### PR TITLE
Compiler: stricter check for generic types

### DIFF
--- a/spec/compiler/codegen/is_a_spec.cr
+++ b/spec/compiler/codegen/is_a_spec.cr
@@ -455,7 +455,7 @@ describe "Codegen: is_a?" do
       )).to_b.should be_true
   end
 
-  it "works with inherited generic class against an instantiation (2)" do
+  it "doesn't work with inherited generic class against an instantiation (2)" do
     run(%(
       class Class1
       end
@@ -471,7 +471,7 @@ describe "Codegen: is_a?" do
 
       bar = Bar.new
       bar.is_a?(Foo(Class1))
-      )).to_b.should be_true
+      )).to_b.should be_false
   end
 
   it "works with inherited generic class against an instantiation (3)" do

--- a/spec/compiler/semantic/pointer_spec.cr
+++ b/spec/compiler/semantic/pointer_spec.cr
@@ -185,4 +185,30 @@ describe "Semantic: pointer" do
       x = pointerof(u)
     ))
   end
+
+  it "errors with non-matching generic value with value= (#10211)" do
+    assert_error %(
+      class Gen(T)
+      end
+
+      ptr = Pointer(Gen(Char | Int32)).malloc(1_u64)
+      ptr.value = Gen(Int32).new
+      ),
+      "no overload matches 'Pointer(Gen(Char | Int32))#value=' with type Gen(Int32)"
+  end
+
+  it "errors with non-matching generic value with value=, generic type (#10211)" do
+    assert_error %(
+      module Moo(T)
+      end
+
+      class Foo(T)
+        include Moo(T)
+      end
+
+      ptr = Pointer(Moo(Char | Int32)).malloc(1_u64)
+      ptr.value = Foo(Int32).new
+      ),
+      "no overload matches 'Pointer(Moo(Char | Int32))#value=' with type Foo(Int32)"
+  end
 end

--- a/src/compiler/crystal/semantic/restrictions.cr
+++ b/src/compiler/crystal/semantic/restrictions.cr
@@ -637,7 +637,7 @@ module Crystal
       type_vars.each do |name, type_var|
         other_type_var = other.type_vars[name]
         if type_var.is_a?(Var) && other_type_var.is_a?(Var)
-          restricted = type_var.type.implements?(other_type_var.type)
+          restricted = type_var.type == other_type_var.type
           return nil unless restricted
         else
           return nil unless type_var == other_type_var
@@ -732,14 +732,14 @@ module Crystal
 
       type_vars.each do |name, type_var|
         other_type_var = other.type_vars[name]
-        restricted = restrict_type_var(type_var, other_type_var, context)
+        restricted = restrict_type_var(type_var, other_type_var, context, strict: true)
         return super unless restricted
       end
 
       self
     end
 
-    def restrict_type_var(type_var, other_type_var, context)
+    def restrict_type_var(type_var, other_type_var, context, strict = false)
       if type_var.is_a?(NumberLiteral)
         case other_type_var
         when NumberLiteral
@@ -773,7 +773,7 @@ module Crystal
 
       if type_var.is_a?(ASTNode)
         type_var.restriction_of?(other_type_var, context.instantiated_type)
-      elsif context.strict?
+      elsif context.strict? || strict
         type_var == other_type_var
       else
         # To prevent infinite recursion, it checks equality between


### PR DESCRIPTION
Fixes #10211

# What changes?

This PR changes a behavior in the language. This code:

```crystal
class Gen(T)
  def foo(x : T)
  end
end

class Other(T)
end

gen = Gen(Other(Int32 | Char)).new
gen.foo(Other(Int32).new)
```

used to compile. With this PR it doesn't anymore:

```
In foo.cr:10:5

 10 | gen.foo(Other(Int32).new)
          ^--
Error: no overload matches 'Gen(Other(Char | Int32))#foo' with type Other(Int32)

Overloads are:
 - Gen(T)#foo(x : T)
```

# Why?

Because the memory representation of `Other(X)` and `Other(X | Y)` are, in the general case, different, so they are incompatible. If these are stored in memory and we allow such types to be compatible it will lead to incorrect memory, which eventually leads to a segfault.

# Is this a breaking change?
 
Unlikely. All tests in the compiler pass without modification (except one because of this behavior change, but it was testing more or less this behavior).

In general when restricting a generic type, the generic type argument is matched as usual. This **compiles**:

```crystal
class Gen(T)
end

def foo(x : Gen(Int32 | Char))
end

foo(Gen(Int32).new)
```

The reason is that `Gen(Int32 | Char)`, as a type restriction, matches `Gen(Int32)` because `Int32` matches `Int32 | Char`. However, in the future I'd like it not to match, and instead you'd have to write something like this:

```crystal
def foo(x : Gen(< Int32 | Char)
end
```

meaning "it's something that is a subtype of `Int32 | Char`". But I didn't want to change the language before 1.0, and this needs more thought.

So how come this PR changes anything? Well, in the compiler there are two kinds of type restrictions: an AST node restriction or a Type restriction. The last example above with `Gen(Int32 | Char)` is an AST node restriction: the restriction's type is not resolved, and instead the type passed to the method is matched against the node's components: first its name, then its type arguments.

Then there's type restrictions which are themselves types. For example when you do:

```crystal
class Gen(T)
  def foo(x : T)
  end
end

Gen(Int32).new.foo('a')
```

In the above example the `T` actually gets mapped to **the type** `Int32`, and then we try to match the argument's type (Char) against an actual type (Int32). It's in those cases where this PR changes things and make generic type arguments require a strict match. That means that if `T` is `Array(Int32 | Char)` then only `Array(Int32 | Char)` will match (or subtypes with a similar type argument). But `Array(Int32)` won't match, nor `Array(Char)`.

This is a bit complex and confusing but it's because this part isn't well designed. It works but it could be done in a better way, but right now this simple patch fixes and important bug while keeping the language more or less the same.