### PR TITLE
Fix union logic between metaclasses of uninstantiated generic classes in same hierarchy

### DIFF
--- a/spec/compiler/semantic/union_spec.cr
+++ b/spec/compiler/semantic/union_spec.cr
@@ -115,6 +115,16 @@ describe "Semantic: union" do
         end
         )) { [types["A"], types["B"], types["A"].virtual_type!] }
     end
+
+    it "uninstantiated generic super-metaclass v.s. uninstantiated generic sub-metaclass" do
+      assert_commutes(%(
+        class A(T)
+        end
+
+        class B(T) < A(T)
+        end
+        )) { [types["A"].metaclass, types["B"].metaclass, types["A"].metaclass.virtual_type!] }
+    end
   end
 
   it "types union when obj is union" do

--- a/src/compiler/crystal/semantic/type_merge.cr
+++ b/src/compiler/crystal/semantic/type_merge.cr
@@ -214,6 +214,16 @@ module Crystal
       nil
     end
 
+    def self.least_common_ancestor(
+      type1 : MetaclassType | GenericClassInstanceMetaclassType,
+      type2 : MetaclassType | GenericClassInstanceMetaclassType
+    )
+      return nil unless unifiable_metaclass?(type1) && unifiable_metaclass?(type2)
+
+      common = least_common_ancestor(type1.instance_type, type2.instance_type)
+      common.try &.metaclass
+    end
+
     def self.least_common_ancestor(type1 : NonGenericModuleType | GenericModuleInstanceType | GenericClassType, type2 : Type)
       type1 if type2.implements?(type1)
     end
@@ -295,16 +305,6 @@ module Crystal
       end
 
       type1.program.named_tuple_of(merged_entries)
-    end
-
-    def self.least_common_ancestor(
-      type1 : MetaclassType | GenericClassInstanceMetaclassType,
-      type2 : MetaclassType | GenericClassInstanceMetaclassType
-    )
-      return nil unless unifiable_metaclass?(type1) && unifiable_metaclass?(type2)
-
-      common = least_common_ancestor(type1.instance_type, type2.instance_type)
-      common.try &.metaclass
     end
 
     private def self.unifiable_metaclass?(type)


### PR DESCRIPTION
#10527 introduced a reducible union that didn't previously exist:

```crystal
class Foo(T)
end

class Bar(T) < Foo(T)
end

typeof(Foo || Bar) # => (Bar(T).class | Foo(T).class)
# before:          # => Foo(T).class
```

It happened because `Foo` and `Bar` were handled like normal classes instead of metaclasses (every `Crystal::MetaclassType` is a `ClassType`), and because `Type#depth` isn't really used for metaclasses yet; changing the overload order of the least common ancestor method fixes this.