### PR TITLE
Compiler: consider free vars in return type in abstract def check

### DIFF
--- a/spec/compiler/semantic/abstract_def_spec.cr
+++ b/spec/compiler/semantic/abstract_def_spec.cr
@@ -674,4 +674,50 @@ describe "Semantic: abstract def" do
       end
     ))
   end
+
+  it "finds free vars in return type (#8766)" do
+    assert_no_warnings(%(
+      module Functor(T)
+        abstract def fmap(&block : T -> U) : Functor(U) forall U
+      end
+
+      class A(T)
+        include Functor(T)
+
+        def fmap(&block : T -> U) : Functor(U) forall U
+        end
+      end
+      ))
+  end
+
+  it "finds free vars in return type, different name (#8766)" do
+    assert_no_warnings(%(
+      module Functor(T)
+        abstract def fmap(&block : T -> U) : Functor(U) forall U
+      end
+
+      class A(T)
+        include Functor(T)
+
+        def fmap(&block : T -> X) : Functor(X) forall X
+        end
+      end
+      ))
+  end
+
+  it "warns if return type doesn't match return type with free var" do
+    assert_warning %(
+      module Functor(T)
+        abstract def fmap(&block : T -> U) : Functor(U) forall U
+      end
+
+      class A(T)
+        include Functor(T)
+
+        def fmap(&block : T -> U) : Functor(Int32) forall U
+        end
+      end
+      ),
+      "warning in line 9\nWarning: this method must return Functor(U), which is the return type of the overridden method Functor(T)#fmap(&block), or a subtype of it, not Functor(Int32)"
+  end
 end

--- a/spec/spec_helper.cr
+++ b/spec/spec_helper.cr
@@ -135,6 +135,11 @@ def assert_warning(code, message, *, file = __FILE__, line = __LINE__)
   warning_failures[0].should start_with(message), file, line
 end
 
+def assert_no_warnings(code, *, file = __FILE__, line = __LINE__)
+  warning_failures = warnings_result(code, file: file)
+  warning_failures.size.should eq(0), file, line
+end
+
 def assert_macro(macro_args, macro_body, call_args, expected, expected_pragmas = nil, flags = nil, file = __FILE__, line = __LINE__)
   assert_macro(macro_args, macro_body, expected, expected_pragmas, flags, file: file, line: line) { call_args }
 end

--- a/src/compiler/crystal/types.cr
+++ b/src/compiler/crystal/types.cr
@@ -1709,6 +1709,29 @@ module Crystal
     end
   end
 
+  # A free variable in a method.
+  class FreeVariable < Type
+    def initialize(program, @name : String)
+      super(program)
+    end
+
+    def implements?(other : FreeVariable)
+      true
+    end
+
+    def unbound?
+      true
+    end
+
+    def ==(other : FreeVariable)
+      true
+    end
+
+    def to_s_with_options(io : IO, skip_union_parens : Bool = false, generic_args : Bool = true, codegen : Bool = false) : Nil
+      io << @name
+    end
+  end
+
   # A splatted type inside an inherited generic class or included generic module.
   #
   # For example, given:


### PR DESCRIPTION
Fixes #8766

Free variables will probably have to be considered in #9585 but it can be done in a later PR.