### PR TITLE
Use `Slice(UInt8)#fill` in the standard library

### DIFF
--- a/src/int.cr
+++ b/src/int.cr
@@ -659,7 +659,7 @@ struct Int
           if precision > count
             difference = precision - count
             ptr -= difference
-            Intrinsics.memset(ptr, '0'.ord.to_u8, difference, false)
+            Slice.new(ptr, difference).fill('0'.ord.to_u8)
             count += difference
           end
 
@@ -678,7 +678,7 @@ struct Int
               buffer += 1
             end
 
-            Intrinsics.memset(buffer, '0'.ord.to_u8, precision - count, false)
+            Slice.new(buffer, precision - count).fill('0'.ord.to_u8)
             ptr.copy_to(buffer + precision - count, count)
             {len, len}
           end

--- a/src/string.cr
+++ b/src/string.cr
@@ -3024,7 +3024,7 @@ class String
       return ""
     elsif bytesize == 1
       return String.new(times) do |buffer|
-        Intrinsics.memset(buffer.as(Void*), to_unsafe[0], times, false)
+        Slice.new(buffer, times).fill(to_unsafe[0])
         {times, times}
       end
     end
@@ -4220,7 +4220,7 @@ class String
     String.new(new_bytesize) do |buffer|
       if leftpadding > 0
         if count == 1
-          Intrinsics.memset(buffer.as(Void*), char.ord.to_u8, leftpadding.to_u32, false)
+          Slice.new(buffer, leftpadding).fill(char.ord.to_u8)
           buffer += leftpadding
         else
           leftpadding.times do
@@ -4233,7 +4233,7 @@ class String
       buffer += bytesize
       if rightpadding > 0
         if count == 1
-          Intrinsics.memset(buffer.as(Void*), char.ord.to_u8, rightpadding.to_u32, false)
+          Slice.new(buffer, rightpadding).fill(char.ord.to_u8)
         else
           rightpadding.times do
             buffer.copy_from(bytes.to_unsafe, count)


### PR DESCRIPTION
With the `memset` optimization available in the standard library since 1.2.0, this PR replaces several direct calls to `Intrinsics.memset` with `Slice(UInt8)#fill`.

(They all happen to fill some `String`'s buffer with ASCII characters.)