### PR TITLE
Allow unions of same-type containers for certain container methods

### DIFF
--- a/spec/std/array_spec.cr
+++ b/spec/std/array_spec.cr
@@ -67,6 +67,18 @@ describe "Array" do
       a2 = (33..96).to_a
       (a1 & a2).should eq((33..64).to_a)
     end
+
+    it "disjoint types" do
+      a = [1] & ['a']
+      a.should eq([] of Int32 | Char)
+      typeof(a).should eq(Array(Int32))
+    end
+
+    it "union of arrays" do
+      a = [1, 'a'] & ([1, 1.0] || ['a', ""])
+      a.should eq([1])
+      typeof(a).should eq(Array(Int32 | Char))
+    end
   end
 
   describe "|" do
@@ -82,19 +94,45 @@ describe "Array" do
       b = [4, 5, 6] * 10
       (a | b).should eq([1, 2, 3, 4, 5, 6])
     end
+
+    it "disjoint types" do
+      a = [1] | ['a']
+      a.should eq([1, 'a'])
+      typeof(a).should eq(Array(Int32 | Char))
+    end
+
+    it "union of arrays" do
+      a = [1, 'a'] | ([1, true] || [1, ""])
+      a.should eq([1, 'a', true])
+      typeof(a).should eq(Array(Int32 | Char | Bool | String))
+    end
   end
 
-  it "does +" do
-    a = [1, 2, 3]
-    b = [4, 5]
-    c = a + b
-    c.size.should eq(5)
-    0.upto(4) { |i| c[i].should eq(i + 1) }
-  end
+  describe "+" do
+    it "same element type" do
+      a = [1, 2, 3]
+      b = [4, 5]
+      c = a + b
+      c.size.should eq(5)
+      0.upto(4) { |i| c[i].should eq(i + 1) }
+    end
 
-  it "does + with empty tuple converted to array (#909)" do
-    ([1, 2] + Tuple.new.to_a).should eq([1, 2])
-    (Tuple.new.to_a + [1, 2]).should eq([1, 2])
+    it "different types" do
+      a = [1, 2, 3] + ['a', 'b']
+      a.should eq([1, 2, 3, 'a', 'b'])
+      typeof(a).should eq(Array(Int32 | Char))
+    end
+
+    it "NoReturn (#909)" do
+      ([1, 2] + Tuple.new.to_a).should eq([1, 2])
+      (Tuple.new.to_a + [1, 2]).should eq([1, 2])
+    end
+
+    it "union of arrays" do
+      a = [1, 'a'] + ([1, true] || [1, ""])
+      a.should eq([1, 'a', 1, true])
+      typeof(a).should eq(Array(Int32 | Char | Bool | String))
+    end
   end
 
   describe "-" do
@@ -108,6 +146,18 @@ describe "Array" do
 
     it "does with even larger arrays" do
       ((1..64).to_a - (1..32).to_a).should eq((33..64).to_a)
+    end
+
+    it "different types" do
+      a = [1, 'a'] - ['a', true]
+      a.should eq([1])
+      typeof(a).should eq(Array(Int32 | Char))
+    end
+
+    it "union of arrays" do
+      a = [1, 'a'] - ([1, true] || [1, ""])
+      a.should eq(['a'])
+      typeof(a).should eq(Array(Int32 | Char))
     end
   end
 
@@ -977,14 +1027,22 @@ describe "Array" do
     end
   end
 
-  it "does product with block" do
-    r = [] of Int32
-    [1, 2, 3].product([5, 6]) { |a, b| r << a; r << b }
-    r.should eq([1, 5, 1, 6, 2, 5, 2, 6, 3, 5, 3, 6])
-  end
+  describe "product" do
+    it "with block" do
+      r = [] of Int32
+      [1, 2, 3].product([5, 6]) { |a, b| r << a; r << b }
+      r.should eq([1, 5, 1, 6, 2, 5, 2, 6, 3, 5, 3, 6])
+    end
 
