### PR TITLE
Add block type restriction to `Iterator#each`

### DIFF
--- a/src/iterator.cr
+++ b/src/iterator.cr
@@ -590,7 +590,7 @@ module Iterator(T)
   # iter = ["a", "b", "c"].each
   # iter.each { |x| print x, " " } # Prints "a b c"
   # ```
-  def each : Nil
+  def each(& : T -> _) : Nil
     while true
       value = self.next
       break if value.is_a?(Stop)


### PR DESCRIPTION
`Iterator#each` implements `Enumerable#each`, but does not apply the same type restriction on the block argument. The compiler currently does not enforce that (see #10902). This change makes the implementation's signature match the abstract def's.

See https://github.com/crystal-lang/crystal/pull/10857#issuecomment-876323139 for details.

There are more implementations of `Enumerable#each` in stdlib which should get the same type restriction. But I encountered some issues with that, so it'll be deferred. `Iterator#each` seems to be fine though, at least with stdlib specs.