### PR TITLE
Add identity methods for #sum and #product

### DIFF
--- a/spec/std/enumerable_spec.cr
+++ b/spec/std/enumerable_spec.cr
@@ -958,10 +958,11 @@ describe "Enumerable" do
     it { (1..3).sum { |x| x * 2 }.should eq(12) }
     it { (1..3).sum(1.5) { |x| x * 2 }.should eq(13.5) }
 
-    it "uses zero from type" do
+    it "uses additive_identity from type" do
       typeof([1, 2, 3].sum).should eq(Int32)
       typeof([1.5, 2.5, 3.5].sum).should eq(Float64)
       typeof([1, 2, 3].sum(&.to_f)).should eq(Float64)
+      typeof(([1, 2, 3] of Float32).sum).should eq(Float32)
     end
 
     it "array of arrays" do
@@ -972,6 +973,11 @@ describe "Enumerable" do
 
     it "strings" do
       ["foo", "bar"].sum.should eq "foobar"
+    end
+
+    it "float" do
+      [1.0, 2.0, 3.5, 4.5].sum.should eq 11.0
+      ([1.0, 2.0, 3.5, 4.5] of Float32).sum.should eq 11.0
     end
   end
 

--- a/spec/std/enumerable_spec.cr
+++ b/spec/std/enumerable_spec.cr
@@ -963,6 +963,10 @@ describe "Enumerable" do
       typeof([1.5, 2.5, 3.5].sum).should eq(Float64)
       typeof([1, 2, 3].sum(&.to_f)).should eq(Float64)
     end
+
+    it "strings" do
+      ["foo", "bar"].sum.should eq "foobar"
+    end
   end
 
   describe "product" do

--- a/spec/std/enumerable_spec.cr
+++ b/spec/std/enumerable_spec.cr
@@ -966,6 +966,7 @@ describe "Enumerable" do
 
     it "array of arrays" do
       [[1, 2, 3], [3, 4, 5]].sum.should eq [1, 2, 3, 3, 4, 5]
+      [[[1, 2], [3]], [[1, 2], [3, 4, 5]]].sum.should eq [[1, 2], [3], [1, 2], [3, 4, 5]]
       Deque{[1, 2, 3], [3, 4, 5]}.sum.should eq [1, 2, 3, 3, 4, 5]
     end
 

--- a/spec/std/enumerable_spec.cr
+++ b/spec/std/enumerable_spec.cr
@@ -964,6 +964,11 @@ describe "Enumerable" do
       typeof([1, 2, 3].sum(&.to_f)).should eq(Float64)
     end
 
+    it "array of arrays" do
+      [[1, 2, 3], [3, 4, 5]].sum.should eq [1, 2, 3, 3, 4, 5]
+      Deque{[1, 2, 3], [3, 4, 5]}.sum.should eq [1, 2, 3, 3, 4, 5]
+    end
+
     it "strings" do
       ["foo", "bar"].sum.should eq "foobar"
     end

--- a/spec/std/range_spec.cr
+++ b/spec/std/range_spec.cr
@@ -19,7 +19,7 @@ struct RangeSpecIntWrapper
     value <=> other.value
   end
 
-  def self.zero
+  def self.additive_identity
     RangeSpecIntWrapper.new(0)
   end
 

--- a/src/array.cr
+++ b/src/array.cr
@@ -1413,6 +1413,16 @@ class Array(T)
     reuse
   end
 
+  # :inherit:
+  def sum
+    {% if T < Array %}
+      # optimize for array
+      flatten
+    {% else %}
+      super
+    {% end %}
+  end
+
   # Returns a new `Array` that is a one-dimensional flattening of `self` (recursively).
   #
   # That is, for every element that is an array or an iterator, extract its elements into the new array.

--- a/src/array.cr
+++ b/src/array.cr
@@ -337,7 +337,7 @@ class Array(T)
   # Returns the additive identity of this type.
   #
   # This is an empty array.
-  def self.additive_identity
+  def self.additive_identity : self
     self.new
   end
 

