### PR TITLE
Let `JSON::PullParser#on_key` yield self and return value

### DIFF
--- a/spec/std/json/pull_parser_spec.cr
+++ b/spec/std/json/pull_parser_spec.cr
@@ -258,15 +258,10 @@ describe JSON::PullParser do
       bar.should eq(2)
     end
 
-    it "finds key" do
+    it "yields parser" do
       pull = JSON::PullParser.new(%({"foo": 1, "bar": 2}))
 
-      bar = nil
-      pull.on_key("bar") do
-        bar = pull.read_int
-      end
-
-      bar.should eq(2)
+      pull.on_key("bar", &.read_int).should eq(2)
     end
 
     it "doesn't find key" do
@@ -289,6 +284,12 @@ describe JSON::PullParser do
       end
 
       bar.should eq(2)
+    end
+
+    it "yields parser with bang" do
+      pull = JSON::PullParser.new(%({"foo": 1, "bar": 2}))
+
+      pull.on_key!("bar", &.read_int).should eq(2)
     end
 
     it "doesn't find key with bang" do

--- a/src/json/pull_parser.cr
+++ b/src/json/pull_parser.cr
@@ -352,6 +352,7 @@ class JSON::PullParser
   #
   # Returns the return value of the block or `Nil` if the key was not read.
   def on_key(key, & : self -> _)
+    result = nil
     read_object do |some_key|
       if some_key == key
         result = yield self

--- a/src/json/pull_parser.cr
+++ b/src/json/pull_parser.cr
@@ -349,23 +349,32 @@ class JSON::PullParser
   # Reads an object keys and yield when *key* is found.
   #
   # All the other object keys are skipped.
-  def on_key(key)
+  #
+  # Returns the return value of the block or `Nil` if the key was not read.
+  def on_key(key, & : self -> _)
     read_object do |some_key|
-      some_key == key ? yield : skip
+      if some_key == key
+        result = yield self
+      else
+        skip
+      end
     end
+    result
   end
 
   # Reads an object keys and yield when *key* is found. If not found, raise an `Exception`.
   #
   # All the other object keys are skipped.
-  def on_key!(key)
+  #
+  # Returns the return value of the block.
+  def on_key!(key, & : self -> _)
     found = false
-    value = uninitialized typeof(yield)
+    value = uninitialized typeof(yield self)
 
     read_object do |some_key|
       if some_key == key
         found = true
-        value = yield
+        value = yield self
       else
         skip
       end


### PR DESCRIPTION
This adds a nice convenience feature for `#on_key` and `#on_key!` to use them with short block syntax like this:

```cr
pull = JSON::PullParser.new(%({"foo": 1, "bar": 2}))
pull.on_key("bar", &.read_int) # => 2
```