### PR TITLE
Add the `Indexable::Mutable(T)` module

### DIFF
--- a/spec/std/indexable/mutable_spec.cr
+++ b/spec/std/indexable/mutable_spec.cr
@@ -1,0 +1,268 @@
+require "spec"
+
+private class SafeIndexableMutable
+  include Indexable::Mutable(Int32)
+
+  getter size
+
+  @values : Array(Tuple(Int32))
+
+  def initialize(@size : Int32, *, offset = 0)
+    @values = Array.new(size) { |i| {i + offset} }
+  end
+
+  def unsafe_fetch(i)
+    raise IndexError.new unless 0 <= i < size
+    @values[i][0]
+  end
+
+  def unsafe_put(i, value : Int32)
+    raise IndexError.new unless 0 <= i < size
+    @values[i] = {value}
+  end
+end
+
+private class Foo
+end
+
+private class SafeIndexableMutableFoo
+  include Indexable::Mutable(Foo)
+
+  getter size
+
+  @values : Array(Tuple(Foo))
+
+  def initialize(@size : Int32)
+    @values = Array.new(size) { {Foo.new} }
+  end
+
+  def unsafe_fetch(i)
+    raise IndexError.new unless 0 <= i < size
+    @values[i][0]
+  end
+
+  def unsafe_put(i, value : Foo)
+    raise IndexError.new unless 0 <= i < size
+    @values[i] = {value}
+  end
+end
+
+describe Indexable::Mutable do
+  # General note: code that tests `#method!` must not rely on the results of
+  # `#method`, as otherwise those tests would trivially pass if the latter were
+  # implemented as `to_a.method!`
+
+  describe "#[]=" do
+    it "sets the value at the given index" do
+      coll = SafeIndexableMutable.new(5)
+      (coll[2] = 123).should eq(123)
+      coll[2].should eq(123)
+
+      coll = SafeIndexableMutableFoo.new(5)
+      foo = Foo.new
+      (coll[2] = foo).should be(foo)
+      coll[2].should be(foo)
+    end
+
+    it "wraps negative indices" do
+      coll = SafeIndexableMutable.new(5)
+      (coll[-2] = 123).should eq(123)
+      coll[3].should eq(123)
+
+      (coll[-5] = 456).should eq(456)
+      coll[0].should eq(456)
+    end
+
+    it "raises on out-of-bound indices" do
+      expect_raises(IndexError) { SafeIndexableMutable.new(5)[5] = 0 }
+      expect_raises(IndexError) { SafeIndexableMutable.new(5)[-6] = 0 }
+    end
+  end
+
+  describe "#update" do
+    it "updates the value at the given index with the block" do
+      coll = SafeIndexableMutable.new(5)
+      coll.update(2) { |x| x + 7 }.should eq(9)
+      coll[2].should eq(9)
+
+      coll = SafeIndexableMutableFoo.new(5)
+      foo = Foo.new
+      coll.update(2) { foo }.should be(foo)
+      coll[2].should be(foo)
+    end
+
+    it "wraps negative indices" do
+      coll = SafeIndexableMutable.new(5)
+      coll.update(-2) { |x| x + 7 }.should eq(10)
+      coll[3].should eq(10)
+
+      coll.update(-5) { |x| x + 14 }.should eq(14)
+      coll[0].should eq(14)
+    end
+
+    it "raises on out-of-bound indices" do
+      expect_raises(IndexError) { SafeIndexableMutable.new(5).update(5, &.itself) }
+      expect_raises(IndexError) { SafeIndexableMutable.new(5).update(-6, &.itself) }
+    end
+  end
+
+  describe "#swap" do
+    it "exchanges the values at two indices" do
+      coll = SafeIndexableMutable.new(12, offset: 50)
+      coll.swap(2, 7).should be(coll)
+      coll[2].should eq(57)
+      coll[7].should eq(52)
+
+      coll = SafeIndexableMutableFoo.new(12)
+      foo2 = coll[2]
+      foo7 = coll[7]
+      coll.swap(2, 7).should be(coll)
+      coll[2].should be(foo7)
+      coll[7].should be(foo2)
+    end
+
+    it "wraps negative indices" do
+      coll = SafeIndexableMutable.new(12, offset: 50)
+      coll.swap(-3, -7).should be(coll)
+      coll[9].should eq(55)
+      coll[5].should eq(59)
+    end
+
+    it "raises on out-of-bound indices" do
+      expect_raises(IndexError) { SafeIndexableMutable.new(5).swap(5, 5) }
+      expect_raises(IndexError) { SafeIndexableMutable.new(5).swap(-6, -6) }
+    end
+  end
+
+  describe "#reverse!" do
+    it "reverses the order of all elements in place" do
+      coll = SafeIndexableMutable.new(5)
+      coll.reverse!.should be(coll)
+      coll.to_a.should eq([4, 3, 2, 1, 0])
+
+      coll = SafeIndexableMutable.new(8)
+      coll.reverse!.should be(coll)
+      coll.to_a.should eq([7, 6, 5, 4, 3, 2, 1, 0])
+
+      coll = SafeIndexableMutableFoo.new(5)
+      foos = coll.to_a
+      coll.reverse!.should be(coll)
+      coll.to_a.should eq([foos[4], foos[3], foos[2], foos[1], foos[0]])
+
+      coll = SafeIndexableMutableFoo.new(8)
+      foos = coll.to_a
+      coll.reverse!.should be(coll)
+      coll.to_a.should eq([foos[7], foos[6], foos[5], foos[4], foos[3], foos[2], foos[1], foos[0]])
+    end
+  end
+
+  describe "#fill" do
+    context "without block" do
+      it "sets all elements to the same value" do
+        coll = SafeIndexableMutable.new(5)
+        coll.fill(4)
+        coll.to_a.should eq([4, 4, 4, 4, 4])
+
+        coll = SafeIndexableMutableFoo.new(5)
+        foo = Foo.new
+        coll.fill(foo)
+        coll.to_a.should eq([foo, foo, foo, foo, foo])
+      end
+    end
+
+    context "with block" do
+      it "yields index to the block and sets all elements" do
+        coll = SafeIndexableMutable.new(5)
+        coll.fill { |i| i * i }
+        coll.to_a.should eq([0, 1, 4, 9, 16])
+
+        coll = SafeIndexableMutableFoo.new(5)
+        foo = Foo.new
+        coll.fill { foo }
+        coll.to_a.should eq([foo, foo, foo, foo, foo])
+      end
+    end
+
+    context "with block + offset" do
+      it "yields index plus offset to the block and sets all elements" do
+        coll = SafeIndexableMutable.new(5)
+        coll.fill(offset: 7) { |i| i * i }
+        coll.to_a.should eq([49, 64, 81, 100, 121])
+
+        coll = SafeIndexableMutableFoo.new(5)
+        foos = coll.to_a
+        coll.fill(offset: -2) { |i| foos[i] }
+        coll.to_a.should eq([foos[-2], foos[-1], foos[0], foos[1], foos[2]])
+      end
+    end
+  end
+
+  describe "#map!" do
+    it "replaces each element with the block value" do
+      coll = SafeIndexableMutable.new(5, offset: 2)
+      coll.map! { |i| 10 - i }
+      coll.to_a.should eq([8, 7, 6, 5, 4])
+
+      coll = SafeIndexableMutableFoo.new(5)
+      foos = coll.to_a
+      coll.map! &.itself
+      coll.to_a.should eq(foos)
+    end
+  end
+
+  describe "#map_with_index!" do
+    context "without offset" do
+      it "yields each element and index to the block" do
+        coll = SafeIndexableMutable.new(5)
+        coll[2] = 4
+        coll[4] = 7
+        coll.map_with_index! { |v, i| v * 100 + i }
+        coll.to_a.should eq([0, 101, 402, 303, 704])
+      end
+    end
+
+    context "with offset" do
+      it "yields each element and index plus offset to the block" do
+        coll = SafeIndexableMutable.new(5)
+        coll[2] = 4
+        coll[4] = 7
+        coll.map_with_index!(offset: 4) { |v, i| v * 100 + i }
+        coll.to_a.should eq([4, 105, 406, 307, 708])
+      end
+    end
+  end
+
+  describe "#shuffle!" do
+    it "randomizes the order of all elements" do
+      coll = SafeIndexableMutable.new(5)
+      coll.shuffle!(Random.new(42)).should be(coll)
+      coll.to_a.should eq([2, 1, 3, 4, 0])
+
+      coll = SafeIndexableMutableFoo.new(5)
+      foos = coll.to_a
+      coll.shuffle!(Random.new(42)).should be(coll)
+      coll.to_a.should eq([foos[2], foos[1], foos[3], foos[4], foos[0]])
+    end
+  end
+
+  describe "#rotate!" do
+    it "left-shifts all elements" do
+      coll = SafeIndexableMutable.new(5)
+      coll.rotate!(2).should be(coll)
+      coll.to_a.should eq([2, 3, 4, 0, 1])
+
+      coll = SafeIndexableMutableFoo.new(5)
+      foos = coll.to_a
+      coll.rotate!(3).should be(coll)
+      coll.to_a.should eq([foos[3], foos[4], foos[0], foos[1], foos[2]])
+
+      SafeIndexableMutable.new(6).rotate!(2).to_a.should eq([2, 3, 4, 5, 0, 1])
+      SafeIndexableMutable.new(6).rotate!(0).to_a.should eq([0, 1, 2, 3, 4, 5])
+      SafeIndexableMutable.new(6).rotate!(12).to_a.should eq([0, 1, 2, 3, 4, 5])
+      SafeIndexableMutable.new(6).rotate!(-1).to_a.should eq([5, 0, 1, 2, 3, 4])
+      SafeIndexableMutable.new(10).rotate!(6).to_a.should eq([6, 7, 8, 9, 0, 1, 2, 3, 4, 5])
+      SafeIndexableMutable.new(10).rotate!(12345678).to_a.should eq([8, 9, 0, 1, 2, 3, 4, 5, 6, 7])
+      SafeIndexableMutable.new(10).rotate!(-1234567).to_a.should eq([3, 4, 5, 6, 7, 8, 9, 0, 1, 2])
+    end
+  end
+end

