### PR TITLE
Add Path#stem

### DIFF
--- a/spec/std/path_spec.cr
+++ b/spec/std/path_spec.cr
@@ -47,10 +47,10 @@ end
 
 private def assert_paths_raw(path, posix, windows = posix, label = nil, file = __FILE__, line = __LINE__, &block : Path -> _)
   it %(#{label} "#{path}" (posix)), file, line do
-    block.call(Path.posix(path)).should eq(posix)
+    block.call(Path.posix(path)).should eq(posix), file: file, line: line
   end
   it %(#{label} "#{path}" (windows)), file, line do
-    block.call(Path.windows(path)).should eq(windows)
+    block.call(Path.windows(path)).should eq(windows), file: file, line: line
   end
 end
 
@@ -343,6 +343,11 @@ describe Path do
     assert_paths_raw("/foo/bar/foo.", "", &.extension)
     assert_paths_raw("test", "", &.extension)
     assert_paths_raw("test.ext/foo", "", &.extension)
+    assert_paths_raw("test.ext/foo/", "", &.extension)
+    assert_paths_raw("test.ext/", ".ext", &.extension)
+    assert_paths_raw("test/.", "", &.extension)
+    assert_paths_raw("test\\.", "", &.extension)
+    assert_paths_raw("test.ext\\", ".ext\\", ".ext", &.extension)
   end
 
   describe "#absolute?" do

--- a/spec/std/path_spec.cr
+++ b/spec/std/path_spec.cr
@@ -837,4 +837,38 @@ describe Path do
       path.relative_to(Path.windows("C:cwd")).should eq path
     end
   end
+
+  describe "#stem" do
+    assert_paths_raw("foo.txt", "foo", &.stem)
+    assert_paths_raw("foo.txt.txt", "foo.txt", &.stem)
+    assert_paths_raw(".txt", ".txt", &.stem)
+    assert_paths_raw(".txt.txt", ".txt", &.stem)
+    assert_paths_raw("foo.", "foo.", &.stem)
+    assert_paths_raw("foo.txt.", "foo.txt.", &.stem)
+    assert_paths_raw("foo..txt", "foo.", &.stem)
+
+    assert_paths_raw("bar/foo.txt", "foo", &.stem)
+    assert_paths_raw("bar/foo.txt.txt", "foo.txt", &.stem)
+    assert_paths_raw("bar/.txt", ".txt", &.stem)
+    assert_paths_raw("bar/.txt.txt", ".txt", &.stem)
+    assert_paths_raw("bar/foo.", "foo.", &.stem)
+    assert_paths_raw("bar/foo.txt.", "foo.txt.", &.stem)
+    assert_paths_raw("bar/foo..txt", "foo.", &.stem)
+
+    assert_paths_raw("bar\\foo.txt", "bar\\foo", "foo", &.stem)
+    assert_paths_raw("bar\\foo.txt.txt", "bar\\foo.txt", "foo.txt", &.stem)
+    assert_paths_raw("bar\\.txt", "bar\\", ".txt", &.stem)
+    assert_paths_raw("bar\\.txt.txt", "bar\\.txt", ".txt", &.stem)
+    assert_paths_raw("bar\\foo.", "bar\\foo.", "foo.", &.stem)
+    assert_paths_raw("bar\\foo.txt.", "bar\\foo.txt.", "foo.txt.", &.stem)
+    assert_paths_raw("bar\\foo..txt", "bar\\foo.", "foo.", &.stem)
+
+    assert_paths_raw("foo.txt/", "foo", &.stem)
+    assert_paths_raw("foo.txt.txt/", "foo.txt", &.stem)
+    assert_paths_raw(".txt/", ".txt", &.stem)
+    assert_paths_raw(".txt.txt/", ".txt", &.stem)
+    assert_paths_raw("foo./", "foo.", &.stem)
+    assert_paths_raw("foo.txt./", "foo.txt.", &.stem)
+    assert_paths_raw("foo..txt/", "foo.", &.stem)
+  end
 end

--- a/src/path.cr
+++ b/src/path.cr
@@ -390,6 +390,19 @@ struct Path
     String.new(bytes[current, slice_end - current])
   end
 
+  # Returns the last component of this path without the extension.
+  #
+  # This is equivalent to `self.basename(self.extension)`.
+  #
+  # ```
+  # Path["file.cr"].stem     # => "file"
+  # Path["file.tar.gz"].stem # => "file.tar"
+  # Path["foo/file.cr"].stem # => "file"
+  # ```
+  def stem
+    basename(extension)
+  end
+
   # Removes redundant elements from this path and returns the shortest equivalent path by purely lexical processing.
   # It applies the following rules iteratively until no further processing can be done:
   #

--- a/src/path.cr
+++ b/src/path.cr
@@ -340,20 +340,28 @@ struct Path
   # Returns the extension of this path, or an empty string if it has no extension.
   #
   # ```
-  # Path["foo.cr"].extension # => ".cr"
-  # Path["foo"].extension    # => ""
+  # Path["foo.cr"].extension     # => ".cr"
+  # Path["foo"].extension        # => ""
+  # Path["foo.tar.gz"].extension # => ".gz"
   # ```
   def extension : String
     bytes = @name.to_slice
 
     return "" if bytes.empty?
 
-    current = bytes.size - 1
+    slice_end = bytes.size
+    current = slice_end - 1
+
+    separators = self.separators.map &.ord
+
+    # ignore trailing separators
+    while separators.includes?(bytes[current]) && current > 0
+      current -= 1
+      slice_end -= 1
+    end
 
     # if the pattern is `foo.`, it has no extension
     return "" if bytes[current] == '.'.ord
-
-    separators = self.separators.map &.ord
 
     # position the reader at the last `.` or SEPARATOR
     # that is not the first char
@@ -379,7 +387,7 @@ struct Path
     # we are not at the beginning,
     # the previous char is not a '/',
     # and we have an extension
-    String.new(bytes[current, bytes.size - current])
+    String.new(bytes[current, slice_end - current])
   end
 
   # Removes redundant elements from this path and returns the shortest equivalent path by purely lexical processing.


### PR DESCRIPTION
This patch adds `Path#stem` which returns the basename of a path without the extension. 
The implementation is `basename(extension)` but could be optimized to avoid intermediary allocation.

The first commit fixes `Path#extension` to ignore trailing separators which aligns it with `#basename`.

Resolves #5706