### PR TITLE
Prefer HTTP basic authentication in OAuth2 client

### DIFF
--- a/spec/std/oauth2/client_spec.cr
+++ b/spec/std/oauth2/client_spec.cr
@@ -48,7 +48,6 @@ describe OAuth2::Client do
           context.response.print response.to_json
         end
 
-        expected = %("redirect_uri=&grant_type=authorization_code&code=SDFhw39fwfg23flSfpawbef")
         address = server.bind_unused_port "::1"
 
         run_server(server) do
@@ -67,14 +66,13 @@ describe OAuth2::Client do
           context.response.print response.to_json
         end
 
-        expected = %("grant_type=password&username=user123&password=monkey&scope=read_posts")
         address = server.bind_unused_port "::1"
 
         run_server(server) do
           client = OAuth2::Client.new "[::1]", "client_id", "client_secret", port: address.port, scheme: "http"
 
           token = client.get_access_token_using_resource_owner_credentials(username: "user123", password: "monkey", scope: "read_posts")
-          token.extra.not_nil!["body"].should eq expected
+          token.extra.not_nil!["body"].should eq %("grant_type=password&username=user123&password=monkey&scope=read_posts")
           token.access_token.should eq "access_token"
         end
       end
@@ -86,14 +84,13 @@ describe OAuth2::Client do
           context.response.print response.to_json
         end
 
-        expected = %("grant_type=client_credentials&scope=read_posts")
         address = server.bind_unused_port "::1"
 
         run_server(server) do
           client = OAuth2::Client.new "[::1]", "client_id", "client_secret", port: address.port, scheme: "http"
 
           token = client.get_access_token_using_client_credentials(scope: "read_posts")
-          token.extra.not_nil!["body"].should eq expected
+          token.extra.not_nil!["body"].should eq %("grant_type=client_credentials&scope=read_posts")
           token.access_token.should eq "access_token"
         end
       end
@@ -105,14 +102,13 @@ describe OAuth2::Client do
           context.response.print response.to_json
         end
 
-        expected = %("grant_type=refresh_token&refresh_token=some_refresh_token&scope=read_posts")
         address = server.bind_unused_port "::1"
 
         run_server(server) do
           client = OAuth2::Client.new "[::1]", "client_id", "client_secret", port: address.port, scheme: "http"
 
           token = client.get_access_token_using_refresh_token(scope: "read_posts", refresh_token: "some_refresh_token")
-          token.extra.not_nil!["body"].should eq expected
+          token.extra.not_nil!["body"].should eq %("grant_type=refresh_token&refresh_token=some_refresh_token&scope=read_posts")
           token.access_token.should eq "access_token"
         end
       end
@@ -125,14 +121,13 @@ describe OAuth2::Client do
           context.response.print response.to_json
         end
 
-        expected = %("client_id=client_id&client_secret=client_secret&redirect_uri=&grant_type=authorization_code&code=SDFhw39fwfg23flSfpawbef")
         address = server.bind_unused_port "::1"
 
         run_server(server) do
           client = OAuth2::Client.new "[::1]", "client_id", "client_secret", port: address.port, scheme: "http", auth_scheme: OAuth2::AuthScheme::RequestBody
 
           token = client.get_access_token_using_authorization_code(authorization_code: "SDFhw39fwfg23flSfpawbef")
-          token.extra.not_nil!["body"].should eq expected
+          token.extra.not_nil!["body"].should eq %("client_id=client_id&client_secret=client_secret&redirect_uri=&grant_type=authorization_code&code=SDFhw39fwfg23flSfpawbef")
           token.access_token.should eq "access_token"
         end
       end
@@ -144,14 +139,13 @@ describe OAuth2::Client do
           context.response.print response.to_json
         end
 
-        expected = %("client_id=client_id&client_secret=client_secret&grant_type=password&username=user123&password=monkey&scope=read_posts")
         address = server.bind_unused_port "::1"
 
         run_server(server) do
           client = OAuth2::Client.new "[::1]", "client_id", "client_secret", port: address.port, scheme: "http", auth_scheme: OAuth2::AuthScheme::RequestBody
 
           token = client.get_access_token_using_resource_owner_credentials(username: "user123", password: "monkey", scope: "read_posts")
