### PR TITLE
Add HTTP::Cookie::SameSite::None

### DIFF
--- a/src/http/cookie.cr
+++ b/src/http/cookie.cr
@@ -5,9 +5,12 @@ module HTTP
   class Cookie
     # Possible values for the `SameSite` cookie as described in the [Same-site Cookies Draft](https://tools.ietf.org/html/draft-west-first-party-cookies-07#section-4.1.1).
     enum SameSite
+      # The browser will send cookies with both cross-site requests and same-site requests.
+      #
+      # The `None` directive requires the `secure` attribute to be `true` to mitigate risks associated with cross-site access.
+      None
       # Prevents the cookie from being sent by the browser in all cross-site browsing contexts.
       Strict
-
       # Allows the cookie to be sent by the browser during top-level navigations that use a [safe](https://tools.ietf.org/html/rfc7231#section-4.2.1) HTTP method.
       Lax
     end


### PR DESCRIPTION
RFC: https://tools.ietf.org/html/draft-ietf-httpbis-cookie-same-site-00#section-4.2
MDN: https://developer.mozilla.org/en-US/docs/Web/HTTP/Cookies#SameSite_cookies

Setting `SameSite` to `None` ensures that the browser will send cookies with both cross-site requests and same-site requests, because `Lax` may be set by default on newer browsers.

MDN states that setting `SameSite` to `None` requires the `Secure` attribute. I did find a [Chromium Blog](https://blog.chromium.org/2019/10/developers-get-ready-for-new.html) saying it is for security reasons.