### PR TITLE
Replace lib version comparisons by functional feature checks

### DIFF
--- a/src/openssl.cr
+++ b/src/openssl.cr
@@ -70,7 +70,7 @@ module OpenSSL
     alias Options = LibSSL::Options
     alias VerifyMode = LibSSL::VerifyMode
     alias ErrorType = LibSSL::SSLError
-    {% if compare_versions(LibSSL::OPENSSL_VERSION, "1.0.2") >= 0 %}
+    {% if LibCrypto.has_constant?(:X509VerifyFlags) %}
       alias X509VerifyFlags = LibCrypto::X509VerifyFlags
     {% end %}
 

--- a/src/openssl/bio.cr
+++ b/src/openssl/bio.cr
@@ -3,7 +3,7 @@ require "./lib_crypto"
 # :nodoc:
 struct OpenSSL::BIO
   def self.get_data(bio) : Void*
-    {% if compare_versions(LibCrypto::OPENSSL_VERSION, "1.1.0") >= 0 %}
+    {% if LibCrypto.has_method?(:BIO_get_data) %}
       LibCrypto.BIO_get_data(bio)
     {% else %}
       bio.value.ptr
@@ -11,7 +11,7 @@ struct OpenSSL::BIO
   end
 
   def self.set_data(bio, data : Void*)
-    {% if compare_versions(LibCrypto::OPENSSL_VERSION, "1.1.0") >= 0 %}
+    {% if LibCrypto.has_method?(:BIO_set_data) %}
       LibCrypto.BIO_set_data(bio, data)
     {% else %}
       bio.value.ptr = data
@@ -65,7 +65,7 @@ struct OpenSSL::BIO
     end
 
     create = LibCrypto::BioMethodCreate.new do |bio|
-      {% if compare_versions(LibCrypto::OPENSSL_VERSION, "1.1.0") >= 0 %}
+      {% if LibCrypto.has_method?(:BIO_set_shutdown) %}
         LibCrypto.BIO_set_shutdown(bio, 1)
         LibCrypto.BIO_set_init(bio, 1)
         # bio.value.num = -1
@@ -82,10 +82,10 @@ struct OpenSSL::BIO
       1
     end
 
-    {% if compare_versions(LibCrypto::OPENSSL_VERSION, "1.1.0") >= 0 %}
+    {% if LibCrypto.has_method?(:BIO_meth_new) %}
       biom = LibCrypto.BIO_meth_new(Int32::MAX, "Crystal BIO")
 
-      {% if compare_versions(LibCrypto::OPENSSL_VERSION, "1.1.1") >= 0 %}
+      {% if LibCrypto.has_method?(:BIO_meth_set_write_ex) %}
         LibCrypto.BIO_meth_set_write_ex(biom, bwrite_ex)
         LibCrypto.BIO_meth_set_read_ex(biom, bread_ex)
       {% else %}

--- a/src/openssl/pkcs5.cr
+++ b/src/openssl/pkcs5.cr
@@ -11,7 +11,7 @@ module OpenSSL::PKCS5
   end
 
   def self.pbkdf2_hmac(secret, salt, iterations = 2**16, algorithm : OpenSSL::Algorithm = OpenSSL::Algorithm::SHA1, key_size = 64) : Bytes
-    {% if compare_versions(LibSSL::OPENSSL_VERSION, "1.0.0") >= 0 %}
+    {% if LibCrypto.has_method?(:pkcs5_pbkdf2_hmac) %}
       evp = algorithm.to_evp
       buffer = Bytes.new(key_size)
       if LibCrypto.pkcs5_pbkdf2_hmac(secret, secret.bytesize, salt, salt.bytesize, iterations, evp, key_size, buffer) != 1

--- a/src/openssl/ssl/context.cr
+++ b/src/openssl/ssl/context.cr
@@ -9,7 +9,7 @@ require "log"
 abstract class OpenSSL::SSL::Context
   # :nodoc:
   def self.default_method
-    {% if compare_versions(LibSSL::OPENSSL_VERSION, "1.1.0") >= 0 %}
+    {% if LibSSL.has_method?(:tls_method) %}
       LibSSL.tls_method
     {% else %}
       LibSSL.sslv23_method
