### PR TITLE
[docs] Add 404.html page

### DIFF
--- a/src/compiler/crystal/tools/doc/generator.cr
+++ b/src/compiler/crystal/tools/doc/generator.cr
@@ -89,6 +89,8 @@ class Crystal::Doc::Generator
     main_index = Main.new(raw_body, Type.new(self, @program), project_info)
     File.write File.join(@output_dir, "index.json"), main_index
     File.write File.join(@output_dir, "search-index.js"), main_index.to_jsonp
+
+    File.write File.join(@output_dir, "404.html"), MainTemplate.new(Error404Template.new.to_s, types, project_info)
   end
 
   def generate_sitemap(types)

--- a/src/compiler/crystal/tools/doc/html/404.html
+++ b/src/compiler/crystal/tools/doc/html/404.html
@@ -5,3 +5,8 @@
 <p>
   This page is unavailable in this version of the API docs.
 </p>
+
+<p>
+  You can use the sidebar to search for your page, or try a different
+  Crystal version.
+</p>

--- a/src/compiler/crystal/tools/doc/html/404.html
+++ b/src/compiler/crystal/tools/doc/html/404.html
@@ -1,0 +1,7 @@
+<h1 class="type-name">
+  404 Not Found
+</h1>
+
+<p>
+  This page is unavailable in this version of the API docs.
+</p>

--- a/src/compiler/crystal/tools/doc/templates.cr
+++ b/src/compiler/crystal/tools/doc/templates.cr
@@ -65,6 +65,10 @@ module Crystal::Doc
     ECR.def_to_s "#{__DIR__}/html/_sidebar.html"
   end
 
+  record Error404Template do
+    ECR.def_to_s "#{__DIR__}/html/404.html"
+  end
+
   struct JsTypeTemplate
     ECR.def_to_s "#{__DIR__}/html/js/doc.js"
   end


### PR DESCRIPTION
This patch adds a simple 404 error page to the generated API docs.

Ref: https://github.com/crystal-lang/crystal-website/issues/118

![grafik](https://user-images.githubusercontent.com/466378/141122117-6b6576fd-b7e9-4ea1-8abd-917dbdb341f3.png)