-  it "does product without block" do
-    [1, 2, 3].product(['a', 'b']).should eq([{1, 'a'}, {1, 'b'}, {2, 'a'}, {2, 'b'}, {3, 'a'}, {3, 'b'}])
+    it "without block" do
+      [1, 2, 3].product(['a', 'b']).should eq([{1, 'a'}, {1, 'b'}, {2, 'a'}, {2, 'b'}, {3, 'a'}, {3, 'b'}])
+    end
+
+    it "union of arrays" do
+      a = [1, 2].product(['a', 'b'] || ["c", "d"])
+      a.should eq([{1, 'a'}, {1, 'b'}, {2, 'a'}, {2, 'b'}])
+      typeof(a).should eq(Array({Int32, Char | String}))
+    end
   end
 
   describe "push" do

--- a/spec/std/deque_spec.cr
+++ b/spec/std/deque_spec.cr
@@ -170,6 +170,12 @@ describe "Deque" do
       a += Deque{"hello"}
       a.should eq(Deque{1, 2, 3, "hello"})
     end
+
+    it "does + with union of deques" do
+      a = Deque{1} + (Deque{'a'} || Deque{""})
+      a.should eq(Deque{1, 'a'})
+      typeof(a).should eq(Deque(Int32 | Char | String))
+    end
   end
 
   describe "[]" do

--- a/spec/std/hash_spec.cr
+++ b/spec/std/hash_spec.cr
@@ -536,6 +536,19 @@ describe "Hash" do
     h3.should eq({1 => "foobar", "fizz" => "buzz"})
   end
 
+  it "merges with union of hashes" do
+    h1 = {1 => 'a'}
+    h2 = {2.0 => "b"} || {true => :c}
+
+    h3 = h1.merge(h2)
+    h3.should eq({1 => 'a', 2.0 => "b"})
+    typeof(h3).should eq(Hash(Int32 | Float64 | Bool, Char | String | Symbol))
+
+    h4 = h1.merge(h2) { |k, v1, v2| true ? v2 : v1 }
+    h4.should eq({1 => 'a', 2.0 => "b"})
+    typeof(h4).should eq(Hash(Int32 | Float64 | Bool, Char | String | Symbol))
+  end
+
   it "merges!" do
     h1 = {1 => 2, 3 => 4}
     h2 = {1 => 5, 2 => 3}

--- a/spec/std/named_tuple_spec.cr
+++ b/spec/std/named_tuple_spec.cr
@@ -378,6 +378,12 @@ describe "NamedTuple" do
     a.merge(b).merge(four: "Four").merge(NamedTuple.new).should eq({one: 1, two: "Two", three: true, four: "Four", five: 5, "new one": "ok", "im \"string": "works"})
   end
 
+  it "merges with union of named tuples" do
+    a = {x: 1}.merge({y: true} || {z: ""})
+    a.should eq({x: 1, y: true})
+    typeof(a).should eq(NamedTuple(x: Int32, y: Bool) | NamedTuple(x: Int32, z: String))
+  end
+
   it "does types" do
     tuple = {a: 1, b: 'a', c: "hello"}
     tuple.class.types.to_s.should eq("{a: Int32, b: Char, c: String}")

--- a/spec/std/set_spec.cr
+++ b/spec/std/set_spec.cr
@@ -147,6 +147,12 @@ describe "Set" do
     set3.should eq(Set{1, 2, 3, 4, 5, "3"})
   end
 
+  it "does | with union of sets" do
+    set = Set{1, 'a'} | (Set{1, true} || Set{1, ""})
+    set.should eq(Set{1, 'a', true})
+    typeof(set).should eq(Set(Int32 | Char | Bool | String))
+  end
+
   it "aliases + to |" do
     set1 = Set{1, 1, 2, 3}
     set2 = Set{3, 4, 5}
