### PR TITLE
Add File::PATH_SEPARATOR and File::PATH_SEPARATOR_STRING constants

### DIFF
--- a/src/file.cr
+++ b/src/file.cr
@@ -54,6 +54,18 @@ class File < IO::FileDescriptor
   # The file/directory separator string. `"/"` on all platforms.
   SEPARATOR_STRING = "/"
 
+  PATH_SEPARATOR = {% if flag?(:win32) %}
+                     ';'
+                   {% else %}
+                     ':'
+                   {% end %}
+
+  PATH_SEPARATOR_STRING = {% if flag?(:win32) %}
+                            ";"
+                          {% else %}
+                            ":"
+                          {% end %}
+
   # :nodoc:
   DEFAULT_CREATE_PERMISSIONS = File::Permissions.new(0o644)
 


### PR DESCRIPTION
* These constants represent the separator character used to separate individual
  directories in the $PATH environment variable.
  On Windows the separator is actually ';', where as on Unix based systems it is ':'.

Resolves #11305