### PR TITLE
Make the `content-length` header more RFC compliant

### DIFF
--- a/spec/std/http/server/handlers/compress_handler_spec.cr
+++ b/spec/std/http/server/handlers/compress_handler_spec.cr
@@ -127,7 +127,7 @@ describe HTTP::CompressHandler do
     response.close
 
     io.rewind
-    io.to_s.should eq("HTTP/1.1 304 Not Modified\r\nContent-Length: 0\r\n\r\n")
+    io.to_s.should eq("HTTP/1.1 304 Not Modified\r\n\r\n")
   end
 
   it "don't try to compress upgraded response" do

--- a/spec/std/http/server/response_spec.cr
+++ b/spec/std/http/server/response_spec.cr
@@ -42,6 +42,40 @@ describe HTTP::Server::Response do
     io.to_s.should eq("HTTP/1.1 200 OK\r\nContent-Length: 0\r\n\r\n")
   end
 
+  it "does not automatically add the `content-length` header if the response is a 304" do
+    io = IO::Memory.new
+    response = Response.new(io)
+    response.status = :not_modified
+    response.close
+    io.to_s.should eq("HTTP/1.1 304 Not Modified\r\n\r\n")
+  end
+
+  it "does not automatically add the `content-length` header if the response is a 204" do
+    io = IO::Memory.new
+    response = Response.new(io)
+    response.status = :no_content
+    response.close
+    io.to_s.should eq("HTTP/1.1 204 No Content\r\n\r\n")
+  end
+
+  it "does not automatically add the `content-length` header if the response is informational" do
+    io = IO::Memory.new
+    response = Response.new(io)
+    response.status = :processing
+    response.close
+    io.to_s.should eq("HTTP/1.1 102 Processing\r\n\r\n")
+  end
+
+  # Case where the content-length represents the size of the data that would have been returned.
+  it "allows specifying the content-length header explicitly" do
+    io = IO::Memory.new
+    response = Response.new(io)
+    response.status = :not_modified
+    response.headers["Content-Length"] = "5"
+    response.close
+    io.to_s.should eq("HTTP/1.1 304 Not Modified\r\nContent-Length: 5\r\n\r\n")
+  end
+
   it "prints less then buffer's size" do
     io = IO::Memory.new
     response = Response.new(io)

--- a/src/http/server/response.cr
+++ b/src/http/server/response.cr
@@ -225,12 +225,10 @@ class HTTP::Server
 
         # Conditionally determine based on status if the `content-length` header should be added automatically.
         # See https://tools.ietf.org/html/rfc7230#section-3.3.2.
-        include_content_length_header = case response.status
-                                        when .not_modified?, .no_content?, .informational? then false
-                                        else                                                    true
-                                        end
+        status = response.status
+        set_content_length = !(status.not_modified? || status.no_content? || status.informational?)
 
-        if !response.wrote_headers? && !response.headers.has_key?("Content-Length") && include_content_length_header
+        if !response.wrote_headers? && !response.headers.has_key?("Content-Length") && set_content_length
           response.content_length = @out_count
         end
 


### PR DESCRIPTION
[RFC7230](https://tools.ietf.org/html/rfc7230#section-3.3.2) says:

> A server MAY send a Content-Length header field in a 304 (Not Modified) response to a conditional GET request (Section 4.1 of [RFC7232]); a server MUST NOT send Content-Length in such a response unless its field-value equals the decimal number of octets that would have been sent in the payload body of a 200 (OK) response to the same request.

and

> A server MUST NOT send a Content-Length header field in any response with a status code of 1xx (Informational) or 204 (No Content).  A server MUST NOT send a Content-Length header field in any 2xx (Successful) response to a CONNECT request (Section 4.3.6 of [RFC7231]).


This PR updates `HTTP::Server` to better follow the RFC in regard to when the `content-length` header is included automatically.  Previously it would be set to `0`, regardless of the response status, if it was not already set.

This PR does _NOT_ handle the `CONNECT` request case, this is much less common and can be handled via another PR in the future.