### PR TITLE
Restrict virtual metaclasses to themselves against `Class`

### DIFF
--- a/spec/compiler/semantic/virtual_metaclass_spec.cr
+++ b/spec/compiler/semantic/virtual_metaclass_spec.cr
@@ -148,4 +148,17 @@ describe "Semantic: virtual metaclass" do
       foo(Bar)
       ") { types["Bar"].metaclass }
   end
+
+  it "restricts virtual metaclass to Class (#11376)" do
+    assert_type(<<-CR) { nilable types["Foo"].virtual_type.metaclass }
+      class Foo
+      end
+
+      class Bar < Foo
+      end
+
+      x = Foo || Bar
+      x if x.is_a?(Class)
+      CR
+  end
 end

--- a/src/compiler/crystal/semantic/type_intersect.cr
+++ b/src/compiler/crystal/semantic/type_intersect.cr
@@ -81,6 +81,9 @@ module Crystal
       # A module class can't be restricted into a class
       return nil if type1.instance_type.module?
 
+      # `T+.class` is always a subtype of `Class`
+      return type2 if type1 == type1.program.class_type
+
       restricted = common_descendent(type1.instance_type, type2.instance_type.base_type)
       restricted.try(&.metaclass)
     end


### PR DESCRIPTION
Fixes #11376.