### PR TITLE
Fix edge cases with unicode method names

### DIFF
--- a/spec/compiler/formatter/formatter_spec.cr
+++ b/spec/compiler/formatter/formatter_spec.cr
@@ -629,9 +629,11 @@ describe Crystal::Formatter do
   assert_format "pointerof( @a )", "pointerof(@a)"
 
   assert_format "_ = 1"
+  assert_format "あ.い = 1"
 
   assert_format "a , b  = 1  ,  2", "a, b = 1, 2"
   assert_format "a[1] , b[2] = 1  ,  2", "a[1], b[2] = 1, 2"
+  assert_format "あ.い, う.え.お = 1, 2"
 
   assert_format "begin\n1\nensure\n2\nend", "begin\n  1\nensure\n  2\nend"
   assert_format "begin\n1\nrescue\n3\nensure\n2\nend", "begin\n  1\nrescue\n  3\nensure\n  2\nend"

--- a/spec/compiler/parser/parser_spec.cr
+++ b/spec/compiler/parser/parser_spec.cr
@@ -167,6 +167,8 @@ module Crystal
     it_parses "@a, b = 1, 2", MultiAssign.new(["@a".instance_var, "b".var] of ASTNode, [1.int32, 2.int32] of ASTNode)
     it_parses "@@a, b = 1, 2", MultiAssign.new(["@@a".class_var, "b".var] of ASTNode, [1.int32, 2.int32] of ASTNode)
 
+    it_parses "あ.い, う.え.お = 1, 2", MultiAssign.new([Call.new("あ".call, "い"), Call.new(Call.new("う".call, "え"), "お")] of ASTNode, [1.int32, 2.int32] of ASTNode)
+
     assert_syntax_error "b? = 1", "unexpected token: ="
     assert_syntax_error "b! = 1", "unexpected token: ="
     assert_syntax_error "a, B = 1, 2", "can't assign to constant in multiple assignment"

--- a/spec/compiler/parser/to_s_spec.cr
+++ b/spec/compiler/parser/to_s_spec.cr
@@ -182,4 +182,7 @@ describe "ASTNode#to_s" do
   expect_to_s "macro foo\n  123\nend"
   expect_to_s "if true\n(  1)\nend"
   expect_to_s "begin\n(  1)\nrescue\nend"
+  expect_to_s %[他.说("你好")]
+  expect_to_s %[他.说 = "你好"]
+  expect_to_s %[あ.い, う.え.お = 1, 2]
 end

--- a/src/compiler/crystal/syntax/lexer.cr
+++ b/src/compiler/crystal/syntax/lexer.cr
@@ -1299,7 +1299,7 @@ module Crystal
           end
           @token.type = :CONST
           @token.value = string_range_from_pool(start)
-        elsif current_char.ascii_lowercase? || current_char == '_' || current_char.ord > 0x9F
+        elsif ident_start?(current_char)
           next_char
           scan_ident(start)
         else
@@ -3134,13 +3134,23 @@ module Crystal
       Slice.new(@reader.string.to_unsafe + start_pos, end_pos - start_pos)
     end
 
-    def ident_start?(char)
+    def self.ident_start?(char)
       char.ascii_letter? || char == '_' || char.ord > 0x9F
     end
 
-    def ident_part?(char)
+    def self.ident_part?(char)
       ident_start?(char) || char.ascii_number?
     end
+
+    def self.ident?(name)
+      !!name[0]?.try { |char| ident_start?(char) }
+    end
+
+    def self.setter?(name)
+      ident?(name) && name.ends_with?('=')
+    end
+
+    private delegate ident_start?, ident_part?, to: Lexer
 
     def ident_part_or_end?(char)
       ident_part?(char) || char == '?' || char == '!'

--- a/src/compiler/crystal/syntax/parser.cr
+++ b/src/compiler/crystal/syntax/parser.cr
@@ -212,10 +212,6 @@ module Crystal
       parse_expression_suffix multi, @token.location
     end
 
-    def setter?(name)
-      name[0]?.try { |char| ident_start?(char) } && name.ends_with?('=')
-    end
-
     def multi_assign_target?(exp)
       case exp
       when Underscore, Var, InstanceVar, ClassVar, Global, Assign
@@ -223,7 +219,7 @@ module Crystal
       when Call
         !exp.has_parentheses? && (
           (exp.args.empty? && !exp.named_args) ||
-            setter?(exp.name) ||
+            Lexer.setter?(exp.name) ||
             exp.name == "[]" || exp.name == "[]="
         )
       else

--- a/src/compiler/crystal/syntax/parser.cr
+++ b/src/compiler/crystal/syntax/parser.cr
@@ -212,6 +212,10 @@ module Crystal
       parse_expression_suffix multi, @token.location
     end
 
+    def setter?(name)
+      name[0]?.try { |char| ident_start?(char) } && name.ends_with?('=')
+    end
+
     def multi_assign_target?(exp)
       case exp
       when Underscore, Var, InstanceVar, ClassVar, Global, Assign
@@ -219,7 +223,7 @@ module Crystal
       when Call
         !exp.has_parentheses? && (
           (exp.args.empty? && !exp.named_args) ||
-            (exp.name[0].ascii_letter? && exp.name.ends_with?('=')) ||
+            setter?(exp.name) ||
             exp.name == "[]" || exp.name == "[]="
         )
       else

--- a/src/compiler/crystal/syntax/to_s.cr
+++ b/src/compiler/crystal/syntax/to_s.cr
@@ -372,7 +372,7 @@ module Crystal
       elsif node_obj && node.name.in?(UNARY_OPERATORS) && node.args.empty? && !node.named_args && !node.block_arg && !block
         @str << decorate_call(node, node.name)
         in_parenthesis(need_parens, node_obj)
