### PR TITLE
Compiler: cast fun function pointer to Proc

### DIFF
--- a/spec/compiler/codegen/closure_spec.cr
+++ b/spec/compiler/codegen/closure_spec.cr
@@ -700,6 +700,8 @@ describe "Code gen: closure" do
 
   it "allows passing an external function along" do
     codegen(%(
+      require "prelude"
+
       lib LibC
         fun exit(c : Int32) : NoReturn
       end
@@ -716,7 +718,9 @@ describe "Code gen: closure" do
         LibA.a(a)
       end
     ))
+  end
 
+  it "allows passing an external function along (2)" do
     codegen(%(
       lib LibFoo
         struct S

--- a/spec/compiler/codegen/closure_spec.cr
+++ b/spec/compiler/codegen/closure_spec.cr
@@ -702,9 +702,6 @@ describe "Code gen: closure" do
     codegen(%(
       require "prelude"
 
-      lib LibC
-        fun exit(c : Int32) : NoReturn
-      end
 
       lib LibA
         fun a(a : Void* -> Void*)

--- a/spec/compiler/codegen/closure_spec.cr
+++ b/spec/compiler/codegen/closure_spec.cr
@@ -706,10 +706,6 @@ describe "Code gen: closure" do
         fun exit(c : Int32) : NoReturn
       end
 
-      def raise(a) : NoReturn
-        LibC.exit(1)
-      end
-
       lib LibA
         fun a(a : Void* -> Void*)
       end

--- a/spec/compiler/codegen/proc_spec.cr
+++ b/spec/compiler/codegen/proc_spec.cr
@@ -819,4 +819,32 @@ describe "Code gen: proc" do
       a
       )).to_i.should eq(3)
   end
+
+  it "calls function pointer" do
+    run(%(
+      require "prelude"
+
+      fun foo(f : Int32 -> Int32) : Int32
+        f.call(1)
+      end
+
+      foo(->(x : Int32) { x &+ 1 })
+    )).to_i.should eq(2)
+  end
+
+  it "casts from function pointer to proc" do
+    codegen(%(
+      fun a(a : Void* -> Void*)
+        Pointer(Proc((Void* -> Void*), Void*)).new(0_u64).value.call(a)
+      end
+    ))
+  end
+
+  it "takes pointerof function pointer" do
+    codegen(%(
+      fun a(a : Void* -> Void*)
+        pointerof(a).value.call(Pointer(Void).new(0_u64))
+      end
+    ))
+  end
 end

--- a/src/compiler/crystal/codegen/codegen.cr
+++ b/src/compiler/crystal/codegen/codegen.cr
@@ -1531,12 +1531,10 @@ module Crystal
     end
 
     def check_proc_is_not_closure(value, type)
-      if value.type == llvm_typer.proc_type
-        check_fun_name = "~check_proc_is_not_closure"
-        func = @main_mod.functions[check_fun_name]? || create_check_proc_is_not_closure_fun(check_fun_name)
-        func = check_main_fun check_fun_name, func
-        value = call func, [value] of LLVM::Value
-      end
+      check_fun_name = "~check_proc_is_not_closure"
+      func = @main_mod.functions[check_fun_name]? || create_check_proc_is_not_closure_fun(check_fun_name)
+      func = check_main_fun check_fun_name, func
+      value = call func, [value] of LLVM::Value
       bit_cast value, llvm_proc_type(type)
     end
 

--- a/src/compiler/crystal/codegen/fun.cr
+++ b/src/compiler/crystal/codegen/fun.cr
@@ -512,12 +512,23 @@ class Crystal::CodeGenVisitor
         context.vars[arg.name] = LLVMVar.new(value, var_type)
         return
       else
+        # If an argument is a Proc inside a C function, we need to cast it to Proc
+        fun_proc = var_type.is_a?(ProcInstanceType) && target_def.is_a?(External)
+
         # We don't need to create a copy of the argument if it's never
         # assigned a value inside the function.
         needs_copy = target_def_var.try &.assigned_to?
+        needs_copy ||= fun_proc
+
         if needs_copy
           pointer = alloca(llvm_type(var_type), arg.name)
           pointer = declare_debug_for_function_argument(arg.name, var_type, index + 1, pointer, location) unless target_def.naked?
+
+          if fun_proc
+            value = bit_cast(value, llvm_context.void_pointer)
+            value = make_fun(var_type, value, llvm_context.void_pointer.null)
+          end
+
           context.vars[arg.name] = LLVMVar.new(pointer, var_type)
 
           if arg.type.passed_by_value? && !context.fun.attributes(index + 1).by_val?

--- a/src/compiler/crystal/codegen/primitives.cr
+++ b/src/compiler/crystal/codegen/primitives.cr
@@ -860,12 +860,10 @@ class Crystal::CodeGenVisitor
     scope = context.type.as(NonGenericClassType)
     field_type = scope.instance_vars[var_name].type
 
-    # Check nil to pointer
+    # Check assigning nil to a field of type pointer or Proc
     if node.type.nil_type? && (field_type.pointer? || field_type.proc?)
       call_arg = llvm_c_type(field_type).null
-    end
-
-    if field_type.proc?
+    elsif field_type.proc?
       call_arg = check_proc_is_not_closure(call_arg, field_type)
     end
 


### PR DESCRIPTION
Like #9255 but correctly done (the check must be done even if the argument doesn't `need_copy`). In #9255 it was almost good, but it didn't work in all cases.

Also does #9248 in a different way.

Fixes #9253
Fixes #9255