### PR TITLE
Add macro method `ASTNode#nil?`

### DIFF
--- a/spec/compiler/macro/macro_methods_spec.cr
+++ b/spec/compiler/macro/macro_methods_spec.cr
@@ -140,6 +140,20 @@ module Crystal
           assert_macro "x", "{{x.class_name}}", [ArrayLiteral.new([Path.new("Foo"), Path.new("Bar")] of ASTNode)] of ASTNode, "\"ArrayLiteral\""
         end
       end
+
+      describe "#nil?" do
+        it "NumberLiteral" do
+          assert_macro "", "{{ 1.nil? }}", [] of ASTNode, "false"
+        end
+
+        it "NilLiteral" do
+          assert_macro "", "{{ nil.nil? }}", [] of ASTNode, "true"
+        end
+
+        it "Nop" do
+          assert_macro "x", "{{ x.nil? }}", [Nop.new] of ASTNode, "true"
+        end
+      end
     end
 
     describe "number methods" do

--- a/src/compiler/crystal/macros.cr
+++ b/src/compiler/crystal/macros.cr
@@ -272,6 +272,10 @@ module Crystal::Macros
     # highlight this node in the error message.
     def raise(message) : NoReturn
     end
+
+    # Returns `true` if this node is a `NilLiteral` or `Nop`.
+    def __crystal_pseudo_nil? : BoolLiteral
+    end
   end
 
   # The empty node. Similar to a `NilLiteral` but its textual representation

--- a/src/compiler/crystal/macros/methods.cr
+++ b/src/compiler/crystal/macros/methods.cr
@@ -382,6 +382,10 @@ module Crystal
         end
       when "!"
         BoolLiteral.new(!truthy?)
+      when "nil?"
+        interpret_argless_method("nil?", args) do
+          BoolLiteral.new(is_a?(NilLiteral) || is_a?(Nop))
+        end
       else
         raise "undefined macro method '#{class_desc}##{method}'", exception_type: Crystal::UndefinedMacroMethodError
       end


### PR DESCRIPTION
#10616 removed a bug that the compiler accepted calls to `nil?` in macro expressions where that method does not exist. These calls were internally transformed to `is_a?(Nil)`. In the macro interpreter, no value can be of type `Nil` because that's a runtime type, so any `nil?` call would always return `false`.
Removing that transformation from the parser made `nil?` calls in macro expressions errors because that method is not defined.

But users would expect `nil.nil?` to return `true`. So this patch implements `ASTNode#nil?` in the macro interpreter. It returns `true` if the value is a `NilLiteral` or `Nop`.

This is technically a feature addition, but we should still merge it for 1.1 despite the feature freeze. It actually avoids a breaking change that would occur with #10616 alone. Code that worked in 1.0 would no longer compile (even though it was already broken before and just worked by chance). With this PR, it continues to compile and fulfills the intended purpose.