### PR TITLE
Ignore response body during WebSocket handshake

### DIFF
--- a/src/http/web_socket/protocol.cr
+++ b/src/http/web_socket/protocol.cr
@@ -298,7 +298,7 @@ class HTTP::WebSocket::Protocol
       handshake.to_io(socket)
       socket.flush
 
-      handshake_response = HTTP::Client::Response.from_io(socket)
+      handshake_response = HTTP::Client::Response.from_io(socket, ignore_body: true)
       unless handshake_response.status.switching_protocols?
         raise Socket::Error.new("Handshake got denied. Status code was #{handshake_response.status.code}.")
       end


### PR DESCRIPTION
HTTP response during WebSocket handler is not supposed to have a body. Still some servers might return malformed responses. That is the case of Slack that is returning this:

```
HTTP/1.1 101 Switching Protocols
upgrade: websocket
connection: upgrade
sec-websocket-accept: HYdFWxnjtSQ2eim/P3Qu/3Fud3s=
date: Wed, 03 Jun 2020 20:58:23 GMT
server: envoy
via: envoy-wss-iad-fg1t
transfer-encoding: chunked
```

That `transfer-encoding` header is making the parsing of the response to fail. This PR ensures the body is ignored.