### PR TITLE
Refactor spec hooks

### DIFF
--- a/spec/std/spec/hooks_spec.cr
+++ b/spec/std/spec/hooks_spec.cr
@@ -7,14 +7,45 @@ describe Spec do
         require "prelude"
         require "spec"
 
-        before_all { puts "top:before_all" }
-        before_each { puts "top:before_each" }
-        after_all { puts "top:after_all" }
-        after_each { puts "top:after_each" }
-        around_each do |example|
-          puts "top:around_each:before"
+        begin
+          before_all {}
+        rescue exc
+          puts exc.message
+        end
+        begin
+          before_each {}
+        rescue exc
+          puts exc.message
+        end
+        begin
+          after_all {}
+        rescue exc
+          puts exc.message
+        end
+        begin
+          after_each {}
+        rescue exc
+          puts exc.message
+        end
+        begin
+          around_all {}
+        rescue exc
+          puts exc.message
+        end
+        begin
+          around_each {}
+        rescue exc
+          puts exc.message
+        end
+
+        Spec.before_suite { puts "Spec:before_suite" }
+        Spec.before_each { puts "Spec:before_each" }
+        Spec.after_suite { puts "Spec:after_all" }
+        Spec.after_each { puts "Spec:after_each" }
+        Spec.around_each do |example|
+          puts "Spec:around_each:before"
           example.run
-          puts "top:around_each:after"
+          puts "Spec:around_each:after"
         end
 
         describe "foo" do
@@ -60,48 +91,54 @@ describe Spec do
           it {}
         end
         CR
-        top:before_all
+        Can't call `before_all` outside of a describe/context
+        Can't call `before_each` outside of a describe/context
+        Can't call `after_all` outside of a describe/context
+        Can't call `after_each` outside of a describe/context
+        Can't call `around_all` outside of a describe/context
+        Can't call `around_each` outside of a describe/context
+        Spec:before_suite
         foo:around_all:before
         foo:before_all
-        top:around_each:before
+        Spec:around_each:before
         foo:around_each:before
-        top:before_each
+        Spec:before_each
         foo:before_each
         .foo:after_each
-        top:after_each
+        Spec:after_each
         foo:around_each:after
-        top:around_each:after
-        top:around_each:before
+        Spec:around_each:after
+        Spec:around_each:before
         foo:around_each:before
-        top:before_each
+        Spec:before_each
         foo:before_each
         .foo:after_each
-        top:after_each
+        Spec:after_each
         foo:around_each:after
-        top:around_each:after
-        top:around_each:before
+        Spec:around_each:after
+        Spec:around_each:before
         foo:around_each:before
-        top:before_each
+        Spec:before_each
         foo:before_each
         .foo:after_each
-        top:after_each
+        Spec:after_each
         foo:around_each:after
-        top:around_each:after
+        Spec:around_each:after
         foo:after_all
         foo:around_all:after
         bar:around_all:before
         bar:before_all
-        top:around_each:before
+        Spec:around_each:before
         bar:around_each:before
-        top:before_each
+        Spec:before_each
         bar:before_each
         .bar:after_each
-        top:after_each
+        Spec:after_each
         bar:around_each:after
-        top:around_each:after
+        Spec:around_each:after
         bar:after_all
         bar:around_all:after
-        top:after_all
+        Spec:after_all
         OUT
     end
   end

