### PR TITLE
Support type splats inside explicit Unions in type restrictions

### DIFF
--- a/spec/compiler/semantic/splat_spec.cr
+++ b/spec/compiler/semantic/splat_spec.cr
@@ -488,15 +488,48 @@ describe "Semantic: splat" do
 
   it "matches with splat" do
     assert_type(%(
-    def foo(&block : *{Int32, Int32} -> U) forall U
-      tup = {1, 2}
-      yield *tup
-    end
+      def foo(&block : *{Int32, Int32} -> U) forall U
+        tup = {1, 2}
+        yield *tup
+      end
 
-    foo do |x, y|
-      {x, y}
-    end
-    )) { tuple_of([int32, int32]) }
+      foo do |x, y|
+        {x, y}
+      end
+      )) { tuple_of([int32, int32]) }
+  end
+
+  it "matches with tuple splat inside explicit Union" do
+    assert_type(%(
+      def foo(x : Union(*{Int32, String}))
+        x
+      end
+
+      foo(1)
+      )) { int32 }
+  end
+
+  it "matches with type var splat inside explicit Union" do
+    assert_type(%(
+      class Foo(*T)
+        def self.foo(x : Union(*T))
+          x
+        end
+      end
+
+      Foo(Int32, String).foo(1)
+      )) { int32 }
+  end
+
+  it "doesn't match free var type splats inside explicit Union" do
+    assert_error %(
+      def foo(x : Union(*T)) forall T
+        x
+      end
+
+      foo(1)
+      ),
+      "no overload matches"
   end
 
   it "matches typed before non-typed (1) (#3134)" do

--- a/spec/compiler/semantic/splat_spec.cr
+++ b/spec/compiler/semantic/splat_spec.cr
@@ -521,6 +521,90 @@ describe "Semantic: splat" do
       )) { int32 }
   end
 
+  it "matches with type var splat inside explicit Union (2)" do
+    assert_type(%(
+      class Foo(*T)
+        def self.foo(x : Union(*T))
+          x
+        end
+      end
+
+      Foo(Int32, String).foo("")
+      )) { string }
+  end
+
+  it "matches with type var splat inside explicit Union, when all splat elements match" do
+    assert_type(%(
+      class Foo(*T)
+        def self.foo(x : Union(*T))
+          x
+        end
+      end
+
+      Foo(Int32 | Bool, Int32 | String, Int32 | Char).foo(1)
+      )) { int32 }
+  end
+
+  it "matches with type var splat inside explicit Union, when one splat fails entirely" do
+    assert_type(%(
+      class Foo(*T)
+        def self.foo(x : Union(*T, Bool))
+          x
+        end
+      end
+
+      Foo(Int32, String).foo(true)
+      )) { bool }
+  end
+
+  it "matches with type var splat inside explicit Union, when non-splat vars fail" do
+    assert_type(%(
+      class Foo(*T)
+        def self.foo(x : Union(*T, Char, Bool))
+          x
+        end
+      end
+
+      Foo(Int32, String).foo(1)
+      )) { int32 }
+  end
+
+  it "matches with type var and splat of itself inside explicit Union" do
+    assert_type(%(
+      class Foo(*T)
+        def self.foo(x : Union(T, *T))
+          x
+        end
+      end
+
+      Foo(Int32, String).foo({1, ""})
+      )) { tuple_of([int32, string]) }
+  end
+
+  it "matches with type var and splat of itself inside explicit Union (2)" do
+    assert_type(%(
+      class Foo(*T)
+        def self.foo(x : Union(T, *T))
+          x
+        end
+      end
+
+      Foo(Int32, String).foo(1)
+      )) { int32 }
+  end
+
+  it "matches with type var and splat of itself inside explicit Union (3)" do
+    assert_type(%(
+      class Foo(*T)
+        def self.foo(x : Union(T, *T))
+          x
+        end
+      end
+
+      Foo(Int32, String).foo("")
+      )) { string }
+  end
+
   it "doesn't match free var type splats inside explicit Union" do
     assert_error %(
       def foo(x : Union(*T)) forall T

--- a/src/compiler/crystal/semantic/restrictions.cr
+++ b/src/compiler/crystal/semantic/restrictions.cr
@@ -504,7 +504,29 @@ module Crystal
       # Special case: consider `Union(X, Y, ...)` the same as `X | Y | ...`
       generic_type = get_generic_type(other, context)
       if generic_type.is_a?(GenericUnionType)
-        return restrict(Union.new(other.type_vars), context)
+        types = [] of Type
+
+        other.type_vars.each do |type_var|
+          if type_var.is_a?(Splat)
+            splat_type = context.defining_type.lookup_type?(type_var.exp)
+            return nil unless splat_type
+            unless splat_type.is_a?(TupleInstanceType)
+              type_var.raise "argument to splat must be a tuple type, not #{splat_type}"
+            end
+
+            splat_type.tuple_types.each do |tuple_type|
+              if type = restrict(tuple_type, context)
+                types << type
+              end
+            end
+          else
+            if type = restrict(type_var, context)
+              types << type
+            end
+          end
+        end
+
+        return types.size > 0 ? program.type_merge_union_of(types) : nil
       end
 
       parents.try &.each do |parent|


### PR DESCRIPTION
Implements https://github.com/crystal-lang/crystal/issues/8520#issuecomment-562979041. The main use case is when the type being splatted is a generic type var of the enclosing type:

```crystal
class Foo(*T)
  def self.foo(x : Union(*T))
  end
end

Foo(Int32, String).foo(1) # ok, `Union(*T)` resolves to `Union(Int32, String)`
```

But it can be any `Tuple` too:

```crystal
def foo(x : Union(*{Int32, String})); end
# same as:
def foo(x : Union(Int32, String)); end
```

This behaviour is consistent with other generic types. Also, unlike other generics multiple splats are allowed inside `Union`, because they must not be free vars (`Union(*T) forall T` will never match anything).