### PR TITLE
Add macro methods for `Return`, `Break`, `Next`, `Yield`, and exception handlers

### DIFF
--- a/src/compiler/crystal/macros.cr
+++ b/src/compiler/crystal/macros.cr
@@ -1453,11 +1453,39 @@ module Crystal::Macros
     end
   end
 
-  # class Rescue < ASTNode
-  # end
+  # A `rescue` clause inside an exception handler.
+  class Rescue < ASTNode
+    # Returns this `rescue` clause's body.
+    def body : ASTNode
+    end
 
-  # class ExceptionHandler < ASTNode
-  # end
+    # Returns this `rescue` clause's exception types, if any.
+    def types : ArrayLiteral | NilLiteral
+    end
+
+    # Returns the variable name of the rescued exception, if any.
+    def name : MacroId | Nop
+    end
+  end
+
+  # A `begin ... end` expression with `rescue` or `ensure` clauses.
+  class ExceptionHandler < ASTNode
+    # Returns this exception handler's main body.
+    def body : ASTNode
+    end
+
+    # Returns this exception handler's `rescue` clauses, if any.
+    def rescues : ArrayLiteral(Rescue) | NilLiteral
+    end
+
+    # Returns this exception handler's `else` clause body, if any.
+    def else : ASTNode | Nop
+    end
+
+    # Returns this exception handler's `ensure` clause body, if any.
+    def ensure : ASTNode | Nop
+    end
+  end
 
   # A proc method, written like:
   # ```
@@ -1510,20 +1538,40 @@ module Crystal::Macros
   # class Self < ASTNode
   # end
 
-  # abstract class ControlExpression < ASTNode
-  # end
+  # The base class of control expressions.
+  abstract class ControlExpression < ASTNode
+    # Returns the argument to this control expression, if any.
+    #
+    # If multiple arguments are present, they are wrapped inside a single
+    # `TupleLiteral`.
+    def exp : ASTNode | Nop
+    end
+  end
 
-  # class Return < ControlExpression
-  # end
+  # A `return` expression.
+  class Return < ControlExpression
+  end
 
-  # class Break < ControlExpression
-  # end
+  # A `break` expression.
+  class Break < ControlExpression
+  end
 
-  # class Next < ControlExpression
-  # end
+  # A `next` expression.
+  class Next < ControlExpression
+  end
 
-  # class Yield < ASTNode
-  # end
+  # A `yield` expression.
+  class Yield < ASTNode
+    # Returns the arguments to this `yield`.
+    def expressions : ArrayLiteral
+    end
+
+    # Returns the scope of this `yield`, if any.
+    #
+    # This refers to the part after `with` in a `with ... yield` expression.
+    def scope : ASTNode | Nop
+    end
+  end
 
   # class Include < ASTNode
   # end

--- a/src/compiler/crystal/macros/methods.cr
+++ b/src/compiler/crystal/macros/methods.cr
@@ -2015,6 +2015,62 @@ module Crystal
     end
   end
 
+  class ExceptionHandler
+    def interpret(method : String, args : Array(ASTNode), named_args : Hash(String, ASTNode)?, block : Crystal::Block?, interpreter : Crystal::MacroInterpreter, name_loc : Location?)
+      case method
+      when "body"
+        interpret_argless_method(method, args) { @body }
+      when "rescues"
+        interpret_argless_method(method, args) { (rescues = @rescues) ? ArrayLiteral.map(rescues, &.itself) : NilLiteral.new }
+      when "else"
+        interpret_argless_method(method, args) { @else || Nop.new }
+      when "ensure"
+        interpret_argless_method(method, args) { @ensure || Nop.new }
+      else
+        super
+      end
+    end
+  end
+
+  class Rescue
+    def interpret(method : String, args : Array(ASTNode), named_args : Hash(String, ASTNode)?, block : Crystal::Block?, interpreter : Crystal::MacroInterpreter, name_loc : Location?)
+      case method
+      when "body"
+        interpret_argless_method(method, args) { body }
+      when "types"
+        interpret_argless_method(method, args) { (types = @types) ? ArrayLiteral.map(types, &.itself) : NilLiteral.new }
+      when "name"
+        interpret_argless_method(method, args) { (name = @name) ? MacroId.new(name) : Nop.new }
+      else
+        super
+      end
+    end
+  end
+
+  class ControlExpression
+    def interpret(method : String, args : Array(ASTNode), named_args : Hash(String, ASTNode)?, block : Crystal::Block?, interpreter : Crystal::MacroInterpreter, name_loc : Location?)
+      case method
+      when "exp"
+        interpret_argless_method(method, args) { exp || Nop.new }
+      else
+        super
+      end
+    end
+  end
+
+  class Yield
+    def interpret(method : String, args : Array(ASTNode), named_args : Hash(String, ASTNode)?, block : Crystal::Block?, interpreter : Crystal::MacroInterpreter, name_loc : Location?)
+      case method
+      when "expressions"
+        interpret_argless_method(method, args) { ArrayLiteral.map(@exps, &.itself) }
+      when "scope"
+        interpret_argless_method(method, args) { scope || Nop.new }
+      else
+        super
+      end
+    end
+  end
+
   class Assign
     def interpret(method : String, args : Array(ASTNode), named_args : Hash(String, ASTNode)?, block : Crystal::Block?, interpreter : Crystal::MacroInterpreter, name_loc : Location?)
       case method


### PR DESCRIPTION
c.f. https://github.com/crystal-lang/crystal/issues/3274#issuecomment-860092436

These macro methods are relatively straightforward. `select` expressions are omitted in this batch since they require turning `Crystal::Select::When` into an actual AST node type.