### PR TITLE
Fix Enum#to_s for private enum

### DIFF
--- a/spec/std/enum_spec.cr
+++ b/spec/std/enum_spec.cr
@@ -11,6 +11,13 @@ enum SpecEnum2
   FORTY_FOUR
 end
 
+private enum PrivateEnum
+  FOO = 0
+  BAR = 1
+  BAZ = 2
+  QUX = 0
+end
+
 @[Flags]
 enum SpecEnumFlags
   One
@@ -18,9 +25,11 @@ enum SpecEnumFlags
   Three
 end
 
-private enum PrivateEnum
+@[Flags]
+private enum PrivateFlagsEnum
   FOO
   BAR
+  BAZ
 end
 
 enum SpecBigEnum : Int64
@@ -43,6 +52,11 @@ describe Enum do
 
     it "for private enum" do
       PrivateEnum::FOO.to_s.should eq "FOO"
+      PrivateFlagsEnum::FOO.to_s.should eq "FOO"
+      PrivateEnum::QUX.to_s.should eq "FOO"
+      String.build {|io| PrivateEnum::FOO.to_s(io)}.should eq "FOO"
+      String.build {|io| PrivateFlagsEnum::FOO.to_s(io)}.should eq "FOO"
+      String.build {|io| (PrivateFlagsEnum::FOO | PrivateFlagsEnum::BAZ).to_s(io)}.should eq "FOO | BAZ"
     end
   end
 
@@ -104,6 +118,17 @@ describe Enum do
       names.should eq([SpecEnumFlags::One, SpecEnumFlags::Three])
       values.should eq([SpecEnumFlags::One.value, SpecEnumFlags::Three.value])
     end
+
+    it "private enum" do
+      names = [] of PrivateFlagsEnum
+      values = [] of Int32
+      (PrivateFlagsEnum::FOO | PrivateFlagsEnum::BAZ).each do |name, value|
+        names << name
+        values << value
+      end
+      names.should eq([PrivateFlagsEnum::FOO, PrivateFlagsEnum::BAZ])
+      values.should eq([PrivateFlagsEnum::FOO.value, PrivateFlagsEnum::BAZ.value])
+    end
   end
 
   describe "names" do
@@ -158,6 +183,10 @@ describe Enum do
       SpecEnumFlags.from_value(3).should eq(SpecEnumFlags::One | SpecEnumFlags::Two)
       expect_raises(Exception, "Unknown enum SpecEnumFlags value: 8") { SpecEnumFlags.from_value(8) }
     end
+
+    it "for private enum" do
+      PrivateEnum.from_value(0).should eq (PrivateEnum::FOO)
+    end
   end
 
   describe "valid?" do
@@ -202,6 +231,10 @@ describe Enum do
     SpecEnum2.parse("FortyFour").should eq(SpecEnum2::FORTY_FOUR)
     SpecEnum2.parse("FORTYFOUR").should eq(SpecEnum2::FORTY_FOUR)
     SpecEnum2.parse("fortyfour").should eq(SpecEnum2::FORTY_FOUR)
+
+    PrivateEnum.parse("FOO").should eq(PrivateEnum::FOO)
+    PrivateEnum.parse("BAR").should eq(PrivateEnum::BAR)
+    PrivateEnum.parse("QUX").should eq(PrivateEnum::QUX)
   end
 
   it "parses?" do
@@ -211,6 +244,26 @@ describe Enum do
 
   it "clones" do
     SpecEnum::One.clone.should eq(SpecEnum::One)
+  end
+
+  describe ".flags" do
+    it "non-flags enum" do
+      SpecEnum.flags().should be_nil
+      SpecEnum.flags(One).should eq SpecEnum::One
+      SpecEnum.flags(One, Two).should eq SpecEnum::One | SpecEnum::Two
+    end
+
+    it "flags enum" do
+      SpecEnumFlags.flags().should be_nil
+      SpecEnumFlags.flags(One).should eq SpecEnumFlags::One
+      SpecEnumFlags.flags(One, Two).should eq SpecEnumFlags::One | SpecEnumFlags::Two
+    end
+
+    it "private flags enum" do
+      PrivateFlagsEnum.flags().should be_nil
+      PrivateFlagsEnum.flags(FOO).should eq PrivateFlagsEnum::FOO
+      PrivateFlagsEnum.flags(FOO, BAR).should eq PrivateFlagsEnum::FOO | PrivateFlagsEnum::BAR
+    end
   end
 
   describe "each" do
@@ -238,6 +291,19 @@ describe Enum do
 
       keys.should eq([SpecEnumFlags::One, SpecEnumFlags::Two, SpecEnumFlags::Three])
       values.should eq([SpecEnumFlags::One.value, SpecEnumFlags::Two.value, SpecEnumFlags::Three.value])
