### PR TITLE
Allow  -Dgc_none to "work" with weak_ref

### DIFF
--- a/src/gc/none.cr
+++ b/src/gc/none.cr
@@ -43,6 +43,9 @@ module GC
   def self.add_finalizer(object)
   end
 
+  def self.register_disappearing_link(pointer : Void**)
+  end
+
   def self.stats
     zero = LibC::ULong.new(0)
     Stats.new(zero, zero, zero, zero, zero)


### PR DESCRIPTION
Otherwise it is impossible on medium projects with crystal-db to run with the gc_none flag.