### PR TITLE
Check abstract def implementations with splats, default values and keyword arguments

### DIFF
--- a/spec/compiler/semantic/abstract_def_spec.cr
+++ b/spec/compiler/semantic/abstract_def_spec.cr
@@ -810,4 +810,32 @@ describe "Semantic: abstract def" do
       end
       )
   end
+
+  it "errors if implementation doesn't have a splat" do
+    assert_error %(
+      abstract class Foo
+        abstract def foo(*args)
+      end
+
+      class Bar < Foo
+        def foo(x = 1)
+        end
+      end
+      ),
+      "abstract `def Foo#foo(*args)` must be implemented by Bar"
+  end
+
+  it "errors if implementation doesn't match splat type" do
+    assert_error %(
+      abstract class Foo
+        abstract def foo(*args : Int32)
+      end
+
+      class Bar < Foo
+        def foo(*args : String)
+        end
+      end
+      ),
+      "abstract `def Foo#foo(*args : Int32)` must be implemented by Bar"
+  end
 end

--- a/spec/compiler/semantic/abstract_def_spec.cr
+++ b/spec/compiler/semantic/abstract_def_spec.cr
@@ -783,4 +783,31 @@ describe "Semantic: abstract def" do
       end
       )
   end
+
+  it "errors if implementation has more keyword arguments" do
+    assert_error %(
+      abstract class Foo
+        abstract def foo(*, x)
+      end
+
+      class Bar < Foo
+        def foo(*, x, y)
+        end
+      end
+      ),
+      "abstract `def Foo#foo(*, x)` must be implemented by Bar"
+  end
+
+  it "doesn't error if implementation has more keyword arguments with default values" do
+    semantic %(
+      abstract class Foo
+        abstract def foo(*, x)
+      end
+
+      class Bar < Foo
+        def foo(*, x, y = 1)
+        end
+      end
+      )
+  end
 end

--- a/spec/compiler/semantic/abstract_def_spec.cr
+++ b/spec/compiler/semantic/abstract_def_spec.cr
@@ -715,4 +715,72 @@ describe "Semantic: abstract def" do
       ),
       "abstract `def Foo#foo(x = 1)` must be implemented by Bar"
   end
+
+  it "errors if implementation doesn't have keyword arguments" do
+    assert_error %(
+      abstract class Foo
+        abstract def foo(*, x)
+      end
+
+      class Bar < Foo
+        def foo(a = 0, b = 0)
+        end
+      end
+      ),
+      "abstract `def Foo#foo(*, x)` must be implemented by Bar"
+  end
+
+  it "errors if implementation doesn't have a keyword argument" do
+    assert_error %(
+      abstract class Foo
+        abstract def foo(*, x)
+      end
+
+      class Bar < Foo
+        def foo(*, y)
+        end
+      end
+      ),
+      "abstract `def Foo#foo(*, x)` must be implemented by Bar"
+  end
+
+  it "doesn't error if implementation matches keyword argument" do
+    semantic %(
+      abstract class Foo
+        abstract def foo(*, x)
+      end
+
+      class Bar < Foo
+        def foo(*, x)
+        end
+      end
+      )
+  end
+
+  it "errors if implementation doesn't match keyword argument type" do
+    assert_error %(
+      abstract class Foo
+        abstract def foo(*, x : Int32)
+      end
+
+      class Bar < Foo
+        def foo(*, x : String)
+        end
+      end
+      ),
+      "abstract `def Foo#foo(*, x : Int32)` must be implemented by Bar"
+  end
+
+  it "doesn't error if implementation have keyword arguments in different order" do
+    semantic %(
+      abstract class Foo
+        abstract def foo(*, x : Int32, y : String)
+      end
+
+      class Bar < Foo
+        def foo(*, y : String, x : Int32)
+        end
+      end
+      )
+  end
 end

--- a/spec/compiler/semantic/abstract_def_spec.cr
+++ b/spec/compiler/semantic/abstract_def_spec.cr
@@ -674,4 +674,45 @@ describe "Semantic: abstract def" do
       end
     ))
   end
