### PR TITLE
Compiler: only make `Pointer(T)#value=` stricter for generic arguments

### DIFF
--- a/spec/compiler/semantic/generic_class_spec.cr
+++ b/spec/compiler/semantic/generic_class_spec.cr
@@ -1161,4 +1161,19 @@ describe "Semantic: generic class" do
       T(*{Int32, Bool})
       )) { generic_class("T", int32, bool).metaclass }
   end
+
+  it "restricts generic type argument through alias in a non-strict way" do
+    assert_type(%(
+      class Gen(T)
+      end
+
+      alias G = Gen(String | Int32)
+
+      def foo(x : G)
+        x
+      end
+
+      foo(Gen(Int32).new)
+      )) { generic_class "Gen", int32 }
+  end
 end

--- a/spec/compiler/semantic/pointer_spec.cr
+++ b/spec/compiler/semantic/pointer_spec.cr
@@ -194,7 +194,7 @@ describe "Semantic: pointer" do
       ptr = Pointer(Gen(Char | Int32)).malloc(1_u64)
       ptr.value = Gen(Int32).new
       ),
-      "no overload matches 'Pointer(Gen(Char | Int32))#value=' with type Gen(Int32)"
+      "type must be Gen(Char | Int32), not Gen(Int32)"
   end
 
   it "errors with non-matching generic value with value=, generic type (#10211)" do
@@ -209,6 +209,6 @@ describe "Semantic: pointer" do
       ptr = Pointer(Moo(Char | Int32)).malloc(1_u64)
       ptr.value = Foo(Int32).new
       ),
-      "no overload matches 'Pointer(Moo(Char | Int32))#value=' with type Foo(Int32)"
+      "type must be Moo(Char | Int32), not Foo(Int32)"
   end
 end

--- a/src/compiler/crystal/semantic/call.cr
+++ b/src/compiler/crystal/semantic/call.cr
@@ -1058,7 +1058,7 @@ class Crystal::Call
       args["self"] = MetaVar.new("self", self_type)
     end
 
-    strict_check = body.is_a?(Primitive) && body.name == "proc_call"
+    strict_check = body.is_a?(Primitive) && (body.name == "proc_call" || body.name == "pointer_set")
 
     arg_types.each_index do |index|
       arg = typed_def.args[index]
@@ -1068,10 +1068,19 @@ class Crystal::Call
       args[arg.name] = var
 
       if strict_check
-        owner = owner.as(ProcInstanceType)
-        proc_arg_type = owner.arg_types[index]
-        unless type.covariant?(proc_arg_type)
-          self.args[index].raise "type must be #{proc_arg_type}, not #{type}"
+        case body.as(Primitive).name
+        when "proc_call"
+          owner = owner.as(ProcInstanceType)
+          proc_arg_type = owner.arg_types[index]
+          unless type.covariant?(proc_arg_type)
+            self.args[index].raise "type must be #{proc_arg_type}, not #{type}"
+          end
+        when "pointer_set"
+          owner = owner.as(PointerInstanceType)
+          pointer_type = owner.var.type
+          unless type.filter_by(pointer_type)
+            self.args[index].raise "type must be #{pointer_type}, not #{type}"
+          end
         end
       end
 

--- a/src/compiler/crystal/semantic/call.cr
+++ b/src/compiler/crystal/semantic/call.cr
@@ -1076,7 +1076,7 @@ class Crystal::Call
             self.args[index].raise "type must be #{proc_arg_type}, not #{type}"
           end
         when "pointer_set"
-          owner = owner.as(PointerInstanceType)
+          owner = owner.remove_typedef.as(PointerInstanceType)
           pointer_type = owner.var.type
           unless type.filter_by(pointer_type)
             self.args[index].raise "type must be #{pointer_type}, not #{type}"

--- a/src/compiler/crystal/semantic/restrictions.cr
+++ b/src/compiler/crystal/semantic/restrictions.cr
@@ -33,39 +33,39 @@ require "../types"
 
 module Crystal
   class ASTNode
-    def restriction_of?(other : Underscore, owner)
+    def restriction_of?(other : Underscore, owner, strict = false)
       true
     end
 
-    def restriction_of?(other : ASTNode, owner)
+    def restriction_of?(other : ASTNode, owner, strict = false)
       self == other
     end
 
