### PR TITLE
Additional Log::Context methods

### DIFF
--- a/spec/std/log/context_spec.cr
+++ b/spec/std/log/context_spec.cr
@@ -54,8 +54,11 @@ describe Log::Context do
     end
 
     describe String do
+      it "empty" do
+        c("").empty?.should be_true
+      end
+
       it "not empty" do
-        c("").empty?.should be_false
         c("foo").empty?.should be_false
       end
     end

--- a/spec/std/log/context_spec.cr
+++ b/spec/std/log/context_spec.cr
@@ -43,14 +43,11 @@ describe Log::Context do
       c(17).empty?.should be_false
     end
 
-    describe Array do
-      it "empty" do
-        c([] of Int32).empty?.should be_true
-      end
-
-      it "not empty" do
-        c([1, 2, 3]).empty?.should be_false
-      end
+    it Bool do
+      c(false).empty?.should be_false
+    end
+    it Nil do
+      c(nil).empty?.should be_true
     end
 
     describe String do
@@ -60,6 +57,16 @@ describe Log::Context do
 
       it "not empty" do
         c("foo").empty?.should be_false
+      end
+    end
+
+    describe Array do
+      it "empty" do
+        c([] of Int32).empty?.should be_true
+      end
+
+      it "not empty" do
+        c([1, 2, 3]).empty?.should be_false
       end
     end
 

--- a/spec/std/log/context_spec.cr
+++ b/spec/std/log/context_spec.cr
@@ -1,5 +1,6 @@
 require "spec"
 require "log"
+require "json"
 
 private def c(value)
   Log::Context.new(value)
@@ -35,6 +36,53 @@ describe Log::Context do
   it "merge" do
     c({a: 1}).merge(c({b: 2})).should eq(c({a: 1, b: 2}))
     c({a: 1, b: 3}).merge(c({b: 2})).should eq(c({a: 1, b: 2}))
+  end
+
+  describe "#empty?" do
+    it Number do
+      c(17).empty?.should be_false
+    end
+
+    describe Array do
+      it "empty" do
+        c([] of Int32).empty?.should be_true
+      end
+
+      it "not empty" do
+        c([1, 2, 3]).empty?.should be_false
+      end
+    end
+
+    describe String do
+      it "not empty" do
+        c("").empty?.should be_false
+        c("foo").empty?.should be_false
+      end
+    end
+
+    describe Hash do
+      it "empty" do
+        c(Hash(String, String).new).empty?.should be_true
+      end
+
+      it "not empty" do
+        c({"key" => "value"}).empty?.should be_false
+      end
+    end
+  end
+
+  describe "#to_json" do
+    it Number do
+      c(17).to_json.should eq "17"
+    end
+
+    it Array do
+      c([1, 2, 3]).to_json.should eq "[1,2,3]"
+    end
+
+    it Hash do
+      c({"key" => "value"}).to_json.should eq %({"key":"value"})
+    end
   end
 
   describe "implicit context" do

--- a/src/crystal/datum.cr
+++ b/src/crystal/datum.cr
@@ -66,8 +66,8 @@ module Crystal
     # then `Enumerable#empty?` is invoked, otherwise `false` is returned.
     def empty? : Bool
       case raw = @raw
-      when Array, Hash
-        raw.empty?
+      when Array, Hash then raw.empty?
+      when String then raw.empty?
       else
         false
       end

--- a/src/crystal/datum.cr
+++ b/src/crystal/datum.cr
@@ -34,10 +34,10 @@ module Crystal
     # All possible `{{@type}}` types.
     alias Type = {% for short, type in types %}{{type}} | {% end %}Array(self) | Hash({{hash_key_type}}, self)
 
-    # Returns the raw underlying value, a `Raw`.
+    # Returns the raw underlying value, a `Type`.
     getter raw : Type
 
-    # Creates a `{{@type}}` that wraps the given `Raw`.
+    # Creates a `{{@type}}` that wraps the given `Type`.
     def initialize(@raw : Type)
     end
 
@@ -53,12 +53,23 @@ module Crystal
     # Raises if the underlying value is not an `Array` or `Hash`.
     def size : Int
       case object = @raw
-      when Array
-        object.size
-      when Hash
+      when Array, Hash
         object.size
       else
         raise "Expected Array or Hash for #size, not #{object.class}"
