### PR TITLE
Add support for DWARF 5

### DIFF
--- a/src/crystal/dwarf/abbrev.cr
+++ b/src/crystal/dwarf/abbrev.cr
@@ -165,36 +165,65 @@ module Crystal
       end
     end
 
+    # DWARF data encoding format.
     enum FORM : UInt32
-      Addr        = 0x01 # address
-      Block2      = 0x03 # block
-      Block4      = 0x04 # block
-      Data2       = 0x05 # constant
-      Data4       = 0x06 # constant
-      Data8       = 0x07 # constant
-      String      = 0x08 # string
-      Block       = 0x09 # block
-      Block1      = 0x0a # block
-      Data1       = 0x0b # constant
-      Flag        = 0x0c # flag
-      Sdata       = 0x0d # constant
-      Strp        = 0x0e # string
-      Udata       = 0x0f # constant
-      RefAddr     = 0x10 # reference
-      Ref1        = 0x11 # reference
-      Ref2        = 0x12 # reference
-      Ref4        = 0x13 # reference
-      Ref8        = 0x14 # reference
-      RefUdata    = 0x15 # reference
-      Indirect    = 0x16 # (see Section 7.5.3)
+      # value formats
+      Addr     = 0x01 # address
+      Block2   = 0x03 # block
+      Block4   = 0x04 # block
+      Data2    = 0x05 # constant
+      Data4    = 0x06 # constant
+      Data8    = 0x07 # constant
+      String   = 0x08 # string
+      Block    = 0x09 # block
+      Block1   = 0x0a # block
+      Data1    = 0x0b # constant
+      Flag     = 0x0c # flag
+      Sdata    = 0x0d # constant
+      Strp     = 0x0e # string
+      Udata    = 0x0f # constant
+      RefAddr  = 0x10 # reference
+      Ref1     = 0x11 # reference
+      Ref2     = 0x12 # reference
+      Ref4     = 0x13 # reference
+      Ref8     = 0x14 # reference
+      RefUdata = 0x15 # reference
+      Indirect = 0x16 # (see Section 7.5.3)
+
+      # The following are new in DWARF 4.
       SecOffset   = 0x17 # lineptr, loclistptr, macptr, rangelistptr
       Exprloc     = 0x18 # exprloc
       FlagPresent = 0x19 # flag
       RefSig8     = 0x20 # reference
+
+      # The following are new in DWARF 5.
+      Strx          = 0x1a
+      Addrx         = 0x1b
+      Refsup4       = 0x1c
+      StrpSup       = 0x1d
+      Data16        = 0x1e
+      LineStrp      = 0x1f
+      ImplicitConst = 0x21
+      Loclistx      = 0x22
+      Rnglistx      = 0x23
+      Refsup8       = 0x24
+      Strx1         = 0x25
+      Strx2         = 0x26
+      Strx3         = 0x27
+      Strx4         = 0x28
+      Addrx1        = 0x29
+      Addrx2        = 0x2a
+      Addrx3        = 0x2b
+      Addrx4        = 0x2c
+
+      # Extensions for multi-file compression (.dwz)
+      # http://www.dwarfstd.org/ShowIssue.php?issue=120604.1
+      GNurefalt  = 0x1f20
+      GnustrpAlt = 0x1f21
     end
 
     struct Abbrev
-      record Attribute, at : AT, form : FORM
+      record Attribute, at : AT, form : FORM, value : Int32
 
       property code : UInt32
       property tag : TAG
@@ -224,7 +253,12 @@ module Crystal
             at = AT.new(DWARF.read_unsigned_leb128(io))
             form = FORM.new(DWARF.read_unsigned_leb128(io))
             break if at.value == 0 && form.value == 0
-            abbrev.attributes << Attribute.new(at, form)
+            if form.implicit_const?
+              value = DWARF.read_signed_leb128(io)
+            else
+              value = 0
+            end
+            abbrev.attributes << Attribute.new(at, form, value)
           end
 
           abbreviations << abbrev

--- a/src/crystal/dwarf/info.cr
+++ b/src/crystal/dwarf/info.cr
@@ -6,6 +6,7 @@ module Crystal
     struct Info
       property unit_length : UInt32 | UInt64
       property version : UInt16
+      property unit_type : UInt8
       property debug_abbrev_offset : UInt32 | UInt64
       property address_size : UInt8
       property! abbreviations : Array(Abbrev)
@@ -27,8 +28,24 @@ module Crystal
 
         @offset = @io.tell
         @version = @io.read_bytes(UInt16)
