### PR TITLE
Allow `describe` without requiring an argument

### DIFF
--- a/src/spec/methods.cr
+++ b/src/spec/methods.cr
@@ -16,7 +16,7 @@ module Spec::Methods
   # ```
   #
   # If `focus` is `true`, only this `describe`, and others marked with `focus: true`, will run.
-  def describe(description, file = __FILE__, line = __LINE__, end_line = __END_LINE__, focus : Bool = false, tags : String | Enumerable(String) | Nil = nil, &block)
+  def describe(description = nil, file = __FILE__, line = __LINE__, end_line = __END_LINE__, focus : Bool = false, tags : String | Enumerable(String) | Nil = nil, &block)
     Spec.root_context.describe(description.to_s, file, line, end_line, focus, tags, &block)
   end
 
@@ -27,7 +27,7 @@ module Spec::Methods
   # It is functionally equivalent to `#describe`.
   #
   # If `focus` is `true`, only this `context`, and others marked with `focus: true`, will run.
-  def context(description, file = __FILE__, line = __LINE__, end_line = __END_LINE__, focus : Bool = false, tags : String | Enumerable(String) | Nil = nil, &block)
+  def context(description = nil, file = __FILE__, line = __LINE__, end_line = __END_LINE__, focus : Bool = false, tags : String | Enumerable(String) | Nil = nil, &block)
     describe(description.to_s, file, line, end_line, focus, tags, &block)
   end
 


### PR DESCRIPTION
The `describe` method of the spec DSL currently requires an argument for the `description`. The general idea behind that is probably, that it makes no sense to describe something without a description.

With spec's focus feature I've several times found myself in a situation where I want to run a couple of related examples in a spec file. Adding `focus: true` on each one is cumbersome, so I created a (temporary) example group with `describe` and added `focus: true` to that. But `describe` requires an argument with a description. For this focus-only example group I don't need a description, so could just be empty.

I'm proposing to add a default value to the `description` argument, to make this use case a bit friendlier. Now I'm no longer forced to pass in an empty description.

`context` is functionally identical to `describe`, so it also gets a default argument.