### PR TITLE
fetch git config correctly

### DIFF
--- a/src/compiler/crystal/tools/init.cr
+++ b/src/compiler/crystal/tools/init.cr
@@ -98,7 +98,7 @@ module Crystal
 
     private def self.git_config(key)
       String.build do |io|
-        Process.run("git", ["--config", key], output: io)
+        Process.run("git", ["config", "--get", key], output: io)
       end.strip.presence
     end
 

--- a/src/compiler/crystal/tools/init/template/license.ecr
+++ b/src/compiler/crystal/tools/init/template/license.ecr
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) <%= Time.local.year %> <%= config.author %>
+Copyright (c) <%= Time.local.year %> <%= config.author %> <<%= config.email %>>
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
for instance user.name config was not fetched

git --config user.name was not a valid command

----

found this because i didn't have my name in the generated LICENSE file for instance

I built crystal from source after this change and it now works correctly

i didn't find any test that and i'm quite new to crystal so not sure how i would make a test