### PR TITLE
Linkification in docs: refactor, fix edge cases and add specs

### DIFF
--- a/spec/compiler/crystal/tools/doc/doc_renderer_spec.cr
+++ b/spec/compiler/crystal/tools/doc/doc_renderer_spec.cr
@@ -98,6 +98,13 @@ describe Doc::Markdown::DocRenderer do
       end
     end
 
+    it "doesn't match with different separator" do
+      {base, base_foo}.each do |obj|
+        assert_code_link(obj, ",baz")
+        assert_code_link(obj, "Base:bar", %(<a href="Base.html">Base</a>:bar))
+      end
+    end
+
     it "finds method with args" do
       {base, base_foo}.each do |obj|
         assert_code_link(obj, "foo2(a, b)", %(<a href="Base.html#foo2(a,b)-instance-method">#foo2(a, b)</a>))
@@ -253,6 +260,13 @@ describe Doc::Markdown::DocRenderer do
     it "doesn't find type not at word boundary" do
       {base, base_foo}.each do |obj|
         assert_code_link(obj, "aBase")
+      end
+    end
+
+    it "finds multiple kinds of things" do
+      {base, base_foo}.each do |obj|
+        assert_code_link(obj, "Base#foo2(a, a) and #foo3 and Base",
+          %(<a href="Base.html#foo2(a,b)-instance-method">Base#foo2(a, a)</a> and <a href="Base.html#foo3(a,b,c)-instance-method">#foo3</a> and <a href="Base.html">Base</a>))
       end
     end
   end

--- a/spec/compiler/crystal/tools/doc/doc_renderer_spec.cr
+++ b/spec/compiler/crystal/tools/doc/doc_renderer_spec.cr
@@ -77,7 +77,7 @@ describe Doc::Markdown::DocRenderer do
       end
     end
 
-    pending "doesn't find sibling methods with fake receiver" do
+    it "doesn't find sibling methods with fake receiver" do
       {base, base_foo}.each do |obj|
         assert_code_link(obj, "wrong#bar")
         assert_code_link(obj, "wrong.bar")
@@ -183,7 +183,7 @@ describe Doc::Markdown::DocRenderer do
       end
     end
 
-    pending "finds method of an absolute type" do
+    it "finds method of an absolute type" do
       {base, base_foo}.each do |obj|
         assert_code_link(obj, "::Base::Nested#foo", %(<a href="Base/Nested.html#foo-instance-method">::Base::Nested#foo</a>))
         assert_code_link(obj, "::Base.baz", %(<a href="Base.html#baz-class-method">::Base.baz</a>))
@@ -250,7 +250,7 @@ describe Doc::Markdown::DocRenderer do
       end
     end
 
-    pending "doesn't find type not at word boundary" do
+    it "doesn't find type not at word boundary" do
       {base, base_foo}.each do |obj|
         assert_code_link(obj, "aBase")
       end

--- a/spec/compiler/crystal/tools/doc/doc_renderer_spec.cr
+++ b/spec/compiler/crystal/tools/doc/doc_renderer_spec.cr
@@ -2,11 +2,11 @@ require "../../../spec_helper"
 
 private def assert_code_link(obj, before, after = before)
   renderer = Doc::Markdown::DocRenderer.new(obj, IO::Memory.new)
-  renderer.detect_code_link(before).should eq(after)
+  renderer.expand_code_links(before).should eq(after)
 end
 
 describe Doc::Markdown::DocRenderer do
-  describe "detect_code_link" do
+  describe "expand_code_links" do
     program = semantic("
       class Base
         def foo

--- a/spec/compiler/crystal/tools/doc/doc_renderer_spec.cr
+++ b/spec/compiler/crystal/tools/doc/doc_renderer_spec.cr
@@ -1,0 +1,269 @@
+require "../../../spec_helper"
+
+private def assert_code_link(obj, before, after = before)
+  renderer = Doc::Markdown::DocRenderer.new(obj, IO::Memory.new)
+  renderer.detect_code_link(before).should eq(after)
+end
+
+describe Doc::Markdown::DocRenderer do
+  describe "detect_code_link" do
+    program = semantic("
+      class Base
+        def foo
+        end
+        def bar
+        end
+        def self.baz
+        end
+
+        def foo2(a, b)
+        end
+        def foo3(a, b, c)
+        end
+
+        def que?
+        end
+        def one!(one)
+        end
+
+        def <=(other)
+        end
+
+        class Nested
+          CONST = true
+
+          def foo
+          end
+        end
+      end
+
+      class Sub < Base
+        def foo
+        end
+      end
+      ", wants_doc: true).program
+    generator = Doc::Generator.new(program, [""])
+
+    base = generator.type(program.types["Base"])
+    base_foo = base.lookup_method("foo").not_nil!
+    sub = generator.type(program.types["Sub"])
+    sub_foo = sub.lookup_method("foo").not_nil!
+    nested = generator.type(program.types["Base"].types["Nested"])
+    nested_foo = nested.lookup_method("foo").not_nil!
+
+    it "finds sibling methods" do
+      {base, base_foo}.each do |obj|
+        assert_code_link(obj, "bar", %(<a href="Base.html#bar-instance-method">#bar</a>))
+        assert_code_link(obj, "baz", %(<a href="Base.html#baz-class-method">.baz</a>))
+      end
+    end
+
+    it "finds sibling methods" do
+      {base, base_foo}.each do |obj|
+        assert_code_link(obj, "#bar", %(<a href="Base.html#bar-instance-method">#bar</a>))
+        assert_code_link(obj, ".baz", %(<a href="Base.html#baz-class-method">.baz</a>))
+      end
+    end
+
+    it "doesn't find substrings for methods" do
+      assert_code_link(base_foo, "not bar")
+      assert_code_link(base_foo, "bazzy")
+    end
+
+    it "doesn't find sibling methods of wrong type" do
+      {base, base_foo}.each do |obj|
+        assert_code_link(obj, "Wrong#bar")
+        assert_code_link(obj, "Wrong.bar")
+      end
+    end
+
+    pending "doesn't find sibling methods with fake receiver" do
+      {base, base_foo}.each do |obj|
+        assert_code_link(obj, "wrong#bar")
+        assert_code_link(obj, "wrong.bar")
+      end
+    end
+
+    it "doesn't find parents' methods" do
+      {sub, sub_foo, nested, nested_foo}.each do |obj|
+        assert_code_link(obj, "bar")
+        assert_code_link(obj, "baz")
+      end
+    end
+
+    it "doesn't find parents' methods" do
+      {sub, sub_foo, nested, nested_foo}.each do |obj|
+        assert_code_link(obj, "#bar")
+        assert_code_link(obj, ".baz")
+      end
+    end
+
+    it "finds method with args" do
+      {base, base_foo}.each do |obj|
+        assert_code_link(obj, "foo2(a, b)", %(<a href="Base.html#foo2(a,b)-instance-method">#foo2(a, b)</a>))
+        assert_code_link(obj, "#foo2(a, a)", %(<a href="Base.html#foo2(a,b)-instance-method">#foo2(a, a)</a>))
+        assert_code_link(obj, "Base#foo2(a, a)", %(<a href="Base.html#foo2(a,b)-instance-method">Base#foo2(a, a)</a>))
+      end
+    end
+
+    pending "finds method with zero args" do
+      {base, base_foo}.each do |obj|
+        assert_code_link(obj, "bar()", %(<a href="Base.html#bar-instance-method">#bar</a>()))
+      end
+    end
+
+    it "finds method with zero args" do
+      {base, base_foo}.each do |obj|
+        assert_code_link(obj, "#bar()", %(<a href="Base.html#bar-instance-method">#bar</a>()))
+        assert_code_link(obj, "Base#bar()", %(<a href="Base.html#bar-instance-method">Base#bar</a>()))
+      end
+    end
+
+    it "doesn't find method with wrong number of args" do
+      {base, base_foo}.each do |obj|
+        assert_code_link(obj, "#foo2(a, a, a, a)")
+        assert_code_link(obj, "#bar(a)")
+      end
+    end
+
+    it "doesn't find method with wrong number of args" do
+      {base, base_foo}.each do |obj|
+        assert_code_link(obj, "Base#foo2(a)")
+        assert_code_link(obj, "Base#bar(a)")
+      end
+    end
+
+    it "finds method with unspecified args" do
+      {base, base_foo}.each do |obj|
+        assert_code_link(obj, "foo2", %(<a href="Base.html#foo2(a,b)-instance-method">#foo2</a>))
+        assert_code_link(obj, "#foo2", %(<a href="Base.html#foo2(a,b)-instance-method">#foo2</a>))
+        assert_code_link(obj, "Base#foo2", %(<a href="Base.html#foo2(a,b)-instance-method">Base#foo2</a>))
+      end
+    end
+
+    pending "finds method with args even with empty brackets" do
+      {base, base_foo}.each do |obj|
+        assert_code_link(obj, "foo2()", %(<a href="Base.html#foo2(a,b)-instance-method">#foo2</a>()))
+      end
+    end
+
+    it "finds method with args even with empty brackets" do
+      {base, base_foo}.each do |obj|
+        assert_code_link(obj, "#foo2()", %(<a href="Base.html#foo2(a,b)-instance-method">#foo2</a>()))
+        assert_code_link(obj, "Base#foo2()", %(<a href="Base.html#foo2(a,b)-instance-method">Base#foo2</a>()))
+      end
+    end
+
+    it "finds method with question mark" do
+      {base, base_foo}.each do |obj|
+        assert_code_link(obj, "que?", %(<a href="Base.html#que?-instance-method">#que?</a>))
+        assert_code_link(obj, "#que?", %(<a href="Base.html#que?-instance-method">#que?</a>))
+        assert_code_link(obj, "Base#que?", %(<a href="Base.html#que?-instance-method">Base#que?</a>))
+      end
+    end
+
+    it "finds method with exclamation mark" do
+      {base, base_foo}.each do |obj|
+        assert_code_link(obj, "one!(one)", %(<a href="Base.html#one!(one)-instance-method">#one!(one)</a>))
+        assert_code_link(obj, "#one!(one)", %(<a href="Base.html#one!(one)-instance-method">#one!(one)</a>))
+        assert_code_link(obj, "Base#one!(one)", %(<a href="Base.html#one!(one)-instance-method">Base#one!(one)</a>))
+      end
+    end
+
+    it "finds operator method" do
+      {base, base_foo}.each do |obj|
+        assert_code_link(obj, "<=(other)", %(<a href="Base.html#%3C=(other)-instance-method">#<=(other)</a>))
+        assert_code_link(obj, "#<=(other)", %(<a href="Base.html#%3C=(other)-instance-method">#<=(other)</a>))
+        assert_code_link(obj, "Base#<=(other)", %(<a href="Base.html#%3C=(other)-instance-method">Base#<=(other)</a>))
+      end
+    end
+
+    it "finds operator method with unspecified args" do
+      {base, base_foo}.each do |obj|
+        assert_code_link(obj, "<=", %(<a href="Base.html#%3C=(other)-instance-method">#<=</a>))
+        assert_code_link(obj, "#<=", %(<a href="Base.html#%3C=(other)-instance-method">#<=</a>))
+        assert_code_link(obj, "Base#<=", %(<a href="Base.html#%3C=(other)-instance-method">Base#<=</a>))
+      end
+    end
+
+    it "finds methods of a type" do
+      {base, base_foo}.each do |obj|
+        assert_code_link(obj, "Base#bar", %(<a href="Base.html#bar-instance-method">Base#bar</a>))
+        assert_code_link(obj, "Base.baz", %(<a href="Base.html#baz-class-method">Base.baz</a>))
+      end
+    end
+
+    pending "finds method of an absolute type" do
+      {base, base_foo}.each do |obj|
+        assert_code_link(obj, "::Base::Nested#foo", %(<a href="Base/Nested.html#foo-instance-method">::Base::Nested#foo</a>))
+        assert_code_link(obj, "::Base.baz", %(<a href="Base.html#baz-class-method">::Base.baz</a>))
+      end
+    end
+
+    pending "doesn't find wrong kind of sibling methods" do
+      {base, base_foo}.each do |obj|
+        assert_code_link(obj, ".bar")
+        assert_code_link(obj, "#baz")
+      end
+    end
+
+    pending "doesn't find wrong kind of methods" do
+      {base, base_foo}.each do |obj|
+        assert_code_link(obj, "Base.bar")
+        assert_code_link(obj, "Base#baz")
+      end
+    end
+
+    it "finds multiple methods with brackets" do
+      {base, base_foo}.each do |obj|
+        assert_code_link(obj, "#foo2(a, a) and Base#foo3(a,b,  c)",
+          %(<a href="Base.html#foo2(a,b)-instance-method">#foo2(a, a)</a> and <a href="Base.html#foo3(a,b,c)-instance-method">Base#foo3(a,b,  c)</a>))
+      end
+    end
+
+    it "finds types from base" do
+      {base, base_foo}.each do |obj|
+        assert_code_link(obj, "Base and Sub and Nested",
+          %(<a href="Base.html">Base</a> and <a href="Sub.html">Sub</a> and <a href="Base/Nested.html">Nested</a>))
+      end
+    end
+
+    it "finds types from nested" do
+      {nested, nested_foo}.each do |obj|
+        assert_code_link(obj, "Base and Sub and Nested",
+          %(<a href="../Base.html">Base</a> and <a href="../Sub.html">Sub</a> and <a href="../Base/Nested.html">Nested</a>))
+      end
+    end
+
+    it "finds constant" do
+      {base, base_foo}.each do |obj|
+        assert_code_link(obj, "Nested::CONST", %(<a href="Base/Nested.html#CONST">Nested::CONST</a>))
+      end
+    end
+
+    it "finds nested type" do
+      {base, base_foo}.each do |obj|
+        assert_code_link(obj, "Base::Nested", %(<a href="Base/Nested.html">Base::Nested</a>))
+      end
+    end
+
+    it "finds absolute type" do
+      {base, base_foo}.each do |obj|
+        assert_code_link(obj, "::Base::Nested",
+          %(<a href="Base/Nested.html">::Base::Nested</a>))
+      end
+    end
+
+    it "doesn't find wrong absolute type" do
+      {base, base_foo}.each do |obj|
+        assert_code_link(obj, "::Nested")
+      end
+    end
+
+    pending "doesn't find type not at word boundary" do
+      {base, base_foo}.each do |obj|
+        assert_code_link(obj, "aBase")
+      end
+    end
+  end
+end

--- a/spec/compiler/crystal/tools/doc/doc_renderer_spec.cr
+++ b/spec/compiler/crystal/tools/doc/doc_renderer_spec.cr
@@ -106,16 +106,11 @@ describe Doc::Markdown::DocRenderer do
       end
     end
 
-    pending "finds method with zero args" do
-      {base, base_foo}.each do |obj|
-        assert_code_link(obj, "bar()", %(<a href="Base.html#bar-instance-method">#bar</a>()))
-      end
-    end
-
     it "finds method with zero args" do
       {base, base_foo}.each do |obj|
-        assert_code_link(obj, "#bar()", %(<a href="Base.html#bar-instance-method">#bar</a>()))
-        assert_code_link(obj, "Base#bar()", %(<a href="Base.html#bar-instance-method">Base#bar</a>()))
+        assert_code_link(obj, "bar()", %(<a href="Base.html#bar-instance-method">#bar()</a>))
+        assert_code_link(obj, "#bar()", %(<a href="Base.html#bar-instance-method">#bar()</a>))
+        assert_code_link(obj, "Base#bar()", %(<a href="Base.html#bar-instance-method">Base#bar()</a>))
       end
     end
 
@@ -141,16 +136,11 @@ describe Doc::Markdown::DocRenderer do
       end
     end
 
-    pending "finds method with args even with empty brackets" do
-      {base, base_foo}.each do |obj|
-        assert_code_link(obj, "foo2()", %(<a href="Base.html#foo2(a,b)-instance-method">#foo2</a>()))
-      end
-    end
-
     it "finds method with args even with empty brackets" do
       {base, base_foo}.each do |obj|
-        assert_code_link(obj, "#foo2()", %(<a href="Base.html#foo2(a,b)-instance-method">#foo2</a>()))
-        assert_code_link(obj, "Base#foo2()", %(<a href="Base.html#foo2(a,b)-instance-method">Base#foo2</a>()))
+        assert_code_link(obj, "foo2()", %(<a href="Base.html#foo2(a,b)-instance-method">#foo2()</a>))
+        assert_code_link(obj, "#foo2()", %(<a href="Base.html#foo2(a,b)-instance-method">#foo2()</a>))
+        assert_code_link(obj, "Base#foo2()", %(<a href="Base.html#foo2(a,b)-instance-method">Base#foo2()</a>))
       end
     end
 

--- a/spec/compiler/crystal/tools/doc/doc_renderer_spec.cr
+++ b/spec/compiler/crystal/tools/doc/doc_renderer_spec.cr
@@ -84,6 +84,12 @@ describe Doc::Markdown::DocRenderer do
       end
     end
 
+    it "finds sibling methods with self receiver" do
+      {base, base_foo}.each do |obj|
+        assert_code_link(obj, "self.bar", %(self<a href="Base.html#bar-instance-method">.bar</a>))
+      end
+    end
+
     it "doesn't find parents' methods" do
       {sub, sub_foo, nested, nested_foo}.each do |obj|
         assert_code_link(obj, "bar")

--- a/src/compiler/crystal/tools/doc/markdown/doc_renderer.cr
+++ b/src/compiler/crystal/tools/doc/markdown/doc_renderer.cr
@@ -30,8 +30,11 @@ class Crystal::Doc::Markdown::DocRenderer < Crystal::Doc::Markdown::HTMLRenderer
   def end_inline_code
     @inside_inline_code = false
 
-    text = @code_buffer.to_s
+    @io << detect_code_link(@code_buffer.to_s)
+    super
+  end
 
+  def detect_code_link(text : String) : String
     # Check method reference (without #, but must be the whole text)
     if text =~ /\A((?:\w|\<|\=|\>|\+|\-|\*|\/|\[|\]|\&|\||\?|\!|\^|\~)+(?:\?|\!)?)(\(.+?\))?\Z/
       name = $1
@@ -39,10 +42,7 @@ class Crystal::Doc::Markdown::DocRenderer < Crystal::Doc::Markdown::HTMLRenderer
 
       method = lookup_method @type, name, args
       if method
-        text = method_link method, "#{method.prefix}#{text}"
-        @io << text
-        super
-        return
+        return method_link method, "#{method.prefix}#{text}"
       end
     end
 
@@ -110,10 +110,6 @@ class Crystal::Doc::Markdown::DocRenderer < Crystal::Doc::Markdown::HTMLRenderer
 
       match_text
     end
-
-    @io << text
-
-    super
   end
 
   def begin_code(language = nil)

--- a/src/compiler/crystal/tools/doc/markdown/doc_renderer.cr
+++ b/src/compiler/crystal/tools/doc/markdown/doc_renderer.cr
@@ -47,12 +47,12 @@ class Crystal::Doc::Markdown::DocRenderer < Crystal::Doc::Markdown::HTMLRenderer
     end
 
     # Check Type#method(...) or Type or #method(...)
-    text.gsub %r(\b
-      ((?:\:\:)?[A-Z]\w+(?:\:\:[A-Z]\w+)*[#\.][\w<=>+\-*\/\[\]&|?!^~]+[?!]?(?:\(.*?\))?)
+    text.gsub %r(
+      ((?:\B::)?\b[A-Z]\w+(?:\:\:[A-Z]\w+)*[#\.][\w<=>+\-*\/\[\]&|?!^~]+[?!]?(?:\(.*?\))?)
         |
-      ((?:\:\:)?[A-Z]\w+(?:\:\:[A-Z]\w+)*)
+      ((?:\B::)?\b[A-Z]\w+(?:\:\:[A-Z]\w+)*)
         |
-      ([#\.][\w<=>+\-*\/\[\]&|?!^~]+[?!]?(?:\(.*?\))?)
+      (\B[#\.][\w<=>+\-*\/\[\]&|?!^~]+[?!]?(?:\(.*?\))?)
       )x do |match_text, match|
       sharp_index = match_text.index('#')
       dot_index = match_text.index('.')

--- a/src/compiler/crystal/tools/doc/markdown/doc_renderer.cr
+++ b/src/compiler/crystal/tools/doc/markdown/doc_renderer.cr
@@ -36,9 +36,9 @@ class Crystal::Doc::Markdown::DocRenderer < Crystal::Doc::Markdown::HTMLRenderer
 
   def detect_code_link(text : String) : String
     # Check method reference (without #, but must be the whole text)
-    if text =~ /\A((?:\w|\<|\=|\>|\+|\-|\*|\/|\[|\]|\&|\||\?|\!|\^|\~)+(?:\?|\!)?)(\(.+?\))?\Z/
+    if text =~ /\A([\w<=>+\-*\/\[\]&|?!^~]+[?!]?)(\(.+?\))?\Z/
       name = $1
-      args = $~.not_nil![2]? || ""
+      args = $2? || ""
 
       method = lookup_method @type, name, args
       if method
@@ -47,13 +47,13 @@ class Crystal::Doc::Markdown::DocRenderer < Crystal::Doc::Markdown::HTMLRenderer
     end
 
     # Check Type#method(...) or Type or #method(...)
-    text = text.gsub /\b
-      ((?:\:\:)?[A-Z]\w+(?:\:\:[A-Z]\w+)*(?:\#|\.)(?:\w|\<|\=|\>|\+|\-|\*|\/|\[|\]|\&|\||\?|\!|\^|\~)+(?:\?|\!)?(?:\(.+?\))?)
+    text.gsub %r(\b
+      ((?:\:\:)?[A-Z]\w+(?:\:\:[A-Z]\w+)*[#\.][\w<=>+\-*\/\[\]&|?!^~]+[?!]?(?:\(.+?\))?)
         |
       ((?:\:\:)?[A-Z]\w+(?:\:\:[A-Z]\w+)*)
         |
-      ((?:\#|\.)(?:\w|\<|\=|\>|\+|\-|\*|\/|\[|\]|\&|\||\?|\!|\^|\~)+(?:\?|\!)?(?:\(.+?\))?)
-      /x do |match_text, match|
+      ([#\.][\w<=>+\-*\/\[\]&|?!^~]+[?!]?(?:\(.+?\))?)
+      )x do |match_text, match|
       sharp_index = match_text.index('#')
       dot_index = match_text.index('.')
       kind = sharp_index ? :instance : :class

--- a/src/compiler/crystal/tools/doc/markdown/doc_renderer.cr
+++ b/src/compiler/crystal/tools/doc/markdown/doc_renderer.cr
@@ -30,11 +30,11 @@ class Crystal::Doc::Markdown::DocRenderer < Crystal::Doc::Markdown::HTMLRenderer
   def end_inline_code
     @inside_inline_code = false
 
-    @io << detect_code_link(@code_buffer.to_s)
+    @io << expand_code_links(@code_buffer.to_s)
     super
   end
 
-  def detect_code_link(text : String) : String
+  def expand_code_links(text : String) : String
     # Check method reference (without #, but must be the whole text)
     if text =~ /\A([\w<=>+\-*\/\[\]&|?!^~]+[?!]?)(?:\((.*?)\))?\Z/
       name = $1

--- a/src/compiler/crystal/tools/doc/markdown/doc_renderer.cr
+++ b/src/compiler/crystal/tools/doc/markdown/doc_renderer.cr
@@ -48,7 +48,7 @@ class Crystal::Doc::Markdown::DocRenderer < Crystal::Doc::Markdown::HTMLRenderer
 
     # Check Type#method(...) or Type or #method(...)
     text.gsub %r(
-      ((?:\B::)?\b[A-Z]\w+(?:\:\:[A-Z]\w+)*|\B)([#.])([\w<=>+\-*\/\[\]&|?!^~]+[?!]?)(?:\((.*?)\))?
+      ((?:\B::)?\b[A-Z]\w+(?:\:\:[A-Z]\w+)*|\B|(?<=\bself))([#.])([\w<=>+\-*\/\[\]&|?!^~]+[?!]?)(?:\((.*?)\))?
         |
       ((?:\B::)?\b[A-Z]\w+(?:\:\:[A-Z]\w+)*)
       )x do |match_text|

--- a/src/compiler/crystal/tools/doc/markdown/doc_renderer.cr
+++ b/src/compiler/crystal/tools/doc/markdown/doc_renderer.cr
@@ -36,7 +36,7 @@ class Crystal::Doc::Markdown::DocRenderer < Crystal::Doc::Markdown::HTMLRenderer
 
   def detect_code_link(text : String) : String
     # Check method reference (without #, but must be the whole text)
-    if text =~ /\A([\w<=>+\-*\/\[\]&|?!^~]+[?!]?)(\(.+?\))?\Z/
+    if text =~ /\A([\w<=>+\-*\/\[\]&|?!^~]+[?!]?)(?:\((.*?)\))?\Z/
       name = $1
       args = $2? || ""
 
@@ -48,11 +48,11 @@ class Crystal::Doc::Markdown::DocRenderer < Crystal::Doc::Markdown::HTMLRenderer
 
     # Check Type#method(...) or Type or #method(...)
     text.gsub %r(\b
-      ((?:\:\:)?[A-Z]\w+(?:\:\:[A-Z]\w+)*[#\.][\w<=>+\-*\/\[\]&|?!^~]+[?!]?(?:\(.+?\))?)
+      ((?:\:\:)?[A-Z]\w+(?:\:\:[A-Z]\w+)*[#\.][\w<=>+\-*\/\[\]&|?!^~]+[?!]?(?:\(.*?\))?)
         |
       ((?:\:\:)?[A-Z]\w+(?:\:\:[A-Z]\w+)*)
         |
-      ([#\.][\w<=>+\-*\/\[\]&|?!^~]+[?!]?(?:\(.+?\))?)
+      ([#\.][\w<=>+\-*\/\[\]&|?!^~]+[?!]?(?:\(.*?\))?)
       )x do |match_text, match|
       sharp_index = match_text.index('#')
       dot_index = match_text.index('.')


### PR DESCRIPTION
Summary of the outcome:

* Methods will no longer be detected after an arbitrary word, e.g. `foo.bar` can be detected as just `.bar` for the current type with the first part just ignored.
   * In some cases that can be seen as a regression, but I think generally it's better to avoid accidental false positives.
   * Only the special case `self.bar` is preserved as before.
* Detection of `::Type.method` is fixed to find the whole thing, not just the `.method` part (also see previous item).
* Detection of `Foo.bar()` will now include the empty brackets themselves, instead of the old `Foo.bar`().
* Detection of `bar()` didn't work at all, now does.
* `aFoo` would've been detected as a`Foo`; now it won't.
* Code is greatly simplified and now has tests.