### PR TITLE
Remove `Hash#key_index` 

### DIFF
--- a/spec/std/hash_spec.cr
+++ b/spec/std/hash_spec.cr
@@ -835,12 +835,6 @@ describe "Hash" do
     h.shift?.should be_nil
   end
 
-  it "gets key index" do
-    h = {1 => 2, 3 => 4}
-    h.key_index(3).should eq(1)
-    h.key_index(2).should be_nil
-  end
-
   it "inserts many" do
     times = 1000
     h = {} of Int32 => Int32

--- a/spec/std/named_tuple_spec.cr
+++ b/spec/std/named_tuple_spec.cr
@@ -280,11 +280,6 @@ describe "NamedTuple" do
     tup.to_a.should eq([{:a, 1}, {:b, 'a'}])
   end
 
-  it "does key_index" do
-    tup = {a: 1, b: 'a'}
-    tup.to_a.should eq([{:a, 1}, {:b, 'a'}])
-  end
-
   it "does map" do
     tup = {a: 1, b: 'a'}
     strings = tup.map { |k, v| "#{k.inspect}-#{v.inspect}" }

--- a/src/compiler/crystal/types.cr
+++ b/src/compiler/crystal/types.cr
@@ -607,7 +607,7 @@ module Crystal
         if index
           index
         else
-          index = instance_vars.key_index(name)
+          index = hash_key_index instance_vars, name
           if index
             superclass.all_instance_vars_count + index
           else
@@ -615,8 +615,15 @@ module Crystal
           end
         end
       else
-        instance_vars.key_index(name)
+        hash_key_index instance_vars, name
       end
+    end
+
+    private def hash_key_index(hash, key)
+      hash.each_with_index do |(my_key, my_value), index|
+        return index if key == my_key
+      end
+      nil
     end
 
     def lookup_instance_var(name)

--- a/src/compiler/crystal/types.cr
+++ b/src/compiler/crystal/types.cr
@@ -607,7 +607,7 @@ module Crystal
         if index
           index
         else
-          index = hash_key_index instance_vars, name
+          index = instance_vars.index { |k, v| k == name }
           if index
             superclass.all_instance_vars_count + index
           else
@@ -615,15 +615,8 @@ module Crystal
           end
         end
       else
-        hash_key_index instance_vars, name
+        instance_vars.index { |k, v| k == name }
       end
-    end
-
-    private def hash_key_index(hash, key)
-      hash.each_with_index do |(my_key, my_value), index|
-        return index if key == my_key
-      end
-      nil
     end
 
     def lookup_instance_var(name)

--- a/src/hash.cr
+++ b/src/hash.cr
@@ -1368,21 +1368,6 @@ class Hash(K, V)
     to_a_impl &.value
   end
 
-  # Returns the index of the given key, or `nil` when not found.
-  # The keys are ordered based on when they were inserted.
-  #
-  # ```
-  # h = {"foo" => "bar", "baz" => "qux"}
-  # h.key_index("foo") # => 0
-  # h.key_index("qux") # => nil
-  # ```
-  def key_index(key)
-    each_with_index do |(my_key, my_value), index|
-      return index if key == my_key
-    end
-    nil
-  end
-
   # Returns a new `Hash` with the keys and values of this hash and *other* combined.
   # A value in *other* takes precedence over the one in this hash.
   #


### PR DESCRIPTION
As I mentioned in https://github.com/crystal-lang/crystal/issues/9952#issuecomment-737264971 I needed this for the compiler and added it to Hash, a really long time ago. I don't think that method is generally useful, and it was only used in one place in the compiler. Ruby doesn't have such method, so let's remove it.

As a side note, I'd also like to remove `Hash#first_key` and `Hash#first_value`: they are redundant because one can do `hash.first[0]` and `hash.first[1]` (plus they don't exist in Ruby either).