### PR TITLE
[formatter] Fix weird interactions with comments near indentation

### DIFF
--- a/spec/compiler/formatter/formatter_spec.cr
+++ b/spec/compiler/formatter/formatter_spec.cr
@@ -1889,4 +1889,12 @@ describe Crystal::Formatter do
       (1 + 2) / 3
     end
     CODE
+  
+  # #10943
+  assert_format <<-CODE
+    foo do # a
+      # b
+      bar
+    end
+    CODE
 end

--- a/spec/compiler/formatter/formatter_spec.cr
+++ b/spec/compiler/formatter/formatter_spec.cr
@@ -1889,7 +1889,7 @@ describe Crystal::Formatter do
       (1 + 2) / 3
     end
     CODE
-  
+
   # #10943
   assert_format <<-CODE
     foo do # a

--- a/spec/compiler/formatter/formatter_spec.cr
+++ b/spec/compiler/formatter/formatter_spec.cr
@@ -1882,4 +1882,11 @@ describe Crystal::Formatter do
                3},
            4}
     CODE
+
+  # #10817
+  assert_format <<-CODE
+    def func # comment
+      (1 + 2) / 3
+    end
+    CODE
 end

--- a/src/compiler/crystal/tools/formatter.cr
+++ b/src/compiler/crystal/tools/formatter.cr
@@ -2957,7 +2957,8 @@ module Crystal
           write " "
         end
         write "do"
-        next_token_skip_space
+        next_token
+        skip_space(@indent + 2)
         body = format_block_args node.args, node
         old_implicit_exception_handler_indent, @implicit_exception_handler_indent = @implicit_exception_handler_indent, @indent
         format_nested_with_end body

--- a/src/compiler/crystal/tools/formatter.cr
+++ b/src/compiler/crystal/tools/formatter.cr
@@ -1466,7 +1466,8 @@ module Crystal
       write node.name
 
       indent do
-        next_token_skip_space
+        next_token
+        skip_space consume_newline: false
         next_token_skip_space if @token.type == :"="
       end
 


### PR DESCRIPTION
Fixes #10817. Fixes #10943. Adds specs for both

(#10817) Previously, if a method had no arguments and a method body began with an opening parenthesis, with a comment after the method name, that comment would be skipped but so would the newline after it, so the paren in the body would be interpreted as the delimiter for arguments instead (of which there are actually none)

(#10943) When skipping a space between `do` and its potential block arguments, before it is actually made sure that there are no block arguments, it is safe to always be indented in case there is actually a comment spanning multiple lines, because block arguments can't be on a new line on their own.