### PR TITLE
Fix path lookup when ancestor finds type with same name as current scope

### DIFF
--- a/spec/compiler/semantic/const_spec.cr
+++ b/spec/compiler/semantic/const_spec.cr
@@ -33,6 +33,18 @@ describe "Semantic: const" do
       )) { int32 }
   end
 
+  it "types a nested type with same name" do
+    assert_type(%(
+      class Foo
+        class Foo
+          A = 1
+        end
+      end
+
+      Foo::Foo::A
+      )) { int32 }
+  end
+
   it "creates container module if not exist when using Path" do
     assert_type(%(
       Foo::Bar = 1
@@ -128,6 +140,58 @@ describe "Semantic: const" do
 
       Foo::Bar.foo
       ") { int32 }
+  end
+
+  it "finds current type before parents (#4086)" do
+    assert_type(%(
+      class Foo
+        class Bar
+          class Baz < Foo
+            def self.foo
+              Baz.new.foo
+            end
+
+            def foo
+              1
+            end
+          end
+        end
+
+        class Baz
+        end
+      end
+
+      Foo::Bar::Baz.foo
+      )) { int32 }
+  end
+
+  it "finds current type only for first path item (1)" do
+    assert_error %(
+      class Foo
+        def self.foo
+          Foo::Foo
+        end
+      end
+
+      Foo.foo
+      ),
+      "undefined constant Foo::Foo"
+  end
+
+  it "finds current type only for first path item (2)" do
+    assert_error %(
+      class Foo
+        class Foo
+        end
+
+        def self.foo
+          Foo::Foo
+        end
+      end
+
+      Foo.foo
+      ),
+      "undefined constant Foo::Foo"
   end
 
   it "types a global constant reference in method" do

--- a/spec/compiler/semantic/const_spec.cr
+++ b/spec/compiler/semantic/const_spec.cr
@@ -165,6 +165,29 @@ describe "Semantic: const" do
       )) { int32 }
   end
 
