### PR TITLE
Compiler: add implicit block arguments (_1, _2, etc.)

### DIFF
--- a/spec/compiler/formatter/formatter_spec.cr
+++ b/spec/compiler/formatter/formatter_spec.cr
@@ -1650,4 +1650,7 @@ describe Crystal::Formatter do
     1 # foo
     / #{1} /
     CODE
+
+  assert_format "_1"
+  assert_format "_42"
 end

--- a/spec/compiler/lexer/lexer_spec.cr
+++ b/spec/compiler/lexer/lexer_spec.cr
@@ -136,6 +136,15 @@ private def it_lexes_global_match_data_index(globals)
   end
 end
 
+private def it_lexes_implicit_block_argument(code, number)
+  it "lexes #{code}" do
+    lexer = Lexer.new code
+    token = lexer.next_token
+    token.type.should eq(:IMPLICIT_BLOCK_ARGUMENT)
+    token.value.should eq(number)
+  end
+end
+
 describe "Lexer" do
   it_lexes "", :EOF
   it_lexes " ", :SPACE
@@ -274,6 +283,10 @@ describe "Lexer" do
 
   it_lexes "$~", :"$~"
   it_lexes "$?", :"$?"
+
+  it_lexes_implicit_block_argument "_1", 1
+  it_lexes_implicit_block_argument "_2", 2
+  it_lexes_implicit_block_argument "_42", 42
 
   assert_syntax_error "128_i8", "128 doesn't fit in an Int8"
   assert_syntax_error "-129_i8", "-129 doesn't fit in an Int8"

--- a/spec/compiler/parser/parser_spec.cr
+++ b/spec/compiler/parser/parser_spec.cr
@@ -398,6 +398,11 @@ module Crystal
     it_parses "foo &.as?(T).bar", Call.new(nil, "foo", block: Block.new([Var.new("__arg0")], Call.new(NilableCast.new(Var.new("__arg0"), "T".path), "bar")))
     it_parses "foo(\n  &.block\n)", Call.new(nil, "foo", block: Block.new([Var.new("__arg0")], Call.new(Var.new("__arg0"), "block")))
 
+    it_parses "_1", ImplicitBlockArgument.new(1)
+    it_parses "_42", ImplicitBlockArgument.new(42)
+
+    it_parses "foo _1", Call.new(nil, "foo", [ImplicitBlockArgument.new(1)] of ASTNode)
+
     it_parses "foo.[0]", Call.new("foo".call, "[]", 0.int32)
     it_parses "foo.[0] = 1", Call.new("foo".call, "[]=", [0.int32, 1.int32] of ASTNode)
 

--- a/spec/compiler/semantic/implicit_block_argument_spec.cr
+++ b/spec/compiler/semantic/implicit_block_argument_spec.cr
@@ -1,0 +1,71 @@
+require "../../spec_helper"
+
+describe "Semantic: implicit block argument" do
+  it "errors if implicit block argument outside of block" do
+    assert_error %(
+      _1
+      ),
+      "implcit block argument can only be used inside a block"
+  end
+
+  it "uses implicit block argument" do
+    assert_type(%(
+      def foo
+        yield 1, 'a', true
+      end
+
+      foo do
+        {_1, _2, _3}
+      end
+    )) { tuple_of [int32, char, bool] }
+  end
+
+  it "errors if uses implicit argument where positional argument already exists" do
+    assert_error %(
+        def foo
+          yield 1
+        end
+
+        foo do |x|
+          _1
+        end
+      ),
+      "an explicit block argument at position 1 already exists"
+  end
+
+  it "uses implicit block argument with macro" do
+    assert_type(%(
+      macro moo(x)
+        {{x}}
+      end
+
+      def foo
+        yield 1
+      end
+
+      def bar
+        foo do
+          moo(_1)
+        end
+      end
+
+      bar
+    )) { int32 }
+  end
+
+  it "uses implicit block argument with macro (top level)" do
+    assert_type(%(
+      macro moo(x)
+        {{x}}
+      end
+
+      def foo
+        yield 1
+      end
+
+      foo do
+        moo(_1)
+      end
+    )) { int32 }
+  end
+end