-        @debug_abbrev_offset = read_ulong
-        @address_size = @io.read_byte.not_nil!
+
+        if @version < 2 || @version > 5
+          raise "Unsupported DWARF version #{@version}"
+        end
+
+        if @version >= 5
+          @unit_type = @io.read_bytes(UInt8)
+          @address_size = @io.read_bytes(UInt8)
+          @debug_abbrev_offset = read_ulong
+        else
+          @unit_type = 0
+          @debug_abbrev_offset = read_ulong
+          @address_size = @io.read_bytes(UInt8)
+        end
+
+        if @address_size.zero?
+          raise "Invalid address size: 0"
+        end
       end
 
       alias Value = Bool | Int32 | Int64 | Slice(UInt8) | String | UInt16 | UInt32 | UInt64 | UInt8
@@ -47,7 +64,7 @@ module Crystal
 
           if abbrev = abbreviations[code &- 1]? # abbreviations.find { |a| a.code == abbrev }
             abbrev.attributes.each do |attr|
-              value = read_attribute_value(attr.form)
+              value = read_attribute_value(attr.form, attr)
               attributes << {attr.at, attr.form, value}
             end
             yield code, abbrev, attributes
@@ -57,7 +74,7 @@ module Crystal
         end
       end
 
-      private def read_attribute_value(form)
+      private def read_attribute_value(form, attr)
         case form
         when FORM::Addr
           case address_size
@@ -93,6 +110,8 @@ module Crystal
           DWARF.read_signed_leb128(@io)
         when FORM::Udata
           DWARF.read_unsigned_leb128(@io)
+        when FORM::ImplicitConst
+          attr.value
         when FORM::Exprloc
           len = DWARF.read_unsigned_leb128(@io)
           @io.read_fully(bytes = Bytes.new(len))
@@ -119,7 +138,7 @@ module Crystal
           @io.read_bytes(UInt64)
         when FORM::String
           @io.gets('\0', chomp: true).to_s
-        when FORM::Strp
+        when FORM::Strp, FORM::LineStrp
           # HACK: A call to read_ulong is failing with an .ud2 / Illegal instruction: 4 error
           #       Calling with @[AlwaysInline] makes no difference.
           if @dwarf64
@@ -129,7 +148,7 @@ module Crystal
           end
         when FORM::Indirect
           form = FORM.new(DWARF.read_unsigned_leb128(@io))
-          read_attribute_value(form)
+          read_attribute_value(form, attr)
         else
           raise "Unknown DW_FORM_#{form.to_s.underscore}"
         end

--- a/src/crystal/dwarf/line_numbers.cr
+++ b/src/crystal/dwarf/line_numbers.cr
@@ -216,7 +216,7 @@ module Crystal
           sequence.version = @io.read_bytes(UInt16)
 
           if sequence.version < 2 || sequence.version > 5
-            # return Error.new("unknown line table version: #{version}")
+            raise Error.new("unknown line table version: #{version}")
           end
 
           if sequence.version >= 5
@@ -237,14 +237,14 @@ module Crystal
           end
 
           if sequence.maximum_operations_per_instruction == 0
-            # return Error.new("invalid maximum operations per instruction: 0")
+            raise Error.new("invalid maximum operations per instruction: 0")
           end
 
           sequence.default_is_stmt = @io.read_byte == 1
           sequence.line_base = @io.read_bytes(Int8).to_i
           sequence.line_range = @io.read_bytes(UInt8).to_i
           if sequence.line_range == 0
-            # return Error.new("invalid line range: 0")
+            raise Error.new("invalid line range: 0")
           end
 
           sequence.opcode_base = @io.read_bytes(UInt8).to_i
@@ -272,7 +272,6 @@ module Crystal
           if @io.tell - @offset < sequence.offset + sequence.total_length
             read_statement_program(sequence)
           end
-          # @io.pos = sequence.offset + sequence.total_length + @offset
         end
       end
 

--- a/src/crystal/dwarf/line_numbers.cr
+++ b/src/crystal/dwarf/line_numbers.cr
@@ -126,13 +126,15 @@ module Crystal
         property! offset : Int64
         property! unit_length : UInt32
         property! version : UInt16
+        property! address_size : Int32
+        property! segment_selector_size : Int32
         property! header_length : UInt32 # FIXME: UInt64 for DWARF64 (uncommon)
-        property! minimum_instruction_length : UInt8
-        property maximum_operations_per_instruction : UInt8
+        property! minimum_instruction_length : Int32
+        property! maximum_operations_per_instruction : Int32
         property! default_is_stmt : Bool
