### PR TITLE
Fix flag for UNIX-like OS

### DIFF
--- a/src/socket/addrinfo.cr
+++ b/src/socket/addrinfo.cr
@@ -101,6 +101,10 @@ class Socket
         new(message, **opts)
       end
 
+      protected def self.new_from_os_error(message : String?, os_error, *, domain, **opts)
+        new(message, **opts)
+      end
+
       def self.build_message(message, *, domain, **opts)
         "Hostname lookup for #{domain} failed"
       end
@@ -160,7 +164,7 @@ class Socket
         {% if flag?(:unix) %}
           # EAI_SYSTEM is not defined on win32
           if ret == LibC::EAI_SYSTEM
-            raise Error.from_errno nil, Errno.value, domain: domain
+            raise Error.from_os_error nil, Errno.value, domain: domain
           end
         {% end %}
 

--- a/src/socket/addrinfo.cr
+++ b/src/socket/addrinfo.cr
@@ -157,7 +157,7 @@ class Socket
 
       ret = LibC.getaddrinfo(domain, service.to_s, pointerof(hints), out ptr)
       unless ret.zero?
-        {% if flag?(:posix) %}
+        {% if flag?(:unix) %}
           # EAI_SYSTEM is not defined on win32
           if ret == LibC::EAI_SYSTEM
             raise Error.from_errno message, domain: domain

--- a/src/socket/addrinfo.cr
+++ b/src/socket/addrinfo.cr
@@ -157,6 +157,13 @@ class Socket
 
       ret = LibC.getaddrinfo(domain, service.to_s, pointerof(hints), out ptr)
       unless ret.zero?
+        {% if flag?(:unix) %}
+          # EAI_SYSTEM is not defined on win32
+          if ret == LibC::EAI_SYSTEM
+            raise Error.from_errno nil, domain: domain
+          end
+        {% end %}
+
         error = {% if flag?(:win32) %}
                   WinError.new(ret.to_u32!)
                 {% else %}

--- a/src/socket/addrinfo.cr
+++ b/src/socket/addrinfo.cr
@@ -160,7 +160,7 @@ class Socket
         {% if flag?(:unix) %}
           # EAI_SYSTEM is not defined on win32
           if ret == LibC::EAI_SYSTEM
-            raise Error.from_errno nil, domain: domain
+            raise Error.from_errno nil, Errno.value, domain: domain
           end
         {% end %}
 

--- a/src/socket/addrinfo.cr
+++ b/src/socket/addrinfo.cr
@@ -157,13 +157,6 @@ class Socket
 
       ret = LibC.getaddrinfo(domain, service.to_s, pointerof(hints), out ptr)
       unless ret.zero?
-        {% if flag?(:unix) %}
-          # EAI_SYSTEM is not defined on win32
-          if ret == LibC::EAI_SYSTEM
-            raise Error.from_errno message, domain: domain
-          end
-        {% end %}
-
         error = {% if flag?(:win32) %}
                   WinError.new(ret.to_u32!)
                 {% else %}

--- a/src/system_error.cr
+++ b/src/system_error.cr
@@ -77,7 +77,7 @@ module SystemError
     end
 
     @[Deprecated("Use `.from_os_error` instead")]
-    def from_errno(message : String? = nil, errno : Errno = nil, **opts)
+    def from_errno(message : String? = nil, errno : Errno? = nil, **opts)
       from_os_error(message, errno, **opts)
     end
 


### PR DESCRIPTION
The flag for UNIX-like operating systems is called `unix`, not `posix`.

Fixup for #10757