### PR TITLE
Add JSON serialization to big number types

### DIFF
--- a/spec/std/json/serialization_spec.cr
+++ b/spec/std/json/serialization_spec.cr
@@ -127,19 +127,19 @@ describe "JSON serialization" do
       tuple.should be_a(NamedTuple(x: Int32?, y: String))
     end
 
-    it "does for BigInt" do
+    pending_win32 "does for BigInt" do
       big = BigInt.from_json("123456789123456789123456789123456789123456789")
       big.should be_a(BigInt)
       big.should eq(BigInt.new("123456789123456789123456789123456789123456789"))
     end
 
-    it "does for BigFloat" do
+    pending_win32 "does for BigFloat" do
       big = BigFloat.from_json("1234.567891011121314")
       big.should be_a(BigFloat)
       big.should eq(BigFloat.new("1234.567891011121314"))
     end
 
-    it "does for BigFloat from int" do
+    pending_win32 "does for BigFloat from int" do
       big = BigFloat.from_json("1234")
       big.should be_a(BigFloat)
       big.should eq(BigFloat.new("1234"))
@@ -163,13 +163,13 @@ describe "JSON serialization" do
       uuid.should eq(UUID.new("ee843b26-56d8-472b-b343-0b94ed9077ff"))
     end
 
-    it "does for BigDecimal from int" do
+    pending_win32 "does for BigDecimal from int" do
       big = BigDecimal.from_json("1234")
       big.should be_a(BigDecimal)
       big.should eq(BigDecimal.new("1234"))
     end
 
-    it "does for BigDecimal from float" do
+    pending_win32 "does for BigDecimal from float" do
       big = BigDecimal.from_json("1234.05")
       big.should be_a(BigDecimal)
       big.should eq(BigDecimal.new("1234.05"))
@@ -398,17 +398,17 @@ describe "JSON serialization" do
       JSONSpecEnum::One.to_json.should eq("1")
     end
 
-    it "does for BigInt" do
+    pending_win32 "does for BigInt" do
       big = BigInt.new("123456789123456789123456789123456789123456789")
       big.to_json.should eq("123456789123456789123456789123456789123456789")
     end
 
-    it "does for BigFloat" do
+    pending_win32 "does for BigFloat" do
       big = BigFloat.new("1234.567891011121314")
       big.to_json.should eq("1234.567891011121314")
     end
 
-    it "does for BigDecimal" do
+    pending_win32 "does for BigDecimal" do
       big = BigDecimal.new("1234.567891011121314")
       big.to_json.should eq("1234.567891011121314")
     end

--- a/spec/std/json/serialization_spec.cr
+++ b/spec/std/json/serialization_spec.cr
@@ -127,19 +127,19 @@ describe "JSON serialization" do
       tuple.should be_a(NamedTuple(x: Int32?, y: String))
     end
 
-    pending_win32 "does for BigInt" do
+    it "does for BigInt" do
       big = BigInt.from_json("123456789123456789123456789123456789123456789")
       big.should be_a(BigInt)
       big.should eq(BigInt.new("123456789123456789123456789123456789123456789"))
     end
 
-    pending_win32 "does for BigFloat" do
+    it "does for BigFloat" do
       big = BigFloat.from_json("1234.567891011121314")
       big.should be_a(BigFloat)
       big.should eq(BigFloat.new("1234.567891011121314"))
     end
 
-    pending_win32 "does for BigFloat from int" do
+    it "does for BigFloat from int" do
       big = BigFloat.from_json("1234")
       big.should be_a(BigFloat)
       big.should eq(BigFloat.new("1234"))
@@ -163,13 +163,13 @@ describe "JSON serialization" do
       uuid.should eq(UUID.new("ee843b26-56d8-472b-b343-0b94ed9077ff"))
     end
 
-    pending_win32 "does for BigDecimal from int" do
+    it "does for BigDecimal from int" do
       big = BigDecimal.from_json("1234")
       big.should be_a(BigDecimal)
       big.should eq(BigDecimal.new("1234"))
     end
 