--- a/spec/std/spec/hooks_spec.cr
+++ b/spec/std/spec/hooks_spec.cr
@@ -1,0 +1,108 @@
+require "../../spec_helper"
+
+describe Spec do
+  describe "hooks" do
+    it "runs in correct order" do
+      run(<<-CR).to_string.lines[..-5].should eq <<-OUT.lines
+        require "prelude"
+        require "spec"
+
+        before_all { puts "top:before_all" }
+        before_each { puts "top:before_each" }
+        after_all { puts "top:after_all" }
+        after_each { puts "top:after_each" }
+        around_each do |example|
+          puts "top:around_each:before"
+          example.run
+          puts "top:around_each:after"
+        end
+
+        describe "foo" do
+          before_all { puts "foo:before_all" }
+          before_each { puts "foo:before_each" }
+          after_all { puts "foo:after_all" }
+          after_each { puts "foo:after_each" }
+          around_all do |example|
+            puts "foo:around_all:before"
+            example.run
+            puts "foo:around_all:after"
+          end
+          around_each do |example|
+            puts "foo:around_each:before"
+            example.run
+            puts "foo:around_each:after"
+          end
+
+          it {}
+          it {}
+
+          describe "foofoo" do
+            it {}
+          end
+        end
+
+        describe "bar" do
+          before_all { puts "bar:before_all" }
+          before_each { puts "bar:before_each" }
+          after_all { puts "bar:after_all" }
+          after_each { puts "bar:after_each" }
+          around_all do |example|
+            puts "bar:around_all:before"
+            example.run
+            puts "bar:around_all:after"
+          end
+          around_each do |example|
+            puts "bar:around_each:before"
+            example.run
+            puts "bar:around_each:after"
+          end
+
+          it {}
+        end
+        CR
+        top:before_all
+        foo:around_all:before
+        foo:before_all
+        top:around_each:before
+        foo:around_each:before
+        top:before_each
+        foo:before_each
+        .foo:after_each
+        top:after_each
+        foo:around_each:after
+        top:around_each:after
+        top:around_each:before
+        foo:around_each:before
+        top:before_each
+        foo:before_each
+        .foo:after_each
+        top:after_each
+        foo:around_each:after
+        top:around_each:after
+        top:around_each:before
+        foo:around_each:before
+        top:before_each
+        foo:before_each
+        .foo:after_each
+        top:after_each
+        foo:around_each:after
+        top:around_each:after
+        foo:after_all
+        foo:around_all:after
+        bar:around_all:before
+        bar:before_all
+        top:around_each:before
+        bar:around_each:before
+        top:before_each
+        bar:before_each
+        .bar:after_each
+        top:after_each
+        bar:around_each:after
+        top:around_each:after
+        bar:after_all
+        bar:around_all:after
+        top:after_all
+        OUT
+    end
+  end
+end

--- a/src/spec/context.cr
+++ b/src/spec/context.cr
@@ -12,6 +12,100 @@ module Spec
       end
       children.shuffle!(randomizer)
     end
+
+    protected def internal_run
+      run_before_all_hooks
+      children.each &.run
+      run_after_all_hooks
+    end
+
+    protected def before_each(&block)
+      (@before_each ||= [] of ->) << block
+    end
+
+    protected def run_before_each_hooks
+      @before_each.try &.each &.call
+    end
+
+    protected def after_each(&block)
+      (@after_each ||= [] of ->) << block
+    end
+
+    protected def run_after_each_hooks
+      @after_each.try &.reverse_each &.call
+    end
+
+    protected def before_all(&block)
+      (@before_all ||= [] of ->) << block
+    end
+
+    protected def run_before_all_hooks
+      @before_all.try &.each &.call
+    end
+
+    protected def after_all(&block)
+      (@after_all ||= [] of ->) << block
+    end
+
+    protected def run_after_all_hooks
+      @after_all.try &.reverse_each &.call
+    end
+
+    protected def around_each(&block : Example::Procsy ->)
+      (@around_each ||= [] of Example::Procsy ->) << block
+    end
+
+    protected def run_around_each_hooks(procsy : Example::Procsy) : Bool
+      internal_run_around_each_hooks(procsy)
+    end
+
+    protected def internal_run_around_each_hooks(procsy : Example::Procsy) : Bool
+      around_each = @around_each
+      return false unless around_each
+
+      run_around_each_hook(around_each, procsy, 0)
+      true
+    end
+
+    protected def run_around_each_hook(around_each, procsy, index) : Nil
+      around_each[index].call(
+        if index == around_each.size - 1
+          # If we don't have any more hooks after this one, call the procsy
+          procsy
+        else
+          # Otherwise, create a procsy that will invoke the next hook
+          Example::Procsy.new(procsy.example) do
+            run_around_each_hook(around_each, procsy, index + 1)
+          end
+        end
+      )
+    end
+
+    protected def around_all(&block : ExampleGroup::Procsy ->)
+      (@around_all ||= [] of ExampleGroup::Procsy ->) << block
+    end
+
+    protected def run_around_all_hooks(procsy : ExampleGroup::Procsy) : Bool
+      around_all = @around_all
+      return false unless around_all
+
+      run_around_all_hook(around_all, procsy, 0)
+      true
+    end
+
+    protected def run_around_all_hook(around_all, procsy, index) : Nil
+      around_all[index].call(
+        if index == around_all.size - 1
+          # If we don't have any more hooks after this one, call the procsy
+          procsy
+        else
+          # Otherwise, create a procsy that will invoke the next hook
+          ExampleGroup::Procsy.new(procsy.example_group) do
+            run_around_all_hook(around_all, procsy, index + 1)
+          end
+        end
+      )
+    end
   end
 
   # :nodoc:
@@ -29,11 +123,16 @@ module Spec
   end
 
   # :nodoc:
+  def self.current_context : Context
+    RootContext.current_context
+  end
+
+  # :nodoc:
   #
   # The root context is the main interface that the spec DSL interacts with.
   class RootContext < Context
     class_getter instance = RootContext.new
-    @@current_context : Context = @@instance
+    class_getter current_context : Context = @@instance
 
     def initialize
       @results = {
@@ -45,7 +144,7 @@ module Spec
     end
 
     def run
-      children.each &.run
+      internal_run
     end
 
     def report(kind, full_description, file, line, elapsed = nil, ex = nil)
@@ -206,68 +305,8 @@ module Spec
       end
     end
 
-    def before_each(&block)
-      if @@current_context == self
-        raise "Can't call `before_each` outside of a describe/context"
-      end
-
-      @@current_context.before_each(&block)
-    end
-
-    def run_before_each_hooks
-      # Nothing
-    end
-
-    def after_each(&block)
-      if @@current_context == self
-        raise "Can't call `after_each` outside of a describe/context"
-      end
-
-      @@current_context.after_each(&block)
-    end
-
-    def run_after_each_hooks
-      # Nothing
-    end
-
-    def before_all(&block)
-      if @@current_context == self
-        raise "Can't call `before_all` outside of a describe/context"
-      end
-
-      @@current_context.before_all(&block)
-    end
-
-    def after_all(&block)
-      if @@current_context == self
-        raise "Can't call `after_all` outside of a describe/context"
-      end
-
-      @@current_context.after_all(&block)
-    end
-
-    def around_each(&block : Example::Procsy ->)
-      if @@current_context == self
-        raise "Can't call `around_each` outside of a describe/context"
-      end
-
-      @@current_context.around_each(&block)
-    end
-
-    def run_around_each_hooks(procsy : Example::Procsy) : Bool
-      false
-    end
-
-    def around_all(&block : ExampleGroup::Procsy ->)
-      if @@current_context == self
-        raise "Can't call `around_all` outside of a describe/context"
-      end
-
-      @@current_context.around_all(&block)
-    end
-
-    def run_around_all_hooks(procsy : ExampleGroup::Procsy) : Bool
-      false
+    protected def around_all(&block : ExampleGroup::Procsy ->)
+      raise "Can't call `around_all` outside of a describe/context"
     end
   end
 
@@ -291,52 +330,18 @@ module Spec
       Spec.formatters.each(&.pop)
     end
 
-    protected def internal_run
-      run_before_all_hooks
-      children.each &.run
-      run_after_all_hooks
-    end
-
     protected def report(kind, description, file, line, elapsed = nil, ex = nil)
       parent.report kind, "#{@description} #{description}", file, line, elapsed, ex
     end
 
-    protected def before_each(&block)
-      (@before_each ||= [] of ->) << block
-    end
-
     protected def run_before_each_hooks
       @parent.run_before_each_hooks
-      @before_each.try &.each &.call
-    end
-
-    protected def after_each(&block)
-      (@after_each ||= [] of ->) << block
+      super
     end
 
     protected def run_after_each_hooks
-      @after_each.try &.reverse_each &.call
+      super
       @parent.run_after_each_hooks
-    end
-
-    protected def before_all(&block)
-      (@before_all ||= [] of ->) << block
-    end
-
-    protected def run_before_all_hooks
-      @before_all.try &.each &.call
-    end
-
-    protected def after_all(&block)
-      (@after_all ||= [] of ->) << block
-    end
-
-    protected def run_after_all_hooks
-      @after_all.try &.reverse_each &.call
-    end
-
-    protected def around_each(&block : Example::Procsy ->)
-      (@around_each ||= [] of Example::Procsy ->) << block
     end
 
     protected def run_around_each_hooks(procsy : Example::Procsy) : Bool
@@ -352,54 +357,6 @@ module Spec
         end
       end)
       ran || internal_run_around_each_hooks(procsy)
