### PR TITLE
Drop deprecated definitions

### DIFF
--- a/spec/compiler/codegen/macro_spec.cr
+++ b/spec/compiler/codegen/macro_spec.cr
@@ -770,7 +770,7 @@ describe "Code gen: macro" do
       )).to_string.should eq("Green")
   end
 
-  it "says that enum has Flags attribute" do
+  it "says that enum has Flags annotation" do
     run(%(
       @[Flags]
       enum Color
@@ -779,11 +779,11 @@ describe "Code gen: macro" do
         Blue
       end
 
-      {{Color.has_attribute?("Flags")}}
+      {{Color.annotation(Flags) ? true : false}}
       )).to_b.should be_true
   end
 
-  it "says that enum doesn't have Flags attribute" do
+  it "says that enum doesn't have Flags annotation" do
     run(%(
       enum Color
         Red
@@ -791,7 +791,7 @@ describe "Code gen: macro" do
         Blue
       end
 
-      {{Color.has_attribute?("Flags")}}
+      {{Color.annotation(Flags) ? true : false}}
       )).to_b.should be_false
   end
 

--- a/spec/compiler/crystal/tools/doc/doc_renderer_spec.cr
+++ b/spec/compiler/crystal/tools/doc/doc_renderer_spec.cr
@@ -15,7 +15,7 @@ private def it_renders(context, input, output, file = __FILE__, line = __LINE__)
         generator.type(program)
       end
       Doc::Markdown.parse input, Doc::Markdown::DocRenderer.new(c, io)
-    end.should eq(output), file, line
+    end.should eq(output), file: file, line: line
   end
 end
 

--- a/spec/std/compress/zlib/stress_spec.cr
+++ b/spec/std/compress/zlib/stress_spec.cr
@@ -5,7 +5,7 @@ module Compress::Zlib
   describe Zlib do
     it "write read should be inverse with random string" do
       expected = String.build do |io|
-        1_000_000.times { rand(2000).to_i.to_s(32, io) }
+        1_000_000.times { rand(2000).to_i.to_s(io, 32) }
       end
 
       io = IO::Memory.new

--- a/spec/std/http/client/client_spec.cr
+++ b/spec/std/http/client/client_spec.cr
@@ -264,11 +264,11 @@ module HTTP
         client = TestClient.new "www.example.com"
         request = HTTP::Request.new("GET", "/")
         client.set_defaults(request)
-        request.host.should eq "www.example.com"
+        request.hostname.should eq "www.example.com"
 
         request = HTTP::Request.new("GET", "/", HTTP::Headers{"Host" => "other.example.com"})
         client.set_defaults(request)
-        request.host.should eq "other.example.com"
+        request.hostname.should eq "other.example.com"
       end
     end
 
@@ -288,7 +288,7 @@ module HTTP
 
       io_request.rewind
       request = HTTP::Request.from_io(io_request).as(HTTP::Request)
-      request.host.should eq("")
+      request.hostname.should eq("")
     end
 
     it "can specify host and port when initialized with IO" do

--- a/spec/std/http/request_spec.cr
+++ b/spec/std/http/request_spec.cr
@@ -439,9 +439,9 @@ module HTTP
         request.query_params.to_s.should eq(new_query)
       end
 
-      it "gets request host from the headers" do
+      it "gets request hostname from the headers" do
         request = Request.from_io(IO::Memory.new("GET / HTTP/1.1\r\nHost: host.example.org:3000\r\nReferer:\r\n\r\n")).as(Request)
-        request.host.should eq("host.example.org")
+        request.hostname.should eq("host.example.org")
       end
 
       it "#hostname" do

--- a/spec/std/http/server/handlers/log_handler_spec.cr
+++ b/spec/std/http/server/handlers/log_handler_spec.cr
@@ -39,22 +39,6 @@ describe HTTP::LogHandler do
     logs.check(:info, %r(^- - GET / HTTP/1.1 - 200 \(\d+(\.\d+)?[mµn]s\)$))
   end
 
