### PR TITLE
Make compiler specs use locally build crystal

### DIFF
--- a/spec/compiler/config_spec.cr
+++ b/spec/compiler/config_spec.cr
@@ -3,7 +3,7 @@ require "./spec_helper"
 
 describe Crystal::Config do
   it ".host_target" do
-    Crystal::Config.host_target.should eq Crystal::Codegen::Target.new({{ `bin/crystal --version`.lines[-1] }}.lstrip("Default target: "))
+    Crystal::Config.host_target.should eq Crystal::Codegen::Target.new({{ `bin/crystal --version`.lines[-1] }}.lchop("Default target: "))
   end
 
   {% if flag?(:linux) %}

--- a/spec/compiler/config_spec.cr
+++ b/spec/compiler/config_spec.cr
@@ -3,7 +3,7 @@ require "./spec_helper"
 
 describe Crystal::Config do
   it ".host_target" do
-    Crystal::Config.host_target.should eq Crystal::Codegen::Target.new({{ `crystal --version`.lines[-1] }}.lstrip("Default target: "))
+    Crystal::Config.host_target.should eq Crystal::Codegen::Target.new({{ `bin/crystal --version`.lines[-1] }}.lstrip("Default target: "))
   end
 
   {% if flag?(:linux) %}


### PR DESCRIPTION
Do not rely on a globally installed Crystal being available.