### PR TITLE
Refactor `CrystalPath#find_in_path_relative_to_dir` for readability

### DIFF
--- a/spec/compiler/crystal_path/crystal_path_spec.cr
+++ b/spec/compiler/crystal_path/crystal_path_spec.cr
@@ -1,5 +1,6 @@
 require "../../spec_helper"
 require "../../support/env"
+require "spec/helpers/iterate"
 
 private def assert_finds(search, results, relative_to = nil, path = __DIR__, file = __FILE__, line = __LINE__)
   it "finds #{search.inspect}", file, line do
@@ -103,6 +104,76 @@ describe Crystal::CrystalPath do
 
   # Don't find relative filenames in src or shards
   assert_doesnt_find "../../src/file_three", relative_to: Path["test_files", "test_folder", "test_folder.cr"].to_s, expected_relative_to: Path["test_files", "test_folder"].to_s
+
+  describe "#each_file_expansion", focus: true do
+    path = Crystal::CrystalPath.new
+
+    it "foo.cr" do
+      assert_iterates_yielding [
+        "x/foo.cr",
+        "x/foo.cr/foo.cr.cr",
+        "x/foo.cr/src/foo.cr.cr"
+      ], path.each_file_expansion("foo.cr", "x")
+    end
+
+    it "foo" do
+      assert_iterates_yielding [
+        "x/foo.cr",
+        "x/foo/foo.cr",
+        "x/foo/src/foo.cr"
+      ], path.each_file_expansion("foo", "x")
+    end
+
+    it "./foo" do
+      assert_iterates_yielding [
+        "x/./foo.cr",
+        "x/./foo/foo.cr",
+      ], path.each_file_expansion("./foo", "x")
+    end
+
+    it "./foo.cr" do
+      assert_iterates_yielding [
+        "x/./foo.cr",
+        "x/./foo/foo.cr",
+      ], path.each_file_expansion("./foo", "x")
+    end
+
+    it "foo/bar" do
+      assert_iterates_yielding [
+        "x/foo/bar.cr",
+        "x/foo/src/bar.cr",
+        "x/foo/src/foo/bar.cr",
+        "x/foo/bar/bar.cr",
+        "x/foo/src/bar/bar.cr",
+        "x/foo/src/foo/bar/bar.cr",
+      ], path.each_file_expansion("foo/bar", "x")
+    end
+
+    it "./foo/bar" do
+      assert_iterates_yielding [
+        "x/./foo/bar.cr",
+        "x/./foo/bar/bar.cr",
+      ], path.each_file_expansion("./foo/bar", "x")
+    end
+
+    it "foo/bar/baz" do
+      assert_iterates_yielding [
+        "x/foo/bar/baz.cr",
+        "x/foo/src/bar/baz.cr",
+        "x/foo/src/foo/bar/baz.cr",
+        "x/foo/bar/baz/baz.cr",
+        "x/foo/src/bar/baz/bar/baz.cr",
+        "x/foo/src/foo/bar/baz/bar/baz.cr",
+      ], path.each_file_expansion("foo/bar/baz", "x")
+    end
+
+    it "./foo/bar/baz" do
+      assert_iterates_yielding [
+        "x/./foo/bar/baz.cr",
+        "x/./foo/bar/baz/baz.cr",
+      ], path.each_file_expansion("./foo/bar/baz", "x")
+    end
+  end
 
   it "includes 'lib' by default" do
     with_env("CRYSTAL_PATH": nil) do

--- a/spec/compiler/crystal_path/crystal_path_spec.cr
+++ b/spec/compiler/crystal_path/crystal_path_spec.cr
@@ -112,7 +112,7 @@ describe Crystal::CrystalPath do
       assert_iterates_yielding [
         "x/foo.cr",
         "x/foo.cr/foo.cr.cr",
-        "x/foo.cr/src/foo.cr.cr"
+        "x/foo.cr/src/foo.cr.cr",
       ], path.each_file_expansion("foo.cr", "x")
     end
 
