### PR TITLE
Require type var splats in included/inherited generic to match splats in definition

### DIFF
--- a/spec/compiler/semantic/generic_class_spec.cr
+++ b/spec/compiler/semantic/generic_class_spec.cr
@@ -17,10 +17,65 @@ describe "Semantic: generic class" do
       class Foo(T)
       end
 
-      class Bar < Foo(A, B)
+      class Bar < Foo(Int32, String)
       end
       ),
       "wrong number of type vars for Foo(T) (given 2, expected 1)"
+  end
+
+  it "errors if inheriting from variadic generic and incorrect number of type vars" do
+    assert_error %(
+      class Foo(*T, U, V)
+      end
+
+      class Bar < Foo(Int32)
+      end
+      ),
+      "wrong number of type vars for Foo(*T, U, V) (given 1, expected 2+)"
+  end
+
+  it "errors if splatting type var into generic without splats" do
+    assert_error %(
+      class Foo(T)
+      end
+
+      class Bar(*T) < Foo(*T)
+      end
+      ),
+      "cannot splat *T into Foo(T)"
+  end
+
+  it "errors if splatting type var into non-splat parameter, before splat in definition" do
+    assert_error %(
+      class Foo(T, *U)
+      end
+
+      class Bar(*T) < Foo(*T, Int32)
+      end
+      ),
+      "cannot splat *T into non-splat type parameter T of Foo(T, *U)"
+  end
+
+  it "errors if splatting type var into non-splat parameter, after splat in definition" do
+    assert_error %(
+      class Foo(*T, U)
+      end
+
+      class Bar(*T) < Foo(Int32, *T)
+      end
+      ),
+      "cannot splat *T into non-splat type parameter U of Foo(*T, U)"
+  end
+
+  it "errors if splatting type var into non-splat parameter, more args" do
+    assert_error %(
+      class Foo(T, *U, V, W)
+      end
+
+      class Bar(T, U, *V, W) < Foo(V, U, T, W, *V, T)
+      end
+      ),
+      "cannot splat *V into non-splat type parameter V of Foo(T, *U, V, W)"
   end
 
   it "inherits from generic with instantiation" do

--- a/spec/compiler/semantic/module_spec.cr
+++ b/spec/compiler/semantic/module_spec.cr
@@ -89,7 +89,7 @@ describe "Semantic: module" do
       "Foo is not a generic type"
   end
 
-  it "includes module but wrong number of arguments" do
+  it "errors if including generic and incorrect number of type vars" do
     assert_error "
       module Foo(T, U)
       end
@@ -99,6 +99,66 @@ describe "Semantic: module" do
       end
       ",
       "wrong number of type vars for Foo(T, U) (given 1, expected 2)"
+  end
+
+  it "errors if including variadic generic and incorrect number of type vars" do
+    assert_error %(
+      module Foo(*T, U, V)
+      end
+
+      class Bar
+        include Foo(Int32)
+      end
+      ),
+      "wrong number of type vars for Foo(*T, U, V) (given 1, expected 2+)"
+  end
+
+  it "errors if splatting type var into generic without splats" do
+    assert_error %(
+      module Foo(T)
+      end
+
+      class Bar(*T)
+        include Foo(*T)
+      end
+      ),
+      "cannot splat *T into Foo(T)"
+  end
+
+  it "errors if splatting type var into non-splat parameter, before splat in definition" do
+    assert_error %(
+      module Foo(T, *U)
+      end
+
+      class Bar(*T)
+        include Foo(*T, Int32)
+      end
+      ),
+      "cannot splat *T into non-splat type parameter T of Foo(T, *U)"
+  end
+
+  it "errors if splatting type var into non-splat parameter, after splat in definition" do
+    assert_error %(
+      module Foo(*T, U)
+      end
+
+      class Bar(*T)
+        include Foo(Int32, *T)
+      end
+      ),
+      "cannot splat *T into non-splat type parameter U of Foo(*T, U)"
+  end
+
+  it "errors if splatting type var into non-splat parameter, more args" do
+    assert_error %(
+      module Foo(T, *U, V, W)
+      end
+
+      class Bar(T, U, *V, W)
+        include Foo(V, U, T, W, *V, T)
+      end
+      ),
+      "cannot splat *V into non-splat type parameter V of Foo(T, *U, V, W)"
   end
 
   it "includes generic module but wrong number of arguments 2" do

--- a/src/compiler/crystal/semantic/type_lookup.cr
+++ b/src/compiler/crystal/semantic/type_lookup.cr
@@ -200,23 +200,8 @@ class Crystal::Type
           node.raise "instantiating #{node}", inner: ex if @raise
         end
       when GenericType
