### PR TITLE
Add `UntypedPointer` as a superclass of `Pointer`

### DIFF
--- a/spec/compiler/codegen/pointer_spec.cr
+++ b/spec/compiler/codegen/pointer_spec.cr
@@ -1,5 +1,20 @@
 require "../../spec_helper"
 
+describe "Code gen: untyped pointer" do
+  it "codegens malloc" do
+    run("UntypedPointer.malloc(10_u64)")
+  end
+
+  it "codegens realloc" do
+    run(%(
+      p = UntypedPointer.malloc(10_u64)
+      (p.as(UInt8*) + 9_i64).value = 1
+      x = p.realloc(20_u64)
+      (x.as(UInt8*) + 9_i64).value &+ 1_i64
+      )).to_i.should eq(2)
+  end
+end
+
 describe "Code gen: pointer" do
   it "get pointer and value of it" do
     run("a = 1; b = pointerof(a); b.value").to_i.should eq(1)

--- a/spec/compiler/semantic/if_spec.cr
+++ b/spec/compiler/semantic/if_spec.cr
@@ -427,7 +427,7 @@ describe "Semantic: if" do
     assert_type(%(
       def foo
         x = 1
-        y = false || pointerof(x) || nil
+        y = false || pointerof(x) || UntypedPointer.new(0_u64) || nil
 
         if !y
           return y
@@ -436,7 +436,7 @@ describe "Semantic: if" do
       end
 
       foo
-      )) { nilable union_of bool, pointer_of(int32), int32 }
+      )) { nilable union_of bool, pointer_of(int32), untyped_pointer, int32 }
   end
 
   it "doesn't fail on Expressions condition (1)" do

--- a/spec/compiler/semantic/pointer_spec.cr
+++ b/spec/compiler/semantic/pointer_spec.cr
@@ -1,5 +1,31 @@
 require "../../spec_helper"
 
+describe "Semantic: untyped pointer" do
+  it "types UntypedPointer.new" do
+    assert_type("UntypedPointer.new(10_u64)") { untyped_pointer }
+  end
+
+  it "types UntypedPointer.malloc" do
+    assert_type("UntypedPointer.malloc(10_u64)") { untyped_pointer }
+  end
+
+  it "types UntypedPointer casting to pointer" do
+    assert_type("UntypedPointer.new(10_u64).as(Char*)") { pointer_of(char) }
+  end
+
+  it "types UntypedPointer casting to pointer of void" do
+    assert_type("UntypedPointer.new(10_u64).as(Void*)") { pointer_of(void) }
+  end
+
+  it "types UntypedPointer casting to object type" do
+    assert_type("UntypedPointer.new(10_u64).as(String)") { string }
+  end
+
+  it "types pointer casting to UntypedPointer" do
+    assert_type("Pointer(Int32).new(10_u64).as(UntypedPointer)") { untyped_pointer }
+  end
+end
+
 describe "Semantic: pointer" do
   it "types int pointer" do
     assert_type("a = 1; pointerof(a)") { pointer_of(int32) }
@@ -48,7 +74,7 @@ describe "Semantic: pointer" do
   it "can't do Pointer.malloc without type var" do
     assert_error "
       Pointer.malloc(1_u64)
-    ", "can't malloc pointer without type, use Pointer(Type).malloc(size)"
+    ", "can't infer the type parameter T for Pointer(T), use UntypedPointer.malloc(size) or Pointer(Type).malloc(size) instead"
   end
 
   it "create pointer by address" do
@@ -96,6 +122,14 @@ describe "Semantic: pointer" do
       x = pointerof(pointer)
       ),
       "recursive pointerof expansion"
+  end
+
+  it "types union of pointers" do
+    assert_type(%(
+      x = 1
+      y = 'a'
+      true ? pointerof(x) : pointerof(y)
+      )) { union_of pointer_of(int32), pointer_of(char) }
   end
 
   it "can assign nil to void pointer" do

