### PR TITLE
Fix `CRYSTAL_OPTS` parsing

### DIFF
--- a/spec/std/process_spec.cr
+++ b/spec/std/process_spec.cr
@@ -461,17 +461,17 @@ describe Process do
     end
   end
 
-  describe "split" do
-    it { Process.split("").should eq(%w[]) }
-    it { Process.split(" ").should eq(%w[]) }
-    it { Process.split("foo").should eq(%w[foo]) }
-    it { Process.split("foo bar").should eq(%w[foo bar]) }
-    it { Process.split(%q("foo bar" 'foo bar' baz)).should eq(["foo bar", "foo bar", "baz"]) }
-    it { Process.split(%q("foo bar"'foo bar'baz)).should eq(["foo barfoo barbaz"]) }
-    it { Process.split(%q(foo\ bar)).should eq(["foo bar"]) }
-    it { Process.split(%q("foo\ bar")).should eq(["foo bar"]) }
-    it { Process.split(%q('foo\ bar')).should eq(["foo\\ bar"]) }
-    it { Process.split("\\").should eq(["\\"]) }
-    it { Process.split(%q["foo bar" '\hello/' Fizz\ Buzz]).should eq(["foo bar", "\\hello/", "Fizz Buzz"]) }
+  describe "parse_arguments" do
+    it { Process.parse_arguments("").should eq(%w[]) }
+    it { Process.parse_arguments(" ").should eq(%w[]) }
+    it { Process.parse_arguments("foo").should eq(%w[foo]) }
+    it { Process.parse_arguments("foo bar").should eq(%w[foo bar]) }
+    it { Process.parse_arguments(%q("foo bar" 'foo bar' baz)).should eq(["foo bar", "foo bar", "baz"]) }
+    it { Process.parse_arguments(%q("foo bar"'foo bar'baz)).should eq(["foo barfoo barbaz"]) }
+    it { Process.parse_arguments(%q(foo\ bar)).should eq(["foo bar"]) }
+    it { Process.parse_arguments(%q("foo\ bar")).should eq(["foo bar"]) }
+    it { Process.parse_arguments(%q('foo\ bar')).should eq(["foo\\ bar"]) }
+    it { Process.parse_arguments("\\").should eq(["\\"]) }
+    it { Process.parse_arguments(%q["foo bar" '\hello/' Fizz\ Buzz]).should eq(["foo bar", "\\hello/", "Fizz Buzz"]) }
   end
 end

--- a/spec/std/process_spec.cr
+++ b/spec/std/process_spec.cr
@@ -460,4 +460,18 @@ describe Process do
       it { Process.quote_windows(["foo ", "", " ", " bar"]).should eq %("foo " "" " " " bar") }
     end
   end
+
+  describe "split" do
+    it { Process.split("").should eq(%w[]) }
+    it { Process.split(" ").should eq(%w[]) }
+    it { Process.split("foo").should eq(%w[foo]) }
+    it { Process.split("foo bar").should eq(%w[foo bar]) }
+    it { Process.split(%q("foo bar" 'foo bar' baz)).should eq(["foo bar", "foo bar", "baz"]) }
+    it { Process.split(%q("foo bar"'foo bar'baz)).should eq(["foo barfoo barbaz"]) }
+    it { Process.split(%q(foo\ bar)).should eq(["foo bar"]) }
+    it { Process.split(%q("foo\ bar")).should eq(["foo bar"]) }
+    it { Process.split(%q('foo\ bar')).should eq(["foo\\ bar"]) }
+    it { Process.split("\\").should eq(["\\"]) }
+    it { Process.split(%q["foo bar" '\hello/' Fizz\ Buzz]).should eq(["foo bar", "\\hello/", "Fizz Buzz"]) }
+  end
 end

--- a/spec/std/process_spec.cr
+++ b/spec/std/process_spec.cr
@@ -469,9 +469,21 @@ describe Process do
     it { Process.parse_arguments(%q("foo bar" 'foo bar' baz)).should eq(["foo bar", "foo bar", "baz"]) }
     it { Process.parse_arguments(%q("foo bar"'foo bar'baz)).should eq(["foo barfoo barbaz"]) }
     it { Process.parse_arguments(%q(foo\ bar)).should eq(["foo bar"]) }
-    it { Process.parse_arguments(%q("foo\ bar")).should eq(["foo bar"]) }
+    it { Process.parse_arguments(%q("foo\ bar")).should eq(["foo\\ bar"]) }
     it { Process.parse_arguments(%q('foo\ bar')).should eq(["foo\\ bar"]) }
     it { Process.parse_arguments("\\").should eq(["\\"]) }
     it { Process.parse_arguments(%q["foo bar" '\hello/' Fizz\ Buzz]).should eq(["foo bar", "\\hello/", "Fizz Buzz"]) }
