### PR TITLE
Correctly render underscores in code blocks

### DIFF
--- a/src/compiler/crystal/tools/doc/highlighter.cr
+++ b/src/compiler/crystal/tools/doc/highlighter.cr
@@ -90,6 +90,8 @@ module Crystal::Doc::Highlighter
         else
           io << token
         end
+      when :UNDERSCORE
+        io << '_'
       else
         io << token
       end


### PR DESCRIPTION
With code:
```
# ```
# def validate(value : _, constraint : AVD::Constraints::MyConstraint) : Nil
#   self.raise_invalid_type value, "Int | Float"
# end
# ```
```

Before:

![image](https://user-images.githubusercontent.com/12136995/95699603-e708f280-0c12-11eb-9ad3-7d1a17208d4f.png)

After:

![image](https://user-images.githubusercontent.com/12136995/95699619-f2f4b480-0c12-11eb-8b2d-65ca2bde2229.png)
