### PR TITLE
Fix `String#index` not working well for broken UTF-8 sequences

### DIFF
--- a/spec/std/char/reader_spec.cr
+++ b/spec/std/char/reader_spec.cr
@@ -1,10 +1,10 @@
 require "spec"
 require "char/reader"
 
-private def assert_invalid_byte_sequence(bytes, width)
+private def assert_invalid_byte_sequence(bytes)
   reader = Char::Reader.new(String.new bytes)
   reader.current_char.should eq(Char::REPLACEMENT)
-  reader.current_char_width.should eq(width)
+  reader.current_char_width.should eq(1)
   reader.error.should eq(bytes[0])
 end
 
@@ -130,51 +130,51 @@ describe "Char::Reader" do
   end
 
   it "errors if 0x80 <= first_byte < 0xC2" do
-    assert_invalid_byte_sequence Bytes[0x80], 1
-    assert_invalid_byte_sequence Bytes[0xC1], 1
+    assert_invalid_byte_sequence Bytes[0x80]
+    assert_invalid_byte_sequence Bytes[0xC1]
   end
 
   it "errors if (second_byte & 0xC0) != 0x80" do
-    assert_invalid_byte_sequence Bytes[0xd0], 1
+    assert_invalid_byte_sequence Bytes[0xd0]
   end
 
   it "errors if first_byte == 0xE0 && second_byte < 0xA0" do
-    assert_invalid_byte_sequence Bytes[0xe0, 0x9F, 0xA0], 3
+    assert_invalid_byte_sequence Bytes[0xe0, 0x9F, 0xA0]
   end
 
   it "errors if first_byte == 0xED && second_byte >= 0xA0" do
-    assert_invalid_byte_sequence Bytes[0xed, 0xB0, 0xA0], 3
+    assert_invalid_byte_sequence Bytes[0xed, 0xB0, 0xA0]
   end
 
   it "errors if first_byte < 0xF0 && (third_byte & 0xC0) != 0x80" do
-    assert_invalid_byte_sequence Bytes[0xe0, 0xA0, 0], 2
+    assert_invalid_byte_sequence Bytes[0xe0, 0xA0, 0]
   end
 
   it "errors if first_byte == 0xF0 && second_byte < 0x90" do
-    assert_invalid_byte_sequence Bytes[0xf0, 0x8F, 0xA0], 3
+    assert_invalid_byte_sequence Bytes[0xf0, 0x8F, 0xA0]
   end
 
   it "errors if first_byte == 0xF4 && second_byte >= 0x90" do
-    assert_invalid_byte_sequence Bytes[0xf4, 0x90, 0xA0], 3
+    assert_invalid_byte_sequence Bytes[0xf4, 0x90, 0xA0]
   end
 
   it "errors if first_byte < 0xF5 && (fourth_byte & 0xC0) != 0x80" do
-    assert_invalid_byte_sequence Bytes[0xf4, 0x8F, 0xA0, 0], 4
+    assert_invalid_byte_sequence Bytes[0xf4, 0x8F, 0xA0, 0]
   end
 
   it "errors if first_byte >= 0xF5" do
-    assert_invalid_byte_sequence Bytes[0xf5, 0x8F, 0xA0, 0xA0], 4
+    assert_invalid_byte_sequence Bytes[0xf5, 0x8F, 0xA0, 0xA0]
   end
 
   it "errors if second_byte is out of bounds" do
-    assert_invalid_byte_sequence Bytes[0xf4], 1
+    assert_invalid_byte_sequence Bytes[0xf4]
   end
 
   it "errors if third_byte is out of bounds" do
-    assert_invalid_byte_sequence Bytes[0xf4, 0x8f], 2
+    assert_invalid_byte_sequence Bytes[0xf4, 0x8f]
   end
 
   it "errors if fourth_byte is out of bounds" do
-    assert_invalid_byte_sequence Bytes[0xf4, 0x8f, 0xa0], 3
+    assert_invalid_byte_sequence Bytes[0xf4, 0x8f, 0xa0]
   end
 end

