### PR TITLE
Allow user-defined macro methods

### DIFF
--- a/spec/compiler/codegen/macro_spec.cr
+++ b/spec/compiler/codegen/macro_spec.cr
@@ -1849,4 +1849,68 @@ describe "Code gen: macro" do
       (Foo.new || Bar.new).foo
     )).to_string.should eq("Foo")
   end
+
+  it "invokes macro method inside Crystal::Macros module" do
+    run(%(
+      module Crystal::Macros
+        macro foo(x)
+          x + "bar"
+        end
+      end
+
+      macro bar(x)
+        {{ foo(x) }}
+      end
+
+      bar("foo")
+    ), inject_primitives: false).to_string.should eq("foobar")
+  end
+
+  it "invokes macro method of ASTNode" do
+    run(%(
+      class Crystal::Macros::StringLiteral
+        macro plus_bar
+          self + "bar"
+        end
+      end
+
+      macro bar(x)
+        {{ x.plus_bar }}
+      end
+
+      bar("foo")
+    ), inject_primitives: false).to_string.should eq("foobar")
+  end
+
+  it "invokes macro method of any type" do
+    run(%(
+      module Foo
+        macro foo(x)
+          x + "bar"
+        end
+      end
+
+      macro bar(x)
+        {{ Foo.foo(x) }}
+      end
+
+      bar("foo")
+    ), inject_primitives: false).to_string.should eq("foobar")
+  end
+
+  it "invokes macro method of any type, with return" do
+    run(%(
+      module Foo
+        macro foo(x)
+          return x + "bar"
+        end
+      end
+
+      macro bar(x)
+        {{ Foo.foo(x) }}
+      end
+
+      bar("foo")
+    ), inject_primitives: false).to_string.should eq("foobar")
+  end
 end

--- a/src/compiler/crystal/macros/interpreter.cr
+++ b/src/compiler/crystal/macros/interpreter.cr
@@ -597,6 +597,11 @@ module Crystal
       end
     end
 
+    def visit(node : OpAssign)
+      @program.normalize(node).accept self
+      false
+    end
+
     def visit(node : ASTNode)
       cant_execute(node)
     end

--- a/src/compiler/crystal/macros/interpreter.cr
+++ b/src/compiler/crystal/macros/interpreter.cr
@@ -597,6 +597,24 @@ module Crystal
       end
     end
 
+    def visit(node : While)
+      while true
+        node.cond.accept self
+        break if !@last.truthy?
+        node.body.accept self
+      end
+      false
+    end
+
+    def visit(node : Until)
+      while true
+        node.cond.accept self
+        break if @last.truthy?
+        node.body.accept self
+      end
+      false
+    end
+
     def visit(node : OpAssign)
       @program.normalize(node).accept self
       false

--- a/src/compiler/crystal/macros/interpreter.cr
+++ b/src/compiler/crystal/macros/interpreter.cr
@@ -74,6 +74,9 @@ module Crystal
 
     record MacroVarKey, name : String, exps : Array(ASTNode)?
 
