### PR TITLE
Fix JSON::Lexer's UTF-16 escape sequence parsing

### DIFF
--- a/src/json/lexer.cr
+++ b/src/json/lexer.cr
@@ -189,14 +189,19 @@ abstract class JSON::Lexer
       '\t'
     when 'u'
       hexnum1 = read_hex_number
-      if hexnum1 > 0xD800 && hexnum1 < 0xDBFF
+      if hexnum1 < 0xd800 || hexnum1 >= 0xe000
+        hexnum1.unsafe_chr
+      elsif hexnum1 < 0xdc00
         if next_char != '\\' || next_char != 'u'
           raise "Unterminated UTF-16 sequence"
         end
         hexnum2 = read_hex_number
-        (0x10000 | (hexnum1 & 0x3FF) << 10 | (hexnum2 & 0x3FF)).chr
+        unless 0xdc00 <= hexnum2 <= 0xdfff
+          raise "Invalid UTF-16 sequence"
+        end
+        ((hexnum1 << 10) &+ hexnum2 &- 0x35fdc00).unsafe_chr
       else
-        hexnum1.chr
+        raise "Invalid UTF-16 sequence"
       end
     else
       raise "Unknown escape char: #{char}"

--- a/src/string/utf16.cr
+++ b/src/string/utf16.cr
@@ -134,18 +134,18 @@ class String
       if byte < 0xd800 || byte >= 0xe000
         # One byte
         codepoint = byte
-      elsif 0xd800 <= byte < 0xdc00 &&
+      elsif byte < 0xdc00 &&
             (i + 1) < slice.size &&
             0xdc00 <= slice[i + 1] <= 0xdfff
         # Surrogate pair
-        codepoint = ((byte - 0xd800) << 10) + (slice[i + 1] - 0xdc00) + 0x10000
+        codepoint = (byte << 10) &+ slice[i + 1] &- 0x35fdc00
         i += 1
       else
         # Invalid byte
         codepoint = 0xfffd
       end
 
-      yield codepoint.chr
+      yield codepoint.unsafe_chr
 
       i += 1
     end
@@ -160,17 +160,17 @@ class String
       if byte < 0xd800 || byte >= 0xe000
         # One byte
         codepoint = byte
-      elsif 0xd800 <= byte < 0xdc00 &&
+      elsif byte < 0xdc00 &&
             0xdc00 <= (pointer + 1).value <= 0xdfff
         # Surrogate pair
         pointer = pointer + 1
-        codepoint = ((byte - 0xd800) << 10) + (pointer.value - 0xdc00) + 0x10000
+        codepoint = (byte << 10) &+ pointer.value &- 0x35fdc00
       else
         # Invalid byte
         codepoint = 0xfffd
       end
 
-      yield codepoint.chr
+      yield codepoint.unsafe_chr
 
       pointer = pointer + 1
     end


### PR DESCRIPTION
`JSON::Lexer`'s handling of UTF-16 escape sequences is entirely wrong, and can produce unpaired surrogates:

```crystal
# should be U+10000 "𐀀"
String.from_json(%("\\uD800\\uDC00")) # => "\xED\xA0\x80\xED\xB0\x80"

# should be U+10FFFD "􏿽"
String.from_json(%("\\uDBFF\\uDFFD")) # => "\xED\xAF\xBF\xED\xBF\xBD"

# should be U+20000 "𠀀"
String.from_json(%("\\uD840\\uDC00")) # => "𐀀"

# should raise
String.from_json(%("\\uDC00")) # => "\xED\xB0\x80"

# should raise
String.from_json(%("\\uD83D\\u0202")) # => "😂"
```

This PR fixes these by copying code from `String`'s UTF-16 methods, which are already conformant. It also makes the methods slightly faster by using the kind of unsafe arithmetic that `Char::Reader` also does.