### PR TITLE
Restore debug level information in specs to fix 32 bits builds

### DIFF
--- a/spec/std/exception/call_stack_spec.cr
+++ b/spec/std/exception/call_stack_spec.cr
@@ -10,7 +10,7 @@ describe "Backtrace" do
     current_dir += File::SEPARATOR unless current_dir.ends_with?(File::SEPARATOR)
     source_file = source_file.lchop(current_dir)
 
-    _, output, _ = compile_and_run_file(source_file, flags: %w(--debug))
+    _, output, _ = compile_and_run_file(source_file)
 
     # resolved file line:column
     output.should match(/#{source_file}:3:10 in 'callee1'/)
@@ -28,7 +28,7 @@ describe "Backtrace" do
   it "prints exception backtrace to stderr" do
     sample = datapath("exception_backtrace_sample")
 
-    _, output, error = compile_and_run_file(sample, flags: %w(--debug))
+    _, output, error = compile_and_run_file(sample)
 
     output.to_s.empty?.should be_true
     error.to_s.should contain("IndexError")
@@ -37,7 +37,7 @@ describe "Backtrace" do
   it "prints crash backtrace to stderr" do
     sample = datapath("crash_backtrace_sample")
 
-    _, output, error = compile_and_run_file(sample, flags: %w(--debug))
+    _, output, error = compile_and_run_file(sample)
 
     output.to_s.empty?.should be_true
     error.to_s.should contain("Invalid memory access")

--- a/spec/std/exception/call_stack_spec.cr
+++ b/spec/std/exception/call_stack_spec.cr
@@ -10,7 +10,7 @@ describe "Backtrace" do
     current_dir += File::SEPARATOR unless current_dir.ends_with?(File::SEPARATOR)
     source_file = source_file.lchop(current_dir)
 
-    _, output, _ = compile_and_run_file(source_file)
+    _, output, _ = compile_and_run_file(source_file, flags: %w(--debug))
 
     # resolved file line:column
     output.should match(/#{source_file}:3:10 in 'callee1'/)
@@ -28,7 +28,7 @@ describe "Backtrace" do
   it "prints exception backtrace to stderr" do
     sample = datapath("exception_backtrace_sample")
 
-    _, output, error = compile_and_run_file(sample)
+    _, output, error = compile_and_run_file(sample, flags: %w(--debug))
 
     output.to_s.empty?.should be_true
     error.to_s.should contain("IndexError")
@@ -37,7 +37,7 @@ describe "Backtrace" do
   it "prints crash backtrace to stderr" do
     sample = datapath("crash_backtrace_sample")
 
-    _, output, error = compile_and_run_file(sample)
+    _, output, error = compile_and_run_file(sample, flags: %w(--debug))
 
     output.to_s.empty?.should be_true
     error.to_s.should contain("Invalid memory access")

--- a/spec/std/spec/hooks_spec.cr
+++ b/spec/std/spec/hooks_spec.cr
@@ -3,7 +3,7 @@ require "./spec_helper"
 describe Spec do
   describe "hooks" do
     it "runs in correct order" do
-      compile_and_run_source(<<-CR)[1].lines[..-5].should eq <<-OUT.lines
+      compile_and_run_source(<<-CR, flags: %w(--no-debug))[1].lines[..-5].should eq <<-OUT.lines
         require "prelude"
         require "spec"
 

--- a/spec/std/spec_helper.cr
+++ b/spec/std/spec_helper.cr
@@ -94,7 +94,7 @@ def compile_source(source, flags = %w(--debug), file = __FILE__)
 end
 
 def compile_and_run_file(source_file, flags = %w(--debug), file = __FILE__)
-  compile_file(source_file, file: file) do |executable_file|
+  compile_file(source_file, flags, file: file) do |executable_file|
     output, error = IO::Memory.new, IO::Memory.new
     status = Process.run executable_file, output: output, error: error
 

--- a/spec/std/spec_helper.cr
+++ b/spec/std/spec_helper.cr
@@ -75,7 +75,7 @@ def spawn_and_check(before : Proc(_), file = __FILE__, line = __LINE__, &block :
   end
 end
 
-def compile_file(source_file, flags = %w(--debug), file = __FILE__)
+def compile_file(source_file, flags = %w(), file = __FILE__)
   with_temp_executable("executable_file", file: file) do |executable_file|
     Process.run("bin/crystal", ["build"] + flags + ["-o", executable_file, source_file])
     File.exists?(executable_file).should be_true
@@ -84,7 +84,7 @@ def compile_file(source_file, flags = %w(--debug), file = __FILE__)
   end
 end
 
-def compile_source(source, flags = %w(--debug), file = __FILE__)
+def compile_source(source, flags = %w(), file = __FILE__)
   with_tempfile("source_file", file: file) do |source_file|
     File.write(source_file, source)
     compile_file(source_file, flags, file: file) do |executable_file|
@@ -93,7 +93,7 @@ def compile_source(source, flags = %w(--debug), file = __FILE__)
   end
 end
 
-def compile_and_run_file(source_file, flags = %w(--debug), file = __FILE__)
+def compile_and_run_file(source_file, flags = %w(), file = __FILE__)
   compile_file(source_file, flags, file: file) do |executable_file|
     output, error = IO::Memory.new, IO::Memory.new
     status = Process.run executable_file, output: output, error: error
@@ -102,7 +102,7 @@ def compile_and_run_file(source_file, flags = %w(--debug), file = __FILE__)
   end
 end
 
-def compile_and_run_source(source, flags = %w(--debug), file = __FILE__)
+def compile_and_run_source(source, flags = %w(), file = __FILE__)
   with_tempfile("source_file", file: file) do |source_file|
     File.write(source_file, source)
     compile_and_run_file(source_file, flags, file: file)


### PR DESCRIPTION
Fixes #9463

Working job with the 0.35.0 https://circleci.com/gh/crystal-lang/crystal/48211

The underlying cause is that `LibC.stat` is not working on 32 bits environment when the path refers to mounted volume (like the docker mounted volume used to share the working copy in the ci, or vagrant shared file). This is seems to be an old issue cause it happens with older compilers also.

Due to the recent refactors #9294 some examples were now compiled with full debug information and that caused the issue. So this PR reverts the spec to use the flags as before. 

The call_stack_spec was using full debug information, but they also failed on 32 bits unless the default debug information level is used. Maybe this was due to the recent debug additions.