### PR TITLE
Add OpenSSL::SSL::Context#security_level

### DIFF
--- a/spec/std/openssl/ssl/context_spec.cr
+++ b/spec/std/openssl/ssl/context_spec.cr
@@ -139,6 +139,13 @@ describe OpenSSL::SSL::Context do
     end
   end
 
+  it "changes security level" do
+    context = OpenSSL::SSL::Context::Client.new
+    level = context.security_level
+    context.security_level = level + 1
+    context.security_level.should eq(level + 1)
+  end
+
   it "adds temporary ecdh curve (P-256)" do
     context = OpenSSL::SSL::Context::Client.new
     context.set_tmp_ecdh_key

--- a/spec/std/openssl/ssl/context_spec.cr
+++ b/spec/std/openssl/ssl/context_spec.cr
@@ -117,13 +117,7 @@ describe OpenSSL::SSL::Context do
     it "sets cipher_suites" do
       cipher_suites = OpenSSL::SSL::Context::CIPHER_SUITES_MODERN
       context = OpenSSL::SSL::Context::Client.new
-      {% if compare_versions(LibSSL::OPENSSL_VERSION, "1.1.0") >= 0 %}
-        (context.cipher_suites = cipher_suites).should eq(cipher_suites)
-      {% else %}
-        expect_raises(Exception, "SSL_CTX_set_ciphersuites not supported") do
-          (context.cipher_suites = cipher_suites).should eq(cipher_suites)
-        end
-      {% end %}
+      (context.cipher_suites = cipher_suites).should eq(cipher_suites)
     end
 
     it "sets modern ciphers" do

--- a/src/openssl/lib_ssl.cr
+++ b/src/openssl/lib_ssl.cr
@@ -241,6 +241,11 @@ lib LibSSL
     fun ssl_ctx_get0_param = SSL_CTX_get0_param(ctx : SSLContext) : X509VerifyParam
     fun ssl_ctx_set1_param = SSL_CTX_set1_param(ctx : SSLContext, param : X509VerifyParam) : Int
   {% end %}
+
+  {% if compare_versions(OPENSSL_VERSION, "1.1.0") >= 0 %}
+    fun ssl_ctx_set_security_level = SSL_CTX_set_security_level(ctx : SSLContext, level : Int) : Void
+    fun ssl_ctx_get_security_level = SSL_CTX_get_security_level(ctx : SSLContext) : Int
+  {% end %}
 end
 
 {% unless compare_versions(LibSSL::OPENSSL_VERSION, "1.1.0") >= 0 %}

--- a/src/openssl/ssl/context.cr
+++ b/src/openssl/ssl/context.cr
@@ -1,4 +1,5 @@
 require "uri/punycode"
+require "log"
 
 # An `SSL::Context` represents a generic secure socket protocol configuration.
 #
@@ -255,7 +256,8 @@ abstract class OpenSSL::SSL::Context
 
   # Specify a list of TLS ciphers to use or discard.
   #
-  # This affects only TLSv1.2 and below.
+  # This affects only TLSv1.2 and below. See `#security_level=` for some
+  # sensible system configuration.
   def ciphers=(ciphers : String)
     ret = LibSSL.ssl_ctx_set_cipher_list(@handle, ciphers)
     raise OpenSSL::Error.new("SSL_CTX_set_cipher_list") if ret == 0
@@ -263,18 +265,21 @@ abstract class OpenSSL::SSL::Context
   end
 
   # Specify a list of TLS cipher suites to use or discard.
+  #
+  # See `#security_level=` for some sensible system configuration.
   def cipher_suites=(cipher_suites : String)
     {% if compare_versions(LibSSL::OPENSSL_VERSION, "1.1.0") >= 0 %}
       ret = LibSSL.ssl_ctx_set_ciphersuites(@handle, cipher_suites)
       raise OpenSSL::Error.new("SSL_CTX_set_ciphersuites") if ret == 0
-      cipher_suites
     {% else %}
-      raise "SSL_CTX_set_ciphersuites not supported"
+      Log.warn { "SSL_CTX_set_ciphersuites not supported" }
     {% end %}
+    cipher_suites
   end
 
   # Sets the current ciphers and ciphers suites to **modern** compatibility level as per Mozilla
-  # recommendations. See `CIPHERS_MODERN` and `CIPHER_SUITES_MODERN`.
+  # recommendations. See `CIPHERS_MODERN` and `CIPHER_SUITES_MODERN`. See `#security_level=` for some
+  # sensible system configuration.
   def set_modern_ciphers
     {% if compare_versions(LibSSL::OPENSSL_VERSION, "1.1.0") >= 0 %}
       self.cipher_suites = CIPHER_SUITES_MODERN
