### PR TITLE
Add fallback for union debug type if current debug file is not set

### DIFF
--- a/spec/compiler/codegen/debug_spec.cr
+++ b/spec/compiler/codegen/debug_spec.cr
@@ -16,6 +16,31 @@ describe "Code gen: debug" do
       ), debug: Crystal::Debug::All)
   end
 
+  it "codegens abstract struct with module include (#11385)" do
+    codegen(%(
+      module FooInterface
+      end
+
+      class Foo
+        include FooInterface
+      end
+
+      abstract struct Bar
+        include FooInterface
+
+        @a : FooInterface
+
+        def initialize(@a : FooInterface); end
+      end
+
+      class Baz
+        @b : FooInterface = Foo.new
+      end
+
+      Baz.new
+      ), debug: Crystal::Debug::All)
+  end
+
   it "inlines instance var access through getter in debug mode" do
     run(%(
       struct Bar

--- a/src/compiler/crystal/codegen/debug.cr
+++ b/src/compiler/crystal/codegen/debug.cr
@@ -76,11 +76,10 @@ module Crystal
     end
 
     def current_debug_file
-      if location = @current_debug_location
-        debug_files_cache[location.filename || "??"] ||= begin
-          file, dir = file_and_dir(location.filename)
-          di_builder.create_file(file, dir)
-        end
+      filename = @current_debug_location.try(&.filename) || "??"
+      debug_files_cache[filename] ||= begin
+        file, dir = file_and_dir(filename)
+        di_builder.create_file(file, dir)
       end
     end
 
@@ -190,7 +189,7 @@ module Crystal
 
       size = @program.target_machine.data_layout.size_in_bits(struct_type.struct_element_types[is_struct ? 0 : 1])
       offset = @program.target_machine.data_layout.offset_of_element(struct_type, 1) * 8u64
-      debug_type = di_builder.create_union_type(nil, nil, current_debug_file.not_nil!, 1, size, size, LLVM::DIFlags::Zero, di_builder.get_or_create_type_array(element_types))
+      debug_type = di_builder.create_union_type(nil, nil, current_debug_file, 1, size, size, LLVM::DIFlags::Zero, di_builder.get_or_create_type_array(element_types))
       unless is_struct
         element_types.clear
         element_types << di_builder.create_member_type(nil, "type_id", nil, 1, 32, 32, 0, LLVM::DIFlags::Zero, get_debug_type(@program.uint32))
@@ -218,7 +217,7 @@ module Crystal
       end
 
       size = @program.target_machine.data_layout.size_in_bits(struct_type)
-      debug_type = di_builder.create_union_type(nil, original_type.to_s, current_debug_file.not_nil!, 1, size, size, LLVM::DIFlags::Zero, di_builder.get_or_create_type_array(element_types))
+      debug_type = di_builder.create_union_type(nil, original_type.to_s, current_debug_file, 1, size, size, LLVM::DIFlags::Zero, di_builder.get_or_create_type_array(element_types))
       di_builder.replace_temporary(tmp_debug_type, debug_type)
       debug_type
     end


### PR DESCRIPTION
A file is required but in some contexts it seems to not be available
so we fallback to the file to the "unknown location" used elsewhere
(i.e. "??", line 1, column 1, as the other debug types do implicitly, it seems)

Fixes #11385
Might fix #11384 (will need to verify on LLVM 10)