### PR TITLE
Let `case when` be non-exhaustive, introduce `case in` as exhaustive

### DIFF
--- a/spec/compiler/formatter/formatter_spec.cr
+++ b/spec/compiler/formatter/formatter_spec.cr
@@ -542,6 +542,8 @@ describe Crystal::Formatter do
   assert_format "case\nend"
   assert_format "case\nelse\n  1\nend"
 
+  assert_format "case  1 \n in Int32 \n 3 \n end", "case 1\nin Int32\n  3\nend"
+
   assert_format <<-CODE
     case 0
     when 0 then 1; 2

--- a/spec/compiler/macro/macro_methods_spec.cr
+++ b/spec/compiler/macro/macro_methods_spec.cr
@@ -1990,7 +1990,7 @@ module Crystal
     end
 
     describe "case methods" do
-      case_node = Case.new(1.int32, [When.new([2.int32, 3.int32] of ASTNode, 4.int32)], 5.int32)
+      case_node = Case.new(1.int32, [When.new([2.int32, 3.int32] of ASTNode, 4.int32)], 5.int32, exhaustive: false)
 
       it "executes cond" do
         assert_macro "x", %({{x.cond}}), [case_node] of ASTNode, "1"

--- a/spec/compiler/macro/macro_methods_spec.cr
+++ b/spec/compiler/macro/macro_methods_spec.cr
@@ -1990,26 +1990,36 @@ module Crystal
     end
 
     describe "case methods" do
-      case_node = Case.new(1.int32, [When.new([2.int32, 3.int32] of ASTNode, 4.int32)], 5.int32, exhaustive: false)
+      describe "when" do
+        case_node = Case.new(1.int32, [When.new([2.int32, 3.int32] of ASTNode, 4.int32)], 5.int32, exhaustive: false)
 
-      it "executes cond" do
-        assert_macro "x", %({{x.cond}}), [case_node] of ASTNode, "1"
+        it "executes cond" do
+          assert_macro "x", %({{x.cond}}), [case_node] of ASTNode, "1"
+        end
+
+        it "executes whens" do
+          assert_macro "x", %({{x.whens}}), [case_node] of ASTNode, "[when 2, 3\n  4\n]"
+        end
+
+        it "executes when conds" do
+          assert_macro "x", %({{x.whens[0].conds}}), [case_node] of ASTNode, "[2, 3]"
+        end
+
+        it "executes when body" do
+          assert_macro "x", %({{x.whens[0].body}}), [case_node] of ASTNode, "4"
+        end
+
+        it "executes else" do
+          assert_macro "x", %({{x.else}}), [case_node] of ASTNode, "5"
+        end
       end
 
-      it "executes whens" do
-        assert_macro "x", %({{x.whens}}), [case_node] of ASTNode, "[when 2, 3\n  4\n]"
-      end
+      describe "in" do
+        case_node = Case.new(1.int32, [When.new([2.int32, 3.int32] of ASTNode, 4.int32)], 5.int32, exhaustive: true)
 
-      it "executes when conds" do
-        assert_macro "x", %({{x.whens[0].conds}}), [case_node] of ASTNode, "[2, 3]"
-      end
-
-      it "executes when body" do
-        assert_macro "x", %({{x.whens[0].body}}), [case_node] of ASTNode, "4"
-      end
-
-      it "executes else" do
-        assert_macro "x", %({{x.else}}), [case_node] of ASTNode, "5"
+        it "executes whens" do
+          assert_macro "x", %({{x.whens}}), [case_node] of ASTNode, "[in 2, 3\n  4\n]"
+        end
       end
     end
 

--- a/spec/compiler/normalize/case_spec.cr
+++ b/spec/compiler/normalize/case_spec.cr
@@ -6,103 +6,103 @@ describe "Normalize: case" do
   end
 
   it "normalizes case with var in cond" do
-    assert_expand_second "x = 1; case x; when 1; 'b'; else; end", "if 1 === x\n  'b'\nend"
+    assert_expand_second "x = 1; case x; when 1; 'b'; end", "if 1 === x\n  'b'\nend"
   end
 
   it "normalizes case with Path to is_a?" do
-    assert_expand_second "x = 1; case x; when Foo; 'b'; else; end", "if x.is_a?(Foo)\n  'b'\nend"
+    assert_expand_second "x = 1; case x; when Foo; 'b'; end", "if x.is_a?(Foo)\n  'b'\nend"
   end
 
   it "normalizes case with generic to is_a?" do
-    assert_expand_second "x = 1; case x; when Foo(T); 'b'; else; end", "if x.is_a?(Foo(T))\n  'b'\nend"
+    assert_expand_second "x = 1; case x; when Foo(T); 'b'; end", "if x.is_a?(Foo(T))\n  'b'\nend"
   end
 
   it "normalizes case with Path.class to is_a?" do
-    assert_expand_second "x = 1; case x; when Foo.class; 'b'; else; end", "if x.is_a?(Foo.class)\n  'b'\nend"
+    assert_expand_second "x = 1; case x; when Foo.class; 'b'; end", "if x.is_a?(Foo.class)\n  'b'\nend"
   end
 
   it "normalizes case with Generic.class to is_a?" do
-    assert_expand_second "x = 1; case x; when Foo(T).class; 'b'; else; end", "if x.is_a?(Foo(T).class)\n  'b'\nend"
+    assert_expand_second "x = 1; case x; when Foo(T).class; 'b'; end", "if x.is_a?(Foo(T).class)\n  'b'\nend"
   end
 
   it "normalizes case with many expressions in when" do
-    assert_expand_second "x = 1; case x; when 1, 2; 'b'; else; end", "if (1 === x) || (2 === x)\n  'b'\nend"
+    assert_expand_second "x = 1; case x; when 1, 2; 'b'; end", "if (1 === x) || (2 === x)\n  'b'\nend"
   end
 
   it "normalizes case with implicit call" do
-    assert_expand "case x; when .foo(1); 2; else; end", "__temp_1 = x\nif __temp_1.foo(1)\n  2\nend"
+    assert_expand "case x; when .foo(1); 2; end", "__temp_1 = x\nif __temp_1.foo(1)\n  2\nend"
   end
 
   it "normalizes case with implicit responds_to? (#3040)" do
-    assert_expand "case x; when .responds_to?(:foo); 2; else; end", "__temp_1 = x\nif __temp_1.responds_to?(:foo)\n  2\nend"
+    assert_expand "case x; when .responds_to?(:foo); 2; end", "__temp_1 = x\nif __temp_1.responds_to?(:foo)\n  2\nend"
   end
 
   it "normalizes case with implicit is_a? (#3040)" do
-    assert_expand "case x; when .is_a?(T); 2; else; end", "__temp_1 = x\nif __temp_1.is_a?(T)\n  2\nend"
+    assert_expand "case x; when .is_a?(T); 2; end", "__temp_1 = x\nif __temp_1.is_a?(T)\n  2\nend"
   end
 
   it "normalizes case with implicit as (#3040)" do
-    assert_expand "case x; when .as(T); 2; else; end", "__temp_1 = x\nif __temp_1.as(T)\n  2\nend"
+    assert_expand "case x; when .as(T); 2; end", "__temp_1 = x\nif __temp_1.as(T)\n  2\nend"
   end
 
   it "normalizes case with implicit as? (#3040)" do
-    assert_expand "case x; when .as?(T); 2; else; end", "__temp_1 = x\nif __temp_1.as?(T)\n  2\nend"
+    assert_expand "case x; when .as?(T); 2; end", "__temp_1 = x\nif __temp_1.as?(T)\n  2\nend"
   end
 
   it "normalizes case with implicit !" do
-    assert_expand "case x; when .!; 2; else; end", "__temp_1 = x\nif !__temp_1\n  2\nend"
+    assert_expand "case x; when .!; 2; end", "__temp_1 = x\nif !__temp_1\n  2\nend"
   end
 
   it "normalizes case with assignment" do
-    assert_expand "case x = 1; when 2; 3; else; end", "x = 1\nif 2 === x\n  3\nend"
+    assert_expand "case x = 1; when 2; 3; end", "x = 1\nif 2 === x\n  3\nend"
   end
 
   it "normalizes case with assignment wrapped by paren" do
-    assert_expand "case (x = 1); when 2; 3; else; end", "x = 1\nif 2 === x\n  3\nend"
+    assert_expand "case (x = 1); when 2; 3; end", "x = 1\nif 2 === x\n  3\nend"
   end
 
   it "normalizes case without value" do
-    assert_expand "case when 2; 3; when 4; 5; else; end", "if 2\n  3\nelse\n  if 4\n    5\n  end\nend"
+    assert_expand "case when 2; 3; when 4; 5; end", "if 2\n  3\nelse\n  if 4\n    5\n  end\nend"
   end
 
   it "normalizes case without value with many expressions in when" do
