### PR TITLE
Make specs pass in non-IPv6 environments

### DIFF
--- a/spec/std/http/client/client_spec.cr
+++ b/spec/std/http/client/client_spec.cr
@@ -142,7 +142,7 @@ module HTTP
       end
     end
 
-    it "sends the host header ipv6 with brackets" do
+    pending_ipv6 "sends the host header ipv6 with brackets" do
       server = HTTP::Server.new do |context|
         context.response.print context.request.headers["Host"]
       end
@@ -157,10 +157,10 @@ module HTTP
       server = HTTP::Server.new do |context|
         context.response.print context.request.headers["connection"]
       end
-      address = server.bind_unused_port "::1"
+      address = server.bind_unused_port "127.0.0.1"
 
       run_server(server) do
-        HTTP::Client.get("http://[::1]:#{address.port}/").body.should eq("close")
+        HTTP::Client.get("http://127.0.0.1:#{address.port}/").body.should eq("close")
       end
     end
 
@@ -168,10 +168,10 @@ module HTTP
       server = HTTP::Server.new do |context|
         context.response.print context.request.headers["connection"]
       end
-      address = server.bind_unused_port "::1"
+      address = server.bind_unused_port "127.0.0.1"
 
       run_server(server) do
-        HTTP::Client.get("http://[::1]:#{address.port}/") do |response|
+        HTTP::Client.get("http://127.0.0.1:#{address.port}/") do |response|
           response.body_io.gets_to_end
         end.should eq("close")
       end

--- a/spec/std/http/client/client_spec.cr
+++ b/spec/std/http/client/client_spec.cr
@@ -1,4 +1,5 @@
 require "../spec_helper"
+require "../../socket/spec_helper"
 require "openssl"
 require "http/client"
 require "http/server"

--- a/spec/std/oauth2/client_spec.cr
+++ b/spec/std/oauth2/client_spec.cr
@@ -48,10 +48,10 @@ describe OAuth2::Client do
           context.response.print response.to_json
         end
 
-        address = server.bind_unused_port "::1"
+        address = server.bind_unused_port "127.0.0.1"
 
         run_server(server) do
-          client = OAuth2::Client.new "[::1]", "client_id", "client_secret", port: address.port, scheme: "http"
+          client = OAuth2::Client.new "127.0.0.1", "client_id", "client_secret", port: address.port, scheme: "http"
 
           token = client.get_access_token_using_authorization_code(authorization_code: "SDFhw39fwfg23flSfpawbef")
           token.extra.not_nil!["body"].should eq %("redirect_uri=&grant_type=authorization_code&code=SDFhw39fwfg23flSfpawbef")
@@ -66,10 +66,10 @@ describe OAuth2::Client do
           context.response.print response.to_json
         end
 
-        address = server.bind_unused_port "::1"
+        address = server.bind_unused_port "127.0.0.1"
 
         run_server(server) do
-          client = OAuth2::Client.new "[::1]", "client_id", "client_secret", port: address.port, scheme: "http"
+          client = OAuth2::Client.new "127.0.0.1", "client_id", "client_secret", port: address.port, scheme: "http"
 
           token = client.get_access_token_using_resource_owner_credentials(username: "user123", password: "monkey", scope: "read_posts")
           token.extra.not_nil!["body"].should eq %("grant_type=password&username=user123&password=monkey&scope=read_posts")
@@ -84,10 +84,10 @@ describe OAuth2::Client do
           context.response.print response.to_json
         end
 
-        address = server.bind_unused_port "::1"
+        address = server.bind_unused_port "127.0.0.1"
 
         run_server(server) do
-          client = OAuth2::Client.new "[::1]", "client_id", "client_secret", port: address.port, scheme: "http"
+          client = OAuth2::Client.new "127.0.0.1", "client_id", "client_secret", port: address.port, scheme: "http"
 
           token = client.get_access_token_using_client_credentials(scope: "read_posts")
           token.extra.not_nil!["body"].should eq %("grant_type=client_credentials&scope=read_posts")
@@ -102,10 +102,10 @@ describe OAuth2::Client do
           context.response.print response.to_json
         end
 
