### PR TITLE
Fix ASTNode#to_s for parenthesized expression in block

### DIFF
--- a/spec/compiler/parser/to_s_spec.cr
+++ b/spec/compiler/parser/to_s_spec.cr
@@ -170,4 +170,6 @@ describe "ASTNode#to_s" do
   expect_to_s "offsetof(Foo, @bar)"
   expect_to_s "def foo(**options, &block)\nend"
   expect_to_s "macro foo\n  123\nend"
+  expect_to_s "if true\n(  1)\nend"
+  expect_to_s "begin\n(  1)\nrescue\nend"
 end

--- a/src/compiler/crystal/syntax/to_s.cr
+++ b/src/compiler/crystal/syntax/to_s.cr
@@ -1562,6 +1562,7 @@ module Crystal
       with_indent do
         node.accept self
       end
+      newline if node.keyword == :"("
     end
 
     def accept_with_indent(node : Nop)


### PR DESCRIPTION
Fixed #9607 

```crystal
macro show(e)
  {% p e %}
end

show(begin
  (1)
rescue
end)

# Before:
#   begin
#   (  1)rescue
#   end
#
# After:
#   begin
#   (  1)
#   rescue
#   end