### PR TITLE
Use function attribute "frame-pointer"

### DIFF
--- a/src/compiler/crystal/codegen/fun.cr
+++ b/src/compiler/crystal/codegen/fun.cr
@@ -88,8 +88,12 @@ class Crystal::CodeGenVisitor
         context.fun.add_attribute LLVM::Attribute::UWTable
         if @program.has_flag?("darwin")
           # Disable frame pointer elimination in Darwin, as it causes issues during stack unwind
-          context.fun.add_target_dependent_attribute "no-frame-pointer-elim", "true"
-          context.fun.add_target_dependent_attribute "no-frame-pointer-elim-non-leaf", "true"
+          {% if compare_versions(Crystal::LLVM_VERSION, "8.0.0") < 0 %}
+            context.fun.add_target_dependent_attribute "no-frame-pointer-elim", "true"
+            context.fun.add_target_dependent_attribute "no-frame-pointer-elim-non-leaf", "true"
+          {% else %}
+            context.fun.add_target_dependent_attribute "frame-pointer", "all"
+          {% end %}
         end
 
         new_entry_block


### PR DESCRIPTION
LLVM 8([D56351](https://reviews.llvm.org/D56351)) introduced frame-pointer which was intended to replace no-frame-pointer-elim and no-frame-pointer-elim-non-leaf.