### PR TITLE
Exclude abstract defs from "no overload matches" errors

### DIFF
--- a/spec/compiler/semantic/abstract_def_spec.cr
+++ b/spec/compiler/semantic/abstract_def_spec.cr
@@ -94,7 +94,12 @@ describe "Semantic: abstract def" do
 
       Bar.new.foo(1 || 'a')
       ),
-      "no overload matches"
+      <<-MSG
+      Overloads are:
+       - Bar#foo(x : Int32)
+      Couldn't find overloads for these types:
+       - Bar#foo(x : Char)
+      MSG
   end
 
   it "errors if using abstract def on non-abstract class" do

--- a/src/compiler/crystal/semantic/call_error.cr
+++ b/src/compiler/crystal/semantic/call_error.cr
@@ -425,6 +425,7 @@ class Crystal::Call
 
   def append_matches(defs, arg_types, str, *, matched_def = nil, argument_name = nil)
     defs.each do |a_def|
+      next if a_def.abstract?
       str << "\n - "
       append_def_full_name a_def.owner, a_def, arg_types, str
       if defs.size > 1 && a_def.same?(matched_def)


### PR DESCRIPTION
Abstract defs are never callable and therefore do not affect whether any overload matches a given call. (Even if they do, every abstract def must be subsumed by another non-abstract def.) Given:

```crystal
module Foo
  abstract def foo(x : Int32)
end

class Bar
  include Foo

  def foo(x : Int32); end
end

Bar.new.foo('a')

# Error: no overload matches 'Bar#foo' with type Char
#
# Overloads are:
#  - Bar#foo(x : Int32)
#  - Foo#foo(x : Int32)
```

This PR removes `Foo#foo(x : Int32)` from the error message.