### PR TITLE
Improve `Int#lcm` and `Int#gcd`

### DIFF
--- a/spec/std/big/big_int_spec.cr
+++ b/spec/std/big/big_int_spec.cr
@@ -362,9 +362,15 @@ describe "BigInt" do
 
     (a_17).gcd(17).should eq(17)
     (-a_17).gcd(17).should eq(17)
+    (17).gcd(a_17).should eq(17)
+    (17).gcd(-a_17).should eq(17)
+
+    (a_17).lcm(17).should eq(a_17)
+    (-a_17).lcm(17).should eq(a_17)
+    (17).lcm(a_17).should eq(a_17)
+    (17).lcm(-a_17).should eq(a_17)
 
     (a_17).gcd(17).should be_a(Int::Unsigned)
-    (a_17).lcm(17).should eq(a_17)
   end
 
   it "can use Number::[]" do

--- a/spec/std/int_spec.cr
+++ b/spec/std/int_spec.cr
@@ -163,6 +163,8 @@ describe "Int" do
     it { 4.lcm(6).should eq(12) }
     it { 0.lcm(2).should eq(0) }
     it { 2.lcm(0).should eq(0) }
+
+    it "doesn't silently overflow" { 2_000_000.lcm(3_000_000).should eq(6_000_000) }
   end
 
   describe "to_s in base" do

--- a/src/big/big_int.cr
+++ b/src/big/big_int.cr
@@ -382,19 +382,23 @@ struct BigInt < Int
     BigInt.new { |mpz| LibGMP.pow_ui(mpz, self, other) }
   end
 
+  # Returns the greatest common divisor of `self` and *other*.
   def gcd(other : BigInt) : BigInt
     BigInt.new { |mpz| LibGMP.gcd(mpz, self, other) }
   end
 
+  # :ditto:
   def gcd(other : Int) : Int
     result = LibGMP.gcd_ui(nil, self, other.abs.to_u64)
     result == 0 ? self : result
   end
 
+  # Returns the least common multiple of `self` and *other*.
   def lcm(other : BigInt) : BigInt
     BigInt.new { |mpz| LibGMP.lcm(mpz, self, other) }
   end
 
+  # :ditto:
   def lcm(other : Int) : BigInt
     BigInt.new { |mpz| LibGMP.lcm_ui(mpz, self, other.abs.to_u64) }
   end
@@ -662,10 +666,12 @@ struct Int
     to_big_i % other
   end
 
-  def gcm(other : BigInt) : Int
-    other.gcm(self)
+  # Returns the greatest common divisor of `self` and *other*.
+  def gcd(other : BigInt) : Int
+    other.gcd(self)
   end
 
+  # Returns the least common multiple of `self` and *other*.
   def lcm(other : BigInt) : BigInt
     other.lcm(self)
   end

--- a/src/int.cr
+++ b/src/int.cr
@@ -431,8 +431,8 @@ struct Int
     end
   end
 
-  # Returns the greatest common divisor of `self` and `other`. Signed
-  # integers may raise overflow if either has value equal to `MIN` of
+  # Returns the greatest common divisor of `self` and *other*. Signed
+  # integers may raise `OverflowError` if either has value equal to `MIN` of
   # its type.
   #
   # ```
@@ -475,8 +475,11 @@ struct Int
     u.unsafe_shl shift
   end
 
+  # Returns the least common multiple of `self` and *other*.
+  #
+  # Raises `OverflowError` in case of overflow.
   def lcm(other : Int)
-    (self * other).abs // gcd(other)
+    (self // gcd(other) * other).abs
   end
 
   def divisible_by?(num)


### PR DESCRIPTION
* Performs division before multiplication in `Int#lcm(other : Int)` to avoid cases where `x.lcm(y)` always overflows if `x * y` does even when the result fits, e.g. `2_000_000.lcm(3_000_000) # => 6000000`.
* Removes the non-functional `Int#gcm(other : BigInt)` overload; it appears to be a typo of `#gcd`, which was also missing. (This is not a breaking change because the original definition simply calls `#gcm` again, so it would have already broken code that relied on it.)
* Adds documentation for all overloads.
