### PR TITLE
Expand named macro expression arguments before outer macro call expansion

### DIFF
--- a/spec/compiler/codegen/macro_spec.cr
+++ b/spec/compiler/codegen/macro_spec.cr
@@ -1272,28 +1272,6 @@ describe "Code gen: macro" do
       )).to_i.should eq(1)
   end
 
-  it "solves macro expression arguments before macro expansion (type)" do
-    run(%(
-      macro name(x)
-        {{x.name.stringify}}
-      end
-
-      name({{String}})
-      )).to_string.should eq("String")
-  end
-
-  it "solves macro expression arguments before macro expansion (constant)" do
-    run(%(
-      CONST = 1
-
-      macro id(x)
-        {{x}}
-      end
-
-      id({{CONST}})
-      )).to_i.should eq(1)
-  end
-
   it "can use macro inside array literal" do
     run(%(
       require "prelude"

--- a/spec/compiler/semantic/macro_spec.cr
+++ b/spec/compiler/semantic/macro_spec.cr
@@ -841,6 +841,35 @@ describe "Semantic: macro" do
       "missing argument: z"
   end
 
+  it "solves macro expression arguments before macro expansion (type)" do
+    assert_type(%(
+      macro foo(x)
+        {% if x.is_a?(TypeNode) && x.name == "String" %}
+          1
+        {% else %}
+          'a'
+        {% end %}
+      end
+
+      foo({{ String }})
+      )) { int32 }
+  end
+
+  it "solves macro expression arguments before macro expansion (constant)" do
+    assert_type(%(
+      macro foo(x)
+        {% if x.is_a?(NumberLiteral) && x == 1 %}
+          1
+        {% else %}
+          'a'
+        {% end %}
+      end
+
+      CONST = 1
+      foo({{ CONST }})
+      )) { int32 }
+  end
+
   it "finds generic type argument of included module" do
     assert_type(%(
       module Bar(T)

--- a/spec/compiler/semantic/macro_spec.cr
+++ b/spec/compiler/semantic/macro_spec.cr
@@ -870,6 +870,35 @@ describe "Semantic: macro" do
       )) { int32 }
   end
 
+  it "solves named macro expression arguments before macro expansion (type) (#2423)" do
+    assert_type(%(
+      macro foo(x)
+        {% if x.is_a?(TypeNode) && x.name == "String" %}
+          1
+        {% else %}
+          'a'
+        {% end %}
+      end
+
+      foo(x: {{ String }})
+      )) { int32 }
+  end
+
+  it "solves named macro expression arguments before macro expansion (constant) (#2423)" do
+    assert_type(%(
+      macro foo(x)
+        {% if x.is_a?(NumberLiteral) && x == 1 %}
+          1
+        {% else %}
+          'a'
+        {% end %}
+      end
+
+      CONST = 1
+      foo(x: {{ CONST }})
+      )) { int32 }
+  end
+
   it "finds generic type argument of included module" do
     assert_type(%(
       module Bar(T)


### PR DESCRIPTION
Fixes #2423.

```crystal
macro foo(x)
  {% p x %}
end

foo({{ 1 }})    # => 1
foo(x: {{ 1 }}) # => 1
# before:       # => {{ 1 }}
```
