### PR TITLE
Cleanup File & FileUtils

### DIFF
--- a/spec/std/dir_spec.cr
+++ b/spec/std/dir_spec.cr
@@ -75,6 +75,15 @@ describe "Dir" do
     end
   end
 
+  it "tests mkdir and delete with a new path" do
+    with_tempfile("mkdir") do |path|
+      Dir.mkdir(path, 0o700)
+      Dir.exists?(path).should be_true
+      Dir.delete(path)
+      Dir.exists?(path).should be_false
+    end
+  end
+
   it "tests mkdir and rmdir with a new path" do
     with_tempfile("mkdir") do |path|
       Dir.mkdir(path, 0o700)
@@ -116,17 +125,17 @@ describe "Dir" do
     end
   end
 
-  it "tests rmdir with an nonexistent path" do
+  it "tests delete with an nonexistent path" do
     with_tempfile("nonexistant") do |path|
       expect_raises(File::NotFoundError, "Unable to remove directory: '#{path.inspect_unquoted}'") do
-        Dir.rmdir(path)
+        Dir.delete(path)
       end
     end
   end
 
-  it "tests rmdir with a path that cannot be removed" do
+  it "tests delete with a path that cannot be removed" do
     expect_raises(File::Error, "Unable to remove directory: '#{datapath.inspect_unquoted}'") do
-      Dir.rmdir(datapath)
+      Dir.delete(datapath)
     end
   end
 
@@ -536,8 +545,8 @@ describe "Dir" do
       Dir.mkdir_p("foo\0bar")
     end
 
-    it_raises_on_null_byte "rmdir" do
-      Dir.rmdir("foo\0bar")
+    it_raises_on_null_byte "delete" do
+      Dir.delete("foo\0bar")
     end
   end
 end

--- a/spec/std/file_spec.cr
+++ b/spec/std/file_spec.cr
@@ -1240,6 +1240,29 @@ describe "File" do
     end
   end
 
+  describe ".copy" do
+    it "copies a file" do
+      src_path = datapath("test_file.txt")
+      with_tempfile("cp.txt") do |out_path|
+        File.copy(src_path, out_path)
+        File.exists?(out_path).should be_true
+        File.same_content?(src_path, out_path).should be_true
+      end
+    end
+
+    it "copies permissions" do
+      with_tempfile("cp-permissions-src.txt", "cp-permissions-out.txt") do |src_path, out_path|
+        File.write(src_path, "foo")
+        File.chmod(src_path, 0o700)
+
+        File.copy(src_path, out_path)
+
+        File.info(out_path).permissions.should eq(File::Permissions.new(0o700))
+        File.same_content?(src_path, out_path).should be_true
+      end
+    end
+  end
+
   describe ".match?" do
     it "matches basics" do
       File.match?("abc", "abc").should be_true

--- a/spec/std/file_spec.cr
+++ b/spec/std/file_spec.cr
@@ -1250,7 +1250,7 @@ describe "File" do
       end
     end
 
-    it "copies permissions" do
+    pending_win32 "copies permissions" do
       with_tempfile("cp-permissions-src.txt", "cp-permissions-out.txt") do |src_path, out_path|
         File.write(src_path, "foo")
         File.chmod(src_path, 0o700)
@@ -1262,7 +1262,7 @@ describe "File" do
       end
     end
 
-    it "overwrites existing destination and permissions" do
+    pending_win32 "overwrites existing destination and permissions" do
       with_tempfile("cp-permissions-src.txt", "cp-permissions-out.txt") do |src_path, out_path|
         File.write(src_path, "foo")
         File.chmod(src_path, 0o700)

--- a/spec/std/file_spec.cr
+++ b/spec/std/file_spec.cr
@@ -359,7 +359,7 @@ describe "File" do
         File.chmod(path, 0o664)
         File.info(path).permissions.should eq(normalize_permissions(0o664, directory: true))
       ensure
-        Dir.rmdir(path) if Dir.exists?(path)
+        Dir.delete(path) if Dir.exists?(path)
       end
     end
 

--- a/spec/std/file_spec.cr
+++ b/spec/std/file_spec.cr
@@ -1261,6 +1261,21 @@ describe "File" do
         File.same_content?(src_path, out_path).should be_true
       end
     end
