### PR TITLE
Implement `BigDecimal`'s missing rounding modes

### DIFF
--- a/spec/std/big/big_decimal_spec.cr
+++ b/spec/std/big/big_decimal_spec.cr
@@ -482,6 +482,229 @@ describe BigDecimal do
     it { -2.91.to_big_d.trunc.should eq(-2) }
   end
 
+  describe "#round" do
+    describe "rounding modes" do
+      it "to_zero" do
+        "-1.5".to_big_d.round(:to_zero).should eq -1.0.to_big_d
+        "-1.0".to_big_d.round(:to_zero).should eq -1.0.to_big_d
+        "-0.9".to_big_d.round(:to_zero).should eq 0.0.to_big_d
+        "-0.5".to_big_d.round(:to_zero).should eq 0.0.to_big_d
+        "-0.1".to_big_d.round(:to_zero).should eq 0.0.to_big_d
+        "0.0".to_big_d.round(:to_zero).should eq 0.0.to_big_d
+        "0.1".to_big_d.round(:to_zero).should eq 0.0.to_big_d
+        "0.5".to_big_d.round(:to_zero).should eq 0.0.to_big_d
+        "0.9".to_big_d.round(:to_zero).should eq 0.0.to_big_d
+        "1.0".to_big_d.round(:to_zero).should eq 1.0.to_big_d
+        "1.5".to_big_d.round(:to_zero).should eq 1.0.to_big_d
+
+        "123456789123456789123.0".to_big_d.round(:to_zero).should eq "123456789123456789123.0".to_big_d
+        "123456789123456789123.1".to_big_d.round(:to_zero).should eq "123456789123456789123.0".to_big_d
+        "123456789123456789123.5".to_big_d.round(:to_zero).should eq "123456789123456789123.0".to_big_d
+        "123456789123456789123.9".to_big_d.round(:to_zero).should eq "123456789123456789123.0".to_big_d
+        "123456789123456789124.0".to_big_d.round(:to_zero).should eq "123456789123456789124.0".to_big_d
+        "-123456789123456789123.0".to_big_d.round(:to_zero).should eq "-123456789123456789123.0".to_big_d
+        "-123456789123456789123.1".to_big_d.round(:to_zero).should eq "-123456789123456789123.0".to_big_d
+        "-123456789123456789123.5".to_big_d.round(:to_zero).should eq "-123456789123456789123.0".to_big_d
+        "-123456789123456789123.9".to_big_d.round(:to_zero).should eq "-123456789123456789123.0".to_big_d
+        "-123456789123456789124.0".to_big_d.round(:to_zero).should eq "-123456789123456789124.0".to_big_d
+      end
+
+      it "to_positive" do
+        "-1.5".to_big_d.round(:to_positive).should eq -1.0.to_big_d
+        "-1.0".to_big_d.round(:to_positive).should eq -1.0.to_big_d
+        "-0.9".to_big_d.round(:to_positive).should eq 0.0.to_big_d
+        "-0.5".to_big_d.round(:to_positive).should eq 0.0.to_big_d
+        "-0.1".to_big_d.round(:to_positive).should eq 0.0.to_big_d
+        "0.0".to_big_d.round(:to_positive).should eq 0.0.to_big_d
+        "0.1".to_big_d.round(:to_positive).should eq 1.0.to_big_d
+        "0.5".to_big_d.round(:to_positive).should eq 1.0.to_big_d
+        "0.9".to_big_d.round(:to_positive).should eq 1.0.to_big_d
+        "1.0".to_big_d.round(:to_positive).should eq 1.0.to_big_d
+        "1.5".to_big_d.round(:to_positive).should eq 2.0.to_big_d
+
+        "123456789123456789123.0".to_big_d.round(:to_positive).should eq "123456789123456789123.0".to_big_d
+        "123456789123456789123.1".to_big_d.round(:to_positive).should eq "123456789123456789124.0".to_big_d
+        "123456789123456789123.5".to_big_d.round(:to_positive).should eq "123456789123456789124.0".to_big_d
+        "123456789123456789123.9".to_big_d.round(:to_positive).should eq "123456789123456789124.0".to_big_d
+        "123456789123456789124.0".to_big_d.round(:to_positive).should eq "123456789123456789124.0".to_big_d
+        "-123456789123456789123.0".to_big_d.round(:to_positive).should eq "-123456789123456789123.0".to_big_d
+        "-123456789123456789123.1".to_big_d.round(:to_positive).should eq "-123456789123456789123.0".to_big_d
+        "-123456789123456789123.5".to_big_d.round(:to_positive).should eq "-123456789123456789123.0".to_big_d
+        "-123456789123456789123.9".to_big_d.round(:to_positive).should eq "-123456789123456789123.0".to_big_d
+        "-123456789123456789124.0".to_big_d.round(:to_positive).should eq "-123456789123456789124.0".to_big_d
+      end
+
+      it "to_negative" do
+        "-1.5".to_big_d.round(:to_negative).should eq -2.0.to_big_d
+        "-1.0".to_big_d.round(:to_negative).should eq -1.0.to_big_d
+        "-0.9".to_big_d.round(:to_negative).should eq -1.0.to_big_d
+        "-0.5".to_big_d.round(:to_negative).should eq -1.0.to_big_d
+        "-0.1".to_big_d.round(:to_negative).should eq -1.0.to_big_d
+        "0.0".to_big_d.round(:to_negative).should eq 0.0.to_big_d
+        "0.1".to_big_d.round(:to_negative).should eq 0.0.to_big_d
+        "0.5".to_big_d.round(:to_negative).should eq 0.0.to_big_d
+        "0.9".to_big_d.round(:to_negative).should eq 0.0.to_big_d
+        "1.0".to_big_d.round(:to_negative).should eq 1.0.to_big_d
+        "1.5".to_big_d.round(:to_negative).should eq 1.0.to_big_d
+
+        "123456789123456789123.0".to_big_d.round(:to_negative).should eq "123456789123456789123.0".to_big_d
+        "123456789123456789123.1".to_big_d.round(:to_negative).should eq "123456789123456789123.0".to_big_d
+        "123456789123456789123.5".to_big_d.round(:to_negative).should eq "123456789123456789123.0".to_big_d
+        "123456789123456789123.9".to_big_d.round(:to_negative).should eq "123456789123456789123.0".to_big_d
+        "123456789123456789124.0".to_big_d.round(:to_negative).should eq "123456789123456789124.0".to_big_d
+        "-123456789123456789123.0".to_big_d.round(:to_negative).should eq "-123456789123456789123.0".to_big_d
+        "-123456789123456789123.1".to_big_d.round(:to_negative).should eq "-123456789123456789124.0".to_big_d
+        "-123456789123456789123.5".to_big_d.round(:to_negative).should eq "-123456789123456789124.0".to_big_d
+        "-123456789123456789123.9".to_big_d.round(:to_negative).should eq "-123456789123456789124.0".to_big_d
+        "-123456789123456789124.0".to_big_d.round(:to_negative).should eq "-123456789123456789124.0".to_big_d
+      end
+
+      it "ties_even" do
+        "-2.5".to_big_d.round(:ties_even).should eq -2.0.to_big_d
+        "-1.5".to_big_d.round(:ties_even).should eq -2.0.to_big_d
+        "-1.0".to_big_d.round(:ties_even).should eq -1.0.to_big_d
+        "-0.9".to_big_d.round(:ties_even).should eq -1.0.to_big_d
+        "-0.5".to_big_d.round(:ties_even).should eq 0.0.to_big_d
+        "-0.1".to_big_d.round(:ties_even).should eq 0.0.to_big_d
+        "0.0".to_big_d.round(:ties_even).should eq 0.0.to_big_d
+        "0.1".to_big_d.round(:ties_even).should eq 0.0.to_big_d
+        "0.5".to_big_d.round(:ties_even).should eq 0.0.to_big_d
+        "0.9".to_big_d.round(:ties_even).should eq 1.0.to_big_d
+        "1.0".to_big_d.round(:ties_even).should eq 1.0.to_big_d
+        "1.5".to_big_d.round(:ties_even).should eq 2.0.to_big_d
+        "2.5".to_big_d.round(:ties_even).should eq 2.0.to_big_d
+
+        "123456789123456789123.0".to_big_d.round(:ties_even).should eq "123456789123456789123.0".to_big_d
+        "123456789123456789123.1".to_big_d.round(:ties_even).should eq "123456789123456789123.0".to_big_d
+        "123456789123456789123.5".to_big_d.round(:ties_even).should eq "123456789123456789124.0".to_big_d
+        "123456789123456789123.9".to_big_d.round(:ties_even).should eq "123456789123456789124.0".to_big_d
+        "123456789123456789124.0".to_big_d.round(:ties_even).should eq "123456789123456789124.0".to_big_d
+        "123456789123456789124.5".to_big_d.round(:ties_even).should eq "123456789123456789124.0".to_big_d
+        "-123456789123456789123.0".to_big_d.round(:ties_even).should eq "-123456789123456789123.0".to_big_d
+        "-123456789123456789123.1".to_big_d.round(:ties_even).should eq "-123456789123456789123.0".to_big_d
+        "-123456789123456789123.5".to_big_d.round(:ties_even).should eq "-123456789123456789124.0".to_big_d
+        "-123456789123456789123.9".to_big_d.round(:ties_even).should eq "-123456789123456789124.0".to_big_d
+        "-123456789123456789124.0".to_big_d.round(:ties_even).should eq "-123456789123456789124.0".to_big_d
+        "-123456789123456789124.5".to_big_d.round(:ties_even).should eq "-123456789123456789124.0".to_big_d
+      end
+
+      it "ties_away" do
+        "-2.5".to_big_d.round(:ties_away).should eq -3.0.to_big_d
+        "-1.5".to_big_d.round(:ties_away).should eq -2.0.to_big_d
+        "-1.0".to_big_d.round(:ties_away).should eq -1.0.to_big_d
+        "-0.9".to_big_d.round(:ties_away).should eq -1.0.to_big_d
+        "-0.5".to_big_d.round(:ties_away).should eq -1.0.to_big_d
+        "-0.1".to_big_d.round(:ties_away).should eq 0.0.to_big_d
+        "0.0".to_big_d.round(:ties_away).should eq 0.0.to_big_d
+        "0.1".to_big_d.round(:ties_away).should eq 0.0.to_big_d
+        "0.5".to_big_d.round(:ties_away).should eq 1.0.to_big_d
+        "0.9".to_big_d.round(:ties_away).should eq 1.0.to_big_d
+        "1.0".to_big_d.round(:ties_away).should eq 1.0.to_big_d
+        "1.5".to_big_d.round(:ties_away).should eq 2.0.to_big_d
+        "2.5".to_big_d.round(:ties_away).should eq 3.0.to_big_d
+
+        "123456789123456789123.0".to_big_d.round(:ties_away).should eq "123456789123456789123.0".to_big_d
+        "123456789123456789123.1".to_big_d.round(:ties_away).should eq "123456789123456789123.0".to_big_d
+        "123456789123456789123.5".to_big_d.round(:ties_away).should eq "123456789123456789124.0".to_big_d
+        "123456789123456789123.9".to_big_d.round(:ties_away).should eq "123456789123456789124.0".to_big_d
+        "123456789123456789124.0".to_big_d.round(:ties_away).should eq "123456789123456789124.0".to_big_d
+        "123456789123456789124.5".to_big_d.round(:ties_away).should eq "123456789123456789125.0".to_big_d
+        "-123456789123456789123.0".to_big_d.round(:ties_away).should eq "-123456789123456789123.0".to_big_d
+        "-123456789123456789123.1".to_big_d.round(:ties_away).should eq "-123456789123456789123.0".to_big_d
+        "-123456789123456789123.5".to_big_d.round(:ties_away).should eq "-123456789123456789124.0".to_big_d
+        "-123456789123456789123.9".to_big_d.round(:ties_away).should eq "-123456789123456789124.0".to_big_d
+        "-123456789123456789124.0".to_big_d.round(:ties_away).should eq "-123456789123456789124.0".to_big_d
+        "-123456789123456789124.5".to_big_d.round(:ties_away).should eq "-123456789123456789125.0".to_big_d
+      end
+
+      it "default (=ties_even)" do
+        "-2.5".to_big_d.round.should eq -2.0.to_big_d
+        "-1.5".to_big_d.round.should eq -2.0.to_big_d
+        "-1.0".to_big_d.round.should eq -1.0.to_big_d
+        "-0.9".to_big_d.round.should eq -1.0.to_big_d
+        "-0.5".to_big_d.round.should eq 0.0.to_big_d
+        "-0.1".to_big_d.round.should eq 0.0.to_big_d
+        "0.0".to_big_d.round.should eq 0.0.to_big_d
+        "0.1".to_big_d.round.should eq 0.0.to_big_d
+        "0.5".to_big_d.round.should eq 0.0.to_big_d
+        "0.9".to_big_d.round.should eq 1.0.to_big_d
+        "1.0".to_big_d.round.should eq 1.0.to_big_d
+        "1.5".to_big_d.round.should eq 2.0.to_big_d
+        "2.5".to_big_d.round.should eq 2.0.to_big_d
+
+        "123456789123456789123.0".to_big_d.round.should eq "123456789123456789123.0".to_big_d
+        "123456789123456789123.1".to_big_d.round.should eq "123456789123456789123.0".to_big_d
+        "123456789123456789123.5".to_big_d.round.should eq "123456789123456789124.0".to_big_d
+        "123456789123456789123.9".to_big_d.round.should eq "123456789123456789124.0".to_big_d
+        "123456789123456789124.0".to_big_d.round.should eq "123456789123456789124.0".to_big_d
+        "123456789123456789124.5".to_big_d.round.should eq "123456789123456789124.0".to_big_d
+        "-123456789123456789123.0".to_big_d.round.should eq "-123456789123456789123.0".to_big_d
+        "-123456789123456789123.1".to_big_d.round.should eq "-123456789123456789123.0".to_big_d
+        "-123456789123456789123.5".to_big_d.round.should eq "-123456789123456789124.0".to_big_d
+        "-123456789123456789123.9".to_big_d.round.should eq "-123456789123456789124.0".to_big_d
+        "-123456789123456789124.0".to_big_d.round.should eq "-123456789123456789124.0".to_big_d
+        "-123456789123456789124.5".to_big_d.round.should eq "-123456789123456789124.0".to_big_d
+      end
+    end
+
+    describe "with digits" do
+      it "to_zero" do
+        "12.345".to_big_d.round(-1, mode: :to_zero).should eq "10".to_big_d
+        "12.345".to_big_d.round(0, mode: :to_zero).should eq "12".to_big_d
+        "12.345".to_big_d.round(1, mode: :to_zero).should eq "12.3".to_big_d
+        "12.345".to_big_d.round(2, mode: :to_zero).should eq "12.34".to_big_d
+        "-12.345".to_big_d.round(-1, mode: :to_zero).should eq "-10".to_big_d
+        "-12.345".to_big_d.round(0, mode: :to_zero).should eq "-12".to_big_d
+        "-12.345".to_big_d.round(1, mode: :to_zero).should eq "-12.3".to_big_d
+        "-12.345".to_big_d.round(2, mode: :to_zero).should eq "-12.34".to_big_d
+      end
+
+      it "to_positive" do
+        "12.345".to_big_d.round(-1, mode: :to_positive).should eq "20".to_big_d
+        "12.345".to_big_d.round(0, mode: :to_positive).should eq "13".to_big_d
+        "12.345".to_big_d.round(1, mode: :to_positive).should eq "12.4".to_big_d
+        "12.345".to_big_d.round(2, mode: :to_positive).should eq "12.35".to_big_d
+        "-12.345".to_big_d.round(-1, mode: :to_positive).should eq "-10".to_big_d
+        "-12.345".to_big_d.round(0, mode: :to_positive).should eq "-12".to_big_d
+        "-12.345".to_big_d.round(1, mode: :to_positive).should eq "-12.3".to_big_d
+        "-12.345".to_big_d.round(2, mode: :to_positive).should eq "-12.34".to_big_d
+      end
+
+      it "to_negative" do
+        "12.345".to_big_d.round(-1, mode: :to_negative).should eq "10".to_big_d
+        "12.345".to_big_d.round(0, mode: :to_negative).should eq "12".to_big_d
+        "12.345".to_big_d.round(1, mode: :to_negative).should eq "12.3".to_big_d
+        "12.345".to_big_d.round(2, mode: :to_negative).should eq "12.34".to_big_d
+        "-12.345".to_big_d.round(-1, mode: :to_negative).should eq "-20".to_big_d
+        "-12.345".to_big_d.round(0, mode: :to_negative).should eq "-13".to_big_d
+        "-12.345".to_big_d.round(1, mode: :to_negative).should eq "-12.4".to_big_d
+        "-12.345".to_big_d.round(2, mode: :to_negative).should eq "-12.35".to_big_d
+      end
+
+      it "ties_away" do
+        "13.825".to_big_d.round(-1, mode: :ties_away).should eq "10".to_big_d
+        "13.825".to_big_d.round(0, mode: :ties_away).should eq "14".to_big_d
+        "13.825".to_big_d.round(1, mode: :ties_away).should eq "13.8".to_big_d
+        "13.825".to_big_d.round(2, mode: :ties_away).should eq "13.83".to_big_d
+        "-13.825".to_big_d.round(-1, mode: :ties_away).should eq "-10".to_big_d
+        "-13.825".to_big_d.round(0, mode: :ties_away).should eq "-14".to_big_d
+        "-13.825".to_big_d.round(1, mode: :ties_away).should eq "-13.8".to_big_d
+        "-13.825".to_big_d.round(2, mode: :ties_away).should eq "-13.83".to_big_d
+      end
+
+      it "ties_even" do
+        "15.255".to_big_d.round(-1, mode: :ties_even).should eq "20".to_big_d
+        "15.255".to_big_d.round(0, mode: :ties_even).should eq "15".to_big_d
+        "15.255".to_big_d.round(1, mode: :ties_even).should eq "15.3".to_big_d
+        "15.255".to_big_d.round(2, mode: :ties_even).should eq "15.26".to_big_d
+        "-15.255".to_big_d.round(-1, mode: :ties_even).should eq "-20".to_big_d
+        "-15.255".to_big_d.round(0, mode: :ties_even).should eq "-15".to_big_d
+        "-15.255".to_big_d.round(1, mode: :ties_even).should eq "-15.3".to_big_d
+        "-15.255".to_big_d.round(2, mode: :ties_even).should eq "-15.26".to_big_d
+      end
+    end
+  end
+
   describe "#inspect" do
     it { "123".to_big_d.inspect.should eq("123") }
   end

