### PR TITLE
DWARF: Disable GC around dl_iterate_phdr in freebsd

### DIFF
--- a/src/exception/call_stack/elf.cr
+++ b/src/exception/call_stack/elf.cr
@@ -9,7 +9,10 @@ struct Exception::CallStack
       1
     end
 
+    # GC needs to be disabled around dl_iterate_phdr in freebsd (#10084)
+    {% if flag?(:freebsd) %} GC.disable {% end %}
     LibC.dl_iterate_phdr(phdr_callback, nil)
+    {% if flag?(:freebsd) %} GC.enable {% end %}
   end
 
   protected def self.read_dwarf_sections(base_address = 0)


### PR DESCRIPTION
Fixes #10084. Prevents deadlock as shown in https://github.com/crystal-lang/crystal/issues/10084#issuecomment-761142066

I don't know if it's a good idea to disable it in every platform or in every bsd platform.