--- a/src/compiler/crystal/codegen/cast.cr
+++ b/src/compiler/crystal/codegen/cast.cr
@@ -344,6 +344,11 @@ class Crystal::CodeGenVisitor
     bit_cast value, llvm_context.void_pointer
   end
 
+  def downcast_distinct(value, to_type : PointerInstanceType, from_type : UntypedPointerType)
+    # cast of a pointer being cast to Void*
+    bit_cast value, llvm_context.void_pointer
+  end
+
   def downcast_distinct(value, to_type : ReferenceUnionType, from_type : ReferenceUnionType)
     value
   end

--- a/src/compiler/crystal/codegen/codegen.cr
+++ b/src/compiler/crystal/codegen/codegen.cr
@@ -1982,15 +1982,22 @@ module Crystal
       generic_malloc(type) { crystal_malloc_atomic_fun }
     end
 
-    def generic_malloc(type)
-      size = type.size
+    # In order for `UntypedPointer.malloc(...).as(ReferenceType)` to consider
+    # potential inner pointers as such, this cannot use `malloc_atomic`.
+    def malloc_untyped(size)
+      malloc_untyped(size) { crystal_malloc_fun }
+    end
 
+    def malloc_untyped(size)
       if malloc_fun = yield
-        pointer = call malloc_fun, size
+        call malloc_fun, size
       else
-        pointer = call_c_malloc size
+        call_c_malloc size
       end
+    end
 
+    def generic_malloc(type)
+      pointer = malloc_untyped(type.size) { yield }
       bit_cast pointer, type.pointer
     end
 
@@ -2004,13 +2011,7 @@ module Crystal
 
     def generic_array_malloc(type, count)
       size = builder.mul type.size, count
-
-      if malloc_fun = yield
-        pointer = call malloc_fun, size
-      else
-        pointer = call_c_malloc size
-      end
-
+      pointer = malloc_untyped(size) { yield }
       memset pointer, int8(0), size
       bit_cast pointer, type.pointer
     end

--- a/src/compiler/crystal/codegen/cond.cr
+++ b/src/compiler/crystal/codegen/cond.cr
@@ -17,7 +17,7 @@ class Crystal::CodeGenVisitor
     codegen_cond type.typedef
   end
 
-  private def codegen_cond_impl(type : NilableType | NilableReferenceUnionType | PointerInstanceType)
+  private def codegen_cond_impl(type : NilableType | NilableReferenceUnionType | PointerInstanceType | UntypedPointerType)
     not_null_pointer? @last
   end
 
@@ -31,7 +31,7 @@ class Crystal::CodeGenVisitor
 
     has_nil = union_types.any? &.nil_type?
     has_bool = union_types.any? &.bool_type?
-    has_pointer = union_types.any? &.is_a?(PointerInstanceType)
+    has_pointer = union_types.any? &.pointer?
 
     cond = llvm_true
 
@@ -51,7 +51,7 @@ class Crystal::CodeGenVisitor
 
       if has_pointer
         union_types.each do |union_type|
-          next unless union_type.is_a?(PointerInstanceType)
+          next unless union_type.pointer?
 
           is_pointer = equal? type_id, type_id(union_type)
           pointer_value = load(bit_cast value_ptr, llvm_type(union_type).pointer)

--- a/src/compiler/crystal/codegen/llvm_typer.cr
+++ b/src/compiler/crystal/codegen/llvm_typer.cr
@@ -164,6 +164,10 @@ module Crystal
       @llvm_context.int32
     end
 
+    private def create_llvm_type(type : UntypedPointerType, wants_size)
+      @llvm_context.void_pointer
+    end
+
     private def create_llvm_type(type : PointerInstanceType, wants_size)
       if wants_size
         return @llvm_context.void_pointer

--- a/src/compiler/crystal/codegen/types.cr
+++ b/src/compiler/crystal/codegen/types.cr
@@ -16,7 +16,7 @@ module Crystal
     # In the codegen phase these types are passed as byval pointers.
     def passed_by_value?
       case self
