### PR TITLE
Don't compute type filters inside `typeof`'s argument

### DIFF
--- a/spec/compiler/semantic/if_spec.cr
+++ b/spec/compiler/semantic/if_spec.cr
@@ -438,4 +438,28 @@ describe "Semantic: if" do
       foo
       )) { nilable union_of bool, pointer_of(int32), int32 }
   end
+
+  it "doesn't fail on new variables inside typeof condition" do
+    assert_type(%(
+      def foo
+        if typeof(1 || 'a')
+          ""
+        end
+      end
+
+      foo
+      )) { nilable string }
+  end
+
+  it "doesn't fail on nested conditionals inside typeof condition" do
+    assert_type(%(
+      def foo
+        if typeof(1 || 'a')
+          ""
+        end
+      end
+
+      foo
+      )) { nilable string }
+  end
 end

--- a/spec/compiler/semantic/if_spec.cr
+++ b/spec/compiler/semantic/if_spec.cr
@@ -442,7 +442,7 @@ describe "Semantic: if" do
   it "doesn't fail on new variables inside typeof condition" do
     assert_type(%(
       def foo
-        if typeof(1 || 'a')
+        if typeof(x = 1)
           ""
         end
       end

--- a/spec/compiler/semantic/while_spec.cr
+++ b/spec/compiler/semantic/while_spec.cr
@@ -334,4 +334,28 @@ describe "Semantic: while" do
       x
       )) { int32 }
   end
+
+  it "doesn't fail on new variables inside typeof condition" do
+    assert_type(%(
+      def foo
+        while typeof(x = 1)
+          return ""
+        end
+      end
+
+      foo
+      )) { nilable string }
+  end
+
+  it "doesn't fail on nested conditionals inside typeof condition" do
+    assert_type(%(
+      def foo
+        while typeof(1 || 'a')
+          return ""
+        end
+      end
+
+      foo
+      )) { nilable string }
+  end
 end

--- a/src/compiler/crystal/semantic/main_visitor.cr
+++ b/src/compiler/crystal/semantic/main_visitor.cr
@@ -2549,7 +2549,9 @@ module Crystal
       @in_type_args = 0
 
       @typeof_nest += 1
-      node.expressions.each &.accept self
+      ignoring_type_filters do
+        node.expressions.each &.accept self
+      end
       @typeof_nest -= 1
 
       @in_type_args = old_in_type_args


### PR DESCRIPTION
The compiler currently computes type filters for expressions inside a `typeof` node's argument. However, not only do (top-level) conditionals inside `typeof` have no effect on the `typeof` itself's type, the variables inside may not even exist outside the node. For example:

```crystal
if typeof(x = 1) # => Missing hash key: "x" (KeyError)
end
```

A less obvious example is the following, where `||` internally expands to if expressions:

```crystal
typeof(1 || 'x') || "" # => Missing hash key: "__temp_499" (KeyError)
```

This PR ensures `typeof`'s argument does not request any type filters.