### PR TITLE
Support using `Path`s in more APIs

### DIFF
--- a/spec/std/mime_spec.cr
+++ b/spec/std/mime_spec.cr
@@ -43,16 +43,32 @@ describe MIME do
     MIME.from_extension?(".fooobar").should be_nil
   end
 
-  it ".from_filename" do
-    MIME.init
-    MIME.from_filename("test.html").should eq MIME.from_extension(".html")
-    MIME.from_filename("foo/bar.not-exists", "foo/bar-exist").should eq "foo/bar-exist"
-    MIME.from_filename("foo/bar.not-exists") { "foo/bar-exist" }.should eq "foo/bar-exist"
+  describe ".from_filename" do
+    it String do
+      MIME.init
+      MIME.from_filename("test.html").should eq MIME.from_extension(".html")
+      MIME.from_filename("foo/bar.not-exists", "foo/bar-exist").should eq "foo/bar-exist"
+      MIME.from_filename("foo/bar.not-exists") { "foo/bar-exist" }.should eq "foo/bar-exist"
+    end
+
+    it Path do
+      MIME.init
+      MIME.from_filename(Path["test.html"]).should eq MIME.from_extension(".html")
+      MIME.from_filename(Path["foo/bar.not-exists"], "foo/bar-exist").should eq "foo/bar-exist"
+      MIME.from_filename(Path["foo/bar.not-exists"]) { "foo/bar-exist" }.should eq "foo/bar-exist"
+    end
   end
 
-  it ".from_filename" do
-    MIME.init
-    MIME.from_filename?("test.html").should eq MIME.from_extension(".html")
+  describe ".from_filename?" do
+    it String do
+      MIME.init
+      MIME.from_filename?("test.html").should eq MIME.from_extension(".html")
+    end
+
+    it Path do
+      MIME.init
+      MIME.from_filename?(Path["test.html"]).should eq MIME.from_extension(".html")
+    end
   end
 
   describe ".register" do

--- a/src/file/error.cr
+++ b/src/file/error.cr
@@ -26,7 +26,8 @@ class File::Error < IO::Error
     "#{message}: '#{file.inspect_unquoted}' -> '#{other.inspect_unquoted}'"
   end
 
-  def initialize(message, *, @file : String, @other : String? = nil)
+  def initialize(message, *, file : String | Path, @other : String? = nil)
+    @file = file.to_s
     super message
   end
 end

--- a/src/mime.cr
+++ b/src/mime.cr
@@ -180,32 +180,32 @@ module MIME
   #
   # A case-sensitive search is tried first, if this yields no result, it is
   # matched case-insensitive. Returns *default* if extension is not registered.
-  def self.from_filename(filename : String, default) : String
-    from_extension(File.extname(filename), default)
+  def self.from_filename(filename : String | Path, default) : String
+    from_extension(File.extname(filename.to_s), default)
   end
 
   # Looks up the MIME type associated with the extension in *filename*.
   #
   # A case-sensitive search is tried first, if this yields no result, it is
   # matched case-insensitive. Raises `KeyError` if extension is not registered.
-  def self.from_filename(filename : String) : String
-    from_extension(File.extname(filename))
+  def self.from_filename(filename : String | Path) : String
+    from_extension(File.extname(filename.to_s))
   end
 
   # Looks up the MIME type associated with the extension in *filename*.
   #
   # A case-sensitive search is tried first, if this yields no result, it is
   # matched case-insensitive. Returns `nil` if extension is not registered.
-  def self.from_filename?(filename : String) : String?
-    from_extension?(File.extname(filename))
+  def self.from_filename?(filename : String | Path) : String?
+    from_extension?(File.extname(filename.to_s))
   end
 
   # Looks up the MIME type associated with the extension in *filename*.
   #
   # A case-sensitive search is tried first, if this yields no result, it is
   # matched case-insensitive. Runs the given block if extension is not registered.
-  def self.from_filename(filename : String, &block)
-    from_extension(File.extname(filename)) { |extension| yield extension }
+  def self.from_filename(filename : String | Path, &block)
+    from_extension(File.extname(filename.to_s)) { |extension| yield extension }
   end
 
   # Register *type* for *extension*.


### PR DESCRIPTION
Supports using `Path` types within `MIME.from_filename` and `File::Error.new`.