### PR TITLE
Document how to generate the SNAPCRAFT_TOKEN

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -434,6 +434,7 @@ jobs:
       - attach_workspace:
           at: /tmp/workspace
       - run:
+          # $SNAPCRAFT_TOKEN is generated using `snapcraft export-login --snaps crystal --channels edge,edge/* -`
           command: |
             cd /tmp/workspace/distribution-scripts
             source build.env


### PR DESCRIPTION
Current token will expire at 2021-06-20. You are welcome, future self.