### PR TITLE
Refactor `JSON::PullParser#consume_number` to use stdlib number parsing

### DIFF
--- a/spec/std/json/pull_parser_spec.cr
+++ b/spec/std/json/pull_parser_spec.cr
@@ -118,6 +118,14 @@ private def assert_raw(string, file = __FILE__, line = __LINE__)
   end
 end
 
+private def it_reads(value, file = __FILE__, line = __LINE__)
+  type = value.class
+  it "reads #{type}: #{value.to_json}", file: file, line: line do
+    pull = JSON::PullParser.new(value.to_json)
+    pull.read?(type).should eq(value)
+  end
+end
+
 describe JSON::PullParser do
   assert_pull_parse "null"
   assert_pull_parse "false"
@@ -358,13 +366,67 @@ describe JSON::PullParser do
       end
     {% end %}
 
+    it_reads Float32::MIN
+    it_reads -10_f32
+    it_reads 0_f32
+    it_reads 10_f32
+    it_reads Float32::MAX
+
+    it_reads Float64::MIN
+    it_reads -10_f64
+    it_reads 0_f64
+    it_reads 10_f64
+    it_reads Float64::MAX
+
+    it_reads Int64::MIN
+    it_reads -10_i64
+    it_reads 0_i64
+    it_reads 10_i64
+    it_reads Int64::MAX
+
+    it "reads > Int64::MAX" do
+      pull = JSON::PullParser.new(Int64::MAX.to_s + "0")
+      pull.read?(Int64).should be_nil
+    end
+
+    it "reads < Int64::MIN" do
+      pull = JSON::PullParser.new(Int64::MIN.to_s + "0")
+      pull.read?(Int64).should be_nil
+    end
+
+    it "reads > Float32::MAX" do
+      pull = JSON::PullParser.new(Float64::MAX.to_s)
+      pull.read?(Float32).should be_nil
+    end
+
+    it "reads < Float32::MIN" do
+      pull = JSON::PullParser.new(Float64::MIN.to_s)
+      pull.read?(Float32).should be_nil
+    end
+
+    it "reads > UInt64::MAX" do
+      pull = JSON::PullParser.new(UInt64::MAX.to_s + "0")
+      pull.read?(UInt64).should be_nil
+    end
+
+    it "reads > Float64::MAX" do
+      pull = JSON::PullParser.new("1" + Float64::MAX.to_s)
+      pull.read?(Float64).should be_nil
+    end
+
+    it "reads < Float64::MIN" do
+      pull = JSON::PullParser.new("-1" + Float64::MAX.to_s)
+      pull.read?(Float64).should be_nil
+    end
+
     {% for pair in [[Int8, Int64::MAX],
                     [Int16, Int64::MAX],
                     [Int32, Int64::MAX],
                     [UInt8, -1],
                     [UInt16, -1],
                     [UInt32, -1],
-                    [UInt64, -1]] %}
+                    [UInt64, -1],
+                    [Float32, Float64::MAX]] %}
       {% type = pair[0] %}
       {% value = pair[1] %}
 
@@ -374,9 +436,18 @@ describe JSON::PullParser do
       end
     {% end %}
 
-    pending "returns nil in place of Float32 when an overflow occurs" do
-      pull = JSON::PullParser.new(Float64::MAX.to_json)
-      pull.read?(Float32).should be_nil
+    it "doesn't accept nan or infinity" do
+      pull = JSON::PullParser.new(%("nan"))
+      pull.read?(Float64).should be_nil
+
+      pull = JSON::PullParser.new(%("infinity"))
+      pull.read?(Float64).should be_nil
+
+      pull = JSON::PullParser.new(%("+infinity"))
+      pull.read?(Float64).should be_nil
+
+      pull = JSON::PullParser.new(%("-infinity"))
+      pull.read?(Float64).should be_nil
     end
   end
 

--- a/src/big/json.cr
+++ b/src/big/json.cr
@@ -12,8 +12,14 @@ end
 
 struct BigInt
   def self.new(pull : JSON::PullParser)
-    pull.read_int
-    new(pull.raw_value)
+    case pull.kind
+    when .int?
+      value = pull.raw_value
+      pull.read_next
+    else
+      value = pull.read_string
+    end
+    new(value)
   end
 
   def self.from_json_object_key?(key : String)
@@ -34,12 +40,9 @@ end
 struct BigFloat
   def self.new(pull : JSON::PullParser)
     case pull.kind
-    when .int?
-      pull.read_int
+    when .int?, .float?
       value = pull.raw_value
-    when .float?
-      pull.read_float
-      value = pull.raw_value
+      pull.read_next
     else
       value = pull.read_string
     end
@@ -64,12 +67,9 @@ end
 struct BigDecimal
   def self.new(pull : JSON::PullParser)
     case pull.kind
