### PR TITLE
HTTP::Params: `#[]=` replaces all values.

### DIFF
--- a/spec/std/http/params_spec.cr
+++ b/spec/std/http/params_spec.cr
@@ -116,16 +116,22 @@ module HTTP
     end
 
     describe "#[]=(name, value)" do
-      it "sets first value for provided param name" do
+      it "sets value for provided param name" do
         params = Params.parse("foo=bar&foo=baz&baz=qux")
         params["foo"] = "notfoo"
-        params.fetch_all("foo").should eq(["notfoo", "baz"])
+        params.fetch_all("foo").should eq(["notfoo"])
       end
 
       it "adds new name => value pair if there is no such param" do
         params = Params.parse("foo=bar&foo=baz&baz=qux")
         params["non_existent_param"] = "test"
         params.fetch_all("non_existent_param").should eq(["test"])
+      end
+
+      it "sets value for provided param name (array)" do
+        params = Params.parse("foo=bar&foo=baz&baz=qux")
+        params["non_existent_param"] = ["test", "something"]
+        params.fetch_all("non_existent_param").should eq(["test", "something"])
       end
     end
 

--- a/spec/std/http/request_spec.cr
+++ b/spec/std/http/request_spec.cr
@@ -408,7 +408,7 @@ module HTTP
         params = request.query_params
 
         params["foo"] = "not-bar"
-        request.query.should eq("foo=not-bar&foo=baz&baz=qux")
+        request.query.should eq("foo=not-bar&baz=qux")
       end
 
       it "updates @resource when modified" do
@@ -416,7 +416,7 @@ module HTTP
         params = request.query_params
 
         params["foo"] = "not-bar"
-        request.resource.should eq("/api/v3/some/resource?foo=not-bar&foo=baz&baz=qux")
+        request.resource.should eq("/api/v3/some/resource?foo=not-bar&baz=qux")
       end
 
       it "updates serialized form when modified" do
@@ -427,7 +427,7 @@ module HTTP
 
         io = IO::Memory.new
         request.to_io(io)
-        io.to_s.should eq("GET /api/v3/some/resource?foo=not-bar&foo=baz&baz=qux HTTP/1.1\r\n\r\n")
+        io.to_s.should eq("GET /api/v3/some/resource?foo=not-bar&baz=qux HTTP/1.1\r\n\r\n")
       end
 
       it "is affected when #query is modified" do

--- a/src/http/params.cr
+++ b/src/http/params.cr
@@ -189,14 +189,26 @@ module HTTP
     # ```
     delegate empty?, to: raw_params
 
-    # Sets first *value* for specified param *name*.
+    # Sets the *name* key to *value*.
     #
     # ```
-    # params["item"] = "pencil"
+    # require "http/params"
+    #
+    # params = HTTP::Params{"a" => ["b", "c"]}
+    # params["a"] = "d"
+    # params["a"]           # => "d"
+    # params.fetch_all("a") # => ["d"]
+    #
+    # params["a"] = ["e", "f"]
+    # params["a"]           # => "e"
+    # params.fetch_all("a") # => ["e", "f"]
     # ```
-    def []=(name, value)
-      raw_params[name] ||= [""]
-      raw_params[name][0] = value
+    def []=(name, value : String | Array(String))
+      raw_params[name] =
+        case value
+        in String        then [value]
+        in Array(String) then value
+        end
     end
 
     # Returns all values for specified param *name*.


### PR DESCRIPTION
Fixes #9604