-    end
-
-    protected def internal_run_around_each_hooks(procsy : Example::Procsy) : Bool
-      around_each = @around_each
-      return false unless around_each
-
-      run_around_each_hook(around_each, procsy, 0)
-      true
-    end
-
-    protected def run_around_each_hook(around_each, procsy, index) : Nil
-      around_each[index].call(
-        if index == around_each.size - 1
-          # If we don't have any more hooks after this one, call the procsy
-          procsy
-        else
-          # Otherwise, create a procsy that will invoke the next hook
-          Example::Procsy.new(procsy.example) do
-            run_around_each_hook(around_each, procsy, index + 1)
-          end
-        end
-      )
-    end
-
-    protected def around_all(&block : ExampleGroup::Procsy ->)
-      (@around_all ||= [] of ExampleGroup::Procsy ->) << block
-    end
-
-    protected def run_around_all_hooks(procsy : ExampleGroup::Procsy) : Bool
-      around_all = @around_all
-      return false unless around_all
-
-      run_around_all_hook(around_all, procsy, 0)
-      true
-    end
-
-    protected def run_around_all_hook(around_all, procsy, index) : Nil
-      around_all[index].call(
-        if index == around_all.size - 1
-          # If we don't have any more hooks after this one, call the procsy
-          procsy
-        else
-          # Otherwise, create a procsy that will invoke the next hook
-          ExampleGroup::Procsy.new(procsy.example_group) do
-            run_around_all_hook(around_all, procsy, index + 1)
-          end
-        end
-      )
     end
   end
 end

--- a/src/spec/dsl.cr
+++ b/src/spec/dsl.cr
@@ -162,7 +162,7 @@ module Spec
   class_property? focus = false
 
   # Instructs the spec runner to execute the given block
-  # before each spec, regardless of where this method is invoked.
+  # before each spec in the spec suite.
   #
   # If multiple blocks are registered they run in the order
   # that they are given.
@@ -175,14 +175,12 @@ module Spec
   # ```
   #
   # will print, just before each spec, 1 and then 2.
-  @[Deprecated("Use `Spec::Methods.before_each` instead")]
   def self.before_each(&block)
-    before_each = @@before_each ||= [] of ->
-    before_each << block
+    root_context.before_each(&block)
   end
 
   # Instructs the spec runner to execute the given block
-  # after each spec, regardless of where this method is invoked.
+  # after each spec spec in the spec suite.
   #
   # If multiple blocks are registered they run in the reversed
   # order that they are given.
