### PR TITLE
Parser: add missing end location to `IsA` node

### DIFF
--- a/src/compiler/crystal/syntax/parser.cr
+++ b/src/compiler/crystal/syntax/parser.cr
@@ -830,12 +830,14 @@ module Crystal
         type = parse_bare_proc_type
         skip_space_or_newline
         check :")"
+        end_location = token_end_location
         next_token_skip_space
       else
         type = parse_union_type
+        end_location = type.end_location
       end
 
-      IsA.new(atomic, type)
+      IsA.new(atomic, type).at_end(end_location)
     end
 
     def parse_as(atomic, klass = Cast)


### PR DESCRIPTION
Found this was missing while working on Ameba