### PR TITLE
Add #each_bit method to IO

### DIFF
--- a/spec/std/io/io_spec.cr
+++ b/spec/std/io/io_spec.cr
@@ -352,6 +352,15 @@ describe IO do
       bytes.should eq ['a'.ord.to_u8, 'b'.ord.to_u8, 'c'.ord.to_u8]
     end
 
+    it "does each_bit" do
+      bits = Array(Bool).new
+      io = SimpleIOMemory.new "\x0F"
+      io.each_bit do |b|
+        bits << b
+      end
+      bits.should eq Array(Bool).new 8, &.< 4
+    end
+
     it "raises on EOF with read_line" do
       str = SimpleIOMemory.new("hello")
       str.read_line.should eq("hello")

--- a/src/io.cr
+++ b/src/io.cr
@@ -995,6 +995,15 @@ abstract class IO
     ByteIterator.new(self)
   end
 
+  # Invokes the given block with each bit (`Bool`) in this IO
+  def each_bit
+    each_byte do |byte|
+      8.times do |i|
+        yield byte.bits_set? 1 << i
+      end
+    end
+  end
+
   # Rewinds this `IO`. By default this method raises, but including types
   # may implement it.
   def rewind


### PR DESCRIPTION
This adds a method to IO which will iterate over each bit. This came up in the discord chat and I thought it would be simple and fun to implement.

Let me know if there's anything I can do to improve the implementation of this feature.