### PR TITLE
Minor fixes to docs of `UnaryExpression` macro nodes

### DIFF
--- a/src/compiler/crystal/macros.cr
+++ b/src/compiler/crystal/macros.cr
@@ -1251,6 +1251,14 @@ module Crystal::Macros
   class Out < UnaryExpression
   end
 
+  # A splat expression: `*exp`.
+  class Splat < UnaryExpression
+  end
+
+  # A double splat expression: `**exp`.
+  class DoubleSplat < UnaryExpression
+  end
+
   # An `offsetof` expression.
   class OffsetOf < ASTNode
     # Returns the type that has been used in this `offsetof` expression.

--- a/src/compiler/crystal/macros.cr
+++ b/src/compiler/crystal/macros.cr
@@ -1610,13 +1610,6 @@ module Crystal::Macros
   # class Underscore < ASTNode
   # end
 
-  # A splat expression: `*exp`.
-  class Splat < ASTNode
-    # Returns the splatted expression.
-    def exp : ASTNode
-    end
-  end
-
   # class MagicConstant < ASTNode
   # end
 

--- a/src/compiler/crystal/macros/methods.cr
+++ b/src/compiler/crystal/macros/methods.cr
@@ -2164,17 +2164,6 @@ module Crystal
     end
   end
 
-  class Splat
-    def interpret(method : String, args : Array(ASTNode), named_args : Hash(String, ASTNode)?, block : Crystal::Block?, interpreter : Crystal::MacroInterpreter, name_loc : Location?)
-      case method
-      when "exp"
-        interpret_argless_method(method, args) { exp }
-      else
-        super
-      end
-    end
-  end
-
   class Generic
     def interpret(method : String, args : Array(ASTNode), named_args : Hash(String, ASTNode)?, block : Crystal::Block?, interpreter : Crystal::MacroInterpreter, name_loc : Location?)
       case method


### PR DESCRIPTION
* Indicates that `Crystal::Macros::Splat` is a subclass of `Crystal::Macros::UnaryExpression`. This is indeed the case for the underlying `ASTNode` types (`Crystal::Splat < Crystal::UnaryExpression`), from which the "subtyping" relationship in the macro language is derived.
* Documents `Crystal::Macros::DoubleSplat`. This already works in the language:
  ```crystal
  macro foo(node)
    {% arg = node.args[0] %}
    {% arg %}                # => **x
    {% arg.class_name %}     # => "DoubleSplat"
    {% arg.exp %}            # => x
    {% arg.exp.class_name %} # => "Call"
  end

  foo(bar(**x))
  ```
* Removes a bit of code in the macro interpreter, since it is exactly the same as the superclass's definition (`Crystal::UnaryExpression#interpret`).

I left `MacroVerbatim` untouched. This is intentional because the rest of the macro nodes are undocumented.