### PR TITLE
Parser: rewrite type parser

### DIFF
--- a/spec/compiler/formatter/formatter_spec.cr
+++ b/spec/compiler/formatter/formatter_spec.cr
@@ -1043,6 +1043,7 @@ describe Crystal::Formatter do
   assert_format "module Readline\n  @@completion_proc : (String -> Array(String)?) | (String -> Array(String)) | Nil\nend"
   assert_format "alias A = (B(C, (C | D)) | E)"
   assert_format "alias A = ((B(C | D) | E) | F)"
+  assert_format "alias A = ({A, (B)})"
 
   assert_format "foo : A(B)\nbar : C"
   assert_format "foo : (A -> B)\nbar : C"

--- a/spec/compiler/formatter/formatter_spec.cr
+++ b/spec/compiler/formatter/formatter_spec.cr
@@ -848,6 +848,7 @@ describe Crystal::Formatter do
   assert_format "if 1\n  ((1) + 2)\nend"
 
   assert_format "def   foo(x   :  self ?) \n  end", "def foo(x : self?)\nend"
+  assert_format "def foo(x : (self)?)\nend"
 
   assert_format "  macro foo\n  end\n\n  :+", "macro foo\n  end\n\n:+"
   assert_format "[\n1, # a\n2, # b\n 3 # c\n]", "[\n  1, # a\n  2, # b\n  3, # c\n]"
@@ -1030,6 +1031,7 @@ describe Crystal::Formatter do
 
   assert_format "foo : self?"
   assert_format "foo : self? | A"
+  assert_format "foo : (self)?"
 
   assert_format "foo : (A) | D"
   assert_format "foo : (F(A)) | D"

--- a/spec/compiler/parser/parser_spec.cr
+++ b/spec/compiler/parser/parser_spec.cr
@@ -226,11 +226,11 @@ module Crystal
     it_parses "def foo(var = 1); end", Def.new("foo", [Arg.new("var", 1.int32)])
     it_parses "def foo(var : Int); end", Def.new("foo", [Arg.new("var", restriction: "Int".path)])
     it_parses "def foo(var : self); end", Def.new("foo", [Arg.new("var", restriction: Self.new)])
-    it_parses "def foo(var : self?); end", Def.new("foo", [Arg.new("var", restriction: Crystal::Generic.new(Path.global("Union"), [Self.new, Path.global("Nil")] of ASTNode))])
+    it_parses "def foo(var : self?); end", Def.new("foo", [Arg.new("var", restriction: Crystal::Union.new([Self.new, Path.global("Nil")] of ASTNode))])
     it_parses "def foo(var : self.class); end", Def.new("foo", [Arg.new("var", restriction: Metaclass.new(Self.new))])
     it_parses "def foo(var : self*); end", Def.new("foo", [Arg.new("var", restriction: Self.new.pointer_of)])
     it_parses "def foo(var : Int | Double); end", Def.new("foo", [Arg.new("var", restriction: Crystal::Union.new(["Int".path, "Double".path] of ASTNode))])
-    it_parses "def foo(var : Int?); end", Def.new("foo", [Arg.new("var", restriction: Crystal::Generic.new(Path.global("Union"), ["Int".path, "Nil".path(true)] of ASTNode))])
+    it_parses "def foo(var : Int?); end", Def.new("foo", [Arg.new("var", restriction: Crystal::Union.new(["Int".path, "Nil".path(true)] of ASTNode))])
     it_parses "def foo(var : Int*); end", Def.new("foo", [Arg.new("var", restriction: "Int".path.pointer_of)])
     it_parses "def foo(var : Int**); end", Def.new("foo", [Arg.new("var", restriction: "Int".path.pointer_of.pointer_of)])
     it_parses "def foo(var : Int -> Double); end", Def.new("foo", [Arg.new("var", restriction: ProcNotation.new(["Int".path] of ASTNode, "Double".path))])
@@ -537,7 +537,7 @@ module Crystal
     it_parses "Foo(T)", Generic.new("Foo".path, ["T".path] of ASTNode)
     it_parses "Foo(T | U)", Generic.new("Foo".path, [Crystal::Union.new(["T".path, "U".path] of ASTNode)] of ASTNode)
     it_parses "Foo(Bar(T | U))", Generic.new("Foo".path, [Generic.new("Bar".path, [Crystal::Union.new(["T".path, "U".path] of ASTNode)] of ASTNode)] of ASTNode)
-    it_parses "Foo(T?)", Generic.new("Foo".path, [Crystal::Generic.new(Path.global("Union"), ["T".path, Path.global("Nil")] of ASTNode)] of ASTNode)
+    it_parses "Foo(T?)", Generic.new("Foo".path, [Crystal::Union.new(["T".path, Path.global("Nil")] of ASTNode)] of ASTNode)
     it_parses "Foo(1)", Generic.new("Foo".path, [1.int32] of ASTNode)
     it_parses "Foo(T, 1)", Generic.new("Foo".path, ["T".path, 1.int32] of ASTNode)
     it_parses "Foo(T, U, 1)", Generic.new("Foo".path, ["T".path, "U".path, 1.int32] of ASTNode)
@@ -554,6 +554,7 @@ module Crystal
 
     it_parses "Foo(x: U)", Generic.new("Foo".path, [] of ASTNode, named_args: [NamedArgument.new("x", "U".path)])
     it_parses "Foo(x: U, y: V)", Generic.new("Foo".path, [] of ASTNode, named_args: [NamedArgument.new("x", "U".path), NamedArgument.new("y", "V".path)])
+    it_parses "Foo(X: U, Y: V)", Generic.new("Foo".path, [] of ASTNode, named_args: [NamedArgument.new("X", "U".path), NamedArgument.new("Y", "V".path)])
     assert_syntax_error "Foo(T, x: U)"
     assert_syntax_error "Foo(x: T y: U)"
 