--- a/src/array.cr
+++ b/src/array.cr
@@ -334,6 +334,13 @@ class Array(T)
     end
   end
 
+  # Returns the additive identity of this type.
+  #
+  # This is an empty array.
+  def self.additive_identity
+    self.new
+  end
+
   # Difference. Returns a new `Array` that is a copy of `self`, removing any items
   # that appear in *other*. The order of `self` is preserved.
   #

--- a/src/array.cr
+++ b/src/array.cr
@@ -1413,16 +1413,6 @@ class Array(T)
     reuse
   end
 
-  # :inherit:
-  def sum
-    {% if T < Array %}
-      # optimize for array
-      flatten
-    {% else %}
-      super
-    {% end %}
-  end
-
   # Returns a new `Array` that is a one-dimensional flattening of `self` (recursively).
   #
   # That is, for every element that is an array or an iterator, extract its elements into the new array.

--- a/src/complex.cr
+++ b/src/complex.cr
@@ -255,11 +255,11 @@ struct Complex
     @real == 0 && @imag == 0
   end
 
-  def self.additive_identity
+  def self.additive_identity : self
     zero
   end
 
-  def multiplicative_identity
+  def multiplicative_identity : self
     new 1, 0
   end
 

--- a/src/complex.cr
+++ b/src/complex.cr
@@ -255,6 +255,14 @@ struct Complex
     @real == 0 && @imag == 0
   end
 
+  def self.additive_identity
+    zero
+  end
+
+  def multiplicative_identity
+    new 1, 0
+  end
+
   # Rounds to the nearest *digits*.
   def round(digits = 0)
     Complex.new(@real.round(digits), @imag.round(digits))

--- a/src/deque.cr
+++ b/src/deque.cr
@@ -124,6 +124,13 @@ class Deque(T)
     dup.concat other
   end
 
+  # Returns the additive identity of this type.
+  #
+  # This is an empty deque.
+  def self.additive_identity
+    self.new
+  end
+
   # Alias for `push`.
   def <<(value : T)
     push(value)

--- a/src/deque.cr
+++ b/src/deque.cr
@@ -127,7 +127,7 @@ class Deque(T)
   # Returns the additive identity of this type.
   #
   # This is an empty deque.
-  def self.additive_identity
+  def self.additive_identity : self
     self.new
   end
 

--- a/src/enumerable.cr
+++ b/src/enumerable.cr
@@ -1351,7 +1351,7 @@ module Enumerable(T)
     {% if T == String %}
       # optimize for string
       join
-    {% elsif T < Array || T < Iterator %}
+    {% elsif T < Array %}
       # optimize for array
       flat_map &.itself
     {% else %}

--- a/src/enumerable.cr
+++ b/src/enumerable.cr
@@ -1333,21 +1333,20 @@ module Enumerable(T)
 
   # Adds all the elements in the collection together.
   #
-  # Only collections of numbers (objects that can be added via an `+` method)
-  # are supported.
+  # Expects all element types to respond to `#+` method.
   #
   # ```
   # [1, 2, 3, 4, 5, 6].sum # => 21
   # ```
   #
-  # If the collection is empty, returns `0`.
+  # This method calls `.additive_identity` on the yielded type to determine the
+  # type of the sum value.
+  #
+  # If the collection is empty, returns `additive_identity`.
   #
   # ```
   # ([] of Int32).sum # => 0
   # ```
-  #
-  # This method calls `.additive_identity` on the yielded type to determine the
-  # type of the sum value.
   def sum
     {% if T == String %}
       # optimize for string
@@ -1374,8 +1373,7 @@ module Enumerable(T)
   # (for instance) you need to specify a large enough type to avoid
   # overflow.
   #
-  # Only collections of numbers (objects that can be added via an `+` method)
-  # are supported.
+  # Expects all element types to respond to `#+` method.
   #
   # ```
   # [1, 2, 3, 4, 5, 6].sum(7) # => 28
@@ -1386,9 +1384,6 @@ module Enumerable(T)
   # ```
   # ([] of Int32).sum(7) # => 7
   # ```
