### PR TITLE
Win CI: Fix for download-artifact@v2 change

### DIFF
--- a/.github/workflows/win.yml
+++ b/.github/workflows/win.yml
@@ -163,7 +163,7 @@ jobs:
           cl /MT /c src\llvm\ext\llvm_ext.cc -I llvm\include /Fosrc\llvm\ext\llvm_ext.obj
       - name: Link Crystal executable
         run: |
-          Invoke-Expression "cl objs\crystal.obj /Fecrystal-cross src\llvm\ext\llvm_ext.obj $(llvm\bin\llvm-config.exe --libs) libs\pcre.lib libs\gc.lib advapi32.lib libcmt.lib legacy_stdio_definitions.lib /F10000000"
+          Invoke-Expression "cl crystal.obj /Fecrystal-cross src\llvm\ext\llvm_ext.obj $(llvm\bin\llvm-config.exe --libs) libs\pcre.lib libs\gc.lib advapi32.lib libcmt.lib legacy_stdio_definitions.lib /F10000000"
 
       - name: Re-build Crystal
         run: |


### PR DESCRIPTION
#9906 incorrectly bumped the version of [actions/download-artifact@v2](https://github.com/actions/download-artifact) without considering [a change in behavior](https://github.com/actions/download-artifact/tree/v2#compatibility-between-v1-and-v2)