### PR TITLE
Compiler: fix incorrect casting between different union types

### DIFF
--- a/spec/llvm-ir/assign-unions.cr
+++ b/spec/llvm-ir/assign-unions.cr
@@ -1,0 +1,13 @@
+class Foo
+  @v : Int32 | Bool | UInt8[12]
+
+  def initialize
+    @v = 1 || true
+
+    # X64: [[DEST:%.*]] = bitcast %"(Bool | Int32 | StaticArray(UInt8, 12))"* {{.*}} to %"(Bool | Int32)"*
+    # X64-NEXT: [[SRC:%.*]] = load %"(Bool | Int32)", %"(Bool | Int32)"* {{.*}}
+    # X64-NEXT: store %"(Bool | Int32)" {{.*}}[[SRC]], %"(Bool | Int32)"* {{.*}}[[DEST]]
+  end
+end
+
+Foo.new

--- a/spec/llvm-ir/cast-unions.cr
+++ b/spec/llvm-ir/cast-unions.cr
@@ -1,0 +1,5 @@
+(1 || true).as(Int32 | Bool | UInt8[12])
+
+# X64: [[DEST:%.*]] = bitcast %"(Bool | Int32 | StaticArray(UInt8, 12))"* {{.*}} to %"(Bool | Int32)"*
+# X64-NEXT: [[SRC:%.*]] = load %"(Bool | Int32)", %"(Bool | Int32)"* {{.*}}
+# X64-NEXT: store %"(Bool | Int32)" {{.*}}[[SRC]], %"(Bool | Int32)"* {{.*}}[[DEST]]

--- a/spec/llvm-ir/test.sh
+++ b/spec/llvm-ir/test.sh
@@ -38,5 +38,8 @@ test memset.cr "--cross-compile --target x86_64-unknown-linux-gnu --prelude=empt
 test memcpy.cr "--cross-compile --target x86_64-apple-darwin --prelude=empty" X64
 test memcpy.cr "--cross-compile --target x86_64-unknown-linux-gnu --prelude=empty" X64
 
+test cast-unions.cr "--cross-compile --target x86_64-apple-darwin --prelude=empty" X64
+test assign-unions.cr "--cross-compile --target x86_64-apple-darwin --prelude=empty" X64
+
 popd >/dev/null
 

--- a/src/compiler/crystal/codegen/unions.cr
+++ b/src/compiler/crystal/codegen/unions.cr
@@ -104,7 +104,7 @@ module Crystal
 
     def assign_distinct_union_types(target_pointer, target_type, value_type, value)
       # If we have:
-      # - target_pointer: Pointer(A | B |C)
+      # - target_pointer: Pointer(A | B | C)
       # - target_type: A | B | C
       # - value_type: A | B
       # - value: Pointer(A | B)

--- a/src/compiler/crystal/codegen/unions.cr
+++ b/src/compiler/crystal/codegen/unions.cr
@@ -103,8 +103,18 @@ module Crystal
     end
 
     def assign_distinct_union_types(target_pointer, target_type, value_type, value)
-      casted_value = cast_to_pointer value, target_type
-      store load(casted_value), target_pointer
+      # If we have:
+      # - target_pointer: Pointer(A | B |C)
+      # - target_type: A | B | C
+      # - value_type: A | B
+      # - value: Pointer(A | B)
+      #
+      # Then we:
+      # - load the value, we get A | B
+      # - cast the target pointer to Pointer(A | B)
+      # - store the A | B from the first pointer into the casted target pointer
+      casted_target_pointer = cast_to_pointer target_pointer, value_type
+      store load(value), casted_target_pointer
     end
 
     def downcast_distinct_union_types(value, to_type : MixedUnionType, from_type : MixedUnionType)
@@ -112,7 +122,11 @@ module Crystal
     end
 
     def upcast_distinct_union_types(value, to_type : MixedUnionType, from_type : MixedUnionType)
-      cast_to_pointer value, to_type
+      # Because we are casting a union to a bigger union, we need new space
+      # for that, hence the alloca. Then we simply reuse `assign_distinct_union_types`.
+      target_pointer = alloca llvm_type(to_type)
+      assign_distinct_union_types target_pointer, to_type, from_type, value
+      target_pointer
     end
 
     private def type_id_impl(value, type : MixedUnionType)


### PR DESCRIPTION
Fixes #10220 🎉 

Check the comments for the correct code. 

If we have:
- target_pointer: Pointer(A | B |C)
- target_type: A | B | C
- value_type: A | B
- value: Pointer(A | B)

This is one correct way to assign a union to a bigger one:
- load the value, we get A | B
- cast the target pointer to Pointer(A | B)
- store the A | B from the first pointer into the casted target pointer

The old way was doing this:
- cast value, which is Pointer(A | B), to Pointer(A | B | C)
- load the value (!!) . This is the problem: we are reading more memory than we are supposed to, because `sizeof(A | B | C)` is potentially larger than `sizeof(A | B)`
- store the value in the target pointer

It seems LLVM 11 notices now that we are reading more memory than we should and generates a program that crashes 😁 . How much smarter can LLVM get? 😄 


