### PR TITLE
Move win32 libc bindings from winbase.cr to approriate files

### DIFF
--- a/src/crystal/system/win32/dir.cr
+++ b/src/crystal/system/win32/dir.cr
@@ -2,6 +2,7 @@ require "crystal/system/windows"
 require "c/winbase"
 require "c/direct"
 require "c/handleapi"
+require "c/processenv"
 
 module Crystal::System::Dir
   private class DirHandle

--- a/src/crystal/system/win32/dir.cr
+++ b/src/crystal/system/win32/dir.cr
@@ -1,6 +1,7 @@
 require "crystal/system/windows"
 require "c/winbase"
 require "c/direct"
+require "c/handleapi"
 
 module Crystal::System::Dir
   private class DirHandle

--- a/src/crystal/system/win32/env.cr
+++ b/src/crystal/system/win32/env.cr
@@ -1,5 +1,6 @@
 require "crystal/system/windows"
 require "c/winbase"
+require "c/processenv"
 
 module Crystal::System::Env
   # Sets an environment variable or unsets it if *value* is `nil`.

--- a/src/crystal/system/win32/file.cr
+++ b/src/crystal/system/win32/file.cr
@@ -4,6 +4,7 @@ require "c/fileapi"
 require "c/sys/utime"
 require "c/sys/stat"
 require "c/winbase"
+require "c/handleapi"
 
 module Crystal::System::File
   def self.open(filename : String, mode : String, perm : Int32 | ::File::Permissions) : LibC::Int

--- a/src/crystal/system/win32/process.cr
+++ b/src/crystal/system/win32/process.cr
@@ -1,4 +1,5 @@
 require "c/processthreadsapi"
+require "c/handleapi"
 require "process/shell"
 
 struct Crystal::System::Process

--- a/src/crystal/system/win32/time.cr
+++ b/src/crystal/system/win32/time.cr
@@ -1,5 +1,6 @@
 require "c/winbase"
 require "c/timezoneapi"
+require "c/windows"
 require "./zone_names"
 
 module Crystal::System::Time

--- a/src/crystal/system/win32/time.cr
+++ b/src/crystal/system/win32/time.cr
@@ -1,4 +1,5 @@
 require "c/winbase"
+require "c/timezoneapi"
 require "./zone_names"
 
 module Crystal::System::Time

--- a/src/lib_c/x86_64-windows-msvc/c/errhandlingapi.cr
+++ b/src/lib_c/x86_64-windows-msvc/c/errhandlingapi.cr
@@ -1,0 +1,6 @@
+require "c/int_safe"
+
+lib LibC
+  fun GetLastError : DWORD
+  fun SetLastError(dwErrCode : DWORD)
+end

--- a/src/lib_c/x86_64-windows-msvc/c/fileapi.cr
+++ b/src/lib_c/x86_64-windows-msvc/c/fileapi.cr
@@ -12,6 +12,15 @@ lib LibC
 
   fun GetFileType(hFile : HANDLE) : DWORD
 
+  struct WIN32_FILE_ATTRIBUTE_DATA
+    dwFileAttributes : DWORD
+    ftCreationTime : FILETIME
+    ftLastAccessTime : FILETIME
+    ftLastWriteTime : FILETIME
+    nFileSizeHigh : DWORD
+    nFileSizeLow : DWORD
+  end
+
   struct BY_HANDLE_FILE_INFORMATION
     dwFileAttributes : DWORD
     ftCreationTime : FILETIME

--- a/src/lib_c/x86_64-windows-msvc/c/fileapi.cr
+++ b/src/lib_c/x86_64-windows-msvc/c/fileapi.cr
@@ -1,5 +1,6 @@
 require "c/winnt"
 require "c/basetsd"
+require "c/wtypesbase"
 
 lib LibC
   fun GetFullPathNameW(lpFileName : LPWSTR, nBufferLength : DWORD, lpBuffer : LPWSTR, lpFilePart : LPWSTR*) : DWORD

