### PR TITLE
Docs: Add a note regarding Log.setup

### DIFF
--- a/src/log.cr
+++ b/src/log.cr
@@ -80,6 +80,8 @@
 #
 # If you need to change the default level, backend or sources call `Log.setup` upon startup.
 #
+# NOTE: Calling `setup` will override previous `setup` calls.
+#
 # ```
 # Log.setup(:debug)                     # Log debug and above for all sources to STDOUT
 # Log.setup("myapp.*, http.*", :notice) # Log notice and above for myapp.* and http.* sources only, and log nothing for any other source.


### PR DESCRIPTION
Added a small note regarding the behaviour of `Log.setup`.

I got shot in the foot by following the example in the docs thinking it would "setup" for the sources defined, and not override previous setup calls.