+      end
+    end
+
+    # Returns `true` if `self` does not currently have a value.
+    #
+    # If the underlying value is `Array` or `Hash`,
+    # then `Enumerable#empty?` is invoked, otherwise `false` is returned.
+    def empty? : Bool
+      case raw = @raw
+      when Array, Hash
+        raw.empty?
+      else
+        false
       end
     end
 
@@ -144,13 +155,18 @@ module Crystal
       @raw.pretty_print(pp)
     end
 
+    # :nodoc:
+    def to_json(builder : JSON::Builder) : Nil
+      @raw.to_json builder
+    end
+
     # Returns `true` if both `self` and *other*'s raw object are equal.
-    def ==(other : self)
+    def ==(other : self) : Bool
       raw == other.raw
     end
 
     # Returns `true` if the raw object is equal to *other*.
-    def ==(other)
+    def ==(other) : Bool
       raw == other
     end
 

--- a/src/crystal/datum.cr
+++ b/src/crystal/datum.cr
@@ -62,8 +62,11 @@ module Crystal
 
     # Returns `true` if `self` does not currently have a value.
     #
-    # If the underlying value is `Array` or `Hash`,
-    # then `Enumerable#empty?` is invoked, otherwise `false` is returned.
+    # If the underlying value is an `Array` or `Hash` then `Enumerable#empty?` is invoked.
+    #
+    # If the underlying value is a `String`, then `String#empty?` is invoked.
+    #
+    # Otherwise, `false` is returned.
     def empty? : Bool
       case raw = @raw
       when Array, Hash then raw.empty?

--- a/src/crystal/datum.cr
+++ b/src/crystal/datum.cr
@@ -60,7 +60,7 @@ module Crystal
       end
     end
 
-    # Returns `true` if `self` does not currently have a value.
+    # Returns `true` if `self` does not currently have a value, or the value is `nil`.
     #
     # If the underlying value is an `Array` or `Hash` then `Enumerable#empty?` is invoked.
     #
@@ -70,7 +70,8 @@ module Crystal
     def empty? : Bool
       case raw = @raw
       when Array, Hash then raw.empty?
-      when String then raw.empty?
+      when String      then raw.empty?
+      when Nil         then true
       else
         false
       end
@@ -156,11 +157,6 @@ module Crystal
     # :nodoc:
     def pretty_print(pp)
       @raw.pretty_print(pp)
-    end
-
-    # :nodoc:
-    def to_json(builder : JSON::Builder) : Nil
-      @raw.to_json builder
     end
 
     # Returns `true` if both `self` and *other*'s raw object are equal.

--- a/src/log.cr
+++ b/src/log.cr
@@ -114,7 +114,7 @@
 #
 # If `Log.setup_from_env` is called on startup you can tweak the logging as:
 #
-# ```
+# ```sh
 # $ CRYSTAL_LOG_LEVEL=DEBUG CRYSTAL_LOG_SOURCES=* ./bin/app
 # ```
 class Log

--- a/src/log/context.cr
+++ b/src/log/context.cr
@@ -2,7 +2,7 @@
 #
 # See `Log.context`, `Log.context=`, `Log::Context#clear`, `Log::Context#set`, `Log.with_context`.
 class Log::Context
-  Crystal.datum types: {bool: Bool, i: Int32, i64: Int64, f: Float32, f64: Float64, s: String, time: Time}, hash_key_type: String, immutable: true
+  Crystal.datum types: {bool: Bool, i: Int32, i64: Int64, f: Float32, f64: Float64, s: String, time: Time, nil: Nil}, hash_key_type: String, immutable: true
 
   # Creates an empty `Log::Context`.
   def initialize
@@ -42,6 +42,11 @@ class Log::Context
   # A value in *other* takes precedence over the one in this context.
   def merge(other : Context)
     Context.new(self.as_h.merge(other.as_h).clone)
+  end
+
+  # :nodoc:
+  def to_json(builder : JSON::Builder) : Nil
+    @raw.to_json builder
   end
 
   private def to_context(value)


### PR DESCRIPTION
* Add #empty? and #to_json(builder) to Log::Context
* Fix some doc display bugs

Implements the two method suggestions from https://forum.crystal-lang.org/t/log-module-suggestions/1962.  Will wait for some feedback on the others, this one was useful/easy enough to just go ahead and do.