### PR TITLE
Add mutating methods to BigInt

### DIFF
--- a/spec/std/big/big_int_spec.cr
+++ b/spec/std/big/big_int_spec.cr
@@ -328,6 +328,144 @@ describe "BigInt" do
     result.to_s.should eq("10715086071862673209484250490600018105614048117055336074437503883703510511249361224931983788156958581275946729175531468251871452856923140435984577574698574803934567774824230985421074605062371141877954182153046474983581941267398767559165543946077062914571196477686542167660429831652624386837205668069376")
   end
 
+  it "adds (mutating)" do
+    (n = 1.to_big_i; n.add! 2.to_big_i; n).should eq(3.to_big_i)
+    (n = 1.to_big_i; n.add! 2; n).should eq(3.to_big_i)
+    (n = 1.to_big_i; n.add! 2_u8; n).should eq(3.to_big_i)
+    (n = 5.to_big_i; n.add! (-2_i64); n).should eq(3.to_big_i)
+    (n = 5.to_big_i; n.add! Int64::MAX; n).should be > Int64::MAX.to_big_i
+    (n = 5.to_big_i; n.add! Int64::MAX; n).should eq(Int64::MAX.to_big_i + 5)
+  end
+
+  it "subs (mutating)" do
+    (n = 5.to_big_i; n.sub! 2.to_big_i; n).should eq(3.to_big_i)
+    (n = 5.to_big_i; n.sub! 2; n).should eq(3.to_big_i)
+    (n = 5.to_big_i; n.sub! 2_u8; n).should eq(3.to_big_i)
+    (n = 5.to_big_i; n.sub! (-2_i64); n).should eq(7.to_big_i)
+    (n = -5.to_big_i; n.sub! Int64::MAX; n).should be < -Int64::MAX.to_big_i
+    (n = -5.to_big_i; n.sub! Int64::MAX; n).should eq(-Int64::MAX.to_big_i - 5)
+  end
+
+  it "negates (mutating)" do
+    (n = -123.to_big_i; n.neg!; n).should eq(123.to_big_i)
+  end
+
+  it "multiplies (mutating)" do
+    (n = 2.to_big_i; n.mul! 3.to_big_i; n).should eq(6.to_big_i)
+    (n = 2.to_big_i; n.mul! 3; n).should eq(6.to_big_i)
+    (n = 2.to_big_i; n.mul! 3_u8; n).should eq(6.to_big_i)
+    (n = 2.to_big_i; n.mul! Int64::MAX; n).should eq(2.to_big_i * Int64::MAX.to_big_i)
+  end
+
+  it "gets absolute value (mutating)" do
+    (n = -10.to_big_i; n.abs!; n).should eq(10.to_big_i)
+  end
+
+  it "gets factorial value (mutating)" do
+    (n = 0.to_big_i; n.factorial!; n).should eq(1.to_big_i)
+    (n = 5.to_big_i; n.factorial!; n).should eq(120.to_big_i)
+    (n = 100.to_big_i; n.factorial!; n).should eq("93326215443944152681699238856266700490715968264381621468592963895217599993229915608941463976156518286253697920827223758251185210916864000000000000000000000000".to_big_i)
+  end
+
+  it "raises if factorial of negative (mutating)" do
+    expect_raises ArgumentError do
+      n = -1.to_big_i
+      n.factorial!
+    end
+
+    expect_raises ArgumentError do
+      n = "-93326215443944152681699238856266700490715968264381621468592963895217599993229915608941463976156518286253697920827223758251185210916864000000000000000000000000".to_big_i
+      n.factorial!
+    end
+  end
+
+  it "raises if factorial of 2^64 (mutating)" do
+    expect_raises ArgumentError do
+      n = LibGMP::ULong::MAX.to_big_i + 1
+      n.factorial!
+    end
+  end
+
+  it "tdivs (mutating)" do
+    (n = 5.to_big_i; n.tdiv!(3); n).should eq(1)
+    (n = -5.to_big_i; n.tdiv!(3); n).should eq(-1)
+    (n = 5.to_big_i; n.tdiv!(-3); n).should eq(-1)
+    (n = -5.to_big_i; n.tdiv!(-3); n).should eq(1)
+  end
+
+  it "does modulo (mutating)" do
+    (n = 10.to_big_i; n.mod! 3.to_big_i; n).should eq(1.to_big_i)
+    (n = 10.to_big_i; n.mod! 3; n).should eq(1.to_big_i)
+  end
+
+  it "does modulo with negative numbers (mutating)" do
+    (n = 7.to_big_i; n.mod! 2; n).should eq(1.to_big_i)
+    (n = 7.to_big_i; n.mod! 2.to_big_i; n).should eq(1.to_big_i)
+    (n = 7.to_big_i; n.mod! -2; n).should eq(-1.to_big_i)
+    (n = 7.to_big_i; n.mod! -2.to_big_i; n).should eq(-1.to_big_i)
+    (n = -7.to_big_i; n.mod! 2; n).should eq(1.to_big_i)
+    (n = -7.to_big_i; n.mod! 2.to_big_i; n).should eq(1.to_big_i)
+    (n = -7.to_big_i; n.mod! -2; n).should eq(-1.to_big_i)
+    (n = -7.to_big_i; n.mod! -2.to_big_i; n).should eq(-1.to_big_i)
+
+    (n = 6.to_big_i; n.mod! 2; n).should eq(0.to_big_i)
+    (n = 6.to_big_i; n.mod! -2; n).should eq(0.to_big_i)
+    (n = -6.to_big_i; n.mod! 2; n).should eq(0.to_big_i)
+    (n = -6.to_big_i; n.mod! -2; n).should eq(0.to_big_i)
+  end
+
+  it "does remainder with negative numbers (mutating)" do
+    (n = 5.to_big_i; n.remainder!(3); n).should eq(2)
+    (n = -5.to_big_i; n.remainder!(3); n).should eq(-2)
+    (n = 5.to_big_i; n.remainder!(-3); n).should eq(2)
+    (n = -5.to_big_i; n.remainder!(-3); n).should eq(-2)
+  end
+
+  it "does bitwise and (mutating)" do
+    (n = 123.to_big_i; n.and! 321; n).should eq(65)
+
+    n = BigInt.new("96238761238973286532")
+    n.and! 86325735648
+    n.should eq(69124358272)
+  end
+
+  it "does bitwise or (mutating)" do
+    (n = 123.to_big_i; n.or! 4; n).should eq(127)
+    n = BigInt.new("96238761238986532")
+    n.or! 8632573
+    n.should eq(96238761247506429)
+  end
+
+  it "does bitwise xor (mutating)" do
+    (n = 123.to_big_i; n.xor! 50; n).should eq(73)
+    n = BigInt.new("96238761238986532")
+    n.xor! 8632573
+    n.should eq(96238761247393753)
+  end
+
+  it "does bitwise not (mutating)" do
+    a = BigInt.new("192623876123689865327")
+    b = BigInt.new("-192623876123689865328")
+    a.com!
+    a.should eq(b)
+  end
+
+  it "does bitwise right shift (mutating)" do
+    (n = 123.to_big_i; n.rshift! 4; n).should eq(7)
+    (n = 123456.to_big_i; n.rshift! 8; n).should eq(482)
+  end
+
+  it "does bitwise left shift (mutating)" do
+    (n = 123.to_big_i; n.lshift! 4; n).should eq(1968)
+    (n = 123456.to_big_i; n.lshift! 8; n).should eq(31604736)
+  end
+
+  it "exponentiates (mutating)" do
+    n = 2.to_big_i
+    n.pow!(1000)
+    n.to_s.should eq("10715086071862673209484250490600018105614048117055336074437503883703510511249361224931983788156958581275946729175531468251871452856923140435984577574698574803934567774824230985421074605062371141877954182153046474983581941267398767559165543946077062914571196477686542167660429831652624386837205668069376")
+  end
+
   it "does to_s in the given base" do
     a = BigInt.new("1234567890123456789")
     b = "1000100100010000100001111010001111101111010011000000100010101"
