### PR TITLE
Add Crystal::Location#size and refactor to struct

### DIFF
--- a/spec/compiler/location_spec.cr
+++ b/spec/compiler/location_spec.cr
@@ -1,0 +1,14 @@
+require "spec"
+require "compiler/crystal/syntax/location"
+
+describe Crystal::Location do
+  it "#inspect" do
+    Crystal::Location.new("foo.cr", 1, 1).inspect.should eq ("Location(foo.cr:1:1)")
+    Crystal::Location.new("foo.cr", 1, 1, 5).inspect.should eq ("Location(foo.cr:1:1+5)")
+  end
+
+  it "#to_s" do
+    Crystal::Location.new("foo.cr", 1, 1).to_s.should eq ("foo.cr:1:1")
+    Crystal::Location.new("foo.cr", 1, 1, 5).to_s.should eq ("foo.cr:1:1+5")
+  end
+end

--- a/src/compiler/crystal/syntax/location.cr
+++ b/src/compiler/crystal/syntax/location.cr
@@ -4,8 +4,8 @@ require "./virtual_file"
 record Crystal::Location,
   filename : String | VirtualFile | Nil,
   line_number : Int32,
-  column_number : Int32 do
-
+  column_number : Int32,
+  size : Int32 = 0 do
   include Comparable(self)
 
   # Returns the directory name of this location's filename. If
@@ -49,11 +49,20 @@ record Crystal::Location,
     when Nil
     end
     io << ':' << line_number << ':' << column_number
+
+    unless size.zero?
+      io << '+' << size
+    end
+
     io << ')'
   end
 
   def to_s(io : IO) : Nil
     io << filename << ':' << line_number << ':' << column_number
+
+    unless size.zero?
+      io << '+' << size
+    end
   end
 
   def pretty_print(pp)

--- a/src/compiler/crystal/syntax/location.cr
+++ b/src/compiler/crystal/syntax/location.cr
@@ -1,13 +1,12 @@
-# A location of an `ASTnode`, including its filename, line number and column number.
-class Crystal::Location
+require "./virtual_file"
+
+# A location of an `ASTNode`, including its filename, line number, column number and (optional) size.
+record Crystal::Location,
+  filename : String | VirtualFile | Nil,
+  line_number : Int32,
+  column_number : Int32 do
+
   include Comparable(self)
-
-  getter line_number
-  getter column_number
-  getter filename
-
-  def initialize(@filename : String | VirtualFile | Nil, @line_number : Int32, @column_number : Int32)
-  end
 
   # Returns the directory name of this location's filename. If
   # the filename is a VirtualFile, this is invoked on its expanded
@@ -41,7 +40,16 @@ class Crystal::Location
   end
 
   def inspect(io : IO) : Nil
-    to_s(io)
+    io << "Location("
+    case filename = @filename
+    when String
+      filename.inspect_unquoted(io)
+    when VirtualFile
+      io << filename
+    when Nil
+    end
+    io << ':' << line_number << ':' << column_number
+    io << ')'
   end
 
   def to_s(io : IO) : Nil

--- a/src/compiler/crystal/syntax/to_s.cr
+++ b/src/compiler/crystal/syntax/to_s.cr
@@ -1,5 +1,6 @@
 require "./ast"
 require "./visitor"
+require "./lexer"
 
 module Crystal
   class ASTNode

--- a/src/compiler/crystal/syntax/virtual_file.cr
+++ b/src/compiler/crystal/syntax/virtual_file.cr
@@ -1,3 +1,5 @@
+require "./ast"
+
 # A VirtualFile is used as a Location's filename when
 # expanding a macro. It contains the macro expanded source
 # code so the user can debug it as if there was a file in the


### PR DESCRIPTION
This PR adds a `size` property on `Crystal::Location` which allows a location to reference not only a single character but a sequence of characters, starting at `line_number:column_number` of `size` length. If `size` is `0` (per default) the meaning is exactly the same as before.
The goal is to allow having a single `location` property on compiler errors, which includes the size as part of the location. This will be used in subsequent refactorings to compiler errors.

This type is also a good use case for a struct because it's a small immutable object combining a few properties. The record macro adds `#copy_with` and `#clone` implementations that will come in handy.

This is the first PR of a series on refactoring compiler errors https://github.com/crystal-lang/crystal/issues/8410#issuecomment-633139982