### PR TITLE
`crystal init`: Improve transformation of project name with hyphens

### DIFF
--- a/spec/compiler/crystal/tools/init_spec.cr
+++ b/spec/compiler/crystal/tools/init_spec.cr
@@ -401,7 +401,7 @@ module Crystal
     it "hyphen follwed by non-ascii letter is replaced by its character" do
       Crystal::Init::View.module_name("my-proj-1").should eq "My::Proj1"
     end
-    it "unserscore is ignored" do
+    it "underscore is ignored" do
       Crystal::Init::View.module_name("my-proj_name").should eq "My::ProjName"
     end
   end

--- a/spec/compiler/crystal/tools/init_spec.cr
+++ b/spec/compiler/crystal/tools/init_spec.cr
@@ -393,4 +393,16 @@ module Crystal
       Crystal::Init.validate_name("grüß-gott")
     end
   end
+
+  describe "View#module_name" do
+    it "namespace is divided by hyphen" do
+      Crystal::Init::View.module_name("my-proj-name").should eq "My::Proj::Name"
+    end
+    it "hyphen follwed by non-ascii letter is replaced by its character" do
+      Crystal::Init::View.module_name("my-proj-1").should eq "My::Proj1"
+    end
+    it "unserscore is ignored" do
+      Crystal::Init::View.module_name("my-proj_name").should eq "My::ProjName"
+    end
+  end
 end

--- a/spec/compiler/crystal/tools/init_spec.cr
+++ b/spec/compiler/crystal/tools/init_spec.cr
@@ -65,6 +65,7 @@ module Crystal
       within_temporary_directory do
         run_init_project("lib", "example", "John Smith", "john@smith.com", "jsmith")
         run_init_project("app", "example_app", "John Smith", "john@smith.com", "jsmith")
+        run_init_project("app", "num-followed-hyphen-1", "John Smith", "john@smith.com", "jsmith")
         run_init_project("lib", "example-lib", "John Smith", "john@smith.com", "jsmith")
         run_init_project("lib", "camel_example-camel_lib", "John Smith", "john@smith.com", "jsmith")
         run_init_project("lib", "example", "John Smith", "john@smith.com", "jsmith", dir: "other-example-directory")
@@ -75,6 +76,10 @@ module Crystal
 
         with_file "camel_example-camel_lib/src/camel_example-camel_lib.cr" do |file|
           file.should contain("CamelExample::CamelLib")
+        end
+
+        with_file "num-followed-hyphen-1/src/num-followed-hyphen-1.cr" do |file|
+          file.should contain("Num::Followed::Hyphen1")
         end
 
         with_file "example/.gitignore" do |gitignore|

--- a/src/compiler/crystal/tools/init.cr
+++ b/src/compiler/crystal/tools/init.cr
@@ -207,7 +207,11 @@ module Crystal
       end
 
       def module_name
-        config.name.gsub(/[-_]([^a-z])/i, "\\1").split('-').compact_map { |name| name.camelcase if name[0]?.try(&.ascii_letter?) }.join("::")
+        View.module_name(config.name)
+      end
+
+      def self.module_name(name)
+        name.gsub(/[-_]([^a-z])/i, "\\1").split('-').compact_map { |name| name.camelcase if name[0]?.try(&.ascii_letter?) }.join("::")
       end
 
       abstract def path

--- a/src/compiler/crystal/tools/init.cr
+++ b/src/compiler/crystal/tools/init.cr
@@ -211,7 +211,13 @@ module Crystal
       end
 
       def self.module_name(name)
-        name.gsub(/[-_]([^a-z])/i, "\\1").split('-').compact_map { |name| name.camelcase if name[0]?.try(&.ascii_letter?) }.join("::")
+        name
+          .gsub(/[-_]([^a-z])/i, "\\1")
+          .split('-')
+          .compact_map do |name| 
+            name.camelcase if name[0]?.try(&.ascii_letter?)
+          end
+          .join("::")
       end
 
       abstract def path

--- a/src/compiler/crystal/tools/init.cr
+++ b/src/compiler/crystal/tools/init.cr
@@ -207,7 +207,7 @@ module Crystal
       end
 
       def module_name
-        config.name.split('-').map(&.camelcase).join("::")
+        config.name.gsub(/-([0-9]+)/, "\\1").split('-').map(&.camelcase).join("::")
       end
 
       abstract def path

--- a/src/compiler/crystal/tools/init.cr
+++ b/src/compiler/crystal/tools/init.cr
@@ -214,7 +214,7 @@ module Crystal
         name
           .gsub(/[-_]([^a-z])/i, "\\1")
           .split('-')
-          .compact_map do |name| 
+          .compact_map do |name|
             name.camelcase if name[0]?.try(&.ascii_letter?)
           end
           .join("::")

--- a/src/http/server.cr
+++ b/src/http/server.cr
@@ -514,10 +514,12 @@ class HTTP::Server
 
     @processor.process(io, io)
   ensure
-    begin
-      io.close
-    rescue IO::Error
-    end
+    {% begin %}
+      begin
+        io.close
+      rescue IO::Error{% unless flag?(:without_openssl) %} | OpenSSL::SSL::Error{% end %}
+      end
+    {% end %}
   end
 
   # This method handles exceptions raised at `Socket#accept?`.


### PR DESCRIPTION
issue #11107 

when executing `crystal init app crystal-proj-1`

before

~~~
module Crystal::Proj::1
~~~

after

~~~
module Crystal::Proj1
~~~