### PR TITLE
Marks else branch of exhaustive case as unreachable

### DIFF
--- a/spec/compiler/semantic/cast_spec.cr
+++ b/spec/compiler/semantic/cast_spec.cr
@@ -359,4 +359,14 @@ describe "Semantic: cast" do
       x.foo if x
       )) { nil_type }
   end
+
+  it "considers else to be unreachable (#9658)" do
+    assert_type(%(
+      case 1
+      in Int32
+        v = 1
+      end
+      v
+      )) { int32 }
+  end
 end

--- a/src/compiler/crystal/semantic/main_visitor.cr
+++ b/src/compiler/crystal/semantic/main_visitor.cr
@@ -3165,6 +3165,7 @@ module Crystal
 
     def visit(node : Unreachable)
       node.type = @program.no_return
+      @unreachable = true
     end
 
     # # Helpers


### PR DESCRIPTION
Fixes #9658 — courtesy of @asterite in https://github.com/crystal-lang/crystal/issues/9658#issuecomment-668191072