--- a/spec/std/big/big_decimal_spec.cr
+++ b/spec/std/big/big_decimal_spec.cr
@@ -485,17 +485,17 @@ describe BigDecimal do
   describe "#round" do
     describe "rounding modes" do
       it "to_zero" do
-        "-1.5".to_big_d.round(:to_zero).should eq -1.0.to_big_d
-        "-1.0".to_big_d.round(:to_zero).should eq -1.0.to_big_d
-        "-0.9".to_big_d.round(:to_zero).should eq 0.0.to_big_d
-        "-0.5".to_big_d.round(:to_zero).should eq 0.0.to_big_d
-        "-0.1".to_big_d.round(:to_zero).should eq 0.0.to_big_d
-        "0.0".to_big_d.round(:to_zero).should eq 0.0.to_big_d
-        "0.1".to_big_d.round(:to_zero).should eq 0.0.to_big_d
-        "0.5".to_big_d.round(:to_zero).should eq 0.0.to_big_d
-        "0.9".to_big_d.round(:to_zero).should eq 0.0.to_big_d
-        "1.0".to_big_d.round(:to_zero).should eq 1.0.to_big_d
-        "1.5".to_big_d.round(:to_zero).should eq 1.0.to_big_d
+        "-1.5".to_big_d.round(:to_zero).should eq "-1".to_big_d
+        "-1.0".to_big_d.round(:to_zero).should eq "-1".to_big_d
+        "-0.9".to_big_d.round(:to_zero).should eq "0".to_big_d
+        "-0.5".to_big_d.round(:to_zero).should eq "0".to_big_d
+        "-0.1".to_big_d.round(:to_zero).should eq "0".to_big_d
+        "0.0".to_big_d.round(:to_zero).should eq "0".to_big_d
+        "0.1".to_big_d.round(:to_zero).should eq "0".to_big_d
+        "0.5".to_big_d.round(:to_zero).should eq "0".to_big_d
+        "0.9".to_big_d.round(:to_zero).should eq "0".to_big_d
+        "1.0".to_big_d.round(:to_zero).should eq "1".to_big_d
+        "1.5".to_big_d.round(:to_zero).should eq "1".to_big_d
 
         "123456789123456789123.0".to_big_d.round(:to_zero).should eq "123456789123456789123.0".to_big_d
         "123456789123456789123.1".to_big_d.round(:to_zero).should eq "123456789123456789123.0".to_big_d
