### PR TITLE
Fix pcre download URL

### DIFF
--- a/.github/workflows/win.yml
+++ b/.github/workflows/win.yml
@@ -65,7 +65,7 @@ jobs:
       - name: Download libpcre
         if: steps.cache-libs.outputs.cache-hit != 'true'
         run: |
-          iwr https://ftp.pcre.org/pub/pcre/pcre-8.43.zip -OutFile pcre.zip
+          iwr https://cs.stanford.edu/pub/exim/pcre/pcre-8.43.zip -OutFile pcre.zip
           7z x pcre.zip
           mv pcre-* pcre
       - name: Build libpcre


### PR DESCRIPTION
The server at ftp://ftp.pcre.org has been shut down. This patch changes to a different mirror for downloading libpcre.

This is the equivalent to https://github.com/crystal-lang/distribution-scripts/pull/166 for our windows CI.