### PR TITLE
Add Experimental annotation and doc label

### DIFF
--- a/spec/compiler/codegen/experimental_spec.cr
+++ b/spec/compiler/codegen/experimental_spec.cr
@@ -1,0 +1,50 @@
+require "../spec_helper"
+
+describe "Code gen: experimental" do
+  it "compiles with no argument" do
+    run(%(
+      @[Experimental]
+      def foo
+      end
+
+      2
+      )).to_i.should eq(2)
+  end
+
+  it "compiles with single string argument" do
+    run(%(
+      @[Experimental("lorem ipsum")]
+      def foo
+      end
+
+      2
+      )).to_i.should eq(2)
+  end
+
+  it "errors if invalid argument type" do
+    assert_error %(
+      @[Experimental(42)]
+      def foo
+      end
+      ),
+      "Error: first argument must be a String"
+  end
+
+  it "errors if too many arguments" do
+    assert_error %(
+      @[Experimental("lorem ipsum", "extra arg")]
+      def foo
+      end
+      ),
+      "Error: wrong number of experimental annotation arguments (given 2, expected 1)"
+  end
+
+  it "errors if missing link arguments" do
+    assert_error %(
+      @[Experimental(invalid: "lorem ipsum")]
+      def foo
+      end
+      ),
+      "Error: too many named arguments (given 1, expected maximum 0)"
+  end
+end

--- a/spec/compiler/crystal/tools/doc/generator_spec.cr
+++ b/spec/compiler/crystal/tools/doc/generator_spec.cr
@@ -1,5 +1,7 @@
 require "../../../spec_helper"
 
+private ANNOTATION_COLORS = {"Deprecated" => "red", "Experimental" => "lime"}
+
 describe Doc::Generator do
   describe "#must_include_toplevel?" do
     it "returns false if program has nothing" do
@@ -99,30 +101,32 @@ describe Doc::Generator do
   end
 
   describe "#formatted_summary" do
-    describe "with a Deprecated annotation, and no docs" do
-      it "should generate just the Deprecated tag" do
-        program = Program.new
-        generator = Doc::Generator.new program, ["."]
-        doc_type = Doc::Type.new generator, program
+    ANNOTATION_COLORS.each do |ann, color|
+      describe "with a #{ann} annotation, and no docs" do
+        it "should generate just the #{ann} tag" do
+          program = Program.new
+          generator = Doc::Generator.new program, ["."]
+          doc_type = Doc::Type.new generator, program
 
