### PR TITLE
Make `File.size` and `FileInfo#size` be Int64 instead of UInt64

### DIFF
--- a/src/crystal/system/unix/file_info.cr
+++ b/src/crystal/system/unix/file_info.cr
@@ -2,8 +2,8 @@ struct Crystal::System::FileInfo < ::File::Info
   def initialize(@stat : LibC::Stat)
   end
 
-  def size : UInt64
-    @stat.st_size.to_u64
+  def size : Int64
+    @stat.st_size.to_i64
   end
 
   def permissions : ::File::Permissions

--- a/src/crystal/system/win32/file_info.cr
+++ b/src/crystal/system/win32/file_info.cr
@@ -27,8 +27,8 @@ struct Crystal::System::FileInfo < ::File::Info
     @reparse_tag = LibC::DWORD.new(0)
   end
 
-  def size : UInt64
-    (@file_attributes.nFileSizeHigh.to_u64 << 32) | @file_attributes.nFileSizeLow.to_u64
+  def size : Int64
+    ((@file_attributes.nFileSizeHigh.to_u64 << 32) | @file_attributes.nFileSizeLow.to_u64).to_i64
   end
 
   def permissions : ::File::Permissions

--- a/src/file.cr
+++ b/src/file.cr
@@ -194,7 +194,7 @@ class File < IO::FileDescriptor
   # File.write("foo", "foo")
   # File.size("foo") # => 3
   # ```
-  def self.size(filename : Path | String) : UInt64
+  def self.size(filename : Path | String) : Int64
     info(filename).size
   end
 

--- a/src/file/info.cr
+++ b/src/file/info.cr
@@ -79,7 +79,7 @@ class File
   # It is returned by `File.info`, `File#info` and `File.info?`.
   abstract struct Info
     # Size of the file, in bytes.
-    abstract def size : UInt64
+    abstract def size : Int64
 
     # The permissions of the file.
     abstract def permissions : Permissions


### PR DESCRIPTION
Fixes #9969