### PR TITLE
Unify format of "unexpected token" error

### DIFF
--- a/spec/compiler/lexer/lexer_spec.cr
+++ b/spec/compiler/lexer/lexer_spec.cr
@@ -323,9 +323,9 @@ describe "Lexer" do
   assert_syntax_error "4f65", "invalid float suffix"
   assert_syntax_error "4f22", "invalid float suffix"
   # Tests for #8782
-  assert_syntax_error "4F32", "unexpected token: F32"
-  assert_syntax_error "4F64", "unexpected token: F64"
-  assert_syntax_error "0F32", "unexpected token: F32"
+  assert_syntax_error "4F32", %(unexpected token: "F32")
+  assert_syntax_error "4F64", %(unexpected token: "F64")
+  assert_syntax_error "0F32", %(unexpected token: "F32")
 
   assert_syntax_error ".42", ".1 style number literal is not supported, put 0 before dot"
   assert_syntax_error "-.42", ".1 style number literal is not supported, put 0 before dot"

--- a/spec/compiler/parser/parser_spec.cr
+++ b/spec/compiler/parser/parser_spec.cr
@@ -184,8 +184,8 @@ module Crystal
 
     it_parses "あ.い, う.え.お = 1, 2", MultiAssign.new([Call.new("あ".call, "い"), Call.new(Call.new("う".call, "え"), "お")] of ASTNode, [1.int32, 2.int32] of ASTNode)
 
-    assert_syntax_error "b? = 1", "unexpected token: ="
-    assert_syntax_error "b! = 1", "unexpected token: ="
+    assert_syntax_error "b? = 1", "unexpected token: '='"
+    assert_syntax_error "b! = 1", "unexpected token: '='"
     assert_syntax_error "a, B = 1, 2", "can't assign to constant in multiple assignment"
 
     assert_syntax_error "1 == 2, a = 4"
@@ -220,8 +220,8 @@ module Crystal
     it_parses "def type(type); end", Def.new("type", ["type".arg])
 
     # #4815
-    assert_syntax_error "def foo!=; end", "unexpected token: !="
-    assert_syntax_error "def foo?=(x); end", "unexpected token: ?"
+    assert_syntax_error "def foo!=; end", %(unexpected token: "!=")
+    assert_syntax_error "def foo?=(x); end", %(unexpected token: "?")
 
     # #5856
     assert_syntax_error "def foo=(a,b); end", "setter method 'foo=' cannot have more than one parameter"
@@ -1635,8 +1635,8 @@ module Crystal
 
     assert_syntax_error %q(asm("nop" ::: "#{foo}")), "interpolation not allowed in asm clobber"
     assert_syntax_error %q(asm("nop" :::: "#{volatile}")), "interpolation not allowed in asm option"
-    assert_syntax_error %q(asm("" ::: ""(var))), "unexpected token: ("
-    assert_syntax_error %q(asm("" : 1)), "unexpected token: 1"
+    assert_syntax_error %q(asm("" ::: ""(var))), %{unexpected token: "("}
+    assert_syntax_error %q(asm("" : 1)), %(unexpected token: "1")
 
     it_parses "foo begin\nbar do\nend\nend", Call.new(nil, "foo", Expressions.new([Call.new(nil, "bar", block: Block.new)] of ASTNode))
     it_parses "foo 1.bar do\nend", Call.new(nil, "foo", args: [Call.new(1.int32, "bar")] of ASTNode, block: Block.new)
@@ -1710,7 +1710,7 @@ module Crystal
     it_parses %({foo:'a', bar:'b'}), NamedTupleLiteral.new([NamedTupleLiteral::Entry.new("foo", CharLiteral.new('a')), NamedTupleLiteral::Entry.new("bar", CharLiteral.new('b'))])
     it_parses %({foo:a, bar:b}), NamedTupleLiteral.new([NamedTupleLiteral::Entry.new("foo", "a".call), NamedTupleLiteral::Entry.new("bar", "b".call)])
 
-    assert_syntax_error "return do\nend", "unexpected token: do"
+    assert_syntax_error "return do\nend", %(unexpected token: "do")
 
     %w(def macro class struct module fun alias abstract include extend lib).each do |keyword|
       assert_syntax_error "def foo\n#{keyword}\nend"
