### PR TITLE
Feat: Enum::StringConverter(T)

### DIFF
--- a/spec/std/json/serializable_spec.cr
+++ b/spec/std/json/serializable_spec.cr
@@ -191,6 +191,18 @@ class JSONAttrWithSmallIntegers
   property bar : Int8
 end
 
+class JSONAttrWithEnumString
+  include JSON::Serializable
+
+  enum Hint
+    One
+    Two
+  end
+
+  @[YAML::Field(converter: Enum::StringConverter(JSONAttrWithEnumString::Hint))]
+  property hint : Hint
+end
+
 class JSONAttrWithTimeEpoch
   include JSON::Serializable
 
@@ -681,6 +693,14 @@ describe "JSON mapping" do
       json = JSONAttrWithDefaults.from_json(%({}))
       json.h.should eq [1, 2, 3]
     end
+  end
+
+  it "uses Enum::StringConverter(T)" do
+    string = %({"hint":"One"})
+    message = JSONAttrWithEnumString.from_json(string)
+    message.hint.should be_a(JSONAttrWithEnumString::Hint)
+    message.hint.should eq(JSONAttrWithEnumString::Hint::One)
+    message.to_json.should eq(string)
   end
 
   it "uses Time::EpochConverter" do

--- a/spec/std/yaml/serializable_spec.cr
+++ b/spec/std/yaml/serializable_spec.cr
@@ -204,6 +204,18 @@ class YAMLAttrWithSmallIntegers
   property bar : Int8
 end
 
+class YAMLAttrWithEnumString
+  include YAML::Serializable
+
+  enum Hint
+    One
+    Two
+  end
+
+  @[YAML::Field(converter: Enum::StringConverter(YAMLAttrWithEnumString::Hint))]
+  property hint : Hint
+end
+
 class YAMLAttrWithTimeEpoch
   include YAML::Serializable
 
@@ -755,6 +767,13 @@ describe "YAML::Serializable" do
       yaml = YAMLAttrWithDefaults.from_yaml(%({}))
       yaml.h.should eq [1, 2, 3]
     end
+  end
+
+  it "uses Enum::StringConverter(T)" do
+    message = YAMLAttrWithEnumString.from_yaml(%({"hint":"One"}))
+    message.hint.should be_a(YAMLAttrWithEnumString::Hint)
+    message.hint.should eq(YAMLAttrWithEnumString::Hint::One)
+    message.to_yaml.should eq("---\nhint: One\n")
   end
 
   it "uses Time::EpochConverter" do

--- a/src/json/from_json.cr
+++ b/src/json/from_json.cr
@@ -370,3 +370,13 @@ module String::RawConverter
     value.read_raw
   end
 end
+
+module Enum::StringConverter(T)
+  def self.from_json(pull : JSON::PullParser) : T
+    if pull.kind.string?
+      T.parse(pull.read_string)
+    else
+      raise "Expecting string in JSON for #{T.class}, not #{pull.kind}"
+    end
+  end
+end

--- a/src/json/to_json.cr
+++ b/src/json/to_json.cr
@@ -216,7 +216,7 @@ end
 #   include JSON::Serializable
 #
 #   @[JSON::Field(converter: JSON::HashValueConverter(Time::EpochConverter))]
-#   birthdays : Hash(String, Time)
+#   getter birthdays : Hash(String, Time)
 # end
 #
 # timestamp = TimestampHash.from_json(%({"birthdays":{"foo":1459859781,"bar":1567628762}}))
@@ -246,7 +246,7 @@ end
 #   include JSON::Serializable
 #
 #   @[JSON::Field(converter: Time::EpochConverter)]
-#   birth_date : Time
+#   getter birth_date : Time
 # end
 #
 # person = Person.from_json(%({"birth_date": 1459859781}))
@@ -270,7 +270,7 @@ end
 #   include JSON::Serializable
 #
 #   @[JSON::Field(converter: Time::EpochMillisConverter)]