@@ -562,6 +563,7 @@ module Crystal
 
     it_parses "Foo({x: X})", Generic.new("Foo".path, [Generic.new(Path.global("NamedTuple"), [] of ASTNode, named_args: [NamedArgument.new("x", "X".path)])] of ASTNode)
     it_parses "Foo({x: X, y: Y})", Generic.new("Foo".path, [Generic.new(Path.global("NamedTuple"), [] of ASTNode, named_args: [NamedArgument.new("x", "X".path), NamedArgument.new("y", "Y".path)])] of ASTNode)
+    it_parses "Foo({X: X, Y: Y})", Generic.new("Foo".path, [Generic.new(Path.global("NamedTuple"), [] of ASTNode, named_args: [NamedArgument.new("X", "X".path), NamedArgument.new("Y", "Y".path)])] of ASTNode)
     it_parses "Foo(T, {x: X})", Generic.new("Foo".path, ["T".path, Generic.new(Path.global("NamedTuple"), [] of ASTNode, named_args: [NamedArgument.new("x", "X".path)])] of ASTNode)
     assert_syntax_error "Foo({x: X, x: Y})", "duplicated key: x"
 
@@ -773,7 +775,7 @@ module Crystal
     it_parses "lib LibC\nfun getchar\nend", LibDef.new("LibC", [FunDef.new("getchar")] of ASTNode)
     it_parses "lib LibC\nfun getchar(...)\nend", LibDef.new("LibC", [FunDef.new("getchar", varargs: true)] of ASTNode)
     it_parses "lib LibC\nfun getchar : Int\nend", LibDef.new("LibC", [FunDef.new("getchar", return_type: "Int".path)] of ASTNode)
-    it_parses "lib LibC\nfun getchar : (->)?\nend", LibDef.new("LibC", [FunDef.new("getchar", return_type: Crystal::Generic.new(Path.global("Union"), [ProcNotation.new, "Nil".path(true)] of ASTNode))] of ASTNode)
+    it_parses "lib LibC\nfun getchar : (->)?\nend", LibDef.new("LibC", [FunDef.new("getchar", return_type: Crystal::Union.new([ProcNotation.new, "Nil".path(true)] of ASTNode))] of ASTNode)
     it_parses "lib LibC\nfun getchar(Int, Float)\nend", LibDef.new("LibC", [FunDef.new("getchar", [Arg.new("", restriction: "Int".path), Arg.new("", restriction: "Float".path)])] of ASTNode)
     it_parses "lib LibC\nfun getchar(a : Int, b : Float)\nend", LibDef.new("LibC", [FunDef.new("getchar", [Arg.new("a", restriction: "Int".path), Arg.new("b", restriction: "Float".path)])] of ASTNode)
     it_parses "lib LibC\nfun getchar(a : Int)\nend", LibDef.new("LibC", [FunDef.new("getchar", [Arg.new("a", restriction: "Int".path)])] of ASTNode)

--- a/spec/compiler/semantic/restrictions_spec.cr
+++ b/spec/compiler/semantic/restrictions_spec.cr
@@ -680,16 +680,6 @@ describe "Restrictions" do
       )) { types["Parent"].metaclass.virtual_type! }
   end
 
-  it "doesn't crash on invalid splat restriction (#3698)" do
-    assert_error %(
-      def foo(arg : *String)
-      end
-
-      foo(1)
-      ),
-      "no overload matches"
-  end
-
   it "errors if using free var without forall" do
     assert_error %(
       def foo(x : T)

--- a/src/compiler/crystal/syntax/parser.cr
+++ b/src/compiler/crystal/syntax/parser.cr
@@ -386,7 +386,7 @@ module Crystal
                )
               push_var atomic
               next_token_skip_space
-              type = parse_single_type
+              type = parse_bare_proc_type
               atomic = UninitializedVar.new(atomic, type).at(location)
               return atomic
             else
@@ -835,12 +835,12 @@ module Crystal
 
       if @token.type == :"("
         next_token_skip_space_or_newline
-        type = parse_single_type
+        type = parse_bare_proc_type
         skip_space_or_newline
         check :")"
         next_token_skip_space
       else
-        type = parse_single_type
+        type = parse_union_type
       end
 
       IsA.new(atomic, type)
@@ -851,13 +851,13 @@ module Crystal
 
       if @token.type == :"("
         next_token_skip_space_or_newline
-        type = parse_single_type
+        type = parse_bare_proc_type
         skip_space_or_newline
         check :")"
         end_location = token_end_location
         next_token_skip_space
       else
-        type = parse_single_type(allow_commas: false)
+        type = parse_union_type
         end_location = token_end_location
       end
 
@@ -942,7 +942,7 @@ module Crystal
       when :"{%"
         parse_percent_macro_control
       when :"::"
-        parse_ident_or_global_call
+        parse_generic_or_global_call
       when :"->"
         parse_fun_literal
       when :"@["
@@ -1156,7 +1156,7 @@ module Crystal
           set_visibility parse_var_or_call
         end
       when :CONST
-        parse_ident_or_literal
+        parse_generic_or_custom_literal
       when :INSTANCE_VAR
         if @in_macro_expression && @token.value == "@type"
           @is_macro_def = true
@@ -1186,7 +1186,7 @@ module Crystal
 
     def parse_type_declaration(var)
       next_token_skip_space_or_newline
-      var_type = parse_single_type(allow_splat: true)
+      var_type = parse_bare_proc_type
       skip_space
       if @token.type == :"="
         next_token_skip_space_or_newline
@@ -1230,12 +1230,12 @@ module Crystal
       end
     end
 
-    def parse_ident_or_literal
-      ident = parse_ident
-      parse_custom_literal ident
+    def parse_generic_or_custom_literal
+      type = parse_generic
+      parse_custom_literal type
     end
 
-    def parse_custom_literal(ident)
+    def parse_custom_literal(type)
       skip_space
 
       if @token.type == :"{"
