### PR TITLE
Log: Avoid hard breaking change in Log.setup_from_env

### DIFF
--- a/src/log/setup.cr
+++ b/src/log/setup.cr
@@ -26,6 +26,14 @@ class Log
     end
   end
 
+  @[Deprecated("Use default_level, default_sources named arguments")]
+  def self.setup_from_env(*, builder : Log::Builder = Log.builder,
+                          level : String,
+                          sources : String,
+                          backend = Log::IOBackend.new)
+    Log.setup(sources, Log::Severity.parse(level), backend, builder: builder)
+  end
+
   # Setups logging based on `LOG_LEVEL` environment variable.
   def self.setup_from_env(*, builder : Log::Builder = Log.builder,
                           default_level : Log::Severity = Log::Severity::Info,


### PR DESCRIPTION
#9145 introduces a breacking change without deprecation. We thought it was not needed. Shards v0.10 (and hence, nightlies) uses an overload that is restored as deprecated in this PR.

Although it does not cover all the overloads, it does cover all the usages found publicly:

* crystal-lang/shards (v0.10.0)
* crystalshards/crystalshards
* jessedoyle/duktape.cr
* RomainFranceschini/quartz

shards master is already updated, but in order to not force a release for unlocking nightlies we can go along with this PR.