### PR TITLE
Compiler: use path lookup when looking up type for autocast match

### DIFF
--- a/spec/compiler/semantic/automatic_cast_spec.cr
+++ b/spec/compiler/semantic/automatic_cast_spec.cr
@@ -596,4 +596,24 @@ describe "Semantic: automatic cast" do
       ),
       "ambiguous call, implicit cast of 255 matches all of UInt64, Int64"
   end
+
+  it "autocasts nested type from non-nested type (#10315)" do
+    assert_no_errors(%(
+      module Moo
+        enum Color
+          Red
+        end
+
+        abstract class Foo
+          def initialize(color : Color = :red)
+          end
+        end
+      end
+
+      class Bar < Moo::Foo
+      end
+
+      Bar.new
+      ))
+  end
 end

--- a/src/compiler/crystal/semantic/main_visitor.cr
+++ b/src/compiler/crystal/semantic/main_visitor.cr
@@ -769,7 +769,7 @@ module Crystal
           # OK
         else
           # Check autocast too
-          restriction_type = scope.lookup_type(restriction, free_vars: free_vars)
+          restriction_type = (path_lookup || scope).lookup_type(restriction, free_vars: free_vars)
           if casted_value = check_automatic_cast(value, restriction_type, node)
             value = casted_value
           else


### PR DESCRIPTION
Fixes #10315

When resolving types, the compiler has a `path_lookup` (which is nilable, I'll explain why later) and a `scope`. The `scope` is the actual type instantiated, while `path_lookup` is used to, well, lookup "paths" (constants, types). So for example:

```crystal
class Foo
  class T; end

  def foo
    T # <------------------
    bar
  end
end

class Bar < Foo
  class T
  end
end

Bar.new.foo
```

When analyzing `foo`, when looking up `T` the compiler will search in Foo (the `path_lookup`), but when analyzing `bar` it will search in `Bar` because that's the actual instantiated types. Type lookup is fixed to the type that mentions it (this is the same in Ruby).

This PR fixes a place where a type is looked up for matching an autocast, but it used `scope` instead of `path_lookup`.

For reference, this is the usual place where paths are looked up:

https://github.com/crystal-lang/crystal/blob/be5de4ac1d6fb4bf1db7878be6acc35734b1e962/src/compiler/crystal/semantic/main_visitor.cr#L165

Also `path_lookup` can be `nil` for the top-level (well, it could be the top-level but that's how things are).
    