### PR TITLE
Fix english language in exception message

### DIFF
--- a/src/compiler/crystal/semantic/exception.cr
+++ b/src/compiler/crystal/semantic/exception.cr
@@ -326,7 +326,7 @@ module Crystal
       msg = String.build do |str|
         str << common
         str << "\n\n"
-        str << undefined_variable_message("class", node.name)
+        str << undefined_variable_message("a class variable", node.name)
         str << "\n\n"
         str << common
       end
@@ -345,7 +345,7 @@ module Crystal
       msg = String.build do |str|
         str << common
         str << "\n\n"
-        str << undefined_variable_message("instance", node.name)
+        str << undefined_variable_message("an instance variable", node.name)
         str << "\n\n"
         str << common
       end
@@ -354,7 +354,7 @@ module Crystal
 
     def undefined_variable_message(kind, example_name)
       <<-MSG
-      The type of a #{kind} variable, if not declared explicitly with
+      The type of #{kind}, if not declared explicitly with
       `#{example_name} : Type`, is inferred from assignments to it across
       the whole program.
 


### PR DESCRIPTION
Let's give proper english sentences to our users.
![2021-08-25 at 21 12](https://user-images.githubusercontent.com/245443/130851056-e9c28c76-f712-421e-91d7-281243b962e0.jpg)
