### PR TITLE
Fix Process.run uses in compiler to handle exec failure

### DIFF
--- a/spec/compiler/crystal/tools/doc/project_info_spec.cr
+++ b/spec/compiler/crystal/tools/doc/project_info_spec.cr
@@ -33,7 +33,17 @@ describe Crystal::Doc::ProjectInfo do
         File.write("shard.yml", "name: foo\nversion: 1.0")
       end
 
-      it "no git" do
+      it "git missing" do
+        ProjectInfo.git_executable = "git-missing-executable"
+
+        assert_with_defaults(ProjectInfo.new(nil, nil), ProjectInfo.new("foo", "1.0", refname: nil))
+        assert_with_defaults(ProjectInfo.new("bar", "2.0"), ProjectInfo.new("bar", "2.0", refname: nil))
+        assert_with_defaults(ProjectInfo.new(nil, "2.0"), ProjectInfo.new("foo", "2.0", refname: nil))
+      ensure
+        ProjectInfo.git_executable = "git"
+      end
+
+      it "not in a git folder" do
         assert_with_defaults(ProjectInfo.new(nil, nil), ProjectInfo.new("foo", "1.0", refname: nil))
         assert_with_defaults(ProjectInfo.new("bar", "2.0"), ProjectInfo.new("bar", "2.0", refname: nil))
         assert_with_defaults(ProjectInfo.new(nil, "2.0"), ProjectInfo.new("foo", "2.0", refname: nil))

--- a/spec/compiler/crystal/tools/doc/project_info_spec.cr
+++ b/spec/compiler/crystal/tools/doc/project_info_spec.cr
@@ -34,13 +34,13 @@ describe Crystal::Doc::ProjectInfo do
       end
 
       it "git missing" do
-        ProjectInfo.git_executable = "git-missing-executable"
+        Crystal::Git.executable = "git-missing-executable"
 
         assert_with_defaults(ProjectInfo.new(nil, nil), ProjectInfo.new("foo", "1.0", refname: nil))
         assert_with_defaults(ProjectInfo.new("bar", "2.0"), ProjectInfo.new("bar", "2.0", refname: nil))
         assert_with_defaults(ProjectInfo.new(nil, "2.0"), ProjectInfo.new("foo", "2.0", refname: nil))
       ensure
-        ProjectInfo.git_executable = "git"
+        Crystal::Git.executable = "git"
       end
 
       it "not in a git folder" do

--- a/src/compiler/crystal/codegen/link.cr
+++ b/src/compiler/crystal/codegen/link.cr
@@ -155,7 +155,7 @@ module Crystal
     # pkg-config is not installed, or the module does not exist.
     private def pkg_config(mod, static = false) : String?
       return unless pkg_config_path = PKG_CONFIG_PATH
-      return unless Process.run(pkg_config_path, {mod}).success?
+      return unless (Process.run(pkg_config_path, {mod}).success? rescue nil)
 
       args = ["--libs"]
       args << "--static" if static

--- a/src/compiler/crystal/tools/doc/project_info.cr
+++ b/src/compiler/crystal/tools/doc/project_info.cr
@@ -121,7 +121,7 @@ module Crystal::Doc
       status = Process.run(git_executable, args, output: output)
       yield unless status.success?
       status
-    rescue File::Error | IO::Error
+    rescue IO::Error
       yield
     end
 

--- a/src/compiler/crystal/tools/doc/project_info.cr
+++ b/src/compiler/crystal/tools/doc/project_info.cr
@@ -130,10 +130,12 @@ module Crystal::Doc
 
     def self.git_clean?
       # Use git to determine if index and working directory are clean
-      capture = Crystal::Git.git_capture(["status", "--porcelain"]) { return }
+      capture = Crystal::Git.git_capture(["status", "--porcelain"]) do
+        # In case the command failed to execute or returned error status, return false
+        return false
+      end
 
-      # If clean, output of `git status --porcelain` is empty. Still need to check
-      # the status code, to make sure empty doesn't mean error.
+      # Index is clean if output is empty (and program status is success, checked by git_capture)
       capture.bytesize == 0
     end
 

