### PR TITLE
Add an environment variable for dumping type IDs

### DIFF
--- a/src/compiler/crystal/codegen/codegen.cr
+++ b/src/compiler/crystal/codegen/codegen.cr
@@ -368,6 +368,30 @@ module Crystal
         # release mode, once we reach 1.0.
         mod.verify
       end
+
+      dump_type_id if ENV["CRYSTAL_DUMP_TYPE_ID"]? == "1"
+    end
+
+    private def dump_type_id
+      ids = @program.llvm_id.@ids.to_a
+      ids.sort_by! { |_, (min, max)| {min, -max} }
+
+      puts "CRYSTAL_DUMP_TYPE_ID"
+      parent_ids = [] of {Int32, Int32}
+      ids.each do |type, (min, max)|
+        while parent_id = parent_ids.last?
+          break if min >= parent_id[0] && max <= parent_id[1]
+          parent_ids.pop
+        end
+        indent = " " * (2 * parent_ids.size)
+
+        show_generic_args = type.is_a?(GenericInstanceType) ||
+                            type.is_a?(GenericClassInstanceMetaclassType) ||
+                            type.is_a?(GenericModuleInstanceMetaclassType)
+        puts "#{indent}{#{min} - #{max}}: #{type.to_s(generic_args: show_generic_args)}"
+        parent_ids << {min, max}
+      end
+      puts
     end
 
     def visit(node : Annotation)


### PR DESCRIPTION
If the environment variable `CRYSTAL_DUMP_TYPE_ID=1` is present, instructs the compiler to print a dump of every type with its type ID bounds; the upper bound is the type's `crystal_instance_type_id`, and the lower bound is the minimum `crystal_instance_type_id` of its subtypes. (The bounds are used by `is_a?` on virtual types.) This is used to generate the type ID dumps in #11167. For a blank program with the empty prelude, the dump looks like:

```
CRYSTAL_DUMP_TYPE_ID
{0 - 0}: Nil
{1 - 37}: Object
  {1 - 6}: Reference
    {1 - 1}: String
    {2 - 2}: Array
    {3 - 3}: Hash
    {4 - 4}: Regex
    {5 - 5}: Exception
  {7 - 36}: Value
    {7 - 21}: Number
      {7 - 17}: Int
        {7 - 7}: Int8
        {8 - 8}: UInt8
        {9 - 9}: Int16
        {10 - 10}: UInt16
        {11 - 11}: Int32
        {12 - 12}: UInt32
        {13 - 13}: Int64
        {14 - 14}: UInt64
        {15 - 15}: Int128
        {16 - 16}: UInt128
      {18 - 20}: Float
        {18 - 18}: Float32
        {19 - 19}: Float64
    {22 - 22}: Bool
    {23 - 23}: Char
    {24 - 24}: Symbol
    {25 - 27}: Pointer
      {25 - 25}: Pointer(UInt8)
      {26 - 26}: Pointer(Pointer(UInt8))
    {28 - 28}: Tuple
    {29 - 29}: NamedTuple
    {30 - 30}: StaticArray
    {31 - 32}: Struct
      {31 - 31}: Range
    {33 - 33}: Enum
    {34 - 34}: Proc
    {35 - 35}: Union
{38 - 38}: Object.class
{39 - 39}: Reference.class
{40 - 40}: String.class
{41 - 41}: Array(T).class
{42 - 42}: Hash(K, V).class
{43 - 43}: Regex.class
{44 - 44}: Exception.class
{45 - 45}: Value.class
{46 - 46}: Number.class
{47 - 47}: Int.class
{48 - 48}: Int8.class
{49 - 49}: UInt8.class
{50 - 50}: Int16.class
{51 - 51}: UInt16.class
{52 - 52}: Int32.class
{53 - 53}: UInt32.class
{54 - 54}: Int64.class
{55 - 55}: UInt64.class
{56 - 56}: Int128.class
{57 - 57}: UInt128.class
{58 - 58}: Float.class
{59 - 59}: Float32.class
{60 - 60}: Float64.class
{61 - 61}: Nil.class
{62 - 62}: Bool.class
{63 - 63}: Char.class
{64 - 64}: Symbol.class
{65 - 65}: Pointer(T).class
{66 - 66}: Pointer(UInt8).class
{67 - 67}: Pointer(Pointer(UInt8)).class
{68 - 68}: Tuple(*T).class
{69 - 69}: NamedTuple(T).class
{70 - 70}: StaticArray(T, N).class
{71 - 71}: Struct.class
{72 - 72}: Range(B, E).class
{73 - 73}: Enum.class
{74 - 74}: Proc(*T, R).class
{75 - 75}: Union(*T).class
```

Some generic metaclasses above are uninstantiated (like `Tuple(*T).class`), so they should not contain the generic parameters. This is handled by #11104.

This is mostly for quickly debugging the compiler itself, similar to `DUMP` and `AFTER`, so there are no specs.