### PR TITLE
Respect explicitly provided type vars for (Named)Tuple.new

### DIFF
--- a/spec/std/named_tuple_spec.cr
+++ b/spec/std/named_tuple_spec.cr
@@ -1,8 +1,23 @@
 require "spec"
 
+private record NamedTupleSpecObj, x : Int32 do
+  def_equals @x
+end
+
 describe "NamedTuple" do
-  it "does new" do
+  it "does NamedTuple.new, without type vars" do
     NamedTuple.new(x: 1, y: 2).should eq({x: 1, y: 2})
+    NamedTuple.new(z: NamedTupleSpecObj.new(10)).should eq({z: NamedTupleSpecObj.new(10)})
+  end
+
+  it "does NamedTuple.new, with type vars" do
+    NamedTuple(foo: Int32, bar: String).new(foo: 1, bar: "a").should eq({foo: 1, bar: "a"})
+    NamedTuple(z: NamedTupleSpecObj).new(z: NamedTupleSpecObj.new(10)).should eq({z: NamedTupleSpecObj.new(10)})
+    typeof(NamedTuple.new).new.should eq(NamedTuple.new)
+
+    t = NamedTuple(foo: Int32 | String, bar: Int32 | String).new(foo: 1, bar: "a")
+    t.should eq({foo: 1, bar: "a"})
+    t.class.should_not eq(NamedTuple(foo: Int32, bar: String))
   end
 
   it "does NamedTuple.from" do

--- a/spec/std/tuple_spec.cr
+++ b/spec/std/tuple_spec.cr
@@ -9,6 +9,8 @@ private class TupleSpecObj
   def clone
     TupleSpecObj.new(@x)
   end
+
+  def_equals @x
 end
 
 describe "Tuple" do
@@ -154,9 +156,20 @@ describe "Tuple" do
     u[1].should_not be(r2)
   end
 
-  it "does Tuple.new" do
+  it "does Tuple.new, without type vars" do
     Tuple.new(1, 2, 3).should eq({1, 2, 3})
     Tuple.new([1, 2, 3]).should eq({[1, 2, 3]})
+    Tuple.new(TupleSpecObj.new(10)).should eq({TupleSpecObj.new(10)})
+  end
+
+  it "does Tuple.new, with type vars" do
+    Tuple(Int32, String).new(1, "a").should eq({1, "a"})
+    Tuple(TupleSpecObj).new(TupleSpecObj.new(10)).should eq({TupleSpecObj.new(10)})
+    typeof(Tuple.new).new.should eq(Tuple.new)
+
+    t = Tuple(Int32 | String, Int32 | String).new(1, "a")
+    t.should eq({1, "a"})
+    t.class.should_not eq(Tuple(Int32, String))
   end
 
   it "does Tuple.from" do

--- a/src/named_tuple.cr
+++ b/src/named_tuple.cr
@@ -46,7 +46,10 @@ struct NamedTuple
       {% begin %}
         {
           {% for key in T %}
-            {{ key.stringify }}: options[{{ key.symbolize }}].as(typeof(0.unsafe_as(self)[{{ key.symbolize }}])),
+            {{ key.stringify }}: options[{{ key.symbolize }}].as(typeof(begin
+              x = uninitialized self
+              x[{{ key.symbolize }}]
+            end)),
           {% end %}
         }
       {% end %}

--- a/src/named_tuple.cr
+++ b/src/named_tuple.cr
@@ -35,7 +35,22 @@ struct NamedTuple
   # {}             # syntax error
   # ```
   def self.new(**options : **T)
-    options
+    {% if @type.name(generic_args: false) == "NamedTuple" %}
+      # deduced type vars
+      options
+    {% elsif @type.name(generic_args: false) == "NamedTuple()" %}
+      # special case: empty named tuple
+      options
+    {% else %}
+      # explicitly provided type vars
+      {% begin %}
+        {
+          {% for key in T %}
+            {{ key.stringify }}: options[{{ key.symbolize }}].as(typeof(0.unsafe_as(self)[{{ key.symbolize }}])),
+          {% end %}
+        }
+      {% end %}
+    {% end %}
   end
 
   # Creates a named tuple from the given hash, with elements casted to the given types.

--- a/src/tuple.cr
+++ b/src/tuple.cr
@@ -89,7 +89,10 @@ struct Tuple
       {% begin %}
         {
           {% for i in 0...@type.size %}
-            args[{{ i }}].as(typeof(0.unsafe_as(self)[{{ i }}])),
+            args[{{ i }}].as(typeof(begin
+              x = uninitialized self
+              x[{{ i }}]
+            end)),
           {% end %}
         }
       {% end %}

--- a/src/tuple.cr
+++ b/src/tuple.cr
@@ -78,7 +78,22 @@ struct Tuple
   # {}                         # syntax error
   # ```
   def self.new(*args : *T)
-    args
+    {% if @type.name(generic_args: false) == "Tuple" %}
+      # deduced type vars
+      args
+    {% elsif @type.name(generic_args: false) == "Tuple()" %}
+      # special case: empty tuple
+      args
+    {% else %}
+      # explicitly provided type vars
+      {% begin %}
+        {
+          {% for i in 0...@type.size %}
+            args[{{ i }}].as(typeof(0.unsafe_as(self)[{{ i }}])),
+          {% end %}
+        }
+      {% end %}
+    {% end %}
   end
 
   # Creates a tuple from the given array, with elements casted to the given types.


### PR DESCRIPTION
Resolves #10041.