### PR TITLE
Use Dwarf information on Exception::CallStack.print_frame

### DIFF
--- a/src/exception/call_stack.cr
+++ b/src/exception/call_stack.cr
@@ -123,6 +123,19 @@ struct Exception::CallStack
   end
 
   private def self.print_frame(repeated_frame)
+    if @@dwarf_loaded &&
+       (name = decode_function_name(repeated_frame.ip.address))
+      file, line, column = Exception::CallStack.decode_line_number(repeated_frame.ip.address)
+      if file && file != "??"
+        if repeated_frame.count == 0
+          Crystal::System.print_error "[0x%lx] %s at %s:%ld:%i\n", repeated_frame.ip, name, file, line, column
+        else
+          Crystal::System.print_error "[0x%lx] %s at %s:%ld:%i (%ld times)\n", repeated_frame.ip, name, file, line, column, repeated_frame.count + 1
+        end
+        return
+      end
+    end
+
     frame = decode_frame(repeated_frame.ip)
     if frame
       offset, sname = frame

--- a/src/exception/call_stack.cr
+++ b/src/exception/call_stack.cr
@@ -123,18 +123,20 @@ struct Exception::CallStack
   end
 
   private def self.print_frame(repeated_frame)
-    if @@dwarf_loaded &&
-       (name = decode_function_name(repeated_frame.ip.address))
-      file, line, column = Exception::CallStack.decode_line_number(repeated_frame.ip.address)
-      if file && file != "??"
-        if repeated_frame.count == 0
-          Crystal::System.print_error "[0x%lx] %s at %s:%ld:%i\n", repeated_frame.ip, name, file, line, column
-        else
-          Crystal::System.print_error "[0x%lx] %s at %s:%ld:%i (%ld times)\n", repeated_frame.ip, name, file, line, column, repeated_frame.count + 1
+    {% if flag?(:debug) %}
+      if @@dwarf_loaded &&
+         (name = decode_function_name(repeated_frame.ip.address))
+        file, line, column = Exception::CallStack.decode_line_number(repeated_frame.ip.address)
+        if file && file != "??"
+          if repeated_frame.count == 0
+            Crystal::System.print_error "[0x%lx] %s at %s:%ld:%i\n", repeated_frame.ip, name, file, line, column
+          else
+            Crystal::System.print_error "[0x%lx] %s at %s:%ld:%i (%ld times)\n", repeated_frame.ip, name, file, line, column, repeated_frame.count + 1
+          end
+          return
         end
-        return
       end
-    end
+    {% end %}
 
     frame = decode_frame(repeated_frame.ip)
     if frame
@@ -215,4 +217,10 @@ struct Exception::CallStack
       end
     end
   end
+
+  {% if flag?(:debug) %}
+    # load dwarf on start up of the program when compiled with --debug
+    # this will make dwarf available on print_frame that is used on __crystal_sigfault_handler
+    load_dwarf
+  {% end %}
 end


### PR DESCRIPTION
This PR enables better stack traces when a program compiled with debug information crashes, in particular for Linux.

This is done by reading the dwarf information in `Exception::CallStack.print_frame`. To be able to 
do that, the dwarf needs to be loaded before hand. So when a program is starting, and was compiled with `--debug`, 
the dwarf information is loaded upon start.

Insttead of `???` or `*callee3:Pointer(UInt8) +14` we will get:
`callee3 at /path/to/spec/std/data/crash_backtrace_sample:14:5`

Using the `crash_backtrace_sample` test case as an example, when compiled with `--release --debug` we have:

* Before this PR:

```
$ bin/crystal run spec/std/data/crash_backtrace_sample --release --debug
Invalid memory access (signal 11) at address 0x20
[0x5576c26fdf50] ???
[0x5576c26fd342] __crystal_sigfault_handler +226
[0x5576c2718784] sigfault_handler +40
[0x7f5a5664f8a0] ???
[0x5576c2705cec] GC_realloc +44
[0x5576c26fdb1d] ???
[0x5576c26a3637] __crystal_realloc64 +39
[0x5576c26ad9bc] ???
[0x5576c26fd4b9] ???
[0x5576c26fd44e] ???
[0x5576c26ff447] ???
[0x5576c26ff2d0] ???
[0x5576c26aa32b] main +27
[0x7f5a55c00b97] __libc_start_main +231
[0x5576c26a319a] _start +42
[0x0] ???
```

