### PR TITLE
Make autocasting work in default values against unions

### DIFF
--- a/spec/compiler/semantic/automatic_cast.cr
+++ b/spec/compiler/semantic/automatic_cast.cr
@@ -492,4 +492,58 @@ describe "Semantic: automatic cast" do
       fill(0, 0)
       )) { float64 }
   end
+
+  it "can autocast to union in default value" do
+    assert_type(%(
+      def fill(x : Int64 | String = 1)
+        x
+      end
+
+      fill()
+      )) { int64 }
+  end
+
+  it "can autocast to alias in default value" do
+    assert_type(%(
+      alias X = Int64 | String
+
+      def fill(x : X = 1)
+        x
+      end
+
+      fill()
+      )) { int64 }
+  end
+
+  it "can autocast to union in default value (symbol and int)" do
+    assert_type(%(
+      enum Color
+        Red
+      end
+
+      def fill(x : Int64 | Color = :red)
+        x
+      end
+
+      fill()
+      )) { types["Color"] }
+  end
+
+  it "can autocast to union in default value (multiple enums)" do
+    assert_type(%(
+      enum Color
+        Red
+      end
+
+      enum AnotherColor
+        Blue
+      end
+
+      def fill(x : Color | AnotherColor = :blue)
+        x
+      end
+
+      fill()
+      )) { types["AnotherColor"] }
+  end
 end

--- a/src/compiler/crystal/semantic/class_vars_initializer_visitor.cr
+++ b/src/compiler/crystal/semantic/class_vars_initializer_visitor.cr
@@ -73,7 +73,7 @@ module Crystal
              (class_var_type = class_var.type?)
             cloned_node = node.clone
             cloned_node.accept MainVisitor.new(self)
-            if casted_value = MainVisitor.check_automatic_cast(cloned_node, class_var_type)
+            if casted_value = MainVisitor.check_automatic_cast(@program, cloned_node, class_var_type)
               node = initializer.node = casted_value
             end
           end

--- a/src/compiler/crystal/semantic/instance_vars_initializer_visitor.cr
+++ b/src/compiler/crystal/semantic/instance_vars_initializer_visitor.cr
@@ -98,7 +98,7 @@ class Crystal::InstanceVarsInitializerVisitor < Crystal::SemanticVisitor
          (scope_initializer = scope_initializers[index])
         cloned_value = value.clone
         cloned_value.accept MainVisitor.new(program)
-        if casted_value = MainVisitor.check_automatic_cast(cloned_value, scope.lookup_instance_var(i.target.name).type)
+        if casted_value = MainVisitor.check_automatic_cast(@program, cloned_value, scope.lookup_instance_var(i.target.name).type)
           scope_initializer.value = casted_value
           next
         end

--- a/src/compiler/crystal/types.cr
+++ b/src/compiler/crystal/types.cr
@@ -1618,7 +1618,7 @@ module Crystal
       # Check if automatic cast can be done
       if instance_var.type != value.type &&
          (value.is_a?(NumberLiteral) || value.is_a?(SymbolLiteral))
-        if casted_value = MainVisitor.check_automatic_cast(value, instance_var.type)
+        if casted_value = MainVisitor.check_automatic_cast(@program, value, instance_var.type)
           value = casted_value
         end
       end


### PR DESCRIPTION
Fixes https://forum.crystal-lang.org/t/does-autocasting-enums-for-default-parameter-work-for-alias-unions/2176

This also makes the default value checking reuse the existing logic to check autocasting, so now default value autocasting and method call autocasting should always work the same 🎉 