### PR TITLE
Complex: moving math methods to Math

### DIFF
--- a/spec/std/complex_spec.cr
+++ b/spec/std/complex_spec.cr
@@ -177,4 +177,29 @@ describe "Complex" do
     (Complex.new(1.125, 0.875).round(2)).should eq(Complex.new(1.13, 0.88))
     (Complex.new(1.125, 0.875).round(digits: 1)).should eq(Complex.new(1.1, 0.9))
   end
+
+  describe "Math" do
+    it "exp" do
+      Math.exp(Complex.new(1.15, -5.1)).should be_close(Complex.new(1.1937266270566773, 2.923901365414129), 1e-15)
+    end
+
+    it "log" do
+      Math.log(Complex.new(1.25, -4.7)).should eq(Complex.new(1.5817344087982312, -1.3108561866063686))
+    end
+
+    it "log2" do
+      Math.log2(Complex.new(-9.1, 3.2)).should eq(Complex.new(3.2699671225858946, +4.044523592551345))
+    end
+
+    it "log10" do
+      Math.log10(Complex.new(2.11, 1.21)).should eq(Complex.new(0.38602142355392594, +0.22612668967405536))
+    end
+
+    it "sqrt" do
+      Math.sqrt(Complex.new(1.32, 7.25)).should be_close(Complex.new(2.0843687106374236, 1.739135682425128), 1e-15)
+      Math.sqrt(Complex.new(7.11, -0.9)).should be_close(Complex.new(2.671772413453534, -0.1684275194002508), 1e-15)
+      Math.sqrt(Complex.new(-2.2, 6.22)).should be_close(Complex.new(1.4828360708935342, 2.0973323087062226), 1e-15)
+      Math.sqrt(Complex.new(-8.3, -1.11)).should be_close(Complex.new(0.1922159681400434, -2.8873771797962275), 1e-15)
+    end
+  end
 end

--- a/spec/std/complex_spec.cr
+++ b/spec/std/complex_spec.cr
@@ -91,31 +91,6 @@ describe "Complex" do
     Complex.new(1.5, -2.5).inv.should eq(Complex.new(0.17647058823529413, 0.29411764705882354))
   end
 
-  it "sqrt" do
-    Complex.new(1.32, 7.25).sqrt.should be_close(Complex.new(2.0843687106374236, 1.739135682425128), 1e-15)
-    Complex.new(7.11, -0.9).sqrt.should be_close(Complex.new(2.671772413453534, -0.1684275194002508), 1e-15)
-    Complex.new(-2.2, 6.22).sqrt.should be_close(Complex.new(1.4828360708935342, 2.0973323087062226), 1e-15)
-    Complex.new(-8.3, -1.11).sqrt.should be_close(Complex.new(0.1922159681400434, -2.8873771797962275), 1e-15)
-  end
-
-  it "exp" do
-    Complex.new(1.15, -5.1).exp.should be_close(Complex.new(1.1937266270566773, 2.923901365414129), 1e-15)
-  end
-
-  describe "logarithms" do
-    it "log" do
-      Complex.new(1.25, -4.7).log.should eq(Complex.new(1.5817344087982312, -1.3108561866063686))
-    end
-
-    it "log2" do
-      Complex.new(-9.1, 3.2).log2.should eq(Complex.new(3.2699671225858946, +4.044523592551345))
-    end
-
-    it "log10" do
-      Complex.new(2.11, 1.21).log10.should eq(Complex.new(0.38602142355392594, +0.22612668967405536))
-    end
-  end
-
   describe "+" do
     it "+ complex" do
       (+Complex.new(-5.43, -27.12)).should eq(Complex.new(-5.43, -27.12))

--- a/spec/std/math_spec.cr
+++ b/spec/std/math_spec.cr
@@ -1,5 +1,4 @@
 require "spec"
-require "complex"
 
 describe "Math" do
   describe "Mathematical constants" do
@@ -41,10 +40,6 @@ describe "Math" do
       Math.sqrt(5.2).should be_close(2.280350850198276, 1e-7)
       Math.sqrt(4_f32).should eq(2)
       Math.sqrt(4).should eq(2)
-      Math.sqrt(Complex.new(1.32, 7.25)).should be_close(Complex.new(2.0843687106374236, 1.739135682425128), 1e-15)
-      Math.sqrt(Complex.new(7.11, -0.9)).should be_close(Complex.new(2.671772413453534, -0.1684275194002508), 1e-15)
-      Math.sqrt(Complex.new(-2.2, 6.22)).should be_close(Complex.new(1.4828360708935342, 2.0973323087062226), 1e-15)
-      Math.sqrt(Complex.new(-8.3, -1.11)).should be_close(Complex.new(0.1922159681400434, -2.8873771797962275), 1e-15)
     end
   end
 
