### PR TITLE
Support applying annotations on aliases and annotations

### DIFF
--- a/spec/compiler/codegen/warnings_spec.cr
+++ b/spec/compiler/codegen/warnings_spec.cr
@@ -137,7 +137,7 @@ describe "Code gen: warnings" do
       "warning in line 4\nWarning: Deprecated alias OtherType."
   end
 
-  pending "detects deprecated namespaced aliases" do
+  it "detects deprecated namespaced aliases" do
     assert_warning <<-CR,
       struct SomeType; end
 
@@ -148,7 +148,7 @@ describe "Code gen: warnings" do
 
       MyNamespace::OtherType.new
       CR
-      "warning in line 4\nWarning: Deprecated alias MyNamespace::OtherType."
+      "warning in line 5\nWarning: Deprecated alias MyNamespace::OtherType."
   end
 
   it "detects deprecated annotations" do
@@ -157,14 +157,14 @@ describe "Code gen: warnings" do
       annotation Foo; end
 
       @[Foo]
-      def bar ;end
+      def bar; end
 
       bar
       CR
       "warning in line 2\nWarning: Deprecated annotation Foo."
   end
 
-  pending "detects deprecated namespaced annotations" do
+  it "detects deprecated namespaced annotations" do
     assert_warning <<-CR,
       module MyNamespace
         @[Deprecated]
@@ -172,11 +172,11 @@ describe "Code gen: warnings" do
       end
 
       @[MyNamespace::Foo]
-      def bar ;end
+      def bar; end
 
       bar
       CR
-      "warning in line 2\nWarning: Deprecated annotation MyNamespace::Foo."
+      "warning in line 3\nWarning: Deprecated annotation MyNamespace::Foo."
   end
 
   it "informs warnings once per call site location (a)" do

--- a/spec/compiler/codegen/warnings_spec.cr
+++ b/spec/compiler/codegen/warnings_spec.cr
@@ -125,6 +125,60 @@ describe "Code gen: warnings" do
       "warning in line 7\nWarning: Deprecated Foo.new:a."
   end
 
+  it "detects deprecated aliases" do
+    assert_warning <<-CR,
+      struct SomeType; end
+
+      @[Deprecated]
+      alias OtherType = SomeType
+
+      OtherType.new
+      CR
+      "warning in line 4\nWarning: Deprecated alias OtherType."
+  end
+
+  pending "detects deprecated namespaced aliases" do
+    assert_warning <<-CR,
+      struct SomeType; end
+
+      module MyNamespace
+        @[Deprecated]
+        alias OtherType = SomeType
+      end
+
+      MyNamespace::OtherType.new
+      CR
+      "warning in line 4\nWarning: Deprecated alias MyNamespace::OtherType."
+  end
+
+  it "detects deprecated annotations" do
+    assert_warning <<-CR,
+      @[Deprecated]
+      annotation Foo; end
+
+      @[Foo]
+      def bar ;end
+
+      bar
+      CR
+      "warning in line 2\nWarning: Deprecated annotation Foo."
+  end
+
+  pending "detects deprecated namespaced annotations" do
+    assert_warning <<-CR,
+      module MyNamespace
+        @[Deprecated]
+        annotation Foo; end
+      end
+
+      @[MyNamespace::Foo]
+      def bar ;end
+
+      bar
+      CR
+      "warning in line 2\nWarning: Deprecated annotation MyNamespace::Foo."
+  end
+
   it "informs warnings once per call site location (a)" do
     warning_failures = warnings_result <<-CR
       class Foo

--- a/spec/compiler/semantic/warnings_spec.cr
+++ b/spec/compiler/semantic/warnings_spec.cr
@@ -137,7 +137,7 @@ describe "Semantic: warnings" do
       "warning in line 4\nWarning: Deprecated alias OtherType."
   end
 
-  pending "detects deprecated namespaced aliases" do
+  it "detects deprecated namespaced aliases" do
     assert_warning <<-CR,
       struct SomeType; end
 
