### PR TITLE
Support closured vars inside Const initializer

### DIFF
--- a/spec/compiler/codegen/const_spec.cr
+++ b/spec/compiler/codegen/const_spec.cr
@@ -533,4 +533,16 @@ describe "Codegen: const" do
       a &+ Foo.x
       )).to_i.should eq(6)
   end
+
+  it "supports storing function returning nil" do
+    run(%(
+      def foo
+        "foo"
+        nil
+      end
+
+      CONST = foo
+      CONST
+      )).to_i.should eq(0)
+  end
 end

--- a/spec/compiler/codegen/const_spec.cr
+++ b/spec/compiler/codegen/const_spec.cr
@@ -565,7 +565,7 @@ describe "Codegen: const" do
       end
 
       CONST = foo
-      CONST
-      ))
+      CONST.nil?
+      )).to_b.should eq(true)
   end
 end

--- a/spec/compiler/codegen/const_spec.cr
+++ b/spec/compiler/codegen/const_spec.cr
@@ -534,6 +534,29 @@ describe "Codegen: const" do
       )).to_i.should eq(6)
   end
 
+  it "supports closured vars inside initializers (#10474)" do
+    run(%(
+      class Foo
+        def bar
+          3
+        end
+      end
+
+      def func(&block : -> Int32)
+        block.call
+      end
+
+      CONST = begin
+        foo = Foo.new
+        func do
+          foo.bar
+        end
+      end
+
+      CONST
+      )).to_i.should eq(3)
+  end
+
   it "supports storing function returning nil" do
     run(%(
       def foo

--- a/spec/compiler/codegen/const_spec.cr
+++ b/spec/compiler/codegen/const_spec.cr
@@ -566,6 +566,6 @@ describe "Codegen: const" do
 
       CONST = foo
       CONST
-      )).to_i.should eq(0)
+      ))
   end
 end

--- a/src/compiler/crystal/codegen/const.cr
+++ b/src/compiler/crystal/codegen/const.cr
@@ -100,7 +100,7 @@ class Crystal::CodeGenVisitor
       # Start with fresh variables
       context.vars = LLVMVars.new
 
-      alloca_vars const.vars
+      alloca_vars const.fake_def.try(&.vars), const.fake_def
       request_value do
         accept const.value
       end
@@ -153,7 +153,7 @@ class Crystal::CodeGenVisitor
           # Start with fresh variables
           context.vars = LLVMVars.new
 
-          alloca_vars const.vars
+          alloca_vars const.fake_def.try(&.vars), const.fake_def
 
           request_value do
             accept const.value

--- a/src/compiler/crystal/codegen/const.cr
+++ b/src/compiler/crystal/codegen/const.cr
@@ -173,7 +173,9 @@ class Crystal::CodeGenVisitor
             end
           else
             global.initializer = llvm_type(const.value.type).null
-            store @last, global
+            unless const.value.type.nil_type? || const.value.type.void?
+              store @last, global
+            end
           end
 
           ret

--- a/src/compiler/crystal/semantic/main_visitor.cr
+++ b/src/compiler/crystal/semantic/main_visitor.cr
@@ -189,7 +189,7 @@ module Crystal
           type_visitor.inside_constant = true
           type.value.accept type_visitor
 
-          type.vars = const_def.vars
+          type.fake_def = const_def
           type.visitor = self
           type.used = true
 

--- a/src/compiler/crystal/types.cr
+++ b/src/compiler/crystal/types.cr
@@ -3155,7 +3155,7 @@ module Crystal
   # saved under a type types like any other type.
   class Const < NamedType
     property value : ASTNode
-    property vars : MetaVars?
+    property fake_def : Def?
     property? used = false
     property? visited = false
 


### PR DESCRIPTION
Probably isn't the cleanest fix, but this solves it with the least changes.

I found another bug with const initializer codegen while I was solving this, that's why there's 2 commits.

Fixes #10474 .