### PR TITLE
Ensure `type_vars` works for generic modules.

### DIFF
--- a/spec/compiler/codegen/macro_spec.cr
+++ b/spec/compiler/codegen/macro_spec.cr
@@ -578,6 +578,17 @@ describe "Code gen: macro" do
     )).to_string.should eq("Int32")
   end
 
+  it "can acccess type variables of a module" do
+    run(%(
+      module Foo(T)
+        def self.foo
+          {{ @type.type_vars.first.name.stringify }}
+        end
+      end
+      Foo(Int32).foo
+    )).to_string.should eq("Int32")
+  end
+
   it "can acccess type variables that are not types" do
     run(%(
       class Foo(T)

--- a/src/compiler/crystal/macros/methods.cr
+++ b/src/compiler/crystal/macros/methods.cr
@@ -1692,7 +1692,7 @@ module Crystal
     end
 
     def self.type_vars(type)
-      if type.is_a?(GenericClassInstanceType)
+      if type.is_a?(GenericClassInstanceType) || type.is_a?(GenericModuleInstanceType)
         if type.is_a?(TupleInstanceType)
           if type.tuple_types.empty?
             empty_no_return_array


### PR DESCRIPTION
The following code prints the types of the generic type vars, as expected ([link](https://play.crystal-lang.org/#/r/8xit)):
```crystal
class Model(*T)
  macro inherited
    {% puts @type.ancestors.first %}
    {% puts @type.ancestors.first.type_vars %}
  end
end
class Foo < Model(String, Float64, Int32)
end
```
Output:
```
Model(String, Float64, Int32)
[Tuple(String, Float64, Int32)]
```
However replacing `class` with `module` does not work ([link](https://play.crystal-lang.org/#/r/8xiu)):
```crystal
module Model(*T)
  macro included
    {% puts @type.ancestors.first %}
    {% puts @type.ancestors.first.type_vars %}
  end
end
class Foo
  include Model(String, Float64, Int32)
end
```
Output:
```
Model(String, Float64, Int32)
[] of ::NoReturn
```
The problem seems to be a missing leg of the conditional to check for an instance of a generic module [here](https://github.com/crystal-lang/crystal/blob/8934d4e91bd7a47d3dabca82fd002522dadca18a/src/compiler/crystal/macros/methods.cr#L1695).

This PR includes an example that illustrates the failure and a fix.
