### PR TITLE
Fix disable unnecessary spec on win32

### DIFF
--- a/spec/std/socket/addrinfo_spec.cr
+++ b/spec/std/socket/addrinfo_spec.cr
@@ -74,10 +74,13 @@ describe Socket::Addrinfo do
   end
 
   describe "Error" do
-    it ".new" do
-      error = Socket::Addrinfo::Error.new(LibC::EAI_NONAME, "No address found", "foobar.com")
-      error.os_error.should eq Errno.new(LibC::EAI_NONAME)
-      error.message.not_nil!.should eq "Hostname lookup for foobar.com failed: No address found"
-    end
+    {% unless flag?(:win32) %}
+      # This method is not available on windows because windows support was introduced after deprecation.
+      it ".new (deprecated)" do
+        error = Socket::Addrinfo::Error.new(LibC::EAI_NONAME, "No address found", "foobar.com")
+        error.os_error.should eq Errno.new(LibC::EAI_NONAME)
+        error.message.not_nil!.should eq "Hostname lookup for foobar.com failed: No address found"
+      end
+    {% end %}
   end
 end


### PR DESCRIPTION
Disables a spec introduced in #10960 to verify the behaviour of a deprecated method. That method doesn't work in win32 anyways and win32 support was added after it was deprecated.