### PR TITLE
fix using big rational `#**`with unsigned ints

### DIFF
--- a/spec/std/big/big_rational_spec.cr
+++ b/spec/std/big/big_rational_spec.cr
@@ -194,7 +194,7 @@ describe BigRational do
       result = br(17, 11) ** 5
       result.should be_a(BigRational)
       result.should eq(br(1419857, 161051))
-      
+
       result = br(17, 11) ** 5_u8
       result.should be_a(BigRational)
       result.should eq(br(1419857, 161051))

--- a/spec/std/big/big_rational_spec.cr
+++ b/spec/std/big/big_rational_spec.cr
@@ -194,6 +194,10 @@ describe BigRational do
       result = br(17, 11) ** 5
       result.should be_a(BigRational)
       result.should eq(br(1419857, 161051))
+      
+      result = br(17, 11) ** 5_u8
+      result.should be_a(BigRational)
+      result.should eq(br(1419857, 161051))
     end
 
     it "exponentiates with negative powers" do

--- a/src/big/big_rational.cr
+++ b/src/big/big_rational.cr
@@ -192,7 +192,7 @@ struct BigRational < Number
   end
 
   # :nodoc:
-  def **(other : UInt8 | UInt16 | UInt32 | UInt64 | UInt128) : BigRational
+  def **(other : Int::Unsigned) : BigRational
     BigRational.new(numerator ** other, denominator ** other)
   end
 

--- a/src/big/big_rational.cr
+++ b/src/big/big_rational.cr
@@ -191,6 +191,11 @@ struct BigRational < Number
     BigRational.new(numerator ** other, denominator ** other)
   end
 
+  # :nodoc:
+  def **(other : UInt8 | UInt16 | UInt32 | UInt64 | UInt128) : BigRational
+    BigRational.new(numerator ** other, denominator ** other)
+  end
+
   # Returns a new `BigRational` as 1/r.
   #
   # This will raise an exception if rational is 0.

--- a/src/big/big_rational.cr
+++ b/src/big/big_rational.cr
@@ -186,13 +186,8 @@ struct BigRational < Number
   # ```
   def **(other : Int) : BigRational
     if other < 0
-      return (self ** -other).inv
+      return (self ** other.abs).inv
     end
-    BigRational.new(numerator ** other, denominator ** other)
-  end
-
-  # :nodoc:
-  def **(other : Int::Unsigned) : BigRational
     BigRational.new(numerator ** other, denominator ** other)
   end
 


### PR DESCRIPTION
the compiler complains that `-other` is not possible when passing an unsigned value to the function
```
    if other < 0
      return (self ** -other).inv
    end
```