@@ -195,10 +193,8 @@ module Spec
   # ```
   #
   # will print, just after each spec, 2 and then 1.
-  @[Deprecated("Use `Spec::Methods.after_each` instead")]
   def self.after_each(&block)
-    after_each = @@after_each ||= [] of ->
-    after_each << block
+    root_context.after_each(&block)
   end
 
   # Instructs the spec runner to execute the given block
@@ -215,10 +211,8 @@ module Spec
   # ```
   #
   # will print, just before the spec suite starts, 1 and then 2.
-  @[Deprecated("Use `Spec::Methods.before_all  ` instead")]
   def self.before_suite(&block)
-    before_suite = @@before_suite ||= [] of ->
-    before_suite << block
+    root_context.before_all(&block)
   end
 
   # Instructs the spec runner to execute the given block
@@ -235,10 +229,32 @@ module Spec
   # ```
   #
   # will print, just after the spec suite ends, 2 and then 1.
-  @[Deprecated("Use `Spec::Methods.after_all` instead")]
   def self.after_suite(&block)
-    after_suite = @@after_suite ||= [] of ->
-    after_suite << block
+    root_context.after_all(&block)
+  end
+
+  # Instructs the spec runner to execute the given block when each spec in the
+  # spec suite runs.
+  #
+  # The block must call `run` on the given `Example::Procsy` object.
+  #
+  # If multiple blocks are registered they run in the reversed
+  # order that they are given.
+  #
+  # ```
+  # require "spec"
+  #
+  # Spec.around_each do |example|
+  #   puts "runs before each sample"
+  #   example.run
+  #   puts "runs after each sample"
+  # end
+  #
+  # it {}
+  # it {}
+  # ```
+  def self.around_each(&block : Example::Procsy ->)
+    root_context.around_each(&block)
   end
 
   @@start_time : Time::Span? = nil

--- a/src/spec/dsl.cr
+++ b/src/spec/dsl.cr
@@ -250,8 +250,8 @@ module Spec
   #   puts "runs after each sample"
   # end
   #
-  # it {}
-  # it {}
+  # it { }
+  # it { }
   # ```
   def self.around_each(&block : Example::Procsy ->)
     root_context.around_each(&block)

--- a/src/spec/dsl.cr
+++ b/src/spec/dsl.cr
@@ -175,6 +175,7 @@ module Spec
   # ```
   #
   # will print, just before each spec, 1 and then 2.
+  @[Deprecated("Use `Spec::Methods.before_each` instead")]
   def self.before_each(&block)
     before_each = @@before_each ||= [] of ->
     before_each << block
@@ -194,6 +195,7 @@ module Spec
   # ```
   #
   # will print, just after each spec, 2 and then 1.
+  @[Deprecated("Use `Spec::Methods.after_each` instead")]
   def self.after_each(&block)
     after_each = @@after_each ||= [] of ->
     after_each << block
@@ -213,6 +215,7 @@ module Spec
   # ```
   #
   # will print, just before the spec suite starts, 1 and then 2.
+  @[Deprecated("Use `Spec::Methods.before_all  ` instead")]
   def self.before_suite(&block)
     before_suite = @@before_suite ||= [] of ->
     before_suite << block
@@ -232,29 +235,10 @@ module Spec
   # ```
   #
   # will print, just after the spec suite ends, 2 and then 1.
+  @[Deprecated("Use `Spec::Methods.after_all` instead")]
   def self.after_suite(&block)
     after_suite = @@after_suite ||= [] of ->
     after_suite << block
-  end
-
-  # :nodoc:
-  def self.run_before_each_hooks
-    @@before_each.try &.each &.call
-  end
-
-  # :nodoc:
-  def self.run_after_each_hooks
-    @@after_each.try &.reverse_each &.call
-  end
-
-  # :nodoc:
-  def self.run_before_suite_hooks
-    @@before_suite.try &.each &.call
-  end
-
-  # :nodoc:
-  def self.run_after_suite_hooks
-    @@after_suite.try &.reverse_each &.call
   end
 
   @@start_time : Time::Span? = nil
