### PR TITLE
Don't compute instance variable initializers on unbound generic instances

### DIFF
--- a/spec/compiler/codegen/generic_class_spec.cr
+++ b/spec/compiler/codegen/generic_class_spec.cr
@@ -142,6 +142,29 @@ describe "Code gen: generic class type" do
       )).to_i.should eq(1)
   end
 
+  it "doesn't run generic instance var initializers in formal superclass's context (#4753)" do
+    run(%(
+      class Foo(T)
+        @foo = T.new
+
+        def foo
+          @foo
+        end
+      end
+
+      class Bar(T) < Foo(T)
+      end
+
+      class Baz
+        def baz
+          7
+        end
+      end
+
+      Bar(Baz).new.foo.baz
+      )).to_i.should eq(7)
+  end
+
   it "codegens static array size after instantiating" do
     run(%(
       struct StaticArray(T, N)

--- a/spec/compiler/semantic/generic_class_spec.cr
+++ b/spec/compiler/semantic/generic_class_spec.cr
@@ -123,6 +123,29 @@ describe "Semantic: generic class" do
       )) { int32 }
   end
 
+  it "doesn't compute generic instance var initializers in formal superclass's context (#4753)" do
+    assert_type(%(
+      class Foo(T)
+        @foo = T.new
+
+        def foo
+          @foo
+        end
+      end
+
+      class Bar(T) < Foo(T)
+      end
+
+      class Baz
+        def baz
+          1
+        end
+      end
+
+      Bar(Baz).new.foo.baz
+      ), inject_primitives: false) { int32 }
+  end
+
   it "inherits non-generic to generic (1)" do
     assert_type(%(
       class Foo(T)

--- a/src/compiler/crystal/types.cr
+++ b/src/compiler/crystal/types.cr
@@ -1603,6 +1603,8 @@ module Crystal
     end
 
     def run_instance_var_initializer(initializer, instance : GenericClassInstanceType | NonGenericClassType)
+      return if instance.unbound?
+
       meta_vars = MetaVars.new
       visitor = MainVisitor.new(program, vars: meta_vars, meta_vars: meta_vars)
       visitor.scope = instance.metaclass


### PR DESCRIPTION
Follow-up to #10729. Fixes #4753. Allows the following to work:

```crystal
class Foo(T)
  @foo = T.new
end

class Bar(T) < Foo(T)
end
```

This currently produces an `undefined method 'new' for T.class` error at `@foo`'s initializer, because when `Bar` is declared, the compiler tries to compute this initializer's type on the unbound superclass `Foo(T)` during the semantic phase. This unbound expression should never be used, as the compiler must go through the same computation anyway, with a substituted `T`, when a bound instance of `Foo` is created. Another example:

```crystal
class Foo(T)
  @foo : T = T.zero
end

class Bar(T) < Foo(T)
end

Bar(Int32).new  # okay
Bar(String).new # Error: undefined method 'zero' for String.class
```

`@foo` is still _added_ to the unbound `Foo(T)`, should one attempt to access it via `{{ Bar.superclass.instance_vars }}` after all instance variables are finalized.