### PR TITLE
String: don't materialize Regex match[0] if not needed

### DIFF
--- a/src/string.cr
+++ b/src/string.cr
@@ -3611,7 +3611,7 @@ class String
 
     while match = separator.match_at_byte_index(self, match_offset)
       index = match.byte_begin(0)
-      match_bytesize = match[0].bytesize
+      match_bytesize = match.byte_end(0) - index
       next_offset = index + match_bytesize
 
       if next_offset == slice_offset
@@ -3856,9 +3856,10 @@ class String
       String.new(bytesize) do |buffer|
         buffer += bytesize
         scan(/\X/) do |match|
-          grapheme = match[0]
-          buffer -= grapheme.bytesize
-          buffer.copy_from(grapheme.to_unsafe, grapheme.bytesize)
+          match_begin = match.byte_begin(0)
+          match_bytesize = match.byte_end(0) - match_begin
+          buffer -= match_bytesize
+          buffer.copy_from(to_unsafe + match_begin, match_bytesize)
         end
         {@bytesize, @length}
       end
@@ -4175,7 +4176,7 @@ class String
       index = match.byte_begin(0)
       $~ = match
       yield match
-      match_bytesize = match[0].bytesize
+      match_bytesize = match.byte_end(0) - index
       match_bytesize += 1 if match_bytesize == 0
       byte_offset = index + match_bytesize
     end


### PR DESCRIPTION
This avoid creating an intermediate string that's produced by `MatchData#[]` that's completely not needed for the task.

Here's a benchmark:

```crystal
require "benchmark"

Benchmark.ips do |x|
  x.report("reverse") do
    "há日本語".reverse
  end
  x.report("scan") do
    "foo".scan(/o+/) { }
  end
  x.report("split") do
    "foboloxoro".split(/o/) { }
  end
end
```

Results before this PR:

```
reverse   1.29M (773.61ns) (± 5.74%)   384B/op 
   scan   6.53M (153.11ns) (± 7.77%)  48.0B/op
  split   1.59M (628.53ns) (± 5.13%)   241B/op 
```

Results after this PR:

```
reverse   2.23M (447.64ns) (± 3.66%)   128B/op
   scan   8.76M (114.15ns) (± 4.63%)  32.0B/op
  split   2.22M (450.89ns) (± 2.36%)   160B/op
```

Note in all these cases less memory is used now, and it's faster.