### PR TITLE
Disallow top-level 'def super'

### DIFF
--- a/spec/compiler/semantic/def_spec.cr
+++ b/spec/compiler/semantic/def_spec.cr
@@ -498,4 +498,18 @@ describe "Semantic: def" do
     ex.column_number.should eq(3)
     ex.size.should eq(6)
   end
+
+  it "does not allow top-level 'def super'" do
+    assert_error <<-CODE, "top-level 'def super' is not allowed due to no way to call this"
+      def super
+      end
+      CODE
+  end
+
+  it "does not allow top-level 'def previous_def'" do
+    assert_error <<-CODE, "top-level 'def previous_def' is not allowed due to no way to call this"
+      def previous_def
+      end
+      CODE
+  end
 end

--- a/src/compiler/crystal/program.cr
+++ b/src/compiler/crystal/program.cr
@@ -578,6 +578,10 @@ module Crystal
     end
 
     def add_def(node : Def)
+      if node.receiver.nil? && node.name.in?("super", "previous_def")
+        node.raise "top-level 'def #{node.name}' is not allowed due to no way to call this"
+      end
+
       if file_module = check_private(node)
         file_module.add_def node
       else


### PR DESCRIPTION
Because there is no way to call this.

- - -

Doubt. We can call such a top-level `def super` via a file private implicit module.

```crystal
private def module_self
  self
end

def super
  p :super
end

module_self.super
```

But it seems like a bug because it does not compile if `def module_self` is `public` or `protected`.