### PR TITLE
Fix link flag behaviour on Windows MSVC

### DIFF
--- a/.github/workflows/win.yml
+++ b/.github/workflows/win.yml
@@ -65,7 +65,7 @@ jobs:
       - name: Download libpcre
         if: steps.cache-libs.outputs.cache-hit != 'true'
         run: |
-          iwr https://ftp.pcre.org/pub/pcre/pcre-8.43.zip -OutFile pcre.zip
+          iwr https://cs.stanford.edu/pub/exim/pcre/pcre-8.43.zip -OutFile pcre.zip
           7z x pcre.zip
           mv pcre-* pcre
       - name: Build libpcre
@@ -172,7 +172,7 @@ jobs:
 
       - name: Re-build Crystal
         run: |
-          .\crystal-cross.exe build src/compiler/crystal.cr -Di_know_what_im_doing -Dwithout_playground --link-flags=/F10000000
+          .\crystal-cross.exe build src/compiler/crystal.cr -Di_know_what_im_doing -Dwithout_playground --link-flags=/STACK:10000000
           mv crystal.exe bin/
 
       - name: Gather Crystal binaries

--- a/src/compiler/crystal/codegen/link.cr
+++ b/src/compiler/crystal/codegen/link.cr
@@ -108,17 +108,27 @@ module Crystal
     end
 
     private def lib_flags_windows
-      String.build do |flags|
-        link_annotations.reverse_each do |ann|
-          if ldflags = ann.ldflags
-            flags << ' ' << ldflags
-          end
+      flags = [] of String
 
-          if libname = ann.lib
-            flags << ' ' << Process.quote_windows("#{libname}.lib")
-          end
+      # Add CRYSTAL_LIBRARY_PATH locations, so the linker preferentially
+      # searches user-given library paths.
+      if has_flag?("msvc")
+        CrystalLibraryPath.paths.each do |path|
+          flags << Process.quote_windows("/LIBPATH:#{path}")
         end
       end
+
+      link_annotations.reverse_each do |ann|
+        if ldflags = ann.ldflags
+          flags << ldflags
+        end
+
+        if libname = ann.lib
+          flags << Process.quote_windows("#{libname}.lib")
+        end
+      end
+
+      flags.join(" ")
     end
 
     private def lib_flags_posix

--- a/src/compiler/crystal/compiler.cr
+++ b/src/compiler/crystal/compiler.cr
@@ -338,7 +338,7 @@ module Crystal
     end
 
     private def linker_command(program : Program, object_names, output_filename, output_dir, expand = false)
-      if program.has_flag? "windows"
+      if program.has_flag? "msvc"
         lib_flags = program.lib_flags
         # Execute and expand `subcommands`.
         lib_flags = lib_flags.gsub(/`(.*?)`/) { `#{$1}` } if expand
@@ -346,7 +346,7 @@ module Crystal
         object_arg = Process.quote_windows(object_names)
         output_arg = Process.quote_windows("/Fe#{output_filename}")
 
-        args = %(/nologo #{object_arg} #{output_arg} #{lib_flags} #{@link_flags})
+        args = %(/nologo #{object_arg} #{output_arg} /link #{lib_flags} #{@link_flags}).gsub("\n", " ")
         cmd = "#{CL} #{args}"
 
         if cmd.to_utf16.size > 32000


### PR DESCRIPTION
Currently, link flags passed through `--link-flags` on MSVC are not considered as such, because CL treats them as compiler options:

```cmd
> crystal build test.cr --verbose --link-flags "/PDB:test.pdb"
cl.exe /nologo _main.obj E-xception5858C-allS-tack.obj ... /FeC:\Users\Quinton\crystal-win\test  pcre.lib gc.lib advapi32.lib WS2_32.lib legacy_stdio_definitions.lib libcmt.lib /PDB:test.pdb
cl : Command line warning D9002 : ignoring unknown option '/PDB:test.pdb'
```

This PR adds a missing `/link` command-line argument, and ensures all the arguments are on the same line to fix this (when the arguments are placed into `linker_args.txt`, for some reason `/link` stops behaving after a newline).

It also adds support for the `CRYSTAL_LIBRARY_PATH` environment variable, via the `/LIBPATH` linker flag.