### PR TITLE
fix IO::ARGF#read should always return i32

### DIFF
--- a/src/io/argf.cr
+++ b/src/io/argf.cr
@@ -10,7 +10,7 @@ class IO::ARGF < IO
     @read_from_stdin = false
   end
 
-  def read(slice : Bytes) : Int32 | Int64
+  def read(slice : Bytes) : Int32
     first_initialize unless @initialized
 
     if current_io = @current_io
@@ -25,7 +25,7 @@ class IO::ARGF < IO
       read_count = 0
     end
 
-    read_count
+    read_count.to_i32
   end
 
   # :nodoc:

--- a/src/io/argf.cr
+++ b/src/io/argf.cr
@@ -10,7 +10,7 @@ class IO::ARGF < IO
     @read_from_stdin = false
   end
 
-  def read(slice : Bytes) : Int32
+  def read(slice : Bytes) : Int32 | Int64
     first_initialize unless @initialized
 
     if current_io = @current_io


### PR DESCRIPTION
seeing errors like this on nightly

<img width="606" alt="image" src="https://user-images.githubusercontent.com/368013/122312919-92173c00-cf58-11eb-9f81-c7b895616587.png">
