### PR TITLE
Run `brew update --preinstall` before installing

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -92,7 +92,6 @@ jobs:
           keys:
             - brew-cache-v1
       - checkout
-      - run: brew update
       - run: bin/ci prepare_system
       - run: echo 'export PKG_CONFIG_PATH="$PKG_CONFIG_PATH:/usr/local/opt/openssl@1.1/lib/pkgconfig"' >> $BASH_ENV
       - run: echo 'export CURRENT_TAG="$CIRCLE_TAG"' >> $BASH_ENV

--- a/bin/ci
+++ b/bin/ci
@@ -117,6 +117,7 @@ prepare_build() {
 
   on_osx curl -L https://github.com/crystal-lang/crystal/releases/download/0.35.1/crystal-0.35.1-1-darwin-x86_64.tar.gz -o ~/crystal.tar.gz
   on_osx 'pushd ~;gunzip -c ~/crystal.tar.gz | tar xopf -;mv crystal-0.35.1-1 crystal;popd'
+  on_osx brew update --preinstall
   on_osx brew bundle --no-lock
 
   # Note: brew link --force might show:


### PR DESCRIPTION
Homebrew sometimes fails while installing dependencies:
  * https://github.com/crystal-lang/crystal/pull/9633/checks?check_run_id=924229357
  * https://circleci.com/gh/crystal-lang/crystal/51085

Apparently these issues could be solved running a `bundle update` before installing. Using the `--preinstall` flag should do it a little bit faster, as explained here: https://github.com/Homebrew/homebrew-bundle/issues/751