### PR TITLE
Format: re-tokenize `/` as regex delimiter if regex literal is needed

### DIFF
--- a/spec/compiler/formatter/formatter_spec.cr
+++ b/spec/compiler/formatter/formatter_spec.cr
@@ -1639,4 +1639,15 @@ describe Crystal::Formatter do
       end
     %}
     CODE
+
+  # #4626
+  assert_format <<-CODE
+    1 # foo
+    / 1 /
+    CODE
+
+  assert_format <<-CODE
+    1 # foo
+    / #{1} /
+    CODE
 end

--- a/src/compiler/crystal/tools/formatter.cr
+++ b/src/compiler/crystal/tools/formatter.cr
@@ -680,6 +680,17 @@ module Crystal
     end
 
     def visit(node : RegexLiteral)
+      # Go back and tokenize again if slash is recognized as divide operator.
+      # In this case, slash is tokenized on comment skipping (#4626).
+      # However this slash must be a start delimiter of regex because
+      # this is parsed as regex literal once before.
+      if @token.type == :"/"
+        @lexer.reader.previous_char
+        @lexer.column_number -= 1
+        slash_is_regex!
+        next_token
+      end
+
       accept node.value
 
       false


### PR DESCRIPTION
Fixed #4626

Now such a code can format:

```crystal
# string literal
" foo "
# regex literal
/ foo /
```

Details are explained in comment ([here](https://github.com/MakeNowJust/crystal/blob/e9fcee0592ba0e5f0b490fb62e315d870adfdd1c/src/compiler/crystal/tools/formatter.cr#L683-L687)).