### PR TITLE
Fix Socket::Connect error in addrinfo inherit os_error 

### DIFF
--- a/src/socket/addrinfo.cr
+++ b/src/socket/addrinfo.cr
@@ -96,7 +96,7 @@ class Socket
         new error_code, nil, domain: domain
       end
 
-      protected def self.new_from_os_error(message : String, os_error, *, domain, type, service, protocol, **opts)
+      protected def self.new_from_os_error(message : String?, os_error, *, domain, type, service, protocol, **opts)
         new(message, **opts)
       end
 

--- a/src/socket/addrinfo.cr
+++ b/src/socket/addrinfo.cr
@@ -71,7 +71,7 @@ class Socket
 
           unless addrinfo = addrinfo.try(&.next?)
             if error.is_a?(Socket::ConnectError)
-              raise Socket::ConnectError.from_errno("Error connecting to '#{domain}:#{service}'")
+              raise Socket::ConnectError.from_os_error("Error connecting to '#{domain}:#{service}'", error.os_error)
             else
               raise error if error
             end

--- a/src/system_error.cr
+++ b/src/system_error.cr
@@ -27,7 +27,7 @@
 #   Prepares the message that goes before the system error description.
 #   By default it returns the original message unchanged. But that could be
 #   customized based on the keyword arguments passed to `from_errno` or `from_winerror`.
-# * `protected def new_from_os_error(message : String, os_error, **opts)`
+# * `protected def new_from_os_error(message : String?, os_error, **opts)`
 #   Creates an instance of the exception that wraps a system error.
 #   This is a factory method and by default it creates an instance
 #   of the current class. It can be overridden to generate different
@@ -103,7 +103,7 @@ module SystemError
     # This is a factory method and by default it creates an instance
     # of the current class. It can be overridden to generate different
     # classes based on the `os_error` value or keyword arguments.
-    protected def new_from_os_error(message : String, os_error, **opts)
+    protected def new_from_os_error(message : String?, os_error, **opts)
       self.new(message, **opts)
     end
 


### PR DESCRIPTION
This change is necessary, because `errno` may not actually have the corresponding value anymore, and the reliance on `Errno` is not portable.

The first commit changes `SystemError.new_from_os_error` to allow `message` parameter be nil. `os_error` in `.from_os_error` may be nil, hence the message can be nil, too.