### PR TITLE
Refactor CrystalPath::Error

### DIFF
--- a/spec/compiler/semantic/require_spec.cr
+++ b/spec/compiler/semantic/require_spec.cr
@@ -18,7 +18,7 @@ describe "Semantic: require" do
       error.message.not_nil!.should_not contain "If you're trying to require a shard:"
     end
 
-    it "wildecard" do
+    it "wildcard" do
       error = assert_error %(require "file_that_doesnt_exist/*"),
         "can't find file 'file_that_doesnt_exist/*'",
         inject_primitives: false
@@ -26,7 +26,7 @@ describe "Semantic: require" do
       error.message.not_nil!.should contain "If you're trying to require a shard:"
     end
 
-    it "relative wildecard" do
+    it "relative wildcard" do
       error = assert_error %(require "./file_that_doesnt_exist/*"),
         "can't find file './file_that_doesnt_exist/*'",
         inject_primitives: false

--- a/spec/compiler/semantic/require_spec.cr
+++ b/spec/compiler/semantic/require_spec.cr
@@ -1,10 +1,37 @@
 require "../../spec_helper"
 
 describe "Semantic: require" do
-  it "raises crystal exception if can't find require (#7385)" do
-    node = parse(%(require "file_that_doesnt_exist"))
-    expect_raises ::Crystal::Exception do
-      semantic(node)
+  describe "file not found" do
+    it "require" do
+      error = assert_error %(require "file_that_doesnt_exist"),
+        "can't find file 'file_that_doesnt_exist'",
+        inject_primitives: false
+
+      error.message.not_nil!.should contain "If you're trying to require a shard:"
+    end
+
+    it "relative require" do
+      error = assert_error %(require "./file_that_doesnt_exist"),
+        "can't find file './file_that_doesnt_exist'",
+        inject_primitives: false
+
+      error.message.not_nil!.should_not contain "If you're trying to require a shard:"
+    end
+
+    it "wildecard" do
+      error = assert_error %(require "file_that_doesnt_exist/*"),
+        "can't find file 'file_that_doesnt_exist/*'",
+        inject_primitives: false
+
+      error.message.not_nil!.should contain "If you're trying to require a shard:"
+    end
+
+    it "relative wildecard" do
+      error = assert_error %(require "./file_that_doesnt_exist/*"),
+        "can't find file './file_that_doesnt_exist/*'",
+        inject_primitives: false
+
+      error.message.not_nil!.should_not contain "If you're trying to require a shard:"
     end
   end
 end

--- a/src/compiler/crystal/crystal_path.cr
+++ b/src/compiler/crystal/crystal_path.cr
@@ -3,7 +3,12 @@ require "./exception"
 
 module Crystal
   struct CrystalPath
-    class Error < LocationlessException
+    class NotFoundError < LocationlessException
+      getter filename
+      getter relative_to
+
+      def initialize(@filename : String, @relative_to : String?)
+      end
     end
 
     private DEFAULT_LIB_PATH = "lib"
@@ -46,7 +51,9 @@ module Crystal
         result = find_in_crystal_path(filename)
       end
 
-      cant_find_file filename, relative_to unless result
+      unless result
+        raise NotFoundError.new(filename, relative_to)
+      end
 
       result = [result] if result.is_a?(String)
       result
@@ -158,24 +165,6 @@ module Crystal
       end
 
       nil
-    end
-
-    private def cant_find_file(filename, relative_to)
-      error = "can't find file '#{filename}'"
-
-      if filename.starts_with? '.'
-        error += " relative to '#{relative_to}'" if relative_to
-      else
-        error = <<-NOTE
-          #{error}
-
-          If you're trying to require a shard:
-          - Did you remember to run `shards install`?
-          - Did you make sure you're running the compiler in the same directory as your shard.yml?
-          NOTE
-      end
-
-      raise Error.new(error)
     end
   end
 end

--- a/src/compiler/crystal/macros/macros.cr
+++ b/src/compiler/crystal/macros/macros.cr
@@ -158,7 +158,7 @@ class Crystal::Program
       begin
         files = @program.find_in_path(recorded_require.filename, recorded_require.relative_to)
         required_files.concat(files) if files
-      rescue Crystal::CrystalPath::Error
+      rescue Crystal::CrystalPath::NotFoundError
         # Maybe the file is gone
         next
       end


### PR DESCRIPTION
Introduces a dedicated error type `CrystalPath::NotFoundError` for path lookup fails which contains information about the path being looked up.
This separates creating the actual compiler error which then happens in `SemanticVisitor#visit(Require)`.

Also refactors the specs to not use absolute paths which could compromise the spec effectiveness.

This PR is part of a series on refactoring compiler errors #8410 (comment)