### PR TITLE
Remove Cookie Name Decoding

### DIFF
--- a/spec/std/http/cookie_spec.cr
+++ b/spec/std/http/cookie_spec.cr
@@ -51,9 +51,9 @@ module HTTP
         cookie.to_set_cookie_header.should eq("key=key%3Dvalue; path=/")
       end
 
-      it "parses key%3Dvalue=value" do
+      it "only decodes values" do
         cookie = parse_first_cookie("key%3Dvalue=value")
-        cookie.name.should eq("key=value")
+        cookie.name.should eq("key%3Dvalue")
         cookie.value.should eq("value")
         cookie.to_set_cookie_header.should eq("key%3Dvalue=value; path=/")
       end
@@ -304,9 +304,9 @@ module HTTP
       it "use encode_www_form to write the cookie's value" do
         headers = Headers.new
         cookies = Cookies.new
-        cookies << Cookie.new("a[0]", "b+c")
+        cookies << Cookie.new("a", "b+c")
         cookies.add_request_headers(headers)
-        headers["Cookie"].should eq "a%5B0%5D=b%2Bc"
+        headers["Cookie"].should eq "a=b%2Bc"
       end
 
       it "merges multiple cookies into one Cookie header" do
@@ -366,12 +366,12 @@ module HTTP
         headers.get("Set-Cookie").includes?("c=d; path=/").should be_true
       end
 
-      it "uses encode_www_form on Set-Cookie" do
+      it "uses encode_www_form on Set-Cookie value" do
         headers = Headers.new
         cookies = Cookies.new
-        cookies << Cookie.new("a[0]", "b+c")
+        cookies << Cookie.new("a", "b+c")
         cookies.add_response_headers(headers)
-        headers.get("Set-Cookie").includes?("a%5B0%5D=b%2Bc; path=/").should be_true
+        headers.get("Set-Cookie").includes?("a=b%2Bc; path=/").should be_true
       end
 
       describe "when no cookies are set" do

--- a/src/http/cookie.cr
+++ b/src/http/cookie.cr
@@ -59,7 +59,7 @@ module HTTP
     end
 
     def to_cookie_header(io)
-      URI.encode_www_form(@name, io)
+      io << @name
       io << '='
       URI.encode_www_form(value, io)
     end
@@ -109,7 +109,7 @@ module HTTP
 
       def parse_cookies(header)
         header.scan(CookieString).each do |pair|
-          yield Cookie.new(URI.decode_www_form(pair["name"]), URI.decode_www_form(pair["value"]))
+          yield Cookie.new(pair["name"], URI.decode_www_form(pair["value"]))
         end
       end
 


### PR DESCRIPTION
Per response from security@manas.tech posting as public PR. Proof of concept to demonstrate the vulnerability can be seen at https://github.com/security-curious/cookie-prefix-crystal-poc

---

Crystal automatically encodes and decodes cookie names. [The cookie spec](https://tools.ietf.org/html/rfc6265#section-4.1.1) encourages the value to be encoded but says nothing about the cookie name (it could be encoded or not).

While encoding is allowed, a vulnerability can occur if the cookie name is decoded in such a way that a cookie not using a correctly formed cookie prefix will overwrite a cookie that is using a proper cookie prefix rendering the protections provided cookie prefixes void.

Since Crystal is encoding the entire cookie name using URL encoding two cookies can be sent by the browser and if in the correct order the server will read the cookie without the proper cookie prefix. An example cookie header value is:

    __Secure-Name=safe; __%53ecure-Name=evil

The exact same issue was recently corrected in [the `rack` library for the Ruby language](https://hackerone.com/reports/895727) as well as [the `werkzeug` library used by Python's Flask web framework](https://github.com/pallets/werkzeug/pull/1965). In fact those corrects are what prompted me to look to see if Crystal had the same issue.

Although NIST rated [the Rack vulnerability "high"](https://nvd.nist.gov/vuln/detail/CVE-2020-8184) the Rack maintainers consider that a mistake and [consider is a low priority vulnerability](https://github.com/rack/rack/pull/1677#issuecomment-651343672). I agree.

The solution taken by both `rack` and `werkzeug` were to simply stop encoding the cookie name. If an application needs it encoded because they have a funky name that might mess with header parsing that application can do the encoding itself. This is the solution implemented on this commit.

An alternative solution that is probably more compatible but also more complex is to encode the part of the cookie name after
the cookie prefix if the cookie has a prefix that matches one of the official cookie prefixes (`__Secure-` and `__Host-`).
While this would preserve the encoding for the most part I don't feel the complexity introduced is worth the benefit.