### PR TITLE
Don't generate type IDs for formal generic instances

### DIFF
--- a/src/compiler/crystal/codegen/llvm_id.cr
+++ b/src/compiler/crystal/codegen/llvm_id.cr
@@ -136,7 +136,7 @@ module Crystal
     private def assign_id_to_metaclass(type : GenericClassType)
       assign_id_to_metaclass(type, type.metaclass)
       type.each_instantiated_type do |instance|
-        assign_id_to_metaclass(instance)
+        assign_id_to_metaclass(instance) unless instance.unbound?
       end
       type.subclasses.each do |subclass|
         assign_id_to_metaclass(subclass)


### PR DESCRIPTION
The compiler traverses through every instantiation of a generic class type when it generates unique IDs for every type's metaclass for the `Object#class` primitive. This includes formal types:

```crystal
class A(T)
end

class B(T) < A(T) # second `T` is an unbound type parameter referring to the first `T`
  @x : A(T) # unbound type parameter referring to the `T` of `B(T)`
end

# the generated `~metaclass` function references `A(T)` and `A(T).class` where
# `T` refers to the type parameter of the generic `B(T)`, see below
```

This PR skips those types because they can never be encountered in any real program. This reduces the number of unique types in a blank source file by about 21%; see [here](https://gist.github.com/HertzDevil/685b92e4905889fc218f82de3987d18b) for a comparison.