### PR TITLE
Fix Process::INITIAL_PWD for non-existent path

### DIFF
--- a/spec/std/exception/call_stack_spec.cr
+++ b/spec/std/exception/call_stack_spec.cr
@@ -57,4 +57,20 @@ describe "Backtrace" do
     output.to_s.empty?.should be_true
     error.to_s.should contain("Invalid memory access")
   end
+
+  it "print exception with non-existing PWD" do
+    source_file = datapath("blank_test_file.txt")
+    compile_file(source_file) do |executable_file|
+      output, error = IO::Memory.new, IO::Memory.new
+      with_tempfile("non-existent") do |path|
+        Dir.mkdir path
+        Dir.cd(path) do
+          Dir.delete(path)
+          status = Process.run executable_file
+
+          status.success?.should be_true
+        end
+      end
+    end
+  end
 end

--- a/src/exception/call_stack.cr
+++ b/src/exception/call_stack.cr
@@ -22,7 +22,7 @@ struct Exception::CallStack
   # Compute current directory at the beginning so filenames
   # are always shown relative to the *starting* working directory.
   CURRENT_DIR = begin
-    dir = Process::INITIAL_PWD
+    dir = Process::INITIAL_PWD || ""
     dir += File::SEPARATOR unless dir.ends_with?(File::SEPARATOR)
     dir
   end

--- a/src/process/executable_path.cr
+++ b/src/process/executable_path.cr
@@ -9,7 +9,16 @@ class Process
   INITIAL_PATH = ENV["PATH"]?
 
   # :nodoc:
-  INITIAL_PWD = Dir.current
+  #
+  # Working directory at program start. Nil if working directory does not exist.
+  #
+  # Used for `Exception::CallStack::CURRENT_DIR`
+  # and `Process.executable_path_impl` on openbsd.
+  INITIAL_PWD = begin
+    Dir.current
+  rescue File::NotFoundError
+    nil
+  end
 
   # Returns an absolute path to the executable file of the currently running
   # program. This is in opposition to `PROGRAM_NAME` which may be a relative or
@@ -166,7 +175,9 @@ end
   # openbsd, ...
   class Process
     private def self.executable_path_impl
-      find_executable(PROGRAM_NAME, INITIAL_PATH, INITIAL_PWD)
+      if pwd = INITIAL_PWD
+        find_executable(PROGRAM_NAME, INITIAL_PATH, pwd)
+      end
     end
   end
 {% end %}


### PR DESCRIPTION
This patch changes runtime behaviour to gracefully handle if the initial working directory does not exist.

* `Exception::CallStack` just ignores it and shows full paths. The initial working directory is just used to shorten paths, no big deal if that's not possible.
* `executable_path_impl` on openbsd returns `nil` if the initial working directory does not exist. It's impossible to find the executable that way.

Resolves #7198