--- a/src/lib_c/x86_64-windows-msvc/c/handleapi.cr
+++ b/src/lib_c/x86_64-windows-msvc/c/handleapi.cr
@@ -1,0 +1,11 @@
+require "c/winnt"
+
+lib LibC
+  INVALID_HANDLE_VALUE = HANDLE.new(-1)
+
+  fun CloseHandle(hObject : HANDLE) : BOOL
+
+  fun DuplicateHandle(hSourceProcessHandle : HANDLE, hSourceHandle : HANDLE,
+                      hTargetProcessHandle : HANDLE, lpTargetHandle : HANDLE*,
+                      dwDesiredAccess : DWORD, bInheritHandle : BOOL, dwOptions : DWORD) : BOOL
+end

--- a/src/lib_c/x86_64-windows-msvc/c/minwinbase.cr
+++ b/src/lib_c/x86_64-windows-msvc/c/minwinbase.cr
@@ -1,0 +1,26 @@
+# part of winbase
+lib LibC
+  struct FILETIME
+    dwLowDateTime : DWORD
+    dwHighDateTime : DWORD
+  end
+
+  struct SYSTEMTIME
+    wYear : WORD
+    wMonth : WORD
+    wDayOfWeek : WORD
+    wDay : WORD
+    wHour : WORD
+    wMinute : WORD
+    wSecond : WORD
+    wMilliseconds : WORD
+  end
+
+  enum GET_FILEEX_INFO_LEVELS
+    GetFileExInfoStandard
+    GetFileExMaxInfoLevel
+  end
+
+  STATUS_PENDING = 0x103
+  STILL_ACTIVE   = STATUS_PENDING
+end

--- a/src/lib_c/x86_64-windows-msvc/c/processenv.cr
+++ b/src/lib_c/x86_64-windows-msvc/c/processenv.cr
@@ -1,0 +1,11 @@
+require "c/winnt"
+
+lib LibC
+  fun GetCurrentDirectoryW(nBufferLength : DWORD, lpBuffer : LPWSTR) : DWORD
+  fun SetCurrentDirectoryW(lpPathname : LPWSTR) : BOOL
+
+  fun GetEnvironmentVariableW(lpName : LPWSTR, lpBuffer : LPWSTR, nSize : DWORD) : DWORD
+  fun GetEnvironmentStringsW : LPWCH
+  fun FreeEnvironmentStringsW(lpszEnvironmentBlock : LPWCH) : BOOL
+  fun SetEnvironmentVariableW(lpName : LPWSTR, lpValue : LPWSTR) : BOOL
+end

--- a/src/lib_c/x86_64-windows-msvc/c/processthreadsapi.cr
+++ b/src/lib_c/x86_64-windows-msvc/c/processthreadsapi.cr
@@ -1,4 +1,5 @@
 require "./basetsd"
+require "c/wtypesbase"
 
 lib LibC
   CREATE_UNICODE_ENVIRONMENT = 0x00000400

--- a/src/lib_c/x86_64-windows-msvc/c/profileapi.cr
+++ b/src/lib_c/x86_64-windows-msvc/c/profileapi.cr
@@ -1,0 +1,6 @@
+# part of windows
+
+lib LibC
+  fun QueryPerformanceCounter(lpPerformanceCount : LARGE_INTEGER*) : BOOL
+  fun QueryPerformanceFrequency(lpFrequency : LARGE_INTEGER*) : BOOL
+end

--- a/src/lib_c/x86_64-windows-msvc/c/sysinfoapi.cr
+++ b/src/lib_c/x86_64-windows-msvc/c/sysinfoapi.cr
@@ -1,8 +1,9 @@
-require "c/winnt"
-require "c/win_def"
-require "c/int_safe"
+require "c/winbase"
 
 lib LibC
+  fun GetSystemTimeAsFileTime(time : FILETIME*)
+  fun GetSystemTimePreciseAsFileTime(time : FILETIME*)
+
   fun GetNativeSystemInfo(system_info : SYSTEM_INFO*)
 
   struct PROCESSOR_INFO

