### PR TITLE
Optimize `Range#sample(n)` for integer ranges, and allow float ranges too

### DIFF
--- a/spec/std/enumerable_spec.cr
+++ b/spec/std/enumerable_spec.cr
@@ -970,7 +970,7 @@ describe "Enumerable" do
       it "samples k elements out of n, with random" do
         a = (1..5)
         b = a.sample(3, Random.new(1))
-        b.should eq([4, 3, 1])
+        b.should eq([3, 4, 2])
       end
     end
   end

--- a/spec/std/enumerable_spec.cr
+++ b/spec/std/enumerable_spec.cr
@@ -970,7 +970,7 @@ describe "Enumerable" do
       it "samples k elements out of n, with random" do
         a = (1..5)
         b = a.sample(3, Random.new(1))
-        b.should eq([3, 4, 2])
+        b.should eq([4, 3, 1])
       end
     end
   end

--- a/spec/std/range_spec.cr
+++ b/spec/std/range_spec.cr
@@ -417,6 +417,86 @@ describe "Range" do
       x = r.sample
       r.includes?(x).should be_true
     end
+
+    it "samples with n = 0" do
+      (1..3).sample(0).empty?.should be_true
+    end
+
+    context "for an integer range" do
+      it "samples an inclusive range without n" do
+        value = (1..3).sample
+        (1 <= value <= 3).should be_true
+      end
+
+      it "samples an exclusive range without n" do
+        value = (1...3).sample
+        (1 <= value <= 2).should be_true
+      end
+
+      it "samples an inclusive range with n = 1" do
+        values = (1..3).sample(1)
+        values.size.should eq(1)
+        (1 <= values.first <= 3).should be_true
+      end
+
+      it "samples an exclusive range with n = 1" do
+        values = (1...3).sample(1)
+        values.size.should eq(1)
+        (1 <= values.first <= 2).should be_true
+      end
+
+      it "samples an inclusive range with n > 1" do
+        values = (1..10).sample(5)
+        values.size.should eq(5)
+        values.uniq.size.should eq(5)
+        values.all? { |value| 1 <= value <= 10 }.should be_true
+      end
+
+      it "samples an exclusive range with n > 1" do
+        values = (1...10).sample(5)
+        values.size.should eq(5)
+        values.uniq.size.should eq(5)
+        values.all? { |value| 1 <= value <= 9 }.should be_true
+      end
+
+      it "samples an inclusive range with n > 16" do
+        values = (1..1000).sample(100)
+        values.size.should eq(100)
+        values.uniq.size.should eq(100)
+        values.all? { |value| 1 <= value <= 1000 }.should be_true
+      end
+
+      it "samples an inclusive range with n equal to or bigger than the available values" do
+        values = (1..10).sample(20)
+        values.size.should eq(10)
+        values.uniq.size.should eq(10)
+        values.all? { |value| 1 <= value <= 10 }.should be_true
+      end
+
+      it "raises on invalid range without n" do
+        expect_raises ArgumentError do
+          (1..0).sample
+        end
+      end
+
+      it "raises on invalid range with n = 1" do
+        expect_raises ArgumentError do
+          (1..0).sample(1)
+        end
+      end
+
+      it "raises on invalid range with n > 1" do
+        expect_raises ArgumentError do
+          (1..0).sample(10)
+        end
+      end
+
+      it "raises on exclusive range that would underflow" do
+        expect_raises ArgumentError do
+          (1_u8...0_u8).sample(10)
+        end
+      end
+    end
   end
 
   describe "#step" do

--- a/spec/std/range_spec.cr
+++ b/spec/std/range_spec.cr
@@ -497,6 +497,54 @@ describe "Range" do
         end
       end
     end
