### PR TITLE
Update for OpenSSL 3.0.0

### DIFF
--- a/.github/workflows/openssl.yml
+++ b/.github/workflows/openssl.yml
@@ -1,0 +1,32 @@
+name: OpenSSL CI
+
+on: [push, pull_request]
+
+jobs:
+  openssl3:
+    runs-on: ubuntu-latest
+    name: "OpenSSL 3.0"
+    container: crystallang/crystal:1.2.1-alpine
+    steps:
+      - name: Download Crystal source
+        uses: actions/checkout@v2
+      - name: Install openssl 3.0
+        run: apk add "openssl-dev=~3.0" --repository=http://dl-cdn.alpinelinux.org/alpine/edge/main
+      - name: Check OpenSSL version
+        run: bin/crystal eval 'require "openssl"; p! LibSSL::OPENSSL_VERSION, LibSSL::LIBRESSL_VERSION'
+      - name: Run OpenSSL specs
+        run: bin/crystal spec spec/std/openssl/
+  openssl111:
+    runs-on: ubuntu-latest
+    name: "OpenSSL 1.1.1"
+    container: crystallang/crystal:1.2.1-alpine
+    steps:
+      - name: Download Crystal source
+        uses: actions/checkout@v2
+      - name: Install openssl 1.1.1
+        run: apk add "openssl-dev=~1.1.1"
+      - name: Check OpenSSL version
+        run: bin/crystal eval 'require "openssl"; p! LibSSL::OPENSSL_VERSION, LibSSL::LIBRESSL_VERSION'
+      - name: Run OpenSSL specs
+        run: bin/crystal spec spec/std/openssl/
+

--- a/spec/std/openssl/hmac_spec.cr
+++ b/spec/std/openssl/hmac_spec.cr
@@ -3,17 +3,25 @@ require "openssl/hmac"
 
 describe OpenSSL::HMAC do
   [
-    {OpenSSL::Algorithm::MD4, "f3593b56f00b25c8af31d02ddef6d2d0"},
     {OpenSSL::Algorithm::MD5, "0c7a250281315ab863549f66cd8a3a53"},
     {OpenSSL::Algorithm::SHA1, "46b4ec586117154dacd49d664e5d63fdc88efb51"},
     {OpenSSL::Algorithm::SHA224, "4c1f774863acb63b7f6e9daa9b5c543fa0d5eccf61e3ffc3698eacdd"},
     {OpenSSL::Algorithm::SHA256, "f9320baf0249169e73850cd6156ded0106e2bb6ad8cab01b7bbbebe6d1065317"},
     {OpenSSL::Algorithm::SHA384, "3d10d391bee2364df2c55cf605759373e1b5a4ca9355d8f3fe42970471eca2e422a79271a0e857a69923839015877fc6"},
     {OpenSSL::Algorithm::SHA512, "114682914c5d017dfe59fdc804118b56a3a652a0b8870759cf9e792ed7426b08197076bf7d01640b1b0684df79e4b67e37485669e8ce98dbab60445f0db94fce"},
-    {OpenSSL::Algorithm::RIPEMD160, "20d23140503df606c91bda9293f1ad4a23afe509"},
   ].each do |(algorithm, expected)|
     it "computes #{algorithm}" do
       OpenSSL::HMAC.hexdigest(algorithm, "foo", "bar").should eq(expected)
     end
   end
+
+  {% if compare_versions(LibSSL::OPENSSL_VERSION, "3.0.0") < 0 %}
+    it "computes MD4" do
+      OpenSSL::HMAC.hexdigest(OpenSSL::Algorithm::MD4, "foo", "bar").should eq("f3593b56f00b25c8af31d02ddef6d2d0")
+    end
+
+    it "computes RIPEMD160" do
+      OpenSSL::HMAC.hexdigest(OpenSSL::Algorithm::RIPEMD160, "foo", "bar").should eq("20d23140503df606c91bda9293f1ad4a23afe509")
+    end
+  {% end %}
 end

--- a/spec/std/openssl/pkcs5_spec.cr
+++ b/spec/std/openssl/pkcs5_spec.cr
@@ -14,41 +14,50 @@ describe OpenSSL::PKCS5 do
   end
 
   {% if compare_versions(LibSSL::OPENSSL_VERSION, "1.0.0") >= 0 %}
