### PR TITLE
AArch64 CI

### DIFF
--- a/.github/workflows/aarch64.yml
+++ b/.github/workflows/aarch64.yml
@@ -1,0 +1,101 @@
+name: AArch64 CI
+
+on: [push, pull_request]
+
+jobs:
+  musl-build:
+    runs-on: [linux, ARM64]
+    steps:
+      - name: Download Crystal source
+        uses: actions/checkout@v2
+      - name: Build Crystal
+        uses: docker://jhass/crystal:0.35.0-alpine-build
+        with:
+          args: make crystal
+      - name: Upload Crystal executable
+        uses: actions/upload-artifact@v1
+        with:
+          name: crystal-aarch64-musl
+          path: .build/crystal
+  musl-test-stdlib:
+    needs: musl-build
+    runs-on: [linux, ARM64]
+    steps:
+      - name: Download Crystal source
+        uses: actions/checkout@v2
+      - name: Download Crystal executable
+        uses: actions/download-artifact@v1
+        with:
+          name: crystal-aarch64-musl
+          path: .build/
+      - name: Mark downloaded compiler as executable
+        run: chmod +x .build/crystal
+      - name: Run stdlib specs
+        uses: docker://jhass/crystal:0.35.0-alpine-build
+        with:
+          args: make std_spec
+  musl-test-compiler:
+    needs: musl-build
+    runs-on: [linux, ARM64]
+    steps:
+      - name: Download Crystal source
+        uses: actions/checkout@v2
+      - name: Download Crystal executable
+        uses: actions/download-artifact@v1
+        with:
+          name: crystal-aarch64-musl
+          path: .build/
+      - name: Mark downloaded compiler as executable
+        run: chmod +x .build/crystal
+      - name: Run compiler specs
+        uses: docker://jhass/crystal:0.35.0-alpine-build
+        with:
+          args: make compiler_spec
+  gnu-build:
+    runs-on: [linux, ARM64]
+    steps:
+      - name: Download Crystal source
+        uses: actions/checkout@v2
+      - name: Build Crystal
+        uses: docker://jhass/crystal:0.35.0-build
+        with:
+          args: make crystal
+      - name: Upload Crystal executable
+        uses: actions/upload-artifact@v1
+        with:
+          name: crystal-aarch64-gnu
+          path: .build/crystal
+  gnu-test-stdlib:
+    needs: gnu-build
+    runs-on: [linux, ARM64]
+    steps:
+      - name: Download Crystal source
+        uses: actions/checkout@v2
+      - name: Download Crystal executable
+        uses: actions/download-artifact@v1
+        with:
+          name: crystal-aarch64-gnu
+          path: .build/
+      - name: Mark downloaded compiler as executable
+        run: chmod +x .build/crystal
+      - name: Run stdlib specs
+        uses: docker://jhass/crystal:0.35.0-build
+        with:
+          args: make std_spec
+  gnu-test-compiler:
+    needs: gnu-build
+    runs-on: [linux, ARM64]
+    steps:
+      - name: Download Crystal source
+        uses: actions/checkout@v2
+      - name: Download Crystal executable
+        uses: actions/download-artifact@v1
+        with:
+          name: crystal-aarch64-gnu
+          path: .build/
+      - name: Mark downloaded compiler as executable
+        run: chmod +x .build/crystal
+      - name: Run compiler specs
+        uses: docker://jhass/crystal:0.35.0-build
+        with:
+          args: make compiler_spec

--- a/spec/std/http/web_socket_spec.cr
+++ b/spec/std/http/web_socket_spec.cr
@@ -393,6 +393,7 @@ describe HTTP::WebSocket do
 
           ws.on_message do |str|
             ws.send("pong #{str}")
+            ws.close
           end
 
           ws.on_close do
@@ -415,7 +416,6 @@ describe HTTP::WebSocket do
       random = Random::Secure.hex
       ws2.on_message do |str|
         str.should eq("pong #{random}")
-        ws2.close
       end
       ws2.send(random)
 


### PR DESCRIPTION
Depends on, and thus includes:
* [x] <del>#9401</del>
* [x] <del>#9422</del>
* [x] <del>#9430</del>
* [x] <del>#9438</del>
* [x] <del>#9437 Probably not really after #9438, I didn't bother yet to rerun without this, but can try to exclude it here if preferred</del> Yeah it passes without now, I still consider it an improvement that should be merged though.

Additional work included here:
* The -gnu build exposed a failure condition in a Websocket spec, probably due to a different OpenSSL version than we run elsewhere? I'm not sure I fully understand it, but it seems to be fixed by the commit included here. Btw #9220 was quite helpful here, if you wonder about the error output in the commit message :)
* <del>A new spec feature, `pending!` to soft-fail a spec in the middle of it. The commit after motiviates the addition of this feature: Sometimes deciding  whether a spec needs to be pending requires significant setup, that the spec needs to do anyway. Rather than duplicating potentially complex setup code, this allows to abort the spec without failing the build. Technically this is part of #9438, but I felt this provides the better context,  as this introduces an execution environment where it becomes necessary, namely IPv6-less Docker.  Of course I can send this separately or include it into #9438 if preferred, or both send the feature separately and including the spec fix in #9438.</del> Extracted to #9566

The runner setup scripts are at https://github.com/jhass/crystal-infrastructure for now. Of course that should be  moved to the crystal-lang org, I just  wanted  your acknowledgement for it first.

I think we can keep the docker images used here on my account for now until we make AArch64 part of our official releases and push appropriate images under crystallang/crystal.

I want to mention some offspring work, which the work included here enabled  and will sustain in the future:

*  The [crystal-git](https://aur.archlinux.org/packages/crystal-git/) and [shards-git](https://aur.archlinux.org/packages/shards-git/) AUR packages now build on AArch64
* Alpine <del>will soon</del> edge ships a AArch64 Crystal package again. In preparation a fully static Crystal  build for AArch64 already appeared at https://dev.alpinelinux.org/archive/crystal/
* I hope to be able to push an AArch64 Crystal  package into the ArchlinuxARM repository: https://github.com/archlinuxarm/PKGBUILDs/pull/1816

I would like to thank the generous Packet and ARM through their [WorksOnArm](https://www.worksonarm.com/) project for providing us with  the necessary server for this.