@@ -510,17 +510,17 @@ describe BigDecimal do
       end
 
       it "to_positive" do
-        "-1.5".to_big_d.round(:to_positive).should eq -1.0.to_big_d
-        "-1.0".to_big_d.round(:to_positive).should eq -1.0.to_big_d
-        "-0.9".to_big_d.round(:to_positive).should eq 0.0.to_big_d
-        "-0.5".to_big_d.round(:to_positive).should eq 0.0.to_big_d
-        "-0.1".to_big_d.round(:to_positive).should eq 0.0.to_big_d
-        "0.0".to_big_d.round(:to_positive).should eq 0.0.to_big_d
-        "0.1".to_big_d.round(:to_positive).should eq 1.0.to_big_d
-        "0.5".to_big_d.round(:to_positive).should eq 1.0.to_big_d
-        "0.9".to_big_d.round(:to_positive).should eq 1.0.to_big_d
-        "1.0".to_big_d.round(:to_positive).should eq 1.0.to_big_d
-        "1.5".to_big_d.round(:to_positive).should eq 2.0.to_big_d
+        "-1.5".to_big_d.round(:to_positive).should eq "-1".to_big_d
+        "-1.0".to_big_d.round(:to_positive).should eq "-1".to_big_d
+        "-0.9".to_big_d.round(:to_positive).should eq "0".to_big_d
+        "-0.5".to_big_d.round(:to_positive).should eq "0".to_big_d
+        "-0.1".to_big_d.round(:to_positive).should eq "0".to_big_d
+        "0.0".to_big_d.round(:to_positive).should eq "0".to_big_d
+        "0.1".to_big_d.round(:to_positive).should eq "1".to_big_d
+        "0.5".to_big_d.round(:to_positive).should eq "1".to_big_d
+        "0.9".to_big_d.round(:to_positive).should eq "1".to_big_d
+        "1.0".to_big_d.round(:to_positive).should eq "1".to_big_d
+        "1.5".to_big_d.round(:to_positive).should eq "2".to_big_d
 
         "123456789123456789123.0".to_big_d.round(:to_positive).should eq "123456789123456789123.0".to_big_d
         "123456789123456789123.1".to_big_d.round(:to_positive).should eq "123456789123456789124.0".to_big_d
