### PR TITLE
Disallow `Slice(T).new(Int)` where `T` is a union of primitive number types

### DIFF
--- a/src/array.cr
+++ b/src/array.cr
@@ -955,7 +955,7 @@ class Array(T)
   # a.fill(9) # => [9, 9, 9]
   # ```
   def fill(value : T)
-    {% if Int::Primitive.union_types.includes?(T) || Float::Primitive.union_types.includes?(T) %}
+    {% if Number::Primitive.union_types.includes?(T) %}
       if value == 0
         to_unsafe.clear(size)
         return self
@@ -974,7 +974,7 @@ class Array(T)
   # a.fill(9, 2) # => [1, 2, 9, 9, 9]
   # ```
   def fill(value : T, from : Int)
-    {% if Int::Primitive.union_types.includes?(T) || Float::Primitive.union_types.includes?(T) %}
+    {% if Number::Primitive.union_types.includes?(T) %}
       if value == 0
         from += size if from < 0
 
@@ -1001,7 +1001,7 @@ class Array(T)
   # a.fill(9, 2, 2) # => [1, 2, 9, 9, 5]
   # ```
   def fill(value : T, from : Int, count : Int)
-    {% if Int::Primitive.union_types.includes?(T) || Float::Primitive.union_types.includes?(T) %}
+    {% if Number::Primitive.union_types.includes?(T) %}
       if value == 0
         return self if count <= 0
 
@@ -1029,7 +1029,7 @@ class Array(T)
   # a.fill(9, 2..3) # => [1, 2, 9, 9, 5]
   # ```
   def fill(value : T, range : Range)
-    {% if Int::Primitive.union_types.includes?(T) || Float::Primitive.union_types.includes?(T) %}
+    {% if Number::Primitive.union_types.includes?(T) %}
       if value == 0
         fill(value, *Indexable.range_to_index_and_count(range, size) || raise IndexError.new)
 

--- a/src/hash.cr
+++ b/src/hash.cr
@@ -923,8 +923,7 @@ class Hash(K, V)
     {% if K == Bool ||
             K == Char ||
             K == Symbol ||
-            K < Int::Primitive ||
-            K < Float::Primitive ||
+            K < Number::Primitive ||
             K < Enum %}
       entry.key == key && entry.hash != 0_u32
     {% else %}

--- a/src/slice.cr
+++ b/src/slice.cr
@@ -83,7 +83,7 @@ struct Slice(T)
   # slice # => Bytes[0, 0, 0]
   # ```
   def self.new(size : Int, *, read_only = false)
-    {% unless T <= Int::Primitive || T <= Float::Primitive %}
+    {% unless Number::Primitive.union_types.includes?(T) %}
       {% raise "Can only use primitive integers and floats with Slice.new(size), not #{T}" %}
     {% end %}
 

--- a/src/static_array.cr
+++ b/src/static_array.cr
@@ -168,7 +168,7 @@ struct StaticArray(T, N)
   # array                               # => StaticArray[2, 2, 2]
   # ```
   def fill(value : T) : self
-    {% if Int::Primitive.union_types.includes?(T) || Float::Primitive.union_types.includes?(T) %}
+    {% if Number::Primitive.union_types.includes?(T) %}
       if value == 0
         to_unsafe.clear(size)
         return self


### PR DESCRIPTION
Fixes #10980.