### PR TITLE
Log: Rename Severity::Warning to Severity::Warn

### DIFF
--- a/spec/std/log/broadcast_backend_spec.cr
+++ b/spec/std/log/broadcast_backend_spec.cr
@@ -68,15 +68,15 @@ describe Log::BroadcastBackend do
 
     it "single backend" do
       main = Log::BroadcastBackend.new
-      main.append(Log::MemoryBackend.new, s(:warning))
+      main.append(Log::MemoryBackend.new, s(:warn))
 
-      main.min_level.should eq(s(:warning))
+      main.min_level.should eq(s(:warn))
     end
 
     it "multiple backends" do
       main = Log::BroadcastBackend.new
       main.append(Log::MemoryBackend.new, s(:info))
-      main.append(Log::MemoryBackend.new, s(:warning))
+      main.append(Log::MemoryBackend.new, s(:warn))
 
       main.min_level.should eq(s(:info))
     end

--- a/spec/std/log/builder_spec.cr
+++ b/spec/std/log/builder_spec.cr
@@ -105,13 +105,13 @@ describe Log::Builder do
     builder = Log::Builder.new
     a = Log::MemoryBackend.new
     builder.bind("*", :fatal, a)
-    builder.bind("db.*", :warning, a)
+    builder.bind("db.*", :warn, a)
     builder.bind("db", :error, a)
     builder.bind("db.pool", :none, a)
 
     builder.for("").level.should eq(s(:fatal))
     builder.for("db").level.should eq(s(:error))
-    builder.for("db.query").level.should eq(s(:warning))
+    builder.for("db.query").level.should eq(s(:warn))
     builder.for("db.pool").level.should eq(s(:none))
   end
 
@@ -130,10 +130,10 @@ describe Log::Builder do
     log.level.should eq(s(:none))
 
     a = Log::MemoryBackend.new
-    builder.bind("*", :warning, a)
+    builder.bind("*", :warn, a)
 
     log.backend.should be(a)
-    log.level.should eq(s(:warning))
+    log.level.should eq(s(:warn))
   end
 
   it "removes all logs backends on .clear" do

--- a/spec/std/log/env_config_spec.cr
+++ b/spec/std/log/env_config_spec.cr
@@ -63,9 +63,9 @@ describe "Log.setup_from_env" do
     it "is used if no LOG_LEVEL is set" do
       with_env "LOG_LEVEL": nil do
         builder = Log::Builder.new
-        Log.setup_from_env(builder: builder, default_level: :warning)
+        Log.setup_from_env(builder: builder, default_level: :warn)
 
-        builder.for("").initial_level.should eq(s(:warning))
+        builder.for("").initial_level.should eq(s(:warn))
       end
     end
 

--- a/spec/std/log/format_spec.cr
+++ b/spec/std/log/format_spec.cr
@@ -79,9 +79,9 @@ class Log
       TestFormatter.format(Entry.new("source", :error, "Oh, no", Log::Metadata.empty, exception), io)
       io.rewind
 
-      io.gets.should eq("   INFO [source] test message ({\"a\" => 1, \"b\" => 2})")
-      io.gets.should eq("   INFO test message")
-      io.gets.should eq("  ERROR [source] test Oh, no")
+      io.gets.should eq("  INFO [source] test message ({\"a\" => 1, \"b\" => 2})")
+      io.gets.should eq("  INFO test message")
+      io.gets.should eq(" ERROR [source] test Oh, no")
       io.gets_to_end.should eq(exception.inspect_with_backtrace)
     end
   end

--- a/spec/std/log/io_backend_spec.cr
+++ b/spec/std/log/io_backend_spec.cr
@@ -23,7 +23,7 @@ describe Log::IOBackend do
       logger.level = s(:debug)
       logger.debug { "debug:show" }
 
-      logger.level = s(:warning)
+      logger.level = s(:warn)
       logger.debug { "debug:skip:again" }
       logger.info { "info:skip" }
       logger.error { "error:show" }
@@ -61,7 +61,7 @@ describe Log::IOBackend do
       logger = io_logger(stdout: w, source: "db.pool")
       logger.warn { "message" }
 
