### PR TITLE
Revert IO#write changes in 0.35.0 and let it return Nil

### DIFF
--- a/spec/std/http/chunked_content_spec.cr
+++ b/spec/std/http/chunked_content_spec.cr
@@ -34,7 +34,7 @@ describe HTTP::ChunkedContent do
     mem = IO::Memory.new("4\r\n123\n\r\n0\r\n\r\n")
     content = HTTP::ChunkedContent.new(mem)
 
-    content.skip(2).should eq(2)
+    content.skip(2)
     content.read_char.should eq('3')
 
     expect_raises(IO::EOFError) do

--- a/spec/std/http/request_spec.cr
+++ b/spec/std/http/request_spec.cr
@@ -6,8 +6,8 @@ private class EmptyIO < IO
     0
   end
 
-  def write(slice : Bytes) : Int64
-    slice.size.to_i64
+  def write(slice : Bytes) : UInt64
+    slice.size.to_u64
   end
 end
 

--- a/spec/std/http/request_spec.cr
+++ b/spec/std/http/request_spec.cr
@@ -6,8 +6,7 @@ private class EmptyIO < IO
     0
   end
 
-  def write(slice : Bytes) : UInt64
-    slice.size.to_u64
+  def write(slice : Bytes) : Nil
   end
 end
 

--- a/spec/std/http/server/response_spec.cr
+++ b/spec/std/http/server/response_spec.cr
@@ -12,11 +12,10 @@ private class ReverseResponseOutput < IO
   def initialize(@output : IO)
   end
 
-  def write(slice : Bytes) : UInt64
+  def write(slice : Bytes) : Nil
     slice.reverse_each do |byte|
       @output.write_byte(byte)
     end
-    slice.size.to_u64
   end
 
   def read(slice : Bytes)

--- a/spec/std/http/server/response_spec.cr
+++ b/spec/std/http/server/response_spec.cr
@@ -12,11 +12,11 @@ private class ReverseResponseOutput < IO
   def initialize(@output : IO)
   end
 
-  def write(slice : Bytes) : Int64
+  def write(slice : Bytes) : UInt64
     slice.reverse_each do |byte|
       @output.write_byte(byte)
     end
-    slice.size.to_i64
+    slice.size.to_u64
   end
 
   def read(slice : Bytes)

--- a/spec/std/io/buffered_spec.cr
+++ b/spec/std/io/buffered_spec.cr
@@ -429,14 +429,14 @@ describe "IO::Buffered" do
   it "skips" do
     str = IO::Memory.new("123456789")
     io = BufferedWrapper.new(str)
-    io.skip(3).should eq(3)
+    io.skip(3)
     io.read_char.should eq('4')
   end
 
   it "skips big" do
     str = IO::Memory.new(("a" * 10_000) + "b")
     io = BufferedWrapper.new(str)
-    io.skip(10_000).should eq(10_000)
+    io.skip(10_000)
     io.read_char.should eq('b')
   end
 

--- a/spec/std/io/io_spec.cr
+++ b/spec/std/io/io_spec.cr
@@ -46,7 +46,7 @@ private class SimpleIOMemory < IO
     count
   end
 
-  def write(slice : Bytes) : Int64
+  def write(slice : Bytes) : UInt64
     count = slice.size
     new_bytesize = bytesize + count
     if new_bytesize > @capacity
@@ -56,7 +56,7 @@ private class SimpleIOMemory < IO
     slice.copy_to(@buffer + @bytesize, count)
     @bytesize += count
 
-    slice.size.to_i64
+    slice.size.to_u64
   end
 
   def to_slice
@@ -99,8 +99,8 @@ private class OneByOneIO < IO
     1
   end
 
-  def write(slice : Bytes) : Int64
-    slice.size.to_i64
+  def write(slice : Bytes) : UInt64
+    slice.size.to_u64
   end
 end
 

--- a/spec/std/io/io_spec.cr
+++ b/spec/std/io/io_spec.cr
@@ -46,7 +46,7 @@ private class SimpleIOMemory < IO
     count
   end
 
-  def write(slice : Bytes) : UInt64
+  def write(slice : Bytes) : Nil
     count = slice.size
     new_bytesize = bytesize + count
     if new_bytesize > @capacity
@@ -56,7 +56,7 @@ private class SimpleIOMemory < IO
     slice.copy_to(@buffer + @bytesize, count)
     @bytesize += count
 
-    slice.size.to_u64
+    nil
   end
 
   def to_slice
@@ -99,8 +99,7 @@ private class OneByOneIO < IO
     1
   end
 
-  def write(slice : Bytes) : UInt64
-    slice.size.to_u64
+  def write(slice : Bytes) : Nil
   end
 end
 
@@ -508,7 +507,7 @@ describe IO do
     it "skips a few bytes" do
       io = SimpleIOMemory.new
       io << "hello world"
-      io.skip(6).should eq(6)
+      io.skip(6)
       io.gets_to_end.should eq("world")
     end
 
@@ -523,14 +522,14 @@ describe IO do
     it "skips more than 4096 bytes" do
       io = SimpleIOMemory.new
       io << "a" * 4100
-      io.skip(4099).should eq(4099)
+      io.skip(4099)
       io.gets_to_end.should eq("a")
     end
 
     it "skips to end" do
       io = SimpleIOMemory.new
       io << "hello"
-      io.skip_to_end.should eq(5)
+      io.skip_to_end
       io.read_byte.should be_nil
     end
 
@@ -542,34 +541,6 @@ describe IO do
         expect_raises(IO::Error, "File not open for writing") do
           r << "hello"
         end
-      end
-    end
-
-    describe "counts written bytes" do
-      it "directly" do
-        with_tempfile("create.txt") do |path|
-          File.open(path, "w") do |io|
-            io.write("hello world".to_slice).should eq(11)
-            io.write_utf8("mañana".to_slice).should eq(7)
-          end
-        end
-      end
-
-      pending_win32 "with encoding" do
-        with_tempfile("create.txt") do |path|
-          File.open(path, "w", File::DEFAULT_CREATE_PERMISSIONS, "CP1252") do |io|
-            # In UTF-8 ñ will use 2 bytes
-            io.write_utf8("mañana".to_slice).should eq(6)
-          end
-        end
-      end
-
-      it "with byte format" do
-        io = SimpleIOMemory.new
-
-        io.write_bytes(1u64).should eq(8)
-        io.write_bytes(1u32).should eq(4)
-        io.write_bytes(1u8).should eq(1)
       end
     end
   end

--- a/spec/std/io/io_spec.cr
+++ b/spec/std/io/io_spec.cr
@@ -55,8 +55,6 @@ private class SimpleIOMemory < IO
 
     slice.copy_to(@buffer + @bytesize, count)
     @bytesize += count
-
-    nil
   end
 
   def to_slice

--- a/spec/std/io/memory_spec.cr
+++ b/spec/std/io/memory_spec.cr
@@ -353,11 +353,11 @@ describe IO::Memory do
 
   it "skips" do
     io = IO::Memory.new("hello")
-    io.skip(2).should eq(2)
+    io.skip(2)
     io.gets_to_end.should eq("llo")
 
     io.rewind
-    io.skip(5).should eq(5)
+    io.skip(5)
     io.gets_to_end.should eq("")
 
     io.rewind
@@ -369,7 +369,7 @@ describe IO::Memory do
 
   it "skips_to_end" do
     io = IO::Memory.new("hello")
-    io.skip_to_end.should eq(5)
+    io.skip_to_end
     io.gets_to_end.should eq("")
   end
 

--- a/spec/std/io/sized_spec.cr
+++ b/spec/std/io/sized_spec.cr
@@ -5,8 +5,8 @@ private class NoPeekIO < IO
     0
   end
 
-  def write(bytes : Bytes) : Int64
-    0i64
+  def write(bytes : Bytes) : UInt64
+    0u64
   end
 
   def peek

