### PR TITLE
Add support for Path pattern to Dir.glob

### DIFF
--- a/spec/std/dir_spec.cr
+++ b/spec/std/dir_spec.cr
@@ -368,6 +368,24 @@ describe "Dir" do
         Dir.glob("#{datapath}/dir/dots/**/*", match_hidden: false).size.should eq 0
       end
     end
+
+    context "with path" do
+      expected = [
+        datapath("dir", "f1.txt"),
+        datapath("dir", "f2.txt"),
+        datapath("dir", "g2.txt"),
+      ]
+
+      it "posix path" do
+        Dir[Path.posix(datapath, "dir", "*.txt")].sort.should eq expected
+        Dir[[Path.posix(datapath, "dir", "*.txt")]].sort.should eq expected
+      end
+
+      it "windows path" do
+        Dir[Path.windows(datapath, "dir", "*.txt")].sort.should eq expected
+        Dir[[Path.windows(datapath, "dir", "*.txt")]].sort.should eq expected
+      end
+    end
   end
 
   describe "cd" do


### PR DESCRIPTION
With this change, `Dir.glob` can receive patterns as `Path`. I initially thought it might be best to only accept strings (hence this was not included in #9153). But it's actually useful to receive `Path` because glob patterns only support forward slashes as separators. If the method only accepts `String` but you have a `Path`, you would likely call `Dir.glob(path.to_s)`. But that won't work for windows paths with backslash separators. By passing the `Path` directly to `Dir.glob` it can make sure to convert the path to a posix path, so it uses the expected separators.