-        address = server.bind_unused_port "::1"
+        address = server.bind_unused_port "127.0.0.1"
 
         run_server(server) do
-          client = OAuth2::Client.new "[::1]", "client_id", "client_secret", port: address.port, scheme: "http"
+          client = OAuth2::Client.new "127.0.0.1", "client_id", "client_secret", port: address.port, scheme: "http"
 
           token = client.get_access_token_using_refresh_token(scope: "read_posts", refresh_token: "some_refresh_token")
           token.extra.not_nil!["body"].should eq %("grant_type=refresh_token&refresh_token=some_refresh_token&scope=read_posts")
@@ -121,10 +121,10 @@ describe OAuth2::Client do
           context.response.print response.to_json
         end
 
-        address = server.bind_unused_port "::1"
+        address = server.bind_unused_port "127.0.0.1"
 
         run_server(server) do
-          client = OAuth2::Client.new "[::1]", "client_id", "client_secret", port: address.port, scheme: "http", auth_scheme: OAuth2::AuthScheme::RequestBody
+          client = OAuth2::Client.new "127.0.0.1", "client_id", "client_secret", port: address.port, scheme: "http", auth_scheme: OAuth2::AuthScheme::RequestBody
 
           token = client.get_access_token_using_authorization_code(authorization_code: "SDFhw39fwfg23flSfpawbef")
           token.extra.not_nil!["body"].should eq %("client_id=client_id&client_secret=client_secret&redirect_uri=&grant_type=authorization_code&code=SDFhw39fwfg23flSfpawbef")
@@ -139,10 +139,10 @@ describe OAuth2::Client do
           context.response.print response.to_json
         end
 
-        address = server.bind_unused_port "::1"
+        address = server.bind_unused_port "127.0.0.1"
 
         run_server(server) do
-          client = OAuth2::Client.new "[::1]", "client_id", "client_secret", port: address.port, scheme: "http", auth_scheme: OAuth2::AuthScheme::RequestBody
+          client = OAuth2::Client.new "127.0.0.1", "client_id", "client_secret", port: address.port, scheme: "http", auth_scheme: OAuth2::AuthScheme::RequestBody
 
           token = client.get_access_token_using_resource_owner_credentials(username: "user123", password: "monkey", scope: "read_posts")
           token.extra.not_nil!["body"].should eq %("client_id=client_id&client_secret=client_secret&grant_type=password&username=user123&password=monkey&scope=read_posts")
@@ -157,10 +157,10 @@ describe OAuth2::Client do
           context.response.print response.to_json
         end
 
-        address = server.bind_unused_port "::1"
+        address = server.bind_unused_port "127.0.0.1"
 
         run_server(server) do
-          client = OAuth2::Client.new "[::1]", "client_id", "client_secret", port: address.port, scheme: "http", auth_scheme: OAuth2::AuthScheme::RequestBody
+          client = OAuth2::Client.new "127.0.0.1", "client_id", "client_secret", port: address.port, scheme: "http", auth_scheme: OAuth2::AuthScheme::RequestBody
 
           token = client.get_access_token_using_client_credentials(scope: "read_posts")
           token.extra.not_nil!["body"].should eq %("client_id=client_id&client_secret=client_secret&grant_type=client_credentials&scope=read_posts")
@@ -175,10 +175,10 @@ describe OAuth2::Client do
           context.response.print response.to_json
         end
 
-        address = server.bind_unused_port "::1"
+        address = server.bind_unused_port "127.0.0.1"
 
         run_server(server) do
-          client = OAuth2::Client.new "[::1]", "client_id", "client_secret", port: address.port, scheme: "http", auth_scheme: OAuth2::AuthScheme::RequestBody
+          client = OAuth2::Client.new "127.0.0.1", "client_id", "client_secret", port: address.port, scheme: "http", auth_scheme: OAuth2::AuthScheme::RequestBody
 
           token = client.get_access_token_using_refresh_token(scope: "read_posts", refresh_token: "some_refresh_token")
           token.extra.not_nil!["body"].should eq %("client_id=client_id&client_secret=client_secret&grant_type=refresh_token&refresh_token=some_refresh_token&scope=read_posts")

