### PR TITLE
Show proper owner for `Class`'s methods in error messages

### DIFF
--- a/spec/compiler/semantic/def_spec.cr
+++ b/spec/compiler/semantic/def_spec.cr
@@ -366,6 +366,48 @@ describe "Semantic: def" do
       "no overload matches 'foo'"
   end
 
+  it "gives correct error for methods in Class" do
+    assert_error %(
+      class Class
+        def foo
+          1
+        end
+      end
+
+      class Foo
+      end
+
+      Foo.foo(1)
+      ),
+      <<-ERROR
+      wrong number of arguments for 'Foo.foo' (given 1, expected 0)
+
+      Overloads are:
+       - Class#foo()
+      ERROR
+  end
+
+  it "gives correct error for methods in Class (2)" do
+    assert_error %(
+      class Class
+        def self.foo
+          1
+        end
+      end
+
+      class Foo
+      end
+
+      Foo.foo(1)
+      ),
+      <<-ERROR
+      wrong number of arguments for 'Foo.foo' (given 1, expected 0)
+
+      Overloads are:
+       - Class#foo()
+      ERROR
+  end
+
   it "errors if declares def inside if" do
     assert_error %(
       if 1 == 2

--- a/src/compiler/crystal/semantic/call_error.cr
+++ b/src/compiler/crystal/semantic/call_error.cr
@@ -658,6 +658,10 @@ class Crystal::Call
     case owner
     when Program
       method_name
+    when owner.program.class_type
+      # Class's instance_type is Object, not Class, so we cannot treat it like
+      # other metaclasses
+      "#{owner}##{method_name}"
     when .metaclass?
       "#{owner.instance_type}.#{method_name}"
     else


### PR DESCRIPTION
`Class`'s own instance / class methods are displayed as `Object` in error messages:

```crystal
Int32 | 1
```

```
Error: no overload matches 'Int32.|' with type Int32

Overloads are:
 - Object.|(other : U.class)
```

But obviously `|` isn't a class method of `Object`. This PR turns that into `Class#|`.