### PR TITLE
Compiler: correctly pass named arguments for previous_def and super

### DIFF
--- a/spec/compiler/codegen/previous_def_spec.cr
+++ b/spec/compiler/codegen/previous_def_spec.cr
@@ -51,4 +51,18 @@ describe "codegen: previous_def" do
       Foo.new.bar.call
       )).to_i.should eq(1)
   end
+
+  it "correctly passes named arguments" do
+    run(%(
+      def foo(x, *args, other = 1)
+        other
+      end
+
+      def foo(x, *args, other = 1)
+        previous_def
+      end
+
+      foo(1, 2, 3, other: 4)
+      )).to_i.should eq(4)
+  end
 end


### PR DESCRIPTION
Fixes https://forum.crystal-lang.org/t/i-may-have-found-a-bug-with-previous-def-but-not-sure/2624/2

The way the compiler handles `super` and `previous_def` without parentheses is by copying the current method's arguments to the call. So for example:

```crystal
def foo(x, y)
  previous_def
end
```

gets expanded to:

```crystal
def foo(x, y)
  previous_def(x, y)
end
```

The logic also took into account splats. This:

```crystal
def foo(x, *y)
  previous_def
end
```

was expanded to:

```crystal
def foo(x, *y)
  previous_def(x, *y)
end
```

However, arguments past the splat were passed as regular arguments. So this:

```crystal
def foo(x, *y, z)
  previous_def
end
```

was incorrectly expanded to:

```crystal
def foo(x, *y, z)
  previous_def(x, *y, z)
end
```

which wouldn't compile, unless `z` had a default value (it does in the bug report).

This PR changes the above expansion to be:

```crystal
def foo(x, *y, z)
  previous_def(x, *y, z: z)
end
```