### PR TITLE
Fix BigInt#to_*64* and #hash

### DIFF
--- a/spec/std/big/big_decimal_spec.cr
+++ b/spec/std/big/big_decimal_spec.cr
@@ -389,7 +389,7 @@ describe BigDecimal do
     bd1 = BigDecimal.new("123.456")
     bd2 = BigDecimal.new("0.12345")
     bd3 = BigDecimal.new("1.23456")
-    bd4 = BigDecimal.new("123456")
+    bd4 = BigDecimal.new("-123456")
     bd5 = BigDecimal.new("0")
 
     hash = {} of BigDecimal => String
@@ -403,7 +403,7 @@ describe BigDecimal do
     hash[BigDecimal.new("123.456")].should eq "bd1"
     hash[BigDecimal.new("0.12345")].should eq "bd2"
     hash[BigDecimal.new("1.23456")].should eq "bd3"
-    hash[BigDecimal.new("123456")].should eq "bd4"
+    hash[BigDecimal.new("-123456")].should eq "bd4"
     hash[BigDecimal.new("0")].should eq "bd5"
 
     # not found

--- a/spec/std/big/big_int_spec.cr
+++ b/spec/std/big/big_int_spec.cr
@@ -401,23 +401,23 @@ describe "BigInt" do
   context "conversion to 64-bit" do
     it "above 64 bits" do
       big = BigInt.new("9" * 20)
-      big.to_i64.should eq(7766279631452241919) # wrong
-      big.to_u64.should eq(7766279631452241919) # wrong
-      big.to_i64!.should eq(7766279631452241919)
+      expect_raises(OverflowError) { big.to_i64 }
+      expect_raises(OverflowError) { big.to_u64 }
+      big.to_i64!.should eq(7766279631452241919) # 99999999999999999999 - 5*(2**64)
       big.to_u64!.should eq(7766279631452241919)
 
       big = BigInt.new("9" * 32)
-      big.to_i64.should eq(408965003513692159)  # wrong
-      big.to_u64.should eq(9632337040368467967) # wrong
-      big.to_i64!.should eq(408965003513692159) # wrong
-      big.to_u64!.should eq(9632337040368467967)
+      expect_raises(OverflowError) { big.to_i64 }
+      expect_raises(OverflowError) { big.to_u64 }
+      big.to_i64!.should eq(-8814407033341083649) # 99999999999999999999999999999999 - 5421010862428*(2**64)
+      big.to_u64!.should eq(9632337040368467967)  # 99999999999999999999999999999999 - 5421010862427*(2**64)
     end
 
     it "between 63 and 64 bits" do
       big = BigInt.new(i = 9999999999999999999)
-      big.to_i64.should eq(776627963145224191) # wrong
+      expect_raises(OverflowError) { big.to_i64 }
       big.to_u64.should eq(i)
-      big.to_i64!.should eq(776627963145224191) # wrong
+      big.to_i64!.should eq(-8446744073709551617) # 9999999999999999999 - 2**64
       big.to_u64!.should eq(i)
     end
 
@@ -434,7 +434,7 @@ describe "BigInt" do
       big.to_i64.should eq(i)
       expect_raises(OverflowError) { big.to_u64 }
       big.to_i64!.should eq(i)
-      big.to_u64!.should eq(9999) # wrong
+      big.to_u64!.should eq(18446744073709541617) # -9999 + 2**64
     end
 
     it "negative between 32 and 63 bits" do
@@ -442,38 +442,35 @@ describe "BigInt" do
       big.to_i64.should eq(i)
       expect_raises(OverflowError) { big.to_u64 }
       big.to_i64!.should eq(i)
-      big.to_u64!.should eq(9999999999999) # wrong
+      big.to_u64!.should eq(18446734073709551617) # -9999999999999 + 2**64
     end
 
     it "negative between 63 and 64 bits" do
       big = BigInt.new("-9999999999999999999")
-      big.to_i64.should eq(-776627963145224191) # wrong
+      expect_raises(OverflowError) { big.to_i64 }
       expect_raises(OverflowError) { big.to_u64 }
-      big.to_i64!.should eq(-776627963145224191) # wrong
-      big.to_u64!.should eq(9999999999999999999) # wrong
+      big.to_i64!.should eq(8446744073709551617) # -9999999999999999999 + 2**64
+      big.to_u64!.should eq(8446744073709551617)
     end
 
     it "negative above 64 bits" do
       big = BigInt.new("-" + "9" * 20)
