### PR TITLE
Win CI: Bootstrap Crystal, build things *on* Windows, publish the binary

### DIFF
--- a/.github/workflows/win.yml
+++ b/.github/workflows/win.yml
@@ -9,9 +9,11 @@ jobs:
     steps:
       - name: Download Crystal source
         uses: actions/checkout@v2
+
       - name: Install LLVM
         run: |
           apt-get -q update; apt-get -qy install llvm-8-dev
+
       - name: Build Crystal
         run: |
           make
@@ -31,10 +33,12 @@ jobs:
       - name: Disable CRLF line ending substitution
         run: |
           git config --global core.autocrlf false
-      - name: Download Crystal source
-        uses: actions/checkout@v2
       - name: Enable Developer Command Prompt
         uses: ilammy/msvc-dev-cmd@1eed9c12159dd2d2f8804980fbba1abe36ff77d2
+
+      - name: Download Crystal source
+        uses: actions/checkout@v2
+
       - name: Cache libraries
         id: cache-libs
         uses: actions/cache@v1
@@ -59,19 +63,19 @@ jobs:
         if: steps.cache-libs.outputs.cache-hit != 'true'
         working-directory: ./bdwgc
         run: |
-          cmake . -G "Visual Studio 16 2019" -DBUILD_SHARED_LIBS=OFF -DCMAKE_POLICY_DEFAULT_CMP0091=NEW -DCMAKE_MSVC_RUNTIME_LIBRARY=MultiThreaded
+          cmake . -DBUILD_SHARED_LIBS=OFF -DCMAKE_POLICY_DEFAULT_CMP0091=NEW -DCMAKE_MSVC_RUNTIME_LIBRARY=MultiThreaded
           cmake --build . --config Release
       - name: Download libpcre
         if: steps.cache-libs.outputs.cache-hit != 'true'
         run: |
           iwr https://ftp.pcre.org/pub/pcre/pcre-8.43.zip -OutFile pcre.zip
-          Expand-Archive pcre.zip -DestinationPath .
-          mv pcre* pcre
+          7z x pcre.zip
+          mv pcre-* pcre
       - name: Build libpcre
         if: steps.cache-libs.outputs.cache-hit != 'true'
         working-directory: ./pcre
         run: |
-          cmake . -G "Visual Studio 16 2019" -DBUILD_SHARED_LIBS=OFF -DPCRE_SUPPORT_UNICODE_PROPERTIES=ON -DPCRE_SUPPORT_JIT=ON -DPCRE_STATIC_RUNTIME=ON
+          cmake . -DBUILD_SHARED_LIBS=OFF -DPCRE_SUPPORT_UNICODE_PROPERTIES=ON -DPCRE_SUPPORT_JIT=ON -DPCRE_STATIC_RUNTIME=ON
           cmake --build . --config Release
       - name: Gather libraries
         if: steps.cache-libs.outputs.cache-hit != 'true'
@@ -79,6 +83,7 @@ jobs:
           mkdir libs
           mv pcre/Release/pcre.lib libs/
           mv bdwgc/Release/gc.lib libs/
+
       - name: Download compiled object
         uses: actions/download-artifact@v1
         with:

--- a/.github/workflows/win.yml
+++ b/.github/workflows/win.yml
@@ -133,6 +133,17 @@ jobs:
         run: |
           .\crystal-cross.exe build src/compiler/crystal.cr -Di_know_what_im_doing -Dwithout_playground --link-flags=/F10000000
 