-    it "computes pbkdf2_hmac" do
+    {% if compare_versions(LibSSL::OPENSSL_VERSION, "3.0.0") < 0 %}
       [
         {OpenSSL::Algorithm::MD4, 1, 16, "1857f69412150bca4542581d0f9e7fd1"},
         {OpenSSL::Algorithm::MD4, 1, 32, "1857f69412150bca4542581d0f9e7fd19332ff5c0b820cb0172457a29c5519be"},
         {OpenSSL::Algorithm::MD4, 2**16, 16, "3d87c982c8c4223f4af39406ac3882e6"},
         {OpenSSL::Algorithm::MD4, 2**16, 32, "3d87c982c8c4223f4af39406ac3882e6e6b92685dcf89f74df8caf7500b41883"},
-        {OpenSSL::Algorithm::MD5, 1, 16, "f31afb6d931392daa5e3130f47f9a9b6"},
-        {OpenSSL::Algorithm::MD5, 1, 32, "f31afb6d931392daa5e3130f47f9a9b6e8e72029d8350b9fb27a9e0e00b9d991"},
-        {OpenSSL::Algorithm::MD5, 2**16, 16, "8b4ffd76e400c3b74b3d0fbfd9232048"},
-        {OpenSSL::Algorithm::MD5, 2**16, 32, "8b4ffd76e400c3b74b3d0fbfd9232048762c86fe7684992c6f581f073f6625ee"},
         {OpenSSL::Algorithm::RIPEMD160, 1, 16, "b725258b125e0bacb0e2307e34feb16a"},
         {OpenSSL::Algorithm::RIPEMD160, 1, 32, "b725258b125e0bacb0e2307e34feb16a4d0d6aed6cb4b0eee458fc1829020428"},
         {OpenSSL::Algorithm::RIPEMD160, 2**16, 16, "93a8e007de2608e54911684cbebe2780"},
         {OpenSSL::Algorithm::RIPEMD160, 2**16, 32, "93a8e007de2608e54911684cbebe27808cc39fa59de9acdf74492155b46c4d2d"},
-        {OpenSSL::Algorithm::SHA1, 1, 16, "0c60c80f961f0e71f3a9b524af601206"},
-        {OpenSSL::Algorithm::SHA1, 1, 32, "0c60c80f961f0e71f3a9b524af6012062fe037a6e0f0eb94fe8fc46bdc637164"},
-        {OpenSSL::Algorithm::SHA1, 2**16, 16, "1b345dd55f62a35aecdb9229bc7ae95b"},
-        {OpenSSL::Algorithm::SHA1, 2**16, 32, "1b345dd55f62a35aecdb9229bc7ae95b305a8d538940134627e46f82d3a41e5e"},
-        {OpenSSL::Algorithm::SHA224, 1, 16, "3c198cbdb9464b7857966bd05b7bc92b"},
-        {OpenSSL::Algorithm::SHA224, 1, 32, "3c198cbdb9464b7857966bd05b7bc92bc1cc4e6e63155d4e490557fd85989497"},
-        {OpenSSL::Algorithm::SHA224, 2**16, 16, "53a7f042a8154092058cfe87e7fbf1c1"},
-        {OpenSSL::Algorithm::SHA224, 2**16, 32, "53a7f042a8154092058cfe87e7fbf1c1f96826a9a2ffd8bcfda50bb9f60786f0"},
-        {OpenSSL::Algorithm::SHA256, 1, 16, "120fb6cffcf8b32c43e7225256c4f837"},
-        {OpenSSL::Algorithm::SHA256, 1, 32, "120fb6cffcf8b32c43e7225256c4f837a86548c92ccc35480805987cb70be17b"},
-        {OpenSSL::Algorithm::SHA256, 2**16, 16, "4156f668bb31db3a17f4d1b91424ef0d"},
-        {OpenSSL::Algorithm::SHA256, 2**16, 32, "4156f668bb31db3a17f4d1b91424ef0d417ad1f35d055aceaebd8da0f6a44b7e"},
-        {OpenSSL::Algorithm::SHA384, 1, 16, "c0e14f06e49e32d73f9f52ddf1d0c5c7"},
-        {OpenSSL::Algorithm::SHA384, 1, 32, "c0e14f06e49e32d73f9f52ddf1d0c5c7191609233631dadd76a567db42b78676"},
-        {OpenSSL::Algorithm::SHA384, 2**16, 16, "c7b5b0b726f6556587cced08d184253b"},
-        {OpenSSL::Algorithm::SHA384, 2**16, 32, "c7b5b0b726f6556587cced08d184253bc9d2eb802db134fb9029b86ab25e7cd0"},
-        {OpenSSL::Algorithm::SHA512, 1, 16, "867f70cf1ade02cff3752599a3a53dc4"},
-        {OpenSSL::Algorithm::SHA512, 1, 32, "867f70cf1ade02cff3752599a3a53dc4af34c7a669815ae5d513554e1c8cf252"},
-        {OpenSSL::Algorithm::SHA512, 2**16, 16, "6f64c3f8023813d8c2cab43cabfaa65e"},
-        {OpenSSL::Algorithm::SHA512, 2**16, 32, "6f64c3f8023813d8c2cab43cabfaa65ed061822afe974060d8079d122fb869f4"},
       ].each do |(algorithm, iterations, key_size, expected)|
