### PR TITLE
Log::Metadata optimizations

### DIFF
--- a/spec/std/log/context_spec.cr
+++ b/spec/std/log/context_spec.cr
@@ -2,7 +2,7 @@ require "spec"
 require "log"
 
 private def m(value)
-  Log::Metadata.new(value)
+  Log::Metadata.build(value)
 end
 
 describe "Log.context" do
@@ -12,12 +12,6 @@ describe "Log.context" do
 
   after_each do
     Log.context.clear
-  end
-
-  it "validates hash" do
-    expect_raises(ArgumentError, "Expected hash context, not Int32") do
-      Log.context = m(1)
-    end
   end
 
   it "can be set and cleared" do
@@ -86,13 +80,6 @@ describe "Log.context" do
   it "is assignable from a hash with symbol keys" do
     Log.context.set a: 1
     extra = {:b => 2}
-    Log.context.set extra
-    Log.context.metadata.should eq(m({a: 1, b: 2}))
-  end
-
-  it "is assignable from a hash with string keys" do
-    Log.context.set a: 1
-    extra = {"b" => 2}
     Log.context.set extra
     Log.context.metadata.should eq(m({a: 1, b: 2}))
   end

--- a/spec/std/log/format_spec.cr
+++ b/spec/std/log/format_spec.cr
@@ -24,17 +24,17 @@ class Log
       end
       io = IO::Memory.new
       ShortFormat.format(entry, io)
-      io.to_s.should match(/^[\d\-.:TZ]+\s* INFO - source: message -- {"a" => 1, "b" => 2}$/)
+      io.to_s.should match(/^[\d\-.:TZ]+\s* INFO - source: message -- {:a => 1, :b => 2}$/)
     end
 
     it "shows context and entry data" do
       entry = Log.with_context do
         Log.context.set a: 1, b: 2
-        Entry.new("source", :info, "message", Log::Metadata.new({c: 3, d: 4}), nil)
+        Entry.new("source", :info, "message", Log::Metadata.build({c: 3, d: 4}), nil)
       end
       io = IO::Memory.new
       ShortFormat.format(entry, io)
-      io.to_s.should match(/^[\d\-.:TZ]+\s* INFO - source: message -- {"c" => 3, "d" => 4} -- {"a" => 1, "b" => 2}$/)
+      io.to_s.should match(/^[\d\-.:TZ]+\s* INFO - source: message -- {:c => 3, :d => 4} -- {:a => 1, :b => 2}$/)
     end
 
     it "appends the exception" do
@@ -79,7 +79,7 @@ class Log
       TestFormatter.format(Entry.new("source", :error, "Oh, no", Log::Metadata.empty, exception), io)
       io.rewind
 
-      io.gets.should eq("  INFO [source] test message ({\"a\" => 1, \"b\" => 2})")
+      io.gets.should eq("  INFO [source] test message ({:a => 1, :b => 2})")
       io.gets.should eq("  INFO test message")
       io.gets.should eq(" ERROR [source] test Oh, no")
       io.gets_to_end.should eq(exception.inspect_with_backtrace)

--- a/spec/std/log/format_spec.cr
+++ b/spec/std/log/format_spec.cr
@@ -24,7 +24,7 @@ class Log
       end
       io = IO::Memory.new
       ShortFormat.format(entry, io)
-      io.to_s.should match(/^[\d\-.:TZ]+\s* INFO - source: message -- {:a => 1, :b => 2}$/)
+      io.to_s.should match(/^[\d\-.:TZ]+\s* INFO - source: message -- a: 1, b: 2$/)
     end
 
     it "shows context and entry data" do
@@ -34,7 +34,7 @@ class Log
       end
       io = IO::Memory.new
       ShortFormat.format(entry, io)
-      io.to_s.should match(/^[\d\-.:TZ]+\s* INFO - source: message -- {:c => 3, :d => 4} -- {:a => 1, :b => 2}$/)
+      io.to_s.should match(/^[\d\-.:TZ]+\s* INFO - source: message -- c: 3, d: 4 -- a: 1, b: 2$/)
     end
 
     it "appends the exception" do
@@ -79,7 +79,7 @@ class Log
       TestFormatter.format(Entry.new("source", :error, "Oh, no", Log::Metadata.empty, exception), io)
       io.rewind
 
-      io.gets.should eq("  INFO [source] test message ({:a => 1, :b => 2})")
+      io.gets.should eq("  INFO [source] test message (a: 1, b: 2)")
       io.gets.should eq("  INFO test message")
       io.gets.should eq(" ERROR [source] test Oh, no")
       io.gets_to_end.should eq(exception.inspect_with_backtrace)

