### PR TITLE
Improve documentation of mathematical functions

### DIFF
--- a/src/big/big_float.cr
+++ b/src/big/big_float.cr
@@ -355,6 +355,7 @@ class String
 end
 
 module Math
+  # Decomposes the given floating-point *value* into a normalized fraction and an integral power of two.
   def frexp(value : BigFloat)
     LibGMP.mpf_get_d_2exp(out exp, value) # we need BigFloat frac, so will skip Float64 one.
     frac = BigFloat.new do |mpf|
@@ -367,11 +368,12 @@ module Math
     {frac, exp}
   end
 
-  # Returns the sqrt of a `BigFloat`.
+  # Calculates the square root of *value*.
   #
   # ```
   # require "big"
-  # Math.sqrt((1000_000_000_0000.to_big_f*1000_000_000_00000.to_big_f))
+  #
+  # Math.sqrt(1_000_000_000_000.to_big_f * 1_000_000_000_000.to_big_f) # => 1000000000000.0
   # ```
   def sqrt(value : BigFloat)
     BigFloat.new { |mpf| LibGMP.mpf_sqrt(mpf, value) }

--- a/src/big/big_int.cr
+++ b/src/big/big_int.cr
@@ -714,12 +714,12 @@ class String
 end
 
 module Math
-  # Returns the sqrt of a `BigInt`.
+  # Calculates the square root of *value*.
   #
   # ```
   # require "big"
   #
-  # Math.sqrt((1000_000_000_0000.to_big_i*1000_000_000_00000.to_big_i))
+  # Math.sqrt(1_000_000_000_000.to_big_i * 1_000_000_000_000.to_big_i) # => 1000000000000.0
   # ```
   def sqrt(value : BigInt)
     sqrt(value.to_big_f)

--- a/src/big/big_rational.cr
+++ b/src/big/big_rational.cr
@@ -345,11 +345,12 @@ struct Float
 end
 
 module Math
-  # Returns the sqrt of a `BigRational`.
+  # Calculates the square root of *value*.
+  #
   # ```
   # require "big"
   #
-  # Math.sqrt((1000_000_000_0000.to_big_r*1000_000_000_00000.to_big_r))
+  # Math.sqrt(1_000_000_000_000.to_big_r * 1_000_000_000_000.to_big_r) # => 1000000000000.0
   # ```
   def sqrt(value : BigRational)
     sqrt(value.to_big_f)

--- a/src/complex.cr
+++ b/src/complex.cr
@@ -296,52 +296,52 @@ struct Number
 end
 
 module Math
-  # Calculates the exponential of the complex number `z`.
+  # Calculates the exponential of *value*.
   #
   # ```
   # require "complex"
   #
   # Math.exp(4 + 2.i) # => -22.720847417619233 + 49.645957334580565i
   # ```
-  def exp(z : Complex)
-    r = exp(z.real)
-    Complex.new(r * cos(z.imag), r * sin(z.imag))
+  def exp(value : Complex)
+    r = exp(value.real)
+    Complex.new(r * cos(value.imag), r * sin(value.imag))
   end
 
-  # Calculates the natural logarithm of the complex number `z`.
+  # Calculates the natural logarithm of *value*.
   #
   # ```
   # require "complex"
   #
   # Math.log(4 + 2.i) # => 1.4978661367769956 + 0.4636476090008061i
   # ```
-  def log(z : Complex)
-    Complex.new(Math.log(z.abs), z.phase)
+  def log(value : Complex)
+    Complex.new(Math.log(value.abs), value.phase)
   end
 
-  # Calculates the base-2 logarithm of the complex number `z`.
+  # Calculates the logarithm of *value* to base 2.
   #
   # ```
   # require "complex"
   #
   # Math.log2(4 + 2.i) # => 2.1609640474436813 + 0.6689021062254881i
   # ```
-  def log2(z : Complex)
-    log(z) / LOG2
+  def log2(value : Complex)
+    log(value) / LOG2
   end
 
