### PR TITLE
Let offsetof pseudo-method support Tuples.

### DIFF
--- a/spec/compiler/codegen/offsetof_spec.cr
+++ b/spec/compiler/codegen/offsetof_spec.cr
@@ -32,4 +32,11 @@ describe "Code gen: offsetof" do
 
     run(code).to_b.should be_true
   end
+
+  it "returns offset allowing manual access of tuple items" do
+    code = "foo = {1, 2_i8, 3}
+            (pointerof(foo).as(Void*) + offsetof({Int32,Int8,Int32}, 2).to_i64).as(Int32*).value == 3"
+
+    run(code).to_b.should be_true
+  end
 end

--- a/spec/compiler/macro/macro_methods_spec.cr
+++ b/spec/compiler/macro/macro_methods_spec.cr
@@ -2151,8 +2151,8 @@ module Crystal
         assert_macro "x", %({{x.type}}), [OffsetOf.new("SomeType".path, "@some_ivar".instance_var)] of ASTNode, "SomeType"
       end
 
-      it "executes instance_var" do
-        assert_macro "x", %({{x.instance_var}}), [OffsetOf.new("SomeType".path, "@some_ivar".instance_var)] of ASTNode, "@some_ivar"
+      it "executes offset" do
+        assert_macro "x", %({{x.offset}}), [OffsetOf.new("SomeType".path, "@some_ivar".instance_var)] of ASTNode, "@some_ivar"
       end
     end
 

--- a/spec/compiler/parser/parser_spec.cr
+++ b/spec/compiler/parser/parser_spec.cr
@@ -971,6 +971,9 @@ module Crystal
     it_parses "sizeof(X)", SizeOf.new("X".path)
     it_parses "instance_sizeof(X)", InstanceSizeOf.new("X".path)
     it_parses "offsetof(X, @a)", OffsetOf.new("X".path, "@a".instance_var)
+    it_parses "offsetof(X, 1)", OffsetOf.new("X".path, 1.int32)
+    assert_syntax_error "offsetof(X, 1.0)", "expecting an integer offset, not '1.0'"
+    assert_syntax_error "offsetof(X, 'c')", "expecting an instance variable or a integer offset, not 'c'"
 
     it_parses "foo.is_a?(Const)", IsA.new("foo".call, "Const".path)
     it_parses "foo.is_a?(Foo | Bar)", IsA.new("foo".call, Crystal::Union.new(["Foo".path, "Bar".path] of ASTNode))
@@ -1889,6 +1892,7 @@ module Crystal
       assert_end_location "pointerof(@foo)"
       assert_end_location "sizeof(Foo)"
       assert_end_location "offsetof(Foo, @a)"
+      assert_end_location "offsetof({X, Y}, 1)"
       assert_end_location "typeof(1)"
       assert_end_location "1 if 2"
       assert_end_location "while 1; end"

--- a/spec/compiler/semantic/offsetof_spec.cr
+++ b/spec/compiler/semantic/offsetof_spec.cr
@@ -3,6 +3,7 @@ require "../../spec_helper"
 describe "Semantic: offsetof" do
   it "types offsetof" do
     assert_type("offsetof(String, @length)") { int32 }
+    assert_type("offsetof({Int32, Int32}, 1)") { int32 }
   end
 
   it "can be used with generic types" do
@@ -25,11 +26,28 @@ describe "Semantic: offsetof" do
     assert_error "offsetof(Int32, @foo)", "type Int32 can't have instance variables"
   end
 
-  it "gives error if using offsetof on something that's neither a class nor a struct" do
-    assert_error "module Foo; @a = 0; end; offsetof(Foo, @a)", "Foo is neither a class nor a struct, it's a module"
+  it "gives error if using offsetof on something that's neither a class, a struct nor a Tuple" do
+    assert_error "module Foo; @a = 0; end; offsetof(Foo, @a)", "Foo is neither a class, a struct nor a Tuple, it's a module"
   end
 
   it "errors on offsetof element of uninstantiated generic type" do
     assert_error "struct Foo(T); @a = 0; end; offsetof(Foo, @a)", "can't take offsetof element @a of uninstantiated generic type Foo(T)"
+  end
+
+  it "gives error if using offsetof on Tuples with negative indexes" do
+    assert_error "offsetof({Int32,UInt8}, -3)", "can't take a negative offset of a tuple"
+  end
+
+  it "gives error if using offsetof on Tuples with indexes greater than tuple size" do
+    assert_error "offsetof({Int32,UInt8}, 2)", "can't take offset element at index 2 from a tuple with 2 elements"
+    assert_error "offsetof({Int32,UInt8}, 3)", "can't take offset element at index 3 from a tuple with 2 elements"
+  end
+
+  it "gives error if using offsetof on Tuples with instance variables" do
+    assert_error "offsetof({Int32,UInt8}, @a)", "can't take offset of a tuple element using an instance variable, use an index"
+  end
+
+  it "gives error if using offsetof on non-Tuples with an index" do
+    assert_error "class Foo; @a = 0; end; offsetof(Foo, 0)", "can't take offset element of Foo using an index, use an instance variable"
   end
 end

