### PR TITLE
Add Log::IOBackend#new with formatter

### DIFF
--- a/spec/std/log/io_backend_spec.cr
+++ b/spec/std/log/io_backend_spec.cr
@@ -78,6 +78,15 @@ describe Log::IOBackend do
     end
   end
 
+  it "allows setting formatter in initializer" do
+    formatter = Log::Formatter.new { |_entry, io| io }
+    backend = Log::IOBackend.new(formatter: formatter)
+
+    log = Log.new("foo", backend, :info)
+
+    log.backend.should eq(backend)
+  end
+
   it "yields message" do
     IO.pipe do |r, w|
       logger = io_logger(stdout: w, progname: "prog", source: "db")

--- a/src/log/io_backend.cr
+++ b/src/log/io_backend.cr
@@ -2,7 +2,7 @@
 class Log::IOBackend < Log::Backend
   property io : IO
   property progname : String
-  property formatter : Formatter? = nil
+  property formatter : Formatter?
 
   def initialize(@io = STDOUT, @formatter = nil)
     @mutex = Mutex.new(:unchecked)

--- a/src/log/io_backend.cr
+++ b/src/log/io_backend.cr
@@ -4,7 +4,7 @@ class Log::IOBackend < Log::Backend
   property progname : String
   property formatter : Formatter? = nil
 
-  def initialize(@io = STDOUT)
+  def initialize(@io = STDOUT, @formatter = nil)
     @mutex = Mutex.new(:unchecked)
     @progname = File.basename(PROGRAM_NAME)
   end


### PR DESCRIPTION
Makes it so you can do stuff like this:

```crystal
Log.builder.bind("*", :info, Log::IOBackend.new(formatter: MyFormatter))
```

Instead of

```crystal
backend = Log::IOBackend.new
backend.formatter = MyFormatter
Log.builder.bind("*", :info, backend)
```