### PR TITLE
Add exception handler in spec at_exit

### DIFF
--- a/src/spec/dsl.cr
+++ b/src/spec/dsl.cr
@@ -272,6 +272,11 @@ module Spec
       maybe_randomize
       run_filters
       root_context.run
+    rescue ex
+      STDERR.print "Unhandled exception: "
+      ex.inspect_with_backtrace(STDERR)
+      STDERR.flush
+      @@aborted = true
     ensure
       finish_run
     end


### PR DESCRIPTION
Exceptions bubbling up from at_exit handlers are printed without backtrace by default, but since the entire spec run happens in an at_exit handler, we should make sure to have full error reporting.