+
+    it "overwrites existing destination and permissions" do
+      with_tempfile("cp-permissions-src.txt", "cp-permissions-out.txt") do |src_path, out_path|
+        File.write(src_path, "foo")
+        File.chmod(src_path, 0o700)
+
+        File.write(out_path, "bar")
+        File.chmod(out_path, 0o777)
+
+        File.copy(src_path, out_path)
+
+        File.info(out_path).permissions.should eq(File::Permissions.new(0o700))
+        File.same_content?(src_path, out_path).should be_true
+      end
+    end
   end
 
   describe ".match?" do

--- a/spec/std/file_spec.cr
+++ b/spec/std/file_spec.cr
@@ -1224,6 +1224,22 @@ describe "File" do
     end
   end
 
+  describe ".same_content?" do
+    it "compares two equal files" do
+      File.same_content?(
+        datapath("test_file.txt"),
+        datapath("test_file.txt")
+      ).should be_true
+    end
+
+    it "compares two different files" do
+      File.same_content?(
+        datapath("test_file.txt"),
+        datapath("test_file.ini")
+      ).should be_false
+    end
+  end
+
   describe ".match?" do
     it "matches basics" do
       File.match?("abc", "abc").should be_true

--- a/spec/std/file_utils_spec.cr
+++ b/spec/std/file_utils_spec.cr
@@ -1,27 +1,6 @@
 require "./spec_helper"
 require "file_utils"
 
-private class OneByOneIO < IO
-  @bytes : Bytes
-
-  def initialize(string)
-    @bytes = string.to_slice
-    @pos = 0
-  end
-
-  def read(slice : Bytes)
-    return 0 if slice.empty?
-    return 0 if @pos >= @bytes.size
-
-    slice[0] = @bytes[@pos]
-    @pos += 1
-    1
-  end
-
-  def write(slice : Bytes) : Nil
-  end
-end
-
 describe "FileUtils" do
   describe "cd" do
     it "should work" do
@@ -68,30 +47,6 @@ describe "FileUtils" do
         datapath("test_file.txt"),
         datapath("test_file.ini")
       ).should be_false
-    end
-
-    it "compares two ios, one way (true)" do
-      io1 = OneByOneIO.new("hello")
-      io2 = IO::Memory.new("hello")
-      FileUtils.cmp(io1, io2).should be_true
-    end
-
-    it "compares two ios, second way (true)" do
-      io1 = OneByOneIO.new("hello")
-      io2 = IO::Memory.new("hello")
-      FileUtils.cmp(io2, io1).should be_true
-    end
-
-    it "compares two ios, one way (false)" do
-      io1 = OneByOneIO.new("hello")
-      io2 = IO::Memory.new("hella")
-      FileUtils.cmp(io1, io2).should be_false
-    end
-
-    it "compares two ios, second way (false)" do
-      io1 = OneByOneIO.new("hello")
-      io2 = IO::Memory.new("hella")
-      FileUtils.cmp(io2, io1).should be_false
     end
   end
 

--- a/spec/std/file_utils_spec.cr
+++ b/spec/std/file_utils_spec.cr
@@ -125,6 +125,23 @@ describe "FileUtils" do
         File.exists?(File.join(dest_path, "b/c")).should be_true
       end
     end
+
+    it "copies a directory recursively if destination exists leaving existing files" do
+      with_tempfile("cp_r-test", "cp_r-test-copied") do |src_path, dest_path|
+        Dir.mkdir_p(dest_path)
+        File.write(File.join(dest_path, "d"), "")
+
+        Dir.mkdir_p(src_path)
+        File.write(File.join(src_path, "a"), "")
+        Dir.mkdir(File.join(src_path, "b"))
+        File.write(File.join(src_path, "b/c"), "")
+
+        FileUtils.cp_r(src_path, dest_path)
+        File.exists?(File.join(dest_path, "a")).should be_true
+        File.exists?(File.join(dest_path, "b/c")).should be_true
+        File.exists?(File.join(dest_path, "d")).should be_true
+      end
+    end
   end
 
   describe "rm_r" do

--- a/src/compiler/crystal/compiler.cr
+++ b/src/compiler/crystal/compiler.cr
@@ -675,7 +675,7 @@ module Crystal
 
         if can_reuse_previous_compilation
           memory_io = IO::Memory.new(memory_buffer.to_slice)
-          changed = File.open(bc_name) { |bc_file| !FileUtils.cmp(bc_file, memory_io) }
+          changed = File.open(bc_name) { |bc_file| !IO.same_content?(bc_file, memory_io) }
 
           # If the user cancelled a previous compilation
           # it might be that the .o file is empty

