### PR TITLE
Allow annotations on ivars defined in base class

### DIFF
--- a/spec/compiler/semantic/annotation_spec.cr
+++ b/spec/compiler/semantic/annotation_spec.cr
@@ -344,6 +344,33 @@ describe "Semantic: annotation" do
     )) { int32 }
     end
 
+    it "finds annotations in instance var (subclass)" do
+      assert_type(%(
+        annotation Foo
+        end
+
+        class Base
+          @[Foo]
+          @x : Nil
+        end
+
+        class Child < Base
+          @[Foo]
+          @x : Nil
+
+          def foo
+            {% if @type.instance_vars.first.annotations(Foo).size == 2 %}
+              1
+            {% else %}
+              'a'
+            {% end %}
+          end
+        end
+
+        Child.new.foo
+      )) { int32 }
+    end
+
     it "collects annotations values in type" do
       assert_type(%(
         annotation Foo
@@ -730,7 +757,7 @@ describe "Semantic: annotation" do
           end
 
           def foo
-            {% if @type.instance_vars.first.annotations(Foo) %}
+            {% if @type.instance_vars.first.annotation(Foo) %}
               1
             {% else %}
               'a'
@@ -740,6 +767,32 @@ describe "Semantic: annotation" do
 
         Moo.new(1).foo
     )) { int32 }
+    end
+
+    it "finds annotation in instance var (subclass)" do
+      assert_type(%(
+        annotation Foo
+        end
+
+        class Base
+          @x : Nil
+        end
+
+        class Child < Base
+          @[Foo]
+          @x : Nil
+
+          def foo
+            {% if @type.instance_vars.first.annotation(Foo) %}
+              1
+            {% else %}
+              'a'
+            {% end %}
+          end
+        end
+
+        Child.new.foo
+      )) { int32 }
     end
 
     it "overrides annotation value in type" do

--- a/src/compiler/crystal/semantic/type_declaration_processor.cr
+++ b/src/compiler/crystal/semantic/type_declaration_processor.cr
@@ -266,6 +266,11 @@ struct Crystal::TypeDeclarationProcessor
       unless supervar.type.same?(type_decl.type)
         raise TypeException.new("instance variable '#{name}' of #{supervar.owner}, with #{owner} < #{supervar.owner}, is already declared as #{supervar.type} (trying to re-declare as #{type_decl.type})", type_decl.location)
       end
+
+      # Assign annotations to the existing instance var
+      type_decl.annotations.try &.each do |annotation_type, ann|
+        supervar.add_annotation(annotation_type, ann)
+      end
     else
       declare_meta_type_var(owner.instance_vars, owner, name, type_decl, instance_var: true, check_nilable: !owner.module?)
       remove_error owner, name


### PR DESCRIPTION
Redefining an instance variable in a subclass is allowed, as long as it has the same type. But annotations declared in the subclass are not considered. For example:

```crystal
class Foo
  @x : Int32
end

class Bar < Foo
  @[Ann] # This annotation is ignored
  @x : Int32
end
```

This PR fixes that. Also I fixed a small typo in one of the specs that otherwise always passes.