### PR TITLE
Fix deprecated method shadowing

### DIFF
--- a/src/spec/expectations.cr
+++ b/src/spec/expectations.cr
@@ -503,14 +503,14 @@ module Spec
       end
     end
 
-    @[Deprecated("Use named arguments .should expectation, file: file, line: line")]
-    def should(expectation, file, line)
-      should(expectation, nil, file: file, line: line)
+    @[Deprecated("Use named arguments `.should(expectation, file: file, line: line)`")]
+    def should(expectation, _file, _line)
+      should(expectation, file: _file, line: _line)
     end
 
-    @[Deprecated("Use named arguments .should_not expectation, file: file, line: line")]
-    def should_not(expectation, file, line)
-      should_not(expectation, nil, file: file, line: line)
+    @[Deprecated("Use named arguments `.should_not(expectation, file: file, line: line)`")]
+    def should_not(expectation, _file, _line)
+      should_not(expectation, file: _file, line: _line)
     end
   end
 end


### PR DESCRIPTION
The deprecated defs override the non-deprecated ones when you use `file:` and `line:` as named arguments which results in an incorrect deprecation warning.