### PR TITLE
Codegen: don't use init check for consts that are declared before read

### DIFF
--- a/src/compiler/crystal/codegen/types.cr
+++ b/src/compiler/crystal/codegen/types.cr
@@ -167,6 +167,15 @@ module Crystal
   class Const
     property initializer : LLVM::Value?
 
+    # Was this constant already read during the codegen phase?
+    # If not, and we are at the place that declares the constant, we can
+    # directly initialize the constant now, without checking for an `init` flag.
+    property? read = false
+
+    # If true, there's no need to check whether the constant was initialized or
+    # not when reading it.
+    property? no_init_flag = false
+
     def initialized_llvm_name
       "#{llvm_name}:init"
     end


### PR DESCRIPTION
The way constant work crystal is:
- If the constant is a number literal, or something that can be computed at compile-time, like a math operation, then the constant value is assigned to an LLVM global that's marked as constant. Accessing this constant is just accessing the LLVM global
- All other constants are lazily initialized: whenever we access them we check if they were initialized (in a thread-safe way) and if not, we initialize them

The problem is that this prevents LLVM from inlining the second group of constants, which is a shame. You'd also expect constants to be inlined whenever possible.

The reason why all constants are lazily initialized is because of hoisting. This works:

```crystal
puts A

A = 1
```

This works fine. The above is a simple example but `puts A` could be some initialization done by a library where constants that are defined in other files are used.

This PR changes the codegen part to track whenever a constant is read. When we reach a constant declaration and it hasn't been read yet, it means that it's safe to initialize it right away, not lazily. This makes startup a bit slower, but accessing a constant is much faster (about 3 times) and we don't pay this price on every access.

For instance, a [Gameboy Advance emulator](https://github.com/mattrberry/crab) used constants in a very tight loop and it resulted in very poor frames per second (FPS), something like 30. When using a compiler with this PR the FPS doubled for me.

Here's another benchmark:

```crystal
require "benchmark"

RANGE = 3..7

a = 1
v = ARGV[0].to_i

Benchmark.ips do |x|
  x.report("constant") do
    case v
    when RANGE
      a &+= 1
    end
  end
  x.report("inline") do
    case v
    when 3..7
      a &+= 1
    end
  end
  x.report("manual") do
    if 3 <= v <= 7
      a &+= 1
    end
  end
end

puts a
```

Before:

```
 constant 291.75M (  3.43ns) (± 8.16%)  0.0B/op   2.66× slower
   inline 769.21M (  1.30ns) (± 6.62%)  0.0B/op   1.01× slower
   manual 777.14M (  1.29ns) (± 7.07%)  0.0B/op        fastest
```

After:

```
 constant 605.09M (  1.65ns) (± 4.55%)  0.0B/op   1.15× slower
   inline 697.44M (  1.43ns) (± 5.34%)  0.0B/op        fastest
   manual 601.71M (  1.66ns) (± 5.20%)  0.0B/op   1.16× slower
```

We can do a similar optimization for class variables, but I'll send it as a separate PR if this PR is merged.