### PR TITLE
Move verbose to a lower level than debug

### DIFF
--- a/spec/std/log/broadcast_backend_spec.cr
+++ b/spec/std/log/broadcast_backend_spec.cr
@@ -34,9 +34,9 @@ describe Log::BroadcastBackend do
     main.append(backend_b, s(:error))
 
     log = Log.new("", main, s(:info))
-    log.level = s(:verbose)
+    log.level = s(:info)
 
-    log.verbose { "lorem" }
+    log.info { "lorem" }
 
     backend_a.entries.should_not be_empty
     backend_b.entries.should_not be_empty

--- a/spec/std/log/log_spec.cr
+++ b/spec/std/log/log_spec.cr
@@ -16,8 +16,8 @@ describe Log do
 
   describe Log::Severity do
     it "values are ordered" do
-      s(:debug).should be < s(:verbose)
-      s(:verbose).should be < s(:info)
+      s(:verbose).should be < s(:debug)
+      s(:debug).should be < s(:info)
       s(:info).should be < s(:warning)
       s(:warning).should be < s(:error)
       s(:error).should be < s(:fatal)

--- a/spec/std/log/log_spec.cr
+++ b/spec/std/log/log_spec.cr
@@ -16,26 +16,29 @@ describe Log do
 
   describe Log::Severity do
     it "values are ordered" do
-      s(:verbose).should be < s(:debug)
+      s(:trace).should be < s(:debug)
       s(:debug).should be < s(:info)
-      s(:info).should be < s(:warning)
+      s(:info).should be < s(:notice)
+      s(:notice).should be < s(:warning)
       s(:warning).should be < s(:error)
       s(:error).should be < s(:fatal)
       s(:fatal).should be < s(:none)
     end
 
     it "parses" do
+      Log::Severity.parse("trace").should eq s(:trace)
       Log::Severity.parse("debug").should eq s(:debug)
-      Log::Severity.parse("verbose").should eq s(:verbose)
       Log::Severity.parse("info").should eq s(:info)
+      Log::Severity.parse("notice").should eq s(:notice)
       Log::Severity.parse("warning").should eq s(:warning)
       Log::Severity.parse("error").should eq s(:error)
       Log::Severity.parse("fatal").should eq s(:fatal)
       Log::Severity.parse("none").should eq s(:none)
 
+      Log::Severity.parse("TRACE").should eq s(:trace)
       Log::Severity.parse("DEBUG").should eq s(:debug)
-      Log::Severity.parse("VERBOSE").should eq s(:verbose)
       Log::Severity.parse("INFO").should eq s(:info)
+      Log::Severity.parse("NOTICE").should eq s(:notice)
       Log::Severity.parse("WARNING").should eq s(:warning)
       Log::Severity.parse("ERROR").should eq s(:error)
       Log::Severity.parse("FATAL").should eq s(:fatal)
@@ -47,9 +50,10 @@ describe Log do
     backend = Log::MemoryBackend.new
     log = Log.new("a", backend, :warning)
 
+    log.trace { "trace message" }
     log.debug { "debug message" }
-    log.verbose { "verbose message" }
     log.info { "info message" }
+    log.notice { "notice message" }
     log.warn { "warning message" }
     log.error { "error message" }
     log.fatal { "fatal message" }
@@ -67,9 +71,10 @@ describe Log do
 
     log.level = :error
 
+    log.trace { "trace message" }
     log.debug { "debug message" }
-    log.verbose { "verbose message" }
     log.info { "info message" }
+    log.notice { "notice message" }
     log.warn { "warning message" }
     log.error { "error message" }
     log.fatal { "fatal message" }
@@ -86,9 +91,10 @@ describe Log do
     backend = Log::MemoryBackend.new
     log = Log.new("a", backend, :debug)
 
+    log.trace(exception: ex) { "trace message" }
     log.debug(exception: ex) { "debug message" }
-    log.verbose(exception: ex) { "verbose message" }
     log.info(exception: ex) { "info message" }
+    log.notice(exception: ex) { "notice message" }
     log.warn(exception: ex) { "warning message" }
     log.error(exception: ex) { "error message" }
     log.fatal(exception: ex) { "fatal message" }

--- a/src/log.cr
+++ b/src/log.cr
@@ -3,7 +3,7 @@
 # The messages, or `Log::Entry` have associated levels, such as `Info` or `Error`
 # that indicate their importance. See `Log::Severity`.
 #
