### PR TITLE
Remove and resolve spurious cast and its associated FIXME

### DIFF
--- a/src/compiler/crystal/semantic/semantic_visitor.cr
+++ b/src/compiler/crystal/semantic/semantic_visitor.cr
@@ -72,8 +72,7 @@ abstract class Crystal::SemanticVisitor < Crystal::Visitor
     message = "can't find file '#{ex.filename}'"
     notes = [] of String
 
-    # FIXME: as(String) should not be necessary
-    if ex.filename.as(String).starts_with? '.'
+    if ex.filename.starts_with? '.'
       if relative_to
         message += " relative to '#{relative_to}'"
       end


### PR DESCRIPTION
According to @straight-shoota, this was needed because of a semantic bug that has been fixed since this code was merged