### PR TITLE
Compiler: fix `is_a?` for virtual metaclass types

### DIFF
--- a/spec/compiler/codegen/is_a_spec.cr
+++ b/spec/compiler/codegen/is_a_spec.cr
@@ -815,4 +815,45 @@ describe "Codegen: is_a?" do
       Sub.new.is_a?(Mod(Sup))
       )).to_b.should be_true
   end
+
+  it "restricts metaclass against virtual metaclass type" do
+    run(%(
+      class A
+      end
+
+      class B < A
+      end
+
+      x = B || A
+      if x.is_a?(B.class)
+        1
+      elsif x.is_a?(A.class)
+        2
+      else
+        3
+      end
+      )).to_i.should eq(1)
+  end
+
+  it "restricts virtual metaclass against virtual metaclass type" do
+    run(%(
+      class A
+      end
+
+      class B < A
+      end
+
+      class C < B
+      end
+
+      x = B || A
+      if x.is_a?(B.class)
+        1
+      elsif x.is_a?(A.class)
+        2
+      else
+        3
+      end
+      )).to_i.should eq(1)
+  end
 end

--- a/src/compiler/crystal/semantic/type_intersect.cr
+++ b/src/compiler/crystal/semantic/type_intersect.cr
@@ -82,7 +82,16 @@ module Crystal
       return nil if type1.instance_type.module?
 
       restricted = common_descendent(type1.instance_type, type2.instance_type.base_type)
-      restricted ? type1 : nil
+      restricted.try(&.virtual_type.metaclass)
+    end
+
+    def self.common_descendent(type1 : VirtualMetaclassType, type2 : MetaclassType)
+      common_descendent(type2, type1)
+    end
+
+    def self.common_descendent(type1 : VirtualMetaclassType, type2 : VirtualMetaclassType)
+      restricted = common_descendent(type1.instance_type.base_type, type2.instance_type.base_type)
+      restricted.try(&.virtual_type.metaclass)
     end
 
     def self.common_descendent(type1 : GenericClassInstanceMetaclassType | GenericModuleInstanceMetaclassType, type2 : MetaclassType)


### PR DESCRIPTION
Fixes https://github.com/crystal-lang/crystal/issues/11120

There are [comments](https://github.com/crystal-lang/crystal/issues/11120#issuecomment-903742390) around further improvements to the type system, but they can be done later and independent of this PR (it's a really small change here.) 