### PR TITLE
Fix SDL examples crashes

### DIFF
--- a/samples/sdl/fire.cr
+++ b/samples/sdl/fire.cr
@@ -281,7 +281,7 @@ class Screen
   end
 
   def put_pixel(point, color)
-    color = color.to_u32
+    color = color.to_u32!
     offset = @surface.offset(point.x, point.y)
     @surface[offset] = color
 

--- a/samples/sdl/sdl/surface.cr
+++ b/samples/sdl/sdl/surface.cr
@@ -24,7 +24,7 @@ class SDL::Surface
   end
 
   def []=(offset, color)
-    (@surface.value.pixels.as(UInt32*))[offset] = color.to_u32
+    (@surface.value.pixels.as(UInt32*))[offset] = color.to_u32!
   end
 
   def []=(x, y, color)

--- a/samples/sdl/tv.cr
+++ b/samples/sdl/tv.cr
@@ -130,34 +130,38 @@ color_maker = ColorMaker.new(delay)
 rects = parse_rectangles
 puts "Rects: #{rects.size}"
 
-while true
-  SDL.poll_events do |event|
-    if event.type == LibSDL::QUIT || event.type == LibSDL::KEYDOWN
-      ms = SDL.ticks - start
-      puts "#{frames} frames in #{ms} ms"
-      puts "Average FPS: #{frames / (ms * 0.001)}"
-      SDL.quit
-      exit
+begin
+  while true
+    SDL.poll_events do |event|
+      if event.type == LibSDL::QUIT || event.type == LibSDL::KEYDOWN
+        ms = SDL.ticks - start
+        puts "#{frames} frames in #{ms} ms"
+        puts "Average FPS: #{frames / (ms * 0.001)}"
+        SDL.quit
+        exit
+      end
     end
-  end
 
-  surface.lock
+    surface.lock
 
-  (height // 10).times do |h|
-    (width // 10).times do |w|
-      rect = rects.find { |rect| rect.contains?(w, h) }
-      10.times do |y|
-        10.times do |x|
-          surface[x + 10 * w, y + 10 * h] = rect ? (rect.light? ? color_maker.light_color : color_maker.dark_color) : color_maker.black_color
+    (height // 10).times do |h|
+      (width // 10).times do |w|
+        rect = rects.find { |rect| rect.contains?(w, h) }
+        10.times do |y|
+          10.times do |x|
+            surface[x + 10 * w, y + 10 * h] = rect ? (rect.light? ? color_maker.light_color : color_maker.dark_color) : color_maker.black_color
+          end
         end
       end
     end
+
+    color_maker.next
+
+    surface.unlock
+    surface.flip
+
+    frames += 1
   end
-
-  color_maker.next
-
-  surface.unlock
-  surface.flip
-
-  frames += 1
+ensure
+  SDL.quit
 end


### PR DESCRIPTION
Tried the SDL _tv_ example and after some seconds it crashed with overflow in the #to_int32 surface method leaving X session on the example app graphics resolution.
First, added an ensure block with SDL #quit to restore previous resolution on crashes.
Then, replaced #to_int32 with #to_int32! to do overflow wrapping.

For fire example, I did same #to_int32! replacement.