### PR TITLE
Add clarification about when `instance_vars` can be called

### DIFF
--- a/src/compiler/crystal/macros.cr
+++ b/src/compiler/crystal/macros.cr
@@ -1752,6 +1752,7 @@ module Crystal::Macros
     end
 
     # Returns the instance variables of this type.
+    # Can only be called from within methods (not top-level code), otherwise will return an empty list.
     def instance_vars : ArrayLiteral(MetaVar)
     end
 


### PR DESCRIPTION
I believe this is in line with [this forum post](https://forum.crystal-lang.org/t/unions-and-macro-methods/3243/6). This would have saved me some confused debugging as to why I kept getting an empty list!