### PR TITLE
Fix version selector in API docs shows current version twice

### DIFF
--- a/src/compiler/crystal/tools/doc/html/js/_versions.js
+++ b/src/compiler/crystal/tools/doc/html/js/_versions.js
@@ -30,7 +30,7 @@ CrystalDocs.loadConfig = function (config) {
   var currentVersion = document.querySelector("html > head > meta[name=\"crystal_docs.project_version\"]").getAttribute("content")
 
   var currentVersionInList = projectVersions.find(function (element) {
-    element.version == currentVersion
+    element.name == currentVersion
   })
 
   if (!currentVersionInList) {


### PR DESCRIPTION
Fixes https://github.com/crystal-lang/crystal/pull/9074#issuecomment-619996737