### PR TITLE
Use 'brew bundle' to install macOS dependencies in CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -93,7 +93,7 @@ jobs:
             - brew-cache-v1
       - checkout
       - run: bin/ci prepare_system
-      - run: echo 'export PKG_CONFIG_PATH="$PKG_CONFIG_PATH:/usr/local/opt/openssl/lib/pkgconfig"' >> $BASH_ENV
+      - run: echo 'export PKG_CONFIG_PATH="$PKG_CONFIG_PATH:/usr/local/opt/openssl@1.1/lib/pkgconfig"' >> $BASH_ENV
       - run: echo 'export CURRENT_TAG="$CIRCLE_TAG"' >> $BASH_ENV
       - run: bin/ci prepare_build
       - run: bin/ci build

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -5,7 +5,7 @@ on: [push, pull_request]
 env:
   TRAVIS_OS_NAME: osx
   LLVM_CONFIG: /usr/local/opt/llvm/bin/llvm-config
-  PKG_CONFIG_PATH: /usr/local/opt/openssl/lib/pkgconfig
+  PKG_CONFIG_PATH: /usr/local/opt/openssl@1.1/lib/pkgconfig
   SPEC_SPLIT_DOTS: 160
 
 jobs:

--- a/Brewfile
+++ b/Brewfile
@@ -1,0 +1,6 @@
+brew "gmp"
+brew "libevent"
+brew "pcre"
+brew "pkg-config"
+brew "openssl@1.1"
+brew "llvm@10", link: true, conflicts_with: ["python@2"]

--- a/bin/ci
+++ b/bin/ci
@@ -77,8 +77,6 @@ on_github() {
 prepare_system() {
   on_linux 'echo '"'"'{"ipv6":true, "fixed-cidr-v6":"2001:db8:1::/64"}'"'"' | sudo tee /etc/docker/daemon.json'
   on_linux sudo service docker restart
-
-  on_osx brew update
 }
 
 build() {
@@ -119,11 +117,8 @@ prepare_build() {
 
   on_osx curl -L https://github.com/crystal-lang/crystal/releases/download/0.35.1/crystal-0.35.1-1-darwin-x86_64.tar.gz -o ~/crystal.tar.gz
   on_osx 'pushd ~;gunzip -c ~/crystal.tar.gz | tar xopf -;mv crystal-0.35.1-1 crystal;popd'
+  on_osx brew bundle --no-lock
 
-  on_osx 'brew unlink python@2 || true'
-  on_osx brew install z3 llvm@10 gmp libevent pcre pkg-config
-  on_osx brew reinstall openssl
-  on_osx brew link --force llvm@10
   # Note: brew link --force might show:
   #   Warning: Refusing to link macOS-provided software: llvm
   #


### PR DESCRIPTION
Fix the build on GitHub Actions by using `brew bundle` to install or upgrade dependencies as needed, avoiding issues if the package is already installed. Explicitly not using the lock file, to keep using the latest version of each dependency for now.

Also fixed the path to pkg-config for openssl, using the `@1.1` version to avoid issues if another version is already installed.

I removed `z3` from the dependencies because it seems it's not needed anymore.