+    getter program
+    property? macro_method_mode = false
+
     def initialize(@program : Program,
                    @scope : Type, @path_lookup : Type, @location : Location?,
                    @vars = {} of String => ASTNode, @block : Block? = nil, @def : Def? = nil,
@@ -581,7 +584,24 @@ module Crystal
       false
     end
 
+    def visit(node : Return)
+      if macro_method_mode?
+        exp = node.exp
+        if exp
+          exp.accept self
+        else
+          @last = NilLiteral.new
+        end
+      else
+        cant_execute(node)
+      end
+    end
+
     def visit(node : ASTNode)
+      cant_execute(node)
+    end
+
+    def cant_execute(node)
       node.raise "can't execute #{node.class_desc} in a macro"
     end
 

--- a/src/compiler/crystal/macros/methods.cr
+++ b/src/compiler/crystal/macros/methods.cr
@@ -88,14 +88,7 @@ module Crystal
       interpreter.macro_method_mode = true
       interpreter.define_var("self", self_value) if self_value
 
-      vars = Set(String).new
-      matching_macro.args.each do |arg|
-        vars << arg.name
-      end
-
-      body = gather_macro_literals(matching_macro.body)
-      body_node = Parser.parse(body, def_vars: [vars])
-      interpreter.accept(body_node)
+      interpreter.accept(matching_macro.parsed_body)
       @last = interpreter.last
     end
 
@@ -130,38 +123,6 @@ module Crystal
         interpret_run(node)
       else
         nil
-      end
-    end
-
-    def gather_macro_literals(body)
-      gatherer = MacroLiteralGatherer.new
-      body.accept gatherer
-      gatherer.to_s
-    end
-
-    class MacroLiteralGatherer < Visitor
-      def initialize
-        @io = String::Builder.new
-      end
-
-      def visit(node : Expressions)
-        node.expressions.each do |exp|
-          exp.accept self
-        end
-        false
-      end
-
-      def visit(node : MacroLiteral)
-        @io << node.value
-        false
-      end
-
-      def visit(node)
-        node.raise "Can't use #{node.class} this inside macro methods"
-      end
-
-      def to_s
-        @io.to_s
       end
     end
 
@@ -1519,6 +1480,45 @@ module Crystal
         end
       else
         super
+      end
+    end
+
+    property(parsed_body : ASTNode) do
+      vars = Set(String).new
+      args.each do |arg|
+        vars << arg.name
+      end
+
+      gatherer = MacroLiteralGatherer.new
+      body.accept gatherer
+      gathered_body = gatherer.to_s
+
+      Parser.parse(gathered_body, def_vars: [vars])
+    end
+
+    class MacroLiteralGatherer < Visitor
+      def initialize
+        @io = String::Builder.new
+      end
+
+      def visit(node : Expressions)
+        node.expressions.each do |exp|
+          exp.accept self
+        end
+        false
+      end
+
+      def visit(node : MacroLiteral)
+        @io << node.value
+        false
+      end
+
+      def visit(node)
+        node.raise "Can't use #{node.class} inside macro methods"
+      end
+
+      def to_s
+        @io.to_s
       end
     end
   end

--- a/src/compiler/crystal/program.cr
+++ b/src/compiler/crystal/program.cr
@@ -205,6 +205,8 @@ module Crystal
       types["Proc"] = @proc = ProcType.new self, self, "Proc", value, ["T", "R"]
       types["Union"] = @union = GenericUnionType.new self, self, "Union", value, ["T"]
       types["Crystal"] = @crystal = NonGenericModuleType.new self, self, "Crystal"
+      crystal.types["Macros"] = macros = NonGenericModuleType.new self, crystal, "Macros"
+      define_crystal_macros_ast_nodes(macros)
 
       types["ARGC_UNSAFE"] = @argc = argc_unsafe = Const.new self, self, "ARGC_UNSAFE", Primitive.new("argc", int32)
       types["ARGV_UNSAFE"] = @argv = argv_unsafe = Const.new self, self, "ARGV_UNSAFE", Primitive.new("argv", pointer_of(pointer_of(uint8)))
@@ -276,6 +278,22 @@ module Crystal
 
     private def define_crystal_constant(name, value)
       crystal.types[name] = Const.new self, crystal, name, value
+    end
+
+    private def define_crystal_macros_ast_nodes(macros)
+      macros.types["ASTNode"] = ast_node = NonGenericClassType.new self, macros, "ASTNode", reference
+
+      %w(Annotation Arg ArrayLiteral Assign BinaryOp Block BoolLiteral
+        Call Case Cast CharLiteral ClassDef ClassVar Def Expressions
+        Generic Global HashLiteral If ImplicitObj InstanceVar IsA Macro
+        MacroId MetaVar MultiAssign NamedArgument NamedTupleLiteral NilableCast
+        NilLiteral Nop NumberLiteral OffsetOf Path ProcLiteral ProcNotation ProcPointer
+        RangeLiteral ReadInstanceVar RegexLiteral Require RespondsTo Splat
+        StringInterpolation StringLiteral SymbolLiteral TupleLiteral TypeDeclaration
+        TypeNode UnaryExpression UninitializedVar Union Var VisibilityModifier
+        When While).each do |name|
+        macros.types[name] = NonGenericClassType.new self, macros, name, ast_node
+      end
     end
 
     property(target_machine : LLVM::TargetMachine) { codegen_target.to_target_machine }


### PR DESCRIPTION
Reopens #8836, fixes #8835.

As it turns out adding `next` and changing the syntax to `macro def` is not a trivial endeavor.  Because of this, and since these changes are BC, I propose to just merge the current state of this to at least have _something_.

This is based on the original PR by @asterite.  I added an additional commit to add some specs for the new `.each` and `.each_with_index` macro methods as well.

We can always iterate on this to improve it in the future.  Considering the breaking change when that happens would be simple to fix, and I doubt this'll be used as much as some stdlib features; it's probably fine to handle that at a later time.