@@ -284,7 +289,8 @@ abstract class OpenSSL::SSL::Context
   end
 
   # Sets the current ciphers and ciphers suites to **intermediate** compatibility level as per Mozilla
-  # recommendations. See `CIPHERS_INTERMEDIATE` and `CIPHER_SUITES_INTERMEDIATE`.
+  # recommendations. See `CIPHERS_INTERMEDIATE` and `CIPHER_SUITES_INTERMEDIATE`. See `#security_level=` for some
+  # sensible system configuration.
   def set_intermediate_ciphers
     {% if compare_versions(LibSSL::OPENSSL_VERSION, "1.1.0") >= 0 %}
       self.cipher_suites = CIPHER_SUITES_INTERMEDIATE
@@ -294,7 +300,8 @@ abstract class OpenSSL::SSL::Context
   end
 
   # Sets the current ciphers and ciphers suites to **old** compatibility level as per Mozilla
-  # recommendations. See `CIPHERS_OLD` and `CIPHER_SUITES_OLD`.
+  # recommendations. See `CIPHERS_OLD` and `CIPHER_SUITES_OLD`. See `#security_level=` for some
+  # sensible system configuration.
   def set_old_ciphers
     {% if compare_versions(LibSSL::OPENSSL_VERSION, "1.1.0") >= 0 %}
       self.cipher_suites = CIPHER_SUITES_OLD
@@ -308,18 +315,23 @@ abstract class OpenSSL::SSL::Context
     {% if compare_versions(LibSSL::OPENSSL_VERSION, "1.1.0") >= 0 %}
       LibSSL.ssl_ctx_get_security_level(@handle)
     {% else %}
-      raise "SSL_CTX_get_security_level not supported"
+      Log.warn { "SSL_CTX_get_security_level not supported" }
+      0
     {% end %}
   end
 
-  # Sets the security level used by this TLS context.
+  # Sets the security level used by this TLS context. The default system
+  # security level might disable some ciphers.
+  #
+  # * https://www.openssl.org/docs/man1.1.1/man3/SSL_CTX_set_security_level.html
+  # * https://wiki.debian.org/ContinuousIntegration/TriagingTips/openssl-1.1.1
   def security_level=(value : Int32)
     {% if compare_versions(LibSSL::OPENSSL_VERSION, "1.1.0") >= 0 %}
       LibSSL.ssl_ctx_set_security_level(@handle, value)
-      value
     {% else %}
-      raise "SSL_CTX_set_security_level not supported"
+      Log.warn { "SSL_CTX_set_security_level not supported" }
     {% end %}
+    value
   end
 
   # Adds a temporary ECDH key curve to the TLS context. This is required to

--- a/src/openssl/ssl/context.cr
+++ b/src/openssl/ssl/context.cr
@@ -303,6 +303,25 @@ abstract class OpenSSL::SSL::Context
     {% end %}
   end
 
+  # Returns the security level used by this TLS context.
+  def security_level : Int32
+    {% if compare_versions(LibSSL::OPENSSL_VERSION, "1.1.0") >= 0 %}
+      LibSSL.ssl_ctx_get_security_level(@handle)
+    {% else %}
+      raise "SSL_CTX_get_security_level not supported"
+    {% end %}
+  end
+
+  # Sets the security level used by this TLS context.
+  def security_level=(value : Int32)
+    {% if compare_versions(LibSSL::OPENSSL_VERSION, "1.1.0") >= 0 %}
+      LibSSL.ssl_ctx_set_security_level(@handle, value)
+      value
+    {% else %}
+      raise "SSL_CTX_set_security_level not supported"
+    {% end %}
+  end
+
   # Adds a temporary ECDH key curve to the TLS context. This is required to
   # enable the EECDH cipher suites. By default the prime256 curve will be used.
   def set_tmp_ecdh_key(curve = LibCrypto::NID_X9_62_prime256v1)


### PR DESCRIPTION
On some up to date configurations the ciphers different ciphers lists will not accept tls 1.0 and tls 1.2 connections. 

This is because on some platforms the default security level is 2 instead of 1. 

This PR exposes `OpenSSL::SSL::Context#security_level` / `OpenSSL::SSL::Context#security_level=` so there is no need to change the global system setting.


Ref:
* https://www.openssl.org/docs/man1.1.1/man3/SSL_CTX_set_security_level.html
* https://wiki.debian.org/ContinuousIntegration/TriagingTips/openssl-1.1.1

cc: @carlhoerberg 