### PR TITLE
Rename CLI argument to json-config-url

### DIFF
--- a/man/crystal.1
+++ b/man/crystal.1
@@ -180,7 +180,7 @@ In case no default can be found, this option is mandatory.
 .It Fl -project-version Ar VERSION
 Set the project version. The default value is extracted from current git commit or shard.yml if available.
 In case no default can be found, this option is mandatory.
-.It Fl -json_config_url Ar URL
+.It Fl -json-config-url Ar URL
 Set the URL pointing to a config file (used for discovering versions).
 .It Fl o Ar DIR, Fl -output Ar DIR
 Set the output directory (default: ./docs).

--- a/src/compiler/crystal/command/docs.cr
+++ b/src/compiler/crystal/command/docs.cr
@@ -44,7 +44,7 @@ class Crystal::Command
         output_format = value
       end
 
-      opts.on("--json_config_url=URL", "Set the URL pointing to a config file (used for discovering versions)") do |value|
+      opts.on("--json-config-url=URL", "Set the URL pointing to a config file (used for discovering versions)") do |value|
         project_info.json_config_url = value
       end
 


### PR DESCRIPTION
All other CLI arguments use kebab-case, this keeps it consistent.

That argument has not been released yet, so we don't need to keep the old spelling as a fallback.