### PR TITLE
Add default "null" to `JSON::Builder#field`

### DIFF
--- a/spec/std/json/builder_spec.cr
+++ b/spec/std/json/builder_spec.cr
@@ -258,23 +258,65 @@ describe JSON::Builder do
     end
   end
 
-  it "writes field with scalar in object" do
-    assert_built(%<{"int":42,"float":0.815,"null":null,"bool":true,"string":"string"}>) do
-      object do
-        field "int", 42
-        field "float", 0.815
-        field "null", nil
-        field "bool", true
-        field "string", "string"
+  describe "#field" do
+    it "writes field with scalar in object" do
+      assert_built(%<{"int":42,"float":0.815,"null":null,"bool":true,"string":"string"}>) do
+        object do
+          field "int", 42
+          field "float", 0.815
+          field "null", nil
+          field "bool", true
+          field "string", "string"
+        end
+      end
+    end
+
+    it "writes field with arbitrary value in object" do
+      assert_built(%<{"hash":{"hash":"value"},"object":{"int":12}}>) do
+        object do
+          field "hash", {"hash" => "value"}
+          field "object", TestObject.new
+        end
       end
     end
   end
 
-  it "writes field with arbitrary value in object" do
-    assert_built(%<{"hash":{"hash":"value"},"object":{"int":12}}>) do
-      object do
-        field "hash", {"hash" => "value"}
-        field "object", TestObject.new
+  describe "#field(name, &)" do
+    it "writes field with scalar in object" do
+      assert_built(%<{"int":42,"float":0.815,"null":null,"bool":true,"string":"string"}>) do
+        object do
+          field "int" { scalar 42 }
+          field "float" { scalar 0.815 }
+          field "null" { scalar nil }
+          field "bool" { scalar true }
+          field "string" { scalar "string" }
+        end
+      end
+    end
+
+    it "writes field with arbitrary value in object" do
+      assert_built(%<{"hash":{"hash":"value"},"object":{"int":12}}>) do |builder|
+        object do
+          field "hash" { {"hash" => "value"}.to_json(builder) }
+          field "object" { TestObject.new.to_json(builder) }
+        end
+      end
+    end
+
+    it "defaults to null" do
+      assert_built(%<{"foo":null}>) do
+        object do
+          field "foo" { }
+        end
+      end
+    end
+
+    it "detects invalid state" do
+      builder = JSON::Builder.new(IO::Memory.new)
+      builder.start_document
+      builder.start_object
+      expect_raises(JSON::Error, "Invalid builder state, not inside an object") do
+        builder.field "foo" { builder.start_array }
       end
     end
   end

--- a/src/json/builder.cr
+++ b/src/json/builder.cr
@@ -255,9 +255,21 @@ class JSON::Builder
   # Writes an object's field and then invokes the block.
   # This is equivalent of invoking `string(value)` and then
   # invoking the block.
+  #
+  # If the block does not write a value, the default is `null`.
   def field(name)
     string(name)
+
     yield
+
+    case state = @state.last
+    when ObjectState
+      unless state.name
+        null
+      end
+    else
+      raise JSON::Error.new("Invalid builder state, not inside an object.")
+    end
   end
 
   # Flushes the underlying `IO`.


### PR DESCRIPTION
The method `JSON::Builder#field(name, &)` expects the block to append a value to the builder. If this doesn't happen (for example because the block is empty), the builder enters an invalid state.

This patch adds detection for this.

* It adds a default `null` value if the builder state still expects the name of an object property (which suggests the block didn't do anything to the builder).
* It raises on any other than `ObjectState`, because that indicates the block appended an incomplete value.

This could be even further enhanced and actually check the validity of the state stack. But that's hardly necessary.
The main use case is code that for some reason just forgets appending a property value in the block.
Defaulting to `null` makes that it still produces valid JSON output which can then be used to investigate the error if a value was expected instead of `null`.

Resolves #5218