-        if instance_type.splat_index
-          if node.named_args
-            node.raise "can only use named arguments with NamedTuple"
-          end
-
-          min_needed = instance_type.type_vars.size - 1
-          if node.type_vars.size < min_needed
-            node.wrong_number_of "type vars", instance_type, node.type_vars.size, "#{min_needed}+"
-          end
-        else
-          if node.named_args
-            node.raise "can only use named arguments with NamedTuple"
-          end
-
-          if instance_type.type_vars.size != node.type_vars.size
-            node.wrong_number_of "type vars", instance_type, node.type_vars.size, instance_type.type_vars.size
-          end
+        if node.named_args
+          node.raise "can only use named arguments with NamedTuple"
         end
       else
         node.raise "#{instance_type} is not a generic type, it's a #{instance_type.type_desc}"
@@ -277,6 +262,41 @@ class Crystal::Type
         end
 
         type_vars << type.virtual_type
+      end
+
+      splat_index = instance_type.splat_index
+      var_count = instance_type.type_vars.size
+
+      case {type_vars.any?(TypeSplat), splat_index}
+      in {true, Int32}
+        # node is `(A, B, C, *D, E)`, definition is `(T, *U, V, W)`; *D would splat into V
+        0.upto(splat_index - 1) do |index|
+          if (splat = type_vars[index]).is_a?(TypeSplat)
+            type_var = instance_type.type_vars[index]
+            node.raise "cannot splat #{splat} into non-splat type parameter #{type_var} of #{instance_type}"
+          end
+        end
+        (splat_index + 1).upto(var_count - 1) do |index|
+          if (splat = type_vars[index - var_count]).is_a?(TypeSplat)
+            type_var = instance_type.type_vars[index]
+            node.raise "cannot splat #{splat} into non-splat type parameter #{type_var} of #{instance_type}"
+          end
+        end
+      in {true, Nil}
+        # node is `(A, B, *C)`, definition is `(T)`; instantiation would always fail
+        splat = type_vars.find(&.is_a?(TypeSplat)).not_nil!
+        node.raise "cannot splat #{splat} into #{instance_type}"
+      in {false, Int32}
+        # node is `(A)`, definition is `(T, U, *V)`; instantiation would always fail
+        min_needed = var_count - 1
+        if type_vars.size < min_needed
+          node.wrong_number_of "type vars", instance_type, type_vars.size, "#{min_needed}+"
+        end
+      in {false, Nil}
+        # neither side contains splats; type var counts must be equal
+        if type_vars.size != var_count
+          node.wrong_number_of "type vars", instance_type, type_vars.size, var_count
+        end
       end
 
       begin

--- a/src/compiler/crystal/types.cr
+++ b/src/compiler/crystal/types.cr
@@ -1796,7 +1796,11 @@ module Crystal
       super
       if generic_args
         io << '('
-        type_vars.join(io, ", ", &.to_s(io))
+        type_vars.each_with_index do |type_var, i|
+          io << ", " if i > 0
+          io << '*' if i == splat_index
+          type_var.to_s(io)
+        end
         io << ')'
       end
     end
@@ -1856,7 +1860,11 @@ module Crystal
       super
       if generic_args
         io << '('
-        type_vars.join(io, ", ", &.to_s(io))
+        type_vars.each_with_index do |type_var, i|
+          io << ", " if i > 0
+          io << '*' if i == splat_index
+          type_var.to_s(io)
+        end
         io << ')'
       end
     end


### PR DESCRIPTION
Resolves #3649.

Given a generic definition and a generic inheritance (or include), there are 4 distinct cases to consider:

```crystal
class Foo(T, U); end
class Bar(A, B, C) < Foo(A, B); end    # okay
class Bar(A, B, C) < Foo(A, B, C); end # error
```

Neither the superclass expression nor the definition includes a splat. The number of type arguments must match exactly. This is already covered.

```crystal
class Foo(T, U, *V); end
class Bar(A, B) < Foo(A, B); end # okay
class Bar(A, B) < Foo(A); end    # error
```

The definition contains a splat, but the superclass expression doesn't. The number of type arguments must not be less than the number of non-splat type vars in the definition. This is also covered. (Note that the definition can only use at most one splat, but the superclass can use any number of splats, including splats of things other than type parameters.)

```crystal
class Foo(T, U); end
class Bar(*A) < Foo(*A); end       # error
class Bar(*A) < Foo(*A, *A); end   # error
class Bar(*A, B) < Foo(*A, B); end # error
```

If the definition doesn't use a splat, _any_ type var splat in the superclass expression now results in a compile-time error.

```crystal
class Foo(T, *U, V); end
class Bar(*A) < Foo(Int32, *A, Int32); end        # okay, *A splats into *U
class Bar(*A) < Foo(Int32, *A, Int32, Int32); end # okay, *A splats into *U
class Bar(*A) < Foo(Int32, *A, *A, Int32); end    # okay, *A and *A splat into *U
class Bar(*A) < Foo(*A, Int32, Int32); end        # error, *A splats into T
class Bar(*A) < Foo(Int32, *A); end               # error, *A splats into V
```

The definition has a splat, and at least one type var splat is also given in the superclass expression. If there are `m` type vars before the splat in `Foo`'s definition and `n` type vars after the splat, then the first `m` and the last `n` type arguments of any included/inherited `Foo` must not contain any type var splats. The remaining type arguments will be collected by the splat parameter.