-  it "logs to io" do
-    request = HTTP::Request.new("GET", "/")
-    response = HTTP::Server::Response.new(IO::Memory.new)
-    context = HTTP::Server::Context.new(request, response)
-
-    backend = Log::MemoryBackend.new
-    io = IO::Memory.new
-    handler = HTTP::LogHandler.new(io)
-    handler.next = ->(ctx : HTTP::Server::Context) {}
-    handler.call(context)
-
-    retry do
-      io.to_s.should match(%r(- - GET / HTTP/1.1 - 200 \(\d+(\.\d+)?[mµn]s\)$))
-    end
-  end
-
   it "log failed request" do
     io = IO::Memory.new
     request = HTTP::Request.new("GET", "/")

--- a/spec/std/int_spec.cr
+++ b/spec/std/int_spec.cr
@@ -9,8 +9,6 @@ end
 
 private def to_s_with_io(num, base, upcase = false)
   String.build { |io| num.to_s(io, base, upcase: upcase) }
-  # Test deprecated overload:
-  String.build { |io| num.to_s(base, io, upcase) }
 end
 
 describe "Int" do
@@ -176,7 +174,6 @@ describe "Int" do
     it { 1234.to_s(36).should eq("ya") }
     it { -1234.to_s(36).should eq("-ya") }
     it { 1234.to_s(16, upcase: true).should eq("4D2") }
-    it { 1234.to_s(16, true).should eq("4D2") } # Deprecated test
     it { -1234.to_s(16, upcase: true).should eq("-4D2") }
     it { 1234.to_s(36, upcase: true).should eq("YA") }
     it { -1234.to_s(36, upcase: true).should eq("-YA") }

--- a/spec/std/set_spec.cr
+++ b/spec/std/set_spec.cr
@@ -340,20 +340,6 @@ describe "Set" do
     iter.next.should be_a(Iterator::Stop)
   end
 
-  it "check subset" do
-    set = Set{1, 2, 3}
-    empty_set = Set(Int32).new
-
-    set.subset?(Set{1, 2, 3, 4}).should be_true
-    set.subset?(Set{1, 2, 3, "4"}).should be_true
-    set.subset?(Set{1, 2, 3}).should be_true
-    set.subset?(Set{1, 2}).should be_false
-    set.subset?(empty_set).should be_false
-
-    empty_set.subset?(Set{1}).should be_true
-    empty_set.subset?(empty_set).should be_true
-  end
-
   it "#subset_of?" do
     set = Set{1, 2, 3}
     empty_set = Set(Int32).new
@@ -366,20 +352,6 @@ describe "Set" do
 
     empty_set.subset_of?(Set{1}).should be_true
     empty_set.subset_of?(empty_set).should be_true
-  end
-
-  it "check proper_subset" do
-    set = Set{1, 2, 3}
-    empty_set = Set(Int32).new
-
-    set.proper_subset?(Set{1, 2, 3, 4}).should be_true
-    set.proper_subset?(Set{1, 2, 3, "4"}).should be_true
-    set.proper_subset?(Set{1, 2, 3}).should be_false
-    set.proper_subset?(Set{1, 2}).should be_false
-    set.proper_subset?(empty_set).should be_false
-
-    empty_set.proper_subset?(Set{1}).should be_true
-    empty_set.proper_subset?(empty_set).should be_false
   end
 
   it "#proper_subset_of?" do
@@ -396,20 +368,6 @@ describe "Set" do
     empty_set.proper_subset_of?(empty_set).should be_false
   end
 
-  it "check superset" do
-    set = Set{1, 2, "3"}
-    empty_set = Set(Int32).new
-
-    set.superset?(empty_set).should be_true
-    set.superset?(Set{1, 2}).should be_true
-    set.superset?(Set{1, 2, "3"}).should be_true
-    set.superset?(Set{1, 2, 3}).should be_false
-    set.superset?(Set{1, 2, 3, 4}).should be_false
-    set.superset?(Set{1, 4}).should be_false
-
-    empty_set.superset?(empty_set).should be_true
-  end
-
   it "#superset_of?" do
     set = Set{1, 2, "3"}
     empty_set = Set(Int32).new
