### PR TITLE
Change default rounding mode to `TIES_EVEN`

### DIFF
--- a/spec/std/benchmark_spec.cr
+++ b/spec/std/benchmark_spec.cr
@@ -108,7 +108,7 @@ describe Benchmark::IPS::Entry, "#human_iteration_time" do
   it { h_ips(0.000_001_234_567).should eq("  1.23µs") }
 
   it { h_ips(0.000_000_123_456).should eq("123.46ns") }
-  it { h_ips(0.000_000_012_345).should eq(" 12.35ns") }
+  it { h_ips(0.000_000_012_345).should eq(" 12.34ns") }
   it { h_ips(0.000_000_001_234).should eq("  1.23ns") }
   it { h_ips(0.000_000_000_123).should eq("  0.12ns") }
 end

--- a/spec/std/complex_spec.cr
+++ b/spec/std/complex_spec.cr
@@ -178,7 +178,8 @@ describe "Complex" do
   end
 
   it "rounds" do
-    (Complex.new(1.125, 0.875).round(2)).should eq(Complex.new(1.13, 0.88))
+    (Complex.new(1.125, 0.875).round(2)).should eq(Complex.new(1.12, 0.88))
+    (Complex.new(1.135, 0.865).round(2)).should eq(Complex.new(1.14, 0.86))
     (Complex.new(1.125, 0.875).round(digits: 1)).should eq(Complex.new(1.1, 0.9))
   end
 

--- a/spec/std/float_spec.cr
+++ b/spec/std/float_spec.cr
@@ -54,7 +54,8 @@ describe "Float" do
   end
 
   describe "round" do
-    it { 2.5.round.should eq(3) }
+    it { 2.5.round.should eq(2) }
+    it { 3.5.round.should eq(4) }
     it { 2.4.round.should eq(2) }
   end
 

--- a/spec/std/humanize_spec.cr
+++ b/spec/std/humanize_spec.cr
@@ -72,7 +72,7 @@ describe Number do
     it { 0.000_001_234_567.humanize(precision: 2, significant: false).should eq("1.23µ") }
 
     it { 0.000_000_123_456.humanize(precision: 2, significant: false).should eq("123.46n") }
-    it { 0.000_000_012_345.humanize(precision: 2, significant: false).should eq("12.35n") }
+    it { 0.000_000_012_345.humanize(precision: 2, significant: false).should eq("12.34n") }
     it { 0.000_000_001_234.humanize(precision: 2, significant: false).should eq("1.23n") }
     it { 0.000_000_000_123.humanize(precision: 2, significant: false).should eq("123.00p") }
 
@@ -102,7 +102,8 @@ describe Int do
     it { 1014.humanize_bytes(format: Int::BinaryPrefixFormat::JEDEC).should eq "0.99KB" }
     it { 1015.humanize_bytes(format: Int::BinaryPrefixFormat::JEDEC).should eq "1.0KB" }
     it { 1024.humanize_bytes(format: Int::BinaryPrefixFormat::JEDEC).should eq "1.0KB" }
-    it { 1025.humanize_bytes(format: Int::BinaryPrefixFormat::JEDEC).should eq "1.01KB" }
+    it { 1025.humanize_bytes(format: Int::BinaryPrefixFormat::JEDEC).should eq "1.0KB" }
+    it { 1026.humanize_bytes(format: Int::BinaryPrefixFormat::JEDEC).should eq "1.01KB" }
     it { 2048.humanize_bytes(format: Int::BinaryPrefixFormat::JEDEC).should eq "2.0KB" }
 
     it { 1536.humanize_bytes(format: Int::BinaryPrefixFormat::JEDEC).should eq("1.5KB") }

--- a/spec/std/number_spec.cr
+++ b/spec/std/number_spec.cr
@@ -130,7 +130,7 @@ describe "Number" do
     end
 
     it "handle medium amount of digits" do
-      1.098765432109876543210987654321.round(15).should eq(1.098765432109877)
+      1.098765432109876543210987654321.round(15).should eq(1.098765432109876)
       1.098765432109876543210987654321.round(21).should eq(1.098765432109876543211)
       6543210987654321.0.round(-15).should eq(7000000000000000.0)
     end
@@ -210,20 +210,20 @@ describe "Number" do
         2.5.round(:ties_away).should eq 3.0
       end
 
-      it "default (=ties_away)" do
-        -2.5.round.should eq -3.0
+      it "default (=ties_even)" do
+        -2.5.round.should eq -2.0
         -1.5.round.should eq -2.0
         -1.0.round.should eq -1.0
         -0.9.round.should eq -1.0
-        -0.5.round.should eq -1.0
+        -0.5.round.should eq 0.0
         -0.1.round.should eq 0.0
         0.0.round.should eq 0.0
         0.1.round.should eq 0.0
-        0.5.round.should eq 1.0
+        0.5.round.should eq 0.0
         0.9.round.should eq 1.0
         1.0.round.should eq 1.0
         1.5.round.should eq 2.0
-        2.5.round.should eq 3.0
+        2.5.round.should eq 2.0
       end
     end
 

--- a/src/number.cr
+++ b/src/number.cr
@@ -395,13 +395,13 @@ struct Number
   # (or before if negative), in base *base*.
   #
   # The rounding *mode* controls the direction of the rounding. The default is
-  # `RoundingMode::TIES_AWAY` which rounds to the nearest integer, with ties
-  # (fractional value of `0.5`) being rounded away from zero.
+  # `RoundingMode::TIES_EVEN` which rounds to the nearest integer, with ties
+  # (fractional value of `0.5`) being rounded to the even neighbor (Banker's rounding).
   #
   # ```
   # -1763.116.round(2) # => -1763.12
   # ```
-  def round(digits : Number, base = 10, *, mode : RoundingMode = :ties_away)
+  def round(digits : Number, base = 10, *, mode : RoundingMode = :ties_even)
     if digits < 0
       multiplier = base.to_f ** digits.abs
       shifted = self / multiplier
@@ -444,10 +444,10 @@ struct Number
 
   # Rounds `self` to an integer value using rounding *mode*.
   #
-  # The rounding mode controls the direction of the rounding. The default is
-  # `RoundingMode::TIES_AWAY` which rounds to the nearest integer, with ties
-  # (fractional value of `0.5`) being rounded away from zero.
-  def round(mode : RoundingMode = :ties_away) : self
+  # The rounding *mode* controls the direction of the rounding. The default is
+  # `RoundingMode::TIES_EVEN` which rounds to the nearest integer, with ties
+  # (fractional value of `0.5`) being rounded to the even neighbor (Banker's rounding).
+  def round(mode : RoundingMode = :ties_even) : self
     case mode
     in .to_zero?
       trunc


### PR DESCRIPTION
The default rounding mode for `Number#round` is changed to `TIES_EVEN` (Banker's rounding).

Resolves #10414

Follow-up to #10413