-          token.extra.not_nil!["body"].should eq expected
+          token.extra.not_nil!["body"].should eq %("client_id=client_id&client_secret=client_secret&grant_type=password&username=user123&password=monkey&scope=read_posts")
           token.access_token.should eq "access_token"
         end
       end
@@ -163,14 +157,13 @@ describe OAuth2::Client do
           context.response.print response.to_json
         end
 
-        expected = %("client_id=client_id&client_secret=client_secret&grant_type=client_credentials&scope=read_posts")
         address = server.bind_unused_port "::1"
 
         run_server(server) do
           client = OAuth2::Client.new "[::1]", "client_id", "client_secret", port: address.port, scheme: "http", auth_scheme: OAuth2::AuthScheme::RequestBody
 
           token = client.get_access_token_using_client_credentials(scope: "read_posts")
-          token.extra.not_nil!["body"].should eq expected
+          token.extra.not_nil!["body"].should eq %("client_id=client_id&client_secret=client_secret&grant_type=client_credentials&scope=read_posts")
           token.access_token.should eq "access_token"
         end
       end
@@ -182,14 +175,13 @@ describe OAuth2::Client do
           context.response.print response.to_json
         end
 
-        expected = %("client_id=client_id&client_secret=client_secret&grant_type=refresh_token&refresh_token=some_refresh_token&scope=read_posts")
         address = server.bind_unused_port "::1"
 
         run_server(server) do
           client = OAuth2::Client.new "[::1]", "client_id", "client_secret", port: address.port, scheme: "http", auth_scheme: OAuth2::AuthScheme::RequestBody
 
           token = client.get_access_token_using_refresh_token(scope: "read_posts", refresh_token: "some_refresh_token")
-          token.extra.not_nil!["body"].should eq expected
+          token.extra.not_nil!["body"].should eq %("client_id=client_id&client_secret=client_secret&grant_type=refresh_token&refresh_token=some_refresh_token&scope=read_posts")
           token.access_token.should eq "access_token"
         end
       end

--- a/spec/std/oauth2/client_spec.cr
+++ b/spec/std/oauth2/client_spec.cr
@@ -55,7 +55,7 @@ describe OAuth2::Client do
           client = OAuth2::Client.new "[::1]", "client_id", "client_secret", port: address.port, scheme: "http"
 
           token = client.get_access_token_using_authorization_code(authorization_code: "SDFhw39fwfg23flSfpawbef")
-          token.extra.not_nil!["body"].should eq expected
+          token.extra.not_nil!["body"].should eq %("redirect_uri=&grant_type=authorization_code&code=SDFhw39fwfg23flSfpawbef")
           token.access_token.should eq "access_token"
         end
       end

--- a/spec/std/oauth2/client_spec.cr
+++ b/spec/std/oauth2/client_spec.cr
@@ -40,79 +40,158 @@ describe OAuth2::Client do
   end
 
   describe "get_access_token_using_*" do
-    it "#get_access_token_using_authorization_code" do
-      server = HTTP::Server.new do |context|
-        body = context.request.body.not_nil!.gets_to_end
-        response = {access_token: "access_token", body: body}
-        context.response.print response.to_json
+    describe "using HTTP Basic authentication to pass credentials" do
+      it "#get_access_token_using_authorization_code" do
+        server = HTTP::Server.new do |context|
+          body = context.request.body.not_nil!.gets_to_end
+          response = {access_token: "access_token", body: body}
+          context.response.print response.to_json
+        end
+
+        expected = %("redirect_uri=&grant_type=authorization_code&code=SDFhw39fwfg23flSfpawbef")
+        address = server.bind_unused_port "::1"
+
+        run_server(server) do
+          client = OAuth2::Client.new "[::1]", "client_id", "client_secret", port: address.port, scheme: "http"
+
+          token = client.get_access_token_using_authorization_code(authorization_code: "SDFhw39fwfg23flSfpawbef")
+          token.extra.not_nil!["body"].should eq expected
+          token.access_token.should eq "access_token"
+        end
       end
 
-      expected = %("client_id=client_id&client_secret=client_secret&redirect_uri=&grant_type=authorization_code&code=SDFhw39fwfg23flSfpawbef")
-      address = server.bind_unused_port "::1"
+      it "#get_access_token_using_resource_owner_credentials" do
+        server = HTTP::Server.new do |context|
+          body = context.request.body.not_nil!.gets_to_end
+          response = {access_token: "access_token", body: body}
+          context.response.print response.to_json
+        end
 
