### PR TITLE
[DocsGenerator] Add API index page

### DIFF
--- a/src/compiler/crystal/tools/doc/generator.cr
+++ b/src/compiler/crystal/tools/doc/generator.cr
@@ -74,6 +74,7 @@ class Crystal::Doc::Generator
     copy_files
     generate_types_docs types, @output_dir, types
     generate_readme program_type, types
+    generate_api_index types
     generate_sitemap types
   end
 
@@ -92,6 +93,10 @@ class Crystal::Doc::Generator
     if sitemap_base_url = @sitemap_base_url
       File.write File.join(@output_dir, "sitemap.xml"), SitemapTemplate.new(types, sitemap_base_url, "1.0", "never")
     end
+  end
+
+  def generate_api_index(types)
+    File.write File.join(@output_dir, "api-index.html"), APIIndexTemplate.new(project_info, types)
   end
 
   def copy_files

--- a/src/compiler/crystal/tools/doc/html/_list_items.html
+++ b/src/compiler/crystal/tools/doc/html/_list_items.html
@@ -1,4 +1,7 @@
 <ul>
+  <li>
+    <a href="<%= current_type.try(&.path_to("")) %>api-index.html" %>API Index</a>
+  </li>
   <% types.each do |type| %>
   <li class="<%= (type.program? || type.types.empty?) ? "" : ("parent" + (type.current?(current_type) || type.parents_of?(current_type) ? " open" : "")) %> <%= type.current?(current_type) ? "current" : "" %>" data-id="<%= type.html_id %>" data-name="<%= type.full_name.downcase %>">
       <a href="<%= type.path_from(current_type) %>"><%= type.name %></a>

--- a/src/compiler/crystal/tools/doc/html/api-index.html
+++ b/src/compiler/crystal/tools/doc/html/api-index.html
@@ -1,0 +1,41 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <%= HeadTemplate.new(project_info, "") %>
+  <meta name="repository-name" content="<%= project_info.name %>">
+  <title>API Index - <%= project_info.name %> <%= project_info.version %></title>
+  <script type="text/javascript">
+  CrystalDocs.base_path = "";
+  </script>
+</head>
+<body>
+
+<%= Crystal::Doc::SVG_DEFS %>
+<%= SidebarTemplate.new(project_info, types, nil) %>
+
+<div class="main-content">
+  <h1 class="type-name">
+    API Index
+  </h1>
+
+  <div class="api-reference">
+    <% iterate_types do |type| %>
+      <div class="api-reference__entry" id="<%= type.html_id %>">
+        <h3 class="type-name">
+          <% unless type.program? %>
+          <span class="kind"><%= type.abstract? ? "abstract " : ""%><%= type.kind %></span>
+          <% end %>
+          <a href="<%= type.path %>">
+            <%= type.full_name %>
+          </a>
+        </h3>
+
+        <div class="entry-content">
+          <%= type.formatted_summary %>
+        </div>
+      </div>
+    <% end %>
+  </div>
+</div>
+</body>
+</html>

--- a/src/compiler/crystal/tools/doc/html/css/style.css
+++ b/src/compiler/crystal/tools/doc/html/css/style.css
@@ -247,8 +247,11 @@ body {
 }
 
 .kind {
-  font-size: 60%;
   color: #866BA6;
+}
+
+h1 > .kind {
+  font-size: 60%;
 }
 
 .superclass-hierarchy {
@@ -723,4 +726,44 @@ span.flag.lime {
 .main-content h5:hover .anchor .octicon-link,
 .main-content h6:hover .anchor .octicon-link {
   visibility: visible
+}
+
+.api-reference {
+  display: grid;
+  grid-template-columns: auto 1.7rem auto;
+  grid-column-gap: .4em;
+  align-items: baseline;
+}
+
+.api-reference__entry {
+  display: contents;
+}
+
+.api-reference__entry > h3 {
+  display: contents;
+}
+
+.api-reference__entry > h3 > .kind,
+.api-reference__entry > h3 > a {
+  margin-top: 1.5rem;
+}
+
+.api-reference__entry > h3 > .kind {
+  grid-column: 1 / 3;
+  justify-self: flex-end;
+}
+.api-reference__entry > h3 > a {
+  grid-column: 3;
+  justify-self: flex-start;
+
+  text-decoration: none;
+}
+
+.api-reference__entry > .entry-content {
+  grid-column: 2 / 4;
+  margin: .5rem 0 0;
+}
+
+.entry-content > p {
+  margin: 0;
 }

--- a/src/compiler/crystal/tools/doc/templates.cr
+++ b/src/compiler/crystal/tools/doc/templates.cr
@@ -84,4 +84,16 @@ module Crystal::Doc
   record SitemapTemplate, types : Array(Type), base_url : String, priority : String, changefreq : String do
     ECR.def_to_s "#{__DIR__}/html/sitemap.xml"
   end
+
+  record APIIndexTemplate, project_info : ProjectInfo, types : Array(Type) do
+    ECR.def_to_s "#{__DIR__}/html/api-index.html"
+
+    def iterate_types(types = self.types, &block : Type ->)
+      types.each do |type|
+        block.call(type)
+
+        iterate_types(type.types, &block) unless type.program?
+      end
+    end
+  end
 end


### PR DESCRIPTION
This patch adds `api-index.html` page to the docs generator which provides an overview of all types. It's like a flattened version of the type list in the sidebar with a summary. It is supposed to help understand the individual pieces of the API in a higher level view.
I've often missed this when trying to understand the moving parts in a shard's API.

![grafik](https://user-images.githubusercontent.com/466378/99158633-32606600-26d5-11eb-9b0a-7923043619fc.png)

The wide margin on the left side is caused by longer type kinds below the fold:
![grafik](https://user-images.githubusercontent.com/466378/99158658-6f2c5d00-26d5-11eb-8dfa-f15fb32d5a18.png)
