### PR TITLE
Add missing specs for `->var.foo` semantics with assignments

### DIFF
--- a/spec/compiler/codegen/proc_spec.cr
+++ b/spec/compiler/codegen/proc_spec.cr
@@ -847,4 +847,83 @@ describe "Code gen: proc" do
       end
     ))
   end
+
+  it "saves receiver value of proc pointer `->var.foo`" do
+    run(%(
+      class Foo
+        def initialize(@foo : Int32)
+        end
+
+        def foo=(@foo)
+        end
+
+        def foo
+          @foo
+        end
+      end
+
+      var = Foo.new(1)
+      proc = ->var.foo
+      var = Foo.new(2)
+      proc.call
+      )).to_i.should eq(1)
+  end
+
+  it "saves receiver value of proc pointer `->@ivar.foo`" do
+    run(%(
+      class Foo
+        def initialize(@foo : Int32)
+        end
+
+        def foo=(@foo)
+        end
+
+        def foo
+          @foo
+        end
+      end
+
+      class Test
+        @ivar = Foo.new(1)
+
+        def test
+          proc = ->@ivar.foo
+          @ivar = Foo.new(2)
+          proc.call
+        end
+      end
+
+      Test.new.test
+      )).to_i.should eq(1)
+  end
+
+  it "saves receiver value of proc pointer `->@@cvar.foo`" do
+    run(%(
+      require "prelude"
+
+      class Foo
+        def initialize(@foo : Int32)
+        end
+
+        def foo=(@foo)
+        end
+
+        def foo
+          @foo
+        end
+      end
+
+      class Test
+        @@cvar = Foo.new(1)
+
+        def self.test
+          proc = ->@@cvar.foo
+          @@cvar = Foo.new(2)
+          proc.call
+        end
+      end
+
+      Test.test
+      )).to_i.should eq(1)
+  end
 end


### PR DESCRIPTION
It is one of the reason of our confusion. Don't you think so, @waj?