### PR TITLE
Fix yielding block return type restriction underscore

### DIFF
--- a/src/array.cr
+++ b/src/array.cr
@@ -1775,7 +1775,7 @@ class Array(T)
   # b # => ["fig", "pear", "apple"]
   # a # => ["apple", "pear", "fig"]
   # ```
-  def sort_by(&block : T -> _) : Array(T)
+  def sort_by(&block : T ->) : Array(T)
     dup.sort_by! { |e| yield(e) }
   end
 
@@ -1788,7 +1788,7 @@ class Array(T)
   # a.sort_by! { |word| word.size }
   # a # => ["fig", "pear", "apple"]
   # ```
-  def sort_by!(&block : T -> _) : Array(T)
+  def sort_by!(&block : T ->) : Array(T)
     sorted = map { |e| {e, yield(e)} }.sort! { |x, y| x[1] <=> y[1] }
     @size.times do |i|
       @buffer[i] = sorted.to_unsafe[i][0]
@@ -1949,7 +1949,7 @@ class Array(T)
   # a.uniq { |s| s[0] } # => [{"student", "sam"}, {"teacher", "matz"}]
   # a                   # => [{"student", "sam"}, {"student", "george"}, {"teacher", "matz"}]
   # ```
-  def uniq(&block : T -> _)
+  def uniq(&block : T ->)
     if size <= 1
       dup
     else

--- a/src/digest/digest.cr
+++ b/src/digest/digest.cr
@@ -102,7 +102,7 @@ abstract class Digest
     # end
     # # => "C+7Hteo/D9vJXQ3UfzxbwnXaijM="
     # ```
-    def base64digest(& : self -> _) : String
+    def base64digest(& : self ->) : String
       hashsum = digest do |ctx|
         yield ctx
       end

--- a/src/dir/glob.cr
+++ b/src/dir/glob.cr
@@ -40,14 +40,14 @@ class Dir
   # If *match_hidden* is `true` the pattern will match hidden files and folders.
   #
   # NOTE: Path separator in patterns needs to be always `/`. The returned file names use system-specific path separators.
-  def self.glob(*patterns : Path | String, match_hidden = false, follow_symlinks = false, &block : String -> _)
+  def self.glob(*patterns : Path | String, match_hidden = false, follow_symlinks = false, &block : String ->)
     glob(patterns, match_hidden: match_hidden, follow_symlinks: follow_symlinks) do |path|
       yield path
     end
   end
 
   # :ditto:
-  def self.glob(patterns : Enumerable, match_hidden = false, follow_symlinks = false, &block : String -> _)
+  def self.glob(patterns : Enumerable, match_hidden = false, follow_symlinks = false, &block : String ->)
     Globber.glob(patterns, match_hidden: match_hidden, follow_symlinks: follow_symlinks) do |path|
       yield path
     end
@@ -72,7 +72,7 @@ class Dir
     end
     alias PatternType = DirectoriesOnly | ConstantEntry | EntryMatch | RecursiveDirectories | ConstantDirectory | RootDirectory | DirectoryMatch
 
-    def self.glob(patterns : Enumerable, *, match_hidden, follow_symlinks, &block : String -> _)
+    def self.glob(patterns : Enumerable, *, match_hidden, follow_symlinks, &block : String ->)
       patterns.each do |pattern|
         if pattern.is_a?(Path)
           pattern = pattern.to_posix.to_s
@@ -147,7 +147,7 @@ class Dir
       true
     end
 
-    private def self.run(sequence, match_hidden, follow_symlinks, &block : String -> _)
+    private def self.run(sequence, match_hidden, follow_symlinks, &block : String ->)
       return if sequence.empty?
 
       path_stack = [] of Tuple(Int32, String?, Crystal::System::Dir::Entry?)

--- a/src/iterator.cr
+++ b/src/iterator.cr
@@ -590,7 +590,7 @@ module Iterator(T)
   # iter = ["a", "b", "c"].each
   # iter.each { |x| print x, " " } # Prints "a b c"
   # ```
-  def each(& : T -> _) : Nil
+  def each(& : T ->) : Nil
     while true
       value = self.next
       break if value.is_a?(Stop)

--- a/src/json/pull_parser.cr
+++ b/src/json/pull_parser.cr
@@ -351,7 +351,7 @@ class JSON::PullParser
   # All the other object keys are skipped.
   #
   # Returns the return value of the block or `Nil` if the key was not read.
-  def on_key(key, & : self -> _)
+  def on_key(key, & : self ->)
     result = nil
     read_object do |some_key|
       if some_key == key
@@ -368,7 +368,7 @@ class JSON::PullParser
   # All the other object keys are skipped.
   #
   # Returns the return value of the block.
-  def on_key!(key, & : self -> _)
+  def on_key!(key, & : self ->)
     found = false
     value = uninitialized typeof(yield self)
 

--- a/src/mime/media_type.cr
+++ b/src/mime/media_type.cr
@@ -89,12 +89,12 @@ module MIME
     # MIME::MediaType.parse("x-application/example").fetch("foo") { |key| key }          # => "foo"
     # MIME::MediaType.parse("x-application/example; foo=bar").fetch("foo") { |key| key } # => "bar"
     # ```
-    def fetch(key : String, &block : String -> _)
+    def fetch(key : String, &block : String ->)
       @params.fetch(key) { |key| yield key }
     end
 
     # Calls the given block for each parameter and passes in the key and the value.