-  # Calculates the base-10 logarithm of the complex number `z`.
+  # Calculates the logarithm of *value* to base 10.
   #
   # ```
   # require "complex"
   #
   # Math.log10(4 + 2.i) # => 0.6505149978319906 + 0.20135959813668655i
   # ```
-  def log10(z : Complex)
-    log(z) / LOG10
+  def log10(value : Complex)
+    log(value) / LOG10
   end
 
-  # Calculates the square root of the complex number `z`.
+  # Calculates the square root of *value*.
   # Inspired by the [following blog post](https://pavpanchekha.com/blog/casio-mathjs.html) of Pavel Panchekha on floating point precision.
   #
   # ```
@@ -359,21 +359,21 @@ module Math
   # Math.sqrt(-1.0)         # => -NaN
   # Math.sqrt(-1.0 + 0.0.i) # => 0.0 + 1.0i
   # ```
-  def sqrt(z : Complex)
-    r = z.abs
+  def sqrt(value : Complex)
+    r = value.abs
 
-    re = if z.real >= 0
-           0.5 * sqrt(2.0 * (r + z.real))
+    re = if value.real >= 0
+           0.5 * sqrt(2.0 * (r + value.real))
          else
-           z.imag.abs / sqrt(2.0 * (r - z.real))
+           value.imag.abs / sqrt(2.0 * (r - value.real))
          end
 
-    im = if z.real <= 0
-           0.5 * sqrt(2.0 * (r - z.real))
+    im = if value.real <= 0
+           0.5 * sqrt(2.0 * (r - value.real))
          else
-           z.imag.abs / sqrt(2.0 * (r + z.real))
+           value.imag.abs / sqrt(2.0 * (r + value.real))
          end
 
-    Complex.new(re, z.imag >= 0 ? im : -im)
+    Complex.new(re, value.imag >= 0 ? im : -im)
   end
 end

--- a/src/math/math.cr
+++ b/src/math/math.cr
@@ -8,44 +8,370 @@ module Math
   LOG2  = LibM.log_f64(2.0)
   LOG10 = LibM.log_f64(10.0)
 
-  {% for name in %w(acos acosh asin asinh atan atanh cbrt cos cosh erf erfc exp
-                   exp2 expm1 ilogb log log10 log1p log2 logb sin sinh sqrt tan tanh) %}
-    # Calculates the {{name.id}} of *value*.
-    def {{name.id}}(value : Float32)
-      LibM.{{name.id}}_f32(value)
-    end
+  # Calculates the sine of *value*, measured in radians.
+  def sin(value : Float32)
+    LibM.sin_f32(value)
+  end
 
-    # :ditto:
-    def {{name.id}}(value : Float64)
-      LibM.{{name.id}}_f64(value)
-    end
+  # :ditto:
+  def sin(value : Float64)
+    LibM.sin_f64(value)
+  end
 
-    # :ditto:
-    def {{name.id}}(value)
-      {{name.id}}(value.to_f)
-    end
-  {% end %}
+  # :ditto:
+  def sin(value)
+    sin(value.to_f)
+  end
 
-  {% for name in %w(besselj0 besselj1 bessely0 bessely1) %}
-    # Calculates the {{name.id}} function of *value*.
-    def {{name.id}}(value : Float32)
-      {% if flag?(:darwin) %}
-        LibM.{{name.id}}_f64(value).to_f32
-      {% else %}
-        LibM.{{name.id}}_f32(value)
-      {% end %}
-    end
+  # Calculates the cosine of *value*, measured in radians.
+  def cos(value : Float32)
+    LibM.cos_f32(value)
+  end
 
-    # :ditto:
-    def {{name.id}}(value : Float64)
-      LibM.{{name.id}}_f64(value)
-    end
+  # :ditto:
+  def cos(value : Float64)
+    LibM.cos_f64(value)
+  end
 
