### PR TITLE
Deprecate `Time::Span#duration`

### DIFF
--- a/src/time/span.cr
+++ b/src/time/span.cr
@@ -228,6 +228,7 @@ struct Time::Span
   end
 
   # Alias of `abs`.
+  @[Deprecated("Use `#abs` instead.")]
   def duration : Time::Span
     abs
   end


### PR DESCRIPTION
`Time::Span#duration` is an alias for `Time::Span#abs` with `#abs` being far more common because it's also used in number types. The method name also doesn't really speak its behaviour.

I don't see a good reason for having this alias when `#abs` is sufficient.