### PR TITLE
Update distribution-scripts and publish nightly packages to bintray

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -522,6 +522,7 @@ workflows:
             branches:
               ignore:
                 - /release\/.+/
+                - /package\/.+/
                 - /.*\bci\b.*/
       - test_linux32_std:
           filters: *unless_maintenance
@@ -752,3 +753,33 @@ workflows:
             - dist_darwin
             - dist_snap
             - dist_docs
+
+  package_build:
+    jobs:
+      - prepare_common:
+          filters: &package
+            branches:
+              only:
+                - /package\/.+/
+      - prepare_maintenance:
+          filters: *package
+          requires:
+            - prepare_common
+      - dist_linux:
+          filters: *package
+          requires:
+            - prepare_maintenance
+      - dist_linux32:
+          filters: *package
+          requires:
+            - prepare_maintenance
+      - dist_darwin:
+          filters: *package
+          requires:
+            - prepare_maintenance
+      - dist_artifacts:
+          filters: *package
+          requires:
+            - dist_linux
+            - dist_linux32
+            - dist_darwin

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -225,12 +225,17 @@ jobs:
     steps:
       - attach_workspace:
           at: /tmp/workspace
+      - checkout
+      - run: |
+          # We need CRYSTAL_VERSION in prepare_nightly to use src/VERSION so we publish them as x.y.z-dev in apt/rpm
+          #
+          # How to brand it
+          echo "export CRYSTAL_VERSION=$(cat src/VERSION)" >> /tmp/workspace/distribution-scripts/build.env
+          #
+          # TODO: We might want to do that on docker images also to support updates on multiple development versions the same date.
       - run: |
           cd /tmp/workspace/distribution-scripts
 
-          # How to brand it
-          export VERSION=nightly-$(date '+%Y%m%d')
-          echo "export CRYSTAL_VERSION=$VERSION" >> build.env
           echo "export DOCKER_TAG=nightly" >> build.env
 
           # Build from working directory (needed for omnibus and when version does not match branch/tag)
@@ -357,6 +362,24 @@ jobs:
           root: /tmp/workspace/distribution-scripts/darwin/
           paths:
             - build
+
+  dist_bintray_nightly:
+    machine: true
+    steps:
+      - attach_workspace:
+          at: /tmp/workspace
+      - run:
+          no_output_timeout: 20m
+          command: |
+            cd /tmp/workspace/distribution-scripts
+            source build.env
+            cd bintray
+            ./publish-nightly.sh $CRYSTAL_VERSION $(date '+%Y-%m-%d') \
+                /tmp/workspace/build/crystal-*-linux-x86_64.tar.gz \
+                /tmp/workspace/build/crystal-*-linux-i686.tar.gz
+      - store_artifacts:
+          path: /tmp/workspace/distribution-scripts/bintray/build/unsigned
+          destination: unsigned
 
   dist_docker:
     machine: true
@@ -645,6 +668,10 @@ workflows:
       - dist_darwin:
           requires:
             - prepare_nightly
+      - dist_bintray_nightly:
+          requires:
+            - dist_linux
+            - dist_linux32
       - dist_docker:
           requires:
             - dist_linux

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -172,7 +172,7 @@ jobs:
       - run: |
           git clone https://github.com/crystal-lang/distribution-scripts.git ~/distribution-scripts
           cd ~/distribution-scripts
-          git checkout cb8f2c51a042609d7c45707ba8369b37d011037f
+          git checkout 44172615fa196fb8592046582471fdfc8d69472c
       # persist relevant information for build process
       - run: |
           cd ~/distribution-scripts


### PR DESCRIPTION
Includes the following changes from distribution-scripts:

* crystal-lang/distribution-scripts#72 Bintray publishing scripts
* crystal-lang/distribution-scripts#73 Update shards v0.12.0 (this means nightly build will be recovered)

It publishes nightly packages to bintray deb and rpm repos. A sample run was made at https://circleci.com/workflow-run/56b17888-c9bd-493a-83a1-d5e1fcb74aa8. The names for the files are changed from `nightly-YYYYMMDD` to `x.y.x-dev` (or whatever is stated in the `src/VERSION` file).

https://bintray.com/beta/#/crystal/deb/crystal/1.0.0-dev?tab=overview

![Screen Shot 2020-08-06 at 16 19 28](https://user-images.githubusercontent.com/459923/89573233-ad75ce80-d800-11ea-8e9c-17706c1f7e5c.png)

---

I'm also including some branch rules to run only the package steps (without test), I've been using this multiple times already to avoid running the whole maintenance workflow in some situations.