--- a/spec/std/indexable/mutable_spec.cr
+++ b/spec/std/indexable/mutable_spec.cr
@@ -5,10 +5,11 @@ private class SafeIndexableMutable
 
   getter size
 
-  @values : Array(Tuple(Int32))
+  # prevents `@values` from being interpretable as a raw slice of elements
+  @values : Array(Array(Int32))
 
   def initialize(@size : Int32, *, offset = 0)
-    @values = Array.new(size) { |i| {i + offset} }
+    @values = Array.new(size) { |i| [i + offset] }
   end
 
   def unsafe_fetch(i)
@@ -18,7 +19,7 @@ private class SafeIndexableMutable
 
   def unsafe_put(i, value : Int32)
     raise IndexError.new unless 0 <= i < size
-    @values[i] = {value}
+    @values[i] = [value]
   end
 end
 
@@ -30,10 +31,10 @@ private class SafeIndexableMutableFoo
 
   getter size
 
-  @values : Array(Tuple(Foo))
+  @values : Array(Array(Foo))
 
   def initialize(@size : Int32)
-    @values = Array.new(size) { {Foo.new} }
+    @values = Array.new(size) { [Foo.new] }
   end
 
   def unsafe_fetch(i)
@@ -43,7 +44,7 @@ private class SafeIndexableMutableFoo
 
   def unsafe_put(i, value : Foo)
     raise IndexError.new unless 0 <= i < size