-    assert_expand "case when 2, 9; 3; when 4; 5; else; end", "if 2 || 9\n  3\nelse\n  if 4\n    5\n  end\nend"
+    assert_expand "case when 2, 9; 3; when 4; 5; end", "if 2 || 9\n  3\nelse\n  if 4\n    5\n  end\nend"
   end
 
   it "normalizes case with nil to is_a?" do
-    assert_expand_second "x = 1; case x; when nil; 'b'; else; end", "if x.is_a?(::Nil)\n  'b'\nend"
+    assert_expand_second "x = 1; case x; when nil; 'b'; end", "if x.is_a?(::Nil)\n  'b'\nend"
   end
 
   it "normalizes case with multiple expressions" do
-    assert_expand_second "x, y = 1, 2; case {x, y}; when {2, 3}; 4; else; end", "if (2 === x) && (3 === y)\n  4\nend"
+    assert_expand_second "x, y = 1, 2; case {x, y}; when {2, 3}; 4; end", "if (2 === x) && (3 === y)\n  4\nend"
   end
 
   it "normalizes case with multiple expressions and types" do
-    assert_expand_second "x, y = 1, 2; case {x, y}; when {Int32, Float64}; 4; else; end", "if x.is_a?(Int32) && y.is_a?(Float64)\n  4\nend"
+    assert_expand_second "x, y = 1, 2; case {x, y}; when {Int32, Float64}; 4; end", "if x.is_a?(Int32) && y.is_a?(Float64)\n  4\nend"
   end
 
   it "normalizes case with multiple expressions and implicit obj" do
-    assert_expand_second "x, y = 1, 2; case {x, y}; when {.foo, .bar}; 4; else; end", "if x.foo && y.bar\n  4\nend"
+    assert_expand_second "x, y = 1, 2; case {x, y}; when {.foo, .bar}; 4; end", "if x.foo && y.bar\n  4\nend"
   end
 
   it "normalizes case with multiple expressions and comma" do
-    assert_expand_second "x, y = 1, 2; case {x, y}; when {2, 3}, {4, 5}; 6; else; end", "if ((2 === x) && (3 === y)) || ((4 === x) && (5 === y))\n  6\nend"
+    assert_expand_second "x, y = 1, 2; case {x, y}; when {2, 3}, {4, 5}; 6; end", "if ((2 === x) && (3 === y)) || ((4 === x) && (5 === y))\n  6\nend"
   end
 
   it "normalizes case with multiple expressions with underscore" do
-    assert_expand_second "x, y = 1, 2; case {x, y}; when {2, _}; 4; else; end", "if 2 === x\n  4\nend"
+    assert_expand_second "x, y = 1, 2; case {x, y}; when {2, _}; 4; end", "if 2 === x\n  4\nend"
   end
 
   it "normalizes case with multiple expressions with all underscores" do
-    assert_expand_second "x, y = 1, 2; case {x, y}; when {_, _}; 4; else; end", "if true\n  4\nend"
+    assert_expand_second "x, y = 1, 2; case {x, y}; when {_, _}; 4; end", "if true\n  4\nend"
   end
 
   it "normalizes case with multiple expressions with all underscores twice" do
-    assert_expand_second "x, y = 1, 2; case {x, y}; when {_, _}, {_, _}; 4; else; end", "if true\n  4\nend"
+    assert_expand_second "x, y = 1, 2; case {x, y}; when {_, _}, {_, _}; 4; end", "if true\n  4\nend"
   end
 
   it "normalizes case with multiple expressions and non-tuple" do
-    assert_expand_second "x, y = 1, 2; case {x, y}; when 1; 4; else; end", "if 1 === {x, y}\n  4\nend"
+    assert_expand_second "x, y = 1, 2; case {x, y}; when 1; 4; end", "if 1 === {x, y}\n  4\nend"
   end
 
   it "normalizes case without when and else" do
@@ -119,5 +119,9 @@ describe "Normalize: case" do
 
   it "normalizes case without cond, when but else" do
     assert_expand "case; else; y; end", "y"
+  end
+
+  it "normalizes case with Path.class to is_a? (in)" do
+    assert_expand_second "x = 1; case x; in Foo.class; 'b'; end", "if x.is_a?(Foo.class)\n  'b'\nelse\n  raise \"unreachable\"\nend"
   end
 end

--- a/spec/compiler/parser/parser_spec.cr
+++ b/spec/compiler/parser/parser_spec.cr
@@ -1068,41 +1068,64 @@ module Crystal
     it_parses "require \"foo\"", Require.new("foo")
     it_parses "require \"foo\"; [1]", [Require.new("foo"), ([1.int32] of ASTNode).array]
 
-    it_parses "case 1; when 1; 2; else; 3; end", Case.new(1.int32, [When.new([1.int32] of ASTNode, 2.int32)], 3.int32)
-    it_parses "case 1; when 0, 1; 2; else; 3; end", Case.new(1.int32, [When.new([0.int32, 1.int32] of ASTNode, 2.int32)], 3.int32)
-    it_parses "case 1\nwhen 1\n2\nelse\n3\nend", Case.new(1.int32, [When.new([1.int32] of ASTNode, 2.int32)], 3.int32)
-    it_parses "case 1\nwhen 1\n2\nend", Case.new(1.int32, [When.new([1.int32] of ASTNode, 2.int32)])
-    it_parses "case / /; when / /; / /; else; / /; end", Case.new(regex(" "), [When.new([regex(" ")] of ASTNode, regex(" "))], regex(" "))
-    it_parses "case / /\nwhen / /\n/ /\nelse\n/ /\nend", Case.new(regex(" "), [When.new([regex(" ")] of ASTNode, regex(" "))], regex(" "))
+    it_parses "case 1; when 1; 2; else; 3; end", Case.new(1.int32, [When.new([1.int32] of ASTNode, 2.int32)], 3.int32, exhaustive: false)
+    it_parses "case 1; when 0, 1; 2; else; 3; end", Case.new(1.int32, [When.new([0.int32, 1.int32] of ASTNode, 2.int32)], 3.int32, exhaustive: false)
+    it_parses "case 1\nwhen 1\n2\nelse\n3\nend", Case.new(1.int32, [When.new([1.int32] of ASTNode, 2.int32)], 3.int32, exhaustive: false)
+    it_parses "case 1\nwhen 1\n2\nend", Case.new(1.int32, [When.new([1.int32] of ASTNode, 2.int32)], else: nil, exhaustive: false)
+    it_parses "case / /; when / /; / /; else; / /; end", Case.new(regex(" "), [When.new([regex(" ")] of ASTNode, regex(" "))], regex(" "), exhaustive: false)
+    it_parses "case / /\nwhen / /\n/ /\nelse\n/ /\nend", Case.new(regex(" "), [When.new([regex(" ")] of ASTNode, regex(" "))], regex(" "), exhaustive: false)
 
-    it_parses "case 1; when 1 then 2; else; 3; end", Case.new(1.int32, [When.new([1.int32] of ASTNode, 2.int32)], 3.int32)
-    it_parses "case 1; when x then 2; else; 3; end", Case.new(1.int32, [When.new(["x".call] of ASTNode, 2.int32)], 3.int32)
-    it_parses "case 1\nwhen 1\n2\nend\nif a\nend", [Case.new(1.int32, [When.new([1.int32] of ASTNode, 2.int32)]), If.new("a".call)]
-    it_parses "case\n1\nwhen 1\n2\nend\nif a\nend", [Case.new(1.int32, [When.new([1.int32] of ASTNode, 2.int32)]), If.new("a".call)]
+    it_parses "case 1; when 1 then 2; else; 3; end", Case.new(1.int32, [When.new([1.int32] of ASTNode, 2.int32)], 3.int32, exhaustive: false)
+    it_parses "case 1; when x then 2; else; 3; end", Case.new(1.int32, [When.new(["x".call] of ASTNode, 2.int32)], 3.int32, exhaustive: false)
+    it_parses "case 1\nwhen 1\n2\nend\nif a\nend", [Case.new(1.int32, [When.new([1.int32] of ASTNode, 2.int32)], else: nil, exhaustive: false), If.new("a".call)]
+    it_parses "case\n1\nwhen 1\n2\nend\nif a\nend", [Case.new(1.int32, [When.new([1.int32] of ASTNode, 2.int32)], else: nil, exhaustive: false), If.new("a".call)]
 
