### PR TITLE
RFC: E notation BigDecimal parser

### DIFF
--- a/spec/std/big/big_decimal_spec.cr
+++ b/spec/std/big/big_decimal_spec.cr
@@ -73,41 +73,23 @@ describe BigDecimal do
       .should eq(BigDecimal.new(BigInt.new(5), 1))
   end
 
-  it "raises InvalidBigDecimalException when initializing from invalid input" do
-    expect_raises(InvalidBigDecimalException) do
-      BigDecimal.new("derp")
+  it "raises when initializing from invalid input" do
+    [
+      "derp", "1.2.3", "..2", "1..2",
+      "a1.2", "1a.2", "1.a2", "1.2a",
+      "1ee1", "e+e1",
+      "1 e1", "1e 1",
+      "..e1", "-..e1",
+      "e1", "e+5", ".e1", ".e+1", "-.e1",
+      "1e.", "1e0.1",
+    ].each do |s|
+      expect_raises(ArgumentError, /^Unexpected '/) { BigDecimal.new(s) }
     end
 
-    expect_raises(InvalidBigDecimalException) do
-      BigDecimal.new("")
-    end
-
-    expect_raises(InvalidBigDecimalException) do
-      BigDecimal.new("1.2.3")
-    end
-
-    expect_raises(InvalidBigDecimalException) do
-      BigDecimal.new("..2")
-    end
-
-    expect_raises(InvalidBigDecimalException) do
-      BigDecimal.new("1..2")
-    end
-
-    expect_raises(InvalidBigDecimalException) do
-      BigDecimal.new("a1.2")
-    end
-
-    expect_raises(InvalidBigDecimalException) do
-      BigDecimal.new("1a.2")
-    end
-
-    expect_raises(InvalidBigDecimalException) do
-      BigDecimal.new("1.a2")
-    end
-
-    expect_raises(InvalidBigDecimalException) do
-      BigDecimal.new("1.2a")
+    [
+      "", ".", "1e+", "1.1e-", "1.0e",
+    ].each do |s|
+      expect_raises(ArgumentError, "Unexpected end of number string") { BigDecimal.new(s) }
     end
   end
 

--- a/src/big/big_decimal.cr
+++ b/src/big/big_decimal.cr
@@ -93,7 +93,7 @@ struct BigDecimal < Number
     end
   end
 
-  private def parse_e_notation(iterator) : Tuple(String, Bool, String | Nil, String | Nil, Bool)
+  private def parse_e_notation(iterator)
     token = take_next_character(iterator)
     value_negative = false
     if token_sign?(token)
@@ -106,11 +106,11 @@ struct BigDecimal < Number
     {value_str, value_negative, fraction_str, exponent_str, exponent_negative}
   end
 
-  private def parse_sign_symbol(token, iterator) : Tuple(Tuple(Char | Nil, Int32), Bool)
+  private def parse_sign_symbol(token, iterator)
     {take_next_character(iterator), token[0] == '-'}
   end
 
-  private def parse_numerical_part(token, iterator) : Tuple(Tuple(Char | Nil, Int32), String, String | Nil, String | Nil, Bool)
+  private def parse_numerical_part(token, iterator)
     value_str = ""
     fraction_str = nil
     if token_digit?(token)
@@ -126,7 +126,7 @@ struct BigDecimal < Number
     {next_token, value_str, fraction_str, exponent_str, exponent_negative}
   end
 
-  private def parse_digits(token, iterator) : Tuple(Tuple(Char | Nil, Int32), String)
+  private def parse_digits(token, iterator)
     val = String.build do |io|
       while token_digit?(token)
         io << token[0]
@@ -136,12 +136,12 @@ struct BigDecimal < Number
     {token, val}
   end
 
-  private def parse_fractional_part(token, iterator) : Tuple(Tuple(Char | Nil, Int32), String)
+  private def parse_fractional_part(token, iterator)
     token = take_next_character(iterator, true) # consume '.'
     parse_digits(token, iterator)
   end
 
-  private def parse_exponent_part(token, iterator) : Tuple(Tuple(Char | Nil, Int32), String, Bool)
+  private def parse_exponent_part(token, iterator)
     token = take_next_character(iterator) # consume 'e'
     if token_sign?(token)
       next_token, exponent_negative = parse_sign_symbol(token, iterator)
@@ -155,7 +155,7 @@ struct BigDecimal < Number
     end
   end
 
-  private def parse_end(token) : Nil
+  private def parse_end(token)
     raise_parse_error(token) unless token_end?(token)
   end
 


### PR DESCRIPTION
Related to : #9580 

This implements a first pass at this (not stack based parser, to avoid needing a stack, just a translation of the parse table into logic)

PR which is still a work in progress and would benefit from your inputs should we wish to progress with this

created with the productions below (syntax below works in http://hackingoff.com/compilers/ll-1-parser-generator)

```
Scientific -> OptionalSign Number
OptionalSign -> s |
Number -> Digits OptionalFractional OptionalExponent | Fractional OptionalExponent
OptionalFractional -> '.' OptionalDigits  
Fractional -> '.' Digits
OptionalExponent -> e OptionalSign Digits | 
OptionalDigits -> Digits |  
Digits -> Digit RepeatDigit
RepeatDigit -> Digit |  
Digit -> n 
```