### PR TITLE
Fix resolve generic argument in block output type restriction mismatch

### DIFF
--- a/spec/compiler/semantic/block_spec.cr
+++ b/spec/compiler/semantic/block_spec.cr
@@ -1456,6 +1456,29 @@ describe "Block inference" do
       )) { tuple_of([tuple_of([int32, int32]), tuple_of([int32, int32]).metaclass]) }
   end
 
+  it "reports mismatch with generic argument type in output type" do
+    assert_error(<<-CR, "expected block to return String, not Int32")
+      class Foo(T)
+        def foo(&block : -> T)
+        end
+      end
+
+      Foo(String).new.foo { 1 }
+      CR
+  end
+
+  it "reports mismatch with generic argument type in input type" do
+    assert_error(<<-CR, "argument #1 of yield expected to be String, not Int32")
+      class Foo(T)
+        def foo(&block : T -> )
+          yield 1
+        end
+      end
+
+      Foo(String).new.foo {}
+      CR
+  end
+
   it "correctly types unpacked tuple block arg after block (#3339)" do
     assert_type(%(
       def foo

--- a/src/compiler/crystal/semantic/call.cr
+++ b/src/compiler/crystal/semantic/call.cr
@@ -1018,13 +1018,13 @@ class Crystal::Call
               end
             else
               output_name = case output
-                when Self
-                  match.context.instantiated_type
-                when Crystal::Path
-                  match.context.defining_type.lookup_path(output)
-                else
-                  output
-                end
+                            when Self
+                              match.context.instantiated_type
+                            when Crystal::Path
+                              match.context.defining_type.lookup_path(output)
+                            else
+                              output
+                            end
               raise "expected block to return #{output_name}, not #{block_type}"
             end
           end

--- a/src/compiler/crystal/semantic/call.cr
+++ b/src/compiler/crystal/semantic/call.cr
@@ -1017,11 +1017,15 @@ class Crystal::Call
                 end
               end
             else
-              if output.is_a?(Self)
-                raise "expected block to return #{match.context.instantiated_type}, not #{block_type}"
-              else
-                raise "expected block to return #{output}, not #{block_type}"
-              end
+              output_name = case output
+                when Self
+                  match.context.instantiated_type
+                when Crystal::Path
+                  match.context.defining_type.lookup_path(output)
+                else
+                  output
+                end
+              raise "expected block to return #{output_name}, not #{block_type}"
             end
           end
 


### PR DESCRIPTION
When a type restriction on a block argument's output type does not match, the error message failed to resolve generic type arguments:
```cr
Array(Int32).new(1) { "String" } # => Error: expected block to return T, not String
```

This patch fixes that, the error message is now `expected block to return Int32, not String`.