### PR TITLE
Fix error message for non-exhaustive case statements of 3 or more Bool/Enum values

### DIFF
--- a/spec/compiler/semantic/case_spec.cr
+++ b/spec/compiler/semantic/case_spec.cr
@@ -425,6 +425,24 @@ describe "semantic: case" do
       "case is not exhaustive.\n\nMissing cases:\n - {false, Char}"
   end
 
+  it "checks exhaustiveness for tuple literal of 3 elements, all bool" do
+    assert_error %(
+        #{bool_case_eq}
+
+        case {true, true, true}
+        in {true, true, true}
+        end
+      ),
+      <<-ERROR
+      case is not exhaustive.
+
+      Missing cases:
+       - {true, true, false}
+       - {true, false, Bool}
+       - {false, Bool, Bool}
+      ERROR
+  end
+
   it "checks exhaustiveness for tuple literal of 2 elements, first is enum" do
     assert_error %(
         #{enum_eq}
@@ -441,6 +459,33 @@ describe "semantic: case" do
         end
       ),
       "case is not exhaustive.\n\nMissing cases:\n - {Color::Green, Char}"
+  end
+
+  it "checks exhaustiveness for tuple literal of 3 elements, all enums" do
+    assert_error %(
+        #{enum_eq}
+
+        enum Color
+          Red
+          Green
+          Blue
+        end
+
+        case {Color::Red, Color::Red, Color::Red}
+        in {.red?, .green?, .blue?}
+        end
+      ),
+      <<-ERROR
+      case is not exhaustive.
+
+      Missing cases:
+       - {Color::Red, Color::Red, Color}
+       - {Color::Red, Color::Green, Color::Red}
+       - {Color::Red, Color::Green, Color::Green}
+       - {Color::Red, Color::Blue, Color}
+       - {Color::Green, Color, Color}
+       - {Color::Blue, Color, Color}
+      ERROR
   end
 
   it "checks exhaustiveness for tuple literal with types and underscore at first position" do

--- a/src/compiler/crystal/semantic/exhaustiveness_checker.cr
+++ b/src/compiler/crystal/semantic/exhaustiveness_checker.cr
@@ -403,8 +403,9 @@ struct Crystal::ExhaustivenessChecker
         end
 
         missing_cases_per_bool.each do |bool, missing_cases|
-          next if missing_cases.empty?
-          gathered_missing_cases << "#{bool}, #{missing_cases.join(", ")}"
+          missing_cases.each do |missing_case|
+            gathered_missing_cases << "#{bool}, #{missing_case}"
+          end
         end
 
         gathered_missing_cases
@@ -533,8 +534,9 @@ struct Crystal::ExhaustivenessChecker
         end
 
         missing_cases_per_member.each do |member, missing_cases|
-          next if missing_cases.empty?
-          gathered_missing_cases << "#{member}, #{missing_cases.join(", ")}"
+          missing_cases.each do |missing_case|
+            gathered_missing_cases << "#{member}, #{missing_case}"
+          end
         end
 
         gathered_missing_cases


### PR DESCRIPTION
Currently, code like

```crystal
case {true, true, true}
in {true, true, true}
end
```

fails with

```
Error: case is not exhaustive.

Missing cases:
 - {true, true, false, false, Bool}
 - {false, Bool, Bool}
```

There is an incorrect `join` that combines multiple subcases into a single case. This PR changes the above to

```
Error: case is not exhaustive.

Missing cases:
 - {true, true, false}
 - {true, false, Bool}
 - {false, Bool, Bool}
```