### PR TITLE
Always copy `Hash`'s default block on `#dup` and `#clone`

### DIFF
--- a/spec/std/hash_spec.cr
+++ b/spec/std/hash_spec.cr
@@ -494,6 +494,16 @@ describe "Hash" do
       clone = h.clone
       clone.should be(clone.first[1])
     end
+
+    it "retains default block on clone" do
+      h1 = Hash(Int32, String).new("a")
+      h2 = h1.clone
+      h2[0].should eq("a")
+
+      h1[1] = "b"
+      h3 = h1.clone
+      h3[0].should eq("a")
+    end
   end
 
   describe "dup" do
@@ -535,6 +545,16 @@ describe "Hash" do
 
       h1.delete(0)
       h2[0].should eq([0])
+    end
+
+    it "retains default block on dup" do
+      h1 = Hash(Int32, String).new("a")
+      h2 = h1.dup
+      h2[0].should eq("a")
+
+      h1[1] = "b"
+      h3 = h1.dup
+      h3[0].should eq("a")
     end
   end
 

--- a/src/hash.cr
+++ b/src/hash.cr
@@ -640,6 +640,7 @@ class Hash(K, V)
   # Initializes a `dup` copy from the contents of `other`.
   protected def initialize_dup(other)
     initialize_compare_by_identity(other)
+    initialize_default_block(other)
 
     return if other.empty?
 
@@ -650,6 +651,7 @@ class Hash(K, V)
   # Initializes a `clone` copy from the contents of `other`.
   protected def initialize_clone(other)
     initialize_compare_by_identity(other)
+    initialize_default_block(other)
 
     return if other.empty?
 
@@ -659,6 +661,10 @@ class Hash(K, V)
 
   private def initialize_compare_by_identity(other)
     compare_by_identity if other.compare_by_identity?
+  end
+
+  private def initialize_default_block(other)
+    @block = other.@block
   end
 
   # Initializes `@entries` for a dup copy.
@@ -685,14 +691,13 @@ class Hash(K, V)
     end
   end
 
-  # Initializes all variables other than `@entries` for a copy.
+  # Initializes all variables other than `@entries` and `@block` for a copy.
   private def initialize_copy_non_entries_vars(other)
     @indices_bytesize = other.@indices_bytesize
     @first = other.@first
     @size = other.@size
     @deleted_count = other.@deleted_count
     @indices_size_pow2 = other.@indices_size_pow2
-    @block = other.@block
 
     unless other.@indices.null?
       @indices = malloc_indices(other.indices_size)


### PR DESCRIPTION
When a hash is copied by either `#dup` or `#clone`, only `compare_by_identity` is copied but not the default block when the hash is empty:

```crystal
hsh = Hash(Int32, String).new("")
hsh.compare_by_identity
hsh.dup.compare_by_identity? # => true
hsh.dup[0]                   # Missing hash key: 0 (KeyError)

hsh = Hash(Int32, String).new("")
hsh[1] = "a"
hsh.compare_by_identity
hsh.dup.compare_by_identity? # => true
hsh.dup[0]                   # => ""
```

Since the default block is part of the hash's internal state, it should always be copied even if the hash has no elements.