-      r.gets(chomp: false).should match(/.+? WARNING - db.pool: message\n/)
+      r.gets(chomp: false).should match(/.+? WARN - db.pool: message\n/)
     end
   end
 

--- a/spec/std/log/log_spec.cr
+++ b/spec/std/log/log_spec.cr
@@ -23,8 +23,8 @@ describe Log do
       s(:trace).should be < s(:debug)
       s(:debug).should be < s(:info)
       s(:info).should be < s(:notice)
-      s(:notice).should be < s(:warning)
-      s(:warning).should be < s(:error)
+      s(:notice).should be < s(:warn)
+      s(:warn).should be < s(:error)
       s(:error).should be < s(:fatal)
       s(:fatal).should be < s(:none)
     end
@@ -34,7 +34,7 @@ describe Log do
       Log::Severity.parse("debug").should eq s(:debug)
       Log::Severity.parse("info").should eq s(:info)
       Log::Severity.parse("notice").should eq s(:notice)
-      Log::Severity.parse("warning").should eq s(:warning)
+      Log::Severity.parse("warn").should eq s(:warn)
       Log::Severity.parse("error").should eq s(:error)
       Log::Severity.parse("fatal").should eq s(:fatal)
       Log::Severity.parse("none").should eq s(:none)
@@ -43,7 +43,7 @@ describe Log do
       Log::Severity.parse("DEBUG").should eq s(:debug)
       Log::Severity.parse("INFO").should eq s(:info)
       Log::Severity.parse("NOTICE").should eq s(:notice)
-      Log::Severity.parse("WARNING").should eq s(:warning)
+      Log::Severity.parse("WARN").should eq s(:warn)
       Log::Severity.parse("ERROR").should eq s(:error)
       Log::Severity.parse("FATAL").should eq s(:fatal)
       Log::Severity.parse("NONE").should eq s(:none)
@@ -52,7 +52,7 @@ describe Log do
 
   it "filter messages to the backend above level only" do
     backend = Log::MemoryBackend.new
-    log = Log.new("a", backend, :warning)
+    log = Log.new("a", backend, :warn)
 
     log.trace { "trace message" }
     log.debug { "debug message" }
@@ -63,7 +63,7 @@ describe Log do
     log.fatal { "fatal message" }
 
     backend.entries.map { |e| {e.severity, e.message} }.should eq([
-      {s(:warning), "warning message"},
+      {s(:warn), "warning message"},
       {s(:error), "error message"},
       {s(:fatal), "fatal message"},
     ])
@@ -71,7 +71,7 @@ describe Log do
 
   it "level can be changed" do
     backend = Log::MemoryBackend.new
-    log = Log.new("a", backend, :warning)
+    log = Log.new("a", backend, :warn)
 
     log.level = :error
 

--- a/spec/std/log/main_spec.cr
+++ b/spec/std/log/main_spec.cr
@@ -32,16 +32,16 @@ describe Log do
     top = Log.for("qux", :info)
     top.level.should eq(Log::Severity::Info)
 
-    Log.for("qux", :warning)
-    top.level.should eq(Log::Severity::Warning)
+    Log.for("qux", :warn)
+    top.level.should eq(Log::Severity::Warn)
   end
 
   it "can build nested with level override" do
     foo_bar = Log.for("foo").for("bar", :info)
     foo_bar.level.should eq(Log::Severity::Info)
 
-    Log.for("foo.bar", :warning)
-    foo_bar.level.should eq(Log::Severity::Warning)
+    Log.for("foo.bar", :warn)
+    foo_bar.level.should eq(Log::Severity::Warn)
   end
 
   it "can build for module type" do

--- a/src/compiler/crystal.cr
+++ b/src/compiler/crystal.cr
@@ -6,6 +6,6 @@
 require "log"
 require "./crystal/**"
 
-Log.setup_from_env(default_level: :warning, default_sources: "crystal.*")
+Log.setup_from_env(default_level: :warn, default_sources: "crystal.*")
 
 Crystal::Command.run

--- a/src/log.cr
+++ b/src/log.cr
@@ -108,7 +108,7 @@
 # Log.setup |c|
 #   backend = Log::IOBackend.new
 #
