### PR TITLE
[CI] Fix test_macos with recent bash for nix-shell

### DIFF
--- a/bin/ci
+++ b/bin/ci
@@ -138,6 +138,9 @@ prepare_build() {
   on_osx brew update --preinstall
   on_osx brew bundle --no-lock
 
+  # initialize nix environment
+  on_nix_shell nix-shell
+
   # Note: brew link --force might show:
   #   Warning: Refusing to link macOS-provided software: llvm
   #

--- a/bin/ci
+++ b/bin/ci
@@ -138,6 +138,11 @@ prepare_build() {
   on_osx brew update --preinstall
   on_osx brew bundle --no-lock
 
+  # Install a recent bash version for nix-shell.
+  # macos ships with an ancient one.
+  if [ `uname` = "Darwin" ]; then
+    on_nix_shell "brew install bash"
+  fi
   # initialize nix environment
   on_nix_shell nix-shell
 


### PR DESCRIPTION
Fixes the original issue of #10110 by installing `bash` from brew:

> 2. The actual error is `/nix/store/r0n4qzr800498l23cq80mg0k03j3aqms-cctools-binutils-darwin-wrapper-927.0.2/nix-support/setup-hook: line 138: ${role_pre}${cmd^^}=${cmd}: bad substitution`. Looks like macos ships a really old bash version (3.2) and the substitution requires at least 4.0. So that should be easy to fix, just install a recent bash.

Also moves nix initialization to `prepare_build` stage.