### PR TITLE
Attach debug locations to auto-generated `initialize` methods

### DIFF
--- a/spec/llvm-ir/argless-initialize-debug-loc.cr
+++ b/spec/llvm-ir/argless-initialize-debug-loc.cr
@@ -1,0 +1,11 @@
+class Foo(T)
+  # CHECK:      define internal %"Foo(Int32)"* @"*Foo(Int32)@Foo(T)::new:Foo(Int32)"(i32 %self)
+  # CHECK-SAME: !dbg [[LOC1:![0-9]+]]
+  # CHECK-NEXT: alloca:
+  # CHECK-NEXT: %_ = alloca %"Foo(Int32)"*
+  # CHECK-SAME: !dbg [[LOC2:![0-9]+]]
+  # CHECK:      [[LOC2]] = !DILocation
+  # CHECK-SAME: scope: [[LOC1]]
+end
+
+Foo(Int32).new

--- a/spec/llvm-ir/test.sh
+++ b/spec/llvm-ir/test.sh
@@ -32,6 +32,7 @@ function test() {
 
 pushd $BUILD_DIR >/dev/null
 
+test argless-initialize-debug-loc.cr "--cross-compile --target x86_64-unknown-linux-gnu --prelude=empty"
 test proc-pointer-debug-loc.cr "--cross-compile --target x86_64-unknown-linux-gnu --prelude=empty"
 
 test memset.cr "--cross-compile --target i386-apple-darwin --prelude=empty --no-debug" X32

--- a/src/compiler/crystal/semantic/new.cr
+++ b/src/compiler/crystal/semantic/new.cr
@@ -59,7 +59,7 @@ module Crystal
 
           # Also add `initialize`, so `super` in a subclass
           # inside an `initialize` will find this one
-          type.add_def Def.argless_initialize
+          type.add_def Def.argless_initialize(type)
         end
 
         # Check to see if a type doesn't define `initialize`
@@ -86,7 +86,7 @@ module Crystal
               # If the type has `self.new()`, don't override it
               unless has_default_self_new
                 type.metaclass.as(ModuleType).add_def(Def.argless_new(type))
-                type.add_def(Def.argless_initialize)
+                type.add_def(Def.argless_initialize(type))
               end
             else
               initialize_owner = nil
@@ -252,8 +252,9 @@ module Crystal
       a_def
     end
 
-    def self.argless_initialize
-      Def.new("initialize", body: Nop.new)
+    def self.argless_initialize(instance_type)
+      loc = instance_type.locations.try &.first?
+      Def.new("initialize", body: Nop.new).at(loc)
     end
 
     def expand_new_default_arguments(instance_type, args_size, named_args)


### PR DESCRIPTION
If a type has no constructors at all, then the compiler automatically generates the `.new` and `#initialize` methods. The former is attached to the first declaration of the type, but the latter isn't; this PR gives it the same treatment.

In particular, `Reference#initialize` used to have no locations, and this caused the auto-generated constructors for generic classes to lose theirs too:

```crystal
class Foo(T)
end

Foo(Int32).new # "*Foo(Int32)@Foo(T)::new:Foo(Int32)" has no location
```

This shows up on Compiler Explorer as the constructors of `Thread::LinkedList(T)` were never considered library code. They are now filtered after this patch.