### PR TITLE
Add method to create a cookie from a header string

### DIFF
--- a/spec/std/http/cookie_spec.cr
+++ b/spec/std/http/cookie_spec.cr
@@ -16,9 +16,9 @@ end
 
 module HTTP
   describe Cookie do
-    describe ".from_header" do
+    describe ".from_set_cookie_header" do
       it "returns a cookie based on the provided header string" do
-        cookie = HTTP::Cookie.from_header "id=a3fWa; Expires=Wed, 21 Oct 2015 07:28:00 GMT; Secure; SameSite=Lax"
+        cookie = HTTP::Cookie.from_set_cookie_header "id=a3fWa; Expires=Wed, 21 Oct 2015 07:28:00 GMT; Secure; SameSite=Lax"
         cookie.name.should eq "id"
         cookie.secure.should be_true
         (cookie.samesite.should_not be_nil).lax?.should be_true
@@ -26,8 +26,8 @@ module HTTP
       end
 
       it "raises if the cookie header is invalid" do
-        expect_raises ArgumentError, "Invalid cookie header: foo:bar." do
-          HTTP::Cookie.from_header "foo:bar"
+        expect_raises ArgumentError, "Invalid set-cookie header: foo:bar." do
+          HTTP::Cookie.from_set_cookie_header "foo:bar"
         end
       end
     end

--- a/spec/std/http/cookie_spec.cr
+++ b/spec/std/http/cookie_spec.cr
@@ -16,18 +16,20 @@ end
 
 module HTTP
   describe Cookie do
-    it "#==" do
-      cookie = Cookie.new("a", "b", path: "/path", expires: Time.utc, domain: "domain", secure: true, http_only: true, samesite: :strict, extension: "foo=bar")
-      cookie.should eq(cookie.dup)
-      cookie.should_not eq(cookie.dup.tap { |c| c.name = "c" })
-      cookie.should_not eq(cookie.dup.tap { |c| c.value = "c" })
-      cookie.should_not eq(cookie.dup.tap { |c| c.path = "/c" })
-      cookie.should_not eq(cookie.dup.tap { |c| c.domain = "c" })
-      cookie.should_not eq(cookie.dup.tap { |c| c.expires = Time.utc(2021, 1, 1) })
-      cookie.should_not eq(cookie.dup.tap { |c| c.secure = false })
-      cookie.should_not eq(cookie.dup.tap { |c| c.http_only = false })
-      cookie.should_not eq(cookie.dup.tap { |c| c.samesite = :lax })
-      cookie.should_not eq(cookie.dup.tap { |c| c.extension = nil })
+    describe ".from_header" do
+      it "returns a cookie based on the provided header string" do
+        cookie = HTTP::Cookie.from_header "id=a3fWa; Expires=Wed, 21 Oct 2015 07:28:00 GMT; Secure; SameSite=Lax"
+        cookie.name.should eq "id"
+        cookie.secure.should be_true
+        (cookie.samesite.should_not be_nil).lax?.should be_true
+        cookie.expires.should eq Time.utc 2015, 10, 21, 7, 28, 0
+      end
+
+      it "raises if the cookie header is invalid" do
+        expect_raises ArgumentError, "Invalid cookie header: foo:bar." do
+          HTTP::Cookie.from_header "foo:bar"
+        end
+      end
     end
 
     describe ".new" do
@@ -47,6 +49,20 @@ module HTTP
         end
         # more extensive specs on #value=
       end
+    end
+
+    it "#==" do
+      cookie = Cookie.new("a", "b", path: "/path", expires: Time.utc, domain: "domain", secure: true, http_only: true, samesite: :strict, extension: "foo=bar")
+      cookie.should eq(cookie.dup)
+      cookie.should_not eq(cookie.dup.tap { |c| c.name = "c" })
+      cookie.should_not eq(cookie.dup.tap { |c| c.value = "c" })
+      cookie.should_not eq(cookie.dup.tap { |c| c.path = "/c" })
+      cookie.should_not eq(cookie.dup.tap { |c| c.domain = "c" })
+      cookie.should_not eq(cookie.dup.tap { |c| c.expires = Time.utc(2021, 1, 1) })
+      cookie.should_not eq(cookie.dup.tap { |c| c.secure = false })
+      cookie.should_not eq(cookie.dup.tap { |c| c.http_only = false })
+      cookie.should_not eq(cookie.dup.tap { |c| c.samesite = :lax })
+      cookie.should_not eq(cookie.dup.tap { |c| c.extension = nil })
     end
 
     describe "#name=" do

--- a/src/http/cookie.cr
+++ b/src/http/cookie.cr
@@ -27,14 +27,14 @@ module HTTP
 
     def_equals_and_hash name, value, path, expires, domain, secure, http_only, samesite, extension
 
-    # Parses a `Cookie` from the provided *header*.
+    # Parses a `Cookie` from the provided `set-cookie` *header*.
     #
     # Raises an `ArgumentError` if the *header* fails to parse.
     #
     # ```
     # require "http/cookie"
     #
-    # HTTP::Cookie.from_header "id=a3fWa; Expires=Wed, 21 Oct 2015 07:28:00 GMT; Secure; SameSite=Lax" # =>
+    # HTTP::Cookie.from_set_cookie_header "id=a3fWa; Expires=Wed, 21 Oct 2015 07:28:00 GMT; Secure; SameSite=Lax" # =>
     # # <HTTP::Cookie:0x7f684eb29770
     # # @domain=nil,
     # # @expires=2015-10-21 07:28:00.0 UTC,
@@ -46,9 +46,9 @@ module HTTP
     # # @secure=true,
     # # @value="a3fWa">
     # ```
-    def self.from_header(header : String) : self
+    def self.from_set_cookie_header(header : String) : self
       unless cookie = Parser.parse_set_cookie header
-        raise ArgumentError.new "Invalid cookie header: #{header}."
+        raise ArgumentError.new "Invalid set-cookie header: #{header}."
       end
 
       cookie

--- a/src/http/cookie.cr
+++ b/src/http/cookie.cr
@@ -27,6 +27,33 @@ module HTTP
 
     def_equals_and_hash name, value, path, expires, domain, secure, http_only, samesite, extension
 
+    # Parses a `Cookie` from the provided *header*.
+    #
+    # Raises an `ArgumentError` if the *header* fails to parse.
+    #
+    # ```
+    # require "http/cookie"
+    #
+    # HTTP::Cookie.from_header "id=a3fWa; Expires=Wed, 21 Oct 2015 07:28:00 GMT; Secure; SameSite=Lax" # =>
+    # # <HTTP::Cookie:0x7f684eb29770
+    # # @domain=nil,
+    # # @expires=2015-10-21 07:28:00.0 UTC,
+    # # @extension=nil,
+    # # @http_only=false,
+    # # @name="id",
+    # # @path=nil,
+    # # @samesite=Lax,
+    # # @secure=true,
+    # # @value="a3fWa">
+    # ```
+    def self.from_header(header : String) : self
+      unless cookie = Parser.parse_set_cookie header
+        raise ArgumentError.new "Invalid cookie header: #{header}."
+      end
+
+      cookie
+    end
+
     # Creates a new `Cookie` instance.
     #
     # Raises `IO::Error` if *name* or *value* are invalid as per [RFC 6265 §4.1.1](https://tools.ietf.org/html/rfc6265#section-4.1.1).


### PR DESCRIPTION
Basically introduces a public API to the internal `HTTP::Cookie::Parser`.