### PR TITLE
Add iterable to CSV

### DIFF
--- a/spec/std/csv/csv_spec.cr
+++ b/spec/std/csv/csv_spec.cr
@@ -113,7 +113,7 @@ describe CSV do
     csv[0].should eq("one")
   end
 
-  it "each returns an iterable" do
+  it "each returns an iterator" do
     tuples = [] of {String, Int32}
     new_csv(headers: true).each.with_index{ |v, i| tuples << {v[0], i} }
     tuples.should eq([{"1", 0}, {"3", 1}, {"5", 2}])

--- a/spec/std/csv/csv_spec.cr
+++ b/spec/std/csv/csv_spec.cr
@@ -113,6 +113,12 @@ describe CSV do
     csv[0].should eq("one")
   end
 
+  it "each returns an iterable" do
+    tuples = [] of {String, Int32}
+    new_csv(headers: true).each.with_index{ |v, i| tuples << {v[0], i} }
+    tuples.should eq([{"1", 0}, {"3", 1}, {"5", 2}])
+  end
+
   it "can do each" do
     csv = new_csv headers: true
     csv.each do

--- a/spec/std/csv/csv_spec.cr
+++ b/spec/std/csv/csv_spec.cr
@@ -115,7 +115,7 @@ describe CSV do
 
   it "each returns an iterator" do
     tuples = [] of {String, Int32}
-    new_csv(headers: true).each.with_index{ |v, i| tuples << {v[0], i} }
+    new_csv(headers: true).each.with_index { |v, i| tuples << {v[0], i} }
     tuples.should eq([{"1", 0}, {"3", 1}, {"5", 2}])
   end
 

--- a/src/csv.cr
+++ b/src/csv.cr
@@ -56,6 +56,8 @@
 #
 # To create CSV data, check `CSV#build` and the `CSV::Builder` class.
 class CSV
+  include Iterator(CSV)
+
   DEFAULT_SEPARATOR  = ','
   DEFAULT_QUOTE_CHAR = '"'
 
@@ -208,7 +210,7 @@ class CSV
     @headers || raise(Error.new("Headers not requested"))
   end
 
-  # Invokes the block once for each row in this CSV, yielding `self`.
+  # Invokes the block once for each row in this CSV, yielding `nil`.
   def each : Nil
     while self.next
       yield self

--- a/src/csv.cr
+++ b/src/csv.cr
@@ -224,7 +224,7 @@ class CSV
   # CSV.new("zero\none\ntwo").each.with_index do |row, index|
   #   tuples << {row[0], index}
   # end
-  # tuples.to_a #=> [{"zero", 0}, {"one", 1}, {"two", 2}]
+  # tuples.to_a # => [{"zero", 0}, {"one", 1}, {"two", 2}]
   # ```
   def each
     RowIterator.new(self)

--- a/src/csv.cr
+++ b/src/csv.cr
@@ -56,7 +56,7 @@
 #
 # To create CSV data, check `CSV#build` and the `CSV::Builder` class.
 class CSV
-  include Iterator(CSV)
+  include Iterator(self)
 
   DEFAULT_SEPARATOR  = ','
   DEFAULT_QUOTE_CHAR = '"'


### PR DESCRIPTION
This enables the Iterator and Enumerable APIs on CSV.

Always updates the `CSV#each` documentation.