### PR TITLE
Syntax errors for invalid 128-bit integer literals

### DIFF
--- a/spec/compiler/lexer/lexer_spec.cr
+++ b/spec/compiler/lexer/lexer_spec.cr
@@ -305,6 +305,12 @@ describe "Lexer" do
   assert_syntax_error "-9223372036854775809", "-9223372036854775809 doesn't fit in an Int64"
   assert_syntax_error "18446744073709551616", "18446744073709551616 doesn't fit in an UInt64"
 
+  assert_syntax_error "9223372036854775808_i64", "9223372036854775808 doesn't fit in an Int64. Int128 literals that don't fit in an Int64 are currently not supported"
+  assert_syntax_error "-9223372036854775809_i64", "-9223372036854775809 doesn't fit in an Int64. Int128 literals that don't fit in an Int64 are currently not supported"
+  assert_syntax_error "118446744073709551616_u64", "118446744073709551616 doesn't fit in an UInt64. UInt128 literals that don't fit in an UInt64 are currently not supported"
+  assert_syntax_error "18446744073709551616_u64", "18446744073709551616 doesn't fit in an UInt64. UInt128 literals that don't fit in an UInt64 are currently not supported"
+  assert_syntax_error "-1_u128", "Invalid negative value -1 for UInt128"
+
   assert_syntax_error "0xFF_i8", "255 doesn't fit in an Int8"
   assert_syntax_error "0o200_i8", "128 doesn't fit in an Int8"
   assert_syntax_error "0b10000000_i8", "128 doesn't fit in an Int8"

--- a/spec/compiler/lexer/lexer_spec.cr
+++ b/spec/compiler/lexer/lexer_spec.cr
@@ -305,10 +305,10 @@ describe "Lexer" do
   assert_syntax_error "-9223372036854775809", "-9223372036854775809 doesn't fit in an Int64"
   assert_syntax_error "18446744073709551616", "18446744073709551616 doesn't fit in an UInt64"
 
-  assert_syntax_error "9223372036854775808_i64", "9223372036854775808 doesn't fit in an Int64. Int128 literals that don't fit in an Int64 are currently not supported"
-  assert_syntax_error "-9223372036854775809_i64", "-9223372036854775809 doesn't fit in an Int64. Int128 literals that don't fit in an Int64 are currently not supported"
-  assert_syntax_error "118446744073709551616_u64", "118446744073709551616 doesn't fit in an UInt64. UInt128 literals that don't fit in an UInt64 are currently not supported"
-  assert_syntax_error "18446744073709551616_u64", "18446744073709551616 doesn't fit in an UInt64. UInt128 literals that don't fit in an UInt64 are currently not supported"
+  assert_syntax_error "9223372036854775808_i128", "9223372036854775808 doesn't fit in an Int64. Int128 literals that don't fit in an Int64 are currently not supported"
+  assert_syntax_error "-9223372036854775809_i128", "-9223372036854775809 doesn't fit in an Int64. Int128 literals that don't fit in an Int64 are currently not supported"
+  assert_syntax_error "118446744073709551616_u128", "118446744073709551616 doesn't fit in an UInt64. UInt128 literals that don't fit in an UInt64 are currently not supported"
+  assert_syntax_error "18446744073709551616_u128", "18446744073709551616 doesn't fit in an UInt64. UInt128 literals that don't fit in an UInt64 are currently not supported"
   assert_syntax_error "-1_u128", "Invalid negative value -1 for UInt128"
 
   assert_syntax_error "0xFF_i8", "255 doesn't fit in an Int8"

--- a/src/compiler/crystal/syntax/lexer.cr
+++ b/src/compiler/crystal/syntax/lexer.cr
@@ -1627,8 +1627,10 @@ module Crystal
         end
 
         check_value_fits_in_uint64 string_value, num_size, start
-      else
-        # TODO: handle i128 and u128
+      when :u128
+        if negative
+          raise "Invalid negative value #{string_value} for UInt128"
+        end
       end
     end
 

--- a/src/compiler/crystal/syntax/lexer.cr
+++ b/src/compiler/crystal/syntax/lexer.cr
@@ -1636,7 +1636,7 @@ module Crystal
 
         check_value_fits_in_uint64 string_value, num_size, start
       when :i128
-        gen_check_int_fits_in_size Int64, to_u64, 19, actual_type: UInt128
+        gen_check_int_fits_in_size Int64, to_u64, 19, actual_type: Int128
       when :u128
         if negative
           raise "Invalid negative value #{string_value} for UInt128"

--- a/src/compiler/crystal/syntax/lexer.cr
+++ b/src/compiler/crystal/syntax/lexer.cr
@@ -1687,7 +1687,7 @@ module Crystal
         i = 1 # skip '-'
         "9223372036854775808".each_byte do |byte|
           string_byte = string_value.byte_at(i)
-          if
+          if string_byte > byte
             raise_value_doesnt_fit_in "Int64", string_value, start
           elsif string_byte < byte
             break

--- a/src/compiler/crystal/syntax/lexer.cr
+++ b/src/compiler/crystal/syntax/lexer.cr
@@ -1578,9 +1578,9 @@ module Crystal
     macro gen_check_int_fits_in_size(type, method, size, *, actual_type = nil)
       if num_size >= 20
         {% if actual_type.nil? %}
-        raise_value_doesnt_fit_in "{{type}}", string_value, start
+          raise_value_doesnt_fit_in "{{type}}", string_value, start
         {% else %}
-        raise_value_restricted_by "{{actual_type}}", "{{type}}", string_value, start
+          raise_value_restricted_by "{{actual_type}}", "{{type}}", string_value, start
         {% end %}
       end
       if num_size >= {{size}}
@@ -1590,9 +1590,9 @@ module Crystal
 
         if int_value > max
           {% if actual_type.nil? %}
-          raise_value_doesnt_fit_in "{{type}}", string_value, start
+            raise_value_doesnt_fit_in "{{type}}", string_value, start
           {% else %}
-          raise_value_restricted_by "{{actual_type}}", "{{type}}", string_value, start
+            raise_value_restricted_by "{{actual_type}}", "{{type}}", string_value, start
           {% end %}
         end
       end


### PR DESCRIPTION
Fixes #10962 

Since I am not skilled enough to resolve these TODOs in the codegen, I simply opted to warn about not being allowed to use literals larger than a 64-bit integer
https://github.com/crystal-lang/crystal/blob/71d6e9b63fa06b3ace5207fc0ea1f1d20a2c6089/src/compiler/crystal/codegen/codegen.cr#L453-L458
