### PR TITLE
Specify pkgconfig name for libevent

### DIFF
--- a/src/crystal/system/unix/lib_event2.cr
+++ b/src/crystal/system/unix/lib_event2.cr
@@ -13,7 +13,11 @@ require "c/netdb"
   @[Link("event")]
 {% end %}
 {% if flag?(:preview_mt) %}
-  @[Link("event_pthreads")]
+  {% if compare_versions(Crystal::VERSION, "0.35.0-0") >= 0 %}
+    @[Link("event_pthreads", pkg_config: "libevent_pthreads")]
+  {% else %}
+    @[Link("event_pthreads")]
+  {% end %}
 {% end %}
 lib LibEvent2
   alias Int = LibC::Int

--- a/src/crystal/system/unix/lib_event2.cr
+++ b/src/crystal/system/unix/lib_event2.cr
@@ -7,6 +7,8 @@ require "c/netdb"
 {% if flag?(:openbsd) %}
   @[Link("event_core")]
   @[Link("event_extra")]
+{% elsif compare_versions(Crystal::VERSION, "0.35.0-0") >= 0 %}
+  @[Link("event", pkg_config: "libevent")]
 {% else %}
   @[Link("event")]
 {% end %}


### PR DESCRIPTION
After #8972 Crystal wouldn't find libevent in my macos homebrew environment anymore without this