### PR TITLE
Let `Range#step` delegate to `begin.step`

### DIFF
--- a/spec/std/number_spec.cr
+++ b/spec/std/number_spec.cr
@@ -247,6 +247,14 @@ describe "Number" do
     it_iterates "empty if `self` can't be compared", [] of Float64, Float64::NAN.step(to: 1.0)
     it_iterates "empty if `self` can't be compared by", [] of Float64, Float64::NAN.step(to: 1.0, by: 1.0)
 
+    describe "exclusive" do
+      it_iterates "basic Int", [1, 2, 3, 4], 1.step(to: 5, exclusive: true)
+      it_iterates "basic Float", [1.0, 2.0, 3.0, 4.0], 1.0.step(to: 5.0, exclusive: true)
+
+      it_iterates "single value Int", [] of Int32, 1.step(to: 1, exclusive: true)
+      it_iterates "single value Float", [] of Float64, 1.0.step(to: 1.0, exclusive: true)
+    end
+
     describe "without limit" do
       describe "iterator" do
         it "basic" do

--- a/src/number.cr
+++ b/src/number.cr
@@ -239,6 +239,29 @@ struct Number
         @current += @step
       end
     end
+
+    # Overrides `Enumerable#sum` to use more performant implementation on integer
+    # ranges.
+    def sum(initial)
+      super if @reached_end
+
+      current = @current
+      limit = @limit
+      step = @step
+
+      if current.is_a?(Int) && limit.is_a?(Int) && step.is_a?(Int)
+        limit -= 1 if @exclusive
+        n = (limit - current) // step + 1
+        if n >= 0
+          limit = current + (n - 1) * step
+          initial + n * (current + limit) // 2
+        else
+          initial
+        end
+      else
+        super
+      end
+    end
   end
 
   # Returns the absolute value of this number.

--- a/src/number.cr
+++ b/src/number.cr
@@ -243,7 +243,7 @@ struct Number
     # Overrides `Enumerable#sum` to use more performant implementation on integer
     # ranges.
     def sum(initial)
-      super if @reached_end
+      return super if @reached_end
 
       current = @current
       limit = @limit

--- a/src/range.cr
+++ b/src/range.cr
@@ -502,7 +502,7 @@ struct Range(B, E)
     end
 
     def sum(initial)
-      super if @reached_end
+      return super if @reached_end
 
       b = @current
       e = @range.end

--- a/src/range.cr
+++ b/src/range.cr
@@ -201,66 +201,68 @@ struct Range(B, E)
     ReverseIterator.new(self)
   end
 
-  # Iterates over this range, passing each nth element to the block.
+  # Iterates from `begin` to `end` incrementing by the amount of *step* on each
+  # iteration.
   #
   # ```
-  # range = Xs.new(1)..Xs.new(10)
-  # range.step(2) { |x| puts x }
-  # puts
-  # range.step(3) { |x| puts x }
+  # ary = [] of Int32
+  # (1..4).step(by: 2) do |x|
+  #   ary << x
+  # end
+  # ary                                      # => [1, 3]
+  # (1..4).step(by: 2).to_a                  # => [1, 3]
+  # (1..4).step(by: 1).to_a                  # => [1, 2, 3, 4]
+  # (1..4).step(by: 1, exclusive: true).to_a # => [1, 2, 3]
   # ```
   #
-  # Produces:
+  # The implementation is based on `B#step` method if available. The interface
+  # is defined at `Number#step`.
+  # Otherwise `#succ` method is expected to be defined on `begin` and its
+  # successors and iteration is based on calling `#succ` sequentially
+  # (*step* times per iteration).
   #
-  # ```text
-  # 1 x
-  # 3 xxx
-  # 5 xxxxx
-  # 7 xxxxxxx
-  # 9 xxxxxxxxx
-  #
-  # 1 x
-  # 4 xxxx
-  # 7 xxxxxxx
-  # 10 xxxxxxxxxx
-  # ```
-  #
-  # See `Range`'s overview for the definition of `Xs`.
-  def step(by = 1)
+  # Raises `ArgumentError` if `begin` is `nil`.
+  def step(by = 1, &) : Nil
     current = @begin
     if current.nil?
       raise ArgumentError.new("Can't step beginless range")
     end
 
-    end_value = @end
-    while end_value.nil? || current < end_value
-      yield current
-      by.times do
-        current = current.succ
-        return if end_value && current > end_value
-      rescue exc : OverflowError
-        if current == end_value
-          return
-        else
-          raise exc
+    if current.responds_to?(:step)
+      current.step(to: @end, by: by, exclusive: @exclusive) do |x|
+        yield x
+      end
+    else
+      end_value = @end
+      while end_value.nil? || current < end_value
+        yield current
+        by.times do
+          current = current.succ
+          return if end_value && current > end_value
+        rescue exc : OverflowError
+          if current == end_value
+            return
+          else
+            raise exc
+          end
         end
       end
+      yield current if !@exclusive && current == @end
     end
-    yield current if !@exclusive && current == @end
-    self
   end
 
-  # Returns an `Iterator` that returns each nth element in this range.
-  #
-  # ```
-  # (1..10).step(3).skip(1).to_a # => [4, 7, 10]
-  # ```
-  def step(by = 1)
-    if @begin.nil?
+  # :ditto:
+  def step(by = 1) : Iterator
+    start = @begin
+    if start.nil?
       raise ArgumentError.new("Can't step beginless range")
     end
 
-    StepIterator(self, B, typeof(by)).new(self, by)
+    if start.responds_to?(:step)
+      start.step(to: @end, by: by, exclusive: @exclusive)
+    else
+      StepIterator(self, B, typeof(by)).new(self, by)
+    end
   end
 
   # Returns `true` if this range excludes the *end* element.


### PR DESCRIPTION
TLDR; This lets `(1.0..5.0).step` work.

Resolves #9339
Precursers: #10203, #10130

`Range#step` previously was based on calling `#succ` to get the next value in the iteration. This works for discrete types like integers which define `#succ`. Floating point numbers don't have a clear successor, so `Float#succ` doesn't exist and `Range(Float64, Float64)#step` wouldn't work.

This patch lets `Range(B, E)#step` delegate to `B#step` (if defined), so the behaviour can be entirely implemented by the value's type. The expected interface is that of `Number#step` which is also extended in this patch by an `exclusive` argument to handle exclusive ranges.

The implementation of `Number#step` is very generic based on simple algebra methods and works for non-number types as well. So a follow up would extract it for re-usability (an example would be `Time` as per #9327).

Note: Non-discrete types don't have an inherent step size. For stepping a `Time` range for example, you would need to specifiy the step size explicitly. `Range#step` uses `1` as default value for the step size, but if the step implementation doesn't accept integer step size, it errors at compile time. The error message doesn't point exactly to the call to `Range#step`, but I guess that's acceptable.

The previous `#succ`-based implementation is retained as an alternative if `begin` doesn't respond to `#step`. This is still used for `String` ranges. I'm not sure if we want to keep this alternative. It's not really necessary, `Range` can just expect every stepable type to implement `#step`. But this is a more complex discussion, because `#succ` and `#pred` methods are currently the defining interface of value types for many methods on `Range`.

So, for now I would just add this as an enhancement. The diff in `range.cr` is actually pretty minimal, it's best viewed with whitespace option.