### PR TITLE
Exhaustive case near and far

### DIFF
--- a/samples/llvm/brainfuck.cr
+++ b/samples/llvm/brainfuck.cr
@@ -183,8 +183,6 @@ class Program
         open_count += 1
       when ']'
         open_count -= 1
-      else
-        # go on
       end
 
       if open_count == 0

--- a/samples/sdl/fire.cr
+++ b/samples/sdl/fire.cr
@@ -386,8 +386,6 @@ while true
         speed_down[3] = true
       when LibSDL::Key::L
         turn_right[3] = true
-      else
-        # ignore
       end
     when LibSDL::KEYUP
       case event.key.key_sym.sym
@@ -423,11 +421,7 @@ while true
         speed_down[3] = false
       when LibSDL::Key::L
         turn_right[3] = false
-      else
-        # ignore
       end
-    else
-      # ignore
     end
   end
 

--- a/src/char.cr
+++ b/src/char.cr
@@ -331,8 +331,6 @@ struct Char
         else # at the beginning of the set or escaped
           return not_negated if self == char
         end
-      else
-        # go on
       end
 
       if range && previous

--- a/src/compiler/crystal/codegen/call.cr
+++ b/src/compiler/crystal/codegen/call.cr
@@ -553,8 +553,6 @@ class Crystal::CodeGenVisitor
         else
           @last = llvm_nil
         end
-      else
-        # go on
       end
     end
 

--- a/src/compiler/crystal/codegen/call.cr
+++ b/src/compiler/crystal/codegen/call.cr
@@ -217,11 +217,11 @@ class Crystal::CodeGenVisitor
 
       abi_arg_type = abi_info.arg_types[i]
       case abi_arg_type.kind
-      when LLVM::ABI::ArgKind::Direct
+      in .direct?
         call_arg = codegen_direct_abi_call(call_arg, abi_arg_type) unless arg.type.nil_type?
-      when LLVM::ABI::ArgKind::Indirect
+      in .indirect?
         # Pass argument as is (will be passed byval)
-      when LLVM::ABI::ArgKind::Ignore
+      in .ignore?
         # Ignore
         next
       end
@@ -522,7 +522,7 @@ class Crystal::CodeGenVisitor
       else
         abi_return = abi_info(external).return_type
         case abi_return.kind
-        when LLVM::ABI::ArgKind::Direct
+        in .direct?
           if cast = abi_return.cast
             cast1 = alloca cast
             store @last, cast1
@@ -535,9 +535,9 @@ class Crystal::CodeGenVisitor
             memcpy(final_value_casted, cast2, size, align, int1(0))
             @last = final_value
           end
-        when LLVM::ABI::ArgKind::Indirect
+        in .indirect?
           @last = @sret_value.not_nil!
-        when LLVM::ABI::ArgKind::Ignore
+        in .ignore?
           # Nothing
         end
       end

--- a/src/compiler/crystal/codegen/cast.cr
+++ b/src/compiler/crystal/codegen/cast.cr
@@ -188,8 +188,6 @@ class Crystal::CodeGenVisitor
         value = upcast(value, compatible_type, value_type)
         return assign(target_pointer, target_type, compatible_type, value)
       end
-    else
-      # go on
     end
 
     value = to_rhs(value, value_type)
@@ -461,8 +459,6 @@ class Crystal::CodeGenVisitor
         value = downcast(value, to_type, compatible_type, true)
         return value
       end
-    else
-      # go on
     end
 
     _, value_ptr = union_type_and_value_pointer(value, from_type)
@@ -677,8 +673,6 @@ class Crystal::CodeGenVisitor
         value = upcast(value, compatible_type, from_type)
         return upcast(value, to_type, compatible_type)
       end
-    else
-      # go on
     end
 
     union_ptr = alloca(llvm_type(to_type))

--- a/src/compiler/crystal/codegen/class_var.cr
+++ b/src/compiler/crystal/codegen/class_var.cr
@@ -181,8 +181,6 @@ class Crystal::CodeGenVisitor
       return read_virtual_class_var_ptr(class_var, owner)
     when VirtualMetaclassType
       return read_virtual_metaclass_class_var_ptr(class_var, owner)
-    else
-      # go on
     end
 
     initializer = class_var.initializer

