### PR TITLE
Implement Process.executable_path by using Win32 API

### DIFF
--- a/src/lib_c/x86_64-windows-msvc/c/libloaderapi.cr
+++ b/src/lib_c/x86_64-windows-msvc/c/libloaderapi.cr
@@ -1,0 +1,5 @@
+require "c/winnt"
+
+lib LibC
+  fun GetModuleFileNameW(hModule : HMODULE, lpFilename : LPWSTR, nSize : DWORD) : DWORD
+end

--- a/src/lib_c/x86_64-windows-msvc/c/winnt.cr
+++ b/src/lib_c/x86_64-windows-msvc/c/winnt.cr
@@ -9,6 +9,7 @@ lib LibC
   alias LPWCH = WCHAR*
 
   alias HANDLE = Void*
+  alias HMODULE = Void*
 
   INVALID_FILE_ATTRIBUTES      = DWORD.new!(-1)
   FILE_ATTRIBUTE_DIRECTORY     =  0x10


### PR DESCRIPTION
This patch uses Win32 API to get the executable path of the current process.