### PR TITLE
Fix E notation parsing in `BigDecimal`

### DIFF
--- a/spec/std/big/big_decimal_spec.cr
+++ b/spec/std/big/big_decimal_spec.cr
@@ -9,6 +9,9 @@ describe BigDecimal do
     BigDecimal.new("41.0123")
       .should eq(BigDecimal.new(BigInt.new(410123), 4))
 
+    BigDecimal.new("000041.0123")
+      .should eq(BigDecimal.new(BigInt.new(410123), 4))
+
     BigDecimal.new(1)
       .should eq(BigDecimal.new(BigInt.new(1)))
 
@@ -245,6 +248,64 @@ describe BigDecimal do
     "10e+8".to_big_d.should eq(BigDecimal.new("1000000000"))
     "10E+8".to_big_d.should eq(BigDecimal.new("1000000000"))
     "10E8".to_big_d.should eq(BigDecimal.new("1000000000"))
+  end
+
+  it "raises InvalidBigDecimalException when initializing from invalid E notation" do
+    expect_raises(InvalidBigDecimalException) do
+      BigDecimal.new("1ee1")
+    end
+
+    expect_raises(InvalidBigDecimalException) do
+      BigDecimal.new("e+e1")
+    end
+
+    expect_raises(InvalidBigDecimalException) do
+      BigDecimal.new("1 e1")
+    end
+
+    expect_raises(InvalidBigDecimalException) do
+      BigDecimal.new("..e1")
+    end
+
+    expect_raises(InvalidBigDecimalException) do
+      BigDecimal.new("-..e1")
+    end
+
+    expect_raises(InvalidBigDecimalException) do
+      BigDecimal.new("e1")
+    end
+
+    expect_raises(InvalidBigDecimalException) do
+      BigDecimal.new("e+5")
+    end
+
+    expect_raises(InvalidBigDecimalException) do
+      BigDecimal.new(".e1")
+    end
+
+    expect_raises(InvalidBigDecimalException) do
+      BigDecimal.new(".e+1")
+    end
+
+    expect_raises(InvalidBigDecimalException) do
+      BigDecimal.new("-.e1")
+    end
+
+    expect_raises(InvalidBigDecimalException) do
+      BigDecimal.new("1e.")
+    end
+
+    expect_raises(InvalidBigDecimalException) do
+      BigDecimal.new("1e0.1")
+    end
+
+    expect_raises(InvalidBigDecimalException) do
+      BigDecimal.new("1e+")
+    end
+
+    expect_raises(InvalidBigDecimalException) do
+      BigDecimal.new("1.0e")
+    end
   end
 
   it "is comparable with other types" do

--- a/spec/std/big/big_decimal_spec.cr
+++ b/spec/std/big/big_decimal_spec.cr
@@ -9,9 +9,6 @@ describe BigDecimal do
     BigDecimal.new("41.0123")
       .should eq(BigDecimal.new(BigInt.new(410123), 4))
 
-    BigDecimal.new("000041.0123")
-      .should eq(BigDecimal.new(BigInt.new(410123), 4))
-
     BigDecimal.new(1)
       .should eq(BigDecimal.new(BigInt.new(1)))
 
@@ -111,6 +108,74 @@ describe BigDecimal do
 
     expect_raises(InvalidBigDecimalException) do
       BigDecimal.new("1.2a")
+    end
+
+    expect_raises(InvalidBigDecimalException) do
+      BigDecimal.new("1ee1")
+    end
+
+    expect_raises(InvalidBigDecimalException) do
+      BigDecimal.new("e+e1")
+    end
+
+    expect_raises(InvalidBigDecimalException) do
+      BigDecimal.new("1e1e")
+    end
+
+    expect_raises(InvalidBigDecimalException) do
+      BigDecimal.new("1 e1")
+    end
+
+    expect_raises(InvalidBigDecimalException) do
+      BigDecimal.new("..e1")
+    end
+
+    expect_raises(InvalidBigDecimalException) do
+      BigDecimal.new("-..e1")
+    end
+
+    expect_raises(InvalidBigDecimalException) do
+      BigDecimal.new("e1")
+    end
+
+    expect_raises(InvalidBigDecimalException) do
+      BigDecimal.new("e+5")
+    end
+
+    expect_raises(InvalidBigDecimalException) do
+      BigDecimal.new(".e1")
+    end
+
+    expect_raises(InvalidBigDecimalException) do
+      BigDecimal.new(".e+1")
+    end
+
+    expect_raises(InvalidBigDecimalException) do
+      BigDecimal.new("-.e1")
+    end
+
+    expect_raises(InvalidBigDecimalException) do
+      BigDecimal.new("1e.")
+    end
+
+    expect_raises(InvalidBigDecimalException) do
+      BigDecimal.new("1e0.1")
+    end
+
+    expect_raises(InvalidBigDecimalException) do
+      BigDecimal.new("1e+")
+    end
+
+    expect_raises(InvalidBigDecimalException) do
+      BigDecimal.new("1.1e-")
+    end
+
+    expect_raises(InvalidBigDecimalException) do
+      BigDecimal.new("-")
+    end
+
+    expect_raises(InvalidBigDecimalException) do
+      BigDecimal.new("1.0e")
     end
   end
 
@@ -248,72 +313,6 @@ describe BigDecimal do
     "10e+8".to_big_d.should eq(BigDecimal.new("1000000000"))
     "10E+8".to_big_d.should eq(BigDecimal.new("1000000000"))
     "10E8".to_big_d.should eq(BigDecimal.new("1000000000"))