@@ -52,7 +47,6 @@ describe "Math" do
     it "exp" do
       Math.exp(0.211_f32).should be_close(1.2349123550613943, 1e-7)
       Math.exp(0.211).should be_close(1.2349123550613943, 1e-7)
-      Math.exp(Complex.new(1.15, -5.1)).should be_close(Complex.new(1.1937266270566773, 2.923901365414129), 1e-15)
     end
 
     it "exp2" do
@@ -102,19 +96,16 @@ describe "Math" do
       Math.log(3.24).should be_close(1.1755733298042381, 1e-7)
       Math.log(0.3_f32, 3).should be_close(-1.0959032742893848, 1e-7)
       Math.log(0.3, 3).should be_close(-1.0959032742893848, 1e-7)
-      Math.log(Complex.new(1.25, -4.7)).should eq(Complex.new(1.5817344087982312, -1.3108561866063686))
     end
 
     it "log2" do
       Math.log2(1.2_f32).should be_close(0.2630344058337938, 1e-7)
       Math.log2(1.2).should be_close(0.2630344058337938, 1e-7)
-      Math.log2(Complex.new(-9.1, 3.2)).should eq(Complex.new(3.2699671225858946, +4.044523592551345))
     end
 
     it "log10" do
       Math.log10(0.5_f32).should be_close(-0.3010299956639812, 1e-7)
       Math.log10(0.5).should be_close(-0.3010299956639812, 1e-7)
-      Math.log10(Complex.new(2.11, 1.21)).should eq(Complex.new(0.38602142355392594, +0.22612668967405536))
     end
 
     it "log1p" do

--- a/spec/std/math_spec.cr
+++ b/spec/std/math_spec.cr
@@ -1,4 +1,5 @@
 require "spec"
+require "complex"
 
 describe "Math" do
   describe "Mathematical constants" do
@@ -40,6 +41,10 @@ describe "Math" do
       Math.sqrt(5.2).should be_close(2.280350850198276, 1e-7)
       Math.sqrt(4_f32).should eq(2)
       Math.sqrt(4).should eq(2)
+      Math.sqrt(Complex.new(1.32, 7.25)).should be_close(Complex.new(2.0843687106374236, 1.739135682425128), 1e-15)
+      Math.sqrt(Complex.new(7.11, -0.9)).should be_close(Complex.new(2.671772413453534, -0.1684275194002508), 1e-15)
+      Math.sqrt(Complex.new(-2.2, 6.22)).should be_close(Complex.new(1.4828360708935342, 2.0973323087062226), 1e-15)
+      Math.sqrt(Complex.new(-8.3, -1.11)).should be_close(Complex.new(0.1922159681400434, -2.8873771797962275), 1e-15)
     end
   end
 
@@ -47,6 +52,7 @@ describe "Math" do
     it "exp" do
       Math.exp(0.211_f32).should be_close(1.2349123550613943, 1e-7)
       Math.exp(0.211).should be_close(1.2349123550613943, 1e-7)
+      Math.exp(Complex.new(1.15, -5.1)).should be_close(Complex.new(1.1937266270566773, 2.923901365414129), 1e-15)
     end
 
     it "exp2" do
@@ -96,16 +102,19 @@ describe "Math" do
       Math.log(3.24).should be_close(1.1755733298042381, 1e-7)
       Math.log(0.3_f32, 3).should be_close(-1.0959032742893848, 1e-7)
       Math.log(0.3, 3).should be_close(-1.0959032742893848, 1e-7)
+      Math.log(Complex.new(1.25, -4.7)).should eq(Complex.new(1.5817344087982312, -1.3108561866063686))
     end
 
     it "log2" do
       Math.log2(1.2_f32).should be_close(0.2630344058337938, 1e-7)
       Math.log2(1.2).should be_close(0.2630344058337938, 1e-7)
+      Math.log2(Complex.new(-9.1, 3.2)).should eq(Complex.new(3.2699671225858946, +4.044523592551345))
     end
 
     it "log10" do
       Math.log10(0.5_f32).should be_close(-0.3010299956639812, 1e-7)
       Math.log10(0.5).should be_close(-0.3010299956639812, 1e-7)
+      Math.log10(Complex.new(2.11, 1.21)).should eq(Complex.new(0.38602142355392594, +0.22612668967405536))
     end
 
     it "log1p" do

--- a/src/complex.cr
+++ b/src/complex.cr
@@ -177,54 +177,6 @@ struct Complex
     conj / abs2
   end
 