-      run_server(server) do
-        client = OAuth2::Client.new "[::1]", "client_id", "client_secret", port: address.port, scheme: "http"
+        expected = %("grant_type=password&username=user123&password=monkey&scope=read_posts")
+        address = server.bind_unused_port "::1"
 
-        token = client.get_access_token_using_authorization_code(authorization_code: "SDFhw39fwfg23flSfpawbef")
-        token.extra.not_nil!["body"].should eq expected
-        token.access_token.should eq "access_token"
+        run_server(server) do
+          client = OAuth2::Client.new "[::1]", "client_id", "client_secret", port: address.port, scheme: "http"
+
+          token = client.get_access_token_using_resource_owner_credentials(username: "user123", password: "monkey", scope: "read_posts")
+          token.extra.not_nil!["body"].should eq expected
+          token.access_token.should eq "access_token"
+        end
+      end
+
+      it "#get_access_token_using_client_credentials" do
+        server = HTTP::Server.new do |context|
+          body = context.request.body.not_nil!.gets_to_end
+          response = {access_token: "access_token", body: body}
+          context.response.print response.to_json
+        end
+
+        expected = %("grant_type=client_credentials&scope=read_posts")
+        address = server.bind_unused_port "::1"
+
+        run_server(server) do
+          client = OAuth2::Client.new "[::1]", "client_id", "client_secret", port: address.port, scheme: "http"
+
+          token = client.get_access_token_using_client_credentials(scope: "read_posts")
+          token.extra.not_nil!["body"].should eq expected
+          token.access_token.should eq "access_token"
+        end
+      end
+
+      it "#get_access_token_using_refresh_token" do
+        server = HTTP::Server.new do |context|
+          body = context.request.body.not_nil!.gets_to_end
+          response = {access_token: "access_token", body: body}
+          context.response.print response.to_json
+        end
+
+        expected = %("grant_type=refresh_token&refresh_token=some_refresh_token&scope=read_posts")
+        address = server.bind_unused_port "::1"
+
+        run_server(server) do
+          client = OAuth2::Client.new "[::1]", "client_id", "client_secret", port: address.port, scheme: "http"
+
+          token = client.get_access_token_using_refresh_token(scope: "read_posts", refresh_token: "some_refresh_token")
+          token.extra.not_nil!["body"].should eq expected
+          token.access_token.should eq "access_token"
+        end
       end
     end
+    describe "using Request Body to pass credentials" do
+      it "#get_access_token_using_authorization_code" do
+        server = HTTP::Server.new do |context|
+          body = context.request.body.not_nil!.gets_to_end
+          response = {access_token: "access_token", body: body}
+          context.response.print response.to_json
+        end
 
-    it "#get_access_token_using_resource_owner_credentials" do
-      server = HTTP::Server.new do |context|
-        body = context.request.body.not_nil!.gets_to_end
-        response = {access_token: "access_token", body: body}
-        context.response.print response.to_json
+        expected = %("client_id=client_id&client_secret=client_secret&redirect_uri=&grant_type=authorization_code&code=SDFhw39fwfg23flSfpawbef")
+        address = server.bind_unused_port "::1"
+
+        run_server(server) do
+          client = OAuth2::Client.new "[::1]", "client_id", "client_secret", port: address.port, scheme: "http", auth_scheme: OAuth2::AuthScheme::Request_Body
+
+          token = client.get_access_token_using_authorization_code(authorization_code: "SDFhw39fwfg23flSfpawbef")
+          token.extra.not_nil!["body"].should eq expected
+          token.access_token.should eq "access_token"
+        end
       end
 
-      expected = %("client_id=client_id&client_secret=client_secret&grant_type=password&username=user123&password=monkey&scope=read_posts")
-      address = server.bind_unused_port "::1"
+      it "#get_access_token_using_resource_owner_credentials" do
+        server = HTTP::Server.new do |context|
+          body = context.request.body.not_nil!.gets_to_end
+          response = {access_token: "access_token", body: body}
+          context.response.print response.to_json
+        end
 
-      run_server(server) do
-        client = OAuth2::Client.new "[::1]", "client_id", "client_secret", port: address.port, scheme: "http"
+        expected = %("client_id=client_id&client_secret=client_secret&grant_type=password&username=user123&password=monkey&scope=read_posts")
+        address = server.bind_unused_port "::1"
 
