### PR TITLE
Add `URI.encode_path` and deprecate `URI.encode`

### DIFF
--- a/spec/compiler/crystal/tools/doc/doc_renderer_spec.cr
+++ b/spec/compiler/crystal/tools/doc/doc_renderer_spec.cr
@@ -288,7 +288,7 @@ describe Doc::MarkdDocRenderer do
     it "finds multiple kinds of things" do
       {base, base_foo}.each do |obj|
         assert_code_link(obj, "Base#foo2(a, a) and #foo3 and Base",
-          %(<a href="Base.html#foo2%28a%2Cb%29-instance-method">Base#foo2(a, a)</a> and <a href="Base.html#foo33%28a%2Cb%2Cc%29-instance-method">#foo3</a> and <a href="Base.html">Base</a>))
+          %(<a href="Base.html#foo2%28a%2Cb%29-instance-method">Base#foo2(a, a)</a> and <a href="Base.html#foo3%28a%2Cb%2Cc%29-instance-method">#foo3</a> and <a href="Base.html">Base</a>))
       end
     end
 

--- a/spec/compiler/crystal/tools/doc/doc_renderer_spec.cr
+++ b/spec/compiler/crystal/tools/doc/doc_renderer_spec.cr
@@ -129,9 +129,9 @@ describe Doc::MarkdDocRenderer do
 
     it "finds method with args" do
       {base, base_foo}.each do |obj|
-        assert_code_link(obj, "foo2(a, b)", %(<a href="Base.html#foo2(a,b)-instance-method">#foo2(a, b)</a>))
-        assert_code_link(obj, "#foo2(a, a)", %(<a href="Base.html#foo2(a,b)-instance-method">#foo2(a, a)</a>))
-        assert_code_link(obj, "Base#foo2(a, a)", %(<a href="Base.html#foo2(a,b)-instance-method">Base#foo2(a, a)</a>))
+        assert_code_link(obj, "foo2(a, b)", %(<a href="Base.html#foo2%28a%2Cb%29-instance-method">#foo2(a, b)</a>))
+        assert_code_link(obj, "#foo2(a, a)", %(<a href="Base.html#foo2%28a%2Cb%29-instance-method">#foo2(a, a)</a>))
+        assert_code_link(obj, "Base#foo2(a, a)", %(<a href="Base.html#foo2%28a%2Cb%29-instance-method">Base#foo2(a, a)</a>))
       end
     end
 
@@ -159,49 +159,49 @@ describe Doc::MarkdDocRenderer do
 
     it "finds method with unspecified args" do
       {base, base_foo}.each do |obj|
-        assert_code_link(obj, "foo2", %(<a href="Base.html#foo2(a,b)-instance-method">#foo2</a>))
-        assert_code_link(obj, "#foo2", %(<a href="Base.html#foo2(a,b)-instance-method">#foo2</a>))
-        assert_code_link(obj, "Base#foo2", %(<a href="Base.html#foo2(a,b)-instance-method">Base#foo2</a>))
+        assert_code_link(obj, "foo2", %(<a href="Base.html#foo2%28a%2Cb%29-instance-method">#foo2</a>))
+        assert_code_link(obj, "#foo2", %(<a href="Base.html#foo2%28a%2Cb%29-instance-method">#foo2</a>))
+        assert_code_link(obj, "Base#foo2", %(<a href="Base.html#foo2%28a%2Cb%29-instance-method">Base#foo2</a>))
       end
     end
 
     it "finds method with args even with empty brackets" do
       {base, base_foo}.each do |obj|
-        assert_code_link(obj, "foo2()", %(<a href="Base.html#foo2(a,b)-instance-method">#foo2()</a>))
-        assert_code_link(obj, "#foo2()", %(<a href="Base.html#foo2(a,b)-instance-method">#foo2()</a>))
-        assert_code_link(obj, "Base#foo2()", %(<a href="Base.html#foo2(a,b)-instance-method">Base#foo2()</a>))
+        assert_code_link(obj, "foo2()", %(<a href="Base.html#foo2%28a%2Cb%29-instance-method">#foo2()</a>))
+        assert_code_link(obj, "#foo2()", %(<a href="Base.html#foo2%28a%2Cb%29-instance-method">#foo2()</a>))
+        assert_code_link(obj, "Base#foo2()", %(<a href="Base.html#foo2%28a%2Cb%29-instance-method">Base#foo2()</a>))
       end
     end
 
     it "finds method with question mark" do
       {base, base_foo}.each do |obj|
-        assert_code_link(obj, "que?", %(<a href="Base.html#que?-instance-method">#que?</a>))
-        assert_code_link(obj, "#que?", %(<a href="Base.html#que?-instance-method">#que?</a>))
-        assert_code_link(obj, "Base#que?", %(<a href="Base.html#que?-instance-method">Base#que?</a>))
+        assert_code_link(obj, "que?", %(<a href="Base.html#que%3F-instance-method">#que?</a>))
+        assert_code_link(obj, "#que?", %(<a href="Base.html#que%3F-instance-method">#que?</a>))
+        assert_code_link(obj, "Base#que?", %(<a href="Base.html#que%3F-instance-method">Base#que?</a>))
       end
     end
 
     it "finds method with exclamation mark" do
       {base, base_foo}.each do |obj|
-        assert_code_link(obj, "one!(one)", %(<a href="Base.html#one!(one)-instance-method">#one!(one)</a>))
-        assert_code_link(obj, "#one!(one)", %(<a href="Base.html#one!(one)-instance-method">#one!(one)</a>))
-        assert_code_link(obj, "Base#one!(one)", %(<a href="Base.html#one!(one)-instance-method">Base#one!(one)</a>))
+        assert_code_link(obj, "one!(one)", %(<a href="Base.html#one%21%28one%29-instance-method">#one!(one)</a>))
+        assert_code_link(obj, "#one!(one)", %(<a href="Base.html#one%21%28one%29-instance-method">#one!(one)</a>))
+        assert_code_link(obj, "Base#one!(one)", %(<a href="Base.html#one%21%28one%29-instance-method">Base#one!(one)</a>))
       end
     end
 
     it "finds operator method" do
       {base, base_foo}.each do |obj|
-        assert_code_link(obj, "<=(other)", %(<a href="Base.html#%3C=(other)-instance-method">#<=(other)</a>))
-        assert_code_link(obj, "#<=(other)", %(<a href="Base.html#%3C=(other)-instance-method">#<=(other)</a>))
-        assert_code_link(obj, "Base#<=(other)", %(<a href="Base.html#%3C=(other)-instance-method">Base#<=(other)</a>))
+        assert_code_link(obj, "<=(other)", %(<a href="Base.html#%3C%3D%28other%29-instance-method">#<=(other)</a>))
+        assert_code_link(obj, "#<=(other)", %(<a href="Base.html#%3C%3D%28other%29-instance-method">#<=(other)</a>))
+        assert_code_link(obj, "Base#<=(other)", %(<a href="Base.html#%3C%3D%28other%29-instance-method">Base#<=(other)</a>))
       end
     end
 
     it "finds operator method with unspecified args" do
       {base, base_foo}.each do |obj|
-        assert_code_link(obj, "<=", %(<a href="Base.html#%3C=(other)-instance-method">#<=</a>))
-        assert_code_link(obj, "#<=", %(<a href="Base.html#%3C=(other)-instance-method">#<=</a>))
-        assert_code_link(obj, "Base#<=", %(<a href="Base.html#%3C=(other)-instance-method">Base#<=</a>))
+        assert_code_link(obj, "<=", %(<a href="Base.html#%3C%3D%28other%29-instance-method">#<=</a>))
+        assert_code_link(obj, "#<=", %(<a href="Base.html#%3C%3D%28other%29-instance-method">#<=</a>))
+        assert_code_link(obj, "Base#<=", %(<a href="Base.html#%3C%3D%28other%29-instance-method">Base#<=</a>))
       end
     end
 
@@ -236,7 +236,7 @@ describe Doc::MarkdDocRenderer do
     it "finds multiple methods with brackets" do
       {base, base_foo}.each do |obj|
         assert_code_link(obj, "#foo2(a, a) and Base#foo3(a,b,  c)",
-          %(<a href="Base.html#foo2(a,b)-instance-method">#foo2(a, a)</a> and <a href="Base.html#foo3(a,b,c)-instance-method">Base#foo3(a,b,  c)</a>))
+          %(<a href="Base.html#foo2%28a%2Cb%29-instance-method">#foo2(a, a)</a> and <a href="Base.html#foo3%28a%2Cb%2Cc%29-instance-method">Base#foo3(a,b,  c)</a>))
       end
     end
 
@@ -288,7 +288,7 @@ describe Doc::MarkdDocRenderer do
     it "finds multiple kinds of things" do
       {base, base_foo}.each do |obj|
         assert_code_link(obj, "Base#foo2(a, a) and #foo3 and Base",
-          %(<a href="Base.html#foo2(a,b)-instance-method">Base#foo2(a, a)</a> and <a href="Base.html#foo3(a,b,c)-instance-method">#foo3</a> and <a href="Base.html">Base</a>))
+          %(<a href="Base.html#foo2%28a%2Cb%29-instance-method">Base#foo2(a, a)</a> and <a href="Base.html#foo33%28a%2Cb%2Cc%29-instance-method">#foo3</a> and <a href="Base.html">Base</a>))
       end
     end
 

--- a/spec/std/uri_spec.cr
+++ b/spec/std/uri_spec.cr
@@ -426,6 +426,42 @@ describe "URI" do
     end
   end
 
+  it ".encode_path_segment" do
+    assert_prints URI.encode_path_segment("hello"), "hello"
+    assert_prints URI.encode_path_segment("hello world"), "hello%20world"
+    assert_prints URI.encode_path_segment("hello%"), "hello%25"
+    assert_prints URI.encode_path_segment("hello%2"), "hello%252"
+    assert_prints URI.encode_path_segment("hello+"), "hello%2B"
+    assert_prints URI.encode_path_segment("hello+world"), "hello%2Bworld"
+    assert_prints URI.encode_path_segment("hello%2+world"), "hello%252%2Bworld"
+    assert_prints URI.encode_path_segment("なな"), "%E3%81%AA%E3%81%AA"
+    assert_prints URI.encode_path_segment(" !\"#$%&'()*+,-./:;<=>?@[\\]^_`{|}~qй"), "%20%21%22%23%24%25%26%27%28%29%2A%2B%2C-.%2F%3A%3B%3C%3D%3E%3F%40%5B%5C%5D%5E_%60%7B%7C%7D~q%D0%B9"
+    assert_prints URI.encode_path_segment("'Stop!' said Fred"), "%27Stop%21%27%20said%20Fred"
+    assert_prints URI.encode_path_segment("\n"), "%0A"
+    assert_prints URI.encode_path_segment("https://en.wikipedia.org/wiki/Crystal (programming language)"), "https%3A%2F%2Fen.wikipedia.org%2Fwiki%2FCrystal%20%28programming%20language%29"
+    assert_prints URI.encode_path_segment("\xFF"), "%FF" # escapes invalid UTF-8 character
+    assert_prints URI.encode_path_segment("foo;bar;baz"), "foo%3Bbar%3Bbaz"
+    assert_prints URI.encode_path_segment("foo/bar/baz"), "foo%2Fbar%2Fbaz"
+    assert_prints URI.encode_path_segment("foo,bar,baz"), "foo%2Cbar%2Cbaz"
+  end
+
+  it ".encode_path" do
+    assert_prints URI.encode_path("hello"), "hello"
+    assert_prints URI.encode_path("hello world"), "hello%20world"
+    assert_prints URI.encode_path("hello%"), "hello%25"
+    assert_prints URI.encode_path("hello%2"), "hello%252"
+    assert_prints URI.encode_path("hello+"), "hello%2B"
+    assert_prints URI.encode_path("hello+world"), "hello%2Bworld"
+    assert_prints URI.encode_path("hello%2+world"), "hello%252%2Bworld"
+    assert_prints URI.encode_path("なな"), "%E3%81%AA%E3%81%AA"
+    assert_prints URI.encode_path(" !\"#$%&'()*+,-./:;<=>?@[\\]^_`{|}~qй"), "%20%21%22%23%24%25%26%27%28%29%2A%2B%2C-./%3A%3B%3C%3D%3E%3F%40%5B%5C%5D%5E_%60%7B%7C%7D~q%D0%B9"
+    assert_prints URI.encode_path("'Stop!' said Fred"), "%27Stop%21%27%20said%20Fred"
+    assert_prints URI.encode_path("\n"), "%0A"
+    assert_prints URI.encode_path("https://en.wikipedia.org/wiki/Crystal (programming language)"), "https%3A//en.wikipedia.org/wiki/Crystal%20%28programming%20language%29"
+    assert_prints URI.encode_path("\xFF"), "%FF" # escapes invalid UTF-8 character
+    assert_prints URI.encode_path("foo/bar/baz"), "foo/bar/baz"
+  end
+
   describe ".encode" do
     it_encodes("hello", "hello")
     it_encodes("hello world", "hello%20world")

--- a/src/compiler/crystal/tools/doc/macro.cr
+++ b/src/compiler/crystal/tools/doc/macro.cr
@@ -43,7 +43,7 @@ class Crystal::Doc::Macro
   end
 
   def anchor
-    '#' + URI.encode(id)
+    '#' + URI.encode_path(id)
   end
 
   def prefix

--- a/src/compiler/crystal/tools/doc/method.cr
+++ b/src/compiler/crystal/tools/doc/method.cr
@@ -198,7 +198,7 @@ class Crystal::Doc::Method
   end
 
   def anchor
-    "#" + URI.encode(id)
+    "#" + URI.encode_path(id)
   end
 
   def to_s(io : IO) : Nil

--- a/src/http/server/handlers/static_file_handler.cr
+++ b/src/http/server/handlers/static_file_handler.cr
@@ -113,7 +113,7 @@ class HTTP::StaticFileHandler
   private def redirect_to(context, url)
     context.response.status = :found
 
-    url = URI.encode(url.to_s)
+    url = URI.encode_path(url.to_s)
     context.response.headers.add "Location", url
   end
 

--- a/src/http/server/handlers/static_file_handler.html
+++ b/src/http/server/handlers/static_file_handler.html
@@ -7,10 +7,10 @@
     <h2>Directory listing for <%= HTML.escape request_path %></h2>
     <hr/>
     <ul>
-      <% encoded_request_path = URI.encode(request_path) %>
+      <% encoded_request_path = URI.encode_path(request_path) %>
       <% each_entry do |entry| %>
         <li>
-          <a href="<%= encoded_request_path %><%= URI.encode entry %>"><%= HTML.escape entry %></a>
+          <a href="<%= encoded_request_path %><%= URI.encode_path entry %>"><%= HTML.escape entry %></a>
         </li>
       <% end %>
     </ul>

--- a/src/uri.cr
+++ b/src/uri.cr
@@ -55,16 +55,18 @@ require "./uri/params"
 #
 # * `.decode(string : String, *, plus_to_space : Bool = false) : String`: Decodes a URL-encoded string.
 # * `.decode(string : String, io : IO, *, plus_to_space : Bool = false) : Nil`: Decodes a URL-encoded string to an IO.
-# * `.encode(string : String, *, space_to_plus : Bool = false) : String`: URL-encodes a string.
-# * `.encode(string : String, io : IO, *, space_to_plus : Bool = false) : Nil`: URL-encodes a string to an IO.
+# * `.encode_path(string : String) : String`: URL-encodes a string.
+# * `.encode_path(string : String, io : IO) : Nil`: URL-encodes a string to an IO.
+# * `.encode_path_segment(string : String) : String`: URL-encodes a string, escaping `/`.
+# * `.encode_path_segment(string : String, io : IO) : Nil`: URL-encodes a string to an IO, escaping `/`.
 # * `.decode_www_form(string : String, *, plus_to_space : Bool = true) : String`: Decodes an `x-www-form-urlencoded` string component.
 # * `.decode_www_form(string : String, io : IO, *, plus_to_space : Bool = true) : Nil`: Decodes an `x-www-form-urlencoded` string component to an IO.
 # * `.encode_www_form(string : String, *, space_to_plus : Bool = true) : String`: Encodes a string as a `x-www-form-urlencoded` component.
 # * `.encode_www_form(string : String, io : IO, *, space_to_plus : Bool = true) : Nil`: Encodes a string as a `x-www-form-urlencoded` component to an IO.
 #
-# The main difference is that `.encode_www_form` encodes reserved characters
-# (see `.reserved?`), while `.encode` does not. The decode methods are
-# identical except for the handling of `+` characters.
+# `.encode_www_form` encodes white space (` `) as `+`, while `.encode_path`
+# and `.encode_path_segment` encode it as `%20`. The decode methods differ regarding
+# the handling of `+` characters, respectively.
 #
 # NOTE: `URI::Params` provides a higher-level API for handling `x-www-form-urlencoded`
 # serialized data.

--- a/src/uri.cr
+++ b/src/uri.cr
@@ -303,7 +303,12 @@ class URI
     end
 
     if host = @host
-      URI.encode(host, io)
+      # https://datatracker.ietf.org/doc/html/rfc3986#section-3.2.2
+      #
+      # host        = IP-literal / IPv4address / reg-name
+      #
+      # The valid characters include unreserved, sub-delims, ':', '[', ']' (IPv6-Adress)
+      URI.encode(host, io) { |byte| URI.unreserved?(byte) || URI.sub_delim?(byte) || byte.unsafe_chr.in?(':', '[', ']') }
     end
 
     if port = @port

--- a/src/uri/encoding.cr
+++ b/src/uri/encoding.cr
@@ -29,7 +29,7 @@ class URI
   # replacing special characters (including `/`) with URI escape sequences as needed.
   #
   # Unreserved characters such as ASCII letters, digits, and the characters
-  # `_.-~` are not encoded ([RFC 3986 §3.3](https://datatracker.ietf.org/doc/html/rfc3986#section-3.3)).
+  # `_.-~` are not encoded (see `.unreserved?`).
   #
   # ```
   # require "uri"

--- a/src/uri/encoding.cr
+++ b/src/uri/encoding.cr
@@ -212,18 +212,30 @@ class URI
   end
 
   # Returns whether given byte is reserved character defined in
-  # [RFC 3986](https://tools.ietf.org/html/rfc3986).
+  # [RFC 3986 §2.2](https://datatracker.ietf.org/doc/html/rfc3986#section-2.2).
   #
   # Reserved characters are ':', '/', '?', '#', '[', ']', '@', '!',
   # '$', '&', "'", '(', ')', '*', '+', ',', ';' and '='.
   def self.reserved?(byte) : Bool
+    sub_delim?(byte) || gen_delim?(byte)
+  end
+
+  # :nodoc:
+  # Returns `true` if the byte is URI gen-delims (https://datatracker.ietf.org/doc/html/rfc3986#section-2.2).
+  def self.gen_delim?(byte)
+    byte.unsafe_chr.in?('#', '/', ':', '?', '@', '[', ']')
+  end
+
+  # :nodoc:
+  # Returns `true` if the byte is URI sub-delims (https://datatracker.ietf.org/doc/html/rfc3986#section-2.2).
+  def self.sub_delim?(byte) : Bool
     char = byte.unsafe_chr
     '&' <= char <= ',' ||
-      char.in?('!', '#', '$', '/', ':', ';', '?', '@', '[', ']', '=')
+      char.in?('!', '$', ';', '=')
   end
 
   # Returns whether given byte is unreserved character defined in
-  # [RFC 3986](https://tools.ietf.org/html/rfc3986).
+  # [RFC 3986 §2.3](https://datatracker.ietf.org/doc/html/rfc3986#section-2.3).
   #
   # Unreserved characters are ASCII letters, ASCII digits, `_`, `.`, `-` and `~`.
   def self.unreserved?(byte) : Bool

--- a/src/uri/encoding.cr
+++ b/src/uri/encoding.cr
@@ -281,7 +281,7 @@ class URI
   # as `+` and `+` is encoded as `%2B`.
   #
   # This method enables some customization, but typical use cases can be implemented
-  # by either `.encode(string : String, *, space_to_plus : Bool = false) : String` or
+  # by either `.encode_path(string : String) : String`, `.encode_path_segment(string : String) : String` or
   # `.encode_www_form(string : String, *, space_to_plus : Bool = true) : String`.
   def self.encode(string : String, io : IO, space_to_plus : Bool = false, &block) : Nil
     string.each_byte do |byte|

--- a/src/uri/encoding.cr
+++ b/src/uri/encoding.cr
@@ -1,4 +1,58 @@
 class URI
+  # Encodes *string* so it can be safely placed as a potentially multi-segmented
+  # URI path, replacing special characters with URI escape sequences as needed.
+  #
+  # Unreserved characters such as ASCII letters, digits, and the characters
+  # `_.-~` are not encoded, as well as the character `/` which represent a
+  # segment separator in hierarchical paths ([RFC 3986 §3.3](https://datatracker.ietf.org/doc/html/rfc3986#section-3.3)).
+  #
+  # ```
+  # require "uri"
+  #
+  # URI.encode_path("foo/bar/baz")  # => "foo/bar/baz"
+  # URI.encode_path("hello world!") # => "hello%20world%21"
+  # URI.encode_path("put: it+й")    # => "put%3A%20it%2B%D0%B9"
+  # ```
+  #
+  # * `.decode` is the reverse operation.
+  # * `.encode_path_segment` encodes a single path segment, escaping `/`.
+  def self.encode_path(string : String) : String
+    String.build { |io| encode_path(io, string) }
+  end
+
+  # :ditto:
+  def self.encode_path(io : IO, string : String) : Nil
+    self.encode(string, io) { |byte| URI.unreserved?(byte) || '/' === byte }
+  end
+
+  # Encodes *string* so it can be safely placed inside a URI path segment,
+  # replacing special characters (including `/`) with URI escape sequences as needed.
+  #
+  # Unreserved characters such as ASCII letters, digits, and the characters
+  # `_.-~` are not encoded ([RFC 3986 §3.3](https://datatracker.ietf.org/doc/html/rfc3986#section-3.3)).
+  #
+  # ```
+  # require "uri"
+  #
+  # URI.encode_path_segment("foo;bar;baz")  # => "foo%3Bbar%3Bbaz"
+  # URI.encode_path_segment("foo/bar/baz")  # => "foo%2Fbar%2Fbaz"
+  # URI.encode_path_segment("foo,bar,baz")  # => "foo%2Cbar%2Cbaz"
+  # URI.encode_path_segment("hello world!") # => "hello%20world%21"
+  # URI.encode_path_segment("put: it+й")    # => "put%3A%20it%2B%D0%B9"
+  # ```
+  #
+  # * `.decode` is the reverse operation.
+  # * `.encode_path` encodes a path consisting of multiple segments, not escaping `/`.
+  # * `.encode_www_form` escapes space character as `+`.
+  def self.encode_path_segment(string : String) : String
+    String.build { |io| encode_path_segment(io, string) }
+  end
+
+  # :ditto:
+  def self.encode_path_segment(io : IO, string : String) : Nil
+    self.encode(string, io) { |byte| URI.unreserved?(byte) }
+  end
+
   # URL-decodes *string*.
   #
   # ```
@@ -60,6 +114,7 @@ class URI
   #
   # * `.decode` is the reverse operation.
   # * `.encode_www_form` also escapes reserved characters.
+  @[Deprecated("Use `.encode_path` instead.")]
   def self.encode(string : String, *, space_to_plus : Bool = false) : String
     String.build { |io| encode(string, io, space_to_plus: space_to_plus) }
   end
@@ -67,6 +122,7 @@ class URI
   # URL-encodes *string* and writes the result to *io*.
   #
   # See `.encode(string : String, *, space_to_plus : Bool = false) : String` for details.
+  @[Deprecated("Use `.encode_path` instead.")]
   def self.encode(string : String, io : IO, *, space_to_plus : Bool = false) : Nil
     self.encode(string, io, space_to_plus: space_to_plus) { |byte| URI.reserved?(byte) || URI.unreserved?(byte) }
   end
@@ -137,7 +193,7 @@ class URI
   # ```
   #
   # * `.decode_www_form` is the reverse operation.
-  # * `.encode` does not escape reserved characters.
+  # * `.encode_path` escapes space character as `%20`.
   def self.encode_www_form(string : String, *, space_to_plus : Bool = true) : String
     String.build do |io|
       encode_www_form(string, io, space_to_plus: space_to_plus)


### PR DESCRIPTION
Resolves #10603

This patch adds two new methods:

* `URI.encode_path`: Encodes all characters except unreserved and path segment separator (`/`).
* `URI.encode_path_segment`: Encodes all characters except unreserved.

Both can be used with an `IO` or as returning `String`.

The similar `URI.encode` overloads are deprecated. The generic, yielding `URI.encode` stays unaffected.