### PR TITLE
Add module Sortable(T)

### DIFF
--- a/src/array.cr
+++ b/src/array.cr
@@ -48,6 +48,7 @@
 class Array(T)
   include Indexable(T)
   include Comparable(Array)
+  include Sortable(T)
 
   # Size of an Array that we consider small to do linear scans or other optimizations.
   private SMALL_ARRAY_SIZE = 16
@@ -1663,96 +1664,20 @@ class Array(T)
     self
   end
 
-  # Returns a new array with all elements sorted based on the return value of
-  # their comparison method `#<=>`
-  #
-  # ```
-  # a = [3, 1, 2]
-  # a.sort # => [1, 2, 3]
-  # a      # => [3, 1, 2]
-  # ```
-  def sort : Array(T)
-    dup.sort!
-  end
-
-  # :ditto:
-  #
-  # This method does not guarantee stability between equally sorting elements.
-  # Which results in a performance advantage over stable sort.
-  def unstable_sort : Array(T)
-    dup.unstable_sort!
-  end
-
-  # Returns a new array with all elements sorted based on the comparator in the
-  # given block.
-  #
-  # The block must implement a comparison between two elements *a* and *b*,
-  # where `a < b` returns `-1`, `a == b` returns `0`, and `a > b` returns `1`.
-  # The comparison operator `<=>` can be used for this.
-  #
-  # ```
-  # a = [3, 1, 2]
-  # b = a.sort { |a, b| b <=> a }
-  #
-  # b # => [3, 2, 1]
-  # a # => [3, 1, 2]
-  # ```
-  def sort(&block : T, T -> U) : Array(T) forall U
-    {% unless U <= Int32? %}
-      {% raise "expected block to return Int32 or Nil, not #{U}" %}
-    {% end %}
-
-    dup.sort! &block
-  end
-
-  # :ditto:
-  #
-  # This method does not guarantee stability between equally sorting elements.
-  # Which results in a performance advantage over stable sort.
-  def unstable_sort(&block : T, T -> U) : Array(T) forall U
-    {% unless U <= Int32? %}
-      {% raise "expected block to return Int32 or Nil, not #{U}" %}
-    {% end %}
-
-    dup.unstable_sort!(&block)
-  end
-
-  # Modifies `self` by sorting all elements based on the return value of their
-  # comparison method `#<=>`
-  #
-  # ```
-  # a = [3, 1, 2]
-  # a.sort!
-  # a # => [1, 2, 3]
-  # ```
-  def sort! : Array(T)
+  # :inherit:
+  def sort! : self
     to_unsafe_slice.sort!
     self
   end
 
-  # :ditto:
-  #
-  # This method does not guarantee stability between equally sorting elements.
-  # Which results in a performance advantage over stable sort.
-  def unstable_sort! : Array(T)
+  # :inherit:
+  def unstable_sort! : self
     to_unsafe_slice.unstable_sort!
     self
   end
 
-  # Modifies `self` by sorting all elements based on the comparator in the given
-  # block.
-  #
-  # The given block must implement a comparison between two elements
-  # *a* and *b*, where `a < b` returns `-1`, `a == b` returns `0`,
-  # and `a > b` returns `1`.
-  # The comparison operator `<=>` can be used for this.
-  #
-  # ```
-  # a = [3, 1, 2]
-  # a.sort! { |a, b| b <=> a }
-  # a # => [3, 2, 1]
-  # ```
-  def sort!(&block : T, T -> U) : Array(T) forall U
+  # :inherit:
+  def sort!(&block : T, T -> U) : self forall U
     {% unless U <= Int32? %}
       {% raise "expected block to return Int32 or Nil, not #{U}" %}
     {% end %}
@@ -1761,11 +1686,8 @@ class Array(T)
     self
   end
 
-  # :ditto:
-  #
-  # This method does not guarantee stability between equally sorting elements.
-  # Which results in a performance advantage over stable sort.
-  def unstable_sort!(&block : T, T -> U) : Array(T) forall U
+  # :inherit:
+  def unstable_sort!(&block : T, T -> U) : self forall U
     {% unless U <= Int32? %}
       {% raise "expected block to return Int32 or Nil, not #{U}" %}
     {% end %}
