### PR TITLE
Fix Command#report_warnings to gracefully handle missing Compiler#program

### DIFF
--- a/src/compiler/crystal/semantic/warnings.cr
+++ b/src/compiler/crystal/semantic/warnings.cr
@@ -169,7 +169,8 @@ module Crystal
       compiler = @compiler
       return unless compiler
 
-      program = compiler.program
+      program = compiler.program?
+      return unless program
       return if program.warning_failures.empty?
 
       program.warning_failures.each do |message|


### PR DESCRIPTION
If the compiler was not setup correctly and `program` is missing, there are no warnings to show and the method should just return gracefully instead of causing a NilAssertion error.

/cc https://github.com/crystal-lang/crystal/issues/9789#issuecomment-719833911