+  it "doesn't count parent types as current type" do
+    assert_type(%(
+      class Foo
+      end
+
+      class Bar
+        class Foo
+          def foo
+            1
+          end
+        end
+
+        class Baz < Foo
+          def self.bar
+            Foo.new
+          end
+        end
+      end
+
+      Bar::Baz.bar.foo
+      )) { int32 }
+  end
+
   it "finds current type only for first path item (1)" do
     assert_error %(
       class Foo

--- a/spec/compiler/semantic/new_spec.cr
+++ b/spec/compiler/semantic/new_spec.cr
@@ -225,7 +225,7 @@ describe "Semantic: new" do
       "wrong number of arguments for 'Bar.new' (given 0, expected 1)"
   end
 
-  it "uses correct receiver for `initialize` in namespaced classes (#4086)" do
+  it "uses correct receiver for `initialize` in namespaced generic classes (#4086)" do
     assert_type %(
       class Foo
         class Baz(T)

--- a/spec/compiler/semantic/new_spec.cr
+++ b/spec/compiler/semantic/new_spec.cr
@@ -224,4 +224,26 @@ describe "Semantic: new" do
       ),
       "wrong number of arguments for 'Bar.new' (given 0, expected 1)"
   end
+
+  it "uses correct receiver for `initialize` in namespaced classes (#4086)" do
+    assert_type %(
+      class Foo
+        class Baz(T)
+        end
+
+        module Bar
+          class Baz(T) < Foo
+            def initialize(x)
+            end
+
+            def foo
+              'a'
+            end
+          end
+        end
+      end
+
+      Foo::Bar::Baz(Int32).new(1).foo
+      ) { char }
+  end
 end

--- a/src/compiler/crystal/semantic/path_lookup.cr
+++ b/src/compiler/crystal/semantic/path_lookup.cr
@@ -44,7 +44,7 @@ module Crystal
       names.each_with_index do |name, i|
         # The search must continue in the namespace only for the first path
         # item: for subsequent path items only the parents must be looked up
-        type = type.lookup_path_item(name, lookup_in_namespace: lookup_in_namespace && i == 0, include_private: i == 0 || include_private, location: location)
+        type = type.lookup_path_item(name, i == 0, lookup_in_namespace, include_private, location)
         return unless type
 
         # Stop if this is the last name
@@ -60,31 +60,38 @@ module Crystal
 
     # Looks up a single path item relative to *self`.
     #
-    # If *lookup_in_namespace* is `true`, if the type is not found
-    # in `self` or `self`'s parents, the path item is searched in this
+    # If *lookup_in_namespace* and *first_item* are `true`, if the type is not
+    # found in `self` or `self`'s parents, the path item is searched in this
     # type's namespace. This parameter is useful because when writing
     # `Foo::Bar::Baz`, `Foo` should be searched in enclosing namespaces,
     # but `Bar` and `Baz` not.
-    def lookup_path_item(name : String, lookup_in_namespace, include_private, location) : Type | ASTNode | Nil
+    def lookup_path_item(name : String, first_item, lookup_in_namespace, include_private, location) : Type | ASTNode | Nil
       # First search in our types
       type = types?.try &.[name]?
       if type
-        if type.private? && !include_private
+        if type.private? && !include_private && !first_item
           return nil
         end
 
         return type
       end
 
+      # Try ourself for the first path item, unless we are the top-level
+      if first_item && self != program
+        if self.is_a?(NamedType) && name == self.name
+          return self
+        end
+      end
+
       # Then try out parents, but don't search in our parents namespace
       parents.try &.each do |parent|
-        match = parent.lookup_path_item(name, lookup_in_namespace: false, include_private: include_private, location: location)
+        match = parent.lookup_path_item(name, first_item, false, include_private, location)
         return match if match
       end
 
       # Try our namespace, unless we are the top-level
-      if lookup_in_namespace && self != program
-        return namespace.lookup_path_item(name, lookup_in_namespace, include_private, location)
+      if lookup_in_namespace && first_item && self != program
+        return namespace.lookup_path_item(name, first_item, lookup_in_namespace, include_private, location)
       end
 
       nil
@@ -92,7 +99,7 @@ module Crystal
   end
 
   class Program
-    def lookup_path_item(name : String, lookup_in_namespace, include_private, location)
+    def lookup_path_item(name : String, first_item, lookup_in_namespace, include_private, location)
       # Check if there's a private type in location
       if location && (original_filename = location.original_filename) &&
          (file_module = file_module?(original_filename)) &&
@@ -105,7 +112,7 @@ module Crystal
   end
 
   module GenericType
-    def lookup_path_item(name : String, lookup_in_namespace, include_private, location)
+    def lookup_path_item(name : String, first_item, lookup_in_namespace, include_private, location)
       # If we are Foo(T) and somebody looks up the type T, we return `nil` because we don't
       # know what type T is, and we don't want to continue search in the namespace
       if type_vars.includes?(name)
@@ -116,7 +123,7 @@ module Crystal
   end
 
   class GenericInstanceType
-    def lookup_path_item(name : String, lookup_in_namespace, include_private, location)
+    def lookup_path_item(name : String, first_item, lookup_in_namespace, include_private, location)
       # Check if *name* is a type variable
       if type_var = type_vars[name]?
         if type_var.is_a?(Var)
@@ -125,26 +132,26 @@ module Crystal
           type_var
         end
       else
-        generic_type.lookup_path_item(name, lookup_in_namespace, include_private, location)
+        generic_type.lookup_path_item(name, first_item, lookup_in_namespace, include_private, location)
       end
     end
   end
 
   class UnionType
-    def lookup_path_item(name : String, lookup_in_namespace, include_private, location)
+    def lookup_path_item(name : String, first_item, lookup_in_namespace, include_private, location)
       # Union type does not currently inherit GenericClassInstanceType,
       # so we check if *name* is the only type variable of Union(*T)
       if name == "T"
         return program.tuple_of(union_types)
       end
-      program.lookup_path_item(name, lookup_in_namespace, include_private, location)
+      program.lookup_path_item(name, first_item, lookup_in_namespace, include_private, location)
     end
   end
 
   class AliasType
-    def lookup_path_item(name : String, lookup_in_namespace, include_private, location)
+    def lookup_path_item(name : String, first_item, lookup_in_namespace, include_private, location)
       if aliased_type = aliased_type?
-        aliased_type.lookup_path_item(name, lookup_in_namespace, include_private, location)
+        aliased_type.lookup_path_item(name, first_item, lookup_in_namespace, include_private, location)
       else
         super
       end

--- a/src/compiler/crystal/semantic/top_level_visitor.cr
+++ b/src/compiler/crystal/semantic/top_level_visitor.cr
@@ -1167,7 +1167,7 @@ class Crystal::TopLevelVisitor < Crystal::SemanticVisitor
     unless target_type
       next_type = base_type
       path.names.each do |name|
-        next_type = base_type.lookup_path_item(name, first_item: false, lookup_in_namespace: false, include_private: true, location: path.location)
+        next_type = base_type.lookup_path_item(name, lookup_self: false, lookup_in_namespace: false, include_private: true, location: path.location)
         if next_type
           if next_type.is_a?(ASTNode)
             path.raise "expected #{name} to be a type"

--- a/src/compiler/crystal/semantic/top_level_visitor.cr
+++ b/src/compiler/crystal/semantic/top_level_visitor.cr
@@ -1167,7 +1167,7 @@ class Crystal::TopLevelVisitor < Crystal::SemanticVisitor
     unless target_type
       next_type = base_type
       path.names.each do |name|
-        next_type = base_type.lookup_path_item(name, lookup_in_namespace: false, include_private: true, location: path.location)
+        next_type = base_type.lookup_path_item(name, first_item: false, lookup_in_namespace: false, include_private: true, location: path.location)
         if next_type
           if next_type.is_a?(ASTNode)
             path.raise "expected #{name} to be a type"


### PR DESCRIPTION
Fixes #4086.

```crystal
class Foo
  class Bar
    class Baz < Foo
      def self.foo
        # `Baz` is now tried in the following order:
        #
        # * `Baz` relative to `::Foo::Bar::Baz` (direct namespace child)
        # * `::Foo::Bar::Baz` (current scope)
        # * `Baz` relative to `::Foo` (ancestors)
        # * `Baz` relative to `::Foo::Bar` (enclosing namespace)
        #
        # this only applies to the first path item; subsequent items must
        # descend along namespaces so `Baz::Baz` is still undefined
        Baz
      end
    end
  end

  class Baz
  end
end

Foo::Bar::Baz.foo # => Foo::Bar::Baz
```

This behaviour is consistent with Ruby and C++.

The path lookup rules are unchanged if the path's first item and the current scope's last path item do not match.