### PR TITLE
Refactor to standardize on first argument for methods receiving `IO`

### DIFF
--- a/spec/std/enumerable_spec.cr
+++ b/spec/std/enumerable_spec.cr
@@ -620,25 +620,35 @@ describe "Enumerable" do
     end
   end
 
-  describe "join" do
-    it "joins with separator and block" do
-      str = [1, 2, 3].join(", ") { |x| x + 1 }
-      str.should eq("2, 3, 4")
+  describe "#join" do
+    it "()" do
+      [1, 2, 3].join.should eq("123")
     end
 
-    it "joins without separator and block" do
+    it "(separator)" do
+      ["Ruby", "Crystal", "Python"].join(", ").should eq "Ruby, Crystal, Python"
+    end
+
+    it "(&)" do
       str = [1, 2, 3].join { |x| x + 1 }
       str.should eq("234")
     end
 
-    it "joins with io and block" do
+    it "(separator, &)" do
+      str = [1, 2, 3].join(", ") { |x| x + 1 }
+      str.should eq("2, 3, 4")
+    end
+
+    it "(separator, io)" do
+      io = IO::Memory.new
+      ["Ruby", "Crystal", "Python"].join(", ", io)
+      io.to_s.should eq "Ruby, Crystal, Python"
+    end
+
+    it "(separator, io, &)" do
       str = IO::Memory.new
       [1, 2, 3].join(", ", str) { |x, io| io << x + 1 }
       str.to_s.should eq("2, 3, 4")
-    end
-
-    it "joins with only separator" do
-      ["Ruby", "Crystal", "Python"].join(", ").should eq "Ruby, Crystal, Python"
     end
   end
 

--- a/spec/std/enumerable_spec.cr
+++ b/spec/std/enumerable_spec.cr
@@ -639,13 +639,37 @@ describe "Enumerable" do
       str.should eq("2, 3, 4")
     end
 
-    it "(separator, io)" do
+    it "(io)" do
+      io = IO::Memory.new
+      [1, 2, 3].join(io)
+      io.to_s.should eq("123")
+    end
+
+    it "(io, separator)" do
+      io = IO::Memory.new
+      ["Ruby", "Crystal", "Python"].join(io, ", ")
+      io.to_s.should eq "Ruby, Crystal, Python"
+    end
+
+    it "(separator, io) (deprecated)" do
       io = IO::Memory.new
       ["Ruby", "Crystal", "Python"].join(", ", io)
       io.to_s.should eq "Ruby, Crystal, Python"
     end
 
-    it "(separator, io, &)" do
+    it "(io, &)" do
+      io = IO::Memory.new
+      [1, 2, 3].join(io) { |x, io| io << x + 1 }
+      io.to_s.should eq("234")
+    end
+
+    it "(io, separator, &)" do
+      io = IO::Memory.new
+      [1, 2, 3].join(io, ", ") { |x, io| io << x + 1 }
+      io.to_s.should eq("2, 3, 4")
+    end
+
+    it "(separator, io, &) (deprecated)" do
       str = IO::Memory.new
       [1, 2, 3].join(", ", str) { |x, io| io << x + 1 }
       str.to_s.should eq("2, 3, 4")

--- a/spec/std/int_spec.cr
+++ b/spec/std/int_spec.cr
@@ -174,6 +174,7 @@ describe "Int" do
     it { 1234.to_s(36).should eq("ya") }
     it { -1234.to_s(36).should eq("-ya") }
     it { 1234.to_s(16, upcase: true).should eq("4D2") }
+    it { 1234.to_s(16, true).should eq("4D2") } # Deprecated test
     it { -1234.to_s(16, upcase: true).should eq("-4D2") }
     it { 1234.to_s(36, upcase: true).should eq("YA") }
     it { -1234.to_s(36, upcase: true).should eq("-YA") }

--- a/spec/std/int_spec.cr
+++ b/spec/std/int_spec.cr
@@ -4,11 +4,13 @@ require "./spec_helper"
 {% end %}
 
 private def to_s_with_io(num)
-  String.build { |str| num.to_s(str) }
+  String.build { |io| num.to_s(io) }
 end
 
 private def to_s_with_io(num, base, upcase = false)
-  String.build { |str| num.to_s(base, str, upcase) }
+  String.build { |io| num.to_s(io, base, upcase: upcase) }
+  # Test deprecated overload:
+  String.build { |io| num.to_s(base, io, upcase) }
 end
 
 describe "Int" do

--- a/spec/std/string_spec.cr
+++ b/spec/std/string_spec.cr
@@ -2031,6 +2031,13 @@ describe "String" do
     it { "12".ljust(7, 'あ').should eq("12あああああ") }
 
     describe "to io" do
+      it { with_io_memory { |io| "123".ljust(io, 2) }.should eq("123") }
+      it { with_io_memory { |io| "123".ljust(io, 5) }.should eq("123  ") }
+      it { with_io_memory { |io| "12".ljust(io, 7, '-') }.should eq("12-----") }
+      it { with_io_memory { |io| "12".ljust(io, 7, 'あ') }.should eq("12あああああ") }
+    end
+
+    describe "to io (deprecated)" do
       it { with_io_memory { |io| "123".ljust(2, io) }.should eq("123") }
       it { with_io_memory { |io| "123".ljust(5, io) }.should eq("123  ") }
       it { with_io_memory { |io| "12".ljust(7, '-', io) }.should eq("12-----") }
@@ -2045,6 +2052,13 @@ describe "String" do
     it { "12".rjust(7, 'あ').should eq("あああああ12") }
 
     describe "to io" do
