### PR TITLE
Move `llvm_ext.o` to `.build`

### DIFF
--- a/.github/workflows/win.yml
+++ b/.github/workflows/win.yml
@@ -165,10 +165,11 @@ jobs:
           name: objs
       - name: Build LLVM extensions
         run: |
-          cl /MT /c src\llvm\ext\llvm_ext.cc -I llvm\include /Fosrc\llvm\ext\llvm_ext.obj
+          mkdir .build
+          cl /MT /c src\llvm\ext\llvm_ext.cc -I llvm\include /Fo.build\llvm_ext.obj
       - name: Link Crystal executable
         run: |
-          Invoke-Expression "cl crystal.obj /Fecrystal-cross src\llvm\ext\llvm_ext.obj $(llvm\bin\llvm-config.exe --libs) libs\pcre.lib libs\gc.lib WS2_32.lib advapi32.lib libcmt.lib legacy_stdio_definitions.lib /F10000000"
+          Invoke-Expression "cl crystal.obj /Fecrystal-cross .build\llvm_ext.obj $(llvm\bin\llvm-config.exe --libs) libs\pcre.lib libs\gc.lib WS2_32.lib advapi32.lib libcmt.lib legacy_stdio_definitions.lib /F10000000"
 
       - name: Re-build Crystal
         run: |

--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,3 @@ coverage/
 all_spec
 /tmp
 /docs/
-/src/llvm/ext/llvm_ext.o
-/src/llvm/ext/llvm_ext.obj
-/src/llvm/ext/llvm_ext.dwo

--- a/Makefile
+++ b/Makefile
@@ -41,7 +41,7 @@ EXPORTS := \
 SHELL = sh
 LLVM_CONFIG := $(shell src/llvm/ext/find-llvm-config)
 LLVM_EXT_DIR = src/llvm/ext
-LLVM_EXT_OBJ = $(LLVM_EXT_DIR)/llvm_ext.o
+LLVM_EXT_OBJ = $(O)/llvm_ext.o
 DEPS = $(LLVM_EXT_OBJ)
 CXXFLAGS += $(if $(debug),-g -O0)
 CRYSTAL_VERSION ?= $(shell cat src/VERSION)
@@ -116,6 +116,7 @@ $(O)/crystal: $(DEPS) $(SOURCES)
 	$(EXPORTS) ./bin/crystal build $(FLAGS) -o $@ src/compiler/crystal.cr -D without_openssl -D without_zlib
 
 $(LLVM_EXT_OBJ): $(LLVM_EXT_DIR)/llvm_ext.cc
+	@mkdir -p $(shell dirname $(LLVM_EXT_OBJ))
 	$(CXX) -c $(CXXFLAGS) -o $@ $< $(shell $(LLVM_CONFIG) --cxxflags)
 
 .PHONY: clean

--- a/src/llvm/lib_llvm_ext.cr
+++ b/src/llvm/lib_llvm_ext.cr
@@ -1,8 +1,8 @@
 require "./lib_llvm"
 {% if flag?(:win32) %}
-  @[Link(ldflags: "#{__DIR__}/ext/llvm_ext.obj")]
+  @[Link(ldflags: "#{__DIR__}/../../.build/llvm_ext.obj")]
 {% else %}
-  @[Link(ldflags: "#{__DIR__}/ext/llvm_ext.o")]
+  @[Link(ldflags: "#{__DIR__}/../../.build/llvm_ext.o")]
 {% end %}
 lib LibLLVMExt
   alias Char = LibC::Char


### PR DESCRIPTION
`llvm_ext.o` is not a source file, it's a binary build artifact. Thus it should not be in the src folder.

This has caused a need for several workarounds like https://github.com/crystal-lang/distribution-scripts/blob/8bc01e26291dc518390129e15df8f757d687871c/docker/alpine.Dockerfile#L40 to exclude this artifact when packaging the src folder for distribution.