### PR TITLE
Deprecate `String#unsafe_byte_at`

### DIFF
--- a/src/io.cr
+++ b/src/io.cr
@@ -768,7 +768,7 @@ abstract class IO
 
     # One byte: use gets(Char)
     if delimiter.bytesize == 1
-      return gets(delimiter.unsafe_byte_at(0).unsafe_chr, chomp: chomp)
+      return gets(delimiter.to_unsafe.unsafe_chr, chomp: chomp)
     end
 
     # One char: use gets(Char)

--- a/src/io.cr
+++ b/src/io.cr
@@ -768,7 +768,7 @@ abstract class IO
 
     # One byte: use gets(Char)
     if delimiter.bytesize == 1
-      return gets(delimiter.to_unsafe.unsafe_chr, chomp: chomp)
+      return gets(delimiter.to_unsafe[0].unsafe_chr, chomp: chomp)
     end
 
     # One char: use gets(Char)

--- a/src/string.cr
+++ b/src/string.cr
@@ -2018,7 +2018,7 @@ class String
     return delete(from) if to.empty?
 
     if from.bytesize == 1
-      return gsub(from.to_unsafe.unsafe_chr, to[0])
+      return gsub(from.to_unsafe[0].unsafe_chr, to[0])
     end
 
     multi = nil
@@ -2436,7 +2436,7 @@ class String
   # ```
   def gsub(char : Char, replacement)
     if replacement.is_a?(String) && replacement.bytesize == 1
-      return gsub(char, replacement.to_unsafe.unsafe_chr)
+      return gsub(char, replacement.to_unsafe[0].unsafe_chr)
     end
 
     if includes?(char)
@@ -2546,7 +2546,7 @@ class String
   # ```
   def gsub(string : String, replacement)
     if string.bytesize == 1
-      gsub(string.to_unsafe.unsafe_chr, replacement)
+      gsub(string.to_unsafe[0].unsafe_chr, replacement)
     else
       gsub(string) { replacement }
     end

--- a/src/string.cr
+++ b/src/string.cr
@@ -1227,6 +1227,7 @@ class String
   end
 
   # Returns the byte at the given *index* without bounds checking.
+  @[Deprecated("Use `to_unsafe[index]` instead.")]
   def unsafe_byte_at(index : Int) : UInt8
     to_unsafe[index]
   end
@@ -1242,7 +1243,7 @@ class String
     if single_byte_optimizable? && (options.none? || options.ascii?)
       return String.new(bytesize) do |buffer|
         bytesize.times do |i|
-          buffer[i] = unsafe_byte_at(i).unsafe_chr.downcase.ord.to_u8
+          buffer[i] = to_unsafe[i].unsafe_chr.downcase.ord.to_u8
         end
         {@bytesize, @length}
       end
@@ -1277,7 +1278,7 @@ class String
     if single_byte_optimizable? && (options.none? || options.ascii?)
       return String.new(bytesize) do |buffer|
         bytesize.times do |i|
-          buffer[i] = unsafe_byte_at(i).unsafe_chr.upcase.ord.to_u8
+          buffer[i] = to_unsafe[i].unsafe_chr.upcase.ord.to_u8
         end
         {@bytesize, @length}
       end
@@ -1314,9 +1315,9 @@ class String
       return String.new(bytesize) do |buffer|
         bytesize.times do |i|
           byte = if i.zero?
-                   unsafe_byte_at(i).unsafe_chr.upcase.ord.to_u8
+                   to_unsafe[i].unsafe_chr.upcase.ord.to_u8
                  else
-                   unsafe_byte_at(i).unsafe_chr.downcase.ord.to_u8
+                   to_unsafe[i].unsafe_chr.downcase.ord.to_u8
                  end
 
           buffer[i] = byte
@@ -1361,7 +1362,7 @@ class String
 
       return String.new(bytesize) do |buffer|
         bytesize.times do |i|
-          char = unsafe_byte_at(i).unsafe_chr
+          char = to_unsafe[i].unsafe_chr
           replaced_char = upcase_next ? char.upcase : char.downcase
           buffer[i] = replaced_char.ord.to_u8
           upcase_next = char.whitespace?
@@ -2017,7 +2018,7 @@ class String
     return delete(from) if to.empty?
 
     if from.bytesize == 1
-      return gsub(from.unsafe_byte_at(0).unsafe_chr, to[0])
+      return gsub(from.to_unsafe.unsafe_chr, to[0])
     end
 
     multi = nil
@@ -2435,7 +2436,7 @@ class String
   # ```
   def gsub(char : Char, replacement)
     if replacement.is_a?(String) && replacement.bytesize == 1
-      return gsub(char, replacement.unsafe_byte_at(0).unsafe_chr)
+      return gsub(char, replacement.to_unsafe.unsafe_chr)
     end
 
     if includes?(char)
@@ -2545,7 +2546,7 @@ class String
   # ```
   def gsub(string : String, replacement)
     if string.bytesize == 1
-      gsub(string.unsafe_byte_at(0).unsafe_chr, replacement)
+      gsub(string.to_unsafe.unsafe_chr, replacement)
     else
       gsub(string) { replacement }
     end

--- a/src/string/utf16.cr
+++ b/src/string/utf16.cr
@@ -21,7 +21,7 @@ class String
         if i == bytesize
           0_u16
         else
-          unsafe_byte_at(i).to_u16
+          to_unsafe[i].to_u16
         end
       end
       return slice[0, bytesize]

--- a/src/uri/encoding.cr
+++ b/src/uri/encoding.cr
@@ -192,7 +192,7 @@ class URI
     i = 0
     bytesize = string.bytesize
     while i < bytesize
-      byte = string.unsafe_byte_at(i)
+      byte = string.to_unsafe[i]
       char = byte.unsafe_chr
       i = decode_one(string, bytesize, i, byte, char, io, plus_to_space) { |byte| yield byte }
     end
@@ -244,7 +244,7 @@ class URI
 
     if char == '%' && i < bytesize - 2
       i += 1
-      first = string.unsafe_byte_at(i)
+      first = string.to_unsafe[i]
       first_num = first.unsafe_chr.to_i? 16
       unless first_num
         io.write_byte byte
@@ -252,7 +252,7 @@ class URI
       end
 
       i += 1
-      second = string.unsafe_byte_at(i)
+      second = string.to_unsafe[i]
       second_num = second.unsafe_chr.to_i? 16
       unless second_num
         io.write_byte byte

--- a/src/uri/params.cr
+++ b/src/uri/params.cr
@@ -40,9 +40,9 @@ class URI
 
       i = 0
       first_equal = true
-      bytesize = query.bytesize
+      bytesize = query.bytes
       while i < bytesize
-        byte = query.unsafe_byte_at(i)
+        byte = query.to_unsafe[i]
         char = byte.unsafe_chr
 
         case char

--- a/src/uri/params.cr
+++ b/src/uri/params.cr
@@ -40,7 +40,7 @@ class URI
 
       i = 0
       first_equal = true
-      bytesize = query.bytes
+      bytesize = query.bytesize
       while i < bytesize
         byte = query.to_unsafe[i]
         char = byte.unsafe_chr


### PR DESCRIPTION
`string.unsafe_byte_at(i)` is equivalent to `string.to_unsafe[i]`. It doesn't make sense to have an extra method for this, which is even longer.

This picks up part of #5503.
