### PR TITLE
Fix uninstantiated generic classes casting to themselves

### DIFF
--- a/spec/compiler/semantic/cast_spec.cr
+++ b/spec/compiler/semantic/cast_spec.cr
@@ -369,4 +369,19 @@ describe "Semantic: cast" do
       v
       )) { int32 }
   end
+
+  it "casts uninstantiated generic class to itself (#10882)" do
+    assert_type(%(
+      class Foo
+      end
+
+      class Bar(T) < Foo
+      end
+
+      x = Foo.new.as(Foo)
+      if x.is_a?(Bar)
+        x.as(Bar)
+      end
+      )) { nilable types["Bar"] }
+  end
 end

--- a/src/compiler/crystal/semantic/restrictions.cr
+++ b/src/compiler/crystal/semantic/restrictions.cr
@@ -367,6 +367,10 @@ module Crystal
       # `SomeGeneric` is never a restriction of `SomeGeneric(X)`
       false
     end
+
+    def restrict(other : GenericClassType, context)
+      self == other ? self : super
+    end
   end
 
   class GenericClassInstanceType


### PR DESCRIPTION
Fixes #10882.

This is a quick regression fix; intersections between two `Crystal::GenericClassType`s are obviously still non-commutative, and that part has to wait for #10781.