@@ -469,3 +607,4 @@ describe "BigInt Math" do
     Math.sqrt(BigInt.new("1" + "0"*48)).should eq(BigFloat.new("1" + "0"*24))
   end
 end
+

--- a/src/big/big_int.cr
+++ b/src/big/big_int.cr
@@ -201,12 +201,12 @@ struct BigInt < Int
   Number.expand_div [BigRational], BigRational
 
   def //(other : Int::Unsigned) : BigInt
-    check_division_by_zero other
+    check_division_by_zero(other)
     unsafe_floored_div(other)
   end
 
   def //(other : Int) : BigInt
-    check_division_by_zero other
+    check_division_by_zero(other)
 
     if other < 0
       (-self).unsafe_floored_div(-other)
@@ -216,8 +216,7 @@ struct BigInt < Int
   end
 
   def tdiv(other : Int) : BigInt
-    check_division_by_zero other
-
+    check_division_by_zero(other)
     unsafe_truncated_div(other)
   end
 
@@ -250,7 +249,7 @@ struct BigInt < Int
   end
 
   def %(other : Int) : BigInt
-    check_division_by_zero other
+    check_division_by_zero(other)
 
     if other < 0
       -(-self).unsafe_floored_mod(-other)
@@ -260,7 +259,7 @@ struct BigInt < Int
   end
 
   def remainder(other : Int) : BigInt
