### PR TITLE
Add sorting methods to `StaticArray`

### DIFF
--- a/spec/std/static_array_spec.cr
+++ b/spec/std/static_array_spec.cr
@@ -183,6 +183,36 @@ describe "StaticArray" do
     b[0].should_not be(a[0])
   end
 
+  describe "#sort" do
+    it "sort without block" do
+      a = StaticArray[3, 4, 1, 2, 5, 6]
+      b = a.sort
+      b.should eq(StaticArray[1, 2, 3, 4, 5, 6])
+      a.should_not eq(b)
+    end
+
+    it "sort with a block" do
+      a = StaticArray["foo", "a", "hello"]
+      b = a.sort { |x, y| x.size <=> y.size }
+      b.should eq(StaticArray["a", "foo", "hello"])
+      a.should_not eq(b)
+    end
+  end
+
+  describe "#sort!" do
+    it "sort! without block" do
+      a = StaticArray[3, 4, 1, 2, 5, 6]
+      a.sort!
+      a.should eq(StaticArray[1, 2, 3, 4, 5, 6])
+    end
+
+    it "sort! with a block" do
+      a = StaticArray["foo", "a", "hello"]
+      a.sort! { |x, y| x.size <=> y.size }
+      a.should eq(StaticArray["a", "foo", "hello"])
+    end
+  end
+
   it_iterates "#each", [1, 2, 3], StaticArray[1, 2, 3].each
   it_iterates "#reverse_each", [3, 2, 1], StaticArray[1, 2, 3].reverse_each
   it_iterates "#each_index", [0, 1, 2], StaticArray[1, 2, 3].each_index

--- a/src/array.cr
+++ b/src/array.cr
@@ -1697,7 +1697,7 @@ class Array(T)
   end
 
   # Returns a new array with all elements sorted based on the return value of
-  # their comparison method `#<=>`
+  # their comparison method `#<=>`.
   #
   # ```
   # a = [3, 1, 2]
@@ -1731,7 +1731,7 @@ class Array(T)
   end
 
   # Modifies `self` by sorting all elements based on the return value of their
-  # comparison method `#<=>`
+  # comparison method `#<=>`.
   #
   # ```
   # a = [3, 1, 2]

--- a/src/slice.cr
+++ b/src/slice.cr
@@ -683,7 +683,7 @@ struct Slice(T)
   end
 
   # Returns a new slice with all elements sorted based on the return value of
-  # their comparison method `<=>`
+  # their comparison method `<=>`.
   #
   # ```
   # a = Slice[3, 1, 2]
@@ -717,7 +717,7 @@ struct Slice(T)
   end
 
   # Modifies `self` by sorting all elements based on the return value of their
-  # comparison method `<=>`
+  # comparison method `<=>`.
   #
   # ```
   # a = Slice[3, 1, 2]

--- a/src/static_array.cr
+++ b/src/static_array.cr
@@ -256,6 +256,79 @@ struct StaticArray(T, N)
     self
   end
 
+  # Returns a new `StaticArray` with all elements sorted based on the return
+  # value of their comparison method `<=>`.
+  #
+  # ```
+  # a = StaticArray[3, 1, 2]
+  # a.sort # => StaticArray[1, 2, 3]
+  # a      # => StaticArray[3, 1, 2]
+  # ```
+  def sort : StaticArray(T, N)
+    # the return value of `dup` must be assigned to a variable first, otherwise
+    # `self` will be mutated if the `sort!` call is chained directly
+    ary = dup
+    ary.sort!
+  end
+
+  # Returns a new `StaticArray` with all elements sorted based on the comparator
+  # in the given block.
+  #
+  # The block must implement a comparison between two elements *a* and *b*,
+  # where `a < b` returns `-1`, `a == b` returns `0`, and `a > b` returns `1`.
+  # The comparison operator `<=>` can be used for this.
+  #
+  # ```
+  # a = StaticArray[3, 1, 2]
+  # b = a.sort { |a, b| b <=> a }
+  #
+  # b # => StaticArray[3, 2, 1]
+  # a # => StaticArray[3, 1, 2]
+  # ```
+  def sort(&block : T, T -> U) : StaticArray(T, N) forall U
+    {% unless U <= Int32? %}
+      {% raise "expected block to return Int32 or Nil, not #{U}" %}
+    {% end %}
+
+    ary = dup
+    ary.sort! &block
+  end
+
+  # Modifies `self` by sorting all elements based on the return value of their
+  # comparison method `<=>`.
+  #
+  # ```
+  # a = StaticArray[3, 1, 2]
+  # a.sort!
+  # a # => StaticArray[1, 2, 3]
+  # ```
+  def sort! : self
+    to_slice.sort!
+    self
+  end
+
+  # Modifies `self` by sorting all elements based on the comparator in the given
+  # block.
+  #
+  # The given block must implement a comparison between two elements
+  # *a* and *b*, where `a < b` returns `-1`, `a == b` returns `0`,
+  # and `a > b` returns `1`.
+  # The comparison operator `<=>` can be used for this.
+  #
+  # ```
+  # a = StaticArray[3, 1, 2]
+  # a.sort! { |a, b| b <=> a }
+  # a # => StaticArray[3, 2, 1]
+  # ```
+  def sort!(&block : T, T -> U) : self forall U
+    {% unless U <= Int32? %}
+      {% raise "expected block to return Int32 or Nil, not #{U}" %}
+    {% end %}
+
+    to_slice.sort!(&block)
+    self
+  end
+
   # Returns a slice that points to the elements of this static array.
   # Changes made to the returned slice also affect this static array.
   #


### PR DESCRIPTION
Closes #6498.

These sorting methods simply forward to `to_slice`, so #10163 can be implemented on top of this easily.