### PR TITLE
Fix error while parsing the subcommand with a hyphen

### DIFF
--- a/spec/std/option_parser_spec.cr
+++ b/spec/std/option_parser_spec.cr
@@ -612,4 +612,31 @@ describe "OptionParser" do
     bar.should be_false
     args.should eq(%w(file --bar))
   end
+
+  it "handles subcommands with hyphen" do
+    args = %w(--verbose sub-command --foo 1 --bar sub2 -z)
+    verbose = false
+    subcommand = false
+    foo = nil
+    bar = false
+    sub2 = false
+    z = false
+    OptionParser.parse(args) do |opts|
+      opts.on("sub-command", "") do
+        subcommand = true
+        opts.on("--foo arg", "") { |v| foo = v }
+        opts.on("--bar", "") { bar = true }
+        opts.on("sub2", "") { sub2 = true }
+      end
+      opts.on("--verbose", "") { verbose = true }
+      opts.on("-z", "--baz", "") { z = true }
+    end
+
+    verbose.should be_true
+    subcommand.should be_true
+    foo.should be("1")
+    bar.should be_true
+    sub2.should be_true
+    z.should be_true
+  end
 end

--- a/src/option_parser.cr
+++ b/src/option_parser.cr
@@ -212,7 +212,7 @@ class OptionParser
       {flag, FlagValue::None}
     when /-(.)\s*\[\S+\]/
       {flag[0..1], FlagValue::Optional}
-    when /-(.)\s+\S+/, /-(.)\s+/, /-(.)\S+/
+    when /-(.)\s+\S+/, /-(.)\s+/, /^-(.)\S+/
       {flag[0..1], FlagValue::Required}
     else
       # This happens for -f without argument


### PR DESCRIPTION
Subcommands can have a hyphen in the name. The parser treats this as
a flag and some junk value. For example, `sub-command` matches the
pattern `/-(.)\S+/` and sets flag as `su`(First two letters) and
Value Required for this flag(`FlagValue::Required`).

With this PR, Regex is modified to check if hyphen exists in the
beginning or not.

Signed-off-by: Aravinda Vishwanathapura <mail@aravindavk.in>