### PR TITLE
[CI] Enable publish docker images on tagged release

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -499,7 +499,7 @@ workflows:
           requires:
             - dist_docker
       - publish_docker:
-          filters: *maintenance
+          filters: *release
           requires:
             - dist_docker
       - dist_docs:


### PR DESCRIPTION
Resolves the main part of https://github.com/crystal-lang/distribution-scripts/issues/120

For now, `latest` tags won't be assigned automatically due to potential issues described in https://github.com/crystal-lang/distribution-scripts/issues/120#issuecomment-934883428
