### PR TITLE
Exclude variables' final types inside `while true` if re-assigned before first break

### DIFF
--- a/spec/compiler/semantic/while_spec.cr
+++ b/spec/compiler/semantic/while_spec.cr
@@ -170,6 +170,80 @@ describe "Semantic: while" do
       )) { nilable int32 }
   end
 
+  it "doesn't use type at end of endless while if variable is reassigned" do
+    assert_type(%(
+      while true
+        a = 1
+        if 1 == 1
+          break
+        end
+        a = 'x'
+      end
+      a
+      )) { int32 }
+  end
+
+  it "doesn't use type at end of endless while if variable is reassigned (2)" do
+    assert_type(%(
+      a = ""
+      while true
+        a = 1
+        if 1 == 1
+          break
+        end
+        a = 'x'
+      end
+      a
+      )) { int32 }
+  end
+
+  it "doesn't use type at end of endless while if variable is reassigned (3)" do
+    assert_type(%(
+      a = {1}
+      while true
+        a = a[0]
+        if 1 == 1
+          break
+        end
+        a = {'x'}
+      end
+      a
+      )) { union_of(int32, char) }
+  end
+
+  it "uses type at end of endless while if variable is reassigned, but not before first break" do
+    assert_type(%(
+      while true
+        if 1 == 1
+          break
+        end
+        a = 1
+        if 1 == 1
+          break
+        end
+        a = 'x'
+      end
+      a
+      )) { nilable union_of(int32, char) }
+  end
+
+  it "uses type at end of endless while if variable is reassigned, but not before first break (2)" do
+    assert_type(%(
+      a = ""
+      while true
+        if 1 == 1
+          break
+        end
+        a = 1
+        if 1 == 1
+          break
+        end
+        a = 'x'
+      end
+      a
+      )) { union_of(int32, char, string) }
+  end
+
   it "rebinds condition variable after while body (#6158)" do
     assert_type(%(
       class Foo

--- a/src/compiler/crystal/semantic/main_visitor.cr
+++ b/src/compiler/crystal/semantic/main_visitor.cr
@@ -2143,6 +2143,15 @@ module Crystal
             # the type at the end of the while body is inaccessible upon exit
             # because the assignment must have executed before the next chance
             # to break
+            #
+            # For example:
+            #
+            #    while true
+            #      x = exp1
+            #      break if true
+            #      x = exp2
+            #    end
+            #    # at this point x's type is never affected by exp2
             break_var = all_break_vars.try &.dig?(0, name)
             unless break_var && !break_var.same?(while_var)
               after_while_var.bind_to(while_var)


### PR DESCRIPTION
Consider the following:

```crystal
while true
  x = 1    # (1)
  if ...
    break
  end
  x = ""   # (2)
end
typeof(x)  # => (Int32 | String)
```

`typeof(x)` after the exit of the `while` expression should not be affected by the assignment on `(2)`, because `(1)` must have been executed before any break could happen. This PR makes it so that `typeof(x)` becomes `Int32`.

Note that if `(1)`'s RHS references `x` itself then the exit type would still depend on `(2)` as well as whatever type `x` has before the whole loop:

```crystal
x = {1}
while true
  x = x[0]  # (1)
  if ...
    break
  end
  x = {"a"} # (2)
end

# before this PR: (Int32 | String | Tuple(String))
typeof(x) # => (Int32 | String)
```

***

This issue was discovered while trying to determine whether `while exp; ...; end` is always semantically equivalent to the following, provided `exp` isn't already the `true` literal:

```crystal
while true
  unless exp
    break
  end
  ...
end
```

`while` loops would be a lot easier to reason about if all of them could be cast like this. This flow typing issue turned out to be a blocker whenever the `while` condition contains an assignment (including #10350).