### PR TITLE
Add LibC::MAP_ANONYMOUS to x86_64-darwin to match other platforms

### DIFF
--- a/src/lib_c/x86_64-darwin/c/sys/mman.cr
+++ b/src/lib_c/x86_64-darwin/c/sys/mman.cr
@@ -9,6 +9,7 @@ lib LibC
   MAP_PRIVATE           = 0x0002
   MAP_SHARED            = 0x0001
   MAP_ANON              = 0x1000
+  MAP_ANONYMOUS         = LibC::MAP_ANON
   MAP_FAILED            = Pointer(Void).new(-1)
   POSIX_MADV_DONTNEED   = 4
   POSIX_MADV_NORMAL     = 0


### PR DESCRIPTION
I guess this bit of the standard library is mostly for internal use, but I noticed that all the BSD platforms except Darwin have a `LibC::MAP_ANONYMOUS` synonym for `LibC::MAP_ANON`, presumably to mirror the synonyms in the actual libc headers and to improve portability of code using `mmap`, so I added that to make it consistent with the others.