### PR TITLE
Channel#close returns boolean

### DIFF
--- a/spec/std/channel_spec.cr
+++ b/spec/std/channel_spec.cr
@@ -633,8 +633,9 @@ describe "unbuffered" do
   it "can be closed" do
     ch = Channel(Int32).new
     ch.closed?.should be_false
-    ch.close.should be_nil
+    ch.close.should be_true
     ch.closed?.should be_true
+    ch.close.should be_false
     expect_raises(Channel::ClosedError) { ch.receive }
   end
 

--- a/src/channel.cr
+++ b/src/channel.cr
@@ -183,11 +183,14 @@ class Channel(T)
   # Both awaiting and subsequent calls to `#send` will consider the channel closed.
   # All items successfully sent to the channel can be received, before `#receive` considers the channel closed.
   # Calling `#close` on a closed channel does not have any effect.
-  def close : Nil
+  #
+  # It returns `true` when the channel was successfuly closed, or `false` if it was already closed.
+  def close : Bool
     sender_list = Crystal::PointerLinkedList(Sender(T)).new
     receiver_list = Crystal::PointerLinkedList(Receiver(T)).new
 
     @lock.sync do
+      return false if @closed
       @closed = true
 
       @senders, sender_list = sender_list, @senders
@@ -196,6 +199,7 @@ class Channel(T)
 
     sender_list.each(&.value.close)
     receiver_list.each(&.value.close)
+    true
   end
 
   def closed?


### PR DESCRIPTION
This makes `Channel#close` to return `true` unless the channel was already closed. This makes easier to solve things like [this](https://github.com/crystal-lang/crystal/blob/65729d9d51a01bf9b8148a2a0f5113d129cb25b6/src/log/dispatch.cr#L68) in multithreaded code.