### PR TITLE
Fix handle leaks when neither Process#close nor #wait is called on Windows

### DIFF
--- a/src/crystal/system/win32/process.cr
+++ b/src/crystal/system/win32/process.cr
@@ -12,7 +12,9 @@ struct Crystal::System::Process
   end
 
   def release
+    return if @process_handle == LibC::HANDLE.null
     close_handle(@process_handle)
+    @process_handle = LibC::HANDLE.null
   end
 
   def wait

--- a/src/process.cr
+++ b/src/process.cr
@@ -232,6 +232,10 @@ class Process
     fork_error.close unless fork_error == error || fork_error == STDERR
   end
 
+  def finalize
+    @process_info.release
+  end
+
   private def stdio_to_fd(stdio : Stdio, for dst_io : IO::FileDescriptor) : IO::FileDescriptor
     case stdio
     when IO::FileDescriptor


### PR DESCRIPTION
Windows process handles are not closed when neither Process#close nor Process#wait is called.
I checked it by the following code:
```crystal
lib LibC
  fun GetProcessHandleCount(hProcess : HANDLE, handleCount : DWORD*) : BOOL
end

def print_handle_count(msg : String)
  if LibC.GetProcessHandleCount(LibC.GetCurrentProcess, out count) != 0
    puts("handle count: #{count} (#{msg})")
  end
end

GC.collect
print_handle_count("before creating processes");

processes = 50.times.map do
  Process.new("cmd.exe", {"/c", "exit"})
end.to_a
print_handle_count("after creating processes and before GC");

processes.clear
GC.collect
print_handle_count("after GC");
```
It printed:
```
handle count: 58 (before creating processes)
handle count: 111 (after creating processes and before GC)
handle count: 111 (after GC)
```
50 processes were created and the number of handle counts increased by 53 even after GC.
It appears that process handles leaked.

After applying this patch, the output was changed as follows:
```
handle count: 51 (before creating processes)
handle count: 104 (after creating processes and before GC)
handle count: 54 (after GC)
```
50 handles were closed by GC.

Well, I don't know what are the additional three handles after GC and why the number of handles before creating processes are different with and without this patch.