### PR TITLE
Fix docs for `Indexable::Mutable#map!`

### DIFF
--- a/src/indexable/mutable.cr
+++ b/src/indexable/mutable.cr
@@ -134,6 +134,7 @@ module Indexable::Mutable(T)
     self
   end
 
+  {% begin %}
   # Invokes the given block for each element of `self`, replacing the element
   # with the value returned by the block. Returns `self`.
   #
@@ -142,9 +143,8 @@ module Indexable::Mutable(T)
   # a.map! { |x| x * x }
   # a # => [1, 4, 9]
   # ```
-  {% begin %}
-  {% if compare_versions(Crystal::VERSION, "1.1.1") >= 0 %} # TODO: add as constant
-  def map!(& : T -> _) : self
+  {% if compare_versions(Crystal::VERSION, "1.1.1") >= 0 %}
+  def map!(& : T -> _) : self # TODO: add as constant
   {% else %}
   def map!(&) # it doesn't compile with the type annotation in the 1.0.0 compiler
   {% end %}


### PR DESCRIPTION
#11267 caused `TODO: add as constant` to overwrite the original documentation. This fixes it.