### PR TITLE
Add URI#authority

### DIFF
--- a/spec/std/uri_spec.cr
+++ b/spec/std/uri_spec.cr
@@ -182,6 +182,22 @@ describe "URI" do
     it { URI.new(path: "/foo").hostname.should be_nil }
   end
 
+  describe "#authority" do
+    it { URI.new.authority.should be_nil }
+    it { URI.new(scheme: "scheme").authority.should be_nil }
+    it { URI.new(scheme: "scheme", host: "example.com").authority.should eq "example.com" }
+    it { URI.new(scheme: "scheme", host: "example.com", port: 123).authority.should eq "example.com:123" }
+    it { URI.new(scheme: "scheme", user: "user", host: "example.com").authority.should eq "user@example.com" }
+    it { URI.new(scheme: "scheme", user: "user").authority.should eq "user@" }
+    it { URI.new(scheme: "scheme", port: 123).authority.should eq ":123" }
+    it { URI.new(scheme: "scheme", user: "user", port: 123).authority.should eq "user@:123" }
+    it { URI.new(scheme: "scheme", user: "user", password: "pass", host: "example.com").authority.should eq "user:pass@example.com" }
+    it { URI.new(scheme: "scheme", user: "user", password: "pass", host: "example.com", port: 123).authority.should eq "user:pass@example.com:123" }
+    it { URI.new(scheme: "scheme", password: "pass", host: "example.com").authority.should eq "example.com" }
+    it { URI.new(scheme: "scheme", path: "opaque").authority.should be_nil }
+    it { URI.new(scheme: "scheme", path: "/path").authority.should be_nil }
+  end
+
   describe "#full_path" do
     it { URI.new(path: "/foo").full_path.should eq("/foo") }
     it { URI.new.full_path.should eq("/") }

--- a/src/uri.cr
+++ b/src/uri.cr
@@ -250,26 +250,53 @@ class URI
     HTTP::Params.parse(@query || "")
   end
 
+  # Returns the authority component of this URI.
+  # It is formatted as `user:pass@host:port` with missing parts being omitted.
+  #
+  # If the URI does not have any authority information, the result is `nil`.
+  #
+  # ```cr
+  # uri = URI.parse "http://user:pass@example.com:80/path?query"
+  # uri.authority # => "user:pass@example.com"
+  #
+  # uri = URI.parse(path: "/relative")
+  # uri.authority # => nil
+  # ```
+  def authority : String?
+    return unless @host || @user || @port
+
+    String.build do |io|
+      authority(io)
+    end
+  end
+
+  # :ditto:
+  def authority(io : IO) : Nil
+    if user = @user
+      userinfo(user, io)
+      io << '@'
+    end
+
+    if host = @host
+      URI.encode(host, io)
+    end
+
+    if port = @port
+      io << ':' << port
+    end
+  end
+
   def to_s(io : IO) : Nil
     if scheme
       io << scheme
       io << ':'
     end
 
-    authority = @user || @host || @port
-    io << "//" if authority
-    if user = @user
-      userinfo(user, io)
-      io << '@'
-    end
-    if host = @host
-      URI.encode(host, io)
-    end
-    if port = @port
-      io << ':' << port
-    end
+    has_authority = @host || @user || @port
+    io << "//" if has_authority
+    authority(io)
 
-    if authority
+    if has_authority
       if !@path.empty? && !@path.starts_with?('/')
         io << '/'
       end

--- a/src/uri.cr
+++ b/src/uri.cr
@@ -255,7 +255,7 @@ class URI
   #
   # If the URI does not have any authority information, the result is `nil`.
   #
-  # ```cr
+  # ```
   # uri = URI.parse "http://user:pass@example.com:80/path?query"
   # uri.authority # => "user:pass@example.com"
   #


### PR DESCRIPTION
Adds a method for querying the authority component of a URI.

Ref: https://github.com/crystal-lang/crystal/pull/9990#issuecomment-735270515