### PR TITLE
Exclude types from docs who are in nodoc namespaces

### DIFF
--- a/src/compiler/crystal/tools/doc/generator.cr
+++ b/src/compiler/crystal/tools/doc/generator.cr
@@ -129,8 +129,11 @@ class Crystal::Doc::Generator
 
   def must_include?(type : Crystal::Type)
     return false if type.private?
-    return false if nodoc?(type, type.locations.try(&.first?))
+    return false if nodoc? type
     return true if crystal_builtin?(type)
+
+    # Don't include types whose namespace is :nodoc:
+    return false if type.namespaces.any? &->nodoc?(Crystal::Type)
 
     # Don't include lib types or types inside a lib type
     return false if type.is_a?(Crystal::LibType) || type.namespace.is_a?(LibType)
@@ -145,7 +148,7 @@ class Crystal::Doc::Generator
   end
 
   def must_include?(a_def : Crystal::Def)
-    return false if nodoc?(a_def, a_def.location)
+    return false if nodoc? a_def
 
     must_include? a_def.location
   end
@@ -155,7 +158,7 @@ class Crystal::Doc::Generator
   end
 
   def must_include?(a_macro : Crystal::Macro)
-    return false if nodoc?(a_macro, a_macro.location)
+    return false if nodoc? a_macro
 
     must_include? a_macro.location
   end
@@ -165,7 +168,7 @@ class Crystal::Doc::Generator
   end
 
   def must_include?(const : Crystal::Const)
-    return false if nodoc?(const, const.locations.try(&.first?))
+    return false if nodoc? const
     return true if crystal_builtin?(const)
 
     const.locations.try &.any? { |location| must_include? location }
@@ -195,32 +198,13 @@ class Crystal::Doc::Generator
     toplevel_items.any? { |item| must_include? item }
   end
 
-  # TODO: remove after 0.34.0
-  # Needed because there are multiple passes while generating docs
-  # and we want to avoid duplicate warnings per location
-  @nodoc_warnings_locations = Set(String).new
-
-  def nodoc?(str : String?, location : Location?) : Bool
+  def nodoc?(str : String?) : Bool
     return false if !str || !@program.wants_doc?
-
-    # TODO: remove after 0.34.0
-    if str.starts_with?("nodoc")
-      if location
-        # Show one line above to highlight the nodoc line
-        location = Location.new(location.filename, location.line_number - 1, location.column_number)
-      end
-
-      if !location || @nodoc_warnings_locations.add?(location.to_s)
-        @program.report_warning_at location, "`nodoc` is no longer supported. Use `:nodoc:` instead"
-      end
-      return true
-    end
-
     str.starts_with?(":nodoc:")
   end
 
-  def nodoc?(obj, location : Location?)
-    nodoc? obj.doc.try(&.strip), location
+  def nodoc?(obj)
+    nodoc? obj.doc.try &.strip
   end
 
   def crystal_builtin?(type)

--- a/src/compiler/crystal/tools/doc/generator.cr
+++ b/src/compiler/crystal/tools/doc/generator.cr
@@ -133,7 +133,9 @@ class Crystal::Doc::Generator
     return true if crystal_builtin?(type)
 
     # Don't include types whose namespace is :nodoc:
-    return false if type.namespaces.any? &->nodoc?(Crystal::Type)
+    type.each_namespace do |ns|
+      return false if nodoc? ns
+    end
 
     # Don't include lib types or types inside a lib type
     return false if type.is_a?(Crystal::LibType) || type.namespace.is_a?(LibType)

--- a/src/compiler/crystal/types.cr
+++ b/src/compiler/crystal/types.cr
@@ -38,6 +38,19 @@ module Crystal
       program
     end
 
+    # The namespaces this type belongs to, excluding the `Program` itself.
+    def namespaces : Array(ModuleType)
+      namespace_types = [] of ModuleType
+
+      ns = self.namespace
+      until ns == program
+        namespace_types << ns
+        ns = ns.namespace
+      end
+
+      namespace_types
+    end
+
     # Returns `true` if this type is abstract.
     def abstract?
       false

--- a/src/compiler/crystal/types.cr
+++ b/src/compiler/crystal/types.cr
@@ -38,17 +38,13 @@ module Crystal
       program
     end
 
-    # The namespaces this type belongs to, excluding the `Program` itself.
-    def namespaces : Array(ModuleType)
-      namespace_types = [] of ModuleType
-
+    # Yields each namespace this type belongs to, excluding the `Program` itself.
+    def each_namespace(& : ModuleType ->) : Nil
       ns = self.namespace
       until ns == program
-        namespace_types << ns
+        yield ns
         ns = ns.namespace
       end
-
-      namespace_types
     end
 
     # Returns `true` if this type is abstract.


### PR DESCRIPTION
Fixes #9816

Also handles a TODO that drops support for `nodoc`, without colons.