### PR TITLE
[Compiler] Add Program#host_compiler

### DIFF
--- a/src/compiler/crystal/compiler.cr
+++ b/src/compiler/crystal/compiler.cr
@@ -202,6 +202,7 @@ module Crystal
 
     private def new_program(sources)
       @program = program = Program.new
+      program.compiler = self
       program.filename = sources.first.filename
       program.cache_dir = CacheDir.instance.directory_for(sources)
       program.codegen_target = codegen_target

--- a/src/compiler/crystal/macros/macros.cr
+++ b/src/compiler/crystal/macros/macros.cr
@@ -95,22 +95,7 @@ class Crystal::Program
       return CompiledMacroRun.new(executable_path, elapsed_time, true)
     end
 
-    compiler = Compiler.new
-
-    # Although release takes longer, once the bc is cached in .crystal
-    # the subsequent times will make program execution faster.
-    compiler.release = true
-
-    # Don't cleanup old directories after compiling: it might happen
-    # that in doing so we remove the directory associated with the current
-    # compilation (for example if we have more than 10 macro runs, the current
-    # directory will be the oldest).
-    compiler.cleanup = false
-
-    # No need to generate debug info for macro run programs
-    compiler.debug = Crystal::Debug::None
-
-    result = compiler.compile Compiler::Source.new(filename, source), executable_path
+    result = host_compiler.compile Compiler::Source.new(filename, source), executable_path
 
     # Write the new files from which 'filename' depends into the cache dir
     # (here we store how to obtain these files, because a require might use
@@ -132,6 +117,48 @@ class Crystal::Program
 
     elapsed_time = Time.monotonic - time
     CompiledMacroRun.new(executable_path, elapsed_time, false)
+  end
+
+  @host_compiler : Compiler?
+
+  # Creates a compiler instance with the host as target used for macro_run
+  # compilation.
+  def host_compiler
+    @host_compiler ||= Compiler.new.tap do |host_compiler|
+      if compiler = self.compiler
+        # When cross-compiling, the host compiler shouldn't copy the config for
+        # the target compiler and use the system defaults instead.
+        # TODO: Add configuration overrides for host compiler to CLI.
+        unless compiler.cross_compile
+          host_compiler.thin_lto = compiler.thin_lto
+          host_compiler.flags = compiler.flags
+          host_compiler.dump_ll = compiler.dump_ll?
+          host_compiler.link_flags = compiler.link_flags
+          host_compiler.mcpu = compiler.mcpu
+          host_compiler.mattr = compiler.mattr
+          host_compiler.mcmodel = compiler.mcmodel
+          host_compiler.single_module = compiler.single_module?
+          host_compiler.static = compiler.static?
+        end
+
+        # Copy default settings that are not specific to host and target context:
+        host_compiler.n_threads = compiler.n_threads
+        host_compiler.prelude = compiler.prelude
+      end
+
+      # Although release takes longer, once the bc is cached in .crystal
+      # the subsequent times will make program execution faster.
+      host_compiler.release = true
+
+      # Don't cleanup old directories after compiling: it might happen
+      # that in doing so we remove the directory associated with the current
+      # compilation (for example if we have more than 10 macro runs, the current
+      # directory will be the oldest).
+      host_compiler.cleanup = false
+
+      # No need to generate debug info for macro run programs
+      host_compiler.debug = Crystal::Debug::None
+    end
   end
 
   private def can_reuse_previous_compilation?(filename, executable_path, recorded_requires_path, requires_path)

--- a/src/compiler/crystal/program.cr
+++ b/src/compiler/crystal/program.cr
@@ -120,6 +120,8 @@ module Crystal
 
     getter predefined_constants = Array(Const).new
 
+    property compiler : Compiler?
+
     def initialize
       super(self, self, "main")
 


### PR DESCRIPTION
This is an implementation of my proposal in https://github.com/crystal-lang/crystal/pull/9425#issuecomment-727559640
It uses the same compiler configuration for host compiler (used for macro run) as for the target compiler (unless cross-compiling). Without this, macros are compiled with default options only.

The compiler instance is now assigned to `Program` and serves as a basis for creating a host compiler.
The host compiler is also cached to re-use a single instance every time. This change may be up for debate. Technically, a compiler instance is capable to be re-used. And I don't think macro runs can be executed concurrently. So this should be fine. I'd like to hear some thoughts on that, though.