### PR TITLE
Support type var splats inside Tuple during generic parameter substitution

### DIFF
--- a/spec/compiler/semantic/generic_class_spec.cr
+++ b/spec/compiler/semantic/generic_class_spec.cr
@@ -714,6 +714,36 @@ describe "Semantic: generic class" do
       )) { tuple_of([int32, char]).metaclass }
   end
 
+  it "instantiates generic variadic class, accesses T from class method through superclass" do
+    assert_type(%(
+      class Foo(*T)
+        def self.t
+          T
+        end
+      end
+
+      class Bar(*T) < Foo(*T)
+      end
+
+      Bar(Int32, Char).t
+      )) { tuple_of([int32, char]).metaclass }
+  end
+
+  it "instantiates generic variadic class, accesses T from instance method through superclass" do
+    assert_type(%(
+      class Foo(*T)
+        def t
+          T
+        end
+      end
+
+      class Bar(*T) < Foo(*T)
+      end
+
+      Bar(Int32, Char).new.t
+      )) { tuple_of([int32, char]).metaclass }
+  end
+
   it "splats generic type var" do
     assert_type(%(
       class Foo(X, Y)
@@ -748,6 +778,21 @@ describe "Semantic: generic class" do
 
       Foo(Int32, Float64, Char).new.t
       )) { tuple_of([int32.metaclass, tuple_of([float64]).metaclass, char.metaclass]) }
+  end
+
+  it "instantiates generic variadic class, accesses T from instance method through superclass, more args" do
+    assert_type(%(
+      class Foo(A, *T, B)
+        def t
+          {A, T, B}
+        end
+      end
+
+      class Bar(*T) < Foo(String, *T, Float64)
+      end
+
+      Bar(Int32, Char).new.t
+      )) { tuple_of([string.metaclass, tuple_of([int32, char]).metaclass, float64.metaclass]) }
   end
 
   it "virtual metaclass type implements super virtual metaclass type (#3007)" do

--- a/spec/compiler/semantic/instance_var_spec.cr
+++ b/spec/compiler/semantic/instance_var_spec.cr
@@ -297,6 +297,60 @@ describe "Semantic: instance var" do
       )) { static_array_of(uint8, 3) }
   end
 
+  it "declares instance var of generic type, with splat" do
+    assert_type(%(
+      class Gen(*T)
+      end
+
+      class Foo(*T)
+        @x : Gen(*T)
+
+        def initialize(@x : Gen(*T))
+        end
+
+        def x
+          @x
+        end
+      end
+
+      Foo.new(Gen(Int32, String).new).x
+      )) { generic_class "Gen", int32, string }
+  end
+
+  it "declares instance var of generic type, with splat inside Tuple" do
+    assert_type(%(
+      class Foo(*T)
+        @x : Tuple(*T)
+
+        def initialize(@x : Tuple(*T))
+        end
+
+        def x
+          @x
+        end
+      end
+
+      Foo.new({1, ""}).x
+      )) { tuple_of([int32, string]) }
+  end
+
+  it "declares instance var of generic type, with splat inside Proc" do
+    assert_type(%(
+      class Foo(R, *T)
+        @x : Proc(*T, R)
+
+        def initialize(@x : Proc(*T, R))
+        end
+
+        def x
+          @x
+        end
+      end
+
+      Foo.new(->(x : Int32, y : String) { true }).x
+      )) { proc_of([int32, string, bool]) }
+  end
+
   it "declares instance var with self, on generic" do
     assert_type(%(
       class Foo(T)

--- a/spec/compiler/semantic/module_spec.cr
+++ b/spec/compiler/semantic/module_spec.cr
@@ -1191,7 +1191,7 @@ describe "Semantic: module" do
       )) { nilable int32 }
   end
 
-  it "declares and includes generic module" do
+  it "instantiates generic variadic module, accesses T from instance method" do
     assert_type(%(
       module Moo(*T)
         def t
@@ -1207,7 +1207,55 @@ describe "Semantic: module" do
       )) { tuple_of([int32, char]).metaclass }
   end
 
