### PR TITLE
Implement User/Group from_name?/from_id? like Ruby

### DIFF
--- a/src/crystal/system/unix.cr
+++ b/src/crystal/system/unix.cr
@@ -1,0 +1,19 @@
+# :nodoc:
+module Crystal::System
+  def self.retry_with_buffer(function_name, max_buffer)
+    initial_buf = uninitialized UInt8[1024]
+    buf = initial_buf
+
+    while (ret = yield buf.to_slice) != 0
+      case ret
+      when LibC::ENOENT, LibC::ESRCH, LibC::EBADF, LibC::EPERM
+        return nil
+      when LibC::ERANGE
+        raise RuntimeError.from_errno(function_name) if buf.size >= max_buffer
+        buf = Bytes.new(buf.size * 2)
+      else
+        raise RuntimeError.from_errno(function_name)
+      end
+    end
+  end
+end


### PR DESCRIPTION
Ruby handles [`ENOENT`, `ESRCH`, `EBADF` and `EPERM` as not found](https://github.com/ruby/ruby/blob/81562f943e4f33fbfd00fdfd115890ba0b76916c/process.c#L5934-L5950) when calling `getgrgid_r`, `getgrnam_r`, `getpwnam_r` or `getpwuid_r`.

I implemented the same behavior for crystal. Unfortunately, it's not possible to write unit tests for this.

Fixes #8069.