### PR TITLE
Fix build for LLVM 6.0

### DIFF
--- a/src/llvm.cr
+++ b/src/llvm.cr
@@ -84,7 +84,11 @@ module LLVM
   end
 
   def self.host_cpu_name : String
-    String.new LibLLVM.get_host_cpu_name
+    {% unless LibLLVM::IS_LT_70 %}
+      String.new LibLLVM.get_host_cpu_name
+    {% else %}
+      raise "LibLLVM.host_cpu_name requires LLVM 7.0 or newer"
+    {% end %}
   end
 
   def self.normalize_triple(triple : String)

--- a/src/llvm/lib_llvm.cr
+++ b/src/llvm/lib_llvm.cr
@@ -183,7 +183,9 @@ lib LibLLVM
   fun get_named_function = LLVMGetNamedFunction(mod : ModuleRef, name : UInt8*) : ValueRef
   fun get_named_global = LLVMGetNamedGlobal(mod : ModuleRef, name : UInt8*) : ValueRef
   fun get_count_params = LLVMCountParams(fn : ValueRef) : UInt
-  fun get_host_cpu_name = LLVMGetHostCPUName : UInt8*
+  {% unless LibLLVM::IS_LT_70 %}
+    fun get_host_cpu_name = LLVMGetHostCPUName : UInt8*
+  {% end %}
   fun get_param = LLVMGetParam(fn : ValueRef, index : Int32) : ValueRef
   fun get_param_types = LLVMGetParamTypes(function_type : TypeRef, dest : TypeRef*)
   fun get_params = LLVMGetParams(fn : ValueRef, params : ValueRef*)


### PR DESCRIPTION
LLVMGetHostCPUName which is used since #10264 is available since LLVM 7.0.

This PR will show a runtime exception is the compiler was built with older LLVM and `--mcpu native` is used.