--- a/src/dir.cr
+++ b/src/dir.cr
@@ -249,8 +249,14 @@ class Dir
   end
 
   # Removes the directory at the given path.
-  def self.rmdir(path : Path | String) : Nil
-    Crystal::System::Dir.delete(path)
+  @[Deprecated("Use `Dir.delete` instead")]
+  def self.rmdir(path : Path | String)
+    delete(path)
+  end
+
+  # Removes the directory at the given path.
+  def self.delete(path : Path | String)
+    Crystal::System::Dir.delete(path.to_s)
   end
 
   def to_s(io : IO) : Nil

--- a/src/file.cr
+++ b/src/file.cr
@@ -177,10 +177,10 @@ class File < IO::FileDescriptor
   # File.same_content?("file.cr", "bar.cr") # => true
   # ```
   def self.same_content?(path1 : Path | String, path2 : Path | String) : Bool
-    return false unless size(path1) == size(path2)
-
     open(path1, "rb") do |file1|
       open(path2, "rb") do |file2|
+        return false unless file1.size == file2.size
+
         same_content?(file1, file2)
       end
     end

--- a/src/file.cr
+++ b/src/file.cr
@@ -729,10 +729,13 @@ class File < IO::FileDescriptor
   # ```
   def self.copy(src : String | Path, dst : String | Path)
     open(src) do |s|
-      open(dst, "wb", s.info.permissions) do |d|
+      open(dst, "wb") do |d|
         # TODO use sendfile or copy_file_range syscall. See #8926, #8919
         IO.copy(s, d)
       end
+
+      # Set the permissions after the content is written in case src permissions is read-only
+      chmod(dst, s.info.permissions)
     end
   end
 

--- a/src/file.cr
+++ b/src/file.cr
@@ -719,6 +719,23 @@ class File < IO::FileDescriptor
     end
   end
 
+  # Copies the file *src* to the file *dst*.
+  # Permission bits are copied too.
+  #
+  # ```
+  # File.chmod("afile", 0o600)
+  # File.copy("afile", "afile_copy")
+  # File.info("afile_copy").permissions.value # => 0o600
+  # ```
+  def self.copy(src : String | Path, dst : String | Path)
+    open(src) do |s|
+      open(dst, "wb", s.info.permissions) do |d|
+        # TODO use sendfile or copy_file_range syscall. See #8926, #8919
+        IO.copy(s, d)
+      end
+    end
+  end
+
   # Returns a new string formed by joining the strings using `File::SEPARATOR`.
   #
   # ```

--- a/src/file.cr
+++ b/src/file.cr
@@ -168,6 +168,24 @@ class File < IO::FileDescriptor
     info(path1.to_s, follow_symlinks).same_file? info(path2.to_s, follow_symlinks)
   end
 
+  # Compares two files *filename1* to *filename2* to determine if they are identical.
+  # Returns `true` if content are the same, `false` otherwise.
+  #
+  # ```
+  # File.write("file.cr", "1")
+  # File.write("bar.cr", "1")
+  # File.same_content?("file.cr", "bar.cr") # => true
+  # ```
+  def self.same_content?(path1 : Path | String, path2 : Path | String) : Bool
+    return false unless size(path1) == size(path2)
+
+    open(path1, "rb") do |file1|
+      open(path2, "rb") do |file2|
+        same_content?(file1, file2)
+      end
+    end
+  end
+
   # Returns the size of the file at *filename* in bytes.
   # Raises `File::NotFoundError` if the file at *filename* does not exist.
   #

--- a/src/file_utils.cr
+++ b/src/file_utils.cr
@@ -381,7 +381,7 @@ module FileUtils
         src = File.join(path, entry)
         rm_r(src)
       end
-      Dir.rmdir(path)
+      Dir.delete(path)
     else
       File.delete(path)
     end
@@ -447,7 +447,7 @@ module FileUtils
   #
   # NOTE: Alias of `Dir.rmdir`
   def rmdir(path : String) : Nil
-    Dir.rmdir(path)
+    Dir.delete(path)
   end
 
   # Removes all directories at the given *paths*.
@@ -459,7 +459,7 @@ module FileUtils
   # ```
   def rmdir(paths : Enumerable(String)) : Nil
     paths.each do |path|
-      Dir.rmdir(path)
+      Dir.delete(path)
     end
   end
 end

