### PR TITLE
Make `TypeNode#name` respect `generic_args: false` in more places

### DIFF
--- a/spec/compiler/macro/macro_methods_spec.cr
+++ b/spec/compiler/macro/macro_methods_spec.cr
@@ -1456,10 +1456,36 @@ module Crystal
             assert_macro("klass", "{{klass.name}}", "SomeType(A, B)") do |program|
               [TypeNode.new(GenericClassType.new(program, program, "SomeType", program.object, ["A", "B"]))] of ASTNode
             end
+
+            assert_macro("klass", "{{klass.name}}", "SomeType(A, B)") do |program|
+              [TypeNode.new(GenericModuleType.new(program, program, "SomeType", ["A", "B"]))] of ASTNode
+            end
+
+            assert_macro("klass", "{{klass.class.name}}", "SomeType(A, B).class") do |program|
+              [TypeNode.new(GenericClassType.new(program, program, "SomeType", program.object, ["A", "B"]))] of ASTNode
+            end
+
+            assert_macro("klass", "{{klass.class.name}}", "SomeType(A, B):Module") do |program|
+              [TypeNode.new(GenericModuleType.new(program, program, "SomeType", ["A", "B"]))] of ASTNode
+            end
           end
 
           it "includes the generic_args of the instantiated type by default" do
             assert_macro("", "{{Array(Int32).name}}", [] of ASTNode, "Array(Int32)")
+            assert_macro("", "{{Tuple(Int32).name}}", [] of ASTNode, "Tuple(Int32)")
+            assert_macro("", "{{Proc(Int32).name}}", [] of ASTNode, "Proc(Int32)")
+            assert_macro("", "{{NamedTuple(a: Int32).name}}", [] of ASTNode, "NamedTuple(a: Int32)")
+            assert_macro("", "{{Array(Int32).class.name}}", [] of ASTNode, "Array(Int32).class")
+
+            assert_macro("mod", "{{mod.name}}", "SomeType(Int32, String)") do |program|
+              generic_module = GenericModuleType.new(program, program, "SomeType", ["A", "B"])
+              [TypeNode.new(generic_module.instantiate([program.int32, program.string] of TypeVar))] of ASTNode
+            end
+
+            assert_macro("mod", "{{mod.class.name}}", "SomeType(Int32, String).class") do |program|
+              generic_module = GenericModuleType.new(program, program, "SomeType", ["A", "B"])
+              [TypeNode.new(generic_module.instantiate([program.int32, program.string] of TypeVar))] of ASTNode
+            end
           end
         end
 
@@ -1469,10 +1495,36 @@ module Crystal
               assert_macro("klass", "{{klass.name(generic_args: true)}}", "SomeType(A, B)") do |program|
                 [TypeNode.new(GenericClassType.new(program, program, "SomeType", program.object, ["A", "B"]))] of ASTNode
               end
+
+              assert_macro("klass", "{{klass.name(generic_args: true)}}", "SomeType(A, B)") do |program|
+                [TypeNode.new(GenericModuleType.new(program, program, "SomeType", ["A", "B"]))] of ASTNode
+              end
+
+              assert_macro("klass", "{{klass.class.name(generic_args: true)}}", "SomeType(A, B).class") do |program|
+                [TypeNode.new(GenericClassType.new(program, program, "SomeType", program.object, ["A", "B"]))] of ASTNode
+              end
+
+              assert_macro("klass", "{{klass.class.name(generic_args: true)}}", "SomeType(A, B):Module") do |program|
+                [TypeNode.new(GenericModuleType.new(program, program, "SomeType", ["A", "B"]))] of ASTNode
+              end
             end
 
             it "includes the generic_args of the instantiated type" do
               assert_macro("", "{{Array(Int32).name(generic_args: true)}}", [] of ASTNode, "Array(Int32)")
+              assert_macro("", "{{Tuple(Int32).name(generic_args: true)}}", [] of ASTNode, "Tuple(Int32)")
+              assert_macro("", "{{Proc(Int32).name(generic_args: true)}}", [] of ASTNode, "Proc(Int32)")
+              assert_macro("", "{{NamedTuple(a: Int32).name(generic_args: true)}}", [] of ASTNode, "NamedTuple(a: Int32)")
+              assert_macro("", "{{Array(Int32).class.name(generic_args: true)}}", [] of ASTNode, "Array(Int32).class")
+
+              assert_macro("mod", "{{mod.name(generic_args: true)}}", "SomeType(Int32, String)") do |program|
+                generic_module = GenericModuleType.new(program, program, "SomeType", ["A", "B"])
+                [TypeNode.new(generic_module.instantiate([program.int32, program.string] of TypeVar))] of ASTNode
+              end
+
+              assert_macro("mod", "{{mod.class.name(generic_args: true)}}", "SomeType(Int32, String).class") do |program|
+                generic_module = GenericModuleType.new(program, program, "SomeType", ["A", "B"])
+                [TypeNode.new(generic_module.instantiate([program.int32, program.string] of TypeVar))] of ASTNode
+              end
             end
           end
 
