### PR TITLE
Compiler: access instantiations of NamedTuple and other generics uniformly

### DIFF
--- a/spec/compiler/codegen/named_tuple_spec.cr
+++ b/spec/compiler/codegen/named_tuple_spec.cr
@@ -333,4 +333,18 @@ describe "Code gen: named tuple" do
       f.x
       ").to_i.should eq(2)
   end
+
+  it "doesn't error if NamedTuple includes a non-generic module (#10380)" do
+    codegen(%(
+      module Foo
+      end
+
+      struct NamedTuple
+        include Foo
+      end
+
+      x = uninitialized Foo
+      x = {a: 1}
+      ))
+  end
 end

--- a/spec/compiler/semantic/def_overload_spec.cr
+++ b/spec/compiler/semantic/def_overload_spec.cr
@@ -1060,6 +1060,31 @@ describe "Semantic: def overload" do
       foo(**{a: 1, b: ""})
       )) { named_tuple_of({a: int32, b: string}).metaclass }
   end
+
+  it "considers NamedTuple in a module's including types (#10380)" do
+    assert_error %(
+      module Foo
+      end
+
+      struct NamedTuple
+        include Foo
+      end
+
+      class Bar
+        include Foo
+      end
+
+      def foo(x : Bar)
+      end
+
+      # force a name tuple instantiation
+      {a: 1}
+
+      x = uninitialized Foo
+      foo(x)
+      ),
+      "no overload matches"
+  end
 end
 
 private def each_union_variant(t1, t2)

--- a/src/compiler/crystal/codegen/llvm_id.cr
+++ b/src/compiler/crystal/codegen/llvm_id.cr
@@ -74,7 +74,7 @@ module Crystal
     end
 
     private def assign_id_impl(type : GenericClassType)
-      subtypes = type.generic_types.values.reject(&.unbound?)
+      subtypes = type.instantiated_types.reject(&.unbound?)
       subtypes.concat(subclasses_of(type))
       assign_id_from_subtypes type, subtypes
     end
@@ -135,8 +135,8 @@ module Crystal
 
     private def assign_id_to_metaclass(type : GenericClassType)
       assign_id_to_metaclass(type, type.metaclass)
-      type.generic_types.values.each do |generic_type|
-        assign_id_to_metaclass(generic_type)
+      type.each_instantiated_type do |instance|
+        assign_id_to_metaclass(instance)
       end
       type.subclasses.each do |subclass|
         assign_id_to_metaclass(subclass)

--- a/src/compiler/crystal/semantic/cleanup_transformer.cr
+++ b/src/compiler/crystal/semantic/cleanup_transformer.cr
@@ -28,7 +28,7 @@ module Crystal
       when GenericClassInstanceType
         cleanup_single_type(type, transformer)
       when GenericClassType
-        type.generic_types.each_value do |instance|
+        type.each_instantiated_type do |instance|
           cleanup_type instance, transformer
         end
       when ClassType

--- a/src/compiler/crystal/semantic/recursive_struct_checker.cr
+++ b/src/compiler/crystal/semantic/recursive_struct_checker.cr
@@ -54,7 +54,7 @@ class Crystal::RecursiveStructChecker
 
   def check_generic_instances(type)
     if type.struct? && type.is_a?(GenericType)
-      type.generic_types.each_value do |instance|
+      type.each_instantiated_type do |instance|
         check_single(instance)
       end
     end

--- a/src/compiler/crystal/semantic/restrictions.cr
+++ b/src/compiler/crystal/semantic/restrictions.cr
@@ -999,7 +999,7 @@ module Crystal
       elsif base_type.is_a?(GenericInstanceType) && other.is_a?(GenericType)
         # Consider the case of Foo(Int32) vs. Bar(T), with Bar(T) < Foo(T):
         # we want to return Bar(Int32), so we search in Bar's generic instantiations
