### PR TITLE
Fix #9715: BigDecimal.to_s

### DIFF
--- a/spec/std/big/big_decimal_spec.cr
+++ b/spec/std/big/big_decimal_spec.cr
@@ -310,6 +310,8 @@ describe BigDecimal do
     BigDecimal.new(0).to_s.should eq "0"
     BigDecimal.new(1).to_s.should eq "1"
     BigDecimal.new(-1).to_s.should eq "-1"
+    BigDecimal.new("-0.35").to_s.should eq "-0.35"
+    BigDecimal.new("-.35").to_s.should eq "-0.35"
     BigDecimal.new("0.01").to_s.should eq "0.01"
     BigDecimal.new("-0.01").to_s.should eq "-0.01"
     BigDecimal.new("0.00123").to_s.should eq "0.00123"

--- a/src/big/big_decimal.cr
+++ b/src/big/big_decimal.cr
@@ -325,8 +325,9 @@ struct BigDecimal < Number
         io << '0'
       end
       io << s[1..-1]
+    elsif (offset = s.size - @scale) == 1 && @value < 0
+      io << "-0." << s[offset..-1]
     else
-      offset = s.size - @scale
       io << s[0...offset] << '.' << s[offset..-1]
     end
   end


### PR DESCRIPTION
- Make BigFloat's negative decimal fractions after converting to string `.to_s` conform to stdlib's float-like number structs' (Float32, Float64, BigDecimal) norm (e.g. `"-0.23"` instead of the anomalous `"-.21"`)

- Fixes #9715 

- For a full explanation, please view this comment https://github.com/crystal-lang/crystal/issues/9715#issuecomment-722758075