### PR TITLE
Fix `#respond_with_status` when headers written or closed 

### DIFF
--- a/spec/std/http/server/response_spec.cr
+++ b/spec/std/http/server/response_spec.cr
@@ -268,5 +268,23 @@ describe HTTP::Server::Response do
       io.to_s.should eq("HTTP/1.1 414 Request Error\r\nContent-Type: text/plain\r\nContent-Length: 18\r\n\r\n414 Request Error\n")
     end
 
+    it "raises when response is closed" do
+      io = IO::Memory.new
+      response = Response.new(io)
+      response.close
+      expect_raises(IO::Error, "Closed stream") do
+        response.respond_with_status(400)
+      end
+    end
+
+    it "raises when headers written" do
+      io = IO::Memory.new
+      response = Response.new(io)
+      response.print("Hello")
+      response.flush
+      expect_raises(IO::Error, "Headers already sent") do
+        response.respond_with_status(400)
+      end
+    end
   end
 end

--- a/spec/std/http/server/response_spec.cr
+++ b/spec/std/http/server/response_spec.cr
@@ -227,6 +227,17 @@ describe HTTP::Server::Response do
     io.to_s.should eq("HTTP/1.1 200 OK\r\nContent-Length: 5\r\nSet-Cookie: Bar=Foo; path=/\r\n\r\nHello")
   end
 
+  it "closes when it fails to write" do
+    io = IO::Memory.new
+    response = Response.new(io)
+    response.print("Hello")
+    response.flush
+    io.close
+    response.print("Hello")
+    expect_raises(HTTP::Server::ClientError) { response.flush }
+    response.closed?.should be_true
+  end
+
   describe "#respond_with_status" do
     it "uses default values" do
       io = IO::Memory.new
@@ -257,15 +268,5 @@ describe HTTP::Server::Response do
       io.to_s.should eq("HTTP/1.1 414 Request Error\r\nContent-Type: text/plain\r\nContent-Length: 18\r\n\r\n414 Request Error\n")
     end
 
-    it "closes when it fails to write" do
-      io = IO::Memory.new
-      response = Response.new(io)
-      response.print("Hello")
-      response.flush
-      io.close
-      response.print("Hello")
-      expect_raises(HTTP::Server::ClientError) { response.flush }
-      response.closed?.should be_true
-    end
   end
 end

--- a/src/http/server/request_processor.cr
+++ b/src/http/server/request_processor.cr
@@ -36,13 +36,14 @@ class HTTP::Server::RequestProcessor
         # EOF
         break unless request
 
+        response.reset
+
         if request.is_a?(HTTP::Status)
           response.respond_with_status(request)
           return
         end
 
         response.version = request.version
-        response.reset
         response.headers["Connection"] = "keep-alive" if request.keep_alive?
         context = Context.new(request, response)
 


### PR DESCRIPTION
This change makes `HTTP::Server::Response#respond_with_status` raise when the response is closed or headers have already been written.

ref. https://github.com/crystal-lang/crystal/issues/10038#issuecomment-739496043

> This method is also completely broken when headers have already been sent, because the reset causes that flag to disapear and `respond_with_status` just writes a second response. https://carc.in/#/r/a2ha

This uses the same `check_headers` method as #10412.

The first commit is just a minor refactoring because the moved spec doesn't belong in the describe group for `#respond_with_status`.