### PR TITLE
Initial nix development environment. Use Nix for OSX CI instead of homebrew.

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -3,10 +3,8 @@ name: macOS CI
 on: [push, pull_request]
 
 env:
-  TRAVIS_OS_NAME: osx
-  LLVM_CONFIG: /usr/local/opt/llvm/bin/llvm-config
-  PKG_CONFIG_PATH: /usr/local/opt/openssl@1.1/lib/pkgconfig
   SPEC_SPLIT_DOTS: 160
+  CI_NIX_SHELL: true
 
 jobs:
   test_macos:
@@ -14,6 +12,12 @@ jobs:
     steps:
       - name: Download Crystal source
         uses: actions/checkout@v2
+
+      - uses: cachix/install-nix-action@v10
+      - uses: cachix/cachix-action@v6
+        with:
+          name: crystal-ci
+          signingKey: '${{ secrets.CACHIX_SIGNING_KEY }}'
 
       - name: Prepare System
         run: bin/ci prepare_system

--- a/bin/ci
+++ b/bin/ci
@@ -46,12 +46,16 @@ on_os() {
   os="$1"
   shift
 
-  verify_environment
+  if [ -z "$CI_NIX_SHELL" ]; then
+    verify_environment
 
-  if [ "$TRAVIS_OS_NAME" = "$os" ]; then
-    echo "${@}"
-    eval "${@}"
-    return $?
+    if [ "$TRAVIS_OS_NAME" = "$os" ]; then
+      echo "${@}"
+      eval "${@}"
+      return $?
+    else
+      return 0
+    fi
   else
     return 0
   fi
@@ -63,6 +67,16 @@ on_linux() {
 
 on_osx() {
   fail_on_error on_os "osx" "${@}"
+}
+
+on_nix_shell() {
+  if [ -n "$CI_NIX_SHELL" ]; then
+    echo "${@}"
+    eval "${@}"
+    return $?
+  else
+    return 0
+  fi
 }
 
 on_github() {
@@ -181,6 +195,8 @@ with_build_env() {
     CRYSTAL_LIBRARY_PATH="~/crystal/embedded/lib" \
     CRYSTAL_CACHE_DIR="/tmp/crystal" \
     /bin/sh -c "'$command'"
+
+  on_nix_shell nix-shell --pure $CI_NIX_SHELL_ARGS --run "'TZ=$TZ $command'"
 
   on_github echo "::endgroup::"
 }

--- a/shell.nix
+++ b/shell.nix
@@ -1,0 +1,126 @@
+# This nix-shell script can be used to get a complette development environment
+# for the Crystal compiler.
+#
+# You can choose which llvm version use and, on Linux, choose to use musl.
+#
+# $ nix-shell --pure
+# $ nix-shell --pure --arg llvm 10
+# $ nix-shell --pure --arg llvm 10 --arg musl true
+# $ nix-shell --pure --arg llvm 9
+# ...
+# $ nix-shell --pure --arg llvm 6
+#
+# If needed, you can use https://app.cachix.org/cache/crystal-ci to avoid building
+# packages that are not available in Nix directly. This is only useful for musl so far.
+#
+# $ nix-env -iA cachix -f https://cachix.org/api/v1/install
+# $ cachix use crystal-ci
+# $ nix-shell --pure --arg musl true
+#
+# Known issue: musl does not work yet.
+#   .../lib/libgc.a(pthread_support.o): in function `GC_thr_init':
+#   pthread_support.c:(.text+0x1137): undefined reference to `gnu_get_libc_version'
+#   .../lib/libgc.a(mach_dep.o): in function `GC_with_callee_saves_pushed':
+#   mach_dep.c:(.text+0x35): undefined reference to `getcontext'
+#   .../lib/libgc.a(pthread_start.o): in function `GC_inner_start_routine':
+#   pthread_start.c:(.text+0x44): undefined reference to `__pthread_register_cancel'
+#   .../bin/ld: pthread_start.c:(.text+0x6b): undefined reference to `__pthread_unregister_cancel'
+
+{llvm ? 10, musl ? false}:
+
+let
+  nixpkgs = import (builtins.fetchTarball {
+    name = "nixpkgs-20.03";
+    url = "https://github.com/NixOS/nixpkgs/archive/2d580cd2793a7b5f4b8b6b88fb2ccec700ee1ae6.tar.gz";
+    sha256 = "1nbanzrir1y0yi2mv70h60sars9scwmm0hsxnify2ldpczir9n37";
+  }) {};
+
+  pkgs = if musl then nixpkgs.pkgsMusl else nixpkgs;
+
+  genericBinary = { url, sha256 }:
+    pkgs.stdenv.mkDerivation rec {
+      name = "crystal-binary";
+      src = builtins.fetchurl { inherit url sha256; };
+
+      # Extract only the compiler binary and the embedded GC
+      buildCommand = ''
+        mkdir -p $out/bin $out/lib $out/tmp
+        tar --strip-components=1 -C $out/tmp -xf ${src}
+
+        # Darwin packages use embedded/bin/crystal and embedded/lib/libgc.a
+        [ -f "$out/tmp/embedded/lib/libgc.a" ] && mv $out/tmp/embedded/lib/libgc.a $out/lib/
+        [ -f "$out/tmp/embedded/bin/crystal" ] && mv $out/tmp/embedded/bin/crystal $out/bin/
+
+        # Linux packages use lib/crystal/bin/crystal and lib/crystal/lib/libgc.a
+        [ -f "$out/tmp/lib/crystal/lib/libgc.a" ] && mv $out/tmp/lib/crystal/lib/libgc.a $out/lib/
+        [ -f "$out/tmp/lib/crystal/bin/crystal" ] && mv $out/tmp/lib/crystal/bin/crystal $out/bin/
+
+        rm -rf $out/tmp
+      '';
+    };
+
+  # Hashes obtained using `nix-prefetch-url --unpack <url>`
+  latestCrystalBinary = genericBinary ({
+    x86_64-darwin = {
+      url = "https://github.com/crystal-lang/crystal/releases/download/0.35.1/crystal-0.35.1-1-darwin-x86_64.tar.gz";
+      sha256 = "sha256:1dhs18riq8lyz82948f44ya1k6pp4fy7j9wkxzqsj3wha03gfxbx";
+    };
+
+    x86_64-linux = {
+      url = "https://github.com/crystal-lang/crystal/releases/download/0.35.1/crystal-0.35.1-1-linux-x86_64.tar.gz";
+      sha256 = "sha256:1ygp4gf0cl8cpa8sw974lsdrngldgkyym6ha3cq0fadkfdhd6gvc";
+    };
+
+    i686-linux = {
+      url = "https://github.com/crystal-lang/crystal/releases/download/0.35.1/crystal-0.35.1-1-linux-i686.tar.gz";
+      sha256 = "sha256:0nfgxjndfslyacicjy4303pvvqfg74v5fnpr4b10ss9rqakmlbgd";
+    };
+  }.${pkgs.stdenv.system});
+
+  pkgconfig = pkgs.pkgconfig;
+
+  llvm_suite = ({
+    llvm_10 = {
+      llvm = pkgs.llvm_10;
+      extra = [ pkgs.lld_10 pkgs.lldb_10 ];
+    };
+    llvm_9 = {
+      llvm = pkgs.llvm_9;
+      extra = [ ]; # lldb it fails to compile on Darwin
+    };
+    llvm_8 = {
+      llvm = pkgs.llvm_8;
+      extra = [ ]; # lldb it fails to compile on Darwin
+    };
+    llvm_7 = {
+      llvm = pkgs.llvm;
+      extra = [ pkgs.lldb ];
+    };
+    llvm_6 = {
+      llvm = pkgs.llvm_6;
+      extra = [ ]; # lldb it fails to compile on Darwin
+    };
+  }."llvm_${toString llvm}");
+
+  stdLibDeps = with pkgs; [
+      gmp libevent libiconv libxml2 libyaml openssl pcre zlib
+    ] ++ stdenv.lib.optionals stdenv.isDarwin [ libiconv ];
+
+  tools = [ pkgs.hostname llvm_suite.extra ];
+in
+
+pkgs.stdenv.mkDerivation rec {
+  name = "crystal-dev";
+
+  buildInputs = tools ++ stdLibDeps ++ [
+    latestCrystalBinary
+    pkgconfig
+    llvm_suite.llvm
+  ];
+
+  CRYSTAL_LIBRARY_PATH = "${latestCrystalBinary}/lib";
+  LLVM_CONFIG = "${llvm_suite.llvm}/bin/llvm-config";
+
+  # ld: warning: object file (.../src/ext/libcrystal.a(sigfault.o)) was built for newer OSX version (10.14) than being linked (10.12)
+  MACOSX_DEPLOYMENT_TARGET = "10.11";
+}

--- a/shell.nix
+++ b/shell.nix
@@ -7,6 +7,7 @@
 # $ nix-shell --pure --arg llvm 10
 # $ nix-shell --pure --arg llvm 10 --arg musl true
 # $ nix-shell --pure --arg llvm 9
+# $ nix-shell --pure --arg llvm 9 --argstr system i686-linux
 # ...
 # $ nix-shell --pure --arg llvm 6
 #
@@ -18,14 +19,16 @@
 # $ nix-shell --pure --arg musl true
 #
 
-{llvm ? 10, musl ? false}:
+{llvm ? 10, musl ? false, system ? builtins.currentSystem}:
 
 let
   nixpkgs = import (builtins.fetchTarball {
     name = "nixpkgs-20.03";
     url = "https://github.com/NixOS/nixpkgs/archive/2d580cd2793a7b5f4b8b6b88fb2ccec700ee1ae6.tar.gz";
     sha256 = "1nbanzrir1y0yi2mv70h60sars9scwmm0hsxnify2ldpczir9n37";
-  }) {};
+  }) {
+    inherit system;
+  };
 
   pkgs = if musl then nixpkgs.pkgsMusl else nixpkgs;
 

--- a/shell.nix
+++ b/shell.nix
@@ -17,14 +17,6 @@
 # $ cachix use crystal-ci
 # $ nix-shell --pure --arg musl true
 #
-# Known issue: musl does not work yet.
-#   .../lib/libgc.a(pthread_support.o): in function `GC_thr_init':
-#   pthread_support.c:(.text+0x1137): undefined reference to `gnu_get_libc_version'
-#   .../lib/libgc.a(mach_dep.o): in function `GC_with_callee_saves_pushed':
-#   mach_dep.c:(.text+0x35): undefined reference to `getcontext'
-#   .../lib/libgc.a(pthread_start.o): in function `GC_inner_start_routine':
-#   pthread_start.c:(.text+0x44): undefined reference to `__pthread_register_cancel'
-#   .../bin/ld: pthread_start.c:(.text+0x6b): undefined reference to `__pthread_unregister_cancel'
 
 {llvm ? 10, musl ? false}:
 
@@ -40,22 +32,17 @@ let
   genericBinary = { url, sha256 }:
     pkgs.stdenv.mkDerivation rec {
       name = "crystal-binary";
-      src = builtins.fetchurl { inherit url sha256; };
+      src = builtins.fetchTarball { inherit url sha256; };
 
-      # Extract only the compiler binary and the embedded GC
+      # Extract only the compiler binary
       buildCommand = ''
-        mkdir -p $out/bin $out/lib $out/tmp
-        tar --strip-components=1 -C $out/tmp -xf ${src}
+        mkdir -p $out/bin
 
-        # Darwin packages use embedded/bin/crystal and embedded/lib/libgc.a
-        [ -f "$out/tmp/embedded/lib/libgc.a" ] && mv $out/tmp/embedded/lib/libgc.a $out/lib/
-        [ -f "$out/tmp/embedded/bin/crystal" ] && mv $out/tmp/embedded/bin/crystal $out/bin/
+        # Darwin packages use embedded/bin/crystal
+        [ -f "${src}/embedded/bin/crystal" ] && cp ${src}/embedded/bin/crystal $out/bin/
 
-        # Linux packages use lib/crystal/bin/crystal and lib/crystal/lib/libgc.a
-        [ -f "$out/tmp/lib/crystal/lib/libgc.a" ] && mv $out/tmp/lib/crystal/lib/libgc.a $out/lib/
-        [ -f "$out/tmp/lib/crystal/bin/crystal" ] && mv $out/tmp/lib/crystal/bin/crystal $out/bin/
-
-        rm -rf $out/tmp
+        # Linux packages use lib/crystal/bin/crystal
+        [ -f "${src}/lib/crystal/bin/crystal" ] && cp ${src}/lib/crystal/bin/crystal $out/bin/
       '';
     };
 
@@ -63,12 +50,12 @@ let
   latestCrystalBinary = genericBinary ({
     x86_64-darwin = {
       url = "https://github.com/crystal-lang/crystal/releases/download/0.35.1/crystal-0.35.1-1-darwin-x86_64.tar.gz";
-      sha256 = "sha256:1dhs18riq8lyz82948f44ya1k6pp4fy7j9wkxzqsj3wha03gfxbx";
+      sha256 = "sha256:0gpn42xh372hw2bqfgxc9wibpbam8gn7gx3p1b8p9adydjg0zxfm";
     };
 
     x86_64-linux = {
       url = "https://github.com/crystal-lang/crystal/releases/download/0.35.1/crystal-0.35.1-1-linux-x86_64.tar.gz";
-      sha256 = "sha256:1ygp4gf0cl8cpa8sw974lsdrngldgkyym6ha3cq0fadkfdhd6gvc";
+      sha256 = "sha256:077pby4ylf0z831gg0hbiwxcq3g0yl0cdlybirgg8rv24a2sa7zh";
     };
 
     i686-linux = {
@@ -102,6 +89,15 @@ let
     };
   }."llvm_${toString llvm}");
 
+  boehmgc = pkgs.boehmgc.overrideAttrs (oldAttrs: rec {
+    patches = [
+      (pkgs.fetchpatch {
+        url = "https://raw.githubusercontent.com/crystal-lang/distribution-scripts/e942880dda3b100ff1143cce88b579bbec3f05b9/linux/files/feature-thread-stackbottom-upstream.patch";
+        sha256 = "784ade9fe1c2668db77a3c08cd195cd7701331bdf8c9d160038cfce099b77e37";
+      })
+    ];
+  });
+
   stdLibDeps = with pkgs; [
       gmp libevent libiconv libxml2 libyaml openssl pcre zlib
     ] ++ stdenv.lib.optionals stdenv.isDarwin [ libiconv ];
@@ -116,9 +112,9 @@ pkgs.stdenv.mkDerivation rec {
     latestCrystalBinary
     pkgconfig
     llvm_suite.llvm
+    boehmgc
   ];
 
-  CRYSTAL_LIBRARY_PATH = "${latestCrystalBinary}/lib";
   LLVM_CONFIG = "${llvm_suite.llvm}/bin/llvm-config";
 
   # ld: warning: object file (.../src/ext/libcrystal.a(sigfault.o)) was built for newer OSX version (10.14) than being linked (10.12)

--- a/shell.nix
+++ b/shell.nix
@@ -1,4 +1,4 @@
-# This nix-shell script can be used to get a complette development environment
+# This nix-shell script can be used to get a complete development environment
 # for the Crystal compiler.
 #
 # You can choose which llvm version use and, on Linux, choose to use musl.


### PR DESCRIPTION
This introduces a shell.nix file to be used with nix-shell to set up a complete development environment for Crystal.

This also changes the GitHub Darwin CI to use Nix instead of homebrew. This will allow more stable CI for PR and commits. Checking if things are fine with homebrew can be done in something decoupled of the CI of Crystal itself.

The shell.nix is working on Darwin and Linux 64 gnu bits already. The musl support in nix is not completely flawless it seems. And the support for 32 bits should not be far also. Yet, the shell.nix already has all the pieces there.

In the future, things could evolve a bit and we could stop needed docker -build images for the CI, or at least stop needing to create new images of every release. Yet there is value already to have [more stable Darwin builds](https://discourse.brew.sh/t/llvm-config-10-0-1-advertise-libxml2-tbd-as-system-libs/8593). 

Another bonus of using Nix is the abiliity to check against different llvm version easily.

Since this is the first non-trivial Nix file I am writing, I am probably doing something wrong. 
cc: `Crystal ∩ Nix` = { @manveru, @peterhoeg, @david50407, @KimBurgess, @Infinisil } in case any of you want to take a look.
