### PR TITLE
Make IO#skip IO#write returns the number of bytes it skipped/written

### DIFF
--- a/spec/std/http/chunked_content_spec.cr
+++ b/spec/std/http/chunked_content_spec.cr
@@ -34,7 +34,7 @@ describe HTTP::ChunkedContent do
     mem = IO::Memory.new("4\r\n123\n\r\n0\r\n\r\n")
     content = HTTP::ChunkedContent.new(mem)
 
-    content.skip(2)
+    content.skip(2).should eq(2)
     content.read_char.should eq('3')
 
     expect_raises(IO::EOFError) do

--- a/spec/std/http/request_spec.cr
+++ b/spec/std/http/request_spec.cr
@@ -6,7 +6,8 @@ private class EmptyIO < IO
     0
   end
 
-  def write(slice : Bytes) : Nil
+  def write(slice : Bytes) : UInt64
+    slice.size.to_u64
   end
 end
 

--- a/spec/std/http/server/response_spec.cr
+++ b/spec/std/http/server/response_spec.cr
@@ -12,10 +12,11 @@ private class ReverseResponseOutput < IO
   def initialize(@output : IO)
   end
 
-  def write(slice : Bytes) : Nil
+  def write(slice : Bytes) : UInt64
     slice.reverse_each do |byte|
       @output.write_byte(byte)
     end
+    slice.size.to_u64
   end
 
   def read(slice : Bytes)

--- a/spec/std/io/buffered_spec.cr
+++ b/spec/std/io/buffered_spec.cr
@@ -429,14 +429,14 @@ describe "IO::Buffered" do
   it "skips" do
     str = IO::Memory.new("123456789")
     io = BufferedWrapper.new(str)
-    io.skip(3)
+    io.skip(3).should eq(3)
     io.read_char.should eq('4')
   end
 
   it "skips big" do
     str = IO::Memory.new(("a" * 10_000) + "b")
     io = BufferedWrapper.new(str)
-    io.skip(10_000)
+    io.skip(10_000).should eq(10_000)
     io.read_char.should eq('b')
   end
 

--- a/spec/std/io/io_spec.cr
+++ b/spec/std/io/io_spec.cr
@@ -46,7 +46,7 @@ private class SimpleIOMemory < IO
     count
   end
 
-  def write(slice : Bytes) : Nil
+  def write(slice : Bytes) : UInt64
     count = slice.size
     new_bytesize = bytesize + count
     if new_bytesize > @capacity
@@ -56,7 +56,7 @@ private class SimpleIOMemory < IO
     slice.copy_to(@buffer + @bytesize, count)
     @bytesize += count
 
-    nil
+    slice.size.to_u64
   end
 
   def to_slice
@@ -99,7 +99,8 @@ private class OneByOneIO < IO
     1
   end
 
-  def write(slice : Bytes) : Nil
+  def write(slice : Bytes) : UInt64
+    slice.size.to_u64
   end
 end
 

--- a/spec/std/io/io_spec.cr
+++ b/spec/std/io/io_spec.cr
@@ -507,7 +507,7 @@ describe IO do
     it "skips a few bytes" do
       io = SimpleIOMemory.new
       io << "hello world"
-      io.skip(6)
+      io.skip(6).should eq(6)
       io.gets_to_end.should eq("world")
     end
 
@@ -522,14 +522,14 @@ describe IO do
     it "skips more than 4096 bytes" do
       io = SimpleIOMemory.new
       io << "a" * 4100
-      io.skip(4099)
+      io.skip(4099).should eq(4099)
       io.gets_to_end.should eq("a")
     end
 
     it "skips to end" do
       io = SimpleIOMemory.new
       io << "hello"
-      io.skip_to_end
+      io.skip_to_end.should eq(5)
       io.read_byte.should be_nil
     end
 

--- a/spec/std/io/io_spec.cr
+++ b/spec/std/io/io_spec.cr
@@ -544,6 +544,42 @@ describe IO do
         end
       end
     end
+
+    describe "counts written bytes" do
+      it "directly" do
+        with_tempfile("create.txt") do |path|
+          File.open(path, "w") do |io|
+            io.write("hello world".to_slice).should eq(11)
+          end
+        end
+      end
+
+      it "using formatter" do
+        with_tempfile("create.txt") do |path|
+          File.open(path, "w") do |io|
+            # Print "           1234.5679"
+            io.printf("%20.8g", 1234.56789).should eq(20)
+          end
+        end
+      end
+
+      pending_win32 "with encoding" do
+        with_tempfile("create.txt") do |path|
+          File.open(path, "w", File::DEFAULT_CREATE_PERMISSIONS, "CP1252") do |io|
+            # In UTF-8 ñ will use 2 bytes
+            io.printf("mañana").should eq(6)
+          end
+        end
+      end
+
+      it "with byte format" do
+        io = SimpleIOMemory.new
+
+        io.write_bytes(1u64).should eq(8)
+        io.write_bytes(1u32).should eq(4)
+        io.write_bytes(1u8).should eq(1)
+      end
+    end
   end
 
   pending_win32 describe: "encoding" do

