### PR TITLE
Specs: add global timeout to individual specs on mt

### DIFF
--- a/spec/std_spec.cr
+++ b/spec/std_spec.cr
@@ -1,5 +1,6 @@
 require "spec"
 {% unless flag?(:win32) %}
+  require "./support/mt_abort_timeout"
   require "./std/**"
 {% else %}
   # This list gives an overview over which specs are currently working on win32.

--- a/spec/support/mt_abort_timeout.cr
+++ b/spec/support/mt_abort_timeout.cr
@@ -1,0 +1,26 @@
+{% skip_file unless flag?(:preview_mt) %}
+
+private SPEC_TIMEOUT = 15.seconds
+
+Spec.around_each do |example|
+  done = Channel(Exception?).new
+
+  spawn(same_thread: true) do
+    begin
+      example.run
+    rescue e
+      done.send(e)
+    else
+      done.send(nil)
+    end
+  end
+
+  select
+  when res = done.receive
+    raise res if res
+  when timeout(SPEC_TIMEOUT)
+    _it = example.example
+    ex = Spec::AssertionFailed.new("spec timeout", _it.file, _it.line)
+    _it.parent.report(:fail, _it.description, _it.file, _it.line, SPEC_TIMEOUT, ex)
+  end
+end


### PR DESCRIPTION
Now and then the preview_mt specs fails.
Initially they used to run in verbose mode to get a notion at which point that happens.

I figure we can add some timeout detection to detect specs that will hang due to events that will not happen. Tight loops will not be aborted, but those should be present in single-thread also.