+        it "computes pbkdf2_hmac #{algorithm}" do
+          OpenSSL::PKCS5.pbkdf2_hmac("password", "salt", iterations, algorithm, key_size).hexstring.should eq expected
+        end
+      end
+    {% end %}
+
+    [
+      {OpenSSL::Algorithm::MD5, 1, 16, "f31afb6d931392daa5e3130f47f9a9b6"},
+      {OpenSSL::Algorithm::MD5, 1, 32, "f31afb6d931392daa5e3130f47f9a9b6e8e72029d8350b9fb27a9e0e00b9d991"},
+      {OpenSSL::Algorithm::MD5, 2**16, 16, "8b4ffd76e400c3b74b3d0fbfd9232048"},
+      {OpenSSL::Algorithm::MD5, 2**16, 32, "8b4ffd76e400c3b74b3d0fbfd9232048762c86fe7684992c6f581f073f6625ee"},
+      {OpenSSL::Algorithm::SHA1, 1, 16, "0c60c80f961f0e71f3a9b524af601206"},
+      {OpenSSL::Algorithm::SHA1, 1, 32, "0c60c80f961f0e71f3a9b524af6012062fe037a6e0f0eb94fe8fc46bdc637164"},
+      {OpenSSL::Algorithm::SHA1, 2**16, 16, "1b345dd55f62a35aecdb9229bc7ae95b"},
+      {OpenSSL::Algorithm::SHA1, 2**16, 32, "1b345dd55f62a35aecdb9229bc7ae95b305a8d538940134627e46f82d3a41e5e"},
+      {OpenSSL::Algorithm::SHA224, 1, 16, "3c198cbdb9464b7857966bd05b7bc92b"},
+      {OpenSSL::Algorithm::SHA224, 1, 32, "3c198cbdb9464b7857966bd05b7bc92bc1cc4e6e63155d4e490557fd85989497"},
+      {OpenSSL::Algorithm::SHA224, 2**16, 16, "53a7f042a8154092058cfe87e7fbf1c1"},
+      {OpenSSL::Algorithm::SHA224, 2**16, 32, "53a7f042a8154092058cfe87e7fbf1c1f96826a9a2ffd8bcfda50bb9f60786f0"},
+      {OpenSSL::Algorithm::SHA256, 1, 16, "120fb6cffcf8b32c43e7225256c4f837"},
+      {OpenSSL::Algorithm::SHA256, 1, 32, "120fb6cffcf8b32c43e7225256c4f837a86548c92ccc35480805987cb70be17b"},
+      {OpenSSL::Algorithm::SHA256, 2**16, 16, "4156f668bb31db3a17f4d1b91424ef0d"},
+      {OpenSSL::Algorithm::SHA256, 2**16, 32, "4156f668bb31db3a17f4d1b91424ef0d417ad1f35d055aceaebd8da0f6a44b7e"},
+      {OpenSSL::Algorithm::SHA384, 1, 16, "c0e14f06e49e32d73f9f52ddf1d0c5c7"},
+      {OpenSSL::Algorithm::SHA384, 1, 32, "c0e14f06e49e32d73f9f52ddf1d0c5c7191609233631dadd76a567db42b78676"},
+      {OpenSSL::Algorithm::SHA384, 2**16, 16, "c7b5b0b726f6556587cced08d184253b"},
+      {OpenSSL::Algorithm::SHA384, 2**16, 32, "c7b5b0b726f6556587cced08d184253bc9d2eb802db134fb9029b86ab25e7cd0"},
+      {OpenSSL::Algorithm::SHA512, 1, 16, "867f70cf1ade02cff3752599a3a53dc4"},
+      {OpenSSL::Algorithm::SHA512, 1, 32, "867f70cf1ade02cff3752599a3a53dc4af34c7a669815ae5d513554e1c8cf252"},
+      {OpenSSL::Algorithm::SHA512, 2**16, 16, "6f64c3f8023813d8c2cab43cabfaa65e"},
+      {OpenSSL::Algorithm::SHA512, 2**16, 32, "6f64c3f8023813d8c2cab43cabfaa65ed061822afe974060d8079d122fb869f4"},
+    ].each do |(algorithm, iterations, key_size, expected)|
+      it "computes pbkdf2_hmac #{algorithm}" do
         OpenSSL::PKCS5.pbkdf2_hmac("password", "salt", iterations, algorithm, key_size).hexstring.should eq expected
       end
     end

