### PR TITLE
Change IO#write, IO#skip, IO.copy to return Int64

### DIFF
--- a/spec/std/http/request_spec.cr
+++ b/spec/std/http/request_spec.cr
@@ -6,8 +6,8 @@ private class EmptyIO < IO
     0
   end
 
-  def write(slice : Bytes) : UInt64
-    slice.size.to_u64
+  def write(slice : Bytes) : Int64
+    slice.size.to_i64
   end
 end
 

--- a/spec/std/http/server/response_spec.cr
+++ b/spec/std/http/server/response_spec.cr
@@ -12,11 +12,11 @@ private class ReverseResponseOutput < IO
   def initialize(@output : IO)
   end
 
-  def write(slice : Bytes) : UInt64
+  def write(slice : Bytes) : Int64
     slice.reverse_each do |byte|
       @output.write_byte(byte)
     end
-    slice.size.to_u64
+    slice.size.to_i64
   end
 
   def read(slice : Bytes)

--- a/spec/std/io/io_spec.cr
+++ b/spec/std/io/io_spec.cr
@@ -46,7 +46,7 @@ private class SimpleIOMemory < IO
     count
   end
 
-  def write(slice : Bytes) : UInt64
+  def write(slice : Bytes) : Int64
     count = slice.size
     new_bytesize = bytesize + count
     if new_bytesize > @capacity
@@ -56,7 +56,7 @@ private class SimpleIOMemory < IO
     slice.copy_to(@buffer + @bytesize, count)
     @bytesize += count
 
-    slice.size.to_u64
+    slice.size.to_i64
   end
 
   def to_slice
@@ -99,8 +99,8 @@ private class OneByOneIO < IO
     1
   end
 
-  def write(slice : Bytes) : UInt64
-    slice.size.to_u64
+  def write(slice : Bytes) : Int64
+    slice.size.to_i64
   end
 end
 

--- a/spec/std/io/sized_spec.cr
+++ b/spec/std/io/sized_spec.cr
@@ -5,8 +5,8 @@ private class NoPeekIO < IO
     0
   end
 
-  def write(bytes : Bytes) : UInt64
-    0u64
+  def write(bytes : Bytes) : Int64
+    0i64
   end
 
   def peek

--- a/spec/support/io.cr
+++ b/spec/support/io.cr
@@ -8,10 +8,10 @@ class RaiseIOError < IO
     raise IO::Error.new("...")
   end
 
-  def write(slice : Bytes) : UInt64
+  def write(slice : Bytes) : Int64
     @writes += 1
     raise IO::Error.new("...") if @raise_on_write
-    slice.size.to_u64
+    slice.size.to_i64
   end
 
   def flush

--- a/src/compress/deflate/writer.cr
+++ b/src/compress/deflate/writer.cr
@@ -43,16 +43,16 @@ class Compress::Deflate::Writer < IO
   end
 
   # See `IO#write`.
-  def write(slice : Bytes) : UInt64
+  def write(slice : Bytes) : Int64
     check_open
 
-    return 0u64 if slice.empty?
+    return 0i64 if slice.empty?
 
     @stream.avail_in = slice.size
     @stream.next_in = slice
     consume_output LibZ::Flush::NO_FLUSH
 
-    slice.size.to_u64
+    slice.size.to_i64
   end
 
   # See `IO#flush`.

--- a/src/compress/gzip/writer.cr
+++ b/src/compress/gzip/writer.cr
@@ -68,10 +68,10 @@ class Compress::Gzip::Writer < IO
   end
 
   # See `IO#write`.
-  def write(slice : Bytes) : UInt64
+  def write(slice : Bytes) : Int64
     check_open
 
-    return 0u64 if slice.empty?
+    return 0i64 if slice.empty?
 
     flate_io = write_header
     flate_io.write(slice)
@@ -83,7 +83,7 @@ class Compress::Gzip::Writer < IO
     # uncompressed data size can be bigger.
     @isize &+= slice.size
 
-    slice.size.to_u64
+    slice.size.to_i64
   end
 
   # Flushes data, forcing writing the gzip header if no

--- a/src/compress/zip/checksum_writer.cr
+++ b/src/compress/zip/checksum_writer.cr
@@ -13,8 +13,8 @@ module Compress::Zip
       raise IO::Error.new "Can't read from Zip::Writer entry"
     end
 
-    def write(slice : Bytes) : UInt64
-      return 0u64 if slice.empty?
+    def write(slice : Bytes) : Int64
+      return 0i64 if slice.empty?
 
       @count += slice.size
       @crc32 = Digest::CRC32.update(slice, @crc32) if @compute_crc32