-    def each_parameter(&block : String, String -> _) : Nil
+    def each_parameter(&block : String, String ->) : Nil
       @params.each do |key, value|
         yield key, value
       end

--- a/src/slice.cr
+++ b/src/slice.cr
@@ -761,7 +761,7 @@ struct Slice(T)
   # b # => Slice["fig", "pear", "apple"]
   # a # => Slice["apple", "pear", "fig"]
   # ```
-  def sort_by(&block : T -> _) : Slice(T)
+  def sort_by(&block : T ->) : Slice(T)
     dup.sort_by! { |e| yield(e) }
   end
 
@@ -774,7 +774,7 @@ struct Slice(T)
   # a.sort_by! { |word| word.size }
   # a # => Slice["fig", "pear", "apple"]
   # ```
-  def sort_by!(&block : T -> _) : Slice(T)
+  def sort_by!(&block : T ->) : Slice(T)
     sorted = map { |e| {e, yield(e)} }.sort! { |x, y| x[1] <=> y[1] }
     size.times do |i|
       to_unsafe[i] = sorted.to_unsafe[i][0]

--- a/src/string.cr
+++ b/src/string.cr
@@ -1792,7 +1792,7 @@ class String
   # ```
   # "bcadefcba".strip { |c| 'a' <= c <= 'c' } # => "def"
   # ```
-  def strip(&block : Char -> _)
+  def strip(&block : Char ->)
     return self if empty?
 
     excess_left = calc_excess_left { |c| yield c }
@@ -1851,7 +1851,7 @@ class String
   # ```
   # "bcadefcba".rstrip { |c| 'a' <= c <= 'c' } # => "bcadef"
   # ```
-  def rstrip(&block : Char -> _)
+  def rstrip(&block : Char ->)
     return self if empty?
 
     excess_right = calc_excess_right { |c| yield c }
@@ -1905,7 +1905,7 @@ class String
   # ```
   # "bcadefcba".lstrip { |c| 'a' <= c <= 'c' } # => "defcba"
   # ```
-  def lstrip(&block : Char -> _)
+  def lstrip(&block : Char ->)
     return self if empty?
 
     excess_left = calc_excess_left { |c| yield c }
@@ -2076,7 +2076,7 @@ class String
   # "hello".sub { |char| char + 1 } # => "iello"
   # "hello".sub { "hi" }            # => "hiello"
   # ```
-  def sub(&block : Char -> _)
+  def sub(&block : Char ->)
     return self if empty?
 
     String.build(bytesize) do |buffer|
@@ -2429,7 +2429,7 @@ class String
   # "hello".gsub { |char| char + 1 } # => "ifmmp"
   # "hello".gsub { "hi" }            # => "hihihihihi"
   # ```
-  def gsub(&block : Char -> _)
+  def gsub(&block : Char ->)
     String.build(bytesize) do |buffer|
       each_char do |my_char|
         buffer << yield my_char
@@ -3498,7 +3498,7 @@ class String
   # old_pond.split(3) { |s| ary << s }
   # ary # => ["Old", "pond", "a frog leaps in\n  water's sound\n"]
   # ```
-  def split(limit : Int32? = nil, &block : String -> _)
+  def split(limit : Int32? = nil, &block : String ->)
     if limit && limit <= 1
       yield self
       return
@@ -3630,7 +3630,7 @@ class String
   # "foo,bar,baz".split(',', 2) { |string| ary << string }
   # ary # => ["foo", "bar,baz"]
   # ```
-  def split(separator : Char, limit = nil, *, remove_empty = false, &block : String -> _)
+  def split(separator : Char, limit = nil, *, remove_empty = false, &block : String ->)
     if empty?
       yield "" unless remove_empty
       return
@@ -3712,7 +3712,7 @@ class String
   # long_river_name.split("") { |s| ary << s }
   # ary # => ["M", "i", "s", "s", "i", "s", "s", "i", "p", "p", "i"]
   # ```
-  def split(separator : String, limit = nil, *, remove_empty = false, &block : String -> _)
+  def split(separator : String, limit = nil, *, remove_empty = false, &block : String ->)
     if empty?
       yield "" unless remove_empty
       return
@@ -3801,7 +3801,7 @@ class String
   # long_river_name.split(/s+/) # => ["Mi", "i", "ippi"]
   # long_river_name.split(//)   # => ["M", "i", "s", "s", "i", "s", "s", "i", "p", "p", "i"]
   # ```
-  def split(separator : Regex, limit = nil, *, remove_empty = false, &block : String -> _)
+  def split(separator : Regex, limit = nil, *, remove_empty = false, &block : String ->)
     if empty?
       yield "" unless remove_empty
       return
@@ -3851,7 +3851,7 @@ class String
     yield byte_slice(slice_offset) unless remove_empty && slice_offset == bytesize
   end
 
-  private def split_by_empty_separator(limit, &block : String -> _)
+  private def split_by_empty_separator(limit, &block : String ->)
     yielded = 0
 
     each_char do |c|


### PR DESCRIPTION
There's an unintended subtle difference for yielding blocks and underscore return value.
See https://github.com/crystal-lang/crystal/pull/10467#discussion_r586517659

This patch replaces all underscore return types in yielding block parameters to avoid potential issues with that. This is essentially a workaround for wanky compiler behaviour.

Related to #10928