### PR TITLE
[CI] Re-enable test_darwin on circle-ci

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -510,6 +510,9 @@ jobs:
 
 workflows:
   version: 2
+  test_all_platforms:
+    jobs:
+      - test_darwin
   tagged_release:
     jobs:
       - test_linux:

--- a/bin/ci
+++ b/bin/ci
@@ -135,6 +135,17 @@ prepare_build() {
 
   on_osx curl -L https://github.com/crystal-lang/crystal/releases/download/0.36.1/crystal-0.36.1-1-darwin-x86_64.tar.gz -o ~/crystal.tar.gz
   on_osx 'pushd ~;gunzip -c ~/crystal.tar.gz | tar xopf -;mv crystal-0.36.1-1 crystal;popd'
+
+  # These commands may take a few minutes to run due to the large size of the repositories.
+  # This restriction has been made on GitHub's request because updating shallow
+  # clones is an extremely expensive operation due to the tree layout and
+  # traffic of Homebrew/homebrew-core and Homebrew/homebrew-cask. We don't do
+  # this for you automatically to avoid repeatedly performing an expensive
+  # unshallow operation in CI systems (which should instead be fixed to not use
+  # shallow clones). Sorry for the inconvenience!
+  on_osx git -C /usr/local/Homebrew/Library/Taps/homebrew/homebrew-core fetch --unshallow
+  on_osx git -C /usr/local/Homebrew/Library/Taps/homebrew/homebrew-cask fetch --unshallow
+
   on_osx brew update --preinstall
   on_osx brew bundle --no-lock
 


### PR DESCRIPTION
This re-activates `test_darwin` job on circle-ci as a temporal workaround for #10110.

We were using this job before but it broke with LLVM 10 and got disabled in #9763. #10078 finally removed the entire `test_all_platforms` workflow on circleci because all PR-jobs were moved to GitHub Actions.

Now the job works again and the nix-based alternative on GitHub Actions is broken instead.

We can see that is works because the job did not succeed, since master is broken on macos (#10475) which wasn't reported by the GitHub Action job.