### PR TITLE
Fix logic for subclass restricted against uninstantiated nested generic superclass

### DIFF
--- a/spec/compiler/codegen/is_a_spec.cr
+++ b/spec/compiler/codegen/is_a_spec.cr
@@ -687,6 +687,36 @@ describe "Codegen: is_a?" do
       )).to_i.should eq(2)
   end
 
+  it "does is_a?(generic type) for nested generic inheritance (1) (#9660)" do
+    run(%(
+      class Foo(T)
+      end
+
+      class Bar(T) < Foo(T)
+      end
+
+      class Baz < Bar(Int32)
+      end
+
+      Baz.new.is_a?(Foo)
+      )).to_b.should be_true
+  end
+
+  it "does is_a?(generic type) for nested generic inheritance (2) (#9660)" do
+    run(%(
+      class Foo(T)
+      end
+
+      class Bar(T) < Foo(T)
+      end
+
+      class Baz(T) < Bar(T)
+      end
+
+      Baz(Int32).new.is_a?(Foo)
+      )).to_b.should be_true
+  end
+
   it "doesn't consider generic type to be a generic type of a recursive alias (#3524)" do
     run(%(
       class Gen(T)

--- a/spec/compiler/codegen/is_a_spec.cr
+++ b/spec/compiler/codegen/is_a_spec.cr
@@ -689,21 +689,27 @@ describe "Codegen: is_a?" do
 
   it "does is_a?(generic type) for nested generic inheritance (1) (#9660)" do
     run(%(
+      class Cxx
+      end
+
       class Foo(T)
       end
 
       class Bar(T) < Foo(T)
       end
 
-      class Baz < Bar(Int32)
+      class Baz < Bar(Cxx)
       end
 
       Baz.new.is_a?(Foo)
-      )).to_b.should be_true
+      ), inject_primitives: false).to_b.should be_true
   end
 
-  it "does is_a?(generic type) for nested generic inheritance (2) (#9660)" do
+  it "does is_a?(generic type) for nested generic inheritance (2)" do
     run(%(
+      class Cxx
+      end
+
       class Foo(T)
       end
 
@@ -713,8 +719,44 @@ describe "Codegen: is_a?" do
       class Baz(T) < Bar(T)
       end
 
-      Baz(Int32).new.is_a?(Foo)
-      )).to_b.should be_true
+      Baz(Cxx).new.is_a?(Foo)
+      ), inject_primitives: false).to_b.should be_true
+  end
+
+  it "does is_a?(generic type) for nested generic inheritance, through upcast (1)" do
+    run(%(
+      class Cxx
+      end
+
+      class Foo(T)
+      end
+
+      class Bar(T) < Foo(T)
+      end
+
+      class Baz < Bar(Cxx)
+      end
+
+      Baz.new.as(Foo(Cxx)).is_a?(Bar)
+      ), inject_primitives: false).to_b.should be_true
+  end
+
+  it "does is_a?(generic type) for nested generic inheritance, through upcast (2)" do
+    run(%(
+      class Cxx
+      end
+
+      class Foo(T)
+      end
+
+      class Bar(T) < Foo(T)
+      end
+
+      class Baz(T) < Bar(T)
+      end
+
+      Baz(Cxx).new.as(Foo(Cxx)).is_a?(Bar)
+      ), inject_primitives: false).to_b.should be_true
   end
 
   it "doesn't consider generic type to be a generic type of a recursive alias (#3524)" do

--- a/spec/compiler/semantic/restrictions_spec.cr
+++ b/spec/compiler/semantic/restrictions_spec.cr
@@ -84,6 +84,30 @@ describe "Restrictions" do
       result = mod.generic_class("Cxx", mod.int32).restrict(mod.t("Axx"), MatchContext.new(mod, mod))
       result.should eq(mod.generic_class("Cxx", mod.int32))
     end
