### PR TITLE
Make virtual unbound types also unbound

### DIFF
--- a/spec/compiler/semantic/instance_var_spec.cr
+++ b/spec/compiler/semantic/instance_var_spec.cr
@@ -5247,4 +5247,46 @@ describe "Semantic: instance var" do
       ),
       "can't infer the type parameter T for the generic class Gen(T)"
   end
+
+  it "doesn't infer unbound generic type on generic method called from generic's subclass" do
+    assert_error %(
+      class Gen(T)
+        def self.new(x : T)
+          Gen(T).build
+        end
+
+        def self.build : self
+          new
+        end
+      end
+
+      class Foo < Gen(Int32)
+        def initialize
+          @x = Gen.new('a')
+        end
+      end
+
+      Foo.new
+      ),
+      "can't infer the type of instance variable '@x' of Foo"
+  end
+
+  it "doesn't infer unbound generic type on generic method called from generic's subclass, metaclass context" do
+    assert_error %(
+      class Gen(T)
+        def self.new(x : T)
+          Gen(T).build
+        end
+
+        def self.build : self
+          new
+        end
+      end
+
+      class Foo < Gen(Int32)
+        @x = Gen.new('a')
+      end
+      ),
+      "can't infer the type of instance variable '@x' of Foo"
+  end
 end

--- a/src/compiler/crystal/types.cr
+++ b/src/compiler/crystal/types.cr
@@ -3201,7 +3201,7 @@ module Crystal
       lookup_defs_with_modules, lookup_instance_var, lookup_instance_var?,
       index_of_instance_var, lookup_macro, lookup_macros, all_instance_vars,
       abstract?, implements?, ancestors, struct?,
-      type_var?, to: base_type
+      type_var?, unbound?, to: base_type
 
     def remove_indirection
       if struct?


### PR DESCRIPTION
Fixes a corner case where an instance variable in a non-generic type is incorrectly deduced to be a virtual, unbound generic type, which should never happen (only generic types may have generic ivars whose unbound type arguments correspond to that of the type itself).