### PR TITLE
Retry HTTP::Client requests once if io is closed

### DIFF
--- a/spec/std/http/client/client_spec.cr
+++ b/spec/std/http/client/client_spec.cr
@@ -193,6 +193,9 @@ module HTTP
         client = HTTP::Client.new("127.0.0.1", address.port)
         client.get(path: "/").body.should eq "foo"
         client.get(path: "/").body.should eq "foo"
+        client.get(path: "/") do |resp|
+          resp.body_io.gets_to_end.should eq "foo"
+        end
       end
     end
 

--- a/spec/std/http/client/client_spec.cr
+++ b/spec/std/http/client/client_spec.cr
@@ -179,6 +179,42 @@ module HTTP
       end
     end
 
+    it "will retry a broken socket" do
+      server = HTTP::Server.new do |context|
+        context.response.output.print "foo"
+        context.response.output.close
+        io = context.response.@io.as(Socket)
+        io.linger = 0 # with linger 0 the socket will be RST on close
+        io.close
+      end
+      address = server.bind_unused_port "127.0.0.1"
+
+      run_server(server) do
+        client = HTTP::Client.new("127.0.0.1", address.port)
+        client.get(path: "/").body.should eq "foo"
+        client.get(path: "/").body.should eq "foo"
+      end
+    end
+
+    it "will retry once on connection error" do
+      requests = 0
+      server = HTTP::Server.new do |context|
+        requests += 1
+        io = context.response.@io.as(Socket)
+        io.linger = 0 # with linger 0 the socket will be RST on close
+        io.close
+      end
+      address = server.bind_unused_port "127.0.0.1"
+
+      run_server(server) do
+        client = HTTP::Client.new("127.0.0.1", address.port)
+        expect_raises(IO::Error) do
+          client.get(path: "/")
+        end
+        requests.should eq 2
+      end
+    end
+
     it "doesn't read the body if request was HEAD" do
       resp_get = test_server("localhost", 0, 0) do |server|
         client = Client.new("localhost", server.local_address.port)

--- a/src/http/client.cr
+++ b/src/http/client.cr
@@ -584,20 +584,18 @@ class HTTP::Client
 
   private def exec_internal(request)
     response = exec_internal_single(request)
-    return handle_response(response) if response
-
+    handle_response(response)
+  rescue IO::Error
     # Server probably closed the connection, so retry one
     close
     request.body.try &.rewind
     response = exec_internal_single(request)
-    return handle_response(response) if response
-
-    raise "Unexpected end of http response"
+    handle_response(response)
   end
 
   private def exec_internal_single(request)
     decompress = send_request(request)
-    HTTP::Client::Response.from_io?(io, ignore_body: request.ignore_body?, decompress: decompress)
+    HTTP::Client::Response.from_io(io, ignore_body: request.ignore_body?, decompress: decompress)
   end
 
   private def handle_response(response)
@@ -626,27 +624,20 @@ class HTTP::Client
 
   private def exec_internal(request, &block : Response -> T) : T forall T
     exec_internal_single(request) do |response|
-      if response
-        return handle_response(response) { yield response }
-      end
-
-      # Server probably closed the connection, so retry once
-      close
-      request.body.try &.rewind
-      exec_internal_single(request) do |response|
-        if response
-          return handle_response(response) do
-            yield response
-          end
-        end
-      end
+      return handle_response(response) { yield response }
     end
-    raise "Unexpected end of http response"
+  rescue IO::Error
+    # Server probably closed the connection, so retry once
+    close
+    request.body.try &.rewind
+    exec_internal_single(request) do |response|
+      return handle_response(response) { yield response }
+    end
   end
 
   private def exec_internal_single(request)
     decompress = send_request(request)
-    HTTP::Client::Response.from_io?(io, ignore_body: request.ignore_body?, decompress: decompress) do |response|
+    HTTP::Client::Response.from_io(io, ignore_body: request.ignore_body?, decompress: decompress) do |response|
       yield response
     end
   end
@@ -761,6 +752,9 @@ class HTTP::Client
   # Closes this client. If used again, a new connection will be opened.
   def close : Nil
     @io.try &.close
+  rescue IO::Error
+    nil # Ignore already closed socket errors, otherwise `exec_internal` won't retry
+  ensure
     @io = nil
   end
 

--- a/src/http/client/response.cr
+++ b/src/http/client/response.cr
@@ -92,7 +92,7 @@ class HTTP::Client::Response
 
   def self.from_io(io, ignore_body = false, decompress = true)
     from_io?(io, ignore_body, decompress) ||
-      raise("Unexpected end of http request")
+      raise IO::EOFError.new("Unexpected end of http request")
   end
 
   # Parses an `HTTP::Client::Response` from the given `IO`.
@@ -114,7 +114,7 @@ class HTTP::Client::Response
       if response
         yield response
       else
-        raise("Unexpected end of http request")
+        raise IO::EOFError.new("Unexpected end of http request")
       end
     end
   end
@@ -149,6 +149,6 @@ class HTTP::Client::Response
       return yield new status, nil, headers, status_message, http_version, body
     end
 
-    nil
+    yield nil
   end
 end

--- a/src/http/client/response.cr
+++ b/src/http/client/response.cr
@@ -92,7 +92,7 @@ class HTTP::Client::Response
 
   def self.from_io(io, ignore_body = false, decompress = true)
     from_io?(io, ignore_body, decompress) ||
-      raise IO::EOFError.new("Unexpected end of http request")
+      raise("Unexpected end of http request")
   end
 
   # Parses an `HTTP::Client::Response` from the given `IO`.
@@ -114,7 +114,7 @@ class HTTP::Client::Response
       if response
         yield response
       else
-        raise IO::EOFError.new("Unexpected end of http request")
+        raise("Unexpected end of http request")
       end
     end
   end
@@ -149,6 +149,6 @@ class HTTP::Client::Response
       return yield new status, nil, headers, status_message, http_version, body
     end
 
-    yield nil
+    nil
   end
 end


### PR DESCRIPTION
Earlier only reads would be retried, but a very common scenario in the
wild is that the HTTP server resets the client connection after some
time. When the persistent HTTP::Client then did a request it would fail,
and it couldn't even be recovered because `close` would raise an
exception too, never setting `@io` to nil.

Without this patch `HTTP::Client` can't be used in any real-world
scenarios using HTTP keepalive, at least not without monkey-patching
`HTTP::Client#close` and catching and retrying your self, not very user
friendly. Also confusing when read errors are retried but not write
errors.

This change makes HTTP::Client::Request.from_io raise an IO::EOFError if the
header can't be read, instead of simply returning nil. That exception is
caught once, the `@io` closed (by ignoring IO::Error in close), and retries
the request once more, next time a proper exception is raised to the
user.