### PR TITLE
Codegen: don't use init flag for string constants

### DIFF
--- a/src/compiler/crystal/codegen/codegen.cr
+++ b/src/compiler/crystal/codegen/codegen.cr
@@ -245,7 +245,7 @@ module Crystal
       # to avoid some memory being allocated with plain malloc.
       codgen_well_known_functions @node
 
-      initialize_argv_and_argc
+      initialize_predefined_constants
 
       if @debug.line_numbers?
         set_current_debug_location Location.new(@program.filename || "(no name)", 1, 1)

--- a/src/compiler/crystal/codegen/const.cr
+++ b/src/compiler/crystal/codegen/const.cr
@@ -209,7 +209,7 @@ class Crystal::CodeGenVisitor
   def read_const_pointer(const)
     const.read = true
 
-    if const == @program.argc || const == @program.argv || const.initializer || const.no_init_flag?
+    if const == @program.argc || const == @program.argv || const.initializer || const.no_init_flag? || const.simple?
       global_name = const.llvm_name
       global = declare_const(const)
 

--- a/src/compiler/crystal/codegen/const.cr
+++ b/src/compiler/crystal/codegen/const.cr
@@ -31,12 +31,11 @@ require "./codegen"
 class Crystal::CodeGenVisitor
   @const_mutex : LLVM::Value?
 
-  # The special constants ARGC_UNSAFE and ARGV_UNSAFE need to be initialized
+  # The special constants ARGC_UNSAFE and ARGV_UNSAFE (and others) need to be initialized
   # as soon as the program starts, because we have access to argc and argv
-  # in the main function
-  def initialize_argv_and_argc
-    {"ARGC_UNSAFE", "ARGV_UNSAFE"}.each do |name|
-      const = @program.types[name].as(Const)
+  # in the main function.
+  def initialize_predefined_constants
+    @program.predefined_constants.each do |const|
       initialize_no_init_flag_const(const)
     end
   end

--- a/src/compiler/crystal/codegen/const.cr
+++ b/src/compiler/crystal/codegen/const.cr
@@ -37,12 +37,7 @@ class Crystal::CodeGenVisitor
   def initialize_argv_and_argc
     {"ARGC_UNSAFE", "ARGV_UNSAFE"}.each do |name|
       const = @program.types[name].as(Const)
-      global = declare_const(const)
-      request_value do
-        accept const.value
-      end
-      store @last, global
-      global.initializer = @last.type.null
+      initialize_no_init_flag_const(const)
     end
   end
 
@@ -209,7 +204,7 @@ class Crystal::CodeGenVisitor
   def read_const_pointer(const)
     const.read = true
 
-    if const == @program.argc || const == @program.argv || const.initializer || const.no_init_flag? || const.simple?
+    if !const.needs_init_flag?
       global_name = const.llvm_name
       global = declare_const(const)
 

--- a/src/compiler/crystal/codegen/types.cr
+++ b/src/compiler/crystal/codegen/types.cr
@@ -183,10 +183,14 @@ module Crystal
     # Returns `true` if this constant's value is a simple literal, like
     # `nil`, a number, char, string or symbol literal.
     def simple?
+      return false if pointer_read?
+
       value.simple_literal?
     end
 
     def needs_init_flag?
+      return true if pointer_read?
+
       !(initializer || no_init_flag? || simple?)
     end
 

--- a/src/compiler/crystal/codegen/types.cr
+++ b/src/compiler/crystal/codegen/types.cr
@@ -186,6 +186,10 @@ module Crystal
       value.simple_literal?
     end
 
+    def needs_init_flag?
+      !(initializer || no_init_flag? || simple?)
+    end
+
     @compile_time_value : (Int16 | Int32 | Int64 | Int8 | UInt16 | UInt32 | UInt64 | UInt8 | Bool | Char | Nil)
     @computed_compile_time_value = false
 

--- a/src/compiler/crystal/program.cr
+++ b/src/compiler/crystal/program.cr
@@ -209,6 +209,9 @@ module Crystal
       types["ARGC_UNSAFE"] = @argc = argc_unsafe = Const.new self, self, "ARGC_UNSAFE", Primitive.new("argc", int32)
       types["ARGV_UNSAFE"] = @argv = argv_unsafe = Const.new self, self, "ARGV_UNSAFE", Primitive.new("argv", pointer_of(pointer_of(uint8)))
 
+      argc_unsafe.no_init_flag = true
+      argv_unsafe.no_init_flag = true
+
       # Make sure to initialize `ARGC_UNSAFE` and `ARGV_UNSAFE` as soon as the program starts
       const_initializers << argc_unsafe
       const_initializers << argv_unsafe

--- a/src/compiler/crystal/program.cr
+++ b/src/compiler/crystal/program.cr
@@ -118,6 +118,8 @@ module Crystal
 
     property codegen_target = Config.host_target
 
+    getter predefined_constants = Array(Const).new
+
     def initialize
       super(self, self, "main")
 
@@ -212,6 +214,9 @@ module Crystal
       argc_unsafe.no_init_flag = true
       argv_unsafe.no_init_flag = true
 
+      predefined_constants << argc_unsafe
+      predefined_constants << argv_unsafe
+
       # Make sure to initialize `ARGC_UNSAFE` and `ARGV_UNSAFE` as soon as the program starts
       const_initializers << argc_unsafe
       const_initializers << argv_unsafe
@@ -278,7 +283,9 @@ module Crystal
     end
 
     private def define_crystal_constant(name, value)
-      crystal.types[name] = Const.new self, crystal, name, value
+      crystal.types[name] = const = Const.new self, crystal, name, value
+      const.no_init_flag = true
+      predefined_constants << const
     end
 
     property(target_machine : LLVM::TargetMachine) { codegen_target.to_target_machine }

--- a/src/compiler/crystal/semantic/main_visitor.cr
+++ b/src/compiler/crystal/semantic/main_visitor.cr
@@ -2566,6 +2566,7 @@ module Crystal
       when Path
         exp.accept self
         if const = exp.target_const
+          const.pointer_read = true
           const.value
         end
       when ReadInstanceVar

--- a/src/compiler/crystal/types.cr
+++ b/src/compiler/crystal/types.cr
@@ -3133,6 +3133,10 @@ module Crystal
     property vars : MetaVars?
     property? used = false
     property? visited = false
+
+    # Is this constant accessed with pointerof(...)?
+    property? pointer_read = false
+
     property visitor : MainVisitor?
 
     def initialize(program, namespace, name, @value)


### PR DESCRIPTION
Also includes a small refacor.

For example if you have code like this:

```crystal
puts FOO

FOO = "hello"
```

Then before this PR when reading `FOO` we would check whether it was initialized or not. This is not needed before a string literal doesn't need a special initialization, it's just data.

Like with #9801, it's not common to find code like the above but it is common that this happens because of order of `require` and the way the compiler works.

Benchmark (`Int#to_s` uses some constants that are string literals):

```crystal
require "benchmark"

null = File.open(File::NULL, "w")

Benchmark.ips do |x|
  x.report("Int#to_s") do
    123456789.to_s(null)
  end
end
```

Before:

```
Int#to_s  89.91M ( 11.12ns) (± 4.98%)  0.0B/op
```

After:

```
Int#to_s  97.35M ( 10.27ns) (± 5.22%)  0.0B/op  fastest
```