### PR TITLE
Avoid requiring non std-lib spec spec_helper in hooks_spec

### DIFF
--- a/spec/std/exception/call_stack_spec.cr
+++ b/spec/std/exception/call_stack_spec.cr
@@ -10,7 +10,7 @@ describe "Backtrace" do
     current_dir += File::SEPARATOR unless current_dir.ends_with?(File::SEPARATOR)
     source_file = source_file.lchop(current_dir)
 
-    output, _ = compile_and_run_file(source_file)
+    _, output, _ = compile_and_run_file(source_file)
 
     # resolved file line:column
     output.should match(/#{source_file}:3:10 in 'callee1'/)
@@ -28,7 +28,7 @@ describe "Backtrace" do
   it "prints exception backtrace to stderr" do
     sample = datapath("exception_backtrace_sample")
 
-    output, error = compile_and_run_file(sample)
+    _, output, error = compile_and_run_file(sample)
 
     output.to_s.empty?.should be_true
     error.to_s.should contain("IndexError")
@@ -37,7 +37,7 @@ describe "Backtrace" do
   it "prints crash backtrace to stderr" do
     sample = datapath("crash_backtrace_sample")
 
-    output, error = compile_and_run_file(sample)
+    _, output, error = compile_and_run_file(sample)
 
     output.to_s.empty?.should be_true
     error.to_s.should contain("Invalid memory access")

--- a/spec/std/exception/call_stack_spec.cr
+++ b/spec/std/exception/call_stack_spec.cr
@@ -1,17 +1,5 @@
 require "../spec_helper"
 
-private def compile_and_run_file(source_file)
-  with_tempfile("executable_file") do |executable_file|
-    Process.run("bin/crystal", ["build", "--debug", "-o", executable_file, source_file])
-    File.exists?(executable_file).should be_true
-
-    output, error = IO::Memory.new, IO::Memory.new
-    Process.run executable_file, output: output, error: error
-
-    {output.to_s, error.to_s}
-  end
-end
-
 describe "Backtrace" do
   it "prints file line:colunm" do
     source_file = datapath("backtrace_sample")

--- a/spec/std/exception_spec.cr
+++ b/spec/std/exception_spec.cr
@@ -1,17 +1,5 @@
 require "./spec_helper"
 
-private def compile_and_run_file(source_file)
-  with_tempfile("executable_file") do |executable_file|
-    Process.run("bin/crystal", ["build", "--release", "-o", executable_file, source_file])
-    File.exists?(executable_file).should be_true
-
-    output, error = IO::Memory.new, IO::Memory.new
-    Process.run executable_file, output: output, error: error
-
-    {output.to_s, error.to_s}
-  end
-end
-
 private class FooError < Exception
   def message
     "#{super || ""} -- bar!"
@@ -51,7 +39,7 @@ describe "Exception" do
     it "collect memory within ensure block" do
       sample = datapath("collect_within_ensure")
 
-      output, error = compile_and_run_file(sample)
+      output, error = compile_and_run_file(sample, ["--release"])
 
       output.to_s.empty?.should be_true
       error.to_s.should contain("Unhandled exception: Oh no! (Exception)")

--- a/spec/std/exception_spec.cr
+++ b/spec/std/exception_spec.cr
@@ -39,7 +39,7 @@ describe "Exception" do
     it "collect memory within ensure block" do
       sample = datapath("collect_within_ensure")
 
-      output, error = compile_and_run_file(sample, ["--release"])
+      _, output, error = compile_and_run_file(sample, ["--release"])
 
       output.to_s.empty?.should be_true
       error.to_s.should contain("Unhandled exception: Oh no! (Exception)")

--- a/spec/std/io/file_descriptor_spec.cr
+++ b/spec/std/io/file_descriptor_spec.cr
@@ -1,9 +1,9 @@
-require "../../spec_helper"
+require "../spec_helper"
 
 describe IO::FileDescriptor do
   it "reopen STDIN with the right mode" do
     code = %q(puts "#{STDIN.blocking} #{STDIN.info.type}")
-    build(code) do |binpath|
+    compile_source(code) do |binpath|
       `#{binpath} < #{binpath}`.chomp.should eq("true File")
       `echo "" | #{binpath}`.chomp.should eq("false Pipe")
     end

--- a/spec/std/kernel_spec.cr
+++ b/spec/std/kernel_spec.cr
@@ -1,14 +1,14 @@
 require "spec"
-require "../spec_helper"
+require "./spec_helper"
 
 describe "exit" do
   it "exits normally with status 0" do
-    status, _ = build_and_run "exit"
+    status, _ = compile_and_run_source "exit"
     status.success?.should be_true
   end
 
   it "exits with given error code" do
-    status, _ = build_and_run "exit 42"
+    status, _ = compile_and_run_source "exit 42"
     status.success?.should be_false
     status.exit_code.should eq(42)
   end
@@ -16,7 +16,7 @@ end
 
 describe "at_exit" do
   it "runs handlers on normal program ending" do
-    status, output = build_and_run <<-CODE
+    status, output = compile_and_run_source <<-CODE
       at_exit do
         puts "handler code"
       end
@@ -27,7 +27,7 @@ describe "at_exit" do
   end
 
   it "runs handlers on explicit program ending" do
-    status, output = build_and_run <<-'CODE'
+    status, output = compile_and_run_source <<-'CODE'
       at_exit do |exit_code|
         puts "handler code, exit code: #{exit_code}"
       end
@@ -40,7 +40,7 @@ describe "at_exit" do
   end
 
   it "runs handlers in reverse order" do
-    status, output = build_and_run <<-CODE
+    status, output = compile_and_run_source <<-CODE
       at_exit do
         puts "first handler code"
       end
@@ -59,7 +59,7 @@ describe "at_exit" do
   end
 
   it "runs all handlers maximum once" do
-    status, output = build_and_run <<-CODE
+    status, output = compile_and_run_source <<-CODE
       at_exit do
         puts "first handler code"
       end
@@ -86,7 +86,7 @@ describe "at_exit" do
   end
 
   it "allows handlers to change the exit code with explicit `exit` call" do
-    status, output = build_and_run <<-'CODE'
+    status, output = compile_and_run_source <<-'CODE'
       at_exit do |exit_code|
         puts "first handler code, exit code: #{exit_code}"
       end
@@ -114,7 +114,7 @@ describe "at_exit" do
   end
 
   it "allows handlers to change the exit code with explicit `exit` call (2)" do
-    status, output = build_and_run <<-'CODE'
+    status, output = compile_and_run_source <<-'CODE'
       at_exit do |exit_code|
         puts "first handler code, exit code: #{exit_code}"
       end
@@ -144,7 +144,7 @@ describe "at_exit" do
   end
 
   it "changes final exit code when an handler raises an error" do
-    status, output, error = build_and_run <<-'CODE'
+    status, output, error = compile_and_run_source <<-'CODE'
       at_exit do |exit_code|
         puts "first handler code, exit code: #{exit_code}"
       end
@@ -173,7 +173,7 @@ describe "at_exit" do
   end
 
   it "errors when used in an at_exit handler" do
-    status, output, error = build_and_run <<-CODE
+    status, output, error = compile_and_run_source <<-CODE
       at_exit do
         at_exit {}
       end
@@ -184,7 +184,7 @@ describe "at_exit" do
   end
 
   it "shows unhandled exceptions after at_exit handlers" do
-    status, _, error = build_and_run <<-CODE
+    status, _, error = compile_and_run_source <<-CODE
       at_exit do
         STDERR.puts "first handler code"
       end
@@ -205,7 +205,7 @@ describe "at_exit" do
   end
 
   it "can get unhandled exception in at_exit handler" do
-    status, _, error = build_and_run <<-CODE
+    status, _, error = compile_and_run_source <<-CODE
       at_exit do |_, ex|
         STDERR.puts ex.try &.message
       end
@@ -223,7 +223,7 @@ end
 
 describe "seg fault" do
   it "reports SIGSEGV" do
-    status, _, error = build_and_run <<-'CODE'
+    status, _, error = compile_and_run_source <<-'CODE'
       puts Pointer(Int64).null.value
     CODE
 
@@ -241,7 +241,7 @@ describe "seg fault" do
       # the default stack size is 0.5G.  Setting a
       # smaller stack size with `ulimit -s 8192`
       # will address this.
-      status, _, error = build_and_run <<-'CODE'
+      status, _, error = compile_and_run_source <<-'CODE'
       def foo
         y = StaticArray(Int8,512).new(0)
         foo
@@ -255,7 +255,7 @@ describe "seg fault" do
   {% end %}
 
   it "detects stack overflow on a fiber stack" do
-    status, _, error = build_and_run <<-'CODE'
+    status, _, error = compile_and_run_source <<-'CODE'
       def foo
         y = StaticArray(Int8,512).new(0)
         foo

--- a/spec/std/process_spec.cr
+++ b/spec/std/process_spec.cr
@@ -1,7 +1,6 @@
 require "spec"
 require "process"
 require "./spec_helper"
-require "../spec_helper"
 
 private def exit_code_command(code)
   {% if flag?(:win32) %}
@@ -138,7 +137,7 @@ describe Process do
   end
 
   pending_win32 "chroot raises when unprivileged" do
-    status, output = build_and_run <<-'CODE'
+    status, output = compile_and_run_source <<-'CODE'
       begin
         Process.chroot("/usr")
         puts "FAIL"

--- a/spec/std/spec/hooks_spec.cr
+++ b/spec/std/spec/hooks_spec.cr
@@ -1,9 +1,22 @@
-require "../../spec_helper"
+require "./spec_helper"
+
+private def compile_and_run_source(source)
+  with_tempfile("executable_file", "source_file") do |executable_file, source_file|
+    File.write(source_file, source)
+    Process.run("bin/crystal", ["build", "--debug", "-o", executable_file, source_file])
+    File.exists?(executable_file).should be_true
+
+    output, error = IO::Memory.new, IO::Memory.new
+    Process.run executable_file, output: output, error: error
+
+    {output.to_s, error.to_s}
+  end
+end
 
 describe Spec do
   describe "hooks" do
     it "runs in correct order" do
-      run(<<-CR).to_string.lines[..-5].should eq <<-OUT.lines
+      compile_and_run_source(<<-CR)[0].lines[..-5].should eq <<-OUT.lines
         require "prelude"
         require "spec"
 

--- a/spec/std/spec/hooks_spec.cr
+++ b/spec/std/spec/hooks_spec.cr
@@ -3,7 +3,7 @@ require "./spec_helper"
 describe Spec do
   describe "hooks" do
     it "runs in correct order" do
-      compile_and_run_source(<<-CR)[0].lines[..-5].should eq <<-OUT.lines
+      compile_and_run_source(<<-CR)[1].lines[..-5].should eq <<-OUT.lines
         require "prelude"
         require "spec"
 

--- a/spec/std/spec/hooks_spec.cr
+++ b/spec/std/spec/hooks_spec.cr
@@ -1,18 +1,5 @@
 require "./spec_helper"
 
-private def compile_and_run_source(source)
-  with_tempfile("executable_file", "source_file") do |executable_file, source_file|
-    File.write(source_file, source)
-    Process.run("bin/crystal", ["build", "--debug", "-o", executable_file, source_file])
-    File.exists?(executable_file).should be_true
-
-    output, error = IO::Memory.new, IO::Memory.new
-    Process.run executable_file, output: output, error: error
-
-    {output.to_s, error.to_s}
-  end
-end
-
 describe Spec do
   describe "hooks" do
     it "runs in correct order" do

--- a/spec/std/spec_helper.cr
+++ b/spec/std/spec_helper.cr
@@ -91,3 +91,22 @@ def spawn_and_check(before : Proc(_), file = __FILE__, line = __LINE__, &block :
     fail "Failed to stress expected path", file, line
   end
 end
+
+def compile_and_run_file(source_file, flags = %w(--debug))
+  with_tempfile("executable_file") do |executable_file|
+    Process.run("bin/crystal", ["build"] + flags + ["-o", executable_file, source_file])
+    File.exists?(executable_file).should be_true
+
+    output, error = IO::Memory.new, IO::Memory.new
+    Process.run executable_file, output: output, error: error
+
+    {output.to_s, error.to_s}
+  end
+end
+
+def compile_and_run_source(source, flags = %w(--debug))
+  with_tempfile("source_file") do |source_file|
+    File.write(source_file, source)
+    compile_and_run_file(source_file, flags)
+  end
+end

--- a/spec/std/spec_helper.cr
+++ b/spec/std/spec_helper.cr
@@ -92,15 +92,30 @@ def spawn_and_check(before : Proc(_), file = __FILE__, line = __LINE__, &block :
   end
 end
 
-def compile_and_run_file(source_file, flags = %w(--debug))
+def compile_file(source_file, flags = %w(--debug))
   with_tempfile("executable_file") do |executable_file|
     Process.run("bin/crystal", ["build"] + flags + ["-o", executable_file, source_file])
     File.exists?(executable_file).should be_true
 
-    output, error = IO::Memory.new, IO::Memory.new
-    Process.run executable_file, output: output, error: error
+    yield executable_file
+  end
+end
 
-    {output.to_s, error.to_s}
+def compile_source(source, flags = %w(--debug))
+  with_tempfile("source_file") do |source_file|
+    File.write(source_file, source)
+    compile_file(source_file, flags) do |executable_file|
+      yield executable_file
+    end
+  end
+end
+
+def compile_and_run_file(source_file, flags = %w(--debug))
+  compile_file(source_file) do |executable_file|
+    output, error = IO::Memory.new, IO::Memory.new
+    status = Process.run executable_file, output: output, error: error
+
+    {status, output.to_s, error.to_s}
   end
 end
 


### PR DESCRIPTION
I noticed that the spec added in #9090 is requiring the top most spec_helper which is not aimed to be used in the std-lib specs

cc: @straight-shoota 