### PR TITLE
Ensure all setter methods in the standard library return the value being set

### DIFF
--- a/samples/havlak.cr
+++ b/samples/havlak.cr
@@ -98,16 +98,19 @@ class SimpleLoop
   def parent=(parent : SimpleLoop)
     @parent = parent
     parent.add_child_loop(self)
+    parent
   end
 
   def header=(bb : BasicBlock)
     @basic_blocks.add(bb)
     @header = bb
+    bb
   end
 
   def nesting_level=(level)
     @nesting_level = level
     @root = true if level == 0
+    level
   end
 end
 

--- a/samples/sdl/sdl/surface.cr
+++ b/samples/sdl/sdl/surface.cr
@@ -25,6 +25,7 @@ class SDL::Surface
 
   def []=(offset, color)
     (@surface.value.pixels.as(UInt32*))[offset] = color.to_u32
+    color
   end
 
   def []=(x, y, color)

--- a/src/array.cr
+++ b/src/array.cr
@@ -1023,6 +1023,7 @@ class Array(T)
   # :nodoc:
   protected def size=(size : Int)
     @size = size.to_i
+    size
   end
 
   # Optimized version of `Enumerable#map`.

--- a/src/big/big_float.cr
+++ b/src/big/big_float.cr
@@ -91,6 +91,7 @@ struct BigFloat < Float
 
   def self.default_precision=(prec : Int)
     LibGMP.mpf_set_default_prec(prec.to_u64)
+    prec
   end
 
   def <=>(other : BigFloat)

--- a/src/bit_array.cr
+++ b/src/bit_array.cr
@@ -61,6 +61,7 @@ struct BitArray
     else
       @bits[bit_index] &= ~(1 << sub_index)
     end
+    value
   end
 
   # Returns all elements that are within the given range.

--- a/src/compiler/crystal/exception.cr
+++ b/src/compiler/crystal/exception.cr
@@ -14,6 +14,7 @@ module Crystal
 
     def warning=(warning)
       @warning = !!warning
+      warning
     end
 
     abstract def to_s_with_source(io : IO, source)

--- a/src/compiler/crystal/progress_tracker.cr
+++ b/src/compiler/crystal/progress_tracker.cr
@@ -64,10 +64,12 @@ module Crystal
 
     def stage_progress=(@stage_progress)
       print_progress
+      stage_progress
     end
 
     def stage_progress_total=(@stage_progress_total)
       print_progress
+      stage_progress_total
     end
   end
 end

--- a/src/compiler/crystal/semantic/ast.cr
+++ b/src/compiler/crystal/semantic/ast.cr
@@ -176,6 +176,7 @@ module Crystal
           end
         end
       end
+      value
     end
 
     # Returns the minimum and maximum number of arguments that must

--- a/src/compiler/crystal/semantic/call.cr
+++ b/src/compiler/crystal/semantic/call.cr
@@ -1137,6 +1137,7 @@ class Crystal::Call
         typed_def.raises = value
       end
     end
+    value
   end
 
   def super?

--- a/src/compiler/crystal/semantic/exception.cr
+++ b/src/compiler/crystal/semantic/exception.cr
@@ -14,16 +14,19 @@ module Crystal
     def color=(color)
       @color = !!color
       inner.try &.color=(color)
+      color
     end
 
     def error_trace=(error_trace)
       @error_trace = !!error_trace
       inner.try &.error_trace=(error_trace)
+      error_trace
     end
 
     def warning=(warning)
       super
       inner.try &.warning=(warning)
+      warning
     end
 
     def self.for_node(node, message, inner = nil)

--- a/src/compiler/crystal/syntax/ast.cr
+++ b/src/compiler/crystal/syntax/ast.cr
@@ -53,6 +53,7 @@ module Crystal
     # having doc comments, so by default this does nothing and some
     # subclasses implement this.
     def doc=(doc)
+      doc
     end
 
     def name_location
@@ -64,6 +65,7 @@ module Crystal
     end
 
     def visibility=(visibility : Visibility)
+      visibility
     end
 
     def visibility

--- a/src/compiler/crystal/syntax/exception.cr
+++ b/src/compiler/crystal/syntax/exception.cr
@@ -15,6 +15,7 @@ module Crystal
 
     def color=(color)
       @color = !!color
+      color
     end
 
     def has_location?