--- a/spec/std/io/io_spec.cr
+++ b/spec/std/io/io_spec.cr
@@ -550,15 +550,7 @@ describe IO do
         with_tempfile("create.txt") do |path|
           File.open(path, "w") do |io|
             io.write("hello world".to_slice).should eq(11)
-          end
-        end
-      end
-
-      it "using formatter" do
-        with_tempfile("create.txt") do |path|
-          File.open(path, "w") do |io|
-            # Print "           1234.5679"
-            io.printf("%20.8g", 1234.56789).should eq(20)
+            io.write_utf8("mañana".to_slice).should eq(7)
           end
         end
       end
@@ -567,7 +559,7 @@ describe IO do
         with_tempfile("create.txt") do |path|
           File.open(path, "w", File::DEFAULT_CREATE_PERMISSIONS, "CP1252") do |io|
             # In UTF-8 ñ will use 2 bytes
-            io.printf("mañana").should eq(6)
+            io.write_utf8("mañana".to_slice).should eq(6)
           end
         end
       end

--- a/spec/std/io/memory_spec.cr
+++ b/spec/std/io/memory_spec.cr
@@ -353,11 +353,11 @@ describe IO::Memory do
 
   it "skips" do
     io = IO::Memory.new("hello")
-    io.skip(2)
+    io.skip(2).should eq(2)
     io.gets_to_end.should eq("llo")
 
     io.rewind
-    io.skip(5)
+    io.skip(5).should eq(5)
     io.gets_to_end.should eq("")
 
     io.rewind
@@ -369,7 +369,7 @@ describe IO::Memory do
 
   it "skips_to_end" do
     io = IO::Memory.new("hello")
-    io.skip_to_end
+    io.skip_to_end.should eq(5)
     io.gets_to_end.should eq("")
   end
 

--- a/spec/std/io/sized_spec.cr
+++ b/spec/std/io/sized_spec.cr
@@ -5,7 +5,8 @@ private class NoPeekIO < IO
     0
   end
 
-  def write(bytes : Bytes) : Nil
+  def write(bytes : Bytes) : UInt64
+    0u64
   end
 
   def peek

--- a/spec/std/io/sized_spec.cr
+++ b/spec/std/io/sized_spec.cr
@@ -138,7 +138,7 @@ describe "IO::Sized" do
   it "skips" do
     io = IO::Memory.new "123456789"
     sized = IO::Sized.new(io, read_size: 6)
-    sized.skip(3)
+    sized.skip(3).should eq(3)
     sized.read_char.should eq('4')
 
     expect_raises(IO::EOFError) do

--- a/spec/std/io/stapled_spec.cr
+++ b/spec/std/io/stapled_spec.cr
@@ -76,6 +76,22 @@ describe IO::Stapled do
     io.peek.should eq Bytes.empty
   end
 
+  it "#skip delegates to reader" do
+    reader = IO::Memory.new "cletus"
+    io = IO::Stapled.new reader, IO::Memory.new
+    io.peek.should eq "cletus".to_slice
+    io.skip(4).should eq(4)
+    io.peek.should eq "us".to_slice
+  end
+
+  it "#skip_to_end delegates to reader" do
+    reader = IO::Memory.new "cletus"
+    io = IO::Stapled.new reader, IO::Memory.new
+    io.peek.should eq "cletus".to_slice
+    io.skip_to_end.should eq(6)
+    io.peek.should eq Bytes.empty
+  end
+
   describe ".pipe" do
     it "creates a bidirectional pipe" do
       a, b = IO::Stapled.pipe

--- a/spec/support/io.cr
+++ b/spec/support/io.cr
@@ -8,9 +8,10 @@ class RaiseIOError < IO
     raise IO::Error.new("...")
   end
 
-  def write(slice : Bytes) : Nil
+  def write(slice : Bytes) : UInt64
     @writes += 1
     raise IO::Error.new("...") if @raise_on_write
+    slice.size.to_u64
   end
 
   def flush

