### PR TITLE
fix parsing cookie Domain attribute with leading dot

### DIFF
--- a/spec/std/http/cookie_spec.cr
+++ b/spec/std/http/cookie_spec.cr
@@ -245,6 +245,14 @@ module HTTP
         cookie.to_set_cookie_header.should eq("key=value; domain=www.example.com")
       end
 
+      it "leading dots in domain names are ignored" do
+        cookie = parse_set_cookie("key=value; domain=.example.com")
+        cookie.name.should eq("key")
+        cookie.value.should eq("value")
+        cookie.domain.should eq("example.com")
+        cookie.to_set_cookie_header.should eq("key=value; domain=example.com")
+      end
+
       it "parses expires iis" do
         cookie = parse_set_cookie("key=value; expires=Sun, 06-Nov-1994 08:49:37 GMT")
         time = Time.utc(1994, 11, 6, 8, 49, 37)

--- a/src/http/cookie.cr
+++ b/src/http/cookie.cr
@@ -141,7 +141,7 @@ module HTTP
         SameSiteAV     = /SameSite=(?<samesite>\w+)/i
         SecureAV       = /(?<secure>Secure)/i
         PathAV         = /Path=(?<path>#{PathValue})/i
-        DomainAV       = /Domain=(?<domain>#{DomainValue})/i
+        DomainAV       = /Domain=\.?(?<domain>#{DomainValue})/i
         MaxAgeAV       = /Max-Age=(?<max_age>[0-9]*)/i
         ExpiresAV      = /Expires=(?<expires>#{SaneCookieDate})/i
         CookieAV       = /(?:#{ExpiresAV}|#{MaxAgeAV}|#{DomainAV}|#{PathAV}|#{SecureAV}|#{HttpOnlyAV}|#{SameSiteAV}|#{ExtensionAV})/


### PR DESCRIPTION
Domain with leading dot (e.g. `.example.com`) breaks cookies parser.

Code to reproduce the issue:

```crystal
cookie = "foo=bar; expires=Thu, 01 Jan 1970 00:00:01 GMT; path=/; domain=.example.com; SameSite=None; secure; HttpOnly"

puts HTTP::Cookie::Parser.parse_set_cookie(cookie).inspect
```
Before:

```
#<HTTP::Cookie:0x7fce81225ee0 @name="foo", @value="bar", @path="/", @expires=1970-01-01 00:00:01.0 UTC, @domain=nil, @secure=false, @http_only=false, @samesite=nil, @extension="domain=.example.com; SameSite=None; secure; HttpOnly">
```

After:

```
#<HTTP::Cookie:0x7f09a3b29ee0 @name="foo", @value="bar", @path="/", @expires=1970-01-01 00:00:01.0 UTC, @domain="example.com", @secure=true, @http_only=true, @samesite=None, @extension=nil>
```

According to [RFC 6265 section 4.1.2.3](https://datatracker.ietf.org/doc/html/rfc6265#section-4.1.2.3)

> (Note that a leading %x2E ("."), if present,
   is ignored even though that character is not permitted, but a
   trailing %x2E ("."), if present, will cause the user agent to ignore
   the attribute.)  If the server omits the Domain attribute, the user
   agent will return the cookie only to the origin server.
