### PR TITLE
Add `Char#unicode_escape` and fix `#dump` and `#inspect` format

### DIFF
--- a/spec/std/char_spec.cr
+++ b/spec/std/char_spec.cr
@@ -1,6 +1,7 @@
 require "spec"
 require "unicode"
 require "spec/helpers/iterate"
+require "../support/string"
 
 describe "Char" do
   describe "upcase" do
@@ -107,30 +108,73 @@ describe "Char" do
     end
   end
 
-  it "dumps" do
-    'a'.dump.should eq("'a'")
-    '\\'.dump.should eq("'\\\\'")
-    '\e'.dump.should eq("'\\e'")
-    '\f'.dump.should eq("'\\f'")
-    '\n'.dump.should eq("'\\n'")
-    '\r'.dump.should eq("'\\r'")
-    '\t'.dump.should eq("'\\t'")
-    '\v'.dump.should eq("'\\v'")
-    'á'.dump.should eq("'\\u{e1}'")
-    '\u{81}'.dump.should eq("'\\u{81}'")
+  it "#dump" do
+    assert_prints 'a'.dump, %('a')
+    assert_prints '\\'.dump, %('\\\\')
+    assert_prints '\0'.dump, %('\\0')
+    assert_prints '\u0001'.dump, %('\\u0001')
+    assert_prints ' '.dump, %(' ')
+    assert_prints '\a'.dump, %('\\a')
+    assert_prints '\b'.dump, %('\\b')
+    assert_prints '\e'.dump, %('\\e')
+    assert_prints '\f'.dump, %('\\f')
+    assert_prints '\n'.dump, %('\\n')
+    assert_prints '\r'.dump, %('\\r')
+    assert_prints '\t'.dump, %('\\t')
+    assert_prints '\v'.dump, %('\\v')
+    assert_prints '\f'.dump, %('\\f')
+    assert_prints 'á'.dump, %('\\u00E1')
+    assert_prints '\uF8FF'.dump, %('\\uF8FF')
+    assert_prints '\u202A'.dump, %('\\u202A')
+    assert_prints '\u{81}'.dump, %('\\u0081')
+    assert_prints '\u{110BD}'.dump, %('\\u{110BD}')
+    assert_prints '\u00AD'.dump, %('\\u00AD')
   end
 
-  it "inspects" do
-    'a'.inspect.should eq("'a'")
-    '\\'.inspect.should eq("'\\\\'")
-    '\e'.inspect.should eq("'\\e'")
-    '\f'.inspect.should eq("'\\f'")
-    '\n'.inspect.should eq("'\\n'")
-    '\r'.inspect.should eq("'\\r'")
-    '\t'.inspect.should eq("'\\t'")
-    '\v'.inspect.should eq("'\\v'")
-    'á'.inspect.should eq("'á'")
-    '\u{81}'.inspect.should eq("'\\u{81}'")
+  it "#inspect" do
+    assert_prints 'a'.inspect, %('a')
+    assert_prints '\\'.inspect, %('\\\\')
+    assert_prints '\0'.inspect, %('\\0')
+    assert_prints '\u0001'.inspect, %('\\u0001')
+    assert_prints ' '.inspect, %(' ')
+    assert_prints '\a'.inspect, %('\\a')
+    assert_prints '\b'.inspect, %('\\b')
+    assert_prints '\e'.inspect, %('\\e')
+    assert_prints '\f'.inspect, %('\\f')
+    assert_prints '\n'.inspect, %('\\n')
+    assert_prints '\r'.inspect, %('\\r')
+    assert_prints '\t'.inspect, %('\\t')
+    assert_prints '\v'.inspect, %('\\v')
+    assert_prints '\f'.inspect, %('\\f')
+    assert_prints 'á'.inspect, %('á')
+    assert_prints '\uF8FF'.inspect, %('\uF8FF')
+    assert_prints '\u202A'.inspect, %('\u202A')
+    assert_prints '\u{81}'.inspect, %('\\u0081')
+    assert_prints '\u{110BD}'.inspect, %('\u{110BD}')
+    assert_prints '\u00AD'.inspect, %('\u00AD')
+  end
+
+  it "#unicode_escape" do
+    assert_prints 'a'.unicode_escape, %(\\u0061)
+    assert_prints '\\'.unicode_escape, %(\\u005C)
+    assert_prints '\0'.unicode_escape, %(\\u0000)
+    assert_prints '\u0001'.unicode_escape, %(\\u0001)
+    assert_prints ' '.unicode_escape, %(\\u0020)
+    assert_prints '\a'.unicode_escape, %(\\u0007)
+    assert_prints '\b'.unicode_escape, %(\\u0008)
+    assert_prints '\e'.unicode_escape, %(\\u001B)
+    assert_prints '\f'.unicode_escape, %(\\u000C)
+    assert_prints '\n'.unicode_escape, %(\\u000A)
+    assert_prints '\r'.unicode_escape, %(\\u000D)
+    assert_prints '\t'.unicode_escape, %(\\u0009)
+    assert_prints '\v'.unicode_escape, %(\\u000B)
+    assert_prints '\f'.unicode_escape, %(\\u000C)
+    assert_prints 'á'.unicode_escape, %(\\u00E1)
+    assert_prints '\uF8FF'.unicode_escape, %(\\uF8FF)
+    assert_prints '\u202A'.unicode_escape, %(\\u202A)
+    assert_prints '\u{81}'.unicode_escape, %(\\u0081)
+    assert_prints '\u{110BD}'.unicode_escape, %(\\u{110BD})
+    assert_prints '\u00AD'.unicode_escape, %(\\u00AD)
   end
 
   it "escapes" do

