### PR TITLE
Fix crash when matching arguments against splat restriction after positional parameters

### DIFF
--- a/spec/compiler/semantic/splat_spec.cr
+++ b/spec/compiler/semantic/splat_spec.cr
@@ -405,6 +405,16 @@ describe "Semantic: splat" do
       )) { tuple_of([] of Type).metaclass }
   end
 
+  it "uses splat restriction after non-splat arguments (#5037)" do
+    assert_type(%(
+      def foo(x, *y : *T) forall T
+        T
+      end
+
+      foo 1, 'a', ""
+      )) { tuple_of([char, string]).metaclass }
+  end
+
   it "uses splat restriction with concrete type" do
     assert_error %(
       struct Tuple(T)

--- a/src/compiler/crystal/semantic/method_lookup.cr
+++ b/src/compiler/crystal/semantic/method_lookup.cr
@@ -262,6 +262,9 @@ module Crystal
         unless match_arg_type
           return nil
         end
+
+        matched_arg_types ||= [] of Type
+        matched_arg_types.concat(splat_arg_types)
       end
 
       found_unmatched_named_arg = false


### PR DESCRIPTION
Fixes #5037.