### PR TITLE
Compiler: add short block syntax &(..., &1)

### DIFF
--- a/spec/compiler/formatter/formatter_spec.cr
+++ b/spec/compiler/formatter/formatter_spec.cr
@@ -1651,6 +1651,6 @@ describe Crystal::Formatter do
     / #{1} /
     CODE
 
-  assert_format "_1"
-  assert_format "_42"
+  assert_format "&1"
+  assert_format "&42"
 end

--- a/spec/compiler/formatter/formatter_spec.cr
+++ b/spec/compiler/formatter/formatter_spec.cr
@@ -1650,4 +1650,7 @@ describe Crystal::Formatter do
     1 # foo
     / #{1} /
     CODE
+
+  assert_format "_1"
+  assert_format "_42"
 end

--- a/spec/compiler/lexer/lexer_spec.cr
+++ b/spec/compiler/lexer/lexer_spec.cr
@@ -136,6 +136,15 @@ private def it_lexes_global_match_data_index(globals)
   end
 end
 
+private def it_lexes_implicit_block_argument(code, number)
+  it "lexes #{code}" do
+    lexer = Lexer.new code
+    token = lexer.next_token
+    token.type.should eq(:IMPLICIT_BLOCK_ARGUMENT)
+    token.value.should eq(number)
+  end
+end
+
 describe "Lexer" do
   it_lexes "", :EOF
   it_lexes " ", :SPACE
@@ -274,6 +283,10 @@ describe "Lexer" do
 
   it_lexes "$~", :"$~"
   it_lexes "$?", :"$?"
+
+  it_lexes_implicit_block_argument "_1", 1
+  it_lexes_implicit_block_argument "_2", 2
+  it_lexes_implicit_block_argument "_42", 42
 
   assert_syntax_error "128_i8", "128 doesn't fit in an Int8"
   assert_syntax_error "-129_i8", "-129 doesn't fit in an Int8"

--- a/spec/compiler/lexer/lexer_spec.cr
+++ b/spec/compiler/lexer/lexer_spec.cr
@@ -284,9 +284,9 @@ describe "Lexer" do
   it_lexes "$~", :"$~"
   it_lexes "$?", :"$?"
 
-  it_lexes_implicit_block_argument "_1", 1
-  it_lexes_implicit_block_argument "_2", 2
-  it_lexes_implicit_block_argument "_42", 42
+  it_lexes_implicit_block_argument "&1", 1
+  it_lexes_implicit_block_argument "&2", 2
+  it_lexes_implicit_block_argument "&42", 42
 
   assert_syntax_error "128_i8", "128 doesn't fit in an Int8"
   assert_syntax_error "-129_i8", "-129 doesn't fit in an Int8"

--- a/spec/compiler/parser/parser_spec.cr
+++ b/spec/compiler/parser/parser_spec.cr
@@ -398,10 +398,10 @@ module Crystal
     it_parses "foo &.as?(T).bar", Call.new(nil, "foo", block: Block.new([Var.new("__arg0")], Call.new(NilableCast.new(Var.new("__arg0"), "T".path), "bar")))
     it_parses "foo(\n  &.block\n)", Call.new(nil, "foo", block: Block.new([Var.new("__arg0")], Call.new(Var.new("__arg0"), "block")))
 
-    it_parses "_1", ImplicitBlockArgument.new(1)
-    it_parses "_42", ImplicitBlockArgument.new(42)
+    it_parses "&1", ImplicitBlockArgument.new(1)
+    it_parses "&42", ImplicitBlockArgument.new(42)
 
-    it_parses "foo _1", Call.new(nil, "foo", [ImplicitBlockArgument.new(1)] of ASTNode)
+    it_parses "foo &1", Call.new(nil, "foo", [ImplicitBlockArgument.new(1)] of ASTNode)
 
     it_parses "foo.[0]", Call.new("foo".call, "[]", 0.int32)
     it_parses "foo.[0] = 1", Call.new("foo".call, "[]=", [0.int32, 1.int32] of ASTNode)

