### PR TITLE
Remove duplicated `sort` related specs

### DIFF
--- a/spec/std/array_spec.cr
+++ b/spec/std/array_spec.cr
@@ -2,27 +2,6 @@ require "spec"
 
 private alias RecursiveArray = Array(RecursiveArray)
 
-private class BadSortingClass
-  include Comparable(self)
-
-  def <=>(other)
-    1
-  end
-end
-
-private class Spaceship
-  getter value : Float64
-
-  def initialize(@value : Float64, @return_nil = false)
-  end
-
-  def <=>(other : Spaceship)
-    return nil if @return_nil
-
-    value <=> other.value
-  end
-end
-
 describe "Array" do
   describe "new" do
     it "creates with default value" do
@@ -1270,42 +1249,6 @@ describe "Array" do
       b.should eq(["a", "foo", "hello"])
       a.should_not eq(b)
     end
-
-    it "doesn't crash on special situations" do
-      [1, 2, 3].sort { 1 }
-      Array.new(10) { BadSortingClass.new }.sort
-    end
-
-    it "can sort just by using <=> (#6608)" do
-      spaceships = [
-        Spaceship.new(2),
-        Spaceship.new(0),
-        Spaceship.new(1),
-        Spaceship.new(3),
-      ]
-
-      sorted = spaceships.sort
-      4.times do |i|
-        sorted[i].value.should eq(i)
-      end
-    end
-
-    it "raises if <=> returns nil" do
-      spaceships = [
-        Spaceship.new(2, return_nil: true),
-        Spaceship.new(0, return_nil: true),
-      ]
-
-      expect_raises(ArgumentError) do
-        spaceships.sort
-      end
-    end
-
-    it "raises if sort block returns nil" do
-      expect_raises(ArgumentError) do
-        [1, 2].sort { nil }
-      end
-    end
   end
 
   describe "sort!" do
@@ -1319,43 +1262,6 @@ describe "Array" do
       a = ["foo", "a", "hello"]
       a.sort! { |x, y| x.size <=> y.size }
       a.should eq(["a", "foo", "hello"])
-    end
-
-    it "sorts with invalid block (#4379)" do
-      a = [1] * 17
-      b = a.sort { -1 }
-      a.should eq(b)
-    end
-
-    it "can sort! just by using <=> (#6608)" do
-      spaceships = [
-        Spaceship.new(2),
-        Spaceship.new(0),
-        Spaceship.new(1),
-        Spaceship.new(3),
-      ]
-
-      spaceships.sort!
-      4.times do |i|
-        spaceships[i].value.should eq(i)
-      end
-    end
-
-    it "raises if <=> returns nil" do
-      spaceships = [
-        Spaceship.new(2, return_nil: true),
-        Spaceship.new(0, return_nil: true),
-      ]
-
-      expect_raises(ArgumentError) do
-        spaceships.sort!
-      end
-    end
-
-    it "raises if sort! block returns nil" do
-      expect_raises(ArgumentError) do
-        [1, 2].sort! { nil }
-      end
     end
   end
 

--- a/spec/std/slice_spec.cr
+++ b/spec/std/slice_spec.cr
@@ -542,42 +542,6 @@ describe "Slice" do
       b.to_a.should eq(["a", "foo", "hello"])
       a.should_not eq(b)
     end
-
-    it "doesn't crash on special situations" do
-      Slice[1, 2, 3].sort { 1 }
-      Slice.[BadSortingClass.new].sort
-    end
-
-    it "can sort just by using <=> (#6608)" do
-      spaceships = [
-        Spaceship.new(2),
-        Spaceship.new(0),
-        Spaceship.new(1),
-        Spaceship.new(3),
-      ]
-
-      sorted = spaceships.sort
-      4.times do |i|
-        sorted[i].value.should eq(i)
-      end
-    end
-
-    it "raises if <=> returns nil" do
-      spaceships = [
-        Spaceship.new(2, return_nil: true),
-        Spaceship.new(0, return_nil: true),
-      ]
-
-      expect_raises(ArgumentError) do
-        spaceships.sort
-      end
-    end
-
-    it "raises if sort block returns nil" do
-      expect_raises(ArgumentError) do
-        [1, 2].sort { nil }
-      end
-    end
   end
 
   describe "sort!" do


### PR DESCRIPTION
See https://github.com/crystal-lang/crystal/pull/10163#issuecomment-754995318

@straight-shoota Could you merge this in 5 minutes? If it is possible, I will rebase #10163 soon.