### PR TITLE
Format: avoid formatter crash on heredoc having interpolation of sting literal

### DIFF
--- a/spec/compiler/formatter/formatter_spec.cr
+++ b/spec/compiler/formatter/formatter_spec.cr
@@ -971,6 +971,12 @@ describe Crystal::Formatter do
   assert_format "<<-HTML\n  \#{1}x\n  HTML"
   assert_format "<<-HTML\n  \#{1}x\n  y\n  HTML"
   assert_format "<<-HTML\n  \#{1}x\n  y\n  z\n  HTML"
+  assert_format %(<<-HTML\n  \#{"foo"}\n  HTML)
+  assert_format %(<<-HTML\n  \#{__FILE__}\n  HTML)
+  assert_format %(<<-HTML\n  \#{"fo\#{"o"}"}\n  HTML)
+  assert_format %(<<-HTML\n  \#{"foo"}\#{1}\n  HTML)
+  assert_format %(<<-HTML\n  foo\n  \#{"foo"}\n  HTML)
+  assert_format %(<<-HTML\n  \#{"foo"}\n  \#{"bar"}\n  HTML)
 
   assert_format "  <<-HTML\n   foo\n  HTML", "<<-HTML\n foo\nHTML"
   assert_format "  <<-HTML\n   \#{1}\n  HTML", "<<-HTML\n \#{1}\nHTML"

--- a/src/compiler/crystal/syntax/ast.cr
+++ b/src/compiler/crystal/syntax/ast.cr
@@ -296,7 +296,11 @@ module Crystal
   class StringInterpolation < ASTNode
     property expressions : Array(ASTNode)
 
-    def initialize(@expressions : Array(ASTNode))
+    # Removed indentation size.
+    # This property is only available when this is created from heredoc.
+    property heredoc_indent : Int32
+
+    def initialize(@expressions : Array(ASTNode), @heredoc_indent = 0)
     end
 
     def accept_children(visitor)

--- a/src/compiler/crystal/syntax/parser.cr
+++ b/src/compiler/crystal/syntax/parser.cr
@@ -2127,6 +2127,8 @@ module Crystal
         node.expressions.push(StringLiteral.new(string).at(node.location).at_end(token_end_location))
       end
 
+      node.heredoc_indent = delimiter_state.heredoc_indent
+
       node.end_location = token_end_location
     end
 

--- a/src/compiler/crystal/tools/formatter.cr
+++ b/src/compiler/crystal/tools/formatter.cr
@@ -538,7 +538,7 @@ module Crystal
       heredoc_end = @line
 
       # To detect the first content of interpolation of string literal correctly,
-      # we should consume the first stirng token if this token contains only removed indentation of heredoc.
+      # we should consume the first string token if this token contains only removed indentation of heredoc.
       if is_heredoc && @token.type == :STRING
         token_is_indent = @token.raw.bytesize == node.heredoc_indent && @token.raw.each_char.all? &.ascii_whitespace?
         if token_is_indent

--- a/src/compiler/crystal/tools/formatter.cr
+++ b/src/compiler/crystal/tools/formatter.cr
@@ -586,7 +586,7 @@ module Crystal
               write @token.invalid_escape ? @token.value : @token.raw
               next_string_token
 
-              # On heredoc, the piece of content is combined due to removing indentation.
+              # On heredoc, pieces of contents are combined due to removing indentation.
               # Thus, we should consume continuous string tokens at once.
               break if !is_heredoc || @token.type != :STRING
             end

--- a/src/compiler/crystal/tools/formatter.cr
+++ b/src/compiler/crystal/tools/formatter.cr
@@ -537,6 +537,16 @@ module Crystal
       heredoc_line = @line
       heredoc_end = @line
 
+      # To detect the first content of interpolation of string literal correctly,
+      # we should consume the first stirng token if this token contains only removed indentation of heredoc.
+      if is_heredoc && @token.type == :STRING
+        token_is_indent = @token.raw.bytesize == node.heredoc_indent && @token.raw.each_char.all? &.ascii_whitespace?
+        if token_is_indent
+          write @token.raw
+          next_string_token
+        end
+      end
+
       node.expressions.each do |exp|
         if @token.type == :DELIMITER_END
           # Heredoc cannot contain string continuation,
@@ -569,17 +579,19 @@ module Crystal
             check :"}"
             write "}"
             @token.delimiter_state = delimiter_state
+            next_string_token
           else
-            if @token.invalid_escape
-              write @token.value
-            else
-              write @token.raw
+            loop do
+              check :STRING
+              write @token.invalid_escape ? @token.value : @token.raw
+              next_string_token
+
+              # On heredoc, the piece of content is combined due to removing indentation.
+              # Thus, we should consume continuous string tokens at once.
+              break if !is_heredoc || @token.type != :STRING
             end
           end
-          next_string_token
         else
-          skip_strings
-
           check :INTERPOLATION_START
           write "\#{"
           delimiter_state = @token.delimiter_state
@@ -606,8 +618,6 @@ module Crystal
         end
       end
 
-      skip_strings
-
       heredoc_end = @line
 
       check :DELIMITER_END
@@ -630,15 +640,6 @@ module Crystal
       @indent = old_indent unless is_heredoc
 
       false
-    end
-
-    private def skip_strings
-      # Heredocs might indice some spaces that are removed
-      # because of indentation
-      while @token.type == :STRING
-        write @token.raw
-        next_string_token
-      end
     end
 
     private def consume_heredocs


### PR DESCRIPTION
Fixed #9362
Close #9373

It adds `heredoc_indent` property to `StringInterpolation` to detect the first interpolation on formatting correctly. In addition, it fixes stirng token consuming on heredoc.