### PR TITLE
Construct an array literal in `NamedTuple#map`

### DIFF
--- a/src/named_tuple.cr
+++ b/src/named_tuple.cr
@@ -481,11 +481,15 @@ struct NamedTuple
   # tuple.map { |k, v| "#{k}: #{v}" } # => ["name: Crystal", "year: 2011"]
   # ```
   def map
-    array = Array(typeof(yield first_key_internal, first_value_internal)).new(size)
-    each do |k, v|
-      array.push yield k, v
-    end
-    array
+    {% if T.size == 0 %}
+      [] of NoReturn
+    {% else %}
+      [
+        {% for key in T %}
+          (yield {{ key.symbolize }}, self[{{ key.symbolize }}]),
+        {% end %}
+      ]
+    {% end %}
   end
 
   # Returns a new `Array` of tuples populated with each key-value pair.


### PR DESCRIPTION
Following some changes made in #10942, I wondered how `NamedTuple#map` would perform if it constructed a literal instead of pushing into an array. 

```crystal
require "benchmark"

struct NamedTuple
  def literal_map
    {% if T.size == 0 %}
      [] of NoReturn
    {% else %}
      [
        {% for key in T %}
          (yield {{ key.symbolize }}, self[{{ key.symbolize }}]),
        {% end %}
      ]
    {% end %}
  end
end

test = {
  a: 1,
  b: "1",
  c: Time.unix(1),
  d: [1],
}

Benchmark.ips do |x|
  x.report("literal") { test.literal_map { |k, v| v } }
  x.report("each") { test.map { |k, v| v } }
end
```

```shell-session
literal  15.56M ( 64.25ns) (± 8.66%)  176B/op        fastest
   each  12.86M ( 77.79ns) (± 8.61%)  176B/op   1.21× slower
```

It looks to be a bit quicker, so here's a PR with the change 🙂