### PR TITLE
Remove deprecated Time::Span.new variants

### DIFF
--- a/spec/std/time/span_spec.cr
+++ b/spec/std/time/span_spec.cr
@@ -31,24 +31,11 @@ describe Time::Span do
 
     t1 = Time::Span.new hours: 25
     t1.to_s.should eq("1.01:00:00")
-
-    t1 = Time::Span.new(1, 2, 3)
-    t1.to_s.should eq("01:02:03")
-    typeof(t1).should eq(Time::Span)
-
-    t1 = Time::Span.new(1, 2, 3, 4, 5)
-    t1.to_s.should eq("1.02:03:04.000000005")
-    typeof(t1).should eq(Time::Span)
   end
 
   it "initializes with big seconds value" do
     t = Time::Span.new hours: 0, minutes: 0, seconds: 1231231231231
     t.total_seconds.should eq(1231231231231)
-  end
-
-  it "initialize deprecated constructors" do
-    t = Time::Span.new(0, 0, 0, 0, nanoseconds: 1)
-    t.total_nanoseconds.should eq(1)
   end
 
   it "days overflows" do

--- a/src/time/span.cr
+++ b/src/time/span.cr
@@ -53,19 +53,6 @@ struct Time::Span
   # @nanoseconds can either be negative or positive).
   @nanoseconds : Int32
 
-  @[Deprecated("Use `new` with named arguments instead.")]
-  def self.new(_hours : Int, _minutes : Int, _seconds : Int)
-    new(0, _hours, _minutes, _seconds)
-  end
-
-  @[Deprecated("Use `new` with named arguments instead.")]
-  def self.new(_days : Int, _hours : Int, _minutes : Int, _seconds : Int, nanoseconds : Int = 0)
-    new(
-      seconds: compute_seconds(_days, _hours, _minutes, _seconds),
-      nanoseconds: nanoseconds.to_i64,
-    )
-  end
-
   # Creates a new `Time::Span` from *seconds* and *nanoseconds*.
   #
   # Nanoseconds get normalized in the range of `0...1_000_000_000`,


### PR DESCRIPTION
Shouldn't they be gone by now?