### PR TITLE
[RFC] Compiler: error on method redefinition in same scope

### DIFF
--- a/src/log/main.cr
+++ b/src/log/main.cr
@@ -170,7 +170,7 @@ class Log
       emit(message, Metadata.empty)
     end
 
-    def emit(message : String, **kwargs) : Entry
+    def emit(message : String, **kwargs : Object) : Entry
       emit(message, kwargs)
     end
 


### PR DESCRIPTION
I wanted to do this for a long time, and [this blog post](https://blog.meadsteve.dev/programming/2020/12/07/advent-of-mistakes/) finally encouraged me to do it.

With this PR the compiler will now error with code like this:

```crystal
def bar
end

def bar # Error!
end
```

Or code like this:

```crystal
class Foo
  def bar
  end

  def qux
  end

  def bar # Error!
  end
end
```

The idea is to detect cases where you redefine a method very close to where it was defined. This means you redefined it without first closing the type and reopening, or going to a different file.

I believe whenever you do that it's most surely a mistake: you didn't realize you already had a method definition and now you are redefining it.

In fact, this spotted a bug in the Log library. The second method redefines the first one:

```crystal
    def emit(message : String) : Entry
      emit(message, Metadata.empty)
    end

    def emit(message : String, **kwargs) : Entry
      emit(message, kwargs)
    end
```

The reason is that no keyword arguments is also caught by the second overload. The special rule in the language to prevent this is to put an `: Object` type restriction which means "at least one keyword argument must be passed":

```crystal
    def emit(message : String) : Entry
      emit(message, Metadata.empty)
    end

    def emit(message : String, **kwargs : Object) : Entry
      emit(message, kwargs)
    end
```

Methods defined through macros, or macro hooks, don't count in this check because it's often the case that such redefinitions are valid and out of the user's control.

I didn't add tests for this but I wanted to see first if you think this is something useful before spending more time on it.