### PR TITLE
Improve error handling for `load_localtime` on unix

### DIFF
--- a/src/crystal/system/unix/time.cr
+++ b/src/crystal/system/unix/time.cr
@@ -54,7 +54,7 @@ module Crystal::System::Time
   end
 
   def self.load_localtime : ::Time::Location?
-    if ::File.exists?(LOCALTIME) && ::File.readable?(LOCALTIME) && ::File.file?(LOCALTIME)
+    if ::File.file?(LOCALTIME) && ::File.readable?(LOCALTIME)
       ::File.open(LOCALTIME) do |file|
         ::Time::Location.read_zoneinfo("Local", file)
       rescue ::Time::Location::InvalidTZDataError

--- a/src/crystal/system/unix/time.cr
+++ b/src/crystal/system/unix/time.cr
@@ -54,9 +54,11 @@ module Crystal::System::Time
   end
 
   def self.load_localtime : ::Time::Location?
-    if ::File.exists?(LOCALTIME)
+    if ::File.exists?(LOCALTIME) && ::File.readable?(LOCALTIME) && ::File.file?(LOCALTIME)
       ::File.open(LOCALTIME) do |file|
         ::Time::Location.read_zoneinfo("Local", file)
+      rescue ::Time::Location::InvalidTZDataError
+        nil
       end
     end
   end


### PR DESCRIPTION
Adds checks that `/etc/localtime` is actually a file and readable, and ignores errors caused by invalid file format.

Resolves #10651