@@ -237,6 +243,12 @@ describe "Set" do
     set2 = [2, 4, 5]
     set3 = set1 ^ set2
     set3.should eq(Set{1, 3, 5, 'b'})
+  end
+
+  it "does ^ with union of sets" do
+    set = Set{1, 'a'} ^ (Set{1, true} || Set{1, ""})
+    set.should eq(Set{'a', true})
+    typeof(set).should eq(Set(Int32 | Char | Bool | String))
   end
 
   it "does subtract" do

--- a/spec/std/tuple_spec.cr
+++ b/spec/std/tuple_spec.cr
@@ -213,6 +213,18 @@ describe "Tuple" do
     iter.next.should be_a(Iterator::Stop)
   end
 
+  it "does +" do
+    tuple = {1, 'a'} + {true, 2}
+    tuple.should eq({1, 'a', true, 2})
+    typeof(tuple).should eq(Tuple(Int32, Char, Bool, Int32))
+  end
+
+  it "does + with union of tuples" do
+    tuple = {1} + ({'a'} || {"", ""})
+    tuple.should eq({1, 'a'})
+    typeof(tuple).should eq(Tuple(Int32, Char) | Tuple(Int32, String, String))
+  end
+
   it "does map" do
     tuple = {1, 2.5, "a"}
     tuple2 = tuple.map &.to_s

--- a/src/array.cr
+++ b/src/array.cr
@@ -245,7 +245,7 @@ class Array(T)
   # ```
   #
   # See also: `#uniq`.
-  def &(other : Array(U)) forall U
+  def &(other : Array)
     return Array(T).new if self.empty? || other.empty?
 
     # Heuristic: for small arrays we do a linear scan, which is usually
@@ -283,11 +283,11 @@ class Array(T)
   # ```
   #
   # See also: `#uniq`.
-  def |(other : Array(U)) forall U
+  def |(other : Array)
     # Heuristic: if the combined size is small we just do a linear scan
     # instead of using a Hash for lookup.
     if size + other.size <= SMALL_ARRAY_SIZE
-      ary = Array(T | U).new
+      ary = Array(T | typeof(other.first)).new
       each do |elem|
         ary << elem unless ary.includes?(elem)
       end
@@ -297,8 +297,8 @@ class Array(T)
       return ary
     end
 
-    Array(T | U).build(size + other.size) do |buffer|
-      hash = Hash(T, Bool).new
+    Array(T | typeof(other.first)).build(size + other.size) do |buffer|
+      hash = Hash(T | typeof(other.first), Bool).new
       i = 0
       each do |obj|
         unless hash.has_key?(obj)
@@ -325,9 +325,9 @@ class Array(T)
   # [1, 2] + ["a"]  # => [1,2,"a"] of (Int32 | String)
   # [1, 2] + [2, 3] # => [1,2,2,3]
   # ```
-  def +(other : Array(U)) forall U
+  def +(other : Array)
     new_size = size + other.size
-    Array(T | U).build(new_size) do |buffer|
+    Array(T | typeof(other.first)).build(new_size) do |buffer|
       buffer.copy_from(@buffer, size)
       (buffer + size).copy_from(other.to_unsafe, other.size)
       new_size
@@ -347,7 +347,7 @@ class Array(T)
   # ```
   # [1, 2, 3] - [2, 1] # => [3]
   # ```
-  def -(other : Array(U)) forall U
+  def -(other : Array)
     # Heuristic: if any of the arrays is small we just do a linear scan
     # instead of using a Hash for lookup.
     if size <= SMALL_ARRAY_SIZE || other.size <= SMALL_ARRAY_SIZE
@@ -1408,8 +1408,8 @@ class Array(T)
     pop { nil }
   end
 
-  def product(ary : Array(U)) forall U
-    result = Array({T, U}).new(size * ary.size)
+  def product(ary : Array)
+    result = Array({T, typeof(ary.first)}).new(size * ary.size)
     product(ary) do |x, y|
       result << {x, y}
     end