-    it_parses "case 1\nwhen .foo\n2\nend", Case.new(1.int32, [When.new([Call.new(ImplicitObj.new, "foo")] of ASTNode, 2.int32)])
-    it_parses "case 1\nwhen .responds_to?(:foo)\n2\nend", Case.new(1.int32, [When.new([RespondsTo.new(ImplicitObj.new, "foo")] of ASTNode, 2.int32)])
-    it_parses "case 1\nwhen .is_a?(T)\n2\nend", Case.new(1.int32, [When.new([IsA.new(ImplicitObj.new, "T".path)] of ASTNode, 2.int32)])
-    it_parses "case 1\nwhen .as(T)\n2\nend", Case.new(1.int32, [When.new([Cast.new(ImplicitObj.new, "T".path)] of ASTNode, 2.int32)])
-    it_parses "case 1\nwhen .as?(T)\n2\nend", Case.new(1.int32, [When.new([NilableCast.new(ImplicitObj.new, "T".path)] of ASTNode, 2.int32)])
-    it_parses "case 1\nwhen .!()\n2\nend", Case.new(1.int32, [When.new([Not.new(ImplicitObj.new)] of ASTNode, 2.int32)])
-    it_parses "case when 1\n2\nend", Case.new(nil, [When.new([1.int32] of ASTNode, 2.int32)])
-    it_parses "case \nwhen 1\n2\nend", Case.new(nil, [When.new([1.int32] of ASTNode, 2.int32)])
-    it_parses "case {1, 2}\nwhen {3, 4}\n5\nend", Case.new(TupleLiteral.new([1.int32, 2.int32] of ASTNode), [When.new([TupleLiteral.new([3.int32, 4.int32] of ASTNode)] of ASTNode, 5.int32)])
-    it_parses "case {1, 2}\nwhen {3, 4}, {5, 6}\n7\nend", Case.new(TupleLiteral.new([1.int32, 2.int32] of ASTNode), [When.new([TupleLiteral.new([3.int32, 4.int32] of ASTNode), TupleLiteral.new([5.int32, 6.int32] of ASTNode)] of ASTNode, 7.int32)])
-    it_parses "case {1, 2}\nwhen {.foo, .bar}\n5\nend", Case.new(TupleLiteral.new([1.int32, 2.int32] of ASTNode), [When.new([TupleLiteral.new([Call.new(ImplicitObj.new, "foo"), Call.new(ImplicitObj.new, "bar")] of ASTNode)] of ASTNode, 5.int32)])
-    it_parses "case {1, 2}\nwhen foo\n5\nend", Case.new(TupleLiteral.new([1.int32, 2.int32] of ASTNode), [When.new(["foo".call] of ASTNode, 5.int32)])
-    it_parses "case a\nwhen b\n1 / 2\nelse\n1 / 2\nend", Case.new("a".call, [When.new(["b".call] of ASTNode, Call.new(1.int32, "/", 2.int32))], Call.new(1.int32, "/", 2.int32))
-    it_parses "case a\nwhen b\n/ /\n\nelse\n/ /\nend", Case.new("a".call, [When.new(["b".call] of ASTNode, RegexLiteral.new(StringLiteral.new(" ")))], RegexLiteral.new(StringLiteral.new(" ")))
+    it_parses "case 1\nwhen .foo\n2\nend", Case.new(1.int32, [When.new([Call.new(ImplicitObj.new, "foo")] of ASTNode, 2.int32)], else: nil, exhaustive: false)
+    it_parses "case 1\nwhen .responds_to?(:foo)\n2\nend", Case.new(1.int32, [When.new([RespondsTo.new(ImplicitObj.new, "foo")] of ASTNode, 2.int32)], else: nil, exhaustive: false)
+    it_parses "case 1\nwhen .is_a?(T)\n2\nend", Case.new(1.int32, [When.new([IsA.new(ImplicitObj.new, "T".path)] of ASTNode, 2.int32)], else: nil, exhaustive: false)
+    it_parses "case 1\nwhen .as(T)\n2\nend", Case.new(1.int32, [When.new([Cast.new(ImplicitObj.new, "T".path)] of ASTNode, 2.int32)], else: nil, exhaustive: false)
+    it_parses "case 1\nwhen .as?(T)\n2\nend", Case.new(1.int32, [When.new([NilableCast.new(ImplicitObj.new, "T".path)] of ASTNode, 2.int32)], else: nil, exhaustive: false)
+    it_parses "case 1\nwhen .!()\n2\nend", Case.new(1.int32, [When.new([Not.new(ImplicitObj.new)] of ASTNode, 2.int32)], else: nil, exhaustive: false)
+    it_parses "case when 1\n2\nend", Case.new(nil, [When.new([1.int32] of ASTNode, 2.int32)], else: nil, exhaustive: false)
+    it_parses "case \nwhen 1\n2\nend", Case.new(nil, [When.new([1.int32] of ASTNode, 2.int32)], else: nil, exhaustive: false)
+    it_parses "case {1, 2}\nwhen {3, 4}\n5\nend", Case.new(TupleLiteral.new([1.int32, 2.int32] of ASTNode), [When.new([TupleLiteral.new([3.int32, 4.int32] of ASTNode)] of ASTNode, 5.int32)], else: nil, exhaustive: false)
+    it_parses "case {1, 2}\nwhen {3, 4}, {5, 6}\n7\nend", Case.new(TupleLiteral.new([1.int32, 2.int32] of ASTNode), [When.new([TupleLiteral.new([3.int32, 4.int32] of ASTNode), TupleLiteral.new([5.int32, 6.int32] of ASTNode)] of ASTNode, 7.int32)], else: nil, exhaustive: false)
+    it_parses "case {1, 2}\nwhen {.foo, .bar}\n5\nend", Case.new(TupleLiteral.new([1.int32, 2.int32] of ASTNode), [When.new([TupleLiteral.new([Call.new(ImplicitObj.new, "foo"), Call.new(ImplicitObj.new, "bar")] of ASTNode)] of ASTNode, 5.int32)], else: nil, exhaustive: false)
+    it_parses "case {1, 2}\nwhen foo\n5\nend", Case.new(TupleLiteral.new([1.int32, 2.int32] of ASTNode), [When.new(["foo".call] of ASTNode, 5.int32)], else: nil, exhaustive: false)
+    it_parses "case a\nwhen b\n1 / 2\nelse\n1 / 2\nend", Case.new("a".call, [When.new(["b".call] of ASTNode, Call.new(1.int32, "/", 2.int32))], Call.new(1.int32, "/", 2.int32), exhaustive: false)
+    it_parses "case a\nwhen b\n/ /\n\nelse\n/ /\nend", Case.new("a".call, [When.new(["b".call] of ASTNode, RegexLiteral.new(StringLiteral.new(" ")))], RegexLiteral.new(StringLiteral.new(" ")), exhaustive: false)
     assert_syntax_error "case {1, 2}; when {3}; 4; end", "wrong number of tuple elements (given 1, expected 2)", 1, 19
