### PR TITLE
Make overloads without double splat more specialized than overloads with one

### DIFF
--- a/spec/compiler/semantic/double_splat_spec.cr
+++ b/spec/compiler/semantic/double_splat_spec.cr
@@ -236,9 +236,11 @@ describe "Semantic: double splat" do
       def foo(*, x : Nil)
         1
       end
+
       def foo(**options)
         :symbol
       end
+
       foo(x: nil)
       ), inject_primitives: false) { int32 }
   end
@@ -248,9 +250,11 @@ describe "Semantic: double splat" do
       def foo(**options)
         :symbol
       end
+
       def foo(*, x : Nil)
         1
       end
+
       foo(x: nil)
       ), inject_primitives: false) { int32 }
   end

--- a/spec/compiler/semantic/double_splat_spec.cr
+++ b/spec/compiler/semantic/double_splat_spec.cr
@@ -230,4 +230,28 @@ describe "Semantic: double splat" do
       {bar(x: 1, y: 2), bar(x: 'a', y: 1)}
       )) { tuple_of([int32, string]) }
   end
+
+  it "orders overloads: unnamed splat vs double splat (1) (#5328)" do
+    assert_type(%(
+      def foo(*, x : Nil)
+        1
+      end
+      def foo(**options)
+        :symbol
+      end
+      foo(x: nil)
+      ), inject_primitives: false) { int32 }
+  end
+
+  it "orders overloads: unnamed splat vs double splat (2) (#5328)" do
+    assert_type(%(
+      def foo(**options)
+        :symbol
+      end
+      def foo(*, x : Nil)
+        1
+      end
+      foo(x: nil)
+      ), inject_primitives: false) { int32 }
+  end
 end

--- a/src/compiler/crystal/semantic/restrictions.cr
+++ b/src/compiler/crystal/semantic/restrictions.cr
@@ -81,6 +81,16 @@ module Crystal
       self_splat_index = self.def.splat_index
       other_splat_index = other.def.splat_index
 
+      # If I double-splat but the other doesn't, I come later
+      if self.def.double_splat && !other.def.double_splat
+        return false
+      end
+
+      # If the other double-splats but I don't, I come first
+      if other.def.double_splat && !self.def.double_splat
+        return true
+      end
+
       # If I splat but the other doesn't, I come later
       if self_splat_index && !other_splat_index
         return false


### PR DESCRIPTION
Fixes #5328.

The fix is simpler than #6425; *all* overloads with a double splat now come after any overload without one. This check is done even before the single splat checks, and doesn't depend on whether the single splat is a named parameter. Thus in the following example

```crystal
def foo(a, b); end
def foo(a, *b); end
def foo(a, b, **c); end
def foo(a, *b, **c); end 
```

every overload is more specialized than the overloads below it.