--- a/src/deque.cr
+++ b/src/deque.cr
@@ -115,8 +115,8 @@ class Deque(T)
   # Concatenation. Returns a new `Deque` built by concatenating
   # two deques together to create a third. The type of the new deque
   # is the union of the types of both the other deques.
-  def +(other : Deque(U)) forall U
-    Deque(T | U).new.concat(self).concat(other)
+  def +(other : Deque)
+    Deque(T | typeof(other.first)).new.concat(self).concat(other)
   end
 
   # :nodoc:

--- a/src/enumerable.cr
+++ b/src/enumerable.cr
@@ -1911,4 +1911,10 @@ module Enumerable(T)
       {% end %}
     end
   end
+
+  # :nodoc:
+  def first_internal
+    # overridden in Tuple to disable literal index lookup
+    first
+  end
 end

--- a/src/hash.cr
+++ b/src/hash.cr
@@ -1359,15 +1359,15 @@ class Hash(K, V)
   # hash
   # # => {"foo" => "bar"}
   # ```
-  def merge(other : Hash(L, W)) forall L, W
-    hash = Hash(K | L, V | W).new
+  def merge(other : Hash)
+    hash = Hash(K | typeof(other.first_key), V | typeof(other.first_value)).new
     hash.merge! self
     hash.merge! other
     hash
   end
 
-  def merge(other : Hash(L, W), &block : L, V, W -> V | W) forall L, W
-    hash = Hash(K | L, V | W).new
+  def merge(other : Hash, &block)
+    hash = Hash(K | typeof(other.first_key), V | typeof(other.first_value)).new
     hash.merge! self
     hash.merge!(other) { |k, v1, v2| yield k, v1, v2 }
     hash

--- a/src/named_tuple.cr
+++ b/src/named_tuple.cr
@@ -228,16 +228,26 @@ struct NamedTuple
   # a.merge(b) # => {foo: "Hello", bar: "New", baz: "Bye"}
   # ```
   def merge(other : NamedTuple)
-    merge(**other)
+    other.prepend_impl(self)
   end
 
   # :ditto:
   def merge(**other : **U) forall U
+    other.prepend_impl(self)
+  end
+
+  protected def prepend_impl(other : U) forall U
     {% begin %}
-    {
-      {% for k in T %} {% unless U.keys.includes?(k) %} {{k.stringify}}: self[{{k.symbolize}}],{% end %} {% end %}
-      {% for k in U %} {{k.stringify}}: other[{{k.symbolize}}], {% end %}
-    }
+      NamedTuple.new(
+        {% for k in U %}
+          {% unless T.keys.includes?(k) %}
+            {{ k.stringify }}: other[{{ k.symbolize }}],
+          {% end %}
+        {% end %}
+        {% for k in T %}
+          {{ k.stringify }}: self[{{ k.symbolize }}],
+        {% end %}
+      )
     {% end %}
   end
 

--- a/src/set.cr
+++ b/src/set.cr
@@ -224,8 +224,8 @@ struct Set(T)
   # ```
   #
   # See also: `#concat` to add elements from a set to `self`.
-  def |(other : Set(U)) forall U
-    set = Set(T | U).new(Math.max(size, other.size))
+  def |(other : Set)
+    set = Set(T | typeof(other.first)).new(Math.max(size, other.size))
     each { |value| set.add value }
     other.each { |value| set.add value }
     set
@@ -236,7 +236,7 @@ struct Set(T)
   # ```
   # Set{1, 1, 2, 3} + Set{3, 4, 5} # => Set{1, 2, 3, 4, 5}
   # ```
-  def +(other : Set(U)) forall U
+  def +(other : Set)
     self | other
   end
 
@@ -280,8 +280,8 @@ struct Set(T)
   # Set{1, 2, 3, 4, 5} ^ Set{2, 4, 6}            # => Set{1, 3, 5, 6}
   # Set{'a', 'b', 'b', 'z'} ^ Set{'a', 'b', 'c'} # => Set{'z', 'c'}
   # ```
