### PR TITLE
Fix Range#step

### DIFF
--- a/spec/std/range_spec.cr
+++ b/spec/std/range_spec.cr
@@ -1,4 +1,5 @@
 require "./spec_helper"
+require "../support/iterate"
 {% unless flag?(:win32) %}
   require "big"
 {% end %}
@@ -384,98 +385,52 @@ describe "Range" do
     end
   end
 
-  describe "step" do
-    it "does with inclusive range" do
-      a = 1..5
-      elems = [] of Int32
-      iter = a.step(2) do |x|
-        elems << x
-      end
-      elems.should eq([1, 3, 5])
-    end
+  describe "#step" do
+    it_iterates "inclusive default", [1, 2, 3, 4, 5], (1..5).step
+    it_iterates "inclusive step", [1, 3, 5], (1..5).step(2)
+    it_iterates "inclusive step over", [1, 3, 5], (1..6).step(2)
 
-    it "does with exclusive range" do
-      a = 1...5
-      elems = [] of Int32
-      iter = a.step(2) do |x|
-        elems << x
-      end
-      elems.should eq([1, 3])
-    end
+    it_iterates "exclusive default", [1, 2, 3, 4], (1...5).step
+    it_iterates "exclusive step", [1, 3], (1...5).step(2)
+    it_iterates "exclusive step over", [1, 3, 5], (1...6).step(2)
 
-    it "does with endless range" do
-      a = (1...nil)
-      elems = [] of Int32
-      iter = a.step(2) do |x|
-        elems << x
-        break if elems.size == 5
-      end
-      elems.should eq([1, 3, 5, 7, 9])
-    end
+    it_iterates "endless range", [1, 3, 5, 7, 9], (1...nil).step(2), infinite: true
 
     it "raises on beginless range" do
-      a = nil..3
       expect_raises(ArgumentError, "Can't step beginless range") do
-        a.step(2) { }
+        (nil..3).step(2) { }
       end
     end
-  end
 
-  describe "step iterator" do
-    it "does next with inclusive range" do
-      a = 1..5
-      iter = a.step(2)
-      iter.next.should eq(1)
-      iter.next.should eq(3)
-      iter.next.should eq(5)
-      iter.next.should be_a(Iterator::Stop)
-    end
+    it_iterates "begin > end inclusive", [] of Int32, (1..0).step(1)
+    it_iterates "begin > end exclusive", [] of Int32, (1...0).step(1)
 
-    it "does next with exclusive range" do
-      a = 1...5
-      iter = a.step(2)
-      iter.next.should eq(1)
-      iter.next.should eq(3)
-      iter.next.should be_a(Iterator::Stop)
-    end
+    it_iterates "begin == end inclusive", [1], (1..1).step(1)
+    it_iterates "begin == end exclusive", [] of Int32, (1...1).step(1)
+    it_iterates "begin.succ == end inclusive", [1, 2] of Int32, (1..2).step(1)
+    it_iterates "begin.succ == end exclusive", [1] of Int32, (1...2).step(1)
 
-    it "does next with exclusive range (2)" do
-      a = 1...6
-      iter = a.step(2)
-      iter.next.should eq(1)
-      iter.next.should eq(3)
-      iter.next.should eq(5)
-      iter.next.should be_a(Iterator::Stop)
-    end
+    describe "with #succ type" do
+      range_basic = RangeSpecIntWrapper.new(1)..RangeSpecIntWrapper.new(5)
+      it_iterates "basic", [1, 2, 3, 4, 5].map(&->RangeSpecIntWrapper.new(Int32)), range_basic.step
+      it_iterates "basic by", [1, 3, 5].map(&->RangeSpecIntWrapper.new(Int32)), range_basic.step(by: 2)
+      it_iterates "missing end by", [1, 4].map(&->RangeSpecIntWrapper.new(Int32)), range_basic.step(by: 3)
 
