### PR TITLE
Bump distribution-scripts

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -144,7 +144,7 @@ jobs:
       - run: |
           git clone https://github.com/crystal-lang/distribution-scripts.git ~/distribution-scripts
           cd ~/distribution-scripts
-          git checkout 80c83b203e1ee2fd54e41398160a67c6a06d34e1
+          git checkout 4caf7cd337087e2ae313b8c7e00be247d34482ad
       # persist relevant information for build process
       - run: |
           cd ~/distribution-scripts


### PR DESCRIPTION
This updates distribution packages with shards 0.14.1

Ref: https://github.com/crystal-lang/distribution-scripts/pull/83