### PR TITLE
Fix `Flatten` for value-type iterators

### DIFF
--- a/spec/std/iterator_spec.cr
+++ b/spec/std/iterator_spec.cr
@@ -1,6 +1,22 @@
 require "spec"
 require "iterator"
 
+struct StructIter
+  include Iterator(Int32)
+
+  def initialize(@a : Int32, @b : Int32); end
+
+  def next
+    if @a > @b
+      stop
+    else
+      cur = @a
+      @a += 1
+      cur
+    end
+  end
+end
+
 describe Iterator do
   describe "Iterator.of" do
     it "creates singleton" do
@@ -691,6 +707,18 @@ describe Iterator do
       iter.next.should eq(4)
       iter.next.should eq({5 => 6})
       iter.next.should eq(7)
+      iter.next.should be_a(Iterator::Stop)
+    end
+
+    it "flattens nested struct iterators with internal state being value types" do
+      iter = (1..2).each.map { |i| StructIter.new(10 * i + 1, 10 * i + 3) }.flatten
+
+      iter.next.should eq(11)
+      iter.next.should eq(12)
+      iter.next.should eq(13)
+      iter.next.should eq(21)
+      iter.next.should eq(22)
+      iter.next.should eq(23)
       iter.next.should be_a(Iterator::Stop)
     end
 

--- a/src/iterator.cr
+++ b/src/iterator.cr
@@ -537,23 +537,26 @@ module Iterator(T)
     @generators : Array(I)
 
     def initialize(@iterator)
-      @generators = [@iterator]
+      @generators = [] of I
       @stopped = [] of I
     end
 
     def next
-      case value = @generators.last.next
+      case value = @iterator.next
       when Iterator
-        @generators.push value
+        @generators.push @iterator
+        @iterator = value
         self.next
       when Array
-        @generators.push value.each
+        @generators.push @iterator
+        @iterator = value.each
         self.next
       when Stop
-        if @generators.size == 1
+        @stopped << @iterator
+        if @generators.empty?
           stop
         else
-          @stopped << @generators.pop
+          @iterator = @generators.pop
           self.next
         end
       else


### PR DESCRIPTION
This requires `Flatten` to always update the iterator value itself,
not a copy.

* Keep current iterator in `@iterator`
* Update only `@iterator`
* `@generators` only contains currently suspended iterators

The issue has been raised in the [forum](https://forum.crystal-lang.org/t/flatten-nested-struct-iterators-leads-to-infinite-loop/2795/1)