### PR TITLE
Check for overflow when extending signed integers to unsigned integers

### DIFF
--- a/spec/compiler/codegen/arithmetics_spec.cr
+++ b/spec/compiler/codegen/arithmetics_spec.cr
@@ -211,6 +211,23 @@ describe "Code gen: arithmetic primitives" do
         end
       {% end %}
 
+      {% if [UInt16, UInt32, UInt64].includes?(type) %}
+        it "raises overflow if lower than {{type}}::MIN (#9997)" do
+          run(%(
+            require "prelude"
+
+            v = -1_i8
+
+            begin
+              v.{{method}}
+              0
+            rescue OverflowError
+              1
+            end
+          )).to_i.should eq(1)
+        end
+      {% end %}
+
       {% if ![Int128].includes?(type) && SupportedInts.includes?(Int128) %}
         it "raises overflow if lower than {{type}}::MIN (using Int128)" do
           run(%(

--- a/spec/compiler/codegen/tuple_spec.cr
+++ b/spec/compiler/codegen/tuple_spec.cr
@@ -62,7 +62,7 @@ describe "Code gen: tuple" do
     run("
       struct Pointer
         def self.malloc(size : Int)
-          malloc(size.to_u64)
+          malloc(size.to_u64!)
         end
       end
 

--- a/src/compiler/crystal/codegen/primitives.cr
+++ b/src/compiler/crystal/codegen/primitives.cr
@@ -612,6 +612,14 @@ class Crystal::CodeGenVisitor
       end
       arg
     when from_type.rank < to_type.rank
+      # extending a signed integer to an unsigned one (eg: Int8 to UInt16)
+      # may still lead to underflow
+      if checked
+        if from_type.signed? && to_type.unsigned?
+          overflow = codegen_out_of_range(to_type, from_type, arg)
+          codegen_raise_overflow_cond(overflow)
+        end
+      end
       extend_int from_type, to_type, arg
     else
       if checked

--- a/src/pointer.cr
+++ b/src/pointer.cr
@@ -413,7 +413,7 @@ struct Pointer(T)
   # ptr.address # => 5678
   # ```
   def self.new(address : Int)
-    new address.to_u64
+    new address.to_u64!
   end
 
   # Allocates `size * sizeof(T)` bytes from the system's heap initialized

--- a/src/random/pcg32.cr
+++ b/src/random/pcg32.cr
@@ -71,7 +71,7 @@ class Random::PCG32
   end
 
   def jump(delta)
-    deltau64 = UInt64.new(delta)
+    deltau64 = UInt64.new!(delta)
     acc_mult = 1u64
     acc_plus = 0u64
     cur_plus = @inc


### PR DESCRIPTION
Fixes #9997. Code like `-1_i8.to_u16` will raise after this PR.

Crystal relies on wrapping conversions from `Int32` to `UInt64` in a few places, but incorrectly used the safe variants:

* `Pointer.new(address : Int)`: Since pointers are already fairly unsafe, this change should be fine. Without this, Crystal would complain about lib constants like `LibC::MAP_FAILED = Pointer(Void).new(-1)`; the alternative fix is to call `.to_u64!` on those `-1` instead.
* `Random::PCG32#jump(delta)`: From the [original source code](https://github.com/imneme/pcg-c/blob/83252d9c23df9c82ecb42210afed61a7b42402d7/src/pcg-advance-64.c): `Even though delta is an unsigned integer, we can pass a signed integer to go backwards, it just goes "the long way round".` Thus wrapping conversion is indeed correct here.
* A spec in `spec/compiler/codegen/tuple_spec.cr`: The same spec uses `&+` instead of `+`, so `.to_u64!` is probably the right thing to do already even without this PR.