### PR TITLE
Fix `Math` linking errors on Windows MSVC

### DIFF
--- a/spec/std/math_spec.cr
+++ b/spec/std/math_spec.cr
@@ -66,7 +66,7 @@ describe "Math" do
     end
 
     it "expm1" do
-      Math.expm1(0.99_f32).should be_close(1.6912344723492623, 1e-7)
+      Math.expm1(0.99_f32).should be_close(1.6912344723492623, 1e-6)
       Math.expm1(0.99).should be_close(1.6912344723492623, 1e-7)
     end
 

--- a/spec/win32_std_spec.cr
+++ b/spec/win32_std_spec.cr
@@ -134,7 +134,7 @@ require "./std/log/io_backend_spec.cr"
 require "./std/log/log_spec.cr"
 require "./std/log/main_spec.cr"
 require "./std/match_data_spec.cr"
-# require "./std/math_spec.cr" (failed linking)
+require "./std/math_spec.cr"
 require "./std/mime/media_type_spec.cr"
 require "./std/mime/multipart/builder_spec.cr"
 require "./std/mime/multipart/parser_spec.cr"

--- a/src/math/libm.cr
+++ b/src/math/libm.cr
@@ -63,18 +63,27 @@ lib LibM
   fun atan_f64 = atan(value : Float64) : Float64
   fun atanh_f32 = atanhf(value : Float32) : Float32
   fun atanh_f64 = atanh(value : Float64) : Float64
-  fun besselj0_f32 = j0f(value : Float32) : Float32
-  fun besselj0_f64 = j0(value : Float64) : Float64
-  fun besselj1_f32 = j1f(value : Float32) : Float32
-  fun besselj1_f64 = j1(value : Float64) : Float64
-  fun besselj_f32 = jnf(value1 : Int32, value2 : Float32) : Float32
-  fun besselj_f64 = jn(value1 : Int32, value2 : Float64) : Float64
-  fun bessely0_f32 = y0f(value : Float32) : Float32
-  fun bessely0_f64 = y0(value : Float64) : Float64
-  fun bessely1_f32 = y1f(value : Float32) : Float32
-  fun bessely1_f64 = y1(value : Float64) : Float64
-  fun bessely_f32 = ynf(value1 : Int32, value2 : Float32) : Float32
-  fun bessely_f64 = yn(value1 : Int32, value2 : Float64) : Float64
+  {% if flag?(:win32) %}
+    fun besselj0_f64 = _j0(value : Float64) : Float64
+    fun besselj1_f64 = _j1(value : Float64) : Float64
+    fun besselj_f64 = _jn(value1 : Int32, value2 : Float64) : Float64
+    fun bessely0_f64 = _y0(value : Float64) : Float64
+    fun bessely1_f64 = _y1(value : Float64) : Float64
+    fun bessely_f64 = _yn(value1 : Int32, value2 : Float64) : Float64
+  {% else %}
+    fun besselj0_f32 = j0f(value : Float32) : Float32
+    fun besselj0_f64 = j0(value : Float64) : Float64
+    fun besselj1_f32 = j1f(value : Float32) : Float32
+    fun besselj1_f64 = j1(value : Float64) : Float64
+    fun besselj_f32 = jnf(value1 : Int32, value2 : Float32) : Float32
+    fun besselj_f64 = jn(value1 : Int32, value2 : Float64) : Float64
+    fun bessely0_f32 = y0f(value : Float32) : Float32
+    fun bessely0_f64 = y0(value : Float64) : Float64
+    fun bessely1_f32 = y1f(value : Float32) : Float32
+    fun bessely1_f64 = y1(value : Float64) : Float64
+    fun bessely_f32 = ynf(value1 : Int32, value2 : Float32) : Float32
+    fun bessely_f64 = yn(value1 : Int32, value2 : Float64) : Float64
+  {% end %}
   fun cbrt_f32 = cbrtf(value : Float32) : Float32
   fun cbrt_f64 = cbrt(value : Float64) : Float64
   fun cosh_f32 = coshf(value : Float32) : Float32
