### PR TITLE
Refactor `Indexable::Mutable#fill`'s overloads

### DIFF
--- a/spec/std/array_spec.cr
+++ b/spec/std/array_spec.cr
@@ -698,173 +698,34 @@ describe "Array" do
   end
 
   describe "#fill" do
-    it "replaces all values" do
-      a = ['a', 'b', 'c']
-      expected = ['x', 'x', 'x']
-      a.fill('x').should be(a)
-      a.should eq(expected)
+    it "replaces values in a subrange" do
+      a = [0, 1, 2, 3, 4]
+      a.fill(7).should be(a)
+      a.should eq([7, 7, 7, 7, 7])
 
-      a = [1, 2, 3]
-      expected = [0, 0, 0]
-      a.fill(0).should be(a)
-      a.should eq(expected)
+      a = [0, 1, 2, 3, 4]
+      a.fill(7, 1, 2).should be(a)
+      a.should eq([0, 7, 7, 3, 4])
 
-      a = [1.0, 2.0, 3.0]
-      expected = [0.0, 0.0, 0.0]
-      a.fill(0.0).should be(a)
-      a.should eq(expected)
-    end
+      a = [0, 1, 2, 3, 4]
+      a.fill(7, 2..3).should be(a)
+      a.should eq([0, 1, 7, 7, 4])
 
-    it "replaces only values between index and size" do
-      a = ['a', 'b', 'c']
-      expected = ['x', 'x', 'c']
-      a.fill('x', 0, 2).should be(a)
-      a.should eq(expected)
+      a = [0, 0, 0, 0, 0]
+      a.fill { |i| i + 7 }.should be(a)
+      a.should eq([7, 8, 9, 10, 11])
 
-      a = [1, 2, 3]
-      expected = [0, 0, 3]
-      a.fill(0, 0, 2).should be(a)
-      a.should eq(expected)
+      a = [0, 0, 0, 0, 0]
+      a.fill(offset: 2) { |i| i * i }.should be(a)
+      a.should eq([4, 9, 16, 25, 36])
 
-      a = [1.0, 2.0, 3.0]
-      expected = [0, 0, 3]
-      a.fill(0, 0, 2).should be(a)
-      a.should eq(expected)
-    end
+      a = [0, 0, 0, 0, 0]
+      a.fill(1, 2) { |i| i + 7 }.should be(a)
+      a.should eq([0, 8, 9, 0, 0])
 
