### PR TITLE
Fix Socket to allow datagram over unix sockets

### DIFF
--- a/spec/std/socket/socket_spec.cr
+++ b/spec/std/socket/socket_spec.cr
@@ -1,4 +1,5 @@
 require "./spec_helper"
+require "../../support/tempfile"
 
 describe Socket do
   describe ".unix" do
@@ -73,6 +74,20 @@ describe Socket do
   ensure
     socket.try &.close
     server.try &.close
+  end
+
+  it "sends datagram over unix socket" do
+    with_tempfile("datagram_unix") do |path|
+      server = Socket.unix(Socket::Type::DGRAM)
+      server.bind Socket::UNIXAddress.new(path)
+
+      client = Socket.unix(Socket::Type::DGRAM)
+      client.connect Socket::UNIXAddress.new(path)
+      client.send "foo"
+
+      message, _ = server.receive
+      message.should eq "foo"
+    end
   end
 
   describe "#bind" do

--- a/src/socket.cr
+++ b/src/socket.cr
@@ -363,6 +363,11 @@ class Socket < IO
 
   protected def recvfrom(bytes)
     sockaddr = Pointer(LibC::SockaddrStorage).malloc.as(LibC::Sockaddr*)
+    # initialize sockaddr with the initialized family of the socket
+    copy = sockaddr.value
+    copy.sa_family = family
+    sockaddr.value = copy
+
     addrlen = LibC::SocklenT.new(sizeof(LibC::SockaddrStorage))
 
     bytes_read = evented_read(bytes, "Error receiving datagram") do |slice|


### PR DESCRIPTION
Fixes #9835.

Make `Socket#recvfrom` keep family. It seems that family needs to be initialized on unix sockets. I reach this by looking at the code in https://stackoverflow.com/questions/3324619/unix-domain-socket-using-datagram-communication-between-one-server-process-and

