### PR TITLE
BigInt: remove incorrect definition of digits

### DIFF
--- a/spec/std/big/big_int_spec.cr
+++ b/spec/std/big/big_int_spec.cr
@@ -454,6 +454,11 @@ describe "BigInt" do
       123.to_big_i.digits(16).should eq([11, 7])
     end
 
+    it "works with bases greater than 36" do
+      12345.to_big_i.digits(100).should eq([45, 23, 1])
+      12345.to_big_i.digits(1000).should eq([345, 12])
+    end
+
     it "raises for invalid base" do
       [1, 0, -1].each do |base|
         expect_raises(ArgumentError, "Invalid base #{base}") do

--- a/src/big/big_int.cr
+++ b/src/big/big_int.cr
@@ -442,18 +442,6 @@ struct BigInt < Int
     String.new(cstr)
   end
 
-  # :nodoc:
-  def digits(base = 10) : Array(Int32)
-    if self < 0
-      raise ArgumentError.new("Can't request digits of negative number")
-    end
-
-    ary = [] of Int32
-    self.to_s(base).each_char { |c| ary << c.to_i(base) }
-    ary.reverse!
-    ary
-  end
-
   def popcount
     LibGMP.popcount(self)
   end


### PR DESCRIPTION
The current definition of `BigInt#digits` does not allow the `base` argument to be greater than 36; this limitation is artificial and unnecessary since we don't need to convert the digits to a string representation. `Int#digits` correctly handles arbitrary bases, so this patch simply removes the `#digits` override on `BigInt` in order to defer to the one on `Int`.