### PR TITLE
Remove unnecessary fallback 'def ==(other)'

### DIFF
--- a/spec/std/bit_array_spec.cr
+++ b/spec/std/bit_array_spec.cr
@@ -74,6 +74,10 @@ describe "BitArray" do
       (b == c).should be_false
       (a == d).should be_false
     end
+
+    it "compares other type" do
+      from_int(3, 0b101).should_not eq("other type")
+    end
   end
 
   describe "[]" do

--- a/spec/std/deque_spec.cr
+++ b/spec/std/deque_spec.cr
@@ -145,6 +145,15 @@ describe "Deque" do
       (b == c).should be_false
       (a == d).should be_false
     end
+
+    it "compares other types" do
+      a = Deque{1, 2, 3}
+      b = Deque{:foo, :bar}
+      c = "other type"
+      (a == b).should be_false
+      (b == c).should be_false
+      (a == c).should be_false
+    end
   end
 
   describe "+" do

--- a/spec/std/http/params_spec.cr
+++ b/spec/std/http/params_spec.cr
@@ -247,5 +247,21 @@ module HTTP
         Params.new.empty?.should be_true
       end
     end
+
+    describe "#==" do
+      it "compares other" do
+        a = Params.parse("a=foo&b=bar")
+        b = Params.parse("a=bar&b=foo")
+        (a == a).should be_true
+        (b == b).should be_true
+        (a == b).should be_false
+      end
+
+      it "compares other types" do
+        a = Params.parse("a=foo&b=bar")
+        b = "other type"
+        (a == b).should be_false
+      end
+    end
   end
 end

--- a/spec/std/socket/address_spec.cr
+++ b/spec/std/socket/address_spec.cr
@@ -244,4 +244,15 @@ describe Socket do
     Socket.ip?("::0::ffff:c0a8:5e4").should be_false
     Socket.ip?("c0a8").should be_false
   end
+
+  it "==" do
+    a = Socket::IPAddress.new("127.0.0.1", 8080)
+    b = Socket::UNIXAddress.new("some_path")
+    c = "sonme_path"
+    (a == a).should be_true
+    (b == b).should be_true
+    (a == b).should be_false
+    (a == c).should be_false
+    (b == c).should be_false
+  end
 end

--- a/src/bit_array.cr
+++ b/src/bit_array.cr
@@ -38,10 +38,6 @@ struct BitArray
     return LibC.memcmp(@bits, other.@bits, malloc_size) == 0
   end
 
-  def ==(other)
-    false
-  end
-
   def unsafe_fetch(index : Int)
     bit_index, sub_index = index.divmod(32)
     (@bits[bit_index] & (1 << sub_index)) > 0

--- a/src/deque.cr
+++ b/src/deque.cr
@@ -112,11 +112,6 @@ class Deque(T)
     equals?(other) { |x, y| x == y }
   end
 
-  # :nodoc:
-  def ==(other)
-    false
-  end
-
   # Concatenation. Returns a new `Deque` built by concatenating
   # two deques together to create a third. The type of the new deque
   # is the union of the types of both the other deques.

--- a/src/http/params.cr
+++ b/src/http/params.cr
@@ -146,10 +146,6 @@ module HTTP
       self.raw_params == other.raw_params
     end
 
-    def ==(other)
-      false
-    end
-
     # Returns first value for specified param name.
     #
     # ```

--- a/src/socket/address.cr
+++ b/src/socket/address.cr
@@ -50,10 +50,6 @@ class Socket
     end
 
     abstract def to_unsafe : LibC::Sockaddr*
-
-    def ==(other)
-      false
-    end
   end
 
   # IP address representation.


### PR DESCRIPTION
There are many fallback 'def ==(other)' (it returns `false` always) in stdlib. However some fallback defs are unnecessary because such fallback is already defined in ancestor type.

Thank you.