### PR TITLE
Parser: fix parsing of named args after call named the same as a var

### DIFF
--- a/spec/compiler/parser/parser_spec.cr
+++ b/spec/compiler/parser/parser_spec.cr
@@ -415,6 +415,20 @@ module Crystal
       Call.new(nil, "a", args: [-1.int32] of ASTNode, named_args: [NamedArgument.new("b", 2.int32)]),
     ]
 
+    it_parses "a = 1; c a b: 2", [
+      Assign.new("a".var, 1.int32),
+      Call.new(nil, "c", args: [
+        Call.new(nil, "a", named_args: [NamedArgument.new("b", 2.int32)]),
+      ] of ASTNode),
+    ]
+
+    it_parses "a = 1; c a -1, b: 2", [
+      Assign.new("a".var, 1.int32),
+      Call.new(nil, "c", args: [
+        Call.new(nil, "a", args: [-1.int32] of ASTNode, named_args: [NamedArgument.new("b", 2.int32)]),
+      ] of ASTNode),
+    ]
+
     it_parses %(foo("foo bar": 1, "baz": 2)), Call.new(nil, "foo", named_args: [NamedArgument.new("foo bar", 1.int32), NamedArgument.new("baz", 2.int32)])
     it_parses %(foo "foo bar": 1, "baz": 2), Call.new(nil, "foo", named_args: [NamedArgument.new("foo bar", 1.int32), NamedArgument.new("baz", 2.int32)])
 

--- a/spec/compiler/parser/parser_spec.cr
+++ b/spec/compiler/parser/parser_spec.cr
@@ -405,6 +405,16 @@ module Crystal
     it_parses "foo(a: 1\n)", Call.new(nil, "foo", named_args: [NamedArgument.new("a", 1.int32)])
     it_parses "foo(\na: 1,\n)", Call.new(nil, "foo", named_args: [NamedArgument.new("a", 1.int32)])
 
+    it_parses "a = 1; a b: 2", [
+      Assign.new("a".var, 1.int32),
+      Call.new(nil, "a", named_args: [NamedArgument.new("b", 2.int32)]),
+    ]
+
+    it_parses "a = 1; a -1, b: 2", [
+      Assign.new("a".var, 1.int32),
+      Call.new(nil, "a", args: [-1.int32] of ASTNode, named_args: [NamedArgument.new("b", 2.int32)]),
+    ]
+
     it_parses %(foo("foo bar": 1, "baz": 2)), Call.new(nil, "foo", named_args: [NamedArgument.new("foo bar", 1.int32), NamedArgument.new("baz", 2.int32)])
     it_parses %(foo "foo bar": 1, "baz": 2), Call.new(nil, "foo", named_args: [NamedArgument.new("foo bar", 1.int32), NamedArgument.new("baz", 2.int32)])
 

--- a/src/compiler/crystal/syntax/parser.cr
+++ b/src/compiler/crystal/syntax/parser.cr
@@ -4055,16 +4055,16 @@ module Crystal
           call.has_parentheses = has_parentheses
           call
         else
-          if args
+          if args || named_args
             maybe_var = !force_call && is_var && !has_parentheses
-            if maybe_var && args.size == 0
+            if maybe_var && (!args || args.size == 0) && !named_args
               Var.new(name)
-            elsif maybe_var && args.size == 1 && (num = args[0]) && (num.is_a?(NumberLiteral) && num.has_sign?)
+            elsif maybe_var && !named_args && (args && args.size == 1) && (num = args[0]) && (num.is_a?(NumberLiteral) && num.has_sign?)
               sign = num.value[0].to_s
               num.value = num.value.byte_slice(1)
               Call.new(Var.new(name), sign, args)
             else
-              call = Call.new(nil, name, args, nil, block_arg, named_args, global)
+              call = Call.new(nil, name, (args || [] of ASTNode), nil, block_arg, named_args, global)
               call.name_location = name_location
               call.has_parentheses = has_parentheses
               call


### PR DESCRIPTION
Fixes #9189