### PR TITLE
Improve handling edge cases for Time::Location#load

### DIFF
--- a/spec/std/time/location_spec.cr
+++ b/spec/std/time/location_spec.cr
@@ -34,11 +34,23 @@ class Time::Location
       end
 
       it "invalid timezone identifier" do
-        expect_raises(InvalidLocationNameError, "Foobar/Baz") do
-          Location.load("Foobar/Baz")
+        with_zoneinfo(datapath("zoneinfo")) do
+          expect_raises(InvalidLocationNameError, "Foobar/Baz") do
+            Location.load("Foobar/Baz")
+          end
         end
 
-        Location.load?("Foobar/Baz", Crystal::System::Time.zone_sources).should be_nil
+        Location.load?("Foobar/Baz", [datapath("zoneinfo")]).should be_nil
+      end
+
+      it "name is folder" do
+        Location.load?("Foo", [datapath("zoneinfo")]).should be_nil
+      end
+
+      it "invalid zone file" do
+        expect_raises(Time::Location::InvalidTZDataError) do
+          Location.load?("Foo/invalid", [datapath("zoneinfo")])
+        end
       end
 
       it "treats UTC as special case" do

--- a/src/time/location/loader.cr
+++ b/src/time/location/loader.cr
@@ -63,11 +63,12 @@ class Time::Location
   def self.find_zoneinfo_file(name : String, sources : Enumerable(String))
     sources.each do |source|
       if source.ends_with?(".zip")
-        return source if File.exists?(source)
+        path = source
       else
         path = File.join(source, name)
-        return source if File.exists?(path)
       end
+
+      return source if File.exists?(path) && File.file?(path) && File.readable?(path)
     end
   end
 
@@ -145,6 +146,8 @@ class Time::Location
     end
 
     new(location_name, zones, transitions)
+  rescue exc : IO::Error
+    raise InvalidTZDataError.new(cause: exc)
   end
 
   private def self.read_int32(io : IO)


### PR DESCRIPTION
This patch makes sure that `find_zoneinfo_file` only returns readable files and `read_zoneinfo` raises `InvalidTZDataError` on any `IOError`.