### PR TITLE
Add locations for `else`, `ensure`, `end` keywords

### DIFF
--- a/spec/compiler/parser/parser_spec.cr
+++ b/spec/compiler/parser/parser_spec.cr
@@ -2258,6 +2258,16 @@ module Crystal
         node.end_location.not_nil!.column_number.should eq(10)
       end
 
+      it "sets correct locations of keywords of exception handler" do
+        parser = Parser.new("begin\nrescue\nelse\nensure\nend")
+        node = parser.parse.as(ExceptionHandler)
+        node.location.not_nil!.line_number.should eq(1)
+        node.rescues.not_nil!.first.location.not_nil!.line_number.should eq(2)
+        node.else_location.not_nil!.line_number.should eq(3)
+        node.ensure_location.not_nil!.line_number.should eq(4)
+        node.end_location.not_nil!.line_number.should eq(5)
+      end
+
       it "doesn't override yield with macro yield" do
         parser = Parser.new("def foo; yield 1; {% begin %} yield 1 {% end %}; end")
         a_def = parser.parse.as(Def)

--- a/spec/compiler/parser/parser_spec.cr
+++ b/spec/compiler/parser/parser_spec.cr
@@ -2213,6 +2213,22 @@ module Crystal
         loc.column_number.should eq(1)
       end
 
+      it "sets correct location of `else` of if statement" do
+        parser = Parser.new("if foo\nelse\nend")
+        node = parser.parse.as(If)
+        node.location.not_nil!.line_number.should eq(1)
+        node.else_location.not_nil!.line_number.should eq(2)
+        node.end_location.not_nil!.line_number.should eq(3)
+      end
+
+      it "sets correct location of `elsif` of if statement" do
+        parser = Parser.new("if foo\nelsif bar\nend")
+        node = parser.parse.as(If)
+        node.location.not_nil!.line_number.should eq(1)
+        node.else_location.not_nil!.line_number.should eq(2)
+        node.end_location.not_nil!.line_number.should eq(3)
+      end
+
       it "doesn't override yield with macro yield" do
         parser = Parser.new("def foo; yield 1; {% begin %} yield 1 {% end %}; end")
         a_def = parser.parse.as(Def)

--- a/spec/compiler/parser/parser_spec.cr
+++ b/spec/compiler/parser/parser_spec.cr
@@ -2244,6 +2244,20 @@ module Crystal
         node.end_location.not_nil!.line_number.should eq(3)
       end
 
+      it "sets correct location and end location of parenthesized empty block" do
+        parser = Parser.new("()")
+        node = parser.parse.as(Expressions)
+        node.location.not_nil!.column_number.should eq(1)
+        node.end_location.not_nil!.column_number.should eq(2)
+      end
+
+      it "sets correct location and end location of parenthesized block" do
+        parser = Parser.new("(foo; bar)")
+        node = parser.parse.as(Expressions)
+        node.location.not_nil!.column_number.should eq(1)
+        node.end_location.not_nil!.column_number.should eq(10)
+      end
+
       it "doesn't override yield with macro yield" do
         parser = Parser.new("def foo; yield 1; {% begin %} yield 1 {% end %}; end")
         a_def = parser.parse.as(Def)

--- a/spec/compiler/parser/parser_spec.cr
+++ b/spec/compiler/parser/parser_spec.cr
@@ -2229,6 +2229,14 @@ module Crystal
         node.end_location.not_nil!.line_number.should eq(3)
       end
 
+      it "sets correct location of `else` of unless statement" do
+        parser = Parser.new("unless foo\nelse\nend")
+        node = parser.parse.as(Unless)
+        node.location.not_nil!.line_number.should eq(1)
+        node.else_location.not_nil!.line_number.should eq(2)
+        node.end_location.not_nil!.line_number.should eq(3)
+      end
+
       it "doesn't override yield with macro yield" do
         parser = Parser.new("def foo; yield 1; {% begin %} yield 1 {% end %}; end")
         a_def = parser.parse.as(Def)

--- a/spec/compiler/parser/parser_spec.cr
+++ b/spec/compiler/parser/parser_spec.cr
@@ -2237,6 +2237,13 @@ module Crystal
         node.end_location.not_nil!.line_number.should eq(3)
       end
 
