### PR TITLE
Fix typos

### DIFF
--- a/man/crystal.1
+++ b/man/crystal.1
@@ -6,7 +6,7 @@
 .Sh NAME
 .Nm crystal
 .Nd Compiler for the Crystal language.
-.Sh SYNOPSYS
+.Sh SYNOPSIS
 .Nm
 command
 .Op switches

--- a/src/openssl/cipher.cr
+++ b/src/openssl/cipher.cr
@@ -92,7 +92,7 @@ class OpenSSL::Cipher
     cipherinit
   end
 
-  # Add the data to be encypted or decrypted to this cipher's buffer.
+  # Add the data to be encrypted or decrypted to this cipher's buffer.
   def update(data)
     slice = data.to_slice
     buffer_length = slice.size + block_size

--- a/src/xml/libxml2.cr
+++ b/src/xml/libxml2.cr
@@ -165,7 +165,7 @@ lib LibXML
     xmlCharEncodingHandlerPtr : Void*
     buffer : Void*
     conv : Void*
-    writter : Int
+    written : Int
     error : Int
   end
 


### PR DESCRIPTION
Using [codespell](https://github.com/codespell-project/codespell), some typos are found.

- encypted -> encrypted
- writter -> written (See http://xmlsoft.org/html/libxml-tree.html#xmlOutputBuffer)
- SYNOPSYS -> SYNOPSIS