+
+    context "for a float range" do
+      it "samples an inclusive range without n" do
+        value = (1.0..2.0).sample
+        (1.0 <= value <= 2.0).should be_true
+      end
+
+      it "samples an exclusive range without n" do
+        value = (1.0...2.0).sample
+        (1.0 <= value < 2.0).should be_true
+      end
+
+      it "samples an inclusive range with n = 1" do
+        values = (1.0..2.0).sample(1)
+        values.size.should eq(1)
+        (1.0 <= values.first <= 2.0).should be_true
+      end
+
+      it "samples an exclusive range with n = 1" do
+        values = (1.0..2.0).sample(1)
+        values.size.should eq(1)
+        (1.0 <= values.first < 2.0).should be_true
+      end
+
+      it "samples an inclusive range with n > 1" do
+        values = (1.0..2.0).sample(10)
+        values.size.should eq(10)
+        values.all? { |value| 1.0 <= value <= 2.0 }.should be_true
+      end
+
+      it "samples an exclusive range with n > 1" do
+        values = (1.0...2.0).sample(10)
+        values.size.should eq(10)
+        values.all? { |value| 1.0 <= value < 2.0 }.should be_true
+      end
+
+      it "samples an inclusive range with n >= 1 and begin == end" do
+        values = (1.0..1.0).sample(3)
+        values.size.should eq(1)
+        values.first.should eq(1.0)
+      end
+
+      it "samples an inclusive range with n > 16" do
+        values = (1.0..2.0).sample(100)
+        values.size.should eq(100)
+        values.all? { |value| 1.0 <= value <= 2.0 }.should be_true
+      end
+    end
   end
 
   describe "#step" do

--- a/spec/std/range_spec.cr
+++ b/spec/std/range_spec.cr
@@ -479,6 +479,12 @@ describe "Range" do
         end
       end
 
+      it "raises on invalid range with n = 0" do
+        expect_raises ArgumentError do
+          (1..0).sample(0)
+        end
+      end
+
       it "raises on invalid range with n = 1" do
         expect_raises ArgumentError do
           (1..0).sample(1)
@@ -543,6 +549,24 @@ describe "Range" do
         values = (1.0..2.0).sample(100)
         values.size.should eq(100)
         values.all? { |value| 1.0 <= value <= 2.0 }.should be_true
+      end
+
+      it "raises on invalid range with n = 0" do
+        expect_raises ArgumentError do
+          (1.0..0.0).sample(0)
+        end
+      end
+
+      it "raises on invalid range with n = 1" do
+        expect_raises ArgumentError do
+          (1.0..0.0).sample(1)
+        end
+      end
+
+      it "raises on invalid range with n > 1" do
+        expect_raises ArgumentError do
+          (1.0..0.0).sample(10)
+        end
       end
     end
   end

--- a/src/range.cr
+++ b/src/range.cr
@@ -392,12 +392,57 @@ struct Range(B, E)
       raise ArgumentError.new("Can't sample an open range")
     end
 
-    return super unless n == 1
+    if n < 0
+      raise ArgumentError.new "Can't sample negative number of elements"
+    end
 
-    if empty?
+    case n
+    when 0
       [] of B
-    else
+    when 1
       [sample(random)]
+    else
+      # For a range of integers we can do much better
+      {% if B < Int && E < Int %}
+        min = self.begin
+        max = self.end
+
+        if (exclusive? && max <= min) || (!exclusive? && max < min)
+          raise ArgumentError.new "Invalid range for rand: #{self}"
+        end
+
+        max -= 1 if self.exclusive?
+
+        available = max - min + 1
+        possible = Math.min(n, available)
+
+        # If we must return all values in the range...
+        if possible == available
+          result = Array(B).new(possible)
+          each { |value| result << value }
+          result.shuffle!
+          result
+        elsif n <= 16
+          # For a small requested amount doing a linear lookup is faster
+          result = Array(B).new(possible)
+          add_n_samples(result, possible, random)
+          result
+        else
+          # Otherwise using a Set is faster
+          result = Set(B).new(possible)
+          add_n_samples(result, possible, random)
+          result.to_a
+        end
+      {% else %}
+        super
+      {% end %}
+    end
+  end
+
+  private def add_n_samples(result, n, random)
+    until result.size == n
+      value = sample
+      result << value unless result.includes?(value)
     end
   end
 

--- a/src/range.cr
+++ b/src/range.cr
@@ -437,7 +437,7 @@ struct Range(B, E)
         min = self.begin
         max = self.end
 
-        if (exclusive? && max <= min) || (!exclusive? && max < min)
+        if max < min || (exclusive? && max == min)
           raise ArgumentError.new "Invalid range for rand: #{self}"
         end
 

--- a/src/range.cr
+++ b/src/range.cr
@@ -433,6 +433,27 @@ struct Range(B, E)
           add_n_samples(result, possible, random)
           result.to_a
         end
