### PR TITLE
HTTP::Request#local_address

### DIFF
--- a/spec/std/http/server/server_spec.cr
+++ b/spec/std/http/server/server_spec.cr
@@ -475,48 +475,54 @@ describe HTTP::Server do
       end
     end
   end
-end
 
-describe "#remote_address" do
-  it "for http server" do
-    remote_address = nil
+  describe "#remote_address / #local_address" do
+    it "for http server" do
+      remote_address = nil
+      local_address = nil
 
-    server = HTTP::Server.new do |context|
-      remote_address = context.request.remote_address
-    end
+      server = HTTP::Server.new do |context|
+        remote_address = context.request.remote_address
+        local_address = context.request.local_address
+      end
 
-    tcp_server = TCPServer.new("127.0.0.1", 0)
-    server.bind tcp_server
-    address1 = tcp_server.local_address
+      tcp_server = TCPServer.new("127.0.0.1", 0)
+      server.bind tcp_server
+      address1 = tcp_server.local_address
 
-    run_server(server) do
-      HTTP::Client.new(URI.parse("http://#{address1}/")) do |client|
-        client.get("/")
+      run_server(server) do
+        HTTP::Client.new(URI.parse("http://#{address1}/")) do |client|
+          client.get("/")
 
-        remote_address.should eq(client.@io.as(IPSocket).local_address)
+          remote_address.should eq(client.@io.as(IPSocket).local_address)
+          local_address.should eq(client.@io.as(IPSocket).remote_address)
+        end
       end
     end
-  end
 
-  it "for https server" do
-    remote_address = nil
+    it "for https server" do
+      remote_address = nil
+      local_address = nil
 
-    server = HTTP::Server.new do |context|
-      remote_address = context.request.remote_address
-    end
+      server = HTTP::Server.new do |context|
+        remote_address = context.request.remote_address
+        local_address = context.request.local_address
+      end
 
-    server_context, client_context = ssl_context_pair
+      server_context, client_context = ssl_context_pair
 
-    socket = OpenSSL::SSL::Server.new(TCPServer.new("127.0.0.1", 0), server_context)
-    server.bind socket
-    ip_address1 = server.bind_tls "127.0.0.1", 0, server_context
+      socket = OpenSSL::SSL::Server.new(TCPServer.new("127.0.0.1", 0), server_context)
+      server.bind socket
+      ip_address1 = server.bind_tls "127.0.0.1", 0, server_context
 
-    run_server(server) do
-      HTTP::Client.new(
-        uri: URI.parse("https://#{ip_address1}"),
-        tls: client_context) do |client|
-        client.get("/")
-        remote_address.should eq(client.@io.as(OpenSSL::SSL::Socket).local_address)
+      run_server(server) do
+        HTTP::Client.new(
+          uri: URI.parse("https://#{ip_address1}"),
+          tls: client_context) do |client|
+          client.get("/")
+          remote_address.should eq(client.@io.as(OpenSSL::SSL::Socket).local_address)
+          local_address.should eq(client.@io.as(OpenSSL::SSL::Socket).remote_address)
+        end
       end
     end
   end

--- a/src/http/request.cr
+++ b/src/http/request.cr
@@ -29,10 +29,20 @@ class HTTP::Request
     #
     # This property is not used by `HTTP::Client`.
     property remote_address : Socket::Address?
+
+    # The network address of the HTTP server.
+    #
+    # `HTTP::Server` will try to fill this property, and its value
+    # will have a format like "IP:port", but this format is not guaranteed.
+    # Middlewares can overwrite this value.
+    #
+    # This property is not used by `HTTP::Client`.
+    property local_address : Socket::Address?
   {% else %}
     # TODO: Remove this once `Socket` is working on Windows
 
     property remote_address : Nil
+    property local_address : Nil
   {% end %}
 
   def self.new(method : String, resource : String, headers : Headers? = nil, body : String | Bytes | IO | Nil = nil, version = "HTTP/1.1")
@@ -117,6 +127,10 @@ class HTTP::Request
 
       if io.responds_to?(:remote_address)
         request.remote_address = io.remote_address
+      end
+
+      if io.responds_to?(:local_address)
+        request.local_address = io.local_address
       end
 
       return request


### PR DESCRIPTION
In Websocket scenarios we would like to log the local address of the connection.

Code copied straight from `HTTP::Request#remote_address`