### PR TITLE
Define `Crystal::Macros::Path#global?` properly

### DIFF
--- a/spec/compiler/macro/macro_methods_spec.cr
+++ b/spec/compiler/macro/macro_methods_spec.cr
@@ -2513,6 +2513,22 @@ module Crystal
     end
 
     describe "path methods" do
+      it "executes names" do
+        assert_macro "x", %({{x.names}}), [Path.new("String")] of ASTNode, %([String])
+        assert_macro "x", %({{x.names}}), [Path.new(["Foo", "Bar"])] of ASTNode, %([Foo, Bar])
+      end
+
+      it "executes global?" do
+        assert_macro "x", %({{x.global?}}), [Path.new("Foo")] of ASTNode, %(false)
+        assert_macro "x", %({{x.global?}}), [Path.new("Foo", global: true)] of ASTNode, %(true)
+      end
+
+      # TODO: remove deprecated tests
+      it "executes global" do
+        assert_macro "x", %({{x.global}}), [Path.new("Foo")] of ASTNode, %(false)
+        assert_macro "x", %({{x.global}}), [Path.new("Foo", global: true)] of ASTNode, %(true)
+      end
+
       it "executes resolve" do
         assert_macro "x", %({{x.resolve}}), [Path.new("String")] of ASTNode, %(String)
 

--- a/src/compiler/crystal/macros.cr
+++ b/src/compiler/crystal/macros.cr
@@ -1350,6 +1350,11 @@ module Crystal::Macros
     def global? : BoolLiteral
     end
 
+    # Returns `true` if this is a global path (starts with `::`)
+    @[Deprecated("Use `#global?` instead")]
+    def global : BoolLiteral
+    end
+
     # Resolves this path to a `TypeNode` if it denotes a type, to
     # the value of a constant if it denotes a constant, or otherwise
     # gives a compile-time error.

--- a/src/compiler/crystal/macros/methods.cr
+++ b/src/compiler/crystal/macros/methods.cr
@@ -2108,6 +2108,9 @@ module Crystal
           ArrayLiteral.map(@names) { |name| MacroId.new(name) }
         end
       when "global"
+        interpreter.report_warning_at(name_loc, "Deprecated Path#global. Use `#global?` instead")
+        interpret_argless_method(method, args) { BoolLiteral.new(@global) }
+      when "global?"
         interpret_argless_method(method, args) { BoolLiteral.new(@global) }
       when "resolve"
         interpret_argless_method(method, args) { interpreter.resolve(self) }


### PR DESCRIPTION
The API docs mention `Crystal::Macros::Path#global?`, but it was actually `#global` that was defined:

```crystal
macro foo(node)
  {% p node.global %}
end

macro bar(node)
  {% p node.global? %}
end

foo(Int32)   # => false
foo(::Int32) # => true
bar(Int32)   # Error: undefined macro method 'Path#global?'
bar(::Int32) # Error: undefined macro method 'Path#global?'
```

This PR adds `#global?` back. It makes sense that this is a question method since it is a predicate returning a `BoolLiteral`. To maintain compatibility, the old `#global` is now marked as deprecated using the facilities introduced in #9950.