-#   c.bind "*", :warning, backend
+#   c.bind "*", :warn, backend
 #   c.bind "db.*", :debug, backend
 #   c.bind "*", :error, ElasticSearchBackend.new("http://localhost:9200")
 # end

--- a/src/log/entry.cr
+++ b/src/log/entry.cr
@@ -9,7 +9,7 @@ enum Log::Severity
   # Used for normal but significant conditions.
   Notice
   # Used for conditions that can potentially cause application oddities, but that can be automatically recovered.
-  Warning
+  Warn
   # Used for any error that is fatal to the operation, but not to the service or application.
   Error
   # Used for any error that is forcing a shutdown of the service or application
@@ -19,14 +19,14 @@ enum Log::Severity
 
   def label
     case self
-    when Trace   then "TRACE"
-    when Debug   then "DEBUG"
-    when Info    then "INFO"
-    when Notice  then "NOTICE"
-    when Warning then "WARNING"
-    when Error   then "ERROR"
-    when Fatal   then "FATAL"
-    when None    then "NONE"
+    when Trace  then "TRACE"
+    when Debug  then "DEBUG"
+    when Info   then "INFO"
+    when Notice then "NOTICE"
+    when Warn   then "WARN"
+    when Error  then "ERROR"
+    when Fatal  then "FATAL"
+    when None   then "NONE"
     else
       raise "unreachable"
     end

--- a/src/log/format.cr
+++ b/src/log/format.cr
@@ -46,8 +46,8 @@ class Log
   # end
   #
   # Log.setup(:info, Log::IOBackend.new(formatter: MyFormat))
-  # Log.info { "Hello" }    # => -    INFO: Hello
-  # Log.error { "Oh, no!" } # => -   ERROR: Oh, no!
+  # Log.info { "Hello" }    # => -   INFO: Hello
+  # Log.error { "Oh, no!" } # => -  ERROR: Oh, no!
   # ```
   #
   # There is also a helper macro to generate these formatters. Here's
@@ -81,7 +81,7 @@ class Log
     # This writes the severity in uppercase and left padded
     # with enough space so all the severities fit
     def severity
-      @entry.severity.label.rjust(@io, 7)
+      @entry.severity.label.rjust(@io, 6)
     end
 
     # Write the source for non-root entries
@@ -180,17 +180,17 @@ end
 #
 # It writes log entries with the following format:
 # ```
-# 2020-05-07T17:40:07.994508000Z    INFO - my.source: Initializing everything
+# 2020-05-07T17:40:07.994508000Z   INFO - my.source: Initializing everything
 # ```
 #
 # When the entries have context data it's also written to the output:
 # ```
-# 2020-05-07T17:40:07.994508000Z    INFO - my.source: Initializing everything -- {"data" => 123}
+# 2020-05-07T17:40:07.994508000Z   INFO - my.source: Initializing everything -- {"data" => 123}
 # ```
 #
 # Exceptions are written in a separate line:
 # ```
-# 2020-05-07T17:40:07.994508000Z   ERROR - my.source: Something failed
+# 2020-05-07T17:40:07.994508000Z  ERROR - my.source: Something failed
 # Oh, no (Exception)
 #   from ...
 # ```

--- a/src/log/log.cr
+++ b/src/log/log.cr
@@ -38,11 +38,10 @@ class Log
                                debug:  Severity::Debug,
                                info:   Severity::Info,
                                notice: Severity::Notice,
-                               warn:   Severity::Warning,
+                               warn:   Severity::Warn,
                                error:  Severity::Error,
                                fatal:  Severity::Fatal,
                              } %}
-
     # Logs a message if the logger's current severity is lower or equal to `{{severity}}`.
     def {{method.id}}(*, exception : Exception? = nil)
       return unless backend = @backend


### PR DESCRIPTION
This make will stop accepting :warning 
 and LOG_LEVEL=WARNING in favor of :warn and LOG_LEVEL=WARN.

Closes #9251 

For reference at `https://github.com/aspnet/Logging/issues/299#issuecomment-159447448` you can find a comparison table among different frameworks.

Since the method is still `Log.warn { }` the breaking-change is not that big