### PR TITLE
Handle already stripped column numbers in exceptions

### DIFF
--- a/src/compiler/crystal/exception.cr
+++ b/src/compiler/crystal/exception.cr
@@ -140,10 +140,15 @@ module Crystal
         decorator = line_number_decorator(line_number)
         lstripped_line = line.lstrip
         space_delta = line.chars.size - lstripped_line.chars.size
+        final_column_number = if column_number < space_delta
+                                1
+                              else
+                                column_number - space_delta
+                              end
 
         io << "\n\n"
         io << colorize(decorator).dim << colorize(lstripped_line.chomp).bold
-        append_error_indicator(io, decorator.chars.size, column_number - space_delta, size || 0)
+        append_error_indicator(io, decorator.chars.size, final_column_number, size || 0)
       end
     end
 

--- a/src/compiler/crystal/exception.cr
+++ b/src/compiler/crystal/exception.cr
@@ -140,11 +140,9 @@ module Crystal
         decorator = line_number_decorator(line_number)
         lstripped_line = line.lstrip
         space_delta = line.chars.size - lstripped_line.chars.size
-        final_column_number = if column_number < space_delta
-                                1
-                              else
-                                column_number - space_delta
-                              end
+        # Column number should start at `1`. We're using `0` to track bogus passed
+        # `column_number`.
+        final_column_number = (column_number - space_delta).clamp(0..)
 
         io << "\n\n"
         io << colorize(decorator).dim << colorize(lstripped_line.chomp).bold


### PR DESCRIPTION
When developing macros, I felt upon a bug in the compiler when an exception is encountered with `--error-trace` specified on the command line.

---

When an exception is raised, the compiler prints out a stack trace. This is handled by `Crystal::Error` and more specifically `Crystal::ErrorFormat`.

When printing a trace, the colum number is computed by subtracting the additional spaces from the file line were the current trace occurs. This is managed by `Crystal::ErrorFormat#format_error`, beginning at line 140.

The problem is that, sometimes, the column number is set to `1` instead of the expected column number. Then, this column number is subtracted by the number of spaces on the line, leading to a negative number which is then passed to `Crystal::ErrorFormat#append_error_indicator`, which calls `String#*`, which raises `Negative argument`.

---

Here's an example with the right behavior (eg. creating a `Crystal::ErrorFormat` with a "non stripped" column number): 

- the code begins at colum number `7` for that line
- then, there are `6` leading spaces
- the resulting column number to pass to `append_error_indicator` is `1`

Here's with the unexpected behavior: 

- the code begins at column number `9`
- but the passed column number is `1`
- there are `8` leading spaces
- the result for the new column number is `-7`

---

To fix the issue, I didn't try to find which code block was passing an "incorrect" column number. It would have take much time and I think it's more the responsibility of the error formatter to filter negative values from its subtraction.

I didn't write tests for this because it would only makes sense to have an integration test instead of a unit test, and the test case is hard to reproduce. As I said earlier, I'm coding some macros (which are generally hard to debug), and I'm using those macros with `spectator`. So... There're macros everywhere and it's tricky to get a reduced/reproducible code from this.

Anyway, here's the end of the stack trace of the crash (I don't think anything above it is really useful, but I can paste the whole thing if needed): 

```
[...]
In spec/src/models/creamy/item_spec.cr:22:5

 22 | context "validation:" do
      ^------
Error: expanding macro


In spec/src/models/creamy/item_spec.cr:23:7

 23 | context "can be nil if 'proginov_id' is not nil" do
      ^------
Error: expanding macro


Unhandled exception: Negative argument (ArgumentError)
  from /crystal/src/string.cr:5024:13 in '*'
  from /crystal/src/compiler/crystal/exception.cr:108:7 in 'append_error_indicator'
  from /crystal/src/string/builder.cr:28:5 in 'error_body'
  from /crystal/src/compiler/crystal/semantic/exception.cr:122:10 in 'append_to_s'
  from /crystal/src/compiler/crystal/semantic/exception.cr:137:9 in 'append_to_s'
  from /crystal/src/compiler/crystal/semantic/exception.cr:137:9 in 'append_to_s'
  from /crystal/src/compiler/crystal/semantic/exception.cr:137:9 in 'append_to_s'
  from /crystal/src/compiler/crystal/semantic/exception.cr:137:9 in 'append_to_s'
  from /crystal/src/compiler/crystal/semantic/exception.cr:137:9 in 'append_to_s'
  from /crystal/src/compiler/crystal/semantic/exception.cr:137:9 in 'append_to_s'
  from /crystal/src/compiler/crystal/semantic/exception.cr:137:9 in 'append_to_s'
  from /crystal/src/compiler/crystal/semantic/exception.cr:137:9 in 'append_to_s'
  from /crystal/src/compiler/crystal/semantic/exception.cr:137:9 in 'append_to_s'
  from /crystal/src/compiler/crystal/semantic/exception.cr:137:9 in 'append_to_s'
  from /crystal/src/compiler/crystal/semantic/exception.cr:137:9 in 'append_to_s'
  from /crystal/src/compiler/crystal/semantic/exception.cr:95:7 in 'run'
  from /crystal/src/compiler/crystal.cr:11:1 in '__crystal_main'
  from /crystal/src/crystal/main.cr:110:5 in 'main'
  from src/env/__libc_start_main.c:94:2 in 'libc_start_main_stage2'
make: *** [Makefile:24: spec] Error 1
```

---

I am open to any suggestion about the fix itself, the lack of tests (or of investigation). 