### PR TITLE
Add .each and .each_with_index to various macro types

### DIFF
--- a/spec/compiler/macro/macro_methods_spec.cr
+++ b/spec/compiler/macro/macro_methods_spec.cr
@@ -556,7 +556,7 @@ module Crystal
       end
     end
 
-    describe "array methods" do
+    describe ArrayLiteral do
       it "executes index 0" do
         assert_macro "", %({{[1, 2, 3][0]}}), [] of ASTNode, "1"
       end
@@ -633,6 +633,56 @@ module Crystal
         context "without either argument" do
           it "returns the resulting array" do
             assert_macro "", %({{[1, 2, 3].map_with_index { 7 }}}), [] of ASTNode, %([7, 7, 7])
+          end
+        end
+      end
+
+      it "#each" do
+        assert_macro("",
+          %({% begin %}{% values = [] of Nil %}{% [1, 2, 3].each { |v| values << v } %}{{values}}{% end %}),
+          [] of ASTNode,
+          %([1, 2, 3])
+        )
+      end
+
+      describe "#each_with_index" do
+        context "with both arguments" do
+          it "builds the correct array" do
+            assert_macro("",
+              %({% begin %}{% values = [] of Nil %}{% [1, 2, 3].each_with_index { |v, idx| values << (v + idx) } %}{{values}}{% end %}),
+              [] of ASTNode,
+              %([1, 3, 5])
+            )
+          end
+        end
+
+        context "without the index argument" do
+          it "builds the correct array" do
+            assert_macro("",
+              %({% begin %}{% values = [] of Nil %}{% [1, 2, 3].each_with_index { |v| values << v } %}{{values}}{% end %}),
+              [] of ASTNode,
+              %([1, 2, 3])
+            )
+          end
+        end
+
+        context "without the element argument" do
+          it "builds the correct array" do
+            assert_macro("",
+              %({% begin %}{% values = [] of Nil %}{% [1, 2, 3].each_with_index { |_, idx| values << idx } %}{{values}}{% end %}),
+              [] of ASTNode,
+              %([0, 1, 2])
+            )
+          end
+        end
+
+        context "without either argument" do
+          it "builds the correct array" do
+            assert_macro("",
+              %({% begin %}{% values = [] of Nil %}{% [1, 2, 3].each_with_index { values << 7 } %}{{values}}{% end %}),
+              [] of ASTNode,
+              %([7, 7, 7])
+            )
           end
         end
       end
@@ -768,7 +818,7 @@ module Crystal
       end
     end
 
-    describe "hash methods" do
+    describe HashLiteral do
       it "executes size" do
         assert_macro "", %({{{:a => 1, :b => 3}.size}}), [] of ASTNode, "2"
       end
@@ -855,9 +905,51 @@ module Crystal
       it "executes double splat with arg" do
         assert_macro "", %({{{1 => 2, 3 => 4}.double_splat(", ")}}), [] of ASTNode, "1 => 2, 3 => 4, "
       end
+
+      describe "#each" do
+        context "with both arguments" do
+          it "builds the correct array" do
+            assert_macro("",
+              %({% begin %}{% values = [] of Nil %}{% {"k1" => "v1", "k2" => "v2"}.each { |k, v| values << {k, v} } %}{{values}}{% end %}),
+              [] of ASTNode,
+              %([{"k1", "v1"}, {"k2", "v2"}])
+            )
+          end
+        end
+
+        context "without the value argument" do
+          it "builds the correct array" do
+            assert_macro("",
+              %({% begin %}{% values = [] of Nil %}{% {"k1" => "v1", "k2" => "v2"}.each { |k| values << k } %}{{values}}{% end %}),
+              [] of ASTNode,
+              %(["k1", "k2"])
+            )
+          end
+        end
+
+        context "without the key argument" do
+          it "builds the correct array" do
+            assert_macro("",
+              %({% begin %}{% values = [] of Nil %}{% {"k1" => "v1", "k2" => "v2"}.each { |_, v| values << v } %}{{values}}{% end %}),
+              [] of ASTNode,
+              %(["v1", "v2"])
+            )
+          end
+        end
+
+        context "without either argument" do
+          it "builds the correct array" do
+            assert_macro("",
+              %({% begin %}{% values = [] of Nil %}{% {"k1" => "v1", "k2" => "v2"}.each { values << {"k3", "v3"} } %}{{values}}{% end %}),
+              [] of ASTNode,
+              %([{"k3", "v3"}, {"k3", "v3"}])
+            )
+          end
+        end
+      end
     end
 
