### PR TITLE
Windows: pass a flag to allow creating symlinks without admin rights

### DIFF
--- a/src/crystal/system/win32/file.cr
+++ b/src/crystal/system/win32/file.cr
@@ -193,7 +193,7 @@ module Crystal::System::File
 
   def self.symlink(old_path : String, new_path : String) : Nil
     # TODO: support directory symlinks (copy Go's stdlib logic here)
-    if LibC.CreateSymbolicLinkW(to_windows_path(new_path), to_windows_path(old_path), 0) == 0
+    if LibC.CreateSymbolicLinkW(to_windows_path(new_path), to_windows_path(old_path), LibC::SYMBOLIC_LINK_FLAG_ALLOW_UNPRIVILEGED_CREATE) == 0
       raise ::File::Error.from_winerror("Error creating symbolic link", file: old_path, other: new_path)
     end
   end


### PR DESCRIPTION
As far as I can tell, passing this flag just has no downsides. Without it, symlinks can be created only as administrator; with it, symlinks still can't be created by default, but can be if only "developer mode" is enabled in Windows. But I'm guessing that'll be a requirement for most things anyway.
