### PR TITLE
Fix documentation for `#[]=` macro methods

### DIFF
--- a/src/compiler/crystal/macros.cr
+++ b/src/compiler/crystal/macros.cr
@@ -689,7 +689,7 @@ module Crystal::Macros
     end
 
     # Similar to `Array#[]=`.
-    def []=(index : NumberLiteral, value : ASTNode)
+    def []=(index : NumberLiteral, value : ASTNode) : ASTNode
     end
 
     # Similar to `Array#unshift`.
@@ -760,7 +760,7 @@ module Crystal::Macros
     end
 
     # Similar to `Hash#[]=`
-    def []=(key : ASTNode) : ASTNode
+    def []=(key : ASTNode, value : ASTNode) : ASTNode
     end
 
     # Returns the type specified at the end of the Hash literal, if any.
@@ -835,7 +835,7 @@ module Crystal::Macros
     end
 
     # Adds or replaces a key.
-    def []=(key : SymbolLiteral | StringLiteral | MacroId) : ASTNode
+    def []=(key : SymbolLiteral | StringLiteral | MacroId, value : ASTNode) : ASTNode
     end
   end
 

--- a/src/compiler/crystal/macros/methods.cr
+++ b/src/compiler/crystal/macros/methods.cr
@@ -2456,7 +2456,7 @@ private def interpret_array_or_tuple_method(object, klass, method, args, block, 
       index += object.elements.size if index < 0
 
       unless 0 <= index < object.elements.size
-        index_node.raise "index out of bounds (index: #{index}, size: #{object.elements.size}"
+        index_node.raise "index out of bounds (index: #{index}, size: #{object.elements.size})"
       end
 
       object.elements[index] = value


### PR DESCRIPTION
The documentation for `HashLiteral#[]=` and `NamedTupleLiteral#[]=` didn't include the `value` parameter, this PR adds them back.

Also fixes a typo in the error message for `ArrayLiteral#[]=`.