### PR TITLE
Consider type var splats in generic type restrictions even if instantiation contains no splats

### DIFF
--- a/spec/compiler/semantic/splat_spec.cr
+++ b/spec/compiler/semantic/splat_spec.cr
@@ -457,7 +457,7 @@ describe "Semantic: splat" do
       )) { no_return.metaclass }
   end
 
-  it "matches splat in generic type" do
+  it "matches type splat with splat in generic type (1)" do
     assert_type(%(
       class Foo(*T)
       end
@@ -469,6 +469,108 @@ describe "Semantic: splat" do
       foo = Foo(Int32, Char, String, Bool).new
       method(foo)
       )) { tuple_of([int32.metaclass, tuple_of([char, string]).metaclass, bool.metaclass]) }
+  end
+
+  it "matches type splat with splat in generic type (2)" do
+    assert_type(%(
+      class Foo(T, *U, V)
+        def t
+          {T, U, V}
+        end
+      end
+
+      def method(x : Foo(*A)) forall A
+        x.t
+      end
+
+      foo = Foo(Int32, Char, String, Bool).new
+      method(foo)
+      )) { tuple_of([int32.metaclass, tuple_of([char, string]).metaclass, bool.metaclass]) }
+  end
+
+  it "matches instantiated generic with splat in generic type" do
+    assert_type(%(
+      class Foo(*T)
+      end
+
+      def method(x : Foo(Int32, String))
+        'a'
+      end
+
+      foo = Foo(Int32, String).new
+      method(foo)
+      )) { char }
+  end
+
+  it "doesn't match splat in generic type with unsplatted tuple (#10164)" do
+    assert_error %(
+      class Foo(*T)
+      end
+
+      def method(x : Foo(Tuple(Int32, String)))
+        'a'
+      end
+
+      foo = Foo(Int32, String).new
+      method(foo)
+      ),
+      "no overload matches"
+  end
+
+  it "matches partially instantiated generic with splat in generic type" do
+    assert_type(%(
+      class Foo(*T)
+      end
+
+      def method(x : Foo(Int32, T)) forall T
+        T
+      end
+
+      foo = Foo(Int32, String).new
+      method(foo)
+      )) { string.metaclass }
+  end
+
+  it "errors with too few non-splat type arguments (1)" do
+    assert_error %(
+      class Foo(T, U, *V)
+      end
+
+      def method(x : Foo(Int32))
+      end
+
+      foo = Foo(Int32, String).new
+      method(foo)
+      ),
+      "wrong number of type vars for Foo(T, U, *V) (given 1, expected 2+)"
+  end
+
+  it "errors with too few non-splat type arguments (2)" do
+    assert_error %(
+      class Foo(T, U, *V)
+      end
+
+      def method(x : Foo(A)) forall A
+      end
+
+      foo = Foo(Int32, String).new
+      method(foo)
+      ),
+      "wrong number of type vars for Foo(T, U, *V) (given 1, expected 2+)"
+  end
+
+  it "errors with too many non-splat type arguments" do
+    assert_error %(
+      class Foo(A)
+      end
+
+      def method(x : Foo(T, U, *V)) forall T, U, V
+      end
+
+      foo = Foo(Int32).new
+      method(foo)
+      ),
+      "wrong number of type vars for Foo(A) (given 2+, expected 1)"
   end
 
   it "errors if using two splat indices on restriction" do

--- a/src/compiler/crystal/semantic/restrictions.cr
+++ b/src/compiler/crystal/semantic/restrictions.cr
@@ -667,20 +667,37 @@ module Crystal
       end
 
       # Consider the case of a splat in the type vars
-      splat_index = other.type_vars.index &.is_a?(Splat)
-      if splat_index
+      splat_index = self.splat_index
+      splat_given = other.type_vars.any? &.is_a?(Splat)
+      if splat_index || splat_given
         types = Array(Type).new(type_vars.size)
         i = 0
         type_vars.each_value do |var|
           return nil unless var.is_a?(Var)
 
           var_type = var.type
-          if i == self.splat_index
+          if i == splat_index
             types.concat(var_type.as(TupleInstanceType).tuple_types)
           else
             types << var_type
           end
           i += 1
+        end
+
+        # We are `(A, B, *C)`, they are `(T)`; matching would always fail
+        if splat_index && !splat_given
+          min_needed = generic_type.type_vars.size - 1
+          if other.type_vars.size < min_needed
+            other.wrong_number_of "type vars", generic_type, other.type_vars.size, "#{min_needed}+"
+          end
+        end
+
+        # We are `(A)`, they are `(T, U, *V)`; matching would always fail
+        if !splat_index && splat_given
+          non_splat_count = other.type_vars.count { |type_var| !type_var.is_a?(Splat) }
+          if non_splat_count > generic_type.type_vars.size
+            other.wrong_number_of "type vars", generic_type, "#{non_splat_count}+", generic_type.type_vars.size
+          end
         end
 
         i = 0
