### PR TITLE
Fix edge case for intersection between virtual metaclasses

### DIFF
--- a/spec/compiler/codegen/cast_spec.cr
+++ b/spec/compiler/codegen/cast_spec.cr
@@ -411,4 +411,16 @@ describe "Code gen: cast" do
       x.foo
       )).to_i.should eq(1)
   end
+
+  it "can cast to metaclass (#11121)" do
+    run(%(
+      class A
+      end
+
+      class B < A
+      end
+
+      A.as(A.class)
+      ))
+  end
 end

--- a/spec/compiler/semantic/cast_spec.cr
+++ b/spec/compiler/semantic/cast_spec.cr
@@ -221,6 +221,18 @@ describe "Semantic: cast" do
       )) { int32.metaclass }
   end
 
+  it "can cast to metaclass (2) (#11121)" do
+    assert_type(%(
+      class A
+      end
+
+      class B < A
+      end
+
+      A.as(A.class)
+      )) { types["A"].virtual_type.metaclass }
+  end
+
   # Later we might want casting something to Object to have a meaning
   # similar to casting to Void*, but for now it's useless.
   it "disallows casting to Object (#815)" do

--- a/src/compiler/crystal/semantic/type_intersect.cr
+++ b/src/compiler/crystal/semantic/type_intersect.cr
@@ -82,7 +82,7 @@ module Crystal
       return nil if type1.instance_type.module?
 
       restricted = common_descendent(type1.instance_type, type2.instance_type.base_type)
-      restricted.try(&.virtual_type.metaclass)
+      restricted.try(&.metaclass)
     end
 
     def self.common_descendent(type1 : VirtualMetaclassType, type2 : MetaclassType)
@@ -90,8 +90,8 @@ module Crystal
     end
 
     def self.common_descendent(type1 : VirtualMetaclassType, type2 : VirtualMetaclassType)
-      restricted = common_descendent(type1.instance_type, type2.instance_type.base_type)
-      restricted.try(&.virtual_type.metaclass)
+      restricted = common_descendent(type1.instance_type, type2.instance_type)
+      restricted.try(&.metaclass)
     end
 
     def self.common_descendent(type1 : GenericClassInstanceMetaclassType | GenericModuleInstanceMetaclassType, type2 : MetaclassType)


### PR DESCRIPTION
Follow-up to #11121. Fixes a regression on master where the following no longer worked:

```crystal
class A
end

class B < A
end

A.as(A.class) # Unhandled exception: cast from Class to A+.class failed
```