@@ -1774,54 +1696,15 @@ class Array(T)
     self
   end
 
-  # Returns a new array with all elements sorted. The given block is called for
-  # each element, then the comparison method #<=> is called on the object
-  # returned from the block to determine sort order.
-  #
-  # ```
-  # a = %w(apple pear fig)
-  # b = a.sort_by { |word| word.size }
-  # b # => ["fig", "pear", "apple"]
-  # a # => ["apple", "pear", "fig"]
-  # ```
-  def sort_by(&block : T -> _) : Array(T)
-    dup.sort_by! { |e| yield(e) }
-  end
-
-  # :ditto:
-  #
-  # This method does not guarantee stability between equally sorting elements.
-  # Which results in a performance advantage over stable sort.
-  def unstable_sort_by(&block : T -> _) : Array(T)
-    dup.unstable_sort_by! { |e| yield(e) }
-  end
-
-  # Modifies `self` by sorting all elements. The given block is called for
-  # each element, then the comparison method #<=> is called on the object
-  # returned from the block to determine sort order.
-  #
-  # ```
-  # a = %w(apple pear fig)
-  # a.sort_by! { |word| word.size }
-  # a # => ["fig", "pear", "apple"]
-  # ```
-  def sort_by!(&block : T -> _) : Array(T)
-    sorted = map { |e| {e, yield(e)} }.sort! { |x, y| x[1] <=> y[1] }
-    @size.times do |i|
-      @buffer[i] = sorted.to_unsafe[i][0]
-    end
+  # :inherit:
+  def sort_by!(&block : T -> _) : self
+    to_unsafe_slice.sort_by! { |t| yield t }
     self
   end
 
-  # :ditto:
-  #
-  # This method does not guarantee stability between equally sorting elements.
-  # Which results in a performance advantage over stable sort.
-  def unstable_sort_by!(&block : T -> _) : Array(T)
-    sorted = map { |e| {e, yield(e)} }.unstable_sort! { |x, y| x[1] <=> y[1] }
-    @size.times do |i|
-      @buffer[i] = sorted.to_unsafe[i][0]
-    end
+  # :inherit:
+  def unstable_sort_by!(&block : T -> _) : self
+    to_unsafe_slice.unstable_sort_by! { |t| yield t }
     self
   end
 

--- a/src/prelude.cr
+++ b/src/prelude.cr
@@ -13,6 +13,7 @@ require "lib_c"
 require "macros"
 require "object"
 require "comparable"
+require "sortable"
 {% if flag?(:win32) %}
   require "windows_stubs"
 {% end %}

--- a/src/slice.cr
+++ b/src/slice.cr
@@ -13,6 +13,7 @@ require "slice/sort"
 struct Slice(T)
   include Indexable(T)
   include Comparable(Slice)
+  include Sortable(T)
 
   # Creates a new `Slice` with the given *args*. The type of the
   # slice will be the union of the type of the given *args*.
@@ -729,98 +730,22 @@ struct Slice(T)
     @pointer
   end
 
