### PR TITLE
Add support for custom failure messages in Spec expectations

### DIFF
--- a/spec/compiler/crystal/tools/doc/highlighter_spec.cr
+++ b/spec/compiler/crystal/tools/doc/highlighter_spec.cr
@@ -5,16 +5,16 @@ require "../../../../spec_helper"
 private def it_highlights(code, expected, file = __FILE__, line = __LINE__)
   it "highlights #{code.inspect}", file, line do
     highlighted = Crystal::Doc::Highlighter.highlight code
-    highlighted.should eq(expected), file, line
+    highlighted.should eq(expected), file: file, line: line
     doc = XML.parse_html highlighted
-    doc.content.should eq(code), file, line
+    doc.content.should eq(code), file: file, line: line
   end
 end
 
 private def it_does_not_highlight(code, file = __FILE__, line = __LINE__)
   it "does not highlight #{code.inspect} due to error", file, line do
     highlighted = Crystal::Doc::Highlighter.highlight code
-    highlighted.should eq(code), file, line
+    highlighted.should eq(code), file: file, line: line
   end
 end
 

--- a/spec/compiler/crystal/tools/doc/markdown_spec.cr
+++ b/spec/compiler/crystal/tools/doc/markdown_spec.cr
@@ -3,7 +3,7 @@ require "../../../../../src/compiler/crystal/tools/doc/markdown"
 
 private def assert_render(input, output, file = __FILE__, line = __LINE__)
   it "renders #{input.inspect}", file, line do
-    Crystal::Doc::Markdown.to_html(input).should eq(output), file, line
+    Crystal::Doc::Markdown.to_html(input).should eq(output), file: file, line: line
   end
 end
 

--- a/spec/compiler/normalize/op_assign_spec.cr
+++ b/spec/compiler/normalize/op_assign_spec.cr
@@ -89,9 +89,9 @@ describe "Normalize: op assign" do
 end
 
 private def assert_name_location(node, line_number, column_number, spec_file = __FILE__, spec_line = __LINE__)
-  node.name_location.should_not be_nil, spec_file, spec_line
+  node.name_location.should_not be_nil, file: spec_file, line: spec_line
 
   name_location = node.name_location.not_nil!
-  name_location.line_number.should eq(line_number), spec_file, spec_line
-  name_location.column_number.should eq(column_number), spec_file, spec_line
+  name_location.line_number.should eq(line_number), file: spec_file, line: spec_line
+  name_location.column_number.should eq(column_number), file: spec_file, line: spec_line
 end

