### PR TITLE
make __crystal_raise_overflow error more clear

### DIFF
--- a/src/compiler/crystal/codegen/codegen.cr
+++ b/src/compiler/crystal/codegen/codegen.cr
@@ -2036,7 +2036,7 @@ module Crystal
       if raise_overflow_fun = @raise_overflow_fun
         check_main_fun RAISE_OVERFLOW_NAME, raise_overflow_fun
       else
-        raise "ERROR: missing __crystal_raise_overflow function, either use std-lib's prelude or define it"
+        raise LocationlessException.new("Missing __crystal_raise_overflow function, either use std-lib's prelude or define it")
       end
     end
 

--- a/src/compiler/crystal/codegen/codegen.cr
+++ b/src/compiler/crystal/codegen/codegen.cr
@@ -2036,7 +2036,7 @@ module Crystal
       if raise_overflow_fun = @raise_overflow_fun
         check_main_fun RAISE_OVERFLOW_NAME, raise_overflow_fun
       else
-        raise "BUG: __crystal_raise_overflow is not defined"
+        raise "ERROR: missing __crystal_raise_overflow function, either use std-lib's prelude or define it"
       end
     end
 


### PR DESCRIPTION
per #8437, make the "__crystal_raise_overflow" error be more explicit about what's actually happening

with this pr, running the shell commands in that bug report (`echo 2+2 > test.cr && crystal build test.cr --prelude=empty`) produces the following output:

```
LLVM function `__crystal_raise_overflow` is not defined (are you using a prelude?) (Exception)
  from src/compiler/crystal/codegen/codegen.cr:2039:9 in 'crystal_raise_overflow_fun'
  [long stack trace]
Error: you've found a bug in the Crystal compiler. Please open an issue, including source code that will allow us to reproduce the bug: https://github.com/crystal-lang/crystal/issues
```

that bug report had some confusion as to whether this was really a bug, and as to what the original error message (`BUG: __crystal_raise_overflow is not defined`) meant. with this pr, the final line still claims there was a compiler bug that should be reported, but at least the error message is imo a bit clearer

i don't think this should report a compiler error, but i have no idea where to go about changing that, and trying to figure it out lead me down a rabbit hole