-    pending_win32 "does for BigDecimal from float" do
+    it "does for BigDecimal from float" do
       big = BigDecimal.from_json("1234.05")
       big.should be_a(BigDecimal)
       big.should eq(BigDecimal.new("1234.05"))
@@ -398,13 +398,18 @@ describe "JSON serialization" do
       JSONSpecEnum::One.to_json.should eq("1")
     end
 
-    pending_win32 "does for BigInt" do
+    it "does for BigInt" do
       big = BigInt.new("123456789123456789123456789123456789123456789")
       big.to_json.should eq("123456789123456789123456789123456789123456789")
     end
 
-    pending_win32 "does for BigFloat" do
+    it "does for BigFloat" do
       big = BigFloat.new("1234.567891011121314")
+      big.to_json.should eq("1234.567891011121314")
+    end
+
+    it "does for BigDecimal" do
+      big = BigDecimal.new("1234.567891011121314")
       big.to_json.should eq("1234.567891011121314")
     end
 

--- a/spec/std/yaml/serialization_spec.cr
+++ b/spec/std/yaml/serialization_spec.cr
@@ -377,6 +377,11 @@ describe "YAML serialization" do
       BigFloat.from_yaml(big.to_yaml).should eq(big)
     end
 
+    pending_win32 "does for BigDecimal" do
+      big = BigDecimal.new("1234.567891011121314")
+      BigDecimal.from_yaml(big.to_yaml).should eq(big)
+    end
+
     it "does for Enum" do
       YAMLSpecEnum.from_yaml(YAMLSpecEnum::One.to_yaml).should eq(YAMLSpecEnum::One)
     end

--- a/src/big/json.cr
+++ b/src/big/json.cr
@@ -1,44 +1,81 @@
 require "json"
 require "big"
 
-def BigInt.new(pull : JSON::PullParser)
-  pull.read_int
-  BigInt.new(pull.raw_value)
-end
-
-def BigInt.from_json_object_key?(key : String)
-  BigInt.new(key)
-rescue ArgumentError
-  nil
-end
-
-def BigFloat.new(pull : JSON::PullParser)
-  pull.read_float
-  BigFloat.new(pull.raw_value)
-end
-
-def BigFloat.from_json_object_key?(key : String)
-  BigFloat.new(key)
-rescue ArgumentError
-  nil
-end
-
-def BigDecimal.new(pull : JSON::PullParser)
-  case pull.kind
-  when .int?
+struct BigInt
+  def self.new(pull : JSON::PullParser)
     pull.read_int
-    value = pull.raw_value
-  when .float?
-    pull.read_float
-    value = pull.raw_value
-  else
-    value = pull.read_string
+    new(pull.raw_value)
   end
-  BigDecimal.new(value)
+
+  def self.from_json_object_key?(key : String)
+    new(key)
+  rescue ArgumentError
+    nil
+  end
+
+  def to_json_object_key
+    to_s
+  end
+
+  def to_json(json : JSON::Builder)
+    json.number(self)
+  end
 end
 
-def BigDecimal.from_json_object_key?(key : String)
-  BigDecimal.new(key)
-rescue InvalidBigDecimalException
-  nil
+struct BigFloat
+  def self.new(pull : JSON::PullParser)
+    case pull.kind
+    when .int?
+      pull.read_int
+      value = pull.raw_value
+    else
+      pull.read_float
+      value = pull.raw_value
+    end
+    new(value)
+  end
+
+  def self.from_json_object_key?(key : String)
+    new(key)
+  rescue ArgumentError
+    nil
+  end
+
+  def to_json_object_key
+    to_s
+  end
+
+  def to_json(json : JSON::Builder)
+    json.number(self)
+  end
+end
+
+struct BigDecimal
+  def self.new(pull : JSON::PullParser)
+    case pull.kind
+    when .int?
+      pull.read_int
+      value = pull.raw_value
+    when .float?
+      pull.read_float
+      value = pull.raw_value
+    else
+      value = pull.read_string
+    end
+    new(value)
+  end
+
+  def self.from_json_object_key?(key : String)
+    new(key)
+  rescue InvalidBigDecimalException
+    nil
+  end
+
+  def to_json_object_key
+    to_s
+  end
+
+  def to_json(json : JSON::Builder)
+    json.number(self)
+  end
 end

