### PR TITLE
Fix `crystal spec` file paths on Windows

### DIFF
--- a/src/compiler/crystal/command/spec.cr
+++ b/src/compiler/crystal/command/spec.cr
@@ -66,7 +66,9 @@ class Crystal::Command
 
     source_filename = File.expand_path("spec")
 
-    source = target_filenames.map { |filename| %(require "./#{filename}") }.join('\n')
+    source = target_filenames.map { |filename|
+      %(require "./#{::Path[filename].to_posix}")
+    }.join('\n')
     sources = [Compiler::Source.new(source_filename, source)]
 
     output_filename = Crystal.temp_executable "spec"


### PR DESCRIPTION
The entry point file is being generated with the paths being pasted directly into source code (`require "string"`) but `require` always needs forward slashes, while backslashes actually end up being interpreted as escape sequences.