### PR TITLE
OpenSSL::digest add require for OpenSSL::Error

### DIFF
--- a/src/digest/io_digest.cr
+++ b/src/digest/io_digest.cr
@@ -1,5 +1,5 @@
 require "./digest"
-require "openssl"
+require "openssl/digest"
 
 # Wraps an `IO` by calculating a specified `Digest` on read or write operations.
 #

--- a/src/openssl.cr
+++ b/src/openssl.cr
@@ -1,4 +1,5 @@
 require "./openssl/lib_ssl"
+require "./openssl/error"
 
 # ## OpenSSL Integration
 #
@@ -64,27 +65,6 @@ require "./openssl/lib_ssl"
 # end
 # ```
 module OpenSSL
-  class Error < Exception
-    getter! code : LibCrypto::ULong
-
-    def initialize(message = nil, fetched = false, cause : Exception? = nil)
-      @code ||= LibCrypto::ULong.new(0)
-
-      if fetched
-        super(message, cause: cause)
-      else
-        @code, error = fetch_error_details
-        super(message ? "#{message}: #{error}" : error, cause: cause)
-      end
-    end
-
-    protected def fetch_error_details
-      code = LibCrypto.err_get_error
-      message = String.new(LibCrypto.err_error_string(code, nil)) unless code == 0
-      {code, message || "Unknown or no error"}
-    end
-  end
-
   module SSL
     alias Modes = LibSSL::Modes
     alias Options = LibSSL::Options

--- a/src/openssl/digest.cr
+++ b/src/openssl/digest.cr
@@ -1,4 +1,5 @@
 require "./lib_crypto"
+require "./error"
 require "digest/digest"
 
 module OpenSSL

--- a/src/openssl/error.cr
+++ b/src/openssl/error.cr
@@ -1,0 +1,25 @@
+require "./lib_ssl"
+require "./lib_crypto"
+
+module OpenSSL
+  class Error < Exception
+    getter! code : LibCrypto::ULong
+
+    def initialize(message = nil, fetched = false, cause : Exception? = nil)
+      @code ||= LibCrypto::ULong.new(0)
+
+      if fetched
+        super(message, cause: cause)
+      else
+        @code, error = fetch_error_details
+        super(message ? "#{message}: #{error}" : error, cause: cause)
+      end
+    end
+
+    protected def fetch_error_details
+      code = LibCrypto.err_get_error
+      message = String.new(LibCrypto.err_error_string(code, nil)) unless code == 0
+      {code, message || "Unknown or no error"}
+    end
+  end
+end


### PR DESCRIPTION
This is related to #10114.

Moving `OpenSSL::Error` to a separate file is not really necessary to solve this issue. But for me, it feels better to use files in the same directory (`error.cr`) than to use parent modules (`openssl`).

To test this PR I also changed the `require` in `io_digest.cr` from `require "openssl"` to `require "openssl/digest"`