-  def ^(other : Set(U)) forall U
-    set = Set(T | U).new
+  def ^(other : Set)
+    set = Set(T | typeof(other.first)).new
     each do |value|
       set.add value unless other.includes?(value)
     end
@@ -298,8 +298,8 @@ struct Set(T)
   # Set{1, 2, 3, 4, 5} ^ [2, 4, 6]            # => Set{1, 3, 5, 6}
   # Set{'a', 'b', 'b', 'z'} ^ ['a', 'b', 'c'] # => Set{'z', 'c'}
   # ```
-  def ^(other : Enumerable(U)) forall U
-    set = Set(T | U).new(self)
+  def ^(other : Enumerable)
+    set = Set(T | typeof(other.first_internal)).new(self)
     other.each do |value|
       if includes?(value)
         set.delete value

--- a/src/tuple.cr
+++ b/src/tuple.cr
@@ -389,17 +389,17 @@ struct Tuple
   # typeof(t3) # => Tuple(Int32, Int32, String, String)
   # ```
   def +(other : Tuple)
-    plus_implementation(other)
+    other.prepend_impl(self)
   end
 
-  private def plus_implementation(other : U) forall U
+  protected def prepend_impl(other : U) forall U
     {% begin %}
       Tuple.new(
-        {% for i in 0...@type.size %}
-          self[{{i}}],
-        {% end %}
         {% for i in 0...U.size %}
-          other[{{i}}],
+          other[{{ i }}],
+        {% end %}
+        {% for i in 0...@type.size %}
+          self[{{ i }}],
         {% end %}
       )
     {% end %}
@@ -586,5 +586,12 @@ struct Tuple
     {% else %}
       self[{{T.size - 1}}]
     {% end %}
+  end
+
+  # :nodoc:
+  def first_internal
+    # overrides Enumerable's definition to disable literal index lookup
+    i = 0
+    self[i]
   end
 end


### PR DESCRIPTION
The following fails to compile, even though it should have a well-defined result:

```crystal
def foo
  true ? [1] : ['a']
end

foo + foo # Error: no overload matches 'Array(Float64)#+' with type (Array(Float64) | Array(Int32))
```

This happens because `Array(T)#+(other : Array(U)) forall U` ensures only that `self` is never a union of arrays, but `other` in general could be one; thus, following the discussion from #8973, it is correct to issue a compiler error here (although `U` shouldn't even be substitutable in the first place). The solution is to remove the unnecessary free var in the `other`'s restriction, which works for most methods affected by this PR. They are:

* `Array#&`
* `Array#|`
* `Array#+`
* `Array#-`
* `Array#product` (#10013 does not have the same free var anymore)
* `Deque#+`
* `Hash#merge` (both block and non-block overloads)
* `Set#|`
* `Set#+`
* `Set#^` (relies on `Enumerable#first_internal` copied from #10445)

In the example above, this makes `typeof(foo + foo)` always equal to `Array(Int32 | Char)`, instead of `Array(Int32 | Char) | Array(Int32) | Array(Char)`. However this trick doesn't work with `Tuple#+` and `NamedTuple#merge`, because even though these types have built-in covariance, the types with different arities / names still cannot be merged. Those two methods are fixed instead by dispatching over the other argument's type. In other words:

```crystal
def foo
  true ? {1} : {'a'}
end

typeof(foo + foo) # => Tuple(Char | Int32, Char | Int32)

def bar
  true ? {1} : {'a', 'a'}
end

typeof(bar + bar) # => (Tuple(Char | Int32, Char, Char | Int32)
                  #   | Tuple(Char, Char, Char, Char)
                  #   | Tuple(Int32, Int32))
```

Note that #10429 disallows unions inside splats, so `a + b` supports more types than `{*a, *b}` (it already does since `a` can already be a union of `Tuple`s).