### PR TITLE
Escape HTML entities in doc comments

### DIFF
--- a/src/html.cr
+++ b/src/html.cr
@@ -83,7 +83,7 @@ module HTML
   # Returns a string where named and numeric character references
   # (e.g. &amp;gt;, &amp;#62;, &amp;#x3e;) in *string* are replaced with the corresponding
   # unicode characters. This method decodes all HTML5 entities including those
-  # without a trailing semicolon (such as `&amp;copy`).
+  # without a trailing semicolon (such as "&amp;copy").
   #
   # ```
   # require "html"

--- a/src/html.cr
+++ b/src/html.cr
@@ -81,9 +81,9 @@ module HTML
   }
 
   # Returns a string where named and numeric character references
-  # (e.g. &gt;, &#62;, &x3e;) in *string* are replaced with the corresponding
+  # (e.g. &amp;gt;, &amp;#62;, &amp;#x3e;) in *string* are replaced with the corresponding
   # unicode characters. This method decodes all HTML5 entities including those
-  # without a trailing semicolon (such as `&copy`).
+  # without a trailing semicolon (such as `&amp;copy`).
   #
   # ```
   # require "html"


### PR DESCRIPTION
The intention is to show their original form, but they get interpreted as HTML and the docs look weird/wrong:
https://crystal-lang.org/api/0.35.1/HTML.html#unescape(string:String):String-class-method