### PR TITLE
Refactor Docs::Generator source link generation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -91,7 +91,7 @@ compiler_spec: $(O)/compiler_spec ## Run compiler specs
 
 .PHONY: docs
 docs: ## Generate standard library documentation
-	$(BUILD_PATH) ./bin/crystal docs src/docs_main.cr $(DOCS_OPTIONS) --project-name=Crystal --project-version=$(CRYSTAL_VERSION)
+	$(BUILD_PATH) ./bin/crystal docs src/docs_main.cr $(DOCS_OPTIONS) --project-name=Crystal --project-version=$(CRYSTAL_VERSION) --source-refname=$(CRYSTAL_CONFIG_BUILD_COMMIT)
 
 .PHONY: crystal
 crystal: $(O)/crystal ## Build the compiler

--- a/man/crystal.1
+++ b/man/crystal.1
@@ -176,12 +176,36 @@ Options:
 .Pp
 .It Fl -project-name Ar NAME
 Set the project name. The default value is extracted from shard.yml if available.
+
 In case no default can be found, this option is mandatory.
 .It Fl -project-version Ar VERSION
 Set the project version. The default value is extracted from current git commit or shard.yml if available.
+
 In case no default can be found, this option is mandatory.
 .It Fl -json_config_url Ar URL
 Set the URL pointing to a config file (used for discovering versions).
+.It Fl -source-refname Ar REFNAME
+Set source refname (e.g. git tag, commit hash). The default value is extracted from current git commit if available.
+
+If this option is missing and can't be automatically determined, the generator can't produce source code links.
+.It Fl -source-url-pattern Ar URL
+Set URL pattern for source code links. The default value is extracted from git remotes ("origin" or first one) if available and the provider's URL pattern is recognized.
+
+.Pp
+Supported replacement tags:
+.Pp
+.Bl -tag -width "%{refname}" -compact
+.It Sy %{refname}
+commit reference
+.It Sy %{path}
+path to source file inside the repository
+.It Sy %{filename}
+basename of the source file
+.It Sy %{line}
+line number
+.El
+.Pp
+If this option is missing and can't be automatically determined, the generator can't produce source code links.
 .It Fl o Ar DIR, Fl -output Ar DIR
 Set the output directory (default: ./docs).
 .It Fl b Ar URL, Fl -sitemap-base-url Ar URL

--- a/spec/compiler/crystal/tools/doc/project_info_spec.cr
+++ b/spec/compiler/crystal/tools/doc/project_info_spec.cr
@@ -282,41 +282,31 @@ describe Crystal::Doc::ProjectInfo do
 
   describe "#source_url" do
     it "fails if refname is missing" do
-      location = Crystal::Doc::Generator::RelativeLocation.new("foo/bar.baz", 42, "", true)
+      location = Crystal::Doc::RelativeLocation.new("foo/bar.baz", 42)
       info = ProjectInfo.new("test", "v1.0", refname: nil, source_url_pattern: "http://git.example.com/test.git/src/%{refname}/%{path}#L%{line}")
       info.source_url(location).should be_nil
     end
 
     it "fails if pattern is missing" do
-      location = Crystal::Doc::Generator::RelativeLocation.new("foo/bar.baz", 42, "", true)
+      location = Crystal::Doc::RelativeLocation.new("foo/bar.baz", 42)
       info = ProjectInfo.new("test", "v1.0", refname: "master")
       info.source_url(location).should be_nil
     end
 
     it "builds url" do
       info = ProjectInfo.new("test", "v1.0", refname: "master", source_url_pattern: "http://git.example.com/test.git/src/%{refname}/%{path}#L%{line}")
-      location = Crystal::Doc::Generator::RelativeLocation.new("foo/bar.baz", 42, "", true)
+      location = Crystal::Doc::RelativeLocation.new("foo/bar.baz", 42)
       info.source_url(location).should eq "http://git.example.com/test.git/src/master/foo/bar.baz#L42"
     end
 
     it "returns nil for empty pattern" do
       info = ProjectInfo.new("test", "v1.0", refname: "master", source_url_pattern: "")