-        property! line_base : Int8
-        property! line_range : UInt8
-        property! opcode_base : UInt8
+        property! line_base : Int32
+        property! line_range : Int32
+        property! opcode_base : Int32
 
         # An array of how many args an array. Starts at 1 because 0 means an
         # extended opcode.
@@ -168,7 +170,7 @@ module Crystal
 
       @offset : Int64
 
-      def initialize(@io : IO::FileDescriptor, size, @base_address : LibC::SizeT = 0)
+      def initialize(@io : IO::FileDescriptor, size, @base_address : LibC::SizeT = 0, @strings : Strings? = nil, @line_strings : Strings? = nil)
         @offset = @io.tell
         @matrix = Array(Array(Row)).new
         decode_sequences(size)
@@ -212,25 +214,65 @@ module Crystal
           sequence.offset = offset
           sequence.unit_length = @io.read_bytes(UInt32)
           sequence.version = @io.read_bytes(UInt16)
-          sequence.header_length = @io.read_bytes(UInt32)
-          sequence.minimum_instruction_length = @io.read_byte.not_nil!
 
-          if sequence.version >= 4
-            sequence.maximum_operations_per_instruction = @io.read_byte.not_nil!
+          if sequence.version < 2 || sequence.version > 5
+            # return Error.new("unknown line table version: #{version}")
           end
 
-          sequence.default_is_stmt = @io.read_byte.not_nil! == 1
-          sequence.line_base = @io.read_bytes(Int8)
-          sequence.line_range = @io.read_byte.not_nil!
-          sequence.opcode_base = @io.read_byte.not_nil!
+          if sequence.version >= 5
+            sequence.address_size = @io.read_bytes(UInt8).to_i
+            sequence.segment_selector_size = @io.read_bytes(UInt8).to_i
+          else
+            sequence.address_size = {{ flag?(:bits64) ? 8 : 4 }}
+            sequence.segment_selector_size = 0
+          end
 
+          sequence.header_length = @io.read_bytes(UInt32)
+          sequence.minimum_instruction_length = @io.read_bytes(UInt8).to_i
+
+          if sequence.version >= 4
+            sequence.maximum_operations_per_instruction = @io.read_bytes(UInt8).to_i
+          else
+            sequence.maximum_operations_per_instruction = 1
+          end
+
+          if sequence.maximum_operations_per_instruction == 0
+            # return Error.new("invalid maximum operations per instruction: 0")
+          end
+
+          sequence.default_is_stmt = @io.read_byte == 1
+          sequence.line_base = @io.read_bytes(Int8).to_i
+          sequence.line_range = @io.read_bytes(UInt8).to_i
+          if sequence.line_range == 0
+            # return Error.new("invalid line range: 0")
+          end
+
+          sequence.opcode_base = @io.read_bytes(UInt8).to_i
           read_opcodes(sequence)
-          read_directory_table(sequence)
-          read_filename_table(sequence)
+
+          if sequence.version < 5
+            read_directory_table(sequence)
+            read_filename_table(sequence)
+          else
+            dir_format = read_lnct_format
+            count = DWARF.read_unsigned_leb128(@io)
+            count.times do
+              dir, _, _ = read_lnct(sequence, dir_format)
+              sequence.include_directories << dir
+            end
+
+            file_format = read_lnct_format
+            count = DWARF.read_unsigned_leb128(@io)
+            count.times do
+              name, mtime, size = read_lnct(sequence, file_format)
+              sequence.file_names << {name, mtime.to_i, size.to_i, 0}
+            end
+          end
 
           if @io.tell - @offset < sequence.offset + sequence.total_length
             read_statement_program(sequence)
           end
+          # @io.pos = sequence.offset + sequence.total_length + @offset
         end
       end
 
@@ -238,6 +280,100 @@ module Crystal
         1.upto(sequence.opcode_base - 1) do
           sequence.standard_opcode_lengths << @io.read_byte.not_nil!
         end
