### PR TITLE
Fix exaö.e `WeakRef` example by removing ref.value call.

### DIFF
--- a/src/weak_ref.cr
+++ b/src/weak_ref.cr
@@ -9,6 +9,9 @@
 # p ref       # => #<WeakRef(String):0x7f83406eafa0 @target=Pointer(Void).null>
 # p ref.value # => nil
 # ```
+#
+# Note that the collection of objects is not deterministic, and depends on many subtle aspects. For instance,
+# if the example above is modified to print `ref.value` in the first print, then the collector will not collect it.
 class WeakRef(T)
   @target : Void*
 

--- a/src/weak_ref.cr
+++ b/src/weak_ref.cr
@@ -4,8 +4,9 @@
 # require "weak_ref"
 #
 # ref = WeakRef.new("oof".reverse)
-# p ref.value # => "foo"
+# p ref # => #<WeakRef(String):0x7f83406eafa0 @target=Pointer(Void)@0x7f83406eafc0>
 # GC.collect
+# p ref       # => #<WeakRef(String):0x7f83406eafa0 @target=Pointer(Void).null>
 # p ref.value # => nil
 # ```
 class WeakRef(T)


### PR DESCRIPTION
The `ref.value` call cause the GC to not collect `ref` until end of scope.

Fixes part of https://github.com/crystal-lang/crystal/issues/10469