### PR TITLE
Fix double string escape in XML::Node#content=

### DIFF
--- a/spec/std/xml/xml_spec.cr
+++ b/spec/std/xml/xml_spec.cr
@@ -242,6 +242,31 @@ describe XML do
     end
   end
 
+  it "escapes content" do
+    doc = XML.parse(<<-XML)
+      <?xml version='1.0' encoding='UTF-8'?>
+      <name>John</name>
+      XML
+
+    root = doc.root.not_nil!
+    root.text = "<foo>"
+    root.text.should eq("<foo>")
+
+    root.to_xml.should eq(%(<name>&lt;foo&gt;</name>))
+  end
+
+  it "escapes content HTML fragment" do
+    doc = XML.parse_html(<<-XML, XML::HTMLParserOptions.default | XML::HTMLParserOptions::NOIMPLIED | XML::HTMLParserOptions::NODEFDTD)
+      <p>foo</p>
+      XML
+
+    node = doc.children.first
+    node.text = "<foo>"
+    node.text.should eq("<foo>")
+
+    node.to_xml.should eq(%(<p>&lt;foo&gt;</p>))
+  end
+
   it "gets empty content" do
     doc = XML.parse("<foo/>")
     doc.children.first.content.should eq("")

--- a/src/xml/node.cr
+++ b/src/xml/node.cr
@@ -92,7 +92,7 @@ struct XML::Node
   # Sets the Node's content to a Text node containing string.
   # The string gets XML escaped, not interpreted as markup.
   def content=(content)
-    content = escape(content.to_s)
+    check_no_null_byte(content)
     LibXML.xmlNodeSetContent(self, content)
   end
 
@@ -580,19 +580,9 @@ struct XML::Node
     ptr ? (ptr.as(Array(XML::Error))) : nil
   end
 
-  private SUBSTITUTIONS = {
-    '>'  => "&gt;",
-    '<'  => "&lt;",
-    '"'  => "&quot;",
-    '\'' => "&apos;",
-    '&'  => "&amp;",
-  }
-
-  private def escape(string)
-    if string.includes? '\0'
+  private def check_no_null_byte(string)
+    if string.includes? Char::ZERO
       raise XML::Error.new("Cannot escape string containing null character", 0)
     end
-
-    string.gsub(SUBSTITUTIONS)
   end
 end


### PR DESCRIPTION
Libxml2 already escapes special characters in node content, there's no need for the custom `escape` method. It lead to double escape which turns `<foo>` content into `&amp;lt;foo&amp;&gt;`.

The escape method was introduced in #4089 but there's no mention of this escape behaviour in neither the PR nor the linked issue and there have been no specs for this. So I assume it was just wrongly added.

/cc @RX14 