### PR TITLE
Add `YAML::Nodes::Node#kind`

### DIFF
--- a/spec/std/yaml/serialization_spec.cr
+++ b/spec/std/yaml/serialization_spec.cr
@@ -241,7 +241,7 @@ describe "YAML serialization" do
             ]
             YAML
         end
-        ex.message.should eq("Expected Nil, not 1 at line 2, column 3")
+        ex.message.should eq(%(Expected Nil, not "1" at line 2, column 3))
         ex.location.should eq({2, 3})
       end
 

--- a/src/yaml/from_yaml.cr
+++ b/src/yaml/from_yaml.cr
@@ -41,10 +41,10 @@ private def parse_scalar(ctx, node, type : T.class) forall T
       ctx.record_anchor(node, value)
       value
     else
-      node.raise "Expected #{T}, not #{node.value}"
+      node.raise "Expected #{T}, not #{node.value.inspect}"
     end
   else
-    node.raise "Expected #{T}, not #{node.class.name}"
+    node.raise "Expected scalar, not #{node.type}"
   end
 end
 
@@ -72,7 +72,7 @@ def String.new(ctx : YAML::ParseContext, node : YAML::Nodes::Node)
     ctx.record_anchor(node, value)
     value
   else
-    node.raise "Expected String, not #{node.class.name}"
+    node.raise "Expected String, not #{node.type}"
   end
 end
 
@@ -105,7 +105,7 @@ end
 
 def Array.new(ctx : YAML::ParseContext, node : YAML::Nodes::Node)
   unless node.is_a?(YAML::Nodes::Sequence)
-    node.raise "Expected sequence, not #{node.class}"
+    node.raise "Expected sequence, not #{node.type}"
   end
 
   node.each do |value|
@@ -130,7 +130,7 @@ end
 
 def Set.new(ctx : YAML::ParseContext, node : YAML::Nodes::Node)
   unless node.is_a?(YAML::Nodes::Sequence)
-    node.raise "Expected sequence, not #{node.class}"
+    node.raise "Expected sequence, not #{node.type}"
   end
 
   node.each do |value|
@@ -155,7 +155,7 @@ end
 
 def Hash.new(ctx : YAML::ParseContext, node : YAML::Nodes::Node)
   unless node.is_a?(YAML::Nodes::Mapping)
-    node.raise "Expected mapping, not #{node.class}"
+    node.raise "Expected mapping, not #{node.type}"
   end
 
   YAML::Schema::Core.each(node) do |key, value|
@@ -165,7 +165,7 @@ end
 
 def Tuple.new(ctx : YAML::ParseContext, node : YAML::Nodes::Node)
   unless node.is_a?(YAML::Nodes::Sequence)
-    node.raise "Expected sequence, not #{node.class}"
+    node.raise "Expected sequence, not #{node.type}"
   end
 
   if node.nodes.size != {{T.size}}
@@ -183,7 +183,7 @@ end
 
 def NamedTuple.new(ctx : YAML::ParseContext, node : YAML::Nodes::Node)
   unless node.is_a?(YAML::Nodes::Mapping)
-    node.raise "Expected mapping, not #{node.class}"
+    node.raise "Expected mapping, not #{node.type}"
   end
 
   {% begin %}
@@ -221,7 +221,7 @@ end
 
 def Enum.new(ctx : YAML::ParseContext, node : YAML::Nodes::Node)
   unless node.is_a?(YAML::Nodes::Scalar)
-    node.raise "Expected scalar, not #{node.class}"
+    node.raise "Expected scalar, not #{node.type}"
   end
 
   string = node.value
@@ -279,7 +279,7 @@ end
 struct Time::Format
   def from_yaml(ctx : YAML::ParseContext, node : YAML::Nodes::Node) : Time
     unless node.is_a?(YAML::Nodes::Scalar)
-      node.raise "Expected scalar, not #{node.class}"
+      node.raise "Expected scalar, not #{node.type}"
     end
 
     parse(node.value, Time::Location::UTC)
@@ -289,7 +289,7 @@ end
 module Time::EpochConverter
   def self.from_yaml(ctx : YAML::ParseContext, node : YAML::Nodes::Node) : Time
     unless node.is_a?(YAML::Nodes::Scalar)
-      node.raise "Expected scalar, not #{node.class}"
+      node.raise "Expected scalar, not #{node.type}"
     end
 
     Time.unix(node.value.to_i)
