### PR TITLE
Fix `Call.def_full_name` print full block parameter

### DIFF
--- a/spec/compiler/semantic/abstract_def_spec.cr
+++ b/spec/compiler/semantic/abstract_def_spec.cr
@@ -695,6 +695,18 @@ describe "Semantic: abstract def" do
     ))
   end
 
+  it "error shows full signature of block parameter" do
+    assert_error(<<-CR, "abstract `def Moo#each(& : (Int32 -> _))` must be implemented by Foo")
+      module Moo
+        abstract def each(& : Int32 -> _)
+      end
+
+      class Foo
+        include Moo
+      end
+      CR
+  end
+
   it "doesn't error if implementation have default value" do
     semantic %(
       abstract class Foo

--- a/src/compiler/crystal/semantic/call_error.cr
+++ b/src/compiler/crystal/semantic/call_error.cr
@@ -497,12 +497,12 @@ class Crystal::Call
       printed = true
     end
 
-    if block_arg = a_def.block_arg
+    if a_def.yields
       str << ", " if printed
-      str << '&' << block_arg.name
-    elsif a_def.yields
-      str << ", " if printed
-      str << "&block"
+      str << '&'
+      if block_arg = a_def.block_arg
+        str << block_arg
+      end
     end
     str << ')'
 


### PR DESCRIPTION
`Call.def_full_name` prints the signature of a method. It's used in error messages about undefined methods and missing / incorrect implementation of abstract defs. The method did not show the type restriction of a block parameter, while all other parameter's type restrictions are shown. This patch makes sure to print block parameters with type restriction.