### PR TITLE
IO#skip returns the number of bytes it skipped

### DIFF
--- a/src/io.cr
+++ b/src/io.cr
@@ -814,22 +814,26 @@ abstract class IO
   # io.gets    # => "world"
   # io.skip(1) # raises IO::EOFError
   # ```
-  def skip(bytes_count : Int) : Nil
+  def skip(bytes_count : Int) : Int
+    remaining = bytes_count
     buffer = uninitialized UInt8[4096]
-    while bytes_count > 0
-      read_count = read(buffer.to_slice[0, Math.min(bytes_count, 4096)])
+    while remaining > 0
+      read_count = read(buffer.to_slice[0, Math.min(remaining, 4096)])
       raise IO::EOFError.new if read_count == 0
-
-      bytes_count -= read_count
+      remaining -= read_count
     end
+    bytes_count
   end
 
   # Reads and discards bytes from `self` until there
   # are no more bytes.
-  def skip_to_end : Nil
+  def skip_to_end : Int
+    bytes_count = 0
     buffer = uninitialized UInt8[4096]
-    while read(buffer.to_slice) > 0
+    while (len = read(buffer.to_slice)) > 0
+      bytes_count += len
     end
+    bytes_count
   end
 
   # Writes a single byte into this `IO`.

--- a/src/io.cr
+++ b/src/io.cr
@@ -814,7 +814,7 @@ abstract class IO
   # io.gets    # => "world"
   # io.skip(1) # raises IO::EOFError
   # ```
-  def skip(bytes_count : Int) : Int
+  def skip(bytes_count : UInt64) : UInt64
     remaining = bytes_count
     buffer = uninitialized UInt8[4096]
     while remaining > 0
@@ -827,8 +827,8 @@ abstract class IO
 
   # Reads and discards bytes from `self` until there
   # are no more bytes.
-  def skip_to_end : Int
-    bytes_count = 0
+  def skip_to_end : UInt64
+    bytes_count = 0_u64
     buffer = uninitialized UInt8[4096]
     while (len = read(buffer.to_slice)) > 0
       bytes_count += len

--- a/src/io/buffered.cr
+++ b/src/io/buffered.cr
@@ -110,18 +110,20 @@ module IO::Buffered
   end
 
   # :nodoc:
-  def skip(bytes_count) : Nil
+  def skip(bytes_count) : Int
     check_open
 
     if bytes_count <= @in_buffer_rem.size
       @in_buffer_rem += bytes_count
-      return
+      return bytes_count
     end
 
-    bytes_count -= @in_buffer_rem.size
+    remaining = bytes_count
+    remaining -= @in_buffer_rem.size
     @in_buffer_rem = Bytes.empty
 
-    super(bytes_count)
+    super(remaining)
+    bytes_count
   end
 
   # Buffered implementation of `IO#write(slice)`.

--- a/src/io/buffered.cr
+++ b/src/io/buffered.cr
@@ -110,7 +110,7 @@ module IO::Buffered
   end
 
   # :nodoc:
-  def skip(bytes_count) : Int
+  def skip(bytes_count : UInt64) : UInt64
     check_open
 
     if bytes_count <= @in_buffer_rem.size

--- a/src/io/memory.cr
+++ b/src/io/memory.cr
@@ -203,6 +203,7 @@ class IO::Memory < IO
     else
       raise IO::EOFError.new
     end
+    bytes_count
   end
 
   # :nodoc:

--- a/src/io/memory.cr
+++ b/src/io/memory.cr
@@ -194,7 +194,7 @@ class IO::Memory < IO
   end
 
   # :nodoc:
-  def skip(bytes_count)
+  def skip(bytes_count : UInt64) : UInt64
     check_open
 
     available = @bytesize - @pos
@@ -207,10 +207,12 @@ class IO::Memory < IO
   end
 
   # :nodoc:
-  def skip_to_end
+  def skip_to_end : UInt64
     check_open
 
+    skipped = @bytesize - @pos
     @pos = @bytesize
+    skipped.to_u64
   end
 
   # :nodoc:

--- a/src/io/sized.cr
+++ b/src/io/sized.cr
@@ -61,7 +61,7 @@ class IO::Sized < IO
     peek
   end
 
-  def skip(bytes_count) : Nil
+  def skip(bytes_count)
     check_open
 
     if bytes_count <= @read_remaining
@@ -70,6 +70,8 @@ class IO::Sized < IO
     else
       raise IO::EOFError.new
     end
+
+    bytes_count
   end
 
   def write(slice : Bytes) : NoReturn

--- a/src/io/sized.cr
+++ b/src/io/sized.cr
@@ -61,7 +61,7 @@ class IO::Sized < IO
     peek
   end
 
-  def skip(bytes_count)
+  def skip(bytes_count : UInt64) : UInt64
     check_open
 
     if bytes_count <= @read_remaining

--- a/src/io/stapled.cr
+++ b/src/io/stapled.cr
@@ -51,7 +51,7 @@ class IO::Stapled < IO
   end
 
   # Skips `reader`.
-  def skip(bytes_count : Int) : Nil
+  def skip(bytes_count : UInt64) : UInt64
     check_open
 
     @reader.skip(bytes_count)


### PR DESCRIPTION
Can make some code much better looking, eg:

```crystal
len = Int32.from_io @file
@file.skip(len)
skipped += len
``` 
can become
```crystal
skipped += @file.skip(Int32.from_io(@file))
```