### PR TITLE
Handle union restrictions with free vars properly

### DIFF
--- a/spec/compiler/semantic/def_overload_spec.cr
+++ b/spec/compiler/semantic/def_overload_spec.cr
@@ -626,6 +626,78 @@ describe "Semantic: def overload" do
       ") { int32.metaclass }
   end
 
+  it "matches a union argument with free var" do
+    each_union_variant("T", "Nil") do |restriction|
+      assert_type(%(
+        def foo(x : #{restriction}) forall T
+          T
+        end
+
+        {foo(1), foo(1 || nil)}
+        )) { tuple_of([int32.metaclass, int32.metaclass]) }
+    end
+  end
+
+  it "matches a union metaclass argument with free var (#8071)" do
+    each_union_variant("T", "Nil") do |restriction|
+      assert_type(%(
+        def foo(x : (#{restriction}).class) forall T
+          T
+        end
+
+        {foo(String), foo(String?)}
+        )) { tuple_of([string.metaclass, string.metaclass]) }
+    end
+  end
+
+  it "matches a union argument with free var, more types (1)" do
+    each_union_variant("T", "Nil") do |restriction|
+      assert_type(%(
+        def foo(x : #{restriction}) forall T
+          T
+        end
+
+        foo(1 || "" || nil)
+        )) { union_of(int32, string).metaclass }
+    end
+  end
+
+  it "matches a union argument with free var, more types (2)" do
+    each_union_variant("T", "(Int32 | String)") do |restriction|
+      assert_type(%(
+        def foo(x : #{restriction}) forall T
+          T
+        end
+
+        foo(1 || "" || 'a')
+        )) { char.metaclass }
+    end
+  end
+
+  it "errors if union restriction has multiple free vars" do
+    each_union_variant("T", "U") do |restriction|
+      assert_error "
+        def foo(x : #{restriction}) forall T, U
+        end
+
+        foo(1)
+        ",
+        "can't specify more than one free var in union restriction"
+    end
+  end
+
+  it "errors if union restriction has multiple free vars (2)" do
+    each_union_variant("T", "U") do |restriction|
+      assert_error "
+        def foo(x : #{restriction}) forall T, U
+        end
+
+        foo(1 || 'a')
+        ",
+        "can't specify more than one free var in union restriction"
+    end
+  end
+
   it "matches virtual type to union" do
     assert_type("
       abstract class Foo
@@ -960,4 +1032,13 @@ describe "Semantic: def overload" do
 			do_something value: 7.as(Int32 | Char)
 			)) { union_of float64, bool }
   end
+end
+
+private def each_union_variant(t1, t2)
+  yield "#{t1} | #{t2}"
+  yield "#{t2} | #{t1}"
+  # yield "Union(#{t1}, #{t2})"
+  # yield "Union(#{t2}, #{t1})"
+  yield "#{t1}?" if t2 == "Nil"
+  yield "#{t2}?" if t1 == "Nil" && t2 != "Nil"
 end

--- a/src/compiler/crystal/semantic/restrictions.cr
+++ b/src/compiler/crystal/semantic/restrictions.cr
@@ -461,6 +461,16 @@ module Crystal
     end
 
     def restrict(other : Union, context)
+      # Match all concrete types first
+      free_var_count = other.types.count do |other_type|
+        other_type.is_a?(Path) &&
+          other_type.names.size == 1 &&
+          context.has_def_free_var?(other_type.names.first)
+      end
+      if free_var_count > 1
+        other.raise "can't specify more than one free var in union restriction"
+      end
+
       types = other.types.compact_map do |ident|
         restrict(ident, context).as(Type?)
       end
@@ -623,9 +633,19 @@ module Crystal
     end
 
     def restrict(other : Union, context)
+      # Match all concrete types first
+      free_vars, other_types = other.types.partition do |other_type|
+        other_type.is_a?(Path) &&
+          other_type.names.size == 1 &&
+          context.has_def_free_var?(other_type.names.first)
+      end
+      if free_vars.size > 1
+        other.raise "can't specify more than one free var in union restriction"
+      end
+
       types = [] of Type
       discarded = [] of Type
-      other.types.each do |other_type|
+      other_types.each do |other_type|
         self.union_types.each do |type|
           next if discarded.includes?(type)
 
@@ -633,6 +653,23 @@ module Crystal
           if restricted
             types << restricted
             discarded << type
+          end
+        end
+      end
+
+      # If there is a free var, we match it last and it'll be the union of the
+      # remaining types in self
+      if free_var = free_vars.first?
+        # If we restrict `T` against `T | U forall U`, then `U` can be any type;
+        # the smallest type satisfying the restriction is Union() or NoReturn,
+        # but we don't want that, so we make this a substitution failure.
+        if discarded.size == self.union_types
+          return nil
+        end
+
+        if remaining_type = program.type_merge_union_of(self.union_types - discarded)
+          if restricted = remaining_type.restrict(free_var, context)
+            types << restricted
           end
         end
       end


### PR DESCRIPTION
Fixes #8071. The reason this fails:

```crystal
def foo(x : T | Nil) forall T
end

foo("" || nil)
```

```
Error: no overload matches 'foo' with type (String | Nil)

Overloads are:
 - foo(x : T | ::Nil)
Couldn't find overloads for these types:
 - foo(x : String)
```

is because the compiler tries to match the argument's union types (`String` and `Nil`) against the restriction's union types element by element, but these matches are performed in an unspecified order. For class types like `String`, the compiler matches `Nil` (from `nil`) against `T` before it tries to match `String` against `T`; since `T` is already instantiated, the call above becomes `foo(x : Nil | Nil)`. On the other hand, struct types are matched before `Nil` so the compiler doesn't fail.

This PR fixes it by matching argument union types against free vars only after other restriction union types have been matched. Thus, `String` and `Nil` will be matched against `Nil` first, and then against `T`. After the first pass, `Nil` satisfies `Nil`, which leaves only `String` for `T`.

More formally, when an argument of type `T` is matched against a restriction of type `U | V forall V`, where `T` and `U` are possibly unions, and `U` does not contain free vars, we deduce `V` to be `T - U`. That notation doesn't exist in the language, but is roughly equivalent to:

```crystal
typeof(begin
  x = uninitialized T
  raise "" if x.is_a?(U)
  x
end)
```

This has the exception that if `T <= U`, **the match now fails** since `V` can be any type, although it can be argued that `V` should be `Union()` or `NoReturn`:

```crystal
def foo(x : Int | V) forall V
end

# T = Int32, U = Int
foo(1) # Error: no overload matches
```

With this semantics, the following snippet now works after this PR (generally speaking, this means the free var may itself be a union):

```crystal
def f(x : Int32 | T) forall T
  T
end

# Before
f(1 || 'a' || "") # Error: no overload matches
# After
f(1 || 'a' || "") # => Char | String
```

A consequence of this change is that destructuring unions with free vars is no longer possible. However, this feature is rather confusing in the first place, especially for overload resolution purposes, due mostly to unions of virtual types in the same hierarchy not becoming another union type:

```crystal
def foo(x : T | U) forall T, U
  [T, U]
end

class Foo; end
class Bar < Foo; end
class Baz < Foo; end

# Before:
foo(1 || 'a')           # => [Char, Int32]
foo(Bar.new || Baz.new) # => [Foo, Foo]
# After:
foo(1 || 'a')           # Error: can't specify more than one free var in union restriction
foo(Bar.new || Baz.new) # Error: can't specify more than one free var in union restriction
```

The above will always be a compile-time error after this PR.

Explicit `Union`s will be addressed in a separate PR.