### PR TITLE
Log: empty singleton context

### DIFF
--- a/spec/std/log/broadcast_backend_spec.cr
+++ b/spec/std/log/broadcast_backend_spec.cr
@@ -1,4 +1,5 @@
 require "spec"
+require "log"
 
 private def s(value : Log::Severity)
   value

--- a/spec/std/log/context_spec.cr
+++ b/spec/std/log/context_spec.cr
@@ -24,6 +24,12 @@ describe Log::Context do
     Log::Context.new.should eq(c(NamedTuple.new))
   end
 
+  it "empty" do
+    Log::Context.empty.should eq(Log::Context.new)
+    Log::Context.empty.object_id.should_not eq(Log::Context.new.object_id)
+    Log::Context.empty.object_id.should eq(Log::Context.empty.object_id)
+  end
+
   it "validates hash" do
     expect_raises(ArgumentError, "Expected hash context, not Int32") do
       Log.context = c(1)
@@ -43,6 +49,12 @@ describe Log::Context do
     c({a: 1}).merge(c({b: 2})).should eq(c({a: 1, b: 2}))
     c({a: 1, b: 3}).merge(c({b: 2})).should eq(c({a: 1, b: 2}))
     c({a: 1, b: 3}).merge(c({b: nil})).should eq(c({a: 1, b: nil}))
+  end
+
+  it "merge against Log::Context.empty without creating a new instance" do
+    c1 = c({a: 1, b: 3})
+    c1.merge(Log::Context.empty).should be(c1)
+    Log::Context.empty.merge(c1).should be(c1)
   end
 
   it "accessors" do

--- a/src/log/context.cr
+++ b/src/log/context.cr
@@ -6,6 +6,15 @@
 class Log::Context
   Crystal.datum types: {nil: Nil, bool: Bool, i: Int32, i64: Int64, f: Float32, f64: Float64, s: String, time: Time}, hash_key_type: String, immutable: true, target_type: Log::Context
 
+  @@empty = Log::Context.new
+
+  # Returns an empty `Log::Context`.
+  #
+  # NOTE: Since `Log::Context` is immutable, it's safe to share this instance.
+  def self.empty
+    @@empty
+  end
+
   # Creates an empty `Log::Context`.
   def initialize
     @raw = Hash(String, Context).new
@@ -43,6 +52,8 @@ class Log::Context
   # Returns a new `Log::Context` with the keys and values of this context and *other* combined.
   # A value in *other* takes precedence over the one in this context.
   def merge(other : Context)
+    return other if self.object_id == @@empty.object_id
+    return self if other.object_id == @@empty.object_id
     Context.new(self.as_h.merge(other.as_h).clone)
   end
 
@@ -53,7 +64,7 @@ end
 
 class Fiber
   # :nodoc:
-  getter logging_context : Log::Context = Log::Context.new
+  getter logging_context : Log::Context = Log::Context.empty
 
   # :nodoc:
   def logging_context=(value : Log::Context)

--- a/src/log/context.cr
+++ b/src/log/context.cr
@@ -6,14 +6,10 @@
 class Log::Context
   Crystal.datum types: {nil: Nil, bool: Bool, i: Int32, i64: Int64, f: Float32, f64: Float64, s: String, time: Time}, hash_key_type: String, immutable: true, target_type: Log::Context
 
-  @@empty = Log::Context.new
-
   # Returns an empty `Log::Context`.
   #
   # NOTE: Since `Log::Context` is immutable, it's safe to share this instance.
-  def self.empty
-    @@empty
-  end
+  class_getter empty : Log::Context = Log::Context.new
 
   # Creates an empty `Log::Context`.
   def initialize

--- a/src/log/main.cr
+++ b/src/log/main.cr
@@ -106,7 +106,7 @@ class Log
     # Log.info { "message with empty context" }
     # ```
     def clear
-      Fiber.current.logging_context = Log::Context.new
+      Fiber.current.logging_context = Log::Context.empty
     end
 
     # Extends the current `Fiber` logging context.


### PR DESCRIPTION
This should reduce stressing the GC a bit due to new context being created for each fiber and merging context against an empty one.