-        other.generic_types.each_value do |instance|
+        other.each_instantiated_type do |instance|
           next if instance.unbound? || instance.abstract?
 
           if instance.implements?(base_type)

--- a/src/compiler/crystal/semantic/type_declaration_processor.cr
+++ b/src/compiler/crystal/semantic/type_declaration_processor.cr
@@ -276,10 +276,10 @@ struct Crystal::TypeDeclarationProcessor
       remove_error owner, name
 
       if owner.is_a?(GenericType)
-        owner.generic_types.each_value do |generic_type|
-          new_type = type_decl.type.replace_type_parameters(generic_type)
+        owner.each_instantiated_type do |instance|
+          new_type = type_decl.type.replace_type_parameters(instance)
           new_type_decl = TypeDeclarationWithLocation.new(new_type, type_decl.location, type_decl.uninitialized, type_decl.annotations)
-          declare_meta_type_var(generic_type.instance_vars, generic_type, name, new_type_decl, instance_var: true, check_nilable: false)
+          declare_meta_type_var(instance.instance_vars, instance, name, new_type_decl, instance_var: true, check_nilable: false)
         end
       end
 
@@ -395,9 +395,9 @@ struct Crystal::TypeDeclarationProcessor
 
       declare_meta_type_var(owner.instance_vars, owner, name, type, type_info.location, instance_var: true, annotations: type_info.annotations)
 
-      owner.generic_types.each_value do |generic_type|
-        new_type = type.replace_type_parameters(generic_type)
-        declare_meta_type_var(generic_type.instance_vars, generic_type, name, new_type, type_info.location, instance_var: true, annotations: type_info.annotations)
+      owner.each_instantiated_type do |instance|
+        new_type = type.replace_type_parameters(instance)
+        declare_meta_type_var(instance.instance_vars, instance, name, new_type, type_info.location, instance_var: true, annotations: type_info.annotations)
       end
 
       remove_error owner, name

--- a/src/compiler/crystal/tools/print_hierarchy.cr
+++ b/src/compiler/crystal/tools/print_hierarchy.cr
@@ -73,7 +73,7 @@ module Crystal
       end
 
       compute_targets type.types, exp, false
-      compute_targets type.generic_types, exp, must_include
+      compute_targets type.instantiated_types, exp, must_include
 
       subtypes = type.subclasses.select { |sub| !sub.is_a?(GenericClassInstanceType) }
       must_include |= compute_targets subtypes, exp, must_include

--- a/src/compiler/crystal/tools/typed_def_processor.cr
+++ b/src/compiler/crystal/tools/typed_def_processor.cr
@@ -24,8 +24,8 @@ module Crystal::TypedDefProcessor
     end
 
     if type.is_a?(GenericType)
-      type.generic_types.each_value do |instanced_type|
-        process_type instanced_type
+      type.each_instantiated_type do |instance|
+        process_type instance
       end
     end
 


### PR DESCRIPTION
Fixes #10380.

https://github.com/crystal-lang/crystal/issues/10380#issuecomment-777697244 now works. The following will now correctly fail to compile (with the default prelude):

```crystal
module Foo
end

struct NamedTuple
  include Foo
end

class Bar
  include Foo
end

def foo(x : Bar)
end

x = uninitialized Foo
foo(x)
```

```
Error: no overload matches 'foo' with type Foo

Overloads are:
 - foo(x : Bar)
Couldn't find overloads for these types:
 - foo(x : NamedTuple())
 - foo(x : NamedTuple(file: String))
 - foo(x : NamedTuple(time: Time, location: Time::Location))
```

This replaces `Crystal::GenericType#generic_types` with `#instantiated_types`, so that `Crystal::NamedTupleType` can redefine it. Note that the keys of `Crystal::GenericType#@generic_types` and `Crystal::NamedTupleType#@instantiations` are never accessed outside those compiler types' instantiation methods repsectively (they are only used for caching instantiations with the same type arguments).