@@ -43,7 +43,7 @@ abstract class OpenSSL::SSL::Context
       super(method)
 
       self.verify_mode = OpenSSL::SSL::VerifyMode::PEER
-      {% if compare_versions(LibSSL::OPENSSL_VERSION, "1.0.2") >= 0 %}
+      {% if LibSSL.has_method?(:x509_verify_param_lookup) %}
         self.default_verify_param = "ssl_server"
       {% end %}
 
@@ -123,7 +123,7 @@ abstract class OpenSSL::SSL::Context
       super(method)
 
       add_options(OpenSSL::SSL::Options::CIPHER_SERVER_PREFERENCE)
-      {% if compare_versions(LibSSL::OPENSSL_VERSION, "1.0.2") >= 0 %}
+      {% if LibSSL.has_method?(:x509_verify_param_lookup) %}
         self.default_verify_param = "ssl_client"
       {% end %}
 
@@ -168,7 +168,7 @@ abstract class OpenSSL::SSL::Context
     # So if you have that kind of behavior (clients that never read) call this method.
     def disable_session_resume_tickets : Nil
       add_options(OpenSSL::SSL::Options::NO_TICKET) # TLS v1.2 and below
-      {% if compare_versions(LibSSL::OPENSSL_VERSION, "1.1.1") >= 0 %}
+      {% if LibSSL.has_method?(:ssl_ctx_set_num_tickets) %}
         ret = LibSSL.ssl_ctx_set_num_tickets(self, 0) # TLS v1.3
         raise OpenSSL::Error.new("SSL_CTX_set_num_tickets") if ret != 1
       {% end %}
@@ -268,7 +268,7 @@ abstract class OpenSSL::SSL::Context
   #
   # See `#security_level=` for some sensible system configuration.
   def cipher_suites=(cipher_suites : String)
-    {% if compare_versions(LibSSL::OPENSSL_VERSION, "1.1.1") >= 0 %}
+    {% if LibSSL.has_method?(:ssl_ctx_set_ciphersuites) %}
       ret = LibSSL.ssl_ctx_set_ciphersuites(@handle, cipher_suites)
       raise OpenSSL::Error.new("SSL_CTX_set_ciphersuites") if ret == 0
     {% else %}
@@ -281,7 +281,7 @@ abstract class OpenSSL::SSL::Context
   # recommendations. See `CIPHERS_MODERN` and `CIPHER_SUITES_MODERN`. See `#security_level=` for some
   # sensible system configuration.
   def set_modern_ciphers
-    {% if compare_versions(LibSSL::OPENSSL_VERSION, "1.1.1") >= 0 %}
+    {% if LibSSL.has_method?(:ssl_ctx_set_ciphersuites) %}
       self.cipher_suites = CIPHER_SUITES_MODERN
     {% else %}
       self.ciphers = CIPHERS_MODERN
@@ -292,7 +292,7 @@ abstract class OpenSSL::SSL::Context
   # recommendations. See `CIPHERS_INTERMEDIATE` and `CIPHER_SUITES_INTERMEDIATE`. See `#security_level=` for some
   # sensible system configuration.
   def set_intermediate_ciphers
-    {% if compare_versions(LibSSL::OPENSSL_VERSION, "1.1.1") >= 0 %}
+    {% if LibSSL.has_method?(:ssl_ctx_set_ciphersuites) %}
       self.cipher_suites = CIPHER_SUITES_INTERMEDIATE
     {% else %}
       self.ciphers = CIPHERS_INTERMEDIATE
@@ -303,7 +303,7 @@ abstract class OpenSSL::SSL::Context
   # recommendations. See `CIPHERS_OLD` and `CIPHER_SUITES_OLD`. See `#security_level=` for some
   # sensible system configuration.
   def set_old_ciphers
-    {% if compare_versions(LibSSL::OPENSSL_VERSION, "1.1.1") >= 0 %}
+    {% if LibSSL.has_method?(:ssl_ctx_set_ciphersuites) %}
       self.cipher_suites = CIPHER_SUITES_OLD
     {% else %}
       self.ciphers = CIPHERS_OLD
@@ -312,7 +312,7 @@ abstract class OpenSSL::SSL::Context
 
   # Returns the security level used by this TLS context.
   def security_level : Int32
