### PR TITLE
Fix: documentation of `#step` in `Number` and `Char`

### DIFF
--- a/src/char.cr
+++ b/src/char.cr
@@ -122,6 +122,12 @@ struct Char
     self - other
   end
 
+  # Performs a `#step` in the direction of the _limit_. For instance:
+  #
+  # ```
+  # 'd'.step(to: 'a').to_a  # => ['d', 'c', 'b', 'a']
+  # 'a'.step(to: 'd').to_a  # => ['a', 'b', 'c', 'd']
+  # ```
   def step(*, to limit = nil, exclusive : Bool = false, &)
     if limit
       direction = limit <=> self
@@ -133,6 +139,7 @@ struct Char
     end
   end
 
+  # :ditto:
   def step(*, to limit = nil, exclusive : Bool = false)
     if limit
       direction = limit <=> self

--- a/src/number.cr
+++ b/src/number.cr
@@ -118,7 +118,12 @@ struct Number
     %array
   end
 
-  # :ditto:
+  # Performs a `#step` in the direction of the _limit_. For instance:
+  #
+  # ```
+  # 10.step(to: 5).to_a # => [10, 9, 8, 7, 6, 5]
+  # 5.step(to: 10).to_a # => [5, 6, 7, 8, 9, 10]
+  # ```
   def step(*, to limit = nil, exclusive : Bool = false, &) : Nil
     if limit
       direction = limit <=> self


### PR DESCRIPTION
As mentioned in [a comment](https://github.com/crystal-lang/crystal/pull/10279#issuecomment-882818672), the documentation got wrong `:ditto` for the step methods in `Number`. Here not only that is fixed, but also the documentation is improved and extended to `Char`.