-    @values[i] = {value}
+    @values[i] = [value]
   end
 end
 

--- a/spec/std/slice_spec.cr
+++ b/spec/std/slice_spec.cr
@@ -557,14 +557,27 @@ describe "Slice" do
 
   it "creates read-only slice" do
     slice = Slice.new(3, 0, read_only: true)
+    slice.read_only?.should be_true
     expect_raises(Exception, "Can't write to read-only Slice") { slice[0] = 1 }
+    expect_raises(Exception, "Can't write to read-only Slice") { slice.update(0, &.itself) }
+    expect_raises(Exception, "Can't write to read-only Slice") { slice.swap(0, 1) }
+    expect_raises(Exception, "Can't write to read-only Slice") { slice.reverse! }
     expect_raises(Exception, "Can't write to read-only Slice") { slice.fill(0) }
+    expect_raises(Exception, "Can't write to read-only Slice") { slice.fill(&.itself) }
+    expect_raises(Exception, "Can't write to read-only Slice") { slice.fill(offset: 0, &.itself) }
+    expect_raises(Exception, "Can't write to read-only Slice") { slice.map!(&.itself) }
+    expect_raises(Exception, "Can't write to read-only Slice") { slice.map_with_index! { |v, i| v } }
+    expect_raises(Exception, "Can't write to read-only Slice") { slice.map_with_index!(offset: 0) { |v, i| v } }
+    expect_raises(Exception, "Can't write to read-only Slice") { slice.shuffle! }
+    expect_raises(Exception, "Can't write to read-only Slice") { slice.rotate!(0) }
     expect_raises(Exception, "Can't write to read-only Slice") { slice.copy_from(slice) }
 
     subslice = slice[0, 1]
+    subslice.read_only?.should be_true
     expect_raises(Exception, "Can't write to read-only Slice") { subslice[0] = 1 }
 
     slice = Bytes[1, 2, 3, read_only: true]
+    slice.read_only?.should be_true
     expect_raises(Exception, "Can't write to read-only Slice") { slice[0] = 0_u8 }
   end
 

--- a/src/array.cr
+++ b/src/array.cr
@@ -922,7 +922,7 @@ class Array(T)
     end
   end
 
-  # :nodoc:
+  # :inherit:
   def fill(value : T) : self
     # enable memset optimization
     to_unsafe_slice.fill(value)

--- a/src/array.cr
+++ b/src/array.cr
@@ -46,7 +46,7 @@
 # set << 3
 # ```
 class Array(T)
-  include Indexable(T)
+  include Indexable::Mutable(T)
   include Comparable(Array)
 
   # Size of an Array that we consider small to do linear scans or other optimizations.
@@ -411,24 +411,6 @@ class Array(T)
     push(value)
   end
 
-  # Sets the given value at the given index.
-  #
-  # Negative indices can be used to start counting from the end of the array.
-  # Raises `IndexError` if trying to set an element outside the array's range.
-  #
-  # ```
-  # ary = [1, 2, 3]
-  # ary[0] = 5
-  # p ary # => [5,2,3]
-  #
-  # ary[3] = 5 # raises IndexError
-  # ```
-  @[AlwaysInline]
-  def []=(index : Int, value : T)
-    index = check_index_out_of_bounds index
-    @buffer[index] = value
-  end
-
   # Replaces a subrange with a single value. All elements in the range
   # `index...index+count` are removed and replaced by a single element
   # *value*.
@@ -668,8 +650,13 @@ class Array(T)
   end
 
   @[AlwaysInline]
-  def unsafe_fetch(index : Int)
+  def unsafe_fetch(index : Int) : T
     @buffer[index]
+  end
+
+  @[AlwaysInline]
+  def unsafe_put(index : Int, value : T)
+    @buffer[index] = value
   end
 
   # Removes all elements from self.
@@ -876,18 +863,6 @@ class Array(T)
     end
   end
 
-  # Yields each index of `self` to the given block and then assigns
-  # the block's value in that position. Returns `self`.
-  #
-  # ```
-  # a = [1, 2, 3, 4]
-  # a.fill { |i| i * i } # => [0, 1, 4, 9]
-  # ```
-  def fill(& : Int32 -> T) : self
-    to_unsafe_slice.fill { |i| yield i }
-    self
-  end
-
   # Yields each index of `self`, starting at *from*, to the given block and then assigns
   # the block's value in that position. Returns `self`.
   #
@@ -947,13 +922,9 @@ class Array(T)
     end
   end
 
-  # Replaces every element in `self` with the given *value*. Returns `self`.
-  #
-  # ```
-  # a = [1, 2, 3]
-  # a.fill(9) # => [9, 9, 9]
-  # ```
+  # :nodoc:
   def fill(value : T) : self
+    # enable memset optimization
     to_unsafe_slice.fill(value)
     self
   end
@@ -1081,19 +1052,6 @@ class Array(T)
     Array(U).new(size) { |i| yield @buffer[i] }
   end
 
-  # Invokes the given block for each element of `self`, replacing the element
-  # with the value returned by the block. Returns `self`.
-  #
-  # ```
-  # a = [1, 2, 3]
-  # a.map! { |x| x * x }
-  # a # => [1, 4, 9]
-  # ```
-  def map!
-    @buffer.map!(size) { |e| yield e }
-    self
-  end
-
   # Modifies `self`, keeping only the elements in the collection for which the
   # passed block returns `true`. Returns `self`.
   #
