### PR TITLE
Doc: show input type path instead of full qualified path on generic

### DIFF
--- a/spec/compiler/crystal/tools/doc/type_spec.cr
+++ b/spec/compiler/crystal/tools/doc/type_spec.cr
@@ -44,4 +44,58 @@ describe Doc::Type do
     foo.lookup_class_method("new").should_not be_nil
     foo.lookup_class_method("new", 1).should_not be_nil
   end
+
+  describe "#node_to_html" do
+    it "shows relative path" do
+      program = semantic(<<-CODE, wants_doc: true).program
+        class Foo
+          class Bar
+          end
+        end
+        CODE
+
+      generator = Doc::Generator.new program, [""]
+      foo = generator.type(program.types["Foo"])
+      foo.node_to_html("Bar".path).should eq(%(<a href="Foo/Bar.html">Bar</a>))
+    end
+
+    it "shows relative generic" do
+      program = semantic(<<-CODE, wants_doc: true).program
+        class Foo
+          class Bar(T)
+          end
+        end
+        CODE
+
+      generator = Doc::Generator.new program, [""]
+      foo = generator.type(program.types["Foo"])
+      foo.node_to_html(Generic.new("Bar".path, ["Foo".path] of ASTNode)).should eq(%(<a href="Foo/Bar.html">Bar</a>(<a href="Foo.html">Foo</a>)))
+    end
+
+    it "shows generic path with necessary colons" do
+      program = semantic(<<-CODE, wants_doc: true).program
+        class Foo
+          class Foo
+          end
+        end
+        CODE
+
+      generator = Doc::Generator.new program, [""]
+      foo = generator.type(program.types["Foo"])
+      foo.node_to_html("Foo".path(global: true)).should eq(%(<a href="Foo.html">::Foo</a>))
+    end
+
+    it "shows generic path with unnecessary colons" do
+      program = semantic(<<-CODE, wants_doc: true).program
+        class Foo
+          class Bar
+          end
+        end
+        CODE
+
+      generator = Doc::Generator.new program, [""]
+      foo = generator.type(program.types["Foo"])
+      foo.node_to_html("Foo".path(global: true)).should eq(%(<a href="Foo.html">Foo</a>))
+    end
+  end
 end

--- a/spec/compiler/crystal/tools/doc/type_spec.cr
+++ b/spec/compiler/crystal/tools/doc/type_spec.cr
@@ -47,7 +47,7 @@ describe Doc::Type do
 
   describe "#node_to_html" do
     it "shows relative path" do
-      program = semantic(<<-CODE, wants_doc: true).program
+      program = semantic(<<-CODE).program
         class Foo
           class Bar
           end
@@ -60,7 +60,7 @@ describe Doc::Type do
     end
 
     it "shows relative generic" do
-      program = semantic(<<-CODE, wants_doc: true).program
+      program = semantic(<<-CODE).program
         class Foo
           class Bar(T)
           end
@@ -73,7 +73,7 @@ describe Doc::Type do
     end
 
     it "shows generic path with necessary colons" do
-      program = semantic(<<-CODE, wants_doc: true).program
+      program = semantic(<<-CODE).program
         class Foo
           class Foo
           end
@@ -86,7 +86,7 @@ describe Doc::Type do
     end
 
     it "shows generic path with unnecessary colons" do
-      program = semantic(<<-CODE, wants_doc: true).program
+      program = semantic(<<-CODE).program
         class Foo
           class Bar
           end

--- a/spec/compiler/crystal/tools/doc/type_spec.cr
+++ b/spec/compiler/crystal/tools/doc/type_spec.cr
@@ -47,54 +47,62 @@ describe Doc::Type do
 
   describe "#node_to_html" do
     it "shows relative path" do
-      program = semantic(<<-CODE, wants_doc: true).program
-        class Foo
-          class Bar
-          end
-        end
-        CODE
-
+      program = Program.new
       generator = Doc::Generator.new program, [""]
