### PR TITLE
Specify pkgconfig name for libxml2

### DIFF
--- a/src/xml/libxml2.cr
+++ b/src/xml/libxml2.cr
@@ -4,7 +4,11 @@ require "./parser_options"
 require "./html_parser_options"
 require "./save_options"
 
-@[Link("xml2")]
+{% if compare_versions(Crystal::VERSION, "0.35.0-0") >= 0 %}
+  @[Link("xml2", pkg_config: "libxml-2.0")]
+{% else %}
+  @[Link("xml2")]
+{% end %}
 lib LibXML
   alias Int = LibC::Int
 


### PR DESCRIPTION
Similar to https://github.com/crystal-lang/crystal/pull/9426.  Seems to resolve https://forum.crystal-lang.org/t/static-linking-with-libxml2/1421?u=blacksmoke16.

I was able to build the program from that thread within alpine statically without any errors; resulting binary was statically linked according to `ldd` as well.

I built `oq` with the change `bin/crystal build --release --static --no-debug -o ./bin/oq src/oq_cli.cr` and ran specs against it; all green.

\cc @jhass 