+      it "sets correct location and end location of `begin` block" do
+        parser = Parser.new("begin\nfoo\nend")
+        node = parser.parse.as(Expressions)
+        node.location.not_nil!.line_number.should eq(1)
+        node.end_location.not_nil!.line_number.should eq(3)
+      end
+
       it "doesn't override yield with macro yield" do
         parser = Parser.new("def foo; yield 1; {% begin %} yield 1 {% end %}; end")
         a_def = parser.parse.as(Def)

--- a/src/compiler/crystal/syntax/ast.cr
+++ b/src/compiler/crystal/syntax/ast.cr
@@ -677,6 +677,9 @@ module Crystal
     property else : ASTNode
     property? ternary : Bool
 
+    # The location of the `else` keyword if present.
+    property else_location : Location?
+
     def initialize(@cond, a_then = nil, a_else = nil, @ternary = false)
       @then = Expressions.from a_then
       @else = Expressions.from a_else

--- a/src/compiler/crystal/syntax/ast.cr
+++ b/src/compiler/crystal/syntax/ast.cr
@@ -703,6 +703,9 @@ module Crystal
     property then : ASTNode
     property else : ASTNode
 
+    # The location of the `else` keyword if present.
+    property else_location : Location?
+
     def initialize(@cond, a_then = nil, a_else = nil)
       @then = Expressions.from a_then
       @else = Expressions.from a_else

--- a/src/compiler/crystal/syntax/ast.cr
+++ b/src/compiler/crystal/syntax/ast.cr
@@ -1616,6 +1616,12 @@ module Crystal
     property implicit = false
     property suffix = false
 
+    # The location of the `else` keyword if present.
+    property else_location : Location?
+
+    # The location of the `ensure` keyword if present.
+    property ensure_location : Location?
+
     def initialize(body = nil, @rescues = nil, @else = nil, @ensure = nil)
       @body = Expressions.from body
     end

--- a/src/compiler/crystal/syntax/parser.cr
+++ b/src/compiler/crystal/syntax/parser.cr
@@ -4011,6 +4011,7 @@ module Crystal
 
       a_else = nil
       if @token.type == :IDENT
+        else_location = @token.location
         case @token.value
         when :else
           next_token_skip_statement_end
@@ -4026,7 +4027,9 @@ module Crystal
         next_token_skip_space
       end
 
-      If.new(cond, a_then, a_else).at(location).at_end(end_location)
+      node = If.new(cond, a_then, a_else).at(location).at_end(end_location)
+      node.else_location = else_location
+      node
     end
 
     def parse_unless

--- a/src/compiler/crystal/syntax/parser.cr
+++ b/src/compiler/crystal/syntax/parser.cr
@@ -1334,7 +1334,7 @@ module Crystal
       node, end_location = parse_exception_handler exps, begin_location: begin_location
       node.end_location = end_location
       if !node.is_a?(ExceptionHandler) && (!node.is_a?(Expressions) || !node.keyword.none?)
-        node = Expressions.new([node]).at(node).at_end(node)
+        node = Expressions.new([node]).at(begin_location).at_end(end_location)
       end
       node.keyword = :begin if node.is_a?(Expressions)
       node
@@ -1764,7 +1764,8 @@ module Crystal
       next_token_skip_space_or_newline
 
       if @token.type == :")"
-        node = Expressions.new([Nop.new] of ASTNode)
+        end_location = token_end_location
+        node = Expressions.new([Nop.new] of ASTNode).at(location).at_end(end_location)
         node.keyword = :paren
         return node_and_next_token node
       end
@@ -1803,7 +1804,7 @@ module Crystal
 
       unexpected_token if @token.type == :"("
 
-      node = Expressions.new(exps)
+      node = Expressions.new(exps).at(location).at_end(end_location)
       node.keyword = :paren
       node
     end

--- a/src/compiler/crystal/syntax/parser.cr
+++ b/src/compiler/crystal/syntax/parser.cr
@@ -1755,7 +1755,8 @@ module Crystal
       next_token_skip_space_or_newline
 
       if @token.type == :")"
-        node = Expressions.new([Nop.new] of ASTNode)
+        end_location = token_end_location
+        node = Expressions.new([Nop.new] of ASTNode).at(location).at_end(end_location)
         node.keyword = :"("
         return node_and_next_token node
       end
