### PR TITLE
Test enable some specs

### DIFF
--- a/spec/compiler/codegen/sizeof_spec.cr
+++ b/spec/compiler/codegen/sizeof_spec.cr
@@ -185,9 +185,8 @@ describe "Code gen: sizeof" do
       )).to_i.should eq(12)
   end
 
-  {% if flag?(:x86_64) %}
-    it "returns correct sizeof for abstract struct (#4319)" do
-      size = run(%(
+  it "returns correct sizeof for abstract struct (#4319)" do
+    size = run(%(
         abstract struct Entry
         end
 
@@ -206,9 +205,8 @@ describe "Code gen: sizeof" do
         sizeof(Entry)
         )).to_i
 
-      size.should eq(16)
-    end
-  {% end %}
+    size.should eq(16)
+  end
 
   it "doesn't precompute sizeof of abstract struct (#7741)" do
     run(%(

--- a/spec/std/http/client/client_spec.cr
+++ b/spec/std/http/client/client_spec.cr
@@ -283,24 +283,19 @@ module HTTP
       end
     end
 
-    {% unless flag?(:darwin) %}
-      # TODO the following spec is failing on Nix Darwin CI when executed
-      #      together with some other tests. If run alone it succeeds.
-      #      The exhibit failure is a Failed to raise an exception: END_OF_STACK.
-      it "tests write_timeout" do
-        # Here we don't want to write a response on the server side because
-        # it doesn't make sense to try to write because the client will already
-        # timeout on read. Writing a response could lead on an exception in
-        # the server if the socket is closed.
-        test_server("localhost", 0, 0, write_response: false) do |server|
-          client = Client.new("localhost", server.local_address.port)
-          expect_raises(IO::TimeoutError, "Write timed out") do
-            client.write_timeout = 0.001
-            client.post("/", body: "a" * 5_000_000)
-          end
+    it "tests write_timeout" do
+      # Here we don't want to write a response on the server side because
+      # it doesn't make sense to try to write because the client will already
+      # timeout on read. Writing a response could lead on an exception in
+      # the server if the socket is closed.
+      test_server("localhost", 0, 0, write_response: false) do |server|
+        client = Client.new("localhost", server.local_address.port)
+        expect_raises(IO::TimeoutError, "Write timed out") do
+          client.write_timeout = 0.001
+          client.post("/", body: "a" * 5_000_000)
         end
       end
-    {% end %}
+    end
 
     it "tests connect_timeout" do
       test_server("localhost", 0, 0) do |server|


### PR DESCRIPTION
These two specs are disabled for specific platforms, but they appear to be passing. So we might be able to just remove those guards.