### PR TITLE
Allow incomplete range arguments for `#[](Range)` macro methods

### DIFF
--- a/spec/compiler/macro/macro_methods_spec.cr
+++ b/spec/compiler/macro/macro_methods_spec.cr
@@ -357,12 +357,12 @@ module Crystal
       end
 
       it "executes [] with incomplete range" do
-        assert_macro "", %({{"hello"[1..]}}), [] of ASTNode, %("ello")
-        assert_macro "", %({{"hello"[1..nil]}}), [] of ASTNode, %("ello")
-        assert_macro "", %({{"hello"[...3]}}), [] of ASTNode, %("hel")
-        assert_macro "", %({{"hello"[nil...3]}}), [] of ASTNode, %("hel")
-        assert_macro "", %({{"hello"[..]}}), [] of ASTNode, %("hello")
-        assert_macro "", %({{"hello"[nil..nil]}}), [] of ASTNode, %("hello")
+        assert_macro %({{"hello"[1..]}}), %("ello")
+        assert_macro %({{"hello"[1..nil]}}), %("ello")
+        assert_macro %({{"hello"[...3]}}), %("hel")
+        assert_macro %({{"hello"[nil...3]}}), %("hel")
+        assert_macro %({{"hello"[..]}}), %("hello")
+        assert_macro %({{"hello"[nil..nil]}}), %("hello")
       end
 
       it "executes string chomp" do
@@ -827,12 +827,12 @@ module Crystal
       end
 
       it "executes [] with incomplete range" do
-        assert_macro "", %({{ [1, 2, 3, 4][1..] }}), [] of ASTNode, %([2, 3, 4])
-        assert_macro "", %({{ [1, 2, 3, 4][1..nil] }}), [] of ASTNode, %([2, 3, 4])
-        assert_macro "", %({{ [1, 2, 3, 4][...2] }}), [] of ASTNode, %([1, 2])
-        assert_macro "", %({{ [1, 2, 3, 4][nil...2] }}), [] of ASTNode, %([1, 2])
-        assert_macro "", %({{ [1, 2, 3, 4][..] }}), [] of ASTNode, %([1, 2, 3, 4])
-        assert_macro "", %({{ [1, 2, 3, 4][nil..nil] }}), [] of ASTNode, %([1, 2, 3, 4])
+        assert_macro %({{ [1, 2, 3, 4][1..] }}), %([2, 3, 4])
+        assert_macro %({{ [1, 2, 3, 4][1..nil] }}), %([2, 3, 4])
+        assert_macro %({{ [1, 2, 3, 4][...2] }}), %([1, 2])
+        assert_macro %({{ [1, 2, 3, 4][nil...2] }}), %([1, 2])
+        assert_macro %({{ [1, 2, 3, 4][..] }}), %([1, 2, 3, 4])
+        assert_macro %({{ [1, 2, 3, 4][nil..nil] }}), %([1, 2, 3, 4])
       end
 
       it "executes [] with two numbers" do
@@ -1107,20 +1107,20 @@ module Crystal
       end
 
       it "executes [] with range" do
-        assert_macro "", %({{ {1, 2, 3, 4}[1...-1] }}), [] of ASTNode, %({2, 3})
+        assert_macro %({{ {1, 2, 3, 4}[1...-1] }}), %({2, 3})
       end
 
       it "executes [] with computed range" do
-        assert_macro "", %({{ {1, 2, 3, 4}[[1].size...-1] }}), [] of ASTNode, %({2, 3})
+        assert_macro %({{ {1, 2, 3, 4}[[1].size...-1] }}), %({2, 3})
       end
 
       it "executes [] with incomplete range" do
-        assert_macro "", %({{ {1, 2, 3, 4}[1..] }}), [] of ASTNode, %({2, 3, 4})
-        assert_macro "", %({{ {1, 2, 3, 4}[1..nil] }}), [] of ASTNode, %({2, 3, 4})
-        assert_macro "", %({{ {1, 2, 3, 4}[...2] }}), [] of ASTNode, %({1, 2})
-        assert_macro "", %({{ {1, 2, 3, 4}[nil...2] }}), [] of ASTNode, %({1, 2})
-        assert_macro "", %({{ {1, 2, 3, 4}[..] }}), [] of ASTNode, %({1, 2, 3, 4})
-        assert_macro "", %({{ {1, 2, 3, 4}[nil..nil] }}), [] of ASTNode, %({1, 2, 3, 4})
+        assert_macro %({{ {1, 2, 3, 4}[1..] }}), %({2, 3, 4})
+        assert_macro %({{ {1, 2, 3, 4}[1..nil] }}), %({2, 3, 4})
+        assert_macro %({{ {1, 2, 3, 4}[...2] }}), %({1, 2})
+        assert_macro %({{ {1, 2, 3, 4}[nil...2] }}), %({1, 2})
+        assert_macro %({{ {1, 2, 3, 4}[..] }}), %({1, 2, 3, 4})
+        assert_macro %({{ {1, 2, 3, 4}[nil..nil] }}), %({1, 2, 3, 4})
       end
 
       it "executes size" do