* After this PR:

```
$ bin/crystal run spec/std/data/crash_backtrace_sample --release --debug
Invalid memory access (signal 11) at address 0x20
[0x55f7be784f70] print_backtrace at /path/to/src/exception/call_stack.cr:121:5
[0x55f7be784362] __crystal_sigfault_handler at /path/to/src/signal.cr:348:3
[0x55f7be79f7a4] sigfault_handler +40
[0x7f53f5e6e8a0] ???
[0x55f7be78cd0c] GC_realloc +44
[0x55f7be784b3d] realloc at /path/to/src/gc/boehm.cr:120:5
[0x55f7be72a627] __crystal_realloc64 at /path/to/src/gc.cr:46:3
[0x55f7be736a7c] realloc at /path/to/src/pointer.cr:350:7
[0x55f7be7844d9] callee1 at /path/to/spec/std/data/crash_backtrace_sample:4:5
[0x55f7be78446e] callee3 at /path/to/spec/std/data/crash_backtrace_sample:14:5
[0x55f7be786467] main_user_code at /path/to/src/crystal/main.cr:105:5
[0x55f7be7862f0] main at /path/to/src/crystal/main.cr:91:7
[0x55f7be77651b] main at /path/to/src/crystal/main.cr:114:3
[0x7f53f541fb97] __libc_start_main +231
[0x55f7be72a19a] _start +42
[0x0] ???
```

When compiled with `--debug` we have:

* Before this PR:

```
$ bin/crystal run spec/std/data/crash_backtrace_sample --debug
Invalid memory access (signal 11) at address 0x20
[0x55b928d4aab6] *Exception::CallStack::print_backtrace:(Int32 | Nil) +118
[0x55b928d3d2fd] __crystal_sigfault_handler +413
[0x55b928dd03c4] sigfault_handler +40
[0x7f0a2cb768a0] ???
[0x55b928dbd92c] GC_realloc +44
[0x55b928d5e341] *GC::realloc<Pointer(Void), UInt64>:Pointer(Void) +49
[0x55b928d2ebd4] __crystal_realloc64 +68
[0x55b928d415ee] *Pointer(UInt8) +94
[0x55b928db642c] *Kls#callee1:Pointer(UInt8) +44
[0x55b928d3d33e] *callee3:Pointer(UInt8) +14
[0x55b928d2eab8] __crystal_main +1112
[0x55b928db733d] *Crystal::main_user_code<Int32, Pointer(Pointer(UInt8))>:Nil +45
[0x55b928db7181] *Crystal::main<Int32, Pointer(Pointer(UInt8))>:Int32 +113
[0x55b928d39e0d] main +45
[0x7f0a2c127b97] __libc_start_main +231
[0x55b928d2e57a] _start +42
[0x0] ???
```

* After this PR:

```
$ bin/crystal run spec/std/data/crash_backtrace_sample --debug
Invalid memory access (signal 11) at address 0x20
[0x5609960f7b16] print_backtrace at /path/to/src/exception/call_stack.cr:121:5
[0x5609960ea35d] __crystal_sigfault_handler at /path/to/src/signal.cr:347:3
[0x56099617d424] sigfault_handler +40
[0x7fc452dc58a0] ???
[0x56099616a98c] GC_realloc +44
[0x56099610c951] realloc at /path/to/src/gc/boehm.cr:120:5
[0x5609960dbc04] __crystal_realloc64 at /path/to/src/gc.cr:46:3
[0x5609960ee6be] realloc at /path/to/src/pointer.cr:350:7
[0x56099616348c] callee1 at /path/to/spec/std/data/crash_backtrace_sample:4:5
[0x5609960ea39e] callee3 at /path/to/spec/std/data/crash_backtrace_sample:14:5
[0x5609960dbae3] __crystal_main at /path/to/spec/std/data/crash_backtrace_sample:18:1
[0x56099616439d] main_user_code at /path/to/src/crystal/main.cr:105:5
[0x5609961641e1] main at /path/to/src/crystal/main.cr:91:7
[0x5609960e808d] main at /path/to/src/crystal/main.cr:114:3
[0x7fc452376b97] __libc_start_main +231
[0x5609960db5aa] _start +42
[0x0] ???
```