-    it_parses "case 1; end", [Case.new(1.int32, [] of When)]
-    it_parses "case foo; end", [Case.new("foo".call, [] of When)]
-    it_parses "case\nend", [Case.new(nil, [] of When)]
-    it_parses "case;end", [Case.new(nil, [] of When)]
-    it_parses "case 1\nelse\n2\nend", [Case.new(1.int32, [] of When, 2.int32)]
-    it_parses "a = 1\ncase 1\nwhen a then 1\nend", [Assign.new("a".var, 1.int32), Case.new(1.int32, [When.new(["a".var] of ASTNode, 1.int32)])] of ASTNode
-    it_parses "case\nwhen true\n1\nend", [Case.new(nil, [When.new([true.bool] of ASTNode, 1.int32)] of When)]
-    it_parses "case;when true;1;end", [Case.new(nil, [When.new([true.bool] of ASTNode, 1.int32)] of When)]
+    it_parses "case 1; end", Case.new(1.int32, [] of When, else: nil, exhaustive: false)
+    it_parses "case foo; end", Case.new("foo".call, [] of When, else: nil, exhaustive: false)
+    it_parses "case\nend", Case.new(nil, [] of When, else: nil, exhaustive: false)
+    it_parses "case;end", Case.new(nil, [] of When, else: nil, exhaustive: false)
+    it_parses "case 1\nelse\n2\nend", Case.new(1.int32, [] of When, 2.int32, exhaustive: false)
+    it_parses "a = 1\ncase 1\nwhen a then 1\nend", [Assign.new("a".var, 1.int32), Case.new(1.int32, [When.new(["a".var] of ASTNode, 1.int32)], else: nil, exhaustive: false)] of ASTNode
+    it_parses "case\nwhen true\n1\nend", Case.new(nil, [When.new([true.bool] of ASTNode, 1.int32)] of When, else: nil, exhaustive: false)
+    it_parses "case;when true;1;end", Case.new(nil, [When.new([true.bool] of ASTNode, 1.int32)] of When, else: nil, exhaustive: false)
+
+    it_parses "case 1\nin Int32; 2; end", Case.new(1.int32, [When.new(["Int32".path] of ASTNode, 2.int32)], else: nil, exhaustive: true)
+    it_parses "case 1\nin Int32.class; 2; end", Case.new(1.int32, [When.new([Call.new("Int32".path, "class")] of ASTNode, 2.int32)], else: nil, exhaustive: true)
+    it_parses "case 1\nin Foo(Int32); 2; end", Case.new(1.int32, [When.new([Generic.new("Foo".path, ["Int32".path] of ASTNode)] of ASTNode, 2.int32)], else: nil, exhaustive: true)
+    it_parses "case 1\nin false; 2; end", Case.new(1.int32, [When.new([false.bool] of ASTNode, 2.int32)], else: nil, exhaustive: true)
+    it_parses "case 1\nin true; 2; end", Case.new(1.int32, [When.new([true.bool] of ASTNode, 2.int32)], else: nil, exhaustive: true)
+    it_parses "case 1\nin nil; 2; end", Case.new(1.int32, [When.new([NilLiteral.new] of ASTNode, 2.int32)], else: nil, exhaustive: true)
+    it_parses "case 1\nin .bar?; 2; end", Case.new(1.int32, [When.new([Call.new(ImplicitObj.new, "bar?")] of ASTNode, 2.int32)], else: nil, exhaustive: true)
+
+    it_parses "case {1}\nin {Int32}; 2; end", Case.new(TupleLiteral.new([1.int32] of ASTNode), [When.new([TupleLiteral.new(["Int32".path] of ASTNode)] of ASTNode, 2.int32)], else: nil, exhaustive: true)
+    it_parses "case {1}\nin {Int32.class}; 2; end", Case.new(TupleLiteral.new([1.int32] of ASTNode), [When.new([TupleLiteral.new([Call.new("Int32".path, "class")] of ASTNode)] of ASTNode, 2.int32)], else: nil, exhaustive: true)
+    it_parses "case {1}\nin {Foo(Int32)}; 2; end", Case.new(TupleLiteral.new([1.int32] of ASTNode), [When.new([TupleLiteral.new([Generic.new("Foo".path, ["Int32".path] of ASTNode)] of ASTNode)] of ASTNode, 2.int32)], else: nil, exhaustive: true)
+    it_parses "case {1}\nin {false}; 2; end", Case.new(TupleLiteral.new([1.int32] of ASTNode), [When.new([TupleLiteral.new([false.bool] of ASTNode)] of ASTNode, 2.int32)], else: nil, exhaustive: true)
+    it_parses "case {1}\nin {true}; 2; end", Case.new(TupleLiteral.new([1.int32] of ASTNode), [When.new([TupleLiteral.new([true.bool] of ASTNode)] of ASTNode, 2.int32)], else: nil, exhaustive: true)
+    it_parses "case {1}\nin {nil}; 2; end", Case.new(TupleLiteral.new([1.int32] of ASTNode), [When.new([TupleLiteral.new([NilLiteral.new] of ASTNode)] of ASTNode, 2.int32)], else: nil, exhaustive: true)
+    it_parses "case {1}\nin {.bar?}; 2; end", Case.new(TupleLiteral.new([1.int32] of ASTNode), [When.new([TupleLiteral.new([Call.new(ImplicitObj.new, "bar?")] of ASTNode)] of ASTNode, 2.int32)], else: nil, exhaustive: true)
+    it_parses "case {1}\nin {_}; 2; end", Case.new(TupleLiteral.new([1.int32] of ASTNode), [When.new([TupleLiteral.new([Underscore.new] of ASTNode)] of ASTNode, 2.int32)], else: nil, exhaustive: true)
+
+    assert_syntax_error "case 1\nin Int32; 2; when 2", "expected 'in', not 'when'"
+    assert_syntax_error "case 1\nwhen Int32; 2; in 2", "expected 'when', not 'in'"
+    assert_syntax_error "case 1\nin Int32; 2; else", "exhaustive case (case ... in) doesn't allow an 'else'"
+    assert_syntax_error "case 1\nin 1; 2", "expression of exhaustive case (case ... in) must be a constant (like `IO::Memory`), a generic (like `Array(Int32)`) a bool literal (true or false), a nil literal (nil) or a question method (like `.red?`)"
+    assert_syntax_error "case 1\nin _;", "'when _' is not supported"
 
     it_parses "select\nwhen foo\n2\nend", Select.new([Select::When.new("foo".call, 2.int32)])
     it_parses "select\nwhen foo\n2\nwhen bar\n4\nend", Select.new([Select::When.new("foo".call, 2.int32), Select::When.new("bar".call, 4.int32)])
@@ -1475,7 +1498,7 @@ module Crystal
     it_parses "call(foo : A, end : B)", Call.new(nil, "call", [TypeDeclaration.new("foo".var, "A".path), TypeDeclaration.new("end".var, "B".path)] of ASTNode)
     it_parses "call foo : A, end : B", Call.new(nil, "call", [TypeDeclaration.new("foo".var, "A".path), TypeDeclaration.new("end".var, "B".path)] of ASTNode)
 
-    it_parses "case :foo; when :bar; 2; end", Case.new("foo".symbol, [When.new(["bar".symbol] of ASTNode, 2.int32)])
+    it_parses "case :foo; when :bar; 2; end", Case.new("foo".symbol, [When.new(["bar".symbol] of ASTNode, 2.int32)], else: nil, exhaustive: false)
 
     it_parses "Foo.foo(count: 3).bar { }", Call.new(Call.new("Foo".path, "foo", named_args: [NamedArgument.new("count", 3.int32)]), "bar", block: Block.new)
 

--- a/spec/compiler/parser/to_s_spec.cr
+++ b/spec/compiler/parser/to_s_spec.cr
@@ -132,6 +132,7 @@ describe "ASTNode#to_s" do
   expect_to_s %((1 <= 2) <= 3)
   expect_to_s %(1 <= (2 <= 3))
   expect_to_s %(case 1; when .foo?; 2; end), %(case 1\nwhen .foo?\n  2\nend)
+  expect_to_s %(case 1; in .foo?; 2; end), %(case 1\nin .foo?\n  2\nend)
   expect_to_s %({(1 + 2)})
   expect_to_s %({foo: (1 + 2)})
   expect_to_s %q("#{(1 + 2)}")

--- a/spec/compiler/semantic/case_spec.cr
+++ b/spec/compiler/semantic/case_spec.cr
@@ -1,48 +1,75 @@
 require "../../spec_helper"
 
 describe "semantic: case" do
-  it "checks exhaustiveness of union type" do
-    assert_error %(
+  it "doesn't check ehxaustiveness when using 'when'" do
+    assert_no_errors %(
         a = 1 || nil
         case a
         when Int32
         end
-      ),
-      "case is not exhaustive.\n\nMissing types:\n - Nil"
+      )
   end
 
   it "checks exhaustiveness of single type" do
     assert_error %(
         case 1
-        when Nil
+        in Nil
         end
       ),
       "case is not exhaustive.\n\nMissing types:\n - Int32"
+  end
+
+  it "checks exhaustiveness of single type (T.class)" do
+    assert_no_errors %(
+        case Int32
+        in Int32.class
+        end
+      )
+  end
+
+  it "checks exhaustiveness of single type (Foo(T).class)" do
+    assert_no_errors %(
+        class Foo(T)
+        end
+
+        case Foo(Int32)
+        in Foo(Int32).class
+        end
+      )
+  end
+
+  it "checks exhaustiveness of single type (generic)" do
+    assert_no_errors %(
+        class Foo(T)
+        end
+
+        case Foo(Int32).new
+        in Foo(Int32)
+        end
+      )
+  end
+
+  it "errors if casing against a constant" do
+    assert_error %(
+        #{bool_case_eq}
+
+        FOO = false
+
+        case true
+        in FOO
+        end
+      ),
+      "can't use constant values in exhaustive case, only constant types"
   end
 
   it "covers all types" do
     assert_no_errors %(
         a = 1 || nil
         case a
-        when Int32
-        when Nil
+        in Int32
+        in Nil
         end
       )
-  end
-
-  it "can't prove exhaustiveness" do
-    assert_error %(
-        struct Int32
-          def ===(other)
-            true
-          end
-        end
-
-        case 1
-        when 2
-        end
-      ),
-      "can't prove case is exhaustive.\n\nPlease add an `else` clause."
   end
 
   it "checks exhaustiveness of bool type (missing true)" do
@@ -50,7 +77,7 @@ describe "semantic: case" do
         #{bool_case_eq}
 
         case false
-        when false
+        in false
         end
       ),
       "case is not exhaustive.\n\nMissing cases:\n - true"
@@ -61,7 +88,7 @@ describe "semantic: case" do
         #{bool_case_eq}
 
         case false
-        when true
+        in true
         end
       ),
       "case is not exhaustive.\n\nMissing cases:\n - false"
@@ -79,7 +106,7 @@ describe "semantic: case" do
 
         e = Color::Red
         case e
-        when .red?
+        in .red?
         end
       ),
       "case is not exhaustive for enum Color.\n\nMissing members:\n - Green\n - Blue"
