### PR TITLE
Add `Slice#hexdump(io : IO)` overload

### DIFF
--- a/spec/std/slice_spec.cr
+++ b/spec/std/slice_spec.cr
@@ -279,6 +279,10 @@ describe "Slice" do
 
   it "does hexdump for empty slice" do
     Bytes.empty.hexdump.should eq("")
+
+    io = IO::Memory.new
+    Bytes.empty.hexdump(io).should eq(0)
+    io.to_s.should eq("")
   end
 
   it "does hexdump" do
@@ -288,7 +292,7 @@ describe "Slice" do
       00000020  40 41 42 43 44 45 46 47  48 49 4a 4b 4c 4d 4e 4f  @ABCDEFGHIJKLMNO
       00000030  50 51 52 53 54 55 56 57  58 59 5a 5b 5c 5d 5e 5f  PQRSTUVWXYZ[\\]^_
       00000040  60 61 62 63 64 65 66 67  68 69 6a 6b 6c 6d 6e 6f  `abcdefghijklmno
-      00000050  70 71 72 73 74 75 76 77  78 79 7a 7b 7c 7d 7e 7f  pqrstuvwxyz{|}~.
+      00000050  70 71 72 73 74 75 76 77  78 79 7a 7b 7c 7d 7e 7f  pqrstuvwxyz{|}~.\n
       EOF
 
     slice = Bytes.new(96) { |i| i.to_u8 + 32 }
@@ -301,11 +305,58 @@ describe "Slice" do
       00000030  50 51 52 53 54 55 56 57  58 59 5a 5b 5c 5d 5e 5f  PQRSTUVWXYZ[\\]^_
       00000040  60 61 62 63 64 65 66 67  68 69 6a 6b 6c 6d 6e 6f  `abcdefghijklmno
       00000050  70 71 72 73 74 75 76 77  78 79 7a 7b 7c 7d 7e 7f  pqrstuvwxyz{|}~.
-      00000060  80 81 82 83 84                                    .....
+      00000060  80 81 82 83 84                                    .....\n
       EOF
 
     plus = Bytes.new(101) { |i| i.to_u8 + 32 }
     plus.hexdump.should eq(ascii_table_plus)
+
+    ascii_table_num = <<-EOF
+      00000000  30 31 32 33 34 35 36 37  38 39                    0123456789\n
+      EOF
+
+    num = Bytes.new(10) { |i| i.to_u8 + 48 }
+    num.hexdump.should eq(ascii_table_num)
+  end
+
+  it "does hexdump to IO" do
+    ascii_table = <<-EOF
+      00000000  20 21 22 23 24 25 26 27  28 29 2a 2b 2c 2d 2e 2f   !"#$%&'()*+,-./
+      00000010  30 31 32 33 34 35 36 37  38 39 3a 3b 3c 3d 3e 3f  0123456789:;<=>?
+      00000020  40 41 42 43 44 45 46 47  48 49 4a 4b 4c 4d 4e 4f  @ABCDEFGHIJKLMNO
+      00000030  50 51 52 53 54 55 56 57  58 59 5a 5b 5c 5d 5e 5f  PQRSTUVWXYZ[\\]^_
+      00000040  60 61 62 63 64 65 66 67  68 69 6a 6b 6c 6d 6e 6f  `abcdefghijklmno
+      00000050  70 71 72 73 74 75 76 77  78 79 7a 7b 7c 7d 7e 7f  pqrstuvwxyz{|}~.\n
+      EOF
+
+    slice = Bytes.new(96) { |i| i.to_u8 + 32 }
+    io = IO::Memory.new
+    slice.hexdump(io).should eq(ascii_table.bytesize)
+    io.to_s.should eq(ascii_table)
+
+    ascii_table_plus = <<-EOF
+      00000000  20 21 22 23 24 25 26 27  28 29 2a 2b 2c 2d 2e 2f   !"#$%&'()*+,-./
+      00000010  30 31 32 33 34 35 36 37  38 39 3a 3b 3c 3d 3e 3f  0123456789:;<=>?
+      00000020  40 41 42 43 44 45 46 47  48 49 4a 4b 4c 4d 4e 4f  @ABCDEFGHIJKLMNO
+      00000030  50 51 52 53 54 55 56 57  58 59 5a 5b 5c 5d 5e 5f  PQRSTUVWXYZ[\\]^_
+      00000040  60 61 62 63 64 65 66 67  68 69 6a 6b 6c 6d 6e 6f  `abcdefghijklmno
+      00000050  70 71 72 73 74 75 76 77  78 79 7a 7b 7c 7d 7e 7f  pqrstuvwxyz{|}~.
+      00000060  80 81 82 83 84                                    .....\n
+      EOF
+
+    plus = Bytes.new(101) { |i| i.to_u8 + 32 }
+    io = IO::Memory.new
+    plus.hexdump(io).should eq(ascii_table_plus.bytesize)
+    io.to_s.should eq(ascii_table_plus)
+
+    ascii_table_num = <<-EOF
+      00000000  30 31 32 33 34 35 36 37  38 39                    0123456789\n
+      EOF
+
+    num = Bytes.new(10) { |i| i.to_u8 + 48 }
+    io = IO::Memory.new
+    num.hexdump(io).should eq(ascii_table_num.bytesize)
+    io.to_s.should eq(ascii_table_num)
   end
 
   it "does iterator" do

--- a/src/io/hexdump.cr
+++ b/src/io/hexdump.cr
@@ -28,7 +28,7 @@ class IO::Hexdump < IO
 
   def read(buf : Bytes)
     @io.read(buf).tap do |read_bytes|
-      @output.puts buf[0, read_bytes].hexdump if @read && read_bytes
+      buf[0, read_bytes].hexdump(@output) if @read && read_bytes
     end
   end
 
@@ -36,7 +36,7 @@ class IO::Hexdump < IO
     return if buf.empty?
 
     @io.write(buf).tap do
-      @output.puts buf.hexdump if @write
+      buf.hexdump(@output) if @write
     end
   end
 


### PR DESCRIPTION
Resolves #10495.

The private method `hexdump_line` refactors most of the original overload and the `IO` overload's bodies together; this leads to a slight speedup even for the overload that returns a `String`. The new overload flushes the `IO` and returns the number of bytes written, similar to `Base64.encode(data, io : IO)`.

[Benchmark and results](https://gist.github.com/HertzDevil/dae3f4e27703ab344b8fda57523c9665). (The oddity with N = 0 seems to be that the benchmark program doesn't inline `bytes.hexdump` into the first report block's body.)