-  #
-  # This method calls `.additive_identity` on the element type to determine the
-  # type of the sum value.
   def sum(initial)
     sum initial, &.itself
   end
@@ -1399,14 +1394,16 @@ module Enumerable(T)
   # ["Alice", "Bob"].sum { |name| name.size } # => 8 (5 + 3)
   # ```
   #
-  # If the collection is empty, returns `0`.
+  # Expects all types returned from the block to respond to `#+` method.
+  #
+  # This method calls `.additive_identity` on the yielded type to determine the
+  # type of the sum value.
+  #
+  # If the collection is empty, returns `additive_identity`.
   #
   # ```
   # ([] of Int32).sum { |x| x + 1 } # => 0
   # ```
-  #
-  # This method calls `.additive_identity` on the yielded type to determine the
-  # type of the sum value.
   def sum(&block)
     sum(additive_identity(Reflect(typeof(yield first)))) do |value|
       yield value
@@ -1419,6 +1416,8 @@ module Enumerable(T)
   # ["Alice", "Bob"].sum(1) { |name| name.size } # => 9 (1 + 5 + 3)
   # ```
   #
+  # Expects all types returned from the block to respond to `#+` method.
+  #
   # If the collection is empty, returns *initial*.
   #
   # ```
@@ -1430,21 +1429,20 @@ module Enumerable(T)
 
   # Multiplies all the elements in the collection together.
   #
-  # Only collections of numbers (objects that can be multiplied via a `*` method)
-  # are supported.
+  # Expects all element types to respond to `#*` method.
   #
   # ```
   # [1, 2, 3, 4, 5, 6].product # => 720
   # ```
   #
-  # If the collection is empty, returns `1`.
+  # This method calls `.multiplicative_identity` on the element type to determine the
+  # type of the sum value.
+  #
+  # If the collection is empty, returns `multiplicative_identity`.
   #
   # ```
   # ([] of Int32).product # => 1
   # ```
-  #
-  # This method calls `.multiplicative_identity` on the element type to determine the
-  # type of the sum value.
   def product
     product Reflect(T).first.multiplicative_identity
   end
@@ -1454,8 +1452,7 @@ module Enumerable(T)
   # so use this if (for instance) you need to specify a large enough
   # type to avoid overflow.
   #
-  # Only collections of numbers (objects that can be multiplied via a `*` method)
-  # are supported.
+  # Expects all element types to respond to `#*` method.
   #
   # ```
   # [1, 2, 3, 4, 5, 6].product(7) # => 5040
@@ -1476,14 +1473,16 @@ module Enumerable(T)
   # ["Alice", "Bob"].product { |name| name.size } # => 15 (5 * 3)
   # ```
   #
-  # If the collection is empty, returns `1`.
+  # Expects all types returned from the block to respond to `#*` method.
+  #
+  # This method calls `.multiplicative_identity` on the element type to determine the
+  # type of the sum value.
+  #
+  # If the collection is empty, returns `multiplicative_identity`.
   #
   # ```
   # ([] of Int32).product { |x| x + 1 } # => 1
   # ```
-  #
-  # This method calls `.multiplicative_identity` on the yielded type to determine the
-  # type of the sum value.
   def product(&block)
     product(Reflect(typeof(yield first)).first.multiplicative_identity) do |value|
       yield value
@@ -1496,6 +1495,8 @@ module Enumerable(T)
   # ```
   # ["Alice", "Bob"].product(2) { |name| name.size } # => 30 (2 * 5 * 3)
   # ```
+  #
+  # Expects all types returned from the block to respond to `#*` method.
   #
   # If the collection is empty, returns `1`.
   #

--- a/src/enumerable.cr
+++ b/src/enumerable.cr
@@ -1349,7 +1349,12 @@ module Enumerable(T)
   # This method calls `.additive_identity` on the yielded type to determine the
   # type of the sum value.
   def sum
-    sum Reflect(T).first.additive_identity
+    {% if T == String %}
+      # optimize for string
+      join
+    {% else %}
+      sum Reflect(T).first.additive_identity
+    {% end %}
   end
 
   # Adds *initial* and all the elements in the collection together.

