### PR TITLE
Spec: show diff between expected and actual values when `should eq` fails

### DIFF
--- a/spec/compiler/formatter/formatter_spec.cr
+++ b/spec/compiler/formatter/formatter_spec.cr
@@ -6,13 +6,43 @@ private def assert_format(input, output = input, strict = false, file = __FILE__
     output = "#{output}\n" unless strict
     result = Crystal.format(input)
     unless result == output
-      fail "Expected\n\n~~~\n#{input}\n~~~\nto format to:\n\n~~~\n#{output}\n~~~\n\nbut got:\n\n~~~\n#{result}\n~~~\n\n  assert_format #{input.inspect}, #{result.chomp.inspect}"
+      fail <<-MSG
+        Expected
+
+        ~~
+        #{input}
+        ~~~
+
+        to format to:
+
+        ~~~
+        #{output}
+        ~~~
+
+        but got:
+
+        ~~~
+        #{result}
+        ~~~
+
+        diff:
+
+        ~~~
+        #{Spec.diff(output, result)}
+        ~~~
+
+        assert_format #{input.inspect}, #{result.chomp.inspect}
+        MSG
     end
 
     # Check idempotency
     result2 = Crystal.format(result)
     unless result == result2
-      fail "Idempotency failed:\nBefore: #{result.inspect}\nAfter:  #{result2.inspect}"
+      fail <<-MSG
+        Idempotency failed:
+        Before: #{result.inspect}
+        After:  #{result2.inspect}
+        MSG
     end
   end
 end

--- a/spec/std/spec/expectations_spec.cr
+++ b/spec/std/spec/expectations_spec.cr
@@ -141,4 +141,48 @@ describe "expectations" do
       expect_raises(Exception, "Ops") { raise Exception.new("Ops") }
     end
   end
+
+  describe "Spec.diff" do
+    it { Spec.diff("", "").should be_nil }
+    it { Spec.diff("foo", "bar").should be_nil }
+    it { Spec.diff("foo\nbar", "foo\nbar").should eq("") }
+    it { Spec.diff("bar\nfoo", "foo\nbar").should eq(<<-DIFF + "\n") }
+      --- expected
+      +++ actual
+      @@ -1,2 +1,2 @@
+      -bar
+       foo
+      +bar
+      DIFF
+  end
+
+  describe "Spec.diff_values" do
+    it { Spec.diff_values("", "").should be_nil }
+    it { Spec.diff_values("foo", "bar").should be_nil }
+
+    it "shows diff of two long arrays" do
+      xs = (1..100).to_a
+      ys = xs[0...50] + [-1] + xs[50...100]
+      Spec.diff_values(xs, ys).should eq(<<-DIFF + "\n")
+       --- expected
+       +++ actual
+       @@ -48,6 +48,7 @@
+         48,
+         49,
+         50,
+       + -1,
+         51,
+         52,
+         53,
+       DIFF
+    end
+
+    it "shows the message when the diff is empty" do
+      xs = (1..100).to_a
+      Spec.diff_values(xs, xs).should eq(<<-MSG)
+        No visible difference in the `Array(Int32)#pretty_inspect` output.
+        You should look at the implementation of `#==` on Array(Int32) or its members.
+        MSG
+    end
+  end
 end

--- a/spec/std/spec_spec.cr
+++ b/spec/std/spec_spec.cr
@@ -15,6 +15,35 @@ private class NilMimicker
 end
 
 describe "Spec matchers" do
+  describe "should eq" do
+    it "passes for the same value" do
+      1.should eq(1)
+    end
+
+    it "should raise an exception with diff when the values are long" do
+      xs = (1..100).to_a
+      ys = xs[0...50] + [-1] + xs[50...100]
+      msg = <<-MSG
+        Expected: #{xs.inspect}
+             got: #{ys.inspect}
+
+        --- expected
+        +++ actual
+        @@ -48,6 +48,7 @@
+          48,
+          49,
+          50,
+        + -1,
+          51,
+          52,
+          53,
+        MSG
+      expect_raises Spec::AssertionFailed, msg do
+        ys.should eq(xs)
+      end
+    end
+  end
+
   describe "should be_truthy" do
     it "passes for true" do
       true.should be_truthy


### PR DESCRIPTION
Fixed #9948

Screenshot:

![スクリーンショット 2020-12-01 20 01 43](https://user-images.githubusercontent.com/6679325/100732433-0dc3f800-3410-11eb-9017-0ca8d52a1894.png)

This PR adds only `diff` output to the `AssertionFailed` message.

We can consider the following enhancements:

  - Make `#pretty_inspect` output stable on `Hash` keys and `Set` values for `diff`.
    (by adding `stable` option to `#pretty_inspect`?)
  - Highlight `diff` output for human readability.
  - Add word diff by using `wdiff` command.

Thank you.