--- a/src/compiler/crystal/codegen/codegen.cr
+++ b/src/compiler/crystal/codegen/codegen.cr
@@ -309,8 +309,6 @@ module Crystal
              @codegen.personality_name, GET_EXCEPTION_NAME, RAISE_OVERFLOW_NAME,
              ONCE_INIT, ONCE
           @codegen.accept node
-        else
-          # go on
         end
 
         false
@@ -1104,8 +1102,6 @@ module Crystal
       when ClassVar
         # This is the case of a class var initializer
         initialize_class_var(var)
-      else
-        # go on
       end
 
       @last = llvm_nil

--- a/src/compiler/crystal/codegen/fun.cr
+++ b/src/compiler/crystal/codegen/fun.cr
@@ -329,27 +329,27 @@ class Crystal::CodeGenVisitor
     llvm_args_types = Array(LLVM::Type).new(abi_info.arg_types.size)
     abi_info.arg_types.each do |arg_type|
       case arg_type.kind
-      when LLVM::ABI::ArgKind::Direct
+      in .direct?
         llvm_args_types << (arg_type.cast || arg_type.type)
-      when LLVM::ABI::ArgKind::Indirect
+      in .indirect?
         llvm_args_types << arg_type.type.pointer
-      when LLVM::ABI::ArgKind::Ignore
+      in .ignore?
         # ignore
       end
     end
 
     ret_type = abi_info.return_type
-    case ret_type.kind
-    when LLVM::ABI::ArgKind::Direct
-      llvm_return_type = (ret_type.cast || ret_type.type)
-    when LLVM::ABI::ArgKind::Indirect
-      sret = true
-      offset += 1
-      llvm_args_types.insert 0, ret_type.type.pointer
-      llvm_return_type = llvm_context.void
-    else
-      llvm_return_type = llvm_context.void
-    end
+    llvm_return_type =
+      case ret_type.kind
+      in .direct?
+        ret_type.cast || ret_type.type
+      in .indirect?
+        offset += 1
+        llvm_args_types.insert 0, ret_type.type.pointer
+        llvm_context.void
+      in .ignore?
+        llvm_context.void
+      end
 
     setup_context_fun(mangled_name, target_def, llvm_args_types, llvm_return_type)
 

--- a/src/compiler/crystal/codegen/primitives.cr
+++ b/src/compiler/crystal/codegen/primitives.cr
@@ -1032,7 +1032,7 @@ class Crystal::CodeGenVisitor
 
       abi_arg_type = abi_info.arg_types[index]
       case abi_arg_type.kind
-      when LLVM::ABI::ArgKind::Direct
+      in .direct?
         call_arg = codegen_direct_abi_call(call_arg, abi_arg_type)
         if cast = abi_arg_type.cast
           null_fun_types << cast
@@ -1040,11 +1040,11 @@ class Crystal::CodeGenVisitor
           null_fun_types << abi_arg_type.type
         end
         null_args << call_arg
-      when LLVM::ABI::ArgKind::Indirect
+      in .indirect?
         # Pass argument as is (will be passed byval)
         null_args << call_arg
         null_fun_types << abi_arg_type.type.pointer
-      when LLVM::ABI::ArgKind::Ignore
+      in .ignore?
         # Ignore
       end
     end

--- a/src/compiler/crystal/codegen/primitives.cr
+++ b/src/compiler/crystal/codegen/primitives.cr
@@ -128,13 +128,11 @@ class Crystal::CodeGenVisitor
     when ">=" then return codegen_binary_op_gte(t1, t2, p1, p2)
     when "==" then return codegen_binary_op_eq(t1, t2, p1, p2)
     when "!=" then return codegen_binary_op_ne(t1, t2, p1, p2)
-    else # go on
     end
 
     case op
     when "+", "-", "*"
       return codegen_binary_op_with_overflow(op, t1, t2, p1, p2)
-    else # go on
     end
 
     tmax, p1, p2 = codegen_binary_extend_int(t1, t2, p1, p2)

--- a/src/compiler/crystal/codegen/types.cr
+++ b/src/compiler/crystal/codegen/types.cr
@@ -205,8 +205,6 @@ module Crystal
           when IntegerType, EnumType
             interpreter = MathInterpreter.new(namespace, visitor)
             @compile_time_value = interpreter.interpret(value) rescue nil
-          else
-            # go on
           end
         end
       end

