### PR TITLE
Remove restriction of bsearch block output type

### DIFF
--- a/spec/std/array_spec.cr
+++ b/spec/std/array_spec.cr
@@ -456,6 +456,7 @@ describe "Array" do
   it "find the element by using binary search" do
     [2, 5, 7, 10].bsearch { |x| x >= 4 }.should eq 5
     [2, 5, 7, 10].bsearch { |x| x > 10 }.should be_nil
+    [2, 5, 7, 10].bsearch { |x| x >= 4 ? 1 : nil }.should eq 5
   end
 
   it "find the index by using binary search" do

--- a/spec/std/range_spec.cr
+++ b/spec/std/range_spec.cr
@@ -145,6 +145,8 @@ describe "Range" do
       (0...ary.size).bsearch { |i| true }.should eq 0
       (0...ary.size).bsearch { |i| false }.should eq nil
 
+      (0...ary.size).bsearch { |i| ary[i] >= 10 ? 1 : nil }.should eq 4
+
       ary = [0, 100, 100, 100, 200]
       (0...ary.size).bsearch { |i| ary[i] >= 100 }.should eq 1
 

--- a/src/indexable.cr
+++ b/src/indexable.cr
@@ -133,40 +133,42 @@ module Indexable(T)
   end
 
   # By using binary search, returns the first element
-  # for which the passed block returns `true`.
+  # for which the passed block returns a truthy value.
   #
-  # If the block returns `false`, the finding element exists
-  # behind. If the block returns `true`, the finding element
-  # is itself or exists in front.
+  # If the block returns a falsey value, the element to be found lies
+  # behind. If the block returns a truthy value, the element to be found
+  # is itself or lies in front.
   #
-  # Binary search needs sorted array, so `self` has to be sorted.
+  # Binary search needs the collection to be sorted in regards to the search
+  # criterion.
   #
-  # Returns `nil` if the block didn't return `true` for any element.
+  # Returns `nil` if the block didn't return a truthy value for any element.
   #
   # ```
   # [2, 5, 7, 10].bsearch { |x| x >= 4 } # => 5
   # [2, 5, 7, 10].bsearch { |x| x > 10 } # => nil
   # ```
-  def bsearch(&block : T -> Bool)
+  def bsearch(&block : T -> _)
     bsearch_index { |value| yield value }.try { |index| unsafe_fetch(index) }
   end
 
   # By using binary search, returns the index of the first element
-  # for which the passed block returns `true`.
+  # for which the passed block returns a truthy value.
   #
-  # If the block returns `false`, the finding element exists
-  # behind. If the block returns `true`, the finding element
-  # is itself or exists in front.
+  # If the block returns a falsey value, the element to be found lies
+  # behind. If the block returns a truthy value, the element to be found
+  # is itself or lies in front.
   #
-  # Binary search needs sorted array, so `self` has to be sorted.
+  # Binary search needs the collection to be sorted in regards to the search
+  # criterion.
   #
-  # Returns `nil` if the block didn't return `true` for any element.
+  # Returns `nil` if the block didn't return a truthy value for any element.
   #
   # ```
   # [2, 5, 7, 10].bsearch_index { |x, i| x >= 4 } # => 1
   # [2, 5, 7, 10].bsearch_index { |x, i| x > 10 } # => nil
   # ```
-  def bsearch_index(&block : T, Int32 -> Bool)
+  def bsearch_index(&block : T, Int32 -> _)
     (0...size).bsearch { |index| yield unsafe_fetch(index), index }
   end
 

--- a/src/range/bsearch.cr
+++ b/src/range/bsearch.cr
@@ -68,20 +68,20 @@
 {% end %}
 
 struct Range(B, E)
-  # By using binary search, returns the first value
-  # for which the passed block returns `true`.
+  # By using binary search, returns the first element
+  # for which the passed block returns a truthy value.
   #
-  # If the block returns `false`, the finding value exists
-  # behind. If the block returns `true`, the finding value
-  # is itself or exists in front.
+  # If the block returns a falsey value, the element to be found lies
+  # behind. If the block returns a truthy value, the element to be found
+  # is itself or lies in front.
+  #
+  # Returns `nil` if the block didn't return a truthy value for any element.
   #
   # ```
   # (0..10).bsearch { |x| x >= 5 }                       # => 5
   # (0..Float64::INFINITY).bsearch { |x| x ** 4 >= 256 } # => 4
   # ```
-  #
-  # Returns `nil` if the block didn't return `true` for any value.
-  def bsearch(&block : B | E -> Bool)
+  def bsearch(&block : B | E -> _)
     from = self.begin
     to = self.end
 


### PR DESCRIPTION
Allows block of `#bsearch` to output truthy and falsey values like other similar methods do. It does no longer require to be `Bool`.

Resolves #11210