### PR TITLE
Use content instead of value when inspect XML::Attribute

### DIFF
--- a/spec/std/xml/xml_spec.cr
+++ b/spec/std/xml/xml_spec.cr
@@ -399,6 +399,12 @@ describe XML do
     res.should be_nil
   end
 
+  it "shows content when inspecting attribute" do
+    doc = XML.parse(%{<foo bar="baz"></foo>})
+    attr = doc.root.not_nil!.attributes.first
+    attr.inspect.should contain(%(content="baz"))
+  end
+
   it ".build" do
     XML.build do |builder|
       builder.element "foo" { }

--- a/src/xml/node.cr
+++ b/src/xml/node.cr
@@ -204,7 +204,7 @@ struct XML::Node
       end
 
       if attribute?
-        io << " value="
+        io << " content="
         content.inspect(io)
       else
         attributes = self.attributes


### PR DESCRIPTION
In Gitter someone said that this doesn't work:

```crystal
require "xml"

xml = <<-XML
<box id="test">TEST</box>
XML

doc = XML.parse(xml)

doc.children.each do |node|
  node.attributes.each do |attr|
    puts attr.name
    # puts attr.value # doesn't compile
  end
end
```

The thing is that there's no `#value` method for `XML::Node`. You have to use `#content`. However, when inspecting an attribute you get:

```
#<XML::Attribute:0x10d9c5930 name="id" value="test">
```

While it's technically the `value`, it can be confusing because there's no `#value` method.

This PR changes that `inspect` output to use `content` instead:

```
#<XML::Attribute:0x10d9c5930 name="id" content="test">
```