--- a/src/compress/zlib/writer.cr
+++ b/src/compress/zlib/writer.cr
@@ -44,17 +44,17 @@ class Compress::Zlib::Writer < IO
   end
 
   # See `IO#write`.
-  def write(slice : Bytes) : UInt64
+  def write(slice : Bytes) : Int64
     check_open
 
-    return 0u64 if slice.empty?
+    return 0i64 if slice.empty?
 
     write_header unless @wrote_header
 
     @flate_io.write(slice)
     @adler32 = Digest::Adler32.update(slice, @adler32)
 
-    slice.size.to_u64
+    slice.size.to_i64
   end
 
   # Flushes data, forcing writing the zlib header if no

--- a/src/float.cr
+++ b/src/float.cr
@@ -93,7 +93,7 @@ struct Float
 
   # Writes this float to the given *io* in the given *format*.
   # See also: `IO#write_bytes`.
-  def to_io(io : IO, format : IO::ByteFormat) : UInt64
+  def to_io(io : IO, format : IO::ByteFormat) : Int64
     format.encode(self, io)
   end
 

--- a/src/http/content.cr
+++ b/src/http/content.cr
@@ -41,7 +41,7 @@ module HTTP
       super
     end
 
-    def skip(bytes_count : Int) : UInt64
+    def skip(bytes_count : Int) : Int64
       ensure_send_continue
       super
     end
@@ -73,7 +73,7 @@ module HTTP
       @io.peek
     end
 
-    def skip(bytes_count : Int) : UInt64
+    def skip(bytes_count : Int) : Int64
       ensure_send_continue
       @io.skip(bytes_count)
     end
@@ -164,8 +164,8 @@ module HTTP
       peek
     end
 
-    def skip(bytes_count : Int) : UInt64
-      bytes_count = bytes_count.to_u64
+    def skip(bytes_count : Int) : Int64
+      bytes_count = bytes_count.to_i64
       ensure_send_continue
 
       if bytes_count <= @chunk_remaining

--- a/src/http/server/response.cr
+++ b/src/http/server/response.cr
@@ -80,8 +80,8 @@ class HTTP::Server
     end
 
     # See `IO#write(slice)`.
-    def write(slice : Bytes) : UInt64
-      return 0u64 if slice.empty?
+    def write(slice : Bytes) : Int64
+      return 0i64 if slice.empty?
 
       @output.write(slice)
     end

--- a/src/http/web_socket/protocol.cr
+++ b/src/http/web_socket/protocol.cr
@@ -52,8 +52,8 @@ class HTTP::WebSocket::Protocol
       @pos = 0
     end
 
-    def write(slice : Bytes) : UInt64
-      return 0u64 if slice.empty?
+    def write(slice : Bytes) : Int64
+      return 0i64 if slice.empty?
 
       count = Math.min(@buffer.size - @pos, slice.size)
       (@buffer + @pos).copy_from(slice.to_unsafe, count)
@@ -67,7 +67,7 @@ class HTTP::WebSocket::Protocol
         write(slice + count)
       end
 
-      slice.size.to_u64
+      slice.size.to_i64
     end
 
     def read(slice : Bytes)

--- a/src/int.cr
+++ b/src/int.cr
@@ -638,7 +638,7 @@ struct Int
   # Writes this integer to the given *io* in the given *format*.
   #
   # See also: `IO#write_bytes`.
-  def to_io(io : IO, format : IO::ByteFormat) : UInt64
+  def to_io(io : IO, format : IO::ByteFormat) : Int64
     format.encode(self, io)
   end
 

--- a/src/io/buffered.cr
+++ b/src/io/buffered.cr
@@ -110,8 +110,8 @@ module IO::Buffered
   end
 
   # :nodoc:
-  def skip(bytes_count : Int) : UInt64
-    bytes_count = bytes_count.to_u64
+  def skip(bytes_count : Int) : Int64
+    bytes_count = bytes_count.to_i64
     check_open
 
     if bytes_count <= @in_buffer_rem.size
@@ -128,18 +128,18 @@ module IO::Buffered
   end
 
   # Buffered implementation of `IO#write(slice)`.
-  def write(slice : Bytes) : UInt64
+  def write(slice : Bytes) : Int64
     # NOTE: It returns the bytes written without differencing whether
     # they are kept in the buffer or sent to the underlying IO.
     check_open
 
-    return 0u64 if slice.empty?
+    return 0i64 if slice.empty?
 
     count = slice.size
 
     if sync?
       unbuffered_write(slice)
-      return slice.size.to_u64
+      return slice.size.to_i64
     end
 
     if flush_on_newline?