+      {% elsif B < Float && E < Float %}
+        min = self.begin
+        max = self.end
+
+        if (exclusive? && max <= min) || (!exclusive? && max < min)
+          raise ArgumentError.new "Invalid range for rand: #{self}"
+        end
+
+        if min == max
+          [min]
+        elsif n <= 16
+          # For a small requested amount doing a linear lookup is faster
+          result = Array(B).new
+          add_n_samples(result, n, random)
+          result
+        else
+          # Otherwise using a Set is faster
+          result = Set(B).new
+          add_n_samples(result, n, random)
+          result.to_a
+        end
       {% else %}
         super
       {% end %}

--- a/src/range.cr
+++ b/src/range.cr
@@ -429,7 +429,7 @@ struct Range(B, E)
         min = self.begin
         max = self.end
 
-        if max < min || (exclusive? && max == min)
+        if (exclusive? ? max <= min : max < min)
           raise ArgumentError.new "Invalid range for rand: #{self}"
         end
 

--- a/src/range.cr
+++ b/src/range.cr
@@ -421,18 +421,10 @@ struct Range(B, E)
           result = Array(B).new(possible)
           each { |value| result << value }
           result.shuffle!
-          result
-        elsif n <= 16
-          # For a small requested amount doing a linear lookup is faster
-          result = Array(B).new(possible)
-          add_n_samples(result, possible, random)
-          result
-        else
-          # Otherwise using a Set is faster
-          result = Set(B).new(possible)
-          add_n_samples(result, possible, random)
-          result.to_a
+          return result
         end
+
+        range_sample(n, random)
       {% elsif B < Float && E < Float %}
         min = self.begin
         max = self.end
@@ -442,28 +434,32 @@ struct Range(B, E)
         end
 
         if min == max
-          [min]
-        elsif n <= 16
-          # For a small requested amount doing a linear lookup is faster
-          result = Array(B).new
-          add_n_samples(result, n, random)
-          result
-        else
-          # Otherwise using a Set is faster
-          result = Set(B).new
-          add_n_samples(result, n, random)
-          result.to_a
+          return [min]
         end
+
+        range_sample(n, random)
       {% else %}
         super
       {% end %}
     end
   end
 
-  private def add_n_samples(result, n, random)
-    until result.size == n
-      value = sample(random)
-      result << value unless result.includes?(value)
+  private def range_sample(n, random)
+    if n <= 16
+      # For a small requested amount doing a linear lookup is faster
+      result = Array(B).new(n)
+      until result.size == n
+        value = sample(random)
+        result << value unless result.includes?(value)
+      end
+      result
+    else
+      # Otherwise using a Set is faster
+      result = Set(B).new(n)
+      until result.size == n
+        result << sample(random)
+      end
+      result.to_a
     end
   end
 

--- a/src/range.cr
+++ b/src/range.cr
@@ -396,59 +396,104 @@ struct Range(B, E)
       raise ArgumentError.new "Can't sample negative number of elements"
     end
 
+    # For a range of integers we can do much better
+    {% if B < Int && E < Int %}
+      min = self.begin
+      max = self.end
+
+      if (exclusive? && max <= min) || (!exclusive? && max < min)
+        raise ArgumentError.new "Invalid range for rand: #{self}"
+      end
+
+      max -= 1 if self.exclusive?
+
+      available = max - min + 1
+
+      # When a big chunk of elements is going to be needed, it's
+      # faster to just traverse the entire range than hitting
+      # a lot of duplicates because or random.
+      if n >= available // 4
+        return super
+      end
+
+      possible = Math.min(n, available)
+
+      # If we must return all values in the range...
+      if possible == available
+        result = Array(B).new(possible)
+        each { |value| result << value }
+        result.shuffle!
+        return result
+      end
+
+      range_sample(n, random)
+    {% elsif B < Float && E < Float %}
+      min = self.begin
+      max = self.end
+
+      if (exclusive? ? max <= min : max < min)
+        raise ArgumentError.new "Invalid range for rand: #{self}"
+      end
+
+      if min == max
+        return [min]
+      end
+
+      range_sample(n, random)
+    {% else %}
+      case n
+      when 0
+        [] of B
+      when 1
+        [sample(random)]
+      else
+        super
+      end
+    {% end %}
+  end
+
+  # :nodoc:
+  def sample_old(n : Int, random = Random::DEFAULT)
+    {% if B == Nil || E == Nil %}
+      {% raise "Can't sample an open range" %}
+    {% end %}
+
+    if self.begin.nil? || self.end.nil?
+      raise ArgumentError.new("Can't sample an open range")
+    end
+
+    if n < 0
+      raise ArgumentError.new "Can't sample negative number of elements"
+    end
+
     case n
     when 0
       [] of B
     when 1
       [sample(random)]
     else