-    when .int?
-      pull.read_int
+    when .int?, .float?
       value = pull.raw_value
-    when .float?
-      pull.read_float
-      value = pull.raw_value
+      pull.read_next
     else
       value = pull.read_string
     end

--- a/src/json/lexer.cr
+++ b/src/json/lexer.cr
@@ -213,57 +213,43 @@ abstract class JSON::Lexer
   end
 
   private def consume_number
-    # TODO once overflow is the default the overflow custom logic can be refactored
-
     number_start
-
-    integer = 0_i64
-    negative = false
-    digits = 0
 
     if current_char == '-'
       append_number_char
-      negative = true
       next_char
     end
 
     case current_char
     when '0'
       append_number_char
-      next_char
-      case current_char
+      char = next_char
+      case char
       when '.'
-        consume_float(negative, integer, digits)
+        consume_float
       when 'e', 'E'
-        consume_exponent(negative, integer.to_f64, digits)
+        consume_exponent
       when '0'..'9'
         unexpected_char
       else
         @token.kind = :int
-        @token.int_value = 0_i64
         number_end
       end
     when '1'..'9'
-      digits = 1
       append_number_char
-      integer = (current_char - '0').to_i64
       char = next_char
       while '0' <= char <= '9'
         append_number_char
-        integer &*= 10
-        integer &+= char - '0'
-        digits += 1
         char = next_char
       end
 
       case char
       when '.'
-        consume_float(negative, integer, digits)
+        consume_float
       when 'e', 'E'
-        consume_exponent(negative, integer.to_f64, digits)
+        consume_exponent
       else
         @token.kind = :int
-        @token.int_value = negative ? -integer : integer
         number_end
       end
     else
@@ -271,11 +257,8 @@ abstract class JSON::Lexer
     end
   end
 
-  private def consume_float(negative, integer, digits)
-    # TODO once overflow is the default the overflow custom logic can be refactored
-
+  private def consume_float
     append_number_char
-    divisor = 1_u64
     char = next_char
 
     unless '0' <= char <= '9'
@@ -284,34 +267,19 @@ abstract class JSON::Lexer
 
     while '0' <= char <= '9'
       append_number_char
-      integer &*= 10
-      integer &+= char - '0'
-      divisor &*= 10
-      digits += 1
       char = next_char
     end
-    float = integer.to_f64 / divisor
 
     if char == 'e' || char == 'E'
-      consume_exponent(negative, float, digits)
+      consume_exponent
     else
       @token.kind = :float
-      # If there's a chance of overflow, we parse the raw string
-      if digits >= 18
-        @token.float_value = number_string.to_f64
-      else
-        @token.float_value = negative ? -float : float
-      end
       number_end
     end
   end
 
-  private def consume_exponent(negative, float, digits)
-    # TODO once overflow is the default the overflow custom logic can be refactored
-
+  private def consume_exponent
     append_number_char
-    exponent = 0
-    negative_exponent = false
 
     char = next_char
     if char == '+'
@@ -320,14 +288,11 @@ abstract class JSON::Lexer
     elsif char == '-'
       append_number_char
       char = next_char
-      negative_exponent = true
     end
 
     if '0' <= char <= '9'
       while '0' <= char <= '9'
         append_number_char
-        exponent *= 10
-        exponent += char - '0'
         char = next_char
       end
     else
@@ -335,16 +300,6 @@ abstract class JSON::Lexer
     end
 
     @token.kind = :float
-
-    exponent = -exponent if negative_exponent
-    float *= (10_f64 ** exponent)
-
-    # If there's a chance of overflow, we parse the raw string
-    if digits >= 18
-      @token.float_value = number_string.to_f64
-    else
-      @token.float_value = negative ? -float : float
-    end
 
     number_end
   end

--- a/src/json/token.cr
+++ b/src/json/token.cr
@@ -17,8 +17,23 @@ class JSON::Token
 
   property kind : Kind
   property string_value : String
-  property int_value : Int64
-  property float_value : Float64
+
+  def int_value : Int64
+    begin
+      raw_value.to_i64
+    rescue exc : ArgumentError
+      raise ParseException.new(exc.message, line_number, column_number)
+    end
+  end
+
+  def float_value : Float64
+    begin
+      raw_value.to_f64
+    rescue exc : ArgumentError
+      raise ParseException.new(exc.message, line_number, column_number)
+    end
+  end
+
   property line_number : Int32
   property column_number : Int32
   property raw_value : String
@@ -28,8 +43,6 @@ class JSON::Token
     @line_number = 0
     @column_number = 0
     @string_value = ""
-    @int_value = 0_i64
-    @float_value = 0.0
     @raw_value = ""
   end
 


### PR DESCRIPTION
The custom parsing algorithm was insufficient and had several issues around range boundaries.
Replacing it with the established conversion methods ensures correctness.

Resolves #10419
Resolves #10920