### PR TITLE
Add default binary name to .gitignore

### DIFF
--- a/src/compiler/crystal/tools/init/template/gitignore.ecr
+++ b/src/compiler/crystal/tools/init/template/gitignore.ecr
@@ -3,6 +3,7 @@
 /bin/
 /.shards/
 *.dwarf
+<%= config.name %>
 <%- if config.skeleton_type == "lib" -%>
 
 # Libraries don't need dependency lock


### PR DESCRIPTION
Ignoring the default binary name that gets generated when you build a project without `-o`