--- a/spec/compiler/macro/macro_methods_spec.cr
+++ b/spec/compiler/macro/macro_methods_spec.cr
@@ -344,16 +344,25 @@ module Crystal
         assert_macro "", %({{"hello".empty?}}), [] of ASTNode, "false"
       end
 
-      it "executes string [Range] inclusive" do
+      it "executes [] with inclusive range" do
         assert_macro "", %({{"hello"[1..-2]}}), [] of ASTNode, %("ell")
       end
 
-      it "executes string [Range] exclusive" do
+      it "executes [] with exclusive range" do
         assert_macro "", %({{"hello"[1...-2]}}), [] of ASTNode, %("el")
       end
 
-      it "executes string [Range] inclusive (computed)" do
+      it "executes [] with computed range" do
         assert_macro "", %({{"hello"[[1].size..-2]}}), [] of ASTNode, %("ell")
+      end
+
+      it "executes [] with incomplete range" do
+        assert_macro "", %({{"hello"[1..]}}), [] of ASTNode, %("ello")
+        assert_macro "", %({{"hello"[1..nil]}}), [] of ASTNode, %("ello")
+        assert_macro "", %({{"hello"[...3]}}), [] of ASTNode, %("hel")
+        assert_macro "", %({{"hello"[nil...3]}}), [] of ASTNode, %("hel")
+        assert_macro "", %({{"hello"[..]}}), [] of ASTNode, %("hello")
+        assert_macro "", %({{"hello"[nil..nil]}}), [] of ASTNode, %("hello")
       end
 
       it "executes string chomp" do
@@ -824,6 +833,15 @@ module Crystal
         assert_macro "", %({{ [1, 2, 3, 4][[1].size...-1] }}), [] of ASTNode, %([2, 3])
       end
 
+      it "executes [] with incomplete range" do
+        assert_macro "", %({{ [1, 2, 3, 4][1..] }}), [] of ASTNode, %([2, 3, 4])
+        assert_macro "", %({{ [1, 2, 3, 4][1..nil] }}), [] of ASTNode, %([2, 3, 4])
+        assert_macro "", %({{ [1, 2, 3, 4][...2] }}), [] of ASTNode, %([1, 2])
+        assert_macro "", %({{ [1, 2, 3, 4][nil...2] }}), [] of ASTNode, %([1, 2])
+        assert_macro "", %({{ [1, 2, 3, 4][..] }}), [] of ASTNode, %([1, 2, 3, 4])
+        assert_macro "", %({{ [1, 2, 3, 4][nil..nil] }}), [] of ASTNode, %([1, 2, 3, 4])
+      end
+
       it "executes [] with two numbers" do
         assert_macro "", %({{ [1, 2, 3, 4, 5][1, 3] }}), [] of ASTNode, %([2, 3, 4])
       end
@@ -1093,16 +1111,33 @@ module Crystal
     end
 
     describe TupleLiteral do
-      it "executes index 0" do
+      it "executes [] with 0" do
         assert_macro "", %({{ {1, 2, 3}[0] }}), [] of ASTNode, "1"
       end
 
-      it "executes index 1" do
+      it "executes [] with 1" do
         assert_macro "", %({{ {1, 2, 3}[1] }}), [] of ASTNode, "2"
       end
 
-      it "executes index out of bounds" do
+      it "executes [] out of bounds" do
         assert_macro "", %({{ {1, 2, 3}[3] }}), [] of ASTNode, "nil"
+      end
+
+      it "executes [] with range" do
+        assert_macro "", %({{ {1, 2, 3, 4}[1...-1] }}), [] of ASTNode, %({2, 3})
+      end
+
+      it "executes [] with computed range" do
+        assert_macro "", %({{ {1, 2, 3, 4}[[1].size...-1] }}), [] of ASTNode, %({2, 3})
+      end
+
+      it "executes [] with incomplete range" do
+        assert_macro "", %({{ {1, 2, 3, 4}[1..] }}), [] of ASTNode, %({2, 3, 4})
+        assert_macro "", %({{ {1, 2, 3, 4}[1..nil] }}), [] of ASTNode, %({2, 3, 4})
+        assert_macro "", %({{ {1, 2, 3, 4}[...2] }}), [] of ASTNode, %({1, 2})
+        assert_macro "", %({{ {1, 2, 3, 4}[nil...2] }}), [] of ASTNode, %({1, 2})
+        assert_macro "", %({{ {1, 2, 3, 4}[..] }}), [] of ASTNode, %({1, 2, 3, 4})
+        assert_macro "", %({{ {1, 2, 3, 4}[nil..nil] }}), [] of ASTNode, %({1, 2, 3, 4})
       end
 
       it "executes size" do

--- a/src/compiler/crystal/macros.cr
+++ b/src/compiler/crystal/macros.cr
@@ -649,6 +649,10 @@ module Crystal::Macros
     def [](index : NumberLiteral) : ASTNode
     end
 