--- a/src/big/json.cr
+++ b/src/big/json.cr
@@ -1,6 +1,29 @@
 require "json"
 require "big"
 
+class JSON::Builder
+  # Writes a big integer.
+  def number(number : BigInt)
+    scalar do
+      @io << number
+    end
+  end
+
+  # Writes a big float.
+  def number(number : BigFloat)
+    scalar do
+      @io << number
+    end
+  end
+
+  # Writes a big decimal.
+  def number(number : BigDecimal)
+    scalar do
+      @io << number
+    end
+  end
+end
+
 struct BigInt
   def self.new(pull : JSON::PullParser)
     pull.read_int

--- a/src/json/builder.cr
+++ b/src/json/builder.cr
@@ -95,27 +95,6 @@ class JSON::Builder
     end
   end
 
-  # Writes a big integer.
-  def number(number : BigInt)
-    scalar do
-      @io << number
-    end
-  end
-
-  # Writes a big float.
-  def number(number : BigFloat)
-    scalar do
-      @io << number
-    end
-  end
-
-  # Writes a big decimal.
-  def number(number : BigDecimal)
-    scalar do
-      @io << number
-    end
-  end
-
   # Writes a string. The given *value* is first converted to a `String`
   # by invoking `to_s` on it.
   #

--- a/src/json/builder.cr
+++ b/src/json/builder.cr
@@ -95,6 +95,27 @@ class JSON::Builder
     end
   end
 
+  # Writes a big integer.
+  def number(number : BigInt)
+    scalar do
+      @io << number
+    end
+  end
+
+  # Writes a big float.
+  def number(number : BigFloat)
+    scalar do
+      @io << number
+    end
+  end
+
+  # Writes a big decimal.
+  def number(number : BigDecimal)
+    scalar do
+      @io << number
+    end
+  end
+
   # Writes a string. The given *value* is first converted to a `String`
   # by invoking `to_s` on it.
   #


### PR DESCRIPTION
This PR:
- Closes #7856

Summary of Changes:
- Allow serialisation: and `.to_json` to all `Big*` structs (`BigInt`,`BigFloat`, `BigDecimal`)
- Serialisation `Big*.to_json` is enabled through adding `JSON::Builder.number` methods for each `Big*` type, serialising into Number types

- Allow deserialisation of `BigFloat` from `Int` or `Float`
- Allow all `Big*` structs to be used as JSON keys: add `.to_json_object_key`

- Add missing `pending_win32 "does for BigDecimal"` to `yaml/serialization_spec.cr`

Further Discussion:
- This PR seeks to resolve #7856, and is built from the exchanges in https://github.com/crystal-lang/crystal/pull/8070 .
- The reason for opening this PR is because issue #7856 should be resolved swiftly as `Big*` finds lots of usage in terms of serialisation, yet https://github.com/crystal-lang/crystal/pull/8070 has been open and without activity for almost a year. In this PR, all comments from PR #8070 are addressed, e.g. disallowing `BigInt` and `BigFloat` to be deserialised from a `String`, allowing `Big*` to only serialise into `Number` and not String.

- With regards to RX14's suggestion on building a custom converter to serialize/ deserialize `Big*` structs into/ from `String` (https://github.com/crystal-lang/crystal/pull/8070#issuecomment-525241993), this can be done as a separate PR, or if the maintainers would like this to be addressed here, I would not mind adding it in. However, IMHO, I think the commit in this PR currently is adequate to resolve the original issue, and any other modification can be addressed in a separate PR.