--- a/spec/std/openssl/ssl/context_spec.cr
+++ b/spec/std/openssl/ssl/context_spec.cr
@@ -239,13 +239,15 @@ describe OpenSSL::SSL::Context do
       expect_raises(ArgumentError, "missing private key") do
         OpenSSL::SSL::Context::Client.from_hash({} of String => String)
       end
-      expect_raises(OpenSSL::Error, "SSL_CTX_use_PrivateKey_file: error:02001002:system library:fopen:No such file or directory") do
+      expect_raises(OpenSSL::Error,
+        {{ compare_versions(LibSSL::OPENSSL_VERSION, "3.0.0") >= 0 ? "SSL_CTX_use_PrivateKey_file: error:80000002:system library::No such file or directory" : "SSL_CTX_use_PrivateKey_file: error:02001002:system library:fopen:No such file or directory" }}) do
         OpenSSL::SSL::Context::Client.from_hash({"key" => nonexistent})
       end
       expect_raises(ArgumentError, "missing certificate") do
         OpenSSL::SSL::Context::Client.from_hash({"key" => private_key})
       end
-      expect_raises(OpenSSL::Error, "SSL_CTX_use_certificate_chain_file: error:02001002:system library:fopen:No such file or directory") do
+      expect_raises(OpenSSL::Error,
+        {{ compare_versions(LibSSL::OPENSSL_VERSION, "3.0.0") >= 0 ? "SSL_CTX_use_certificate_chain_file: error:80000002:system library::No such file or directory" : "SSL_CTX_use_certificate_chain_file: error:02001002:system library:fopen:No such file or directory" }}) do
         OpenSSL::SSL::Context::Client.from_hash({"key" => private_key, "cert" => nonexistent})
       end
       expect_raises(ArgumentError, "Invalid SSL context: missing CA certificate") do
@@ -257,7 +259,8 @@ describe OpenSSL::SSL::Context do
       expect_raises(ArgumentError, "Invalid SSL context: missing CA certificate") do
         OpenSSL::SSL::Context::Client.from_hash({"key" => private_key, "cert" => certificate, "verify_mode" => "peer"})
       end
-      expect_raises(OpenSSL::Error, "SSL_CTX_load_verify_locations: error:02001002:system library:fopen:No such file or directory") do
+      expect_raises(OpenSSL::Error,
+        {{ compare_versions(LibSSL::OPENSSL_VERSION, "3.0.0") >= 0 ? "SSL_CTX_load_verify_locations: error:80000002:system library::No such file or directory" : "SSL_CTX_load_verify_locations: error:02001002:system library:fopen:No such file or directory" }}) do
         OpenSSL::SSL::Context::Client.from_hash({"key" => private_key, "cert" => certificate, "ca" => nonexistent})
       end
     end

--- a/spec/std/openssl/x509/certificate_spec.cr
+++ b/spec/std/openssl/x509/certificate_spec.cr
@@ -28,9 +28,14 @@ describe OpenSSL::X509::Certificate do
     end
   end
 
