### PR TITLE
[CI] Publish nightly builds to OBS

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -350,7 +350,7 @@ jobs:
             export PAGER=cat
 
             packages/obs-setup.sh
-            packages/obs-push.sh home:straight-shoota:Crystal:nightly $CRYSTAL_VERSION $(date '+%Y%m%d') $CRYSTAL_SHA1 \
+            packages/obs-push.sh home:straight-shoota:Crystal:nightly ${CRYSTAL_VERSION%-*} $(date '+%Y%m%d') $CRYSTAL_SHA1 \
                 /tmp/workspace/build/crystal-*-linux-x86_64.tar.gz \
                 /tmp/workspace/build/crystal-*-linux-i686.tar.gz \
                 /tmp/workspace/build/crystal-*-docs.tar.gz

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -346,6 +346,9 @@ jobs:
           command: |
             cd /tmp/workspace/distribution-scripts
             source build.env
+            # osc may try to use a pager, even if stdout is not a TTY,
+            # cat avoids stalling on that.
+            export PAGER=cat
 
             packages/obs-setup.sh
             packages/obs-push.sh home:straight-shoota:Crystal:nightly $CRYSTAL_VERSION $(date '+%Y%m%d') $CRYSTAL_SHA1 \

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -239,7 +239,7 @@ jobs:
 
           # How to brand it
           export VERSION=${CIRCLE_BRANCH/release\//}
-          export VERSION=${VERSION/\//-}-dev
+          export VERSION=${VERSION//\//-}-dev
           echo "export CRYSTAL_VERSION=$VERSION" >> build.env
           echo "export DOCKER_TAG=$VERSION" >> build.env
 
@@ -374,7 +374,7 @@ jobs:
             export PAGER=cat
 
             packages/obs-setup.sh
-            packages/obs-push.sh devel:languages:crystal:unstable ${CRYSTAL_NEXT_VERSION%-*} ${CRYSTAL_VERSION/-/} $CRYSTAL_SHA1 \
+            packages/obs-push.sh devel:languages:crystal:unstable ${CRYSTAL_NEXT_VERSION%-*} ${CRYSTAL_VERSION//-/} $CRYSTAL_SHA1 \
                 /tmp/workspace/build/crystal-*-linux-x86_64.tar.gz \
                 /tmp/workspace/build/crystal-*-linux-i686.tar.gz \
                 /tmp/workspace/build/crystal-*-docs.tar.gz

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -144,7 +144,7 @@ jobs:
       - run: |
           git clone https://github.com/crystal-lang/distribution-scripts.git ~/distribution-scripts
           cd ~/distribution-scripts
-          git checkout 8cb711986432b0d13ed0eb12229d5d4ef1cc0be3
+          git checkout 6a6d063916206848775f31d6090533d3ca47bc38
       # persist relevant information for build process
       - run: |
           cd ~/distribution-scripts

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -144,7 +144,7 @@ jobs:
       - run: |
           git clone https://github.com/crystal-lang/distribution-scripts.git ~/distribution-scripts
           cd ~/distribution-scripts
-          git checkout 6a6d063916206848775f31d6090533d3ca47bc38
+          git checkout 8307d8d2e8fea4c8dd64ff15877fe0c3027e0d80
       # persist relevant information for build process
       - run: |
           cd ~/distribution-scripts

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -144,7 +144,7 @@ jobs:
       - run: |
           git clone https://github.com/crystal-lang/distribution-scripts.git ~/distribution-scripts
           cd ~/distribution-scripts
-          git checkout c2518d8bbb8bf8f76c0b1600a19d9d9f50b5774d
+          git checkout 8cb711986432b0d13ed0eb12229d5d4ef1cc0be3
       # persist relevant information for build process
       - run: |
           cd ~/distribution-scripts
@@ -336,7 +336,8 @@ jobs:
             - build
 
   dist_obs_nightly:
-    machine: true
+    docker:
+      - image: straightshoota/osc
     steps:
       - attach_workspace:
           at: /tmp/workspace
@@ -347,10 +348,10 @@ jobs:
             source build.env
 
             packages/obs-setup.sh
-            packages/obs-push.sh home:straight-shoota:Crystal:nightly $CRYSTAL_VERSION $(date '+%Y%m%d') $CRYSTAL_SHA \
-                /tmp/workspace/build/crystal-$CRYSTAL_VERSION-linux-x86_64.tar.gz \
-                /tmp/workspace/build/crystal-$CRYSTAL_VERSION-linux-i686.tar.gz \
-                /tmp/workspace/build/crystal-$CRYSTAL_VERSION-docs.tar.gz
+            packages/obs-push.sh home:straight-shoota:Crystal:nightly $CRYSTAL_VERSION $(date '+%Y%m%d') $CRYSTAL_SHA1 \
+                /tmp/workspace/build/crystal-*-linux-x86_64.tar.gz \
+                /tmp/workspace/build/crystal-*-linux-i686.tar.gz \
+                /tmp/workspace/build/crystal-*-docs.tar.gz
 
   dist_docker:
     machine: true
@@ -586,13 +587,6 @@ workflows:
             - dist_docs
 
   nightly_release:
-    triggers:
-      - schedule:
-          cron: "0 0 * * *"
-          filters:
-            branches:
-              only:
-                - master
     jobs:
       - test_linux
       - test_linux32_std
@@ -722,11 +716,6 @@ workflows:
             - dist_linux32
             - dist_darwin
             - dist_snap
-            - dist_docs
-      - dist_obs_nightly:
-          requires:
-            - dist_linux
-            - dist_linux32
             - dist_docs
 
   package_build:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -339,7 +339,7 @@ jobs:
           paths:
             - build
 
-  dist_obs_nightly:
+  push_obs_nightly:
     docker:
       - image: straightshoota/osc
     steps:
@@ -359,7 +359,7 @@ jobs:
                 /tmp/workspace/build/crystal-*-linux-i686.tar.gz \
                 /tmp/workspace/build/crystal-*-docs.tar.gz
 
-  dist_obs_maintenance:
+  push_obs_maintenance:
     docker:
       - image: straightshoota/osc
     steps:
@@ -639,7 +639,7 @@ workflows:
       - dist_darwin:
           requires:
             - prepare_nightly
-      - dist_obs_nightly:
+      - push_obs_nightly:
           requires:
             - dist_linux
             - dist_linux32
@@ -742,7 +742,7 @@ workflows:
           filters: *maintenance
           requires:
             - dist_docker
-      - dist_obs_maintenance:
+      - push_obs_maintenance:
           requires:
             - dist_linux
             - dist_linux32

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -144,7 +144,7 @@ jobs:
       - run: |
           git clone https://github.com/crystal-lang/distribution-scripts.git ~/distribution-scripts
           cd ~/distribution-scripts
-          git checkout e5f21df883d800e9e68f63b79cf796696f905cf1
+          git checkout c2518d8bbb8bf8f76c0b1600a19d9d9f50b5774d
       # persist relevant information for build process
       - run: |
           cd ~/distribution-scripts
@@ -335,7 +335,7 @@ jobs:
           paths:
             - build
 
-  dist_bintray_nightly:
+  dist_obs_nightly:
     machine: true
     steps:
       - attach_workspace:
@@ -345,13 +345,12 @@ jobs:
           command: |
             cd /tmp/workspace/distribution-scripts
             source build.env
-            cd bintray
-            ./publish-nightly.sh $CRYSTAL_VERSION $(date '+%Y-%m-%d') \
-                /tmp/workspace/build/crystal-*-linux-x86_64.tar.gz \
-                /tmp/workspace/build/crystal-*-linux-i686.tar.gz
-      - store_artifacts:
-          path: /tmp/workspace/distribution-scripts/bintray/build/unsigned
-          destination: unsigned
+
+            packages/obs-setup.sh
+            packages/obs-push.sh home:straight-shoota:Crystal:nightly $CRYSTAL_VERSION $(date '+%Y%m%d') $CRYSTAL_SHA \
+                /tmp/workspace/build/crystal-$CRYSTAL_VERSION-linux-x86_64.tar.gz \
+                /tmp/workspace/build/crystal-$CRYSTAL_VERSION-linux-i686.tar.gz \
+                /tmp/workspace/build/crystal-$CRYSTAL_VERSION-docs.tar.gz
 
   dist_docker:
     machine: true
@@ -613,10 +612,11 @@ workflows:
       - dist_darwin:
           requires:
             - prepare_nightly
-      - dist_bintray_nightly:
+      - dist_obs_nightly:
           requires:
             - dist_linux
             - dist_linux32
+            - dist_docs
       - dist_docker:
           requires:
             - dist_linux

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -144,7 +144,7 @@ jobs:
       - run: |
           git clone https://github.com/crystal-lang/distribution-scripts.git ~/distribution-scripts
           cd ~/distribution-scripts
-          git checkout 8307d8d2e8fea4c8dd64ff15877fe0c3027e0d80
+          git checkout 2d7716ae3d1a28130d7f681de8510e46bd6f6638
       # persist relevant information for build process
       - run: |
           cd ~/distribution-scripts

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -723,6 +723,11 @@ workflows:
             - dist_darwin
             - dist_snap
             - dist_docs
+      - dist_obs_nightly:
+          requires:
+            - dist_linux
+            - dist_linux32
+            - dist_docs
 
   package_build:
     jobs:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -349,9 +349,6 @@ jobs:
           command: |
             cd /tmp/workspace/distribution-scripts
             source build.env
-            # osc may try to use a pager, even if stdout is not a TTY,
-            # cat avoids stalling on that.
-            export PAGER=cat
 
             packages/obs-setup.sh
             packages/obs-push.sh devel:languages:crystal:nightly ${CRYSTAL_VERSION%-*} $(date '+%Y%m%d') $CRYSTAL_SHA1 \

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -589,6 +589,13 @@ workflows:
             - dist_docs
 
   nightly_release:
+    triggers:
+      - schedule:
+          cron: "0 0 * * *"
+          filters:
+            branches:
+              only:
+                - master
     jobs:
       - test_linux
       - test_linux32_std

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -230,10 +230,6 @@ jobs:
     steps:
       - attach_workspace:
           at: /tmp/workspace
-      - checkout
-      - run: |
-          # CRYSTAL_NEXT_VERSION uses src/VERSION to publish maintenance releases as prereleases
-          echo "export CRYSTAL_NEXT_VERSION=$(cat src/VERSION)" >> /tmp/workspace/distribution-scripts/build.env
       - run: |
           cd /tmp/workspace/distribution-scripts
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -342,7 +342,6 @@ jobs:
       - attach_workspace:
           at: /tmp/workspace
       - run:
-          no_output_timeout: 20m
           command: |
             cd /tmp/workspace/distribution-scripts
             source build.env

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -230,6 +230,10 @@ jobs:
     steps:
       - attach_workspace:
           at: /tmp/workspace
+      - checkout
+      - run: |
+          # CRYSTAL_NEXT_VERSION uses src/VERSION to publish maintenance releases as prereleases
+          echo "export CRYSTAL_NEXT_VERSION=$(cat src/VERSION)" >> /tmp/workspace/distribution-scripts/build.env
       - run: |
           cd /tmp/workspace/distribution-scripts
 
@@ -351,6 +355,26 @@ jobs:
 
             packages/obs-setup.sh
             packages/obs-push.sh devel:languages:crystal:nightly ${CRYSTAL_VERSION%-*} $(date '+%Y%m%d') $CRYSTAL_SHA1 \
+                /tmp/workspace/build/crystal-*-linux-x86_64.tar.gz \
+                /tmp/workspace/build/crystal-*-linux-i686.tar.gz \
+                /tmp/workspace/build/crystal-*-docs.tar.gz
+
+  dist_obs_maintenance:
+    docker:
+      - image: straightshoota/osc
+    steps:
+      - attach_workspace:
+          at: /tmp/workspace
+      - run:
+          command: |
+            cd /tmp/workspace/distribution-scripts
+            source build.env
+            # osc may try to use a pager, even if stdout is not a TTY,
+            # cat avoids stalling on that.
+            export PAGER=cat
+
+            packages/obs-setup.sh
+            packages/obs-push.sh devel:languages:crystal:nightly ${CRYSTAL_NEXT_VERSION%-*} ${CRYSTAL_VERSION} $CRYSTAL_SHA1 \
                 /tmp/workspace/build/crystal-*-linux-x86_64.tar.gz \
                 /tmp/workspace/build/crystal-*-linux-i686.tar.gz \
                 /tmp/workspace/build/crystal-*-docs.tar.gz
@@ -718,6 +742,11 @@ workflows:
           filters: *maintenance
           requires:
             - dist_docker
+      - dist_obs_maintenance:
+          requires:
+            - dist_linux
+            - dist_linux32
+            - dist_docs
       - dist_artifacts:
           filters: *maintenance
           requires:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -356,26 +356,6 @@ jobs:
                 /tmp/workspace/build/crystal-*-linux-i686.tar.gz \
                 /tmp/workspace/build/crystal-*-docs.tar.gz
 
-  push_obs_maintenance:
-    docker:
-      - image: crystallang/osc
-    steps:
-      - attach_workspace:
-          at: /tmp/workspace
-      - run:
-          command: |
-            cd /tmp/workspace/distribution-scripts
-            source build.env
-            # osc may try to use a pager, even if stdout is not a TTY,
-            # cat avoids stalling on that.
-            export PAGER=cat
-
-            packages/obs-setup.sh
-            packages/obs-push.sh devel:languages:crystal:unstable ${CRYSTAL_NEXT_VERSION%-*} ${CRYSTAL_VERSION//-/} $CRYSTAL_SHA1 \
-                /tmp/workspace/build/crystal-*-linux-x86_64.tar.gz \
-                /tmp/workspace/build/crystal-*-linux-i686.tar.gz \
-                /tmp/workspace/build/crystal-*-docs.tar.gz
-
   dist_docker:
     machine: true
     steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -374,7 +374,7 @@ jobs:
             export PAGER=cat
 
             packages/obs-setup.sh
-            packages/obs-push.sh devel:languages:crystal:nightly ${CRYSTAL_NEXT_VERSION%-*} ${CRYSTAL_VERSION} $CRYSTAL_SHA1 \
+            packages/obs-push.sh devel:languages:crystal:unstable ${CRYSTAL_NEXT_VERSION%-*} ${CRYSTAL_VERSION/-/} $CRYSTAL_SHA1 \
                 /tmp/workspace/build/crystal-*-linux-x86_64.tar.gz \
                 /tmp/workspace/build/crystal-*-linux-i686.tar.gz \
                 /tmp/workspace/build/crystal-*-docs.tar.gz

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -350,7 +350,7 @@ jobs:
             export PAGER=cat
 
             packages/obs-setup.sh
-            packages/obs-push.sh home:straight-shoota:Crystal:nightly ${CRYSTAL_VERSION%-*} $(date '+%Y%m%d') $CRYSTAL_SHA1 \
+            packages/obs-push.sh devel:languages:crystal:nightly ${CRYSTAL_VERSION%-*} $(date '+%Y%m%d') $CRYSTAL_SHA1 \
                 /tmp/workspace/build/crystal-*-linux-x86_64.tar.gz \
                 /tmp/workspace/build/crystal-*-linux-i686.tar.gz \
                 /tmp/workspace/build/crystal-*-docs.tar.gz

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -341,7 +341,7 @@ jobs:
 
   push_obs_nightly:
     docker:
-      - image: straightshoota/osc
+      - image: crystallang/osc
     steps:
       - attach_workspace:
           at: /tmp/workspace
@@ -358,7 +358,7 @@ jobs:
 
   push_obs_maintenance:
     docker:
-      - image: straightshoota/osc
+      - image: crystallang/osc
     steps:
       - attach_workspace:
           at: /tmp/workspace

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -715,11 +715,6 @@ workflows:
           filters: *maintenance
           requires:
             - dist_docker
-      - push_obs_maintenance:
-          requires:
-            - dist_linux
-            - dist_linux32
-            - dist_docs
       - dist_artifacts:
           filters: *maintenance
           requires:


### PR DESCRIPTION
The base is laid out in https://github.com/crystal-lang/distribution-scripts/pull/94

Maintenance releases are automatically pushed to the unstable channel. I'm not sure if we want that, but it was simple to set up with just duplicating the OBS integration for nightlies.