### PR TITLE
Allow the use of UTC time in `Time::MonthSpan`

### DIFF
--- a/src/time/span.cr
+++ b/src/time/span.cr
@@ -580,13 +580,15 @@ struct Time::MonthSpan
   end
 
   # Returns a `Time` that happens N months after now.
-  def from_now : Time
-    Time.local + self
+  # If `utc` is true, UTC time is used instead of the local time.
+  def from_now(utc = false) : Time
+    (utc ? Time.utc : Time.local) + self
   end
 
   # Returns a `Time` that happens N months before now.
-  def ago : Time
-    Time.local - self
+  # If `utc` is true, UTC time is used instead of the local time.
+  def ago(utc = false) : Time
+    (utc ? Time.utc : Time.local) - self
   end
 end
 


### PR DESCRIPTION
Allow UTC time to be used in `Time::MonthSpan.from_now` and `Time::MonthSpan.ago`