-# To log a message `debug`, `verbose`, `info`, `warn`, `error`, and `fatal` methods
+# To log a message `trace`, `debug`, `info`, `notice`, `warn`, `error`, and `fatal` methods
 # can be used. They expect a block that will evaluate to the message of the entry.
 #
 # ```

--- a/src/log/entry.cr
+++ b/src/log/entry.cr
@@ -1,19 +1,28 @@
 # A logging severity level.
 enum Log::Severity
-  Verbose
+  # Used for tracing the code and trying to find one part of a function specifically.
+  Trace
+  # Used for information that is diagnostically helpful to people more than just developers (IT, sysadmins, etc.).
   Debug
+  # Used for generally useful information to log.
   Info
+  # Used for normal but significant conditions.
+  Notice
+  # Used for conditions that can potentially cause application oddities, but that can be automatically recovered.
   Warning
+  # Used for any error that is fatal to the operation, but not to the service or application.
   Error
+  # Used for any error that is forcing a shutdown of the service or application
   Fatal
   # Used only for severity level filter.
   None
 
   def label
     case self
-    when Verbose then "VERBOSE"
+    when Trace   then "TRACE"
     when Debug   then "DEBUG"
     when Info    then "INFO"
+    when Notice  then "NOTICE"
     when Warning then "WARNING"
     when Error   then "ERROR"
     when Fatal   then "FATAL"

--- a/src/log/entry.cr
+++ b/src/log/entry.cr
@@ -1,7 +1,7 @@
 # A logging severity level.
 enum Log::Severity
-  Debug
   Verbose
+  Debug
   Info
   Warning
   Error
@@ -11,8 +11,8 @@ enum Log::Severity
 
   def label
     case self
-    when Debug   then "DEBUG"
     when Verbose then "VERBOSE"
+    when Debug   then "DEBUG"
     when Info    then "INFO"
     when Warning then "WARNING"
     when Error   then "ERROR"

--- a/src/log/io_backend.cr
+++ b/src/log/io_backend.cr
@@ -33,7 +33,7 @@ class Log::IOBackend < Log::Backend
     io << label[0] << ", ["
     entry.timestamp.to_rfc3339(io)
     io << " #" << Process.pid << "] "
-    label.rjust(7, io)
+    label.rjust(6, io)
     io << " -- " << @progname << ":" << entry.source << ": " << entry.message
     if entry.context.size > 0
       io << " -- " << entry.context

--- a/src/log/log.cr
+++ b/src/log/log.cr
@@ -34,12 +34,13 @@ class Log
   end
 
   {% for method, severity in {
-                               debug:   Severity::Debug,
-                               verbose: Severity::Verbose,
-                               info:    Severity::Info,
-                               warn:    Severity::Warning,
-                               error:   Severity::Error,
-                               fatal:   Severity::Fatal,
+                               trace:  Severity::Trace,
+                               debug:  Severity::Debug,
+                               info:   Severity::Info,
+                               notice: Severity::Notice,
+                               warn:   Severity::Warning,
+                               error:  Severity::Error,
+                               fatal:  Severity::Fatal,
                              } %}
 
     # Logs a message if the logger's current severity is lower or equal to `{{severity}}`.

--- a/src/log/main.cr
+++ b/src/log/main.cr
@@ -35,7 +35,7 @@ class Log
 
   private Top = Log.for("")
 
-  {% for method in %i(debug verbose info warn error fatal) %}
+  {% for method in %i(trace debug info notice warn error fatal) %}
     # See `Log#{{method.id}}`.
     def self.{{method.id}}(*, exception : Exception? = nil)
       Top.{{method.id}}(exception: exception) do


### PR DESCRIPTION
Typically "verbose" is the most verbose output you can get and implies
verbose will give you "more"

Right now "debug" is lower than verbose which does not seem like it
matches how most people think of or are using these levels.

My proposal is to make "verbose" the most "verbose" log level possible.

For example and ORM might use "debug" to show what queries run, and what
the args are, but might have "verbose" mode that tells you when the
transactions start, when it was committed, whether there was a cache
hit, etc. Stuff that normally is not helpful, but if you *really* need
it you can go "verbose" and get all the nitty gritty details