### PR TITLE
Add Union#nilable? macro method

### DIFF
--- a/spec/compiler/macro/macro_methods_spec.cr
+++ b/spec/compiler/macro/macro_methods_spec.cr
@@ -1947,7 +1947,7 @@ module Crystal
       end
     end
 
-    describe "union methods" do
+    describe Union do
       it "executes types" do
         assert_macro "x", %({{x.types}}), [Crystal::Union.new(["Int32".path, "String".path] of ASTNode)] of ASTNode, "[Int32, String]"
       end
@@ -1959,6 +1959,17 @@ module Crystal
       it "executes resolve?" do
         assert_macro "x", %({{x.resolve?}}), [Crystal::Union.new(["Int32".path, "String".path] of ASTNode)] of ASTNode, "(Int32 | String)"
         assert_macro "x", %({{x.resolve?}}), [Crystal::Union.new(["Int32".path, "Unknown".path] of ASTNode)] of ASTNode, "nil"
+      end
+
+      describe "#nilable?" do
+        it "without nil" do
+          assert_macro "", %({{Union(Int32, Bool, String).nilable?}}), [] of ASTNode, "false"
+        end
+
+        it "with nil" do
+          assert_macro "", "{{Union(Int32, Nil, String).nilable?}}", [] of ASTNode, "true"
+          assert_macro "", "{{Int32?.nilable?}}", [] of ASTNode, "true"
+        end
       end
     end
 

--- a/spec/compiler/macro/macro_methods_spec.cr
+++ b/spec/compiler/macro/macro_methods_spec.cr
@@ -1970,6 +1970,24 @@ module Crystal
           assert_macro "", "{{Union(Int32, Nil, String).nilable?}}", [] of ASTNode, "true"
           assert_macro "", "{{Int32?.nilable?}}", [] of ASTNode, "true"
         end
+
+        it "method args" do
+          assert_type(%(
+            class Foo
+              def is_nilable(arg : Int32?)
+              end
+
+              def not_nilable(arg : Int32)
+              end
+            end
+
+            {% if Foo.methods[0].args.first.restriction.resolve.nilable? == true && Foo.methods[1].args.first.restriction.resolve.nilable? == false %}
+              1
+            {% else %}
+              'a'
+            {% end %}
+          )) { int32 }
+        end
       end
     end
 

--- a/src/compiler/crystal/macros/methods.cr
+++ b/src/compiler/crystal/macros/methods.cr
@@ -1282,6 +1282,8 @@ module Crystal
         interpret_argless_method(method, args) { interpreter.resolve?(self) || NilLiteral.new }
       when "types"
         interpret_argless_method(method, args) { ArrayLiteral.new(@types) }
+      when "nilable?"
+        interpret_argless_method(method, args) { BoolLiteral.new(@types.any? &.nil?) }
       else
         super
       end

--- a/src/compiler/crystal/macros/methods.cr
+++ b/src/compiler/crystal/macros/methods.cr
@@ -1283,7 +1283,7 @@ module Crystal
       when "types"
         interpret_argless_method(method, args) { ArrayLiteral.new(@types) }
       when "nilable?"
-        interpret_argless_method(method, args) { BoolLiteral.new(@types.any? &.nil?) }
+        interpret_argless_method(method, args) { BoolLiteral.new(interpreter.resolve(self).type.nilable?) }
       else
         super
       end


### PR DESCRIPTION
Returns `true` if any type in the union is `Nil`.