### PR TITLE
Move recent additions to DIBuilder to LLVMExt

### DIFF
--- a/spec/debug/blocks.cr
+++ b/spec/debug/blocks.cr
@@ -1,0 +1,8 @@
+["hello world"].each do |v|
+  a = v
+  b = 0 # break
+  # lldb-command: print a
+  # lldb-check: (String *) $0 = {{0x[0-9a-f]+}} "hello world"
+  # lldb-command: print v
+  # lldb-check: (String *) $1 = {{0x[0-9a-f]+}} "hello world"
+end

--- a/spec/debug/test.sh
+++ b/spec/debug/test.sh
@@ -32,3 +32,4 @@ $crystal build $SCRIPT_ROOT/driver.cr -o $driver
 
 $driver $SCRIPT_ROOT/top_level.cr
 $driver $SCRIPT_ROOT/strings.cr
+$driver $SCRIPT_ROOT/blocks.cr

--- a/src/llvm/di_builder.cr
+++ b/src/llvm/di_builder.cr
@@ -30,7 +30,7 @@ struct LLVM::DIBuilder
   end
 
   def create_lexical_block_file(scope, file_scope, discriminator = 0)
-    LibLLVM.di_builder_create_lexical_block_file(self, scope, file_scope, discriminator)
+    LibLLVMExt.di_builder_create_lexical_block_file(self, scope, file_scope, discriminator)
   end
 
   def create_function(scope, name, linkage_name, file, line, composite_type, is_local_to_unit, is_definition,
@@ -101,7 +101,7 @@ struct LLVM::DIBuilder
   end
 
   def create_unspecified_type(name : String)
-    LibLLVM.di_builder_create_unspecified_yype(self, name, name.size)
+    LibLLVMExt.di_builder_create_unspecified_type(self, name, name.size)
   end
 
   def get_or_create_array_subrange(lo, count)

--- a/src/llvm/ext/llvm_ext.cc
+++ b/src/llvm/ext/llvm_ext.cc
@@ -272,6 +272,21 @@ LLVMMetadataRef LLVMExtDIBuilderCreateReplaceableCompositeType(
   return wrap(CT);
 }
 
+// LLVM 7.0 LLVMDIBuilderCreateUnspecifiedType
+LLVMMetadataRef LLVMExtDIBuilderCreateUnspecifiedType(
+  DIBuilderRef Dref, const char *Name, size_t NameLen) {
+  return wrap(Dref->createUnspecifiedType({Name, NameLen}));
+}
+
+// LLVM 7.0 LLVMDIBuilderCreateLexicalBlockFile
+LLVMMetadataRef LLVMExtDIBuilderCreateLexicalBlockFile(
+  DIBuilderRef Dref,
+  LLVMMetadataRef Scope, LLVMMetadataRef File, unsigned Discriminator) {
+  return wrap(Dref->createLexicalBlockFile(unwrapDI<DIScope>(Scope),
+                                           unwrapDI<DIFile>(File),
+                                           Discriminator));
+}
+
 void LLVMExtDIBuilderReplaceTemporary(
   DIBuilderRef Dref, LLVMMetadataRef From, LLVMMetadataRef To) {
   auto *Node = unwrap<MDNode>(From);
@@ -461,7 +476,7 @@ char *LLVMExtBasicBlockName(LLVMBasicBlockRef BB) {
 }
 
 LLVMMetadataRef LLVMExtDIBuilderGetOrCreateArraySubrange(
-  DIBuilderRef Dref, uint64_t Lo, 
+  DIBuilderRef Dref, uint64_t Lo,
   uint64_t Count) {
     return wrap(Dref->getOrCreateSubrange(Lo, Count));
 }

--- a/src/llvm/lib_llvm.cr
+++ b/src/llvm/lib_llvm.cr
@@ -371,7 +371,4 @@ lib LibLLVM
   fun set_instr_param_alignment = LLVMSetInstrParamAlignment(instr : ValueRef, index : UInt, align : UInt)
 
   fun set_param_alignment = LLVMSetParamAlignment(arg : ValueRef, align : UInt)
-  fun di_builder_create_unspecified_yype = LLVMDIBuilderCreateUnspecifiedType(builder : LibLLVMExt::DIBuilder, name : Void*, size : LibC::SizeT) : LibLLVMExt::Metadata
-  fun di_builder_create_lexical_block_file = LLVMDIBuilderCreateLexicalBlockFile(builder : LibLLVMExt::DIBuilder,
-                                                                                 scope : LibLLVMExt::Metadata, file_scope : LibLLVMExt::Metadata, discriminator : UInt32) : LibLLVMExt::Metadata
 end

--- a/src/llvm/lib_llvm_ext.cr
+++ b/src/llvm/lib_llvm_ext.cr
@@ -100,6 +100,16 @@ lib LibLLVMExt
                                                                                                     name : Char*,
                                                                                                     file : Metadata,
                                                                                                     line : UInt) : Metadata
+
+  fun di_builder_create_unspecified_type = LLVMExtDIBuilderCreateUnspecifiedType(builder : LibLLVMExt::DIBuilder,
+                                                                                 name : Void*,
+                                                                                 size : LibC::SizeT) : LibLLVMExt::Metadata
+
+  fun di_builder_create_lexical_block_file = LLVMExtDIBuilderCreateLexicalBlockFile(builder : LibLLVMExt::DIBuilder,
+                                                                                    scope : LibLLVMExt::Metadata,
+                                                                                    file_scope : LibLLVMExt::Metadata,
+                                                                                    discriminator : UInt32) : LibLLVMExt::Metadata
+
   fun di_builder_replace_temporary = LLVMExtDIBuilderReplaceTemporary(builder : DIBuilder, from : Metadata, to : Metadata)
 
   fun set_current_debug_location = LLVMExtSetCurrentDebugLocation(LibLLVM::BuilderRef, Int, Int, Metadata, Metadata)


### PR DESCRIPTION
#8538 cause some issues in the packaging that this PR should fix.

As stated by https://github.com/crystal-lang/crystal/pull/8538#issuecomment-580254461 the C API used is available since llvm 7.0.

Instead of just porting the code to work with older LLVM I added an explicit call to the C API. This way I think is easier to identify what will be the benefits of a cleanup.

No other method in llvm_ext.cc does this today. But is a way to be more ready to clean up llvm_ext eventually.

@skuznetsov can you point me to what small program should stress these funciontions / definitions?