### PR TITLE
XML Namespace improvements

### DIFF
--- a/spec/std/xml/xml_spec.cr
+++ b/spec/std/xml/xml_spec.cr
@@ -173,12 +173,12 @@ describe XML do
       describe "with a prefix" do
         it "return the prefixed namespace" do
           doc = XML.parse(<<-XML
-          <?xml version="1.0" encoding="UTF-8"?>
-          <openSearch:feed xmlns:foo="http://www.w3.org/2005/Atom" xmlns:openSearch="http://a9.com/-/spec/opensearchrss/1.0/"></feed>
-          XML
+            <?xml version="1.0" encoding="UTF-8"?>
+            <openSearch:feed xmlns:foo="http://www.w3.org/2005/Atom" xmlns:openSearch="http://a9.com/-/spec/opensearchrss/1.0/"></feed>
+            XML
           )
 
-          namespace = doc.root.not_nil!.namespace.should_not be_nil
+          namespace = doc.root.not_nil!.namespace.should be_a XML::Namespace
           namespace.href.should eq "http://a9.com/-/spec/opensearchrss/1.0/"
           namespace.prefix.should eq "openSearch"
         end
@@ -187,12 +187,12 @@ describe XML do
       describe "with a default prefix" do
         it "return the default namespace" do
           doc = XML.parse(<<-XML
-          <?xml version="1.0" encoding="UTF-8"?>
-          <feed xmlns:foo="http://www.w3.org/2005/Atom" xmlns="http://a9.com/-/spec/opensearchrss/1.0/"></feed>
-          XML
+            <?xml version="1.0" encoding="UTF-8"?>
+            <feed xmlns:foo="http://www.w3.org/2005/Atom" xmlns="http://a9.com/-/spec/opensearchrss/1.0/"></feed>
+            XML
           )
 
-          namespace = doc.root.not_nil!.namespace.should_not be_nil
+          namespace = doc.root.not_nil!.namespace.should be_a XML::Namespace
           namespace.href.should eq "http://a9.com/-/spec/opensearchrss/1.0/"
           namespace.prefix.should be_nil
         end
@@ -211,11 +211,11 @@ describe XML do
 
           root = doc.root.not_nil!
 
-          namespace = root.children[1].namespace.should_not be_nil
+          namespace = root.children[1].namespace.should be_a XML::Namespace
           namespace.href.should eq "http://www.w3.org/2005/Atom"
           namespace.prefix.should be_nil
 
-          namespace = root.children[3].namespace.should_not be_nil
+          namespace = root.children[3].namespace.should be_a XML::Namespace
           namespace.href.should eq "https://a-namespace"
           namespace.prefix.should eq "a"
         end
@@ -225,9 +225,9 @@ describe XML do
     describe "when the node does not have namespace" do
       it "should return nil" do
         doc = XML.parse(<<-XML
-        <?xml version="1.0" encoding="UTF-8"?>
-        <feed></feed>
-        XML
+          <?xml version="1.0" encoding="UTF-8"?>
+          <feed></feed>
+          XML
         )
 
         doc.root.not_nil!.namespace.should be_nil
@@ -237,9 +237,9 @@ describe XML do
     describe "when the element does not have a namespace, but has namespace declarations" do
       it "should return nil" do
         doc = XML.parse(<<-XML
-        <?xml version="1.0" encoding="UTF-8"?>
-        <feed xmlns:foo="http://www.w3.org/2005/Atom" xmlns:openSearch="http://a9.com/-/spec/opensearchrss/1.0/"></feed>
-        XML
+          <?xml version="1.0" encoding="UTF-8"?>
+          <feed xmlns:foo="http://www.w3.org/2005/Atom" xmlns:openSearch="http://a9.com/-/spec/opensearchrss/1.0/"></feed>
+          XML
         )
 
         doc.root.not_nil!.namespace.should be_nil
@@ -250,11 +250,11 @@ describe XML do
   describe "#namespace_definitions" do
     it "returns namespaces explicitly defined" do
       doc = XML.parse(<<-XML
-      <?xml version="1.0" encoding="UTF-8"?>
-      <feed xmlns="http://www.w3.org/2005/Atom" xmlns:openSearch="http://a9.com/-/spec/opensearchrss/1.0/">
-        <item xmlns:c="http://c"></item>
-      </feed>
-      XML
+        <?xml version="1.0" encoding="UTF-8"?>
+        <feed xmlns="http://www.w3.org/2005/Atom" xmlns:openSearch="http://a9.com/-/spec/opensearchrss/1.0/">
+          <item xmlns:c="http://c"></item>
+        </feed>
+        XML
       )
 
       namespaces = doc.root.not_nil!.first_element_child.not_nil!.namespace_definitions
