### PR TITLE
Split Digest::Base from Digest::Algorithm

### DIFF
--- a/spec/std/digest/algorithm.cr
+++ b/spec/std/digest/algorithm.cr
@@ -1,0 +1,47 @@
+macro acts_as_digest_algorithm(expr)
+  it "#hexdigest can update within a loop from explicit expr (#9483)" do
+    %i = 0
+    {{expr}}.hexdigest do |%digest|
+      while %i < 3
+        %digest.update("")
+        %i += 1
+      end
+    end
+  end
+
+  it "#hexdigest can update within a loop by indirect expr (#9483)" do
+    %algorithm = {} of String => Digest::Algorithm.class
+    %algorithm["me"] = {{expr}}
+    %i = 0
+    %algorithm["me"].hexdigest do |%digest|
+      while %i < 3
+        %digest.update("")
+        %i += 1
+      end
+    end
+  end
+
+  it "context are independent" do
+    %algorithm = {{expr}}
+    %res = %algorithm.hexdigest do |%digest|
+      %digest.update("a")
+      %digest.update("b")
+    end
+
+    %inner_res = nil
+
+    %outer_res = %algorithm.hexdigest do |%outer|
+      %outer.update("a")
+
+      %inner_res = %algorithm.hexdigest do |%inner|
+        %inner.update("a")
+        %inner.update("b")
+      end
+
+      %outer.update("b")
+    end
+
+    %outer_res.should eq(%res)
+    %inner_res.should eq(%res)
+  end
+end

--- a/spec/std/digest/algorithm.cr
+++ b/spec/std/digest/algorithm.cr
@@ -1,47 +1,47 @@
-macro acts_as_digest_algorithm(expr)
+def acts_as_digest_algorithm(type : T.class) forall T
   it "#hexdigest can update within a loop from explicit expr (#9483)" do
-    %i = 0
-    {{expr}}.hexdigest do |%digest|
-      while %i < 3
-        %digest.update("")
-        %i += 1
+    i = 0
+    type.hexdigest do |digest|
+      while i < 3
+        digest.update("")
+        i += 1
       end
     end
   end
 
   it "#hexdigest can update within a loop by indirect expr (#9483)" do
-    %algorithm = {} of String => Digest::Algorithm.class
-    %algorithm["me"] = {{expr}}
-    %i = 0
-    %algorithm["me"].hexdigest do |%digest|
-      while %i < 3
-        %digest.update("")
-        %i += 1
+    algorithm = {} of String => Digest::Algorithm.class
+    algorithm["me"] = type
+    i = 0
+    algorithm["me"].hexdigest do |digest|
+      while i < 3
+        digest.update("")
+        i += 1
       end
     end
   end
 
   it "context are independent" do
-    %algorithm = {{expr}}
-    %res = %algorithm.hexdigest do |%digest|
-      %digest.update("a")
-      %digest.update("b")
+    algorithm = type
+    res = algorithm.hexdigest do |digest|
+      digest.update("a")
+      digest.update("b")
     end
 
-    %inner_res = nil
+    inner_res = nil
 
-    %outer_res = %algorithm.hexdigest do |%outer|
-      %outer.update("a")
+    outer_res = algorithm.hexdigest do |outer|
+      outer.update("a")
 
-      %inner_res = %algorithm.hexdigest do |%inner|
-        %inner.update("a")
-        %inner.update("b")
+      inner_res = algorithm.hexdigest do |inner|
+        inner.update("a")
+        inner.update("b")
       end
 
-      %outer.update("b")
+      outer.update("b")
     end
 
-    %outer_res.should eq(%res)
-    %inner_res.should eq(%res)
+    outer_res.should eq(res)
+    inner_res.should eq(res)
   end
 end

--- a/spec/std/digest/md5_spec.cr
+++ b/spec/std/digest/md5_spec.cr
@@ -1,7 +1,10 @@
 require "spec"
+require "./algorithm"
 require "digest/md5"
 
 describe Digest::MD5 do
+  acts_as_digest_algorithm Digest::MD5
+
   it "calculates digest from string" do
     Digest::MD5.digest("foo").to_slice.should eq Bytes[0xac, 0xbd, 0x18, 0xdb, 0x4c, 0xc2, 0xf8, 0x5c, 0xed, 0xef, 0x65, 0x4f, 0xcc, 0xc4, 0xa4, 0xd8]
   end

