### PR TITLE
Add specs for Errno

### DIFF
--- a/spec/std/errno_spec.cr
+++ b/spec/std/errno_spec.cr
@@ -1,0 +1,14 @@
+require "spec"
+
+describe Errno do
+  it ".value" do
+    Errno.value = Errno::EACCES
+    Errno.value.should eq Errno::EACCES
+    Errno.value = Errno::EPERM
+    Errno.value.should eq Errno::EPERM
+  end
+
+  it "#message" do
+    Errno::EACCES.message.should eq "Permission denied"
+  end
+end

--- a/src/errno.cr
+++ b/src/errno.cr
@@ -60,7 +60,7 @@ enum Errno
       LibC.__error.value = errno.value
     {% elsif flag?(:win32) %}
       ret = LibC._set_errno(errno.value)
-      raise RuntimeError.from_os_error("_set_errno", ret) unless ret == 0
+      raise RuntimeError.from_os_error("_set_errno", Errno.new(ret)) unless ret == 0
     {% end %}
     errno
   end


### PR DESCRIPTION
This patch adds specs for `Errno` (and in the process discovered a bug in `Errno.value=` on win32).

Related to #10762 (specs for `WinError`)