### PR TITLE
Allow overriding CRYSTAL_PATH in the wrapper script

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -92,6 +92,7 @@ jobs:
           keys:
             - brew-cache-v1
       - checkout
+      - run: brew update
       - run: bin/ci prepare_system
       - run: echo 'export PKG_CONFIG_PATH="$PKG_CONFIG_PATH:/usr/local/opt/openssl@1.1/lib/pkgconfig"' >> $BASH_ENV
       - run: echo 'export CURRENT_TAG="$CIRCLE_TAG"' >> $BASH_ENV

--- a/bin/crystal
+++ b/bin/crystal
@@ -138,14 +138,14 @@ SCRIPT_ROOT="$(dirname "$SCRIPT_PATH")"
 CRYSTAL_ROOT="$(dirname "$SCRIPT_ROOT")"
 CRYSTAL_DIR="$CRYSTAL_ROOT/.build"
 
-export CRYSTAL_PATH=lib:$CRYSTAL_ROOT/src
+export CRYSTAL_PATH="${CRYSTAL_PATH:-lib:$CRYSTAL_ROOT/src}"
 export CRYSTAL_HAS_WRAPPER=true
 
 export CRYSTAL="${CRYSTAL:-"crystal"}"
 
 if [ -z "$CRYSTAL_CONFIG_LIBRARY_PATH" ]; then
   export CRYSTAL_CONFIG_LIBRARY_PATH="$(
-    export PATH="$(remove_path_item "$(remove_path_item "$PATH" "$SCRIPT_ROOT")" "bin")" 
+    export PATH="$(remove_path_item "$(remove_path_item "$PATH" "$SCRIPT_ROOT")" "bin")"
     crystal env CRYSTAL_LIBRARY_PATH || echo ""
   )"
 fi

--- a/bin/crystal
+++ b/bin/crystal
@@ -139,6 +139,10 @@ CRYSTAL_ROOT="$(dirname "$SCRIPT_ROOT")"
 CRYSTAL_DIR="$CRYSTAL_ROOT/.build"
 
 export CRYSTAL_PATH="${CRYSTAL_PATH:-lib:$CRYSTAL_ROOT/src}"
+if [ -n "${CRYSTAL_PATH##*$CRYSTAL_ROOT/src*}" ]; then
+  __warning_msg "CRYSTAL_PATH env variable does not contains $CRYSTAL_ROOT/src"
+fi
+
 export CRYSTAL_HAS_WRAPPER=true
 
 export CRYSTAL="${CRYSTAL:-"crystal"}"


### PR DESCRIPTION
This will allow setting the CRYSTAL_PATH in the same fashion as in official packages.

`CRYSTAL_PATH=/path/to/prepend:$(bin/crystal env CRYSTAL_PATH)`

It is mainly convenient for test-ecosystem to reduce the noise on specific deprecation warnings by overriding some files of the std-lib.