-    it "replaces only values between index and size (2)" do
-      a = ['a', 'b', 'c']
-      expected = ['a', 'x', 'x']
-      a.fill('x', 1, 2).should be(a)
-      a.should eq(expected)
-
-      a = [1, 2, 3]
-      expected = [1, 0, 0]
-      a.fill(0, 1, 2).should be(a)
-      a.should eq(expected)
-
-      a = [1.0, 2.0, 3.0]
-      expected = [1, 0, 0]
-      a.fill(0, 1, 2).should be(a)
-      a.should eq(expected)
-    end
-
-    it "replaces all values from index onwards" do
-      a = ['a', 'b', 'c']
-      expected = ['a', 'x', 'x']
-      a.fill('x', -2).should be(a)
-      a.should eq(expected)
-
-      a = [1, 2, 3]
-      expected = [1, 0, 0]
-      a.fill(0, -2).should be(a)
-      a.should eq(expected)
-
-      a = [1.0, 2.0, 3.0]
-      expected = [1, 0, 0]
-      a.fill(0, -2).should be(a)
-      a.should eq(expected)
-    end
-
-    it "raises when given big negative number (#4539)" do
-      expect_raises(IndexError) do
-        ['a', 'b', 'c'].fill('x', -4)
-      end
-      expect_raises(IndexError) do
-        [1, 2, 3].fill(0, -4)
-      end
-      expect_raises(IndexError) do
-        [1.0, 2.0, 3.0].fill(0, -4)
-      end
-    end
-
-    it "replaces only values between negative index and size" do
-      a = ['a', 'b', 'c']
-      expected = ['a', 'b', 'x']
-      a.fill('x', -1, 1).should be(a)
-      a.should eq(expected)
-
-      a = [1, 2, 3]
-      expected = [1, 2, 0]
-      a.fill(0, -1, 1).should be(a)
-      a.should eq(expected)
-
-      a = [1.0, 2.0, 3.0]
-      expected = [1, 2, 0]
-      a.fill(0, -1, 1).should be(a)
-      a.should eq(expected)
-    end
-
-    it "raises when given big negative number in from/count (#4539)" do
-      expect_raises(IndexError) do
-        ['a', 'b', 'c'].fill('x', -4, 1)
-      end
-      expect_raises(IndexError) do
-        [1, 2, 3].fill(0, -4, 1)
-      end
-      expect_raises(IndexError) do
-        [1.0, 2.0, 3.0].fill(0, -4, 1)
-      end
-    end
-
-    it "replaces only values in range" do
-      a = ['a', 'b', 'c']
-      expected = ['x', 'x', 'c']
-      a.fill('x', -3..1).should be(a)
-      a.should eq(expected)
-
-      a = [1, 2, 3]
-      expected = [0, 0, 3]
-      a.fill(0, -3..1).should be(a)
-      a.should eq(expected)
-
-      a = [1.0, 2.0, 3.0]
-      expected = [0, 0, 3]
-      a.fill(0, -3..1).should be(a)
-      a.should eq(expected)
-    end
-
-    it "replaces only values in range without end" do
-      a = ['a', 'b', 'c']
-      expected = ['a', 'x', 'x']
-      a.fill('x', 1..nil).should be(a)
-      a.should eq(expected)
-
-      a = [1, 2, 3]
-      expected = [1, 0, 0]
-      a.fill(0, 1..nil).should be(a)
-      a.should eq(expected)
-
-      a = [1.0, 2.0, 3.0]
-      expected = [1, 0, 0]
-      a.fill(0, 1..nil).should be(a)
-      a.should eq(expected)
-    end
-
-    it "replaces only values in range begin" do
-      a = ['a', 'b', 'c']
-      expected = ['x', 'x', 'c']
-      a.fill('x', nil..1).should be(a)
-      a.should eq(expected)
-
-      a = [1, 2, 3]
-      expected = [0, 0, 3]
-      a.fill(0, nil..1).should be(a)
-      a.should eq(expected)
-
-      a = [1.0, 2.0, 3.0]
-      expected = [0, 0, 3]
-      a.fill(0, nil..1).should be(a)
-      a.should eq(expected)
-    end
-
-    it "works with a block" do
-      a = [3, 6, 9]
-      a.clone.fill { 0 }.should eq([0, 0, 0])
-      a.clone.fill { |i| i }.should eq([0, 1, 2])
-      a.clone.fill(1) { |i| i ** i }.should eq([3, 1, 4])
-      a.clone.fill(1, 1) { |i| i ** i }.should eq([3, 1, 9])
-      a.clone.fill(1..1) { |i| i ** i }.should eq([3, 1, 9])
+      a = [0, 0, 0, 0, 0]
+      a.fill(2..3) { |i| i + 7 }.should be(a)
+      a.should eq([0, 0, 9, 10, 0])
     end
   end
 

--- a/spec/std/indexable/mutable_spec.cr
+++ b/spec/std/indexable/mutable_spec.cr
@@ -161,39 +161,179 @@ describe Indexable::Mutable do
     context "without block" do
       it "sets all elements to the same value" do
         coll = SafeIndexableMutable.new(5)
-        coll.fill(4)
+        coll.fill(4).should be(coll)
         coll.to_a.should eq([4, 4, 4, 4, 4])
 
         coll = SafeIndexableMutableFoo.new(5)
         foo = Foo.new
-        coll.fill(foo)
+        coll.fill(foo).should be(coll)
         coll.to_a.should eq([foo, foo, foo, foo, foo])
