### PR TITLE
Deprecate `Enumerable#size`

### DIFF
--- a/src/enumerable.cr
+++ b/src/enumerable.cr
@@ -1281,6 +1281,7 @@ module Enumerable(T)
   # ```
   # [1, 2, 3, 4].size # => 4
   # ```
+  @[Deprecated("Use `#count` instead.")]
   def size
     count { true }
   end

--- a/src/xml/attributes.cr
+++ b/src/xml/attributes.cr
@@ -14,6 +14,7 @@ struct XML::Attributes
   end
 
   def [](index : Int)
+    # TODO: Optimize to avoid double iteration
     size = self.size
 
     index += size if index < 0
@@ -27,6 +28,10 @@ struct XML::Attributes
     end
 
     raise IndexError.new
+  end
+
+  def size
+    count { true }
   end
 
   def [](name : String)


### PR DESCRIPTION
Deprecates `Enumerable#size` to finally remove it as proposed in #10014.

`XML::Attributes#size` is used in a spec explicitly, and defining that method using `count { true }` is fine (it's finite). I don't think the libxml2 API offers any alternative to iterating all items if you want to determine their number, anyways. Maybe this can be improved, so I added a TODO for that.

`Range#size` can be calculated in constant time for integer types, but not for every type. There are options to keep this method, but that should be a separate discussion.