### PR TITLE
Add Regex#capture_count

### DIFF
--- a/spec/std/regex_spec.cr
+++ b/spec/std/regex_spec.cr
@@ -117,6 +117,15 @@ describe "Regex" do
     end
   end
 
+  describe "capture_count" do
+    it "returns the number of (named & non-named) capture groups" do
+      /(?:.)/x.capture_count.should eq(0)
+      /(?<foo>.+)/.capture_count.should eq(1)
+      /(.)?/x.capture_count.should eq(1)
+      /(.)|(.)/x.capture_count.should eq(2)
+    end
+  end
+
   it "raises exception with invalid regex" do
     expect_raises(ArgumentError) { Regex.new("+") }
   end

--- a/src/regex.cr
+++ b/src/regex.cr
@@ -563,6 +563,19 @@ class Regex
     lookup
   end
 
+  # Returns the number of (named & non-named) capture groups.
+  #
+  # ```
+  # /(?:.+)/.capture_count     # => 0
+  # /(?<foo>.+)/.capture_count # => 1
+  # /(.)/.capture_count        # => 1
+  # /(.)|(.)/.capture_count    # => 2
+  # ```
+  def capture_count : Int32
+    LibPCRE.full_info(@re, @extra, LibPCRE::INFO_CAPTURECOUNT, out capture_count)
+    capture_count
+  end
+
   # Convert to `String` in subpattern format. Produces a `String` which can be
   # embedded in another `Regex` via interpolation, where it will be interpreted
   # as a non-capturing subexpression in another regular expression.


### PR DESCRIPTION
Adds missing method counterpart to `Regex#name_table`.