@@ -535,17 +535,17 @@ describe BigDecimal do
       end
 
       it "to_negative" do
-        "-1.5".to_big_d.round(:to_negative).should eq -2.0.to_big_d
-        "-1.0".to_big_d.round(:to_negative).should eq -1.0.to_big_d
-        "-0.9".to_big_d.round(:to_negative).should eq -1.0.to_big_d
-        "-0.5".to_big_d.round(:to_negative).should eq -1.0.to_big_d
-        "-0.1".to_big_d.round(:to_negative).should eq -1.0.to_big_d
-        "0.0".to_big_d.round(:to_negative).should eq 0.0.to_big_d
-        "0.1".to_big_d.round(:to_negative).should eq 0.0.to_big_d
-        "0.5".to_big_d.round(:to_negative).should eq 0.0.to_big_d
-        "0.9".to_big_d.round(:to_negative).should eq 0.0.to_big_d
-        "1.0".to_big_d.round(:to_negative).should eq 1.0.to_big_d
-        "1.5".to_big_d.round(:to_negative).should eq 1.0.to_big_d
+        "-1.5".to_big_d.round(:to_negative).should eq "-2.0".to_big_d
+        "-1.0".to_big_d.round(:to_negative).should eq "-1.0".to_big_d
+        "-0.9".to_big_d.round(:to_negative).should eq "-1.0".to_big_d
+        "-0.5".to_big_d.round(:to_negative).should eq "-1.0".to_big_d
+        "-0.1".to_big_d.round(:to_negative).should eq "-1.0".to_big_d
+        "0.0".to_big_d.round(:to_negative).should eq "0.0".to_big_d
+        "0.1".to_big_d.round(:to_negative).should eq "0.0".to_big_d
+        "0.5".to_big_d.round(:to_negative).should eq "0.0".to_big_d
+        "0.9".to_big_d.round(:to_negative).should eq "0.0".to_big_d
+        "1.0".to_big_d.round(:to_negative).should eq "1.0".to_big_d
+        "1.5".to_big_d.round(:to_negative).should eq "1.0".to_big_d
 
         "123456789123456789123.0".to_big_d.round(:to_negative).should eq "123456789123456789123.0".to_big_d
         "123456789123456789123.1".to_big_d.round(:to_negative).should eq "123456789123456789123.0".to_big_d
