### PR TITLE
Adds Client Credentials Overload

### DIFF
--- a/spec/std/oauth2/client_spec.cr
+++ b/spec/std/oauth2/client_spec.cr
@@ -110,6 +110,25 @@ describe OAuth2::Client do
           token.access_token.should eq "access_token"
         end
       end
+      
+      it "#get_access_token_using_client_credentials" do
+        handler = HTTP::Handler::HandlerProc.new do |context|
+          body = context.request.body.not_nil!.gets_to_end
+          response = {access_token: "access_token", body: body}
+          context.response.print response.to_json
+        end
+
+        run_handler(handler) do |http_client|
+          client_id = "example_client"
+          client_secret = "example_client_secret"
+          client = OAuth2::Client.new "127.0.0.1", "client_id", "client_secret", scheme: "http"
+          client.http_client = http_client
+
+          token = client.get_access_token_using_client_credentials(client_id, client_secret, scope: "read_posts")
+          token.extra.not_nil!["body"].should eq %("grant_type=client_credentials&client_id=example_client&client_secret=example_client_secret&scope=read_posts")
+          token.access_token.should eq "access_token"
+        end
+      end
 
       it "#get_access_token_using_refresh_token" do
         handler = HTTP::Handler::HandlerProc.new do |context|

--- a/src/oauth2/client.cr
+++ b/src/oauth2/client.cr
@@ -148,6 +148,15 @@ class OAuth2::Client
       form.add("scope", scope) unless scope.nil?
     end
   end
+  
+  def get_access_token_using_client_credentials(client_id : String, secret : String, scope = nil) : AccessToken
+    get_access_token do |form|
+      form.add("grant_type", "client_credentials")
+      form.add("client_id", client_id)
+      form.add("client_secret", secret)
+      form.add("scope", scope) unless scope.nil?
+    end
+  end
 
   # Gets an access token using a refresh token, as specified by
   # [RFC 6749, Section 6](https://tools.ietf.org/html/rfc6749#section-6).


### PR DESCRIPTION
### Why this change?

While the RFC does not required the client credentials for security purposes is best to authenticate the client using the client_id and secret. Many libraries from other languages also implement the client_id and client_secret authentication for the client credentials grant. 

### Changes 

- Adds method overload to the OAuth2::Client for client credentials that accepts client id, client secret and scope

### Side Effects

- No regression side effects 
- Enables client credentials grant to authenticate clients using client id and client secret.