@@ -1195,21 +1153,6 @@ class Array(T)
   # ```
   def map_with_index(offset = 0, &block : T, Int32 -> U) forall U
     Array(U).new(size) { |i| yield @buffer[i], offset + i }
-  end
-
-  # Like `map_with_index`, but mutates `self` instead of allocating a new object.
-  #
-  # Accepts an optional *offset* parameter, which tells it to start counting
-  # from there.
-  #
-  # ```
-  # gems = ["crystal", "pearl", "diamond"]
-  # gems.map_with_index! { |gem, i| "#{i}: #{gem}" }
-  # gems # => ["0: crystal", "1: pearl", "2: diamond"]
-  # ```
-  def map_with_index!(offset = 0, &block : (T, Int32) -> T)
-    to_unsafe.map_with_index!(size) { |e, i| yield e, offset + i }
-    self
   end
 
   # Returns an `Array` with the first *count* elements removed
@@ -1468,27 +1411,7 @@ class Array(T)
     Array(T).new(size) { |i| @buffer[size - i - 1] }
   end
 
-  # Reverses in-place all the elements of `self`.
-  def reverse!
-    to_unsafe_slice.reverse!
-    self
-  end
-
-  # Returns `self` with all the elements shifted `n` times.
-  #
-  # ```
-  # a1 = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
-  # a2 = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
-  # a3 = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
-  #
-  # a1.rotate!
-  # a2.rotate!(1)
-  # a3.rotate!(3)
-  #
-  # a1 # => [1, 2, 3, 4, 5, 6, 7, 8, 9, 0]
-  # a2 # => [1, 2, 3, 4, 5, 6, 7, 8, 9, 0]
-  # a3 # => [3, 4, 5, 6, 7, 8, 9, 0, 1, 2]
-  # ```
+  # :inherit:
   def rotate!(n = 1) : self
     return self if size == 0
     n %= size
@@ -1524,7 +1447,7 @@ class Array(T)
     self
   end
 
-  # Returns an array with all the elements shifted `n` times.
+  # Returns an array with all the elements shifted to the left `n` times.
   #
   # ```
   # a = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
@@ -1654,13 +1577,6 @@ class Array(T)
   # using the given *random* number generator.
   def shuffle(random = Random::DEFAULT) : Array(T)
     dup.shuffle!(random)
-  end
-
-  # Modifies `self` by randomizing the order of elements in the collection
-  # using the given *random* number generator. Returns `self`.
-  def shuffle!(random = Random::DEFAULT) : self
-    @buffer.shuffle!(size, random)
-    self
   end
 
   # Returns a new array with all elements sorted based on the return value of
@@ -1822,26 +1738,6 @@ class Array(T)
     @size.times do |i|
       @buffer[i] = sorted.to_unsafe[i][0]
     end
-    self
-  end
-
-  # Swaps the elements at *index0* and *index1* and returns `self`.
-  # Raises an `IndexError` if either index is out of bounds.
-  #
-  # ```
-  # a = ["first", "second", "third"]
-  # a.swap(1, 2)  # => ["first", "third", "second"]
-  # a             # => ["first", "third", "second"]
-  # a.swap(0, -1) # => ["second", "third", "first"]
-  # a             # => ["second", "third", "first"]
-  # a.swap(2, 3)  # => raises "Index out of bounds (IndexError)"
-  # ```
-  def swap(index0, index1) : Array(T)
-    index0 = check_index_out_of_bounds(index0)
-    index1 = check_index_out_of_bounds(index1)
-
-    @buffer[index0], @buffer[index1] = @buffer[index1], @buffer[index0]
-
     self
   end
 
@@ -2075,11 +1971,6 @@ class Array(T)
       unshift(value)
     end
     self
-  end
-
-  def update(index : Int)
-    index = check_index_out_of_bounds index
-    @buffer[index] = yield @buffer[index]
   end
 
   private def check_needs_resize

--- a/src/bit_array.cr
+++ b/src/bit_array.cr
@@ -16,7 +16,7 @@
 # ba[2] # => true
 # ```
 struct BitArray
-  include Indexable(Bool)
+  include Indexable::Mutable(Bool)
 
   # The number of bits the BitArray stores
   getter size : Int32
@@ -44,23 +44,24 @@ struct BitArray
     (@bits[bit_index] & (1 << sub_index)) > 0
   end
 
-  # Sets the bit at the given *index*.
-  # Negative indices can be used to start counting from the end of the array.
-  # Raises `IndexError` if trying to access a bit outside the array's range.
-  #
-  # ```
-  # require "bit_array"
-  #
-  # ba = BitArray.new(5)
-  # ba[3] = true
-  # ```
-  def []=(index, value : Bool)
+  def unsafe_put(index : Int, value : Bool)
+    bit_index, sub_index = index.divmod(32)
+    if value
+      @bits[bit_index] |= 1 << sub_index
+    else
+      @bits[bit_index] &= ~(1 << sub_index)
+    end
+  end
+
+  # :inherit:
+  def []=(index : Int, value : Bool) : Bool
     bit_index, sub_index = bit_index_and_sub_index(index)
     if value
       @bits[bit_index] |= 1 << sub_index
     else
       @bits[bit_index] &= ~(1 << sub_index)
     end
+    value
   end
 
   # Returns all elements that are within the given range.

--- a/src/deque.cr
+++ b/src/deque.cr
@@ -10,7 +10,7 @@
 # This Deque is implemented with a [dynamic array](http://en.wikipedia.org/wiki/Dynamic_array) used as a
 # [circular buffer](https://en.wikipedia.org/wiki/Circular_buffer).
 class Deque(T)
