### PR TITLE
Add HTTP::Client logging and basic instrumentation

### DIFF
--- a/spec/std/http/client/client_spec.cr
+++ b/spec/std/http/client/client_spec.cr
@@ -3,6 +3,7 @@ require "../../socket/spec_helper"
 require "openssl"
 require "http/client"
 require "http/server"
+require "log/spec"
 
 private def test_server(host, port, read_time = 0, content_type = "text/plain", write_response = true)
   server = TCPServer.new(host, port)
@@ -298,6 +299,39 @@ module HTTP
       io.closed?.should be_true
       expect_raises(Exception, "This HTTP::Client cannot be reconnected") do
         client.get("/")
+      end
+    end
+
+    describe "logging" do
+      it "emit logs" do
+        test_server("localhost", 0, content_type: "") do |server|
+          client = Client.new("localhost", server.local_address.port)
+          Log.capture("http.client") do |logs|
+            client.get("/")
+
+            logs.check(:debug, "Performing request")
+            logs.entry.data[:method].should eq("GET")
+            logs.entry.data[:host].should eq("localhost")
+            logs.entry.data[:port].should eq(server.local_address.port)
+            logs.entry.data[:resource].should eq("/")
+          end
+        end
+      end
+
+      it "emit logs with block" do
+        test_server("localhost", 0, content_type: "") do |server|
+          Client.new("localhost", server.local_address.port) do |client|
+            Log.capture("http.client") do |logs|
+              client.get("/") do |response|
+                logs.check(:debug, "Performing request")
+                logs.entry.data[:method].should eq("GET")
+                logs.entry.data[:host].should eq("localhost")
+                logs.entry.data[:port].should eq(server.local_address.port)
+                logs.entry.data[:resource].should eq("/")
+              end
+            end
+          end
+        end
       end
     end
   end

--- a/src/http.cr
+++ b/src/http.cr
@@ -2,6 +2,7 @@ require "uri"
 {% unless flag?(:win32) %}
   require "./http/client"
   require "./http/server"
+  require "./http/log"
 {% end %}
 require "./http/common"
 

--- a/src/http/client.cr
+++ b/src/http/client.cr
@@ -867,10 +867,27 @@ class HTTP::Client
     end
   end
 
+  # This method is called when executing the request. Although it can be
+  # redefined, it is recommended to use the `def_around_exec` macro to be
+  # able to add new behaviors without loosing prior existing ones.
   protected def around_exec(request)
     yield
   end
 
+  # This macro allows injecting code to be run before and after the execution
+  # of the request. It should return the yielded value. It must be called with 1
+  # block argument that will be used to pass the `HTTP::Request`.
+  #
+  # ```
+  # class HTTP::Client
+  #   def_around_exec do |request|
+  #     # do something before exec
+  #     res = yield
+  #     # do something after exec
+  #     res
+  #   end
+  # end
+  # ```
   macro def_around_exec(&block)
     protected def around_exec(%request)
       previous_def do

--- a/src/http/client.cr
+++ b/src/http/client.cr
@@ -868,13 +868,18 @@ class HTTP::Client
   end
 
   protected def around_exec(request)
-    yield request
+    yield
   end
 
-  macro def_around_exec
-    protected def around_exec(request)
+  macro def_around_exec(&block)
+    protected def around_exec(%request)
       previous_def do
-        {{ yield :request.id }}
+        {% if block.args.size != 1 %}
+          {% raise "Wrong number of block arguments (given #{block.args.size}, expected: 1)" %}
+        {% end %}
+
+        {{ block.args.first.id }} = %request
+        {{ block.body }}
       end
     end
   end

--- a/src/http/client.cr
+++ b/src/http/client.cr
@@ -577,7 +577,10 @@ class HTTP::Client
   # response.body # => "..."
   # ```
   def exec(request : HTTP::Request) : HTTP::Client::Response
+    before_exec(request)
     exec_internal(request)
+  ensure
+    after_exec(request)
   end
 
   private def exec_internal(request)
@@ -615,9 +618,12 @@ class HTTP::Client
   # end
   # ```
   def exec(request : HTTP::Request, &block)
+    before_exec(request)
     exec_internal(request) do |response|
       yield response
     end
+  ensure
+    after_exec(request)
   end
 
   private def exec_internal(request, &block : Response -> T) : T forall T
@@ -861,6 +867,12 @@ class HTTP::Client
       end
       yield client, path
     end
+  end
+
+  protected def before_exec(request)
+  end
+
+  protected def after_exec(request)
   end
 end
 

--- a/src/http/log.cr
+++ b/src/http/log.cr
@@ -4,7 +4,7 @@ class HTTP::Client
   Log = ::Log.for(self)
 
   def_around_exec do |request|
-    emit_log({{request}})
+    emit_log(request)
     yield
   end
 

--- a/src/http/log.cr
+++ b/src/http/log.cr
@@ -1,0 +1,19 @@
+require "log"
+
+class HTTP::Client
+  Log = ::Log.for(self)
+
+  protected def before_exec(request)
+    previous_def
+    emit_log(request)
+  end
+
+  protected def emit_log(request)
+    Log.debug &.emit("Performing request",
+      method: request.method,
+      host: host,
+      port: port,
+      resource: request.resource,
+    )
+  end
+end

--- a/src/http/log.cr
+++ b/src/http/log.cr
@@ -3,9 +3,9 @@ require "log"
 class HTTP::Client
   Log = ::Log.for(self)
 
-  protected def before_exec(request)
-    previous_def
-    emit_log(request)
+  def_around_exec do |request|
+    emit_log({{request}})
+    yield
   end
 
   protected def emit_log(request)


### PR DESCRIPTION
This adds protected methods HTTP::Client#before_exec and #after_exec that can be used to hook into the lifecycle of the http client.

A first utility for this is adding a http.client log source to know a request is starting.

This enables some basic instrumentation to monitor the activity of the application without monkey patching sensitive parts of the http client.

---

As an example if one wants to log also when a request is completed and measure the elapsed time the app could define

```crystal
class HTTP::Client
  protected def before_exec(request)
    previous_def
    @start = Time.monotonic
  end

  protected def after_exec(request)
    previous_def
    elapsed = Time.monotonic - @start.not_nil!
    Log.debug &.emit("Finished request",
      method: request.method,
      host: host,
      port: port,
      resource: request.resource,
      elapsed: "#{elapsed.total_seconds.humanize(precision: 2, significant: false)}s"
    )
  end
end
```