### PR TITLE
Fix passing a function pointer to a proc argument

### DIFF
--- a/spec/compiler/codegen/cast_spec.cr
+++ b/spec/compiler/codegen/cast_spec.cr
@@ -411,4 +411,12 @@ describe "Code gen: cast" do
       x.foo
       )).to_i.should eq(1)
   end
+
+  it "casts from function pointer to proc" do
+    codegen(%(
+      fun a(a : Void* -> Void*)
+        Pointer(Proc((Void* -> Void*), Void*)).new(0_u64).value.call(a)
+      end
+    ))
+  end
 end

--- a/src/compiler/crystal/codegen/cast.cr
+++ b/src/compiler/crystal/codegen/cast.cr
@@ -549,6 +549,9 @@ class Crystal::CodeGenVisitor
 
     if to_type != from_type
       value = upcast_distinct(value, to_type, from_type)
+    elsif to_type.is_a?(ProcInstanceType) && value.type != llvm_typer.proc_type
+      value = bit_cast(value, llvm_context.void_pointer)
+      value = make_fun(to_type, value, llvm_context.void_pointer.null)
     end
     value
   end


### PR DESCRIPTION
Couldn't find an existing issue for this :)

Not sure this is the best place to do this conversion in the code, it does feel a bit out of place.

Maybe it's just a mistake that function pointers are typed as Proc and they should have their own Crystal type. Right now it's a bit weird that Proc's are sometimes generated as function pointers in LLVM and sometimes as `{i8*, i8*}`. I feel like this basically the origin of these bugs.