### PR TITLE
Fix `Indexable#join` with IO

### DIFF
--- a/spec/std/indexable_spec.cr
+++ b/spec/std/indexable_spec.cr
@@ -185,28 +185,37 @@ describe Indexable do
     return_value.should eq(indexable)
   end
 
-  it "joins strings (empty case)" do
-    indexable = SafeStringIndexable.new(0)
-    indexable.join.should eq("")
-    indexable.join(", ").should eq("")
-  end
+  describe "#join" do
+    it "joins strings (empty case)" do
+      indexable = SafeStringIndexable.new(0)
+      indexable.join.should eq("")
+      indexable.join(", ").should eq("")
+    end
 
-  it "joins strings (non-empty case)" do
-    indexable = SafeStringIndexable.new(12)
-    indexable.join(", ").should eq("0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11")
-    indexable.join(98).should eq("098198298398498598698798898998109811")
-  end
+    it "joins strings (non-empty case)" do
+      indexable = SafeStringIndexable.new(12)
+      indexable.join(", ").should eq("0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11")
+      indexable.join(98).should eq("098198298398498598698798898998109811")
+    end
 
-  it "joins non-strings" do
-    indexable = SafeIndexable.new(12)
-    indexable.join(", ").should eq("0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11")
-    indexable.join(98).should eq("098198298398498598698798898998109811")
-  end
+    it "joins non-strings" do
+      indexable = SafeIndexable.new(12)
+      indexable.join(", ").should eq("0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11")
+      indexable.join(98).should eq("098198298398498598698798898998109811")
+    end
 
-  it "joins when T has String" do
-    indexable = SafeMixedIndexable.new(12)
-    indexable.join(", ").should eq("0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11")
-    indexable.join(98).should eq("098198298398498598698798898998109811")
+    it "joins when T has String" do
+      indexable = SafeMixedIndexable.new(12)
+      indexable.join(", ").should eq("0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11")
+      indexable.join(98).should eq("098198298398498598698798898998109811")
+    end
+
+    it "with IO" do
+      String.build do |io|
+        indexable = SafeStringIndexable.new(12)
+        indexable.join(io)
+      end.should eq "01234567891011"
+    end
   end
 
   describe "dig?" do

--- a/src/indexable.cr
+++ b/src/indexable.cr
@@ -340,13 +340,6 @@ module Indexable(T)
     {% end %}
   end
 
-  # :nodoc:
-  #
-  # Avoid shadowing by previous overload.
-  def join(io : IO)
-    super
-  end
-
   private def join_strings(separator)
     separator = separator.to_s
 

--- a/src/indexable.cr
+++ b/src/indexable.cr
@@ -324,7 +324,7 @@ module Indexable(T)
   # all of the elements in this indexable are strings: the total string
   # bytesize to return can be computed before creating the final string,
   # which performs better because there's no need to do reallocations.
-  def join(separator : String | Number = "")
+  def join(separator : String | Char | Number = "")
     return "" if empty?
 
     {% if T == String %}

--- a/src/indexable.cr
+++ b/src/indexable.cr
@@ -340,6 +340,13 @@ module Indexable(T)
     {% end %}
   end
 
+  # :nodoc:
+  #
+  # Avoid shadowing by previous overload.
+  def join(io : IO)
+    super
+  end
+
   private def join_strings(separator)
     separator = separator.to_s
 

--- a/src/indexable.cr
+++ b/src/indexable.cr
@@ -324,7 +324,7 @@ module Indexable(T)
   # all of the elements in this indexable are strings: the total string
   # bytesize to return can be computed before creating the final string,
   # which performs better because there's no need to do reallocations.
-  def join(separator = "")
+  def join(separator : String | Number = "")
     return "" if empty?
 
     {% if T == String %}


### PR DESCRIPTION
`Indexable#join(separator = "")` shadows all inherited overloads from `Enumerable`, including `#join(io : IO)` with stronger type restriction. As a result, when calling `join` with an `IO` it is treated as `separator`:

```cr
io = IO::Memory.new
["foo", "bar"].join(io) # => "foobar"
io.to_s # => ""
```

<del>This fix adds an overload `Indexable#join(io : IO)` which delegates to `super`.</del>
<ins>This fix restricts the optimized method's argument to `String | Number`.</ins> The optimized version expects the same separator and calls `to_s` on it exactly once. This is different from the non-optimized version which calls `to_s` every time and the result could be different each time. So restricting to types that can't change their `to_s` fixes another issue. I'd expect `String | Number` to be good enough for >90% of use cases.

I'm wondering if the overload shadowing mechanics should really work this way... 



