### PR TITLE
Add github-changelog script

### DIFF
--- a/scripts/github-changelog.cr
+++ b/scripts/github-changelog.cr
@@ -14,8 +14,7 @@
 #   scripts/github-changelog.cr <milestone>
 #
 # Environment variables:
-#
-# * GITHUB_TOKEN: Access token for GitHub API (required)
+#   GITHUB_TOKEN: Access token for the GitHub API (required)
 require "http/client"
 require "json"
 
@@ -107,9 +106,15 @@ record PullRequest,
   end
 
   def <=>(other : self)
-    return -1 if labels.includes?("breaking-change") && !other.labels.includes?("breaking-change")
-    return -1 if labels.includes?("security") && !other.labels.includes?("security")
-    return -1 if labels.includes?("performance") && !other.labels.includes?("performance")
+    x = (other.labels.includes?("security") ? 1 : 0) <=> (labels.includes?("security") ? 1 : 0)
+    return x unless x.zero?
+    x = (other.labels.includes?("breaking-change") ? 1 : 0) <=> (labels.includes?("breaking-change") ? 1 : 0)
+    return x unless x.zero?
+
+    if (mergedAt = self.mergedAt) && (otherMergedAt = other.mergedAt)
+      mergedAt <=> otherMergedAt
+    end
+
     0
   end
 end

--- a/scripts/github-changelog.cr
+++ b/scripts/github-changelog.cr
@@ -113,7 +113,12 @@ record PullRequest,
   end
 
   def sort_tuple
-    {labels.includes?("security") ? 0 : 1, labels.includes?("breaking-change") ? 0 : 1, labels.includes?("kind:bug") ? 0 : 1, mergedAt || Time.unix(0)}
+    {
+      labels.includes?("security") ? 0 : 1,
+      labels.includes?("breaking-change") ? 0 : 1,
+      labels.includes?("kind:bug") ? 0 : 1,
+      mergedAt || Time.unix(0),
+    }
   end
 end
 

