### PR TITLE
Fix i386 Fiber.swapcontext

### DIFF
--- a/src/fiber/context/i386.cr
+++ b/src/fiber/context/i386.cr
@@ -21,6 +21,8 @@ class Fiber
     {% if compare_versions(Crystal::LLVM_VERSION, "9.0.0") >= 0 %}
       #                %ecx           , %eax
       asm("
+      movl 8(%esp), %eax
+      movl 4(%esp), %ecx
       pushl %edi        // push 1st argument (because of initial resume)
       pushl %ebx        // push callee-saved registers on the stack
       pushl %ebp


### PR DESCRIPTION
Regression introduced by #9829

Before #9829 the asm emitted by `Fiber.swapcontext` was:

```asm
"*Fiber::swapcontext<Pointer(Fiber::Context), Pointer(Fiber::Context)>:Nil":
	.cfi_startproc
	movl	8(%esp), %eax
	movl	4(%esp), %ecx
	#APP

	pushl	%edi	# push 1st argument (because of initial resume)
	pushl	%ebx	# push callee-saved registers on the stack
	pushl	%ebp
	pushl	%esi
	movl	%esp, (%ecx)	# current_context.stack_top = %esp
	movl	$1, 4(%ecx)	# current_context.resumable = 1

	movl	$0, 4(%eax)	# new_context.resumable = 0
	movl	(%eax), %esp	# %esp = new_context.stack_top
	popl	%esi	# pop callee-saved registers from the stack
	popl	%ebp
	popl	%ebx
	popl	%edi	# pop first argument (for initial resume)

	#NO_APP
	retl
```

i386 is the only target that has this prelude in the swapcontext. It seems I didn't notice it before but test-ecosystem in 32 bits platforms was complaining.