### PR TITLE
Reject hash literals with mixed syntax

### DIFF
--- a/spec/compiler/parser/parser_spec.cr
+++ b/spec/compiler/parser/parser_spec.cr
@@ -1115,6 +1115,7 @@ module Crystal
 
     it_parses "{1 => 2, 3 => 4}", HashLiteral.new([HashLiteral::Entry.new(1.int32, 2.int32), HashLiteral::Entry.new(3.int32, 4.int32)])
     it_parses %({A::B => 1, C::D => 2}), HashLiteral.new([HashLiteral::Entry.new(Path.new(["A", "B"]), 1.int32), HashLiteral::Entry.new(Path.new(["C", "D"]), 2.int32)])
+    assert_syntax_error %({"foo" => 1, "bar": 2}), "can't use 'key: value' syntax in a hash literal"
 
     it_parses "{a: 1}", NamedTupleLiteral.new([NamedTupleLiteral::Entry.new("a", 1.int32)])
     it_parses "{a: 1, b: 2}", NamedTupleLiteral.new([NamedTupleLiteral::Entry.new("a", 1.int32), NamedTupleLiteral::Entry.new("b", 2.int32)])

--- a/src/compiler/crystal/syntax/parser.cr
+++ b/src/compiler/crystal/syntax/parser.cr
@@ -2419,10 +2419,11 @@ module Crystal
           end
 
           while @token.type != :"}"
+            key_loc = @token.location
             key = parse_op_assign_no_control
             skip_space_or_newline
             if @token.type == :":" && key.is_a?(StringLiteral)
-              # Nothing: it's a string key
+              raise "can't use 'key: value' syntax in a hash literal", key_loc
             else
               check :"=>"
             end


### PR DESCRIPTION
Fix #11074

The parser rejects a hash literal like `{"foo" => 1, "bar": 2}` now. Notice that `{"bar": 1, "foo" => 2}` is already a syntax error.