### PR TITLE
Let `IO::Memory` not be writable with read-only `Slice`

### DIFF
--- a/spec/std/io/memory_spec.cr
+++ b/spec/std/io/memory_spec.cr
@@ -281,6 +281,15 @@ describe IO::Memory do
     end
   end
 
+  it "creates from read-only slice" do
+    slice = Slice.new(6, read_only: true) { |i| ('a'.ord + i).to_u8 }
+    io = IO::Memory.new slice
+
+    expect_raises(IO::Error, "Read-only stream") do
+      io.print 'z'
+    end
+  end
+
   it "writes past end" do
     io = IO::Memory.new
     io.pos = 1000

--- a/src/io/memory.cr
+++ b/src/io/memory.cr
@@ -51,7 +51,7 @@ class IO::Memory < IO
     @pos = 0
     @closed = false
     @resizeable = false
-    @writeable = writeable
+    @writeable = !slice.read_only? && writeable
   end
 
   # Creates an `IO::Memory` whose contents are the exact contents of *string*.


### PR DESCRIPTION
Resolves #10362