### PR TITLE
Rename `IO#write_utf8` to `#write_string`.

### DIFF
--- a/src/big/big_int.cr
+++ b/src/big/big_int.cr
@@ -484,7 +484,7 @@ struct BigInt < Int
       end
 
       base62_swapcase(buffer) if base == 62
-      io.write_utf8 buffer
+      io.write_string buffer
     end
   end
 

--- a/src/big/big_rational.cr
+++ b/src/big/big_rational.cr
@@ -259,7 +259,7 @@ struct BigRational < Number
 
   def to_s(io : IO, base : Int = 10) : Nil
     str = to_cstr(base)
-    io.write_utf8 Slice.new(str, LibC.strlen(str))
+    io.write_string Slice.new(str, LibC.strlen(str))
   end
 
   def inspect : String

--- a/src/char.cr
+++ b/src/char.cr
@@ -799,7 +799,7 @@ struct Char
 
       # Optimization: writing a slice is much slower than writing a byte
       if io.has_non_utf8_encoding?
-        io.write_utf8 Slice.new(pointerof(byte), 1)
+        io.write_string Slice.new(pointerof(byte), 1)
       else
         io.write_byte byte
       end
@@ -810,7 +810,7 @@ struct Char
         chars[i] = byte
         i += 1
       end
-      io.write_utf8 chars.to_slice[0, i]
+      io.write_string chars.to_slice[0, i]
     end
   end
 

--- a/src/float/printer.cr
+++ b/src/float/printer.cr
@@ -47,7 +47,7 @@ module Float::Printer
         LibC.snprintf(buffer.to_unsafe, BUFFER_SIZE, "%g", v.to_f64)
       end
       len = LibC.strlen(buffer)
-      io.write_utf8 buffer.to_slice[0, len]
+      io.write_string buffer.to_slice[0, len]
       return
     end
 
@@ -65,11 +65,11 @@ module Float::Printer
     # add integer part digits
     if decimal_exponent > 0 && !exp_mode
       # whole number but not big enough to be exp form
-      io.write_utf8 buffer.to_slice[i, length - i]
+      io.write_string buffer.to_slice[i, length - i]
       i = length
       (point - length).times { io << '0' }
     elsif i < point
-      io.write_utf8 buffer.to_slice[i, point - i]
+      io.write_string buffer.to_slice[i, point - i]
       i = point
     end
 
@@ -81,7 +81,7 @@ module Float::Printer
     end
 
     # add fractional part digits
-    io.write_utf8 buffer.to_slice[i, length - i]
+    io.write_string buffer.to_slice[i, length - i]
     i = length
 
     # print trailing 0 if whole number or exp notation of power of ten

--- a/src/int.cr
+++ b/src/int.cr
@@ -716,7 +716,7 @@ struct Int
         if precision > count
           (precision - count).times { io << '0' }
         end
-        io.write_utf8 Slice.new(ptr, count)
+        io.write_string Slice.new(ptr, count)
       end
     end
   end

--- a/src/io.cr
+++ b/src/io.cr
@@ -463,8 +463,20 @@ abstract class IO
     nil
   end
 
-  # Writes a slice of UTF-8 or ASCII encoded bytes to this `IO`, using the
+  # Writes the contents of *slice*, interpreted as a sequence of UTF-8 or ASCII
+  # characters, into this `IO`. The contents are transcoded into this `IO`'s
   # current encoding.
+  #
+  # ```
+  # bytes = "你".to_slice # => Bytes[228, 189, 160]
+  #
+  # io = IO::Memory.new
+  # io.set_encoding("GB2312")
+  # io.write_string(bytes)
+  # io.to_slice # => Bytes[196, 227]
+  #
+  # "你".encode("GB2312") # => Bytes[196, 227]
+  # ```
   def write_string(slice : Bytes) : Nil
     if encoder = encoder()
       encoder.write(self, slice)

--- a/src/io.cr
+++ b/src/io.cr
@@ -463,8 +463,9 @@ abstract class IO
     nil
   end
 
-  # Writes a slice of UTF-8 encoded bytes to this `IO`, using the current encoding.
-  def write_utf8(slice : Bytes) : Nil
+  # Writes a slice of UTF-8 or ASCII encoded bytes to this `IO`, using the
+  # current encoding.
+  def write_string(slice : Bytes) : Nil
     if encoder = encoder()
       encoder.write(self, slice)
     else
@@ -472,6 +473,12 @@ abstract class IO
     end
 
     nil
+  end
+
+  # :ditto:
+  @[Deprecated("Use `#write_string` instead.")]
+  def write_utf8(slice : Bytes) : Nil
+    write_string(slice)
   end
 
   private def encoder

--- a/src/string.cr
+++ b/src/string.cr
@@ -4958,7 +4958,7 @@ class String
 
   # Appends `self` to *io*.
   def to_s(io : IO) : Nil
-    io.write_utf8(to_slice)
+    io.write_string(to_slice)
   end
 
   # Returns the underlying bytes of this String.

--- a/src/string/builder.cr
+++ b/src/string/builder.cr
@@ -64,7 +64,7 @@ class String::Builder < IO
     nil
   end
 
-  def write_utf8(slice : Bytes) : Nil
+  def write_string(slice : Bytes) : Nil
     write(slice)
   end
 

--- a/src/string/formatter.cr
+++ b/src/string/formatter.cr
@@ -273,7 +273,7 @@ struct String::Formatter(A)
       temp_buf = temp_buf(len)
       LibC.snprintf(temp_buf, len, format_buf, float)
 
-      @io.write_utf8 Slice.new(temp_buf, len - 1)
+      @io.write_string Slice.new(temp_buf, len - 1)
     else
       raise ArgumentError.new("Expected a float, not #{arg.inspect}")
     end


### PR DESCRIPTION
> `#write_utf8` appears as if it should be used when writing UTF-8 characters. But in fact, it must be used for *any* string, even if it consists entirely of ASCII characters (they're technically also UTF-8 but we typically differentiate between (non-ASCII) UTF-8 and ASCII (UTF-8) characters for practical purposes).
> 
> I'd propose to rename that method to a more expressive name: `#write_string`

Ref https://github.com/crystal-lang/crystal/issues/11009#issuecomment-886178292