### PR TITLE
Semantic: turn `->var.foo` into just syntax sugar of `-> { var.foo }`

### DIFF
--- a/spec/compiler/normalize/proc_pointer_spec.cr
+++ b/spec/compiler/normalize/proc_pointer_spec.cr
@@ -1,0 +1,23 @@
+require "../../spec_helper"
+
+describe "Normalize: proc pointer" do
+  it "normalizes proc pointer to proc literal (->foo)" do
+    assert_expand %(->foo), %(-> do\n  foo\nend)
+  end
+
+  it "normalizes proc pointer to proc literal (->var.foo)" do
+    assert_expand_second %(var = 1; ->var.foo), %(-> do\n  var.foo\nend)
+  end
+
+  it "normalizes proc pointer to proc literal (->@ivar.foo)" do
+    assert_expand %(->@ivar.foo), %(-> do\n  @ivar.foo\nend)
+  end
+
+  it "normalizes proc pointer to proc literal (->Foo.foo)" do
+    assert_expand %(->Foo.foo), %(-> do\n  Foo.foo\nend)
+  end
+
+  it "normalizes proc pointer to proc literal (->foo(Type))" do
+    assert_expand %(->foo(Type)), %(->(__temp_1 : Type) do\n  foo(__temp_1)\nend)
+  end
+end

--- a/spec/compiler/semantic/closure_spec.cr
+++ b/spec/compiler/semantic/closure_spec.cr
@@ -259,7 +259,7 @@ describe "Semantic: closure" do
 
       Foo.new.foo
       ),
-      "can't send closure to C function (closured vars: self)"
+      "can't send closure to C function"
   end
 
   it "errors if sending closured proc pointer to C (2)" do
@@ -276,7 +276,7 @@ describe "Semantic: closure" do
       foo = Foo.new
       LibC.foo(->foo.bar)
       ),
-      "can't send closure to C function (closured vars: self)"
+      "can't send closure to C function (closured vars: foo)"
   end
 
   it "errors if sending closured proc pointer to C (3)" do

--- a/spec/compiler/semantic/proc_spec.cr
+++ b/spec/compiler/semantic/proc_spec.cr
@@ -955,48 +955,6 @@ describe "Semantic: proc" do
       )) { proc_of(nil_type) }
   end
 
-  it "errors when using macro as proc value (top-level) (#7465)" do
-    ex = assert_error %(
-      macro bar
-      end
-
-      ->bar
-      ),
-      "undefined method 'bar'"
-
-    ex.to_s.should contain "'bar' exists as a macro, but macros can't be used in proc pointers"
-  end
-
-  it "errors when using macro as proc value (top-level with obj) (#7465)" do
-    ex = assert_error %(
-      class Foo
-        macro bar
-        end
-      end
-
-      ->Foo.bar
-      ),
-      "undefined method 'bar' for Foo.class"
-
-    ex.to_s.should contain "'bar' exists as a macro, but macros can't be used in proc pointers"
-  end
-
-  it "errors when using macro as proc value (inside method) (#7465)" do
-    ex = assert_error %(
-      macro bar
-      end
-
-      def foo
-        ->bar
-      end
-
-      foo
-      ),
-      "undefined method 'bar'\n\n"
-
-    ex.to_s.should contain "'bar' exists as a macro, but macros can't be used in proc pointers"
-  end
-
   it "virtualizes proc type (#6789)" do
     assert_type(%(
       class Foo

--- a/src/compiler/crystal/codegen/codegen.cr
+++ b/src/compiler/crystal/codegen/codegen.cr
@@ -587,37 +587,6 @@ module Crystal
       fun_literal_name
     end
 
-    def visit(node : ProcPointer)
-      owner = node.call.target_def.owner
-
-      if obj = node.obj
-        accept obj
-
-        # If obj is a primitive like an integer we need to pass
-        # the variable as is (without loading it)
-        if obj.is_a?(Var) && obj.type.is_a?(PrimitiveType)
-          call_self = context.vars[obj.name].pointer
-        else
-          call_self = @last
-        end
-      elsif owner.passed_as_self?
-        call_self = llvm_self
-      end
-
-      last_fun = target_def_fun(node.call.target_def, owner)
-
-      set_current_debug_location(node) if @debug.line_numbers?
-      fun_ptr = bit_cast(last_fun, llvm_context.void_pointer)
-      if call_self && !owner.metaclass? && !owner.is_a?(LibType)
-        ctx_ptr = bit_cast(call_self, llvm_context.void_pointer)
-      else
-        ctx_ptr = llvm_context.void_pointer.null
-      end
-      @last = make_fun node.type, fun_ptr, ctx_ptr
-
-      false
-    end
-
     def visit(node : Expressions)
       old_needs_value = @needs_value
       @needs_value = false

--- a/src/compiler/crystal/semantic/ast.cr
+++ b/src/compiler/crystal/semantic/ast.cr
@@ -593,7 +593,8 @@ module Crystal
                    ArrayLiteral HashLiteral RegexLiteral RangeLiteral
                    Case StringInterpolation
                    MacroExpression MacroIf MacroFor MacroVerbatim MultiAssign
-                   SizeOf InstanceSizeOf OffsetOf Global Require Select) %}
+                   SizeOf InstanceSizeOf OffsetOf Global Require Select
+                   ProcPointer) %}
     class {{name.id}}
       include ExpandableNode
     end

