### PR TITLE
Fix `HTTP::Cookie` parse quoted cookie value

### DIFF
--- a/spec/std/http/cookie_spec.cr
+++ b/spec/std/http/cookie_spec.cr
@@ -162,6 +162,13 @@ module HTTP
         cookie.to_set_cookie_header.should eq("key%3Dvalue=value")
       end
 
+      it %(parses key="value") do
+        cookie = parse_first_cookie(%(key="value"))
+        cookie.name.should eq("key")
+        cookie.value.should eq("value")
+        cookie.to_set_cookie_header.should eq("key=value")
+      end
+
       it "parses multiple cookies" do
         cookies = Cookie::Parser.parse_cookies("foo=bar; foobar=baz")
         cookies.size.should eq(2)

--- a/src/http/cookie.cr
+++ b/src/http/cookie.cr
@@ -152,7 +152,12 @@ module HTTP
 
       def parse_cookies(header)
         header.scan(CookieString).each do |pair|
-          yield Cookie.new(pair["name"], pair["value"])
+          value = pair["value"]
+          if value.starts_with?('"')
+            # Unwrap quoted cookie value
+            value = value.byte_slice(1, value.bytesize - 2)
+          end
+          yield Cookie.new(pair["name"], value)
         end
       end
 


### PR DESCRIPTION
`HTTP::Cookies::Parser` correctly recognizes a quoted cookie value, but it doesn't dequote when creating the  `HTTP::Cookie` instance. This leads to a validation error (#10485).

Reported in https://forum.crystal-lang.org/t/invalid-cookie-value-error-in-kemal-how-to-fix/3427