### PR TITLE
Verify downloads' hashes in Windows CI

### DIFF
--- a/.github/workflows/win.yml
+++ b/.github/workflows/win.yml
@@ -66,6 +66,7 @@ jobs:
         if: steps.cache-libs.outputs.cache-hit != 'true'
         run: |
           iwr https://cs.stanford.edu/pub/exim/pcre/pcre-8.43.zip -OutFile pcre.zip
+          (Get-FileHash -Algorithm SHA256 .\pcre.zip).hash -eq "ae236dc25d7e0e738a94e103218e0085eb02ff9bd98f637b6e061a48decdb433"
           7z x pcre.zip
           mv pcre-* pcre
       - name: Build libpcre
@@ -78,6 +79,7 @@ jobs:
         if: steps.cache-libs.outputs.cache-hit != 'true'
         run: |
           iwr https://github.com/madler/zlib/archive/v1.2.11.zip -OutFile zlib.zip
+          (Get-FileHash -Algorithm SHA256 .\zlib.zip).hash -eq "f5cc4ab910db99b2bdbba39ebbdc225ffc2aa04b4057bc2817f1b94b6978cfc3"
           7z x zlib.zip
           mv zlib-* zlib
       - name: Build zlib
@@ -90,6 +92,7 @@ jobs:
         if: steps.cache-libs.outputs.cache-hit != 'true'
         run: |
           iwr https://github.com/yaml/libyaml/archive/0.2.4.zip -OutFile libyaml.zip
+          (Get-FileHash -Algorithm SHA256 .\libyaml.zip).hash -eq "5882285b8265096d045ecebbee651b73bef6cead34e439b63e86bf393c936793"
           7z x libyaml.zip
           mv libyaml-* libyaml
       - name: Build libyaml
@@ -131,6 +134,7 @@ jobs:
         if: steps.cache-llvm.outputs.cache-hit != 'true'
         run: |
           iwr https://github.com/llvm/llvm-project/releases/download/llvmorg-10.0.0/llvm-10.0.0.src.tar.xz -OutFile llvm.tar.xz
+          (Get-FileHash -Algorithm SHA256 .\llvm.tar.xz).hash -eq "df83a44b3a9a71029049ec101fb0077ecbbdf5fe41e395215025779099a98fdf"
           7z x llvm.tar.xz
           7z x llvm.tar
           mv llvm-* llvm-src


### PR DESCRIPTION
Check the downloaded file's SHA256 hash when building in Windows.

We should apply this after #11422 so the build doesn't fail because of that.