### PR TITLE
Refactor some target flag uses

### DIFF
--- a/spec/compiler/codegen/c_abi/c_abi_x86_64_spec.cr
+++ b/spec/compiler/codegen/c_abi/c_abi_x86_64_spec.cr
@@ -1,164 +1,163 @@
+{% skip_file unless flag?(:x86_64) && !flag?(:win32) %}
 require "../../../spec_helper"
 
-{% if flag?(:x86_64) && !flag?(:win32) %}
-  describe "Code gen: C ABI x86_64" do
-    it "passes struct less than 64 bits as { i64 }" do
-      mod = codegen(%(
-        lib LibFoo
-          struct Struct
-            x : Int8
-            y : Int16
-          end
-
-          fun foo(s : Struct)
+describe "Code gen: C ABI x86_64" do
+  it "passes struct less than 64 bits as { i64 }" do
+    mod = codegen(%(
+      lib LibFoo
+        struct Struct
+          x : Int8
+          y : Int16
         end
 
-        s = LibFoo::Struct.new
-        LibFoo.foo(s)
-        ))
-      str = mod.to_s
-      str.should contain("call void @foo({ i64 }")
-      str.should contain("declare void @foo({ i64 })")
-    end
-
-    it "passes struct less than 64 bits as { i64 } in varargs" do
-      mod = codegen(%(
-        lib LibFoo
-          struct Struct
-            x : Int8
-            y : Int16
-          end
-
-          fun foo(...)
-        end
-
-        s = LibFoo::Struct.new
-        LibFoo.foo(s)
-        ))
-      str = mod.to_s
-      str.should contain("call void (...)")
-    end
-
-    it "passes struct between 64 and 128 bits as { i64, i64 }" do
-      mod = codegen(%(
-        lib LibFoo
-          struct Struct
-            x : Int64
-            y : Int16
-          end
-
-          fun foo(s : Struct)
-        end
-
-        s = LibFoo::Struct.new
-        LibFoo.foo(s)
-        ))
-      str = mod.to_s
-      str.should contain("call void @foo({ i64, i64 }")
-      str.should contain("declare void @foo({ i64, i64 })")
-    end
-
-    it "passes struct between 64 and 128 bits as { i64, i64 } (with multiple modules/contexts)" do
-      codegen(%(
-        require "prelude"
-
-        lib LibFoo
-          struct Struct
-            x : Int64
-            y : Int16
-          end
-
-          fun foo(s : Struct)
-        end
-
-        module Moo
-          def self.moo
-            s = LibFoo::Struct.new
-            LibFoo.foo(s)
-          end
-        end
-
-        Moo.moo
-        ))
-    end
-
-    it "passes struct bigger than128 bits with byval" do
-      mod = codegen(%(
-        lib LibFoo
-          struct Struct
-            x : Int64
-            y : Int64
-            z : Int8
-          end
-
-          fun foo(s : Struct)
-        end
-
-        s = LibFoo::Struct.new
-        LibFoo.foo(s)
-        ))
-      str = mod.to_s
-      str.scan(/byval/).size.should eq(2)
-    end
-
-    it "returns struct less than 64 bits as { i64 }" do
-      mod = codegen(%(
-        lib LibFoo
-          struct Struct
-            x : Int8
-            y : Int16
-          end
-
-          fun foo : Struct
-        end
-
-        str = LibFoo.foo
-        ))
-      str = mod.to_s
-      str.should contain("call { i64 } @foo()")
-      str.should contain("declare { i64 } @foo()")
-    end
-
-    it "returns struct between 64 and 128 bits as { i64, i64 }" do
-      mod = codegen(%(
-        lib LibFoo
-          struct Struct
-            x : Int64
-            y : Int16
-          end
-
-          fun foo : Struct
-        end
-
-        str = LibFoo.foo
-        ))
-      str = mod.to_s
-      str.should contain("call { i64, i64 } @foo()")
-      str.should contain("declare { i64, i64 } @foo()")
-    end
-
-    it "returns struct bigger than 128 bits with sret" do
-      mod = codegen(%(
-        lib LibFoo
-          struct Struct
-            x : Int64
-            y : Int64
-            z : Int8
-          end
-
-          fun foo(w : Int32) : Struct
-        end
-
-        str = LibFoo.foo(1)
-        ))
-      str = mod.to_s
-      str.scan(/sret/).size.should eq(2)
-
-      if LibLLVM::IS_LT_120
-        str.should contain("sret, i32") # sret goes as first argument
-      else
-        str.should contain("sret(%\"struct.LibFoo::Struct\") %0, i32") # sret goes as first argument
+        fun foo(s : Struct)
       end
+
+      s = LibFoo::Struct.new
+      LibFoo.foo(s)
+      ))
+    str = mod.to_s
+    str.should contain("call void @foo({ i64 }")
+    str.should contain("declare void @foo({ i64 })")
+  end
+
+  it "passes struct less than 64 bits as { i64 } in varargs" do
+    mod = codegen(%(
+      lib LibFoo
+        struct Struct
+          x : Int8
+          y : Int16
+        end
+
+        fun foo(...)
+      end
+
+      s = LibFoo::Struct.new
+      LibFoo.foo(s)
+      ))
+    str = mod.to_s
+    str.should contain("call void (...)")
+  end
+
+  it "passes struct between 64 and 128 bits as { i64, i64 }" do
+    mod = codegen(%(
+      lib LibFoo
+        struct Struct
+          x : Int64
+          y : Int16
+        end
+
+        fun foo(s : Struct)
+      end
+
+      s = LibFoo::Struct.new
+      LibFoo.foo(s)
+      ))
+    str = mod.to_s
+    str.should contain("call void @foo({ i64, i64 }")
+    str.should contain("declare void @foo({ i64, i64 })")
+  end
+
+  it "passes struct between 64 and 128 bits as { i64, i64 } (with multiple modules/contexts)" do
+    codegen(%(
+      require "prelude"
+
+      lib LibFoo
+        struct Struct
+          x : Int64
+          y : Int16
+        end
+
+        fun foo(s : Struct)
+      end
+
+      module Moo
+        def self.moo
+          s = LibFoo::Struct.new
+          LibFoo.foo(s)
+        end
+      end
+
+      Moo.moo
+      ))
+  end
+
+  it "passes struct bigger than128 bits with byval" do
+    mod = codegen(%(
+      lib LibFoo
+        struct Struct
+          x : Int64
+          y : Int64
+          z : Int8
+        end
+
+        fun foo(s : Struct)
+      end
+
+      s = LibFoo::Struct.new
+      LibFoo.foo(s)
+      ))
+    str = mod.to_s
+    str.scan(/byval/).size.should eq(2)
+  end
+
+  it "returns struct less than 64 bits as { i64 }" do
+    mod = codegen(%(
+      lib LibFoo
+        struct Struct
+          x : Int8
+          y : Int16
+        end
+
+        fun foo : Struct
+      end
+
+      str = LibFoo.foo
+      ))
+    str = mod.to_s
+    str.should contain("call { i64 } @foo()")
+    str.should contain("declare { i64 } @foo()")
+  end
+
+  it "returns struct between 64 and 128 bits as { i64, i64 }" do
+    mod = codegen(%(
+      lib LibFoo
+        struct Struct
+          x : Int64
+          y : Int16
+        end
+
+        fun foo : Struct
+      end
+
+      str = LibFoo.foo
+      ))
+    str = mod.to_s
+    str.should contain("call { i64, i64 } @foo()")
+    str.should contain("declare { i64, i64 } @foo()")
+  end
+
+  it "returns struct bigger than 128 bits with sret" do
+    mod = codegen(%(
+      lib LibFoo
+        struct Struct
+          x : Int64
+          y : Int64
+          z : Int8
+        end
+
+        fun foo(w : Int32) : Struct
+      end
+
+      str = LibFoo.foo(1)
+      ))
+    str = mod.to_s
+    str.scan(/sret/).size.should eq(2)
+
+    if LibLLVM::IS_LT_120
+      str.should contain("sret, i32") # sret goes as first argument
+    else
+      str.should contain("sret(%\"struct.LibFoo::Struct\") %0, i32") # sret goes as first argument
     end
   end
