### PR TITLE
Format: avoid formatter crash on string interpolations in heredoc

### DIFF
--- a/spec/compiler/formatter/formatter_spec.cr
+++ b/spec/compiler/formatter/formatter_spec.cr
@@ -971,6 +971,10 @@ describe Crystal::Formatter do
   assert_format "<<-HTML\n  \#{1}x\n  HTML"
   assert_format "<<-HTML\n  \#{1}x\n  y\n  HTML"
   assert_format "<<-HTML\n  \#{1}x\n  y\n  z\n  HTML"
+  assert_format %(<<-HTML\n  \#{"foo"}\n  HTML)
+  assert_format %(<<-HTML\n  \#{__FILE__}\n  HTML)
+  assert_format %(<<-HTML\n  \#{"fo\#{"o"}"}\n  HTML)
+  assert_format %(<<-HTML\n  \#{"foo"}\#{1}\n  HTML)
 
   assert_format "  <<-HTML\n   foo\n  HTML", "<<-HTML\n foo\nHTML"
   assert_format "  <<-HTML\n   \#{1}\n  HTML", "<<-HTML\n \#{1}\nHTML"

--- a/src/compiler/crystal/syntax/ast.cr
+++ b/src/compiler/crystal/syntax/ast.cr
@@ -293,6 +293,16 @@ module Crystal
     def_equals_and_hash value
   end
 
+  class StringInterpolationContent < StringLiteral
+    def class_desc
+      "StringLiteral"
+    end
+
+    def clone_without_location
+      StringInterpolationContent.new(@value)
+    end
+  end
+
   class StringInterpolation < ASTNode
     property expressions : Array(ASTNode)
 

--- a/src/compiler/crystal/tools/formatter.cr
+++ b/src/compiler/crystal/tools/formatter.cr
@@ -558,23 +558,11 @@ module Crystal
           next_string_token
         end
 
-        if exp.is_a?(StringLiteral)
-          # It might be #{__DIR__}, for example
-          if @token.type == :INTERPOLATION_START
-            write "\#{"
-            delimiter_state = @token.delimiter_state
-            next_token_skip_space_or_newline
-            indent(@column, exp)
-            skip_space_or_newline
-            check :"}"
-            write "}"
-            @token.delimiter_state = delimiter_state
+        if exp.is_a?(StringInterpolationContent)
+          if @token.invalid_escape
+            write @token.value
           else
-            if @token.invalid_escape
-              write @token.value
-            else
-              write @token.raw
-            end
+            write @token.raw
           end
           next_string_token
         else


### PR DESCRIPTION
Fixed #9362

Now, we can format the following code with formatter crash:

```crystal
foo = <<-FOO
  #{__FILE__}#{__LINE__}
  FOO
```

This PR introduce a new AST node named `StringInterpolationContent` to distinguish between usual string literal and part of string interpolation content. `StringInterpolationContent` inherits `StringLiteral`. It seems a bit tricky, but changes are little in fact.

Note, this distinction is necessary for formatter surely. It is impossible that lexer and formatter on heredoc synchronize without this.