### PR TITLE
HTTP::Client retry once on socket error (if server reset the connection on keepalive timeout)

### DIFF
--- a/spec/std/http/client/client_spec.cr
+++ b/spec/std/http/client/client_spec.cr
@@ -179,6 +179,68 @@ module HTTP
       end
     end
 
+    it "can close a broken socket" do
+      server = HTTP::Server.new do |context|
+        context.response.output.print "foo"
+        io = context.response.@io.as(Socket)
+        spawn do
+          io.linger = 0 # with linger 0 the socket will be RST on close
+          io.close
+        end
+      end
+      address = server.bind_unused_port "127.0.0.1"
+
+      run_server(server) do
+        client = HTTP::Client.new("127.0.0.1", address.port)
+        client.get(path: "/").body.should eq "foo"
+        begin
+          client.get(path: "/") # will raise a broken socket error
+        rescue IO::Error
+          client.close rescue nil
+        end
+        client.get(path: "/").body.should eq "foo"
+      end
+    end
+
+    it "will retry a broken socket" do
+      server = HTTP::Server.new do |context|
+        context.response.output.print "foo"
+        io = context.response.@io.as(Socket)
+        spawn do
+          io.linger = 0 # with linger 0 the socket will be RST on close
+          io.close
+        end
+      end
+      address = server.bind_unused_port "127.0.0.1"
+
+      run_server(server) do
+        client = HTTP::Client.new("127.0.0.1", address.port)
+        client.get(path: "/").body.should eq "foo"
+        client.get(path: "/").body.should eq "foo"
+      end
+    end
+
+    it "will retry once on connection error" do
+      requests = 0
+      server = HTTP::Server.new do |context|
+        requests += 1
+        io = context.response.@io.as(Socket)
+        io.linger = 0 # with linger 0 the socket will be RST on close
+        io.close
+      end
+      address = server.bind_unused_port "127.0.0.1"
+
+      run_server(server) do
+        client = HTTP::Client.new("127.0.0.1", address.port)
+        begin
+          client.get(path: "/")
+        rescue ex
+          ex.message.should eq "Unexpected end of http response"
+        end
+        requests.should eq 2
+      end
+    end
+
     it "doesn't read the body if request was HEAD" do
       resp_get = test_server("localhost", 0, 0) do |server|
         client = Client.new("localhost", server.local_address.port)

--- a/spec/std/http/client/client_spec.cr
+++ b/spec/std/http/client/client_spec.cr
@@ -208,7 +208,7 @@ module HTTP
 
       run_server(server) do
         client = HTTP::Client.new("127.0.0.1", address.port)
-        expect_raises(Exception, "Unexpected end of http response") do
+        expect_raises(IO::Error) do
           client.get(path: "/")
         end
         requests.should eq 2

--- a/src/http/client.cr
+++ b/src/http/client.cr
@@ -638,7 +638,7 @@ class HTTP::Client
   private def exec_internal_single(request)
     decompress = send_request(request)
     HTTP::Client::Response.from_io(io, ignore_body: request.ignore_body?, decompress: decompress) do |response|
-      return yield response
+      yield response
     end
   end
 

--- a/src/http/client.cr
+++ b/src/http/client.cr
@@ -631,16 +631,14 @@ class HTTP::Client
     close
     request.body.try &.rewind
     exec_internal_single(request) do |response|
-      return handle_response(response) do
-        yield response
-      end
+      return handle_response(response) { yield response }
     end
   end
 
-  private def exec_internal_single(request) : HTTP::Client::Response
+  private def exec_internal_single(request)
     decompress = send_request(request)
     HTTP::Client::Response.from_io(io, ignore_body: request.ignore_body?, decompress: decompress) do |response|
-      yield response
+      return yield response
     end
   end
 

--- a/src/http/client.cr
+++ b/src/http/client.cr
@@ -760,7 +760,7 @@ class HTTP::Client
 
   # Closes this client. If used again, a new connection will be opened.
   def close : Nil
-    @io.try &.close
+    @io.try &.close rescue nil
     @io = nil
   end
 

--- a/src/http/client/response.cr
+++ b/src/http/client/response.cr
@@ -149,6 +149,6 @@ class HTTP::Client::Response
       return yield new status, nil, headers, status_message, http_version, body
     end
 
-    return yield nil
+    yield nil
   end
 end

--- a/src/http/client/response.cr
+++ b/src/http/client/response.cr
@@ -92,7 +92,7 @@ class HTTP::Client::Response
 
   def self.from_io(io, ignore_body = false, decompress = true)
     from_io?(io, ignore_body, decompress) ||
-      raise("Unexpected end of http request")
+      raise IO::EOFError.new("Unexpected end of http request")
   end
 
   # Parses an `HTTP::Client::Response` from the given `IO`.
@@ -114,9 +114,9 @@ class HTTP::Client::Response
       if response
         yield response
       else
-        raise("Unexpected end of http request")
+        raise IO::EOFError.new("Unexpected end of http request")
       end
-    end
+    end || raise IO::EOFError.new("Unexpected end of http request")
   end
 
   # Parses an `HTTP::Client::Response` from the given `IO` and yields

--- a/src/http/client/response.cr
+++ b/src/http/client/response.cr
@@ -116,7 +116,7 @@ class HTTP::Client::Response
       else
         raise IO::EOFError.new("Unexpected end of http request")
       end
-    end || raise IO::EOFError.new("Unexpected end of http request")
+    end
   end
 
   # Parses an `HTTP::Client::Response` from the given `IO` and yields
@@ -149,6 +149,6 @@ class HTTP::Client::Response
       return yield new status, nil, headers, status_message, http_version, body
     end
 
-    nil
+    return yield nil
   end
 end


### PR DESCRIPTION
Without this change `@io` is never set to nil, if the `@io.close` raises, so the same (broken) `@io` is reused again and again even if the exception is rescued further up, the http client will never try to reconnect.

```crystal
http = HTTP::Client.new("localhost")
loop do
  sleep 1
  # If localhost closes the socket while writing we first get `Error writing to socket: Broken pipe (IO::Error)`
  # and then in the next iteration `Closed stream (IO::Error)`
  http.get("/") 
rescue
  http.close rescue nil # `Closed stream (IO::Error)` is raised when trying to close and reconnect
end
```

But maybe a wider change is desirable? 

If the socket is closed while reading (but not when sending the request), the HTTP::Client automatically retry one time: https://github.com/crystal-lang/crystal/blob/master/src/http/client.cr#L589-L593

And that's because: https://github.com/crystal-lang/crystal/blob/master/src/http/client/response.cr#L127

Should the http client automaitcally retry one time also when trying to write to a socket? I think so, it's very common that a TCP connection is closed by the server when there's longer delay between requests to a server that supports keepalive. 