### PR TITLE
Fix `Process.parse_argument` behavior against a quote in a word

### DIFF
--- a/spec/std/process_spec.cr
+++ b/spec/std/process_spec.cr
@@ -452,6 +452,9 @@ describe Process do
     it { Process.parse_arguments(%q('foo\ bar')).should eq(["foo\\ bar"]) }
     it { Process.parse_arguments("\\").should eq(["\\"]) }
     it { Process.parse_arguments(%q["foo bar" '\hello/' Fizz\ Buzz]).should eq(["foo bar", "\\hello/", "Fizz Buzz"]) }
+    it { Process.parse_arguments(%q[foo"bar"baz]).should eq(["foobarbaz"]) }
+    it { Process.parse_arguments(%q[foo'bar'baz]).should eq(["foobarbaz"]) }
+    it { Process.parse_arguments(%(this 'is a "'very wei"rd co"m"mand please" don't do t'h'a't p"leas"e)).should eq(["this", "is a \"very", "weird command please", "dont do that", "please"]) }
 
     it "raises an error when double quote is unclosed" do
       expect_raises ArgumentError, "Unmatched quote" do

--- a/src/process/shell.cr
+++ b/src/process/shell.cr
@@ -130,7 +130,7 @@ class Process
             reader.next_char
           end
 
-          until (char = reader.current_char) == quote || (!quote && char.ascii_whitespace?)
+          until (char = reader.current_char) == quote || (!quote && (char.ascii_whitespace? || char.in?('\'', '"')))
             break unless reader.has_next?
             reader.next_char
             if char == '\\' && quote != '\''


### PR DESCRIPTION
Fixed #10306
Thanks, @erdnaxeli for reporting.

It fixes the condition to an end of a bare word on a quote character.

Now, it works as we expected.

```crystal
require "process"

pp ARGV
pp Process.parse_arguments(%(this 'is a "'very wei"rd co"m"mand please" don't do t'h'a't p"leas"e))
```

```console
$ bin/crystal run a.cr -- this 'is a "'very wei"rd co"m"mand please" don't do t'h'a't p"leas"e
["this", "is a \"very", "weird command please", "dont do that", "please"]
["this", "is a \"very", "weird command please", "dont do that", "please"]
```