### PR TITLE
Fix Enumerable#{zip,zip?} when self is an Iterator (#9328)

### DIFF
--- a/spec/std/enumerable_spec.cr
+++ b/spec/std/enumerable_spec.cr
@@ -17,6 +17,17 @@ private class SpecEmptyEnumerable
   end
 end
 
+private class SpecCountUpIterator
+  include Iterator(Int32)
+
+  def initialize(@size : Int32, @count = 0)
+  end
+
+  def next
+    (@count += 1) <= @size ? (@count - 1) : stop
+  end
+end
+
 describe "Enumerable" do
   describe "all? with block" do
     it "returns true" do
@@ -1038,6 +1049,18 @@ describe "Enumerable" do
 
     it "with block" do
       (1..3).to_h { |i| {i, i ** 2} }.should eq({1 => 1, 2 => 4, 3 => 9})
+    end
+  end
+
+  describe "zip" do
+    it "works for Iterators as receiver" do
+      SpecCountUpIterator.new(3).zip(1..3, 2..4).should eq([{0, 1, 2}, {1, 2, 3}, {2, 3, 4}])
+    end
+  end
+
+  describe "zip?" do
+    it "works for Iterators as receiver" do
+      SpecCountUpIterator.new(3).zip?(1..2, 2..4).should eq([{0, 1, 2}, {1, 2, 3}, {2, nil, 4}])
     end
   end
 end

--- a/src/enumerable.cr
+++ b/src/enumerable.cr
@@ -1634,7 +1634,7 @@ module Enumerable(T)
   # a.zip(b, c) # => [{1, 4, 8}, {2, 5, 7}, {3, 6, 6}]
   # ```
   def zip(*others : Indexable | Iterable | Iterator)
-    pairs = Array(typeof(zip(*others) { |e| break e }.not_nil!)).new(size)
+    pairs = Array(typeof(zip(*others) { |e| break e }.not_nil!)).new
     zip(*others) { |e| pairs << e }
     pairs
   end
@@ -1704,7 +1704,7 @@ module Enumerable(T)
   # a.zip?(b, c) # => [{1, 4, 8}, {2, 5, 7}, {3, nil, nil}]
   # ```
   def zip?(*others : Indexable | Iterable | Iterator)
-    pairs = Array(typeof(zip?(*others) { |e| break e }.not_nil!)).new(size)
+    pairs = Array(typeof(zip?(*others) { |e| break e }.not_nil!)).new
     zip?(*others) { |e| pairs << e }
     pairs
   end

--- a/src/enumerable.cr
+++ b/src/enumerable.cr
@@ -1634,7 +1634,8 @@ module Enumerable(T)
   # a.zip(b, c) # => [{1, 4, 8}, {2, 5, 7}, {3, 6, 6}]
   # ```
   def zip(*others : Indexable | Iterable | Iterator)
-    pairs = Array(typeof(zip(*others) { |e| break e }.not_nil!)).new
+    size = self.is_a?(Indexable) ? self.size : 0
+    pairs = Array(typeof(zip(*others) { |e| break e }.not_nil!)).new(size)
     zip(*others) { |e| pairs << e }
     pairs
   end
@@ -1704,7 +1705,8 @@ module Enumerable(T)
   # a.zip?(b, c) # => [{1, 4, 8}, {2, 5, 7}, {3, nil, nil}]
   # ```
   def zip?(*others : Indexable | Iterable | Iterator)
-    pairs = Array(typeof(zip?(*others) { |e| break e }.not_nil!)).new
+    size = self.is_a?(Indexable) ? self.size : 0
+    pairs = Array(typeof(zip?(*others) { |e| break e }.not_nil!)).new(size)
     zip?(*others) { |e| pairs << e }
     pairs
   end


### PR DESCRIPTION
Both methods call `size` and as such consume the Iterator (`self`). Then they
call Enumerable.zip which tries to again iterate over the now empty Iterator
resulting in an empty array.

Running std_spec "before" removing the call to `size` results in the following
failures:

    Failures:

      1) Enumerable zip works for Iterators as receiver
         Failure/Error: SpecCountUpIterator.new(3).zip(1..3, 2..4).should eq([{0, 1, 2}, {1, 2, 3}, {2, 3, 4}])

           Expected: [{0, 1, 2}, {1, 2, 3}, {2, 3, 4}]
                got: []

         # spec/std/enumerable_spec.cr:1057

      2) Enumerable zip? works for Iterators as receiver
         Failure/Error: SpecCountUpIterator.new(3).zip?(1..2, 2..4).should eq([{0, 1, 2}, {1, 2, 3}, {2, nil, 4}])

           Expected: [{0, 1, 2}, {1, 2, 3}, {2, nil, 4}]
                got: []

         # spec/std/enumerable_spec.cr:1063

Fixes: #9328