-      foo = generator.type(program.types["Foo"])
+
+      foo_class = NonGenericClassType.new program, program, "Foo", nil
+      bar_class = NonGenericClassType.new program, foo_class, "Bar", nil
+      foo_class.add_location Location.new("", 0, 0)
+      bar_class.add_location Location.new("", 0, 0)
+      program.types["Foo"] = foo_class
+      foo_class.types["Bar"] = bar_class
+
+      foo = generator.type(foo_class)
       foo.node_to_html("Bar".path).should eq(%(<a href="Foo/Bar.html">Bar</a>))
     end
 
     it "shows relative generic" do
-      program = semantic(<<-CODE, wants_doc: true).program
-        class Foo
-          class Bar(T)
-          end
-        end
-        CODE
-
+      program = Program.new
       generator = Doc::Generator.new program, [""]
-      foo = generator.type(program.types["Foo"])
+
+      foo_class = NonGenericClassType.new program, program, "Foo", nil
+      bar_class = GenericClassType.new program, foo_class, "Bar", nil, %w[T]
+      foo_class.add_location Location.new("", 0, 0)
+      bar_class.add_location Location.new("", 0, 0)
+      program.types["Foo"] = foo_class
+      foo_class.types["Bar"] = bar_class
+
+      foo = generator.type(foo_class)
       foo.node_to_html(Generic.new("Bar".path, ["Foo".path] of ASTNode)).should eq(%(<a href="Foo/Bar.html">Bar</a>(<a href="Foo.html">Foo</a>)))
     end
 
     it "shows generic path with necessary colons" do
-      program = semantic(<<-CODE, wants_doc: true).program
-        class Foo
-          class Foo
-          end
-        end
-        CODE
-
+      program = Program.new
       generator = Doc::Generator.new program, [""]
-      foo = generator.type(program.types["Foo"])
+
+      outer_foo_class = NonGenericClassType.new program, program, "Foo", nil
+      inter_foo_class = NonGenericClassType.new program, outer_foo_class, "Foo", nil
+      outer_foo_class.add_location Location.new("", 0, 0)
+      inter_foo_class.add_location Location.new("", 0, 0)
+      program.types["Foo"] = outer_foo_class
+      outer_foo_class.types["Foo"] = inter_foo_class
+
+      foo = generator.type(outer_foo_class)
       foo.node_to_html("Foo".path(global: true)).should eq(%(<a href="Foo.html">::Foo</a>))
     end
 
     it "shows generic path with unnecessary colons" do
-      program = semantic(<<-CODE, wants_doc: true).program
-        class Foo
-          class Bar
-          end
-        end
-        CODE
-
+      program = Program.new
       generator = Doc::Generator.new program, [""]
-      foo = generator.type(program.types["Foo"])
+
+      foo_class = NonGenericClassType.new program, program, "Foo", nil
+      bar_class = NonGenericClassType.new program, foo_class, "Bar", nil
+      foo_class.add_location Location.new("", 0, 0)
+      bar_class.add_location Location.new("", 0, 0)
+      program.types["Foo"] = foo_class
+      foo_class.types["Bar"] = bar_class
+
+      foo = generator.type(foo_class)
       foo.node_to_html("Foo".path(global: true)).should eq(%(<a href="Foo.html">Foo</a>))
     end
   end

--- a/spec/compiler/crystal/tools/doc/type_spec.cr
+++ b/spec/compiler/crystal/tools/doc/type_spec.cr
@@ -47,62 +47,54 @@ describe Doc::Type do
 
   describe "#node_to_html" do
     it "shows relative path" do
-      program = Program.new
+      program = semantic(<<-CODE, wants_doc: true).program
+        class Foo
+          class Bar
+          end
+        end
+        CODE
+
       generator = Doc::Generator.new program, [""]
-
-      foo_class = NonGenericClassType.new program, program, "Foo", nil
-      bar_class = NonGenericClassType.new program, foo_class, "Bar", nil
-      foo_class.add_location Location.new("", 0, 0)
-      bar_class.add_location Location.new("", 0, 0)
-      program.types["Foo"] = foo_class
-      foo_class.types["Bar"] = bar_class
-
-      foo = generator.type(foo_class)
+      foo = generator.type(program.types["Foo"])
       foo.node_to_html("Bar".path).should eq(%(<a href="Foo/Bar.html">Bar</a>))
     end
 
     it "shows relative generic" do
