### PR TITLE
Isolate `included` macro evaluation context from including type

### DIFF
--- a/spec/compiler/semantic/hooks_spec.cr
+++ b/spec/compiler/semantic/hooks_spec.cr
@@ -36,6 +36,27 @@ describe "Semantic: hooks" do
       ") { int32 }
   end
 
+  it "evaluate included macro on included module context" do
+    assert_type("
+      module Foo
+        A = 1
+
+        macro included
+          def self.foo
+            {{A}}
+          end
+        end
+      end
+
+      class Bar
+        A = 1.5
+        include Foo
+      end
+
+      Bar.foo
+      ") { int32 }
+  end
+
   it "does extended macro" do
     assert_type("
       module Foo
@@ -51,6 +72,27 @@ describe "Semantic: hooks" do
       end
 
       Bar.bar
+      ") { int32 }
+  end
+
+  it "evaluate extended macro on extended module context" do
+    assert_type("
+      module Foo
+        A = 1
+
+        macro extended
+          def self.foo
+            {{A}}
+          end
+        end
+      end
+
+      class Bar
+        A = 1.5
+        extend Foo
+      end
+
+      Bar.foo
       ") { int32 }
   end
 

--- a/src/compiler/crystal/semantic/top_level_visitor.cr
+++ b/src/compiler/crystal/semantic/top_level_visitor.cr
@@ -992,21 +992,21 @@ class Crystal::TopLevelVisitor < Crystal::SemanticVisitor
 
     begin
       current_type.as(ModuleType).include type
-      run_hooks hook_type(type), current_type, kind, node
+      run_hooks hook_type(type), current_type, kind, node, path_lookup: type
     rescue ex : TypeException
       node.raise "at '#{kind}' hook", ex
     end
   end
 
-  def run_hooks(type_with_hooks, current_type, kind, node, call = nil)
+  def run_hooks(type_with_hooks, current_type, kind, node, call = nil, path_lookup = current_type.instance_type)
     type_with_hooks.as?(ModuleType).try &.hooks.try &.each do |hook|
       next if hook.kind != kind
 
       expansion = expand_macro(hook.macro, node, visibility: :public) do
         if call
-          @program.expand_macro hook.macro, call, current_type.instance_type
+          @program.expand_macro hook.macro, call, current_type.instance_type, path_lookup
         else
-          @program.expand_macro hook.macro.body, current_type.instance_type
+          @program.expand_macro hook.macro.body, current_type.instance_type, path_lookup
         end
       end
 


### PR DESCRIPTION
Fixed #9488

Now `included` macro is evaluated on included module context. It makes intuitive and useful result in many cases. And, `extended` macro is also evaluated on extended module context.

One example is #9488, and other example is the following:

```crystal
module Collect
  NAMES = [] of String

  macro included
    {% NAMES << @type.name.stringify %}
  end
end

class Foo
  include Collect
end

class Bar
  NAMES = ["hey"]
  include Collect
end

p Collect::NAMES
```

The last `p` prints `["Foo"]` currently, however my expected result is `["Foo", "Bar"]`. This PR also fix such case.

MEMO: it is **breaking change**.