-    it "is empty with .. and begin > end" do
-      (1..0).step(1).to_a.empty?.should be_true
-    end
-
-    it "is empty with ... and begin > end" do
-      (1...0).step(1).to_a.empty?.should be_true
-    end
-
-    it "is not empty with .. and begin == end" do
-      (1..1).step(1).to_a.should eq([1])
-    end
-
-    it "is not empty with ... and begin.succ == end" do
-      (1...2).step(1).to_a.should eq([1])
-    end
-
-    it "does with endless range" do
-      a = (1...nil)
-      iter = a.step(2)
-      iter.next.should eq(1)
-      iter.next.should eq(3)
-    end
-
-    it "raises with beginless range" do
-      a = nil..3
-      expect_raises(ArgumentError, "Can't step beginless range") do
-        a.step(2)
-      end
+      it_iterates "at definition range",
+        [Int32::MAX - 2, Int32::MAX - 1, Int32::MAX].map(&->RangeSpecIntWrapper.new(Int32)),
+        (RangeSpecIntWrapper.new(Int32::MAX - 2)..RangeSpecIntWrapper.new(Int32::MAX)).step
+      it_iterates "at definition range by",
+        [RangeSpecIntWrapper.new(Int32::MAX - 2), RangeSpecIntWrapper.new(Int32::MAX)],
+        (RangeSpecIntWrapper.new(Int32::MAX - 2)..RangeSpecIntWrapper.new(Int32::MAX)).step(by: 2)
+      it_iterates "at definition range missing by",
+        [RangeSpecIntWrapper.new(Int32::MAX - 1)],
+        (RangeSpecIntWrapper.new(Int32::MAX - 1)..RangeSpecIntWrapper.new(Int32::MAX)).step(by: 2)
+      it_iterates "at definition range by",
+        [RangeSpecIntWrapper.new(Int32::MAX - 3), RangeSpecIntWrapper.new(Int32::MAX - 1)],
+        (RangeSpecIntWrapper.new(Int32::MAX - 3)..RangeSpecIntWrapper.new(Int32::MAX - 1)).step(by: 2)
+      it_iterates "at definition range missing by",
+        [RangeSpecIntWrapper.new(Int32::MAX - 2)],
+        (RangeSpecIntWrapper.new(Int32::MAX - 2)..RangeSpecIntWrapper.new(Int32::MAX - 1)).step(by: 2)
     end
   end
 

--- a/spec/support/iterate.cr
+++ b/spec/support/iterate.cr
@@ -1,11 +1,21 @@
 # spec helper for generic iteration methods which tests both yielding and
 # iterator overloads.
-macro it_iterates(description, expected, method)
+macro it_iterates(description, expected, method, *, infinite = false)
   describe {{ description }} do
     it "yielding" do
+      remaining = ({{ expected }}).size
       ary = [] of typeof(({{ expected }})[0])
       {{ method.id }} do |x|
+        if remaining == 0
+          if {{ infinite }}
+            break
+          else
+            fail "Reached iteration limit #{({{ expected }}).size} receiving value #{x.inspect}"
+          end
+        end
+
         ary << x
+        remaining -= 1
       end
 
       ary.should eq {{ expected }}
@@ -24,7 +34,9 @@ macro it_iterates(description, expected, method)
         break if v.is_a?(Iterator::Stop)
         ary << v
       end
-      iter.next.should be_a(Iterator::Stop)
+      unless {{ infinite }}
+        iter.next.should be_a(Iterator::Stop)
+      end
 
       ary.should eq {{ expected }}
       ary.zip({{ expected }}).each_with_index do |(a, b), i|


### PR DESCRIPTION
Similar to #10130 this fixes `Range#step` for some edge cases. Behaviour of `Number#step` and `Range#step` should have identical behaviour now (except for exclusive option). See https://github.com/crystal-lang/crystal/issues/9339#issuecomment-749281784 for context.

Specs are simplified by a lot and now work combined for yielding and iterator overloads using `it_iterates` helper (see #10158) .