### PR TITLE
Compiler: carry FileModule information inside Block

### DIFF
--- a/src/compiler/crystal/semantic/main_visitor.cr
+++ b/src/compiler/crystal/semantic/main_visitor.cr
@@ -87,6 +87,7 @@ module Crystal
     property last_block_kind : Symbol?
     property? inside_ensure : Bool = false
     property? inside_constant = false
+    property file_module : FileModule?
 
     @unreachable = false
     @is_initialize = false
@@ -99,7 +100,6 @@ module Crystal
     @found_self_in_initialize_call : Array(ASTNode)?
     @used_ivars_in_calls_in_initialize : Hash(String, Array(ASTNode))?
     @block_context : Block?
-    @file_module : FileModule?
     @while_vars : MetaVars?
 
     # Type filters for `exp` in `!exp`, used after a `while`
@@ -1060,6 +1060,7 @@ module Crystal
       block_visitor.parent = self
       block_visitor.with_scope = node.scope || with_scope
       block_visitor.exception_handler_vars = @exception_handler_vars
+      block_visitor.file_module = @file_module
 
       block_scope = @scope
       block_scope ||= current_type.metaclass unless current_type.is_a?(Program)


### PR DESCRIPTION
While developing the interpreter I noticed some variables were considered closured by the compiler when they aren't. The consequence of this is that they are allocated on the heap, leading to slower code.

I don't think this will actually impact real world programs performance, but it's still a bug.

This happens specifically on required files, on the top level. For example:

```crystal
# foo.cr
require "./bar"
```

```crystal
# bar.cr
def foo
  yield
end

a = 1

foo do
  foo do
    a
  end
end
```

Compile like this:

```
crystal build foo.cr --prelude=empty --emit llvm-ir
```

Then open `foo.ll` and notice there's a closure, and `a` is put into it:

```ll
  %0 = call i8* @malloc(i64 ptrtoint (i32* getelementptr (i32, i32* null, i32 1) to i64)), !dbg !9
  %1 = bitcast i8* %0 to %closure_1*, !dbg !9
  %a = getelementptr inbounds %closure_1, %closure_1* %1, i32 0, i32 0, !dbg !9
  store i32 1, i32* %a, align 4, !dbg !12
  %2 = load i32, i32* %a, align 4, !dbg !13
```

With this PR there's no such closure.