### PR TITLE
Semantic: handle typedef type restriction against alias type correctly

### DIFF
--- a/spec/compiler/semantic/restrictions_spec.cr
+++ b/spec/compiler/semantic/restrictions_spec.cr
@@ -716,4 +716,21 @@ describe "Restrictions" do
       foo(Int32)
       )) { int32 }
   end
+
+  it "restricts aliased typedef type (#9474)" do
+    assert_type(%(
+      lib A
+        alias B = Int32
+      end
+
+      alias C = A::B
+
+      def foo(x : C)
+        1
+      end
+
+      x = uninitialized C
+      foo x
+      )) { int32 }
+  end
 end

--- a/src/compiler/crystal/semantic/restrictions.cr
+++ b/src/compiler/crystal/semantic/restrictions.cr
@@ -1016,6 +1016,12 @@ module Crystal
       super
     end
 
+    def restrict(other : AliasType, context)
+      other = other.remove_alias
+      return self if self == other
+      restrict(other, context)
+    end
+
     def restrict(other : Type, context)
       return self if self == other
 


### PR DESCRIPTION
Fixed #9474

Alias type should be resolved before typedef type resolution. Because it causes a problem like the issue when alias type points typedef type.

Thank you @HertzDevil.