### PR TITLE
[Revert] Remove type restriction on `Random::Secure#next_u`

### DIFF
--- a/src/random/secure.cr
+++ b/src/random/secure.cr
@@ -19,7 +19,7 @@ module Random::Secure
   extend Random
   extend self
 
-  def next_u : UInt8
+  def next_u
     Crystal::System::Random.next_u
   end
 


### PR DESCRIPTION
Reverts the return type restriction `Random::Secure#next_u : UInt8` added in #10585 which breaks on OpenBSD and NetBSD because the underlying arc4random implementation actually returns `UInt32`.

This change is essentially a workaround. Eventually, the return type should be identical on all platforms, but that would be a breaking API change.

Resolves #10847