### PR TITLE
HTTP::Server: don't override content-lenght if already set

### DIFF
--- a/spec/std/http/server/response_spec.cr
+++ b/spec/std/http/server/response_spec.cr
@@ -91,6 +91,14 @@ describe HTTP::Server::Response do
     io.to_s.should eq("HTTP/1.1 200 OK\r\nContent-Length: 10\r\n\r\n1234567890")
   end
 
+  it "doesn't override content-length when there's no body" do
+    io = IO::Memory.new
+    response = Response.new(io)
+    response.content_length = 10
+    response.close
+    io.to_s.should eq("HTTP/1.1 200 OK\r\nContent-Length: 10\r\n\r\n")
+  end
+
   it "adds header" do
     io = IO::Memory.new
     response = Response.new(io)

--- a/src/http/server/response.cr
+++ b/src/http/server/response.cr
@@ -223,7 +223,7 @@ class HTTP::Server
       def close
         return if closed?
 
-        unless response.wrote_headers?
+        if !response.wrote_headers? && !response.headers.has_key?("Content-Length")
           response.content_length = @out_count
         end
 


### PR DESCRIPTION
Maybe fixes #8834, but since we don't know what the actual code to trigger the bug is, we don't know.

In any case I think this is a good fix.