--- a/src/compiler/crystal/codegen/types.cr
+++ b/src/compiler/crystal/codegen/types.cr
@@ -201,7 +201,7 @@ module Crystal
         when CharLiteral
           @compile_time_value = value.value
         else
-          case type = value.type?
+          case value.type?
           when IntegerType, EnumType
             interpreter = MathInterpreter.new(namespace, visitor)
             @compile_time_value = interpreter.interpret(value) rescue nil

--- a/src/compiler/crystal/exception.cr
+++ b/src/compiler/crystal/exception.cr
@@ -106,13 +106,13 @@ module Crystal
 
     def error_body(source, default_message) : String | Nil
       case filename = @filename
-      when VirtualFile
+      in VirtualFile
         return format_macro_error(filename)
-      when String
+      in String
         if File.file?(filename)
           return format_error_from_file(filename)
         end
-      else
+      in Nil
         # go on
       end
 
@@ -151,11 +151,11 @@ module Crystal
 
       String.build do |io|
         case filename
-        when String
+        in String
           io << filename_row_col_message(filename, line_number, column_number)
-        when VirtualFile
+        in VirtualFile
           io << "macro '" << colorize("#{filename.macro.name}").underline << '\''
-        else
+        in Nil
           io << "unknown location"
         end
 
@@ -209,15 +209,15 @@ module Crystal
 
     def source_lines(filename)
       case filename
-      when Nil
+      in Nil
         nil
-      when String
+      in String
         if File.file? filename
           File.read_lines(filename)
         else
           nil
         end
-      when VirtualFile
+      in VirtualFile
         filename.source.lines
       end
     end
@@ -229,11 +229,11 @@ module Crystal
       column_number = macro_source.try &.column_number
 
       case source_filename
-      when String
+      in String
         io << colorize("#{relative_filename(source_filename)}:#{line_number}:#{column_number}").underline
-      when VirtualFile
+      in VirtualFile
         io << "macro '" << colorize("#{source_filename.macro.name}").underline << '\''
-      else
+      in Nil
         "unknown location"
       end
 

--- a/src/compiler/crystal/macros/interpreter.cr
+++ b/src/compiler/crystal/macros/interpreter.cr
@@ -468,8 +468,6 @@ module Crystal
               return NamedTupleLiteral.new(entries)
             when UnionType
               return TupleLiteral.map(matched_type.union_types) { |t| TypeNode.new(t) }
-            else
-              # go on
             end
           end
         end

--- a/src/compiler/crystal/semantic/call.cr
+++ b/src/compiler/crystal/semantic/call.cr
@@ -43,8 +43,6 @@ class Crystal::Call
     when LibType
       # `LibFoo.call` has a separate logic
       return recalculate_lib_call obj_type
-    else
-      # Nothing
     end
 
     # Check if its call is inside LibFoo

--- a/src/compiler/crystal/semantic/class_vars_initializer_visitor.cr
+++ b/src/compiler/crystal/semantic/class_vars_initializer_visitor.cr
@@ -163,8 +163,6 @@ module Crystal
           node_to_discard.discarded = true
         when TypeDeclaration
           node_to_discard.discarded = true
-        else
-          # nothing to do
         end
       end
     end

--- a/src/compiler/crystal/semantic/cleanup_transformer.cr
+++ b/src/compiler/crystal/semantic/cleanup_transformer.cr
@@ -538,8 +538,6 @@ module Crystal
         if owner.passed_as_self?
           arg.raise "#{message} (closured vars: self)"
         end
-      else
-        # nothing to do
       end
     end
 

--- a/src/compiler/crystal/semantic/lib.cr
+++ b/src/compiler/crystal/semantic/lib.cr
@@ -194,8 +194,6 @@ class Crystal::Call
       return if convert_numeric_argument self_arg, unaliased_type, expected_type, actual_type, index
     when FloatType
       return if convert_numeric_argument self_arg, unaliased_type, expected_type, actual_type, index
-    else
-      # go on
     end
 
     implicit_call = Conversions.try_to_unsafe(self_arg.clone, parent_visitor) do |ex|

--- a/src/compiler/crystal/semantic/main_visitor.cr
+++ b/src/compiler/crystal/semantic/main_visitor.cr
@@ -1428,8 +1428,6 @@ module Crystal
         case exp
         when Var, InstanceVar, ClassVar, Global
           next
-        else
-          # go on
         end
 
         temp_var = @program.new_temp_var.at(arg.location)
