### PR TITLE
Add `HTTP::Request#hostname`+ utils

### DIFF
--- a/spec/std/http/request_spec.cr
+++ b/spec/std/http/request_spec.cr
@@ -444,6 +444,35 @@ module HTTP
         request.host.should eq("host.example.org")
       end
 
+      it "#hostname" do
+        request = Request.new("GET", "/", HTTP::Headers{"Host" => "host.example.org"})
+        request.hostname.should eq("host.example.org")
+
+        request = Request.new("GET", "/", HTTP::Headers{"Host" => "0.0.0.0"})
+        request.hostname.should eq("0.0.0.0")
+
+        request = Request.new("GET", "/", HTTP::Headers{"Host" => "[1234:5678::1]"})
+        request.hostname.should eq("1234:5678::1")
+
+        request = Request.new("GET", "/", HTTP::Headers{"Host" => "[::1]"})
+        request.hostname.should eq("::1")
+
+        request = Request.new("GET", "/", HTTP::Headers{"Host" => "host.example.org:3000"})
+        request.hostname.should eq("host.example.org")
+
+        request = Request.new("GET", "/", HTTP::Headers{"Host" => "0.0.0.0:3000"})
+        request.hostname.should eq("0.0.0.0")
+
+        request = Request.new("GET", "/", HTTP::Headers{"Host" => "[1234:5678::1]:80"})
+        request.hostname.should eq("1234:5678::1")
+
+        request = Request.new("GET", "/", HTTP::Headers{"Host" => "[::1]:3000"})
+        request.hostname.should eq("::1")
+
+        request = Request.new("GET", "/")
+        request.hostname.should be_nil
+      end
+
       it "gets request host with port from the headers" do
         request = Request.from_io(IO::Memory.new("GET / HTTP/1.1\r\nHost: host.example.org:3000\r\nReferer:\r\n\r\n")).as(Request)
         request.host_with_port.should eq("host.example.org:3000")

--- a/spec/std/socket/address_spec.cr
+++ b/spec/std/socket/address_spec.cr
@@ -118,6 +118,15 @@ describe Socket::IPAddress do
     Socket::IPAddress.new(Socket::IPAddress::UNSPECIFIED, 0).unspecified?.should be_true
     Socket::IPAddress.new(Socket::IPAddress::UNSPECIFIED6, 0).unspecified?.should be_true
   end
+
+  it ".valid_port?" do
+    Socket::IPAddress.valid_port?(0).should be_true
+    Socket::IPAddress.valid_port?(80).should be_true
+    Socket::IPAddress.valid_port?(65_535).should be_true
+
+    Socket::IPAddress.valid_port?(-1).should be_false
+    Socket::IPAddress.valid_port?(65_536).should be_false
+  end
 end
 
 describe Socket::UNIXAddress do

--- a/spec/std/uri_spec.cr
+++ b/spec/std/uri_spec.cr
@@ -723,4 +723,11 @@ describe "URI" do
       assert_relativize("mailto:urbi@orbi.va#bar", "mailto:urbi@orbi.va", "mailto:urbi@orbi.va")
     end
   end
+
+  it ".unwrap_ipv6" do
+    URI.unwrap_ipv6("[::1]").should eq("::1")
+    URI.unwrap_ipv6("127.0.0.1").should eq("127.0.0.1")
+    URI.unwrap_ipv6("example.com").should eq("example.com")
+    URI.unwrap_ipv6("[1234:5678::1]").should eq "1234:5678::1"
+  end
 end

--- a/src/http/request.cr
+++ b/src/http/request.cr
@@ -256,7 +256,7 @@ class HTTP::Request
 
   # Extracts the hostname from `Host` header.
   #
-  # Returns `nil` if `Host` header is missing.
+  # Returns `nil` if the `Host` header is missing.
   #
   # If the `Host` header contains a port number, it is stripped off.
   def hostname : String?

--- a/src/http/request.cr
+++ b/src/http/request.cr
@@ -269,6 +269,8 @@ class HTTP::Request
       host = header
     else
       port = port.to_i?(whitespace: false)
