### PR TITLE
Use `Process.quote` for `crystal env` output

### DIFF
--- a/src/compiler/crystal/command/env.cr
+++ b/src/compiler/crystal/command/env.cr
@@ -16,7 +16,7 @@ class Crystal::Command
 
     if ARGV.empty?
       vars.each do |key, value|
-        puts "#{key}=#{value.inspect}"
+        puts "#{key}=#{Process.quote(value)}"
       end
     else
       ARGV.each do |key|


### PR DESCRIPTION
Then we can use `eval "$(crystal env)"` in shell script safely.