### PR TITLE
Fix downcasting float infinity

### DIFF
--- a/spec/std/float_spec.cr
+++ b/spec/std/float_spec.cr
@@ -265,6 +265,26 @@ describe "Float" do
     (-0.0/0.0).finite?.should be_false
   end
 
+  {% if compare_versions(Crystal::VERSION, "0.36.1") > 0 %}
+    it "converts infinity" do
+      Float32::INFINITY.to_f64.infinite?.should eq 1
+      Float32::INFINITY.to_f32.infinite?.should eq 1
+      expect_raises(OverflowError) { Float32::INFINITY.to_i }
+      (-Float32::INFINITY).to_f64.infinite?.should eq -1
+      (-Float32::INFINITY).to_f32.infinite?.should eq -1
+      expect_raises(OverflowError) { (-Float32::INFINITY).to_i }
+
+      Float64::INFINITY.to_f64.infinite?.should eq 1
+      Float64::INFINITY.to_f32.infinite?.should eq 1
+      expect_raises(OverflowError) { Float64::INFINITY.to_i }
+      (-Float64::INFINITY).to_f64.infinite?.should eq -1
+      (-Float64::INFINITY).to_f32.infinite?.should eq -1
+      expect_raises(OverflowError) { (-Float64::INFINITY).to_i }
+    end
+  {% else %}
+    pending "converts infinity"
+  {% end %}
+
   it "does unary -" do
     f = -(1.5)
     f.should eq(-1.5)

--- a/spec/std/json/pull_parser_spec.cr
+++ b/spec/std/json/pull_parser_spec.cr
@@ -364,8 +364,7 @@ describe JSON::PullParser do
                     [UInt8, -1],
                     [UInt16, -1],
                     [UInt32, -1],
-                    [UInt64, -1],
-                    [Float32, Float64::MAX]] %}
+                    [UInt64, -1]] %}
       {% type = pair[0] %}
       {% value = pair[1] %}
 
@@ -374,5 +373,10 @@ describe JSON::PullParser do
         pull.read?({{type}}).should be_nil
       end
     {% end %}
+
+    pending "returns nil in place of Float32 when an overflow occurs" do
+      pull = JSON::PullParser.new(Float64::MAX.to_json)
+      pull.read?(Float32).should be_nil
+    end
   end
 end

--- a/src/compiler/crystal/codegen/primitives.cr
+++ b/src/compiler/crystal/codegen/primitives.cr
@@ -291,10 +291,14 @@ class Crystal::CodeGenVisitor
 
   private def codegen_out_of_range(target_type : FloatType, arg_type : FloatType, arg)
     min_value, max_value = target_type.range
-    # arg < min_value || arg > max_value
-    or(
-      builder.fcmp(LLVM::RealPredicate::OLT, arg, float(min_value, arg_type)),
-      builder.fcmp(LLVM::RealPredicate::OGT, arg, float(max_value, arg_type))
+    # checks for arg being outside of range and not infinity
+    # (arg < min_value || arg > max_value) && arg != 2 * arg
+    and(
+      or(
+        builder.fcmp(LLVM::RealPredicate::OLT, arg, float(min_value, arg_type)),
+        builder.fcmp(LLVM::RealPredicate::OGT, arg, float(max_value, arg_type))
+      ),
+      builder.fcmp(LLVM::RealPredicate::ONE, arg, builder.fmul(float(2, arg_type), arg))
     )
   end
 


### PR DESCRIPTION
Infinity stays infinity, regardless of the data type. This already worked for upcasting, but downcasting triggers an overflow error.

```cr
Float32::INFINITY.to_f64 # => Infinity
Float64::INFINITY.to_f32 # Error: Arithmetic overflow
```

The error showed up in the specs for #10413.

The JSON spec had to be disabled because of #10419. It happend to pass by coincidence because `Float64::MAX` value was parsed as `Float::INFINITY`. With infinity downcasting fixed, there's no longer an overflow and the spec fails because float parsing is just broken.