-      location = Crystal::Doc::Generator::RelativeLocation.new("foo/bar.baz", 42, "", true)
-      info.source_url(location).should be_nil
-    end
-  end
-
-  describe "#source_url" do
-    it "fails if refname is missing" do
-      location = Crystal::Doc::Generator::RelativeLocation.new("foo/bar.baz", 42, "", true)
-      info = ProjectInfo.new("test", "v1.0")
-      info.source_url_pattern = "http://git.example.com/test.git/src/%{refname}/%{path}#L%{line}"
-      info.refname = nil
+      location = Crystal::Doc::RelativeLocation.new("foo/bar.baz", 42)
       info.source_url(location).should be_nil
     end
 
     it "fails if pattern is missing" do
-      location = Crystal::Doc::Generator::RelativeLocation.new("foo/bar.baz", 42, "", true)
+      location = Crystal::Doc::RelativeLocation.new("foo/bar.baz", 42)
       info = ProjectInfo.new("test", "v1.0")
       info.refname = "master"
       info.source_url(location).should be_nil
@@ -326,7 +316,7 @@ describe Crystal::Doc::ProjectInfo do
       info = ProjectInfo.new("test", "v1.0")
       info.refname = "master"
       info.source_url_pattern = "http://git.example.com/test.git/src/%{refname}/%{path}#L%{line}"
-      location = Crystal::Doc::Generator::RelativeLocation.new("foo/bar.baz", 42, "", true)
+      location = Crystal::Doc::RelativeLocation.new("foo/bar.baz", 42)
       info.source_url(location).should eq "http://git.example.com/test.git/src/master/foo/bar.baz#L42"
     end
   end

--- a/spec/compiler/crystal/tools/doc_spec.cr
+++ b/spec/compiler/crystal/tools/doc_spec.cr
@@ -1,51 +1,6 @@
 require "../../../spec_helper"
 
-private def assert_matches_pattern(url, **options)
-  match = Crystal::Doc::Generator::GIT_REMOTE_PATTERNS.each_key.compact_map(&.match(url)).first?
-  if match
-    options.each { |k, v| match[k.to_s].should eq(v) }
-  end
-end
-
 describe Crystal::Doc::Generator do
