### PR TITLE
Compiler: try literal type in autocast first

### DIFF
--- a/spec/compiler/codegen/automatic_cast.cr
+++ b/spec/compiler/codegen/automatic_cast.cr
@@ -260,4 +260,14 @@ describe "Code gen: automatic cast" do
       Bar.new.as(Foo).foo(1)
       )).to_i.should eq(2)
   end
+
+  it "doesn't autocast number on union (#8655)" do
+    run(%(
+      def foo(x : UInt8 | Int32, y : Float64)
+        x
+      end
+
+      foo(255, 60)
+      )).to_i.should eq(255)
+  end
 end

--- a/spec/compiler/semantic/automatic_cast_spec.cr
+++ b/spec/compiler/semantic/automatic_cast_spec.cr
@@ -575,4 +575,14 @@ describe "Semantic: automatic cast" do
       Baz.new.as(Foo).foo(1)
       )) { int64 }
   end
+
+  it "doesn't autocast number on union (#8655)" do
+    assert_type(%(
+      def foo(x : UInt8 | Int32, y : Float64)
+        x
+      end
+
+      foo(255, 60)
+      )) { int32 }
+  end
 end

--- a/spec/compiler/semantic/automatic_cast_spec.cr
+++ b/spec/compiler/semantic/automatic_cast_spec.cr
@@ -585,4 +585,15 @@ describe "Semantic: automatic cast" do
       foo(255, 60)
       )) { int32 }
   end
+
+  it "says ambiguous call on union (#8655)" do
+    assert_error %(
+      def foo(x : UInt64 | Int64, y : Float64)
+        x
+      end
+
+      foo(255, 60)
+      ),
+      "ambiguous call, implicit cast of 255 matches all of UInt64, Int64"
+  end
 end

--- a/src/compiler/crystal/semantic/restrictions.cr
+++ b/src/compiler/crystal/semantic/restrictions.cr
@@ -1232,8 +1232,8 @@ module Crystal
           literal.type.restrict(other, context)
         end
       else
-        type = super(other, context) ||
-               literal.type.restrict(other, context)
+        type = literal.type.restrict(other, context) ||
+               super(other, context)
         if type == self
           type = @match || literal.type
         end
@@ -1260,8 +1260,8 @@ module Crystal
           literal.type.restrict(other, context)
         end
       else
-        type = super(other, context) ||
-               literal.type.restrict(other, context)
+        type = literal.type.restrict(other, context) ||
+               super(other, context)
         if type == self
           type = @match || literal.type
         end


### PR DESCRIPTION
Fixes #8655

When trying to match `Int32` with autocasting enabled against a union type, we should always try to match first using the regular approach (check if Int32 matches any of the union types without autocasting) and then try to match using autocasting. The logic was reversed in the compiler so this fixes that.

So before, the 255 literal, as an `Int32`, vs `UInt8 | Int32` would match both types because of autocasting. Now it only matches `Int32` exactly.