-    # :ditto:
-    def {{name.id}}(value)
-      {{name.id}}(value.to_f)
-    end
-  {% end %}
+  # :ditto:
+  def cos(value)
+    cos(value.to_f)
+  end
+
+  # Calculates the tangent of *value*, measured in radians.
+  def tan(value : Float32)
+    LibM.tan_f32(value)
+  end
+
+  # :ditto:
+  def tan(value : Float64)
+    LibM.tan_f64(value)
+  end
+
+  # :ditto:
+  def tan(value)
+    tan(value.to_f)
+  end
+
+  # Calculates the arc sine of *value*.
+  def asin(value : Float32)
+    LibM.asin_f32(value)
+  end
+
+  # :ditto:
+  def asin(value : Float64)
+    LibM.asin_f64(value)
+  end
+
+  # :ditto:
+  def asin(value)
+    asin(value.to_f)
+  end
+
+  # Calculates the arc cosine of *value*.
+  def acos(value : Float32)
+    LibM.acos_f32(value)
+  end
+
+  # :ditto:
+  def acos(value : Float64)
+    LibM.acos_f64(value)
+  end
+
+  # :ditto:
+  def acos(value)
+    acos(value.to_f)
+  end
+
+  # Calculates the arc tangent of *value*.
+  def atan(value : Float32)
+    LibM.atan_f32(value)
+  end
+
+  # :ditto:
+  def atan(value : Float64)
+    LibM.atan_f64(value)
+  end
+
+  # :ditto:
+  def atan(value)
+    atan(value.to_f)
+  end
+
+  # Calculates the two-argument arc tangent of the ray from (0, 0) to (*x*, *y*).
+  def atan2(y : Float32, x : Float32)
+    LibM.atan2_f32(y, x)
+  end
+
+  # :ditto:
+  def atan2(y : Float64, x : Float64)
+    LibM.atan2_f64(y, x)
+  end
+
+  # :ditto:
+  def atan2(y, x)
+    atan2(y.to_f, x.to_f)
+  end
+
+  # Calculates the hyperbolic sine of *value*.
+  def sinh(value : Float32)
+    LibM.sinh_f32(value)
+  end
+
+  # :ditto:
+  def sinh(value : Float64)
+    LibM.sinh_f64(value)
+  end
+
+  # :ditto:
+  def sinh(value)
+    sinh(value.to_f)
+  end
+
+  # Calculates the hyperbolic cosine of *value*.
+  def cosh(value : Float32)
+    LibM.cosh_f32(value)
+  end
+
+  # :ditto:
+  def cosh(value : Float64)
+    LibM.cosh_f64(value)
+  end
+
+  # :ditto:
+  def cosh(value)
+    cosh(value.to_f)
+  end
+
+  # Calculates the hyperbolic tangent of *value*.
+  def tanh(value : Float32)
+    LibM.tanh_f32(value)
+  end
+
+  # :ditto:
+  def tanh(value : Float64)
+    LibM.tanh_f64(value)
+  end
+
+  # :ditto:
+  def tanh(value)
+    tanh(value.to_f)
+  end
+
+  # Calculates the inverse hyperbolic sine of *value*.
+  def asinh(value : Float32)
+    LibM.asinh_f32(value)
+  end
+
+  # :ditto:
+  def asinh(value : Float64)
+    LibM.asinh_f64(value)
+  end
+
+  # :ditto:
+  def asinh(value)
+    asinh(value.to_f)
+  end
+
+  # Calculates the inverse hyperbolic cosine of *value*.
+  def acosh(value : Float32)
+    LibM.acosh_f32(value)
+  end
+
+  # :ditto:
+  def acosh(value : Float64)
+    LibM.acosh_f64(value)
+  end
+
+  # :ditto:
+  def acosh(value)
+    acosh(value.to_f)
+  end
+
+  # Calculates the inverse hyperbolic tangent of *value*.
+  def atanh(value : Float32)
+    LibM.atanh_f32(value)
+  end
+
+  # :ditto:
+  def atanh(value : Float64)
+    LibM.atanh_f64(value)
+  end
+
+  # :ditto:
+  def atanh(value)
+    atanh(value.to_f)
+  end
+
+  # Calculates the exponential of *value*.
+  def exp(value : Float32)
+    LibM.exp_f32(value)
+  end
+
+  # :ditto:
+  def exp(value : Float64)
+    LibM.exp_f64(value)
+  end
+
+  # :ditto:
+  def exp(value)
+    exp(value.to_f)
+  end
+
+  # Calculates the exponential of *value*, minus 1.
+  def expm1(value : Float32)
+    LibM.expm1_f32(value)
+  end
+
+  # :ditto:
+  def expm1(value : Float64)
+    LibM.expm1_f64(value)
+  end
+
+  # :ditto:
+  def expm1(value)
+    expm1(value.to_f)
+  end
+
+  # Calculates 2 raised to the power *value*.
+  def exp2(value : Float32)
+    LibM.exp2_f32(value)
+  end
+
+  # :ditto:
+  def exp2(value : Float64)
+    LibM.exp2_f64(value)
+  end
+
+  # :ditto:
+  def exp2(value)
+    exp2(value.to_f)
+  end
+
+  # Calculates the natural logarithm of *value*.
+  def log(value : Float32)
+    LibM.log_f32(value)
+  end
+
+  # :ditto:
+  def log(value : Float64)
+    LibM.log_f64(value)
+  end
+
+  # :ditto:
+  def log(value)
+    log(value.to_f)
+  end
+
+  # Calculates the natural logarithm of 1 plus *value*.
+  def log1p(value : Float32)
+    LibM.log1p_f32(value)
+  end
+
+  # :ditto:
+  def log1p(value : Float64)
+    LibM.log1p_f64(value)
+  end
+
+  # :ditto:
+  def log1p(value)
+    log1p(value.to_f)
+  end
+
+  # Calculates the logarithm of *value* to base 2.
+  def log2(value : Float32)
+    LibM.log2_f32(value)
+  end
+
+  # :ditto:
+  def log2(value : Float64)
+    LibM.log2_f64(value)
+  end
+
+  # :ditto:
+  def log2(value)
+    log2(value.to_f)
+  end
+
+  # Calculates the logarithm of *value* to base 10.
+  def log10(value : Float32)
+    LibM.log10_f32(value)
+  end
+
+  # :ditto:
+  def log10(value : Float64)
+    LibM.log10_f64(value)
+  end
+
+  # :ditto:
+  def log10(value)
+    log10(value.to_f)
+  end
+
+  # Calculates the logarithm of *value* to the given *base*.
+  def log(value, base)
+    log(value) / log(base)
+  end
+
+  # Calculates the square root of *value*.
+  def sqrt(value : Float32)
+    LibM.sqrt_f32(value)
+  end
+
+  # :ditto:
+  def sqrt(value : Float64)
+    LibM.sqrt_f64(value)
+  end
+
+  # :ditto:
+  def sqrt(value)
+    sqrt(value.to_f)
+  end
+
+  # Calculates the cubic root of *value*.
+  def cbrt(value : Float32)
+    LibM.cbrt_f32(value)
+  end
+
+  # :ditto:
+  def cbrt(value : Float64)
+    LibM.cbrt_f64(value)
+  end
+
+  # :ditto:
+  def cbrt(value)
+    cbrt(value.to_f)
+  end
+
+  # Calculates the error function of *value*.
+  def erf(value : Float32)
+    LibM.erf_f32(value)
+  end
+
+  # :ditto:
+  def erf(value : Float64)
+    LibM.erf_f64(value)
+  end
+
+  # :ditto:
+  def erf(value)
+    erf(value.to_f)
+  end
+
+  # Calculates 1 minus the error function of *value*.
+  def erfc(value : Float32)
+    LibM.erfc_f32(value)
+  end
+
+  # :ditto:
+  def erfc(value : Float64)
+    LibM.erfc_f64(value)
+  end
+
+  # :ditto:
+  def erfc(value)
+    erfc(value.to_f)
+  end
 
   # Calculates the gamma function of *value*.
   #