@@ -266,11 +266,11 @@ describe XML do
 
     it "returns an empty array if no namespaces are defined" do
       doc = XML.parse(<<-XML
-      <?xml version="1.0" encoding="UTF-8"?>
-      <feed xmlns="http://www.w3.org/2005/Atom" xmlns:openSearch="http://a9.com/-/spec/opensearchrss/1.0/">
-        <item></item>
-      </feed>
-      XML
+        <?xml version="1.0" encoding="UTF-8"?>
+        <feed xmlns="http://www.w3.org/2005/Atom" xmlns:openSearch="http://a9.com/-/spec/opensearchrss/1.0/">
+          <item></item>
+        </feed>
+        XML
       )
 
       doc.root.not_nil!.first_element_child.not_nil!.namespace_definitions.should be_empty
@@ -280,10 +280,10 @@ describe XML do
   describe "#namespace_scopes" do
     it "gets root namespaces scopes" do
       doc = XML.parse(<<-XML
-      <?xml version="1.0" encoding="UTF-8"?>
-      <feed xmlns="http://www.w3.org/2005/Atom" xmlns:openSearch="http://a9.com/-/spec/opensearchrss/1.0/">
-      </feed>
-      XML
+        <?xml version="1.0" encoding="UTF-8"?>
+        <feed xmlns="http://www.w3.org/2005/Atom" xmlns:openSearch="http://a9.com/-/spec/opensearchrss/1.0/">
+        </feed>
+        XML
       )
       namespaces = doc.root.not_nil!.namespace_scopes
 
@@ -296,9 +296,9 @@ describe XML do
 
     it "returns empty array if no namespaces scopes exists" do
       doc = XML.parse(<<-XML
-      <?xml version='1.0' encoding='UTF-8'?>
-      <name>John</name>
-      XML
+        <?xml version='1.0' encoding='UTF-8'?>
+        <name>John</name>
+        XML
       )
       namespaces = doc.root.not_nil!.namespace_scopes
 
@@ -307,11 +307,11 @@ describe XML do
 
     it "includes parent namespaces" do
       doc = XML.parse(<<-XML
-      <?xml version="1.0" encoding="UTF-8"?>
-      <feed xmlns="http://www.w3.org/2005/Atom" xmlns:openSearch="http://a9.com/-/spec/opensearchrss/1.0/">
-        <item xmlns:c="http://c"></item>
-      </feed>
-      XML
+        <?xml version="1.0" encoding="UTF-8"?>
+        <feed xmlns="http://www.w3.org/2005/Atom" xmlns:openSearch="http://a9.com/-/spec/opensearchrss/1.0/">
+          <item xmlns:c="http://c"></item>
+        </feed>
+        XML
       )
       namespaces = doc.root.not_nil!.first_element_child.not_nil!.namespace_scopes
 
