### PR TITLE
XML: fix deprecation warning

### DIFF
--- a/spec/std/xml/xpath_spec.cr
+++ b/spec/std/xml/xpath_spec.cr
@@ -206,5 +206,10 @@ module XML
       result = doc.xpath_string("string(//feed/person[@id=$value]/@id)", variables: {"value" => 2})
       result.should eq("2")
     end
+
+    it "NodeSet#to_s" do
+      doc = doc()
+      doc.xpath("//people/person").to_s
+    end
   end
 end

--- a/src/xml/node_set.cr
+++ b/src/xml/node_set.cr
@@ -46,7 +46,7 @@ struct XML::NodeSet
   end
 
   def to_s(io : IO) : Nil
-    join '\n', io
+    join io, '\n'
   end
 
   def to_unsafe


### PR DESCRIPTION
Fix #10332

The spec could have been the following

```crystal
      doc.xpath("//people/person").to_s.should eq(<<-OUTPUT)
        <person id="1">
                <name>John</name>
              </person>
        <person id="2">
                <name>Peter</name>
              </person>
        OUTPUT
```

But the indentation is weird and it could defer depending on libxml version. At least the code is stressed.