--- a/spec/std/log/io_backend_spec.cr
+++ b/spec/std/log/io_backend_spec.cr
@@ -43,7 +43,7 @@ describe Log::IOBackend do
         logger.info { "info:show" }
       end
 
-      r.gets.should match(/info:show -- {"foo" => "bar"}/)
+      r.gets.should match(/info:show -- {:foo => "bar"}/)
     end
   end
 

--- a/spec/std/log/io_backend_spec.cr
+++ b/spec/std/log/io_backend_spec.cr
@@ -43,7 +43,7 @@ describe Log::IOBackend do
         logger.info { "info:show" }
       end
 
-      r.gets.should match(/info:show -- {:foo => "bar"}/)
+      r.gets.should match(/info:show -- foo: "bar"/)
     end
   end
 

--- a/spec/std/log/log_spec.cr
+++ b/spec/std/log/log_spec.cr
@@ -6,7 +6,7 @@ private def s(value : Log::Severity)
 end
 
 private def m(value)
-  Log::Metadata.new(value)
+  Log::Metadata.build(value)
 end
 
 describe Log do
@@ -114,7 +114,7 @@ describe Log do
 
     log.info { "info message" }
 
-    backend.entries.first.context.should eq(Log::Metadata.new({a: 1}))
+    backend.entries.first.context.should eq(Log::Metadata.build({a: 1}))
   end
 
   it "context can be changed within the block, yet it's not restored" do
@@ -125,8 +125,8 @@ describe Log do
 
     log.info { Log.context.set(b: 2); "info message" }
 
-    backend.entries.first.context.should eq(Log::Metadata.new({a: 1, b: 2}))
-    Log.context.metadata.should eq(Log::Metadata.new({a: 1, b: 2}))
+    backend.entries.first.context.should eq(Log::Metadata.build({a: 1, b: 2}))
+    Log.context.metadata.should eq(Log::Metadata.build({a: 1, b: 2}))
   end
 
   describe "emitter dsl" do
@@ -256,15 +256,6 @@ describe Log do
       entry.message.should eq("")
       entry.data.should eq(m({a: 1}))
       entry.exception.should be_nil
-    end
-
-    it "validates hash" do
-      expect_raises(ArgumentError, "Expected hash data, not Int32") do
-        backend = Log::MemoryBackend.new
-        log = Log.new("a", backend, :notice)
-
-        log.notice &.emit(m(1))
-      end
     end
   end
 end

--- a/spec/std/log/metadata_spec.cr
+++ b/spec/std/log/metadata_spec.cr
@@ -3,41 +3,18 @@ require "log"
 require "log/json"
 
 private def m(value)
-  Log::Metadata.new(value)
+  Log::Metadata.build(value)
+end
+
+private def v(value)
+  Log::Metadata::Value.new(value)
 end
 
 describe Log::Metadata do
-  it "initialize" do
-    m({a: 1}).should eq(m({"a" => m(1)}))
-    m({a: 1, b: ["str", true], num: 1i64}).should eq(m({"a" => m(1), "b" => m([m("str"), m(true)]), "num" => m(1i64)}))
-    m({a: 1f32, b: 1f64}).should eq(m({"a" => m(1f32), "b" => m(1f64)}))
-    t = Time.local
-    m({time: t}).should eq(m({"time" => m(t)}))
-    Log::Metadata.new.should eq(m(NamedTuple.new))
-  end
-
   it "empty" do
     Log::Metadata.empty.should eq(Log::Metadata.new)
     Log::Metadata.empty.object_id.should_not eq(Log::Metadata.new.object_id)
     Log::Metadata.empty.object_id.should eq(Log::Metadata.empty.object_id)
-  end
-
-  it "immutability" do
-    context = m({a: 1})
-    other = context.as_h
-    other["a"] = m(2)
-
-    other.should eq({"a" => m(2)})
-    context.should eq(m({a: 1}))
-  end
-
-  it "nested immutability" do
-    context = m({a: {b: 1}})
-    other = context.as_h
-    other["a"].raw.as(Hash)["b"] = m(2)
-
-    other.should eq({"a" => m({"b" => 2})})
-    context.should eq({"a" => m({"b" => 1})})
   end
 
   it "extend" do
@@ -49,21 +26,41 @@ describe Log::Metadata do
   it "extend against empty values without creating a new instance" do
     c1 = m({a: 1, b: 3})
     c1.extend(NamedTuple.new).should be(c1)
