### PR TITLE
Add various `String#delete_at` methods

### DIFF
--- a/spec/std/string_spec.cr
+++ b/spec/std/string_spec.cr
@@ -2724,4 +2724,23 @@ describe "String" do
       String.interpolation("a", 123, "b", 456, "cde").should eq("a123b456cde")
     end
   end
+
+  describe "delete_at" do
+    describe "char" do
+      it { "abcde".delete_at(0).should eq("bcde") }
+      it { "abcde".delete_at(1).should eq("acde") }
+      it { "abcde".delete_at(2).should eq("abde") }
+      it { "abcde".delete_at(4).should eq("abcd") }
+      it { "abcde".delete_at(-2).should eq("abce") }
+      it { expect_raises(IndexError) { "abcde".delete_at(5) } }
+      it { expect_raises(IndexError) { "abcde".delete_at(-6) } }
+
+      it { "二ノ国".delete_at(0).should eq("ノ国") }
+      it { "二ノ国".delete_at(1).should eq("二国") }
+      it { "二ノ国".delete_at(2).should eq("二ノ") }
+      it { "二ノ国".delete_at(-2).should eq("二国") }
+      it { expect_raises(IndexError) { "二ノ国".delete_at(3) } }
+      it { expect_raises(IndexError) { "二ノ国".delete_at(-4) } }
+    end
+  end
 end

--- a/spec/std/string_spec.cr
+++ b/spec/std/string_spec.cr
@@ -2742,5 +2742,35 @@ describe "String" do
       it { expect_raises(IndexError) { "二ノ国".delete_at(3) } }
       it { expect_raises(IndexError) { "二ノ国".delete_at(-4) } }
     end
+
+    describe "start, count" do
+      it { "abcdefg".delete_at(0, 2).should eq("cdefg") }
+      it { "abcdefg".delete_at(1, 2).should eq("adefg") }
+      it { "abcdefg".delete_at(3, 10).should eq("abc") }
+      it { "abcdefg".delete_at(-3, 2).should eq("abcdg") }
+      it { "abcdefg".delete_at(7, 10).should eq("abcdefg") }
+      it { expect_raises(IndexError) { "abcdefg".delete_at(8, 1) } }
+      it { expect_raises(IndexError) { "abcdefg".delete_at(-8, 1) } }
+
+      it "raises on negative count" do
+        expect_raises(ArgumentError, "Negative count: -1") {
+          "abcdefg".delete_at(1, -1)
+        }
+      end
+
+      it { "セキロ：シャドウズ ダイ トゥワイス".delete_at(4, 6).should eq("セキロ：ダイ トゥワイス") }
+      it { "セキロ：シャドウズ ダイ トゥワイス".delete_at(0, 4).should eq("シャドウズ ダイ トゥワイス") }
+      it { "セキロ：シャドウズ ダイ トゥワイス".delete_at(3, 20).should eq("セキロ") }
+      it { "セキロ：シャドウズ ダイ トゥワイス".delete_at(-14, 6).should eq("セキロ：ダイ トゥワイス") }
+      it { "セキロ：シャドウズ ダイ トゥワイス".delete_at(18, 3).should eq("セキロ：シャドウズ ダイ トゥワイス") }
+      it { expect_raises(IndexError) { "セキロ：シャドウズ ダイ トゥワイス".delete_at(19, 1) } }
+      it { expect_raises(IndexError) { "セキロ：シャドウズ ダイ トゥワイス".delete_at(-19, 1) } }
+
+      it "raises on negative count" do
+        expect_raises(ArgumentError, "Negative count: -1") {
+          "セキロ：シャドウズ ダイ トゥワイス".delete_at(1, -1)
+        }
+      end
+    end
   end
 end

--- a/spec/std/string_spec.cr
+++ b/spec/std/string_spec.cr
@@ -2772,5 +2772,21 @@ describe "String" do
         }
       end
     end
+
+    describe "range" do
+      it { "abcdefg".delete_at(0..1).should eq("cdefg") }
+      it { "abcdefg".delete_at(0...2).should eq("cdefg") }
+      it { "abcdefg".delete_at(1..3).should eq("aefg") }
+      it { "abcdefg".delete_at(3..10).should eq("abc") }
+      it { "abcdefg".delete_at(-3..-2).should eq("abcdg") }
+      it { "abcdefg".delete_at(3..).should eq("abc") }
+      it { "abcdefg".delete_at(..-3).should eq("fg") }
+      it { expect_raises(IndexError) { "abcdefg".delete_at(8..1) } }
+      it { expect_raises(IndexError) { "abcdefg".delete_at(-8..1) } }
+
+      it { "セキロ：シャドウズ ダイ トゥワイス".delete_at(4...10).should eq("セキロ：ダイ トゥワイス") }
+      it { expect_raises(IndexError) { "セキロ：シャドウズ ダイ トゥワイス".delete_at(19..1) } }
+      it { expect_raises(IndexError) { "セキロ：シャドウズ ダイ トゥワイス".delete_at(-19..1) } }
+    end
   end
 end

