### PR TITLE
Avoid needless union in `LLVM::ABI::AArch64#homogeneous_aggregate?`

### DIFF
--- a/src/llvm/abi/aarch64.cr
+++ b/src/llvm/abi/aarch64.cr
@@ -18,16 +18,16 @@ class LLVM::ABI::AArch64 < LLVM::ABI
   end
 
   def homogeneous_aggregate?(type)
-    homog_agg = case type
-                when Type::Kind::Float
-                  return {type, 1}
-                when Type::Kind::Double
-                  return {type, 1}
-                when Type::Kind::Array
-                  check_array(type)
-                when Type::Kind::Struct
-                  check_struct(type)
-                end
+    homog_agg : {Type, UInt64}? = case type
+    when Type::Kind::Float
+      return {type, 1_u64}
+    when Type::Kind::Double
+      return {type, 1_u64}
+    when Type::Kind::Array
+      check_array(type)
+    when Type::Kind::Struct
+      check_struct(type)
+    end
 
     # Ensure we have at most four uniquely addressable members
     if homog_agg
@@ -54,7 +54,7 @@ class LLVM::ABI::AArch64 < LLVM::ABI
     return if elements.empty?
 
     base_type = nil
-    members = 0
+    members = 0_u64
 
     elements.each do |element|
       opt_homog_agg = homogeneous_aggregate?(element)


### PR DESCRIPTION
The type of `homog_agg` ended up being like `Tuple(Type, Int32 | UInt64)?` but using `UInt64` all the time works.

There's really no need to do this change, but... with this, the interpreter can process a lot more files. It's a bit of cheating, because the interpreter should support this, but right now I'm a bit lazy to implement that. I will! Eventually...

But with this change, for instance, the interpreter can already interpreter the compiler's formatter, and even doing something like `crystal i src/compiler/crystal.cr tool format foo.cr` works 😮 

That said, it still takes a lot of time... doing the semantic analysis takes the same time, of course, but then producing bytecode, when there's a lot of code, takes a significant amount of time. It's less that what it takes to generate LLVM, but it's also not incredibly fast. Maybe there's still room for optimization!

(just to curb your enthusiasm, the interpreter might not be a fast alternative to compiled mode, but at least it will bring a repl and a debugger 🤷 )