### PR TITLE
Update aarch64.yml

### DIFF
--- a/.github/workflows/aarch64.yml
+++ b/.github/workflows/aarch64.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Mark downloaded compiler as executable
         run: chmod +x .build/crystal
       - name: Run stdlib specs
-        uses: docker://jhass/crystal:0.35.0-alpine-build
+        uses: docker://jhass/crystal:1.0.0-alpine-build
         with:
           args: make std_spec
   musl-test-compiler:


### PR DESCRIPTION
One of the processes was pointing at an older image. We are using 1.0.0 images on purpose, as discussed in [this post](https://forum.crystal-lang.org/t/compiler-compilability/3651) (no need to upgrade the images at the moment).