### PR TITLE
Add `Socket::Addrinfo#inspect`

### DIFF
--- a/spec/std/socket/addrinfo_spec.cr
+++ b/spec/std/socket/addrinfo_spec.cr
@@ -65,11 +65,11 @@ describe Socket::Addrinfo do
     end
   end
 
-  it "#to_s" do
+  it "#inspect" do
     addrinfos = Socket::Addrinfo.tcp("127.0.0.1", 12345)
-    addrinfos.first.to_s.should eq "Socket::Addrinfo(127.0.0.1:12345, INET, STREAM, TCP)"
+    addrinfos.first.inspect.should eq "Socket::Addrinfo(127.0.0.1:12345, INET, STREAM, TCP)"
 
     addrinfos = Socket::Addrinfo.udp("127.0.0.1", 12345)
-    addrinfos.first.to_s.should eq "Socket::Addrinfo(127.0.0.1:12345, INET, DGRAM, UDP)"
+    addrinfos.first.inspect.should eq "Socket::Addrinfo(127.0.0.1:12345, INET, DGRAM, UDP)"
   end
 end

--- a/spec/std/socket/addrinfo_spec.cr
+++ b/spec/std/socket/addrinfo_spec.cr
@@ -64,4 +64,12 @@ describe Socket::Addrinfo do
       typeof(addrinfos.first.ip_address).should eq(Socket::IPAddress)
     end
   end
+
+  it "#to_s" do
+    addrinfos = Socket::Addrinfo.tcp("127.0.0.1", 12345)
+    addrinfos.first.to_s.should eq "Socket::Addrinfo(127.0.0.1:12345, INET, STREAM, TCP)"
+
+    addrinfos = Socket::Addrinfo.udp("127.0.0.1", 12345)
+    addrinfos.first.to_s.should eq "Socket::Addrinfo(127.0.0.1:12345, INET, DGRAM, UDP)"
+  end
 end

--- a/src/socket/addrinfo.cr
+++ b/src/socket/addrinfo.cr
@@ -212,7 +212,7 @@ class Socket
       @ip_address ||= IPAddress.from(to_unsafe, size)
     end
 
-    def to_s(io : IO)
+    def inspect(io : IO)
       io << "Socket::Addrinfo("
       io << ip_address << ", "
       io << family << ", "

--- a/src/socket/addrinfo.cr
+++ b/src/socket/addrinfo.cr
@@ -212,6 +212,15 @@ class Socket
       @ip_address ||= IPAddress.from(to_unsafe, size)
     end
 
+    def to_s(io : IO)
+      io << "Socket::Addrinfo("
+      io << ip_address << ", "
+      io << family << ", "
+      io << type << ", "
+      io << protocol
+      io << ")"
+    end
+
     def to_unsafe
       pointerof(@addr).as(LibC::Sockaddr*)
     end


### PR DESCRIPTION
I needed some addrinfo debug print out and didn't like digesting the raw `SockaddrIn` data structures, so I added a quick `#inspect` method.