### PR TITLE
Add `NamedTuple#key_for?` and `NamedTuple#key_for`

### DIFF
--- a/spec/std/named_tuple_spec.cr
+++ b/spec/std/named_tuple_spec.cr
@@ -165,6 +165,46 @@ describe "NamedTuple" do
     end
   end
 
+  describe "key_for" do
+    it "returns the first key with the given value" do
+      h = {foo: "bar", baz: "qux"}
+      h.key_for("bar").should eq(:foo)
+      h.key_for("qux").should eq(:baz)
+    end
+
+    it "raises when no key pairs with the given value" do
+      expect_raises KeyError do
+        {foo: "bar"}.key_for("qux")
+      end
+    end
+
+    describe "if block is given," do
+      it "returns the first key with the given value" do
+        h = {foo: "bar", baz: "bar"}
+        h.key_for("bar") { |value| value.upcase }.should eq(:foo)
+      end
+
+      it "yields the argument if no hash key pairs with the value" do
+        h = {foo: "bar"}
+        h.key_for("qux") { |value| value.upcase }.should eq("QUX")
+      end
+    end
+  end
+
+  describe "key_for?" do
+    it "returns the first key with the given value" do
+      h = {foo: "bar", baz: "qux"}
+      h.key_for?("bar").should eq(:foo)
+      h.key_for?("qux").should eq(:baz)
+    end
+
+    it "returns nil if no key pairs with the given value" do
+      h = {foo: "bar", baz: "qux"}
+      h.key_for?("foobar").should eq nil
+      h.key_for?("bazqux").should eq nil
+    end
+  end
+
   describe "dig" do
     it "gets the value at given path given splat" do
       h = {a: {b: {c: [10, 20]}}, x: {a: "b", c: nil}}

--- a/src/named_tuple.cr
+++ b/src/named_tuple.cr
@@ -219,6 +219,47 @@ struct NamedTuple
     yield
   end
 
+  # Returns a key with the given *value*, else raises `KeyError`.
+  #
+  # ```
+  # tuple = {foo: "bar", baz: "qux"}
+  # tuple.key_for("bar")    # => "foo"
+  # tuple.key_for("qux")    # => "baz"
+  # tuple.key_for("foobar") # raises KeyError (Missing named tuple key for value: foobar)
+  # tuple = {name: "Crystal", year: 2011}
+  # tuple.key_for("Crystal")          # => :name
+  # tuple.key_forfetch("other") { 0 } # => 0
+  # ```
+  def key_for(value) : Symbol
+    key_for(value) { raise KeyError.new "Missing named tuple key for value: #{value}" }
+  end
+
+  # Returns a key with the given *value*, else `nil`.
+  #
+  # ```
+  # tuple = {foo: "bar", baz: "qux"}
+  # tuple.key_for?("bar")    # => "foo"
+  # tuple.key_for?("qux")    # => "baz"
+  # tuple.key_for?("foobar") # => nil
+  # ```
+  def key_for?(value)
+    key_for(value) { nil }
+  end
+
+  # Returns a key with the given *value*, else yields *value* with the given block.
+  #
+  # ```
+  # tuple = {"foo" => "bar"}
+  # tuple.key_for("bar") { |value| value.upcase } # => "foo"
+  # tuple.key_for("qux") { |value| value.upcase } # => "QUX"
+  # ```
+  def key_for(value)
+    each do |k, v|
+      return k if v == value
+    end
+    yield value
+  end
+
   # Merges two named tuples into one, returning a new named tuple.
   # If a key is defined in both tuples, the value and its type is used from *other*.
   #

--- a/src/named_tuple.cr
+++ b/src/named_tuple.cr
@@ -223,12 +223,10 @@ struct NamedTuple
   #
   # ```
   # tuple = {foo: "bar", baz: "qux"}
-  # tuple.key_for("bar")    # => "foo"
-  # tuple.key_for("qux")    # => "baz"
-  # tuple.key_for("foobar") # raises KeyError (Missing named tuple key for value: foobar)
-  # tuple = {name: "Crystal", year: 2011}
-  # tuple.key_for("Crystal")          # => :name
-  # tuple.key_forfetch("other") { 0 } # => 0
+  # tuple.key_for("bar")          # => :foo
+  # tuple.key_for("qux")          # => :baz
+  # tuple.key_for("foobar")       # raises KeyError (Missing named tuple key for value: foobar)
+  # tuple.key_for("foobar") { 0 } # => 0
   # ```
   def key_for(value) : Symbol
     key_for(value) { raise KeyError.new "Missing named tuple key for value: #{value}" }
@@ -238,19 +236,19 @@ struct NamedTuple
   #
   # ```
   # tuple = {foo: "bar", baz: "qux"}
-  # tuple.key_for?("bar")    # => "foo"
-  # tuple.key_for?("qux")    # => "baz"
+  # tuple.key_for?("bar")    # => :foo
+  # tuple.key_for?("qux")    # => :baz
   # tuple.key_for?("foobar") # => nil
   # ```
-  def key_for?(value)
+  def key_for?(value) : Symbol?
     key_for(value) { nil }
   end
 
   # Returns a key with the given *value*, otherwise yields *value* to the given block.
   #
   # ```
-  # tuple = {"foo" => "bar"}
-  # tuple.key_for("bar") { |value| value.upcase } # => "foo"
+  # tuple = {foo: "bar"}
+  # tuple.key_for("bar") { |value| value.upcase } # => :foo
   # tuple.key_for("qux") { |value| value.upcase } # => "QUX"
   # ```
   def key_for(value)

--- a/src/named_tuple.cr
+++ b/src/named_tuple.cr
@@ -219,7 +219,7 @@ struct NamedTuple
     yield
   end
 
-  # Returns a key with the given *value*, else raises `KeyError`.
+  # Returns a key with the given *value*, otherwise raises `KeyError`.
   #
   # ```
   # tuple = {foo: "bar", baz: "qux"}
@@ -234,7 +234,7 @@ struct NamedTuple
     key_for(value) { raise KeyError.new "Missing named tuple key for value: #{value}" }
   end
 
-  # Returns a key with the given *value*, else `nil`.
+  # Returns a key with the given *value*, otherwise `nil`.
   #
   # ```
   # tuple = {foo: "bar", baz: "qux"}
@@ -246,7 +246,7 @@ struct NamedTuple
     key_for(value) { nil }
   end
 
-  # Returns a key with the given *value*, else yields *value* with the given block.
+  # Returns a key with the given *value*, otherwise yields *value* to the given block.
   #
   # ```
   # tuple = {"foo" => "bar"}


### PR DESCRIPTION
Adding an extension to `NamedTuple` that I've used in the past in case there is interest.

Adds...
- `NamedTuple#key_for : Symbol`
- `NamedTuple#key_for? : Symbol?`