### PR TITLE
Workaround block type restriction on Digest::Base

### DIFF
--- a/spec/std/digest/base.cr
+++ b/spec/std/digest/base.cr
@@ -1,0 +1,23 @@
+macro acts_as_digest_base(type)
+  it "#hexdigest can update within a loop from explicit type (#9483)" do
+    i = 0
+    {{type}}.hexdigest do |digest|
+      while i < 3
+        digest.update("")
+        i += 1
+      end
+    end
+  end
+
+  it "#hexdigest can update within a loop by indirect type (#9483)" do
+    algorithm = {} of String => Digest::Base.class
+    algorithm["me"] = {{type}}
+    i = 0
+    algorithm["me"].hexdigest do |digest|
+      while i < 3
+        digest.update("")
+        i += 1
+      end
+    end
+  end
+end

--- a/spec/std/digest/md5_spec.cr
+++ b/spec/std/digest/md5_spec.cr
@@ -1,7 +1,10 @@
 require "spec"
+require "./base"
 require "digest/md5"
 
 describe Digest::MD5 do
+  acts_as_digest_base Digest::MD5
+
   it "calculates digest from string" do
     Digest::MD5.digest("foo").to_slice.should eq Bytes[0xac, 0xbd, 0x18, 0xdb, 0x4c, 0xc2, 0xf8, 0x5c, 0xed, 0xef, 0x65, 0x4f, 0xcc, 0xc4, 0xa4, 0xd8]
   end

--- a/spec/std/digest/sha1_spec.cr
+++ b/spec/std/digest/sha1_spec.cr
@@ -1,7 +1,10 @@
 require "spec"
+require "./base"
 require "digest/sha1"
 
 describe Digest::SHA1 do
+  acts_as_digest_base Digest::SHA1
+
   [
     {"", "da39a3ee5e6b4b0d3255bfef95601890afd80709", "2jmj7l5rSw0yVb/vlWAYkK/YBwk="},
     {"The quick brown fox jumps over the lazy dog", "2fd4e1c67a2d28fced849ee1bb76e7391b93eb12", "L9ThxnotKPzthJ7hu3bnORuT6xI="},

--- a/src/digest/base.cr
+++ b/src/digest/base.cr
@@ -25,7 +25,7 @@ abstract class Digest::Base
     # digest.to_slice.hexstring # => "acbd18db4cc2f85cedef654fccc4a4d8"
     # ```
     def self.digest(& : Digest::Base -> _) : Bytes
-      context = new
+      context = new.as(Digest::Base)
       yield context
       context.final
     end


### PR DESCRIPTION
Ref: #9483
Follow-up:  #8426

The added specs add some coverage to untested methods and ensure the use case where the digest algorithm are registered by name and picked there. This way they can be used without explicit mention of the type.