--- a/src/lib_c/x86_64-windows-msvc/c/timezoneapi.cr
+++ b/src/lib_c/x86_64-windows-msvc/c/timezoneapi.cr
@@ -1,0 +1,21 @@
+require "c/winnt"
+require "c/winbase"
+
+lib LibC
+  struct TIME_ZONE_INFORMATION
+    bias : LONG
+    standardName : StaticArray(WCHAR, 32)
+    standardDate : SYSTEMTIME
+    standardBias : LONG
+    daylightName : StaticArray(WCHAR, 32)
+    daylightDate : SYSTEMTIME
+    daylightBias : LONG
+  end
+
+  TIME_TONE_ID_INVALID  = 0xffffffff_u32
+  TIME_ZONE_ID_UNKNOWN  =          0_u32
+  TIME_ZONE_ID_STANDARD =          1_u32
+  TIME_ZONE_ID_DAYLIGHT =          2_u32
+
+  fun GetTimeZoneInformation(tz_info : TIME_ZONE_INFORMATION*) : DWORD
+end

--- a/src/lib_c/x86_64-windows-msvc/c/winbase.cr
+++ b/src/lib_c/x86_64-windows-msvc/c/winbase.cr
@@ -27,12 +27,6 @@ lib LibC
   fun CreateHardLinkW(lpFileName : LPWSTR, lpExistingFileName : LPWSTR, lpSecurityAttributes : Void*) : BOOL
   fun CreateSymbolicLinkW(lpSymlinkFileName : LPWSTR, lpTargetFileName : LPWSTR, dwFlags : DWORD) : BOOLEAN
 
-  struct SECURITY_ATTRIBUTES
-    nLength : DWORD
-    lpSecurityDescriptor : Void*
-    bInheritHandle : BOOL
-  end
-
   fun GetEnvironmentVariableW(lpName : LPWSTR, lpBuffer : LPWSTR, nSize : DWORD) : DWORD
   fun GetEnvironmentStringsW : LPWCH
   fun FreeEnvironmentStringsW(lpszEnvironmentBlock : LPWCH) : BOOL

--- a/src/lib_c/x86_64-windows-msvc/c/winbase.cr
+++ b/src/lib_c/x86_64-windows-msvc/c/winbase.cr
@@ -1,6 +1,7 @@
 require "c/winnt"
 require "c/win_def"
 require "c/int_safe"
+require "c/minwinbase"
 
 lib LibC
   FORMAT_MESSAGE_ALLOCATE_BUFFER = 0x00000100_u32
@@ -13,22 +14,6 @@ lib LibC
 
   fun FormatMessageW(dwFlags : DWORD, lpSource : Void*, dwMessageId : DWORD, dwLanguageId : DWORD,
                      lpBuffer : LPWSTR, nSize : DWORD, arguments : Void*) : DWORD
-
-  struct FILETIME
-    dwLowDateTime : DWORD
-    dwHighDateTime : DWORD
-  end
-
-  struct SYSTEMTIME
-    wYear : WORD
-    wMonth : WORD
-    wDayOfWeek : WORD
-    wDay : WORD
-    wHour : WORD
-    wMinute : WORD
-    wSecond : WORD
-    wMilliseconds : WORD
-  end
 
   struct TIME_ZONE_INFORMATION
     bias : LONG
@@ -69,11 +54,6 @@ lib LibC
     nFileSizeLow : DWORD
   end
 
-  enum GET_FILEEX_INFO_LEVELS
-    GetFileExInfoStandard
-    GetFileExMaxInfoLevel
-  end
-
   struct SECURITY_ATTRIBUTES
     nLength : DWORD
     lpSecurityDescriptor : Void*
@@ -86,8 +66,6 @@ lib LibC
   fun SetEnvironmentVariableW(lpName : LPWSTR, lpValue : LPWSTR) : BOOL
 
   INFINITE = 0xFFFFFFFF
-
-  STILL_ACTIVE = 0x103
 
   STARTF_USESTDHANDLES = 0x00000100
 

