### PR TITLE
Revert optimization of constants and class vars

### DIFF
--- a/spec/compiler/codegen/class_spec.cr
+++ b/spec/compiler/codegen/class_spec.cr
@@ -429,6 +429,8 @@ describe "Code gen: class" do
 
   it "allows using self in class scope" do
     run(%(
+      require "prelude"
+
       class Foo
         def self.foo
           1

--- a/src/compiler/crystal/codegen/class_var.cr
+++ b/src/compiler/crystal/codegen/class_var.cr
@@ -86,9 +86,7 @@ class Crystal::CodeGenVisitor
 
     # For unsafe class var we just initialize them without
     # using a flag to know if they were initialized
-    if class_var.uninitialized? || !init_func || !class_var.read?
-      class_var.no_init_flag = true
-
+    if class_var.uninitialized? || !init_func
       global = declare_class_var(class_var)
       global = ensure_class_var_in_this_module(global, class_var)
       if init_func
@@ -99,7 +97,7 @@ class Crystal::CodeGenVisitor
 
     global, initialized_flag = declare_class_var_and_initialized_flag_in_this_module(class_var)
 
-    lazy_initialize_class_var(initializer.node, init_func.not_nil!, global, initialized_flag)
+    lazy_initialize_class_var(initializer.node, init_func, global, initialized_flag)
   end
 
   def lazy_initialize_class_var(node, init_func, global, initialized_flag)
@@ -177,8 +175,6 @@ class Crystal::CodeGenVisitor
   end
 
   def read_class_var_ptr(class_var : MetaTypeVar)
-    class_var.read = true
-
     owner = class_var.owner
     case owner
     when VirtualType
@@ -188,7 +184,7 @@ class Crystal::CodeGenVisitor
     end
 
     initializer = class_var.initializer
-    if !initializer || class_var.uninitialized? || class_var.no_init_flag?
+    if !initializer || class_var.uninitialized?
       # Read directly without init flag, but make sure to declare the global in this module too
       return get_class_var_global(class_var)
     end

--- a/src/compiler/crystal/codegen/const.cr
+++ b/src/compiler/crystal/codegen/const.cr
@@ -119,13 +119,6 @@ class Crystal::CodeGenVisitor
   end
 
   def initialize_const(const)
-    # If the constant wasn't read yet, we can initialize it right now and
-    # avoid checking an "initialized" flag every time we read it.
-    unless const.read?
-      const.no_init_flag = true
-      return initialize_no_init_flag_const(const)
-    end
-
     # Maybe the constant was simple and doesn't need a real initialization
     global, initialized_flag = declare_const_and_initialized_flag(const)
     return global if const.initializer
@@ -201,8 +194,6 @@ class Crystal::CodeGenVisitor
   end
 
   def read_const_pointer(const)
-    const.read = true
-
     if !const.needs_init_flag?
       global_name = const.llvm_name
       global = declare_const(const)

--- a/src/compiler/crystal/codegen/types.cr
+++ b/src/compiler/crystal/codegen/types.cr
@@ -167,11 +167,6 @@ module Crystal
   class Const
     property initializer : LLVM::Value?
 
-    # Was this constant already read during the codegen phase?
-    # If not, and we are at the place that declares the constant, we can
-    # directly initialize the constant now, without checking for an `init` flag.
-    property? read = false
-
     # If true, there's no need to check whether the constant was initialized or
     # not when reading it.
     property? no_init_flag = false

--- a/src/compiler/crystal/semantic/ast.cr
+++ b/src/compiler/crystal/semantic/ast.cr
@@ -534,15 +534,6 @@ module Crystal
     # Is this variable "unsafe" (no need to check if it was initialized)?
     property? uninitialized = false
 
-    # Was this class_var already read during the codegen phase?
-    # If not, and we are at the place that declares the class var, we can
-    # directly initialize it now, without checking for an `init` flag.
-    property? read = false
-
-    # If true, there's no need to check whether the class var was initialized or
-    # not when reading it.
-    property? no_init_flag = false
-
     def kind
       case name[0]
       when '@'


### PR DESCRIPTION
As I explain [here](https://forum.crystal-lang.org/t/specs-on-crystal-0-36-0-are-taking-a-long-time/2910/15?u=asterite), it seems these changes are the reason the 0.36.0 compiler is so slow.

Reverts #9801
Reverts #9995

I didn't use `git revert` because then an optimization to not use an "init" flag for string constants came in, and that's fine.

Fixes https://forum.crystal-lang.org/t/specs-on-crystal-0-36-0-are-taking-a-long-time/2910