@@ -560,19 +560,19 @@ describe BigDecimal do
       end
 
       it "ties_even" do
-        "-2.5".to_big_d.round(:ties_even).should eq -2.0.to_big_d
-        "-1.5".to_big_d.round(:ties_even).should eq -2.0.to_big_d
-        "-1.0".to_big_d.round(:ties_even).should eq -1.0.to_big_d
-        "-0.9".to_big_d.round(:ties_even).should eq -1.0.to_big_d
-        "-0.5".to_big_d.round(:ties_even).should eq 0.0.to_big_d
-        "-0.1".to_big_d.round(:ties_even).should eq 0.0.to_big_d
-        "0.0".to_big_d.round(:ties_even).should eq 0.0.to_big_d
-        "0.1".to_big_d.round(:ties_even).should eq 0.0.to_big_d
-        "0.5".to_big_d.round(:ties_even).should eq 0.0.to_big_d
-        "0.9".to_big_d.round(:ties_even).should eq 1.0.to_big_d
-        "1.0".to_big_d.round(:ties_even).should eq 1.0.to_big_d
-        "1.5".to_big_d.round(:ties_even).should eq 2.0.to_big_d
-        "2.5".to_big_d.round(:ties_even).should eq 2.0.to_big_d
+        "-2.5".to_big_d.round(:ties_even).should eq "-2.0".to_big_d
+        "-1.5".to_big_d.round(:ties_even).should eq "-2.0".to_big_d
+        "-1.0".to_big_d.round(:ties_even).should eq "-1.0".to_big_d
+        "-0.9".to_big_d.round(:ties_even).should eq "-1.0".to_big_d
+        "-0.5".to_big_d.round(:ties_even).should eq "0.0".to_big_d
+        "-0.1".to_big_d.round(:ties_even).should eq "0.0".to_big_d
+        "0.0".to_big_d.round(:ties_even).should eq "0.0".to_big_d
+        "0.1".to_big_d.round(:ties_even).should eq "0.0".to_big_d
+        "0.5".to_big_d.round(:ties_even).should eq "0.0".to_big_d
+        "0.9".to_big_d.round(:ties_even).should eq "1.0".to_big_d
+        "1.0".to_big_d.round(:ties_even).should eq "1.0".to_big_d
+        "1.5".to_big_d.round(:ties_even).should eq "2.0".to_big_d
+        "2.5".to_big_d.round(:ties_even).should eq "2.0".to_big_d
 
         "123456789123456789123.0".to_big_d.round(:ties_even).should eq "123456789123456789123.0".to_big_d
         "123456789123456789123.1".to_big_d.round(:ties_even).should eq "123456789123456789123.0".to_big_d