-    def restriction_of?(other : Type, owner)
+    def restriction_of?(other : Type, owner, strict = false)
       false
     end
 
-    def restriction_of?(other, owner)
+    def restriction_of?(other, owner, strict = false)
       raise "BUG: called #{self}.restriction_of?(#{other})"
     end
   end
 
   class Self
-    def restriction_of?(type : Type, owner)
-      owner.restriction_of?(type, owner)
+    def restriction_of?(type : Type, owner, strict = false)
+      owner.restriction_of?(type, owner, strict)
     end
 
-    def restriction_of?(type : Self, owner)
+    def restriction_of?(type : Self, owner, strict = false)
       true
     end
 
-    def restriction_of?(type : ASTNode, owner)
+    def restriction_of?(type : ASTNode, owner, strict = false)
       false
     end
   end
 
   struct DefWithMetadata
-    def restriction_of?(other : DefWithMetadata, owner)
+    def restriction_of?(other : DefWithMetadata, owner, strict = false)
       # This is how multiple defs are sorted by 'restrictions' (?)
 
       # If one yields and the other doesn't, none is stricter than the other
@@ -108,7 +108,7 @@ module Crystal
           # If this is a splat arg and the other not, this is not stricter than the other
           return false if index == self.def.splat_index
 
-          return false unless self_type.restriction_of?(other_type, owner)
+          return false unless self_type.restriction_of?(other_type, owner, strict)
         end
       end
 
@@ -121,7 +121,7 @@ module Crystal
 
           if self_restriction && other_restriction
             # If both splat have restrictions, check which one is stricter
-            return false unless self_restriction.restriction_of?(other_restriction, owner)
+            return false unless self_restriction.restriction_of?(other_restriction, owner, strict)
           elsif self_restriction
             # If only self has a restriction, it's stricter than the other
             return true
@@ -155,7 +155,7 @@ module Crystal
           return false if self_restriction == nil && other_restriction != nil
 
           if self_restriction && other_restriction
-            return false unless self_restriction.restriction_of?(other_restriction, owner)
+            return false unless self_restriction.restriction_of?(other_restriction, owner, strict)
           end
         end
 
@@ -172,7 +172,7 @@ module Crystal
 
       # If both double splat have restrictions, check which one is stricter
       if self_double_splat_restriction && other_double_splat_restriction
-        return false unless self_double_splat_restriction.restriction_of?(other_double_splat_restriction, owner)
+        return false unless self_double_splat_restriction.restriction_of?(other_double_splat_restriction, owner, strict)
       elsif self_double_splat_restriction
         # If only self has a restriction, it's stricter than the other
         return true
@@ -231,14 +231,14 @@ module Crystal
   end
 
   class Path
-    def restriction_of?(other : Path, owner)
+    def restriction_of?(other : Path, owner, strict = false)
       return true if self == other
 
       self_type = owner.lookup_path(self)
       if self_type
         other_type = owner.lookup_path(other)
         if other_type
-          return self_type.restriction_of?(other_type, owner)
+          return self_type.restriction_of?(other_type, owner, strict)
         else
           return true
         end
@@ -247,17 +247,17 @@ module Crystal
       false
     end
 
-    def restriction_of?(other : Union, owner)
+    def restriction_of?(other : Union, owner, strict = false)
       # `true` if this type is a restriction of any type in the union
-      other.types.any? { |o| self.restriction_of?(o, owner) }
+      other.types.any? { |o| self.restriction_of?(o, owner, strict) }
     end
 
-    def restriction_of?(other : Generic, owner)
+    def restriction_of?(other : Generic, owner, strict = false)
       self_type = owner.lookup_path(self)
       if self_type
         other_type = owner.lookup_type?(other)
         if other_type
-          return self_type.restriction_of?(other_type, owner)
+          return self_type.restriction_of?(other_type, owner, strict)
         end
       end
 
@@ -271,23 +271,23 @@ module Crystal
       false
     end
 
-    def restriction_of?(other, owner)
+    def restriction_of?(other, owner, strict = false)
       false
     end
   end
 
   class Union
