### PR TITLE
`def_equals` compare first by reference

### DIFF
--- a/spec/std/object_spec.cr
+++ b/spec/std/object_spec.cr
@@ -154,6 +154,20 @@ private class HashedTestObject
   def_hash :a, :b
 end
 
+private struct NonReflexive
+  def ==(other)
+    false
+  end
+end
+
+private class DefEquals
+  def initialize
+    @x = NonReflexive.new
+  end
+
+  def_equals @x
+end
+
 describe Object do
   describe "delegate" do
     it "delegates" do
@@ -495,5 +509,14 @@ describe Object do
 
   it "applies annotation to lazy property (#9139)" do
     TestObject.test_annotation_count.should eq(1)
+  end
+
+  describe "def_equals" do
+    it "compares by reference" do
+      x = DefEquals.new
+      y = DefEquals.new
+      (x == x).should be_true
+      (x == y).should be_false
+    end
   end
 end

--- a/src/object.cr
+++ b/src/object.cr
@@ -1287,6 +1287,9 @@ class Object
   # Defines an `==` method by comparing the given fields.
   #
   # The generated `==` method has a `self` restriction.
+  # For classes it will first compare by reference and return `true`
+  # when an object instance is compared with itself, without comparing
+  # any of the fields.
   #
   # ```
   # class Person
@@ -1299,6 +1302,9 @@ class Object
   # ```
   macro def_equals(*fields)
     def ==(other : self)
+      {% if @type.class? %}
+        return true if same?(other)
+      {% end %}
       {% for field in fields %}
         return false unless {{field.id}} == other.{{field.id}}
       {% end %}


### PR DESCRIPTION
I'm not sure if there is a good reason not to do this. But as equality should always be reflexive, it sounds reasonable and valid.