### PR TITLE
Docs: fix links to methods with String default values

### DIFF
--- a/src/compiler/crystal/tools/doc/html/js/doc.js
+++ b/src/compiler/crystal/tools/doc/html/js/doc.js
@@ -186,14 +186,12 @@ document.addEventListener('DOMContentLoaded', function() {
   var scrollToEntryFromLocationHash = function() {
     var hash = window.location.hash;
     if (hash) {
-      var targetAnchor = unescape(hash.substr(1));
-      var targetEl = document.querySelectorAll('.entry-detail[id="' + targetAnchor.replace(/"/g, '&quot;') + '"]')
-
-      if (targetEl && targetEl.length > 0) {
-        targetEl[0].offsetParent.scrollTop = targetEl[0].offsetTop;
+      var targetAnchor = decodeURI(hash.substr(1));
+      var targetEl = document.getElementById(targetAnchor)
+      if (targetEl) {
+        targetEl.offsetParent.scrollTop = targetEl.offsetTop;
       }
     }
   };
-  window.addEventListener("hashchange", scrollToEntryFromLocationHash, false);
   scrollToEntryFromLocationHash();
 });

--- a/src/compiler/crystal/tools/doc/html/js/doc.js
+++ b/src/compiler/crystal/tools/doc/html/js/doc.js
@@ -193,5 +193,6 @@ document.addEventListener('DOMContentLoaded', function() {
       }
     }
   };
+  window.addEventListener("hashchange", scrollToEntryFromLocationHash, false);
   scrollToEntryFromLocationHash();
 });

--- a/src/compiler/crystal/tools/doc/html/js/doc.js
+++ b/src/compiler/crystal/tools/doc/html/js/doc.js
@@ -187,7 +187,7 @@ document.addEventListener('DOMContentLoaded', function() {
     var hash = window.location.hash;
     if (hash) {
       var targetAnchor = unescape(hash.substr(1));
-      var targetEl = document.querySelectorAll('.entry-detail[id="' + targetAnchor + '"]');
+      var targetEl = document.querySelectorAll('.entry-detail[id="' + targetAnchor.replace(/"/g, '&quot;') + '"]')
 
       if (targetEl && targetEl.length > 0) {
         targetEl[0].offsetParent.scrollTop = targetEl[0].offsetTop;

--- a/src/compiler/crystal/tools/doc/method.cr
+++ b/src/compiler/crystal/tools/doc/method.cr
@@ -194,7 +194,7 @@ class Crystal::Doc::Method
   end
 
   def html_id
-    HTML.escape(id)
+    id
   end
 
   def anchor


### PR DESCRIPTION
The double-quotes value in the id need to be escaped with &quot; in order to work.

For example https://crystal-lang.org/api/0.34.0/Path.html#new(name:String=%22%22):Path-class-method is not working without this PR.