### PR TITLE
Compiler: fixes and improvements to closured variables

### DIFF
--- a/spec/compiler/semantic/closure_spec.cr
+++ b/spec/compiler/semantic/closure_spec.cr
@@ -603,6 +603,56 @@ describe "Semantic: closure" do
       "undefined method '&+'"
   end
 
+  it "does assign all types to metavar if closured but only assigned to once in a loop through block" do
+    assert_error %(
+      def capture(&block)
+        block
+      end
+
+      def loop
+        while 1 == 1
+          yield
+        end
+      end
+
+      x = 1
+      loop do
+        x = 1 == 2 ? 1 : nil
+        if x
+          capture do
+            x &+ 1
+          end
+        end
+      end
+      ),
+      "undefined method '&+'"
+  end
+
+  it "does assign all types to metavar if closured but only assigned to once in a loop through captured block" do
+    assert_error %(
+      def capture(&block)
+        block
+      end
+
+      def loop(&block)
+        while 1 == 1
+          block.call
+        end
+      end
+
+      x = 1
+      loop do
+        x = 1 == 2 ? 1 : nil
+        if x
+          capture do
+            x &+ 1
+          end
+        end
+      end
+      ),
+      "undefined method '&+'"
+  end
+
   it "considered as closure if assigned once but comes from a method arg" do
     assert_error %(
       def capture(&block)

--- a/spec/compiler/semantic/closure_spec.cr
+++ b/spec/compiler/semantic/closure_spec.cr
@@ -619,6 +619,21 @@ describe "Semantic: closure" do
       "undefined method '&+'"
   end
 
+  it "considers var as closure-readonly if it was assigned multiple times before it was closured" do
+    assert_no_errors(%(
+      def capture(&block)
+        block
+      end
+
+      x = "hello"
+      x = 1
+
+      capture do
+        x &+ 1
+      end
+      ))
+  end
+
   it "correctly captures type of closured block arg" do
     assert_type(%(
       def capture(&block)

--- a/spec/compiler/semantic/closure_spec.cr
+++ b/spec/compiler/semantic/closure_spec.cr
@@ -653,7 +653,50 @@ describe "Semantic: closure" do
       "undefined method '&+'"
   end
 
-  it "considered as closure if assigned once but comes from a method arg" do
+  it "doesn't assign all types to metavar if closured but declared inside block and never re-assigned" do
+    assert_no_errors %(
+      def capture(&block)
+        block
+      end
+
+      def loop(&block)
+        yield
+      end
+
+      loop do
+        x = 1 == 2 ? 1 : nil
+        if x
+          capture do
+            x &+ 1
+          end
+        end
+      end
+      )
+  end
+
+  it "doesn't assign all types to metavar if closured but declared inside block and re-assigned inside the same context before the closure" do
+    assert_no_errors %(
+      def capture(&block)
+        block
+      end
+
+      def loop(&block)
+        yield
+      end
+
+      loop do
+        x = 1 == 2 ? 1 : nil
+        x = 1 == 2 ? 1 : nil
+        if x
+          capture do
+            x &+ 1
+          end
+        end
+      end
+      )
+  end
+
+  it "is considered as closure if assigned once but comes from a method arg" do
     assert_error %(
       def capture(&block)
         block

--- a/spec/compiler/semantic/closure_spec.cr
+++ b/spec/compiler/semantic/closure_spec.cr
@@ -619,7 +619,7 @@ describe "Semantic: closure" do
       "undefined method '&+'"
   end
 
-  it "..." do
+  it "correctly captures type of closured block arg" do
     assert_type(%(
       def capture(&block)
         block.call

--- a/src/compiler/crystal/semantic/ast.cr
+++ b/src/compiler/crystal/semantic/ast.cr
@@ -497,8 +497,8 @@ module Crystal
       end
       io << " (nil-if-read)" if nil_if_read?
       io << " (closured)" if closured?
+      io << " (mutably-closured)" if mutably_closured?
       io << " (assigned-to)" if assigned_to?
-      io << " (readonly)" if readonly?
       io << " (object id: #{object_id})"
     end
 

--- a/src/compiler/crystal/semantic/ast.cr
+++ b/src/compiler/crystal/semantic/ast.cr
@@ -431,22 +431,37 @@ module Crystal
 
     # A variable is closured if it's used in a ProcLiteral context
     # where it wasn't created.
-    property? closured = false
+    getter? closured = false
 
     # Is this metavar assigned a value?
     property? assigned_to = false
 
-    # Is this metavar readonly? This means it was assigned once
-    # and then read, never reassigned again.
-    # If not, when it's closured then all local variable related to
+    # Is this metavar mutable? This means it got a value assigned to it more than once.
+    # If that's the case, when it's closured then all local variable related to
     # it will also be bound to it.
-    property? readonly = true
+    property? mutable = false
 
     # Local variables associated with this meta variable.
     # Can be Var or MetaVar.
     property(local_vars) { [] of ASTNode }
 
     def initialize(@name : String, @type : Type? = nil)
+    end
+
+    # Marks this variable as closured.
+    def mark_as_closured
+      @closured = true
+
+      return unless mutable?
+
+      local_vars = @local_vars
+      return unless local_vars
+
+      # If a meta var is mutable and it became a closure we must
+      # bind all previously related local vars to it so that
+      # they get all types assigned to it.
+      local_vars.each &.bind_to self
+      local_vars = nil
     end
 
     # True if this variable belongs to the given context
@@ -463,11 +478,6 @@ module Crystal
     # Is this metavar associated with any local vars?
     def local_vars?
       @local_vars
-    end
-
-    # TODO: rename and document
-    def closured_multibound?
-      closured? && !readonly?
     end
 
     def ==(other : self)
@@ -487,7 +497,7 @@ module Crystal
       io << " (nil-if-read)" if nil_if_read?
       io << " (closured)" if closured?
       io << " (assigned-to)" if assigned_to?
-      io << " (readonly)" if readonly?
+      io << " (mutable)" if mutable?
       io << " (object id: #{object_id})"
     end
 

--- a/src/compiler/crystal/semantic/ast.cr
+++ b/src/compiler/crystal/semantic/ast.cr
@@ -436,10 +436,11 @@ module Crystal
     # Is this metavar assigned a value?
     property? assigned_to = false
 
-    # Is this metavar readonly? This means it got a value assigned to it just once.
-    # If that's not the case, when it's closured then all local variable related to
+    # Is this metavar closured in a mutable way?
+    # This means it's closured and it got a value assigned to it more than once.
+    # If that's the case, when it's closured then all local variable related to
     # it will also be bound to it.
-    property? readonly = true
+    property? mutably_closured = false
 
     # Local variables associated with this meta variable.
     # Can be Var or MetaVar.
@@ -452,7 +453,7 @@ module Crystal
     def mark_as_closured
       @closured = true
 
-      return if readonly?
+      return unless mutably_closured?
 
       local_vars = @local_vars
       return unless local_vars

--- a/src/compiler/crystal/semantic/ast.cr
+++ b/src/compiler/crystal/semantic/ast.cr
@@ -436,6 +436,16 @@ module Crystal
     # Is this metavar assigned a value?
     property? assigned_to = false
 
+    # Is this metavar readonly? This means it was assigned once
+    # and then read, never reassigned again.
+    # If not, when it's closured then all local variable related to
+    # it will also be bound to it.
+    property? readonly = true
+
+    # Local variables associated with this meta variable.
+    # Can be Var or MetaVar.
+    property(local_vars) { [] of ASTNode }
+
     def initialize(@name : String, @type : Type? = nil)
     end
 
@@ -448,6 +458,16 @@ module Crystal
     # True if this variable belongs to the given context.
     def belongs_to?(context)
       @context.same?(context)
+    end
+
+    # Is this metavar associated with any local vars?
+    def local_vars?
+      @local_vars
+    end
+
+    # TODO: rename and document
+    def closured_multibound?
+      closured? && !readonly?
     end
 
     def ==(other : self)
@@ -467,6 +487,7 @@ module Crystal
       io << " (nil-if-read)" if nil_if_read?
       io << " (closured)" if closured?
       io << " (assigned-to)" if assigned_to?
+      io << " (readonly)" if readonly?
       io << " (object id: #{object_id})"
     end
 

--- a/src/compiler/crystal/semantic/ast.cr
+++ b/src/compiler/crystal/semantic/ast.cr
@@ -436,10 +436,10 @@ module Crystal
     # Is this metavar assigned a value?
     property? assigned_to = false
 
-    # Is this metavar mutable? This means it got a value assigned to it more than once.
-    # If that's the case, when it's closured then all local variable related to
+    # Is this metavar readonly? This means it got a value assigned to it just once.
+    # If that's not the case, when it's closured then all local variable related to
     # it will also be bound to it.
-    property? mutable = false
+    property? readonly = true
 
     # Local variables associated with this meta variable.
     # Can be Var or MetaVar.
@@ -452,12 +452,12 @@ module Crystal
     def mark_as_closured
       @closured = true
 
-      return unless mutable?
+      return if readonly?
 
       local_vars = @local_vars
       return unless local_vars
 
-      # If a meta var is mutable and it became a closure we must
+      # If a meta var is not readonly and it became a closure we must
       # bind all previously related local vars to it so that
       # they get all types assigned to it.
       local_vars.each &.bind_to self
@@ -497,7 +497,7 @@ module Crystal
       io << " (nil-if-read)" if nil_if_read?
       io << " (closured)" if closured?
       io << " (assigned-to)" if assigned_to?
-      io << " (mutable)" if mutable?
+      io << " (readonly)" if readonly?
       io << " (object id: #{object_id})"
     end
 

--- a/src/compiler/crystal/semantic/bindings.cr
+++ b/src/compiler/crystal/semantic/bindings.cr
@@ -164,6 +164,14 @@ module Crystal
       nodes.each &.remove_observer self
     end
 
+    def bound_to?(node : ASTNode)
+      @dependencies.try &.any? &.same?(node)
+    end
+
+    def bind_to_unless_bound(node : ASTNode)
+      bind_to(node) unless bound_to?(node)
+    end
+
     def add_observer(observer)
       observers = @observers ||= [] of ASTNode
       observers.push observer

--- a/src/compiler/crystal/semantic/bindings.cr
+++ b/src/compiler/crystal/semantic/bindings.cr
@@ -164,14 +164,6 @@ module Crystal
       nodes.each &.remove_observer self
     end
 
-    def bound_to?(node : ASTNode)
-      @dependencies.try &.any? &.same?(node)
-    end
-
-    def bind_to_unless_bound(node : ASTNode)
-      bind_to(node) unless bound_to?(node)
-    end
-
     def add_observer(observer)
       observers = @observers ||= [] of ASTNode
       observers.push observer

--- a/src/compiler/crystal/semantic/main_visitor.cr
+++ b/src/compiler/crystal/semantic/main_visitor.cr
@@ -3373,10 +3373,14 @@ module Crystal
         @meta_vars[name] = meta_var = new_meta_var(name)
       end
 
-      # If a variable is being assigned inside a loop then it's considered
+      # If a variable is being assigned inside a while then it's considered
       # as mutably closured: it will get a value assigned to it multiple times
       # exactly because it's in a loop.
-      meta_var.mutably_closured = true if inside_loop?
+      # If a variable is being assigned inside a block... well, we don't know.
+      # It could be that the `yield` is inside a `while` or not but right
+      # now we have no way to detect that, so we assume that can happen
+      # and always mark the var as mutably closured.
+      meta_var.mutably_closured = true if inside_while? || @block
 
       {meta_var, meta_var_existed}
     end
@@ -3389,7 +3393,7 @@ module Crystal
       @untyped_def || @block_context
     end
 
-    def inside_loop?
+    def inside_while?
       !@while_stack.empty?
     end
 


### PR DESCRIPTION
Fixes #5609
Fixes #3093

My previous attempts at this were almost fine but they had a flaw: I was reusing an existing property of `MetaVar` when I shouldn't have done that. I had this realization this morning (without really thinking about it, who knows how the brain works) and it's in this PR and it's working!

# Please ignore this section

This PR is great! No, it's **AWESOME**! I know, I know, who do I think I am, but after my [four](https://github.com/crystal-lang/crystal/pull/8587) [previously](https://github.com/crystal-lang/crystal/pull/8588) [failed](https://github.com/crystal-lang/crystal/pull/9977) [attempts](https://github.com/crystal-lang/crystal/pull/9980) I just want to celebrate and consider this the best PR in the history (not just in this repo, mind you).

# What's the bug

So, #5609 is this bug:

```crystal
def capture(&block)
  block
end

x = 1
3.times do
  p x
  capture do
    x = "hello"
  end.call
end
```

The output is:

```
1
194613232
194613232
```

It works in a wrong way, yet the code compiles fine. **These are the worst bug to have in a compiler.** It would be better if the code didn't compile at all. Just don't produce invalid code, compiler!

# How does the compiler detect and implement closured variables?

The way we detect a variable is closured is if we see it being used inside a captured block. Then, every subsequent occurrence of the variable will get the type of all types previously assigned to it (because you never know, or, well, the compiler never knows, when the block is going to be called). Additionally, things like `if x` or `if x.is_a?(T)` don't filter types because the code might be called after that check, so there's no guarantee the type will still be the same after it (remember this: it's important for something I will explain later on).

The problem was that variables declared or used **before** the closure was detected didn't also got bound to all types assigned to it. That's usually not a problem because if a variable is declared and used before a block captures it, why would it then get all types assigned to it later on? That code was already executed! Well... not always. If the variable is used in a loop then that can happen. And that's the bug.

# How does this PR fix the bug?

The idea is simple: for every occurrence of a variable (like `x` above) we keep a list of all the locations (well, nodes) it was used in. Then, if we detect it was closured, we can go ahead and bind those nodes to all types assigned to it, even if they came before we detect the closure ("all types assigned to it" is dynamic, the type is recomputed if the set of types or assignments changes, as usual throughout the compiler).

However, doing that fix alone introduces an annoyance. For example this code:

```crystal
def capture(&block)
  block
end

def foo(x)
  puts x.to_i if x.is_a?(String)
  capture do
    puts x
  end
end

foo(1 || "2")
```

Here `x` is of type `Int32 | String`. Now, `x` is closured in `capture` so every occurrence of `x` must have the type `Int32 | String` and, as I said before, things like `if x.is_a?(String)` don't filter types. So this code, which used to compile, wouldn't compile with just the fix I mentioned above. And that's annoying.

So, this PR also tracks whether a variable is **readonly**. This means whether a value was assigned to it just once. And it also takes loops (`while`) into consideration, because something assigned inside a `while` gets a value assigned to it potentially more than once.

Then, if a variable is closured but it's readonly, there's no need for all occurrences of it to get all types. It will never get assigned a value again, no problem. And that fixes #3093 . That's actually a long standing feature that I wanted to have in the language because closured readonly vars are very common, and it's nice to be able to filter their types if needed, without needing an extra local variable.

# Ugh, tracking all those local variables will surely make the compiler slower

It turns out, not that much. Compiling the compiler went from 28.59s and 1173.23MB to 29.2s and 1240.18MB without any cache. Subsequent compilations went from 18.06s to 18.37s, so not a big difference. I think the reason is that usually you don't assign to a variable multiple times, so in most cases a variable will have a list of just one element attached to it.

And, as I always like to think about this, I prefer things working well but maybe a bit slower, or consuming a bit more memory, than silently working wrong. There will be time in the future to optimize all of this, or to clean it up, and when that time comes we'll have a solid spec suite to make sure things continue to work as expected.

# Summary

This PR fixes one of the worst bugs a language could have, and also introduces a really neat feature, making coding simpler. What's not to like about it?