### PR TITLE
Prevent recursive call in bin/crystal wrapper

### DIFF
--- a/bin/crystal
+++ b/bin/crystal
@@ -142,7 +142,10 @@ export CRYSTAL_PATH=lib:$CRYSTAL_ROOT/src
 export CRYSTAL_HAS_WRAPPER=true
 
 if [ -z "$CRYSTAL_CONFIG_LIBRARY_PATH" ]; then
-  export CRYSTAL_CONFIG_LIBRARY_PATH="$(crystal env CRYSTAL_LIBRARY_PATH || echo "")"
+  export CRYSTAL_CONFIG_LIBRARY_PATH="$(
+    export PATH="$(remove_path_item "$(remove_path_item "$PATH" "$SCRIPT_ROOT")" "bin")" 
+    crystal env CRYSTAL_LIBRARY_PATH || echo ""
+  )"
 fi
 
 if [ -x "$CRYSTAL_DIR/crystal" ]; then


### PR DESCRIPTION
Apply the existing PATH removal technique to the new call to crystal env, allowing to put bin/ into one's PATH again