### PR TITLE
HTTP::Server Implement graceful shutdown with timeout

### DIFF
--- a/spec/std/http/server/server_spec.cr
+++ b/spec/std/http/server/server_spec.cr
@@ -436,6 +436,7 @@ describe HTTP::Server do
         client = HTTP::Client.new(address.address, address.port, client_context)
         client.read_timeout = client.connect_timeout = 3
         client.get("/").body.should eq "ok"
+        client.close
       ensure
         ch.send nil
       end


### PR DESCRIPTION
The `#close` documentation says it should be graceful.  This implements it.

Current problems:
* Concerns in #5957 upgraded connections are not addressed
* Limit of 2**32 - 1 active connections