-        a_def = Def.new "foo"
-        a_def.add_annotation(program.deprecated_annotation, Annotation.new(Crystal::Path.new("Deprecated"), ["don't use me".string] of ASTNode))
-        doc_method = Doc::Method.new generator, doc_type, a_def, false
-        doc_method.formatted_summary.should eq %(<p><span class="flag red">DEPRECATED</span>  don't use me</p>\n\n)
+          a_def = Def.new "foo"
+          a_def.add_annotation(program.types[ann].as(Crystal::AnnotationType), Annotation.new(Crystal::Path.new(ann), ["lorem ipsum".string] of ASTNode))
+          doc_method = Doc::Method.new generator, doc_type, a_def, false
+          doc_method.formatted_summary.should eq %(<p><span class="flag #{color}">#{ann.upcase}</span>  lorem ipsum</p>\n\n)
+        end
       end
-    end
 
-    describe "with a Deprecated annotation, and docs" do
-      it "should generate both the docs and Deprecated tag" do
-        program = Program.new
-        generator = Doc::Generator.new program, ["."]
-        doc_type = Doc::Type.new generator, program
+      describe "with a #{ann} annotation, and docs" do
+        it "should generate both the docs and #{ann} tag" do
+          program = Program.new
+          generator = Doc::Generator.new program, ["."]
+          doc_type = Doc::Type.new generator, program
 
-        a_def = Def.new "foo"
-        a_def.doc = "Some Method"
-        a_def.add_annotation(program.deprecated_annotation, Annotation.new(Crystal::Path.new("Deprecated"), ["don't use me".string] of ASTNode))
-        doc_method = Doc::Method.new generator, doc_type, a_def, false
-        doc_method.formatted_summary.should eq %(<p>Some Method</p>\n\n<p><span class="flag red">DEPRECATED</span>  don't use me</p>\n\n)
+          a_def = Def.new "foo"
+          a_def.doc = "Some Method"
+          a_def.add_annotation(program.types[ann].as(Crystal::AnnotationType), Annotation.new(Crystal::Path.new(ann), ["lorem ipsum".string] of ASTNode))
+          doc_method = Doc::Method.new generator, doc_type, a_def, false
+          doc_method.formatted_summary.should eq %(<p>Some Method</p>\n\n<p><span class="flag #{color}">#{ann.upcase}</span>  lorem ipsum</p>\n\n)
+        end
       end
     end
 
@@ -162,30 +166,32 @@ describe Doc::Generator do
   end
 
   describe "#formatted_doc" do
-    describe "with a Deprecated annotation, and no docs" do
-      it "should generate just the Deprecated tag" do
-        program = Program.new
-        generator = Doc::Generator.new program, ["."]
-        doc_type = Doc::Type.new generator, program
+    ANNOTATION_COLORS.each do |ann, color|
+      describe "with a #{ann} annotation, and no docs" do
+        it "should generate just the #{ann} tag" do
+          program = Program.new
+          generator = Doc::Generator.new program, ["."]
+          doc_type = Doc::Type.new generator, program
 
-        a_def = Def.new "foo"
-        a_def.add_annotation(program.deprecated_annotation, Annotation.new(Crystal::Path.new("Deprecated"), ["don't use me".string] of ASTNode))
-        doc_method = Doc::Method.new generator, doc_type, a_def, false
-        doc_method.formatted_doc.should eq %(<p><span class="flag red">DEPRECATED</span>  don't use me</p>\n\n)
+          a_def = Def.new "foo"
+          a_def.add_annotation(program.types[ann].as(Crystal::AnnotationType), Annotation.new(Crystal::Path.new(ann), ["lorem ipsum".string] of ASTNode))
+          doc_method = Doc::Method.new generator, doc_type, a_def, false
+          doc_method.formatted_doc.should eq %(<p><span class="flag #{color}">#{ann.upcase}</span>  lorem ipsum</p>\n\n)
+        end
       end
-    end
 
-    describe "with a Deprecated annotation, and docs" do
-      it "should generate both the docs and Deprecated tag" do
-        program = Program.new
-        generator = Doc::Generator.new program, ["."]
-        doc_type = Doc::Type.new generator, program
+      describe "with a #{ann} annotation, and docs" do
+        it "should generate both the docs and #{ann} tag" do
+          program = Program.new
+          generator = Doc::Generator.new program, ["."]
+          doc_type = Doc::Type.new generator, program
 
-        a_def = Def.new "foo"
-        a_def.doc = "Some Method"
-        a_def.add_annotation(program.deprecated_annotation, Annotation.new(Crystal::Path.new("Deprecated"), ["don't use me".string] of ASTNode))
-        doc_method = Doc::Method.new generator, doc_type, a_def, false
-        doc_method.formatted_doc.should eq %(<p>Some Method</p>\n\n<p><span class="flag red">DEPRECATED</span>  don't use me</p>\n\n)
+          a_def = Def.new "foo"
+          a_def.doc = "Some Method"
+          a_def.add_annotation(program.types[ann].as(Crystal::AnnotationType), Annotation.new(Crystal::Path.new(ann), ["lorem ipsum".string] of ASTNode))
+          doc_method = Doc::Method.new generator, doc_type, a_def, false
+          doc_method.formatted_doc.should eq %(<p>Some Method</p>\n\n<p><span class="flag #{color}">#{ann.upcase}</span>  lorem ipsum</p>\n\n)
+        end
       end
     end
 

--- a/src/annotations.cr
+++ b/src/annotations.cr
@@ -51,3 +51,16 @@ end
 # using `ldflags`: `@[Link(ldflags: "-Lvendor/bin")]`.
 annotation Link
 end
+
+# This annotation marks methods, classes, constants, and macros as experimental.
+#
+# Experimental features are subject to change or be removed despite the
+# [https://semver.org/](https://semver.org/) guarantees.
+#
+# ```
+# @[Experimental("Join discussion about this topic at ...")]
+# def foo
+# end
+# ```
+annotation Experimental
+end

--- a/src/compiler/crystal/codegen/experimental.cr
+++ b/src/compiler/crystal/codegen/experimental.cr
@@ -1,0 +1,34 @@
+module Crystal
+  struct ExperimentalAnnotation
+    getter message : String?
+
+    def initialize(@message = nil)
+    end
+
+    def self.from(ann : Annotation)
+      args = ann.args
+      named_args = ann.named_args
+
+      if named_args
+        ann.raise "too many named arguments (given #{named_args.size}, expected maximum 0)"
+      end
+
+      message = nil
+      count = 0
+
+      args.each do |arg|
+        case count
+        when 0
+          arg.raise "first argument must be a String" unless arg.is_a?(StringLiteral)
+          message = arg.value
+        else
+          ann.wrong_number_of "experimental annotation arguments", args.size, "1"
+        end
+
+        count += 1
+      end
+
+      new(message)
+    end
+  end
+end

--- a/src/compiler/crystal/program.cr
+++ b/src/compiler/crystal/program.cr
@@ -242,6 +242,7 @@ module Crystal
       types["ReturnsTwice"] = @returns_twice_annotation = AnnotationType.new self, self, "ReturnsTwice"
       types["ThreadLocal"] = @thread_local_annotation = AnnotationType.new self, self, "ThreadLocal"
       types["Deprecated"] = @deprecated_annotation = AnnotationType.new self, self, "Deprecated"
+      types["Experimental"] = @experimental_annotation = AnnotationType.new self, self, "Experimental"
 
       define_crystal_constants
     end
@@ -451,7 +452,7 @@ module Crystal
                      packed_annotation thread_local_annotation no_inline_annotation
                      always_inline_annotation naked_annotation returns_twice_annotation
                      raises_annotation primitive_annotation call_convention_annotation
-                     flags_annotation link_annotation extern_annotation deprecated_annotation) %}
+                     flags_annotation link_annotation extern_annotation deprecated_annotation experimental_annotation) %}
       def {{name.id}}
         @{{name.id}}.not_nil!
       end

--- a/src/compiler/crystal/semantic/top_level_visitor.cr
+++ b/src/compiler/crystal/semantic/top_level_visitor.cr
@@ -1098,6 +1098,10 @@ class Crystal::TopLevelVisitor < Crystal::SemanticVisitor
         # arguments makes sense here.
         DeprecatedAnnotation.from(ann)
         yield annotation_type, ann
+      when @program.experimental_annotation
+        # ditto DeprecatedAnnotation
+        ExperimentalAnnotation.from(ann)
+        yield annotation_type, ann
       else
         yield annotation_type, ann
       end

--- a/src/compiler/crystal/tools/doc/generator.cr
+++ b/src/compiler/crystal/tools/doc/generator.cr
@@ -8,12 +8,13 @@ class Crystal::Doc::Generator
 
   # Adding a flag and associated css class will add support in parser
   FLAG_COLORS = {
-    "BUG"        => "red",
-    "DEPRECATED" => "red",
-    "FIXME"      => "yellow",
-    "NOTE"       => "purple",
-    "OPTIMIZE"   => "green",
-    "TODO"       => "orange",
+    "BUG"          => "red",
+    "DEPRECATED"   => "red",
+    "EXPERIMENTAL" => "lime",
+    "FIXME"        => "yellow",
+    "NOTE"         => "purple",
+    "OPTIMIZE"     => "green",
+    "TODO"         => "orange",
   }
   FLAGS = FLAG_COLORS.keys
 
@@ -306,7 +307,7 @@ class Crystal::Doc::Generator
   def summary(obj : Type | Method | Macro | Constant)
     doc = obj.doc
 
-    return if !doc && !obj.annotations(@program.deprecated_annotation)
+    return if !doc && !has_doc_annotations?(obj)
 
     summary obj, doc || ""
   end
@@ -325,9 +326,13 @@ class Crystal::Doc::Generator
   def doc(obj : Type | Method | Macro | Constant)
     doc = obj.doc
 
-    return if !doc && !obj.annotations(@program.deprecated_annotation)
+    return if !doc && !has_doc_annotations?(obj)
 
     doc obj, doc || ""
+  end
+
+  def has_doc_annotations?(obj)
+    obj.annotations(@program.deprecated_annotation) || obj.annotations(@program.experimental_annotation)
   end
 
   def doc(context, string)
@@ -378,6 +383,14 @@ class Crystal::Doc::Generator
           io << "\n\n" if first
           first = false
           io << "DEPRECATED: #{DeprecatedAnnotation.from(ann).message}\n\n"
+        end
+      end
+
+      if anns = context.annotations(@program.experimental_annotation)
+        anns.each do |ann|
+          io << "\n\n" if first
+          first = false
+          io << "EXPERIMENTAL: #{ExperimentalAnnotation.from(ann).message}\n\n"
         end
       end
     end

--- a/src/compiler/crystal/tools/doc/html/css/style.css
+++ b/src/compiler/crystal/tools/doc/html/css/style.css
@@ -459,6 +459,12 @@ span.flag.purple {
   border-color: #1F0B37;
 }
 
+span.flag.lime {
+  background-color: #a3ff00;
+  color: #222222;
+  border-color: #00ff1e;
+}
+
 .tooltip>span {
   position: absolute;
   opacity: 0;


### PR DESCRIPTION
The annotation can be used without args or with a single string argument (similar to Deprecated).

There is no semantics given to the annotation.

Eventually we can have a compiler flag that disables experimental (and maybe deprecated) features to stay in a strict version of the language/std-lib/shard.

For now is a way to document unstable features.