### PR TITLE
Use only last sub-expression of `Expressions` nodes for conditional type filters

### DIFF
--- a/spec/compiler/semantic/if_spec.cr
+++ b/spec/compiler/semantic/if_spec.cr
@@ -438,4 +438,28 @@ describe "Semantic: if" do
       foo
       )) { nilable union_of bool, pointer_of(int32), int32 }
   end
+
+  it "doesn't fail on Expressions condition (1)" do
+    assert_type(%(
+      def foo
+        if (v = 1; true)
+          typeof(v)
+        end
+      end
+
+      foo
+      )) { nilable int32.metaclass }
+  end
+
+  it "doesn't fail on Expressions condition (2)" do
+    assert_type(%(
+      def foo
+        if (v = nil; true)
+          typeof(v)
+        end
+      end
+
+      foo
+      )) { nilable nil_type.metaclass }
+  end
 end

--- a/spec/compiler/semantic/while_spec.cr
+++ b/spec/compiler/semantic/while_spec.cr
@@ -334,4 +334,30 @@ describe "Semantic: while" do
       x
       )) { int32 }
   end
+
+  it "doesn't fail on Expressions condition (1)" do
+    assert_type(%(
+      def foo
+        while (v = 1; true)
+          return typeof(v)
+        end
+        'a'
+      end
+
+      foo
+      )) { union_of int32.metaclass, char }
+  end
+
+  it "doesn't fail on Expressions condition (2)" do
+    assert_type(%(
+      def foo
+        while (v = nil; true)
+          return typeof(v)
+        end
+        'a'
+      end
+
+      foo
+      )) { union_of nil_type.metaclass, char }
+  end
 end

--- a/src/compiler/crystal/semantic/main_visitor.cr
+++ b/src/compiler/crystal/semantic/main_visitor.cr
@@ -729,20 +729,18 @@ module Crystal
     end
 
     def visit(node : Expressions)
-      expressions = node.expressions
-      if needs_type_filters? && expressions.size > 1
-        ignoring_type_filters do
-          expressions.each(within: 0..-2, &.accept(self))
+      exp_count = node.expressions.size
+      node.expressions.each_with_index do |exp, i|
+        if i == exp_count - 1
+          exp.accept self
+          node.bind_to exp
+        else
+          ignoring_type_filters { exp.accept self }
         end
-        expressions.last.accept(self)
-      else
-        expressions.each &.accept(self)
       end
 
       if node.empty?
         node.set_type(@program.nil)
-      else
-        node.bind_to node.last
       end
 
       false

--- a/src/compiler/crystal/semantic/main_visitor.cr
+++ b/src/compiler/crystal/semantic/main_visitor.cr
@@ -728,12 +728,24 @@ module Crystal
       end
     end
 
-    def end_visit(node : Expressions)
+    def visit(node : Expressions)
+      expressions = node.expressions
+      if needs_type_filters? && expressions.size > 1
+        ignoring_type_filters do
+          expressions.each(within: 0..-2, &.accept(self))
+        end
+        expressions.last.accept(self)
+      else
+        expressions.each &.accept(self)
+      end
+
       if node.empty?
         node.set_type(@program.nil)
       else
         node.bind_to node.last
       end
+
+      false
     end
 
     def visit(node : Assign)


### PR DESCRIPTION
Fixes the following run-time error:

```crystal
if (x = nil; true)
  p x # => can't execute `p(x)` at eval:2:3: `x` has no type (Exception)
end
```

This happens because Crystal computes the type filter from all sub-expressions of the `(x = nil; true)` node, and `x = nil` produces a truthy filter on `x`, even though the `Nil` type is never truthy; thus flow typing gives `x` no type inside the if-clause. This PR restricts the filter computation to the last sub-expression.

Similar errors can be triggered with while expressions; #10350 probably requires this PR.