### PR TITLE
Forbid reopening generic types with different type var splats

### DIFF
--- a/spec/compiler/semantic/class_spec.cr
+++ b/spec/compiler/semantic/class_spec.cr
@@ -648,6 +648,28 @@ describe "Semantic: class" do
       "wrong number of arguments for 'Foo.new' (given 0, expected 1)"
   end
 
+  it "can't reopen as struct" do
+    assert_error %(
+      class Foo
+      end
+
+      struct Foo
+      end
+      ),
+      "Foo is not a struct, it's a class"
+  end
+
+  it "can't reopen as module" do
+    assert_error %(
+      class Foo
+      end
+
+      module Foo
+      end
+      ),
+      "Foo is not a module, it's a class"
+  end
+
   it "errors if reopening non-generic class as generic" do
     assert_error %(
       class Foo
@@ -679,6 +701,39 @@ describe "Semantic: class" do
       end
       ),
       "type vars must be A, B, not C"
+  end
+
+  it "errors if reopening generic class with different splat index" do
+    assert_error %(
+      class Foo(A)
+      end
+
+      class Foo(*A)
+      end
+      ),
+      "type var must be A, not *A"
+  end
+
+  it "errors if reopening generic class with different splat index (2)" do
+    assert_error %(
+      class Foo(*A)
+      end
+
+      class Foo(A)
+      end
+      ),
+      "type var must be *A, not A"
+  end
+
+  it "errors if reopening generic class with different splat index (3)" do
+    assert_error %(
+      class Foo(*A, B)
+      end
+
+      class Foo(A, *B)
+      end
+      ),
+      "type vars must be *A, B, not A, *B"
   end
 
   it "allows declaring a variable in an initialize and using it" do

--- a/spec/compiler/semantic/module_spec.cr
+++ b/spec/compiler/semantic/module_spec.cr
@@ -898,6 +898,92 @@ describe "Semantic: module" do
       "can't declare module dynamically"
   end
 
