### PR TITLE
Fix `FileDescriptor#pos` return `Int64` on armv6

### DIFF
--- a/src/crystal/dwarf/info.cr
+++ b/src/crystal/dwarf/info.cr
@@ -11,8 +11,8 @@ module Crystal
       property! abbreviations : Array(Abbrev)
 
       property dwarf64 : Bool
-      @offset : LibC::OffT
-      @ref_offset : LibC::OffT
+      @offset : Int64
+      @ref_offset : Int64
 
       def initialize(@io : IO::FileDescriptor, @offset)
         @ref_offset = offset

--- a/src/crystal/dwarf/line_numbers.cr
+++ b/src/crystal/dwarf/line_numbers.cr
@@ -123,7 +123,7 @@ module Crystal
       #
       # An individual compressed sequence.
       struct Sequence
-        property! offset : LibC::OffT
+        property! offset : Int64
         property! unit_length : UInt32
         property! version : UInt16
         property! header_length : UInt32 # FIXME: UInt64 for DWARF64 (uncommon)
@@ -166,7 +166,7 @@ module Crystal
       # reduce the memory usage of repeating a String many times.
       getter matrix : Array(Array(Row))
 
-      @offset : LibC::OffT
+      @offset : Int64
 
       def initialize(@io : IO::FileDescriptor, size, @base_address : LibC::SizeT = 0)
         @offset = @io.tell

--- a/src/crystal/system/unix/file_descriptor.cr
+++ b/src/crystal/system/unix/file_descriptor.cr
@@ -80,7 +80,7 @@ module Crystal::System::FileDescriptor
   end
 
   private def system_pos
-    pos = LibC.lseek(fd, 0, IO::Seek::Current).to_i64!
+    pos = LibC.lseek(fd, 0, IO::Seek::Current).to_i64
     raise IO::Error.from_errno "Unable to tell" if pos == -1
     pos
   end
@@ -153,7 +153,7 @@ module Crystal::System::FileDescriptor
   end
 
   def self.pread(fd, buffer, offset)
-    bytes_read = LibC.pread(fd, buffer, buffer.size, offset).to_i64!
+    bytes_read = LibC.pread(fd, buffer, buffer.size, offset).to_i64
 
     if bytes_read == -1
       raise IO::Error.from_errno "Error reading file"

--- a/src/crystal/system/unix/file_descriptor.cr
+++ b/src/crystal/system/unix/file_descriptor.cr
@@ -80,7 +80,7 @@ module Crystal::System::FileDescriptor
   end
 
   private def system_pos
-    pos = LibC.lseek(fd, 0, IO::Seek::Current)
+    pos = LibC.lseek(fd, 0, IO::Seek::Current).to_i64!
     raise IO::Error.from_errno "Unable to tell" if pos == -1
     pos
   end

--- a/src/crystal/system/unix/file_descriptor.cr
+++ b/src/crystal/system/unix/file_descriptor.cr
@@ -153,7 +153,7 @@ module Crystal::System::FileDescriptor
   end
 
   def self.pread(fd, buffer, offset)
-    bytes_read = LibC.pread(fd, buffer, buffer.size, offset)
+    bytes_read = LibC.pread(fd, buffer, buffer.size, offset).to_i64!
 
     if bytes_read == -1
       raise IO::Error.from_errno "Error reading file"

--- a/src/crystal/system/win32/file_descriptor.cr
+++ b/src/crystal/system/win32/file_descriptor.cr
@@ -157,11 +157,11 @@ module Crystal::System::FileDescriptor
     overlapped.union.offset.offsetHigh = LibC::DWORD.new(offset >> 32)
     if LibC.ReadFile(handle, buffer, buffer.size, out bytes_read, pointerof(overlapped)) == 0
       error = WinError.value
-      return 0 if error == WinError::ERROR_HANDLE_EOF
+      return 0_i64 if error == WinError::ERROR_HANDLE_EOF
       raise IO::Error.from_winerror "Error reading file", error
     end
 
-    bytes_read
+    bytes_read.to_i64!
   end
 
   def self.from_stdio(fd)

--- a/src/crystal/system/win32/file_descriptor.cr
+++ b/src/crystal/system/win32/file_descriptor.cr
@@ -161,7 +161,7 @@ module Crystal::System::FileDescriptor
       raise IO::Error.from_winerror "Error reading file", error
     end
 
-    bytes_read.to_i64!
+    bytes_read.to_i64
   end
 
   def self.from_stdio(fd)

--- a/src/file/preader.cr
+++ b/src/file/preader.cr
@@ -6,6 +6,7 @@ class File::PReader < IO
 
   @offset : Int64
   @bytesize : Int64
+  @pos : Int64
 
   def initialize(@file : File, offset : Int, bytesize : Int)
     @offset = offset.to_i64

--- a/src/file/preader.cr
+++ b/src/file/preader.cr
@@ -13,7 +13,7 @@ class File::PReader < IO
     @pos = 0
   end
 
-  def unbuffered_read(slice : Bytes)
+  def unbuffered_read(slice : Bytes) : Int64
     check_open
 
     count = slice.size


### PR DESCRIPTION
Since #10580, the return type of `IO::FileDescriptor#pos` is restricted to `Int64`. This means it's actually broken on armv6.

Similarly, `IO::FileDescriptor#pread` was missing a type restriction and returned different types depending on the target platform. This is getting unified.

This resolves the initial reports of #10645, but there may be more (https://github.com/crystal-lang/crystal/issues/10645#issuecomment-866726758).
