### PR TITLE
Fix node locations for `ProcLiteral`s with parameters

### DIFF
--- a/spec/compiler/parser/parser_spec.cr
+++ b/spec/compiler/parser/parser_spec.cr
@@ -2162,6 +2162,14 @@ module Crystal
         name_location.column_number.should eq(12)
       end
 
+      it "sets correct location of proc literal" do
+        parser = Parser.new("->(\n  x : Int32,\n  y : String\n) { }")
+        node = parser.parse.as(ProcLiteral)
+        loc = node.location.not_nil!
+        loc.line_number.should eq(1)
+        loc.column_number.should eq(1)
+      end
+
       it "doesn't override yield with macro yield" do
         parser = Parser.new("def foo; yield 1; {% begin %} yield 1 {% end %}; end")
         a_def = parser.parse.as(Def)

--- a/src/compiler/crystal/syntax/parser.cr
+++ b/src/compiler/crystal/syntax/parser.cr
@@ -1782,10 +1782,10 @@ module Crystal
       if @token.type == :"("
         next_token_skip_space_or_newline
         while @token.type != :")"
-          location = @token.location
-          arg = parse_fun_literal_arg.at(location)
+          param_location = @token.location
+          arg = parse_fun_literal_arg.at(param_location)
           if args.any? &.name.==(arg.name)
-            raise "duplicated proc literal parameter name: #{arg.name}", location
+            raise "duplicated proc literal parameter name: #{arg.name}", param_location
           end
 
           args << arg


### PR DESCRIPTION
The location of a `ProcLiteral` AST node refers to the last parameter of the literal (if it exists) due to a shadowed local variable in the parser:

```crystal
macro f(x)
  {% puts "#{(x.filename || "??").id}:#{x.line_number || "??"}:#{x.column_number || "??"}" %}
end

f(-> { })            # => eval:5:3
f(->() { })          # => eval:6:3
f(->(x : Int32) { }) # => eval:7:6
f(->(
  x : Int32,
  y : String
) { })               # => eval:10:3
```

This PR makes it so that the locations always refer to the `->`:

```crystal
f(-> { })            # => eval:5:3
f(->() { })          # => eval:6:3
f(->(x : Int32) { }) # => eval:7:3
f(->(
  x : Int32,
  y : String
) { })               # => eval:8:3
```