### PR TITLE
Refactor Crystal::Exception to Crystal::CodeError

### DIFF
--- a/src/compiler/crystal/codegen/codegen.cr
+++ b/src/compiler/crystal/codegen/codegen.cr
@@ -2027,7 +2027,7 @@ module Crystal
       if raise_overflow_fun = @raise_overflow_fun
         check_main_fun RAISE_OVERFLOW_NAME, raise_overflow_fun
       else
-        raise LocationlessException.new("Missing __crystal_raise_overflow function, either use std-lib's prelude or define it")
+        raise Error.new("Missing __crystal_raise_overflow function, either use std-lib's prelude or define it")
       end
     end
 

--- a/src/compiler/crystal/codegen/target.cr
+++ b/src/compiler/crystal/codegen/target.cr
@@ -1,8 +1,8 @@
 require "llvm"
-require "../exception"
+require "../error"
 
 class Crystal::Codegen::Target
-  class Error < Crystal::LocationlessException
+  class Error < Crystal::Error
   end
 
   getter architecture : String

--- a/src/compiler/crystal/command.cr
+++ b/src/compiler/crystal/command.cr
@@ -122,10 +122,6 @@ class Crystal::Command
         error "unknown command: #{command}"
       end
     end
-  rescue ex : Crystal::LocationlessException
-    report_warnings
-
-    error ex.message
   rescue ex : Crystal::Exception
     report_warnings
 
@@ -137,6 +133,10 @@ class Crystal::Command
       STDERR.puts ex
     end
     exit 1
+  rescue ex : Crystal::Error
+    report_warnings
+
+    error ex.message
   rescue ex : OptionParser::Exception
     error ex.message
   rescue ex
@@ -623,7 +623,7 @@ class Crystal::Command
   private def use_crystal_opts
     @options = Process.parse_arguments(ENV.fetch("CRYSTAL_OPTS", "")).concat(options)
   rescue ex
-    raise LocationlessException.new("Failed to parse CRYSTAL_OPTS: #{ex.message}")
+    raise Error.new("Failed to parse CRYSTAL_OPTS: #{ex.message}")
   end
 
   private def new_compiler

--- a/src/compiler/crystal/command.cr
+++ b/src/compiler/crystal/command.cr
@@ -122,7 +122,7 @@ class Crystal::Command
         error "unknown command: #{command}"
       end
     end
-  rescue ex : Crystal::Exception
+  rescue ex : Crystal::CodeError
     report_warnings
 
     ex.color = @color

--- a/src/compiler/crystal/compiler.cr
+++ b/src/compiler/crystal/compiler.cr
@@ -159,7 +159,7 @@ module Crystal
     # Compiles the given *source*, with *output_filename* as the name
     # of the generated executable.
     #
-    # Raises `Crystal::Exception` if there's an error in the
+    # Raises `Crystal::CodeError` if there's an error in the
     # source code.
     #
     # Raises `InvalidByteSequenceError` if the source code is not
@@ -183,7 +183,7 @@ module Crystal
     # contain all types and methods. This can be useful to generate
     # API docs, analyze type relationships, etc.
     #
-    # Raises `Crystal::Exception` if there's an error in the
+    # Raises `Crystal::CodeError` if there's an error in the
     # source code.
     #
     # Raises `InvalidByteSequenceError` if the source code is not

--- a/src/compiler/crystal/crystal_path.cr
+++ b/src/compiler/crystal/crystal_path.cr
@@ -1,9 +1,9 @@
 require "./config"
-require "./exception"
+require "./error"
 
 module Crystal
   struct CrystalPath
-    class NotFoundError < LocationlessException
+    class NotFoundError < Crystal::Error
       getter filename
       getter relative_to
 

--- a/src/compiler/crystal/error.cr
+++ b/src/compiler/crystal/error.cr
@@ -1,0 +1,5 @@
+module Crystal
+  # Base class for all errors in the compiler.
+  class Error < ::Exception
+  end
+end

--- a/src/compiler/crystal/exception.cr
+++ b/src/compiler/crystal/exception.cr
@@ -1,8 +1,9 @@
 require "./util"
+require "./error"
 require "colorize"
 
 module Crystal
-  abstract class Exception < ::Exception
+  abstract class Exception < Error
     property? color = false
     property? error_trace = false
 
@@ -72,30 +73,6 @@ module Crystal
           found_non_space = true
           char
         end
-      end
-    end
-  end
-
-  class LocationlessException < Exception
-    def to_s_with_source(io : IO, source)
-      io << @message
-    end
-
-    def append_to_s(io : IO, source)
-      io << @message
-    end
-
-    def has_location?
-      false
-    end
-
-    def deepest_error_message
-      @message
-    end
-
-    def to_json_single(json)
-      json.object do
-        json.field "message", @message
       end
     end
   end

--- a/src/compiler/crystal/exception.cr
+++ b/src/compiler/crystal/exception.cr
@@ -3,7 +3,8 @@ require "./error"
 require "colorize"
 
 module Crystal
