### PR TITLE
Fix flush methods to always flush underlying IO

### DIFF
--- a/src/compress/deflate/writer.cr
+++ b/src/compress/deflate/writer.cr
@@ -60,6 +60,7 @@ class Compress::Deflate::Writer < IO
     return if @closed
 
     consume_output LibZ::Flush::SYNC_FLUSH
+    @output.flush
   end
 
   # Closes this writer. Must be invoked after all data has been written.

--- a/src/pretty_print.cr
+++ b/src/pretty_print.cr
@@ -191,6 +191,8 @@ class PrettyPrint
     end
     @buffer.clear
     @buffer_width = 0
+
+    @output.flush
   end
 
   private class Text

--- a/src/xml/builder.cr
+++ b/src/xml/builder.cr
@@ -378,7 +378,6 @@ module XML
     # when StartDocument is omitted.
     xml.end_document
     xml.flush
-    io.flush
     v
   end
 end

--- a/src/xml/builder.cr
+++ b/src/xml/builder.cr
@@ -11,7 +11,7 @@ struct XML::Builder
   @box : Void*
 
   # Creates a builder that writes to the given *io*.
-  def initialize(io : IO)
+  def initialize(@io : IO)
     @box = Box.box(io)
     buffer = LibXML.xmlOutputBufferCreateIO(
       ->(ctx, buffer, len) {
@@ -249,6 +249,8 @@ struct XML::Builder
   # this writer's `IO`.
   def flush
     call Flush
+
+    @io.flush
   end
 
   # Sets the indent string.

--- a/src/yaml/builder.cr
+++ b/src/yaml/builder.cr
@@ -183,6 +183,8 @@ class YAML::Builder
   # Flushes any pending data to the underlying `IO`.
   def flush
     LibYAML.yaml_emitter_flush(@emitter)
+
+    @io.flush
   end
 
   def finalize


### PR DESCRIPTION
It seems like a good idea to flush the underlying IO when `flush` is called on a wrapper.

https://github.com/crystal-lang/crystal/issues/8891#issuecomment-630766505