@@ -97,7 +124,7 @@ describe "semantic: case" do
 
         e = Color::Red
         case e
-        when Color::Red
+        in Color::Red
         end
       ),
       "case is not exhaustive for enum Color.\n\nMissing members:\n - Green\n - Blue"
@@ -115,9 +142,9 @@ describe "semantic: case" do
 
         e = Color::Red
         case e
-        when .red?
-        when .green?
-        when .blue?
+        in .red?
+        in .green?
+        in .blue?
         end
       )
   end
@@ -137,9 +164,9 @@ describe "semantic: case" do
         end
 
         case foo
-        when .red?
-        when .green?
-        when .blue?
+        in .red?
+        in .green?
+        in .blue?
         end
       )
   end
@@ -149,9 +176,9 @@ describe "semantic: case" do
         #{bool_case_eq}
 
         case 1 || true
-        when Int32
-        when true
-        when false
+        in Int32
+        in true
+        in false
         end
       )
   end
@@ -166,13 +193,13 @@ describe "semantic: case" do
 
         a = 1 || Foo.new || Bar.new
         case a
-        when Foo
+        in Foo
         end
       ),
       "case is not exhaustive.\n\nMissing types:\n - Int32"
   end
 
-  it "checks exhaustiveness, covers when base type covers" do
+  it "checks exhaustiveness, covers in base type covers" do
     assert_no_errors %(
         class Foo
         end
@@ -182,19 +209,19 @@ describe "semantic: case" do
 
         a = Bar.new
         case a
-        when Foo
+        in Foo
         end
       )
   end
 
-  it "checks exhaustiveness, covers when base type covers (generic type)" do
+  it "checks exhaustiveness, covers in base type covers (generic type)" do
     assert_no_errors %(
         class Foo(T)
         end
 
         a = Foo(Int32).new
         case a
-        when Foo
+        in Foo
         end
       )
   end
@@ -208,7 +235,7 @@ describe "semantic: case" do
         end
 
         case nil
-        when nil
+        in nil
         end
       )
   end
@@ -223,21 +250,13 @@ describe "semantic: case" do
 
         a = 1 || nil
         case a
-        when nil
-        when Int32
+        in nil
+        in Int32
         end
       )
   end
 
-  it "never warns on condless case without else" do
-    assert_no_errors %(
-        case
-        when 1 == 2
-        end
-      )
-  end
-
-  it "always requires an else for Flags enum (no coverage)" do
+  it "can't prove case is exhaustive for @[Flags] enum" do
     assert_error %(
         struct Enum
           def includes?(other : self)
@@ -254,13 +273,13 @@ describe "semantic: case" do
 
         e = Color::Red
         case e
-        when .red?
+        in .red?
         end
       ),
-      "can't prove case is exhaustive.\n\nPlease add an `else` clause."
+      "can't prove case is exhaustive for @[Flags] enum Color (@[Flags] enums can't be exhaustively checked)"
   end
 
-  it "always requires an else for Flags enum (all members covered but doesn't count)" do
+  it "can't prove case is exhaustive for @[Flags] enum (tuple case)" do
     assert_error %(
         struct Enum
           def includes?(other : self)
@@ -276,13 +295,11 @@ describe "semantic: case" do
         end
 
         e = Color::Red
-        case e
-        when .red?
-        when .green?
-        when .blue?
+        case {e}
+        in {.red?}
         end
       ),
-      "can't prove case is exhaustive.\n\nPlease add an `else` clause."
+      "can't prove case is exhaustive for @[Flags] enum Color (@[Flags] enums can't be exhaustively checked)"
   end
 
   it "checks exhaustiveness of enum combined with another type" do
@@ -297,8 +314,8 @@ describe "semantic: case" do
 
         e = Color::Red || 1
         case e
-        when Int32
-        when .red?
+        in Int32
+        in .red?
         end
       ),
       "case is not exhaustive for enum Color.\n\nMissing members:\n - Green\n - Blue"
@@ -310,7 +327,7 @@ describe "semantic: case" do
 
         e = 1 || true
         case e
-        when true
+        in true
         end
       ),
       "case is not exhaustive.\n\nMissing cases:\n - false\n - Int32"
@@ -322,10 +339,10 @@ describe "semantic: case" do
         b = 1 || 'a'
 
         case {a, b}
-        when {Int32, Char}
-        when {Int32, Int32}
-        when {Char, Int32}
-        when {Char, Char}
+        in {Int32, Char}
+        in {Int32, Int32}
+        in {Char, Int32}
+        in {Char, Char}
         end
       )
   end
@@ -335,9 +352,9 @@ describe "semantic: case" do
         a = 1 || 'a'
 
         case {a, a}
-        when {Int32, Char}
-        when {Int32, Int32}
-        when {Char, Char}
+        in {Int32, Char}
+        in {Int32, Int32}
+        in {Char, Char}
         end
       ),
       "case is not exhaustive.\n\nMissing cases:\n - {Char, Int32}"
@@ -348,12 +365,12 @@ describe "semantic: case" do
         a = 1 || 'a'
 
         case {a, a, a}
-        when {Int32, Int32, Int32}
-        when {Int32, Char, Int32}
-        when {Int32, Char, Char}
-        when {Char, Int32, Int32}
-        when {Char, Char, Int32}
-        when {Char, Char, Char}
+        in {Int32, Int32, Int32}
+        in {Int32, Char, Int32}
+        in {Int32, Char, Char}
+        in {Char, Int32, Int32}
+        in {Char, Char, Int32}
+        in {Char, Char, Char}
         end
       ),
       "case is not exhaustive.\n\nMissing cases:\n - {Char, Int32, Char}\n - {Int32, Int32, Char}"
@@ -364,7 +381,7 @@ describe "semantic: case" do
         #{bool_case_eq}
 
         case {true, 'a'}
-        when {true, Char}
+        in {true, Char}
         end
       ),
       "case is not exhaustive.\n\nMissing cases:\n - {false, Char}"
@@ -381,8 +398,8 @@ describe "semantic: case" do
         end
 
         case {Color::Red, 'a'}
-        when {.red?, Char}
-        when {.blue?, Char}
+        in {.red?, Char}
+        in {.blue?, Char}
         end
       ),
       "case is not exhaustive.\n\nMissing cases:\n - {Color::Green, Char}"
@@ -393,7 +410,7 @@ describe "semantic: case" do
         a = 1 || 'a'
 
         case {a, a}
-        when {_, Int32}
+        in {_, Int32}
         end
       ),
       "case is not exhaustive.\n\nMissing cases:\n - {Char, Char}\n - {Int32, Char}"
@@ -404,7 +421,7 @@ describe "semantic: case" do
         a = 1 || 'a'
 
         case {a, a}
-        when {Int32, _}
+        in {Int32, _}
         end
       ),
       "case is not exhaustive.\n\nMissing cases:\n - {Char, Char}\n - {Char, Int32}"
@@ -415,7 +432,7 @@ describe "semantic: case" do
         #{bool_case_eq}
 
         case {true, 1 || 'a'}
-        when {_, Int32}
+        in {_, Int32}
         end
       ),
       "case is not exhaustive.\n\nMissing cases:\n - {Bool, Char}"
@@ -426,8 +443,8 @@ describe "semantic: case" do
         #{bool_case_eq}
 
         case {true, 1 || 'a'}
-        when {_, Int32}
-        when {false, Char}
+        in {_, Int32}
+        in {false, Char}
         end
       ),
       "case is not exhaustive.\n\nMissing cases:\n - {true, Char}"
@@ -438,7 +455,7 @@ describe "semantic: case" do
         #{bool_case_eq}
 
         case {1 || 'a', true}
-        when {Int32, _}
+        in {Int32, _}
         end
       ),
       "case is not exhaustive.\n\nMissing cases:\n - {Char, Bool}"
@@ -449,8 +466,8 @@ describe "semantic: case" do
         #{bool_case_eq}
 
         case {1 || 'a', true}
-        when {Int32, _}
-        when {Char, false}
+        in {Int32, _}
+        in {Char, false}
         end
       ),
       "case is not exhaustive.\n\nMissing cases:\n - {Char, true}"
@@ -467,7 +484,7 @@ describe "semantic: case" do
         end
 
         case {Color::Red, 1 || 'a'}
-        when {_, Int32}
+        in {_, Int32}
         end
       ),
       "case is not exhaustive.\n\nMissing cases:\n - {Color, Char}"
@@ -484,8 +501,8 @@ describe "semantic: case" do
         end
 
         case {Color::Red, 1 || 'a'}
-        when {_, Int32}
-        when {.blue?, Char}
+        in {_, Int32}
+        in {.blue?, Char}
         end
       ),
       "case is not exhaustive.\n\nMissing cases:\n - {Color::Red, Char}\n - {Color::Green, Char}"