+    # Similar to `Array#[]`.
+    def [](index : RangeLiteral) : ArrayLiteral(ASTNode)
+    end
+
     # Similar to `Array#[]=`.
     def []=(index : NumberLiteral, value : ASTNode) : ASTNode
     end

--- a/src/compiler/crystal/macros/interpreter.cr
+++ b/src/compiler/crystal/macros/interpreter.cr
@@ -197,28 +197,11 @@ module Crystal
           {MacroId.new(entry.key), entry.value}
         end
       when RangeLiteral
-        exp.from.accept self
-        from = @last
-
-        unless from.is_a?(NumberLiteral)
-          node.raise "range begin #{exp.from} must evaluate to a NumberLiteral"
-        end
-
-        from = from.to_number.to_i
-
-        exp.to.accept self
-        to = @last
-
-        unless to.is_a?(NumberLiteral)
-          node.raise "range end #{exp.to} must evaluate to a NumberLiteral"
-        end
-
-        to = to.to_number.to_i
+        range = exp.interpret_to_range(self)
 
         element_var = node.vars[0]
         index_var = node.vars[1]?
 
-        range = Range.new(from, to, exp.exclusive?)
         range.each_with_index do |element, index|
           @vars[element_var.name] = NumberLiteral.new(element)
           if index_var

--- a/src/compiler/crystal/macros/methods.cr
+++ b/src/compiler/crystal/macros/methods.cr
@@ -568,20 +568,7 @@ module Crystal
         interpret_check_args do |arg|
           case arg
           when RangeLiteral
-            from, to = arg.from, arg.to
-            from = interpreter.accept(from)
-            to = interpreter.accept(to)
-
-            unless from.is_a?(NumberLiteral)
-              raise "range from in StringLiteral#[] must be a number, not #{from.class_desc}: #{from}"
-            end
-
-            unless to.is_a?(NumberLiteral)
-              raise "range to in StringLiteral#[] must be a number, not #{to.class_desc}: #{from}"
-            end
-
-            from, to = from.to_number.to_i, to = to.to_number.to_i
-            range = Range.new(from, to, arg.exclusive?)
+            range = arg.interpret_to_nilable_range(interpreter)
             StringLiteral.new(@value[range])
           else
             raise "wrong argument for StringLiteral#[] (#{arg.class_desc}): #{arg}"
@@ -1068,24 +1055,47 @@ module Crystal
     end
 
     def interpret_to_range(interpreter)
-      from = self.from
-      to = self.to
+      node = interpreter.accept(self.from)
+      from = case node
+             when NumberLiteral
+               node.to_number.to_i
+             else
+               raise "range begin must be a NumberLiteral, not #{node.class_desc}"
+             end
 
-      from = interpreter.accept(from)
-      to = interpreter.accept(to)
+      node = interpreter.accept(self.to)
+      to = case node
+           when NumberLiteral
+             node.to_number.to_i
+           else
+             raise "range end must be a NumberLiteral, not #{node.class_desc}"
+           end
 
-      unless from.is_a?(NumberLiteral)
-        raise "range begin must be a NumberLiteral, not #{from.class_desc}"
-      end
+      Range.new(from, to, self.exclusive?)
+    end
 
-      unless to.is_a?(NumberLiteral)
-        raise "range end must be a NumberLiteral, not #{to.class_desc}"
-      end
+    def interpret_to_nilable_range(interpreter)
+      node = interpreter.accept(self.from)
+      from = case node
+             when NumberLiteral
+               node.to_number.to_i
+             when NilLiteral, Nop
+               nil
+             else
+               raise "range begin must be a NumberLiteral | NilLiteral | Nop, not #{node.class_desc}"
+             end
 
-      from = from.to_number.to_i
-      to = to.to_number.to_i
+      node = interpreter.accept(self.to)
+      to = case node
+           when NumberLiteral
+             node.to_number.to_i
+           when NilLiteral, Nop
+             nil
+           else
+             raise "range end must be a NumberLiteral | NilLiteral | Nop, not #{node.class_desc}"
+           end
 
-      self.exclusive? ? (from...to) : (from..to)
+      Range.new(from, to, self.exclusive?)
     end
   end
 
@@ -2356,7 +2366,7 @@ private def interpret_array_or_tuple_method(object, klass, method, args, named_a
           index = arg.to_number.to_i
           value = object.elements[index]? || Crystal::NilLiteral.new
         when Crystal::RangeLiteral
-          range = arg.interpret_to_range(interpreter)
+          range = arg.interpret_to_nilable_range(interpreter)
           begin
             klass.new(object.elements[range])
           rescue ex


### PR DESCRIPTION
Resolves #8570.

This affects `ArrayLiteral#[]`, `StringLiteral#[]`, and `TupleLiteral#[]`; all `RangeLiteral`s in other macro contexts must still be complete ranges, in particular arguments to `for` loops. No new overloads are added.