### PR TITLE
Fix Number::StepIterator overflow

### DIFF
--- a/spec/std/number_spec.cr
+++ b/spec/std/number_spec.cr
@@ -301,32 +301,17 @@ describe "Number" do
     end
 
     describe "whole range" do
-      it "iterates UInt8 upwards" do
-        (UInt8::MIN..UInt8::MAX).each.count { true }.should eq(256)
-        (UInt8::MIN..UInt8::MAX).step(by: 1).each.count { true }.should eq(256)
-      end
+        it { (UInt8::MIN..UInt8::MAX).each.count { true }.should eq(256) }
+        it_iterates "UInt8 upwards", (UInt8::MIN.to_i..UInt8::MAX.to_i).map(&.to_u8), (UInt8::MIN..UInt8::MAX).step(by: 1)
+        it_iterates "UInt8 downwards", (UInt8::MIN.to_i..UInt8::MAX.to_i).map(&.to_u8).reverse, (UInt8::MAX..UInt8::MIN).step(by: -1)
 
-      it "iterates UInt8 downwards" do
-        (UInt8::MAX..UInt8::MIN).step(by: -1).each.count { true }.should eq(256)
-      end
+        it { (Int8::MIN..Int8::MAX).each.count { true }.should eq(256) }
+        it_iterates "Int8 upwards", (Int8::MIN.to_i..Int8::MAX.to_i).map(&.to_i8), (Int8::MIN..Int8::MAX).step(by: 1)
+        it_iterates "Int8 downwards", (Int8::MIN.to_i..Int8::MAX.to_i).map(&.to_i8).reverse, (Int8::MAX..Int8::MIN).step(by: -1)
 
-      it "iterates Int8 upwards" do
-        (Int8::MIN..Int8::MAX).each.count { true }.should eq(256)
-        (Int8::MIN..Int8::MAX).step(by: 1).each.count { true }.should eq(256)
-      end
-
-      it "iterates Int8 downwards" do
-        (Int8::MAX..Int8::MIN).step(by: -1).each.count { true }.should eq(256)
-      end
-
-      it "iterates Int16 upwards" do
-        (Int16::MIN..Int16::MAX).each.count { true }.should eq(65536)
-        (Int16::MIN..Int16::MAX).step(by: 1).each.count { true }.should eq(65536)
-      end
-
-      it "iterates Int16 downwards" do
-        (Int16::MAX..Int16::MIN).step(by: -1).each.count { true }.should eq(65536)
-      end
+        it { (Int16::MIN..Int16::MAX).each.count { true }.should eq(65536) }
+        it_iterates "Int16 upwards", (Int16::MIN.to_i..Int16::MAX.to_i).map(&.to_i16), (Int16::MIN..Int16::MAX).step(by: 1)
+        it_iterates "Int16 downwards", (Int16::MIN.to_i..Int16::MAX.to_i).map(&.to_i16).reverse, (Int16::MAX..Int16::MIN).step(by: -1)
     end
 
     it_iterates "towards limit [max-4, max-2, max]", [Int32::MAX - 4, Int32::MAX - 2, Int32::MAX], (Int32::MAX - 4).step(to: Int32::MAX, by: 2)

--- a/spec/std/number_spec.cr
+++ b/spec/std/number_spec.cr
@@ -301,17 +301,17 @@ describe "Number" do
     end
 
     describe "whole range" do
-        it { (UInt8::MIN..UInt8::MAX).each.count { true }.should eq(256) }
-        it_iterates "UInt8 upwards", (UInt8::MIN.to_i..UInt8::MAX.to_i).map(&.to_u8), (UInt8::MIN..UInt8::MAX).step(by: 1)
-        it_iterates "UInt8 downwards", (UInt8::MIN.to_i..UInt8::MAX.to_i).map(&.to_u8).reverse, (UInt8::MAX..UInt8::MIN).step(by: -1)
+      it { (UInt8::MIN..UInt8::MAX).each.count { true }.should eq(256) }
+      it_iterates "UInt8 upwards", (UInt8::MIN.to_i..UInt8::MAX.to_i).map(&.to_u8), (UInt8::MIN..UInt8::MAX).step(by: 1)
+      it_iterates "UInt8 downwards", (UInt8::MIN.to_i..UInt8::MAX.to_i).map(&.to_u8).reverse, (UInt8::MAX..UInt8::MIN).step(by: -1)
 
