### PR TITLE
Fix or revert some return type restrictions from  #10575

### DIFF
--- a/src/digest/io_digest.cr
+++ b/src/digest/io_digest.cr
@@ -30,8 +30,8 @@ class IO::Digest < IO
   def initialize(@io : IO, @digest_algorithm : ::Digest, @mode = DigestMode::Read)
   end
 
-  def read(slice : Bytes)
-    read_bytes = io.read(slice)
+  def read(slice : Bytes) : Int32
+    read_bytes = io.read(slice).to_i32
     if @mode.read?
       digest_algorithm.update(slice[0, read_bytes])
     end

--- a/src/digest/io_digest.cr
+++ b/src/digest/io_digest.cr
@@ -30,7 +30,7 @@ class IO::Digest < IO
   def initialize(@io : IO, @digest_algorithm : ::Digest, @mode = DigestMode::Read)
   end
 
-  def read(slice : Bytes) : Int32
+  def read(slice : Bytes)
     read_bytes = io.read(slice)
     if @mode.read?
       digest_algorithm.update(slice[0, read_bytes])

--- a/src/enumerable.cr
+++ b/src/enumerable.cr
@@ -238,7 +238,7 @@ module Enumerable(T)
   # ```
   # [1, 2, 3, 4].count { |i| i % 2 == 0 } # => 2
   # ```
-  def count
+  def count(& : T -> _) : Int32
     count = 0
     each { |e| count += 1 if yield e }
     count
@@ -624,7 +624,7 @@ module Enumerable(T)
   # ```
   #
   # Returns `nil` if the block didn't return `true` for any element.
-  def index
+  def index(& : T -> _) : Int32?
     each_with_index do |e, i|
       return i if yield e
     end
@@ -638,7 +638,7 @@ module Enumerable(T)
   # ```
   #
   # Returns `nil` if *obj* is not in the collection.
-  def index(obj)
+  def index(obj) : Int32?
     index { |e| e == obj }
   end
 

--- a/src/enumerable.cr
+++ b/src/enumerable.cr
@@ -1099,7 +1099,7 @@ module Enumerable(T)
   end
 
   # Like `minmax` but returns `{nil, nil}` if the collection is empty.
-  def minmax? : {T?, T?}
+  def minmax? : {T, T} | {Nil, Nil}
     minmax_by? &.itself
   end
 

--- a/src/enumerable.cr
+++ b/src/enumerable.cr
@@ -1099,7 +1099,7 @@ module Enumerable(T)
   end
 
   # Like `minmax` but returns `{nil, nil}` if the collection is empty.
-  def minmax? : {T, T} | {Nil, Nil}
+  def minmax? : {T?, T?}
     minmax_by? &.itself
   end
 

--- a/src/http/content.cr
+++ b/src/http/content.cr
@@ -26,7 +26,7 @@ module HTTP
   class FixedLengthContent < IO::Sized
     include Content
 
-    def read(slice : Bytes)
+    def read(slice : Bytes) : Int32
       ensure_send_continue
       super
     end
@@ -58,9 +58,9 @@ module HTTP
     def initialize(@io : IO)
     end
 
-    def read(slice : Bytes)
+    def read(slice : Bytes) : Int32
       ensure_send_continue
-      @io.read(slice)
+      @io.read(slice).to_i32
     end
 
     def read_byte : UInt8?
@@ -112,7 +112,7 @@ module HTTP
       @received_final_chunk = false
     end
 
-    def read(slice : Bytes)
+    def read(slice : Bytes) : Int32
       ensure_send_continue
       count = slice.size
       return 0 if count == 0
@@ -123,7 +123,7 @@ module HTTP
 
       to_read = Math.min(count, @chunk_remaining)
 
-      bytes_read = @io.read slice[0, to_read]
+      bytes_read = @io.read(slice[0, to_read]).to_i32
 
       if bytes_read == 0
         raise IO::EOFError.new("Invalid HTTP chunked content")

--- a/src/http/content.cr
+++ b/src/http/content.cr
@@ -73,7 +73,7 @@ module HTTP
       @io.peek
     end
 
-    def skip(bytes_count) : Int32?
+    def skip(bytes_count) : Nil
       ensure_send_continue
       @io.skip(bytes_count)
     end
@@ -164,7 +164,7 @@ module HTTP
       peek
     end
 
-    def skip(bytes_count) : Int32?
+    def skip(bytes_count) : Nil
       ensure_send_continue
       if bytes_count <= @chunk_remaining
         @io.skip(bytes_count)

--- a/src/http/content.cr
+++ b/src/http/content.cr
@@ -26,7 +26,7 @@ module HTTP
   class FixedLengthContent < IO::Sized
     include Content
 
-    def read(slice : Bytes) : Int32
+    def read(slice : Bytes)
       ensure_send_continue
       super
     end
@@ -58,7 +58,7 @@ module HTTP
     def initialize(@io : IO)
     end
 
-    def read(slice : Bytes) : Int32
+    def read(slice : Bytes)
       ensure_send_continue
       @io.read(slice)
     end
@@ -112,7 +112,7 @@ module HTTP
       @received_final_chunk = false
     end
 
-    def read(slice : Bytes) : Int32
+    def read(slice : Bytes)
       ensure_send_continue
       count = slice.size
       return 0 if count == 0