-  # Returns a new slice with all elements sorted based on the return value of
-  # their comparison method `<=>`
-  #
-  # ```
-  # a = Slice[3, 1, 2]
-  # a.sort # => Slice[1, 2, 3]
-  # a      # => Slice[3, 1, 2]
-  # ```
-  def sort : Slice(T)
-    dup.sort!
-  end
-
-  # :ditto:
-  #
-  # This method does not guarantee stability between equally sorting elements.
-  # Which results in a performance advantage over stable sort.
-  def unstable_sort : Slice(T)
-    dup.unstable_sort!
-  end
-
-  # Returns a new slice with all elements sorted based on the comparator in the
-  # given block.
-  #
-  # The block must implement a comparison between two elements *a* and *b*,
-  # where `a < b` returns `-1`, `a == b` returns `0`, and `a > b` returns `1`.
-  # The comparison operator `<=>` can be used for this.
-  #
-  # ```
-  # a = Slice[3, 1, 2]
-  # b = a.sort { |a, b| b <=> a }
-  #
-  # b # => Slice[3, 2, 1]
-  # a # => Slice[3, 1, 2]
-  # ```
-  def sort(&block : T, T -> U) : Slice(T) forall U
-    {% unless U <= Int32? %}
-      {% raise "expected block to return Int32 or Nil, not #{U}" %}
-    {% end %}
-
-    dup.sort! &block
-  end
-
-  # :ditto:
-  #
-  # This method does not guarantee stability between equally sorting elements.
-  # Which results in a performance advantage over stable sort.
-  def unstable_sort(&block : T, T -> U) : Slice(T) forall U
-    {% unless U <= Int32? %}
-      {% raise "expected block to return Int32 or Nil, not #{U}" %}
-    {% end %}
-
-    dup.unstable_sort!(&block)
-  end
-
-  # Modifies `self` by sorting all elements based on the return value of their
-  # comparison method `<=>`
-  #
-  # ```
-  # a = Slice[3, 1, 2]
-  # a.sort!
-  # a # => Slice[1, 2, 3]
-  # ```
-  def sort! : Slice(T)
+  # :inherit:
+  def sort! : self
     Slice.merge_sort!(self)
 
     self
   end
 
-  # :ditto:
-  #
-  # This method does not guarantee stability between equally sorting elements.
-  # Which results in a performance advantage over stable sort.
-  def unstable_sort! : Slice(T)
+  # :inherit:
+  def unstable_sort! : self
     Slice.intro_sort!(to_unsafe, size)
 
     self
   end
 
-  # Modifies `self` by sorting all elements based on the comparator in the given
-  # block.
-  #
-  # The given block must implement a comparison between two elements
-  # *a* and *b*, where `a < b` returns `-1`, `a == b` returns `0`,
-  # and `a > b` returns `1`.
-  # The comparison operator `<=>` can be used for this.
-  #
-  # ```
-  # a = Slice[3, 1, 2]
-  # a.sort! { |a, b| b <=> a }
-  # a # => Slice[3, 2, 1]
-  # ```
-  def sort!(&block : T, T -> U) : Slice(T) forall U
+  # :inherit:
+  def sort!(&block : T, T -> U) : self forall U
     {% unless U <= Int32? %}
       {% raise "expected block to return Int32 or Nil, not #{U}" %}
     {% end %}
@@ -830,11 +755,8 @@ struct Slice(T)
     self
   end
 
-  # :ditto:
-  #
-  # This method does not guarantee stability between equally sorting elements.
-  # Which results in a performance advantage over stable sort.
-  def unstable_sort!(&block : T, T -> U) : Slice(T) forall U
+  # :inherit:
+  def unstable_sort!(&block : T, T -> U) : self forall U
     {% unless U <= Int32? %}
       {% raise "expected block to return Int32 or Nil, not #{U}" %}
     {% end %}
@@ -844,38 +766,8 @@ struct Slice(T)
     self
   end
 
-  # Returns a new array with all elements sorted. The given block is called for
-  # each element, then the comparison method `<=>` is called on the object
-  # returned from the block to determine sort order.
-  #
-  # ```
-  # a = Slice["apple", "pear", "fig"]
-  # b = a.sort_by { |word| word.size }
-  # b # => Slice["fig", "pear", "apple"]
-  # a # => Slice["apple", "pear", "fig"]
-  # ```
-  def sort_by(&block : T -> _) : Slice(T)
-    dup.sort_by! { |e| yield(e) }
-  end
-
-  # :ditto:
-  #
-  # This method does not guarantee stability between equally sorting elements.
-  # Which results in a performance advantage over stable sort.
-  def unstable_sort_by(&block : T -> _) : Slice(T)
-    dup.unstable_sort_by! { |e| yield(e) }
-  end
-
-  # Modifies `self` by sorting all elements. The given block is called for
-  # each element, then the comparison method `<=>` is called on the object
-  # returned from the block to determine sort order.
-  #
-  # ```
-  # a = Slice["apple", "pear", "fig"]
-  # a.sort_by! { |word| word.size }
-  # a # => Slice["fig", "pear", "apple"]
-  # ```
-  def sort_by!(&block : T -> _) : Slice(T)
+  # :inherit:
+  def sort_by!(&block : T -> _) : self
     sorted = map { |e| {e, yield(e)} }.sort! { |x, y| x[1] <=> y[1] }
     size.times do |i|
       to_unsafe[i] = sorted.to_unsafe[i][0]