@@ -502,7 +519,7 @@ describe "semantic: case" do
         end
 
         case {1 || 'a', Color::Red}
-        when {Int32, _}
+        in {Int32, _}
         end
       ),
       "case is not exhaustive.\n\nMissing cases:\n - {Char, Color}"
@@ -519,8 +536,8 @@ describe "semantic: case" do
         end
 
         case {1 || 'a', Color::Red}
-        when {Int32, _}
-        when {Char, .blue?}
+        in {Int32, _}
+        in {Char, .blue?}
         end
       ),
       "case is not exhaustive.\n\nMissing cases:\n - {Char, Color::Red}\n - {Char, Color::Green}"
@@ -537,10 +554,10 @@ describe "semantic: case" do
         foo = 1
 
         case {foo.bar, foo.bar}
-        when {Int32, Char}
-        when {Int32, Int32}
-        when {Char, Int32}
-        when {Char, Char}
+        in {Int32, Char}
+        in {Int32, Int32}
+        in {Char, Int32}
+        in {Char, Char}
         end
       )
   end

--- a/spec/compiler/semantic/case_spec.cr
+++ b/spec/compiler/semantic/case_spec.cr
@@ -258,6 +258,8 @@ describe "semantic: case" do
 
   it "can't prove case is exhaustive for @[Flags] enum" do
     assert_error %(
+        #{enum_eq}
+
         struct Enum
           def includes?(other : self)
             false
@@ -276,11 +278,39 @@ describe "semantic: case" do
         in .red?
         end
       ),
-      "can't prove case is exhaustive for @[Flags] enum Color (@[Flags] enums can't be exhaustively checked)"
+      <<-ERROR
+      case is not exhaustive.
+
+      Missing cases:
+       - Color
+
+      Note that @[Flags] enum can't be proved to be exhaustive by matching against enum members.
+      In particular, the enum Color can't be proved to be exhaustive like that.
+      ERROR
   end
 
-  it "can't prove case is exhaustive for @[Flags] enum (tuple case)" do
+  it "can prove case is exhaustive for @[Flags] enum when matching type" do
+    assert_no_errors %(
+        require "prelude"
+
+        @[Flags]
+        enum Color
+          Red
+          Green
+          Blue
+        end
+
+        e = Color::Red
+        case e
+        in Color
+        end
+      )
+  end
+
+  it "can't prove case is exhaustive for @[Flags] enum, tuple case" do
     assert_error %(
+        #{enum_eq}
+
         struct Enum
           def includes?(other : self)
             false
@@ -299,7 +329,15 @@ describe "semantic: case" do
         in {.red?}
         end
       ),
-      "can't prove case is exhaustive for @[Flags] enum Color (@[Flags] enums can't be exhaustively checked)"
+      <<-ERROR
+      case is not exhaustive.
+
+      Missing cases:
+       - {Color}
+
+      Note that @[Flags] enum can't be proved to be exhaustive by matching against enum members.
+      In particular, the enum Color can't be proved to be exhaustive like that.
+      ERROR
   end
 
   it "checks exhaustiveness of enum combined with another type" do

--- a/src/compiler/crystal/semantic/cleanup_transformer.cr
+++ b/src/compiler/crystal/semantic/cleanup_transformer.cr
@@ -172,10 +172,10 @@ module Crystal
     end
 
     def transform(node : Case)
-      @exhaustiveness_checker.check(node)
+      @exhaustiveness_checker.check(node) if node.exhaustive?
 
       if expanded = node.expanded
-        unless node.else
+        if node.exhaustive?
           replace_unreachable_if_needed(node, expanded)
         end
 
@@ -188,8 +188,7 @@ module Crystal
     # If any of the types checked in `case` is an enum, it can happen that
     # the unreachable can be reached by doing `SomeEnum.new(some_value)`.
     # In that case we replace the Unreachable node with `raise "..."`.
-    # In the future we should disallow creating such values unless the
-    # enum is marked as "open".
+    # In the future we should disallow creating such values.
     def replace_unreachable_if_needed(node, expanded)
       cond = node.cond
       return unless cond

--- a/src/compiler/crystal/semantic/exhaustiveness_checker.cr
+++ b/src/compiler/crystal/semantic/exhaustiveness_checker.cr
@@ -3,13 +3,7 @@ struct Crystal::ExhaustivenessChecker
   end
 
   def check(node : Case)
-    # If there's an else clause we don't need to check anything
-    return if node.else
-
-    cond = node.cond
-
-    # No condition means it's just like a series of if/else
-    return unless cond
+    cond = node.cond.not_nil!
 
     if cond.is_a?(TupleLiteral)
       check_tuple_exp(node, cond)
@@ -33,16 +27,15 @@ struct Crystal::ExhaustivenessChecker
     # Compute all the targets that we must cover
     targets = cond_types.map { |cond_type| compute_target(cond_type) }
 
+    # Is any type a @[Flags] enum?
+    cond_types.each do |type|
+      if type.is_a?(EnumType) && type.flags?
+        cond.raise "can't prove case is exhaustive for @[Flags] enum #{type} (@[Flags] enums can't be exhaustively checked)"
+      end
+    end
+
     # Are all patterns Path types?
     all_patterns_are_types = true
-
-    # Are all patterns things that we can handle?
-    # For example an integer literal is something that we don't
-    # take into account for exhaustiveness.
-    all_provable_patterns = true
-
-    # Is any type a @[Flags] enum?
-    has_flags_enum = cond_types.any? { |type| type.is_a?(EnumType) && type.flags? }
 
     # Start checking each `when`...
     node.whens.each do |a_when|
@@ -53,11 +46,7 @@ struct Crystal::ExhaustivenessChecker
           all_patterns_are_types = false
         end
 
-        if pattern
-          targets.each &.cover(pattern)
-        else
-          all_provable_patterns = false
-        end
+        targets.each &.cover(pattern)
       end
     end
 
@@ -96,20 +85,11 @@ struct Crystal::ExhaustivenessChecker
       # No specific error messages for non-single types
     end
 
-    if all_provable_patterns && !has_flags_enum
-      node.raise <<-MSG
-        case is not exhaustive.
-
-        Missing cases:
-         - #{targets.flat_map(&.missing_cases).join("\n - ")}
-        MSG
-    end
-
-    # Otherwise we can't prove exhaustiveness and an `else` clause is required
     node.raise <<-MSG
-      can't prove case is exhaustive.
+      case is not exhaustive.
 
-      Please add an `else` clause.
+      Missing cases:
+       - #{targets.flat_map(&.missing_cases).join("\n - ")}
       MSG
   end
 
@@ -123,16 +103,15 @@ struct Crystal::ExhaustivenessChecker
     element_types = elements.map &.type
 
     all_expanded_types = element_types.map do |element_type|
+      if element_type.is_a?(EnumType) && element_type.flags?
+        cond.raise "can't prove case is exhaustive for @[Flags] enum #{element_type} (@[Flags] enums can't be exhaustively checked)"
+      end
+
       expand_types(element_type)
     end
 
     # Compute all the targets that we must cover
     targets = compute_targets(all_expanded_types)
-
-    # Are all patterns things that we can handle?
-    # For example an integer literal is something that we don't
-    # take into account for exhaustiveness.
-    all_provable_patterns = true
 
     # Start checking each `when`...
     node.whens.each do |a_when|
@@ -142,12 +121,7 @@ struct Crystal::ExhaustivenessChecker
             when_pattern(when_cond_exp)
           end
 
-          if patterns.all?
-            patterns = patterns.map &.not_nil!
-            targets.each &.cover(patterns, 0)
-          else
-            all_provable_patterns = false
-          end
+          targets.each &.cover(patterns, 0)
         else
           # Not a tuple literal so we don't care
           # TODO: one could put `Tuple` or `Object` here and that would make
@@ -162,26 +136,16 @@ struct Crystal::ExhaustivenessChecker
     # If we covered all types, we are done.
     return if targets.empty?
 
-    # If all patterns are stuff we can handle, show the missing cases
-    if all_provable_patterns
-      missing_cases = targets
-        .flat_map(&.missing_cases)
-        .map { |cases| "{#{cases}}" }
-        .join("\n - ")
+    missing_cases = targets
+      .flat_map(&.missing_cases)
+      .map { |cases| "{#{cases}}" }
+      .join("\n - ")
 
-      node.raise <<-MSG
-        case is not exhaustive.
-
-        Missing cases:
-         - #{missing_cases}
-        MSG
-    end
-
-    # Otherwise we can't prove exhaustiveness and an `else` clause is required
     node.raise <<-MSG
-      can't prove case is exhaustive.
+      case is not exhaustive.
 
-      Please add an `else` clause.
+      Missing cases:
+       - #{missing_cases}
       MSG
   end
 