--- a/src/compiler/crystal/tools/doc/project_info.cr
+++ b/src/compiler/crystal/tools/doc/project_info.cr
@@ -117,7 +117,7 @@ module Crystal::Doc
       # check whether inside git work-tree
       Crystal::Git.git_command(["rev-parse", "--is-inside-work-tree"]) { return }
 
-      capture = Crystal::Git.git_capture(["remote", "-v"]) { return }
+      capture = Crystal::Git.git_capture(["remote", "-v"]) || return
       remotes = capture.lines.select(&.ends_with?(" (fetch)"))
 
       git_remote = remotes.find(&.starts_with?("origin\t")) || remotes.first? || return
@@ -130,10 +130,8 @@ module Crystal::Doc
 
     def self.git_clean?
       # Use git to determine if index and working directory are clean
-      capture = Crystal::Git.git_capture(["status", "--porcelain"]) do
-        # In case the command failed to execute or returned error status, return false
-        return false
-      end
+      # In case the command failed to execute or returned error status, return false
+      capture = Crystal::Git.git_capture(["status", "--porcelain"]) || return false
 
       # Index is clean if output is empty (and program status is success, checked by git_capture)
       capture.bytesize == 0
@@ -141,7 +139,7 @@ module Crystal::Doc
 
     def self.git_ref(*, branch)
       # Check if current HEAD is tagged
-      capture = Crystal::Git.git_capture(["tag", "--points-at", "HEAD"]) { return }
+      capture = Crystal::Git.git_capture(["tag", "--points-at", "HEAD"]) || return
       tags = capture.lines
       # Return tag if commit is tagged, select first one if multiple
       if tag = tags.first?
@@ -150,7 +148,7 @@ module Crystal::Doc
 
       if branch
         # Read current branch name
-        capture = Crystal::Git.git_capture(["rev-parse", "--abbrev-ref", "HEAD"]) { return }
+        capture = Crystal::Git.git_capture(["rev-parse", "--abbrev-ref", "HEAD"]) || return
 
         if branch_name = capture.strip.presence
           return branch_name
@@ -158,7 +156,7 @@ module Crystal::Doc
       end
 
       # Otherwise, return current commit sha
-      capture = Crystal::Git.git_capture(["rev-parse", "HEAD"]) { return }
+      capture = Crystal::Git.git_capture(["rev-parse", "HEAD"]) || return
 
       if sha = capture.strip.presence
         return sha

--- a/src/compiler/crystal/tools/doc/project_info.cr
+++ b/src/compiler/crystal/tools/doc/project_info.cr
@@ -54,8 +54,7 @@ module Crystal::Doc
     end
 
     def self.git_dir?
-      Crystal::Git.git_command(["rev-parse", "--is-inside-work-tree"]) { return false }
-      true
+      Crystal::Git.git_command(["rev-parse", "--is-inside-work-tree"])
     end
 
     VERSION_TAG = /^v(\d+[-.][-.a-zA-Z\d]+)$/
@@ -115,7 +114,7 @@ module Crystal::Doc
 
     def self.git_remote
       # check whether inside git work-tree
-      Crystal::Git.git_command(["rev-parse", "--is-inside-work-tree"]) { return }
+      Crystal::Git.git_command(["rev-parse", "--is-inside-work-tree"]) || return
 
       capture = Crystal::Git.git_capture(["remote", "-v"]) || return
       remotes = capture.lines.select(&.ends_with?(" (fetch)"))

--- a/src/compiler/crystal/tools/git.cr
+++ b/src/compiler/crystal/tools/git.cr
@@ -13,11 +13,11 @@ module Crystal::Git
 
   def self.git_capture(args)
     String.build do |io|
-      git_command(args, output: io) { yield }
+      git_command(args, output: io) { return }
     end
   end
 
   def self.git_config(key)
-    git_capture(["config", "--get", key]) { nil }.presence
+    git_capture(["config", "--get", key]).presence
   end
 end

--- a/src/compiler/crystal/tools/git.cr
+++ b/src/compiler/crystal/tools/git.cr
@@ -5,15 +5,14 @@ module Crystal::Git
   # Yields block if exec fails or process status is not success.
   def self.git_command(args, output : Process::Stdio = Process::Redirect::Close)
     status = Process.run(executable, args, output: output)
-    yield unless status.success?
-    status
+    return status.success?
   rescue IO::Error