--- a/spec/compiler/parser/parser_spec.cr
+++ b/spec/compiler/parser/parser_spec.cr
@@ -398,6 +398,11 @@ module Crystal
     it_parses "foo &.as?(T).bar", Call.new(nil, "foo", block: Block.new([Var.new("__arg0")], Call.new(NilableCast.new(Var.new("__arg0"), "T".path), "bar")))
     it_parses "foo(\n  &.block\n)", Call.new(nil, "foo", block: Block.new([Var.new("__arg0")], Call.new(Var.new("__arg0"), "block")))
 
+    it_parses "_1", ImplicitBlockArgument.new(1)
+    it_parses "_42", ImplicitBlockArgument.new(42)
+
+    it_parses "foo _1", Call.new(nil, "foo", [ImplicitBlockArgument.new(1)] of ASTNode)
+
     it_parses "foo.[0]", Call.new("foo".call, "[]", 0.int32)
     it_parses "foo.[0] = 1", Call.new("foo".call, "[]=", [0.int32, 1.int32] of ASTNode)
 

--- a/spec/compiler/semantic/implicit_block_argument_spec.cr
+++ b/spec/compiler/semantic/implicit_block_argument_spec.cr
@@ -1,0 +1,71 @@
+require "../../spec_helper"
+
+describe "Semantic: implicit block argument" do
+  it "errors if implicit block argument outside of block" do
+    assert_error %(
+      _1
+      ),
+      "implcit block argument can only be used inside a block"
+  end
+
+  it "uses implicit block argument" do
+    assert_type(%(
+      def foo
+        yield 1, 'a', true
+      end
+
+      foo do
+        {_1, _2, _3}
+      end
+    )) { tuple_of [int32, char, bool] }
+  end
+
+  it "errors if uses implicit argument where positional argument already exists" do
+    assert_error %(
+        def foo
+          yield 1
+        end
+
+        foo do |x|
+          _1
+        end
+      ),
+      "an explicit block argument at position 1 already exists"
+  end
+
+  it "uses implicit block argument with macro" do
+    assert_type(%(
+      macro moo(x)
+        {{x}}
+      end
+
+      def foo
+        yield 1
+      end
+
+      def bar
+        foo do
+          moo(_1)
+        end
+      end
+
+      bar
+    )) { int32 }
+  end
+
+  it "uses implicit block argument with macro (top level)" do
+    assert_type(%(
+      macro moo(x)
+        {{x}}
+      end
+
+      def foo
+        yield 1
+      end
+
+      foo do
+        moo(_1)
+      end
+    )) { int32 }
+  end
+end

--- a/spec/compiler/semantic/implicit_block_argument_spec.cr
+++ b/spec/compiler/semantic/implicit_block_argument_spec.cr
@@ -3,69 +3,42 @@ require "../../spec_helper"
 describe "Semantic: implicit block argument" do
   it "errors if implicit block argument outside of block" do
     assert_error %(
-      _1
+      &1
       ),
       "implcit block argument can only be used inside a block"
   end
 
-  it "uses implicit block argument" do
+  it "uses implicit block argument with call" do
+    assert_type(%(
+      def foo
+        yield 1
+      end
+
+      def bar(x)
+        x
+      end
+
+      foo &bar(&1)
+    )) { int32 }
+  end
+
+  it "uses implicit block argument with parentheses" do
+    assert_type(%(
+      def foo
+        yield 1
+      end
+
+      foo &(&1 &+ 1)
+    )) { int32 }
+  end
+
+  it "uses implicit block argument with tuple syntax" do
     assert_type(%(
       def foo
         yield 1, 'a', true
       end
 
-      foo do
-        {_1, _2, _3}
-      end
+      foo &{&1, &2, &3}
     )) { tuple_of [int32, char, bool] }