@@ -1481,10 +1533,36 @@ module Crystal
               assert_macro("klass", "{{klass.name(generic_args: false)}}", "SomeType") do |program|
                 [TypeNode.new(GenericClassType.new(program, program, "SomeType", program.object, ["A", "B"]))] of ASTNode
               end
+
+              assert_macro("klass", "{{klass.name(generic_args: false)}}", "SomeType") do |program|
+                [TypeNode.new(GenericModuleType.new(program, program, "SomeType", ["A", "B"]))] of ASTNode
+              end
+
+              assert_macro("klass", "{{klass.class.name(generic_args: false)}}", "SomeType.class") do |program|
+                [TypeNode.new(GenericClassType.new(program, program, "SomeType", program.object, ["A", "B"]))] of ASTNode
+              end
+
+              assert_macro("klass", "{{klass.class.name(generic_args: false)}}", "SomeType:Module") do |program|
+                [TypeNode.new(GenericModuleType.new(program, program, "SomeType", ["A", "B"]))] of ASTNode
+              end
             end
 
             it "does not include the generic_args of the instantiated type" do
               assert_macro("", "{{Array(Int32).name(generic_args: false)}}", [] of ASTNode, "Array")
+              assert_macro("", "{{Tuple(Int32).name(generic_args: false)}}", [] of ASTNode, "Tuple")
+              assert_macro("", "{{Proc(Int32).name(generic_args: false)}}", [] of ASTNode, "Proc")
+              assert_macro("", "{{NamedTuple(a: Int32).name(generic_args: false)}}", [] of ASTNode, "NamedTuple")
+              assert_macro("", "{{Array(Int32).class.name(generic_args: false)}}", [] of ASTNode, "Array.class")
+
+              assert_macro("mod", "{{mod.name(generic_args: false)}}", "SomeType") do |program|
+                generic_module = GenericModuleType.new(program, program, "SomeType", ["A", "B"])
+                [TypeNode.new(generic_module.instantiate([program.int32, program.string] of TypeVar))] of ASTNode
+              end
+
+              assert_macro("mod", "{{mod.class.name(generic_args: false)}}", "SomeType.class") do |program|
+                generic_module = GenericModuleType.new(program, program, "SomeType", ["A", "B"])
+                [TypeNode.new(generic_module.instantiate([program.int32, program.string] of TypeVar))] of ASTNode
+              end
             end
           end
 

--- a/src/compiler/crystal/types.cr
+++ b/src/compiler/crystal/types.cr
@@ -2283,16 +2283,19 @@ module Crystal
     end
 
     def to_s_with_options(io : IO, skip_union_parens : Bool = false, generic_args : Bool = true, codegen : Bool = false) : Nil
-      io << "Proc("
-      arg_types.each do |type|
-        type = type.devirtualize unless codegen
-        type.to_s_with_options(io, codegen: codegen)
-        io << ", "
+      io << "Proc"
+      if generic_args
+        io << '('
+        arg_types.each do |type|
+          type = type.devirtualize unless codegen
+          type.to_s_with_options(io, codegen: codegen)
+          io << ", "
+        end
+        return_type = self.return_type
+        return_type = return_type.devirtualize unless codegen
+        return_type.to_s_with_options(io, codegen: codegen)
+        io << ')'
       end
-      return_type = self.return_type
-      return_type = return_type.devirtualize unless codegen
-      return_type.to_s_with_options(io, codegen: codegen)
-      io << ')'
     end
   end
 
@@ -2410,12 +2413,15 @@ module Crystal
     end
 
     def to_s_with_options(io : IO, skip_union_parens : Bool = false, generic_args : Bool = true, codegen : Bool = false) : Nil
-      io << "Tuple("
-      @tuple_types.join(io, ", ") do |tuple_type|
-        tuple_type = tuple_type.devirtualize unless codegen
-        tuple_type.to_s_with_options(io, skip_union_parens: true, codegen: codegen)
+      io << "Tuple"
+      if generic_args
+        io << '('
+        @tuple_types.join(io, ", ") do |tuple_type|
+          tuple_type = tuple_type.devirtualize unless codegen
+          tuple_type.to_s_with_options(io, skip_union_parens: true, codegen: codegen)
+        end
+        io << ')'
       end
