### PR TITLE
Add wrapped unary negation to unsigned integer types

### DIFF
--- a/spec/std/uint_spec.cr
+++ b/spec/std/uint_spec.cr
@@ -6,4 +6,48 @@ describe "UInt" do
     (0_u32 <=> 0_u32).should eq(0)
     (0_u32 <=> 1_u32).should eq(-1)
   end
+
+  describe "&-" do
+    it "returns the wrapped negation" do
+      x = &-0_u32
+      x.should eq(0_u32)
+      x.should be_a(UInt32)
+
+      x = &-100_u8
+      x.should eq(156_u8)
+      x.should be_a(UInt8)
+
+      x = &-1_u8
+      x.should eq(255_u8)
+      x.should be_a(UInt8)
+
+      x = &-255_u8
+      x.should eq(1_u8)
+      x.should be_a(UInt8)
+
+      x = &-1_u16
+      x.should eq(65535_u16)
+      x.should be_a(UInt16)
+
+      x = &-65535_u16
+      x.should eq(1_u16)
+      x.should be_a(UInt16)
+
+      x = &-1_u32
+      x.should eq(4294967295_u32)
+      x.should be_a(UInt32)
+
+      x = &-4294967295_u32
+      x.should eq(1_u32)
+      x.should be_a(UInt32)
+
+      x = &-1_u64
+      x.should eq(18446744073709551615_u64)
+      x.should be_a(UInt64)
+
+      x = &-18446744073709551615_u64
+      x.should eq(1_u64)
+      x.should be_a(UInt64)
+    end
+  end
 end

--- a/src/int.cr
+++ b/src/int.cr
@@ -980,6 +980,10 @@ struct UInt8
   Number.expand_div [Float32], Float32
   Number.expand_div [Float64], Float64
 
+  def &-
+    0_u8 &- self
+  end
+
   def abs
     self
   end
@@ -1019,6 +1023,10 @@ struct UInt16
   Number.expand_div [Int8, UInt8, Int16, UInt16, Int32, UInt32, Int64, UInt64, Int128, UInt128], Float64
   Number.expand_div [Float32], Float32
   Number.expand_div [Float64], Float64
+
+  def &-
+    0_u16 &- self
+  end
 
   def abs
     self
@@ -1060,6 +1068,10 @@ struct UInt32
   Number.expand_div [Float32], Float32
   Number.expand_div [Float64], Float64
 
+  def &-
+    0_u32 &- self
+  end
+
   def abs
     self
   end
@@ -1099,6 +1111,10 @@ struct UInt64
   Number.expand_div [Int8, UInt8, Int16, UInt16, Int32, UInt32, Int64, UInt64, Int128, UInt128], Float64
   Number.expand_div [Float32], Float32
   Number.expand_div [Float64], Float64
+
+  def &-
+    0_u64 &- self
+  end
 
   def abs
     self
@@ -1140,6 +1156,11 @@ struct UInt128
   Number.expand_div [Int8, UInt8, Int16, UInt16, Int32, UInt32, Int64, UInt64, Int128, UInt128], Float64
   Number.expand_div [Float32], Float32
   Number.expand_div [Float64], Float64
+
+  def &-
+    # TODO: use 0_u128 - self
+    UInt128.new(0) &- self
+  end
 
   def abs
     self

--- a/src/int.cr
+++ b/src/int.cr
@@ -1158,7 +1158,7 @@ struct UInt128
   Number.expand_div [Float64], Float64
 
   def &-
-    # TODO: use 0_u128 - self
+    # TODO: use 0_u128 &- self
     UInt128.new(0) &- self
   end
 


### PR DESCRIPTION
Resolves #9914. These definitions simply mirror their signed counterparts.

Although some tests for unsigned integers go into `spec/std/int_spec.cr`, the tests for `#&-` are exclusively in `spec/std/uint_spec.cr` because this PR doesn't define the same method in signed integer types.