### PR TITLE
Rename "sigfault" to "segfault"

### DIFF
--- a/shell.nix
+++ b/shell.nix
@@ -146,6 +146,6 @@ pkgs.stdenv.mkDerivation rec {
 
   LLVM_CONFIG = "${llvm_suite.llvm}/bin/llvm-config";
 
-  # ld: warning: object file (.../src/ext/libcrystal.a(sigfault.o)) was built for newer OSX version (10.14) than being linked (10.12)
+  # ld: warning: object file (.../src/ext/libcrystal.a(segfault.o)) was built for newer OSX version (10.14) than being linked (10.12)
   MACOSX_DEPLOYMENT_TARGET = "10.11";
 }

--- a/src/ext.cr
+++ b/src/ext.cr
@@ -1,4 +1,4 @@
 @[Link(ldflags: "#{__DIR__}/ext/libcrystal.a")]
 lib LibExt
-  fun setup_sigfault_handler
+  fun setup_segfault_handler
 end

--- a/src/ext/segfault.c
+++ b/src/ext/segfault.c
@@ -3,13 +3,13 @@
 #include <unistd.h>
 #include <stdlib.h>
 
-void __crystal_sigfault_handler(int sig, void *addr);
+void __crystal_segfault_handler(int sig, void *addr);
 
-void sigfault_handler(int sig, siginfo_t *info, void *data) {
-  __crystal_sigfault_handler(sig, info->si_addr);
+void segfault_handler(int sig, siginfo_t *info, void *data) {
+  __crystal_segfault_handler(sig, info->si_addr);
 }
 
-void setup_sigfault_handler() {
+void setup_segfault_handler() {
   stack_t altstack;
   struct sigaction action;
 
@@ -20,7 +20,7 @@ void setup_sigfault_handler() {
 
   sigemptyset(&action.sa_mask);
   action.sa_flags = SA_ONSTACK | SA_SIGINFO;
-  action.sa_sigaction = &sigfault_handler;
+  action.sa_sigaction = &segfault_handler;
 
   sigaction(SIGSEGV, &action, NULL);
   sigaction(SIGBUS, &action, NULL);

--- a/src/kernel.cr
+++ b/src/kernel.cr
@@ -535,12 +535,12 @@ end
   end
 
   Signal.setup_default_handlers
-  LibExt.setup_sigfault_handler
+  LibExt.setup_segfault_handler
 {% end %}
 
 {% if !flag?(:win32) %}
   # load dwarf on start up of the program is executed with CRYSTAL_LOAD_DWARF=1
-  # this will make dwarf available on print_frame that is used on __crystal_sigfault_handler
+  # this will make dwarf available on print_frame that is used on __crystal_segfault_handler
   #
   # - CRYSTAL_LOAD_DWARF=0 will never use dwarf information (See Exception::CallStack.load_dwarf)
   # - CRYSTAL_LOAD_DWARF=1 will load dwarf on startup

--- a/src/signal.cr
+++ b/src/signal.cr
@@ -322,7 +322,7 @@ module Crystal::SignalChildHandler
 end
 
 # :nodoc:
-fun __crystal_sigfault_handler(sig : LibC::Int, addr : Void*)
+fun __crystal_segfault_handler(sig : LibC::Int, addr : Void*)
   # Capture fault signals (SEGV, BUS) and finish the process printing a backtrace first
 
   # Determine if the SEGV was inside or 'near' the top of the stack


### PR DESCRIPTION
"sigfault" doesn't exist: this is either "segfault" for [Segmentation fault](https://en.wikipedia.org/wiki/Segmentation_fault), or SIGSEGV.

When I was starting to say "sigfault" and realized this word doesn't exist, I knew it was time to change this :sweat_smile: 

Perhaps it is a portmanteau for "Segmentation fault signal"?