+  it "can't reopen as class" do
+    assert_error "
+      module Foo
+      end
+
+      class Foo
+      end
+      ", "Foo is not a class, it's a module"
+  end
+
+  it "can't reopen as struct" do
+    assert_error "
+      module Foo
+      end
+
+      struct Foo
+      end
+      ", "Foo is not a struct, it's a module"
+  end
+
+  it "errors if reopening non-generic module as generic" do
+    assert_error %(
+      module Foo
+      end
+
+      module Foo(T)
+      end
+      ),
+      "Foo is not a generic module"
+  end
+
+  it "errors if reopening generic module with different type vars" do
+    assert_error %(
+      module Foo(T)
+      end
+
+      module Foo(U)
+      end
+      ),
+      "type var must be T, not U"
+  end
+
+  it "errors if reopening generic module with different type vars (2)" do
+    assert_error %(
+      module Foo(A, B)
+      end
+
+      module Foo(C)
+      end
+      ),
+      "type vars must be A, B, not C"
+  end
+
+  it "errors if reopening generic module with different splat index" do
+    assert_error %(
+      module Foo(A)
+      end
+
+      module Foo(*A)
+      end
+      ),
+      "type var must be A, not *A"
+  end
+
+  it "errors if reopening generic module with different splat index (2)" do
+    assert_error %(
+      module Foo(*A)
+      end
+
+      module Foo(A)
+      end
+      ),
+      "type var must be *A, not A"
+  end
+
+  it "errors if reopening generic module with different splat index (3)" do
+    assert_error %(
+      module Foo(*A, B)
+      end
+
+      module Foo(A, *B)
+      end
+      ),
+      "type vars must be *A, B, not A, *B"
+  end
+
   it "uses :Module name for modules in errors" do
     assert_error %(
       module Moo; end

--- a/spec/compiler/semantic/splat_spec.cr
+++ b/spec/compiler/semantic/splat_spec.cr
@@ -407,7 +407,7 @@ describe "Semantic: splat" do
 
   it "uses splat restriction with concrete type" do
     assert_error %(
-      struct Tuple(T)
+      struct Tuple(*T)
         def self.foo(*args : *T)
         end
       end

--- a/spec/compiler/semantic/struct_spec.cr
+++ b/spec/compiler/semantic/struct_spec.cr
@@ -87,7 +87,7 @@ describe "Semantic: struct" do
       ", "can't make class 'Bar' inherit struct 'Foo'"
   end
 
-  it "can't reopen as different type" do
+  it "can't reopen as class" do
     assert_error "
       struct Foo
       end
@@ -95,6 +95,16 @@ describe "Semantic: struct" do
       class Foo
       end
       ", "Foo is not a class, it's a struct"
+  end
+
+  it "can't reopen as module" do
+    assert_error "
+      struct Foo
+      end
+
+      module Foo
+      end
+      ", "Foo is not a module, it's a struct"
   end
 
   it "can't extend struct from non-abstract struct" do

--- a/src/compiler/crystal/semantic/top_level_visitor.cr
+++ b/src/compiler/crystal/semantic/top_level_visitor.cr
@@ -63,14 +63,7 @@ class Crystal::TopLevelVisitor < Crystal::SemanticVisitor
 
       if type_vars = node.type_vars
         if type.is_a?(GenericType)
-          type_type_vars = type.type_vars
-          if type_vars != type_type_vars
-            if type_type_vars.size == 1
-              node.raise "type var must be #{type_type_vars.join ", "}, not #{type_vars.join ", "}"
-            else
-              node.raise "type vars must be #{type_type_vars.join ", "}, not #{type_vars.join ", "}"
-            end
-          end
+          check_reopened_generic(type, node, type_vars)
         else
           node.raise "#{name} is not a generic #{type.type_desc}"
         end
@@ -220,6 +213,14 @@ class Crystal::TopLevelVisitor < Crystal::SemanticVisitor
         node.raise "#{type} is not a module, it's a #{type.type_desc}"
       end
 
+      if type_vars = node.type_vars
+        if type.is_a?(GenericType)
+          check_reopened_generic(type, node, type_vars)
+        else
+          node.raise "#{name} is not a generic module"
+        end
+      end
+
       type = type.as(ModuleType)
     else
       if type_vars = node.type_vars
@@ -246,6 +247,29 @@ class Crystal::TopLevelVisitor < Crystal::SemanticVisitor
     end
 
     false
+  end
+
+  private def check_reopened_generic(generic, node, new_type_vars)
+    generic_type_vars = generic.type_vars
+    if new_type_vars != generic_type_vars || node.splat_index != generic.splat_index
+      msg = String.build do |io|
+        io << "type var"
+        io << 's' if generic_type_vars.size > 1
+        io << " must be "
+        generic_type_vars.each_with_index do |var, i|
+          io << ", " if i > 0
+          io << '*' if i == generic.splat_index
+          var.to_s(io)
+        end
+        io << ", not "
+        new_type_vars.each_with_index do |var, i|
+          io << ", " if i > 0
+          io << '*' if i == node.splat_index
+          var.to_s(io)
+        end
+      end
+      node.raise msg
+    end
   end
 
   def visit(node : AnnotationDef)


### PR DESCRIPTION
The following (taken from specs) currently compiles:

```crystal
class Foo(A); end
class Foo(*A); end

class Bar(*A); end
class Bar(A); end

class Baz(*A, B); end
class Baz(A, *B); end
```

This is misleading because when reopening a generic class/struct the compiler already checks the arity and the names of the formal type vars, but not the splat indices, which affect how many type vars are allowed in instantiations and which formal vars they are bound to. This patch rejects code like the above. (It remains possible to reopen a generic type with omitted type vars.)

Notice how I said "class/struct"; Crystal performs no checks on reopened generic _modules_, not even their arity. This patch also adds them.