### PR TITLE
Compiler: implement autocasting in a better way

### DIFF
--- a/spec/compiler/codegen/automatic_cast.cr
+++ b/spec/compiler/codegen/automatic_cast.cr
@@ -239,4 +239,25 @@ describe "Code gen: automatic cast" do
       foo(1, "a" || 1)
       )).to_i.should eq(20)
   end
+
+  it "does multidispatch with automatic casting (3)" do
+    run(%(
+      abstract class Foo
+      end
+
+      class Bar < Foo
+        def foo(x : UInt8)
+          2
+        end
+      end
+
+      class Baz < Foo
+        def foo(x : UInt8)
+          3
+        end
+      end
+
+      Bar.new.as(Foo).foo(1)
+      )).to_i.should eq(2)
+  end
 end

--- a/spec/compiler/semantic/automatic_cast_spec.cr
+++ b/spec/compiler/semantic/automatic_cast_spec.cr
@@ -546,4 +546,33 @@ describe "Semantic: automatic cast" do
       fill()
       )) { types["AnotherColor"] }
   end
+
+  it "doesn't do multidispatch if an overload matches exactly (#8217)" do
+    assert_type(%(
+      abstract class Foo
+      end
+
+      class Bar < Foo
+        def foo(x : Int64)
+          x
+        end
+
+        def foo(*xs : Int64)
+          xs
+        end
+      end
+
+      class Baz < Foo
+        def foo(x : Int64)
+          x
+        end
+
+        def foo(*xs : Int64)
+          xs
+        end
+      end
+
+      Baz.new.as(Foo).foo(1)
+      )) { int64 }
+  end
 end

--- a/src/compiler/crystal/program.cr
+++ b/src/compiler/crystal/program.cr
@@ -581,8 +581,8 @@ module Crystal
       end
     end
 
-    def lookup_private_matches(filename, signature)
-      file_module?(filename).try &.lookup_matches(signature)
+    def lookup_private_matches(filename, signature, analyze_all = false)
+      file_module?(filename).try &.lookup_matches(signature, analyze_all: analyze_all)
     end
 
     def file_module?(filename)

--- a/src/compiler/crystal/semantic/restrictions.cr
+++ b/src/compiler/crystal/semantic/restrictions.cr
@@ -1240,6 +1240,10 @@ module Crystal
         type
       end
     end
+
+    def compatible_with?(type)
+      literal.type == type || literal.can_be_autocast_to?(type)
+    end
   end
 
   class SymbolLiteralType
@@ -1262,6 +1266,17 @@ module Crystal
           type = @match || literal.type
         end
         type
+      end
+    end
+
+    def compatible_with?(type)
+      case type
+      when SymbolType
+        true
+      when EnumType
+        !!(type.find_member(literal.value))
+      else
+        false
       end
     end
   end


### PR DESCRIPTION
I thought of a better, more resilient way to implement autocasting. This removes the existing hacks around it.

I added a big chunk of comment explaining how this is currently done, and what `with_literals` and `analyze_all` means, with a bunch of examples.

Makes #9492 obsolete.