### PR TITLE
Win CI: Patch LLVM to fix broken build

### DIFF
--- a/.github/workflows/win.yml
+++ b/.github/workflows/win.yml
@@ -134,6 +134,11 @@ jobs:
           7z x llvm.tar.xz
           7z x llvm.tar
           mv llvm-* llvm-src
+      - name: Patch LLVM for VS 2019 16.7.0
+        working-directory: ./llvm-src
+        if: steps.cache-llvm.outputs.cache-hit != 'true'
+        run: |
+          sed -i 's/#ifdef HAVE_STD_IS_TRIVIALLY_COPYABLE/#if 0/' include/llvm/Support/type_traits.h
       - name: Build LLVM
         if: steps.cache-llvm.outputs.cache-hit != 'true'
         working-directory: ./llvm-src


### PR DESCRIPTION
Prevents the error:

    type_traits.h(181,23): error C2338: inconsistent behavior between llvm:: and std:: implementation of is_trivially_copyable (compiling source file

Ref:
* https://github.com/microsoft/vcpkg/pull/12884/files
* https://github.com/microsoft/vcpkg/pull/12884#issuecomment-703789627