### PR TITLE
Logging dispatcher

### DIFF
--- a/spec/std/http/server/handlers/log_handler_spec.cr
+++ b/spec/std/http/server/handlers/log_handler_spec.cr
@@ -2,6 +2,7 @@ require "spec"
 require "log/spec"
 require "http/server/handler"
 require "../../../../support/io"
+require "../../../../support/retry"
 
 describe HTTP::LogHandler do
   it "logs" do
@@ -49,7 +50,9 @@ describe HTTP::LogHandler do
     handler.next = ->(ctx : HTTP::Server::Context) {}
     handler.call(context)
 
-    io.to_s.should match(%r(- - GET / HTTP/1.1 - 200 \(\d+(\.\d+)?[mµn]s\)$))
+    retry do
+      io.to_s.should match(%r(- - GET / HTTP/1.1 - 200 \(\d+(\.\d+)?[mµn]s\)$))
+    end
   end
 
   it "log failed request" do

--- a/spec/std/log/dispatch_spec.cr
+++ b/spec/std/log/dispatch_spec.cr
@@ -1,0 +1,57 @@
+require "spec"
+require "log"
+require "../../support/retry"
+
+class Log
+  describe Dispatcher do
+    it "create dispatcher from enum" do
+      Dispatcher.for(:direct).should eq(DirectDispatcher)
+      Dispatcher.for(:async).should be_a(AsyncDispatcher)
+      Dispatcher.for(:sync).should be_a(SyncDispatcher)
+    end
+  end
+
+  describe DirectDispatcher do
+    it "dispatches entry" do
+      backend = Log::MemoryBackend.new
+      backend.dispatcher = DirectDispatcher
+      backend.dispatch entry = Entry.new("source", :info, "message", Log::Metadata.empty, nil)
+      backend.entries.size.should eq(1)
+    end
+  end
+
+  describe SyncDispatcher do
+    it "dispatches entry" do
+      backend = Log::MemoryBackend.new
+      backend.dispatcher = SyncDispatcher.new
+      backend.dispatch entry = Entry.new("source", :info, "message", Log::Metadata.empty, nil)
+      backend.entries.size.should eq(1)
+    end
+  end
+
+  describe AsyncDispatcher do
+    it "dispatches entry" do
+      backend = Log::MemoryBackend.new
+      backend.dispatcher = AsyncDispatcher.new
+      backend.dispatch entry = Entry.new("source", :info, "message", Log::Metadata.empty, nil)
+      retry { backend.entries.size.should eq(1) }
+    end
+
+    it "wait for entries to flush before closing" do
+      backend = Log::MemoryBackend.new
+      backend.dispatcher = AsyncDispatcher.new
+      backend.dispatch entry = Entry.new("source", :info, "message", Log::Metadata.empty, nil)
+      backend.close
+      backend.entries.size.should eq(1)
+    end
+
+    it "can be closed twice" do
+      backend = Log::MemoryBackend.new
+      backend.dispatcher = AsyncDispatcher.new
+      backend.dispatch entry = Entry.new("source", :info, "message", Log::Metadata.empty, nil)
+      backend.close
+      backend.close
+      backend.entries.size.should eq(1)
+    end
+  end
+end

--- a/spec/std/log/io_backend_spec.cr
+++ b/spec/std/log/io_backend_spec.cr
@@ -14,6 +14,13 @@ private def io_logger(*, stdout : IO, config = nil, source : String = "")
 end
 
 describe Log::IOBackend do
+  pending_win32 "creates with defaults" do
+    backend = Log::IOBackend.new
+    backend.io.should eq(STDOUT)
+    backend.formatter.should eq(Log::ShortFormat)
+    backend.dispatcher.should be_a(Log::AsyncDispatcher)
+  end
+
   it "logs messages" do
     IO.pipe do |r, w|
       logger = io_logger(stdout: w)

--- a/spec/std/log/io_backend_spec.cr
+++ b/spec/std/log/io_backend_spec.cr
@@ -1,4 +1,4 @@
-require "spec"
+require "../spec_helper"
 require "log"
 
 private def s(value : Log::Severity)

