### PR TITLE
Use less strict cipher compatibility for OpenSSL client context

### DIFF
--- a/spec/std/openssl/ssl/context_spec.cr
+++ b/spec/std/openssl/ssl/context_spec.cr
@@ -100,7 +100,7 @@ describe OpenSSL::SSL::Context do
 
   pending "uses intermediate default ciphers" do
     # Can't be checked because `Context#ciphers` is not implemented.
-    OpenSSL::SSL::Context::Client.new.ciphers.should eq OpenSSL::SSL::Context::CIPHERS_INTERMEDIATE
+    OpenSSL::SSL::Context::Client.new.ciphers.should eq OpenSSL::SSL::Context::CIPHERS_OLD
     OpenSSL::SSL::Context::Server.new.ciphers.should eq OpenSSL::SSL::Context::CIPHERS_INTERMEDIATE
   end
 


### PR DESCRIPTION
Following the discussion in https://forum.crystal-lang.org/t/http-client-connection-reset-by-peer/2226 this separates the default cipher compatibility level for OpenSSL contexts:

* `OpenSSL::SSL::Context::Client` uses `OpenSSL::SSL::Context::CIPHERS_OLD`
* `OpenSSL::SSL::Context::Server` uses `OpenSSL::SSL::Context::CIPHERS_INTERMEDIATE`

This lets clients connect to servers which accept only weak ciphers, but a server only accepts relatively strong ciphers.