### PR TITLE
Fix missing required args for `Socket::Addrinfo::Error.new`

### DIFF
--- a/spec/std/socket/addrinfo_spec.cr
+++ b/spec/std/socket/addrinfo_spec.cr
@@ -72,4 +72,12 @@ describe Socket::Addrinfo do
     addrinfos = Socket::Addrinfo.udp("127.0.0.1", 12345)
     addrinfos.first.inspect.should eq "Socket::Addrinfo(127.0.0.1:12345, INET, DGRAM, UDP)"
   end
+
+  describe "Error" do
+    it ".new" do
+      error = Socket::Addrinfo::Error.new(LibC::EAI_NONAME, "No address found", "foobar.com")
+      error.os_error.should eq Errno.new(LibC::EAI_NONAME)
+      error.message.not_nil!.should eq "Hostname lookup for foobar.com failed: No address found"
+    end
+  end
 end

--- a/src/socket/addrinfo.cr
+++ b/src/socket/addrinfo.cr
@@ -88,7 +88,7 @@ class Socket
 
       @[Deprecated("Use `.from_os_error` instead")]
       def self.new(error_code : Int32, message, domain)
-        from_os_error(message, Errno.new(error_code), domain: domain)
+        from_os_error(message, Errno.new(error_code), domain: domain, type: nil, service: nil, protocol: nil)
       end
 
       @[Deprecated("Use `.from_os_error` instead")]


### PR DESCRIPTION
Resolves #10958

Fixes a regression introduced in #10761