--- a/spec/std/digest/sha1_spec.cr
+++ b/spec/std/digest/sha1_spec.cr
@@ -1,7 +1,10 @@
 require "spec"
+require "./algorithm"
 require "digest/sha1"
 
 describe Digest::SHA1 do
+  acts_as_digest_algorithm Digest::SHA1
+
   [
     {"", "da39a3ee5e6b4b0d3255bfef95601890afd80709", "2jmj7l5rSw0yVb/vlWAYkK/YBwk="},
     {"The quick brown fox jumps over the lazy dog", "2fd4e1c67a2d28fced849ee1bb76e7391b93eb12", "L9ThxnotKPzthJ7hu3bnORuT6xI="},

--- a/spec/std/openssl/digest_spec.cr
+++ b/spec/std/openssl/digest_spec.cr
@@ -1,4 +1,5 @@
 require "spec"
+require "../digest/algorithm"
 require "../../../src/openssl"
 
 describe OpenSSL::Digest do
@@ -58,4 +59,8 @@ describe OpenSSL::Digest do
 
     digest.final.hexstring.should eq("2c26b46b68ffc68ff99b453c1d30413413422d706483bfa0f98a5e886266e7ae")
   end
+
+  acts_as_digest_algorithm OpenSSL::Digest::SHA1
+  acts_as_digest_algorithm OpenSSL::Digest::SHA256
+  acts_as_digest_algorithm OpenSSL::Digest::SHA512
 end

--- a/src/digest/base.cr
+++ b/src/digest/base.cr
@@ -4,98 +4,6 @@ class Digest::FinalizedError < Exception
 end
 
 abstract class Digest::Base
-  macro inherited
-    # Returns the hash of *data*. *data* must respond to `#to_slice`.
-    def self.digest(data)
-      digest do |ctx|
-        ctx.update(data.to_slice)
-      end
-    end
-
-    # Yields an instance of `self` which can receive calls to `#update(data : String | Bytes)`
-    # and returns the finalized digest afterwards.
-    #
-    # ```
-    # require "digest/md5"
-    #
-    # digest = Digest::MD5.digest do |ctx|
-    #   ctx.update "f"
-    #   ctx.update "oo"
-    # end
-    # digest.to_slice.hexstring # => "acbd18db4cc2f85cedef654fccc4a4d8"
-    # ```
-    def self.digest(& : Digest::Base -> _) : Bytes
-      context = new
-      yield context
-      context.final
-    end
-
-    # Returns the hexadecimal representation of the hash of *data*.
-    #
-    # ```
-    # require "digest/md5"
-    #
-    # Digest::MD5.hexdigest("foo") # => "acbd18db4cc2f85cedef654fccc4a4d8"
-    # ```
-    def self.hexdigest(data) : String
-      hexdigest &.update(data)
-    end
-
-    # Yields a context object with an `#update(data : String | Bytes)`
-    # method available. Returns the resulting digest in hexadecimal representation
-    # afterwards.
-    #
-    # ```
-    # require "digest/md5"
-    #
-    # Digest::MD5.hexdigest("foo") # => "acbd18db4cc2f85cedef654fccc4a4d8"
-    # Digest::MD5.hexdigest do |ctx|
-    #   ctx.update "f"
-    #   ctx.update "oo"
-    # end
-    # # => "acbd18db4cc2f85cedef654fccc4a4d8"
-    # ```
-    def self.hexdigest(& : Digest::Base -> _) : String
-      hashsum = digest do |ctx|
-        yield ctx
-      end
-
-      hashsum.to_slice.hexstring
-    end
-
-    # Returns the base64-encoded hash of *data*.
-    #
-    # ```
-    # require "digest/sha1"
-    #
-    # Digest::SHA1.base64digest("foo") # => "C+7Hteo/D9vJXQ3UfzxbwnXaijM="
-    # ```
-    def self.base64digest(data) : String
-      base64digest &.update(data)
-    end
-
-    # Yields a context object with an `#update(data : String | Bytes)`
-    # method available. Returns the resulting digest in base64 representation
-    # afterwards.
-    #
-    # ```
-    # require "digest/sha1"
-    #
-    # Digest::SHA1.base64digest do |ctx|
-    #   ctx.update "f"
-    #   ctx.update "oo"
-    # end
-    # # => "C+7Hteo/D9vJXQ3UfzxbwnXaijM="
-    # ```
-    def self.base64digest(& : Digest::Base -> _) : String
-      hashsum = digest do |ctx|
-        yield ctx
-      end
-
-      Base64.strict_encode(hashsum)
-    end
-  end
-
   @finished = false
 
   def update(data) : self
@@ -155,4 +63,96 @@ abstract class Digest::Base
   abstract def reset_impl : Nil
   # Returns the digest output size in bytes.
   abstract def digest_size : Int32
+end
+
+abstract class Digest::Algorithm < Digest::Base
+  # Returns the hash of *data*. *data* must respond to `#to_slice`.
+  def self.digest(data)
+    digest do |ctx|
+      ctx.update(data.to_slice)
+    end
+  end
+
+  # Yields an instance of `self` which can receive calls to `#update(data : String | Bytes)`
+  # and returns the finalized digest afterwards.
+  #
+  # ```
+  # require "digest/md5"
+  #
+  # digest = Digest::MD5.digest do |ctx|
+  #   ctx.update "f"
+  #   ctx.update "oo"
+  # end
+  # digest.to_slice.hexstring # => "acbd18db4cc2f85cedef654fccc4a4d8"
+  # ```
+  def self.digest(& : self -> _) : Bytes
+    context = new
+    yield context
+    context.final
+  end
+
+  # Returns the hexadecimal representation of the hash of *data*.
+  #
+  # ```
+  # require "digest/md5"
+  #
+  # Digest::MD5.hexdigest("foo") # => "acbd18db4cc2f85cedef654fccc4a4d8"
+  # ```
+  def self.hexdigest(data) : String
+    hexdigest &.update(data)
+  end
+
+  # Yields a context object with an `#update(data : String | Bytes)`
+  # method available. Returns the resulting digest in hexadecimal representation
+  # afterwards.
+  #
+  # ```
+  # require "digest/md5"
+  #
+  # Digest::MD5.hexdigest("foo") # => "acbd18db4cc2f85cedef654fccc4a4d8"
+  # Digest::MD5.hexdigest do |ctx|
+  #   ctx.update "f"
+  #   ctx.update "oo"
+  # end
+  # # => "acbd18db4cc2f85cedef654fccc4a4d8"
+  # ```
+  def self.hexdigest(& : self -> _) : String
+    hashsum = digest do |ctx|
+      yield ctx
+    end
+
+    hashsum.to_slice.hexstring
+  end
+
+  # Returns the base64-encoded hash of *data*.
+  #
+  # ```
+  # require "digest/sha1"
+  #
+  # Digest::SHA1.base64digest("foo") # => "C+7Hteo/D9vJXQ3UfzxbwnXaijM="
+  # ```
+  def self.base64digest(data) : String
+    base64digest &.update(data)
+  end
+
+  # Yields a context object with an `#update(data : String | Bytes)`
+  # method available. Returns the resulting digest in base64 representation
+  # afterwards.
+  #
+  # ```
+  # require "digest/sha1"
+  #
+  # Digest::SHA1.base64digest do |ctx|
+  #   ctx.update "f"
+  #   ctx.update "oo"
+  # end
+  # # => "C+7Hteo/D9vJXQ3UfzxbwnXaijM="
+  # ```
+  def self.base64digest(& : self -> _) : String
+    hashsum = digest do |ctx|
+      yield ctx
+    end
+
+    Base64.strict_encode(hashsum)
+  end
 end

--- a/src/digest/md5.cr
+++ b/src/digest/md5.cr
@@ -6,7 +6,7 @@ require "./base"
 # used in security-related components, like password hashing. For passwords, see
 # `Crypto::Bcrypt::Password`. For a generic cryptographic hash, use SHA-256 via
 # `OpenSSL::Digest.new("SHA256")`.
-class Digest::MD5 < Digest::Base
+class Digest::MD5 < Digest::Algorithm
   @i = StaticArray(UInt32, 2).new(0_u32)
   @buf = StaticArray(UInt32, 4).new(0_u32)
   @in = StaticArray(UInt8, 64).new(0_u8)

--- a/src/digest/sha1.cr
+++ b/src/digest/sha1.cr
@@ -6,7 +6,7 @@ require "./base"
 # used in security-related components, like password hashing. For passwords, see
 # `Crypto::Bcrypt::Password`. For a generic cryptographic hash, use SHA-256 via
 # `OpenSSL::Digest.new("SHA256")`.
-class Digest::SHA1 < Digest::Base
+class Digest::SHA1 < Digest::Algorithm
   # This is a direct translation of https://tools.ietf.org/html/rfc3174#section-7
   # but we use loop unrolling for faster execution (about 1.07x slower than OpenSSL::SHA1).
 

--- a/src/openssl/digest/digest.cr
+++ b/src/openssl/digest/digest.cr
@@ -48,20 +48,20 @@ module OpenSSL
       Digest.new(@name, ctx)
     end
 
-    private def reset_impl : Nil
+    protected def reset_impl : Nil
       if LibCrypto.evp_digestinit_ex(self, to_unsafe_md, nil) != 1
         raise Error.new "Digest initialization failed."
       end
     end
 
-    private def update_impl(data : Bytes) : Nil
+    protected def update_impl(data : Bytes) : Nil
       check_finished
       if LibCrypto.evp_digestupdate(self, data, data.bytesize) != 1
         raise Error.new "EVP_DigestUpdate"
       end
     end
 
-    private def final_impl(data : Bytes) : Nil
+    protected def final_impl(data : Bytes) : Nil
       raise ArgumentError.new("data size incorrect") unless data.bytesize == digest_size
       if LibCrypto.evp_digestfinal_ex(@ctx, data, nil) != 1
         raise Error.new "EVP_DigestFinal_ex"
@@ -83,5 +83,23 @@ module OpenSSL
     def to_unsafe
       @ctx
     end
+  end
+
+  class Digest::SHA1 < ::Digest::Algorithm
+    @digest = OpenSSL::Digest.new("SHA1")
+
+    delegate update_impl, final_impl, reset_impl, digest_size, to: @digest
+  end
+
+  class Digest::SHA256 < ::Digest::Algorithm
+    @digest = OpenSSL::Digest.new("SHA256")
+
+    delegate update_impl, final_impl, reset_impl, digest_size, to: @digest
+  end
+
+  class Digest::SHA512 < ::Digest::Algorithm
+    @digest = OpenSSL::Digest.new("SHA512")
+
+    delegate update_impl, final_impl, reset_impl, digest_size, to: @digest
   end
 end


### PR DESCRIPTION



`Digest::Base` holds the state of a digest algorithm.
`Digest::Algorithm` defines the API to be used as entry point. 

Crystal native implementation like `Digest::MD5`, `Digest::SHA1` are now `Digest::Algorithm`.

`OpenSSL::Digest` do not follow the same design asn native implementation. The user needs to input the name of the algorithm. This cause that the class methods to not work as they were defined.

An attempt to extend the class methods to forward constructor arguments as:

```cr
OpenSSL::Digest.hexdigest("SHA256") do |ctx|
  ctx.update(data)
end
```

will not work because other class methods that were defined in `Digest::Base` that has arguments.

```cr
Digest::SHA1.digest(data)
OpenSSL::Digest.digest(data, "SHA256") # Should the constructor be specified before/after. It's weird.
```

So I think the cleaner path to avoid changing the expected API is to decouple `Digest::Base` as a helper class to keep the state of the algorithm, and `Digest::Algorithm` to be used as entry point.

All `Digest::Algorithm` can be created without argument. So the class methods can be well defined. `OpenSSL::Digest` does not fall in this case. For convenience `OpenSSL::Digest::SHA1`/`SHA256`/`SHA512` are defined as shameless wrapper to a `OpenSSL::Digest`.

Finally, it is now possible to be able to have a registry of algorithm by name as defined by `String => Digest::Algorithm.class`.

Maybe if the OpenSSL module got redesigned things can be simplified since the noise is introduced by it's difference with the native implementation.

Ref: #9483
Follow-up: #8426