### PR TITLE
Fix bug with passing many args then a struct in Win64 C lib ABI

### DIFF
--- a/spec/compiler/codegen/c_abi/c_abi_spec.cr
+++ b/spec/compiler/codegen/c_abi/c_abi_spec.cr
@@ -84,6 +84,36 @@ describe "Code gen: C ABI" do
       ), &.to_i.should eq(6))
   end
 
+  {% if flag?(:x86_64) && !flag?(:win32) %}
+    pending "passes struct after many other args (for real) (#9519)"
+  {% else %}
+    it "passes struct after many other args (for real)" do
+      test_c(
+        %(
+          struct s {
+            long long x, y;
+          };
+
+          long long foo(long long a, long long b, long long c, long long d, long long e, struct s v) {
+            return a + b + c + d + e + v.x + v.y;
+          }
+        ),
+        %(
+          lib LibFoo
+            struct S
+              x : Int64
+              y : Int64
+            end
+
+            fun foo(a : Int64, b : Int64, c : Int64, d : Int64, e : Int64, v : S) : Int64
+          end
+
+          v = LibFoo::S.new(x: 6, y: 7)
+          LibFoo.foo(1, 2, 3, 4, 5, v)
+        ), &.to_string.should eq("28"))
+    end
+  {% end %}
+
   it "returns struct less than 64 bits (for real)" do
     test_c(
       %(

--- a/src/llvm/abi/x86_win64.cr
+++ b/src/llvm/abi/x86_win64.cr
@@ -12,7 +12,7 @@ class LLVM::ABI::X86_Win64 < LLVM::ABI::X86
         when 2 then ArgType.direct(t, context.int16)
         when 4 then ArgType.direct(t, context.int32)
         when 8 then ArgType.direct(t, context.int64)
-        else        ArgType.indirect(t, LLVM::Attribute::ByVal)
+        else        ArgType.indirect(t, nil)
         end
       else
         non_struct(t, context)


### PR DESCRIPTION
Also add a compilation spec for it (which actually fails on x86_64! -- see #9519)

The fix was suggested by @jhass and directly mirrors the change in #9430. The same mistake supposedly spread from [the original Rust code](https://github.com/rust-lang/rust/blob/29ac04402d53d358a1f6200bea45a301ff05b2d1/src/librustc_trans/trans/cabi_x86_win64.rs#L49) which [has since been fixed](https://github.com/rust-lang/rust/blob/033013cab3a861224fd55f494c8be1cb0349eb49/src/librustc_target/abi/call/x86_win64.rs#L15).

[Chat conversation](https://gitter.im/crystal-lang/crystal?at=5eee0d546c06cd1bf443f464)

[Real function that led me to find this problem](https://github.com/slembcke/Chipmunk2D/blob/6b5b827a1c739437ba191dde5cf2446648417b82/include/chipmunk/cpPivotJoint.h#L31)