### PR TITLE
Update distribution-scripts (universal darwin & demote alpine to 3.12) 

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -82,7 +82,7 @@ jobs:
 
   test_darwin:
     macos:
-      xcode: "11.1.0"
+      xcode: 12.4.0
     environment:
       <<: *env
       TRAVIS_OS_NAME: osx
@@ -144,7 +144,7 @@ jobs:
       - run: |
           git clone https://github.com/crystal-lang/distribution-scripts.git ~/distribution-scripts
           cd ~/distribution-scripts
-          git checkout 8bc01e26291dc518390129e15df8f757d687871c
+          git checkout 613311673a83dbce963cad6f8af219b71fe3a0d2
       # persist relevant information for build process
       - run: |
           cd ~/distribution-scripts
@@ -294,7 +294,7 @@ jobs:
 
   dist_darwin:
     macos:
-      xcode: "11.1.0"
+      xcode: 12.4.0
     shell: /bin/bash --login -eo pipefail
     steps:
       - restore_cache:
@@ -305,7 +305,7 @@ jobs:
           command: |
             brew unlink python@2 || true
 
-            ruby-install ruby 2.5.6
+            ruby-install ruby 2.7.3
 
             brew install pkgconfig libtool
 
@@ -318,7 +318,7 @@ jobs:
       - run:
           no_output_timeout: 40m
           command: |
-            echo "2.5.6" > /tmp/workspace/distribution-scripts/.ruby-version
+            echo "2.7.3" > /tmp/workspace/distribution-scripts/.ruby-version
             cd /tmp/workspace/distribution-scripts
             source build.env
             cd omnibus


### PR DESCRIPTION
Includes the following relevant PRs of distribution-scripts in this update

- https://github.com/crystal-lang/distribution-scripts/pull/104
- https://github.com/crystal-lang/distribution-scripts/pull/127
- https://github.com/crystal-lang/distribution-scripts/pull/128
- https://github.com/crystal-lang/distribution-scripts/pull/111

Something to have in mind is that after this is merged  -darwin-x86_64.tar.gz  will no longer be generated. The new name will be -darwin-universal.tar.gz 

Follow up work is mentioned in https://github.com/crystal-lang/distribution-scripts/pull/104#issuecomment-920887960 regarding github action install-crystal, yet this is also a change that might impact others wanting to download the darwin tar.gz or .pkg from github directly