### PR TITLE
Make `NamedTuple#sorted_keys` public

### DIFF
--- a/spec/std/named_tuple_spec.cr
+++ b/spec/std/named_tuple_spec.cr
@@ -352,6 +352,11 @@ describe "NamedTuple" do
     tup.keys.should eq({:a, :b})
   end
 
+  it "does sorted_keys" do
+    tup = {foo: 1, bar: 2, baz: 3}
+    tup.sorted_keys.should eq({:bar, :baz, :foo})
+  end
+
   it "does values" do
     tup = {a: 1, b: 'a'}
     tup.values.should eq({1, 'a'})

--- a/src/named_tuple.cr
+++ b/src/named_tuple.cr
@@ -266,7 +266,13 @@ struct NamedTuple
     {% end %}
   end
 
-  protected def sorted_keys
+  # Returns a `Tuple` of symbols with the keys in this named tuple, sorted by name.
+  #
+  # ```
+  # tuple = {foo: 1, bar: 2, baz: 3}
+  # tuple.sorted_keys # => {:bar, :baz, :foo}
+  # ```
+  def sorted_keys
     {% begin %}
       Tuple.new(
         {% for key in T.keys.sort %}


### PR DESCRIPTION
In a project I needed to sort the keys of a named tuple and it turned out that method exists already, but it's not public.