### PR TITLE
Enable large-file support on i386-linux-gnu

### DIFF
--- a/src/lib_c/i386-linux-gnu/c/dirent.cr
+++ b/src/lib_c/i386-linux-gnu/c/dirent.cr
@@ -7,7 +7,7 @@ lib LibC
 
   struct Dirent
     d_ino : InoT
-    d_off : Long
+    d_off : OffT
     d_reclen : UShort
     d_type : Char
     d_name : StaticArray(Char, 256)
@@ -15,6 +15,6 @@ lib LibC
 
   fun closedir(dirp : DIR*) : Int
   fun opendir(name : Char*) : DIR*
-  fun readdir(dirp : DIR*) : Dirent*
+  fun readdir = readdir64(dirp : DIR*) : Dirent*
   fun rewinddir(dirp : DIR*) : Void
 end

--- a/src/lib_c/i386-linux-gnu/c/fcntl.cr
+++ b/src/lib_c/i386-linux-gnu/c/fcntl.cr
@@ -28,5 +28,5 @@ lib LibC
   end
 
   fun fcntl(fd : Int, cmd : Int, ...) : Int
-  fun open(file : Char*, oflag : Int, ...) : Int
+  fun open = open64(file : Char*, oflag : Int, ...) : Int
 end

--- a/src/lib_c/i386-linux-gnu/c/stdlib.cr
+++ b/src/lib_c/i386-linux-gnu/c/stdlib.cr
@@ -13,8 +13,8 @@ lib LibC
   fun free(ptr : Void*) : Void
   fun getenv(name : Char*) : Char*
   fun malloc(size : SizeT) : Void*
-  fun mkstemp(template : Char*) : Int
-  fun mkstemps(template : Char*, suffixlen : Int) : Int
+  fun mkstemp = mkstemp64(template : Char*) : Int
+  fun mkstemps = mkstemps64(template : Char*, suffixlen : Int) : Int
   fun putenv(string : Char*) : Int
   fun realloc(ptr : Void*, size : SizeT) : Void*
   fun realpath(name : Char*, resolved : Char*) : Char*

--- a/src/lib_c/i386-linux-gnu/c/sys/mman.cr
+++ b/src/lib_c/i386-linux-gnu/c/sys/mman.cr
@@ -24,7 +24,7 @@ lib LibC
   MADV_HUGEPAGE         = 14
   MADV_NOHUGEPAGE       = 15
 
-  fun mmap(addr : Void*, len : SizeT, prot : Int, flags : Int, fd : Int, offset : OffT) : Void*
+  fun mmap = mmap64(addr : Void*, len : SizeT, prot : Int, flags : Int, fd : Int, offset : OffT) : Void*
   fun mprotect(addr : Void*, len : SizeT, prot : Int) : Int
   fun munmap(addr : Void*, len : SizeT) : Int
   fun madvise(addr : Void*, len : SizeT, advice : Int) : Int

--- a/src/lib_c/i386-linux-gnu/c/sys/stat.cr
+++ b/src/lib_c/i386-linux-gnu/c/sys/stat.cr
@@ -29,7 +29,7 @@ lib LibC
   struct Stat
     st_dev : DevT
     __pad1 : UShort
-    st_ino : InoT
+    __st_ino : ULong
     st_mode : ModeT
     st_nlink : NlinkT
     st_uid : UidT
@@ -42,16 +42,15 @@ lib LibC
     st_atim : Timespec
     st_mtim : Timespec
     st_ctim : Timespec
-    __unused4 : ULong
-    __unused5 : ULong
+    st_ino : InoT
   end
 
   fun chmod(file : Char*, mode : ModeT) : Int
-  fun fstat(fd : Int, buf : Stat*) : Int
-  fun lstat(file : Char*, buf : Stat*) : Int
+  fun fstat = fstat64(fd : Int, buf : Stat*) : Int
+  fun lstat = lstat64(file : Char*, buf : Stat*) : Int
   fun mkdir(path : Char*, mode : ModeT) : Int
   fun mkfifo(path : Char*, mode : ModeT) : Int
   fun mknod(path : Char*, mode : ModeT, dev : DevT) : Int
-  fun stat(file : Char*, buf : Stat*) : Int
+  fun stat = stat64(file : Char*, buf : Stat*) : Int
   fun umask(mask : ModeT) : ModeT
 end

--- a/src/lib_c/i386-linux-gnu/c/sys/types.cr
+++ b/src/lib_c/i386-linux-gnu/c/sys/types.cr
@@ -2,17 +2,17 @@ require "../stddef"
 require "../stdint"
 
 lib LibC
-  alias BlkcntT = Long
+  alias BlkcntT = LongLong
   alias BlksizeT = Long
   alias ClockT = Long
   alias ClockidT = Int
   alias DevT = ULongLong
   alias GidT = UInt
   alias IdT = UInt
-  alias InoT = ULong
+  alias InoT = ULongLong
   alias ModeT = UInt
   alias NlinkT = UInt
-  alias OffT = Long
+  alias OffT = LongLong
   alias PidT = Int
 
   union PthreadAttrT

--- a/src/lib_c/i386-linux-gnu/c/unistd.cr
+++ b/src/lib_c/i386-linux-gnu/c/unistd.cr
@@ -21,7 +21,7 @@ lib LibC
   @[ReturnsTwice]
   fun fork : PidT
   fun fsync(fd : Int) : Int
-  fun ftruncate(fd : Int, length : OffT) : Int
+  fun ftruncate = ftruncate64(fd : Int, length : OffT) : Int
   fun getcwd(buf : Char*, size : SizeT) : Char*
   fun gethostname(name : Char*, len : SizeT) : Int
   fun getpgid(pid : PidT) : PidT
@@ -31,11 +31,11 @@ lib LibC
   fun ttyname_r(fd : Int, buf : Char*, buffersize : SizeT) : Int
   fun lchown(file : Char*, owner : UidT, group : GidT) : Int
   fun link(from : Char*, to : Char*) : Int
-  fun lockf(fd : Int, cmd : Int, len : OffT) : Int
-  fun lseek(fd : Int, offset : OffT, whence : Int) : OffT
+  fun lockf = lockf64(fd : Int, cmd : Int, len : OffT) : Int
+  fun lseek = lseek64(fd : Int, offset : OffT, whence : Int) : OffT
   fun pipe(pipedes : StaticArray(Int, 2)) : Int
   fun read(fd : Int, buf : Void*, nbytes : SizeT) : SSizeT
-  fun pread(x0 : Int, x1 : Void*, x2 : SizeT, x3 : OffT) : SSizeT
+  fun pread = pread64(x0 : Int, x1 : Void*, x2 : SizeT, x3 : OffT) : SSizeT
   fun rmdir(path : Char*) : Int
   fun symlink(from : Char*, to : Char*) : Int
   fun readlink(path : Char*, buf : Char*, size : SizeT) : SSizeT


### PR DESCRIPTION
#9463, https://github.com/crystal-lang/crystal/issues/9297#issuecomment-640078900

Without large-file support `File.open`, `File.info`, `Dir#read` fail for files whose size is larger than 2G or whose inode number is larger than 4G on 32-bit linux.

This commit enables large-file support by using type definitions, function names and structure members when `_FILE_OFFSET_BITS=64` is defined in C.