@@ -422,20 +380,6 @@ describe "Set" do
     set.superset_of?(Set{1, 4}).should be_false
 
     empty_set.superset_of?(empty_set).should be_true
-  end
-
-  it "check proper_superset" do
-    set = Set{1, 2, "3"}
-    empty_set = Set(Int32).new
-
-    set.proper_superset?(empty_set).should be_true
-    set.proper_superset?(Set{1, 2}).should be_true
-    set.proper_superset?(Set{1, 2, "3"}).should be_false
-    set.proper_superset?(Set{1, 2, 3}).should be_false
-    set.proper_superset?(Set{1, 2, 3, 4}).should be_false
-    set.proper_superset?(Set{1, 4}).should be_false
-
-    empty_set.proper_superset?(empty_set).should be_false
   end
 
   it "#proper_superset_of?" do

--- a/spec/std/string_spec.cr
+++ b/spec/std/string_spec.cr
@@ -2162,13 +2162,6 @@ describe "String" do
       it { String.build { |io| "12".ljust(io, 7, '-') }.should eq("12-----") }
       it { String.build { |io| "12".ljust(io, 7, 'あ') }.should eq("12あああああ") }
     end
-
-    describe "to io (deprecated)" do
-      it { String.build { |io| "123".ljust(2, io) }.should eq("123") }
-      it { String.build { |io| "123".ljust(5, io) }.should eq("123  ") }
-      it { String.build { |io| "12".ljust(7, '-', io) }.should eq("12-----") }
-      it { String.build { |io| "12".ljust(7, 'あ', io) }.should eq("12あああああ") }
-    end
   end
 
   describe "rjust" do
@@ -2183,13 +2176,6 @@ describe "String" do
       it { String.build { |io| "12".rjust(io, 7, '-') }.should eq("-----12") }
       it { String.build { |io| "12".rjust(io, 7, 'あ') }.should eq("あああああ12") }
     end
-
-    describe "to io (deprecated)" do
-      it { String.build { |io| "123".rjust(2, io) }.should eq("123") }
-      it { String.build { |io| "123".rjust(5, io) }.should eq("  123") }
-      it { String.build { |io| "12".rjust(7, '-', io) }.should eq("-----12") }
-      it { String.build { |io| "12".rjust(7, 'あ', io) }.should eq("あああああ12") }
-    end
   end
 
   describe "center" do
@@ -2203,13 +2189,6 @@ describe "String" do
       it { String.build { |io| "123".center(io, 5) }.should eq(" 123 ") }
       it { String.build { |io| "12".center(io, 7, '-') }.should eq("--12---") }
       it { String.build { |io| "12".center(io, 7, 'あ') }.should eq("ああ12あああ") }
-    end
-
-    describe "to io (deprecated)" do
-      it { String.build { |io| "123".center(2, io) }.should eq("123") }
-      it { String.build { |io| "123".center(5, io) }.should eq(" 123 ") }
-      it { String.build { |io| "12".center(7, '-', io) }.should eq("--12---") }
-      it { String.build { |io| "12".center(7, 'あ', io) }.should eq("ああ12あああ") }
     end
   end
 

--- a/spec/std/time/span_spec.cr
+++ b/spec/std/time/span_spec.cr
@@ -173,9 +173,8 @@ describe Time::Span do
     1_000_000.5.days.to_s.should eq("1000000.12:00:00")
   end
 
-  it "test negate and duration" do
+  it "test negate and abs" do
     (-Time::Span.new(nanoseconds: 1234500)).to_s.should eq("-00:00:00.001234500")
