### PR TITLE
Compiler: make sure `Pointer#value=` only accepts covariant values

### DIFF
--- a/spec/compiler/semantic/pointer_spec.cr
+++ b/spec/compiler/semantic/pointer_spec.cr
@@ -185,4 +185,15 @@ describe "Semantic: pointer" do
       x = pointerof(u)
     ))
   end
+
+  it "errors when assigning non-covariant type with value= (#10211)" do
+    assert_error %(
+      class Gen(T)
+      end
+
+      ptr = Pointer(Gen(Char | Int32)).malloc(1_u64)
+      ptr.value = Gen(Int32).new
+      ),
+      "type must be Gen(Char | Int32), not Gen(Int32)"
+  end
 end

--- a/src/compiler/crystal/semantic/call.cr
+++ b/src/compiler/crystal/semantic/call.cr
@@ -1058,7 +1058,7 @@ class Crystal::Call
       args["self"] = MetaVar.new("self", self_type)
     end
 
-    strict_check = body.is_a?(Primitive) && body.name == "proc_call"
+    strict_check = body.is_a?(Primitive) && (body.name == "proc_call" || body.name == "pointer_set")
 
     arg_types.each_index do |index|
       arg = typed_def.args[index]
@@ -1068,10 +1068,19 @@ class Crystal::Call
       args[arg.name] = var
 
       if strict_check
-        owner = owner.as(ProcInstanceType)
-        proc_arg_type = owner.arg_types[index]
-        unless type.covariant?(proc_arg_type)
-          self.args[index].raise "type must be #{proc_arg_type}, not #{type}"
+        case body.as(Primitive).name
+        when "proc_call"
+          owner = owner.as(ProcInstanceType)
+          proc_arg_type = owner.arg_types[index]
+          unless type.covariant?(proc_arg_type)
+            self.args[index].raise "type must be #{proc_arg_type}, not #{type}"
+          end
+        when "pointer_set"
+          owner = owner.as(PointerInstanceType)
+          pointer_type = owner.var.type
+          unless type.covariant?(pointer_type)
+            self.args[index].raise "type must be #{pointer_type}, not #{type}"
+          end
         end
       end
 


### PR DESCRIPTION
Fixes #10211

This is a temporary solution. Ideally all generic type restrictions should be invariant, but that's a really big breaking change. So for now it's only done when setting a pointer's value, which is what all containers eventually do.