### PR TITLE
Add Iterator#with_object(obj, &)

### DIFF
--- a/spec/std/enumerable_spec.cr
+++ b/spec/std/enumerable_spec.cr
@@ -422,7 +422,7 @@ describe "Enumerable" do
       object = "a"
       (1..3).each_with_object(object) do |e, o|
         collection << {e, o}
-      end
+      end.should be(object)
       collection.should eq [{1, object}, {2, object}, {3, object}]
     end
 

--- a/spec/std/hash_spec.cr
+++ b/spec/std/hash_spec.cr
@@ -1002,15 +1002,15 @@ describe "Hash" do
         memo.should eq(:memo)
         k.should eq(:a)
         v.should eq('b')
-      end
+      end.should eq(:memo)
     end
 
     it "reduces the hash to the accumulated value of memo" do
       hash = {:a => 'b', :c => 'd', :e => 'f'}
-      result = nil
-      result = hash.each_with_object({} of Char => Symbol) do |(k, v), memo|
+      result = {} of Char => Symbol
+      hash.each_with_object(result) do |(k, v), memo|
         memo[v] = k
-      end
+      end.should be(result)
       result.should eq({'b' => :a, 'd' => :c, 'f' => :e})
     end
   end

--- a/spec/std/iterator_spec.cr
+++ b/spec/std/iterator_spec.cr
@@ -591,6 +591,15 @@ describe Iterator do
       iter.next.should eq({3, "a"})
       iter.next.should be_a(Iterator::Stop)
     end
+
+    it "does with object, with block" do
+      tuples = [] of {Int32, String}
+      object = "a"
+      (1..3).each.with_object(object) do |value, obj|
+        tuples << {value, obj}
+      end.should be(object)
+      tuples.should eq([{1, object}, {2, object}, {3, object}])
+    end
   end
 
   describe "zip" do

--- a/src/iterator.cr
+++ b/src/iterator.cr
@@ -1225,6 +1225,14 @@ module Iterator(T)
     WithObject(typeof(self), T, typeof(obj)).new(self, obj)
   end
 
+  # Yields each element in this iterator together with *obj*. Returns that object.
+  def with_object(obj, &)
+    each do |value|
+      yield value, obj
+    end
+    obj
+  end
+
   private struct WithObject(I, T, O)
     include Iterator({T, O})
     include IteratorWrapper


### PR DESCRIPTION
Code like

```crystal
(1..).each.with_object("x") { |n, str| puts str * n }
```

currently fails with

```
'Range::ItemIterator(Int32, Nil)#with_object' is not expected to be invoked with a block, but a block was given`
```

This is rather unexpected because the same code works on Ruby and the similar `Iterator#with_index(offset, &)` already exists in Crystal. This PR adds this corresponding block variant of `Iterator#with_object`.