### PR TITLE
Use Set#add in Set#add documentation.

### DIFF
--- a/src/set.cr
+++ b/src/set.cr
@@ -90,7 +90,7 @@ struct Set(T)
   # ```
   # s = Set{1, 5}
   # s.includes? 8 # => false
-  # s << 8
+  # s.add(8)
   # s.includes? 8 # => true
   # ```
   def add(object : T)


### PR DESCRIPTION
The doc example was using `<<`, but `<<` is a alias for `add`, not the inverse.