### PR TITLE
OpenSSL::DigestIO - add missing delegate final

### DIFF
--- a/src/openssl/digest/digest_io.cr
+++ b/src/openssl/digest/digest_io.cr
@@ -20,7 +20,7 @@ module OpenSSL
     getter mode : DigestMode
 
     delegate close, closed?, flush, peek, tty?, rewind, to: @io
-    delegate digest, hexdigest, base64digest, to: @digest_algorithm
+    delegate final, digest, hexdigest, base64digest, to: @digest_algorithm
 
     enum DigestMode
       Read


### PR DESCRIPTION
The following warning is shown when using `hexdigest` on a `OpenSSL::DigestIO` instance. This change delegates the missing `final` method so the instructions can be followed.

```text
In /usr/local/Cellar/crystal/0.35.1_1/src/openssl/digest/digest_io.cr:23:5

 23 | delegate digest, hexdigest, base64digest, to: @digest_algorithm
      ^
Warning: expanding macro


There was a problem expanding macro 'delegate'

Called macro defined in /usr/local/Cellar/crystal/0.35.1_1/src/object.cr:1245:3

 1245 | macro delegate(*methods, to object)

Which expanded to:

    1 |
    2 |
    3 |         def digest(*args, **options)
    4 |           @digest_algorithm.digest(*args, **options)
    5 |         end
    6 |
    7 |
    8 |           def digest(*args, **options)
    9 |             @digest_algorithm.digest(*args, **options) do |*yield_args|
   10 |               yield *yield_args
   11 |             end
   12 |           end
   13 |
   14 |
   15 |
   16 |
   17 |         def hexdigest(*args, **options)
 > 18 |           @digest_algorithm.hexdigest(*args, **options)
   19 |         end
   20 |
   21 |
   22 |           def hexdigest(*args, **options)
   23 |             @digest_algorithm.hexdigest(*args, **options) do |*yield_args|
   24 |               yield *yield_args
   25 |             end
   26 |           end
   27 |
   28 |
   29 |
   30 |
   31 |         def base64digest(*args, **options)
   32 |           @digest_algorithm.base64digest(*args, **options)
   33 |         end
   34 |
   35 |
   36 |           def base64digest(*args, **options)
   37 |             @digest_algorithm.base64digest(*args, **options) do |*yield_args|
   38 |               yield *yield_args
   39 |             end
   40 |           end
   41 |
   42 |
   43 |
   44 |
Warning: Deprecated OpenSSL::Digest#hexdigest. Use `final.hexstring` instead.

In /usr/local/Cellar/crystal/0.35.1_1/src/digest/base.cr:143:5

 143 | digest.hexstring
       ^-----
Warning: Deprecated OpenSSL::Digest#digest. Use `final` instead.

A total of 2 warnings were found.
```