-        it { (Int8::MIN..Int8::MAX).each.count { true }.should eq(256) }
-        it_iterates "Int8 upwards", (Int8::MIN.to_i..Int8::MAX.to_i).map(&.to_i8), (Int8::MIN..Int8::MAX).step(by: 1)
-        it_iterates "Int8 downwards", (Int8::MIN.to_i..Int8::MAX.to_i).map(&.to_i8).reverse, (Int8::MAX..Int8::MIN).step(by: -1)
+      it { (Int8::MIN..Int8::MAX).each.count { true }.should eq(256) }
+      it_iterates "Int8 upwards", (Int8::MIN.to_i..Int8::MAX.to_i).map(&.to_i8), (Int8::MIN..Int8::MAX).step(by: 1)
+      it_iterates "Int8 downwards", (Int8::MIN.to_i..Int8::MAX.to_i).map(&.to_i8).reverse, (Int8::MAX..Int8::MIN).step(by: -1)
 
-        it { (Int16::MIN..Int16::MAX).each.count { true }.should eq(65536) }
-        it_iterates "Int16 upwards", (Int16::MIN.to_i..Int16::MAX.to_i).map(&.to_i16), (Int16::MIN..Int16::MAX).step(by: 1)
-        it_iterates "Int16 downwards", (Int16::MIN.to_i..Int16::MAX.to_i).map(&.to_i16).reverse, (Int16::MAX..Int16::MIN).step(by: -1)
+      it { (Int16::MIN..Int16::MAX).each.count { true }.should eq(65536) }
+      it_iterates "Int16 upwards", (Int16::MIN.to_i..Int16::MAX.to_i).map(&.to_i16), (Int16::MIN..Int16::MAX).step(by: 1)
+      it_iterates "Int16 downwards", (Int16::MIN.to_i..Int16::MAX.to_i).map(&.to_i16).reverse, (Int16::MAX..Int16::MIN).step(by: -1)
     end
 
     it_iterates "towards limit [max-4, max-2, max]", [Int32::MAX - 4, Int32::MAX - 2, Int32::MAX], (Int32::MAX - 4).step(to: Int32::MAX, by: 2)

--- a/spec/std/number_spec.cr
+++ b/spec/std/number_spec.cr
@@ -299,6 +299,39 @@ describe "Number" do
         end
       end
     end
+
+    describe "whole range" do
+      it "iterates UInt8 upwards" do
+        (UInt8::MIN..UInt8::MAX).each.count { true }.should eq(256)
+        (UInt8::MIN..UInt8::MAX).step(by: 1).each.count { true }.should eq(256)
+      end
+
+      it "iterates UInt8 downwards" do
+        (UInt8::MAX..UInt8::MIN).step(by: -1).each.count { true }.should eq(256)
+      end
+
+      it "iterates Int8 upwards" do
+        (Int8::MIN..Int8::MAX).each.count { true }.should eq(256)
+        (Int8::MIN..Int8::MAX).step(by: 1).each.count { true }.should eq(256)
+      end
+
+      it "iterates Int8 downwards" do
+        (Int8::MAX..Int8::MIN).step(by: -1).each.count { true }.should eq(256)
+      end
+
+      it "iterates Int16 upwards" do
+        (Int16::MIN..Int16::MAX).each.count { true }.should eq(65536)
+        (Int16::MIN..Int16::MAX).step(by: 1).each.count { true }.should eq(65536)
+      end
+
+      it "iterates Int16 downwards" do
+        (Int16::MAX..Int16::MIN).step(by: -1).each.count { true }.should eq(65536)
+      end
+    end
+
+    it_iterates "towards limit [max-4, max-2, max]", [Int32::MAX - 4, Int32::MAX - 2, Int32::MAX], (Int32::MAX - 4).step(to: Int32::MAX, by: 2)
+    it_iterates "towards limit [max-4, max-2, max)", [Int32::MAX - 4, Int32::MAX - 2], (Int32::MAX - 4).step(to: Int32::MAX, by: 2, exclusive: true)
+    it_iterates "towards limit [max-3, max-1, max)", [Int32::MAX - 3, Int32::MAX - 1], (Int32::MAX - 3).step(to: Int32::MAX, by: 2)
   end
 
   floor_division_returns_lhs_type {{BUILTIN_NUMBER_TYPES}}, {{BUILTIN_NUMBER_TYPES}}

