### PR TITLE
Fix `ProcNotation#to_s` remove whitespace for nil output type

### DIFF
--- a/spec/compiler/parser/to_s_spec.cr
+++ b/spec/compiler/parser/to_s_spec.cr
@@ -92,6 +92,7 @@ describe "ASTNode#to_s" do
   expect_to_s "def foo(x, **args)\nend"
   expect_to_s "def foo(x, **args, &block)\nend"
   expect_to_s "def foo(x, **args, &block : (_ -> _))\nend"
+  expect_to_s "def foo(& : (->))\nend"
   expect_to_s "macro foo(**args)\nend"
   expect_to_s "macro foo(x, **args)\nend"
   expect_to_s "def foo(x y)\nend"

--- a/src/compiler/crystal/syntax/to_s.cr
+++ b/src/compiler/crystal/syntax/to_s.cr
@@ -848,8 +848,9 @@ module Crystal
         inputs.join(@str, ", ", &.accept self)
         @str << ' '
       end
-      @str << "-> "
+      @str << "->"
       if output = node.output
+        @str << ' '
         output.accept self
       end
       @str << ')'


### PR DESCRIPTION
When a block parameter type restriction's output type is `Nil`, it prints as an empty output type (`(->)`). The formatter removes trailing whitespace in that case, while the `ToSVisitor` always adds whitespace. Thus there are two different formatting `-> ` and `->`.
This patch adjust the `ToSVisitor` to only add whitespace when the output type is not nil.

Changing the formatter to always add whitespace would equally be possible.