-  abstract class Exception < Error
+  # Base class for all errors related to specific user code.
+  abstract class CodeError < Error
     property? color = false
     property? error_trace = false
 

--- a/src/compiler/crystal/macros/interpreter.cr
+++ b/src/compiler/crystal/macros/interpreter.cr
@@ -379,7 +379,7 @@ module Crystal
           @last = receiver.interpret(node.name, args, named_args, node.block, self)
         rescue ex : MacroRaiseException
           raise ex
-        rescue ex : Crystal::Exception
+        rescue ex : Crystal::CodeError
           node.raise ex.message, inner: ex
         rescue ex
           node.raise ex.message
@@ -492,7 +492,7 @@ module Crystal
 
     def resolve?(node : Generic)
       resolve(node)
-    rescue Crystal::Exception
+    rescue Crystal::CodeError
       nil
     end
 

--- a/src/compiler/crystal/semantic/bindings.cr
+++ b/src/compiler/crystal/semantic/bindings.cr
@@ -586,7 +586,7 @@ module Crystal
 
         begin
           generic_type = instance_type.as(GenericType).instantiate(type_vars_types)
-        rescue ex : Crystal::Exception
+        rescue ex : Crystal::CodeError
           raise ex.message, ex
         end
       end

--- a/src/compiler/crystal/semantic/call.cr
+++ b/src/compiler/crystal/semantic/call.cr
@@ -909,7 +909,7 @@ class Crystal::Call
             begin
               block_type = lookup_node_type(match.context, output).virtual_type
               block_type = program.nil if block_type.void?
-            rescue ex : Crystal::Exception
+            rescue ex : Crystal::CodeError
               cant_infer_block_return_type
             end
           else
@@ -923,7 +923,7 @@ class Crystal::Call
             if output.is_a?(ASTNode) && !output.is_a?(Underscore) && block_type.no_return?
               begin
                 block_type = lookup_node_type(match.context, output).virtual_type
-              rescue ex : Crystal::Exception
+              rescue ex : Crystal::CodeError
                 if block_type
                   raise "couldn't match #{block_type} to #{output}", ex
                 else
@@ -992,7 +992,7 @@ class Crystal::Call
   def bubbling_exception
     begin
       yield
-    rescue ex : Crystal::Exception
+    rescue ex : Crystal::CodeError
       if obj = @obj
         if name == "initialize"
           # Avoid putting 'initialize' in the error trace

--- a/src/compiler/crystal/semantic/conversions.cr
+++ b/src/compiler/crystal/semantic/conversions.cr
@@ -5,7 +5,7 @@ module Crystal::Conversions
 
     begin
       convert_call.accept visitor
-    rescue ex : Crystal::Exception
+    rescue ex : Crystal::CodeError
       if ex.message.try(&.includes?("undefined method '#{convert_call_name}'"))
         return nil
       end

--- a/src/compiler/crystal/semantic/exception.cr
+++ b/src/compiler/crystal/semantic/exception.cr
@@ -2,11 +2,11 @@ require "../exception"
 require "../types"
 
 module Crystal
-  class TypeException < Exception
+  class TypeException < CodeError
     include ErrorFormat
 
     getter node
-    property inner : Exception?
+    property inner : CodeError?
     getter line_number : Int32?
     getter column_number : Int32
     getter size : Int32
@@ -171,7 +171,7 @@ module Crystal
     end
   end
 
-  class MethodTraceException < Exception
+  class MethodTraceException < CodeError
     def initialize(@owner : Type?, @trace : Array(ASTNode), @nil_reason : NilReason?, @show : Bool)
       super(nil)
     end

--- a/src/compiler/crystal/semantic/main_visitor.cr
+++ b/src/compiler/crystal/semantic/main_visitor.cr
@@ -1294,7 +1294,7 @@ module Crystal
 
       begin
         call.recalculate
-      rescue ex : Crystal::Exception
+      rescue ex : Crystal::CodeError
         node.raise "error instantiating #{node}", ex
       end
 
@@ -1916,7 +1916,7 @@ module Crystal
 
       begin
         body.accept visitor
-      rescue ex : Crystal::Exception
+      rescue ex : Crystal::CodeError
         node.raise ex.message, ex
       end
 

--- a/src/compiler/crystal/semantic/semantic_visitor.cr
+++ b/src/compiler/crystal/semantic/semantic_visitor.cr
@@ -86,7 +86,7 @@ abstract class Crystal::SemanticVisitor < Crystal::Visitor
     end
 
     node.raise "#{message}\n\n#{notes.join("\n")}"
-  rescue ex : Crystal::Exception
+  rescue ex : Crystal::CodeError
     node.raise "while requiring \"#{node.string}\"", ex
   rescue ex
     raise Error.new("while requiring \"#{node.string}\"", ex)
@@ -439,7 +439,7 @@ abstract class Crystal::SemanticVisitor < Crystal::Visitor
     yield
   rescue ex : MacroRaiseException
     node.raise ex.message, exception_type: MacroRaiseException