+    end
+
+    it "iterates private enum members" do
+      keys = [] of PrivateEnum
+      values = [] of Int32
+
+      PrivateEnum.each do |key, value|
+        keys << key
+        values << value
+      end
+
+      keys.should eq([PrivateEnum::FOO, PrivateEnum::BAR, PrivateEnum::BAZ, PrivateEnum::QUX])
+      values.should eq([PrivateEnum::FOO.value, PrivateEnum::BAR.value, PrivateEnum::BAZ.value, PrivateEnum::QUX.value])
     end
   end
 

--- a/spec/std/enum_spec.cr
+++ b/spec/std/enum_spec.cr
@@ -18,6 +18,11 @@ enum SpecEnumFlags
   Three
 end
 
+private enum PrivateEnum
+  FOO
+  BAR
+end
+
 enum SpecBigEnum : Int64
   TooBig = 4294967296i64 # == 2**32
 end
@@ -34,6 +39,10 @@ describe Enum do
       SpecEnumFlags::None.to_s.should eq("None")
       SpecEnumFlags::All.to_s.should eq("One | Two | Three")
       (SpecEnumFlags::One | SpecEnumFlags::Two).to_s.should eq("One | Two")
+    end
+
+    it "for private enum" do
+      PrivateEnum::FOO.to_s.should eq "FOO"
     end
   end
 

--- a/spec/std/enum_spec.cr
+++ b/spec/std/enum_spec.cr
@@ -54,9 +54,9 @@ describe Enum do
       PrivateEnum::FOO.to_s.should eq "FOO"
       PrivateFlagsEnum::FOO.to_s.should eq "FOO"
       PrivateEnum::QUX.to_s.should eq "FOO"
-      String.build {|io| PrivateEnum::FOO.to_s(io)}.should eq "FOO"
-      String.build {|io| PrivateFlagsEnum::FOO.to_s(io)}.should eq "FOO"
-      String.build {|io| (PrivateFlagsEnum::FOO | PrivateFlagsEnum::BAZ).to_s(io)}.should eq "FOO | BAZ"
+      String.build { |io| PrivateEnum::FOO.to_s(io) }.should eq "FOO"
+      String.build { |io| PrivateFlagsEnum::FOO.to_s(io) }.should eq "FOO"
+      String.build { |io| (PrivateFlagsEnum::FOO | PrivateFlagsEnum::BAZ).to_s(io) }.should eq "FOO | BAZ"
     end
   end
 
@@ -248,19 +248,19 @@ describe Enum do
 
   describe ".flags" do
     it "non-flags enum" do
-      SpecEnum.flags().should be_nil
+      SpecEnum.flags.should be_nil
       SpecEnum.flags(One).should eq SpecEnum::One
       SpecEnum.flags(One, Two).should eq SpecEnum::One | SpecEnum::Two
     end
 
     it "flags enum" do
-      SpecEnumFlags.flags().should be_nil
+      SpecEnumFlags.flags.should be_nil
       SpecEnumFlags.flags(One).should eq SpecEnumFlags::One
       SpecEnumFlags.flags(One, Two).should eq SpecEnumFlags::One | SpecEnumFlags::Two
     end
 
     it "private flags enum" do
-      PrivateFlagsEnum.flags().should be_nil
+      PrivateFlagsEnum.flags.should be_nil
       PrivateFlagsEnum.flags(FOO).should eq PrivateFlagsEnum::FOO
       PrivateFlagsEnum.flags(FOO, BAR).should eq PrivateFlagsEnum::FOO | PrivateFlagsEnum::BAR
     end

--- a/src/compiler/crystal/tools/doc/html/type.html
+++ b/src/compiler/crystal/tools/doc/html/type.html
@@ -54,12 +54,12 @@
     Defined in:
   </h2>
   <% locations.each do |location| %>
-    <% if url = location.url %>
-      <a href="<%= url %>#L<%= location.line_number %>" target="_blank">
-        <%= location.filename %><% if location.show_line_number %>:<%= location.line_number %><% end %>
+    <% if url = project_info.source_url(location) %>
+      <a href="<%= url %>" target="_blank">
+        <%= location.filename_in_project %><% if location.show_line_number %>:<%= location.line_number %><% end %>
       </a>
     <% else %>
-      <%= location.filename %><% if location.show_line_number %>:<%= location.line_number %><% end %>
+      <%= location.filename_in_project %><% if location.show_line_number %>:<%= location.line_number %><% end %>
     <% end %>
     <br/>
   <% end %>

--- a/src/compiler/crystal/tools/doc/html/type.html
+++ b/src/compiler/crystal/tools/doc/html/type.html
@@ -54,12 +54,12 @@
     Defined in:
   </h2>
   <% locations.each do |location| %>
