### PR TITLE
Compiler: don't use init check for class vars initialized before read

### DIFF
--- a/src/compiler/crystal/codegen/class_var.cr
+++ b/src/compiler/crystal/codegen/class_var.cr
@@ -86,7 +86,9 @@ class Crystal::CodeGenVisitor
 
     # For unsafe class var we just initialize them without
     # using a flag to know if they were initialized
-    if class_var.uninitialized? || !init_func
+    if class_var.uninitialized? || !init_func || !class_var.read?
+      class_var.no_init_flag = true
+
       global = declare_class_var(class_var)
       global = ensure_class_var_in_this_module(global, class_var)
       if init_func
@@ -97,7 +99,7 @@ class Crystal::CodeGenVisitor
 
     global, initialized_flag = declare_class_var_and_initialized_flag_in_this_module(class_var)
 
-    lazy_initialize_class_var(initializer.node, init_func, global, initialized_flag)
+    lazy_initialize_class_var(initializer.node, init_func.not_nil!, global, initialized_flag)
   end
 
   def lazy_initialize_class_var(node, init_func, global, initialized_flag)
@@ -175,6 +177,8 @@ class Crystal::CodeGenVisitor
   end
 
   def read_class_var_ptr(class_var : MetaTypeVar)
+    class_var.read = true
+
     owner = class_var.owner
     case owner
     when VirtualType
@@ -184,7 +188,7 @@ class Crystal::CodeGenVisitor
     end
 
     initializer = class_var.initializer
-    if !initializer || class_var.uninitialized?
+    if !initializer || class_var.uninitialized? || class_var.no_init_flag?
       # Read directly without init flag, but make sure to declare the global in this module too
       return get_class_var_global(class_var)
     end

--- a/src/compiler/crystal/semantic/ast.cr
+++ b/src/compiler/crystal/semantic/ast.cr
@@ -502,6 +502,15 @@ module Crystal
     # Is this variable "unsafe" (no need to check if it was initialized)?
     property? uninitialized = false
 
+    # Was this class_var already read during the codegen phase?
+    # If not, and we are at the place that declares the class var, we can
+    # directly initialize it now, without checking for an `init` flag.
+    property? read = false
+
+    # If true, there's no need to check whether the class var was initialized or
+    # not when reading it.
+    property? no_init_flag = false
+
     def kind
       case name[0]
       when '@'


### PR DESCRIPTION
Similar to #9801 but for class variables.

# Benchmarks

Here's one benchmark to show how things improve, and more benchmarks to show that the standard library already benefits from this change.

## Generic benchmark for accessing a class variable

Run by passing `4` as an argument:

```crystal
require "benchmark"

class Foo
  class_property range = 3..7
end

a = 1
v = ARGV[0].to_i

Benchmark.ips do |x|
  x.report("class var") do
    case v
    when Foo.range
      a &+= 1
    end
  end
  x.report("inline") do
    case v
    when 3..7
      a &+= 1
    end
  end
  x.report("manual") do
    if 3 <= v <= 7
      a &+= 1
    end
  end
end

puts a
```

Before:

```
class var 299.07M (  3.34ns) (± 7.23%)  0.0B/op   2.74× slower
   inline 819.16M (  1.22ns) (± 6.16%)  0.0B/op        fastest
   manual 808.29M (  1.24ns) (± 6.69%)  0.0B/op   1.01× slower
```

After:

```
class var 670.64M (  1.49ns) (± 5.67%)  0.0B/op   1.19× slower
   inline 672.62M (  1.49ns) (± 7.11%)  0.0B/op   1.18× slower
   manual 796.03M (  1.26ns) (± 7.52%)  0.0B/op        fastest
```


## spawn

All fibers are stored in a stack_pool class variable.

```crystal
require "benchmark"

Benchmark.ips do |x|
  x.report("spawn") do
    spawn do
    end
  end
end
```

Before:

```
spawn 163.08k (  6.13µs) (±42.48%)  212B/op  fastest
```

After:

```
spawn 208.27k (  4.80µs) (±31.17%)  207B/op  fastest
```

## caller

This depends on a `skip` class variable to check for files that are skipped when building the caller stack.

```crystal
require "benchmark"

Benchmark.ips do |x|
  x.report("caller") do
    caller
  end
end
```

Before:

```
caller 152.18k (  6.57µs) (± 6.94%)  4.03kB/op  fastest
```

After:

```
caller 170.98k (  5.85µs) (± 3.64%)  2.71kB/op  fastest
```

## Array#to_s

This depends on a class variable to check for recursive execution.

```crystal
require "benchmark"

a = [1, 2, 3]
null = File.open(File::NULL, "w")

Benchmark.ips do |x|
  x.report("Array#to_s") do
    a.to_s(null)
  end
end
```

Before:

```
Array#to_s  12.84M ( 77.91ns) (± 2.26%)  0.0B/op  fastest
```

After:

```
Array#to_s  13.07M ( 76.52ns) (± 2.27%)  0.0B/op  fastest
```