### PR TITLE
here is gone

### DIFF
--- a/src/compiler/crystal/syntax/lexer.cr
+++ b/src/compiler/crystal/syntax/lexer.cr
@@ -202,7 +202,6 @@ module Crystal
           when '='
             next_char :"<<="
           when '-'
-            here = IO::Memory.new(20)
             has_single_quote = false
             found_closing_single_quote = false
 


### PR DESCRIPTION
This commit only contains removing a line to assign to `here`.
In fact this `here` is unused in anywhere, then we should remove this.