@@ -1249,16 +1249,17 @@ module Crystal
 
         case tuple_or_hash
         when TupleLiteral
-          ary = ArrayLiteral.new(tuple_or_hash.elements, name: ident).at(tuple_or_hash.location)
+          ary = ArrayLiteral.new(tuple_or_hash.elements, name: type).at(tuple_or_hash.location)
           return ary
         when HashLiteral
-          tuple_or_hash.name = ident
+          tuple_or_hash.name = type
           return tuple_or_hash
         else
           raise "BUG: tuple_or_hash should be tuple or hash, not #{tuple_or_hash}"
         end
       end
-      ident
+
+      type
     end
 
     def check_not_inside_def(message)
@@ -1433,7 +1434,7 @@ module Crystal
     def parse_rescue_types
       types = [] of ASTNode
       while true
-        types << parse_ident
+        types << parse_generic
         skip_space
         if @token.type == :"|"
           next_token_skip_space
@@ -1623,7 +1624,7 @@ module Crystal
           superclass = Self.new.at(@token.location)
           next_token
         else
-          superclass = parse_ident
+          superclass = parse_generic
         end
       end
       skip_statement_end
@@ -1858,7 +1859,7 @@ module Crystal
       if @token.type == :":"
         next_token_skip_space_or_newline
 
-        type = parse_single_type
+        type = parse_bare_proc_type
       end
 
       if @token.type == :","
@@ -1900,7 +1901,7 @@ module Crystal
           end
         end
       when :CONST
-        obj = parse_ident
+        obj = parse_generic
         check :"."
         name = consume_def_or_macro_name
         next_token_skip_space
@@ -1914,7 +1915,7 @@ module Crystal
 
       if @token.type == :"("
         next_token_skip_space
-        types = parse_types
+        types = parse_union_types(:")")
         check :")"
         next_token_skip_space
       else
@@ -2278,7 +2279,7 @@ module Crystal
       next_token_skip_space
       if @token.keyword?(:of)
         next_token_skip_space_or_newline
-        of = parse_single_type
+        of = parse_bare_proc_type
         ArrayLiteral.new(of: of).at_end(of)
       else
         raise "for empty arrays use '[] of ElementType'", line, column
@@ -2317,7 +2318,7 @@ module Crystal
       of = nil
       if @token.keyword?(:of)
         next_token_skip_space_or_newline
-        of = parse_single_type
+        of = parse_bare_proc_type
         end_location = of.end_location
       elsif exps.size == 0
         raise "for empty arrays use '[] of ElementType'", line, column
@@ -2472,10 +2473,10 @@ module Crystal
       if allow_of
         if @token.keyword?(:of)
           next_token_skip_space_or_newline
-          of_key = parse_single_type
+          of_key = parse_bare_proc_type
           check :"=>"
           next_token_skip_space_or_newline
-          of_value = parse_single_type
+          of_value = parse_bare_proc_type
           of = HashLiteral::Entry.new(of_key, of_value)
           end_location = of_value.end_location
         end
@@ -2879,7 +2880,7 @@ module Crystal
         name.end_location = token_end_location
         next_token_skip_space
       else
-        name = parse_ident
+        name = parse_generic
       end
 
       klass.new name
@@ -3371,7 +3372,7 @@ module Crystal
       end_location = token_end_location
 
       if @token.type == :CONST
-        receiver = parse_ident(allow_type_vars: false)
+        receiver = parse_path
       elsif @token.type == :IDENT
         check_valid_def_name
         name = @token.value.to_s
@@ -3518,7 +3519,7 @@ module Crystal
 
       if @token.type == :":"
         next_token_skip_space
-        return_type = parse_single_type
+        return_type = parse_bare_proc_type
         end_location = return_type.end_location
       end
 
@@ -3699,7 +3700,7 @@ module Crystal
           next_token
         end
 
-        restriction = parse_single_type(allow_splat: !splat_restriction)
+        restriction = parse_bare_proc_type
 
         if splat_restriction
           restriction = splat ? Splat.new(restriction) : DoubleSplat.new(restriction)
@@ -3769,7 +3770,7 @@ module Crystal
 
         location = @token.location
 
-        type_spec = parse_single_type(allow_splat: true)
+        type_spec = parse_bare_proc_type
       end
 
       block_arg = Arg.new(arg_name, restriction: type_spec).at(name_location)
@@ -4640,7 +4641,7 @@ module Crystal
       end
     end
 
-    def parse_ident_or_global_call
+    def parse_generic_or_global_call
       location = @token.location
       next_token_skip_space_or_newline
 
@@ -4648,46 +4649,187 @@ module Crystal
       when :IDENT
         set_visibility parse_var_or_call global: true
       when :CONST
-        ident = parse_ident_after_colons location,
-          global: true,
-          allow_type_vars: true,
-          parse_nilable: true
+        ident = parse_generic global: true, location: location
         parse_custom_literal ident
       else
         unexpected_token
       end
     end
 
