### PR TITLE
Make Errno enum values a set union of all possible LibC Errno values

### DIFF
--- a/src/errno.cr
+++ b/src/errno.cr
@@ -16,21 +16,35 @@ end
 
 # Errno wraps and gives access to libc's errno. This is mostly useful when
 # dealing with C libraries.
+#
+# The integer values of these errors are platform-specific and should not be directly relied on.
+# If an error code is not applicable on the current platform, its value will be `INVALID`.
+#
+# Intended usages are of the form `if exc.os_error == Errno::ENOATTR`: with this we are checking
+# whether the OS-specific error is of the `ENOATTR` kind, even if the actual value of
+# `Errno::ENOATTR` might vary across platforms or be equal to `Errno::INVALID` if that platform has
+# no such error (so the equality can never be true on that platform, but the code still compiles).
 enum Errno
-  NONE = 0
+  NONE    =  0
+  INVALID = -1
 
-  {% for value in %w(E2BIG EPERM ENOENT ESRCH EINTR EIO ENXIO ENOEXEC EBADF ECHILD EDEADLK ENOMEM
-                    EACCES EFAULT ENOTBLK EBUSY EEXIST EXDEV ENODEV ENOTDIR EISDIR EINVAL ENFILE
-                    EMFILE ENOTTY ETXTBSY EFBIG ENOSPC ESPIPE EROFS EMLINK EPIPE EDOM ERANGE EAGAIN
-                    EWOULDBLOCK EINPROGRESS EALREADY ENOTSOCK EDESTADDRREQ EMSGSIZE EPROTOTYPE ENOPROTOOPT
-                    EPROTONOSUPPORT ESOCKTNOSUPPORT EPFNOSUPPORT EAFNOSUPPORT EADDRINUSE EADDRNOTAVAIL
-                    ENETDOWN ENETUNREACH ENETRESET ECONNABORTED ECONNRESET ENOBUFS EISCONN ENOTCONN
-                    ESHUTDOWN ETOOMANYREFS ETIMEDOUT ECONNREFUSED ELOOP ENAMETOOLONG EHOSTDOWN
-                    EHOSTUNREACH ENOTEMPTY EUSERS EDQUOT ESTALE EREMOTE ENOLCK ENOSYS EOVERFLOW
-                    ECANCELED EIDRM ENOMSG EILSEQ EBADMSG EMULTIHOP ENODATA ENOLINK ENOSR ENOSTR
-                    EPROTO ETIME EOPNOTSUPP ENOTRECOVERABLE EOWNERDEAD) %}
+  # grep -hE '^ *\w+ *=' src/lib_c/*/c/errno.cr | awk '{print $1}' | sort -u | xargs | fold -s -w81
+
+  {% for value in %w(
+                    E2BIG EACCES EADDRINUSE EADDRNOTAVAIL EAFNOSUPPORT EAGAIN EALREADY EBADF EBADMSG
+                    EBUSY ECANCELED ECHILD ECONNABORTED ECONNREFUSED ECONNRESET EDEADLK EDESTADDRREQ
+                    EDOM EDQUOT EEXIST EFAULT EFBIG EHOSTUNREACH EIDRM EILSEQ EINPROGRESS EINTR
+                    EINVAL EIO EISCONN EISDIR ELOOP EMFILE EMLINK EMSGSIZE EMULTIHOP ENAMETOOLONG
+                    ENETDOWN ENETRESET ENETUNREACH ENFILE ENOBUFS ENODATA ENODEV ENOENT ENOEXEC
+                    ENOLCK ENOLINK ENOMEM ENOMSG ENOPROTOOPT ENOSPC ENOSR ENOSTR ENOSYS ENOTCONN
+                    ENOTDIR ENOTEMPTY ENOTRECOVERABLE ENOTSOCK ENOTSUP ENOTTY ENXIO EOPNOTSUPP
+                    EOVERFLOW EOWNERDEAD EPERM EPIPE EPROTO EPROTONOSUPPORT EPROTOTYPE ERANGE EROFS
+                    ESPIPE ESRCH ESTALE ETIME ETIMEDOUT ETXTBSY EWOULDBLOCK EXDEV STRUNCATE
+                  ) %}
     {% if LibC.has_constant?(value) %}
       {{value.id}} = LibC::{{value.id}}
+    {% else %}
+      {{value.id}} = INVALID
     {% end %}
   {% end %}
 


### PR DESCRIPTION
So, if an error name is available on at least one platform, it is possible to refer to it on all platforms, even if its value is `INVALID = -1`.
That is in accordance with Crystal's planned API guarantee: if it compiles on one platform, it should compile on any platform.
This is not problematic because all usages should be of the form `if err == Errno::ENOATTR`, and if such a value is not possible to encounter on a given platform, it's expected that the equality will never be true. Additionally, if the platform in the future gains more possible error codes that we're not aware of yet, the equality with them will also be false (they are not clumped into `INVALID` but rather have their normal integer value, just that it's not known to the `enum` -- `to_s` and such).

Also update and sort the list of all errors accordingly.

---

Prior discussion: https://github.com/crystal-lang/crystal/pull/8885#discussion_r390700078
This is an alternative to https://github.com/crystal-lang/crystal/pull/9523#issuecomment-653021203