@@ -328,41 +328,41 @@ describe XML do
   describe "#namespaces" do
     it "gets root namespaces as hash" do
       doc = XML.parse(<<-XML
-      <?xml version="1.0" encoding="UTF-8"?>
-      <feed xmlns="http://www.w3.org/2005/Atom" xmlns:openSearch="http://a9.com/-/spec/opensearchrss/1.0/">
-      </feed>
-      XML
+        <?xml version="1.0" encoding="UTF-8"?>
+        <feed xmlns="http://www.w3.org/2005/Atom" xmlns:openSearch="http://a9.com/-/spec/opensearchrss/1.0/">
+        </feed>
+        XML
       )
       namespaces = doc.root.not_nil!.namespaces
       namespaces.should eq({
-        "xmlns"          => "http://www.w3.org/2005/Atom",
-        "xmlns:openSearch": "http://a9.com/-/spec/opensearchrss/1.0/",
+        "xmlns"            => "http://www.w3.org/2005/Atom",
+        "xmlns:openSearch" => "http://a9.com/-/spec/opensearchrss/1.0/",
       })
     end
 
     it "includes parent namespaces" do
       doc = XML.parse(<<-XML
-      <?xml version="1.0" encoding="UTF-8"?>
-      <feed xmlns="http://www.w3.org/2005/Atom" xmlns:openSearch="http://a9.com/-/spec/opensearchrss/1.0/">
-        <item xmlns:c="http://c"></item>
-      </feed>
-      XML
+        <?xml version="1.0" encoding="UTF-8"?>
+        <feed xmlns="http://www.w3.org/2005/Atom" xmlns:openSearch="http://a9.com/-/spec/opensearchrss/1.0/">
+          <item xmlns:c="http://c"></item>
+        </feed>
+        XML
       )
       namespaces = doc.root.not_nil!.first_element_child.not_nil!.namespaces
       namespaces.should eq({
-        "xmlns:c"        => "http://c",
-        "xmlns"          => "http://www.w3.org/2005/Atom",
-        "xmlns:openSearch": "http://a9.com/-/spec/opensearchrss/1.0/",
+        "xmlns:c"          => "http://c",
+        "xmlns"            => "http://www.w3.org/2005/Atom",
+        "xmlns:openSearch" => "http://a9.com/-/spec/opensearchrss/1.0/",
       })
     end
 
     it "returns an empty hash if there are no namespaces" do
       doc = XML.parse(<<-XML
-      <?xml version="1.0" encoding="UTF-8"?>
-      <feed>
-        <item></item>
-      </feed>
-      XML
+        <?xml version="1.0" encoding="UTF-8"?>
+        <feed>
+          <item></item>
+        </feed>
+        XML
       )
       namespaces = doc.root.not_nil!.first_element_child.not_nil!.namespaces
       namespaces.should eq({} of String => String?)

--- a/spec/std/xml/xml_spec.cr
+++ b/spec/std/xml/xml_spec.cr
@@ -172,11 +172,10 @@ describe XML do
     describe "when the node has a namespace" do
       describe "with a prefix" do
         it "return the prefixed namespace" do
-          doc = XML.parse(<<-XML
+          doc = XML.parse(<<-XML)
             <?xml version="1.0" encoding="UTF-8"?>
             <openSearch:feed xmlns:foo="http://www.w3.org/2005/Atom" xmlns:openSearch="http://a9.com/-/spec/opensearchrss/1.0/"></feed>
             XML
-          )
 
           namespace = doc.root.not_nil!.namespace.should be_a XML::Namespace
           namespace.href.should eq "http://a9.com/-/spec/opensearchrss/1.0/"
@@ -186,11 +185,10 @@ describe XML do
 
       describe "with a default prefix" do
         it "return the default namespace" do
-          doc = XML.parse(<<-XML
+          doc = XML.parse(<<-XML)
             <?xml version="1.0" encoding="UTF-8"?>
             <feed xmlns:foo="http://www.w3.org/2005/Atom" xmlns="http://a9.com/-/spec/opensearchrss/1.0/"></feed>
             XML
-          )
 
           namespace = doc.root.not_nil!.namespace.should be_a XML::Namespace
           namespace.href.should eq "http://a9.com/-/spec/opensearchrss/1.0/"
@@ -200,14 +198,13 @@ describe XML do
 
       describe "without an explicit declaration on the node" do
         it "returns the related namespace" do
-          doc = XML.parse(<<-XML
+          doc = XML.parse(<<-XML)
             <?xml version="1.0" encoding="UTF-8"?>
             <feed xmlns="http://www.w3.org/2005/Atom" xmlns:a="https://a-namespace">
               <name></name>
               <a:age></a:age>
             </feed>
             XML
-          )
 
           root = doc.root.not_nil!
 
@@ -224,11 +221,10 @@ describe XML do
 
     describe "when the node does not have namespace" do
       it "should return nil" do
-        doc = XML.parse(<<-XML
+        doc = XML.parse(<<-XML)
           <?xml version="1.0" encoding="UTF-8"?>
           <feed></feed>
           XML
-        )
 
         doc.root.not_nil!.namespace.should be_nil
       end
@@ -236,11 +232,10 @@ describe XML do
 
     describe "when the element does not have a namespace, but has namespace declarations" do
       it "should return nil" do
