### PR TITLE
HTTP server do SSL handshake in client fiber

### DIFF
--- a/spec/std/http/server/server_spec.cr
+++ b/spec/std/http/server/server_spec.cr
@@ -413,6 +413,35 @@ describe HTTP::Server do
     end
   end
 
+  it "can process simultaneous SSL handshakes" do
+    server = HTTP::Server.new do |context|
+      context.response.print "ok"
+    end
+
+    server_context, client_context = ssl_context_pair
+    address = server.bind_tls "localhost", server_context
+
+    run_server(server) do |server_done|
+      ch = Channel(Nil).new
+
+      spawn do
+        TCPSocket.open(address.address, address.port) do |socket|
+          ch.send nil
+          ch.receive
+        end
+      end
+
+      begin
+        ch.receive
+        client = HTTP::Client.new(address.address, address.port, client_context)
+        client.read_timeout = client.connect_timeout = 3
+        client.get("/").body.should eq "ok"
+      ensure
+        ch.send nil
+      end
+    end
+  end
+
   describe "#close" do
     it "closes gracefully" do
       server = HTTP::Server.new do |context|

--- a/spec/std/http/server/server_spec.cr
+++ b/spec/std/http/server/server_spec.cr
@@ -421,7 +421,7 @@ describe HTTP::Server do
     server_context, client_context = ssl_context_pair
     address = server.bind_tls "localhost", server_context
 
-    run_server(server) do |server_done|
+    run_server(server) do
       ch = Channel(Nil).new
 
       spawn do

--- a/src/openssl/ssl/server.cr
+++ b/src/openssl/ssl/server.cr
@@ -63,7 +63,7 @@ class OpenSSL::SSL::Server
   #
   # This method calls `@wrapped.accept` and wraps the resulting IO in a SSL socket (`OpenSSL::SSL::Socket::Server`) with `context` configuration.
   def accept : OpenSSL::SSL::Socket::Server
-    new_server(@wrapped.accept)
+    new_ssl_socket(@wrapped.accept)
   end
 
   # Implements `::Socket::Server#accept?`.
@@ -71,11 +71,11 @@ class OpenSSL::SSL::Server
   # This method calls `@wrapped.accept?` and wraps the resulting IO in a SSL socket (`OpenSSL::SSL::Socket::Server`) with `context` configuration.
   def accept? : OpenSSL::SSL::Socket::Server?
     if socket = @wrapped.accept?
-      new_server(socket)
+      new_ssl_socket(socket)
     end
   end
 
-  private def new_server(io)
+  private def new_ssl_socket(io)
     server = OpenSSL::SSL::Socket::Server.new(io, @context, sync_close: @sync_close)
     server.accept if @start_immediately
     server

--- a/src/openssl/ssl/server.cr
+++ b/src/openssl/ssl/server.cr
@@ -76,9 +76,7 @@ class OpenSSL::SSL::Server
   end
 
   private def new_ssl_socket(io)
-    server = OpenSSL::SSL::Socket::Server.new(io, @context, sync_close: @sync_close)
-    server.accept if @start_immediately
-    server
+    OpenSSL::SSL::Socket::Server.new(io, @context, sync_close: @sync_close, accept: @start_immediately)
   end
 
   # Closes this SSL server.

--- a/src/openssl/ssl/server.cr
+++ b/src/openssl/ssl/server.cr
@@ -35,6 +35,9 @@ class OpenSSL::SSL::Server
   # Returns `true` if this SSL server has been closed.
   getter? closed : Bool = false
 
+  # When `true` a call to `#accept` will also initiate the SSL handshake.
+  property start_immediately : Bool = true
+
   # Creates a new SSL server wrapping *wrapped*.
   #
   # *context* configures the SSL options, see `OpenSSL::SSL::Context::Server` for details
@@ -60,7 +63,7 @@ class OpenSSL::SSL::Server
   #
   # This method calls `@wrapped.accept` and wraps the resulting IO in a SSL socket (`OpenSSL::SSL::Socket::Server`) with `context` configuration.
   def accept : OpenSSL::SSL::Socket::Server
-    OpenSSL::SSL::Socket::Server.new(@wrapped.accept, @context, sync_close: @sync_close)
+    new_server(@wrapped.accept)
   end
 
   # Implements `::Socket::Server#accept?`.
@@ -68,8 +71,14 @@ class OpenSSL::SSL::Server
   # This method calls `@wrapped.accept?` and wraps the resulting IO in a SSL socket (`OpenSSL::SSL::Socket::Server`) with `context` configuration.
   def accept? : OpenSSL::SSL::Socket::Server?
     if socket = @wrapped.accept?
-      OpenSSL::SSL::Socket::Server.new(socket, @context, sync_close: @sync_close)
+      new_server(socket)
     end
+  end
+
+  private def new_server(io)
+    server = OpenSSL::SSL::Socket::Server.new(io, @context, sync_close: @sync_close)
+    server.accept if @start_immediately
+    server
   end
 
   # Closes this SSL server.

--- a/src/openssl/ssl/socket.cr
+++ b/src/openssl/ssl/socket.cr
@@ -51,8 +51,18 @@ abstract class OpenSSL::SSL::Socket < IO
   end
 
   class Server < Socket
-    def initialize(io, context : Context::Server = Context::Server.new, sync_close : Bool = false)
+    def initialize(io, context : Context::Server = Context::Server.new,
+                   sync_close : Bool = false, accept : Bool = true)
       super(io, context, sync_close)
+
+      if accept
+        begin
+          self.accept
+        rescue ex
+          LibSSL.ssl_free(@ssl) # GC never calls finalize, avoid mem leak
+          raise ex
+        end
+      end
     end
 
     def accept

--- a/src/openssl/ssl/socket.cr
+++ b/src/openssl/ssl/socket.cr
@@ -53,10 +53,13 @@ abstract class OpenSSL::SSL::Socket < IO
   class Server < Socket
     def initialize(io, context : Context::Server = Context::Server.new, sync_close : Bool = false)
       super(io, context, sync_close)
+    end
+
+    def accept
       begin
         ret = LibSSL.ssl_accept(@ssl)
         unless ret == 1
-          io.close if sync_close
+          @bio.io.close if @sync_close
           raise OpenSSL::SSL::Error.new(@ssl, ret, "SSL_accept")
         end
       rescue ex

--- a/src/openssl/ssl/socket.cr
+++ b/src/openssl/ssl/socket.cr
@@ -56,15 +56,10 @@ abstract class OpenSSL::SSL::Socket < IO
     end
 
     def accept
-      begin
-        ret = LibSSL.ssl_accept(@ssl)
-        unless ret == 1
-          @bio.io.close if @sync_close
-          raise OpenSSL::SSL::Error.new(@ssl, ret, "SSL_accept")
-        end
-      rescue ex
-        LibSSL.ssl_free(@ssl) # GC never calls finalize, avoid mem leak
-        raise ex
+      ret = LibSSL.ssl_accept(@ssl)
+      unless ret == 1
+        @bio.io.close if @sync_close
+        raise OpenSSL::SSL::Error.new(@ssl, ret, "SSL_accept")
       end
     end
 


### PR DESCRIPTION
This fixes #8108 by forcing the call to `SSL_accept` within the fiber that handles the request.

To implement this fix, I added the `OpenSSL::SSL::Server#start_immediately` property just like Ruby does: https://ruby-doc.org/stdlib-2.5.1/libdoc/openssl/rdoc/OpenSSL/SSL/SSLServer.html