### PR TITLE
Fix http specs on mt

### DIFF
--- a/spec/support/fibers.cr
+++ b/spec/support/fibers.cr
@@ -1,11 +1,16 @@
-def wait_until_blocked(f : Fiber)
+def wait_until_blocked(f : Fiber, timeout = 5.seconds)
+  now = Time.monotonic
+
   until f.resumable?
     Fiber.yield
+    raise "fiber failed to block within #{timeout}" if (Time.monotonic - now) > timeout
   end
 end
 
-def wait_until_finished(f : Fiber)
+def wait_until_finished(f : Fiber, timeout = 5.seconds)
+  now = Time.monotonic
   until f.dead?
     Fiber.yield
+    raise "fiber failed to finish within #{timeout}" if (Time.monotonic - now) > timeout
   end
 end


### PR DESCRIPTION
I found that the recent failures in preview_mt are due to the http server is flagged as listening before the fiber is accepting connections.

While fixing that, I implemented a timeout in the fiber's helpers. It seems a good idea to abort on timeout instead of hanging the specs if something went wrong. 