### PR TITLE
Implement Process.times on Windows.

### DIFF
--- a/src/crystal/system/win32/process.cr
+++ b/src/crystal/system/win32/process.cr
@@ -83,7 +83,14 @@ struct Crystal::System::Process
   end
 
   def self.times
-    raise NotImplementedError.new("Process.times")
+    if LibC.GetProcessTimes(LibC.GetCurrentProcess, out create, out exit, out kernel, out user) == 0
+      raise RuntimeError.from_winerror("GetProcessTimes")
+    end
+    ::Process::Tms.new(
+      Crystal::System::Time.filetime_to_f64secs(user),
+      Crystal::System::Time.filetime_to_f64secs(kernel),
+      0,
+      0)
   end
 
   def self.fork

--- a/src/crystal/system/win32/time.cr
+++ b/src/crystal/system/win32/time.cr
@@ -35,6 +35,10 @@ module Crystal::System::Time
     ::Time.utc(seconds: seconds, nanoseconds: nanoseconds)
   end
 
+  def self.filetime_to_f64secs(filetime) : Float64
+    ((filetime.dwHighDateTime.to_u64 << 32) | filetime.dwLowDateTime.to_u64).to_f64 / FILETIME_TICKS_PER_SECOND.to_f64
+  end
+
   @@performance_frequency : Int64 = begin
     ret = LibC.QueryPerformanceFrequency(out frequency)
     if ret == 0

--- a/src/lib_c/x86_64-windows-msvc/c/processthreadsapi.cr
+++ b/src/lib_c/x86_64-windows-msvc/c/processthreadsapi.cr
@@ -39,6 +39,8 @@ lib LibC
                      bInheritHandles : BOOL, dwCreationFlags : DWORD,
                      lpEnvironment : Void*, lpCurrentDirectory : LPWSTR,
                      lpStartupInfo : STARTUPINFOW*, lpProcessInformation : PROCESS_INFORMATION*) : BOOL
+  fun GetProcessTimes(hProcess : HANDLE, lpCreationTime : FILETIME*, lpExitTime : FILETIME*,
+                      lpKernelTime : FILETIME*, lpUserTime : FILETIME*) : BOOL
 
   PROCESS_QUERY_INFORMATION = 0x0400
 end

--- a/src/process.cr
+++ b/src/process.cr
@@ -62,9 +62,7 @@ class Process
   end
 
   # Returns a `Tms` for the current process. For the children times, only those
-  # of terminated children are returned.
-  #
-  # Available only on Unix-like operating systems.
+  # of terminated children are returned on Unix; they are zero on Windows.
   def self.times : Tms
     Crystal::System::Process.times
   end


### PR DESCRIPTION
Process.times using Win32 API GetProcessTimes (#9131)

I tested this PR by the following code:
```crystal
require "benchmark"

Benchmark.bm do |x|
  x.report("consuming user time:") do
    start_time = Time.monotonic
    n = 0_u128
    while Time.monotonic - start_time < 5.seconds
      n += 1
    end
  end
  x.report("consuming system time as possible:") do
    start_time = Time.monotonic
    while Time.monotonic - start_time < 5.seconds
      File.open(File::NULL).close
    end
  end
end
```

On Linux to check the test code:
```
                                         user     system      total        real
consuming user time:                 4.994000   0.000000   4.994000 (  5.000003)
consuming system time as possible:   2.305000   2.821000   5.126000 (  5.000813)
```

On Windows after applying this patch:
```
                                         user     system      total        real
consuming user time:                 5.000000   0.000000   5.000000 (  5.000005)
consuming system time as possible:   1.812500   3.421875   5.234375 (  5.000005)
```

Closes #9131