-  rescue ex : Crystal::Exception
+  rescue ex : Crystal::CodeError
     node.raise "expanding macro", ex
   end
 

--- a/src/compiler/crystal/semantic/semantic_visitor.cr
+++ b/src/compiler/crystal/semantic/semantic_visitor.cr
@@ -89,7 +89,7 @@ abstract class Crystal::SemanticVisitor < Crystal::Visitor
   rescue ex : Crystal::Exception
     node.raise "while requiring \"#{node.string}\"", ex
   rescue ex
-    raise ::Exception.new("while requiring \"#{node.string}\"", ex)
+    raise Error.new("while requiring \"#{node.string}\"", ex)
   end
 
   def visit(node : ClassDef)

--- a/src/compiler/crystal/semantic/top_level_visitor.cr
+++ b/src/compiler/crystal/semantic/top_level_visitor.cr
@@ -313,7 +313,7 @@ class Crystal::TopLevelVisitor < Crystal::SemanticVisitor
     target = current_type.metaclass.as(ModuleType)
     begin
       target.add_macro node
-    rescue ex : Crystal::Exception
+    rescue ex : Crystal::CodeError
       node.raise ex.message
     end
 

--- a/src/compiler/crystal/semantic/type_lookup.cr
+++ b/src/compiler/crystal/semantic/type_lookup.cr
@@ -196,7 +196,7 @@ class Crystal::Type
 
         begin
           return instance_type.instantiate_named_args(entries)
-        rescue ex : Crystal::Exception
+        rescue ex : Crystal::CodeError
           node.raise "instantiating #{node}", inner: ex if @raise
         end
       when GenericType
@@ -257,7 +257,7 @@ class Crystal::Type
             begin
               num = interpreter.interpret(type.value)
               type_vars << NumberLiteral.new(num)
-            rescue ex : Crystal::Exception
+            rescue ex : Crystal::CodeError
               type_var.raise "expanding constant value for a number value", inner: ex
             end
             next
@@ -289,7 +289,7 @@ class Crystal::Type
         else
           instance_type.as(GenericType).instantiate(type_vars)
         end
-      rescue ex : Crystal::Exception
+      rescue ex : Crystal::CodeError
         node.raise "instantiating #{node}", inner: ex if @raise
       end
     end
@@ -375,7 +375,7 @@ class Crystal::Type
       expressions = node.expressions.clone
       begin
         expressions.each &.accept visitor
-      rescue ex : Crystal::Exception
+      rescue ex : Crystal::CodeError
         node.raise "typing typeof", inner: ex
       end
       program.type_merge expressions

--- a/src/compiler/crystal/syntax/exception.cr
+++ b/src/compiler/crystal/syntax/exception.cr
@@ -1,7 +1,7 @@
 require "../exception"
 
 module Crystal
-  class SyntaxException < Exception
+  class SyntaxException < CodeError
     include ErrorFormat
 
     getter line_number : Int32

--- a/src/compiler/crystal/tools/init.cr
+++ b/src/compiler/crystal/tools/init.cr
@@ -6,7 +6,7 @@ require "./git"
 
 module Crystal
   module Init
-    class Error < ::Exception
+    class Error < Crystal::Error
       def self.new(message, opts : OptionParser)
         new("#{message}\n#{opts}\n")
       end

--- a/src/compiler/crystal/tools/playground/server.cr
+++ b/src/compiler/crystal/tools/playground/server.cr
@@ -51,7 +51,7 @@ module Crystal::Playground
       @tag = tag
       begin
         sources = self.class.instrument_and_prelude(@session_key, @port, tag, source)
-      rescue ex : Crystal::Exception
+      rescue ex : Crystal::CodeError
         send_exception ex, tag
         return
       end
@@ -103,7 +103,7 @@ module Crystal::Playground
 
       begin
         value = Crystal.format source
-      rescue ex : Crystal::Exception
+      rescue ex : Crystal::CodeError
         send_exception ex, tag
         return
       end
@@ -148,7 +148,7 @@ module Crystal::Playground
     def append_exception(json, ex)
       json.object do
         json.field "message", ex.to_s
-        if ex.is_a?(Crystal::Exception)
+        if ex.is_a?(Crystal::CodeError)
           json.field "payload" do
             ex.to_json(json)
           end

--- a/src/compiler/crystal/tools/playground/server.cr
+++ b/src/compiler/crystal/tools/playground/server.cr
@@ -445,7 +445,7 @@ module Crystal::Playground
     end
   end
 
-  class Error < Crystal::LocationlessException
+  class Error < Crystal::Error
   end
 
   class Server


### PR DESCRIPTION
This patch introduces `Crystal::Error` as base class for all compiler errors and renames `Crystal::Exception` to `Crystal::CodeError`.

`Crystal::LocationlessException` as a more specific error type is unnecessary. The relationship is now reversed: `CodeError < Error` (previously: `LocationlessException < Exception`) and `Crystal::Error` is used as exception type for non code-related errors.