### PR TITLE
Fix Digest::Base block argument type restrictions

### DIFF
--- a/spec/std/digest/md5_spec.cr
+++ b/spec/std/digest/md5_spec.cr
@@ -1,7 +1,10 @@
 require "spec"
+require "./spec_helper"
 require "digest/md5"
 
 describe Digest::MD5 do
+  it_acts_as_digest_algorithm Digest::MD5
+
   it "calculates digest from string" do
     Digest::MD5.digest("foo").to_slice.should eq Bytes[0xac, 0xbd, 0x18, 0xdb, 0x4c, 0xc2, 0xf8, 0x5c, 0xed, 0xef, 0x65, 0x4f, 0xcc, 0xc4, 0xa4, 0xd8]
   end

--- a/spec/std/digest/sha1_spec.cr
+++ b/spec/std/digest/sha1_spec.cr
@@ -1,7 +1,10 @@
 require "spec"
+require "./spec_helper"
 require "digest/sha1"
 
 describe Digest::SHA1 do
+  it_acts_as_digest_algorithm Digest::SHA1
+
   [
     {"", "da39a3ee5e6b4b0d3255bfef95601890afd80709", "2jmj7l5rSw0yVb/vlWAYkK/YBwk="},
     {"The quick brown fox jumps over the lazy dog", "2fd4e1c67a2d28fced849ee1bb76e7391b93eb12", "L9ThxnotKPzthJ7hu3bnORuT6xI="},

--- a/spec/std/digest/spec_helper.cr
+++ b/spec/std/digest/spec_helper.cr
@@ -1,0 +1,47 @@
+def it_acts_as_digest_algorithm(type : T.class) forall T
+  it "#hexdigest can update within a loop from explicit expr (#9483)" do
+    i = 0
+    type.hexdigest do |digest|
+      while i < 3
+        digest.update("")
+        i += 1
+      end
+    end
+  end
+
+  pending "#hexdigest can update within a loop by indirect expr (#9483)" do
+    algorithm = {} of String => Digest::Base.class
+    algorithm["me"] = type
+    i = 0
+    algorithm["me"].hexdigest do |digest|
+      while i < 3
+        digest.update("")
+        i += 1
+      end
+    end
+  end
+
+  it "context are independent" do
+    algorithm = type
+    res = algorithm.hexdigest do |digest|
+      digest.update("a")
+      digest.update("b")
+    end
+
+    inner_res = nil
+
+    outer_res = algorithm.hexdigest do |outer|
+      outer.update("a")
+
+      inner_res = algorithm.hexdigest do |inner|
+        inner.update("a")
+        inner.update("b")
+      end
+
+      outer.update("b")
+    end
+
+    outer_res.should eq(res)
+    inner_res.should eq(res)
+  end
+end

--- a/src/digest/base.cr
+++ b/src/digest/base.cr
@@ -24,7 +24,7 @@ abstract class Digest::Base
     # end
     # digest.to_slice.hexstring # => "acbd18db4cc2f85cedef654fccc4a4d8"
     # ```
-    def self.digest(& : ->) : Bytes
+    def self.digest(& : self ->) : Bytes
       context = new
       yield context
       context.final
@@ -55,7 +55,7 @@ abstract class Digest::Base
     # end
     # # => "acbd18db4cc2f85cedef654fccc4a4d8"
     # ```
-    def self.hexdigest(& : ->) : String
+    def self.hexdigest(& : self ->) : String
       hashsum = digest do |ctx|
         yield ctx
       end
@@ -87,7 +87,7 @@ abstract class Digest::Base
     # end
     # # => "C+7Hteo/D9vJXQ3UfzxbwnXaijM="
     # ```
-    def self.base64digest(& : Digest::Base -> _) : String
+    def self.base64digest(& : self -> _) : String
       hashsum = digest do |ctx|
         yield ctx
       end

--- a/src/digest/base.cr
+++ b/src/digest/base.cr
@@ -24,7 +24,7 @@ abstract class Digest::Base
     # end
     # digest.to_slice.hexstring # => "acbd18db4cc2f85cedef654fccc4a4d8"
     # ```
-    def self.digest(& : Digest::Base -> _) : Bytes
+    def self.digest(& : ->) : Bytes
       context = new
       yield context
       context.final
@@ -55,7 +55,7 @@ abstract class Digest::Base
     # end
     # # => "acbd18db4cc2f85cedef654fccc4a4d8"
     # ```
-    def self.hexdigest(& : Digest::Base -> _) : String
+    def self.hexdigest(& : ->) : String
       hashsum = digest do |ctx|
         yield ctx
       end


### PR DESCRIPTION
This applies a workaround to the immediate problem described in #9483 by removing the type restrictions on the block arguments. It does not solve the compiler error. It's an alternative and less-intrusive solution to #9496

Ref #9483
Follow-up: #8426