### PR TITLE
examples: fix (2020-04)

### DIFF
--- a/src/compress/zip/reader.cr
+++ b/src/compress/zip/reader.cr
@@ -13,14 +13,12 @@ require "./file_info"
 # ```
 # require "compress/zip"
 #
-# Compress::File.open("./file.zip") do |file|
-#   Zip::Reader.open(file) do |zip|
-#     zip.each_entry do |entry|
-#       p entry.filename
-#       p entry.file?
-#       p entry.dir?
-#       p entry.io.gets_to_end
-#     end
+# Compress::Zip::Reader.open("./file.zip") do |zip|
+#   zip.each_entry do |entry|
+#     p entry.filename
+#     p entry.file?
+#     p entry.dir?
+#     p entry.io.gets_to_end
 #   end
 # end
 # ```

--- a/src/docs_pseudo_methods.cr
+++ b/src/docs_pseudo_methods.cr
@@ -173,7 +173,7 @@ class Object
   # typeof(a.as?(Int32)) # => Int32 | Nil
   # a.as?(Int32)         # => 1
   #
-  # typeof(a.as?(Bool)) # => Nil
+  # typeof(a.as?(Bool)) # => Bool | Nil
   # a.as?(Bool)         # => nil
   #
   # typeof(a.as?(String)) # => String | Nil

--- a/src/json/to_json.cr
+++ b/src/json/to_json.cr
@@ -185,14 +185,14 @@ end
 # ```
 # require "json"
 #
-# class Timestamp
+# class TimestampArray
 #   JSON.mapping({
-#     values: {type: Array(Time), converter: JSON::ArrayConverter(Time::EpochConverter)},
+#     dates: {type: Array(Time), converter: JSON::ArrayConverter(Time::EpochConverter)},
 #   })
 # end
 #
-# timestamp = Timestamp.from_json(%({"dates":[1459859781,1567628762]}))
-# timestamp.values  # => [2016-04-05 12:36:21 UTC, 2019-09-04 20:26:02 UTC]
+# timestamp = TimestampArray.from_json(%({"dates":[1459859781,1567628762]}))
+# timestamp.dates   # => [2016-04-05 12:36:21 UTC, 2019-09-04 20:26:02 UTC]
 # timestamp.to_json # => %({"dates":[1459859781,1567628762]})
 # ```
 module JSON::ArrayConverter(Converter)
@@ -211,15 +211,15 @@ end
 # ```
 # require "json"
 #
-# class Timestamp
+# class TimestampHash
 #   JSON.mapping({
-#     values: {type: Hash(String, Time), converter: JSON::HashValueConverter(Time::EpochConverter)},
+#     birthdays: {type: Hash(String, Time), converter: JSON::HashValueConverter(Time::EpochConverter)},
 #   })
 # end
 #
-# timestamp = Timestamp.from_json(%({"birthdays":{"foo":1459859781,"bar":1567628762}}))
-# timestamp.values  # => {"foo" => 2016-04-05 12:36:21 UTC, "bar" => 2019-09-04 20:26:02 UTC)}
-# timestamp.to_json # => {"birthdays":{"foo":1459859781,"bar":1567628762}}
+# timestamp = TimestampHash.from_json(%({"birthdays":{"foo":1459859781,"bar":1567628762}}))
+# timestamp.birthdays # => {"foo" => 2016-04-05 12:36:21 UTC, "bar" => 2019-09-04 20:26:02 UTC)}
+# timestamp.to_json   # => {"birthdays":{"foo":1459859781,"bar":1567628762}}
 # ```
 module JSON::HashValueConverter(Converter)
   def self.to_json(values : Hash, builder : JSON::Builder)

--- a/src/levenshtein.cr
+++ b/src/levenshtein.cr
@@ -107,12 +107,13 @@ module Levenshtein
   # ```
   # require "levenshtein"
   #
