### PR TITLE
Primitive annotations for interpreter

### DIFF
--- a/spec/compiler/codegen/primitives_spec.cr
+++ b/spec/compiler/codegen/primitives_spec.cr
@@ -301,4 +301,15 @@ describe "Code gen: primitives" do
       Moo.symbol_to_s(:hello)
       )).to_string.should eq("hello")
   end
+
+  it "allows @[Primitive] on fun declarations" do
+    run(%(
+      lib LibFoo
+        @[Primitive(:enum_value)]
+        fun enum_value(x : Int32) : Int32
+      end
+
+      LibFoo.enum_value(1)
+      )).to_i.should eq(1)
+  end
 end

--- a/spec/compiler/codegen/primitives_spec.cr
+++ b/spec/compiler/codegen/primitives_spec.cr
@@ -288,4 +288,17 @@ describe "Code gen: primitives" do
       end
     {% end %}
   end
+
+  it "allows @[Primitive] on method that has body" do
+    run(%(
+      module Moo
+        @[Primitive(:symbol_to_s)]
+        def self.symbol_to_s(symbol : Symbol) : String
+          untyped
+        end
+      end
+
+      Moo.symbol_to_s(:hello)
+      )).to_string.should eq("hello")
+  end
 end

--- a/spec/compiler/semantic/primitives_spec.cr
+++ b/spec/compiler/semantic/primitives_spec.cr
@@ -212,16 +212,15 @@ describe "Semantic: primitives" do
       "expected Primitive argument to be a symbol literal"
   end
 
-  it "errors if @[Primitive] method has body" do
-    assert_error %(
+  it "allows @[Primitive] on method that has body" do
+    assert_no_errors %(
       struct Int32
         @[Primitive(:binary)]
         def +(other : Int32) : Int32
           1
         end
       end
-      ),
-      "method marked as Primitive must have an empty body"
+      )
   end
 
   pending_win32 "types va_arg primitive" do

--- a/src/compiler/crystal/semantic/top_level_visitor.cr
+++ b/src/compiler/crystal/semantic/top_level_visitor.cr
@@ -444,10 +444,6 @@ class Crystal::TopLevelVisitor < Crystal::SemanticVisitor
 
     value = arg.value
 
-    unless node.body.is_a?(Nop)
-      node.raise "method marked as Primitive must have an empty body"
-    end
-
     primitive = Primitive.new(value)
     primitive.location = node.location
 

--- a/src/compiler/crystal/semantic/top_level_visitor.cr
+++ b/src/compiler/crystal/semantic/top_level_visitor.cr
@@ -880,6 +880,8 @@ class Crystal::TopLevelVisitor < Crystal::SemanticVisitor
     process_def_annotations(external, annotations) do |annotation_type, ann|
       if annotation_type == @program.call_convention_annotation
         call_convention = parse_call_convention(ann, call_convention)
+      elsif annotation_type == @program.primitive_annotation
+        process_primitive_annotation(external, ann)
       else
         ann.raise "funs can only be annotated with: NoInline, AlwaysInline, Naked, ReturnsTwice, Raises, CallConvention"
       end


### PR DESCRIPTION
This PR extracts a couple of changes from #10910 so that later that PR has the last amount of changes to non-interpreted Crystal.

There are two changes here:
1. Allowing `@[Primitive]` on top of methods that have bodies. This is useful because for example `raise` will be a primitive in the interpreter, and it's a bit cumbersome to define the signature twice, one with an empty body and a primitive annotation, and the other one without an annotation and a body. It's just simpler to conditionally mark a method as `@[Primitive]` for the interpreter.
2. Allowing `@[Primitive]` on top of lib fun declarations. In the interpreter all of the functions defined in the `Intrinsics` and `LibM` libs need to be primitives, and this is never needed in compiled Crystal.

This PR doesn't affect compiled Crystal. Well, a user could use `@[Primitive]` somewhere, but there's really no reason to do that.