+      # TODO: Remove temporal fix when Socket::IPAddress has been ported to
+      # win32
       unless port && {% if flag?(:win32) %}port.in?(0..UInt16::MAX){% else %}Socket::IPAddress.valid_port?(port){% end %}
         # what we identified as port is not valid, so use the entire header
         host = header

--- a/src/http/request.cr
+++ b/src/http/request.cr
@@ -246,6 +246,7 @@ class HTTP::Request
   end
 
   # Returns request host from headers.
+  @[Deprecated("Use `#hostname` instead.")]
   def host
     host = @headers["Host"]?
     return unless host
@@ -278,6 +279,7 @@ class HTTP::Request
   end
 
   # Returns request host with port from headers.
+  @[Deprecated(%q(Use `headers["Host"]?` instead.))]
   def host_with_port
     @headers["Host"]?
   end

--- a/src/http/request.cr
+++ b/src/http/request.cr
@@ -269,7 +269,7 @@ class HTTP::Request
       host = header
     else
       port = port.to_i?(whitespace: false)
-      unless port && Socket::IPAddress.valid_port?(port)
+      unless port && {% if flag?(:win32) %}port.in?(0..UInt16::MAX){% else %}Socket::IPAddress.valid_port?(port){% end %}
         # what we identified as port is not valid, so use the entire header
         host = header
       end

--- a/src/http/request.cr
+++ b/src/http/request.cr
@@ -264,15 +264,15 @@ class HTTP::Request
     return unless header
 
     host, _, port = header.rpartition(":")
-    if host.nil?
+    if host.empty?
       # no colon in header
-      return port
-    end
-
-    port = port.to_i?(whitespace: false)
-    unless port && Socket::IPAddress.valid_port?(port)
-      # what we identified as port is not valid, so use the entire header
       host = header
+    else
+      port = port.to_i?(whitespace: false)
+      unless port && Socket::IPAddress.valid_port?(port)
+        # what we identified as port is not valid, so use the entire header
+        host = header
+      end
     end
 
     URI.unwrap_ipv6(host)

--- a/src/socket/address.cr
+++ b/src/socket/address.cr
@@ -292,6 +292,13 @@ class Socket
       sockaddr.value.sin_addr = addr
       sockaddr.as(LibC::Sockaddr*)
     end
+
+    # Returns `true` if *port* is a valid port number.
+    #
+    # Valid port numbers are in the range `0..65_535`.
+    def self.valid_port?(port : Int) : Bool
+      port.in?(0..UInt16::MAX)
+    end
   end
 
   # UNIX address representation.

--- a/src/uri.cr
+++ b/src/uri.cr
@@ -183,7 +183,24 @@ class URI
   # URI.parse("http://[::1]/bar").host     # => "[::1]"
   # ```
   def hostname
-    host.try { |host| host.starts_with?('[') && host.ends_with?(']') ? host[1..-2] : host }
+    host.try { |host| self.class.unwrap_ipv6(host) }
+  end
+
+  # Unwraps IPv6 address wrapped in square brackets.
+  #
+  # Everything that is not wrapped in square brackets is returned unchanged.
+  #
+  # ```cr
+  # URI.unwrap_ipv6("[::1]") # => "::1"
+  # URI.unwrap_ipv6("127.0.0.1") # => "127.0.0.1"
+  # URI.unwrap_ipv6("example.com") # => "example.com"
+  # ```
+  def self.unwrap_ipv6(host)
+    if host.starts_with?('[') && host.ends_with?(']')
+      host.byte_slice(1, host.bytesize - 2)
+    else
+      host
+    end
   end
 
   # Returns the full path of this URI.


### PR DESCRIPTION
This patch moves `HTTP::Request#host` to `#hostname` and fixes its issues as discussed in #9962.

It also introduces two utility methods to avoid code duplication. This is optional, but I figure it could be useful elsewhere, too:
* `URI.unwrap_ipv6` removes square brackets around a string to unwrap an IPv6 address (does no verification of the address, though).
* `Socket::IPAddress.valid_port?(port : Int)` checks whether a port number is in the valid range.

As propsed in #9962 `Host#host_with_port` is deprecated without an replacement method. It is just a short cut to `headers["Host"]` which can be used instead and is less confusing.

Resolves #9962