-  include Indexable(T)
+  include Indexable::Mutable(T)
 
   # This Deque is based on a circular buffer. It works like a normal array, but when an item is removed from the left
   # side, instead of shifting all the items, only the start position is shifted. This can lead to configurations like:
@@ -136,23 +136,16 @@ class Deque(T)
     push(value)
   end
 
-  # Sets the given value at the given *index*.
-  #
-  # Raises `IndexError` if the deque had no previous value at the given *index*.
-  def []=(index : Int, value : T)
-    index += @size if index < 0
-    unless 0 <= index < @size
-      raise IndexError.new
-    end
-    index += @start
-    index -= @capacity if index >= @capacity
-    @buffer[index] = value
-  end
-
-  def unsafe_fetch(index : Int)
+  def unsafe_fetch(index : Int) : T
     index += @start
     index -= @capacity if index >= @capacity
     @buffer[index]
+  end
+
+  def unsafe_put(index : Int, value : T)
+    index += @start
+    index -= @capacity if index >= @capacity
+    @buffer[index] = value
   end
 
   # Removes all elements from `self`.
@@ -489,10 +482,7 @@ class Deque(T)
     self
   end
 
-  # Rotates this deque in place so that the element at *n* becomes first.
-  #
-  # * For positive *n*, equivalent to `n.times { push(shift) }`.
-  # * For negative *n*, equivalent to `(-n).times { unshift(pop) }`.
+  # :inherit:
   def rotate!(n : Int = 1) : Nil
     return if @size <= 1
     if @size == @capacity
@@ -553,12 +543,6 @@ class Deque(T)
     n = Math.min(n, @size)
     n.times { shift }
     nil
-  end
-
-  # Swaps the items at the indices *i* and *j*.
-  def swap(i, j) : self
-    self[i], self[j] = self[j], self[i]
-    self
   end
 
   def to_s(io : IO) : Nil

--- a/src/indexable.cr
+++ b/src/indexable.cr
@@ -1088,3 +1088,5 @@ end
 private def dup_as_array(a)
   a.is_a?(Array) ? a.dup : a.to_a
 end
+
+require "./indexable/*"

--- a/src/indexable/mutable.cr
+++ b/src/indexable/mutable.cr
@@ -1,0 +1,222 @@
+# An `Indexable` container that is additionally mutable.
+#
+# Including types may write values to numeric indices, apart from reading them.
+# This module does not cover cases where the container is resized.
+module Indexable::Mutable(T)
+  include Indexable(T)
+
+  # Sets the element at the given *index* to *value*, without doing any bounds
+  # check.
+  #
+  # `Indexable::Mutable` makes sure to invoke this method with *index* in
+  # `0...size`, so converting negative indices to positive ones is not needed
+  # here.
+  #
+  # Clients never invoke this method directly. Instead, they modify elements
+  # with `#[]=(index, value)`.
+  #
+  # This method should only be directly invoked if you are absolutely
+  # sure the index is in bounds, to avoid a bounds check for a small boost
+  # of performance.
+  abstract def unsafe_put(index : Int, value : T)
+
+  # Sets the given *value* at the given *index*. Returns *value*.
+  #
+  # Negative indices can be used to start counting from the end of the
+  # container. Raises `IndexError` if trying to set an element outside the
+  # container's range.
+  #
+  # ```
+  # ary = [1, 2, 3]
+  # ary[0] = 5
+  # ary # => [5, 2, 3]
+  #
+  # ary[3] = 5 # raises IndexError
+  # ```
+  @[AlwaysInline]
+  def []=(index : Int, value : T) : T
+    index = check_index_out_of_bounds index
+    unsafe_put(index, value)
+    value
+  end
+
+  # Yields the current element at the given *index* and updates the value
+  # at that *index* with the block's value. Returns the new value.
+  #
+  # Raises `IndexError` if trying to set an element outside the array's range.
+  #
+  # ```
+  # array = [1, 2, 3]
+  # array.update(1) { |x| x * 2 } # => 4
+  # array                         # => [1, 4, 3]
+  # array.update(5) { |x| x * 2 } # raises IndexError
+  # ```
+  def update(index : Int, & : T -> T) : T
+    index = check_index_out_of_bounds index
+    value = yield unsafe_fetch(index)
+    unsafe_put(index, value)
+    value
+  end
+
+  # Swaps the elements at *index0* and *index1*. Returns `self`.
+  #
+  # Negative indices can be used to start counting from the end of the
+  # container. Raises `IndexError` if either index is out of bounds.
+  #
+  # ```
+  # a = ["first", "second", "third"]
+  # a.swap(1, 2)  # => ["first", "third", "second"]
+  # a             # => ["first", "third", "second"]
+  # a.swap(0, -1) # => ["second", "third", "first"]
+  # a             # => ["second", "third", "first"]
+  # a.swap(2, 3)  # raises IndexError
+  # ```
+  def swap(index0 : Int, index1 : Int) : self
+    index0 = check_index_out_of_bounds(index0)
+    index1 = check_index_out_of_bounds(index1)
+
+    unless index0 == index1
+      tmp = unsafe_fetch(index0)
+      unsafe_put(index0, unsafe_fetch(index1))
+      unsafe_put(index1, tmp)
+    end
+
+    self
+  end
+
+  # Reverses in-place all the elements of `self`. Returns `self`.
+  def reverse! : self
+    return self if size <= 1
+
+    index0 = 0
+    index1 = size - 1
+
+    while index0 < index1
+      swap(index0, index1)
+      index0 += 1
+      index1 -= 1
+    end
+
+    self
+  end
+
+  # Replaces every element in `self` with the given *value*. Returns `self`.
+  #
+  # ```
+  # array = [1, 2, 3, 4]
+  # array.fill(2) # => [2, 2, 2, 2]
+  # array         # => [2, 2, 2, 2]
+  # ```
+  def fill(value : T) : self
+    each_index do |i|
+      unsafe_put(i, value)
+    end
+    self
+  end
+
+  # Yields each index of `self` to the given block and then assigns
+  # the block's value in that position. Returns `self`.
+  #
+  # Accepts an optional *offset* parameter, which tells the block to start
+  # counting from there.
+  #
+  # ```
+  # array = [2, 1, 1, 1]
+  # array.fill { |i| i * i }            # => [0, 1, 4, 9]
+  # array                               # => [0, 1, 4, 9]
+  # array.fill(offset: 3) { |i| i * i } # => [9, 16, 25, 36]
+  # array                               # => [9, 16, 25, 36]
+  # ```
+  def fill(*, offset : Int = 0, & : Int32 -> T) : self
+    each_index do |i|
+      unsafe_put(i, yield offset + i)
+    end
+    self
+  end
+
+  # Invokes the given block for each element of `self`, replacing the element
+  # with the value returned by the block. Returns `self`.
+  #
+  # ```
+  # a = [1, 2, 3]
+  # a.map! { |x| x * x }
+  # a # => [1, 4, 9]
+  # ```
+  def map!(& : T -> T) : self
+    each_index do |i|
+      unsafe_put(i, yield unsafe_fetch(i))
+    end
+    self
+  end
+
+  # Like `#map!`, but the block gets passed both the element and its index.
+  #
+  # Accepts an optional *offset* parameter, which tells it to start counting
+  # from there.
+  #
+  # ```
+  # gems = ["crystal", "pearl", "diamond"]
+  # gems.map_with_index! { |gem, i| "#{i}: #{gem}" }
+  # gems # => ["0: crystal", "1: pearl", "2: diamond"]
+  # ```
+  def map_with_index!(offset = 0, & : T, Int32 -> T) : self
+    each_index do |i|
+      unsafe_put(i, yield(unsafe_fetch(i), offset + i))
+    end
+    self
+  end
+
+  # Modifies `self` by randomizing the order of elements in the collection
+  # using the given *random* number generator. Returns `self`.
+  #
+  # ```
+  # a = [1, 2, 3, 4, 5]
+  # a.shuffle!(Random.new(42)) # => [3, 2, 4, 5, 1]
+  # a                          # => [3, 2, 4, 5, 1]
+  # ```
+  def shuffle!(random = Random::DEFAULT) : self
+    (size - 1).downto(1) do |i|
+      j = random.rand(i + 1)
+      swap(i, j)
+    end
+    self
+  end
+
+  # Shifts all elements of `self` to the left *n* times. Returns `self`.
+  #
+  # ```
+  # a1 = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
+  # a2 = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
+  # a3 = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
+  #
+  # a1.rotate!
+  # a2.rotate!(1)
+  # a3.rotate!(3)
+  #
+  # a1 # => [1, 2, 3, 4, 5, 6, 7, 8, 9, 0]
+  # a2 # => [1, 2, 3, 4, 5, 6, 7, 8, 9, 0]
+  # a3 # => [3, 4, 5, 6, 7, 8, 9, 0, 1, 2]
+  # ```
+  def rotate!(n : Int = 1) : self
+    return self if size <= 1
+    n %= size
+
+    # juggling algorithm
+    size.gcd(n).times do |i|
+      tmp = unsafe_fetch(i)
+      j = i
+
+      while true
+        k = j + n
+        k -= size if k >= size
+        break if k == i
+        unsafe_put(j, unsafe_fetch(k))
+        j = k
+      end
+
+      unsafe_put(j, tmp)
+    end
+
+    self
+  end
+end

