### PR TITLE
Add `StaticArray#fill`

### DIFF
--- a/spec/std/static_array_spec.cr
+++ b/spec/std/static_array_spec.cr
@@ -79,7 +79,7 @@ describe "StaticArray" do
     a.to_s.should eq("StaticArray[1, 2, 3]")
   end
 
-  it "fills" do
+  it "does #fill, without block" do
     a = StaticArray(Int32, 3).new { |i| i + 1 }
     a.fill(0).should eq(StaticArray[0, 0, 0])
     a.should eq(StaticArray[0, 0, 0])
@@ -87,7 +87,7 @@ describe "StaticArray" do
     a.should eq(StaticArray[2, 2, 2])
   end
 
-  it "fills, with block" do
+  it "does #fill, with block" do
     a = StaticArray(Int32, 4).new { |i| i + 1 }
     a.fill { |i| i * i }.should eq(StaticArray[0, 1, 4, 9])
     a.should eq(StaticArray[0, 1, 4, 9])

--- a/spec/std/static_array_spec.cr
+++ b/spec/std/static_array_spec.cr
@@ -79,6 +79,20 @@ describe "StaticArray" do
     a.to_s.should eq("StaticArray[1, 2, 3]")
   end
 
+  it "fills" do
+    a = StaticArray(Int32, 3).new { |i| i + 1 }
+    a.fill(0).should eq(StaticArray[0, 0, 0])
+    a.should eq(StaticArray[0, 0, 0])
+    a.fill(2).should eq(StaticArray[2, 2, 2])
+    a.should eq(StaticArray[2, 2, 2])
+  end
+
+  it "fills, with block" do
+    a = StaticArray(Int32, 4).new { |i| i + 1 }
+    a.fill { |i| i * i }.should eq(StaticArray[0, 1, 4, 9])
+    a.should eq(StaticArray[0, 1, 4, 9])
+  end
+
   it "shuffles" do
     a = StaticArray(Int32, 3).new { |i| i + 1 }
     a.shuffle!

--- a/src/array.cr
+++ b/src/array.cr
@@ -879,14 +879,11 @@ class Array(T)
     {% if Int::Primitive.union_types.includes?(T) || Float::Primitive.union_types.includes?(T) %}
       if value == 0
         to_unsafe.clear(size)
-
-        self
-      else
-        fill { value }
+        return self
       end
-    {% else %}
-      fill { value }
     {% end %}
+
+    fill { value }
   end
 
   # Replaces every element in `self`, starting at *from*, with the given *value*. Returns `self`.

--- a/src/static_array.cr
+++ b/src/static_array.cr
@@ -160,6 +160,42 @@ struct StaticArray(T, N)
     N
   end
 
+  # Replaces every element in `self` with the given *value*. Returns `self`.
+  #
+  # ```
+  # array = StaticArray(Int32, 3).new 0 # => StaticArray[0, 0, 0]
+  # array.fill(2)                       # => StaticArray[2, 2, 2]
+  # array                               # => StaticArray[2, 2, 2]
+  # ```
+  def fill(value : T)
+    {% if Int::Primitive.union_types.includes?(T) || Float::Primitive.union_types.includes?(T) %}
+      if value == 0
+        to_unsafe.clear(size)
+
+        self
+      else
+        fill { value }
+      end
+    {% else %}
+      fill { value }
+    {% end %}
+  end
+
+  # Yields each index of `self` to the given block and then assigns
+  # the block's value in that position. Returns `self`.
+  #
+  # ```
+  # array = StaticArray[2, 1, 1, 1]
+  # array.fill { |i| i * i } # => StaticArray[0, 1, 4, 9]
+  # array                    # => StaticArray[0, 1, 4, 9]
+  # ```
+  def fill
+    size.times do |i|
+      to_unsafe[i] = yield i
+    end
+    self
+  end
+
   # Fills the array by substituting all elements with the given value.
   #
   # ```
@@ -167,6 +203,7 @@ struct StaticArray(T, N)
   # array.[]= 2 # => nil
   # array       # => StaticArray[2, 2, 2]
   # ```
+  @[Deprecated("Use `#fill(value : T)` instead")]
   def []=(value : T)
     size.times do |i|
       to_unsafe[i] = value

--- a/src/static_array.cr
+++ b/src/static_array.cr
@@ -171,14 +171,11 @@ struct StaticArray(T, N)
     {% if Int::Primitive.union_types.includes?(T) || Float::Primitive.union_types.includes?(T) %}
       if value == 0
         to_unsafe.clear(size)
-
-        self
-      else
-        fill { value }
+        return self
       end
-    {% else %}
-      fill { value }
     {% end %}
+
+    fill { value }
   end
 
   # Yields each index of `self` to the given block and then assigns

--- a/src/static_array.cr
+++ b/src/static_array.cr
@@ -167,7 +167,7 @@ struct StaticArray(T, N)
   # array.fill(2)                       # => StaticArray[2, 2, 2]
   # array                               # => StaticArray[2, 2, 2]
   # ```
-  def fill(value : T)
+  def fill(value : T) : self
     {% if Int::Primitive.union_types.includes?(T) || Float::Primitive.union_types.includes?(T) %}
       if value == 0
         to_unsafe.clear(size)
@@ -186,7 +186,7 @@ struct StaticArray(T, N)
   # array.fill { |i| i * i } # => StaticArray[0, 1, 4, 9]
   # array                    # => StaticArray[0, 1, 4, 9]
   # ```
-  def fill
+  def fill(& : Int32 -> T) : self
     size.times do |i|
       to_unsafe[i] = yield i
     end


### PR DESCRIPTION
Resolves #10024.

Only adds the `#fill(value : T)` and `#fill(&)` overloads, compared to the 8 in `Array`; the former deprecates the one-argument `#[]=`, the latter resembles `StaticArray`'s block constructor so adding it here would be reasonable.