### PR TITLE
Fix bug in SHA1 implementation

### DIFF
--- a/src/digest/sha1.cr
+++ b/src/digest/sha1.cr
@@ -35,10 +35,10 @@ class Digest::SHA1 < Digest::Base
     data.each do |byte|
       @message_block[@message_block_index] = byte & 0xFF_u8
       @message_block_index += 1
-      @length_low += 8
+      @length_low &+= 8
 
       if @length_low == 0
-        @length_high += 1
+        @length_high &+= 1
         if @length_high == 0
           raise ArgumentError.new "Crypto.sha1: message too long"
         end


### PR DESCRIPTION
Fixes #9694 

There is a check for overflow that wasn't being executed because the overflow protection would kick in. This fixes that bug.

Also, while I was in there, I noticed that the `length` members were `UInt32` regardless of the architecture, so I added a check for 32-bit vs 64-bit so that large files can be hashed on a 32-bit system