### PR TITLE
Fix: raise error when abstract def implementation adds a type restriction

### DIFF
--- a/spec/compiler/semantic/abstract_def_spec.cr
+++ b/spec/compiler/semantic/abstract_def_spec.cr
@@ -716,6 +716,19 @@ describe "Semantic: abstract def" do
       "abstract `def Foo#foo(x = 1)` must be implemented by Bar"
   end
 
+  it "errors if implementation adds type restriction" do
+    assert_error %(
+      abstract class Foo
+        abstract def foo(x)
+      end
+
+      class Bar < Foo
+        def foo(x : Int32)
+        end
+      end
+    ), "abstract `def Foo#foo(x)` must be implemented by Bar"
+  end
+
   it "errors if implementation doesn't have keyword arguments" do
     assert_error %(
       abstract class Foo

--- a/src/compiler/crystal/semantic/abstract_def_checker.cr
+++ b/src/compiler/crystal/semantic/abstract_def_checker.cr
@@ -222,6 +222,7 @@ class Crystal::AbstractDefChecker
 
     r1 = a1.restriction
     r2 = a2.restriction
+    return false if r1 && !r2
     if r2 && r1 && r1 != r2
       # Check if a1.restriction is contravariant with a2.restriction
       begin


### PR DESCRIPTION
Currently this passes without any error:
```crystal
abstract class Foo
  abstract def foo(x)
end

class Bar < Foo
  def foo(x : Int32)
  end
end
```

But it shouldn't because the implementation only allows `Int32` to be passed as argument, while the abstract definition doesn't impose any restriction on the argument.

With this PR the compiler will properly raise:
```
Error: abstract `def Foo#foo(x)` must be implemented by Bar
```