### PR TITLE
Cache socket.local_address and socket.remote_address

### DIFF
--- a/spec/std/socket/udp_socket_spec.cr
+++ b/spec/std/socket/udp_socket_spec.cr
@@ -4,9 +4,9 @@ require "socket"
 describe UDPSocket do
   it "#remote_address resets after connect" do
     socket = UDPSocket.new
-    socket.connect("localhost", 1)
+    socket.connect("127.0.0.1", 1)
     socket.remote_address.port.should eq 1
-    socket.connect("localhost", 2)
+    socket.connect("127.0.0.1", 2)
     socket.remote_address.port.should eq 2
   end
 

--- a/spec/std/socket/udp_socket_spec.cr
+++ b/spec/std/socket/udp_socket_spec.cr
@@ -2,6 +2,14 @@ require "./spec_helper"
 require "socket"
 
 describe UDPSocket do
+  it "#remote_address resets after connect" do
+    socket = UDPSocket.new
+    socket.connect("localhost", 1)
+    socket.remote_address.port.should eq 1
+    socket.connect("localhost", 2)
+    socket.remote_address.port.should eq 2
+  end
+
   each_ip_family do |family, address, unspecified_address|
     it "#bind" do
       port = unused_local_port
@@ -12,14 +20,6 @@ describe UDPSocket do
       socket = UDPSocket.new(family)
       socket.bind(address, 0)
       socket.local_address.address.should eq address
-    end
-
-    it "#remote_address resets after connect" do
-      socket = UDPSocket.new
-      socket.connect(address, 1)
-      socket.remote_address.port.should eq 1
-      socket.connect(address, 2)
-      socket.remote_address.port.should eq 2
     end
 
     it "sends and receives messages" do

--- a/spec/std/socket/udp_socket_spec.cr
+++ b/spec/std/socket/udp_socket_spec.cr
@@ -2,12 +2,20 @@ require "./spec_helper"
 require "socket"
 
 describe UDPSocket do
+  # Note: This spec fails with a IPv6 address. See pending below.
   it "#remote_address resets after connect" do
     socket = UDPSocket.new
     socket.connect("127.0.0.1", 1)
     socket.remote_address.port.should eq 1
     socket.connect("127.0.0.1", 2)
     socket.remote_address.port.should eq 2
+    socket.close
+  end
+
+  pending "#connect with a IPv6 address" do
+    socket = UDPSocket.new
+    socket.connect("::1", 1)
+    socket.close
   end
 
   each_ip_family do |family, address, unspecified_address|

--- a/spec/std/socket/udp_socket_spec.cr
+++ b/spec/std/socket/udp_socket_spec.cr
@@ -14,6 +14,14 @@ describe UDPSocket do
       socket.local_address.address.should eq address
     end
 
+    it "#remote_address resets after connect" do
+      socket = UDPSocket.new
+      socket.connect(address, 1)
+      socket.remote_address.port.should eq 1
+      socket.connect(address, 2)
+      socket.remote_address.port.should eq 2
+    end
+
     it "sends and receives messages" do
       port = unused_local_port
 

--- a/src/crystal/system/unix/socket.cr
+++ b/src/crystal/system/unix/socket.cr
@@ -239,7 +239,7 @@ module Crystal::System::Socket
     end
   end
 
-  private getter(system_local_address : ::Socket::IPAddress) do
+  private def system_local_address
     sockaddr6 = uninitialized LibC::SockaddrIn6
     sockaddr = pointerof(sockaddr6).as(LibC::Sockaddr*)
     addrlen = sizeof(LibC::SockaddrIn6).to_u32!
@@ -251,7 +251,7 @@ module Crystal::System::Socket
     ::Socket::IPAddress.from(sockaddr, addrlen)
   end
 
-  private getter(system_remote_address : ::Socket::IPAddress) do
+  private def system_remote_address
     sockaddr6 = uninitialized LibC::SockaddrIn6
     sockaddr = pointerof(sockaddr6).as(LibC::Sockaddr*)
     addrlen = sizeof(LibC::SockaddrIn6).to_u32!

--- a/src/crystal/system/unix/socket.cr
+++ b/src/crystal/system/unix/socket.cr
@@ -239,35 +239,28 @@ module Crystal::System::Socket
     end
   end
 
-  @local_address_cache : ::Socket::IPAddress?
-  @remote_address_cache : ::Socket::IPAddress?
+  private getter(system_local_address : ::Socket::IPAddress) do
+    sockaddr6 = uninitialized LibC::SockaddrIn6
+    sockaddr = pointerof(sockaddr6).as(LibC::Sockaddr*)
+    addrlen = sizeof(LibC::SockaddrIn6).to_u32!
 
