### PR TITLE
Allow executing OpAssign (+=, ||=, etc.) inside macros

### DIFF
--- a/spec/compiler/semantic/macro_spec.cr
+++ b/spec/compiler/semantic/macro_spec.cr
@@ -1463,4 +1463,18 @@ describe "Semantic: macro" do
     method = result.program.types["Foo"].lookup_first_def("bar", false).not_nil!
     method.location.not_nil!.expanded_location.not_nil!.line_number.should eq(10)
   end
+
+  it "executes OpAssign (#9356)" do
+    assert_type(%(
+      {% begin %}
+        {% a = nil %}
+        {% a ||= 1 %}
+        {% if a %}
+          1
+        {% else %}
+          'a'
+        {% end %}
+      {% end %}
+      )) { int32 }
+  end
 end

--- a/src/compiler/crystal/macros/interpreter.cr
+++ b/src/compiler/crystal/macros/interpreter.cr
@@ -318,6 +318,11 @@ module Crystal
       false
     end
 
+    def visit(node : OpAssign)
+      @program.normalize(node).accept(self)
+      false
+    end
+
     def visit(node : And)
       node.left.accept self
       if @last.truthy?


### PR DESCRIPTION
Fixes #9356