### PR TITLE
Enable `LogHandler` address for win32

### DIFF
--- a/spec/std/http/server/handlers/log_handler_spec.cr
+++ b/spec/std/http/server/handlers/log_handler_spec.cr
@@ -5,24 +5,20 @@ require "../../../../support/io"
 require "../../../../support/retry"
 
 describe HTTP::LogHandler do
-  {% unless flag?(:win32) %}
-    # TODO: Remove this once `Socket` is working on Windows
+  it "logs" do
+    io = IO::Memory.new
+    request = HTTP::Request.new("GET", "/")
+    request.remote_address = Socket::IPAddress.new("192.168.0.1", 1234)
+    response = HTTP::Server::Response.new(io)
+    context = HTTP::Server::Context.new(request, response)
 
-    it "logs" do
-      io = IO::Memory.new
-      request = HTTP::Request.new("GET", "/")
-      request.remote_address = Socket::IPAddress.new("192.168.0.1", 1234)
-      response = HTTP::Server::Response.new(io)
-      context = HTTP::Server::Context.new(request, response)
-
-      called = false
-      handler = HTTP::LogHandler.new
-      handler.next = ->(ctx : HTTP::Server::Context) { called = true }
-      logs = Log.capture("http.server") { handler.call(context) }
-      logs.check(:info, %r(^192.168.0.1 - GET / HTTP/1.1 - 200 \(\d+(\.\d+)?[mµn]s\)$))
-      called.should be_true
-    end
-  {% end %}
+    called = false
+    handler = HTTP::LogHandler.new
+    handler.next = ->(ctx : HTTP::Server::Context) { called = true }
+    logs = Log.capture("http.server") { handler.call(context) }
+    logs.check(:info, %r(^192.168.0.1 - GET / HTTP/1.1 - 200 \(\d+(\.\d+)?[mµn]s\)$))
+    called.should be_true
+  end
 
   it "logs to custom logger" do
     request = HTTP::Request.new("GET", "/")

--- a/src/http/server/handlers/log_handler.cr
+++ b/src/http/server/handlers/log_handler.cr
@@ -21,18 +21,14 @@ class HTTP::LogHandler
       res = context.response
 
       addr =
-        {% begin %}
         case remote_address = req.remote_address
         when nil
           "-"
-        {% unless flag?(:win32) %}
         when Socket::IPAddress
           remote_address.address
-        {% end %}
         else
           remote_address
         end
-        {% end %}
 
       @log.info { "#{addr} - #{req.method} #{req.resource} #{req.version} - #{res.status_code} (#{elapsed_text})" }
     end


### PR DESCRIPTION
Socket has been implemented on win32 (#10784), so this code can be enabled.