--- a/src/compress/deflate/writer.cr
+++ b/src/compress/deflate/writer.cr
@@ -52,7 +52,6 @@ class Compress::Deflate::Writer < IO
     @stream.next_in = slice
     consume_output LibZ::Flush::NO_FLUSH
 
-    # CHECK: should we return the bytes written in the consume_output?
     slice.size.to_u64
   end
 

--- a/src/compress/deflate/writer.cr
+++ b/src/compress/deflate/writer.cr
@@ -43,14 +43,17 @@ class Compress::Deflate::Writer < IO
   end
 
   # See `IO#write`.
-  def write(slice : Bytes) : Nil
+  def write(slice : Bytes) : UInt64
     check_open
 
-    return if slice.empty?
+    return 0u64 if slice.empty?
 
     @stream.avail_in = slice.size
     @stream.next_in = slice
     consume_output LibZ::Flush::NO_FLUSH
+
+    # CHECK: should we return the bytes written in the consume_output?
+    slice.size.to_u64
   end
 
   # See `IO#flush`.

--- a/src/compress/gzip/writer.cr
+++ b/src/compress/gzip/writer.cr
@@ -83,7 +83,6 @@ class Compress::Gzip::Writer < IO
     # uncompressed data size can be bigger.
     @isize &+= slice.size
 
-    # CHECK: should we return the bytes written in the flate_io (also by the write_header)?
     slice.size.to_u64
   end
 

--- a/src/compress/gzip/writer.cr
+++ b/src/compress/gzip/writer.cr
@@ -68,10 +68,10 @@ class Compress::Gzip::Writer < IO
   end
 
   # See `IO#write`.
-  def write(slice : Bytes) : Nil
+  def write(slice : Bytes) : UInt64
     check_open
 
-    return if slice.empty?
+    return 0u64 if slice.empty?
 
     flate_io = write_header
     flate_io.write(slice)
@@ -82,6 +82,9 @@ class Compress::Gzip::Writer < IO
     # Using wrapping addition here because isize is only 32 bits wide but
     # uncompressed data size can be bigger.
     @isize &+= slice.size
+
+    # CHECK: should we return the bytes written in the flate_io (also by the write_header)?
+    slice.size.to_u64
   end
 
   # Flushes data, forcing writing the gzip header if no

--- a/src/compress/zip/checksum_writer.cr
+++ b/src/compress/zip/checksum_writer.cr
@@ -13,8 +13,8 @@ module Compress::Zip
       raise IO::Error.new "Can't read from Zip::Writer entry"
     end
 
-    def write(slice : Bytes) : Nil
-      return if slice.empty?
+    def write(slice : Bytes) : UInt64
+      return 0u64 if slice.empty?
 
       @count += slice.size
       @crc32 = Digest::CRC32.update(slice, @crc32) if @compute_crc32

--- a/src/compress/zlib/writer.cr
+++ b/src/compress/zlib/writer.cr
@@ -44,15 +44,18 @@ class Compress::Zlib::Writer < IO
   end
 
   # See `IO#write`.
-  def write(slice : Bytes) : Nil
+  def write(slice : Bytes) : UInt64
     check_open
 
-    return if slice.empty?
+    return 0u64 if slice.empty?
 
     write_header unless @wrote_header
 
     @flate_io.write(slice)
     @adler32 = Digest::Adler32.update(slice, @adler32)
+
+    # CHECK: should we return the bytes written in the flate_io (also by the write_header)?
+    slice.size.to_u64
   end
 
   # Flushes data, forcing writing the zlib header if no

--- a/src/compress/zlib/writer.cr
+++ b/src/compress/zlib/writer.cr
@@ -54,7 +54,6 @@ class Compress::Zlib::Writer < IO
     @flate_io.write(slice)
     @adler32 = Digest::Adler32.update(slice, @adler32)
 
-    # CHECK: should we return the bytes written in the flate_io (also by the write_header)?
     slice.size.to_u64
   end
 

--- a/src/float.cr
+++ b/src/float.cr
@@ -93,7 +93,7 @@ struct Float
 
   # Writes this float to the given *io* in the given *format*.
   # See also: `IO#write_bytes`.
-  def to_io(io : IO, format : IO::ByteFormat)
+  def to_io(io : IO, format : IO::ByteFormat) : UInt64
     format.encode(self, io)
   end
 

--- a/src/http/content.cr
+++ b/src/http/content.cr
@@ -41,7 +41,7 @@ module HTTP
       super
     end
 
-    def skip(bytes_count)
+    def skip(bytes_count : Int) : UInt64
       ensure_send_continue
       super
     end
