### PR TITLE
Add Path#relative_to

### DIFF
--- a/src/exception/call_stack.cr
+++ b/src/exception/call_stack.cr
@@ -27,14 +27,6 @@ end
 
 # :nodoc:
 struct Exception::CallStack
-  # Compute current directory at the beginning so filenames
-  # are always shown relative to the *starting* working directory.
-  CURRENT_DIR = begin
-    dir = Process::INITIAL_PWD
-    dir += File::SEPARATOR unless dir.ends_with?(File::SEPARATOR)
-    dir
-  end
-
   @@skip = [] of String
 
   def self.skip(filename)
@@ -168,7 +160,7 @@ struct Exception::CallStack
         next if @@skip.includes?(file)
 
         # Turn to relative to the current dir, if possible
-        file = file.lchop(CURRENT_DIR)
+        file = Path.new(file).relative_to(Process::INITIAL_PWD)
 
         file_line_column = "#{file}:#{line}:#{column}"
       end

--- a/src/spec/junit_formatter.cr
+++ b/src/spec/junit_formatter.cr
@@ -119,13 +119,8 @@ module Spec
     end
 
     private def classname(result)
-      path = Path[result.file].expand
-      path = path.to_s
-        .lchop(Dir.current)
-        .rchop(path.extension)
-        .lchop(Path::SEPARATORS[0])
-
-      Path[path].parts.join(".")
+      path = Path.new result.file
+      path.expand.relative_to(Dir.current).parts.join('.').rchop path.extension
     end
   end
 end


### PR DESCRIPTION
This PR adds a method `Path#relative_to` which is essentially the inverse of `#expand` and calculates the path that describes the relationship between two other paths.

Also includes a commit which applies this method in stdlib.
The compiler also has a number of use cases, but I haven't included them here because it's a bigger refactoring and will be a subsequent PR.