### PR TITLE
Remove incorrect note about negative timeout not triggering

### DIFF
--- a/src/channel.cr
+++ b/src/channel.cr
@@ -733,7 +733,6 @@ end
 # ```
 #
 # NOTE: It won't trigger if the `select` has an `else` case (i.e.: a non-blocking select).
-#
 def timeout_select_action(timeout : Time::Span)
   Channel::TimeoutAction.new(timeout)
 end

--- a/src/channel.cr
+++ b/src/channel.cr
@@ -734,8 +734,6 @@ end
 #
 # NOTE: It won't trigger if the `select` has an `else` case (i.e.: a non-blocking select).
 #
-# NOTE: Using negative amounts will cause the timeout to not trigger.
-#
 def timeout_select_action(timeout : Time::Span)
   Channel::TimeoutAction.new(timeout)
 end


### PR DESCRIPTION
The documentation does clearly not reflect the actual behaviour, so we should at least remove it.
Which one is the expected behaviour can be discussed in #8832