--- a/src/slice.cr
+++ b/src/slice.cr
@@ -11,7 +11,7 @@ require "slice/sort"
 # will raise. For example the slice of bytes returned by
 # `String#to_slice` is read-only.
 struct Slice(T)
-  include Indexable(T)
+  include Indexable::Mutable(T)
   include Comparable(Slice)
 
   # Creates a new `Slice` with the given *args*. The type of the
@@ -169,25 +169,13 @@ struct Slice(T)
     Slice.new(@pointer + offset, @size - offset, read_only: @read_only)
   end
 
-  # Sets the given value at the given *index*.
+  # :inherit:
   #
-  # Negative indices can be used to start counting from the end of the slice.
-  # Raises `IndexError` if trying to set an element outside the slice's range.
-  #
-  # ```
-  # slice = Slice.new(5) { |i| i + 10 }
-  # slice[0] = 20
-  # slice[-1] = 30
-  # slice # => Slice[20, 11, 12, 13, 30]
-  #
-  # slice[10] = 1 # raises IndexError
-  # ```
+  # Raises if this slice is read-only.
   @[AlwaysInline]
-  def []=(index : Int, value : T)
+  def []=(index : Int, value : T) : T
     check_writable
-
-    index = check_index_out_of_bounds(index)
-    @pointer[index] = value
+    super
   end
 
   # Returns a new slice that starts at *start* elements from this slice's start,
@@ -283,43 +271,57 @@ struct Slice(T)
     @pointer[index]
   end
 
-  # Reverses in-place all the elements of `self`.
+  @[AlwaysInline]
+  def unsafe_put(index : Int, value : T)
+    @pointer[index] = value
+  end
+
+  # :inherit:
+  #
+  # Raises if this slice is read-only.
+  def update(index : Int, & : T -> T) : T
+    check_writable
+    super
+  end
+
+  # :inherit:
+  #
+  # Raises if this slice is read-only.
+  def swap(index0 : Int, index1 : Int) : self
+    check_writable
+    super
+  end
+
+  # :inherit:
+  #
+  # Raises if this slice is read-only.
   def reverse! : self
     check_writable