@@ -1573,8 +1571,6 @@ module Crystal
           if instance_type.namespace.is_a?(LibType) && (named_args = node.named_args)
             return special_c_struct_or_union_new_with_named_args(node, instance_type, named_args)
           end
-        else
-          # go on, nothing special
         end
       end
 
@@ -1846,8 +1842,6 @@ module Crystal
       when Expressions
         return unless exp = exp.single_expression?
         return get_expression_var(exp)
-      else
-        # go on
       end
       nil
     end
@@ -1872,8 +1866,6 @@ module Crystal
         node.raise "can't cast to Reference yet"
       when @program.class_type
         node.raise "can't cast to Class yet"
-      else
-        # go on
       end
 
       obj_type = node.obj.type?
@@ -1979,8 +1971,6 @@ module Crystal
         elsif or_right_type_filters
           filter_vars or_right_type_filters.not
         end
-      else
-        # go on
       end
 
       before_else_vars = @vars.dup
@@ -2001,8 +1991,6 @@ module Crystal
           @or_left_type_filters = or_left_type_filters = then_type_filters
           @or_right_type_filters = or_right_type_filters = else_type_filters
           @type_filters = TypeFilters.or(cond_type_filters, then_type_filters, else_type_filters)
-        else
-          # go on: a regular if
         end
       end
 
@@ -2294,8 +2282,6 @@ module Crystal
       when Expressions
         return unless node = node.single_expression?
         return get_while_cond_assign_target(node)
-      else
-        # go on
       end
 
       nil
@@ -2519,8 +2505,6 @@ module Crystal
           node.extra = convert_call
           return
         end
-      else
-        # go on
       end
 
       unsafe_call = Conversions.to_unsafe(node, Var.new("value").at(node), self, actual_type, expected_type)
@@ -3072,12 +3056,8 @@ module Crystal
           case element
           when Var         then element.accept(self)
           when InstanceVar then element.accept(self)
-          else
-            # Nothing to do
           end
         end
-      else
-        # Nothing to do
       end
 
       expand(node)
@@ -3131,8 +3111,6 @@ module Crystal
         case exp
         when Var, IsA, RespondsTo, Not
           return type_filters.not
-        else
-          # go on
         end
       end
 

--- a/src/compiler/crystal/semantic/semantic_visitor.cr
+++ b/src/compiler/crystal/semantic/semantic_visitor.cr
@@ -394,8 +394,6 @@ abstract class Crystal::SemanticVisitor < Crystal::Visitor
               expanded = expanded_type.value
             when Type
               expanded = TypeNode.new(expanded_type)
-            else
-              # go on
             end
           end
           expanded
@@ -486,8 +484,6 @@ abstract class Crystal::SemanticVisitor < Crystal::Visitor
     when @program.experimental_annotation
       # ditto DeprecatedAnnotation
       ExperimentalAnnotation.from(ann)
-    else
-      # go on
     end
   end
 

--- a/src/compiler/crystal/semantic/top_level_visitor.cr
+++ b/src/compiler/crystal/semantic/top_level_visitor.cr
@@ -357,8 +357,6 @@ class Crystal::TopLevelVisitor < Crystal::SemanticVisitor
                       receiver.raise "can't define method in generic instance #{metaclass}"
                     when GenericModuleInstanceMetaclassType
                       receiver.raise "can't define method in generic instance #{metaclass}"
-                    else
-                      # go on
                     end
                     metaclass
                   end
@@ -824,8 +822,6 @@ class Crystal::TopLevelVisitor < Crystal::SemanticVisitor
       # Don't give an error yet: wait to see if the
       # call doesn't resolve to a method/macro
       return false
-    else
-      # go on
     end
 
     node.raise "can't apply visibility modifier"

--- a/src/compiler/crystal/semantic/type_guess_visitor.cr
+++ b/src/compiler/crystal/semantic/type_guess_visitor.cr
@@ -319,8 +319,6 @@ module Crystal
         value = process_assign_instance_var(owner, target, value)
       when GenericModuleType
         value = process_assign_instance_var(owner, target, value)
-      else
-        # go on
       end
 
       unless current_type.allows_instance_vars?

--- a/src/compiler/crystal/semantic/type_lookup.cr
+++ b/src/compiler/crystal/semantic/type_lookup.cr
@@ -246,8 +246,6 @@ class Crystal::Type
             type_var.raise "can only splat tuple type, not #{splat_type}"
           end
           next
