### PR TITLE
Serialize Enum to underscored String

### DIFF
--- a/spec/std/json/serialization_spec.cr
+++ b/spec/std/json/serialization_spec.cr
@@ -18,6 +18,7 @@ end
 enum JSONSpecFlagEnum
   One
   Two
+  OneHundred
 end
 
 describe "JSON serialization" do
@@ -235,10 +236,29 @@ describe "JSON serialization" do
       JSONSpecFlagEnum.from_json("0").should eq(JSONSpecFlagEnum::None)
       JSONSpecFlagEnum.from_json("1").should eq(JSONSpecFlagEnum::One)
       JSONSpecFlagEnum.from_json("2").should eq(JSONSpecFlagEnum::Two)
-      JSONSpecFlagEnum.from_json("3").should eq(JSONSpecFlagEnum::All)
+      JSONSpecFlagEnum.from_json("4").should eq(JSONSpecFlagEnum::OneHundred)
+      JSONSpecFlagEnum.from_json("7").should eq(JSONSpecFlagEnum::All)
 
-      expect_raises(Exception, "Unknown enum JSONSpecFlagEnum value: 4") do
-        JSONSpecFlagEnum.from_json("4")
+      expect_raises(Exception, "Unknown enum JSONSpecFlagEnum value: 8") do
+        JSONSpecFlagEnum.from_json("8")
+      end
+    end
+
+    it "does for flag Enum with string" do
+      JSONSpecFlagEnum.from_json(%("one")).should eq(JSONSpecFlagEnum::One)
+      JSONSpecFlagEnum.from_json(%("two")).should eq(JSONSpecFlagEnum::Two)
+
+      expect_raises(Exception, "Unknown enum JSONSpecFlagEnum value: three") do
+        JSONSpecFlagEnum.from_json(%("three"))
+      end
+    end
+
+    it "does for flag Enum with array" do
+      JSONSpecFlagEnum.from_json(%(["one", "two", "one_hundred"])).should eq(JSONSpecFlagEnum::All)
+      JSONSpecFlagEnum.from_json(%(["one"])).should eq(JSONSpecFlagEnum::One)
+
+      expect_raises(Exception, "Unknown enum JSONSpecFlagEnum value: three") do
+        JSONSpecFlagEnum.from_json(%(["one", "three"]))
       end
     end
 
@@ -448,6 +468,12 @@ describe "JSON serialization" do
     it "does for Enum" do
       JSONSpecEnum::One.to_json.should eq(%("one"))
       JSONSpecEnum::OneHundred.to_json.should eq(%("one_hundred"))
+    end
+
+    it "does for flag Enum" do
+      JSONSpecFlagEnum::One.to_json.should eq(%(["one"]))
+      JSONSpecFlagEnum::OneHundred.to_json.should eq(%(["one_hundred"]))
+      JSONSpecFlagEnum::All.to_json.should eq(%(["one","two","one_hundred"]))
     end
 
     pending_win32 "does for BigInt" do

--- a/spec/std/json/serialization_spec.cr
+++ b/spec/std/json/serialization_spec.cr
@@ -11,6 +11,7 @@ enum JSONSpecEnum
   Zero
   One
   Two
+  OneHundred
 end
 
 @[Flags]
@@ -215,13 +216,15 @@ describe "JSON serialization" do
     it "does for Enum with number" do
       JSONSpecEnum.from_json("1").should eq(JSONSpecEnum::One)
 
-      expect_raises(Exception, "Unknown enum JSONSpecEnum value: 3") do
-        JSONSpecEnum.from_json("3")
+      expect_raises(Exception, "Unknown enum JSONSpecEnum value: 4") do
+        JSONSpecEnum.from_json("4")
       end
     end
 
     it "does for Enum with string" do
       JSONSpecEnum.from_json(%("One")).should eq(JSONSpecEnum::One)
+
+      JSONSpecEnum.from_json(%("one_hundred")).should eq(JSONSpecEnum::OneHundred)
 
       expect_raises(ArgumentError, "Unknown enum JSONSpecEnum value: Three") do
         JSONSpecEnum.from_json(%("Three"))
@@ -443,7 +446,8 @@ describe "JSON serialization" do
     end
 
     it "does for Enum" do
-      JSONSpecEnum::One.to_json.should eq("1")
+      JSONSpecEnum::One.to_json.should eq(%("one"))
+      JSONSpecEnum::OneHundred.to_json.should eq(%("one_hundred"))
     end
 
     pending_win32 "does for BigInt" do

--- a/spec/std/yaml/serialization_spec.cr
+++ b/spec/std/yaml/serialization_spec.cr
@@ -9,6 +9,7 @@ enum YAMLSpecEnum
   Zero
   One
   Two
+  OneHundred
 end
 
 @[Flags]
