### PR TITLE
fix: getrandom syscall was blocking and didn't had proper error checking

### DIFF
--- a/src/crystal/system/unix/getrandom.cr
+++ b/src/crystal/system/unix/getrandom.cr
@@ -62,15 +62,16 @@ module Crystal::System::Random
       end
 
       read_bytes = sys_getrandom(buf[0, chunk_size])
-      raise RuntimeError.from_errno("getrandom") if read_bytes == -1
 
       buf += read_bytes
     end
   end
 
   # Low-level wrapper for the `getrandom(2)` syscall, returns the number of
-  # bytes read or `-1` if an error occurred (or the syscall isn't available)
-  # and sets `Errno.value`.
+  # bytes read or the errno as a negative number if an error occurred (or the
+  # syscall isn't available). This syscall is blocking by default unless the
+  # NON_BLOCK flag is passed, in which case it returns -EAGAIN if the
+  # requested entropy was not available,
   #
   # We use the kernel syscall instead of the `getrandom` C function so any
   # binary compiled for Linux will always use getrandom if the kernel is 3.17+
@@ -78,9 +79,14 @@ module Crystal::System::Random
   # portable).
   private def self.sys_getrandom(buf : Bytes)
     loop do
-      read_bytes = Syscall.getrandom(buf.to_unsafe, LibC::SizeT.new(buf.size), 0)
-      if read_bytes < 0 && (Errno.value == Errno::EINTR || Errno.value == Errno::EAGAIN)
-        ::Fiber.yield
+      read_bytes = Syscall.getrandom(buf.to_unsafe, LibC::SizeT.new(buf.size), :non_block)
+      if read_bytes < 0
+        err = Errno.new(-read_bytes.to_i)
+        if err == Errno::EINTR || err == Errno::EAGAIN
+          ::Fiber.yield
+        else
+          raise RuntimeError.from_os_error("getrandom", err)
+        end
       else
         return read_bytes
       end

--- a/src/crystal/system/unix/getrandom.cr
+++ b/src/crystal/system/unix/getrandom.cr
@@ -78,7 +78,7 @@ module Crystal::System::Random
   # portable).
   private def self.sys_getrandom(buf : Bytes)
     loop do
-      read_bytes = Syscall.getrandom(buf.to_unsafe, LibC::SizeT.new(buf.size), 1)
+      read_bytes = Syscall.getrandom(buf.to_unsafe, LibC::SizeT.new(buf.size), Syscall::GRND_NONBLOCK)
       if read_bytes < 0
         err = Errno.new(-read_bytes.to_i)
         if err == Errno::EINTR || err == Errno::EAGAIN

--- a/src/crystal/system/unix/getrandom.cr
+++ b/src/crystal/system/unix/getrandom.cr
@@ -69,9 +69,8 @@ module Crystal::System::Random
 
   # Low-level wrapper for the `getrandom(2)` syscall, returns the number of
   # bytes read or the errno as a negative number if an error occurred (or the
-  # syscall isn't available). This syscall is blocking by default unless the
-  # NON_BLOCK flag is passed, in which case it returns -EAGAIN if the
-  # requested entropy was not available,
+  # syscall isn't available). The GRND_NONBLOCK=1 flag is passed as last argument,
+  # so that it returns -EAGAIN if the requested entropy was not available.
   #
   # We use the kernel syscall instead of the `getrandom` C function so any
   # binary compiled for Linux will always use getrandom if the kernel is 3.17+
@@ -79,7 +78,7 @@ module Crystal::System::Random
   # portable).
   private def self.sys_getrandom(buf : Bytes)
     loop do
-      read_bytes = Syscall.getrandom(buf.to_unsafe, LibC::SizeT.new(buf.size), :non_block)
+      read_bytes = Syscall.getrandom(buf.to_unsafe, LibC::SizeT.new(buf.size), 1)
       if read_bytes < 0
         err = Errno.new(-read_bytes.to_i)
         if err == Errno::EINTR || err == Errno::EAGAIN

--- a/src/crystal/system/unix/syscall.cr
+++ b/src/crystal/system/unix/syscall.cr
@@ -4,5 +4,7 @@ require "c/unistd"
 require "syscall"
 
 module Crystal::System::Syscall
+  GRND_NONBLOCK = 1u32
+
   ::Syscall.def_syscall getrandom, LibC::SSizeT, buf : UInt8*, buflen : LibC::SizeT, flags : UInt32
 end

--- a/src/crystal/system/unix/syscall.cr
+++ b/src/crystal/system/unix/syscall.cr
@@ -4,12 +4,5 @@ require "c/unistd"
 require "syscall"
 
 module Crystal::System::Syscall
-  ::Syscall.def_syscall getrandom, LibC::SSizeT, buf : UInt8*, buflen : LibC::SizeT, flags : GetRandomFlags
-
-  @[Flags]
-  enum GetRandomFlags : UInt32
-    NonBlock # Don't block and return EAGAIN instead
-    Random   # No effect
-    Insecure # Return non-cryptographic random bytes
-  end
+  ::Syscall.def_syscall getrandom, LibC::SSizeT, buf : UInt8*, buflen : LibC::SizeT, flags : UInt32
 end

--- a/src/crystal/system/unix/syscall.cr
+++ b/src/crystal/system/unix/syscall.cr
@@ -4,5 +4,12 @@ require "c/unistd"
 require "syscall"
 
 module Crystal::System::Syscall
-  ::Syscall.def_syscall getrandom, LibC::SSizeT, buf : UInt8*, buflen : LibC::SizeT, flags : UInt32
+  ::Syscall.def_syscall getrandom, LibC::SSizeT, buf : UInt8*, buflen : LibC::SizeT, flags : GetRandomFlags
+
+  @[Flags]
+  enum GetRandomFlags : UInt32
+    NonBlock # Don't block and return EAGAIN instead
+    Random   # No effect
+    Insecure # Return non-cryptographic random bytes
+  end
 end


### PR DESCRIPTION
On Linux the `getrandom` syscall is used to obtain truly random bytes. It was being misused because:

1. The `flags` parameter was being passed `0`, which means the syscall will block the thread until enough entropy is available. This is clearly unintended as the code checks for `EAGAIN`. It should use the flag `1` instead. Or `GRND_NONBLOCK`. I created a flag enum for that.
2. Syscalls never set the `errno` global variable. The `errno` variable is a libc thing, not a Linux thing. Syscalls always return the error number directly as a negative value. This is confusing because the manpages usually document the libc behavior and aren't clear about this.

Both issues were already present since getrandom was introduced in 2016.