### PR TITLE
Add MatchData#matches_full_string?

### DIFF
--- a/spec/std/match_data_spec.cr
+++ b/spec/std/match_data_spec.cr
@@ -272,4 +272,10 @@ describe "Regex::MatchData" do
     hash.should eq(re.match("a").hash)
     hash.should_not eq(re.match("b").hash)
   end
+
+  it "#matches_full_string?" do
+    /foo/.match("foo").not_nil!.matches_full_string?.should be_true
+    /foo/.match("fooo").not_nil!.matches_full_string?.should be_false
+    /foo/.match("ofoo").not_nil!.matches_full_string?.should be_false
+  end
 end

--- a/spec/std/match_data_spec.cr
+++ b/spec/std/match_data_spec.cr
@@ -277,5 +277,7 @@ describe "Regex::MatchData" do
     /foo/.match("foo").not_nil!.matches_full_string?.should be_true
     /foo/.match("fooo").not_nil!.matches_full_string?.should be_false
     /foo/.match("ofoo").not_nil!.matches_full_string?.should be_false
+    /(\A)?pattern(\z)?/.match("pattern").not_nil!.matches_full_string?.should be_true
+    /(\A)?pattern(\z)?/.match("_pattern_").not_nil!.matches_full_string?.should be_false
   end
 end

--- a/src/regex/match_data.cr
+++ b/src/regex/match_data.cr
@@ -117,7 +117,7 @@ class Regex
     # Returns `true` if `string` was matched entirely from start to end.
     #
     # ```
-    # /foo/.match("foo").try(&.matches_full_string?) # => true
+    # /foo/.match("foo").try(&.matches_full_string?)  # => true
     # /foo/.match("fooo").try(&.matches_full_string?) # => false
     # /foo/.match("ofoo").try(&.matches_full_string?) # => false
     # ```

--- a/src/regex/match_data.cr
+++ b/src/regex/match_data.cr
@@ -114,6 +114,17 @@ class Regex
       @ovector[n * 2 + 1]
     end
 
+    # Returns `true` if `string` was matched entirely from start to end.
+    #
+    # ```
+    # /foo/.match("foo").try(&.matches_full_string?) # => true
+    # /foo/.match("fooo").try(&.matches_full_string?) # => false
+    # /foo/.match("ofoo").try(&.matches_full_string?) # => false
+    # ```
+    def matches_full_string?
+      byte_begin(0) == 0 && byte_end(0) == string.bytesize
+    end
+
     # Returns the match of the *n*th capture group, or `nil` if there isn't
     # an *n*th capture group.
     #


### PR DESCRIPTION
Adds a methd that tells whether a regex matched the entire string or not.
I found such a method useful, so maybe it would be good to have it by default.