### PR TITLE
WebSocket shouldn't reply with same close code

### DIFF
--- a/src/http/web_socket.cr
+++ b/src/http/web_socket.cr
@@ -159,7 +159,7 @@ class HTTP::WebSocket
           message = @current_message.gets_to_end
 
           @on_close.try &.call(code, message)
-          close(code)
+          close
 
           @current_message.clear
           break


### PR DESCRIPTION
Currently `WebSocket` is replying to a close event with the same close code. But this causes this error on Chrome for example:

```
WebSocket connection to 'ws://localhost:8080/' failed: Received a broken close frame containing a reserved status code.
```

This is because not all error codes are meant to be sent.

This PR doesn't include any new spec because currently the `WebSocket` acting as a client is closing the `IO` before awaiting for the response, thus always returning an "abnormal close". I promise I'll send another PR later fixing that and properly testing this change also. For now I think this is ok, because it solves the issue and as can be seen, it doesn't even break any existing spec.