### PR TITLE
Add links to literal types in the language reference

### DIFF
--- a/src/array.cr
+++ b/src/array.cr
@@ -12,6 +12,8 @@
 # [1, "hello", 'x'] # Array(Int32 | String | Char)
 # ```
 #
+# See [`Array` literals](https://crystal-lang.org/reference/syntax_and_semantics/literals/array.html) in the language reference.
+#
 # An `Array` can have mixed types, meaning T will be a union of types, but these are determined
 # when the array is created, either by specifying T or by using an array literal. In the latter
 # case, T will be set to the union of the array literal elements' types.

--- a/src/bool.cr
+++ b/src/bool.cr
@@ -4,6 +4,8 @@
 # true  # A Bool that is true
 # false # A Bool that is false
 # ```
+#
+# See [`Bool` literals](https://crystal-lang.org/reference/syntax_and_semantics/literals/bool.html) in the language reference.
 struct Bool
   # Bitwise OR. Returns `true` if this bool or *other* is `true`, otherwise returns `false`.
   #

--- a/src/char.cr
+++ b/src/char.cr
@@ -38,6 +38,8 @@ require "steppable"
 # ```
 # '\u{41}' # == 'A'
 # ```
+#
+# See [`Char` literals](https://crystal-lang.org/reference/syntax_and_semantics/literals/char.html) in the language reference.
 struct Char
   include Comparable(Char)
   include Steppable

--- a/src/compiler/crystal/macros.cr
+++ b/src/compiler/crystal/macros.cr
@@ -68,6 +68,14 @@ module Crystal::Macros
 
   # Executes a system command and returns the output as a `MacroId`.
   # Gives a compile-time error if the command failed to execute.
+  #
+  # It is impossible to call this method with any regular call syntax. There is an associated literal type which calls the method with the literal content as command:
+  #
+  # ```
+  # {{ `echo hi` }} # => "hi\n"
+  # ```
+  #
+  # See [`Command` literals](https://crystal-lang.org/reference/syntax_and_semantics/literals/command.html) in the language reference.
   def `(command) : MacroId
   end
 

--- a/src/float.cr
+++ b/src/float.cr
@@ -34,6 +34,8 @@ require "./float/printer"
 # ```
 # 1_000_000.111_111 # better than 1000000.111111
 # ```
+#
+# See [`Float` literals](https://crystal-lang.org/reference/syntax_and_semantics/literals/floats.html) in the language reference.
 struct Float
   alias Primitive = Float32 | Float64
 

--- a/src/int.cr
+++ b/src/int.cr
@@ -55,6 +55,8 @@
 # 0xFE012D # == 16646445
 # 0xfe012d # == 16646445
 # ```
+#
+# See [`Integer` literals](https://crystal-lang.org/reference/syntax_and_semantics/literals/integers.html) in the language reference.
 struct Int
   alias Signed = Int8 | Int16 | Int32 | Int64 | Int128
   alias Unsigned = UInt8 | UInt16 | UInt32 | UInt64 | UInt128

--- a/src/named_tuple.cr
+++ b/src/named_tuple.cr
@@ -14,6 +14,8 @@
 # language[:other] # compile time error
 # ```
 #
+# See [`NamedTuple` literals](https://crystal-lang.org/reference/syntax_and_semantics/literals/named_tuple.html) in the language reference.
+#
 # The compiler knows what types are in each key, so when indexing a named tuple
 # with a symbol literal the compiler will return the value for that key and
 # with the expected type, like in the above snippet. Indexing with a symbol

--- a/src/nil.cr
+++ b/src/nil.cr
@@ -39,6 +39,8 @@
 # # if our assumption doesn't hold.
 # idx3 = str.index('o').not_nil!
 # ```
+#
+# See [`Nil` literal](https://crystal-lang.org/reference/syntax_and_semantics/literals/nil.html) in the language reference.
 struct Nil
   # Returns `0_u64`. Even though `Nil` is not a `Reference` type, it is usually
   # mixed with them to form nilable types so it's useful to have an

--- a/src/proc.cr
+++ b/src/proc.cr
@@ -12,6 +12,8 @@
 # ->(x : Int32, y : Int32) { x + y } # Proc(Int32, Int32, Int32)
 # ```
 #
