### PR TITLE
Don't merge NamedTuple metaclasses through instance types

### DIFF
--- a/spec/compiler/semantic/named_tuple_spec.cr
+++ b/spec/compiler/semantic/named_tuple_spec.cr
@@ -332,4 +332,15 @@ describe "Semantic: named tuples" do
       call("")
       )) { int32 }
   end
+
+  it "doesn't unify named tuple metaclasses (#5384)" do
+    assert_type(%(
+      NamedTuple(a: Int32) || NamedTuple(a: String)
+      )) {
+      union_of(
+        named_tuple_of({"a": int32}).metaclass,
+        named_tuple_of({"a": string}).metaclass,
+      )
+    }
+  end
 end

--- a/src/compiler/crystal/semantic/type_merge.cr
+++ b/src/compiler/crystal/semantic/type_merge.cr
@@ -249,6 +249,9 @@ module Crystal
       # Tuple instances might be unified, but never tuple metaclasses
       return nil if instance_type.is_a?(TupleInstanceType) || other.instance_type.is_a?(TupleInstanceType)
 
+      # NamedTuple instances might be unified, but never named tuple metaclasses
+      return nil if instance_type.is_a?(NamedTupleInstanceType) || other.instance_type.is_a?(NamedTupleInstanceType)
+
       common = instance_type.common_ancestor(other.instance_type)
       common.try &.metaclass
     end


### PR DESCRIPTION
Follow-up to #6342. Makes the following not crash:

```crystal
x = typeof({a: 1})
x = typeof({a: 'x'}) # BUG: trying to assign NamedTuple(a: Char | Int32).class <- NamedTuple(a: Int32).class
```
