### PR TITLE
Clarify behaviour of unsafe `Float`-to-number conversions

### DIFF
--- a/src/primitives.cr
+++ b/src/primitives.cr
@@ -288,7 +288,11 @@ end
         end
 
         # Returns `self` converted to `{{type}}`.
-        # In case of overflow a wrapping is performed.
+        # In case of overflow
+        # {% if ints.includes?(num) %} a wrapping is performed.
+        # {% elsif type < Int %} the result is undefined.
+        # {% else %} infinity is returned.
+        # {% end %}
         @[Primitive(:unchecked_convert)]
         def {{name.id}}! : {{type}}
         end


### PR DESCRIPTION
Closes #10629.

Float-to-float overflow is defined by LLVM; [`fptrunc`](https://llvm.org/docs/LangRef.html#fptrunc-to-instruction) "is assumed to execute in the default floating-point environment", which will produce infinities, in contrast to `Float`-to-integers that return a poison value.