### PR TITLE
Add `dup` to BitArray

### DIFF
--- a/spec/std/bit_array_spec.cr
+++ b/spec/std/bit_array_spec.cr
@@ -337,4 +337,13 @@ describe "BitArray" do
     iter.next.should be_true
     iter.next.should be_a(Iterator::Stop)
   end
+
+  it "provides dup" do
+    a = BitArray.new(2)
+    b = a.dup
+
+    b[0] = true
+    a[0].should be_false
+    b[0].should be_true
+  end
 end

--- a/src/bit_array.cr
+++ b/src/bit_array.cr
@@ -243,6 +243,13 @@ struct BitArray
     hasher
   end
 
+  # Returns a new `BitArray` with all of the same elements.
+  def dup
+    bit_array = BitArray.new(@size)
+    @bits.copy_to(bit_array.@bits, malloc_size)
+    bit_array
+  end
+
   private def bit_index_and_sub_index(index)
     bit_index_and_sub_index(index) { raise IndexError.new }
   end


### PR DESCRIPTION
Adds `dup` to BitArray, which didn't exist before.