+
+    it "raises an error when double quote is unclosed" do
+      expect_raises ArgumentError, "Unmatched quote" do
+        Process.parse_arguments(%q["foo])
+      end
+    end
+
+    it "raises an error if single quote is unclosed" do
+      expect_raises ArgumentError, "Unmatched quote" do
+        Process.parse_arguments(%q['foo])
+      end
+    end
   end
 end

--- a/src/compiler/crystal/command.cr
+++ b/src/compiler/crystal/command.cr
@@ -620,7 +620,7 @@ class Crystal::Command
   end
 
   private def use_crystal_opts
-    @options = ENV.fetch("CRYSTAL_OPTS", "").split.concat(options)
+    @options = Process.split(ENV.fetch("CRYSTAL_OPTS", "")).concat(options)
   end
 
   private def new_compiler

--- a/src/compiler/crystal/command.cr
+++ b/src/compiler/crystal/command.cr
@@ -620,7 +620,7 @@ class Crystal::Command
   end
 
   private def use_crystal_opts
-    @options = Process.split(ENV.fetch("CRYSTAL_OPTS", "")).concat(options)
+    @options = Process.parse_arguments(ENV.fetch("CRYSTAL_OPTS", "")).concat(options)
   end
 
   private def new_compiler

--- a/src/compiler/crystal/command.cr
+++ b/src/compiler/crystal/command.cr
@@ -621,6 +621,8 @@ class Crystal::Command
 
   private def use_crystal_opts
     @options = Process.parse_arguments(ENV.fetch("CRYSTAL_OPTS", "")).concat(options)
+  rescue ex
+    raise LocationlessException.new("Failed to parse CRYSTAL_OPTS: #{ex.message}")
   end
 
   private def new_compiler

--- a/src/process/shell.cr
+++ b/src/process/shell.cr
@@ -134,17 +134,22 @@ class Process
             break unless reader.has_next?
             reader.next_char
             if char == '\\' && quote != '\''
+              str << char if quote == '"'
               char = reader.current_char
               if reader.has_next?
                 reader.next_char
               else
+                break if quote == '"'
                 char = '\\'
               end
             end
             str << char
           end
 
-          reader.next_char if quote
+          if quote
+            raise ArgumentError.new("Unmatched quote") unless reader.has_next?
+            reader.next_char
+          end
         end
       end
 

--- a/src/process/shell.cr
+++ b/src/process/shell.cr
@@ -110,7 +110,7 @@ class Process
   # ```
   #
   # See https://pubs.opengroup.org/onlinepubs/009695399/utilities/xcu_chap02.html#tag_02_03
-  def self.split(line : String) : Array(String)
+  def self.parse_arguments(line : String) : Array(String)
     tokens = [] of String
 
     reader = Char::Reader.new(line)

--- a/src/process/shell.cr
+++ b/src/process/shell.cr
@@ -106,7 +106,7 @@ class Process
   # Split a *line* string into the array of tokens in the same way the POSIX shell.
   #
   # ```
-  # p Process.split(%q["foo bar" '\hello/' Fizz\ Buzz]) # => ["foo bar", "\\hello/", "Fizz Buzz"]
+  # Process.split(%q["foo bar" '\hello/' Fizz\ Buzz]) # => ["foo bar", "\\hello/", "Fizz Buzz"]
   # ```
   #
   # See https://pubs.opengroup.org/onlinepubs/009695399/utilities/xcu_chap02.html#tag_02_03

--- a/src/process/shell.cr
+++ b/src/process/shell.cr
@@ -125,7 +125,7 @@ class Process
       token = String.build do |str|
         while reader.has_next? && !reader.current_char.ascii_whitespace?
           quote = nil
-          if {'\'', '"'}.includes?(reader.current_char)
+          if reader.current_char.in?('\'', '"')
             quote = reader.current_char
             reader.next_char
           end

--- a/src/process/shell.cr
+++ b/src/process/shell.cr
@@ -106,7 +106,7 @@ class Process
   # Split a *line* string into the array of tokens in the same way the POSIX shell.
   #
   # ```
-  # Process.split(%q["foo bar" '\hello/' Fizz\ Buzz]) # => ["foo bar", "\\hello/", "Fizz Buzz"]
+  # Process.parse_arguments(%q["foo bar" '\hello/' Fizz\ Buzz]) # => ["foo bar", "\\hello/", "Fizz Buzz"]
   # ```
   #
   # See https://pubs.opengroup.org/onlinepubs/009695399/utilities/xcu_chap02.html#tag_02_03


### PR DESCRIPTION
Fixed #9509
Ref https://github.com/crystal-lang/crystal/pull/8900#discussion_r391925011

This PR adds `Process.split`, which is similar to [`Shellwords.split`
in Ruby](https://ruby-doc.org/stdlib-2.5.1/libdoc/shellwords/rdoc/Shellwords.html#method-c-split). Then, this is used to parse `CRYSTAL_OPTS`.

I'm not sure `Process.split` is good naming. However I have no idea of better name. And also, I'm not sure Windows version of `Process.split` is needed.