### PR TITLE
Expose "args_html" in doc JSON

### DIFF
--- a/src/compiler/crystal/tools/doc/method.cr
+++ b/src/compiler/crystal/tools/doc/method.cr
@@ -317,6 +317,7 @@ class Crystal::Doc::Method
       builder.field "abstract", abstract?
       builder.field "args", args
       builder.field "args_string", args_to_s
+      builder.field "args_html", args_to_html
       builder.field "location", location
       builder.field "def", self.def
     end


### PR DESCRIPTION
https://github.com/crystal-lang/crystal/pull/10117 really makes things correct and explains everything in detail. But for now, my doc generator project is really suffering because this "args_html" is not available. So please just merge this small part.