### PR TITLE
Fix multidispatch on hierarchy with autocasting

### DIFF
--- a/spec/compiler/codegen/automatic_cast.cr
+++ b/spec/compiler/codegen/automatic_cast.cr
@@ -239,4 +239,25 @@ describe "Code gen: automatic cast" do
       foo(1, "a" || 1)
       )).to_i.should eq(20)
   end
+
+  it "does multidispatch with automatic casting (3)" do
+    run(%(
+      abstract class Foo
+      end
+
+      class Bar < Foo
+        def foo(x : UInt8)
+          2
+        end
+      end
+
+      class Baz < Foo
+        def foo(x : UInt8)
+          3
+        end
+      end
+
+      Bar.new.as(Foo).foo(1)
+      )).to_i.should eq(2)
+  end
 end

--- a/src/compiler/crystal/semantic/call.cr
+++ b/src/compiler/crystal/semantic/call.cr
@@ -368,9 +368,10 @@ class Crystal::Call
       # matches and they were not ambiguous). If so, only keep matches up to
       # that exact match. We need to do this here because with autocasting
       # we consider all overloads to detect ambiguous usage.
-      stop_index = matches.index do |match|
+      stop_index = matches.matches.try &.rindex do |match|
         signature.matches_exactly?(match, with_literals: true)
       end
+
       matches = matches[..stop_index] if stop_index
     end
 


### PR DESCRIPTION
This fixes another case of multidispatch with autocasting, this time when a call is made over a hierarchy. Thanks @asterite for the patch.