### PR TITLE
Optimize `BitArray#reverse!`

### DIFF
--- a/spec/std/bit_array_spec.cr
+++ b/spec/std/bit_array_spec.cr
@@ -384,6 +384,63 @@ describe "BitArray" do
     ary.count { |b| b }.should eq(2)
   end
 
+  describe "#reverse!" do
+    it "reverses empty BitArray" do
+      ba = from_int(0, 0)
+      ba.reverse!
+      ba.should eq(from_int(0, 0))
+    end
+
+    it "reverses short BitArray" do
+      ba = from_int(5, 0b01011)
+      ba.reverse!
+      ba.should eq(from_int(5, 0b11010))
+      assert_no_unused_bits ba
+
+      ba = from_int(8, 0b11101001)
+      ba.reverse!
+      ba.should eq(from_int(8, 0b10010111))
+      assert_no_unused_bits ba
+
+      ba = from_int(20, 0b1010_00110011_00001111)
+      ba.reverse!
+      ba.should eq(from_int(20, 0b1111_00001100_11000101))
+      assert_no_unused_bits ba
+
+      ba = from_int(32, 0b11000101_00011111_11000001_00011101_u32)
+      ba.reverse!
+      ba.should eq(from_int(32, 0b10111000_10000011_11111000_10100011_u32))
+    end
+
+    it "reverses medium BitArray" do
+      ba = from_int(45, 0b00111_01001000_00000000_00000000_00000111_01001000_u64)
+      ba.reverse!
+      ba.should eq(from_int(45, 0b00010_01011100_00000000_00000000_00000010_01011100_u64))
+      assert_no_unused_bits ba
+
+      ba = from_int(64, 0b11001100_00101001_01111010_10110001_10111111_00100101_11101100_10101010_u64)
+      ba.reverse!
+      ba.should eq(from_int(64, 0b01010101_00110111_10100100_11111101_10001101_01011110_10010100_00110011_u64))
+    end
+
+    it "reverses large BitArray" do
+      ba = BitArray.new(200)
+      ba[0] = ba[2] = ba[5] = ba[11] = ba[64] = ba[103] = ba[193] = ba[194] = true
+      ba.reverse!
+      ba2 = BitArray.new(200)
+      ba2[199] = ba2[197] = ba2[194] = ba2[188] = ba2[135] = ba2[96] = ba2[6] = ba2[5] = true
+      ba.should eq(ba2)
+      assert_no_unused_bits ba
+
+      ba = BitArray.new(256)
+      ba[0] = ba[2] = ba[5] = ba[11] = ba[64] = ba[103] = ba[193] = ba[194] = true
+      ba.reverse!
+      ba2 = BitArray.new(256)
+      ba2[255] = ba2[253] = ba2[250] = ba2[244] = ba2[191] = ba2[152] = ba2[62] = ba2[61] = true
+      ba.should eq(ba2)
+    end
+  end
+
   describe "#rotate!" do
     it "rotates empty BitArray" do
       assert_rotates! from_int(0, 0), from_int(0, 0)

--- a/src/intrinsics.cr
+++ b/src/intrinsics.cr
@@ -25,6 +25,11 @@ lib LibIntrinsics
   {% end %}
 
   fun read_cycle_counter = "llvm.readcyclecounter" : UInt64
+
+  fun bitreverse64 = "llvm.bitreverse.i64"(id : UInt64) : UInt64
+  fun bitreverse32 = "llvm.bitreverse.i32"(id : UInt32) : UInt32
+  fun bitreverse16 = "llvm.bitreverse.i16"(id : UInt16) : UInt16
+
   fun bswap32 = "llvm.bswap.i32"(id : UInt32) : UInt32
   fun bswap16 = "llvm.bswap.i16"(id : UInt16) : UInt16
 
@@ -91,6 +96,18 @@ module Intrinsics
 
   def self.read_cycle_counter
     LibIntrinsics.read_cycle_counter
+  end
+
+  def self.bitreverse64(id) : UInt64
+    LibIntrinsics.bitreverse64(id)
+  end
+
+  def self.bitreverse32(id) : UInt32
+    LibIntrinsics.bitreverse32(id)
+  end
+
+  def self.bitreverse16(id) : UInt16
+    LibIntrinsics.bitreverse16(id)
   end
 
   def self.bswap32(id) : UInt32


### PR DESCRIPTION
With `BitArray#reverse!` available through `Indexable::Mutable`, this PR adds a much more performant implementation through the addition of the `llvm.bitreverse.*` intrinsics. These intrinsics are available in all LLVM releases supported by Crystal ([latest](https://llvm.org/docs/LangRef.html#llvm-bitreverse-intrinsics) down to [3.8](https://releases.llvm.org/3.8.0/docs/LangRef.html#llvm-bitreverse-intrinsics)).

On large `BitArray`s, this new implementation is ~20x faster for sizes that are multiples of 32, ~13x faster for sizes that aren't. On small `BitArray`s this becomes a constant-time operation. Benchmarks:

```crystal
require "benchmark"
require "bit_array"

struct BitArray
  # implementation from `Indexable::Mutable`
  def reverse_old! : self
    return self if size <= 1

    index0 = 0
    index1 = size - 1

    while index0 < index1
      swap(index0, index1)
      index0 += 1
      index1 -= 1
    end

    self
  end
end

module A
  @@ba = uninitialized BitArray
  def self.ba; @@ba; end
  def self.ba=(@@ba); end
end

N = {0, 1, 2, 4, 5, 8, 10, 16, 32, 50, 64, 100, 128, 256, 500, 512, 1000, 1024, 2048, 4096, 5000}

N.each do |n|
  A.ba = BitArray.new(n)
  A.ba.map! { rand > 0.5 }

  Benchmark.ips do |b|
    b.report("old #{n}") do
      A.ba.reverse_old!
    end

    b.report("new #{n}") do
      A.ba.reverse!
    end
  end
end
```

![reverse](https://user-images.githubusercontent.com/1361918/138679404-29a2ebf2-63eb-4bc6-9126-f30b321cc0a1.png)
