### PR TITLE
Parser: allow ->@ivar.foo and ->@@cvar.foo

### DIFF
--- a/spec/compiler/formatter/formatter_spec.cr
+++ b/spec/compiler/formatter/formatter_spec.cr
@@ -720,6 +720,9 @@ describe Crystal::Formatter do
   assert_format "->( x , y )   { x }", "->(x, y) { x }"
   assert_format "->( x : Int32 , y )   { x }", "->(x : Int32, y) { x }"
 
+  assert_format "->@foo.foo"
+  assert_format "->@@foo.foo"
+
   {:+, :-, :*, :/, :^, :>>, :<<, :|, :&, :&+, :&-, :&*, :&**}.each do |sym|
     assert_format ":#{sym}"
   end

--- a/spec/compiler/parser/parser_spec.cr
+++ b/spec/compiler/parser/parser_spec.cr
@@ -1200,6 +1200,8 @@ module Crystal
     it_parses "[] of ->\n", ArrayLiteral.new(of: ProcNotation.new)
     it_parses "->foo=", ProcPointer.new(nil, "foo=")
     it_parses "foo = 1; ->foo.foo=", [Assign.new("foo".var, 1.int32), ProcPointer.new("foo".var, "foo=")]
+    it_parses "->@foo.foo", [ProcPointer.new("@foo".instance_var, "foo")]
+    it_parses "->@@foo.foo", [ProcPointer.new("@@foo".class_var, "foo")]
 
     it_parses "foo &->bar", Call.new(nil, "foo", block_arg: ProcPointer.new(nil, "bar"))
 

--- a/spec/compiler/semantic/proc_spec.cr
+++ b/spec/compiler/semantic/proc_spec.cr
@@ -1069,4 +1069,42 @@ describe "Semantic: proc" do
       foo
       )) { proc_of nil_type }
   end
+
+  it "can use @ivar as pointer syntax receiver (#9239)" do
+    assert_type(%(
+      class Foo
+        def foo
+          1
+        end
+      end
+
+      class Bar
+        @foo = Foo.new
+
+        def foo
+          ->@foo.foo
+        end
+      end
+
+      Bar.new.foo
+    )) { proc_of int32 }
+  end
+
+  it "can use @@cvar as pointer syntax receiver (#9239)" do
+    assert_type(%(
+      class Foo
+        @@foo = new
+
+        def self.foo
+          ->@@foo.foo
+        end
+
+        def foo
+          1
+        end
+      end
+
+      Foo.foo
+    )) { proc_of int32 }
+  end
 end

--- a/src/compiler/crystal/syntax/parser.cr
+++ b/src/compiler/crystal/syntax/parser.cr
@@ -1904,6 +1904,18 @@ module Crystal
         check :"."
         name = consume_def_or_macro_name
         next_token_skip_space
+      when :INSTANCE_VAR
+        obj = InstanceVar.new(@token.value.to_s)
+        next_token_skip_space
+        check :"."
+        name = consume_def_or_macro_name
+        next_token_skip_space
+      when :CLASS_VAR
+        obj = ClassVar.new(@token.value.to_s)
+        next_token_skip_space
+        check :"."
+        name = consume_def_or_macro_name
+        next_token_skip_space
       else
         unexpected_token
       end


### PR DESCRIPTION
Fixed #9239

Now, we can compile such a code:

```crystal
class Foo
  def initialize
    @foo = "foo"
    proc = ->@foo.upcase
    p proc.call # => "FOO"
  end
end

Foo.new
```