-#   value : Time
+#   getter value : Time
 # end
 #
 # timestamp = Timestamp.from_json(%({"value": 1459860483856}))
@@ -297,7 +297,7 @@ end
 #   include JSON::Serializable
 #
 #   @[JSON::Field(converter: String::RawConverter)]
-#   value : String
+#   getter value : String
 # end
 #
 # raw = Raw.from_json(%({"value": 123456789876543212345678987654321}))

--- a/src/json/to_json.cr
+++ b/src/json/to_json.cr
@@ -309,3 +309,34 @@ module String::RawConverter
     json.raw(value)
   end
 end
+
+# Converter to be used with `JSON::Serializable` to write and read
+# an `Enum` exclusively as a `String`.
+#
+# This is useful if you wish to serialise to `String`, instead of
+# the default of a number representation of the `Enum`.
+#
+# ```
+# require "json"
+#
+# class EnumStringMessage
+#   include JSON::Serializable
+#
+#   enum Hint
+#     Up
+#     Down
+#   end
+#
+#   @[JSON::Field(converter: Enum::StringConverter(EnumStringMessage::Hint))]
+#   getter hint : Hint
+# end
+#
+# message = EnumStringMessage.from_json(%({"hint":"Up"}))
+# message.hint    # => EnumStringMessage::Hint::Up
+# message.to_json # => %({"hint":"Up"})
+# ```
+module Enum::StringConverter(T)
+  def self.to_json(value : T, json : JSON::Builder)
+    json.string(value.to_s)
+  end
+end

--- a/src/yaml/from_yaml.cr
+++ b/src/yaml/from_yaml.cr
@@ -322,6 +322,15 @@ module YAML::ArrayConverter(Converter)
   end
 end
 
+module Enum::StringConverter(T)
+  def self.from_yaml(ctx : YAML::ParseContext, node : YAML::Nodes::Node) : T
+    unless node.is_a?(YAML::Nodes::Scalar)
+      node.raise "Expected scalar, not #{node.class}"
+    end
+    T.parse(node.value)
+  end
+end
+
 struct Slice
   def self.new(ctx : YAML::ParseContext, node : YAML::Nodes::Node)
     {% if T != UInt8 %}

--- a/src/yaml/to_yaml.cr
+++ b/src/yaml/to_yaml.cr
@@ -161,7 +161,7 @@ end
 #   include YAML::Serializable
 #
 #   @[YAML::Field(converter: YAML::ArrayConverter(Time::EpochConverter))]
-#   values : Array(Time)
+#   getter values : Array(Time)
 # end
 #
 # timestamp = Timestamp.from_yaml(%({"values":[1459859781,1567628762]}))

--- a/src/yaml/to_yaml.cr
+++ b/src/yaml/to_yaml.cr
@@ -178,6 +178,12 @@ module YAML::ArrayConverter(Converter)
   end
 end
 
+module Enum::StringConverter(T)
+  def self.to_yaml(value : T, yaml : YAML::Nodes::Builder)
+    yaml.scalar value.to_s
+  end
+end
+
 struct Slice
   def to_yaml(yaml : YAML::Nodes::Builder)
     {% if T != UInt8 %}


### PR DESCRIPTION
Adds `Enum::StringConverter(T)`, a converter to be used with `JSON::Serializable` to write and read
an `Enum` exclusively as a `String`.
                                                                            
This is useful if you wish to serialise to `String`, instead of
the default of a number representation of the `Enum`.

Closes #9881 

Includes fixes to minor typos in a few serialization examples.

Usage:

```crystal                                                            
require "json"
                                                                            
class EnumStringMessage
  include JSON::Serializable
                                                                            
  enum Hint
    Up
    Down
  end
                                                                            
  @[JSON::Field(converter: Enum::StringConverter(EnumStringMessage::Hint))]
  getter hint : Hint
end
                                                                            
message = EnumStringMessage.from_json(%({"hint":"Up"}))
message.hint    # => EnumStringMessage::Hint::Up
message.to_json # => %({"hint":"Up"})
```