@@ -73,7 +73,7 @@ module HTTP
       @io.peek
     end
 
-    def skip(bytes_count)
+    def skip(bytes_count : Int) : UInt64
       ensure_send_continue
       @io.skip(bytes_count)
     end
@@ -164,14 +164,18 @@ module HTTP
       peek
     end
 
-    def skip(bytes_count)
+    def skip(bytes_count : Int) : UInt64
+      bytes_count = bytes_count.to_u64
       ensure_send_continue
+
       if bytes_count <= @chunk_remaining
         @io.skip(bytes_count)
         @chunk_remaining -= bytes_count
       else
         super
       end
+
+      bytes_count
     end
 
     # Checks if the last read consumed a chunk and we

--- a/src/http/server/response.cr
+++ b/src/http/server/response.cr
@@ -80,8 +80,8 @@ class HTTP::Server
     end
 
     # See `IO#write(slice)`.
-    def write(slice : Bytes) : Nil
-      return if slice.empty?
+    def write(slice : Bytes) : UInt64
+      return 0u64 if slice.empty?
 
       @output.write(slice)
     end

--- a/src/http/web_socket/protocol.cr
+++ b/src/http/web_socket/protocol.cr
@@ -52,8 +52,8 @@ class HTTP::WebSocket::Protocol
       @pos = 0
     end
 
-    def write(slice : Bytes) : Nil
-      return if slice.empty?
+    def write(slice : Bytes) : UInt64
+      return 0u64 if slice.empty?
 
       count = Math.min(@buffer.size - @pos, slice.size)
       (@buffer + @pos).copy_from(slice.to_unsafe, count)
@@ -66,6 +66,8 @@ class HTTP::WebSocket::Protocol
       if count < slice.size
         write(slice + count)
       end
+
+      slice.size.to_u64
     end
 
     def read(slice : Bytes)

--- a/src/int.cr
+++ b/src/int.cr
@@ -638,7 +638,7 @@ struct Int
   # Writes this integer to the given *io* in the given *format*.
   #
   # See also: `IO#write_bytes`.
-  def to_io(io : IO, format : IO::ByteFormat)
+  def to_io(io : IO, format : IO::ByteFormat) : UInt64
     format.encode(self, io)
   end
 

--- a/src/io.cr
+++ b/src/io.cr
@@ -830,7 +830,7 @@ abstract class IO
     bytes_count = 0_u64
     buffer = uninitialized UInt8[4096]
     while (len = read(buffer.to_slice)) > 0
-      bytes_count += len
+      bytes_count &+= len
     end
     bytes_count
   end

--- a/src/io.cr
+++ b/src/io.cr
@@ -261,14 +261,15 @@ abstract class IO
 
   # Writes a formatted string to this IO.
   # For details on the format string, see `Kernel::sprintf`.
-  def printf(format_string, *args) : Nil
+  def printf(format_string, *args) : UInt64
     printf format_string, args
   end
 
   # :ditto:
-  def printf(format_string, args : Array | Tuple) : Nil
-    String::Formatter(typeof(args)).new(format_string, args, self).format
-    nil
+  def printf(format_string, args : Array | Tuple) : UInt64
+    io = BytesCounter.new(self)
+    String::Formatter(typeof(args)).new(format_string, args, io).format
+    io.bytes_written
   end
 
   # Reads a single byte from this `IO`. Returns `nil` if there is no more
@@ -1218,6 +1219,7 @@ abstract class IO
     getter io : IO
 
     def initialize(@io : IO)
+      @encoding = @io.@encoding
     end
 
     def write(slice : Bytes) : UInt64

--- a/src/io.cr
+++ b/src/io.cr
@@ -814,22 +814,26 @@ abstract class IO
   # io.gets    # => "world"
   # io.skip(1) # raises IO::EOFError
   # ```
-  def skip(bytes_count : Int) : Nil
+  def skip(bytes_count : Int) : Int
+    remaining = bytes_count
     buffer = uninitialized UInt8[4096]
-    while bytes_count > 0
-      read_count = read(buffer.to_slice[0, Math.min(bytes_count, 4096)])
+    while remaining > 0
+      read_count = read(buffer.to_slice[0, Math.min(remaining, 4096)])
       raise IO::EOFError.new if read_count == 0
-
-      bytes_count -= read_count
+      remaining -= read_count
     end
+    bytes_count
   end
 
   # Reads and discards bytes from `self` until there
   # are no more bytes.
