### PR TITLE
Forbid calls with both block arg and block

### DIFF
--- a/spec/compiler/parser/parser_spec.cr
+++ b/spec/compiler/parser/parser_spec.cr
@@ -620,6 +620,8 @@ module Crystal
     it_parses "1.foo do; 1; end", Call.new(1.int32, "foo", block: Block.new(body: 1.int32))
     it_parses "a b() {}", Call.new(nil, "a", Call.new(nil, "b", block: Block.new))
 
+    assert_syntax_error "foo(&block) {}"
+
     it_parses "foo { |a, (b, c), (d, e)| a; b; c; d; e }", Call.new(nil, "foo",
       block: Block.new(["a".var, "__arg0".var, "__arg1".var],
         Expressions.new([

--- a/src/compiler/crystal/syntax/parser.cr
+++ b/src/compiler/crystal/syntax/parser.cr
@@ -4126,6 +4126,10 @@ module Crystal
         block = parse_block(block)
       end
 
+      if block && block_arg
+        raise "can't forward block argument and specify block together", location
+      end
+
       node =
         if block || block_arg || global
           call = Call.new(nil, name, (args || [] of ASTNode), block, block_arg, named_args, global)
@@ -4138,7 +4142,7 @@ module Crystal
             if maybe_var && args.size == 0
               Var.new(name)
             else
-              call = Call.new(nil, name, args, nil, block_arg, named_args, global)
+              call = Call.new(nil, name, args, nil, nil, named_args, global)
               call.name_location = name_location
               call.has_parentheses = has_parentheses
               call
@@ -4154,11 +4158,11 @@ module Crystal
               end
               Var.new(name)
             else
-              if !force_call && !block_arg && !named_args && !global && !has_parentheses && @assigned_vars.includes?(name)
+              if !force_call && !named_args && !global && !has_parentheses && @assigned_vars.includes?(name)
                 raise "can't use variable name '#{name}' inside assignment to variable '#{name}'", location
               end
 
-              call = Call.new(nil, name, [] of ASTNode, nil, block_arg, named_args, global)
+              call = Call.new(nil, name, [] of ASTNode, nil, nil, named_args, global)
               call.name_location = name_location
               call.has_parentheses = has_parentheses
               call

--- a/src/compiler/crystal/syntax/parser.cr
+++ b/src/compiler/crystal/syntax/parser.cr
@@ -4127,7 +4127,7 @@ module Crystal
       end
 
       if block && block_arg
-        raise "can't forward block argument and specify block together", location
+        raise "can't use captured and non-captured blocks together", location
       end
 
       node =


### PR DESCRIPTION
Rejects code like

```crystal
def foo(&block)
  block.call
end

def bar(&block : ->)
  foo(&block) { puts 1 }
end

bar { puts 2 } # => 2
```

Currently the block argument will be used and `{ puts 1 }` is silently ignored. The same code in Ruby (without the type restriction) results in a `both block arg and actual block given` syntax error.