### PR TITLE
Fix stack overflow in MT when initializing Log::Context.empty

### DIFF
--- a/src/log/context.cr
+++ b/src/log/context.cr
@@ -60,7 +60,7 @@ end
 
 class Fiber
   # :nodoc:
-  getter logging_context : Log::Context = Log::Context.empty
+  getter logging_context : Log::Context { Log::Context.empty }
 
   # :nodoc:
   def logging_context=(value : Log::Context)


### PR DESCRIPTION
Since #9150 builds in MT are failing with a segmentation fault. There is an infinite recursion within the initialization of the class variable `Log::Context.empty`.

It works like this:
  * `Log::Context.empty` is initialized at startup
  * For the initialization it needs a `Mutex` (https://github.com/crystal-lang/crystal/blob/master/src/crystal/once.cr#L15)
  * To create a `Mutex` it looks for the current `Fiber`
  * But `Fiber` has a `Logging::Context`, thus requiring that its class variables are initialized already.

This PR breaks this loop with a lazy initializer for the logging context.