### PR TITLE
Refer to `T.class` as "metaclass" in error messages, not "class"

### DIFF
--- a/spec/compiler/semantic/class_spec.cr
+++ b/spec/compiler/semantic/class_spec.cr
@@ -1115,6 +1115,18 @@ describe "Semantic: class" do
       "Moo is not a class, it's a module"
   end
 
+  it "errors if inherits from metaclass" do
+    assert_error <<-CR, "Foo.class is not a class, it's a metaclass"
+      class Foo
+      end
+
+      alias FooClass = Foo.class
+
+      class Bar < FooClass
+      end
+      CR
+  end
+
   it "can use short name for top-level type" do
     assert_type(%(
       class T

--- a/spec/compiler/semantic/metaclass_spec.cr
+++ b/spec/compiler/semantic/metaclass_spec.cr
@@ -246,4 +246,28 @@ describe "Semantic: metaclass" do
       bar_class.implements?(foo_class).should be_false
     end
   end
+
+  it "can't reopen as struct" do
+    assert_error <<-CR, "Bar is not a struct, it's a metaclass"
+      class Foo
+      end
+
+      alias Bar = Foo.class
+
+      struct Bar
+      end
+      CR
+  end
+
+  it "can't reopen as module" do
+    assert_error <<-CR, "Bar is not a module, it's a metaclass"
+      class Foo
+      end
+
+      alias Bar = Foo.class
+
+      module Bar
+      end
+      CR
+  end
 end

--- a/spec/compiler/semantic/sizeof_spec.cr
+++ b/spec/compiler/semantic/sizeof_spec.cr
@@ -48,6 +48,15 @@ describe "Semantic: sizeof" do
       "instance_sizeof can only be used with a class, but Moo is a module"
   end
 
+  it "gives error if using instance_sizeof on a metaclass" do
+    assert_error <<-CR, "instance_sizeof can only be used with a class, but Foo.class is a metaclass"
+      class Foo
+      end
+
+      instance_sizeof(Foo.class)
+      CR
+  end
+
   it "gives error if using instance_sizeof on a generic type without type vars" do
     assert_error "instance_sizeof(Array)", "can't take instance_sizeof uninstantiated generic type Array(T)"
   end

--- a/src/compiler/crystal/semantic/cleanup_transformer.cr
+++ b/src/compiler/crystal/semantic/cleanup_transformer.cr
@@ -861,8 +861,8 @@ module Crystal
       exp_type = node.exp.type?
 
       if exp_type
-        instance_type = exp_type.instance_type.devirtualize
-        if instance_type.struct? || instance_type.module? || instance_type.is_a?(UnionType)
+        instance_type = exp_type.devirtualize
+        if instance_type.struct? || instance_type.module? || instance_type.metaclass? || instance_type.is_a?(UnionType)
           node.exp.raise "instance_sizeof can only be used with a class, but #{instance_type} is a #{instance_type.type_desc}"
         end
       end

--- a/src/compiler/crystal/semantic/main_visitor.cr
+++ b/src/compiler/crystal/semantic/main_visitor.cr
@@ -2518,7 +2518,7 @@ module Crystal
       # Try to resolve the instance_sizeof right now to a number literal
       # (useful for sizeof inside as a generic type argument, but also
       # to make it easier for LLVM to optimize things)
-      if type && type.instance_type.devirtualize.class? && !node.exp.is_a?(TypeOf)
+      if type && type.devirtualize.class? && !type.metaclass? && !node.exp.is_a?(TypeOf)
         expanded = NumberLiteral.new(@program.instance_size_of(type.sizeof_type).to_s, :i32)
         expanded.type = @program.int32
         node.expanded = expanded

--- a/src/compiler/crystal/semantic/top_level_visitor.cr
+++ b/src/compiler/crystal/semantic/top_level_visitor.cr
@@ -210,7 +210,7 @@ class Crystal::TopLevelVisitor < Crystal::SemanticVisitor
       type = type.remove_alias
 
       unless type.module?
-        node.raise "#{type} is not a module, it's a #{type.type_desc}"
+        node.raise "#{name} is not a module, it's a #{type.type_desc}"
       end
 
       if type_vars = node.type_vars

--- a/src/compiler/crystal/types.cr
+++ b/src/compiler/crystal/types.cr
@@ -2824,6 +2824,10 @@ module Crystal
     def to_s_with_options(io : IO, skip_union_parens : Bool = false, generic_args : Bool = true, codegen : Bool = false) : Nil
       io << @name
     end
+
+    def type_desc
+      "metaclass"
+    end
   end
 
   # The metaclass of a generic class instance type, like `Array(String).class`
@@ -2894,6 +2898,10 @@ module Crystal
       instance_type.to_s(io)
       io << ".class"
     end
+
+    def type_desc
+      "metaclass"
+    end
   end
 
   # The metaclass of a generic module instance type, like `Enumerable(Int32).class`
@@ -2943,6 +2951,10 @@ module Crystal
     def to_s_with_options(io : IO, skip_union_parens : Bool = false, generic_args : Bool = true, codegen : Bool = false) : Nil
       instance_type.to_s(io)
       io << ".class"
+    end
+
+    def type_desc
+      "metaclass"
     end
   end
 
@@ -3408,6 +3420,10 @@ module Crystal
     def to_s_with_options(io : IO, skip_union_parens : Bool = false, generic_args : Bool = true, codegen : Bool = false) : Nil
       instance_type.to_s_with_options(io, codegen: codegen)
       io << ".class"
+    end
+
+    def type_desc
+      "metaclass"
     end
   end
 end


### PR DESCRIPTION
Metaclasses are special in that they are classes but inherit from `Value` other than `Reference`. This produces some nonsensical error messages:

```crystal
class Foo
end

alias A = Foo.class

class B < A # Error: Foo.class is not a class, it's a class
end
```

This PR makes it so that they are reported as "metaclass" instead. Doing so also fixes an internal compiler error:

```crystal
class Foo
end

instance_sizeof(Foo.class) # BUG: called llvm_struct_type for Foo.class
```