-  end
-
-  it "errors if uses implicit argument where positional argument already exists" do
-    assert_error %(
-        def foo
-          yield 1
-        end
-
-        foo do |x|
-          _1
-        end
-      ),
-      "an explicit block argument at position 1 already exists"
-  end
-
-  it "uses implicit block argument with macro" do
-    assert_type(%(
-      macro moo(x)
-        {{x}}
-      end
-
-      def foo
-        yield 1
-      end
-
-      def bar
-        foo do
-          moo(_1)
-        end
-      end
-
-      bar
-    )) { int32 }
-  end
-
-  it "uses implicit block argument with macro (top level)" do
-    assert_type(%(
-      macro moo(x)
-        {{x}}
-      end
-
-      def foo
-        yield 1
-      end
-
-      foo do
-        moo(_1)
-      end
-    )) { int32 }
   end
 end

--- a/spec/compiler/semantic/implicit_block_argument_spec.cr
+++ b/spec/compiler/semantic/implicit_block_argument_spec.cr
@@ -41,4 +41,32 @@ describe "Semantic: implicit block argument" do
       foo &{&1, &2, &3}
     )) { tuple_of [int32, char, bool] }
   end
+
+  it "errors if 'it' variable outside of block (assign)" do
+    assert_error %(
+      it = 1
+      ),
+      "implcit block argument 'it' can only be used inside a block"
+  end
+
+  it "errors if 'it' argless call outside of block (assign)" do
+    assert_error %(
+      it
+      ),
+      "implcit block argument 'it' can only be used inside a block"
+  end
+
+  it "uses implicit block argument 'it' with call" do
+    assert_type(%(
+      def foo
+        yield 1
+      end
+
+      def bar(x)
+        x
+      end
+
+      foo &bar(it)
+    )) { int32 }
+  end
 end

--- a/spec/std/deque_spec.cr
+++ b/spec/std/deque_spec.cr
@@ -579,8 +579,8 @@ describe "Deque" do
     it "works while modifying deque" do
       a = Deque{1, 2, 3}
       count = 0
-      it = a.each
-      it.each do
+      iter = a.each
+      iter.each do
         count += 1
         a.clear
       end
@@ -601,7 +601,7 @@ describe "Deque" do
     it "works while modifying deque" do
       a = Deque{1, 2, 3}
       count = 0
-      it = a.each_index
+      iter = a.each_index
       a.each_index.each do
         count += 1
         a.clear

--- a/src/compiler/crystal/semantic/implicit_block_argument.cr
+++ b/src/compiler/crystal/semantic/implicit_block_argument.cr
@@ -1,0 +1,76 @@
+module Crystal
+  class ImplicitBlockArgumentDetector < Visitor
+    def self.has_implicit_block_arguments?(block : Block)
+      detector = new
+      block.body.accept(detector)
+      detector.has_implicit_block_arguments?
+    end
+
+    getter? has_implicit_block_arguments = false
+
+    def visit(node : ImplicitBlockArgument)
+      @has_implicit_block_arguments = true
+    end
+
+    def visit(node : ExpandableNode | Call)
+      if expanded = node.expanded
+        expanded.accept(self)
+        false
+      else
+        true
+      end
+    end
+
+    def visit(node : Block)
+      false
+    end
+
+    def visit(node : ASTNode)
+      !@has_implicit_block_arguments
+    end
+  end
+
+  class ImplicitBlockArgumentTransformer < Transformer
+    def self.transform(program : Program, block : Block)
+      transformer = new(program, block)
+      block.body = block.body.transform(transformer)
+    end
+
+    @initial_block_args_size : Int32
+
+    def initialize(@program : Program, @block : Block)
+      @initial_block_args_size = @block.args.try(&.size) || 0
+    end
+
+    def transform(node : ExpandableNode | Call)
+      expanded = node.expanded
+      if expanded
+        node.expanded = expanded.transform(self)
+        node
+      else
+        super
+      end
+    end
+
+    def transform(node : Block)
+      # Don't go inside nested blocks
+      node
+    end
+
+    def transform(node : ImplicitBlockArgument)
+      number = node.number
+
+      if @initial_block_args_size >= number
+        node.raise "an explicit block argument at position #{number} already exists"
+      end
+
+      args = @block.args ||= [] of Var
+
+      (number - args.size).times do |i|
+        args << @program.new_temp_var
+      end
+
+      args[number - 1].clone.at(node)
+    end
+  end
+end

