### PR TITLE
Skip no closure check for non-Crystal procs

### DIFF
--- a/spec/compiler/codegen/closure_spec.cr
+++ b/spec/compiler/codegen/closure_spec.cr
@@ -697,4 +697,35 @@ describe "Code gen: closure" do
       ))
     end
   end
+
+  it "allows passing an external function along" do
+    codegen(%(
+      lib LibC
+        fun exit(c : Int32) : NoReturn
+      end
+
+      def raise(a) : NoReturn
+        LibC.exit(1)
+      end
+
+      lib LibA
+        fun a(a : Void* -> Void*)
+      end
+
+      fun b(a : Void* -> Void*)
+        LibA.a(a)
+      end
+    ))
+
+    codegen(%(
+      lib LibFoo
+        struct S
+          callback : ->
+        end
+      end
+
+      s = LibFoo::S.new
+      s.callback = nil
+    ))
+  end
 end

--- a/spec/compiler/codegen/closure_spec.cr
+++ b/spec/compiler/codegen/closure_spec.cr
@@ -681,4 +681,20 @@ describe "Code gen: closure" do
       f1.call &+ f2.call
     ))
   end
+
+  it "ensures it can raise from the closure check" do
+    expect_raises(Exception, "::raise must be of NoReturn return type!") do
+      codegen(%(
+        def raise(m : String)
+        end
+
+        fun a(a : -> Int32)
+        end
+
+        value = 1
+        p = ->{ value }
+        a(p)
+      ))
+    end
+  end
 end

--- a/src/compiler/crystal/codegen/codegen.cr
+++ b/src/compiler/crystal/codegen/codegen.cr
@@ -1324,6 +1324,7 @@ module Crystal
         location = Location.new(@program.filename, 1, 1)
         call = Call.global("raise", StringLiteral.new("passing a closure to C is not allowed")).at(location)
         @program.visit_main call
+        call.raise "::raise must be of NoReturn return type!" unless call.type.is_a?(NoReturnType)
         call
       end
     end

--- a/src/compiler/crystal/codegen/codegen.cr
+++ b/src/compiler/crystal/codegen/codegen.cr
@@ -1531,10 +1531,12 @@ module Crystal
     end
 
     def check_proc_is_not_closure(value, type)
-      check_fun_name = "~check_proc_is_not_closure"
-      func = @main_mod.functions[check_fun_name]? || create_check_proc_is_not_closure_fun(check_fun_name)
-      func = check_main_fun check_fun_name, func
-      value = call func, [value] of LLVM::Value
+      if value.type == llvm_typer.proc_type
+        check_fun_name = "~check_proc_is_not_closure"
+        func = @main_mod.functions[check_fun_name]? || create_check_proc_is_not_closure_fun(check_fun_name)
+        func = check_main_fun check_fun_name, func
+        value = call func, [value] of LLVM::Value
+      end
       bit_cast value, llvm_proc_type(type)
     end
 


### PR DESCRIPTION
They can't have a closure anyways and more importantly are represented as a
single pointer. So the check could not even deconstruct them into two
pointers. This previously generated invalid code trying to pass the
function pointer type to the check function expecting the Crystal proc type

fixes #7279