### PR TITLE
Fix bug for c structs assigned to a type

### DIFF
--- a/spec/compiler/codegen/c_struct_spec.cr
+++ b/spec/compiler/codegen/c_struct_spec.cr
@@ -379,4 +379,19 @@ describe "Code gen: struct" do
       foo.x.call(1)
       )).to_i.should eq(2)
   end
+
+  it "can access member of uninitialized struct behind type (#8774)" do
+    run(%(
+      lib LibFoo
+        struct Foo
+          x : Int32
+        end
+
+        type FooT = Foo
+      end
+
+      foo = uninitialized LibFoo::FooT
+      foo.x
+    ))
+  end
 end

--- a/src/compiler/crystal/codegen/codegen.cr
+++ b/src/compiler/crystal/codegen/codegen.cr
@@ -1186,15 +1186,12 @@ module Crystal
       read_instance_var node.type, node.obj.type, node.name, @last
     end
 
-    def read_instance_var(node_type, type : TypeDefType, name, value)
-      read_instance_var(node_type, type.typedef, name, value)
-    end
-
     def read_instance_var(node_type, type, name, value)
-      ivar = type.lookup_instance_var(name)
-      ivar_ptr = instance_var_ptr type, name, value
+      type_without_typedef = type.remove_typedef
+      ivar = type_without_typedef.lookup_instance_var(name)
+      ivar_ptr = instance_var_ptr type_without_typedef, name, value
       @last = downcast ivar_ptr, node_type, ivar.type, false
-      if type.extern?
+      if type_without_typedef.extern?
         # When reading the instance variable of a C struct or union
         # we need to convert C functions to Crystal procs. This
         # can happen for example in Struct#to_s, where all fields

--- a/src/compiler/crystal/codegen/codegen.cr
+++ b/src/compiler/crystal/codegen/codegen.cr
@@ -1187,11 +1187,11 @@ module Crystal
     end
 
     def read_instance_var(node_type, type, name, value)
-      type_without_typedef = type.remove_typedef
-      ivar = type_without_typedef.lookup_instance_var(name)
-      ivar_ptr = instance_var_ptr type_without_typedef, name, value
+      type = type.remove_typedef
+      ivar = type.lookup_instance_var(name)
+      ivar_ptr = instance_var_ptr type, name, value
       @last = downcast ivar_ptr, node_type, ivar.type, false
-      if type_without_typedef.extern?
+      if type.extern?
         # When reading the instance variable of a C struct or union
         # we need to convert C functions to Crystal procs. This
         # can happen for example in Struct#to_s, where all fields

--- a/src/compiler/crystal/codegen/codegen.cr
+++ b/src/compiler/crystal/codegen/codegen.cr
@@ -1186,6 +1186,10 @@ module Crystal
       read_instance_var node.type, node.obj.type, node.name, @last
     end
 
+    def read_instance_var(node_type, type : TypeDefType, name, value)
+      read_instance_var(node_type, type.typedef, name, value)
+    end
+
     def read_instance_var(node_type, type, name, value)
       ivar = type.lookup_instance_var(name)
       ivar_ptr = instance_var_ptr type, name, value


### PR DESCRIPTION
Fixes #8774

When instance variables of C structs were accessed through a type declaration it failed because it was looking for instance variables on the `TypeDefType` instead of the type that it was representing.