### PR TITLE
Compiler: turn proc pointer into proc literal in some cases

### DIFF
--- a/spec/compiler/codegen/proc_spec.cr
+++ b/spec/compiler/codegen/proc_spec.cr
@@ -847,4 +847,38 @@ describe "Code gen: proc" do
       end
     ))
   end
+
+  it "closures var on ->var.call (#8584)" do
+    run(%(
+      def bar(x)
+        x
+      end
+
+      struct Foo
+        def initialize
+          @value = 1
+        end
+
+        def value
+          bar(@value)
+          @value
+        end
+      end
+
+      def get_proc_a
+        foo = Foo.new
+        ->foo.value
+      end
+
+      def get_proc_b
+        foo = Foo.new
+        ->{ foo.value }
+      end
+
+      proc_a = get_proc_a
+      proc_b = get_proc_b
+      proc_b.call
+      proc_a.call
+      )).to_i.should eq(1)
+  end
 end

--- a/spec/compiler/semantic/closure_spec.cr
+++ b/spec/compiler/semantic/closure_spec.cr
@@ -276,7 +276,7 @@ describe "Semantic: closure" do
       foo = Foo.new
       LibC.foo(->foo.bar)
       ),
-      "can't send closure to C function (closured vars: self)"
+      "can't send closure to C function (closured vars: foo)"
   end
 
   it "errors if sending closured proc pointer to C (3)" do

--- a/src/compiler/crystal/codegen/codegen.cr
+++ b/src/compiler/crystal/codegen/codegen.cr
@@ -592,14 +592,7 @@ module Crystal
 
       if obj = node.obj
         accept obj
-
-        # If obj is a primitive like an integer we need to pass
-        # the variable as is (without loading it)
-        if obj.is_a?(Var) && obj.type.is_a?(PrimitiveType)
-          call_self = context.vars[obj.name].pointer
-        else
-          call_self = @last
-        end
+        call_self = @last
       elsif owner.passed_as_self?
         call_self = llvm_self
       end

--- a/src/compiler/crystal/semantic/ast.cr
+++ b/src/compiler/crystal/semantic/ast.cr
@@ -784,6 +784,12 @@ module Crystal
     end
   end
 
+  class ProcLiteral
+    # If this ProcLiteral was created from expanding a ProcPointer,
+    # this holds the reference to it.
+    property proc_pointer : ProcPointer?
+  end
+
   class ProcPointer
     property expanded : ASTNode?
   end

--- a/src/compiler/crystal/semantic/ast.cr
+++ b/src/compiler/crystal/semantic/ast.cr
@@ -783,4 +783,8 @@ module Crystal
       Unreachable.new
     end
   end
+
+  class ProcPointer
+    property expanded : ASTNode?
+  end
 end

--- a/src/compiler/crystal/semantic/bindings.cr
+++ b/src/compiler/crystal/semantic/bindings.cr
@@ -470,6 +470,10 @@ module Crystal
     property! call : Call
 
     def map_type(type)
+      if self.expanded
+        return type
+      end
+
       return nil unless call.type?
 
       arg_types = call.args.map &.type.virtual_type

--- a/src/compiler/crystal/semantic/cleanup_transformer.cr
+++ b/src/compiler/crystal/semantic/cleanup_transformer.cr
@@ -528,6 +528,10 @@ module Crystal
     def transform(node : ProcPointer)
       super
 
+      if expanded = node.expanded
+        return transform(expanded)
+      end
+
       if call = node.call?
         result = call.transform(self)
 

--- a/src/compiler/crystal/semantic/cleanup_transformer.cr
+++ b/src/compiler/crystal/semantic/cleanup_transformer.cr
@@ -500,28 +500,46 @@ module Crystal
 
     def check_args_are_not_closure(node, message)
       node.args.each do |arg|
-        case arg
-        when ProcLiteral
-          if arg.def.closure?
-            vars = ClosuredVarsCollector.collect arg.def
-            unless vars.empty?
-              message += " (closured vars: #{vars.join ", "})"
-            end
+        check_arg_is_not_closure(node, message, arg)
+      end
+    end
 
-            arg.raise message
-          end
-        when ProcPointer
-          if arg.obj.try &.type?.try &.passed_as_self?
-            arg.raise "#{message} (closured vars: self)"
-          end
-
-          owner = arg.call.target_def.owner
-          if owner.passed_as_self?
-            arg.raise "#{message} (closured vars: self)"
-          end
-        else
-          # nothing to do
+    def check_arg_is_not_closure(node, message, arg)
+      case arg
+      when Expressions
+        arg.expressions.each do |exp|
+          check_arg_is_not_closure(node, message, exp)
         end
