### PR TITLE
Match named arguments by external parameter names when checking overload cover

### DIFF
--- a/spec/compiler/semantic/def_overload_spec.cr
+++ b/spec/compiler/semantic/def_overload_spec.cr
@@ -892,6 +892,17 @@ describe "Semantic: def overload" do
       "no overload matches"
   end
 
+  it "errors if no overload matches on union against named arg with external param name (#10516)" do
+    assert_error %(
+      def f(a b : Int32)
+      end
+
+      a = 1 || nil
+      f(a: a)
+      ),
+      "no overload matches"
+  end
+
   it "dispatches with named arg" do
     assert_type(%(
       def f(a : Int32, b : Int32)

--- a/src/compiler/crystal/semantic/cover.cr
+++ b/src/compiler/crystal/semantic/cover.cr
@@ -63,7 +63,7 @@ module Crystal
         end
 
         signature.named_args.try &.each_with_index do |named_arg, i|
-          arg = match.def.args.find(&.name.==(named_arg.name))
+          arg = match.def.args.find(&.external_name.==(named_arg.name))
           if arg && (arg.type? || arg.restriction)
             indices[args_size + i] = true
           end


### PR DESCRIPTION
Fixes #10516.