@@ -883,11 +775,8 @@ struct Slice(T)
     self
   end
 
-  # :ditto:
-  #
-  # This method does not guarantee stability between equally sorting elements.
-  # Which results in a performance advantage over stable sort.
-  def unstable_sort_by!(&block : T -> _) : Slice(T)
+  # :inherit:
+  def unstable_sort_by!(&block : T -> _) : self
     sorted = map { |e| {e, yield(e)} }.unstable_sort! { |x, y| x[1] <=> y[1] }
     size.times do |i|
       to_unsafe[i] = sorted.to_unsafe[i][0]

--- a/src/sortable.cr
+++ b/src/sortable.cr
@@ -1,0 +1,252 @@
+module Sortable(T)
+  # Returns a new instance with all elements sorted based on the return value of
+  # their comparison method `T#<=>` (see `Comparable`), using a stable sort algorithm.
+  #
+  # ```
+  # a = [3, 1, 2]
+  # a.sort # => [1, 2, 3]
+  # a      # => [3, 1, 2]
+  # ```
+  #
+  # See `#sort!` for details on the sorting mechanism.
+  def sort : self
+    dup.sort!
+  end
+
+  # Returns a new instance with all elements sorted based on the return value of
+  # their comparison method `T#<=>` (see `Comparable`).
+  #
+  # The sort is unstable.
+  #
+  # ```
+  # a = [3, 1, 2]
+  # a.sort # => [1, 2, 3]
+  # a      # => [3, 1, 2]
+  # ```
+  #
+  # See `#unstable_sort!` for details on the sorting mechanism.
+  def unstable_sort : self
+    dup.unstable_sort!
+  end
+
+  # Returns a new instance with all elements sorted based on the comparator in the
+  # given block, using a stable sort algorithm.
+  #
+  # ```
+  # a = [3, 1, 2]
+  # b = a.sort { |a, b| b <=> a }
+  #
+  # b # => [3, 2, 1]
+  # a # => [3, 1, 2]
+  # ```
+  #
+  # See `#sort!(&block : T, T -> U)` for details on the sorting mechanism.
+  def sort(&block : T, T -> U) : self forall U
+    {% unless U <= Int32? %}
+      {% raise "expected block to return Int32 or Nil, not #{U}" %}
+    {% end %}
+
+    dup.sort! &block
+  end
+
+  # Returns a new instance with all elements sorted based on the comparator in the
+  # given block.
+  #
+  # ```
+  # a = [3, 1, 2]
+  # b = a.unstable_sort { |a, b| b <=> a }
+  #
+  # b # => [3, 2, 1]
+  # a # => [3, 1, 2]
+  # ```
+  #
+  # See `#unstable_sort!(&block : T, T -> U)` for details on the sorting mechanism.
+  def unstable_sort(&block : T, T -> U) : self forall U
+    {% unless U <= Int32? %}
+      {% raise "expected block to return Int32 or Nil, not #{U}" %}
+    {% end %}
+
+    dup.unstable_sort!(&block)
+  end
+
+  # Sorts all elements in `self` based on the return value of the comparison
+  # method `T#<=>` (see `Comparable`), using a stable sort algorithm.
+  #
+  # ```
+  # a = [3, 1, 2]
+  # a.sort!
+  # a # => [1, 2, 3]
+  # ```
+  #
+  # This sort operation modifies `self`. See `#sort` for a non-modifying option
+  # that allocates a new instance.
+  #
+  # The sort mechanism is stable, which is typically a good default.
+  #
+  # Stablility means that two elements which compare equal (i.e. `a <=> b == 0`)
+  # keep their original relation. Stable sort guarantees that `[a, b].sort!`
+  # always results in `[a, b]` (given they compare equal). With unstable sort,
+  # the result could also be `[b, a]`.
+  #
+  # If stability is expendable, `#unstable_sort!` performance advantage over
+  # stable sort.
+  abstract def sort! : Sortable(T)
+
+  # Sorts all elements in `self` based on the return value of the comparison
+  # method `T#<=>` (see `Comparable`).
+  #
+  # ```
+  # a = [3, 1, 2]
+  # a.unstable_sort!
+  # a # => [1, 2, 3]
+  # ```
+  #
+  # This sort operation modifies `self`. See `#unstable_sort` for a non-modifying
+  # option that allocates a new instance.
+  #
+  # The sort mechanism does not guarantee stability between equally comparing
+  # elements. This offers higher performance but may be unexpected in some situations.
+  #
+  # Stablility means that two elements which compare equal (i.e. `a <=> b == 0`)
+  # keep their original relation. Stable sort guarantees that `[a, b].sort!`
+  # always results in `[a, b]` (given they compare equal). With unstable sort,
+  # the result could also be `[b, a]`.
+  #
+  # If stability is necessary, use  `#sort!` instead.
+  abstract def unstable_sort! : Sortable(T)
+
+  # Sorts all elements in `self` based on the comparator in the given block, using
+  # a stable sort algorithm.
+  #
+  # The block must implement a comparison between two elements *a* and *b*,
+  # where `a < b` returns `-1`, `a == b` returns `0`, and `a > b` returns `1`.
+  # The comparison operator `<=>` can be used for this.
+  #
+  # ```
+  # a = [3, 1, 2]
+  # # This is a reverse sort (forward sort would be `a <=> b`)
+  # a.sort! { |a, b| b <=> a }
+  # a # => [3, 2, 1]
+  # ```
+  #
+  # This sort operation modifies `self`. See `#sort(&block : T, T -> U)` for a
+  # non-modifying option that allocates a new instance.
+  #
+  # The sort mechanism is stable, which is typically a good default.
+  #
+  # Stablility means that two elements which compare equal (i.e. `a <=> b == 0`)
+  # keep their original relation. Stable sort guarantees that `[a, b].sort!`
+  # always results in `[a, b]` (given they compare equal). With unstable sort,
+  # the result could also be `[b, a]`.
+  #
+  # If stability is expendable, `#unstable_sort!(&block : T, T -> U)` performance
+  # advantage over stable sort.
+  abstract def sort!(&block : T, T -> U) : Sortable(T) forall U
+
+  # Sorts all elements in `self` based on the comparator in the given block.
+  #
+  # The block must implement a comparison between two elements *a* and *b*,
+  # where `a < b` returns `-1`, `a == b` returns `0`, and `a > b` returns `1`.
+  # The comparison operator `<=>` can be used for this.
+  #
+  # ```
+  # a = [3, 1, 2]
+  # # This is a reverse sort (forward sort would be `a <=> b`)
+  # a.unstable_sort! { |a, b| b <=> a }
+  # a # => [3, 2, 1]
+  # ```
+  #
+  # This sort operation modifies `self`. See `#unstable_sort(&block : T, T -> U)`
+  # for a non-modifying option that allocates a new instance.
+  #
+  # The sort mechanism does not guarantee stability between equally comparing
+  # elements. This offers higher performance but may be unexpected in some situations.
+  #
+  # Stablility means that two elements which compare equal (i.e. `a <=> b == 0`)
+  # keep their original relation. Stable sort guarantees that `[a, b].sort!`
+  # always results in `[a, b]` (given they compare equal). With unstable sort,
+  # the result could also be `[b, a]`.
+  #
+  # If stability is necessary, use  `#sort!(&block : T, T -> U)` instead.
+  abstract def unstable_sort!(&block : T, T -> U) : Sortable(T) forall U
+
+  # Returns a new instance with all elements sorted by the output value of the
+  # block. The output values are compared via the comparison method `T#<=>`
+  # (see `Comparable`), using a stable sort algorithm.
+  #
+  # ```
+  # a = %w(apple pear fig)
+  # b = a.sort_by { |word| word.size }
+  # b # => ["fig", "pear", "apple"]
+  # a # => ["apple", "pear", "fig"]
+  # ```
+  #
+  # See `#sort_by!(&block : T -> _)` for details on the sorting mechanism.
+  def sort_by(&block : T -> _) : self
+    dup.sort_by! { |e| yield(e) }
+  end
+
+  # Returns a new instance with all elements sorted by the output value of the
+  # block. The output values are compared via the comparison method `#<=>`
+  # (see `Comparable`).
+  #
+  # ```
+  # a = %w(apple pear fig)
+  # b = a.unstable_sort_by { |word| word.size }
+  # b # => ["fig", "pear", "apple"]
+  # a # => ["apple", "pear", "fig"]
+  # ```
+  #
+  # See `#unstable_sort!(&block : T -> _)` for details on the sorting mechanism.
+  def unstable_sort_by(&block : T -> _) : self
+    dup.unstable_sort_by! { |e| yield(e) }
+  end
+
+  # Sorts all elements in `self` by the output value of the
+  # block. The output values are compared via the comparison method `#<=>`
+  # (see `Comparable`), using a stable sort algorithm.
+  #
+  # ```
+  # a = %w(apple pear fig)
+  # a.sort_by! { |word| word.size }
+  # a # => ["fig", "pear", "apple"]
+  # ```
+  #
+  # This sort operation modifies `self`. See `#sort_by(&block : T -> _)` for a
+  # non-modifying option that allocates a new instance.
+  #
+  # The sort mechanism is stable, which is typically a good default.
+  #
+  # Stablility means that two elements which compare equal (i.e. `a <=> b == 0`)
+  # keep their original relation. Stable sort guarantees that `[a, b].sort!`
+  # always results in `[a, b]` (given they compare equal). With unstable sort,
+  # the result could also be `[b, a]`.
+  #
+  # If stability is expendable, `#unstable_sort!(&block : T -> _)` performance
+  # advantage over stable sort.
+  abstract def sort_by!(&block : T -> _) : Sortable(T)
+
+  # Sorts all elements in `self` by the output value of the
+  # block. The output values are compared via the comparison method `#<=>`
+  # (see `Comparable`).
+  #
+  # ```
+  # a = %w(apple pear fig)
+  # a.usntable_sort_by! { |word| word.size }
+  # a # => ["fig", "pear", "apple"]
+  # ```
+  #
+  # This sort operation modifies `self`. See `#unstable_sort_by(&block : T -> _)`
+  # for a non-modifying option that allocates a new instance.
+  #
+  # The sort mechanism does not guarantee stability between equally comparing
+  # elements. This offers higher performance but may be unexpected in some situations.
+  #
+  # Stablility means that two elements which compare equal (i.e. `a <=> b == 0`)
+  # keep their original relation. Stable sort guarantees that `[a, b].sort!`
+  # always results in `[a, b]` (given they compare equal). With unstable sort,
+  # the result could also be `[b, a]`.
+  #
+  # If stability is necessary, use  `#sort_by!(&block : T -> _)` instead.
+  abstract def unstable_sort_by!(&block : T -> _) : Sortable(T)
+end


### PR DESCRIPTION
Follow-up on #11029 continuing the proposal from https://github.com/crystal-lang/crystal/issues/6057#issuecomment-886083888 to combine common sort behaviour in a generic module.

The implementation of all non-modifying sort methods (without bang) is extracted to `Sortable(T)` and it also defines the interface for all modifying sort methods (with bang).

Inheriting types only need to implement the modifying methods (which are very similar for the current types). Making `StaticArray` sortable (#10889) works as well, but is not part of this PR (only a little modification is necessary to break the dup method chain to get proper copy behaviour). The interface should also work for other, non-slice based collection types (like `Deque`) as long as they implement the respective modifying sort methods (and `#dup`).



