### PR TITLE
Disallow non-UTF-8 encoding settings for `String::Builder`

### DIFF
--- a/src/io.cr
+++ b/src/io.cr
@@ -1010,10 +1010,7 @@ abstract class IO
   # String operations (`gets`, `gets_to_end`, `read_char`, `<<`, `print`, `puts`
   # `printf`) will use this encoding.
   def set_encoding(encoding : String, invalid : Symbol? = nil) : Nil
-    if invalid != :skip && (
-         encoding.compare("UTF-8", case_insensitive: true) == 0 ||
-         encoding.compare("UTF8", case_insensitive: true) == 0
-       )
+    if utf8_encoding?(encoding, invalid)
       @encoding = nil
     else
       @encoding = EncodingOptions.new(encoding, invalid)
@@ -1028,6 +1025,13 @@ abstract class IO
   # Returns this `IO`'s encoding. The default is `UTF-8`.
   def encoding : String
     @encoding.try(&.name) || "UTF-8"
+  end
+
+  private def utf8_encoding?(encoding : String, invalid : Symbol? = nil) : Bool
+    invalid.nil? && (
+      encoding.compare("UTF-8", case_insensitive: true) == 0 ||
+        encoding.compare("UTF8", case_insensitive: true) == 0
+    )
   end
 
   # :nodoc:

--- a/src/string/builder.cr
+++ b/src/string/builder.cr
@@ -64,6 +64,16 @@ class String::Builder < IO
     nil
   end
 
+  def write_utf8(slice : Bytes) : Nil
+    write(slice)
+  end
+
+  def set_encoding(encoding : String, invalid : Symbol? = nil) : Nil
+    unless utf8_encoding?(encoding, invalid)
+      raise "Can't change encoding of String::Builder"
+    end
+  end
+
   def buffer : Pointer(UInt8)
     @buffer + String::HEADER_SIZE
   end


### PR DESCRIPTION
The purpose of `String::Builder` is to implement `String.build` which always creates well-formed Crystal `String`s, so there is never a need to support non-UTF-8 encodings in it.

With this PR we can assume that `String::Builder#write_utf8` and `String::Builder#write` are exactly equivalent. This change also has a negligible speed impact, but is big enough to alter the inlining behaviour of some functions in release mode.