--- a/spec/support/retry.cr
+++ b/spec/support/retry.cr
@@ -1,0 +1,17 @@
+def retry(n = 5)
+  exception = nil
+  n.times do |i|
+    yield
+  rescue ex
+    exception = ex
+    if i == 0
+      Fiber.yield
+    else
+      sleep 0.01 * (2**i)
+    end
+  else
+    return
+  end
+
+  raise exception.not_nil!
+end

--- a/src/log.cr
+++ b/src/log.cr
@@ -155,5 +155,6 @@ require "./log/setup"
 require "./log/log"
 require "./log/memory_backend"
 require "./log/io_backend"
+require "./log/dispatch"
 
 Log.setup

--- a/src/log/backend.cr
+++ b/src/log/backend.cr
@@ -2,10 +2,19 @@ require "crystal/datum"
 
 # Base class for all backends.
 abstract class Log::Backend
+  def initialize(@dispatcher : Dispatcher)
+  end
+
   # Writes the *entry* to this backend.
   abstract def write(entry : Entry)
 
   # Closes underlying resources used by this backend.
   def close
+    @dispatcher.close
+  end
+
+  # :nodoc:
+  def dispatch(entry : Entry)
+    @dispatcher.dispatch entry, self
   end
 end

--- a/src/log/backend.cr
+++ b/src/log/backend.cr
@@ -2,6 +2,12 @@ require "crystal/datum"
 
 # Base class for all backends.
 abstract class Log::Backend
+  property dispatcher : Dispatcher
+
+  def initialize(dispatch_mode : DispatchMode = :async)
+    @dispatcher = Dispatcher.for(dispatch_mode)
+  end
+
   def initialize(@dispatcher : Dispatcher)
   end
 

--- a/src/log/broadcast_backend.cr
+++ b/src/log/broadcast_backend.cr
@@ -12,7 +12,7 @@ class Log::BroadcastBackend < Log::Backend
   @backends = Hash(Log::Backend, Severity).new
 
   def initialize
-    super(DirectDispatcher)
+    super(:direct)
   end
 
   def append(backend : Log::Backend, level : Severity)

--- a/src/log/broadcast_backend.cr
+++ b/src/log/broadcast_backend.cr
@@ -26,6 +26,7 @@ class Log::BroadcastBackend < Log::Backend
   end
 
   def close
+    @backends.each_key &.close
   end
 
   # :nodoc:

--- a/src/log/broadcast_backend.cr
+++ b/src/log/broadcast_backend.cr
@@ -11,13 +11,17 @@ class Log::BroadcastBackend < Log::Backend
 
   @backends = Hash(Log::Backend, Severity).new
 
+  def initialize
+    super(DirectDispatcher)
+  end
+
   def append(backend : Log::Backend, level : Severity)
     @backends[backend] = level
   end
 
   def write(entry : Entry)
     @backends.each do |backend, level|
-      backend.write(entry) if (@level || level) <= entry.severity
+      backend.dispatch(entry) if (@level || level) <= entry.severity
     end
   end
 

--- a/src/log/builder.cr
+++ b/src/log/builder.cr
@@ -143,6 +143,11 @@ class Log::Builder
     end
   end
 
+  # :nodoc
+  def close
+    @bindings.each &.backend.close
+  end
+
   # :nodoc:
   def self.matches(source : String, pattern : String) : Bool
     return true if source == pattern

--- a/src/log/builder.cr
+++ b/src/log/builder.cr
@@ -143,7 +143,7 @@ class Log::Builder
     end
   end
 
-  # :nodoc
+  # :nodoc:
   def close
     @bindings.each &.backend.close
   end

--- a/src/log/dispatch.cr
+++ b/src/log/dispatch.cr
@@ -1,9 +1,15 @@
 class Log
+  # Base interface implemented by log entry dispatchers
+  #
+  # Dispatchers are in charge of sending log entries according
+  # to different strategies.
   module Dispatcher
     alias Spec = Dispatcher | DispatchMode
 
+    # Dispatch a log entry to the specified backend
     abstract def dispatch(entry : Entry, backend : Backend)
 