@@ -299,7 +299,7 @@ end
 module Time::EpochMillisConverter
   def self.from_yaml(ctx : YAML::ParseContext, node : YAML::Nodes::Node) : Time
     unless node.is_a?(YAML::Nodes::Scalar)
-      node.raise "Expected scalar, not #{node.class}"
+      node.raise "Expected scalar, not #{node.type}"
     end
 
     Time.unix_ms(node.value.to_i64)
@@ -309,7 +309,7 @@ end
 module YAML::ArrayConverter(Converter)
   def self.from_yaml(ctx : YAML::ParseContext, node : YAML::Nodes::Node) : Array
     unless node.is_a?(YAML::Nodes::Sequence)
-      node.raise "Expected sequence, not #{node.class}"
+      node.raise "Expected sequence, not #{node.type}"
     end
 
     ary = Array(typeof(Converter.from_yaml(ctx, node))).new

--- a/src/yaml/from_yaml.cr
+++ b/src/yaml/from_yaml.cr
@@ -44,7 +44,7 @@ private def parse_scalar(ctx, node, type : T.class) forall T
       node.raise "Expected #{T}, not #{node.value.inspect}"
     end
   else
-    node.raise "Expected scalar, not #{node.type}"
+    node.raise "Expected scalar, not #{node.kind}"
   end
 end
 
@@ -72,7 +72,7 @@ def String.new(ctx : YAML::ParseContext, node : YAML::Nodes::Node)
     ctx.record_anchor(node, value)
     value
   else
-    node.raise "Expected String, not #{node.type}"
+    node.raise "Expected String, not #{node.kind}"
   end
 end
 
@@ -105,7 +105,7 @@ end
 
 def Array.new(ctx : YAML::ParseContext, node : YAML::Nodes::Node)
   unless node.is_a?(YAML::Nodes::Sequence)
-    node.raise "Expected sequence, not #{node.type}"
+    node.raise "Expected sequence, not #{node.kind}"
   end
 
   node.each do |value|
@@ -130,7 +130,7 @@ end
 
 def Set.new(ctx : YAML::ParseContext, node : YAML::Nodes::Node)
   unless node.is_a?(YAML::Nodes::Sequence)
-    node.raise "Expected sequence, not #{node.type}"
+    node.raise "Expected sequence, not #{node.kind}"
   end
 
   node.each do |value|
@@ -155,7 +155,7 @@ end
 
 def Hash.new(ctx : YAML::ParseContext, node : YAML::Nodes::Node)
   unless node.is_a?(YAML::Nodes::Mapping)
-    node.raise "Expected mapping, not #{node.type}"
+    node.raise "Expected mapping, not #{node.kind}"
   end
 
   YAML::Schema::Core.each(node) do |key, value|
@@ -165,7 +165,7 @@ end
 
 def Tuple.new(ctx : YAML::ParseContext, node : YAML::Nodes::Node)
   unless node.is_a?(YAML::Nodes::Sequence)
-    node.raise "Expected sequence, not #{node.type}"
+    node.raise "Expected sequence, not #{node.kind}"
   end
 
   if node.nodes.size != {{T.size}}
@@ -183,7 +183,7 @@ end
 
 def NamedTuple.new(ctx : YAML::ParseContext, node : YAML::Nodes::Node)
   unless node.is_a?(YAML::Nodes::Mapping)
-    node.raise "Expected mapping, not #{node.type}"
+    node.raise "Expected mapping, not #{node.kind}"
   end
 
   {% begin %}
@@ -221,7 +221,7 @@ end
 
 def Enum.new(ctx : YAML::ParseContext, node : YAML::Nodes::Node)
   unless node.is_a?(YAML::Nodes::Scalar)
-    node.raise "Expected scalar, not #{node.type}"
+    node.raise "Expected scalar, not #{node.kind}"
   end
 
   string = node.value
@@ -279,7 +279,7 @@ end
 struct Time::Format
   def from_yaml(ctx : YAML::ParseContext, node : YAML::Nodes::Node) : Time
     unless node.is_a?(YAML::Nodes::Scalar)
-      node.raise "Expected scalar, not #{node.type}"
+      node.raise "Expected scalar, not #{node.kind}"
     end
 
     parse(node.value, Time::Location::UTC)
@@ -289,7 +289,7 @@ end
 module Time::EpochConverter
   def self.from_yaml(ctx : YAML::ParseContext, node : YAML::Nodes::Node) : Time
     unless node.is_a?(YAML::Nodes::Scalar)
