### PR TITLE
Fix `Path#sibling` return type

### DIFF
--- a/src/path.cr
+++ b/src/path.cr
@@ -959,7 +959,7 @@ struct Path
   # Resolves path *name* in this path's parent directory.
   #
   # Raises `Path::Error` if `#parent` is `nil`.
-  def sibling(name : Path | String) : Path?
+  def sibling(name : Path | String) : Path
     if parent = self.parent
       parent.join(name)
     else


### PR DESCRIPTION
There's no way for that method to return `nil`.