### PR TITLE
feat(docs): display constant/method list in sidebar

### DIFF
--- a/src/compiler/crystal/tools/doc/html/_list_items.html
+++ b/src/compiler/crystal/tools/doc/html/_list_items.html
@@ -1,9 +1,81 @@
 <ul>
   <% types.each do |type| %>
-  <li class="<%= (type.program? || type.types.empty?) ? "" : ("parent" + (type.current?(current_type) || type.parents_of?(current_type) ? " open" : "")) %> <%= type.current?(current_type) ? "current" : "" %>" data-id="<%= type.html_id %>" data-name="<%= type.full_name.downcase %>">
-      <a href="<%= type.path_from(current_type) %>"><%= type.name %></a>
-      <% unless type.program? || type.types.empty? %>
-        <%= ListItemsTemplate.new(type.types, current_type) %>
+    <% child_types = type.types %>
+    <% constants = type.constants %>
+    <% constructors = type.constructors %>
+    <% class_methods = type.class_methods %>
+    <% instance_methods = type.instance_methods %>
+    <% path = type.path_from(current_type) %>
+    <% empty = child_types.empty? && constants.empty? && constructors.empty? && class_methods.empty? && instance_methods.empty? %>
+
+    <li class="<%= empty ? "" : ("parent" + (type.current?(current_type) || type.parents_of?(current_type) ? " open" : "")) %> <%= type.current?(current_type) ? "current" : "" %>" data-id="<%= type.html_id %>" data-name="<%= type.full_name.downcase %>">
+      <a href="<%= path %>"><%= type.name %></a>
+      <% unless type.program? || child_types.empty? %>
+        <%= ListItemsTemplate.new(child_types, current_type) %>
+      <% end %>
+
+      <% unless empty %>
+        <ul style="margin: 0.25rem 0">
+          <% unless constants.empty? %>
+            <li class="parent hide-toggle" data-id="<%= type.html_id %>__constants">
+              <h3>Constants</h3>
+              <ul class="blockquote">
+                <% constants.each do |constant| %>
+                  <li>
+                    <a href="<%= path %>#constant-summary">
+                      <%= constant.name %>
+                    </a>
+                  </li>
+                <% end %>
+              </ul>
+            </li>
+          <% end %>
+
+          <% unless constructors.empty? %>
+            <li class="parent hide-toggle" data-id="<%= type.html_id %>__constructors">
+              <h3>Constructors</h3>
+              <ul class="blockquote">
+                <% constructors.each do |constructor| %>
+                  <li>
+                    <a href="<%= path %>#<%= constructor.html_id %>">
+                      <%= constructor.name %><%= constructor.args_to_html abbr: true %>
+                    </a>
+                  </li>
+                <% end %>
+              </ul>
+            </li>
+          <% end %>
+
+          <% unless class_methods.empty? %>
+            <li class="parent hide-toggle" data-id="<%= type.html_id %>__class_methods">
+              <h3>Class Methods</h3>
+              <ul class="blockquote">
+                <% class_methods.each do |method| %>
+                  <li>
+                    <a href="<%= path %>#<%= method.html_id %>">
+                      <%= method.name %><%= method.args_to_html abbr: true %>
+                    </a>
+                  </li>
+                <% end %>
+              </ul>
+            </li>
+          <% end %>
+
+          <% unless instance_methods.empty? %>
+            <li class="parent hide-toggle" data-id="<%= type.html_id %>__instance_methods">
+              <h3>Instance Methods</h3>
+              <ul class="blockquote">
+                <% instance_methods.each do |method| %>
+                  <li>
+                    <a href="<%= path %>#<%= method.html_id %>">
+                      <%= method.name %><%= method.args_to_html abbr: true %>
+                    </a>
+                  </li>
+                <% end %>
+              </ul>
+            </li>
+          <% end %>
+        </ul>
       <% end %>
     </li>
   <% end %>

--- a/src/compiler/crystal/tools/doc/html/css/style.css
+++ b/src/compiler/crystal/tools/doc/html/css/style.css
@@ -107,6 +107,16 @@ body {
   text-indent: 2px;
 }
 
+.sidebar h3 {
+  margin: 0;
+  padding: 0.25rem 0;
+  color: #866BA6;
+  font-size: 0.8rem;
+  font-weight: 400;
+  user-select: none;
+  cursor: pointer;
+}
+
 .project-summary {
   padding: 9px 15px 30px 30px;
 }
@@ -205,11 +215,11 @@ body {
   transition: 1s ease-in-out;
 }
 