-  describe "GIT_REMOTE_PATTERNS" do
-    it "matches github repos" do
-      assert_matches_pattern "https://www.github.com/foo/bar", user: "foo", repo: "bar"
-      assert_matches_pattern "http://www.github.com/foo/bar", user: "foo", repo: "bar"
-      assert_matches_pattern "http://github.com/foo/bar", user: "foo", repo: "bar"
-
-      assert_matches_pattern "https://github.com/foo/bar", user: "foo", repo: "bar"
-      assert_matches_pattern "https://github.com/foo/bar.git", user: "foo", repo: "bar"
-      assert_matches_pattern "https://github.com/foo/bar.cr", user: "foo", repo: "bar.cr"
-      assert_matches_pattern "https://github.com/foo/bar.cr.git", user: "foo", repo: "bar.cr"
-
-      assert_matches_pattern "origin\thttps://github.com/foo/bar.cr.git (fetch)\n", user: "foo", repo: "bar.cr"
-      assert_matches_pattern "origin\tgit@github.com/foo/bar.cr.git (fetch)\n", user: "foo", repo: "bar.cr"
-
-      assert_matches_pattern "https://github.com/fOO-Bar/w00den-baRK.ab.cd", user: "fOO-Bar", repo: "w00den-baRK.ab.cd"
-      assert_matches_pattern "https://github.com/fOO-Bar/w00den-baRK.ab.cd.git", user: "fOO-Bar", repo: "w00den-baRK.ab.cd"
-      assert_matches_pattern "https://github.com/foo_bar/_baz-buzz.cx", user: "foo_bar", repo: "_baz-buzz.cx"
-    end
-
-    it "matches gitlab repos" do
-      assert_matches_pattern "https://www.gitlab.com/foo/bar", user: "foo", repo: "bar"
-      assert_matches_pattern "http://www.gitlab.com/foo/bar", user: "foo", repo: "bar"
-      assert_matches_pattern "http://gitlab.com/foo/bar", user: "foo", repo: "bar"
-
-      assert_matches_pattern "https://gitlab.com/foo/bar", user: "foo", repo: "bar"
-      assert_matches_pattern "https://gitlab.com/foo/bar.git", user: "foo", repo: "bar"
-      assert_matches_pattern "https://gitlab.com/foo/bar.cr", user: "foo", repo: "bar.cr"
-      assert_matches_pattern "https://gitlab.com/foo/bar.cr.git", user: "foo", repo: "bar.cr"
-
-      assert_matches_pattern "origin\thttps://gitlab.com/foo/bar.cr.git (fetch)\n", user: "foo", repo: "bar.cr"
-      assert_matches_pattern "origin\tgit@gitlab.com/foo/bar.cr.git (fetch)\n", user: "foo", repo: "bar.cr"
-
-      assert_matches_pattern "https://gitlab.com/fOO-Bar/w00den-baRK.ab.cd", user: "fOO-Bar", repo: "w00den-baRK.ab.cd"
-      assert_matches_pattern "https://gitlab.com/fOO-Bar/w00den-baRK.ab.cd.git", user: "fOO-Bar", repo: "w00den-baRK.ab.cd"
-      assert_matches_pattern "https://gitlab.com/foo_bar/_baz-buzz.cx", user: "foo_bar", repo: "_baz-buzz.cx"
-    end
-  end
-
   describe ".anchor_link" do
     it "generates the correct anchor link" do
       Crystal::Doc.anchor_link("anchor").should eq(

--- a/src/compiler/crystal/command/docs.cr
+++ b/src/compiler/crystal/command/docs.cr
@@ -33,6 +33,14 @@ class Crystal::Command
         project_info.version = value
       end
 
+      opts.on("--source-refname=REFNAME", "Set source refname (e.g. git tag, commit hash)") do |value|
+        project_info.refname = value
+      end
+
+      opts.on("--source-url-pattern=REFNAME", "Set URL pattern for source code links") do |value|
+        project_info.source_url_pattern = value
+      end
+
       opts.on("--output=DIR", "-o DIR", "Set the output directory (default: #{output_directory})") do |value|
         output_directory = value
       end

--- a/src/compiler/crystal/tools/doc/generator.cr
+++ b/src/compiler/crystal/tools/doc/generator.cr
@@ -3,7 +3,6 @@ class Crystal::Doc::Generator
 
   @base_dir : String
   @repository : String? = nil
-  getter repository_name = ""
   getter project_info
 
   # Adding a flag and associated css class will add support in parser
@@ -39,7 +38,6 @@ class Crystal::Doc::Generator
                  @project_info : ProjectInfo)
     @base_dir = Dir.current.chomp
     @types = {} of Crystal::Type => Doc::Type
-    @repo_name = ""
     compute_repository
   end
 
@@ -80,7 +78,7 @@ class Crystal::Doc::Generator
 
   def generate_docs_json(program_type, types)
     readme = read_readme
-    json = Main.new(readme, Type.new(self, @program), repository_name)
+    json = Main.new(readme, Type.new(self, @program), project_info)
     puts json
   end
 
@@ -97,7 +95,7 @@ class Crystal::Doc::Generator
 
     File.write File.join(@output_dir, "index.html"), MainTemplate.new(body, types, project_info)
 
-    main_index = Main.new(raw_body, Type.new(self, @program), repository_name)
+    main_index = Main.new(raw_body, Type.new(self, @program), project_info)
     File.write File.join(@output_dir, "index.json"), main_index
     File.write File.join(@output_dir, "search-index.js"), main_index.to_jsonp
   end
@@ -404,7 +402,6 @@ class Crystal::Doc::Generator
 
     info = GIT_REMOTE_PATTERNS[origin.regex]
     @repository = info[:repository] % {user: user, repo: repo, rev: rev}
-    @repository_name = info[:repo_name] % {user: user, repo: repo}
   end
 
   def source_link(node)

--- a/src/compiler/crystal/tools/doc/html/type.html
+++ b/src/compiler/crystal/tools/doc/html/type.html
@@ -54,12 +54,12 @@
     Defined in:
   </h2>
   <% locations.each do |location| %>
-    <% if url = location.url %>
-      <a href="<%= url %>#L<%= location.line_number %>" target="_blank">
-        <%= location.filename %><% if location.show_line_number %>:<%= location.line_number %><% end %>
+    <% if url = project_info.source_url(location) %>
+      <a href="<%= url %>" target="_blank">
+        <%= location.filename_in_project %><% if location.show_line_number %>:<%= location.line_number %><% end %>
       </a>
     <% else %>
