### PR TITLE
Compiler: warn on deprecated macros

### DIFF
--- a/spec/compiler/codegen/warnings_spec.cr
+++ b/spec/compiler/codegen/warnings_spec.cr
@@ -255,7 +255,7 @@ describe "Code gen: warnings" do
       "Error: wrong number of deprecated annotation arguments (given 2, expected 1)"
   end
 
-  it "errors if missing link arguments" do
+  it "errors if invalid named arguments" do
     assert_error %(
       @[Deprecated(invalid: "Do not use me")]
       def foo

--- a/spec/compiler/semantic/macro_spec.cr
+++ b/spec/compiler/semantic/macro_spec.cr
@@ -1461,6 +1461,6 @@ describe "Semantic: macro" do
     ), inject_primitives: false)
 
     method = result.program.types["Foo"].lookup_first_def("bar", false).not_nil!
-    method.location.not_nil!.original_location.not_nil!.line_number.should eq(10)
+    method.location.not_nil!.expanded_location.not_nil!.line_number.should eq(10)
   end
 end

--- a/spec/compiler/semantic/warnings_spec.cr
+++ b/spec/compiler/semantic/warnings_spec.cr
@@ -1,0 +1,176 @@
+require "../spec_helper"
+
+describe "Semantic: warnings" do
+  it "detects top-level deprecated marcos" do
+    assert_warning %(
+      @[Deprecated("Do not use me")]
+      macro foo
+      end
+
+      foo
+    ), "warning in line 6\nWarning: Deprecated top-level foo. Do not use me",
+      inject_primitives: false
+  end
+
+  it "deprecation reason is optional" do
+    assert_warning %(
+      @[Deprecated]
+      macro foo
+      end
+
+      foo
+    ), "warning in line 6\nWarning: Deprecated top-level foo.",
+      inject_primitives: false
+  end
+
+  it "detects deprecated class macros" do
+    assert_warning %(
+      class Foo
+        @[Deprecated("Do not use me")]
+        macro m
+        end
+      end
+
+      Foo.m
+    ), "warning in line 8\nWarning: Deprecated Foo.m. Do not use me",
+      inject_primitives: false
+  end
+
+  it "detects deprecated generic class macros" do
+    assert_warning %(
+      class Foo(T)
+        @[Deprecated("Do not use me")]
+        macro m
+        end
+      end
+
+      Foo.m
+    ), "warning in line 8\nWarning: Deprecated Foo.m. Do not use me",
+      inject_primitives: false
+  end
+
+  it "detects deprecated module macros" do
+    assert_warning %(
+      module Foo
+        @[Deprecated("Do not use me")]
+        macro m
+        end
+      end
+
+      Foo.m
+    ), "warning in line 8\nWarning: Deprecated Foo.m. Do not use me",
+      inject_primitives: false
+  end
+
+  it "detects deprecated macros with named arguments" do
+    assert_warning %(
+      @[Deprecated]
+      macro foo(*, a)
+      end
+
+      foo(a: 2)
+    ), "warning in line 6\nWarning: Deprecated top-level foo.",
+      inject_primitives: false
+  end
+
+  it "informs warnings once per call site location (a)" do
+    warning_failures = warnings_result %(
+      class Foo
+        @[Deprecated("Do not use me")]
+        macro m
+        end
+
+        macro b
+          Foo.m
+        end
+      end
+
+      Foo.b
+      Foo.b
+    ), inject_primitives: false
+
+    warning_failures.size.should eq(1)
+  end
+
+  it "informs warnings once per call site location (b)" do
+    warning_failures = warnings_result %(
+      class Foo
+        @[Deprecated("Do not use me")]
+        macro m
+        end
+      end
+
+      Foo.m
+      Foo.m
+    ), inject_primitives: false
+
+    warning_failures.size.should eq(2)
+  end
+
+  it "ignore deprecation excluded locations" do
+    with_tempfile("check_warnings_excludes") do |path|
+      FileUtils.mkdir_p File.join(path, "lib")
+
+      # NOTE tempfile might be created in symlinked folder
+      # which affects how to match current dir /var/folders/...
+      # with the real path /private/var/folders/...
+      path = File.real_path(path)
+
+      main_filename = File.join(path, "main.cr")
+      output_filename = File.join(path, "main")
+
+      Dir.cd(path) do
+        File.write main_filename, %(
+          require "./lib/foo"
+
+          bar
+          foo
+        )
+        File.write File.join(path, "lib", "foo.cr"), %(
+          @[Deprecated("Do not use me")]
+          macro foo
+          end
+
+          macro bar
+            foo
+          end
+        )
+
+        compiler = create_spec_compiler
+        compiler.warnings = Warnings::All
+        compiler.warnings_exclude << Crystal.normalize_path "lib"
+        compiler.prelude = "empty"
+        result = compiler.compile Compiler::Source.new(main_filename, File.read(main_filename)), output_filename
+
+        result.program.warning_failures.size.should eq(1)
+      end
+    end
+  end
+
+  it "errors if invalid argument type" do
+    assert_error %(
+      @[Deprecated(42)]
+      macro foo
+      end
+      ),
+      "Error: first argument must be a String"
+  end
+
+  it "errors if too many arguments" do
+    assert_error %(
+      @[Deprecated("Do not use me", "extra arg")]
+      macro foo
+      end
+      ),
+      "Error: wrong number of deprecated annotation arguments (given 2, expected 1)"
+  end
+
+  it "errors if invalid named argument" do
+    assert_error %(
+      @[Deprecated(invalid: "Do not use me")]
+      macro foo
+      end
+      ),
+      "Error: too many named arguments (given 1, expected maximum 0)"
+  end
+end

