### PR TITLE
Make `WARNING` an admonition keyword

### DIFF
--- a/src/compiler/crystal/tools/doc/generator.cr
+++ b/src/compiler/crystal/tools/doc/generator.cr
@@ -8,7 +8,7 @@ class Crystal::Doc::Generator
   FLAG_COLORS = {
     "BUG"          => "red",
     "DEPRECATED"   => "red",
-    "WARNING"      => "red",
+    "WARNING"      => "yellow",
     "EXPERIMENTAL" => "lime",
     "FIXME"        => "yellow",
     "NOTE"         => "purple",

--- a/src/compiler/crystal/tools/doc/generator.cr
+++ b/src/compiler/crystal/tools/doc/generator.cr
@@ -8,6 +8,7 @@ class Crystal::Doc::Generator
   FLAG_COLORS = {
     "BUG"          => "red",
     "DEPRECATED"   => "red",
+    "WARNING"      => "red",
     "EXPERIMENTAL" => "lime",
     "FIXME"        => "yellow",
     "NOTE"         => "purple",

--- a/src/crystal/digest/md5.cr
+++ b/src/crystal/digest/md5.cr
@@ -2,7 +2,7 @@ require "digest/digest"
 
 # Implements the MD5 digest algorithm.
 #
-# Warning: MD5 is no longer a cryptographically secure hash, and should not be
+# WARNING: MD5 is no longer a cryptographically secure hash, and should not be
 # used in security-related components, like password hashing. For passwords, see
 # `Crypto::Bcrypt::Password`. For a generic cryptographic hash, use SHA-256 via
 # `OpenSSL::Digest.new("SHA256")`.

--- a/src/crystal/digest/sha1.cr
+++ b/src/crystal/digest/sha1.cr
@@ -2,7 +2,7 @@ require "digest/digest"
 
 # Implements the SHA1 digest algorithm.
 #
-# Warning: SHA1 is no longer a cryptographically secure hash, and should not be
+# WARNING: SHA1 is no longer a cryptographically secure hash, and should not be
 # used in security-related components, like password hashing. For passwords, see
 # `Crypto::Bcrypt::Password`. For a generic cryptographic hash, use SHA-256 via
 # `OpenSSL::Digest.new("SHA256")`.

--- a/src/digest/md5.cr
+++ b/src/digest/md5.cr
@@ -3,7 +3,7 @@ require "openssl"
 
 # Implements the MD5 digest algorithm.
 #
-# Warning: MD5 is no longer a cryptographically secure hash, and should not be
+# WARNING: MD5 is no longer a cryptographically secure hash, and should not be
 # used in security-related components, like password hashing. For passwords, see
 # `Crypto::Bcrypt::Password`. For a generic cryptographic hash, use SHA-256 via
 # `Digest::SHA256`.

--- a/src/digest/sha1.cr
+++ b/src/digest/sha1.cr
@@ -3,7 +3,7 @@ require "openssl"
 
 # Implements the SHA1 digest algorithm.
 #
-# Warning: SHA1 is no longer a cryptographically secure hash, and should not be
+# WARNING: SHA1 is no longer a cryptographically secure hash, and should not be
 # used in security-related components, like password hashing. For passwords, see
 # `Crypto::Bcrypt::Password`. For a generic cryptographic hash, use SHA-256 via
 # `Digest::SHA256`.

--- a/src/openssl/md5.cr
+++ b/src/openssl/md5.cr
@@ -2,7 +2,7 @@ require "./lib_crypto"
 
 # Binds the OpenSSL MD5 hash functions.
 #
-# Warning: MD5 is no longer a cryptographically secure hash, and should not be
+# WARNING: MD5 is no longer a cryptographically secure hash, and should not be
 # used in security-related components, like password hashing. For passwords, see
 # `Crypto::Bcrypt::Password`. For a generic cryptographic hash, use SHA-256 via
 # `OpenSSL::Digest.new("SHA256")`.

--- a/src/openssl/sha1.cr
+++ b/src/openssl/sha1.cr
@@ -2,7 +2,7 @@ require "./lib_crypto"
 
 # Binds the OpenSSL SHA1 hash functions.
 #
-# Warning: SHA1 is no longer a cryptographically secure hash, and should not be
+# WARNING: SHA1 is no longer a cryptographically secure hash, and should not be
 # used in security-related components, like password hashing. For passwords, see
 # `Crypto::Bcrypt::Password`. For a generic cryptographic hash, use SHA-256 via
 # `OpenSSL::Digest.new("SHA256")`.


### PR DESCRIPTION
Resolves #10808.

Some `NOTE` admonitions in the standard library documentation can probably be promoted to warnings. This PR currently promotes none.