### PR TITLE
Handle invalid option errors on 'crystal spec'.

### DIFF
--- a/src/spec.cr
+++ b/src/spec.cr
@@ -110,7 +110,11 @@ def Spec.configure_formatter(formatter, output_path = nil)
   end
 end
 
-Spec.option_parser.parse(ARGV)
+begin
+  Spec.option_parser.parse(ARGV)
+rescue e : OptionParser::InvalidOption
+  abort("Error: #{e.message}")
+end
 
 unless ARGV.empty?
   STDERR.puts "Error: unknown argument '#{ARGV.first}'"


### PR DESCRIPTION
This just rescue OptionParser::InvalidOption, so instead of:

```
$ crystal spec -asd
Unhandled exception: Invalid option: -asd (OptionParser::InvalidOption)
  from /usr/lib/crystal/option_parser.cr:124:45 in '->'
  from /usr/lib/crystal/primitives.cr:255:3 in 'parse'
  from /usr/lib/crystal/option_parser.cr:114:5 in '__crystal_main'
  from /usr/lib/crystal/crystal/main.cr:110:5 in 'main_user_code'
  from /usr/lib/crystal/crystal/main.cr:96:7 in 'main'
  from /usr/lib/crystal/crystal/main.cr:119:3 in 'main'
  from __libc_start_main
  from _start
  from ???
```

It does:

```
$ crystal spec --asd
Error: Invalid option: --asd
```