### PR TITLE
Devirtualize types in `TypeNode#==(other : TypeNode)` and `#!=`

### DIFF
--- a/spec/compiler/codegen/generic_class_spec.cr
+++ b/spec/compiler/codegen/generic_class_spec.cr
@@ -123,8 +123,7 @@ describe "Code gen: generic class type" do
     run(%(
       class Bar(T)
         def x
-          # TODO: devirtualize T
-          {% if T <= FooBase(Int32) && T >= FooBase(Int32) %} 1 {% else %} 2 {% end %}
+          {% if T == FooBase(Int32) %} 1 {% else %} 2 {% end %}
         end
       end
 

--- a/spec/compiler/macro/macro_methods_spec.cr
+++ b/spec/compiler/macro/macro_methods_spec.cr
@@ -1622,6 +1622,27 @@ module Crystal
         end
       end
 
+      it "== and != devirtualize generic type arguments (#10730)" do
+        assert_type(%(
+          class A
+          end
+
+          class B < A
+          end
+
+          module Foo(T)
+            def self.foo
+              {
+                {% if T == A %} 1 {% else %} 'a' {% end %},
+                {% if T != A %} 1 {% else %} 'a' {% end %},
+              }
+            end
+          end
+
+          Foo(A).foo
+          )) { tuple_of([int32, char]) }
+      end
+
       it "executes <" do
         assert_macro("x", "{{x < Reference}}", "true") do |program|
           [TypeNode.new(program.string)] of ASTNode

--- a/src/compiler/crystal/macros/methods.cr
+++ b/src/compiler/crystal/macros/methods.cr
@@ -1693,6 +1693,20 @@ module Crystal
         interpret_argless_method(method, args) { TypeNode.new(type.metaclass) }
       when "instance"
         interpret_argless_method(method, args) { TypeNode.new(type.instance_type) }
+      when "==", "!="
+        interpret_one_arg_method(method, args) do |arg|
+          return super unless arg.is_a?(TypeNode)
+
+          self_type = self.type.devirtualize
+          other_type = arg.type.devirtualize
+
+          case method
+          when "=="
+            BoolLiteral.new(self_type == other_type)
+          else # "!="
+            BoolLiteral.new(self_type != other_type)
+          end
+        end
       when "<", "<=", ">", ">="
         interpret_one_arg_method(method, args) do |arg|
           unless arg.is_a?(TypeNode)


### PR DESCRIPTION
Fixes #10730.