### PR TITLE
Refactor compiler warning formatting

### DIFF
--- a/src/compiler/crystal/semantic/ast.cr
+++ b/src/compiler/crystal/semantic/ast.cr
@@ -13,13 +13,14 @@ module Crystal
       ::raise exception_type.for_node(self, message, inner)
     end
 
-    def warning(message, inner = nil, exception_type = Crystal::TypeException)
-      # TODO extract message formatting from exceptions
-      String.build do |io|
-        exception = exception_type.for_node(self, message, inner)
-        exception.warning = true
-        exception.append_to_s(io, nil)
+    def warning(message)
+      if location = name_location || self.location
+        message = String.build do |io|
+          io << "warning in line " << location.line_number << "\nWarning: "
+          io << message.sub("\n", "\n\n")
+        end
       end
+      message
     end
 
     def simple_literal?

--- a/src/compiler/crystal/semantic/warnings.cr
+++ b/src/compiler/crystal/semantic/warnings.cr
@@ -13,9 +13,8 @@ module Crystal
 
       if location
         message = String.build do |io|
-          exception = SyntaxException.new message, location.line_number, location.column_number, location.filename
-          exception.warning = true
-          exception.append_to_s(io, nil)
+          io << "warning in line " << location.line_number << "\nWarning: "
+          io << message.sub('\n', "\n\n")
         end
       end
 


### PR DESCRIPTION
This removes the immediate dependency of compiler warning on `Crystal::Exception` which just provides a really trivial formatting.

The main purpose is to avoid covering these additional cases for refactoring compiler errors. I'm planning a major overhaul for warnings afterwards based on that refactoring.

Depends on #9367