### PR TITLE
Keep Log::Severity::Warning as deprecated definition

### DIFF
--- a/src/log/entry.cr
+++ b/src/log/entry.cr
@@ -10,6 +10,8 @@ enum Log::Severity
   Notice
   # Used for conditions that can potentially cause application oddities, but that can be automatically recovered.
   Warn
+  # DEPRECATED: Use `Warn`.
+  Warning = Warn
   # Used for any error that is fatal to the operation, but not to the service or application.
   Error
   # Used for any error that is forcing a shutdown of the service or application


### PR DESCRIPTION
This will unlock nightlies since shards 0.10.0 uses that definition. Ref: #9293 