### PR TITLE
Allow assignments from generic instance metaclasses to virtual metaclasses

### DIFF
--- a/spec/compiler/codegen/class_spec.cr
+++ b/spec/compiler/codegen/class_spec.cr
@@ -1197,4 +1197,106 @@ describe "Code gen: class" do
       Foo(Int32).new.x
       )).to_i.should eq(42)
   end
+
+  pending "codegens assignment of generic metaclasses (1) (#10394)" do
+    run(%(
+      class Class
+        def name : String
+          {{ @type.name.stringify }}
+        end
+      end
+
+      class Foo(T); end
+      class Bar(T) < Foo(T); end
+
+      x = Foo
+      x = Bar
+      x.name
+      )).to_string.should eq("Bar(T)")
+  end
+
+  pending "codegens assignment of generic metaclasses (2) (#10394)" do
+    run(%(
+      class Class
+        def name : String
+          {{ @type.name.stringify }}
+        end
+      end
+
+      class Foo(T); end
+      class Bar(T) < Foo(T); end
+
+      x = Foo
+      x = Bar(Int32)
+      x.name
+      )).to_string.should eq("Bar(Int32)")
+  end
+
+  it "codegens assignment of generic metaclasses (3) (#10394)" do
+    run(%(
+      class Class
+        def name : String
+          {{ @type.name.stringify }}
+        end
+      end
+
+      class Foo(T); end
+      class Bar(T) < Foo(T); end
+
+      x = Foo(Int32)
+      x = Bar(Int32)
+      x.name
+      )).to_string.should eq("Bar(Int32)")
+  end
+
+  it "codegens assignment of generic metaclasses (4) (#10394)" do
+    run(%(
+      class Class
+        def name : String
+          {{ @type.name.stringify }}
+        end
+      end
+
+      class Foo(T); end
+      class Bar(T) < Foo(T); end
+
+      x = Foo(String)
+      x = Bar(Int32)
+      x.name
+      )).to_string.should eq("Bar(Int32)")
+  end
+
+  it "codegens assignment of generic metaclasses, base is non-generic (1) (#10394)" do
+    run(%(
+      class Class
+        def name : String
+          {{ @type.name.stringify }}
+        end
+      end
+
+      class Foo; end
+      class Bar(T) < Foo; end
+
+      x = Foo
+      x = Bar
+      x.name
+      )).to_string.should eq("Bar(T)")
+  end
+
+  it "codegens assignment of generic metaclasses, base is non-generic (2) (#10394)" do
+    run(%(
+      class Class
+        def name : String
+          {{ @type.name.stringify }}
+        end
+      end
+
+      class Foo; end
+      class Bar(T) < Foo; end
+
+      x = Foo
+      x = Bar(Int32)
+      x.name
+      )).to_string.should eq("Bar(Int32)")
+  end
 end

--- a/src/compiler/crystal/codegen/cast.cr
+++ b/src/compiler/crystal/codegen/cast.cr
@@ -204,11 +204,7 @@ class Crystal::CodeGenVisitor
     store cast_to(value, target_type), target_pointer
   end
 
-  def assign_distinct(target_pointer, target_type : VirtualMetaclassType, value_type : MetaclassType, value)
-    store value, target_pointer
-  end
-
-  def assign_distinct(target_pointer, target_type : VirtualMetaclassType, value_type : VirtualMetaclassType, value)
+  def assign_distinct(target_pointer, target_type : VirtualMetaclassType, value_type : MetaclassType | GenericClassInstanceMetaclassType | GenericModuleInstanceMetaclassType | VirtualMetaclassType, value)
     store value, target_pointer
   end
 
@@ -271,7 +267,7 @@ class Crystal::CodeGenVisitor
   end
 
   def assign_distinct(target_pointer, target_type : Type, value_type : Type, value)
-    raise "BUG: trying to assign #{target_type} <- #{value_type}"
+    raise "BUG: trying to assign #{target_type} (#{target_type.class}) <- #{value_type} (#{value_type.class})"
   end
 
   def downcast(value, to_type, from_type : VoidType, already_loaded)
@@ -514,7 +510,7 @@ class Crystal::CodeGenVisitor
   end
 
   def downcast_distinct(value, to_type : Type, from_type : Type)
-    raise "BUG: trying to downcast #{to_type} <- #{from_type}"
+    raise "BUG: trying to downcast #{to_type} (#{to_type.class}) <- #{from_type} (#{from_type.class})"
   end
 
   def upcast(value, to_type, from_type)
@@ -669,6 +665,6 @@ class Crystal::CodeGenVisitor
   end
 
   def upcast_distinct(value, to_type : Type, from_type : Type)
-    raise "BUG: trying to upcast #{to_type} <- #{from_type}"
+    raise "BUG: trying to upcast #{to_type} (#{to_type.class}) <- #{from_type} (#{from_type.class})"
   end
 end


### PR DESCRIPTION
Fixes part of #10394.

This appears to be simply oversight during the codegen phase.

Note that in the following example:

```crystal
class Foo(T); end
class Bar(T) < Foo(T); end

x = Foo
x = Bar
```

`x`'s type is `Foo.class`, which is _not_ virtual, so the assignment will still break. Those remaining specs are marked as pending.