### PR TITLE
Fix trailing rescue syntax

### DIFF
--- a/src/http/server.cr
+++ b/src/http/server.cr
@@ -514,7 +514,10 @@ class HTTP::Server
 
     @processor.process(io, io)
   ensure
-    io.close rescue IO::Error
+    begin
+      io.close
+    rescue IO::Error
+    end
   end
 
   # This method handles exceptions raised at `Socket#accept?`.


### PR DESCRIPTION
This syntax is used incorrectly due to confusion with block rescue syntax where `rescue IO::Error` means rescuing an exception of type `IO::Error`.

In this case, `expr rescue IO::Error` means if `expr` raises, the value becomes `IO::Error`. 

See https://github.com/crystal-lang/crystal/issues/11017#issuecomment-886725814