### PR TITLE
HTTP::CompressHandler doesn't compress on upgrade

### DIFF
--- a/src/http/server/handlers/compress_handler.cr
+++ b/src/http/server/handlers/compress_handler.cr
@@ -14,12 +14,14 @@ class HTTP::CompressHandler
     {% else %}
       request_headers = context.request.headers
 
-      if request_headers.includes_word?("Accept-Encoding", "gzip")
-        context.response.headers["Content-Encoding"] = "gzip"
-        context.response.output = Compress::Gzip::Writer.new(context.response.output, sync_close: true)
-      elsif request_headers.includes_word?("Accept-Encoding", "deflate")
-        context.response.headers["Content-Encoding"] = "deflate"
-        context.response.output = Compress::Deflate::Writer.new(context.response.output, sync_close: true)
+      unless request_headers.includes_word?("Connection", "upgrade")
+        if request_headers.includes_word?("Accept-Encoding", "gzip")
+          context.response.headers["Content-Encoding"] = "gzip"
+          context.response.output = Compress::Gzip::Writer.new(context.response.output, sync_close: true)
+        elsif request_headers.includes_word?("Accept-Encoding", "deflate")
+          context.response.headers["Content-Encoding"] = "deflate"
+          context.response.output = Compress::Deflate::Writer.new(context.response.output, sync_close: true)
+        end
       end
 
       call_next(context)


### PR DESCRIPTION
Currently `HTTP::CompressHandler` is corrupting the output when used in combination of a `HTTP::WebSocketHandler`. This started to happen due to changes done in #9115 and #9243. But actually it worked before because the `response.output` was never closed and instead manually pushed to get the upgrade response headers written.

This PR is not ideal either. Actually the `HTTP::CompressHandler` should defer compression maybe until the response is starting to flush and decide right there if it's worth or correct to compress the output, for example if the body is too small, or it shouldn't even exist (like in upgrades). But that would probably require some refactors.