### PR TITLE
Add bindings to `__fxstat` and `__lxstat` for x86_64-linux-gnu

### DIFF
--- a/src/crystal/system/unix/file_descriptor.cr
+++ b/src/crystal/system/unix/file_descriptor.cr
@@ -64,11 +64,26 @@ module Crystal::System::FileDescriptor
   end
 
   private def system_info
-    if LibC.fstat(fd, out stat) != 0
-      raise IO::Error.from_errno("Unable to get info")
-    end
+    {% begin %}
+      # On some systems, the symbols `fstat` and `lstat` are not part of the GNU
+      # shared library `libc.so` and instead provided by `libc_noshared.a`.
+      # That makes them unavailable for dynamic runtime symbol lookup via `dlsym`
+      # which we use for interpreted mode.
+      # See https://github.com/crystal-lang/crystal/issues/11157#issuecomment-949640034 for details.
+      # Linking against the internal counterparts `__fxstat` and `__lxstat` directly
+      # should work in both interpreted and compiled mode.
+      {% if LibC.has_method?(:__fxstat) %}
+        ret = LibC.__fxstat(1, fd, out stat)
+      {% else %}
+        ret = LibC.fstat(fd, out stat)
+      {% end %}
 
-    FileInfo.new(stat)
+      if ret != 0
+        raise IO::Error.from_errno("Unable to get info")
+      end
+
+      FileInfo.new(stat)
+    {% end %}
   end
 
   private def system_seek(offset, whence : IO::Seek) : Nil

--- a/src/lib_c/x86_64-linux-gnu/c/sys/stat.cr
+++ b/src/lib_c/x86_64-linux-gnu/c/sys/stat.cr
@@ -47,6 +47,8 @@ lib LibC
   fun chmod(file : Char*, mode : ModeT) : Int
   fun fstat(fd : Int, buf : Stat*) : Int
   fun lstat(file : Char*, buf : Stat*) : Int
+  fun __fxstat(ver : Int, fd : Int, buf : Stat*) : Int
+  fun __lxstat(ver : Int, file : Char*, buf : Stat*) : Int
   fun mkdir(path : Char*, mode : ModeT) : Int
   fun mkfifo(path : Char*, mode : ModeT) : Int
   fun mknod(path : Char*, mode : ModeT, dev : DevT) : Int


### PR DESCRIPTION
On some systems, the symbols `fstat` and `lstat` are not part of the GNU `libc.so` shared library, and instead provided by `libc_noshared.a`. That makes them unavailable for dynamic runtime symbol lookup via `dlsym` which we use for interpreted mode.
See https://github.com/crystal-lang/crystal/issues/11157#issuecomment-949640034 for details.

The symbols `__fxstat` and `__lxstat` are the internal counterparts and should be available in any GNU `libc.so`. Thus it makes sense to link against those directly (which would otherwise happen through `libc_noshared.a`) because that works both in interpreted and compiled mode.

GNU libraries on other architectures (especially `aarch64`)  might be similarly affected, but I couldn't verify that yet.

Resolves #11157