-      when PrimitiveType, PointerInstanceType, ProcInstanceType
+      when PrimitiveType, PointerInstanceType, UntypedPointerType, ProcInstanceType
         false
       when TupleInstanceType, NamedTupleInstanceType, MixedUnionType
         true
@@ -51,6 +51,8 @@ module Crystal
         # We consider Void to have pointers, so doing
         # Pointer(Void).malloc(...).as(ReferenceType)
         # will consider potential inner pointers as such.
+        true
+      when UntypedPointerType
         true
       when PointerInstanceType
         true

--- a/src/compiler/crystal/program.cr
+++ b/src/compiler/crystal/program.cr
@@ -169,7 +169,11 @@ module Crystal
       types["Float64"] = @float64 = FloatType.new self, self, "Float64", float, 8, 10
 
       types["Symbol"] = @symbol = SymbolType.new self, self, "Symbol", value, 4
-      types["Pointer"] = pointer = @pointer = PointerType.new self, self, "Pointer", value, ["T"]
+
+      types["UntypedPointer"] = untyped_pointer = @untyped_pointer = UntypedPointerType.new self, self, "UntypedPointer", value, 8 # TODO: don't hard-code this
+      untyped_pointer.struct = true
+
+      types["Pointer"] = pointer = @pointer = PointerType.new self, self, "Pointer", untyped_pointer, ["T"]
       pointer.struct = true
       pointer.can_be_stored = false
 
