### PR TITLE
Some `Log` improvements

### DIFF
--- a/spec/std/log/io_backend_spec.cr
+++ b/spec/std/log/io_backend_spec.cr
@@ -14,6 +14,16 @@ private def io_logger(*, stdout : IO, config = nil, source : String = "", progna
   builder.for(source)
 end
 
+private def assert_logged(expected : Regex, & : Log -> Nil)
+  IO.pipe do |r, w|
+    logger = io_logger(stdout: w)
+
+    yield logger
+
+    r.gets.should match expected
+  end
+end
+
 describe Log::IOBackend do
   it "logs messages" do
     IO.pipe do |r, w|
@@ -35,16 +45,60 @@ describe Log::IOBackend do
     end
   end
 
-  it "logs context" do
-    IO.pipe do |r, w|
-      logger = io_logger(stdout: w)
-      Log.context.clear
-      Log.with_context do
-        Log.context.set foo: "bar"
-        logger.info { "info:show" }
+  describe "logging context" do
+    it "via Log.context" do
+      assert_logged(/info:show -- {"foo" => "bar"}/) do |logger|
+        Log.with_context do
+          Log.context.set foo: "bar"
+          logger.info { "info:show" }
+        end
+      end
+    end
+
+    describe Hash do
+      it "directly" do
+        assert_logged(/info:show -- {"foo" => "bar"}/) do |logger|
+          logger.info context: {"foo" => "bar"} { "info:show" }
+        end
       end
 
-      r.gets.should match(/info:show -- {"foo" => "bar"}/)
+      it "with mixed type keys" do
+        assert_logged(/info:show -- {"foo" => "bar", "1" => 17, "true" => false}/) do |logger|
+          logger.info context: {"foo" => "bar", 1 => 17, true => false} { "info:show" }
+        end
+      end
+
+      it Exception do
+        assert_logged(/info:show -- {"foo" => "bar", "1" => 17, "true" => false}/) do |logger|
+          logger.info exception: Exception.new("ERR"), context: {"foo" => "bar", 1 => 17, true => false} { "info:show" }
+        end
+      end
+    end
+
+    describe NamedTuple do
+      it "directly" do
+        assert_logged(/info:show -- {"foo" => "bar"}/) do |logger|
+          logger.info context: {foo: "bar"} { "info:show" }
+        end
+      end
+
+      it Exception do
+        assert_logged(/info:show -- {"foo" => "bar"}/) do |logger|
+          logger.info exception: Exception.new("ERR"), context: {foo: "bar"} { "info:show" }
+        end
+      end
+    end
+
+    it "with named args" do
+      assert_logged(/info:show -- {"foo" => "bar"}/) do |logger|
+        logger.info(foo: "bar") { "info:show" }
+      end
+    end
+
+    it Exception do
+      assert_logged(/info:show --/) do |logger|
+        logger.info(exception: Exception.new("ERR")) { "info:show" }
+      end
     end
   end
 

--- a/spec/std/log/log_spec.cr
+++ b/spec/std/log/log_spec.cr
@@ -43,6 +43,21 @@ describe Log do
     end
   end
 
+  # Just make sure these compile
+  describe Log.class do
+    it "logs with exception & hash" do
+      Log.info { "STR" }
+      Log.info(exception: Exception.new("err")) { "STR" }
+      Log.info(context: {"key" => "value"}) { "STR" }
+      Log.info(context: {key: "value"}) { "STR" }
+    end
+
+    it "logs with exception & named args" do
+      Log.info(key: "value", exception: Exception.new("err")) { "STR" }
+      Log.info(key: "value") { "STR" }
+    end
+  end
+
   it "filter messages to the backend above level only" do
     backend = Log::MemoryBackend.new
     log = Log.new("a", backend, :warning)
@@ -105,5 +120,15 @@ describe Log do
     log.info { "info message" }
 
     backend.entries.first.context.should eq(Log::Context.new({a: 1}))
+  end
+
+  describe "#supports?" do
+    it true do
+      Log.new("a", nil, s(:warning)).supports?(s(:warning)).should be_true
+    end
+
+    it false do
+      Log.new("a", nil, s(:warning)).supports?(s(:info)).should be_false
+    end
   end
 end

--- a/src/log/context.cr
+++ b/src/log/context.cr
@@ -5,42 +5,31 @@ class Log::Context
   Crystal.datum types: {bool: Bool, i: Int32, i64: Int64, f: Float32, f64: Float64, s: String, time: Time}, hash_key_type: String, immutable: true
 
   # Creates an empty `Log::Context`.
-  def initialize
+  def initialize : Nil
     @raw = Hash(String, Context).new
   end
 
-  # Creates `Log::Context` from the given *tuple*.
-  def initialize(tuple : NamedTuple)
-    @raw = raw = Hash(String, Context).new
-    tuple.each do |key, value|
-      raw[key.to_s] = to_context(value)
-    end
+  # Creates a `Log::Context` from the given *named_args*.
+  def self.new(**named_args : Type) : self
+    new named_args
   end
 
-  # Creates `Log::Context` from the given *hash*.
-  def initialize(hash : Hash(String, V)) forall V
+  # Creates `Log::Context` from the given *collection*.
+  def initialize(collection : Hash | NamedTuple) : Nil
     @raw = raw = Hash(String, Context).new
-    hash.each do |key, value|
-      raw[key] = to_context(value)
-    end
-  end
-
-  # Creates `Log::Context` from the given *hash*.
-  def initialize(hash : Hash(Symbol, V)) forall V
-    @raw = raw = Hash(String, Context).new
-    hash.each do |key, value|
+    collection.each do |key, value|
       raw[key.to_s] = to_context(value)
     end
   end
 
   # :nodoc:
-  def initialize(ary : Array)
+  def initialize(ary : Array) : Nil
     @raw = ary.map { |e| to_context(e) }
   end
 
   # Returns a new `Log::Context` with the keys and values of this context and *other* combined.
   # A value in *other* takes precedence over the one in this context.
-  def merge(other : Context)
+  def merge(other : self) : self
     Context.new(self.as_h.merge(other.as_h).clone)
   end
 

--- a/src/log/log.cr
+++ b/src/log/log.cr
@@ -1,4 +1,6 @@
 class Log
+  private Top = Log.for("")
+
   getter source : String
   getter backend : Backend?
   @level : Severity?
@@ -33,23 +35,67 @@ class Log
     @backend = value
   end
 
+  # Returns `true` if `self` handles logging the provided *severity*.
+  def supports?(severity : Log::Severity) : Bool
+    level <= severity
+  end
+
+  # Define severities as a string so they dont resolve to a `NumberLieral`.
   {% for method, severity in {
-                               debug:   Severity::Debug,
-                               verbose: Severity::Verbose,
-                               info:    Severity::Info,
-                               warn:    Severity::Warning,
-                               error:   Severity::Error,
-                               fatal:   Severity::Fatal,
+                               debug:   "Severity::Debug",
+                               verbose: "Severity::Verbose",
+                               info:    "Severity::Info",
+                               warn:    "Severity::Warning",
+                               error:   "Severity::Error",
+                               fatal:   "Severity::Fatal",
                              } %}
 
-    # Logs a message if the logger's current severity is lower or equal to `{{severity}}`.
-    def {{method.id}}(*, exception : Exception? = nil)
-      return unless backend = @backend
-      severity = Severity.new({{severity}})
-      return unless level <= severity
-      message = yield.to_s
-      entry = Entry.new @source, severity, message, exception
-      backend.write entry
+    # See `Log#{{method.id}}`.
+    def self.{{method.id}}(context : Hash | NamedTuple | Nil = nil, exception : Exception? = nil, &block : -> _) : Nil
+      Top.log {{severity.id}}, block, context, exception
+    end
+
+    # Logs a message if the logger's current severity is lower or equal to `{{severity.id}}`.
+    #
+    # Optionally including the provided *context*, and/or *exception*.  The context is specific to this entry.
+    def {{method.id}}(context : Hash | NamedTuple | Nil = nil, exception : Exception? = nil, &block : -> _) : Nil
+      self.log {{severity.id}}, block, context, exception
+    end
+
+    # See `Log#{{method.id}}`.
+    def self.{{method.id}}(exception : Exception? = nil, **named_args : Log::Context::Type, &block : -> _) : Nil
+      Top.log {{severity.id}}, block, named_args, exception
+    end
+
+    # Logs a message if the logger's current severity is lower or equal to `{{severity.id}}`.
+    #
+    # The provided *named_args* are added to the created `Log::Entry` as context specific to this entry.
+    #
+    # ```
+    # # Log some metadata about the user who just logged in
+    # Log.info(user_id: user.id, user_name: user.name) { "#{user.name} Logged in" }
+    #
+    # # Or include metadata about a failed request
+    # Log.error(exception, request_id: ctx.request.headers["X-REQUEST-ID"]) { "Unexpected exception #{exception.class}" }
+    # ```
+    def {{method.id}}(exception : Exception? = nil, **named_args : Log::Context::Type, &block : -> _) : Nil
+      self.log {{severity.id}}, block, named_args, exception
     end
   {% end %}
+
+  protected def log(severity : Log::Severity, message_block, context : Hash | NamedTuple | Nil = nil, exception : Exception? = nil) : Nil
+    return unless backend = @backend
+    return unless self.supports? severity
+    message = message_block.call.to_s
+    return write_entry backend, severity, message, exception unless (ctx = context)
+
+    Log.with_context do
+      Log.context.set ctx
+      write_entry backend, severity, message, exception
+    end
+  end
+
+  private def write_entry(backend : Log::Backend, severity : Log::Severity, message : String, exception : Exception? = nil) : Nil
+    backend.write Entry.new @source, severity, message, exception
+  end
 end

--- a/src/log/main.cr
+++ b/src/log/main.cr
@@ -33,17 +33,6 @@ class Log
     ::Log.for(type, level)
   end
 
-  private Top = Log.for("")
-
-  {% for method in %i(debug verbose info warn error fatal) %}
-    # See `Log#{{method.id}}`.
-    def self.{{method.id}}(*, exception : Exception? = nil)
-      Top.{{method.id}}(exception: exception) do
-        yield
-      end
-    end
-  {% end %}
-
   @@builder = Builder.new
 
   # Returns the default `Log::Builder` used for `Log.for` calls.
@@ -123,21 +112,11 @@ class Log
     # Log.info { %q(message with {"a" => 1, "b" => 2, "c" => 3 } context) }
     # ```
     def set(**kwargs)
-      extend_fiber_context(Fiber.current, Log::Context.new(kwargs))
+      set kwargs
     end
 
     # :ditto:
-    def set(values : Hash(String, V)) forall V
-      extend_fiber_context(Fiber.current, Log::Context.new(values))
-    end
-
-    # :ditto:
-    def set(values : Hash(Symbol, V)) forall V
-      extend_fiber_context(Fiber.current, Log::Context.new(values))
-    end
-
-    # :ditto:
-    def set(values : NamedTuple)
+    def set(values : Hash | NamedTuple)
       extend_fiber_context(Fiber.current, Log::Context.new(values))
     end
 


### PR DESCRIPTION
Implements the first suggestion from https://forum.crystal-lang.org/t/log-module-suggestions/1962.

* Simplify `initializer` and `set` overloads for `Log::Context`
  * `#new` and `#set` now allows any type of hash and calls `.to_s` on each key
* Add overloads to `Log` to support passing entry specific context.  Including:
  * Hash
  * NamedTuple
  * named arguments
* Add `Log#supports?(severity)` that returns `true` if a given logger is able to handle the provided severity
  * Usecase would be to check if a given logger would log before logging so that context arguments do not have to be executed if it would not log anyway.  Mainly in the case where the context would require some none trivial calculations.