### PR TITLE
Make Hash#reject!, Hash#select!, and Hash#compact! consistent with Array

### DIFF
--- a/spec/std/hash_spec.cr
+++ b/spec/std/hash_spec.cr
@@ -598,16 +598,9 @@ describe "Hash" do
     h1 = {:a => 1, :b => 2, :c => 3}
 
     h2 = h1.select! { |k, v| k == :b }
+    h2.should be_a(Hash(Symbol, Int32))
     h2.should eq({:b => 2})
     h2.should be(h1)
-  end
-
-  it "returns nil when using select! and no changes were made" do
-    h1 = {:a => 1, :b => 2, :c => 3}
-
-    h2 = h1.select! { true }
-    h2.should eq(nil)
-    h1.should eq({:a => 1, :b => 2, :c => 3})
   end
 
   it "rejects" do
@@ -622,16 +615,9 @@ describe "Hash" do
     h1 = {:a => 1, :b => 2, :c => 3}
 
     h2 = h1.reject! { |k, v| k == :b }
+    h2.should be_a(Hash(Symbol, Int32))
     h2.should eq({:a => 1, :c => 3})
     h2.should be(h1)
-  end
-
-  it "returns nil when using reject! and no changes were made" do
-    h1 = {:a => 1, :b => 2, :c => 3}
-
-    h2 = h1.reject! { false }
-    h2.should eq(nil)
-    h1.should eq({:a => 1, :b => 2, :c => 3})
   end
 
   it "compacts" do
@@ -646,16 +632,9 @@ describe "Hash" do
     h1 = {:a => 1, :b => 2, :c => nil}
 
     h2 = h1.compact!
+    h2.should be_a(Hash(Symbol, Int32 | Nil))
     h2.should eq({:a => 1, :b => 2})
     h2.should be(h1)
-  end
-
-  it "returns nil when using compact! and no changes were made" do
-    h1 = {:a => 1, :b => 2, :c => 3}
-
-    h2 = h1.compact!
-    h2.should be_nil
-    h1.should eq({:a => 1, :b => 2, :c => 3})
   end
 
   it "transforms keys" do

--- a/src/hash.cr
+++ b/src/hash.cr
@@ -1451,7 +1451,7 @@ class Hash(K, V)
     reject { |k, v| !yield(k, v) }
   end
 
-  # Equivalent to `Hash#select` but makes modification on the current object rather that returning a new one. Returns `nil` if no changes were made
+  # Equivalent to `Hash#select` but makes modification on the current object rather than returning a new one. Returns `self`.
   def select!(&block : K, V -> _)
     reject! { |k, v| !yield(k, v) }
   end
@@ -1468,13 +1468,12 @@ class Hash(K, V)
     end
   end
 
-  # Equivalent to `Hash#reject`, but makes modification on the current object rather that returning a new one. Returns `nil` if no changes were made.
+  # Equivalent to `Hash#reject`, but makes modification on the current object rather than returning a new one. Returns `self`.
   def reject!(&block : K, V -> _)
-    num_entries = size
     each do |key, value|
       delete(key) if yield(key, value)
     end
-    num_entries == size ? nil : self
+    self
   end
 
   # Returns a new `Hash` without the given keys.
@@ -1551,7 +1550,7 @@ class Hash(K, V)
     end
   end
 
-  # Removes all `nil` value from `self`. Returns `nil` if no changes were made.
+  # Removes all `nil` value from `self`. Returns `self`.
   #
   # ```
   # hash = {"hello" => "world", "foo" => nil}


### PR DESCRIPTION
Following the discussion in #9878 

- `Hash#reject!` returns self
- `Hash#select!` returns self
- `Hash#compact!` returns self

This brings `Hash` into line with `Array`