### PR TITLE
[docs] Compact some JSON fields for search

### DIFF
--- a/src/compiler/crystal/tools/doc/constant.cr
+++ b/src/compiler/crystal/tools/doc/constant.cr
@@ -34,8 +34,8 @@ class Crystal::Doc::Constant
       builder.field "id", id
       builder.field "name", name
       builder.field "value", value.try(&.to_s)
-      builder.field "doc", doc
-      builder.field "summary", formatted_summary
+      builder.field "doc", doc unless doc.nil?
+      builder.field "summary", formatted_summary unless formatted_summary.nil?
     end
   end
 

--- a/src/compiler/crystal/tools/doc/html/js/_search.js
+++ b/src/compiler/crystal/tools/doc/html/js/_search.js
@@ -71,7 +71,7 @@ CrystalDocs.runQuery = function(query) {
     }
 
     method.args?.forEach(function(arg){
-      var argMatches = query.matches(arg.external_name);
+      var argMatches = query.matches(arg.external_name ?? arg.name);
       if (argMatches) {
         matches = matches.concat(argMatches);
         matchedFields.push("args");

--- a/src/compiler/crystal/tools/doc/html/js/_search.js
+++ b/src/compiler/crystal/tools/doc/html/js/_search.js
@@ -41,24 +41,36 @@ CrystalDocs.runQuery = function(query) {
       });
     }
 
-    type.instance_methods?.forEach(function(method) {
-      searchMethod(method, type, "instance_method", query, results);
-    })
-    type.class_methods?.forEach(function(method) {
-      searchMethod(method, type, "class_method", query, results);
-    })
-    type.constructors?.forEach(function(constructor) {
-      searchMethod(constructor, type, "constructor", query, results);
-    })
-    type.macros?.forEach(function(macro) {
-      searchMethod(macro, type, "macro", query, results);
-    })
-    type.constants?.forEach(function(constant){
-      searchConstant(constant, type, query, results);
-    });
-    type.types?.forEach(function(subtype){
-      searchType(subtype, query, results);
-    });
+    if (type.instance_methods) {
+      type.instance_methods.forEach(function(method) {
+        searchMethod(method, type, "instance_method", query, results);
+      })
+    }
+    if (type.class_methods) {
+      type.class_methods.forEach(function(method) {
+        searchMethod(method, type, "class_method", query, results);
+      })
+    }
+    if (type.constructors) {
+      type.constructors.forEach(function(constructor) {
+        searchMethod(constructor, type, "constructor", query, results);
+      })
+    }
+    if (type.macros) {
+      type.macros.forEach(function(macro) {
+        searchMethod(macro, type, "macro", query, results);
+      })
+    }
+    if (type.constants) {
+      type.constants.forEach(function(constant){
+        searchConstant(constant, type, query, results);
+      });
+    }
+    if (type.types) {
+      type.types.forEach(function(subtype){
+        searchType(subtype, query, results);
+      });
+    }
   };
 
   function searchMethod(method, type, kind, query, results) {

--- a/src/compiler/crystal/tools/doc/html/js/_search.js
+++ b/src/compiler/crystal/tools/doc/html/js/_search.js
@@ -82,13 +82,15 @@ CrystalDocs.runQuery = function(query) {
       matchedFields.push("name");
     }
 
-    method.args?.forEach(function(arg){
-      var argMatches = query.matches(arg.external_name ?? arg.name);
-      if (argMatches) {
-        matches = matches.concat(argMatches);
-        matchedFields.push("args");
-      }
-    });
+    if (method.args) {
+      method.args.forEach(function(arg){
+        var argMatches = query.matches(arg.external_name);
+        if (argMatches) {
+          matches = matches.concat(argMatches);
+          matchedFields.push("args");
+        }
+      });
+    }
 
     var docMatches = query.matches(type.doc);
     if(docMatches){

--- a/src/compiler/crystal/tools/doc/html/js/_search.js
+++ b/src/compiler/crystal/tools/doc/html/js/_search.js
@@ -41,23 +41,22 @@ CrystalDocs.runQuery = function(query) {
       });
     }
 
