### PR TITLE
Compiler: fix type check not considering virtual types

### DIFF
--- a/spec/compiler/codegen/is_a_spec.cr
+++ b/spec/compiler/codegen/is_a_spec.cr
@@ -727,4 +727,20 @@ describe "Codegen: is_a?" do
       Class.is_a?(Class.class.class)
     ").to_b.should be_true
   end
+
+  it "passes is_a? with generic module type on virtual type (#10302)" do
+    run(%(
+      module Mod(T)
+      end
+
+      abstract struct Sup
+        include Mod(Sup)
+      end
+
+      struct Sub < Sup
+      end
+
+      Sub.new.is_a?(Mod(Sup))
+      )).to_b.should be_true
+  end
 end

--- a/src/compiler/crystal/semantic/restrictions.cr
+++ b/src/compiler/crystal/semantic/restrictions.cr
@@ -714,7 +714,7 @@ module Crystal
         other_type_var = other.type_vars[name]
         if type_var.is_a?(Var) && other_type_var.is_a?(Var)
           restricted = if strict
-                         type_var.type == other_type_var.type
+                         type_var.type.devirtualize == other_type_var.type.devirtualize
                        else
                          type_var.type.implements?(other_type_var.type)
                        end


### PR DESCRIPTION
Fixes #10302

It turns out the `Sup` in one case is a non-virtual type (right when the module is included) but it's a virtual type when it's checked (because at that point a subtype was added).

Regardless of whether virtual types should be produced in all cases, this fixes the regression now. We can improve this later on.