+# See [`Proc` literals](https://crystal-lang.org/reference/syntax_and_semantics/literals/proc.html) in the language reference.
+#
 # The types of the arguments (`T`) are mandatory, except when directly
 # sending a proc literal to a lib fun in C bindings.
 #

--- a/src/process.cr
+++ b/src/process.cr
@@ -427,7 +427,7 @@ end
 # It is impossible to call this method with any regular call syntax. There is an associated literal type which calls the method with the literal content as command:
 #
 # ```
-# `echo hi` # => "hi\n"
+# `echo hi`   # => "hi\n"
 # $?.success? # => true
 # ```
 #

--- a/src/process.cr
+++ b/src/process.cr
@@ -424,11 +424,14 @@ end
 # Standard input, and error are inherited.
 # The special `$?` variable is set to a `Process::Status` associated with this execution.
 #
-# Example:
+# It is impossible to call this method with any regular call syntax. There is an associated literal type which calls the method with the literal content as command:
 #
 # ```
 # `echo hi` # => "hi\n"
+# $?.success? # => true
 # ```
+#
+# See [`Command` literals](https://crystal-lang.org/reference/syntax_and_semantics/literals/command.html) in the language reference.
 def `(command) : String
   process = Process.new(command, shell: true, input: Process::Redirect::Inherit, output: Process::Redirect::Pipe, error: Process::Redirect::Inherit)
   output = process.output.gets_to_end

--- a/src/range.cr
+++ b/src/range.cr
@@ -10,6 +10,8 @@
 # ...y  # a beginless exclusive range, in mathematics: < y
 # ```
 #
+# See [`Range` literals](https://crystal-lang.org/reference/syntax_and_semantics/literals/range.html) in the language reference.
+#
 # An easy way to remember which one is inclusive and which one is exclusive it
 # to think of the extra dot as if it pushes *y* further away, thus leaving it outside of the range.
 #

--- a/src/regex.cr
+++ b/src/regex.cr
@@ -12,6 +12,8 @@ require "./regex/*"
 # /y/.match("haystack") # => Regex::MatchData("y")
 # ```
 #
+# See [`Range` literals](https://crystal-lang.org/reference/syntax_and_semantics/literals/range.html) in the language reference.
+#
 # Interpolation works in regular expression literals just as it does in string
 # literals. Be aware that using this feature will cause an exception to be
 # raised at runtime, if the resulting string would not be a valid regular

--- a/src/string.cr
+++ b/src/string.cr
@@ -13,74 +13,7 @@ require "c/string"
 # "hello world"
 # ```
 #
-# A backslash can be used to denote some characters inside the string:
-#
-# ```
-# "\"" # double quote
-# "\\" # backslash
-# "\e" # escape
-# "\f" # form feed
-# "\n" # newline
-# "\r" # carriage return
-# "\t" # tab
-# "\v" # vertical tab
-# ```
-#
-# You can use a backslash followed by an *u* and four hexadecimal characters to denote a unicode codepoint written:
-#
-# ```
-# "\u0041" # == "A"
-# ```
-#
-# Or you can use curly braces and specify up to six hexadecimal numbers (0 to 10FFFF):
-#
-# ```
-# "\u{41}" # == "A"
-# ```
-#
-# A string can span multiple lines:
-#
-# ```
-# "hello
-#       world" # same as "hello\n      world"
-# ```
-#
-# Note that in the above example trailing and leading spaces, as well as newlines,
-# end up in the resulting string. To avoid this, you can split a string into multiple lines
-# by joining multiple literals with a backslash:
-#
-# ```
-# "hello " \
-# "world, " \
-# "no newlines" # same as "hello world, no newlines"
-# ```
-#
-# Alternatively, a backslash followed by a newline can be inserted inside the string literal:
-#
-# ```
-# "hello \
-#      world, \
-#      no newlines" # same as "hello world, no newlines"
-# ```
-#
-# In this case, leading whitespace is not included in the resulting string.
-#
-# If you need to write a string that has many double quotes, parentheses, or similar
-# characters, you can use alternative literals:
-#
-# ```
-# # Supports double quotes and nested parentheses
-# %(hello ("world")) # same as "hello (\"world\")"
-#
-# # Supports double quotes and nested brackets
-# %[hello ["world"]] # same as "hello [\"world\"]"
-#
-# # Supports double quotes and nested curlies
-# %{hello {"world"}} # same as "hello {\"world\"}"
-#
-# # Supports double quotes and nested angles
-# %<hello <"world">> # same as "hello <\"world\">"
-# ```
+# See [`String` literals](https://crystal-lang.org/reference/syntax_and_semantics/literals/string.html) in the language reference.
 #
 # To create a `String` with embedded expressions, you can use string interpolation:
 #

