### PR TITLE
Make {Enumerable,Iterator}#flat_map work with mixed element types

### DIFF
--- a/spec/std/enumerable_spec.cr
+++ b/spec/std/enumerable_spec.cr
@@ -501,6 +501,10 @@ describe "Enumerable" do
     it "flattens iterators" do
       [[1, 2], [3, 4]].flat_map(&.each).should eq([1, 2, 3, 4])
     end
+
+    it "accepts mixed element types" do
+      [[1, 2, 3], ['a', 'b'].each, "cde"].flat_map { |e| e }.should eq([1, 2, 3, 'a', 'b', "cde"])
+    end
   end
 
   describe "group_by" do

--- a/spec/std/iterator_spec.cr
+++ b/spec/std/iterator_spec.cr
@@ -748,6 +748,7 @@ describe Iterator do
       iter.next.should eq(2)
       iter.next.should eq(3)
       iter.next.should eq(3)
+      iter.next.should be_a(Iterator::Stop)
     end
 
     it "flattens returned items" do
@@ -756,6 +757,7 @@ describe Iterator do
       iter.next.should eq(1)
       iter.next.should eq(2)
       iter.next.should eq(3)
+      iter.next.should be_a(Iterator::Stop)
     end
 
     it "flattens returned iterators" do
@@ -767,6 +769,7 @@ describe Iterator do
       iter.next.should eq(2)
       iter.next.should eq(3)
       iter.next.should eq(3)
+      iter.next.should be_a(Iterator::Stop)
     end
 
     it "flattens returned values" do
@@ -786,6 +789,21 @@ describe Iterator do
       iter.next.should eq(2)
       iter.next.should eq(3)
       iter.next.should eq(3)
+      iter.next.should be_a(Iterator::Stop)
+    end
+
+    it "flattens returned values of mixed element types in #to_a" do
+      iter = [1, 'a', ""].each.flat_map do |x|
+        case x
+        when Int32
+          x
+        when Char
+          [x, x]
+        else
+          [x, x].each
+        end
+      end
+      iter.to_a.should eq([1, 'a', 'a', "", ""])
     end
   end
 

--- a/src/enumerable.cr
+++ b/src/enumerable.cr
@@ -514,7 +514,9 @@ module Enumerable(T)
   end
 
   # Returns a new array with the concatenated results of running the block
-  # (which is expected to return arrays) once for every element in the collection.
+  # once for every element in the collection.
+  # Only `Array` and `Iterator` results are concatenated; every other value is
+  # directly appended to the new array.
   #
   # ```
   # array = ["Alice", "Bob"].flat_map do |user|
@@ -522,8 +524,8 @@ module Enumerable(T)
   # end
   # array # => ['A', 'l', 'i', 'c', 'e', 'B', 'o', 'b']
   # ```
-  def flat_map(&block : T -> Array(U) | Iterator(U) | U) forall U
-    ary = [] of U
+  def flat_map(&block : T -> _)
+    ary = [] of typeof(flat_map_type(yield first))
     each do |e|
       case v = yield e
       when Array, Iterator
@@ -533,6 +535,15 @@ module Enumerable(T)
       end
     end
     ary
+  end
+
+  private def flat_map_type(elem)
+    case elem
+    when Array, Iterator
+      elem.first
+    else
+      elem
+    end
   end
 
   # Returns a `Hash` whose keys are each different value that the passed block

--- a/src/iterator.cr
+++ b/src/iterator.cr
@@ -590,8 +590,9 @@ module Iterator(T)
   end
 
   # Returns a new iterator with the concatenated results of running the block
-  # (which is expected to return arrays or iterators)
   # once for every element in the collection.
+  # Only `Array` and `Iterator` results are concatenated; every other value is
+  # returned once in the new iterator.
   #
   # ```
   # iter = [1, 2, 3].each.flat_map { |x| [x, x] }
@@ -604,8 +605,13 @@ module Iterator(T)
   #
   # iter.to_a # => [1, 1, 2, 2, 3, 3]
   # ```
-  def flat_map(&func : T -> Array(U) | Iterator(U) | U) forall U
-    FlatMap(typeof(self), U, typeof(FlatMap.iterator_type(self, func)), typeof(func)).new self, func
+  def flat_map(&func : T -> _)
+    FlatMap(
+      typeof(self),
+      typeof(FlatMap.element_type(self, func)),
+      typeof(FlatMap.iterator_type(self, func)),
+      typeof(func)
+    ).new self, func
   end
 
   private class FlatMap(I0, T, I, F)
@@ -643,6 +649,18 @@ module Iterator(T)
         else
           value
         end
+      end
+    end
+
+    def self.element_type(iter, func)
+      value = iter.next
+      raise "" if value.is_a?(Stop)
+
+      case value = func.call value
+      when Array, Iterator
+        value.first
+      else
+        value
       end
     end
 

--- a/src/iterator.cr
+++ b/src/iterator.cr
@@ -606,12 +606,7 @@ module Iterator(T)
   # iter.to_a # => [1, 1, 2, 2, 3, 3]
   # ```
   def flat_map(&func : T -> _)
-    FlatMap(
-      typeof(self),
-      typeof(FlatMap.element_type(self, func)),
-      typeof(FlatMap.iterator_type(self, func)),
-      typeof(func)
-    ).new self, func
+    FlatMap(typeof(self), typeof(FlatMap.element_type(self, func)), typeof(FlatMap.iterator_type(self, func)), typeof(func)).new self, func
   end
 
   private class FlatMap(I0, T, I, F)


### PR DESCRIPTION
Currently, the following code fails:

```crystal
[[1, 2, 3], ['a', 'b']].flat_map &.itself
# Error: expected block to return Array(U) | Iterator(U) | U, not (Array(Char) | Array(Int32))
```

There is no reason that the block must return `Array`s and `Iterator`s of the same element type; `Array#concat` and `#push`, which this method relies on, already work with element types that differ from self's.

The `Iterator` form will yield the correct elements, but it uses the wrong generic type argument, breaking certain methods like `#to_a`:

```crystal
[[1, 2, 3], ['a', 'b']].each.flat_map(&.itself).each { |x| print x } # => 123ab

[[1, 2, 3], ['a', 'b']].each.flat_map(&.itself).to_a
# Error: no overload matches 'Array(Char)#<<' with type (Char | Int32)
#
# Overloads are:
#  - Array(T)#<<(value : T)
# Couldn't find overloads for these types:
#  - Array(Char)#<<(value : Int32)
```

The type restriction `Array(U) | Iterator(U) | U forall U` is used in the block's return type. This restriction is unneeded, since whether a value should be flattened or not depends on its dynamic type, not static type. This PR fixes both methods by replacing the restrictions with `typeof` expressions that deduce the common element type. Fixes #5803:

```crystal
array = [1, 2, [[3]]]
result = array.flat_map do |item|
  if item.is_a?(Array)
    item
  else
    [item] of typeof(array) | typeof(array.first)
  end
end
result         # => [1, 2, [3]]
typeof(result) # => Array(Array(Array(Array(Int32)) | Int32) | Array(Array(Int32)) | Array(Int32) | Int32)
```