-
-    return self if size <= 1
-
-    p = @pointer
-    q = @pointer + size - 1
-
-    while p < q
-      p.value, q.value = q.value, p.value
-      p += 1
-      q -= 1
-    end
-
-    self
+    super
   end
 
-  def shuffle!(random = Random::DEFAULT)
-    check_writable
-
-    @pointer.shuffle!(size, random)
-  end
-
-  # Invokes the given block for each element of `self`, replacing the element
-  # with the value returned by the block. Returns `self`.
+  # :inherit:
   #
-  # ```
-  # slice = Slice[1, 2, 3]
-  # slice.map! { |x| x * x }
-  # slice # => Slice[1, 4, 9]
-  # ```
-  def map!
+  # Raises if this slice is read-only.
+  def shuffle!(random = Random::DEFAULT) : self
     check_writable
+    super
+  end
 
-    @pointer.map!(size) { |e| yield e }
-    self
+  # :inherit:
+  #
+  # Raises if this slice is read-only.
+  def rotate!(n : Int = 1) : self
+    check_writable
+    super
+  end
+
+  # :inherit:
+  #
+  # Raises if this slice is read-only.
+  def map!(& : T -> T) : self
+    check_writable
+    super { |elem| yield elem }
   end
 
   # Returns a new slice where elements are mapped by the given block.
@@ -332,15 +334,12 @@ struct Slice(T)
     Slice.new(size, read_only: read_only) { |i| yield @pointer[i] }
   end
 
-  # Like `map!`, but the block gets passed both the element and its index.
+  # :inherit:
   #
-  # Accepts an optional *offset* parameter, which tells it to start counting
-  # from there.
-  def map_with_index!(offset = 0, &block : (T, Int32) -> T)
+  # Raises if this slice is read-only.
+  def map_with_index!(offset = 0, & : T, Int32 -> T) : self
     check_writable
-
-    @pointer.map_with_index!(size) { |e, i| yield e, offset + i }
-    self
+    super { |elem, i| yield elem, i }
   end
 
   # Like `map`, but the block gets passed both the element and its index.
@@ -351,13 +350,9 @@ struct Slice(T)
     Slice.new(size, read_only: read_only) { |i| yield @pointer[i], offset + i }
   end
 
-  # Replaces every element in `self` with the given *value*. Returns `self`.
+  # :inherit:
   #
-  # ```
-  # slice = Slice[1, 2, 3, 4]
-  # slice.fill(2) # => Slice[2, 2, 2, 2]
-  # slice         # => Slice[2, 2, 2, 2]
-  # ```
+  # Raises if this slice is read-only.
   def fill(value : T) : self
     check_writable
 
@@ -376,26 +371,12 @@ struct Slice(T)
     {% end %}
   end
 
-  # Yields each index of `self` to the given block and then assigns
-  # the block's value in that position. Returns `self`.
+  # :inherit:
   #
-  # Accepts an optional *offset* parameter, which tells the block to start
-  # counting from there.
-  #
-  # ```
-  # slice = Slice[2, 1, 1, 1]
-  # slice.fill { |i| i * i }            # => Slice[0, 1, 4, 9]
-  # slice                               # => Slice[0, 1, 4, 9]
-  # slice.fill(offset: 3) { |i| i * i } # => Slice[9, 16, 25, 36]
-  # slice                               # => Slice[9, 16, 25, 36]
-  # ```
+  # Raises if this slice is read-only.
   def fill(*, offset : Int = 0, & : Int32 -> T) : self
     check_writable
-
-    size.times do |i|
-      to_unsafe[i] = yield offset + i
-    end
-    self
+    super { |i| yield i }
   end
 
   def copy_from(source : Pointer(T), count)

--- a/src/slice.cr
+++ b/src/slice.cr
@@ -281,7 +281,7 @@ struct Slice(T)
   # Raises if this slice is read-only.
   def update(index : Int, & : T -> T) : T
     check_writable
-    super
+    super { |elem| yield elem }
   end
 
   # :inherit:

--- a/src/static_array.cr
+++ b/src/static_array.cr
@@ -133,7 +133,7 @@ struct StaticArray(T, N)
     N
   end
 
-  # :nodoc:
+  # :inherit:
   def fill(value : T) : self
     # enable memset optimization
     to_slice.fill(value)

--- a/src/static_array.cr
+++ b/src/static_array.cr
@@ -33,7 +33,7 @@
 # doesn't specify a type but a size. Its value can be an `Int32` literal or
 # constant.
 struct StaticArray(T, N)
-  include Indexable(T)
+  include Indexable::Mutable(T)
 
   # Creates a new `StaticArray` with the given *args*. The type of the
   # static array will be the union of the type of the given *args*,
@@ -114,40 +114,13 @@ struct StaticArray(T, N)
   end
 
   @[AlwaysInline]
-  def unsafe_fetch(index : Int)
+  def unsafe_fetch(index : Int) : T
     to_unsafe[index]
   end
 
-  # Sets the given value at the given *index*.
-  #
-  # Negative indices can be used to start counting from the end of the array.
-  # Raises `IndexError` if trying to set an element outside the array's range.
-  #
-  # ```
-  # array = StaticArray(Int32, 3).new { |i| i + 1 } # => StaticArray[1, 2, 3]
-  # array[2] = 2                                    # => 2
-  # array                                           # => StaticArray[1, 2, 2]
-  # array[4] = 4                                    # raises IndexError
-  # ```
   @[AlwaysInline]
-  def []=(index : Int, value : T)
-    index = check_index_out_of_bounds index
+  def unsafe_put(index : Int, value : T)
     to_unsafe[index] = value