-    check_division_by_zero other
+    check_division_by_zero(other)
 
     unsafe_truncated_mod(other)
   end
@@ -401,6 +400,236 @@ struct BigInt < Int
 
   def bit_length : Int32
     LibGMP.sizeinbase(self, 2).to_i
+  end
+
+  # Mutating +
+  def add!(other : BigInt) : BigInt
+    LibGMP.add(mpz, self, other)
+    self
+  end
+
+  # Mutating +
+  def add!(other : Int) : BigInt
+    if other < 0
+      sub!(other.abs)
+    elsif other <= LibGMP::ULong::MAX
+      LibGMP.add_ui(mpz, self, other)
+      self
+    else
+      add!(other.to_big_i)
+    end
+  end
+
+  # Mutating -
+  def sub!(other : BigInt) : BigInt
+    LibGMP.sub(mpz, self, other)
+    self
+  end
+
+  # Mutating -
+  def sub!(other : Int) : BigInt
+    if other < 0
+      add!(other.abs)
+    elsif other <= LibGMP::ULong::MAX
+      LibGMP.sub_ui(mpz, self, other)
+      self
+    else
+      sub!(other.to_big_i)
+    end
+  end
+
+  def abs! : BigInt
+    LibGMP.abs(mpz, self)
+    self
+  end
+
+  # Mutating unary -
+  def neg! : BigInt
+    LibGMP.neg(mpz, self)
+    self
+  end
+
+  def factorial! : BigInt
+    if self < 0
+      raise ArgumentError.new("Factorial not defined for negative values")
+    elsif self > LibGMP::ULong::MAX
+      raise ArgumentError.new("Factorial not supported for numbers bigger than 2^64")
+    end
+    LibGMP.fac_ui(mpz, self)
+    self
+  end
+
+  # Mutating *
+  def mul!(other : BigInt) : BigInt
+    LibGMP.mul(mpz, self, other)
+    self
+  end
+
+  # Mutating *
+  def mul!(other : LibGMP::IntPrimitiveSigned) : BigInt
+    LibGMP.mul_si(mpz, self, other)
+    self
+  end
+
+  # Mutating *
+  def mul!(other : LibGMP::IntPrimitiveUnsigned) : BigInt
+    LibGMP.mul_ui(mpz, self, other)
+    self
+  end
+
+  # Mutating *
+  def mul!(other : Int) : BigInt
+    mul!(other.to_big_i)
+  end
+
+  def fdiv!(other : Int::Unsigned) : BigInt
+    check_division_by_zero(other)
+    unsafe_floored_div!(other)
+  end
+
+  def fdiv!(other : Int) : BigInt
+    check_division_by_zero(other)
+
+    if other < 0
+      neg!.unsafe_floored_div!(-other)
+    else
+      unsafe_floored_div!(other)
+    end
+  end
+
+  def tdiv!(other : Int) : BigInt
+    check_division_by_zero(other)
+    unsafe_truncated_div!(other)
+  end
+
+  def unsafe_floored_div!(other : BigInt) : BigInt
+    LibGMP.fdiv_q(mpz, self, other)
+    self
+  end
+
+  def unsafe_floored_div!(other : Int) : BigInt
+    if LibGMP::ULong == UInt32 && (other < Int32::MIN || other > UInt32::MAX)
+      unsafe_floored_div!(other.to_big_i)
+    elsif other < 0
+      LibGMP.fdiv_q_ui(mpz, neg!, other.abs)
+    else
+      LibGMP.fdiv_q_ui(mpz, self, other)
+    end
+
+    self
+  end
+
+  def unsafe_truncated_div!(other : BigInt) : BigInt
+    LibGMP.tdiv_q(mpz, self, other)
+    self
+  end
+
+  def unsafe_truncated_div!(other : Int) : BigInt
+    if LibGMP::ULong == UInt32 && (other < Int32::MIN || other > UInt32::MAX)
+      unsafe_truncated_div!(other.to_big_i)
+    elsif other < 0
+      LibGMP.tdiv_q_ui(mpz, neg!, other.abs)
+    else
+      LibGMP.tdiv_q_ui(mpz, self, other)
+    end
+
+    self
+  end
+
+  # Mutating %
+  def mod!(other : Int) : BigInt
+    check_division_by_zero(other)
+
+    if other < 0
+      neg!
+      unsafe_floored_mod!(-other)
+      neg!
+    else
+      unsafe_floored_mod!(other)
+    end
+  end
+
+  def remainder!(other : Int) : BigInt
+    check_division_by_zero(other)
+    unsafe_truncated_mod!(other)
+  end
+
+  def unsafe_floored_mod!(other : BigInt) : BigInt
+    LibGMP.fdiv_r(mpz, self, other)
+    self
+  end
+
+  def unsafe_floored_mod!(other : Int) : BigInt
+    if other < LibGMP::Long::MIN || other > LibGMP::ULong::MAX
+      unsafe_floored_mod!(other.to_big_i)
+    elsif other < 0
+      LibGMP.fdiv_r_ui(mpz, self, other.abs)
+      neg!
+    else
+      LibGMP.fdiv_r_ui(mpz, self, other)
+    end
+
+    self
+  end
+
+  def unsafe_truncated_mod!(other : BigInt) : BigInt
+    LibGMP.tdiv_r(mpz, self, other)
+    self
+  end
+
+  def unsafe_truncated_mod!(other : LibGMP::IntPrimitive) : BigInt
+    LibGMP.tdiv_r_ui(mpz, self, other.abs)
+    self
+  end
+
+  def unsafe_truncated_mod!(other : Int) : BigInt
+    LibGMP.tdiv_r_ui(mpz, self, other.abs.to_big_i)
+    self
+  end
+
+  # Mutating ~
+  def com! : BigInt
+    LibGMP.com(mpz, self)
+    self
+  end
+
+  # Mutating &
+  def and!(other : Int) : BigInt
+    LibGMP.and(mpz, self, other.to_big_i)
+    self
+  end
+
+  # Mutating |
+  def or!(other : Int) : BigInt
+    LibGMP.ior(mpz, self, other.to_big_i)
+    self
+  end
+
+  # Mutating ^
+  def xor!(other : Int) : BigInt
+    LibGMP.xor(mpz, self, other.to_big_i)
+    self
+  end
+
+  # Mutating >>
+  def rshift!(other : Int) : BigInt
+    LibGMP.fdiv_q_2exp(mpz, self, other)
+    self
+  end
+
+  # Mutating <<
+  def lshift!(other : Int) : BigInt
+    LibGMP.mul_2exp(mpz, self, other)
+    self
+  end
+
+  # Mutating **
+  def pow!(other : Int) : BigInt
+    if other < 0
+      raise ArgumentError.new("Negative exponent isn't supported")
+    end
+    LibGMP.pow_ui(mpz, self, other)
+    self
   end
 
   # TODO: improve this
@@ -785,3 +1014,4 @@ struct Crystal::Hasher
     end
   end
 end
+


### PR DESCRIPTION
As discussed [here](https://forum.crystal-lang.org/t/bigint-performance/2616/2).

This adds mutating versions of:

- unary `-` -> `neg!`
- `-` -> `sub!`
- `+` -> `add!`
- `*` -> `mul!`
- `abs` -> `abs!`
- `factorial` -> `factorial!`
- `**` -> `pow!`
- `fdiv` -> `fdiv!`
- `tdiv` -> `tdiv!`
- `unsafe_floored_div` -> `unsafe_floored_div!`
- `unsafe_truncated_div` -> `unsafe_truncated_div!`
- `%` -> `mod!`
- `remainder` -> `remainder!`
- `unsafe_floored_mod` -> `unsafe_floored_mod!`
- `unsafe_truncated_mod` -> `unsafe_truncated_mod!`
- unary `~` -> `com!`
- `&` -> `and!`
- `|` -> `or!`
- `^` -> `xor!`
- `>>` -> `rshift!`
- `<<` -> `lshift!`