### PR TITLE
`Scheduler#reschedule`: Shortcut lookup for current fiber.

### DIFF
--- a/src/crystal/scheduler.cr
+++ b/src/crystal/scheduler.cr
@@ -143,7 +143,7 @@ class Crystal::Scheduler
   protected def reschedule : Nil
     loop do
       if runnable = @lock.sync { @runnables.shift? }
-        unless runnable == Fiber.current
+        unless runnable == @current
           runnable.resume
         end
         break


### PR DESCRIPTION
The call chain before this change is

`Fiber.current` =>
`Scheduler.current_fiber` =>
`Thread.current.scheduler.@current`

`Thread.current.scheduler` is by necessity the scheduler that is
currently executing. Also, `Thread.current` is resolved by hitting a
`ThreadLocal`, and these are protected by a mutex, so this should also
reduce contention a bit.