### PR TITLE
[CI] Fix enable nix-command as experimental feature

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -14,6 +14,9 @@ jobs:
         uses: actions/checkout@v2
 
       - uses: cachix/install-nix-action@v12
+        with:
+          extra_nix_config: |
+            experimental-features = nix-command
       - uses: cachix/cachix-action@v8
         with:
           name: crystal-ci

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -13,11 +13,12 @@ jobs:
       - name: Download Crystal source
         uses: actions/checkout@v2
 
-      - uses: cachix/install-nix-action@v12
+      - uses: cachix/install-nix-action@v14
         with:
+          install_url: https://releases.nixos.org/nix/nix-2.4/nix-2.4-x86_64-darwin.tar.xz
           extra_nix_config: |
             experimental-features = nix-command
-      - uses: cachix/cachix-action@v8
+      - uses: cachix/cachix-action@v10
         with:
           name: crystal-ci
           signingKey: '${{ secrets.CACHIX_SIGNING_KEY }}'

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -15,7 +15,7 @@ jobs:
 
       - uses: cachix/install-nix-action@v14
         with:
-          install_url: https://releases.nixos.org/nix/nix-2.4/nix-2.4-x86_64-darwin.tar.xz
+          install_url: https://releases.nixos.org/nix/nix-2.4/install
           extra_nix_config: |
             experimental-features = nix-command
       - uses: cachix/cachix-action@v10


### PR DESCRIPTION
The newly released nix 2.4 changes `nix-command` to an experimental feature: https://nixos.wiki/wiki/Nix_command. This breaks our CI setup. It must be explicitly enabled now. (Personal note: WTF?)

This patch fixes that by adding `experimental-features = nix-command` to nix config.

Also pins the nix release to 2.4 in order to avoid such surprises in the future (could've pinned to 2.3 as well, but we might just use the newer one since it's not that hard to make it work).

Additionally, I've updated the actions (that's not necessary to make any of the above work, but it's still a good change).