### PR TITLE
Pass hostname to web socket instead of hardcoded localhost

### DIFF
--- a/spec/compiler/crystal/tools/playground_spec.cr
+++ b/spec/compiler/crystal/tools/playground_spec.cr
@@ -578,7 +578,7 @@ describe Playground::AgentInstrumentorTransformer do
 end
 
 private def assert_compile(source)
-  sources = Playground::Session.instrument_and_prelude("", "", 0, source)
+  sources = Playground::Session.instrument_and_prelude("", "", 0, 0, source)
   compiler = Compiler.new
   compiler.no_codegen = true
   result = compiler.compile sources, "fake-no-build"

--- a/src/compiler/crystal/tools/playground/server.cr
+++ b/src/compiler/crystal/tools/playground/server.cr
@@ -452,12 +452,12 @@ module Crystal::Playground
     @sessions = {} of Int32 => Session
     @sessions_key = 0
 
-    property host : String?
+    property host : String
     property port
     property source : Compiler::Source?
 
     def initialize
-      @host = nil
+      @host = "localhost"
       @port = 8080
       @verbose = false
     end
@@ -491,7 +491,7 @@ module Crystal::Playground
           ws.close :policy_violation, "Invalid Request Origin"
         else
           @sessions_key += 1
-          @sessions[@sessions_key] = session = Session.new(ws, @sessions_key, @host || "localhost", @port)
+          @sessions[@sessions_key] = session = Session.new(ws, @sessions_key, @host, @port)
           Log.info { "/client WebSocket connected as session=#{@sessions_key}" }
 
           ws.on_message do |message|
@@ -546,7 +546,7 @@ module Crystal::Playground
 
     private def accept_request?(origin)
       case @host
-      when nil
+      when "localhost"
         origin == "http://127.0.0.1:#{@port}" || origin == "http://localhost:#{@port}"
       when "0.0.0.0"
         true


### PR DESCRIPTION
When attempting to use the playground with an IP other than "localhost" or "0.0.0.0" the output is unable to update.  The following error is thrown when clicking the "Show Output" button in the interface.

```crystal
Unhandled exception: Error connecting to 'localhost:8080': Connection refused (Socket::ConnectError)
  from /usr/share/crystal/src/socket/addrinfo.cr:73:15 in 'initialize'
  from /usr/share/crystal/src/socket/tcp_socket.cr:27:3 in 'initialize'
  from /usr/share/crystal/src/socket/tcp_socket.cr:27:3 in 'new'
  from /usr/share/crystal/src/http/web_socket/protocol.cr:275:5 in 'new'
  from /usr/share/crystal/src/http/web_socket/protocol.cr:323:14 in 'new'
  from /usr/share/crystal/src/http/web_socket.cr:35:5 in 'new'
  from /usr/share/crystal/src/http/web_socket.cr:34:3 in 'new'
  from /usr/share/crystal/src/compiler/crystal/tools/playground/agent.cr:10:11 in 'initialize'
  from /usr/share/crystal/src/compiler/crystal/tools/playground/agent.cr:9:3 in 'new'
  from /usr/share/crystal/src/gc/boehm.cr:164:23 in '~Crystal::Playground::Agent::instance:init'
  from /play:1:6 in '__crystal_main'
  from /usr/share/crystal/src/crystal/main.cr:110:5 in 'main_user_code'
  from /usr/share/crystal/src/crystal/main.cr:96:7 in 'main'
  from /usr/share/crystal/src/crystal/main.cr:119:3 in 'main'
  from __libc_start_main
  from _start
  from ???

exit status: 1
```

This is a small change that passes the hostname to the session so that it can be used for the web socket instead of the hardcoded "localhost".