-      big.to_i64.should eq(-7766279631452241919) # wrong
+      expect_raises(OverflowError) { big.to_i64 }
       expect_raises(OverflowError) { big.to_u64 }
-      big.to_i64!.should eq(-7766279631452241919)
-      big.to_u64!.should eq(7766279631452241919) # wrong
+      big.to_i64!.should eq(-7766279631452241919) # -9999999999999999999 + 5*(2**64)
+      big.to_u64!.should eq(10680464442257309697) # -9999999999999999999 + 6*(2**64)
 
       big = BigInt.new("-" + "9" * 32)
-      big.to_i64.should eq(-408965003513692159) # wrong
+      expect_raises(OverflowError) { big.to_i64 }
       expect_raises(OverflowError) { big.to_u64 }
-      big.to_i64!.should eq(-408965003513692159) # wrong
-      big.to_u64!.should eq(9632337040368467967) # wrong
+      big.to_i64!.should eq(8814407033341083649) # -99999999999999999999999999999999 + 5421010862428*(2**64)
+      big.to_u64!.should eq(8814407033341083649)
     end
   end
 
-  {% if flag?(:x86_64) %}
-    # For 32 bits libgmp can't seem to be able to do it
-    it "can cast UInt64::MAX to UInt64 (#2264)" do
-      BigInt.new(UInt64::MAX).to_u64.should eq(UInt64::MAX)
-    end
-  {% end %}
+  it "can cast UInt64::MAX to UInt64 (#2264)" do
+    BigInt.new(UInt64::MAX).to_u64.should eq(UInt64::MAX)
+  end
 
   it "does String#to_big_i" do
     "123456789123456789".to_big_i.should eq(BigInt.new("123456789123456789"))

--- a/spec/std/big/big_int_spec.cr
+++ b/spec/std/big/big_int_spec.cr
@@ -488,10 +488,12 @@ describe "BigInt" do
   it "#hash" do
     b1 = 5.to_big_i
     b2 = 5.to_big_i
-    b3 = 6.to_big_i
+    b3 = -6.to_big_i
 
     b1.hash.should eq(b2.hash)
     b1.hash.should_not eq(b3.hash)
+
+    b3.hash.should eq((-6).hash)
   end
 
   it "clones" do

--- a/spec/std/big/big_int_spec.cr
+++ b/spec/std/big/big_int_spec.cr
@@ -398,6 +398,76 @@ describe "BigInt" do
     u64.should be_a(UInt64)
   end
 
+  context "conversion to 64-bit" do
+    it "above 64 bits" do
+      big = BigInt.new("9" * 20)
+      big.to_i64.should eq(7766279631452241919) # wrong
+      big.to_u64.should eq(7766279631452241919) # wrong
+      big.to_i64!.should eq(7766279631452241919)
+      big.to_u64!.should eq(7766279631452241919)
+
+      big = BigInt.new("9" * 32)
+      big.to_i64.should eq(408965003513692159)  # wrong
+      big.to_u64.should eq(9632337040368467967) # wrong
+      big.to_i64!.should eq(408965003513692159) # wrong
+      big.to_u64!.should eq(9632337040368467967)
+    end
+
+    it "between 63 and 64 bits" do
+      big = BigInt.new(i = 9999999999999999999)
+      big.to_i64.should eq(776627963145224191) # wrong
+      big.to_u64.should eq(i)
+      big.to_i64!.should eq(776627963145224191) # wrong
+      big.to_u64!.should eq(i)
+    end
+
+    it "between 32 and 63 bits" do
+      big = BigInt.new(i = 9999999999999)
+      big.to_i64.should eq(i)
+      big.to_u64.should eq(i)
+      big.to_i64!.should eq(i)
+      big.to_u64!.should eq(i)
+    end
+
+    it "negative under 32 bits" do
+      big = BigInt.new(i = -9999)
+      big.to_i64.should eq(i)
+      expect_raises(OverflowError) { big.to_u64 }
+      big.to_i64!.should eq(i)
+      big.to_u64!.should eq(9999) # wrong
+    end
+
+    it "negative between 32 and 63 bits" do
+      big = BigInt.new(i = -9999999999999)
+      big.to_i64.should eq(i)
+      expect_raises(OverflowError) { big.to_u64 }
+      big.to_i64!.should eq(i)
+      big.to_u64!.should eq(9999999999999) # wrong
+    end
+
+    it "negative between 63 and 64 bits" do
+      big = BigInt.new("-9999999999999999999")
+      big.to_i64.should eq(-776627963145224191) # wrong
+      expect_raises(OverflowError) { big.to_u64 }
+      big.to_i64!.should eq(-776627963145224191) # wrong
+      big.to_u64!.should eq(9999999999999999999) # wrong
+    end
+
+    it "negative above 64 bits" do
+      big = BigInt.new("-" + "9" * 20)
+      big.to_i64.should eq(-7766279631452241919) # wrong
+      expect_raises(OverflowError) { big.to_u64 }
+      big.to_i64!.should eq(-7766279631452241919)
+      big.to_u64!.should eq(7766279631452241919) # wrong
+
+      big = BigInt.new("-" + "9" * 32)
+      big.to_i64.should eq(-408965003513692159) # wrong
+      expect_raises(OverflowError) { big.to_u64 }
+      big.to_i64!.should eq(-408965003513692159) # wrong
+      big.to_u64!.should eq(9632337040368467967) # wrong
+    end
+  end
+
   {% if flag?(:x86_64) %}
     # For 32 bits libgmp can't seem to be able to do it
     it "can cast UInt64::MAX to UInt64 (#2264)" do

