### PR TITLE
Add `Crystal::Macros::ProcNotation#resolve` and `#resolve?`

### DIFF
--- a/spec/compiler/macro/macro_methods_spec.cr
+++ b/spec/compiler/macro/macro_methods_spec.cr
@@ -2077,6 +2077,24 @@ module Crystal
       it "gets empty output" do
         assert_macro "x", %({{x.output}}), [ProcNotation.new([Path.new("SomeType")] of ASTNode)] of ASTNode, "nil"
       end
+
+      it "executes resolve" do
+        assert_macro "x", %({{x.resolve}}), [ProcNotation.new(([Path.new("Int32")] of ASTNode), Path.new("String"))] of ASTNode, %(Proc(Int32, String))
+
+        expect_raises(Crystal::TypeException, "undefined constant Foo") do
+          assert_macro "x", %({{x.resolve}}), [ProcNotation.new(([Path.new("Foo")] of ASTNode))] of ASTNode, %()
+        end
+
+        expect_raises(Crystal::TypeException, "undefined constant Foo") do
+          assert_macro "x", %({{x.resolve}}), [ProcNotation.new(([] of ASTNode), Path.new("Foo"))] of ASTNode, %()
+        end
+      end
+
+      it "executes resolve?" do
+        assert_macro "x", %({{x.resolve?}}), [ProcNotation.new(([Path.new("Int32")] of ASTNode), Path.new("String"))] of ASTNode, %(Proc(Int32, String))
+        assert_macro "x", %({{x.resolve?}}), [ProcNotation.new(([Path.new("Foo")] of ASTNode))] of ASTNode, %(nil)
+        assert_macro "x", %({{x.resolve?}}), [ProcNotation.new(([] of ASTNode), Path.new("Foo"))] of ASTNode, %(nil)
+      end
     end
 
     describe "proc literal methods" do

--- a/spec/compiler/macro/macro_methods_spec.cr
+++ b/spec/compiler/macro/macro_methods_spec.cr
@@ -2055,21 +2055,21 @@ module Crystal
       end
 
       it "executes resolve" do
-        assert_macro "x", %({{x.resolve}}), [ProcNotation.new(([Path.new("Int32")] of ASTNode), Path.new("String"))] of ASTNode, %(Proc(Int32, String))
+        assert_macro %({{x.resolve}}), "Proc(Int32, String)", {x: ProcNotation.new(([Path.new("Int32")] of ASTNode), Path.new("String"))}
 
-        expect_raises(Crystal::TypeException, "undefined constant Foo") do
-          assert_macro "x", %({{x.resolve}}), [ProcNotation.new(([Path.new("Foo")] of ASTNode))] of ASTNode, %()
+        assert_macro_error(%({{x.resolve}}), "undefined constant Foo") do
+          {x: ProcNotation.new(([Path.new("Foo")] of ASTNode))}
         end
 
-        expect_raises(Crystal::TypeException, "undefined constant Foo") do
-          assert_macro "x", %({{x.resolve}}), [ProcNotation.new(([] of ASTNode), Path.new("Foo"))] of ASTNode, %()
+        assert_macro_error(%({{x.resolve}}), "undefined constant Foo") do
+          {x: ProcNotation.new(([] of ASTNode), Path.new("Foo"))}
         end
       end
 
       it "executes resolve?" do
-        assert_macro "x", %({{x.resolve?}}), [ProcNotation.new(([Path.new("Int32")] of ASTNode), Path.new("String"))] of ASTNode, %(Proc(Int32, String))
-        assert_macro "x", %({{x.resolve?}}), [ProcNotation.new(([Path.new("Foo")] of ASTNode))] of ASTNode, %(nil)
-        assert_macro "x", %({{x.resolve?}}), [ProcNotation.new(([] of ASTNode), Path.new("Foo"))] of ASTNode, %(nil)
+        assert_macro %({{x.resolve?}}), "Proc(Int32, String)", {x: ProcNotation.new(([Path.new("Int32")] of ASTNode), Path.new("String"))}
+        assert_macro %({{x.resolve?}}), "nil", {x: ProcNotation.new(([Path.new("Foo")] of ASTNode))}
+        assert_macro %({{x.resolve?}}), "nil", {x: ProcNotation.new(([] of ASTNode), Path.new("Foo"))}
       end
     end
 

--- a/src/compiler/crystal/macros.cr
+++ b/src/compiler/crystal/macros.cr
@@ -1098,6 +1098,16 @@ module Crystal::Macros
     # Returns the output type, or nil if there is no return type.
     def output : ASTNode | NilLiteral
     end
+
+    # Resolves this proc notation to a `TypeNode` if it denotes a type,
+    # or otherwise gives a compile-time error.
+    def resolve : ASTNode
+    end
+
+    # Resolves this proc notation to a `TypeNode` if it denotes a type,
+    # or otherwise returns a `NilLiteral`.
+    def resolve? : ASTNode | NilLiteral
+    end
   end
 
   # A method definition.

--- a/src/compiler/crystal/macros/interpreter.cr
+++ b/src/compiler/crystal/macros/interpreter.cr
@@ -485,12 +485,12 @@ module Crystal
       end
     end
 
-    def resolve(node : Generic)
+    def resolve(node : Generic | ProcNotation)
       type = @path_lookup.lookup_type(node, self_type: @scope, free_vars: @free_vars)
       TypeNode.new(type)
     end
 
-    def resolve?(node : Generic)
+    def resolve?(node : Generic | ProcNotation)
       resolve(node)
     rescue Crystal::CodeError
       nil

--- a/src/compiler/crystal/macros/methods.cr
+++ b/src/compiler/crystal/macros/methods.cr
@@ -1175,6 +1175,10 @@ module Crystal
         interpret_check_args { ArrayLiteral.new(@inputs || [] of ASTNode) }
       when "output"
         interpret_check_args { @output || NilLiteral.new }
+      when "resolve"
+        interpret_check_args { interpreter.resolve(self) }
+      when "resolve?"
+        interpret_check_args { interpreter.resolve?(self) || NilLiteral.new }
       else
         super
       end


### PR DESCRIPTION
`ProcNotation`s represent type names, so it makes sense that they should have the `#resolve` and `#resolve?` macro methods. In particular, they may appear in `TypeDeclaration`s, so the following is now allowed:

```crystal
macro foo(node)
  {{ node.type.resolve }}
end

foo(x : Int32 -> String) # => Proc(Int32, String)
```
