### PR TITLE
Compiler: don't trigger "already had enclosing call" for same object

### DIFF
--- a/spec/compiler/semantic/block_spec.cr
+++ b/spec/compiler/semantic/block_spec.cr
@@ -1556,4 +1556,33 @@ describe "Block inference" do
       recursive
       ))
   end
+
+  it "doesn't fail with 'already had enclosing call' (#11200)" do
+    semantic(%(
+      def capture(&block)
+        block
+      end
+
+      abstract class Foo
+      end
+
+      class Bar(Input) < Foo
+        def method
+        end
+
+        def foo
+          capture do
+            self.method
+            Baz(Input)
+          end
+        end
+      end
+
+      class Baz(Input) < Bar(Input)
+      end
+
+      foo = Bar(Bool).new.as(Foo)
+      foo.foo
+      ))
+  end
 end

--- a/src/compiler/crystal/semantic/bindings.cr
+++ b/src/compiler/crystal/semantic/bindings.cr
@@ -178,17 +178,15 @@ module Crystal
     def set_enclosing_call(enclosing_call)
       current_enclosing_call = @enclosing_call
       if current_enclosing_call
-        if current_enclosing_call.same?(enclosing_call)
-          # This can happen when a block is typed, and meanwhile a new
-          # generic instance type is created that triggers the block to
-          # be typed again, potentially analyzing a call twice.
-          return
-        else
+        # This can happen when a block is typed, and meanwhile a new
+        # generic instance type is created that triggers the block to
+        # be typed again, potentially analyzing a call twice.
+        unless current_enclosing_call.same?(enclosing_call)
           raise "BUG: already had a different enclosing call"
         end
+      else
+        @enclosing_call = enclosing_call
       end
-
-      @enclosing_call = enclosing_call
     end
 
     def remove_enclosing_call(enclosing_call)

--- a/src/compiler/crystal/semantic/bindings.cr
+++ b/src/compiler/crystal/semantic/bindings.cr
@@ -176,7 +176,18 @@ module Crystal
     end
 
     def set_enclosing_call(enclosing_call)
-      raise "BUG: already had enclosing call" if @enclosing_call
+      current_enclosing_call = @enclosing_call
+      if current_enclosing_call
+        if current_enclosing_call.same?(enclosing_call)
+          # This can happen when a block is typed, and meanwhile a new
+          # generic instance type is created that triggers the block to
+          # be typed again, potentially analyzing a call twice.
+          return
+        else
+          raise "BUG: already had a different enclosing call"
+        end
+      end
+
       @enclosing_call = enclosing_call
     end
 


### PR DESCRIPTION
Fixes #11200

Every AST node can have an `enclosing_call` property: that's the call they belong to, if they are the call's receiver or one of the arguments. When that node's type changes, the call is recomputed. Obviously a node can only belong to at most a single call.

We have code in place to make sure that if a node's `enclosing_call` property is set twice, there's something wrong. However, that's perfectly fine if the `enclosing_call` we are setting is the same as the one they already had.

In reality, I think `set_enclosing_call` shouldn't be called more than once on every node. But this requires more time and thinking from my side, which I don't have right now.

I think this is a good-enough fix for now. It doesn't fix all related bugs of "already had enclosing call", but it unblocks people and we can move forward.

Makes #10059 compile, but it then fails at runtime because the value added to the hash was added during a macro expansion and it didn't get a chance to be typed (I think!)

Fixes #8416

Doesn't fix #7113

Makes #5299 gives a different error message now ("trying to downcast (A | B) <- A (Exception)")