### PR TITLE
Fix FileUtils.cp_r

### DIFF
--- a/spec/std/file_utils_spec.cr
+++ b/spec/std/file_utils_spec.cr
@@ -126,6 +126,21 @@ describe "FileUtils" do
       end
     end
 
+    it "copies a directory recursively if destination exists and is empty" do
+      with_tempfile("cp_r-test", "cp_r-test-copied") do |src_path, dest_path|
+        Dir.mkdir_p(dest_path)
+
+        Dir.mkdir_p(src_path)
+        File.write(File.join(src_path, "a"), "")
+        Dir.mkdir(File.join(src_path, "b"))
+        File.write(File.join(src_path, "b/c"), "")
+
+        FileUtils.cp_r(src_path, dest_path)
+        File.exists?(File.join(dest_path, "cp_r-test", "a")).should be_true
+        File.exists?(File.join(dest_path, "cp_r-test", "b/c")).should be_true
+      end
+    end
+
     it "copies a directory recursively if destination exists leaving existing files" do
       with_tempfile("cp_r-test", "cp_r-test-copied") do |src_path, dest_path|
         Dir.mkdir_p(dest_path)

--- a/spec/std/file_utils_spec.cr
+++ b/spec/std/file_utils_spec.cr
@@ -130,6 +130,8 @@ describe "FileUtils" do
       with_tempfile("cp_r-test", "cp_r-test-copied") do |src_path, dest_path|
         Dir.mkdir_p(dest_path)
         File.write(File.join(dest_path, "d"), "")
+        Dir.mkdir(File.join(dest_path, "cp_r-test"))
+        Dir.mkdir(File.join(dest_path, "cp_r-test", "b"))
 
         Dir.mkdir_p(src_path)
         File.write(File.join(src_path, "a"), "")
@@ -137,8 +139,8 @@ describe "FileUtils" do
         File.write(File.join(src_path, "b/c"), "")
 
         FileUtils.cp_r(src_path, dest_path)
-        File.exists?(File.join(dest_path, "a")).should be_true
-        File.exists?(File.join(dest_path, "b/c")).should be_true
+        File.exists?(File.join(dest_path, "cp_r-test", "a")).should be_true
+        File.exists?(File.join(dest_path, "cp_r-test", "b/c")).should be_true
         File.exists?(File.join(dest_path, "d")).should be_true
       end
     end

--- a/src/file_utils.cr
+++ b/src/file_utils.cr
@@ -111,6 +111,7 @@ module FileUtils
 
   # Copies a file or directory *src_path* to *dest_path*.
   # If *src_path* is a directory, this method copies all its contents recursively.
+  # If *dest* is a directory, copies src to dest/src.
   #
   # ```
   # require "file_utils"
@@ -118,12 +119,17 @@ module FileUtils
   # FileUtils.cp_r("files", "dir")
   # ```
   def cp_r(src_path : String, dest_path : String)
+    dest_path = File.join(dest_path, File.basename(src_path)) if File.directory?(dest_path)
+    cp_recursive(src_path, dest_path)
+  end
+
+  private def cp_recursive(src_path : String, dest_path : String)
     if Dir.exists?(src_path)
       Dir.mkdir(dest_path) unless Dir.exists?(dest_path)
       Dir.each_child(src_path) do |entry|
         src = File.join(src_path, entry)
         dest = File.join(dest_path, entry)
-        cp_r(src, dest)
+        cp_recursive(src, dest)
       end
     else
       cp(src_path, dest_path)


### PR DESCRIPTION
This fixes the behavior of `FileUtils.cp_r`. According to the [Ruby implementation](https://github.com/ruby/ruby/blob/9b9cbbbc17bb5840581c7da37fd0feb0a7d4c1f3/lib/fileutils.rb#L1610-L1614) the destination is calculated with `File.join(dest_path, File.basename(src_path))` if `dest_path` is a directory.

Resolves #7816.