### PR TITLE
Compiler: don't bleed annotations into other scopes

### DIFF
--- a/spec/compiler/semantic/annotation_spec.cr
+++ b/spec/compiler/semantic/annotation_spec.cr
@@ -943,4 +943,15 @@ describe "Semantic: annotation" do
       ),
       "can't declare type inside annotation Ann"
   end
+
+  it "doesn't bleed annotation from class into class variable (#8314)" do
+    semantic(%(
+      annotation Attr; end
+
+      @[Attr]
+      class Bar
+        @@x = 0
+      end
+      ))
+  end
 end

--- a/src/compiler/crystal/semantic/semantic_visitor.cr
+++ b/src/compiler/crystal/semantic/semantic_visitor.cr
@@ -520,7 +520,15 @@ abstract class Crystal::SemanticVisitor < Crystal::Visitor
   def pushing_type(type : ModuleType)
     old_type = @current_type
     @current_type = type
+    read_annotations
     yield
     @current_type = old_type
+  end
+
+  # Returns the current annotations and clears them for subsequent readers.
+  def read_annotations
+    annotations = @annotations
+    @annotations = nil
+    annotations
   end
 end

--- a/src/compiler/crystal/semantic/top_level_visitor.cr
+++ b/src/compiler/crystal/semantic/top_level_visitor.cr
@@ -46,8 +46,7 @@ class Crystal::TopLevelVisitor < Crystal::SemanticVisitor
 
     scope, name, type = lookup_type_def(node)
 
-    annotations = @annotations
-    @annotations = nil
+    annotations = read_annotations
 
     created_new_type = false
 
@@ -210,8 +209,7 @@ class Crystal::TopLevelVisitor < Crystal::SemanticVisitor
   def visit(node : ModuleDef)
     check_outside_exp node, "declare module"
 
-    annotations = @annotations
-    @annotations = nil
+    annotations = read_annotations
 
     scope, name, type = lookup_type_def(node)
 
@@ -316,8 +314,7 @@ class Crystal::TopLevelVisitor < Crystal::SemanticVisitor
   def visit(node : Def)
     check_outside_exp node, "declare def"
 
-    annotations = @annotations
-    @annotations = nil
+    annotations = read_annotations
 
     process_def_annotations(node, annotations) do |annotation_type, ann|
       if annotation_type == @program.primitive_annotation
@@ -440,8 +437,7 @@ class Crystal::TopLevelVisitor < Crystal::SemanticVisitor
   def visit(node : LibDef)
     check_outside_exp node, "declare lib"
 
-    annotations = @annotations
-    @annotations = nil
+    annotations = read_annotations
 
     scope = current_type_scope(node)
 
@@ -478,8 +474,7 @@ class Crystal::TopLevelVisitor < Crystal::SemanticVisitor
   end
 
   def visit(node : CStructOrUnionDef)
-    annotations = @annotations
-    @annotations = nil
+    annotations = read_annotations
 
     packed = false
     unless node.union?
@@ -533,8 +528,7 @@ class Crystal::TopLevelVisitor < Crystal::SemanticVisitor
   def visit(node : EnumDef)
     check_outside_exp node, "declare enum"
 
-    annotations = @annotations
-    @annotations = nil
+    annotations = read_annotations
 
     annotations_doc = annotations_doc(annotations)
 
@@ -844,8 +838,7 @@ class Crystal::TopLevelVisitor < Crystal::SemanticVisitor
       node.raise "can only declare fun at lib or global scope"
     end
 
-    annotations = @annotations
-    @annotations = nil
+    annotations = read_annotations
 
     external = External.new(node.name, ([] of Arg), node.body, node.real_name).at(node)
 


### PR DESCRIPTION
Fixes #8314

I also tried it on #8983 and the snippet no longer errors.