### PR TITLE
Accept pointer instance types on falsey conditional branches

### DIFF
--- a/spec/compiler/semantic/if_spec.cr
+++ b/spec/compiler/semantic/if_spec.cr
@@ -422,4 +422,20 @@ describe "Semantic: if" do
       foo
       ), inject_primitives: false) { int32 }
   end
+
+  it "includes pointer types in falsey branch" do
+    assert_type(%(
+      def foo
+        x = 1
+        y = false || pointerof(x) || nil
+
+        if !y
+          return y
+        end
+        1
+      end
+
+      foo
+      )) { nilable union_of bool, pointer_of(int32), int32 }
+  end
 end

--- a/src/compiler/crystal/semantic/filters.cr
+++ b/src/compiler/crystal/semantic/filters.cr
@@ -189,9 +189,13 @@ module Crystal
 
       resulting_types = other_types - types
 
-      # Special case: not truthy (falsey) can also be bool
-      if @filter.is_a?(TruthyFilter) && (bool_type = types.find(&.bool_type?))
-        resulting_types << bool_type
+      # Special case: not truthy (falsey) can also be bool or pointer
+      if @filter.is_a?(TruthyFilter)
+        types.each do |type|
+          if type.bool_type? || type.pointer?
+            resulting_types << type
+          end
+        end
       end
 
       case resulting_types.size


### PR DESCRIPTION
Crystal currently only allows `Bool` and `Nil` when performing flow typing on a falsey variable, but all `Pointer` instances can also be falsey. This leads to the following bug:

```crystal
x = false || Pointer(Void).null if true # => Pointer(Void).null
typeof(x)                               # => (Bool | Pointer(Void) | Nil)

if !x
  typeof(x) # => (Bool | Nil)
  p x       # Invalid memory access (signal 11) at address 0xb4
end
```

This PR adds all `Pointer` instance types to those falsey branches, so that the inner `typeof` will report the same type as the outer one.