-  def skip_to_end : Nil
+  def skip_to_end : Int
+    bytes_count = 0
     buffer = uninitialized UInt8[4096]
-    while read(buffer.to_slice) > 0
+    while (len = read(buffer.to_slice)) > 0
+      bytes_count += len
     end
+    bytes_count
   end
 
   # Writes a single byte into this `IO`.

--- a/src/io.cr
+++ b/src/io.cr
@@ -814,7 +814,8 @@ abstract class IO
   # io.gets    # => "world"
   # io.skip(1) # raises IO::EOFError
   # ```
-  def skip(bytes_count : UInt64) : UInt64
+  def skip(bytes_count : Int) : UInt64
+    bytes_count = bytes_count.to_u64
     remaining = bytes_count
     buffer = uninitialized UInt8[4096]
     while remaining > 0

--- a/src/io.cr
+++ b/src/io.cr
@@ -814,7 +814,7 @@ abstract class IO
   # io.gets    # => "world"
   # io.skip(1) # raises IO::EOFError
   # ```
-  def skip(bytes_count : Int) : Int
+  def skip(bytes_count : UInt64) : UInt64
     remaining = bytes_count
     buffer = uninitialized UInt8[4096]
     while remaining > 0
@@ -827,8 +827,8 @@ abstract class IO
 
   # Reads and discards bytes from `self` until there
   # are no more bytes.
-  def skip_to_end : Int
-    bytes_count = 0
+  def skip_to_end : UInt64
+    bytes_count = 0_u64
     buffer = uninitialized UInt8[4096]
     while (len = read(buffer.to_slice)) > 0
       bytes_count += len

--- a/src/io/buffered.cr
+++ b/src/io/buffered.cr
@@ -110,18 +110,20 @@ module IO::Buffered
   end
 
   # :nodoc:
-  def skip(bytes_count) : Nil
+  def skip(bytes_count) : Int
     check_open
 
     if bytes_count <= @in_buffer_rem.size
       @in_buffer_rem += bytes_count
-      return
+      return bytes_count
     end
 
-    bytes_count -= @in_buffer_rem.size
+    remaining = bytes_count
+    remaining -= @in_buffer_rem.size
     @in_buffer_rem = Bytes.empty
 
-    super(bytes_count)
+    super(remaining)
+    bytes_count
   end
 
   # Buffered implementation of `IO#write(slice)`.

--- a/src/io/buffered.cr
+++ b/src/io/buffered.cr
@@ -110,7 +110,8 @@ module IO::Buffered
   end
 
   # :nodoc:
-  def skip(bytes_count : UInt64) : UInt64
+  def skip(bytes_count : Int) : UInt64
+    bytes_count = bytes_count.to_u64
     check_open
 
     if bytes_count <= @in_buffer_rem.size

--- a/src/io/buffered.cr
+++ b/src/io/buffered.cr
@@ -110,7 +110,7 @@ module IO::Buffered
   end
 
   # :nodoc:
-  def skip(bytes_count) : Int
+  def skip(bytes_count : UInt64) : UInt64
     check_open
 
     if bytes_count <= @in_buffer_rem.size

--- a/src/io/byte_format.cr
+++ b/src/io/byte_format.cr
@@ -33,27 +33,27 @@
 # io.to_slice # => Bytes[0x34, 0x12]
 # ```
 module IO::ByteFormat
-  abstract def encode(int : Int8, io : IO)
-  abstract def encode(int : UInt8, io : IO)
-  abstract def encode(int : Int16, io : IO)
-  abstract def encode(int : UInt16, io : IO)
-  abstract def encode(int : Int32, io : IO)
-  abstract def encode(int : UInt32, io : IO)
-  abstract def encode(int : Int64, io : IO)
-  abstract def encode(int : UInt64, io : IO)
-  abstract def encode(int : Int128, io : IO)
-  abstract def encode(int : UInt128, io : IO)
+  abstract def encode(int : Int8, io : IO) : UInt64
+  abstract def encode(int : UInt8, io : IO) : UInt64
+  abstract def encode(int : Int16, io : IO) : UInt64
+  abstract def encode(int : UInt16, io : IO) : UInt64
+  abstract def encode(int : Int32, io : IO) : UInt64
+  abstract def encode(int : UInt32, io : IO) : UInt64
+  abstract def encode(int : Int64, io : IO) : UInt64
+  abstract def encode(int : UInt64, io : IO) : UInt64
+  abstract def encode(int : Int128, io : IO) : UInt64
+  abstract def encode(int : UInt128, io : IO) : UInt64
 
