### PR TITLE
Allow `previous_def` to init superclass's non-nilable ivars

### DIFF
--- a/spec/compiler/semantic/instance_var_spec.cr
+++ b/spec/compiler/semantic/instance_var_spec.cr
@@ -2001,6 +2001,34 @@ describe "Semantic: instance var" do
       )) { int32 }
   end
 
+  it "doesn't error if not initializing variables but calling super and previous_def" do
+    assert_type(%(
+      class Foo
+        @x : Int32
+
+        def initialize
+          @x = 1
+        end
+
+        def x
+          @x
+        end
+      end
+
+      class Bar < Foo
+        def initialize(x)
+          super()
+        end
+
+        def initialize(x)
+          previous_def(x)
+        end
+      end
+
+      Bar.new(10).x
+      )) { int32 }
+  end
+
   it "doesn't error if not initializing variables but calling previous_def (2) (#3210)" do
     assert_type(%(
       class Some

--- a/src/compiler/crystal/semantic/type_declaration_processor.cr
+++ b/src/compiler/crystal/semantic/type_declaration_processor.cr
@@ -477,7 +477,7 @@ struct Crystal::TypeDeclarationProcessor
     # super or assign all of those variables
     if ancestor_non_nilable
       infos.each do |info|
-        unless info.def.calls_super? || info.def.calls_initialize? || info.def.macro_def?
+        unless info.def.calls_super? || info.def.calls_previous_def? || info.def.calls_initialize? || info.def.macro_def?
           ancestor_non_nilable.each do |name|
             # If the variable is initialized outside, it's OK
             next if initialized_outside?(owner, name)


### PR DESCRIPTION
The following works:

```crystal
class Foo
  @x : Int32?

  def initialize
    @x = 1
  end
end

class Bar < Foo
  def initialize
    super
  end

  def initialize
    previous_def
  end
end
```

But as soon as `@x`'s type is not nilable, the compiler errors with `this 'initialize' doesn't initialize instance variable '@x' of Foo, with Bar < Foo, rendering it nilable`. This PR fixes that. (The compiler already has the same logic for nilable ivars, as well as when the def calls `super` or `initialize`.)