### PR TITLE
Compiler: initialize right-away constants in a separate function

### DIFF
--- a/src/compiler/crystal/codegen/const.cr
+++ b/src/compiler/crystal/codegen/const.cr
@@ -121,10 +121,7 @@ class Crystal::CodeGenVisitor
   def initialize_const(const)
     # If the constant wasn't read yet, we can initialize it right now and
     # avoid checking an "initialized" flag every time we read it.
-    unless const.read?
-      const.no_init_flag = true
-      return initialize_no_init_flag_const(const)
-    end
+    const.no_init_flag = true unless const.read?
 
     # Maybe the constant was simple and doesn't need a real initialization
     global, initialized_flag = declare_const_and_initialized_flag(const)
@@ -135,7 +132,12 @@ class Crystal::CodeGenVisitor
     func = check_main_fun init_function_name, func
 
     set_current_debug_location const.locations.try &.first? if @debug.line_numbers?
-    run_once(initialized_flag, func)
+
+    if const.no_init_flag?
+      call func
+    else
+      run_once(initialized_flag, func)
+    end
     global
   end
 


### PR DESCRIPTION
Fixes the slowness in the compiler.

Alternative to https://github.com/crystal-lang/crystal/pull/10330

The idea is to still eagerly initialize the constants that can be initialized like that, but do that in a separate function. It seems like that LLVM has an easier time optimizing things.

The code for doing that was already there in the compiler: it's used for all other constants, but doing that in a wrapper that makes sure they are only initialized once.

# Does it really work, and is it really fast?

Please help me try it out. Here's what you can do:
- Run `crystal build src/ecr/process.cr --release -s` with the existing 0.36.0 compiler, or by compiling a compiler from master. Check how long the "bc+obj|" phase takes. For me this takes about 30 seconds.
- Compile a compiler with the code in this PR. Then run `bin/crystal build src/ecr/process.cr --release -s`. It should be faster. For me this takes about 8 seconds.
- Also try the previous point with #10330 . It should take about the same time as before (8 seconds for me).

Then with a compiler built from this PR make sure [this benchmark](https://github.com/crystal-lang/crystal/pull/10330#issuecomment-769866160) is still fast.

You can also compare the times with a 0.35.1 compiler. For me that "bc+obj" phase takes about 6 seconds, not 8. I think LLVM 11 is a bit slower in this aspect.