### PR TITLE
Implement Indexable#==

### DIFF
--- a/spec/std/indexable_spec.cr
+++ b/spec/std/indexable_spec.cr
@@ -19,12 +19,12 @@ private class SafeStringIndexable
 
   property size
 
-  def initialize(@size : Int32)
+  def initialize(@size : Int32, @offset = 0)
   end
 
   def unsafe_fetch(i)
     raise IndexError.new unless 0 <= i < size
-    i.to_s
+    (i + @offset).to_s
   end
 end
 
@@ -283,5 +283,31 @@ describe Indexable do
 
     a.hash.should_not eq c.hash
     c.hash.should_not eq a.hash
+  end
+
+  describe "#<=>" do
+    it "equal" do
+      a = SafeStringIndexable.new(3)
+      b = SafeMixedIndexable.new(3)
+
+      (a <=> b).should eq 0
+      (b <=> a).should eq 0
+    end
+
+    it "different elements" do
+      a = SafeStringIndexable.new(3, 1)
+      b = SafeMixedIndexable.new(3)
+
+      (a <=> b).should eq 1
+      (b <=> a).should eq -1
+    end
+
+    it "different size" do
+      a = SafeStringIndexable.new(3)
+      b = SafeMixedIndexable.new(4)
+
+      (a <=> b).should eq -1
+      (b <=> a).should eq 1
+    end
   end
 end

--- a/spec/std/indexable_spec.cr
+++ b/spec/std/indexable_spec.cr
@@ -258,4 +258,30 @@ describe Indexable do
       a.should eq([0, 1, 2])
     end
   end
+
+  describe "#==" do
+    it "equal" do
+      a = SafeStringIndexable.new(3)
+      b = SafeMixedIndexable.new(3)
+      c = SafeMixedIndexable.new(4)
+
+      a.should eq b
+      b.should eq a
+
+      a.should_not eq c
+      c.should_not eq a
+    end
+  end
+
+  describe "#hash" do
+    a = SafeStringIndexable.new(3)
+    b = SafeMixedIndexable.new(3)
+    c = SafeMixedIndexable.new(4)
+
+    a.hash.should eq b.hash
+    b.hash.should eq a.hash
+
+    a.hash.should_not eq c.hash
+    c.hash.should_not eq a.hash
+  end
 end

--- a/spec/std/tuple_spec.cr
+++ b/spec/std/tuple_spec.cr
@@ -102,6 +102,10 @@ describe "Tuple" do
     {1, 2}.should_not eq(1)
   end
 
+  it "#hash" do
+    {1, 2, 3}.hash.should eq [1, 2, 3].hash
+  end
+
   it "does compare" do
     a = {1, 2}
     b = {3, 4}

--- a/src/array.cr
+++ b/src/array.cr
@@ -45,7 +45,6 @@
 # ```
 class Array(T)
   include Indexable(T)
-  include Comparable(Array)
 
   # Size of an Array that we consider small to do linear scans or other optimizations.
   private SMALL_ARRAY_SIZE = 16
@@ -183,31 +182,6 @@ class Array(T)
   # [:foo, :bar].size # => 2
   # ```
   getter size : Int32
-
-  # Combined comparison operator.
-  #
-  # Returns `-1`, `0` or `1` depending on whether `self` is less than *other*, equals *other*
-  # or is greater than *other*.
-  #
-  # It compares the elements of both arrays in the same position using the
-  # `<=>` operator. As soon as one of such comparisons returns a non-zero
-  # value, that result is the return value of the comparison.
-  #
-  # If all elements are equal, the comparison is based on the size of the arrays.
-  #
-  # ```
-  # [8] <=> [1, 2, 3] # => 1
-  # [2] <=> [4, 2, 3] # => -1
-  # [1, 2] <=> [1, 2] # => 0
-  # ```
-  def <=>(other : Array)
-    min_size = Math.min(size, other.size)
-    0.upto(min_size - 1) do |i|
-      n = @buffer[i] <=> other.to_unsafe[i]
-      return n if n != 0
-    end
-    size <=> other.size
-  end
 
   # Set intersection: returns a new `Array` containing elements common to `self`
   # and *other*, excluding any duplicates. The order is preserved from `self`.

--- a/src/array.cr
+++ b/src/array.cr
@@ -184,23 +184,6 @@ class Array(T)
   # ```
   getter size : Int32
 
-  # Equality. Returns `true` if each element in `self` is equal to each
-  # corresponding element in *other*.
-  #
-  # ```
-  # ary = [1, 2, 3]
-  # ary == [1, 2, 3] # => true
-  # ary == [2, 3]    # => false
-  # ```
-  def ==(other : Array)
-    equals?(other) { |x, y| x == y }
-  end
-
-  # :nodoc:
-  def ==(other)
-    false
-  end
-
   # Combined comparison operator.
   #
   # Returns `-1`, `0` or `1` depending on whether `self` is less than *other*, equals *other*