@@ -453,7 +457,7 @@ module Crystal
     end
 
     {% for name in %w(object no_return value number reference void nil bool char int int8 int16 int32 int64 int128
-                     uint8 uint16 uint32 uint64 uint128 float float32 float64 string symbol pointer array static_array
+                     uint8 uint16 uint32 uint64 uint128 float float32 float64 string symbol untyped_pointer pointer array static_array
                      exception tuple named_tuple proc union enum range regex crystal
                      packed_annotation thread_local_annotation no_inline_annotation
                      always_inline_annotation naked_annotation returns_twice_annotation

--- a/src/compiler/crystal/semantic/main_visitor.cr
+++ b/src/compiler/crystal/semantic/main_visitor.cr
@@ -1852,7 +1852,7 @@ module Crystal
       end
 
       obj_type = node.obj.type?
-      if obj_type.is_a?(PointerInstanceType)
+      if obj_type.is_a?(PointerInstanceType) || obj_type.is_a?(UntypedPointerType)
         to_type = node.to.type.instance_type
         if to_type.is_a?(GenericType)
           node.raise "can't cast #{obj_type} to #{to_type}"
@@ -2423,7 +2423,7 @@ module Crystal
 
     def visit_pointer_malloc(node)
       if scope.instance_type.is_a?(GenericClassType)
-        node.raise "can't malloc pointer without type, use Pointer(Type).malloc(size)"
+        node.raise "can't infer the type parameter T for Pointer(T), use UntypedPointer.malloc(size) or Pointer(Type).malloc(size) instead"
       end
 
       node.type = scope.instance_type
@@ -2446,7 +2446,7 @@ module Crystal
 
     def visit_pointer_new(node)
       if scope.instance_type.is_a?(GenericClassType)
-        node.raise "can't create pointer without type, use Pointer(Type).new(address)"
+        node.raise "can't infer the type parameter T for Pointer(T), use UntypedPointer.new(address) or Pointer(Type).new(address) instead"
       end
 
       node.type = scope.instance_type

--- a/src/compiler/crystal/semantic/recursive_struct_checker.cr
+++ b/src/compiler/crystal/semantic/recursive_struct_checker.cr
@@ -177,7 +177,7 @@ class Crystal::RecursiveStructChecker
   end
 
   def struct?(type)
-    type.struct? && type.is_a?(InstanceVarContainer) && !type.is_a?(PrimitiveType) && !type.is_a?(ProcInstanceType) && !type.abstract?
+    type.struct? && type.is_a?(InstanceVarContainer) && !type.is_a?(PrimitiveType) && !type.pointer? && !type.is_a?(ProcInstanceType) && !type.abstract?
   end
 
   def push(path, type)

--- a/src/compiler/crystal/types.cr
+++ b/src/compiler/crystal/types.cr
@@ -184,7 +184,7 @@ module Crystal
     end
 
     def pointer?
-      self.is_a?(PointerInstanceType)
+      self.is_a?(PointerInstanceType) || self.is_a?(UntypedPointerType)
     end
 
     def nil_type?
@@ -549,7 +549,8 @@ module Crystal
       case self
       when program.object, program.value, program.struct,
            program.number, program.int, program.float,
-           PrimitiveType, program.reference
+           PrimitiveType, program.reference,
+           program.pointer, program.untyped_pointer
         false
       else
         true
@@ -1358,6 +1359,9 @@ module Crystal
   class NilType < PrimitiveType
   end
 
+  class UntypedPointerType < PrimitiveType
+  end
+
   class NoReturnType < NamedType
     # NoReturn can be assigned to any other type (because it never will)
     def implements?(other_type)
@@ -2142,6 +2146,11 @@ module Crystal
 
     def type_desc
       "generic struct"
+    end
+
+    def all_instance_vars
+      # don't use superclass (UntypedPointer)
+      instance_vars
     end
   end
 

--- a/src/primitives.cr
+++ b/src/primitives.cr
@@ -132,6 +132,53 @@ struct Symbol
   end
 end
 
+struct UntypedPointer
+  # Allocates `size` bytes from the system's heap initialized
+  # to zero and returns a pointer to the first byte from that memory.
+  # The memory is allocated by the `GC`, so when there are
+  # no pointers to this memory, it will be automatically freed.
+  #
+  # The implementation uses `GC.malloc`, so that the allocated memory is
+  # expected to contain inner address pointers.
+  @[Primitive(:pointer_malloc)]
+  def self.malloc(size : UInt64) : self
+  end
+
+  # Tries to change the size of the allocation pointed to by this pointer to *size*,
+  # and returns that pointer.
+  #
+  # Since the space after the end of the block may be in use, realloc may find it
+  # necessary to copy the block to a new address where more free space is available.
+  # The value of realloc is the new address of the block.
+  # If the block needs to be moved, realloc copies the old contents.
+  #
+  # Remember to always assign the value of realloc.
+  @[Primitive(:pointer_realloc)]
+  def realloc(byte_count : UInt64) : self
+  end
+
+  # Returns a pointer that points to the given memory address.
+  # This doesn't allocate memory.
+  #
+  # ```
+  # ptr = UntypedPointer.new(5678_u64)
+  # ptr.address # => 5678
+  # ```
+  @[Primitive(:pointer_new)]
+  def self.new(address : UInt64)
+  end
+
+  # Returns the address of this pointer.
+  #
+  # ```
+  # ptr = UntypedPointer.new(1234)
+  # ptr.address # => 1234
+  # ```
+  @[Primitive(:pointer_address)]
+  def address : UInt64
+  end
+end
+
 struct Pointer(T)
   # Allocates `size * sizeof(T)` bytes from the system's heap initialized
   # to zero and returns a pointer to the first byte from that memory.


### PR DESCRIPTION
This is a proof-of-concept implementation for https://github.com/crystal-lang/crystal/issues/10657#issuecomment-842426941.

`UntypedPointer` has no support for pointer arithmetic at all and cannot be dereferenced; other than that, it has the same semantics as `Pointer(Void)`, and the two types should be interchangeable. `Pointer` is unique in that the union of a `Pointer(T)` instance with another `Pointer(U)` or `UntypedPointer` does not merge into `UntypedPointer`.

Code that uses `Pointer(Void)` shall continue to work for the rest of 1.x; this PR does not apply `UntypedPointer` to the standard library yet, because it is a primitive type and the 1.0 compiler has no knowledge of its existence.