+      it { with_io_memory { |io| "123".rjust(io, 2) }.should eq("123") }
+      it { with_io_memory { |io| "123".rjust(io, 5) }.should eq("  123") }
+      it { with_io_memory { |io| "12".rjust(io, 7, '-') }.should eq("-----12") }
+      it { with_io_memory { |io| "12".rjust(io, 7, 'あ') }.should eq("あああああ12") }
+    end
+
+    describe "to io (deprecated)" do
       it { with_io_memory { |io| "123".rjust(2, io) }.should eq("123") }
       it { with_io_memory { |io| "123".rjust(5, io) }.should eq("  123") }
       it { with_io_memory { |io| "12".rjust(7, '-', io) }.should eq("-----12") }
@@ -2059,6 +2073,13 @@ describe "String" do
     it { "12".center(7, 'あ').should eq("ああ12あああ") }
 
     describe "to io" do
+      it { with_io_memory { |io| "123".center(io, 2) }.should eq("123") }
+      it { with_io_memory { |io| "123".center(io, 5) }.should eq(" 123 ") }
+      it { with_io_memory { |io| "12".center(io, 7, '-') }.should eq("--12---") }
+      it { with_io_memory { |io| "12".center(io, 7, 'あ') }.should eq("ああ12あああ") }
+    end
+
+    describe "to io (deprecated)" do
       it { with_io_memory { |io| "123".center(2, io) }.should eq("123") }
       it { with_io_memory { |io| "123".center(5, io) }.should eq(" 123 ") }
       it { with_io_memory { |io| "12".center(7, '-', io) }.should eq("--12---") }

--- a/src/array.cr
+++ b/src/array.cr
@@ -1875,7 +1875,7 @@ class Array(T)
   def to_s(io : IO) : Nil
     executed = exec_recursive(:to_s) do
       io << '['
-      join ", ", io, &.inspect(io)
+      join io, ", ", &.inspect(io)
       io << ']'
     end
     io << "[...]" unless executed

--- a/src/char.cr
+++ b/src/char.cr
@@ -477,7 +477,7 @@ struct Char
     dump_or_inspect do |io|
       if ascii_control?
         io << "\\u{"
-        ord.to_s(16, io)
+        ord.to_s(io, 16)
         io << '}'
       else
         to_s(io)
@@ -505,7 +505,7 @@ struct Char
     dump_or_inspect do |io|
       if ascii_control? || ord >= 0x80
         io << "\\u{"
-        ord.to_s(16, io)
+        ord.to_s(io, 16)
         io << '}'
       else
         to_s(io)

--- a/src/colorize.cr
+++ b/src/colorize.cr
@@ -224,12 +224,16 @@ module Colorize
     blue : UInt8 do
     def fore(io : IO) : Nil
       io << "38;2;"
-      {red, green, blue}.join(';', io, &.to_s io)
+      io << red << ";"
+      io << green << ";"
+      io << blue
     end
 
     def back(io : IO) : Nil
       io << "48;2;"
-      {red, green, blue}.join(';', io, &.to_s io)
+      io << red << ";"
+      io << green << ";"
+      io << blue
     end
   end
 end

--- a/src/compiler/crystal/codegen/codegen.cr
+++ b/src/compiler/crystal/codegen/codegen.cr
@@ -2212,7 +2212,7 @@ module Crystal
             str << char
           else
             str << '.'
-            char.ord.to_s(16, str, upcase: true)
+            char.ord.to_s(str, 16, upcase: true)
             str << '.'
           end
         end

--- a/src/compiler/crystal/exception.cr
+++ b/src/compiler/crystal/exception.cr
@@ -9,14 +9,14 @@ module Crystal
     @filename : String | VirtualFile | Nil
 
     def to_s(io) : Nil
-      to_s_with_source(nil, io)
+      to_s_with_source(io, nil)
     end
 
     def warning=(warning)
       @warning = !!warning
     end
 
-    abstract def to_s_with_source(source, io)
+    abstract def to_s_with_source(io : IO, source)
 
     def to_json(json : JSON::Builder)
       json.array do
@@ -43,7 +43,7 @@ module Crystal
 
     def to_s_with_source(source)
       String.build do |io|
-        to_s_with_source source, io
+        to_s_with_source(io, source)
       end
     end
 
@@ -77,11 +77,11 @@ module Crystal
   end
 
   class LocationlessException < Exception
-    def to_s_with_source(source, io)
+    def to_s_with_source(io : IO, source)
       io << @message
     end
 
-    def append_to_s(source, io)
+    def append_to_s(io : IO, source)
       io << @message
     end
 

--- a/src/compiler/crystal/semantic/ast.cr
+++ b/src/compiler/crystal/semantic/ast.cr
@@ -18,7 +18,7 @@ module Crystal
       String.build do |io|
         exception = exception_type.for_node(self, message, inner)
         exception.warning = true
-        exception.append_to_s(nil, io)
+        exception.append_to_s(io, nil)
       end
     end
 

--- a/src/compiler/crystal/semantic/call_error.cr
+++ b/src/compiler/crystal/semantic/call_error.cr
@@ -216,7 +216,7 @@ class Crystal::Call
             str << ".."
             str << all_arguments_sizes.last
           else
-            all_arguments_sizes.join ", ", str
+            all_arguments_sizes.join str, ", "
           end
 
           str << '+' if min_splat != Int32::MAX
@@ -268,7 +268,7 @@ class Crystal::Call
           msg << " with type"
           msg << 's' if arg_types.size > 1 || named_args_types
           msg << ' '
-          arg_types.join(", ", msg)
+          arg_types.join(msg, ", ")
         end
 
         if named_args_types

--- a/src/compiler/crystal/semantic/exception.cr
+++ b/src/compiler/crystal/semantic/exception.cr
@@ -91,16 +91,16 @@ module Crystal
       io.flush
     end
 
-    def to_s_with_source(source, io)
-      append_to_s source, io
+    def to_s_with_source(io : IO, source)
+      append_to_s io, source
     end
 
