### PR TITLE
Fix OptionParser to handle sub-commands with hyphen

### DIFF
--- a/spec/std/option_parser_spec.cr
+++ b/spec/std/option_parser_spec.cr
@@ -572,6 +572,16 @@ describe "OptionParser" do
       USAGE
   end
 
+  it "handles subcommands with hyphen" do
+    subcommand = false
+    OptionParser.parse(%w(sub-command)) do |opts|
+      opts.banner = "Usage: foo"
+      opts.on("sub-command", "Subcommand description") { subcommand = true }
+    end
+
+    subcommand.should be_true
+  end
+
   it "stops when asked" do
     args = %w(--foo --stop --bar)
     foo = false

--- a/src/option_parser.cr
+++ b/src/option_parser.cr
@@ -203,16 +203,16 @@ class OptionParser
 
   private def parse_flag_definition(flag : String)
     case flag
-    when /--(\S+)\s+\[\S+\]/
+    when /\A--(\S+)\s+\[\S+\]\z/
       {"--#{$1}", FlagValue::Optional}
-    when /--(\S+)(\s+|\=)(\S+)?/
+    when /\A--(\S+)(\s+|\=)(\S+)?\z/
       {"--#{$1}", FlagValue::Required}
-    when /--\S+/
+    when /\A--\S+\z/
       # This can't be merged with `else` otherwise /-(.)/ matches
       {flag, FlagValue::None}
-    when /-(.)\s*\[\S+\]/
+    when /\A-(.)\s*\[\S+\]\z/
       {flag[0..1], FlagValue::Optional}
-    when /-(.)\s+\S+/, /-(.)\s+/, /-(.)\S+/
+    when /\A-(.)\s+\S+\z/, /\A-(.)\s+\z/, /\A-(.)\S+\z/
       {flag[0..1], FlagValue::Required}
     else
       # This happens for -f without argument


### PR DESCRIPTION
It was matching regexs anywhere on the string, but we want the regexs to
match the full string. In particular this behavior made that a flag
`sub-command` was interpeted as `su`, because it matches the `-(.)\S+`
regex.