@@ -189,13 +190,15 @@ describe "YAML serialization" do
     it "does for Enum with number" do
       YAMLSpecEnum.from_yaml(%("1")).should eq(YAMLSpecEnum::One)
 
-      expect_raises(Exception, "Unknown enum YAMLSpecEnum value: 3") do
-        YAMLSpecEnum.from_yaml(%("3"))
+      expect_raises(Exception, "Unknown enum YAMLSpecEnum value: 4") do
+        YAMLSpecEnum.from_yaml(%("4"))
       end
     end
 
     it "does for Enum with string" do
       YAMLSpecEnum.from_yaml(%("One")).should eq(YAMLSpecEnum::One)
+
+      YAMLSpecEnum.from_yaml(%("one_hundred")).should eq(YAMLSpecEnum::OneHundred)
 
       expect_raises(ArgumentError, "Unknown enum YAMLSpecEnum value: Three") do
         YAMLSpecEnum.from_yaml(%("Three"))
@@ -401,6 +404,10 @@ describe "YAML serialization" do
 
     it "does for Enum" do
       YAMLSpecEnum.from_yaml(YAMLSpecEnum::One.to_yaml).should eq(YAMLSpecEnum::One)
+      YAMLSpecEnum::One.to_yaml.should eq "--- one\n"
+
+      YAMLSpecEnum.from_yaml(YAMLSpecEnum::OneHundred.to_yaml).should eq(YAMLSpecEnum::OneHundred)
+      YAMLSpecEnum::OneHundred.to_yaml.should eq "--- one_hundred\n"
     end
 
     it "does for utc time" do

--- a/spec/std/yaml/serialization_spec.cr
+++ b/spec/std/yaml/serialization_spec.cr
@@ -404,10 +404,10 @@ describe "YAML serialization" do
 
     it "does for Enum" do
       YAMLSpecEnum.from_yaml(YAMLSpecEnum::One.to_yaml).should eq(YAMLSpecEnum::One)
-      YAMLSpecEnum::One.to_yaml.should eq "--- one\n"
+      assert_yaml_document_end(YAMLSpecEnum::One.to_yaml, "--- one\n")
 
       YAMLSpecEnum.from_yaml(YAMLSpecEnum::OneHundred.to_yaml).should eq(YAMLSpecEnum::OneHundred)
-      YAMLSpecEnum::OneHundred.to_yaml.should eq "--- one_hundred\n"
+      assert_yaml_document_end(YAMLSpecEnum::OneHundred.to_yaml, "--- one_hundred\n")
     end
 
     it "does for utc time" do

--- a/spec/std/yaml/serialization_spec.cr
+++ b/spec/std/yaml/serialization_spec.cr
@@ -16,6 +16,7 @@ end
 enum YAMLSpecFlagEnum
   One
   Two
+  OneHundred
 end
 
 alias YamlRec = Int32 | Array(YamlRec) | Hash(YamlRec, YamlRec)
@@ -209,10 +210,29 @@ describe "YAML serialization" do
       YAMLSpecFlagEnum.from_json("0").should eq(YAMLSpecFlagEnum::None)
       YAMLSpecFlagEnum.from_json("1").should eq(YAMLSpecFlagEnum::One)
       YAMLSpecFlagEnum.from_json("2").should eq(YAMLSpecFlagEnum::Two)
-      YAMLSpecFlagEnum.from_json("3").should eq(YAMLSpecFlagEnum::All)
+      YAMLSpecFlagEnum.from_json("4").should eq(YAMLSpecFlagEnum::OneHundred)
+      YAMLSpecFlagEnum.from_json("7").should eq(YAMLSpecFlagEnum::All)
 
-      expect_raises(Exception, "Unknown enum YAMLSpecFlagEnum value: 4") do
-        YAMLSpecFlagEnum.from_json("4")
+      expect_raises(Exception, "Unknown enum YAMLSpecFlagEnum value: 8") do
+        YAMLSpecFlagEnum.from_json("8")
+      end
+    end
+
+    it "does for flag Enum with string" do
+      YAMLSpecFlagEnum.from_json(%("one")).should eq(YAMLSpecFlagEnum::One)
+      YAMLSpecFlagEnum.from_json(%("two")).should eq(YAMLSpecFlagEnum::Two)
+
+      expect_raises(Exception, "Unknown enum YAMLSpecFlagEnum value: three") do
+        YAMLSpecFlagEnum.from_json(%("three"))
+      end
+    end
+
+    it "does for flag Enum with array" do
+      YAMLSpecFlagEnum.from_json(%(["one", "two", "one_hundred"])).should eq(YAMLSpecFlagEnum::All)
+      YAMLSpecFlagEnum.from_json(%(["one"])).should eq(YAMLSpecFlagEnum::One)
+
+      expect_raises(Exception, "Unknown enum YAMLSpecFlagEnum value: three") do
+        YAMLSpecFlagEnum.from_json(%(["one", "three"]))
       end
     end
 