--- a/spec/spec_helper.cr
+++ b/spec/spec_helper.cr
@@ -104,10 +104,10 @@ def assert_after_cleanup(before, after)
   result.node.to_s.strip.should eq(after.strip)
 end
 
-def assert_error(str, message, inject_primitives = true)
+def assert_error(str, message, inject_primitives = true, file = __FILE__, line = __LINE__)
   str = inject_primitives(str) if inject_primitives
   nodes = parse str
-  expect_raises TypeException, message do
+  expect_raises TypeException, message, file, line do
     semantic nodes
   end
 end
@@ -132,15 +132,15 @@ def warnings_result(code, inject_primitives = true)
   result.program.warning_failures
 end
 
-def assert_warning(code, message, inject_primitives = true)
+def assert_warning(code, message, inject_primitives = true, file = __FILE__, line = __LINE__)
   warning_failures = warnings_result(code, inject_primitives)
-  warning_failures.size.should eq(1)
-  warning_failures[0].should start_with(message)
+  warning_failures.size.should eq(1), file, line
+  warning_failures[0].should start_with(message), file, line
 end
 
-def assert_no_warnings(code, inject_primitives = true)
+def assert_no_warnings(code, inject_primitives = true, file = __FILE__, line = __LINE__)
   warning_failures = warnings_result(code, inject_primitives)
-  warning_failures.size.should eq(0)
+  warning_failures.size.should eq(0), file, line
 end
 
 def assert_macro(macro_args, macro_body, call_args, expected, expected_pragmas = nil, flags = nil)

--- a/src/compiler/crystal/codegen/codegen.cr
+++ b/src/compiler/crystal/codegen/codegen.cr
@@ -563,7 +563,7 @@ module Crystal
     end
 
     def fun_literal_name(node : ProcLiteral)
-      location = node.location.try &.original_location
+      location = node.location.try &.expanded_location
       if location && (type = node.type?)
         proc_name = true
         filename = location.filename.as(String)
@@ -1305,7 +1305,7 @@ module Crystal
       ] of ASTNode
 
       if location = node.location
-        pieces << StringLiteral.new(", at #{location.original_location}:#{location.line_number}").at(node)
+        pieces << StringLiteral.new(", at #{location.expanded_location}:#{location.line_number}").at(node)
       end
 
       ex = Call.new(Path.global("TypeCastError").at(node), "new", StringInterpolation.new(pieces).at(node)).at(node)

--- a/src/compiler/crystal/codegen/debug.cr
+++ b/src/compiler/crystal/codegen/debug.cr
@@ -318,7 +318,7 @@ module Crystal
     end
 
     private def declare_local(type, alloca, location, basic_block : LLVM::BasicBlock? = nil)
-      location = location.try &.original_location
+      location = location.try &.expanded_location
       return false unless location
 
       file, dir = file_and_dir(location.filename)
@@ -435,7 +435,7 @@ module Crystal
     end
 
     def set_current_debug_location(location)
-      location = location.try &.original_location
+      location = location.try &.expanded_location
       return unless location
 
       @current_debug_location = location
@@ -464,7 +464,7 @@ module Crystal
     end
 
     def emit_def_debug_metadata(target_def)
-      location = target_def.location.try &.original_location
+      location = target_def.location.try &.expanded_location
       return unless location
 
       file, dir = file_and_dir(location.filename)

--- a/src/compiler/crystal/macros/macros.cr
+++ b/src/compiler/crystal/macros/macros.cr
@@ -16,6 +16,8 @@ class Crystal::Program
   property compiled_macros_cache = {} of String => CompiledMacroRun
 
   def expand_macro(a_macro : Macro, call : Call, scope : Type, path_lookup : Type? = nil, a_def : Def? = nil)
