### PR TITLE
Fix error message when default parameter value doesn't match non-type restriction

### DIFF
--- a/spec/compiler/semantic/def_spec.cr
+++ b/spec/compiler/semantic/def_spec.cr
@@ -181,6 +181,16 @@ describe "Semantic: def" do
       "can't restrict Char to Int64"
   end
 
+  it "errors when default value is incompatible with non-type restriction" do
+    assert_error "
+      def foo(x : Tuple(_) = 'a')
+      end
+
+      foo
+      ",
+      "can't restrict Char to Tuple(_)"
+  end
+
   it "types call with global scope" do
     assert_type("
       def bar

--- a/src/compiler/crystal/semantic/main_visitor.cr
+++ b/src/compiler/crystal/semantic/main_visitor.cr
@@ -769,7 +769,7 @@ module Crystal
           # OK
         else
           # Check autocast too
-          restriction_type = (path_lookup || scope).lookup_type(restriction, free_vars: free_vars)
+          restriction_type = (path_lookup || scope).lookup_type?(restriction, free_vars: free_vars)
           if casted_value = check_automatic_cast(value, restriction_type, node)
             value = casted_value
           else


### PR DESCRIPTION
When a call uses a def's default parameter value, but that value doesn't satisfy the parameter's restriction, the compiler tries to look up the restriction's type to determine whether auto-casting is possible. This assumes the restriction always denotes a type, which produces the following confusing error message because type lookup fails:

```crystal
def foo(x : Array(_) = 1); end

foo([1]) # okay
foo      # Error: can't use underscore as generic type argument
```

This PR turns that error message into the more accurate `can't restrict Int32 to Array(_)`.