--- a/spec/std/string/utf16_spec.cr
+++ b/spec/std/string/utf16_spec.cr
@@ -28,7 +28,7 @@ describe "String UTF16" do
 
     it "in the range U+D800..U+DFFF" do
       encoded = "\u{D800}\u{DFFF}".to_utf16
-      encoded.should eq(Slice[0xFFFD_u16, 0xFFFD_u16])
+      encoded.should eq(Slice[0xFFFD_u16, 0xFFFD_u16, 0xFFFD_u16, 0xFFFD_u16, 0xFFFD_u16, 0xFFFD_u16])
       encoded.unsafe_fetch(encoded.size).should eq 0_u16
     end
   end

--- a/spec/std/string_spec.cr
+++ b/spec/std/string_spec.cr
@@ -831,6 +831,7 @@ describe "String" do
       it { "foo".index("").should eq(0) }
       it { "foo".index("foo").should eq(0) }
       it { "日本語日本語".index("本語").should eq(1) }
+      it { "\xFF\xFFcrystal".index("crystal").should eq(2) }
 
       describe "with offset" do
         it { "foobarbaz".index("ba", 4).should eq(6) }

--- a/spec/std/string_spec.cr
+++ b/spec/std/string_spec.cr
@@ -1976,25 +1976,31 @@ describe "String" do
     end
   end
 
-  it "answers ascii_only?" do
-    "a".ascii_only?.should be_true
-    "あ".ascii_only?.should be_false
+  describe "ascii_only?" do
+    it "answers ascii_only?" do
+      "a".ascii_only?.should be_true
+      "あ".ascii_only?.should be_false
 
-    str = String.new(1) do |buffer|
-      buffer.value = 'a'.ord.to_u8
-      {1, 0}
-    end
-    str.ascii_only?.should be_true
-
-    str = String.new(4) do |buffer|
-      count = 0
-      'あ'.each_byte do |byte|
-        buffer[count] = byte
-        count += 1
+      str = String.new(1) do |buffer|
+        buffer.value = 'a'.ord.to_u8
+        {1, 0}
       end
-      {count, 0}
+      str.ascii_only?.should be_true
+
+      str = String.new(4) do |buffer|
+        count = 0
+        'あ'.each_byte do |byte|
+          buffer[count] = byte
+          count += 1
+        end
+        {count, 0}
+      end
+      str.ascii_only?.should be_false
     end
-    str.ascii_only?.should be_false
+
+    it "broken UTF-8 is not ascii_only" do
+      "\xED\xA0\x80\xED\xBF\xBF".ascii_only?.should be_false
+    end
   end
 
   describe "scan" do

--- a/spec/std/string_spec.cr
+++ b/spec/std/string_spec.cr
@@ -832,6 +832,7 @@ describe "String" do
       it { "foo".index("foo").should eq(0) }
       it { "日本語日本語".index("本語").should eq(1) }
       it { "\xFF\xFFcrystal".index("crystal").should eq(2) }
+      it { "\xFD\x9A\xAD\x50NG".index("PNG").should eq(3) }
 
       describe "with offset" do
         it { "foobarbaz".index("ba", 4).should eq(6) }
@@ -2696,9 +2697,9 @@ describe "String" do
 
     it "scrubs" do
       string = String.new(Bytes[255, 129, 97, 255, 97])
-      string.scrub.bytes.should eq([239, 191, 189, 97, 239, 191, 189, 97])
+      string.scrub.bytes.should eq([239, 191, 189, 239, 191, 189, 97, 239, 191, 189, 97])
 
-      string.scrub("?").should eq("?a?a")
+      string.scrub("?").should eq("??a?a")
 
       "hello".scrub.should eq("hello")
     end

--- a/spec/std/string_spec.cr
+++ b/spec/std/string_spec.cr
@@ -842,6 +842,8 @@ describe "String" do
         it { "foo".index("", 3).should eq(3) }
         it { "foo".index("", 4).should be_nil }
         it { "日本語日本語".index("本語", 2).should eq(4) }