-        else
-          # go on
         end
 
         # Check the case of T resolving to a number
@@ -266,8 +264,6 @@ class Crystal::Type
           when ASTNode
             type_vars << type
             next
-          else
-            # go on
           end
         end
 
@@ -278,8 +274,6 @@ class Crystal::Type
         case instance_type
         when GenericUnionType, PointerType, StaticArrayType, TupleType, ProcType
           check_type_can_be_stored(type_var, type, "can't use #{type} as a generic type argument")
-        else
-          # go on
         end
 
         type_vars << type.virtual_type

--- a/src/compiler/crystal/syntax/lexer.cr
+++ b/src/compiler/crystal/syntax/lexer.cr
@@ -2462,8 +2462,6 @@ module Crystal
                 if delimiter_state.open_count == 0
                   delimiter_state = nil
                 end
-              else
-                # Nothing to do
               end
             end
 

--- a/src/compiler/crystal/syntax/parser.cr
+++ b/src/compiler/crystal/syntax/parser.cr
@@ -2717,8 +2717,6 @@ module Crystal
            !exp.block
           return
         end
-      else
-        # Go on
       end
 
       raise "expression of exhaustive case (case ... in) must be a constant (like `IO::Memory`), a generic (like `Array(Int32)`) a bool literal (true or false), a nil literal (nil) or a question method (like `.red?`)", exp.location.not_nil!
@@ -3965,8 +3963,6 @@ module Crystal
           a_else = parse_expressions
         when :elsif
           a_else = parse_if check_end: false
-        else
-          # go on
         end
       end
 

--- a/src/compiler/crystal/tools/context.cr
+++ b/src/compiler/crystal/tools/context.cr
@@ -239,8 +239,6 @@ module Crystal
         if (obj = cond.obj).is_a?(Var)
           filters = TypeFilters.new(obj, SimpleTypeFilter.new(cond.const.type))
         end
-      else
-        # go on
       end
 
       if filters

--- a/src/compiler/crystal/tools/doc/markdown/parser.cr
+++ b/src/compiler/crystal/tools/doc/markdown/parser.cr
@@ -409,8 +409,6 @@ class Crystal::Doc::Markdown::Parser
           cursor = pos + 1
           in_link = false
         end
-      else
-        # Nothing
       end
       last_is_space = pos < bytesize && str[pos].unsafe_chr.ascii_whitespace?
       pos += 1
@@ -448,8 +446,6 @@ class Crystal::Doc::Markdown::Parser
         if bracket_count == 0
           break
         end
-      else
-        # nothing to do
       end
       pos += 1
     end

--- a/src/compiler/crystal/tools/doc/type.cr
+++ b/src/compiler/crystal/tools/doc/type.cr
@@ -90,8 +90,6 @@ class Crystal::Doc::Type
       superclass = type.superclass
     when GenericClassInstanceType
       superclass = type.superclass
-    else
-      # go on
     end
 
     if superclass
@@ -268,8 +266,6 @@ class Crystal::Doc::Type
             next
           when NonGenericClassType
             next if subclass.extern?
-          else
-            # go on
           end
 
           next unless @generator.must_include?(subclass)

--- a/src/compiler/crystal/tools/formatter.cr
+++ b/src/compiler/crystal/tools/formatter.cr
@@ -3069,8 +3069,6 @@ module Crystal
         else
           clear_object(node.exp)
         end
-      else
-        # nothing to do
       end
     end
 

--- a/src/csv/lexer/string_based.cr
+++ b/src/csv/lexer/string_based.cr
@@ -34,8 +34,6 @@ class CSV::Lexer::StringBased < CSV::Lexer
         break
       when @quote_char
         raise "Unexpected quote"
-      else
-        # go on
       end
     end
     @reader.string.byte_slice(start_pos, end_pos - start_pos)

--- a/src/dir/glob.cr
+++ b/src/dir/glob.cr
@@ -159,10 +159,10 @@ class Dir
 
         next_pos = pos - 1
         case cmd
-        when RootDirectory
+        in RootDirectory
           raise "unreachable" if path
           path_stack << {next_pos, root, nil}
