### PR TITLE
Compiler: fix proc of self causing multidispatch

### DIFF
--- a/spec/compiler/codegen/proc_spec.cr
+++ b/spec/compiler/codegen/proc_spec.cr
@@ -881,4 +881,30 @@ describe "Code gen: proc" do
       proc_a.call
       )).to_i.should eq(1)
   end
+
+  it "doesn't crash when taking a proc pointer to a virtual type (#9823)" do
+    run(%(
+      abstract struct Parent
+        abstract def work(a : Int32, b : Int32)
+
+        def get
+          ->work(Int32, Int32)
+        end
+      end
+
+      struct Child1 < Parent
+        def work(a : Int32, b : Int32)
+          a &+ b
+        end
+      end
+
+      struct Child2 < Parent
+        def work(a : Int32, b : Int32)
+          a &- b
+        end
+      end
+
+      Child1.new.as(Parent).get
+    ))
+  end
 end

--- a/spec/compiler/codegen/proc_spec.cr
+++ b/spec/compiler/codegen/proc_spec.cr
@@ -908,7 +908,7 @@ describe "Code gen: proc" do
     ))
   end
 
-  it "doesn't crash when taking a proc pointer that multidispatches (#3822)" do
+  it "doesn't crash when taking a proc pointer that multidispatches on the top-level (#3822)" do
     run(%(
       class Foo
         def initialize(@proc : Proc(Bar, Nil))
@@ -932,6 +932,35 @@ describe "Code gen: proc" do
       end
 
       Foo.new(->test(Bar))
+    ))
+  end
+
+  it "doesn't crash when taking a proc pointer that multidispatches on a module (#3822)" do
+    run(%(
+      class Foo
+        def initialize(@proc : Proc(Bar, Nil))
+        end
+      end
+
+      module Bar
+      end
+
+      class Baz
+        include Bar
+      end
+
+      module Moo
+        def self.test(bar : Bar)
+          if bar.is_a? Baz
+            test bar
+          end
+        end
+
+        def self.test(baz : Baz)
+        end
+      end
+
+      Foo.new(->Moo.test(Bar))
     ))
   end
 end

--- a/spec/compiler/codegen/proc_spec.cr
+++ b/spec/compiler/codegen/proc_spec.cr
@@ -907,4 +907,31 @@ describe "Code gen: proc" do
       Child1.new.as(Parent).get
     ))
   end
+
+  it "doesn't crash when taking a proc pointer that multidispatches (#3822)" do
+    run(%(
+      class Foo
+        def initialize(@proc : Proc(Bar, Nil))
+        end
+      end
+
+      module Bar
+      end
+
+      class Baz
+        include Bar
+      end
+
+      def test(bar : Bar)
+        if bar.is_a? Baz
+          test bar
+        end
+      end
+
+      def test(baz : Baz)
+      end
+
+      Foo.new(->test(Bar))
+    ))
+  end
 end

--- a/spec/compiler/semantic/closure_spec.cr
+++ b/spec/compiler/semantic/closure_spec.cr
@@ -262,6 +262,26 @@ describe "Semantic: closure" do
       "can't send closure to C function (closured vars: self)"
   end
 