--- a/src/json/from_json.cr
+++ b/src/json/from_json.cr
@@ -249,20 +249,11 @@ def Enum.new(pull : JSON::PullParser)
     #       but there's a bug in `crystal tool format` with
     #       macros and case statements
     if pull.kind.begin_array?
-      values = [] of self
+      value = 0
       pull.read_array do
-        values << new(pull)
+        value += new(pull).value
       end
-
-      flags = if values.empty?
-                {{@type.id}}::None
-              else
-                values.reduce do |set, value|
-                  set | value
-                end
-              end
-
-      return flags
+      return from_value(value)
     end
   {% end %}
 

--- a/src/json/to_json.cr
+++ b/src/json/to_json.cr
@@ -161,7 +161,15 @@ end
 
 struct Enum
   def to_json(json : JSON::Builder)
-    json.string(to_s.underscore)
+    {% if @type.annotation(Flags) %}
+      json.array do
+        each do |member, _value|
+          json.string(member.to_s.underscore)
+        end
+      end
+    {% else %}
+      json.string(to_s.underscore)
+    {% end %}
   end
 end
 

--- a/src/json/to_json.cr
+++ b/src/json/to_json.cr
@@ -161,7 +161,7 @@ end
 
 struct Enum
   def to_json(json : JSON::Builder)
-    json.number(value)
+    json.string(to_s.underscore)
   end
 end
 

--- a/src/yaml/from_yaml.cr
+++ b/src/yaml/from_yaml.cr
@@ -229,18 +229,12 @@ def Enum.new(ctx : YAML::ParseContext, node : YAML::Nodes::Node)
     end
   else
     {% if @type.annotation(Flags) %}
-      values = [] of self
-      node.each do |value|
-        values << new(ctx, value)
+      value = 0
+      node.each do |element|
+        value += new(ctx, element).value
       end
 
-      if values.empty?
-        {{@type.id}}::None
-      else
-        values.reduce do |set, value|
-          set | value
-        end
-      end
+      from_value(value)
     {% else %}
       node.raise "Expected scalar, not #{node.class}"
     {% end %}

--- a/src/yaml/to_yaml.cr
+++ b/src/yaml/to_yaml.cr
@@ -123,7 +123,7 @@ end
 
 struct Enum
   def to_yaml(yaml : YAML::Nodes::Builder)
-    yaml.scalar value
+    yaml.scalar to_s.underscore
   end
 end
 

--- a/src/yaml/to_yaml.cr
+++ b/src/yaml/to_yaml.cr
@@ -123,7 +123,12 @@ end
 
 struct Enum
   def to_yaml(yaml : YAML::Nodes::Builder)
-    yaml.scalar to_s.underscore
+    string = to_s.underscore
+    if YAML::Schema::Core.reserved_string?(string)
+      yaml.scalar string, style: YAML::ScalarStyle::DOUBLE_QUOTED
+    else
+      yaml.scalar string
+    end
   end
 end
 

--- a/src/yaml/to_yaml.cr
+++ b/src/yaml/to_yaml.cr
@@ -123,7 +123,19 @@ end
 
 struct Enum
   def to_yaml(yaml : YAML::Nodes::Builder)
-    string = to_s.underscore
+    {% if @type.annotation(Flags) %}
+      yaml.sequence do
+        each do |member, _value|
+          build_safe_yaml_string(yaml, member)
+        end
+      end
+    {% else %}
+      build_safe_yaml_string(yaml, self)
+    {% end %}
+  end
+
+  private def build_safe_yaml_string(yaml : YAML::Nodes::Builder, member)
+    string = member.to_s.underscore
     if YAML::Schema::Core.reserved_string?(string)
       yaml.scalar string, style: YAML::ScalarStyle::DOUBLE_QUOTED
     else


### PR DESCRIPTION
This PR makes enums default JSON/YAML serialization target an underscored `string`. 

For backwards compatibility, I could merge a modified converter from #9887 to allow the specification of the serialisation target of an enum via a converter in a `(JSON|YAML)::Field`  annotation 

Follows from the discussion from #9887

Additionally, enums using the `Flags` annotation are now serialized to an array of downcased strings
```crystal
@[Flags]
enum Example
  Foo
  Bar
end

Example::All.to_json # => ["foo","bar"]
```

To retain the previous serialization behaviour for your enum, you can do the following
```crystal
enum Example
  Foo
  Bar
  
  def to_json(json)
    json.number to_i
  end
  
  def to_yaml(json)
    yaml.scalar to_i
  end
 end
```