### PR TITLE
Refactor block type restriction underscore output to nil

### DIFF
--- a/src/digest/digest.cr
+++ b/src/digest/digest.cr
@@ -102,7 +102,7 @@ abstract class Digest
     # end
     # # => "C+7Hteo/D9vJXQ3UfzxbwnXaijM="
     # ```
-    def base64digest(& : self -> _) : String
+    def base64digest(& : self ->) : String
       hashsum = digest do |ctx|
         yield ctx
       end

--- a/src/dir/glob.cr
+++ b/src/dir/glob.cr
@@ -40,14 +40,14 @@ class Dir
   # If *match_hidden* is `true` the pattern will match hidden files and folders.
   #
   # NOTE: Path separator in patterns needs to be always `/`. The returned file names use system-specific path separators.
-  def self.glob(*patterns : Path | String, match_hidden = false, follow_symlinks = false, &block : String -> _)
+  def self.glob(*patterns : Path | String, match_hidden = false, follow_symlinks = false, &block : String ->)
     glob(patterns, match_hidden: match_hidden, follow_symlinks: follow_symlinks) do |path|
       yield path
     end
   end
 
   # :ditto:
-  def self.glob(patterns : Enumerable, match_hidden = false, follow_symlinks = false, &block : String -> _)
+  def self.glob(patterns : Enumerable, match_hidden = false, follow_symlinks = false, &block : String ->)
     Globber.glob(patterns, match_hidden: match_hidden, follow_symlinks: follow_symlinks) do |path|
       yield path
     end
@@ -72,7 +72,7 @@ class Dir
     end
     alias PatternType = DirectoriesOnly | ConstantEntry | EntryMatch | RecursiveDirectories | ConstantDirectory | RootDirectory | DirectoryMatch
 
-    def self.glob(patterns : Enumerable, *, match_hidden, follow_symlinks, &block : String -> _)
+    def self.glob(patterns : Enumerable, *, match_hidden, follow_symlinks, &block : String ->)
       patterns.each do |pattern|
         if pattern.is_a?(Path)
           pattern = pattern.to_posix.to_s
@@ -147,7 +147,7 @@ class Dir
       true
     end
 
-    private def self.run(sequence, match_hidden, follow_symlinks, &block : String -> _)
+    private def self.run(sequence, match_hidden, follow_symlinks, &block : String ->)
       return if sequence.empty?
 
       path_stack = [] of Tuple(Int32, String?, Crystal::System::Dir::Entry?)

--- a/src/iterator.cr
+++ b/src/iterator.cr
@@ -590,7 +590,7 @@ module Iterator(T)
   # iter = ["a", "b", "c"].each
   # iter.each { |x| print x, " " } # Prints "a b c"
   # ```
-  def each(& : T -> _) : Nil
+  def each(& : T ->) : Nil
     while true
       value = self.next
       break if value.is_a?(Stop)

--- a/src/mime/media_type.cr
+++ b/src/mime/media_type.cr
@@ -94,7 +94,7 @@ module MIME
     end
 
     # Calls the given block for each parameter and passes in the key and the value.
-    def each_parameter(&block : String, String -> _) : Nil
+    def each_parameter(&block : String, String ->) : Nil
       @params.each do |key, value|
         yield key, value
       end

--- a/src/string.cr
+++ b/src/string.cr
@@ -3498,7 +3498,7 @@ class String
   # old_pond.split(3) { |s| ary << s }
   # ary # => ["Old", "pond", "a frog leaps in\n  water's sound\n"]
   # ```
-  def split(limit : Int32? = nil, &block : String -> _)
+  def split(limit : Int32? = nil, &block : String ->)
     if limit && limit <= 1
       yield self
       return
@@ -3630,7 +3630,7 @@ class String
   # "foo,bar,baz".split(',', 2) { |string| ary << string }
   # ary # => ["foo", "bar,baz"]
   # ```
-  def split(separator : Char, limit = nil, *, remove_empty = false, &block : String -> _)
+  def split(separator : Char, limit = nil, *, remove_empty = false, &block : String ->)
     if empty?
       yield "" unless remove_empty
       return
@@ -3712,7 +3712,7 @@ class String
   # long_river_name.split("") { |s| ary << s }
   # ary # => ["M", "i", "s", "s", "i", "s", "s", "i", "p", "p", "i"]
   # ```
-  def split(separator : String, limit = nil, *, remove_empty = false, &block : String -> _)
+  def split(separator : String, limit = nil, *, remove_empty = false, &block : String ->)
     if empty?
       yield "" unless remove_empty
       return
@@ -3801,7 +3801,7 @@ class String
   # long_river_name.split(/s+/) # => ["Mi", "i", "ippi"]
   # long_river_name.split(//)   # => ["M", "i", "s", "s", "i", "s", "s", "i", "p", "p", "i"]
   # ```
-  def split(separator : Regex, limit = nil, *, remove_empty = false, &block : String -> _)
+  def split(separator : Regex, limit = nil, *, remove_empty = false, &block : String ->)
     if empty?
       yield "" unless remove_empty
       return
@@ -3851,7 +3851,7 @@ class String
     yield byte_slice(slice_offset) unless remove_empty && slice_offset == bytesize
   end
 
-  private def split_by_empty_separator(limit, &block : String -> _)
+  private def split_by_empty_separator(limit, &block : String ->)
     yielded = 0
 
     each_char do |c|


### PR DESCRIPTION
This patch replaces underscore output types in block restrictions with nil (empty) for methods where the result of the yielded block is irrelevant and unused. Underscore should be used where the result type is not specified but the value is actually used.

See #10931

This had previously been a part of #10929