### PR TITLE
Remove delete_if

### DIFF
--- a/spec/std/deque_spec.cr
+++ b/spec/std/deque_spec.cr
@@ -457,6 +457,24 @@ describe "Deque" do
     end
   end
 
+  describe "reject!" do
+    it "with block" do
+      a1 = Deque{1, 2, 3, 4, 5}
+
+      a2 = a1.reject! &.even?
+      a2.should eq(Deque{1, 3, 5})
+      a2.should be(a1)
+    end
+
+    it "with pattern" do
+      a1 = Deque{1, 2, 3, 4, 5}
+
+      a2 = a1.reject!(2..4)
+      a2.should eq(Deque{1, 5})
+      a2.should be(a1)
+    end
+  end
+
   describe "rotate!" do
     it "rotates" do
       a = Deque{1, 2, 3, 4, 5}
@@ -488,6 +506,24 @@ describe "Deque" do
       a = Deque{1}
       a.rotate!
       a.should eq(Deque{1})
+    end
+  end
+
+  describe "select!" do
+    it "with block" do
+      a1 = Deque{1, 2, 3, 4, 5}
+
+      a2 = a1.select! &.even?
+      a2.should eq(Deque{2, 4})
+      a2.should be(a1)
+    end
+
+    it "with pattern" do
+      a1 = Deque{1, 2, 3, 4, 5}
+
+      a2 = a1.select!(2..4)
+      a2.should eq(Deque{2, 3, 4})
+      a2.should be(a1)
     end
   end
 

--- a/src/deque.cr
+++ b/src/deque.cr
@@ -182,21 +182,83 @@ class Deque(T)
   # a             # => Deque{"a", "c"}
   # ```
   def delete(obj)
-    delete_if { |i| i == obj }
+    match = internal_delete { |i| i == obj }
+    !match.nil?
   end
 
-  def delete_if
-    found = false
+  # Modifies `self`, keeping only the elements in the collection for which the
+  # passed block returns `true`. Returns `self`.
+  #
+  # ```
+  # a = Deque{1, 6, 2, 4, 8}
+  # a.select! { |x| x > 3 }
+  # a # => Deque{6, 4, 8}
+  # ```
+  #
+  # See also: `Deque#select`.
+  def select!
+    reject! { |elem| !yield(elem) }
+  end
+
+  # Modifies `self`, keeping only the elements in the collection for which
+  # `pattern === element`.
+  #
+  # ```
+  # ary = [1, 6, 2, 4, 8]
+  # ary.select!(3..7)
+  # ary # => [6, 4]
+  # ```
+  #
+  # See also: `Deque#select`.
+  def select!(pattern)
+    self.select! { |elem| pattern === elem }
+  end
+
+  # Modifies `self`, deleting the elements in the collection for which the
+  # passed block returns `true`. Returns `self`.
+  #
+  # ```
+  # a = Deque{1, 6, 2, 4, 8}
+  # a.reject! { |x| x > 3 }
+  # a # => Deque{1, 2}
+  # ```
+  #
+  # See also: `Deque#reject`.
+  def reject!
+    internal_delete { |e| yield e }
+    self
+  end
+
+  # Modifies `self`, deleting the elements in the collection for which
+  # `pattern === element`.
+  #
+  # ```
+  # a = Deque{1, 6, 2, 4, 8}
+  # a.reject!(3..7)
+  # a # => Deque{1, 2, 8}
+  # ```
+  #
+  # See also: `Deque#reject`.
+  def reject!(pattern)
+    reject! { |elem| pattern === elem }
+    self
+  end
+
+  # `reject!` and `delete` implementation:
+  # returns the last matching element, or nil
+  private def internal_delete
+    match = nil
     i = 0
     while i < @size
-      if yield self[i]
+      e = self[i]
+      if yield e
+        match = e
         delete_at(i)
-        found = true
       else
         i += 1
       end
     end
-    found
+    match
   end
 
   # Deletes the item that is present at the *index*. Items to the right

--- a/src/hash.cr
+++ b/src/hash.cr
@@ -1215,6 +1215,7 @@ class Hash(K, V)
   # h.delete_if { |key, value| key.starts_with?("fo") }
   # h # => { "bar" => "qux" }
   # ```
+  @[Deprecated("Use `#reject!` instead")]
   def delete_if
     keys_to_delete = [] of K
     each do |key, value|


### PR DESCRIPTION
Implementing changes referenced by @asterite in #9856

- Deprecates `Hash#delete_if`
- Removes `Deque#delete_if`
- Adds `Deque#reject!`
- Adds `Deque#select!`