### PR TITLE
Support linking to section headings in same tab

### DIFF
--- a/src/compiler/crystal/tools/doc/markdown/doc_renderer.cr
+++ b/src/compiler/crystal/tools/doc/markdown/doc_renderer.cr
@@ -139,7 +139,15 @@ class Crystal::Doc::Markdown::DocRenderer < Crystal::Doc::Markdown::HTMLRenderer
   def begin_link(url)
     @io << %(<a href=")
     @io << url
-    @io << %(" target="_blank">)
+    @io << '"'
+
+    # Don't open anchor links in new tab.
+    unless url.starts_with? '#'
+      @io << %( target="_blank")
+    end
+
+    @io << '>'
+
     @inside_link = true
   end
 

--- a/src/compiler/crystal/tools/doc/markdown/doc_renderer.cr
+++ b/src/compiler/crystal/tools/doc/markdown/doc_renderer.cr
@@ -139,14 +139,7 @@ class Crystal::Doc::Markdown::DocRenderer < Crystal::Doc::Markdown::HTMLRenderer
   def begin_link(url)
     @io << %(<a href=")
     @io << url
-    @io << '"'
-
-    # Don't open anchor links in new tab.
-    unless url.starts_with? '#'
-      @io << %( target="_blank")
-    end
-
-    @io << '>'
+    @io << %(">)
 
     @inside_link = true
   end

--- a/src/compiler/crystal/tools/doc/markdown/parser.cr
+++ b/src/compiler/crystal/tools/doc/markdown/parser.cr
@@ -391,8 +391,7 @@ class Crystal::Doc::Markdown::Parser
         end
       when '['
         unless in_link
-          link = check_link str, (pos + 1), bytesize
-          if link
+          if link = check_link str, (pos + 1), bytesize
             @renderer.text line.byte_slice(cursor, pos - cursor)
             cursor = pos + 1
             @renderer.begin_link link


### PR DESCRIPTION
Allows doing like:

```md
# # Main Heading
# 
# Some text
# 
# ## Sub Heading
#
# [Back to top](#main-heading)
```

The `Back to top` link will now take you to the `Main Heading` heading in same same tab.  Old behavior was opening that section in a new tab.  Links to sections in other files, or external links, will still open a new tab.