### PR TITLE
Fix body locations for def nodes that have default args 

### DIFF
--- a/spec/compiler/normalize/def_spec.cr
+++ b/spec/compiler/normalize/def_spec.cr
@@ -237,16 +237,16 @@ module Crystal
        "default arg with restriction" => "def testing(foo : Int = 5)",
        "splat arg"                    => "def testing(*foo : Array)",
        "block instance var arg"       => "def testing(&@foo : ->)",
-      }.each do |(suf, definition)|
-        describe suf + "," do
-          {"with body" => "zzz = 7\n", "without body" => ""}.each do |(suf, body)|
-            it suf do
-              a_def = parse("#{definition}\n#{body}end").as(Def)
-              actual = a_def.expand_default_arguments(Program.new, 1)
+      }.each do |(suffix1, definition)|
+        {"with body"    => "zzz = 7\n",
+         "without body" => "",
+        }.each do |(suffix2, body)|
+          it "#{suffix1}, #{suffix2}" do
+            a_def = parse("#{definition}\n#{body}end").as(Def)
+            actual = a_def.expand_default_arguments(Program.new, 1)
 
-              actual.location.should eq Location.new("", line_number: 1, column_number: 1)
-              actual.body.location.should eq Location.new("", line_number: 2, column_number: 1)
-            end
+            actual.location.should eq Location.new("", line_number: 1, column_number: 1)
+            actual.body.location.should eq Location.new("", line_number: 2, column_number: 1)
           end
         end
       end

--- a/spec/compiler/normalize/def_spec.cr
+++ b/spec/compiler/normalize/def_spec.cr
@@ -231,5 +231,25 @@ module Crystal
       other_def = a_def.expand_default_arguments(Program.new, 0, ["abstract"])
       other_def.to_s.should eq("def foo:abstract(abstract __arg0)\n  options = {}\n  @abstract = __arg0\nend")
     end
+
+    describe "gives correct body location with" do
+      {"default arg"                  => "def testing(foo = 5)",
+       "default arg with restriction" => "def testing(foo : Int = 5)",
+       "splat arg"                    => "def testing(*foo : Array)",
+       "block instance var arg"       => "def testing(&@foo : ->)",
+      }.each do |(suf, definition)|
+        describe suf + "," do
+          {"with body" => "zzz = 7\n", "without body" => ""}.each do |(suf, body)|
+            it suf do
+              a_def = parse("#{definition}\n#{body}end").as(Def)
+              actual = a_def.expand_default_arguments(Program.new, 1)
+
+              actual.location.should eq Location.new("", line_number: 1, column_number: 1)
+              actual.body.location.should eq Location.new("", line_number: 2, column_number: 1)
+            end
+          end
+        end
+      end
+    end
   end
 end

--- a/src/compiler/crystal/semantic/default_arguments.cr
+++ b/src/compiler/crystal/semantic/default_arguments.cr
@@ -166,7 +166,7 @@ class Crystal::Def
       end
 
       new_body.push body
-      expansion.body = Expressions.new(new_body)
+      expansion.body = Expressions.new(new_body).at(body)
     else
       new_args = [] of ASTNode
       body = [] of ASTNode
@@ -203,7 +203,7 @@ class Crystal::Def
       call.expansion = true
       body << call
 
-      expansion.body = Expressions.new(body)
+      expansion.body = Expressions.new(body).at(self.body)
     end
 
     expansion

--- a/src/compiler/crystal/semantic/new.cr
+++ b/src/compiler/crystal/semantic/new.cr
@@ -224,7 +224,7 @@ module Crystal
         init.block_arg = Var.new(block_arg.name).at(self)
       end
 
-      self.body = Expressions.from(exps).at(self)
+      self.body = Expressions.from(exps).at(self.body)
     end
 
     def self.argless_new(instance_type)

--- a/src/compiler/crystal/syntax/parser.cr
+++ b/src/compiler/crystal/syntax/parser.cr
@@ -3573,7 +3573,7 @@ module Crystal
         end_location = token_end_location
 
         if @token.keyword?(:end)
-          body = Expressions.from(extra_assigns)
+          body = Expressions.from(extra_assigns).at(@token.location)
           next_token_skip_space
         else
           body = parse_expressions
@@ -3585,7 +3585,7 @@ module Crystal
             else
               exps.push body
             end
-            body = Expressions.from(exps)
+            body = Expressions.from(exps).at(body)
           end
           body, end_location = parse_exception_handler body, implicit: true
         end
@@ -3852,6 +3852,7 @@ module Crystal
         uses_arg = false
         do_next_token = true
       when :INSTANCE_VAR
+        # Transform `def foo(@x); end` to `def foo(x); @x = x; end`
         arg_name = @token.value.to_s[1..-1]
         if arg_name == external_name
           raise "when specified, external name must be different than internal name", @token
@@ -4367,7 +4368,7 @@ module Crystal
         else
           exps.push block_body
         end
-        block_body = Expressions.from exps
+        block_body = Expressions.from(exps).at(block_body)
       end
 
       block_body, end_location = yield block_body


### PR DESCRIPTION


Currently it is reported that the actual body of the method begins at the first "assignment" to a default arg, if there is one:

              \/here
    def foo(x, y=5)
      test
     /\not here
    end

I think that's a bit arbitrary and won't be helpful for whatever tooling may rely on this, so I change it to be shown at the point of the "not here" example on the diagram.

This also fixes the body location for `def self.new` generated from `def initialize`.