### PR TITLE
Parser: fix parsing of proc in hash `of` key type

### DIFF
--- a/spec/compiler/parser/parser_spec.cr
+++ b/spec/compiler/parser/parser_spec.cr
@@ -1066,6 +1066,7 @@ module Crystal
     assert_syntax_error "{a: 1, a: 2}", "duplicated key: a"
 
     it_parses "{} of Int => Double", HashLiteral.new([] of HashLiteral::Entry, of: HashLiteral::Entry.new("Int".path, "Double".path))
+    it_parses "{} of Int32 -> Int32 => Int32", HashLiteral.new([] of HashLiteral::Entry, of: HashLiteral::Entry.new(ProcNotation.new(["Int32".path] of ASTNode, "Int32".path), "Int32".path))
 
     it_parses "require \"foo\"", Require.new("foo")
     it_parses "require \"foo\"; [1]", [Require.new("foo"), ([1.int32] of ASTNode).array]

--- a/src/compiler/crystal/syntax/parser.cr
+++ b/src/compiler/crystal/syntax/parser.cr
@@ -5102,7 +5102,7 @@ module Crystal
         # They are conflicted with operators, so more look-ahead is needed.
         next_token_skip_space
         delimiter_or_type_suffix?
-      when :"->", :"|", :",", :NEWLINE, :EOF, :"=", :";", :"(", :")", :"[", :"]"
+      when :"->", :"|", :",", :"=>", :NEWLINE, :EOF, :"=", :";", :"(", :")", :"[", :"]"
         true
       else
         false


### PR DESCRIPTION
Fixed #9451

I forgot to add `=>` as delimiter. Sorry 🙇‍♂️ 