@@ -148,7 +148,7 @@ describe "Semantic: warnings" do
 
       MyNamespace::OtherType.new
       CR
-      "warning in line 4\nWarning: Deprecated alias MyNamespace::OtherType."
+      "warning in line 5\nWarning: Deprecated alias MyNamespace::OtherType."
   end
 
   it "detects deprecated annotations" do
@@ -157,14 +157,14 @@ describe "Semantic: warnings" do
       annotation Foo; end
 
       @[Foo]
-      def bar ;end
+      def bar; end
 
       bar
       CR
       "warning in line 2\nWarning: Deprecated annotation Foo."
   end
 
-  pending "detects deprecated namespaced annotations" do
+  it "detects deprecated namespaced annotations" do
     assert_warning <<-CR,
       module MyNamespace
         @[Deprecated]
@@ -172,11 +172,11 @@ describe "Semantic: warnings" do
       end
 
       @[MyNamespace::Foo]
-      def bar ;end
+      def bar; end
 
       bar
       CR
-      "warning in line 2\nWarning: Deprecated annotation MyNamespace::Foo."
+      "warning in line 3\nWarning: Deprecated annotation MyNamespace::Foo."
   end
 
   it "informs warnings once per call site location (a)" do

--- a/spec/compiler/semantic/warnings_spec.cr
+++ b/spec/compiler/semantic/warnings_spec.cr
@@ -125,6 +125,60 @@ describe "Semantic: warnings" do
       "warning in line 7\nWarning: Deprecated Foo.new:a."
   end
 
+  it "detects deprecated aliases" do
+    assert_warning <<-CR,
+      struct SomeType; end
+
+      @[Deprecated]
+      alias OtherType = SomeType
+
+      OtherType.new
+      CR
+      "warning in line 4\nWarning: Deprecated alias OtherType."
+  end
+
+  pending "detects deprecated namespaced aliases" do
+    assert_warning <<-CR,
+      struct SomeType; end
+
+      module MyNamespace
+        @[Deprecated]
+        alias OtherType = SomeType
+      end
+
+      MyNamespace::OtherType.new
+      CR
+      "warning in line 4\nWarning: Deprecated alias MyNamespace::OtherType."
+  end
+
+  it "detects deprecated annotations" do
+    assert_warning <<-CR,
+      @[Deprecated]
+      annotation Foo; end
+
+      @[Foo]
+      def bar ;end
+
+      bar
+      CR
+      "warning in line 2\nWarning: Deprecated annotation Foo."
+  end
+
+  pending "detects deprecated namespaced annotations" do
+    assert_warning <<-CR,
+      module MyNamespace
+        @[Deprecated]
+        annotation Foo; end
+      end
+
+      @[MyNamespace::Foo]
+      def bar ;end
+
+      bar
+      CR
+      "warning in line 2\nWarning: Deprecated annotation MyNamespace::Foo."
+  end
+
   it "informs warnings once per call site location (a)" do
     warning_failures = warnings_result <<-CR
       class Foo

--- a/src/compiler/crystal/semantic/ast.cr
+++ b/src/compiler/crystal/semantic/ast.cr
@@ -657,7 +657,13 @@ module Crystal
   end
 
   class Alias
+    include Annotatable
+
     property! resolved_type : AliasType
+  end
+
+  class AnnotationDef
+    include Annotatable
   end
 
   class External < Def

--- a/src/compiler/crystal/semantic/ast.cr
+++ b/src/compiler/crystal/semantic/ast.cr
@@ -664,6 +664,8 @@ module Crystal
 
   class AnnotationDef
     include Annotatable
+
+    property! resolved_type : AnnotationType
   end
 
   class External < Def

--- a/src/compiler/crystal/semantic/cleanup_transformer.cr
+++ b/src/compiler/crystal/semantic/cleanup_transformer.cr
@@ -114,6 +114,18 @@ module Crystal
       {@last_is_truthy, @last_is_falsey}
     end
 