+      - name: Gather Crystal executable
+        run: |
+          mkdir crystal
+          cp crystal.exe crystal/
+          cp libs/* crystal/
+      - name: Upload Crystal executable
+        uses: actions/upload-artifact@v1
+        with:
+          name: crystal
+          path: crystal
+
       - name: Build stdlib specs executable
         run: |
           .\crystal.exe build spec/std_spec.cr --exclude-warnings spec/std -Dwithout_zlib -Dwithout_openssl -Di_know_what_im_doing

--- a/.github/workflows/win.yml
+++ b/.github/workflows/win.yml
@@ -14,17 +14,18 @@ jobs:
         run: |
           apt-get -q update; apt-get -qy install llvm-8-dev
 
-      - name: Build Crystal
+      - name: Build LLVM extensions
         run: |
-          make
-      - name: Cross-compile stdlib specs
+          make deps
+      - name: Cross-compile Crystal
         run: |
-          bin/crystal build --cross-compile --target x86_64-pc-windows-msvc --exclude-warnings spec/std spec/std_spec.cr -Dwithout_zlib -Dwithout_openssl
-      - name: Upload compiled object
+          LLVM_TARGETS=X86 bin/crystal build --cross-compile --target x86_64-pc-windows-msvc src/compiler/crystal.cr -Dwithout_playground
+
+      - name: Upload Crystal object file
         uses: actions/upload-artifact@v1
         with:
           name: objs
-          path: std_spec.o
+          path: crystal.o
 
   windows-job:
     needs: linux-job
@@ -63,7 +64,7 @@ jobs:
         if: steps.cache-libs.outputs.cache-hit != 'true'
         working-directory: ./bdwgc
         run: |
-          cmake . -DBUILD_SHARED_LIBS=OFF -DCMAKE_POLICY_DEFAULT_CMP0091=NEW -DCMAKE_MSVC_RUNTIME_LIBRARY=MultiThreaded
+          cmake . -DBUILD_SHARED_LIBS=OFF -Denable_large_config=ON -DCMAKE_POLICY_DEFAULT_CMP0091=NEW -DCMAKE_MSVC_RUNTIME_LIBRARY=MultiThreaded
           cmake --build . --config Release
       - name: Download libpcre
         if: steps.cache-libs.outputs.cache-hit != 'true'
@@ -84,13 +85,57 @@ jobs:
           mv pcre/Release/pcre.lib libs/
           mv bdwgc/Release/gc.lib libs/
 
-      - name: Download compiled object
+      - name: Cache LLVM
+        id: cache-llvm
+        uses: actions/cache@v1
+        with:
+          path: llvm
+          key: llvm-libs-10.0.0
+      - name: Download LLVM
+        if: steps.cache-llvm.outputs.cache-hit != 'true'
+        run: |
+          iwr https://github.com/llvm/llvm-project/releases/download/llvmorg-10.0.0/llvm-10.0.0.src.tar.xz -OutFile llvm.tar.xz
+          7z x llvm.tar.xz
+          7z x llvm.tar
+          mv llvm-* llvm-src
+      - name: Build LLVM
+        if: steps.cache-llvm.outputs.cache-hit != 'true'
+        working-directory: ./llvm-src
+        run: |
+          cmake . -Thost=x64 -DLLVM_TARGETS_TO_BUILD="X86" -DLLVM_USE_CRT_RELEASE=MT -DBUILD_SHARED_LIBS=OFF
+          cmake --build . --config Release
+      - name: Gather LLVM
+        if: steps.cache-llvm.outputs.cache-hit != 'true'
+        run: |
+          mv llvm-src/Release llvm
+          mv llvm-src/include llvm/
+
+      - name: Set up environment
+        run: |
+          echo "::set-env name=CRYSTAL_PATH::src"
+          echo "::set-env name=LIB::${env:LIB};$(pwd)\libs"
+          echo "::set-env name=TERM::dumb"
+          echo "::set-env name=LLVM_CONFIG::$(pwd)\llvm\bin\llvm-config.exe"
+          echo "::set-env name=SOURCE_DATE_EPOCH::$(Get-Date -Millisecond 0 -UFormat %s)"
+
+      - name: Download Crystal object file
         uses: actions/download-artifact@v1
         with:
           name: objs
-      - name: Link stdlib spec executable
+      - name: Build LLVM extensions
         run: |
-          cl objs\std_spec.o /Festd_spec libs\pcre.lib libs\gc.lib advapi32.lib libcmt.lib legacy_stdio_definitions.lib
+          cl /MT /c src\llvm\ext\llvm_ext.cc -I llvm\include /Fosrc\llvm\ext\llvm_ext.o
+      - name: Link Crystal executable
+        run: |
+          Invoke-Expression "cl objs\crystal.o /Fecrystal-cross src\llvm\ext\llvm_ext.o $(llvm\bin\llvm-config.exe --libs) libs\pcre.lib libs\gc.lib advapi32.lib libcmt.lib legacy_stdio_definitions.lib /F10000000"
+
+      - name: Re-build Crystal
+        run: |
+          .\crystal-cross.exe build src/compiler/crystal.cr -Di_know_what_im_doing -Dwithout_playground --link-flags=/F10000000
+
+      - name: Build stdlib specs executable
+        run: |
+          .\crystal.exe build spec/std_spec.cr --exclude-warnings spec/std -Dwithout_zlib -Dwithout_openssl -Di_know_what_im_doing
       - name: Run stdlib specs
         run: |
           .\std_spec.exe


### PR DESCRIPTION
Example:
First run: https://github.com/crystal-lang/crystal/runs/598199987
With cache: https://github.com/crystal-lang/crystal/runs/598303791

Sadly, LLVM here, if not cached, takes 1 hour to build. Although future builds will not need to build it, this might be too much reliance on the cache. Ideally Crystal org would provide a pre-built LLVM download. There is no official download that has the necessary "*.lib" files. Zig lang [provides LLVM downloads](https://github.com/ziglang/zig/wiki/Building-Zig-on-Windows) but surely we can't just use it.

In the future, if there is also a permanent place to grab a "crystal.exe" from, we can just drop the Linux step from this.