-.types-list li.parent {
+.types-list li.parent:not(.hide-toggle) {
   padding-left: 30px;
 }
 
-.types-list li.parent::before {
+.types-list li.parent:not(.hide-toggle)::before {
   box-sizing: border-box;
   content: "▼";
   display: block;
@@ -230,6 +240,7 @@ body {
 
 .types-list li.parent > a {
   padding-left: 0;
+  user-select: none;
 }
 
 .types-list li.parent.open::before {
@@ -239,6 +250,30 @@ body {
 .types-list li.open > ul {
   height: auto;
   max-height: 1000em;
+}
+
+.types-list ul.blockquote {
+  font-size: 0.75rem;
+  margin-bottom: 0.25rem;
+}
+
+.types-list ul.blockquote > li {
+  position: relative;
+}
+
+.types-list ul.blockquote > li::before {
+  content: '';
+  display: block;
+  position: absolute;
+  width: 2px;
+  height: 100%;
+  left: 3px;
+  top: 0;
+  background: rgba(255, 255, 255, 0.15);
+}
+
+.types-list ul.blockquote > li > a {
+  padding: 2px 15px;
 }
 
 .main-content {

--- a/src/compiler/crystal/tools/doc/html/js/doc.js
+++ b/src/compiler/crystal/tools/doc/html/js/doc.js
@@ -44,15 +44,23 @@ document.addEventListener('DOMContentLoaded', function() {
     _parent.addEventListener('click', function(e) {
       e.stopPropagation();
 
-      if(e.target.tagName.toLowerCase() == 'li') {
-        if(e.target.className.match(/open/)) {
-          sessionStorage.removeItem(e.target.getAttribute('data-id'));
-          e.target.className = e.target.className.replace(/ +open/g, '');
-        } else {
-          sessionStorage.setItem(e.target.getAttribute('data-id'), '1');
-          if(e.target.className.indexOf('open') == -1) {
-            e.target.className += ' open';
-          }
+      var li;
+      var tagName = e.target.tagName.toLowerCase();
+      if (tagName === 'li' /* toggle arrow */) {
+        li = e.target;
+      } else if (tagName === 'h3' /* subsection header */) {
+        li = e.target.parentNode;
+      } else {
+        return;
+      }
+
+      if(li.className.match(/open/)) {
+        sessionStorage.removeItem(li.getAttribute('data-id'));
+        li.className = li.className.replace(/ +open/g, '');
+      } else {
+        sessionStorage.setItem(li.getAttribute('data-id'), '1');
+        if(li.className.indexOf('open') == -1) {
+          li.className += ' open';
         }
       }
     });

--- a/src/compiler/crystal/tools/doc/method.cr
+++ b/src/compiler/crystal/tools/doc/method.cr
@@ -206,19 +206,19 @@ class Crystal::Doc::Method
     args_to_s io
   end
 
-  def args_to_s
-    String.build { |io| args_to_s io }
+  def args_to_s(abbr = false)
+    String.build { |io| args_to_s io, abbr }
   end
 
-  def args_to_s(io : IO) : Nil
-    args_to_html(io, html: :none)
+  def args_to_s(io : IO, abbr = false) : Nil
+    args_to_html(io, html: :none, abbr: abbr)
   end
 
-  def args_to_html(html : HTMLOption = :all)
-    String.build { |io| args_to_html io, html }
+  def args_to_html(html : HTMLOption = :all, abbr = false)
+    String.build { |io| args_to_html io, html, abbr }
   end
 
-  def args_to_html(io : IO, html : HTMLOption = :all) : Nil
+  def args_to_html(io : IO, html : HTMLOption = :all, abbr = false) : Nil
     return_type = self.return_type
 
     return unless has_args? || return_type
@@ -229,7 +229,7 @@ class Crystal::Doc::Method
       @def.args.each_with_index do |arg, i|
         io << ", " if printed
         io << '*' if @def.splat_index == i
-        arg_to_html arg, io, html: html
+        arg_to_html arg, io, html: html, abbr: abbr
         printed = true
       end
       if double_splat = @def.double_splat
@@ -241,13 +241,15 @@ class Crystal::Doc::Method
       if block_arg = @def.block_arg
         io << ", " if printed
         io << '&'
-        arg_to_html block_arg, io, html: html
+        arg_to_html block_arg, io, html: html, abbr: abbr
       elsif @def.yields
         io << ", " if printed
         io << '&'
       end
       io << ')'
     end
+
+    return if abbr
 
     case return_type
     when Nil
@@ -268,7 +270,7 @@ class Crystal::Doc::Method
     io
   end
 
-  def arg_to_html(arg : Arg, io, html : HTMLOption = :all)
+  def arg_to_html(arg : Arg, io, html : HTMLOption = :all, abbr = false)
     if arg.external_name != arg.name
       if name = arg.external_name.presence
         if Symbol.needs_quotes_for_named_argument? name
@@ -287,6 +289,8 @@ class Crystal::Doc::Method
     end
 
     io << arg.name
+
+    return if abbr
 
     if restriction = arg.restriction
       io << " : "


### PR DESCRIPTION
This PR adds collapsible lists to the documentation sidebar that display an overview of available:

- constants
- constructors
- class methods
- instance methods

![image](https://user-images.githubusercontent.com/18172185/133953120-0176e0e9-55df-4d7e-ac47-934975218f9c.png)

This should make navigating around documenation for large projects (including the Crystal stdlib) a bit easier; clicking on a constant will link to the Constants Overview section of the parent type, and clicking on any other method will link directly to that method's documentation. This PR purposefully only lists direct methods, and omits type restrictions and return types in order to keep the list as succinct as possible, but I'm open to feedback around what content should be displayed in the sidebar and how it should be laid out.