--- a/src/compiler/crystal/syntax/parser.cr
+++ b/src/compiler/crystal/syntax/parser.cr
@@ -76,6 +76,7 @@ module Crystal
     def wants_doc=(wants_doc)
       @wants_doc = !!wants_doc
       @doc_enabled = !!wants_doc
+      wants_doc
     end
 
     def parse

--- a/src/compiler/crystal/types.cr
+++ b/src/compiler/crystal/types.cr
@@ -703,6 +703,7 @@ module Crystal
     end
 
     def private=(set_private)
+      set_private
     end
 
     # Returns true if *name* if an unbound type variable in this (generic) type.
@@ -1217,6 +1218,7 @@ module Crystal
     def superclass=(@superclass)
       @depth = superclass ? (superclass.depth + 1) : 0
       parents.push superclass if superclass
+      superclass
     end
 
     def add_subclass(subclass)

--- a/src/compress/zip/checksum_writer.cr
+++ b/src/compress/zip/checksum_writer.cr
@@ -24,6 +24,7 @@ module Compress::Zip
     def io=(@io)
       @count = 0_u32
       @crc32 = ::Digest::CRC32.initial
+      io
     end
   end
 end

--- a/src/crystal/system/unix/file_descriptor.cr
+++ b/src/crystal/system/unix/file_descriptor.cr
@@ -41,6 +41,7 @@ module Crystal::System::FileDescriptor
       new_flags |= LibC::O_NONBLOCK
     end
     fcntl(LibC::F_SETFL, new_flags) unless new_flags == current_flags
+    value
   end
 
   private def system_close_on_exec?

--- a/src/crystal/system/win32/file_descriptor.cr
+++ b/src/crystal/system/win32/file_descriptor.cr
@@ -37,6 +37,7 @@ module Crystal::System::FileDescriptor
 
   private def system_blocking=(blocking)
     raise NotImplementedError.new("Crystal::System::FileDescriptor#system_blocking=") unless blocking
+    blocking
   end
 
   private def system_close_on_exec?
@@ -45,6 +46,7 @@ module Crystal::System::FileDescriptor
 
   private def system_close_on_exec=(close_on_exec)
     raise NotImplementedError.new("Crystal::System::FileDescriptor#system_close_on_exec=") if close_on_exec
+    close_on_exec
   end
 
   private def system_closed?

--- a/src/http/client.cr
+++ b/src/http/client.cr
@@ -281,6 +281,7 @@ class HTTP::Client
   # ```
   def read_timeout=(read_timeout : Number)
     @read_timeout = read_timeout.to_f
+    read_timeout
   end
 
   # Sets the read timeout with a `Time::Span`, to wait when reading before raising an `IO::TimeoutError`.
@@ -298,18 +299,21 @@ class HTTP::Client
   # ```
   def read_timeout=(read_timeout : Time::Span)
     self.read_timeout = read_timeout.total_seconds
+    read_timeout
   end
 
   # Sets the write timeout - if any chunk of request is not written
   # within the number of seconds provided, `IO::TimeoutError` exception is raised.
   def write_timeout=(write_timeout : Number)
     @write_timeout = write_timeout.to_f
+    write_timeout
   end
 
   # Sets the write timeout - if any chunk of request is not written
   # within the provided `Time::Span`,  `IO::TimeoutError` exception is raised.
   def write_timeout=(write_timeout : Time::Span)
     self.write_timeout = write_timeout.total_seconds
+    write_timeout
   end
 
   # Sets the number of seconds to wait when connecting, before raising an `IO::TimeoutError`.
@@ -327,6 +331,7 @@ class HTTP::Client
   # ```
   def connect_timeout=(connect_timeout : Number)
     @connect_timeout = connect_timeout.to_f
+    connect_timeout
   end
 
   # Sets the open timeout with a `Time::Span` to wait when connecting, before raising an `IO::TimeoutError`.
@@ -344,6 +349,7 @@ class HTTP::Client
   # ```
   def connect_timeout=(connect_timeout : Time::Span)
     self.connect_timeout = connect_timeout.total_seconds
+    connect_timeout
   end
 
   # **This method has no effect right now**
@@ -363,6 +369,7 @@ class HTTP::Client
   # ```
   def dns_timeout=(dns_timeout : Number)
     @dns_timeout = dns_timeout.to_f
+    dns_timeout
   end
 
   # **This method has no effect right now**
