### PR TITLE
Update CRYSTAL_PATH to allow .crystal/shards

### DIFF
--- a/bin/crystal
+++ b/bin/crystal
@@ -138,7 +138,7 @@ SCRIPT_ROOT="$(dirname "$SCRIPT_PATH")"
 CRYSTAL_ROOT="$(dirname "$SCRIPT_ROOT")"
 CRYSTAL_DIR="$CRYSTAL_ROOT/.build"
 
-export CRYSTAL_PATH=lib:$CRYSTAL_ROOT/src
+export CRYSTAL_PATH=.crystal/shards:lib:$CRYSTAL_ROOT/src
 export CRYSTAL_HAS_WRAPPER=true
 
 if [ -x "$CRYSTAL_DIR/crystal" ]; then


### PR DESCRIPTION
We need to keep :lib: for a couple of releases as a migration path.

Depends on https://github.com/crystal-lang/shards/pull/367