### PR TITLE
Array: fix delete_at bug with negative start index

### DIFF
--- a/spec/std/array_spec.cr
+++ b/spec/std/array_spec.cr
@@ -594,6 +594,14 @@ describe "Array" do
       a.should eq([1, 2, 3, 6])
     end
 
+    it "deletes negative index with range, out of bounds" do
+      a = [1, 2, 3, 4, 5, 6]
+
+      expect_raises IndexError do
+        a.delete_at(-7, 2)
+      end
+    end
+
     it "deletes out of bounds" do
       expect_raises IndexError do
         [1].delete_at(2)

--- a/spec/std/array_spec.cr
+++ b/spec/std/array_spec.cr
@@ -588,6 +588,12 @@ describe "Array" do
       a.should eq([1, 3, 4])
     end
 
+    it "deletes negative index with range" do
+      a = [1, 2, 3, 4, 5, 6]
+      a.delete_at(-3, 2).should eq([4, 5])
+      a.should eq([1, 2, 3, 6])
+    end
+
     it "deletes out of bounds" do
       expect_raises IndexError do
         [1].delete_at(2)

--- a/src/array.cr
+++ b/src/array.cr
@@ -752,6 +752,9 @@ class Array(T)
   # ```
   def delete_at(index : Int, count : Int)
     index += size if index < 0
+    unless 0 <= index <= size
+      raise IndexError.new
+    end
 
     val = self[index, count]
     count = index + count <= size ? count : size - index

--- a/src/array.cr
+++ b/src/array.cr
@@ -751,6 +751,8 @@ class Array(T)
   # a.delete_at(99, 1) # raises IndexError
   # ```
   def delete_at(index : Int, count : Int)
+    index += size if index < 0
+
     val = self[index, count]
     count = index + count <= size ? count : size - index
     (@buffer + index).move_from(@buffer + index + count, size - index - count)


### PR DESCRIPTION
Before this PR:

```crystal
a = [1, 2, 3, 4, 5, 6]
a.delete_at(-3, 2) # => [4, 5]
a # => [3, 4, 5, 6]
```

After this PR:

```crystal
a = [1, 2, 3, 4, 5, 6]
p! a.delete_at(-3, 2) # => [4, 5]
p! a # => [1, 2, 3, 6]

```