+      end
+    end
+
+    context "without block, with start + count" do
+      it "sets a subrange of elements to the same value" do
+        coll = SafeIndexableMutable.new(5)
+        coll.fill(7, 2, 2).should be(coll)
+        coll.to_a.should eq([0, 1, 7, 7, 4])
+
+        coll = SafeIndexableMutableFoo.new(5)
+        foos = coll.to_a
+        foo = Foo.new
+        coll.fill(foo, -4, 2).should be(coll)
+        coll.to_a.should eq([foos[0], foo, foo, foos[3], foos[4]])
+      end
+
+      it "sets zero elements" do
+        coll = SafeIndexableMutable.new(5)
+        coll.fill(7, 1, 0).to_a.should eq([0, 1, 2, 3, 4])
+        coll.fill(7, 5, 0).to_a.should eq([0, 1, 2, 3, 4])
+        coll.fill(7, -3, 0).to_a.should eq([0, 1, 2, 3, 4])
+        coll.fill(7, -5, 0).to_a.should eq([0, 1, 2, 3, 4])
+        coll.fill(7, 4, -1).to_a.should eq([0, 1, 2, 3, 4])
+
+        coll = SafeIndexableMutableFoo.new(5)
+        foo = Foo.new
+        coll.fill(foo, 1, 0).includes?(foo).should be_false
+        coll.fill(foo, 5, 0).includes?(foo).should be_false
+        coll.fill(foo, -3, 0).includes?(foo).should be_false
+        coll.fill(foo, -5, 0).includes?(foo).should be_false
+        coll.fill(foo, 4, -1).includes?(foo).should be_false
+      end
+
+      it "raises on out of bound start index" do
+        expect_raises(IndexError) { SafeIndexableMutable.new(5).fill(7, 6, 1) }
+        expect_raises(IndexError) { SafeIndexableMutable.new(5).fill(7, -6, 1) }
+      end
+    end
+
+    context "without block, with range" do
+      it "sets a subrange of elements to the same value" do
+        coll = SafeIndexableMutable.new(5)
+        coll.fill(7, 2..3).should be(coll)
+        coll.to_a.should eq([0, 1, 7, 7, 4])
+
+        coll = SafeIndexableMutableFoo.new(5)
+        foos = coll.to_a
+        foo = Foo.new
+        coll.fill(foo, -4...-2).should be(coll)
+        coll.to_a.should eq([foos[0], foo, foo, foos[3], foos[4]])
+      end
+
+      it "sets zero elements" do
+        coll = SafeIndexableMutable.new(5)
+        coll.fill(7, 1..0).to_a.should eq([0, 1, 2, 3, 4])
+        coll.fill(7, 5...5).to_a.should eq([0, 1, 2, 3, 4])
+        coll.fill(7, -3...1).to_a.should eq([0, 1, 2, 3, 4])
+        coll.fill(7, -5..-6).to_a.should eq([0, 1, 2, 3, 4])
+
+        coll = SafeIndexableMutableFoo.new(5)
+        foo = Foo.new
+        coll.fill(foo, 1..0).includes?(foo).should be_false
+        coll.fill(foo, 5...5).includes?(foo).should be_false
+        coll.fill(foo, -3...1).includes?(foo).should be_false
+        coll.fill(foo, -5..-6).includes?(foo).should be_false
+      end
+
+      it "raises on out of bound start index" do
+        expect_raises(IndexError) { SafeIndexableMutable.new(5).fill(7, 6..7) }
+        expect_raises(IndexError) { SafeIndexableMutable.new(5).fill(7, -6..-1) }
       end
     end
 
     context "with block" do
       it "yields index to the block and sets all elements" do
-        coll = SafeIndexableMutable.new(5)
-        coll.fill { |i| i * i }
+        coll = SafeIndexableMutable.new(5, offset: 10)
+        coll.fill { |i| i * i }.should be(coll)
         coll.to_a.should eq([0, 1, 4, 9, 16])
 
         coll = SafeIndexableMutableFoo.new(5)
         foo = Foo.new
-        coll.fill { foo }
+        coll.fill { foo }.should be(coll)
         coll.to_a.should eq([foo, foo, foo, foo, foo])
       end
     end
 
     context "with block + offset" do
       it "yields index plus offset to the block and sets all elements" do
-        coll = SafeIndexableMutable.new(5)
-        coll.fill(offset: 7) { |i| i * i }
+        coll = SafeIndexableMutable.new(5, offset: 10)
+        coll.fill(offset: 7) { |i| i * i }.should be(coll)
         coll.to_a.should eq([49, 64, 81, 100, 121])
 
         coll = SafeIndexableMutableFoo.new(5)
         foos = coll.to_a
-        coll.fill(offset: -2) { |i| foos[i] }
+        coll.fill(offset: -2) { |i| foos[i] }.should be(coll)
         coll.to_a.should eq([foos[-2], foos[-1], foos[0], foos[1], foos[2]])