-    def restriction_of?(other : Path, owner)
+    def restriction_of?(other : Path, owner, strict = false)
       # For a union to be considered before a path,
       # all types in the union must be considered before
       # that path.
       # For example when using all subtypes of a parent type.
-      types.all? &.restriction_of?(other, owner)
+      types.all? &.restriction_of?(other, owner, strict)
     end
   end
 
   class Generic
-    def restriction_of?(other : Path, owner)
+    def restriction_of?(other : Path, owner, strict = false)
       # ```
       # def foo(param : Array(T)) forall T
       # end
@@ -302,7 +302,7 @@ module Crystal
       if self_type
         other_type = owner.lookup_path(other)
         if other_type
-          return self_type.restriction_of?(other_type, owner)
+          return self_type.restriction_of?(other_type, owner, strict)
         end
       end
 
@@ -322,12 +322,12 @@ module Crystal
       true
     end
 
-    def restriction_of?(other : Generic, owner)
+    def restriction_of?(other : Generic, owner, strict = false)
       return true if self == other
       return false unless name == other.name && type_vars.size == other.type_vars.size
 
       type_vars.zip(other.type_vars) do |type_var, other_type_var|
-        return false unless type_var.restriction_of?(other_type_var, owner)
+        return false unless type_var.restriction_of?(other_type_var, owner, strict)
       end
 
       true
@@ -335,7 +335,7 @@ module Crystal
   end
 
   class GenericClassType
-    def restriction_of?(other : GenericClassInstanceType, owner)
+    def restriction_of?(other : GenericClassInstanceType, owner, strict = false)
       # ```
       # def foo(param : Array)
       # end
@@ -353,7 +353,7 @@ module Crystal
   end
 
   class GenericClassInstanceType
-    def restriction_of?(other : GenericClassType, owner)
+    def restriction_of?(other : GenericClassType, owner, strict = false)
       # ```
       # def foo(param : Array(Int32))
       # end
@@ -371,11 +371,11 @@ module Crystal
   end
 
   class Metaclass
-    def restriction_of?(other : Metaclass, owner)
-      name.restriction_of?(other.name, owner)
+    def restriction_of?(other : Metaclass, owner, strict = false)
+      name.restriction_of?(other.name, owner, strict)
     end
 
-    def restriction_of?(other : Path, owner)
+    def restriction_of?(other : Path, owner, strict = false)
       other_type = owner.lookup_type(other)
 
       # Special case: when comparing Foo.class to Class, Foo.class has precedence
@@ -402,7 +402,7 @@ module Crystal
         return self
       end
 
-      if parents.try &.any? &.restriction_of?(other, context.instantiated_type)
+      if parents.try &.any? &.restriction_of?(other, context.instantiated_type, context.strict?)
         return self
       end
 
@@ -545,31 +545,31 @@ module Crystal
       raise "BUG: unsupported restriction: #{self} vs. #{other}"
     end
 
-    def restriction_of?(other : UnionType, owner)
-      other.union_types.any? { |subtype| restriction_of?(subtype, owner) }
+    def restriction_of?(other : UnionType, owner, strict = false)
+      other.union_types.any? { |subtype| restriction_of?(subtype, owner, strict) }
     end
 
-    def restriction_of?(other : VirtualType, owner)
+    def restriction_of?(other : VirtualType, owner, strict = false)
       implements? other.base_type
     end
 
-    def restriction_of?(other : Type, owner)
+    def restriction_of?(other : Type, owner, strict = false)
       if self == other
         return true
       end
 
-      parents.try &.any? &.restriction_of?(other, owner)
+      parents.try &.any? &.restriction_of?(other, owner, strict)
     end
 
-    def restriction_of?(other : AliasType, owner)
+    def restriction_of?(other : AliasType, owner, strict = false)
       if self == other
         true
       else
-        restriction_of?(other.remove_alias, owner)
+        restriction_of?(other.remove_alias, owner, strict)
       end
     end
 
-    def restriction_of?(other : ASTNode, owner)
+    def restriction_of?(other : ASTNode, owner, strict = false)
       raise "BUG: called #{self}.restriction_of?(#{other})"
     end
 
@@ -579,8 +579,8 @@ module Crystal
   end
 
   class UnionType