@@ -589,19 +589,19 @@ describe BigDecimal do
       end
 
       it "ties_away" do
-        "-2.5".to_big_d.round(:ties_away).should eq -3.0.to_big_d
-        "-1.5".to_big_d.round(:ties_away).should eq -2.0.to_big_d
-        "-1.0".to_big_d.round(:ties_away).should eq -1.0.to_big_d
-        "-0.9".to_big_d.round(:ties_away).should eq -1.0.to_big_d
-        "-0.5".to_big_d.round(:ties_away).should eq -1.0.to_big_d
-        "-0.1".to_big_d.round(:ties_away).should eq 0.0.to_big_d
-        "0.0".to_big_d.round(:ties_away).should eq 0.0.to_big_d
-        "0.1".to_big_d.round(:ties_away).should eq 0.0.to_big_d
-        "0.5".to_big_d.round(:ties_away).should eq 1.0.to_big_d
-        "0.9".to_big_d.round(:ties_away).should eq 1.0.to_big_d
-        "1.0".to_big_d.round(:ties_away).should eq 1.0.to_big_d
-        "1.5".to_big_d.round(:ties_away).should eq 2.0.to_big_d
-        "2.5".to_big_d.round(:ties_away).should eq 3.0.to_big_d
+        "-2.5".to_big_d.round(:ties_away).should eq "-3.0".to_big_d
+        "-1.5".to_big_d.round(:ties_away).should eq "-2.0".to_big_d
+        "-1.0".to_big_d.round(:ties_away).should eq "-1.0".to_big_d
+        "-0.9".to_big_d.round(:ties_away).should eq "-1.0".to_big_d
+        "-0.5".to_big_d.round(:ties_away).should eq "-1.0".to_big_d
+        "-0.1".to_big_d.round(:ties_away).should eq "0.0".to_big_d
+        "0.0".to_big_d.round(:ties_away).should eq "0.0".to_big_d
+        "0.1".to_big_d.round(:ties_away).should eq "0.0".to_big_d
+        "0.5".to_big_d.round(:ties_away).should eq "1.0".to_big_d
+        "0.9".to_big_d.round(:ties_away).should eq "1.0".to_big_d
+        "1.0".to_big_d.round(:ties_away).should eq "1.0".to_big_d
+        "1.5".to_big_d.round(:ties_away).should eq "2.0".to_big_d
+        "2.5".to_big_d.round(:ties_away).should eq "3.0".to_big_d
 
         "123456789123456789123.0".to_big_d.round(:ties_away).should eq "123456789123456789123.0".to_big_d
         "123456789123456789123.1".to_big_d.round(:ties_away).should eq "123456789123456789123.0".to_big_d
@@ -618,19 +618,19 @@ describe BigDecimal do
       end
 
       it "default (=ties_even)" do
