### PR TITLE
Also expand `subcommands` in Windows linker flags

### DIFF
--- a/src/compiler/crystal/compiler.cr
+++ b/src/compiler/crystal/compiler.cr
@@ -323,14 +323,11 @@ module Crystal
 
     private def linker_command(program : Program, object_names, output_filename, output_dir, expand = false)
       if program.has_flag? "windows"
-        if link_flags = @link_flags.presence
-          link_flags = "/link #{link_flags}"
-        end
         lib_flags = program.lib_flags
         # Execute and expand `subcommands`.
         lib_flags = lib_flags.gsub(/`(.*?)`/) { `#{$1}` } if expand
 
-        args = %(#{object_names.join(" ")} "/Fe#{output_filename}" #{lib_flags} #{link_flags})
+        args = %(#{object_names.join(" ")} "/Fe#{output_filename}" #{lib_flags} #{@link_flags})
         cmd = "#{CL} #{args}"
 
         if cmd.to_utf16.size > 32000

--- a/src/llvm/lib_llvm.cr
+++ b/src/llvm/lib_llvm.cr
@@ -5,12 +5,10 @@ end
 {% end %}
 
 {% begin %}
-  @[Link("stdc++")]
-  {% if flag?(:static) %}
-    @[Link(ldflags: "`{{LibLLVM::LLVM_CONFIG.id}} --libs --system-libs --ldflags --link-static 2> /dev/null`")]
-  {% else %}
-    @[Link(ldflags: "`{{LibLLVM::LLVM_CONFIG.id}} --libs --system-libs --ldflags 2> /dev/null`")]
+  {% unless flag?(:win32) %}
+    @[Link("stdc++")]
   {% end %}
+  @[Link(ldflags: {{"`#{LibLLVM::LLVM_CONFIG} --libs --system-libs --ldflags#{" --link-static".id if flag?(:static)}#{" 2> /dev/null".id unless flag?(:win32)}`"}})]
   lib LibLLVM
     VERSION = {{`#{LibLLVM::LLVM_CONFIG} --version`.chomp.stringify}}
     BUILT_TARGETS = {{ (


### PR DESCRIPTION
This is a hack to get the compiler to compile itself on Windows without interventions.

See #9089