### PR TITLE
`crystal docs`: use `shard.yml` version when no git tag present

### DIFF
--- a/spec/compiler/crystal/tools/doc/project_info_spec.cr
+++ b/spec/compiler/crystal/tools/doc/project_info_spec.cr
@@ -52,7 +52,7 @@ describe Crystal::Doc::ProjectInfo do
       it "git but no commit" do
         run_git "init"
 
-        assert_with_defaults(ProjectInfo.new(nil, nil), ProjectInfo.new("foo", nil, refname: nil))
+        assert_with_defaults(ProjectInfo.new(nil, nil), ProjectInfo.new("foo", "1.0", refname: nil))
         assert_with_defaults(ProjectInfo.new("bar", "2.0"), ProjectInfo.new("bar", "2.0", refname: nil))
         assert_with_defaults(ProjectInfo.new(nil, "2.0"), ProjectInfo.new("foo", "2.0", refname: nil))
       end
@@ -118,7 +118,7 @@ describe Crystal::Doc::ProjectInfo do
         run_git "remote add origin git@github.com:foo/bar"
 
         url_pattern = "https://github.com/foo/bar/blob/%{refname}/%{path}#L%{line}"
-        assert_with_defaults(ProjectInfo.new(nil, nil), ProjectInfo.new("foo", nil, refname: nil, source_url_pattern: url_pattern))
+        assert_with_defaults(ProjectInfo.new(nil, nil), ProjectInfo.new("foo", "1.0", refname: nil, source_url_pattern: url_pattern))
         assert_with_defaults(ProjectInfo.new("bar", "2.0"), ProjectInfo.new("bar", "2.0", refname: nil, source_url_pattern: url_pattern))
         assert_with_defaults(ProjectInfo.new(nil, "2.0"), ProjectInfo.new("foo", "2.0", refname: nil, source_url_pattern: url_pattern))
         assert_with_defaults(ProjectInfo.new(nil, "2.0", source_url_pattern: "foo_bar"), ProjectInfo.new("foo", "2.0", refname: nil, source_url_pattern: "foo_bar"))

--- a/src/compiler/crystal/tools/doc/project_info.cr
+++ b/src/compiler/crystal/tools/doc/project_info.cr
@@ -38,7 +38,7 @@ module Crystal::Doc
         if shard_name && !name?
           self.name = shard_name
         end
-        if shard_version && !version? && !ProjectInfo.git_dir?
+        if shard_version && !version?
           self.version = shard_version
         end
       end
@@ -52,10 +52,6 @@ module Crystal::Doc
 
       url = url_pattern % {refname: refname, path: location.filename, filename: File.basename(location.filename), line: location.line_number}
       url.presence
-    end
-
-    def self.git_dir?
-      Crystal::Git.git_command(["rev-parse", "--is-inside-work-tree"])
     end
 
     VERSION_TAG = /^v(\d+[-.][-.a-zA-Z\d]+)$/


### PR DESCRIPTION
When generating project documentation with `crystal docs`, the project version may be inferred from either the latest git tag or the `version` key in `shard.yml`. However, the version in `shard.yml` will only be used if the project is **not** a git repository. This requirement is counter-intuitive, and means that a project created with

```plain
$ crystal init app my_app
```

won't generate documentation out of the box without explicitly specifying `--project-version`:

```plain
$ crystal docs
Couldn't determine version from git or shard.yml, please provide --project-version option
```

This PR allows the version in `shard.yml` to be used regardless of whether or not a project is contained in a git repository; the latest git tag will still be used (if present), so I think this preserves the intention of the original implementation, while also improving the out-of-the-box DX for new projects.
