### PR TITLE
Add docs to `Crypto::Bcrypt`

### DIFF
--- a/src/crypto/bcrypt.cr
+++ b/src/crypto/bcrypt.cr
@@ -47,7 +47,7 @@ class Crypto::Bcrypt
     0x64657253, 0x63727944, 0x6f756274,
   )
 
-  # Hashes the *password* using bcrypt algorithm using salt obtained via `Random::Secure.random_bytes`.
+  # Hashes the *password* using bcrypt algorithm using salt obtained via `Random::Secure.random_bytes(SALT_SIZE)`.
   #
   # ```
   # require "crypto/bcrypt"
@@ -61,7 +61,7 @@ class Crypto::Bcrypt
     new(passwordb, saltb, cost).to_s
   end
 
-  # Creates a new `Bcrypt` object from the given *password* with *salt* and *cost*.
+  # Creates a new `Crypto::Bcrypt` object from the given *password* with *salt* and *cost*.
   #
   # ```
   # require "crypto/bcrypt"
@@ -80,7 +80,7 @@ class Crypto::Bcrypt
   getter salt : Bytes
   getter cost : Int32
 
-  # Creates a new `Bcrypt` object from the given *password* with *salt* in bytes and *cost*.
+  # Creates a new `Crypto::Bcrypt` object from the given *password* with *salt* in bytes and *cost*.
   #
   # ```
   # require "crypto/bcrypt"

--- a/src/crypto/bcrypt.cr
+++ b/src/crypto/bcrypt.cr
@@ -47,7 +47,7 @@ class Crypto::Bcrypt
     0x64657253, 0x63727944, 0x6f756274,
   )
 
-  # Hashes a password using Bcrypt.
+  # Hashes the *password* using bcrypt algorithm using salt obtained via `Random::Secure.random_bytes`.
   #
   # ```
   # require "crypto/bcrypt"
@@ -61,7 +61,7 @@ class Crypto::Bcrypt
     new(passwordb, saltb, cost).to_s
   end
 
-  # Creates a new Bcrypt object from a string password and a salt.
+  # Creates a new `Bcrypt` object from the given *password* with *salt* and *cost*.
   #
   # ```
   # require "crypto/bcrypt"
@@ -80,7 +80,7 @@ class Crypto::Bcrypt
   getter salt : Bytes
   getter cost : Int32
 
-  # Creates a new Bcrypt object from a password and a salt in bytes.
+  # Creates a new `Bcrypt` object from the given *password* with *salt* in bytes and *cost*.
   #
   # ```
   # require "crypto/bcrypt"

--- a/src/crypto/bcrypt.cr
+++ b/src/crypto/bcrypt.cr
@@ -47,6 +47,13 @@ class Crypto::Bcrypt
     0x64657253, 0x63727944, 0x6f756274,
   )
 
+  # Hashes a password using Bcrypt.
+  #
+  # ```
+  # require "crypto/bcrypt"
+  #
+  # Crypto::Bcrypt.hash_secret "secret"
+  # ```
   def self.hash_secret(password, cost = DEFAULT_COST) : String
     # We make a clone here to we don't keep a mutable reference to the original string
     passwordb = password.to_unsafe.to_slice(password.bytesize + 1).clone # include leading 0
@@ -54,6 +61,14 @@ class Crypto::Bcrypt
     new(passwordb, saltb, cost).to_s
   end
 
+  # Creates a new Bcrypt object from a string password and a salt.
+  #
+  # ```
+  # require "crypto/bcrypt"
+  #
+  # password = Crypto::Bcrypt.new "secret", "salt_of_16_chars"
+  # password.digest
+  # ```
   def self.new(password : String, salt : String, cost = DEFAULT_COST)
     # We make a clone here to we don't keep a mutable reference to the original string
     passwordb = password.to_unsafe.to_slice(password.bytesize + 1).clone # include leading 0
@@ -65,6 +80,14 @@ class Crypto::Bcrypt
   getter salt : Bytes
   getter cost : Int32
 
+  # Creates a new Bcrypt object from a password and a salt in bytes.
+  #
+  # ```
+  # require "crypto/bcrypt"
+  #
+  # password = Crypto::Bcrypt.new "secret".to_slice, "salt_of_16_chars".to_slice
+  # password.digest
+  # ```
   def initialize(@password : Bytes, @salt : Bytes, @cost = DEFAULT_COST)
     raise Error.new("Invalid cost") unless COST_RANGE.includes?(cost)
     raise Error.new("Invalid salt size") unless salt.size == SALT_SIZE


### PR DESCRIPTION
~This method is untested, and is a little variation of the "standard" `Crypto::Bcrypt.new` constructor.~

~There are also other points I think can be improved in `Crypto::Bcrypt`, I have kept this PR minimal.~

Only adding docs on this PR.