### PR TITLE
Remove Reference to `Kernel`.

### DIFF
--- a/src/io.cr
+++ b/src/io.cr
@@ -259,7 +259,7 @@ abstract class IO
   end
 
   # Writes a formatted string to this IO.
-  # For details on the format string, see top-level `printf`.
+  # For details on the format string, see top-level `::printf`.
   def printf(format_string, *args) : Nil
     printf format_string, args
   end

--- a/src/io.cr
+++ b/src/io.cr
@@ -259,7 +259,7 @@ abstract class IO
   end
 
   # Writes a formatted string to this IO.
-  # For details on the format string, see top-level `sprintf`.
+  # For details on the format string, see top-level `printf`.
   def printf(format_string, *args) : Nil
     printf format_string, args
   end

--- a/src/io.cr
+++ b/src/io.cr
@@ -259,7 +259,7 @@ abstract class IO
   end
 
   # Writes a formatted string to this IO.
-  # For details on the format string, see `Kernel::sprintf`.
+  # For details on the format string, see top-level `sprintf`.
   def printf(format_string, *args) : Nil
     printf format_string, args
   end

--- a/src/string.cr
+++ b/src/string.cr
@@ -4634,7 +4634,7 @@ class String
     !!($~ = /#{re}\z/.match(self))
   end
 
-  # Interpolates *other* into the string using top-level `sprintf`.
+  # Interpolates *other* into the string using top-level `::sprintf`.
   #
   # ```
   # "I have %d apples" % 5                                             # => "I have 5 apples"

--- a/src/string.cr
+++ b/src/string.cr
@@ -4634,7 +4634,7 @@ class String
     !!($~ = /#{re}\z/.match(self))
   end
 
-  # Interpolates *other* into the string using `Kernel#sprintf`.
+  # Interpolates *other* into the string using top-level `sprintf`.
   #
   # ```
   # "I have %d apples" % 5                                             # => "I have 5 apples"


### PR DESCRIPTION
Removes a reference to the `Kernel` module, which does not exist in Crystal.