-  it "#digest" do
-    cert = OpenSSL::X509::Certificate.new
-    expect_raises(ArgumentError) { cert.digest("not a real algo") }
-    cert.digest("SHA256").should_not be_nil
-  end
+  # Starting with 3.0.0 OpenSSL complains about generating a digest signature for an empty certificate
+  {% if compare_versions(LibSSL::OPENSSL_VERSION, "3.0.0") < 0 %}
+    it "#digest" do
+      cert = OpenSSL::X509::Certificate.new
+      expect_raises(ArgumentError, %(Could not find digest for "not a real algo")) { cert.digest("not a real algo") }
+      cert.digest("SHA256").should_not be_nil
+    end
+  {% else %}
+    pending "#digest"
+  {% end %}
 end

--- a/src/openssl/bio.cr
+++ b/src/openssl/bio.cr
@@ -55,7 +55,7 @@ struct OpenSSL::BIO
             when LibCrypto::CTRL_FLUSH
               io.flush
               1
-            when LibCrypto::CTRL_PUSH, LibCrypto::CTRL_POP
+            when LibCrypto::CTRL_PUSH, LibCrypto::CTRL_POP, LibCrypto::CTRL_EOF
               0
             else
               STDERR.puts "WARNING: Unsupported BIO ctrl call (#{cmd})"

--- a/src/openssl/lib_crypto.cr
+++ b/src/openssl/lib_crypto.cr
@@ -51,6 +51,7 @@ lib LibCrypto
   EVP_MAX_KEY_LENGTH = 32
   EVP_MAX_IV_LENGTH  = 16
 
+  CTRL_EOF   =  2
   CTRL_PUSH  =  6
   CTRL_POP   =  7
   CTRL_FLUSH = 11
@@ -174,8 +175,15 @@ lib LibCrypto
   fun evp_digestupdate = EVP_DigestUpdate(ctx : EVP_MD_CTX, data : UInt8*, count : LibC::SizeT) : Int32
   fun evp_md_ctx_copy = EVP_MD_CTX_copy(dst : EVP_MD_CTX, src : EVP_MD_CTX) : Int32
   fun evp_md_ctx_md = EVP_MD_CTX_md(ctx : EVP_MD_CTX) : EVP_MD
-  fun evp_md_size = EVP_MD_size(md : EVP_MD) : Int32
-  fun evp_md_block_size = EVP_MD_block_size(md : EVP_MD) : LibC::Int
+
+  {% if compare_versions(OPENSSL_VERSION, "3.0.0") >= 0 %}
+    fun evp_md_size = EVP_MD_get_size(md : EVP_MD) : Int32
+    fun evp_md_block_size = EVP_MD_get_block_size(md : EVP_MD) : LibC::Int
+  {% else %}
+    fun evp_md_size = EVP_MD_size(md : EVP_MD) : Int32
+    fun evp_md_block_size = EVP_MD_block_size(md : EVP_MD) : LibC::Int
+  {% end %}
+
   fun evp_digestfinal_ex = EVP_DigestFinal_ex(ctx : EVP_MD_CTX, md : UInt8*, size : UInt32*) : Int32
 
   {% if compare_versions(OPENSSL_VERSION, "1.1.0") >= 0 %}
@@ -187,11 +195,22 @@ lib LibCrypto
   {% end %}
 
   fun evp_get_cipherbyname = EVP_get_cipherbyname(name : UInt8*) : EVP_CIPHER
-  fun evp_cipher_name = EVP_CIPHER_name(cipher : EVP_CIPHER) : UInt8*
-  fun evp_cipher_nid = EVP_CIPHER_nid(cipher : EVP_CIPHER) : Int32
-  fun evp_cipher_block_size = EVP_CIPHER_block_size(cipher : EVP_CIPHER) : Int32
-  fun evp_cipher_key_length = EVP_CIPHER_key_length(cipher : EVP_CIPHER) : Int32
-  fun evp_cipher_iv_length = EVP_CIPHER_iv_length(cipher : EVP_CIPHER) : Int32
+
+  {% if compare_versions(OPENSSL_VERSION, "3.0.0") >= 0 %}
+    fun evp_cipher_name = EVP_CIPHER_get_name(cipher : EVP_CIPHER) : UInt8*
+    fun evp_cipher_nid = EVP_CIPHER_get_nid(cipher : EVP_CIPHER) : Int32
+    fun evp_cipher_block_size = EVP_CIPHER_get_block_size(cipher : EVP_CIPHER) : Int32
+    fun evp_cipher_key_length = EVP_CIPHER_get_key_length(cipher : EVP_CIPHER) : Int32
+    fun evp_cipher_iv_length = EVP_CIPHER_get_iv_length(cipher : EVP_CIPHER) : Int32
+    fun evp_cipher_flags = EVP_CIPHER_get_flags(ctx : EVP_CIPHER_CTX) : CipherFlags
+  {% else %}
+    fun evp_cipher_name = EVP_CIPHER_name(cipher : EVP_CIPHER) : UInt8*
+    fun evp_cipher_nid = EVP_CIPHER_nid(cipher : EVP_CIPHER) : Int32
+    fun evp_cipher_block_size = EVP_CIPHER_block_size(cipher : EVP_CIPHER) : Int32
+    fun evp_cipher_key_length = EVP_CIPHER_key_length(cipher : EVP_CIPHER) : Int32
+    fun evp_cipher_iv_length = EVP_CIPHER_iv_length(cipher : EVP_CIPHER) : Int32
+    fun evp_cipher_flags = EVP_CIPHER_flags(ctx : EVP_CIPHER_CTX) : CipherFlags
+  {% end %}
 
   fun evp_cipher_ctx_new = EVP_CIPHER_CTX_new : EVP_CIPHER_CTX
   fun evp_cipher_ctx_free = EVP_CIPHER_CTX_free(ctx : EVP_CIPHER_CTX)