@@ -382,6 +389,7 @@ class HTTP::Client
   # ```
   def dns_timeout=(dns_timeout : Time::Span)
     self.dns_timeout = dns_timeout.total_seconds
+    dns_timeout
   end
 
   # Adds a callback to execute before each request. This is usually

--- a/src/http/cookie.cr
+++ b/src/http/cookie.cr
@@ -197,6 +197,7 @@ module HTTP
     # ```
     def []=(key, value : String)
       self[key] = Cookie.new(key, value)
+      value
     end
 
     # Sets a new cookie in the collection to the given `HTTP::Cookie`

--- a/src/http/params.cr
+++ b/src/http/params.cr
@@ -205,6 +205,7 @@ module HTTP
         in String        then [value]
         in Array(String) then value
         end
+      value
     end
 
     # Returns all values for specified param *name*.

--- a/src/http/request.cr
+++ b/src/http/request.cr
@@ -72,6 +72,7 @@ class HTTP::Request
 
   def content_length=(length : Int)
     headers["Content-Length"] = length.to_s
+    length
   end
 
   def content_length
@@ -81,11 +82,13 @@ class HTTP::Request
   def body=(body : String)
     @body = IO::Memory.new(body)
     self.content_length = body.bytesize
+    body
   end
 
   def body=(body : Bytes)
     @body = IO::Memory.new(body)
     self.content_length = body.size
+    body
   end
 
   def body=(@body : IO)
@@ -93,6 +96,7 @@ class HTTP::Request
 
   def body=(@body : Nil)
     @headers["Content-Length"] = "0" if @method == "POST" || @method == "PUT"
+    body
   end
 
   def to_io(io)

--- a/src/http/server/response.cr
+++ b/src/http/server/response.cr
@@ -66,6 +66,7 @@ class HTTP::Server
     # Convenience method to set the `Content-Length` header.
     def content_length=(content_length : Int)
       headers["Content-Length"] = content_length.to_s
+      content_length
     end
 
     # Convenience method to retrieve the HTTP status code.

--- a/src/io/buffered.cr
+++ b/src/io/buffered.cr
@@ -185,6 +185,7 @@ module IO::Buffered
   def sync=(sync)
     flush if sync && !@sync
     @sync = !!sync
+    sync
   end
 
   # Determines if this `IO` does write buffering. If `true`, no buffering is done.
@@ -195,6 +196,7 @@ module IO::Buffered
   # Turns on/off `IO` **read** buffering.
   def read_buffering=(read_buffering)
     @read_buffering = !!read_buffering
+    read_buffering
   end
 
   # Determines whether this `IO` buffers reads.
@@ -205,6 +207,7 @@ module IO::Buffered
   # Turns on/off flushing the underlying `IO` when a newline is written.
   def flush_on_newline=(flush_on_newline)
     @flush_on_newline = !!flush_on_newline
+    flush_on_newline
   end
 
   # Determines if this `IO` flushes automatically when a newline is written.

--- a/src/io/memory.cr
+++ b/src/io/memory.cr
@@ -332,6 +332,7 @@ class IO::Memory < IO
     raise ArgumentError.new("Negative pos") if value < 0
 
     @pos = value.to_i
+    value
   end
 
   # Yields an `IO::Memory` to read a section of this `IO`'s buffer.

--- a/src/json/builder.cr
+++ b/src/json/builder.cr
@@ -272,6 +272,7 @@ class JSON::Builder
     else
       @indent = string
     end
+    string
   end
 
   # Sets the indent *level* (number of spaces).
@@ -281,6 +282,7 @@ class JSON::Builder
     else
       @indent = " " * level
     end
+    level
   end
 
   # Returns `true` if the next thing that must pushed into this

--- a/src/llvm/function.cr
+++ b/src/llvm/function.cr
@@ -13,6 +13,7 @@ struct LLVM::Function
 
   def call_convention=(cc)
     LibLLVM.set_function_call_convention(self, cc)
+    cc
   end
 
   def add_attribute(attribute : Attribute, index = AttributeIndex::FunctionIndex)
@@ -78,6 +79,7 @@ struct LLVM::Function
 
   def personality_function=(fn)
     LibLLVM.set_personality_fn(self, fn)
+    fn
   end
 
   def delete

--- a/src/llvm/module.cr
+++ b/src/llvm/module.cr
@@ -27,11 +27,13 @@ class LLVM::Module
 
     def name=(name : String)
       LibLLVM.set_module_identifier(self, name, name.bytesize)