+      end
+    end
+
+    context "with block + start + count" do
+      it "yields index to the block and sets elements in a subrange" do
+        coll = SafeIndexableMutable.new(5, offset: 10)
+        coll.fill(2, 2) { |i| i + 7 }.should be(coll)
+        coll.to_a.should eq([10, 11, 9, 10, 14])
+
+        coll = SafeIndexableMutableFoo.new(5)
+        foos = coll.to_a
+        foo = Foo.new
+        coll.fill(-4, 2) { foo }.should be(coll)
+        coll.to_a.should eq([foos[0], foo, foo, foos[3], foos[4]])
+      end
+
+      it "sets zero elements" do
+        coll = SafeIndexableMutable.new(5, offset: 10)
+        coll.fill(1, 0) { |i| i + 7 }.to_a.should eq([10, 11, 12, 13, 14])
+        coll.fill(5, 0) { |i| i + 7 }.to_a.should eq([10, 11, 12, 13, 14])
+        coll.fill(-3, 0) { |i| i + 7 }.to_a.should eq([10, 11, 12, 13, 14])
+        coll.fill(-5, 0) { |i| i + 7 }.to_a.should eq([10, 11, 12, 13, 14])
+        coll.fill(4, -1) { |i| i + 7 }.to_a.should eq([10, 11, 12, 13, 14])
+
+        coll = SafeIndexableMutableFoo.new(5)
+        foo = Foo.new
+        coll.fill(1, 0) { foo }.includes?(foo).should be_false
+        coll.fill(5, 0) { foo }.includes?(foo).should be_false
+        coll.fill(-3, 0) { foo }.includes?(foo).should be_false
+        coll.fill(-5, 0) { foo }.includes?(foo).should be_false
+        coll.fill(4, -1) { foo }.includes?(foo).should be_false
+      end
+
+      it "raises on out of bound start index" do
+        expect_raises(IndexError) { SafeIndexableMutable.new(5).fill(6, 1, &.itself) }
+        expect_raises(IndexError) { SafeIndexableMutable.new(5).fill(-6, 1, &.itself) }
+      end
+    end
+
+    context "with block + range" do
+      it "yields index to the block and sets elements in a subrange" do
+        coll = SafeIndexableMutable.new(5, offset: 10)
+        coll.fill(2..3) { |i| i + 7 }.should be(coll)
+        coll.to_a.should eq([10, 11, 9, 10, 14])
+
+        coll = SafeIndexableMutableFoo.new(5)
+        foos = coll.to_a
+        foo = Foo.new
+        coll.fill(-4...-2) { foo }.should be(coll)
+        coll.to_a.should eq([foos[0], foo, foo, foos[3], foos[4]])
+      end
+
+      it "sets zero elements" do
+        coll = SafeIndexableMutable.new(5, offset: 10)
+        coll.fill(1..0) { |i| i + 7 }.to_a.should eq([10, 11, 12, 13, 14])
+        coll.fill(5...5) { |i| i + 7 }.to_a.should eq([10, 11, 12, 13, 14])
+        coll.fill(-3...1) { |i| i + 7 }.to_a.should eq([10, 11, 12, 13, 14])
+        coll.fill(-5..-6) { |i| i + 7 }.to_a.should eq([10, 11, 12, 13, 14])
+
+        coll = SafeIndexableMutableFoo.new(5)
+        foo = Foo.new
+        coll.fill(1..0) { foo }.includes?(foo).should be_false
+        coll.fill(5...5) { foo }.includes?(foo).should be_false
+        coll.fill(-3...1) { foo }.includes?(foo).should be_false
+        coll.fill(-5..-6) { foo }.includes?(foo).should be_false
+      end
+
+      it "raises on out of bound start index" do
+        expect_raises(IndexError) { SafeIndexableMutable.new(5).fill(6..7, &.itself) }
+        expect_raises(IndexError) { SafeIndexableMutable.new(5).fill(-6..-1, &.itself) }
       end
     end
   end

--- a/spec/std/static_array_spec.cr
+++ b/spec/std/static_array_spec.cr
@@ -81,22 +81,34 @@ describe "StaticArray" do
   end
 
   describe "#fill" do
