### PR TITLE
Add Crystal::Path#name_size implementation

### DIFF
--- a/src/compiler/crystal/syntax/ast.cr
+++ b/src/compiler/crystal/syntax/ast.cr
@@ -1269,7 +1269,6 @@ module Crystal
   class Path < ASTNode
     property names : Array(String)
     property? global : Bool
-    property name_size = 0
     property visibility = Visibility::Public
 
     def initialize(@names : Array, @global = false)
@@ -1283,6 +1282,10 @@ module Crystal
       new names, true
     end
 
+    def name_size
+      names.sum(&.size) + (names.size + (global? ? 0 : -1)) * 2
+    end
+
     # Returns true if this path has a single component
     # with the given name
     def single?(name)
@@ -1291,7 +1294,6 @@ module Crystal
 
     def clone_without_location
       ident = Path.new(@names.clone, @global)
-      ident.name_size = name_size
       ident
     end
 


### PR DESCRIPTION
This implementation was missing

There are no unit tests for ASTNode yet, so I don't know how to test this. It's used for underlining error locations, that's where this popped up. But it's hard to test that way.
I'm also not sure anymore how to reproduce the failing behaviour... this fix was in my compiler error refactor branch for quite some time and I don't remember the exact circumstances.

However, considering the ivar `@name_size` was never actually assigned, it doesn't seem to be actually used. It's still nice to have a correct implementation and it's going to be used in the compiler error refactor.