### PR TITLE
Refactor `BigInt#to_s`

### DIFF
--- a/src/big/big_int.cr
+++ b/src/big/big_int.cr
@@ -451,7 +451,6 @@ struct BigInt < Int
             # "____85\0\0" -> "____885\0" for positive
             # "____-85\0\0" -> "____-885\0" for negative
             # `start` will be zero-filled later
-            start += 1 if negative
             start.move_to(start + 1, len)
             offset += 1
           else

--- a/src/big/big_int.cr
+++ b/src/big/big_int.cr
@@ -441,7 +441,7 @@ struct BigInt < Int
       # (required by libgmp).
       String.new(len + 1) do |buffer|
         # Explicitly clear the memory of the second-to last byte because that
-        # migt not be overriden by `LibGMP.get_str` because the value returned
+        # might not be overriden by `LibGMP.get_str` because the value returned
         # by `LibGMP.sizeinbase` can be 1 too big.
         buffer[len - 1] = 0
 

--- a/src/big/big_int.cr
+++ b/src/big/big_int.cr
@@ -426,13 +426,21 @@ struct BigInt < Int
       count = LibGMP.sizeinbase(self, base).to_i
       negative = self < 0
 
-      len = Math.max(count, precision) + (negative ? 1 : 0)
+      if precision > count
+        len = precision
+        offset = precision - count
+      else
+        len = count
+        offset = 0
+      end
+
+      len += 1 if negative
+
       String.new(len + 1) do |buffer|
         # e.g. precision = 13, count = 8
         # "_____12345678\0" for positive
         # "_____-12345678\0" for negative
         buffer[len - 1] = 0
-        offset = (precision - count).clamp(0..)
         start = buffer + offset
         LibGMP.get_str(start, upcase ? -base : base, self)
 


### PR DESCRIPTION
Follow-up on #11063

This patch combines the two branches in the implementation of `BigInt#to_s` into one to reduce duplication. This was originally suggested in https://github.com/crystal-lang/crystal/pull/11063#issuecomment-893011866 (see following comments for initial discussion). There are also some smaller improvements and additional code comments.

I think this is an improvement because it reduces the code and makes it easier to reason about when there's only a single code path instead of two separate ones for almost the same operations.