-      # For a range of integers we can do much better
-      {% if B < Int && E < Int %}
-        min = self.begin
-        max = self.end
+      raise ArgumentError.new("Can't sample negative number of elements") if n < 0
 
-        if (exclusive? && max <= min) || (!exclusive? && max < min)
-          raise ArgumentError.new "Invalid range for rand: #{self}"
+      # Unweighted reservoir sampling:
+      # https://en.wikipedia.org/wiki/Reservoir_sampling#Simple_algorithm
+      # "Algorithm L" does not provide any performance improvements on Enumerable,
+      # because it is not possible to discard multiple elements at once
+
+      ary = Array(B).new(n)
+      return ary if n == 0
+
+      each_with_index do |elem, i|
+        if i < n
+          ary << elem
+        else
+          j = random.rand(i + 1)
+          if j < n
+            ary.to_unsafe[j] = elem
+          end
         end
+      end
 
-        max -= 1 if self.exclusive?
-
-        available = max - min + 1
-
-        # When a big chunk of elements is going to be needed, it's
-        # faster to just traverse the entire range than hitting
-        # a lot of duplicates because or random.
-        if n >= available // 4
-          return super
-        end
-
-        possible = Math.min(n, available)
-
-        # If we must return all values in the range...
-        if possible == available
-          result = Array(B).new(possible)
-          each { |value| result << value }
-          result.shuffle!
-          return result
-        end
-
-        range_sample(n, random)
-      {% elsif B < Float && E < Float %}
-        min = self.begin
-        max = self.end
-
-        if (exclusive? ? max <= min : max < min)
-          raise ArgumentError.new "Invalid range for rand: #{self}"
-        end
-
-        if min == max
-          return [min]
-        end
-
-        range_sample(n, random)
-      {% else %}
-        super
-      {% end %}
+      ary.shuffle!(random)
     end
   end
 

--- a/src/range.cr
+++ b/src/range.cr
@@ -414,6 +414,14 @@ struct Range(B, E)
         max -= 1 if self.exclusive?
 
         available = max - min + 1
+
+        # When a big chunk of elements is going to be needed, it's
+        # faster to just traverse the entire range than hitting
+        # a lot of duplicates because or random.
+        if n >= available // 4
+          return super
+        end
+
         possible = Math.min(n, available)
 
         # If we must return all values in the range...

--- a/src/range.cr
+++ b/src/range.cr
@@ -422,7 +422,7 @@ struct Range(B, E)
       if possible == available
         result = Array(B).new(possible)
         each { |value| result << value }
-        result.shuffle!
+        result.shuffle!(random)
         return result
       end
 

--- a/src/range.cr
+++ b/src/range.cr
@@ -462,7 +462,7 @@ struct Range(B, E)
 
   private def add_n_samples(result, n, random)
     until result.size == n
-      value = sample
+      value = sample(random)
       result << value unless result.includes?(value)
     end
   end


### PR DESCRIPTION
On a gitter discussion it was mentioned that this:

```crystal
(0..1_000_000_000).sample(10)
```

is pretty slow, while in Python it's very fast.

I don't know how Python does it, but one way to do that is, if the range is an integer range, then we can call `rand(range)` (which is optimized to pick a number between those two) `n` times until we get all the necessary values. Without this optimization the default implementation ends up traversing the entire `Enumerable`.

A benchmark for the above gives, before this PR:

```
sample(n) 138.12m (  7.24s ) (± 0.00%) 
```

With this PR:

```
sample(n)   7.02M (142.43ns) (± 3.11%) 
```

So it goes down from 7 seconds to 142 nanoseconds :-)

Then we can do a similar thing for float ranges, which previously weren't supported by this functionality.