@@ -266,9 +250,7 @@ module Spec
     at_exit do
       maybe_randomize
       run_filters
-      run_before_suite_hooks
       root_context.run
-      run_after_suite_hooks
     ensure
       finish_run
     end

--- a/src/spec/example.cr
+++ b/src/spec/example.cr
@@ -29,12 +29,8 @@ module Spec
         non_nil_block = block
         start = Time.monotonic
 
-        Spec.run_before_each_hooks
-
         ran = @parent.run_around_each_hooks(Example::Procsy.new(self) { internal_run(start, non_nil_block) })
         ran || internal_run(start, non_nil_block)
-
-        Spec.run_after_each_hooks
 
         # We do this to give a chance for signals (like CTRL+C) to be handled,
         # which currently are only handled when there's a fiber switch

--- a/src/spec/methods.cr
+++ b/src/spec/methods.cr
@@ -89,10 +89,6 @@ module Spec::Methods
   # ```
   # require "spec
   #
-  # before_each do
-  #   puts "runs before each sample"
-  # end
-  #
   # it "sample_a" {}
   #
   # describe "nested_context" do
@@ -104,6 +100,9 @@ module Spec::Methods
   # end
   # ```
   def before_each(&block)
+    if Spec.current_context.is_a?(RootContext)
+      raise "Can't call `before_each` outside of a describe/context"
+    end
     Spec.current_context.before_each(&block)
   end
 
@@ -120,14 +119,10 @@ module Spec::Methods
   # ```
   # require "spec
   #
-  # before_each do
-  #   puts "runs after each sample"
-  # end
-  #
   # it "sample_a" {}
   #
   # describe "nested_context" do
-  #   before_each do
+  #   after_each do
   #     puts "runs after sample_b"
   #   end
   #
@@ -135,6 +130,9 @@ module Spec::Methods
   # end
   # ```
   def after_each(&block)
+    if Spec.current_context.is_a?(RootContext)
+      raise "Can't call `after_each` outside of a describe/context"
+    end
     Spec.current_context.after_each(&block)
   end
 
@@ -151,10 +149,6 @@ module Spec::Methods
   # ```
   # require "spec
   #
-  # before_all do
-  #   puts "runs at start of spec suite"
-  # end
-  #
   # it "sample_a" {}
   #
   # describe "nested_context" do
@@ -166,6 +160,9 @@ module Spec::Methods
   # end
   # ```
   def before_all(&block)
+    if Spec.current_context.is_a?(RootContext)
+      raise "Can't call `before_all` outside of a describe/context"
+    end
     Spec.current_context.before_all(&block)
   end
 
@@ -182,10 +179,6 @@ module Spec::Methods
   # ```
   # require "spec
   #
-  # after_all do
-  #   puts "runs at end of spec suite"
-  # end
-  #
   # it "sample_a" {}
   #
   # describe "nested_context" do
@@ -197,6 +190,9 @@ module Spec::Methods
   # end
   # ```
   def after_all(&block)
+    if Spec.current_context.is_a?(RootContext)
+      raise "Can't call `after_all` outside of a describe/context"
+    end
     Spec.current_context.after_all(&block)
   end
 
@@ -219,12 +215,6 @@ module Spec::Methods
   # ```
   # require "spec
   #
-  # around_each do |example|
-  #   puts "runs before each sample"
-  #   example.run
-  #   puts "runs after each sample"
-  # end
-  #
   # it "sample_a" {}
   #
   # describe "nested_context" do
@@ -238,6 +228,9 @@ module Spec::Methods
   # end
   # ```
   def around_each(&block : Example::Procsy ->)
+    if Spec.current_context.is_a?(RootContext)
+      raise "Can't call `around_each` outside of a describe/context"
+    end
     Spec.current_context.around_each(&block)
   end
 