-  abstract def encode(int : Int8, bytes : Bytes)
-  abstract def encode(int : UInt8, bytes : Bytes)
-  abstract def encode(int : Int16, bytes : Bytes)
-  abstract def encode(int : UInt16, bytes : Bytes)
-  abstract def encode(int : Int32, bytes : Bytes)
-  abstract def encode(int : UInt32, bytes : Bytes)
-  abstract def encode(int : Int64, bytes : Bytes)
-  abstract def encode(int : UInt64, bytes : Bytes)
-  abstract def encode(int : Int128, bytes : Bytes)
-  abstract def encode(int : UInt128, bytes : Bytes)
+  abstract def encode(int : Int8, bytes : Bytes) : UInt64
+  abstract def encode(int : UInt8, bytes : Bytes) : UInt64
+  abstract def encode(int : Int16, bytes : Bytes) : UInt64
+  abstract def encode(int : UInt16, bytes : Bytes) : UInt64
+  abstract def encode(int : Int32, bytes : Bytes) : UInt64
+  abstract def encode(int : UInt32, bytes : Bytes) : UInt64
+  abstract def encode(int : Int64, bytes : Bytes) : UInt64
+  abstract def encode(int : UInt64, bytes : Bytes) : UInt64
+  abstract def encode(int : Int128, bytes : Bytes) : UInt64
+  abstract def encode(int : UInt128, bytes : Bytes) : UInt64
 
   abstract def decode(int : Int8.class, io : IO)
   abstract def decode(int : UInt8.class, io : IO)
@@ -77,11 +77,11 @@ module IO::ByteFormat
   abstract def decode(int : Int128.class, bytes : Bytes)
   abstract def decode(int : UInt128.class, bytes : Bytes)
 
-  def encode(float : Float32, io : IO)
+  def encode(float : Float32, io : IO) : UInt64
     encode(float.unsafe_as(Int32), io)
   end
 
-  def encode(float : Float32, bytes : Bytes)
+  def encode(float : Float32, bytes : Bytes) : UInt64
     encode(float.unsafe_as(Int32), bytes)
   end
 
@@ -93,11 +93,11 @@ module IO::ByteFormat
     decode(Int32, bytes).unsafe_as(Float32)
   end
 
-  def encode(float : Float64, io : IO)
+  def encode(float : Float64, io : IO) : UInt64
     encode(float.unsafe_as(Int64), io)
   end
 
-  def encode(float : Float64, bytes : Bytes)
+  def encode(float : Float64, bytes : Bytes) : UInt64
     encode(float.unsafe_as(Int64), bytes)
   end
 
