### PR TITLE
Deprecate top-level fork

### DIFF
--- a/src/compiler/crystal/compiler.cr
+++ b/src/compiler/crystal/compiler.cr
@@ -457,7 +457,7 @@ module Crystal
               end
             end
 
-            codegen_process = fork do
+            codegen_process = Process.fork do
               pipe_w = pw
               slice.each do |unit|
                 unit.compile

--- a/src/crystal/system/unix/event_loop_libevent.cr
+++ b/src/crystal/system/unix/event_loop_libevent.cr
@@ -5,6 +5,7 @@ class Thread
   getter(event_base) { Crystal::Event::Base.new }
 end
 
+# :nodoc:
 module Crystal::EventLoop
   {% unless flag?(:preview_mt) %}
     # Reinitializes the event loop after a fork.

--- a/src/kernel.cr
+++ b/src/kernel.cr
@@ -491,6 +491,8 @@ end
 
 {% unless flag?(:preview_mt) %}
   class Process
+    # :nodoc:
+    #
     # Hooks are defined here due to load order problems.
     def self.after_fork_child_callbacks
       @@after_fork_child_callbacks ||= [

--- a/src/process.cr
+++ b/src/process.cr
@@ -69,6 +69,8 @@ class Process
     Crystal::System::Process.times
   end
 
+  # :nodoc:
+  #
   # Runs the given block inside a new process and
   # returns a `Process` representing the new child process.
   #
@@ -90,6 +92,8 @@ class Process
     end
   end
 
+  # :nodoc:
+  #
   # Duplicates the current process.
   # Returns a `Process` representing the new child process in the current process
   # and `nil` inside the new child process.
@@ -439,22 +443,6 @@ def `(command) : String
   status = process.wait
   $? = status
   output
-end
-
-# See also: `Process.fork`
-#
-# Available only on Unix-like operating systems.
-@[Deprecated("Use `Process.fork` instead")]
-def fork
-  Process.fork { yield }
-end
-
-# See also: `Process.fork`
-#
-# Available only on Unix-like operating systems.
-@[Deprecated("Use `Process.fork` instead")]
-def fork
-  Process.fork
 end
 
 require "./process/*"

--- a/src/process.cr
+++ b/src/process.cr
@@ -444,6 +444,7 @@ end
 # See also: `Process.fork`
 #
 # Available only on Unix-like operating systems.
+@[Deprecated("Use `Process.fork` instead")]
 def fork
   Process.fork { yield }
 end
@@ -451,6 +452,7 @@ end
 # See also: `Process.fork`
 #
 # Available only on Unix-like operating systems.
+@[Deprecated("Use `Process.fork` instead")]
 def fork
   Process.fork
 end


### PR DESCRIPTION
`Process.fork` is still available, yet it will only work in single-thread.

There is no point in having a top-level API that will work in only one mode.