+        it { "\xFD\x9A\xAD\x50NG".index("PNG", 2).should eq(3) }
+        it { "\xFD\x9A\xAD\x50NG".index("PNG", 4).should be_nil }
       end
     end
 

--- a/spec/std/string_spec.cr
+++ b/spec/std/string_spec.cr
@@ -699,6 +699,7 @@ describe "String" do
 
   describe "rchop?" do
     it { "".rchop?.should be_nil }
+    it { "\n".rchop?.should eq("") }
     it { "foo".rchop?.should eq("fo") }
     it { "foo\n".rchop?.should eq("foo") }
     it { "foo\r".rchop?.should eq("foo") }

--- a/spec/std/string_spec.cr
+++ b/spec/std/string_spec.cr
@@ -931,57 +931,57 @@ describe "String" do
 
   describe "partition" do
     describe "by char" do
-      "hello".partition('h').should eq ({"", "h", "ello"})
-      "hello".partition('o').should eq ({"hell", "o", ""})
-      "hello".partition('l').should eq ({"he", "l", "lo"})
-      "hello".partition('x').should eq ({"hello", "", ""})
+      it { "hello".partition('h').should eq ({"", "h", "ello"}) }
+      it { "hello".partition('o').should eq ({"hell", "o", ""}) }
+      it { "hello".partition('l').should eq ({"he", "l", "lo"}) }
+      it { "hello".partition('x').should eq ({"hello", "", ""}) }
     end
 
     describe "by string" do
-      "hello".partition("h").should eq ({"", "h", "ello"})
-      "hello".partition("o").should eq ({"hell", "o", ""})
-      "hello".partition("l").should eq ({"he", "l", "lo"})
-      "hello".partition("ll").should eq ({"he", "ll", "o"})
-      "hello".partition("x").should eq ({"hello", "", ""})
+      it { "hello".partition("h").should eq ({"", "h", "ello"}) }
+      it { "hello".partition("o").should eq ({"hell", "o", ""}) }
+      it { "hello".partition("l").should eq ({"he", "l", "lo"}) }
+      it { "hello".partition("ll").should eq ({"he", "ll", "o"}) }
+      it { "hello".partition("x").should eq ({"hello", "", ""}) }
     end
 
     describe "by regex" do
-      "hello".partition(/h/).should eq ({"", "h", "ello"})
-      "hello".partition(/o/).should eq ({"hell", "o", ""})
-      "hello".partition(/l/).should eq ({"he", "l", "lo"})
-      "hello".partition(/ll/).should eq ({"he", "ll", "o"})
-      "hello".partition(/.l/).should eq ({"h", "el", "lo"})
-      "hello".partition(/.h/).should eq ({"hello", "", ""})
-      "hello".partition(/h./).should eq ({"", "he", "llo"})
-      "hello".partition(/o./).should eq ({"hello", "", ""})
-      "hello".partition(/.o/).should eq ({"hel", "lo", ""})
-      "hello".partition(/x/).should eq ({"hello", "", ""})
+      it { "hello".partition(/h/).should eq ({"", "h", "ello"}) }
+      it { "hello".partition(/o/).should eq ({"hell", "o", ""}) }
+      it { "hello".partition(/l/).should eq ({"he", "l", "lo"}) }
+      it { "hello".partition(/ll/).should eq ({"he", "ll", "o"}) }
+      it { "hello".partition(/.l/).should eq ({"h", "el", "lo"}) }
+      it { "hello".partition(/.h/).should eq ({"hello", "", ""}) }
+      it { "hello".partition(/h./).should eq ({"", "he", "llo"}) }
+      it { "hello".partition(/o./).should eq ({"hello", "", ""}) }
+      it { "hello".partition(/.o/).should eq ({"hel", "lo", ""}) }
+      it { "hello".partition(/x/).should eq ({"hello", "", ""}) }
     end
   end
 
   describe "rpartition" do
     describe "by char" do