--- a/src/compiler/crystal/semantic/main_visitor.cr
+++ b/src/compiler/crystal/semantic/main_visitor.cr
@@ -753,6 +753,10 @@ module Crystal
     end
 
     def type_assign(target : Var, value, node, restriction = nil)
+      if target.name == "it"
+        node.raise "implcit block argument 'it' can only be used inside a block"
+      end
+
       value.accept self
 
       var_name = target.name
@@ -1291,6 +1295,10 @@ module Crystal
     end
 
     def visit(node : Call)
+      if node.args.empty? && !node.named_args && !node.block && !node.block_arg && node.name == "it"
+        node.raise "implcit block argument 'it' can only be used inside a block"
+      end
+
       prepare_call(node)
 
       if expand_macro(node)

--- a/src/compiler/crystal/syntax/ast.cr
+++ b/src/compiler/crystal/syntax/ast.cr
@@ -526,6 +526,19 @@ module Crystal
     def_equals_and_hash args, body, splat_index
   end
 
+  class ImplicitBlockArgument < ASTNode
+    property number : Int32
+
+    def initialize(@number : Int32)
+    end
+
+    def clone_without_location
+      ImplicitBlockArgument.new(@number)
+    end
+
+    def_equals_and_hash number
+  end
+
   # A method call.
   #
   #     [ obj '.' ] name '(' ')' [ block ]

--- a/src/compiler/crystal/syntax/lexer.cr
+++ b/src/compiler/crystal/syntax/lexer.cr
@@ -1237,7 +1237,8 @@ module Crystal
         end
         scan_ident(start)
       when '_'
-        case next_char
+        char = next_char
+        case char
         when '_'
           case next_char
           when 'D'
@@ -1284,9 +1285,20 @@ module Crystal
             # scan_ident
           end
         else
-          unless ident_part?(current_char)
-            @token.type = :UNDERSCORE
+          if char.ascii_number?
+            number = 0
+            while char.ascii_number?
+              number = number * 10 + char.to_i
+              char = next_char
+            end
+            @token.type = :IMPLICIT_BLOCK_ARGUMENT
+            @token.value = number
             return @token
+          else
+            unless ident_part?(current_char)
+              @token.type = :UNDERSCORE
+              return @token
+            end
           end
         end
 

--- a/src/compiler/crystal/syntax/lexer.cr
+++ b/src/compiler/crystal/syntax/lexer.cr
@@ -648,7 +648,8 @@ module Crystal
           @token.type = :"."
         end
       when '&'
-        case next_char
+        char = next_char
+        case char
         when '&'
           case next_char
           when '='
@@ -689,7 +690,18 @@ module Crystal
             @token.type = :"&*"
           end
         else
-          @token.type = :"&"
+          if char.ascii_number?
+            number = 0
+            while char.ascii_number?
+              number = number * 10 + char.to_i
+              char = next_char
+            end
+            @token.type = :IMPLICIT_BLOCK_ARGUMENT
+            @token.value = number
+            return @token
+          else
+            @token.type = :"&"
+          end
         end
       when '|'
         case next_char
@@ -1285,20 +1297,9 @@ module Crystal
             # scan_ident
           end
         else
-          if char.ascii_number?
-            number = 0
-            while char.ascii_number?
-              number = number * 10 + char.to_i
-              char = next_char
-            end
-            @token.type = :IMPLICIT_BLOCK_ARGUMENT
-            @token.value = number
+          unless ident_part?(current_char)
+            @token.type = :UNDERSCORE
             return @token
-          else
-            unless ident_part?(current_char)
-              @token.type = :UNDERSCORE
-              return @token
-            end
           end
         end
 

