### PR TITLE
Fix `BitArray#toggle` when toggling empty subrange

### DIFF
--- a/spec/std/bit_array_spec.cr
+++ b/spec/std/bit_array_spec.cr
@@ -366,6 +366,16 @@ describe "BitArray" do
       ary.toggle(30..35)
       ary[24..].should eq(from_int(16, 0b00110000_10100101))
     end
+
+    it "toggles zero bits correctly" do
+      ary = BitArray.new(32)
+      ary.toggle(0, 0)
+      ary.none?.should be_true
+      ary.toggle(32, 0)
+      ary.none?.should be_true
+      ary.toggle(32, 2)
+      ary.none?.should be_true
+    end
   end
 
   it "inverts all bits" do

--- a/src/bit_array.cr
+++ b/src/bit_array.cr
@@ -225,6 +225,7 @@ struct BitArray
   # ```
   def toggle(start : Int, count : Int)
     start, count = normalize_start_and_count(start, count)
+    return if count == 0
 
     start_bit_index, start_sub_index = start.divmod(32)
     end_bit_index, end_sub_index = (start + count - 1).divmod(32)


### PR DESCRIPTION
When `#toggle` is called on a `BitArray` with an empty subrange and a start index that is a multiple of 32, the method incorrectly toggles the entire `UInt32`s at and before the given start index:

```crystal
x = BitArray.new(70)
x.to_slice # => Bytes[0, 0, 0, 0, 0, 0, 0, 0, 0, 0]
x.toggle(64, 0)
x.to_slice # => Bytes[0, 0, 0, 0, 255, 255, 255, 255, 255]
# note that `x` also has its unused bits set
```

This PR fixes it by adding an early return for `count == 0`.