### PR TITLE
Fix docs generator when git executable is missing

### DIFF
--- a/spec/compiler/crystal/tools/doc/project_info_spec.cr
+++ b/spec/compiler/crystal/tools/doc/project_info_spec.cr
@@ -33,7 +33,17 @@ describe Crystal::Doc::ProjectInfo do
         File.write("shard.yml", "name: foo\nversion: 1.0")
       end
 
-      it "no git" do
+      it "git missing" do
+        ProjectInfo.git_executable = "git-missing-executable"
+
+        assert_with_defaults(ProjectInfo.new(nil, nil), ProjectInfo.new("foo", "1.0", refname: nil))
+        assert_with_defaults(ProjectInfo.new("bar", "2.0"), ProjectInfo.new("bar", "2.0", refname: nil))
+        assert_with_defaults(ProjectInfo.new(nil, "2.0"), ProjectInfo.new("foo", "2.0", refname: nil))
+      ensure
+        ProjectInfo.git_executable = "git"
+      end
+
+      it "not in a git folder" do
         assert_with_defaults(ProjectInfo.new(nil, nil), ProjectInfo.new("foo", "1.0", refname: nil))
         assert_with_defaults(ProjectInfo.new("bar", "2.0"), ProjectInfo.new("bar", "2.0", refname: nil))
         assert_with_defaults(ProjectInfo.new(nil, "2.0"), ProjectInfo.new("foo", "2.0", refname: nil))

--- a/src/compiler/crystal/tools/doc/project_info.cr
+++ b/src/compiler/crystal/tools/doc/project_info.cr
@@ -121,7 +121,7 @@ module Crystal::Doc
       status = Process.run(git_executable, args, output: output)
       yield unless status.success?
       status
-    rescue File::Error | IO::Error
+    rescue IO::Error
       yield
     end
 


### PR DESCRIPTION
The code for executing the `git` program didn't take into account that `Process.run` raises if the executable can't be found. This is now fixed. I also refactored the code for capturing the program output (DRY).

Fixes #9789