### PR TITLE
Compiler: fix autocasting case for crossed types

### DIFF
--- a/spec/compiler/semantic/automatic_cast_spec.cr
+++ b/spec/compiler/semantic/automatic_cast_spec.cr
@@ -596,4 +596,34 @@ describe "Semantic: automatic cast" do
       ),
       "ambiguous call, implicit cast of 255 matches all of UInt64, Int64"
   end
+
+  it "says ambiguous call on crossed types (number)" do
+    assert_error %(
+      def foo(x : Int8, y : Int64)
+      end
+
+      def foo(x : Int64, y : Int8)
+      end
+
+      foo(1_i8, 2_i8)
+      ),
+      "ambiguous call"
+  end
+
+  it "says ambiguous call on crossed types (symbol)" do
+    assert_error %(
+      enum Color
+        Red
+      end
+
+      def foo(x : Symbol, y : Color)
+      end
+
+      def foo(x : Color, y : Symbol)
+      end
+
+      foo(:red, :red)
+      ),
+      "ambiguous call"
+  end
 end

--- a/src/compiler/crystal/types.cr
+++ b/src/compiler/crystal/types.cr
@@ -1393,11 +1393,6 @@ module Crystal
     # All matches. It's nil if `@match` is an exact match.
     @all_matches : Set(Type)?
 
-    def set_exact_match(type)
-      @match = type
-      @all_matches = nil
-    end
-
     def add_match(type)
       if (match = @match) && match != type
         all_matches = @all_matches
@@ -1409,10 +1404,6 @@ module Crystal
       else
         @match = type
       end
-    end
-
-    def exact_match?
-      literal.type == @match
     end
 
     def remove_literal


### PR DESCRIPTION
Fixes a couple of scenarios with autocasting. It's a big refactor but it's a good one.