### PR TITLE
Fixed broken output in option_parser

### DIFF
--- a/src/option_parser.cr
+++ b/src/option_parser.cr
@@ -274,7 +274,7 @@ class OptionParser
       io << banner
       io << '\n'
     end
-    @flags.join io, '\n'
+    @flags.join('\n', io)
   end
 
   private def append_flag(flag, description)


### PR DESCRIPTION
Separator should be the first argument to `#join` followed by io, not the other way around.