-    c1.extend(Hash(String, String).new).should be(c1)
+    c1.extend(Hash(Symbol, String).new).should be(c1)
+  end
+
+  it "json" do
+    m({a: 1}).to_json.should eq(%({"a":1}))
+    m({a: 1, b: 1}).extend({b: 2}).to_json.should eq(%({"b":2,"a":1}))
+  end
+end
+
+describe Log::Metadata::Value do
+  it "initialize" do
+    v({a: 1}).should eq(v({"a" => v(1)}))
+    v({a: 1, b: ["str", true], num: 1i64}).should eq(v({"a" => v(1), "b" => v([v("str"), v(true)]), "num" => v(1i64)}))
+    v({a: 1f32, b: 1f64}).should eq(v({"a" => v(1f32), "b" => v(1f64)}))
+    t = Time.local
+    v({time: t}).should eq(v({"time" => v(t)}))
+    v({} of String => String).should eq(v(NamedTuple.new))
   end
 
   it "accessors" do
-    m(nil).as_nil.should be_nil
+    v(nil).as_nil.should be_nil
 
-    m(1).as_i.should eq(1)
+    v(1).as_i.should eq(1)
 
-    m("a").as_s.should eq("a")
-    m(1).as_s?.should be_nil
+    v("a").as_s.should eq("a")
+    v(1).as_s?.should be_nil
 
-    m(true).as_bool.should eq(true)
-    m(false).as_bool.should eq(false)
-    m(true).as_bool?.should eq(true)
-    m(false).as_bool?.should eq(false)
-    m(nil).as_bool?.should be_nil
+    v(true).as_bool.should eq(true)
+    v(false).as_bool.should eq(false)
+    v(true).as_bool?.should eq(true)
+    v(false).as_bool?.should eq(false)
+    v(nil).as_bool?.should be_nil
+  end
+
+  it "json" do
+    v({a: 1}).to_json.should eq(%({"a":1}))
   end
 end

--- a/spec/std/log/metadata_spec.cr
+++ b/spec/std/log/metadata_spec.cr
@@ -17,6 +17,17 @@ describe Log::Metadata do
     Log::Metadata.empty.object_id.should eq(Log::Metadata.empty.object_id)
   end
 
+  it "empty?" do
+    Log::Metadata.empty.should be_empty
+    m({} of Symbol => String).should be_empty
+    Log::Metadata.new.should be_empty
+    m({} of Symbol => String).extend({} of Symbol => String).should be_empty
+
+    m({a: 1}).should_not be_empty
+    m({} of Symbol => String).extend({a: 1}).should_not be_empty
+    m({a: 1}).extend({} of Symbol => String).should_not be_empty
+  end
+
   it "extend" do
     m({a: 1}).extend({b: 2}).should eq(m({a: 1, b: 2}))
     m({a: 1, b: 3}).extend({b: 2}).should eq(m({a: 1, b: 2}))
@@ -27,6 +38,19 @@ describe Log::Metadata do
     c1 = m({a: 1, b: 3})
     c1.extend(NamedTuple.new).should be(c1)
     c1.extend(Hash(Symbol, String).new).should be(c1)
+  end
+
+  it "==" do
+    m({} of Symbol => String).should eq(m({} of Symbol => String))
+    m({a: 1}).should eq(m({a: 1}))
+    m({a: 1, b: 2}).should eq(m({b: 2, a: 1}))
+
+    m({a: 1}).should_not eq(m({a: 2}))
+    m({a: 1}).should_not eq(m({b: 1}))
+
+    m({a: 1}).extend({b: 2}).should eq(m({b: 2}).extend({a: 1}))
+    m({a: 1, b: 1}).extend({b: 2}).should eq(m({b: 2}).extend({a: 1}))
+    m({a: 1, b: 2}).extend({b: 1}).should eq(m({a: 1, b: 1}))
   end
 
   it "json" do

--- a/spec/std/log/metadata_spec.cr
+++ b/spec/std/log/metadata_spec.cr
@@ -40,16 +40,16 @@ describe Log::Metadata do
     context.should eq({"a" => m({"b" => 1})})
   end
 
-  it "merge" do
-    m({a: 1}).merge(m({b: 2})).should eq(m({a: 1, b: 2}))
-    m({a: 1, b: 3}).merge(m({b: 2})).should eq(m({a: 1, b: 2}))
-    m({a: 1, b: 3}).merge(m({b: nil})).should eq(m({a: 1, b: nil}))
+  it "extend" do
+    m({a: 1}).extend({b: 2}).should eq(m({a: 1, b: 2}))
+    m({a: 1, b: 3}).extend({b: 2}).should eq(m({a: 1, b: 2}))
+    m({a: 1, b: 3}).extend({b: nil}).should eq(m({a: 1, b: nil}))
   end
 