--- a/spec/std/io/sized_spec.cr
+++ b/spec/std/io/sized_spec.cr
@@ -5,8 +5,7 @@ private class NoPeekIO < IO
     0
   end
 
-  def write(bytes : Bytes) : UInt64
-    0u64
+  def write(bytes : Bytes) : Nil
   end
 
   def peek
@@ -139,7 +138,7 @@ describe "IO::Sized" do
   it "skips" do
     io = IO::Memory.new "123456789"
     sized = IO::Sized.new(io, read_size: 6)
-    sized.skip(3).should eq(3)
+    sized.skip(3)
     sized.read_char.should eq('4')
 
     expect_raises(IO::EOFError) do

--- a/spec/std/io/stapled_spec.cr
+++ b/spec/std/io/stapled_spec.cr
@@ -76,6 +76,22 @@ describe IO::Stapled do
     io.peek.should eq Bytes.empty
   end
 
+  it "#skip delegates to reader" do
+    reader = IO::Memory.new "cletus"
+    io = IO::Stapled.new reader, IO::Memory.new
+    io.peek.should eq "cletus".to_slice
+    io.skip(4)
+    io.peek.should eq "us".to_slice
+  end
+
+  it "#skip_to_end delegates to reader" do
+    reader = IO::Memory.new "cletus"
+    io = IO::Stapled.new reader, IO::Memory.new
+    io.peek.should eq "cletus".to_slice
+    io.skip_to_end
+    io.peek.should eq Bytes.empty
+  end
+
   describe ".pipe" do
     it "creates a bidirectional pipe" do
       a, b = IO::Stapled.pipe

--- a/spec/std/io/stapled_spec.cr
+++ b/spec/std/io/stapled_spec.cr
@@ -76,22 +76,6 @@ describe IO::Stapled do
     io.peek.should eq Bytes.empty
   end
 
-  it "#skip delegates to reader" do
-    reader = IO::Memory.new "cletus"
-    io = IO::Stapled.new reader, IO::Memory.new
-    io.peek.should eq "cletus".to_slice
-    io.skip(4).should eq(4)
-    io.peek.should eq "us".to_slice
-  end
-
-  it "#skip_to_end delegates to reader" do
-    reader = IO::Memory.new "cletus"
-    io = IO::Stapled.new reader, IO::Memory.new
-    io.peek.should eq "cletus".to_slice
-    io.skip_to_end.should eq(6)
-    io.peek.should eq Bytes.empty
-  end
-
   describe ".pipe" do
     it "creates a bidirectional pipe" do
       a, b = IO::Stapled.pipe

--- a/spec/support/io.cr
+++ b/spec/support/io.cr
@@ -8,10 +8,9 @@ class RaiseIOError < IO
     raise IO::Error.new("...")
   end
 
-  def write(slice : Bytes) : UInt64
+  def write(slice : Bytes) : Nil
     @writes += 1
     raise IO::Error.new("...") if @raise_on_write
-    slice.size.to_u64
   end
 
   def flush

--- a/spec/support/io.cr
+++ b/spec/support/io.cr
@@ -8,10 +8,10 @@ class RaiseIOError < IO
     raise IO::Error.new("...")
   end
 
-  def write(slice : Bytes) : Int64
+  def write(slice : Bytes) : UInt64
     @writes += 1
     raise IO::Error.new("...") if @raise_on_write
-    slice.size.to_i64
+    slice.size.to_u64
   end
 
   def flush

--- a/src/compress/deflate/writer.cr
+++ b/src/compress/deflate/writer.cr
@@ -43,16 +43,16 @@ class Compress::Deflate::Writer < IO
   end
 
   # See `IO#write`.
-  def write(slice : Bytes) : Int64
+  def write(slice : Bytes) : UInt64
     check_open
 
-    return 0i64 if slice.empty?
+    return 0u64 if slice.empty?
 
     @stream.avail_in = slice.size
     @stream.next_in = slice
     consume_output LibZ::Flush::NO_FLUSH
 
-    slice.size.to_i64
+    slice.size.to_u64
   end
 
   # See `IO#flush`.

--- a/src/compress/deflate/writer.cr
+++ b/src/compress/deflate/writer.cr
@@ -43,16 +43,14 @@ class Compress::Deflate::Writer < IO
   end
 
   # See `IO#write`.
-  def write(slice : Bytes) : UInt64
+  def write(slice : Bytes) : Nil
     check_open
 
-    return 0u64 if slice.empty?
+    return if slice.empty?
 
     @stream.avail_in = slice.size
     @stream.next_in = slice
     consume_output LibZ::Flush::NO_FLUSH
-
-    slice.size.to_u64
   end
 
   # See `IO#flush`.

--- a/src/compress/gzip/writer.cr
+++ b/src/compress/gzip/writer.cr
@@ -68,10 +68,10 @@ class Compress::Gzip::Writer < IO
   end
 
   # See `IO#write`.
-  def write(slice : Bytes) : UInt64
+  def write(slice : Bytes) : Nil
     check_open
 
-    return 0u64 if slice.empty?
+    return if slice.empty?
 
     flate_io = write_header
     flate_io.write(slice)
@@ -82,8 +82,6 @@ class Compress::Gzip::Writer < IO
     # Using wrapping addition here because isize is only 32 bits wide but
     # uncompressed data size can be bigger.
     @isize &+= slice.size
-
-    slice.size.to_u64
   end
 
   # Flushes data, forcing writing the gzip header if no

--- a/src/compress/gzip/writer.cr
+++ b/src/compress/gzip/writer.cr
@@ -68,10 +68,10 @@ class Compress::Gzip::Writer < IO
   end
 
   # See `IO#write`.
-  def write(slice : Bytes) : Int64
+  def write(slice : Bytes) : UInt64
     check_open
 
-    return 0i64 if slice.empty?
+    return 0u64 if slice.empty?
 
     flate_io = write_header
     flate_io.write(slice)
@@ -83,7 +83,7 @@ class Compress::Gzip::Writer < IO
     # uncompressed data size can be bigger.
     @isize &+= slice.size
 
-    slice.size.to_i64
+    slice.size.to_u64
   end
 
   # Flushes data, forcing writing the gzip header if no

--- a/src/compress/zip/checksum_writer.cr
+++ b/src/compress/zip/checksum_writer.cr
@@ -13,8 +13,8 @@ module Compress::Zip
       raise IO::Error.new "Can't read from Zip::Writer entry"
     end
 
-    def write(slice : Bytes) : Int64
-      return 0i64 if slice.empty?
+    def write(slice : Bytes) : UInt64
+      return 0u64 if slice.empty?
 
       @count += slice.size
       @crc32 = Digest::CRC32.update(slice, @crc32) if @compute_crc32

--- a/src/compress/zip/checksum_writer.cr
+++ b/src/compress/zip/checksum_writer.cr
@@ -13,8 +13,8 @@ module Compress::Zip
       raise IO::Error.new "Can't read from Zip::Writer entry"
     end
 
-    def write(slice : Bytes) : UInt64
-      return 0u64 if slice.empty?
+    def write(slice : Bytes) : Nil
+      return if slice.empty?
 
       @count += slice.size
       @crc32 = Digest::CRC32.update(slice, @crc32) if @compute_crc32

--- a/src/compress/zlib/writer.cr
+++ b/src/compress/zlib/writer.cr
@@ -44,17 +44,15 @@ class Compress::Zlib::Writer < IO
   end
 
   # See `IO#write`.
-  def write(slice : Bytes) : UInt64
+  def write(slice : Bytes) : Nil
     check_open
 
-    return 0u64 if slice.empty?
+    return if slice.empty?
 
     write_header unless @wrote_header
 
     @flate_io.write(slice)
     @adler32 = Digest::Adler32.update(slice, @adler32)
