### PR TITLE
De-bump LLVM to v9 in Brewfile

### DIFF
--- a/Brewfile
+++ b/Brewfile
@@ -3,4 +3,4 @@ brew "libevent"
 brew "pcre"
 brew "pkg-config"
 brew "openssl@1.1"
-brew "llvm@10", link: true, conflicts_with: ["python@2"]
+brew "llvm@9", link: true, conflicts_with: ["python@2"]


### PR DESCRIPTION
Followup to #9829.

Btw, there's no `llvm@10` (right now).