@@ -156,7 +156,7 @@ module IO::Buffered
     if count >= @buffer_size
       flush
       unbuffered_write slice[0, count]
-      return slice.size.to_u64
+      return slice.size.to_i64
     end
 
     if count > @buffer_size - @out_count
@@ -166,11 +166,11 @@ module IO::Buffered
     slice.copy_to(out_buffer + @out_count, count)
     @out_count += count
 
-    slice.size.to_u64
+    slice.size.to_i64
   end
 
   # :nodoc:
-  def write_byte(byte : UInt8) : UInt64
+  def write_byte(byte : UInt8) : Int64
     check_open
 
     if sync?
@@ -187,7 +187,7 @@ module IO::Buffered
       flush
     end
 
-    1u64
+    1i64
   end
 
   # Turns on/off `IO` **write** buffering. When *sync* is set to `true`, no buffering

--- a/src/io/byte_format.cr
+++ b/src/io/byte_format.cr
@@ -33,27 +33,27 @@
 # io.to_slice # => Bytes[0x34, 0x12]
 # ```
 module IO::ByteFormat
-  abstract def encode(int : Int8, io : IO) : UInt64
-  abstract def encode(int : UInt8, io : IO) : UInt64
-  abstract def encode(int : Int16, io : IO) : UInt64
-  abstract def encode(int : UInt16, io : IO) : UInt64
-  abstract def encode(int : Int32, io : IO) : UInt64
-  abstract def encode(int : UInt32, io : IO) : UInt64
-  abstract def encode(int : Int64, io : IO) : UInt64
-  abstract def encode(int : UInt64, io : IO) : UInt64
-  abstract def encode(int : Int128, io : IO) : UInt64
-  abstract def encode(int : UInt128, io : IO) : UInt64
+  abstract def encode(int : Int8, io : IO) : Int64
+  abstract def encode(int : UInt8, io : IO) : Int64
+  abstract def encode(int : Int16, io : IO) : Int64
+  abstract def encode(int : UInt16, io : IO) : Int64
+  abstract def encode(int : Int32, io : IO) : Int64
+  abstract def encode(int : UInt32, io : IO) : Int64
+  abstract def encode(int : Int64, io : IO) : Int64
+  abstract def encode(int : UInt64, io : IO) : Int64
+  abstract def encode(int : Int128, io : IO) : Int64
+  abstract def encode(int : UInt128, io : IO) : Int64
 
-  abstract def encode(int : Int8, bytes : Bytes) : UInt64
-  abstract def encode(int : UInt8, bytes : Bytes) : UInt64
-  abstract def encode(int : Int16, bytes : Bytes) : UInt64
-  abstract def encode(int : UInt16, bytes : Bytes) : UInt64
-  abstract def encode(int : Int32, bytes : Bytes) : UInt64
-  abstract def encode(int : UInt32, bytes : Bytes) : UInt64
-  abstract def encode(int : Int64, bytes : Bytes) : UInt64
-  abstract def encode(int : UInt64, bytes : Bytes) : UInt64
-  abstract def encode(int : Int128, bytes : Bytes) : UInt64
-  abstract def encode(int : UInt128, bytes : Bytes) : UInt64
+  abstract def encode(int : Int8, bytes : Bytes) : Int64
+  abstract def encode(int : UInt8, bytes : Bytes) : Int64
+  abstract def encode(int : Int16, bytes : Bytes) : Int64
+  abstract def encode(int : UInt16, bytes : Bytes) : Int64
+  abstract def encode(int : Int32, bytes : Bytes) : Int64
+  abstract def encode(int : UInt32, bytes : Bytes) : Int64
+  abstract def encode(int : Int64, bytes : Bytes) : Int64
+  abstract def encode(int : UInt64, bytes : Bytes) : Int64
+  abstract def encode(int : Int128, bytes : Bytes) : Int64
+  abstract def encode(int : UInt128, bytes : Bytes) : Int64
 
   abstract def decode(int : Int8.class, io : IO)
   abstract def decode(int : UInt8.class, io : IO)
@@ -77,11 +77,11 @@ module IO::ByteFormat
   abstract def decode(int : Int128.class, bytes : Bytes)
   abstract def decode(int : UInt128.class, bytes : Bytes)
 
-  def encode(float : Float32, io : IO) : UInt64
+  def encode(float : Float32, io : IO) : Int64
     encode(float.unsafe_as(Int32), io)
   end
 
-  def encode(float : Float32, bytes : Bytes) : UInt64
+  def encode(float : Float32, bytes : Bytes) : Int64
     encode(float.unsafe_as(Int32), bytes)
   end
 
