### PR TITLE
Revert "Fix Hash#dup and Hash#clone to return correct type for subclasses (#9871)"

### DIFF
--- a/spec/std/hash_spec.cr
+++ b/spec/std/hash_spec.cr
@@ -22,9 +22,6 @@ private class HashWrapper(K, V)
   delegate each, to: @hash
 end
 
-private class HashSubclass(K, V) < Hash(K, V)
-end
-
 describe "Hash" do
   describe "empty" do
     it "size should be zero" do
@@ -442,20 +439,6 @@ describe "Hash" do
       clone = h.clone
       clone.should be(clone.first[1])
     end
-
-    it "clones subclass" do
-      h1 = HashSubclass(Int32, Array(Int32)).new
-      h1[0] = [0]
-      h2 = h1.clone
-      h1.should_not be(h2)
-      h1.should eq(h2)
-      typeof(h2).should eq(HashSubclass(Int32, Array(Int32)))
-
-      h1[0].should_not be(h2[0])
-
-      h1.delete(0)
-      h2[0].should eq([0])
-    end
   end
 
   describe "dup" do
@@ -494,20 +477,6 @@ describe "Hash" do
       1_000.times do |i|
         h1[i].should be(h2[i])
       end
-
-      h1.delete(0)
-      h2[0].should eq([0])
-    end
-
-    it "dups subclass" do
-      h1 = HashSubclass(Int32, Array(Int32)).new
-      h1[0] = [0]
-      h2 = h1.dup
-      h1.should_not be(h2)
-      h1.should eq(h2)
-      typeof(h2).should eq(HashSubclass(Int32, Array(Int32)))
-
-      h1[0].should be(h2[0])
 
       h1.delete(0)
       h2[0].should eq([0])

--- a/src/hash.cr
+++ b/src/hash.cr
@@ -1772,7 +1772,7 @@ class Hash(K, V)
   # hash_a # => {"foo" => "bar"}
   # ```
   def dup
-    hash = self.class.new
+    hash = Hash(K, V).new
     hash.initialize_dup(self)
     hash
   end
@@ -1787,12 +1787,12 @@ class Hash(K, V)
   # ```
   def clone
     {% if V == ::Bool || V == ::Char || V == ::String || V == ::Symbol || V < ::Number::Primitive %}
-      clone = self.class.new
+      clone = Hash(K, V).new
       clone.initialize_clone(self)
       clone
     {% else %}
       exec_recursive_clone do |hash|
-        clone = self.class.new
+        clone = Hash(K, V).new
         hash[object_id] = clone.object_id
         clone.initialize_clone(self)
         clone


### PR DESCRIPTION
This reverts commit b6742f0480394168e2f51e2e87c6645a05f6c929

Changes from #9800 are retained.

Resolves #10328