### PR TITLE
[Docs] Fix source_url_pattern with canonical repo name

### DIFF
--- a/spec/compiler/crystal/tools/doc/project_info_spec.cr
+++ b/spec/compiler/crystal/tools/doc/project_info_spec.cr
@@ -258,7 +258,7 @@ describe Crystal::Doc::ProjectInfo do
     ProjectInfo.find_source_url_pattern("http://example.com/foo/bar").should be_nil
 
     ProjectInfo.find_source_url_pattern("git@github.com:foo/bar/").should eq "https://github.com/foo/bar/blob/%{refname}/%{path}#L%{line}"
-    ProjectInfo.find_source_url_pattern("git@github.com:foo/bar.git").should eq "https://github.com/foo/bar.git/blob/%{refname}/%{path}#L%{line}"
+    ProjectInfo.find_source_url_pattern("git@github.com:foo/bar.git").should eq "https://github.com/foo/bar/blob/%{refname}/%{path}#L%{line}"
 
     ProjectInfo.find_source_url_pattern("git@github.com:foo/bar").should eq "https://github.com/foo/bar/blob/%{refname}/%{path}#L%{line}"
     ProjectInfo.find_source_url_pattern("http://github.com/foo/bar").should eq "https://github.com/foo/bar/blob/%{refname}/%{path}#L%{line}"
@@ -266,18 +266,21 @@ describe Crystal::Doc::ProjectInfo do
     ProjectInfo.find_source_url_pattern("http://www.github.com/foo/bar").should eq "https://github.com/foo/bar/blob/%{refname}/%{path}#L%{line}"
     ProjectInfo.find_source_url_pattern("https://www.github.com/foo/bar").should eq "https://github.com/foo/bar/blob/%{refname}/%{path}#L%{line}"
 
-    ProjectInfo.find_source_url_pattern("https://github.com/foo/bar.git").should eq "https://github.com/foo/bar.git/blob/%{refname}/%{path}#L%{line}"
+    ProjectInfo.find_source_url_pattern("https://github.com/foo/bar.git").should eq "https://github.com/foo/bar/blob/%{refname}/%{path}#L%{line}"
     ProjectInfo.find_source_url_pattern("https://github.com/foo/bar.cr").should eq "https://github.com/foo/bar.cr/blob/%{refname}/%{path}#L%{line}"
-    ProjectInfo.find_source_url_pattern("https://github.com/foo/bar.cr.git").should eq "https://github.com/foo/bar.cr.git/blob/%{refname}/%{path}#L%{line}"
+    ProjectInfo.find_source_url_pattern("https://github.com/foo/bar.cr.git").should eq "https://github.com/foo/bar.cr/blob/%{refname}/%{path}#L%{line}"
 
     ProjectInfo.find_source_url_pattern("git@gitlab.com:foo/bar").should eq "https://gitlab.com/foo/bar/blob/%{refname}/%{path}#L%{line}"
     ProjectInfo.find_source_url_pattern("http://gitlab.com/foo/bar").should eq "https://gitlab.com/foo/bar/blob/%{refname}/%{path}#L%{line}"
+    ProjectInfo.find_source_url_pattern("http://gitlab.com/foo/bar.git").should eq "https://gitlab.com/foo/bar/blob/%{refname}/%{path}#L%{line}"
 
     ProjectInfo.find_source_url_pattern("git@bitbucket.com:foo/bar").should eq "https://bitbucket.com/foo/bar/src/%{refname}/%{path}#%{filename}-%{line}"
     ProjectInfo.find_source_url_pattern("http://bitbucket.com/foo/bar").should eq "https://bitbucket.com/foo/bar/src/%{refname}/%{path}#%{filename}-%{line}"
+    ProjectInfo.find_source_url_pattern("http://bitbucket.com/foo/bar.git").should eq "https://bitbucket.com/foo/bar/src/%{refname}/%{path}#%{filename}-%{line}"
 
     ProjectInfo.find_source_url_pattern("git@git.sr.ht:~foo/bar").should eq "https://git.sr.ht/~foo/bar/tree/%{refname}/%{path}#L%{line}"
     ProjectInfo.find_source_url_pattern("http://git.sr.ht/~foo/bar").should eq "https://git.sr.ht/~foo/bar/tree/%{refname}/%{path}#L%{line}"
+    ProjectInfo.find_source_url_pattern("http://git.sr.ht/~foo/bar.git").should eq "https://git.sr.ht/~foo/bar.git/tree/%{refname}/%{path}#L%{line}"
   end
 
   describe "#source_url" do

--- a/src/compiler/crystal/tools/doc/project_info.cr
+++ b/src/compiler/crystal/tools/doc/project_info.cr
@@ -92,12 +92,20 @@ module Crystal::Doc
 
       case host
       when "github.com", "www.github.com"
+        # GitHub only resolves URLs with the canonical repo name without .git extension.
+        path = path.rchop(".git")
         "https://github.com/#{path}/blob/%{refname}/%{path}#L%{line}"
       when "gitlab.com", "www.gitlab.com"
+        # Gitlab only resolves URLs with the canonical repo name without .git extension.
+        path = path.rchop(".git")
         "https://gitlab.com/#{path}/blob/%{refname}/%{path}#L%{line}"
       when "bitbucket.com", "www.bitbucket.com"
+        # Bitbucket does resolve URLs the URL with .git extension, but without it
+        # the canonical form and should be preferred.
+        path = path.rchop(".git")
         "https://bitbucket.com/#{path}/src/%{refname}/%{path}#%{filename}-%{line}"
       when "git.sr.ht"
+        # On git.sr.ht ~foo/bar and ~foo/bar.git seem to mean different repos.
         "https://git.sr.ht/#{path}/tree/%{refname}/%{path}#L%{line}"
       else
         # Unknown remote host, can't determine source url pattern


### PR DESCRIPTION
GitHub and Gitlab won't resolve source URLs when the repo name has a .git extension. This extension works for other use cases (like git URLs).

Fixes #9304