### PR TITLE
Respect block arg restriction when given block has a splat parameter

### DIFF
--- a/spec/compiler/semantic/block_spec.cr
+++ b/spec/compiler/semantic/block_spec.cr
@@ -1250,7 +1250,7 @@ describe "Block inference" do
         {x, y, z, w}
       end
       ),
-      "too many block arguments (given 3+, expected maximum 1+)"
+      "too many block arguments (given 3+, expected maximum 1)"
   end
 
   it "errors if splat argument becomes a union" do
@@ -1442,5 +1442,37 @@ describe "Block inference" do
         typeof(bar)
       end
       ))
+  end
+
+  it "respects block arg restriction when block has a splat parameter (#6473)" do
+    assert_type(%(
+      def foo(&block : Int32 ->)
+        yield 1
+      end
+
+      def bar(x)
+        x
+      end
+
+      foo do |*x|
+        bar(*x)
+      end
+      )) { int32 }
+  end
+
+  it "respects block arg restriction when block has a splat parameter (2) (#9524)" do
+    assert_type(%(
+      def foo(&block : {Int32, Int32} ->)
+        yield({1, 2})
+      end
+
+      def bar(x)
+        x
+      end
+
+      foo do |*x|
+        bar(*x)
+      end
+      )) { tuple_of([int32, int32]) }
   end
 end

--- a/src/compiler/crystal/semantic/bindings.cr
+++ b/src/compiler/crystal/semantic/bindings.cr
@@ -735,6 +735,15 @@ module Crystal
         end
       end
 
+      if splat_index
+        # Error if there are less expressions than the number of block arguments
+        if exps_types.size < (args_size - 1)
+          block.raise "too many block arguments (given #{args_size - 1}+, expected maximum #{exps_types.size})"
+        end
+        splat_range = (splat_index..splat_index - args_size)
+        exps_types[splat_range] = @program.tuple_of(exps_types[splat_range])
+      end
+
       # Check if there are missing yield expressions to match
       # the (optional) block signature, and if they match the declared types
       if yield_vars
@@ -752,52 +761,24 @@ module Crystal
         end
       end
 
+      # Check if tuple unpacking is needed
+      if exps_types.size == 1 &&
+         (exp_type = exps_types.first).is_a?(TupleInstanceType) &&
+         args_size > 1 &&
+         !splat_index
+        exps_types = exp_type.tuple_types
+      end
+
       # Now move exps_types to block_arg_types
-      if splat_index
-        # Error if there are less expressions than the number of block arguments
-        if exps_types.size < (args_size - 1)
-          block.raise "too many block arguments (given #{args_size - 1}+, expected maximum #{exps_types.size}+)"
-        end
+      if block.args.size > exps_types.size
+        block.raise "too many block arguments (given #{block.args.size}, expected maximum #{exps_types.size})"
+      end
 
-        j = 0
-        args_size.times do |i|
-          types = block_arg_types[i] ||= [] of Type
-          if i == splat_index
-            tuple_types = exps_types[i, exps_types.size - (args_size - 1)]
-            types << @program.tuple_of(tuple_types)
-            j += tuple_types.size
-          else
-            types << exps_types[j]
-            j += 1
-          end
-        end
-      else
-        # Check if tuple unpacking is needed
-        if exps_types.size == 1 &&
-           (exp_type = exps_types.first).is_a?(TupleInstanceType) &&
-           args_size > 1
-          if block.args.size > exp_type.tuple_types.size
-            block.raise "too many block arguments (given #{block.args.size}, expected maximum #{exp_type.tuple_types.size})"
-          end
+      exps_types.each_with_index do |exp_type, i|
+        break if i >= block_arg_types.size
 
-          exp_type.tuple_types.each_with_index do |tuple_type, i|
-            break if i >= block_arg_types.size
-
-            types = block_arg_types[i] ||= [] of Type
-            types << tuple_type
-          end
-        else
-          if block.args.size > exps_types.size
-            block.raise "too many block arguments (given #{block.args.size}, expected maximum #{exps_types.size})"
-          end
-
-          exps_types.each_with_index do |exp_type, i|
-            break if i >= block_arg_types.size
-
-            types = block_arg_types[i] ||= [] of Type
-            types << exp_type
-          end
-        end
+        types = block_arg_types[i] ||= [] of Type
+        types << exp_type
       end
     end
 


### PR DESCRIPTION
Fixes #6473. Fixes #9524.

The reason this fails

```crystal
def yielding_method(&block : Int32 ->)
  yield 1
end

def call_it
  yielding_method do |*yield_args|
    yield *yield_args # Error: expected splat expression to be a tuple type, not Int32
  end
end

call_it {}
```

is because the type of `yield_args` is inferred from the block arg restriction (`Int32 ->`) instead of the individual yield expressions in `yielding_method` when the former is given, but that code path doesn't consider splat parameters in the given block, whereas type deduction from yields handles them. With the splat parameter, the block is still allowed to accept an `Int32`, but internally this type needs to be packed into a `Tuple(Int32)` for `yield_args` (this has nothing to do with auto-splatting, which doesn't occur whenever there is a splat parameter in the block).

The second yield is not actually required for this bug; forwarding the splat argument suffices:

```crystal
def foo(& : Int32 ->)
  yield 1
end

def bar(x)
end

foo do |*x|
  bar(*x)
end
```