--- a/src/compiler/crystal/macros.cr
+++ b/src/compiler/crystal/macros.cr
@@ -1257,8 +1257,8 @@ module Crystal::Macros
     def type : ASTNode
     end
 
-    # Returns the instance variable used in this `offsetof` expression.
-    def instance_var : ASTNode
+    # Returns the offset argument used in this `offsetof` expression.
+    def offset : ASTNode
     end
   end
 

--- a/src/compiler/crystal/macros/methods.cr
+++ b/src/compiler/crystal/macros/methods.cr
@@ -1442,8 +1442,8 @@ module Crystal
       case method
       when "type"
         interpret_argless_method(method, args) { @offsetof_type }
-      when "instance_var"
-        interpret_argless_method(method, args) { @instance_var }
+      when "offset"
+        interpret_argless_method(method, args) { @offset }
       else
         super
       end

--- a/src/compiler/crystal/syntax/ast.cr
+++ b/src/compiler/crystal/syntax/ast.cr
@@ -1092,21 +1092,21 @@ module Crystal
 
   class OffsetOf < ASTNode
     property offsetof_type : ASTNode
-    property instance_var : ASTNode
+    property offset : ASTNode
 
-    def initialize(@offsetof_type, @instance_var)
+    def initialize(@offsetof_type, @offset)
     end
 
     def accept_children(visitor)
       @offsetof_type.accept visitor
-      @instance_var.accept visitor
+      @offset.accept visitor
     end
 
     def clone_without_location
-      OffsetOf.new(@offsetof_type.clone, @instance_var.clone)
+      OffsetOf.new(@offsetof_type.clone, @offset.clone)
     end
 
-    def_equals_and_hash @offsetof_type, @instance_var
+    def_equals_and_hash @offsetof_type, @offset
   end
 
   class VisibilityModifier < ASTNode

--- a/src/compiler/crystal/syntax/to_s.cr
+++ b/src/compiler/crystal/syntax/to_s.cr
@@ -1284,7 +1284,7 @@ module Crystal
       @str << '('
       node.offsetof_type.accept(self)
       @str << ", "
-      node.instance_var.accept(self)
+      node.offset.accept(self)
       @str << ')'
       false
     end

--- a/src/compiler/crystal/syntax/transformer.cr
+++ b/src/compiler/crystal/syntax/transformer.cr
@@ -182,7 +182,7 @@ module Crystal
 
     def transform(node : OffsetOf)
       node.offsetof_type = node.offsetof_type.transform(self)
-      node.instance_var = node.instance_var.transform(self)
+      node.offset = node.offset.transform(self)
       node
     end
 

--- a/src/compiler/crystal/tools/formatter.cr
+++ b/src/compiler/crystal/tools/formatter.cr
@@ -3807,7 +3807,7 @@ module Crystal
     end
 
     def visit(node : OffsetOf)
-      visit Call.new(nil, "offsetof", [node.offsetof_type, node.instance_var])
+      visit Call.new(nil, "offsetof", [node.offsetof_type, node.offset])
     end
 
     def visit(node : PointerOf)

--- a/src/docs_pseudo_methods.cr
+++ b/src/docs_pseudo_methods.cr
@@ -78,14 +78,17 @@ end
 # Returns the byte offset of an instance variable in a struct or class type.
 #
 # *type* must be a constant or `typeof()` expression. It cannot be evaluated at runtime.
-# *variable*  must be the name of an instance variable of *type*, prefixed
-# by `@`.
+# *offset*  must be the name of an instance variable of *type*, prefixed by `@`,
+# or the index of an element in a Tuple, starting from 0, if *type* is a `Tuple`.
 # ```
-# offsetof(String, @bytesize)   # => 4
-# offsetof(Exception, @message) # => 8
-# offsetof(Time, @location)     # => 16
+# offsetof(String, @bytesize)       # => 4
+# offsetof(Exception, @message)     # => 8
+# offsetof(Time, @location)         # => 16
+# offsetof({Int32, Int8, Int32}, 0) # => 0
+# offsetof({Int32, Int8, Int32}, 1) # => 4
+# offsetof({Int32, Int8, Int32}, 2) # => 8
 # ```
-def __crystal_pseudo_offsetof(type : Class, variable) : Int32
+def __crystal_pseudo_offsetof(type : Class, offset) : Int32
 end
 
 class Object


### PR DESCRIPTION
For tuples, the index of the element should be used instead of a instance var.

Following up https://forum.crystal-lang.org/t/get-offset-of-a-tuple-item/2844/3