### PR TITLE
Be more strict about printing operator calls as short forms

### DIFF
--- a/spec/compiler/parser/to_s_spec.cr
+++ b/spec/compiler/parser/to_s_spec.cr
@@ -133,6 +133,7 @@ describe "ASTNode#to_s" do
   expect_to_s %(1 <= (2 <= 3))
   expect_to_s %(case 1; when .foo?; 2; end), %(case 1\nwhen .foo?\n  2\nend)
   expect_to_s %(case 1; in .foo?; 2; end), %(case 1\nin .foo?\n  2\nend)
+  expect_to_s %(case 1; when .!; 2; when .< 0; 3; end), %(case 1\nwhen .!\n  2\nwhen .<(0)\n  3\nend)
   expect_to_s %({(1 + 2)})
   expect_to_s %({foo: (1 + 2)})
   expect_to_s %q("#{(1 + 2)}")

--- a/spec/compiler/parser/to_s_spec.cr
+++ b/spec/compiler/parser/to_s_spec.cr
@@ -134,6 +134,7 @@ describe "ASTNode#to_s" do
   expect_to_s %(case 1; when .foo?; 2; end), %(case 1\nwhen .foo?\n  2\nend)
   expect_to_s %(case 1; in .foo?; 2; end), %(case 1\nin .foo?\n  2\nend)
   expect_to_s %(case 1; when .!; 2; when .< 0; 3; end), %(case 1\nwhen .!\n  2\nwhen .<(0)\n  3\nend)
+  expect_to_s %(case 1\nwhen .[](2)\n  3\nwhen .[]=(4)\n  5\nend)
   expect_to_s %({(1 + 2)})
   expect_to_s %({foo: (1 + 2)})
   expect_to_s %q("#{(1 + 2)}")
@@ -158,6 +159,14 @@ describe "ASTNode#to_s" do
   expect_to_s "1.&*"
   expect_to_s "1.&**"
   expect_to_s "1.~(2)"
+  expect_to_s "1.~(2) do\nend"
+  expect_to_s "1.+ do\nend"
+  expect_to_s "1.[](2) do\nend"
+  expect_to_s "1.[]="
+  expect_to_s "1.+(a: 2)"
+  expect_to_s "1.+(&block)"
+  expect_to_s "1.//(2, a: 3)"
+  expect_to_s "1.//(2, &block)"
   expect_to_s %({% verbatim do %}\n  1{{ 2 }}\n  3{{ 4 }}\n{% end %})
   expect_to_s %({% for foo in bar %}\n  {{ if true\n  foo\n  bar\nend }}\n{% end %})
   expect_to_s %(asm("nop" ::::))

--- a/src/compiler/crystal/syntax/to_s.cr
+++ b/src/compiler/crystal/syntax/to_s.cr
@@ -329,6 +329,8 @@ module Crystal
       visit_call node
     end
 
+    UNARY_OPERATORS = {"+", "-", "~", "&+", "&-"}
+
     def visit_call(node, ignore_obj = false)
       if node.name == "`"
         visit_backtick(node.args[0])
@@ -336,6 +338,7 @@ module Crystal
       end
 
       node_obj = ignore_obj ? nil : node.obj
+      block = node.block
 
       need_parens = need_parens(node_obj)
       call_args_need_parens = false
@@ -346,7 +349,7 @@ module Crystal
         node_obj = nil
       end
 
-      if node_obj && (node.name == "[]" || node.name == "[]?")
+      if node_obj && (node.name == "[]" || node.name == "[]?") && !block
         in_parenthesis(need_parens, node_obj)
 
         @str << decorate_call(node, "[")
@@ -356,7 +359,7 @@ module Crystal
         else
           @str << decorate_call(node, "]?")
         end
-      elsif node_obj && node.name == "[]="
+      elsif node_obj && node.name == "[]=" && !node.args.empty? && !block
         in_parenthesis(need_parens, node_obj)
 
         @str << decorate_call(node, "[")
@@ -366,32 +369,17 @@ module Crystal
         @str << decorate_call(node, "=")
         @str << ' '
         node.args.last.accept self
-      elsif node_obj && !letter_or_underscore?(node.name) && node.args.size == 0
-        if node.name == "+" || node.name == "-" || node.name == "~" || node.name == "&+" || node.name == "&-"
-          @str << decorate_call(node, node.name)
-          in_parenthesis(need_parens, node_obj)
-        else
-          # It is for something like `foo.%` and `foo.*`.
-          in_parenthesis(need_parens, node_obj)
-          @str << '.'
-          @str << node.name
-        end
-      elsif node_obj && !letter_or_underscore?(node.name) && node.args.size == 1
+      elsif node_obj && node.name.in?(UNARY_OPERATORS) && node.args.empty? && !node.named_args && !node.block_arg && !block
+        @str << decorate_call(node, node.name)
+        in_parenthesis(need_parens, node_obj)
+      elsif node_obj && !letter_or_underscore?(node.name) && node.name != "~" && node.args.size == 1 && !node.named_args && !node.block_arg && !block
         in_parenthesis(need_parens, node_obj)
 
         arg = node.args[0]
-        if node.name == "~" # it is `foo.~(bar)` case.
-          @str << '.'
-          @str << node.name
-          @str << '('
-          arg.accept self
-          @str << ')'
-        else
-          @str << ' '
-          @str << decorate_call(node, node.name)
-          @str << ' '
-          in_parenthesis(need_parens(arg), arg)
-        end
+        @str << ' '
+        @str << decorate_call(node, node.name)
+        @str << ' '
+        in_parenthesis(need_parens(arg), arg)
       else
         if node_obj
           in_parenthesis(need_parens, node_obj)
@@ -410,8 +398,6 @@ module Crystal
           visit_args(node)
         end
       end
-
-      block = node.block
 
       if block
         # Check if this is foo &.bar

--- a/src/compiler/crystal/syntax/to_s.cr
+++ b/src/compiler/crystal/syntax/to_s.cr
@@ -341,6 +341,10 @@ module Crystal
       call_args_need_parens = false
 
       @str << "::" if node.global?
+      if node_obj.is_a?(ImplicitObj)
+        @str << '.'
+        node_obj = nil
+      end
 
       if node_obj && (node.name == "[]" || node.name == "[]?")
         in_parenthesis(need_parens, node_obj)
@@ -1108,6 +1112,7 @@ module Crystal
     end
 
     def visit(node : Not)
+      @str << '.' if node.exp.is_a?(ImplicitObj)
       @str << '!'
       need_parens = need_parens(node.exp)
       in_parenthesis(need_parens, node.exp)


### PR DESCRIPTION
Fixes #8777.

Any operator call that uses an implicit object is ineligible for the operator short form. This PR also catches some other edge cases:

```crystal
1.+(a: 2)   # => +1
1.+(2, &f)  # => 1 + 2
1.[](2) { } # => 1[2] do; end
1.[]=       # 1[] = Index out of bounds (IndexError)
```

The above calls will no longer be printed using the short form.