### PR TITLE
Fix `WebSocket#stream` flushing for not exactly buffer size, add specs

### DIFF
--- a/src/http/web_socket/protocol.cr
+++ b/src/http/web_socket/protocol.cr
@@ -76,7 +76,7 @@ class HTTP::WebSocket::Protocol
 
     def flush(final = true) : Nil
       @websocket.send(
-        @buffer + (@pos % @buffer.size),
+        @buffer[0...@pos],
         @opcode,
         flags: final ? Flags::FINAL : Flags::None,
         flush: final


### PR DESCRIPTION
StreamIO#flush was incorrectly sending data from the insertion position
until the end of the buffer, instead of from the start of the buffer up
until the position.

The existing tests did not catch this because they were sending 1.5x
buffer size of the same character, and so when it did the second flush,
the position happened to have the exact number of bytes left and they
were already set with that character from the first time around.

This patch fixes the problem, and adds a test for streaming less than
one buffer size.

It also adds a few end-to-end websocket integration tests to cover
several different situations to hopefully prevent regressions in the
future.

Fixes #11296