--- a/src/char.cr
+++ b/src/char.cr
@@ -496,12 +496,18 @@ struct Char
 
   # Returns this char as a string that contains a char literal.
   #
+  # ASCII control characters are escaped.
+  #
   # ```
   # 'a'.inspect      # => "'a'"
   # '\t'.inspect     # => "'\\t'"
   # 'あ'.inspect      # => "'あ'"
   # '\u0012'.inspect # => "'\\u0012'"
+  # '😀'.inspect     # => "'\u{1F600}'"
   # ```
+  #
+  # See `#unicode_escape` for the format used to escape charactes without a
+  # special escape sequence.
   def inspect : String
     dump_or_inspect do |io|
       if ascii_control?
@@ -520,14 +526,19 @@ struct Char
   end
 
   # Returns this char as a string that contains a char literal as written in Crystal,
-  # with characters with a codepoint greater than `0x79` written as `\u{...}`.
+  # with all non-ASCII characters (codepoint greater than `0x79`) as well as
+  # ASCII control characters escaped.
   #
   # ```
   # 'a'.dump      # => "'a'"
   # '\t'.dump     # => "'\\t'"
   # 'あ'.dump      # => "'\\u3042'"
   # '\u0012'.dump # => "'\\u0012'"
+  # '😀'.dump     # => "'\\u{1F600}'"
   # ```
+  #
+  # See `#unicode_escape` for the format used to escape charactes without a
+  # special escape sequence.
   def dump : String
     dump_or_inspect do |io|
       if ascii_control? || ord >= 0x80
@@ -569,13 +580,17 @@ struct Char
 
   # Returns the Unicode escape sequence representing this character.
   #
-  # This is like `#dump` except that it escapes any character.
+  # The codepoints are expressed as hexadecimal digits with uppercase letters.
+  # Unicode escapes always use the four digit style for codepoints `U+FFFF`
+  # and lower, adding leading zeros when necessary. Higher codepoints have their
+  # digits wrapped in curly braces and no leading zeros.
   #
   # ```
   # 'a'.unicode_escape      # => "\\u00E1"
   # '\t'.unicode_escape     # => "\\u0009"
   # 'あ'.unicode_escape      # => "\\u3042"
   # '\u0012'.unicode_escape # => "\\u0012"
+  # '😀'.unicode_escape     # => "\\u{1F600}"
   # ```
   def unicode_escape : String
     String.build do |io|

--- a/src/char.cr
+++ b/src/char.cr
@@ -503,7 +503,7 @@ struct Char
   # '\t'.inspect     # => "'\\t'"
   # 'あ'.inspect      # => "'あ'"
   # '\u0012'.inspect # => "'\\u0012'"
-  # '😀'.inspect     # => "'\u{1F600}'"
+  # '😀'.inspect      # => "'\u{1F600}'"
   # ```
   #
   # See `#unicode_escape` for the format used to escape charactes without a
@@ -534,7 +534,7 @@ struct Char
   # '\t'.dump     # => "'\\t'"
   # 'あ'.dump      # => "'\\u3042'"
   # '\u0012'.dump # => "'\\u0012'"
-  # '😀'.dump     # => "'\\u{1F600}'"
+  # '😀'.dump      # => "'\\u{1F600}'"
   # ```
   #
   # See `#unicode_escape` for the format used to escape charactes without a
@@ -590,7 +590,7 @@ struct Char
   # '\t'.unicode_escape     # => "\\u0009"
   # 'あ'.unicode_escape      # => "\\u3042"
   # '\u0012'.unicode_escape # => "\\u0012"
-  # '😀'.unicode_escape     # => "\\u{1F600}"
+  # '😀'.unicode_escape      # => "\\u{1F600}"
   # ```
   def unicode_escape : String
     String.build do |io|

--- a/src/string.cr
+++ b/src/string.cr
@@ -4697,7 +4697,7 @@ class String
     if error
       dump_hex(error, io)
     elsif yield
-      dump_unicode(char, io)
+      char.unicode_escape(io)
     else
       io << char
     end
@@ -4707,16 +4707,6 @@ class String
     io << "\\x"
     io << '0' if char < 0x0F
     char.to_s(io, 16, upcase: true)
-  end
-
-  private def dump_unicode(char, io)
-    io << "\\u"
-    io << '{' if char.ord > 0xFFFF
-    io << '0' if char.ord < 0x1000
-    io << '0' if char.ord < 0x0100
-    io << '0' if char.ord < 0x0010
-    char.ord.to_s(io, 16, upcase: true)
-    io << '}' if char.ord > 0xFFFF
   end
 
   # Returns `true` if this string starts with the given *str*.


### PR DESCRIPTION
The new method is used for `#inspect` and `#dump` methods of `Char` and `String`. It unifies the format of Unicode escape sequences to upper-cased four-digit style (`\uFFFF`).

Char specs are updated to use the `assert_prints` helper, which revealed a bug in `Char#dump(IO)` where all results where double quoted.

Finally, this patch adds a special rule for `'\0'.inspect` to use the special zero escape sequence instead of Unicode escape `\u0000`.

Resolves  #11405