### PR TITLE
Replace Crystal::Type#covariant? with #implements?

### DIFF
--- a/spec/compiler/semantic/abstract_def_spec.cr
+++ b/spec/compiler/semantic/abstract_def_spec.cr
@@ -383,6 +383,19 @@ describe "Semantic: abstract def" do
       )
   end
 
+  it "doesn't error if implements a NoReturn param" do
+    assert_no_errors %(
+      abstract class Foo
+        abstract def foo(x : NoReturn)
+      end
+
+      class Bar < Foo
+        def foo(x : Int32)
+        end
+      end
+      )
+  end
+
   it "finds implements in included module in disorder (#4052)" do
     semantic %(
       module B

--- a/src/compiler/crystal/semantic/abstract_def_checker.cr
+++ b/src/compiler/crystal/semantic/abstract_def_checker.cr
@@ -249,7 +249,7 @@ class Crystal::AbstractDefChecker
       begin
         rt1 = t1.lookup_type(r1)
         rt2 = t2.lookup_type(r2)
-        return false unless rt2.covariant?(rt1)
+        return false unless rt2.implements?(rt1)
       rescue Crystal::TypeException
         # Ignore if we can't find a type (assume the method is implemented)
         return true

--- a/src/compiler/crystal/semantic/call.cr
+++ b/src/compiler/crystal/semantic/call.cr
@@ -1117,7 +1117,7 @@ class Crystal::Call
         when "proc_call"
           owner = owner.as(ProcInstanceType)
           proc_arg_type = owner.arg_types[index]
-          unless type.covariant?(proc_arg_type)
+          unless type.implements?(proc_arg_type)
             self.args[index].raise "type must be #{proc_arg_type}, not #{type}"
           end
         when "pointer_set"

--- a/src/compiler/crystal/types.cr
+++ b/src/compiler/crystal/types.cr
@@ -294,21 +294,6 @@ module Crystal
       end
     end
 
-    def covariant?(other_type : Type)
-      return true if self == other_type
-
-      other_type = other_type.remove_alias
-
-      case other_type
-      when UnionType
-        other_type.union_types.any? do |union_type|
-          covariant?(union_type)
-        end
-      else
-        false
-      end
-    end
-
     def filter_by(other_type)
       restrict other_type, MatchContext.new(self, self, strict: true)
     end
@@ -971,10 +956,6 @@ module Crystal
       end
     end
 
-    def covariant?(other_type)
-      super || parents.any? &.covariant?(other_type)
-    end
-
     def type_desc
       "module"
     end
@@ -1270,11 +1251,6 @@ module Crystal
 
     def class?
       true
-    end
-
-    def covariant?(other_type)
-      other_type = other_type.base_type if other_type.is_a?(VirtualType)
-      implements?(other_type) || super
     end
   end
 
@@ -1964,14 +1940,6 @@ module Crystal
     def implements?(other_type)
       other_type = other_type.remove_alias
       super || generic_type.implements?(other_type)
-    end
-
-    def covariant?(other_type)
-      if other_type.is_a?(GenericInstanceType)
-        super
-      else
-        implements?(other_type)
-      end
     end
 
     def has_in_type_vars?(type)
@@ -3003,10 +2971,6 @@ module Crystal
       union_types.any? &.includes_type?(other_type)
     end
 
-    def covariant?(other_type)
-      union_types.all? &.covariant? other_type
-    end
-
     def filter_by_responds_to(name)
       filtered_types = union_types.compact_map &.filter_by_responds_to(name)
       program.type_merge_union_of filtered_types
@@ -3236,7 +3200,7 @@ module Crystal
     delegate leaf?, superclass, lookup_first_def, lookup_defs,
       lookup_defs_with_modules, lookup_instance_var, lookup_instance_var?,
       index_of_instance_var, lookup_macro, lookup_macros, all_instance_vars,
-      abstract?, implements?, covariant?, ancestors, struct?,
+      abstract?, implements?, ancestors, struct?,
       type_var?, to: base_type
 
     def remove_indirection


### PR DESCRIPTION
`Crystal::Type#covariant?` is only used in two places by the compiler:

* During abstract def checking, when it ensures that an implementation's parameter restrictions are contravariant to an abstract def. (The return type restriction must be covariant, but that is done by `#implements?`.)
* When instantiating a call to `Proc(*T, R)#call(*args : *T)` to ensure that the arguments are indeed covariant. This was introduced at a time when `Proc#call` was defined in the compiler itself instead of in `primitives.cr`, but now splat restrictions have probably achieved the same checks.

Everywhere else in the compiler uses `#implements?` instead when the notion of `A <= B` between types is needed. There is little reason to believe that the compiler needs two different ways of computing this, so this PR removes `#covariant?`. The two methods do diverge on certain types, but `#covariant?` ends up calling `#implements?` for the vast majority of the types, so the differences are very minimal. One such difference fixed by this PR is the following:

```crystal
abstract class Foo
  abstract def foo(x : NoReturn)
end

class Bar < Foo
  # should be allowed because Int32 >= NoReturn, but `covariant?` returns false
  def foo(x : Int32); end # Error: abstract `def Foo#f(x : NoReturn)` must be implemented by Bar
end
```