### PR TITLE
Adjust docs for `Crystal::Macros::HashLiteral#[]`

### DIFF
--- a/src/compiler/crystal/macros.cr
+++ b/src/compiler/crystal/macros.cr
@@ -755,7 +755,7 @@ module Crystal::Macros
     def map : ArrayLiteral
     end
 
-    # Similar to `Hash#[]`
+    # Similar to `Hash#[]?`
     def [](key : ASTNode) : ASTNode
     end
 


### PR DESCRIPTION
`HashLiteral#[]` returns `Nil` in case an entry isn't found. It does not
raise a compile time exception.

https://github.com/crystal-lang/crystal/blob/12f71b070377c5179bdde30818dd1673a3c2ee2d/src/compiler/crystal/macros/methods.cr#L906-L914