### PR TITLE
Change Slice#size to Int64

### DIFF
--- a/spec/std/io/delimited_spec.cr
+++ b/spec/std/io/delimited_spec.cr
@@ -10,7 +10,7 @@ private class PartialReaderIO < IO
   def read(slice : Bytes)
     return 0 if @slice.size == 0
     max_read_size = {slice.size, @slice.size}.min
-    read_size = rand(1..max_read_size)
+    read_size = rand(1..max_read_size.to_i32)
     slice.copy_from(@slice[0, read_size])
     @slice += read_size
     read_size

--- a/spec/std/io/io_spec.cr
+++ b/spec/std/io/io_spec.cr
@@ -19,7 +19,7 @@ private class SimpleIOMemory < IO
   def initialize(capacity = 64, @max_read = nil)
     @buffer = GC.malloc_atomic(capacity.to_u32).as(UInt8*)
     @bytesize = 0
-    @capacity = capacity
+    @capacity = capacity.to_i32
     @pos = 0
   end
 

--- a/src/enumerable.cr
+++ b/src/enumerable.cr
@@ -1634,7 +1634,7 @@ module Enumerable(T)
   # a.zip(b, c) # => [{1, 4, 8}, {2, 5, 7}, {3, 6, 6}]
   # ```
   def zip(*others : Indexable | Iterable | Iterator)
-    size = self.is_a?(Indexable) ? self.size : 0
+    size = self.is_a?(Indexable) ? self.size.to_i32 : 0
     pairs = Array(typeof(zip(*others) { |e| break e }.not_nil!)).new(size)
     zip(*others) { |e| pairs << e }
     pairs
@@ -1705,7 +1705,7 @@ module Enumerable(T)
   # a.zip?(b, c) # => [{1, 4, 8}, {2, 5, 7}, {3, nil, nil}]
   # ```
   def zip?(*others : Indexable | Iterable | Iterator)
-    size = self.is_a?(Indexable) ? self.size : 0
+    size = self.is_a?(Indexable) ? self.size.to_i32 : 0
     pairs = Array(typeof(zip?(*others) { |e| break e }.not_nil!)).new(size)
     zip?(*others) { |e| pairs << e }
     pairs

--- a/src/indexable.cr
+++ b/src/indexable.cr
@@ -167,7 +167,7 @@ module Indexable(T)
   # [2, 5, 7, 10].bsearch_index { |x, i| x > 10 } # => nil
   # ```
   def bsearch_index(&block : T, Int32 -> Bool)
-    (0...size).bsearch { |index| yield unsafe_fetch(index), index }
+    (0...size.to_i32).bsearch { |index| yield unsafe_fetch(index), index }
   end
 
   # Calls the given block once for each element in `self`, passing that
@@ -304,7 +304,7 @@ module Indexable(T)
   # ```text
   # 2 -- 3 --
   # ```
-  def each_index(*, start : Int, count : Int)
+  def each_index(*, start : Int32, count : Int)
     raise ArgumentError.new "negative count: #{count}" if count < 0
 
     start += size if start < 0
@@ -345,8 +345,8 @@ module Indexable(T)
 
     # The total bytesize of the string to return is:
     length =
-      ((self.size - 1) * separator.bytesize) + # the bytesize of all separators
-        self.sum(&.to_s.bytesize)              # the bytesize of all the elements
+      ((self.size.to_i32 - 1) * separator.bytesize) + # the bytesize of all separators
+        self.sum(&.to_s.bytesize)                     # the bytesize of all the elements
 
     String.new(length) do |buffer|
       # Also compute the UTF-8 size if we can
@@ -377,7 +377,7 @@ module Indexable(T)
       end
 
       # Add size of all separators
-      size += (self.size - 1) * separator.size if size_known
+      size += (self.size.to_i32 - 1) * separator.size if size_known
 
       {length, size_known ? size : 0}
     end
@@ -389,7 +389,7 @@ module Indexable(T)
   # {1, 2, 3}.to_a # => [1, 2, 3]
   # ```
   def to_a
