### PR TITLE
[CI] Remove test_linux_32 and add smoke test for 32-bit gnu

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -25,24 +25,6 @@ jobs:
       - name: Test
         run: bin/ci build
 
-  test_linux_32:
-    env:
-      ARCH: i386
-      ARCH_CMD: linux32
-    runs-on: ubuntu-latest
-    steps:
-      - name: Download Crystal source
-        uses: actions/checkout@v2
-
-      - name: Prepare System
-        run: bin/ci prepare_system
-
-      - name: Prepare Build
-        run: bin/ci prepare_build
-
-      - name: Test
-        run: bin/ci with_build_env 'make std_spec threads=1'
-
   test_alpine:
     env:
       ARCH: x86_64-musl

--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -46,6 +46,7 @@ jobs:
           - aarch64-darwin
           - arm-linux-gnueabihf
           - i386-linux-musl
+          - i386-linux-gnu
           - x86_64-dragonfly
           - x86_64-freebsd
           - x86_64-netbsd


### PR DESCRIPTION
32-bit linux specs are broken (#11073) and it appears hard to even diagnose the error or even fix it (#11077). Considering the limited relevance of 32-bit linux platforms, there's not a lot of force behind this.
Having a test that constantly fails doesn't help anything.

The core team decided to move platform support for `i386-linux-gnu` to tier 2. The platform is still supported and it's still expected to build (the errors seem to be very specific to the test environment). But we won't run automated tests (at least for the time being).