-    <% if url = project_info.source_url(location) %>
-      <a href="<%= url %>" target="_blank">
-        <%= location.filename_in_project %><% if location.show_line_number %>:<%= location.line_number %><% end %>
+    <% if url = location.url %>
+      <a href="<%= url %>#L<%= location.line_number %>" target="_blank">
+        <%= location.filename %><% if location.show_line_number %>:<%= location.line_number %><% end %>
       </a>
     <% else %>
-      <%= location.filename_in_project %><% if location.show_line_number %>:<%= location.line_number %><% end %>
+      <%= location.filename %><% if location.show_line_number %>:<%= location.line_number %><% end %>
     <% end %>
     <br/>
   <% end %>

--- a/src/enum.cr
+++ b/src/enum.cr
@@ -139,10 +139,9 @@ struct Enum
     {% if @type.has_attribute?("Flags") %}
       String.build { |io| to_s(io) }
     {% else %}
-      case value
-      {% for member in @type.constants %}
-      when {{@type}}::{{member}}.value
-        {{member.stringify}}
+      {% for member, i in @type.constants %}
+        {{ (i > 0 ? "elsif" : "if").id }} value == {{@type.constant(member)}}
+          {{member.stringify}}
       {% end %}
       else
         value.to_s

--- a/src/enum.cr
+++ b/src/enum.cr
@@ -140,6 +140,8 @@ struct Enum
       String.build { |io| to_s(io) }
     {% else %}
       {% for member, i in @type.constants %}
+        # Can't use `case` here because case with duplicate values do
+        # not compile, but enums can have duplicates (such as `enum Foo; FOO = 1; BAR = 1; end`).
         {{ (i > 0 ? "elsif" : "if").id }} value == {{@type.constant(member)}}
           {{member.stringify}}
       {% end %}

--- a/src/enum.cr
+++ b/src/enum.cr
@@ -105,7 +105,7 @@ struct Enum
         found = false
         {% for member in @type.constants %}
           {% if member.stringify != "All" %}
-            if {{@type}}::{{member}}.value != 0 && value.bits_set? {{@type}}::{{member}}.value
+            if {{@type.constant(member)}} != 0 && value.bits_set? {{@type.constant(member)}}
               io << " | " if found
               io << {{member.stringify}}
               found = true
@@ -139,15 +139,15 @@ struct Enum
     {% if @type.has_attribute?("Flags") %}
       String.build { |io| to_s(io) }
     {% else %}
+      # Can't use `case` here because case with duplicate values do
+      # not compile, but enums can have duplicates (such as `enum Foo; FOO = 1; BAR = 1; end`).
       {% for member, i in @type.constants %}
-        # Can't use `case` here because case with duplicate values do
-        # not compile, but enums can have duplicates (such as `enum Foo; FOO = 1; BAR = 1; end`).
-        {{ (i > 0 ? "elsif" : "if").id }} value == {{@type.constant(member)}}
-          {{member.stringify}}
+        if value == {{@type.constant(member)}}
+          return {{member.stringify}}
+        end
       {% end %}
-      else
-        value.to_s
-      end
+
+      value.to_s
     {% end %}
   end
 
@@ -308,8 +308,8 @@ struct Enum
       return if value == 0
       {% for member in @type.constants %}
         {% if member.stringify != "All" %}
-          if includes?({{@type}}::{{member}})
-            yield {{@type}}::{{member}}, {{@type}}::{{member}}.value
+          if includes?(self.class.new({{@type.constant(member)}}))
+            yield self.class.new({{@type.constant(member)}}), {{@type.constant(member)}}
           end
         {% end %}
       {% end %}
@@ -360,7 +360,7 @@ struct Enum
       return new(value)
     {% else %}
       {% for member in @type.constants %}
-        return {{@type}}::{{member}} if {{@type}}::{{member}}.value == value
+        return new({{@type.constant(member)}}) if {{@type.constant(member)}} == value
       {% end %}
     {% end %}
     nil
@@ -435,7 +435,7 @@ struct Enum
       case string.camelcase.downcase
       {% for member in @type.constants %}
         when {{member.stringify.camelcase.downcase}}
-          {{@type}}::{{member}}
+          new({{@type.constant(member)}})
       {% end %}
       else
         nil
@@ -471,7 +471,7 @@ struct Enum
   def self.each
     {% for member in @type.constants %}
       {% unless @type.has_attribute?("Flags") && %w(none all).includes?(member.stringify.downcase) %}
-        yield {{@type}}::{{member}}, {{@type}}::{{member}}.value
+        yield new({{@type.constant(member)}}), {{@type.constant(member)}}
       {% end %}
     {% end %}
   end


### PR DESCRIPTION
`Enum#to_s` no longer relies on constant lookup which would fail if the type is declared with private visibility.

Resolves #9044