### PR TITLE
Wyrand PRNG

### DIFF
--- a/spec/std/random/wyrand_spec.cr
+++ b/spec/std/random/wyrand_spec.cr
@@ -1,0 +1,33 @@
+require "spec"
+require "random/wyrand"
+
+describe Random::Wyrand do
+  # There does not appear to be a spec by the original implementor. The
+  # following are pulled from the Swift implementation by one of the co-authors.
+  # https://github.com/lemire/SwiftWyhash/blob/3183bb1f473d7da2e7b6f856bad56a8aab3a56fa/Tests/SwiftWyhashTests/SwiftWyhashTests.swift#L6-L9
+  it "generates outputs expected for a known seed" do
+    seed = 42_u64
+    outs = {12558987674375533620, 16846851108956068306, 14652274819296609082}
+    gen = Random::Wyrand.new seed
+    outs.each do |expected|
+      gen.next_u.should eq(expected)
+    end
+  end
+
+  it "can be initialized without an explicit seed" do
+    Random::Wyrand.new.should be_a Random::Wyrand
+  end
+
+  it "generates ranged values within the upper bound" do
+    gen = Random::Wyrand.new
+    {% for size in [8, 16, 32, 64] %}
+      {% type = "UInt#{size}".id %}
+      1_000.times do
+        max = gen.rand {{type}}::MIN.succ..{{type}}::MAX
+        1_000.times do
+          (gen.rand(max) < max).should be_true
+        end
+      end
+    {% end %}
+  end
+end

--- a/src/random/wyrand.cr
+++ b/src/random/wyrand.cr
@@ -6,7 +6,7 @@ require "random/secure"
 # Based on the original C implementation by 王一 (Wang Yi).
 # https://github.com/wangyi-fudan/wyhash
 #
-# Provides a 64 bit output based on mix and multply operation. This provides
+# Provides a 64 bit output based on mix and multiply operation. This provides
 # exceptionly fast performance on modern processors, but may yield slower
 # results on older architectures.
 struct Random::Wyrand
@@ -56,7 +56,7 @@ struct Random::Wyrand
   {% end %}
 end
 
-# TODO: BidEndian support. Crystal is currently pinned to LittleEndian so low
+# TODO: BigEndian support. Crystal is currently pinned to LittleEndian so low
 # priority. This is here as a guard rail for when this changes.
 {% if IO::ByteFormat::SystemEndian != IO::ByteFormat::LittleEndian %}
   {{ raise "Wyrand BigEndian support not implemented" }}

