### PR TITLE
Use crystal 1.0.0 containers in workflows

### DIFF
--- a/.github/workflows/aarch64.yml
+++ b/.github/workflows/aarch64.yml
@@ -10,7 +10,7 @@ jobs:
       - name: Download Crystal source
         uses: actions/checkout@v2
       - name: Build Crystal
-        uses: docker://jhass/crystal:0.35.0-alpine-build
+        uses: docker://crystallang/crystal:1.0.0-alpine-build
         with:
           args: make crystal
       - name: Upload Crystal executable
@@ -33,7 +33,7 @@ jobs:
       - name: Mark downloaded compiler as executable
         run: chmod +x .build/crystal
       - name: Run stdlib specs
-        uses: docker://jhass/crystal:0.35.0-alpine-build
+        uses: docker://crystallang/crystal:1.0.0-alpine-build
         with:
           args: make std_spec
   musl-test-compiler:
@@ -51,7 +51,7 @@ jobs:
       - name: Mark downloaded compiler as executable
         run: chmod +x .build/crystal
       - name: Run compiler specs
-        uses: docker://jhass/crystal:0.35.0-alpine-build
+        uses: docker://crystallang/crystal:1.0.0-alpine-build
         with:
           args: make compiler_spec
   gnu-build:
@@ -61,7 +61,7 @@ jobs:
       - name: Download Crystal source
         uses: actions/checkout@v2
       - name: Build Crystal
-        uses: docker://jhass/crystal:0.35.0-build
+        uses: docker://crystallang/crystal:1.0.0-build
         with:
           args: make crystal
       - name: Upload Crystal executable
@@ -84,7 +84,7 @@ jobs:
       - name: Mark downloaded compiler as executable
         run: chmod +x .build/crystal
       - name: Run stdlib specs
-        uses: docker://jhass/crystal:0.35.0-build
+        uses: docker://crystallang/crystal:1.0.0-build
         with:
           args: make std_spec
   gnu-test-compiler:
@@ -102,6 +102,6 @@ jobs:
       - name: Mark downloaded compiler as executable
         run: chmod +x .build/crystal
       - name: Run compiler specs
-        uses: docker://jhass/crystal:0.35.0-build
+        uses: docker://crystallang/crystal:1.0.0-build
         with:
           args: make compiler_spec


### PR DESCRIPTION
- Removes dependency on @jhass's image in the aarch64 workflow, perhaps this image is specifically generated for aarch64 support.
- Updates `0.35.0` containers to `1.0.0`