### PR TITLE
Exclude `Object.class` from generic module instance metaclasses' ancestors

### DIFF
--- a/spec/compiler/semantic/reflection_spec.cr
+++ b/spec/compiler/semantic/reflection_spec.cr
@@ -29,4 +29,14 @@ describe "Semantic: reflection" do
 
     mod.types["Bar"].metaclass.as(ClassType).superclass.should eq(mod.types["Foo"].metaclass)
   end
+
+  it "doesn't put Object.class as the parent of generic module instance metaclasses (#11110)" do
+    mod = semantic(%(
+      module Foo(T); end
+      )).program
+
+    foo_int32_class = mod.generic_module("Foo", mod.int32).metaclass
+    foo_int32_class.parents.should eq([mod.class_type])
+    foo_int32_class.ancestors.should eq([mod.class_type, mod.value, mod.object])
+  end
 end

--- a/src/compiler/crystal/types.cr
+++ b/src/compiler/crystal/types.cr
@@ -2828,7 +2828,8 @@ module Crystal
     end
 
     def replace_type_parameters(instance)
-      instance_type.replace_type_parameters(instance).metaclass
+      type = instance_type.replace_type_parameters(instance)
+      type == instance_type ? self : type.metaclass
     end
 
     def to_s_with_options(io : IO, skip_union_parens : Bool = false, generic_args : Bool = true, codegen : Bool = false) : Nil
@@ -2856,8 +2857,9 @@ module Crystal
       end
     end
 
-    def replace_type_parameters(instance_type)
-      self.instance_type.replace_type_parameters(instance_type).metaclass
+    def replace_type_parameters(instance)
+      type = instance_type.replace_type_parameters(instance)
+      type == instance_type ? self : type.metaclass
     end
 
     def virtual_type
@@ -2909,8 +2911,9 @@ module Crystal
       end
     end
 
-    def replace_type_parameters(instance_type)
-      self.instance_type.replace_type_parameters(instance_type).metaclass
+    def replace_type_parameters(instance)
+      type = instance_type.replace_type_parameters(instance)
+      type == instance_type ? self : type.metaclass
     end
 
     delegate defs, macros, to: instance_type.generic_type.metaclass
@@ -3345,7 +3348,8 @@ module Crystal
     delegate lookup_first_def, to: instance_type.metaclass
 
     def replace_type_parameters(instance)
-      base_type.replace_type_parameters(instance).virtual_type.metaclass
+      type = instance_type.replace_type_parameters(instance)
+      type == instance_type ? self : type.metaclass
     end
 
     def each_concrete_type

--- a/src/json/from_json.cr
+++ b/src/json/from_json.cr
@@ -1,30 +1,32 @@
-# Deserializes the given JSON in *string_or_io* into
-# an instance of `self`. This simply creates a `parser = JSON::PullParser`
-# and invokes `new(parser)`: classes that want to provide JSON
-# deserialization must provide an `def initialize(parser : JSON::PullParser)`
-# method.
-#
-# ```
-# Int32.from_json("1")                # => 1
-# Array(Int32).from_json("[1, 2, 3]") # => [1, 2, 3]
-# ```
-def Object.from_json(string_or_io)
-  parser = JSON::PullParser.new(string_or_io)
-  new parser
-end
-
-# Deserializes the given JSON in *string_or_io* into
-# an instance of `self`, assuming the JSON consists
-# of an JSON object with key *root*, and whose value is
-# the value to deserialize.
-#
-# ```
-# Int32.from_json(%({"main": 1}), root: "main") # => 1
-# ```
-def Object.from_json(string_or_io, root : String)
-  parser = JSON::PullParser.new(string_or_io)
-  parser.on_key!(root) do
+class Class
+  # Deserializes the given JSON in *string_or_io* into
+  # an instance of `self`. This simply creates a `parser = JSON::PullParser`
+  # and invokes `new(parser)`: classes that want to provide JSON
+  # deserialization must provide an `def initialize(parser : JSON::PullParser)`
+  # method.
+  #
+  # ```
+  # Int32.from_json("1")                # => 1
+  # Array(Int32).from_json("[1, 2, 3]") # => [1, 2, 3]
+  # ```
+  def from_json(string_or_io)
+    parser = JSON::PullParser.new(string_or_io)
     new parser
+  end
+
+  # Deserializes the given JSON in *string_or_io* into
+  # an instance of `self`, assuming the JSON consists
+  # of an JSON object with key *root*, and whose value is
+  # the value to deserialize.
+  #
+  # ```
+  # Int32.from_json(%({"main": 1}), root: "main") # => 1
+  # ```
+  def from_json(string_or_io, root : String)
+    parser = JSON::PullParser.new(string_or_io)
+    parser.on_key!(root) do
+      new parser
+    end
   end
 end
 

--- a/src/yaml/from_yaml.cr
+++ b/src/yaml/from_yaml.cr
@@ -1,15 +1,17 @@
-# Deserializes the given YAML in *string_or_io* into
-# an instance of `self`. This simply creates an instance of
-# `YAML::ParseContext` and invokes `new(parser, yaml)`:
-# classes that want to provide YAML deserialization must provide an
-# `def initialize(parser : YAML::ParseContext, yaml : string_or_io)`
-# method.
-#
-# ```
-# Hash(String, String).from_yaml("{env: production}") # => {"env" => "production"}
-# ```
-def Object.from_yaml(string_or_io : String | IO)
-  new(YAML::ParseContext.new, parse_yaml(string_or_io))
+class Class
+  # Deserializes the given YAML in *string_or_io* into
+  # an instance of `self`. This simply creates an instance of
+  # `YAML::ParseContext` and invokes `new(parser, yaml)`:
+  # classes that want to provide YAML deserialization must provide an
+  # `def initialize(parser : YAML::ParseContext, yaml : string_or_io)`
+  # method.
+  #
+  # ```
+  # Hash(String, String).from_yaml("{env: production}") # => {"env" => "production"}
+  # ```
+  def from_yaml(string_or_io : String | IO)
+    new(YAML::ParseContext.new, parse_yaml(string_or_io))
+  end
 end
 
 def Array.from_yaml(string_or_io : String | IO)


### PR DESCRIPTION
Fixes #11110.

If the result of substituting some generic type variables into `T` is also `T` itself, then we also make `T.class` return itself upon the same substitutions. This avoids the need to hardcode `Class`'s identity.