### PR TITLE
Take timestamp as an argument in Log::Entry initializer

### DIFF
--- a/src/log/entry.cr
+++ b/src/log/entry.cr
@@ -39,11 +39,11 @@ struct Log::Entry
   getter source : String
   getter severity : Severity
   getter message : String
-  getter timestamp = Time.local
+  getter timestamp : Time
   getter context : Metadata = Log.context.metadata
   getter data : Metadata
   getter exception : Exception?
 
-  def initialize(@source : String, @severity : Severity, @message : String, @data : Log::Metadata, @exception : Exception?)
+  def initialize(@source : String, @severity : Severity, @message : String, @data : Log::Metadata, @exception : Exception?, *, @timestamp = Time.local)
   end
 end


### PR DESCRIPTION
I want to store re-created `Log::Entries` from another logging system. In order to do so I need to set `Log::Entry#timestamp` property, which atm is being set to `Time.local` on object creation.