@@ -70,7 +396,7 @@ module Math
   # ```
   # Math.lgamma(2.96)
   # ```
-  # is the same as
+  # is equivalent to
   # ```
   # Math.log(Math.gamma(2.96).abs)
   # ```
@@ -92,93 +418,205 @@ module Math
     lgamma(value.to_f)
   end
 
-  {% for name in %w(atan2 copysign hypot) %}
-    # Calculates {{name.id}} with parameters *value1* and *value2*.
-    def {{name.id}}(value1 : Float32, value2 : Float32)
-      LibM.{{name.id}}_f32(value1, value2)
-    end
-
-    # :ditto:
-    def {{name.id}}(value1 : Float64, value2 : Float64)
-      LibM.{{name.id}}_f64(value1, value2)
-    end
-
-    # :ditto:
-    def {{name.id}}(value1, value2)
-      {{name.id}}(value1.to_f, value2.to_f)
-    end
-  {% end %}
-
-  # Returns the logarithm of *numeric* to the base *base*.
-  def log(numeric, base)
-    log(numeric) / log(base)
+  # Calculates the cylindrical Bessel function of the first kind of *value* for the given *order*.
+  def besselj(order : Int32, value : Float32)
+    {% if flag?(:darwin) %}
+      LibM.besselj_f64(order, value).to_f32
+    {% else %}
+      LibM.besselj_f32(order, value)
+    {% end %}
   end
 
