### PR TITLE
Remove #check_needs_resize from IO::Memory, String::Builder

### DIFF
--- a/spec/std/io/io_spec.cr
+++ b/spec/std/io/io_spec.cr
@@ -71,10 +71,6 @@ private class SimpleIOMemory < IO
     self
   end
 
-  private def check_needs_resize
-    resize_to_capacity(@capacity * 2) if @bytesize == @capacity
-  end
-
   private def resize_to_capacity(capacity)
     @capacity = capacity
     @buffer = @buffer.realloc(@capacity)

--- a/src/io/memory.cr
+++ b/src/io/memory.cr
@@ -428,10 +428,6 @@ class IO::Memory < IO
     end
   end
 
-  private def check_needs_resize
-    resize_to_capacity(@capacity * 2) if @bytesize == @capacity
-  end
-
   private def resize_to_capacity(capacity)
     @capacity = capacity
     @buffer = @buffer.realloc(@capacity)

--- a/src/string/builder.cr
+++ b/src/string/builder.cr
@@ -116,10 +116,6 @@ class String::Builder < IO
     @bytesize + String::HEADER_SIZE
   end
 
-  private def check_needs_resize
-    resize_to_capacity(@capacity * 2) if real_bytesize == @capacity
-  end
-
   private def resize_to_capacity(capacity)
     @capacity = capacity
     @buffer = @buffer.realloc(@capacity)


### PR DESCRIPTION
These methods have apparently been unused since forever, even before `MemoryIO` became `IO::Memory`.
They're private, so we can just remove them without deprecation.