### PR TITLE
Compiler: enable `x.@y` where `x` is a union type

### DIFF
--- a/spec/compiler/codegen/class_spec.cr
+++ b/spec/compiler/codegen/class_spec.cr
@@ -313,6 +313,134 @@ describe "Code gen: class" do
       )).to_i.should eq(1)
   end
 
+  it "reads a union type instance var (reference union, first type)" do
+    run(%(
+      class Foo
+        def initialize(@x : Int32)
+        end
+
+        def x
+          @x
+        end
+      end
+
+      class Bar
+        def initialize(@y : Int32, @x : Bool)
+        end
+
+        def x
+          @x
+        end
+      end
+
+      foo = Foo.new(10)
+      bar = Bar.new(2, true)
+      union = foo || bar
+      var = union.@x
+      if var.is_a?(Int32)
+        var
+      else
+        20
+      end
+      )).to_i.should eq(10)
+  end
+
+  it "reads a union type instance var (reference union, second type)" do
+    run(%(
+      class Foo
+        def initialize(@x : Int32)
+        end
+
+        def x
+          @x
+        end
+      end
+
+      class Bar
+        def initialize(@y : Int32, @x : Char)
+        end
+
+        def x
+          @x
+        end
+      end
+
+      foo = Foo.new(10)
+      bar = Bar.new(2, 'a')
+      union = bar || foo
+      var = union.@x
+      if var.is_a?(Char)
+        var
+      else
+        'b'
+      end
+      )).to_i.should eq('a'.ord)
+  end
+
+  it "reads a union type instance var (mixed union, first type)" do
+    run(%(
+      struct Foo
+        def initialize(@x : Int32)
+        end
+
+        def x
+          @x
+        end
+      end
+
+      class Bar
+        def initialize(@y : Int32, @x : Bool)
+        end
+
+        def x
+          @x
+        end
+      end
+
+      foo = Foo.new(10)
+      bar = Bar.new(2, true)
+      union = foo || bar
+      var = union.@x
+      if var.is_a?(Int32)
+        var
+      else
+        20
+      end
+      )).to_i.should eq(10)
+  end
+
+  it "reads a union type instance var (mixed union, second type)" do
+    run(%(
+      struct Foo
+        def initialize(@x : Int32)
+        end
+
+        def x
+          @x
+        end
+      end
+
+      class Bar
+        def initialize(@y : Int32, @x : Char)
+        end
+
+        def x
+          @x
+        end
+      end
+
+      foo = Foo.new(10)
+      bar = Bar.new(2, 'a')
+      union = bar || foo
+      var = union.@x
+      if var.is_a?(Char)
+        var
+      else
+        'b'
+      end
+      )).to_i.should eq('a'.ord)
+  end
+
   it "runs with nilable instance var" do
     run("
       struct Nil

--- a/spec/compiler/semantic/class_spec.cr
+++ b/spec/compiler/semantic/class_spec.cr
@@ -524,6 +524,25 @@ describe "Semantic: class" do
       "can't use instance variables inside primitive types (at Int32)"
   end
 
+  it "reads an object instance var from a union type" do
+    assert_type(%(
+      class Foo
+        def initialize(@x : Int32)
+        end
+      end
+
+      class Bar
+        def initialize(@y : Int32, @x : Char)
+        end
+      end
+
+      foo = Foo.new(1)
+      bar = Bar.new(2, 'a')
+      union = foo || bar
+      union.@x
+      )) { union_of(int32, char) }
+  end
+
   it "says that instance vars are not allowed in metaclass" do
     assert_error %(
       module Foo

--- a/spec/compiler/semantic/class_spec.cr
+++ b/spec/compiler/semantic/class_spec.cr
@@ -1148,22 +1148,6 @@ describe "Semantic: class" do
     )) { tuple_of [types["Foo"].metaclass, types["Foo"].metaclass] }
   end
 
-  it "errors if reading instance var of union type (#7187)" do
-    assert_error %(
-      class Foo
-        @x = 1
-      end
-
-      class Bar
-        @x = 1
-      end
-
-      z = Foo.new || Bar.new
-      z.@x
-      ),
-      "can't read instance variables of union types (@x of (Bar | Foo))"
-  end
-
   it "types as no return if calling method on abstract class with all abstract subclasses (#6996)" do
     assert_type(%(
       require "prelude"

--- a/src/compiler/crystal/semantic/bindings.cr
+++ b/src/compiler/crystal/semantic/bindings.cr
@@ -652,12 +652,16 @@ module Crystal
       obj_type = obj.type?
       return unless obj_type
 
-      if obj_type.is_a?(UnionType)
-        raise "can't read instance variables of union types (#{name} of #{obj_type})"
-      end
-
-      var = visitor.lookup_instance_var(self, obj_type)
-      self.type = var.type
+      self.type =
+        if obj_type.is_a?(UnionType)
+          obj_type.program.type_merge(
+            obj_type.union_types.map do |union_type|
+              visitor.lookup_instance_var(self, union_type).type
+            end
+          )
+        else
+          visitor.lookup_instance_var(self, obj_type).type
+        end
     end
   end
 


### PR DESCRIPTION
Previously this would not compile:

```crystal
class Foo
  def initialize(@x : Int32)
  end

  def x
    @x
  end
end

class Bar
  def initialize(@y : Int32, @x : Char)
  end

  def x
    @x
  end
end

foo = Foo.new(10)
bar = Bar.new(2, 'a')
union = bar || foo
var = union.@x # Error: can't read instance variable of union type
```

The reason for not enabling this was just laziness on my part. This PR makes it work. It works similar to a multi-dispatch: depending on the real type of `union` we access the instance var accordingly.

Fixes #10767
Fixes #7187