### PR TITLE
Run instance variable initializers on instantiated generic superclasses only

### DIFF
--- a/spec/compiler/codegen/generic_class_spec.cr
+++ b/spec/compiler/codegen/generic_class_spec.cr
@@ -96,6 +96,53 @@ describe "Code gen: generic class type" do
       )).to_i.should eq(1)
   end
 
+  it "runs generic instance var initializers in superclass's metaclass context (#4753)" do
+    run(%(
+      class Bar(T)
+        def x
+          {% if T == Int32 %} 1 {% else %} 2 {% end %}
+        end
+      end
+
+      class FooBase(T)
+        @bar = Bar(T).new
+
+        def bar
+          @bar
+        end
+      end
+
+      class Foo(T) < FooBase(T)
+      end
+
+      Foo(Int32).new.bar.x
+      )).to_i.should eq(1)
+  end
+
+  it "runs generic instance var initializers in superclass's metaclass context (2) (#6482)" do
+    run(%(
+      class Bar(T)
+        def x
+          # TODO: devirtualize T
+          {% if T <= FooBase(Int32) && T >= FooBase(Int32) %} 1 {% else %} 2 {% end %}
+        end
+      end
+
+      class FooBase(T)
+        @bar = Bar(FooBase(T)).new
+
+        def bar
+          @bar
+        end
+      end
+
+      class Foo(T) < FooBase(T)
+      end
+
+      Foo(Int32).new.bar.x
+      )).to_i.should eq(1)
+  end
+
   it "codegens static array size after instantiating" do
     run(%(
       struct StaticArray(T, N)

--- a/src/compiler/crystal/codegen/codegen.cr
+++ b/src/compiler/crystal/codegen/codegen.cr
@@ -1940,17 +1940,10 @@ module Crystal
       struct_type
     end
 
-    def run_instance_vars_initializers(real_type, type : GenericClassInstanceType, type_ptr)
-      run_instance_vars_initializers(real_type, type.generic_type, type_ptr)
-      run_instance_vars_initializers_non_recursive real_type, type, type_ptr
-    end
-
-    def run_instance_vars_initializers(real_type, type : ClassType | GenericClassType, type_ptr)
+    def run_instance_vars_initializers(real_type, type : ClassType | GenericClassInstanceType, type_ptr)
       if superclass = type.superclass
         run_instance_vars_initializers(real_type, superclass, type_ptr)
       end
-
-      return if type.is_a?(GenericClassType)
 
       run_instance_vars_initializers_non_recursive real_type, type, type_ptr
     end


### PR DESCRIPTION
Fixes #4753. Fixes #6482 (duplicate). Fixes #8551 (duplicate). Fixes #10352 (duplicate).

Consider:

```crystal
class A(T)
end

class B(T)
  @x = A(T).new
end

class C(T) < B(T)
end

C(Int32).new # BUG: trying to assign A(Int32) <- A(T) (Exception)
```

When the `C(Int32)` instance is constructed, the compiler must run all the instance variable initializers (in metaclass context) in `C(Int32)`'s ancestors. The current behaviour is to run the uninstantiated `C(T)`'s initializers, which in turn rely on the *instantiated*, bound superclass `B(T)`'s initializers (this `T` comes from the `C(T)`'s parameter), ending up with `A(T).new`. This `T`, of course, is also bound to `C(T)`, and since the compiler never substitutes this type in the codegen phase, an internal compiler error occurs.

It turns out we don't need to care about uninstantiated generics at all, as `C(Int32)` itself's superclass will instantiate `T` in the corresponding ivar initializers properly. So the correct behaviour here is to run `B(Int32)`'s initializers instead.