### PR TITLE
Don't count failed signature matches as autocast matches

### DIFF
--- a/spec/compiler/semantic/automatic_cast_spec.cr
+++ b/spec/compiler/semantic/automatic_cast_spec.cr
@@ -106,6 +106,16 @@ describe "Semantic: automatic cast" do
       )) { int64 }
   end
 
+  it "casts literal integer through union" do
+    assert_type(%(
+      def foo(x : Int64 | String)
+        x
+      end
+
+      foo(12345)
+      )) { int64 }
+  end
+
   it "casts literal integer through alias with union" do
     assert_type(%(
       alias A = Int64 | String
@@ -115,6 +125,30 @@ describe "Semantic: automatic cast" do
       end
 
       foo(12345)
+      )) { int64 }
+  end
+
+  it "casts literal integer through self restriction" do
+    assert_type(%(
+      struct Int64
+        def self.foo(x : self)
+          x
+        end
+      end
+
+      Int64.foo(12345)
+      )) { int64 }
+  end
+
+  it "casts literal integer through generic type argument" do
+    assert_type(%(
+      class Foo(T)
+        def foo(x : T)
+          x
+        end
+      end
+
+      Foo(Int64).new.foo(12345)
       )) { int64 }
   end
 
@@ -177,7 +211,23 @@ describe "Semantic: automatic cast" do
       )) { types["Foo"] }
   end
 
