### PR TITLE
Parse empty array/hash like literals

### DIFF
--- a/spec/compiler/parser/parser_spec.cr
+++ b/spec/compiler/parser/parser_spec.cr
@@ -1371,6 +1371,8 @@ module Crystal
 
     it_parses "Set {1, 2, 3}", ArrayLiteral.new([1.int32, 2.int32, 3.int32] of ASTNode, name: "Set".path)
     it_parses "Set(Int32) {1, 2, 3}", ArrayLiteral.new([1.int32, 2.int32, 3.int32] of ASTNode, name: Generic.new("Set".path, ["Int32".path] of ASTNode))
+    it_parses "Set {}", ArrayLiteral.new([] of ASTNode, name: "Set".path)
+    it_parses "Set(Int32) {}", ArrayLiteral.new([] of ASTNode, name: Generic.new("Set".path, ["Int32".path] of ASTNode))
 
     it_parses "foo(Bar) { 1 }", Call.new(nil, "foo", args: ["Bar".path] of ASTNode, block: Block.new(body: 1.int32))
     it_parses "foo Bar { 1 }", Call.new(nil, "foo", args: [ArrayLiteral.new([1.int32] of ASTNode, name: "Bar".path)] of ASTNode)
@@ -1637,7 +1639,9 @@ module Crystal
     assert_syntax_error "def foo(x, **x); end", "duplicated argument name: x"
 
     assert_syntax_error "Set {1, 2, 3} of Int32"
-    assert_syntax_error "Hash {foo: 1} of Int32 => Int32"
+    assert_syntax_error "Hash {foo => 1} of Int32 => Int32"
+    assert_syntax_error "Set {} of Int32"
+    assert_syntax_error "Hash {} of Int32 => Int32"
     assert_syntax_error "enum Foo < UInt16; end"
     assert_syntax_error "foo(1 2)"
     assert_syntax_error %(foo("bar" "baz"))

--- a/spec/compiler/semantic/array_literal_spec.cr
+++ b/spec/compiler/semantic/array_literal_spec.cr
@@ -1,0 +1,15 @@
+require "../../spec_helper"
+
+describe "array literal" do
+  it "empty literal" do
+    assert_type("Array(Int32){}") { array_of int32 }
+    # An empty array-like literal transforms into a single `.new` call, so it
+    # technically works with any type that has an argless `.new` method, even if
+    # it does not respond to `#<<`.
+    assert_type("String{}") { string }
+  end
+
+  it "empty literal missing generic arguments" do
+    assert_error("Array{}", "wrong number of type vars for Array(T) (given 0, expected 1)")
+  end
+end

--- a/spec/compiler/semantic/hash_literal_spec.cr
+++ b/spec/compiler/semantic/hash_literal_spec.cr
@@ -1,0 +1,12 @@
+require "../../spec_helper"
+
+describe "hash literal" do
+  it "empty literal" do
+    assert_type("Hash(Int32, Int32){}") { hash_of int32, int32 }
+  end
+
+  it "empty literal missing generic arguments" do
+    assert_error("Hash{}", "wrong number of type vars for Hash(K, V) (given 0, expected 2)")
+    assert_error("Hash(Int32){}", "wrong number of type vars for Hash(K, V) (given 1, expected 2)")
+  end
+end

--- a/src/compiler/crystal/semantic/main_visitor.cr
+++ b/src/compiler/crystal/semantic/main_visitor.cr
@@ -2994,7 +2994,12 @@ module Crystal
         case type
         when GenericClassType
           generic_type = TypeNode.new(type).at(node.location)
-          type_of = TypeOf.new(node.elements).at(node.location)
+
+          if node.elements.empty?
+            type_of = [] of ASTNode
+          else
+            type_of = TypeOf.new(node.elements).at(node.location)
+          end
 
           generic = Generic.new(generic_type, type_of).at(node.location)
 

--- a/src/compiler/crystal/syntax/parser.cr
+++ b/src/compiler/crystal/syntax/parser.cr
@@ -1256,8 +1256,14 @@ module Crystal
           ary = ArrayLiteral.new(tuple_or_hash.elements, name: type).at(tuple_or_hash.location)
           return ary
         when HashLiteral
-          tuple_or_hash.name = type
-          return tuple_or_hash
+          if tuple_or_hash.entries.empty?
+            # an empty literal is ambiguous, we're picking ArrayLiteral for simplicity
+            ary = ArrayLiteral.new([] of ASTNode, name: type).at(tuple_or_hash.location)
+            return ary
+          else
+            tuple_or_hash.name = type
+            return tuple_or_hash
+          end
         else
           raise "BUG: tuple_or_hash should be tuple or hash, not #{tuple_or_hash}"
         end
@@ -2356,7 +2362,7 @@ module Crystal
       if @token.type == :"}"
         end_location = token_end_location
         next_token_skip_space
-        new_hash_literal([] of HashLiteral::Entry, line, column, end_location)
+        new_hash_literal([] of HashLiteral::Entry, line, column, end_location, allow_of: allow_of)
       else
         if named_tuple_start?
           unless allow_of


### PR DESCRIPTION
Fixes #9551

As a byproduct this also allows empty array literals like `String{}` because that's just a different syntax for `String.new`.

If we don't want to allow that syntax for everything, it could be further restricted. But this patch focuses on fixing a bug.