+      name
     end
   {% end %}
 
   def target=(target)
     LibLLVM.set_target(self, target)
+    target
   end
 
   def data_layout=(data : TargetData)
@@ -41,6 +43,7 @@ class LLVM::Module
       # LLVM >= 3.9
       LibLLVM.set_module_data_layout(self, data)
     {% end %}
+    data
   end
 
   def dump

--- a/src/llvm/pass_manager_builder.cr
+++ b/src/llvm/pass_manager_builder.cr
@@ -5,22 +5,27 @@ class LLVM::PassManagerBuilder
 
   def opt_level=(level)
     LibLLVM.pass_manager_builder_set_opt_level self, level
+    level
   end
 
   def size_level=(level)
     LibLLVM.pass_manager_builder_set_size_level self, level
+    level
   end
 
   def disable_unroll_loops=(value)
     LibLLVM.pass_manager_builder_set_disable_unroll_loops self, value ? 1 : 0
+    value
   end
 
   def disable_simplify_lib_calls=(value)
     LibLLVM.pass_manager_builder_set_disable_simplify_lib_calls self, value ? 1 : 0
+    value
   end
 
   def use_inliner_with_threshold=(threshold)
     LibLLVM.pass_manager_builder_use_inliner_with_threshold self, threshold
+    threshold
   end
 
   def populate(pm : FunctionPassManager)

--- a/src/llvm/target_machine.cr
+++ b/src/llvm/target_machine.cr
@@ -34,6 +34,7 @@ class LLVM::TargetMachine
 
   def enable_global_isel=(enable : Bool)
     LibLLVMExt.target_machine_enable_global_isel(self, enable)
+    enable
   end
 
   private def emit_to_file(llvm_mod, filename, type)

--- a/src/llvm/value_methods.cr
+++ b/src/llvm/value_methods.cr
@@ -4,6 +4,7 @@ module LLVM::ValueMethods
 
   def name=(name)
     LibLLVM.set_value_name(self, name)
+    name
   end
 
   def name
@@ -36,6 +37,7 @@ module LLVM::ValueMethods
 
   def thread_local=(thread_local)
     LibLLVM.set_thread_local(self, thread_local ? 1 : 0)
+    thread_local
   end
 
   def thread_local?
@@ -44,6 +46,7 @@ module LLVM::ValueMethods
 
   def linkage=(linkage)
     LibLLVM.set_linkage(self, linkage)
+    linkage
   end
 
   def linkage
@@ -52,6 +55,7 @@ module LLVM::ValueMethods
 
   def call_convention=(call_convention)
     LibLLVM.set_instruction_call_convention(self, call_convention)
+    call_convention
   end
 
   def call_convention
@@ -60,6 +64,7 @@ module LLVM::ValueMethods
 
   def global_constant=(global_constant)
     LibLLVM.set_global_constant(self, global_constant ? 1 : 0)
+    global_constant
   end
 
   def global_constant?
@@ -68,6 +73,7 @@ module LLVM::ValueMethods
 
   def initializer=(initializer)
     LibLLVM.set_initializer(self, initializer)
+    initializer
   end
 
   def initializer
@@ -77,14 +83,17 @@ module LLVM::ValueMethods
 
   def volatile=(volatile)
     LibLLVM.set_volatile(self, volatile ? 1 : 0)
+    volatile
   end
 
   def ordering=(ordering)
     LibLLVMExt.set_ordering(self, ordering)
+    ordering
   end
 
   def alignment=(bytes)
     LibLLVM.set_alignment(self, bytes)
+    bytes
   end
 
   def const_int_get_sext_value

--- a/src/log/main.cr
+++ b/src/log/main.cr
@@ -69,6 +69,7 @@ class Log
     # because `Log.context` returns a `Log::Context` for allowing DSL like `Log.context.set(a: 1)`
     # but if the metadata is built manually the construct `Log.context = metadata` will be used.
     Log.context = value.metadata
+    value
   end
 
   # Returns the current fiber logging context.

--- a/src/openssl/ssl/context.cr
+++ b/src/openssl/ssl/context.cr
@@ -230,6 +230,7 @@ abstract class OpenSSL::SSL::Context
   def ca_certificates=(file_path : String)
     ret = LibSSL.ssl_ctx_load_verify_locations(@handle, file_path, nil)
     raise OpenSSL::Error.new("SSL_CTX_load_verify_locations") unless ret == 1
