### PR TITLE
OptionParser: don't call handler if value is given to none value handler

### DIFF
--- a/spec/std/option_parser_spec.cr
+++ b/spec/std/option_parser_spec.cr
@@ -230,6 +230,22 @@ describe "OptionParser" do
     end
   end
 
+  it "raises on invalid option if value is given to none value handler (short flag, #9553) " do
+    expect_raises OptionParser::InvalidOption, "Invalid option: -foo" do
+      OptionParser.parse(["-foo"]) do |opts|
+        opts.on("-f", "some flag") { }
+      end
+    end
+  end
+
+  it "raises on invalid option if value is given to none value handler (long flag, #9553)" do
+    expect_raises OptionParser::InvalidOption, "Invalid option: --foo=bar" do
+      OptionParser.parse(["--foo=bar"]) do |opts|
+        opts.on("-foo", "some flag") { }
+      end
+    end
+  end
+
   it "calls the handler for invalid options" do
     called = false
     OptionParser.parse(["-f", "-j"]) do |opts|

--- a/src/option_parser.cr
+++ b/src/option_parser.cr
@@ -366,7 +366,9 @@ class OptionParser
           value = nil
         end
 
-        if handler = @handlers[flag]?
+        # Fetch handler of the flag.
+        # If value is given even though handler does not take value, it is invalid, then it is skipped.
+        if (handler = @handlers[flag]?) && !(handler.value_type.none? && value)
           handled_args << arg_index
 
           # Pull in the next argument if we don't already have it and an argument


### PR DESCRIPTION
Fixed #9553

It is regression fix. Before 0.34.0 (or #9009), it worked in this way.