+
+  it "doesn't error if implementation have default value" do
+    semantic %(
+      abstract class Foo
+        abstract def foo(x)
+      end
+
+      class Bar < Foo
+        def foo(x = 1)
+        end
+      end
+      )
+  end
+
+  it "errors if implementation doesn't have default value" do
+    assert_error %(
+      abstract class Foo
+        abstract def foo(x = 1)
+      end
+
+      class Bar < Foo
+        def foo(x)
+        end
+      end
+      ),
+      "abstract `def Foo#foo(x = 1)` must be implemented by Bar"
+  end
+
+  it "errors if implementation doesn't have the same default value" do
+    assert_error %(
+      abstract class Foo
+        abstract def foo(x = 1)
+      end
+
+      class Bar < Foo
+        def foo(x = 2)
+        end
+      end
+      ),
+      "abstract `def Foo#foo(x = 1)` must be implemented by Bar"
+  end
 end

--- a/spec/compiler/semantic/abstract_def_spec.cr
+++ b/spec/compiler/semantic/abstract_def_spec.cr
@@ -838,4 +838,43 @@ describe "Semantic: abstract def" do
       ),
       "abstract `def Foo#foo(*args : Int32)` must be implemented by Bar"
   end
+
+  it "doesn't error with splat" do
+    semantic %(
+      abstract class Foo
+        abstract def foo(*args)
+      end
+
+      class Bar < Foo
+        def foo(*args)
+        end
+      end
+    )
+  end
+
+  it "doesn't error with splat and args with default value" do
+    semantic %(
+      abstract class Foo
+        abstract def foo(*args)
+      end
+
+      class Bar < Foo
+        def foo(a = 1, *args)
+        end
+      end
+    )
+  end
+
+  it "allows arguments to be collapsed into splat" do
+    semantic %(
+      abstract class Foo
+        abstract def foo(a : Int32, b : String)
+      end
+
+      class Bar < Foo
+        def foo(*args : Int32 | String)
+        end
+      end
+    )
+  end
 end

--- a/src/compiler/crystal/semantic/abstract_def_checker.cr
+++ b/src/compiler/crystal/semantic/abstract_def_checker.cr
@@ -48,8 +48,8 @@ class Crystal::AbstractDefChecker
         defs_with_metadata.each do |def_with_metadata|
           a_def = def_with_metadata.def
           if a_def.abstract?
-            # TODO: for now we skip methods with splats and default arguments
-            next if a_def.splat_index || a_def.args.any? &.default_value
+            # TODO: for now we skip methods with splats
+            next if a_def.splat_index
 
             check_implemented_in_subtypes(type, a_def)
           end
@@ -138,6 +138,10 @@ class Crystal::AbstractDefChecker
     end
 
     m2.args.zip(m1.args) do |a2, a1|
+      if a2.default_value
+        return false unless a1.default_value == a2.default_value
+      end
+
       r1 = a1.restriction
       r2 = a2.restriction
       if r2 && r1 && r1 != r2

--- a/src/compiler/crystal/semantic/abstract_def_checker.cr
+++ b/src/compiler/crystal/semantic/abstract_def_checker.cr
@@ -145,14 +145,24 @@ class Crystal::AbstractDefChecker
       return false unless m1.args[m2_args.size].default_value
     end
 
+    # Index keyword arguments
+    kargs =
+      m1_kargs.to_h do |i|
+        a1 = m1.args[i]
+        {a1.name, a1}
+      end
+
     # Check keyword arguments
     m2_kargs.each do |i|
       a2 = m2.args[i]
-      j = m1.args.index(m1_kargs.begin) { |a1| a1.name == a2.name }
-      return false unless j
-      a1 = m1.args[j]
-
+      a1 = kargs.delete(a2.name)
+      return false unless a1
       return false unless check_arg(t1, a1, t2, a2)
+    end
+
+    # Remaining keyword arguments must have a default value
+    kargs.each_value do |a1|
+      return false unless a1.default_value
     end
 
     true

--- a/src/compiler/crystal/semantic/abstract_def_checker.cr
+++ b/src/compiler/crystal/semantic/abstract_def_checker.cr
@@ -116,6 +116,15 @@ class Crystal::AbstractDefChecker
     return false unless m1.yields == m2.yields
     return false if m1.args.size < m2.args.size
 
+    # Check splat argument
+    if s2 = m2.splat_index
+      return false unless s1 = m1.splat_index
+
+      a1 = m1.args[s1]
+      a2 = m2.args[s2]
+      return false unless check_arg(t1, a1, t2, a2)
+    end
+
     m1_args, m1_kargs = def_arg_ranges(m1)
     m2_args, m2_kargs = def_arg_ranges(m2)
 