--- a/src/big/big_int.cr
+++ b/src/big/big_int.cr
@@ -479,10 +479,10 @@ struct BigInt < Int
   end
 
   def to_i64
-    if LibGMP::Long == Int64 || (Int32::MIN <= self <= Int32::MAX)
+    if LibGMP::Long::MIN <= self <= LibGMP::Long::MAX
       LibGMP.get_si(self).to_i64
     else
-      to_s.to_i64
+      to_s.to_i64 { raise OverflowError.new }
     end
   end
 
@@ -503,11 +503,7 @@ struct BigInt < Int
   end
 
   def to_i64!
-    if LibGMP::Long == Int64 || (Int32::MIN <= self <= Int32::MAX)
-      LibGMP.get_si(self).to_i64!
-    else
-      to_s.to_i64
-    end
+    (self % BITS64).to_u64.to_i64!
   end
 
   def to_u
@@ -527,11 +523,10 @@ struct BigInt < Int
   end
 
   def to_u64
-    raise OverflowError.new if self < 0
-    if LibGMP::ULong == UInt64 || (UInt32::MIN <= self <= UInt32::MAX)
+    if LibGMP::ULong::MIN <= self <= LibGMP::ULong::MAX
       LibGMP.get_ui(self).to_u64
     else
-      to_s.to_u64
+      to_s.to_u64 { raise OverflowError.new }
     end
   end
 
@@ -552,12 +547,10 @@ struct BigInt < Int
   end
 
   def to_u64!
-    if LibGMP::Long == Int64 || (Int32::MIN <= self <= Int32::MAX)
-      LibGMP.get_ui(self).to_u64!
-    else
-      to_s.to_u64
-    end
+    (self % BITS64).to_u64
   end
+
+  private BITS64 = BigInt.new(1) << 64
 
   def to_f
     to_f64

--- a/src/big/big_int.cr
+++ b/src/big/big_int.cr
@@ -407,8 +407,8 @@ struct BigInt < Int
     LibGMP.sizeinbase(self, 2).to_i
   end
 
-  # TODO: improve this
-  def_hash to_u64
+  # TODO: check hash equality for numbers >= 2**63
+  def_hash to_i64!
 
   # Returns a string representation of self.
   #


### PR DESCRIPTION
Fixes #10107
Closes #10115

---

The main cause of the old problems is that `LibGMP.get_ui` and `get_si` return basically garbage if the number would have overflowed. But the code assumed that it truncates the number correctly, same as Crystal.

https://gmplib.org/manual/Converting-Integers

* mpz_get_ui

   > The sign of *op* is ignored, only the absolute value is used.

* mpz_get_si

   > If *op* is too big to fit in a `signed long int`, the returned result is probably not very useful.

So this takes matters into our own hands and pre-truncates the number with modulo where appropriate.

---

Another issue was that for non-`!` variants it was checking only for negative arguments, but all other cases silently "garbage-overflowed".

---

This only fixes the *-64 variants, the others are still broken, though hopefully not as horribly.

---

The hash itself obviously can just work with `to_i64!` and actually there's no better implementation than that, so I just fixed it.

I'm actually having some difficulty in making the hashes equal with both `Int64` < 0 and `UInt64` > `Int64::MAX` at the same time, so I chose to skip the latter (so, for numbers greater than `Int64::MAX` hashes across `UInt64` and `BigInt` don't actually match). Too difficult to fix everything for now.

It's curious, it seems like the code at the bottom of the file *big_int.cr* tries to fix this, but the code is unused and became broken!