-  # Levenshtein.find("hello") do |l|
+  # best_match = Levenshtein.find("hello") do |l|
   #   l.test "hulk"
   #   l.test "holk"
   #   l.test "halka"
   #   l.test "ello"
-  # end # => "ello"
+  # end
+  # best_match # => "ello"
   # ```
   def self.find(name, tolerance = nil)
     Finder.find(name, tolerance) do |sn|

--- a/src/path.cr
+++ b/src/path.cr
@@ -488,7 +488,7 @@ struct Path
   # Returns the components of this path as an `Array(String)`.
   #
   # ```
-  # Path.new("foo/bar/").parts                   # => ["foo", "bar]
+  # Path.new("foo/bar/").parts                   # => ["foo", "bar"]
   # Path.new("/Users/foo/bar.cr").parts          # => ["/", "Users", "foo", "bar.cr"]
   # Path.windows("C:\\Users\\foo\\bar.cr").parts # => ["C:\\", "Users", "foo", "bar.cr"]
   # Path.posix("C:\\Users\\foo\\bar.cr").parts   # => ["C:\\Users\\foo\\bar.cr"]

--- a/src/string.cr
+++ b/src/string.cr
@@ -3110,7 +3110,7 @@ class String
   # "Dizzy Miss Lizzy".byte_index("izzy")     # => 1
   # "Dizzy Miss Lizzy".byte_index("izzy", 2)  # => 12
   # "Dizzy Miss Lizzy".byte_index("izzy", -4) # => 12
-  # "Dizzy Miss Lizzy".byte_index("izzy", -4) # => nil
+  # "Dizzy Miss Lizzy".byte_index("izzy", -3) # => nil
   # ```
   def byte_index(search : String, offset = 0) : Int32?
     offset += bytesize if offset < 0
@@ -4442,7 +4442,7 @@ class String
   # "22hello".starts_with?(/[0-9]/) # => true
   # "22hello".starts_with?(/[a-z]/) # => false
   # "h22".starts_with?(/[a-z]/)     # => true
-  # "h22".starts_with?(/[A-Z]/)     # => true
+  # "h22".starts_with?(/[A-Z]/)     # => false
   # "h22".starts_with?(/[a-z]{2}/)  # => false
   # "hh22".starts_with?(/[a-z]{2}/) # => true
   # ```
@@ -4491,7 +4491,7 @@ class String
   # "22hello".ends_with?(/[0-9]/) # => false
   # "22hello".ends_with?(/[a-z]/) # => true
   # "22h".ends_with?(/[a-z]/)     # => true
-  # "22h".ends_with?(/[A-Z]/)     # => true
+  # "22h".ends_with?(/[A-Z]/)     # => false
   # "22h".ends_with?(/[a-z]{2}/)  # => false
   # "22hh".ends_with?(/[a-z]{2}/) # => true
   # ```

--- a/src/uuid/json.cr
+++ b/src/uuid/json.cr
@@ -17,6 +17,7 @@ struct UUID
   #
   # example = Example.from_json(%({"id": "ba714f86-cac6-42c7-8956-bcf5105e1b81"}))
   # example.id # => UUID(ba714f86-cac6-42c7-8956-bcf5105e1b81)
+  # ```
   def self.new(pull : JSON::PullParser)
     new(pull.read_string)
   end


### PR DESCRIPTION
Catched up examples for crystal-0.34.0.

* checked by https://github.com/maiha/crystal-examples
* target src: e2717c6cb Refactor: Use Set#add? in compiler (#9195)
* compiler: Crystal 0.34.0 [4401e90f0] (2020-04-06)

#### Optional fixes
There are two more corrections due to the limitations of my tools.  These are not required fixes, so I will remove them if it's not appropriate.

* **src/json/to_json.cr**: The `Timestamp` class has been defined three times. I changed the duplicated names to `TimestampArray` and `TimestampHash` because defining the same class name would break my testing.

* **src/levenshtein.cr**: Since my comment based testing needs to be completed on a row-by-row basis, I put the execution result of the block in a temporary variable.

Best regards,