### PR TITLE
Workaround slow compile times for big StaticArray

### DIFF
--- a/src/static_array.cr
+++ b/src/static_array.cr
@@ -62,11 +62,13 @@ struct StaticArray(T, N)
   # ```
   # StaticArray(Int32, 3).new { |i| i * 2 } # => StaticArray[0, 2, 4]
   # ```
-  def self.new(&block : Int32 -> T)
+  def self.new(& : Int32 -> T)
     array = uninitialized self
-    N.times do |i|
-      array.to_unsafe[i] = yield i
-    end
+    buf = array.to_unsafe
+    # Unroll the loop in Crystal land to avoid slow compile times in release mode. See https://github.com/crystal-lang/crystal/issues/2485#issuecomment-644416515
+    {% for i in 0...N %}
+      buf[{{i}}] = yield {{i}}
+    {% end %}
     array
   end
 


### PR DESCRIPTION
Fixes #2485.

I didn't add details on the commit message, having no knowledge of what is causing this slow compile times in the background with LLVM - be free to edit it if somebody wants.