### PR TITLE
Add support for CRYSTAL_PATH resolution relative to compiler

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -33,10 +33,12 @@ SPEC_WARNINGS_OFF := --exclude-warnings spec/std --exclude-warnings spec/compile
 SPEC_FLAGS := $(if $(verbose),-v )$(if $(junit_output),--junit_output $(junit_output) )
 CRYSTAL_CONFIG_LIBRARY_PATH := $(shell bin/crystal env CRYSTAL_LIBRARY_PATH 2> /dev/null)
 CRYSTAL_CONFIG_BUILD_COMMIT := $(shell git rev-parse --short HEAD 2> /dev/null)
+CRYSTAL_CONFIG_PATH := "%{COMPILER_DIR}/../share/crystal/src"
 SOURCE_DATE_EPOCH := $(shell (git show -s --format=%ct HEAD || stat -c "%Y" Makefile || stat -f "%m" Makefile) 2> /dev/null)
 EXPORTS := \
   CRYSTAL_CONFIG_LIBRARY_PATH="$(CRYSTAL_CONFIG_LIBRARY_PATH)" \
   CRYSTAL_CONFIG_BUILD_COMMIT="$(CRYSTAL_CONFIG_BUILD_COMMIT)" \
+	CRYSTAL_CONFIG_PATH="$(CRYSTAL_CONFIG_PATH)" \
 	SOURCE_DATE_EPOCH="$(SOURCE_DATE_EPOCH)"
 SHELL = sh
 LLVM_CONFIG := $(shell src/llvm/ext/find-llvm-config)

--- a/man/crystal.1
+++ b/man/crystal.1
@@ -387,6 +387,8 @@ Defines path where Crystal caches partial compilation results for faster subsequ
 .It Sy CRYSTAL_PATH
 Defines paths where Crystal searches for required files.
 .Pp
+The pattern '%{COMPILER_DIR}' in the value expands to the directory where the compiler binary is located. For example, '%{COMPILER_DIR}/../share/crystal/src' resolves the standard library path relative to the compiler location in a generic way, independent of the absolute paths, assuming the relative location is correct.
+.Pp
 .It
 .It Sy CRYSTAL_OPTS
 Defines options for the Crystal compiler to be used besides the command line arguments. The syntax is identical to the command line arguments. This is hany when using Crystal in build setups, for example 'CRYSTAL_OPTS=--debug make build'.

--- a/src/compiler/crystal/crystal_path.cr
+++ b/src/compiler/crystal/crystal_path.cr
@@ -14,13 +14,12 @@ module Crystal
     private DEFAULT_LIB_PATH = "lib"
 
     def self.default_path
-      path = ENV["CRYSTAL_PATH"]? || begin
-        if Crystal::Config.path.blank?
-          DEFAULT_LIB_PATH
-        elsif Crystal::Config.path.split(Process::PATH_DELIMITER).includes?(DEFAULT_LIB_PATH)
-          Crystal::Config.path
-        else
-          {DEFAULT_LIB_PATH, Crystal::Config.path}.join(Process::PATH_DELIMITER)
+      path = ENV["CRYSTAL_PATH"]?
+
+      unless path
+        path = Crystal::Config.path.presence || DEFAULT_LIB_PATH
+        unless path.split(Process::PATH_DELIMITER).includes?(DEFAULT_LIB_PATH)
+          path = {DEFAULT_LIB_PATH, Crystal::Config.path}.join(Process::PATH_DELIMITER)
         end
       end
 


### PR DESCRIPTION
Resolves #7391

This patch adds support for runtime expansion of the `CRYSTAL_PATH` environment variable. It allows resolving the path to the standard library relative to the compiler location at runtime. This avoids the need to bake absolute paths into the compiler and using a wrapper script for distribution (https://github.com/crystal-lang/distribution-scripts/blob/8bc01e26291dc518390129e15df8f757d687871c/linux/files/crystal-wrapper). In fact, this essentially replicates the behaviour of the wrapper script, just embedded in the compiler directly.

It integrates perfectly with all existing usage. The new behaviour only becomes active when `CRYSTAL_PATH` includes the pattern `%{COMPILER_DIR}`. Existing use cases such as the wrapper script or baking ing absolute paths continue to work and will continue to do so.

The real value comes when this is baked in via `CRYSTAL_CONFIG_PATH` because that makes the compiler binary work standalone, as long as it finds the standard library in the designated path relative to its location.
So the default path `%{COMPILER_DIR}/../share/crystal/src` is configured in the `Makefile`. This location fits the typical install paths `/usr/bin/crystal` and `/usr/share/crystal/src`. This will become even more useful with `make install` (#10702) and adaptation in distribution-scripts.