-  # `Complex#sqrt` was inspired by the [following blog post](https://pavpanchekha.com/casio/)
-  # of Pavel Panchekha on floating point precision.
-  #
-  def sqrt
-    r = abs
-
-    re = if @real >= 0
-           0.5 * Math.sqrt(2.0 * (r + @real))
-         else
-           @imag.abs / Math.sqrt(2 * (r - @real))
-         end
-
-    im = if @real <= 0
-           0.5 * Math.sqrt(2.0 * (r - @real))
-         else
-           @imag.abs / Math.sqrt(2 * (r + @real))
-         end
-
-    Complex.new(re, @imag >= 0 ? im : -im)
-  end
-
-  # Calculates the exp of `self`.
-  #
-  # ```
-  # require "complex"
-  #
-  # Complex.new(4, 2).exp # => -22.720847417619233 + 49.645957334580565i
-  # ```
-  def exp
-    r = Math.exp(@real)
-    Complex.new(r * Math.cos(@imag), r * Math.sin(@imag))
-  end
-
-  # Calculates the log of `self`.
-  def log
-    Complex.new(Math.log(abs), phase)
-  end
-
-  # Calculates the log2 of `self`.
-  def log2
-    log / Math::LOG2
-  end
-
-  # Calculates the log10 of `self`.
-  def log10
-    log / Math::LOG10
-  end
-
   # Returns `self`.
   def +
     self
@@ -340,5 +292,88 @@ struct Number
 
   def /(other : Complex)
     self * other.inv
+  end
+end
+
+module Math
+  # Calculates the exponential of the complex number `z`.
+  #
+  # ```
+  # require "complex"
+  #
+  # Math.exp(4 + 2.i) # => -22.720847417619233 + 49.645957334580565i
+  # ```
+  def exp(z : Complex)
+    r = exp(z.real)
+    Complex.new(r * cos(z.imag), r * sin(z.imag))
+  end
+  
+  # Calculates the natural logarithm of the complex number `z`.
+  #
+  # ```
+  # require "complex"
+  #
+  # Math.log(4 + 2.i) # => 1.4978661367769956 + 0.4636476090008061i
+  # ```
+  def log(z : Complex)
+    Complex.new(Math.log(z.abs), z.phase)
+  end
+
+  # Calculates the base-2 logarithm of the complex number `z`.
+  #
+  # ```
+  # require "complex"
+  #
+  # Math.log2(4 + 2.i) # => 2.1609640474436813 + 0.6689021062254881i
+  # ```
+  def log2(z : Complex)
+    log(z) / LOG2
+  end
+
+  # Calculates the base-10 logarithm of the complex number `z`.
+  #
+  # ```
+  # require "complex"
+  #
+  # Math.log10(4 + 2.i) # => 0.6505149978319906 + 0.20135959813668655i
+  # ```
+  def log10(z : Complex)
+    log(z) / LOG10
+  end
+
+  # Calculates the square root of the complex number `z`.
+  # Inspired by the [following blog post](https://pavpanchekha.com/blog/casio-mathjs.html) of Pavel Panchekha on floating point precision.
+  #
+  # ```
+  # require "complex"
+  #
+  # Math.sqrt(4 + 2.i) # => 2.0581710272714924 + 0.48586827175664565i
+  # ```
+  #
+  # Although the imaginary number is defined as i = sqrt(-1),
+  # calling `Math.sqrt` with a negative number will return `-NaN`.
+  # To obtain the result in the complex plane, `Math.sqrt` must
+  # be called with a complex number.
+  #
+  # ```
+  # Math.sqrt(-1.0)         # => -NaN
+  # Math.sqrt(-1.0 + 0.0.i) # => 0.0 + 1.0i
+  # ```
+  def sqrt(z : Complex)
+    r = z.abs
+
+    re = if z.real >= 0
+           0.5 * sqrt(2.0 * (r + z.real))
+         else
+           z.imag.abs / sqrt(2.0 * (r - z.real))
+         end
+
+    im = if z.real <= 0
+           0.5 * sqrt(2.0 * (r - z.real))
+         else
+           z.imag.abs / sqrt(2.0 * (r + z.real))
+         end
+
+    Complex.new(re, z.imag >= 0 ? im : -im)
   end
 end

--- a/src/complex.cr
+++ b/src/complex.cr
@@ -307,7 +307,7 @@ module Math
     r = exp(z.real)
     Complex.new(r * cos(z.imag), r * sin(z.imag))
   end
-  
+
   # Calculates the natural logarithm of the complex number `z`.
   #
   # ```


### PR DESCRIPTION
Following the discussion in the issue #9729 
I moved `Complex#exp`, `Complex#log`, `Complex#log2`, `Complex#log10` and `Complex#sqrt` to `Math#exp`, `Math#log`, `Math#log2`, `Math#log10` and `Math#sqrt`.
And I completed the documentation with examples. 
