### PR TITLE
Consider free variables and underscores when determining abstract def implementations

### DIFF
--- a/spec/compiler/semantic/abstract_def_spec.cr
+++ b/spec/compiler/semantic/abstract_def_spec.cr
@@ -808,7 +808,22 @@ describe "Semantic: abstract def" do
       ))
   end
 
-  it "errors if free var is more constrained than abstract def" do
+  it "errors if free var is bound in including type" do
+    assert_error %(
+      module Foo
+        abstract def foo(x : T) forall T
+      end
+
+      class Bar(T)
+        include Foo
+
+        def foo(x : T)
+        end
+      end
+      ), "abstract `def Foo#foo(x : T)` must be implemented by Bar(T)"
+  end
+
+  it "errors if free var is more constrained than abstract def, inside generic" do
     assert_error %(
       module Val(T); end
 
@@ -825,22 +840,7 @@ describe "Semantic: abstract def" do
       ), "abstract `def Foo#foo(x : Val(T))` must be implemented by Bar"
   end
 
-  it "errors if free var is bound in including type" do
-    assert_error %(
-      module Foo
-        abstract def foo(x : T) forall T
-      end
-
-      class Bar(T)
-        include Foo
-
-        def foo(x : T)
-        end
-      end
-      ), "abstract `def Foo#foo(x : T)` must be implemented by Bar(T)"
-  end
-
-  it "errors if free vars in implementation are less constrained than abstract def (1)" do
+  it "errors if free vars are more constrained than abstract def (1)" do
     assert_error %(
       module Foo
         abstract def foo(x : T, y : U) forall T, U
@@ -855,7 +855,7 @@ describe "Semantic: abstract def" do
       ), "abstract `def Foo#foo(x : T, y : U)` must be implemented by Bar"
   end
 
-  it "errors if free vars in implementation are less constrained than abstract def (2)" do
+  it "errors if free vars are more constrained than abstract def (2)" do
     assert_error %(
       module Foo
         abstract def foo(x : T, y : _) forall T
@@ -870,7 +870,7 @@ describe "Semantic: abstract def" do
       ), "abstract `def Foo#foo(x : T, y : _)` must be implemented by Bar"
   end
 
-  it "errors if free vars in implementation are less constrained than abstract def (3)" do
+  it "errors if free vars are more constrained than abstract def (3)" do
     assert_error %(
       module Foo
         abstract def foo(x : _, y : _)
@@ -885,7 +885,7 @@ describe "Semantic: abstract def" do
       ), "abstract `def Foo#foo(x : _, y : _)` must be implemented by Bar"
   end
 
-  it "errors if free vars in implementation are less constrained than abstract def, inside generics (1)" do
+  it "errors if free vars are more constrained than abstract def, inside generics (1)" do
     assert_error %(
       module Val(T, U); end
 
@@ -902,7 +902,7 @@ describe "Semantic: abstract def" do
       ), "abstract `def Foo#foo(x : Val(T, U))` must be implemented by Bar"
   end
 
-  it "errors if free vars in implementation are less constrained than abstract def, inside generics (2)" do
+  it "errors if free vars are more constrained than abstract def, inside generics (2)" do
     assert_error %(
       module Val(T, U); end
 
@@ -919,7 +919,7 @@ describe "Semantic: abstract def" do
       ), "abstract `def Foo#foo(x : Val(T, _))` must be implemented by Bar"
   end
 
-  it "errors if free vars in implementation are less constrained than abstract def, inside generics (3)" do
+  it "errors if free vars are more constrained than abstract def, inside generics (3)" do
     assert_error %(
       module Val(T, U); end
 


### PR DESCRIPTION
Like #10042, but for abstract defs. Here the direction is reversed compared to specialization ordering; an implementation's free vars must be _less_ constrained than the abstract def it implements. So the following will work:

```crystal
abstract class Foo
  abstract def f(x : Hash(Tuple(K, _), V)) forall K, V
  abstract def f(x : Hash(K, Tuple(V, _))) forall K, V
end

class Bar < Foo
  # substituable for both abstract overloads
  def f(x : Hash(_, T)) forall T; end
end
```

The following used to silently compile until a call with incompatible arguments (that match the abstract def but not its implementations) is instantiated. This PR catches them:

```crystal
abstract class Foo
  abstract def f(x : _)

  abstract def g(x : T, y : U) forall T, U
end

class Bar < Foo
  # not substitutable
  def f(x : Int32); end
  # not substitutable
  def f(x : Array(T)) forall T; end

  # free vars are more constrained than abstract def
  def g(x : T, y : T) forall T; end
end

class Baz(T) < Foo
  # `T` is not a free var
  def f(x : T); end
end
```

As with the other PR, underscores are interchangeable with unbound free vars that do not already appear after `forall`.