### PR TITLE
[doc] Remove superclass from ASTNode in API docs

### DIFF
--- a/spec/compiler/crystal/tools/doc/type_spec.cr
+++ b/spec/compiler/crystal/tools/doc/type_spec.cr
@@ -117,6 +117,5 @@ describe Doc::Type do
       # Sanity check: subclasses of ASTNode has the right superclass
       generator.type(macros_module.types["Arg"]).superclass.should eq(astnode)
     end
-
   end
 end

--- a/spec/compiler/crystal/tools/doc/type_spec.cr
+++ b/spec/compiler/crystal/tools/doc/type_spec.cr
@@ -97,5 +97,26 @@ describe Doc::Type do
       foo = generator.type(program.types["Foo"])
       foo.node_to_html("Foo".path(global: true)).should eq(%(<a href="Foo.html">Foo</a>))
     end
+
+    it "ASTNode has no superclass" do
+      program = semantic(<<-CODE).program
+        module Crystal
+          module Macros
+            class ASTNode
+            end
+            class Arg < ASTNode
+            end
+          end
+        end
+        CODE
+
+      generator = Doc::Generator.new program, [""]
+      macros_module = program.types["Crystal"].types["Macros"]
+      astnode = generator.type(macros_module.types["ASTNode"])
+      astnode.superclass.should eq(nil)
+      # Sanity check: subclasses of ASTNode has the right superclass
+      generator.type(macros_module.types["Arg"]).superclass.should eq(astnode)
+    end
+
   end
 end

--- a/src/compiler/crystal/tools/doc/type.cr
+++ b/src/compiler/crystal/tools/doc/type.cr
@@ -89,7 +89,7 @@ class Crystal::Doc::Type
   def superclass
     case type = @type
     when ClassType
-      superclass = type.superclass
+      superclass = type.superclass unless type.full_name == Crystal::Macros::ASTNode.name
     when GenericClassInstanceType
       superclass = type.superclass
     end


### PR DESCRIPTION
Fixes #9932 by avoiding the inclusion of any superclass of ASTNode in the generation of docs.

Check the discussion in PR #9965 (if this is approved, said PR should be rejected).