### PR TITLE
Fix link on regex.cr

### DIFF
--- a/src/regex.cr
+++ b/src/regex.cr
@@ -12,7 +12,7 @@ require "./regex/*"
 # /y/.match("haystack") # => Regex::MatchData("y")
 # ```
 #
-# See [`Range` literals](https://crystal-lang.org/reference/syntax_and_semantics/literals/range.html) in the language reference.
+# See [`Regex` literals](https://crystal-lang.org/reference/syntax_and_semantics/literals/regex.html) in the language reference.
 #
 # Interpolation works in regular expression literals just as it does in string
 # literals. Be aware that using this feature will cause an exception to be


### PR DESCRIPTION
Fixed the link to the `Range` section of the language reference in the documentation comment to a link to `Regex`.