### PR TITLE
Quick fix for broken Int8#to_s

### DIFF
--- a/spec/std/int_spec.cr
+++ b/spec/std/int_spec.cr
@@ -194,7 +194,6 @@ describe "Int" do
     it { 97.to_s(62).should eq("1z") }
     it { 3843.to_s(62).should eq("ZZ") }
 
-
     it "Int8#to_s" do
       (60..105).map(&.to_i8.to_s).should eq (60..105).map(&.to_s)
       (60..105).map(&.to_u8.to_s).should eq (60..105).map(&.to_s)

--- a/spec/std/int_spec.cr
+++ b/spec/std/int_spec.cr
@@ -194,6 +194,12 @@ describe "Int" do
     it { 97.to_s(62).should eq("1z") }
     it { 3843.to_s(62).should eq("ZZ") }
 
+
+    it "Int8#to_s" do
+      (60..105).map(&.to_i8.to_s).should eq (60..105).map(&.to_s)
+      (60..105).map(&.to_u8.to_s).should eq (60..105).map(&.to_s)
+    end
+
     it "raises on base 1" do
       expect_raises(ArgumentError, "Invalid base 1") { 123.to_s(1) }
     end

--- a/src/int.cr
+++ b/src/int.cr
@@ -662,10 +662,12 @@ struct Int
 
     neg = num < 0
 
-    if base == 10
+    if base == 10 && !self.is_a?(Int8)
       # Optimization for `base == 10`.
       # The base idea is explained by "Three Optimization Tips for C++".
       # See https://www.slideshare.net/andreialexandrescu1/three-optimization-tips-for-c.
+      # FIXME: The optimization is broken for Int8, so use the unoptimized algorithm (https://github.com/crystal-lang/crystal/issues/10286)
+
       digits = DIGITS2.to_unsafe
 
       while num >= 100 || num <= -100


### PR DESCRIPTION
Quick fix for #10286 to use the unoptimized algorithm for `Int8#to_s`.