### PR TITLE
Change Set#delete to return Bool

### DIFF
--- a/spec/std/set_spec.cr
+++ b/spec/std/set_spec.cr
@@ -63,9 +63,14 @@ describe "Set" do
       set.includes?(3).should be_true
     end
 
-    it "returns self" do
+    it "returns the object is present" do
       set = Set{1, 2, 3}
-      set.delete(2).should eq(set)
+      set.delete(2).should eq(2)
+    end
+
+    it "returns nil if the object is absent" do
+      set = Set{1, 2, 3}
+      set.delete(0).should eq(nil)
     end
   end
 

--- a/spec/std/set_spec.cr
+++ b/spec/std/set_spec.cr
@@ -65,12 +65,12 @@ describe "Set" do
 
     it "returns the object is present" do
       set = Set{1, 2, 3}
-      set.delete(2).should eq(2)
+      set.delete(2).should be_true
     end
 
     it "returns nil if the object is absent" do
       set = Set{1, 2, 3}
-      set.delete(0).should eq(nil)
+      set.delete(0).should be_false
     end
   end
 

--- a/spec/std/set_spec.cr
+++ b/spec/std/set_spec.cr
@@ -63,12 +63,12 @@ describe "Set" do
       set.includes?(3).should be_true
     end
 
-    it "returns the object is present" do
+    it "returns true when the object was present" do
       set = Set{1, 2, 3}
       set.delete(2).should be_true
     end
 
-    it "returns nil if the object is absent" do
+    it "returns false when the object was absent" do
       set = Set{1, 2, 3}
       set.delete(0).should be_false
     end

--- a/src/set.cr
+++ b/src/set.cr
@@ -145,8 +145,7 @@ struct Set(T)
   # s.includes? 5 # => false
   # ```
   def delete(object) : T?
-    @hash.delete(object) { return }
-    object
+    @hash.delete(object) { return nil }
   end
 
   # Returns the number of elements in the set.

--- a/src/set.cr
+++ b/src/set.cr
@@ -144,7 +144,7 @@ struct Set(T)
   # s.delete 5    # => 5
   # s.includes? 5 # => false
   # ```
-  def delete(object)
+  def delete(object) : T?
     @hash.delete(object) { return }
     object
   end

--- a/src/set.cr
+++ b/src/set.cr
@@ -144,7 +144,8 @@ struct Set(T)
   # s.delete 5    # => 5
   # s.includes? 5 # => false
   # ```
-  def delete(object)
+  def delete(object) : T?
+    return nil if !object.is_a? T
     @hash.delete(object) { return nil }
     object
   end

--- a/src/set.cr
+++ b/src/set.cr
@@ -136,7 +136,7 @@ struct Set(T)
     @hash.has_key?(object)
   end
 
-  # Deletes the *object* and returns it, otherwise returns nil.
+  # Removes the *object* and returns it, otherwise returns `nil`.
   #
   # ```
   # s = Set{1, 5}

--- a/src/set.cr
+++ b/src/set.cr
@@ -136,7 +136,7 @@ struct Set(T)
     @hash.has_key?(object)
   end
 
-  # Removes the *object* and returns it, otherwise returns `nil`.
+  # Removes the *object* from the set and returns `true`—if present, otherwise returns `false`.
   #
   # ```
   # s = Set{1, 5}

--- a/src/set.cr
+++ b/src/set.cr
@@ -147,7 +147,6 @@ struct Set(T)
   def delete(object) : T?
     return nil if !object.is_a? T
     @hash.delete(object) { return nil }
-    object
   end
 
   # Returns the number of elements in the set.

--- a/src/set.cr
+++ b/src/set.cr
@@ -144,8 +144,9 @@ struct Set(T)
   # s.delete 5    # => 5
   # s.includes? 5 # => false
   # ```
-  def delete(object) : T?
+  def delete(object)
     @hash.delete(object) { return nil }
+    object
   end
 
   # Returns the number of elements in the set.

--- a/src/set.cr
+++ b/src/set.cr
@@ -141,12 +141,13 @@ struct Set(T)
   # ```
   # s = Set{1, 5}
   # s.includes? 5 # => true
-  # s.delete 5    # => 5
+  # s.delete 5    # => true
   # s.includes? 5 # => false
+  # s.delete 5    # => false
   # ```
-  def delete(object) : T?
-    return nil if !object.is_a? T
-    @hash.delete(object) { return nil }
+  def delete(object) : Bool
+    @hash.delete(object) { return false }
+    true
   end
 
   # Returns the number of elements in the set.

--- a/src/set.cr
+++ b/src/set.cr
@@ -311,7 +311,9 @@ struct Set(T)
   # ```
   def subtract(other : Enumerable)
     other.each do |value|
-      delete value
+      if value.is_a? T
+        delete value
+      end
     end
     self
   end

--- a/src/set.cr
+++ b/src/set.cr
@@ -136,7 +136,7 @@ struct Set(T)
     @hash.has_key?(object)
   end
 
-  # Removes the *object* from the set and returns `true`—if present, otherwise returns `false`.
+  # Removes the *object* from the set and returns `true` if it was present, otherwise returns `false`.
   #
   # ```
   # s = Set{1, 5}

--- a/src/set.cr
+++ b/src/set.cr
@@ -136,17 +136,17 @@ struct Set(T)
     @hash.has_key?(object)
   end
 
-  # Removes the *object* from the set and returns `self`.
+  # Deletes the *object* and returns it, otherwise returns nil.
   #
   # ```
   # s = Set{1, 5}
   # s.includes? 5 # => true
-  # s.delete 5
+  # s.delete 5    # => 5
   # s.includes? 5 # => false
   # ```
   def delete(object)
-    @hash.delete(object)
-    self
+    @hash.delete(object) { return }
+    object
   end
 
   # Returns the number of elements in the set.

--- a/src/set.cr
+++ b/src/set.cr
@@ -310,9 +310,7 @@ struct Set(T)
   # ```
   def subtract(other : Enumerable)
     other.each do |value|
-      if value.is_a? T
-        delete value
-      end
+      delete value
     end
     self
   end


### PR DESCRIPTION
It adds a simple and efficient way to know if the value was present or not.

### Design explanations

Having `Set#delete` returns `object` or `nil` is consistent with other `#delete` methods in the stdlib:
- `Hash#delete(object)` returns the `value` if `object` was present.
- `Array#delete_at(index)` returns the removed `value` at the given index, or raises an exception.

However, `Deque#delete(object)` returns a boolean (maybe it would be better to return a count of deleted objects, but not the topic).

Other options are:
- add `Set#delete?(object) : Bool` to have parity with `Set#add?`, but it can be considered redundant
- have `Set#delete(object)` return a `Bool`. Why not, but could be confusing: `#add` does not return a `Bool` (but `#add?` does)

Side note: I don't think `Set#add` and `Set#add?` are redundant, because `Set#<<` is using `Set#add`, and one can easily chain object additions like `set << one << second << third`.

Closes #9591