### PR TITLE
Rework dwarf eager loading (follow up to #9792)

### DIFF
--- a/src/exception/call_stack.cr
+++ b/src/exception/call_stack.cr
@@ -217,10 +217,4 @@ struct Exception::CallStack
       end
     end
   end
-
-  {% if flag?(:debug) %}
-    # load dwarf on start up of the program when compiled with --debug
-    # this will make dwarf available on print_frame that is used on __crystal_sigfault_handler
-    load_dwarf
-  {% end %}
 end

--- a/src/exception/call_stack/dwarf.cr
+++ b/src/exception/call_stack/dwarf.cr
@@ -10,8 +10,14 @@ struct Exception::CallStack
   @@dwarf_line_numbers : Crystal::DWARF::LineNumbers?
   @@dwarf_function_names : Array(Tuple(LibC::SizeT, LibC::SizeT, String))?
 
+  # :nodoc:
+  def self.load_dwarf
+    load_dwarf_impl unless @@dwarf_loaded
+    @@dwarf_loaded = true
+  end
+
   protected def self.decode_line_number(pc)
-    load_dwarf unless @@dwarf_loaded
+    load_dwarf
     if ln = @@dwarf_line_numbers
       if row = ln.find(pc)
         path = "#{row.directory}/#{row.file}"
@@ -22,7 +28,7 @@ struct Exception::CallStack
   end
 
   protected def self.decode_function_name(pc)
-    load_dwarf unless @@dwarf_loaded
+    load_dwarf
     if fn = @@dwarf_function_names
       fn.each do |(low_pc, high_pc, function_name)|
         return function_name if low_pc <= pc <= high_pc

--- a/src/exception/call_stack/elf.cr
+++ b/src/exception/call_stack/elf.cr
@@ -2,7 +2,7 @@ require "crystal/elf"
 require "c/link"
 
 struct Exception::CallStack
-  protected def self.load_dwarf
+  protected def self.load_dwarf_impl
     phdr_callback = LibC::DlPhdrCallback.new do |info, size, data|
       # The first entry is the header for the current program
       read_dwarf_sections(info.value.addr)
@@ -10,7 +10,6 @@ struct Exception::CallStack
     end
 
     LibC.dl_iterate_phdr(phdr_callback, nil)
-    @@dwarf_loaded = true
   end
 
   protected def self.read_dwarf_sections(base_address = 0)

--- a/src/exception/call_stack/mach_o.cr
+++ b/src/exception/call_stack/mach_o.cr
@@ -9,9 +9,8 @@ end
 struct Exception::CallStack
   @@image_slide : LibC::Long?
 
-  protected def self.load_dwarf
+  protected def self.load_dwarf_impl
     read_dwarf_sections
-    @@dwarf_loaded = true
   end
 
   protected def self.read_dwarf_sections

--- a/src/kernel.cr
+++ b/src/kernel.cr
@@ -527,6 +527,12 @@ end
   LibExt.setup_sigfault_handler
 {% end %}
 
+{% if flag?(:debug) %}
+  # load dwarf on start up of the program when compiled with --debug
+  # this will make dwarf available on print_frame that is used on __crystal_sigfault_handler
+  Exception::CallStack.load_dwarf
+{% end %}
+
 {% if flag?(:preview_mt) %}
   Crystal::Scheduler.init_workers
 {% end %}

--- a/src/kernel.cr
+++ b/src/kernel.cr
@@ -527,7 +527,7 @@ end
   LibExt.setup_sigfault_handler
 {% end %}
 
-{% if flag?(:debug) %}
+{% if flag?(:debug) && !flag?(:win32) %}
   # load dwarf on start up of the program when compiled with --debug
   # this will make dwarf available on print_frame that is used on __crystal_sigfault_handler
   Exception::CallStack.load_dwarf


### PR DESCRIPTION
The initialization included in #9792 causes the spec in preview_mt to hang. I was able to reproduce this locally with small programs, but not in a consistent manner.

I moved the `load_dwarf` call to kernel, which is a better place for it to be. That seems enough to avoid the problem introduced in #9792.

Since `load_dwarf` needed to be public (yet :nodoc:) I refactored a bit the code to use `@@dwarf_loaded` only in `dwarf.cr` and not in `elf|mach_o`.cr