### PR TITLE
Make `Pointer(T)#value=` even stricter for generic arguments

### DIFF
--- a/spec/compiler/semantic/pointer_spec.cr
+++ b/spec/compiler/semantic/pointer_spec.cr
@@ -195,4 +195,21 @@ describe "Semantic: pointer" do
       ),
       "type must be Moo(Char | Int32), not Foo(Int32)"
   end
+
+  it "errors with non-matching generic value with value=, union of generic types (#10544)" do
+    assert_error %(
+      class Foo(T)
+      end
+
+      class Bar1
+      end
+
+      class Bar2
+      end
+
+      ptr = Pointer(Foo(Char | Int32)).malloc(1_u64)
+      ptr.value = Foo(Int32).new || Foo(Char | Int32).new
+      ),
+      "type must be Foo(Char | Int32), not (Foo(Char | Int32) | Foo(Int32))"
+  end
 end

--- a/src/compiler/crystal/semantic/call.cr
+++ b/src/compiler/crystal/semantic/call.cr
@@ -1123,7 +1123,7 @@ class Crystal::Call
         when "pointer_set"
           owner = owner.remove_typedef.as(PointerInstanceType)
           pointer_type = owner.var.type
-          unless type.filter_by(pointer_type)
+          unless (type.nil_type? && pointer_type.void?) || type.implements?(pointer_type)
             self.args[index].raise "type must be #{pointer_type}, not #{type}"
           end
         end


### PR DESCRIPTION
Follow-up to #10224. Resolves #10544. That code will now produce the following error:

```
In src/array.cr:409:5

 409 | push(value)
       ^---
Error: instantiating 'push((Hash(Symbol, Int32 | String | Symbol) | Hash(Symbol, Int32 | Symbol)))'


In src/array.cr:1439:12

 1439 | @buffer[@size] = value
               ^
Error: instantiating 'Pointer(Hash(Symbol, Int32 | String | Symbol))#[]=(Int32, (Hash(Symbol, Int32 | String | Symbol) | Hash(Symbol, Int32 | Symbol)))'


In src/pointer.cr:130:29

 130 | (self + offset).value = value
                               ^----
Error: type must be Hash(Symbol, Int32 | String | Symbol), not (Hash(Symbol, Int32 | String | Symbol) | Hash(Symbol, Int32 | Symbol))
```

The correct check for covariance is `implements?`, because roughly speaking `filter_by` only performs intersection between two types. (`x.implements?(y)` implies `x.filter_by(y).implements?(x) && x.implements?(x.filter_by(y))`.)

The relation between `Nil` and `Void` is not captured by `implements?` yet, so it is specially handled here. I would expect `Void` to be a module-like type that has no parents, and whose includer is `Nil` and nothing else.