### PR TITLE
Drop redundant codeblocks' language identifier

### DIFF
--- a/src/compiler/crystal/codegen/exception.cr
+++ b/src/compiler/crystal/codegen/exception.cr
@@ -7,7 +7,7 @@ class Crystal::CodeGenVisitor
     # In this codegen, we assume that LLVM only provides us with a basic try/catch abstraction with no
     # type restrictions on the exception caught. The basic strategy is to codegen this
     #
-    # ```cr
+    # ```
     # begin
     #   body
     # else
@@ -25,7 +25,7 @@ class Crystal::CodeGenVisitor
     #
     # Into something like (assuming goto is implemented in crystal):
     #
-    # ```cr
+    # ```
     # begin
     #   body
     # rescue ex

--- a/src/fiber.cr
+++ b/src/fiber.cr
@@ -186,7 +186,7 @@ class Fiber
   # example using `#enqueue`) the current fiber won't ever reach any instructions
   # after the call to this method.
   #
-  # ```cr
+  # ```
   # fiber = Fiber.new do
   #   puts "in fiber"
   # end
@@ -250,7 +250,7 @@ class Fiber
   # computation intensive and don't offer natural opportunities for swapping
   # fibers as with IO operations.
   #
-  # ```cr
+  # ```
   # counter = 0
   # spawn name: "status" do
   #   loop do

--- a/src/time.cr
+++ b/src/time.cr
@@ -20,7 +20,7 @@ require "crystal/system/time"
 # There are several methods to retrieve a `Time` instance representing the
 # current time:
 #
-# ```crystal
+# ```
 # Time.utc                                        # returns the current time in UTC
 # Time.local Time::Location.load("Europe/Berlin") # returns the current time in time zone Europe/Berlin
 # Time.local                                      # returns the current time in current time zone

--- a/src/uri.cr
+++ b/src/uri.cr
@@ -190,9 +190,9 @@ class URI
   #
   # Everything that is not wrapped in square brackets is returned unchanged.
   #
-  # ```cr
-  # URI.unwrap_ipv6("[::1]") # => "::1"
-  # URI.unwrap_ipv6("127.0.0.1") # => "127.0.0.1"
+  # ```
+  # URI.unwrap_ipv6("[::1]")       # => "::1"
+  # URI.unwrap_ipv6("127.0.0.1")   # => "127.0.0.1"
   # URI.unwrap_ipv6("example.com") # => "example.com"
   # ```
   def self.unwrap_ipv6(host)

--- a/src/yaml/builder.cr
+++ b/src/yaml/builder.cr
@@ -144,7 +144,7 @@ class YAML::Builder
 
   # Emits an alias to the given *anchor*.
   #
-  # ```crystal
+  # ```
   # require "yaml"
   #
   # yaml = YAML.build do |builder|
@@ -165,7 +165,7 @@ class YAML::Builder
   #
   # See [YAML Merge](https://yaml.org/type/merge.html).
   #
-  # ```crystal
+  # ```
   # require "yaml"
   #
   # yaml = YAML.build do |builder|

--- a/src/yaml/nodes/builder.cr
+++ b/src/yaml/nodes/builder.cr
@@ -24,7 +24,7 @@ class YAML::Nodes::Builder
 
   # Emits an alias to the given *anchor*.
   #
-  # ```crystal
+  # ```
   # require "yaml"
   #
   # nodes_builder = YAML::Nodes::Builder.new
@@ -48,7 +48,7 @@ class YAML::Nodes::Builder
   #
   # See [YAML Merge](https://yaml.org/type/merge.html).
   #
-  # ```crystal
+  # ```
   # require "yaml"
   #
   # nodes_builder = YAML::Nodes::Builder.new


### PR DESCRIPTION
These prevent examples from being formatted correctly too.