-    def restriction_of?(type, owner)
-      self == type || union_types.all? &.restriction_of?(type, owner)
+    def restriction_of?(type, owner, strict = false)
+      self == type || union_types.all? &.restriction_of?(type, owner, strict)
     end
 
     def restrict(other : Union, context)
@@ -626,18 +626,22 @@ module Crystal
   end
 
   class GenericInstanceType
-    def restriction_of?(other : GenericType, owner)
+    def restriction_of?(other : GenericType, owner, strict = false)
       return true if generic_type == other
       super
     end
 
-    def restriction_of?(other : GenericInstanceType, owner)
+    def restriction_of?(other : GenericInstanceType, owner, strict = false)
       return super unless generic_type == other.generic_type
 
       type_vars.each do |name, type_var|
         other_type_var = other.type_vars[name]
         if type_var.is_a?(Var) && other_type_var.is_a?(Var)
-          restricted = type_var.type == other_type_var.type
+          restricted = if strict
+                         type_var.type == other_type_var.type
+                       else
+                         type_var.type.implements?(other_type_var.type)
+                       end
           return nil unless restricted
         else
           return nil unless type_var == other_type_var
@@ -732,14 +736,14 @@ module Crystal
 
       type_vars.each do |name, type_var|
         other_type_var = other.type_vars[name]
-        restricted = restrict_type_var(type_var, other_type_var, context, strict: true)
+        restricted = restrict_type_var(type_var, other_type_var, context)
         return super unless restricted
       end
 
       self
     end
 
-    def restrict_type_var(type_var, other_type_var, context, strict = false)
+    def restrict_type_var(type_var, other_type_var, context)
       if type_var.is_a?(NumberLiteral)
         case other_type_var
         when NumberLiteral
@@ -772,8 +776,8 @@ module Crystal
       end
 
       if type_var.is_a?(ASTNode)
-        type_var.restriction_of?(other_type_var, context.instantiated_type)
-      elsif context.strict? || strict
+        type_var.restriction_of?(other_type_var, context.instantiated_type, context.strict?)
+      elsif context.strict?
         type_var == other_type_var
       else
         # To prevent infinite recursion, it checks equality between
@@ -785,7 +789,7 @@ module Crystal
   end
 
   class TupleInstanceType
-    def restriction_of?(other : TupleInstanceType, owner)
+    def restriction_of?(other : TupleInstanceType, owner, strict = false)
       return true if self == other || self.implements?(other)
 
       false
@@ -845,7 +849,7 @@ module Crystal
   end
 
   class NamedTupleInstanceType
-    def restriction_of?(other : NamedTupleInstanceType, owner)
+    def restriction_of?(other : NamedTupleInstanceType, owner, strict = false)
       return true if self == other || self.implements?(other)
 
       false
@@ -884,7 +888,7 @@ module Crystal
   end
 
   class VirtualType
-    def restriction_of?(other : Type, owner)
+    def restriction_of?(other : Type, owner, strict = false)
       other = other.base_type if other.is_a?(VirtualType)
       base_type.implements?(other) || other.implements?(base_type)
     end
@@ -959,10 +963,10 @@ module Crystal
   end
 
   class AliasType
-    def restriction_of?(other, owner)
+    def restriction_of?(other, owner, strict = false)
       return true if self == other
 
-      remove_alias.restriction_of?(other, owner)
+      remove_alias.restriction_of?(other, owner, strict)
     end
 
     def restrict(other : Path, context)
@@ -1044,8 +1048,8 @@ module Crystal
       restricted ? self : nil
     end
 
-    def restriction_of?(other : VirtualMetaclassType, owner)
-      restriction_of?(other.base_type.metaclass, owner)
+    def restriction_of?(other : VirtualMetaclassType, owner, strict = false)
+      restriction_of?(other.base_type.metaclass, owner, strict)
     end
   end
 


### PR DESCRIPTION
Alternative to #10214 (partially reverts that one)
Fixes #10211

This makes the compiler apply the logic of #10214 to only `Pointer(T)#value=`, preventing incorrect memory from being assigned. In every other case it will work as it used to work (in a more permissive way).

In a way, this is similar to how assigning `Array(Array(Int32))` to `Array(Array(String | Int32))` is invalid, but passing the former to a method that restricts it by the latter works. `Pointer(T)#value=` is like an assignment and it should be treated in a more strict way.