### PR TITLE
Parser: allow keyword as named argument inside macros

### DIFF
--- a/spec/compiler/parser/parser_spec.cr
+++ b/spec/compiler/parser/parser_spec.cr
@@ -1850,6 +1850,8 @@ module Crystal
       end
       CR
 
+    it_parses "macro foo; bar class: 1; end", Macro.new("foo", body: MacroLiteral.new(" bar class: 1; "))
+
     describe "end locations" do
       assert_end_location "nil"
       assert_end_location "false"

--- a/src/compiler/crystal/syntax/lexer.cr
+++ b/src/compiler/crystal/syntax/lexer.cr
@@ -3142,7 +3142,7 @@ module Crystal
     end
 
     def peek_not_ident_part_or_end_next_char
-      !ident_part_or_end?(peek_next_char) && next_char
+      !ident_part_or_end?(peek_next_char) && peek_next_char != ':' && next_char
     end
 
     def closing_char(char = current_char)


### PR DESCRIPTION
If you have code like this:

```crystal
macro foo
  span class: "hello" do
  end
end
```

the parser complains because it thinks `class` will start a class and doesn't find a matching `end` (it also finds the `do` and there's a matching `end` for that). However the compiler could tell that it's not a class because colon comes next, and that's a named argument.

This PR fixes that.