### PR TITLE
Allow Int64 values within `IO#read_at`

### DIFF
--- a/spec/std/file_spec.cr
+++ b/spec/std/file_spec.cr
@@ -946,8 +946,13 @@ describe "File" do
       file.read_at(6, 100) do |io|
         io.gets_to_end.should eq("World\nHello World\nHello World\nHello World\nHello World\nHello World\nHello World\nHello World\nHello Worl")
       end
+
       file.read_at(0, 240) do |io|
         io.gets_to_end.should eq(File.read(filename))
+      end
+
+      file.read_at(6_i64, 5_i64) do |io|
+        io.gets_to_end.should eq("World")
       end
     end
   end

--- a/src/file.cr
+++ b/src/file.cr
@@ -804,7 +804,7 @@ class File < IO::FileDescriptor
 
   # Yields an `IO` to read a section inside this file.
   # Multiple sections can be read concurrently.
-  def read_at(offset : Int64, bytesize : Int64, & : IO ->)
+  def read_at(offset, bytesize, & : IO ->)
     self_bytesize = self.size
 
     unless 0 <= offset <= self_bytesize

--- a/src/file.cr
+++ b/src/file.cr
@@ -804,7 +804,7 @@ class File < IO::FileDescriptor
 
   # Yields an `IO` to read a section inside this file.
   # Multiple sections can be read concurrently.
-  def read_at(offset, bytesize, &block)
+  def read_at(offset : Int64, bytesize : Int64, & : IO ->)
     self_bytesize = self.size
 
     unless 0 <= offset <= self_bytesize

--- a/src/file/preader.cr
+++ b/src/file/preader.cr
@@ -4,11 +4,12 @@ class File::PReader < IO
 
   getter? closed = false
 
-  def self.new(file : File, offset : Int32, bytesize : Int32)
-    new file, offset.to_i64, bytesize.to_i64
-  end
+  @offset : Int64
+  @bytesize : Int64
 
-  def initialize(@file : File, @offset : Int64, @bytesize : Int64)
+  def initialize(@file : File, offset : Int, bytesize : Int)
+    @offset = offset.to_i64
+    @bytesize = bytesize.to_i64
     @pos = 0
   end
 

--- a/src/file/preader.cr
+++ b/src/file/preader.cr
@@ -4,7 +4,7 @@ class File::PReader < IO
 
   getter? closed = false
 
-  def initialize(@file : File, @offset : Int32, @bytesize : Int32)
+  def initialize(@file : File, @offset : Int64, @bytesize : Int64)
     @pos = 0
   end
 

--- a/src/file/preader.cr
+++ b/src/file/preader.cr
@@ -4,6 +4,10 @@ class File::PReader < IO
 
   getter? closed = false
 
+  def self.new(file : File, offset : Int32, bytesize : Int32)
+    new file, offset.to_i64, bytesize.to_i64
+  end
+
   def initialize(@file : File, @offset : Int64, @bytesize : Int64)
     @pos = 0
   end

--- a/src/io.cr
+++ b/src/io.cr
@@ -1099,7 +1099,7 @@ abstract class IO
   # `File` and `IO::Memory` implement it.
   #
   # Multiple sections can be read concurrently.
-  def read_at(offset, bytesize, &block)
+  def read_at(offset : Int64, bytesize : Int64, & : IO ->)
     raise Error.new "Unable to read_at"
   end
 

--- a/src/io.cr
+++ b/src/io.cr
@@ -1099,7 +1099,7 @@ abstract class IO
   # `File` and `IO::Memory` implement it.
   #
   # Multiple sections can be read concurrently.
-  def read_at(offset : Int64, bytesize : Int64, & : IO ->)
+  def read_at(offset, bytesize, & : IO ->)
     raise Error.new "Unable to read_at"
   end
 

--- a/src/io/memory.cr
+++ b/src/io/memory.cr
@@ -338,7 +338,7 @@ class IO::Memory < IO
   #
   # During the block duration `self` becomes read-only,
   # so multiple concurrent open are allowed.
-  def read_at(offset, bytesize)
+  def read_at(offset : Int64, bytesize : Int64, & : IO ->)
     unless 0 <= offset <= @bytesize
       raise ArgumentError.new("Offset out of bounds")
     end

--- a/src/io/memory.cr
+++ b/src/io/memory.cr
@@ -338,7 +338,7 @@ class IO::Memory < IO
   #
   # During the block duration `self` becomes read-only,
   # so multiple concurrent open are allowed.
-  def read_at(offset : Int64, bytesize : Int64, & : IO ->)
+  def read_at(offset, bytesize, & : IO ->)
     unless 0 <= offset <= @bytesize
       raise ArgumentError.new("Offset out of bounds")
     end


### PR DESCRIPTION
Fixes #10032.


The C bindings have this arg typed as `SizeT`, which from what I know is an unsigned int.  Do we need to worry/do anything about the case where an Int64 is passed on a 32bit system where a sufficiently large enough Int64 would overflow a UInt32?