### PR TITLE
Use `name: nightly` in docs-versions.sh for HEAD

### DIFF
--- a/scripts/docs-versions.sh
+++ b/scripts/docs-versions.sh
@@ -8,8 +8,7 @@ awk '
   BEGIN {
     print "{"
     print "  \"versions\": ["
-    getline current_version < "src/VERSION"
-    printf "    {\"name\": \"" current_version "\", \"url\": \"/api/master/\", \"released\": false}"
+    printf "    {\"name\": \"master\", \"url\": \"/api/master/\", \"released\": false}"
   }
 
   {

--- a/scripts/docs-versions.sh
+++ b/scripts/docs-versions.sh
@@ -8,7 +8,7 @@ awk '
   BEGIN {
     print "{"
     print "  \"versions\": ["
-    printf "    {\"name\": \"master\", \"url\": \"/api/master/\", \"released\": false}"
+    printf "    {\"name\": \"nightly\", \"url\": \"/api/master/\", \"released\": false}"
   }
 
   {


### PR DESCRIPTION
At the time when this list is generated (at release), `src/VERSION` is
typically equivalent to the most recent tagged version.
It's better to just call it master and not present the development version.

This is what the top of the generated versions select currently looks like (for 0.35.1):
```html
<option value="/api/master/" selected="true" disabled="true">0.35.1</option>
<option value="/api/0.35.1/" selected="true" disabled="true">0.35.1</option>
```

This is what it looks like after this patch:
```html
<option value="/api/master/">master</option>
<option value="/api/0.35.1/" selected="true" disabled="true">0.35.1</option>
```