### PR TITLE
Don't use `:nodoc:` when overriding public methods

### DIFF
--- a/src/array.cr
+++ b/src/array.cr
@@ -208,7 +208,6 @@ class Array(T)
     equals?(other) { |x, y| x == y }
   end
 
-  # :nodoc:
   def ==(other)
     false
   end
@@ -1052,7 +1051,6 @@ class Array(T)
     self
   end
 
-  # :nodoc:
   def inspect(io : IO) : Nil
     to_s io
   end
@@ -2268,7 +2266,6 @@ class Array(T)
     end
   end
 
-  # :nodoc:
   def index(object, offset : Int = 0)
     # Optimize for the case of looking for a byte in a byte slice
     if T.is_a?(UInt8.class) &&

--- a/src/big/big_int.cr
+++ b/src/big/big_int.cr
@@ -535,7 +535,6 @@ struct BigInt < Int
     end
   end
 
-  # :nodoc:
   def digits(base = 10) : Array(Int32)
     if self < 0
       raise ArgumentError.new("Can't request digits of negative number")

--- a/src/compress/deflate/reader.cr
+++ b/src/compress/deflate/reader.cr
@@ -148,7 +148,6 @@ class Compress::Deflate::Reader < IO
     initialize(@io, @sync_close, @dict)
   end
 
-  # :nodoc:
   def inspect(io : IO) : Nil
     to_s(io)
   end

--- a/src/compress/deflate/writer.cr
+++ b/src/compress/deflate/writer.cr
@@ -81,7 +81,6 @@ class Compress::Deflate::Writer < IO
     @closed
   end
 
-  # :nodoc:
   def inspect(io : IO) : Nil
     to_s(io)
   end

--- a/src/crystal/datum.cr
+++ b/src/crystal/datum.cr
@@ -130,12 +130,10 @@ module Crystal
       self[index_or_key]
     end
 
-    # :nodoc:
     def inspect(io : IO) : Nil
       @raw.inspect(io)
     end
 
-    # :nodoc:
     def to_s(io : IO) : Nil
       @raw.to_s(io)
     end

--- a/src/enum.cr
+++ b/src/enum.cr
@@ -248,7 +248,6 @@ struct Enum
     value <=> other.value
   end
 
-  # :nodoc:
   def ==(other)
     false
   end

--- a/src/indexable.cr
+++ b/src/indexable.cr
@@ -572,7 +572,11 @@ module Indexable(T)
     unsafe_fetch(random.rand(size))
   end
 
-  # :nodoc:
+  # :inherit:
+  #
+  # If `self` is not empty and `n` is equal to 1, calls `sample(random)` exactly
+  # once. Thus, *random* will be left in a different state compared to the
+  # implementation in `Enumerable`.
   def sample(n : Int, random = Random::DEFAULT) : Array(T)
     return super unless n == 1
 

--- a/src/io/memory.cr
+++ b/src/io/memory.cr
@@ -169,7 +169,6 @@ class IO::Memory < IO
     string
   end
 
-  # :nodoc:
   def read_byte : UInt8?
     check_open
 
@@ -184,7 +183,6 @@ class IO::Memory < IO
     end
   end
 
-  # :nodoc:
   def peek : Bytes
     check_open
 
@@ -203,14 +201,12 @@ class IO::Memory < IO
     end
   end
 
-  # :nodoc:
   def skip_to_end : Nil
     check_open
 
     @pos = @bytesize
   end
 
-  # :nodoc:
   def gets_to_end : String
     return super if @encoding
 

--- a/src/json/any.cr
+++ b/src/json/any.cr
@@ -246,12 +246,10 @@ struct JSON::Any
     as_h if @raw.is_a?(Hash)
   end
 
-  # :nodoc:
   def inspect(io : IO) : Nil
     @raw.inspect(io)
   end
 
-  # :nodoc:
   def to_s(io : IO) : Nil
     @raw.to_s(io)
   end

--- a/src/log/metadata.cr
+++ b/src/log/metadata.cr
@@ -175,7 +175,6 @@ class Log::Metadata
     true
   end
 
-  # :nodoc:
   def ==(other)
     false
   end

--- a/src/range.cr
+++ b/src/range.cr
@@ -327,14 +327,12 @@ struct Range(B, E)
     includes?(value)
   end
 
-  # :nodoc:
   def to_s(io : IO) : Nil
     @begin.try &.inspect(io)
     io << (@exclusive ? "..." : "..")
     @end.try &.inspect(io)
   end
 
-  # :nodoc:
   def inspect(io : IO) : Nil
     to_s(io)
   end
@@ -387,7 +385,11 @@ struct Range(B, E)
     {% end %}
   end
 
-  # :nodoc:
+  # :inherit:
+  #
+  # If `self` is not empty and `n` is equal to 1, calls `sample(random)` exactly
+  # once. Thus, *random* will be left in a different state compared to the
+  # implementation in `Enumerable`.
   def sample(n : Int, random = Random::DEFAULT)
     {% if B == Nil || E == Nil %}
       {% raise "Can't sample an open range" %}
@@ -411,7 +413,6 @@ struct Range(B, E)
     Range.new(@begin.clone, @end.clone, @exclusive)
   end
 
-  # :nodoc:
   def map(&block : B -> U) forall U
     b = self.begin
     e = self.end
@@ -427,7 +428,15 @@ struct Range(B, E)
     end
   end
 
-  # :nodoc:
+  # Returns the number of values in this range.
+  #
+  # If both the beginning and the end of this range are `Int`s, runs in constant
+  # time instead of linear.
+  #
+  # ```
+  # (3..8).size  # => 5
+  # (3...8).size # => 6
+  # ```
   def size
     {% if B == Nil || E == Nil %}
       {% raise "Can't calculate size of an open range" %}

--- a/src/slice.cr
+++ b/src/slice.cr
@@ -895,7 +895,6 @@ struct Slice(T)
     self
   end
 
-  # :nodoc:
   def index(object, offset : Int = 0)
     # Optimize for the case of looking for a byte in a byte slice
     if T.is_a?(UInt8.class) &&

--- a/src/static_array.cr
+++ b/src/static_array.cr
@@ -300,7 +300,6 @@ struct StaticArray(T, N)
     array
   end
 
-  # :nodoc:
   def index(object, offset : Int = 0)
     # Optimize for the case of looking for a byte in a byte slice
     if T.is_a?(UInt8.class) &&

--- a/src/yaml/any.cr
+++ b/src/yaml/any.cr
@@ -279,12 +279,10 @@ struct YAML::Any
     @raw.as?(Bytes)
   end
 
-  # :nodoc:
   def inspect(io : IO) : Nil
     @raw.inspect(io)
   end
 
-  # :nodoc:
   def to_s(io : IO) : Nil
     @raw.to_s(io)
   end


### PR DESCRIPTION
See https://github.com/crystal-lang/crystal/issues/11085#issuecomment-898330099.