-    Time::Span.new(nanoseconds: -1234500).duration.to_s.should eq("00:00:00.001234500")
     Time::Span.new(nanoseconds: -1234500).abs.to_s.should eq("00:00:00.001234500")
     (-Time::Span.new(nanoseconds: 7700)).to_s.should eq("-00:00:00.000007700")
     (+Time::Span.new(nanoseconds: 7700)).to_s.should eq("00:00:00.000007700")

--- a/spec/std/uri_spec.cr
+++ b/spec/std/uri_spec.cr
@@ -204,21 +204,6 @@ describe "URI" do
     it { URI.new(scheme: "scheme", path: "/path").authority.should be_nil }
   end
 
-  describe "#full_path" do
-    it { URI.new(path: "/foo").full_path.should eq("/foo") }
-    it { URI.new.full_path.should eq("/") }
-    it { URI.new(path: "/foo", query: "q=1").full_path.should eq("/foo?q=1") }
-    it { URI.new(path: "/", query: "q=1").full_path.should eq("/?q=1") }
-    it { URI.new(query: "q=1").full_path.should eq("/?q=1") }
-    it { URI.new(path: "/a%3Ab").full_path.should eq("/a%3Ab") }
-
-    it "does not add '?' to the end if the query params are empty" do
-      uri = URI.parse("http://www.example.com/foo")
-      uri.query = ""
-      uri.full_path.should eq("/foo")
-    end
-  end
-
   describe "#request_target" do
     it { URI.new(path: "/foo").request_target.should eq("/foo") }
     it { URI.new.request_target.should eq("/") }

--- a/spec/std/yaml/builder_spec.cr
+++ b/spec/std/yaml/builder_spec.cr
@@ -190,16 +190,4 @@ describe YAML::Builder do
       end
     end.should eq 1.to_yaml
   end
-
-  it ".new (with block)" do
-    String.build do |io|
-      YAML::Builder.new(io) do |builder|
-        builder.stream do
-          builder.document do
-            builder.scalar(1)
-          end
-        end
-      end
-    end.should eq 1.to_yaml
-  end
 end

--- a/src/compiler/crystal/macros.cr
+++ b/src/compiler/crystal/macros.cr
@@ -1919,13 +1919,6 @@ module Crystal::Macros
     def has_method?(name : StringLiteral | SymbolLiteral) : BoolLiteral
     end
 
-    # Returns `true` if this type has an attribute. For example `@[Flags]`
-    # or `@[Packed]` (the name you pass to this method is `"Flags"` or `"Packed"`
-    # in these cases).
-    @[Deprecated("Use #annotation instead")]
-    def has_attribute?(name : StringLiteral | SymbolLiteral) : BoolLiteral
-    end
-
     # Returns the last `Annotation` with the given `type`
     # attached to this variable or `NilLiteral` if there are none.
     def annotation(type : TypeNode) : Annotation | NilLiteral

--- a/src/compiler/crystal/macros/methods.cr
+++ b/src/compiler/crystal/macros/methods.cr
@@ -1624,19 +1624,6 @@ module Crystal
           value = arg.to_string("argument to 'TypeNode#has_method?'")
           TypeNode.has_method?(type, value)
         end
-      when "has_attribute?"
-        interpreter.report_warning_at(name_loc, "Deprecated TypeNode#has_attribute?. Use #annotation instead")
-        interpret_one_arg_method(method, args) do |arg|
-          value = arg.to_string("argument to 'TypeNode#has_attribute?'")
-          case value
-          when "Flags"
-            BoolLiteral.new(!!type.as?(EnumType).try &.flags?)
-          when "Packed"
-            BoolLiteral.new(!!type.as?(ClassType).try &.packed?)
-          else
-            BoolLiteral.new(false)
-          end
-        end
       when "annotation"
         fetch_annotation(self, method, args) do |type|
           self.type.annotation(type)

--- a/src/dir.cr
+++ b/src/dir.cr
@@ -249,12 +249,6 @@ class Dir
   end
 
   # Removes the directory at the given path.
