### PR TITLE
Revert block type of `Enumerable#in_groups_of` introduced in #10467

### DIFF
--- a/src/enumerable.cr
+++ b/src/enumerable.cr
@@ -598,7 +598,7 @@ module Enumerable(T)
   #
   # This can be used to prevent many memory allocations when each slice of
   # interest is to be used in a read-only fashion.
-  def in_groups_of(size : Int, filled_up_with : U = nil, reuse = false, & : Array(T | U) ->) forall U
+  def in_groups_of(size : Int, filled_up_with : U = nil, reuse = false, &) forall U
     raise ArgumentError.new("Size must be positive") if size <= 0
 
     each_slice_internal(size, Array(T | U), reuse) do |slice|


### PR DESCRIPTION
Resolves issue noted in https://github.com/crystal-lang/crystal/issues/11244#issuecomment-940488965 