-      node.raise "Expected scalar, not #{node.type}"
+      node.raise "Expected scalar, not #{node.kind}"
     end
 
     Time.unix(node.value.to_i)
@@ -299,7 +299,7 @@ end
 module Time::EpochMillisConverter
   def self.from_yaml(ctx : YAML::ParseContext, node : YAML::Nodes::Node) : Time
     unless node.is_a?(YAML::Nodes::Scalar)
-      node.raise "Expected scalar, not #{node.type}"
+      node.raise "Expected scalar, not #{node.kind}"
     end
 
     Time.unix_ms(node.value.to_i64)
@@ -309,7 +309,7 @@ end
 module YAML::ArrayConverter(Converter)
   def self.from_yaml(ctx : YAML::ParseContext, node : YAML::Nodes::Node) : Array
     unless node.is_a?(YAML::Nodes::Sequence)
-      node.raise "Expected sequence, not #{node.type}"
+      node.raise "Expected sequence, not #{node.kind}"
     end
 
     ary = Array(typeof(Converter.from_yaml(ctx, node))).new

--- a/src/yaml/nodes/nodes.cr
+++ b/src/yaml/nodes/nodes.cr
@@ -29,6 +29,9 @@ module YAML::Nodes
     def raise(message)
       ::raise YAML::ParseException.new(message, *location)
     end
+
+    # Returns the type of this node, which is equivalent to the class name.
+    abstract def type : String
   end
 
   # A YAML document.
@@ -51,6 +54,10 @@ module YAML::Nodes
     def to_yaml(builder : YAML::Builder)
       nodes.each &.to_yaml(builder)
     end
+
+    def type : String
+      "document"
+    end
   end
 
   # A scalar value.
@@ -67,6 +74,10 @@ module YAML::Nodes
 
     def to_yaml(builder : YAML::Builder)
       builder.scalar(value, anchor, tag, style)
+    end
+
+    def type : String
+      "scalar"
     end
   end
 
@@ -95,6 +106,10 @@ module YAML::Nodes
       builder.sequence(anchor, tag, style) do
         each &.to_yaml(builder)
       end
+    end
+
+    def type : String
+      "sequence"
     end
   end
 
@@ -131,6 +146,10 @@ module YAML::Nodes
         end
       end
     end
+
+    def type : String
+      "mapping"
+    end
   end
 
   # An alias.
@@ -145,6 +164,10 @@ module YAML::Nodes
 
     def to_yaml(builder : YAML::Builder)
       builder.alias(anchor.not_nil!)
+    end
+
+    def type : String
+      "alias"
     end
   end
 end

--- a/src/yaml/nodes/nodes.cr
+++ b/src/yaml/nodes/nodes.cr
@@ -30,8 +30,8 @@ module YAML::Nodes
       ::raise YAML::ParseException.new(message, *location)
     end
 
-    # Returns the type of this node, which is equivalent to the class name.
-    abstract def type : String
+    # Returns the kind of this node, which is equivalent to the class name.
+    abstract def kind : String
   end
 
   # A YAML document.
@@ -55,7 +55,7 @@ module YAML::Nodes
       nodes.each &.to_yaml(builder)
     end
 
-    def type : String
+    def kind : String
       "document"
     end
   end
@@ -76,7 +76,7 @@ module YAML::Nodes
       builder.scalar(value, anchor, tag, style)
     end
 
-    def type : String
+    def kind : String
       "scalar"
     end
   end
@@ -108,7 +108,7 @@ module YAML::Nodes
       end
     end
 
-    def type : String
+    def kind : String
       "sequence"
     end
   end
@@ -147,7 +147,7 @@ module YAML::Nodes
       end
     end
 
-    def type : String
+    def kind : String
       "mapping"
     end
   end
@@ -166,7 +166,7 @@ module YAML::Nodes
       builder.alias(anchor.not_nil!)
     end
 
-    def type : String
+    def kind : String
       "alias"
     end
   end


### PR DESCRIPTION
This method is already included in #10431 but this is a proper introduction and wide-spread adaptation.

<del>`Node#type`</del><ins>`Node#kind`</ins> returns a string represntation of the node type (document, scalar, sequence, mapping, alias) and makes error message nicer. Now they say `Expected scalar, not sequence` instead of `Expected scalar, not YAML::Nodes::Sequence`. There's no need for the full Crystal path name.

EDIT: The method name was changed from `Node#type` to `Node#kind`.