--- a/src/enumerable.cr
+++ b/src/enumerable.cr
@@ -1352,6 +1352,9 @@ module Enumerable(T)
     {% if T == String %}
       # optimize for string
       join
+    {% elsif T < Array || T < Iterator %}
+      # optimize for array
+      flat_map &.itself
     {% else %}
       sum additive_identity(Reflect(T))
     {% end %}

--- a/src/enumerable.cr
+++ b/src/enumerable.cr
@@ -1353,8 +1353,17 @@ module Enumerable(T)
       # optimize for string
       join
     {% else %}
-      sum Reflect(T).first.additive_identity
+      sum additive_identity(Reflect(T))
     {% end %}
+  end
+
+  private def additive_identity(reflect)
+    type = reflect.first
+    if type.responds_to? :additive_identity
+      type.additive_identity
+    else
+      type.zero
+    end
   end
 
   # Adds *initial* and all the elements in the collection together.
@@ -1396,7 +1405,7 @@ module Enumerable(T)
   # This method calls `.additive_identity` on the yielded type to determine the
   # type of the sum value.
   def sum(&block)
-    sum(Reflect(typeof(yield first)).first.additive_identity) do |value|
+    sum(additive_identity(Reflect(typeof(yield first)))) do |value|
       yield value
     end
   end

--- a/src/enumerable.cr
+++ b/src/enumerable.cr
@@ -1345,8 +1345,11 @@ module Enumerable(T)
   # ```
   # ([] of Int32).sum # => 0
   # ```
+  #
+  # This method calls `.additive_identity` on the yielded type to determine the
+  # type of the sum value.
   def sum
-    sum Reflect(T).first.zero
+    sum Reflect(T).first.additive_identity
   end
 
   # Adds *initial* and all the elements in the collection together.
@@ -1366,6 +1369,9 @@ module Enumerable(T)
   # ```
   # ([] of Int32).sum(7) # => 7
   # ```
+  #
+  # This method calls `.additive_identity` on the element type to determine the
+  # type of the sum value.
   def sum(initial)
     sum initial, &.itself
   end
@@ -1381,8 +1387,11 @@ module Enumerable(T)
   # ```
   # ([] of Int32).sum { |x| x + 1 } # => 0
   # ```
+  #
+  # This method calls `.additive_identity` on the yielded type to determine the
+  # type of the sum value.
   def sum(&block)
-    sum(Reflect(typeof(yield first)).first.zero) do |value|
+    sum(Reflect(typeof(yield first)).first.additive_identity) do |value|
       yield value
     end
   end
@@ -1416,8 +1425,11 @@ module Enumerable(T)
   # ```
   # ([] of Int32).product # => 1
   # ```
+  #
+  # This method calls `.multiplicative_identity` on the element type to determine the
+  # type of the sum value.
   def product
-    product Reflect(T).first.zero + 1
+    product Reflect(T).first.multiplicative_identity
   end
 
   # Multiplies *initial* and all the elements in the collection
@@ -1452,8 +1464,11 @@ module Enumerable(T)
   # ```
   # ([] of Int32).product { |x| x + 1 } # => 1
   # ```
+  #
+  # This method calls `.multiplicative_identity` on the yielded type to determine the
+  # type of the sum value.
   def product(&block)
-    product(Reflect(typeof(yield first)).first.zero + 1) do |value|
+    product(Reflect(typeof(yield first)).first.multiplicative_identity) do |value|
       yield value
     end
   end

--- a/src/number.cr
+++ b/src/number.cr
@@ -4,8 +4,38 @@ struct Number
 
   alias Primitive = Int::Primitive | Float::Primitive
 
+  # Returns the value zero in the respective type.
+  #
+  # ```cr
+  # Int32.zero   # => 0
+  # Float64.zero # => 0.0
+  # ```
   def self.zero : self
     new(0)