-
-    slice.size.to_u64
   end
 
   # Flushes data, forcing writing the zlib header if no

--- a/src/compress/zlib/writer.cr
+++ b/src/compress/zlib/writer.cr
@@ -44,17 +44,17 @@ class Compress::Zlib::Writer < IO
   end
 
   # See `IO#write`.
-  def write(slice : Bytes) : Int64
+  def write(slice : Bytes) : UInt64
     check_open
 
-    return 0i64 if slice.empty?
+    return 0u64 if slice.empty?
 
     write_header unless @wrote_header
 
     @flate_io.write(slice)
     @adler32 = Digest::Adler32.update(slice, @adler32)
 
-    slice.size.to_i64
+    slice.size.to_u64
   end
 
   # Flushes data, forcing writing the zlib header if no

--- a/src/float.cr
+++ b/src/float.cr
@@ -93,7 +93,7 @@ struct Float
 
   # Writes this float to the given *io* in the given *format*.
   # See also: `IO#write_bytes`.
-  def to_io(io : IO, format : IO::ByteFormat) : Int64
+  def to_io(io : IO, format : IO::ByteFormat) : UInt64
     format.encode(self, io)
   end
 

--- a/src/float.cr
+++ b/src/float.cr
@@ -93,7 +93,7 @@ struct Float
 
   # Writes this float to the given *io* in the given *format*.
   # See also: `IO#write_bytes`.
-  def to_io(io : IO, format : IO::ByteFormat) : UInt64
+  def to_io(io : IO, format : IO::ByteFormat)
     format.encode(self, io)
   end
 

--- a/src/http/content.cr
+++ b/src/http/content.cr
@@ -41,7 +41,7 @@ module HTTP
       super
     end
 
-    def skip(bytes_count : Int) : Int64
+    def skip(bytes_count : Int) : UInt64
       ensure_send_continue
       super
     end
@@ -73,7 +73,7 @@ module HTTP
       @io.peek
     end
 
-    def skip(bytes_count : Int) : Int64
+    def skip(bytes_count : Int) : UInt64
       ensure_send_continue
       @io.skip(bytes_count)
     end
@@ -164,8 +164,8 @@ module HTTP
       peek
     end
 
-    def skip(bytes_count : Int) : Int64
-      bytes_count = bytes_count.to_i64
+    def skip(bytes_count : Int) : UInt64
+      bytes_count = bytes_count.to_u64
       ensure_send_continue
 
       if bytes_count <= @chunk_remaining

--- a/src/http/content.cr
+++ b/src/http/content.cr
@@ -41,7 +41,7 @@ module HTTP
       super
     end
 
-    def skip(bytes_count : Int) : UInt64
+    def skip(bytes_count)
       ensure_send_continue
       super
     end
@@ -73,7 +73,7 @@ module HTTP
       @io.peek
     end
 
-    def skip(bytes_count : Int) : UInt64
+    def skip(bytes_count)
       ensure_send_continue
       @io.skip(bytes_count)
     end
@@ -164,18 +164,14 @@ module HTTP
       peek
     end
 
-    def skip(bytes_count : Int) : UInt64
-      bytes_count = bytes_count.to_u64
+    def skip(bytes_count)
       ensure_send_continue
-
       if bytes_count <= @chunk_remaining
         @io.skip(bytes_count)
         @chunk_remaining -= bytes_count
       else
         super
       end
-
-      bytes_count
     end
 
     # Checks if the last read consumed a chunk and we

--- a/src/http/server/response.cr
+++ b/src/http/server/response.cr
@@ -80,8 +80,8 @@ class HTTP::Server
     end
 
     # See `IO#write(slice)`.
-    def write(slice : Bytes) : UInt64
-      return 0u64 if slice.empty?
+    def write(slice : Bytes) : Nil
+      return if slice.empty?
 
       @output.write(slice)
     end

--- a/src/http/server/response.cr
+++ b/src/http/server/response.cr
@@ -80,8 +80,8 @@ class HTTP::Server
     end
 
     # See `IO#write(slice)`.
-    def write(slice : Bytes) : Int64
-      return 0i64 if slice.empty?
+    def write(slice : Bytes) : UInt64
+      return 0u64 if slice.empty?
 
       @output.write(slice)
     end

--- a/src/http/web_socket/protocol.cr
+++ b/src/http/web_socket/protocol.cr
@@ -52,8 +52,8 @@ class HTTP::WebSocket::Protocol
       @pos = 0
     end
 
-    def write(slice : Bytes) : Int64
-      return 0i64 if slice.empty?
+    def write(slice : Bytes) : UInt64
+      return 0u64 if slice.empty?
 
       count = Math.min(@buffer.size - @pos, slice.size)
       (@buffer + @pos).copy_from(slice.to_unsafe, count)
@@ -67,7 +67,7 @@ class HTTP::WebSocket::Protocol
         write(slice + count)
       end
 
-      slice.size.to_i64
+      slice.size.to_u64
     end
 
     def read(slice : Bytes)

--- a/src/http/web_socket/protocol.cr
+++ b/src/http/web_socket/protocol.cr
@@ -52,8 +52,8 @@ class HTTP::WebSocket::Protocol
       @pos = 0
     end
 
-    def write(slice : Bytes) : UInt64
-      return 0u64 if slice.empty?
+    def write(slice : Bytes) : Nil
+      return if slice.empty?
 
       count = Math.min(@buffer.size - @pos, slice.size)
       (@buffer + @pos).copy_from(slice.to_unsafe, count)
@@ -66,8 +66,6 @@ class HTTP::WebSocket::Protocol
       if count < slice.size
         write(slice + count)
       end
-
-      slice.size.to_u64
     end
 
     def read(slice : Bytes)

--- a/src/int.cr
+++ b/src/int.cr
@@ -673,7 +673,7 @@ struct Int
   # Writes this integer to the given *io* in the given *format*.
   #
   # See also: `IO#write_bytes`.
-  def to_io(io : IO, format : IO::ByteFormat) : UInt64
+  def to_io(io : IO, format : IO::ByteFormat)
     format.encode(self, io)
   end
 

--- a/src/int.cr
+++ b/src/int.cr
@@ -673,7 +673,7 @@ struct Int
   # Writes this integer to the given *io* in the given *format*.
   #
   # See also: `IO#write_bytes`.
-  def to_io(io : IO, format : IO::ByteFormat) : Int64
+  def to_io(io : IO, format : IO::ByteFormat) : UInt64
     format.encode(self, io)
   end
 

--- a/src/io.cr
+++ b/src/io.cr
@@ -32,7 +32,6 @@ require "c/errno"
 #   def write(slice : Bytes) : Nil
 #     slice.size.times { |i| @slice[i] = slice[i] }
 #     @slice += slice.size
-#     nil
 #   end
 # end
 #
@@ -268,7 +267,6 @@ abstract class IO
   # :ditto:
   def printf(format_string, args : Array | Tuple) : Nil
     String::Formatter(typeof(args)).new(format_string, args, self).format
-    nil
   end
 
   # Reads a single byte from this `IO`. Returns `nil` if there is no more
@@ -471,6 +469,7 @@ abstract class IO
     else
       write(slice)
     end
+
     nil
   end
 

--- a/src/io.cr
+++ b/src/io.cr
@@ -1114,12 +1114,12 @@ abstract class IO
   #
   # io2.to_s # => "hello"
   # ```
-  def self.copy(src, dst) : UInt64
+  def self.copy(src, dst) : Int64
     buffer = uninitialized UInt8[4096]
-    count = 0_u64
+    count = 0_i64
     while (len = src.read(buffer.to_slice).to_i32) > 0
       dst.write buffer.to_slice[0, len]
-      count += len
+      count &+= len
     end
     count
   end
@@ -1134,16 +1134,16 @@ abstract class IO
   #
   # io2.to_s # => "hel"
   # ```