+      end
+
+      record LNCTFormat,
+        lnct : LNCT,
+        format : FORM
+
+      enum LNCT : UInt32
+        PATH            = 0x01
+        DIRECTORY_INDEX = 0x02
+        TIMESTAMP       = 0x03
+        SIZE            = 0x04
+        MD5             = 0x05
+      end
+
+      private def read_lnct_format
+        count = @io.read_bytes(UInt8)
+        Array(LNCTFormat).new(count) do
+          LNCTFormat.new(
+            lnct: LNCT.new(DWARF.read_unsigned_leb128(@io)),
+            format: FORM.new(DWARF.read_unsigned_leb128(@io))
+          )
+        end
+      end
+
+      private def read_lnct(sequence, formats)
+        dir = ""
+        path : String = ""
+        mtime : UInt64 = 0_u64
+        size : UInt64 = 0_u64
+        formats.each do |format|
+          str = nil
+          val = 0_u64
+
+          case format.format
+          when .string?
+            str = @io.gets('\0', chomp: true) # .to_s
+          when .line_strp?
+            offset = @io.read_bytes(UInt32)
+            str = @line_strings.try &.decode(offset)
+          when .strp?
+            offset = @io.read_bytes(UInt32)
+            str = @strings.try &.decode(offset)
+          when .strp_sup?
+            @io.read_bytes(UInt32)
+          when .strx?
+            # .debug_line.dwo sections not yet supported.
+            DWARF.read_unsigned_leb128(@io)
+          when .strx1?
+            @io.read_bytes(UInt8)
+          when .strx2?
+            @io.read_bytes(UInt16)
+          when .strx3?
+            @io.skip 3
+          when .strx4?
+            @io.read_bytes(UInt32)
+          when .data1?
+            val = @io.read_bytes(UInt8).to_u64
+          when .data2?
+            val = @io.read_bytes(UInt16).to_u64
+          when .data4?
+            val = @io.read_bytes(UInt32).to_u64
+          when .data8?
+            val = @io.read_bytes(UInt64)
+          when .data16?
+            @io.skip(16)
+          when .block?
+            @io.skip(DWARF.read_unsigned_leb128(@io))
+          when .udata?
+            val = DWARF.read_unsigned_leb128(@io)
+          else
+            raise "Unexpected encoding format: #{format.format}"
+          end
+
+          case format.lnct
+          in .path?
+            path = str if str
+          in .directory_index?
+            if val
+              dir = sequence.include_directories[val]
+            end
+          in .timestamp?
+            mtime = val.to_u64
+          in .size?
+            size = val.to_u64
+          in .md5?
+            # ignore
+          end
+        end
+
+        if dir != "" && path != ""
+          path = File.join(dir, path)
+        end
+
+        return path, mtime, size
       end
 
       private def read_directory_table(sequence)

--- a/src/crystal/dwarf/line_numbers.cr
+++ b/src/crystal/dwarf/line_numbers.cr
@@ -216,7 +216,7 @@ module Crystal
           sequence.version = @io.read_bytes(UInt16)
 
           if sequence.version < 2 || sequence.version > 5
-            raise Error.new("unknown line table version: #{version}")
+            raise "unknown line table version: #{version}"
           end
 
           if sequence.version >= 5
@@ -237,14 +237,14 @@ module Crystal
           end
 
           if sequence.maximum_operations_per_instruction == 0
-            raise Error.new("invalid maximum operations per instruction: 0")
+            raise "invalid maximum operations per instruction: 0"
           end
 
           sequence.default_is_stmt = @io.read_byte == 1
           sequence.line_base = @io.read_bytes(Int8).to_i
           sequence.line_range = @io.read_bytes(UInt8).to_i
           if sequence.line_range == 0
-            raise Error.new("invalid line range: 0")
+            raise "invalid line range: 0"
           end
 
           sequence.opcode_base = @io.read_bytes(UInt8).to_i

--- a/src/crystal/dwarf/line_numbers.cr
+++ b/src/crystal/dwarf/line_numbers.cr
@@ -216,7 +216,7 @@ module Crystal
           sequence.version = @io.read_bytes(UInt16)
 
           if sequence.version < 2 || sequence.version > 5
-            raise "unknown line table version: #{version}"
+            raise "unknown line table version: #{sequence.version}"
           end
 
           if sequence.version >= 5

--- a/src/crystal/dwarf/line_numbers.cr
+++ b/src/crystal/dwarf/line_numbers.cr
@@ -396,7 +396,7 @@ module Crystal
           length = DWARF.read_unsigned_leb128(@io)
 
           dir = sequence.include_directories[dir]
-          if(name != "" && dir != "")
+          if (name != "" && dir != "")
             name = File.join(dir, name)
           end
           ary << Sequence::FileEntry.new(name, time.to_u64, length.to_u64)

--- a/src/crystal/dwarf/line_numbers.cr
+++ b/src/crystal/dwarf/line_numbers.cr
@@ -285,6 +285,10 @@ module Crystal
         lnct : LNCT,
         format : FORM
 
+      # :nodoc:
+      #
+      # DWARF-defined content type codes
+      # New in DWARF 5 § 6.2.4.1
       enum LNCT : UInt32
         PATH            = 0x01
         DIRECTORY_INDEX = 0x02

