### PR TITLE
Makefile: support changing the current crystal via env var and argument

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,8 @@
 ## Run all specs in verbose mode
 ##   $ make spec verbose=1
 
-LLVM_CONFIG ?= ## llvm-config command path to use
+CRYSTAL ?= crystal ## which previous crystal compiler use
+LLVM_CONFIG ?=     ## llvm-config command path to use
 
 release ?=      ## Compile in release mode
 stats ?=        ## Enable statistics output

--- a/bin/crystal
+++ b/bin/crystal
@@ -141,6 +141,8 @@ CRYSTAL_DIR="$CRYSTAL_ROOT/.build"
 export CRYSTAL_PATH=lib:$CRYSTAL_ROOT/src
 export CRYSTAL_HAS_WRAPPER=true
 
+CRYSTAL="${CRYSTAL:-"crystal"}"
+
 if [ -z "$CRYSTAL_CONFIG_LIBRARY_PATH" ]; then
   export CRYSTAL_CONFIG_LIBRARY_PATH="$(crystal env CRYSTAL_LIBRARY_PATH || echo "")"
 fi
@@ -148,12 +150,12 @@ fi
 if [ -x "$CRYSTAL_DIR/crystal" ]; then
   __warning_msg "Using compiled compiler at ${CRYSTAL_DIR#"$PWD/"}/crystal"
   exec "$CRYSTAL_DIR/crystal" "$@"
-elif ! command -v crystal > /dev/null; then
-  __error_msg 'You need to have a crystal executable in your path!'
+elif ! command -v $CRYSTAL > /dev/null; then
+  __error_msg 'You need to have a crystal executable in your path! or set CRYSTAL env variable'
   exit 1
-elif [ "$(command -v crystal)" = "$SCRIPT_PATH" ] || [ "$(command -v crystal)" = "bin/crystal" ]; then
+elif [ "$(command -v $CRYSTAL)" = "$SCRIPT_PATH" ] || [ "$(command -v $CRYSTAL)" = "bin/crystal" ]; then
   export PATH="$(remove_path_item "$(remove_path_item "$PATH" "$SCRIPT_ROOT")" "bin")"
   exec "$SCRIPT_PATH" "$@"
 else
-  exec crystal "$@"
+  exec $CRYSTAL "$@"
 fi

--- a/bin/crystal
+++ b/bin/crystal
@@ -141,7 +141,7 @@ CRYSTAL_DIR="$CRYSTAL_ROOT/.build"
 export CRYSTAL_PATH=lib:$CRYSTAL_ROOT/src
 export CRYSTAL_HAS_WRAPPER=true
 
-CRYSTAL="${CRYSTAL:-"crystal"}"
+export CRYSTAL="${CRYSTAL:-"crystal"}"
 
 if [ -z "$CRYSTAL_CONFIG_LIBRARY_PATH" ]; then
   export CRYSTAL_CONFIG_LIBRARY_PATH="$(crystal env CRYSTAL_LIBRARY_PATH || echo "")"


### PR DESCRIPTION
Allow bin/crystal and makefile to not require installed crystal in path by reading CRYSTAL env var or makefile argument

make CRYSTAL=path/to/previous/compiler

This will help package maintainers to avoid installing previous compiler and directly pointing to the compiler binary. 

cc: @jhass 