### PR TITLE
[CI] Sanitize version from branch name

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -209,9 +209,16 @@ jobs:
       - run: |
           cd /tmp/workspace/distribution-scripts
 
-          # How to brand it
-          export VERSION=${CIRCLE_BRANCH/release\//}
-          export VERSION=${VERSION//\//-}-dev
+          # The version is based on the branch name.
+          VERSION=$CIRCLE_BRANCH
+
+          # We need to sanitize it because there are restrictions on some places
+          # where the version is use (Mac pkg names, snap branch).
+          VERSION=${VERSION/release\//}
+          VERSION=${VERSION//_/-}
+          VERSION=${VERSION//\//-}-dev
+
+          export VERSION
           echo "export CRYSTAL_VERSION=$VERSION" >> build.env
           echo "export DOCKER_TAG=$VERSION" >> build.env
 


### PR DESCRIPTION
For maintenance builds, the Crystal version is derived from the branch name. But some characters we typically use in branch names are not valid in some places where the version value is used.
There had already been some sanitizing (replace `/` by `-` and strip leading `release/`). This patch adds replacing `_` by `-`. The latter has caused issues in https://github.com/crystal-lang/distribution-scripts/pull/143#issuecomment-937218523 and the succeeding workflow https://app.circleci.com/pipelines/github/crystal-lang/crystal/6981/workflows/94c27061-f6c0-4e12-b58b-252c9a03c39d shows that the change was successful.