### PR TITLE
Add type restriction and conversion to `YAML::PullParser#location`

### DIFF
--- a/src/yaml/pull_parser.cr
+++ b/src/yaml/pull_parser.cr
@@ -273,11 +273,11 @@ class YAML::PullParser
   end
 
   def end_line : Int32
-    @event.end_mark.line + 1
+    @event.end_mark.line.to_i32 + 1
   end
 
   def end_column : Int32
-    @event.end_mark.column + 1
+    @event.end_mark.column.to_i32 + 1
   end
 
   private def problem_line_number

--- a/src/yaml/pull_parser.cr
+++ b/src/yaml/pull_parser.cr
@@ -260,23 +260,23 @@ class YAML::PullParser
 
   # Note: YAML starts counting from 0, we want to count from 1
 
-  def location
+  def location : {Int32, Int32}
     {start_line, start_column}
   end
 
-  def start_line : Int
-    @event.start_mark.line + 1
+  def start_line : Int32
+    @event.start_mark.line.to_i32 + 1
   end
 
-  def start_column : Int
-    @event.start_mark.column + 1
+  def start_column : Int32
+    @event.start_mark.column.to_i32 + 1
   end
 
-  def end_line : Int
+  def end_line : Int32
     @event.end_mark.line + 1
   end
 
-  def end_column : Int
+  def end_column : Int32
     @event.end_mark.column + 1
   end
 


### PR DESCRIPTION
`YAML::PullParser` location numbers are `Int` because of `SizeT` in `LibYAML::Mark` properties. This patch casts the return types to `Int32`. This is technically a breaking change, because it was previously `UInt64` on 64-bit systems and `UInt32` on 32-bit.

Most methods already had a type restriction of `Int`. Narrowing that to `Int32` should technically be fine, but it can still break code expecting the return value to be some `UInt` (because the compiler does not use the type restriction for determining the return type, it just makes sure the actual return type fulfills the restriction).
`#location` itself had no prior type restriction at all and returned `{LibC::SizeT, LibC::SizeT}`. Changing that to `{Int32, Int32}` is a pretty hard change. I wouldn't expect much collateral from changing it though.

Question is if we can accept this as a necessary bug fix for a minor release.

See https://github.com/crystal-lang/crystal/issues/10645#issuecomment-885612694