### PR TITLE
Fix check_type_allowed_as_proc_argument to show show type name

### DIFF
--- a/spec/compiler/semantic/proc_spec.cr
+++ b/spec/compiler/semantic/proc_spec.cr
@@ -733,7 +733,7 @@ describe "Semantic: proc" do
       )) { int32 }
   end
 
-  %w(Object Value Reference Number Int Float Struct Class Proc Tuple Enum StaticArray Pointer).each do |type|
+  %w(Object Value Reference Number Int Float Struct Proc Tuple Enum StaticArray Pointer).each do |type|
     it "disallows #{type} in procs" do
       assert_error %(
         ->(x : #{type}) { }
@@ -759,6 +759,38 @@ describe "Semantic: proc" do
         ->foo(#{type})
         ),
         "can't use #{type} as a Proc argument type"
+    end
+  end
+
+  describe "Class" do
+    # FIXME: Class reports as Object type in two of these examples.
+    # This should be fixed and the specs inlined with the above.
+    # See https://github.com/crystal-lang/crystal/pull/10688#issuecomment-852931558
+    it "disallows Class in procs" do
+      assert_error %(
+        ->(x : Class) { }
+        ),
+        "can't use Object as a Proc argument type"
+    end
+
+    it "disallows Class in captured block" do
+      assert_error %(
+        def foo(&block : Class ->)
+        end
+
+        foo {}
+        ),
+        "can't use Class as a Proc argument type"
+    end
+
+    it "disallows Class in proc pointer" do
+      assert_error %(
+        def foo(x)
+        end
+
+        ->foo(Class)
+        ),
+        "can't use Object as a Proc argument type"
     end
   end
 

--- a/spec/compiler/semantic/proc_spec.cr
+++ b/spec/compiler/semantic/proc_spec.cr
@@ -738,7 +738,7 @@ describe "Semantic: proc" do
       assert_error %(
         ->(x : #{type}) { }
         ),
-        "as a Proc argument type"
+        "can't use #{type} as a Proc argument type"
     end
 
     it "disallows #{type} in captured block" do
@@ -748,7 +748,7 @@ describe "Semantic: proc" do
 
         foo {}
         ),
-        "as a Proc argument type"
+        "can't use #{type} as a Proc argument type"
     end
 
     it "disallows #{type} in proc pointer" do
@@ -758,7 +758,7 @@ describe "Semantic: proc" do
 
         ->foo(#{type})
         ),
-        "as a Proc argument type"
+        "can't use #{type} as a Proc argument type"
     end
   end
 

--- a/src/compiler/crystal/semantic/ast.cr
+++ b/src/compiler/crystal/semantic/ast.cr
@@ -4,7 +4,6 @@ module Crystal
   def self.check_type_can_be_stored(node, type, msg)
     return if type.can_be_stored?
 
-    type = type.union_types.find { |t| !t.can_be_stored? } if type.is_a?(UnionType)
     node.raise "#{msg} yet, use a more specific type"
   end
 

--- a/src/compiler/crystal/semantic/main_visitor.cr
+++ b/src/compiler/crystal/semantic/main_visitor.cr
@@ -1229,7 +1229,7 @@ module Crystal
     end
 
     def self.check_type_allowed_as_proc_argument(node, type)
-      Crystal.check_type_can_be_stored(node, type, "cannot be used as a Proc argument type")
+      Crystal.check_type_can_be_stored(node, type, "can't use #{type.to_s(generic_args: false)} as a Proc argument type")
     end
 
     def visit(node : ProcPointer)


### PR DESCRIPTION
All other call sites of `check_type_can_be_stored` mention the respective type in the message, only for proc arguments this was missing.

Specs fail because `Class` type restriction sometimes reports as `Object`. Not sure about the reason or if that's intended, but it looks unexpected to me.
```cr
->(x : Class) { } # Can't use Object as a Proc argument type

def foo(&block : Class ->)
end

foo {} # Can't use Class as a Proc argument type

def foo(x)
end

->foo(Class) # Can't use Object as a Proc argument type
```