### PR TITLE
Fix `Time#shift` cover date boundaries with zone offset

### DIFF
--- a/spec/std/time/time_spec.cr
+++ b/spec/std/time/time_spec.cr
@@ -450,6 +450,11 @@ describe Time do
 
       Time.local(2020, 2, 5, 0, 13, location: zone).shift(months: 3).should eq Time.local(2020, 5, 5, 0, 13, location: zone)
     end
+
+    it "covers date boundaries with zone offset (#10869)" do
+      location = Time::Location.fixed(2 * 3600)
+      Time.local(2021, 7, 1, location: location).shift(months: 1).should eq Time.local(2021, 8, 1, location: location)
+    end
   end
 
   it "#time_of_day" do

--- a/src/time.cr
+++ b/src/time.cr
@@ -704,7 +704,7 @@ struct Time
       # are applied to the equivalent UTC representation of this local time.
       seconds += offset_seconds
     else
-      year, month, day, _ = to_utc.year_month_day_day_year
+      year, month, day, _ = year_month_day_day_year
 
       year += years
 
@@ -723,8 +723,7 @@ struct Time
       end
 
       seconds += Time.absolute_days(year, month, day).to_i64 * SECONDS_PER_DAY
-      seconds += @seconds % SECONDS_PER_DAY
-      seconds += offset
+      seconds += offset_seconds % SECONDS_PER_DAY
     end
 
     # FIXME: These operations currently don't have overflow checks applied.


### PR DESCRIPTION
Fixes #10869

This is actually a pretty significant bug. The cause is that the date arithmetic in `Time#shift` should be time-zone neutral (floating) and only use the wall clock / calendar representation. But that was flawed in that the `year, month, day` representation was incorrectly calculated for the UTC date (which can be a different date than the local one).
This had already been discovered in #8741 but the fix in #8742 is insufficient. It only counters the error for *most* values. The effect is still visible under specific circumstances, when `(@seconds + offset) % SECONDS_PER_DAY` is different from `@seconds % SECONDS_PER_DAY + offset`. This means the time zone offset moves the UTC date to a different day than the local date and the calculation is off by one day.
```cr
location = Time::Location.fixed(2 * 3600)
Time.local(2021, 7, 1, 1, 59, location: location).shift(months: 1) # => 2021-07-31 01:59:00.0 +02:00
Time.local(2021, 7, 1, 2, 1, location: location).shift(months: 1)  # => 2021-08-01 02:01:00.0 +02:00
```