### PR TITLE
Fix spec for HTTP::Params can't run on its own

### DIFF
--- a/spec/std/http/params_spec.cr
+++ b/spec/std/http/params_spec.cr
@@ -1,4 +1,4 @@
-require "uri/params"
+require "http/params"
 require "spec"
 
 describe "HTTP::Params" do


### PR DESCRIPTION
If you do:

```
bin/crystal spec spec/std/http/params_spec.cr
```

it fails because it can't find `HTTP::Params`. The entire spec suite works because that type will be defined somewhere else.

For the interpreter I have a script that runs each spec file separately to see how many spec files still fail, and that one was failing but for an entirely different reason.