### PR TITLE
Fix Range#== to ignore generic type arguments

### DIFF
--- a/spec/std/range_spec.cr
+++ b/spec/std/range_spec.cr
@@ -60,6 +60,19 @@ describe "Range" do
     r.excludes_end?.should be_true
   end
 
+  it "#==" do
+    ((1..1) == (1..1)).should be_true
+    ((1...1) == (1..1)).should be_false
+    ((1...1) == (1...1)).should be_true
+    ((1..1) == (1...1)).should be_false
+
+    ((1..nil) == (1..nil)).should be_true
+
+    (1..1).should eq Range(Int32?, Int32?).new(1, 1)
+    ((1..1) == Range(Int32?, Int32?).new(1, 1)).should be_true
+    ((1.0..1.0) == (1..1)).should be_true
+  end
+
   it "includes?" do
     (1..5).includes?(1).should be_true
     (1..5).includes?(5).should be_true

--- a/src/range.cr
+++ b/src/range.cr
@@ -87,6 +87,10 @@ struct Range(B, E)
   def initialize(@begin : B, @end : E, @exclusive : Bool = false)
   end
 
+  def ==(other : Range)
+    @begin == other.@begin && @end == other.@end && @exclusive == other.@exclusive
+  end
+
   # Returns an `Iterator` that cycles over the values of this range.
   #
   # ```


### PR DESCRIPTION
`(1..1) == (1.0..1.0)` currently returns `false`. The equality operator `Struct#==` includes a type restriction to `self` but the types are different because of generic type arguments: `Range(Int32, Int32)` and `Range(Float64, Float64)`.

The same problem appears with nilable generic type arguments like comparing `Range(Int32?, Int32?)` with `Range(Int32, Int32)` always fails, even if both have identical begin and end values.

This patch overrides the equality operator as `Range#==(other : Range)` which defines quality based on actual values, ignoring generic type arguments.

A more comprehensive fix would be to change the type restriction in `Struct#==` from `self` to the generic class type. I'll look into that, too. But this is a minimal fix for now and IMO worth merging as is.