### PR TITLE
Compiler: fix incorrect type generated with `as?` when type is a union

### DIFF
--- a/spec/compiler/codegen/nilable_cast_spec.cr
+++ b/spec/compiler/codegen/nilable_cast_spec.cr
@@ -147,4 +147,26 @@ describe "Code gen: nilable cast" do
       x.try &.as?(Foo)
       ))
   end
+
+  it "casts union type to nilable type (#9342)" do
+    run(%(
+      struct Nil
+        def foo
+          0
+        end
+      end
+
+      class Gen(T)
+        def initialize(@value : Int32)
+        end
+
+        def foo
+          @value
+        end
+      end
+
+      a = Gen(String).new(10) || Gen(Int32).new(20)
+      a.as?(Gen).foo
+      )).to_i.should eq(10)
+  end
 end

--- a/src/compiler/crystal/program.cr
+++ b/src/compiler/crystal/program.cr
@@ -326,10 +326,18 @@ module Crystal
 
     # Returns the `Type` for `type | Nil`
     def nilable(type)
-      # Nil | Nil # => Nil
-      return self.nil if type == self.nil
-
-      union_of self.nil, type
+      case type
+      when self.nil
+        # Nil | Nil # => Nil
+        return self.nil
+      when UnionType
+        types = Array(Type).new(type.union_types.size + 1)
+        types.concat type.union_types
+        types << self.nil
+        Type.merge(types)
+      else
+        union_of self.nil, type
+      end
     end
 
     # Returns the `Type` for `type1 | type2`


### PR DESCRIPTION
Fixes #9342

Calling `Program#nilable` was wrong because it expects a non-union type. Then that generated an incorrect type. Theoretically it was right, if you print `typeof` you get a good value, but in practice the union type implementation was not the correct one, which made the codegen choose incorrect branches and eventually end up in segfault at runtime.

This is probably the reason `as?` wasn't working as expected in many cases. With this, `as?` becomes reliable (I tried to avoid it in the past because I didn't know why it would fail in some cases).