### PR TITLE
BigInt: GCD with Bézout coefficients

### DIFF
--- a/spec/std/big/big_int_spec.cr
+++ b/spec/std/big/big_int_spec.cr
@@ -365,6 +365,10 @@ describe "BigInt" do
 
     (a_17).gcd(17).should be_a(Int::Unsigned)
     (a_17).lcm(17).should eq(a_17)
+
+    g, s, t = a.gcd_ext(b)
+    g.should eq(1)
+    (s*a + t*b).should eq(1)
   end
 
   it "can use Number::[]" do

--- a/src/big/big_int.cr
+++ b/src/big/big_int.cr
@@ -391,6 +391,17 @@ struct BigInt < Int
     result == 0 ? self : result
   end
 
+  # Computes `GCD(self,other)`, as well as its Bézout coefficients.
+  #
+  # ```
+  # g, s, t = 7.to_big_i.gcd_ext(2.to_big_i) # => {1, 1, -3}
+  # ```
+  def gcd_ext(other : BigInt) : {BigInt, BigInt, BigInt}
+    a = BigInt.new
+    b = BigInt.new
+    {BigInt.new { |mpz| LibGMP.gcd_ext(mpz, a, b, self, other) }, a, b}
+  end
+
   def lcm(other : BigInt) : BigInt
     BigInt.new { |mpz| LibGMP.lcm(mpz, self, other) }
   end

--- a/src/big/lib_gmp.cr
+++ b/src/big/lib_gmp.cr
@@ -114,6 +114,7 @@ lib LibGMP
 
   fun gcd = __gmpz_gcd(rop : MPZ*, op1 : MPZ*, op2 : MPZ*)
   fun gcd_ui = __gmpz_gcd_ui(rop : MPZ*, op1 : MPZ*, op2 : ULong) : ULong
+  fun gcd_ext = __gmpz_gcdext(rop : MPZ*, c1 : MPZ*, c2 : MPZ*, op1 : MPZ*, op2 : MPZ*)
   fun lcm = __gmpz_lcm(rop : MPZ*, op1 : MPZ*, op2 : MPZ*)
   fun lcm_ui = __gmpz_lcm_ui(rop : MPZ*, op1 : MPZ*, op2 : ULong)
 


### PR DESCRIPTION
Add `BigInt#gcd_ext` to the standard library.

This function returns the greatest common denominator `g` of two numbers `a` and `b`, as well as its Bézout coefficients `u` and `v` so that `au + bv = g`.