-        "-2.5".to_big_d.round.should eq -2.0.to_big_d
-        "-1.5".to_big_d.round.should eq -2.0.to_big_d
-        "-1.0".to_big_d.round.should eq -1.0.to_big_d
-        "-0.9".to_big_d.round.should eq -1.0.to_big_d
-        "-0.5".to_big_d.round.should eq 0.0.to_big_d
-        "-0.1".to_big_d.round.should eq 0.0.to_big_d
-        "0.0".to_big_d.round.should eq 0.0.to_big_d
-        "0.1".to_big_d.round.should eq 0.0.to_big_d
-        "0.5".to_big_d.round.should eq 0.0.to_big_d
-        "0.9".to_big_d.round.should eq 1.0.to_big_d
-        "1.0".to_big_d.round.should eq 1.0.to_big_d
-        "1.5".to_big_d.round.should eq 2.0.to_big_d
-        "2.5".to_big_d.round.should eq 2.0.to_big_d
+        "-2.5".to_big_d.round.should eq "-2.0".to_big_d
+        "-1.5".to_big_d.round.should eq "-2.0".to_big_d
+        "-1.0".to_big_d.round.should eq "-1.0".to_big_d
+        "-0.9".to_big_d.round.should eq "-1.0".to_big_d
+        "-0.5".to_big_d.round.should eq "0.0".to_big_d
+        "-0.1".to_big_d.round.should eq "0.0".to_big_d
+        "0.0".to_big_d.round.should eq "0.0".to_big_d
+        "0.1".to_big_d.round.should eq "0.0".to_big_d
+        "0.5".to_big_d.round.should eq "0.0".to_big_d
+        "0.9".to_big_d.round.should eq "1.0".to_big_d
+        "1.0".to_big_d.round.should eq "1.0".to_big_d
+        "1.5".to_big_d.round.should eq "2.0".to_big_d
+        "2.5".to_big_d.round.should eq "2.0".to_big_d
 
         "123456789123456789123.0".to_big_d.round.should eq "123456789123456789123.0".to_big_d
         "123456789123456789123.1".to_big_d.round.should eq "123456789123456789123.0".to_big_d

--- a/src/big/big_decimal.cr
+++ b/src/big/big_decimal.cr
@@ -351,7 +351,7 @@ struct BigDecimal < Number
   end
 
   def round(digits : Number, base = 10, *, mode : RoundingMode = :ties_even) : BigDecimal
-    return self if base == 10 && @scale <= digits
+    return self if (base == 10 && @scale <= digits) || zero?
 
     # the following is same as the overload in `Number` except `base.to_f`
     # becomes `.to_big_d`

--- a/src/big/big_decimal.cr
+++ b/src/big/big_decimal.cr
@@ -294,17 +294,17 @@ struct BigDecimal < Number
     BigDecimal.new(@value ** other, @scale * other)
   end
 
-  # Rounds towards the nearest integer towards positive infinity.
+  # Rounds towards positive infinity.
   def ceil : BigDecimal
     round_impl { |rem| rem > 0 }
   end
 
-  # Rounds towards the nearest integer towards negative infinity.
+  # Rounds towards negative infinity.
   def floor : BigDecimal
     round_impl { |rem| rem < 0 }
   end
 
-  # Rounds towards the nearest integer towards zero.
+  # Rounds towards zero.
   def trunc : BigDecimal
     round_impl { false }
   end

--- a/src/big/big_decimal.cr
+++ b/src/big/big_decimal.cr
@@ -339,7 +339,7 @@ struct BigDecimal < Number
     #
     # Where:
     # - `mantissa` and `rem` are both integers
-    # - `10 ** @scale < rem < 10 ** @scale`
+    # - `rem.abs < 10 ** @scale`
     # - if `self` is negative, so are `mantissa` and `rem`
     multiplier = power_ten_to(@scale)
     mantissa, rem = @value.unsafe_truncated_divmod(multiplier)
@@ -350,38 +350,6 @@ struct BigDecimal < Number
     BigDecimal.new(mantissa, 0)
   end
 
-  # Rounds `self` to an integer value using rounding *mode*.
-  #
-  # The rounding *mode* controls the direction of the rounding. The default is
-  # `RoundingMode::TIES_EVEN` which rounds to the nearest integer, with ties
-  # (fractional value of `0.5`) being rounded to the even neighbor (Banker's rounding).
-  def round(mode : RoundingMode = :ties_even) : BigDecimal
-    case mode
-    in .to_zero?
-      trunc
-    in .to_positive?
-      ceil
-    in .to_negative?
-      floor
-    in .ties_away?
-      round_away
-    in .ties_even?
-      round_even
-    end
-  end
-
-  # Rounds this number to a given precision.
-  #
-  # Rounds to the specified number of *digits* after the decimal place,
-  # (or before if negative), in base *base*.
-  #
-  # The rounding *mode* controls the direction of the rounding. The default is
-  # `RoundingMode::TIES_EVEN` which rounds to the nearest integer, with ties
-  # (fractional value of `0.5`) being rounded to the even neighbor (Banker's rounding).
-  #
-  # ```
-  # -1763.116.round(2) # => -1763.12
-  # ```
   def round(digits : Number, base = 10, *, mode : RoundingMode = :ties_even) : BigDecimal
     return self if base == 10 && @scale <= digits
 

--- a/src/big/big_decimal.cr
+++ b/src/big/big_decimal.cr
@@ -259,6 +259,10 @@ struct BigDecimal < Number
     end
   end
 
+  def zero? : Bool
+    @value.zero?
+  end
+
   # Scales a `BigDecimal` to another `BigDecimal`, so they can be
   # computed easier.
   def scale_to(new_scale : BigDecimal) : BigDecimal


