### PR TITLE
Fix typo in Nagle’s algorithm name

### DIFF
--- a/src/socket/tcp_socket.cr
+++ b/src/socket/tcp_socket.cr
@@ -60,7 +60,7 @@ class TCPSocket < IPSocket
     end
   end
 
-  # Returns `true` if the Nable algorithm is disabled.
+  # Returns `true` if the Nagle algorithm is disabled.
   def tcp_nodelay?
     getsockopt_bool LibC::TCP_NODELAY, level: Protocol::TCP
   end


### PR DESCRIPTION
Little typo, should be `Nagle` as in `John Nagle` like in `tcp_nodelay=`.