### PR TITLE
Log: check severity before backend

### DIFF
--- a/src/log/log.cr
+++ b/src/log/log.cr
@@ -44,9 +44,10 @@ class Log
                              } %}
     # Logs a message if the logger's current severity is lower or equal to `{{severity}}`.
     def {{method.id}}(*, exception : Exception? = nil)
-      return unless backend = @backend
       severity = Severity.new({{severity}})
       return unless level <= severity
+
+      return unless backend = @backend
 
       dsl = Emitter.new(@source, severity, exception)
       result = yield dsl


### PR DESCRIPTION
If the log must be discarded, it's better to check the severity first. Checking the backend first is a memory read operation and that's not needed if the severity will not match.

Benchmark:

```crystal
require "benchmark"
require "log"

Benchmark.ips do |x|
  x.report("old") do
    Log.debug { "hello world!" }
  end
  x.report("new") do
    Log.debug_ { "hello world!" }
  end
end
```

(this is with new methods added with underscore with the new functionality)

Output:

```
old 279.02M (  3.58ns) (± 6.51%)  0.0B/op   1.09× slower
new 304.53M (  3.28ns) (± 5.29%)  0.0B/op        fastest
```

Doing first new and old later (just in case):

```
new 305.40M (  3.27ns) (± 5.38%)  0.0B/op        fastest
old 265.39M (  3.77ns) (± 5.05%)  0.0B/op   1.15× slower
```