### PR TITLE
Disable AArch64 jobs on forks

### DIFF
--- a/.github/workflows/aarch64.yml
+++ b/.github/workflows/aarch64.yml
@@ -5,6 +5,7 @@ on: [push, pull_request]
 jobs:
   musl-build:
     runs-on: [linux, ARM64]
+    if: github.repository == 'crystal-lang/crystal'
     steps:
       - name: Download Crystal source
         uses: actions/checkout@v2
@@ -20,6 +21,7 @@ jobs:
   musl-test-stdlib:
     needs: musl-build
     runs-on: [linux, ARM64]
+    if: github.repository == 'crystal-lang/crystal'
     steps:
       - name: Download Crystal source
         uses: actions/checkout@v2
@@ -37,6 +39,7 @@ jobs:
   musl-test-compiler:
     needs: musl-build
     runs-on: [linux, ARM64]
+    if: github.repository == 'crystal-lang/crystal'
     steps:
       - name: Download Crystal source
         uses: actions/checkout@v2
@@ -53,6 +56,7 @@ jobs:
           args: make compiler_spec
   gnu-build:
     runs-on: [linux, ARM64]
+    if: github.repository == 'crystal-lang/crystal'
     steps:
       - name: Download Crystal source
         uses: actions/checkout@v2
@@ -68,6 +72,7 @@ jobs:
   gnu-test-stdlib:
     needs: gnu-build
     runs-on: [linux, ARM64]
+    if: github.repository == 'crystal-lang/crystal'
     steps:
       - name: Download Crystal source
         uses: actions/checkout@v2
@@ -85,6 +90,7 @@ jobs:
   gnu-test-compiler:
     needs: gnu-build
     runs-on: [linux, ARM64]
+    if: github.repository == 'crystal-lang/crystal'
     steps:
       - name: Download Crystal source
         uses: actions/checkout@v2


### PR DESCRIPTION
Now that #9508 is merged, the workflow is being executed on every commit, even on repository forks. I don't know a better way to disable it. I tried with an environment variable, but seems like unfortunately they are not available at the `job.if` level.