+    def transform(node : Alias)
+      @program.check_call_to_deprecated_alias node
+
+      node
+    end
+
+    def transform(node : AnnotationDef)
+      @program.check_call_to_deprecated_annotation node
+
+      node
+    end
+
     def transform(node : Def)
       node.hook_expansions.try &.map! &.transform self
       node

--- a/src/compiler/crystal/semantic/top_level_visitor.cr
+++ b/src/compiler/crystal/semantic/top_level_visitor.cr
@@ -275,6 +275,11 @@ class Crystal::TopLevelVisitor < Crystal::SemanticVisitor
   def visit(node : AnnotationDef)
     check_outside_exp node, "declare annotation"
 
+    annotations = read_annotations
+    process_annotations(annotations) do |annotation_type, ann|
+      node.add_annotation(annotation_type, ann)
+    end
+
     scope, name, type = lookup_type_def(node)
 
     if type
@@ -286,7 +291,7 @@ class Crystal::TopLevelVisitor < Crystal::SemanticVisitor
       scope.types[name] = type
     end
 
-    attach_doc type, node, annotations: nil
+    attach_doc type, node, annotations
 
     false
   end
@@ -295,6 +300,10 @@ class Crystal::TopLevelVisitor < Crystal::SemanticVisitor
     check_outside_exp node, "declare alias"
 
     annotations = read_annotations
+
+    process_annotations(annotations) do |annotation_type, ann|
+      node.add_annotation(annotation_type, ann)
+    end
 
     scope, name, existing_type = lookup_type_def(node)
 

--- a/src/compiler/crystal/semantic/top_level_visitor.cr
+++ b/src/compiler/crystal/semantic/top_level_visitor.cr
@@ -291,6 +291,8 @@ class Crystal::TopLevelVisitor < Crystal::SemanticVisitor
       scope.types[name] = type
     end
 
+    node.resolved_type = type
+
     attach_doc type, node, annotations
 
     false

--- a/src/compiler/crystal/semantic/warnings.cr
+++ b/src/compiler/crystal/semantic/warnings.cr
@@ -118,15 +118,13 @@ module Crystal
 
   class Alias
     def short_reference
-      # TODO: Define `#owner` on `self`.
-      "alias #{name}"
+      "alias #{resolved_type}"
     end
   end
 
   class AnnotationDef
     def short_reference
-      # TODO: Define `#owner` on `self`.
-      "annotation #{name}"
+      "annotation #{resolved_type}"
     end
   end
 

--- a/src/compiler/crystal/syntax/ast.cr
+++ b/src/compiler/crystal/syntax/ast.cr
@@ -1378,6 +1378,8 @@ module Crystal
   #     'end'
   #
   class AnnotationDef < ASTNode
+    include Annotatable
+
     property name : Path
     property doc : String?
     property name_location : Location?
@@ -1899,6 +1901,8 @@ module Crystal
   end
 
   class Alias < ASTNode
+    include Annotatable
+
     property name : Path
     property value : ASTNode
     property doc : String?

--- a/src/compiler/crystal/syntax/ast.cr
+++ b/src/compiler/crystal/syntax/ast.cr
@@ -1378,8 +1378,6 @@ module Crystal
   #     'end'
   #
   class AnnotationDef < ASTNode
-    include Annotatable
-
     property name : Path
     property doc : String?
     property name_location : Location?
@@ -1901,8 +1899,6 @@ module Crystal
   end
 
   class Alias < ASTNode
-    include Annotatable
-
     property name : Path
     property value : ASTNode
     property doc : String?


### PR DESCRIPTION
Resolves #10125.

This PR allows annotations to be applied to aliases and annotation defs.  I chose not to add new macro methods to access them as the main goal of this PR is to support the built in `@[Deprecated]` annotation, not custom ones.  I also refactored the warning logic to reduce the duplication given two new types of nodes were added.

One thing I'm not 100% on is how to display the FQN of the alias/annotation like methods/macros do.  From what I can tell an `owner` property would need to be added to both aliases and annotations.