-  end
-
-  it "raises InvalidBigDecimalException when initializing from invalid E notation" do
-    expect_raises(InvalidBigDecimalException) do
-      BigDecimal.new("1ee1")
-    end
-
-    expect_raises(InvalidBigDecimalException) do
-      BigDecimal.new("e+e1")
-    end
-
-    expect_raises(InvalidBigDecimalException) do
-      BigDecimal.new("1e1e")
-    end
-
-    expect_raises(InvalidBigDecimalException) do
-      BigDecimal.new("1 e1")
-    end
-
-    expect_raises(InvalidBigDecimalException) do
-      BigDecimal.new("..e1")
-    end
-
-    expect_raises(InvalidBigDecimalException) do
-      BigDecimal.new("-..e1")
-    end
-
-    expect_raises(InvalidBigDecimalException) do
-      BigDecimal.new("e1")
-    end
-
-    expect_raises(InvalidBigDecimalException) do
-      BigDecimal.new("e+5")
-    end
-
-    expect_raises(InvalidBigDecimalException) do
-      BigDecimal.new(".e1")
-    end
-
-    expect_raises(InvalidBigDecimalException) do
-      BigDecimal.new(".e+1")
-    end
-
-    expect_raises(InvalidBigDecimalException) do
-      BigDecimal.new("-.e1")
-    end
-
-    expect_raises(InvalidBigDecimalException) do
-      BigDecimal.new("1e.")
-    end
-
-    expect_raises(InvalidBigDecimalException) do
-      BigDecimal.new("1e0.1")
-    end
-
-    expect_raises(InvalidBigDecimalException) do
-      BigDecimal.new("1e+")
-    end
-
-    expect_raises(InvalidBigDecimalException) do
-      BigDecimal.new("1.1e-")
-    end
-
-    expect_raises(InvalidBigDecimalException) do
-      BigDecimal.new("1.0e")
-    end
   end
 
   it "is comparable with other types" do

--- a/spec/std/big/big_decimal_spec.cr
+++ b/spec/std/big/big_decimal_spec.cr
@@ -260,6 +260,10 @@ describe BigDecimal do
     end
 
     expect_raises(InvalidBigDecimalException) do
+      BigDecimal.new("1e1e")
+    end
+
+    expect_raises(InvalidBigDecimalException) do
       BigDecimal.new("1 e1")
     end
 
@@ -301,6 +305,10 @@ describe BigDecimal do
 
     expect_raises(InvalidBigDecimalException) do
       BigDecimal.new("1e+")
+    end
+
+    expect_raises(InvalidBigDecimalException) do
+      BigDecimal.new("1.1e-")
     end
 
     expect_raises(InvalidBigDecimalException) do

--- a/src/big/big_decimal.cr
+++ b/src/big/big_decimal.cr
@@ -76,6 +76,8 @@ struct BigDecimal < Number
     # Check str's validity and find index of 'e'
     exponent_index = nil
 
+    input_length = str.bytesize
+
     str.each_char_with_index do |char, index|
       case char
       when '-'
@@ -83,16 +85,16 @@ struct BigDecimal < Number
           raise InvalidBigDecimalException.new(str, "Unexpected '-' character")
         end
       when '+'
-        unless exponent_index == index - 1
+        if index == input_length - 1 || exponent_index != index - 1
           raise InvalidBigDecimalException.new(str, "Unexpected '+' character")
         end
       when '.'
-        if decimal_index
+        if decimal_index || exponent_index
           raise InvalidBigDecimalException.new(str, "Unexpected '.' character")
         end
         decimal_index = index
       when 'e', 'E'
-        if exponent_index
+        if index == 0 || index == input_length - 1 || exponent_index || decimal_index == index - 1
           raise InvalidBigDecimalException.new(str, "Unexpected #{char.inspect} character")
         end
         exponent_index = index
@@ -103,7 +105,7 @@ struct BigDecimal < Number
       end
     end
 
-    decimal_end_index = (exponent_index || str.bytesize) - 1
+    decimal_end_index = (exponent_index || input_length) - 1
     if decimal_index
       decimal_count = (decimal_end_index - decimal_index).to_u64
 

--- a/src/big/big_decimal.cr
+++ b/src/big/big_decimal.cr
@@ -79,13 +79,15 @@ struct BigDecimal < Number
     input_length = str.bytesize
 
     str.each_char_with_index do |char, index|
+      final_character = index == input_length - 1
+      first_character = index == 0
       case char
       when '-'
-        unless index == 0 || exponent_index == index - 1
+        unless first_character || (exponent_index == index - 1 && !final_character)
           raise InvalidBigDecimalException.new(str, "Unexpected '-' character")
         end
       when '+'
-        if index == input_length - 1 || exponent_index != index - 1
+        if final_character || exponent_index != index - 1
           raise InvalidBigDecimalException.new(str, "Unexpected '+' character")
         end
       when '.'
@@ -94,7 +96,7 @@ struct BigDecimal < Number
         end
         decimal_index = index
       when 'e', 'E'
-        if index == 0 || index == input_length - 1 || exponent_index || decimal_index == index - 1
+        if first_character || final_character || exponent_index || decimal_index == index - 1
           raise InvalidBigDecimalException.new(str, "Unexpected #{char.inspect} character")
         end
         exponent_index = index

--- a/src/big/big_decimal.cr
+++ b/src/big/big_decimal.cr
@@ -83,7 +83,7 @@ struct BigDecimal < Number
       first_character = index == 0
       case char
       when '-'
-        unless first_character || (exponent_index == index - 1 && !final_character)
+        unless (first_character && !final_character) || (exponent_index == index - 1 && !final_character)
           raise InvalidBigDecimalException.new(str, "Unexpected '-' character")
         end
       when '+'


### PR DESCRIPTION
Fixes #9547 

These changes fix the various classes of problems i could find by fuzzing the passing of E notation in `BigDecimal`

