### PR TITLE
Datagram support for UNIXServer

### DIFF
--- a/spec/std/socket/unix_server_spec.cr
+++ b/spec/std/socket/unix_server_spec.cr
@@ -147,4 +147,18 @@ describe UNIXServer do
       end
     end
   end
+
+  describe "datagrams" do
+    it "can send and receive datagrams" do
+      with_tempfile("unix_dgram_server.sock") do |path|
+        UNIXServer.open(path, Socket::Type::DGRAM) do |s|
+          UNIXSocket.open(path, Socket::Type::DGRAM) do |c|
+            c.send("foobar")
+            msg, _addr = s.receive(512)
+            msg.should eq "foobar"
+          end
+        end
+      end
+    end
+  end
 end

--- a/src/socket/unix_server.cr
+++ b/src/socket/unix_server.cr
@@ -39,6 +39,7 @@ class UNIXServer < UNIXSocket
       raise error
     end
 
+    return if type == Type::DGRAM
     listen(backlog) do |error|
       close
       raise error


### PR DESCRIPTION
Don't try to listen when the type is DGRAM in UNIXServer