### PR TITLE
Force secure renegotiation on server

### DIFF
--- a/spec/std/openssl/ssl/context_spec.cr
+++ b/spec/std/openssl/ssl/context_spec.cr
@@ -41,6 +41,9 @@ describe OpenSSL::SSL::Context do
     (context.options & OpenSSL::SSL::Options::SINGLE_ECDH_USE).should eq(OpenSSL::SSL::Options::SINGLE_ECDH_USE)
     (context.options & OpenSSL::SSL::Options::SINGLE_DH_USE).should eq(OpenSSL::SSL::Options::SINGLE_DH_USE)
     (context.options & OpenSSL::SSL::Options::CIPHER_SERVER_PREFERENCE).should eq(OpenSSL::SSL::Options::CIPHER_SERVER_PREFERENCE)
+    {% if compare_versions(LibSSL::OPENSSL_VERSION, "1.1.0") >= 0 %}
+      (context.options & OpenSSL::SSL::Options::NO_RENEGOTIATION).should eq(OpenSSL::SSL::Options::NO_RENEGOTIATION)
+    {% end %}
 
     context.modes.should eq(OpenSSL::SSL::Modes.flags(AUTO_RETRY, RELEASE_BUFFERS))
     context.verify_mode.should eq(OpenSSL::SSL::VerifyMode::NONE)

--- a/src/openssl/lib_ssl.cr
+++ b/src/openssl/lib_ssl.cr
@@ -99,6 +99,9 @@ lib LibSSL
     NO_TLS_V1_3 = 0x20000000
     NO_TLS_V1_2 = 0x08000000
     NO_TLS_V1_1 = 0x10000000
+    {% if compare_versions(OPENSSL_VERSION, "1.1.0") >= 0 %}
+      NO_RENEGOTIATION = 0x40000000
+    {% end %}
 
     NETSCAPE_CA_DN_BUG              = 0x20000000
     NETSCAPE_DEMO_CIPHER_CHANGE_BUG = 0x40000000

--- a/src/openssl/ssl/context.cr
+++ b/src/openssl/ssl/context.cr
@@ -191,6 +191,10 @@ abstract class OpenSSL::SSL::Context
       SINGLE_DH_USE
     ))
 
+    {% if compare_versions(LibSSL::OPENSSL_VERSION, "1.1.0") >= 0 %}
+      add_options(OpenSSL::SSL::Options::NO_RENEGOTIATION)
+    {% end %}
+
     add_modes(OpenSSL::SSL::Modes.flags(AUTO_RETRY, RELEASE_BUFFERS))
   end
 


### PR DESCRIPTION
Prevent Secure Client-Initiated Renegotiation vulnerability attack by default on servers

Ref: https://www.openssl.org/docs/man1.1.0/man3/SSL_CTX_set_options.html#SECURE-RENEGOTIATION

https://testssl.sh/ can be used to verify the current status.

Current applications can be patched by doing `context.add_options(OpenSSL::SSL::Options.new(0x40000000))`. This PR will ensure safer defaults.

After this PR when the vulnerability is being checked the following trace is shown

```
Unhandled exception in spawn: SSL_read: error:14094410:SSL routines:ssl3_read_bytes:sslv3 alert handshake failure (OpenSSL::SSL::Error)
  from src/openssl/ssl/socket.cr:132:9 in 'unbuffered_read'
  from src/io/buffered.cr:239:12 in 'fill_buffer'
  from src/io/buffered.cr:103:7 in 'peek'
  from src/http/request.cr:134:15 in 'parse_request_line'
  from src/http/request.cr:111:12 in 'from_io:max_request_line_size:max_headers_size'
  from src/http/server/request_processor.cr:30:19 in 'process'
  from src/http/server.cr:513:5 in 'handle_client'
  from src/http/server.cr:468:13 in '->'
  from src/primitives.cr:255:3 in 'run'
  from src/fiber.cr:92:34 in '->'
```

cc: @carlhoerberg 