### PR TITLE
Minor performance improvements to `HTTP::Cookies`

### DIFF
--- a/src/http/cookie.cr
+++ b/src/http/cookie.cr
@@ -272,8 +272,8 @@ module HTTP
     end
 
     # Yields each `HTTP::Cookie` in the collection.
-    def each(&block : Cookie ->)
-      @cookies.values.each do |cookie|
+    def each(& : Cookie ->)
+      @cookies.each_value do |cookie|
         yield cookie
       end
     end

--- a/src/http/cookie.cr
+++ b/src/http/cookie.cr
@@ -297,8 +297,15 @@ module HTTP
     # given `HTTP::Headers` instance and returns it. Removes any existing
     # `Cookie` headers in it.
     def add_request_headers(headers)
-      headers.delete("Cookie")
-      headers.add("Cookie", map(&.to_cookie_header).join("; ")) unless empty?
+      if empty?
+        headers.delete("Cookie")
+      else
+        capacity = sum { |cookie| cookie.name.bytesize + cookie.value.bytesize + 1 }
+        capacity += (size - 1) * 2
+        headers["Cookie"] = String.build(capacity) do |io|
+          join(io, "; ", &.to_cookie_header(io))
+        end
+      end
 
       headers
     end


### PR DESCRIPTION
Adds three small improvemnts with regard to collection operations in `HTTP::Cookies`.

The capacity calculation currently underestimates because it doesn't take URI encoding into account. With #10485 it is 100% accurate.