--- a/spec/compiler/parser/to_s_spec.cr
+++ b/spec/compiler/parser/to_s_spec.cr
@@ -10,15 +10,15 @@ private def expect_to_s(original, expected = original, emit_doc = false, file = 
       parser.wants_doc = emit_doc
       node = parser.parse
       node.to_s(str, emit_doc: emit_doc)
-      str.to_s.should eq(expected), file, line
+      str.to_s.should eq(expected), file: file, line: line
 
       # Check keeping information for `to_s` on clone
       cloned = node.clone
       str.clear
       cloned.to_s(str, emit_doc: emit_doc)
-      str.to_s.should eq(expected), file, line
+      str.to_s.should eq(expected), file: file, line: line
     else
-      source.to_s.should eq(expected), file, line
+      source.to_s.should eq(expected), file: file, line: line
     end
   end
 end

--- a/spec/spec_helper.cr
+++ b/spec/spec_helper.cr
@@ -131,8 +131,8 @@ end
 
 def assert_warning(code, message, *, file = __FILE__, line = __LINE__)
   warning_failures = warnings_result(code, file: file)
-  warning_failures.size.should eq(1), file, line
-  warning_failures[0].should start_with(message), file, line
+  warning_failures.size.should eq(1), file: file, line: line
+  warning_failures[0].should start_with(message), file: file, line: line
 end
 
 def assert_macro(macro_args, macro_body, call_args, expected, expected_pragmas = nil, flags = nil, file = __FILE__, line = __LINE__)

--- a/spec/std/big/big_rational_spec.cr
+++ b/spec/std/big/big_rational_spec.cr
@@ -6,20 +6,20 @@ private def br(n, d)
 end
 
 private def test_comp(val, less, equal, greater, file = __FILE__, line = __LINE__)
-  (val < greater).should eq(true), file, line
-  (greater < val).should eq(false), file, line
-  (val <=> greater).should eq(-1), file, line
-  (greater <=> val).should eq(1), file, line
+  (val < greater).should eq(true), file: file, line: line
+  (greater < val).should eq(false), file: file, line: line
+  (val <=> greater).should eq(-1), file: file, line: line
+  (greater <=> val).should eq(1), file: file, line: line
 
-  (val == equal).should eq(true), file, line
-  (equal == val).should eq(true), file, line
-  (val <=> equal).should eq(0), file, line
-  (equal <=> val).should eq(0), file, line
+  (val == equal).should eq(true), file: file, line: line
+  (equal == val).should eq(true), file: file, line: line
+  (val <=> equal).should eq(0), file: file, line: line
+  (equal <=> val).should eq(0), file: file, line: line
 
-  (val > less).should eq(true), file, line
-  (less > val).should eq(false), file, line
-  (val <=> less).should eq(1), file, line
-  (less <=> val).should eq(-1), file, line
+  (val > less).should eq(true), file: file, line: line
+  (less > val).should eq(false), file: file, line: line
+  (val <=> less).should eq(1), file: file, line: line
+  (less <=> val).should eq(-1), file: file, line: line
 end
 
 describe BigRational do

--- a/spec/std/crystal/compiler_rt/mulodi4_spec.cr
+++ b/spec/std/crystal/compiler_rt/mulodi4_spec.cr
@@ -6,9 +6,9 @@ private def test__mulodi4(a : Int64, b : Int64, expected : Int64, expected_overf
   it "passes compiler-rt builtins unit tests" do
     actual_overflow : Int32 = 0
     actual = __mulodi4(a, b, pointerof(actual_overflow))
-    actual_overflow.should eq(expected_overflow), file, line
+    actual_overflow.should eq(expected_overflow), file: file, line: line
     if !expected_overflow
-      actual.should eq(expected), file, line
+      actual.should eq(expected), file: file, line: line
     end
   end
 end

--- a/spec/std/csv/csv_lex_spec.cr
+++ b/spec/std/csv/csv_lex_spec.cr
@@ -4,16 +4,16 @@ require "csv"
 class CSV::Lexer
   def expect_cell(value, file = __FILE__, line = __LINE__)
     token = next_token
-    token.kind.should eq(CSV::Token::Kind::Cell), file, line
-    token.value.should eq(value), file, line
+    token.kind.should eq(CSV::Token::Kind::Cell), file: file, line: line
+    token.value.should eq(value), file: file, line: line
   end
 
   def expect_eof(file = __FILE__, line = __LINE__)
-    next_token.kind.should eq(CSV::Token::Kind::Eof), file, line
+    next_token.kind.should eq(CSV::Token::Kind::Eof), file: file, line: line
   end
 
   def expect_newline(file = __FILE__, line = __LINE__)
-    next_token.kind.should eq(CSV::Token::Kind::Newline), file, line
+    next_token.kind.should eq(CSV::Token::Kind::Newline), file: file, line: line
   end
 end
 

--- a/spec/std/float_printer_spec.cr
+++ b/spec/std/float_printer_spec.cr
@@ -52,7 +52,7 @@ private def test_pair(v : UInt32, str, file = __FILE__, line = __LINE__)
 end
 
 private def test_pair(v : Float64 | Float32, str, file = __FILE__, line = __LINE__)
-  float_to_s(v).should eq(str), file, line
+  float_to_s(v).should eq(str), file: file, line: line
 end
 
 describe "#print Float64" do

--- a/spec/std/mime/media_type_spec.cr
+++ b/spec/std/mime/media_type_spec.cr
@@ -8,7 +8,7 @@ private def parse(string)
 end
 
 private def assert_format(string, format = string, file = __FILE__, line = __LINE__)
-  MIME::MediaType.parse(string).to_s.should eq(format), file, line
+  MIME::MediaType.parse(string).to_s.should eq(format), file: file, line: line
 end
 
 describe MIME::MediaType do

--- a/spec/std/spec/expectations_spec.cr
+++ b/spec/std/spec/expectations_spec.cr
@@ -1,6 +1,15 @@
 require "spec"
 
 describe "expectations" do
+  describe "accept a custom failure message" do
+    it { 1.should be < 3, "custom message!" }
+    it do
+      expect_raises(Spec::AssertionFailed, "custom message!") do
+        1.should_not be < 3, "custom message!"
+      end
+    end
+  end
+
   describe "be" do
     it { 1.should be < 3 }
     it { 2.should be <= 3 }

--- a/spec/std/uri_spec.cr
+++ b/spec/std/uri_spec.cr
@@ -10,41 +10,41 @@ end
 
 private def it_encodes(string, expected_result, file = __FILE__, line = __LINE__, **options)
   it "encodes #{string.inspect}", file, line do
-    URI.encode(string, **options).should eq(expected_result), file, line
+    URI.encode(string, **options).should eq(expected_result), file: file, line: line
 
     String.build do |io|
       URI.encode(string, io, **options)
-    end.should eq(expected_result), file, line
+    end.should eq(expected_result), file: file, line: line
   end
 end
 
 private def it_decodes(string, expected_result, file = __FILE__, line = __LINE__, **options)
   it "decodes #{string.inspect}", file, line do
-    URI.decode(string, **options).should eq(expected_result), file, line
+    URI.decode(string, **options).should eq(expected_result), file: file, line: line
 
     String.build do |io|
       URI.decode(string, io, **options)
-    end.should eq(expected_result), file, line
+    end.should eq(expected_result), file: file, line: line
   end
 end
 
 private def it_encodes_www_form(string, expected_result, file = __FILE__, line = __LINE__, **options)
   it "encodes #{string.inspect}", file, line do
-    URI.encode_www_form(string, **options).should eq(expected_result), file, line
+    URI.encode_www_form(string, **options).should eq(expected_result), file: file, line: line
 
     String.build do |io|
       URI.encode_www_form(string, io, **options)
-    end.should eq(expected_result), file, line
+    end.should eq(expected_result), file: file, line: line
   end
 end
 
 private def it_decodes_www_form(string, expected_result, file = __FILE__, line = __LINE__, **options)
   it "decodes #{string.inspect}", file, line do
-    URI.decode_www_form(string, **options).should eq(expected_result), file, line
+    URI.decode_www_form(string, **options).should eq(expected_result), file: file, line: line
 
     String.build do |io|
       URI.decode_www_form(string, io, **options)
-    end.should eq(expected_result), file, line
+    end.should eq(expected_result), file: file, line: line
   end
 end
 

--- a/src/spec/expectations.cr
+++ b/src/spec/expectations.cr
@@ -502,6 +502,16 @@ module Spec
         fail(failure_message, file, line)
       end
     end
+
+    @[Deprecated("Use named arguments .should expectation, file: file, line: line")]
+    def should(expectation, file, line)
+      should(expectation, nil, file: file, line: line)
+    end
+
+    @[Deprecated("Use named arguments .should_not expectation, file: file, line: line")]
+    def should_not(expectation, file, line)
+      should_not(expectation, nil, file: file, line: line)
+    end
   end
 end
 

--- a/src/spec/expectations.cr
+++ b/src/spec/expectations.cr
@@ -431,7 +431,7 @@ module Spec
     # ```
     #
     # See `Spec::Expectations` for available expectations.
-    def should(expectation : BeAExpectation(T), failure_message : String? = nil, file = __FILE__, line = __LINE__) : T forall T
+    def should(expectation : BeAExpectation(T), failure_message : String? = nil, *, file = __FILE__, line = __LINE__) : T forall T
       if expectation.match self
         self.is_a?(T) ? self : (raise "Bug: expected #{self} to be a #{T}")
       else
@@ -443,7 +443,7 @@ module Spec
     # Validates an expectation and fails the example if it does not match.
     #
     # See `Spec::Expectations` for available expectations.
-    def should(expectation, failure_message : String? = nil, file = __FILE__, line = __LINE__)
+    def should(expectation, failure_message : String? = nil, *, file = __FILE__, line = __LINE__)
       unless expectation.match self
         failure_message ||= expectation.failure_message(self)
         fail(failure_message, file, line)
@@ -463,7 +463,7 @@ module Spec
     # ```
     #
     # See `Spec::Expectations` for available expectations.
-    def should_not(expectation : BeAExpectation(T), failure_message : String? = nil, file = __FILE__, line = __LINE__) forall T
+    def should_not(expectation : BeAExpectation(T), failure_message : String? = nil, *, file = __FILE__, line = __LINE__) forall T
       if expectation.match self
         failure_message ||= expectation.negative_failure_message(self)
         fail(failure_message, file, line)
@@ -484,7 +484,7 @@ module Spec
     # ```
     #
     # See `Spec::Expectations` for available expectations.
-    def should_not(expectation : BeNilExpectation, failure_message : String? = nil, file = __FILE__, line = __LINE__)
+    def should_not(expectation : BeNilExpectation, failure_message : String? = nil, *, file = __FILE__, line = __LINE__)
       if expectation.match self
         failure_message ||= expectation.negative_failure_message(self)
         fail(failure_message, file, line)
@@ -496,7 +496,7 @@ module Spec
     # Validates an expectation and fails the example if it matches.
     #
     # See `Spec::Expectations` for available expectations.
-    def should_not(expectation, failure_message : String? = nil, file = __FILE__, line = __LINE__)
+    def should_not(expectation, failure_message : String? = nil, *, file = __FILE__, line = __LINE__)
       if expectation.match self
         failure_message ||= expectation.negative_failure_message(self)
         fail(failure_message, file, line)

--- a/src/spec/expectations.cr
+++ b/src/spec/expectations.cr
@@ -431,20 +431,22 @@ module Spec
     # ```
     #
     # See `Spec::Expectations` for available expectations.
-    def should(expectation : BeAExpectation(T), file = __FILE__, line = __LINE__) : T forall T
+    def should(expectation : BeAExpectation(T), failure_message : String? = nil, file = __FILE__, line = __LINE__) : T forall T
       if expectation.match self
         self.is_a?(T) ? self : (raise "Bug: expected #{self} to be a #{T}")
       else
-        fail(expectation.failure_message(self), file, line)
+        failure_message ||= expectation.failure_message(self)
+        fail(failure_message, file, line)
       end
     end
 
     # Validates an expectation and fails the example if it does not match.
     #
     # See `Spec::Expectations` for available expectations.
-    def should(expectation, file = __FILE__, line = __LINE__)
+    def should(expectation, failure_message : String? = nil, file = __FILE__, line = __LINE__)
       unless expectation.match self
-        fail(expectation.failure_message(self), file, line)
+        failure_message ||= expectation.failure_message(self)
+        fail(failure_message, file, line)
       end
     end
 
@@ -461,9 +463,10 @@ module Spec
     # ```
     #
     # See `Spec::Expectations` for available expectations.
-    def should_not(expectation : BeAExpectation(T), file = __FILE__, line = __LINE__) forall T
+    def should_not(expectation : BeAExpectation(T), failure_message : String? = nil, file = __FILE__, line = __LINE__) forall T
       if expectation.match self
-        fail(expectation.negative_failure_message(self), file, line)
+        failure_message ||= expectation.negative_failure_message(self)
+        fail(failure_message, file, line)
       else
         self.is_a?(T) ? (raise "Bug: expected #{self} not to be a #{T}") : self
       end
@@ -481,9 +484,10 @@ module Spec
     # ```
     #
     # See `Spec::Expectations` for available expectations.
-    def should_not(expectation : BeNilExpectation, file = __FILE__, line = __LINE__)
+    def should_not(expectation : BeNilExpectation, failure_message : String? = nil, file = __FILE__, line = __LINE__)
       if expectation.match self
-        fail(expectation.negative_failure_message(self), file, line)
+        failure_message ||= expectation.negative_failure_message(self)
+        fail(failure_message, file, line)
       else
         self.not_nil!
       end
@@ -492,9 +496,10 @@ module Spec
     # Validates an expectation and fails the example if it matches.
     #
     # See `Spec::Expectations` for available expectations.
-    def should_not(expectation, file = __FILE__, line = __LINE__)
+    def should_not(expectation, failure_message : String? = nil, file = __FILE__, line = __LINE__)
       if expectation.match self
-        fail(expectation.negative_failure_message(self), file, line)
+        failure_message ||= expectation.negative_failure_message(self)
+        fail(failure_message, file, line)
       end
     end
   end


### PR DESCRIPTION
This PR introduces a breaking change if people happened to be using file and line as positional parameters, which is why I'd like to get this in before 1.0.  The reason I introduced this breaking change is because as a user I'd expect the failure message to come immediately after the expectation (as it is in RSpec), and I believe it will be much more likely for users to use custom error messages than file and line (based on my experience in Ruby with RSpec).

The fix for the file and line change is very straightforward.  In this PR I've fixed the core specs by using keyword notation, since core had both keyword-style and positional-style, and keyword-style seemed cleaner.  I had even considered "forcing" keywords to be used for the file and line parameters, but thought that might warrant some discussion first.

See also the brief discussion in this thread: https://forum.crystal-lang.org/t/spec-assertion-with-custom-message/1781

