### PR TITLE
Fix logic for `responds_to?` of generic module instances

### DIFF
--- a/spec/compiler/codegen/responds_to_spec.cr
+++ b/spec/compiler/codegen/responds_to_spec.cr
@@ -133,6 +133,40 @@ describe "Codegen: responds_to?" do
       )).to_b.should be_false
   end
 
+  it "works with generic virtual superclass (1)" do
+    run(%(
+      class Foo(T)
+      end
+
+      class Bar < Foo(Int32)
+
+        def foo
+          1
+        end
+      end
+
+      foo = Bar.new.as(Foo(Int32))
+      foo.responds_to?(:foo)
+      )).to_b.should be_true
+  end
+
+  it "works with generic virtual superclass (2)" do
+    run(%(
+      class Foo(T)
+      end
+
+      class Bar(T) < Foo(T)
+
+        def foo
+          1
+        end
+      end
+
+      foo = Bar(Int32).new.as(Foo(Int32))
+      foo.responds_to?(:foo)
+      )).to_b.should be_true
+  end
+
   it "works with module" do
     run(%(
       module Moo
@@ -160,6 +194,42 @@ describe "Codegen: responds_to?" do
 
       moo = ptr.value
       moo.responds_to?(:foo)
+      )).to_b.should be_true
+  end
+
+  it "works with generic virtual module (1)" do
+    run(%(
+      module Foo(T)
+      end
+
+      class Bar
+        include Foo(Int32)
+
+        def foo
+          1
+        end
+      end
+
+      foo = Bar.new.as(Foo(Int32))
+      foo.responds_to?(:foo)
+      )).to_b.should be_true
+  end
+
+  it "works with generic virtual module (2) (#8334)" do
+    run(%(
+      module Foo(T)
+      end
+
+      class Bar(T)
+        include Foo(T)
+
+        def foo
+          1
+        end
+      end
+
+      foo = Bar(Int32).new.as(Foo(Int32))
+      foo.responds_to?(:foo)
       )).to_b.should be_true
   end
 

--- a/spec/compiler/semantic/responds_to_spec.cr
+++ b/spec/compiler/semantic/responds_to_spec.cr
@@ -40,4 +40,56 @@ describe "Semantic: responds_to?" do
       end
       ") { int32 }
   end
+
+  it "restricts virtual generic superclass to subtypes" do
+    assert_type(%(
+      module Foo(T)
+      end
+
+      class Bar
+        include Foo(Int32)
+
+        def foo
+          'a'
+        end
+      end
+
+      class Baz(T)
+        include Foo(T)
+
+        def foo
+          ""
+        end
+      end
+
+      x = Baz(Int32).new.as(Foo(Int32))
+      if x.responds_to?(:foo)
+        x.foo
+      end
+      )) { nilable union_of(char, string) }
+  end
+
+  it "restricts virtual generic module to including types (#8334)" do
+    assert_type(%(
+      class Foo(T)
+      end
+
+      class Bar < Foo(Int32)
+        def foo
+          'a'
+        end
+      end
+
+      class Baz(T) < Foo(T)
+        def foo
+          ""
+        end
+      end
+
+      x = Baz(Int32).new.as(Foo(Int32))
+      if x.responds_to?(:foo)
+        x.foo
+      end
+      )) { nilable union_of(char, string) }
+  end
 end

--- a/src/compiler/crystal/types.cr
+++ b/src/compiler/crystal/types.cr
@@ -2124,7 +2124,7 @@ module Crystal
     end
 
     def filter_by_responds_to(name)
-      @generic_type.filter_by_responds_to(name) ? self : nil
+      including_types.try &.filter_by_responds_to(name)
     end
 
     def module?


### PR DESCRIPTION
Fixes #8334 (more specifically snippet 4 there). This resembles #10519 but the mechanisms are vastly different.

There are essentially two kinds of logic used in `responds_to?(:foo)` filters:

* Non-virtual: If `T` or its parents define any method called `foo`, the filtered type is `T`.
* Virtual: The filtered type is the union of all subtypes of `T`, through either including or inheriting `T`, that respond to `foo`.

Virtual classes and modules are supposed to use the latter, but generic module instances use the former for some reason. This PR makes them behave like non-generic modules:

```crystal
module A(T)
end

class B(T)
  include A(T)

  def f; end
end

typeof(begin
  x = B(Int32).new.as(A(Int32))
  x.responds_to?(:f) ? x : raise ""
end)      # => B(Int32)
# before: # => NoReturn
```

One consequence is that even if the generic module itself defines that method, `responds_to?` will filter the variable to all including types of the module:

```crystal
module A(T)
  def f; end
end

class B(T)
  include A(T)
end

class C
  include A(Int32)
end

typeof(begin
  x = B(Int32).new.as(A(Int32))
  x.responds_to?(:f) ? x : raise ""
end)      # => B(Int32) | C
# before: # => A(Int32)
```

This behaviour is currently consistent with non-generic modules. There might be a follow-up PR to make modules exhibit both non-virtual logic and fall back to virtual logic, which can eliminate very large unions and/or `NoReturn` in some places. (In fact I said the exact same thing on #10519.)

Type filtering and codegen are both backed by `Crystal::Type#filter_by_responds_to` so this PR fixes both at once.