-    type.instance_methods.forEach(function(method) {
+    type.instance_methods?.forEach(function(method) {
       searchMethod(method, type, "instance_method", query, results);
     })
-    type.class_methods.forEach(function(method) {
+    type.class_methods?.forEach(function(method) {
       searchMethod(method, type, "class_method", query, results);
     })
-    type.constructors.forEach(function(constructor) {
+    type.constructors?.forEach(function(constructor) {
       searchMethod(constructor, type, "constructor", query, results);
     })
-    type.macros.forEach(function(macro) {
+    type.macros?.forEach(function(macro) {
       searchMethod(macro, type, "macro", query, results);
     })
-    type.constants.forEach(function(constant){
+    type.constants?.forEach(function(constant){
       searchConstant(constant, type, query, results);
     });
-
-    type.types.forEach(function(subtype){
+    type.types?.forEach(function(subtype){
       searchType(subtype, query, results);
     });
   };
@@ -71,7 +70,7 @@ CrystalDocs.runQuery = function(query) {
       matchedFields.push("name");
     }
 
-    method.args.forEach(function(arg){
+    method.args?.forEach(function(arg){
       var argMatches = query.matches(arg.external_name);
       if (argMatches) {
         matches = matches.concat(argMatches);

--- a/src/compiler/crystal/tools/doc/macro.cr
+++ b/src/compiler/crystal/tools/doc/macro.cr
@@ -154,7 +154,7 @@ class Crystal::Doc::Macro
       builder.field "args", args unless args.empty?
       builder.field "args_string", args_to_s unless args.empty?
       builder.field "args_html", args_to_html unless args.empty?
-      builder.field "location", location
+      builder.field "location", location unless location.nil?
       builder.field "def", self.macro
     end
   end

--- a/src/compiler/crystal/tools/doc/macro.cr
+++ b/src/compiler/crystal/tools/doc/macro.cr
@@ -148,8 +148,8 @@ class Crystal::Doc::Macro
     builder.object do
       builder.field "html_id", id
       builder.field "name", name
-      builder.field "doc", doc
-      builder.field "summary", formatted_summary
+      builder.field "doc", doc unless doc.nil?
+      builder.field "summary", formatted_summary unless formatted_summary.nil?
       builder.field "abstract", abstract?
       builder.field "args", args unless args.empty?
       builder.field "args_string", args_to_s unless args.empty?

--- a/src/compiler/crystal/tools/doc/macro.cr
+++ b/src/compiler/crystal/tools/doc/macro.cr
@@ -151,9 +151,9 @@ class Crystal::Doc::Macro
       builder.field "doc", doc
       builder.field "summary", formatted_summary
       builder.field "abstract", abstract?
-      builder.field "args", args
-      builder.field "args_string", args_to_s
-      builder.field "args_html", args_to_html
+      builder.field "args", args unless args.empty?
+      builder.field "args_string", args_to_s unless args.empty?
+      builder.field "args_html", args_to_html unless args.empty?
       builder.field "location", location
       builder.field "def", self.macro
     end

--- a/src/compiler/crystal/tools/doc/method.cr
+++ b/src/compiler/crystal/tools/doc/method.cr
@@ -322,8 +322,8 @@ class Crystal::Doc::Method
     builder.object do
       builder.field "html_id", id
       builder.field "name", name
-      builder.field "doc", doc
-      builder.field "summary", formatted_summary
+      builder.field "doc", doc unless doc.nil?
+      builder.field "summary", formatted_summary unless formatted_summary.nil?
       builder.field "abstract", abstract?
       builder.field "args", args
       builder.field "args_string", args_to_s

--- a/src/compiler/crystal/tools/doc/method.cr
+++ b/src/compiler/crystal/tools/doc/method.cr
@@ -325,9 +325,9 @@ class Crystal::Doc::Method
       builder.field "doc", doc unless doc.nil?
       builder.field "summary", formatted_summary unless formatted_summary.nil?
       builder.field "abstract", abstract?
-      builder.field "args", args
-      builder.field "args_string", args_to_s
-      builder.field "args_html", args_to_html
+      builder.field "args", args unless args.empty?
+      builder.field "args_string", args_to_s unless args.empty?
+      builder.field "args_html", args_to_html unless args.empty?
       builder.field "location", location
       builder.field "def", self.def
     end

--- a/src/compiler/crystal/tools/doc/method.cr
+++ b/src/compiler/crystal/tools/doc/method.cr
@@ -328,7 +328,7 @@ class Crystal::Doc::Method
       builder.field "args", args unless args.empty?
       builder.field "args_string", args_to_s unless args.empty?
       builder.field "args_html", args_to_html unless args.empty?
-      builder.field "location", location
+      builder.field "location", location unless location.nil?
       builder.field "def", self.def
     end
   end

--- a/src/compiler/crystal/tools/doc/to_json.cr
+++ b/src/compiler/crystal/tools/doc/to_json.cr
@@ -4,7 +4,7 @@ class Crystal::Arg
       builder.field "name", name
       builder.field "doc", doc unless doc.nil?
       builder.field "default_value", default_value.to_s unless default_value.nil?
-      builder.field "external_name", external_name.to_s
+      builder.field "external_name", external_name unless external_name == name
       builder.field "restriction", restriction.to_s
     end
   end

--- a/src/compiler/crystal/tools/doc/to_json.cr
+++ b/src/compiler/crystal/tools/doc/to_json.cr
@@ -30,7 +30,7 @@ class Crystal::Macro
   def to_json(builder : JSON::Builder)
     builder.object do
       builder.field "name", name
-      builder.field "args", args
+      builder.field "args", args unless args.empty?
       builder.field "double_splat", double_splat unless double_splat.nil?
       builder.field "splat_index", splat_index unless splat_index.nil?
       builder.field "block_arg", block_arg unless block_arg.nil?

--- a/src/compiler/crystal/tools/doc/to_json.cr
+++ b/src/compiler/crystal/tools/doc/to_json.cr
@@ -4,7 +4,7 @@ class Crystal::Arg
       builder.field "name", name
       builder.field "doc", doc unless doc.nil?
       builder.field "default_value", default_value.to_s unless default_value.nil?
-      builder.field "external_name", external_name unless external_name == name
+      builder.field "external_name", external_name.to_s
       builder.field "restriction", restriction.to_s
     end
   end

--- a/src/compiler/crystal/tools/doc/to_json.cr
+++ b/src/compiler/crystal/tools/doc/to_json.cr
@@ -2,8 +2,8 @@ class Crystal::Arg
   def to_json(builder : JSON::Builder)
     builder.object do
       builder.field "name", name
-      builder.field "doc", doc
-      builder.field "default_value", default_value.to_s
+      builder.field "doc", doc unless doc.nil?
+      builder.field "default_value", default_value.to_s unless default_value.nil?
       builder.field "external_name", external_name.to_s
       builder.field "restriction", restriction.to_s
     end
@@ -14,12 +14,12 @@ class Crystal::Def
   def to_json(builder : JSON::Builder)
     builder.object do
       builder.field "name", name
-      builder.field "args", args
-      builder.field "double_splat", double_splat
-      builder.field "splat_index", splat_index
-      builder.field "yields", yields
-      builder.field "block_arg", block_arg
-      builder.field "return_type", return_type.to_s
+      builder.field "args", args unless args.empty?
+      builder.field "double_splat", double_splat unless double_splat.nil?
+      builder.field "splat_index", splat_index unless splat_index.nil?
+      builder.field "yields", yields unless yields.nil?
+      builder.field "block_arg", block_arg unless block_arg.nil?
+      builder.field "return_type", return_type.to_s unless return_type.nil?
       builder.field "visibility", visibility.to_s
       builder.field "body", body.to_s
     end
@@ -31,9 +31,9 @@ class Crystal::Macro
     builder.object do
       builder.field "name", name
       builder.field "args", args
-      builder.field "double_splat", double_splat
-      builder.field "splat_index", splat_index
-      builder.field "block_arg", block_arg
+      builder.field "double_splat", double_splat unless double_splat.nil?
+      builder.field "splat_index", splat_index unless splat_index.nil?
+      builder.field "block_arg", block_arg unless block_arg.nil?
       builder.field "visibility", visibility.to_s
       builder.field "body", body.to_s
     end

--- a/src/compiler/crystal/tools/doc/type.cr
+++ b/src/compiler/crystal/tools/doc/type.cr
@@ -805,30 +805,30 @@ class Crystal::Doc::Type
         builder.array do
           included_modules.each &.to_json_simple(builder)
         end
-      end
+      end unless included_modules.empty?
       builder.field "extended_modules" do
         builder.array do
           extended_modules.each &.to_json_simple(builder)
         end
-      end
+      end unless extended_modules.empty?
       builder.field "subclasses" do
         builder.array do
           subclasses.each &.to_json_simple(builder)
         end
-      end
+      end unless subclasses.empty?
       builder.field "including_types" do
         builder.array do
           including_types.each &.to_json_simple(builder)
         end
-      end
+      end unless including_types.empty?
       builder.field "namespace" { (n = namespace) ? n.to_json_simple(builder) : builder.null }
       builder.field "doc", doc
       builder.field "summary", formatted_summary
-      builder.field "class_methods", class_methods
-      builder.field "constructors", constructors
-      builder.field "instance_methods", instance_methods
-      builder.field "macros", macros
-      builder.field "types", types
+      builder.field "class_methods", class_methods unless class_methods.empty?
+      builder.field "constructors", constructors unless constructors.empty?
+      builder.field "instance_methods", instance_methods unless instance_methods.empty?
+      builder.field "macros", macros unless macros.empty?
+      builder.field "types", types unless types.empty?
     end
   end
 

--- a/src/compiler/crystal/tools/doc/type.cr
+++ b/src/compiler/crystal/tools/doc/type.cr
@@ -829,7 +829,7 @@ class Crystal::Doc::Type
           including_types.each &.to_json_simple(builder)
         end
       end unless including_types.empty?
-      builder.field "namespace" { (n = namespace) ? n.to_json_simple(builder) : builder.null }
+      builder.field "namespace" { namespace.try &.to_json_simple(builder) } unless namespace.nil?
       builder.field "doc", doc unless doc.nil?
       builder.field "summary", formatted_summary unless formatted_summary.nil?
       builder.field "class_methods", class_methods unless class_methods.empty?

--- a/src/compiler/crystal/tools/doc/type.cr
+++ b/src/compiler/crystal/tools/doc/type.cr
@@ -791,7 +791,7 @@ class Crystal::Doc::Type
         builder.array do
           ancestors.each &.to_json_simple(builder)
         end
-      end
+      end unless ancestors.empty?
       builder.field "locations", locations
       builder.field "repository_name", @generator.project_info.name
       builder.field "program", program?
@@ -800,7 +800,7 @@ class Crystal::Doc::Type
       builder.field "aliased", alias_definition.to_s if alias?
       builder.field "aliased_html", formatted_alias_definition if alias?
       builder.field "const", const?
-      builder.field "constants", constants
+      builder.field "constants", constants unless constants.empty?
       builder.field "included_modules" do
         builder.array do
           included_modules.each &.to_json_simple(builder)

--- a/src/compiler/crystal/tools/doc/type.cr
+++ b/src/compiler/crystal/tools/doc/type.cr
@@ -787,11 +787,13 @@ class Crystal::Doc::Type
       builder.field "name", name
       builder.field "abstract", abstract?
       builder.field "superclass" { superclass.try &.to_json_simple(builder) } unless superclass.nil?
-      builder.field "ancestors" do
-        builder.array do
-          ancestors.each &.to_json_simple(builder)
+      unless ancestors.empty?
+        builder.field "ancestors" do
+          builder.array do
+            ancestors.each &.to_json_simple(builder)
+          end
         end
-      end unless ancestors.empty?
+      end
       builder.field "locations", locations
       builder.field "repository_name", @generator.project_info.name
       builder.field "program", program?
@@ -801,21 +803,27 @@ class Crystal::Doc::Type
       builder.field "aliased_html", formatted_alias_definition if alias?
       builder.field "const", const?
       builder.field "constants", constants unless constants.empty?
-      builder.field "included_modules" do
-        builder.array do
-          included_modules.each &.to_json_simple(builder)
+      unless included_modules.empty?
+        builder.field "included_modules" do
+          builder.array do
+            included_modules.each &.to_json_simple(builder)
+          end
         end
-      end unless included_modules.empty?
-      builder.field "extended_modules" do
-        builder.array do
-          extended_modules.each &.to_json_simple(builder)
+      end
+      unless extended_modules.empty?
+        builder.field "extended_modules" do
+          builder.array do
+            extended_modules.each &.to_json_simple(builder)
+          end
         end
-      end unless extended_modules.empty?
-      builder.field "subclasses" do
-        builder.array do
-          subclasses.each &.to_json_simple(builder)
+      end
+      unless subclasses.empty?
+        builder.field "subclasses" do
+          builder.array do
+            subclasses.each &.to_json_simple(builder)
+          end
         end
-      end unless subclasses.empty?
+      end
       builder.field "including_types" do
         builder.array do
           including_types.each &.to_json_simple(builder)

--- a/src/compiler/crystal/tools/doc/type.cr
+++ b/src/compiler/crystal/tools/doc/type.cr
@@ -786,7 +786,7 @@ class Crystal::Doc::Type
       builder.field "full_name", full_name
       builder.field "name", name
       builder.field "abstract", abstract?
-      builder.field "superclass" { (s = superclass) ? s.to_json_simple(builder) : builder.null }
+      builder.field "superclass" { superclass.try &.to_json_simple(builder) } unless superclass.nil?
       builder.field "ancestors" do
         builder.array do
           ancestors.each &.to_json_simple(builder)
@@ -822,8 +822,8 @@ class Crystal::Doc::Type
         end
       end unless including_types.empty?
       builder.field "namespace" { (n = namespace) ? n.to_json_simple(builder) : builder.null }
-      builder.field "doc", doc
-      builder.field "summary", formatted_summary
+      builder.field "doc", doc unless doc.nil?
+      builder.field "summary", formatted_summary unless formatted_summary.nil?
       builder.field "class_methods", class_methods unless class_methods.empty?
       builder.field "constructors", constructors unless constructors.empty?
       builder.field "instance_methods", instance_methods unless instance_methods.empty?

--- a/src/compiler/crystal/tools/doc/type.cr
+++ b/src/compiler/crystal/tools/doc/type.cr
@@ -824,11 +824,13 @@ class Crystal::Doc::Type
           end
         end
       end
-      builder.field "including_types" do
-        builder.array do
-          including_types.each &.to_json_simple(builder)
+      unless including_types.empty?
+        builder.field "including_types" do
+          builder.array do
+            including_types.each &.to_json_simple(builder)
+          end
         end
-      end unless including_types.empty?
+      end
       builder.field "namespace" { namespace.try &.to_json_simple(builder) } unless namespace.nil?
       builder.field "doc", doc unless doc.nil?
       builder.field "summary", formatted_summary unless formatted_summary.nil?

--- a/src/compiler/crystal/tools/doc/type.cr
+++ b/src/compiler/crystal/tools/doc/type.cr
@@ -797,8 +797,8 @@ class Crystal::Doc::Type
       builder.field "program", program?
       builder.field "enum", enum?
       builder.field "alias", alias?
-      builder.field "aliased", alias? ? alias_definition.to_s : nil
-      builder.field "aliased_html", alias? ? formatted_alias_definition : nil
+      builder.field "aliased", alias_definition.to_s if alias?
+      builder.field "aliased_html", formatted_alias_definition if alias?
       builder.field "const", const?
       builder.field "constants", constants
       builder.field "included_modules" do


### PR DESCRIPTION
work towards #11427

With these changes so far, according to my testing the docs `index.json` file for the crystal stdlib goes from **12MB to** ~~8.8MB~~ **9.2MB** with no change in functionality, as only `nil` fields or empty arrays are omitted. These are handled gracefully in javascript using null-aware operators (hopefully supporting internet explorer isn't required)

This barely gets under the 10MB limiting factor brought up in the issue but there is more that could be done.  
For example, the json contains the body of every method, which I never found references to in the search, however, it could be used by others tools or displayed in the future, so I didn't remove them (yet), I'd like to hear more opinions on if that should be kept around (or put somewhere separate, not included for the search).
Removing method bodies in particular would knock off **over a megabyte**

There is definitely more that could be done, but this was the most "non-destructive" thing I could think of