--- a/src/number.cr
+++ b/src/number.cr
@@ -168,7 +168,7 @@ struct Number
       while true
         # only proceed if difference to limit is at least as big as step size to
         # avoid potential overflow errors.
-        sign = ((limit - current) <=> step).try(&.sign)
+        sign = ((limit - step) <=> current).try(&.sign)
         break unless sign == direction || (sign == 0 && !exclusive)
 
         current += step
@@ -246,14 +246,11 @@ struct Number
         @current
       elsif limit
         # compare distance to current with step size
-        direction = @step.sign
-        current = @current
-
-        if (current < limit && direction == 1 && current < limit - @step) ||
-           (limit < current && direction == -1 && limit - @step < current)
+        case ((limit - @step) <=> @current).try(&.sign)
+        when @step.sign
+          # distance is more than step size, so iteration proceeds
           @current += @step
-        elsif (current < limit && direction == 1 && current == limit - @step) ||
-              (limit < current && direction == -1 && limit - @step == current)
+        when 0
           # distance is exactly step size, so we're at the end
           @reached_end = true
           if @exclusive

--- a/src/number.cr
+++ b/src/number.cr
@@ -246,11 +246,14 @@ struct Number
         @current
       elsif limit
         # compare distance to current with step size
-        case (limit - @current <=> @step).try(&.sign)
-        when @step.sign
-          # distance is more than step size, so iteration proceeds
+        direction = @step.sign
+        current = @current
+
+        if (current < limit && direction == 1 && current < limit - @step) ||
+           (limit < current && direction == -1 && limit - @step < current)
           @current += @step
-        when 0
+        elsif (current < limit && direction == 1 && current == limit - @step) ||
+              (limit < current && direction == -1 && limit - @step == current)
           # distance is exactly step size, so we're at the end
           @reached_end = true
           if @exclusive
@@ -262,7 +265,6 @@ struct Number
           # we've either overshot the limit or the comparison failed, so we can't
           # continue
           @reached_end = true
-
           stop
         end
       else


### PR DESCRIPTION
Before this PR the `Number::StepIterator#next` could raise because of `limit - @current` 
Fixes a regression introduced in #10130

