### PR TITLE
Set `sync` or `flush_on_newline` for standard I/O on Windows.

### DIFF
--- a/src/crystal/system/unix/file_descriptor.cr
+++ b/src/crystal/system/unix/file_descriptor.cr
@@ -161,4 +161,24 @@ module Crystal::System::FileDescriptor
 
     bytes_read
   end
+
+  def self.from_stdio(fd)
+    # If we have a TTY for stdin/out/err, it is possibly a shared terminal.
+    # We need to reopen it to use O_NONBLOCK without causing other programs to break
+
+    # Figure out the terminal TTY name. If ttyname fails we have a non-tty, or something strange.
+    # For non-tty we set flush_on_newline to true for reasons described in STDOUT and STDERR docs.
+    path = uninitialized UInt8[256]
+    ret = LibC.ttyname_r(fd, path, 256)
+    return IO::FileDescriptor.new(fd).tap(&.flush_on_newline=(true)) unless ret == 0
+
+    clone_fd = LibC.open(path, LibC::O_RDWR)
+    return IO::FileDescriptor.new(fd).tap(&.flush_on_newline=(true)) if clone_fd == -1
+
+    # We don't buffer output for TTY devices to see their output right away
+    io = IO::FileDescriptor.new(clone_fd)
+    io.close_on_exec = true
+    io.sync = true
+    io
+  end
 end

--- a/src/crystal/system/win32/file_descriptor.cr
+++ b/src/crystal/system/win32/file_descriptor.cr
@@ -162,4 +162,8 @@ module Crystal::System::FileDescriptor
 
     bytes_read
   end
+
+  def self.from_stdio(fd)
+    IO::FileDescriptor.new(fd)
+  end
 end

--- a/src/crystal/system/win32/file_descriptor.cr
+++ b/src/crystal/system/win32/file_descriptor.cr
@@ -1,4 +1,5 @@
 require "c/io"
+require "c/consoleapi"
 
 module Crystal::System::FileDescriptor
   @volatile_fd : Atomic(LibC::Int)
@@ -164,6 +165,22 @@ module Crystal::System::FileDescriptor
   end
 
   def self.from_stdio(fd)
-    IO::FileDescriptor.new(fd)
+    console_handle = false
+    handle = LibC._get_osfhandle(fd)
+    if handle != -1
+      if LibC.GetConsoleMode(LibC::HANDLE.new(handle), out _) != 0
+        console_handle = true
+      end
+    end
+
+    io = IO::FileDescriptor.new(fd)
+    # Set sync or flush_on_newline as described in STDOUT and STDERR docs.
+    # See https://crystal-lang.org/api/toplevel.html#STDERR
+    if console_handle
+      io.sync = true
+    else
+      io.flush_on_newline = true
+    end
+    io
   end
 end

--- a/src/lib_c/x86_64-windows-msvc/c/consoleapi.cr
+++ b/src/lib_c/x86_64-windows-msvc/c/consoleapi.cr
@@ -1,0 +1,5 @@
+require "c/winnt"
+
+lib LibC
+  fun GetConsoleMode(hConsoleHandle : HANDLE, lpMode : DWORD*) : BOOL
+end


### PR DESCRIPTION
This PR sets `sync` or `flush_on_newline` for standard I/O on Windows as on Unix.
This uses [GetConsoleMode][], which succeeds only when the handle is to the console.

I tested it by the code in https://github.com/crystal-lang/crystal/pull/9149#issue-406684705. Without this PR, the benchmark results are displayed on process exit. With this PR, they are displayed as on Unix.

I want to hear opinions. Is it better to move win32 and unix code in `IO::FileDescriptor.from_stdio` to `crystal/system/win32/file_descriptor.cr` and `crystal/system/unix/file_descriptor.cr` respectively?

[GetConsoleMode]: https://docs.microsoft.com/en-us/windows/console/getconsolemode