-  @[Deprecated("Use `Dir.delete` instead")]
-  def self.rmdir(path : Path | String)
-    delete(path)
-  end
-
-  # Removes the directory at the given path.
   def self.delete(path : Path | String)
     Crystal::System::Dir.delete(path.to_s)
   end

--- a/src/file/info.cr
+++ b/src/file/info.cr
@@ -96,20 +96,8 @@ class File
     # The user ID that the file belongs to.
     abstract def owner_id : String
 
-    # :ditto:
-    @[Deprecated("Use File#owner_id instead")]
-    def owner : UInt32
-      owner_id.to_u32
-    end
-
     # The group ID that the file belongs to.
     abstract def group_id : String
-
-    # :ditto:
-    @[Deprecated("Use File#group_id instead")]
-    def group : UInt32
-      group_id.to_u32
-    end
 
     # Returns true if this `Info` and *other* are of the same file.
     #

--- a/src/hash.cr
+++ b/src/hash.cr
@@ -1208,25 +1208,6 @@ class Hash(K, V)
     entry ? entry.value : yield key
   end
 
-  # Deletes each key-value pair for which the given block returns `true`.
-  #
-  # ```
-  # h = {"foo" => "bar", "fob" => "baz", "bar" => "qux"}
-  # h.delete_if { |key, value| key.starts_with?("fo") }
-  # h # => { "bar" => "qux" }
-  # ```
-  @[Deprecated("Use `#reject!` instead")]
-  def delete_if
-    keys_to_delete = [] of K
-    each do |key, value|
-      keys_to_delete << key if yield(key, value)
-    end
-    keys_to_delete.each do |key|
-      delete(key)
-    end
-    self
-  end
-
   # Returns `true` when hash contains no key-value pairs.
   #
   # ```

--- a/src/http/request.cr
+++ b/src/http/request.cr
@@ -245,15 +245,6 @@ class HTTP::Request
     value
   end
 
-  # Returns request host from headers.
-  @[Deprecated("Use `#hostname` instead.")]
-  def host
-    host = @headers["Host"]?
-    return unless host
-    index = host.index(":")
-    index ? host[0...index] : host
-  end
-
   # Extracts the hostname from `Host` header.
   #
   # Returns `nil` if the `Host` header is missing.

--- a/src/http/server/handlers/log_handler.cr
+++ b/src/http/server/handlers/log_handler.cr
@@ -5,11 +5,6 @@ require "log"
 class HTTP::LogHandler
   include HTTP::Handler
 
-  @[Deprecated("Use `new([Log])` instead")]
-  def initialize(io : IO)
-    @log = Log.new("http.server", Log::IOBackend.new(io), :info)
-  end
-
   def initialize(@log = Log.for("http.server"))
   end
 

--- a/src/http/web_socket.cr
+++ b/src/http/web_socket.cr
@@ -103,11 +103,6 @@ class HTTP::WebSocket
     end
   end
 
-  @[Deprecated("Use WebSocket#close(code, message) instead")]
-  def close(message)
-    close(nil, message)
-  end
-
   # Sends a close frame to the client, and closes the connection.
   # The close frame may contain a body (message) that indicates the reason for closing.
   def close(code : CloseCode | Int? = nil, message = nil)

--- a/src/int.cr
+++ b/src/int.cr
@@ -620,11 +620,6 @@ struct Int
     end
   end
 
-  @[Deprecated("Use `#to_s(base : Int, *, upcase : Bool = false)` instead")]
-  def to_s(base : Int, _upcase : Bool) : String
-    to_s(base, upcase: _upcase)
-  end
-
   def to_s(io : IO, base : Int = 10, *, upcase : Bool = false) : Nil
     raise ArgumentError.new("Invalid base #{base}") unless 2 <= base <= 36 || base == 62
     raise ArgumentError.new("upcase must be false for base 62") if upcase && base == 62
@@ -639,11 +634,6 @@ struct Int
         io.write_utf8 Slice.new(ptr, count)
       end
     end