-        when DirectoriesOnly
+        in DirectoriesOnly
           raise "unreachable" unless path
           # FIXME: [win32] File::SEPARATOR_STRING comparison is not sufficient for Windows paths.
           if path == File::SEPARATOR_STRING
@@ -176,13 +176,13 @@ class Dir
           else
             yield fullpath if dir?(fullpath)
           end
-        when EntryMatch
+        in EntryMatch
           return if sequence[pos + 1]?.is_a?(RecursiveDirectories)
           each_child(path) do |entry|
             next if !options[:match_hidden] && entry.name.starts_with?('.')
             yield join(path, entry.name) if cmd.matches?(entry.name)
           end
-        when DirectoryMatch
+        in DirectoryMatch
           next_cmd = sequence[next_pos]?
 
           each_child(path) do |entry|
@@ -193,15 +193,15 @@ class Dir
               end
             end
           end
-        when ConstantEntry
+        in ConstantEntry
           return if sequence[pos + 1]?.is_a?(RecursiveDirectories)
           full = join(path, cmd.path)
           yield full if File.exists?(full) || File.symlink?(full)
-        when ConstantDirectory
+        in ConstantDirectory
           path_stack << {next_pos, join(path, cmd.path), nil}
           # Don't check if full exists. It just costs us time
           # and the downstream node will be able to check properly.
-        when RecursiveDirectories
+        in RecursiveDirectories
           path_stack << {next_pos, path, nil}
           next_cmd = sequence[next_pos]?
 
@@ -267,8 +267,6 @@ class Dir
               dir = dir_stack.last
             end
           end
-        else
-          raise "unreachable"
         end
       end
     end

--- a/src/dir/glob.cr
+++ b/src/dir/glob.cr
@@ -246,8 +246,6 @@ class Dir
                 yield fullpath if next_cmd.path == entry.name
               when EntryMatch
                 yield fullpath if next_cmd.matches?(entry.name)
-              else
-                # go on
               end
 
               if entry.dir?

--- a/src/http/server/request_processor.cr
+++ b/src/http/server/request_processor.cr
@@ -88,8 +88,6 @@ class HTTP::Server::RequestProcessor
         when ChunkedContent
           # Close the connection if the IO has still bytes to read.
           break unless body.closed?
-        else
-          # Nothing to do
         end
       end
     rescue IO::Error

--- a/src/llvm/abi/aarch64.cr
+++ b/src/llvm/abi/aarch64.cr
@@ -27,8 +27,6 @@ class LLVM::ABI::AArch64 < LLVM::ABI
                   check_array(type)
                 when Type::Kind::Struct
                   check_struct(type)
-                else
-                  # go on
                 end
 
     # Ensure we have at most four uniquely addressable members

--- a/src/log/entry.cr
+++ b/src/log/entry.cr
@@ -10,8 +10,6 @@ enum Log::Severity
   Notice
   # Used for conditions that can potentially cause application oddities, but that can be automatically recovered.
   Warn
-  # DEPRECATED: Use `Warn`.
-  Warning = Warn
   # Used for any error that is fatal to the operation, but not to the service or application.
   Error
   # Used for any error that is forcing a shutdown of the service or application

--- a/src/log/entry.cr
+++ b/src/log/entry.cr
@@ -19,16 +19,14 @@ enum Log::Severity
 
   def label
     case self
-    when Trace  then "TRACE"
-    when Debug  then "DEBUG"
-    when Info   then "INFO"
-    when Notice then "NOTICE"
-    when Warn   then "WARN"
-    when Error  then "ERROR"
-    when Fatal  then "FATAL"
-    when None   then "NONE"
-    else
-      raise "unreachable"
+    in Trace  then "TRACE"
+    in Debug  then "DEBUG"
+    in Info   then "INFO"
+    in Notice then "NOTICE"
+    in Warn   then "WARN"
+    in Error  then "ERROR"
+    in Fatal  then "FATAL"
+    in None   then "NONE"
     end
   end
 end

--- a/src/string.cr
+++ b/src/string.cr
@@ -2374,8 +2374,6 @@ class String
         buffer << capture
         index = end_index + 1
         first_index = index
-      else
-        # Nothing
       end
     end
 


### PR DESCRIPTION
This PR aims to be a small followup to #8424, it:

- Uses exhaustive `case` statements in few places throughout the stdlib
- Drops empty `else # go on / ignore / nothing to do` branches
- Removes deprecated `Log::Severity::Warning`