### PR TITLE
Add String#matches_full, #match_full

### DIFF
--- a/spec/std/string_spec.cr
+++ b/spec/std/string_spec.cr
@@ -2067,6 +2067,22 @@ describe "String" do
     "foo".matches?(/bar/).should eq(false)
   end
 
+  it "#matches_full?" do
+    "foo".matches_full?(/foo/).should be_true
+    "fooo".matches_full?(/foo/).should be_false
+    "ofoo".matches_full?(/foo/).should be_false
+    "pattern".matches_full?(/(\A)?pattern(\z)?/).should be_true
+    "_pattern_".matches_full?(/(\A)?pattern(\z)?/).should be_false
+  end
+
+  it "#match_full?" do
+    "foo".match_full(/foo/).not_nil![0].should eq "foo"
+    "fooo".match_full(/foo/).should be_nil
+    "ofoo".match_full(/foo/).should be_nil
+    "pattern".match_full(/(\A)?pattern(\z)?/).not_nil![0].should eq "pattern"
+    "_pattern_".match_full(/(\A)?pattern(\z)?/).should be_nil
+  end
+
   it "has size (same as size)" do
     "テスト".size.should eq(3)
   end

--- a/spec/std/string_spec.cr
+++ b/spec/std/string_spec.cr
@@ -2075,7 +2075,7 @@ describe "String" do
     "_pattern_".matches_full?(/(\A)?pattern(\z)?/).should be_false
   end
 
-  it "#match_full?" do
+  it "#match_full" do
     "foo".match_full(/foo/).not_nil![0].should eq "foo"
     "fooo".match_full(/foo/).should be_nil
     "ofoo".match_full(/foo/).should be_nil

--- a/src/string.cr
+++ b/src/string.cr
@@ -4166,6 +4166,34 @@ class String
     regex.matches? self, pos
   end
 
+  # Returns `true` if the regular expression *regex* matches this string entirely.
+  # It also updates `$~` with the result.
+  #
+  # ```
+  # "foo".match_full(/foo/)   # => Regex::MatchData("foo")
+  # $~                        # => Regex::MatchData("foo")
+  # "fooo".match_full(/foo/)  # => nil
+  # $~                        # raises Exception
+  # ```
+  def match_full(regex : Regex) : Regex::MatchData?
+    match = /(?:#{regex})\z/.match_at_byte_index(self, 0, Regex::Options::ANCHORED)
+    $~ = match
+    match
+  end
+
+  # Returns `true` if the regular expression *regex* matches this string entirely.
+  #
+  # ```
+  # "foo".matches_full?(/foo/)  # => true
+  # "fooo".matches_full?(/foo/) # => false
+  #
+  # # `$~` is not set even if last match succeeds.
+  # $~ # raises Exception
+  # ```
+  def matches_full?(regex : Regex) : Bool
+    starts_with?(/(?:#{regex})\z/)
+  end
+
   # Searches the string for instances of *pattern*,
   # yielding a `Regex::MatchData` for each match.
   def scan(pattern : Regex)

--- a/src/string.cr
+++ b/src/string.cr
@@ -4166,7 +4166,8 @@ class String
     regex.matches? self, pos
   end
 
-  # Returns `true` if the regular expression *regex* matches this string entirely.
+  # Matches the regular expression *regex* against the entire string and returns
+  # the resulting `MatchData`.
   # It also updates `$~` with the result.
   #
   # ```


### PR DESCRIPTION
Adds method to `String` to matche a regular expression over the entire string.

See #9309 for a related PR (which is probably not necessary after this one) and the discussion that brought up the idea for this.