### PR TITLE
Change protocol socket fd to `Socket::Handle`

### DIFF
--- a/src/socket/tcp_server.cr
+++ b/src/socket/tcp_server.cr
@@ -49,7 +49,7 @@ class TCPServer < TCPSocket
   end
 
   # Creates a TCPServer from an already configured raw file descriptor
-  def initialize(*, fd : Int32, family : Family = Family::INET)
+  def initialize(*, fd : Handle, family : Family = Family::INET)
     super(fd: fd, family: family)
   end
 

--- a/src/socket/tcp_socket.cr
+++ b/src/socket/tcp_socket.cr
@@ -38,12 +38,12 @@ class TCPSocket < IPSocket
     super family, type, protocol
   end
 
-  protected def initialize(fd : Int32, family : Family, type : Type, protocol : Protocol)
+  protected def initialize(fd : Handle, family : Family, type : Type, protocol : Protocol)
     super fd, family, type, protocol
   end
 
   # Creates a TCPSocket from an already configured raw file descriptor
-  def initialize(*, fd : Int32, family : Family = Family::INET)
+  def initialize(*, fd : Handle, family : Family = Family::INET)
     super fd, family, Type::STREAM, Protocol::TCP
   end
 

--- a/src/socket/unix_server.cr
+++ b/src/socket/unix_server.cr
@@ -46,7 +46,7 @@ class UNIXServer < UNIXSocket
   end
 
   # Creates a UNIXServer from an already configured raw file descriptor
-  def initialize(*, fd : Int32, type : Type = Type::STREAM, @path : String? = nil)
+  def initialize(*, fd : Handle, type : Type = Type::STREAM, @path : String? = nil)
     super(fd: fd, type: type, path: @path)
   end
 

--- a/src/socket/unix_socket.cr
+++ b/src/socket/unix_socket.cr
@@ -29,7 +29,7 @@ class UNIXSocket < Socket
   end
 
   # Creates a UNIXSocket from an already configured raw file descriptor
-  def initialize(*, fd : Int32, type : Type = Type::STREAM, @path : String? = nil)
+  def initialize(*, fd : Handle, type : Type = Type::STREAM, @path : String? = nil)
     super fd, Family::UNIX, type, Protocol::IP
   end
 


### PR DESCRIPTION
This fixes a couple of refactors missed in #10706. Socket uses `Handle` as a platform-independent handle type. The protocol sockets should do the same.
On Linux, `Handle` is `Int32`, so this change has no real effect, but it enables those methods to work on windows.