### PR TITLE
Improve ASTNode#to_s output of parenthesized expression

### DIFF
--- a/spec/compiler/parser/to_s_spec.cr
+++ b/spec/compiler/parser/to_s_spec.cr
@@ -139,7 +139,7 @@ describe "ASTNode#to_s" do
   expect_to_s %({(1 + 2) => (3 + 4)})
   expect_to_s %([(1 + 2)] of Int32)
   expect_to_s %(foo(1, (2 + 3), bar: (4 + 5)))
-  expect_to_s %(if (1 + 2\n3)\n  4\nend)
+  expect_to_s %(if (1 + 2; 3)\n  4\nend)
   expect_to_s "%x(whoami)", "`whoami`"
   expect_to_s %(begin\n  ()\nend)
   expect_to_s %q("\e\0\""), %q("\e\u0000\"")
@@ -170,6 +170,8 @@ describe "ASTNode#to_s" do
   expect_to_s "offsetof(Foo, @bar)"
   expect_to_s "def foo(**options, &block)\nend"
   expect_to_s "macro foo\n  123\nend"
-  expect_to_s "if true\n(  1)\nend"
-  expect_to_s "begin\n(  1)\nrescue\nend"
+  expect_to_s "if true\n  (1)\nend"
+  expect_to_s "begin\n  (1)\nrescue\nend"
+  expect_to_s "(1; 2)"
+  expect_to_s "begin\n  (1; 2)\nend"
 end

--- a/src/compiler/crystal/syntax/to_s.cr
+++ b/src/compiler/crystal/syntax/to_s.cr
@@ -210,9 +210,13 @@ module Crystal
       else
         node.expressions.each_with_index do |exp, i|
           unless exp.nop?
-            append_indent
+            append_indent unless parens
             exp.accept self
-            newline unless parens && i == node.expressions.size - 1
+            if parens
+              @str << "; " unless i == node.expressions.size - 1
+            else
+              newline
+            end
           end
         end
       end
@@ -1559,10 +1563,12 @@ module Crystal
     end
 
     def accept_with_indent(node : Expressions)
+      parens = node.keyword == :"("
       with_indent do
+        append_indent if parens
         node.accept self
       end
-      newline if node.keyword == :"("
+      newline if parens
     end
 
     def accept_with_indent(node : Nop)


### PR DESCRIPTION
This fix does not have to be needed. However, it benefits to reduce user surprise in many cases (e.g. `p!` macro output).

```crystal
macro show(e)
  {% p e %}
end

show((1; 2))
show(begin
  (1 + 2)
end)

# Before:
#   (1
#   2)
#   begin
#   (  1 + 2)
#   end

# After:
#   (1; 2)
#   begin
#     (1 + 2)
#   end
```

Thank you.