### PR TITLE
Retrieve filename of shared libs, use in stacktraces

### DIFF
--- a/src/exception/call_stack/libunwind.cr
+++ b/src/exception/call_stack/libunwind.cr
@@ -114,11 +114,11 @@ struct Exception::CallStack
 
     frame = decode_frame(repeated_frame.ip)
     if frame
-      offset, sname = frame
+      offset, sname, fname = frame
       if repeated_frame.count == 0
-        Crystal::System.print_error "[0x%lx] %s +%ld\n", repeated_frame.ip, sname, offset
+        Crystal::System.print_error "[0x%lx] %s +%ld in %s\n", repeated_frame.ip, sname, offset, fname
       else
-        Crystal::System.print_error "[0x%lx] %s +%ld (%ld times)\n", repeated_frame.ip, sname, offset, repeated_frame.count + 1
+        Crystal::System.print_error "[0x%lx] %s +%ld in %s (%ld times)\n", repeated_frame.ip, sname, offset, fname, repeated_frame.count + 1
       end
     else
       if repeated_frame.count == 0
@@ -151,25 +151,27 @@ struct Exception::CallStack
       if name = CallStack.decode_function_name(pc)
         function = name
       elsif frame = CallStack.decode_frame(ip)
-        _, sname = frame
-        function = String.new(sname)
-
+        _, function, file = frame
         # Crystal methods (their mangled name) start with `*`, so
         # we remove that to have less clutter in the output.
         function = function.lchop('*')
       else
-        function = "???"
+        function = "??"
       end
 
       if file_line_column
         if show_full_info && (frame = CallStack.decode_frame(ip))
-          _, sname = frame
-          line = "#{file_line_column} in '#{String.new(sname)}'"
+          _, sname, _ = frame
+          line = "#{file_line_column} in '#{sname}'"
         else
           line = "#{file_line_column} in '#{function}'"
         end
       else
-        line = function
+        if file == "??" && function == "??"
+          line = "???"
+        else
+          line = "#{file} in '#{function}'"
+        end
       end
 
       if show_full_info
@@ -187,10 +189,18 @@ struct Exception::CallStack
       if offset == 0
         return decode_frame(ip - 1, original_ip)
       end
-
-      unless info.dli_sname.null?
-        {offset, info.dli_sname}
+      return if info.dli_sname.null? && info.dli_fname.null?
+      if info.dli_sname.null?
+        symbol = "??"
+      else
+        symbol = String.new(info.dli_sname)
       end
+      if info.dli_fname.null?
+        file = "??"
+      else
+        file = String.new(info.dli_fname)
+      end
+      {offset, symbol, file}
     end
   end
 end


### PR DESCRIPTION
Before:

```
Unhandled exception: hello (Exception)
  from src/crystal/system/unix/socket.cr:215:5 in 'unbuffered_write'
  from src/io/buffered.cr:136:14 in 'write'
  from src/openssl/bio.cr:31:7 in '->'
  from ???
  from BIO_write
  from ???
  from BIO_ctrl
  from ???
  from ???
  from ???
  from SSL_do_handshake
  from src/openssl/ssl/socket.cr:32:15 in 'initialize'
  from src/openssl/ssl/socket.cr:3:5 in 'new:context:sync_close:hostname'
  from src/http/client.cr:794:5 in 'io'
  from src/http/client.cr:671:5 in 'send_request'
  from src/http/client.cr:603:5 in 'exec_internal_single'
  from src/http/client.cr:587:18 in 'exec_internal'
  from src/http/client.cr:581:7 in 'exec'
  from src/http/client.cr:713:5 in 'exec'
  from src/http/client.cr:745:7 in 'exec'
  from src/http/client.cr:406:3 in 'get'
  from ssl.cr:2:1 in '__crystal_main'
  from src/crystal/main.cr:110:5 in 'main_user_code'
  from src/crystal/main.cr:96:7 in 'main'
  from src/crystal/main.cr:119:3 in 'main'
  from __libc_start_main
  from _start
  from ???
```

After:

```
Unhandled exception: hello (Exception)
  from src/crystal/system/unix/socket.cr:215:5 in 'unbuffered_write'
  from src/io/buffered.cr:136:14 in 'write'
  from src/openssl/bio.cr:31:7 in '->'
  from /usr/lib/x86_64-linux-gnu/libcrypto.so.1.1 in '??'
  from /usr/lib/x86_64-linux-gnu/libcrypto.so.1.1 in 'BIO_write'
  from /usr/lib/x86_64-linux-gnu/libcrypto.so.1.1 in '??'
  from /usr/lib/x86_64-linux-gnu/libcrypto.so.1.1 in 'BIO_ctrl'
  from /usr/lib/x86_64-linux-gnu/libssl.so.1.1 in '??'
  from /usr/lib/x86_64-linux-gnu/libssl.so.1.1 in '??'
  from /usr/lib/x86_64-linux-gnu/libssl.so.1.1 in '??'
  from /usr/lib/x86_64-linux-gnu/libssl.so.1.1 in 'SSL_do_handshake'
  from src/openssl/ssl/socket.cr:32:15 in 'initialize'
  from src/openssl/ssl/socket.cr:3:5 in 'new:context:sync_close:hostname'
  from src/http/client.cr:794:5 in 'io'
  from src/http/client.cr:671:5 in 'send_request'
  from src/http/client.cr:603:5 in 'exec_internal_single'
  from src/http/client.cr:587:18 in 'exec_internal'
  from src/http/client.cr:581:7 in 'exec'
  from src/http/client.cr:713:5 in 'exec'
  from src/http/client.cr:745:7 in 'exec'
  from src/http/client.cr:406:3 in 'get'
  from ssl.cr:2:1 in '__crystal_main'
  from src/crystal/main.cr:110:5 in 'main_user_code'
  from src/crystal/main.cr:96:7 in 'main'
  from src/crystal/main.cr:119:3 in 'main'
  from /lib/x86_64-linux-gnu/libc.so.6 in '__libc_start_main'
  from ./ssl in '_start'
  from ???
```

Resolves #8534