+    file_path
   end
 
   # Sets the path to a directory containing all CA certificates used to
@@ -238,6 +239,7 @@ abstract class OpenSSL::SSL::Context
   def ca_certificates_path=(dir_path : String)
     ret = LibSSL.ssl_ctx_load_verify_locations(@handle, nil, dir_path)
     raise OpenSSL::Error.new("SSL_CTX_load_verify_locations") unless ret == 1
+    dir_path
   end
 
   # Specify the path to the certificate chain file to use. In server mode this
@@ -245,6 +247,7 @@ abstract class OpenSSL::SSL::Context
   def certificate_chain=(file_path : String)
     ret = LibSSL.ssl_ctx_use_certificate_chain_file(@handle, file_path)
     raise OpenSSL::Error.new("SSL_CTX_use_certificate_chain_file") unless ret == 1
+    file_path
   end
 
   # Specify the path to the private key to use. The key must in PEM format.
@@ -252,6 +255,7 @@ abstract class OpenSSL::SSL::Context
   def private_key=(file_path : String)
     ret = LibSSL.ssl_ctx_use_privatekey_file(@handle, file_path, LibSSL::SSLFileType::PEM)
     raise OpenSSL::Error.new("SSL_CTX_use_PrivateKey_file") unless ret == 1
+    file_path
   end
 
   # Specify a list of TLS ciphers to use or discard.
@@ -410,6 +414,7 @@ abstract class OpenSSL::SSL::Context
   # Sets the verify mode. See the `SSL_CTX_set_verify(3)` manpage for more details.
   def verify_mode=(mode : OpenSSL::SSL::VerifyMode)
     LibSSL.ssl_ctx_set_verify(@handle, mode, nil)
+    mode
   end
 
   {% if compare_versions(LibSSL::OPENSSL_VERSION, "1.0.2") >= 0 %}
@@ -428,6 +433,7 @@ abstract class OpenSSL::SSL::Context
       proto[0] = protocol.bytesize.to_u8
       protocol.to_slice.copy_to(proto.to_unsafe + 1, protocol.bytesize)
       self.alpn_protocol = proto
+      protocol
     end
 
     private def alpn_protocol=(protocol : Bytes)
@@ -442,6 +448,7 @@ abstract class OpenSSL::SSL::Context
       }
       @alpn_protocol = alpn_protocol = Box.box(protocol)
       LibSSL.ssl_ctx_set_alpn_select_cb(@handle, alpn_cb, alpn_protocol)
+      protocol
     end
 
     # Sets this context verify param to the default one of the given name.
@@ -453,6 +460,7 @@ abstract class OpenSSL::SSL::Context
       raise ArgumentError.new("#{name} is an unsupported default verify param") unless param
       ret = LibSSL.ssl_ctx_set1_param(@handle, param)
       raise OpenSSL::Error.new("SSL_CTX_set1_param") unless ret == 1
+      name
     end
 
     # Sets the given `OpenSSL::X509VerifyFlags` in this context, additionally to

--- a/src/openssl/x509/certificate.cr
+++ b/src/openssl/x509/certificate.cr
@@ -39,6 +39,7 @@ module OpenSSL::X509
     # Refer to `Name.parse` for the format.
     def subject=(subject : String)
       self.subject = Name.parse(subject)
+      subject
     end
 
     def subject=(subject : Name)

--- a/src/signal.cr
+++ b/src/signal.cr
@@ -161,7 +161,7 @@ module Crystal::Signal
     end
   end
 
-  def self.child_handler=(handler : Handler) : Nil
+  def self.child_handler=(handler : Handler)
     @@child_handler = handler
   end
 

--- a/src/socket.cr
+++ b/src/socket.cr
@@ -535,6 +535,7 @@ class Socket < IO
       flags |= LibC::O_NONBLOCK
     end
     fcntl(LibC::F_SETFL, flags)
+    value
   end
 
   def close_on_exec?

--- a/src/socket/tcp_socket.cr
+++ b/src/socket/tcp_socket.cr
@@ -68,6 +68,7 @@ class TCPSocket < IPSocket
   # Disables the Nagle algorithm when set to `true`, otherwise enables it.
   def tcp_nodelay=(val : Bool)
     setsockopt_bool LibC::TCP_NODELAY, val, level: Protocol::TCP