-  def max(value1 : Float32, value2 : Float32)
-    LibM.max_f32(value1, value2)
+  # :ditto:
+  def besselj(order : Int32, value : Float64)
+    LibM.besselj_f64(order, value)
   end
 
-  def max(value1 : Float64, value2 : Float64)
-    LibM.max_f64(value1, value2)
+  # :ditto:
+  def besselj(order, value)
+    besselj(order.to_i32, value.to_f)
   end
 
-  # Returns the greater of *value1* and *value2*.
-  def max(value1, value2)
-    value1 >= value2 ? value1 : value2
+  # Calculates the cylindrical Bessel function of the first kind of *value* for order 0.
+  def besselj0(value : Float32)
+    {% if flag?(:darwin) %}
+      LibM.besselj0_f64(value).to_f32
+    {% else %}
+      LibM.besselj0_f32(value)
+    {% end %}
   end
 
-  def min(value1 : Float32, value2 : Float32)
-    LibM.min_f32(value1, value2)
+  # :ditto:
+  def besselj0(value : Float64)
+    LibM.besselj0_f64(value)
   end
 
-  def min(value1 : Float64, value2 : Float64)
-    LibM.min_f64(value1, value2)
+  # :ditto:
+  def besselj0(value)
+    besselj0(value.to_f)
   end
 
-  # Returns the smaller of *value1* and *value2*.
-  def min(value1, value2)
-    value1 <= value2 ? value1 : value2
+  # Calculates the cylindrical Bessel function of the first kind of *value* for order 1.
+  def besselj1(value : Float32)
+    {% if flag?(:darwin) %}
+      LibM.besselj1_f64(value).to_f32
+    {% else %}
+      LibM.besselj1_f32(value)
+    {% end %}
   end
 
-  {% for name in %w(besselj bessely) %}
-    # Calculates {{name.id}} with parameters *value1* and *value2*.
-    def {{name.id}}(value1 : Int32, value2 : Float32)
-      {% if flag?(:darwin) %}
-        LibM.{{name.id}}_f64(value1, value2).to_f32
-      {% else %}
-        LibM.{{name.id}}_f32(value1, value2)
-      {% end %}
-    end
+  # :ditto:
+  def besselj1(value : Float64)
+    LibM.besselj1_f64(value)
+  end
 
-    # :ditto:
-    def {{name.id}}(value1 : Int32, value2 : Float64)
-      LibM.{{name.id}}_f64(value1, value2)
-    end
+  # :ditto:
+  def besselj1(value)
+    besselj1(value.to_f)
+  end
 
