### PR TITLE
Add pending spec for recursive abstract struct

### DIFF
--- a/spec/compiler/codegen/debug_spec.cr
+++ b/spec/compiler/codegen/debug_spec.cr
@@ -16,31 +16,6 @@ describe "Code gen: debug" do
       ), debug: Crystal::Debug::All)
   end
 
-  it "codegens abstract struct with module include (#11385)" do
-    codegen(%(
-      module FooInterface
-      end
-
-      class Foo
-        include FooInterface
-      end
-
-      abstract struct Bar
-        include FooInterface
-
-        @a : FooInterface
-
-        def initialize(@a : FooInterface); end
-      end
-
-      class Baz
-        @b : FooInterface = Foo.new
-      end
-
-      Baz.new
-      ), debug: Crystal::Debug::All)
-  end
-
   it "inlines instance var access through getter in debug mode" do
     run(%(
       struct Bar

--- a/spec/compiler/semantic/recursive_struct_check_spec.cr
+++ b/spec/compiler/semantic/recursive_struct_check_spec.cr
@@ -80,6 +80,23 @@ describe "Semantic: recursive struct check" do
     ex.to_s.should contain "`@moo : Moo` -> `Moo` -> `Foo`"
   end
 
+  pending "errors on recursive abstract struct through module (#11384)" do
+    ex = assert_error %(
+      module Moo
+      end
+
+      abstract struct Foo
+        include Moo
+
+        def initialize(@moo : Moo)
+        end
+      end
+      ),
+      "recursive struct Foo detected"
+
+    ex.to_s.should contain "`@moo : Moo` -> `Moo` -> `Foo`"
+  end
+
   it "detects recursive generic struct through module (#4720)" do
     ex = assert_error %(
       module Bar


### PR DESCRIPTION
Removes the positive codegen spec introduced in #11390, and adds a pending negative semantic spec.

The recursive struct check should apply to abstract structs as well, even when they are leaf types:

```crystal
module Moo
end

# any attempt to instantiate `Foo` must produce a recursive non-abstract struct
abstract struct Foo
  include Moo

  def initialize(@moo : Moo)
  end
end
```

See https://github.com/crystal-lang/crystal/issues/11384#issuecomment-969673740 for details.