### PR TITLE
Optimize block-less overloads of `BitArray#fill`

### DIFF
--- a/spec/std/bit_array_spec.cr
+++ b/spec/std/bit_array_spec.cr
@@ -394,6 +394,99 @@ describe "BitArray" do
     ary.count { |b| b }.should eq(2)
   end
 
+  describe "#fill" do
+    context "without block" do
+      it "clears all bits" do
+        ba = BitArray.new(7, true)
+        ba.fill(false).none?.should be_true
+        ba.none?.should be_true
+
+        ba = BitArray.new(32, true)
+        ba.fill(false).none?.should be_true
+        ba.none?.should be_true
+
+        ba = BitArray.new(100, true)
+        ba.fill(false).none?.should be_true
+        ba.none?.should be_true
+      end
+
+      it "sets all bits" do
+        ba = BitArray.new(7)
+        ba.fill(true).all?.should be_true
+        ba.all?.should be_true
+        assert_no_unused_bits ba
+
+        ba = BitArray.new(32)
+        ba.fill(true).all?.should be_true
+        ba.all?.should be_true
+
+        ba = BitArray.new(100)
+        ba.fill(true).all?.should be_true
+        ba.all?.should be_true
+        assert_no_unused_bits ba
+      end
+    end
+
+    context "without block, with start and count" do
+      it "sets or clears a subrange of bits" do
+        ba = from_int(5, 0b01011)
+        ba.fill(true, 1, 3).should eq(from_int(5, 0b01111))
+        ba.should eq(from_int(5, 0b01111))
+        ba.fill(false, 2, 5).should eq(from_int(5, 0b01000))
+        ba.should eq(from_int(5, 0b01000))
+        ba.fill(true, -2, 7).should eq(from_int(5, 0b01011))
+        ba.should eq(from_int(5, 0b01011))
+        assert_no_unused_bits ba
+
+        ba = from_int(8, 0b11010001)
+        ba.fill(false, 1, 3).should eq(from_int(8, 0b10000001))
+        ba.should eq(from_int(8, 0b10000001))
+        ba.fill(true, 4, 5).should eq(from_int(8, 0b10001111))
+        ba.should eq(from_int(8, 0b10001111))
+        ba.fill(true, 8, 0).should eq(from_int(8, 0b10001111))
+        ba.should eq(from_int(8, 0b10001111))
+        ba.fill(true, 8, 10).should eq(from_int(8, 0b10001111))
+        ba.should eq(from_int(8, 0b10001111))
+        ba.fill(true, -6, 0).should eq(from_int(8, 0b10001111))
+        ba.should eq(from_int(8, 0b10001111))
+
+        ba = from_int(32, 0b11000101_00011111_11000001_00011101_u32)
+        ba.fill(true, 6, 15).should eq(from_int(32, 0b11000111_11111111_11111001_00011101_u32))
+        ba.should eq(from_int(32, 0b11000111_11111111_11111001_00011101_u32))
+        ba.fill(false, -20, 12).should eq(from_int(32, 0b11000111_11110000_00000000_00011101_u32))
+        ba.should eq(from_int(32, 0b11000111_11110000_00000000_00011101_u32))
+        ba.fill(true, 23, 2).should eq(from_int(32, 0b11000111_11110000_00000001_10011101_u32))
+        ba.should eq(from_int(32, 0b11000111_11110000_00000001_10011101_u32))
+        ba.fill(false, 24, 0).should eq(from_int(32, 0b11000111_11110000_00000001_10011101_u32))
+        ba.should eq(from_int(32, 0b11000111_11110000_00000001_10011101_u32))
+      end
+
+      it "raises if start index is out of range" do
+        expect_raises(IndexError) { BitArray.new(7).fill(true, 8, 0) }
+        expect_raises(IndexError) { BitArray.new(7).fill(true, -8, 0) }
+      end
+    end
+
+    context "without block, with range" do
+      it "sets or clears a subrange of bits" do
+        ba = from_int(5, 0b01011)
+        ba.fill(true, 1..3).should eq(from_int(5, 0b01111))
+        ba.should eq(from_int(5, 0b01111))
+        ba.fill(false, 2..).should eq(from_int(5, 0b01000))
+        ba.should eq(from_int(5, 0b01000))
+        ba.fill(true, ...-2).should eq(from_int(5, 0b11100))
+        ba.should eq(from_int(5, 0b11100))
+        ba.fill(true, 0...0).should eq(from_int(5, 0b11100))
+        ba.should eq(from_int(5, 0b11100))
+      end
+
+      it "raises if start index is out of range" do
+        expect_raises(IndexError) { BitArray.new(7).fill(true, 8..9) }
+        expect_raises(IndexError) { BitArray.new(7).fill(true, -8...) }
+      end
+    end
+  end
+
   describe "#reverse!" do
     it "reverses empty BitArray" do
       ba = from_int(0, 0)