--- a/src/random/wyrand.cr
+++ b/src/random/wyrand.cr
@@ -1,0 +1,63 @@
+require "random/secure"
+
+# A native Crystal implementation of the beautifully simple and impressively
+# fast PRNG from Wyhash.
+#
+# Based on the original C implementation by 王一 (Wang Yi).
+# https://github.com/wangyi-fudan/wyhash
+#
+# Provides a 64 bit output based on mix and multply operation. This provides
+# exceptionly fast performance on modern processors, but may yield slower
+# results on older architectures.
+struct Random::Wyrand
+  include Random
+
+  private P = {0xa0761d6478bd642f_u64, 0xe7037ed1a0b428db_u64}
+
+  @state : UInt64
+
+  def initialize(seed = Random::Secure.rand(UInt64))
+    @state = seed
+  end
+
+  def next_u : UInt64
+    a = @state &+= P[0]
+    b = a ^ P[1]
+
+    r = UInt128.new! a
+    r &*= b
+
+    p = pointerof(r).as UInt64*
+    a = p.value
+    b = (p + 1).value
+
+    a ^ b
+  end
+
+  {% for size in [8, 16, 32, 64] %}
+    {% type = "UInt#{size}".id %}
+
+    def rand(type : {{type}}.class) : {{type}}
+      r = next_u
+      p = pointerof(r).as {{type}}*
+      p.value
+    end
+
+    private def rand_int(max : {{type}}) : {{type}}
+      a = next_u
+      b = UInt64.new! max
+
+      r = UInt128.new! a
+      r &*= b
+
+      p = pointerof(r).as {{type}}*
+      (p + {{128 // size - 1}}).value
+    end
+  {% end %}
+end
+
+# TODO: BidEndian support. Crystal is currently pinned to LittleEndian so low
+# priority. This is here as a guard rail for when this changes.
+{% if IO::ByteFormat::SystemEndian != IO::ByteFormat::LittleEndian %}
+  {{ raise "Wyrand BigEndian support not implemented" }}
+{% end %}


### PR DESCRIPTION
Implements the PRNG by @wangyi-fudan described in [wyhash](https://github.com/wangyi-fudan/wyhash), including the fast `[0,k)` range generation proposed by @lemire  (within the same repository).

The provides fast generation of 64 bit outputs based on a [MUM operation](https://github.com/vnmakarov/mum-hash) and sufficient randomness for non-cryptographic use. Outputs pass BigCrush and PractRand.

Performance against the current PCG32 implemention:
```
> crystal run benchmark/perf.cr --release

#next_u (direct PRNG cycle output)
 pcg32 440.63M (  2.27ns) (± 1.38%)  0.0B/op   1.40x slower
wyrand 615.84M (  1.62ns) (± 1.71%)  0.0B/op         fastest

UInt32 (native for PCG32)
 pcg32 440.51M (  2.27ns) (± 1.15%)  0.0B/op   1.40x slower
wyrand 614.72M (  1.63ns) (± 1.31%)  0.0B/op         fastest

UInt64 (native for wyrand)
 pcg32  59.52M ( 16.80ns) (± 0.96%)  0.0B/op  10.12x slower
wyrand 602.20M (  1.66ns) (± 6.02%)  0.0B/op         fastest

Random bytes (10MB)
 pcg32  53.74  ( 18.61ms) (±11.09%)  10.0MB/op 2.25x slower
wyrand 120.78  (  8.28ms) (± 6.45%)  10.0MB/op       fastest

UInt8 (1..n)
 pcg32 170.91M (  5.85ns) (± 1.17%)  0.0B/op   2.57x slower
wyrand 438.72M (  2.28ns) (± 2.38%)  0.0B/op         fastest

UInt16 (1..n)
 pcg32 204.95M (  4.88ns) (± 0.93%)  0.0B/op   2.11x slower
wyrand 432.88M (  2.31ns) (± 4.26%)  0.0B/op         fastest

UInt32 (1..n)
 pcg32 125.08M (  7.99ns) (± 0.91%)  0.0B/op   3.44x slower
wyrand 430.53M (  2.32ns) (± 6.82%)  0.0B/op         fastest

UInt64 (1..n)
 pcg32  48.72M ( 20.52ns) (± 0.49%)  0.0B/op  12.62x slower
wyrand 614.89M (  1.63ns) (± 0.88%)  0.0B/op         fastest
```

Entropy over a 10GB output:
```
> ent pcg32.out
Entropy = 8.000000 bits per byte.

Optimum compression would reduce the size
of this 10737418240 byte file by 0 percent.

Chi square distribution for 10737418240 samples is 262.41, and randomly
would exceed this value 36.15 percent of the times.

Arithmetic mean value of data bytes is 127.5001 (127.5 = random).
Monte Carlo value for Pi is 3.141557000 (error 0.00 percent).
Serial correlation coefficient is -0.000012 (totally uncorrelated = 0.0).


> ent wyrand.out
Entropy = 8.000000 bits per byte.

Optimum compression would reduce the size
of this 10737418240 byte file by 0 percent.

Chi square distribution for 10737418240 samples is 231.31, and randomly
would exceed this value 85.40 percent of the times.

Arithmetic mean value of data bytes is 127.5000 (127.5 = random).
Monte Carlo value for Pi is 3.141572366 (error 0.00 percent).
Serial correlation coefficient is 0.000002 (totally uncorrelated = 0.0).
```

Benchmarking and other tools available at https://git.sr.ht/~kb/wyhash.

---

_Note:_ I plan to come back to the actual wyhash too, just a little short on time at the moment and this is both complete and can remain discrete from that _if_ it proves to be a potential alternative to the current funnyhash `Hasher`.