### PR TITLE
Support breaks with values inside `while` expressions

### DIFF
--- a/spec/compiler/codegen/while_spec.cr
+++ b/spec/compiler/codegen/while_spec.cr
@@ -66,7 +66,7 @@ describe "Codegen: while" do
       )).to_i.should eq(4)
   end
 
-  it "conditional break with value" do
+  it "endless conditional break with value" do
     run(%(
       a = 0
       while true

--- a/spec/compiler/codegen/while_spec.cr
+++ b/spec/compiler/codegen/while_spec.cr
@@ -21,6 +21,61 @@ describe "Codegen: while" do
     run("a = 0; while a < 10; a &+= 1; break if a > 5; end; a").to_i.should eq(6)
   end
 
+  it "break with value" do
+    run(%(
+      struct Nil; def to_i!; 0; end; end
+
+      a = 0
+      b = while a < 10
+        a &+= 1
+        break a &+ 3
+      end
+      b.to_i!
+      )).to_i.should eq(4)
+  end
+
+  it "conditional break with value" do
+    run(%(
+      struct Nil; def to_i!; 0; end; end
+
+      a = 0
+      b = while a < 10
+        a &+= 1
+        break a &+ 3 if a > 5
+      end
+      b.to_i!
+      )).to_i.should eq(9)
+  end
+
+  it "break with value, condition fails" do
+    run(%(
+      a = while 1 == 2
+        break 1
+      end
+      a.nil?
+      )).to_b.should be_true
+  end
+
+  it "endless break with value" do
+    run(%(
+      a = 0
+      while true
+        a &+= 1
+        break a &+ 3
+      end
+      )).to_i.should eq(4)
+  end
+
+  it "conditional break with value" do
+    run(%(
+      a = 0
+      while true
+        a &+= 1
+        break a &+ 3 if a > 5
+      end
+      )).to_i.should eq(9)
+  end
+
   it "codegens endless while" do
     codegen "while true; end"
   end

--- a/spec/compiler/semantic/while_spec.cr
+++ b/spec/compiler/semantic/while_spec.cr
@@ -6,11 +6,37 @@ describe "Semantic: while" do
   end
 
   it "types while with break without value" do
-    assert_type("while true; break; end") { nil_type }
+    assert_type("while 1; break; end") { nil_type }
   end
 
   it "types while with break with value" do
-    assert_type("while true; break 1; end") { nil_type }
+    assert_type("while 1; break 'a'; end") { nilable char }
+  end
+
+  it "types while with multiple breaks with value" do
+    assert_type(%(
+      while 1
+        break 'a' if 1
+        break "", 123 if 1
+      end
+      )) { nilable union_of(char, tuple_of([string, int32])) }
+  end
+
+  it "types endless while with break without value" do
+    assert_type("while true; break; end") { nil_type }
+  end
+
+  it "types endless while with break with value" do
+    assert_type("while true; break 1; end") { int32 }
+  end
+
+  it "types endless while with multiple breaks with value" do
+    assert_type(%(
+      while true
+        break 'a' if 1
+        break "", 123 if 1
+      end
+      )) { union_of(char, tuple_of([string, int32])) }
   end
 
   it "reports break cannot be used outside a while" do

--- a/src/compiler/crystal/codegen/context.cr
+++ b/src/compiler/crystal/codegen/context.cr
@@ -11,7 +11,6 @@ class Crystal::CodeGenVisitor
     property break_phi : Phi?
     property next_phi : Phi?
     property while_block : LLVM::BasicBlock?
-    property while_exit_block : LLVM::BasicBlock?
     property! block : Block
     property! block_context : Context
     property closure_vars : Array(MetaVar)?
@@ -44,7 +43,6 @@ class Crystal::CodeGenVisitor
       context.break_phi = @break_phi
       context.next_phi = @next_phi
       context.while_block = @while_block
-      context.while_exit_block = @while_exit_block
       if block = @block
         context.block = block
       end

--- a/src/compiler/crystal/semantic/main_visitor.cr
+++ b/src/compiler/crystal/semantic/main_visitor.cr
@@ -2110,7 +2110,7 @@ module Crystal
         filter_vars TypeFilters.not(cond_type_filters)
       end
 
-      node.type = @program.nil
+      node.bind_to(@program.nil_var) unless endless_while
 
       false
     end
@@ -2293,6 +2293,7 @@ module Crystal
 
         break_vars = (target_while.break_vars ||= [] of MetaVars)
         break_vars.push @vars.dup
+        target_while.bind_to(node_exp_or_nil_literal(node))
       else
         if @typed_def.try &.captured_block?
           node.raise "can't break from captured block, try using `next`."


### PR DESCRIPTION
Resolves #1277. This makes the behaviour of `while` expressions behaviour consistent with Ruby.

```crystal
x = while true
  break 1, 2  if true
  break 3     if true
  break 4, "" if true
end       # => {1, 2}
typeof(x) # => (Int32 | Tuple(Int32, Int32 | String))
```

Contrast with `loop`: (apart from lacking a condition, this also creates a new scope whereas `while` doesn't):

```crystal
x = loop do
  break 1, 2 if true
  break 3 if true
  break 4, "" if true
end       # => {1, 2}
typeof(x) # => (Int32 | Tuple(Int32, Int32 | String))
```

The type of a `while` expression is now the union of all `break` expressions within the body, plus `Nil` if the condition isn't exactly the `true` literal; the `while` expression returns `nil` if the condition fails. The type of a `break` expression is computed similarly to a `break` inside a block or a `return` (`Nil` if empty, `Tuple` if multiple values). The condition's effect on the return type becomes apparent if we rewrite those loops as follows: (see also #10538)

```crystal
x = while cond
  # other breaks here...
end

# should be equivalent to:
x = while true
  unless cond
    # the Nil type comes from here
    # (for an endless loop this break will be gone, so if there are no other breaks,
    # it follows that the loop will be typed as NoReturn, just as before)
    break
  end
  # other breaks here...
end
```

This PR doesn't change whether a `break` is interpreted as a `while` break or a block break.