### PR TITLE
Allow `Enumerable(T)#reduce`'s return type to differ from `T`

### DIFF
--- a/spec/std/enumerable_spec.cr
+++ b/spec/std/enumerable_spec.cr
@@ -615,6 +615,20 @@ describe "Enumerable" do
       result = ([] of Int32).reduce(10) { |memo, i| memo + i }
       result.should eq 10
     end
+
+    it "allows block return type to be different from element type" do
+      [1, 2, 3].reduce { |x, y| "#{x}-#{y}" }.should eq("1-2-3")
+      [1].reduce { |x, y| "#{x}-#{y}" }.should eq(1)
+      {1}.reduce { |x, y| "#{x}-#{y}" }.should eq(1)
+
+      expect_raises Enumerable::EmptyError do
+        ([] of Int32).reduce { |x, y| "#{x}-#{y}" }
+      end
+
+      expect_raises Enumerable::EmptyError do
+        Tuple.new.reduce { |x, y| "#{x}-#{y}" }
+      end
+    end
   end
 
   describe "reduce?" do
@@ -622,6 +636,14 @@ describe "Enumerable" do
 
     it "returns nil if empty" do
       ([] of Int32).reduce? { |memo, i| memo + i }.should be_nil
+    end
+
+    it "allows block return type to be different from element type" do
+      [1, 2, 3].reduce? { |x, y| "#{x}-#{y}" }.should eq("1-2-3")
+      [1].reduce? { |x, y| "#{x}-#{y}" }.should eq(1)
+      {1}.reduce? { |x, y| "#{x}-#{y}" }.should eq(1)
+      ([] of Int32).reduce? { |x, y| "#{x}-#{y}" }.should be_nil
+      Tuple.new.reduce? { |x, y| "#{x}-#{y}" }.should be_nil
     end
   end
 

--- a/src/enumerable.cr
+++ b/src/enumerable.cr
@@ -675,7 +675,7 @@ module Enumerable(T)
   # [1, 2, 3, 4, 5].reduce { |acc, i| acc + i } # => 15
   # ```
   def reduce
-    memo = uninitialized T
+    memo = uninitialized typeof(reduce(Enumerable.element_type(self)) { |acc, i| yield acc, i })
     found = false
 
     each do |elem|
@@ -706,7 +706,7 @@ module Enumerable(T)
   # ([] of Int32).reduce? { |acc, i| acc + i } # => nil
   # ```
   def reduce?
-    memo = uninitialized T
+    memo = uninitialized typeof(reduce(Enumerable.element_type(self)) { |acc, i| yield acc, i })
     found = false
 
     each do |elem|

--- a/src/enumerable.cr
+++ b/src/enumerable.cr
@@ -668,11 +668,23 @@ module Enumerable(T)
   # For each element in the collection the block is passed an accumulator value (*memo*) and the element. The
   # result becomes the new value for *memo*. At the end of the iteration, the final value of *memo* is
   # the return value for the method. The initial value for the accumulator is the first element in the collection.
+  # If the collection has only one element, that element is returned.
   #
   # Raises `Enumerable::EmptyError` if the collection is empty.
   #
   # ```
   # [1, 2, 3, 4, 5].reduce { |acc, i| acc + i } # => 15
+  # [1].reduce { |acc, i| acc + i }             # => 1
+  # ([] of Int32).reduce { |acc, i| acc + i }   # raises Enumerable::EmptyError
+  # ```
+  #
+  # The block is not required to return a `T`, in which case the accumulator's
+  # type includes whatever the block returns.
+  #
+  # ```
+  # # `acc` is an `Int32 | String`
+  # [1, 2, 3, 4, 5].reduce { |acc, i| "#{acc}-#{i}" } # => "1-2-3-4-5"
+  # [1].reduce { |acc, i| "#{acc}-#{i}" }             # => 1
   # ```
   def reduce
     memo = uninitialized typeof(reduce(Enumerable.element_type(self)) { |acc, i| yield acc, i })

--- a/src/tuple.cr
+++ b/src/tuple.cr
@@ -530,6 +530,34 @@ struct Tuple
     nil
   end
 
+  # :inherit:
+  def reduce
+    {% if T.empty? %}
+      raise Enumerable::EmptyError.new
+    {% else %}
+      memo = self[0]
+      {% for i in 1...T.size %}
+        memo = yield memo, self[{{ i }}]
+      {% end %}
+      memo
+    {% end %}
+  end
+
+  # :inherit:
+  def reduce(memo)
+    {% for i in 0...T.size %}
+      memo = yield memo, self[{{ i }}]
+    {% end %}
+    memo
+  end
+
+  # :inherit:
+  def reduce?
+    {% unless T.empty? %}
+      reduce { |memo, elem| yield memo, elem }
+    {% end %}
+  end
+
   # Returns the first element of this tuple. Doesn't compile
   # if the tuple is empty.
   #


### PR DESCRIPTION
The following seemingly innocuous code doesn't work: (don't actually do this as it takes up quadratic space)

```crystal
def join(values : Enumerable, separator : String = "")
  values.reduce? { |a, b| "#{a}#{separator}#{b}" } || ""
end

join [1, 3, 6, 10, 15], "-"
```

```
In /usr/share/crystal/src/enumerable.cr:713:7

 713 | memo = found ? (yield memo, elem) : elem
       ^---
Error: type must be Int32, not (Int32 | String)
```

This is because the accumulator type is forced to `T`, which is `Int32` in this case, so it can never be a `String`. This PR makes the type same as the one when an initial accumulator value of type `T` is explicitly given:

```crystal
x = join [1, 3, 6, 10, 15], "-"
x         # => "1-3-6-10-15"
typeof(x) # => (Int32 | String)
```

```crystal
class A; end
class B < A; end

class C < A
  def initialize(@left : A, @right : A)
  end
end

x = [B.new, B.new, B.new].reduce { |x, y| C.new(x, y) }
x         # => #<C:... @left=#<C:... @left=#<B:...>, @right=#<B:...>>, @right=#<B:...>>
typeof(x) # => A
```

The unrolled implementations in `Tuple` are needed because otherwise this deduced type seems to break on `Tuple()`.