### PR TITLE
Add HTTP::Client::Response#body_io?

### DIFF
--- a/src/http/client/response.cr
+++ b/src/http/client/response.cr
@@ -33,6 +33,10 @@ class HTTP::Client::Response
     @body
   end
 
+  def body_io? : IO?
+    @body_io
+  end
+
   # Returns `true` if the response status code is between 200 and 299.
   def success? : Bool
     @status.success?


### PR DESCRIPTION
Currently, there is no way to know if a response has a `body_io` or not. It is useful in case one need to stream the response to another IO via `IO.copy`.

Use case: I was writing an HTTP proxy and had to access the instance var directly.

```cr
server = HTTP::Server.new do |context|
  host, port = get_target_host_and_port(context)
  context.request.headers["Host"] = host
  context.request.headers["Accept-Encoding"] = "gzip, deflate"
  client = HTTP::Client.new(host, port)
  client.exec(context.request) do |response|
    context.response.status_code = response.status_code
    context.response.headers.clear
    response.headers.each do |key, value|
      next if key == "Transfer-Encoding"
      context.response.headers[key] = value
    end
    IO.copy(response.body_io, context.response) if response.@body_io # <<<<<<<<< HERE
  end
end
```

This PR adds `.body_io?`. With it the last line would be:

```cr
if body_io = response.body_io?
  IO.copy(body_io, context.response)
end
```