@@ -212,8 +231,6 @@ lib LibCrypto
     EVP_CIPH_FLAG_TLS1_1_MULTIBLOCK = 0x400000
     EVP_CIPH_FLAG_PIPELINE          = 0x800000
   end
-
-  fun evp_cipher_flags = EVP_CIPHER_flags(ctx : EVP_CIPHER_CTX) : CipherFlags
 
   fun hmac = HMAC(evp : EVP_MD, key : Char*, key_len : Int,
                   d : Char*, n : SizeT, md : Char*, md_len : UInt*) : Char*

--- a/src/openssl/lib_ssl.cr
+++ b/src/openssl/lib_ssl.cr
@@ -202,7 +202,11 @@ lib LibSSL
   fun ssl_ctx_set_default_verify_paths = SSL_CTX_set_default_verify_paths(ctx : SSLContext) : Int
   fun ssl_ctx_ctrl = SSL_CTX_ctrl(ctx : SSLContext, cmd : Int, larg : ULong, parg : Void*) : ULong
 
-  fun ssl_get_peer_certificate = SSL_get_peer_certificate(handle : SSL) : LibCrypto::X509
+  {% if compare_versions(OPENSSL_VERSION, "3.0.0") >= 0 %}
+    fun ssl_get_peer_certificate = SSL_get1_peer_certificate(handle : SSL) : LibCrypto::X509
+  {% else %}
+    fun ssl_get_peer_certificate = SSL_get_peer_certificate(handle : SSL) : LibCrypto::X509
+  {% end %}
 
   {% if compare_versions(OPENSSL_VERSION, "1.1.0") >= 0 %}
     fun ssl_ctx_get_options = SSL_CTX_get_options(ctx : SSLContext) : ULong

--- a/src/openssl/x509/certificate.cr
+++ b/src/openssl/x509/certificate.cr
@@ -87,7 +87,7 @@ module OpenSSL::X509
       raise ArgumentError.new "Could not find digest for #{algorithm_name.inspect}" if algo_type.null?
       hash = Bytes.new(64) # EVP_MAX_MD_SIZE for SHA512
       result = LibCrypto.x509_digest(@cert, algo_type, hash, out size)
-      raise "Could not generate certificate hash" unless result == 1
+      raise Error.new "Could not generate certificate hash" unless result == 1
 
       hash[0, size]
     end


### PR DESCRIPTION
This is a minimal patch to make our OpenSSL specs pass for the latest release OpenSSL 3.0.0 without errors and warnings. It does not necessarily add full support. Our test cases are a bit thin on some fronts, so they might not catch some behavioural changes. 
Nevertheless, this is a first step and getting it into nightly releases gives the opportunity to test the OpenSSL bindings in the wild. Make sure to install OpenSSL 3.0.0 for that.

Most of the relevant changes are just renamed methods but with consistent semantics.

A couple of algorithms have been deprecated (MD4 and RIPEMD160).

And some error messages have changed, which is relevant for our failure test which verify the specific error cause.

I also added explicit CI jobs for testing against 3.0 and 1.1.1 releases to validate compatibility.

Resolves https://github.com/crystal-lang/crystal/issues/11231