### PR TITLE
[CI] Update nixpkgs

### DIFF
--- a/bin/ci
+++ b/bin/ci
@@ -154,6 +154,10 @@ prepare_build() {
   if [ `uname` = "Darwin" ]; then
     on_nix_shell "brew install bash"
   fi
+
+  # FIXME: Workaround for https://github.com/crystal-lang/crystal/issues/11279
+  nix-channel --update
+
   # initialize nix environment
   on_nix_shell nix-shell
 


### PR DESCRIPTION
Resolves #11279

According to https://github.com/crystal-lang/crystal/issues/11279#issuecomment-934606564 the failure is caused by the GHA spec base system being upgraded to MacOS 11 but the version of nixpkgs is not compatible. Until that's fixed, we can uddate the nix  version explicitly.