### PR TITLE
Add titleize method to String.

### DIFF
--- a/spec/std/string_spec.cr
+++ b/spec/std/string_spec.cr
@@ -563,6 +563,16 @@ describe "String" do
     it { "iO".capitalize(Unicode::CaseOptions::Turkic).should eq("İo") }
   end
 
+  describe "titleize" do
+    it { "hEllO tAb\tworld".titleize.should eq("Hello Tab\tWorld") }
+    it { "  spaces before".titleize.should eq("  Spaces Before") }
+    it { "testa-se muito".titleize.should eq("Testa-se Muito") }
+    it { "hÉllÕ tAb\tworld".titleize.should eq("Héllõ Tab\tWorld") }
+    it { "  spáçes before".titleize.should eq("  Spáçes Before") }
+    it { "testá-se múitô".titleize.should eq("Testá-se Múitô") }
+    it { "iO iO".titleize(Unicode::CaseOptions::Turkic).should eq("İo İo") }
+  end
+
   describe "chomp" do
     it { "hello\n".chomp.should eq("hello") }
     it { "hello\r".chomp.should eq("hello") }

--- a/src/string.cr
+++ b/src/string.cr
@@ -1147,6 +1147,39 @@ class String
     end
   end
 
+  # Returns a new `String` with the first letter after any space converted to uppercase and every
+  # other letter converted to lowercase.
+  #
+  # ```
+  # "hEllO tAb\tworld".titleize      # => "Hello Tab\tWorld"
+  # "  spaces before".titleize       # => "  Spaces Before"
+  # "x-men: the last stand".titleize # => "X-men: The Last Stand"
+  # ```
+  def titleize(options = Unicode::CaseOptions::None)
+    return self if empty?
+
+    upcase_next = true
+    if ascii_only? && (options.none? || options.ascii?)
+      String.new(bytesize) do |buffer|
+        bytesize.times do |i|
+          char = to_unsafe[i].unsafe_chr
+          replaced_char = upcase_next ? char.upcase : char.downcase
+          buffer[i] = replaced_char.ord.to_u8
+          upcase_next = char.whitespace?
+        end
+        {@bytesize, @length}
+      end
+    else
+      String.build(bytesize) do |io|
+        each_char_with_index do |char, i|
+          replaced_char = upcase_next ? char.upcase(options) : char.downcase(options)
+          io << replaced_char
+          upcase_next = char.whitespace?
+        end
+      end
+    end
+  end
+
   # Returns a new `String` with the last carriage return removed (that is, it
   # will remove \n, \r, and \r\n).
   #


### PR DESCRIPTION
If you guys like the idea I can add tests to this PR.

This is similar `titleize` method Rails[1] add to Ruby strings, however with a difference:

Rails replaces the `-` by spaces from words, but this doesn't work on all languages, e.g. in portuguese `"fala-se muito"` should be `"Fala-se Muito"`, not `"Fala Se Muito"` as rails does.

So this titleize just upcase letters after whitespaces, similar to already existing `capitalize` method.

[1] https://apidock.com/rails/ActiveSupport/Inflector/titleize