--- a/spec/std/openssl/ssl/server_spec.cr
+++ b/spec/std/openssl/ssl/server_spec.cr
@@ -54,7 +54,7 @@ describe OpenSSL::SSL::Server do
 
   describe "#accept?" do
     it "accepts" do
-      tcp_server = TCPServer.new(0)
+      tcp_server = TCPServer.new("127.0.0.1", 0)
 
       server_context, client_context = ssl_context_pair
 
@@ -79,7 +79,7 @@ describe OpenSSL::SSL::Server do
 
   describe "#accept" do
     it "accepts and do handshake" do
-      tcp_server = TCPServer.new(0)
+      tcp_server = TCPServer.new("127.0.0.1", 0)
 
       server_context, client_context = ssl_context_pair
 
@@ -100,7 +100,7 @@ describe OpenSSL::SSL::Server do
     end
 
     it "doesn't to SSL handshake with start_immediately = false" do
-      tcp_server = TCPServer.new(0)
+      tcp_server = TCPServer.new("127.0.0.1", 0)
 
       server_context, client_context = ssl_context_pair
 
@@ -125,7 +125,7 @@ describe OpenSSL::SSL::Server do
   end
 
   it "detects SNI hostname" do
-    tcp_server = TCPServer.new(0)
+    tcp_server = TCPServer.new("127.0.0.1", 0)
     server_context, client_context = ssl_context_pair
 
     OpenSSL::SSL::Server.open tcp_server, server_context do |server|

--- a/spec/std/openssl/ssl/socket_spec.cr
+++ b/spec/std/openssl/ssl/socket_spec.cr
@@ -1,12 +1,13 @@
 require "spec"
 require "socket"
 require "../../spec_helper"
+require "../../socket/spec_helper"
 require "../../../support/ssl"
 
 describe OpenSSL::SSL::Socket do
   describe OpenSSL::SSL::Socket::Server do
     it "auto accept client by default" do
-      TCPServer.open(0) do |tcp_server|
+      TCPServer.open("127.0.0.1", 0) do |tcp_server|
         server_context, client_context = ssl_context_pair
 
         spawn do
@@ -23,7 +24,7 @@ describe OpenSSL::SSL::Socket do
     end
 
     it "doesn't accept client when specified" do
-      TCPServer.open(0) do |tcp_server|
+      TCPServer.open("127.0.0.1", 0) do |tcp_server|
         server_context, client_context = ssl_context_pair
 
         spawn do
@@ -42,7 +43,7 @@ describe OpenSSL::SSL::Socket do
   end
 
   it "returns the cipher that is currently in use" do
-    tcp_server = TCPServer.new(0)
+    tcp_server = TCPServer.new("127.0.0.1", 0)
     server_context, client_context = ssl_context_pair
 
     OpenSSL::SSL::Server.open(tcp_server, server_context) do |server|
@@ -58,7 +59,7 @@ describe OpenSSL::SSL::Socket do
   end
 
   it "returns the TLS version" do
-    tcp_server = TCPServer.new(0)
+    tcp_server = TCPServer.new("127.0.0.1", 0)
     server_context, client_context = ssl_context_pair
 
     OpenSSL::SSL::Server.open(tcp_server, server_context) do |server|
@@ -74,7 +75,7 @@ describe OpenSSL::SSL::Socket do
   end
 
   it "accepts clients that only write then close the connection" do
-    tcp_server = TCPServer.new(0)
+    tcp_server = TCPServer.new("127.0.0.1", 0)
     server_context, client_context = ssl_context_pair
     # in tls 1.3, if clients don't read anything and close the connection
     # the server still try and write to it a ticket, resulting in a "pipe failure"
@@ -96,7 +97,7 @@ describe OpenSSL::SSL::Socket do
   end
 
   it "closes connection to server that doesn't properly terminate SSL session" do
-    tcp_server = TCPServer.new(0)
+    tcp_server = TCPServer.new("127.0.0.1", 0)
     server_context, client_context = ssl_context_pair
     server_context.disable_session_resume_tickets # avoid Broken pipe
 
