### PR TITLE
Compiler: cache cleanup transformer

### DIFF
--- a/src/compiler/crystal/semantic/cleanup_transformer.cr
+++ b/src/compiler/crystal/semantic/cleanup_transformer.cr
@@ -4,15 +4,19 @@ require "../types"
 
 module Crystal
   class Program
+    getter(cleanup_transformer : CleanupTransformer) do
+      CleanupTransformer.new(self)
+    end
+
     def cleanup(node)
-      transformer = CleanupTransformer.new(self)
+      transformer = self.cleanup_transformer
       node = node.transform(transformer)
       puts node if ENV["AFTER"]? == "1"
       node
     end
 
     def cleanup_types
-      transformer = CleanupTransformer.new(self)
+      transformer = self.cleanup_transformer
 
       after_inference_types.each do |type|
         cleanup_type type, transformer


### PR DESCRIPTION
Otherwise on every `finished` hook we might potentially be cleaning up big chunks
of the program over and over agin.

Consider this program:

```crystal
{% for i in 0..3000 %}
  puts "Hello"
{% end %}
```

On my machine it takes about a second to compile.

Now this program:

```crystal
{% for i in 0..3000 %}
  macro finished
    puts "Hello"
  end
{% end %}
```

It takes 8.5 seconds to compile! 😱 

The reason is that we call `cleanup` on every `finished` hook, and that ends up creating a new `CleanupTransformer`. Every transformer will cleanup calls and their respective target methods (`target_defs`), and keep a cache of which have been transformed (many calls might end up hitting the same method, of course.) However, because we create a new `CleanupTransformer` on every `finished` hook, these methods are "cleaned up" over and over again (this could spawn a big chunk of the program, because it goes into those methods, calls in those methods, and target methods of those calls, etc.)

I noticed this because the interpreter uses `cleanup` a lot more, and it was taking like 1 minute to create bytecode for the compiler's program, while it took about 20 seconds to generate LLVM code, which was very unreasonable.

I know Lucky and other programs use `macro finished` a lot so this might improve compilation times a bit, but I don't expect a huge difference (in this sample program I have 3000 macro finished hooks, maybe a regular program have a dozen of them, I don't know)
