### PR TITLE
[CI] Update previous crystal compiler version to 1.2.1

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -134,7 +134,7 @@ jobs:
           echo "export CRYSTAL_SHA1=$CIRCLE_SHA1" >> build.env
 
           # Which previous version use
-          export PREVIOUS_CRYSTAL_BASE_URL="https://github.com/crystal-lang/crystal/releases/download/1.2.0/crystal-1.2.0-1"
+          export PREVIOUS_CRYSTAL_BASE_URL="https://github.com/crystal-lang/crystal/releases/download/1.2.1/crystal-1.2.1-1"
           echo "export PREVIOUS_CRYSTAL_RELEASE_LINUX64_TARGZ=${PREVIOUS_CRYSTAL_BASE_URL}-linux-x86_64.tar.gz" >> build.env
           echo "export PREVIOUS_CRYSTAL_RELEASE_DARWIN_TARGZ=${PREVIOUS_CRYSTAL_BASE_URL}-darwin-universal.tar.gz" >> build.env
 

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        crystal_bootstrap_version: [1.0.0, 1.1.1, 1.2.0]
+        crystal_bootstrap_version: [1.0.0, 1.1.1, 1.2.1]
     steps:
       - name: Download Crystal source
         uses: actions/checkout@v2

--- a/.github/workflows/win.yml
+++ b/.github/workflows/win.yml
@@ -5,7 +5,7 @@ on: [push, pull_request]
 jobs:
   linux-job:
     runs-on: ubuntu-latest
-    container: crystallang/crystal:1.2.0-build
+    container: crystallang/crystal:1.2.1-build
     steps:
       - name: Download Crystal source
         uses: actions/checkout@v2

--- a/bin/ci
+++ b/bin/ci
@@ -133,8 +133,8 @@ format() {
 prepare_build() {
   on_linux verify_linux_environment
 
-  on_osx curl -L https://github.com/crystal-lang/crystal/releases/download/1.2.0/crystal-1.2.0-1-darwin-universal.tar.gz -o ~/crystal.tar.gz
-  on_osx 'pushd ~;gunzip -c ~/crystal.tar.gz | tar xopf -;mv crystal-1.2.0-1 crystal;popd'
+  on_osx curl -L https://github.com/crystal-lang/crystal/releases/download/1.2.1/crystal-1.2.1-1-darwin-universal.tar.gz -o ~/crystal.tar.gz
+  on_osx 'pushd ~;gunzip -c ~/crystal.tar.gz | tar xopf -;mv crystal-1.2.1-1 crystal;popd'
 
   # These commands may take a few minutes to run due to the large size of the repositories.
   # This restriction has been made on GitHub's request because updating shallow
@@ -187,7 +187,7 @@ with_build_env() {
 
   on_linux verify_linux_environment
 
-  export DOCKER_TEST_PREFIX="${DOCKER_TEST_PREFIX:=crystallang/crystal:1.2.0}"
+  export DOCKER_TEST_PREFIX="${DOCKER_TEST_PREFIX:=crystallang/crystal:1.2.1}"
 
   case $ARCH in
     x86_64)

--- a/shell.nix
+++ b/shell.nix
@@ -52,13 +52,13 @@ let
   # Hashes obtained using `nix-prefetch-url --unpack <url>`
   latestCrystalBinary = genericBinary ({
     x86_64-darwin = {
-      url = "https://github.com/crystal-lang/crystal/releases/download/1.2.0/crystal-1.2.0-1-darwin-universal.tar.gz";
-      sha256 = "sha256:00bc2i0qnx7x1z8qqx3x5fsgzcij4b61vsibgddddvwpzk1qhaaj";
+      url = "https://github.com/crystal-lang/crystal/releases/download/1.2.1/crystal-1.2.1-1-darwin-universal.tar.gz";
+      sha256 = "sha256:1h9m8h1ad200gg1nmqs9qnsi455b6m2zj3y6kd7qb9ics9rdksca";
     };
 
     x86_64-linux = {
-      url = "https://github.com/crystal-lang/crystal/releases/download/1.2.0/crystal-1.2.0-1-linux-x86_64.tar.gz";
-      sha256 = "sha256:0whz250ki9l8dw7kwk0wh27vn2p9n5w7007wqb8sd3hm38a2mdha";
+      url = "https://github.com/crystal-lang/crystal/releases/download/1.2.1/crystal-1.2.1-1-linux-x86_64.tar.gz";
+      sha256 = "sha256:1x0g7wrg6bdbwi0ig9bpn5vaysld2nb56xa1ba5qaqr3wz91prb6";
     };
   }.${pkgs.stdenv.system});
 


### PR DESCRIPTION
This is a follow-up to #11317 and updates the latest crystal compiler version to 1.2.1