### PR TITLE
Parser: apply string pieces combination even if heredoc has no indent

### DIFF
--- a/spec/compiler/formatter/formatter_spec.cr
+++ b/spec/compiler/formatter/formatter_spec.cr
@@ -999,6 +999,8 @@ describe Crystal::Formatter do
   assert_format "<<-FOO\n#{"foo"}bar\nFOO"
   assert_format "<<-FOO\nbar#{"foo"}\nFOO"
   assert_format "<<-FOO\nbar#{"foo"}bar\nFOO"
+  assert_format "<<-FOO\nfoo\n#{"foo"}\nFOO"
+  assert_format "<<-FOO\nfoo\n#{1}\nFOO"
 
   assert_format "#!shebang\n1 + 2"
 

--- a/src/compiler/crystal/syntax/parser.cr
+++ b/src/compiler/crystal/syntax/parser.cr
@@ -2145,7 +2145,7 @@ module Crystal
     end
 
     def needs_heredoc_indent_removed?(delimiter_state)
-      delimiter_state.kind == :heredoc && delimiter_state.heredoc_indent > 0
+      delimiter_state.kind == :heredoc && delimiter_state.heredoc_indent >= 0
     end
 
     def remove_heredoc_indent(pieces : Array, indent)


### PR DESCRIPTION
Fixed #9473

It is important to simplify the formatter implementation.