--- a/src/lib_c/x86_64-windows-msvc/c/winbase.cr
+++ b/src/lib_c/x86_64-windows-msvc/c/winbase.cr
@@ -18,9 +18,6 @@ lib LibC
   fun GetSystemTimeAsFileTime(time : FILETIME*)
   fun GetSystemTimePreciseAsFileTime(time : FILETIME*)
 
-  fun QueryPerformanceCounter(performance_count : Int64*) : BOOL
-  fun QueryPerformanceFrequency(frequency : Int64*) : BOOL
-
   fun GetCurrentDirectoryW(nBufferLength : DWORD, lpBuffer : LPWSTR) : DWORD
   fun SetCurrentDirectoryW(lpPathname : LPWSTR) : BOOL
 

--- a/src/lib_c/x86_64-windows-msvc/c/winbase.cr
+++ b/src/lib_c/x86_64-windows-msvc/c/winbase.cr
@@ -15,21 +15,6 @@ lib LibC
   fun FormatMessageW(dwFlags : DWORD, lpSource : Void*, dwMessageId : DWORD, dwLanguageId : DWORD,
                      lpBuffer : LPWSTR, nSize : DWORD, arguments : Void*) : DWORD
 
-  struct TIME_ZONE_INFORMATION
-    bias : LONG
-    standardName : StaticArray(WCHAR, 32)
-    standardDate : SYSTEMTIME
-    standardBias : LONG
-    daylightName : StaticArray(WCHAR, 32)
-    daylightDate : SYSTEMTIME
-    daylightBias : LONG
-  end
-
-  TIME_ZONE_ID_UNKNOWN  = 0_u32
-  TIME_ZONE_ID_STANDARD = 1_u32
-  TIME_ZONE_ID_DAYLIGHT = 2_u32
-
-  fun GetTimeZoneInformation(tz_info : TIME_ZONE_INFORMATION*) : DWORD
   fun GetSystemTimeAsFileTime(time : FILETIME*)
   fun GetSystemTimePreciseAsFileTime(time : FILETIME*)
 

--- a/src/lib_c/x86_64-windows-msvc/c/winbase.cr
+++ b/src/lib_c/x86_64-windows-msvc/c/winbase.cr
@@ -27,15 +27,6 @@ lib LibC
   fun CreateHardLinkW(lpFileName : LPWSTR, lpExistingFileName : LPWSTR, lpSecurityAttributes : Void*) : BOOL
   fun CreateSymbolicLinkW(lpSymlinkFileName : LPWSTR, lpTargetFileName : LPWSTR, dwFlags : DWORD) : BOOLEAN
 
-  struct WIN32_FILE_ATTRIBUTE_DATA
-    dwFileAttributes : DWORD
-    ftCreationTime : FILETIME
-    ftLastAccessTime : FILETIME
-    ftLastWriteTime : FILETIME
-    nFileSizeHigh : DWORD
-    nFileSizeLow : DWORD
-  end
-
   struct SECURITY_ATTRIBUTES
     nLength : DWORD
     lpSecurityDescriptor : Void*

--- a/src/lib_c/x86_64-windows-msvc/c/winbase.cr
+++ b/src/lib_c/x86_64-windows-msvc/c/winbase.cr
@@ -83,10 +83,6 @@ lib LibC
     bInheritHandle : BOOL
   end
 
-  INVALID_HANDLE_VALUE = HANDLE.new(-1)
-
-  fun CloseHandle(hObject : HANDLE) : BOOL
-
   fun GetEnvironmentVariableW(lpName : LPWSTR, lpBuffer : LPWSTR, nSize : DWORD) : DWORD
   fun GetEnvironmentStringsW : LPWCH
   fun FreeEnvironmentStringsW(lpszEnvironmentBlock : LPWCH) : BOOL
@@ -97,10 +93,6 @@ lib LibC
   STILL_ACTIVE = 0x103
 
   STARTF_USESTDHANDLES = 0x00000100
