### PR TITLE
Add section about pull requests to the contributing guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -125,7 +125,6 @@ the specs. All specs should pass. You can use `make help` for a list of availabl
 
 If this guide is not clear and it needs improvements, please send pull requests against it. Thanks! :-)
 
-
 ## Making good pull requests
 
 The commit history should consist of commits that transform the codebase from one state into another one, motivated by something that
@@ -138,6 +137,35 @@ fixup commits. Please do not amend previous commits and force push to the PR bra
 because reference to previous state is hidden.
 
 If changes introduced to `master` branch result in conflicts, it should be merged with a merge commit (`git fetch upstream/master; git merge upstream/master`).
+
+### Minimum requirements
+
+1. Describe reasons and result of the change in the pull request comment.
+2. Do not force push to a pull request. The development history should be easily traceable.
+3. Any change to a public API requires appropriate documentation: params (and particularly interesting combinations of them if the method is complex), results, interesting, self-contained examples.
+4. Any change to behaviour needs to be reflected and validated with specs.
+5. Any change affecting the compiler or performance-critical features in the standard library
+   should be checked with benchmarks how it affects performance.
+
+### Approval Process
+
+1. To be accepted, a pull request requires recent approvals from at least two core team members; if the author is a core team
+   member, this counts as one approval. Approvals only count when based on the current code version (except for minor changes like fixing a typo).
+2. When the required approvals are given and CI is satisfied, a core team member can add the pull request to the
+   current development milestone. This signals that it is scheduled to be merged soon and gives another chance for final reviews.
+3. The wait time in this state depends on the gravity of the change and the activity of the previous discussion,
+   but it should at least be a full business day after the milestone was added.
+4. Before merging, make sure the pull request is properly labeled and its title appropriately describes the change.
+4. Finally, the pull request can be merged. Use squash merge to not pollute the version history of the main branch with
+   details of the pull request process. For non-trivial changes, the merge commit should contain a short description.
+
+This process is a guideline and not a strict rule so there might be occasional exceptions within reason.
+Urgent infrastructure fixes for example can be expected to skip the line.
+
+### For maintainers with push access
+
+1. Do not directly commit to the `master` branch. Always create a feature branch and pull request.
+2. Feature branches should typically be created in your fork. The main repo should only contain essential branches.
 
 ## Git pre-commit hook
 


### PR DESCRIPTION
This is an updated version of the wiki page [*Merging PRs*](https://github.com/crystal-lang/crystal/wiki/Merging-PRs) documenting the process as described in [Approval and Merging process](https://forum.crystal-lang.org/t/approval-and-merging-process/2020).
The wiki is not very accessible and mentioning such processes in the contrib guide seems a good idea.

Preview at https://github.com/straight-shoota/crystal/blob/docs/contributing-pull-requests/CONTRIBUTING.md#minimum-requirements