### PR TITLE
Fix C ABI for AArch64

### DIFF
--- a/spec/compiler/codegen/c_abi/c_abi_spec.cr
+++ b/spec/compiler/codegen/c_abi/c_abi_spec.cr
@@ -55,7 +55,7 @@ describe "Code gen: C ABI" do
       ), &.to_i.should eq(3))
   end
 
-  it "passes struct bigger than128 bits (for real)" do
+  it "passes struct bigger than 128 bits (for real)" do
     test_c(
       %(
         struct s {

--- a/spec/std/llvm/aarch64_spec.cr
+++ b/spec/std/llvm/aarch64_spec.cr
@@ -140,7 +140,7 @@ class LLVM::ABI
           info = abi.abi_info(arg_types, return_type, true, ctx)
           info.arg_types.size.should eq(1)
 
-          info.arg_types[0].should eq(ArgType.indirect(str, Attribute::ByVal))
+          info.arg_types[0].should eq(ArgType.indirect(str, nil))
           info.return_type.should eq(ArgType.indirect(str, Attribute::StructRet))
         end
       end

--- a/src/llvm/abi/aarch64.cr
+++ b/src/llvm/abi/aarch64.cr
@@ -136,7 +136,7 @@ class LLVM::ABI::AArch64 < LLVM::ABI
                end
         ArgType.direct(aty, cast)
       else
-        ArgType.indirect(aty, LLVM::Attribute::ByVal)
+        ArgType.indirect(aty, nil)
       end
     end
   end


### PR DESCRIPTION
I don't claim to understand why this is more correct, I just compared the LLVM IR from one failing spec to what Clang would generate for the equivalent code.

It doesn't seem to break any other specs.

@ysbaddaden I think you did the initial port? If you care and maybe remember why you set it like this, that would be much appreciated :)