### PR TITLE
Range: use `while true` when possible in `each` and `reverse_each`

### DIFF
--- a/spec/std/range_spec.cr
+++ b/spec/std/range_spec.cr
@@ -28,6 +28,18 @@ struct RangeSpecIntWrapper
   end
 end
 
+private def range_endless_each
+  (2..).each do |x|
+    return x
+  end
+end
+
+private def range_beginless_reverse_each
+  (..2).reverse_each do |x|
+    return x
+  end
+end
+
 describe "Range" do
   it "initialized with new method" do
     Range.new(1, 10).should eq(1..10)
@@ -214,6 +226,14 @@ describe "Range" do
       expect_raises(ArgumentError, "Can't each beginless range") do
         range.each { }
       end
+    end
+
+    it "doesn't have Nil as a type for endless each" do
+      typeof(range_endless_each).should eq(Int32)
+    end
+
+    it "doesn't have Nil as a type for beginless each" do
+      typeof(range_beginless_reverse_each).should eq(Int32)
     end
   end
 

--- a/src/range.cr
+++ b/src/range.cr
@@ -112,12 +112,22 @@ struct Range(B, E)
       raise ArgumentError.new("Can't each beginless range")
     end
 
-    end_value = @end
-    while end_value.nil? || current < end_value
-      yield current
-      current = current.succ
-    end
-    yield current if !@exclusive && current == end_value
+    # TODO: This typeof and the macro interpolations are a workaround until #9324 is fixed.
+    typeof(yield current)
+
+    {% if E == Nil %}
+      while true
+        {{ "yield current".id }}
+        current = current.succ
+      end
+    {% else %}
+      end_value = @end
+      while end_value.nil? || current < end_value
+        {{ "yield current".id }}
+        current = current.succ
+      end
+      {{ "yield current".id }} if !@exclusive && current == end_value
+    {% end %}
   end
 
   # Returns an `Iterator` over the elements of this range.
@@ -159,10 +169,19 @@ struct Range(B, E)
     yield end_value if !@exclusive && (begin_value.nil? || !(end_value < begin_value))
     current = end_value
 
-    while begin_value.nil? || begin_value < current
-      current = current.pred
-      yield current
-    end
+    # TODO: The macro interpolations are a workaround until #9324 is fixed.
+
+    {% if B == Nil %}
+      while true
+        current = current.pred
+        {{ "yield current".id }}
+      end
+    {% else %}
+      while begin_value.nil? || begin_value < current
+        current = current.pred
+        {{ "yield current".id }}
+      end
+    {% end %}
   end
 
   # Returns a reverse `Iterator` over the elements of this range.


### PR DESCRIPTION
Puts an end to the discussion in https://forum.crystal-lang.org/t/compiler-issue-with-non-existent-nil-conditions/2134

The code will now compile just fine.

Doing it correctly, without all of the `typeof` and macro interpolation stuff can be done, but it depends on https://github.com/crystal-lang/crystal/pull/9324 merged. Since this is something nice to have, we can merge it now and in a later version remove the ugly code.