### PR TITLE
Parser: introduce endless method syntax

### DIFF
--- a/spec/compiler/formatter/formatter_spec.cr
+++ b/spec/compiler/formatter/formatter_spec.cr
@@ -226,6 +226,62 @@ describe Crystal::Formatter do
   assert_format "def foo\n  1 #\nrescue\nend"
   assert_format "def foo\n  1\n  #\n\n\nrescue\nend", "def foo\n  1\n  #\n\nrescue\nend"
 
+  assert_format <<-BEFORE, <<-AFTER
+    def   foo   =   1
+    BEFORE
+    def foo = 1
+    AFTER
+
+  assert_format <<-BEFORE, <<-AFTER
+    def   foo   =
+         1
+    BEFORE
+    def foo =
+      1
+    AFTER
+
+  assert_format <<-BEFORE, <<-AFTER
+    def   foo   =   if 1
+      2
+    else
+      3
+    end
+    BEFORE
+    def foo = if 1
+                2
+              else
+                3
+              end
+    AFTER
+
+  assert_format <<-BEFORE, <<-AFTER
+    def   foo   =
+      if 1
+        2
+      else
+        3
+      end
+    BEFORE
+    def foo =
+      if 1
+        2
+      else
+        3
+      end
+    AFTER
+
+  assert_format <<-BEFORE, <<-AFTER
+    def   foo ( x )  =   1
+    BEFORE
+    def foo(x) = 1
+    AFTER
+
+  assert_format <<-BEFORE, <<-AFTER
+    def   foo ( @x )  =   1
+    BEFORE
+    def foo(@x) = 1
+    AFTER
+
   assert_format "loop do\n  1\nrescue\n  2\nend"
   assert_format "loop do\n  1\n  loop do\n    2\n  rescue\n    3\n  end\n  4\nend"
 

--- a/spec/compiler/parser/parser_spec.cr
+++ b/spec/compiler/parser/parser_spec.cr
@@ -176,6 +176,12 @@ module Crystal
     it_parses "def foo(n); foo(n -1); end", Def.new("foo", ["n".arg], "foo".call(Call.new("n".var, "-", 1.int32)))
     it_parses "def type(type); end", Def.new("type", ["type".arg])
 
+    it_parses "def foo = 1", Def.new("foo", body: 1.int32)
+    it_parses "def foo =\n1", Def.new("foo", body: 1.int32)
+    it_parses "def foo(x) = 1", Def.new("foo", ["x".arg], body: 1.int32)
+    it_parses "def foo(x) =\n1", Def.new("foo", ["x".arg], body: 1.int32)
+    it_parses "def foo(@x) =\n1", Def.new("foo", ["x".arg], body: Expressions.new([Assign.new("@x".instance_var, "x".var), 1.int32]))
+
     # #4815
     assert_syntax_error "def foo!=; end", "unexpected token: !="
     assert_syntax_error "def foo?=(x); end", "unexpected token: ?"

--- a/src/compiler/crystal/tools/formatter.cr
+++ b/src/compiler/crystal/tools/formatter.cr
@@ -1449,7 +1449,7 @@ module Crystal
 
       indent do
         next_token_skip_space
-        next_token_skip_space if @token.type == :"="
+        next_token_skip_space if @token.type == :"=" && node.name.ends_with?('=')
       end
 
       to_skip = format_def_args node
@@ -1481,8 +1481,25 @@ module Crystal
 
       body = remove_to_skip node, to_skip
 
-      unless node.abstract?
-        format_nested_with_end body
+      indent { skip_space }
+
+      if @token.type == :"="
+        write " = "
+        next_token_skip_space
+        if @token.type == :NEWLINE
+          skip_space_or_newline
+          write_line
+          indent do
+            write_indent
+            accept body
+          end
+        else
+          indent(@column) { accept body }
+        end
+      else
+        unless node.abstract?
+          format_nested_with_end body
+        end
       end
 
       @vars.pop


### PR DESCRIPTION
Fixes #9080

Just for fun. Doesn't mean we are going to go with this.

Let's keep the discussions on #9080

But given that Crystal already tries to be succinct... for example we have `def initialize(@name)`, or we have `record Point, x : Int32, y : Int32`... maybe not having to write a full method body, `end` included, is nice. Specially for really short methods that are just literals, forwarding, small stuff like that.