-        token = client.get_access_token_using_resource_owner_credentials(username: "user123", password: "monkey", scope: "read_posts")
-        token.extra.not_nil!["body"].should eq expected
-        token.access_token.should eq "access_token"
-      end
-    end
+        run_server(server) do
+          client = OAuth2::Client.new "[::1]", "client_id", "client_secret", port: address.port, scheme: "http", auth_scheme: OAuth2::AuthScheme::Request_Body
 
-    it "#get_access_token_using_client_credentials" do
-      server = HTTP::Server.new do |context|
-        body = context.request.body.not_nil!.gets_to_end
-        response = {access_token: "access_token", body: body}
-        context.response.print response.to_json
-      end
-
-      expected = %("client_id=client_id&client_secret=client_secret&grant_type=client_credentials&scope=read_posts")
-      address = server.bind_unused_port "::1"
-
-      run_server(server) do
-        client = OAuth2::Client.new "[::1]", "client_id", "client_secret", port: address.port, scheme: "http"
-
-        token = client.get_access_token_using_client_credentials(scope: "read_posts")
-        token.extra.not_nil!["body"].should eq expected
-        token.access_token.should eq "access_token"
-      end
-    end
-
-    it "#get_access_token_using_refresh_token" do
-      server = HTTP::Server.new do |context|
-        body = context.request.body.not_nil!.gets_to_end
-        response = {access_token: "access_token", body: body}
-        context.response.print response.to_json
+          token = client.get_access_token_using_resource_owner_credentials(username: "user123", password: "monkey", scope: "read_posts")
+          token.extra.not_nil!["body"].should eq expected
+          token.access_token.should eq "access_token"
+        end
       end
 
-      expected = %("client_id=client_id&client_secret=client_secret&grant_type=refresh_token&refresh_token=some_refresh_token&scope=read_posts")
-      address = server.bind_unused_port "::1"
+      it "#get_access_token_using_client_credentials" do
+        server = HTTP::Server.new do |context|
+          body = context.request.body.not_nil!.gets_to_end
+          response = {access_token: "access_token", body: body}
+          context.response.print response.to_json
+        end
 
-      run_server(server) do
-        client = OAuth2::Client.new "[::1]", "client_id", "client_secret", port: address.port, scheme: "http"
+        expected = %("client_id=client_id&client_secret=client_secret&grant_type=client_credentials&scope=read_posts")
+        address = server.bind_unused_port "::1"
 
-        token = client.get_access_token_using_refresh_token(scope: "read_posts", refresh_token: "some_refresh_token")
-        token.extra.not_nil!["body"].should eq expected
-        token.access_token.should eq "access_token"
+        run_server(server) do
+          client = OAuth2::Client.new "[::1]", "client_id", "client_secret", port: address.port, scheme: "http", auth_scheme: OAuth2::AuthScheme::Request_Body
+
+          token = client.get_access_token_using_client_credentials(scope: "read_posts")
+          token.extra.not_nil!["body"].should eq expected
+          token.access_token.should eq "access_token"
+        end
+      end
+
+      it "#get_access_token_using_refresh_token" do
+        server = HTTP::Server.new do |context|
+          body = context.request.body.not_nil!.gets_to_end
+          response = {access_token: "access_token", body: body}
+          context.response.print response.to_json
+        end
+
+        expected = %("client_id=client_id&client_secret=client_secret&grant_type=refresh_token&refresh_token=some_refresh_token&scope=read_posts")
+        address = server.bind_unused_port "::1"
+
+        run_server(server) do
+          client = OAuth2::Client.new "[::1]", "client_id", "client_secret", port: address.port, scheme: "http", auth_scheme: OAuth2::AuthScheme::Request_Body
+
+          token = client.get_access_token_using_refresh_token(scope: "read_posts", refresh_token: "some_refresh_token")
+          token.extra.not_nil!["body"].should eq expected
+          token.access_token.should eq "access_token"
+        end
       end
     end
   end

--- a/spec/std/oauth2/client_spec.cr
+++ b/spec/std/oauth2/client_spec.cr
@@ -129,7 +129,7 @@ describe OAuth2::Client do
         address = server.bind_unused_port "::1"
 
         run_server(server) do