@@ -236,20 +200,26 @@ struct Crystal::ExhaustivenessChecker
         # if it's an enum member, try to remove it from the targets.
         EnumMemberPattern.new(target_const)
       else
-        nil
+        when_cond.raise "can't use constant values in exhaustive case, only constant types"
       end
+    when Generic
+      TypePattern.new(when_cond.type.devirtualize)
     when Call
+      obj = when_cond.obj
+
       # Check if it's something like `.foo?` to remove that member from the ones
       # we must cover.
       # Note: a user could override the meaning of such methods.
       # In the future it would be wise to mark these as non-redefinable
       # so this checks are sounds.
-      if when_cond.obj.is_a?(ImplicitObj) &&
-         when_cond.args.empty? && when_cond.named_args.nil? &&
-         !when_cond.block && !when_cond.block_arg && when_cond.name.ends_with?('?')
+      if obj.is_a?(ImplicitObj) && when_cond.name.ends_with?('?')
         EnumMemberNamePattern.new(when_cond.name.rchop)
+      elsif obj.is_a?(Path) && when_cond.name == "class"
+        TypePattern.new(obj.type.metaclass.devirtualize)
+      elsif obj.is_a?(Generic) && when_cond.name == "class"
+        TypePattern.new(obj.type.metaclass.devirtualize)
       else
-        nil
+        raise "Bug: unknown pattern in exhaustive case"
       end
     when BoolLiteral
       BoolPattern.new(when_cond.value)
@@ -258,7 +228,7 @@ struct Crystal::ExhaustivenessChecker
     when Underscore
       UnderscorePattern.new
     else
-      nil
+      raise "Bug: unknown pattern in exhaustive case"
     end
   end
 

--- a/src/compiler/crystal/syntax/ast.cr
+++ b/src/compiler/crystal/syntax/ast.cr
@@ -1199,8 +1199,9 @@ module Crystal
     property cond : ASTNode?
     property whens : Array(When)
     property else : ASTNode?
+    property? exhaustive : Bool
 
-    def initialize(@cond, @whens, @else = nil)
+    def initialize(@cond : ASTNode?, @whens : Array(When), @else : ASTNode?, @exhaustive : Bool)
     end
 
     def accept_children(visitor)
@@ -1210,10 +1211,10 @@ module Crystal
     end
 
     def clone_without_location
-      Case.new(@cond.clone, @whens.clone, @else.clone)
+      Case.new(@cond.clone, @whens.clone, @else.clone, @exhaustive)
     end
 
-    def_equals_and_hash @cond, @whens, @else
+    def_equals_and_hash @exhaustive, @cond, @whens, @else
   end
 
   class Select < ASTNode

--- a/src/compiler/crystal/syntax/ast.cr
+++ b/src/compiler/crystal/syntax/ast.cr
@@ -1178,8 +1178,9 @@ module Crystal
   class When < ASTNode
     property conds : Array(ASTNode)
     property body : ASTNode
+    property? exhaustive : Bool
 
-    def initialize(@conds, body = nil)
+    def initialize(@conds : Array(ASTNode), body : ASTNode? = nil, @exhaustive = false)
       @body = Expressions.from body
     end
 
@@ -1189,10 +1190,10 @@ module Crystal
     end
 
     def clone_without_location
-      When.new(@conds.clone, @body.clone)
+      When.new(@conds.clone, @body.clone, @exhaustive)
     end
 
-    def_equals_and_hash @conds, @body
+    def_equals_and_hash @conds, @body, @exhaustive
   end
 
   class Case < ASTNode
@@ -1202,6 +1203,9 @@ module Crystal
     property? exhaustive : Bool
 
     def initialize(@cond : ASTNode?, @whens : Array(When), @else : ASTNode?, @exhaustive : Bool)
+      @whens.each do |wh|
+        wh.exhaustive = self.exhaustive?
+      end
     end
 
     def accept_children(visitor)

--- a/src/compiler/crystal/syntax/parser.cr
+++ b/src/compiler/crystal/syntax/parser.cr
@@ -2578,6 +2578,7 @@ module Crystal
 
       whens = [] of When
       a_else = nil
+      exhaustive = nil
 
       # All when expressions, so we can detect duplicates
       when_exps = Set(ASTNode).new
@@ -2586,7 +2587,18 @@ module Crystal
         case @token.type
         when :IDENT
           case @token.value
-          when :when
+          when :when, :in
+            if exhaustive.nil?
+              exhaustive = @token.value == :in
+              if exhaustive && !cond
+                raise "exhaustive case (case ... in) requires a case expression (case exp; in ..)"
+              end
+            elsif exhaustive && @token.value == :when
+              raise "expected 'in', not 'when'"
+            elsif !exhaustive && @token.value == :in
+              raise "expected 'when', not 'in'"
+            end
+
             location = @token.location
             slash_is_regex!
             next_token_skip_space_or_newline
@@ -2602,7 +2614,11 @@ module Crystal
                   tuple_elements = [] of ASTNode
 
                   while true
-                    tuple_elements << parse_when_expression(cond, single: false)
+                    exp = parse_when_expression(cond, single: false, exhaustive: exhaustive)
+                    check_valid_exhaustive_expression(exp) if exhaustive
+
+                    tuple_elements << exp
+
                     skip_space
                     if @token.type == :","
                       next_token_skip_space_or_newline
@@ -2622,7 +2638,7 @@ module Crystal
                   check :"}"
                   next_token_skip_space
                 else
-                  exp = parse_when_expression(cond, single: true)
+                  exp = parse_when_expression(cond, single: true, exhaustive: exhaustive)
                   when_conds << exp
                   add_when_exp(when_exps, exp)
                   skip_space
@@ -2632,7 +2648,9 @@ module Crystal
               end
             else
               while true
-                exp = parse_when_expression(cond, single: true)
+                exp = parse_when_expression(cond, single: true, exhaustive: exhaustive)
+                check_valid_exhaustive_expression(exp) if exhaustive
+
                 when_conds << exp
                 add_when_exp(when_exps, exp)
                 skip_space
@@ -2644,6 +2662,10 @@ module Crystal
             skip_space_or_newline
             whens << When.new(when_conds, when_body).at(location)
           when :else
+            if exhaustive
+              raise "exhaustive case (case ... in) doesn't allow an 'else'"
+            end
+
             next_token_skip_statement_end
             a_else = parse_expressions
             skip_statement_end
@@ -2661,7 +2683,30 @@ module Crystal
         end
       end
 
-      Case.new(cond, whens, a_else)
+      Case.new(cond, whens, a_else, exhaustive.nil? ? false : exhaustive)
+    end
+
+    def check_valid_exhaustive_expression(exp)
+      case exp
+      when NilLiteral, BoolLiteral, Path, Generic, Underscore
+        return
+      when Call
+        if exp.obj.is_a?(ImplicitObj) && exp.name.ends_with?('?') &&
+           exp.args.empty? && !exp.named_args &&
+           !exp.block
+          return
+        end
+
+        if (exp.obj.is_a?(Path) || exp.obj.is_a?(Generic)) && exp.name == "class" &&
+           exp.args.empty? && !exp.named_args &&
+           !exp.block
+          return
+        end
+      else
+        # Go on
+      end
+
+      raise "expression of exhaustive case (case ... in) must be a constant (like `IO::Memory`), a generic (like `Array(Int32)`) a bool literal (true or false), a nil literal (nil) or a question method (like `.red?`)", exp.location.not_nil!
     end
 
     # Adds an expression to all when expressions and error on duplicates
@@ -2720,7 +2765,7 @@ module Crystal
       false
     end
 
-    def parse_when_expression(cond, single)
+    def parse_when_expression(cond, single, exhaustive)
       if cond && @token.type == :"."
         next_token
         call = parse_var_or_call(force_call: true)
@@ -2736,7 +2781,11 @@ module Crystal
         end
         call
       elsif single && @token.type == :UNDERSCORE
-        raise "'when _' is not supported, use 'else' block instead"
+        if exhaustive
+          raise "'when _' is not supported"
+        else
+          raise "'when _' is not supported, use 'else' block instead"
+        end
       else
         parse_op_assign_no_control
       end
@@ -5794,7 +5843,7 @@ module Crystal
         true
       when :IDENT
         case @token.value
-        when :do, :end, :else, :elsif, :when, :rescue, :ensure, :then
+        when :do, :end, :else, :elsif, :when, :in, :rescue, :ensure, :then
           !next_comes_colon_space?
         else
           false

--- a/src/compiler/crystal/syntax/to_s.cr
+++ b/src/compiler/crystal/syntax/to_s.cr
@@ -21,7 +21,6 @@ module Crystal
       @indent = 0
       @inside_macro = 0
       @inside_lib = false
-      @inside_exhaustive_case = false
     end
 
     def visit_any(node)
@@ -1345,14 +1344,9 @@ module Crystal
       end
       newline
 
