### PR TITLE
Support generic module instances in `TypeNode#includers`

### DIFF
--- a/spec/compiler/macro/macro_methods_spec.cr
+++ b/spec/compiler/macro/macro_methods_spec.cr
@@ -1374,7 +1374,7 @@ module Crystal
 
     describe TypeNode do
       describe "#includers" do
-        it "returns an array of types `self` is included in" do
+        it "returns an array of types `self` is directly included in" do
           assert_type(%(
             module Foo
             end
@@ -1419,14 +1419,18 @@ module Crystal
             end
 
             class ChildT(T) < SubT(T)
+              include Enumt(T)
             end
 
-          {% if Baz.includers.map(&.stringify) == ["Baz::Tar", "Enumt(T)", "Bar", "Str", "Gen(T)", "AStr", "ACla", "SubT(T)"] && Enumt.includers.map(&.stringify) == ["Str"]  %}
-            1
-          {% else %}
-            'a'
-          {% end %}
-        )) { int32 }
+            class Witness < ChildT(String)
+            end
+
+            {
+              {% if Baz.includers.map(&.stringify).sort == %w(ACla AStr Bar Baz::Tar Enumt(T) Gen(T) Str SubT(T)) %} 1 {% else %} 'a' {% end %},
+              {% if Enumt.includers.map(&.stringify).sort == %w(ChildT(String) ChildT(T) Str) %} 1 {% else %} 'a' {% end %},
+              {% if Enumt(String).includers.map(&.stringify).sort == %w(ChildT(String) Str) %} 1 {% else %} 'a' {% end %},
+            }
+            )) { tuple_of([int32, int32, int32]) }
         end
       end
 

--- a/src/compiler/crystal/macros/methods.cr
+++ b/src/compiler/crystal/macros/methods.cr
@@ -1753,7 +1753,7 @@ module Crystal
 
     def self.includers(type)
       case type
-      when NonGenericModuleType, GenericModuleType
+      when NonGenericModuleType, GenericModuleType, GenericModuleInstanceType
         types = type.raw_including_types
         return empty_no_return_array unless types
         ArrayLiteral.map(types) do |including_type|


### PR DESCRIPTION
`TypeNode#includers` does not work when the receiver is a generic module instance:

```crystal
module A(T)
end

class B(T)
  include A(T)
end

class C
  include A(Int32)
end

# main code (processed after the top-level visitor)
B(Int32).new
B(String).new

{% A.includers %}        # => [B(T), C]
{% A(Int32).includers %} # => [] of ::NoReturn

def foo
  {% A.includers %}        # => [B(T), C, B(Int32), B(String)]
  {% A(Int32).includers %} # => [] of ::NoReturn
end

foo
```

This PR fixes that:

```crystal
{% A(Int32).includers %} # => [C]

def foo
  {% A(Int32).includers %} # => [C, B(Int32)]
end
```