### PR TITLE
Support different number of fraction digits for RFC3339 time format

### DIFF
--- a/spec/std/time/format_spec.cr
+++ b/spec/std/time/format_spec.cr
@@ -153,6 +153,23 @@ describe Time::Format do
     Time.parse_rfc2822(time.to_rfc2822).should eq time
   end
 
+  it "formats rfc3339 with different fraction digits" do
+    time = Time.utc(2016, 2, 15, 8, 23, 45, nanosecond: 123456789)
+    time.to_rfc3339.should eq "2016-02-15T08:23:45.123456789Z"
+    time.to_rfc3339(fraction_digits: 0).should eq "2016-02-15T08:23:45Z"
+    time.to_rfc3339(fraction_digits: 3).should eq "2016-02-15T08:23:45.123Z"
+    time.to_rfc3339(fraction_digits: 6).should eq "2016-02-15T08:23:45.123456Z"
+    time.to_rfc3339(fraction_digits: 9).should eq "2016-02-15T08:23:45.123456789Z"
+    expect_raises(ArgumentError, "Invalid fraction digits: 5") { time.to_rfc3339(fraction_digits: 5) }
+
+    time = Time.utc(2016, 2, 15, 8, 23, 45)
+    time.to_rfc3339.should eq "2016-02-15T08:23:45Z"
+    time.to_rfc3339(fraction_digits: 0).should eq "2016-02-15T08:23:45Z"
+    time.to_rfc3339(fraction_digits: 3).should eq "2016-02-15T08:23:45.000Z"
+    time.to_rfc3339(fraction_digits: 6).should eq "2016-02-15T08:23:45.000000Z"
+    time.to_rfc3339(fraction_digits: 9).should eq "2016-02-15T08:23:45.000000000Z"
+  end
+
   it "parses empty" do
     t = Time.parse("", "", Time::Location.local)
     t.year.should eq(1)

--- a/spec/std/time/format_spec.cr
+++ b/spec/std/time/format_spec.cr
@@ -155,7 +155,7 @@ describe Time::Format do
 
   it "formats rfc3339 with different fraction digits" do
     time = Time.utc(2016, 2, 15, 8, 23, 45, nanosecond: 123456789)
-    time.to_rfc3339.should eq "2016-02-15T08:23:45.123456789Z"
+    time.to_rfc3339.should eq "2016-02-15T08:23:45Z"
     time.to_rfc3339(fraction_digits: 0).should eq "2016-02-15T08:23:45Z"
     time.to_rfc3339(fraction_digits: 3).should eq "2016-02-15T08:23:45.123Z"
     time.to_rfc3339(fraction_digits: 6).should eq "2016-02-15T08:23:45.123456Z"

--- a/spec/std/time/format_spec.cr
+++ b/spec/std/time/format_spec.cr
@@ -161,6 +161,7 @@ describe Time::Format do
     time.to_rfc3339(fraction_digits: 6).should eq "2016-02-15T08:23:45.123456Z"
     time.to_rfc3339(fraction_digits: 9).should eq "2016-02-15T08:23:45.123456789Z"
     expect_raises(ArgumentError, "Invalid fraction digits: 5") { time.to_rfc3339(fraction_digits: 5) }
+    expect_raises(ArgumentError, "Invalid fraction digits: -1") { time.to_rfc3339(fraction_digits: -1) }
 
     time = Time.utc(2016, 2, 15, 8, 23, 45)
     time.to_rfc3339.should eq "2016-02-15T08:23:45Z"

--- a/spec/std/yaml/serialization_spec.cr
+++ b/spec/std/yaml/serialization_spec.cr
@@ -1,3 +1,4 @@
+require "../spec_helper"
 require "spec"
 require "yaml"
 {% unless flag?(:win32) %}
@@ -349,7 +350,7 @@ describe "YAML serialization" do
 
     it "does for utc time" do
       time = Time.utc(2010, 11, 12, 1, 2, 3)
-      assert_yaml_document_end(time.to_yaml, "--- 2010-11-12 01:02:03\n")
+      assert_yaml_document_end(time.to_yaml, "--- 2010-11-12 01:02:03.000000000\n")
     end
 
     it "does for time at date" do

--- a/src/log/format.cr
+++ b/src/log/format.cr
@@ -63,7 +63,7 @@ class Log
 
     # Write the entry timestamp in RFC3339 format
     def timestamp
-      @entry.timestamp.to_rfc3339(@io)
+      @entry.timestamp.to_rfc3339(@io, fraction_digits: 6)
     end
 
     # Write a fixed string

--- a/src/time.cr
+++ b/src/time.cr
@@ -1105,14 +1105,23 @@ struct Time
   # ISO 8601 allows some freedom over the syntax and RFC 3339 exercises that
   # freedom to rigidly define a fixed format intended for use in internet
   # protocols and standards.
