### PR TITLE
Fix `File.match?` to accept `Path` type as `path` argument

### DIFF
--- a/spec/std/file_spec.cr
+++ b/spec/std/file_spec.cr
@@ -1315,6 +1315,7 @@ describe "File" do
 
   describe ".match?" do
     it "matches basics" do
+      File.match?("abc", Path["abc"]).should be_true
       File.match?("abc", "abc").should be_true
       File.match?("*", "abc").should be_true
       File.match?("*c", "abc").should be_true

--- a/src/file.cr
+++ b/src/file.cr
@@ -398,7 +398,7 @@ class File < IO::FileDescriptor
     File.expand_brace_pattern(pattern, expanded_patterns)
 
     expanded_patterns.each do |expanded_pattern|
-      return true if match_single_pattern(expanded_pattern, path)
+      return true if match_single_pattern(expanded_pattern, path.to_s)
     end
     false
   end


### PR DESCRIPTION
See https://github.com/crystal-lang/crystal/issues/11014

Added to_s to get Path as a string.