### PR TITLE
Use unchecked arithmetics in `Int#times`

### DIFF
--- a/src/int.cr
+++ b/src/int.cr
@@ -508,7 +508,7 @@ struct Int
     i = self ^ self
     while i < self
       yield i
-      i += 1
+      i &+= 1
     end
   end
 
@@ -707,7 +707,7 @@ struct Int
     def next
       if @index < @n
         value = @index
-        @index += 1
+        @index &+= 1
         value
       else
         stop


### PR DESCRIPTION
There is no need to check for overflows in `Int#times`. LLVM figures out that and removes the check, but it's always good to generate less code, and this function is used a LOT. In my machine, compiling in release mode `samples/http_server.cr`, the codegen step goes from 23s down to 19.5s.