### PR TITLE
bug-fix: VerifyMode::FAIL_IF_NO_PEER_CERT

### DIFF
--- a/src/openssl/ssl/context.cr
+++ b/src/openssl/ssl/context.cr
@@ -410,7 +410,7 @@ abstract class OpenSSL::SSL::Context
     when "peer"
       context.verify_mode = OpenSSL::SSL::VerifyMode::PEER
     when "force-peer"
-      context.verify_mode = OpenSSL::SSL::VerifyMode::FAIL_IF_NO_PEER_CERT
+      context.verify_mode = OpenSSL::SSL::VerifyMode::PEER | OpenSSL::SSL::VerifyMode::FAIL_IF_NO_PEER_CERT
     when "none"
       context.verify_mode = OpenSSL::SSL::VerifyMode::NONE
     when nil


### PR DESCRIPTION
force-peer: VerifyMode::FAIL_IF_NO_PEER_CERT is only valid when set together with VerifyMode::PEER

Source: https://www.openssl.org/docs/man1.1.1/man3/SSL_CTX_set_verify.html