--- a/src/compiler/crystal/semantic/abstract_def_checker.cr
+++ b/src/compiler/crystal/semantic/abstract_def_checker.cr
@@ -114,21 +114,9 @@ class Crystal::AbstractDefChecker
     return false if m1.abstract?
     return false unless m1.name == m2.name
     return false unless m1.yields == m2.yields
-    return false if m1.args.size < m2.args.size
-
-    # Check splat argument
-    if s2 = m2.splat_index
-      return false unless s1 = m1.splat_index
-
-      a1 = m1.args[s1]
-      a2 = m2.args[s2]
-      return false unless check_arg(t1, a1, t2, a2)
-    end
 
     m1_args, m1_kargs = def_arg_ranges(m1)
     m2_args, m2_kargs = def_arg_ranges(m2)
-
-    return false if m1_args.size < m2_args.size || m1_kargs.size < m2_kargs.size
 
     # If the base type is a generic type, we find the generic instantiation of
     # t1 for it. This will have a mapping of type vars to types, for example
@@ -142,16 +130,54 @@ class Crystal::AbstractDefChecker
       m2 = replace_method_arg_paths_with_type_vars(t2, m2, generic_base)
     end
 
-    # Check positional arguments
-    m2_args.each do |i|
-      a1 = m1.args[i]
-      a2 = m2.args[i]
-      return false unless check_arg(t1, a1, t2, a2)
-    end
+    # First check positional arguments
+    # The following algorithm walk through the arguments in the abstract
+    # method and the implementation at the same time, until a splat argument is found
+    # or the end of the positional argument list is reached in both lists.
+    # The table below resumes the allowed cases (OK) and rejected (x) for each combination
+    # of the argument in the implementation (a1) and the abstract def (a2).
+    # `an = Dn` represents an argument with a default value. `-` represents that
+    # no more arguments are available to compare.
+    # Allowed cases are then verified that they have compatible default value
+    # and type restrictions.
+    #
+    #         |  a2  | a2 = D2 | *a2 |  -  |
+    # a1      |  OK  |   x     | x   |  x  |
+    # a1 = D1 |  OK  |   OK    | OK  |  OK |
+    # *a1     |  OK  |   x     | OK  |  OK |
+    # -       |  x   |   x     | x   |  OK |
+    i1 = i2 = 0
+    loop do
+      a1 = i1 <= m1_args ? m1.args[i1] : nil
+      a2 = i2 <= m2_args ? m2.args[i2] : nil
 
-    # If the method has more arguments, but default values for them, it implements it
-    if m1_args.size > m2_args.size
-      return false unless m1.args[m2_args.size].default_value
+      case
+      when !a1
+        # No more arguments in the implementation
+        return false unless !a2
+      when i1 == m1.splat_index
+        # The argument in the implementation is a splat
+        return false if a2 && a2.default_value
+      when !a1.default_value
+        # The argument in the implementation doesn't have a default value
+        return false if !a2 || a2.default_value || i2 == m2.splat_index
+      end
+
+      if a1 && a2
+        return false unless check_arg(t1, a1, t2, a2)
+      end
+
+      # Move next, unless we're on the splat already or at the end of the arguments
+      done = true
+      unless i1 == m1.splat_index || a1 == nil
+        i1 += 1
+        done = false
+      end
+      unless i2 == m2.splat_index || a2 == nil
+        i2 += 1
+        done = false
+      end
+      break if done
     end
 
     # Index keyword arguments
@@ -179,9 +205,13 @@ class Crystal::AbstractDefChecker
 
   private def def_arg_ranges(method : Def)
     if splat = method.splat_index
-      {(0...splat), (splat + 1...method.args.size)}
+      if method.args[splat].name.size == 0
+        {splat - 1, (splat + 1...method.args.size)}
+      else
+        {splat, (splat + 1...method.args.size)}
+      end
     else
-      {(0...method.args.size), (0...0)}
+      {method.args.size - 1, (0...0)}
     end
   end
 


### PR DESCRIPTION
Now methods with default arguments are checked that are implemented with the exact same value. In the future this restriction could be relaxed, by making the abstract def to implicitly define an overload with less arguments, just like other methods.

Methods with splats can be implemented exactly as the abstract method defines, but also cases like these are supported:
```crystal
abstract def foo(*args)
def foo(a = 1, b = 2, *args)
```

```crystal
abstract def foo(a : T1, b : T2, *args : T3)
def foo(*args : T1 | T2 | T3)
```

Keywords arguments are allowed in any order. Extra keyword arguments are allowed if they have a default value.