### PR TITLE
Always clear unused bits of `BitArray`s

### DIFF
--- a/spec/std/bit_array_spec.cr
+++ b/spec/std/bit_array_spec.cr
@@ -73,6 +73,17 @@ describe "BitArray" do
       (a == b).should be_true
       (b == c).should be_false
       (a == d).should be_false
+
+      e = from_int(16, 0b01001101_00011111)
+      f = from_int(16, 0b00000000_00011111)
+      (e == f).should be_false
+    end
+
+    it "compares other initialized with true (#8543)" do
+      a = BitArray.new(26, true)
+      b = BitArray.new(26, true)
+      b[23] = false
+      (a == b).should be_false
     end
 
     it "compares other type" do
@@ -200,7 +211,7 @@ describe "BitArray" do
       ba[34] = true
       ba[37] = true
 
-      ba[28..-1].should eq(from_int(12, 0b001110100100))
+      ba[28..-1].should eq(from_int(12, 0b0011_10100100))
     end
 
     it "gets on large bitarrays" do
@@ -211,7 +222,7 @@ describe "BitArray" do
       ba[34] = true
       ba[37] = true
 
-      ba[28..40].should eq(from_int(13, 0b0011101001000))
+      ba[28..40].should eq(from_int(13, 0b00111_01001000))
 
       ba[62] = true
       ba[63] = true
@@ -219,15 +230,15 @@ describe "BitArray" do
       ba[66] = true
       ba[69] = true
 
-      ba[60..72].should eq(from_int(13, 0b0011101001000))
-      ba[28..72].should eq(from_int(45, 0b001110100100000000000000000000000011101001000_u64))
+      ba[60..72].should eq(from_int(13, 0b00111_01001000))
+      ba[28..72].should eq(from_int(45, 0b00111_01001000_00000000_00000000_00000111_01001000_u64))
     end
 
     it "preserves equality" do
       ba = BitArray.new(100)
       25.upto(42) { |i| ba[i] = true }
 
-      ba[28..40].should eq(from_int(13, 0b1111111111111))
+      ba[28..40].should eq(from_int(13, 0b11111_11111111))
     end
   end
 
@@ -248,6 +259,7 @@ describe "BitArray" do
 
     ary.invert
     ary.all?.should be_true
+    (100..127).each { |i| ary.unsafe_fetch(i).should be_false }
 
     ary[50] = false
     ary[33] = false
@@ -278,6 +290,11 @@ describe "BitArray" do
     ary.size.times { |i| ary[i].should be_true }
   end
 
+  it "initializes with unused bits cleared" do
+    ary = BitArray.new(3, true)
+    (0...32).each { |i| ary.unsafe_fetch(i).should eq(i < ary.size) }
+  end
+
   it "reads bits from slice" do
     ary = BitArray.new(43) # 5 bytes 3 bits
     # 11010000_00000000_00001011_00000000_00000000_101xxxxx
@@ -305,7 +322,7 @@ describe "BitArray" do
     slice = ary.to_slice
     slice[0] = 0b10101010_u8
     slice[1] = 0b01010101_u8
-    slice[5] = 0b11111101_u8
+    slice[5] = 0b00000101_u8
     ary.each_with_index do |e, i|
       e.should eq(i.in?(1, 3, 5, 7, 8, 10, 12, 14, 40, 42))
     end

--- a/src/bit_array.cr
+++ b/src/bit_array.cr
@@ -28,6 +28,7 @@ struct BitArray
   def initialize(@size, initial : Bool = false)
     value = initial ? UInt32::MAX : UInt32::MIN
     @bits = Pointer(UInt32).malloc(malloc_size, value)
+    clear_unused_bits if initial
   end
 
   def ==(other : BitArray)
@@ -35,7 +36,7 @@ struct BitArray
     # NOTE: If BitArray implements resizing, there may be more than 1 binary
     # representation and their hashes for equivalent BitArrays after a downsize as the
     # discarded bits may not have been zeroed.
-    return LibC.memcmp(@bits, other.@bits, malloc_size) == 0
+    return LibC.memcmp(@bits, other.@bits, bytesize) == 0
   end
 
   def unsafe_fetch(index : Int)
@@ -165,6 +166,9 @@ struct BitArray
         i += 1
       end
 
+      # The last assignment to `bits` might refer to a `UInt32` in the middle of
+      # the buffer, so the last `UInt32` of `ba` might contain unused bits.
+      ba.clear_unused_bits
       ba
     end
   end
@@ -202,6 +206,7 @@ struct BitArray
     malloc_size.times do |i|
       @bits[i] = ~@bits[i]
     end
+    clear_unused_bits
   end
 
   # Creates a string representation of self.
@@ -228,8 +233,11 @@ struct BitArray
   # Returns a `Bytes` able to read and write bytes from a buffer.
   # The slice will be long enough to hold all the bits groups in bytes despite the `UInt32` internal representation.
   # It's useful for reading and writing a bit array from a byte buffer directly.
+  #
+  # It is undefined behaviour to set any of the unused bits of a bit array to
+  # `true` via a slice.
   def to_slice : Bytes
-    Slice.new(@bits.as(Pointer(UInt8)), (@size / 8.0).ceil.to_i)
+    Slice.new(@bits.as(Pointer(UInt8)), bytesize)
   end
 
   # See `Object#hash(hasher)`
@@ -257,7 +265,17 @@ struct BitArray
     index.divmod(32)
   end
 
+  protected def clear_unused_bits
+    # There are no unused bits if `size` is a multiple of 32.
+    bit_index, sub_index = @size.divmod(32)
+    @bits[bit_index] &= (1 << sub_index) - 1 unless sub_index == 0
+  end
+
+  private def bytesize
+    (@size - 1) // 8 + 1
+  end
+
   private def malloc_size
-    (@size / 32.0).ceil.to_i
+    (@size - 1) // 32 + 1
   end
 end

--- a/src/bit_array.cr
+++ b/src/bit_array.cr
@@ -234,7 +234,7 @@ struct BitArray
   # The slice will be long enough to hold all the bits groups in bytes despite the `UInt32` internal representation.
   # It's useful for reading and writing a bit array from a byte buffer directly.
   #
-  # It is undefined behaviour to set any of the unused bits of a bit array to
+  # WARNING: It is undefined behaviour to set any of the unused bits of a bit array to
   # `true` via a slice.
   def to_slice : Bytes
     Slice.new(@bits.as(Pointer(UInt8)), bytesize)


### PR DESCRIPTION
Fixes #8543. Does not affect #8494.

`.new` and `#invert` could also set unused bits in a `BitArray`, besides `#[]` according to https://github.com/crystal-lang/crystal/pull/8494#discussion_r354503447. These cases are also checked.