@@ -280,6 +273,9 @@ module Spec::Methods
   # end
   # ```
   def around_all(&block : ExampleGroup::Procsy ->)
+    if Spec.current_context.is_a?(RootContext)
+      raise "Can't call `around_all` outside of a describe/context"
+    end
     Spec.current_context.around_all(&block)
   end
 end

--- a/src/spec/methods.cr
+++ b/src/spec/methods.cr
@@ -76,78 +76,211 @@ module Spec::Methods
     raise Spec::AssertionFailed.new(msg, file, line)
   end
 
-  # Executes the given block before each spec runs.
+  # Executes the given block before each spec in the current context runs.
+  #
+  # A context is defined by `describe` or `context` blocks, or outside of them
+  # it's the root context. Nested contexts inherit the `*_each` blocks of
+  # their ancestors.
+  #
+  # If multiple blocks are registered for the same spec, the blocks defined in
+  # the outermost context go first. Blocks on the same context are executed in
+  # order of definition.
+  #
+  # ```
+  # require "spec
+  #
+  # before_each do
+  #   puts "runs before each sample"
+  # end
+  #
+  # it "sample_a" {}
+  #
+  # describe "nested_context" do
+  #   before_each do
+  #     puts "runs before sample_b"
+  #   end
+  #
+  #   it "sample_b" {}
+  # end
+  # ```
   def before_each(&block)
-    Spec.root_context.before_each(&block)
+    Spec.current_context.before_each(&block)
   end
 
-  # Executes the given block after each spec runs.
+  # Executes the given block after each spec in the current context runs.
+  #
+  # A context is defined by `describe` or `context` blocks, or outside of them
+  # it's the root context. Nested contexts inherit the `*_each` blocks of
+  # their ancestors.
+  #
+  # If multiple blocks are registered for the same spec, the blocks defined in
+  # the outermost context go first. Blocks on the same context are executed in
+  # order of definition.
+  #
+  # ```
+  # require "spec
+  #
+  # before_each do
+  #   puts "runs after each sample"
+  # end
+  #
+  # it "sample_a" {}
+  #
+  # describe "nested_context" do
+  #   before_each do
+  #     puts "runs after sample_b"
+  #   end
+  #
+  #   it "sample_b" {}
+  # end
+  # ```
   def after_each(&block)
-    Spec.root_context.after_each(&block)
+    Spec.current_context.after_each(&block)
   end
 
-  # Executes the given block before all specs in a given
-  # `description` or `context` run.
+  # Executes the given block before the first spec in the current context runs.
+  #
+  # A context is defined by `describe` or `context` blocks, or outside of them
+  # it's the root context.
+  # This is independent of the source location the specs and this hook are
+  # defined.
+  #
+  # If multiple blocks are registered on the same context, they are executed in
+  # order of definition.
+  #
+  # ```
+  # require "spec
+  #
+  # before_all do
+  #   puts "runs at start of spec suite"
+  # end
+  #
+  # it "sample_a" {}
+  #
+  # describe "nested_context" do
+  #   before_all do
+  #     puts "runs at start of nested_context"
+  #   end
+  #
+  #   it "sample_b" {}
+  # end
+  # ```
   def before_all(&block)
-    Spec.root_context.before_all(&block)
+    Spec.current_context.before_all(&block)
   end
 
-  # Executes the given block after all specs in a given
-  # `description` or `context` run.
+  # Executes the given block after the last spec in the current context runs.
+  #
+  # A context is defined by `describe` or `context` blocks, or outside of them
+  # it's the root context.
+  # This is independent of the source location the specs and this hook are
+  # defined.
+  #
+  # If multiple blocks are registered on the same context, they are executed in
+  # order of definition.
+  #
+  # ```
+  # require "spec
+  #
+  # after_all do
+  #   puts "runs at end of spec suite"
+  # end
+  #
+  # it "sample_a" {}
+  #
+  # describe "nested_context" do
+  #   after_all do
+  #     puts "runs at end of nested_context"
+  #   end
+  #
+  #   it "sample_b" {}
+  # end
+  # ```
   def after_all(&block)
