### PR TITLE
Don't emit debug info for unused variable declarations

### DIFF
--- a/spec/compiler/codegen/debug_spec.cr
+++ b/spec/compiler/codegen/debug_spec.cr
@@ -171,6 +171,12 @@ describe "Code gen: debug" do
       ), debug: Crystal::Debug::All)
   end
 
+  it "doesn't emit debug info for unused variable declarations (#9882)" do
+    codegen(%(
+      x : Int32
+      ), debug: Crystal::Debug::All)
+  end
+
   it "stores and restores debug location after jumping to main (#6920)" do
     codegen(%(
       require "prelude"

--- a/src/compiler/crystal/codegen/debug.cr
+++ b/src/compiler/crystal/codegen/debug.cr
@@ -351,7 +351,9 @@ module Crystal
       return if @debug.none?
       in_alloca_block do
         vars.each do |name, var|
-          llvm_var = context.vars[name]
+          # If a variable is deduced to have type `NoReturn` it might not be
+          # allocated at all
+          next unless (llvm_var = context.vars[name]?)
           next if llvm_var.debug_variable_created
           set_current_debug_location var.location
           declare_variable name, var.type, llvm_var.pointer, var.location, alloca_block


### PR DESCRIPTION
Fixes #6919. Fixes #9882.

More specifically, given:

```crystal
x : Int32
```

Its type is deduced to be `NoReturn` after semantic analysis is completed, because it is never used; conversely, if any variable is `NoReturn`, then no assignments to it are possible, so it must also be unused, e.g.:

```crystal
x = uninitialized NoReturn
x = raise "" # CleanupTransformer discards the assignment and retains only the raise
```

`NoReturn` variables never allocate stack space during code generation. Thus `NoReturn` or unused variables in a semantic context will not appear in its corresponding codegen context. This PR makes sure to ignore those variables.