-  end
-
-  # Yields the current element at the given index and updates the value
-  # at the given *index* with the block's value.
-  # Raises `IndexError` if trying to set an element outside the array's range.
-  #
-  # ```
-  # array = StaticArray(Int32, 3).new { |i| i + 1 } # => StaticArray[1, 2, 3]
-  # array.update(1) { |x| x * 2 }                   # => 4
-  # array                                           # => StaticArray[1, 4, 3]
-  # array.update(5) { |x| x * 2 }                   # raises IndexError
-  # ```
-  def update(index : Int)
-    index = check_index_out_of_bounds index
-    to_unsafe[index] = yield to_unsafe[index]
   end
 
   # Returns the size of `self`
@@ -160,53 +133,10 @@ struct StaticArray(T, N)
     N
   end
 
-  # Replaces every element in `self` with the given *value*. Returns `self`.
-  #
-  # ```
-  # array = StaticArray(Int32, 3).new 0 # => StaticArray[0, 0, 0]
-  # array.fill(2)                       # => StaticArray[2, 2, 2]
-  # array                               # => StaticArray[2, 2, 2]
-  # ```
+  # :nodoc:
   def fill(value : T) : self
+    # enable memset optimization
     to_slice.fill(value)
-    self
-  end
-
-  # Yields each index of `self` to the given block and then assigns
-  # the block's value in that position. Returns `self`.
-  #
-  # ```
-  # array = StaticArray[2, 1, 1, 1]
-  # array.fill { |i| i * i } # => StaticArray[0, 1, 4, 9]
-  # array                    # => StaticArray[0, 1, 4, 9]
-  # ```
-  def fill(& : Int32 -> T) : self
-    to_slice.fill { |i| yield i }
-    self
-  end
-
-  # Modifies `self` by randomizing the order of elements in the array
-  # using the given *random* number generator. Returns `self`.
-  #
-  # ```
-  # a = StaticArray(Int32, 3).new { |i| i + 1 } # => StaticArray[1, 2, 3]
-  # a.shuffle!(Random.new(42))                  # => StaticArray[3, 2, 1]
-  # a                                           # => StaticArray[3, 2, 1]
-  # ```
-  def shuffle!(random = Random::DEFAULT)
-    to_slice.shuffle!(random)
-    self
-  end
-
-  # Invokes the given block for each element of `self`, replacing the element
-  # with the value returned by the block. Returns `self`.
-  #
-  # ```
-  # array = StaticArray(Int32, 3).new { |i| i + 1 }
-  # array.map! { |x| x*x } # => StaticArray[1, 4, 9]
-  # ```
-  def map!
-    to_unsafe.map!(size) { |e| yield e }
     self
   end
 
@@ -220,32 +150,12 @@ struct StaticArray(T, N)
     StaticArray(U, N).new { |i| yield to_unsafe[i] }
   end
 
-  # Like `map!`, but the block gets passed both the element and its index.
-  #
-  # Accepts an optional *offset* parameter, which tells it to start counting
-  # from there.
-  def map_with_index!(offset = 0, &block : (T, Int32) -> T)
-    to_unsafe.map_with_index!(size) { |e, i| yield e, offset + i }
-    self
-  end
-
   # Like `map`, but the block gets passed both the element and its index.
   #
   # Accepts an optional *offset* parameter, which tells it to start counting
   # from there.
   def map_with_index(offset = 0, &block : (T, Int32) -> U) forall U
     StaticArray(U, N).new { |i| yield to_unsafe[i], offset + i }
-  end
-
-  # Reverses the elements of this array in-place, then returns `self`.
-  #
-  # ```
-  # array = StaticArray(Int32, 3).new { |i| i + 1 }
-  # array.reverse! # => StaticArray[3, 2, 1]
-  # ```
-  def reverse!
-    to_slice.reverse!
-    self
   end
 
   # Returns a slice that points to the elements of this static array.


### PR DESCRIPTION
Resolves #5142. The new module has only one abstract def:

```crystal
module Indexable::Mutable(T)
  include Indexable(T)

  abstract def unsafe_put(index : Int, value : T)
end
```

All includers of `Indexable` include this module instead, except for `Tuple` and `LLVM::ParameterCollection`. This implicitly adds the following methods:

* `Array`: `fill(*, offset, &)`
* `BitArray`: `fill`, `map!`, `map_with_index!`, `reverse!`, `rotate!`, `shuffle!`, `swap`, `update`
* `Deque`: `fill`, `map!`, `map_with_index!`, `reverse!`, `shuffle!`, `update`
* `Slice`: `rotate!`, `swap`, `update`
* `StaticArray`: `fill(*, offset, &)`, `rotate!`, `swap`

Some notes:

* `Indexable::Mutable#[]=` always returns the value being set, and this is extended to `BitArray` (see #7707). This has a small chance of breaking existing code. (`#unsafe_put` is not a setter and not meant to be used freely, so it doesn't have a return value restriction.)
* For now `Indexable::Mutable#rotate!` uses the juggling algorithm, briefly mentioned in #5400, which has O(size) time complexity and O(1) space complexity. `Array#rotate!` and `Deque#rotate!` have been kept intact because it is not known yet if they are faster than this new implementation.
* The range-like overloads of `#fill`, as well as `Array#fill(offset)`, are not added to `Indexable::Mutable`. I would like to address those overloads later.
* Mutating sorting methods from https://github.com/crystal-lang/crystal/pull/11057#issuecomment-892077962 are not added yet.
* Container indices and integer parameters are restricted by `Int`. This shouldn't break any working code, since non-integers will break `Pointer#+` for existing implementations already.
* A _lot_ of those new methods in `BitArray` can be further optimized. Those have to wait too.
* ~~Specs for `Indexable::Mutable` itself are not written yet.~~