### PR TITLE
Docs generator: Respect overload order between methods

### DIFF
--- a/src/compiler/crystal/tools/doc/type.cr
+++ b/src/compiler/crystal/tools/doc/type.cr
@@ -166,7 +166,7 @@ class Crystal::Doc::Type
             defs << method(def_with_metadata.def, false)
           end
         end
-        defs.sort_by! &.name.downcase
+        stable_sort! defs, &.name.downcase
       end
     end
   end
@@ -191,7 +191,7 @@ class Crystal::Doc::Type
           end
         end
       end
-      class_methods.sort_by! &.name.downcase
+      stable_sort! class_methods, &.name.downcase
     end
   end
 
@@ -215,7 +215,7 @@ class Crystal::Doc::Type
           end
         end
       end
-      macros.sort_by! &.name.downcase
+      stable_sort! macros, &.name.downcase
     end
   end
 
@@ -817,5 +817,11 @@ class Crystal::Doc::Type
 
   def annotations(annotation_type)
     @type.annotations(annotation_type)
+  end
+
+  private def stable_sort!(list)
+    # TODO: use #10163 instead
+    i = 0
+    list.sort_by! { |elem| {yield(elem), i += 1} }
   end
 end


### PR DESCRIPTION
The docs generator sorts instance method / class methods / macros by their name, but since the current sort algorithm is unstable, overloads with the same name can be indeterminately ordered. Consider, for example, the `Math` module between two Crystal versions:

[0.35.0](https://crystal-lang.org/api/0.35.0/Math.html#instance-method-summary):

* `#acos(value : Float32)`, `#acos(value : Float64)`, `#acos(value)`
* `#acosh(value : Float32)`, `#acosh(value : Float64)`, `#acosh(value)`
* `#asin(value : Float32)`, `#asin(value : Float64)`, `#asin(value)`
* `#asinh(value : Float32)`, `#asinh(value : Float64)`, `#asinh(value)`
* `#atan(value)`, `#atan(value : Float64)`, `#atan(value : Float32)`
* ...

[1.0.0](https://crystal-lang.org/api/1.0.0/Math.html#instance-method-summary):

* `#acos(value)`, `#acos(value : Float64)`, `#acos(value : Float32)`
* `#acosh(value : Float32)`, `#acosh(value : Float64)`, `#acosh(value)`
* `#asin(value : Float32)`, `#asin(value : Float64)`, `#asin(value)`
* `#asinh(value : Float64)`, `#asinh(value)`, `#asinh(value : Float32)`
* `#atan(value : Float32)`, `#atan(value : Float64)`, `#atan(value)`
* ...

Overloads of each method are internally sorted by their strictness order already, so this PR exposes that order using a custom stable sort. The result is that each of the methods above will always show the `Float32` overload, then the `Float64` overload, and finally the restriction-less one.

This PR does not depend on #10163 (this sort would have to be stable whether or not the standard library supports it).