### PR TITLE
Bump distribution-scripts

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -144,7 +144,7 @@ jobs:
       - run: |
           git clone https://github.com/crystal-lang/distribution-scripts.git ~/distribution-scripts
           cd ~/distribution-scripts
-          git checkout 4caf7cd337087e2ae313b8c7e00be247d34482ad
+          git checkout e5f21df883d800e9e68f63b79cf796696f905cf1
       # persist relevant information for build process
       - run: |
           cd ~/distribution-scripts


### PR DESCRIPTION
* Fix static executable specs (https://github.com/crystal-lang/distribution-scripts/pull/88)
* Remove compilation of libcrystal.a (https://github.com/crystal-lang/distribution-scripts/pull/87)
* Update Dockerfile to alpine 3.13 (https://github.com/crystal-lang/distribution-scripts/pull/79, https://github.com/crystal-lang/distribution-scripts/pull/81, https://github.com/crystal-lang/distribution-scripts/pull/80)