### PR TITLE
XML: improve xpath regarding namespaces

### DIFF
--- a/spec/std/xml/xpath_spec.cr
+++ b/spec/std/xml/xpath_spec.cr
@@ -75,7 +75,7 @@ module XML
       doc.xpath_node("//invalid").should be_nil
     end
 
-    it "finds with namespace" do
+    it "finds with explicit namespace" do
       doc = XML.parse(%(\
         <?xml version="1.0" encoding="UTF-8"?>
         <feed xmlns="http://www.w3.org/2005/Atom" xmlns:openSearch="http://a9.com/-/spec/opensearchrss/1.0/">
@@ -87,6 +87,22 @@ module XML
       ns = nodes[0].namespace.not_nil!
       ns.href.should eq("http://www.w3.org/2005/Atom")
       ns.prefix.should be_nil
+    end
+
+    it "finds with implicit (root) namespaces" do
+      doc = XML.parse(%(\
+        <?xml version="1.0" encoding="UTF-8"?>
+        <openSearch:feed xmlns="http://www.w3.org/2005/Atom" xmlns:openSearch="http://a9.com/-/spec/opensearchrss/1.0/">
+          <openSearch:something>
+          </openSearch:something>
+        </openSearch:feed>
+        ))
+      nodes = doc.xpath("//openSearch:feed/openSearch:something").as(NodeSet)
+      nodes.size.should eq(1)
+      nodes[0].name.should eq("something")
+      ns = nodes[0].namespace.not_nil!
+      ns.href.should eq("http://a9.com/-/spec/opensearchrss/1.0/")
+      ns.prefix.should eq("openSearch")
     end
 
     it "finds with root namespaces" do
@@ -101,6 +117,20 @@ module XML
       ns = nodes[0].namespace.not_nil!
       ns.href.should eq("http://www.w3.org/2005/Atom")
       ns.prefix.should be_nil
+    end
+
+    it "finds with root namespaces (using prefix)" do
+      doc = XML.parse(%(\
+        <?xml version="1.0" encoding="UTF-8"?>
+        <openSearch:feed xmlns="http://www.w3.org/2005/Atom" xmlns:openSearch="http://a9.com/-/spec/opensearchrss/1.0/">
+        </openSearch:feed>
+        ))
+      nodes = doc.xpath("//openSearch:feed", namespaces: doc.root.not_nil!.namespaces).as(NodeSet)
+      nodes.size.should eq(1)
+      nodes[0].name.should eq("feed")
+      ns = nodes[0].namespace.not_nil!
+      ns.href.should eq("http://a9.com/-/spec/opensearchrss/1.0/")
+      ns.prefix.should eq("openSearch")
     end
 
     it "finds with variable binding" do

--- a/src/xml/node.cr
+++ b/src/xml/node.cr
@@ -284,7 +284,7 @@ struct XML::Node
   end
 
   # Returns the namespace for this node or `nil` if not found.
-  def namespace
+  def namespace : Namespace?
     case type
     when Type::DOCUMENT_NODE, Type::ATTRIBUTE_DECL, Type::DTD_NODE, Type::ELEMENT_DECL
       nil
@@ -301,7 +301,7 @@ struct XML::Node
   # Default namespaces for ancestors, however, are not.
   #
   # See also `#namespaces`
-  def namespace_scopes
+  def namespace_scopes : Array(Namespace)
     scopes = [] of Namespace
 
     ns_list = LibXML.xmlGetNsList(@node.value.doc, @node)
@@ -326,7 +326,7 @@ struct XML::Node
   #
   # NOTE: Note that the keys in this hash XML attributes that would be used to
   # define this namespace, such as `"xmlns:prefix"`, not just the prefix.
-  def namespaces
+  def namespaces : Hash(String, String?)
     namespaces = {} of String => String?
     each_namespace do |namespace|
       prefix = namespace.prefix ? "xmlns:#{namespace.prefix}" : "xmlns"

--- a/src/xml/xpath_context.cr
+++ b/src/xml/xpath_context.cr
@@ -42,6 +42,7 @@ struct XML::XPathContext
   end
 
   def register_namespace(prefix, uri)
+    prefix = prefix.lchop("xmlns:")
     LibXML.xmlXPathRegisterNs(self, prefix.to_s, uri.to_s)
   end
 

--- a/src/xml/xpath_context.cr
+++ b/src/xml/xpath_context.cr
@@ -41,9 +41,9 @@ struct XML::XPathContext
     end
   end
 
-  def register_namespace(prefix, uri)
+  def register_namespace(prefix : String, uri : String?)
     prefix = prefix.lchop("xmlns:")
-    LibXML.xmlXPathRegisterNs(self, prefix.to_s, uri.to_s)
+    LibXML.xmlXPathRegisterNs(self, prefix, uri.to_s)
   end
 
   def register_variables(variables)


### PR DESCRIPTION
Fixes #9279

I checked Nokogiri and if you do this:

```ruby
require "nokogiri"

str_xml = <<-XML
<?xml version="1.0" encoding="utf-8"?>
<soap:Envelope xmlns:soap="http://www.w3.org/2003/05/soap-envelope">
  <soap:Body>
    <NumberToWordsResponse xmlns="http://www.dataaccess.com/webservicesserver/">
      <NumberToWordsResult>string</NumberToWordsResult>
    </NumberToWordsResponse>
  </soap:Body>
</soap:Envelope>
XML

xml = Nokogiri::XML(str_xml)
xml.xpath("/soap:Envelope/soap:Body")
```

It works out of the box. My guess is that it passes the root namespaces of the document so they can be found with the registered prefixes. So in this PR I do the same.

I also `lchop` the "xmlns:" prefix of namespaces when registering them. Again, checking what Nokogiri does, the namespaces are returned with the "xmlns:" prefix, but that needs to be removed when registering namespaces for the xpath lookup.