### PR TITLE
added not_empty? and not_includes?

### DIFF
--- a/spec/std/enumerable_spec.cr
+++ b/spec/std/enumerable_spec.cr
@@ -439,6 +439,11 @@ describe "Enumerable" do
     it { SpecEmptyEnumerable.new.empty?.should be_true }
   end
 
+  describe "not_empty?" do
+    it { SpecEnumerable.new.not_empty?.should be_true }
+    it { SpecEmptyEnumerable.new.not_empty?.should be_false }
+  end
+
   describe "find" do
     it "finds" do
       [1, 2, 3].find { |x| x > 2 }.should eq(3)
@@ -564,6 +569,16 @@ describe "Enumerable" do
 
     it "is false if the object is not part of the collection" do
       [1, 2, 3].includes?(5).should be_false
+    end
+  end
+
+  describe "not_includes?" do
+    it "is true if the object does not exists in the collection" do
+      [1, 2, 3].not_includes?(5).should be_true
+    end
+
+    it "is false if the object exists in the collection" do
+      [1, 2, 3].not_includes?(2).should be_false
     end
   end
 

--- a/src/enumerable.cr
+++ b/src/enumerable.cr
@@ -617,6 +617,16 @@ module Enumerable(T)
     any? { |e| e == obj }
   end
 
+  # Returns `true` if the collection does not contains *obj*, `false` otherwise.
+  #
+  # ```
+  # [1, 2, 3].not_includes?(5) # => true
+  # [1, 2, 3].not_includes?(2) # => false
+  # ```
+  def not_includes?(obj) : Bool
+    !includes?(obj)
+  end
+
   # Returns the index of the first element for which the passed block returns `true`.
   #
   # ```
@@ -1452,6 +1462,16 @@ module Enumerable(T)
   def empty? : Bool
     each { return false }
     true
+  end
+
+  # Returns `true` if `self` is not empty, `false` otherwise.
+  #
+  # ```
+  # ([1]).not_empty?         # => true
+  # ([] of Int32).not_empty? # => false
+  # ```
+  def not_empty? : Bool
+    !empty?
   end
 
   # Returns an `Array` with the first *count* elements removed

--- a/src/indexable.cr
+++ b/src/indexable.cr
@@ -704,6 +704,16 @@ module Indexable(T)
     size == 0
   end
 
+  # Returns `true` if `self` is not empty, `false` otherwise.
+  #
+  # ```
+  # ([1]).not_empty?         # => true
+  # ([] of Int32).not_empty? # => false
+  # ```
+  def not_empty? : Bool
+    !empty?
+  end
+
   # Optimized version of `equals?` used when `other` is also an `Indexable`.
   def equals?(other : Indexable, &) : Bool
     return false if size != other.size


### PR DESCRIPTION
## What?

This PR adds:

+ `Enumerable#not_empty?`
+ `Enumerable#not_includes?`
+ `Indexable#not_empty?`

## Why?

I personally often forget to add `!` when I want to check if e.g. an array is not empty or when I want to check if an item is already in the array. I also find that negating the result of `empty?` and `includes?` to be less readable compared to the methods added in this PR.

This PR tries to improve the readability of code.
