### PR TITLE
Improve error message for autocast error at Var assign

### DIFF
--- a/spec/compiler/semantic/automatic_cast_spec.cr
+++ b/spec/compiler/semantic/automatic_cast_spec.cr
@@ -616,4 +616,18 @@ describe "Semantic: automatic cast" do
       Bar.new
       ))
   end
+
+  it "errors when autocast default value doesn't match enum member" do
+    assert_error <<-CR,
+      enum Foo
+        FOO
+      end
+
+      def foo(foo : Foo = :bar)
+      end
+
+      foo
+      CR
+      "can't autocast :bar to Foo: no matching enum member"
+  end
 end

--- a/src/compiler/crystal/semantic/main_visitor.cr
+++ b/src/compiler/crystal/semantic/main_visitor.cr
@@ -773,6 +773,10 @@ module Crystal
           if casted_value = check_automatic_cast(value, restriction_type, node)
             value = casted_value
           else
+            if value.is_a?(SymbolLiteral) && restriction_type.is_a?(EnumType)
+              node.raise "can't autocast #{value} to #{restriction_type}: no matching enum member"
+            end
+
             node.raise "can't restrict #{value.type} to #{restriction}"
           end
         end


### PR DESCRIPTION
When an symbol as default argument to an enum restriction can't be autocasted, the error message doesn't properly reflect this use case and is more generic:

```cr
enum Foo
  FOO
end

def foo(foo : Foo = :bar) # Error: can't restrict Symbol to Foo
end
```

In this situation the intention is pretty clear, the symbol is supposed to be autocasted to the matching enum member. When that doesn't succeed, the error is most likely because the requested enum member doesn't exist because of a typo, merge conflict or similar.

So this patch generates a more appropriate error message: `can't autocast :bar to Foo: no matching enum member`