### PR TITLE
Improve error message for ELF reader on uninitialized runtime

### DIFF
--- a/src/crystal/elf.cr
+++ b/src/crystal/elf.cr
@@ -160,6 +160,25 @@ module Crystal
 
     private def read_magic
       @io.read(magic = Bytes.new(4))
+
+      if MAGIC.empty?
+        # If constant initialization is not working (for example when an
+        # error occurred during runtime setup or a custom main function doesn't
+        # do the initialization), continuing the ELF reader results in a
+        # seg fault. This condition detects the uninitialized constant and
+        # and errors.
+        # A simple program to reproduce is:
+        # ```
+        # module Crystal
+        #   def self.main(&block)
+        #     raise "foo"
+        #   end
+        # end
+        # ```
+        Crystal::System.print_error "Error: %s\n", "Runtime is not initialized"
+        LibC.exit 1
+      end
+
       raise Error.new("Invalid magic number") unless magic == MAGIC
     end
 


### PR DESCRIPTION
The ELF reader errors when runtime constants are not initialized.

With 0.35.1 compiler the sample code produces a segfault while reading ELF. With master compiler it errors with `Error while trying to dump the backtrace: Invalid magic number (Crystal::ELF::Error)`. That's nicer but misleading because the magic number is fine, it's just that runtime constants are not initialized.

Resolves #10088