### PR TITLE
Be more strict about `ProcNotation` variable declarations

### DIFF
--- a/spec/compiler/semantic/const_spec.cr
+++ b/spec/compiler/semantic/const_spec.cr
@@ -451,6 +451,22 @@ describe "Semantic: const" do
       "A is not a type, it's a constant"
   end
 
+  it "errors if using const in proc notation parameter type" do
+    assert_error <<-CR, "A is not a type, it's a constant"
+      A = 1
+
+      x : A ->
+      CR
+  end
+
+  it "errors if using const in proc notation return type" do
+    assert_error <<-CR, "A is not a type, it's a constant"
+      A = 1
+
+      x : -> A
+      CR
+  end
+
   it "errors if using return inside constant value (#5391)" do
     assert_error %(
       class Foo

--- a/spec/compiler/semantic/proc_spec.cr
+++ b/spec/compiler/semantic/proc_spec.cr
@@ -782,6 +782,14 @@ describe "Semantic: proc" do
         ),
         "can't use #{type} as a Proc argument type"
     end
+
+    it "disallows #{type} in proc notation parameter type" do
+      assert_error "x : #{type} ->", "can't use #{type} as a Proc argument type"
+    end
+
+    it "disallows #{type} in proc notation return type" do
+      assert_error "x : -> #{type}", "can't use #{type} as a Proc argument type"
+    end
   end
 
   describe "Class" do
@@ -814,6 +822,30 @@ describe "Semantic: proc" do
         ),
         "can't use Object as a Proc argument type"
     end
+
+    it "disallows Class in proc notation parameter type" do
+      assert_error "x : Class ->", "can't use Class as a Proc argument type"
+    end
+
+    it "disallows Class in proc notation return type" do
+      assert_error "x : -> Class", "can't use Class as a Proc argument type"
+    end
+  end
+
+  it "allows metaclass in proc notation parameter type" do
+    assert_type(<<-CR) { proc_of(int32.metaclass, nil_type) }
+      #{proc_new}
+
+      x : Int32.class -> = Proc(Int32.class, Nil).new { }
+      x
+      CR
+  end
+
+  it "allows metaclass in proc notation return type" do
+    assert_type(<<-CR) { proc_of(int32.metaclass) }
+      x : -> Int32.class = ->{ Int32 }
+      x
+      CR
   end
 
   it "..." do


### PR DESCRIPTION
The following is an error:

```crystal
x : -> Int32.class = ->{ Int32 } # Error: type must be Proc(Int32), not Proc(Int32.class)
```

Here the `Int32.class` is already read as a type expression. This PR removes an incorrect conversion to `Int32.class`'s instance type.

This PR also now disallows the following `ProcNotation`s, because they would have been rejected if they were rewritten into their equivalent `Proc` instances:

```crystal
x : -> Reference # ditto for similar base types like Object and Number
x : Array ->     # uninstantiated generics
x : -> ARGV      # constants
```

No `Proc`s with these argument types could possibly be constructed, so this shouldn't be a breaking change. Resolves part of #11371.