-    def append_to_s(source, io)
+    def append_to_s(io : IO, source)
       inner = @inner
 
       unless @error_trace || inner.is_a? MethodTraceException
         if inner && inner.has_location?
-          return inner.append_to_s(source, io)
+          return inner.append_to_s(io, source)
         end
       end
 
@@ -134,7 +134,7 @@ module Crystal
         return unless inner.has_location?
         io << "\n\n"
         io << '\n' unless inner.is_a? MethodTraceException
-        inner.append_to_s source, io
+        inner.append_to_s io, source
       end
     end
 
@@ -183,8 +183,8 @@ module Crystal
     def to_json_single(json)
     end
 
-    def to_s_with_source(source, io)
-      append_to_s(source, io)
+    def to_s_with_source(io : IO, source)
+      append_to_s(io, source)
     end
 
     def has_trace?
@@ -195,7 +195,7 @@ module Crystal
       @nil_reason || has_trace? && @show
     end
 
-    def append_to_s(source, io)
+    def append_to_s(io : IO, source)
       nil_reason = @nil_reason
 
       if !@show

--- a/src/compiler/crystal/semantic/warnings.cr
+++ b/src/compiler/crystal/semantic/warnings.cr
@@ -15,7 +15,7 @@ module Crystal
         message = String.build do |io|
           exception = SyntaxException.new message, location.line_number, location.column_number, location.filename
           exception.warning = true
-          exception.append_to_s(nil, io)
+          exception.append_to_s(io, nil)
         end
       end
 

--- a/src/compiler/crystal/syntax/exception.cr
+++ b/src/compiler/crystal/syntax/exception.cr
@@ -31,7 +31,7 @@ module Crystal
       end
     end
 
-    def append_to_s(source, io)
+    def append_to_s(io : IO, source)
       msg = @message.to_s
       error_message_lines = msg.lines
       default_message = "syntax error in #{@filename}:#{@line_number}"
@@ -42,8 +42,8 @@ module Crystal
       io << remaining error_message_lines
     end
 
-    def to_s_with_source(source, io)
-      append_to_s source, io
+    def to_s_with_source(io : IO, source)
+      append_to_s io, source
     end
 
     def deepest_error_message

--- a/src/compiler/crystal/syntax/to_s.cr
+++ b/src/compiler/crystal/syntax/to_s.cr
@@ -125,7 +125,7 @@ module Crystal
         @str << '['
       end
 
-      node.elements.join(", ", @str, &.accept self)
+      node.elements.join(@str, ", ", &.accept self)
 
       if name
         @str << '}'
@@ -177,7 +177,7 @@ module Crystal
 
     def visit(node : NamedTupleLiteral)
       @str << '{'
-      node.entries.join(", ", @str) do |entry|
+      node.entries.join(@str, ", ") do |entry|
         visit_named_arg_name(entry.key)
         @str << ": "
         entry.value.accept self
@@ -396,7 +396,7 @@ module Crystal
         if node.name.ends_with?('=') && node.name[0].ascii_letter?
           @str << decorate_call(node, node.name.rchop)
           @str << " = "
-          node.args.join(", ", @str, &.accept self)
+          node.args.join(@str, ", ", &.accept self)
         else
           @str << decorate_call(node, node.name)
 
@@ -592,9 +592,9 @@ module Crystal
     end
 
     def visit(node : MultiAssign)
-      node.targets.join(", ", @str, &.accept self)
+      node.targets.join(@str, ", ", &.accept self)
       @str << " = "
-      node.values.join(", ", @str, &.accept self)
+      node.values.join(@str, ", ", &.accept self)
       false
     end
 
@@ -631,7 +631,7 @@ module Crystal
       @str << "->"
       if node.def.args.size > 0
         @str << '('
-        node.def.args.join(", ", @str, &.accept self)
+        node.def.args.join(@str, ", ", &.accept self)
         @str << ')'
       end
       @str << ' '
@@ -653,7 +653,7 @@ module Crystal
 
       if node.args.size > 0
         @str << '('
-        node.args.join(", ", @str, &.accept self)
+        node.args.join(@str, ", ", &.accept self)
         @str << ')'
       end
       false
@@ -698,7 +698,7 @@ module Crystal
 
       if free_vars = node.free_vars
         @str << " forall "
-        free_vars.join(", ", @str)
+        free_vars.join(@str, ", ")
       end
 
       newline
@@ -779,7 +779,7 @@ module Crystal
 
     def visit(node : MacroFor)
       @str << "{% for "
-      node.vars.join(", ", @str, &.accept self)
+      node.vars.join(@str, ", ", &.accept self)
       @str << " in "
       node.exp.accept self
       @str << " %}"
@@ -795,7 +795,7 @@ module Crystal
       @str << node.name
       if exps = node.exps
         @str << '{'
-        exps.join(", ", @str, &.accept self)
+        exps.join(@str, ", ", &.accept self)
         @str << '}'
       end
       false
@@ -855,7 +855,7 @@ module Crystal
     def visit(node : ProcNotation)
       @str << '('
       if inputs = node.inputs
-        inputs.join(", ", @str, &.accept self)
+        inputs.join(@str, ", ", &.accept self)
         @str << ' '
       end
       @str << "-> "
@@ -872,7 +872,7 @@ module Crystal
 
     def visit(node : Path)
       @str << "::" if node.global?
-      node.names.join("::", @str)
+      node.names.join(@str, "::")
     end
 
     def visit(node : Generic)
@@ -902,7 +902,7 @@ module Crystal
       printed_arg = false
 
       @str << '('
-      node.type_vars.join(", ", @str) do |var|
+      node.type_vars.join(@str, ", ") do |var|
         var.accept self
         printed_arg = true
       end