-      elsif node_obj && !letter_or_underscore?(node.name) && node.name != "~" && node.args.size == 1 && !node.named_args && !node.block_arg && !block
+      elsif node_obj && !ident?(node.name) && node.name != "~" && node.args.size == 1 && !node.named_args && !node.block_arg && !block
         in_parenthesis(need_parens, node_obj)
 
         arg = node.args[0]
@@ -385,7 +385,7 @@ module Crystal
           in_parenthesis(need_parens, node_obj)
           @str << '.'
         end
-        if node.name.ends_with?('=') && node.name[0].ascii_letter?
+        if setter?(node.name)
           @str << decorate_call(node, node.name.rchop)
           @str << " = "
           node.args.join(@str, ", ", &.accept self)
@@ -461,7 +461,7 @@ module Crystal
       when Call
         case obj.args.size
         when 0
-          !letter_or_underscore?(obj.name)
+          !ident?(obj.name)
         else
           case obj.name
           when "[]", "[]?", "<", "<=", ">", ">="
@@ -556,12 +556,14 @@ module Crystal
       str
     end
 
-    def letter?(string)
-      string[0].ascii_letter?
+    def ident?(name)
+      name[0]?.try do |char|
+        char.ascii_letter? || char == '_' || char.ord > 0x9F
+      end
     end
 
-    def letter_or_underscore?(string)
-      string[0].ascii_letter? || string[0] == '_'
+    def setter?(name)
+      ident?(name) && name.ends_with?('=')
     end
 
     def visit(node : Assign)

--- a/src/compiler/crystal/syntax/to_s.cr
+++ b/src/compiler/crystal/syntax/to_s.cr
@@ -372,7 +372,7 @@ module Crystal
       elsif node_obj && node.name.in?(UNARY_OPERATORS) && node.args.empty? && !node.named_args && !node.block_arg && !block
         @str << decorate_call(node, node.name)
         in_parenthesis(need_parens, node_obj)
-      elsif node_obj && !ident?(node.name) && node.name != "~" && node.args.size == 1 && !node.named_args && !node.block_arg && !block
+      elsif node_obj && !Lexer.ident?(node.name) && node.name != "~" && node.args.size == 1 && !node.named_args && !node.block_arg && !block
         in_parenthesis(need_parens, node_obj)
 
         arg = node.args[0]
@@ -385,7 +385,7 @@ module Crystal
           in_parenthesis(need_parens, node_obj)
           @str << '.'
         end
-        if setter?(node.name)
+        if Lexer.setter?(node.name)
           @str << decorate_call(node, node.name.rchop)
           @str << " = "
           node.args.join(@str, ", ", &.accept self)
@@ -461,7 +461,7 @@ module Crystal
       when Call
         case obj.args.size
         when 0
-          !ident?(obj.name)
+          !Lexer.ident?(obj.name)
         else
           case obj.name
           when "[]", "[]?", "<", "<=", ">", ">="
@@ -554,16 +554,6 @@ module Crystal
 
     def decorate_class_var(node, str)
       str
-    end
-
-    def ident?(name)
-      name[0]?.try do |char|
-        char.ascii_letter? || char == '_' || char.ord > 0x9F
-      end
-    end
-
-    def setter?(name)
-      ident?(name) && name.ends_with?('=')
     end
 
     def visit(node : Assign)

--- a/src/compiler/crystal/tools/formatter.cr
+++ b/src/compiler/crystal/tools/formatter.cr
@@ -2609,7 +2609,7 @@ module Crystal
         return false
       end
 
-      assignment = setter?(node.name)
+      assignment = Lexer.setter?(node.name)
 
       if assignment
         write node.name.rchop
@@ -2903,10 +2903,6 @@ module Crystal
         next_token
       end
       finish_args(true, has_newlines, ends_with_newline, found_comment, @indent)
-    end
-
-    def setter?(name)
-      name[0]?.try { |char| @lexer.ident_start?(char) } && name.ends_with?('=')
     end
 
     def visit(node : NamedArgument)

--- a/src/compiler/crystal/tools/formatter.cr
+++ b/src/compiler/crystal/tools/formatter.cr
@@ -2609,7 +2609,7 @@ module Crystal
         return false
       end
 
-      assignment = node.name.ends_with?('=') && node.name.chars.any?(&.ascii_letter?)
+      assignment = setter?(node.name)
 
       if assignment
         write node.name.rchop
@@ -2903,6 +2903,10 @@ module Crystal
         next_token
       end
       finish_args(true, has_newlines, ends_with_newline, found_comment, @indent)
+    end
+
+    def setter?(name)
+      name[0]?.try { |char| @lexer.ident_start?(char) } && name.ends_with?('=')
     end
 
     def visit(node : NamedArgument)


### PR DESCRIPTION
Fixes #10970, where `😂` is considered an operator:

```crystal
macro foo(x)
  {% p x %}
end

# Before
foo x.😂(1)  # => x 😂 1
foo x.😂 = 1 # => x 😂= 1

# After
foo x.😂(1)  # => x.😂(1)
foo x.😂 = 1 # => x.😂 = 1
```

Also fixes some other places where setter methods are currently detected via `ascii_letter?`:

* Fixes parser failures with the following, as `y.😂` is not recognized as a setter target inside a multi-assign:
  ```crystal
  class Foo
    property 😂 : Int32?
  end

  y = Foo.new
  x, y.😂 = 1, 2
  ```
* Fixes formatter failures with the following, as they are not considered setters:
  ```crystal
  x._1 = 2
  x.😂 = 1
  ```