-    def parse_ident(allow_type_vars = true, parse_nilable = true)
+    # Parse a **bare** proc type like `A, B, C -> D`.
+    # Generally it is entyr point of type parsing and
+    # it is used on the context expected type (e.g. type restrictions, rhs of `alias` and more)
+    def parse_bare_proc_type
+      type = parse_type_splat { parse_union_type }
+
+      # To determine to consume comma, looking-ahead is needed.
+      # Consider `[ [] of Int32, Foo.new ]`, we want to parse it as `[ ([] of Int32), Foo.new ]` of course.
+      # If the parser consumes comma afrer Int32 quickly, it may cause parsing error.
+      unless @token.type == :"->" || (@token.type == :"," && type_start?)
+        if type.is_a?(Splat)
+          raise "invalid type splat", type.location.not_nil!
+        end
+        return type
+      end
+
+      input_types = [type]
+      if @token.type != :"->"
+        loop do
+          next_token_skip_space_or_newline
+          input_types << parse_type_splat { parse_union_type }
+          break unless @token.type == :"," && type_start?
+        end
+      end
+
+      parse_proc_type_output(input_types, input_types.first.location)
+    end
+
+    def parse_union_type
+      type = parse_atomic_type_with_suffix
+      return type unless @token.type == :|
+
+      types = [type]
+      while @token.type == :|
+        next_token_skip_space_or_newline
+        types << parse_atomic_type_with_suffix
+      end
+
+      Union.new(types).at(types.first).at_end(types.last)
+    end
+
+    def parse_atomic_type_with_suffix
+      type = parse_atomic_type
+      parse_type_suffix type
+    end
+
+    def parse_atomic_type
+      location = @token.location
+
+      case @token.type
+      when :IDENT
+        case @token.value
+        when :self
+          next_token_skip_space
+          Self.new.at(location)
+        when "self?"
+          next_token_skip_space
+          make_nilable_type Self.new.at(location)
+        when :typeof
+          parse_typeof
+        else
+          unexpected_token
+        end
+      when :UNDERSCORE
+        next_token_skip_space
+        Underscore.new.at(location)
+      when :CONST, :"::"
+        parse_generic
+      when :"{"
+        next_token_skip_space_or_newline
+        if named_tuple_start? || @token.type == :DELIMITER_START
+          type = make_named_tuple_type parse_named_type_args(:"}")
+        else
+          type = make_tuple_type parse_union_types(:"}")
+        end
+        check :"}"
+        next_token_skip_space
+        type
+      when :"->"
+        parse_proc_type_output(nil, location)
+      when :"("
+        next_token_skip_space_or_newline
+        type = parse_type_splat { parse_union_type }
+        if @token.type == :")"
+          next_token_skip_space
+          if @token.type == :"->" # `(A) -> B` case
+            type = parse_proc_type_output([type], location)
+          elsif type.is_a?(Splat)
+            raise "invalid type splat", type.location.not_nil!
+          end
+        else
+          input_types = [type]
+          while @token.type == :","
+            next_token_skip_space_or_newline
+            break if @token.type == :")" # allow trailing comma
+            input_types << parse_type_splat { parse_union_type }
+          end
+          if @token.type == :"->" # `(A, B, C -> D)` case
+            type = parse_proc_type_output(input_types, input_types.first.location)
+            check :")"
+            next_token_skip_space
+          else # `(A, B, C) -> D` case
+            check :")"
+            next_token_skip_space
+            type = parse_proc_type_output(input_types, location)
+          end
+        end
+        type
+      else
+        unexpected_token
+      end
+    end
+
+    def parse_union_types(end_token)
+      types = [parse_union_type]
+      while @token.type == :","
+        next_token_skip_space_or_newline
+        break if @token.type == end_token # allow trailing comma
+        types << parse_union_type
+      end
+      types
+    end
+
+    # Parse generic type path like `A::B(C, D)?`.
+    # This method is used to parse not only a type, but also an expression represents type.
+    # And it also consumes prefix `::` to specify global path.
+    def parse_generic
       location = @token.location
 
       global = false
-
-      if @token.type == :UNDERSCORE
-        return node_and_next_token Underscore.new.at(location)
-      end
-
       if @token.type == :"::"
-        global = true
         next_token_skip_space_or_newline
+        global = true
       end
 
-      check :CONST
-      parse_ident_after_colons(location, global, allow_type_vars, parse_nilable)
+      parse_generic global, location
     end
 
+    def parse_generic(global, location)
+      path = parse_path(global, location)
+      type = parse_type_args(path)
+
+      # Nilable suffixes without any spaces are consumed here
+      # for expression represents nilable type. Typically such an expression
+      # is appeared in macro expression. (e.g. `{% if T <= Int32? %} ... {% end %}`)
+      # Note that the parser cannot consume any spaces because it conflicts ternary operator.
+      while @token.type == :"?"
+        next_token
+        type = make_nilable_type(type)
+      end
+
+      skip_space
+
+      type
+    end
+
+    # Parse type path.
+    # It also consumes prefix `::` to specify global path.
     def parse_path
-      name = parse_ident(allow_type_vars: false, parse_nilable: false)
-      raise "BUG: expected a Path" unless name.is_a?(Path)
-      name
+      location = @token.location
+
+      global = false
+      if @token.type == :"::"
+        next_token_skip_space_or_newline
+        global = true
+      end
+
+      path = parse_path(global, @token.location)
+      skip_space
+      path
     end
 
-    def parse_ident_after_colons(location, global, allow_type_vars, parse_nilable)
-      start_line = location.line_number
-      start_column = location.column_number
-
-      names = [] of String
-      names << @token.value.to_s
+    def parse_path(global, location)
+      names = [check_const]
       end_location = token_end_location
 
       @wants_regex = false
@@ -4696,58 +4838,44 @@ module Crystal
         next_token_skip_space_or_newline
         names << check_const
         end_location = token_end_location
+
         @wants_regex = false
         next_token
       end
 
-      const = Path.new(names, global).at(location)
-      const.end_location = end_location
-
-      token_location = @token.location
-      if token_location && token_location.line_number == start_line
-        const.name_size = token_location.column_number - start_column
-      end
-
-      if allow_type_vars && @token.type == :"("
-        next_token_skip_space_or_newline
-
-        if named_tuple_start? || @token.type == :DELIMITER_START
-          types = [] of ASTNode
-          named_args = parse_type_named_args(:")")
-        else
-          types = parse_types allow_primitives: true, allow_splat: true
-          if types.empty?
-            raise "must specify at least one type var"
-          end
-          named_args = nil
-        end
-
-        next_token if @token.type == :","
-
-        skip_space_or_newline
-        check :")"
-        const = Generic.new(const, types, named_args).at(location)
-        const.end_location = token_end_location
-
-        next_token
-      end
-
-      if parse_nilable
-        while @token.type == :"?"
-          const = Generic.new(Path.global("Union").at(const), [
-            const, Path.global("Nil").at(const),
-          ] of ASTNode)
-          const.question = true
-          next_token
-        end
-      end
-
-      skip_space
-
-      const
+      Path.new(names, global).at(location).at_end(end_location)
     end
 
