### PR TITLE
Pass read-only flag to peeked slice in IO::Memory

### DIFF
--- a/spec/std/io/memory_spec.cr
+++ b/spec/std/io/memory_spec.cr
@@ -360,6 +360,16 @@ describe IO::Memory do
     io.peek.should eq(Bytes.empty)
   end
 
+  it "peek readonly" do
+    str = "hello world"
+    io = IO::Memory.new(str)
+
+    slice = io.peek
+    expect_raises(Exception) do
+      slice[0] = 0
+    end
+  end
+
   it "skips" do
     io = IO::Memory.new("hello")
     io.skip(2)

--- a/src/io/memory.cr
+++ b/src/io/memory.cr
@@ -188,7 +188,7 @@ class IO::Memory < IO
   def peek : Bytes
     check_open
 
-    Slice.new(@buffer + @pos, @bytesize - @pos)
+    Slice.new(@buffer + @pos, @bytesize - @pos, read_only: !@writeable)
   end
 
   # :nodoc:


### PR DESCRIPTION
Prevents potential segfaults or other unintended states caused by ignoring the read-protection of the inherited buffer in `IO::Memory`.

Reported by a user in Discord who was trying to re-use the buffer prior to `pos` as they were processing data from `peek`/`read`. Unsure how common this kind of scenario is (specifically with ROM), but this seems like a sensible change for safety's sake.

Unsure of the best way to organize the spec. Please feel free to move or change it.