### PR TITLE
Print a message pointing to the online playground if compiled without it

### DIFF
--- a/src/compiler/crystal/command.cr
+++ b/src/compiler/crystal/command.cr
@@ -77,6 +77,7 @@ class Crystal::Command
       options.shift
       {% if flag?(:without_playground) %}
         puts "Crystal was compiled without playground support"
+        puts "You can play with the online version here: https://play.crystal-lang.org"
         exit 1
       {% else %}
         playground

--- a/src/compiler/crystal/command.cr
+++ b/src/compiler/crystal/command.cr
@@ -77,7 +77,7 @@ class Crystal::Command
       options.shift
       {% if flag?(:without_playground) %}
         puts "Crystal was compiled without playground support"
-        puts "You can play with the online version here: https://play.crystal-lang.org"
+        puts "Try the online code evaluation and sharing tool at https://play.crystal-lang.org"
         exit 1
       {% else %}
         playground


### PR DESCRIPTION
Hi,

For the Debian packaging, we remove the support for the playgroud due to the lack of octicons fonts in the archive. We will use the flag `-Dwithout_playground`, to deactivate it. 

This change simply add a message pointing the user to the online version.

---

Maybe, the next if out of context for this pull request, but for what we know, the `-Dwithout_playground` flag was added only for the use case of compiling crystal in windows (that lacks sockets support) [0].

Is posible to maintain this flag for the entire lifecycle of crystal ? (we expect that at some point, when windows get's socket funcionality, the flag will be removed).

[0] https://github.com/crystal-lang/crystal/pull/9031