### PR TITLE
Delay setup of HTTP::CompressHandler until content is written

### DIFF
--- a/spec/std/http/server/handlers/compress_handler_spec.cr
+++ b/spec/std/http/server/handlers/compress_handler_spec.cr
@@ -66,4 +66,88 @@ describe HTTP::CompressHandler do
     gzip = Compress::Gzip::Reader.new(io2)
     gzip.gets_to_end.should eq("Hello")
   end
+
+  it "doesn't compress twice" do
+    io = IO::Memory.new
+    request = HTTP::Request.new("GET", "/")
+    request.headers["Accept-Encoding"] = "gzip"
+
+    response = HTTP::Server::Response.new(io)
+    context = HTTP::Server::Context.new(request, response)
+
+    handler1 = HTTP::CompressHandler.new
+    handler2 = HTTP::CompressHandler.new
+    handler1.next = handler2
+    handler2.next = HTTP::Handler::HandlerProc.new do |ctx|
+      ctx.response.print "Hello"
+    end
+    handler1.call(context)
+    response.close
+
+    io.rewind
+    response2 = HTTP::Client::Response.from_io(io)
+    response2.body.should eq("Hello")
+  end
+
+  it "fix content-length header" do
+    io = IO::Memory.new
+    request = HTTP::Request.new("GET", "/")
+    request.headers["Accept-Encoding"] = "gzip"
+
+    response = HTTP::Server::Response.new(io)
+    context = HTTP::Server::Context.new(request, response)
+
+    handler = HTTP::CompressHandler.new
+    handler.next = HTTP::Handler::HandlerProc.new do |ctx|
+      ctx.response.content_length = 5
+      ctx.response.print "Hello"
+      ctx.response.flush
+    end
+    handler.call(context)
+    response.close
+
+    io.rewind
+    response = HTTP::Client::Response.from_io(io)
+    response.body.should eq("Hello")
+  end
+
+  it "don't try to compress for empty body responses" do
+    io = IO::Memory.new
+    request = HTTP::Request.new("GET", "/")
+    request.headers["Accept-Encoding"] = "gzip"
+
+    response = HTTP::Server::Response.new(io)
+    context = HTTP::Server::Context.new(request, response)
+
+    handler = HTTP::CompressHandler.new
+    handler.next = HTTP::Handler::HandlerProc.new do |ctx|
+      context.response.status = :not_modified
+    end
+    handler.call(context)
+    response.close
+
+    io.rewind
+    io.to_s.should eq("HTTP/1.1 304 Not Modified\r\nContent-Length: 0\r\n\r\n")
+  end
+
+  it "don't try to compress upgraded response" do
+    io = IO::Memory.new
+    request = HTTP::Request.new("GET", "/")
+    request.headers["Accept-Encoding"] = "gzip"
+
+    response = HTTP::Server::Response.new(io)
+    context = HTTP::Server::Context.new(request, response)
+
+    handler = HTTP::CompressHandler.new
+    handler.next = HTTP::Handler::HandlerProc.new do |ctx|
+      response.status = :switching_protocols
+      response.upgrade do |io|
+      end
+    end
+    handler.call(context)
+    response.close
+
+    io.rewind
+    io.to_s.should eq("HTTP/1.1 101 Switching Protocols\r\n\r\n")
+  end
 end

--- a/src/http/server/handlers/compress_handler.cr
+++ b/src/http/server/handlers/compress_handler.cr
@@ -12,17 +12,50 @@ class HTTP::CompressHandler
     {% if flag?(:without_zlib) %}
       call_next(context)
     {% else %}
-      request_headers = context.request.headers
-
-      if request_headers.includes_word?("Accept-Encoding", "gzip")
-        context.response.headers["Content-Encoding"] = "gzip"
-        context.response.output = Compress::Gzip::Writer.new(context.response.output, sync_close: true)
-      elsif request_headers.includes_word?("Accept-Encoding", "deflate")
-        context.response.headers["Content-Encoding"] = "deflate"
-        context.response.output = Compress::Deflate::Writer.new(context.response.output, sync_close: true)
-      end
-
+      context.response.output = CompressIO.new(context.response.output, context)
       call_next(context)
     {% end %}
+  end
+
+  private class CompressIO < IO
+    def initialize(@io : IO, @context : HTTP::Server::Context)
+      @checked = false
+    end
+
+    def read(slice : Bytes)
+      raise NotImplementedError.new("read")
+    end
+
+    def write(slice : Bytes) : Nil
+      check_output unless @checked
+      @io.write(slice)
+    end
+
+    def flush
+      @io.flush
+    end
+
+    def close
+      @io.close
+    end
+
+    private def check_output
+      @checked = true
+
+      return if @context.response.wrote_headers?
+      return if @context.response.headers.has_key?("Content-Encoding")
+
+      request_headers = @context.request.headers
+
+      if request_headers.includes_word?("Accept-Encoding", "gzip")
+        @context.response.headers["Content-Encoding"] = "gzip"
+        @context.response.headers.delete("Content-Length")
+        @io = Compress::Gzip::Writer.new(@io, sync_close: true)
+      elsif request_headers.includes_word?("Accept-Encoding", "deflate")
+        @context.response.headers["Content-Encoding"] = "deflate"
+        @context.response.headers.delete("Content-Length")
+        @io = Compress::Deflate::Writer.new(@io, sync_close: true)
+      end
+    end
   end
 end


### PR DESCRIPTION
This fixes many issues with the `HTTP::CompressHandler` in combination of other handlers and some kind of responses.

The setup is delayed until some content is written, and only then decide if the compression is feasible or allowed. This fixes these cases:
  * Responses with no output, like 304 or a websocket upgrade, are not compressed
  * Response already compressed by another handler is not compressed again
  * If compression is enabled, the `Content-Length` header is removed

Supersedes #9608 
Fixes #9196 