-      "hello".rpartition('l').should eq ({"hel", "l", "o"})
-      "hello".rpartition('o').should eq ({"hell", "o", ""})
-      "hello".rpartition('h').should eq ({"", "h", "ello"})
+      it { "hello".rpartition('l').should eq ({"hel", "l", "o"}) }
+      it { "hello".rpartition('o').should eq ({"hell", "o", ""}) }
+      it { "hello".rpartition('h').should eq ({"", "h", "ello"}) }
     end
 
     describe "by string" do
-      "hello".rpartition("l").should eq ({"hel", "l", "o"})
-      "hello".rpartition("x").should eq ({"", "", "hello"})
-      "hello".rpartition("o").should eq ({"hell", "o", ""})
-      "hello".rpartition("h").should eq ({"", "h", "ello"})
-      "hello".rpartition("ll").should eq ({"he", "ll", "o"})
-      "hello".rpartition("lo").should eq ({"hel", "lo", ""})
-      "hello".rpartition("he").should eq ({"", "he", "llo"})
+      it { "hello".rpartition("l").should eq ({"hel", "l", "o"}) }
+      it { "hello".rpartition("x").should eq ({"", "", "hello"}) }
+      it { "hello".rpartition("o").should eq ({"hell", "o", ""}) }
+      it { "hello".rpartition("h").should eq ({"", "h", "ello"}) }
+      it { "hello".rpartition("ll").should eq ({"he", "ll", "o"}) }
+      it { "hello".rpartition("lo").should eq ({"hel", "lo", ""}) }
+      it { "hello".rpartition("he").should eq ({"", "he", "llo"}) }
     end
 
     describe "by regex" do
-      "hello".rpartition(/.l/).should eq ({"he", "ll", "o"})
-      "hello".rpartition(/ll/).should eq ({"he", "ll", "o"})
-      "hello".rpartition(/.o/).should eq ({"hel", "lo", ""})
-      "hello".rpartition(/.e/).should eq ({"", "he", "llo"})
-      "hello".rpartition(/l./).should eq ({"hel", "lo", ""})
+      it { "hello".rpartition(/.l/).should eq ({"he", "ll", "o"}) }
+      it { "hello".rpartition(/ll/).should eq ({"he", "ll", "o"}) }
+      it { "hello".rpartition(/.o/).should eq ({"hel", "lo", ""}) }
+      it { "hello".rpartition(/.e/).should eq ({"", "he", "llo"}) }
+      it { "hello".rpartition(/l./).should eq ({"hel", "lo", ""}) }
     end
   end
 

--- a/src/char/reader.cr
+++ b/src/char/reader.cr
@@ -191,12 +191,12 @@ struct Char
       end
 
       if first < 0xc2
-        invalid_byte_sequence 1
+        invalid_byte_sequence
       end
 
       second = byte_at?(pos + 1)
       if second.nil? || (second & 0xc0) != 0x80
-        invalid_byte_sequence 1
+        invalid_byte_sequence
       end
 
       if first < 0xe0
@@ -205,45 +205,45 @@ struct Char
 
       third = byte_at?(pos + 2)
       if third.nil? || (third & 0xc0) != 0x80
-        invalid_byte_sequence 2
+        invalid_byte_sequence
       end
 
       if first < 0xf0
         if first == 0xe0 && second < 0xa0
-          invalid_byte_sequence 3
+          invalid_byte_sequence
         end
 
         if first == 0xed && second >= 0xa0
-          invalid_byte_sequence 3
+          invalid_byte_sequence
         end
 
         return yield (first << 12) &+ (second << 6) &+ (third &- 0xE2080), 3, nil
       end
 
       if first == 0xf0 && second < 0x90
-        invalid_byte_sequence 3
+        invalid_byte_sequence
       end
 
       if first == 0xf4 && second >= 0x90
-        invalid_byte_sequence 3
+        invalid_byte_sequence
       end
 
       fourth = byte_at?(pos + 3)
       if fourth.nil?
-        invalid_byte_sequence 3
+        invalid_byte_sequence
       elsif (fourth & 0xc0) != 0x80
-        invalid_byte_sequence 4
+        invalid_byte_sequence
       end
 
       if first < 0xf5
         return yield (first << 18) &+ (second << 12) &+ (third << 6) &+ (fourth &- 0x3C82080), 4, nil
       end
 