--- a/src/compiler/crystal/semantic/implicit_block_argument.cr
+++ b/src/compiler/crystal/semantic/implicit_block_argument.cr
@@ -1,0 +1,76 @@
+module Crystal
+  class ImplicitBlockArgumentDetector < Visitor
+    def self.has_implicit_block_arguments?(block : Block)
+      detector = new
+      block.body.accept(detector)
+      detector.has_implicit_block_arguments?
+    end
+
+    getter? has_implicit_block_arguments = false
+
+    def visit(node : ImplicitBlockArgument)
+      @has_implicit_block_arguments = true
+    end
+
+    def visit(node : ExpandableNode | Call)
+      if expanded = node.expanded
+        expanded.accept(self)
+        false
+      else
+        true
+      end
+    end
+
+    def visit(node : Block)
+      false
+    end
+
+    def visit(node : ASTNode)
+      !@has_implicit_block_arguments
+    end
+  end
+
+  class ImplicitBlockArgumentTransformer < Transformer
+    def self.transform(program : Program, block : Block)
+      transformer = new(program, block)
+      block.body = block.body.transform(transformer)
+    end
+
+    @initial_block_args_size : Int32
+
+    def initialize(@program : Program, @block : Block)
+      @initial_block_args_size = @block.args.try(&.size) || 0
+    end
+
+    def transform(node : ExpandableNode | Call)
+      expanded = node.expanded
+      if expanded
+        node.expanded = expanded.transform(self)
+        node
+      else
+        super
+      end
+    end
+
+    def transform(node : Block)
+      # Don't go inside nested blocks
+      node
+    end
+
+    def transform(node : ImplicitBlockArgument)
+      number = node.number
+
+      if @initial_block_args_size >= number
+        node.raise "an explicit block argument at position #{number} already exists"
+      end
+
+      args = @block.args ||= [] of Var
+
+      (number - args.size).times do |i|
+        args << @program.new_temp_var
+      end
+
+      args[number - 1].clone.at(node)
+    end
+  end
+end

--- a/src/compiler/crystal/syntax/ast.cr
+++ b/src/compiler/crystal/syntax/ast.cr
@@ -526,6 +526,19 @@ module Crystal
     def_equals_and_hash args, body, splat_index
   end
 
+  class ImplicitBlockArgument < ASTNode
+    property number : Int32
+
+    def initialize(@number : Int32)
+    end
+
+    def clone_without_location
+      ImplicitBlockArgument.new(@number)
+    end
+
+    def_equals_and_hash number
+  end
+
   # A method call.
   #
   #     [ obj '.' ] name '(' ')' [ block ]

--- a/src/compiler/crystal/syntax/lexer.cr
+++ b/src/compiler/crystal/syntax/lexer.cr
@@ -1237,7 +1237,8 @@ module Crystal
         end
         scan_ident(start)
       when '_'
-        case next_char
+        char = next_char
+        case char
         when '_'
           case next_char
           when 'D'
@@ -1284,9 +1285,20 @@ module Crystal
             # scan_ident
           end
         else
-          unless ident_part?(current_char)
-            @token.type = :UNDERSCORE
+          if char.ascii_number?
+            number = 0
+            while char.ascii_number?
+              number = number * 10 + char.to_i
+              char = next_char
+            end
+            @token.type = :IMPLICIT_BLOCK_ARGUMENT
+            @token.value = number
             return @token
+          else
+            unless ident_part?(current_char)
+              @token.type = :UNDERSCORE
+              return @token
+            end
           end
         end
 

--- a/src/compiler/crystal/syntax/parser.cr
+++ b/src/compiler/crystal/syntax/parser.cr
@@ -993,6 +993,10 @@ module Crystal
         end
         location = @token.location
         node_and_next_token Call.new(Global.new("$~").at(location), method, NumberLiteral.new(value.to_i))
+      when :IMPLICIT_BLOCK_ARGUMENT
+        number = @token.value.as(Int32)
+        location = @token.location
+        node_and_next_token ImplicitBlockArgument.new(number).at(location)
       when :__LINE__
         node_and_next_token MagicConstant.expand_line_node(@token.location)
       when :__END_LINE__
@@ -4365,7 +4369,13 @@ module Crystal
         end
       when :"{"
         return nil unless allow_curly
-      when :CHAR, :STRING, :DELIMITER_START, :STRING_ARRAY_START, :SYMBOL_ARRAY_START, :NUMBER, :IDENT, :SYMBOL, :INSTANCE_VAR, :CLASS_VAR, :CONST, :GLOBAL, :"$~", :"$?", :GLOBAL_MATCH_DATA_INDEX, :REGEX, :"(", :"!", :"[", :"[]", :"~", :"->", :"{{", :__LINE__, :__END_LINE__, :__FILE__, :__DIR__, :UNDERSCORE
+      when :CHAR, :STRING, :DELIMITER_START, :STRING_ARRAY_START,
+           :SYMBOL_ARRAY_START, :NUMBER, :IDENT, :SYMBOL, :INSTANCE_VAR,
+           :CLASS_VAR, :CONST, :GLOBAL, :"$~", :"$?",
+           :GLOBAL_MATCH_DATA_INDEX, :REGEX,
+           :"(", :"!", :"[", :"[]", :"~", :"->", :"{{",
+           :__LINE__, :__END_LINE__, :__FILE__, :__DIR__,
+           :UNDERSCORE, :IMPLICIT_BLOCK_ARGUMENT
         # Nothing
       when :"*", :"**"
         if current_char.ascii_whitespace?