-  it "merge against Log::Metadata.empty without creating a new instance" do
+  it "extend against empty values without creating a new instance" do
     c1 = m({a: 1, b: 3})
-    c1.merge(Log::Metadata.empty).should be(c1)
-    Log::Metadata.empty.merge(c1).should be(c1)
+    c1.extend(NamedTuple.new).should be(c1)
+    c1.extend(Hash(String, String).new).should be(c1)
   end
 
   it "accessors" do

--- a/spec/std/log/metadata_spec.cr
+++ b/spec/std/log/metadata_spec.cr
@@ -64,12 +64,14 @@ describe Log::Metadata do
 
     md.@size.should eq(1)
     md.@max_total_size.should eq(4)
+    md.@overriden_size.should eq(1)
     md.@parent.should be(parent)
 
     md.should eq(m({a: 3, b: 2}))
 
     md.@size.should eq(2)
     md.@max_total_size.should eq(2)
+    md.@overriden_size.should eq(1)
     md.@parent.should be_nil
   end
 end

--- a/spec/std/log/metadata_spec.cr
+++ b/spec/std/log/metadata_spec.cr
@@ -74,6 +74,22 @@ describe Log::Metadata do
     md.@overriden_size.should eq(1)
     md.@parent.should be_nil
   end
+
+  it "[]" do
+    md = m({a: 1, b: 2}).extend({a: 3})
+
+    md[:a].should eq(3)
+    md[:b].should eq(2)
+    expect_raises(KeyError) { md[:c] }
+  end
+
+  it "[]?" do
+    md = m({a: 1, b: 2}).extend({a: 3})
+
+    md[:a]?.should eq(3)
+    md[:b]?.should eq(2)
+    md[:c]?.should be_nil
+  end
 end
 
 describe Log::Metadata::Value do

--- a/spec/std/log/metadata_spec.cr
+++ b/spec/std/log/metadata_spec.cr
@@ -57,6 +57,21 @@ describe Log::Metadata do
     m({a: 1}).to_json.should eq(%({"a":1}))
     m({a: 1, b: 1}).extend({b: 2}).to_json.should eq(%({"b":2,"a":1}))
   end
+
+  it "defrags" do
+    parent = m({a: 1, b: 2}).extend({a: 2})
+    md = parent.extend({a: 3})
+
+    md.@size.should eq(1)
+    md.@max_total_size.should eq(4)
+    md.@parent.should be(parent)
+
+    md.should eq(m({a: 3, b: 2}))
+
+    md.@size.should eq(2)
+    md.@max_total_size.should eq(2)
+    md.@parent.should be_nil
+  end
 end
 
 describe Log::Metadata::Value do

--- a/src/log/entry.cr
+++ b/src/log/entry.cr
@@ -43,6 +43,6 @@ struct Log::Entry
   getter exception : Exception?
 
   def initialize(@source : String, @severity : Severity, @message : String, @data : Log::Metadata, @exception : Exception?)
-    raise ArgumentError.new "Expected hash data, not #{data.raw.class}" unless data.as_h?
+    raise ArgumentError.new "Expected hash data, not #{data.raw.class}" unless data.raw.as?(Hash)
   end
 end

--- a/src/log/entry.cr
+++ b/src/log/entry.cr
@@ -43,6 +43,5 @@ struct Log::Entry
   getter exception : Exception?
 
   def initialize(@source : String, @severity : Severity, @message : String, @data : Log::Metadata, @exception : Exception?)
-    raise ArgumentError.new "Expected hash data, not #{data.raw.class}" unless data.raw.as?(Hash)
   end
 end

--- a/src/log/format.cr
+++ b/src/log/format.cr
@@ -104,7 +104,7 @@ class Log
     # Parameters `before` and `after` can be provided to be written around
     # the value.
     def data(*, before = nil, after = nil)
-      if @entry.data.size > 0
+      unless @entry.data.empty?
         @io << before << @entry.data << after
       end
     end
@@ -115,7 +115,7 @@ class Log
     # Parameters `before` and `after` can be provided to be written around
     # the value.
     def context(*, before = nil, after = nil)
-      if @entry.context.size > 0
+      unless @entry.context.empty?
         @io << before << @entry.context << after
       end
     end

--- a/src/log/json.cr
+++ b/src/log/json.cr
@@ -9,6 +9,21 @@ class Log::Metadata
   # log_entry.context.to_json # => "{\"user_id\":1}"
   # ```
   def to_json(builder : JSON::Builder) : Nil
