### PR TITLE
adding math ops and compare to Time::MonthSpan

### DIFF
--- a/spec/std/time/monthspan_spec.cr
+++ b/spec/std/time/monthspan_spec.cr
@@ -1,0 +1,119 @@
+require "spec"
+
+private def expect_overflow
+  expect_raises OverflowError, "Arithmetic overflow" do
+    yield
+  end
+end
+
+describe Time::MonthSpan do
+  it "initializes" do
+    t1 = Time::MonthSpan.new 123_456_789_123
+    t1.value.should eq(123_456_789_123)
+
+    t1 = Time::MonthSpan.new 0
+    t1.value.should eq(0)
+
+    t1 = Time::MonthSpan.new 1
+    t1.value.should eq(1)
+
+    t1 = Time::MonthSpan.new Int64::MAX
+    t1.value.should eq(Int64::MAX)
+
+    t1 = Time::MonthSpan.new Int64::MIN
+    t1.value.should eq(Int64::MIN)
+  end
+
+  it "test add" do
+    t1 = Time::MonthSpan.new 5
+    t2 = Time::MonthSpan.new 10
+    t3 = t1 + t2
+
+    t3.value.should eq(15)
+
+    # TODO check overflow
+  end
+
+  it "test subtract" do
+    t1 = Time::MonthSpan.new 36
+    t2 = Time::MonthSpan.new 12
+    t3 = t1 - t2
+    t3.value.should eq(24)
+
+    t1 = Time::MonthSpan.new 5
+    t2 = Time::MonthSpan.new 10
+    t3 = t1 - t2
+    t3.value.should eq(-5)
+
+    # TODO check overflow
+  end
+
+  it "test multiply" do
+    t1 = Time::MonthSpan.new 12
+    t2 = t1 * 2
+    t3 = t1 * 0.5
+
+    t2.should eq(Time::MonthSpan.new 24)
+    t3.should eq(Time::MonthSpan.new 6)
+
+    # TODO check overflow
+  end
+
+  it "test divide" do
+    t1 = Time::MonthSpan.new 24
+    t2 = t1 / 2
+    t3 = t1 / 1.5
+
+    t2.should eq(Time::MonthSpan.new 12)
+    t3.should eq(Time::MonthSpan.new 16)
+
+    # TODO check overflow
+  end
+
+  it "test compare" do
+    t1 = Time::MonthSpan.new -1
+    t2 = Time::MonthSpan.new 1
+
+    (t1 <=> t2).should eq(-1)
+    (t2 <=> t1).should eq(1)
+    (t2 <=> t2).should eq(0)
+
+    (t1 == t2).should be_false
+    (t1 > t2).should be_false
+    (t1 >= t2).should be_false
+    (t1 != t2).should be_true
+    (t1 < t2).should be_true
+    (t1 <= t2).should be_true
+  end
+
+  it "test equals" do
+    t1 = Time::MonthSpan.new 1
+    t2 = Time::MonthSpan.new 2
+
+    (t1 == t1).should be_true
+    (t1 == t2).should be_false
+    (t1 == "hello").should be_false
+  end
+
+  it "> Int64::MAX overflows" do
+    expect_overflow do
+      month = Int64::MAX.to_i128 + 1
+      Time::MonthSpan.new month
+    end
+  end
+
+  it "< Int64::MIN overflows" do
+    expect_overflow do
+      month = Int64::MIN.to_i128 - 1
+      Time::MonthSpan.new month
+    end
+  end
+
+  it "negate overflow" do
+    expect_overflow do
+      month = Int64::MIN
+      t1 = Time::MonthSpan.new month
+      -t1
+    end
+  end
+end

--- a/src/time/span.cr
+++ b/src/time/span.cr
@@ -524,6 +524,8 @@ end
 # Time.local(2016, 2, 29) + 2.years  # => 2018-02-28 00:00:00
 # ```
 struct Time::MonthSpan
+  include Comparable(self)
+
   # The number of months.
   getter value : Int64
 
@@ -539,6 +541,58 @@ struct Time::MonthSpan
   # Returns a `Time` that happens N months before now.
   def ago : Time
     Time.local - self
+  end
+
+  def -(other : self) : Time::MonthSpan
+    # TODO check overflow
+    MonthSpan.new(@value - other.value)
+  end
+
+  def - : Time::MonthSpan
+    # TODO check overflow
+    MonthSpan.new(-@value)
+  end
+
+  def +(other : self) : Time::MonthSpan
+    # TODO check overflow
+    MonthSpan.new(@value + other.value)
+  end
+
+  def + : self
+    self
+  end
+
+  # Returns a `Time::MonthSpan` that is *number* times longer.
+  def *(number : Int) : Time::MonthSpan
+    # TODO check overflow
+    MonthSpan.new((@value * number).to_i64)
+  end
+
+  # Returns a `Time::MonthSpan` that is *number* times longer.
+  def *(number : Float) : Time::MonthSpan
+    # TODO check overflow
+    MonthSpan.new((@value * number).to_i64)
+  end
+
+  # Returns a `Time::MonthSpan` that is divided by *number*.
+  def /(number : Int) : Time::MonthSpan
+    # TODO check overflow
+    MonthSpan.new((@value / number).to_i64)
+  end
+
+  # Returns a `Time::MonthSpan` that is divided by *number*.
+  def /(other : self) : Float64
+    # TODO check overflow
+    @value / other.value
+  end
+
+  def /(number : Float) : Time::MonthSpan
+    # TODO check overflow
+    MonthSpan.new((@value / number).to_i64)
+  end
+
+  def <=>(other : self)
+    @value <=> other.value
   end
 end
 


### PR DESCRIPTION
after realizing `Time::MonthSpan` cannot be compared or used with arithmetic operations, I've expanded the class to support it. 

Then found https://github.com/crystal-lang/crystal/pull/7454, which would solve the issue.. but it looks like there are some concerns about merging `Time::Span` and `Time::MonthSpan`, so this MR might be a small iterative improvement until bigger conceptual issues are resolved.