### PR TITLE
Substitute unbound type parameters in virtual metaclass types

### DIFF
--- a/spec/compiler/semantic/generic_class_spec.cr
+++ b/spec/compiler/semantic/generic_class_spec.cr
@@ -1221,4 +1221,23 @@ describe "Semantic: generic class" do
       foo(Gen(Int32).new)
       )) { generic_class "Gen", int32 }
   end
+
+  it "replaces type parameters in virtual metaclasses (#10691)" do
+    assert_type(%(
+      class Parent(T)
+      end
+
+      class Child < Parent(Int32)
+      end
+
+      class Foo(T)
+      end
+
+      class Bar(T)
+        @foo = Foo(Parent(T).class).new
+      end
+
+      Bar(Int32).new.@foo
+      ), inject_primitives: false) { generic_class("Foo", generic_class("Parent", int32).virtual_type.metaclass) }
+  end
 end

--- a/src/compiler/crystal/types.cr
+++ b/src/compiler/crystal/types.cr
@@ -3342,6 +3342,10 @@ module Crystal
 
     delegate lookup_first_def, to: instance_type.metaclass
 
+    def replace_type_parameters(instance)
+      base_type.replace_type_parameters(instance).virtual_type.metaclass
+    end
+
     def each_concrete_type
       instance_type.subtypes.each do |type|
         yield type.metaclass


### PR DESCRIPTION
Fixes #10691. In:

```crystal
class Parent(T)
end

class Child < Parent(Int32)
end

class Foo(T)
end

class Bar(T)
  @foo = Foo(Parent(T).class).new
end

Bar(Int32).new.@foo
```

Because `Parent` has a subclass, the type `Parent(T).class` in `@foo`'s initializer is a virtual metaclass and refers to `Parent(T)+.class`. It turns out these metaclass types never supported type parameter substitution. This PR adds it back; the result of substituting `Parent(T)+.class` with `T = Int32` is now the virtual metaclass of the substituted result for `Parent(T)`.