-  def to_rfc3339
-    Format::RFC_3339.format(to_utc)
+  #
+  # Number of seconds decimals can be selected with *fraction_digits*.
+  # Values accepted are 0 (no decimals), 3 (milliseconds), 6 (microseconds) or 9 (nanoseconds).
+  # The default value `nil` prints all the available decimals (currently 9).
+  def to_rfc3339(fraction_digits : Int? = nil)
+    Format::RFC_3339.format(to_utc, fraction_digits)
   end
 
   # Format this time using the format specified by [RFC 3339](https://tools.ietf.org/html/rfc3339) ([ISO 8601](http://xml.coverpages.org/ISO-FDIS-8601.pdf) profile).
   # into the given *io*.
-  def to_rfc3339(io : IO)
-    Format::RFC_3339.format(to_utc, io)
+  #
+  #
+  # Number of seconds decimals can be selected with *fraction_digits*.
+  # Values accepted are 0 (no decimals), 3 (milliseconds), 6 (microseconds) or 9 (nanoseconds).
+  # The default value `nil` prints all the available decimals (currently 9).
+  def to_rfc3339(io : IO, fraction_digits : Int? = nil)
+    Format::RFC_3339.format(to_utc, io, fraction_digits)
   end
 
   # Parse time format specified by [RFC 3339](https://tools.ietf.org/html/rfc3339) ([ISO 8601](http://xml.coverpages.org/ISO-FDIS-8601.pdf) profile).

--- a/src/time.cr
+++ b/src/time.cr
@@ -1109,7 +1109,7 @@ struct Time
   # Number of seconds decimals can be selected with *fraction_digits*.
   # Values accepted are 0 (no decimals), 3 (milliseconds), 6 (microseconds) or 9 (nanoseconds).
   # The default value `nil` prints all the available decimals (currently 9).
-  def to_rfc3339(fraction_digits : Int? = nil)
+  def to_rfc3339(*, fraction_digits : Int? = nil)
     Format::RFC_3339.format(to_utc, fraction_digits)
   end
 
@@ -1120,7 +1120,7 @@ struct Time
   # Number of seconds decimals can be selected with *fraction_digits*.
   # Values accepted are 0 (no decimals), 3 (milliseconds), 6 (microseconds) or 9 (nanoseconds).
   # The default value `nil` prints all the available decimals (currently 9).
-  def to_rfc3339(io : IO, fraction_digits : Int? = nil)
+  def to_rfc3339(io : IO, *, fraction_digits : Int? = nil)
     Format::RFC_3339.format(to_utc, io, fraction_digits)
   end
 

--- a/src/time.cr
+++ b/src/time.cr
@@ -1107,9 +1107,8 @@ struct Time
   # protocols and standards.
   #
   # Number of seconds decimals can be selected with *fraction_digits*.
-  # Values accepted are 0 (no decimals), 3 (milliseconds), 6 (microseconds) or 9 (nanoseconds).
-  # The default value `nil` prints all the available decimals (currently 9).
-  def to_rfc3339(*, fraction_digits : Int? = nil)
+  # Values accepted are 0 (the default, no decimals), 3 (milliseconds), 6 (microseconds) or 9 (nanoseconds).
+  def to_rfc3339(*, fraction_digits : Int = 0)
     Format::RFC_3339.format(to_utc, fraction_digits)
   end
 
@@ -1118,9 +1117,8 @@ struct Time
   #
   #
   # Number of seconds decimals can be selected with *fraction_digits*.
-  # Values accepted are 0 (no decimals), 3 (milliseconds), 6 (microseconds) or 9 (nanoseconds).
-  # The default value `nil` prints all the available decimals (currently 9).
-  def to_rfc3339(io : IO, *, fraction_digits : Int? = nil)
+  # Values accepted are 0 (the default, no decimals), 3 (milliseconds), 6 (microseconds) or 9 (nanoseconds).
+  def to_rfc3339(io : IO, *, fraction_digits : Int = 0)
     Format::RFC_3339.format(to_utc, io, fraction_digits)
   end
 

--- a/src/time/format/custom/rfc_3339.cr
+++ b/src/time/format/custom/rfc_3339.cr
@@ -9,14 +9,14 @@ struct Time::Format
     end
 
     # Formats a `Time` into the given *io*.
-    def self.format(time : Time, io : IO, fraction_digits = nil)
+    def self.format(time : Time, io : IO, fraction_digits = 0)
       formatter = Formatter.new(time, io)
       formatter.rfc_3339(fraction_digits: fraction_digits)
       io
     end
 
     # Formats a `Time` into a `String`.