-        doc = XML.parse(<<-XML
+        doc = XML.parse(<<-XML)
           <?xml version="1.0" encoding="UTF-8"?>
           <feed xmlns:foo="http://www.w3.org/2005/Atom" xmlns:openSearch="http://a9.com/-/spec/opensearchrss/1.0/"></feed>
           XML
-        )
 
         doc.root.not_nil!.namespace.should be_nil
       end
@@ -249,13 +244,12 @@ describe XML do
 
   describe "#namespace_definitions" do
     it "returns namespaces explicitly defined" do
-      doc = XML.parse(<<-XML
+      doc = XML.parse(<<-XML)
         <?xml version="1.0" encoding="UTF-8"?>
         <feed xmlns="http://www.w3.org/2005/Atom" xmlns:openSearch="http://a9.com/-/spec/opensearchrss/1.0/">
           <item xmlns:c="http://c"></item>
         </feed>
         XML
-      )
 
       namespaces = doc.root.not_nil!.first_element_child.not_nil!.namespace_definitions
 
@@ -265,13 +259,12 @@ describe XML do
     end
 
     it "returns an empty array if no namespaces are defined" do
-      doc = XML.parse(<<-XML
+      doc = XML.parse(<<-XML)
         <?xml version="1.0" encoding="UTF-8"?>
         <feed xmlns="http://www.w3.org/2005/Atom" xmlns:openSearch="http://a9.com/-/spec/opensearchrss/1.0/">
           <item></item>
         </feed>
         XML
-      )
 
       doc.root.not_nil!.first_element_child.not_nil!.namespace_definitions.should be_empty
     end
@@ -279,12 +272,12 @@ describe XML do
 
   describe "#namespace_scopes" do
     it "gets root namespaces scopes" do
-      doc = XML.parse(<<-XML
+      doc = XML.parse(<<-XML)
         <?xml version="1.0" encoding="UTF-8"?>
         <feed xmlns="http://www.w3.org/2005/Atom" xmlns:openSearch="http://a9.com/-/spec/opensearchrss/1.0/">
         </feed>
         XML
-      )
+
       namespaces = doc.root.not_nil!.namespace_scopes
 
       namespaces.size.should eq(2)
@@ -295,24 +288,24 @@ describe XML do
     end
 
     it "returns empty array if no namespaces scopes exists" do
-      doc = XML.parse(<<-XML
+      doc = XML.parse(<<-XML)
         <?xml version='1.0' encoding='UTF-8'?>
         <name>John</name>
         XML
-      )
+
       namespaces = doc.root.not_nil!.namespace_scopes
 
       namespaces.size.should eq(0)
     end
 
     it "includes parent namespaces" do
-      doc = XML.parse(<<-XML
+      doc = XML.parse(<<-XML)
         <?xml version="1.0" encoding="UTF-8"?>
         <feed xmlns="http://www.w3.org/2005/Atom" xmlns:openSearch="http://a9.com/-/spec/opensearchrss/1.0/">
           <item xmlns:c="http://c"></item>
         </feed>
         XML
-      )
+
       namespaces = doc.root.not_nil!.first_element_child.not_nil!.namespace_scopes
 
       namespaces.size.should eq(3)
@@ -327,12 +320,12 @@ describe XML do
 
   describe "#namespaces" do
     it "gets root namespaces as hash" do
