### PR TITLE
Revert partially #10682 

### DIFF
--- a/spec/compiler/codegen/macro_spec.cr
+++ b/spec/compiler/codegen/macro_spec.cr
@@ -1864,7 +1864,7 @@ describe "Code gen: macro" do
       end
 
       Foo.new.bar
-      )).to_string.should eq("top_level")
+      )).to_string.should eq("main")
   end
 
   it "responds correctly to has_constant? with @top_level" do

--- a/src/compiler/crystal/program.cr
+++ b/src/compiler/crystal/program.cr
@@ -123,7 +123,7 @@ module Crystal
     property compiler : Compiler?
 
     def initialize
-      super(self, self, "top_level")
+      super(self, self, "main")
 
       # Every crystal program comes with some predefined types that we initialize here,
       # like Object, Value, Reference, etc.


### PR DESCRIPTION
Make the name of the top_level module 'main', as it was in 1.0.0.

Fixes #10992