### PR TITLE
Formatter: Fix indentation of heredocs relative to delimiter

### DIFF
--- a/spec/compiler/formatter/formatter_spec.cr
+++ b/spec/compiler/formatter/formatter_spec.cr
@@ -6,13 +6,35 @@ private def assert_format(input, output = input, strict = false, file = __FILE__
     output = "#{output}\n" unless strict
     result = Crystal.format(input)
     unless result == output
-      fail "Expected\n\n~~~\n#{input}\n~~~\nto format to:\n\n~~~\n#{output}\n~~~\n\nbut got:\n\n~~~\n#{result}\n~~~\n\n  assert_format #{input.inspect}, #{result.chomp.inspect}"
+      message = <<-ERROR
+        Expected
+
+        ~~~
+        #{input}
+        ~~~
+
+        to format to:
+
+        ~~~
+        #{output}
+        ~~~
+
+        but got:
+
+        ~~~
+        #{result}
+        ~~~
+
+          assert_format #{input.inspect}, #{result.chomp.inspect}
+        ERROR
+
+      fail message, file: file, line: line
     end
 
     # Check idempotency
     result2 = Crystal.format(result)
     unless result == result2
-      fail "Idempotency failed:\nBefore: #{result.inspect}\nAfter:  #{result2.inspect}"
+      fail "Idempotency failed:\nBefore: #{result.inspect}\nAfter:  #{result2.inspect}", file: file, line: line
     end
   end
 end
@@ -1006,7 +1028,7 @@ describe Crystal::Formatter do
   assert_format "  <<-HTML\n   foo\n  HTML", "<<-HTML\n foo\nHTML"
   assert_format "  <<-HTML\n   \#{1}\n  HTML", "<<-HTML\n \#{1}\nHTML"
   assert_format "  <<-HTML\n  \#{1} \#{2}\n  HTML", "<<-HTML\n\#{1} \#{2}\nHTML"
-  assert_format "  <<-HTML\n  foo\nHTML", "<<-HTML\nfoo\nHTML"
+  assert_format "  <<-HTML\n  foo\nHTML", "<<-HTML\n  foo\nHTML"
 
   assert_format "<<-HTML\n  hello \n  HTML"
   assert_format "<<-HTML\n  hello \n  world   \n  HTML"
@@ -1285,6 +1307,12 @@ describe Crystal::Formatter do
   assert_format "Hash{\n  foo => <<-EOF,\n  foo\n  EOF\n  bar => <<-BAR,\n  bar\n  BAR\n}"
   assert_format "Hash{\n  foo => <<-EOF\n  foo\n  EOF\n}"
   assert_format "{\n  <<-KEY => 1,\n  key\n  KEY\n}"
+
+  # #10734
+  assert_format " <<-EOF\n 1\nEOF", "<<-EOF\n 1\nEOF"
+  assert_format "  <<-EOF\n   1\n EOF", "<<-EOF\n  1\nEOF"
+  assert_format "x =  <<-EOF\n 1\nEOF", "x = <<-EOF\n 1\nEOF"
+  assert_format "  <<-EOF\n 1\n  2\n EOF", "<<-EOF\n1\n 2\nEOF"
 
   assert_format "begin 0[1] rescue 2 end"
   assert_format "begin\n 0[1] rescue 2 end", "begin 0[1] rescue 2 end"

--- a/src/compiler/crystal/tools/formatter.cr
+++ b/src/compiler/crystal/tools/formatter.cr
@@ -4752,7 +4752,7 @@ module Crystal
       result = to_s.rstrip
 
       lines = result.split('\n')
-      fix_heredocs(lines, @heredoc_fixes)
+      fix_heredocs(lines)
       align_infos(lines, @when_infos)
       align_infos(lines, @hash_infos)
       align_infos(lines, @assign_infos)
@@ -4775,15 +4775,24 @@ module Crystal
       result
     end
 
-    def fix_heredocs(lines, @heredoc_fixes)
+    def fix_heredocs(lines)
       @heredoc_fixes.each do |fix|
+        min_difference = (fix.start_line..fix.end_line).min_of do |line_number|
+          leading_space_count(lines[line_number], fix.difference)
+        end
+
         fix.start_line.upto(fix.end_line) do |line_number|
           line = lines[line_number]
-          if (0...fix.difference).all? { |index| line[index]?.try &.ascii_whitespace? }
-            lines[line_number] = line[fix.difference..-1]
-          end
+          lines[line_number] = line[min_difference..]
         end
       end
+    end
+
+    def leading_space_count(line, max_count)
+      max_count.times do |index|
+        return index unless line[index]?.try &.ascii_whitespace?
+      end
+      max_count
     end
 
     # Align series of successive inline when/else (in a case),

--- a/src/compiler/crystal/tools/formatter.cr
+++ b/src/compiler/crystal/tools/formatter.cr
@@ -4790,7 +4790,7 @@ module Crystal
 
     def leading_space_count(line, max_count)
       max_count.times do |index|
-        return index unless line[index]?.try &.ascii_whitespace?
+        return index unless line.byte_at?(index) == 0x20 # ' '
       end
       max_count
     end


### PR DESCRIPTION
Fixes #10734.

For #10735 the heredoc contents are no longer altered, but formatting is still non-idempotent; it will repeat until the heredoc's end identifier is at the beginning of a line.