### PR TITLE
Fix `Struct#==` for generic types

### DIFF
--- a/spec/std/struct_spec.cr
+++ b/spec/std/struct_spec.cr
@@ -3,7 +3,7 @@ require "./spec_helper"
   require "big"
 {% end %}
 
-private module StructSpec
+module StructSpec
   struct TestClass
     @x : Int32
     @y : String
@@ -39,6 +39,11 @@ private module StructSpec
   end
 
   struct BarStruct < GeneralStruct
+  end
+
+  struct GenericStruct(T)
+    def initialize(@value : T)
+    end
   end
 end
 
@@ -90,5 +95,12 @@ describe "Struct" do
     set = Set{foo, bar}
     set.includes?(foo).should be_true
     set.includes?(bar).should be_true
+  end
+
+  describe "#==" do
+    it "equality for generic types" do
+      StructSpec::GenericStruct.new(1).should eq StructSpec::GenericStruct.new(1.0)
+      StructSpec::GenericStruct.new(1).should_not eq StructSpec::GenericStruct.new("1")
+    end
   end
 end

--- a/src/struct.cr
+++ b/src/struct.cr
@@ -64,15 +64,18 @@ struct Struct
   # p1 == p3 # => false
   # ```
   def ==(other) : Bool
-    # TODO: This is a workaround for https://github.com/crystal-lang/crystal/issues/5249
-    if other.is_a?(self)
-      {% for ivar in @type.instance_vars %}
-        return false unless @{{ivar.id}} == other.@{{ivar.id}}
-      {% end %}
-      return true
-    else
-      return false
-    end
+    {% begin %}
+      # TODO: This is a workaround for https://github.com/crystal-lang/crystal/issues/5249
+      # and https://github.com/crystal-lang/crystal/issues/4269
+      if other.is_a?({{ @type.type_vars.empty? ? "self".id : @type.name(generic_args: false) }})
+        {% for ivar in @type.instance_vars %}
+          return false unless @{{ivar.id}} == other.@{{ivar.id}}
+        {% end %}
+        return true
+      else
+        return false
+      end
+    {% end %}
   end
 
   # See `Object#hash(hasher)`


### PR DESCRIPTION
The type restriction `self` would be strict about the generic type argument, but that's not wanted here.

The solution does not work for private generic struct types because the explicit path won't have visibility (https://github.com/crystal-lang/crystal/issues/4269).

Resolves #10311 (for the most part).