--- a/src/compiler/crystal/semantic/bindings.cr
+++ b/src/compiler/crystal/semantic/bindings.cr
@@ -466,19 +466,6 @@ module Crystal
     end
   end
 
-  class ProcPointer
-    property! call : Call
-
-    def map_type(type)
-      return nil unless call.type?
-
-      arg_types = call.args.map &.type.virtual_type
-      arg_types.push call.type.virtual_type
-
-      call.type.program.proc_of(arg_types)
-    end
-  end
-
   class Generic
     property! instance_type : GenericType
     property scope : Type?

--- a/src/compiler/crystal/semantic/cleanup_transformer.cr
+++ b/src/compiler/crystal/semantic/cleanup_transformer.cr
@@ -508,35 +508,10 @@ module Crystal
 
             arg.raise message
           end
-        when ProcPointer
-          if arg.obj.try &.type?.try &.passed_as_self?
-            arg.raise "#{message} (closured vars: self)"
-          end
-
-          owner = arg.call.target_def.owner
-          if owner.passed_as_self?
-            arg.raise "#{message} (closured vars: self)"
-          end
         else
           # nothing to do
         end
       end
-    end
-
-    def transform(node : ProcPointer)
-      super
-
-      if call = node.call?
-        result = call.transform(self)
-
-        # If the transform didn't end up in a Call, it means the
-        # call will never be executed.
-        if result.is_a?(Call)
-          node.call = result
-        end
-      end
-
-      node
     end
 
     def transform(node : ProcLiteral)

--- a/src/compiler/crystal/semantic/fix_missing_types.cr
+++ b/src/compiler/crystal/semantic/fix_missing_types.cr
@@ -41,19 +41,6 @@ class Crystal::FixMissingTypes < Crystal::Visitor
     false
   end
 
-  def visit(node : ProcPointer)
-    node.call?.try &.accept self
-    false
-  end
-
-  def end_visit(node : ProcPointer)
-    if !node.type? && node.call?
-      arg_types = node.call.args.map &.type
-      arg_types.push @program.no_return
-      node.type = node.call.type = @program.proc_of(arg_types)
-    end
-  end
-
   def visit(node : ExpandableNode)
     node.expanded.try &.accept self
     false

--- a/src/compiler/crystal/semantic/literal_expander.cr
+++ b/src/compiler/crystal/semantic/literal_expander.cr
@@ -613,6 +613,19 @@ module Crystal
       end
     end
 
+    def expand(node : ProcPointer)
+      args = [] of Arg
+      arg_vars = [] of ASTNode
+      node.args.each do |arg|
+        arg_var = new_temp_var.at(arg)
+        arg_vars << arg_var
+        args << Arg.new(arg_var.name, restriction: arg).at(arg)
+      end
+      body = Call.new(node.obj, node.name, arg_vars).at(node)
+      a_def = Def.new("->", args, body).at(node)
+      ProcLiteral.new(a_def).at(node)
+    end
+
     private def case_when_comparison(temp_var, cond)
       return cond unless temp_var
 

--- a/src/compiler/crystal/semantic/top_level_visitor.cr
+++ b/src/compiler/crystal/semantic/top_level_visitor.cr
@@ -932,21 +932,6 @@ class Crystal::TopLevelVisitor < Crystal::SemanticVisitor
     !expand_macro(node, raise_on_missing_const: false, first_pass: true)
   end
 
-  def visit(node : ProcPointer)
-    # A proc pointer at the top-level might refer to a macro, so we check
-    # that here but we don't yet give an error: we let the real semantic visitor
-    # (MainVisitor) do that job to avoid duplicating code.
-    obj = node.obj
-
-    call = Call.new(obj, node.name).at(obj)
-    call.scope = current_type.metaclass
-    node.call = call
-
-    expand_macro(call, raise_on_missing_const: false, first_pass: true)
-
-    false
-  end
-
   def visit(node : Out)
     exp = node.exp
     if exp.is_a?(Var)


### PR DESCRIPTION
Now, `->var.foo` is just syntax sugar of `-> { var.foo }`.

It is PoC and an objection against @waj's [comment](https://github.com/crystal-lang/crystal/pull/9268#issuecomment-636045055).

/cc @hugopl