### PR TITLE
Show proper syntax errors in some edge cases in the parser

### DIFF
--- a/spec/compiler/lexer/lexer_spec.cr
+++ b/spec/compiler/lexer/lexer_spec.cr
@@ -402,6 +402,7 @@ describe "Lexer" do
   end
 
   assert_syntax_error "/foo", "Unterminated regular expression"
+  assert_syntax_error "/\\", "Unterminated regular expression"
   assert_syntax_error ":\"foo", "unterminated quoted symbol"
 
   it "lexes utf-8 char" do

--- a/spec/compiler/parser/parser_spec.cr
+++ b/spec/compiler/parser/parser_spec.cr
@@ -1121,6 +1121,9 @@ module Crystal
     it_parses "foo $1", Call.new(nil, "foo", Call.new(Global.new("$~"), "[]", 1.int32))
     it_parses "$~ = 1", Assign.new("$~".var, 1.int32)
 
+    assert_syntax_error "$2147483648"
+    assert_syntax_error "$99999999999999999999999?", "Regex capture index 99999999999999999999999 doesn't fit in an Int32"
+
     it_parses "foo /a/", Call.new(nil, "foo", regex("a"))
     it_parses "foo(/a/)", Call.new(nil, "foo", regex("a"))
     it_parses "foo(//)", Call.new(nil, "foo", regex(""))

--- a/spec/compiler/parser/parser_spec.cr
+++ b/spec/compiler/parser/parser_spec.cr
@@ -1122,7 +1122,7 @@ module Crystal
     it_parses "$~ = 1", Assign.new("$~".var, 1.int32)
 
     assert_syntax_error "$2147483648"
-    assert_syntax_error "$99999999999999999999999?", "Regex capture index 99999999999999999999999 doesn't fit in an Int32"
+    assert_syntax_error "$99999999999999999999999?", "Index $99999999999999999999999 doesn't fit in an Int32"
 
     it_parses "foo /a/", Call.new(nil, "foo", regex("a"))
     it_parses "foo(/a/)", Call.new(nil, "foo", regex("a"))

--- a/src/compiler/crystal/syntax/lexer.cr
+++ b/src/compiler/crystal/syntax/lexer.cr
@@ -2019,6 +2019,7 @@ module Crystal
         if delimiter_state.allow_escapes
           if delimiter_state.kind == :regex
             char = next_char
+            raise_unterminated_quoted delimiter_state if char == '\0'
             next_char
             @token.type = :STRING
             if char == '/' || char.ascii_whitespace?

--- a/src/compiler/crystal/syntax/parser.cr
+++ b/src/compiler/crystal/syntax/parser.cr
@@ -998,7 +998,7 @@ module Crystal
         end
         location = @token.location
         index = value.to_i?
-        raise "Regex capture index #{value} doesn't fit in an Int32" unless index
+        raise "Index $#{value} doesn't fit in an Int32" unless index
         node_and_next_token Call.new(Global.new("$~").at(location), method, NumberLiteral.new(index))
       when :__LINE__
         node_and_next_token MagicConstant.expand_line_node(@token.location)

--- a/src/compiler/crystal/syntax/parser.cr
+++ b/src/compiler/crystal/syntax/parser.cr
@@ -997,7 +997,9 @@ module Crystal
           method = "[]"
         end
         location = @token.location
-        node_and_next_token Call.new(Global.new("$~").at(location), method, NumberLiteral.new(value.to_i))
+        index = value.to_i?
+        raise "Regex capture index #{value} doesn't fit in an Int32" unless index
+        node_and_next_token Call.new(Global.new("$~").at(location), method, NumberLiteral.new(index))
       when :__LINE__
         node_and_next_token MagicConstant.expand_line_node(@token.location)
       when :__END_LINE__


### PR DESCRIPTION
* A backslash in a regex at the end of the source code was a crash.
* A regex capture `$123` with too big of an integer was a crash.

Found with [fuzzing](https://github.com/oprypin/crystal-fuzzing) :)