### PR TITLE
fix undefined constant error for http/params

### DIFF
--- a/src/http/params.cr
+++ b/src/http/params.cr
@@ -1,3 +1,5 @@
+require "uri/params"
+
 module HTTP
   alias Params = ::URI::Params
 end


### PR DESCRIPTION
`Error: undefined constant ::URI::Params`