### PR TITLE
Print unhandled exceptions from main routine with #inspect_with_backtrace

### DIFF
--- a/spec/std/kernel_spec.cr
+++ b/spec/std/kernel_spec.cr
@@ -229,6 +229,16 @@ describe "at_exit" do
     status.success?.should be_true
     output.should eq("3\n4\n1\n2\n")
   end
+
+  it "prints unhandled exception with cause" do
+    status, _, error = compile_and_run_source <<-CODE
+      raise Exception.new("secondary", cause: Exception.new("primary"))
+    CODE
+
+    status.success?.should be_false
+    error.should contain "Unhandled exception: secondary"
+    error.should contain "Caused by: primary"
+  end
 end
 
 describe "seg fault" do

--- a/src/crystal/main.cr
+++ b/src/crystal/main.cr
@@ -43,10 +43,15 @@ module Crystal
       end
 
     status = Crystal::AtExitHandlers.run status, ex
+
+    if ex
+      STDERR.print "Unhandled exception: "
+      ex.inspect_with_backtrace(STDERR)
+    end
+
     ignore_stdio_errors { STDOUT.flush }
     ignore_stdio_errors { STDERR.flush }
 
-    raise ex if ex
     status
   end
 


### PR DESCRIPTION
Exceptions from the main routine should be safe to print using `Exception#inspect_with_backtrace`.
They don't need be printed directly to STDERR using `Crystal::System.print_exception`.

This fixes a regression introduced in #8791 (f2c339b96df7339290924814d9ddd9b55f9f4182) where exception's causes would not be printed (that's not implemented in `print_exception`).