### PR TITLE
Add String#to_(u/i)128(?) methods (Int128 literal support part 3)

### DIFF
--- a/spec/std/string_spec.cr
+++ b/spec/std/string_spec.cr
@@ -396,6 +396,30 @@ describe "String" do
       it { "18446744073709551616".to_u64 { 0 }.should eq(0) }
     end
 
+    describe "to_i128" do
+      pending_win32 { "170141183460469231731687303715884105727".to_i128.should eq(Int128::MAX) }
+      pending_win32 { "-170141183460469231731687303715884105728".to_i128.should eq(Int128::MIN) }
+      pending_win32 { expect_raises(ArgumentError) { "170141183460469231731687303715884105728".to_i128 } }
+      pending_win32 { expect_raises(ArgumentError) { "-170141183460469231731687303715884105729".to_i128 } }
+
+      pending_win32 { "170141183460469231731687303715884105727".to_i128?.should eq(Int128::MAX) }
+      pending_win32 { "170141183460469231731687303715884105728".to_i128?.should be_nil }
+      pending_win32 { "170141183460469231731687303715884105728".to_i128 { 0 }.should eq(0) }
+
+      pending_win32 { expect_raises(ArgumentError) { "340282366920938463463374607431768211456".to_i128 } }
+    end
+
+    describe "to_u128" do
+      pending_win32 { "340282366920938463463374607431768211455".to_u128.should eq(UInt128::MAX) }
+      pending_win32 { "0".to_u128.should eq(0) }
+      pending_win32 { expect_raises(ArgumentError) { "340282366920938463463374607431768211456".to_u128 } }
+      pending_win32 { expect_raises(ArgumentError) { "-1".to_u128 } }
+
+      pending_win32 { "340282366920938463463374607431768211455".to_u128?.should eq(UInt128::MAX) }
+      pending_win32 { "340282366920938463463374607431768211456".to_u128?.should be_nil }
+      pending_win32 { "340282366920938463463374607431768211456".to_u128 { 0 }.should eq(0) }
+    end
+
     it { "1234".to_i32.should eq(1234) }
     it { "1234123412341234".to_i64.should eq(1234123412341234_i64) }
     it { "9223372036854775808".to_u64.should eq(9223372036854775808_u64) }

--- a/src/string.cr
+++ b/src/string.cr
@@ -477,6 +477,36 @@ class String
     gen_to_ UInt64, UInt64
   end
 
+  # Same as `#to_i` but returns an `Int128`.
+  def to_i128(base : Int = 10, whitespace : Bool = true, underscore : Bool = false, prefix : Bool = false, strict : Bool = true, leading_zero_is_octal : Bool = false) : Int128
+    to_i128(base, whitespace, underscore, prefix, strict, leading_zero_is_octal) { raise ArgumentError.new("Invalid Int128: #{self}") }
+  end
+
+  # Same as `#to_i` but returns an `Int128` or `nil`.
+  def to_i128?(base : Int = 10, whitespace : Bool = true, underscore : Bool = false, prefix : Bool = false, strict : Bool = true, leading_zero_is_octal : Bool = false) : Int128?
+    to_i128(base, whitespace, underscore, prefix, strict, leading_zero_is_octal) { nil }
+  end
+
+  # Same as `#to_i` but returns an `Int128` or the block's value.
+  def to_i128(base : Int = 10, whitespace : Bool = true, underscore : Bool = false, prefix : Bool = false, strict : Bool = true, leading_zero_is_octal : Bool = false, &block)
+    gen_to_ Int128, UInt128, Int128::MAX, (UInt128.new(Int128::MAX) + 1)
+  end
+
+  # Same as `#to_i` but returns an `UInt128`.
+  def to_u128(base : Int = 10, whitespace : Bool = true, underscore : Bool = false, prefix : Bool = false, strict : Bool = true, leading_zero_is_octal : Bool = false) : UInt128
+    to_u128(base, whitespace, underscore, prefix, strict, leading_zero_is_octal) { raise ArgumentError.new("Invalid UInt128: #{self}") }
+  end
+
+  # Same as `#to_i` but returns an `UInt128` or `nil`.
+  def to_u128?(base : Int = 10, whitespace : Bool = true, underscore : Bool = false, prefix : Bool = false, strict : Bool = true, leading_zero_is_octal : Bool = false) : UInt128?
+    to_u128(base, whitespace, underscore, prefix, strict, leading_zero_is_octal) { nil }
+  end
+
+  # Same as `#to_i` but returns an `UInt128` or the block's value.
+  def to_u128(base : Int = 10, whitespace : Bool = true, underscore : Bool = false, prefix : Bool = false, strict : Bool = true, leading_zero_is_octal : Bool = false, &block)
+    gen_to_ UInt128, UInt128
+  end
+
   # :nodoc:
   CHAR_TO_DIGIT = begin
     table = StaticArray(Int8, 256).new(-1_i8)


### PR DESCRIPTION
With #11206 now merged, we can now easily add the `String#to_(u/i)128(?)` methods to crystal!
It's a very small change that doesn't change any existing methods, should be easy to review.