### PR TITLE
Update distribution-scripts

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -144,7 +144,7 @@ jobs:
       - run: |
           git clone https://github.com/crystal-lang/distribution-scripts.git ~/distribution-scripts
           cd ~/distribution-scripts
-          git checkout e1704da2a215264ea8e101eb15d4ec1baae98222
+          git checkout 80c83b203e1ee2fd54e41398160a67c6a06d34e1
       # persist relevant information for build process
       - run: |
           cd ~/distribution-scripts

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -526,8 +526,6 @@ workflows:
       #     filters: *per_tag
       - test_preview_mt:
           filters: *per_tag
-      - check_format:
-          filters: *per_tag
       - prepare_common:
           filters: *per_tag
       - prepare_tagged:
@@ -663,8 +661,6 @@ workflows:
       # - test_darwin: # See https://github.com/crystal-lang/crystal/pull/9763
       #     filters: *maintenance
       - test_preview_mt:
-          filters: *maintenance
-      - check_format:
           filters: *maintenance
       - prepare_common:
           filters: *maintenance


### PR DESCRIPTION
Use Shards 0.13.0

The check_format job was dropped in #10078 but some workflows still referenced it.