-  private def system_local_address
-    @local_address_cache ||= begin
-      sockaddr6 = uninitialized LibC::SockaddrIn6
-      sockaddr = pointerof(sockaddr6).as(LibC::Sockaddr*)
-      addrlen = sizeof(LibC::SockaddrIn6).to_u32!
-
-      if LibC.getsockname(fd, sockaddr, pointerof(addrlen)) != 0
-        raise ::Socket::Error.from_errno("getsockname")
-      end
-
-      ::Socket::IPAddress.from(sockaddr, addrlen)
+    if LibC.getsockname(fd, sockaddr, pointerof(addrlen)) != 0
+      raise ::Socket::Error.from_errno("getsockname")
     end
+
+    ::Socket::IPAddress.from(sockaddr, addrlen)
   end
 
-  private def system_remote_address
-    @remote_address_cache ||= begin
-      sockaddr6 = uninitialized LibC::SockaddrIn6
-      sockaddr = pointerof(sockaddr6).as(LibC::Sockaddr*)
-      addrlen = sizeof(LibC::SockaddrIn6).to_u32!
+  private getter(system_remote_address : ::Socket::IPAddress) do
+    sockaddr6 = uninitialized LibC::SockaddrIn6
+    sockaddr = pointerof(sockaddr6).as(LibC::Sockaddr*)
+    addrlen = sizeof(LibC::SockaddrIn6).to_u32!
 
-      if LibC.getpeername(fd, sockaddr, pointerof(addrlen)) != 0
-        raise ::Socket::Error.from_errno("getpeername")
-      end
-
-      ::Socket::IPAddress.from(sockaddr, addrlen)
+    if LibC.getpeername(fd, sockaddr, pointerof(addrlen)) != 0
+      raise ::Socket::Error.from_errno("getpeername")
     end
+
+    ::Socket::IPAddress.from(sockaddr, addrlen)
   end
 
   {% if flag?(:openbsd) %}

--- a/src/socket/ip_socket.cr
+++ b/src/socket/ip_socket.cr
@@ -7,6 +7,7 @@ class IPSocket < Socket
 
   def close
     super
+  ensure
     @local_address = nil
     @remote_address = nil
   end

--- a/src/socket/ip_socket.cr
+++ b/src/socket/ip_socket.cr
@@ -13,12 +13,14 @@ class IPSocket < Socket
 
   def connect(addr, timeout = nil, &)
     super(addr, timeout) { |error| yield error }
+  ensure
     @local_address = nil
     @remote_address = nil
   end
 
   def bind(addr)
     super(addr)
+  ensure
     @local_address = nil
     @remote_address = nil
   end

--- a/src/socket/ip_socket.cr
+++ b/src/socket/ip_socket.cr
@@ -1,11 +1,7 @@
 class IPSocket < Socket
   # Returns the `IPAddress` for the local end of the IP socket.
-  def local_address
-    system_local_address
-  end
+  getter local_address : Socket::IPAddress { system_local_address }
 
   # Returns the `IPAddress` for the remote end of the IP socket.
-  def remote_address
-    system_remote_address
-  end
+  getter remote_address : Socket::IPAddress { system_remote_address }
 end

--- a/src/socket/ip_socket.cr
+++ b/src/socket/ip_socket.cr
@@ -10,4 +10,16 @@ class IPSocket < Socket
     @local_address = nil
     @remote_address = nil
   end
+
+  def connect(addr, timeout = nil, &)
+    super(addr, timeout) { |error| yield error }
+    @local_address = nil
+    @remote_address = nil
+  end
+
+  def bind(addr)
+    super(addr)
+    @local_address = nil
+    @remote_address = nil
+  end
 end

--- a/src/socket/ip_socket.cr
+++ b/src/socket/ip_socket.cr
@@ -4,4 +4,10 @@ class IPSocket < Socket
 
   # Returns the `IPAddress` for the remote end of the IP socket.
   getter remote_address : Socket::IPAddress { system_remote_address }
+
+  def close
+    super
+    @local_address = nil
+    @remote_address = nil
+  end
 end


### PR DESCRIPTION
`HTTP::Request.from_io` queries the io's local_address and remote_address which involves calling `getsockname` and `getpeername` into the system on every request. Doing that can be expensive.

Here I propose caching this information with the socket as it won't ever change. This improves the requests/second throughput.

Before:

```
$ wrk -t12 -c100 -d30s http://127.0.0.1:8080
Running 30s test @ http://127.0.0.1:8080
  12 threads and 100 connections
  Thread Stats   Avg      Stdev     Max   +/- Stdev
    Latency     0.95ms  288.83us  12.16ms   86.64%
    Req/Sec     8.48k   523.58    20.32k    92.73%
  3042411 requests in 30.10s, 293.05MB read
Requests/sec: 101077.24
Transfer/sec:      9.74MB
```

After: (~9% improvement)
```
$ wrk -t12 -c100 -d30s http://127.0.0.1:8080
Running 30s test @ http://127.0.0.1:8080
  12 threads and 100 connections
  Thread Stats   Avg      Stdev     Max   +/- Stdev
    Latency     0.89ms  488.80us  25.49ms   94.96%
    Req/Sec     9.20k   377.40    10.80k    80.03%
  3296845 requests in 30.01s, 317.56MB read
Requests/sec: 109868.71
Transfer/sec:     10.58MB
```