@@ -1734,7 +1734,7 @@ module Crystal
 
     assert_syntax_error "case when .foo? then 1; end"
     assert_syntax_error "macro foo;{%end};end"
-    assert_syntax_error "foo {1, 2}", "unexpected token: ,"
+    assert_syntax_error "foo {1, 2}", %(unexpected token: ",")
     assert_syntax_error "pointerof(self)", "can't take address of self"
     assert_syntax_error "def foo 1; end"
 
@@ -1747,8 +1747,8 @@ module Crystal
     assert_syntax_error %(macro foo x; 1 + 2; end), "parentheses are mandatory for macro parameters"
     assert_syntax_error %(macro foo x\n 1 + 2; end), "parentheses are mandatory for macro parameters"
 
-    assert_syntax_error "1 2", "unexpected token: 2"
-    assert_syntax_error "macro foo(*x, *y); end", "unexpected token: *"
+    assert_syntax_error "1 2", %(unexpected token: "2")
+    assert_syntax_error "macro foo(*x, *y); end", %(unexpected token: "*")
 
     assert_syntax_error "foo x: 1, x: 1", "duplicated named argument: x", 1, 11
 
@@ -1805,8 +1805,8 @@ module Crystal
     assert_syntax_error "/foo)/", "invalid regex"
     assert_syntax_error "def =\nend"
     assert_syntax_error "def foo; A = 1; end", "dynamic constant assignment. Constants can only be declared at the top level or inside other types."
-    assert_syntax_error "{1, ->{ |x| x } }", "unexpected token '|'"
-    assert_syntax_error "{1, ->do\n|x| x\end }", "unexpected token '|'"
+    assert_syntax_error "{1, ->{ |x| x } }", "unexpected token: '|'"
+    assert_syntax_error "{1, ->do\n|x| x\end }", "unexpected token: '|'"
 
     assert_syntax_error "1 while 3", "trailing `while` is not supported"
     assert_syntax_error "1 until 3", "trailing `until` is not supported"
@@ -1825,7 +1825,7 @@ module Crystal
     assert_syntax_error "def foo(x: Int32); end", "space required before colon in type restriction"
     assert_syntax_error "def foo(x :Int32); end", "space required after colon in type restriction"
 
-    assert_syntax_error "def f end", "unexpected token: end (expected ';' or newline)"
+    assert_syntax_error "def f end", %(unexpected token: "end" (expected ';' or newline))
 
     assert_syntax_error "fun foo\nclass", "can't define class inside fun"
     assert_syntax_error "fun foo\nFoo = 1", "dynamic constant assignment"

--- a/spec/compiler/parser/parser_spec.cr
+++ b/spec/compiler/parser/parser_spec.cr
@@ -184,8 +184,8 @@ module Crystal
 
     it_parses "あ.い, う.え.お = 1, 2", MultiAssign.new([Call.new("あ".call, "い"), Call.new(Call.new("う".call, "え"), "お")] of ASTNode, [1.int32, 2.int32] of ASTNode)
 
-    assert_syntax_error "b? = 1", "unexpected token: '='"
-    assert_syntax_error "b! = 1", "unexpected token: '='"
+    assert_syntax_error "b? = 1", %(unexpected token: "=")
+    assert_syntax_error "b! = 1", %(unexpected token: "=")
     assert_syntax_error "a, B = 1, 2", "can't assign to constant in multiple assignment"
 
     assert_syntax_error "1 == 2, a = 4"
@@ -1805,8 +1805,8 @@ module Crystal
     assert_syntax_error "/foo)/", "invalid regex"
     assert_syntax_error "def =\nend"
     assert_syntax_error "def foo; A = 1; end", "dynamic constant assignment. Constants can only be declared at the top level or inside other types."
-    assert_syntax_error "{1, ->{ |x| x } }", "unexpected token: '|'"
-    assert_syntax_error "{1, ->do\n|x| x\end }", "unexpected token: '|'"
+    assert_syntax_error "{1, ->{ |x| x } }", %(unexpected token: "|")
+    assert_syntax_error "{1, ->do\n|x| x\end }", %(unexpected token: "|")
 
     assert_syntax_error "1 while 3", "trailing `while` is not supported"
     assert_syntax_error "1 until 3", "trailing `until` is not supported"
