### PR TITLE
[CI] Pin macOS runner to 10.15

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -8,7 +8,7 @@ env:
 
 jobs:
   test_macos:
-    runs-on: macos-latest
+    runs-on: macos-10.15
     steps:
       - name: Download Crystal source
         uses: actions/checkout@v2


### PR DESCRIPTION
Resolves #11279 

The failure seems to be caused by the rolling update to macOS 11. We should pin the OS version to avoid such issues. We do this for other other runners already.