### PR TITLE
Improve compilation time for big StaticArray initializers

### DIFF
--- a/src/static_array.cr
+++ b/src/static_array.cr
@@ -62,12 +62,10 @@ struct StaticArray(T, N)
   # ```
   # StaticArray(Int32, 3).new { |i| i * 2 } # => StaticArray[0, 2, 4]
   # ```
-  def self.new(&block : Int32 -> T)
-    array = uninitialized self
+  def initialize(&block : Int32 -> T)
     N.times do |i|
-      array.to_unsafe[i] = yield i
+      to_unsafe[i] = yield i
     end
-    array
   end
 
   # Creates a new static array filled with the given value.

--- a/src/static_array.cr
+++ b/src/static_array.cr
@@ -62,7 +62,7 @@ struct StaticArray(T, N)
   # ```
   # StaticArray(Int32, 3).new { |i| i * 2 } # => StaticArray[0, 2, 4]
   # ```
-  def initialize(&block : Int32 -> T)
+  def initialize(& : Int32 -> T)
     N.times do |i|
       to_unsafe[i] = yield i
     end


### PR DESCRIPTION
This is another workaround for #2485.

Apparently the combination of the large loop unroll and returning the big array as value trigger some edge case on the LLVM optimizer. I replaced the `new` by `initialize` that works with the struct pointer instead. The result binary should be exactly the same. I noticed that this very slightly improves compilation time in general, specially in release mode (around 3% to compile `samples/http_server.cr`)

Fixes #2485 