-      doc = XML.parse(<<-XML
+      doc = XML.parse(<<-XML)
         <?xml version="1.0" encoding="UTF-8"?>
         <feed xmlns="http://www.w3.org/2005/Atom" xmlns:openSearch="http://a9.com/-/spec/opensearchrss/1.0/">
         </feed>
         XML
-      )
+
       namespaces = doc.root.not_nil!.namespaces
       namespaces.should eq({
         "xmlns"            => "http://www.w3.org/2005/Atom",
@@ -341,13 +334,13 @@ describe XML do
     end
 
     it "includes parent namespaces" do
-      doc = XML.parse(<<-XML
+      doc = XML.parse(<<-XML)
         <?xml version="1.0" encoding="UTF-8"?>
         <feed xmlns="http://www.w3.org/2005/Atom" xmlns:openSearch="http://a9.com/-/spec/opensearchrss/1.0/">
           <item xmlns:c="http://c"></item>
         </feed>
         XML
-      )
+
       namespaces = doc.root.not_nil!.first_element_child.not_nil!.namespaces
       namespaces.should eq({
         "xmlns:c"          => "http://c",
@@ -357,13 +350,13 @@ describe XML do
     end
 
     it "returns an empty hash if there are no namespaces" do
-      doc = XML.parse(<<-XML
+      doc = XML.parse(<<-XML)
         <?xml version="1.0" encoding="UTF-8"?>
         <feed>
           <item></item>
         </feed>
         XML
-      )
+
       namespaces = doc.root.not_nil!.first_element_child.not_nil!.namespaces
       namespaces.should eq({} of String => String?)
     end
@@ -377,11 +370,11 @@ describe XML do
   end
 
   it "sets node text/content" do
-    doc = XML.parse(<<-XML
+    doc = XML.parse(<<-XML)
       <?xml version='1.0' encoding='UTF-8'?>
       <name>John</name>
       XML
-    )
+
     root = doc.root.not_nil!
     root.text = "Peter"
     root.text.should eq("Peter")
@@ -391,11 +384,11 @@ describe XML do
   end
 
   it "doesn't set invalid node content" do
-    doc = XML.parse(<<-XML
+    doc = XML.parse(<<-XML)
       <?xml version='1.0' encoding='UTF-8'?>
       <name>John</name>
       XML
-    )
+
     root = doc.root.not_nil!
     expect_raises(Exception, "Cannot escape") do
       root.content = "\0"

--- a/spec/std/xml/xml_spec.cr
+++ b/spec/std/xml/xml_spec.cr
@@ -197,6 +197,29 @@ describe XML do
           namespace.prefix.should be_nil
         end
       end
+
+      describe "without an explicit declaration on the node" do
+        it "returns the related namespace" do
+          doc = XML.parse(<<-XML
+            <?xml version="1.0" encoding="UTF-8"?>
+            <feed xmlns="http://www.w3.org/2005/Atom" xmlns:a="https://a-namespace">
+              <name></name>
+              <a:age></a:age>
+            </feed>
+            XML
+          )
+
+          root = doc.root.not_nil!
+
+          namespace = root.children[1].namespace.should_not be_nil
+          namespace.href.should eq "http://www.w3.org/2005/Atom"
+          namespace.prefix.should be_nil
+
+          namespace = root.children[3].namespace.should_not be_nil
+          namespace.href.should eq "https://a-namespace"
+          namespace.prefix.should eq "a"
+        end
+      end
     end
 
     describe "when the node does not have namespace" do

--- a/src/xml/node.cr
+++ b/src/xml/node.cr
@@ -298,11 +298,10 @@ class XML::Node
   def namespace_definitions : Array(Namespace)
     namespaces = [] of Namespace
 
-    if ns = @node.value.ns_def
-      while ns
-        namespaces << Namespace.new(document, ns)
-        ns = ns.value.next
-      end
+    ns = @node.value.ns_def
+    while ns
+      namespaces << Namespace.new(document, ns)
+      ns = ns.value.next
     end
 
     namespaces

--- a/src/xml/node.cr
+++ b/src/xml/node.cr
@@ -294,6 +294,20 @@ class XML::Node
     end
   end
 
+  # Returns namespaces defined on self element directly.
+  def namespace_definitions : Array(Namespace)
+    namespaces = [] of Namespace
+
+    if ns = @node.value.ns_def
+      while ns
+        namespaces << Namespace.new(document, ns)
+        ns = ns.value.next
+      end
+    end
+
+    namespaces
+  end
+
   # Returns namespaces in scope for self – those defined on self element
   # directly or any ancestor node – as an `Array` of `XML::Namespace` objects.
   #
@@ -304,13 +318,8 @@ class XML::Node
   def namespace_scopes : Array(Namespace)
     scopes = [] of Namespace
 
-    ns_list = LibXML.xmlGetNsList(@node.value.doc, @node)
-
-    if ns_list
-      while ns_list.value
-        scopes << Namespace.new(document, ns_list.value)
-        ns_list += 1
-      end
+    each_namespace do |namespace|
+      scopes << namespace
     end
 
     scopes


### PR DESCRIPTION
Resolves #11037.

* Improves test coverage `XML::Node` namespace methods
* Adds method to get namespaces explicitly declared on a node
* Leverage the pre-existing `#each_namespace` within `#namespace_scopes`.