### PR TITLE
Fix `String#to_f` out of range

### DIFF
--- a/spec/std/string_spec.cr
+++ b/spec/std/string_spec.cr
@@ -433,8 +433,12 @@ describe "String" do
     "x1.2".to_f64?(strict: false).should be_nil
     "1#{Float64::MAX}".to_f?.should be_nil
     "-1#{Float64::MAX}".to_f?.should be_nil
-    " NaN".to_f?.should be_nil
-    " INF".to_f?.should be_nil
+    " NaN".to_f?.try(&.nan?).should be_true
+    "NaN".to_f?.try(&.nan?).should be_true
+    " INF".to_f?.should eq Float64::INFINITY
+    "INF".to_f?.should eq Float64::INFINITY
+    "-INF".to_f?.should eq -Float64::INFINITY
+    " +INF".to_f?.should eq Float64::INFINITY
   end
 
   it "does to_f32" do
@@ -465,8 +469,12 @@ describe "String" do
     "x1.2".to_f32?(strict: false).should be_nil
     "1#{Float32::MAX}".to_f32?.should be_nil
     "-1#{Float32::MAX}".to_f32?.should be_nil
-    " NaN".to_f32?.should be_nil
-    " INF".to_f32?.should be_nil
+    " NaN".to_f32?.try(&.nan?).should be_true
+    "NaN".to_f32?.try(&.nan?).should be_true
+    " INF".to_f32?.should eq Float32::INFINITY
+    "INF".to_f32?.should eq Float32::INFINITY
+    "-INF".to_f32?.should eq -Float32::INFINITY
+    " +INF".to_f32?.should eq Float32::INFINITY
   end
 
   it "does to_f64" do
@@ -497,8 +505,12 @@ describe "String" do
     "x1.2".to_f64?(strict: false).should be_nil
     "1#{Float64::MAX}".to_f64?.should be_nil
     "-1#{Float64::MAX}".to_f64?.should be_nil
-    " NaN".to_f64?.should be_nil
-    " INF".to_f64?.should be_nil
+    " NaN".to_f64?.try(&.nan?).should be_true
+    "NaN".to_f64?.try(&.nan?).should be_true
+    " INF".to_f64?.should eq Float64::INFINITY
+    "INF".to_f64?.should eq Float64::INFINITY
+    "-INF".to_f64?.should eq -Float64::INFINITY
+    " +INF".to_f64?.should eq Float64::INFINITY
   end
 
   it "compares strings: different size" do

--- a/spec/std/string_spec.cr
+++ b/spec/std/string_spec.cr
@@ -431,6 +431,10 @@ describe "String" do
     "x1.2".to_f64?.should be_nil
     expect_raises(ArgumentError) { "x1.2".to_f64(strict: false) }
     "x1.2".to_f64?(strict: false).should be_nil
+    "1#{Float64::MAX}".to_f?.should be_nil
+    "-1#{Float64::MAX}".to_f?.should be_nil
+    " NaN".to_f?.should be_nil
+    " INF".to_f?.should be_nil
   end
 
   it "does to_f32" do
@@ -459,6 +463,10 @@ describe "String" do
     "x1.2".to_f32?.should be_nil
     expect_raises(ArgumentError) { "x1.2".to_f32(strict: false) }
     "x1.2".to_f32?(strict: false).should be_nil
+    "1#{Float32::MAX}".to_f32?.should be_nil
+    "-1#{Float32::MAX}".to_f32?.should be_nil
+    " NaN".to_f32?.should be_nil
+    " INF".to_f32?.should be_nil
   end
 
   it "does to_f64" do
@@ -487,6 +495,10 @@ describe "String" do
     "x1.2".to_f64?.should be_nil
     expect_raises(ArgumentError) { "x1.2".to_f64(strict: false) }
     "x1.2".to_f64?(strict: false).should be_nil
+    "1#{Float64::MAX}".to_f64?.should be_nil
+    "-1#{Float64::MAX}".to_f64?.should be_nil
+    " NaN".to_f64?.should be_nil
+    " INF".to_f64?.should be_nil
   end
 
   it "compares strings: different size" do

--- a/spec/std/string_spec.cr
+++ b/spec/std/string_spec.cr
@@ -435,6 +435,7 @@ describe "String" do
     "-1#{Float64::MAX}".to_f?.should be_nil
     " NaN".to_f?.try(&.nan?).should be_true
     "NaN".to_f?.try(&.nan?).should be_true