@@ -1825,7 +1825,7 @@ module Crystal
     assert_syntax_error "def foo(x: Int32); end", "space required before colon in type restriction"
     assert_syntax_error "def foo(x :Int32); end", "space required after colon in type restriction"
 
-    assert_syntax_error "def f end", %(unexpected token: "end" (expected ';' or newline))
+    assert_syntax_error "def f end", %(unexpected token: "end" (expected ";" or newline))
 
     assert_syntax_error "fun foo\nclass", "can't define class inside fun"
     assert_syntax_error "fun foo\nFoo = 1", "dynamic constant assignment"

--- a/src/compiler/crystal/syntax/parser.cr
+++ b/src/compiler/crystal/syntax/parser.cr
@@ -378,7 +378,7 @@ module Crystal
             end
 
             if atomic.is_a?(Call) && (atomic.name.ends_with?('?') || atomic.name.ends_with?('!'))
-              raise "unexpected token: '='", location
+              raise %(unexpected token: "="), location
             end
 
             atomic = Var.new(atomic.name).at(atomic) if atomic.is_a?(Call)
@@ -1865,7 +1865,7 @@ module Crystal
         next_token_skip_space
 
         msg = String.build do |msg|
-          msg << "unexpected token: '|', proc literals specify their parameters like this: ->("
+          msg << %[unexpected token: "|", proc literals specify their parameters like this: ->(]
           if @token.type == :IDENT
             msg << @token.value.to_s << " : Type"
             next_token_skip_space_or_newline
@@ -3182,7 +3182,7 @@ module Crystal
         when :"}"
           break
         else
-          unexpected_token msg: "expecting ',' or '}'"
+          unexpected_token msg: %(expecting "," or "}")
         end
       end
       exps
@@ -3561,7 +3561,7 @@ module Crystal
         end
       when :IDENT, :INSTANCE_VAR, :CLASS_VAR, :"*", :"**"
         if @token.keyword?(:end)
-          unexpected_token @token.to_s, "expected ';' or newline"
+          unexpected_token @token.to_s, %(expected ";" or newline)
         else
           unexpected_token @token.to_s, "parentheses are mandatory for def parameters"
         end

--- a/src/compiler/crystal/syntax/parser.cr
+++ b/src/compiler/crystal/syntax/parser.cr
@@ -345,6 +345,7 @@ module Crystal
     def parse_op_assign(allow_ops = true, allow_suffix = true)
       doc = @token.doc
       location = @token.location
+      start_token = @token
 
       atomic = parse_question_colon
 
@@ -378,7 +379,7 @@ module Crystal
             end
 
             if atomic.is_a?(Call) && (atomic.name.ends_with?('?') || atomic.name.ends_with?('!'))
-              raise %(unexpected token: "="), location
+              unexpected_token token: start_token
             end
 
             atomic = Var.new(atomic.name).at(atomic) if atomic.is_a?(Call)
@@ -3934,14 +3935,14 @@ module Crystal
       else
         if external_name
           if found_string_literal
-            raise "unexpected token: #{@token.inspect}, expected parameter internal name"
+            unexpected_token "expected parameter internal name"
           end
           if invalid_internal_name
             raise "cannot use '#{invalid_internal_name}' as a parameter name", invalid_internal_name
           end
           arg_name = external_name
         else
-          raise "unexpected token: #{@token.inspect}"
+          unexpected_token
         end
       end
 

--- a/src/compiler/crystal/syntax/parser.cr
+++ b/src/compiler/crystal/syntax/parser.cr
@@ -3182,7 +3182,7 @@ module Crystal
         when :"}"
           break
         else
-          unexpected_token @token, "expecting ',' or '}'"
+          unexpected_token msg: "expecting ',' or '}'"
         end
       end
       exps
@@ -6105,11 +6105,19 @@ module Crystal
       @token.value.to_s
     end
 
-    def unexpected_token(token = @token.to_s, msg = nil)
+    def unexpected_token(token : String, msg = nil)
       if msg
         raise "unexpected token: #{token.inspect} (#{msg})", @token
       else
         raise "unexpected token: #{token.inspect}", @token
+      end
+    end
+
+    def unexpected_token(*, msg = nil)
+      if msg
+        raise "unexpected token: #{@token.type == :EOF ? "EOF" : token.to_s.inspect} (#{msg})", @token
+      else
+        raise "unexpected token: #{@token.type == :EOF ? "EOF" : token.to_s.inspect}", @token
       end
     end
 

--- a/src/compiler/crystal/syntax/parser.cr
+++ b/src/compiler/crystal/syntax/parser.cr
@@ -898,7 +898,7 @@ module Crystal
         name = parse_responds_to_name
         next_token_skip_space
       else
-        unexpected_token msg: "expected space or '('"
+        unexpected_token "expected space or '('"
       end
 
       RespondsTo.new(atomic, name)
@@ -906,7 +906,7 @@ module Crystal
 
     def parse_responds_to_name
       if @token.type != :SYMBOL
-        unexpected_token msg: "expected symbol"
+        unexpected_token "expected symbol"
       end
 
       @token.value.to_s
@@ -1786,7 +1786,7 @@ module Crystal
         end
       end
 
-      unexpected_token "(" if @token.type == :"("
+      unexpected_token if @token.type == :"("
 
       node = Expressions.new(exps)
       node.keyword = :"("
@@ -2739,10 +2739,10 @@ module Crystal
             next_token
             break
           else
-            unexpected_token @token.to_s, "expecting when, else or end"
+            unexpected_token "expecting when, else or end"
           end
         else
-          unexpected_token @token.to_s, "expecting when, else or end"
+          unexpected_token "expecting when, else or end"
         end
       end
 
@@ -2820,7 +2820,7 @@ module Crystal
           skip_statement_end
           return true
         else
-          unexpected_token @token.to_s, "expecting ',', ';' or '\n'"
+          unexpected_token "expecting ',', ';' or '\n'"
         end
       end
       false
@@ -2876,7 +2876,7 @@ module Crystal
 
             skip_space
             unless when_expression_end
-              unexpected_token @token.to_s, "expecting then, ';' or newline"
+              unexpected_token "expecting then, ';' or newline"
             end
             skip_statement_end
 
@@ -2886,7 +2886,7 @@ module Crystal
             whens << Select::When.new(condition, body)
           when :else
             if whens.size == 0
-              unexpected_token @token.to_s, "expecting when"
+              unexpected_token "expecting when"
             end
             slash_is_regex!
             next_token_skip_statement_end
@@ -2897,15 +2897,15 @@ module Crystal
             break
           when :end
             if whens.empty?
-              unexpected_token @token.to_s, "expecting when, else or end"
+              unexpected_token "expecting when, else or end"
             end
             next_token
             break
           else
-            unexpected_token @token.to_s, "expecting when, else or end"
+            unexpected_token "expecting when, else or end"
           end
         else
-          unexpected_token @token.to_s, "expecting when, else or end"
+          unexpected_token "expecting when, else or end"
         end
       end
 
@@ -3070,9 +3070,9 @@ module Crystal
           next_token
         when :IDENT, :"*"
           if @token.keyword?(:end)
-            unexpected_token @token.to_s, "expected ';' or newline"
+            unexpected_token "expected ';' or newline"
           else
-            unexpected_token @token.to_s, "parentheses are mandatory for macro parameters"
+            unexpected_token "parentheses are mandatory for macro parameters"
           end
         when :";", :"NEWLINE"
           # Skip
@@ -3182,7 +3182,7 @@ module Crystal
         when :"}"
           break
         else
-          unexpected_token msg: %(expecting "," or "}")
+          unexpected_token %(expecting "," or "}")
         end
       end
       exps
@@ -3264,7 +3264,7 @@ module Crystal
                   when :IDENT
                     @token.value.to_s
                   else
-                    unexpected_token msg: "expecting ident or underscore"
+                    unexpected_token "expecting ident or underscore"
                   end
             vars << Var.new(var).at(@token.location)
 
@@ -3561,16 +3561,16 @@ module Crystal
         end
       when :IDENT, :INSTANCE_VAR, :CLASS_VAR, :"*", :"**"
         if @token.keyword?(:end)
-          unexpected_token @token.to_s, %(expected ";" or newline)
+          unexpected_token %(expected ";" or newline)
         else
-          unexpected_token @token.to_s, "parentheses are mandatory for def parameters"
+          unexpected_token "parentheses are mandatory for def parameters"
         end
       when :";", :"NEWLINE"
         # Skip
       when :":"
         # Skip
       when :"&"
-        unexpected_token @token.to_s, "parentheses are mandatory for def parameters"
+        unexpected_token "parentheses are mandatory for def parameters"
       when :SYMBOL
         raise "a space is mandatory between ':' and return type", @token
       else
@@ -6105,19 +6105,12 @@ module Crystal
       @token.value.to_s
     end
 
-    def unexpected_token(token : String, msg = nil)
+    def unexpected_token(msg : String? = nil, token : Token = @token)
+      token_str = token.type == :EOF ? "EOF" : token.to_s.inspect
       if msg
-        raise "unexpected token: #{token.inspect} (#{msg})", @token
+        raise "unexpected token: #{token_str} (#{msg})", @token
       else
-        raise "unexpected token: #{token.inspect}", @token
-      end
-    end
-
-    def unexpected_token(*, msg = nil)
-      if msg
-        raise "unexpected token: #{@token.type == :EOF ? "EOF" : token.to_s.inspect} (#{msg})", @token
-      else
-        raise "unexpected token: #{@token.type == :EOF ? "EOF" : token.to_s.inspect}", @token
+        raise "unexpected token: #{token_str}", @token
       end
     end
 

--- a/src/compiler/crystal/syntax/parser.cr
+++ b/src/compiler/crystal/syntax/parser.cr
@@ -378,7 +378,7 @@ module Crystal
             end
 
             if atomic.is_a?(Call) && (atomic.name.ends_with?('?') || atomic.name.ends_with?('!'))
-              raise "unexpected token: =", location
+              raise "unexpected token: '='", location
             end
 
             atomic = Var.new(atomic.name).at(atomic) if atomic.is_a?(Call)
@@ -1865,7 +1865,7 @@ module Crystal
         next_token_skip_space
 
         msg = String.build do |msg|
-          msg << "unexpected token '|', proc literals specify their parameters like this: ->("
+          msg << "unexpected token: '|', proc literals specify their parameters like this: ->("
           if @token.type == :IDENT
             msg << @token.value.to_s << " : Type"
             next_token_skip_space_or_newline
@@ -3934,14 +3934,14 @@ module Crystal
       else
         if external_name
           if found_string_literal
-            raise "unexpected token: #{@token}, expected parameter internal name"
+            raise "unexpected token: #{@token.inspect}, expected parameter internal name"
           end
           if invalid_internal_name
             raise "cannot use '#{invalid_internal_name}' as a parameter name", invalid_internal_name
           end
           arg_name = external_name
         else
-          raise "unexpected token: #{@token}"
+          raise "unexpected token: #{@token.inspect}"
         end
       end
 
@@ -6107,9 +6107,9 @@ module Crystal
 
     def unexpected_token(token = @token.to_s, msg = nil)
       if msg
-        raise "unexpected token: #{token} (#{msg})", @token
+        raise "unexpected token: #{token.inspect} (#{msg})", @token
       else
-        raise "unexpected token: #{token}", @token
+        raise "unexpected token: #{token.inspect}", @token
       end
     end
 

--- a/src/json/parser.cr
+++ b/src/json/parser.cr
@@ -118,7 +118,7 @@ class JSON::Parser
   end
 
   private def unexpected_token
-    parse_exception "unexpected token '#{token}'"
+    parse_exception "unexpected token #{token.inspect}"
   end
 
   private def parse_exception(msg)

--- a/src/json/parser.cr
+++ b/src/json/parser.cr
@@ -118,7 +118,7 @@ class JSON::Parser
   end
 
   private def unexpected_token
-    parse_exception "unexpected token #{token.inspect}"
+    parse_exception "unexpected token: #{token.inspect}"
   end
 
   private def parse_exception(msg)

--- a/src/json/parser.cr
+++ b/src/json/parser.cr
@@ -118,7 +118,7 @@ class JSON::Parser
   end
 
   private def unexpected_token
-    parse_exception "unexpected token: #{token.inspect}"
+    parse_exception "unexpected token '#{token}'"
   end
 
   private def parse_exception(msg)


### PR DESCRIPTION
The parser error used different formats throughout different locations in the parser.
This patch standardizes on the format "unexpected token: #{token.inspect}".
Since token can be char or string, it's wrapped in single or double quotes accordingly.