### PR TITLE
[CI] Add build matrix with 1.0.0 and 1.1.1

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -11,7 +11,11 @@ jobs:
     env:
       ARCH: x86_64
       ARCH_CMD: linux64
+      DOCKER_TEST_PREFIX: crystallang/crystal:${{ matrix.crystal_bootstrap_version }}
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        crystal_bootstrap_version: [1.0.0, 1.1.1]
     steps:
       - name: Download Crystal source
         uses: actions/checkout@v2


### PR DESCRIPTION
In order to ensure compatibility with older Crystal releases, we need to run specs for that.

This is just a first step. We're duplicating the specs for `test_linux` to run with both, the latest stable release (`1.1.1`) and its predecessor (`1.0.0`).

It's still open how we want to progress in the future. For example, how long we keep `1.0.0` as the lower bound and if we add tests for more releases between upper and lower bound. That's to be determined at a later point.

See https://forum.crystal-lang.org/t/compiler-compilability/3651 for the discussion thread.