-  it "casts literal integer through alias with union" do
+  it "casts symbol literal through union" do
+    assert_type(%(
+      enum Foo
+        One
+        Two
+        Three
+      end
+
+      def foo(x : Foo | String)
+        x
+      end
+
+      foo(:two)
+      )) { types["Foo"] }
+  end
+
+  it "casts symbol literal through alias with union" do
     assert_type(%(
       enum Foo
         One
@@ -449,6 +499,62 @@ describe "Semantic: automatic cast" do
       a + :red
       ),
       "no overload matches"
+  end
+
+  it "doesn't say 'ambiguous call' when only one exact match exists" do
+    assert_type(%(
+      def foo(x : Int8, y : Char)
+        true
+      end
+
+      def foo(x : UInt8, y : String)
+        1.5
+      end
+
+      foo(1, 'a')
+      )) { bool }
+  end
+
+  it "doesn't say 'ambiguous call' when only one exact match exists (2)" do
+    assert_type(%(
+      def foo(x : Char, y : Int8)
+        true
+      end
+
+      def foo(x : String, y : UInt8)
+        1.5
+      end
+
+      foo('a', 1)
+      )) { bool }
+  end
+
+  it "doesn't say 'ambiguous call' when only one exact match exists (3)" do
+    assert_type(%(
+      def foo(x : Int8, y : Char)
+        true
+      end
+
+      def foo(x : UInt8, y : String)
+        1.5
+      end
+
+      foo(y: 'a', x: 1)
+      )) { bool }
+  end
+
+  it "doesn't say 'ambiguous call' when only one exact match exists (4)" do
+    assert_type(%(
+      def foo(x : Char, y : Int8)
+        true
+      end
+
+      def foo(x : String, y : UInt8)
+        1.5
+      end
+
+      foo(y: 1, x: 'a')
+      )) { bool }
   end
 
   it "can use automatic cast with `with ... yield` (#7736)" do

--- a/src/compiler/crystal/semantic/main_visitor.cr
+++ b/src/compiler/crystal/semantic/main_visitor.cr
@@ -982,7 +982,13 @@ module Crystal
     def self.check_automatic_cast(program, value, var_type, assign = nil)
       if value.is_a?(NumberLiteral) && value.type != var_type
         literal_type = NumberLiteralType.new(program, value)
-        restricted = literal_type.restrict(var_type, MatchContext.new(value.type, value.type))
+        context = MatchContext.new(value.type, value.type, autocast_allowed: true)
+        restricted = literal_type.restrict(var_type, context)
+        if restricted && var_type
+          literal_type.add_literal_matches(var_type, context)
+          restricted = literal_type.match || restricted
+        end
+
         if restricted.is_a?(IntegerType) || restricted.is_a?(FloatType)
           value.type = restricted
           value.kind = restricted.kind
@@ -991,7 +997,13 @@ module Crystal
         end
       elsif value.is_a?(SymbolLiteral) && value.type != var_type
         literal_type = SymbolLiteralType.new(program, value)
-        restricted = literal_type.restrict(var_type, MatchContext.new(value.type, value.type))
+        context = MatchContext.new(value.type, value.type, autocast_allowed: true)
+        restricted = literal_type.restrict(var_type, context)
+        if restricted && var_type
+          literal_type.add_literal_matches(var_type, context)
+          restricted = literal_type.match || restricted
+        end
+
         if restricted.is_a?(EnumType)
           member = restricted.find_member(value.value).not_nil!
           path = Path.new(member.name)

--- a/src/compiler/crystal/semantic/match.cr
+++ b/src/compiler/crystal/semantic/match.cr
@@ -51,7 +51,9 @@ module Crystal
     # Def free variables, unbound (`def (X, Y) ...`)
     property def_free_vars : Array(String)?
 
-    def initialize(@instantiated_type, @defining_type, @free_vars = nil, @strict = false, @def_free_vars = nil)
+    getter? autocast_allowed : Bool
+
+    def initialize(@instantiated_type, @defining_type, *, @free_vars = nil, @strict = false, @def_free_vars = nil, @autocast_allowed = false)
     end
 
     def get_free_var(name)
@@ -93,7 +95,7 @@ module Crystal
     end
 
     def clone
-      MatchContext.new(@instantiated_type, @defining_type, @free_vars.dup, @strict, @def_free_vars.dup)
+      MatchContext.new(@instantiated_type, @defining_type, free_vars: @free_vars.dup, strict: @strict, def_free_vars: @def_free_vars.dup, autocast_allowed: @autocast_allowed)
     end
   end
 

--- a/src/compiler/crystal/semantic/method_lookup.cr
+++ b/src/compiler/crystal/semantic/method_lookup.cr
@@ -40,13 +40,13 @@ require "../types"
 # def foo(x : Int64)
 # end
 #
-# def foo(x : *Int64)
+# def foo(*x : Int64)
 # end
 #
 # foo(1)
 # ```
 #
-# In this case there's no ambiguity: 1 means `Int64`. However, the first overload
+# In this case there's no ambiguity: 1 means `Int64`. The first overload
 # is an exact match and there's no need to consider the second overload in the
 # multidispatch. However, we do need to analyze it to check if there's an ambiguity.
 
@@ -107,7 +107,7 @@ module Crystal
 
     def lookup_matches_without_parents(signature, owner = self, path_lookup = self, matches_array = nil, analyze_all = false)
       if defs = self.defs.try &.[signature.name]?
-        context = MatchContext.new(owner, path_lookup)
+        context = MatchContext.new(owner, path_lookup, autocast_allowed: analyze_all)
 
         exact_match = nil
 
@@ -140,7 +140,7 @@ module Crystal
               break unless analyze_all
             end
 
-            context = MatchContext.new(owner, path_lookup)
+            context = MatchContext.new(owner, path_lookup, autocast_allowed: analyze_all)
           else
             context.defining_type = path_lookup if macro_owner
             context.def_free_vars = nil
@@ -227,6 +227,7 @@ module Crystal
 
       matched_arg_types = nil
       matched_named_arg_types = nil
+      matched_literals = nil
 
       # If there's a restriction on a splat (that's not a splat restriction),
       # zero splatted args don't match
@@ -248,12 +249,15 @@ module Crystal
         end
 
         match_arg_type = arg_type.restrict(arg, context)
-        if match_arg_type
-          matched_arg_types ||= [] of Type
-          matched_arg_types.push match_arg_type
-          mandatory_args[arg_index] = true if mandatory_args
-        else
-          return nil
+        return nil unless match_arg_type
+
+        matched_arg_types ||= [] of Type
+        matched_arg_types.push match_arg_type
+        mandatory_args[arg_index] = true if mandatory_args
+
+        if arg_type.is_a?(LiteralType)
+          matched_literals ||= [] of {LiteralType, ASTNode}
+          matched_literals << {arg_type, arg}
         end
       end
 
@@ -261,9 +265,7 @@ module Crystal
       if splat_arg_types && splat_restriction.is_a?(Splat)
         tuple_type = context.instantiated_type.program.tuple_of(splat_arg_types)
         match_arg_type = tuple_type.restrict(splat_restriction.exp, context)
-        unless match_arg_type
-          return nil
-        end
+        return nil unless match_arg_type
 
         matched_arg_types ||= [] of Type
         matched_arg_types.concat(splat_arg_types)
@@ -298,27 +300,32 @@ module Crystal
               end
             end
 
-            match_arg_type = named_arg.type.restrict(a_def.args[found_index], context)
-            unless match_arg_type
-              return nil
-            end
+            named_arg_type = named_arg.type
+            match_arg_type = named_arg_type.restrict(a_def.args[found_index], context)
+            return nil unless match_arg_type
 
             matched_named_arg_types ||= [] of NamedArgumentType
             matched_named_arg_types << NamedArgumentType.new(named_arg.name, match_arg_type)
+
+            if named_arg_type.is_a?(LiteralType)
+              matched_literals ||= [] of {LiteralType, ASTNode}
+              matched_literals << {named_arg_type, a_def.args[found_index]}
+            end
           else
             # If there's a double splat it's OK, the named arg will be put there
-            if a_def.double_splat
-              match_arg_type = named_arg.type
+            if double_splat
+              match_arg_type = named_arg_type = named_arg.type
 
-              # If there's a restriction on the double splat, check that it matches
-              if double_splat_restriction
-                if double_splat_entries
-                  double_splat_entries << named_arg
-                else
-                  match_arg_type = named_arg.type.restrict(double_splat_restriction, context)
-                  unless match_arg_type
-                    return nil
-                  end
+              if double_splat_entries
+                double_splat_entries << named_arg
+              else
+                # If there's a restriction on the double splat, check that it matches
+                match_arg_type = named_arg_type.restrict(double_splat_restriction, context)
+                return nil unless match_arg_type
+
+                if named_arg_type.is_a?(LiteralType)
+                  matched_literals ||= [] of {LiteralType, ASTNode}
+                  matched_literals << {named_arg_type, double_splat}
                 end
               end
 
@@ -338,9 +345,7 @@ module Crystal
       if double_splat_entries && double_splat_restriction.is_a?(DoubleSplat)
         named_tuple_type = context.instantiated_type.program.named_tuple_of(double_splat_entries)
         value = named_tuple_type.restrict(double_splat_restriction.exp, context)
-        unless value
-          return nil
-        end
+        return nil unless value
       end
 
       # Check that all mandatory args were specified
@@ -363,10 +368,16 @@ module Crystal
       # new ones when there are free vars.
       context = context.clone if context.free_vars
 
+      if matched_literals
+        matched_literals.try &.each do |(arg, restriction)|
+          arg.add_literal_matches(restriction, context)
+        end
+      end
+
       Match.new(a_def, (matched_arg_types || arg_types), context, matched_named_arg_types)
     end
 
-    def matches_exactly?(match : Match, *, with_literals : Bool = false)
+    def matches_exactly?(match : Match)
       arg_types_equal = self.arg_types.equals?(match.arg_types) do |x, y|
         x.compatible_with?(y)
       end
@@ -466,7 +477,7 @@ module Crystal
                 end
 
                 new_subtype_matches ||= [] of Match
-                new_subtype_matches.push Match.new(cloned_def, full_subtype_match.arg_types, MatchContext.new(subtype_lookup, full_subtype_match.context.defining_type, full_subtype_match.context.free_vars), full_subtype_match.named_arg_types)
+                new_subtype_matches.push Match.new(cloned_def, full_subtype_match.arg_types, MatchContext.new(subtype_lookup, full_subtype_match.context.defining_type, free_vars: full_subtype_match.context.free_vars), full_subtype_match.named_arg_types)
               end
             end
           end

--- a/src/compiler/crystal/semantic/restrictions.cr
+++ b/src/compiler/crystal/semantic/restrictions.cr
@@ -1342,66 +1342,174 @@ module Crystal
     end
   end
 
-  class NumberLiteralType
+  class LiteralType
+    # Returns `true` if this literal denotes a value of the *other* type.
+    abstract def matches_exactly?(other : Type)
+
+    # Returns `true` if this literal denotes a value that is convertible to the
+    # *other* type, but is itself not of that type.
+    abstract def matches_partially?(other : Type)
+
     def restrict(other, context)
-      if other.is_a?(IntegerType) || other.is_a?(FloatType)
-        # Check for an exact match, which can't produce an ambiguous call
-        if literal.type == other
-          set_exact_match(other)
-          other
-        elsif !exact_match? && literal.can_be_autocast_to?(other)
-          add_match(other)
-          other
-        else
-          literal.type.restrict(other, context)
-        end
+      restricted = literal.type.restrict(other, context)
+      return restricted.try(&.remove_literal) if restricted || !context.autocast_allowed?
+      restrict_literal(other, context).first.try(&.remove_literal)
+    end
+
+    # `#restrict_literal` returns two values: the result of restricting `self`
+    # to the given AST node or type, and whether the result is an exact match
+    # for that literal. An exact match has higher priority over partial matches.
+    # Note that at this point we don't need to consider non-autocasting matches.
+    #
+    # `#add_literal_matches` is invoked only immediately after a call signature
+    # is fully matched. This ensures failed signature matches do not count
+    # towards partial autocasting matches.
+
+    def restrict_literal(other : ASTNode, context)
+      {nil, false}
+    end
+
+    def restrict_literal(other : Type, context)
+      if matches_exactly?(other)
+        {other, true}
+      elsif matches_partially?(other)
+        {other, false}
       else
-        type = literal.type.restrict(other, context) ||
-               super(other, context)
-        if type == self
-          type = @match || literal.type
-        end
-        type
+        {nil, false}
       end
     end
 
-    def compatible_with?(type)
-      literal.type == type || literal.can_be_autocast_to?(type)
+    def restrict_literal(other : Nil, context)
+      # lack of restrictions
+      {literal.type, false}
+    end
+
+    def restrict_literal(other : Self, context)
+      restrict_literal(context.instantiated_type.instance_type, context)
+    end
+
+    def restrict_literal(other : Path, context)
+      if type = context.defining_type.lookup_path(other)
+        restrict_literal(type, context)
+      else
+        {nil, false}
+      end
+    end
+
+    def restrict_literal(other : Arg, context)
+      restrict_literal(other.type? || other.restriction, context)
+    end
+
+    # Given `x : T | U | ...`, if one of these variant types produces an exact
+    # match, we ignore the other variant types
+    def restrict_literal(other : Union, context)
+      types = [] of Type
+
+      other.types.each do |union_type|
+        restricted, exact = restrict_literal(union_type, context)
+        if restricted
+          return {restricted, true} if exact
+          types << restricted
+        end
+      end
+
+      {types.size > 0 ? program.type_merge_union_of(types) : nil, false}
+    end
+
+    def restrict_literal(other : UnionType, context)
+      types = [] of Type
+
+      other.union_types.each do |union_type|
+        restricted, exact = restrict_literal(union_type, context)
+        if restricted
+          return {restricted, true} if exact
+          types << restricted
+        end
+      end
+
+      {types.size > 0 ? program.type_merge_union_of(types) : nil, false}
+    end
+
+    def restrict_literal(other : AliasType, context)
+      aliased_type = other.remove_alias
+      if aliased_type != other
+        restrict_literal(aliased_type, context)
+      else
+        # recursive alias
+        {nil, false}
+      end
+    end
+
+    def add_literal_matches(other : ASTNode, context)
+    end
+
+    def add_literal_matches(other : Type, context)
+      if matches_exactly?(other)
+        set_exact_match(other)
+      elsif !exact_match? && matches_partially?(other)
+        add_match(other)
+      end
+    end
+
+    def add_literal_matches(other : Self, context)
+      add_literal_matches(context.instantiated_type.instance_type, context)
+    end
+
+    def add_literal_matches(other : Path, context)
+      if type = context.defining_type.lookup_path(other)
+        add_literal_matches(type, context)
+      end
+    end
+
+    def add_literal_matches(other : Arg, context)
+      if restriction = other.type? || other.restriction
+        add_literal_matches(restriction, context)
+      end
+    end
+
+    def add_literal_matches(other : Union, context)
+      other.types.each do |union_type|
+        add_literal_matches(union_type, context)
+      end
+    end
+
+    def add_literal_matches(other : UnionType, context)
+      other.union_types.each do |union_type|
+        add_literal_matches(union_type, context)
+      end
+    end
+
+    def add_literal_matches(other : AliasType, context)
+      aliased_type = other.remove_alias
+      add_literal_matches(aliased_type, context) unless aliased_type == other
+    end
+
+    def compatible_with?(type : UnionType)
+      type.union_types.all? { |union_type| compatible_with?(union_type) }
+    end
+
+    def compatible_with?(type : Type)
+      matches_exactly?(type) || matches_partially?(type)
+    end
+  end
+
+  class NumberLiteralType
+    def matches_exactly?(other : Type)
+      literal.type == other
+    end
+
+    def matches_partially?(other : Type)
+      literal.can_be_autocast_to?(other)
     end
   end
 
   class SymbolLiteralType
-    def restrict(other, context)
-      case other
-      when SymbolType
-        set_exact_match(other)
-        other
-      when EnumType
-        if !exact_match? && other.find_member(literal.value)
-          add_match(other)
-          other
-        else
-          literal.type.restrict(other, context)
-        end
-      else
-        type = literal.type.restrict(other, context) ||
-               super(other, context)
-        if type == self
-          type = @match || literal.type
-        end
-        type
-      end
+    def matches_exactly?(other : Type)
+      other.is_a?(SymbolType)
     end
 
-    def compatible_with?(type)
-      case type
-      when SymbolType
-        true
-      when EnumType
-        !!(type.find_member(literal.value))
-      else
-        false
-      end
+    def matches_partially?(other : Type)
+      other.is_a?(EnumType) && !!(other.find_member(literal.value))
     end
   end
 end


### PR DESCRIPTION
Consider the following:

```crystal
def foo(x : Int8, y : Char); end
def foo(x : UInt8, y : String); end

foo(1, 'a')       # Error: ambiguous call, implicit cast of 1 matches all of Int8, UInt8
foo(y: 'a', x: 1) # okay

def bar(x : Char, y : Int8); end
def bar(x : String, y : UInt8); end

bar('a', 1)       # okay
bar(y: 1, x: 'a') # Error: ambiguous call, implicit cast of 1 matches all of Int8, UInt8
```

Each overload set is checked in that order, because neither overload is more restricted than the other. What happens here is:

* Neither overload matches when autocasting is disabled.
* Method lookup is repeated with autocasting enabled, and proceeds to check argument compatibility following argument order.
* `1` successfully matches `Int8` because `1` is within `Int8`'s range. The compiler adds this to a list of autocast matches.
* `'a'` successfully matches `Char`, so there is a successful signature match. But the compiler must also check other defs to detect ambiguous autocasts.
* `1` successfully matches `UInt8` because `1` is within `UInt8`'s range. The autocast match list now contains both integer types.
* `'a'` does not match `String`, so this signature match fails, but the compiler does not reset the autocast matches. Thus `1` is considered to be ambiguous even though the `UInt8` autocast match is useless.

This PR refactors the literal restriction logic so that autocast matches are added only after a signature match succeeds (with `LiteralType#add_literal_matches`), making both error calls above unambiguous. The method `LiteralType#restrict_literal` is also added to perform literal restriction without relying on the autocast match state (`@match` and `exact_match?`).