--- a/src/string.cr
+++ b/src/string.cr
@@ -15,6 +15,75 @@ require "c/string"
 #
 # See [`String` literals](https://crystal-lang.org/reference/syntax_and_semantics/literals/string.html) in the language reference.
 #
+# A backslash can be used to denote some characters inside the string:
+#
+# ```
+# "\"" # double quote
+# "\\" # backslash
+# "\e" # escape
+# "\f" # form feed
+# "\n" # newline
+# "\r" # carriage return
+# "\t" # tab
+# "\v" # vertical tab
+# ```
+#
+# You can use a backslash followed by an *u* and four hexadecimal characters to denote a unicode codepoint written:
+#
+# ```
+# "\u0041" # == "A"
+# ```
+#
+# Or you can use curly braces and specify up to six hexadecimal numbers (0 to 10FFFF):
+#
+# ```
+# "\u{41}" # == "A"
+# ```
+#
+# A string can span multiple lines:
+#
+# ```
+# "hello
+#       world" # same as "hello\n      world"
+# ```
+#
+# Note that in the above example trailing and leading spaces, as well as newlines,
+# end up in the resulting string. To avoid this, you can split a string into multiple lines
+# by joining multiple literals with a backslash:
+#
+# ```
+# "hello " \
+# "world, " \
+# "no newlines" # same as "hello world, no newlines"
+# ```
+#
+# Alternatively, a backslash followed by a newline can be inserted inside the string literal:
+#
+# ```
+# "hello \
+#      world, \
+#      no newlines" # same as "hello world, no newlines"
+# ```
+#
+# In this case, leading whitespace is not included in the resulting string.
+#
+# If you need to write a string that has many double quotes, parentheses, or similar
+# characters, you can use alternative literals:
+#
+# ```
+# # Supports double quotes and nested parentheses
+# %(hello ("world")) # same as "hello (\"world\")"
+#
+# # Supports double quotes and nested brackets
+# %[hello ["world"]] # same as "hello [\"world\"]"
+#
+# # Supports double quotes and nested curlies
+# %{hello {"world"}} # same as "hello {\"world\"}"
+#
+# # Supports double quotes and nested angles
+# %<hello <"world">> # same as "hello <\"world\">"
+# ```
+#
 # To create a `String` with embedded expressions, you can use string interpolation:
 #
 # ```

--- a/src/symbol.cr
+++ b/src/symbol.cr
@@ -8,6 +8,8 @@
 # :"symbol with spaces"
 # ```
 #
+# See [`Symbol` literals](https://crystal-lang.org/reference/syntax_and_semantics/literals/symbol.html) in the language reference.
+#
 # Internally a symbol is represented as an `Int32`, so it's very efficient.
 #
 # You can't dynamically create symbols. When you compile your program, each symbol

--- a/src/tuple.cr
+++ b/src/tuple.cr
@@ -13,6 +13,8 @@
 # tuple[2]                  # => 'x'
 # ```
 #
+# See [`Tuple` literals](https://crystal-lang.org/reference/syntax_and_semantics/literals/tuple.html) in the language reference.
+#
 # The compiler knows what types are in each position, so when indexing
 # a tuple with an integer literal the compiler will return
 # the value in that index and with the expected type, like in the above


### PR DESCRIPTION
Adds links to the respective [section on the language reference](https://crystal-lang.org/reference/syntax_and_semantics/literals/index.html) to the API docs for types that have corresponding literals.

<del>String literals are explained in much detail in the reference, so we can remove the duplication on the `String` type docs.</del>

Also adds some clarification on the usage of the command methods (`` ::`() ``).

Resolves #10731