-    # :ditto:
-    def {{name.id}}(value1, value2)
-      {{name.id}}(value1.to_i32, value1.to_f)
-    end
-  {% end %}
+  # Calculates the cylindrical Bessel function of the second kind of *value* for the given *order*.
+  def bessely(order : Int32, value : Float32)
+    {% if flag?(:darwin) %}
+      LibM.bessely_f64(order, value).to_f32
+    {% else %}
+      LibM.bessely_f32(order, value)
+    {% end %}
+  end
 
-  {% for name in %w(ldexp scalbn) %}
-    # Calculates {{name.id}} with parameters *value1* and *value2*.
-    def {{name.id}}(value1 : Float32, value2 : Int32)
-      LibM.{{name.id}}_f32(value1, value2)
-    end
+  # :ditto:
+  def bessely(order : Int32, value : Float64)
+    LibM.bessely_f64(order, value)
+  end
 
-    # :ditto:
-    def {{name.id}}(value1 : Float64, value2 : Int32)
-      LibM.{{name.id}}_f64(value1, value2)
-    end
+  # :ditto:
+  def bessely(order, value)
+    bessely(order.to_i32, value.to_f)
+  end
 
-    # :ditto:
-    def {{name.id}}(value1, value2)
-      {{name.id}}(value1.to_f, value2.to_i32)
-    end
-  {% end %}
+  # Calculates the cylindrical Bessel function of the second kind of *value* for order 0.
+  def bessely0(value : Float32)
+    {% if flag?(:darwin) %}
+      LibM.bessely0_f64(value).to_f32
+    {% else %}
+      LibM.bessely0_f32(value)
+    {% end %}
+  end
 
-  # Multiplies *value* by 2 raised to power *exp*.
+  # :ditto:
+  def bessely0(value : Float64)
+    LibM.bessely0_f64(value)
+  end
+
+  # :ditto:
+  def bessely0(value)
+    bessely0(value.to_f)
+  end
+
+  # Calculates the cylindrical Bessel function of the second kind of *value* for order 1.
+  def bessely1(value : Float32)
+    {% if flag?(:darwin) %}
+      LibM.bessely1_f64(value).to_f32
+    {% else %}
+      LibM.bessely1_f32(value)
+    {% end %}
+  end
+
+  # :ditto:
+  def bessely1(value : Float64)
+    LibM.bessely1_f64(value)
+  end
+
+  # :ditto:
+  def bessely1(value)
+    bessely1(value.to_f)
+  end
+
+  # Calculates the length of the hypotenuse from (0, 0) to (*value1*, *value2*).
+  #
+  # Equivalent to
+  # ```
+  # Math.sqrt(value1 ** 2 + value2 ** 2)
+  # ```
+  def hypot(value1 : Float32, value2 : Float32)
+    LibM.hypot_f32(value1, value2)
+  end
+
+  # :ditto:
+  def hypot(value1 : Float64, value2 : Float64)
+    LibM.hypot_f64(value1, value2)
+  end
+
+  # :ditto:
+  def hypot(value1, value2)
+    hypot(value1.to_f, value2.to_f)
+  end
+
+  # Returns the unbiased base 2 exponent of the given floating-point *value*.
+  def ilogb(value : Float32)
+    LibM.ilogb_f32(value)
+  end
+
+  # :ditto:
+  def ilogb(value : Float64)
+    LibM.ilogb_f64(value)
+  end
+
+  # :ditto:
+  def ilogb(value)
+    ilogb(value.to_f)
+  end
+
+  # Returns the unbiased radix-independent exponent of the given floating-point *value*.
+  #
+  # For `Float32` and `Float64` this is equivalent to `ilogb`.
+  def logb(value : Float32)
+    LibM.logb_f32(value)
+  end
+
+  # :ditto:
+  def logb(value : Float64)
+    LibM.logb_f64(value)
+  end
+
+  # :ditto:
+  def logb(value)
+    logb(value.to_f)
+  end
+
+  # Multiplies the given floating-point *value* by 2 raised to the power *exp*.
+  def ldexp(value : Float32, exp : Int32)
+    LibM.ldexp_f32(value, exp)
+  end
+
+  # :ditto:
+  def ldexp(value : Float64, exp : Int32)
+    LibM.ldexp_f64(value, exp)
+  end
+
+  # :ditto:
+  def ldexp(value, exp)
+    ldexp(value.to_f, exp.to_i32)
+  end
+
+  # Returns the floating-point *value* with its exponent raised by *exp*.
+  #
+  # For `Float32` and `Float64` this is equivalent to `ldexp`.
+  def scalbn(value : Float32, exp : Int32)
+    LibM.scalbn_f32(value, exp)
+  end
+
+  # :ditto:
+  def scalbn(value : Float64, exp : Int32)
+    LibM.scalbn_f64(value, exp)
+  end
+
+  # :ditto:
+  def scalbn(value, exp)
+    scalbn(value.to_f, exp.to_i32)
+  end
+
+  # :ditto:
   def scalbln(value : Float32, exp : Int64)
     LibM.scalbln_f32(value, exp)
   end
