### PR TITLE
Add `%Z` time format directive

### DIFF
--- a/spec/std/time/format_spec.cr
+++ b/spec/std/time/format_spec.cr
@@ -70,19 +70,21 @@ describe Time::Format do
       t.to_s("%^Z").should eq("UTC")
       t.to_s("%Z").should eq("UTC")
 
-      zoned = Time.local(2017, 11, 24, 13, 5, 6, location: Time::Location.load("Europe/Berlin"))
-      zoned.to_s("%z").should eq("+0100")
-      zoned.to_s("%:z").should eq("+01:00")
-      zoned.to_s("%::z").should eq("+01:00:00")
-      zoned.to_s("%^Z").should eq("CET")
-      zoned.to_s("%Z").should eq("Europe/Berlin")
+      with_zoneinfo do
+        zoned = Time.local(2017, 11, 24, 13, 5, 6, location: Time::Location.load("Europe/Berlin"))
+        zoned.to_s("%z").should eq("+0100")
+        zoned.to_s("%:z").should eq("+01:00")
+        zoned.to_s("%::z").should eq("+01:00:00")
+        zoned.to_s("%^Z").should eq("CET")
+        zoned.to_s("%Z").should eq("Europe/Berlin")
 
-      zoned = Time.local(2017, 11, 24, 13, 5, 6, location: Time::Location.load("America/Buenos_Aires"))
-      zoned.to_s("%z").should eq("-0300")
-      zoned.to_s("%:z").should eq("-03:00")
-      zoned.to_s("%::z").should eq("-03:00:00")
-      zoned.to_s("%^Z").should eq("-03")
-      zoned.to_s("%Z").should eq("America/Buenos_Aires")
+        zoned = Time.local(2017, 11, 24, 13, 5, 6, location: Time::Location.load("America/Buenos_Aires"))
+        zoned.to_s("%z").should eq("-0300")
+        zoned.to_s("%:z").should eq("-03:00")
+        zoned.to_s("%::z").should eq("-03:00:00")
+        zoned.to_s("%^Z").should eq("-03")
+        zoned.to_s("%Z").should eq("America/Buenos_Aires")
+      end
 
       offset = Time.local(2017, 11, 24, 13, 5, 6, location: Time::Location.fixed(9000))
       offset.to_s("%z").should eq("+0230")
@@ -494,16 +496,18 @@ describe Time::Format do
       time.utc?.should be_false
       time.location.fixed?.should be_true
 
-      time = Time.parse!("CET", pattern)
-      time.offset.should eq 3600
-      time.utc?.should be_false
-      time.location.fixed?.should be_false
+      with_zoneinfo do
+        time = Time.parse!("CET", pattern)
+        time.offset.should eq 3600
+        time.utc?.should be_false
+        time.location.fixed?.should be_false
 
-      time = Time.parse!("Europe/Berlin", pattern)
-      time.location.should eq Time::Location.load("Europe/Berlin")
+        time = Time.parse!("Europe/Berlin", pattern)
+        time.location.should eq Time::Location.load("Europe/Berlin")
 
-      expect_raises(Time::Location::InvalidLocationNameError) do
-        Time.parse!("INVALID", pattern)
+        expect_raises(Time::Location::InvalidLocationNameError) do
+          Time.parse!("INVALID", pattern)
+        end
       end
     end
   end

--- a/spec/std/time/format_spec.cr
+++ b/spec/std/time/format_spec.cr
@@ -67,26 +67,36 @@ describe Time::Format do
       t.to_s("%z").should eq("+0000")
       t.to_s("%:z").should eq("+00:00")
       t.to_s("%::z").should eq("+00:00:00")
+      t.to_s("%^Z").should eq("UTC")
+      t.to_s("%Z").should eq("UTC")
 
       zoned = Time.local(2017, 11, 24, 13, 5, 6, location: Time::Location.load("Europe/Berlin"))
       zoned.to_s("%z").should eq("+0100")
       zoned.to_s("%:z").should eq("+01:00")
       zoned.to_s("%::z").should eq("+01:00:00")
+      zoned.to_s("%^Z").should eq("CET")
+      zoned.to_s("%Z").should eq("Europe/Berlin")
 
       zoned = Time.local(2017, 11, 24, 13, 5, 6, location: Time::Location.load("America/Buenos_Aires"))
       zoned.to_s("%z").should eq("-0300")
       zoned.to_s("%:z").should eq("-03:00")
       zoned.to_s("%::z").should eq("-03:00:00")
+      zoned.to_s("%^Z").should eq("-03")
+      zoned.to_s("%Z").should eq("America/Buenos_Aires")
 
       offset = Time.local(2017, 11, 24, 13, 5, 6, location: Time::Location.fixed(9000))
       offset.to_s("%z").should eq("+0230")
       offset.to_s("%:z").should eq("+02:30")
       offset.to_s("%::z").should eq("+02:30:00")
+      offset.to_s("%^Z").should eq("+02:30")
+      offset.to_s("%Z").should eq("+02:30")
 
       offset = Time.local(2017, 11, 24, 13, 5, 6, location: Time::Location.fixed(9001))
       offset.to_s("%z").should eq("+0230")
       offset.to_s("%:z").should eq("+02:30")
       offset.to_s("%::z").should eq("+02:30:01")
+      offset.to_s("%^Z").should eq("+02:30:01")
+      offset.to_s("%Z").should eq("+02:30:01")
 
       t.to_s("%A").to_s.should eq("Thursday")
       t.to_s("%^A").to_s.should eq("THURSDAY")