--- a/src/compiler/crystal/syntax/to_s.cr
+++ b/src/compiler/crystal/syntax/to_s.cr
@@ -1085,6 +1085,12 @@ module Crystal
       false
     end
 
+    def visit(node : ImplicitBlockArgument)
+      @str << '_' << node.number
+
+      false
+    end
+
     def visit(node : Include)
       @str << keyword("include")
       @str << ' '

--- a/src/compiler/crystal/syntax/token.cr
+++ b/src/compiler/crystal/syntax/token.cr
@@ -3,7 +3,7 @@ require "./location"
 module Crystal
   class Token
     property type : Symbol
-    property value : Char | String | Symbol | Nil
+    property value : Char | String | Symbol | Int32 | Nil
     property number_kind : Symbol
     property line_number : Int32
     property column_number : Int32

--- a/src/compiler/crystal/syntax/transformer.cr
+++ b/src/compiler/crystal/syntax/transformer.cr
@@ -331,6 +331,10 @@ module Crystal
       node
     end
 
+    def transform(node : ImplicitBlockArgument)
+      node
+    end
+
     def transform(node : ProcLiteral)
       node.def.body = node.def.body.transform(self)
       node

--- a/src/compiler/crystal/tools/formatter.cr
+++ b/src/compiler/crystal/tools/formatter.cr
@@ -4136,6 +4136,15 @@ module Crystal
       false
     end
 
+    def visit(node : ImplicitBlockArgument)
+      write "_"
+      write node.number
+
+      next_token
+
+      false
+    end
+
     def visit(node : Block)
       # Handled in format_block
       return false


### PR DESCRIPTION
**Note**: this PR exists because I wanted to see how hard was it to implement it. It's not decided yet whether this is something that we want... but I enjoy coding these things :-) . Also with this people can try it out themselves.

This is exactly like in Ruby. I chose `_1`, `_2`, etc. instead of `&1`, `&2`, etc. because `&` means the start of a block or a block arguments:

```crystal
foo &.bar
foo &block_argument
```

so it would be a bit confusing to reuse `&` to also mean "block argument":

```crystal
foo { bar &1 } # is &1 a block given to bar?
```

I also think `_1` is visually less noisy than `&1`. And maybe `_1` is a bit easier to type (no need to move the right hand to the middle of the keyboard).

Finally, it's the same as in Ruby so Rubyists will feel familiar with this syntax.

## Examples

```crystal
[1, 2, 3].each { puts _1 }
# Output:
# 1
# 2
# 3

files = ["foo.cr", "bar.cr"]
files.map { File.exists?(_1) }

# same as:
files.map { |file| File.exists?(file) }

%w(World Computer).each { puts "Hello #{_1}!" }
# Output:
# Hello World
# Hello Computer

Hash(String, Array(Int32)).new { _1[_2] = [0] }

# same as:
Hash(String, Array(Int32)).new { |h, k| h[k] = [0] }
```

## Do I like it?

I think for cases like the `File.exists?` above where it's obvious that each block argument will be a file, and the block is pretty small, that it actually improves readability.

Also with `try` when you need to do something other than invoke a method on the yielded object:

```crystal
file = # a nilable string
file.try { File.exists?(_1) }

# instead of:
file.try { |file| File.exists?(file) } # So many files! So confusing!

# or:
file.try { |the_file| File.exists?(the_file) }
```

Note how the two latter ways of writing it introduce a lot of noise (the block syntax, the variable name). The first way is pretty "zen" in my mind.

I also think it finishes generalizing the block syntax. Right now we have the explicit block syntax:

```crystal
[1, 2, 3].map { |x| x.to_s }
```

We have the `&.` shorthand for when you want to invoke a method on the first and only block argument:

```crystal
[1, 2, 3].map &.to_s
```

But no syntax exists for the general case when you want to do something with the block arguments without needing to explicitly mention them. Other languages have `it` (Kotlin, just for the first argument), Ruby now has `_1` and `_2`, and Elixir has the general `&(exp(&1, &2))` expansion syntax.

## Breaking change

This is a tiny breaking change because if you had a variable named `_1`, well, now it's no longer a variable. But I think those cases shouldn't exist... I hope! And fixing those occurrences is easy.