-    ary = Array(T).new(size)
+    ary = Array(T).new(size.to_i32)
     each { |e| ary << e }
     ary
   end
@@ -509,7 +509,7 @@ module Indexable(T)
 
   # Same as `#each`, but works in reverse.
   def reverse_each(&block) : Nil
-    (size - 1).downto(0) do |i|
+    (size.to_i32 - 1).downto(0) do |i|
       yield unsafe_fetch(i)
     end
   end
@@ -529,7 +529,7 @@ module Indexable(T)
   # [1, 2, 3, 2, 3].rindex(2)            # => 3
   # [1, 2, 3, 2, 3].rindex(2, offset: 2) # => 1
   # ```
-  def rindex(value, offset = size - 1)
+  def rindex(value, offset = size.to_i32 - 1)
     rindex(offset) { |elem| elem == value }
   end
 
@@ -544,7 +544,7 @@ module Indexable(T)
   # [1, 2, 3, 2, 3].rindex { |x| x < 3 }            # => 3
   # [1, 2, 3, 2, 3].rindex(offset: 2) { |x| x < 3 } # => 1
   # ```
-  def rindex(offset = size - 1)
+  def rindex(offset = size.to_i32 - 1)
     offset += size if offset < 0
     return nil if offset >= size
 
@@ -605,7 +605,7 @@ module Indexable(T)
 
     end_index = range.end
     if end_index.nil?
-      count = collection_size - start_index
+      count = collection_size.to_i32 - start_index
     else
       end_index += collection_size if end_index < 0
       end_index -= 1 if range.excludes_end?
@@ -636,7 +636,7 @@ module Indexable(T)
   private class ReverseItemIterator(A, T)
     include Iterator(T)
 
-    def initialize(@array : A, @index : Int32 = array.size - 1)
+    def initialize(@array : A, @index : Int32 = array.size.to_i32 - 1)
     end
 
     def next

--- a/src/openssl/cipher.cr
+++ b/src/openssl/cipher.cr
@@ -53,7 +53,7 @@ class OpenSSL::Cipher
 
   def update(data)
     slice = data.to_slice
-    buffer_length = slice.size + block_size
+    buffer_length = slice.size.to_i32 + block_size
     buffer = Bytes.new(buffer_length)
     if LibCrypto.evp_cipherupdate(@ctx, buffer, pointerof(buffer_length), slice, slice.size) != 1
       raise Error.new "EVP_CipherUpdate"

--- a/src/pointer.cr
+++ b/src/pointer.cr
@@ -474,6 +474,7 @@ struct Pointer(T)
   # ptr[3] # => 13
   # ```
   def self.malloc(size : Int, &block : Int32 -> T)
+    size = size.to_i32
     ptr = Pointer(T).malloc(size)
     size.times { |i| ptr[i] = yield i }
     ptr

--- a/src/slice.cr
+++ b/src/slice.cr
@@ -49,7 +49,7 @@ struct Slice(T)
   # ```
   # Slice(UInt8).new(3).size # => 3
   # ```
-  getter size : Int32
+  getter size : Int64
 
   # Returns `true` if this slice cannot be written to.
   getter? read_only : Bool
@@ -67,7 +67,7 @@ struct Slice(T)
   # String.new(slice) # => "abc"
   # ```
   def initialize(@pointer : Pointer(T), size : Int, *, @read_only = false)
-    @size = size.to_i32
+    @size = size.to_i64
   end
 
   # Allocates `size * sizeof(T)` bytes of heap memory initialized to zero


### PR DESCRIPTION
This is a breaking change but only a few small updates are required.

`Int64` was chosen over `UInt64`, because it'll be a long time until a 63-bit memory range will need to be represented, and there were less changes required to continue using a signed type instead of an unsigned one. This design should handle all practical workloads for the next 10 years at least, and in 10 years we'll either have crystal 2.0 or the project will be dead.