### PR TITLE
Make `.as?(NoReturn)` always return `nil`

### DIFF
--- a/spec/compiler/semantic/nilable_cast_spec.cr
+++ b/spec/compiler/semantic/nilable_cast_spec.cr
@@ -19,6 +19,12 @@ describe "Semantic: nilable cast" do
       )) { nil_type }
   end
 
+  it "types as? with NoReturn" do
+    assert_type(%(
+      1.as?(NoReturn)
+      )) { nil_type }
+  end
+
   it "does upcast" do
     assert_type(%(
       class Foo

--- a/src/compiler/crystal/program.cr
+++ b/src/compiler/crystal/program.cr
@@ -327,9 +327,10 @@ module Crystal
     # Returns the `Type` for `type | Nil`
     def nilable(type)
       case type
-      when self.nil
-        # Nil | Nil # => Nil
-        return self.nil
+      when self.nil, self.no_return
+        # Nil | Nil      # => Nil
+        # NoReturn | Nil # => Nil
+        self.nil
       when UnionType
         types = Array(Type).new(type.union_types.size + 1)
         types.concat type.union_types


### PR DESCRIPTION
The irreducible union type `NoReturn | Nil` can leak through the expression `x.as?(NoReturn)`, but the same union should reduce to `Nil` because `NoReturn` is the bottom type. This PR fixes that.