### PR TITLE
Fix subtype relation when generic type variable is a virtual abstract struct

### DIFF
--- a/spec/compiler/semantic/struct_spec.cr
+++ b/spec/compiler/semantic/struct_spec.cr
@@ -180,4 +180,49 @@ describe "Semantic: struct" do
       ),
       "structs can't have finalizers because they are not tracked by the GC"
   end
+
+  it "passes subtype check with generic module type on virtual type" do
+    mod = semantic(%(
+      module Base(T)
+      end
+
+      abstract struct Foo
+        include Base(Foo)
+      end
+      )).program
+
+    base_foo = mod.generic_module("Base", mod.types["Foo"].virtual_type!)
+    mod.types["Foo"].implements?(base_foo).should be_true
+  end
+
+  it "passes subtype check with generic module type on virtual type (2) (#10302)" do
+    mod = semantic(%(
+      module Base(T)
+      end
+
+      abstract struct Foo
+        include Base(Foo)
+      end
+
+      struct Bar < Foo
+      end
+      )).program
+
+    base_foo = mod.generic_module("Base", mod.types["Foo"].virtual_type)
+    mod.types["Bar"].implements?(base_foo).should be_true
+  end
+
+  it "passes subtype check with generic module type on virtual type (3)" do
+    mod = semantic(%(
+      module Base(T, N)
+      end
+
+      abstract struct Foo
+        include Base(Foo, 10)
+      end
+      )).program
+
+    mod.types["Foo"].implements?(mod.generic_module("Base", mod.types["Foo"].virtual_type!, NumberLiteral.new("10", :i32))).should be_true
+    mod.types["Foo"].implements?(mod.generic_module("Base", mod.types["Foo"].virtual_type!, NumberLiteral.new("9", :i32))).should be_false
+  end
 end

--- a/src/compiler/crystal/types.cr
+++ b/src/compiler/crystal/types.cr
@@ -1937,6 +1937,23 @@ module Crystal
       generic_type.instantiate(new_type_vars)
     end
 
+    def implements?(other_type : GenericInstanceType)
+      if other_type.is_a?(GenericInstanceType) && generic_type == other_type.generic_type
+        type_vars.each do |name, type_var|
+          other_type_var = other_type.type_vars[name]
+          if type_var.is_a?(Var) && other_type_var.is_a?(Var)
+            # type vars are invariant here; (Named)TupleInstanceType have their own logic
+            return super unless type_var.type.devirtualize == other_type_var.type.devirtualize
+          else
+            return super unless type_var == other_type_var
+          end
+        end
+        return true
+      end
+
+      super
+    end
+
     def implements?(other_type)
       other_type = other_type.remove_alias
       super || generic_type.implements?(other_type)


### PR DESCRIPTION
Fixes part of #10302 (see https://github.com/crystal-lang/crystal/issues/10302#issuecomment-853608648), by applying #10304's logic to `Crystal::Type#implements?`.