### PR TITLE
Secure array slicing when expanding macro for stack trace

### DIFF
--- a/src/compiler/crystal/exception.cr
+++ b/src/compiler/crystal/exception.cr
@@ -253,8 +253,9 @@ module Crystal
         source, _ = minimize_indentation(source.lines)
         io << Crystal.with_line_numbers(source, line_number, @color)
       else
-        from_index = [0, line_number - MACRO_LINES_TO_SHOW].max
-        source_slice = source.lines[from_index...line_number]
+        to_index = line_number.clamp(0..source.lines.size)
+        from_index = {0, to_index - MACRO_LINES_TO_SHOW}.max
+        source_slice = source.lines[from_index...to_index]
         source_slice, spaces_removed = minimize_indentation(source_slice)
 
         io << Crystal.with_line_numbers(source_slice, line_number, @color, line_number_start = from_index + 1)


### PR DESCRIPTION
As #11008 I fell upon a bug into the stack trace generation. This time, I haven't the stack trace that was occuring with this error, but it wasn't very talkative about the origin of the problem.

Anyway, it is possible the two issues are related. The previous PR was fixing an issue with colum numbers, and this one is dealing with line numbers. This time, there's a crash because the caller is passing an incorrect line number for a macro that is less tinier than expected.

I tried to understand why but sadly I couldn't find a way to know what the original caller of that stack trace printing was.

---

Since it's the second time I encounter this kind of bug, maybe it would be good to verify the globality of `src/compiler/crystal/exception.cr` and `src/compiler/crystal/semantic/exception.cr` to avoid these errors ?