--- a/src/bit_array.cr
+++ b/src/bit_array.cr
@@ -191,25 +191,26 @@ struct BitArray
     if start_bit_index == end_bit_index
       # same UInt8, don't perform the loop at all
       mask = uint8_mask(start_sub_index, end_sub_index)
-      set_bits(value, start_bit_index, mask)
+      set_bits(bytes, value, start_bit_index, mask)
     else
       mask = uint8_mask(start_sub_index, 7)
-      set_bits(value, start_bit_index, mask)
+      set_bits(bytes, value, start_bit_index, mask)
 
       bytes[start_bit_index + 1..end_bit_index - 1].fill(value ? 0xFF_u8 : 0x00_u8)
 
       mask = uint8_mask(0, end_sub_index)
-      set_bits(value, end_bit_index, mask)
+      set_bits(bytes, value, end_bit_index, mask)
     end
 
     self
   end
 
-  private macro set_bits(value, index, mask)
-    if {{ value }}
-      bytes[{{ index }}] |= {{ mask }}
+  @[AlwaysInline]
+  private def set_bits(bytes : Slice(UInt8), value, index, mask)
+    if value
+      bytes[index] |= mask
     else
-      bytes[{{ index }}] &= ~{{ mask }}
+      bytes[index] &= ~mask
     end
   end
 

--- a/src/bit_array.cr
+++ b/src/bit_array.cr
@@ -165,6 +165,54 @@ struct BitArray
     end
   end
 
+  # :inherit:
+  def fill(value : Bool) : self
+    return self if size == 0
+
+    if size <= 32
+      @bits.value = value ? ~(UInt32::MAX << size) : 0_u32
+    elsif size <= 64
+      @bits.as(UInt64*).value = value ? ~(UInt64::MAX << size) : 0_u64
+    else
+      to_slice.fill(value ? 0xFF_u8 : 0x00_u8)
+      clear_unused_bits if value
+    end
+
+    self
+  end
+
+  # :inherit:
+  def fill(value : Bool, start : Int, count : Int) : self
+    start, count = normalize_start_and_count(start, count)
+    return self if count <= 0
+    bytes = to_slice
+
+    start_bit_index, start_sub_index = start.divmod(8)
+    end_bit_index, end_sub_index = (start + count - 1).divmod(8)
+
+    if start_bit_index == end_bit_index
+      # same UInt8, don't perform the loop at all
+      mask = uint8_mask(start_sub_index, end_sub_index)
+      value ? (bytes[start_bit_index] |= mask) : (bytes[start_bit_index] &= ~mask)
+    else
+      mask = uint8_mask(start_sub_index, 7)
+      value ? (bytes[start_bit_index] |= mask) : (bytes[start_bit_index] &= ~mask)
+
+      bytes[start_bit_index + 1..end_bit_index - 1].fill(value ? 0xFF_u8 : 0x00_u8)
+
+      mask = uint8_mask(0, end_sub_index)
+      value ? (bytes[end_bit_index] |= mask) : (bytes[end_bit_index] &= ~mask)
+    end
+
+    self
+  end
+
+  # returns (1 << from) | (1 << (from + 1)) | ... | (1 << to)
+  @[AlwaysInline]
+  private def uint8_mask(from, to)
+    (Int8::MIN >> (to - from)).to_u8! >> (7 - to)
+  end
+
   # Toggles the bit at the given *index*. A `false` bit becomes a `true` bit,
   # and vice versa.
   #


### PR DESCRIPTION
Now that even more overloads of `Indexable::Mutable#fill` are available, this PR uses `Slice#fill`, i.e. `memset`, to speed up the block-less overloads of `BitArray#fill`.

Improvements over 1000x were observed on very large `BitArray`s.