### PR TITLE
Docs: fix syntax highlighting of unterminated string array literal

### DIFF
--- a/spec/compiler/crystal/tools/doc/highlighter_spec.cr
+++ b/spec/compiler/crystal/tools/doc/highlighter_spec.cr
@@ -76,6 +76,10 @@ describe "Crystal::Doc::Highlighter#highlight" do
   it_highlights "%w(foo  bar\n  baz)", %(<span class="s">%w(foo  bar\n  baz)</span>)
   it_highlights "%w<foo bar baz>", %(<span class="s">%w&lt;foo bar baz&gt;</span>)
   it_highlights "%i(foo bar baz)", %(<span class="s">%i(foo bar baz)</span>)
+  it_highlights "%w(foo", %{<span class="s">%w(foo</span>}
+  it_highlights "%w(foo ", %{<span class="s">%w(foo </span>}
+  it_highlights "%i(foo", %{<span class="s">%i(foo</span>}
+  it_highlights "%i(foo ", %{<span class="s">%i(foo </span>}
 
   it_highlights <<-CR, <<-HTML
     foo, bar = <<-FOO, <<-BAR

--- a/src/compiler/crystal/tools/doc/highlighter.cr
+++ b/src/compiler/crystal/tools/doc/highlighter.cr
@@ -132,18 +132,17 @@ module Crystal::Doc::Highlighter
       consume_space_or_newline(lexer, io)
       token = lexer.next_string_array_token
       case token.type
-      when :STRING
-        HTML.escape(token.raw, io)
       when :STRING_ARRAY_END
         HTML.escape(token.raw, io)
-        end_highlight_class io
         break
       when :EOF
-        raise "Unterminated symbol array literal"
+        break
       else
-        raise "Bug: shouldn't happen"
+        HTML.escape(token.raw, io)
       end
     end
+  ensure # This ensure is necessary to handle unterminated string array literal.
+    end_highlight_class io
   end
 
   def consume_space_or_newline(lexer, io)


### PR DESCRIPTION
Currently syntax highlighter raises an error against unterminated string array literal. However it is not consistent behavior with string literal.

I think syntax highlighter should work any inputs, even though they are broken.