### PR TITLE
Make `#is_a?` in macros respect the AST node hierarchy

### DIFF
--- a/spec/compiler/macro/macro_methods_spec.cr
+++ b/spec/compiler/macro/macro_methods_spec.cr
@@ -771,6 +771,7 @@ module Crystal
 
       it "executes is_a?" do
         assert_macro "", %({{[1, 2, 3].is_a?(ArrayLiteral)}}), [] of ASTNode, "true"
+        assert_macro "", %({{[1, 2, 3].is_a?(ASTNode)}}), [] of ASTNode, "true"
         assert_macro "", %({{[1, 2, 3].is_a?(NumberLiteral)}}), [] of ASTNode, "false"
       end
 
@@ -883,6 +884,7 @@ module Crystal
 
       it "executes is_a?" do
         assert_macro "", %({{{:a => 1}.is_a?(HashLiteral)}}), [] of ASTNode, "true"
+        assert_macro "", %({{{:a => 1}.is_a?(ASTNode)}}), [] of ASTNode, "true"
         assert_macro "", %({{{:a => 1}.is_a?(RangeLiteral)}}), [] of ASTNode, "false"
       end
 
@@ -1018,6 +1020,7 @@ module Crystal
 
       it "executes is_a?" do
         assert_macro "", %({{{a: 1}.is_a?(NamedTupleLiteral)}}), [] of ASTNode, "true"
+        assert_macro "", %({{{a: 1}.is_a?(ASTNode)}}), [] of ASTNode, "true"
         assert_macro "", %({{{a: 1}.is_a?(RangeLiteral)}}), [] of ASTNode, "false"
       end
 
@@ -1264,6 +1267,7 @@ module Crystal
 
       it "executes is_a?" do
         assert_macro "", %({{ {1, 2, 3}.is_a?(TupleLiteral) }}), [] of ASTNode, "true"
+        assert_macro "", %({{ {1, 2, 3}.is_a?(ASTNode) }}), [] of ASTNode, "true"
         assert_macro "", %({{ {1, 2, 3}.is_a?(ArrayLiteral) }}), [] of ASTNode, "false"
       end
 
@@ -2188,6 +2192,14 @@ module Crystal
     describe "unary expression methods" do
       it "executes exp" do
         assert_macro "x", %({{x.exp}}), [Not.new("some_call".call)] of ASTNode, "some_call"
+      end
+
+      it "executes is_a?" do
+        assert_macro "x", %({{ x.is_a?(Not) }}), [Not.new("some_call".call)] of ASTNode, "true"
+        assert_macro "x", %({{ x.is_a?(Splat) }}), [Not.new("some_call".call)] of ASTNode, "false"
+        assert_macro "x", %({{ x.is_a?(UnaryExpression) }}), [Not.new("some_call".call)] of ASTNode, "true"
+        assert_macro "x", %({{ x.is_a?(ASTNode) }}), [Not.new("some_call".call)] of ASTNode, "true"
+        assert_macro "x", %({{ x.is_a?(TypeNode) }}), [Not.new("some_call".call)] of ASTNode, "false"
       end
     end
 

--- a/src/compiler/crystal/macros.cr
+++ b/src/compiler/crystal/macros.cr
@@ -273,6 +273,20 @@ module Crystal::Macros
     def raise(message) : NoReturn
     end
 
+    # Returns `true` if this node's type is the given *type* or any of its
+    # subclasses.
+    #
+    # *type* always refers to an AST node type, never a type in the program.
+    #
+    # ```
+    # {{ 1.is_a?(NumberLiteral) }} # => true
+    # {{ 1.is_a?(BoolLiteral) }}   # => false
+    # {{ 1.is_a?(ASTNode) }}       # => true
+    # {{ 1.is_a?(Int32) }}         # => false
+    # ```
+    def __crystal_pseudo_is_a?(type : TypeNode) : BoolLiteral
+    end
+
     # Returns `true` if this node is a `NilLiteral` or `Nop`.
     def __crystal_pseudo_nil? : BoolLiteral
     end

--- a/src/compiler/crystal/macros/interpreter.cr
+++ b/src/compiler/crystal/macros/interpreter.cr
@@ -536,8 +536,7 @@ module Crystal
     def visit(node : IsA)
       node.obj.accept self
       const_name = node.const.to_s
-      obj_class_desc = @last.class_desc
-      @last = BoolLiteral.new(@last.class_desc == const_name)
+      @last = BoolLiteral.new(@last.class_desc_is_a?(const_name))
       false
     end
 

--- a/src/compiler/crystal/semantic/ast.cr
+++ b/src/compiler/crystal/semantic/ast.cr
@@ -791,7 +791,7 @@ module Crystal
     def initialize(@name, @type)
     end
 
-    def class_desc
+    def self.class_desc
       "MetaVar"
     end
 

--- a/src/compiler/crystal/syntax/ast.cr
+++ b/src/compiler/crystal/syntax/ast.cr
@@ -82,8 +82,33 @@ module Crystal
       self.is_a?(BoolLiteral) && !self.value
     end
 
-    def class_desc : String
+    def self.class_desc : String
       {{@type.name.split("::").last.id.stringify}}
+    end
+
+    def class_desc
+      self.class.class_desc
+    end
+
+    def class_desc_is_a?(name)
+      # e.g. for `Splat < UnaryExpression < ASTNode` this produces:
+      #
+      # ```
+      # name.in?({class_desc, UnaryExpression.class_desc, ASTNode.class_desc})
+      # ```
+      #
+      # this assumes the macro AST node hierarchy matches exactly that of the
+      # compiler internal node types
+      {% begin %}
+        name.in?({
+          class_desc,
+          {% for t in @type.ancestors %}
+            {% if t <= Crystal::ASTNode %}
+              {{ t }}.class_desc,
+            {% end %}
+          {% end %}
+        })
+      {% end %}
     end
 
     def pretty_print(pp)


### PR DESCRIPTION
Currently, `is_a?` in macros compares the class names directly:

```crystal
{{ [1, 2, 3].is_a?(ASTNode) }} # => false

# the above is akin to the following in normal code:
[1, 2, 3].class.name == Object.class.name # => false
```

Since `Crystal::ASTNode` is an abstract class, it follows that `is_a?(ASTNode)` always fails, even though every AST node obviously inherits from that class, both in the macro language and internally. This PR makes the internal AST node hierarchy available here, so `is_a?(ASTNode)` becomes true.

More useful is the ability to match abstract AST node types that aren't `ASTNode`:

```crystal
macro foo(x)
  {% puts x.exp if x.is_a?(UnaryExpression) %}
end

foo !true         # => true
foo sizeof(Int32) # => Int32
foo *[1, 2, 3]    # => [1, 2, 3]
foo 4 + 5
foo /bar/
```