### PR TITLE
[CI] Disable broken test_darwin job on circleci

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -509,9 +509,6 @@ jobs:
 
 workflows:
   version: 2
-  test_all_platforms:
-    jobs:
-      - test_darwin
   tagged_release:
     jobs:
       - test_linux:


### PR DESCRIPTION
The test_darwin job on circleci has been broken for some time now and there is no perspective on fixing that. This looks like an issue specific to the CI environment, not a generic Crystal bug that just happens to not show anywhere else.

This constantly breaking CI job is irritating in PRs that are otherwise all green and might cause real issues to be overlooked.

The CI failure is still tracked in #10110, but for now we should ignore it in the typical CI runs.