### PR TITLE
Fix key type restriction of `Hash#merge` block

### DIFF
--- a/spec/std/hash_spec.cr
+++ b/spec/std/hash_spec.cr
@@ -521,6 +521,14 @@ describe "Hash" do
     result.should eq({:foo => "bar", :foobar => "foo"})
   end
 
+  it "merges other type with block" do
+    h1 = {1 => "foo"}
+    h2 = {1 => "bar", "fizz" => "buzz"}
+
+    h3 = h1.merge(h2) { |k, v1, v2| v1 + v2 }
+    h3.should eq({1 => "foobar", "fizz" => "buzz"})
+  end
+
   it "merges!" do
     h1 = {1 => 2, 3 => 4}
     h2 = {1 => 5, 2 => 3}

--- a/src/hash.cr
+++ b/src/hash.cr
@@ -1399,7 +1399,7 @@ class Hash(K, V)
     hash
   end
 
-  def merge(other : Hash(L, W), &block : K, V, W -> V | W) forall L, W
+  def merge(other : Hash(L, W), &block : L, V, W -> V | W) forall L, W
     hash = Hash(K | L, V | W).new
     hash.merge! self
     hash.merge!(other) { |k, v1, v2| yield k, v1, v2 }


### PR DESCRIPTION
The key type restriction of `Hash#merge` block is wrong. `K` (receiver's key type) is specified, but it yields `L` (argument's key type) value in fact. This type mismatch causes a problem when key type is difference. For instance, the following sample cannot work due to this bug.

```crystal
foo = {1 => "foo"}
bar = {1 => "bar", "fizz" => "buzz"}

p foo.merge(bar) { |k, v1, v2| v1 + v2 }
# Error: argument #1 of yield expected to be Int32, not (Int32 | String)
```

This PR fixes this restriction type into `L` correctly.