-    yield
+    false
   end
 
   def self.git_capture(args)
     String.build do |io|
-      git_command(args, output: io) { return }
+      git_command(args, output: io) || return
     end
   end
 

--- a/src/compiler/crystal/tools/git.cr
+++ b/src/compiler/crystal/tools/git.cr
@@ -1,0 +1,23 @@
+module Crystal::Git
+  class_property executable = "git"
+
+  # Tries to run git command with args.
+  # Yields block if exec fails or process status is not success.
+  def self.git_command(args, output : Process::Stdio = Process::Redirect::Close)
+    status = Process.run(executable, args, output: output)
+    yield unless status.success?
+    status
+  rescue IO::Error
+    yield
+  end
+
+  def self.git_capture(args)
+    String.build do |io|
+      git_command(args, output: io) { yield }
+    end
+  end
+
+  def self.git_config(key)
+    git_capture(["config", "--get", key]) { nil }.presence
+  end
+end

--- a/src/compiler/crystal/tools/init.cr
+++ b/src/compiler/crystal/tools/init.cr
@@ -2,6 +2,7 @@
 
 require "ecr/macros"
 require "option_parser"
+require "./git"
 
 module Crystal
   module Init
@@ -96,22 +97,16 @@ module Crystal
       config
     end
 
-    private def self.git_config(key)
-      String.build do |io|
-        Process.run("git", ["config", "--get", key], output: io)
-      end.strip.presence
-    end
-
     def self.fetch_author
-      git_config("user.name") || "your-name-here"
+      Crystal.git_config("user.name") || "your-name-here"
     end
 
     def self.fetch_email
-      git_config("user.email") || "your-email-here"
+      Crystal.git_config("user.email") || "your-email-here"
     end
 
     def self.fetch_github_name
-      git_config("github.user") || "your-github-user"
+      Crystal.git_config("github.user") || "your-github-user"
     end
 
     def self.fetch_skeleton_type(opts, args)
@@ -255,7 +250,7 @@ module Crystal
 
     class GitInitView < View
       def render
-        Process.run("git", ["init", config.dir], output: config.silent ? Process::Redirect::Close : STDOUT)
+        Crystal.git_command(["init", config.dir], output: config.silent ? Process::Redirect::Close : STDOUT) { }
       end
 
       def path

--- a/src/compiler/crystal/tools/init.cr
+++ b/src/compiler/crystal/tools/init.cr
@@ -250,7 +250,7 @@ module Crystal
 
     class GitInitView < View
       def render
-        Crystal::Git.git_command(["init", config.dir], output: config.silent ? Process::Redirect::Close : STDOUT) { }
+        Crystal::Git.git_command(["init", config.dir], output: config.silent ? Process::Redirect::Close : STDOUT)
       end
 
       def path

--- a/src/compiler/crystal/tools/init.cr
+++ b/src/compiler/crystal/tools/init.cr
@@ -98,15 +98,15 @@ module Crystal
     end
 
     def self.fetch_author
-      Crystal.git_config("user.name") || "your-name-here"
+      Crystal::Git.git_config("user.name") || "your-name-here"
     end
 
     def self.fetch_email
-      Crystal.git_config("user.email") || "your-email-here"
+      Crystal::Git.git_config("user.email") || "your-email-here"
     end
 
     def self.fetch_github_name
-      Crystal.git_config("github.user") || "your-github-user"
+      Crystal::Git.git_config("github.user") || "your-github-user"
     end
 
     def self.fetch_skeleton_type(opts, args)
@@ -250,7 +250,7 @@ module Crystal
 
     class GitInitView < View
       def render
-        Crystal.git_command(["init", config.dir], output: config.silent ? Process::Redirect::Close : STDOUT) { }
+        Crystal::Git.git_command(["init", config.dir], output: config.silent ? Process::Redirect::Close : STDOUT) { }
       end
 
       def path


### PR DESCRIPTION
Fixes more uses of `Process.run` to handle exec error (see #9867 and #9789). Also refactors the git code used in ProjectInfo to a common location for reusability.

See https://github.com/crystal-lang/crystal/pull/9867#issuecomment-723262588

<del/>Depends on #9867</del> <ins>includes #9867</ins>
Fixes #9789