+  end
+
+  # Returns the additive identity of this type.
+  #
+  # For numerical types, it is the value `0` expressed in the respective type.
+  #
+  # ```cr
+  # Int32.additive_identity   # => 0
+  # Float64.additive_identity # => 0.0
+  # ```
+  def self.additive_identity
+    zero
+  end
+
+  # Returns the multiplicative identity of this type.
+  #
+  # For numerical types, it is the value `1` expressed in the respective type.
+  #
+  # ```cr
+  # Int32.multiplicative_identity   # => 1
+  # Float64.multiplicative_identity # => 1.0
+  # ```
+  def self.multiplicative_identity
+    new(1)
   end
 
   # Returns self.

--- a/src/number.cr
+++ b/src/number.cr
@@ -6,7 +6,7 @@ struct Number
 
   # Returns the value zero in the respective type.
   #
-  # ```cr
+  # ```
   # Int32.zero   # => 0
   # Float64.zero # => 0.0
   # ```
@@ -18,7 +18,7 @@ struct Number
   #
   # For numerical types, it is the value `0` expressed in the respective type.
   #
-  # ```cr
+  # ```
   # Int32.additive_identity   # => 0
   # Float64.additive_identity # => 0.0
   # ```
@@ -30,7 +30,7 @@ struct Number
   #
   # For numerical types, it is the value `1` expressed in the respective type.
   #
-  # ```cr
+  # ```
   # Int32.multiplicative_identity   # => 1
   # Float64.multiplicative_identity # => 1.0
   # ```

--- a/src/number.cr
+++ b/src/number.cr
@@ -22,7 +22,7 @@ struct Number
   # Int32.additive_identity   # => 0
   # Float64.additive_identity # => 0.0
   # ```
-  def self.additive_identity
+  def self.additive_identity : self
     zero
   end
 
@@ -34,7 +34,7 @@ struct Number
   # Int32.multiplicative_identity   # => 1
   # Float64.multiplicative_identity # => 1.0
   # ```
-  def self.multiplicative_identity
+  def self.multiplicative_identity : self
     new(1)
   end
 

--- a/src/set.cr
+++ b/src/set.cr
@@ -243,7 +243,7 @@ struct Set(T)
   # Returns the additive identity of this type.
   #
   # This is an empty set.
-  def self.additive_identity
+  def self.additive_identity : self
     new
   end
 

--- a/src/set.cr
+++ b/src/set.cr
@@ -240,6 +240,13 @@ struct Set(T)
     self | other
   end
 
+  # Returns the additive identity of this type.
+  #
+  # This is an empty set.
+  def self.additive_identity
+    new
+  end
+
   # Difference: returns a new set containing elements in this set that are not
   # present in the other.
   #

--- a/src/time/span.cr
+++ b/src/time/span.cr
@@ -272,6 +272,13 @@ struct Time::Span
     )
   end
 
+  # Returns the additive identity of this type.
+  #
+  # This is `zero`.
+  def self.additive_identity
+    zero
+  end
+
   def + : self
     self
   end

--- a/src/time/span.cr
+++ b/src/time/span.cr
@@ -275,7 +275,7 @@ struct Time::Span
   # Returns the additive identity of this type.
   #
   # This is `zero`.
-  def self.additive_identity
+  def self.additive_identity : self
     zero
   end
 


### PR DESCRIPTION
This patch adds `additive_identity` and `multiplicative_identity` to types that support addition and multiplication, respectively.
`Enumerable#sum` and `#product` use those methods to determine the initial value if none is provided. They previously relied on `zero` and `zero + 1` which works only for numerical arithmetics.

I didn't include a fallback to `zero` or `zero + 1` if the new methods are not available. There's probably no way to add a warning for that be cause `zero` method itself is not deprecated. So it should just break hard instead of continue to work for a while. It doesn't make sense to support `zero` in the long term, so we should just drop it directly. I wouldn't expect many custom types rely on `sum` + `zero` behaviour.

Some optimizations are also included:
* `Enumerable#sum` for `String` element type delegates to `#join`
* `Array#sum` for `Array` element type delegates to `#flatten`

Resolves #10126