### PR TITLE
[lexer] Correctly increase nesting for escaped macro "unless"

### DIFF
--- a/spec/compiler/lexer/lexer_macro_spec.cr
+++ b/spec/compiler/lexer/lexer_macro_spec.cr
@@ -574,6 +574,28 @@ describe "Lexer macro" do
     token.macro_state.nest.should eq(1)
   end
 
+  it "lexes with unless inside escaped macro (#5664)" do
+    lexer = Lexer.new(%(\\{%    unless true %} 2 \\{% end %} end))
+
+    token = lexer.next_macro_token(Token::MacroState.default, false)
+    token.type.should eq(:MACRO_LITERAL)
+    token.value.should eq("{%    unless")
+    token.macro_state.beginning_of_line.should be_false
+    token.macro_state.nest.should eq(1)
+
+    token = lexer.next_macro_token(token.macro_state, token.macro_state.beginning_of_line)
+    token.type.should eq(:MACRO_LITERAL)
+    token.value.should eq(" true %} 2 ")
+    token.macro_state.beginning_of_line.should be_false
+    token.macro_state.nest.should eq(1)
+
+    token = lexer.next_macro_token(token.macro_state, token.macro_state.beginning_of_line)
+    token.type.should eq(:MACRO_LITERAL)
+    token.value.should eq("{% end")
+    token.macro_state.beginning_of_line.should be_false
+    token.macro_state.nest.should eq(0)
+  end
+
   it "lexes begin end" do
     lexer = Lexer.new(%(begin\nend end))
     token = lexer.next_macro_token(Token::MacroState.default, false)

--- a/src/compiler/crystal/syntax/lexer.cr
+++ b/src/compiler/crystal/syntax/lexer.cr
@@ -2275,6 +2275,11 @@ module Crystal
               next_char
               nest += 1
             end
+          when 'u'
+            if next_char == 'n' && next_char == 'l' && next_char == 'e' && next_char == 's' && next_char == 's' && !ident_part_or_end?(peek_next_char)
+              next_char
+              nest += 1
+            end
           else
             # no nesting
           end


### PR DESCRIPTION
Also adds a spec for it. Fixes #5664.