### PR TITLE
Rename URI#full_path to URI#request_target

### DIFF
--- a/spec/std/uri_spec.cr
+++ b/spec/std/uri_spec.cr
@@ -197,6 +197,28 @@ describe "URI" do
     end
   end
 
+  describe "#request_target" do
+    it { URI.new(path: "/foo").request_target.should eq("/foo") }
+    it { URI.new.request_target.should eq("/") }
+    it { URI.new(scheme: "https", host: "example.com").request_target.should eq("/") }
+    it { URI.new(scheme: "https", host: "example.com", path: "/%2F/%2F/").request_target.should eq("/%2F/%2F/") }
+    it { URI.new(scheme: "scheme", path: "opaque").request_target.should eq "opaque" }
+    it { URI.new(scheme: "scheme", query: "foo=bar&foo=baz").request_target.should eq "?foo=bar&foo=baz" }
+
+    it { URI.new(path: "//foo").request_target.should eq("//foo") }
+    it { URI.new(path: "/foo", query: "q=1").request_target.should eq("/foo?q=1") }
+    it { URI.new(path: "/", query: "q=1").request_target.should eq("/?q=1") }
+    it { URI.new(query: "q=1").request_target.should eq("/?q=1") }
+    it { URI.new(path: "/a%3Ab").request_target.should eq("/a%3Ab") }
+    it { URI.new("scheme").request_target.should eq "" }
+
+    it "does not add '?' to the end if the query params are empty" do
+      uri = URI.parse("http://www.example.com/foo")
+      uri.query = ""
+      uri.request_target.should eq("/foo")
+    end
+  end
+
   describe "#absolute?" do
     it { URI.parse("http://www.example.com/foo").absolute?.should be_true }
     it { URI.parse("http://www.example.com").absolute?.should be_true }

--- a/src/http/client.cr
+++ b/src/http/client.cr
@@ -855,7 +855,7 @@ class HTTP::Client
     host = validate_host(uri)
 
     port = uri.port
-    path = uri.full_path
+    path = uri.request_target
     user = uri.user
     password = uri.password
 

--- a/src/http/request.cr
+++ b/src/http/request.cr
@@ -59,7 +59,7 @@ class HTTP::Request
 
   def resource
     update_uri
-    @uri.try(&.full_path) || @resource
+    @uri.try(&.request_target) || @resource
   end
 
   def keep_alive?

--- a/src/http/web_socket/protocol.cr
+++ b/src/http/web_socket/protocol.cr
@@ -318,7 +318,7 @@ class HTTP::WebSocket::Protocol
   def self.new(uri : URI | String, headers = HTTP::Headers.new)
     uri = URI.parse(uri) if uri.is_a?(String)
 
-    if (host = uri.hostname) && (path = uri.full_path)
+    if (host = uri.hostname) && (path = uri.request_target)
       tls = uri.scheme.in?("https", "wss")
       return new(host, path, uri.port, tls, headers)
     end

--- a/src/oauth/consumer.cr
+++ b/src/oauth/consumer.cr
@@ -138,7 +138,7 @@ class OAuth::Consumer
     # If the target uri is absolute, we use that instead of the default values
     if uri.host
       client = HTTP::Client.new(uri)
-      target_uri = "#{uri.path}?#{uri.query}"
+      target_uri = uri.request_target
     else
       client = HTTP::Client.new @host, @port, tls: @tls
     end

--- a/src/uri.cr
+++ b/src/uri.cr
@@ -203,21 +203,38 @@ class URI
     end
   end
 
-  # Returns the full path of this URI.
+  # Returns the concatenation of `path` and `query` as it would be used as a
+  # request target in an HTTP request.
+  #
+  # If `path` is empty in an hierarchical URI, `"/"` is used.
   #
   # ```
   # require "uri"
   #
-  # uri = URI.parse "http://foo.com/posts?id=30&limit=5#time=1305298413"
-  # uri.full_path # => "/posts?id=30&limit=5"
+  # uri = URI.parse "http://example.com/posts?id=30&limit=5#time=1305298413"
+  # uri.request_target # => "/posts?id=30&limit=5"
+  #
+  # uri = URI.new(path: "", query: "foo=bar")
+  # uri.request_target # => "/?foo=bar"
   # ```
-  def full_path : String
+  def request_target : String
     String.build do |str|
-      str << (@path.empty? ? '/' : @path)
+      if @path.empty?
+        str << "/" unless opaque?
+      else
+        str << @path
+      end
+
       if (query = @query) && !query.empty?
         str << '?' << query
       end
     end
+  end
+
+  # :ditto:
+  @[Deprecated("Use `#request_target` instead.")]
+  def full_path : String
+    request_target
   end
 
   # Returns `true` if URI has a *scheme* specified.


### PR DESCRIPTION
`full_path` is an unspecified term and open to interpretation. `path` in an URI context is _just_ `path` and there is no "full" version of it.

The intention of this method is direct at extracting an HTTP request target in origin form. So it should be named appropriately.

This also includes a minor behavioural change: for opaque URIs the path does not default to `/` when empty. Otherwise it would turn an opaque URI into a hierarchical one. This method would typically not be used with opaque URI's, but it doesn't hurt to be complete on this.

Closes #9990