--- a/src/string.cr
+++ b/src/string.cr
@@ -1006,26 +1006,26 @@ class String
       return ""
     else
       if ascii_only?
-        byte_delete_at(index, count)
+        byte_delete_at(index, count, count)
       else
         unicode_delete_at(index, count)
       end
     end
   end
 
-  private def byte_delete_at(start, count)
-    new_bytesize = bytesize - count
+  private def byte_delete_at(start, count, byte_count)
+    new_bytesize = bytesize - byte_count
     String.new(new_bytesize) do |buffer|
       # Copy left part
       buffer.copy_from(to_unsafe, start)
 
       # Copy right part
       (buffer + start).copy_from(
-        to_unsafe + start + count,
-        bytesize - start - count,
+        to_unsafe + start + byte_count,
+        bytesize - start - byte_count,
       )
 
-      {new_bytesize, new_bytesize}
+      {new_bytesize, size - count}
     end
   end
 
@@ -1054,19 +1054,7 @@ class String
     end_pos ||= reader.pos
 
     byte_count = end_pos - start_pos
-    new_bytesize = bytesize - byte_count
-    String.new(new_bytesize) do |buffer|
-      # Copy left part
-      buffer.copy_from(to_unsafe, start_pos)
-
-      # Copy right part
-      (buffer + start_pos).copy_from(
-        to_unsafe + start_pos + byte_count,
-        bytesize - start_pos - byte_count,
-      )
-
-      {new_bytesize, size - count}
-    end
+    byte_delete_at(start_pos, count, byte_count)
   end
 
   # Returns a new string built from *count* bytes starting at *start* byte.

--- a/src/string.cr
+++ b/src/string.cr
@@ -909,7 +909,7 @@ class String
   # "abcde".delete_at(4) # => "abcd"
   # ```
   #
-  # A negative index counts from the end of the string:
+  # A negative *index* counts from the end of the string:
   #
   # ```
   # "abcde".delete_at(-2) # => "abce"

--- a/src/string.cr
+++ b/src/string.cr
@@ -900,7 +900,24 @@ class String
     end
   end
 
-  # Returns a new string that result from deleting the character
+  # Returns a new string that results from deleting characters
+  # at the given range.
+  #
+  # ```
+  # "abcdef".delete_at(1..3) # => "aef"
+  # ```
+  #
+  # Negative indices can be used to start counting from the end of the string:
+  #
+  # ```
+  # "abcdef".delete_at(-3..-2) # => "abcf"
+  # ```
+  #
+  # Raises `IndexError` if any index is outside the bounds of this string.
+  def delete_at(range : Range)
+    delete_at(*Indexable.range_to_index_and_count(range, size))
+  end
+
   # Returns a new string that results from deleting the character
   # at the given *index*.
   #

--- a/src/string.cr
+++ b/src/string.cr
@@ -901,6 +901,7 @@ class String
   end
 
   # Returns a new string that result from deleting the character
+  # Returns a new string that results from deleting the character
   # at the given *index*.
   #
   # ```

--- a/src/string.cr
+++ b/src/string.cr
@@ -900,6 +900,47 @@ class String
     end
   end
 
+  # Returns a new string that result from deleting the character
+  # at the given *index*.
+  #
+  # ```
+  # "abcde".delete_at(0) # => "bcde"
+  # "abcde".delete_at(2) # => "abde"
+  # "abcde".delete_at(4) # => "abcd"
+  # ```
+  #
+  # A negative index counts from the end of the string:
+  #
+  # ```
+  # "abcde".delete_at(-2) # => "abce"
+  # ```
+  #
+  # If *index* is outside the bounds of the string, `IndexError` is raised.
+  def delete_at(index : Int) : String
+    index += size if index < 0
+
+    byte_index = char_index_to_byte_index(index)
+    if byte_index && byte_index < @bytesize
+      char_bytesize = char_bytesize_at(byte_index)
+
+      new_bytesize = self.bytesize - char_bytesize
+      String.new(new_bytesize) do |buffer|
+        # Copy left part
+        buffer.copy_from(to_unsafe, byte_index)
+
+        # Copy right part
+        (buffer + byte_index).copy_from(
+          to_unsafe + byte_index + char_bytesize,
+          self.bytesize - byte_index - char_bytesize,
+        )
+
+        {new_bytesize, size - 1}
+      end
+    else
+      raise IndexError.new
+    end
+  end
+
   # Returns a new string built from *count* bytes starting at *start* byte.
   #
   # *start* can can be negative to start counting


### PR DESCRIPTION
For https://forum.crystal-lang.org/t/deleting-arbitrary-string-char/2188

The new methods are:
- `String#delete_at(index : Int)`
- `String#delete_at(range : Range)`
- `String#delete_at(index : Int, count : Int)`

The API is exactly the same as in `Array`. The difference is that the string isn't modified in place (of course), and a new string is returned without the portion that was deleted.

I think these methods are useful. One can do `"#{string[...]string[...]}" to archive something similar but `delete_at` is more expressive and it's more efficient.

In Ruby this is called `slice!`, but I think `delete_at` is a better name, and it also matches the API of Array.