### PR DESCRIPTION
Resolves #5714. Resolves #10599. Supersedes #7126.

The main difference with #7126 is this PR depends only on the previously unused `BigInt#unsafe_truncated_divmod` method and not `Number#digits`, which means an `Array` allocation can be avoided:

```crystal
require "benchmark"

N = ENV["N"].to_i

struct BigDecimal
  # implementation from #7126
  def round_old(digits : Int = 0, *, mode : RoundingMode)
    ...
    n_digits = @value.abs.digits.reverse! # small optimization i added
    ...
  end
end

macro test(method, mode)
  (N // 1000).times do
    x = Random.rand(-100.0..100.0).to_big_d
    1000.times { x.{{ method.id }}(2, mode: {{ mode }}) }
  end
end

Benchmark.ips do |b|
  b.report("ties_even new") { test round, :ties_even }
  b.report("ties_even old") { test round_old, :ties_even }
  b.report("ties_away new") { test round, :ties_away }
  b.report("ties_away old") { test round_old, :ties_away }
  b.report("to_positive new") { test round, :to_positive }
  b.report("to_positive old") { test round_old, :to_positive }
  b.report("to_negative new") { test round, :to_negative }
  b.report("to_negative old") { test round_old, :to_negative }
  b.report("to_zero new") { test round, :to_zero }
  b.report("to_zero old") { test round_old, :to_zero }
end
```

```
$ N=500000 bin/crystal run --release test.cr
  ties_even new   1.86  (537.30ms) (± 1.45%)  279MB/op   1.15× slower
  ties_even old   1.78  (561.14ms) (± 1.70%)  420MB/op   1.20× slower
  ties_away new   1.86  (537.10ms) (± 1.46%)  279MB/op   1.15× slower
  ties_away old   1.74  (575.14ms) (± 3.60%)  423MB/op   1.23× slower
to_positive new   1.97  (506.82ms) (± 3.40%)  268MB/op   1.08× slower
to_positive old   1.76  (568.56ms) (± 3.21%)  419MB/op   1.21× slower
to_negative new   2.04  (491.06ms) (± 2.75%)  260MB/op   1.05× slower
to_negative old   1.79  (557.82ms) (± 2.55%)  419MB/op   1.19× slower
    to_zero new   2.13  (468.69ms) (± 2.54%)  246MB/op        fastest
    to_zero old   2.05  (488.43ms) (± 1.89%)  378MB/op   1.04× slower
```

Similar benchmarks for `BigDecimal`s with known low scales:

```crystal
macro test(method, mode)
  (N // 1000).times do
    x = BigDecimal.new(Random.rand(20000) - 10000) / 100.0
    1000.times { x.{{ method.id }}(1, mode: {{ mode }}) }
  end
end
```

```
$ N=500000 bin/crystal run --release test.cr
  ties_even new   2.73  (366.45ms) (± 2.33%)  182MB/op   1.18× slower
  ties_even old   2.61  (383.56ms) (± 2.36%)  288MB/op   1.24× slower
  ties_away new   2.67  (375.16ms) (± 3.51%)  184MB/op   1.21× slower
  ties_away old   2.57  (388.99ms) (± 2.38%)  290MB/op   1.26× slower
to_positive new   2.88  (346.71ms) (± 5.91%)  173MB/op   1.12× slower
to_positive old   2.60  (385.17ms) (± 3.27%)  287MB/op   1.25× slower
to_negative new   2.92  (342.06ms) (± 6.60%)  166MB/op   1.11× slower
to_negative old   2.56  (390.17ms) (± 3.06%)  290MB/op   1.26× slower
    to_zero new   3.23  (309.36ms) (± 5.18%)  152MB/op        fastest
    to_zero old   3.11  (321.83ms) (± 5.22%)  250MB/op   1.04× slower
```

The existing rounding modes are also reimplemented on top of this PR. This dramatically improves `#ceil`'s performance:

```crystal
struct BigDecimal
  # implementations before this PR
  def ceil_old; ...; end
  def floor_old; ...; end
  def trunc_old; ...; end
end

macro test(method)
  (N // 1000).times do
    x = BigDecimal.new(Random.rand(20000) - 10000) / 100.0
    1000.times { x.{{ method.id }} }
  end
end

Benchmark.ips do |b|
  b.report("ceil new") { test :ceil }
  b.report("ceil old") { test :ceil_old }
  b.report("floor new") { test :floor }
  b.report("floor old") { test :floor_old }
  b.report("trunc new") { test :trunc }
  b.report("trunc old") { test :trunc_old }
end
```

```
$ N=500000 bin/crystal run --release test.cr
 ceil new   8.44  (118.43ms) (± 5.35%)  67.7MB/op   1.45× slower
 ceil old   3.64  (274.99ms) (± 3.26%)   128MB/op   3.37× slower
floor new   9.40  (106.38ms) (± 4.79%)  60.1MB/op   1.30× slower
floor old   7.17  (139.48ms) (± 4.10%)  67.6MB/op   1.71× slower
trunc new  12.24  ( 81.70ms) (± 5.93%)  45.2MB/op        fastest
trunc old   4.24  (235.79ms) (± 3.41%)   113MB/op   2.89× slower
```
