### PR TITLE
Improve error message for type errors in container literals 

### DIFF
--- a/spec/compiler/codegen/array_literal_spec.cr
+++ b/spec/compiler/codegen/array_literal_spec.cr
@@ -266,7 +266,7 @@ end
 
 private def enumerable_element_type
   %(
-    struct Enumerable(T)
+    module Enumerable(T)
       def self.element_type(x)
         x.each { |elem| return elem }
         ret = uninitialized NoReturn

--- a/spec/compiler/semantic/array_spec.cr
+++ b/spec/compiler/semantic/array_spec.cr
@@ -40,4 +40,62 @@ describe "Semantic: array" do
   it "types array literal of int with splats" do
     assert_type("require \"prelude\"; [1, *{2_i8, 3_i8}, 4] of Int8") { array_of(int8) }
   end
+
+  it "errors if typed array literal has incorrect element type" do
+    ex = assert_error <<-CR,
+      require "prelude"
+      ["", "", 123, ""] of String
+      CR
+      "element of typed array literal must be String, not Int32"
+
+    ex.line_number.should eq(2)
+    ex.column_number.should eq(10)
+  end
+
+  it "errors if typed array literal has incorrect splat element type" do
+    ex = assert_error <<-CR,
+      require "prelude"
+      ["", "", *{123, ""}, ""] of String
+      CR
+      "splat element of typed array literal must be Enumerable(T) for some T <= String, not Tuple(Int32, String)"
+
+    ex.line_number.should eq(2)
+    ex.column_number.should eq(10)
+  end
+
+  it "errors if typed array literal has incorrect splat element type (2)" do
+    ex = assert_error <<-CR,
+      require "prelude"
+
+      class Foo
+      end
+
+      class Bar < Foo
+      end
+
+      [*[Foo.new]] of Bar
+      CR
+      "splat element of typed array literal must be Enumerable(T) for some T <= Bar, not Array(Foo)"
+
+    ex.line_number.should eq(9)
+    ex.column_number.should eq(2)
+  end
+
+  it "doesn't error if typed array literal has compatible splat element type" do
+    assert_type("require \"prelude\"; [*[1], *{true}] of Int32 | Bool") { array_of(union_of int32, bool) }
+  end
+
+  it "doesn't error if typed array literal has compatible splat element type (2)" do
+    assert_type(%(
+      require "prelude"
+
+      class Foo
+      end
+
+      class Bar < Foo
+      end
+
+      [*[Bar.new], *{Bar.new}] of Foo
+      )) { array_of types["Foo"].virtual_type }
+  end
 end

--- a/spec/compiler/semantic/array_spec.cr
+++ b/spec/compiler/semantic/array_spec.cr
@@ -17,7 +17,7 @@ describe "Semantic: array" do
     assert_type("require \"prelude\"; [1, 2, 3] of Int32") { array_of(int32) }
   end
 
-  it "types non-empty typed array literal of int" do
+  it "types non-empty typed array literal of int, with autocast" do
     assert_type("require \"prelude\"; [1, 2, 3] of Int8") { array_of(int8) }
   end
 

--- a/spec/compiler/semantic/hash_spec.cr
+++ b/spec/compiler/semantic/hash_spec.cr
@@ -1,6 +1,34 @@
 require "../../spec_helper"
 
 describe "Semantic: hash" do
+  it "types hash literal of int" do
+    assert_type("require \"prelude\"; {1 => 2, 3 => 4, 5 => 6}") { hash_of(int32, int32) }
+  end
+
+  it "types hash literal of union" do
+    assert_type("require \"prelude\"; {1 => 2.5, 'a' => \"foo\"}") { hash_of(union_of(int32, char), union_of(float64, string)) }
+  end
+
+  it "types empty typed hash literal of int32 => int32" do
+    assert_type("require \"prelude\"; {} of Int32 => Int32") { hash_of(int32, int32) }
+  end
+
+  it "types non-empty typed hash literal of int" do
+    assert_type("require \"prelude\"; {1 => 2, 3 => 4, 5 => 6} of Int32 => Int32") { hash_of(int32, int32) }
+  end
+
+  it "types non-empty typed hash literal of int, with autocast" do
+    assert_type("require \"prelude\"; {1 => 2, 3 => 4, 5 => 6} of Int8 => Int64") { hash_of(int8, int64) }
+  end
+
+  it "types hash literal size correctly" do
+    assert_type("require \"prelude\"; {1 => 2}.size") { int32 }
+  end
+
+  it "assignment in hash literal works" do
+    assert_type("require \"prelude\"; {(a = 1) => (b = 2)}; {a, b}") { tuple_of [int32, int32] }
+  end
+
   it "errors if typed hash literal has incorrect key element type" do
     ex = assert_error <<-CR,
       require "prelude"

--- a/spec/compiler/semantic/hash_spec.cr
+++ b/spec/compiler/semantic/hash_spec.cr
@@ -1,0 +1,25 @@
+require "../../spec_helper"
+
+describe "Semantic: hash" do
+  it "errors if typed hash literal has incorrect key element type" do
+    ex = assert_error <<-CR,
+      require "prelude"
+      {1 => 'a', "" => 'b'} of Int32 => Char
+      CR
+      "key element of typed hash literal must be Int32, not String"
+
+    ex.line_number.should eq(2)
+    ex.column_number.should eq(12)
+  end
+
+  it "errors if typed hash literal has incorrect value element type" do
+    ex = assert_error <<-CR,
+      require "prelude"
+      {'a' => 1, 'b' => ""} of Char => Int32
+      CR
+      "value element of typed hash literal must be Int32, not String"
+
+    ex.line_number.should eq(2)
+    ex.column_number.should eq(19)
+  end
+end

--- a/src/compiler/crystal/program.cr
+++ b/src/compiler/crystal/program.cr
@@ -169,6 +169,8 @@ module Crystal
       pointer.struct = true
       pointer.can_be_stored = false
 
+      types["Enumerable"] = @enumerable = GenericModuleType.new self, self, "Enumerable", ["T"]
+
       types["Tuple"] = tuple = @tuple = TupleType.new self, self, "Tuple", value, ["T"]
       tuple.can_be_stored = false
 
@@ -451,7 +453,7 @@ module Crystal
 
     {% for name in %w(object no_return value number reference void nil bool char int int8 int16 int32 int64 int128
                      uint8 uint16 uint32 uint64 uint128 float float32 float64 string symbol pointer array static_array
-                     exception tuple named_tuple proc union enum range regex crystal
+                     exception enumerable tuple named_tuple proc union enum range regex crystal
                      packed_annotation thread_local_annotation no_inline_annotation
                      always_inline_annotation naked_annotation returns_twice_annotation
                      raises_annotation primitive_annotation call_convention_annotation


### PR DESCRIPTION
Fixes #10937. Fixes #8700.

All element nodes are cloned prior to checking for type errors. I tried not to and macOS CI gave me a very cryptic arithmetic overflow inside a 128-bit integer constant during codegen.

`Enumerable` is now a built-in module, but no other built-in types include it inside `Crystal::Program` yet; they are still done in the standard library.