### PR TITLE
Fix variance checks between generic instances for `Proc#call` and abstract defs

### DIFF
--- a/spec/compiler/semantic/abstract_def_spec.cr
+++ b/spec/compiler/semantic/abstract_def_spec.cr
@@ -344,7 +344,7 @@ describe "Semantic: abstract def" do
   end
 
   it "doesn't error if implements with parent class" do
-    semantic %(
+    assert_no_errors %(
       class Parent; end
       class Child < Parent; end
 
@@ -359,8 +359,64 @@ describe "Semantic: abstract def" do
       )
   end
 
+  it "doesn't error if implements with generic parent class instance" do
+    assert_no_errors %(
+      class Parent(T); end
+      class Child(T) < Parent(T); end
+
+      abstract class Foo
+        abstract def foo(x : Child(Int32))
+      end
+
+      class Bar < Foo
+        def foo(x : Parent(Int32))
+        end
+      end
+      )
+  end
+
+  it "doesn't error if implements with included module" do
+    assert_no_errors %(
+      module Moo
+      end
+
+      module Moo2
+        include Moo
+      end
+
+      abstract class Foo
+        abstract def foo(x : Moo2)
+      end
+
+      class Bar < Foo
+        def foo(x : Moo)
+        end
+      end
+      )
+  end
+
+  it "doesn't error if implements with generic included module instance" do
+    assert_no_errors %(
+      module Moo(T)
+      end
+
+      module Moo2(T)
+        include Moo(T)
+      end
+
+      abstract class Foo
+        abstract def foo(x : Moo2(Int32))
+      end
+
+      class Bar < Foo
+        def foo(x : Moo(Int32))
+        end
+      end
+      )
+  end
+
   it "doesn't error if implements with parent module" do
-    semantic %(
+    assert_no_errors %(
       module Moo
       end
 

--- a/spec/compiler/semantic/proc_spec.cr
+++ b/spec/compiler/semantic/proc_spec.cr
@@ -656,7 +656,7 @@ describe "Semantic: proc" do
       "no overload matches"
   end
 
-  it "allows invoking a function with a generic subtype" do
+  it "allows invoking a function with a generic subtype (1)" do
     assert_type(%(
       module Moo
         def foo
@@ -669,6 +669,28 @@ describe "Semantic: proc" do
       end
 
       def func(&block : Moo -> _)
+        block
+      end
+
+      foo = Foo(Int32).new
+      f = func { |moo| moo.foo }
+      f.call foo
+      )) { int32 }
+  end
+
+  it "allows invoking a function with a generic subtype (2)" do
+    assert_type(%(
+      module Moo(T)
+        def foo
+          1
+        end
+      end
+
+      class Foo(T)
+        include Moo(T)
+      end
+
+      def func(&block : Moo(Int32) -> _)
         block
       end
 


### PR DESCRIPTION
Follow-up to #10507. This simply adds the newly discovered specs in https://github.com/crystal-lang/crystal/pull/10507#issuecomment-875666816.