@@ -193,7 +631,7 @@ module Math
     scalbln(value.to_f, exp.to_i64)
   end
 
-  # Decomposes given floating point *value* into a normalized fraction and an integral power of two.
+  # Decomposes the given floating-point *value* into a normalized fraction and an integral power of two.
   def frexp(value : Float32)
     frac = LibM.frexp_f32(value, out exp)
     {frac, exp}
@@ -208,6 +646,51 @@ module Math
   # :ditto:
   def frexp(value)
     frexp(value.to_f)
+  end
+
+  # Returns the floating-point value with the magnitude of *value1* and the sign of *value2*.
+  def copysign(value1 : Float32, value2 : Float32)
+    LibM.copysign_f32(value1, value2)
+  end
+
+  # :ditto:
+  def copysign(value1 : Float64, value2 : Float64)
+    LibM.copysign_f64(value1, value2)
+  end
+
+  # :ditto:
+  def copysign(value1, value2)
+    copysign(value1.to_f, value2.to_f)
+  end
+
+  # Returns the greater of *value1* and *value2*.
+  def max(value1 : Float32, value2 : Float32)
+    LibM.max_f32(value1, value2)
+  end
+
+  # :ditto:
+  def max(value1 : Float64, value2 : Float64)
+    LibM.max_f64(value1, value2)
+  end
+
+  # :ditto:
+  def max(value1, value2)
+    value1 >= value2 ? value1 : value2
+  end
+
+  # Returns the smaller of *value1* and *value2*.
+  def min(value1 : Float32, value2 : Float32)
+    LibM.min_f32(value1, value2)
+  end
+
+  # :ditto:
+  def min(value1 : Float64, value2 : Float64)
+    LibM.min_f64(value1, value2)
+  end
+
+  # :ditto:
+  def min(value1, value2)
+    value1 <= value2 ? value1 : value2
   end
 
   # Computes the next highest power of 2 of *v*.


### PR DESCRIPTION
Adds better documentation to the functions from the `Math` module. Unfortunately, this means the module no longer uses macros to quickly generate those `LibM` wrappers.

Also changes the parameter names of some functions, for consistency with either similar functions or other overloads:

* `Math.atan2(value1, value2)` => `Math.atan2(y, x)`
* `Math.log(numeric, base)` => `Math.log(value, base)`
* `Math.besselj(value1, value2)` => `Math.besselj(order, value)`, ditto for `.bessely`
* `Math.ldexp(value1, value2)` => `Math.ldexp(value, exp)`
* `Math.scalbn(value1, value2)` => `Math.scalbn(value, exp)`
* `Math.exp(z : Complex)` => `Math.exp(value : Complex)`, ditto for the `Complex` overloads of `.log`, `.log2`, `.log10`, and `.sqrt`

This could break code that uses named arguments for these mathematical functions. They are probably very rare though.