+    # Close the dispatcher, releasing resources
     def close
     end
 
@@ -26,6 +32,7 @@ class Log
     Direct
   end
 
+  # Stateless dispatcher that deliver log entries immediately
   module DirectDispatcher
     extend Dispatcher
 
@@ -34,6 +41,7 @@ class Log
     end
   end
 
+  # Deliver log entries asynchronously through a channels
   class AsyncDispatcher
     include Dispatcher
 
@@ -58,6 +66,8 @@ class Log
     end
   end
 
+  # Deliver log entries directly. It uses a mutex to guarantee
+  # one entry is delivered at a time.
   class SyncDispatcher
     include Dispatcher
 

--- a/src/log/dispatch.cr
+++ b/src/log/dispatch.cr
@@ -1,9 +1,29 @@
 class Log
   module Dispatcher
+    alias Spec = Dispatcher | DispatchMode
+
     abstract def dispatch(entry : Entry, backend : Backend)
 
     def close
     end
+
+    # :nodoc:
+    def self.for(mode : DispatchMode)
+      case mode
+      when .sync?
+        SyncDispatcher.new
+      when .async?
+        AsyncDispatcher.new
+      else
+        DirectDispatcher
+      end
+    end
+  end
+
+  enum DispatchMode
+    Sync
+    Async
+    Direct
   end
 
   module DirectDispatcher

--- a/src/log/dispatch.cr
+++ b/src/log/dispatch.cr
@@ -1,0 +1,54 @@
+class Log
+  module Dispatcher
+    abstract def dispatch(entry : Entry, backend : Backend)
+
+    def close
+    end
+  end
+
+  module DirectDispatcher
+    extend Dispatcher
+
+    def self.dispatch(entry : Entry, backend : Backend)
+      backend.write(entry)
+    end
+  end
+
+  class AsyncDispatcher
+    include Dispatcher
+
+    def initialize(buffer_size = 2048)
+      @channel = Channel({Entry, Backend}).new(buffer_size)
+      spawn write_logs
+    end
+
+    def dispatch(entry : Entry, backend : Backend)
+      @channel.send({entry, backend})
+    end
+
+    private def write_logs
+      while msg = @channel.receive?
+        entry, backend = msg
+        backend.write(entry)
+      end
+    end
+
+    def close
+      @channel.close
+    end
+  end
+
+  class SyncDispatcher
+    include Dispatcher
+
+    def initialize
+      @mutex = Mutex.new(:unchecked)
+    end
+
+    def dispatch(entry : Entry, backend : Backend)
+      @mutex.synchronize do
+        backend.write(entry)
+      end
+    end
+  end
+end

--- a/src/log/dispatch.cr
+++ b/src/log/dispatch.cr
@@ -16,11 +16,11 @@ class Log
     # :nodoc:
     def self.for(mode : DispatchMode)
       case mode
-      when .sync?
+      in .sync?
         SyncDispatcher.new
-      when .async?
+      in .async?
         AsyncDispatcher.new
-      else
+      in .direct?
         DirectDispatcher
       end
     end

--- a/src/log/io_backend.cr
+++ b/src/log/io_backend.cr
@@ -3,8 +3,8 @@ class Log::IOBackend < Log::Backend
   property io : IO
   property formatter : Formatter
 
-  def initialize(@io = STDOUT, *, @formatter : Formatter = ShortFormat)
-    super(AsyncDispatcher.new)
+  def initialize(@io = STDOUT, *, @formatter : Formatter = ShortFormat, dispatcher : Dispatcher::Spec? = nil)
+    super(dispatcher || DispatchMode::Async)
   end
 
   def write(entry : Entry)

--- a/src/log/io_backend.cr
+++ b/src/log/io_backend.cr
@@ -3,8 +3,14 @@ class Log::IOBackend < Log::Backend
   property io : IO
   property formatter : Formatter
 
+  {% if flag?(:win32) %}
+    private DEFAULT_DISPATCHER = DispatchMode::Sync
+  {% else %}
+    private DEFAULT_DISPATCHER = DispatchMode::Async
+  {% end %}
+
   def initialize(@io = STDOUT, *, @formatter : Formatter = ShortFormat, dispatcher : Dispatcher::Spec? = nil)
