### PR TITLE
Expose `@block` in macros

### DIFF
--- a/src/compiler/crystal/macros/interpreter.cr
+++ b/src/compiler/crystal/macros/interpreter.cr
@@ -549,6 +549,8 @@ module Crystal
         @last = TypeNode.new(@program)
       when "@def"
         @last = @def || NilLiteral.new
+      when "@block"
+        @last = @block || NilLiteral.new
       else
         node.raise "unknown macro instance var: '#{node.name}'"
       end


### PR DESCRIPTION
This is a proposal to facilitate manipulating blocks inside macros. This allows, for example:

```cr
macro call_block
  begin
    {{ @block.args[0] }} = 10
    {{ @block.args[1] }} = 20
    {{ @block.args[2] }} = 30
    {{ @block.body }}
  end
end

p call_block { |a, b, c| a + b + c }
```

Or:

```cr
macro define_method(name)
  def {{ name.id }}({{ *@block.args }})
    {{ @block.body }}
  end
end

define_method(:hello) do |xx|
  puts xx
end

hello(1)
```

As a follow-up PR I would suggest implementing `{{ @block.call(1, 2, 3) }}` that generates something similar to the `call_block` above. This could be a replacement for macro yield (https://github.com/crystal-lang/crystal/issues/11012#issuecomment-886657349) in the future.

What do you think?