### PR TITLE
Add `Set#sample`

### DIFF
--- a/spec/std/set_spec.cr
+++ b/spec/std/set_spec.cr
@@ -396,6 +396,79 @@ describe "Set" do
     empty_set.proper_superset?(empty_set).should be_false
   end
 
+  describe "#sample" do
+    it "gets one sample" do
+      Set{1}.sample.should eq(1)
+
+      set = Set{1, 2, 3}
+      set.includes?(set.sample).should be_true
+    end
+
+    it "gets one sample with random" do
+      set = Set{1, 2, 3}
+      set.sample(Random.new(1)).should eq(2)
+    end
+
+    it "gets sample of empty set raises" do
+      expect_raises IndexError do
+        Set(Int32).new.sample
+      end
+    end
+
+    it "gets sample of k elements from empty set doesn't raise" do
+      empty_set = Set(Int32).new
+      empty_set.sample(0).should eq(empty_set)
+      empty_set.sample(1).should eq(empty_set)
+      empty_set.sample(2).should eq(empty_set)
+    end
+
+    it "gets sample of negative count elements raises" do
+      expect_raises ArgumentError do
+        Set{1}.sample(-1)
+      end
+    end
+
+    it "gets sample of 0 elements" do
+      Set{1}.sample(0).should eq(Set(Int32).new)
+    end
+
+    it "gets sample of 1 elements" do
+      Set{1}.sample(1).should eq(Set{1})
+
+      set = Set{1, 2, 3}
+      x = set.sample(1)
+      x.size.should eq(1)
+      x = x.to_a.first
+      set.includes?(x).should be_true
+    end
+
+    it "gets sample of k elements out of n" do
+      a = Set{1, 2, 3, 4, 5}
+      b = a.sample(3)
+      b.size.should eq(3)
+
+      b.each do |e|
+        a.includes?(e).should be_true
+      end
+    end
+
+    it "gets sample of k elements out of n, where k > n" do
+      a = Set{1, 2, 3, 4, 5}
+      b = a.sample(10)
+      b.size.should eq(5)
+
+      b.each do |e|
+        a.includes?(e).should be_true
+      end
+    end
+
+    it "gets sample of k elements out of n, with random" do
+      a = Set{1, 2, 3, 4, 5}
+      b = a.sample(3, Random.new(1))
+      b.should eq(Set{4, 3, 1})
+    end
+  end
+
   it "has object_id" do
     Set(Int32).new.object_id.should be > 0
   end

--- a/src/set.cr
+++ b/src/set.cr
@@ -463,6 +463,42 @@ struct Set(T)
     other.proper_subset?(self)
   end
 
+  # Returns a random element from `self`, using the given *random* number generator.
+  #
+  # Raises `IndexError` if `self` is empty.
+  #
+  # ```
+  # a = Set{1, 3, 5, 7, 9}
+  # a.sample                # => 3
+  # a.sample                # => 9
+  # a.sample(Random.new(1)) # => 5
+  # ```
+  def sample(random = Random::DEFAULT)
+    @hash.sample_impl(random) do |entry|
+      entry.key
+    end
+  end
+
+  # Returns a `Set` of *n* random elements from `self`, using the given *random*
+  # number generator. All elements are drawn without replacement; if *n* is
+  # larger than the size of this set, the returned `Set` has the same size as `self`.
+  #
+  # Raises `ArgumentError` if *n* is negative.
+  #
+  # ```
+  # a = Set{1, 3, 5, 7, 9}
+  # a.sample(2)                # => Set{9, 5}
+  # a.sample(2)                # => Set{5, 3}
+  # a.sample(2, Random.new(1)) # => Set{9, 1}
+  # ```
+  def sample(n : Int, random = Random::DEFAULT)
+    values = Set(T).new
+    @hash.sample_impl(n, random) do |entry|
+      values << entry.key
+    end
+    values
+  end
+
   # :nodoc:
   def object_id
     @hash.object_id


### PR DESCRIPTION
Augments #9954.

Both single-element and multiple-element overloads are provided. The latter returns a `Set` instead of an `Array` because element uniqueness is guaranteed, and also because `Set` isn't `Indexable` so there are no variance issues. Both overloads run in linear time (sampling a single element in an `Array` is constant-time).

The actual implementation lives in `Hash` because `Set` is ultimately a wrapper around it, but it is less obvious what `Hash#sample` should return, so that's not defined here.