-    def parse_type_named_args(end_token)
+    def parse_type_args(name)
+      return name unless @token.type == :"("
+
+      next_token_skip_space_or_newline
+      args = [] of ASTNode
+      if named_tuple_start? || string_literal_start?
+        named_args = parse_named_type_args(:")")
+      else
+        args << parse_type_splat { parse_type_arg }
+        while @token.type == :","
+          next_token_skip_space_or_newline
+          break if @token.type == :")" # allow trailing comma
+          args << parse_type_splat { parse_type_arg }
+        end
+
+        has_int = args.any? { |arg| arg.is_a?(NumberLiteral) || arg.is_a?(SizeOf) || arg.is_a?(InstanceSizeOf) || arg.is_a?(OffsetOf) }
+        if @token.type == :"->" && !has_int
+          args = [parse_proc_type_output(args, args.first.location)] of ASTNode
+        end
+      end
+
+      skip_space_or_newline
+      check :")"
+      end_location = token_end_location
+      next_token
+
+      Generic.new(name, args, named_args).at(name).at_end(end_location)
+    end
+
+    def parse_named_type_args(end_token)
       named_args = [] of NamedArgument
 
       while @token.type != end_token
@@ -4767,7 +4895,7 @@ module Crystal
         check :":"
         next_token_skip_space_or_newline
 
-        type = parse_single_type(allow_commas: false)
+        type = parse_bare_proc_type
         skip_space
 
         named_args << NamedArgument.new(name, type)
@@ -4784,235 +4912,150 @@ module Crystal
       named_args
     end
 
-    def parse_types(allow_primitives = false, allow_splat = false)
-      type = parse_type(allow_primitives: allow_primitives, allow_splat: allow_splat, inside_paren: true)
-      case type
-      when Array
-        type
-      when ASTNode
-        [type] of ASTNode
-      else
-        raise "BUG"
-      end
-    end
-
-    def parse_single_type(allow_primitives = false, allow_commas = true, allow_splat = false)
-      location = @token.location
-      type = parse_type(allow_primitives: allow_primitives, allow_commas: allow_commas, allow_splat: allow_splat)
-      case type
-      when Array
-        raise "unexpected ',' in type (use parentheses to disambiguate)", location
-      when ASTNode
-        type
-      else
-        raise "BUG"
-      end
-    end
-
-    def parse_type(allow_primitives, allow_commas = true, allow_splat = false, inside_paren = false)
+    def parse_type_splat
       location = @token.location
 
-      if @token.type == :"->"
-        input_types = nil
-      else
-        input_types = parse_type_union(allow_primitives, allow_splat)
-        input_types = [input_types] unless input_types.is_a?(Array)
-        while allow_commas && @token.type == :"," && (
-                (allow_primitives && next_comes_type_or_int) ||
-                (!allow_primitives && next_comes_type) ||
-                (inside_paren && next_comes_curly)
-              )
-          next_token_skip_space_or_newline
-          if @token.type == :"->"
-            next_types = parse_type(false)
-            case next_types
-            when Array
-              input_types.concat next_types
-            when ASTNode
-              input_types << next_types
-            end
-            next
-          else
-            type_union = parse_type_union(allow_primitives, allow_splat)
-            if type_union.is_a?(Array)
-              input_types.concat type_union
-            else
-              input_types << type_union
-            end
-          end
-        end
-      end
-
-      if @token.type == :"->"
-        next_token_skip_space
-        case @token.type
-        when :"=", :",", :")", :"}", :";", :NEWLINE
-          return_type = nil
-        else
-          type_union = parse_type_union(allow_primitives, allow_splat)
-          if type_union.is_a?(Array)
-            raise "can't return more than more type", location.line_number, location.column_number
-          else
-            return_type = type_union
-          end
-        end
-        ProcNotation.new(input_types, return_type).at(location)
-      else
-        input_types = input_types.not_nil!
-        if input_types.size == 1
-          input_types.first
-        else
-          input_types
-        end
-      end
-    end
-
-    def parse_type_union(allow_primitives, allow_splat)
-      types = [] of ASTNode
-      parse_type_with_suffix(types, allow_primitives, allow_splat)
-      if @token.type == :"|"
-        while @token.type == :"|"
-          next_token_skip_space_or_newline
-          parse_type_with_suffix(types, allow_primitives, allow_splat)
-        end
-
-        if types.size == 1
-          types.first
-        else
-          Union.new(types).at(types.first.location)
-        end
-      elsif types.size == 1
-        types.first
-      else
-        types
-      end
-    end
-
-    def parse_type_with_suffix(types, allow_primitives, allow_splat)
       splat = false
-      if allow_splat && @token.type == :"*"
+      if @token.type == :"*"
+        next_token_skip_space_or_newline
         splat = true
-        next_token
       end
 