-    it "replaces all values, without block" do
-      a = StaticArray(Int32, 3).new { |i| i + 1 }
-      expected = StaticArray[0, 0, 0]
-      a.fill(0).should eq(expected)
-      a.should eq(expected)
+    it "replaces values in a subrange" do
+      a = StaticArray[0, 1, 2, 3, 4]
+      a.fill(7)
+      a.should eq(StaticArray[7, 7, 7, 7, 7])
 
-      expected = StaticArray[2, 2, 2]
-      a.fill(2).should eq(expected)
-      a.should eq(expected)
-    end
+      a = StaticArray[0, 1, 2, 3, 4]
+      a.fill(7, 1, 2)
+      a.should eq(StaticArray[0, 7, 7, 3, 4])
 
-    it "replaces all values, with block" do
-      a = StaticArray(Int32, 4).new { |i| i + 1 }
-      expected = StaticArray[0, 1, 4, 9]
-      a.fill { |i| i * i }.should eq(expected)
-      a.should eq(expected)
+      a = StaticArray[0, 1, 2, 3, 4]
+      a.fill(7, 2..3)
+      a.should eq(StaticArray[0, 1, 7, 7, 4])
+
+      a = StaticArray[0, 0, 0, 0, 0]
+      a.fill { |i| i + 7 }
+      a.should eq(StaticArray[7, 8, 9, 10, 11])
+
+      a = StaticArray[0, 0, 0, 0, 0]
+      a.fill(offset: 2) { |i| i * i }
+      a.should eq(StaticArray[4, 9, 16, 25, 36])
+
+      a = StaticArray[0, 0, 0, 0, 0]
+      a.fill(1, 2) { |i| i + 7 }
+      a.should eq(StaticArray[0, 8, 9, 0, 0])
+
+      a = StaticArray[0, 0, 0, 0, 0]
+      a.fill(2..3) { |i| i + 7 }
+      a.should eq(StaticArray[0, 0, 9, 10, 0])
     end
   end
 

--- a/src/indexable/mutable.cr
+++ b/src/indexable/mutable.cr
@@ -43,7 +43,8 @@ module Indexable::Mutable(T)
   # Yields the current element at the given *index* and updates the value
   # at that *index* with the block's value. Returns the new value.
   #
-  # Raises `IndexError` if trying to set an element outside the array's range.
+  # Raises `IndexError` if trying to set an element outside the container's
+  # range.
   #
   # ```
   # array = [1, 2, 3]
@@ -114,6 +115,44 @@ module Indexable::Mutable(T)
     self
   end
 
+  # Replaces *count* or less (if there aren't enough) elements starting at the
+  # given *start* index with *value*. Returns `self`.
+  #
+  # Negative values of *start* count from the end of the container.
+  #
+  # Raises `IndexError` if the *start* index is out of range.
+  #
+  # Raises `ArgumentError` if *count* is negative.
+  #
+  # ```
+  # array = [1, 2, 3, 4, 5]
+  # array.fill(9, 2, 2) # => [1, 2, 9, 9, 5]
+  # array               # => [1, 2, 9, 9, 5]
+  # ```
+  def fill(value : T, start : Int, count : Int) : self
+    return self if count <= 0
+    start, count = normalize_start_and_count(start, count)
+    count.times do |i|
+      unsafe_put(start + i, value)
+    end
+    self
+  end
+
+  # Replaces the elements within the given *range* with *value*. Returns `self`.
+  #
+  # Negative indices count backward from the end of the container.
+  #
+  # Raises `IndexError` if the starting index is out of range.
+  #
+  # ```
+  # array = [1, 2, 3, 4, 5]
+  # array.fill(9, 2..3) # => [1, 2, 9, 9, 5]
+  # array               # => [1, 2, 9, 9, 5]
+  # ```
+  def fill(value : T, range : Range) : self
+    fill(value, *Indexable.range_to_index_and_count(range, size) || raise IndexError.new)
+  end
+
   # Yields each index of `self` to the given block and then assigns
   # the block's value in that position. Returns `self`.
   #
@@ -132,6 +171,46 @@ module Indexable::Mutable(T)
       unsafe_put(i, yield offset + i)
     end
     self
