### PR TITLE
YAML: parse quoted empty string as string, never as nil

### DIFF
--- a/spec/std/yaml/serializable_spec.cr
+++ b/spec/std/yaml/serializable_spec.cr
@@ -374,6 +374,12 @@ end
 class YAMLVariableDiscriminatorEnum < YAMLVariableDiscriminatorValueType
 end
 
+class YAMLAttrWithNilableString
+  include YAML::Serializable
+
+  property value : String? = "default"
+end
+
 describe "YAML::Serializable" do
   it "works with record" do
     YAMLAttrPoint.new(1, 2).to_yaml.should eq "---\nx: 1\ny: 2\n"
@@ -826,6 +832,21 @@ describe "YAML::Serializable" do
     obj = YAMLAttrWithNilableUnion2.from_yaml(%({}))
     obj.value.should be_nil
     obj.to_yaml.should eq("--- {}\n")
+  end
+
+  it "doesn't parse single quoted string as nil (#10606)" do
+    obj = YAMLAttrWithNilableString.from_yaml(%{"value": ''})
+    obj.value.should eq("")
+  end
+
+  it "doesn't parse double quoted string as nil (#10606)" do
+    obj = YAMLAttrWithNilableString.from_yaml(%{"value": ""})
+    obj.value.should eq("")
+  end
+
+  it "uses the default value for nilable string when the property is missing (#10606)" do
+    obj = YAMLAttrWithNilableString.from_yaml(%{})
+    obj.value.should eq("default")
   end
 
   describe "parses YAML with presence markers" do

--- a/src/yaml/schema/core.cr
+++ b/src/yaml/schema/core.cr
@@ -129,7 +129,10 @@ module YAML::Schema::Core
   # If `node` parses to a null value, returns `nil`, otherwise
   # invokes the given block.
   def self.parse_null_or(node : YAML::Nodes::Node)
-    if node.is_a?(YAML::Nodes::Scalar) && parse_null?(node.value)
+    if node.is_a?(YAML::Nodes::Scalar) &&
+      !node.style.single_quoted? &&
+      !node.style.double_quoted? &&
+      parse_null?(node.value)
       nil
     else
       yield


### PR DESCRIPTION
Fixes #10606