### PR TITLE
Fix type of HTTP::Server::Response#closed? to Bool

### DIFF
--- a/src/http/server/response.cr
+++ b/src/http/server/response.cr
@@ -175,6 +175,7 @@ class HTTP::Server
 
       def initialize(@io)
         @chunked = false
+        @closed = false
       end
 
       def reset
@@ -215,7 +216,7 @@ class HTTP::Server
         raise ClientError.new("Error while writing data to the client", ex)
       end
 
-      def closed?
+      def closed? : Bool
         @closed
       end
 


### PR DESCRIPTION
Without this, the type of `@closed` and `#closed?` is `Bool | Nil`.