### PR TITLE
Add methods for cumulative folding and prefix sums

### DIFF
--- a/spec/std/enumerable_spec.cr
+++ b/spec/std/enumerable_spec.cr
@@ -625,6 +625,42 @@ describe "Enumerable" do
     end
   end
 
+  describe "#accumulate" do
+    context "prefix sums" do
+      it { SpecEnumerable.new.accumulate.should eq([1, 3, 6]) }
+      it { [1.5, 3.75, 6.125].accumulate.should eq([1.5, 5.25, 11.375]) }
+      it { Array(Int32).new.accumulate.should eq(Array(Int32).new) }
+    end
+
+    context "prefix sums, with init" do
+      it { SpecEnumerable.new.accumulate(0).should eq([0, 1, 3, 6]) }
+      it { [1.5, 3.75, 6.125].accumulate(0.5).should eq([0.5, 2.0, 5.75, 11.875]) }
+      it { Array(Int32).new.accumulate(7).should eq([7]) }
+
+      it "preserves initial type" do
+        x = SpecEnumerable.new.accumulate(4.0)
+        x.should be_a(Array(Float64))
+        x.should eq([4.0, 5.0, 7.0, 10.0])
+      end
+    end
+
+    context "generic cumulative fold" do
+      it { SpecEnumerable.new.accumulate { |x, y| x * 10 + y }.should eq([1, 12, 123]) }
+      it { Array(Int32).new.accumulate { raise "" }.should eq(Array(Int32).new) }
+    end
+
+    context "generic cumulative fold, with init" do
+      it { SpecEnumerable.new.accumulate(4) { |x, y| x * 10 + y }.should eq([4, 41, 412, 4123]) }
+      it { Array(Int32).new.accumulate(7) { raise "" }.should eq([7]) }
+
+      it "preserves initial type" do
+        x = [4, 3, 2].accumulate("X") { |x, y| x * y }
+        x.should be_a(Array(String))
+        x.should eq(%w(X XXXX XXXXXXXXXXXX XXXXXXXXXXXXXXXXXXXXXXXX))
+      end
+    end
+  end
+
   describe "#join" do
     it "()" do
       [1, 2, 3].join.should eq("123")

--- a/spec/std/iterator_spec.cr
+++ b/spec/std/iterator_spec.cr
@@ -44,6 +44,92 @@ describe Iterator do
     end
   end
 
