### PR TITLE
Use class instead of struct for objects in XML module.

### DIFF
--- a/src/xml/attributes.cr
+++ b/src/xml/attributes.cr
@@ -1,6 +1,6 @@
 require "./node"
 
-struct XML::Attributes
+class XML::Attributes
   include Enumerable(Node)
 
   def initialize(@node : Node)

--- a/src/xml/builder.cr
+++ b/src/xml/builder.cr
@@ -4,7 +4,7 @@
 # an invalid XML (for example, if invoking `end_element`
 # without a matching `start_element`, or trying to use
 # a non-string value as an object's field name)
-struct XML::Builder
+class XML::Builder
   private CDATA_END    = "]]>"
   private CDATA_ESCAPE = "]]]]><![CDATA[>"
 

--- a/src/xml/namespace.cr
+++ b/src/xml/namespace.cr
@@ -1,4 +1,4 @@
-struct XML::Namespace
+class XML::Namespace
   getter document : Node
 
   def initialize(@document : Node, @ns : LibXML::NS*)

--- a/src/xml/node.cr
+++ b/src/xml/node.cr
@@ -1,4 +1,4 @@
-struct XML::Node
+class XML::Node
   LOOKS_LIKE_XPATH = /^(\.\/|\/|\.\.|\.$)/
 
   # Creates a new node.

--- a/src/xml/node/type.cr
+++ b/src/xml/node/type.cr
@@ -1,4 +1,4 @@
-struct XML::Node
+class XML::Node
   enum Type
     NONE               =  0
     ELEMENT_NODE       =  1

--- a/src/xml/node_set.cr
+++ b/src/xml/node_set.cr
@@ -1,4 +1,4 @@
-struct XML::NodeSet
+class XML::NodeSet
   include Enumerable(Node)
 
   def initialize(@doc : Node, @set : LibXML::NodeSet*)

--- a/src/xml/reader.cr
+++ b/src/xml/reader.cr
@@ -1,7 +1,7 @@
 require "./libxml2"
 require "./parser_options"
 
-struct XML::Reader
+class XML::Reader
   # Creates a new reader from a string.
   #
   # See `XML::ParserOptions.default` for default options.

--- a/src/xml/reader/type.cr
+++ b/src/xml/reader/type.cr
@@ -1,4 +1,4 @@
-struct XML::Reader
+class XML::Reader
   enum Type
     NONE                   =  0
     ELEMENT                =  1

--- a/src/xml/xpath_context.cr
+++ b/src/xml/xpath_context.cr
@@ -1,4 +1,4 @@
-struct XML::XPathContext
+class XML::XPathContext
   def initialize(node : Node)
     @ctx = LibXML.xmlXPathNewContext(node.to_unsafe.value.doc)
     @ctx.value.node = node.to_unsafe


### PR DESCRIPTION
This will allow a future change to let the XML module manage the libXML2 memory,
fixing https://github.com/crystal-lang/crystal/issues/10435 without breaking the API.