### PR TITLE
Fix call nodes' location after transforming its splats

### DIFF
--- a/spec/compiler/semantic/splat_spec.cr
+++ b/spec/compiler/semantic/splat_spec.cr
@@ -817,4 +817,14 @@ describe "Semantic: splat" do
       i.should eq(4)
     end
   end
+
+  it "doesn't shift a call's location", focus: true do
+    result = semantic %(class Foo\ndef bar(x)\nbar(*{"test"})\nend\nend\nFoo.new.bar("test"))
+    program = result.program
+    a_typ = program.types["Foo"].as(NonGenericClassType)
+    a_def = a_typ.def_instances.values[0]
+
+    a_def.location.should eq Location.new("", line_number: 2, column_number: 1)
+    a_def.body.location.should eq Location.new("", line_number: 3, column_number: 1)
+  end
 end

--- a/spec/compiler/semantic/splat_spec.cr
+++ b/spec/compiler/semantic/splat_spec.cr
@@ -818,12 +818,12 @@ describe "Semantic: splat" do
     end
   end
 
-  it "doesn't shift a call's location", focus: true do
+  it "doesn't shift a call's location" do
     result = semantic <<-CR
       class Foo
-      def bar(x)
-      bar(*{"test"})
-      end
+        def bar(x)
+          bar(*{"test"})
+        end
       end
       Foo.new.bar("test")
       CR
@@ -831,7 +831,7 @@ describe "Semantic: splat" do
     a_typ = program.types["Foo"].as(NonGenericClassType)
     a_def = a_typ.def_instances.values[0]
 
-    a_def.location.should eq Location.new("", line_number: 2, column_number: 1)
-    a_def.body.location.should eq Location.new("", line_number: 3, column_number: 1)
+    a_def.location.should eq Location.new("", line_number: 2, column_number: 3)
+    a_def.body.location.should eq Location.new("", line_number: 3, column_number: 5)
   end
 end

--- a/spec/compiler/semantic/splat_spec.cr
+++ b/spec/compiler/semantic/splat_spec.cr
@@ -819,7 +819,14 @@ describe "Semantic: splat" do
   end
 
   it "doesn't shift a call's location", focus: true do
-    result = semantic %(class Foo\ndef bar(x)\nbar(*{"test"})\nend\nend\nFoo.new.bar("test"))
+    result = semantic <<-CR
+      class Foo
+      def bar(x)
+      bar(*{"test"})
+      end
+      end
+      Foo.new.bar("test")
+      CR
     program = result.program
     a_typ = program.types["Foo"].as(NonGenericClassType)
     a_def = a_typ.def_instances.values[0]

--- a/src/compiler/crystal/semantic/main_visitor.cr
+++ b/src/compiler/crystal/semantic/main_visitor.cr
@@ -1454,7 +1454,7 @@ module Crystal
       end
 
       exps << expanded
-      expansion = Expressions.from(exps)
+      expansion = Expressions.from(exps).at(expanded)
       expansion.accept self
       node.expanded = expansion
       node.bind_to(expanded)


### PR DESCRIPTION
This used to report the call's location incorrectly:

         \/here
     bar(*{"test"})
    /\not here

The added spec used to fail:

```
Failures:

  1) Semantic: splat doesn't shift a call's location
     Failure/Error: a_def.body.location.should eq Location.new("", line_number: 3, column_number: 1)

       Expected: :3:1
            got: :3:6

     # spec/compiler/semantic/splat_spec.cr:828
```