-  end
-
-  @[Deprecated("Use `#to_s(io : IO, base : Int, *, upcase : Bool = false)` instead")]
-  def to_s(base : Int, io : IO, upcase : Bool = false) : Nil
-    to_s(io, base, upcase: upcase)
   end
 
   private def internal_to_s(base, upcase = false)

--- a/src/log/setup.cr
+++ b/src/log/setup.cr
@@ -26,14 +26,6 @@ class Log
     end
   end
 
-  @[Deprecated("Use default_level, default_sources named arguments")]
-  def self.setup_from_env(*, builder : Log::Builder = Log.builder,
-                          level : String,
-                          sources : String,
-                          backend = Log::IOBackend.new)
-    Log.setup(sources, Log::Severity.parse(level), backend, builder: builder)
-  end
-
   # Setups logging based on `LOG_LEVEL` environment variable.
   def self.setup_from_env(*, builder : Log::Builder = Log.builder,
                           default_level : Log::Severity = Log::Severity::Info,

--- a/src/option_parser.cr
+++ b/src/option_parser.cr
@@ -115,11 +115,6 @@ class OptionParser
     parser
   end
 
-  @[Deprecated("Use `parse` instead.")]
-  def self.parse! : self
-    parse(ARGV) { |parser| yield parser }
-  end
-
   # Creates a new parser.
   def initialize
     @flags = [] of String
@@ -446,10 +441,5 @@ class OptionParser
         end
       end
     end
-  end
-
-  @[Deprecated("Use `parse` instead.")]
-  def parse!
-    parse
   end
 end

--- a/src/process.cr
+++ b/src/process.cr
@@ -41,14 +41,6 @@ class Process
     Crystal::System::Process.ppid.to_i64
   end
 
-  # Sends a *signal* to the processes identified by the given *pids*.
-  @[Deprecated("Use #signal instead")]
-  def self.kill(signal : Signal, *pids : Int)
-    pids.each do |pid|
-      signal(signal, pid)
-    end
-  end
-
   # Sends *signal* to the process identified by *pid*.
   def self.signal(signal : Signal, pid : Int) : Nil
     Crystal::System::Process.signal(pid, signal.value)
@@ -294,12 +286,6 @@ class Process
 
   private def initialize(pid)
     @process_info = Crystal::System::Process.new(pid)
-  end
-
-  # See also: `Process.kill`
-  @[Deprecated("Use #signal instead")]
-  def kill(sig = Signal::TERM)
-    signal sig
   end
 
   # Sends *signal* to this process.

--- a/src/set.cr
+++ b/src/set.cr
@@ -430,11 +430,6 @@ struct Set(T)
     all? { |value| other.includes?(value) }
   end
 
-  @[Deprecated("Use #subset_of? instead.")]
-  def subset?(other : Set)
-    subset_of?(other)
-  end
-
   # Returns `true` if the set is a proper subset of the *other* set.
   #
   # This set must have fewer elements than the *other* set, and all
@@ -447,11 +442,6 @@ struct Set(T)
   def proper_subset_of?(other : Set)
     return false if other.size <= size
     all? { |value| other.includes?(value) }
-  end
-
-  @[Deprecated("Use #proper_subset_of? instead.")]
-  def proper_subset?(other : Set)
-    proper_subset_of?(other)
   end
 
   # Returns `true` if the set is a superset of the *other* set.
@@ -467,11 +457,6 @@ struct Set(T)
     other.subset_of?(self)
   end
 
-  @[Deprecated("Use #superset_of? instead.")]
-  def superset?(other : Set)
-    superset_of?(other)
-  end
-
   # Returns `true` if the set is a superset of the *other* set.
   #
   # The *other* must have the same or fewer elements than this set, and all of
@@ -483,11 +468,6 @@ struct Set(T)
   # ```
   def proper_superset_of?(other : Set)
     other.proper_subset_of?(self)
-  end
-
-  @[Deprecated("Use #proper_superset_of? instead.")]
-  def proper_superset?(other : Set)
-    proper_superset_of?(other)
   end
 
   # :nodoc:

--- a/src/spec/expectations.cr
+++ b/src/spec/expectations.cr
@@ -502,16 +502,6 @@ module Spec
         fail(failure_message, file, line)
       end
     end
-
-    @[Deprecated("Use named arguments `.should(expectation, file: file, line: line)`")]
-    def should(expectation, _file, _line)
-      should(expectation, file: _file, line: _line)
-    end
-
-    @[Deprecated("Use named arguments `.should_not(expectation, file: file, line: line)`")]
-    def should_not(expectation, _file, _line)
-      should_not(expectation, file: _file, line: _line)
-    end
   end
 end
 

--- a/src/static_array.cr
+++ b/src/static_array.cr
@@ -193,20 +193,6 @@ struct StaticArray(T, N)
     self
   end
 
-  # Fills the array by substituting all elements with the given value.
-  #
-  # ```
-  # array = StaticArray(Int32, 3).new { |i| i + 1 }
-  # array.[]= 2 # => nil
-  # array       # => StaticArray[2, 2, 2]
-  # ```
-  @[Deprecated("Use `#fill(value : T)` instead")]
-  def []=(value : T)
-    size.times do |i|
-      to_unsafe[i] = value
-    end
-  end
-
   # Modifies `self` by randomizing the order of elements in the array
   # using the given *random* number generator. Returns `self`.
   #

--- a/src/string.cr
+++ b/src/string.cr
@@ -4014,19 +4014,6 @@ class String
     just len, char, -1
   end
 
-  # Adds spaces to right of the string until it is at least size of *len*,
-  # and then appends the result to the given IO.
-  #
-  # ```
-  # io = IO::Memory.new
-  # "Purple".ljust(8, io)
-  # io.to_s # => "Purple  "
-  # ```
-  @[Deprecated("Use `#ljust(io :IO, len : Int, char : Char = ' ')` instead")]
-  def ljust(len : Int, io : IO) : Nil
-    ljust(io, len)
-  end
-
   # Adds instances of *char* to right of the string until it is at least size of *len*,
   # and then appends the result to the given IO.
   #
@@ -4040,19 +4027,6 @@ class String
     (len - size).times { io << char }
   end
 
-  # Adds instances of *char* to right of the string until it is at least size of *len*,
-  # and then appends the result to the given IO.
-  #
-  # ```
-  # io = IO::Memory.new
-  # "Purple".ljust(8, '-', io)
-  # io.to_s # => "Purple--"
-  # ```
-  @[Deprecated("Use `#ljust(io :IO, len : Int, char : Char = ' ')` instead")]
-  def ljust(len : Int, char : Char, io : IO) : Nil
-    ljust(io, len, char)
-  end
-
   # Adds instances of *char* to left of the string until it is at least size of *len*.
   #
   # ```
@@ -4062,19 +4036,6 @@ class String
   # ```
   def rjust(len : Int, char : Char = ' ')
     just len, char, 1
-  end
-
-  # Adds spaces to left of the string until it is at least size of *len*,
-  # and then appends the result to the given IO.
-  #
-  # ```
-  # io = IO::Memory.new
-  # "Purple".rjust(8, io)
-  # io.to_s # => "  Purple"
-  # ```
-  @[Deprecated("Use `#rjust(io :IO, len : Int, char : Char = ' ')` instead")]
-  def rjust(len : Int, io : IO) : Nil
-    rjust(io, len)
   end
 
   # Adds instances of *char* to left of the string until it is at least size of *len*,
@@ -4090,19 +4051,6 @@ class String
     io << self
   end
 
-  # Adds instances of *char* to left of the string until it is at least size of *len*,
-  # and then appends the result to the given IO.
-  #
-  # ```
-  # io = IO::Memory.new
-  # "Purple".rjust(8, '-', io)
-  # io.to_s # => "--Purple"
-  # ```
-  @[Deprecated("Use `#rjust(io :IO, len : Int, char : Char = ' ')` instead")]
-  def rjust(len : Int, char : Char, io : IO) : Nil
-    rjust(io, len, char)
-  end
-
   # Adds instances of *char* to left and right of the string until it is at least size of *len*.
   #
   # ```
@@ -4113,19 +4061,6 @@ class String
   # ```
   def center(len : Int, char : Char = ' ')
     just len, char, 0
-  end
-
-  # Adds spaces to left and right of the string until it is at least size of *len*,
-  # then appends the result to the given IO.
-  #
-  # ```
-  # io = IO::Memory.new
-  # "Purple".center(9, io)
-  # io.to_s # => " Purple  "
-  # ```
-  @[Deprecated("Use `#center(io :IO, len : Int, char : Char = ' ')` instead")]
-  def center(len : Int, io : IO) : Nil
-    center(io, len)
   end
 
   # Adds instances of *char* to left and right of the string until it is at least size of *len*,
@@ -4150,19 +4085,6 @@ class String
     left_padding.times { io << char }
     io << self
     right_padding.times { io << char }
-  end
-
-  # Adds instances of *char* to left and right of the string until it is at least size of *len*,
-  # then appends the result to the given IO.
-  #
-  # ```
-  # io = IO::Memory.new
-  # "Purple".center(9, '-', io)
-  # io.to_s # => "-Purple--"
-  # ```
-  @[Deprecated("Use `#center(io :IO, len : Int, char : Char = ' ')` instead")]
-  def center(len : Int, char : Char, io : IO) : Nil
-    center(io, len, char)
   end
 
   private def just(len, char, justify)

--- a/src/time.cr
+++ b/src/time.cr
@@ -1091,14 +1091,6 @@ struct Time
     Format.new(format).format(self, io)
   end
 
-  # Formats this `Time` according to the pattern in *format* to the given *io*.
-  #
-  # See `Time::Format` for details.
-  @[Deprecated("Use `#to_s(io : IO, format : String)` instead")]
-  def to_s(format : String, io : IO) : Nil
-    to_s(io, format)
-  end
-
   # Format this time using the format specified by [RFC 3339](https://tools.ietf.org/html/rfc3339) ([ISO 8601](http://xml.coverpages.org/ISO-FDIS-8601.pdf) profile).
   #
   # ```

--- a/src/time/span.cr
+++ b/src/time/span.cr
@@ -227,12 +227,6 @@ struct Time::Span
     @seconds
   end
 
-  # Alias of `abs`.
-  @[Deprecated("Use `#abs` instead.")]
-  def duration : Time::Span
-    abs
-  end
-
   # Returns the absolute (non-negative) amount of time this `Time::Span`
   # represents by removing the sign.
   def abs : Time::Span

--- a/src/uri.cr
+++ b/src/uri.cr
@@ -232,12 +232,6 @@ class URI
     end
   end
 
-  # :ditto:
-  @[Deprecated("Use `#request_target` instead.")]
-  def full_path : String
-    request_target
-  end
-
   # Returns `true` if URI has a *scheme* specified.
   def absolute? : Bool
     @scheme ? true : false

--- a/src/yaml/builder.cr
+++ b/src/yaml/builder.cr
@@ -56,14 +56,6 @@ class YAML::Builder
     io.flush
   end
 
-  # :ditto:
-  @[Deprecated("Use .build instead")]
-  def self.new(io : IO, & : self ->) : Nil
-    build(io) do |builder|
-      yield builder
-    end
-  end
-
   # Starts a YAML stream.
   def start_stream
     emit stream_start, LibYAML::Encoding::UTF8


### PR DESCRIPTION
I think these are all the deprecated definitions. If some are really recent and we will prefer to keep them during 1.x please comment.

For example I am not dropping the recent alias `HTTP::Params` mostly because there is no deprecation warning on it. But if others prefer it can be dropped in this PR also.