--- a/src/exception/call_stack/dwarf.cr
+++ b/src/exception/call_stack/dwarf.cr
@@ -45,7 +45,7 @@ struct Exception::CallStack
     end
   end
 
-  protected def self.parse_function_names_from_dwarf(info, strings)
+  protected def self.parse_function_names_from_dwarf(info, strings, line_strings)
     info.each do |code, abbrev, attributes|
       next unless abbrev && abbrev.tag.subprogram?
       name = low_pc = high_pc = nil
@@ -54,6 +54,7 @@ struct Exception::CallStack
         case at
         when Crystal::DWARF::AT::DW_AT_name
           value = strings.try(&.decode(value.as(UInt32 | UInt64))) if form.strp?
+          value = line_strings.try(&.decode(value.as(UInt32 | UInt64))) if form.line_strp?
           name = value.as(String)
         when Crystal::DWARF::AT::DW_AT_low_pc
           low_pc = value.as(LibC::SizeT)

--- a/src/exception/call_stack/dwarf.cr
+++ b/src/exception/call_stack/dwarf.cr
@@ -29,8 +29,7 @@ struct Exception::CallStack
     load_dwarf
     if ln = @@dwarf_line_numbers
       if row = ln.find(pc)
-        path = "#{row.directory}/#{row.file}"
-        return {path, row.line, row.column}
+        return {row.path, row.line, row.column}
       end
     end
     {"??", 0, 0}

--- a/src/exception/call_stack/elf.cr
+++ b/src/exception/call_stack/elf.cr
@@ -19,12 +19,16 @@ struct Exception::CallStack
     program = Process.executable_path
     return unless program && File.readable? program
     Crystal::ELF.open(program) do |elf|
-      elf.read_section?(".debug_line") do |sh, io|
-        @@dwarf_line_numbers = Crystal::DWARF::LineNumbers.new(io, sh.size, base_address)
+      line_strings = elf.read_section?(".debug_line_str") do |sh, io|
+        Crystal::DWARF::Strings.new(io, sh.offset, sh.size)
       end
 
       strings = elf.read_section?(".debug_str") do |sh, io|
         Crystal::DWARF::Strings.new(io, sh.offset, sh.size)
+      end
+
+      elf.read_section?(".debug_line") do |sh, io|
+        @@dwarf_line_numbers = Crystal::DWARF::LineNumbers.new(io, sh.size, base_address, strings, line_strings)
       end
 
       elf.read_section?(".debug_info") do |sh, io|
@@ -37,7 +41,7 @@ struct Exception::CallStack
             info.read_abbreviations(io)
           end
 
-          parse_function_names_from_dwarf(info, strings) do |low_pc, high_pc, name|
+          parse_function_names_from_dwarf(info, strings, line_strings) do |low_pc, high_pc, name|
             names << {low_pc + base_address, high_pc + base_address, name}
           end
         end

--- a/src/exception/call_stack/mach_o.cr
+++ b/src/exception/call_stack/mach_o.cr
@@ -15,12 +15,16 @@ struct Exception::CallStack
 
   protected def self.read_dwarf_sections
     locate_dsym_bundle do |mach_o|
-      mach_o.read_section?("__debug_line") do |sh, io|
-        @@dwarf_line_numbers = Crystal::DWARF::LineNumbers.new(io, sh.size)
+      line_strings = mach_o.read_section?("__debug_line_str") do |sh, io|
+        Crystal::DWARF::Strings.new(io, sh.offset, sh.size)
       end
 
       strings = mach_o.read_section?("__debug_str") do |sh, io|
         Crystal::DWARF::Strings.new(io, sh.offset, sh.size)
+      end
+
+      mach_o.read_section?("__debug_line") do |sh, io|
+        @@dwarf_line_numbers = Crystal::DWARF::LineNumbers.new(io, sh.size, strings: strings, line_strings: line_strings)
       end
 
       mach_o.read_section?("__debug_info") do |sh, io|
@@ -33,7 +37,7 @@ struct Exception::CallStack
             info.read_abbreviations(io)
           end
 
-          parse_function_names_from_dwarf(info, strings) do |low_pc, high_pc, name|
+          parse_function_names_from_dwarf(info, strings, line_strings) do |low_pc, high_pc, name|
             names << {low_pc, high_pc, name}
           end
         end


### PR DESCRIPTION
This patch adds support for parsing DWARF 5 data. This version of the format seems to be the default with GCC 11, which breaks debug output when a Crystal program is linked with a recent GCC release.

Also adds a check to validate the DWARF version. In the future, the dwarf reader will error when it encounters an unknown version number. This makes the problem obvious instead of silently failing because of incompatible changes.

Resolves #11192