### PR TITLE
Cleanup YAML/JSON Any#dig methods

### DIFF
--- a/src/crystal/datum.cr
+++ b/src/crystal/datum.cr
@@ -106,30 +106,27 @@ module Crystal
 
     # Traverses the depth of a structure and returns the value.
     # Returns `nil` if not found.
-    def dig?(index_or_key, *subkeys)
-      if value = self[index_or_key]?
-        value.dig?(*subkeys)
-      end
+    def dig?(index_or_key, *subkeys) : self?
+      self[index_or_key]?.try &.dig?(*subkeys)
     end
 
     # :nodoc:
-    def dig?(index_or_key)
+    def dig?(index_or_key) : self?
       case @raw
       when Hash, Array
         self[index_or_key]?
+      else
+        nil
       end
     end
 
     # Traverses the depth of a structure and returns the value, otherwise raises.
-    def dig(index_or_key, *subkeys)
-      if (value = self[index_or_key]) && value.responds_to?(:dig)
-        return value.dig(*subkeys)
-      end
-      raise "#{self.class} value not diggable for key: #{index_or_key.inspect}"
+    def dig(index_or_key, *subkeys) : self
+      self[index_or_key].dig(*subkeys)
     end
 
     # :nodoc:
-    def dig(index_or_key)
+    def dig(index_or_key) : self
       self[index_or_key]
     end
 

--- a/src/json/any.cr
+++ b/src/json/any.cr
@@ -119,28 +119,28 @@ struct JSON::Any
 
   # Traverses the depth of a structure and returns the value.
   # Returns `nil` if not found.
-  def dig?(key : String | Int, *subkeys) : JSON::Any?
-    self[key]?.try &.dig?(*subkeys)
+  def dig?(index_or_key : String | Int, *subkeys) : JSON::Any?
+    self[index_or_key]?.try &.dig?(*subkeys)
   end
 
   # :nodoc:
-  def dig?(key : String | Int) : JSON::Any?
+  def dig?(index_or_key : String | Int) : JSON::Any?
     case @raw
     when Hash, Array
-      self[key]?
+      self[index_or_key]?
     else
       nil
     end
   end
 
   # Traverses the depth of a structure and returns the value, otherwise raises.
-  def dig(key : String | Int, *subkeys) : JSON::Any
-    self[key].dig(*subkeys)
+  def dig(index_or_key : String | Int, *subkeys) : JSON::Any
+    self[index_or_key].dig(*subkeys)
   end
 
   # :nodoc:
-  def dig(key : String | Int) : JSON::Any
-    self[key]
+  def dig(index_or_key : String | Int) : JSON::Any
+    self[index_or_key]
   end
 
   # Checks that the underlying value is `Nil`, and returns `nil`.

--- a/src/json/any.cr
+++ b/src/json/any.cr
@@ -119,12 +119,12 @@ struct JSON::Any
 
   # Traverses the depth of a structure and returns the value.
   # Returns `nil` if not found.
-  def dig?(key : String | Int, *subkeys)
+  def dig?(key : String | Int, *subkeys) : JSON::Any?
     self[key]?.try &.dig?(*subkeys)
   end
 
   # :nodoc:
-  def dig?(key : String | Int)
+  def dig?(key : String | Int) : JSON::Any?
     case @raw
     when Hash, Array
       self[key]?
@@ -134,12 +134,12 @@ struct JSON::Any
   end
 
   # Traverses the depth of a structure and returns the value, otherwise raises.
-  def dig(key : String | Int, *subkeys)
+  def dig(key : String | Int, *subkeys) : JSON::Any
     self[key].dig(*subkeys)
   end
 
   # :nodoc:
-  def dig(key : String | Int)
+  def dig(key : String | Int) : JSON::Any
     self[key]
   end
 

--- a/src/json/any.cr
+++ b/src/json/any.cr
@@ -120,9 +120,7 @@ struct JSON::Any
   # Traverses the depth of a structure and returns the value.
   # Returns `nil` if not found.
   def dig?(key : String | Int, *subkeys)
-    if value = self[key]?
-      value.dig?(*subkeys)
-    end
+    self[key]?.try &.dig?(*subkeys)
   end
 
   # :nodoc:
@@ -137,10 +135,7 @@ struct JSON::Any
 
   # Traverses the depth of a structure and returns the value, otherwise raises.
   def dig(key : String | Int, *subkeys)
-    if (value = self[key]) && value.responds_to?(:dig)
-      return value.dig(*subkeys)
-    end
-    raise "JSON::Any value not diggable for key: #{key.inspect}"
+    self[key].dig(*subkeys)
   end
 
   # :nodoc:

--- a/src/yaml/any.cr
+++ b/src/yaml/any.cr
@@ -128,12 +128,12 @@ struct YAML::Any
 
   # Traverses the depth of a structure and returns the value.
   # Returns `nil` if not found.
-  def dig?(index_or_key, *subkeys)
+  def dig?(index_or_key, *subkeys) : YAML::Any?
     self[index_or_key]?.try &.dig?(*subkeys)
   end
 
   # :nodoc:
-  def dig?(index_or_key)
+  def dig?(index_or_key) : YAML::Any?
     case @raw
     when Hash, Array
       self[index_or_key]?
@@ -143,12 +143,12 @@ struct YAML::Any
   end
 
   # Traverses the depth of a structure and returns the value, otherwise raises.
-  def dig(index_or_key, *subkeys)
+  def dig(index_or_key, *subkeys) : YAML::Any
     self[index_or_key].dig(*subkeys)
   end
 
   # :nodoc:
-  def dig(index_or_key)
+  def dig(index_or_key) : YAML::Any
     self[index_or_key]
   end
 

--- a/src/yaml/any.cr
+++ b/src/yaml/any.cr
@@ -129,9 +129,7 @@ struct YAML::Any
   # Traverses the depth of a structure and returns the value.
   # Returns `nil` if not found.
   def dig?(index_or_key, *subkeys)
-    if value = self[index_or_key]?
-      value.dig?(*subkeys)
-    end
+    self[index_or_key]?.try &.dig?(*subkeys)
   end
 
   # :nodoc:
@@ -146,10 +144,7 @@ struct YAML::Any
 
   # Traverses the depth of a structure and returns the value, otherwise raises.
   def dig(index_or_key, *subkeys)
-    if (value = self[index_or_key]) && value.responds_to?(:dig)
-      return value.dig(*subkeys)
-    end
-    raise "YAML::Any value not diggable for key: #{index_or_key.inspect}"
+    self[index_or_key].dig(*subkeys)
   end
 
   # :nodoc:


### PR DESCRIPTION
Any#[] always return an Any, so it is always diggable.
This also means the exception is superfluous.

The logic inside the methods is also simplified, and return types added.