### PR TITLE
Improve Exception backtrace API

### DIFF
--- a/src/exception/call_stack.cr
+++ b/src/exception/call_stack.cr
@@ -50,12 +50,6 @@ struct Exception::CallStack
     # the column number would be `5`.
     getter column_number : Int32
 
-    # Returns the memory address
-    #
-    # Assuming a frame like `/home/crystal/test.cr:24:5 in 'test_method' at 0x55df02499e76`,
-    # the address would be the hexstring `5df02499e76`.
-    getter address : String?
-
     protected def initialize(
       @file : String,
       @function : String,


### PR DESCRIPTION
Resolves #10681.

Some questions/items that still need to be answered/completed:

1. ~Ideally we should expose the docs of the frame type, but not the `CallStack` type~
  * Probably could move the `:nodoc:` to each method so it appears as just an empty module with the `Frame` type, similar to what we do for `Unicode`.
2. Might want to tweak the API a bit, e.g. what to call the method on `Exception`?
  * Probably `#frames` and/or `#each_frame(&)`?
3. ~Add some specs/docs for the new type/method~
4. Should `file` be nilable versus `"???"` if the file is not known?