+  describe "#accumulate" do
+    context "prefix sums" do
+      it "returns prefix sums" do
+        iter = (1..4).each.accumulate
+        iter.next.should eq(1)
+        iter.next.should eq(3)
+        iter.next.should eq(6)
+        iter.next.should eq(10)
+        iter.next.should be_a(Iterator::Stop)
+      end
+
+      it "empty iterator stops immediately" do
+        (1..0).each.accumulate.next.should be_a(Iterator::Stop)
+      end
+    end
+
+    context "prefix sums, with init" do
+      it "returns prefix sums" do
+        iter = (1..4).each.accumulate(5)
+        iter.next.should eq(5)
+        iter.next.should eq(6)
+        iter.next.should eq(8)
+        iter.next.should eq(11)
+        iter.next.should eq(15)
+        iter.next.should be_a(Iterator::Stop)
+      end
+
+      it "preserves initial type" do
+        iter = {'a', 'b', 'c'}.each.accumulate("def")
+        iter.next.should eq("def")
+        iter.next.should eq("defa")
+        iter.next.should eq("defab")
+        iter.next.should eq("defabc")
+        iter.next.should be_a(Iterator::Stop)
+      end
+
+      it "empty iterator returns only initial value" do
+        iter = (1..0).each.accumulate(7)
+        iter.next.should eq(7)
+        iter.next.should be_a(Iterator::Stop)
+      end
+    end
+
+    context "generic cumulative fold" do
+      it "accumulates values" do
+        iter = (4..7).each.accumulate { |x, y| x * 10 + y }
+        iter.next.should eq(4)
+        iter.next.should eq(45)
+        iter.next.should eq(456)
+        iter.next.should eq(4567)
+        iter.next.should be_a(Iterator::Stop)
+      end
+
+      it "empty iterator stops immediately" do
+        (1..0).each.accumulate { raise "" }.next.should be_a(Iterator::Stop)
+      end
+    end
+
+    context "generic cumulative fold, with init" do
+      it "accumulates values" do
+        iter = (4..7).each.accumulate(8) { |x, y| x * 10 + y }
+        iter.next.should eq(8)
+        iter.next.should eq(84)
+        iter.next.should eq(845)
+        iter.next.should eq(8456)
+        iter.next.should eq(84567)
+        iter.next.should be_a(Iterator::Stop)
+      end
+
+      it "preserves initial type" do
+        iter = {4, 3, 2}.each.accumulate("X") { |x, y| x * y }
+        iter.next.should eq("X")
+        iter.next.should eq("XXXX")
+        iter.next.should eq("XXXXXXXXXXXX")
+        iter.next.should eq("XXXXXXXXXXXXXXXXXXXXXXXX")
+        iter.next.should be_a(Iterator::Stop)
+      end
+
+      it "empty iterator returns only initial value" do
+        iter = (1..0).each.accumulate(7) { raise "" }
+        iter.next.should eq(7)
+        iter.next.should be_a(Iterator::Stop)
+      end
+    end
+  end
+
   describe "compact_map" do
     it "applies the function and removes nil values" do
       iter = (1..3).each.compact_map { |e| e.odd? ? e : nil }

--- a/src/iterable.cr
+++ b/src/iterable.cr
@@ -75,4 +75,24 @@ module Iterable(T)
   def chunk_while(reuse : Bool | Array(T) = false, &block : T, T -> B) forall B
     each.chunk_while(reuse, &block)
   end
+
+  # Same as `each.accumulate`.
+  def each_accumulated
+    each.accumulate
+  end
+
+  # Same as `each.accumulate(initial)`.
+  def each_accumulated(initial : U) forall U
+    each.accumulate(initial)
+  end
+
+  # Same as `each.accumulate(&block)`.
+  def each_accumulated(&block : T, T -> T)
+    each.accumulate(&block)
+  end
+
+  # Same as `each.accumulate(initial, &block)`.
+  def each_accumulated(initial : U, &block : U, T -> U) forall U
+    each.accumulate(initial, &block)
+  end
 end

--- a/src/iterable.cr
+++ b/src/iterable.cr
@@ -75,24 +75,4 @@ module Iterable(T)
   def chunk_while(reuse : Bool | Array(T) = false, &block : T, T -> B) forall B
     each.chunk_while(reuse, &block)
   end
-
-  # Same as `each.accumulate`.
-  def each_accumulated
-    each.accumulate
-  end
-
-  # Same as `each.accumulate(initial)`.
-  def each_accumulated(initial : U) forall U
-    each.accumulate(initial)
-  end
-
-  # Same as `each.accumulate(&block)`.
-  def each_accumulated(&block : T, T -> T)
-    each.accumulate(&block)
-  end
-
-  # Same as `each.accumulate(initial, &block)`.
-  def each_accumulated(initial : U, &block : U, T -> U) forall U
-    each.accumulate(initial, &block)
-  end
 end

--- a/src/iterator.cr
+++ b/src/iterator.cr
@@ -144,6 +144,113 @@ module Iterator(T)
   # are no more elements.
   abstract def next
 
