### PR TITLE
Drop `skip_abstract_def_check` flag support

### DIFF
--- a/src/compiler/crystal/semantic.cr
+++ b/src/compiler/crystal/semantic.cr
@@ -70,12 +70,8 @@ class Crystal::Program
       TypeDeclarationProcessor.new(self).process(node)
     end
 
-    # TODO: remove this check a couple of versions after 0.30.0 once
-    # we are sure it's working fine for everyone
-    unless has_flag?("skip_abstract_def_check")
-      @progress_tracker.stage("Semantic (abstract def check)") do
-        AbstractDefChecker.new(self).run
-      end
+    @progress_tracker.stage("Semantic (abstract def check)") do
+      AbstractDefChecker.new(self).run
     end
 
     {node, processor}


### PR DESCRIPTION
Nine months have passed since 0.30.0 was released. It's about time to drop it.