-          client = OAuth2::Client.new "[::1]", "client_id", "client_secret", port: address.port, scheme: "http", auth_scheme: OAuth2::AuthScheme::Request_Body
+          client = OAuth2::Client.new "[::1]", "client_id", "client_secret", port: address.port, scheme: "http", auth_scheme: OAuth2::AuthScheme::RequestBody
 
           token = client.get_access_token_using_authorization_code(authorization_code: "SDFhw39fwfg23flSfpawbef")
           token.extra.not_nil!["body"].should eq expected
@@ -148,7 +148,7 @@ describe OAuth2::Client do
         address = server.bind_unused_port "::1"
 
         run_server(server) do
-          client = OAuth2::Client.new "[::1]", "client_id", "client_secret", port: address.port, scheme: "http", auth_scheme: OAuth2::AuthScheme::Request_Body
+          client = OAuth2::Client.new "[::1]", "client_id", "client_secret", port: address.port, scheme: "http", auth_scheme: OAuth2::AuthScheme::RequestBody
 
           token = client.get_access_token_using_resource_owner_credentials(username: "user123", password: "monkey", scope: "read_posts")
           token.extra.not_nil!["body"].should eq expected
@@ -167,7 +167,7 @@ describe OAuth2::Client do
         address = server.bind_unused_port "::1"
 
         run_server(server) do
-          client = OAuth2::Client.new "[::1]", "client_id", "client_secret", port: address.port, scheme: "http", auth_scheme: OAuth2::AuthScheme::Request_Body
+          client = OAuth2::Client.new "[::1]", "client_id", "client_secret", port: address.port, scheme: "http", auth_scheme: OAuth2::AuthScheme::RequestBody
 
           token = client.get_access_token_using_client_credentials(scope: "read_posts")
           token.extra.not_nil!["body"].should eq expected
@@ -186,7 +186,7 @@ describe OAuth2::Client do
         address = server.bind_unused_port "::1"
 
         run_server(server) do
-          client = OAuth2::Client.new "[::1]", "client_id", "client_secret", port: address.port, scheme: "http", auth_scheme: OAuth2::AuthScheme::Request_Body
+          client = OAuth2::Client.new "[::1]", "client_id", "client_secret", port: address.port, scheme: "http", auth_scheme: OAuth2::AuthScheme::RequestBody
 
           token = client.get_access_token_using_refresh_token(scope: "read_posts", refresh_token: "some_refresh_token")
           token.extra.not_nil!["body"].should eq expected

--- a/src/oauth2/auth_scheme.cr
+++ b/src/oauth2/auth_scheme.cr
@@ -1,0 +1,4 @@
+enum OAuth2::AuthScheme
+  HTTP_Basic
+  Request_Body
+end

--- a/src/oauth2/auth_scheme.cr
+++ b/src/oauth2/auth_scheme.cr
@@ -11,6 +11,6 @@
 # be used if the server does not support HTTP Basic.
 #  
 enum OAuth2::AuthScheme
-  HTTP_Basic
-  Request_Body
+  HTTPBasic
+  RequestBody
 end

--- a/src/oauth2/auth_scheme.cr
+++ b/src/oauth2/auth_scheme.cr
@@ -1,3 +1,15 @@
+# Enum of supported mechanisms used to pass credentials to the server.
+#
+# According to https://tools.ietf.org/html/rfc6749#section-2.3.1:
+#
+# "Including the client credentials in the request-body using the
+#  two parameters is NOT RECOMMENDED and SHOULD be limited to
+#  clients unable to directly utilize the HTTP Basic authentication
+#   scheme (or other password-based HTTP authentication schemes)."
+#
+# Therefore, HTTP Basic is preferred, and Request Body should only
+# be used if the server does not support HTTP Basic.
+#  
 enum OAuth2::AuthScheme
   HTTP_Basic
   Request_Body

--- a/src/oauth2/auth_scheme.cr
+++ b/src/oauth2/auth_scheme.cr
@@ -9,7 +9,6 @@
 #
 # Therefore, HTTP Basic is preferred, and Request Body should only
 # be used if the server does not support HTTP Basic.
-#  
 enum OAuth2::AuthScheme
   HTTPBasic
   RequestBody

