### PR TITLE
Make `Class` and all metaclasses non-abstract

### DIFF
--- a/spec/compiler/semantic/virtual_metaclass_spec.cr
+++ b/spec/compiler/semantic/virtual_metaclass_spec.cr
@@ -33,6 +33,36 @@ describe "Semantic: virtual metaclass" do
     ") { union_of(int32, float64) }
   end
 
+  it "errors if virtual metaclass method is not defined on base class" do
+    assert_error %(
+      class A
+      end
+
+      class B < A
+        def self.foo
+        end
+      end
+
+      (A || B).foo
+      ),
+      "undefined method 'foo' for A.class (compile-time type is A+.class)"
+  end
+
+  it "errors if virtual metaclass method is not defined on abstract base class" do
+    assert_error %(
+      abstract class A
+      end
+
+      class B < A
+        def self.foo
+        end
+      end
+
+      (A || B).foo
+      ),
+      "undefined method 'foo' for A.class (compile-time type is A+.class)"
+  end
+
   it "allows allocating virtual type when base class is abstract" do
     assert_type("
       abstract class Foo

--- a/src/compiler/crystal/semantic/method_lookup.cr
+++ b/src/compiler/crystal/semantic/method_lookup.cr
@@ -410,7 +410,7 @@ module Crystal
       base_type_covers_all = base_type_matches.cover_all?
 
       # If the base type doesn't cover every possible type combination, it's a failure
-      if !base_type.abstract? && !base_type_covers_all
+      if !abstract? && !base_type_covers_all
         return Matches.new(base_type_matches.matches, base_type_matches.cover, base_type_lookup, false)
       end
 

--- a/src/compiler/crystal/types.cr
+++ b/src/compiler/crystal/types.cr
@@ -2806,7 +2806,14 @@ module Crystal
       program.class_type
     end
 
-    delegate abstract?, generic_nest, lookup_new_in_ancestors?,
+    def abstract?
+      # the value `T` is an instance of the type `T.class`, and the value
+      # `Class` is an instance of the type `Class`, so metaclasses are never
+      # abstract
+      false
+    end
+
+    delegate generic_nest, lookup_new_in_ancestors?,
       type_var?, to: instance_type
 
     def class_var_owner


### PR DESCRIPTION
Resolves #11132. Resolves #9959. The following code will now fail to compile:

```crystal
abstract class A
end

class B < A
  def self.foo
  end
end

class C < A
  def self.foo
  end
end

x = B || C
x.foo # Error: undefined method 'foo' for A.class (compile-time type is A+.class)
```

This is because the value of `x` can also be `A`, so a definition for `A.foo` must be present. Currently, if `x` is indeed `A`, calling `x.foo` leads to undefined behaviour whenever multiple target defs are available, because virtual dispatch on `x` does not produce a branch for `A.class`.

Does not affect #3835, because `.new` is still implicitly available on all metaclasses (and `.allocate` on all class metaclasses). Also related to #5956.

Making `Class` non-abstract doesn't seem to have any significant consequences yet.