--- a/src/file_utils.cr
+++ b/src/file_utils.cr
@@ -38,39 +38,10 @@ module FileUtils
   # File.write("bar.cr", "1")
   # FileUtils.cmp("file.cr", "bar.cr") # => true
   # ```
+  #
+  # NOTE: Alias of `File.same_content?`
   def cmp(filename1 : String, filename2 : String)
-    return false unless File.size(filename1) == File.size(filename2)
-
-    File.open(filename1, "rb") do |file1|
-      File.open(filename2, "rb") do |file2|
-        cmp(file1, file2)
-      end
-    end
-  end
-
-  # Compares two streams *stream1* to *stream2* to determine if they are identical.
-  # Returns `true` if content are the same, `false` otherwise.
-  #
-  # ```
-  # require "file_utils"
-  #
-  # File.write("afile", "123")
-  # stream1 = File.open("afile")
-  # stream2 = IO::Memory.new("123")
-  # FileUtils.cmp(stream1, stream2) # => true
-  # ```
-  def cmp(stream1 : IO, stream2 : IO)
-    buf1 = uninitialized UInt8[1024]
-    buf2 = uninitialized UInt8[1024]
-
-    while true
-      read1 = stream1.read(buf1.to_slice)
-      read2 = stream2.read_fully?(buf2.to_slice[0, read1])
-      return false unless read2
-
-      return false if buf1.to_unsafe.memcmp(buf2.to_unsafe, read1) != 0
-      return true if read1 == 0
-    end
+    File.same_content?(filename1, filename2)
   end
 
   # Attempts to set the access and modification times of the file named

--- a/src/file_utils.cr
+++ b/src/file_utils.cr
@@ -118,7 +118,7 @@ module FileUtils
   # ```
   def cp_r(src_path : String, dest_path : String)
     if Dir.exists?(src_path)
-      Dir.mkdir(dest_path)
+      Dir.mkdir(dest_path) unless Dir.exists?(dest_path)
       Dir.each_child(src_path) do |entry|
         src = File.join(src_path, entry)
         dest = File.join(dest_path, entry)

--- a/src/file_utils.cr
+++ b/src/file_utils.cr
@@ -88,12 +88,8 @@ module FileUtils
   # File.info("afile_copy").permissions.value # => 0o600
   # ```
   def cp(src_path : String, dest : String)
-    File.open(src_path) do |s|
-      dest += File::SEPARATOR + File.basename(src_path) if Dir.exists?(dest)
-      File.open(dest, "wb", s.info.permissions) do |d|
-        IO.copy(s, d)
-      end
-    end
+    dest += File::SEPARATOR + File.basename(src_path) if Dir.exists?(dest)
+    File.copy(src_path, dest)
   end
 
   # Copies a list of files *src* to *dest*.


### PR DESCRIPTION
* Add missing methods to File of features available in FileUtils: same_content?/cmp copy/cp
* Only `FileUtils.cp` treats the dest as a potential directory. `File.copy` works with file paths.
* I left a TODO related to #8926, #8919 for `File.copy` optimizations via syscall.
* Deprecate `Dir.rmdir` in favor of `Dir.delete` (`File.delete` is the file counter-part)
* Another breacking change is the straight removal of `FileUtils.cmp(IO, IO)` (which seems totally misplaced)
* Allow `File.same?` and `File.touch` with `Path` arguments.

Related to #5231.

The APIs that are not strict aliases in FileUtils are

* `FileUtils.touch, .mv, .mkdir, .mkdir_p, .rm`: because they allow multiple files
* `FileUtils.cp`: because it allows destination to be a directory (and allows multiple files)
* `FileUtils.cp_r`: there is no Dir counter-part and it handle the semantic of File vs Dir source / destination.
* `FileUtils.ln[_s|_sf]`: because it allows destination to be a directory and allows multiple files
* `FileUtils.rm_r[f]`: there is no Dir counter-part and allows multiple directories.

So, the following are the criteria that limited the scope of the PR are:

* I don't think we need to allow multiple input in File/Dir API.
* I'm not sure about doing the special treatment in the destination path that `cp_r`, `ln_s` will fit in File API.
* There is also some treatment of `File.symlink?` in `rm_r` that I hesistated to move into `Dir`, and so, I didn't implement `Dir.delete(recursive: true)` proposal of https://github.com/crystal-lang/crystal/issues/5231#issuecomment-343418239