--- a/src/oauth2/auth_scheme.cr
+++ b/src/oauth2/auth_scheme.cr
@@ -2,10 +2,10 @@
 #
 # According to https://tools.ietf.org/html/rfc6749#section-2.3.1:
 #
-# "Including the client credentials in the request-body using the
-#  two parameters is NOT RECOMMENDED and SHOULD be limited to
-#  clients unable to directly utilize the HTTP Basic authentication
-#   scheme (or other password-based HTTP authentication schemes)."
+# > "Including the client credentials in the request-body using the
+# > two parameters is NOT RECOMMENDED and SHOULD be limited to
+# > clients unable to directly utilize the HTTP Basic authentication
+# > scheme (or other password-based HTTP authentication schemes)."
 #
 # Therefore, HTTP Basic is preferred, and Request Body should only
 # be used if the server does not support HTTP Basic.

--- a/src/oauth2/client.cr
+++ b/src/oauth2/client.cr
@@ -60,6 +60,12 @@ class OAuth2::Client
   # *token_uri* can be relative or absolute.
   # If they are relative, the given *host*, *port* and *scheme* will be used.
   # If they are absolute, the absolute URL will be used.
+  #
+  # As per https://tools.ietf.org/html/rfc6749#section-2.3.1,
+  # HTTP Basic is the default `auth_scheme` (the mechanism used to
+  #  transmit the client credentials to the server).
+  #  Request Body should only be used if the server does not support
+  #  HTTP Basic.
   def initialize(@host : String, @client_id : String, @client_secret : String,
                  @port : Int32? = nil,
                  @scheme = "https",

--- a/src/oauth2/client.cr
+++ b/src/oauth2/client.cr
@@ -72,7 +72,7 @@ class OAuth2::Client
                  @authorize_uri = "/oauth2/authorize",
                  @token_uri = "/oauth2/token",
                  @redirect_uri : String? = nil,
-                 @auth_scheme = AuthScheme::HTTP_Basic)
+                 @auth_scheme = AuthScheme::HTTPBasic)
   end
 
   # Builds an authorize URI, as specified by

--- a/src/oauth2/client.cr
+++ b/src/oauth2/client.cr
@@ -188,7 +188,7 @@ class OAuth2::Client
     if uri.host
       uri
     else
-      URI.new(scheme, host, port)
+      URI.new(scheme, host, port, token_uri)
     end
   end
 end

--- a/src/oauth2/client.cr
+++ b/src/oauth2/client.cr
@@ -54,8 +54,6 @@
 # You can also use an `OAuth2::Session` to automatically refresh expired
 # tokens before each request.
 class OAuth2::Client
-  private getter host, client_id, client_secret, port, scheme, authorize_uri,
-    redirect_uri, auth_scheme
 
   # Creates an OAuth client.
   #
@@ -89,16 +87,16 @@ class OAuth2::Client
   # Yields an `HTTP::Params::Builder` to add extra parameters other than those
   # defined by the standard.
   def get_authorize_uri(scope = nil, state = nil, &block : HTTP::Params::Builder ->) : String
-    uri = URI.parse(authorize_uri)
+    uri = URI.parse(@authorize_uri)
 
     # Use the default URI if it's not an absolute one
     unless uri.host
-      uri = URI.new(scheme, host, port, authorize_uri)
+      uri = URI.new(@scheme, @host, @port, @authorize_uri)
     end
 
     uri.query = HTTP::Params.build do |form|
-      form.add "client_id", client_id
-      form.add "redirect_uri", redirect_uri
+      form.add "client_id", @client_id
+      form.add "redirect_uri", @redirect_uri
       form.add "response_type", "code"
       form.add "scope", scope unless scope.nil?
       form.add "state", state unless state.nil?
@@ -117,7 +115,7 @@ class OAuth2::Client
   # [RFC 6749, Section 4.1.3](https://tools.ietf.org/html/rfc6749#section-4.1.3).
   def get_access_token_using_authorization_code(authorization_code : String) : AccessToken
     get_access_token do |form|
-      form.add("redirect_uri", redirect_uri)
+      form.add("redirect_uri", @redirect_uri)
       form.add("grant_type", "authorization_code")
       form.add("code", authorization_code)
     end
@@ -160,14 +158,14 @@ class OAuth2::Client
     }
 
     body = HTTP::Params.build do |form|
-      case auth_scheme
+      case @auth_scheme
       when .request_body?
