### PR TITLE
`undef` is not a keyword

### DIFF
--- a/src/compiler/crystal/tools/doc/highlighter.cr
+++ b/src/compiler/crystal/tools/doc/highlighter.cr
@@ -69,7 +69,7 @@ module Crystal::Doc::Highlighter
                :lib, :fun, :type, :struct, :union, :enum, :macro, :out, :require,
                :case, :when, :select, :then, :of, :abstract, :rescue, :ensure, :is_a?,
                :alias, :pointerof, :sizeof, :instance_sizeof, :offsetof, :as, :as?, :typeof, :for, :in,
-               :undef, :with, :self, :super, :private, :asm, :nil?, :protected, :uninitialized, "new",
+               :with, :self, :super, :private, :asm, :nil?, :protected, :uninitialized, "new",
                :annotation, :verbatim
             highlight token, "k", io
           when :true, :false, :nil


### PR DESCRIPTION
`undef` is highlighted as keyword but it seems actually not a keyword of Crystal. This PR removes the highlight.

Relate to https://github.com/vim-crystal/vim-crystal/pull/110.