### PR TITLE
Parser: better error message when an `end` is missing

### DIFF
--- a/spec/compiler/parser/parser_spec.cr
+++ b/spec/compiler/parser/parser_spec.cr
@@ -2080,6 +2080,183 @@ module Crystal
         exps = Parser.parse(code).as(Expressions)
         exps.expressions[1].location.not_nil!.line_number.should eq(7)
       end
+
+      context "missing end" do
+        assert_syntax_error <<-CODE, <<-ERROR, line: 6
+          class Foo
+            class Bar
+              class Baz
+                @x : Int32 = 0
+
+            end
+          end
+          CODE
+          missing `end` before this line to match `class` at line 3
+
+          Note: the above line number is just a suggestion based on the general indentation of the file.
+          The missing `end` could be somewhere else.
+          ERROR
+
+        assert_syntax_error <<-CODE, <<-ERROR, line: 6
+          class Foo
+            private class Bar
+              private class Baz
+                @x : Int32 = 0
+
+            end
+          end
+          CODE
+          missing `end` before this line to match `class` at line 3
+
+          Note: the above line number is just a suggestion based on the general indentation of the file.
+          The missing `end` could be somewhere else.
+          ERROR
+
+        assert_syntax_error <<-CODE, <<-ERROR, line: 6
+          class Foo
+            abstract class Bar
+              abstract class Baz
+                @x : Int32 = 0
+
+            end
+          end
+          CODE
+          missing `end` before this line to match `class` at line 3
+
+          Note: the above line number is just a suggestion based on the general indentation of the file.
+          The missing `end` could be somewhere else.
+          ERROR
+
+        assert_syntax_error <<-CODE, <<-ERROR, line: 6
+          class Foo
+            class Bar
+              class Baz
+                @x : Int32 = 0
+
+              class Qux
+              end
+            end
+          end
+          CODE
+          missing `end` before this line to match `class` at line 3
+
+          Note: the above line number is just a suggestion based on the general indentation of the file.
+          The missing `end` could be somewhere else.
+          ERROR
+
+        assert_syntax_error <<-CODE, <<-ERROR, line: 6
+          class Foo
+            class Bar
+              foo do
+                x = 0
+
+              class Qux
+              end
+            end
+          end
+          CODE
+          missing `end` before this line to match `do` at line 3
+
+          Note: the above line number is just a suggestion based on the general indentation of the file.
+          The missing `end` could be somewhere else.
+          ERROR
+
+        assert_syntax_error <<-CODE, <<-ERROR, line: 6
+          class Foo
+            class Bar
+              foo do
+                x = 0
+
+              @x : Int32
+
+              class Qux
+              end
+            end
+          end
+          CODE
+          missing `end` before this line to match `do` at line 3
+
+          Note: the above line number is just a suggestion based on the general indentation of the file.
+          The missing `end` could be somewhere else.
+          ERROR
+
+        assert_syntax_error <<-CODE, <<-ERROR, line: 6
+          class Foo
+            class Bar
+              begin
+                x = 0
+
+              @x : Int32
+
+              class Qux
+              end
+            end
+          end
+          CODE
+          missing `end` before this line to match `begin` at line 3
+
+          Note: the above line number is just a suggestion based on the general indentation of the file.
+          The missing `end` could be somewhere else.
+          ERROR
+
+        assert_syntax_error <<-CODE, <<-ERROR, line: 9
+          class Foo
+            def foo
+            end
+
+            class Bar
+              class Baz
+                @x : Int32 = 0
+
+            end
+          end
+          CODE
+          missing `end` before this line to match `class` at line 6
+
+          Note: the above line number is just a suggestion based on the general indentation of the file.
+          The missing `end` could be somewhere else.
+          ERROR
+
+        assert_syntax_error <<-CODE, <<-ERROR, line: 11
+          class Foo
+            if 1
+            elsif 2
+            else
+            end
+
+            class Bar
+              class Baz
+                @x : Int32 = 0
+
+            end
+          end
+          CODE
+          missing `end` before this line to match `class` at line 8
+
+          Note: the above line number is just a suggestion based on the general indentation of the file.
+          The missing `end` could be somewhere else.
+          ERROR
+
+        assert_syntax_error <<-CODE, <<-ERROR, line: 11
+          class Foo
+            case 1
+            when 2
+            else
+            end
+
+            class Bar
+              class Baz
+                @x : Int32 = 0
+
+            end
+          end
+          CODE
+          missing `end` before this line to match `class` at line 8
+
+          Note: the above line number is just a suggestion based on the general indentation of the file.
+          The missing `end` could be somewhere else.
+          ERROR
+      end
     end
   end
 end


### PR DESCRIPTION
# What is this?

For example if you have this code:

```crystal
class Foo
  class Bar

  class Baz
  end
end
```

The old error message was:

```
In foo.cr:7:1
Error: expecting identifier 'end', not 'EOF'
```

The new error message is:

```
In foo.cr:4:1

 4 | class Baz
   ^
Error: missing `end` before this line to match `class` at line 2

Note: the above line number is just a suggestion based on the general indentation of the file.
The missing `end` could be somewhere else.
```

# How does it work?

The parser tracks the minimum expected indentation for every line. It starts with 0, and as declarations nest the minimum is increased. Whenever we find an indent that doesn't match this minimum, we store that as a possible indentation error. Then, when we reach the end of file but we were expecting to find an `end`, we check if we had an indent mismatch and use that.

This depends on the user properly indenting this code.

I think this frequently happens on accidental edits: you remove a chunk of code and you are left with some missing `end`s, but the entire file is still mostly correctly indented (assuming you format your code on save, or you just indent it well manually). Otherwise the error might be misleading, but the "Note" says it's just a suggestion, so it's better than nothing.

# What issue does this solve?

I can't remember... @straight-shoota do you remember? I did this based on your excellent comment that this feature can be implemented if indentation is taken into account.