+  end
+
+  # Yields each index of `self`, starting at *start* and for *count* times (or
+  # less if there aren't enough elements), to the given block and then assigns
+  # the block's value in that position. Returns `self`.
+  #
+  # Negative values of *start* count from the end of the container.
+  #
+  # Has no effect if *count* is zero or negative.
+  #
+  # Raises `IndexError` if *start* is outside the array range.
+  #
+  # ```
+  # a = [1, 2, 3, 4, 5, 6]
+  # a.fill(2, 3) { |i| i * i * i } # => [1, 2, 8, 27, 125, 6]
+  # ```
+  def fill(start : Int, count : Int, & : Int32 -> T) : self
+    return self if count <= 0
+    start, count = normalize_start_and_count(start, count)
+    count.times do |i|
+      unsafe_put(start + i, yield start + i)
+    end
+    self
+  end
+
+  # Yields each index of `self`, in the given *range*, to the given block and
+  # then assigns the block's value in that position. Returns `self`.
+  #
+  # Negative indices count backward from the end of the container.
+  #
+  # Raises `IndexError` if the starting index is out of range.
+  #
+  # ```
+  # a = [1, 2, 3, 4, 5, 6]
+  # a.fill(2..4) { |i| i * i * i } # => [1, 2, 8, 27, 125, 6]
+  # ```
+  def fill(range : Range, & : Int32 -> T) : self
+    fill(*Indexable.range_to_index_and_count(range, size) || raise IndexError.new) do |i|
+      yield i
+    end
   end
 
   # Invokes the given block for each element of `self`, replacing the element

--- a/src/slice.cr
+++ b/src/slice.cr
@@ -406,9 +406,43 @@ struct Slice(T)
   # :inherit:
   #
   # Raises if this slice is read-only.
+  def fill(value : T, start : Int, count : Int) : self
+    # since `#[]` requires exactly *count* elements but we allow fewer here, we
+    # must normalize the indices beforehand
+    start, count = normalize_start_and_count(start, count)
+    self[start, count].fill(value)
+    self
+  end
+
+  # :inherit:
+  #
+  # Raises if this slice is read-only.
+  def fill(value : T, range : Range) : self
+    fill(value, *Indexable.range_to_index_and_count(range, size) || raise IndexError.new)
+  end
+
+  # :inherit:
+  #
+  # Raises if this slice is read-only.
   def fill(*, offset : Int = 0, & : Int32 -> T) : self
     check_writable
     super { |i| yield i }
+  end
+
+  # :inherit:
+  #
+  # Raises if this slice is read-only.
+  def fill(start : Int, count : Int, & : Int32 -> T) : self
+    check_writable
+    super(start, count) { |i| yield i }
+  end
+
+  # :inherit:
+  #
+  # Raises if this slice is read-only.
+  def fill(range : Range, & : Int32 -> T) : self
+    check_writable
+    super(range) { |i| yield i }
   end
 
   def copy_from(source : Pointer(T), count)

--- a/src/static_array.cr
+++ b/src/static_array.cr
@@ -140,6 +140,18 @@ struct StaticArray(T, N)
     self
   end
 
+  # :inherit:
+  def fill(value : T, start : Int, count : Int) : self
+    to_slice.fill(value, start, count)
+    self
+  end
+
+  # :inherit:
+  def fill(value : T, range : Range) : self
+    to_slice.fill(value, range)
+    self
+  end
+
   # Returns a new static array where elements are mapped by the given block.
   #
   # ```


### PR DESCRIPTION
This PR reworks `Indexable::Mutable#fill`'s overloads so that they follow the convention of other subrange-accepting methods in the Crystal standard library.

* The following overloads are now available in `Indexable::Mutable(T)`:
  * `#fill(value : T, start : Int, count : Int)`
  * `#fill(value : T, range : Range)`
  * `#fill(start : Int, count : Int, & : Int32 -> T)`
  * `#fill(range : Range, & : Int32 -> T)`
* `Array(T)#fill(value : T, start : Int)` and `Array(T)#fill(start : Int, & : Int32 -> T)` are now deprecated. They are redundant because the `Range` overloads take care of them with a `start..` argument; no other method in the standard library has such an overload on top of `start + count` and `range` ones.
* Having `start == size` or `start + count > size` no longer raise an exception. `#fill` will now replace fewer than `count` elements in that case (possibly zero). This is also the behaviour in Ruby.
* The non-block overloads in `Array` and `StaticArray` delegate to their underlying `Slice`s to take advantage of the `memset` optimization. This includes also the subrange-accepting overloads.