-    describe "named tuple literal methods" do
+    describe NamedTupleLiteral do
       it "executes size" do
         assert_macro "", %({{{a: 1, b: 3}.size}}), [] of ASTNode, "2"
       end
@@ -923,9 +1015,51 @@ module Crystal
       it "executes double splat with arg" do
         assert_macro "", %({{{a: 1, "foo bar": 2}.double_splat(", ")}}), [] of ASTNode, %(a: 1, "foo bar": 2, )
       end
+
+      describe "#each" do
+        context "with both arguments" do
+          it "builds the correct array" do
+            assert_macro("",
+              %({% begin %}{% values = [] of Nil %}{% {k1: "v1", k2: "v2"}.each { |k, v| values << {k, v} } %}{{values}}{% end %}),
+              [] of ASTNode,
+              %([{k1, "v1"}, {k2, "v2"}])
+            )
+          end
+        end
+
+        context "without the value argument" do
+          it "builds the correct array" do
+            assert_macro("",
+              %({% begin %}{% values = [] of Nil %}{% {k1: "v1", k2: "v2"}.each { |k| values << k } %}{{values}}{% end %}),
+              [] of ASTNode,
+              %([k1, k2])
+            )
+          end
+        end
+
+        context "without the key argument" do
+          it "builds the correct array" do
+            assert_macro("",
+              %({% begin %}{% values = [] of Nil %}{% {k1: "v1", k2: "v2"}.each { |_, v| values << v } %}{{values}}{% end %}),
+              [] of ASTNode,
+              %(["v1", "v2"])
+            )
+          end
+        end
+
+        context "without either argument" do
+          it "builds the correct array" do
+            assert_macro("",
+              %({% begin %}{% values = [] of Nil %}{% {k1: "v1", k2: "v2"}.each { values << {"k3", "v3"} } %}{{values}}{% end %}),
+              [] of ASTNode,
+              %([{"k3", "v3"}, {"k3", "v3"}])
+            )
+          end
+        end
+      end
     end
 
-    describe "tuple methods" do
+    describe TupleLiteral do
       it "executes index 0" do
         assert_macro "", %({{ {1, 2, 3}[0] }}), [] of ASTNode, "1"
       end
@@ -988,6 +1122,56 @@ module Crystal
         context "without either argument" do
           it "returns the resulting tuple" do
             assert_macro "", %({{{1, 2, 3}.map_with_index { 7 }}}), [] of ASTNode, %({7, 7, 7})
+          end
+        end
+      end
+
+      it "#each" do
+        assert_macro("",
+          %({% begin %}{% values = [] of Nil %}{% {1, 2, 3}.each { |v| values << v } %}{{values}}{% end %}),
+          [] of ASTNode,
+          %([1, 2, 3])
+        )
+      end
+
+      describe "#each_with_index" do
+        context "with both arguments" do
+          it "builds the correct array" do
+            assert_macro("",
+              %({% begin %}{% values = [] of Nil %}{% {1, 2, 3}.each_with_index { |v, idx| values << (v + idx) } %}{{values}}{% end %}),
+              [] of ASTNode,
+              %([1, 3, 5])
+            )
+          end
+        end
+
+        context "without the index argument" do
+          it "builds the correct array" do
+            assert_macro("",
+              %({% begin %}{% values = [] of Nil %}{% {1, 2, 3}.each_with_index { |v| values << v } %}{{values}}{% end %}),
+              [] of ASTNode,
+              %([1, 2, 3])
+            )
+          end
+        end
+
+        context "without the element argument" do
+          it "builds the correct array" do
+            assert_macro("",
+              %({% begin %}{% values = [] of Nil %}{% {1, 2, 3}.each_with_index { |_, idx| values << idx } %}{{values}}{% end %}),
+              [] of ASTNode,
+              %([0, 1, 2])
+            )
+          end
+        end
+
+        context "without either argument" do
+          it "builds the correct array" do
+            assert_macro("",
+              %({% begin %}{% values = [] of Nil %}{% {1, 2, 3}.each_with_index { values << 7 } %}{{values}}{% end %}),
+              [] of ASTNode,
+              %([7, 7, 7])
+            )
           end
         end
       end
@@ -1962,7 +2146,7 @@ module Crystal
       end
     end
 
-    describe "range methods" do
+    describe RangeLiteral do
       it "executes begin" do
         assert_macro "x", %({{x.begin}}), [RangeLiteral.new(1.int32, 2.int32, true)] of ASTNode, "1"
       end
@@ -1983,6 +2167,14 @@ module Crystal
       it "executes to_a" do
         assert_macro "x", %({{x.to_a}}), [RangeLiteral.new(1.int32, 3.int32, false)] of ASTNode, %([1, 2, 3])
         assert_macro "x", %({{x.to_a}}), [RangeLiteral.new(1.int32, 3.int32, true)] of ASTNode, %([1, 2])