+    check_call_to_deprecated_macro a_macro, call
+
     interpreter = MacroInterpreter.new self, scope, path_lookup || scope, a_macro, call, a_def, in_macro: true
     a_macro.body.accept interpreter
     {interpreter.to_s, interpreter.macro_expansion_pragmas}

--- a/src/compiler/crystal/macros/methods.cr
+++ b/src/compiler/crystal/macros/methods.cr
@@ -352,22 +352,22 @@ module Crystal
         end
       when "line_number"
         interpret_argless_method("line_number", args) do
-          line_number = location.try &.original_location.try &.line_number
+          line_number = location.try &.expanded_location.try &.line_number
           line_number ? NumberLiteral.new(line_number) : NilLiteral.new
         end
       when "column_number"
         interpret_argless_method("column_number", args) do
-          column_number = location.try &.original_location.try &.column_number
+          column_number = location.try &.expanded_location.try &.column_number
           column_number ? NumberLiteral.new(column_number) : NilLiteral.new
         end
       when "end_line_number"
         interpret_argless_method("end_line_number", args) do
-          line_number = end_location.try &.original_location.try &.line_number
+          line_number = end_location.try &.expanded_location.try &.line_number
           line_number ? NumberLiteral.new(line_number) : NilLiteral.new
         end
       when "end_column_number"
         interpret_argless_method("end_column_number", args) do
-          column_number = end_location.try &.original_location.try &.column_number
+          column_number = end_location.try &.expanded_location.try &.column_number
           column_number ? NumberLiteral.new(column_number) : NilLiteral.new
         end
       when "=="

--- a/src/compiler/crystal/semantic/ast.cr
+++ b/src/compiler/crystal/semantic/ast.cr
@@ -234,6 +234,8 @@ module Crystal
   class Macro
     include Annotatable
 
+    property! owner : Type
+
     # Yields `arg, arg_index, object, object_index` corresponding
     # to arguments matching the given objects, taking into account this
     # macro's splat index.

--- a/src/compiler/crystal/semantic/semantic_visitor.cr
+++ b/src/compiler/crystal/semantic/semantic_visitor.cr
@@ -429,7 +429,9 @@ abstract class Crystal::SemanticVisitor < Crystal::Visitor
 
   def process_annotations(annotations)
     annotations.try &.each do |ann|
-      yield lookup_annotation(ann), ann
+      annotation_type = lookup_annotation(ann)
+      validate_annotation(annotation_type, ann)
+      yield annotation_type, ann
     end
   end
 
@@ -454,6 +456,21 @@ abstract class Crystal::SemanticVisitor < Crystal::Visitor
     end
 
     type
+  end
+
+  def validate_annotation(annotation_type, ann)
+    case annotation_type
+    when @program.deprecated_annotation
+      # Check whether a DeprecatedAnnotation can be built.
+      # There is no need to store it, but enforcing
+      # arguments makes sense here.
+      DeprecatedAnnotation.from(ann)
+    when @program.experimental_annotation
+      # ditto DeprecatedAnnotation
+      ExperimentalAnnotation.from(ann)
+    else
+      # go on
+    end
   end
 
   def check_class_var_annotations

--- a/src/compiler/crystal/semantic/top_level_visitor.cr
+++ b/src/compiler/crystal/semantic/top_level_visitor.cr
@@ -1100,16 +1100,6 @@ class Crystal::TopLevelVisitor < Crystal::SemanticVisitor
         node.returns_twice = true
       when @program.raises_annotation
         node.raises = true
-      when @program.deprecated_annotation
-        # Check whether a DeprecatedAnnotation can be built.
-        # There is no need to store it, but enforcing
-        # arguments makes sense here.
-        DeprecatedAnnotation.from(ann)
-        yield annotation_type, ann
-      when @program.experimental_annotation
-        # ditto DeprecatedAnnotation
-        ExperimentalAnnotation.from(ann)
-        yield annotation_type, ann
       else
         yield annotation_type, ann
       end

--- a/src/compiler/crystal/semantic/warnings.cr
+++ b/src/compiler/crystal/semantic/warnings.cr
@@ -21,5 +21,45 @@ module Crystal
 
       self.warning_failures << message
     end
