### PR TITLE
Allow underscores in macro `for`'s loop variables

### DIFF
--- a/spec/compiler/parser/parser_spec.cr
+++ b/spec/compiler/parser/parser_spec.cr
@@ -965,6 +965,7 @@ module Crystal
     it_parses "abstract def foo(x) : Int32", Def.new("foo", args: ["x".arg], return_type: "Int32".path, abstract: true)
 
     it_parses "{% for x in y %}body{% end %}", MacroFor.new(["x".var], "y".var, "body".macro_literal)
+    it_parses "{% for _, x, _ in y %}body{% end %}", MacroFor.new(["_".var, "x".var, "_".var], "y".var, "body".macro_literal)
     it_parses "{% if x %}body{% end %}", MacroIf.new("x".var, "body".macro_literal)
     it_parses "{% begin %}{% if true %}if true{% end %}\n{% if true %}end{% end %}{% end %}", MacroIf.new(true.bool, [MacroIf.new(true.bool, "if true".macro_literal), "\n".macro_literal, MacroIf.new(true.bool, "end".macro_literal)] of ASTNode)
     it_parses "{{ foo }}", MacroExpression.new("foo".var)

--- a/src/compiler/crystal/syntax/parser.cr
+++ b/src/compiler/crystal/syntax/parser.cr
@@ -3220,7 +3220,15 @@ module Crystal
           vars = [] of Var
 
           while true
-            vars << Var.new(check_ident).at(@token.location)
+            var = case @token.type
+                  when :UNDERSCORE
+                    "_"
+                  when :IDENT
+                    @token.value.to_s
+                  else
+                    unexpected_token msg: "expecting ident or underscore"
+                  end
+            vars << Var.new(var).at(@token.location)
 
             next_token_skip_space
             if @token.type == :","


### PR DESCRIPTION
This PR allows one to write:

```crystal
{% for _, v, i in {1 => 2, 3 => 4, 5 => 6} %}
{% end %}
```

There are no changes to the abstract syntax; those underscores are `Var` nodes with `_` as their names, not `Underscore` nodes, and any other occurrences of `_` in the macro language still cannot be used to read those variables. The same treatment is already done for underscore block parameters.