@@ -712,7 +729,7 @@ module Crystal
         return self
       end
 
-      if generic_type.type_vars.size != other.type_vars.size
+      if other.type_vars.size != generic_type.type_vars.size
         other.wrong_number_of "type vars", generic_type, other.type_vars.size, generic_type.type_vars.size
       end
 
@@ -798,8 +815,8 @@ module Crystal
       generic_type = generic_type.as(TupleType)
 
       # Consider the case of a splat in the type vars
-      splat_index = other.type_vars.index &.is_a?(Splat)
-      if splat_index
+      splat_given = other.type_vars.any? &.is_a?(Splat)
+      if splat_given
         found_splat = false
         i = 0
         other.type_vars.each do |type_var|
@@ -1084,7 +1101,7 @@ module Crystal
       output = other.output
 
       # Consider the case of a splat in the type vars
-      if inputs && (splat_index = inputs.index &.is_a?(Splat))
+      if inputs && (splat_given = inputs.any? &.is_a?(Splat))
         i = 0
         inputs.each do |input|
           if input.is_a?(Splat)
@@ -1141,8 +1158,8 @@ module Crystal
       return super unless generic_type.is_a?(ProcType)
 
       # Consider the case of a splat in the type vars
-      splat_index = other.type_vars.index &.is_a?(Splat)
-      if splat_index
+      splat_given = other.type_vars.any? &.is_a?(Splat)
+      if splat_given
         proc_types = arg_types + [return_type]
 
         i = 0

--- a/src/compiler/crystal/semantic/restrictions.cr
+++ b/src/compiler/crystal/semantic/restrictions.cr
@@ -668,7 +668,7 @@ module Crystal
 
       # Consider the case of a splat in the type vars
       splat_index = self.splat_index
-      splat_given = other.type_vars.any? &.is_a?(Splat)
+      splat_given = other.type_vars.any?(Splat)
       if splat_index || splat_given
         types = Array(Type).new(type_vars.size)
         i = 0
@@ -815,7 +815,7 @@ module Crystal
       generic_type = generic_type.as(TupleType)
 
       # Consider the case of a splat in the type vars
-      splat_given = other.type_vars.any? &.is_a?(Splat)
+      splat_given = other.type_vars.any?(Splat)
       if splat_given
         found_splat = false
         i = 0
@@ -1101,7 +1101,7 @@ module Crystal
       output = other.output
 
       # Consider the case of a splat in the type vars
-      if inputs && (splat_given = inputs.any? &.is_a?(Splat))
+      if inputs && (splat_given = inputs.any?(Splat))
         i = 0
         inputs.each do |input|
           if input.is_a?(Splat)
@@ -1158,7 +1158,7 @@ module Crystal
       return super unless generic_type.is_a?(ProcType)
 
       # Consider the case of a splat in the type vars
-      splat_given = other.type_vars.any? &.is_a?(Splat)
+      splat_given = other.type_vars.any?(Splat)
       if splat_given
         proc_types = arg_types + [return_type]
 

--- a/src/compiler/crystal/types.cr
+++ b/src/compiler/crystal/types.cr
@@ -1796,7 +1796,11 @@ module Crystal
       super
       if generic_args
         io << '('
-        type_vars.join(io, ", ", &.to_s(io))
+        type_vars.each_with_index do |type_var, i|
+          io << ", " if i > 0
+          io << '*' if i == splat_index
+          type_var.to_s(io)
+        end
         io << ')'
       end
     end
@@ -1856,7 +1860,11 @@ module Crystal
       super
       if generic_args
         io << '('
-        type_vars.join(io, ", ", &.to_s(io))
+        type_vars.each_with_index do |type_var, i|
+          io << ", " if i > 0
+          io << '*' if i == splat_index
+          type_var.to_s(io)
+        end
         io << ')'
       end
     end


### PR DESCRIPTION
Fixes #10164. No attempt was made to factor out the restriction code in `ProcInstanceType` and `TupleInstanceType`.

This fix has identified code like below that would previously crash the compiler with an `IndexError`:

```crystal
class Foo(A)
end

# After this PR:
# wrong number of type vars for Foo(A) (given 2+, expected 1)
def method(x : Foo(T, U, *V)) forall T, U, V
end

foo = Foo(Int32).new
method(foo)
```