-      location = @token.location
-
-      if @token.type == :IDENT && @token.value == "self?"
-        type = Self.new.at(location)
-        type = Union.new([type, Path.global("Nil")] of ASTNode).at(location)
-        next_token_skip_space
-      elsif @token.keyword?(:self)
-        type = Self.new.at(location)
-        next_token_skip_space
-      else
-        case @token.type
-        when :"{"
-          next_token_skip_space_or_newline
-
-          if named_tuple_start? || @token.type == :DELIMITER_START
-            named_args = parse_type_named_args(:"}")
-          else
-            type = parse_type(allow_primitives)
-          end
-
-          # Allow a trailing comma
-          if @token.type == :","
-            next_token_skip_space_or_newline
-          end
-
-          check :"}"
-          next_token_skip_space
-
-          if named_args
-            type = make_named_tuple_type(named_args).at(location)
-          else
-            case type
-            when Array
-              type = make_tuple_type(type).at(location)
-            when ASTNode
-              type = make_tuple_type([type] of ASTNode).at(location)
-            else
-              raise "BUG"
-            end
-          end
-        when :"("
-          next_token_skip_space_or_newline
-          type = parse_type(allow_primitives, allow_splat: allow_splat)
-          check :")"
-          next_token_skip_space
-          case type
-          when Array
-            types.concat type
-            return
-          when ASTNode
-            # skip
-          else
-            raise "BUG"
-          end
-        else
-          if allow_primitives
-            if @token.type == :NUMBER
-              num = NumberLiteral.new(@token.value.to_s, @token.number_kind).at(@token.location)
-              types << node_and_next_token(num)
-              skip_space
-              return types
-            end
-          end
-
-          type = parse_simple_type
-        end
-      end
-
+      type = yield
       type = Splat.new(type).at(location) if splat
-      types << parse_type_suffix(type)
+      type
     end
 
-    def parse_simple_type
-      case @token
-      when .keyword?(:typeof)
-        type = parse_typeof
-      when .keyword?(:sizeof)
-        type = parse_sizeof
-      when .keyword?(:instance_sizeof)
-        type = parse_instance_sizeof
-      when .keyword?(:offsetof)
-        type = parse_offsetof
-      else
-        type = parse_ident(parse_nilable: false)
+    def parse_type_arg
+      if @token.type == :NUMBER
+        num = NumberLiteral.new(@token.value.to_s, @token.number_kind).at(@token.location)
+        next_token_skip_space
+        return num
       end
-      skip_space
-      type
+
+      case @token
+      when .keyword?(:sizeof)
+        parse_sizeof
+      when .keyword?(:instance_sizeof)
+        parse_instance_sizeof
+      when .keyword?(:offsetof)
+        parse_offsetof
+      else
+        parse_union_type
+      end
     end
 
     def parse_type_suffix(type)
-      while true
+      loop do
         case @token.type
-        when :"?"
-          type = Union.new([type, Path.global("Nil")] of ASTNode).at(type.location)
-          next_token_skip_space
-        when :"*"
-          type = make_pointer_type(type).at(type.location)
-          next_token_skip_space
-        when :"**"
-          type = make_pointer_type(make_pointer_type(type)).at(type.location)
-          next_token_skip_space
-        when :"["
-          next_token_skip_space
-          size = parse_single_type allow_primitives: true
-          check :"]"
-          @wants_regex = false
-          next_token_skip_space
-          type = make_static_array_type(type, size).at(type.location)
         when :"."
-          next_token
+          next_token_skip_space_or_newline
           check_ident :class
-          type = Metaclass.new(type).at(type.location)
           next_token_skip_space
+          type = Metaclass.new(type).at(type)
+        when :"?"
+          next_token_skip_space
+          type = make_nilable_type(type)
+        when :"*"
+          next_token_skip_space
+          type = make_pointer_type(type)
+        when :"**"
+          next_token_skip_space
+          type = make_pointer_type(make_pointer_type(type))
+        when :"["
+          next_token_skip_space_or_newline
+          size = parse_type_arg
+          skip_space_or_newline
+          check :"]"
+          next_token_skip_space
+          type = make_static_array_type(type, size)
         else
-          break
+          return type
         end
       end
+    end
+
+    def parse_proc_type_output(input_types, location)
+      has_output_type = type_start?(consume_newlines: false)
+
+      check :"->"
+      next_token_skip_space
+
+      if has_output_type
+        skip_space_or_newline
+        output_type = parse_union_type
+      end
+
+      ProcNotation.new(input_types, output_type).at(location)
+    end
+
+    def make_nilable_type(type)
+      type = Generic.new(Path.global("Union").at(type), [type, Path.global("Nil").at(type)]).at(type)
+      type.question = true
       type
+    end
+
+    def make_pointer_type(type)
+      Generic.new(Path.global("Pointer").at(type), [type] of ASTNode).at(type)
+    end
+
+    def make_static_array_type(type, size)
+      Generic.new(Path.global("StaticArray").at(type), [type, size] of ASTNode).at(type)
+    end
+
+    def make_tuple_type(types)
+      Generic.new(Path.global("Tuple"), types)
+    end
+
+    def make_named_tuple_type(named_args)
+      Generic.new(Path.global("NamedTuple"), [] of ASTNode, named_args: named_args)
+    end
+
+    # Looks ahead next tokens to check whether they indicate type.
+    def type_start?(consume_newlines = true)
+      old_pos, old_line, old_column = current_pos, @line_number, @column_number
+      @temp_token.copy_from(@token)
+
+      if consume_newlines
+        next_token_skip_space_or_newline
+      else
+        next_token_skip_space
+      end
+
+      while @token.type == :"(" || @token.type == :"{"
+        next_token_skip_space_or_newline
+      end
+
+      # TODO: the below conditions are not complete, and there are many false-positive or true-negative examples.
+      # For example, `[ [] of Int32, Foo::Bar.new ]` should be parsed to `[ ([] of Int32), Foo::Bar.new ]`,
+      # however, the current implementation mistakes `Foo::Bar` as type name, so parsing is failed.
+
+      begin
+        case @token.type
+        when :IDENT
+          case @token.value
+          when :typeof, :self, "self?"
+            true
+          else
+            false
+          end
+        when :CONST
+          next_token_skip_space
+          return true unless @token.type == :"."
+          next_token_skip_space_or_newline
+          @token.keyword?(:class)
+        when :"::"
+          next_token
+          @token.type == :CONST
+        when :UNDERSCORE, :"->"
+          true
+        else
+          false
+        end
+      ensure
+        @token.copy_from(@temp_token)
+        self.current_pos, @line_number, @column_number = old_pos, old_line, old_column
+      end
     end
 
     def parse_typeof
