### PR TITLE
Use simple method definition when delegating regex operators (=~, !~)

### DIFF
--- a/spec/std/object_spec.cr
+++ b/spec/std/object_spec.cr
@@ -4,6 +4,7 @@ require "../support/finalize"
 private class StringWrapper
   delegate downcase, to: @string
   delegate upcase, capitalize, char_at, scan, to: @string
+  delegate :==, :!=, :=~, :!~, to: @string
 
   @string : String
 
@@ -172,6 +173,12 @@ describe Object do
         matches << match[0]
       end
       matches.should eq(["l", "l"])
+
+      (wrapper == "HellO").should be_true
+      (wrapper != "HellO").should be_false
+
+      (wrapper =~ /hello/i).should eq(0)
+      (wrapper !~ /hello/i).should be_false
     end
 
     it "delegates setter" do

--- a/src/object.cr
+++ b/src/object.cr
@@ -1244,7 +1244,7 @@ class Object
   # ```
   macro delegate(*methods, to object)
     {% for method in methods.map(&.id) %}
-      {% if method.ends_with?('=') && method != "[]=" %}
+      {% if (method.ends_with?('=') || method.ends_with?('~')) && method != "[]=" %}
         def {{method}}(arg)
           {{object.id}}.{{method}} arg
         end

--- a/src/object.cr
+++ b/src/object.cr
@@ -1243,19 +1243,19 @@ class Object
   # wrapper.capitalize     # => "Hello"
   # ```
   macro delegate(*methods, to object)
-    {% for method in methods %}
-      {% if method.id.ends_with?('=') && method.id != "[]=" %}
-        def {{method.id}}(arg)
-          {{object.id}}.{{method.id}} arg
+    {% for method in methods.map(&.id) %}
+      {% if method.ends_with?('=') && method != "[]=" %}
+        def {{method}}(arg)
+          {{object.id}}.{{method}} arg
         end
       {% else %}
-        def {{method.id}}(*args, **options)
-          {{object.id}}.{{method.id}}(*args, **options)
+        def {{method}}(*args, **options)
+          {{object.id}}.{{method}}(*args, **options)
         end
 
-        {% if method.id != "[]=" %}
-          def {{method.id}}(*args, **options)
-            {{object.id}}.{{method.id}}(*args, **options) do |*yield_args|
+        {% if method != "[]=" %}
+          def {{method}}(*args, **options)
+            {{object.id}}.{{method}}(*args, **options) do |*yield_args|
               yield *yield_args
             end
           end


### PR DESCRIPTION
Right now doing `delegate :=~, :!~, to: @obj` is needlessly expanding the delegated methods into 2 methods definitions (regular + block variant), this PR changes that to make them treated the same as regular equality operators (`==`, `!=`).