-      io << ')'
     end
 
     def type_desc
@@ -2535,19 +2541,22 @@ module Crystal
     end
 
     def to_s_with_options(io : IO, skip_union_parens : Bool = false, generic_args : Bool = true, codegen : Bool = false) : Nil
-      io << "NamedTuple("
-      @entries.join(io, ", ") do |entry|
-        if Symbol.needs_quotes_for_named_argument?(entry.name)
-          entry.name.inspect(io)
-        else
-          io << entry.name
+      io << "NamedTuple"
+      if generic_args
+        io << '('
+        @entries.join(io, ", ") do |entry|
+          if Symbol.needs_quotes_for_named_argument?(entry.name)
+            entry.name.inspect(io)
+          else
+            io << entry.name
+          end
+          io << ": "
+          entry_type = entry.type
+          entry_type = entry_type.devirtualize unless codegen
+          entry_type.to_s_with_options(io, skip_union_parens: true, codegen: codegen)
         end
-        io << ": "
-        entry_type = entry.type
-        entry_type = entry_type.devirtualize unless codegen
-        entry_type.to_s_with_options(io, skip_union_parens: true, codegen: codegen)
+        io << ')'
       end
-      io << ')'
     end
 
     def type_desc
@@ -2832,7 +2841,8 @@ module Crystal
     end
 
     def to_s_with_options(io : IO, skip_union_parens : Bool = false, generic_args : Bool = true, codegen : Bool = false) : Nil
-      io << @name
+      @instance_type.to_s_with_options(io, generic_args: generic_args, codegen: codegen)
+      io << (instance_type.module? ? ":Module" : ".class")
     end
   end
 
@@ -2884,7 +2894,7 @@ module Crystal
     end
 
     def to_s_with_options(io : IO, skip_union_parens : Bool = false, generic_args : Bool = true, codegen : Bool = false) : Nil
-      instance_type.to_s(io)
+      instance_type.to_s_with_options(io, generic_args: generic_args, codegen: codegen)
       io << ".class"
     end
   end
@@ -2921,7 +2931,7 @@ module Crystal
     end
 
     def to_s_with_options(io : IO, skip_union_parens : Bool = false, generic_args : Bool = true, codegen : Bool = false) : Nil
-      instance_type.to_s(io)
+      instance_type.to_s_with_options(io, generic_args: generic_args, codegen: codegen)
       io << ".class"
     end
   end
@@ -3377,7 +3387,7 @@ module Crystal
     end
 
     def to_s_with_options(io : IO, skip_union_parens : Bool = false, generic_args : Bool = true, codegen : Bool = false) : Nil
-      instance_type.to_s_with_options(io, codegen: codegen)
+      instance_type.to_s_with_options(io, generic_args: generic_args, codegen: codegen)
       io << ".class"
     end
   end

--- a/src/named_tuple.cr
+++ b/src/named_tuple.cr
@@ -37,10 +37,11 @@ struct NamedTuple
   # {}             # syntax error
   # ```
   def self.new(**options : **T)
-    {% if @type.name(generic_args: false) == "NamedTuple" %}
-      # deduced type vars
+    {% if @type.name == "NamedTuple(T)" %}
+      # deduced type vars (note that `NamedTuple(T)` is never the name of a
+      # valid `NamedTuple` instance because `T` is a positional argument here)
       options
-    {% elsif @type.name(generic_args: false) == "NamedTuple()" %}
+    {% elsif @type.name == "NamedTuple()" %}
       # special case: empty named tuple
       options
     {% else %}

--- a/src/tuple.cr
+++ b/src/tuple.cr
@@ -89,10 +89,10 @@ struct Tuple
   # {}                         # syntax error
   # ```
   def self.new(*args : *T)
-    {% if @type.name(generic_args: false) == "Tuple" %}
+    {% if @type.name == "Tuple(*T)" %}
       # deduced type vars
       args
-    {% elsif @type.name(generic_args: false) == "Tuple()" %}
+    {% elsif @type.name == "Tuple()" %}
       # special case: empty tuple
       args
     {% else %}


### PR DESCRIPTION
Follow-up to #9224. Makes `TypeNode#name(generic_args: false)` strip the generic arguments when the receiver type is a `Tuple` instance, `NamedTuple` instance, `Proc` instance, or any generic metaclass type (instantiated or not).