### PR TITLE
Update readme to point to IRC channel on libera.chat

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -5,4 +5,4 @@ contact_links:
     about: Questions about installing, using Crystal and any related issues.
   - name: "\U0001F4AC Crystal Community Chat"
     url: https://gitter.im/crystal-lang/crystal
-    about: "Get in touch with the community, ask for help and talk about Crystal. (IRC: #crystal-lang on freenode)"
+    about: "Get in touch with the community, ask for help and talk about Crystal. (IRC: #crystal-lang on libera.chat)"

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ Documentation
 Community
 ---------
 
-Questions or suggestions? Ask on the [Crystal Forum](https://forum.crystal-lang.org), on our [Gitter channel](https://gitter.im/crystal-lang/crystal) or IRC channel [#crystal-lang](http://webchat.freenode.net/?channels=#crystal-lang) at chat.freenode.net, or on Stack Overflow under the [crystal-lang](http://stackoverflow.com/questions/tagged/crystal-lang) tag. There is also an archived [Google Group](https://groups.google.com/forum/?fromgroups#!forum/crystal-lang).
+Questions or suggestions? Ask on the [Crystal Forum](https://forum.crystal-lang.org), on our [Gitter channel](https://gitter.im/crystal-lang/crystal) or IRC channel [#crystal-lang](https://web.libera.chat/#crystal-lang) at irc.libera.chat, or on Stack Overflow under the [crystal-lang](http://stackoverflow.com/questions/tagged/crystal-lang) tag. There is also an archived [Google Group](https://groups.google.com/forum/?fromgroups#!forum/crystal-lang).
 
 Contributing
 ------------


### PR DESCRIPTION
Missed the reference in the readme here
