### PR TITLE
CSV: don't eagerly check next char after newline

### DIFF
--- a/src/csv/lexer.cr
+++ b/src/csv/lexer.cr
@@ -36,6 +36,14 @@ abstract class CSV::Lexer
     @column_number = 1
     @line_number = 1
     @last_empty_column = false
+
+    # When the lexer finds \n or \r it produces a newline token
+    # but it doesn't eagerly consume the next token. It does this
+    # so that if a CSV is streamed from STDIN or from a socket
+    # the parser will produce a row as soon as a newline is reached,
+    # without having to wait for more content.
+    @last_was_slash_r = false
+    @last_was_slash_n = false
   end
 
   # Rewinds this lexer to the beginning
@@ -43,6 +51,8 @@ abstract class CSV::Lexer
     @column_number = 1
     @line_number = 1
     @last_empty_column = false
+    @last_was_slash_r = false
+    @last_was_slash_n = false
   end
 
   private abstract def consume_unquoted_cell
@@ -58,6 +68,16 @@ abstract class CSV::Lexer
       return @token
     end
 
+    if @last_was_slash_r
+      if next_char == '\n'
+        next_char
+      end
+      @last_was_slash_r = false
+    elsif @last_was_slash_n
+      next_char
+      @last_was_slash_n = false
+    end
+
     case current_char
     when '\0'
       @token.kind = Token::Kind::Eof
@@ -66,22 +86,11 @@ abstract class CSV::Lexer
       @token.value = ""
       check_last_empty_column
     when '\r'
-      @token.kind =
-        case next_char
-        when '\0'
-          Token::Kind::Eof
-        when '\n'
-          case next_char
-          when '\0'
-            Token::Kind::Eof
-          else
-            Token::Kind::Newline
-          end
-        else
-          Token::Kind::Newline
-        end
+      @token.kind = Token::Kind::Newline
+      @last_was_slash_r = true
     when '\n'
-      @token.kind = next_char == '\0' ? Token::Kind::Eof : Token::Kind::Newline
+      @token.kind = Token::Kind::Newline
+      @last_was_slash_n = true
     when @quote_char
       @token.kind = Token::Kind::Cell
       @token.value = consume_quoted_cell


### PR DESCRIPTION
Fixes #11172

When a `\n` char was detected by the lexer, it would check what the next char was. If it was `\0` it means the end of the file/stream as opposed to a newline. However, doing this when streaming over an IO meant that the newline token wasn't returned until more content was available after the newline. This isn't ideal.

This PR changes that so that we only check the content after the newline if a next token is asked. This allows the parser to produce a row right after a newline comes.

This is technically a breaking change because something like "a\n" would previously produce `Cell("a"), EOF` but now it will produce `Cell("a"), Newline, EOF`. I think this breaking change is acceptable because:
- it's very unlikely to break client code (I doubt anyone is using the lexer instead of the high-level code)
- it can be considered a bugfix: now you can distinguish between "a\n" and "a", if that matters to you
- the parser will still produce the same output