-      invalid_byte_sequence 4
+      invalid_byte_sequence
     end
 
-    private macro invalid_byte_sequence(width)
-      return yield Char::REPLACEMENT.ord, {{width}}, first.to_u8
+    private macro invalid_byte_sequence
+      return yield Char::REPLACEMENT.ord, 1, first.to_u8
     end
 
     @[AlwaysInline]

--- a/src/char/reader.cr
+++ b/src/char/reader.cr
@@ -185,7 +185,7 @@ struct Char
     end
 
     private def decode_char_at(pos)
-      first = byte_at?(pos) || 0u32
+      first = byte_at(pos)
       if first < 0x80
         return yield first, 1, nil
       end
@@ -194,8 +194,8 @@ struct Char
         invalid_byte_sequence
       end
 
-      second = byte_at?(pos + 1)
-      if second.nil? || (second & 0xc0) != 0x80
+      second = byte_at(pos + 1)
+      if (second & 0xc0) != 0x80
         invalid_byte_sequence
       end
 
@@ -203,8 +203,8 @@ struct Char
         return yield (first << 6) &+ (second &- 0x3080), 2, nil
       end
 
-      third = byte_at?(pos + 2)
-      if third.nil? || (third & 0xc0) != 0x80
+      third = byte_at(pos + 2)
+      if (third & 0xc0) != 0x80
         invalid_byte_sequence
       end
 
@@ -228,10 +228,8 @@ struct Char
         invalid_byte_sequence
       end
 
-      fourth = byte_at?(pos + 3)
-      if fourth.nil?
-        invalid_byte_sequence
-      elsif (fourth & 0xc0) != 0x80
+      fourth = byte_at(pos + 3)
+      if (fourth & 0xc0) != 0x80
         invalid_byte_sequence
       end
 
@@ -274,11 +272,7 @@ struct Char
     end
 
     private def byte_at(i)
-      @string.byte_at(i).to_u32
-    end
-
-    private def byte_at?(i)
-      @string.byte_at?(i).try(&.to_u32)
+      @string.to_unsafe[i].to_u32
     end
   end
 end

--- a/src/path.cr
+++ b/src/path.cr
@@ -828,7 +828,7 @@ struct Path
       # Copy the part
       buffer.copy_from(part_ptr, part_bytesize)
 
-      {bytesize, @name.ascii_only? && part.ascii_only? ? bytesize : 0}
+      {bytesize, @name.single_byte_optimizable? && part.single_byte_optimizable? ? bytesize : 0}
     end
 
     new_instance new_name

--- a/src/string.cr
+++ b/src/string.cr
@@ -1516,7 +1516,7 @@ class String
   # "".rchop?           # => nil
   # ```
   def rchop? : String?
-    return if bytesize <= 1
+    return if empty?
 
     if to_unsafe[bytesize - 1] < 128 || ascii_only?
       return unsafe_byte_slice_string(0, bytesize - 1)

--- a/src/string.cr
+++ b/src/string.cr
@@ -3030,7 +3030,7 @@ class String
     pointer = to_unsafe
     end_pointer = pointer + bytesize
     while char_index < offset && pointer < end_pointer
-      char_bytesize = String.char_bytesize_at(to_slice + (pointer - to_unsafe))
+      char_bytesize = String.char_bytesize_at(pointer)
       pointer += char_bytesize
       char_index += 1
     end
@@ -3055,7 +3055,7 @@ class String
       return if pointer >= end_pointer
 
       byte = head_pointer.value
-      char_bytesize = String.char_bytesize_at(to_slice + (head_pointer - to_unsafe))
+      char_bytesize = String.char_bytesize_at(head_pointer)
       case char_bytesize
       when 1 then update_hash 1
       when 2 then update_hash 2
@@ -4858,11 +4858,11 @@ class String
   end
 
   protected def char_bytesize_at(byte_index)