@@ -116,7 +117,7 @@ describe OpenSSL::SSL::Socket do
   end
 
   it "interprets graceful EOF of underlying socket as SSL termination" do
-    tcp_server = TCPServer.new(0)
+    tcp_server = TCPServer.new("127.0.0.1", 0)
     server_context, client_context = ssl_context_pair
     server_context.disable_session_resume_tickets # avoid Broken pipe
 

--- a/spec/std/socket/socket_spec.cr
+++ b/spec/std/socket/socket_spec.cr
@@ -44,10 +44,10 @@ describe Socket do
 
   it "sends messages" do
     port = unused_local_port
-    server = Socket.tcp(Socket::Family::INET6)
-    server.bind("::1", port)
+    server = Socket.tcp(Socket::Family::INET)
+    server.bind("127.0.0.1", port)
     server.listen
-    address = Socket::IPAddress.new("::1", port)
+    address = Socket::IPAddress.new("127.0.0.1", port)
     spawn do
       client = server.not_nil!.accept
       client.gets.should eq "foo"
@@ -55,7 +55,7 @@ describe Socket do
     ensure
       client.try &.close
     end
-    socket = Socket.tcp(Socket::Family::INET6)
+    socket = Socket.tcp(Socket::Family::INET)
     socket.connect(address)
     socket.puts "foo"
     socket.gets.should eq "bar"

--- a/spec/std/socket/spec_helper.cr
+++ b/spec/std/socket/spec_helper.cr
@@ -1,9 +1,24 @@
 require "spec"
 require "socket"
 
-def unused_local_port
-  TCPServer.open("::", 0) do |server|
-    server.local_address.port
+module SocketSpecHelper
+  @supports_ipv6 : Bool? = nil
+
+  def self.supports_ipv6?
+    return @@supports_ipv6 unless @@supports_ipv6.nil?
+
+    TCPServer.open("::1", 0) { return @@supports_ipv6 = true }
+    @@supports_ipv6 = false
+  rescue Socket::BindError
+    @@supports_ipv6 = false
+  end
+end
+
+def pending_ipv6(description = "assert", file = __FILE__, line = __LINE__, end_line = __END_LINE__, &block)
+  if SocketSpecHelper.supports_ipv6?
+    it(description, file: file, line: line, end_line: end_line, &block)
+  else
+    pending(description, file: file, line: line, end_line: end_line)
   end
 end
 
@@ -12,7 +27,17 @@ def each_ip_family(&block : Socket::Family, String, String ->)
     block.call Socket::Family::INET, "127.0.0.1", "0.0.0.0"
   end
 
-  describe "using IPv6" do
-    block.call Socket::Family::INET6, "::1", "::"
+  if SocketSpecHelper.supports_ipv6?
+    describe "using IPv6" do
+      block.call Socket::Family::INET6, "::1", "::"
+    end
+  else
+    pending "using IPv6"
+  end
+end
+
+def unused_local_port
+  TCPServer.open("::", 0) do |server|
+    server.local_address.port
   end
 end

--- a/spec/std/socket/spec_helper.cr
+++ b/spec/std/socket/spec_helper.cr
@@ -2,15 +2,11 @@ require "spec"
 require "socket"
 
 module SocketSpecHelper
-  @supports_ipv6 : Bool? = nil
-
-  def self.supports_ipv6?
-    return @@supports_ipv6 unless @@supports_ipv6.nil?
-
-    TCPServer.open("::1", 0) { return @@supports_ipv6 = true }
-    @@supports_ipv6 = false
+  class_getter?(supports_ipv6 : Bool) do
+    TCPServer.open("::1", 0) { return true }
+    false
   rescue Socket::BindError
-    @@supports_ipv6 = false
+    false
   end
 end
 


### PR DESCRIPTION
It's 2020 and sadly IPv6 is not yet truly ubiquitous. While supported by all relevant operating systems, enabled, even just locally, in all relevant execution environments, not so much. Prominently Docker does not enable it in its default configuration.