### PR TITLE
CI: Disable darwin ci on CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -551,8 +551,8 @@ workflows:
           filters: *unless_maintenance
       - test_alpine:
           filters: *unless_maintenance
-      - test_darwin:
-          filters: *unless_maintenance
+      # - test_darwin:
+      #     filters: *unless_maintenance
       - test_preview_mt:
           filters: *unless_maintenance
       - check_format:
@@ -577,8 +577,8 @@ workflows:
           filters: *per_tag
       - test_alpine:
           filters: *per_tag
-      - test_darwin:
-          filters: *per_tag
+      # - test_darwin:
+      #     filters: *per_tag
       - test_preview_mt:
           filters: *per_tag
       - check_format:
@@ -652,7 +652,7 @@ workflows:
       - test_linux
       - test_linux32_std
       - test_alpine
-      - test_darwin
+      # - test_darwin
       - test_preview_mt
       - check_format
       - prepare_common
@@ -716,8 +716,8 @@ workflows:
           filters: *maintenance
       - test_alpine:
           filters: *maintenance
-      - test_darwin:
-          filters: *maintenance
+      # - test_darwin:
+      #     filters: *maintenance
       - test_preview_mt:
           filters: *maintenance
       - check_format:


### PR DESCRIPTION
In GitHub Action the darwin ci is using Nix.
The CircleCI alternative still uses brew and llvm@10 (10.0.1) is not usable as is.
Most likely the CI for PR will be moved entirely to GitHub Actions and CircleCI will remain for nightly and releases builds, at least, for while.