### PR TITLE
Fix doc Set#each returns `nil` instead of `self`

### DIFF
--- a/src/set.cr
+++ b/src/set.cr
@@ -185,8 +185,8 @@ struct Set(T)
     @hash.empty?
   end
 
-  # Yields each element of the set, and returns `self`.
-  def each
+  # Yields each element of the set, and returns `nil`.
+  def each : Nil
     @hash.each_key do |key|
       yield key
     end


### PR DESCRIPTION
I think current spec is correct.

https://github.com/crystal-lang/crystal/blob/9d7e162cc25b908f8af3dbf6d528ae60348fa789/spec/std/set_spec.cr#L328-L331

My understanding is below. If it is not correct, I'll fix the implementation and spec instead of documentation changes.

```
Returning self on `#each` method is a Ruby conventional interface.
Crystal style is returning nil on `#each` method.
```

https://github.com/crystal-lang/crystal/blob/9d7e162cc25b908f8af3dbf6d528ae60348fa789/src/hash.cr#L1259-L1263
