### PR TITLE
Fix return type restriction for `Number#humanize` overload

### DIFF
--- a/src/humanize.cr
+++ b/src/humanize.cr
@@ -239,7 +239,7 @@ struct Number
   end
 
   # :ditto:
-  def humanize(precision = 3, separator = '.', delimiter = ',', *, base = 10 ** 3, significant = true, prefixes : Proc) : Nil
+  def humanize(precision = 3, separator = '.', delimiter = ',', *, base = 10 ** 3, significant = true, prefixes : Proc) : String
     String.build do |io|
       humanize(io, precision, separator, delimiter, base: base, significant: significant, prefixes: prefixes)
     end


### PR DESCRIPTION
A smaller alternative to #10591 that only changes the return type restriction.

As noted in that PR, this overload is currently not callable due to the existing overload ordering rules, so this is still a documentation change more than a bug fix.