### PR TITLE
Allow Nil values in Log::Context

### DIFF
--- a/spec/std/log/context_spec.cr
+++ b/spec/std/log/context_spec.cr
@@ -115,6 +115,11 @@ describe Log::Context do
       Log.context.should eq(c({a: 1, b: 2}))
     end
 
+    it "allows setting Nil values" do
+      Log.context.set current_user_id: nil
+      Log.context.should eq(c({current_user_id: nil}))
+    end
+
     it "is assignable from a named tuple" do
       Log.context.set a: 1
       extra = {b: 2}

--- a/src/log/context.cr
+++ b/src/log/context.cr
@@ -2,7 +2,7 @@
 #
 # See `Log.context`, `Log.context=`, `Log::Context#clear`, `Log::Context#set`, `Log.with_context`.
 class Log::Context
-  Crystal.datum types: {bool: Bool, i: Int32, i64: Int64, f: Float32, f64: Float64, s: String, time: Time}, hash_key_type: String, immutable: true
+  Crystal.datum types: {bool: Bool, i: Int32, i64: Int64, f: Float32, f64: Float64, s: String, time: Time, nil: Nil}, hash_key_type: String, immutable: true
 
   # Creates an empty `Log::Context`.
   def initialize


### PR DESCRIPTION
It is often helpful to log when something is *not* set.

Right now that is not possible without weird workarounds like settings
nil to `""`. Even that doesn't always work because you may have a
complex Hash/NamedTuple where doing this is complex.

This allows setting values to `nil` and adds a spec to make sure it
works along with an example use case

> Note: this does not allow `Log::Context.set nil`. So we still protect against accidental logging of *just* nil

