### PR TITLE
Update contact section of CODE of CONDUCT

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -55,7 +55,7 @@ further defined and clarified by project maintainers.
 ## Enforcement
 
 Instances of abusive, harassing, or otherwise unacceptable behavior may be
-reported by contacting the project maintainers in private. All
+reported by contacting the project maintainers in private or by sending an email to [crystal@manas.tech](mailto:crystal@manas.tech). All
 complaints will be reviewed and investigated and will result in a response that
 is deemed necessary and appropriate to the circumstances. The project team is
 obligated to maintain confidentiality with regard to the reporter of an incident.

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -55,7 +55,7 @@ further defined and clarified by project maintainers.
 ## Enforcement
 
 Instances of abusive, harassing, or otherwise unacceptable behavior may be
-reported by opening an issue or contacting the project maintainers. All
+reported by contacting the project maintainers in private. All
 complaints will be reviewed and investigated and will result in a response that
 is deemed necessary and appropriate to the circumstances. The project team is
 obligated to maintain confidentiality with regard to the reporter of an incident.


### PR DESCRIPTION
In an effort to help enforce the code of conduct I did things the wrong way. According to this I should have opened an issue (instead I opened a discussion which I think is pretty much the same, both are public)

This remove the line about opening an issue and instead says to contact privately.

**I think for this to be really effective** there needs to be some kind of email (like `coc@crsytal-lang.org`) or *some* way of contacting. Right now I was expected to contact people privately, but did not know *who* to contact or how