### PR TITLE
 Don't merge proc types but allow assigning them if they are compatible

### DIFF
--- a/spec/compiler/semantic/proc_spec.cr
+++ b/spec/compiler/semantic/proc_spec.cr
@@ -889,6 +889,18 @@ describe "Semantic: proc" do
       )) { union_of proc_of(int32, int32), proc_of(int32, nil_type) }
   end
 
+  it "*doesn't* merge Proc that returns NoReturn with another one that returns something else (#9971)" do
+    assert_type(%(
+      lib LibC
+        fun exit : NoReturn
+      end
+
+      a = ->(x : Int32) { 1 }
+      b = ->(x : Int32) { LibC.exit }
+      a || b
+      )) { union_of proc_of(int32, int32), proc_of(int32, no_return) }
+  end
+
   it "merges return type" do
     assert_type(%(
       a = ->(x : Int32) { 1 }

--- a/src/compiler/crystal/semantic/bindings.cr
+++ b/src/compiler/crystal/semantic/bindings.cr
@@ -228,10 +228,21 @@ module Crystal
     #
     # Special cases are listed inside the method body.
     def restrict_type_to_freeze_type(freeze_type, type)
-      # We allow assigning Proc(*T, R) to Proc(*T, Nil)
-      if freeze_type.is_a?(ProcInstanceType) && freeze_type.return_type.nil_type?
-        if (type.is_a?(UnionType) && type.union_types.all?(&.implements?(freeze_type))) ||
-           type.implements?(freeze_type)
+      if freeze_type.is_a?(ProcInstanceType)
+        # We allow assigning Proc(*T, R) to Proc(*T, Nil)
+        if freeze_type.return_type.nil_type?
+          if (type.is_a?(UnionType) && type.union_types.all?(&.implements?(freeze_type))) ||
+             type.implements?(freeze_type)
+            return freeze_type
+          end
+        end
+
+        # We also allow assining Proc(*T, NoReturn) to Proc(*T, U)
+        if type.all? { |a_type|
+             a_type.is_a?(ProcInstanceType) &&
+             (a_type.return_type.is_a?(NoReturnType) || a_type.return_type == freeze_type.return_type) &&
+             a_type.arg_types == freeze_type.arg_types
+           }
           return freeze_type
         end
       end

--- a/src/compiler/crystal/semantic/bindings.cr
+++ b/src/compiler/crystal/semantic/bindings.cr
@@ -230,11 +230,11 @@ module Crystal
     def restrict_type_to_freeze_type(freeze_type, type)
       if freeze_type.is_a?(ProcInstanceType)
         # We allow assigning Proc(*T, R) to Proc(*T, Nil)
-        if freeze_type.return_type.nil_type?
-          if (type.is_a?(UnionType) && type.union_types.all?(&.implements?(freeze_type))) ||
-             type.implements?(freeze_type)
-            return freeze_type
-          end
+        if freeze_type.return_type.nil_type? &&
+           type.all? { |a_type|
+             a_type.is_a?(ProcInstanceType) && a_type.arg_types == freeze_type.arg_types
+           }
+          return freeze_type
         end
 
         # We also allow assining Proc(*T, NoReturn) to Proc(*T, U)

--- a/src/compiler/crystal/semantic/type_merge.cr
+++ b/src/compiler/crystal/semantic/type_merge.cr
@@ -273,22 +273,6 @@ module Crystal
     end
   end
 
-  class ProcInstanceType
-    def common_ancestor(other : ProcInstanceType)
-      # For Proc(..., NoReturn), Proc(..., T) we keep Proc(..., T)
-      if return_type.no_return? && arg_types == other.arg_types
-        return other
-      end
-
-      # Same but the other way around
-      if other.return_type.no_return? && arg_types == other.arg_types
-        return self
-      end
-
-      nil
-    end
-  end
-
   class TupleInstanceType
     def common_ancestor(other : TupleInstanceType)
       return nil unless self.size == other.size

--- a/src/compiler/crystal/types.cr
+++ b/src/compiler/crystal/types.cr
@@ -732,6 +732,13 @@ module Crystal
       nil
     end
 
+    # Yields self and returns true if the block returns a truthy value.
+    # UnionType overrides it and yields all types in turn and returns
+    # true if for each of them the block returns true.
+    def all?
+      (yield self) ? true : false
+    end
+
     def to_s(*, generic_args : Bool = true)
       String.build do |io|
         to_s_with_options io, generic_args: generic_args
@@ -1654,7 +1661,7 @@ module Crystal
   end
 
   # An un-bound type parameter of a generic type.
-  #
+
   # For example, given:
   #
   # ```
@@ -3049,6 +3056,10 @@ module Crystal
         end
       end
       program.type_merge(new_union_types) || program.no_return
+    end
+
+    def all?
+      union_types.all? { |union_type| yield union_type }
     end
 
     def to_s_with_options(io : IO, skip_union_parens : Bool = false, generic_args : Bool = true, codegen : Bool = false) : Nil


### PR DESCRIPTION
Fixes #9935

The idea is that if we have two variables, one of type `Proc(T, U)` and another one of type `Proc(T, NoReturn)` we **don't** merge them to be of type `Proc(T, U)`. It will always form a union now.

However, assigning a Proc that returns `NoReturn` to a Proc that returns a value is valid:

```crystal
class Foo
  @x : -> Int32

  def initialize
    @x = ->{ raise "OH NO" } # This compiles just fine. Value can't be extracted anyway...
  end
end

Foo.new.x
```

We are already doing something similar with `Proc(T, Nil)` and `Proc(T, U)`:

```crystal
class Foo
  @block : -> Nil

  def initialize
    @block = ->{ 1 } # This is fine! Value is ignored.
  end

  def block
    @block
  end
end

Foo.new.block
```

I also changed the code for the latter case to be a bit more explicit.