@@ -5040,90 +5083,6 @@ module Crystal
       next_token_skip_space
 
       TypeOf.new(exps).at(location).at_end(end_location)
-    end
-
-    def next_comes_type
-      next_comes_type_or_int allow_int: false
-    end
-
-    def next_comes_type_or_int(allow_int = true)
-      old_pos, old_line, old_column = current_pos, @line_number, @column_number
-
-      @temp_token.copy_from(@token)
-
-      next_token_skip_space_or_newline
-
-      while @token.type == :"{" || @token.type == :"("
-        next_token_skip_space_or_newline
-      end
-
-      begin
-        case @token.type
-        when :CONST
-          next_token_skip_space
-          if @token.type == :"."
-            next_token_skip_space
-            @token.keyword?(:class)
-          else
-            true
-          end
-        when :UNDERSCORE
-          true
-        when :"->"
-          true
-        when :"*"
-          next_token
-          @token.type == :CONST
-        when :NUMBER
-          allow_int && @token.number_kind == :i32
-        when :IDENT
-          case @token.value
-          when :typeof, :self, :sizeof, :instance_sizeof, :offsetof
-            true
-          else
-            false
-          end
-        when :"::"
-          next_token_skip_space
-          @token.type == :CONST
-        else
-          false
-        end
-      ensure
-        @token.copy_from(@temp_token)
-        self.current_pos, @line_number, @column_number = old_pos, old_line, old_column
-      end
-    end
-
-    def next_comes_curly
-      old_pos, old_line, old_column = current_pos, @line_number, @column_number
-
-      @temp_token.copy_from(@token)
-
-      next_token_skip_space_or_newline
-
-      curly = @token.type == :"{"
-
-      @token.copy_from(@temp_token)
-      self.current_pos, @line_number, @column_number = old_pos, old_line, old_column
-
-      curly
-    end
-
-    def make_pointer_type(node)
-      Generic.new(Path.global("Pointer").at(node), [node] of ASTNode).at(node)
-    end
-
-    def make_static_array_type(type, size)
-      Generic.new(Path.global("StaticArray").at(type), [type, size] of ASTNode).at(type.location).at(type)
-    end
-
-    def make_tuple_type(types)
-      Generic.new(Path.global("Tuple"), types)
-    end
-
-    def make_named_tuple_type(named_args)
-      Generic.new(Path.global("NamedTuple"), [] of ASTNode, named_args: named_args)
     end
 
     def parse_visibility_modifier(modifier)
@@ -5380,7 +5339,7 @@ module Crystal
           unexpected_token
         end
       when :CONST
-        ident = parse_ident
+        ident = parse_path(global: false, location: @token.location)
         skip_space
         check :"="
         next_token_skip_space_or_newline
@@ -5399,7 +5358,7 @@ module Crystal
         end
         check :":"
         next_token_skip_space_or_newline
-        type = parse_single_type
+        type = parse_bare_proc_type
 
         if name[0].ascii_uppercase?
           raise "external variables must start with lowercase, use for example `$#{name.underscore} = #{name} : #{type}`", location
@@ -5471,17 +5430,15 @@ module Crystal
             next_token_skip_space_or_newline
             check :":"
             next_token_skip_space_or_newline
-            arg_type = parse_single_type
+            arg_type = parse_bare_proc_type
             skip_space_or_newline
 
             args << Arg.new(arg_name, nil, arg_type).at(arg_location)
 
             push_var_name arg_name if require_body
           else
-            arg_types = parse_types
-            arg_types.each do |arg_type_2|
-              args << Arg.new("", nil, arg_type_2).at(arg_type_2.location)
-            end
+            arg_type = parse_union_type
+            args << Arg.new("", nil, arg_type).at(arg_type.location)
           end
 
           if @token.type == :","
@@ -5497,7 +5454,7 @@ module Crystal
 
       if @token.type == :":"
         next_token_skip_space_or_newline
-        return_type = parse_single_type
+        return_type = parse_bare_proc_type
       end
 
       skip_statement_end
@@ -5538,7 +5495,7 @@ module Crystal
       check :"="
       next_token_skip_space_or_newline
 
-      value = parse_single_type
+      value = parse_bare_proc_type
       skip_space
 
       alias_node = Alias.new(name, value)
@@ -5581,7 +5538,7 @@ module Crystal
       next_token_skip_space_or_newline
 
       location = @token.location
-      exp = parse_single_type.at(location)
+      exp = parse_bare_proc_type.at(location)
 
       skip_space_or_newline
 
@@ -5598,7 +5555,7 @@ module Crystal
 
       next_token_skip_space_or_newline
       type_location = @token.location
-      type = parse_single_type.at(type_location)
+      type = parse_bare_proc_type.at(type_location)
 
       skip_space
       check :","
@@ -5626,7 +5583,7 @@ module Crystal
       check :"="
       next_token_skip_space_or_newline
 
-      type = parse_single_type
+      type = parse_bare_proc_type
       skip_space
 
       typedef = TypeDef.new name, type
@@ -5701,7 +5658,7 @@ module Crystal
       check :":"
       next_token_skip_space_or_newline
 
-      type = parse_single_type
+      type = parse_bare_proc_type
 
       skip_statement_end
 
@@ -5722,7 +5679,7 @@ module Crystal
       case @token.type
       when :":"
         next_token_skip_space_or_newline
-        base_type = parse_single_type
+        base_type = parse_bare_proc_type
         skip_statement_end
       when :";", :NEWLINE
         skip_statement_end

--- a/src/compiler/crystal/syntax/parser.cr
+++ b/src/compiler/crystal/syntax/parser.cr
@@ -4657,7 +4657,7 @@ module Crystal
     end
 
     # Parse a **bare** proc type like `A, B, C -> D`.
-    # Generally it is entyr point of type parsing and
+    # Generally it is entry point of type parsing and
     # it is used on the context expected type (e.g. type restrictions, rhs of `alias` and more)
     def parse_bare_proc_type
       type = parse_type_splat { parse_union_type }

