### PR TITLE
Optimize Indexable#sample(n, random)

### DIFF
--- a/spec/std/enumerable_spec.cr
+++ b/spec/std/enumerable_spec.cr
@@ -968,9 +968,8 @@ describe "Enumerable" do
       end
 
       it "samples k elements out of n, with random" do
-        a = (1..5)
-        b = a.sample(3, Random.new(1))
-        b.should eq([4, 3, 1])
+        (1..7).sample(3, Random.new(1)).should eq([3, 7, 4])
+        [1, 2, 3, 4, 5, 6, 7].sample(3, Random.new(1)).should eq([4, 6, 1])
       end
     end
   end

--- a/src/enumerable.cr
+++ b/src/enumerable.cr
@@ -1258,6 +1258,7 @@ module Enumerable(T)
     # https://en.wikipedia.org/wiki/Reservoir_sampling#Simple_algorithm
     # "Algorithm L" does not provide any performance improvements on Enumerable,
     # because it is not possible to discard multiple elements at once
+    # (this is done in Indexable)
 
     ary = Array(T).new(n)
     return ary if n == 0

--- a/src/random.cr
+++ b/src/random.cr
@@ -99,6 +99,12 @@ module Random
     next_float
   end
 
+  # :nodoc:
+  def rand_exclusive : Float64
+    max_prec = (1u64 << 53) - 1 # Float64, excluding mantissa, has 2^53 values
+    (rand(max_prec) + 1) / max_prec.to_f64
+  end
+
   # Generates a random integer which is greater than or equal to `0`
   # and less than *max*.
   #


### PR DESCRIPTION
Implements [*Algorithm L*](https://en.wikipedia.org/wiki/Reservoir_sampling#An_optimal_algorithm) for multiple-element sampling, which reduces the time complexity from `O(size)` to `O(k(1 + log(size / k)))`. This requires the ability to skip multiple elements at once, which is only doable in `Indexable` but not `Enumerable`.

I personally think we may expose `Random#rand_exclusive` later. It is required here because the algorithm will overflow if `#rand` returns exactly 0.0.