### PR TITLE
BigInt: add method to calculate modulo inverse

### DIFF
--- a/spec/std/big/big_int_spec.cr
+++ b/spec/std/big/big_int_spec.cr
@@ -367,6 +367,14 @@ describe "BigInt" do
     (a_17).lcm(17).should eq(a_17)
   end
 
+  it "calculates the modulo inverse" do
+    a = BigInt.new("48112959837082048697")
+    b = BigInt.new("12764787846358441471")
+    c = a.mod_invert(b)
+
+    (a*c % b).should eq(1)
+  end
+
   it "can use Number::[]" do
     a = BigInt[146, "3464", 97, "545"]
     b = [BigInt.new(146), BigInt.new(3464), BigInt.new(97), BigInt.new(545)]

--- a/src/big/big_int.cr
+++ b/src/big/big_int.cr
@@ -399,6 +399,15 @@ struct BigInt < Int
     BigInt.new { |mpz| LibGMP.lcm_ui(mpz, self, other.abs.to_u64) }
   end
 
+  # Return the multiplicative inverse of `self` modulo `other`.
+  #
+  # ```
+  # 7.to_big_i.mod_invert(4.to_big_i) # => 3
+  # ```
+  def mod_invert(other : BigInt) : BigInt
+    BigInt.new { |mpz| LibGMP.mod_invert(mpz, self, other) }
+  end
+
   def bit_length : Int32
     LibGMP.sizeinbase(self, 2).to_i
   end

--- a/src/big/lib_gmp.cr
+++ b/src/big/lib_gmp.cr
@@ -116,6 +116,7 @@ lib LibGMP
   fun gcd_ui = __gmpz_gcd_ui(rop : MPZ*, op1 : MPZ*, op2 : ULong) : ULong
   fun lcm = __gmpz_lcm(rop : MPZ*, op1 : MPZ*, op2 : MPZ*)
   fun lcm_ui = __gmpz_lcm_ui(rop : MPZ*, op1 : MPZ*, op2 : ULong)
+  fun mod_invert = __gmpz_invert(rop : MPZ*, op1 : MPZ*, op2 : MPZ*)
 
   # MPQ
   struct MPQ


### PR DESCRIPTION
Add `BigInt#mov_invert` to calculate the modulo inverse of a number.