--- a/src/compiler/crystal/tools/formatter.cr
+++ b/src/compiler/crystal/tools/formatter.cr
@@ -1111,7 +1111,14 @@ module Crystal
       end
 
       if node.question?
+        if @token.type == :IDENT && @token.value == "self?" && node.type_vars.first.is_a?(Self)
+          write "self?"
+          next_token
+          return false
+        end
+
         node.type_vars[0].accept self
+        skip_space
         write_token :"?"
         return false
       end
@@ -1232,20 +1239,12 @@ module Crystal
       # Restore the old parentheses count
       @paren_count = old_paren_count
 
-      check_close_paren
-
       false
+    ensure
+      check_close_paren
     end
 
     def visit(node : Union)
-      if @token.type == :IDENT && @token.value == "self?" && node.types.size == 2 &&
-         node.types.any?(&.is_a?(Self)) &&
-         node.types.any? { |t| t.to_s == "::Nil" }
-        write "self?"
-        next_token
-        return false
-      end
-
       check_open_paren
 
       paren_count = @paren_count
@@ -2339,7 +2338,9 @@ module Crystal
     end
 
     def visit(node : Self)
+      check_open_paren
       write_keyword :self
+      check_close_paren
       false
     end
 

--- a/src/compiler/crystal/tools/formatter.cr
+++ b/src/compiler/crystal/tools/formatter.cr
@@ -1247,6 +1247,14 @@ module Crystal
     def visit(node : Union)
       check_open_paren
 
+      if @token.type == :IDENT && @token.value == "self?" && node.types.size == 2 &&
+         node.types[0].is_a?(Self) && node.types[1].to_s == "::Nil"
+        write "self?"
+        next_token
+        check_close_paren
+        return false
+      end
+
       paren_count = @paren_count
       column = @column
 

--- a/src/compiler/crystal/tools/formatter.cr
+++ b/src/compiler/crystal/tools/formatter.cr
@@ -1111,12 +1111,6 @@ module Crystal
       end
 
       if node.question?
-        if @token.type == :IDENT && @token.value == "self?" && node.type_vars.first.is_a?(Self)
-          write "self?"
-          next_token
-          return false
-        end
-
         node.type_vars[0].accept self
         skip_space
         write_token :"?"


### PR DESCRIPTION
## Problem

For some reasons, the parser for types and generic type path literals is known as one of the most complex part of the parser. (Another one is `do ... end` block parsing.)

- **too much sharing**: the parser for a single type, type arguments, proc type arguments, tuple element types and others are unified to just one method. This code-sharing is excessive. They are not share syntax really, so there are many conditions and branches, thus it is hard to follow code flow.
- **historical naming**: a type path (or part ot this) is called as `ident` for historical reason. However `ident` means different today.

As the above reasons, gazillion bugs live in there unfortunately. For instance, they are valid type restriction for now:

  - `*Foo` (orphan splat)
  - `(Foo, Bar) | Baz` (comma + union type)
  - `{(Foo, Bar), Baz}` (comma + tuple type)

So, refining type grammar and rewriting type parser is necessary.

## Type Grammar

The following is complete type grammar which is supported by this PR.

```
bare-proc-type := union-type ("," union-type)* proc-type-output?

union-type := atomic-type-with-suffix ("|" atomic-type-with-suffix)*

atomic-type-with-suffix := atomic-type type-suffix*

atomic-type := "_"                                                            # underscore type
             / "self"                                                         # self type
             / "self?"                                                        # nilable self type
             / typeof                                                         # typeof type
             / generic                                                        # generic type
             / "{" union-type ("," union-type)* ","? "}"                      # tuple type
             / "{" named-type-list "}"                                        # named tuple type
             / proc-type-output                                               # proc type without input types
             / "(" (union-type ("," union-type)* ","?)? ")" proc-type-output  # proc type
             / "(" bare-proc-type ")"

proc-type-output := "->" union-type?

generic := path type-args?

path := "::"? CONST ("::" CONST)*

type-args := "(" "*"? type-arg ("," "*"? type-arg)* ","? ")"
           / "(" bare-proc-type ")"
           / "(" named-type-args ")"

named-type-args := key ":" bare-proc-type ("," key ":" bare-proc-type)* ","?

type-arg := NUMBER / sizeof / instance-sizeof / offsetof / union-type

type-suffix := "." "class"       # class type
             / "*"               # pointer type
             / "**"              # double-pointer type
             / "?"               # nilable type
             / "[" type-arg "]"  # static array type

typeof := ...
sizeof := ...
instance-sizeof := ...
offsetof := ...
```

I think this grammar behaves as we expect.
(Repeatedly the type parser is broken, so we cannot know the current right grammar. I tried to observe the parser behavior and reject unexpected ones.)

At least, modifying stdlib and all specs for this grammar compatibility was not needed.

## Fixes

Rewriting type parser is done in this PR, then some bugs are fixed.

### Reject orphan splat

Now, splat (`*`) can appear only in type arguments (proc input type arguments also).

The following example is syntax error by this PR:

```crystal
def foo(x : *Int32)
end
```

### Disable auto-flatting comma list

Currently `{(Foo, Bar), Baz}` is parsed to `{Foo, Bar, Baz}`. However no one wants this behavior. In addition `(Foo, Bar) | Baz` is valid for near reason. They should be disabled.

The following example is syntax error by this PR:

```crystal
def foo(x : {(Int32, Int32), Int32}, y : (Int32, Int32) | Int32)
end
```

And, some minor bugs are fixed:

  - Format `(self)?` restriction correctly.
  - ~~Unify parsed AST for `self?` and `A?`. (Current compiler generates `self | ::Nil` and `::Union(A, ::Nil)`. I think the latter is correct AST because `Generic` has `question` flag to represent nilable type.)~~

/cc @asterite 