### PR TITLE
Add type restrictions for splat-less overloads of some methods

### DIFF
--- a/src/array.cr
+++ b/src/array.cr
@@ -1262,7 +1262,7 @@ class Array(T)
     FlattenHelper(typeof(FlattenHelper.element_type(self))).flatten(self)
   end
 
-  def self.product(arrays)
+  def self.product(arrays : Array(Array))
     result = [] of Array(typeof(arrays.first.first))
     each_product(arrays) do |product|
       result << product

--- a/src/io.cr
+++ b/src/io.cr
@@ -184,7 +184,7 @@ abstract class IO
   # io.print "Crystal"
   # io.to_s # => "1-Crystal"
   # ```
-  def print(obj) : Nil
+  def print(obj : _) : Nil
     self << obj
     nil
   end
@@ -227,7 +227,7 @@ abstract class IO
   # io.puts "Crystal"
   # io.to_s # => "1\nCrystal\n"
   # ```
-  def puts(obj) : Nil
+  def puts(obj : _) : Nil
     self << obj
     puts
   end

--- a/src/object.cr
+++ b/src/object.cr
@@ -209,7 +209,7 @@ class Object
   # 10.in?(0, 1, 10)   # => true
   # 10.in?(:foo, :bar) # => false
   # ```
-  def in?(collection) : Bool
+  def in?(collection : Object) : Bool
     collection.includes?(self)
   end
 


### PR DESCRIPTION
Prepares the standard library for a potential fix of #10231. With the new semantics (WIP [here](https://github.com/HertzDevil/crystal/tree/bug/def-restriction-of)), the first overload will become stricter than the second overload below, which isn't currently the case:

```crystal
def foo(*xs : Int32); 1; end
def foo(x); 2; end

# 1 after the redefinition of overload order
foo(0) # => 2
```

This is because when one positional argument is passed, it would be matched against `x` and `*xs : Int32`; putting a restriction is always stricter than not putting one at all, so it makes sense the splat overload should take precedence here. (Note that `xs` is never an empty `Tuple`, since a restriction is applied to it.) Preserving the old semantics would then require putting a restriction also on the splat-less overload:

```crystal
def foo(*xs : Int32); 1; end
def foo(x : Int32); 2; end
def foo(x); 3; end # (not required for this PR)

# still 2 after the redefinition of overload order
foo(0) # => 2
```

In this case, `Int32 <= Int32`, and a required parameter is preferable to a splat parameter, so the splat-less overload would continue to come first.

This PR adds those restrictions to the standard library methods that do this. None of them should be breaking changes:

* `Object#in?(collection)`: Clashes with `#in?(*values : Object)`. Restricting `collection` to `Object` would exclude only `Void` values, which do not respond to `#includes?` anyway.
* `IO#print(obj)`: Clashes with `#print(*objects : _)`. The parameter `obj : _` will continue to match everything.
* `IO#puts(obj)`: Clashes with `#puts(*objects : _)` and `#puts(string : String)`. Similar to above.
* `Array.product(arrays)`: Clashes with `.product(*arrays : Array)`. This calls `each_product(arrays)`, whose type restriction is `Array(Array)`, so the same can be put here. (`Indexable.product` from #10013 doesn't have a splat overload; there the type restriction on the only overload is `Indexable(Indexable)` already.)