@@ -93,11 +93,11 @@ module IO::ByteFormat
     decode(Int32, bytes).unsafe_as(Float32)
   end
 
-  def encode(float : Float64, io : IO) : UInt64
+  def encode(float : Float64, io : IO) : Int64
     encode(float.unsafe_as(Int64), io)
   end
 
-  def encode(float : Float64, bytes : Bytes) : UInt64
+  def encode(float : Float64, bytes : Bytes) : Int64
     encode(float.unsafe_as(Int64), bytes)
   end
 
@@ -125,18 +125,18 @@ module IO::ByteFormat
       {% for type, i in %w(Int8 UInt8 Int16 UInt16 Int32 UInt32 Int64 UInt64 Int128 UInt128) %}
         {% bytesize = 2 ** (i // 2) %}
 
-        def self.encode(int : {{type.id}}, io : IO) : UInt64
+        def self.encode(int : {{type.id}}, io : IO) : Int64
           buffer = int.unsafe_as(StaticArray(UInt8, {{bytesize}}))
           buffer.reverse! unless SystemEndian == self
           io.write(buffer.to_slice)
-          UInt64.new({{bytesize}})
+          Int64.new({{bytesize}})
         end
 
-        def self.encode(int : {{type.id}}, bytes : Bytes) : UInt64
+        def self.encode(int : {{type.id}}, bytes : Bytes) : Int64
           buffer = int.unsafe_as(StaticArray(UInt8, {{bytesize}}))
           buffer.reverse! unless SystemEndian == self
           buffer.to_slice.copy_to(bytes)
-          UInt64.new({{bytesize}})
+          Int64.new({{bytesize}})
         end
 
         def self.decode(type : {{type.id}}.class, io : IO)

--- a/src/io/delimited.cr
+++ b/src/io/delimited.cr
@@ -107,7 +107,7 @@ class IO::Delimited < IO
     read_bytes
   end
 
-  def write(slice : Bytes) : UInt64
+  def write(slice : Bytes) : Int64
     raise IO::Error.new "Can't write to IO::Delimited"
   end
 

--- a/src/io/encoding.cr
+++ b/src/io/encoding.cr
@@ -27,8 +27,8 @@ class IO
       @closed = false
     end
 
-    def write(io, slice : Bytes) : UInt64
-      bytes_written = 0u64
+    def write(io, slice : Bytes) : Int64
+      bytes_written = 0i64
       inbuf_ptr = slice.to_unsafe
       inbytesleft = LibC::SizeT.new(slice.size)
       outbuf = uninitialized UInt8[1024]

--- a/src/io/hexdump.cr
+++ b/src/io/hexdump.cr
@@ -32,8 +32,8 @@ class IO::Hexdump < IO
     end
   end
 
-  def write(buf : Bytes) : UInt64
-    return 0u64 if buf.empty?
+  def write(buf : Bytes) : Int64
+    return 0i64 if buf.empty?
 
     @io.write(buf).tap do
       @output.puts buf.hexdump if @write

--- a/src/io/memory.cr
+++ b/src/io/memory.cr
@@ -82,13 +82,13 @@ class IO::Memory < IO
 
   # See `IO#write(slice)`. Raises if this `IO::Memory` is non-writeable,
   # or if it's non-resizeable and a resize is needed.
-  def write(slice : Bytes) : UInt64
+  def write(slice : Bytes) : Int64
     check_writeable
     check_open
 
     count = slice.size
 
-    return 0u64 if count == 0
+    return 0i64 if count == 0
 
     new_bytesize = @pos + count
     if new_bytesize > @capacity
@@ -105,12 +105,12 @@ class IO::Memory < IO
     @pos += count
     @bytesize = @pos if @pos > @bytesize
 
-    slice.size.to_u64
+    slice.size.to_i64
   end
 
   # See `IO#write_byte`. Raises if this `IO::Memory` is non-writeable,
   # or if it's non-resizeable and a resize is needed.
-  def write_byte(byte : UInt8)
+  def write_byte(byte : UInt8) : Int64
     check_writeable
     check_open
 
@@ -129,7 +129,7 @@ class IO::Memory < IO
     @pos += 1
     @bytesize = @pos if @pos > @bytesize
 
-    nil
+    1i64
   end
 
   # :nodoc:
@@ -194,8 +194,8 @@ class IO::Memory < IO
   end
 
   # :nodoc:
-  def skip(bytes_count : Int) : UInt64
-    bytes_count = bytes_count.to_u64
+  def skip(bytes_count : Int) : Int64
+    bytes_count = bytes_count.to_i64
     check_open
 
     available = @bytesize - @pos
@@ -208,12 +208,12 @@ class IO::Memory < IO
   end
 
   # :nodoc:
-  def skip_to_end : UInt64
+  def skip_to_end : Int64
     check_open
 
     skipped = @bytesize - @pos
     @pos = @bytesize
-    skipped.to_u64
+    skipped.to_i64
   end
 
   # :nodoc:

--- a/src/io/multi_writer.cr
+++ b/src/io/multi_writer.cr
@@ -29,14 +29,14 @@ class IO::MultiWriter < IO
     @writers = writers.map(&.as(IO)).to_a
   end
 
-  def write(slice : Bytes) : UInt64
+  def write(slice : Bytes) : Int64
     check_open
 
-    return 0u64 if slice.empty?
+    return 0i64 if slice.empty?
 
     @writers.each { |writer| writer.write(slice) }
 
-    slice.size.to_u64
+    slice.size.to_i64
   end
 
   def read(slice : Bytes)

--- a/src/io/sized.cr
+++ b/src/io/sized.cr
@@ -61,8 +61,8 @@ class IO::Sized < IO
     peek
   end
 
-  def skip(bytes_count : Int) : UInt64
-    bytes_count = bytes_count.to_u64
+  def skip(bytes_count : Int) : Int64
+    bytes_count = bytes_count.to_i64
     check_open
 
     if bytes_count <= @read_remaining

--- a/src/io/stapled.cr
+++ b/src/io/stapled.cr
@@ -51,31 +51,31 @@ class IO::Stapled < IO
   end
 
   # Skips `reader`.
-  def skip(bytes_count : Int) : UInt64
+  def skip(bytes_count : Int) : Int64
     check_open
 
     @reader.skip(bytes_count)
   end
 
   # Skips `reader`.
-  def skip_to_end : UInt64
+  def skip_to_end : Int64
     check_open
 
     @reader.skip_to_end
   end
 
   # Writes a byte to `writer`.
-  def write_byte(byte : UInt8) : Nil
+  def write_byte(byte : UInt8) : Int64
     check_open
 
     @writer.write_byte(byte)
   end
 
   # Writes a slice to `writer`.
-  def write(slice : Bytes) : UInt64
+  def write(slice : Bytes) : Int64
     check_open
 
-    return 0u64 if slice.empty?
+    return 0i64 if slice.empty?
 
     @writer.write(slice)
   end

--- a/src/openssl/digest/digest_io.cr
+++ b/src/openssl/digest/digest_io.cr
@@ -42,8 +42,8 @@ module OpenSSL
       read_bytes
     end
 
-    def write(slice : Bytes) : UInt64
-      return 0u64 if slice.empty?
+    def write(slice : Bytes) : Int64
+      return 0i64 if slice.empty?
 
       if @mode.write?
         digest_algorithm.update(slice)

--- a/src/string/builder.cr
+++ b/src/string/builder.cr
@@ -38,8 +38,8 @@ class String::Builder < IO
     raise "Not implemented"
   end
 
-  def write(slice : Bytes) : UInt64
-    return 0u64 if slice.empty?
+  def write(slice : Bytes) : Int64
+    return 0i64 if slice.empty?
 
     count = slice.size
     new_bytesize = real_bytesize + count
@@ -50,10 +50,10 @@ class String::Builder < IO
     slice.copy_to(@buffer + real_bytesize, count)
     @bytesize += count
 
-    slice.size.to_u64
+    slice.size.to_i64
   end
 
-  def write_byte(byte : UInt8)
+  def write_byte(byte : UInt8) : Int64
     new_bytesize = real_bytesize + 1
     if new_bytesize > @capacity
       resize_to_capacity(Math.pw2ceil(new_bytesize))
@@ -63,7 +63,7 @@ class String::Builder < IO
 
     @bytesize += 1
 
-    nil
+    1i64
   end
 
   def buffer


### PR DESCRIPTION
This PR 

* Updates the unreleased changes in #9233 to return `Int64` instead of `UInt64`.
* Changes `IO.copy` to return `Int64` for consistency
* Updates `IO::Stapled#write_byte`, `String::Builder#write_byte` which were missing in #9233.

The dilema between using UInt64 or Int64 was due to:
* OS / libc uses unsigned int under the hood in some places.
  * Odly, I was sure `LibC.write` returned unsigned, but I was wrong 🤷‍♂️. I know we are not using the turned value directly in `IO#write`, but they are related.
* Keeping consistency with existing `IO.copy`

But since mixing signed and unsigned types will impose some performance issues, we can avoid them if we discourage unsigned int in some cases like this one.