### PR TITLE
Expose "aliased_html" in doc JSON, make "aliased" field nullable

### DIFF
--- a/src/compiler/crystal/tools/doc/type.cr
+++ b/src/compiler/crystal/tools/doc/type.cr
@@ -771,7 +771,8 @@ class Crystal::Doc::Type
       builder.field "program", program?
       builder.field "enum", enum?
       builder.field "alias", alias?
-      builder.field "aliased", alias_definition.to_s
+      builder.field "aliased", alias? ? alias_definition.to_s : nil
+      builder.field "aliased_html", alias? ? formatted_alias_definition : nil
       builder.field "const", const?
       builder.field "constants", constants
       builder.field "included_modules" do


### PR DESCRIPTION
I split out this change from https://github.com/crystal-lang/crystal/pull/10109 because it's not strictly related.

Same as there, I need this for my external doc generator, to detect where Crystal decides to linkify types and such.

Example output:

```json
"alias": true,
"aliased": "Slice(UInt8)",
"aliased_html": "<a href=\"Slice.html\">Slice</a>(<a href=\"UInt8.html\">UInt8</a>)",
```
```json
"alias": false,
"aliased": null,
"aliased_html": null,
```

Before:

```json
"alias": true,
"aliased": "Slice(UInt8)",
```
```json
"alias": false,
"aliased": "",
```