-    {% if compare_versions(LibSSL::OPENSSL_VERSION, "1.1.0") >= 0 %}
+    {% if LibSSL.has_method?(:ssl_ctx_get_security_level) %}
       LibSSL.ssl_ctx_get_security_level(@handle)
     {% else %}
       Log.warn { "SSL_CTX_get_security_level not supported" }
@@ -326,7 +326,7 @@ abstract class OpenSSL::SSL::Context
   # * https://www.openssl.org/docs/man1.1.1/man3/SSL_CTX_set_security_level.html
   # * https://wiki.debian.org/ContinuousIntegration/TriagingTips/openssl-1.1.1
   def security_level=(value : Int32)
-    {% if compare_versions(LibSSL::OPENSSL_VERSION, "1.1.0") >= 0 %}
+    {% if LibSSL.has_method?(:ssl_ctx_set_security_level) %}
       LibSSL.ssl_ctx_set_security_level(@handle, value)
     {% else %}
       Log.warn { "SSL_CTX_set_security_level not supported" }
@@ -360,7 +360,7 @@ abstract class OpenSSL::SSL::Context
 
   # Returns the current options set on the TLS context.
   def options : LibSSL::Options
-    opts = {% if compare_versions(LibSSL::OPENSSL_VERSION, "1.1.0") >= 0 %}
+    opts = {% if LibSSL.has_method?(:ssl_ctx_get_options) %}
              LibSSL.ssl_ctx_get_options(@handle)
            {% else %}
              LibSSL.ssl_ctx_ctrl(@handle, LibSSL::SSL_CTRL_OPTIONS, 0, nil)
@@ -379,7 +379,7 @@ abstract class OpenSSL::SSL::Context
   # )
   # ```
   def add_options(options : OpenSSL::SSL::Options)
-    opts = {% if compare_versions(LibSSL::OPENSSL_VERSION, "1.1.0") >= 0 %}
+    opts = {% if LibSSL.has_method?(:ssl_ctx_set_options) %}
              LibSSL.ssl_ctx_set_options(@handle, options)
            {% else %}
              LibSSL.ssl_ctx_ctrl(@handle, LibSSL::SSL_CTRL_OPTIONS, options, nil)
@@ -394,7 +394,7 @@ abstract class OpenSSL::SSL::Context
   # context.remove_options(OpenSSL::SSL::Options::NO_SSL_V3)
   # ```
   def remove_options(options : OpenSSL::SSL::Options)
-    opts = {% if compare_versions(LibSSL::OPENSSL_VERSION, "1.1.0") >= 0 %}
+    opts = {% if LibSSL.has_method?(:ssl_ctx_clear_options) %}
              LibSSL.ssl_ctx_clear_options(@handle, options)
            {% else %}
              LibSSL.ssl_ctx_ctrl(@handle, LibSSL::SSL_CTRL_CLEAR_OPTIONS, options, nil)
@@ -412,25 +412,25 @@ abstract class OpenSSL::SSL::Context
     LibSSL.ssl_ctx_set_verify(@handle, mode, nil)
   end
 
-  {% if compare_versions(LibSSL::OPENSSL_VERSION, "1.0.2") >= 0 %}
-    @alpn_protocol : Pointer(Void)?
+  @alpn_protocol : Pointer(Void)?
 
-    # Specifies an ALPN protocol to negotiate with the remote endpoint. This is
-    # required to negotiate HTTP/2 with browsers, since browser vendors decided
-    # not to implement HTTP/2 over insecure connections.
-    #
-    # Example:
-    # ```
-    # context.alpn_protocol = "h2"
-    # ```
-    def alpn_protocol=(protocol : String)
-      proto = Bytes.new(protocol.bytesize + 1)
-      proto[0] = protocol.bytesize.to_u8
-      protocol.to_slice.copy_to(proto.to_unsafe + 1, protocol.bytesize)
-      self.alpn_protocol = proto
-    end
+  # Specifies an ALPN protocol to negotiate with the remote endpoint. This is
+  # required to negotiate HTTP/2 with browsers, since browser vendors decided
+  # not to implement HTTP/2 over insecure connections.
+  #
+  # Example:
+  # ```
+  # context.alpn_protocol = "h2"
+  # ```
+  def alpn_protocol=(protocol : String)
+    proto = Bytes.new(protocol.bytesize + 1)
+    proto[0] = protocol.bytesize.to_u8
+    protocol.to_slice.copy_to(proto.to_unsafe + 1, protocol.bytesize)
+    self.alpn_protocol = proto
+  end
 
