### PR TITLE
[Experimental] Compiler: replace `&->proc` with block

### DIFF
--- a/spec/compiler/semantic/block_spec.cr
+++ b/spec/compiler/semantic/block_spec.cr
@@ -1443,4 +1443,51 @@ describe "Block inference" do
       end
       ))
   end
+
+  it "autofills args when using &->foo as block arg" do
+    assert_type(%(
+      def foo(x)
+        x + 1
+      end
+
+      def bar
+        yield 1
+      end
+
+      bar(&->foo)
+      )) { int32 }
+  end
+
+  it "autofills args when using &->Type.foo as block arg" do
+    assert_type(%(
+      class Foo
+        def self.foo(x)
+          x + 1
+        end
+      end
+
+      def bar
+        yield 1
+      end
+
+      bar(&->Foo.foo)
+      )) { int32 }
+  end
+
+  it "autofills args when using &->obj.foo as block arg" do
+    assert_type(%(
+      class Foo
+        def foo(x)
+          x + 1
+        end
+      end
+
+      def bar
+        yield 1
+      end
+
+      x = Foo.new
+      bar(&->x.foo)
+      )) { int32 }
+  end
 end


### PR DESCRIPTION
## Before this PR

For example before this PR you can do:

```crystal
["foo.cr", "bar.cr"].find &->File.exists?(String)
```

That's passing the method `File.exists?(String)` as a block argument to `find`.

However, having to specify the type is a bit redundant: we already know that the block arg is a string, and that it's just one argument.

One can also write:

```crystal
["foo.cr", "bar.cr"].find { |arg| File.exists?(arg) }
```

which is the same. However, one has to mention `arg`.

## After this PR

This PR essentially rewrites lets you write this:

```crystal
["foo.cr", "bar.cr"].find &->File.exists?
```

and it just works. It gets rewritten to:

```crystal
["foo.cr", "bar.cr"].find { |arg| File.exists?(arg) }
```

It adds as many arguments to the call as expressions are yielded in `find` (or any other method).

This also works with `&->foo` and `&->obj.foo`. For example (probably not a nice example :-P):

```crystal
x = 10
p [1, 2, 3].map &->x.+ # => [11, 12, 13]

s = "a"
p [2, 3, 4].map &->s.rjust # => [" a", "  a", "   a"]
```

## Why experimental?

Because I don't know if it's intuitive.

What do you think?

## Why are you sending this?

I see in gitter a lot of people use `&->`, and having to specify the types is not nice.

Well... mmm... maybe it's just Kai Leahy that does that, I don't know 😊 





