### PR TITLE
Compiler: fix yield computation inside macro code

### DIFF
--- a/spec/compiler/parser/parser_spec.cr
+++ b/spec/compiler/parser/parser_spec.cr
@@ -1995,6 +1995,12 @@ module Crystal
         name_location.line_number.should eq(1)
         name_location.column_number.should eq(12)
       end
+
+      it "doesn't override yield with macro yield" do
+        parser = Parser.new("def foo; yield 1; {% begin %} yield 1 {% end %}; end")
+        a_def = parser.parse.as(Def)
+        a_def.yields.should eq(1)
+      end
     end
   end
 end

--- a/spec/compiler/semantic/abstract_def_spec.cr
+++ b/spec/compiler/semantic/abstract_def_spec.cr
@@ -636,4 +636,42 @@ describe "Semantic: abstract def" do
       end
     ))
   end
+
+  it "can implement even if yield comes later in macro code" do
+    semantic(%(
+      module Moo
+        abstract def each(& : Int32 -> _)
+      end
+
+      class Foo
+        include Moo
+
+        def each
+          yield 1
+
+          {% if true %}
+            yield 2
+          {% end %}
+        end
+      end
+    ))
+  end
+
+  it "can implement by block signature even if yield comes later in macro code" do
+    semantic(%(
+      module Moo
+        abstract def each(& : Int32 -> _)
+      end
+
+      class Foo
+        include Moo
+
+        def each(& : Int32 -> _)
+          {% if true %}
+            yield 2
+          {% end %}
+        end
+      end
+    ))
+  end
 end

--- a/src/compiler/crystal/syntax/parser.cr
+++ b/src/compiler/crystal/syntax/parser.cr
@@ -3042,7 +3042,7 @@ module Crystal
         next_macro_token macro_state, skip_whitespace
         macro_state = @token.macro_state
         if macro_state.yields
-          @yields = 0
+          @yields ||= 0
         end
 
         skip_whitespace = false


### PR DESCRIPTION
Try the code snippets in `abstract_def_spec.cr`, they will fail in `master`. This PR fixes them.