### PR TITLE
Encoding: remove unnecessary and wrong optimization

### DIFF
--- a/src/io/encoding.cr
+++ b/src/io/encoding.cr
@@ -80,14 +80,6 @@ class IO
           @in_buffer_left = LibC::SizeT.new(io.read(@buffer))
         end
 
-        # If we just have a few bytes to decode, read more, just in case these don't produce a character
-        if @in_buffer_left < 16
-          buffer_remaining = BUFFER_SIZE - @in_buffer_left - (@in_buffer - @buffer.to_unsafe)
-          @buffer.copy_from(@in_buffer, @in_buffer_left)
-          @in_buffer = @buffer.to_unsafe
-          @in_buffer_left += LibC::SizeT.new(io.read(Slice.new(@in_buffer + @in_buffer_left, buffer_remaining)))
-        end
-
         # If, after refilling the buffer, we couldn't read new bytes
         # it means we reached the end
         break if @in_buffer_left == 0


### PR DESCRIPTION
Fixes #9056

`IO::Decoder` had an optimization/code that I introduced a long time ago when we failed to get a complete char from the underlying IO. It turned out that later on that didn't work well and more code was added to handle those cases (the "Check for errors") section a bit below. And with that, the old code isn't necessary anymore. Not only that, but it's also wrong.

All specs pass with this change, and #9056 starts working.