### PR TITLE
Remove .dockerignore

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,3 +1,0 @@
-.git
-.crystal
-.vagrant


### PR DESCRIPTION
There was a change to move Dockerfiles to separate repositories in https://github.com/crystal-lang/crystal/pull/6141.
It does not make sense to keep the `.dockerignore`. 
The last change was 6 years ago.