@@ -120,7 +120,7 @@ describe Crystal::CrystalPath do
       assert_iterates_yielding [
         "x/foo.cr",
         "x/foo/foo.cr",
-        "x/foo/src/foo.cr"
+        "x/foo/src/foo.cr",
       ], path.each_file_expansion("foo", "x")
     end
 

--- a/src/compiler/crystal/crystal_path.cr
+++ b/src/compiler/crystal/crystal_path.cr
@@ -93,24 +93,27 @@ module Crystal
 
       filename_is_relative = filename.starts_with?('.')
 
-      if !filename_is_relative && (slash_index = filename.index('/'))
-        # If it's "foo/bar/baz", check if "foo/src/bar/baz.cr" exists (for a shard, non-namespaced structure)
-        before_slash, after_slash = filename.split('/', 2)
+      shard_name, _, shard_path = filename.partition("/")
+      shard_path = shard_path.presence
 
-        yield "#{relative_to}/#{before_slash}/src/#{after_slash}.cr"
+      if !filename_is_relative && shard_path
+        shard_src = "#{relative_to}/#{shard_name}/src"
+
+        # If it's "foo/bar/baz", check if "foo/src/bar/baz.cr" exists (for a shard, non-namespaced structure)
+        yield "#{shard_src}/#{shard_path}.cr"
 
         # Then check if "foo/src/foo/bar/baz.cr" exists (for a shard, namespaced structure)
-        yield "#{relative_to}/#{before_slash}/src/#{before_slash}/#{after_slash}.cr"
+        yield "#{shard_src}/#{shard_name}/#{shard_path}.cr"
 
         # If it's "foo/bar/baz", check if "foo/bar/baz/baz.cr" exists (std, nested)
         basename = File.basename(relative_filename)
-        yield "#{relative_to}/#{filename}/#{basename}.cr"
+        yield "#{relative_filename}/#{basename}.cr"
 
         # If it's "foo/bar/baz", check if "foo/src/foo/bar/baz/baz.cr" exists (shard, non-namespaced, nested)
-        yield "#{relative_to}/#{before_slash}/src/#{after_slash}/#{after_slash}.cr"
+        yield "#{shard_src}/#{shard_path}/#{shard_path}.cr"
 
         # If it's "foo/bar/baz", check if "foo/src/foo/bar/baz/baz.cr" exists (shard, namespaced, nested)
-        yield "#{relative_to}/#{before_slash}/src/#{before_slash}/#{after_slash}/#{after_slash}.cr"
+        yield "#{shard_src}/#{shard_name}/#{shard_path}/#{shard_path}.cr"
 
         return nil
       end

--- a/src/compiler/crystal/crystal_path.cr
+++ b/src/compiler/crystal/crystal_path.cr
@@ -86,7 +86,7 @@ module Crystal
       nil
     end
 
-    private def each_file_expansion(filename, relative_to, &)
+    def each_file_expansion(filename, relative_to, &)
       relative_filename = "#{relative_to}/#{filename}"
       # Check if .cr file exists.
       yield relative_filename.ends_with?(".cr") ? relative_filename : "#{relative_filename}.cr"

--- a/src/compiler/crystal/crystal_path.cr
+++ b/src/compiler/crystal/crystal_path.cr
@@ -78,13 +78,18 @@ module Crystal
         return nil
       end
 
-      relative_filename = "#{relative_to}/#{filename}"
-
-      # Check if .cr file exists.
-      relative_filename_cr = relative_filename.ends_with?(".cr") ? relative_filename : "#{relative_filename}.cr"
-      if File.exists?(relative_filename_cr)
-        return File.expand_path(relative_filename_cr)
+      each_file_expansion(filename, relative_to) do |path|
+        absolute_path = File.expand_path(path)
+        return absolute_path if File.exists?(absolute_path)
       end
