### PR TITLE
Revert Hash#each restriction added in #8887

### DIFF
--- a/spec/std/hash_spec.cr
+++ b/spec/std/hash_spec.cr
@@ -14,6 +14,14 @@ end
 
 private alias RecursiveType = String | Int32 | Array(RecursiveType) | Hash(Symbol, RecursiveType)
 
+private class HashWrapper(K, V)
+  include Enumerable({K, V})
+
+  @hash = {} of K => V
+
+  delegate each, to: @hash
+end
+
 describe "Hash" do
   describe "empty" do
     it "size should be zero" do
@@ -1224,5 +1232,9 @@ describe "Hash" do
       h = ({} of String => Int32).compare_by_identity
       h.clone.compare_by_identity?.should be_true
     end
+  end
+
+  it "can be wrapped" do
+    HashWrapper(Int32, Int32).new.to_a.should be_empty
   end
 end

--- a/src/hash.cr
+++ b/src/hash.cr
@@ -1255,7 +1255,7 @@ class Hash(K, V)
   # ```
   #
   # The enumeration follows the order the keys were inserted.
-  def each(& : Tuple(K, V) ->) : Nil
+  def each : Nil
     each_entry_with_index do |entry, i|
       yield({entry.key, entry.value})
     end


### PR DESCRIPTION
Workaround for #9450
Actual fix should deal with https://github.com/crystal-lang/crystal/issues/9450#issuecomment-641609520
Partially revert #8887