-  it "declares and includes generic module, more args" do
+  it "instantiates generic variadic module, accesses T from class method" do
+    assert_type(%(
+      module Moo(*T)
+        def t
+          T
+        end
+      end
+
+      class Foo
+        extend Moo(Int32, Char)
+      end
+
+      Foo.t
+      )) { tuple_of([int32, char]).metaclass }
+  end
+
+  it "instantiates generic variadic module, accesses T from instance method through generic include" do
+    assert_type(%(
+      module Moo(*T)
+        def t
+          T
+        end
+      end
+
+      class Foo(*T)
+        include Moo(*T)
+      end
+
+      Foo(Int32, Char).new.t
+      )) { tuple_of([int32, char]).metaclass }
+  end
+
+  it "instantiates generic variadic module, accesses T from class method through generic extend" do
+    assert_type(%(
+      module Moo(*T)
+        def t
+          T
+        end
+      end
+
+      class Foo(*T)
+        extend Moo(*T)
+      end
+
+      Foo(Int32, Char).t
+      )) { tuple_of([int32, char]).metaclass }
+  end
+
+  it "instantiates generic variadic module, accesses T from instance method, more args" do
     assert_type(%(
       module Moo(A, *T, B)
         def t
@@ -1220,6 +1268,22 @@ describe "Semantic: module" do
       end
 
       Foo.new.t
+      )) { tuple_of([int32.metaclass, tuple_of([float64, char]).metaclass, string.metaclass]) }
+  end
+
+  it "instantiates generic variadic module, accesses T from instance method through generic include, more args" do
+    assert_type(%(
+      module Moo(A, *T, B)
+        def t
+          {A, T, B}
+        end
+      end
+
+      class Foo(*T)
+        include Moo(Int32, *T, String)
+      end
+
+      Foo(Float64, Char).new.t
       )) { tuple_of([int32.metaclass, tuple_of([float64, char]).metaclass, string.metaclass]) }
   end
 

--- a/src/compiler/crystal/types.cr
+++ b/src/compiler/crystal/types.cr
@@ -2389,7 +2389,19 @@ module Crystal
     end
 
     def replace_type_parameters(instance)
-      new_tuple_types = tuple_types.map &.replace_type_parameters(instance)
+      new_tuple_types = [] of Type
+      tuple_types.each do |tuple_type|
+        if tuple_type.is_a?(TypeSplat)
+          type = tuple_type.splatted_type.replace_type_parameters(instance)
+          if type.is_a?(TupleInstanceType)
+            new_tuple_types.concat(type.tuple_types)
+          else
+            raise "expected type to be a tuple type, not #{type}"
+          end
+        else
+          new_tuple_types << tuple_type.replace_type_parameters(instance)
+        end
+      end
       program.tuple_of(new_tuple_types)
     end
 


### PR DESCRIPTION
Fixes #8520.

Consider the example from there:

```crystal
class Foo(R, *A)
  def initialize(@action : Proc(*A, R))
  end
end
 
Foo(String, Int32, Bool).new ->(a : Int32, b : Bool) { "foo" }
```

When `Foo(String, Int32, Bool)` is instantiated, the compiler requests the type of the `@action` instance variable; this must be a type, not an AST node. (Generic type splats inside AST nodes are already supported, so the type restriction of `#initialize` works as intended.) The compiler knows the following type parameter substitutions:

* `R` -> `String`
* `A` -> `Tuple(Int32, Bool)`

It then proceeds to perform type parameter substitution on `Proc(*A, R)`. The compiler also "instiantiates" an unbound `Crystal::GenericInstanceType` from this expression, even if the type arguments are not known in advance. This "type" has the following type vars:

* `T` (from `Proc`'s definition) -> `Tuple(*A)` (this `A` is from the outer `Foo`)
* `R` (from `Proc`'s definition) -> `R` (from the outer `Foo`)

The compiler doesn't know how to substitute `A` -> `Tuple(Int32, Bool)` into `Tuple(*A)`, as it previously assumes there are no type var splats inside an unbound `Tuple(...)` expression; this is what this PR implements. As `Crystal::TupleInstanceType` backs all generic type var splats, including ones in included/inherited types, this PR also makes the following possible:

```crystal
class C(*T)
  def foo
    T
  end
end

module M(*T)
  def bar
    T
  end
end

class Baz(*T) < C(*T, Int32)
  include M(String, *T)
end

x = Baz(Bool, Char).new
x.foo # Before: Tuple(*T, Int32)
      # After:  Tuple(Bool, Char, Int32)
x.bar # Before: Tuple(String, *T)
      # After:  Tuple(String, Bool, Char)

{% Baz(Bool, Char).ancestors %} # Before: [M(String, *T), C(*T, Int32), Reference, Object]
                                # After:  [M(String, Bool, Char), C(Bool, Char, Int32), Reference, Object]
```

The "more args" specs are written in such a way that splat expansions in unbound generic expressions always correspond to splat parameters in the generic definitions; see https://github.com/crystal-lang/crystal/issues/3649#issuecomment-757447288 for the rationale behind this.