-  def self.copy(src, dst, limit : Int) : UInt64
+  def self.copy(src, dst, limit : Int) : Int64
     raise ArgumentError.new("Negative limit") if limit < 0
 
-    limit = limit.to_u64
+    limit = limit.to_i64
 
     buffer = uninitialized UInt8[4096]
     remaining = limit
     while (len = src.read(buffer.to_slice[0, Math.min(buffer.size, Math.max(remaining, 0))])) > 0
       dst.write buffer.to_slice[0, len]
-      remaining -= len
+      remaining &-= len
     end
     limit - remaining
   end

--- a/src/io.cr
+++ b/src/io.cr
@@ -29,10 +29,10 @@ require "c/errno"
 #     slice.size
 #   end
 #
-#   def write(slice : Bytes) : Int64
+#   def write(slice : Bytes) : UInt64
 #     slice.size.times { |i| @slice[i] = slice[i] }
 #     @slice += slice.size
-#     slice.size.to_i64
+#     slice.size.to_u64
 #   end
 # end
 #
@@ -100,7 +100,7 @@ abstract class IO
   # io.write(slice)
   # io.to_s # => "abcd"
   # ```
-  abstract def write(slice : Bytes) : Int64
+  abstract def write(slice : Bytes) : UInt64
 
   # Closes this `IO`.
   #
@@ -464,7 +464,7 @@ abstract class IO
   end
 
   # Writes a slice of UTF-8 encoded bytes to this `IO`, using the current encoding.
-  def write_utf8(slice : Bytes) : Int64
+  def write_utf8(slice : Bytes) : UInt64
     if encoder = encoder()
       encoder.write(self, slice)
     else
@@ -812,8 +812,8 @@ abstract class IO
   # io.gets    # => "world"
   # io.skip(1) # raises IO::EOFError
   # ```
-  def skip(bytes_count : Int) : Int64
-    bytes_count = bytes_count.to_i64
+  def skip(bytes_count : Int) : UInt64
+    bytes_count = bytes_count.to_u64
     remaining = bytes_count
     buffer = uninitialized UInt8[4096]
     while remaining > 0
@@ -826,8 +826,8 @@ abstract class IO
 
   # Reads and discards bytes from `self` until there
   # are no more bytes.
-  def skip_to_end : Int64
-    bytes_count = 0i64
+  def skip_to_end : UInt64
+    bytes_count = 0_u64
     buffer = uninitialized UInt8[4096]
     while (len = read(buffer.to_slice)) > 0
       bytes_count &+= len
@@ -842,7 +842,7 @@ abstract class IO
   # io.write_byte 97_u8
   # io.to_s # => "a"
   # ```
-  def write_byte(byte : UInt8) : Int64
+  def write_byte(byte : UInt8) : UInt64
     x = byte
     write Slice.new(pointerof(x), 1)
   end
@@ -861,7 +861,7 @@ abstract class IO
   # io.rewind
   # io.gets(4) # => "\u{4}\u{3}\u{2}\u{1}"
   # ```
-  def write_bytes(object, format : IO::ByteFormat = IO::ByteFormat::SystemEndian) : Int64
+  def write_bytes(object, format : IO::ByteFormat = IO::ByteFormat::SystemEndian) : UInt64
     object.to_io(self, format)
   end
 
@@ -1117,12 +1117,12 @@ abstract class IO
   #
   # io2.to_s # => "hello"
   # ```
-  def self.copy(src, dst) : Int64
+  def self.copy(src, dst) : UInt64
     buffer = uninitialized UInt8[4096]
-    count = 0_i64
+    count = 0_u64
     while (len = src.read(buffer.to_slice).to_i32) > 0
       dst.write buffer.to_slice[0, len]
-      count &+= len
+      count += len
     end
     count
   end
@@ -1137,16 +1137,16 @@ abstract class IO
   #
   # io2.to_s # => "hel"
   # ```
-  def self.copy(src, dst, limit : Int) : Int64
+  def self.copy(src, dst, limit : Int) : UInt64
     raise ArgumentError.new("Negative limit") if limit < 0
 
-    limit = limit.to_i64
+    limit = limit.to_u64
 
     buffer = uninitialized UInt8[4096]
     remaining = limit
     while (len = src.read(buffer.to_slice[0, Math.min(buffer.size, Math.max(remaining, 0))])) > 0
       dst.write buffer.to_slice[0, len]
-      remaining &-= len
+      remaining -= len
     end
     limit - remaining
   end

--- a/src/io.cr
+++ b/src/io.cr
@@ -14,7 +14,7 @@ require "c/errno"
 # these two methods:
 #
 # * `read(slice : Bytes)`: read at most *slice.size* bytes from IO into *slice* and return the number of bytes read
-# * `write(slice : Bytes)`: write the whole *slice* into the IO and return the number of bytes written
+# * `write(slice : Bytes)`: write the whole *slice* into the IO
 #
 # For example, this is a simple `IO` on top of a `Bytes`:
 #
@@ -29,10 +29,10 @@ require "c/errno"
 #     slice.size
 #   end
 #
-#   def write(slice : Bytes) : UInt64
+#   def write(slice : Bytes) : Nil
 #     slice.size.times { |i| @slice[i] = slice[i] }
 #     @slice += slice.size
-#     slice.size.to_u64
+#     nil
 #   end
 # end
 #
@@ -100,7 +100,7 @@ abstract class IO
   # io.write(slice)
   # io.to_s # => "abcd"
   # ```
-  abstract def write(slice : Bytes) : UInt64
+  abstract def write(slice : Bytes) : Nil
 
   # Closes this `IO`.
   #
@@ -268,6 +268,7 @@ abstract class IO
   # :ditto:
   def printf(format_string, args : Array | Tuple) : Nil
     String::Formatter(typeof(args)).new(format_string, args, self).format
+    nil
   end
 
   # Reads a single byte from this `IO`. Returns `nil` if there is no more
@@ -464,12 +465,13 @@ abstract class IO
   end
 
   # Writes a slice of UTF-8 encoded bytes to this `IO`, using the current encoding.
-  def write_utf8(slice : Bytes) : UInt64
+  def write_utf8(slice : Bytes)
     if encoder = encoder()
       encoder.write(self, slice)
     else
       write(slice)
     end
+    nil
   end
 
   private def encoder
@@ -812,27 +814,22 @@ abstract class IO
   # io.gets    # => "world"
   # io.skip(1) # raises IO::EOFError
   # ```
-  def skip(bytes_count : Int) : UInt64
-    bytes_count = bytes_count.to_u64
-    remaining = bytes_count
+  def skip(bytes_count : Int) : Nil
     buffer = uninitialized UInt8[4096]
-    while remaining > 0
-      read_count = read(buffer.to_slice[0, Math.min(remaining, 4096)])
+    while bytes_count > 0
+      read_count = read(buffer.to_slice[0, Math.min(bytes_count, 4096)])
       raise IO::EOFError.new if read_count == 0
-      remaining -= read_count
+
+      bytes_count -= read_count
     end
-    bytes_count
   end
 
   # Reads and discards bytes from `self` until there
   # are no more bytes.
-  def skip_to_end : UInt64
-    bytes_count = 0_u64
+  def skip_to_end : Nil
     buffer = uninitialized UInt8[4096]
-    while (len = read(buffer.to_slice)) > 0
-      bytes_count &+= len
+    while read(buffer.to_slice) > 0
     end
-    bytes_count
   end
 
   # Writes a single byte into this `IO`.
@@ -842,7 +839,7 @@ abstract class IO
   # io.write_byte 97_u8
   # io.to_s # => "a"
   # ```
-  def write_byte(byte : UInt8) : UInt64
+  def write_byte(byte : UInt8)
     x = byte
     write Slice.new(pointerof(x), 1)
   end
