### PR TITLE
Compiler: make `is_a?(union)` work correctly for virtual types

### DIFF
--- a/spec/compiler/codegen/is_a_spec.cr
+++ b/spec/compiler/codegen/is_a_spec.cr
@@ -856,4 +856,42 @@ describe "Codegen: is_a?" do
       end
       )).to_i.should eq(1)
   end
+
+  it "does is_a? with union type, don't resolve to virtual type (#10244)" do
+    run(%(
+      class A
+      end
+
+      class B < A
+      end
+
+      class C < A
+      end
+
+      class D < A
+      end
+
+      x = D.new || C.new
+      x.is_a?(B | C)
+    )).to_b.should be_false
+  end
+
+  it "does is_a? with union type as Union(X, Y), don't resolve to virtual type (#10244)" do
+    run(%(
+      class A
+      end
+
+      class B < A
+      end
+
+      class C < A
+      end
+
+      class D < A
+      end
+
+      x = D.new || C.new
+      x.is_a?(Union(B, C))
+    )).to_b.should be_false
+  end
 end

--- a/src/compiler/crystal/semantic/main_visitor.cr
+++ b/src/compiler/crystal/semantic/main_visitor.cr
@@ -220,6 +220,7 @@ module Crystal
 
     def visit(node : Generic)
       node.in_type_args = @in_type_args > 0
+      node.inside_is_a = @inside_is_a
       node.scope = @scope
 
       node.name.accept self

--- a/src/compiler/crystal/semantic/type_intersect.cr
+++ b/src/compiler/crystal/semantic/type_intersect.cr
@@ -161,7 +161,7 @@ module Crystal
       types = type2.union_types.compact_map do |t|
         common_descendent(type1, t)
       end
-      type1.program.type_merge types
+      type1.program.type_merge_union_of types
     end
 
     def self.common_descendent(type1 : VirtualType, type2 : Type)

--- a/src/compiler/crystal/types.cr
+++ b/src/compiler/crystal/types.cr
@@ -2946,7 +2946,7 @@ module Crystal
     @splat_index = 0
     @struct = true
 
-    def instantiate(type_vars)
+    def instantiate(type_vars, type_merge_union_of = false)
       types = type_vars.map do |type_var|
         unless type_var.is_a?(Type)
           type_var.raise "argument to Union must be a type, not #{type_var}"
@@ -2957,7 +2957,12 @@ module Crystal
         # and not T+ (which might lead to some inconsistencies).
         type_var.devirtualize.as(Type)
       end
-      program.type_merge(types) || program.no_return
+
+      if type_merge_union_of
+        program.type_merge_union_of(types) || program.no_return
+      else
+        program.type_merge(types) || program.no_return
+      end
     end
 
     def new_generic_instance(program, generic_type, type_vars)


### PR DESCRIPTION
Fixes #10244

Now the snippet in that issue gives this:

```crystal
class Foo; end

class BarA < Foo; end
class BarB < Foo; end
class BarC < Foo; end

Union(BarB, BarC)              # => Foo
BarB | BarC                    # => Foo

x = BarA.new || BarB.new || BarC.new
typeof(x)                      # => Foo
x.is_a?(BarB) || x.is_a?(BarC) # => false
x.is_a?(BarB | BarC)           # => false
x.is_a?(Union(BarB, BarC))     # => false
x.is_a?(Foo)                   # => true

y = BarA.new
typeof(y)                      # => BarA
y.is_a?(BarB) || x.is_a?(BarC) # => false
y.is_a?(BarB | BarC)           # => false
y.is_a?(Union(BarB, BarC))     # => false
y.is_a?(Foo)                   # => true
```

which I believe is more correct than the previous behavior.

Please note that this change only applies to `is_a?`: as you can see, `Union(BarB, BarC)` unifies to the parent type. In theory we could also make that change, but it's much more complex (a quick change to this already makes the compiler stop compiling itself, or the std.) But, I think checking `x.is_a?(X | Y)` is much more common than using union types outside of `is_a?`. So for now I'd like to defer this.

Also, I need this change to keep working on the interpreter. The way I implemented multidispatch there, I end up generating code like `exp.is_a?(B | C)` and if that resolves to the parent type then it's not the same condition I'm looking for. I could do some hacks around that, or try to implement multidispatch in a different, but much harder, way, but I think it's better if we also fix these small edges in the language.

It seems this change also fixes this bug:

```crystal
class A
end

class B < A
end

class C < B
end

x = C.new || B.new
if x.is_a?(B | C)
  # This would print "B" before this PR, not it prints "B | C"
  puts typeof(x)
end
```