### PR TITLE
Add IO::Sized#remaining=(value) to reuse an existing instance

### DIFF
--- a/spec/std/io/sized_spec.cr
+++ b/spec/std/io/sized_spec.cr
@@ -60,6 +60,8 @@ describe "IO::Sized" do
       sized.read(slice).should eq(5)
       String.new(slice).should eq("12345\0\0\0\0\0")
 
+      sized.read_remaining = 5
+
       sized.read(slice).should eq(5)
       String.new(slice).should eq("67890\0\0\0\0\0")
     end

--- a/spec/std/io/sized_spec.cr
+++ b/spec/std/io/sized_spec.cr
@@ -52,6 +52,18 @@ describe "IO::Sized" do
       String.new(slice).should eq("12345\0\0\0\0\0")
     end
 
+    it "allows extending the size" do
+      io = IO::Memory.new("1234567890")
+      sized = IO::Sized.new(io, read_size: 5)
+      slice = Bytes.new(10)
+
+      sized.read(slice).should eq(5)
+      String.new(slice).should eq("12345\0\0\0\0\0")
+
+      sized.read(slice).should eq(5)
+      String.new(slice).should eq("67890\0\0\0\0\0")
+    end
+
     it "raises on negative numbers" do
       io = IO::Memory.new
       expect_raises(ArgumentError, "Negative read_size") do

--- a/src/io/sized.cr
+++ b/src/io/sized.cr
@@ -13,7 +13,7 @@ class IO::Sized < IO
   property? sync_close : Bool
 
   # The number of remaining bytes to be read.
-  getter read_remaining : UInt64
+  property read_remaining : UInt64
   getter? closed : Bool
 
   # Creates a new `IO::Sized` which wraps *io*, and can read a maximum of


### PR DESCRIPTION
`IO::Sized` is an excellent abstraction for segmenting an `IO` and gives you the tools to ensure that that segment is completely consumed when you leave a block regardless of whether it was consumed inside the block itself. But if you need to segment that `IO` into a lot of small-ish chunks you end up re-allocating hundreds, thousands, or even millions of `IO::Sized` instances, which can involve a _lot_ of `malloc`, GC, and `free` calls.

You can see the impact in [this PR to `will/crystal-pg`](https://github.com/will/crystal-pg/pull/228) where we reduced CPU usage by 73% for a Postgres query that returns 500k values (5 columns x 100k rows). In that PR [@straight-shoota recommended adding that functionality directly to `IO::Sized`](https://github.com/will/crystal-pg/pull/228#issuecomment-802380919).