### PR TITLE
Always include `lib` directory in the CRYSTAL_PATH

### DIFF
--- a/spec/compiler/crystal_path/crystal_path_spec.cr
+++ b/spec/compiler/crystal_path/crystal_path_spec.cr
@@ -1,4 +1,5 @@
 require "../../spec_helper"
+require "../../support/env"
 
 private def assert_finds(search, results, relative_to = nil, path = __DIR__, file = __FILE__, line = __LINE__)
   it "finds #{search.inspect}", file, line do
@@ -113,5 +114,19 @@ describe Crystal::CrystalPath do
     end
 
     ex.message.not_nil!.should_not contain "If you're trying to require a shard"
+  end
+
+  it "includes 'lib' by default" do
+    with_env("CRYSTAL_PATH": nil) do
+      crystal_path = Crystal::CrystalPath.new
+      crystal_path.entries[0].should eq("lib")
+    end
+  end
+
+  it "overrides path with environment variable" do
+    with_env("CRYSTAL_PATH": "foo:bar") do
+      crystal_path = Crystal::CrystalPath.new
+      crystal_path.entries.should eq(%w(foo bar))
+    end
   end
 end

--- a/spec/std/log/env_config_spec.cr
+++ b/spec/std/log/env_config_spec.cr
@@ -1,26 +1,10 @@
 require "spec"
 require "log"
 require "log/spec"
+require "../../support/env"
 
 private def s(value : Log::Severity)
   value
-end
-
-private def with_env(**values)
-  old_values = {} of String => String?
-  begin
-    values.each do |key, value|
-      key = key.to_s
-      old_values[key] = ENV[key]?
-      ENV[key] = value
-    end
-
-    yield
-  ensure
-    old_values.each do |key, old_value|
-      ENV[key] = old_value
-    end
-  end
 end
 
 describe "Log.setup_from_env" do

--- a/spec/support/env.cr
+++ b/spec/support/env.cr
@@ -1,0 +1,16 @@
+def with_env(**values)
+  old_values = {} of String => String?
+  begin
+    values.each do |key, value|
+      key = key.to_s
+      old_values[key] = ENV[key]?
+      ENV[key] = value
+    end
+
+    yield
+  ensure
+    old_values.each do |key, old_value|
+      ENV[key] = old_value
+    end
+  end
+end


### PR DESCRIPTION
As discussed in #9280, this always includes `lib` as part of the source path. This is still overridable with a new `CRYSTAL_PATH` environment variable, but it's not required anymore that `lib` is included in the CRYSTAL_CONFIG_PATH and/or write wrapper scripts to inject that value.