### PR TITLE
Allow annotations and ditto in macro

### DIFF
--- a/spec/compiler/semantic/doc_spec.cr
+++ b/spec/compiler/semantic/doc_spec.cr
@@ -148,6 +148,21 @@ describe "Semantic: doc" do
     bar.doc.should eq("Hello")
   end
 
+  it "stores doc for macro when using ditto" do
+    result = semantic %(
+      # Hello
+      macro bar
+      end
+
+      # :ditto:
+      macro bar2
+      end
+    ), wants_doc: true
+    program = result.program
+    bar2 = program.lookup_macros("bar2").as(Array(Macro)).first
+    bar2.doc.should eq("Hello")
+  end
+
   {% for def_type in %w[def macro].map &.id %}
     it "overwrites doc for {{def_type}} when redefining" do
       result = semantic %(
@@ -485,6 +500,21 @@ describe "Semantic: doc" do
       program = result.program
       a_def = program.lookup_defs("foo").first
       a_def.doc.should eq("Some description")
+    end
+
+    it "attached to macro" do
+      result = semantic %(
+        annotation Ann
+        end
+
+        # Some description
+        @[Ann]
+        macro foo
+        end
+      ), wants_doc: true
+      program = result.program
+      type = program.lookup_macros("foo").as(Array(Macro)).first
+      type.doc.should eq("Some description")
     end
   end
 end

--- a/src/compiler/crystal/annotatable.cr
+++ b/src/compiler/crystal/annotatable.cr
@@ -1,0 +1,23 @@
+module Crystal
+  module Annotatable
+    # Annotations on this instance
+    property annotations : Hash(AnnotationType, Array(Annotation))?
+
+    # Adds an annotation with the given type and value
+    def add_annotation(annotation_type : AnnotationType, value : Annotation)
+      annotations = @annotations ||= {} of AnnotationType => Array(Annotation)
+      annotations[annotation_type] ||= [] of Annotation
+      annotations[annotation_type] << value
+    end
+
+    # Returns the last defined annotation with the given type, if any, or `nil` otherwise
+    def annotation(annotation_type) : Annotation?
+      @annotations.try &.[annotation_type]?.try &.last?
+    end
+
+    # Returns all annotations with the given type, if any, or `nil` otherwise
+    def annotations(annotation_type) : Array(Annotation)?
+      @annotations.try &.[annotation_type]?
+    end
+  end
+end

--- a/src/compiler/crystal/semantic/ast.cr
+++ b/src/compiler/crystal/semantic/ast.cr
@@ -119,6 +119,8 @@ module Crystal
   end
 
   class Def
+    include Annotatable
+
     property! owner : Type
     property! original_owner : Type
     property vars : MetaVars?
@@ -147,9 +149,6 @@ module Crystal
     # Is this a `new` method that was expanded from an initialize?
     property? new = false
 
-    # Annotations on this def
-    property annotations : Hash(AnnotationType, Array(Annotation))?
-
     @macro_owner : Type?
 
     def macro_owner=(@macro_owner)
@@ -177,23 +176,6 @@ module Crystal
           end
         end
       end
-    end
-
-    # Adds an annotation with the given type and value
-    def add_annotation(annotation_type : AnnotationType, value : Annotation)
-      annotations = @annotations ||= {} of AnnotationType => Array(Annotation)
-      annotations[annotation_type] ||= [] of Annotation
-      annotations[annotation_type] << value
-    end
-
-    # Returns the last defined annotation with the given type, if any, or `nil` otherwise
-    def annotation(annotation_type) : Annotation?
-      @annotations.try &.[annotation_type]?.try &.last?
-    end
-
-    # Returns all annotations with the given type, if any, or `nil` otherwise
-    def annotations(annotation_type) : Array(Annotation)?
-      @annotations.try &.[annotation_type]?
     end
 
     # Returns the minimum and maximum number of arguments that must
@@ -250,6 +232,8 @@ module Crystal
   end
 
   class Macro
+    include Annotatable
+
     # Yields `arg, arg_index, object, object_index` corresponding
     # to arguments matching the given objects, taking into account this
     # macro's splat index.
@@ -494,6 +478,8 @@ module Crystal
   # A variable belonging to a type: a global,
   # class or instance variable (globals belong to the program).
   class MetaTypeVar < Var
+    include Annotatable
+
     property nil_reason : NilReason?
 
     # The owner of this variable, useful for showing good
@@ -514,9 +500,6 @@ module Crystal
     # Is this variable "unsafe" (no need to check if it was initialized)?
     property? uninitialized = false
 
-    # Annotations of this instance var
-    property annotations : Hash(AnnotationType, Array(Annotation))?
-
     def kind
       case name[0]
       when '@'
@@ -532,23 +515,6 @@ module Crystal
 
     def global?
       kind == :global
-    end
-
-    # Adds an annotation with the given type and value
-    def add_annotation(annotation_type : AnnotationType, value : Annotation)
-      annotations = @annotations ||= {} of AnnotationType => Array(Annotation)
-      annotations[annotation_type] ||= [] of Annotation
-      annotations[annotation_type] << value
-    end
-
-    # Returns the last defined annotation with the given type, if any, or `nil` otherwise
-    def annotation(annotation_type) : Annotation?
-      @annotations.try &.[annotation_type]?.try &.last?
-    end
-
-    # Returns all annotations with the given type, if any, or `nil` otherwise
-    def annotations(annotation_type) : Array(Annotation)?
-      @annotations.try &.[annotation_type]?
     end
   end
 

--- a/src/compiler/crystal/semantic/top_level_visitor.cr
+++ b/src/compiler/crystal/semantic/top_level_visitor.cr
@@ -296,6 +296,13 @@ class Crystal::TopLevelVisitor < Crystal::SemanticVisitor
   def visit(node : Macro)
     check_outside_exp node, "declare macro"
 
+    annotations = read_annotations
+    process_annotations(annotations) do |annotation_type, ann|
+      node.add_annotation(annotation_type, ann)
+    end
+    node.doc ||= annotations_doc(annotations)
+    check_ditto node, node.location
+
     node.set_type @program.nil
 
     if node.name == "finished"
@@ -1058,7 +1065,7 @@ class Crystal::TopLevelVisitor < Crystal::SemanticVisitor
     end
   end
 
-  def check_ditto(node : Def | Assign | FunDef | Const, location : Location?) : Nil
+  def check_ditto(node : Def | Assign | FunDef | Const | Macro, location : Location?) : Nil
     return if !@program.wants_doc?
     stripped_doc = node.doc.try &.strip
     if stripped_doc == ":ditto:"

--- a/src/compiler/crystal/tools/doc/macro.cr
+++ b/src/compiler/crystal/tools/doc/macro.cr
@@ -145,7 +145,6 @@ class Crystal::Doc::Macro
   end
 
   def annotations(annotation_type)
-    # macros does not support annotations
-    nil
+    @macro.annotations(annotation_type)
   end
 end

--- a/src/compiler/crystal/types.cr
+++ b/src/compiler/crystal/types.cr
@@ -3,6 +3,8 @@ require "./syntax/ast"
 module Crystal
   # Abstract base class of all types
   abstract class Type
+    include Annotatable
+
     # Returns the program where this type belongs.
     getter program
 
@@ -708,23 +710,6 @@ module Crystal
       else
         devirtualize
       end
-    end
-
-    # Adds an annotation with the given type and value
-    def add_annotation(annotation_type : AnnotationType, value : Annotation)
-      annotations = @annotations ||= {} of AnnotationType => Array(Annotation)
-      annotations[annotation_type] ||= [] of Annotation
-      annotations[annotation_type] << value
-    end
-
-    # Returns the last defined annotation with the given type, if any, or `nil` otherwise
-    def annotation(annotation_type) : Annotation?
-      @annotations.try &.[annotation_type]?.try &.last?
-    end
-
-    # Returns all annotations with the given type, if any, or `nil` otherwise
-    def annotations(annotation_type) : Array(Annotation)?
-      @annotations.try &.[annotation_type]?
     end
 
     def get_instance_var_initializer(name)


### PR DESCRIPTION
Enable doc generator tool to keep same treatment for macros as for method annotations.

Refactor AST & Types annotation related methods to Annotable module.

Ref: #9272
