### PR TITLE
Fix: `Socket#accept` obeys `read_timeout`

### DIFF
--- a/spec/std/socket/socket_spec.cr
+++ b/spec/std/socket/socket_spec.cr
@@ -42,6 +42,17 @@ describe Socket do
     end
   end
 
+  it "accept raises timeout error if read_timeout is specified" do
+    server = Socket.new(Socket::Family::INET, Socket::Type::STREAM, Socket::Protocol::TCP)
+    port = unused_local_port
+    server.bind("0.0.0.0", port)
+    server.read_timeout = 0.1
+    server.listen
+
+    expect_raises(IO::TimeoutError) { server.accept }
+    expect_raises(IO::TimeoutError) { server.accept? }
+  end
+
   it "sends messages" do
     port = unused_local_port
     server = Socket.tcp(Socket::Family::INET)

--- a/src/io/evented.cr
+++ b/src/io/evented.cr
@@ -117,11 +117,11 @@ module IO::Evented
 
   # :nodoc:
   def wait_readable(timeout = @read_timeout)
-    wait_readable(timeout: timeout) { |err| raise err }
+    wait_readable(timeout: timeout) { raise TimeoutError.new("Read timed out") }
   end
 
   # :nodoc:
-  def wait_readable(timeout = @read_timeout) : Nil
+  def wait_readable(timeout = @read_timeout, *, raise_if_closed = true) : Nil
     readers = @readers.get { Deque(Fiber).new }
     readers << Fiber.current
     add_read_event(timeout)
@@ -129,10 +129,10 @@ module IO::Evented
 
     if @read_timed_out
       @read_timed_out = false
-      yield TimeoutError.new("Read timed out")
+      yield
     end
 
-    check_open
+    check_open if raise_if_closed
   end
 
   private def add_read_event(timeout = @read_timeout) : Nil
@@ -142,7 +142,7 @@ module IO::Evented
 
   # :nodoc:
   def wait_writable(timeout = @write_timeout)
-    wait_writable(timeout: timeout) { |err| raise err }
+    wait_writable(timeout: timeout) { raise TimeoutError.new("Write timed out") }
   end
 
   # :nodoc:
@@ -154,7 +154,7 @@ module IO::Evented
 
     if @write_timed_out
       @write_timed_out = false
-      yield TimeoutError.new("Write timed out")
+      yield
     end
 
     check_open


### PR DESCRIPTION
Currently if a `read_timeout` is used on a `Socket`, `accept_impl` will just keep looping until a connection is received. This was already noticed by @grioja on this [comment](https://github.com/crystal-lang/crystal/pull/8707#discussion_r415385790). I refactored the internal implementation so it doesn't rely on exception handling.

I was hesitant about making `accept?` to return `nil` in case of timeout. But there are currently parts of the code that assumes that if a `nil` is returned it's because the socket was closed. On the other hand this was the behaviour until #8707 was merged so that would be a breaking change to do in a separate PR if that's desired.