### PR TITLE
Include fragment within URI `#full_path`

### DIFF
--- a/spec/std/uri_spec.cr
+++ b/spec/std/uri_spec.cr
@@ -184,8 +184,11 @@ describe "URI" do
 
   describe "#full_path" do
     it { URI.new(path: "/foo").full_path.should eq("/foo") }
+    it { URI.new(path: "/foo", fragment: "anchor").full_path.should eq("/foo#anchor") }
     it { URI.new.full_path.should eq("/") }
+    it { URI.new(fragment: "anchor").full_path.should eq("/#anchor") }
     it { URI.new(path: "/foo", query: "q=1").full_path.should eq("/foo?q=1") }
+    it { URI.new(path: "/foo", query: "q=1", fragment: "anchor").full_path.should eq("/foo?q=1#anchor") }
     it { URI.new(path: "/", query: "q=1").full_path.should eq("/?q=1") }
     it { URI.new(query: "q=1").full_path.should eq("/?q=1") }
     it { URI.new(path: "/a%3Ab").full_path.should eq("/a%3Ab") }

--- a/src/uri.cr
+++ b/src/uri.cr
@@ -197,8 +197,12 @@ class URI
   def full_path : String
     String.build do |str|
       str << (@path.empty? ? '/' : @path)
-      if (query = @query) && !query.empty?
+      if query = @query.presence
         str << '?' << query
+      end
+
+      if fragment = @fragment.presence
+        str << '#' << fragment
       end
     end
   end

--- a/src/uri.cr
+++ b/src/uri.cr
@@ -192,7 +192,7 @@ class URI
   # require "uri"
   #
   # uri = URI.parse "http://foo.com/posts?id=30&limit=5#time=1305298413"
-  # uri.full_path # => "/posts?id=30&limit=5"
+  # uri.full_path # => "/posts?id=30&limit=5#time=1305298413"
   # ```
   def full_path : String
     String.build do |str|


### PR DESCRIPTION
Previously it was only included in the full URL representation via `.to_s`.