+
+    it "restricts virtual generic class against uninstantiated generic subclass (1)" do
+      mod = Program.new
+      mod.semantic parse("
+        class Axx(T); end
+        class Bxx(T) < Axx(T); end
+        class Cxx < Bxx(Int32); end
+      ")
+
+      result = mod.generic_class("Axx", mod.int32).virtual_type.restrict(mod.generic_class("Bxx", mod.int32), MatchContext.new(mod, mod))
+      result.should eq(mod.generic_class("Bxx", mod.int32).virtual_type)
+    end
+
+    it "restricts virtual generic class against uninstantiated generic subclass (2)" do
+      mod = Program.new
+      mod.semantic parse("
+        class Axx(T); end
+        class Bxx(T) < Axx(T); end
+        class Cxx(T) < Bxx(T); end
+      ")
+
+      result = mod.generic_class("Axx", mod.int32).virtual_type.restrict(mod.generic_class("Bxx", mod.int32), MatchContext.new(mod, mod))
+      result.should eq(mod.generic_class("Bxx", mod.int32).virtual_type)
+    end
   end
 
   describe "restriction_of?" do

--- a/spec/compiler/semantic/restrictions_spec.cr
+++ b/spec/compiler/semantic/restrictions_spec.cr
@@ -60,6 +60,30 @@ describe "Restrictions" do
 
       mod.t("Axx+").restrict(mod.t("Mxx"), MatchContext.new(mod, mod)).should eq(mod.union_of(mod.t("Bxx+"), mod.t("Cxx+")))
     end
+
+    it "restricts class against uninstantiated generic base class through multiple inheritance (1) (#9660)" do
+      mod = Program.new
+      mod.semantic parse("
+        class Axx(T); end
+        class Bxx(T) < Axx(T); end
+        class Cxx < Bxx(Int32); end
+      ")
+
+      result = mod.t("Cxx").restrict(mod.t("Axx"), MatchContext.new(mod, mod))
+      result.should eq(mod.t("Cxx"))
+    end
+
+    it "restricts class against uninstantiated generic base class through multiple inheritance (2) (#9660)" do
+      mod = Program.new
+      mod.semantic parse("
+        class Axx(T); end
+        class Bxx(T) < Axx(T); end
+        class Cxx(T) < Bxx(T); end
+      ")
+
+      result = mod.generic_class("Cxx", mod.int32).restrict(mod.t("Axx"), MatchContext.new(mod, mod))
+      result.should eq(mod.generic_class("Cxx", mod.int32))
+    end
   end
 
   describe "restriction_of?" do

--- a/src/compiler/crystal/semantic/restrictions.cr
+++ b/src/compiler/crystal/semantic/restrictions.cr
@@ -462,10 +462,12 @@ module Crystal
 
     def restrict(other : GenericClassType, context)
       parents.try &.each do |parent|
-        next if parent.is_a?(NonGenericModuleType)
-
-        restricted = parent.restrict other, context
-        return self if restricted
+        if parent.module?
+          return self if parent.restriction_of?(other, context.instantiated_type, context)
+        else
+          restricted = parent.restrict other, context
+          return self if restricted
+        end
       end
 
       nil
@@ -742,10 +744,12 @@ module Crystal
       return self if generic_type == other
 
       parents.try &.each do |parent|
-        next if parent.is_a?(NonGenericModuleType)
-
-        restricted = parent.restrict other, context
-        return self if restricted
+        if parent.module?
+          return self if parent.restriction_of?(other, context.instantiated_type, context)
+        else
+          restricted = parent.restrict other, context
+          return self if restricted
+        end
       end
 
       nil

--- a/src/compiler/crystal/semantic/restrictions.cr
+++ b/src/compiler/crystal/semantic/restrictions.cr
@@ -1036,14 +1036,11 @@ module Crystal
       elsif base_type.is_a?(GenericInstanceType) && other.is_a?(GenericType)
         # Consider the case of Foo(Int32) vs. Bar(T), with Bar(T) < Foo(T):
         # we want to return Bar(Int32), so we search in Bar's generic instantiations
-        other.each_instantiated_type do |instance|
+        types = other.instantiated_types.compact_map do |instance|
           next if instance.unbound? || instance.abstract?
-
-          if instance.implements?(base_type)
-            return instance
-          end
+          instance.virtual_type if instance.implements?(base_type)
         end
-        nil
+        program.type_merge_union_of types
       else
         nil
       end

--- a/src/compiler/crystal/semantic/restrictions.cr
+++ b/src/compiler/crystal/semantic/restrictions.cr
@@ -460,6 +460,17 @@ module Crystal
       implements?(other.base_type) ? self : nil
     end
 
+    def restrict(other : GenericClassType, context)
+      parents.try &.each do |parent|
+        next if parent.is_a?(NonGenericModuleType)
+
+        restricted = parent.restrict other, context
+        return self if restricted
+      end
+
+      nil
+    end
+
     def restrict(other : Union, context)
       # Match all concrete types first
       free_var_count = other.types.count do |other_type|
@@ -728,7 +739,16 @@ module Crystal
     end
 
     def restrict(other : GenericType, context)
-      generic_type == other ? self : super
+      return self if generic_type == other
+
+      parents.try &.each do |parent|
+        next if parent.is_a?(NonGenericModuleType)
+
+        restricted = parent.restrict other, context
+        return self if restricted
+      end
+
+      nil
     end
 
     def restrict(other : Generic, context)


### PR DESCRIPTION
Fixes #9660.

Also affects certain flow typing constructs:

```crystal
class A(T); end
class B(T) < A(T); end
class C(T) < B(T); end
class C2 < B(Int32); end

# NoReturn before this PR
typeof((x = C(Int32).new).is_a?(A) ? x : raise "") # => C(Int32)

# NoReturn before this PR
typeof((y = C2.new).is_a?(A) ? y : raise "") # => C2

# [#<C(Int32):...>] before this PR
[C(Int32).new].reject(A) # => []

# [#<C2:...>] before this PR
[C2.new].reject(A) # => []
```

The second commit relates to virtual generic types and fixes the following:

```crystal
# false even with the first commit alone
C(Int32).new.as(A(Int32)).is_a?(B) # => true
C2.new.as(A(Int32)).is_a?(B)       # => true

# B(Int32) (non-virtual) before this PR
typeof((z = C(Int32).new || A(Int32).new).is_a?(B) ? z : raise "") # => B(Int32)+

# [#<A(Int32):...>, #<C(Int32):...>, #<C2:...>] before this PR
[A(Int32).new, B(Int32).new, C(Int32).new, C2.new].reject(B) # => [#<A(Int32):...>]
```

The following cases, where a _superclass_ is restricted against a _subclass_, are unaffected and left to a future PR: (this part is related to #10519)

```crystal
# should be B(Int32)+
typeof((x = A(Int32).new).is_a?(B) ? x : raise "") # => NoReturn

# should be C2
typeof((x = A(Int32).new).is_a?(C2) ? x : raise "") # => NoReturn
```