### PR TITLE
[Compiler] Add method name to frozen type error

### DIFF
--- a/spec/compiler/semantic/def_spec.cr
+++ b/spec/compiler/semantic/def_spec.cr
@@ -272,7 +272,7 @@ describe "Semantic: def" do
 
       foo
       ),
-      "method must return Int32 but it is returning Char"
+      "method top-level foo must return Int32 but it is returning Char"
   end
 
   it "errors if return type doesn't match on instance method" do
@@ -285,7 +285,7 @@ describe "Semantic: def" do
 
       Foo.new.foo
       ),
-      "method must return Int32 but it is returning Char"
+      "method Foo#foo must return Int32 but it is returning Char"
   end
 
   it "errors if return type doesn't match on class method" do
@@ -298,7 +298,7 @@ describe "Semantic: def" do
 
       Foo.foo
       ),
-      "method must return Int32 but it is returning Char"
+      "method Foo.foo must return Int32 but it is returning Char"
   end
 
   it "is ok if returns Int32? with explicit return" do

--- a/spec/compiler/semantic/generic_class_spec.cr
+++ b/spec/compiler/semantic/generic_class_spec.cr
@@ -1122,7 +1122,7 @@ describe "Semantic: generic class" do
 
       Gen(String).new
       ),
-      "method must return Bool but it is returning Nil"
+      "method Gen(String)#valid? must return Bool but it is returning Nil"
   end
 
   it "resolves T through metaclass inheritance (#7914)" do

--- a/spec/compiler/semantic/instance_var_spec.cr
+++ b/spec/compiler/semantic/instance_var_spec.cr
@@ -5042,7 +5042,7 @@ describe "Semantic: instance var" do
 
       Foo.new
       ),
-      "method must return Gen(T) but it is returning Nil"
+      "method Gen(T).new must return Gen(T) but it is returning Nil"
   end
 
   it "guesses virtual array type (1) (#5342)" do

--- a/spec/compiler/semantic/macro_spec.cr
+++ b/spec/compiler/semantic/macro_spec.cr
@@ -53,7 +53,7 @@ describe "Semantic: macro" do
 
       Foo.new.foo
       ),
-      "method must return Int32 but it is returning Char"
+      "method Foo#foo must return Int32 but it is returning Char"
   end
 
   it "allows subclasses of return type for macro def" do
@@ -143,7 +143,7 @@ describe "Semantic: macro" do
       end
 
       Bar.new.bar
-    }, "method must return Foo(String) but it is returning Foo(Int32)",
+    }, "method Bar#bar must return Foo(String) but it is returning Foo(Int32)",
       inject_primitives: false
   end
 

--- a/spec/compiler/semantic/module_spec.cr
+++ b/spec/compiler/semantic/module_spec.cr
@@ -383,7 +383,7 @@ describe "Semantic: module" do
       end
 
       Baz.new.foo
-      ", "method must return Bar(Float64) but it is returning Bar(Int32)"
+      ", "method Baz#foo must return Bar(Float64) but it is returning Bar(Int32)"
   end
 
   it "includes generic module with self (check return subclass type, error)" do
@@ -405,7 +405,7 @@ describe "Semantic: module" do
       end
 
       Baz1.new.foo
-      ", "method must return Bar(Int32) but it is returning Baz2"
+      ", "method Baz1#foo must return Bar(Int32) but it is returning Baz2"
   end
 
   it "includes module but can't access metaclass methods" do

--- a/src/compiler/crystal/semantic/bindings.cr
+++ b/src/compiler/crystal/semantic/bindings.cr
@@ -82,7 +82,9 @@ module Crystal
           from.raise "#{self.kind} variable '#{self.name}' of #{self.owner} must be #{freeze_type}, not #{invalid_type}", inner, Crystal::FrozenTypeException
         end
       when Def
-        (self.return_type || self).raise "method must return #{freeze_type} but it is returning #{invalid_type}", inner, Crystal::FrozenTypeException
+        (self.return_type || self).raise "method #{self.short_reference} must return #{freeze_type} but it is returning #{invalid_type}", inner, Crystal::FrozenTypeException
+      when NamedType
+        from.raise "type #{self.full_name} must be #{freeze_type}, not #{invalid_type}", inner, Crystal::FrozenTypeException
       else
         from.raise "type must be #{freeze_type}, not #{invalid_type}", inner, Crystal::FrozenTypeException
       end


### PR DESCRIPTION
When the return type of a method mismatches, the error message pointed to the source location but didn't tell you which concrete type it belongs to. Now the full name of the method is shown which should be helpful when a method is used in multiple types.

```cr
class Foo(T)
  def foo : T
    "foo"
  end
end

Foo(Int32).new.foo # Error: method Foo(Int32)#foo must return Int32 but it is returning String
# old error message: Error: method must return Int32 but it is returning String
```