-{% end %}
+end

--- a/spec/compiler/codegen/extern_spec.cr
+++ b/spec/compiler/codegen/extern_spec.cr
@@ -167,7 +167,7 @@ describe "Codegen: extern struct" do
   # These specs *should* also work for 32 bits, but for now we'll
   # make sure they work in 64 bits (they probably work in 32 bits too,
   # it's just that the specs need to be a bit different)
-  {% if flag?(:x86_64) %}
+  {% if flag?(:bits64) %}
     it "codegens proc that takes an extern struct with C ABI" do
       test_c(
         %(

--- a/spec/compiler/codegen/extern_spec.cr
+++ b/spec/compiler/codegen/extern_spec.cr
@@ -167,7 +167,7 @@ describe "Codegen: extern struct" do
   # These specs *should* also work for 32 bits, but for now we'll
   # make sure they work in 64 bits (they probably work in 32 bits too,
   # it's just that the specs need to be a bit different)
-  {% if flag?(:bits64) %}
+  {% if flag?(:x86_64) %}
     it "codegens proc that takes an extern struct with C ABI" do
       test_c(
         %(

--- a/spec/compiler/codegen/if_spec.cr
+++ b/spec/compiler/codegen/if_spec.cr
@@ -194,7 +194,7 @@ describe "Code gen: if" do
       )).to_i.should eq(3)
   end
 
-  {% if flag?(:x86_64) %}
+  {% if flag?(:bits64) %}
     it "codegens if with pointer 0x100000000 pointer" do
       run(%(
         ptr = Pointer(Void).new(0x100000000_u64)

--- a/spec/compiler/codegen/if_spec.cr
+++ b/spec/compiler/codegen/if_spec.cr
@@ -194,7 +194,7 @@ describe "Code gen: if" do
       )).to_i.should eq(3)
   end
 
-  {% if flag?(:bits64) %}
+  {% if flag?(:x86_64) %}
     it "codegens if with pointer 0x100000000 pointer" do
       run(%(
         ptr = Pointer(Void).new(0x100000000_u64)

--- a/spec/compiler/codegen/thread_local_spec.cr
+++ b/spec/compiler/codegen/thread_local_spec.cr
@@ -1,66 +1,66 @@
+{% skip_file if flag?(:openbsd) %}
+
 require "../../spec_helper"
 
-{% if !flag?(:openbsd) %}
-  describe "Codegen: thread local" do
-    pending_win32 "works with class variables" do
-      run(%(
-      require "prelude"
+describe "Codegen: thread local" do
+  pending_win32 "works with class variables" do
+    run(%(
+    require "prelude"
 
-      class Foo
-        @[ThreadLocal]
-        @@var = 123
+    class Foo
+      @[ThreadLocal]
+      @@var = 123
 
-        def self.var
-          @@var
-        end
-
-        def self.var=(@@var)
-        end
+      def self.var
+        @@var
       end
 
-      Thread.new { Foo.var = 456 }.join
-
-      Foo.var
-    )).to_i.should eq(123)
-    end
-
-    it "works with class variable in main thread" do
-      run(%(
-      require "prelude"
-
-      class Foo
-        @[ThreadLocal]
-        @@a = 123
-
-        def self.a
-          @@a
-        end
+      def self.var=(@@var)
       end
-
-      Foo.a
-      )).to_i.should eq(123)
     end
 
-    it "compiles with class variable referenced from initializer" do
-      run(%(
-      require "prelude"
+    Thread.new { Foo.var = 456 }.join
 
-      class Foo
-        @[ThreadLocal]
-        @@x : Foo?
-        @@x = nil
-
-        def self.x
-          @@x ||= new
-        end
-
-        def initialize
-          Foo.x
-        end
-      end
-
-      0
-    ))
-    end
+    Foo.var
+  )).to_i.should eq(123)
   end
-{% end %}
+
+  it "works with class variable in main thread" do
+    run(%(
+    require "prelude"
+
+    class Foo
+      @[ThreadLocal]
+      @@a = 123
+
+      def self.a
+        @@a
+      end
+    end
+
+    Foo.a
+    )).to_i.should eq(123)
+  end
+
+  it "compiles with class variable referenced from initializer" do
+    run(%(
+    require "prelude"
+
+    class Foo
+      @[ThreadLocal]
+      @@x : Foo?
+      @@x = nil
+
+      def self.x
+        @@x ||= new
+      end
+
+      def initialize
+        Foo.x
+      end
+    end
+
+    0
+  ))
+  end
+end

--- a/spec/std/socket/address_spec.cr
+++ b/spec/std/socket/address_spec.cr
@@ -153,7 +153,7 @@ describe Socket::IPAddress do
   end
 end
 
-{% unless flag?(:win32) %}
+{% if flag?(:unix) %}
   describe Socket::UNIXAddress do
     it "transforms into a C struct and back" do
       path = "unix_address.sock"

--- a/src/lib_c.cr
+++ b/src/lib_c.cr
@@ -10,12 +10,14 @@ lib LibC
   alias Int = Int32
   alias UInt = UInt32
 
-  {% if flag?(:win32) || flag?(:i386) || flag?(:arm) %}
+  {% if flag?(:bits32) || flag?(:win32) %}
     alias Long = Int32
     alias ULong = UInt32
-  {% elsif flag?(:x86_64) || flag?(:aarch64) %}
+  {% elsif flag?(:bits64) %}
     alias Long = Int64
     alias ULong = UInt64
+  {% else %}
+    {% raise "Architecture with unsupported word size" %}
   {% end %}
 
   alias LongLong = Int64


### PR DESCRIPTION
This patch improves some macro flag uses. 

* Use `skip_file` instead of wrapping the entire content in a conditional
* Use generalized flags for arch size (`bits32` and `bits64`) instead of specific architectures
* Use `if flag?(:unix)` instead of `unless flag?(:win32)` for platform-specific opt-in