-    Spec.root_context.after_all(&block)
+    Spec.current_context.after_all(&block)
   end
 
-  # Executes the given block when each spec runs.
+  # Executes the given block when each spec in the current context runs.
   #
   # The block must call `run` on the given `Example::Procsy`
   # object.
   #
-  # For example:
+  # This is essentially a `before_each` and `after_each` hook combined into one.
+  # It is useful for example when setup and teardown steps need shared state.
+  #
+  # A context is defined by `describe` or `context` blocks, or outside of them
+  # it's the root context. Nested contexts inherit the `*_each` blocks of
+  # their ancestors.
+  #
+  # If multiple blocks are registered for the same spec, the blocks defined in
+  # the outermost context go first. Blocks on the same context are executed in
+  # order of definition.
   #
   # ```
-  # require "spec"
+  # require "spec
   #
-  # describe "something" do
+  # around_each do |example|
+  #   puts "runs before each sample"
+  #   example.run
+  #   puts "runs after each sample"
+  # end
+  #
+  # it "sample_a" {}
+  #
+  # describe "nested_context" do
   #   around_each do |example|
-  #     puts "before example runs"
+  #     puts "runs before sample_b"
   #     example.run
-  #     puts "after example runs"
+  #     puts "runs after sample_b"
   #   end
   #
-  #   it "tests something" do
-  #     # ...
-  #   end
+  #   it "sample_b" {}
   # end
   # ```
   def around_each(&block : Example::Procsy ->)
-    Spec.root_context.around_each(&block)
+    Spec.current_context.around_each(&block)
   end
 
-  # Executes the given block when each `describe` or `context` runs.
+  # Executes the given block when the current context runs.
   #
   # The block must call `run` on the given `Context::Procsy`
   # object.
   #
-  # For example:
+  # This is essentially a `before_all` and `after_all` hook combined into one.
+  # It is useful for example when setup and teardown steps need shared state.
+  #
+  # A context is defined by `describe` or `context` blocks. This hook does not
+  # work outside such a block (i.e. in the root context).
+  #
+  # If multiple blocks are registered for the same spec, the blocks defined in
+  # the outermost context go first. Blocks on the same context are executed in
+  # order of definition.
   #
   # ```
-  # require "spec"
+  # require "spec
   #
-  # describe "something" do
-  #   around_all do |context|
-  #     puts "before describe runs"
+  # describe "main_context" do
+  #   around_each do |example|
+  #     puts "runs at beginning of main_context"
   #     example.run
-  #     puts "after describe runs"
+  #     puts "runs at end of main_context"
   #   end
   #
-  #   it "tests something" do
-  #     # ...
+  #   it "sample_a" {}
+  #
+  #   describe "nested_context" do
+  #     around_each do |example|
+  #       puts "runs at beginning of nested_context"
+  #       example.run
+  #       puts "runs at end of nested_context"
+  #     end
+  #
+  #     it "sample_b" {}
   #   end
   # end
   # ```
   def around_all(&block : ExampleGroup::Procsy ->)
-    Spec.root_context.around_all(&block)
+    Spec.current_context.around_all(&block)
   end
 end
 


### PR DESCRIPTION
* <del>Refactor all spec hooks to work in the root context</del>
* <del>Deprecate hook methods in Spec namespace</del>
* <ins>Refactor and simplify implementation of spec hooks</ins>
* Improve documentation of spec hooks
* Add spec for spec hooks

Note: `around_all` does not work on the root context. Because the block is supposed to be called with a `ExampleGroup`. We could perhaps make it work with some effort, but I don't think that's necessary. It would not be have many use cases anyways. This wasn't possible before, so it won't be in this PR.