+      when ProcLiteral
+        if proc_pointer = arg.proc_pointer
+          case proc_pointer.obj
+          when Var
+            arg.raise "#{message} (closured vars: #{proc_pointer.obj})"
+          when InstanceVar
+            arg.raise "#{message} (closured vars: self)"
+          end
+          return
+        end
+
+        if arg.def.closure?
+          vars = ClosuredVarsCollector.collect arg.def
+          unless vars.empty?
+            message += " (closured vars: #{vars.join ", "})"
+          end
+
+          arg.raise message
+        end
+      when ProcPointer
+        if arg.obj.try &.type?.try &.passed_as_self?
+          arg.raise "#{message} (closured vars: self)"
+        end
+
+        owner = arg.call.target_def.owner
+        if owner.passed_as_self?
+          arg.raise "#{message} (closured vars: self)"
+        end
+      else
+        # nothing to do
       end
     end
 

--- a/src/compiler/crystal/semantic/fix_missing_types.cr
+++ b/src/compiler/crystal/semantic/fix_missing_types.cr
@@ -42,7 +42,11 @@ class Crystal::FixMissingTypes < Crystal::Visitor
   end
 
   def visit(node : ProcPointer)
-    node.call?.try &.accept self
+    if expanded = node.expanded
+      expanded.accept(self)
+    else
+      node.call?.try &.accept self
+    end
     false
   end
 

--- a/src/compiler/crystal/semantic/literal_expander.cr
+++ b/src/compiler/crystal/semantic/literal_expander.cr
@@ -666,6 +666,39 @@ module Crystal
       end
     end
 
+    # Expand this:
+    #
+    # ```
+    # ->foo.bar(X, Y)
+    # ```
+    #
+    # To this:
+    #
+    # ```
+    # tmp = foo
+    # ->(x : X, y : Y) { tmp.bar(x, y) }
+    # ```
+    def expand(node : ProcPointer)
+      obj = node.obj.not_nil!
+
+      temp_var = new_temp_var.at(obj)
+      assign = Assign.new(temp_var, obj)
+      obj = temp_var
+
+      def_args = node.args.map do |arg|
+        Arg.new(@program.new_temp_var_name, restriction: arg).at(arg)
+      end
+
+      call_args = def_args.map do |def_arg|
+        Var.new(def_arg.name).at(def_arg).as(ASTNode)
+      end
+
+      body = Call.new(obj, node.name, call_args).at(node)
+      proc_literal = ProcLiteral.new(Def.new("->", def_args, body)).at(node)
+
+      Expressions.new([assign, proc_literal])
+    end
+
     private def regex_new_call(node, value)
       Call.new(Path.global("Regex").at(node), "new", value, regex_options(node)).at(node)
     end

--- a/src/compiler/crystal/semantic/literal_expander.cr
+++ b/src/compiler/crystal/semantic/literal_expander.cr
@@ -695,6 +695,7 @@ module Crystal
 
       body = Call.new(obj, node.name, call_args).at(node)
       proc_literal = ProcLiteral.new(Def.new("->", def_args, body)).at(node)
+      proc_literal.proc_pointer = node
 
       Expressions.new([assign, proc_literal])
     end

--- a/src/compiler/crystal/semantic/main_visitor.cr
+++ b/src/compiler/crystal/semantic/main_visitor.cr
@@ -1236,6 +1236,13 @@ module Crystal
     def visit(node : ProcPointer)
       obj = node.obj
 
+      # If it's something like `->foo.bar` we turn it into a closure
+      # where `foo` is assigned to a temporary variable.
+      if obj.is_a?(Var) || obj.is_a?(InstanceVar) || obj.is_a?(ClassVar)
+        expand(node)
+        return false
+      end
+
       if obj
         obj.accept self
       end


### PR DESCRIPTION
Fixes #8584 

This essentially makes the compiler transform this:

```
->foo.bar(X, Y)
```

To this:

```
tmp = foo
->(x : X, y : Y) { tmp.bar(x, y) }
```

The effect is the same: it captures the value at the point of creating the proc/closure. However, the compiler has already logic for closuring `tmp` so it remains in the heap.