+      end
+
+      it "#each" do
+        assert_macro("",
+          %({% begin %}{% values = [] of Nil %}{% (1..3).each { |v| values << v } %}{{values}}{% end %}),
+          [] of ASTNode,
+          %([1, 2, 3])
+        )
       end
     end
 

--- a/src/compiler/crystal/macros.cr
+++ b/src/compiler/crystal/macros.cr
@@ -569,11 +569,11 @@ module Crystal::Macros
   # An array literal.
   class ArrayLiteral < ASTNode
     # Similar to `Enumerable#any?`
-    def any?(&block) : BoolLiteral
+    def any?(&) : BoolLiteral
     end
 
     # Similar to `Enumerable#all?`
-    def all?(&block) : BoolLiteral
+    def all?(&) : BoolLiteral
     end
 
     # Returns a `MacroId` with all of this array's elements joined
@@ -595,7 +595,7 @@ module Crystal::Macros
     end
 
     # Similar to `Enumerable#find`
-    def find(&block) : ASTNode | NilLiteral
+    def find(&) : ASTNode | NilLiteral
     end
 
     # Similar to `Array#first`, but returns a `NilLiteral` if the array is empty.
@@ -619,27 +619,35 @@ module Crystal::Macros
     end
 
     # Similar to `Enumerable#map`
-    def map(&block) : ArrayLiteral
+    def map(&) : ArrayLiteral
     end
 
     # Similar to `Enumerable#map_with_index`
-    def map_with_index(&block) : ArrayLiteral
+    def map_with_index(&) : ArrayLiteral
+    end
+
+    # Similar to `Array#each`
+    def each(&) : Nil
+    end
+
+    # Similar to `Enumerable#each_with_index`
+    def each_with_index(&) : Nil
     end
 
     # Similar to `Enumerable#select`
-    def select(&block) : ArrayLiteral
+    def select(&) : ArrayLiteral
     end
 
     # Similar to `Enumerable#reject`
-    def reject(&block) : ArrayLiteral
+    def reject(&) : ArrayLiteral
     end
 
     # Similar to `Enumerable#reduce`
-    def reduce(&block) : ASTNode
+    def reduce(&) : ASTNode
     end
 
     # Similar to `Enumerable#reduce`
-    def reduce(memo : ASTNode, &block) : ASTNode
+    def reduce(memo : ASTNode, &) : ASTNode
     end
 
     # Similar to `Array#shuffle`
@@ -651,7 +659,7 @@ module Crystal::Macros
     end
 
     # Similar to `Array#sort_by`
-    def sort_by(&block) : ArrayLiteral
+    def sort_by(&) : ArrayLiteral
     end
 
     # Similar to `Array#uniq`
@@ -699,6 +707,10 @@ module Crystal::Macros
   class HashLiteral < ASTNode
     # Similar to `Hash#clear`
     def clear : HashLiteral
+    end
+
+    # Similar to `Hash#each`
+    def each(&) : Nil
     end
 
     # Similar to `Hash#empty?`
@@ -764,6 +776,14 @@ module Crystal::Macros
 
   # A named tuple literal.
   class NamedTupleLiteral < ASTNode
+    # Similar to `NamedTuple#each`
+    def each(&) : Nil
+    end
+
+    # Similar to `NamedTuple#each_with_index`
+    def each_with_index(&) : Nil
+    end
+
     # Similar to `NamedTuple#empty?`
     def empty? : BoolLiteral
     end
@@ -807,6 +827,10 @@ module Crystal::Macros
     def begin : ASTNode
     end
 
+    # Similar to `Range#each`
+    def each(&) : Nil
+    end
+
     # Similar to `Range#end`
     def end : ASTNode
     end
@@ -817,7 +841,7 @@ module Crystal::Macros
 
     # Similar to `Enumerable#map` for a `Range`.
     # Only works on ranges of `NumberLiteral`s considered as integers.
-    def map : ArrayLiteral
+    def map(&) : ArrayLiteral
     end
 
     # Similar to `Enumerable#to_a` for a `Range`.


### PR DESCRIPTION
* Extracted from 131fcba77536997be90f7ca9b214a05ee77faab7 and 63e37f03dfa0be78f0b78799473598cd24b57c94

Since #9091 is in a holding pattern; I figured it would good to at least add some of macro methods that it was adding.  I was actually able to reimplement my DI refactor (minus the compiler passes) with just this PR, and a lot of duplication.  This will satisfy my needs until #9091 can go through a proper design phase.