### PR TITLE
Tag std specs that need network access

### DIFF
--- a/spec/std/socket/addrinfo_spec.cr
+++ b/spec/std/socket/addrinfo_spec.cr
@@ -1,7 +1,7 @@
 require "spec"
 require "socket/addrinfo"
 
-describe Socket::Addrinfo do
+describe Socket::Addrinfo, tags: "network" do
   describe ".resolve" do
     it "returns an array" do
       addrinfos = Socket::Addrinfo.resolve("localhost", 80, type: Socket::Type::STREAM)

--- a/spec/std/socket/socket_spec.cr
+++ b/spec/std/socket/socket_spec.cr
@@ -1,7 +1,7 @@
 require "./spec_helper"
 require "../../support/tempfile"
 
-describe Socket do
+describe Socket, tags: "network" do
   describe ".unix" do
     it "creates a unix socket" do
       sock = Socket.unix

--- a/spec/std/socket/tcp_server_spec.cr
+++ b/spec/std/socket/tcp_server_spec.cr
@@ -1,6 +1,6 @@
 require "./spec_helper"
 
-describe TCPServer do
+describe TCPServer, tags: "network" do
   describe ".new" do
     each_ip_family do |family, address|
       it "listens on local address" do

--- a/spec/std/socket/tcp_socket_spec.cr
+++ b/spec/std/socket/tcp_socket_spec.cr
@@ -1,6 +1,6 @@
 require "./spec_helper"
 
-describe TCPSocket do
+describe TCPSocket, tags: "network" do
   describe "#connect" do
     each_ip_family do |family, address|
       it "connects to server" do

--- a/spec/std/socket/udp_socket_spec.cr
+++ b/spec/std/socket/udp_socket_spec.cr
@@ -1,7 +1,7 @@
 require "./spec_helper"
 require "socket"
 
-describe UDPSocket do
+describe UDPSocket, tags: "network" do
   # Note: This spec fails with a IPv6 address. See pending below.
   it "#remote_address resets after connect" do
     socket = UDPSocket.new


### PR DESCRIPTION
Some test environments do not grant privileges to use the network (even to bind/listen on sockets).

In order to still run most of the test suite in those environments, this tags tests that need those features so they can be disabled if needed with `--tag ~network`