-        form.add("client_id", client_id)
-        form.add("client_secret", client_secret)
+        form.add("client_id", @client_id)
+        form.add("client_secret", @client_secret)
       when .http_basic?
         headers.add(
           "Authorization",
-          "Basic #{Base64.strict_encode("#{client_id}:#{client_secret}")}"
+          "Basic #{Base64.strict_encode("#{@client_id}:#{@client_secret}")}"
         )
       end
       yield form
@@ -187,7 +185,7 @@ class OAuth2::Client
     if uri.host
       uri
     else
-      URI.new(scheme, host, port, @token_uri)
+      URI.new(@scheme, @host, @port, @token_uri)
     end
   end
 end

--- a/src/oauth2/client.cr
+++ b/src/oauth2/client.cr
@@ -168,7 +168,7 @@ class OAuth2::Client
       when .http_basic?
         headers.add(
           "Authorization",
-          "Basic #{Base64.strict_encode "#{@client_id}:#{@client_secret}"}"
+          "Basic #{Base64.strict_encode("#{client_id}:#{client_secret}")}"
         )
       end
       yield form

--- a/src/oauth2/client.cr
+++ b/src/oauth2/client.cr
@@ -75,7 +75,7 @@ class OAuth2::Client
                  @authorize_uri = "/oauth2/authorize",
                  @token_uri = "/oauth2/token",
                  @redirect_uri : String? = nil,
-                 @auth_scheme : AuthScheme = AuthScheme::HTTPBasic)
+                 @auth_scheme : AuthScheme = :http_basic)
   end
 
   # Builds an authorize URI, as specified by

--- a/src/oauth2/client.cr
+++ b/src/oauth2/client.cr
@@ -54,7 +54,6 @@
 # You can also use an `OAuth2::Session` to automatically refresh expired
 # tokens before each request.
 class OAuth2::Client
-
   # Creates an OAuth client.
   #
   # Any or all of the customizable URIs *authorize_uri* and

--- a/src/oauth2/client.cr
+++ b/src/oauth2/client.cr
@@ -65,10 +65,9 @@ class OAuth2::Client
   # If they are absolute, the absolute URL will be used.
   #
   # As per https://tools.ietf.org/html/rfc6749#section-2.3.1,
-  # HTTP Basic is the default `auth_scheme` (the mechanism used to
-  #  transmit the client credentials to the server).
-  #  Request Body should only be used if the server does not support
-  #  HTTP Basic.
+  # `AuthScheme::HTTPBasic` is the default *auth_scheme* (the mechanism used to
+  # transmit the client credentials to the server). `AuthScheme::RequestBody` should
+  # only be used if the server does not support HTTP Basic.
   def initialize(@host : String, @client_id : String, @client_secret : String,
                  @port : Int32? = nil,
                  @scheme = "https",

--- a/src/oauth2/client.cr
+++ b/src/oauth2/client.cr
@@ -55,7 +55,7 @@
 # tokens before each request.
 class OAuth2::Client
   private getter host, client_id, client_secret, port, scheme, authorize_uri,
-    redirect_uri, auth_scheme, token_uri
+    redirect_uri, auth_scheme
 
   # Creates an OAuth client.
   #
@@ -173,7 +173,7 @@ class OAuth2::Client
       yield form
     end
 
-    response = HTTP::Client.post get_token_uri, form: body, headers: headers
+    response = HTTP::Client.post token_uri, form: body, headers: headers
     case response.status
     when .ok?, .created?
       OAuth2::AccessToken.from_json(response.body)
@@ -182,12 +182,12 @@ class OAuth2::Client
     end
   end
 
-  private def get_token_uri : URI
-    uri = URI.parse(token_uri)
+  private def token_uri : URI
+    uri = URI.parse(@token_uri)
     if uri.host
       uri
     else
-      URI.new(scheme, host, port, token_uri)
+      URI.new(scheme, host, port, @token_uri)
     end
   end
 end


### PR DESCRIPTION
As discussed in forum post [Can't get OAuth2 access token with grant type client credentials](https://forum.crystal-lang.org/t/cant-get-oauth2-access-token-with-grant-type-client-credentials/1958), the preferred behaviour should be to use HTTP Basic authentication to pass client  credentials.

This PR provides the option to specify HTTP Basic or passing the credentials in the request body when creating the client, with HTTP Basic as the default.