### PR TITLE
Resolve the always-present Windows linker's warnings

### DIFF
--- a/.github/workflows/win.yml
+++ b/.github/workflows/win.yml
@@ -147,10 +147,10 @@ jobs:
           name: objs
       - name: Build LLVM extensions
         run: |
-          cl /MT /c src\llvm\ext\llvm_ext.cc -I llvm\include /Fosrc\llvm\ext\llvm_ext.o
+          cl /MT /c src\llvm\ext\llvm_ext.cc -I llvm\include /Fosrc\llvm\ext\llvm_ext.obj
       - name: Link Crystal executable
         run: |
-          Invoke-Expression "cl objs\crystal.obj /Fecrystal-cross src\llvm\ext\llvm_ext.o $(llvm\bin\llvm-config.exe --libs) libs\pcre.lib libs\gc.lib advapi32.lib libcmt.lib legacy_stdio_definitions.lib /F10000000"
+          Invoke-Expression "cl objs\crystal.obj /Fecrystal-cross src\llvm\ext\llvm_ext.obj $(llvm\bin\llvm-config.exe --libs) libs\pcre.lib libs\gc.lib advapi32.lib libcmt.lib legacy_stdio_definitions.lib /F10000000"
 
       - name: Re-build Crystal
         run: |

--- a/.github/workflows/win.yml
+++ b/.github/workflows/win.yml
@@ -16,12 +16,13 @@ jobs:
       - name: Cross-compile Crystal
         run: |
           LLVM_TARGETS=X86 bin/crystal build --cross-compile --target x86_64-pc-windows-msvc src/compiler/crystal.cr -Dwithout_playground
+          mv crystal.o crystal.obj || true  # TODO: Remove this after 0.35.0
 
       - name: Upload Crystal object file
         uses: actions/upload-artifact@v1
         with:
           name: objs
-          path: crystal.o
+          path: crystal.obj
 
   windows-job:
     needs: linux-job
@@ -149,7 +150,7 @@ jobs:
           cl /MT /c src\llvm\ext\llvm_ext.cc -I llvm\include /Fosrc\llvm\ext\llvm_ext.o
       - name: Link Crystal executable
         run: |
-          Invoke-Expression "cl objs\crystal.o /Fecrystal-cross src\llvm\ext\llvm_ext.o $(llvm\bin\llvm-config.exe --libs) libs\pcre.lib libs\gc.lib advapi32.lib libcmt.lib legacy_stdio_definitions.lib /F10000000"
+          Invoke-Expression "cl objs\crystal.obj /Fecrystal-cross src\llvm\ext\llvm_ext.o $(llvm\bin\llvm-config.exe --libs) libs\pcre.lib libs\gc.lib advapi32.lib libcmt.lib legacy_stdio_definitions.lib /F10000000"
 
       - name: Re-build Crystal
         run: |

--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@ all_spec
 /tmp
 /docs/
 /src/llvm/ext/llvm_ext.o
+/src/llvm/ext/llvm_ext.obj
 /src/llvm/ext/llvm_ext.dwo
 /src/ext/*.o
 /src/ext/libcrystal.a

--- a/src/compiler/crystal/codegen/link.cr
+++ b/src/compiler/crystal/codegen/link.cr
@@ -86,6 +86,10 @@ module Crystal
   end
 
   class Program
+    def object_extension
+      has_flag?("windows") ? ".obj" : ".o"
+    end
+
     def lib_flags
       has_flag?("windows") ? lib_flags_windows : lib_flags_posix
     end

--- a/src/llvm/lib_llvm_ext.cr
+++ b/src/llvm/lib_llvm_ext.cr
@@ -1,5 +1,9 @@
 require "./lib_llvm"
-@[Link(ldflags: "#{__DIR__}/ext/llvm_ext.o")]
+{% if flag?(:win32) %}
+  @[Link(ldflags: "#{__DIR__}/ext/llvm_ext.obj")]
+{% else %}
+  @[Link(ldflags: "#{__DIR__}/ext/llvm_ext.o")]
+{% end %}
 lib LibLLVMExt
   alias Char = LibC::Char
   alias Int = LibC::Int


### PR DESCRIPTION
Currently when building on Windows, the version of MSVC linker is always printed first, then the list of all inputs, then a warning for every object file because it ends with .o, not .obj.

So, use the .obj extension and disable the default outputs. So errors are still printed, but normally the output is empty.

Also switch the file extension for llvm_ext.obj
