### PR TITLE
if I have installed an llvm-config that is newer than crystal yet sup…

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -55,7 +55,7 @@ ifeq ($(shell command -v ld.lld >/dev/null && uname -s),Linux)
 endif
 
 ifeq (${LLVM_CONFIG},)
-  $(error Could not locate llvm-config, or unrecognized version, make sure it is installed and in your PATH, or set LLVM_CONFIG)
+  $(error Could not locate compatible llvm-config, make sure it is installed and in your PATH, or set LLVM_CONFIG)
 else
   $(shell echo $(shell printf '\033[33m')Using $(LLVM_CONFIG) [version=$(shell $(LLVM_CONFIG) --version)]$(shell printf '\033[0m') >&2)
 endif

--- a/Makefile
+++ b/Makefile
@@ -55,7 +55,7 @@ ifeq ($(shell command -v ld.lld >/dev/null && uname -s),Linux)
 endif
 
 ifeq (${LLVM_CONFIG},)
-  $(error Could not locate llvm-config, make sure it is installed and in your PATH, or set LLVM_CONFIG)
+  $(error Could not locate llvm-config, or unrecognized version, make sure it is installed and in your PATH, or set LLVM_CONFIG)
 else
   $(shell echo $(shell printf '\033[33m')Using $(LLVM_CONFIG) [version=$(shell $(LLVM_CONFIG) --version)]$(shell printf '\033[0m') >&2)
 endif

--- a/Makefile
+++ b/Makefile
@@ -55,7 +55,7 @@ ifeq ($(shell command -v ld.lld >/dev/null && uname -s),Linux)
 endif
 
 ifeq (${LLVM_CONFIG},)
-  $(error Could not locate compatible llvm-config, make sure it is installed and in your PATH, or set LLVM_CONFIG)
+  $(error Could not locate compatible llvm-config, make sure it is installed and in your PATH, or set LLVM_CONFIG. Compatible versions are listed in src/llvm/ext/find-llvm-config)
 else
   $(shell echo $(shell printf '\033[33m')Using $(LLVM_CONFIG) [version=$(shell $(LLVM_CONFIG) --version)]$(shell printf '\033[0m') >&2)
 endif


### PR DESCRIPTION
…ports, it says 'Could not locate llvm-config' even though it can locate it, it's just the wrong version, attempt fix message