### PR TITLE
Add `#to_unsafe_slice` to `StaticArray` and `IO::Memory`

### DIFF
--- a/spec/std/io/memory_spec.cr
+++ b/spec/std/io/memory_spec.cr
@@ -294,14 +294,14 @@ describe IO::Memory do
     io = IO::Memory.new
     io.pos = 1000
     io.print 'a'
-    io.to_slice.to_a.should eq([0] * 1000 + [97])
+    io.to_unsafe_slice.to_a.should eq([0] * 1000 + [97])
   end
 
   it "writes past end with write_byte" do
     io = IO::Memory.new
     io.pos = 1000
     io.write_byte 'a'.ord.to_u8
-    io.to_slice.to_a.should eq([0] * 1000 + [97])
+    io.to_unsafe_slice.to_a.should eq([0] * 1000 + [97])
   end
 
   it "reads at offset" do


### PR DESCRIPTION
Adds new `#to_unsafe_slice` and deprecates the respective `#to_slice` methods.

We could consider re-activating the `#to_slice` methods as allocating, safe alternatives. But that should be a follow-up and probably only after they have been deprecated (and potentially removed in 2.0).

Resolves #9606