### PR TITLE
Update distribution-scripts for shards 0.15.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -144,7 +144,7 @@ jobs:
       - run: |
           git clone https://github.com/crystal-lang/distribution-scripts.git ~/distribution-scripts
           cd ~/distribution-scripts
-          git checkout 85028bd13d6f9f80499a0aa9fa18fda7bd398f49
+          git checkout 37a307f786ebc86eaa61f8ae9e92bbe8524cddb9
       # persist relevant information for build process
       - run: |
           cd ~/distribution-scripts

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -144,7 +144,7 @@ jobs:
       - run: |
           git clone https://github.com/crystal-lang/distribution-scripts.git ~/distribution-scripts
           cd ~/distribution-scripts
-          git checkout 37a307f786ebc86eaa61f8ae9e92bbe8524cddb9
+          git checkout 8bc01e26291dc518390129e15df8f757d687871c
       # persist relevant information for build process
       - run: |
           cd ~/distribution-scripts


### PR DESCRIPTION
Include upgrade to https://github.com/crystal-lang/shards/releases/tag/v0.15.0

Update and merge after https://github.com/crystal-lang/distribution-scripts/pull/101 is merged