### PR TITLE
[CI] Update ruby-install

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -305,6 +305,9 @@ jobs:
           command: |
             brew unlink python@2 || true
 
+            # We need ruby-install >= 0.8.3
+            brew install ruby-install
+
             ruby-install ruby 2.7.3
 
             brew install pkgconfig libtool


### PR DESCRIPTION
Resolves #11275

Building Ruby on darwin with the default installed `ruby-install` (`0.8.1`) currently fails because of incompatibilities with the newely available OpenSSL 3.

The newest patch release of `ruby-install` ([`0.8.3`](https://github.com/postmodern/ruby-install/releases/tag/v0.8.3)) fixes that. It's already in Homebrew but apparently not included in Circle CI's darwin base system. Thus we need to install the update ourselves for now.