--- a/src/compiler/crystal/syntax/parser.cr
+++ b/src/compiler/crystal/syntax/parser.cr
@@ -993,6 +993,10 @@ module Crystal
         end
         location = @token.location
         node_and_next_token Call.new(Global.new("$~").at(location), method, NumberLiteral.new(value.to_i))
+      when :IMPLICIT_BLOCK_ARGUMENT
+        number = @token.value.as(Int32)
+        location = @token.location
+        node_and_next_token ImplicitBlockArgument.new(number).at(location)
       when :__LINE__
         node_and_next_token MagicConstant.expand_line_node(@token.location)
       when :__END_LINE__
@@ -4365,7 +4369,13 @@ module Crystal
         end
       when :"{"
         return nil unless allow_curly
-      when :CHAR, :STRING, :DELIMITER_START, :STRING_ARRAY_START, :SYMBOL_ARRAY_START, :NUMBER, :IDENT, :SYMBOL, :INSTANCE_VAR, :CLASS_VAR, :CONST, :GLOBAL, :"$~", :"$?", :GLOBAL_MATCH_DATA_INDEX, :REGEX, :"(", :"!", :"[", :"[]", :"~", :"->", :"{{", :__LINE__, :__END_LINE__, :__FILE__, :__DIR__, :UNDERSCORE
+      when :CHAR, :STRING, :DELIMITER_START, :STRING_ARRAY_START,
+           :SYMBOL_ARRAY_START, :NUMBER, :IDENT, :SYMBOL, :INSTANCE_VAR,
+           :CLASS_VAR, :CONST, :GLOBAL, :"$~", :"$?",
+           :GLOBAL_MATCH_DATA_INDEX, :REGEX,
+           :"(", :"!", :"[", :"[]", :"~", :"->", :"{{",
+           :__LINE__, :__END_LINE__, :__FILE__, :__DIR__,
+           :UNDERSCORE, :IMPLICIT_BLOCK_ARGUMENT
         # Nothing
       when :"*", :"**"
         if current_char.ascii_whitespace?

--- a/src/compiler/crystal/syntax/to_s.cr
+++ b/src/compiler/crystal/syntax/to_s.cr
@@ -1085,6 +1085,12 @@ module Crystal
       false
     end
 
+    def visit(node : ImplicitBlockArgument)
+      @str << '_' << node.number
+
+      false
+    end
+
     def visit(node : Include)
       @str << keyword("include")
       @str << ' '

--- a/src/compiler/crystal/syntax/to_s.cr
+++ b/src/compiler/crystal/syntax/to_s.cr
@@ -1086,7 +1086,7 @@ module Crystal
     end
 
     def visit(node : ImplicitBlockArgument)
-      @str << '_' << node.number
+      @str << '&' << node.number
 
       false
     end

--- a/src/compiler/crystal/syntax/token.cr
+++ b/src/compiler/crystal/syntax/token.cr
@@ -3,7 +3,7 @@ require "./location"
 module Crystal
   class Token
     property type : Symbol
-    property value : Char | String | Symbol | Nil
+    property value : Char | String | Symbol | Int32 | Nil
     property number_kind : Symbol
     property line_number : Int32
     property column_number : Int32

--- a/src/compiler/crystal/syntax/transformer.cr
+++ b/src/compiler/crystal/syntax/transformer.cr
@@ -331,6 +331,10 @@ module Crystal
       node
     end
 
+    def transform(node : ImplicitBlockArgument)
+      node
+    end
+
     def transform(node : ProcLiteral)
       node.def.body = node.def.body.transform(self)
       node

--- a/src/compiler/crystal/tools/formatter.cr
+++ b/src/compiler/crystal/tools/formatter.cr
@@ -4136,6 +4136,15 @@ module Crystal
       false
     end
 
+    def visit(node : ImplicitBlockArgument)
+      write "_"
+      write node.number
+
+      next_token
+
+      false
+    end
+
     def visit(node : Block)
       # Handled in format_block
       return false

