### PR TITLE
Fix `Enum.from_value?` for flag enum with non `Int32` base type

### DIFF
--- a/spec/std/enum_spec.cr
+++ b/spec/std/enum_spec.cr
@@ -26,6 +26,13 @@ enum SpecEnumFlags
 end
 
 @[Flags]
+enum SpecEnumFlags8 : Int8
+  One
+  Two
+  Three
+end
+
+@[Flags]
 private enum PrivateFlagsEnum
   FOO
   BAR
@@ -167,6 +174,7 @@ describe Enum do
       SpecEnumFlags.from_value?(2).should eq(SpecEnumFlags::Two)
       SpecEnumFlags.from_value?(3).should eq(SpecEnumFlags::One | SpecEnumFlags::Two)
       SpecEnumFlags.from_value?(8).should be_nil
+      SpecEnumFlags8.from_value?(1_i8).should eq(SpecEnumFlags8::One)
     end
   end
 

--- a/src/enum.cr
+++ b/src/enum.cr
@@ -357,7 +357,7 @@ struct Enum
     {% if @type.annotation(Flags) %}
       all_mask = {{@type}}::All.value
       return if all_mask & value != value
-      return new(value.to_i)
+      return new(all_mask.class.new(value))
     {% else %}
       {% for member in @type.constants %}
         return new({{@type.constant(member)}}) if {{@type.constant(member)}} == value


### PR DESCRIPTION
Fixes #10301

I had even proposed this solution originally in https://github.com/crystal-lang/crystal/issues/9883#issuecomment-721793286 but #10145 ended up using `#to_i` instead 🤦 