### PR TITLE
Fix compiler flags with optional arg eating following flags

### DIFF
--- a/spec/std/option_parser_spec.cr
+++ b/spec/std/option_parser_spec.cr
@@ -85,6 +85,109 @@ describe "OptionParser" do
     expect_capture_option ["-f", "-g -h"], "-f FLAG", "-g -h"
   end
 
+  describe "Consumption of flags following an ungiven optional argument" do
+    context "Given a short option with an optional value" do
+      it "doesn't eat a following short option" do
+        flag = nil
+        not_eaten = [] of String
+        args = ["-f", "-g", "-i"]
+        OptionParser.parse(args) do |opts|
+          opts.on("-f [FLAG]", "some flag") do |flag_value|
+            flag = flag_value
+          end
+          opts.on("-g", "shouldn't be eaten") do
+            not_eaten << "-g"
+          end
+          opts.on("-i", "shouldn't be eaten") do
+            not_eaten << "-i"
+          end
+        end
+        flag.should eq("")
+        not_eaten.should eq(["-g", "-i"])
+        args.size.should eq(0)
+      end
+
+      it "doesn't eat a following long option" do
+        flag = nil
+        not_eaten = [] of String
+        args = ["-f", "--g-long", "-i"]
+        OptionParser.parse(args) do |opts|
+          opts.on("-f [FLAG]", "some flag") do |flag_value|
+            flag = flag_value
+          end
+          opts.on("-g", "--g-long", "shouldn't be eaten") do
+            not_eaten << "--g-long"
+          end
+          opts.on("-i", "shouldn't be eaten") do
+            not_eaten << "-i"
+          end
+        end
+        flag.should eq("")
+        not_eaten.should eq(["--g-long", "-i"])
+        args.size.should eq(0)
+      end
+
+      it "does eat a value that looks like an option" do
+        flag = nil
+        not_eaten = [] of String
+        args = ["-f", "--not-an-option--", "-i"]
+        OptionParser.parse(args) do |opts|
+          opts.on("-f [FLAG]", "some flag") do |flag_value|
+            flag = flag_value
+          end
+          opts.on("-i", "shouldn't be eaten") do
+            not_eaten << "-i"
+          end
+        end
+        flag.should eq("--not-an-option--")
+        not_eaten.should eq(["-i"])
+        args.size.should eq(0)
+      end
+    end
+
+    context "Given a long option with an optional value" do
+      it "doesn't eat further short options" do
+        flag = nil
+        not_eaten = [] of String
+        args = ["--long-flag", "-g", "-i"]
+        OptionParser.parse(args) do |opts|
+          opts.on("--long-flag [FLAG]", "some flag") do |flag_value|
+            flag = flag_value
+          end
+          opts.on("-g", "shouldn't be eaten") do
+            not_eaten << "-g"
+          end
+          opts.on("-i", "shouldn't be eaten") do
+            not_eaten << "-i"
+          end
+        end
+        flag.should eq("")
+        not_eaten.should eq(["-g", "-i"])
+        args.size.should eq(0)
+      end
+
+      it "doesn't eat further long options" do
+        flag = nil
+        not_eaten = [] of String
+        args = ["--long-flag", "--g-long", "-i"]
+        OptionParser.parse(args) do |opts|
+          opts.on("--long-flag [FLAG]", "some flag") do |flag_value|
+            flag = flag_value
+          end
+          opts.on("--g-long", "shouldn't be eaten") do
+            not_eaten << "--g-long"
+          end
+          opts.on("-i", "shouldn't be eaten") do
+            not_eaten << "-i"
+          end
+        end
+        flag.should eq("")
+        not_eaten.should eq(["--g-long", "-i"])
+        args.size.should eq(0)
+      end
+    end
+  end
+
   it "raises if missing required option with space" do
     expect_missing_option ["-f"], "-f FLAG", "-f"
   end

--- a/src/option_parser.cr
+++ b/src/option_parser.cr
@@ -368,18 +368,28 @@ class OptionParser
         if (handler = @handlers[flag]?) && !(handler.value_type.none? && value)
           handled_args << arg_index
 
-          # Pull in the next argument if we don't already have it and an argument
-          # is taken (i.e. not FlagValue::None)
-          if !value && !handler.value_type.none?
-            value = args[arg_index + 1]?
-            if value
-              handled_args << arg_index + 1
-              arg_index += 1
+          if !value
+            case handler.value_type
+            in FlagValue::Required
+              value = args[arg_index + 1]?
+              if value
+                handled_args << arg_index + 1
+                arg_index += 1
+              else
+                @missing_option.call(flag)
+              end
+            in FlagValue::Optional
+              value = args[arg_index + 1]?
+              if value && !@handlers.has_key?(value)
+                handled_args << arg_index + 1
+                arg_index += 1
+              else
+                value = nil
+              end
+            in FlagValue::None
+              # do nothing
             end
           end
-
-          # If we require a value and we don't have one, call missing option
-          @missing_option.call(flag) if handler.value_type.required? && value.nil?
 
           # If this is a subcommand (flag not starting with -), delete all
           # subcommands since they are no longer valid.


### PR DESCRIPTION
Hi all,

I don't know if this should be part of #5338, #8656 or #11136, and I see a PR in #9909, so it's possible there's some overlap. What I do know is that I had an itch to scratch because my CLI app has defined within it several flags with optional arguments that would then eat following arguments if not provided a value.

All existing specs pass on my machine.

Let me know if there's anything untoward.

Regards,
iain