### PR TITLE
Fix no overflow check when primitive int converts to same type

### DIFF
--- a/spec/compiler/codegen/primitives_spec.cr
+++ b/spec/compiler/codegen/primitives_spec.cr
@@ -34,6 +34,10 @@ describe "Code gen: primitives" do
       )).to_i.should eq(1)
   end
 
+  it "skips bounds checking when to_i produces same type" do
+    run("1.to_i32").to_i.should eq(1)
+  end
+
   it "codegens char" do
     run("'a'").to_i.should eq('a'.ord)
   end

--- a/src/compiler/crystal/codegen/primitives.cr
+++ b/src/compiler/crystal/codegen/primitives.cr
@@ -610,7 +610,7 @@ class Crystal::CodeGenVisitor
     when from_type.normal_rank == to_type.normal_rank
       # if the normal_rank is the same (eg: UInt64 / Int64)
       # there is still chance for overflow
-      if checked
+      if from_type.kind != to_type.kind && checked
         overflow = codegen_out_of_range(to_type, from_type, arg)
         codegen_raise_overflow_cond(overflow)
       end


### PR DESCRIPTION
The expression `1.to_i32` is apparently [not a no-op](https://godbolt.org/z/rs1bbfaxx), at least in non-release mode, as it requires a definition of `__crystal_raise_overflow`. This PR fixes that.

The same is already done for primitive floats converting to their own types.