@@ -85,7 +94,9 @@ lib LibM
   fun erf_f64 = erf(value : Float64) : Float64
   fun expm1_f32 = expm1f(value : Float32) : Float32
   fun expm1_f64 = expm1(value : Float64) : Float64
-  fun frexp_f32 = frexpf(value : Float32, exp : Int32*) : Float32
+  {% unless flag?(:win32) %}
+    fun frexp_f32 = frexpf(value : Float32, exp : Int32*) : Float32
+  {% end %}
   fun frexp_f64 = frexp(value : Float64, exp : Int32*) : Float64
   fun gamma_f32 = lgammaf(value : Float32) : Float32
   fun gamma_f64 = lgamma(value : Float64) : Float64

--- a/src/math/math.cr
+++ b/src/math/math.cr
@@ -443,7 +443,7 @@ module Math
 
   # Calculates the cylindrical Bessel function of the first kind of *value* for the given *order*.
   def besselj(order : Int32, value : Float32)
-    {% if flag?(:darwin) %}
+    {% if flag?(:darwin) || flag?(:win32) %}
       LibM.besselj_f64(order, value).to_f32
     {% else %}
       LibM.besselj_f32(order, value)
@@ -462,7 +462,7 @@ module Math
 
   # Calculates the cylindrical Bessel function of the first kind of *value* for order 0.
   def besselj0(value : Float32)
-    {% if flag?(:darwin) %}
+    {% if flag?(:darwin) || flag?(:win32) %}
       LibM.besselj0_f64(value).to_f32
     {% else %}
       LibM.besselj0_f32(value)
@@ -481,7 +481,7 @@ module Math
 
   # Calculates the cylindrical Bessel function of the first kind of *value* for order 1.
   def besselj1(value : Float32)
-    {% if flag?(:darwin) %}
+    {% if flag?(:darwin) || flag?(:win32) %}
       LibM.besselj1_f64(value).to_f32
     {% else %}
       LibM.besselj1_f32(value)
@@ -500,7 +500,7 @@ module Math
 
   # Calculates the cylindrical Bessel function of the second kind of *value* for the given *order*.
   def bessely(order : Int32, value : Float32)
-    {% if flag?(:darwin) %}
+    {% if flag?(:darwin) || flag?(:win32) %}
       LibM.bessely_f64(order, value).to_f32
     {% else %}
       LibM.bessely_f32(order, value)
@@ -519,7 +519,7 @@ module Math
 
   # Calculates the cylindrical Bessel function of the second kind of *value* for order 0.
   def bessely0(value : Float32)
-    {% if flag?(:darwin) %}
+    {% if flag?(:darwin) || flag?(:win32) %}
       LibM.bessely0_f64(value).to_f32
     {% else %}
       LibM.bessely0_f32(value)
@@ -538,7 +538,7 @@ module Math
 
   # Calculates the cylindrical Bessel function of the second kind of *value* for order 1.
   def bessely1(value : Float32)
-    {% if flag?(:darwin) %}
+    {% if flag?(:darwin) || flag?(:win32) %}
       LibM.bessely1_f64(value).to_f32
     {% else %}
       LibM.bessely1_f32(value)
@@ -656,8 +656,14 @@ module Math
 
   # Decomposes the given floating-point *value* into a normalized fraction and an integral power of two.
   def frexp(value : Float32) : {Float32, Int32}
-    frac = LibM.frexp_f32(value, out exp)
-    {frac, exp}
+    {% if flag?(:win32) %}
+      # libucrt does not export `frexpf` and instead defines it like this
+      frac = LibM.frexp_f64(value, out exp)
+      {frac.to_f32, exp}
+    {% else %}
+      frac = LibM.frexp_f32(value, out exp)
+      {frac, exp}
+    {% end %}
   end
 
   # :ditto:


### PR DESCRIPTION
The Bessel functions' names have `_` [prepended on MSVC](https://docs.microsoft.com/en-us/cpp/c-runtime-library/reference/j0-j1-jn?view=msvc-170), so the lib fun declarations need to be adjusted there.

The fix for `Math.frexp(Float32)` is copied from #11412.