-
-  fun DuplicateHandle(hSourceProcessHandle : HANDLE, hSourceHandle : HANDLE,
-                      hTargetProcessHandle : HANDLE, lpTargetHandle : HANDLE*,
-                      dwDesiredAccess : DWORD, bInheritHandle : BOOL, dwOptions : DWORD) : BOOL
 
   MOVEFILE_REPLACE_EXISTING      =  0x1_u32
   MOVEFILE_COPY_ALLOWED          =  0x2_u32

--- a/src/lib_c/x86_64-windows-msvc/c/winbase.cr
+++ b/src/lib_c/x86_64-windows-msvc/c/winbase.cr
@@ -18,9 +18,6 @@ lib LibC
   fun GetSystemTimeAsFileTime(time : FILETIME*)
   fun GetSystemTimePreciseAsFileTime(time : FILETIME*)
 
-  fun GetCurrentDirectoryW(nBufferLength : DWORD, lpBuffer : LPWSTR) : DWORD
-  fun SetCurrentDirectoryW(lpPathname : LPWSTR) : BOOL
-
   SYMBOLIC_LINK_FLAG_DIRECTORY                 = 0x1
   SYMBOLIC_LINK_FLAG_ALLOW_UNPRIVILEGED_CREATE = 0x2
 

--- a/src/lib_c/x86_64-windows-msvc/c/winbase.cr
+++ b/src/lib_c/x86_64-windows-msvc/c/winbase.cr
@@ -3,9 +3,6 @@ require "c/win_def"
 require "c/int_safe"
 
 lib LibC
-  fun GetLastError : DWORD
-  fun SetLastError(dwErrCode : DWORD)
-
   FORMAT_MESSAGE_ALLOCATE_BUFFER = 0x00000100_u32
   FORMAT_MESSAGE_IGNORE_INSERTS  = 0x00000200_u32
   FORMAT_MESSAGE_FROM_STRING     = 0x00000400_u32

--- a/src/lib_c/x86_64-windows-msvc/c/windows.cr
+++ b/src/lib_c/x86_64-windows-msvc/c/windows.cr
@@ -1,0 +1,3 @@
+require "c/winnt"
+
+require "c/profileapi"

--- a/src/lib_c/x86_64-windows-msvc/c/winnt.cr
+++ b/src/lib_c/x86_64-windows-msvc/c/winnt.cr
@@ -3,6 +3,7 @@ require "c/int_safe"
 lib LibC
   alias BOOLEAN = BYTE
   alias LONG = Int32
+  alias LARGE_INTEGER = Int64
 
   alias CHAR = UChar
   alias WCHAR = UInt16

--- a/src/lib_c/x86_64-windows-msvc/c/winnt.cr
+++ b/src/lib_c/x86_64-windows-msvc/c/winnt.cr
@@ -1,3 +1,5 @@
+require "c/int_safe"
+
 lib LibC
   alias BOOLEAN = BYTE
   alias LONG = Int32

--- a/src/lib_c/x86_64-windows-msvc/c/wtypesbase.cr
+++ b/src/lib_c/x86_64-windows-msvc/c/wtypesbase.cr
@@ -1,0 +1,9 @@
+require "c/winnt"
+
+lib LibC
+  struct SECURITY_ATTRIBUTES
+    nLength : DWORD
+    lpSecurityDescriptor : Void*
+    bInheritHandle : BOOL
+  end
+end

--- a/src/winerror.cr
+++ b/src/winerror.cr
@@ -1,5 +1,6 @@
 {% if flag?(:win32) %}
   require "c/winbase"
+  require "c/errhandlingapi"
 {% end %}
 
 # `WinError` represents Windows' [System Error Codes](https://docs.microsoft.com/en-us/windows/win32/debug/system-error-codes#system-error-codes-1).


### PR DESCRIPTION
`winbase.cr` served as a kind of holding center for all kinds of methods, that are actually defined in other headers files. This patch moves them all to the appropriate places. Everything that's left is as far as I can see, actually defined in `winbase.h`.