+  it "errors if sending closured proc pointer to C (1.2)" do
+    assert_error %(
+      lib LibC
+        fun foo(callback : ->)
+      end
+
+      class Foo
+        def foo
+          LibC.foo(->{ bar })
+        end
+
+        def bar
+        end
+      end
+
+      Foo.new.foo
+      ),
+      "can't send closure to C function (closured vars: self)"
+  end
+
   it "errors if sending closured proc pointer to C (2)" do
     assert_error %(
       lib LibC

--- a/src/compiler/crystal/semantic/cleanup_transformer.cr
+++ b/src/compiler/crystal/semantic/cleanup_transformer.cr
@@ -518,18 +518,23 @@ module Crystal
           when InstanceVar
             arg.raise "#{message} (closured vars: self)"
           end
-          return
         end
 
         if arg.def.closure?
           vars = ClosuredVarsCollector.collect arg.def
-          unless vars.empty?
+          if vars.empty?
+            message += " (closured vars: self)"
+          else
             message += " (closured vars: #{vars.join ", "})"
           end
 
           arg.raise message
         end
       when ProcPointer
+        if expanded = arg.expanded
+          return check_arg_is_not_closure(node, message, expanded)
+        end
+
         if arg.obj.try &.type?.try &.passed_as_self?
           arg.raise "#{message} (closured vars: self)"
         end

--- a/src/compiler/crystal/semantic/literal_expander.cr
+++ b/src/compiler/crystal/semantic/literal_expander.cr
@@ -679,7 +679,19 @@ module Crystal
     # ->(x : X, y : Y) { tmp.bar(x, y) }
     # ```
     #
-    # And expand this:
+    # Expand this:
+    #
+    # ```
+    # ->Foo.bar(X, Y)
+    # ```
+    #
+    # To this:
+    #
+    # ```
+    # ->(x : X, y : Y) { Foo.bar(x, y) }
+    # ```
+    #
+    # Expand this:
     #
     # ```
     # ->bar(X, Y)
@@ -695,7 +707,7 @@ module Crystal
     def expand(node : ProcPointer)
       obj = node.obj
 
-      if obj
+      if obj && !obj.is_a?(Path)
         temp_var = new_temp_var.at(obj)
         assign = Assign.new(temp_var, obj)
         obj = temp_var

--- a/src/compiler/crystal/semantic/literal_expander.cr
+++ b/src/compiler/crystal/semantic/literal_expander.cr
@@ -678,12 +678,28 @@ module Crystal
     # tmp = foo
     # ->(x : X, y : Y) { tmp.bar(x, y) }
     # ```
+    #
+    # And expand this:
+    #
+    # ```
+    # ->bar(X, Y)
+    # ```
+    #
+    # To this:
+    #
+    # ```
+    # ->(x : X, y : Y) { bar(x, y) }
+    # ```
+    #
+    # in case the implicit `self` is a class or a virtual class.
     def expand(node : ProcPointer)
-      obj = node.obj.not_nil!
+      obj = node.obj
 
-      temp_var = new_temp_var.at(obj)
-      assign = Assign.new(temp_var, obj)
-      obj = temp_var
+      if obj
+        temp_var = new_temp_var.at(obj)
+        assign = Assign.new(temp_var, obj)
+        obj = temp_var
+      end
 
       def_args = node.args.map do |arg|
         Arg.new(@program.new_temp_var_name, restriction: arg).at(arg)
@@ -697,7 +713,11 @@ module Crystal
       proc_literal = ProcLiteral.new(Def.new("->", def_args, body)).at(node)
       proc_literal.proc_pointer = node
 
-      Expressions.new([assign, proc_literal])
+      if assign
+        Expressions.new([assign, proc_literal])
+      else
+        proc_literal
+      end
     end
 
     private def regex_new_call(node, value)

--- a/src/compiler/crystal/semantic/main_visitor.cr
+++ b/src/compiler/crystal/semantic/main_visitor.cr
@@ -1256,6 +1256,15 @@ module Crystal
         obj.accept self
       end
 
+      # If it's something like `->Foo.bar` and `Foo` is not a lib type,
+      # it could also be producing a multidispatch so we rewrite that too
+      # (lib types can never produce a mutlidispatch and in that case we can
+      # actually generate a function pointer that points right into the C fun).
+      if obj.is_a?(Path) && !obj.type.is_a?(LibType)
+        expand(node)
+        return false
+      end
+
       # The call might have been created if this is a proc pointer at the top-level
       call = node.call? || Call.new(obj, node.name).at(obj)
       prepare_call(call)

--- a/src/compiler/crystal/semantic/main_visitor.cr
+++ b/src/compiler/crystal/semantic/main_visitor.cr
@@ -1245,16 +1245,9 @@ module Crystal
 
       # If it's something like `->foo.bar` we turn it into a closure
       # where `foo` is assigned to a temporary variable.
-      if obj.is_a?(Var) || obj.is_a?(InstanceVar) || obj.is_a?(ClassVar)
-        expand(node)
-        return false
-      end
-
-      # If it's something like `->bar` where the implicit `self` is something
-      # that is passed as self in the codegen phase (like a class, or a virtual class)
-      # then we also turn it into a closure because ProcPointer doesn't support
-      # multidispatch and in the end the behavior is equivalent.
-      if !obj && (scope = @scope) && scope.passed_as_self?
+      # If it's something like `->foo` then we also turn it into a closure
+      # because it could be doing a mutlidispatch and that's not supported in ProcPointer.
+      if !obj || obj.is_a?(Var) || obj.is_a?(InstanceVar) || obj.is_a?(ClassVar)
         expand(node)
         return false
       end

--- a/src/compiler/crystal/semantic/main_visitor.cr
+++ b/src/compiler/crystal/semantic/main_visitor.cr
@@ -1250,6 +1250,15 @@ module Crystal
         return false
       end
 
+      # If it's something like `->bar` where the implicit `self` is something
+      # that is passed as self in the codegen phase (like a class, or a virtual class)
+      # then we also turn it into a closure because ProcPointer doesn't support
+      # multidispatch and in the end the behavior is equivalent.
+      if !obj && (scope = @scope) && scope.passed_as_self?
+        expand(node)
+        return false
+      end
+
       if obj
         obj.accept self
       end


### PR DESCRIPTION
Fixes #9823
Fixes #3822

We rewrite `->foo(X)` to `->(x : X) { foo(x) }` in case `self` in that context could cause a multi-dispatch. This is similar to #9824

I believe with this, Procs don't have any more bugs (that **I** am aware of, so this is probably a lie 😛 )