@@ -125,16 +125,18 @@ module IO::ByteFormat
       {% for type, i in %w(Int8 UInt8 Int16 UInt16 Int32 UInt32 Int64 UInt64 Int128 UInt128) %}
         {% bytesize = 2 ** (i // 2) %}
 
-        def self.encode(int : {{type.id}}, io : IO)
+        def self.encode(int : {{type.id}}, io : IO) : UInt64
           buffer = int.unsafe_as(StaticArray(UInt8, {{bytesize}}))
           buffer.reverse! unless SystemEndian == self
           io.write(buffer.to_slice)
+          UInt64.new({{bytesize}})
         end
 
-        def self.encode(int : {{type.id}}, bytes : Bytes)
+        def self.encode(int : {{type.id}}, bytes : Bytes) : UInt64
           buffer = int.unsafe_as(StaticArray(UInt8, {{bytesize}}))
           buffer.reverse! unless SystemEndian == self
           buffer.to_slice.copy_to(bytes)
+          UInt64.new({{bytesize}})
         end
 
         def self.decode(type : {{type.id}}.class, io : IO)

--- a/src/io/delimited.cr
+++ b/src/io/delimited.cr
@@ -107,7 +107,7 @@ class IO::Delimited < IO
     read_bytes
   end
 
-  def write(slice : Bytes) : Nil
+  def write(slice : Bytes) : UInt64
     raise IO::Error.new "Can't write to IO::Delimited"
   end
 

--- a/src/io/encoding.cr
+++ b/src/io/encoding.cr
@@ -39,7 +39,7 @@ class IO
         if err == Crystal::Iconv::ERROR
           @iconv.handle_invalid(pointerof(inbuf_ptr), pointerof(inbytesleft))
         end
-        bytes_written += io.write(outbuf.to_slice[0, outbuf.size - outbytesleft])
+        bytes_written &+= io.write(outbuf.to_slice[0, outbuf.size - outbytesleft])
       end
       bytes_written
     end

--- a/src/io/encoding.cr
+++ b/src/io/encoding.cr
@@ -28,7 +28,7 @@ class IO
     end
 
     def write(io, slice : Bytes) : UInt64
-      io = BytesCounter.new(io)
+      bytes_written = 0u64
       inbuf_ptr = slice.to_unsafe
       inbytesleft = LibC::SizeT.new(slice.size)
       outbuf = uninitialized UInt8[1024]
@@ -39,9 +39,9 @@ class IO
         if err == Crystal::Iconv::ERROR
           @iconv.handle_invalid(pointerof(inbuf_ptr), pointerof(inbytesleft))
         end
-        io.write(outbuf.to_slice[0, outbuf.size - outbytesleft])
+        bytes_written += io.write(outbuf.to_slice[0, outbuf.size - outbytesleft])
       end
-      io.bytes_written
+      bytes_written
     end
 
     def close

--- a/src/io/encoding.cr
+++ b/src/io/encoding.cr
@@ -27,7 +27,8 @@ class IO
       @closed = false
     end
 
-    def write(io, slice : Bytes)
+    def write(io, slice : Bytes) : UInt64
+      io = BytesCounter.new(io)
       inbuf_ptr = slice.to_unsafe
       inbytesleft = LibC::SizeT.new(slice.size)
       outbuf = uninitialized UInt8[1024]
@@ -40,6 +41,7 @@ class IO
         end
         io.write(outbuf.to_slice[0, outbuf.size - outbytesleft])
       end
+      io.bytes_written
     end
 
     def close

--- a/src/io/hexdump.cr
+++ b/src/io/hexdump.cr
@@ -32,8 +32,8 @@ class IO::Hexdump < IO
     end
   end
 
-  def write(buf : Bytes) : Nil
-    return if buf.empty?
+  def write(buf : Bytes) : UInt64
+    return 0u64 if buf.empty?
 
     @io.write(buf).tap do
       @output.puts buf.hexdump if @write

--- a/src/io/memory.cr
+++ b/src/io/memory.cr
@@ -203,6 +203,7 @@ class IO::Memory < IO
     else
       raise IO::EOFError.new
     end
+    bytes_count
   end
 
   # :nodoc:

--- a/src/io/memory.cr
+++ b/src/io/memory.cr
@@ -194,7 +194,7 @@ class IO::Memory < IO
   end
 
   # :nodoc:
-  def skip(bytes_count)
+  def skip(bytes_count : UInt64) : UInt64
     check_open
 
     available = @bytesize - @pos
@@ -207,10 +207,12 @@ class IO::Memory < IO
   end
 
   # :nodoc:
-  def skip_to_end
+  def skip_to_end : UInt64
     check_open
 
+    skipped = @bytesize - @pos
     @pos = @bytesize
+    skipped.to_u64
   end
 
   # :nodoc:

--- a/src/io/memory.cr
+++ b/src/io/memory.cr
@@ -82,13 +82,13 @@ class IO::Memory < IO
 
   # See `IO#write(slice)`. Raises if this `IO::Memory` is non-writeable,
   # or if it's non-resizeable and a resize is needed.
-  def write(slice : Bytes) : Nil
+  def write(slice : Bytes) : UInt64
     check_writeable
     check_open
 
     count = slice.size
 
-    return if count == 0
+    return 0u64 if count == 0
 
     new_bytesize = @pos + count
     if new_bytesize > @capacity
@@ -105,7 +105,7 @@ class IO::Memory < IO
     @pos += count
     @bytesize = @pos if @pos > @bytesize
 
-    nil
+    slice.size.to_u64
   end
 
   # See `IO#write_byte`. Raises if this `IO::Memory` is non-writeable,

--- a/src/io/memory.cr
+++ b/src/io/memory.cr
@@ -194,7 +194,8 @@ class IO::Memory < IO
   end
 
   # :nodoc:
-  def skip(bytes_count : UInt64) : UInt64
+  def skip(bytes_count : Int) : UInt64
+    bytes_count = bytes_count.to_u64
     check_open
 
     available = @bytesize - @pos

--- a/src/io/multi_writer.cr
+++ b/src/io/multi_writer.cr
@@ -29,12 +29,14 @@ class IO::MultiWriter < IO
     @writers = writers.map(&.as(IO)).to_a
   end
 
-  def write(slice : Bytes) : Nil
+  def write(slice : Bytes) : UInt64
     check_open
 
-    return if slice.empty?
+    return 0u64 if slice.empty?
 
     @writers.each { |writer| writer.write(slice) }
+
+    slice.size.to_u64
   end
 
   def read(slice : Bytes)

--- a/src/io/sized.cr
+++ b/src/io/sized.cr
@@ -61,7 +61,7 @@ class IO::Sized < IO
     peek
   end
 
-  def skip(bytes_count) : Nil
+  def skip(bytes_count)
     check_open
 
     if bytes_count <= @read_remaining
@@ -70,6 +70,8 @@ class IO::Sized < IO
     else
       raise IO::EOFError.new
     end
+
+    bytes_count
   end
 
   def write(slice : Bytes) : NoReturn

--- a/src/io/sized.cr
+++ b/src/io/sized.cr
@@ -61,7 +61,8 @@ class IO::Sized < IO
     peek
   end
 
-  def skip(bytes_count : UInt64) : UInt64
+  def skip(bytes_count : Int) : UInt64
+    bytes_count = bytes_count.to_u64
     check_open
 
     if bytes_count <= @read_remaining

--- a/src/io/sized.cr
+++ b/src/io/sized.cr
@@ -61,7 +61,7 @@ class IO::Sized < IO
     peek
   end
 
-  def skip(bytes_count)
+  def skip(bytes_count : UInt64) : UInt64
     check_open
 
     if bytes_count <= @read_remaining

--- a/src/io/stapled.cr
+++ b/src/io/stapled.cr
@@ -51,7 +51,7 @@ class IO::Stapled < IO
   end
 
   # Skips `reader`.
-  def skip(bytes_count : UInt64) : UInt64
+  def skip(bytes_count : Int) : UInt64
     check_open
 
     @reader.skip(bytes_count)

--- a/src/io/stapled.cr
+++ b/src/io/stapled.cr
@@ -51,7 +51,7 @@ class IO::Stapled < IO
   end
 
   # Skips `reader`.
-  def skip(bytes_count : Int) : Nil
+  def skip(bytes_count : UInt64) : UInt64
     check_open
 
     @reader.skip(bytes_count)

--- a/src/io/stapled.cr
+++ b/src/io/stapled.cr
@@ -72,10 +72,10 @@ class IO::Stapled < IO
   end
 
   # Writes a slice to `writer`.
-  def write(slice : Bytes) : Nil
+  def write(slice : Bytes) : UInt64
     check_open
 
-    return if slice.empty?
+    return 0u64 if slice.empty?
 
     @writer.write(slice)
   end

--- a/src/io/stapled.cr
+++ b/src/io/stapled.cr
@@ -57,6 +57,13 @@ class IO::Stapled < IO
     @reader.skip(bytes_count)
   end
 
+  # Skips `reader`.
+  def skip_to_end : UInt64
+    check_open
+
+    @reader.skip_to_end
+  end
+
   # Writes a byte to `writer`.
   def write_byte(byte : UInt8) : Nil
     check_open

--- a/src/openssl/digest/digest_io.cr
+++ b/src/openssl/digest/digest_io.cr
@@ -42,8 +42,8 @@ module OpenSSL
       read_bytes
     end
 
-    def write(slice : Bytes) : Nil
-      return if slice.empty?
+    def write(slice : Bytes) : UInt64
+      return 0u64 if slice.empty?
 
       if @mode.write?
         digest_algorithm.update(slice)

--- a/src/openssl/ssl/socket.cr
+++ b/src/openssl/ssl/socket.cr
@@ -144,7 +144,6 @@ abstract class OpenSSL::SSL::Socket < IO
     unless bytes > 0
       raise OpenSSL::SSL::Error.new(@ssl, bytes, "SSL_write")
     end
-    nil
   end
 
   def unbuffered_flush

--- a/src/string/builder.cr
+++ b/src/string/builder.cr
@@ -38,8 +38,8 @@ class String::Builder < IO
     raise "Not implemented"
   end
 
-  def write(slice : Bytes) : Nil
-    return if slice.empty?
+  def write(slice : Bytes) : UInt64
+    return 0u64 if slice.empty?
 
     count = slice.size
     new_bytesize = real_bytesize + count
@@ -50,7 +50,7 @@ class String::Builder < IO
     slice.copy_to(@buffer + real_bytesize, count)
     @bytesize += count
 
-    nil
+    slice.size.to_u64
   end
 
   def write_byte(byte : UInt8)


### PR DESCRIPTION
Closes #9185

* `IO#skip` still allows any Int as the argument, but UInt64 is returned
* Fix build (🤞) and added a couple of assertions w.r.t. #9185
* Make `IO#write_* : UInt64`
* Make `IO#printf(...) : UInt64`
