### PR TITLE
Update distribution-scripts

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -123,7 +123,7 @@ jobs:
       - run: |
           git clone https://github.com/crystal-lang/distribution-scripts.git ~/distribution-scripts
           cd ~/distribution-scripts
-          git checkout d7b2e1af04e36af692f8bb7e0a5e48609a3fbbac
+          git checkout 406d7d2bb371fd819b9977cc5e91e5dc58bfd5f2
       # persist relevant information for build process
       - run: |
           cd ~/distribution-scripts


### PR DESCRIPTION
This includes the following changes:

* crystal-lang/distribution-scripts#166
* crystal-lang/distribution-scripts#163
* crystal-lang/distribution-scripts#162
* crystal-lang/distribution-scripts#161
* crystal-lang/distribution-scripts#164
* crystal-lang/distribution-scripts#155
* crystal-lang/distribution-scripts#159

The first one is most relevant for getting our release workflow working again.