### PR TITLE
Fix handling of EAI_SYSTEM for getaddrinfo

### DIFF
--- a/src/socket/addrinfo.cr
+++ b/src/socket/addrinfo.cr
@@ -137,10 +137,14 @@ class Socket
         raise Error.new(ret, "The requested socket type #{type} protocol #{protocol} is not supported", domain)
       when LibC::EAI_SERVICE
         raise Error.new(ret, "The requested service #{service} is not available for the requested socket type #{type}", domain)
-      when LibC::EAI_SYSTEM
-        errno = Errno.value
-        raise Error.new(errno.value, errno.message, domain)
       else
+        {% if flag?(:posix) %}
+          # EAI_SYSTEM is not defined on win32
+          if ret == LibC::EAI_SYSTEM
+            errno = Errno.value
+            raise Error.new(errno.value, errno.message, domain)
+          end
+        {% end %}
         raise Error.new(ret, domain)
       end
 

--- a/src/socket/addrinfo.cr
+++ b/src/socket/addrinfo.cr
@@ -137,6 +137,9 @@ class Socket
         raise Error.new(ret, "The requested socket type #{type} protocol #{protocol} is not supported", domain)
       when LibC::EAI_SERVICE
         raise Error.new(ret, "The requested service #{service} is not available for the requested socket type #{type}", domain)
+      when LibC::EAI_SYSTEM
+        errno = Errno.value
+        raise Error.new(errno.value, errno.message, domain)
       else
         raise Error.new(ret, domain)
       end


### PR DESCRIPTION
When `getaddrinfo` returns `EAI_SYSTEM`, it describes a system error and the actual error value is to be retrieved from `errno`.

Ref: https://forum.crystal-lang.org/t/intermittent-dns-errors-inside-crystal/3326