### PR TITLE
Replace "whitelisting" with "filtering"

### DIFF
--- a/src/http/server/handler.cr
+++ b/src/http/server/handler.cr
@@ -2,7 +2,7 @@ require "./context"
 
 # A handler is a class which includes `HTTP::Handler` and implements the `call` method.
 # You can use a handler to intercept any incoming request and can modify the response.
-# These can be used for request throttling, ip-based whitelisting, adding custom headers e.g.
+# These can be used for request throttling, ip-based filtering, adding custom headers e.g.
 #
 # ### A custom handler
 #


### PR DESCRIPTION
This is the only potentially offensive word that I found in the source code. I also searched for "master", "slave" and "blacklist".

I think there shouldn't be any opposition to this because these are just referring to example handlers that could be written.