### PR TITLE
Added from_json_object_key? to UUID

### DIFF
--- a/spec/std/uuid/json_spec.cr
+++ b/spec/std/uuid/json_spec.cr
@@ -1,0 +1,14 @@
+require "spec"
+require "uuid/json"
+
+describe "UUID", focus: true do
+  describe "serializes" do
+    it "#to_json" do
+      UUID.new("50a11da6-377b-4bdf-b9f0-076f9db61c93").to_json.should eq "\"50a11da6-377b-4bdf-b9f0-076f9db61c93\""
+    end
+
+    it "from_json_object_key?" do
+      UUID.from_json_object_key?("50a11da6-377b-4bdf-b9f0-076f9db61c93").should eq UUID.new("50a11da6-377b-4bdf-b9f0-076f9db61c93")
+    end
+  end
+end

--- a/spec/std/uuid/json_spec.cr
+++ b/spec/std/uuid/json_spec.cr
@@ -1,7 +1,7 @@
 require "spec"
 require "uuid/json"
 
-describe "UUID", focus: true do
+describe "UUID" do
   describe "serializes" do
     it "#to_json" do
       UUID.new("50a11da6-377b-4bdf-b9f0-076f9db61c93").to_json.should eq "\"50a11da6-377b-4bdf-b9f0-076f9db61c93\""

--- a/src/uuid/json.cr
+++ b/src/uuid/json.cr
@@ -35,7 +35,7 @@ struct UUID
   def to_json(json : JSON::Builder)
     json.string(to_s)
   end
-  
+
   # Deserializes the given JSON in *string* into a UUID instance
   #
   # NOTE: `require "uuid/json"` is required to opt-in to this feature.

--- a/src/uuid/json.cr
+++ b/src/uuid/json.cr
@@ -36,6 +36,11 @@ struct UUID
     json.string(to_s)
   end
 
+  # :nodoc:
+  def to_json_object_key
+    to_s
+  end
+
   # Deserializes the given JSON *key* into a `UUID`.
   #
   # NOTE: `require "uuid/json"` is required to opt-in to this feature.

--- a/src/uuid/json.cr
+++ b/src/uuid/json.cr
@@ -35,4 +35,12 @@ struct UUID
   def to_json(json : JSON::Builder)
     json.string(to_s)
   end
+  
+  # Deserializes the given JSON in *string* into a UUID instance
+  #
+  # NOTE: `require "uuid/json"` is required to opt-in to this feature.
+  #
+  def self.from_json_object_key?(key : String)
+    UUID.new(key)
+  end
 end

--- a/src/uuid/json.cr
+++ b/src/uuid/json.cr
@@ -44,7 +44,6 @@ struct UUID
   # Deserializes the given JSON *key* into a `UUID`.
   #
   # NOTE: `require "uuid/json"` is required to opt-in to this feature.
-  #
   def self.from_json_object_key?(key : String)
     UUID.new(key)
   end

--- a/src/uuid/json.cr
+++ b/src/uuid/json.cr
@@ -36,7 +36,7 @@ struct UUID
     json.string(to_s)
   end
 
-  # Deserializes the given JSON in *string* into a UUID instance
+  # Deserializes the given JSON *key* into a `UUID`.
   #
   # NOTE: `require "uuid/json"` is required to opt-in to this feature.
   #


### PR DESCRIPTION
Added the the required `from_json_object_key?` to UUID so that it can be used as a hash key.