@@ -947,7 +947,7 @@ module Crystal
     end
 
     def visit(node : Union)
-      node.types.join(" | ", @str, &.accept self)
+      node.types.join(@str, " | ", &.accept self)
       false
     end
 
@@ -982,7 +982,7 @@ module Crystal
       @str << keyword("yield")
       if node.exps.size > 0
         @str << ' '
-        node.exps.join(", ", @str, &.accept self)
+        node.exps.join(@str, ", ", &.accept self)
       end
       false
     end
@@ -1039,7 +1039,7 @@ module Crystal
       first = node.elements.first?
       space = first.is_a?(TupleLiteral) || first.is_a?(NamedTupleLiteral) || first.is_a?(HashLiteral)
       @str << ' ' if space
-      node.elements.join(", ", @str, &.accept self)
+      node.elements.join(@str, ", ", &.accept self)
       @str << ' ' if space
       @str << '}'
       false
@@ -1167,7 +1167,7 @@ module Crystal
       end
       if node.args.size > 0
         @str << '('
-        node.args.join(", ", @str) do |arg|
+        node.args.join(@str, ", ") do |arg|
           if arg_name = arg.name
             @str << arg_name << " : "
           end
@@ -1363,7 +1363,7 @@ module Crystal
       append_indent
       @str << keyword(node.exhaustive? ? "in" : "when")
       @str << ' '
-      node.conds.join(", ", @str, &.accept self)
+      node.conds.join(@str, ", ", &.accept self)
       newline
       accept_with_indent node.body
       false
@@ -1433,7 +1433,7 @@ module Crystal
           @str << " :"
         end
         @str << ' '
-        types.join(" | ", @str, &.accept self)
+        types.join(@str, " | ", &.accept self)
       end
       newline
       accept_with_indent node.body
@@ -1452,7 +1452,7 @@ module Crystal
     def visit(node : TypeOf)
       @str << keyword("typeof")
       @str << '('
-      node.expressions.join(", ", @str, &.accept self)
+      node.expressions.join(@str, ", ", &.accept self)
       @str << ')'
       false
     end
@@ -1463,7 +1463,7 @@ module Crystal
       if !node.args.empty? || node.named_args
         @str << '('
         printed_arg = false
-        node.args.join(", ", @str) do |arg|
+        node.args.join(@str, ", ") do |arg|
           arg.accept self
           printed_arg = true
         end
@@ -1492,19 +1492,19 @@ module Crystal
       @str << " :"
       if outputs = node.outputs
         @str << ' '
-        outputs.join(", ", @str, &.accept self)
+        outputs.join(@str, ", ", &.accept self)
         @str << ' '
       end
       @str << ':'
       if inputs = node.inputs
         @str << ' '
-        inputs.join(", ", @str, &.accept self)
+        inputs.join(@str, ", ", &.accept self)
         @str << ' '
       end
       @str << ":"
       if clobbers = node.clobbers
         @str << ' '
-        clobbers.join(", ", @str, &.inspect @str)
+        clobbers.join(@str, ", ", &.inspect @str)
         @str << ' '
       end
       @str << ":"

