### PR TITLE
Add implicit yield for tap and try

### DIFF
--- a/src/object.cr
+++ b/src/object.cr
@@ -184,7 +184,7 @@ class Object
   #   .map { |x| x*x }.tap { |x| puts "squares: #{x.inspect}" }
   # ```
   def tap
-    yield self
+    with self yield self
     self
   end
 
@@ -198,7 +198,7 @@ class Object
   # ARGV[0]?.try &.downcase
   # ```
   def try
-    yield self
+    with self yield self
   end
 
   # Returns `true` if `self` is included in the *collection* argument.


### PR DESCRIPTION
The point of this is  to enable using methods on some object implicitly within a `#tap` or `#try` block. This small but valuable (IMHO) change is inspired by Groovy, and would allow things like

```crystal
class MyException < Exception
  getter extra : Int32
  getter data : String
  def initialize(msg, @extra, @data)
    super msg
  end
end


begin
  raise MyException.new "test", 123, "error"
rescue error
  error.tap do
    STDERR.puts "received error #{message} with extra data #{extra} and #{data}
  end
end
```

instead of

```crystal
begin
  raise MyException.new "test", 123, "error"
rescue error
      STDERR.puts "received error #{error.message} with extra data #{error.extra} and #{error.data}
end
```

Since this change *both* sets the context *and* yields self to the block, it's mostly backwards compatible, and seems well worth adding to me, but I'm more than willing to hear dissenting opinions. The only major counter-argument I can see is against making a breaking change so close to 1.0.