@@ -850,7 +847,7 @@ abstract class IO
   # Writes the given object to this `IO` using the specified *format*.
   #
   # This ends up invoking `object.to_io(self, format)`, so any object defining a
-  # `to_io(io : IO, format : IO::ByteFormat = IO::ByteFormat::SystemEndian) : UInt64`
+  # `to_io(io : IO, format : IO::ByteFormat = IO::ByteFormat::SystemEndian)`
   # method can be written in this way.
   #
   # See `Int#to_io` and `Float#to_io`.
@@ -861,7 +858,7 @@ abstract class IO
   # io.rewind
   # io.gets(4) # => "\u{4}\u{3}\u{2}\u{1}"
   # ```
-  def write_bytes(object, format : IO::ByteFormat = IO::ByteFormat::SystemEndian) : UInt64
+  def write_bytes(object, format : IO::ByteFormat = IO::ByteFormat::SystemEndian)
     object.to_io(self, format)
   end
 

--- a/src/io/buffered.cr
+++ b/src/io/buffered.cr
@@ -158,7 +158,6 @@ module IO::Buffered
 
     slice.copy_to(out_buffer + @out_count, count)
     @out_count += count
-    nil
   end
 
   # :nodoc:

--- a/src/io/buffered.cr
+++ b/src/io/buffered.cr
@@ -110,36 +110,30 @@ module IO::Buffered
   end
 
   # :nodoc:
-  def skip(bytes_count : Int) : UInt64
-    bytes_count = bytes_count.to_u64
+  def skip(bytes_count) : Nil
     check_open
 
     if bytes_count <= @in_buffer_rem.size
       @in_buffer_rem += bytes_count
-      return bytes_count
+      return
     end
 
-    remaining = bytes_count
-    remaining -= @in_buffer_rem.size
+    bytes_count -= @in_buffer_rem.size
     @in_buffer_rem = Bytes.empty
 
-    super(remaining)
-    bytes_count
+    super(bytes_count)
   end
 
   # Buffered implementation of `IO#write(slice)`.
-  def write(slice : Bytes) : UInt64
-    # NOTE: It returns the bytes written without differencing whether
-    # they are kept in the buffer or sent to the underlying IO.
+  def write(slice : Bytes) : Nil
     check_open
 
-    return 0u64 if slice.empty?
+    return if slice.empty?
 
     count = slice.size
 
     if sync?
-      unbuffered_write(slice)
-      return slice.size.to_u64
+      return unbuffered_write(slice)
     end
 
     if flush_on_newline?
@@ -155,8 +149,7 @@ module IO::Buffered
 
     if count >= @buffer_size
       flush
-      unbuffered_write slice[0, count]
-      return slice.size.to_u64
+      return unbuffered_write slice[0, count]
     end
 
     if count > @buffer_size - @out_count
@@ -165,12 +158,11 @@ module IO::Buffered
 
     slice.copy_to(out_buffer + @out_count, count)
     @out_count += count
-
-    slice.size.to_u64
+    nil
   end
 
   # :nodoc:
-  def write_byte(byte : UInt8) : UInt64
+  def write_byte(byte : UInt8)
     check_open
 
     if sync?
@@ -186,8 +178,6 @@ module IO::Buffered
     if flush_on_newline? && byte === '\n'
       flush
     end
-
-    1u64
   end
 
   # Turns on/off `IO` **write** buffering. When *sync* is set to `true`, no buffering

--- a/src/io/buffered.cr
+++ b/src/io/buffered.cr
@@ -110,8 +110,8 @@ module IO::Buffered
   end
 
   # :nodoc:
-  def skip(bytes_count : Int) : Int64
-    bytes_count = bytes_count.to_i64
+  def skip(bytes_count : Int) : UInt64
+    bytes_count = bytes_count.to_u64
     check_open
 
     if bytes_count <= @in_buffer_rem.size
@@ -128,18 +128,18 @@ module IO::Buffered
   end
 
   # Buffered implementation of `IO#write(slice)`.
-  def write(slice : Bytes) : Int64
+  def write(slice : Bytes) : UInt64
     # NOTE: It returns the bytes written without differencing whether
     # they are kept in the buffer or sent to the underlying IO.
     check_open
 
-    return 0i64 if slice.empty?
+    return 0u64 if slice.empty?
 
     count = slice.size
 
     if sync?
       unbuffered_write(slice)
-      return slice.size.to_i64
+      return slice.size.to_u64
     end
 
     if flush_on_newline?
@@ -156,7 +156,7 @@ module IO::Buffered
     if count >= @buffer_size
       flush
       unbuffered_write slice[0, count]
-      return slice.size.to_i64
+      return slice.size.to_u64
     end
 
     if count > @buffer_size - @out_count
@@ -166,11 +166,11 @@ module IO::Buffered
     slice.copy_to(out_buffer + @out_count, count)
     @out_count += count
 
-    slice.size.to_i64
+    slice.size.to_u64
   end
 
   # :nodoc:
-  def write_byte(byte : UInt8) : Int64
+  def write_byte(byte : UInt8) : UInt64
     check_open
 
     if sync?
@@ -187,7 +187,7 @@ module IO::Buffered
       flush
     end
 
-    1i64
+    1u64
   end
 
   # Turns on/off `IO` **write** buffering. When *sync* is set to `true`, no buffering

--- a/src/io/byte_format.cr
+++ b/src/io/byte_format.cr
@@ -33,27 +33,27 @@
 # io.to_slice # => Bytes[0x34, 0x12]
 # ```
 module IO::ByteFormat
-  abstract def encode(int : Int8, io : IO) : UInt64
-  abstract def encode(int : UInt8, io : IO) : UInt64
-  abstract def encode(int : Int16, io : IO) : UInt64
-  abstract def encode(int : UInt16, io : IO) : UInt64
-  abstract def encode(int : Int32, io : IO) : UInt64
-  abstract def encode(int : UInt32, io : IO) : UInt64
-  abstract def encode(int : Int64, io : IO) : UInt64
-  abstract def encode(int : UInt64, io : IO) : UInt64
-  abstract def encode(int : Int128, io : IO) : UInt64
-  abstract def encode(int : UInt128, io : IO) : UInt64
+  abstract def encode(int : Int8, io : IO)
+  abstract def encode(int : UInt8, io : IO)
+  abstract def encode(int : Int16, io : IO)
+  abstract def encode(int : UInt16, io : IO)
+  abstract def encode(int : Int32, io : IO)
+  abstract def encode(int : UInt32, io : IO)
+  abstract def encode(int : Int64, io : IO)
+  abstract def encode(int : UInt64, io : IO)
+  abstract def encode(int : Int128, io : IO)
+  abstract def encode(int : UInt128, io : IO)
 
-  abstract def encode(int : Int8, bytes : Bytes) : UInt64
-  abstract def encode(int : UInt8, bytes : Bytes) : UInt64
-  abstract def encode(int : Int16, bytes : Bytes) : UInt64
-  abstract def encode(int : UInt16, bytes : Bytes) : UInt64
-  abstract def encode(int : Int32, bytes : Bytes) : UInt64
-  abstract def encode(int : UInt32, bytes : Bytes) : UInt64
-  abstract def encode(int : Int64, bytes : Bytes) : UInt64
-  abstract def encode(int : UInt64, bytes : Bytes) : UInt64
-  abstract def encode(int : Int128, bytes : Bytes) : UInt64
-  abstract def encode(int : UInt128, bytes : Bytes) : UInt64
+  abstract def encode(int : Int8, bytes : Bytes)
+  abstract def encode(int : UInt8, bytes : Bytes)
+  abstract def encode(int : Int16, bytes : Bytes)
+  abstract def encode(int : UInt16, bytes : Bytes)
+  abstract def encode(int : Int32, bytes : Bytes)
+  abstract def encode(int : UInt32, bytes : Bytes)
+  abstract def encode(int : Int64, bytes : Bytes)
+  abstract def encode(int : UInt64, bytes : Bytes)
+  abstract def encode(int : Int128, bytes : Bytes)
+  abstract def encode(int : UInt128, bytes : Bytes)
 
   abstract def decode(int : Int8.class, io : IO)
   abstract def decode(int : UInt8.class, io : IO)