+    val
   end
 
   {% unless flag?(:openbsd) %}

--- a/src/socket/udp_socket.cr
+++ b/src/socket/udp_socket.cr
@@ -115,6 +115,7 @@ class UDPSocket < IPSocket
     else
       raise Socket::Error.new "Unsupported IP address family: #{@family}"
     end
+    val
   end
 
   # Returns the current value of the `hoplimit` field on uni-cast packets.

--- a/src/spec/dsl.cr
+++ b/src/spec/dsl.cr
@@ -89,11 +89,13 @@ module Spec
 
     @@randomizer_seed = seed
     @@randomizer = seed ? Random::PCG32.new(seed) : nil
+    mode
   end
 
   # :nodoc:
   def self.pattern=(pattern)
     @@pattern = Regex.new(Regex.escape(pattern))
+    pattern
   end
 
   # :nodoc:

--- a/src/static_array.cr
+++ b/src/static_array.cr
@@ -205,6 +205,7 @@ struct StaticArray(T, N)
     size.times do |i|
       to_unsafe[i] = value
     end
+    value
   end
 
   # Modifies `self` by randomizing the order of elements in the array

--- a/src/string_scanner.cr
+++ b/src/string_scanner.cr
@@ -69,6 +69,7 @@ class StringScanner
   def offset=(position : Int)
     raise IndexError.new unless position >= 0
     @byte_offset = @str.char_index_to_byte_index(position) || @str.bytesize
+    position
   end
 
   # Returns the current position of the scan offset.

--- a/src/xml/builder.cr
+++ b/src/xml/builder.cr
@@ -261,6 +261,7 @@ struct XML::Builder
       call SetIndent, 1
       call SetIndentString, string_to_unsafe(str)
     end
+    str
   end
 
   # Sets the indent *level* (number of spaces).
@@ -271,6 +272,7 @@ struct XML::Builder
       call SetIndent, 1
       call SetIndentString, " " * level
     end
+    level
   end
 
   # Sets the quote char to use, either `'` or `"`.
@@ -280,6 +282,7 @@ struct XML::Builder
     end
 
     call SetQuoteChar, char.ord
+    char
   end
 
   private macro call(name, *args)

--- a/src/xml/node.cr
+++ b/src/xml/node.cr
@@ -94,6 +94,7 @@ struct XML::Node
   def content=(content)
     check_no_null_byte(content)
     LibXML.xmlNodeSetContent(self, content)
+    content
   end
 
   # Gets the document for this Node as a `XML::Node`.
@@ -270,17 +271,18 @@ struct XML::Node
       raise XML::Error.new("Can't set name of XML #{type}", 0)
     end
 
-    name = name.to_s
+    name_str = name.to_s
 
-    if name.includes? '\0'
-      raise XML::Error.new("Invalid node name: #{name.inspect} (contains null character)", 0)
+    if name_str.includes? '\0'
+      raise XML::Error.new("Invalid node name: #{name_str.inspect} (contains null character)", 0)
     end
 
-    if LibXML.xmlValidateNameValue(name) == 0
-      raise XML::Error.new("Invalid node name: #{name.inspect}", 0)
+    if LibXML.xmlValidateNameValue(name_str) == 0
+      raise XML::Error.new("Invalid node name: #{name_str.inspect}", 0)
     end
 
-    LibXML.xmlNodeSetName(self, name)
+    LibXML.xmlNodeSetName(self, name_str)
+    name
   end
 
   # Returns the namespace for this node or `nil` if not found.
@@ -571,6 +573,7 @@ struct XML::Node
   # :nodoc:
   def errors=(errors)
     @node.value._private = errors.as(Void*)
+    errors
   end
 
   # Returns the list of `XML::Error` found when parsing this document.

--- a/src/yaml/nodes/nodes.cr
+++ b/src/yaml/nodes/nodes.cr
@@ -109,6 +109,7 @@ module YAML::Nodes
     # Appends two nodes into this mapping.
     def []=(key, value)
       @nodes << key << value
+      value
     end
 
     # Appends a single node into this mapping.


### PR DESCRIPTION
Until the more general #7707 is resolved, this ensures all setter methods always return the value arguments that are passed to them.

The setters were identified using `/def (self\.)?([a-z_0-9]+|\[\])=/`. Setters inside specs are ignored. One conflicting return type restriction was removed, but it was internal to the compiler (`Crystal::Signal.child_handler=`).