### PR TITLE
Move the nodoc flags to the right place to hide the __mul* functions.

### DIFF
--- a/src/crystal/compiler_rt/mul.cr
+++ b/src/crystal/compiler_rt/mul.cr
@@ -1,7 +1,7 @@
 # :nodoc:
 private macro __mul_impl(name, type, n)
-  # Ported from https://github.com/llvm/llvm-project/blob/ce59ccd04023cab3a837da14079ca2dcbfebb70c/compiler-rt/lib/builtins/int_mulo_impl.inc
   # :nodoc:
+  # Ported from https://github.com/llvm/llvm-project/blob/ce59ccd04023cab3a837da14079ca2dcbfebb70c/compiler-rt/lib/builtins/int_mulo_impl.inc
   fun {{name}}(a : {{type}}, b : {{type}}, overflow : Int32*) : {{type}}
     overflow.value = 0
     result = a &* b


### PR DESCRIPTION
The toplevel docs @ https://crystal-lang.org/api/1.2.0/toplevel.html show the __mulodi4, __mulosi4, and __muloti4 functions, which are supposed to be nodoc. The problem is just the positioning of the nodoc marker. This PR fixes that.

Fixes #11327