-    private def alpn_protocol=(protocol : Bytes)
+  private def alpn_protocol=(protocol : Bytes)
+    {% if LibSSL.has_method?(:ssl_ctx_set_alpn_select_cb) %}
       alpn_cb = ->(ssl : LibSSL::SSL, o : LibC::Char**, olen : LibC::Char*, i : LibC::Char*, ilen : LibC::Int, data : Void*) {
         proto = Box(Bytes).unbox(data)
         ret = LibSSL.ssl_select_next_proto(o, olen, proto, 2, i, ilen)
@@ -442,27 +442,37 @@ abstract class OpenSSL::SSL::Context
       }
       @alpn_protocol = alpn_protocol = Box.box(protocol)
       LibSSL.ssl_ctx_set_alpn_select_cb(@handle, alpn_cb, alpn_protocol)
-    end
+    {% else %}
+      raise NotImplementedError.new("LibSSL.ssl_ctx_set_alpn_select_cb")
+    {% end %}
+  end
 
-    # Sets this context verify param to the default one of the given name.
-    #
-    # Depending on the OpenSSL version, the available defaults are
-    # `default`, `pkcs7`, `smime_sign`, `ssl_client` and `ssl_server`.
-    def default_verify_param=(name : String)
+  # Sets this context verify param to the default one of the given name.
+  #
+  # Depending on the OpenSSL version, the available defaults are
+  # `default`, `pkcs7`, `smime_sign`, `ssl_client` and `ssl_server`.
+  def default_verify_param=(name : String)
+    {% if LibSSL.has_method?(:x509_verify_param_lookup) %}
       param = LibCrypto.x509_verify_param_lookup(name)
       raise ArgumentError.new("#{name} is an unsupported default verify param") unless param
       ret = LibSSL.ssl_ctx_set1_param(@handle, param)
       raise OpenSSL::Error.new("SSL_CTX_set1_param") unless ret == 1
-    end
+    {% else %}
+      raise NotImplementedError.new("LibSSL.x509_verify_param_lookup")
+    {% end %}
+  end
 
-    # Sets the given `OpenSSL::SSL::X509VerifyFlags` in this context, additionally to
-    # the already set ones.
-    def add_x509_verify_flags(flags : OpenSSL::SSL::X509VerifyFlags)
+  # Sets the given `OpenSSL::SSL::X509VerifyFlags` in this context, additionally to
+  # the already set ones.
+  def add_x509_verify_flags(flags : OpenSSL::SSL::X509VerifyFlags)
+    {% if LibSSL.has_method?(:x509_verify_param_set_flags) %}
       param = LibSSL.ssl_ctx_get0_param(@handle)
       ret = LibCrypto.x509_verify_param_set_flags(param, flags)
       raise OpenSSL::Error.new("X509_VERIFY_PARAM_set_flags)") unless ret == 1
-    end
-  {% end %}
+    {% else %}
+      raise NotImplementedError.new("LibSSL.x509_verify_param_set_flags")
+    {% end %}
+  end
 
   def to_unsafe
     @handle

--- a/src/openssl/x509/certificate.cr
+++ b/src/openssl/x509/certificate.cr
@@ -62,7 +62,7 @@ module OpenSSL::X509
 
     # Returns the name of the signature algorithm.
     def signature_algorithm : String
-      {% if compare_versions(LibSSL::OPENSSL_VERSION, "1.0.2") >= 0 %}
+      {% if LibCrypto.has_method?(:obj_find_sigid_algs) %}
         sigid = LibCrypto.x509_get_signature_nid(@cert)
         result = LibCrypto.obj_find_sigid_algs(sigid, out algo_nid, nil)
         raise "Could not determine certificate signature algorithm" if result == 0


### PR DESCRIPTION
We don't need to check the library version at the binding definition and    call site again. Checking the availability of lib methods is easier    and enables cross-library usability (libressl and openssl define the    same functions).

This also fixes differences in the API of SSL::Context depending on the    library version. Stdlib APIs must be consistent. Some methods that were    missing when linking against older library versions now raise    NotImplementedError at runtime.
