### PR TITLE
Allow underscore in block return type even if the type can't be computed

### DIFF
--- a/spec/compiler/semantic/block_spec.cr
+++ b/spec/compiler/semantic/block_spec.cr
@@ -1475,4 +1475,20 @@ describe "Block inference" do
       end
       )) { tuple_of([int32, int32]) }
   end
+
+  it "allows underscore in block return type even if the return type can't be computed" do
+    semantic(%(
+      def foo(& : -> _)
+        yield
+      end
+
+      def recursive
+        if true
+          foo { recursive }
+        end
+      end
+
+      recursive
+      ))
+  end
 end

--- a/src/compiler/crystal/semantic/call.cr
+++ b/src/compiler/crystal/semantic/call.cr
@@ -948,7 +948,8 @@ class Crystal::Call
 
       # Similar to above: we check that the block's type matches the block arg specification,
       # and we delay it if possible.
-      if output
+      # If the return type is an underscore, we just ignore any return type checking.
+      if output && !output.is_a?(Underscore)
         if !block.type?
           if !match.def.free_var?(output) && output.is_a?(ASTNode) && !output.is_a?(Underscore)
             begin
@@ -983,8 +984,9 @@ class Crystal::Call
               end
             end
           end
+
+          block.freeze_type = block_type
         end
-        block.freeze_type = block_type
       end
     end
 


### PR DESCRIPTION
Fixes #10932

Alternative to #10929