### PR TITLE
Add missing `ArrayLiteral#-(other : ArrayLiteral)` macro method

### DIFF
--- a/spec/compiler/macro/macro_methods_spec.cr
+++ b/spec/compiler/macro/macro_methods_spec.cr
@@ -816,6 +816,10 @@ module Crystal
         assert_macro "", %({{ [1, 2] + [3, 4, 5] }}), [] of ASTNode, %([1, 2, 3, 4, 5])
       end
 
+      it "executes -" do
+        assert_macro "", %({{ [1, 2, 3, 4, 5] - [3, 4, 5] }}), [] of ASTNode, %([1, 2])
+      end
+
       it "executes [] with range" do
         assert_macro "", %({{ [1, 2, 3, 4][1...-1] }}), [] of ASTNode, %([2, 3])
       end

--- a/src/compiler/crystal/macros.cr
+++ b/src/compiler/crystal/macros.cr
@@ -665,6 +665,10 @@ module Crystal::Macros
     def +(other : ArrayLiteral) : ArrayLiteral
     end
 
+    # Similar to `Array#-`.
+    def -(other : ArrayLiteral) : ArrayLiteral
+    end
+
     # Returns the type specified at the end of the array literal, if any.
     #
     # This refers to the part after brackets in `[] of String`.

--- a/src/compiler/crystal/macros/methods.cr
+++ b/src/compiler/crystal/macros/methods.cr
@@ -2394,6 +2394,16 @@ private def interpret_array_or_tuple_method(object, klass, method, args, named_a
       end
       klass.new(object.elements + other_elements)
     end
+  when "-"
+    interpret_check_args(node: object) do |arg|
+      case arg
+      when Crystal::ArrayLiteral
+        other_elements = arg.elements
+      else
+        arg.raise "argument to `#{klass}#-` must be array, not #{arg.class_desc}:\n\n#{arg}"
+      end
+      klass.new(object.elements - other_elements)
+    end
   else
     nil
   end


### PR DESCRIPTION
For some reason `ArrayLiteral#-(other : ArrayLiteral)` did not exist.