### PR TITLE
Fix array literals consisting entirely of splat expansions

### DIFF
--- a/spec/compiler/normalize/array_literal_spec.cr
+++ b/spec/compiler/normalize/array_literal_spec.cr
@@ -48,4 +48,12 @@ describe "Normalize: array literal" do
       __temp_1
       CR
   end
+
+  it "normalizes non-empty without of, with splat only" do
+    assert_expand "[*1]", <<-CR
+      __temp_1 = ::Array(typeof(::Enumerable.element_type(1))).new(0)
+      __temp_1.concat(1)
+      __temp_1
+      CR
+  end
 end

--- a/src/compiler/crystal/semantic/literal_expander.cr
+++ b/src/compiler/crystal/semantic/literal_expander.cr
@@ -50,9 +50,7 @@ module Crystal
 
       generic = Generic.new(Path.global("Array"), type_var).at(node)
 
-      if capacity.zero?
-        Call.new(generic, "new").at(node)
-      elsif node.elements.any?(Splat)
+      if node.elements.any?(Splat)
         ary_var = new_temp_var.at(node)
 
         ary_instance = Call.new(generic, "new", args: [NumberLiteral.new(capacity).at(node)] of ASTNode).at(node)
@@ -71,6 +69,8 @@ module Crystal
         exps << ary_var.clone
 
         Expressions.new(exps).at(node)
+      elsif capacity.zero?
+        Call.new(generic, "new").at(node)
       else
         ary_var = new_temp_var.at(node)
 


### PR DESCRIPTION
Follow-up to #10429. Literals like the following:

```crystal
[*1..4]
```

compute the initial capacity of the array to be 0 (the number of non-splat initializers), which the literal expander assumes to represent an empty array (`::Array(typeof(::Enumerable.element_type(1..4))).new`). This PR fixes that:

```crystal
__temp_1 = ::Array(typeof(::Enumerable.element_type(1..4))).new(0)
__temp_1.concat(1..4)
__temp_1
```