--- a/src/humanize.cr
+++ b/src/humanize.cr
@@ -82,7 +82,7 @@ struct Number
   end
 
   # :nodoc:
-  def self.prefix_index(i, group = 3) : Int32
+  def self.prefix_index(i : Int32, group : Int32 = 3) : Int32
     ((i - (i > 0 ? 1 : 0)) // group) * group
   end
 

--- a/src/io/argf.cr
+++ b/src/io/argf.cr
@@ -10,7 +10,7 @@ class IO::ARGF < IO
     @read_from_stdin = false
   end
 
-  def read(slice : Bytes)
+  def read(slice : Bytes) : Int32
     first_initialize unless @initialized
 
     if current_io = @current_io

--- a/src/io/argf.cr
+++ b/src/io/argf.cr
@@ -10,7 +10,7 @@ class IO::ARGF < IO
     @read_from_stdin = false
   end
 
-  def read(slice : Bytes) : Int32
+  def read(slice : Bytes)
     first_initialize unless @initialized
 
     if current_io = @current_io

--- a/src/io/hexdump.cr
+++ b/src/io/hexdump.cr
@@ -26,8 +26,8 @@ class IO::Hexdump < IO
   def initialize(@io : IO, @output : IO = STDERR, @read = false, @write = false)
   end
 
-  def read(buf : Bytes)
-    @io.read(buf).tap do |read_bytes|
+  def read(buf : Bytes) : Int32
+    @io.read(buf).to_i32.tap do |read_bytes|
       buf[0, read_bytes].hexdump(@output) if @read && read_bytes
     end
   end

--- a/src/io/hexdump.cr
+++ b/src/io/hexdump.cr
@@ -26,7 +26,7 @@ class IO::Hexdump < IO
   def initialize(@io : IO, @output : IO = STDERR, @read = false, @write = false)
   end
 
-  def read(buf : Bytes) : Int32
+  def read(buf : Bytes)
     @io.read(buf).tap do |read_bytes|
       buf[0, read_bytes].hexdump(@output) if @read && read_bytes
     end

--- a/src/io/memory.cr
+++ b/src/io/memory.cr
@@ -192,7 +192,7 @@ class IO::Memory < IO
   end
 
   # :nodoc:
-  def skip(bytes_count)
+  def skip(bytes_count) : Nil
     check_open
 
     available = @bytesize - @pos

--- a/src/io/sized.cr
+++ b/src/io/sized.cr
@@ -25,11 +25,11 @@ class IO::Sized < IO
     @read_remaining = read_size.to_u64
   end
 
-  def read(slice : Bytes)
+  def read(slice : Bytes) : Int32
     check_open
 
     count = {slice.size.to_u64, @read_remaining}.min
-    bytes_read = @io.read slice[0, count]
+    bytes_read = @io.read(slice[0, count]).to_i32
     @read_remaining -= bytes_read
     bytes_read
   end

--- a/src/io/sized.cr
+++ b/src/io/sized.cr
@@ -25,7 +25,7 @@ class IO::Sized < IO
     @read_remaining = read_size.to_u64
   end
 
-  def read(slice : Bytes) : Int32
+  def read(slice : Bytes)
     check_open
 
     count = {slice.size.to_u64, @read_remaining}.min

--- a/src/io/stapled.cr
+++ b/src/io/stapled.cr
@@ -30,10 +30,10 @@ class IO::Stapled < IO
   end
 
   # Reads a slice from `reader`.
-  def read(slice : Bytes)
+  def read(slice : Bytes) : Int32
     check_open
 
-    @reader.read(slice)
+    @reader.read(slice).to_i32
   end
 
   # Gets a string from `reader`.

--- a/src/io/stapled.cr
+++ b/src/io/stapled.cr
@@ -30,7 +30,7 @@ class IO::Stapled < IO
   end
 
   # Reads a slice from `reader`.
-  def read(slice : Bytes) : Int32
+  def read(slice : Bytes)
     check_open
 
     @reader.read(slice)

--- a/src/string.cr
+++ b/src/string.cr
@@ -817,7 +817,7 @@ class String
   # s[-2..-4] # => ""
   # s[-2..1]  # => ""
   # s[3..-4]  # => ""
-  # ``` : String
+  # ```
   def [](range : Range) : String
     self[*Indexable.range_to_index_and_count(range, size) || raise IndexError.new]
   end
@@ -5010,7 +5010,7 @@ class String
   # Raises an `ArgumentError` if `self` has null bytes. Returns `self` otherwise.
   #
   # This method should sometimes be called before passing a `String` to a C function.
-  def check_no_null_byte(name = nil) : String
+  def check_no_null_byte(name = nil) : self
     if byte_index(0)
       name = "`#{name}` " if name
       raise ArgumentError.new("String #{name}contains null byte")


### PR DESCRIPTION
This PR fixes some issues with return type restrictions added in the first batch of #10575.

A couple of `IO#read` implementations <del>needed to remove</del> `Int32` because we can't be sure that the wrapped IO implementations return `Int32` (continuation of #10855). <ins>The restrictions stay, we're casting the value instead.</ins>

Return type restrictions are added to a couple of `Enumerable` methods because those are delegated to from other methods which already have that restriction. This makes sure to honor that.

`IO#skip` always returns `Nil`. One implementation of an HTTP IO leaked an Int32 into other implementations as well. Adding `Nil` everywhere avoids that.