### PR TITLE
Fix overflow checking for operations with mixed sign

### DIFF
--- a/spec/std/overflow_spec.cr
+++ b/spec/std/overflow_spec.cr
@@ -35,9 +35,15 @@ macro run_op_tests(t, u, op)
   end
 end
 
+{% if flag?(:darwin) %}
+  private OVERFLOW_TEST_TYPES = [Int8, UInt8, Int16, UInt16, Int32, UInt32, Int64, UInt64, Int128, UInt128]
+{% else %}
+  private OVERFLOW_TEST_TYPES = [Int8, UInt8, Int16, UInt16, Int32, UInt32, Int64, UInt64]
+{% end %}
+
 describe "overflow" do
-  {% for t in Int::Primitive.union_types %}
-    {% for u in Int::Primitive.union_types %}
+  {% for t in OVERFLOW_TEST_TYPES %}
+    {% for u in OVERFLOW_TEST_TYPES %}
       run_op_tests {{t}}, {{u}}, :+
       run_op_tests {{t}}, {{u}}, :-
       run_op_tests {{t}}, {{u}}, :*

--- a/spec/std/overflow_spec.cr
+++ b/spec/std/overflow_spec.cr
@@ -1,0 +1,46 @@
+require "big"
+require "spec"
+
+{% for i in Int::Signed.union_types %}
+  struct {{i}}
+    TEST_CASES = [MIN, MIN &+ 1, MIN &+ 2, -1, 0, 1, MAX &- 2, MAX &- 1, MAX] of {{i}}
+  end
+{% end %}
+
+{% for i in Int::Unsigned.union_types %}
+  struct {{i}}
+    TEST_CASES = [MIN, MIN &+ 1, MIN &+ 2, MAX &- 2, MAX &- 1, MAX] of {{i}}
+  end
+{% end %}
+
+macro run_op_tests(t, u, op)
+  it "overflow test #{{{t}}} #{{{op}}} #{{{u}}}" do
+    {{t}}::TEST_CASES.each do |lhs|
+      {{u}}::TEST_CASES.each do |rhs|
+        result = lhs.to_big_i {{op.id}} rhs.to_big_i
+        passes = {{t}}::MIN <= result <= {{t}}::MAX
+        begin
+          if passes
+            (lhs {{op.id}} rhs).should eq(lhs &{{op.id}} rhs)
+          else
+            expect_raises(OverflowError) { lhs {{op.id}} rhs }
+          end
+        rescue e : Spec::AssertionFailed
+          raise Spec::AssertionFailed.new("#{e.message}: #{lhs} #{{{op}}} #{rhs}", e.file, e.line)
+        rescue e : OverflowError
+          raise OverflowError.new("#{e.message}: #{lhs} #{{{op}}} #{rhs}")
+        end
+      end
+    end
+  end
+end
+
+describe "overflow" do
+  {% for t in Int::Primitive.union_types %}
+    {% for u in Int::Primitive.union_types %}
+      run_op_tests {{t}}, {{u}}, :+
+      run_op_tests {{t}}, {{u}}, :-
+      run_op_tests {{t}}, {{u}}, :*
+    {% end %}
+  {% end %}
+end

--- a/spec/std/overflow_spec.cr
+++ b/spec/std/overflow_spec.cr
@@ -1,3 +1,5 @@
+{% skip_file unless compare_versions(Crystal::VERSION, "0.35.0-0") > 0 %}
+
 require "big"
 require "spec"
 

--- a/src/compiler/crystal/program.cr
+++ b/src/compiler/crystal/program.cr
@@ -486,6 +486,30 @@ module Crystal
       end
     end
 
+    def int_type(signed, size)
+      if signed
+        case size
+        when  1 then int8
+        when  2 then int16
+        when  4 then int32
+        when  8 then int64
+        when 16 then int128
+        else
+          raise "BUG: Invalid int size: #{size}"
+        end
+      else
+        case size
+        when  1 then uint8
+        when  2 then uint16
+        when  4 then uint32
+        when  8 then uint64
+        when 16 then uint128
+        else
+          raise "BUG: Invalid int size: #{size}"
+        end
+      end
+    end
+
     # Returns the `IntegerType` that matches the given Int value
     def int?(int)
       case int

--- a/src/primitives.cr
+++ b/src/primitives.cr
@@ -413,36 +413,4 @@ end
       end
     end
   {% end %}
-
-  {% for sint in Int::Signed.union_types %}
-    {% for uint in Int::Unsigned.union_types %}
-      struct {{sint}}
-        def *(other : {{uint}})
-          if self >= 0
-            tmp = U{{sint}}.new!(self) * other
-            if tmp > U{{sint}}.new!({{sint}}::MAX)
-              __crystal_raise_overflow
-            end
-            {{sint}}.new!(tmp)
-          else
-            tmp = (~U{{sint}}.new!(self) &+ 1) * other
-            if tmp > U{{sint}}.new!({{sint}}::MIN)
-              __crystal_raise_overflow
-            end
-            ~{{sint}}.new!(tmp) &+ 1
-          end
-        end
-      end
-
-      struct {{uint}}
-        def *(other : {{sint}})
-          if self != 0 && other < 0
-            __crystal_raise_overflow
-          else
-            self * U{{sint}}.new!(other)
-          end
-        end
-      end
-    {% end %}
-  {% end %}
 {% end %}

--- a/src/primitives.cr
+++ b/src/primitives.cr
@@ -413,4 +413,36 @@ end
       end
     end
   {% end %}
+
+  {% for sint in Int::Signed.union_types %}
+    {% for uint in Int::Unsigned.union_types %}
+      struct {{sint}}
+        def *(other : {{uint}})
+          if self >= 0
+            tmp = U{{sint}}.new!(self) * other
+            if tmp > U{{sint}}.new!({{sint}}::MAX)
+              __crystal_raise_overflow
+            end
+            {{sint}}.new!(tmp)
+          else
+            tmp = (~U{{sint}}.new!(self) &+ 1) * other
+            if tmp > U{{sint}}.new!({{sint}}::MIN)
+              __crystal_raise_overflow
+            end
+            ~{{sint}}.new!(tmp) &+ 1
+          end
+        end
+      end
+
+      struct {{uint}}
+        def *(other : {{sint}})
+          if self != 0 && other < 0
+            __crystal_raise_overflow
+          else
+            self * U{{sint}}.new!(other)
+          end
+        end
+      end
+    {% end %}
+  {% end %}
 {% end %}


### PR DESCRIPTION
This is a rebuilt of arithmetic operations with overflow checking (`+`, `-`, `*`) to fix issues on cases with arguments of different sign.

I implemented the same approach used by clang (https://github.com/llvm/llvm-project/blob/796898172c48a475f27f038e587c35dbba9ab7a6/clang/lib/CodeGen/CGBuiltin.cpp#L3378-L3465) for the builtin operations (`__builtin_add_overflow`, etc.) and using the same workaround for multiplication of integers mixed sign. This workaround is needed to avoid internal i128 multiplication for i64 values and to avoid sigfaults for i128 multiplications.

This also adds specs to test operations between all integer types, using some extreme values from each type and contrasting results using BigInt.

Before implementing this approach I've been testing a port of [SafeInt](https://github.com/dcleblanc/SafeInt). It's a more exhaustive case by case approach that produces shorter binary code, but it requires more work and detailed testing. I assume shorter also means faster although I didn't perform any benchmark. I decided to go with this easier but correct code first.

Fixes #9277 