### PR TITLE
Eliminate extraneous types in certain non-commutative unions

### DIFF
--- a/spec/compiler/semantic/union_spec.cr
+++ b/spec/compiler/semantic/union_spec.cr
@@ -105,6 +105,16 @@ describe "Semantic: union" do
         end
         )) { [types["A"].virtual_type!.metaclass, generic_class("B", types["Cxx"]).metaclass, types["A"].virtual_type!.metaclass] }
     end
+
+    it "superclass v.s. uninstantiated generic subclass" do
+      assert_commutes(%(
+        class A
+        end
+
+        class B(T) < A
+        end
+        )) { [types["A"], types["B"], types["A"].virtual_type!] }
+    end
   end
 
   it "types union when obj is union" do

--- a/spec/compiler/semantic/union_spec.cr
+++ b/spec/compiler/semantic/union_spec.cr
@@ -1,6 +1,112 @@
 require "../../spec_helper"
 
+private def assert_commutes(str, *, file = __FILE__, line = __LINE__, &)
+  result = semantic(str, inject_primitives: false)
+  program = result.program
+  type1, type2, expected = with program yield program
+  union1 = program.type_merge([type1, type2])
+  union2 = program.type_merge([type2, type1])
+  union1.should eq(expected), file: file, line: line
+  union2.should eq(expected), file: file, line: line
+end
+
 describe "Semantic: union" do
+  context "commutativity" do
+    it "module v.s. including module" do
+      assert_commutes(%(
+        module A
+        end
+
+        module B
+          include A
+        end
+        )) { [types["A"], types["B"], types["A"]] }
+    end
+
+    it "module v.s. including generic module instance" do
+      assert_commutes(%(
+        class Cxx
+        end
+
+        module A
+        end
+
+        module B(T)
+          include A
+        end
+        )) { [types["A"], generic_module("B", types["Cxx"]), types["A"]] }
+    end
+
+    it "generic module instance v.s. including module" do
+      assert_commutes(%(
+        class Cxx
+        end
+
+        module A(T)
+        end
+
+        module B
+          include A(Cxx)
+        end
+        )) { [generic_module("A", types["Cxx"]), types["B"], generic_module("A", types["Cxx"])] }
+    end
+
+    it "generic module instance v.s. including generic module instance" do
+      assert_commutes(%(
+        class Cxx
+        end
+
+        module A(T)
+        end
+
+        module B(T)
+          include A(T)
+        end
+        )) { [generic_module("A", types["Cxx"]), generic_module("B", types["Cxx"]), generic_module("A", types["Cxx"])] }
+    end
+
+    it "module v.s. extending generic module instance metaclass" do
+      assert_commutes(%(
+        class Cxx
+        end
+
+        module A
+        end
+
+        module B(T)
+          extend A
+        end
+        )) { [types["A"], generic_module("B", types["Cxx"]).metaclass, types["A"]] }
+    end
+
+    it "generic module instance v.s. extending generic module instance metaclass" do
+      assert_commutes(%(
+        class Cxx
+        end
+
+        module A(T)
+        end
+
+        module B(T)
+          extend A(T)
+        end
+        )) { [generic_module("A", types["Cxx"]), generic_module("B", types["Cxx"]).metaclass, generic_module("A", types["Cxx"])] }
+    end
+
+    it "virtual metaclass v.s. generic subclass instance metaclass" do
+      assert_commutes(%(
+        class Cxx
+        end
+
+        class A
+        end
+
+        class B(T) < A
+        end
+        )) { [types["A"].virtual_type!.metaclass, generic_class("B", types["Cxx"]).metaclass, types["A"].virtual_type!.metaclass] }
+    end
+  end
+
   it "types union when obj is union" do
     assert_type("struct Char; def +(other); self; end; end; a = 1 || 'a'; a + 1") { union_of(int32, char) }
   end

--- a/src/compiler/crystal/semantic/type_merge.cr
+++ b/src/compiler/crystal/semantic/type_merge.cr
@@ -145,7 +145,7 @@ module Crystal
       all_types
     end
 
-    # Returns true if `type` can be used as a virtual root; that is, it must not
+    # Returns true if *type* can be used as a virtual root; that is, it must not
     # be one of Object, Reference, Value, Struct, Number, Int, Float, or their
     # corresponding metaclasses.
     def virtual_root?(type)
@@ -202,8 +202,14 @@ module Crystal
     # * LCA is associative up to equivalence.
     #
     # If such a type exists and this type can be used as a virtual root (see
-    # `#virtual_root?`), then T | U is precisely the virtual type of LCA(T, U).
-    # Otherwise, T | U is an irreducible union and this method returns `nil`.
+    # `Program#virtual_root?`), then T | U is precisely the virtual type of
+    # LCA(T, U). Otherwise, T | U is an irreducible union and this method should
+    # return `nil`.
+    #
+    # The above applies only if T and U are unequal; this is guaranteed by
+    # `Program#add_type`, so T | T produces a non-virtual type. However, this
+    # method should not break in case it recursively calls itself with two
+    # identical types.
     def self.least_common_ancestor(type1 : Type, type2 : Type)
       nil
     end


### PR DESCRIPTION
The unions between certain pairs of types are currently non-commutative, in the sense that if `Derived <= Base`, then `Union(Derived, Base)` may produce the irreducible union type `(Base | Derived)` whereas `Union(Base, Derived)` produces `Base`. An example is that between two modules:

```crystal
module Foo
end

module Bar
  include Foo
end

Foo | Bar # => Foo
Bar | Foo # => (Bar | Foo)
```

Some more examples are in the specs. This PR rewrites `Crystal::Type#common_ancestor` into a class method `.least_common_ancestor` that is commutative by construction and makes this property more obvious, eliminating these extraneous unions. (My plan is to refactor `#restrict(Type)` in a similar manner in the future.)

Type checks in the examples identified so far remain the same, since `Foo <= (Bar | Foo)` and `(Bar | Foo) <= Foo`. However, macro methods such as `TypeNode#union_types` may be affected by this PR.