### PR TITLE
Fix segfaults when static linking with musl

### DIFF
--- a/src/crystal/system/unix/pthread.cr
+++ b/src/crystal/system/unix/pthread.cr
@@ -178,3 +178,19 @@ class Thread
     @th
   end
 end
+
+# In musl (alpine) the calls to unwind API segfaults
+# when the binary is statically linked. This is because
+# some symbols like `pthread_once` are defined as "weak"
+# and, for some reason, not linked into the final binary.
+# Adding an explicit reference to the symbol ensures it's
+# included in the statically linked binary.
+{% if flag?(:musl) && flag?(:static) %}
+  lib LibC
+    fun pthread_once(Void*, Void*)
+  end
+
+  fun __crystal_static_musl_workaround
+    LibC.pthread_once(nil, nil)
+  end
+{% end %}


### PR DESCRIPTION
This is a workaround for segfaults that are showing up when raising exceptions in musl and the binary was statically linked.

The issue is with `pthread_once`. In musl is defined as a weak symbol:
```
$ nm /usr/lib/gcc/x86_64-alpine-linux-musl/9.2.0/libgcc.a
...
                 w pthread_once
...
```

The unwind API implementation uses this function, but through a wrapper `__gthread_once`: https://github.com/gcc-mirror/gcc/blob/8d9254fc8aa32619f640efb01cfe87cc6cdc9ce1/libgcc/unwind-dw2.c#L1597-L1600

But the implementation of `__gthread_once` refers to the weak version of the function:
https://github.com/gcc-mirror/gcc/blob/8d9254fc8aa32619f640efb01cfe87cc6cdc9ce1/libgcc/gthr-posix.h#L696-L703

For some reason I don't fully understand yet, that makes the linker to not include that function in the final binary.

Note also that `__gthread_once` checks `__gthread_active_p` to see if the current code is multithreaded or not. It's a hack that looks for other existing symbols within the same binary. That's why when linking with the GC it failed but it doesn't when compiling with `-Dgc_none`: the GC uses multithreaded code and thus links to `pthread_create` and other symbols.

Thank you very much to @ggiraldez for help with this debugging!!!

*NOTE*: the backtraces still cannot be decoded with static linking, but that's a different issue

Fixes: #4276, #6934