+
+      nil
+    end
+
+    private def each_file_expansion(filename, relative_to, &)
+      relative_filename = "#{relative_to}/#{filename}"
+      # Check if .cr file exists.
+      yield relative_filename.ends_with?(".cr") ? relative_filename : "#{relative_filename}.cr"
 
       filename_is_relative = filename.starts_with?('.')
 
@@ -92,25 +97,20 @@ module Crystal
         # If it's "foo/bar/baz", check if "foo/src/bar/baz.cr" exists (for a shard, non-namespaced structure)
         before_slash, after_slash = filename.split('/', 2)
 
-        absolute_filename = File.expand_path("#{relative_to}/#{before_slash}/src/#{after_slash}.cr")
-        return absolute_filename if File.exists?(absolute_filename)
+        yield "#{relative_to}/#{before_slash}/src/#{after_slash}.cr"
 
         # Then check if "foo/src/foo/bar/baz.cr" exists (for a shard, namespaced structure)
-        absolute_filename = File.expand_path("#{relative_to}/#{before_slash}/src/#{before_slash}/#{after_slash}.cr")
-        return absolute_filename if File.exists?(absolute_filename)
+        yield "#{relative_to}/#{before_slash}/src/#{before_slash}/#{after_slash}.cr"
 
         # If it's "foo/bar/baz", check if "foo/bar/baz/baz.cr" exists (std, nested)
         basename = File.basename(relative_filename)
-        absolute_filename = File.expand_path("#{relative_to}/#{filename}/#{basename}.cr")
-        return absolute_filename if File.exists?(absolute_filename)
+        yield "#{relative_to}/#{filename}/#{basename}.cr"
 
         # If it's "foo/bar/baz", check if "foo/src/foo/bar/baz/baz.cr" exists (shard, non-namespaced, nested)
-        absolute_filename = File.expand_path("#{relative_to}/#{before_slash}/src/#{after_slash}/#{after_slash}.cr")
-        return absolute_filename if File.exists?(absolute_filename)
+        yield "#{relative_to}/#{before_slash}/src/#{after_slash}/#{after_slash}.cr"
 
         # If it's "foo/bar/baz", check if "foo/src/foo/bar/baz/baz.cr" exists (shard, namespaced, nested)
-        absolute_filename = File.expand_path("#{relative_to}/#{before_slash}/src/#{before_slash}/#{after_slash}/#{after_slash}.cr")
-        return absolute_filename if File.exists?(absolute_filename)
+        yield "#{relative_to}/#{before_slash}/src/#{before_slash}/#{after_slash}/#{after_slash}.cr"
 
         return nil
       end
@@ -118,16 +118,12 @@ module Crystal
       basename = File.basename(relative_filename)
 
       # If it's "foo", check if "foo/foo.cr" exists (for the std, nested)
-      absolute_filename = File.expand_path("#{relative_filename}/#{basename}.cr")
-      return absolute_filename if File.exists?(absolute_filename)
+      yield "#{relative_filename}/#{basename}.cr"
 
       unless filename_is_relative
         # If it's "foo", check if "foo/src/foo.cr" exists (for a shard)
-        absolute_filename = File.expand_path("#{relative_filename}/src/#{basename}.cr")
-        return absolute_filename if File.exists?(absolute_filename)
+        yield "#{relative_filename}/src/#{basename}.cr"
       end
-
-      nil
     end
 
     private def gather_dir_files(dir, files_accumulator, recursive)


### PR DESCRIPTION
This is a pure refactoring for readability, easier testing and some small performance improvements. It should not introduce any change in behaviour.

The main benefit is that it shows clearly, what paths each require filename expands to (cf https://github.com/crystal-lang/crystal/issues/10820#issuecomment-872862940).
Some of them look very questionable and should be subject to discussion in a subsequent issue (cf https://github.com/crystal-lang/crystal/issues/10820#issuecomment-872870071).