-    @raw.to_json builder
+    builder.object do
+      each do |(key, value)|
+        builder.field key.to_json_object_key do
+          value.to_json(builder)
+        end
+      end
+    end
+  end
+
+  struct Value
+    # Returns `Log::Metadata::Value` as JSON value.
+    #
+    # NOTE: `require "log/json"` is required to opt-in to this feature.
+    def to_json(builder : JSON::Builder) : Nil
+      @raw.to_json builder
+    end
   end
 end

--- a/src/log/main.cr
+++ b/src/log/main.cr
@@ -136,17 +136,17 @@ class Log
     # Log.info { %q(message with {"a" => 1, "b" => 2, "c" => 3 } context) }
     # ```
     def set(**kwargs)
-      extend_fiber_context(Fiber.current, Log::Metadata.build(kwargs))
+      extend_fiber_context(Fiber.current, kwargs)
     end
 
     # :ditto:
     def set(values)
-      extend_fiber_context(Fiber.current, Log::Metadata.build(values))
+      extend_fiber_context(Fiber.current, values)
     end
 
-    private def extend_fiber_context(fiber : Fiber, values : Metadata)
+    private def extend_fiber_context(fiber : Fiber, values)
       context = fiber.logging_context
-      fiber.logging_context = @metadata = context.merge(values)
+      fiber.logging_context = @metadata = context.extend(values)
     end
   end
 

--- a/src/log/metadata.cr
+++ b/src/log/metadata.cr
@@ -61,7 +61,7 @@ class Fiber
 
   # :nodoc:
   def logging_context=(value : Log::Metadata)
-    raise ArgumentError.new "Expected hash context, not #{value.raw.class}" unless value.as_h?
+    raise ArgumentError.new "Expected hash context, not #{value.raw.class}" unless value.raw.as?(Hash)
     @logging_context = value
   end
 end

--- a/src/log/metadata.cr
+++ b/src/log/metadata.cr
@@ -181,16 +181,14 @@ class Log::Metadata
   end
 
   def to_s(io : IO) : Nil
-    io << '{'
     found_one = false
     each do |(key, value)|
       io << ", " if found_one
-      key.inspect(io)
-      io << " => "
+      io << key
+      io << ": "
       value.inspect(io)
       found_one = true
     end
-    io << '}'
   end
 
   struct Value

--- a/src/log/metadata.cr
+++ b/src/log/metadata.cr
@@ -20,7 +20,7 @@ class Log::Metadata
   @first = uninitialized Entry
 
   def self.new(parent : Metadata? = nil, entries : NamedTuple | Hash = NamedTuple.new)
-    data_size = instance_sizeof(self) + sizeof(Entry) * (entries.size - 1)
+    data_size = instance_sizeof(self) + sizeof(Entry) * {entries.size - 1, 0}.max
     data = GC.malloc(data_size).as(self)
     data.setup(parent, entries)
     data
@@ -56,14 +56,13 @@ class Log::Metadata
   # Returns a `Log::Metadata` with all the entries of *self*
   # and *other*. If a key is defined in both, the values in *other* are used.
   def extend(other : NamedTuple | Hash) : Metadata
-    return Metadata.build(other) if self.object_id == @@empty.object_id
+    return Metadata.build(other) if self.empty?
     return self if other.empty?
 
     Metadata.new(self, other)
   end
 
   def empty?
-    # TODO: Add specs
     parent = @parent
 
     @size == 0 && (parent.nil? || parent.empty?)
@@ -94,7 +93,6 @@ class Log::Metadata
   end
 
   def ==(other : Metadata)
-    # TODO: Add specs
     self_kv = self.to_a
     other_kv = other.to_a
 


### PR DESCRIPTION
Related to https://github.com/crystal-lang/crystal/pull/9227#issuecomment-626840159, this PR introduces some modifications proposed in #9188 and some optimizations needed to avoid performance penalties in the presence of implicit contexts mainly.

This PR effectively 
* changes the representation of Metadata to be a structure for the top-level (`Log::Metadata`) and the datum (`Log::Metadata::Value`) for the rest of it
* `Log::Metadata` keys are symbols, but `Log::Metadata::Value` keys are still String. (main api `Log.context.set v: expr` is not changed)
* Since Metadata is always a hash-like structure, there is no need for runtime validation 🚀  
* Metadata are no longer _mergeable_ but they are _extendable_ which was the original intention.
  * This API allow a better representation that delays the merging when it's needed 🚀  
* The output of the metadata (context and local data) is tweaked a bit to be less noisy
* Finally the `Log::Metadata::Value` is no longer immutable. If we would have a way to freeze objects it would be better story. But cloning, always, is way too expensive.

cc: @paulcsmith @carlhoerberg 