### PR TITLE
Expose "location" in doc JSON

### DIFF
--- a/src/compiler/crystal/tools/doc/generator.cr
+++ b/src/compiler/crystal/tools/doc/generator.cr
@@ -367,13 +367,12 @@ class Crystal::Doc::Generator
     end
   end
 
-  def source_link(node)
+  def relative_location(node)
     location = RelativeLocation.from(node, @base_dir)
     return unless location
-    project_info.source_url(location)
+    location.url = project_info.source_url(location)
+    location
   end
-
-  SRC_SEP = "src#{File::SEPARATOR}"
 
   def relative_locations(type)
     locations = [] of RelativeLocation

--- a/src/compiler/crystal/tools/doc/html/_method_detail.html
+++ b/src/compiler/crystal/tools/doc/html/_method_detail.html
@@ -23,7 +23,7 @@
       <% end %>
       <br/>
       <div>
-        <% if source_link = method.source_link %>
+        <% if source_link = method.location.try(&.url) %>
           [<a href="<%= source_link %>" target="_blank">View source</a>]
         <% end %>
       </div>

--- a/src/compiler/crystal/tools/doc/macro.cr
+++ b/src/compiler/crystal/tools/doc/macro.cr
@@ -27,8 +27,8 @@ class Crystal::Doc::Macro
     nil
   end
 
-  def source_link
-    @generator.source_link(@macro)
+  def location
+    @generator.relative_location(@macro)
   end
 
   def id
@@ -139,7 +139,7 @@ class Crystal::Doc::Macro
       builder.field "abstract", abstract?
       builder.field "args", args
       builder.field "args_string", args_to_s
-      builder.field "source_link", source_link
+      builder.field "location", location
       builder.field "def", self.macro
     end
   end

--- a/src/compiler/crystal/tools/doc/method.cr
+++ b/src/compiler/crystal/tools/doc/method.cr
@@ -119,8 +119,8 @@ class Crystal::Doc::Method
     nil
   end
 
-  def source_link
-    @generator.source_link(@def)
+  def location
+    @generator.relative_location(@def)
   end
 
   def prefix
@@ -317,7 +317,7 @@ class Crystal::Doc::Method
       builder.field "abstract", abstract?
       builder.field "args", args
       builder.field "args_string", args_to_s
-      builder.field "source_link", source_link
+      builder.field "location", location
       builder.field "def", self.def
     end
   end


### PR DESCRIPTION
\- this is consistent with type.cr which already exposes this structure in a list of "locations".

Before:
```json
"source_link": null
```
```json
"source_link": "https://....../blob/master/src/array.cr#L1509"
```
After:
```json
"location": {
  "filename": "src/array.cr",
  "line_number": 1509,
  "url": null
},
```
```json
"location": {
  "filename": "src/array.cr",
  "line_number": 1509,
  "url": "https://....../blob/master/src/array.cr#L1509"
},
```