-    String.char_bytesize_at(to_slice + byte_index)
+    String.char_bytesize_at(to_unsafe + byte_index)
   end
 
-  protected def self.char_bytesize_at(bytes : Bytes)
-    first = bytes[0]
+  protected def self.char_bytesize_at(bytes : Pointer(UInt8))
+    first = bytes.value
 
     if first < 0x80
       return 1
@@ -4872,10 +4872,7 @@ class String
       return 1 # Invalid
     end
 
-    second = bytes[1]?
-    unless second
-      return 1 # Invalid
-    end
+    second = bytes[1]
 
     if (second & 0xc0) != 0x80
       return 1 # Invalid
@@ -4885,10 +4882,7 @@ class String
       return 2
     end
 
-    third = bytes[2]?
-    unless third
-      return 1 # Invalid
-    end
+    third = bytes[2]
 
     if (third & 0xc0) != 0x80
       return 1 # Invalid
@@ -4914,10 +4908,7 @@ class String
       return 1 # Invalid
     end
 
-    fourth = bytes[3]?
-    unless fourth
-      return 1 # Invalid
-    end
+    fourth = bytes[3]
 
     if (fourth & 0xc0) != 0x80
       return 1 # Invalid

--- a/src/string.cr
+++ b/src/string.cr
@@ -4857,48 +4857,65 @@ class String
     end
 
     if first < 0xc2
-      return 1
+      return 1 # Invalid
     end
 
-    if bytes.size < 2
-      return 1
+    second = bytes[1]?
+    unless second
+      return 1 # Invalid
     end
 
-    second = bytes[1]
     if (second & 0xc0) != 0x80
-      return 1
+      return 1 # Invalid
     end
 
     if first < 0xe0
       return 2
     end
 
-    if bytes.size < 3
-      return 2
+    third = bytes[2]?
+    unless third
+      return 1 # Invalid
     end
 
-    third = bytes[2]
     if (third & 0xc0) != 0x80
-      return 2
+      return 1 # Invalid
     end
 
     if first < 0xf0
+      if first == 0xe0 && second < 0xa0
+        return 1 # Invalid
+      end
+
+      if first == 0xed && second >= 0xa0
+        return 1 # Invalid
+      end
+
       return 3
     end
 
     if first == 0xf0 && second < 0x90
-      return 3
+      return 1 # Invalid
     end
 
     if first == 0xf4 && second >= 0x90
-      return 3
+      return 1 # Invalid
     end
 
-    if bytes.size < 4
-      return 3
+    fourth = bytes[3]?
+    unless fourth
+      return 1 # Invalid
     end
 
-    return 4
+    if (fourth & 0xc0) != 0x80
+      return 1 # Invalid
+    end
+
+    if first < 0xf5
+      return 4
+    end
+
+    1 # Invalid
   end
 
   # :nodoc:

--- a/src/string.cr
+++ b/src/string.cr
@@ -4807,7 +4807,14 @@ class String
   # "你好".ascii_only?    # => false
   # ```
   def ascii_only?
-    @bytesize == size
+    if @bytesize == size
+      each_byte do |byte|
+        return false unless byte < 0x80
+      end
+      true
+    else
+      false
+    end
   end
 
   # Returns `true` if this String is encoded correctly


### PR DESCRIPTION
Fixes #8785 (and #9712)

Additionally, this changes the behavior of `Char::Reader` when consuming invalid byte sequences: instead of advancing as much as possible (as much as valid bytes could be consumed before detecting the invalid byte) we now always advance one byte. I think this makes more sense because if the sequence is broken then we should just skip one byte and try consuming beginning from the second one and so on.

I checked and this is similar to what Ruby does. So now `scrub` and other methods, including `index` and `includes?` behave exactly like in Ruby.

I didn't check what the performance is with these changes but right now I care more about correct code. Optimizations can come later.

Update: it turns out that by doing the change above the implementation of `ascii_only?` can't be just comparing the string's bytesize to its size because for a string that only has broken utf-8 chars it would be `true`. So I introduced a hidden `single_byte_optimizable?` for the old answer and use that in some algorithms for some optimizations.