### PR TITLE
Remove Enumerable#grep

### DIFF
--- a/spec/std/enumerable_spec.cr
+++ b/spec/std/enumerable_spec.cr
@@ -503,16 +503,6 @@ describe "Enumerable" do
     end
   end
 
-  describe "grep" do
-    it "works with regexes for instance" do
-      ["Alice", "Bob", "Cipher", "Anna"].grep(/^A/).should eq ["Alice", "Anna"]
-    end
-
-    it "returns empty array if nothing matches" do
-      %w(Alice Bob Mallory).grep(/nothing/).should eq [] of String
-    end
-  end
-
   describe "group_by" do
     it { [1, 2, 2, 3].group_by { |x| x == 2 }.should eq({true => [2, 2], false => [1, 3]}) }
 

--- a/src/enumerable.cr
+++ b/src/enumerable.cr
@@ -535,17 +535,6 @@ module Enumerable(T)
     ary
   end
 
-  # Returns an `Array` with all the elements in the collection that
-  # match the `RegExp` *pattern*.
-  #
-  # ```
-  # ["Alice", "Bob"].grep(/^A/) # => ["Alice"]
-  # ```
-  @[Deprecated("Use `#select` instead")]
-  def grep(pattern)
-    self.select { |elem| pattern === elem }
-  end
-
   # Returns a `Hash` whose keys are each different value that the passed block
   # returned when run for each element in the collection, and which values are
   # an `Array` of the elements for which the block returned that value.


### PR DESCRIPTION
The commit deprecating `Enumerable#grep` https://github.com/crystal-lang/crystal/commit/7a86e8cf7557f632c63ee67f2965dc22a7453a18 date from 9 months, released in Crystal 0.32.0.