--- a/src/bit_array.cr
+++ b/src/bit_array.cr
@@ -240,13 +240,6 @@ struct BitArray
     Slice.new(@bits.as(Pointer(UInt8)), bytesize)
   end
 
-  # See `Object#hash(hasher)`
-  def hash(hasher)
-    hasher = size.hash(hasher)
-    hasher = to_slice.hash(hasher)
-    hasher
-  end
-
   # Returns a new `BitArray` with all of the same elements.
   def dup
     bit_array = BitArray.new(@size)

--- a/src/deque.cr
+++ b/src/deque.cr
@@ -99,19 +99,6 @@ class Deque(T)
     Deque(T).new(array.size) { |i| array[i] }
   end
 
-  # Returns `true` if it is passed a `Deque` and `equals?` returns `true`
-  # for both deques, the caller and the argument.
-  #
-  # ```
-  # deq = Deque{2, 3}
-  # deq.unshift 1
-  # deq == Deque{1, 2, 3} # => true
-  # deq == Deque{2, 3}    # => false
-  # ```
-  def ==(other : Deque)
-    equals?(other) { |x, y| x == y }
-  end
-
   # Concatenation. Returns a new `Deque` built by concatenating
   # two deques together to create a third. The type of the new deque
   # is the union of the types of both the other deques.

--- a/src/indexable.cr
+++ b/src/indexable.cr
@@ -439,6 +439,35 @@ module Indexable(T)
     size == 0 ? yield : unsafe_fetch(0)
   end
 
+  # Returns `true` if each element in `self` is equal to each
+  # corresponding element in *other*.
+  #
+  # ```
+  # [1, 2, 3] == {1, 2, 3} # => true
+  # [1, 2, 3] == {2, 3}    # => false
+  # ```
+  #
+  # Two indexables are defined to be equal if they contain the same elements in
+  # the same order. This definition ensures that comparison works
+  # properly across different implementing types.
+  def ==(other : Indexable)
+    equals?(other) { |x, y| x == y }
+  end
+
+  # Equality with an object that is not `Indexable`. Always returns `false`.
+  def ==(other)
+    false
+  end
+
+  # Appends this indexable to *hasher* and returns the modified *hasher*.
+  #
+  # The hash is computed by hashing `size` and then hashing each element in order.
+  # This ensures that any `Indexable` implementation results in the same hash
+  # (given the same contents) and that two hashes who test equal (`==`) also
+  # produce the same hash.
+  #
+  # Implementing types should usually not override this method.
+  #
   # See `Object#hash(hasher)`
   def hash(hasher)
     hasher = size.hash(hasher)

--- a/src/indexable.cr
+++ b/src/indexable.cr
@@ -8,6 +8,7 @@
 module Indexable(T)
   include Iterable(T)
   include Enumerable(T)
+  include Comparable(Indexable)
 
   # Returns the number of elements in this container.
   abstract def size
@@ -402,6 +403,36 @@ module Indexable(T)
   # ```
   def empty?
     size == 0
+  end
+
+  # The comparison operator.
+  #
+  # Returns `-1`, `0` or `1` depending on whether `self` is less than *other*,
+  # equals *other* or is greater than *other*.
+  #
+  # ```
+  # [8] <=> [1, 2, 3] # => 1
+  # [2] <=> [4, 2, 3] # => -1
+  # [1, 2] <=> [1, 2] # => 0
+  # [1, 2] <=> {1, 2} # => 0
+  # ```
+  #
+  # Indexables are compared in an "element-wise" manner; the first element of
+  # `self` is compared with the first one of *other* using the `<=>` operator,
+  # then the second elements, etc.
+  # As soon as any such comparison is non-zero (i.e. the two corresponding
+  # elements are not equal), that result is returned for the whole comparison.
+  #
+  # If all common elements are equal, the comparison is based on the size of the
+  # indexables. If both have exactly the same number of elements and all
+  # elements are equal, both indexables are equal and the result is `0`.
+  def <=>(other : Indexable)
+    min_size = Math.min(size, other.size)
+    0.upto(min_size - 1) do |i|
+      n = self.unsafe_fetch(i) <=> other.unsafe_fetch(i)
+      return n if n != 0
+    end
+    size <=> other.size
   end
 
   # Optimized version of `equals?` used when `other` is also an `Indexable`.

--- a/src/slice.cr
+++ b/src/slice.cr
@@ -12,7 +12,6 @@ require "slice/sort"
 # `String#to_slice` is read-only.
 struct Slice(T)
   include Indexable(T)