-      <%= location.filename %><% if location.show_line_number %>:<%= location.line_number %><% end %>
+      <%= location.filename_in_project %><% if location.show_line_number %>:<%= location.line_number %><% end %>
     <% end %>
     <br/>
   <% end %>

--- a/src/compiler/crystal/tools/doc/main.cr
+++ b/src/compiler/crystal/tools/doc/main.cr
@@ -1,5 +1,5 @@
 module Crystal::Doc
-  record Main, body : String, program : Type, repository_name : String do
+  record Main, body : String, program : Type, project_info : ProjectInfo do
     def to_s(io : IO) : Nil
       to_json(io)
     end
@@ -18,7 +18,7 @@ module Crystal::Doc
 
     def to_json(builder : JSON::Builder)
       builder.object do
-        builder.field "repository_name", repository_name
+        builder.field "repository_name", project_info.name
         builder.field "body", body
         builder.field "program", program
       end

--- a/src/compiler/crystal/tools/doc/project_info.cr
+++ b/src/compiler/crystal/tools/doc/project_info.cr
@@ -43,7 +43,7 @@ module Crystal::Doc
       end
     end
 
-    def source_url(location : Generator::RelativeLocation)
+    def source_url(location : RelativeLocation)
       refname = self.refname
       url_pattern = source_url_pattern
 

--- a/src/compiler/crystal/tools/doc/relative_location.cr
+++ b/src/compiler/crystal/tools/doc/relative_location.cr
@@ -1,0 +1,52 @@
+class Crystal::Doc::RelativeLocation
+  include Comparable(self)
+  property show_line_number : Bool = false
+
+  # This property is only used to keep backwards compatibility in JSON output.
+  property url : String?
+
+  getter filename, line_number
+
+  def initialize(@filename : String, @line_number : Int32)
+  end
+
+  def_equals_and_hash @filename, @line_number
+
+  def filename_in_project
+    filename.lchop("src/")
+  end
+
+  def to_json(builder : JSON::Builder)
+    builder.object do
+      builder.field "filename", filename
+      builder.field "line_number", line_number
+      builder.field "url", url
+    end
+  end
+
+  def <=>(other : self)
+    cmp = filename <=> other.filename
+    return cmp unless cmp == 0
+    line_number <=> other.line_number
+  end
+
+  def self.from(node : ASTNode, base_dir : String)
+    if location = node.location
+      from(location, base_dir)
+    end
+  end
+
+  def self.from(location : Location, base_dir : String)
+    filename = location.filename
+    if filename.is_a?(VirtualFile)
+      location = filename.expanded_location || return
+      filename = location.filename
+    end
+
+    return unless filename.is_a?(String)
+    return unless filename.starts_with? base_dir
+    filename = filename[(base_dir.size + 1)..]
+
+    new(filename, location.line_number)
+  end
+end

--- a/src/compiler/crystal/tools/doc/type.cr
+++ b/src/compiler/crystal/tools/doc/type.cr
@@ -758,7 +758,7 @@ class Crystal::Doc::Type
   end
 
   def html_id
-    "#{@generator.repository_name}/" + (
+    "#{@generator.project_info.name}/" + (
       if program?
         "toplevel"
       elsif namespace = self.namespace
@@ -786,7 +786,7 @@ class Crystal::Doc::Type
         end
       end
       builder.field "locations", locations
-      builder.field "repository_name", @generator.repository_name
+      builder.field "repository_name", @generator.project_info.name
       builder.field "program", program?
       builder.field "enum", enum?
       builder.field "alias", alias?


### PR DESCRIPTION
This refactors how the docs generator generates source links to hosted git providers. All configuration is done via `ProjectInfo` which is already responsible for name and version properties.

The default behaviour is still to extract the remote tracking branch from the current git checkout and derive the URL pattern from there if it is a known git provider. But there is now also an option `--source_url_pattern` to configure the URL pattern explicitly, which can be used to point source links to providers not covered by the automatic recognition and also works outside a git repository. `--source-refname` accompanies that use case and is used to configure the refname in source URL links.

Changes to the generated HTML output are minimal and shouldn't have a perceivable effect. The only visual difference is that the locations in a type's locations list are now ordered. Internal data-id values have changed because they are no longer based on the repository but the configured name.