### PR TITLE
Update-distribution scripts

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -172,7 +172,7 @@ jobs:
       - run: |
           git clone https://github.com/crystal-lang/distribution-scripts.git ~/distribution-scripts
           cd ~/distribution-scripts
-          git checkout 44172615fa196fb8592046582471fdfc8d69472c
+          git checkout e1704da2a215264ea8e101eb15d4ec1baae98222
       # persist relevant information for build process
       - run: |
           cd ~/distribution-scripts


### PR DESCRIPTION
This update will make linux tar.gz ship with llvm 10 and move docker images to focal

Ref: https://github.com/crystal-lang/distribution-scripts/pull/68
Maintenance build: https://app.circleci.com/pipelines/github/crystal-lang/crystal/4287/workflows/a9d9c79f-cd82-4a79-a97f-9790079075db