### PR TITLE
Add security policy

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,11 @@
+## Reporting a Vulnerability
+
+Should you find any security-related issue, please *do not share them openly* in
+the issue tracker. We have a dedicated mailbox where we keep track of them:
+
+<security@manas.tech>
+
+You can encrypt your message via [Keybase](https://keybase.io/encrypt) (set
+recipient `crystal`) or with our [PGP key](https://crystal-lang.org/crystal-pgp-key.txt)
+(fingerprint `5995 C83C D754 BE44 8164 1929 0961 7FD3 7CC0 6B54`)
+also available on [Keybase server](https://keybase.io/crystal/pgp_keys.asc).


### PR DESCRIPTION
Adds the security advisory section copied from https://crystal-lang.org/community/
This kind of information should be distributed with the code.