### PR TITLE
Add IO::Memory#truncate

### DIFF
--- a/spec/std/io/memory_spec.cr
+++ b/spec/std/io/memory_spec.cr
@@ -382,6 +382,36 @@ describe IO::Memory do
     io.gets_to_end.should eq("")
   end
 
+  it "truncate shrink" do
+    io = IO::Memory.new
+
+    io.write "foofoo".to_slice
+    io.truncate 3
+    io.pos.should eq 3
+    io.to_slice.should eq("foo".to_slice)
+
+    io.write "bar".to_slice
+    io.to_slice.should eq("foobar".to_slice)
+  end
+
+  it "truncate expand" do
+    io = IO::Memory.new
+
+    io.write "foobar".to_slice
+    io.truncate 9
+    io.pos.should eq 6
+    io.bytesize.should eq 9
+    io.to_slice.should eq("foobar\0\0\0".to_slice)
+  end
+
+  it "can't truncate nonresizable" do
+    io = IO::Memory.new("hello")
+
+    expect_raises(IO::Error, "Non-resizeable stream") do
+      io.truncate
+    end
+  end
+
   pending_win32 describe: "encoding" do
     describe "decode" do
       it "gets_to_end" do

--- a/src/io/memory.cr
+++ b/src/io/memory.cr
@@ -334,6 +334,27 @@ class IO::Memory < IO
     @pos = value.to_i
   end
 
+  # Truncates the file to the specified *size*. Requires that the current IO is writable.
+  def truncate(size = 0) : Nil
+    if bytesize >= size # Shrink: Reposition pos to eof if file smaller than cur pos
+      check_open
+      check_resizeable
+      @bytesize = size
+      self.pos = size if @pos > size
+    else # Expand: Leaves pos at cur position
+      if size > @capacity
+        check_resizeable
+        resize_to_capacity(Math.pw2ceil(size))
+      end
+
+      if @pos > @bytesize
+        (@buffer + @bytesize).clear(@pos - @bytesize)
+      end
+
+      @bytesize = size
+    end
+  end
+
   # Yields an `IO::Memory` to read a section of this `IO`'s buffer.
   #
   # During the block duration `self` becomes read-only,


### PR DESCRIPTION
Uses:
1. As a stand in for `File` in tests or other.
2. Mixing binary reading/writing with zero copy encoding/compression/encryption
3. Others.

Example:
```
io = IO::Memory.new
until x
  io.write_bytes y # Or other binary writing
  cur_size = io.size
  io.truncate (cur_size + maximum_expanded_size)
  dst = io.to_slice[cur_size, maximum_expanded_size]
  # How much it will write isn't known before completion
  compressed_slice = zstd.compress(src, dst)
  # Encryption takes a Slice, not IO.
  # Using an IO would require an extra Bytes to store the encrypted data before calling #write
  # Again the size may not be known ahead of time when using c libs.  They return the size written.
  real_size = encrypt_with_padding(compressed_slice, dst) # Encrypt in place
  io.truncate (cur_size + real_size)
```