### PR TITLE
Allow union types to be unbound

### DIFF
--- a/spec/compiler/semantic/union_spec.cr
+++ b/spec/compiler/semantic/union_spec.cr
@@ -314,4 +314,31 @@ describe "Semantic: union" do
       Union(Foo)
       )) { types["Foo"].metaclass }
   end
+
+  it "doesn't run virtual lookup on unbound unions (#9173)" do
+    assert_type(%(
+      class Object
+        def foo
+          self
+        end
+      end
+
+      abstract class Parent
+      end
+
+      class Child(T) < Parent
+        @buffer = uninitialized T
+
+        def bar
+          @buffer.foo
+        end
+      end
+
+      class Foo(U)
+        @x = Child(U | Char).new
+      end
+
+      Child(Int32).new.as(Parent).bar
+      )) { int32 }
+  end
 end

--- a/src/compiler/crystal/types.cr
+++ b/src/compiler/crystal/types.cr
@@ -3070,6 +3070,10 @@ module Crystal
       program.type_merge(new_union_types) || program.no_return
     end
 
+    def unbound?
+      union_types.any? &.unbound?
+    end
+
     def all?
       union_types.all? { |union_type| yield union_type }
     end


### PR DESCRIPTION
Fixes #9173. In

```crystal
class Object
  def foo
    self
  end
end

abstract class Parent
end

class Child(T) < Parent
  @buffer = uninitialized T

  def bar
    @buffer.foo # Error: undefined method 'foo' for U (compile-time type is (Char | U))
  end
end

class Foo(U)
  @x = Child(U | Char).new
end

Child(Int32).new.as(Parent).bar
```

When `Parent#bar` is called the compiler runs type inference on the implementations in all concrete subtypes of it. This incorrectly included `Child(U | Char)` because it and `U | Char` were not considered unbound types. This PR fixes that. (In the original issue this is triggered through `Array(T | U)#inspect` of an instance variable inside `Iterator::InGroupsOf(I, T, N, U)`.)