### PR TITLE
Allow executing MultiAssign inside macros

### DIFF
--- a/spec/compiler/semantic/macro_spec.cr
+++ b/spec/compiler/semantic/macro_spec.cr
@@ -1477,4 +1477,23 @@ describe "Semantic: macro" do
       {% end %}
       )) { int32 }
   end
+
+  it "executes MultiAssign" do
+    assert_type(%(
+      {% begin %}
+        {% a, b = 1, 2 %}
+        { {{a}}, {{b}} }
+      {% end %}
+      )) { tuple_of([int32, int32] of Type) }
+  end
+
+  it "executes MultiAssign with ArrayLiteral value" do
+    assert_type(%(
+      {% begin %}
+        {% xs = [1, 2] %}
+        {% a, b = xs %}
+        { {{a}}, {{b}} }
+      {% end %}
+      )) { tuple_of([int32, int32] of Type) }
+  end
 end

--- a/src/compiler/crystal/macros/interpreter.cr
+++ b/src/compiler/crystal/macros/interpreter.cr
@@ -323,6 +323,11 @@ module Crystal
       false
     end
 
+    def visit(node : MultiAssign)
+      @program.literal_expander.expand(node).accept(self)
+      false
+    end
+
     def visit(node : And)
       node.left.accept self
       if @last.truthy?


### PR DESCRIPTION
I think there is no reason why it is not supported today.