### PR TITLE
Support More Literals Inside Macros

### DIFF
--- a/spec/compiler/parser/parser_spec.cr
+++ b/spec/compiler/parser/parser_spec.cr
@@ -1564,9 +1564,13 @@ module Crystal
     it_parses "foo.Bar", Call.new("foo".call, "Bar")
 
     [{'(', ')'}, {'[', ']'}, {'<', '>'}, {'{', '}'}, {'|', '|'}].each do |open, close|
-      it_parses "{% begin %}%r#{open}\\A#{close}{% end %}", MacroIf.new(true.bool, MacroLiteral.new("%r#{open}\\A#{close}"))
       it_parses "{% begin %}%#{open} %s #{close}{% end %}", MacroIf.new(true.bool, MacroLiteral.new("%#{open} %s #{close}"))
       it_parses "{% begin %}%q#{open} %s #{close}{% end %}", MacroIf.new(true.bool, MacroLiteral.new("%q#{open} %s #{close}"))
+      it_parses "{% begin %}%Q#{open} %s #{close}{% end %}", MacroIf.new(true.bool, MacroLiteral.new("%Q#{open} %s #{close}"))
+      it_parses "{% begin %}%i#{open} %s #{close}{% end %}", MacroIf.new(true.bool, MacroLiteral.new("%i#{open} %s #{close}"))
+      it_parses "{% begin %}%w#{open} %s #{close}{% end %}", MacroIf.new(true.bool, MacroLiteral.new("%w#{open} %s #{close}"))
+      it_parses "{% begin %}%x#{open} %s #{close}{% end %}", MacroIf.new(true.bool, MacroLiteral.new("%x#{open} %s #{close}"))
+      it_parses "{% begin %}%r#{open}\\A#{close}{% end %}", MacroIf.new(true.bool, MacroLiteral.new("%r#{open}\\A#{close}"))
     end
 
     it_parses %(foo(bar:"a", baz:"b")), Call.new(nil, "foo", named_args: [NamedArgument.new("bar", "a".string), NamedArgument.new("baz", "b".string)])

--- a/src/compiler/crystal/syntax/lexer.cr
+++ b/src/compiler/crystal/syntax/lexer.cr
@@ -2322,6 +2322,22 @@ module Crystal
           next_char
           delimiter_state = Token::DelimiterState.new(:string, char, closing_char, 1)
           next_char
+        elsif char == 'Q' && (peek = peek_next_char) && peek.in?('(', '<', '[', '{', '|')
+          next_char
+          delimiter_state = Token::DelimiterState.new(:string, char, closing_char, 1)
+          next_char
+        elsif char == 'i' && (peek = peek_next_char) && peek.in?('(', '<', '[', '{', '|')
+          next_char
+          delimiter_state = Token::DelimiterState.new(:symbol_array, char, closing_char, 1)
+          next_char
+        elsif char == 'w' && (peek = peek_next_char) && peek.in?('(', '<', '[', '{', '|')
+          next_char
+          delimiter_state = Token::DelimiterState.new(:string_array, char, closing_char, 1)
+          next_char
+        elsif char == 'x' && (peek = peek_next_char) && peek.in?('(', '<', '[', '{', '|')
+          next_char
+          delimiter_state = Token::DelimiterState.new(:command, char, closing_char, 1)
+          next_char
         elsif char == 'r' && (peek = peek_next_char) && peek.in?('(', '<', '[', '{', '|')
           next_char
           delimiter_state = Token::DelimiterState.new(:regex, char, closing_char, 1)


### PR DESCRIPTION
Macros don't seem to permit percent literals aside from `%` and `%q`. This PR adds support for `%Q`, `%i`, `%w` and `%x`.

See https://play.crystal-lang.org/#/r/9rgn
```crystal
macro foo_bar
  %q|#{test}|
end
 
test = "hello, world"
puts foo_bar
```

Outputs "#{test}".

While https://play.crystal-lang.org/#/r/9rgo
```crystal
macro foo_bar
  %Q|#{test}|
end
 
test = "hello, world"
puts foo_bar
```

Prints
```
There was a problem expanding macro 'foo_bar'


Called macro defined in eval:1:1

Which expanded to:

 > 1 | __temp_24|#{test}|
     ^
Error: unexpected token: EOF
```

I'd expect it to output "hello, world".