### PR TITLE
Fix double flushing json/yaml builders

### DIFF
--- a/src/json/builder.cr
+++ b/src/json/builder.cr
@@ -53,7 +53,7 @@ class JSON::Builder
     when DocumentEndState
       # okay
     end
-    @io.flush
+    flush
   end
 
   def document
@@ -415,6 +415,5 @@ module JSON
     builder.document do
       yield builder
     end
-    io.flush
   end
 end

--- a/src/yaml/builder.cr
+++ b/src/yaml/builder.cr
@@ -53,7 +53,6 @@ class YAML::Builder
   def self.build(io : IO, & : self ->) : Nil
     builder = new(io)
     yield builder ensure builder.close
-    io.flush
   end
 
   # Starts a YAML stream.
@@ -64,7 +63,7 @@ class YAML::Builder
   # Ends a YAML stream.
   def end_stream
     emit stream_end
-    @io.flush
+    flush
   end
 
   # Starts a YAML stream, invokes the block, and ends it.


### PR DESCRIPTION
Fix #10709 

Left the only flush in the ending method for JSON and YAML builders and switched to calling the `flush` method instead of directly flushing the `@io`