### PR TITLE
Partially reverting annotations from #11059

### DIFF
--- a/src/array.cr
+++ b/src/array.cr
@@ -1046,8 +1046,8 @@ class Array(T)
   end
 
   # Optimized version of `Enumerable#map`.
-  def map(& : T -> U) forall U
-    Array(U).new(size) { |i| yield @buffer[i] }
+  def map(& : T -> _)
+    Array.new(size) { |i| yield @buffer[i] }
   end
 
   # Modifies `self`, keeping only the elements in the collection for which the
@@ -1149,8 +1149,8 @@ class Array(T)
   # results = gems.map_with_index { |gem, i| "#{i}: #{gem}" }
   # results # => ["0: crystal", "1: pearl", "2: diamond"]
   # ```
-  def map_with_index(offset = 0, & : T, Int32 -> U) forall U
-    Array(U).new(size) { |i| yield @buffer[i], offset + i }
+  def map_with_index(offset = 0, & : T, Int32 -> _)
+    Array.new(size) { |i| yield @buffer[i], offset + i }
   end
 
   # Returns an `Array` with the first *count* elements removed

--- a/src/indexable/mutable.cr
+++ b/src/indexable/mutable.cr
@@ -51,7 +51,7 @@ module Indexable::Mutable(T)
   # array                         # => [1, 4, 3]
   # array.update(5) { |x| x * 2 } # raises IndexError
   # ```
-  def update(index : Int, & : T -> T) : T
+  def update(index : Int, & : T -> _) : T
     index = check_index_out_of_bounds index
     value = yield unsafe_fetch(index)
     unsafe_put(index, value)
@@ -142,7 +142,7 @@ module Indexable::Mutable(T)
   # a.map! { |x| x * x }
   # a # => [1, 4, 9]
   # ```
-  def map!(& : T -> T) : self
+  def map!(& : T -> _) : self
     each_index do |i|
       unsafe_put(i, yield unsafe_fetch(i))
     end
@@ -159,7 +159,7 @@ module Indexable::Mutable(T)
   # gems.map_with_index! { |gem, i| "#{i}: #{gem}" }
   # gems # => ["0: crystal", "1: pearl", "2: diamond"]
   # ```
-  def map_with_index!(offset = 0, & : T, Int32 -> T) : self
+  def map_with_index!(offset = 0, & : T, Int32 -> _) : self
     each_index do |i|
       unsafe_put(i, yield(unsafe_fetch(i), offset + i))
     end

--- a/src/slice.cr
+++ b/src/slice.cr
@@ -277,7 +277,7 @@ struct Slice(T)
   # :inherit:
   #
   # Raises if this slice is read-only.
-  def update(index : Int, & : T -> T) : T
+  def update(index : Int, & : T -> _) : T
     check_writable
     super { |elem| yield elem }
   end
@@ -351,7 +351,7 @@ struct Slice(T)
   # :inherit:
   #
   # Raises if this slice is read-only.
-  def map!(& : T -> T) : self
+  def map!(& : T -> _) : self
     check_writable
     super { |elem| yield elem }
   end
@@ -362,14 +362,14 @@ struct Slice(T)
   # slice = Slice[1, 2.5, "a"]
   # slice.map &.to_s # => Slice["1", "2.5", "a"]
   # ```
-  def map(*, read_only = false, & : T -> U) forall U
+  def map(*, read_only = false, & : T -> _)
     Slice.new(size, read_only: read_only) { |i| yield @pointer[i] }
   end
 
   # :inherit:
   #
   # Raises if this slice is read-only.
-  def map_with_index!(offset = 0, & : T, Int32 -> T) : self
+  def map_with_index!(offset = 0, & : T, Int32 -> _) : self
     check_writable
     super { |elem, i| yield elem, i }
   end
@@ -378,7 +378,7 @@ struct Slice(T)
   #
   # Accepts an optional *offset* parameter, which tells it to start counting
   # from there.
-  def map_with_index(offset = 0, *, read_only = false, & : (T, Int32) -> U) forall U
+  def map_with_index(offset = 0, *, read_only = false, & : (T, Int32) -> _)
     Slice.new(size, read_only: read_only) { |i| yield @pointer[i], offset + i }
   end
 


### PR DESCRIPTION
Solves #11263 by transforming annotations of the form `-> T` to be unrestricted `-> _`.