-      program = Program.new
+      program = semantic(<<-CODE, wants_doc: true).program
+        class Foo
+          class Bar(T)
+          end
+        end
+        CODE
+
       generator = Doc::Generator.new program, [""]
-
-      foo_class = NonGenericClassType.new program, program, "Foo", nil
-      bar_class = GenericClassType.new program, foo_class, "Bar", nil, %w[T]
-      foo_class.add_location Location.new("", 0, 0)
-      bar_class.add_location Location.new("", 0, 0)
-      program.types["Foo"] = foo_class
-      foo_class.types["Bar"] = bar_class
-
-      foo = generator.type(foo_class)
+      foo = generator.type(program.types["Foo"])
       foo.node_to_html(Generic.new("Bar".path, ["Foo".path] of ASTNode)).should eq(%(<a href="Foo/Bar.html">Bar</a>(<a href="Foo.html">Foo</a>)))
     end
 
     it "shows generic path with necessary colons" do
-      program = Program.new
+      program = semantic(<<-CODE, wants_doc: true).program
+        class Foo
+          class Foo
+          end
+        end
+        CODE
+
       generator = Doc::Generator.new program, [""]
-
-      outer_foo_class = NonGenericClassType.new program, program, "Foo", nil
-      inter_foo_class = NonGenericClassType.new program, outer_foo_class, "Foo", nil
-      outer_foo_class.add_location Location.new("", 0, 0)
-      inter_foo_class.add_location Location.new("", 0, 0)
-      program.types["Foo"] = outer_foo_class
-      outer_foo_class.types["Foo"] = inter_foo_class
-
-      foo = generator.type(outer_foo_class)
+      foo = generator.type(program.types["Foo"])
       foo.node_to_html("Foo".path(global: true)).should eq(%(<a href="Foo.html">::Foo</a>))
     end
 
     it "shows generic path with unnecessary colons" do
-      program = Program.new
+      program = semantic(<<-CODE, wants_doc: true).program
+        class Foo
+          class Bar
+          end
+        end
+        CODE
+
       generator = Doc::Generator.new program, [""]
-
-      foo_class = NonGenericClassType.new program, program, "Foo", nil
-      bar_class = NonGenericClassType.new program, foo_class, "Bar", nil
-      foo_class.add_location Location.new("", 0, 0)
-      bar_class.add_location Location.new("", 0, 0)
-      program.types["Foo"] = foo_class
-      foo_class.types["Bar"] = bar_class
-
-      foo = generator.type(foo_class)
+      foo = generator.type(program.types["Foo"])
       foo.node_to_html("Foo".path(global: true)).should eq(%(<a href="Foo.html">Foo</a>))
     end
   end

--- a/src/compiler/crystal/tools/doc/type.cr
+++ b/src/compiler/crystal/tools/doc/type.cr
@@ -496,24 +496,7 @@ class Crystal::Doc::Type
   end
 
   def node_to_html(node : Generic, io, links = true)
-    match = lookup_path(node.name.as(Path))
-    if match
-      if match.must_be_included?
-        if links
-          io << %(<a href=")
-          io << match.path_from(self)
-          io << %(">)
-        end
-        match.full_name_without_type_vars(io)
-        if links
-          io << "</a>"
-        end
-      else
-        io << node.name
-      end
-    else
-      io << node.name
-    end
+    node_to_html node.name, io, links: links
     io << '('
     node.type_vars.join(io, ", ") do |type_var|
       node_to_html type_var, io, links: links


### PR DESCRIPTION
The following is all. Input code:

```crystal
module Foo
  class Bar(T)
    def path : Bar
    end

    def generic : Bar(Foo)
    end
  end
end
```

Before:

![スクリーンショット 2020-05-15 23 33 34](https://user-images.githubusercontent.com/6679325/82062694-72826400-9705-11ea-8659-3d13f7658009.png)

After:

![スクリーンショット 2020-05-15 23 35 28](https://user-images.githubusercontent.com/6679325/82062704-757d5480-9705-11ea-90b2-5f3a80528651.png)
