### PR TITLE
Compiler: preserve all union types in `as?`

### DIFF
--- a/spec/compiler/semantic/nilable_cast_spec.cr
+++ b/spec/compiler/semantic/nilable_cast_spec.cr
@@ -47,4 +47,25 @@ describe "Semantic: nilable cast" do
       end
       )) { string }
   end
+
+  it "casts to module" do
+    assert_type(%(
+      module Moo
+      end
+
+      class Base
+      end
+
+      class Foo < Base
+        include Moo
+      end
+
+      class Bar < Base
+        include Moo
+      end
+
+      base = (Foo.new || Bar.new)
+      base.as?(Moo)
+      )) { union_of([types["Foo"], types["Bar"], nil_type] of Type) }
+  end
 end

--- a/src/compiler/crystal/program.cr
+++ b/src/compiler/crystal/program.cr
@@ -333,8 +333,8 @@ module Crystal
       when UnionType
         types = Array(Type).new(type.union_types.size + 1)
         types.concat type.union_types
-        types << self.nil
-        Type.merge(types)
+        types << self.nil unless types.includes? self.nil
+        union_of types
       else
         union_of self.nil, type
       end


### PR DESCRIPTION
Follow up to #9417