### PR TITLE
fix ssl context add_x509_verify_flags

### DIFF
--- a/src/openssl/ssl/context.cr
+++ b/src/openssl/ssl/context.cr
@@ -455,7 +455,7 @@ abstract class OpenSSL::SSL::Context
       raise OpenSSL::Error.new("SSL_CTX_set1_param") unless ret == 1
     end
 
-    # Sets the given `OpenSSL::X509VerifyFlags` in this context, additionally to
+    # Sets the given `OpenSSL::SSL::X509VerifyFlags` in this context, additionally to
     # the already set ones.
     def add_x509_verify_flags(flags : OpenSSL::SSL::X509VerifyFlags)
       param = LibSSL.ssl_ctx_get0_param(@handle)

--- a/src/openssl/ssl/context.cr
+++ b/src/openssl/ssl/context.cr
@@ -457,7 +457,7 @@ abstract class OpenSSL::SSL::Context
 
     # Sets the given `OpenSSL::X509VerifyFlags` in this context, additionally to
     # the already set ones.
-    def add_x509_verify_flags(flags : OpenSSL::X509VerifyFlags)
+    def add_x509_verify_flags(flags : OpenSSL::SSL::X509VerifyFlags)
       param = LibSSL.ssl_ctx_get0_param(@handle)
       ret = LibCrypto.x509_verify_param_set_flags(param, flags)
       raise OpenSSL::Error.new("X509_VERIFY_PARAM_set_flags)") unless ret == 1


### PR DESCRIPTION
invalid type specified on function, solving:

```
> 46 | def add_x509_verify_flags(flags : OpenSSL::X509VerifyFlags)
                                         ^-----------------------
Error: undefined constant OpenSSL::X509VerifyFlags
```