### PR TITLE
Disable specs for `StaticArray#sort_by` on broken targets

### DIFF
--- a/spec/std/static_array_spec.cr
+++ b/spec/std/static_array_spec.cr
@@ -263,8 +263,10 @@ describe "StaticArray" do
       end
     end
 
-    # Deactivated due to https://github.com/crystal-lang/crystal/issues/11358
-    {% unless flag?(:aarch64) && (flag?(:musl) || flag?(:darwin)) %}
+    # StaticArray#sort_by and #sort_by! don't compile on aarch64-darwin and
+    # aarch64-linux-musl due to a codegen error caused by LLVM < 13.0.0.
+    # See https://github.com/crystal-lang/crystal/issues/11358 for details.
+    {% unless compare_versions(Crystal::LLVM_VERSION, "13.0.0") < 0 && flag?(:aarch64) && (flag?(:musl) || flag?(:darwin)) %}
       describe "{{ sort }}_by" do
         it "sorts by" do
           a = StaticArray["foo", "a", "hello"]


### PR DESCRIPTION
The `#sort_by` and `#sort_by!` methods are broken on aarch64-linux-musl and aarch64-darwin (https://github.com/crystal-lang/crystal/issues/11358), so we temporarily disable them.