-    super(dispatcher || DispatchMode::Async)
+    super(dispatcher || DEFAULT_DISPATCHER)
   end
 
   def write(entry : Entry)

--- a/src/log/io_backend.cr
+++ b/src/log/io_backend.cr
@@ -4,15 +4,13 @@ class Log::IOBackend < Log::Backend
   property formatter : Formatter
 
   def initialize(@io = STDOUT, *, @formatter : Formatter = ShortFormat)
-    @mutex = Mutex.new(:unchecked)
+    super(AsyncDispatcher.new)
   end
 
   def write(entry : Entry)
-    @mutex.synchronize do
-      format(entry)
-      io.puts
-      io.flush
-    end
+    format(entry)
+    io.puts
+    io.flush
   end
 
   # Emits the *entry* to the given *io*.

--- a/src/log/io_backend.cr
+++ b/src/log/io_backend.cr
@@ -4,14 +4,15 @@ class Log::IOBackend < Log::Backend
   property formatter : Formatter
 
   {% if flag?(:win32) %}
-    private DEFAULT_DISPATCHER = DispatchMode::Sync
+    # TODO: this constructor must go away once channels are fixed in Windows
+    def initialize(@io = STDOUT, *, @formatter : Formatter = ShortFormat, dispatcher : Dispatcher::Spec = DispatchMode::Sync)
+      super(dispatcher)
+    end
   {% else %}
-    private DEFAULT_DISPATCHER = DispatchMode::Async
+    def initialize(@io = STDOUT, *, @formatter : Formatter = ShortFormat, dispatcher : Dispatcher::Spec = DispatchMode::Async)
+      super(dispatcher)
+    end
   {% end %}
-
-  def initialize(@io = STDOUT, *, @formatter : Formatter = ShortFormat, dispatcher : Dispatcher::Spec? = nil)
-    super(dispatcher || DEFAULT_DISPATCHER)
-  end
 
   def write(entry : Entry)
     format(entry)

--- a/src/log/log.cr
+++ b/src/log/log.cr
@@ -59,7 +59,7 @@ class Log
           dsl.emit(result.to_s)
         end
 
-      backend.write entry
+      backend.dispatch entry
     end
   {% end %}
 end

--- a/src/log/main.cr
+++ b/src/log/main.cr
@@ -46,6 +46,8 @@ class Log
 
   @@builder = Builder.new
 
+  at_exit { @@builder.close }
+
   # Returns the default `Log::Builder` used for `Log.for` calls.
   def self.builder
     @@builder

--- a/src/log/memory_backend.cr
+++ b/src/log/memory_backend.cr
@@ -3,6 +3,10 @@
 class Log::MemoryBackend < Log::Backend
   getter entries = Array(Log::Entry).new
 
+  def initialize
+    super(:direct)
+  end
+
   def write(entry : Log::Entry)
     @entries << entry
   end


### PR DESCRIPTION
Currently logs are written synchronously thus involving some overhead to the process. This PR adds a level of indirection (dispatchers) to inject strategies to deliver the log entries. Current implementation provides three alternatives: direct (just send the entry to the backend), sync (sends the entries acquiring a lock), and async (send the entries through a channel).

By default, `IOBackend` now uses the async dispatcher, and doing some performance tests on a simple HTTP server, logging every request to a file, I obtained the following results on my machine (using `wrk -c 10 -d 10 -t 10` several times):

Single thread

```
Without logs         119445.98
With logs             66579.82
With logs & this PR   82162.56
```

Multiple threads

```
Without logs         135044.66
With logs             99995.77
With logs & this PR  115875.06
```

The gain is noticeable, but I think it could be improved in the future (for example, if fibers had different priorities, or with a dispatcher that send the entries in batches).

The `Dispatcher` is just a module, allowing stateless implementations like `DirectDispatcher`. The API exposes also an enum to make it easier to customise backends like this:

```crystal
backend = IOBackend.new(file, dispatcher: :sync)
```

