### PR TITLE
Update issue template for the latest Github suggestion

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,6 +1,8 @@
-# Submitting questions
-
-If you have a question like "how do I do X?", this is not the right place for asking it. Please ask on the [Crystal Forum](https://forum.crystal-lang.org), on our combined [Gitter](https://gitter.im/crystal-lang/crystal)/[IRC](http://webchat.freenode.net/?channels=#crystal-lang) or on [StackOverflow](http://stackoverflow.com/questions/tagged/crystal-lang).
+---
+name: Bug report
+about: Create a report to help us improve
+labels: kind:bug
+---
 
 # Submitting bugs
 
@@ -12,3 +14,7 @@ Make sure to review these points before submitting issues - thank you!
 - Reduce code, if possible, to the minimum size that reproduces the bug.
 - If all of the above is impossible due to a large project, create a branch that reproduces the bug and point us to it.
 - Include Crystal compiler version (`crystal -v`) and OS. If possible, try to see if the bug still reproduces on master.
+
+## Submitting questions
+
+If you have a question like "how do I do X?", this is not the right place for asking it. Please ask on the one of [contact_links](https://github.com/crystal-lang/crystal/blob/master/.github/ISSUE_TEMPLATE/config.yml).

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,14 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Forum
+    url: https://forum.crystal-lang.org
+    about: Please ask and answer questions here.
+  - name: Gitter
+    url: https://gitter.im/crystal-lang/crystal
+    about: Please ask and answer questions here.
+  - name: IRC
+    url: http://webchat.freenode.net/?channels=#crystal-lang
+    about: Please ask and answer questions here.
+  - name: Stack Overflow
+    url: http://stackoverflow.com/questions/tagged/crystal-lang
+    about: Please ask and answer questions here.


### PR DESCRIPTION
Current style looks similar as https://docs.github.com/en/github/building-a-strong-community/manually-creating-a-single-issue-template-for-your-repository
Github said it is the `legacy` way.

<img width="821" alt="スクリーンショット 2021-03-07 15 29 10" src="https://user-images.githubusercontent.com/1180335/110231334-87f9a080-7f5a-11eb-819b-dfe6a529de5b.png">
<img width="748" alt="スクリーンショット 2021-03-07 15 32 42" src="https://user-images.githubusercontent.com/1180335/110231336-88923700-7f5a-11eb-9321-7933def436a9.png">

So the latest style suggested at here.

https://docs.github.com/en/github/building-a-strong-community/about-issue-and-pull-request-templates
https://docs.github.com/en/github/building-a-strong-community/configuring-issue-templates-for-your-repository#configuring-the-template-chooser

You can check the behavior at https://github.com/kachick/crystal-sandbox-issue-template/issues/new/choose. It shows as <img width="1157" alt="スクリーンショット 2021-03-07 15 27 57" src="https://user-images.githubusercontent.com/1180335/110231333-85974680-7f5a-11eb-8416-b3f40b4aff06.png">