### PR TITLE
Split `HTTP::Cookies.from_headers` into separate methods for server/client

### DIFF
--- a/spec/std/http/cookie_spec.cr
+++ b/spec/std/http/cookie_spec.cr
@@ -234,6 +234,28 @@ module HTTP
   end
 
   describe Cookies do
+    describe ".from_client_headers" do
+      it "parses Cookie header" do
+        cookies = Cookies.from_client_headers Headers{"Cookie" => "a=b"}
+        cookies.to_h.should eq({"a" => Cookie.new("a", "b")})
+      end
+      it "does not accept Set-Cookie header" do
+        cookies = Cookies.from_client_headers Headers{"Cookie" => "a=b", "Set-Cookie" => "x=y"}
+        cookies.to_h.should eq({"a" => Cookie.new("a", "b")})
+      end
+    end
+
+    describe ".from_server_headers" do
+      it "parses Set-Cookie header" do
+        cookies = Cookies.from_server_headers Headers{"Set-Cookie" => "a=b; path=/foo"}
+        cookies.to_h.should eq({"a" => Cookie.new("a", "b", path: "/foo")})
+      end
+      it "does not accept Cookie header" do
+        cookies = Cookies.from_server_headers Headers{"Set-Cookie" => "a=b", "Cookie" => "x=y"}
+        cookies.to_h.should eq({"a" => Cookie.new("a", "b")})
+      end
+    end
+
     it "allows adding cookies and retrieving" do
       cookies = Cookies.new
       cookies << Cookie.new("a", "b")

--- a/src/http/client/response.cr
+++ b/src/http/client/response.cr
@@ -41,7 +41,7 @@ class HTTP::Client::Response
   # Returns a convenience wrapper around querying and setting cookie related
   # headers, see `HTTP::Cookies`.
   def cookies
-    @cookies ||= Cookies.from_headers(headers)
+    @cookies ||= Cookies.from_server_headers(headers)
   end
 
   def keep_alive?

--- a/src/http/cookie.cr
+++ b/src/http/cookie.cr
@@ -159,19 +159,46 @@ module HTTP
     # headers in the given `HTTP::Headers`.
     #
     # See `HTTP::Request#cookies` and `HTTP::Client::Response#cookies`.
+    @[Deprecated("Use `.from_client_headers` or `.from_server_headers` instead.")]
     def self.from_headers(headers) : self
       new.tap { |cookies| cookies.fill_from_headers(headers) }
     end
 
     # Filling cookies by parsing the `Cookie` and `Set-Cookie`
     # headers in the given `HTTP::Headers`.
+    @[Deprecated("Use `#fill_from_client_headers` or `#fill_from_server_headers` instead.")]
     def fill_from_headers(headers)
+      fill_from_client_headers(headers)
+      fill_from_server_headers(headers)
+      self
+    end
+
+    # Creates a new instance by parsing the `Cookie` headers in the given `HTTP::Headers`.
+    #
+    # See `HTTP::Client::Response#cookies`.
+    def self.from_client_headers(headers) : self
+      new.tap { |cookies| cookies.fill_from_client_headers(headers) }
+    end
+
+    # Filling cookies by parsing the `Cookie` headers in the given `HTTP::Headers`.
+    def fill_from_client_headers(headers)
       if values = headers.get?("Cookie")
         values.each do |header|
           Cookie::Parser.parse_cookies(header) { |cookie| self << cookie }
         end
       end
+      self
+    end
 
+    # Creates a new instance by parsing the `Set-Cookie` headers in the given `HTTP::Headers`.
+    #
+    # See `HTTP::Request#cookies`.
+    def self.from_server_headers(headers) : self
+      new.tap { |cookies| cookies.fill_from_server_headers(headers) }
+    end
+
+    # Filling cookies by parsing the `Set-Cookie` headers in the given `HTTP::Headers`.
+    def fill_from_server_headers(headers)
       if values = headers.get?("Set-Cookie")
         values.each do |header|
           Cookie::Parser.parse_set_cookie(header).try { |cookie| self << cookie }

--- a/src/http/request.cr
+++ b/src/http/request.cr
@@ -58,7 +58,7 @@ class HTTP::Request
   # Returns a convenience wrapper around querying and setting cookie related
   # headers, see `HTTP::Cookies`.
   def cookies
-    @cookies ||= Cookies.from_headers(headers)
+    @cookies ||= Cookies.from_client_headers(headers)
   end
 
   # Returns a convenience wrapper around querying and setting query params,


### PR DESCRIPTION
`HTTP::Cookies.from_headers` populates a `Cookie` collection from HTTP headers. It parses both `Cookie` and `Set-Cookie` headers, which seems odd. They are distinct features you really never want to use in combination (you can't have both in the same set of headers).
In practice it means `HTTP::Client` accepts cookies defined by `Cookie` header and `HTTP::Server` accepts cookies defined by `Set-Cookie` header. Both is very confusing and could even offer an opportunity for abuse by circumventing the correct header mechanincs.

This patch deprecates `{fill_,}from_headers` and replaces it with distinct `{fill_,}from_client_headers` and  `{fill_,}from_server_headers` methods.