### PR TITLE
Add `BigRational#to_big_r`

### DIFF
--- a/spec/std/big/big_rational_spec.cr
+++ b/spec/std/big/big_rational_spec.cr
@@ -96,6 +96,11 @@ describe BigRational do
     r.to_big_f.should be_close(f, 0.001)
   end
 
+  it "#to_big_r" do
+    r = br(10, 3)
+    r.to_big_r.should eq(r)
+  end
+
   it "Int#to_big_r" do
     3.to_big_r.should eq(br(3, 1))
   end

--- a/src/big/big_rational.cr
+++ b/src/big/big_rational.cr
@@ -233,6 +233,17 @@ struct BigRational < Number
 
   delegate to_i8, to_i16, to_i32, to_i64, to_u8, to_u16, to_u32, to_u64, to: to_f64
 
+  # Returns `self`.
+  #
+  # ```
+  # require "big"
+  #
+  # BigRational.new(4, 5).to_big_r # => 4/5
+  # ```
+  def to_big_r : BigRational
+    self
+  end
+
   def to_big_f : BigFloat
     BigFloat.new { |mpf| LibGMP.mpf_set_q(mpf, mpq) }
   end


### PR DESCRIPTION
`#to_big_r` is defined in `Int`, `Float`, `BigInt`, and `BigDecimal`, but oddly not `BigRational` itself; since `BigRational` inherits from `Number` directly, it does not define `#to_big_r`. This PR adds it back.