### PR TITLE
Reject annotations on ivars defined in base class

### DIFF
--- a/spec/compiler/semantic/annotation_spec.cr
+++ b/spec/compiler/semantic/annotation_spec.cr
@@ -730,7 +730,7 @@ describe "Semantic: annotation" do
           end
 
           def foo
-            {% if @type.instance_vars.first.annotations(Foo) %}
+            {% if @type.instance_vars.first.annotation(Foo) %}
               1
             {% else %}
               'a'
@@ -916,6 +916,23 @@ describe "Semantic: annotation" do
         {{ Child.superclass.annotation(Ann)[0] }}
       )) { int32 }
     end
+  end
+
+  it "errors when annotate instance variable in subclass" do
+    assert_error %(
+      annotation Foo
+      end
+
+      class Base
+        @x : Nil
+      end
+
+      class Child < Base
+        @[Foo]
+        @x : Nil
+      end
+      ),
+      "can't annotate an instance variable not defined in this class"
   end
 
   it "errors if wanting to add type inside annotation (1) (#8614)" do

--- a/spec/compiler/semantic/annotation_spec.cr
+++ b/spec/compiler/semantic/annotation_spec.cr
@@ -932,7 +932,7 @@ describe "Semantic: annotation" do
         @x : Nil
       end
       ),
-      "can't annotate an instance variable not defined in this class"
+      "can't annotate @x here because it was first defined in Base"
   end
 
   it "errors if wanting to add type inside annotation (1) (#8614)" do

--- a/spec/compiler/semantic/annotation_spec.cr
+++ b/spec/compiler/semantic/annotation_spec.cr
@@ -932,7 +932,7 @@ describe "Semantic: annotation" do
         @x : Nil
       end
       ),
-      "can't annotate @x here because it was first defined in Base"
+      "can't annotate @x in Child because it was first defined in Base"
   end
 
   it "errors if wanting to add type inside annotation (1) (#8614)" do

--- a/src/compiler/crystal/semantic/type_declaration_processor.cr
+++ b/src/compiler/crystal/semantic/type_declaration_processor.cr
@@ -269,7 +269,7 @@ struct Crystal::TypeDeclarationProcessor
 
       # Reject annotations to existing instance var
       type_decl.annotations.try &.each do |_, ann|
-        ann.raise "can't annotate #{name} here because it was first defined in #{supervar.owner}"
+        ann.raise "can't annotate #{name} in #{owner} because it was first defined in #{supervar.owner}"
       end
     else
       declare_meta_type_var(owner.instance_vars, owner, name, type_decl, instance_var: true, check_nilable: !owner.module?)

--- a/src/compiler/crystal/semantic/type_declaration_processor.cr
+++ b/src/compiler/crystal/semantic/type_declaration_processor.cr
@@ -266,6 +266,11 @@ struct Crystal::TypeDeclarationProcessor
       unless supervar.type.same?(type_decl.type)
         raise TypeException.new("instance variable '#{name}' of #{supervar.owner}, with #{owner} < #{supervar.owner}, is already declared as #{supervar.type} (trying to re-declare as #{type_decl.type})", type_decl.location)
       end
+
+      # Reject annotations to existing instance var
+      type_decl.annotations.try &.each do |_, ann|
+        ann.raise "can't annotate an instance variable not defined in this class"
+      end
     else
       declare_meta_type_var(owner.instance_vars, owner, name, type_decl, instance_var: true, check_nilable: !owner.module?)
       remove_error owner, name

--- a/src/compiler/crystal/semantic/type_declaration_processor.cr
+++ b/src/compiler/crystal/semantic/type_declaration_processor.cr
@@ -269,7 +269,7 @@ struct Crystal::TypeDeclarationProcessor
 
       # Reject annotations to existing instance var
       type_decl.annotations.try &.each do |_, ann|
-        ann.raise "can't annotate an instance variable not defined in this class"
+        ann.raise "can't annotate #{name} here because it was first defined in #{supervar.owner}"
       end
     else
       declare_meta_type_var(owner.instance_vars, owner, name, type_decl, instance_var: true, check_nilable: !owner.module?)


### PR DESCRIPTION
Following up from #9499 

This raises an error instead of silently ignoring annotations on instance variables defined in a base class.