### PR TITLE
Regex: use PCRE_UCP

### DIFF
--- a/spec/std/regex_spec.cr
+++ b/spec/std/regex_spec.cr
@@ -75,6 +75,10 @@ describe "Regex" do
     ("foo\n<bar\n>baz" =~ /<bar.*?>/m).should eq(4)
   end
 
+  it "matches unicode char against [[:print:]] (#11262)" do
+    ("\n☃" =~ /[[:print:]]/).should eq(1)
+  end
+
   it "matches with =~ and captures" do
     ("fooba" =~ /f(o+)(bar?)/).should eq(0)
     $~.group_size.should eq(2)

--- a/src/regex.cr
+++ b/src/regex.cr
@@ -225,6 +225,8 @@ class Regex
     NO_UTF8_CHECK = 0x00002000
     # :nodoc:
     DUPNAMES = 0x00080000
+    # :nodoc:
+    UCP = 0x20000000
   end
 
   # Returns a `Regex::Options` representing the optional flags applied to this `Regex`.
@@ -255,7 +257,7 @@ class Regex
     source = source.gsub('\u{0}', "\\0")
     @source = source
 
-    @re = LibPCRE.compile(@source, (options | Options::UTF_8 | Options::NO_UTF8_CHECK | Options::DUPNAMES), out errptr, out erroffset, nil)
+    @re = LibPCRE.compile(@source, (options | Options::UTF_8 | Options::NO_UTF8_CHECK | Options::DUPNAMES | Options::UCP), out errptr, out erroffset, nil)
     raise ArgumentError.new("#{String.new(errptr)} at #{erroffset}") if @re.null?
     @extra = LibPCRE.study(@re, 0, out studyerrptr)
     raise ArgumentError.new("#{String.new(studyerrptr)}") if @extra.null? && studyerrptr


### PR DESCRIPTION
Fixes #11262

See https://www.pcre.org/original/doc/html/pcre_compile.html (search for PCRE_UCP.) It doesn't mention `[:print:]` but I assume it applies to that as well, because with this it starts working fine.