-      old_inside_exhaustive_case = @inside_exhaustive_case
-      @inside_exhaustive_case = node.exhaustive?
-
       node.whens.each do |wh|
         wh.accept self
       end
-
-      @inside_exhaustive_case = old_inside_exhaustive_case
 
       if node_else = node.else
         append_indent
@@ -1367,7 +1361,7 @@ module Crystal
 
     def visit(node : When)
       append_indent
-      @str << keyword(@inside_exhaustive_case ? "in" : "when")
+      @str << keyword(node.exhaustive? ? "in" : "when")
       @str << ' '
       node.conds.join(", ", @str, &.accept self)
       newline

--- a/src/compiler/crystal/syntax/to_s.cr
+++ b/src/compiler/crystal/syntax/to_s.cr
@@ -1344,7 +1344,7 @@ module Crystal
       end
       newline
       node.whens.each do |wh|
-        wh.accept self
+        visit_when(wh, node.exhaustive?)
       end
       if node_else = node.else
         append_indent
@@ -1357,13 +1357,17 @@ module Crystal
       false
     end
 
-    def visit(node : When)
+    def visit_when(node, exhaustive)
       append_indent
-      @str << keyword("when")
+      @str << keyword(exhaustive ? "in" : "when")
       @str << ' '
       node.conds.join(", ", @str, &.accept self)
       newline
       accept_with_indent node.body
+    end
+
+    def visit(node : When)
+      # Handled by visit(node : Case)
       false
     end
 

--- a/src/compiler/crystal/tools/formatter.cr
+++ b/src/compiler/crystal/tools/formatter.cr
@@ -3573,7 +3573,7 @@ module Crystal
       align_number = node.whens.all? { |a_when| a_when.conds.size === 1 && a_when.conds.first.is_a?(NumberLiteral) }
 
       node.whens.each_with_index do |a_when, i|
-        format_when(node, a_when, last?(i, node.whens), align_number, node.exhaustive?)
+        format_when(node, a_when, last?(i, node.whens), align_number)
         skip_space_or_newline(@indent + 2)
       end
 
@@ -3608,12 +3608,12 @@ module Crystal
       false
     end
 
-    def format_when(case_node, node, is_last, align_number, exhaustive)
+    def format_when(case_node, node, is_last, align_number)
       skip_space_or_newline
 
       slash_is_regex!
       write_indent
-      write_keyword(exhaustive ? :in : :when, " ")
+      write_keyword(node.exhaustive? ? :in : :when, " ")
       base_indent = @column
       when_start_line = @line
       when_start_column = @column

--- a/src/compiler/crystal/tools/formatter.cr
+++ b/src/compiler/crystal/tools/formatter.cr
@@ -3573,7 +3573,7 @@ module Crystal
       align_number = node.whens.all? { |a_when| a_when.conds.size === 1 && a_when.conds.first.is_a?(NumberLiteral) }
 
       node.whens.each_with_index do |a_when, i|
-        format_when(node, a_when, last?(i, node.whens), align_number)
+        format_when(node, a_when, last?(i, node.whens), align_number, node.exhaustive?)
         skip_space_or_newline(@indent + 2)
       end
 
@@ -3608,12 +3608,12 @@ module Crystal
       false
     end
 
-    def format_when(case_node, node, is_last, align_number)
+    def format_when(case_node, node, is_last, align_number, exhaustive)
       skip_space_or_newline
 
       slash_is_regex!
       write_indent
-      write_keyword :when, " "
+      write_keyword(exhaustive ? :in : :when, " ")
       base_indent = @column
       when_start_line = @line
       when_start_column = @column

--- a/src/digest/md5.cr
+++ b/src/digest/md5.cr
@@ -24,7 +24,7 @@ class Digest::MD5 < Digest::Base
   end
 
   def update(inBuf, inLen)
-    in = uninitialized UInt32[16]
+    tmp_in = uninitialized UInt32[16]
 
     # compute number of bytes mod 64
     mdi = (@i[0] >> 3) & 0x3F
@@ -44,13 +44,13 @@ class Digest::MD5 < Digest::Base
       if mdi == 0x40
         ii = 0
         16.times do |i|
-          in[i] = (@in[ii + 3].to_u32 << 24) |
-                  (@in[ii + 2].to_u32 << 16) |
-                  (@in[ii + 1].to_u32 << 8) |
-                  (@in[ii])
+          tmp_in[i] = (@in[ii + 3].to_u32 << 24) |
+                      (@in[ii + 2].to_u32 << 16) |
+                      (@in[ii + 1].to_u32 << 8) |
+                      (@in[ii])
           ii += 4
         end
-        transform in
+        transform tmp_in
         mdi = 0
       end
     end
@@ -208,11 +208,11 @@ class Digest::MD5 < Digest::Base
   end
 
   def final
-    in = uninitialized UInt32[16]
+    tmp_in = uninitialized UInt32[16]
 
     # save number of bits
-    in[14] = @i[0]
-    in[15] = @i[1]
+    tmp_in[14] = @i[0]
+    tmp_in[15] = @i[1]
 
     # compute number of bytes mod 64
     mdi = ((@i[0] >> 3) & 0x3F).to_i32
@@ -224,13 +224,13 @@ class Digest::MD5 < Digest::Base
     # append length in bits and transform
     ii = 0
     14.times do |i|
-      in[i] = (@in[ii + 3].to_u32 << 24) |
-              (@in[ii + 2].to_u32 << 16) |
-              (@in[ii + 1].to_u32 << 8) |
-              (@in[ii])
+      tmp_in[i] = (@in[ii + 3].to_u32 << 24) |
+                  (@in[ii + 2].to_u32 << 16) |
+                  (@in[ii + 1].to_u32 << 8) |
+                  (@in[ii])
       ii += 4
     end
-    transform in
+    transform tmp_in
 
     # store buffer in digest
     ii = 0

--- a/src/time.cr
+++ b/src/time.cr
@@ -1296,7 +1296,7 @@ struct Time
     if local?
       self
     else
-      in(Location.local)
+      self.in(Location.local)
     end
   end
 


### PR DESCRIPTION
## Overview

This PR makes `case ... when` behave like it was before:
- exhaustiveness is not checked
- `else` can be omitted, by default it's `nil`

This make Crystal behave exactly like Ruby in that sense.

Then, `case ... in` is introduced as the exhaustive variant.

For example:

```crystal
# Compiles! Totally fine
case 1 || "a"
when Int32
end

# Error: missing case String
case 1 || "a"
in Int32
end
```

`case .. in`, from now on called "exhaustive case" is a bit different than `case .. when`:
- the expression that comes after `case` is mandatory (in the regular case you can omit it and it behaves like an if-elsif-else)
- the expressions that you can put after `in` are limited to:
  - nil literal
  - bool literals
  - constants that refer to types (Foo::Bar)
  - constants that refer to enum members (Color::Red)
  - generics
  - question methods like `.red?` (for enum members)
- an `else` can't be used: because it's exhaustive, you should list all the cases you expect to handle. If you need an `else` you can use `case ... when`.

## Experimental

The exhaustive case will be released in version 1.0 as experimental. That means that we could, in the future, either remove it, or replace its syntax, or change its behavior. It's very unlikely (I don't see why we would do that), but that's what we'll do.

## Wait... Ruby has `case ... in` too!

We know, but this `case ... in` is much more limited than the Ruby version.

In Ruby you can do:

```crystal
case array
in [1, 2]
in [1, 2, a]
  puts a
end
```

That will pattern match `array` against an array of values in the first case, and an array of two values and a third value that's captured into a variable.

None of that is possible right now.

Will it be possible in the future? We didn't even think about it. Maybe it would be nice. But note that if we really wanted to do that, we need to allow an `else` clause because there's no way we can know, at compile time, all the shapes of all arrays.

Also, this feature is experimental in Ruby, so who knows what will happen to it.

## Breaking change?

Yes, this is a small breaking change because `in` now needs to be a keyword that signals the end of an expression. That way the compiler knows that when it finds `in`, it knows the previous `in` ends. Same reason why `when` is a keyword and you can't use it as a variable name.

I first thought "Wait, did Ruby made a breaking change with this?". The answer is no: Ruby has the `for x in y` syntax so `in` was already a keyword. In Crystal I think it's used in macros but it was never a proper keyword. Now it is. This PR includes a fix for three such usages.

I believe making this breaking change is fine and it should be easy to upgrade. Also, `in` is a keyword in a lot of languages so having it as a keyword might enable us to use it in more places later on.

## Thoughts

I personally think having these two syntaxes will be great! If you are casing over a big enum, or just casing over some chars, strings, numbers, whatever, you can use the good old `case ... when`. But when you want to make sure you cover all types, or all enum members, you can use `case ... in` and get a bit more type safety, and also avoid having to write `else raise "can't happen"`.