### PR TITLE
Allow HTTP::Client to work with any IO

### DIFF
--- a/spec/std/http/client/client_spec.cr
+++ b/spec/std/http/client/client_spec.cr
@@ -265,5 +265,36 @@ module HTTP
         request.host.should eq "other.example.com"
       end
     end
+
+    it "works with IO" do
+      io_response = IO::Memory.new <<-RESPONSE.gsub('\n', "\r\n")
+      HTTP/1.1 200 OK
+      Content-Type: text/plain
+      Content-Length: 3
+
+      Hi!
+      RESPONSE
+      io_request = IO::Memory.new
+      io = IO::Stapled.new(io_response, io_request)
+      client = Client.new(io)
+      response = client.get("/")
+      response.body.should eq("Hi!")
+    end
+
+    it "can specify host and port when initialized with IO" do
+      client = Client.new(IO::Memory.new, "host", 1234)
+      client.host.should eq("host")
+      client.port.should eq(1234)
+    end
+
+    it "cannot reconnect when initialized with IO" do
+      io = IO::Memory.new
+      client = Client.new(io)
+      client.close
+      io.closed?.should be_true
+      expect_raises(Exception, "This HTTP::Client cannot be reconnected") do
+        client.get("/")
+      end
+    end
   end
 end

--- a/spec/std/http/client/client_spec.cr
+++ b/spec/std/http/client/client_spec.cr
@@ -279,6 +279,10 @@ module HTTP
       client = Client.new(io)
       response = client.get("/")
       response.body.should eq("Hi!")
+
+      io_request.rewind
+      request = HTTP::Request.from_io(io_request).as(HTTP::Request)
+      request.host.should eq("")
     end
 
     it "can specify host and port when initialized with IO" do

--- a/spec/std/http/server/server_spec.cr
+++ b/spec/std/http/server/server_spec.cr
@@ -493,7 +493,7 @@ describe "#remote_address" do
       HTTP::Client.new(URI.parse("http://#{address1}/")) do |client|
         client.get("/")
 
-        remote_address.should eq(client.@socket.as(IPSocket).local_address)
+        remote_address.should eq(client.@io.as(IPSocket).local_address)
       end
     end
   end
@@ -516,7 +516,7 @@ describe "#remote_address" do
         uri: URI.parse("https://#{ip_address1}"),
         tls: client_context) do |client|
         client.get("/")
-        remote_address.should eq(client.@socket.as(OpenSSL::SSL::Socket).local_address)
+        remote_address.should eq(client.@io.as(OpenSSL::SSL::Socket).local_address)
       end
     end
   end

--- a/src/http/client.cr
+++ b/src/http/client.cr
@@ -105,17 +105,16 @@ class HTTP::Client
   # ```
   {% if flag?(:without_openssl) %}
     getter! tls : Nil
-    @socket : TCPSocket | Nil
     alias TLSContext = Bool | Nil
   {% else %}
     getter! tls : OpenSSL::SSL::Context::Client
-    @socket : TCPSocket | OpenSSL::SSL::Socket | Nil
     alias TLSContext = OpenSSL::SSL::Context::Client | Bool | Nil
   {% end %}
 
   # Whether automatic compression/decompression is enabled.
   property? compress : Bool = true
 
+  @socket : IO?
   @dns_timeout : Float64?
   @connect_timeout : Float64?
   @read_timeout : Float64?
@@ -146,6 +145,9 @@ class HTTP::Client
     {% end %}
 
     @port = (port || (@tls ? 443 : 80)).to_i
+  end
+
+  def initialize(@socket = IO, @host = "localhost", @port = 80)
   end
 
   private def check_host_only(string : String)

--- a/src/http/client.cr
+++ b/src/http/client.cr
@@ -147,7 +147,7 @@ class HTTP::Client
     @port = (port || (@tls ? 443 : 80)).to_i
   end
 
-  def initialize(@socket = IO, @host = "localhost", @port = 80)
+  def initialize(@socket : IO, @host = "localhost", @port = 80)
   end
 
   private def check_host_only(string : String)

--- a/src/http/client.cr
+++ b/src/http/client.cr
@@ -154,7 +154,7 @@ class HTTP::Client
   # Instances created with this constructor cannot be reconnected. Once
   # `close` is called explicitly or if the connection doesn't support keep-alive,
   # the next call to make a request will raise an exception.
-  def initialize(@socket : IO, @host = "localhost", @port = 80)
+  def initialize(@socket : IO, @host = "", @port = 80)
     @reconnect = false
   end
 


### PR DESCRIPTION
I know there was attempts to make `HTTP::Client` more generic. In the long term that would be desirable to support connection pools or socket factories. But this change was so easy and allow other scenarios currently unsupported. For example, talk through UNIX socket. The added initializer looks ugly because still needs to fill `host` and `port` but those are used for the `Host` header anyway. Another option is just make the `@socket` available through a property so it can be externally set. The issue I found is that if `close` is called the next request will try to open a `TCPSocket`.

Dunno, again this feel incomplete but it's a simple change that open possibilities.