### PR TITLE
Disable specs added in #9724 on windows

### DIFF
--- a/spec/std/io/io_spec.cr
+++ b/spec/std/io/io_spec.cr
@@ -1,8 +1,8 @@
 require "../spec_helper"
 require "../../support/channel"
-require "socket"
 
 {% unless flag?(:win32) %}
+  require "socket"
   require "big"
 {% end %}
 require "base64"
@@ -769,7 +769,7 @@ describe IO do
         io.gets_to_end.should eq("\r\nFoo\nBar")
       end
 
-      it "gets ascii from socket (#9056)" do
+      pending_win32 "gets ascii from socket (#9056)" do
         server = TCPServer.new "localhost", 0
         sock = TCPSocket.new "localhost", server.local_address.port
         begin


### PR DESCRIPTION
Disable specs added in #9724 on windows since they were failing with a 

```
In src\socket.cr:1:1

 1 | require "c/arpa/inet"
     ^
Error: can't find file 'c/arpa/inet'
```