@@ -460,6 +470,47 @@ describe Time::Format do
     time.offset.should eq -1 * (4 * 3600 + 12 * 60 + 39)
     time.utc?.should be_false
     time.location.fixed?.should be_true
+  end
+
+  it "parses zone name" do
+    ["%^Z", "%Z"].each do |pattern|
+      time = Time.parse!("UTC", pattern)
+      time.offset.should eq 0
+      time.utc?.should be_true
+      time.location.fixed?.should be_true
+
+      time = Time.parse!("-00:00", pattern)
+      time.offset.should eq 0
+      time.utc?.should be_false
+      time.location.fixed?.should be_true
+
+      time = Time.parse!("+00:00", pattern)
+      time.offset.should eq 0
+      time.utc?.should be_false
+      time.location.fixed?.should be_true
+
+      time = Time.parse!("+00:00:00", pattern)
+      time.offset.should eq 0
+      time.utc?.should be_false
+      time.location.fixed?.should be_true
+
+      time = Time.parse!("CET", pattern)
+      time.offset.should eq 3600
+      time.utc?.should be_false
+      time.location.fixed?.should be_false
+
+      time = Time.parse!("PST", pattern)
+      time.offset.should eq -28800
+      time.utc?.should be_false
+      time.location.fixed?.should be_true
+
+      time = Time.parse!("Europe/Berlin", pattern)
+      time.location.should eq Time::Location.load("Europe/Berlin")
+
+      expect_raises(Time::Location::InvalidLocationNameError) do
+        Time.parse!("INVALID", pattern)
+      end
+    end
   end
 
   it "raises when time zone missing" do

--- a/spec/std/time/format_spec.cr
+++ b/spec/std/time/format_spec.cr
@@ -499,11 +499,6 @@ describe Time::Format do
       time.utc?.should be_false
       time.location.fixed?.should be_false
 
-      time = Time.parse!("PST", pattern)
-      time.offset.should eq -28800
-      time.utc?.should be_false
-      time.location.fixed?.should be_true
-
       time = Time.parse!("Europe/Berlin", pattern)
       time.location.should eq Time::Location.load("Europe/Berlin")
 

--- a/src/time/format.cr
+++ b/src/time/format.cr
@@ -55,9 +55,11 @@ require "./format/parser"
 # * **%X**: (same as %T) 24-hour time (13:04:05)
 # * **%y**: year modulo 100
 # * **%Y**: year, zero padded
-# * **%z**: time zone as hour and minute offset from UTC (+0900)
-# * **%:z**: time zone as hour and minute offset from UTC with a colon (+09:00)
-# * **%::z**: time zone as hour, minute and second offset from UTC with a colon (+09:00:00)
+# * **%z**: time zone offset from UTC as hour and minute with no separator (+0900)
+# * **%:z**: time zone offset from UTC as hour and minute separated by colon (+09:00)
+# * **%::z**: time zone offset from UTC as hour, minute and second separated by colon (+09:00:00)
+# * **%Z**: location name or offset (e.g. `Europe/Berlin`)
+# * **%^Z**: abbreviated time zone identifier or offset (e.g. `CET`)
 struct Time::Format
   # :nodoc:
   MONTH_NAMES = %w(January February March April May June July August September October November December)

--- a/src/time/format/formatter.cr
+++ b/src/time/format/formatter.cr
@@ -218,6 +218,14 @@ struct Time::Format
       end
     end
 
+    def time_zone_name(zone = false)
+      if zone
+        io << time.zone.name
+      else
+        io << time.location
+      end
+    end
+
     def char(char, *alternatives)
       io << char
     end

--- a/src/time/format/parser.cr
+++ b/src/time/format/parser.cr
@@ -460,6 +460,25 @@ struct Time::Format
       time_zone_rfc2822
     end
 
+    def time_zone_name(zone = false)
+      case char = current_char
+      when '-', '+'
+        time_zone_offset
+      else
+        start_pos = @reader.pos
+        while @reader.has_next? && (!current_char.whitespace? || current_char == Char::ZERO)
+          next_char
+        end
+        zone_name = @reader.string.byte_slice(start_pos, @reader.pos - start_pos)
+
+        if zone_name.in?("Z", "UTC")
+          @location = Time::Location::UTC
+        else
+          @location = Time::Location.load(zone_name)
+        end
+      end
+    end
+
     def char?(char, *alternatives)
       if current_char == char || alternatives.includes?(current_char)
         next_char

--- a/src/time/format/pattern.cr
+++ b/src/time/format/pattern.cr
@@ -82,6 +82,8 @@ struct Time::Format
           year
         when 'z'
           time_zone
+        when 'Z'
+          time_zone_name
         when '_'
           case char = reader.next_char
           when 'm'
@@ -112,6 +114,8 @@ struct Time::Format
             short_month_name_upcase
           when 'B'
             month_name_upcase
+          when 'Z'
+            time_zone_name(zone: true)
           else
             char '%'
             char '^'


### PR DESCRIPTION
Resolves #5823

This patch adds two new directives for `Time::Format`:

`%Z` prints the location name (e.g. `Europe/Berlin`), or if not available the time zone offset.
`%^Z` prints the abbreviated time zone identifier (e.g. `CET`), or if not available the time zone offset.

For parsing, both accept either a location name, abbreviated time zone identifier or zone offset.