### PR TITLE
Add multiline comments

### DIFF
--- a/spec/compiler/lexer/lexer_comment_spec.cr
+++ b/spec/compiler/lexer/lexer_comment_spec.cr
@@ -1,7 +1,7 @@
 require "../../support/syntax"
 
 describe "Lexer comments" do
-  it "lexes without comments enabled" do
+  it "lexes line comments without comments enabled" do
     lexer = Lexer.new(%(# Hello\n1))
 
     token = lexer.next_token
@@ -11,7 +11,17 @@ describe "Lexer comments" do
     token.type.should eq(:NUMBER)
   end
 
-  it "lexes with comments enabled" do
+  it "lexes multiline comments without comments enabled" do
+    lexer = Lexer.new(%(#[ Hello\nWorld ]#\n1))
+
+    token = lexer.next_token
+    token.type.should eq(:NEWLINE)
+
+    token = lexer.next_token
+    token.type.should eq(:NUMBER)
+  end
+
+  it "lexes line comments with comments enabled" do
     lexer = Lexer.new(%(# Hello\n1))
     lexer.comments_enabled = true
 
@@ -26,7 +36,22 @@ describe "Lexer comments" do
     token.type.should eq(:NUMBER)
   end
 
-  it "lexes with comments enabled (2)" do
+  it "lexes multiline comments with comments enabled" do
+    lexer = Lexer.new(%(#[Hello\nWorld]#\n1))
+    lexer.comments_enabled = true
+
+    token = lexer.next_token
+    token.type.should eq(:COMMENT)
+    token.value.should eq("#[Hello\nWorld]#")
+
+    token = lexer.next_token
+    token.type.should eq(:NEWLINE)
+
+    token = lexer.next_token
+    token.type.should eq(:NUMBER)
+  end
+
+  it "lexes line comments with comments enabled (2)" do
     lexer = Lexer.new(%(1 # Hello))
     lexer.comments_enabled = true
 

--- a/src/compiler/crystal/syntax/lexer.cr
+++ b/src/compiler/crystal/syntax/lexer.cr
@@ -110,7 +110,11 @@ module Crystal
           elsif @comments_enabled
             return consume_comment(start)
           else
-            skip_comment
+            if current_char == '['
+              skip_multiline_comment
+            else
+              skip_comment
+            end
           end
         end
       end
@@ -1327,7 +1331,12 @@ module Crystal
     end
 
     def consume_comment(start_pos)
-      skip_comment
+      if current_char == '['
+        skip_multiline_comment
+      else
+        skip_comment
+      end
+      
       @token.type = :COMMENT
       @token.value = string_range(start_pos)
       @token
@@ -1361,6 +1370,17 @@ module Crystal
       while char != '\n' && char != '\0'
         char = next_char_no_column_increment
       end
+    end
+
+    def skip_multiline_comment
+      char = current_char
+      while peek_next_char != '\0' && char != ']' && peek_next_char != '#'
+        char = next_char_no_column_increment
+      end
+
+      #step over '#'
+      next_char_no_column_increment
+      next_char_no_column_increment if current_char == '#'
     end
 
     def consume_whitespace


### PR DESCRIPTION
Hello,

I added multiline comments to Crystal.
They use this syntax:
```
puts "this prints"
#[
puts "this doesn't"
]# puts "this does
```

I chose the `#[...]#` syntax but I think `<#...#>` might also be a good fit (like PowerShell).

The problem that I have with the current syntax is that a line like `]# something` seems to suggest that the something statement gets commented, but it doesn't.

I though about `#[..]` but I am scared that it would be too easy to accidentally close.

Let me know what you think.