### PR TITLE
Restore libressl support and add CI for that

### DIFF
--- a/.github/workflows/openssl.yml
+++ b/.github/workflows/openssl.yml
@@ -12,7 +12,7 @@ jobs:
         uses: actions/checkout@v2
       - name: Install openssl 3.0
         run: apk add "openssl-dev=~3.0" --repository=http://dl-cdn.alpinelinux.org/alpine/edge/main
-      - name: Check OpenSSL version
+      - name: Check LibSSL version
         run: bin/crystal eval 'require "openssl"; p! LibSSL::OPENSSL_VERSION, LibSSL::LIBRESSL_VERSION'
       - name: Run OpenSSL specs
         run: bin/crystal spec spec/std/openssl/
@@ -25,8 +25,40 @@ jobs:
         uses: actions/checkout@v2
       - name: Install openssl 1.1.1
         run: apk add "openssl-dev=~1.1.1"
-      - name: Check OpenSSL version
+      - name: Check LibSSL version
         run: bin/crystal eval 'require "openssl"; p! LibSSL::OPENSSL_VERSION, LibSSL::LIBRESSL_VERSION'
       - name: Run OpenSSL specs
         run: bin/crystal spec spec/std/openssl/
-
+  libressl31:
+    runs-on: ubuntu-latest
+    name: "LibreSSL 3.1"
+    container: crystallang/crystal:1.2.1-alpine
+    steps:
+      - name: Download Crystal source
+        uses: actions/checkout@v2
+      - name: Uninstall openssl
+        run: apk del openssl-dev openssl-libs-static
+      - name: Install libressl 3.1
+        run: apk add "libressl-dev=~3.1"
+      - name: Check LibSSL version
+        run: bin/crystal eval 'require "openssl"; p! LibSSL::OPENSSL_VERSION, LibSSL::LIBRESSL_VERSION'
+      - name: Run OpenSSL specs
+        run: bin/crystal spec spec/std/openssl/
+  libressl34:
+    runs-on: ubuntu-latest
+    name: "LibreSSL 3.4"
+    container: crystallang/crystal:1.2.1-alpine
+    steps:
+      - name: Download Crystal source
+        uses: actions/checkout@v2
+      - name: Uninstall openssl
+        run: apk del openssl-dev openssl-libs-static
+      - name: Install libressl 3.4
+        run: apk add "libressl-dev=~3.4" --repository=http://dl-cdn.alpinelinux.org/alpine/edge/community
+      # We need a recent libc which include reallocarray
+      - name: Upgrade musl-dev
+        run: apk add "musl-dev=~1.2" --repository=http://dl-cdn.alpinelinux.org/alpine/v3.14/main
+      - name: Check LibSSL version
+        run: bin/crystal eval 'require "openssl"; p! LibSSL::OPENSSL_VERSION, LibSSL::LIBRESSL_VERSION'
+      - name: Run OpenSSL specs
+        run: bin/crystal spec spec/std/openssl/

--- a/src/openssl/lib_crypto.cr
+++ b/src/openssl/lib_crypto.cr
@@ -131,7 +131,7 @@ lib LibCrypto
   fun obj_obj2nid = OBJ_obj2nid(obj : ASN1_OBJECT) : Int
   fun obj_ln2nid = OBJ_ln2nid(ln : Char*) : Int
   fun obj_sn2nid = OBJ_sn2nid(sn : Char*) : Int
-  {% if compare_versions(OPENSSL_VERSION, "1.0.2") >= 0 %}
+  {% if compare_versions(OPENSSL_VERSION, "1.0.2") >= 0 || compare_versions(LIBRESSL_VERSION, "0.0.0") > 0 %}
     fun obj_find_sigid_algs = OBJ_find_sigid_algs(sigid : Int32, pdig_nid : Int32*, ppkey_nid : Int32*) : Int32
   {% end %}
 
@@ -303,7 +303,7 @@ lib LibCrypto
   fun x509_get_ext = X509_get_ext(x : X509, idx : Int) : X509_EXTENSION
   fun x509_get_ext_count = X509_get_ext_count(x : X509) : Int
   fun x509_get_ext_d2i = X509_get_ext_d2i(x : X509, nid : Int, crit : Int*, idx : Int*) : Void*
-  {% if compare_versions(OPENSSL_VERSION, "1.0.2") >= 0 %}
+  {% if compare_versions(OPENSSL_VERSION, "1.0.2") >= 0 || compare_versions(LIBRESSL_VERSION, "0.0.0") > 0 %}
     fun x509_get_signature_nid = X509_get_signature_nid(x509 : X509) : Int32
   {% end %}
 


### PR DESCRIPTION
This patch improves `OpenSSL` support for linking against libressl. Bindings to some functions were missing for libressl. Together with #11374 this enables some missing functionality.

But most of the changes are about fixing some specs to comply with libressl behaviour.

To ensure libressl support doesn't break in the future, new jobs are added to the openssl CI workflow (introduced in #11360) to test against libressl 3.1 and 3.4. These versions are easiest to obtain on the crystal alpine docker image.

