### PR TITLE
Compiler: don't form a closure on `typeof(@ivar)`

### DIFF
--- a/spec/compiler/semantic/closure_spec.cr
+++ b/spec/compiler/semantic/closure_spec.cr
@@ -524,4 +524,29 @@ describe "Semantic: closure" do
       ),
       "can't send closure to C function (closured vars: x)"
   end
+
+  it "doesn't closure typeof local var" do
+    result = assert_type("x = 1; -> { typeof(x) }; x") { int32 }
+    program = result.program
+    var = program.vars["x"]
+    var.closured?.should be_false
+  end
+
+  it "doesn't closure typeof instance var (#9479)" do
+    result = assert_type("
+      class Foo
+        @x : Int32?
+
+        def foo
+          -> { typeof(@x) }
+        end
+      end
+
+      Foo.new.foo
+      1
+    ") { int32 }
+    node = result.node.as(Expressions)
+    call = node.expressions[-2].as(Call)
+    call.target_def.self_closured?.should be_false
+  end
 end

--- a/src/compiler/crystal/semantic/main_visitor.cr
+++ b/src/compiler/crystal/semantic/main_visitor.cr
@@ -3212,6 +3212,8 @@ module Crystal
     end
 
     def check_self_closured
+      return if @typeof_nest > 0
+
       scope = @scope
       return unless scope
 


### PR DESCRIPTION
Fixes #9479