+  # Returns an iterator that returns the prefix sums of the original iterator's
+  # elements.
+  #
+  # Expects `T` to respond to the `#+` method.
+  #
+  # ```
+  # iter = (3..6).each.accumulate
+  # iter.next # => 3
+  # iter.next # => 7
+  # iter.next # => 12
+  # iter.next # => 18
+  # iter.next # => Iterator::Stop::INSTANCE
+  # ```
+  def accumulate
+    accumulate { |x, y| x + y }
+  end
+
+  # Returns an iterator that returns *initial* and its prefix sums with the
+  # original iterator's elements.
+  #
+  # Expects `U` to respond to the `#+` method.
+  #
+  # ```
+  # iter = (3..6).each.accumulate(7)
+  # iter.next # => 7
+  # iter.next # => 10
+  # iter.next # => 14
+  # iter.next # => 19
+  # iter.next # => 25
+  # iter.next # => Iterator::Stop::INSTANCE
+  # ```
+  def accumulate(initial : U) forall U
+    accumulate(initial) { |x, y| x + y }
+  end
+
+  # Returns an iterator that accumulates the original iterator's elements by
+  # the given *block*.
+  #
+  # For each element of the original iterator the block is passed an accumulator
+  # value and the element. The result becomes the new value for the accumulator
+  # and is then returned. The initial value for the accumulator is the first
+  # element of the original iterator.
+  #
+  # ```
+  # iter = %w(the quick brown fox).each.accumulate { |x, y| "#{x}, #{y}" }
+  # iter.next # => "the"
+  # iter.next # => "the, quick"
+  # iter.next # => "the, quick, brown"
+  # iter.next # => "the, quick, brown, fox"
+  # iter.next # => Iterator::Stop::INSTANCE
+  # ```
+  def accumulate(&block : T, T -> T)
+    Accumulate(typeof(self), T).new(self, block)
+  end
+
+  # Returns an iterator that accumulates *initial* with the original iterator's
+  # elements by the given *block*.
+  #
+  # Similar to `#accumulate(&block : T, T -> T)`, except the initial value is
+  # provided by an argument and needs not have the same type as the elements of
+  # the original iterator. This initial value is returned first.
+  #
+  # ```
+  # iter = [4, 3, 2].each.accumulate("X") { |x, y| x * y }
+  # iter.next # => "X"
+  # iter.next # => "XXXX"
+  # iter.next # => "XXXXXXXXXXXX"
+  # iter.next # => "XXXXXXXXXXXXXXXXXXXXXXXX"
+  # iter.next # => Iterator::Stop::INSTANCE
+  # ```
+  def accumulate(initial : U, &block : U, T -> U) forall U
+    AccumulateInit(typeof(self), T, U).new(self, initial, block)
+  end
+
+  private class AccumulateInit(I, T, U)
+    include Iterator(U)
+
+    @acc : U | Iterator::Stop
+
+    def initialize(@iterator : I, @acc : U, @func : U, T -> U)
+    end
+
+    def next
+      old_acc = @acc
+      return old_acc if old_acc.is_a?(Iterator::Stop)
+      elem = @iterator.next
+      @acc = elem.is_a?(Iterator::Stop) ? elem : @func.call(old_acc, elem)
+      old_acc
+    end
+  end
+
+  private class Accumulate(I, T)
+    include Iterator(T)
+    include IteratorWrapper
+
+    @acc : T | Iterator::Stop = Iterator::Stop::INSTANCE
+
+    def initialize(@iterator : I, @func : T, T -> T)
+    end
+
+    def next
+      elem = wrapped_next
+      old_acc = @acc
+      @acc = old_acc.is_a?(Iterator::Stop) ? elem : @func.call(old_acc, elem)
+    end
+  end
+
   # Returns an iterator that returns elements from the original iterator until
   # it is exhausted and then returns the elements of the second iterator.
   # Compared to `.chain(Iterator(Iter))`, it has better performance when the quantity of


### PR DESCRIPTION
Closes #8496.

The interfaces (`Enumerable#accumulate`, `Iterator#accumulate`, `Iterable#each_accumulated`) are based on https://github.com/crystal-lang/crystal/issues/8496#issuecomment-848841261, i.e. block-less overloads are used for prefix sums. All overloads are O(n).