### PR TITLE
Process raises `IO::Error` (or subclasses)

### DIFF
--- a/spec/std/process_spec.cr
+++ b/spec/std/process_spec.cr
@@ -357,6 +357,12 @@ describe Process do
         File.exists?(path).should be_true
       end
     end
+
+    it "gets error from exec" do
+      expect_raises(File::NotFoundError, "Error executing process: 'foobarbaz'") do
+        Process.exec("foobarbaz")
+      end
+    end
   {% end %}
 
   pending_win32 "checks for existence" do

--- a/spec/std/process_spec.cr
+++ b/spec/std/process_spec.cr
@@ -75,7 +75,7 @@ describe Process do
     end
   end
 
-  it "raises if command is not executable" do
+  pending_win32 "raises if command is not executable" do
     with_tempfile("crystal-spec-run") do |path|
       File.touch path
       expect_raises(File::AccessDeniedError, "Error executing process: '#{path}'") do
@@ -84,7 +84,7 @@ describe Process do
     end
   end
 
-  it "raises if command could not be executed" do
+  pending_win32 "raises if command could not be executed" do
     with_tempfile("crystal-spec-run") do |path|
       File.touch path
       command = File.join(path, "foo")

--- a/spec/std/process_spec.cr
+++ b/spec/std/process_spec.cr
@@ -78,17 +78,17 @@ describe Process do
   pending_win32 "raises if command is not executable" do
     with_tempfile("crystal-spec-run") do |path|
       File.touch path
-      expect_raises(File::AccessDeniedError, "Error executing process: '#{path}'") do
+      expect_raises(File::AccessDeniedError, "Error executing process: '#{path.inspect_unquoted}'") do
         Process.new(path)
       end
     end
   end
 
-  pending_win32 "raises if command could not be executed" do
+  it "raises if command could not be executed" do
     with_tempfile("crystal-spec-run") do |path|
       File.touch path
       command = File.join(path, "foo")
-      expect_raises(IO::Error, "Error executing process: '#{command}'") do
+      expect_raises(IO::Error, "Error executing process: '#{command.inspect_unquoted}'") do
         Process.new(command)
       end
     end

--- a/spec/std/process_spec.cr
+++ b/spec/std/process_spec.cr
@@ -71,7 +71,7 @@ describe Process do
 
   it "raises if command doesn't exist" do
     expect_raises(File::NotFoundError, "Error executing process: 'foobarbaz'") do
-      Process.new("foobarbaz", ["foo"])
+      Process.new("foobarbaz")
     end
   end
 

--- a/spec/std/process_spec.cr
+++ b/spec/std/process_spec.cr
@@ -69,9 +69,28 @@ describe Process do
     process.wait.exit_code.should eq(1)
   end
 
-  it "raises if command could not be executed" do
-    expect_raises(RuntimeError, "Error executing process:") do
+  it "raises if command doesn't exist" do
+    expect_raises(File::NotFoundError, "Error executing process: 'foobarbaz'") do
       Process.new("foobarbaz", ["foo"])
+    end
+  end
+
+  it "raises if command is not executable" do
+    with_tempfile("crystal-spec-run") do |path|
+      File.touch path
+      expect_raises(File::AccessDeniedError, "Error executing process: '#{path}'") do
+        Process.new(path)
+      end
+    end
+  end
+
+  it "raises if command could not be executed" do
+    with_tempfile("crystal-spec-run") do |path|
+      File.touch path
+      command = File.join(path, "foo")
+      expect_raises(IO::Error, "Error executing process: '#{command}'") do
+        Process.new(command)
+      end
     end
   end
 

--- a/src/process.cr
+++ b/src/process.cr
@@ -156,7 +156,7 @@ class Process
   #
   # Available only on Unix-like operating systems.
   def self.exec(command : String, args = nil, env : Env = nil, clear_env : Bool = false, shell : Bool = false,
-                input : ExecStdio = Redirect::Inherit, output : ExecStdio = Redirect::Inherit, error : ExecStdio = Redirect::Inherit, chdir : String? = nil)
+                input : ExecStdio = Redirect::Inherit, output : ExecStdio = Redirect::Inherit, error : ExecStdio = Redirect::Inherit, chdir : String? = nil) : NoReturn
     command_args = Crystal::System::Process.prepare_args(command, args, shell)
 
     input = exec_stdio_to_fd(input, for: STDIN)


### PR DESCRIPTION
This replaces the current generic `RuntimeError` exception being raised for any error during process execution.

For example:
  * When the process file doesn't exist: `Error executing process: 'foo': No such file or directory (File::NotFoundError)`
  * When the file is not executable or not allowed for the current user: `Error executing process: 'foo': Permission denied (File::AccessDeniedError)`
  * Other errors: `Error executing process: './foo/bar': Not a directory (IO::Error)`

This makes it easier to handle errors during subprocess execution (for example if a particular action or more detailed error message will be displayed to the user when the process file was not found) or at least provide better error messages by default.

At first I hesitated to use `IO::Error` for this, as there is no `IO` directly involved. But the same could be said with `File::Error`. Well, at least a `File` is an `IO` but many operations in `File` doesn't involve an `IO` at all. I considered have a `ProcessError` and use the `IO::Error` as a `cause`, but that just makes the error handling more complicated, and I prefer design error hierarchies based on handling. Another option would be returning either `File::Error` or `ProcessError`, but again, that makes it more complicated to handle just *any* error raised at process execution. After all, I think it was probably a mistake to use `IO` as the base class for streams, and should be `IO::Stream` instead 🤷‍♂️. 