### PR TITLE
DWARF: Avoid loading dwarf if env var CRYSTAL_LOAD_DWARF=0

### DIFF
--- a/src/exception/call_stack/dwarf.cr
+++ b/src/exception/call_stack/dwarf.cr
@@ -15,7 +15,7 @@ struct Exception::CallStack
     unless @@dwarf_loaded
       @@dwarf_loaded = true
       begin
-        return if ENV["CRYSTAL_DWARF"]? == "0"
+        return if ENV["CRYSTAL_LOAD_DWARF"]? == "0"
         load_dwarf_impl
       rescue ex
         @@dwarf_line_numbers = nil

--- a/src/exception/call_stack/dwarf.cr
+++ b/src/exception/call_stack/dwarf.cr
@@ -15,6 +15,7 @@ struct Exception::CallStack
     unless @@dwarf_loaded
       @@dwarf_loaded = true
       begin
+        return if ENV["CRYSTAL_DWARF"]? == "0"
         load_dwarf_impl
       rescue ex
         @@dwarf_line_numbers = nil


### PR DESCRIPTION
This enables a workaround for future issues when loading dwarf. Ref: https://github.com/crystal-lang/crystal/issues/10084#issuecomment-761162716

The following program will look as 
```crystal
puts "hi"
raise "error"
```

```
$ ./baz
hi
Unhandled exception: error (Exception)
  from baz.cr:2:1 in '__crystal_main'
  from src/crystal/main.cr:105:5 in 'main_user_code'
  from src/crystal/main.cr:91:7 in 'main'
  from src/crystal/main.cr:114:3 in 'main'

$ CRYSTAL_DWARF=0 ./baz
hi
Unhandled exception: error (Exception)
  from Exception::CallStack::unwind:Array(Pointer(Void))
  from Exception::CallStack#initialize:Array(Pointer(Void))
  from Exception::CallStack::new:Exception::CallStack
  from raise<Exception>:NoReturn
  from raise<String>:NoReturn
  from __crystal_main
  from Crystal::main_user_code<Int32, Pointer(Pointer(UInt8))>:Nil
  from Crystal::main<Int32, Pointer(Pointer(UInt8))>:Int32
  from main
```