### PR TITLE
Support `Tuple#[](Range)` with compile-time range literals

### DIFF
--- a/spec/compiler/codegen/tuple_spec.cr
+++ b/spec/compiler/codegen/tuple_spec.cr
@@ -25,6 +25,169 @@ describe "Code gen: tuple" do
     run("{'a', 42}[2]? || 84").to_i.should eq(84)
   end
 
+  it "codegens tuple metaclass [0]" do
+    run("Tuple(Int32, Char)[0].is_a?(Int32.class)").to_b.should be_true
+  end
+
+  it "codegens tuple metaclass [1]" do
+    run("Tuple(Int32, Char)[1].is_a?(Char.class)").to_b.should be_true
+  end
+
+  it "codegens tuple metaclass [2]?" do
+    run("Tuple(Int32, Char)[2]?.nil?").to_b.should be_true
+  end
+
+  it "codegens tuple [0..0]" do
+    run("
+      #{range_new}
+
+      val = {1, true}[0..0]
+      val.is_a?(Tuple(Int32)) && val[0] == 1
+      ").to_b.should be_true
+  end
+
+  it "codegens tuple [0..1]" do
+    run("
+      #{range_new}
+
+      val = {1, true}[0..1]
+      val.is_a?(Tuple(Int32, Bool)) && val[0] == 1 && val[1] == true
+      ").to_b.should be_true
+  end
+
+  it "codegens tuple [0..2]" do
+    run("
+      #{range_new}
+
+      val = {1, true}[0..2]
+      val.is_a?(Tuple(Int32, Bool)) && val[0] == 1&& val[1] == true
+      ").to_b.should be_true
+  end
+
+  it "codegens tuple [1..1]" do
+    run("
+      #{range_new}
+
+      val = {1, true}[1..1]
+      val.is_a?(Tuple(Bool)) && val[0] == true
+      ").to_b.should be_true
+  end
+
+  it "codegens tuple [1..0]" do
+    run("
+      #{range_new}
+
+      def empty(*args)
+        args
+      end
+
+      {1, true}[1..0].is_a?(typeof(empty))
+      ").to_b.should be_true
+  end
+
+  it "codegens tuple [2..2]" do
+    run("
+      #{range_new}
+
+      def empty(*args)
+        args
+      end
+
+      {1, true}[2..2].is_a?(typeof(empty))
+      ").to_b.should be_true
+  end
+
+  it "codegens tuple [0..0]?" do
+    run("
+      #{range_new}
+
+      val = {1, true}[0..0]?
+      val.is_a?(Tuple(Int32)) && val[0] == 1
+      ").to_b.should be_true
+  end
+
+  it "codegens tuple [0..1]?" do
+    run("
+      #{range_new}
+
+      val = {1, true}[0..1]?
+      val.is_a?(Tuple(Int32, Bool)) && val[0] == 1 && val[1] == true
+      ").to_b.should be_true
+  end
+
+  it "codegens tuple [0..2]?" do
+    run("
+      #{range_new}
+
+      val = {1, true}[0..2]?
+      val.is_a?(Tuple(Int32, Bool)) && val[0] == 1&& val[1] == true
+      ").to_b.should be_true
+  end
+
+  it "codegens tuple [1..1]?" do
+    run("
+      #{range_new}
+
+      val = {1, true}[1..1]?
+      val.is_a?(Tuple(Bool)) && val[0] == true
+      ").to_b.should be_true
+  end
+
+  it "codegens tuple [1..0]?" do
+    run("
+      #{range_new}
+
+      def empty(*args)
+        args
+      end
+
+      {1, true}[1..0]?.is_a?(typeof(empty))
+      ").to_b.should be_true
+  end
+
+  it "codegens tuple [2..2]?" do
+    run("
+      #{range_new}
+
+      def empty(*args)
+        args
+      end
+
+      {1, true}[2..2]?.is_a?(typeof(empty))
+      ").to_b.should be_true
+  end
+
+  it "codegens tuple [3..2]?" do
+    run("#{range_new}; {1, true}[3..2]?.nil?").to_b.should be_true
+  end
+
+  it "codegens tuple [-3..2]?" do
+    run("#{range_new}; {1, true}[-3..2]?.nil?").to_b.should be_true
+  end
+
+  it "codegens tuple metaclass [0..0]" do
+    run("#{range_new}; Tuple(Int32, Char)[0..0].is_a?(Tuple(Int32).class)").to_b.should be_true
+  end
+
+  it "codegens tuple metaclass [0..1]" do
+    run("#{range_new}; Tuple(Int32, Char)[0..1].is_a?(Tuple(Int32, Char).class)").to_b.should be_true
+  end
+
+  it "codegens tuple metaclass [1..0]" do
+    run("
+      #{range_new}
+
+      def empty(*args)
+        args.class
+      end
+
+      Tuple(Int32, Char)[1..0].is_a?(typeof(empty))").to_b.should be_true
+  end
+
+  it "codegens tuple metaclass [3..2]?" do
+    run("#{range_new}; Tuple(Int32, Char)[3..2]?.nil?").to_b.should be_true
+  end
+
   it "passed tuple to def" do
     run("
       def foo(t)
@@ -364,4 +527,13 @@ describe "Code gen: tuple" do
       x = {0, z}
       ))
   end
+end
+
+private def range_new
+  %(
+    struct Range(B, E)
+      def initialize(@begin : B, @end : E, @exclusive : Bool = false)
+      end
+    end
+  )
 end

--- a/src/compiler/crystal/semantic/ast.cr
+++ b/src/compiler/crystal/semantic/ast.cr
@@ -57,7 +57,7 @@ module Crystal
 
   # Fictitious node to represent a tuple indexer
   class TupleIndexer < Primitive
-    getter index : Int32 | Range(Int32, Int32)
+    getter index : TupleInstanceType::Index
 
     def initialize(@index)
       super("tuple_indexer_known_index")

--- a/src/compiler/crystal/semantic/ast.cr
+++ b/src/compiler/crystal/semantic/ast.cr
@@ -57,9 +57,9 @@ module Crystal
 
   # Fictitious node to represent a tuple indexer
   class TupleIndexer < Primitive
-    getter index : Int32
+    getter index : Int32 | Range(Int32, Int32)
 
-    def initialize(@index : Int32)
+    def initialize(@index)
       super("tuple_indexer_known_index")
     end
 

--- a/src/compiler/crystal/semantic/main_visitor.cr
+++ b/src/compiler/crystal/semantic/main_visitor.cr
@@ -2895,17 +2895,19 @@ module Crystal
     def visit(node : TupleIndexer)
       scope = @scope
       if scope.is_a?(TupleInstanceType)
-        if (index = node.index).is_a?(Range)
+        case index = node.index
+        in Range
           node.type = @program.tuple_of(scope.tuple_types[index].map &.as(Type))
-        else
+        in Int32
           node.type = scope.tuple_types[index].as(Type)
         end
       elsif scope.is_a?(NamedTupleInstanceType)
         node.type = scope.entries[node.index.as(Int32)].type
       elsif scope && (instance_type = scope.instance_type).is_a?(TupleInstanceType)
-        if (index = node.index).is_a?(Range)
+        case index = node.index
+        in Range
           node.type = @program.tuple_of(instance_type.tuple_types[index].map &.as(Type)).metaclass
-        else
+        in Int32
           node.type = instance_type.tuple_types[index].as(Type).metaclass
         end
       elsif scope && (instance_type = scope.instance_type).is_a?(NamedTupleInstanceType)

--- a/src/compiler/crystal/semantic/main_visitor.cr
+++ b/src/compiler/crystal/semantic/main_visitor.cr
@@ -2895,13 +2895,21 @@ module Crystal
     def visit(node : TupleIndexer)
       scope = @scope
       if scope.is_a?(TupleInstanceType)
-        node.type = scope.tuple_types[node.index].as(Type)
+        if (index = node.index).is_a?(Range)
+          node.type = @program.tuple_of(scope.tuple_types[index].map &.as(Type))
+        else
+          node.type = scope.tuple_types[index].as(Type)
+        end
       elsif scope.is_a?(NamedTupleInstanceType)
-        node.type = scope.entries[node.index].type
+        node.type = scope.entries[node.index.as(Int32)].type
       elsif scope && (instance_type = scope.instance_type).is_a?(TupleInstanceType)
-        node.type = instance_type.tuple_types[node.index].as(Type).metaclass
+        if (index = node.index).is_a?(Range)
+          node.type = @program.tuple_of(instance_type.tuple_types[index].map &.as(Type)).metaclass
+        else
+          node.type = instance_type.tuple_types[index].as(Type).metaclass
+        end
       elsif scope && (instance_type = scope.instance_type).is_a?(NamedTupleInstanceType)
-        node.type = instance_type.entries[node.index].type.metaclass
+        node.type = instance_type.entries[node.index.as(Int32)].type.metaclass
       else
         node.raise "unsupported TupleIndexer scope"
       end

--- a/src/compiler/crystal/types.cr
+++ b/src/compiler/crystal/types.cr
@@ -2321,6 +2321,8 @@ module Crystal
 
   # An instantiated tuple type, like Tuple(Char, Int32).
   class TupleInstanceType < GenericClassInstanceType
+    alias Index = Int32 | Range(Int32, Int32)
+
     getter tuple_types : Array(Type)
 
     def initialize(program, @tuple_types)
@@ -2332,12 +2334,12 @@ module Crystal
     end
 
     def tuple_indexer(index)
-      indexers = @tuple_indexers ||= {} of (Int32 | Range(Int32, Int32)) => Def
+      indexers = @tuple_indexers ||= {} of Index => Def
       tuple_indexer(indexers, index)
     end
 
     def tuple_metaclass_indexer(index)
-      indexers = @tuple_metaclass_indexers ||= {} of (Int32 | Range(Int32, Int32)) => Def
+      indexers = @tuple_metaclass_indexers ||= {} of Index => Def
       tuple_indexer(indexers, index)
     end
 

--- a/src/compiler/crystal/types.cr
+++ b/src/compiler/crystal/types.cr
@@ -2332,12 +2332,12 @@ module Crystal
     end
 
     def tuple_indexer(index)
-      indexers = @tuple_indexers ||= {} of Int32 => Def
+      indexers = @tuple_indexers ||= {} of (Int32 | Range(Int32, Int32)) => Def
       tuple_indexer(indexers, index)
     end
 
     def tuple_metaclass_indexer(index)
-      indexers = @tuple_metaclass_indexers ||= {} of Int32 => Def
+      indexers = @tuple_metaclass_indexers ||= {} of (Int32 | Range(Int32, Int32)) => Def
       tuple_indexer(indexers, index)
     end
 

--- a/src/tuple.cr
+++ b/src/tuple.cr
@@ -204,7 +204,7 @@ struct Tuple
   # tuple[i..2] # Error: Tuple#[](Range) can only be called with range literals known at compile-time
   #
   # i = 0..2
-  # tuple[i]    # Error: Tuple#[](Range) can only be called with range literals known at compile-time
+  # tuple[i] # Error: Tuple#[](Range) can only be called with range literals known at compile-time
   # ```
   def [](range : Range)
     {% raise "Tuple#[](Range) can only be called with range literals known at compile-time" %}

--- a/src/tuple.cr
+++ b/src/tuple.cr
@@ -23,6 +23,15 @@
 # a value whose type is the union of all the types in the tuple, and might raise
 # `IndexError`.
 #
+# Indexing with a range literal known at compile-time is also allowed, and the
+# returned value will have the correct sub-tuple type:
+#
+# ```
+# tuple = {1, "hello", 'x'} # Tuple(Int32, String, Char)
+# sub = tuple[0..1]         # => {1, "hello"}
+# typeof(sub)               # => Tuple(Int32, String)
+# ```
+#
 # Tuples are the preferred way to return fixed-size multiple return
 # values because no memory is needed to be allocated for them:
 #
@@ -173,6 +182,32 @@ struct Tuple
   # ```
   def []?(index : Int)
     at(index) { nil }
+  end
+
+  # Returns all elements that are within the given *range*. *range* must be a
+  # range literal whose value is known at compile-time.
+  #
+  # Negative indices count backward from the end of the array (-1 is the last
+  # element). Additionally, an empty array is returned when the starting index
+  # for an element range is at the end of the array.
+  #
+  # Raises a compile-time error if `range.begin` is out of range.
+  #
+  # ```
+  # tuple = {1, "hello", 'x'}
+  # tuple[0..1] # => {1, "hello"}
+  # tuple[-2..] # => {"hello", 'x'}
+  # tuple[...1] # => {1}
+  # tuple[4..]  # Error: begin index out of bounds for Tuple(Int32, Char, Array(Int32), String) (5 not in -4..4)
+  #
+  # i = 0
+  # tuple[i..2] # Error: Tuple#[](Range) can only be called with range literals known at compile-time
+  #
+  # i = 0..2
+  # tuple[i]    # Error: Tuple#[](Range) can only be called with range literals known at compile-time
+  # ```
+  def [](range : Range)
+    {% raise "Tuple#[](Range) can only be called with range literals known at compile-time" %}
   end
 
   # Returns the element at the given *index* or raises IndexError if out of bounds.


### PR DESCRIPTION
`Tuple#[](index : Int)` returns the element in the proper type if `index` is an integer literal known at compile-time. This PR adds a `Tuple#[](range : Range)` pseudo-overload that _only_ supports compile-time range literals, and returns the elements in a proper sub-tuple type:

```crystal
tuple = {1, "hello", 'x'}
v = tuple[0..1] # => {1, "hello"}
typeof(v)       # => Tuple(Int32, String)

i = 0
tuple[i..1] # Error: Tuple#[](Range) can only be called with range literals known at compile-time

i = 0..1
tuple[i] # Error: Tuple#[](Range) can only be called with range literals known at compile-time
```

The motivation is to enable #132 for `Tuple` values on the RHS, without creating temporary `Array`s: (only one layer of decomposition is considered here)

```crystal
a, *b, c = {1, 2, 3, 4, 5}
a # => 1
b # => {2, 3, 4}
c # => 5
```

It is assumed that the Crystal compiler should transform the above multi-assign expression into the following, in a purely syntactic manner:

```crystal
__temp = {1, 2, 3, 4, 5}
a = __temp[0]
b = __temp[1..-2] # => {2, 3, 4}
c = __temp[-1]
```

The method supports incomplete and exclusive ranges to match the behaviour of other `#[](Range)` methods, even though the expansion here doesn't require them.

The range index corresponding to the splat variable is always known at compile-time, because it can be deduced from the number of non-splat variables before and after it; thus it suffices to implement the special case for `Tuple`s where this range is a constant expression. (The same syntactic transformation already works out of the box for types that implement `#[](Range)`, like `Array`.)

On the other hand, the only sensible return type of `Tuple(*T)#[](Range)` for runtime range arguments is `Array(Union(*T))`. This PR does not address this discrepancy at all, that's left to #7619. Method lookup bypasses prelude definitions of `(Named)Tuple#[]` if a compile-time indexer is found, so the compile-time error seen in the top example will not be triggered by constant range literals.

The documentation for this method does not take #10243 into account.

Also see the [Gitter discussion](https://gitter.im/crystal-lang/crystal?at=6022c37a9fa6765ef80af478) that led up to this.