### PR TITLE
Fix touching directories on win32

### DIFF
--- a/spec/std/file_spec.cr
+++ b/spec/std/file_spec.cr
@@ -1180,7 +1180,7 @@ describe "File" do
     end
   end
 
-  describe "touch" do
+  describe ".touch" do
     it "creates file if it doesn't exist" do
       with_tempfile("touch-create.txt") do |path|
         File.exists?(path).should be_false
@@ -1212,6 +1212,36 @@ describe "File" do
       with_tempfile(File.join("nonexistent-dir", "touch.txt")) do |path|
         expect_raises(File::NotFoundError, "Error opening file with mode 'a': '#{path.inspect_unquoted}'") do
           File.touch(path)
+        end
+      end
+    end
+
+    describe "touches existing" do
+      it "file" do
+        with_tempfile("touch-file") do |path|
+          File.write(path, "")
+
+          File.touch(path, Time.utc(2021, 1, 23))
+          info = File.info(path)
+          info.modification_time.should eq Time.utc(2021, 1, 23)
+
+          File.touch(path)
+          info = File.info(path)
+          info.modification_time.should be_close(Time.utc, 1.second)
+        end
+      end
+
+      it "directory" do
+        with_tempfile("touch-directory") do |path|
+          Dir.mkdir(path)
+
+          File.touch(path, Time.utc(2021, 1, 23))
+          info = File.info(path)
+          info.modification_time.should eq Time.utc(2021, 1, 23)
+
+          File.touch(path)
+          info = File.info(path)
+          info.modification_time.should be_close(Time.utc, 1.second)
         end
       end
     end

--- a/src/crystal/system/win32/file.cr
+++ b/src/crystal/system/win32/file.cr
@@ -217,7 +217,7 @@ module Crystal::System::File
       LibC::FILE_SHARE_READ | LibC::FILE_SHARE_WRITE | LibC::FILE_SHARE_DELETE,
       nil,
       LibC::OPEN_EXISTING,
-      LibC::FILE_ATTRIBUTE_NORMAL,
+      LibC::FILE_FLAG_BACKUP_SEMANTICS,
       LibC::HANDLE.null
     )
     if handle == LibC::INVALID_HANDLE_VALUE


### PR DESCRIPTION
This patch fixes `File.touch` with a directory on win32 which currently errors with "Access is denied". To get a handle on a directory with `CreateFile`, the [`FILE_FLAG_BACKUP_SEMANTICS` flag needs to be set](https://docs.microsoft.com/en-us/windows/win32/fileio/obtaining-a-handle-to-a-directory).
The other place where such a handle is retrieved is in `File.info?` which already uses this flag.

Also adds specs for `File.touch` with existing file and directory.

cf. https://github.com/crystal-lang/shards/pull/467#issuecomment-765892131