### PR TITLE
Consistency: Return Hash yields with key,value using tuples

### DIFF
--- a/src/hash.cr
+++ b/src/hash.cr
@@ -1219,7 +1219,7 @@ class Hash(K, V)
   def delete_if
     keys_to_delete = [] of K
     each do |key, value|
-      keys_to_delete << key if yield(key, value)
+      keys_to_delete << key if yield({key, value})
     end
     keys_to_delete.each do |key|
       delete(key)
@@ -1385,10 +1385,10 @@ class Hash(K, V)
     hash
   end
 
-  def merge(other : Hash(L, W), &block : L, V, W -> V | W) forall L, W
+  def merge(other : Hash(L, W), &block : {L, V, W} -> V | W) forall L, W
     hash = Hash(K | L, V | W).new
     hash.merge! self
-    hash.merge!(other) { |k, v1, v2| yield k, v1, v2 }
+    hash.merge!(other) { |k, v1, v2| yield({k, v1, v2}) }
     hash
   end
 
@@ -1419,7 +1419,7 @@ class Hash(K, V)
   def merge!(other : Hash, &block) : self
     other.each do |k, v|
       if self.has_key?(k)
-        self[k] = yield k, self[k], v
+        self[k] = yield({k, self[k], v})
       else
         self[k] = v
       end
@@ -1433,13 +1433,13 @@ class Hash(K, V)
   # h.select { |k, v| k > "a" } # => {"b" => 200, "c" => 300}
   # h.select { |k, v| v < 200 } # => {"a" => 100}
   # ```
-  def select(&block : K, V -> _)
-    reject { |k, v| !yield(k, v) }
+  def select(&block : {K, V} -> _)
+    reject { |k, v| !yield({k, v}) }
   end
 
   # Equivalent to `Hash#select` but makes modification on the current object rather than returning a new one. Returns `self`.
-  def select!(&block : K, V -> _)
-    reject! { |k, v| !yield(k, v) }
+  def select!(&block : {K, V} -> _)
+    reject! { |k, v| !yield({k, v}) }
   end
 
   # Returns a new hash consisting of entries for which the block returns `false`.
@@ -1448,16 +1448,16 @@ class Hash(K, V)
   # h.reject { |k, v| k > "a" } # => {"a" => 100}
   # h.reject { |k, v| v < 200 } # => {"b" => 200, "c" => 300}
   # ```
-  def reject(&block : K, V -> _)
+  def reject(&block : {K, V} -> _)
     each_with_object({} of K => V) do |(k, v), memo|
-      memo[k] = v unless yield k, v
+      memo[k] = v unless yield({k, v})
     end
   end
 
   # Equivalent to `Hash#reject`, but makes modification on the current object rather than returning a new one. Returns `self`.
-  def reject!(&block : K, V -> _)
+  def reject!(&block : {K, V} -> _)
     each do |key, value|
-      delete(key) if yield(key, value)
+      delete(key) if yield({key, value})
     end
     self
   end


### PR DESCRIPTION
Right now with the short block syntax, we are only able to get the first argument sent to yield. There have been many ways to get arguments beyond the first ([such as &1, &2](#9218)). In the meantime, there exists a discrepancy between some methods that yield multiple arguments but in different ways.

`Hash#each` yields a tuple of `{key, value}` meaning they are both available as the first argument. This is inconsistent with other yields such as `Hash#select`, `Hash#reject`, and others.

In this PR, I have moved any that yield key, value to pass them as a tuple for consistency. This has the unfortunate consequence of having to acknowledge each parameter using normal block arguments.

For example, before

```cr
{0=>'0', 1=>'1', 2=>'2'}.select do |k|
  k > 1
end
```

After, (or currently with each) this would error with `Error: no overload matches 'Tuple(Int32, Char)#>' with type Int32`. We must do the below instead.

```cr
{0=>'0', 1=>'1', 2=>'2'}.select do |k, _|
  k > 1
end
```

I did not include the protected method `Hash#each_entry_with_index` in this PR.

I looked into letting multiple argument yields be returned as Tuples, but this is a big language change and would lead to less concise code, as well as other problems.

An alternative approach to this PR would be to let `#each` return each value separately, but if we were to go down this avenue. this should be delayed until after we have a method of getting other arguments with the short block syntax.

If we extended this behaviour across the language, we'd end up with a [mess like this](https://github.com/Daniel-Worrall/crystal/commit/af72fbb302dc70852e550ade568810a9623f9a8a)