### PR TITLE
Fix: realpath on macOS 10.15 (Catalina)

### DIFF
--- a/src/lib_c/x86_64-darwin/c/stdlib.cr
+++ b/src/lib_c/x86_64-darwin/c/stdlib.cr
@@ -17,7 +17,7 @@ lib LibC
   fun mkstemps(x0 : Char*, x1 : Int) : Int
   fun putenv(x0 : Char*) : Int
   fun realloc(x0 : Void*, x1 : SizeT) : Void*
-  fun realpath(x0 : Char*, x1 : Char*) : Char*
+  fun realpath = "realpath$DARWIN_EXTSN"(x0 : Char*, x1 : Char*) : Char*
   fun setenv(x0 : Char*, x1 : Char*, x2 : Int) : Int
   fun strtof(x0 : Char*, x1 : Char**) : Float
   fun strtod(x0 : Char*, x1 : Char**) : Double


### PR DESCRIPTION
This makes use of the alternative symbol `realpath$DARWIN_EXTSN` in macOS. Apparently the original symbol (`realpath`) is not working on 10.15 and it's returing `EONENT` instead.

When using `realpath` in a C program the linked function is `_realpath$DARWIN_EXTSN` so I think we should do the same. I tried to find when was that function introduced and apparently it was around 10.5 (https://newsgroup.xnview.com/viewtopic.php?t=18491). That is, more than 10 years ago. So it's probably safe to use it for any macOS version.

Closes #8547, #8431 