### PR TITLE
Parser: allow more macros names back

### DIFF
--- a/spec/compiler/formatter/formatter_spec.cr
+++ b/spec/compiler/formatter/formatter_spec.cr
@@ -617,6 +617,8 @@ describe Crystal::Formatter do
   assert_format "def foo(@x)\n\nrescue\nend"
 
   assert_format "macro foo\nend"
+  assert_format "macro foo=(x)\nend"
+  assert_format "macro []=(x, y)\nend"
   assert_format "macro foo()\nend", "macro foo\nend"
   assert_format "macro foo( x , y )\nend", "macro foo(x, y)\nend"
   assert_format "macro foo( x  =   1, y  =  2,  &block)\nend", "macro foo(x = 1, y = 2, &block)\nend"

--- a/spec/compiler/parser/parser_spec.cr
+++ b/spec/compiler/parser/parser_spec.cr
@@ -925,16 +925,18 @@ module Crystal
     assert_syntax_error "macro foo; {% foo = 1 }; end"
     assert_syntax_error "macro def foo : String; 1; end"
 
-    assert_syntax_error "macro foo=;end", "macro can't be a setter"
+    it_parses "macro foo=;end", Macro.new("foo=", body: Expressions.new)
     assert_syntax_error "macro Foo;end", "macro can't have a receiver"
     assert_syntax_error "macro foo.bar;end", "macro can't have a receiver"
     assert_syntax_error "macro Foo.bar;end", "macro can't have a receiver"
     assert_syntax_error "macro foo&&;end"
     assert_syntax_error "macro foo"
 
-    ["`", "<<", "<", "<=", "==", "===", "!=", "=~", "!~", ">>", ">", ">=", "+", "-", "*", "/", "//", "~", "%", "!", "&", "|", "^", "**", "[]?", "[]=", "<=>", "&+", "&-", "&*", "&**"].each do |op|
-      assert_syntax_error "macro #{op};end", "invalid macro name"
+    ["`", "<<", "<", "<=", "==", "===", "!=", "=~", "!~", ">>", ">", ">=", "+", "-", "*", "/", "//", "~", "%", "&", "|", "^", "**", "[]?", "[]=", "<=>", "&+", "&-", "&*", "&**"].each do |op|
+      it_parses "macro #{op};end", Macro.new(op, body: Expressions.new)
     end
+
+    assert_syntax_error "macro !;end", "'!' is a pseudo-method and can't be redefined"
 
     it_parses "def foo;{{@type}};end", Def.new("foo", body: Expressions.from([MacroExpression.new("@type".instance_var)] of ASTNode), macro_def: true)
 

--- a/src/compiler/crystal/syntax/parser.cr
+++ b/src/compiler/crystal/syntax/parser.cr
@@ -2978,13 +2978,13 @@ module Crystal
         check_valid_def_name
         next_token
         if @token.type == :"="
-          raise "macro can't be a setter"
+          name += '='
+          next_token
         end
         skip_space
-      when :"[]"
-        next_token_skip_space
       else
-        raise "invalid macro name"
+        check_valid_def_op_name
+        next_token_skip_space
       end
 
       args = [] of Arg

--- a/src/compiler/crystal/tools/formatter.cr
+++ b/src/compiler/crystal/tools/formatter.cr
@@ -1673,6 +1673,11 @@ module Crystal
 
       write node.name
       next_token
+
+      if @token.type == :"=" && node.name.ends_with?('=')
+        next_token
+      end
+
       skip_space(consume_newline: false)
 
       format_def_args node


### PR DESCRIPTION
Partially reverts #10069
Superseds #10314

This retains the "macros can't have a receiver" from #10069 but allows all kinds of names and operators for macros, including setters (this is new). Because this is perfectly fine:

```crystal
class Foo
  macro bar=(x)
    puts "Setting #{ {{x}} }"
  end
end

Foo.bar = 1
```