### PR TITLE
Add link to GitHub repo to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,8 @@ Questions or suggestions? Ask on the [Crystal Forum](https://forum.crystal-lang.
 Contributing
 ------------
 
+The Crystal repository is hosted at [crystal-lang/crystal](https://github.com/crystal-lang/crystal) on GitHub.
+
 Read the general [Contributing guide](https://github.com/crystal-lang/crystal/blob/master/CONTRIBUTING.md), and then:
 
 1. Fork it (<https://github.com/crystal-lang/crystal/fork>)


### PR DESCRIPTION
The README should have a direct reference to the repository. It's not just used internally to GitHub.

Maybe it should even be more prominently placed?