-    def self.format(time : Time, fraction_digits = nil)
+    def self.format(time : Time, fraction_digits = 0)
       String.build do |io|
         format(time, io, fraction_digits: fraction_digits)
       end
@@ -24,7 +24,7 @@ struct Time::Format
   end
 
   module Pattern
-    def rfc_3339(fraction_digits = nil)
+    def rfc_3339(fraction_digits = 0)
       year_month_day
       char 'T', 't', ' '
       twenty_four_hour_time_with_seconds

--- a/src/time/format/custom/yaml_date.cr
+++ b/src/time/format/custom/yaml_date.cr
@@ -120,7 +120,7 @@ struct Time::Format
       year_month_day
       char ' '
       twenty_four_hour_time_with_seconds
-      second_fraction?(9)
+      second_fraction?
 
       unless time.utc?
         time_zone_z_or_offset(force_colon: true)

--- a/src/time/format/custom/yaml_date.cr
+++ b/src/time/format/custom/yaml_date.cr
@@ -120,7 +120,7 @@ struct Time::Format
       year_month_day
       char ' '
       twenty_four_hour_time_with_seconds
-      second_fraction?
+      second_fraction?(9)
 
       unless time.utc?
         time_zone_z_or_offset(force_colon: true)

--- a/src/time/format/formatter.cr
+++ b/src/time/format/formatter.cr
@@ -147,21 +147,14 @@ struct Time::Format
       nanoseconds
     end
 
-    def second_fraction?(fraction_digits = nil)
-      if fraction_digits
-        case fraction_digits
-        when 0
-        when 3 then char '.'; milliseconds
-        when 6 then char '.'; microseconds
-        when 9 then char '.'; nanoseconds
-        else
-          raise ArgumentError.new("Invalid fraction digits: #{fraction_digits}")
-        end
+    def second_fraction?(fraction_digits : Int = 0)
+      case fraction_digits
+      when 0
+      when 3 then char '.'; milliseconds
+      when 6 then char '.'; microseconds
+      when 9 then char '.'; nanoseconds
       else
-        unless time.nanosecond == 0
-          char '.'
-          second_fraction
-        end
+        raise ArgumentError.new("Invalid fraction digits: #{fraction_digits}")
       end
     end
 

--- a/src/time/format/formatter.cr
+++ b/src/time/format/formatter.cr
@@ -148,9 +148,22 @@ struct Time::Format
     end
 
     def second_fraction?(fraction_digits = nil)
-      unless time.nanosecond == 0 || fraction_digits == 0
-        char '.'
-        second_fraction
+      if fraction_digits
+        if fraction_digits > 0
+          char '.'
+          case fraction_digits
+          when 3 then milliseconds
+          when 6 then microseconds
+          when 9 then nanoseconds
+          else
+            raise ArgumentError.new("Invalid fraction digits: #{fraction_digits}")
+          end
+        end
+      else
+        unless time.nanosecond == 0
+          char '.'
+          second_fraction
+        end
       end
     end
 

--- a/src/time/format/formatter.cr
+++ b/src/time/format/formatter.cr
@@ -149,15 +149,13 @@ struct Time::Format
 
     def second_fraction?(fraction_digits = nil)
       if fraction_digits
-        if fraction_digits > 0
-          char '.'
-          case fraction_digits
-          when 3 then milliseconds
-          when 6 then microseconds
-          when 9 then nanoseconds
-          else
-            raise ArgumentError.new("Invalid fraction digits: #{fraction_digits}")
-          end
+        case fraction_digits
+        when 0
+        when 3 then char '.'; milliseconds
+        when 6 then char '.'; microseconds
+        when 9 then char '.'; nanoseconds
+        else
+          raise ArgumentError.new("Invalid fraction digits: #{fraction_digits}")
         end
       else
         unless time.nanosecond == 0

--- a/src/time/format/formatter.cr
+++ b/src/time/format/formatter.cr
@@ -147,7 +147,7 @@ struct Time::Format
       nanoseconds
     end
 
-    def second_fraction?(fraction_digits : Int = 0)
+    def second_fraction?(fraction_digits : Int = 9)
       case fraction_digits
       when 0
       when 3 then char '.'; milliseconds


### PR DESCRIPTION
This makes possible to select 0, 3, 6 or 9 decimal digits in RFC3339 time format.
Also I added the optional `fraction_digits` parameter to `Time#to_rfc3339` and `Time#to_rfc3339(IO)`

Something I still feel weird is that by default (`fraction_digits = nil`) the output will print all the decimals or no decimals at all depending on the time value. I know it might be really unlikely that `nanoseconds == 0` but still I think the output format should be always the same.
Maybe the default could be something in between, like printing microseconds?