@@ -77,11 +77,11 @@ module IO::ByteFormat
   abstract def decode(int : Int128.class, bytes : Bytes)
   abstract def decode(int : UInt128.class, bytes : Bytes)
 
-  def encode(float : Float32, io : IO) : UInt64
+  def encode(float : Float32, io : IO)
     encode(float.unsafe_as(Int32), io)
   end
 
-  def encode(float : Float32, bytes : Bytes) : UInt64
+  def encode(float : Float32, bytes : Bytes)
     encode(float.unsafe_as(Int32), bytes)
   end
 
@@ -93,11 +93,11 @@ module IO::ByteFormat
     decode(Int32, bytes).unsafe_as(Float32)
   end
 
-  def encode(float : Float64, io : IO) : UInt64
+  def encode(float : Float64, io : IO)
     encode(float.unsafe_as(Int64), io)
   end
 
-  def encode(float : Float64, bytes : Bytes) : UInt64
+  def encode(float : Float64, bytes : Bytes)
     encode(float.unsafe_as(Int64), bytes)
   end
 
@@ -125,18 +125,16 @@ module IO::ByteFormat
       {% for type, i in %w(Int8 UInt8 Int16 UInt16 Int32 UInt32 Int64 UInt64 Int128 UInt128) %}
         {% bytesize = 2 ** (i // 2) %}
 
-        def self.encode(int : {{type.id}}, io : IO) : UInt64
+        def self.encode(int : {{type.id}}, io : IO)
           buffer = int.unsafe_as(StaticArray(UInt8, {{bytesize}}))
           buffer.reverse! unless SystemEndian == self
           io.write(buffer.to_slice)
-          UInt64.new({{bytesize}})
         end
 
-        def self.encode(int : {{type.id}}, bytes : Bytes) : UInt64
+        def self.encode(int : {{type.id}}, bytes : Bytes)
           buffer = int.unsafe_as(StaticArray(UInt8, {{bytesize}}))
           buffer.reverse! unless SystemEndian == self
           buffer.to_slice.copy_to(bytes)
-          UInt64.new({{bytesize}})
         end
 
         def self.decode(type : {{type.id}}.class, io : IO)

--- a/src/io/byte_format.cr
+++ b/src/io/byte_format.cr
@@ -33,27 +33,27 @@
 # io.to_slice # => Bytes[0x34, 0x12]
 # ```
 module IO::ByteFormat
-  abstract def encode(int : Int8, io : IO) : Int64
-  abstract def encode(int : UInt8, io : IO) : Int64
-  abstract def encode(int : Int16, io : IO) : Int64
-  abstract def encode(int : UInt16, io : IO) : Int64
-  abstract def encode(int : Int32, io : IO) : Int64
-  abstract def encode(int : UInt32, io : IO) : Int64
-  abstract def encode(int : Int64, io : IO) : Int64
-  abstract def encode(int : UInt64, io : IO) : Int64
-  abstract def encode(int : Int128, io : IO) : Int64
-  abstract def encode(int : UInt128, io : IO) : Int64
+  abstract def encode(int : Int8, io : IO) : UInt64
+  abstract def encode(int : UInt8, io : IO) : UInt64
+  abstract def encode(int : Int16, io : IO) : UInt64
+  abstract def encode(int : UInt16, io : IO) : UInt64
+  abstract def encode(int : Int32, io : IO) : UInt64
+  abstract def encode(int : UInt32, io : IO) : UInt64
+  abstract def encode(int : Int64, io : IO) : UInt64
+  abstract def encode(int : UInt64, io : IO) : UInt64
+  abstract def encode(int : Int128, io : IO) : UInt64
+  abstract def encode(int : UInt128, io : IO) : UInt64
 
-  abstract def encode(int : Int8, bytes : Bytes) : Int64
-  abstract def encode(int : UInt8, bytes : Bytes) : Int64
-  abstract def encode(int : Int16, bytes : Bytes) : Int64
-  abstract def encode(int : UInt16, bytes : Bytes) : Int64
-  abstract def encode(int : Int32, bytes : Bytes) : Int64
-  abstract def encode(int : UInt32, bytes : Bytes) : Int64
-  abstract def encode(int : Int64, bytes : Bytes) : Int64
-  abstract def encode(int : UInt64, bytes : Bytes) : Int64
-  abstract def encode(int : Int128, bytes : Bytes) : Int64
-  abstract def encode(int : UInt128, bytes : Bytes) : Int64
+  abstract def encode(int : Int8, bytes : Bytes) : UInt64
+  abstract def encode(int : UInt8, bytes : Bytes) : UInt64
+  abstract def encode(int : Int16, bytes : Bytes) : UInt64
+  abstract def encode(int : UInt16, bytes : Bytes) : UInt64
+  abstract def encode(int : Int32, bytes : Bytes) : UInt64
+  abstract def encode(int : UInt32, bytes : Bytes) : UInt64
+  abstract def encode(int : Int64, bytes : Bytes) : UInt64
+  abstract def encode(int : UInt64, bytes : Bytes) : UInt64
+  abstract def encode(int : Int128, bytes : Bytes) : UInt64
+  abstract def encode(int : UInt128, bytes : Bytes) : UInt64
 
   abstract def decode(int : Int8.class, io : IO)
   abstract def decode(int : UInt8.class, io : IO)
@@ -77,11 +77,11 @@ module IO::ByteFormat
   abstract def decode(int : Int128.class, bytes : Bytes)
   abstract def decode(int : UInt128.class, bytes : Bytes)
 
-  def encode(float : Float32, io : IO) : Int64
+  def encode(float : Float32, io : IO) : UInt64
     encode(float.unsafe_as(Int32), io)
   end
 
-  def encode(float : Float32, bytes : Bytes) : Int64
+  def encode(float : Float32, bytes : Bytes) : UInt64
     encode(float.unsafe_as(Int32), bytes)
   end
 
@@ -93,11 +93,11 @@ module IO::ByteFormat
     decode(Int32, bytes).unsafe_as(Float32)
   end
 
-  def encode(float : Float64, io : IO) : Int64
+  def encode(float : Float64, io : IO) : UInt64
     encode(float.unsafe_as(Int64), io)
   end
 
-  def encode(float : Float64, bytes : Bytes) : Int64
+  def encode(float : Float64, bytes : Bytes) : UInt64
     encode(float.unsafe_as(Int64), bytes)
   end
 
@@ -125,18 +125,18 @@ module IO::ByteFormat
       {% for type, i in %w(Int8 UInt8 Int16 UInt16 Int32 UInt32 Int64 UInt64 Int128 UInt128) %}
         {% bytesize = 2 ** (i // 2) %}
 
-        def self.encode(int : {{type.id}}, io : IO) : Int64
+        def self.encode(int : {{type.id}}, io : IO) : UInt64
           buffer = int.unsafe_as(StaticArray(UInt8, {{bytesize}}))
           buffer.reverse! unless SystemEndian == self
           io.write(buffer.to_slice)
-          Int64.new({{bytesize}})
+          UInt64.new({{bytesize}})
         end
 
-        def self.encode(int : {{type.id}}, bytes : Bytes) : Int64
+        def self.encode(int : {{type.id}}, bytes : Bytes) : UInt64
           buffer = int.unsafe_as(StaticArray(UInt8, {{bytesize}}))
           buffer.reverse! unless SystemEndian == self
           buffer.to_slice.copy_to(bytes)
-          Int64.new({{bytesize}})
+          UInt64.new({{bytesize}})
         end
 
         def self.decode(type : {{type.id}}.class, io : IO)

--- a/src/io/delimited.cr
+++ b/src/io/delimited.cr
@@ -107,7 +107,7 @@ class IO::Delimited < IO
     read_bytes
   end
 
-  def write(slice : Bytes) : Int64
+  def write(slice : Bytes) : UInt64
     raise IO::Error.new "Can't write to IO::Delimited"
   end
 

--- a/src/io/delimited.cr
+++ b/src/io/delimited.cr
@@ -107,7 +107,7 @@ class IO::Delimited < IO
     read_bytes
   end
 
-  def write(slice : Bytes) : UInt64
+  def write(slice : Bytes) : Nil
     raise IO::Error.new "Can't write to IO::Delimited"
   end
 

--- a/src/io/encoding.cr
+++ b/src/io/encoding.cr
@@ -27,8 +27,7 @@ class IO
       @closed = false
     end
 
-    def write(io, slice : Bytes) : UInt64
-      bytes_written = 0u64
+    def write(io, slice : Bytes)
       inbuf_ptr = slice.to_unsafe
       inbytesleft = LibC::SizeT.new(slice.size)
       outbuf = uninitialized UInt8[1024]
@@ -39,9 +38,8 @@ class IO
         if err == Crystal::Iconv::ERROR
           @iconv.handle_invalid(pointerof(inbuf_ptr), pointerof(inbytesleft))
         end
-        bytes_written &+= io.write(outbuf.to_slice[0, outbuf.size - outbytesleft])
+        io.write(outbuf.to_slice[0, outbuf.size - outbytesleft])
       end
-      bytes_written
     end
 
     def close

--- a/src/io/encoding.cr
+++ b/src/io/encoding.cr
@@ -27,8 +27,8 @@ class IO
       @closed = false
     end
 
-    def write(io, slice : Bytes) : Int64
-      bytes_written = 0i64
+    def write(io, slice : Bytes) : UInt64
+      bytes_written = 0u64
       inbuf_ptr = slice.to_unsafe
       inbytesleft = LibC::SizeT.new(slice.size)
       outbuf = uninitialized UInt8[1024]

--- a/src/io/hexdump.cr
+++ b/src/io/hexdump.cr
@@ -32,8 +32,8 @@ class IO::Hexdump < IO
     end
   end
 
-  def write(buf : Bytes) : Int64
-    return 0i64 if buf.empty?
+  def write(buf : Bytes) : UInt64
+    return 0u64 if buf.empty?
 
     @io.write(buf).tap do
       @output.puts buf.hexdump if @write

--- a/src/io/hexdump.cr
+++ b/src/io/hexdump.cr
@@ -32,8 +32,8 @@ class IO::Hexdump < IO
     end
   end
 
-  def write(buf : Bytes) : UInt64
-    return 0u64 if buf.empty?
+  def write(buf : Bytes) : Nil
+    return if buf.empty?
 
     @io.write(buf).tap do
       @output.puts buf.hexdump if @write

--- a/src/io/memory.cr
+++ b/src/io/memory.cr
@@ -104,8 +104,6 @@ class IO::Memory < IO
 
     @pos += count
     @bytesize = @pos if @pos > @bytesize
-
-    nil
   end
 
   # See `IO#write_byte`. Raises if this `IO::Memory` is non-writeable,
@@ -206,7 +204,7 @@ class IO::Memory < IO
   end
 
   # :nodoc:
-  def skip_to_end
+  def skip_to_end : Nil
     check_open
 
     @pos = @bytesize

--- a/src/io/memory.cr
+++ b/src/io/memory.cr
@@ -82,13 +82,13 @@ class IO::Memory < IO
 
   # See `IO#write(slice)`. Raises if this `IO::Memory` is non-writeable,
   # or if it's non-resizeable and a resize is needed.
-  def write(slice : Bytes) : Int64
+  def write(slice : Bytes) : UInt64
     check_writeable
     check_open
 
     count = slice.size
 
-    return 0i64 if count == 0
+    return 0u64 if count == 0
 
     new_bytesize = @pos + count
     if new_bytesize > @capacity
@@ -105,12 +105,12 @@ class IO::Memory < IO
     @pos += count
     @bytesize = @pos if @pos > @bytesize
 
-    slice.size.to_i64
+    slice.size.to_u64
   end
 
   # See `IO#write_byte`. Raises if this `IO::Memory` is non-writeable,
   # or if it's non-resizeable and a resize is needed.
-  def write_byte(byte : UInt8) : Int64
+  def write_byte(byte : UInt8)
     check_writeable
     check_open
 
@@ -129,7 +129,7 @@ class IO::Memory < IO
     @pos += 1
     @bytesize = @pos if @pos > @bytesize
 
-    1i64
+    nil
   end
 
   # :nodoc:
@@ -194,8 +194,8 @@ class IO::Memory < IO
   end
 
   # :nodoc:
-  def skip(bytes_count : Int) : Int64
-    bytes_count = bytes_count.to_i64
+  def skip(bytes_count : Int) : UInt64
+    bytes_count = bytes_count.to_u64
     check_open
 
     available = @bytesize - @pos
@@ -208,12 +208,12 @@ class IO::Memory < IO
   end
 
   # :nodoc:
-  def skip_to_end : Int64
+  def skip_to_end : UInt64
     check_open
 
     skipped = @bytesize - @pos
     @pos = @bytesize
-    skipped.to_i64
+    skipped.to_u64
   end
 
   # :nodoc:

--- a/src/io/memory.cr
+++ b/src/io/memory.cr
@@ -82,13 +82,13 @@ class IO::Memory < IO
 
   # See `IO#write(slice)`. Raises if this `IO::Memory` is non-writeable,
   # or if it's non-resizeable and a resize is needed.
-  def write(slice : Bytes) : UInt64
+  def write(slice : Bytes) : Nil
     check_writeable
     check_open
 
     count = slice.size
 
-    return 0u64 if count == 0
+    return if count == 0
 
     new_bytesize = @pos + count
     if new_bytesize > @capacity
@@ -105,7 +105,7 @@ class IO::Memory < IO
     @pos += count
     @bytesize = @pos if @pos > @bytesize
 
-    slice.size.to_u64
+    nil
   end
 
   # See `IO#write_byte`. Raises if this `IO::Memory` is non-writeable,
@@ -194,8 +194,7 @@ class IO::Memory < IO
   end
 
   # :nodoc:
-  def skip(bytes_count : Int) : UInt64
-    bytes_count = bytes_count.to_u64
+  def skip(bytes_count)
     check_open
 
     available = @bytesize - @pos
@@ -204,16 +203,13 @@ class IO::Memory < IO
     else
       raise IO::EOFError.new
     end
-    bytes_count
   end
 
   # :nodoc:
-  def skip_to_end : UInt64
+  def skip_to_end
     check_open
 
-    skipped = @bytesize - @pos
     @pos = @bytesize
-    skipped.to_u64
   end
 
   # :nodoc:

--- a/src/io/multi_writer.cr
+++ b/src/io/multi_writer.cr
@@ -29,14 +29,14 @@ class IO::MultiWriter < IO
     @writers = writers.map(&.as(IO)).to_a
   end
 
-  def write(slice : Bytes) : Int64
+  def write(slice : Bytes) : UInt64
     check_open
 
-    return 0i64 if slice.empty?
+    return 0u64 if slice.empty?
 
     @writers.each { |writer| writer.write(slice) }
 
-    slice.size.to_i64
+    slice.size.to_u64
   end
 
   def read(slice : Bytes)

--- a/src/io/multi_writer.cr
+++ b/src/io/multi_writer.cr
@@ -29,14 +29,12 @@ class IO::MultiWriter < IO
     @writers = writers.map(&.as(IO)).to_a
   end
 
-  def write(slice : Bytes) : UInt64
+  def write(slice : Bytes) : Nil
     check_open
 
-    return 0u64 if slice.empty?
+    return if slice.empty?
 
     @writers.each { |writer| writer.write(slice) }
-
-    slice.size.to_u64
   end
 
   def read(slice : Bytes)

--- a/src/io/sized.cr
+++ b/src/io/sized.cr
@@ -61,8 +61,7 @@ class IO::Sized < IO
     peek
   end
 
-  def skip(bytes_count : Int) : UInt64
-    bytes_count = bytes_count.to_u64
+  def skip(bytes_count) : Nil
     check_open
 
     if bytes_count <= @read_remaining
@@ -71,8 +70,6 @@ class IO::Sized < IO
     else
       raise IO::EOFError.new
     end
-
-    bytes_count
   end
 
   def write(slice : Bytes) : NoReturn

--- a/src/io/sized.cr
+++ b/src/io/sized.cr
@@ -61,8 +61,8 @@ class IO::Sized < IO
     peek
   end
 
-  def skip(bytes_count : Int) : Int64
-    bytes_count = bytes_count.to_i64
+  def skip(bytes_count : Int) : UInt64
+    bytes_count = bytes_count.to_u64
     check_open
 
     if bytes_count <= @read_remaining

--- a/src/io/stapled.cr
+++ b/src/io/stapled.cr
@@ -51,17 +51,10 @@ class IO::Stapled < IO
   end
 
   # Skips `reader`.
-  def skip(bytes_count : Int) : UInt64
+  def skip(bytes_count : Int) : Nil
     check_open
 
     @reader.skip(bytes_count)
-  end
-
-  # Skips `reader`.
-  def skip_to_end : UInt64
-    check_open
-
-    @reader.skip_to_end
   end
 
   # Writes a byte to `writer`.
@@ -72,10 +65,10 @@ class IO::Stapled < IO
   end
 
   # Writes a slice to `writer`.
-  def write(slice : Bytes) : UInt64
+  def write(slice : Bytes) : Nil
     check_open
 
-    return 0u64 if slice.empty?
+    return if slice.empty?
 
     @writer.write(slice)
   end

--- a/src/io/stapled.cr
+++ b/src/io/stapled.cr
@@ -51,31 +51,31 @@ class IO::Stapled < IO
   end
 
   # Skips `reader`.
-  def skip(bytes_count : Int) : Int64
+  def skip(bytes_count : Int) : UInt64
     check_open
 
     @reader.skip(bytes_count)
   end
 
   # Skips `reader`.
-  def skip_to_end : Int64
+  def skip_to_end : UInt64
     check_open
 
     @reader.skip_to_end
   end
 
   # Writes a byte to `writer`.
-  def write_byte(byte : UInt8) : Int64
+  def write_byte(byte : UInt8) : Nil
     check_open
 
     @writer.write_byte(byte)
   end
 
   # Writes a slice to `writer`.
-  def write(slice : Bytes) : Int64
+  def write(slice : Bytes) : UInt64
     check_open
 
-    return 0i64 if slice.empty?
+    return 0u64 if slice.empty?
 
     @writer.write(slice)
   end

--- a/src/io/stapled.cr
+++ b/src/io/stapled.cr
@@ -57,6 +57,13 @@ class IO::Stapled < IO
     @reader.skip(bytes_count)
   end
 
+  # Skips `reader`.
+  def skip_to_end : Nil
+    check_open
+
+    @reader.skip_to_end
+  end
+
   # Writes a byte to `writer`.
   def write_byte(byte : UInt8) : Nil
     check_open

--- a/src/io/stapled.cr
+++ b/src/io/stapled.cr
@@ -65,7 +65,7 @@ class IO::Stapled < IO
   end
 
   # Writes a byte to `writer`.
-  def write_byte(byte : UInt8) : Nil
+  def write_byte(byte : UInt8)
     check_open
 
     @writer.write_byte(byte)

--- a/src/openssl/digest/digest_io.cr
+++ b/src/openssl/digest/digest_io.cr
@@ -42,8 +42,8 @@ module OpenSSL
       read_bytes
     end
 
-    def write(slice : Bytes) : UInt64
-      return 0u64 if slice.empty?
+    def write(slice : Bytes) : Nil
+      return if slice.empty?
 
       if @mode.write?
         digest_algorithm.update(slice)

--- a/src/openssl/digest/digest_io.cr
+++ b/src/openssl/digest/digest_io.cr
@@ -42,8 +42,8 @@ module OpenSSL
       read_bytes
     end
 
-    def write(slice : Bytes) : Int64
-      return 0i64 if slice.empty?
+    def write(slice : Bytes) : UInt64
+      return 0u64 if slice.empty?
 
       if @mode.write?
         digest_algorithm.update(slice)

--- a/src/openssl/ssl/socket.cr
+++ b/src/openssl/ssl/socket.cr
@@ -144,7 +144,6 @@ abstract class OpenSSL::SSL::Socket < IO
     unless bytes > 0
       raise OpenSSL::SSL::Error.new(@ssl, bytes, "SSL_write")
     end
-    nil
   end
 
   def unbuffered_flush

--- a/src/openssl/ssl/socket.cr
+++ b/src/openssl/ssl/socket.cr
@@ -144,6 +144,7 @@ abstract class OpenSSL::SSL::Socket < IO
     unless bytes > 0
       raise OpenSSL::SSL::Error.new(@ssl, bytes, "SSL_write")
     end
+    nil
   end
 
   def unbuffered_flush

--- a/src/string/builder.cr
+++ b/src/string/builder.cr
@@ -49,8 +49,6 @@ class String::Builder < IO
 
     slice.copy_to(@buffer + real_bytesize, count)
     @bytesize += count
-
-    nil
   end
 
   def write_byte(byte : UInt8)

--- a/src/string/builder.cr
+++ b/src/string/builder.cr
@@ -38,8 +38,8 @@ class String::Builder < IO
     raise "Not implemented"
   end
 
-  def write(slice : Bytes) : UInt64
-    return 0u64 if slice.empty?
+  def write(slice : Bytes) : Nil
+    return if slice.empty?
 
     count = slice.size
     new_bytesize = real_bytesize + count
@@ -50,7 +50,7 @@ class String::Builder < IO
     slice.copy_to(@buffer + real_bytesize, count)
     @bytesize += count
 
-    slice.size.to_u64
+    nil
   end
 
   def write_byte(byte : UInt8)

--- a/src/string/builder.cr
+++ b/src/string/builder.cr
@@ -38,8 +38,8 @@ class String::Builder < IO
     raise "Not implemented"
   end
 
-  def write(slice : Bytes) : Int64
-    return 0i64 if slice.empty?
+  def write(slice : Bytes) : UInt64
+    return 0u64 if slice.empty?
 
     count = slice.size
     new_bytesize = real_bytesize + count
@@ -50,10 +50,10 @@ class String::Builder < IO
     slice.copy_to(@buffer + real_bytesize, count)
     @bytesize += count
 
-    slice.size.to_i64
+    slice.size.to_u64
   end
 
-  def write_byte(byte : UInt8) : Int64
+  def write_byte(byte : UInt8)
     new_bytesize = real_bytesize + 1
     if new_bytesize > @capacity
       resize_to_capacity(Math.pw2ceil(new_bytesize))
@@ -63,7 +63,7 @@ class String::Builder < IO
 
     @bytesize += 1
 
-    1i64
+    nil
   end
 
   def buffer


### PR DESCRIPTION
Reverts #9233 and #9363, yet keeps some cleanup, minor fixes and the return type of `IO.copy` as Int64.

You can read the motivations for reverting these changes at https://github.com/crystal-lang/crystal/pull/9233#issuecomment-642726015

Although is a breaking-change from 0.35.0, it's better to revert it now than make all the ecosystem adapt for the change in 0.35.0. That's why it's better to do it in 0.35.1.