```
Failures:

  1) Number #step whole range iterates UInt8 downwards

       Arithmetic overflow (OverflowError)
         from src/number.cr:249:21 in 'next'
         from src/iterator.cr:488:15 in '->'
         from src/primitives.cr:255:3 in 'internal_run'
         from src/spec/example.cr:33:16 in 'run'
         from src/spec/context.cr:18:23 in 'internal_run'
         from src/spec/context.cr:330:7 in 'run'
         from src/spec/context.cr:18:23 in 'internal_run'
         from src/spec/context.cr:330:7 in 'run'
         from src/spec/context.cr:18:23 in 'internal_run'
         from src/spec/context.cr:330:7 in 'run'
         from src/spec/context.cr:18:23 in 'internal_run'
         from src/spec/context.cr:147:7 in 'run'
         from src/spec/dsl.cr:274:7 in '->'
         from src/primitives.cr:255:3 in 'run'
         from src/crystal/main.cr:45:14 in 'main'
         from src/crystal/main.cr:119:3 in 'main'
       

  2) Number #step whole range iterates Int8 upwards

       Arithmetic overflow (OverflowError)
         from src/number.cr:249:21 in 'next'
         from src/iterator.cr:488:15 in '->'
         from src/primitives.cr:255:3 in 'internal_run'
         from src/spec/example.cr:33:16 in 'run'
         from src/spec/context.cr:18:23 in 'internal_run'
         from src/spec/context.cr:330:7 in 'run'
         from src/spec/context.cr:18:23 in 'internal_run'
         from src/spec/context.cr:330:7 in 'run'
         from src/spec/context.cr:18:23 in 'internal_run'
         from src/spec/context.cr:330:7 in 'run'
         from src/spec/context.cr:18:23 in 'internal_run'
         from src/spec/context.cr:147:7 in 'run'
         from src/spec/dsl.cr:274:7 in '->'
         from src/primitives.cr:255:3 in 'run'
         from src/crystal/main.cr:45:14 in 'main'
         from src/crystal/main.cr:119:3 in 'main'
       

  3) Number #step whole range iterates Int8 downwards

       Arithmetic overflow (OverflowError)
         from src/number.cr:249:21 in 'next'
         from src/iterator.cr:488:15 in '->'
         from src/primitives.cr:255:3 in 'internal_run'
         from src/spec/example.cr:33:16 in 'run'
         from src/spec/context.cr:18:23 in 'internal_run'
         from src/spec/context.cr:330:7 in 'run'
         from src/spec/context.cr:18:23 in 'internal_run'
         from src/spec/context.cr:330:7 in 'run'
         from src/spec/context.cr:18:23 in 'internal_run'
         from src/spec/context.cr:330:7 in 'run'
         from src/spec/context.cr:18:23 in 'internal_run'
         from src/spec/context.cr:147:7 in 'run'
         from src/spec/dsl.cr:274:7 in '->'
         from src/primitives.cr:255:3 in 'run'
         from src/crystal/main.cr:45:14 in 'main'
         from src/crystal/main.cr:119:3 in 'main'
       

  4) Number #step whole range iterates Int16 upwards

       Arithmetic overflow (OverflowError)
         from src/number.cr:249:21 in 'next'
         from src/iterator.cr:488:15 in '->'
         from src/primitives.cr:255:3 in 'internal_run'
         from src/spec/example.cr:33:16 in 'run'
         from src/spec/context.cr:18:23 in 'internal_run'
         from src/spec/context.cr:330:7 in 'run'
         from src/spec/context.cr:18:23 in 'internal_run'
         from src/spec/context.cr:330:7 in 'run'
         from src/spec/context.cr:18:23 in 'internal_run'
         from src/spec/context.cr:330:7 in 'run'
         from src/spec/context.cr:18:23 in 'internal_run'
         from src/spec/context.cr:147:7 in 'run'
         from src/spec/dsl.cr:274:7 in '->'
         from src/primitives.cr:255:3 in 'run'
         from src/crystal/main.cr:45:14 in 'main'
         from src/crystal/main.cr:119:3 in 'main'
       

  5) Number #step whole range iterates Int16 downwards

       Arithmetic overflow (OverflowError)
         from src/number.cr:249:21 in 'next'
         from src/iterator.cr:488:15 in '->'
         from src/primitives.cr:255:3 in 'internal_run'
         from src/spec/example.cr:33:16 in 'run'
         from src/spec/context.cr:18:23 in 'internal_run'
         from src/spec/context.cr:330:7 in 'run'
         from src/spec/context.cr:18:23 in 'internal_run'
         from src/spec/context.cr:330:7 in 'run'
         from src/spec/context.cr:18:23 in 'internal_run'
         from src/spec/context.cr:330:7 in 'run'
         from src/spec/context.cr:18:23 in 'internal_run'
         from src/spec/context.cr:147:7 in 'run'
         from src/spec/dsl.cr:274:7 in '->'
         from src/primitives.cr:255:3 in 'run'
         from src/crystal/main.cr:45:14 in 'main'
         from src/crystal/main.cr:119:3 in 'main'
       

Finished in 53.71 milliseconds
733 examples, 0 failures, 5 errors, 0 pending

Failed examples:

crystal spec spec/std/number_spec.cr:309 # Number #step whole range iterates UInt8 downwards
crystal spec spec/std/number_spec.cr:313 # Number #step whole range iterates Int8 upwards
crystal spec spec/std/number_spec.cr:318 # Number #step whole range iterates Int8 downwards
crystal spec spec/std/number_spec.cr:322 # Number #step whole range iterates Int16 upwards
crystal spec spec/std/number_spec.cr:327 # Number #step whole range iterates Int16 downwards
```