+
+    @deprecated_macros_detected = Set(String).new
+
+    def check_call_to_deprecated_macro(a_macro : Macro, call : Call)
+      return unless self.warnings.all?
+
+      if (ann = a_macro.annotation(self.deprecated_annotation)) &&
+         (deprecated_annotation = DeprecatedAnnotation.from(ann))
+        call_location = call.location.try(&.user_location) || call.location
+
+        return if self.ignore_warning_due_to_location?(call_location)
+        short_reference = a_macro.short_reference
+        warning_key = call_location.try { |l| "#{short_reference} #{l}" }
+
+        # skip warning if the call site was already informed
+        # if there is no location information just inform it.
+        return if !warning_key || @deprecated_macros_detected.includes?(warning_key)
+        @deprecated_macros_detected.add(warning_key) if warning_key
+
+        message = deprecated_annotation.message
+        message = message ? " #{message}" : ""
+
+        full_message = call.warning "Deprecated #{short_reference}.#{message}"
+
+        self.warning_failures << full_message
+      end
+    end
+  end
+
+  class Macro
+    def short_reference
+      case owner
+      when Program
+        "top-level #{name}"
+      when MetaclassType
+        "#{owner.instance_type.to_s(generic_args: false)}.#{name}"
+      else
+        "#{owner}.#{name}"
+      end
+    end
   end
 end

--- a/src/compiler/crystal/semantic/warnings.cr
+++ b/src/compiler/crystal/semantic/warnings.cr
@@ -29,7 +29,7 @@ module Crystal
 
       if (ann = a_macro.annotation(self.deprecated_annotation)) &&
          (deprecated_annotation = DeprecatedAnnotation.from(ann))
-        call_location = call.location.try(&.user_location) || call.location
+        call_location = call.location.try(&.macro_location) || call.location
 
         return if self.ignore_warning_due_to_location?(call_location)
         short_reference = a_macro.short_reference

--- a/src/compiler/crystal/syntax/ast.cr
+++ b/src/compiler/crystal/syntax/ast.cr
@@ -2188,7 +2188,7 @@ module Crystal
     end
 
     def self.expand_line(location)
-      (location.try(&.original_location) || location).try(&.line_number) || 0
+      (location.try(&.expanded_location) || location).try(&.line_number) || 0
     end
 
     def self.expand_file_node(location)

--- a/src/compiler/crystal/syntax/location.cr
+++ b/src/compiler/crystal/syntax/location.cr
@@ -31,12 +31,12 @@ class Crystal::Location
 
   # Returns the Location whose filename is a String, not a VirtualFile,
   # traversing virtual file expanded locations leading to the original user source code
-  def user_location
+  def macro_location
     case filename = @filename
     when String
       self
     when VirtualFile
-      filename.macro.location.try(&.user_location)
+      filename.macro.location.try(&.macro_location)
     else
       nil
     end

--- a/src/compiler/crystal/syntax/location.cr
+++ b/src/compiler/crystal/syntax/location.cr
@@ -18,12 +18,12 @@ class Crystal::Location
 
   # Returns the Location whose filename is a String, not a VirtualFile,
   # traversing virtual file expanded locations.
-  def original_location
+  def expanded_location
     case filename = @filename
     when String
       self
     when VirtualFile
-      filename.expanded_location.try &.original_location
+      filename.expanded_location.try &.expanded_location
     else
       nil
     end
@@ -42,9 +42,9 @@ class Crystal::Location
     end
   end
 
-  # Returns the filename of the `original_location`
+  # Returns the filename of the `expanded_location`
   def original_filename
-    original_location.try &.filename.as?(String)
+    expanded_location.try &.filename.as?(String)
   end
 
   def between?(min, max)

--- a/src/compiler/crystal/syntax/location.cr
+++ b/src/compiler/crystal/syntax/location.cr
@@ -29,6 +29,19 @@ class Crystal::Location
     end
   end
 
+  # Returns the Location whose filename is a String, not a VirtualFile,
+  # traversing virtual file expanded locations leading to the original user source code
+  def user_location
+    case filename = @filename
+    when String
+      self
+    when VirtualFile
+      filename.macro.location.try(&.user_location)
+    else
+      nil
+    end
+  end
+
   # Returns the filename of the `original_location`
   def original_filename
     original_location.try &.filename.as?(String)

--- a/src/compiler/crystal/types.cr
+++ b/src/compiler/crystal/types.cr
@@ -895,6 +895,8 @@ module Crystal
     end
 
     def add_macro(a_macro)
+      a_macro.owner = self
+
       case a_macro.name
       when "inherited"
         return add_hook :inherited, a_macro


### PR DESCRIPTION
Depends on #9341
Ref: #9272

It forced me to go deeper into how the location in macros are traced. I added a `Location#user_location` which I thought it was the same as `Location#original_location`, but I was wrong. This will come handy on the implementation tool also. 🎉 

The specs are ported from the codegen/warnings_spec that applies to methods.