### PR TITLE
Check for non-default positional arguments of setter methods

### DIFF
--- a/spec/compiler/parser/parser_spec.cr
+++ b/spec/compiler/parser/parser_spec.cr
@@ -210,6 +210,9 @@ module Crystal
     assert_syntax_error "def foo=(a = 1); end", "setter method 'foo=' cannot have default positional arguments"
     assert_syntax_error "def []=(a = 1); end", "setter method '[]=' cannot have default positional arguments"
     it_parses "def []=(a, *b, c = 1); end", Def.new("[]=", ["a".arg, "b".arg, Arg.new("c", 1.int32)], splat_index: 1)
+    assert_syntax_error "def []=(*, a); end", "setter method '[]=' must have at least one positional argument"
+    assert_syntax_error "def []=(*a); end", "setter method '[]=' must have at least one positional argument"
+    it_parses "def []=(*a : Int); end", Def.new("[]=", [Arg.new("a", restriction: "Int".path)], splat_index: 0)
 
     # #5895, #6042, #5997
     %w(

--- a/src/compiler/crystal/syntax/parser.cr
+++ b/src/compiler/crystal/syntax/parser.cr
@@ -3496,14 +3496,6 @@ module Crystal
           index += 1
         end
 
-        if name.ends_with?('=')
-          if name != "[]=" && (args.size > 1 || found_splat || found_double_splat)
-            raise "setter method '#{name}' cannot have more than one argument"
-          elsif found_block
-            raise "setter method '#{name}' cannot have a block"
-          end
-        end
-
         if splat_index == args.size - 1 && args.last.name.empty?
           raise "named arguments must follow bare *", args.last.location.not_nil!
         end
@@ -3531,6 +3523,22 @@ module Crystal
           # OK
         else
           unexpected_token
+        end
+      end
+
+      if name.ends_with?('=') && !name.in?("<=", "==", ">=", "!=", "===")
+        if name != "[]=" && (args.size != 1 || found_splat || found_double_splat)
+          raise "setter method '#{name}' must have exactly one positional argument"
+        elsif name == "[]=" && args.size < 1
+          raise "setter method '#{name}' must have at least one positional argument"
+        elsif found_block
+          raise "setter method '#{name}' cannot have a block"
+        end
+
+        args.each(within: 0...splat_index) do |arg|
+          if arg.default_value
+            raise "setter method '#{name}' cannot have default positional arguments"
+          end
         end
       end
 

--- a/src/compiler/crystal/syntax/parser.cr
+++ b/src/compiler/crystal/syntax/parser.cr
@@ -3529,9 +3529,19 @@ module Crystal
       if name.ends_with?('=') && !name.in?("<=", "==", ">=", "!=", "===")
         if name != "[]=" && (args.size != 1 || found_splat || found_double_splat)
           raise "setter method '#{name}' must have exactly one positional argument"
-        elsif name == "[]=" && args.size < 1
-          raise "setter method '#{name}' must have at least one positional argument"
-        elsif found_block
+        elsif name == "[]="
+          if args.empty?
+            raise "setter method '#{name}' must have at least one positional argument"
+          elsif splat_index == 0
+            # disallow `[]=(*, x)` and `[]=(*x)`
+            first_arg = args.first
+            if first_arg.name.empty? || !first_arg.restriction
+              raise "setter method '#{name}' must have at least one positional argument"
+            end
+          end
+        end
+
+        if found_block
           raise "setter method '#{name}' cannot have a block"
         end
 

--- a/src/object.cr
+++ b/src/object.cr
@@ -1244,7 +1244,11 @@ class Object
   # ```
   macro delegate(*methods, to object)
     {% for method in methods %}
-      {% if method.id.ends_with?('=') && method.id != "[]=" %}
+      {% if method.id == "[]=" %}
+        def {{method.id}}(arg, *args, **options)
+          {{object.id}}.{{method.id}}(arg, *args, **options)
+        end
+      {% elsif method.id.ends_with?('=') %}
         def {{method.id}}(arg)
           {{object.id}}.{{method.id}} arg
         end
@@ -1253,13 +1257,11 @@ class Object
           {{object.id}}.{{method.id}}(*args, **options)
         end
 
-        {% if method.id != "[]=" %}
-          def {{method.id}}(*args, **options)
-            {{object.id}}.{{method.id}}(*args, **options) do |*yield_args|
-              yield *yield_args
-            end
+        def {{method.id}}(*args, **options)
+          {{object.id}}.{{method.id}}(*args, **options) do |*yield_args|
+            yield *yield_args
           end
-        {% end %}
+        end
       {% end %}
     {% end %}
   end


### PR DESCRIPTION
Resolves #10023.

Excluding the comparison methods from the error checks is intentional; we could revisit them in a later PR. (See also https://github.com/crystal-lang/crystal/issues/9963#issuecomment-732536027.)