--- a/src/compiler/crystal/tools/doc/generator.cr
+++ b/src/compiler/crystal/tools/doc/generator.cr
@@ -365,7 +365,7 @@ class Crystal::Doc::Generator
   def isolate_flag_lines(string)
     flag_regexp = /^ ?(#{FLAGS.join('|')}):?/
     String.build do |io|
-      string.each_line(chomp: false).join("", io) do |line, io|
+      string.each_line(chomp: false).join(io) do |line, io|
         if line =~ flag_regexp
           io << '\n' << line
         else

--- a/src/compiler/crystal/tools/doc/method.cr
+++ b/src/compiler/crystal/tools/doc/method.cr
@@ -262,7 +262,7 @@ class Crystal::Doc::Method
 
     if free_vars = @def.free_vars
       io << " forall "
-      free_vars.join(", ", io)
+      free_vars.join(io, ", ")
     end
 
     io

--- a/src/compiler/crystal/tools/doc/type.cr
+++ b/src/compiler/crystal/tools/doc/type.cr
@@ -515,7 +515,7 @@ class Crystal::Doc::Type
       io << node.name
     end
     io << '('
-    node.type_vars.join(", ", io) do |type_var|
+    node.type_vars.join(io, ", ") do |type_var|
       node_to_html type_var, io, links: links
     end
     io << ')'
@@ -523,7 +523,7 @@ class Crystal::Doc::Type
 
   def node_to_html(node : ProcNotation, io, links = true)
     if inputs = node.inputs
-      inputs.join(", ", io) do |input|
+      inputs.join(io, ", ") do |input|
         node_to_html input, io, links: links
       end
     end
@@ -544,7 +544,7 @@ class Crystal::Doc::Type
       end
     end
 
-    node.types.join(" | ", io) do |elem|
+    node.types.join(io, " | ") do |elem|
       node_to_html elem, io, links: links
     end
   end
@@ -597,7 +597,7 @@ class Crystal::Doc::Type
       separator = " | "
     end
 
-    type.union_types.join(separator, io) do |union_type|
+    type.union_types.join(io, separator) do |union_type|
       type_to_html union_type, io, text, links: links
     end
 
@@ -605,7 +605,7 @@ class Crystal::Doc::Type
   end
 
   def type_to_html(type : Crystal::ProcInstanceType, io, text = nil, links = true)
-    type.arg_types.join(", ", io) do |arg_type|
+    type.arg_types.join(io, ", ") do |arg_type|
       type_to_html arg_type, io, links: links
     end
     io << " -> "
@@ -615,7 +615,7 @@ class Crystal::Doc::Type
 
   def type_to_html(type : Crystal::TupleInstanceType, io, text = nil, links = true)
     io << '{'
-    type.tuple_types.join(", ", io) do |tuple_type|
+    type.tuple_types.join(io, ", ") do |tuple_type|
       type_to_html tuple_type, io, links: links
     end
     io << '}'
@@ -623,7 +623,7 @@ class Crystal::Doc::Type
 
   def type_to_html(type : Crystal::NamedTupleInstanceType, io, text = nil, links = true)
     io << '{'
-    type.entries.join(", ", io) do |entry|
+    type.entries.join(io, ", ") do |entry|
       if Symbol.needs_quotes?(entry.name)
         entry.name.inspect(io)
       else
@@ -655,7 +655,7 @@ class Crystal::Doc::Type
     io << "</a>" if must_be_included && links && has_link_in_type_vars
 
     io << '('
-    type.type_vars.values.join(", ", io) do |type_var|
+    type.type_vars.values.join(io, ", ") do |type_var|
       case type_var
       when Var
         type_to_html type_var.type, io, links: links

--- a/src/compiler/crystal/types.cr
+++ b/src/compiler/crystal/types.cr
@@ -1793,7 +1793,7 @@ module Crystal
       super
       if generic_args
         io << '('
-        type_vars.join(", ", io, &.to_s(io))
+        type_vars.join(io, ", ", &.to_s(io))
         io << ')'
       end
     end
@@ -1853,7 +1853,7 @@ module Crystal
       super
       if generic_args
         io << '('
-        type_vars.join(", ", io, &.to_s(io))
+        type_vars.join(io, ", ", &.to_s(io))
         io << ')'
       end
     end
@@ -1987,7 +1987,7 @@ module Crystal
           if type_var.is_a?(Var)
             if i == splat_index
               tuple = type_var.type.as(TupleInstanceType)
-              tuple.tuple_types.join(", ", io) do |tuple_type|
+              tuple.tuple_types.join(io, ", ") do |tuple_type|
                 tuple_type = tuple_type.devirtualize unless codegen
                 tuple_type.to_s_with_options(io, codegen: codegen)
               end
@@ -2396,7 +2396,7 @@ module Crystal
 
     def to_s_with_options(io : IO, skip_union_parens : Bool = false, generic_args : Bool = true, codegen : Bool = false) : Nil
       io << "Tuple("
-      @tuple_types.join(", ", io) do |tuple_type|
+      @tuple_types.join(io, ", ") do |tuple_type|
         tuple_type = tuple_type.devirtualize unless codegen
         tuple_type.to_s_with_options(io, skip_union_parens: true, codegen: codegen)
       end
@@ -2513,7 +2513,7 @@ module Crystal
 
     def to_s_with_options(io : IO, skip_union_parens : Bool = false, generic_args : Bool = true, codegen : Bool = false) : Nil
       io << "NamedTuple("
-      @entries.join(", ", io) do |entry|
+      @entries.join(io, ", ") do |entry|
         if Symbol.needs_quotes?(entry.name)
           entry.name.inspect(io)
         else
@@ -3063,7 +3063,7 @@ module Crystal
         union_types = @union_types.dup
         union_types << union_types.delete_at(nil_type_index)
       end
-      union_types.join(" | ", io) do |type|
+      union_types.join(io, " | ") do |type|
         type = type.devirtualize unless codegen
         type.to_s_with_options(io, codegen: codegen)
       end

--- a/src/deque.cr
+++ b/src/deque.cr
@@ -336,7 +336,7 @@ class Deque(T)
   def inspect(io : IO) : Nil
     executed = exec_recursive(:inspect) do
       io << "Deque{"
-      join ", ", io, &.inspect(io)
+      join io, ", ", &.inspect(io)
       io << '}'
     end
     io << "Deque{...}" unless executed

--- a/src/enumerable.cr
+++ b/src/enumerable.cr
@@ -723,7 +723,7 @@ module Enumerable(T)
   # ```
   def join(separator = "")
     String.build do |io|
-      join separator, io
+      join io, separator
     end
   end
 
@@ -733,9 +733,9 @@ module Enumerable(T)
   # ```
   # [1, 2, 3, 4, 5].join(", ") { |i| -i } # => "-1, -2, -3, -4, -5"
   # ```
-  def join(separator = "")
+  def join(separator = "", & : T ->)
     String.build do |io|
-      join(separator, io) do |elem|
+      join(io, separator) do |elem|
         io << yield elem
       end
     end
@@ -744,7 +744,7 @@ module Enumerable(T)
   # Prints to *io* all the elements in the collection, separated by *separator*.
   #
   # ```
-  # [1, 2, 3, 4, 5].join(", ", STDOUT)
+  # [1, 2, 3, 4, 5].join(STDOUT, ", ")
   # ```
   #
   # Prints:
@@ -752,17 +752,33 @@ module Enumerable(T)
   # ```text
   # 1, 2, 3, 4, 5
   # ```
-  def join(separator, io)
-    join(separator, io) do |elem|
+  def join(io : IO, separator = "")
+    join(io, separator) do |elem|
       elem.to_s(io)
     end
+  end
+
+  # Prints to *io* all the elements in the collection, separated by *separator*.
+  #
+  # ```
+  # [1, 2, 3, 4, 5].join(STDOUT, ", ")
+  # ```
+  #
+  # Prints:
+  #
+  # ```text
+  # 1, 2, 3, 4, 5
+  # ```
+  @[Deprecated(%(Use `#join(io : IO, separator = "") instead`))]
+  def join(separator, io : IO)
+    join(io, separator)
   end
 
   # Prints to *io* the concatenation of the elements, with the possibility of
   # controlling how the printing is done via a block.
   #
   # ```
-  # [1, 2, 3, 4, 5].join(", ", STDOUT) { |i, io| io << "(#{i})" }
+  # [1, 2, 3, 4, 5].join(STDOUT, ", ") { |i, io| io << "(#{i})" }
   # ```
   #
   # Prints:
@@ -770,9 +786,28 @@ module Enumerable(T)
   # ```text
   # (1), (2), (3), (4), (5)
   # ```
-  def join(separator, io)
+  def join(io : IO, separator = "", & : T, IO ->)
     each_with_index do |elem, i|
       io << separator if i > 0
+      yield elem, io
+    end
+  end
+
+  # Prints to *io* the concatenation of the elements, with the possibility of
+  # controlling how the printing is done via a block.
+  #
+  # ```
+  # [1, 2, 3, 4, 5].join(STDOUT, ", ") { |i, io| io << "(#{i})" }
+  # ```
+  #
+  # Prints:
+  #
+  # ```text
+  # (1), (2), (3), (4), (5)
+  # ```
+  @[Deprecated(%(Use `#join(io : IO, separator = "", & : T, IO ->) instead`))]
+  def join(separator, io : IO)
+    join(io, separator) do |elem, io|
       yield elem, io
     end
   end

--- a/src/fiber.cr
+++ b/src/fiber.cr
@@ -273,7 +273,7 @@ class Fiber
 
   def to_s(io : IO) : Nil
     io << "#<" << self.class.name << ":0x"
-    object_id.to_s(16, io)
+    object_id.to_s(io, 16)
     if name = @name
       io << ": " << name
     end

--- a/src/http/common.cr
+++ b/src/http/common.cr
@@ -293,7 +293,7 @@ module HTTP
   def self.serialize_chunked_body(io, body)
     buf = uninitialized UInt8[8192]
     while (buf_length = body.read(buf.to_slice)) > 0
-      buf_length.to_s(16, io)
+      buf_length.to_s(io, 16)
       io << "\r\n"
       io.write(buf.to_slice[0, buf_length])
       io << "\r\n"

--- a/src/http/server/response.cr
+++ b/src/http/server/response.cr
@@ -203,7 +203,7 @@ class HTTP::Server
         ensure_headers_written
 
         if @chunked
-          slice.size.to_s(16, @io)
+          slice.size.to_s(@io, 16)
           @io << "\r\n"
           @io.write(slice)
           @io << "\r\n"

--- a/src/int.cr
+++ b/src/int.cr
@@ -566,7 +566,7 @@ struct Int
   private DIGITS_UPCASE   = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ"
   private DIGITS_BASE62   = "0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ"
 
-  def to_s(base : Int = 10, upcase : Bool = false) : String
+  def to_s(base : Int = 10, *, upcase : Bool = false) : String
     raise ArgumentError.new("Invalid base #{base}") unless 2 <= base <= 36 || base == 62
     raise ArgumentError.new("upcase must be false for base 62") if upcase && base == 62
 

--- a/src/int.cr
+++ b/src/int.cr
@@ -566,15 +566,7 @@ struct Int
   private DIGITS_UPCASE   = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ"
   private DIGITS_BASE62   = "0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ"
 
-  def to_s : String
-    to_s(10)
-  end
-
-  def to_s(io : IO) : Nil
-    to_s(10, io)
-  end
-
-  def to_s(base : Int, upcase : Bool = false) : String
+  def to_s(base : Int = 10, upcase : Bool = false) : String
     raise ArgumentError.new("Invalid base #{base}") unless 2 <= base <= 36 || base == 62
     raise ArgumentError.new("upcase must be false for base 62") if upcase && base == 62
 
@@ -590,7 +582,12 @@ struct Int
     end
   end
 
-  def to_s(base : Int, io : IO, upcase : Bool = false) : Nil
+  @[Deprecated("Use `#to_s(base : Int, *, upcase : Bool = false)` instead")]
+  def to_s(base : Int, _upcase : Bool) : String
+    to_s(base, upcase: _upcase)
+  end
+
+  def to_s(io : IO, base : Int = 10, *, upcase : Bool = false) : Nil
     raise ArgumentError.new("Invalid base #{base}") unless 2 <= base <= 36 || base == 62
     raise ArgumentError.new("upcase must be false for base 62") if upcase && base == 62
 
@@ -604,6 +601,11 @@ struct Int
         io.write_utf8 Slice.new(ptr, count)
       end
     end
+  end
+
+  @[Deprecated("Use `#to_s(io : IO, base : Int, *, upcase : Bool = false)` instead")]
+  def to_s(base : Int, io : IO, upcase : Bool = false) : Nil
+    to_s(io, base, upcase: upcase)
   end
 
   private def internal_to_s(base, upcase = false)

--- a/src/json/builder.cr
+++ b/src/json/builder.cr
@@ -131,7 +131,7 @@ class JSON::Builder
           io << '0' if ord < 0x1000
           io << '0' if ord < 0x100
           io << '0' if ord < 0x10
-          ord.to_s(16, io)
+          ord.to_s(io, 16)
           reader.next_char
           start_pos = reader.pos
           next

--- a/src/option_parser.cr
+++ b/src/option_parser.cr
@@ -274,7 +274,7 @@ class OptionParser
       io << banner
       io << '\n'
     end
-    @flags.join '\n', io
+    @flags.join io, '\n'
   end
 
   private def append_flag(flag, description)

--- a/src/pointer.cr
+++ b/src/pointer.cr
@@ -326,7 +326,7 @@ struct Pointer(T)
       io << ".null"
     else
       io << "@0x"
-      address.to_s(16, io)
+      address.to_s(io, 16)
     end
   end
 

--- a/src/proc.cr
+++ b/src/proc.cr
@@ -194,7 +194,7 @@ struct Proc
     io << "#<"
     io << {{@type.name.stringify}}
     io << ":0x"
-    pointer.address.to_s(16, io)
+    pointer.address.to_s(io, 16)
     if closure?
       io << ":closure"
     end

--- a/src/reference.cr
+++ b/src/reference.cr
@@ -70,7 +70,7 @@ class Reference
   # ```
   def inspect(io : IO) : Nil
     io << "#<" << {{@type.name.id.stringify}} << ":0x"
-    object_id.to_s(16, io)
+    object_id.to_s(io, 16)
 
     executed = exec_recursive(:inspect) do
       {% for ivar, i in @type.instance_vars %}
@@ -129,7 +129,7 @@ class Reference
   # ```
   def to_s(io : IO) : Nil
     io << "#<" << self.class.name << ":0x"
-    object_id.to_s(16, io)
+    object_id.to_s(io, 16)
     io << '>'
   end
 

--- a/src/semantic_version.cr
+++ b/src/semantic_version.cr
@@ -147,7 +147,7 @@ struct SemanticVersion
     # semver.prerelease.to_s # => "rc.1"
     # ```
     def to_s(io : IO) : Nil
-      identifiers.join('.', io)
+      identifiers.join(io, '.')
     end
 
     # The comparison operator.

--- a/src/set.cr
+++ b/src/set.cr
@@ -404,7 +404,7 @@ struct Set(T)
   # Writes a string representation of the set to *io*.
   def to_s(io : IO) : Nil
     io << "Set{"
-    join ", ", io, &.inspect(io)
+    join io, ", ", &.inspect(io)
     io << '}'
   end
 

--- a/src/slice.cr
+++ b/src/slice.cr
@@ -596,11 +596,11 @@ struct Slice(T)
     if T == UInt8
       io << "Bytes["
       # Inspect using to_s because we know this is a UInt8.
-      join ", ", io, &.to_s(io)
+      join io, ", ", &.to_s(io)
       io << ']'
     else
       io << "Slice["
-      join ", ", io, &.inspect(io)
+      join io, ", ", &.inspect(io)
       io << ']'
     end
   end

--- a/src/static_array.cr
+++ b/src/static_array.cr
@@ -267,7 +267,7 @@ struct StaticArray(T, N)
   # ```
   def to_s(io : IO) : Nil
     io << "StaticArray["
-    join ", ", io, &.inspect(io)
+    join io, ", ", &.inspect(io)
     io << ']'
   end
 

--- a/src/string.cr
+++ b/src/string.cr
@@ -4430,7 +4430,7 @@ class String
   private def dump_hex(char, io)
     io << "\\x"
     io << '0' if char < 0x0F
-    char.to_s(16, io, upcase: true)
+    char.to_s(io, 16, upcase: true)
   end
 
   private def dump_unicode(char, io)
@@ -4439,7 +4439,7 @@ class String
     io << '0' if char.ord < 0x1000
     io << '0' if char.ord < 0x0100
     io << '0' if char.ord < 0x0010
-    char.ord.to_s(16, io, upcase: true)
+    char.ord.to_s(io, 16, upcase: true)
     io << '}' if char.ord > 0xFFFF
   end
 

--- a/src/string.cr
+++ b/src/string.cr
@@ -3824,8 +3824,22 @@ class String
   # "Purple".ljust(8, io)
   # io.to_s # => "Purple  "
   # ```
+  @[Deprecated("Use `#ljust(io :IO, len : Int, char : Char = ' ')` instead")]
   def ljust(len : Int, io : IO) : Nil
-    ljust(len, ' ', io)
+    ljust(io, len)
+  end
+
+  # Adds instances of *char* to right of the string until it is at least size of *len*,
+  # and then appends the result to the given IO.
+  #
+  # ```
+  # io = IO::Memory.new
+  # "Purple".ljust(io, 8, '-')
+  # io.to_s # => "Purple--"
+  # ```
+  def ljust(io : IO, len : Int, char : Char = ' ') : Nil
+    io << self
+    (len - size).times { io << char }
   end
 
   # Adds instances of *char* to right of the string until it is at least size of *len*,
@@ -3836,9 +3850,9 @@ class String
   # "Purple".ljust(8, '-', io)
   # io.to_s # => "Purple--"
   # ```
+  @[Deprecated("Use `#ljust(io :IO, len : Int, char : Char = ' ')` instead")]
   def ljust(len : Int, char : Char, io : IO) : Nil
-    io << self
-    (len - size).times { io << char }
+    ljust(io, len, char)
   end
 
   # Adds instances of *char* to left of the string until it is at least size of *len*.
@@ -3860,8 +3874,9 @@ class String
   # "Purple".rjust(8, io)
   # io.to_s # => "  Purple"
   # ```
+  @[Deprecated("Use `#rjust(io :IO, len : Int, char : Char = ' ')` instead")]
   def rjust(len : Int, io : IO) : Nil
-    rjust(len, ' ', io)
+    rjust(io, len)
   end
 
   # Adds instances of *char* to left of the string until it is at least size of *len*,
@@ -3872,9 +3887,22 @@ class String
   # "Purple".rjust(8, '-', io)
   # io.to_s # => "--Purple"
   # ```
-  def rjust(len : Int, char : Char, io : IO) : Nil
+  def rjust(io : IO, len : Int, char : Char = ' ') : Nil
     (len - size).times { io << char }
     io << self
+  end
+
+  # Adds instances of *char* to left of the string until it is at least size of *len*,
+  # and then appends the result to the given IO.
+  #
+  # ```
+  # io = IO::Memory.new
+  # "Purple".rjust(8, '-', io)
+  # io.to_s # => "--Purple"
+  # ```
+  @[Deprecated("Use `#rjust(io :IO, len : Int, char : Char = ' ')` instead")]
+  def rjust(len : Int, char : Char, io : IO) : Nil
+    rjust(io, len, char)
   end
 
   # Adds instances of *char* to left and right of the string until it is at least size of *len*.
@@ -3897,8 +3925,9 @@ class String
   # "Purple".center(9, io)
   # io.to_s # => " Purple  "
   # ```
+  @[Deprecated("Use `#center(io :IO, len : Int, char : Char = ' ')` instead")]
   def center(len : Int, io : IO) : Nil
-    center(len, ' ', io)
+    center(io, len)
   end
 
   # Adds instances of *char* to left and right of the string until it is at least size of *len*,
@@ -3909,7 +3938,7 @@ class String
   # "Purple".center(9, '-', io)
   # io.to_s # => "-Purple--"
   # ```
-  def center(len : Int, char : Char, io : IO) : Nil
+  def center(io : IO, len : Int, char : Char = ' ') : Nil
     difference = len - size
 
     if difference <= 0
@@ -3923,6 +3952,19 @@ class String
     left_padding.times { io << char }
     io << self
     right_padding.times { io << char }
+  end
+
+  # Adds instances of *char* to left ond right of the string until it is at least size of *len*,
+  # then appends the result to the given IO.
+  #
+  # ```
+  # io = IO::Memory.new
+  # "Purple".center(9, '-', io)
+  # io.to_s # => "-Purple--"
+  # ```
+  @[Deprecated("Use `#center(io :IO, len : Int, char : Char = ' ')` instead")]
+  def center(len : Int, char : Char, io : IO) : Nil
+    center(io, len, char)
   end
 
   private def just(len, char, justify)

--- a/src/string/formatter.cr
+++ b/src/string/formatter.cr
@@ -243,7 +243,7 @@ struct String::Formatter(A)
         end
       end
 
-      int.to_s(flags.base, @io, upcase: flags.type == 'X')
+      int.to_s(@io, flags.base, upcase: flags.type == 'X')
 
       if flags.right_padding?
         pad_int int, flags

--- a/src/time.cr
+++ b/src/time.cr
@@ -1084,8 +1084,16 @@ struct Time
   # Formats this `Time` according to the pattern in *format* to the given *io*.
   #
   # See `Time::Format` for details.
-  def to_s(format : String, io : IO) : Nil
+  def to_s(io : IO, format : String) : Nil
     Format.new(format).format(self, io)
+  end
+
+  # Formats this `Time` according to the pattern in *format* to the given *io*.
+  #
+  # See `Time::Format` for details.
+  @[Deprecated("Use `#to_s(io : IO, format : String)` instead")]
+  def to_s(format : String, io : IO) : Nil
+    to_s(io, format)
   end
 
   # Format this time using the format specified by [RFC 3339](https://tools.ietf.org/html/rfc3339) ([ISO 8601](http://xml.coverpages.org/ISO-FDIS-8601.pdf) profile).

--- a/src/tuple.cr
+++ b/src/tuple.cr
@@ -393,7 +393,7 @@ struct Tuple
   # ```
   def to_s(io : IO) : Nil
     io << '{'
-    join ", ", io, &.inspect(io)
+    join io, ", ", &.inspect(io)
     io << '}'
   end
 

--- a/src/uri.cr
+++ b/src/uri.cr
@@ -446,7 +446,7 @@ class URI
       elsif dst_path.first.includes?(':') # (see RFC2396 Section 5)
         String.build do |io|
           io << "./"
-          dst_path.join('/', io)
+          dst_path.join(io, '/')
         end
       else
         string = dst_path.join('/')
@@ -459,7 +459,7 @@ class URI
     else
       String.build do |io|
         base_path.size.times { io << "../" }
-        dst_path.join('/', io)
+        dst_path.join(io, '/')
       end
     end
   end

--- a/src/uri/encoding.cr
+++ b/src/uri/encoding.cr
@@ -222,7 +222,7 @@ class URI
       else
         io.write_byte '%'.ord.to_u8
         io.write_byte '0'.ord.to_u8 if byte < 16
-        byte.to_s(16, io, upcase: true)
+        byte.to_s(io, 16, upcase: true)
       end
     end
     io

--- a/src/xml/attributes.cr
+++ b/src/xml/attributes.cr
@@ -60,7 +60,7 @@ struct XML::Attributes
 
   def to_s(io : IO) : Nil
     io << '['
-    join ", ", io, &.inspect(io)
+    join io, ", ", &.inspect(io)
     io << ']'
   end
 

--- a/src/xml/namespace.cr
+++ b/src/xml/namespace.cr
@@ -21,7 +21,7 @@ struct XML::Namespace
 
   def to_s(io : IO) : Nil
     io << "#<XML::Namespace:0x"
-    object_id.to_s(16, io)
+    object_id.to_s(io, 16)
 
     if prefix = self.prefix
       io << " prefix="

--- a/src/xml/node.cr
+++ b/src/xml/node.cr
@@ -192,7 +192,7 @@ struct XML::Node
     end
 
     io << ":0x"
-    object_id.to_s(16, io)
+    object_id.to_s(io, 16)
 
     if text?
       io << ' '

--- a/src/xml/node_set.cr
+++ b/src/xml/node_set.cr
@@ -33,7 +33,7 @@ struct XML::NodeSet
 
   def inspect(io : IO) : Nil
     io << '['
-    join ", ", io, &.inspect(io)
+    join io, ", ", &.inspect(io)
     io << ']'
   end
 


### PR DESCRIPTION
This introduces some breaking changes but rewards with great developer happyness because you don't need to recall the different placements of `io` arguments. It is now always the first argument.

There is a somewhat unrelated change in cf613ea which makes `upcase` argument to `Int#to_s` a named argument. But it makes sense to introduce that change at the same time as the argument order. It was already only used as a named argument in stdlib so this didn't even need any changes here and it underlines the fact that you would not pass it as positional argument.

Resolves #5916