### PR TITLE
Fix semantic version

### DIFF
--- a/spec/std/semantic_version_spec.cr
+++ b/spec/std/semantic_version_spec.cr
@@ -27,11 +27,11 @@ describe SemanticVersion do
   end
 
   it "compares build equivalence" do
-    sversions = [
-      "1.2.3+1",
-      "1.2.3+999",
-      "1.2.3+a",
-    ]
+    sversions = %w(
+      1.2.3+1
+      1.2.3+999
+      1.2.3+a
+    )
     versions = sversions.map { |s| SemanticVersion.parse(s) }.to_a
 
     versions.each_with_index do |v, i|
@@ -45,11 +45,11 @@ describe SemanticVersion do
 
   describe SemanticVersion::Prerelease do
     it "compares <" do
-      sprereleases = %w[
+      sprereleases = %w(
         alpha.1
         beta.1
         beta.2
-      ]
+      )
       prereleases = sprereleases.map { |s|
         SemanticVersion::Prerelease.parse(s)
       }

--- a/spec/std/semantic_version_spec.cr
+++ b/spec/std/semantic_version_spec.cr
@@ -31,6 +31,8 @@ describe SemanticVersion do
       1.2.3+1
       1.2.3+999
       1.2.3+a
+      1.2.3+a.b
+      1.2.3+a.b.c
     )
     versions = sversions.map { |s| SemanticVersion.parse(s) }.to_a
 
@@ -40,6 +42,49 @@ describe SemanticVersion do
 
     versions.each_cons(2) do |pair|
       pair[0].should eq(pair[1])
+    end
+  end
+
+  it "does not accept bad versions" do
+    sversions = %w(
+      1
+      1.2
+      1.2.3-0123
+      1.2.3-0123.0123
+      0.0.4--.
+      1.1.2+.123
+      +invalid
+      -invalid
+      -invalid+invalid
+      -invalid.01
+      alpha
+      alpha.beta
+      alpha.beta.1
+      alpha.1
+      alpha+beta
+      alpha_beta
+      alpha.
+      alpha..
+      1.0.0-alpha_beta
+      -alpha.
+      1.0.0-alpha..
+      1.0.0-alpha..1
+      1.0.0-alpha...1
+      01.1.1
+      1.01.1
+      1.1.01
+      1.2.3.DEV
+      1.2-SNAPSHOT
+      1.2.31.2.3----RC-SNAPSHOT.12.09.1--..12+788
+      1.2-RC-SNAPSHOT
+      -1.0.3-gamma+b7718
+      +justmeta
+      9.8.7+meta+meta
+      9.8.7-whatever+meta+meta
+      99999999999999999999999.999999999999999999.99999999999999999----RC-SNAPSHOT.12.09.1--------------------------------..12
+    )
+    sversions.each do |s|
+      expect_raises(ArgumentError) { SemanticVersion.parse(s) }
     end
   end
 

--- a/src/semantic_version.cr
+++ b/src/semantic_version.cr
@@ -30,12 +30,14 @@ struct SemanticVersion
   #
   # Raises `ArgumentError` if *str* is not a semantic version.
   def self.parse(str : String) : self
-    if m = str.match /^(\d+)\.(\d+)\.(\d+)(-([\w\.]+))?(\+(\w+))??$/
+    if m = str.match /^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)
+                      (?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?
+                      (?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?$/x
       major = m[1].to_i
       minor = m[2].to_i
       patch = m[3].to_i
-      prerelease = m[5]?
-      build = m[7]?
+      prerelease = m[4]?
+      build = m[5]?
       new major, minor, patch, prerelease, build
     else
       raise ArgumentError.new("Not a semantic version: #{str.inspect}")


### PR DESCRIPTION
The regexp used in the SemanticVersion class were accepting bad versions like `01.2.3` and `1.2.3-hey.` and rejecting good versions like `1.2.3+hey.ho`.

I just picked the regexp provided by https://semver.org/ itself and added few tests.