### PR TITLE
Fix overflows in md5 and sha1

### DIFF
--- a/spec/manual/digest_large_file_spec.cr
+++ b/spec/manual/digest_large_file_spec.cr
@@ -1,0 +1,27 @@
+require "spec"
+require "digest/sha1"
+require "digest/md5"
+
+private DATA          = "a" * 1024
+private TOTAL_SIZE_GB = 1
+private TOTAL_SIZE    = TOTAL_SIZE_GB * 1024 * 1024 * 1024
+
+describe Digest::SHA1 do
+  it "does digest for large file" do
+    Digest::SHA1.digest do |ctx|
+      (TOTAL_SIZE / DATA.size).ceil.to_i.times do
+        ctx.update DATA
+      end
+    end
+  end
+end
+
+describe Digest::MD5 do
+  it "does digest for large file" do
+    Digest::MD5.digest do |ctx|
+      (TOTAL_SIZE / DATA.size).ceil.to_i.times do
+        ctx.update DATA
+      end
+    end
+  end
+end

--- a/src/digest/md5.cr
+++ b/src/digest/md5.cr
@@ -35,9 +35,9 @@ class Digest::MD5 < Digest::Base
     mdi = (@i[0] >> 3) & 0x3F
 
     # update number of bits
-    @i[1] += 1 if (@i[0] + (inLen << 3)) < @i[0]
-    @i[0] += (inLen << 3)
-    @i[1] += (inLen >> 29)
+    @i[1] &+= 1 if (@i[0] &+ (inLen << 3)) < @i[0]
+    @i[0] &+= (inLen << 3)
+    @i[1] &+= (inLen >> 29)
 
     inLen.times do
       # add new character to buffer, increment mdi

--- a/src/digest/sha1.cr
+++ b/src/digest/sha1.cr
@@ -35,10 +35,10 @@ class Digest::SHA1 < Digest::Base
     data.each do |byte|
       @message_block[@message_block_index] = byte & 0xFF_u8
       @message_block_index += 1
-      @length_low += 8
+      @length_low &+= 8
 
       if @length_low == 0
-        @length_high += 1
+        @length_high &+= 1
         if @length_high == 0
           raise ArgumentError.new "Crypto.sha1: message too long"
         end


### PR DESCRIPTION
Closes #9695
Fixes #9694

It adds two slow manual specs as suggested by https://github.com/crystal-lang/crystal/pull/9695#issuecomment-681738249

I validated the output of both algorithms on a ~2gb file against md5 and openssl sha1