### PR TITLE
Make YAML specs robust against libyaml 0.2.5

### DIFF
--- a/spec/std/yaml/serializable_spec.cr
+++ b/spec/std/yaml/serializable_spec.cr
@@ -497,7 +497,7 @@ describe "YAML::Serializable" do
 
   it "emit_nulls option" do
     person = YAMLAttrPersonEmittingNullsByOptions.from_yaml("---\nname: John\n")
-    person.to_yaml.should match /---\nname: John\nage: ?\nvalue1: ?\n/
+    person.to_yaml.should match /\A---\nname: John\nage: ?\nvalue1: ?\n\z/
   end
 
   it "parses yaml with Time::Format converter" do
@@ -528,7 +528,7 @@ describe "YAML::Serializable" do
 
   it "outputs with converter when nilable when emit_null is true" do
     yaml = YAMLAttrWithNilableTimeEmittingNull.new
-    yaml.to_yaml.should match(/---\nvalue: ?\n/)
+    yaml.to_yaml.should match(/\A---\nvalue: ?\n\z/)
   end
 
   it "outputs YAML with properties key" do

--- a/spec/std/yaml/serializable_spec.cr
+++ b/spec/std/yaml/serializable_spec.cr
@@ -497,7 +497,7 @@ describe "YAML::Serializable" do
 
   it "emit_nulls option" do
     person = YAMLAttrPersonEmittingNullsByOptions.from_yaml("---\nname: John\n")
-    person.to_yaml.should eq "---\nname: John\nage: \nvalue1: \n"
+    person.to_yaml.should match /---\nname: John\nage: ?\nvalue1: ?\n/
   end
 
   it "parses yaml with Time::Format converter" do
@@ -528,7 +528,7 @@ describe "YAML::Serializable" do
 
   it "outputs with converter when nilable when emit_null is true" do
     yaml = YAMLAttrWithNilableTimeEmittingNull.new
-    yaml.to_yaml.should eq("---\nvalue: \n")
+    yaml.to_yaml.should match(/---\nvalue: ?\n/)
   end
 
   it "outputs YAML with properties key" do

--- a/spec/std/yaml/serialization_spec.cr
+++ b/spec/std/yaml/serialization_spec.cr
@@ -386,7 +386,7 @@ describe "YAML serialization" do
         :null  => nil,
       }
 
-      expected = /---\nhello: World\ninteger: 2\nfloat: 3.5\nhash:\n  a: 1\n  b: 2\narray:\n- 1\n- 2\n- 3\nnull: ?\n/
+      expected = /\A---\nhello: World\ninteger: 2\nfloat: 3.5\nhash:\n  a: 1\n  b: 2\narray:\n- 1\n- 2\n- 3\nnull: ?\n\z/
 
       data.to_yaml.should match(expected)
     end
@@ -409,7 +409,7 @@ describe "YAML serialization" do
       h[1] = 2
       h[h] = h
 
-      h.to_yaml.should match(/--- &1\n1: 2\n\*1 ?: \*1\n/)
+      h.to_yaml.should match(/\A--- &1\n1: 2\n\*1 ?: \*1\n\z/)
     end
   end
 end

--- a/spec/std/yaml/serialization_spec.cr
+++ b/spec/std/yaml/serialization_spec.cr
@@ -386,9 +386,9 @@ describe "YAML serialization" do
         :null  => nil,
       }
 
-      expected = "---\nhello: World\ninteger: 2\nfloat: 3.5\nhash:\n  a: 1\n  b: 2\narray:\n- 1\n- 2\n- 3\nnull: \n"
+      expected = /---\nhello: World\ninteger: 2\nfloat: 3.5\nhash:\n  a: 1\n  b: 2\narray:\n- 1\n- 2\n- 3\nnull: ?\n/
 
-      data.to_yaml.should eq(expected)
+      data.to_yaml.should match(expected)
     end
 
     it "writes to a stream" do
@@ -409,7 +409,7 @@ describe "YAML serialization" do
       h[1] = 2
       h[h] = h
 
-      h.to_yaml.should eq("--- &1\n1: 2\n*1: *1\n")
+      h.to_yaml.should match(/--- &1\n1: 2\n\*1 ?: \*1\n/)
     end
   end
 end


### PR DESCRIPTION
... or maybe 0.2.4 already, I didn't test. They're failing on Archlinux now for these extra spaces. Not sure why the homebrew build of the same version seems to be not doing that ...