### PR TITLE
Make all AST nodes immutable through container-returning methods

### DIFF
--- a/spec/compiler/macro/macro_methods_spec.cr
+++ b/spec/compiler/macro/macro_methods_spec.cr
@@ -2779,4 +2779,51 @@ module Crystal
       assert_macro_error %({{flag?}}), "wrong number of arguments for top-level macro 'flag?' (given 0, expected 1)"
     end
   end
+
+  describe "immutability of returned container literals (#10818)" do
+    it "Annotation#args" do
+      node = Annotation.new(Path.new("Foo"), [42.int32, "a".string] of ASTNode)
+      assert_macro %({{ (x.args << "a"; x.args.size) }}), "2", {x: node}
+    end
+
+    it "Generic#type_vars" do
+      node = Generic.new("Foo".path, ["Bar".path, "Int32".path] of ASTNode)
+      assert_macro %({{ (x.type_vars << "a"; x.type_vars.size) }}), "2", {x: node}
+    end
+
+    it "MultiAssign#targets" do
+      node = MultiAssign.new(["foo".var, "bar".var] of ASTNode, [2.int32, "a".string] of ASTNode)
+      assert_macro %({{ (x.targets << "a"; x.targets.size) }}), "2", {x: node}
+    end
+
+    it "MultiAssign#values" do
+      node = MultiAssign.new(["foo".var, "bar".var] of ASTNode, [2.int32, "a".string] of ASTNode)
+      assert_macro %({{ (x.values << "a"; x.values.size) }}), "2", {x: node}
+    end
+
+    it "ProcNotation#inputs" do
+      node = ProcNotation.new([Path.new("SomeType"), Path.new("OtherType")] of ASTNode)
+      assert_macro %({{ (x.inputs << "a"; x.inputs.size) }}), "2", {x: node}
+    end
+
+    it "ProcPointer#args" do
+      node = ProcPointer.new(Var.new("some_object"), "method", [Path.new("SomeType"), Path.new("OtherType")] of ASTNode)
+      assert_macro %({{ (x.args << "a"; x.args.size) }}), "2", {x: node}
+    end
+
+    it "StringInterpolation#expressions" do
+      node = StringInterpolation.new(["fo".string, 1.int32, "o".string] of ASTNode)
+      assert_macro %({{ (x.expressions << "a"; x.expressions.size) }}), "3", {x: node}
+    end
+
+    it "Union#types" do
+      node = Crystal::Union.new(["Int32".path, "String".path] of ASTNode)
+      assert_macro %({{ (x.types << "a"; x.types.size) }}), "2", {x: node}
+    end
+
+    it "When#conds" do
+      node = When.new([2.int32, 3.int32] of ASTNode, 4.int32)
+      assert_macro %({{ (x.conds << "a"; x.conds.size) }}), "2", {x: node}
+    end
+  end
 end

--- a/src/compiler/crystal/macros/methods.cr
+++ b/src/compiler/crystal/macros/methods.cr
@@ -785,7 +785,7 @@ module Crystal
     def interpret(method : String, args : Array(ASTNode), named_args : Hash(String, ASTNode)?, block : Crystal::Block?, interpreter : Crystal::MacroInterpreter, name_loc : Location?)
       case method
       when "expressions"
-        interpret_check_args { ArrayLiteral.new(expressions) }
+        interpret_check_args { ArrayLiteral.map(expressions, &.itself) }
       else
         super
       end
@@ -1172,7 +1172,13 @@ module Crystal
     def interpret(method : String, args : Array(ASTNode), named_args : Hash(String, ASTNode)?, block : Crystal::Block?, interpreter : Crystal::MacroInterpreter, name_loc : Location?)
       case method
       when "inputs"
-        interpret_check_args { ArrayLiteral.new(@inputs || [] of ASTNode) }
+        interpret_check_args do
+          if inputs = @inputs
+            ArrayLiteral.map(inputs, &.itself)
+          else
+            ArrayLiteral.new
+          end
+        end
       when "output"
         interpret_check_args { @output || NilLiteral.new }
       else
@@ -1200,7 +1206,7 @@ module Crystal
       when "name"
         interpret_check_args { MacroId.new(@name) }
       when "args"
-        interpret_check_args { ArrayLiteral.new(@args) }
+        interpret_check_args { ArrayLiteral.map(@args, &.itself) }
       else
         super
       end
@@ -1277,7 +1283,7 @@ module Crystal
       when "resolve?"
         interpret_check_args { interpreter.resolve?(self) || NilLiteral.new }
       when "types"
-        interpret_check_args { ArrayLiteral.new(@types) }
+        interpret_check_args { ArrayLiteral.map(@types, &.itself) }
       else
         super
       end
@@ -1954,7 +1960,7 @@ module Crystal
     def interpret(method : String, args : Array(ASTNode), named_args : Hash(String, ASTNode)?, block : Crystal::Block?, interpreter : Crystal::MacroInterpreter, name_loc : Location?)
       case method
       when "conds"
-        interpret_check_args { ArrayLiteral.new(conds) }
+        interpret_check_args { ArrayLiteral.map(conds, &.itself) }
       when "body"
         interpret_check_args { body }
       else
@@ -1980,9 +1986,9 @@ module Crystal
     def interpret(method : String, args : Array(ASTNode), named_args : Hash(String, ASTNode)?, block : Crystal::Block?, interpreter : Crystal::MacroInterpreter, name_loc : Location?)
       case method
       when "targets"
-        interpret_check_args { ArrayLiteral.new(targets) }
+        interpret_check_args { ArrayLiteral.map(targets, &.itself) }
       when "values"
-        interpret_check_args { ArrayLiteral.new(values) }
+        interpret_check_args { ArrayLiteral.map(values, &.itself) }
       else
         super
       end
@@ -2120,7 +2126,7 @@ module Crystal
       when "name"
         interpret_check_args { name }
       when "type_vars"
-        interpret_check_args { ArrayLiteral.new(type_vars) }
+        interpret_check_args { ArrayLiteral.map(type_vars, &.itself) }
       when "named_args"
         interpret_check_args do
           if named_args = @named_args
@@ -2164,7 +2170,7 @@ module Crystal
         end
       when "args"
         interpret_check_args do
-          TupleLiteral.new self.args
+          TupleLiteral.map self.args, &.itself
         end
       when "named_args"
         interpret_check_args do


### PR DESCRIPTION
Fixes #10818. The affected macro methods are:

* `Annotation#args`
* `Generic#type_vars`
* `MultiAssign#targets`, `#values`
* `ProcNotation#inputs`
* `ProcPointer#args`
* `StringInterpolation#expressions`
* `Union#types`
* `When#conds`