@@ -1776,12 +1777,14 @@ module Crystal
         case @token.type
         when :")"
           @wants_regex = false
+          end_location = token_end_location
           next_token_skip_space
           break
         when :NEWLINE, :";"
           next_token_skip_space
           if @token.type == :")"
             @wants_regex = false
+            end_location = token_end_location
             next_token_skip_space
             break
           end
@@ -1792,7 +1795,7 @@ module Crystal
 
       unexpected_token if @token.type == :"("
 
-      node = Expressions.new(exps)
+      node = Expressions.new(exps).at(location).at_end(end_location)
       node.keyword = :"("
       node
     end

--- a/src/compiler/crystal/syntax/parser.cr
+++ b/src/compiler/crystal/syntax/parser.cr
@@ -4051,6 +4051,7 @@ module Crystal
 
       a_else = nil
       if @token.keyword?(:else)
+        else_location = @token.location
         next_token_skip_statement_end
         a_else = parse_expressions
       end
@@ -4059,7 +4060,9 @@ module Crystal
       end_location = token_end_location
       next_token_skip_space
 
-      Unless.new(cond, a_then, a_else).at(location).at_end(end_location)
+      node = Unless.new(cond, a_then, a_else).at(location).at_end(end_location)
+      node.else_location = else_location
+      node
     end
 
     def set_visibility(node)

--- a/src/compiler/crystal/syntax/parser.cr
+++ b/src/compiler/crystal/syntax/parser.cr
@@ -1407,21 +1407,26 @@ module Crystal
     ConstOrDoubleColon = [:CONST, :"::"]
 
     def parse_rescue
+      location = @token.location
+      end_location = token_end_location
       next_token_skip_space
 
       case @token.type
       when :IDENT
         name = @token.value.to_s
         push_var_name name
+        end_location = token_end_location
         next_token_skip_space
 
         if @token.type == :":"
           next_token_skip_space_or_newline
           check ConstOrDoubleColon
           types = parse_rescue_types
+          end_location = types.last.end_location
         end
       when :CONST, :"::"
         types = parse_rescue_types
+        end_location = types.last.end_location
       else
         # keep going
       end
@@ -1434,10 +1439,11 @@ module Crystal
         body = nil
       else
         body = parse_expressions
+        end_location = body.end_location
         skip_statement_end
       end
 
-      Rescue.new(body, types, name)
+      Rescue.new(body, types, name).at(location).at_end(end_location)
     end
 
     def parse_rescue_types

--- a/src/compiler/crystal/syntax/parser.cr
+++ b/src/compiler/crystal/syntax/parser.cr
@@ -1327,13 +1327,14 @@ module Crystal
     end
 
     def parse_begin
+      begin_location = @token.location
       slash_is_regex!
       next_token_skip_statement_end
       exps = parse_expressions
       node, end_location = parse_exception_handler exps
       node.end_location = end_location
       if !node.is_a?(ExceptionHandler) && (!node.is_a?(Expressions) || node.keyword)
-        node = Expressions.new([node]).at(node).at_end(node)
+        node = Expressions.new([node]).at(begin_location).at_end(end_location)
       end
       node.keyword = :begin if node.is_a?(Expressions)
       node


### PR DESCRIPTION
This adds some `Location` fields to `If`, `Expressions`, and `ExceptionHandler` nodes for keywords `else`, `ensure`, etc. and also fills the empty `location` field of `Rescue` nodes.

These will be helpful in [Ameba](https://github.com/crystal-ameba/ameba) to report style issues. For example:

- https://github.com/crystal-ameba/ameba/pull/254
  ```cr
  # bad
  def test
    if something
      work
    end
  end

  # good
  def test
    return unless something
    work
  end
  ```
  ```cr
  # good
  def test
    if something
      work
    else
      # nothing
    end
  end
  ```
- https://github.com/crystal-ameba/ameba/blob/63a6c73/src/ameba/rule/style/redundant_begin.cr#L106-L154
  ```cr
  # bad
  def method
    begin
      read_content
    rescue
      close_file
    end
  end

  # good
  def method
    read_content
  rescue
    close_file
  end
  ```