-  include Comparable(Slice)
 
   # Creates a new `Slice` with the given *args*. The type of the
   # slice will be the union of the type of the given *args*.

--- a/src/static_array.cr
+++ b/src/static_array.cr
@@ -85,34 +85,6 @@ struct StaticArray(T, N)
   private def initialize
   end
 
-  # Equality. Returns `true` if each element in `self` is equal to each
-  # corresponding element in *other*.
-  #
-  # ```
-  # array = StaticArray(Int32, 3).new 0  # => StaticArray[0, 0, 0]
-  # array2 = StaticArray(Int32, 3).new 0 # => StaticArray[0, 0, 0]
-  # array3 = StaticArray(Int32, 3).new 1 # => StaticArray[1, 1, 1]
-  # array == array2                      # => true
-  # array == array3                      # => false
-  # ```
-  def ==(other : StaticArray)
-    return false unless size == other.size
-    each_with_index do |e, i|
-      return false unless e == other[i]
-    end
-    true
-  end
-
-  # Equality with another object. Always returns `false`.
-  #
-  # ```
-  # array = StaticArray(Int32, 3).new 0 # => StaticArray[0, 0, 0]
-  # array == nil                        # => false
-  # ```
-  def ==(other)
-    false
-  end
-
   @[AlwaysInline]
   def unsafe_fetch(index : Int)
     to_unsafe[index]

--- a/src/tuple.cr
+++ b/src/tuple.cr
@@ -224,20 +224,6 @@ struct Tuple
     true
   end
 
-  # :ditto:
-  def ==(other : Tuple)
-    return false unless size == other.size
-
-    size.times do |i|
-      return false unless self[i] == other[i]
-    end
-    true
-  end
-
-  def ==(other)
-    false
-  end
-
   # Returns `true` if case equality holds for the elements in `self` and *other*.
   #
   # ```
@@ -307,8 +293,9 @@ struct Tuple
     size <=> other.size
   end
 
-  # See `Object#hash(hasher)`
+  # Optimized implementation of `Indexable#hash(hasher)`.
   def hash(hasher)
+    hasher = {{ T.size }}.hash(hasher)
     {% for i in 0...T.size %}
       hasher = self[{{i}}].hash(hasher)
     {% end %}

--- a/src/tuple.cr
+++ b/src/tuple.cr
@@ -64,7 +64,6 @@
 # ```
 struct Tuple
   include Indexable(Union(*T))
-  include Comparable(Tuple)
 
   # Creates a tuple that will contain the given values.
   #
@@ -281,16 +280,6 @@ struct Tuple
       return cmp unless cmp == 0
     {% end %}
     0
-  end
-
-  # :ditto:
-  def <=>(other : Tuple)
-    min_size = Math.min(size, other.size)
-    min_size.times do |i|
-      cmp = self[i] <=> other[i]
-      return cmp unless cmp == 0
-    end
-    size <=> other.size
   end
 
   # Optimized implementation of `Indexable#hash(hasher)`.


### PR DESCRIPTION
This patch includes `Comparable(Indexable)` into `Indexable` and thus enables generic comparison of any `Indexable` instances, no matter what their type is.

So you can do `[1, 2, 3] > {1, 2}` (true) and `[1, 2, 3] == {1, 2, 3}` (true).

`Indexable` has everything necessary to allow type-agnostic comparison. It's an indexed container type and comparison is simply defined by comparison of elements in order.

If we can compare two objects, we can also determine if they are equal. Thus, `Indexable#==` is implemented in a similar manner and works across different types (in fact `Comparable` already defines `#==`).
`Indexable#hash` was already implemented in a generic way. So this fixes the discrepancy between hash and equality.

Regarding downsides to this, I don't think there are any. #529 has been open for five years and the only counter argument was posted rather recently that objects of different types should never be equal. But that proposition does not hold anyways. Every `Comparable` also defines equality. `{JSON,YAML}::Any` define equality for a lot of types. Primitives have lot of equality across types. And there's things like `HTTP::Headers#==(Hash)`.
I don't think there's anything wrong with having equality for different types, as long as the data they describe is comparable. If you need to make sure that two values tested for equality are actually of the same type, you can add a test for class equality. But that seems hardly necessary.

I suppose a minor downside is that complex types implementing `Indexable` might have more data that is not affected in the generic comparison. But it would be questionable if such a compound type should implement `Indexable` in the first place. Compared to the benefits of being able to freely compare any indexables this doesn't weigh much.

Existing specific implementations are removed in favour of the generic one. A few other optimizations are left in place. `Tuple` comparison is more performant of identical instance typesand enhances the generic implementation. `Tuple#hash` is changed to align with `Indexable#hash`.

Resolves #529 and #10065