### PR TITLE
Compiler: remove the special logic of union of pointer and nil

### DIFF
--- a/spec/compiler/semantic/lib_spec.cr
+++ b/spec/compiler/semantic/lib_spec.cr
@@ -422,15 +422,16 @@ describe "Semantic: lib" do
       "lib fun call is not supported in dispatch"
   end
 
-  it "allows passing nil or pointer to arg expecting pointer" do
-    assert_type(%(
+  it "disallows passing nil or pointer to arg expecting pointer" do
+    assert_error %(
       lib Foo
         fun foo(x : Int32*) : Int64
       end
 
       a = 1 == 1 ? nil : Pointer(Int32).malloc(1_u64)
       Foo.foo(a)
-      )) { int64 }
+      ),
+      "argument 'x' of 'Foo#foo' must be Pointer(Int32), not (Pointer(Int32) | Nil)"
   end
 
   it "correctly attached link flags if there's a macro if" do

--- a/spec/compiler/semantic/pointer_spec.cr
+++ b/spec/compiler/semantic/pointer_spec.cr
@@ -55,22 +55,6 @@ describe "Semantic: pointer" do
     assert_type("Pointer(Int32).new(123_u64)") { pointer_of(int32) }
   end
 
-  it "types nil or pointer type" do
-    result = assert_type("1 == 1 ? nil : Pointer(Int32).new(0_u64)") { nilable pointer_of(int32) }
-    result.node.type.should be_a(NilablePointerType)
-  end
-
-  it "types nil or pointer type with typedef" do
-    result = assert_type(%(
-      lib LibC
-        type T = Void*
-        fun foo : T?
-      end
-      LibC.foo
-      )) { nilable types["LibC"].types["T"] }
-    result.node.type.should be_a(NilablePointerType)
-  end
-
   it "types pointer of constant" do
     result = assert_type("
       FOO = 1

--- a/src/compiler/crystal/codegen/cast.cr
+++ b/src/compiler/crystal/codegen/cast.cr
@@ -232,18 +232,6 @@ class Crystal::CodeGenVisitor
     assign_distinct target_pointer, target_type, value_type.typedef, value
   end
 
-  def assign_distinct(target_pointer, target_type : NilablePointerType, value_type : NilType, value)
-    store llvm_type(target_type).null, target_pointer
-  end
-
-  def assign_distinct(target_pointer, target_type : NilablePointerType, value_type : PointerInstanceType, value)
-    store value, target_pointer
-  end
-
-  def assign_distinct(target_pointer, target_type : NilablePointerType, value_type : TypeDefType, value)
-    assign_distinct target_pointer, target_type, value_type.typedef, value
-  end
-
   def assign_distinct(target_pointer, target_type : TupleInstanceType, value_type : TupleInstanceType, value)
     index = 0
     target_type.tuple_types.zip(value_type.tuple_types) do |target_tuple_type, value_tuple_type|
@@ -351,17 +339,9 @@ class Crystal::CodeGenVisitor
     downcast_distinct value, to_type.typedef, from_type
   end
 
-  def downcast_distinct(value, to_type : PointerInstanceType, from_type : NilablePointerType)
-    value
-  end
-
   def downcast_distinct(value, to_type : PointerInstanceType, from_type : PointerInstanceType)
     # cast of a pointer being cast to Void*
     bit_cast value, llvm_context.void_pointer
-  end
-
-  def downcast_distinct(value, to_type : TypeDefType, from_type : NilablePointerType)
-    downcast_distinct value, to_type.typedef, from_type
   end
 
   def downcast_distinct(value, to_type : ReferenceUnionType, from_type : ReferenceUnionType)
@@ -582,18 +562,6 @@ class Crystal::CodeGenVisitor
   end
 
   def upcast_distinct(value, to_type : NilableProcType, from_type : TypeDefType)
-    upcast_distinct value, to_type, from_type.typedef
-  end
-
-  def upcast_distinct(value, to_type : NilablePointerType, from_type : NilType)
-    llvm_type(to_type).null
-  end
-
-  def upcast_distinct(value, to_type : NilablePointerType, from_type : PointerInstanceType)
-    value
-  end
-
-  def upcast_distinct(value, to_type : NilablePointerType, from_type : TypeDefType)
     upcast_distinct value, to_type, from_type.typedef
   end
 

--- a/src/compiler/crystal/codegen/cond.cr
+++ b/src/compiler/crystal/codegen/cond.cr
@@ -17,7 +17,7 @@ class Crystal::CodeGenVisitor
     codegen_cond type.typedef
   end
 
-  private def codegen_cond_impl(type : NilableType | NilableReferenceUnionType | PointerInstanceType | NilablePointerType)
+  private def codegen_cond_impl(type : NilableType | NilableReferenceUnionType | PointerInstanceType)
     not_null_pointer? @last
   end
 

--- a/src/compiler/crystal/codegen/debug.cr
+++ b/src/compiler/crystal/codegen/debug.cr
@@ -206,10 +206,6 @@ module Crystal
       get_debug_type(type.not_nil_type, original_type)
     end
 
-    def create_debug_type(type : NilablePointerType, original_type : Type)
-      get_debug_type(type.pointer_type, original_type)
-    end
-
     def create_debug_type(type : StaticArrayInstanceType, original_type : Type)
       debug_type = get_debug_type(type.element_type)
       return unless debug_type

--- a/src/compiler/crystal/codegen/llvm_typer.cr
+++ b/src/compiler/crystal/codegen/llvm_typer.cr
@@ -233,10 +233,6 @@ module Crystal
       proc_type
     end
 
-    private def create_llvm_type(type : NilablePointerType, wants_size)
-      llvm_type(type.pointer_type, wants_size)
-    end
-
     private def create_llvm_type(type : TypeDefType, wants_size)
       llvm_type(type.typedef, wants_size)
     end

--- a/src/compiler/crystal/codegen/type_id.cr
+++ b/src/compiler/crystal/codegen/type_id.cr
@@ -39,10 +39,6 @@ class Crystal::CodeGenVisitor
     phi llvm_context.int32, phi_table
   end
 
-  private def type_id_impl(value, type : NilablePointerType)
-    builder.select null_pointer?(value), type_id(@program.nil), type_id(type.pointer_type)
-  end
-
   private def type_id_impl(value, type : NilableProcType)
     fun_ptr = extract_value value, 0
     builder.select null_pointer?(fun_ptr), type_id(@program.nil), type_id(type.proc_type)

--- a/src/compiler/crystal/program.cr
+++ b/src/compiler/crystal/program.cr
@@ -374,8 +374,6 @@ module Crystal
             untyped_type = other_type.remove_typedef
             if untyped_type.proc?
               return NilableProcType.new(self, other_type)
-            elsif untyped_type.is_a?(PointerInstanceType)
-              return NilablePointerType.new(self, other_type)
             end
           end
         end

--- a/src/compiler/crystal/semantic/lib.cr
+++ b/src/compiler/crystal/semantic/lib.cr
@@ -287,8 +287,6 @@ class Crystal::Type
       self.not_nil_type.allowed_in_lib?
     when NilableProcType
       self.proc_type.allowed_in_lib?
-    when NilablePointerType
-      self.pointer_type.allowed_in_lib?
     when ProcInstanceType
       self.arg_types.all?(&.allowed_in_lib?) && (self.return_type.allowed_in_lib? || self.return_type.nil_type?)
     when StaticArrayInstanceType
@@ -310,9 +308,6 @@ class Crystal::Type
     when ProcInstanceType
       # fun will be cast to return nil
       expected_type.is_a?(ProcInstanceType) && expected_type.return_type == program.nil && expected_type.arg_types == self.arg_types
-    when NilablePointerType
-      # nilable pointer is just a pointer
-      self.pointer_type == expected_type
     when PointerInstanceType
       # any pointer matches a void*
       expected_type.is_a?(PointerInstanceType) && expected_type.element_type.void?

--- a/src/compiler/crystal/types.cr
+++ b/src/compiler/crystal/types.cr
@@ -3097,17 +3097,6 @@ module Crystal
     end
   end
 
-  # A union type of nil and a single pointer type.
-  class NilablePointerType < UnionType
-    def initialize(program, pointer_type)
-      super(program, [program.nil, pointer_type] of Type)
-    end
-
-    def pointer_type
-      @union_types.last.remove_typedef.as(PointerInstanceType)
-    end
-  end
-
   # A union type that doesn't match any of the previous definitions,
   # so it can contain Nil with primitive types, or Reference types with
   # primitives types.

--- a/src/llvm/lib_llvm.cr
+++ b/src/llvm/lib_llvm.cr
@@ -237,8 +237,8 @@ lib LibLLVM
   fun start_multithreaded = LLVMStartMultithreaded : Int32
   fun stop_multithreaded = LLVMStopMultithreaded
   fun is_multithreaded = LLVMIsMultithreaded : Int32
-  fun get_first_function = LLVMGetFirstFunction(m : ModuleRef) : ValueRef?
-  fun get_next_function = LLVMGetNextFunction(f : ValueRef) : ValueRef?
+  fun get_first_function = LLVMGetFirstFunction(m : ModuleRef) : ValueRef
+  fun get_next_function = LLVMGetNextFunction(f : ValueRef) : ValueRef
   fun get_next_basic_block = LLVMGetNextBasicBlock(bb : BasicBlockRef) : BasicBlockRef
   fun get_next_instruction = LLVMGetNextInstruction(inst : ValueRef) : ValueRef
   fun get_global_pass_registry = LLVMGetGlobalPassRegistry : PassRegistryRef

--- a/src/openssl/cipher.cr
+++ b/src/openssl/cipher.cr
@@ -101,7 +101,7 @@ class OpenSSL::Cipher
 
   def finalize
     LibCrypto.evp_cipher_ctx_free(@ctx) if @ctx
-    @ctx = nil
+    @ctx = typeof(@ctx).null
   end
 
   def authenticated?


### PR DESCRIPTION
Fixes #9870

Making `Pointer(T) | Nil` be represented as a pointer is unsound: when it's a null pointer it's not clear whether that's `nil` or `Pointer(T)`. When interfacing with C this doesn't matter, but when not it can be problematic. And since pointers can be used for things that aren't just C bindings, I think we should change this.

It's a small breaking change, but nothing huge. Most people probably don't use nilable pointer types explicitly.