### PR TITLE
Properly handle indirect arguments for external C functions

### DIFF
--- a/spec/compiler/codegen/c_abi/c_abi_spec.cr
+++ b/spec/compiler/codegen/c_abi/c_abi_spec.cr
@@ -200,46 +200,42 @@ describe "Code gen: C ABI" do
       ), &.to_i.should eq(6))
   end
 
-  {% if flag?(:win32) || flag?(:aarch64) %}
-    pending "accepts large struct in a callback (for real) (#9533)"
-  {% else %}
-    it "accepts large struct in a callback (for real)" do
-      test_c(
-        %(
-          struct s {
-              long long x, y, z;
-          };
+  it "accepts large struct in a callback (for real)" do
+    test_c(
+      %(
+        struct s {
+            long long x, y, z;
+        };
 
-          void ccaller(void (*func)(struct s)) {
-              struct s v = {1, 2, 3};
-              func(v);
-          }
-        ),
-        %(
-          lib LibFoo
-            struct S
-              x : Int64
-              y : Int64
-              z : Int64
-            end
-
-            fun ccaller(func : (S) ->)
+        void ccaller(void (*func)(struct s)) {
+            struct s v = {1, 2, 3};
+            func(v);
+        }
+      ),
+      %(
+        lib LibFoo
+          struct S
+            x : Int64
+            y : Int64
+            z : Int64
           end
 
-          module Global
-            class_property x = 0i64
-          end
+          fun ccaller(func : (S) ->)
+        end
 
-          fun callback(v : LibFoo::S)
-            Global.x = v.x &+ v.y &+ v.z
-          end
+        module Global
+          class_property x = 0i64
+        end
 
-          LibFoo.ccaller(->callback)
+        fun callback(v : LibFoo::S)
+          Global.x = v.x &+ v.y &+ v.z
+        end
 
-          Global.x
-        ), &.to_string.should eq("6"))
-    end
-  {% end %}
+        LibFoo.ccaller(->callback)
+
+        Global.x
+      ), &.to_string.should eq("6"))
+  end
 
   it "promotes variadic args (float to double)" do
     test_c(


### PR DESCRIPTION
Fixes #9533 

- When making a call to a C function with an indirect argument, make a caller allocated copy and substitute the argument with a pointer to the copy
- Do not attempt to cast an indirect argument on the receiving side 
- Enable pending spec in AArch64 and Windows 64 (from #9534)

From the description of #9533 and linked issues I gather the C ABI argument passing was ported from Rust, which has the concept of indirect argument passing. Reading the ABI specs for [ARM64](https://c9x.me/compile/bib/abi-arm64.pdf) (see section 5.4.2, B-3) and for [Windows 64 x86](https://docs.microsoft.com/en-us/cpp/build/x64-calling-convention?view=msvc-160#parameter-passing), and analyzing the LLVM IR code generated by Clang, it's clear that an indirect argument should be passed as a pointer to caller-allocated memory. This is different than passing an argument on the stack, which seems to be the default in Linux and Darwin on x86: this is handled by LLVM when the argument is annotated with `byval`, and the generated assembly code pushes the value on the stack instead of passing it on a register.

This PR fixes two problems, one on the caller and one on the callee:

- On the caller, when an argument should be passed indirectly, it allocates stack memory to hold a copy and the pointer to the allocated memory is passed instead.
- On the callee, when receiving an indirect argument, no special cast/copy is attempted as the code can modify the memory on the passed pointer freely.

The change in [fun.cr](https://github.com/crystal-lang/crystal/compare/master...ggiraldez:issue-9533?expand=1#diff-cd5ad7a37019c36f28b7874ebfc6000a268d3ac7321ef445177a68d80cbe5555) is pretty ugly, but I don't currently know what are all the cases it should cover and it's not immediately obvious from the code. The method `create_local_copy_of_arg` is doing way too much already IMHO.