### PR TITLE
Align Proc.new(&block)'s behaviour with other captured blocks

### DIFF
--- a/spec/compiler/codegen/alias_spec.cr
+++ b/spec/compiler/codegen/alias_spec.cr
@@ -103,6 +103,12 @@ describe "Code gen: alias" do
 
   it "lazily solves aliases (#1346)" do
     run(%(
+      struct Proc
+        def self.new(&block : self)
+          block
+        end
+      end
+
       class Session; end
 
       alias CmdHandler = Proc(Session, Int32)

--- a/spec/compiler/codegen/proc_spec.cr
+++ b/spec/compiler/codegen/proc_spec.cr
@@ -393,6 +393,12 @@ describe "Code gen: proc" do
 
   it "does new on proc type" do
     run("
+      struct Proc
+        def self.new(&block : self)
+          block
+        end
+      end
+
       alias Func = Int32 -> Int32
 
       a = 2

--- a/spec/compiler/semantic/closure_spec.cr
+++ b/spec/compiler/semantic/closure_spec.cr
@@ -535,6 +535,24 @@ describe "Semantic: closure" do
       "can't send closure to C function (closured vars: a)"
   end
 
+  it "says can't send closure to C with captured block" do
+    assert_error %(
+      def capture(&block : -> Int32)
+        block
+      end
+
+      lib LibC
+        fun foo(x : ->)
+      end
+
+      a = 1
+      LibC.foo(capture do
+        a
+      end)
+      ),
+      "can't send closure to C function (closured vars: a)"
+  end
+
   it "doesn't crash for non-existing variable (#3789)" do
     assert_error %(
       lib LibFoo

--- a/spec/compiler/semantic/closure_spec.cr
+++ b/spec/compiler/semantic/closure_spec.cr
@@ -517,6 +517,12 @@ describe "Semantic: closure" do
 
   it "says can't send closure to C with new notation" do
     assert_error %(
+      struct Proc
+        def self.new(&block : self)
+          block
+        end
+      end
+
       lib LibC
         fun foo(x : ->)
       end

--- a/spec/compiler/semantic/proc_spec.cr
+++ b/spec/compiler/semantic/proc_spec.cr
@@ -344,6 +344,18 @@ describe "Semantic: proc" do
       ") { proc_of(int32, int32) }
   end
 
+  it "says cannot redefine new on proc type" do
+    assert_error "
+      struct Proc
+        def self.new(&block : self)
+        end
+      end
+
+      Proc(Int32, Int32).new { |x| x + 1 }
+      ",
+      "cannot redefine Proc(Int32, Int32).new(&block)"
+  end
+
   it "says wrong number of block args in new on proc type" do
     assert_error "
       #{proc_new}

--- a/spec/compiler/semantic/proc_spec.cr
+++ b/spec/compiler/semantic/proc_spec.cr
@@ -344,18 +344,6 @@ describe "Semantic: proc" do
       ") { proc_of(int32, int32) }
   end
 
-  it "says cannot redefine new on proc type" do
-    assert_error "
-      struct Proc
-        def self.new(&block : self)
-        end
-      end
-
-      Proc(Int32, Int32).new { |x| x + 1 }
-      ",
-      "cannot redefine Proc(Int32, Int32).new(&block)"
-  end
-
   it "says wrong number of block args in new on proc type" do
     assert_error "
       #{proc_new}

--- a/src/compiler/crystal/semantic/cleanup_transformer.cr
+++ b/src/compiler/crystal/semantic/cleanup_transformer.cr
@@ -510,6 +510,14 @@ module Crystal
         arg.expressions.each do |exp|
           check_arg_is_not_closure(node, message, exp)
         end
+      when Call
+        # detect closured vars in a call to Proc.new(&block)
+        if arg.name == "new" && (block = arg.block) && (obj_type = arg.obj.try &.type?)
+          instance_type = obj_type.instance_type.remove_typedef
+          if instance_type.is_a?(ProcInstanceType)
+            check_arg_is_not_closure(node, message, block.fun_literal)
+          end
+        end
       when ProcLiteral
         if proc_pointer = arg.proc_pointer
           case proc_pointer.obj

--- a/src/compiler/crystal/semantic/main_visitor.cr
+++ b/src/compiler/crystal/semantic/main_visitor.cr
@@ -1571,8 +1571,6 @@ module Crystal
 
       if node.name == "new"
         case instance_type
-        when ProcInstanceType
-          return special_proc_type_new_call(node, instance_type)
         when .extern?
           if instance_type.namespace.is_a?(LibType) && (named_args = node.named_args)
             return special_c_struct_or_union_new_with_named_args(node, instance_type, named_args)
@@ -1581,41 +1579,6 @@ module Crystal
       end
 
       false
-    end
-
-    def special_proc_type_new_call(node, proc_type)
-      if node.args.size != 0
-        return false
-      end
-
-      block = node.block
-      unless block
-        return false
-      end
-
-      if block.args.size > proc_type.arg_types.size
-        node.wrong_number_of "block arguments", "#{proc_type}#new", block.args.size, proc_type.arg_types.size
-      end
-
-      # We create a ->(...) { } from the block
-      proc_args = proc_type.arg_types.map_with_index do |arg_type, index|
-        block_arg = block.args[index]?
-        Arg.new(block_arg.try(&.name) || @program.new_temp_var_name, type: arg_type)
-      end
-
-      expected_return_type = proc_type.return_type
-      expected_return_type = @program.nil if expected_return_type.void?
-
-      proc_def = Def.new("->", proc_args, block.body).at(node)
-      proc_literal = ProcLiteral.new(proc_def).at(node)
-      proc_literal.expected_return_type = expected_return_type
-      proc_literal.force_nil = true if expected_return_type.nil_type?
-      proc_literal.accept self
-
-      node.bind_to proc_literal
-      node.expanded = proc_literal
-
-      true
     end
 
     # Rewrite:

--- a/src/proc.cr
+++ b/src/proc.cr
@@ -104,6 +104,23 @@ struct Proc
     ptr.value
   end
 
+  # Creates a `Proc` by capturing the given *block*.
+  #
+  # The block argument types are inferred from the `Proc`'s type arguments. The
+  # return type of the block must match the return type specified in the `Proc`
+  # type.
+  #
+  # ```
+  # gt = Proc(Int32, Int32, Bool).new do |x, y|
+  #   x > y
+  # end
+  # gt.call(3, 1) # => true
+  # gt.call(1, 2) # => false
+  # ```
+  def self.new(&block : self)
+    block
+  end
+
   # Returns a new `Proc` that has its first arguments fixed to
   # the values given by *args*.
   #


### PR DESCRIPTION
Defines `Proc.new(&block)` in the standard library instead of hard-coding its behaviour in the compiler, c.f. https://github.com/crystal-lang/crystal/issues/10001#issuecomment-735942599.

Resolves #9813. Although unconfirmed, this constructor should also benefit from #10251.

<strike>There is still compiler magic involving `Proc.new(&block)` in the cleanup transformer:

* Direct uses of this constructor inside a lib fun call, whether through an alias or not, still check for closured vars during compile-time. This is already done for `->` literals; the reason `Proc.new` used to work is because the compiler internally rewrote these calls to `->` literals.
* As per request, all definitions of `Proc.new(&block)` must match the standard library's definition exactly; that is, it must take only a block argument matching the `Proc`'s instantiated type, return that block, and do nothing else. This shouldn't affect any existing code since the constructor is definitely not meant to be redefined.</strike>

Additionally, the compiler will now check for closured vars in any captured block inside a lib fun call as long as the enclosing method returns the captured block and does nothing else. This applies for `Proc.new(&)`, but also cases like the following are detected:

```crystal
def capture(&block : -> Int32) # checked, body consists only of `block`
  block
end

lib LibC
  fun foo(x : ->)
end

a = 1
LibC.foo(capture do            # Error: can't send closure to C function (closured vars: a)
  a
end)
```

This means there is now far less compiler magic involving `Proc.new(&block)` (probably none after this PR).