### PR TITLE
for fixed def write(buf : Bytes) : Int64 > Error: method must return …

### DIFF
--- a/src/io/hexdump.cr
+++ b/src/io/hexdump.cr
@@ -33,11 +33,11 @@ class IO::Hexdump < IO
   end
 
   def write(buf : Bytes) : Int64
-    return 0i64 if buf.empty?
-
+    return 0_i64 if buf.empty?
     @io.write(buf).tap do
       @output.puts buf.hexdump if @write
     end
+    0_i64
   end
 
   delegate :peek, :close, :closed?, :flush, :tty?, :pos, :pos=, :seek, to: @io


### PR DESCRIPTION
…Int64 but it is returning (Int64 | Nil)

Since https://github.com/kalinon/mongo.cr migrated from the crystal 0.34.0 -> 0.35.0
I use this dependence in many projects. And everything is broken because of a
`` Error: method must return Int64 but it returns (Int64 | Nil) ''
In /usr/local/Cellar/crystal/0.35.0/src/io/hexdump.cr:35:28

I just offered a basic fix

```
In src/main.cr:1:1

 1 | require "./Service/run"
     ^
Error: while requiring "./Service/run"


In src/Service/run.cr:1:1

 1 | require "../Layer/Layer"
     ^
Error: while requiring "../Layer/Layer"


In src/Layer/Layer.cr:1:1

 1 | require "./modules/RESTful/*"
     ^
Error: while requiring "./modules/RESTful/*"


In src/Layer/modules/RESTful/API.cr:2:1

 2 | require "./Routing"
     ^
Error: while requiring "./Routing"


In src/Layer/modules/RESTful/Routing.cr:3:1

 3 | require "./toolbar/Toolbar"
     ^
Error: while requiring "./toolbar/Toolbar"


In src/Layer/modules/RESTful/toolbar/Toolbar.cr:3:1

 3 | require "./stickynote/StickyNote"
     ^
Error: while requiring "./stickynote/StickyNote"


In src/Layer/modules/RESTful/toolbar/stickynote/StickyNote.cr:2:1

 2 | require "mongo"
     ^
Error: while requiring "mongo"


In lib/mongo/src/mongo.cr:45:10

 45 | self.log(level, String.new(domain), String.new(msg))
           ^--
Error: instantiating 'Mongo:Module#log(LibMongoC::LogLevel, String, String)'


In lib/mongo/src/mongo.cr:28:11

 28 | Log.error { msg }
          ^----
Error: instantiating 'Log#error()'


In /usr/local/Cellar/crystal/0.35.0/src/log/log.cr:36:3

 36 | {% for method, severity in {
      ^
Error: expanding macro


There was a problem expanding macro 'macro_4642242384'

Called macro defined in /usr/local/Cellar/crystal/0.35.0/src/log/log.cr:36:3

 36 | {% for method, severity in {

Which expanded to:

 >   1 |
 >   2 |     # Logs a message if the logger's current severity is lower or equal to `0`.
 >   3 |     def trace(*, exception : Exception? = nil)
 >   4 |       severity = Severity.new(0)
 >   5 |       return unless level <= severity
 >   6 |
 >   7 |       return unless backend = @backend
 >   8 |
 >   9 |       dsl = Emitter.new(@source, severity, exception)
 >  10 |       result = yield dsl
 >  11 |       entry =
 >  12 |         case result
 >  13 |         when Entry
 >  14 |           result
 >  15 |         else
 >  16 |           dsl.emit(result.to_s)
 >  17 |         end
 >  18 |
 >  19 |       backend.write entry
 >  20 |     end
 >  21 |
 >  22 |     # Logs a message if the logger's current severity is lower or equal to `1`.
 >  23 |     def debug(*, exception : Exception? = nil)
 >  24 |       severity = Severity.new(1)
 >  25 |       return unless level <= severity
 >  26 |
 >  27 |       return unless backend = @backend
 >  28 |
 >  29 |       dsl = Emitter.new(@source, severity, exception)
 >  30 |       result = yield dsl
 >  31 |       entry =
 >  32 |         case result
 >  33 |         when Entry
 >  34 |           result
 >  35 |         else
 >  36 |           dsl.emit(result.to_s)
 >  37 |         end
 >  38 |
 >  39 |       backend.write entry
 >  40 |     end
 >  41 |
 >  42 |     # Logs a message if the logger's current severity is lower or equal to `2`.
 >  43 |     def info(*, exception : Exception? = nil)
 >  44 |       severity = Severity.new(2)
 >  45 |       return unless level <= severity
 >  46 |
 >  47 |       return unless backend = @backend
 >  48 |
 >  49 |       dsl = Emitter.new(@source, severity, exception)
 >  50 |       result = yield dsl
 >  51 |       entry =
 >  52 |         case result
 >  53 |         when Entry
 >  54 |           result
 >  55 |         else
 >  56 |           dsl.emit(result.to_s)
 >  57 |         end
 >  58 |
 >  59 |       backend.write entry
 >  60 |     end
 >  61 |
 >  62 |     # Logs a message if the logger's current severity is lower or equal to `3`.
 >  63 |     def notice(*, exception : Exception? = nil)
 >  64 |       severity = Severity.new(3)
 >  65 |       return unless level <= severity
 >  66 |
 >  67 |       return unless backend = @backend
 >  68 |
 >  69 |       dsl = Emitter.new(@source, severity, exception)
 >  70 |       result = yield dsl
 >  71 |       entry =
 >  72 |         case result
 >  73 |         when Entry
 >  74 |           result
 >  75 |         else
 >  76 |           dsl.emit(result.to_s)
 >  77 |         end
 >  78 |
 >  79 |       backend.write entry
 >  80 |     end
 >  81 |
 >  82 |     # Logs a message if the logger's current severity is lower or equal to `4`.
 >  83 |     def warn(*, exception : Exception? = nil)
 >  84 |       severity = Severity.new(4)
 >  85 |       return unless level <= severity
 >  86 |
 >  87 |       return unless backend = @backend
 >  88 |
 >  89 |       dsl = Emitter.new(@source, severity, exception)
 >  90 |       result = yield dsl
 >  91 |       entry =
 >  92 |         case result
 >  93 |         when Entry
 >  94 |           result
 >  95 |         else
 >  96 |           dsl.emit(result.to_s)
 >  97 |         end
 >  98 |
 >  99 |       backend.write entry
 > 100 |     end
 > 101 |
 > 102 |     # Logs a message if the logger's current severity is lower or equal to `5`.
 > 103 |     def error(*, exception : Exception? = nil)
 > 104 |       severity = Severity.new(5)
 > 105 |       return unless level <= severity
 > 106 |
 > 107 |       return unless backend = @backend
 > 108 |
 > 109 |       dsl = Emitter.new(@source, severity, exception)
 > 110 |       result = yield dsl
 > 111 |       entry =
 > 112 |         case result
 > 113 |         when Entry
 > 114 |           result
 > 115 |         else
 > 116 |           dsl.emit(result.to_s)
 > 117 |         end
 > 118 |
 > 119 |       backend.write entry
 > 120 |     end
 > 121 |
 > 122 |     # Logs a message if the logger's current severity is lower or equal to `6`.
 > 123 |     def fatal(*, exception : Exception? = nil)
 > 124 |       severity = Severity.new(6)
 > 125 |       return unless level <= severity
 > 126 |
 > 127 |       return unless backend = @backend
 > 128 |
 > 129 |       dsl = Emitter.new(@source, severity, exception)
 > 130 |       result = yield dsl
 > 131 |       entry =
 > 132 |         case result
 > 133 |         when Entry
 > 134 |           result
 > 135 |         else
 > 136 |           dsl.emit(result.to_s)
 > 137 |         end
 > 138 |
 > 139 |       backend.write entry
 > 140 |     end
 > 141 |
Error: instantiating 'Log::Backend+#write(Log::Entry)'


In /usr/local/Cellar/crystal/0.35.0/src/log/io_backend.cr:11:12

 11 | @mutex.synchronize do
             ^----------
Error: instantiating 'Mutex#synchronize()'


In /usr/local/Cellar/crystal/0.35.0/src/log/io_backend.cr:11:12

 11 | @mutex.synchronize do
             ^----------
Error: instantiating 'Mutex#synchronize()'


In /usr/local/Cellar/crystal/0.35.0/src/log/io_backend.cr:12:7

 12 | format(entry)
      ^-----
Error: instantiating 'format(Log::Entry)'


In /usr/local/Cellar/crystal/0.35.0/src/log/io_backend.cr:21:16

 21 | @formatter.format(entry, io)
                 ^-----
Error: instantiating 'Log::Formatter#format(Log::Entry, IO+)'


In /usr/local/Cellar/crystal/0.35.0/src/log/format.cr:149:22

 149 | new(entry, io).run
                      ^--
Error: instantiating 'Log::StaticFormatter+#run()'


In /usr/local/Cellar/crystal/0.35.0/src/log/format.cr:197:43

 197 | Log.define_formatter Log::ShortFormat, "#{timestamp} #{severity} - #{source(after: ": ")}#{message}" \
                                                 ^--------
Error: instantiating 'timestamp()'


In /usr/local/Cellar/crystal/0.35.0/src/log/format.cr:66:24

 66 | @entry.timestamp.to_rfc3339(@io, fraction_digits: 6)
                       ^---------
Error: instantiating 'Time#to_rfc3339(IO+)'


In /usr/local/Cellar/crystal/0.35.0/src/time.cr:1125:22

 1125 | Format::RFC_3339.format(to_utc, io, fraction_digits)
                         ^-----
Error: instantiating 'Time::Format::RFC_3339:Module#format(Time, IO+, Int32)'


In /usr/local/Cellar/crystal/0.35.0/src/time/format/custom/rfc_3339.cr:14:17

 14 | formatter.rfc_3339(fraction_digits: fraction_digits)
                ^-------
Error: instantiating 'Time::Format::Formatter#rfc_3339()'


In /usr/local/Cellar/crystal/0.35.0/src/time/format/custom/rfc_3339.cr:28:7

 28 | year_month_day
      ^-------------
Error: instantiating 'year_month_day()'


In /usr/local/Cellar/crystal/0.35.0/src/time/format/pattern.cr:191:7

 191 | year
       ^---
Error: instantiating 'year()'


In /usr/local/Cellar/crystal/0.35.0/src/time/format/formatter.cr:15:7

 15 | pad4(time.year, '0')
      ^---
Error: instantiating 'pad4(Int32, Char)'


In /usr/local/Cellar/crystal/0.35.0/src/time/format/formatter.cr:260:10

 260 | io.write_byte padding.ord.to_u8 if value < 1000
          ^---------
Error: instantiating 'IO+#write_byte(UInt8)'


In /usr/local/Cellar/crystal/0.35.0/src/io/buffered.cr:177:14

 177 | return super
              ^----
Error: instantiating 'super(UInt8)'


In /usr/local/Cellar/crystal/0.35.0/src/io.cr:847:5

 847 | write Slice.new(pointerof(x), 1)
       ^----
Error: instantiating 'write(Slice(UInt8))'


In /usr/local/Cellar/crystal/0.35.0/src/io/buffered.cr:141:7

 141 | unbuffered_write(slice)
       ^---------------
Error: instantiating 'unbuffered_write(Slice(UInt8))'


In /usr/local/Cellar/crystal/0.35.0/src/http/server/response.cr:203:9

 203 | ensure_headers_written
       ^---------------------
Error: instantiating 'ensure_headers_written()'


In /usr/local/Cellar/crystal/0.35.0/src/http/server/response.cr:242:30

 242 | response.cookies.add_response_headers(response.headers)
                        ^-------------------
Error: instantiating 'HTTP::Cookies#add_response_headers(HTTP::Headers)'


In /usr/local/Cellar/crystal/0.35.0/src/http/cookie.cr:309:42

 309 | headers.add("Set-Cookie", cookie.to_set_cookie_header)
                                        ^-------------------
Error: instantiating 'HTTP::Cookie#to_set_cookie_header()'


In /usr/local/Cellar/crystal/0.35.0/src/http/cookie.cr:40:14

 40 | String.build do |header|
             ^----
Error: instantiating 'String.class#build()'


In /usr/local/Cellar/crystal/0.35.0/src/string.cr:271:21

 271 | String::Builder.build(capacity) do |builder|
                       ^----
Error: instantiating 'String::Builder.class#build(Int32)'


In /usr/local/Cellar/crystal/0.35.0/src/string.cr:271:21

 271 | String::Builder.build(capacity) do |builder|
                       ^----
Error: instantiating 'String::Builder.class#build(Int32)'


In /usr/local/Cellar/crystal/0.35.0/src/http/cookie.cr:40:14

 40 | String.build do |header|
             ^----
Error: instantiating 'String.class#build()'


In /usr/local/Cellar/crystal/0.35.0/src/http/cookie.cr:44:37

 44 | header << "; expires=#{HTTP.format_time(expires)}" if expires
                                  ^----------
Error: instantiating 'HTTP:Module#format_time(Time)'


In /usr/local/Cellar/crystal/0.35.0/src/http/common.cr:366:29

 366 | Time::Format::HTTP_DATE.format(time)
                               ^-----
Error: instantiating 'Time::Format::HTTP_DATE:Module#format(Time)'


In /usr/local/Cellar/crystal/0.35.0/src/time/format/custom/http_date.cr:41:14

 41 | String.build do |io|
             ^----
Error: instantiating 'String.class#build()'


In /usr/local/Cellar/crystal/0.35.0/src/string.cr:271:21

 271 | String::Builder.build(capacity) do |builder|
                       ^----
Error: instantiating 'String::Builder.class#build(Int32)'


In /usr/local/Cellar/crystal/0.35.0/src/string.cr:271:21

 271 | String::Builder.build(capacity) do |builder|
                       ^----
Error: instantiating 'String::Builder.class#build(Int32)'


In /usr/local/Cellar/crystal/0.35.0/src/time/format/custom/http_date.cr:41:14

 41 | String.build do |io|
             ^----
Error: instantiating 'String.class#build()'


In /usr/local/Cellar/crystal/0.35.0/src/time/format/custom/http_date.cr:42:9

 42 | format(time, io)
      ^-----
Error: instantiating 'format(Time, String::Builder)'


In /usr/local/Cellar/crystal/0.35.0/src/time/format/custom/http_date.cr:33:17

 33 | formatter.rfc_2822(time_zone_gmt: true, two_digit_day: true)
                ^-------
Error: instantiating 'Time::Format::Formatter#rfc_2822()'


In /usr/local/Cellar/crystal/0.35.0/src/time/format/custom/rfc_2822.cr:31:7

 31 | short_day_name_with_comma?
      ^-------------------------
Error: instantiating 'short_day_name_with_comma?()'


In /usr/local/Cellar/crystal/0.35.0/src/time/format/formatter.cr:99:7

 99 | short_day_name
      ^-------------
Error: instantiating 'short_day_name()'


In /usr/local/Cellar/crystal/0.35.0/src/time/format/formatter.cr:91:10

 91 | io << get_short_day_name
         ^-
Error: instantiating 'IO+#<<(String)'


In /usr/local/Cellar/crystal/0.35.0/src/io.cr:175:9

 175 | obj.to_s self
           ^---
Error: instantiating 'String#to_s(IO+)'


In /usr/local/Cellar/crystal/0.35.0/src/string.cr:4789:8

 4789 | io.write_utf8(to_slice)
           ^---------
Error: instantiating 'IO+#write_utf8(Slice(UInt8))'


In /usr/local/Cellar/crystal/0.35.0/src/io.cr:469:15

 469 | encoder.write(self, slice)
               ^----
Error: instantiating 'IO::Encoder#write(IO+, Slice(UInt8))'


In /usr/local/Cellar/crystal/0.35.0/src/io/encoding.cr:42:30

 42 | bytes_written &+= io.write(outbuf.to_slice[0, outbuf.size - outbytesleft])
                           ^----
Error: instantiating 'IO+#write(Slice(UInt8))'


In /usr/local/Cellar/crystal/0.35.0/src/http/web_socket/protocol.cr:63:9

 63 | flush(final: false)
      ^----
Error: instantiating 'flush()'


In /usr/local/Cellar/crystal/0.35.0/src/http/web_socket/protocol.cr:78:18

 78 | @websocket.send(
                 ^---
Error: instantiating 'HTTP::WebSocket::Protocol#send(Slice(UInt8), HTTP::WebSocket::Protocol::Opcode)'


In /usr/local/Cellar/crystal/0.35.0/src/http/web_socket/protocol.cr:104:5

 104 | write_header(data.size, opcode, flags)
       ^-----------
Error: instantiating 'write_header(Int32, HTTP::WebSocket::Protocol::Opcode, HTTP::WebSocket::Protocol::Flags)'


In /usr/local/Cellar/crystal/0.35.0/src/http/web_socket/protocol.cr:122:9

 122 | @io.write_byte(flags.value | opcode.value)
           ^---------
Error: instantiating 'IO+#write_byte(UInt8)'


In /usr/local/Cellar/crystal/0.35.0/src/io/buffered.cr:177:14

 177 | return super
              ^----
Error: instantiating 'super(UInt8)'


In /usr/local/Cellar/crystal/0.35.0/src/io.cr:847:5

 847 | write Slice.new(pointerof(x), 1)
       ^----
Error: instantiating 'write(Slice(UInt8))'


In /usr/local/Cellar/crystal/0.35.0/src/io/buffered.cr:148:9

 148 | flush
       ^----
Error: instantiating 'flush()'


In /usr/local/Cellar/crystal/0.35.0/src/io/buffered.cr:229:5

 229 | unbuffered_flush
       ^---------------
Error: instantiating 'unbuffered_flush()'


In /usr/local/Cellar/crystal/0.35.0/src/openssl/ssl/socket.cr:150:13

 150 | @bio.io.flush
               ^----
Error: instantiating 'IO+#flush()'


In /usr/local/Cellar/crystal/0.35.0/src/http/server/response.cr:108:15

 108 | @output.flush
               ^----
Error: instantiating 'IO+#flush()'


In /usr/local/Cellar/crystal/0.35.0/src/io/buffered.cr:229:5

 229 | unbuffered_flush
       ^---------------
Error: instantiating 'unbuffered_flush()'


In /usr/local/Cellar/crystal/0.35.0/src/http/server/response.cr:258:13

 258 | @io.flush
           ^----
Error: instantiating 'IO+#flush()'


In /usr/local/Cellar/crystal/0.35.0/src/compress/gzip/writer.cr:96:16

 96 | flate_io = write_header
                 ^-----------
Error: instantiating 'write_header()'


In /usr/local/Cellar/crystal/0.35.0/src/compress/gzip/writer.cr:118:14

 118 | header.to_io(@io)
              ^----
Error: instantiating 'Compress::Gzip::Header#to_io(IO+)'


In /usr/local/Cellar/crystal/0.35.0/src/compress/gzip/header.cr:66:8

 66 | io.write_byte ID1
         ^---------
Error: instantiating 'IO+#write_byte(UInt8)'


In /usr/local/Cellar/crystal/0.35.0/src/io/stapled.cr:71:13

 71 | @writer.write_byte(byte)
              ^---------
Error: instantiating 'IO+#write_byte(UInt8)'


In /usr/local/Cellar/crystal/0.35.0/src/io.cr:847:5

 847 | write Slice.new(pointerof(x), 1)
       ^----
Error: instantiating 'write(Slice(UInt8))'


In /usr/local/Cellar/crystal/0.35.0/src/http/server/response.cr:86:15

 86 | @output.write(slice)
              ^----
Error: instantiating 'IO+#write(Slice(UInt8))'


In /usr/local/Cellar/crystal/0.35.0/src/compress/deflate/writer.cr:53:5

 53 | consume_output LibZ::Flush::NO_FLUSH
      ^-------------
Error: instantiating 'consume_output(LibZ::Flush)'


In /usr/local/Cellar/crystal/0.35.0/src/compress/deflate/writer.cr:92:5

 92 | loop do
      ^---
Error: instantiating 'loop()'


In /usr/local/Cellar/crystal/0.35.0/src/compress/deflate/writer.cr:92:5

 92 | loop do
      ^---
Error: instantiating 'loop()'


In /usr/local/Cellar/crystal/0.35.0/src/compress/deflate/writer.cr:96:15

 96 | @output.write(@buf.to_slice[0, @buf.size - @stream.avail_out])
              ^----
Error: instantiating 'IO+#write(Slice(UInt8))'


In /usr/local/Cellar/crystal/0.35.0/src/openssl/digest/digest_io.cr:51:10

 51 | io.write(slice)
         ^----
Error: instantiating 'IO+#write(Slice(UInt8))'


In /usr/local/Cellar/crystal/0.35.0/src/io/stapled.cr:80:13

 80 | @writer.write(slice)
              ^----
Error: instantiating 'IO+#write(Slice(UInt8))'


In /usr/local/Cellar/crystal/0.35.0/src/io/multi_writer.cr:37:14

 37 | @writers.each { |writer| writer.write(slice) }
               ^---
Error: instantiating 'Array(IO)#each()'


In /usr/local/Cellar/crystal/0.35.0/src/indexable.cr:187:5

 187 | each_index do |i|
       ^---------
Error: instantiating 'each_index()'


In /usr/local/Cellar/crystal/0.35.0/src/indexable.cr:187:5

 187 | each_index do |i|
       ^---------
Error: instantiating 'each_index()'


In /usr/local/Cellar/crystal/0.35.0/src/io/multi_writer.cr:37:14

 37 | @writers.each { |writer| writer.write(slice) }
               ^---
Error: instantiating 'Array(IO)#each()'


In /usr/local/Cellar/crystal/0.35.0/src/io/multi_writer.cr:37:37

 37 | @writers.each { |writer| writer.write(slice) }
                                      ^----
Error: instantiating 'IO+#write(Slice(UInt8))'


In /usr/local/Cellar/crystal/0.35.0/src/io/hexdump.cr:35:28

 35 | def write(buf : Bytes) : Int64
                               ^
Error: method must return Int64 but it is returning (Int64 | Nil)

Nil trace:

  /usr/local/Cellar/crystal/0.35.0/src/io/hexdump.cr:36

        return 0i64 if buf.empty?


  /usr/local/Cellar/crystal/0.35.0/src/io/hexdump.cr:38

        @io.write(buf).tap do
                       ^~~

  /usr/local/Cellar/crystal/0.35.0/src/object.cr:186

      def tap
          ^~~

  /usr/local/Cellar/crystal/0.35.0/src/object.cr:187

        yield self


  /usr/local/Cellar/crystal/0.35.0/src/object.cr:188

        self
```