+    "-NaN".to_f?.try(&.nan?).should be_true
     " INF".to_f?.should eq Float64::INFINITY
     "INF".to_f?.should eq Float64::INFINITY
     "-INF".to_f?.should eq -Float64::INFINITY
@@ -471,6 +472,7 @@ describe "String" do
     "-1#{Float32::MAX}".to_f32?.should be_nil
     " NaN".to_f32?.try(&.nan?).should be_true
     "NaN".to_f32?.try(&.nan?).should be_true
+    "-NaN".to_f32?.try(&.nan?).should be_true
     " INF".to_f32?.should eq Float32::INFINITY
     "INF".to_f32?.should eq Float32::INFINITY
     "-INF".to_f32?.should eq -Float32::INFINITY
@@ -507,6 +509,7 @@ describe "String" do
     "-1#{Float64::MAX}".to_f64?.should be_nil
     " NaN".to_f64?.try(&.nan?).should be_true
     "NaN".to_f64?.try(&.nan?).should be_true
+    "-NaN".to_f64?.try(&.nan?).should be_true
     " INF".to_f64?.should eq Float64::INFINITY
     "INF".to_f64?.should eq Float64::INFINITY
     "-INF".to_f64?.should eq -Float64::INFINITY

--- a/src/string.cr
+++ b/src/string.cr
@@ -714,7 +714,7 @@ class String
     unless v.finite?
       startptr = to_unsafe
       if whitespace
-        while(startptr.value.chr.ascii_whitespace?)
+        while startptr.value.chr.ascii_whitespace?
           startptr += 1
         end
       end

--- a/src/string.cr
+++ b/src/string.cr
@@ -718,13 +718,13 @@ class String
           startptr += 1
         end
       end
+      if startptr.value.chr.in?('+', '-')
+        startptr += 1
+      end
 
       if v.nan?
         return unless startptr.value.chr.in?('n', 'N')
       else
-        if startptr.value.chr.in?('+', '-')
-          startptr += 1
-        end
         return unless startptr.value.chr.in?('i', 'I')
       end
     end

--- a/src/string.cr
+++ b/src/string.cr
@@ -643,7 +643,7 @@ class String
   # Returns the result of interpreting characters in this string as a floating point number (`Float64`).
   # This method raises an exception if the string is not a valid float representation
   # or exceeds the range of the data type. Values representing infinity or NaN
-  # are not considered valid.
+  # are considered valid.
   #
   # Options:
   # * **whitespace**: if `true`, leading and trailing whitespaces are allowed
@@ -668,7 +668,7 @@ class String
   # Returns the result of interpreting characters in this string as a floating point number (`Float64`).
   # This method returns `nil` if the string is not a valid float representation
   # or exceeds the range of the data type. Values representing infinity or NaN
-  # are not considered valid.
+  # are considered valid.
   #
   # Options:
   # * **whitespace**: if `true`, leading and trailing whitespaces are allowed
@@ -710,11 +710,24 @@ class String
     return unless whitespace || '0' <= self[0] <= '9' || self[0] == '-' || self[0] == '+'
 
     v, endptr = yield
-    # Infinity and NaN is not handled by this method.
-    # When whitespace is enabled, infinity and NaN values can be parsed when
-    # precede by whitespace (`" NAN"`).
-    # Infinity value can be returned when the parsed value is out of range.
-    return unless v.finite?
+
+    unless v.finite?
+      startptr = to_unsafe
+      if whitespace
+        while(startptr.value.chr.whitespace?)
+          startptr += 1
+        end
+      end
+
+      if v.nan?
+        return unless startptr.value.chr.in?('n', 'N')
+      else
+        if startptr.value.chr.in?('+', '-')
+          startptr += 1
+        end
+        return unless startptr.value.chr.in?('i', 'I')
+      end
+    end
 
     string_end = to_unsafe + bytesize
 

--- a/src/string.cr
+++ b/src/string.cr
@@ -714,7 +714,7 @@ class String
     unless v.finite?
       startptr = to_unsafe
       if whitespace
-        while(startptr.value.chr.whitespace?)
+        while(startptr.value.chr.ascii_whitespace?)
           startptr += 1
         end
       end


### PR DESCRIPTION
<del>`String#to_f` generally does not accept values representing infinity or NaN. It would allow them if the first character is whitespace (and whitespace is enabled), them.</del>

`String#to_f` returns infinity for values outside of the data type's range. <ins>That's incorrect, it should be an error.</ins>

This patch fixes that and makes sure it fails when `strtod`/`strtof` return a non-finite value.

We should probably consider an option for parsing infinity and NaN. But for now this is just a simple bug fix.