### PR TITLE
Add JSON and YAML serialization to Path

### DIFF
--- a/spec/std/json/serialization_spec.cr
+++ b/spec/std/json/serialization_spec.cr
@@ -15,6 +15,14 @@ end
 
 describe "JSON serialization" do
   describe "from_json" do
+    it "does String.from_json" do
+      String.from_json(%("foo bar")).should eq "foo bar"
+    end
+
+    it "does Path.from_json" do
+      Path.from_json(%("foo/bar")).should eq(Path.new("foo/bar"))
+    end
+
     it "does Array(Nil)#from_json" do
       Array(Nil).from_json("[null, null]").should eq([nil, nil])
     end
@@ -331,6 +339,11 @@ describe "JSON serialization" do
       "ab\u{19}cd".to_json.should eq(%q("ab\u0019cd"))
       "ab\u{19}cd\u{19}".to_json.should eq(%q("ab\u0019cd\u0019"))
       "ab\u{19}cd\u{19}e".to_json.should eq(%q("ab\u0019cd\u0019e"))
+    end
+
+    it "does for Path" do
+      Path.posix("foo", "bar", "baz").to_json.should eq(%("foo/bar/baz"))
+      Path.windows("foo", "bar", "baz").to_json.should eq(%("foo\\\\bar\\\\baz"))
     end
 
     it "does for Array" do

--- a/spec/std/yaml/serialization_spec.cr
+++ b/spec/std/yaml/serialization_spec.cr
@@ -63,6 +63,10 @@ describe "YAML serialization" do
       String.from_yaml(%(1.2)).should eq ("1.2")
     end
 
+    it "does Path.from_yaml" do
+      Path.from_yaml(%("foo/bar")).should eq(Path.new("foo/bar"))
+    end
+
     it "does Float32#from_yaml" do
       Float32.from_yaml("1.5").should eq(1.5_f32)
       Float32.from_yaml(".inf").should eq(Float32::INFINITY)
@@ -297,6 +301,10 @@ describe "YAML serialization" do
       ["1", "1.2", "true", "2010-11-12"].each do |string|
         string.to_yaml.should eq(%(--- "#{string}"\n))
       end
+    end
+
+    it "does for Path" do
+      Path.from_yaml(Path.new("foo", "bar", "baz").to_yaml).should eq(Path.new("foo", "bar", "baz"))
     end
 
     it "does for Array" do

--- a/src/json/from_json.cr
+++ b/src/json/from_json.cr
@@ -132,6 +132,10 @@ def String.new(pull : JSON::PullParser)
   pull.read_string
 end
 
+def Path.new(pull : JSON::PullParser)
+  new(pull.read_string)
+end
+
 def String.from_json_object_key?(key : String)
   key
 end

--- a/src/json/to_json.cr
+++ b/src/json/to_json.cr
@@ -70,6 +70,16 @@ class String
   end
 end
 
+struct Path
+  def to_json(json : JSON::Builder)
+    @name.to_json(json)
+  end
+
+  def to_json_object_key
+    @name
+  end
+end
+
 struct Symbol
   def to_json(json : JSON::Builder)
     json.string(to_s)

--- a/src/yaml/from_yaml.cr
+++ b/src/yaml/from_yaml.cr
@@ -76,6 +76,10 @@ def String.new(ctx : YAML::ParseContext, node : YAML::Nodes::Node)
   end
 end
 
+def Path.new(ctx : YAML::ParseContext, node : YAML::Nodes::Node)
+  new(String.new(ctx, node))
+end
+
 def Float32.new(ctx : YAML::ParseContext, node : YAML::Nodes::Node)
   parse_scalar(ctx, node, Float64).to_f32!
 end

--- a/src/yaml/to_yaml.cr
+++ b/src/yaml/to_yaml.cr
@@ -68,6 +68,12 @@ class String
   end
 end
 
+struct Path
+  def to_yaml(yaml : YAML::Nodes::Builder)
+    @name.to_yaml(yaml)
+  end
+end
+
 struct Number
   def to_yaml(yaml : YAML::Nodes::Builder)
     yaml.scalar self.to_s


### PR DESCRIPTION
`Path` is essentially just a `String` wrapper, so we can easily serialize it to JSON and YAML as string.