--- a/scripts/github-changelog.cr
+++ b/scripts/github-changelog.cr
@@ -1,0 +1,155 @@
+#! /usr/bin/env crystal
+
+# This helper queries merged pull requests for a given milestone from the GitHub API
+# and creates formatted changelog entries.
+#
+# Pull requests that are already referenced in CHANGELOG.md are omitted, which
+# makes it easy to incrementally add entries.
+#
+# Entries are grouped by topic (based on topic labels) and ordered by date.
+# Some annotations are automatically added based on labels.
+#
+# Usage:
+#
+#   scripts/github-changelog.cr <milestone>
+#
+# Environment variables:
+#
+# * GITHUB_TOKEN: Access token for GitHub API (required)
+require "http/client"
+require "json"
+
+api_token = ENV["GITHUB_TOKEN"]
+repository = "crystal-lang/crystal"
+milestone = ARGV.first
+
+query = <<-GRAPHQL
+  query($milestone: String) {
+    repository(owner: $owner, name: $repository) {
+      milestones(query: $milestone, first: 1) {
+        nodes {
+          pullRequests(first: 300) {
+            nodes {
+              number
+              title
+              mergedAt
+              permalink
+              author {
+                login
+              }
+              labels(first: 10) {
+              nodes {
+                name
+              }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+  GRAPHQL
+
+owner, _, name = repository.partition("/")
+variables = {
+  owner: owner,
+  repository: name,
+  milestone: milestone,
+}
+
+response = HTTP::Client.post("https://api.github.com/graphql", body: {query: query, variables: variables}.to_json, headers: HTTP::Headers{"Authorization" => "bearer #{api_token}"})
+
+module LabelNameConverter
+  def self.from_json(pull : JSON::PullParser)
+    pull.on_key! "name" do
+      String.new(pull)
+    end
+  end
+end
+
+record PullRequest,
+  number : Int32,
+  title : String,
+  mergedAt : Time?,
+  permalink : String,
+  author : String?,
+  labels : Array(String) do
+  include JSON::Serializable
+  include Comparable(self)
+
+  @[JSON::Field(root: "login")]
+  @author : String?
+
+  @[JSON::Field(root: "nodes", converter: JSON::ArrayConverter(LabelNameConverter))]
+  @labels : Array(String)
+
+  def to_s(io : IO)
+    if labels.includes?("breaking-change")
+      io << "**(breaking-change)** "
+    end
+    if labels.includes?("security")
+      io << "**(security)** "
+    end
+    if labels.includes?("performance")
+      io << "**(performance)** "
+    end
+    io << title << " ("
+    io << "[#" << number << "](" << permalink << ")"
+    if author = self.author
+      io << ", thanks @" << author
+    end
+    io << ")"
+  end
+
+  def <=>(other : self)
+    return -1 if labels.includes?("breaking-change") && !other.labels.includes?("breaking-change")
+    return -1 if labels.includes?("security") && !other.labels.includes?("security")
+    return -1 if labels.includes?("performance") && !other.labels.includes?("performance")
+    0
+  end
+end
+
+parser = JSON::PullParser.new(response.body)
+array = parser.on_key! "data" do
+  parser.on_key! "repository" do
+    parser.on_key! "milestones" do
+      parser.on_key! "nodes" do
+        parser.read_begin_array
+        a = parser.on_key! "pullRequests" do
+          parser.on_key! "nodes" do
+            Array(PullRequest).new(parser)
+          end
+        end
+        parser.read_end_array
+        a
+      end
+    end
+  end
+end
+
+changelog = File.read("CHANGELOG.md")
+array.select! { |pr| pr.mergedAt && !changelog.index(pr.permalink) }
+sections = array.group_by { |pr|
+  case pr.labels
+  when .any? &.starts_with?("topic:lang")
+    "Language"
+  when .any? &.starts_with?("topic:compiler")
+    "Compiler"
+  when .any? &.starts_with?("topic:tools")
+    "Tools"
+  when .any? &.starts_with?("topic:stdlib")
+    "Standard Library"
+  else
+    "Other"
+  end
+}
+
+sections.each do |name, prs|
+  puts "## #{name}"
+  puts
+  prs.sort!
+  prs.each do |pr|
+    puts "- #{pr}"
+  end
+  puts
+end

--- a/scripts/github-changelog.cr
+++ b/scripts/github-changelog.cr
@@ -6,7 +6,7 @@
 # Pull requests that are already referenced in CHANGELOG.md are omitted, which
 # makes it easy to incrementally add entries.
 #
-# Entries are grouped by topic (based on topic labels) and ordered by date.
+# Entries are grouped by topic (based on topic labels) and ordered by merge date.
 # Some annotations are automatically added based on labels.
 #
 # Usage:

--- a/scripts/github-changelog.cr
+++ b/scripts/github-changelog.cr
@@ -26,7 +26,7 @@ repository = "crystal-lang/crystal"
 milestone = ARGV.first
 
 query = <<-GRAPHQL
-  query($milestone: String) {
+  query($milestone: String, $owner: String!, $repository: String!) {
     repository(owner: $owner, name: $repository) {
       milestones(query: $milestone, first: 1) {
         nodes {

--- a/scripts/github-changelog.cr
+++ b/scripts/github-changelog.cr
@@ -109,16 +109,11 @@ record PullRequest,
   end
 
   def <=>(other : self)
-    x = (other.labels.includes?("security") ? 1 : 0) <=> (labels.includes?("security") ? 1 : 0)
-    return x unless x.zero?
-    x = (other.labels.includes?("breaking-change") ? 1 : 0) <=> (labels.includes?("breaking-change") ? 1 : 0)
-    return x unless x.zero?
+    sort_tuple <=> other.sort_tuple
+  end
 
-    if (mergedAt = self.mergedAt) && (otherMergedAt = other.mergedAt)
-      mergedAt <=> otherMergedAt
-    end
-
-    0
+  def sort_tuple
+    {labels.includes?("security") ? 0 : 1, labels.includes?("breaking-change") ? 0 : 1, labels.includes?("kind:bug") ? 0 : 1, mergedAt || Time.unix(0)}
   end
 end
 

--- a/scripts/github-changelog.cr
+++ b/scripts/github-changelog.cr
@@ -38,9 +38,9 @@ query = <<-GRAPHQL
                 login
               }
               labels(first: 10) {
-              nodes {
-                name
-              }
+                nodes {
+                  name
+                }
               }
             }
           }
@@ -52,12 +52,17 @@ query = <<-GRAPHQL
 
 owner, _, name = repository.partition("/")
 variables = {
-  owner: owner,
+  owner:      owner,
   repository: name,
-  milestone: milestone,
+  milestone:  milestone,
 }
 
-response = HTTP::Client.post("https://api.github.com/graphql", body: {query: query, variables: variables}.to_json, headers: HTTP::Headers{"Authorization" => "bearer #{api_token}"})
+response = HTTP::Client.post("https://api.github.com/graphql",
+  body: {query: query, variables: variables}.to_json,
+  headers: HTTP::Headers{
+    "Authorization" => "bearer #{api_token}",
+  }
+)
 
 module LabelNameConverter
   def self.from_json(pull : JSON::PullParser)

--- a/scripts/github-changelog.cr
+++ b/scripts/github-changelog.cr
@@ -18,6 +18,9 @@
 require "http/client"
 require "json"
 
+abort "Missing GITHUB_TOKEN env variable" unless ENV["GITHUB_TOKEN"]?
+abort "Missing <milestone> argument" unless ARGV.first?
+
 api_token = ENV["GITHUB_TOKEN"]
 repository = "crystal-lang/crystal"
 milestone = ARGV.first


### PR DESCRIPTION
This helper queries merged pull requests for a given milestone from the GitHub API and creates formatted changelog entries.

Resolves https://github.com/crystal-lang/distribution-scripts/issues/114

<details>
<summary>Example output</summary>

```
## Compiler

- **(breaking-change)** Change nonsense return types to Nil: JSON and YAML ([#10622](https://github.com/crystal-lang/crystal/pull/10622), thanks @oprypin)
- Add helpful error message for invalid number literal like '.42' ([#4665](https://github.com/crystal-lang/crystal/pull/4665), thanks @MakeNowJust)
- Substitute unbound type parameters in virtual metaclass types ([#11067](https://github.com/crystal-lang/crystal/pull/11067), thanks @HertzDevil)
- Compiler: carry FileModule information inside Block ([#11039](https://github.com/crystal-lang/crystal/pull/11039), thanks @asterite)
- Add `CrystalPath.expand_paths`, expand relative to compiler path ([#11030](https://github.com/crystal-lang/crystal/pull/11030), thanks @straight-shoota)
- Handle already stripped column numbers in exceptions ([#11008](https://github.com/crystal-lang/crystal/pull/11008), thanks @pyrsmk)
- Fix no overflow check when primitive int converts to same type ([#11003](https://github.com/crystal-lang/crystal/pull/11003), thanks @HertzDevil)
- Don't compute instance variable initializers on unbound generic instances ([#11000](https://github.com/crystal-lang/crystal/pull/11000), thanks @HertzDevil)
- Fix `CrystalPath#each_file_expansion` spec ([#10990](https://github.com/crystal-lang/crystal/pull/10990), thanks @straight-shoota)
- Remove `focus: true` ([#10988](https://github.com/crystal-lang/crystal/pull/10988), thanks @straight-shoota)
- Syntax errors for invalid 128-bit integer literals ([#10975](https://github.com/crystal-lang/crystal/pull/10975), thanks @rymiel)
- Fix proc_spec forcing normal compilation instead of JIT ([#10964](https://github.com/crystal-lang/crystal/pull/10964), thanks @straight-shoota)
- Do not use globals for regex ([#10951](https://github.com/crystal-lang/crystal/pull/10951), thanks @asterite)
- Fix `ProcNotation#to_s` remove whitespace for nil output type ([#10935](https://github.com/crystal-lang/crystal/pull/10935), thanks @straight-shoota)
- Attach debug locations to generated internal LLVM functions ([#10934](https://github.com/crystal-lang/crystal/pull/10934), thanks @HertzDevil)
- Refactor `CrystalPath#find_in_path_relative_to_dir` for readability ([#10876](https://github.com/crystal-lang/crystal/pull/10876), thanks @straight-shoota)
- Add support for LLVM 12 ([#10873](https://github.com/crystal-lang/crystal/pull/10873), thanks @Blacksmoke16)
- Define type filtering through an intersection operation ([#10781](https://github.com/crystal-lang/crystal/pull/10781), thanks @HertzDevil)
- Allow constants and instance / class variables as receivers for setter proc pointers ([#10741](https://github.com/crystal-lang/crystal/pull/10741), thanks @HertzDevil)
- Improve detection of instance variables in extended modules ([#10554](https://github.com/crystal-lang/crystal/pull/10554), thanks @HertzDevil)
- Detect cyclic includes between generic modules ([#10529](https://github.com/crystal-lang/crystal/pull/10529), thanks @HertzDevil)
- Clarify usage of "arguments" and "parameters" in error messages ([#10378](https://github.com/crystal-lang/crystal/pull/10378), thanks @HertzDevil)
- Support auto-splatting in captured block literals ([#10251](https://github.com/crystal-lang/crystal/pull/10251), thanks @HertzDevil)
- Splat values correctly inside return/break/next statements ([#10193](https://github.com/crystal-lang/crystal/pull/10193), thanks @HertzDevil)
- Compiler: fix `is_a?` for virtual metaclass types ([#11121](https://github.com/crystal-lang/crystal/pull/11121), thanks @asterite)

## Language

- Add docs to string methods in `SymbolLiteral` and `MacroId` ([#9298](https://github.com/crystal-lang/crystal/pull/9298), thanks @MakeNowJust)
- Add stricter checks for arguments to macro methods on AST nodes ([#10498](https://github.com/crystal-lang/crystal/pull/10498), thanks @HertzDevil)
- Make `.as?(NoReturn)` always return `nil` ([#10896](https://github.com/crystal-lang/crystal/pull/10896), thanks @HertzDevil)
- Make `#is_a?` in macros respect the AST node hierarchy ([#11062](https://github.com/crystal-lang/crystal/pull/11062), thanks @HertzDevil)

## Tools

- Include parent headings in anchor links ([#9839](https://github.com/crystal-lang/crystal/pull/9839), thanks @Blacksmoke16)
- Formatter: Handle leading tuple literals in multi-expression `return`/`break`/`next` properly ([#10597](https://github.com/crystal-lang/crystal/pull/10597), thanks @HertzDevil)
- Refactor hierarchy printers ([#10791](https://github.com/crystal-lang/crystal/pull/10791), thanks @HertzDevil)
- Make `WARNING` an admonition keyword ([#10898](https://github.com/crystal-lang/crystal/pull/10898), thanks @HertzDevil)
- Formatter: Handle `(-> )` correctly ([#10945](https://github.com/crystal-lang/crystal/pull/10945), thanks @HertzDevil)
- Use markd for markdown rendering in the compiler ([#11040](https://github.com/crystal-lang/crystal/pull/11040), thanks @straight-shoota)

## Standard Library

- **(breaking-change)** Change nonsense return types to Nil in IO-related methods ([#10621](https://github.com/crystal-lang/crystal/pull/10621), thanks @oprypin)
- **(breaking-change)** Change nonsense return types to Nil in formatter classes ([#10623](https://github.com/crystal-lang/crystal/pull/10623), thanks @oprypin)
- **(breaking-change)** Change nonsense return types to Nil in HTTP-related methods and Log ([#10624](https://github.com/crystal-lang/crystal/pull/10624), thanks @oprypin)
- **(breaking-change)** Change nonsense return types to Nil: uncategorized ([#10625](https://github.com/crystal-lang/crystal/pull/10625), thanks @oprypin)
- **(breaking-change)** Rename `IO#write_utf8` to `#write_string`. ([#11051](https://github.com/crystal-lang/crystal/pull/11051), thanks @straight-shoota)
- **(breaking-change)** Add type restriction and conversion to `YAML::PullParser#location` ([#10997](https://github.com/crystal-lang/crystal/pull/10997), thanks @straight-shoota)
- **(performance)** Improve Int parsing performance ([#11093](https://github.com/crystal-lang/crystal/pull/11093), thanks @BlobCodes)
- **(performance)** Construct an array literal in `NamedTuple#map` ([#10950](https://github.com/crystal-lang/crystal/pull/10950), thanks @caspiano)
- Add stable sort implementation to `Slice` and `Array` ([#10163](https://github.com/crystal-lang/crystal/pull/10163), thanks @MakeNowJust)
- Make `Int#chr` reject surrogate halves ([#10451](https://github.com/crystal-lang/crystal/pull/10451), thanks @HertzDevil)
- SystemError: Fix inconsistent signature. ([#11002](https://github.com/crystal-lang/crystal/pull/11002), thanks @yxhuvud)
- Use `#write_string` instead of `#write` whenever writing strings to unknown `IO`s ([#11011](https://github.com/crystal-lang/crystal/pull/11011), thanks @HertzDevil)
- Disallow non-UTF-8 encoding settings for `String::Builder` ([#11025](https://github.com/crystal-lang/crystal/pull/11025), thanks @HertzDevil)
- Refactor sort methods to `#sort` and `#unstable_sort` ([#11029](https://github.com/crystal-lang/crystal/pull/11029), thanks @straight-shoota)
- Tag std specs that need network access ([#11048](https://github.com/crystal-lang/crystal/pull/11048), thanks @toshokan)
- Add base64 to prelude ([#11050](https://github.com/crystal-lang/crystal/pull/11050), thanks @straight-shoota)
- Fix `BigInt#to_s` emitting null bytes for certain values ([#11063](https://github.com/crystal-lang/crystal/pull/11063), thanks @HertzDevil)
- Allow `Enumerable(T)#reduce`'s return type to differ from `T` ([#11065](https://github.com/crystal-lang/crystal/pull/11065), thanks @HertzDevil)
- XML Namespace improvements ([#11072](https://github.com/crystal-lang/crystal/pull/11072), thanks @Blacksmoke16)
- Fix `File.match?` to accept `Path` type as `path` argument ([#11075](https://github.com/crystal-lang/crystal/pull/11075), thanks @fishnibble)
- Fix trailing rescue syntax ([#11083](https://github.com/crystal-lang/crystal/pull/11083), thanks @straight-shoota)
- Make `Array#transpose`, `Enumerable#reject`, `Enumerable#to_h` work with tuples ([#10445](https://github.com/crystal-lang/crystal/pull/10445), thanks @HertzDevil)
- fix parsing cookie Domain attribute with leading dot ([#11098](https://github.com/crystal-lang/crystal/pull/11098), thanks @mamantoha)
- Fix spec for HTTP::Params can't run on its own ([#11128](https://github.com/crystal-lang/crystal/pull/11128), thanks @asterite)
- Fix `Range#step` for non-integer `Steppable` types ([#11130](https://github.com/crystal-lang/crystal/pull/11130), thanks @straight-shoota)
- Add missing require in iterator_spec ([#11148](https://github.com/crystal-lang/crystal/pull/11148), thanks @asterite)
- Add FileUtils method specs with String and Path arguments ([#10987](https://github.com/crystal-lang/crystal/pull/10987), thanks @straight-shoota)
- Add integer square root ([#10549](https://github.com/crystal-lang/crystal/pull/10549), thanks @kimburgess)
- Proper handling of max-age and expires for cookies ([#10564](https://github.com/crystal-lang/crystal/pull/10564), thanks @straight-shoota)
- Add range overloads for `BitArray#toggle` ([#10743](https://github.com/crystal-lang/crystal/pull/10743), thanks @HertzDevil)
- Make FileUtils.mv work across filesystems ([#10783](https://github.com/crystal-lang/crystal/pull/10783), thanks @naqvis)
- Fix overflow in `BitArray#[](Int, Int)` for sizes between 33 and 64 ([#10809](https://github.com/crystal-lang/crystal/pull/10809), thanks @HertzDevil)
- Support basic auth from URI in websockets ([#10854](https://github.com/crystal-lang/crystal/pull/10854), thanks @willhbr)
- Allow EOF IO passed to JSON::PullParser.new ([#10864](https://github.com/crystal-lang/crystal/pull/10864), thanks @Blacksmoke16)
- add negative exponential support to BigDecimal ([#10892](https://github.com/crystal-lang/crystal/pull/10892), thanks @stakach)
- Add `#next_float` and `#prev_float` to `Float32` and `Float64` ([#10908](https://github.com/crystal-lang/crystal/pull/10908), thanks @HertzDevil)
- Quote the named tuple's keys on deserialization ([#10919](https://github.com/crystal-lang/crystal/pull/10919), thanks @Blacksmoke16)
- Implement `Enumerable#tally_by` ([#10922](https://github.com/crystal-lang/crystal/pull/10922), thanks @caspiano)
- Add `Slice#fill` ([#10924](https://github.com/crystal-lang/crystal/pull/10924), thanks @HertzDevil)
- Add precision parameter to `Int#to_s` ([#10926](https://github.com/crystal-lang/crystal/pull/10926), thanks @HertzDevil)
- Fix `Enumerable#each` block return type ([#10928](https://github.com/crystal-lang/crystal/pull/10928), thanks @straight-shoota)
- Fix key type for empty `NamedTuple` be `Symbol` ([#10942](https://github.com/crystal-lang/crystal/pull/10942), thanks @caspiano)
- Make `IO#read_char`'s default behaviour UTF-8-strict ([#10446](https://github.com/crystal-lang/crystal/pull/10446), thanks @HertzDevil)
- Allow `describe` without requiring an argument ([#10974](https://github.com/crystal-lang/crystal/pull/10974), thanks @straight-shoota)
- Disallow `Slice(T).new(Int)` where `T` is a union of primitive number types ([#10982](https://github.com/crystal-lang/crystal/pull/10982), thanks @HertzDevil)
- Add missing requires to run a couple of specs standalone ([#11152](https://github.com/crystal-lang/crystal/pull/11152), thanks @asterite)

## Other

- PR template ([#10894](https://github.com/crystal-lang/crystal/pull/10894), thanks @beta-ziliani)
- Update previous release Crystal 1.1.0 ([#10955](https://github.com/crystal-lang/crystal/pull/10955), thanks @straight-shoota)
- Update readme to point to IRC channel on libera.chat ([#11024](https://github.com/crystal-lang/crystal/pull/11024), thanks @jhass)
- Merge changelog entry for 1.1.1 ([#11028](https://github.com/crystal-lang/crystal/pull/11028), thanks @straight-shoota)
- fix typo: contains -> contain ([#11045](https://github.com/crystal-lang/crystal/pull/11045), thanks @toshokan)
- Update previous release Crystal 1.1.1 ([#11053](https://github.com/crystal-lang/crystal/pull/11053), thanks @straight-shoota)
- [CI] Remove test_linux_32 and add smoke test for 32-bit gnu ([#11127](https://github.com/crystal-lang/crystal/pull/11127), thanks @straight-shoota)
- Primitive annotations for interpreter ([#11147](https://github.com/crystal-lang/crystal/pull/11147), thanks @asterite)
```

</details>