### PR TITLE
Log: Allow override context within logging calls

### DIFF
--- a/spec/std/log/log_spec.cr
+++ b/spec/std/log/log_spec.cr
@@ -106,4 +106,16 @@ describe Log do
 
     backend.entries.first.context.should eq(Log::Context.new({a: 1}))
   end
+
+  it "context can be changed within the block and is restored" do
+    Log.context.set a: 1
+
+    backend = Log::MemoryBackend.new
+    log = Log.new("a", backend, :debug)
+
+    log.info { Log.context.set(b: 2); "info message" }
+
+    backend.entries.first.context.should eq(Log::Context.new({a: 1, b: 2}))
+    Log.context.should eq(Log::Context.new({a: 1}))
+  end
 end

--- a/src/log/log.cr
+++ b/src/log/log.cr
@@ -47,8 +47,10 @@ class Log
       return unless backend = @backend
       severity = Severity.new({{severity}})
       return unless level <= severity
-      message = yield.to_s
-      entry = Entry.new @source, severity, message, exception
+      entry = Log.with_context do
+        message = yield.to_s
+        Entry.new @source, severity, message, exception
+      end
       backend.write entry
     end
   {% end %}


### PR DESCRIPTION
Extracted from https://forum.crystal-lang.org/t/proposal-to-have-all-data-be-key-value-data-in-log/1966/14

Let's add a spec to ensure that will keep working + allow the restoring of the previous context.

cc: @paulcsmith 