--- a/src/compiler/crystal/tools/formatter.cr
+++ b/src/compiler/crystal/tools/formatter.cr
@@ -4137,7 +4137,7 @@ module Crystal
     end
 
     def visit(node : ImplicitBlockArgument)
-      write "_"
+      write "&"
       write node.number
 
       next_token


### PR DESCRIPTION
**Note:** Like before, I wanted to see how hard this was to implement. Nothing is decided yet.

Alternative to #9216

This PR lets you specify a block argument with references to block arguments. `&1` is the first block argument, `&2` is the second, and so on.

For example:

```crystal
[1, 2, 3].each &puts(&1)
```

The above is the same as:

```crystal
[1, 2, 3].each { |x| puts(x) }
```

You can use **any** expression after `&`. For example:

```crystal
[1, 2, 3].map &(&1 * 2) # => [2, 4, 6]
[1, 2, 3].map &{&1, &1 * 10} # => [{1, 10}, {2, 20}, {3, 30}]
[1, 2, 3].map &[&1] # => [[1], [2], [3]]

["foo.cr", "bar.cr"].map &File.exists?(&1)

["World", "Computer"].each &puts("OK #{&1}")
# Output:
# OK World
# OK Computer

record Point, x : Int32, y : Int32
[{1, 2}, {3, 4}].map &Point.new(&1, &2) # => [Point(@x=1, @y=2), Point(@x=3, @y=4)]
```

Since you can use **any** expression, this is valid too:

```crystal
# Not advised... if we really wanted we could disallow this
[1, 2, 3].each &begin
  puts &1
end
```

## Do I like it?

I think I like it better than #9216 because:
- `&1`, `&2`, etc. are clearly surrounded by `&...`
- unless you use `begin`, or if we disallow it, the things you can put inside are pretty limited, so the block will end up being short and understandable
- no need to write `do/end` nor `{ ... }` so it's actually shorter than the alternative:
    ```crystal
    ["foo.cr", "bar.cr"].map &File.exists?(&1)    # shorter, simpler
    ["foo.cr", "bar.cr"].map { File.exists?(&1) }
    ```


This is exactly the same in Elixir... except that in Elixir you can use `&(...)` in general to create functions, but in this PR you can only use it in a block argument.

## What happens with regular block arguments?

They still work! For example:

```crystal
proc = ->(x : Int32) { puts x }
[1, 2, 3].each &proc
```

The rule is that if there's `&1`, `&2`, etc. inside the block argument, then it gets expanded to a block. Otherwise it's just forwarded as a block argument. Because the type of the block argument needs to be a `Proc`, you will, in most if not all cases, get a compiler error if you try to misuse it. For example:

```crystal
p [1, 2, 3].map &puts("hello")
                 ^---
Error: expected a function type, not Nil
```

And we can improve the error above saying "If using the short block syntax, be sure to use one of &1, &2, etc." (this PR doesn't do that yet, but it's super easy to implement).

Another alternative is to restrict the block argument to:
- a variable
- a proc literal (like `&->File.exists?(String)`)
- anything else, but it must include `&1`, `&2`, etc, otherwise it's an error

That alternative is probably better because we can give better error messages.

## Implementation details

For #9216 the first idea that came to my mind for implementing it is:
- before analyzing a call's block, check if it has `&1`, `&2`, etc
- if so, add missing block arguments, etc.

This means that the compiler has to do this for **every block** out there. I'm sure there are more optimal ways to implement this: for example we could detect at parse time which blocks need expansions. But this requires a bit more tracking.

In this PR we need to do the same, but only for block arguments (`&...)`, not for every block. And usually block arguments are just a forwarded variable, or a more complex expression which, with this PR, it's very likely to include these `&1` thingies. So the implementation is much more performant.

## Final thoughts

I think this solves the missing use case of short block syntaxes where one would like to put the first argument in a position other than the caller. And it also generalizes it for any number of arguments. All of this being kept surrounded by `&` so the code becomes easier to understand.

/cc @waj 