### PR TITLE
Implement File#fsync on Windows

### DIFF
--- a/src/crystal/system/win32/file.cr
+++ b/src/crystal/system/win32/file.cr
@@ -241,6 +241,8 @@ module Crystal::System::File
   end
 
   private def system_fsync(flush_metadata = true) : Nil
-    raise NotImplementedError.new("File#fsync")
+    if LibC._commit(fd) != 0
+      raise IO::Error.from_errno("Error syncing file")
+    end
   end
 end

--- a/src/file.cr
+++ b/src/file.cr
@@ -771,6 +771,9 @@ class File < IO::FileDescriptor
   # then the syscall *fdatasync* will be used and only data required for
   # subsequent data retrieval is flushed. Metadata such as modified time and
   # access time is not written.
+  #
+  # NOTE: Metadata is flushed even when *flush_metadata* is false on Windows
+  # and DragonFly BSD.
   def fsync(flush_metadata = true) : Nil
     flush
     system_fsync(flush_metadata)

--- a/src/lib_c/x86_64-windows-msvc/c/io.cr
+++ b/src/lib_c/x86_64-windows-msvc/c/io.cr
@@ -15,4 +15,5 @@ lib LibC
   fun _get_osfhandle(fd : Int) : IntPtrT
   fun _pipe(pfds : Int*, psize : UInt, textmode : Int) : Int
   fun _dup2(fd1 : Int, fd2 : Int) : Int
+  fun _commit(fd : Int) : Int
 end


### PR DESCRIPTION
This PR uses [`_commit`][] to implement `File#fsync` on Windows.

Metadata is also flushed as [`fsync`][].
* `_commit` calls [`FlushFileBuffers`][] internally. (I checked it by looking the source code of crt  installed with MSVC.)
* In [`CreateFileW`][] document:
  > To ensure that the metadata is flushed to disk, use the FlushFileBuffers function.

[`_commit`]: https://docs.microsoft.com/en-us/cpp/c-runtime-library/reference/commit
[`fsync`]: https://linux.die.net/man/2/fsync
[`FlushFileBuffers`]: https://docs.microsoft.com/en-us/windows/win32/api/fileapi/nf-fileapi-flushfilebuffers
[`CreateFileW`]: https://docs.microsoft.com/en-us/windows/win32/api/fileapi/nf-fileapi-createfilew
