### PR TITLE
Support OpenSSL on Windows

### DIFF
--- a/.github/workflows/win.yml
+++ b/.github/workflows/win.yml
@@ -151,7 +151,6 @@ jobs:
           path: |
             libs/crypto.lib
             libs/ssl.lib
-            libs/openssl_VERSION
           key: win-openssl-libs-3.0.0
       - name: Set up NASM
         if: steps.cache-openssl.outputs.cache-hit != 'true'
@@ -176,7 +175,9 @@ jobs:
         run: |
           cp openssl/libcrypto.lib libs/crypto.lib
           cp openssl/libssl.lib libs/ssl.lib
-          [IO.File]::WriteAllLines("libs/openssl_VERSION", "3.0.0")
+      - name: Set OpenSSL version
+        run: |
+          echo "CRYSTAL_OPENSSL_VERSION=3.0.0" >> ${env:GITHUB_ENV}
 
       - name: Cache LLVM
         id: cache-llvm

--- a/.github/workflows/win.yml
+++ b/.github/workflows/win.yml
@@ -40,7 +40,13 @@ jobs:
         id: cache-libs
         uses: actions/cache@v2
         with:
-          path: libs
+          path: | # openssl and llvm take much longer to build so they are cached separately
+            libs/pcre.lib
+            libs/gc.lib
+            libs/z.lib
+            libs/mpir.lib
+            libs/yaml.lib
+            libs/xml2.lib
           key: win-libs-${{ hashFiles('.github/workflows/win.yml') }}
       - name: Download libgc
         if: steps.cache-libs.outputs.cache-hit != 'true'
@@ -138,6 +144,40 @@ jobs:
           mv libyaml/Release/yaml.lib libs/
           mv libxml2/Release/libxml2s.lib libs/xml2.lib
 
+      - name: Cache OpenSSL
+        id: cache-openssl
+        uses: actions/cache@v2
+        with:
+          path: |
+            libs/crypto.lib
+            libs/ssl.lib
+            libs/openssl_VERSION
+          key: win-openssl-libs-3.0.0
+      - name: Set up NASM
+        if: steps.cache-openssl.outputs.cache-hit != 'true'
+        uses: ilammy/setup-nasm@v1.2.1
+      - name: Download OpenSSL
+        if: steps.cache-openssl.outputs.cache-hit != 'true'
+        run: |
+          iwr https://www.openssl.org/source/openssl-3.0.0.tar.gz -OutFile openssl.tar.gz
+          (Get-FileHash -Algorithm SHA256 .\openssl.tar.gz).hash -eq "59eedfcb46c25214c9bd37ed6078297b4df01d012267fe9e9eee31f61bc70536"
+          7z x openssl.tar.gz
+          7z x openssl.tar
+          del pax_global_header
+          mv openssl-* openssl
+      - name: Build OpenSSL
+        if: steps.cache-openssl.outputs.cache-hit != 'true'
+        working-directory: ./openssl
+        run: |
+          perl Configure VC-WIN64A /MT -static no-tests --with-zlib-lib=..\zlib\Release --with-zlib-include=..\zlib
+          nmake
+      - name: Gather OpenSSL
+        if: steps.cache-openssl.outputs.cache-hit != 'true'
+        run: |
+          cp openssl/libcrypto.lib libs/crypto.lib
+          cp openssl/libssl.lib libs/ssl.lib
+          [IO.File]::WriteAllLines("libs/openssl_VERSION", "3.0.0")
+
       - name: Cache LLVM
         id: cache-llvm
         uses: actions/cache@v2
@@ -172,6 +212,7 @@ jobs:
       - name: Set up environment
         run: |
           echo "CRYSTAL_PATH=$(pwd)\src" >> ${env:GITHUB_ENV}
+          echo "CRYSTAL_LIBRARY_PATH=$(pwd)\libs" >> ${env:GITHUB_ENV}
           echo "LIB=${env:LIB};$(pwd)\libs" >> ${env:GITHUB_ENV}
           echo "TERM=dumb" >> ${env:GITHUB_ENV}
           echo "LLVM_CONFIG=$(pwd)\llvm\bin\llvm-config.exe" >> ${env:GITHUB_ENV}
@@ -206,7 +247,7 @@ jobs:
 
       - name: Build stdlib specs executable
         run: |
-          bin\crystal.exe build spec/std_spec.cr --exclude-warnings spec/std --exclude-warnings spec/compiler -Dwithout_openssl -Di_know_what_im_doing
+          bin\crystal.exe build spec/std_spec.cr --exclude-warnings spec/std --exclude-warnings spec/compiler -Di_know_what_im_doing
       - name: Run socket specs
         run: |
           .\std_spec.exe --verbose -e TCPSocket

--- a/.github/workflows/win.yml
+++ b/.github/workflows/win.yml
@@ -154,7 +154,7 @@ jobs:
           key: win-openssl-libs-3.0.0
       - name: Set up NASM
         if: steps.cache-openssl.outputs.cache-hit != 'true'
-        uses: ilammy/setup-nasm@v1.2.1
+        uses: ilammy/setup-nasm@e2335e5fc95548c09cd2deea2768793e0e8f0941 # v1.2.1
       - name: Download OpenSSL
         if: steps.cache-openssl.outputs.cache-hit != 'true'
         run: |

--- a/spec/win32_std_spec.cr
+++ b/spec/win32_std_spec.cr
@@ -49,11 +49,11 @@ require "./std/csv/csv_spec.cr"
 require "./std/deque_spec.cr"
 require "./std/digest/adler32_spec.cr"
 require "./std/digest/crc32_spec.cr"
-# require "./std/digest/io_digest_spec.cr" (failed codegen)
-# require "./std/digest/md5_spec.cr" (failed codegen)
-# require "./std/digest/sha1_spec.cr" (failed codegen)
-# require "./std/digest/sha256_spec.cr" (failed codegen)
-# require "./std/digest/sha512_spec.cr" (failed codegen)
+require "./std/digest/io_digest_spec.cr"
+require "./std/digest/md5_spec.cr"
+require "./std/digest/sha1_spec.cr"
+require "./std/digest/sha256_spec.cr"
+require "./std/digest/sha512_spec.cr"
 require "./std/dir_spec.cr"
 require "./std/double_spec.cr"
 require "./std/ecr/ecr_lexer_spec.cr"
@@ -150,26 +150,26 @@ require "./std/mime_spec.cr"
 # require "./std/mutex_spec.cr" (failed codegen)
 require "./std/named_tuple_spec.cr"
 require "./std/number_spec.cr"
-# require "./std/oauth/access_token_spec.cr" (failed codegen)
-# require "./std/oauth/authorization_header_spec.cr" (failed codegen)
-# require "./std/oauth/consumer_spec.cr" (failed codegen)
-# require "./std/oauth/params_spec.cr" (failed codegen)
-# require "./std/oauth/request_token_spec.cr" (failed codegen)
-# require "./std/oauth/signature_spec.cr" (failed codegen)
-# require "./std/oauth2/access_token_spec.cr" (failed codegen)
+require "./std/oauth/access_token_spec.cr"
+require "./std/oauth/authorization_header_spec.cr"
+require "./std/oauth/consumer_spec.cr"
+require "./std/oauth/params_spec.cr"
+require "./std/oauth/request_token_spec.cr"
+require "./std/oauth/signature_spec.cr"
+require "./std/oauth2/access_token_spec.cr"
 # require "./std/oauth2/client_spec.cr" (failed codegen)
 # require "./std/oauth2/session_spec.cr" (failed codegen)
 require "./std/object_spec.cr"
-# require "./std/openssl/cipher_spec.cr" (failed codegen)
-# require "./std/openssl/digest_spec.cr" (failed codegen)
-# require "./std/openssl/hmac_spec.cr" (failed codegen)
-# require "./std/openssl/pkcs5_spec.cr" (failed codegen)
-# require "./std/openssl/ssl/context_spec.cr" (failed codegen)
-# require "./std/openssl/ssl/hostname_validation_spec.cr" (failed codegen)
+require "./std/openssl/cipher_spec.cr"
+require "./std/openssl/digest_spec.cr"
+require "./std/openssl/hmac_spec.cr"
+require "./std/openssl/pkcs5_spec.cr"
+require "./std/openssl/ssl/context_spec.cr"
+require "./std/openssl/ssl/hostname_validation_spec.cr"
 # require "./std/openssl/ssl/server_spec.cr" (failed codegen)
 # require "./std/openssl/ssl/socket_spec.cr" (failed codegen)
-# require "./std/openssl/x509/certificate_spec.cr" (failed codegen)
-# require "./std/openssl/x509/name_spec.cr" (failed codegen)
+require "./std/openssl/x509/certificate_spec.cr"
+require "./std/openssl/x509/name_spec.cr"
 require "./std/option_parser_spec.cr"
 require "./std/overflow_spec.cr"
 require "./std/path_spec.cr"

--- a/src/http/client/response.cr
+++ b/src/http/client/response.cr
@@ -1,154 +1,156 @@
 require "../common"
 require "mime/media_type"
 
-class HTTP::Client::Response
-  getter version : String
-  getter status : HTTP::Status
-  getter status_message : String?
-  getter headers : Headers
-  getter! body_io : IO
-  @cookies : Cookies?
+class HTTP::Client
+  class Response
+    getter version : String
+    getter status : HTTP::Status
+    getter status_message : String?
+    getter headers : Headers
+    getter! body_io : IO
+    @cookies : Cookies?
 
-  def initialize(@status : HTTP::Status, @body : String? = nil, @headers : Headers = Headers.new, status_message = nil, @version = "HTTP/1.1", @body_io = nil)
-    @status_message = status_message || @status.description
+    def initialize(@status : HTTP::Status, @body : String? = nil, @headers : Headers = Headers.new, status_message = nil, @version = "HTTP/1.1", @body_io = nil)
+      @status_message = status_message || @status.description
 
-    if Response.mandatory_body?(@status)
-      @body = "" unless @body || @body_io
-    else
-      if (@body || @body_io) && (headers["Content-Length"]? != "0")
-        raise ArgumentError.new("Status #{status.code} should not have a body")
+      if Response.mandatory_body?(@status)
+        @body = "" unless @body || @body_io
+      else
+        if (@body || @body_io) && (headers["Content-Length"]? != "0")
+          raise ArgumentError.new("Status #{status.code} should not have a body")
+        end
       end
     end
-  end
 
-  def self.new(status_code : Int32, body : String? = nil, headers : Headers = Headers.new, status_message = nil, version = "HTTP/1.1", body_io = nil)
-    new(HTTP::Status.new(status_code), body, headers, status_message, version, body_io)
-  end
-
-  def body : String
-    @body || ""
-  end
-
-  def body? : String?
-    @body
-  end
-
-  # Returns `true` if the response status code is between 200 and 299.
-  def success? : Bool
-    @status.success?
-  end
-
-  # Returns a convenience wrapper around querying and setting cookie related
-  # headers, see `HTTP::Cookies`.
-  def cookies : HTTP::Cookies
-    @cookies ||= Cookies.from_server_headers(headers)
-  end
-
-  def keep_alive? : Bool
-    HTTP.keep_alive?(self)
-  end
-
-  def content_type : String?
-    mime_type.try &.media_type
-  end
-
-  # Convenience method to retrieve the HTTP status code.
-  def status_code : Int32
-    status.code
-  end
-
-  def charset : String?
-    mime_type.try &.["charset"]?
-  end
-
-  def mime_type : MIME::MediaType?
-    if content_type = headers["Content-Type"]?.presence
-      MIME::MediaType.parse(content_type)
+    def self.new(status_code : Int32, body : String? = nil, headers : Headers = Headers.new, status_message = nil, version = "HTTP/1.1", body_io = nil)
+      new(HTTP::Status.new(status_code), body, headers, status_message, version, body_io)
     end
-  end
 
-  def to_io(io)
-    io << @version << ' ' << @status.code << ' ' << @status_message << "\r\n"
-    cookies = @cookies
-    headers = cookies ? cookies.add_response_headers(@headers) : @headers
-    HTTP.serialize_headers_and_body(io, headers, @body, @body_io, @version)
-  end
-
-  # :nodoc:
-  def consume_body_io : Nil
-    if io = @body_io
-      @body = io.gets_to_end
-      @body_io = nil
+    def body : String
+      @body || ""
     end
-  end
 
-  def self.mandatory_body?(status : HTTP::Status) : Bool
-    !(status.informational? || status.no_content? || status.not_modified?)
-  end
+    def body? : String?
+      @body
+    end
 
-  def self.supports_chunked?(version) : Bool
-    version == "HTTP/1.1"
-  end
+    # Returns `true` if the response status code is between 200 and 299.
+    def success? : Bool
+      @status.success?
+    end
 
-  def self.from_io(io, ignore_body = false, decompress = true)
-    from_io?(io, ignore_body, decompress) ||
-      raise("Unexpected end of http request")
-  end
+    # Returns a convenience wrapper around querying and setting cookie related
+    # headers, see `HTTP::Cookies`.
+    def cookies : HTTP::Cookies
+      @cookies ||= Cookies.from_server_headers(headers)
+    end
 
-  # Parses an `HTTP::Client::Response` from the given `IO`.
-  # Might return `nil` if there's no data in the `IO`,
-  # which probably means that the connection was closed.
-  def self.from_io?(io, ignore_body = false, decompress = true) : self?
-    from_io?(io, ignore_body: ignore_body, decompress: decompress) do |response|
-      if response
-        response.consume_body_io
-        return response
-      else
-        return nil
+    def keep_alive? : Bool
+      HTTP.keep_alive?(self)
+    end
+
+    def content_type : String?
+      mime_type.try &.media_type
+    end
+
+    # Convenience method to retrieve the HTTP status code.
+    def status_code : Int32
+      status.code
+    end
+
+    def charset : String?
+      mime_type.try &.["charset"]?
+    end
+
+    def mime_type : MIME::MediaType?
+      if content_type = headers["Content-Type"]?.presence
+        MIME::MediaType.parse(content_type)
       end
     end
-  end
 
-  def self.from_io(io, ignore_body = false, decompress = true)
-    from_io?(io, ignore_body, decompress) do |response|
-      if response
-        yield response
-      else
+    def to_io(io)
+      io << @version << ' ' << @status.code << ' ' << @status_message << "\r\n"
+      cookies = @cookies
+      headers = cookies ? cookies.add_response_headers(@headers) : @headers
+      HTTP.serialize_headers_and_body(io, headers, @body, @body_io, @version)
+    end
+
+    # :nodoc:
+    def consume_body_io : Nil
+      if io = @body_io
+        @body = io.gets_to_end
+        @body_io = nil
+      end
+    end
+
+    def self.mandatory_body?(status : HTTP::Status) : Bool
+      !(status.informational? || status.no_content? || status.not_modified?)
+    end
+
+    def self.supports_chunked?(version) : Bool
+      version == "HTTP/1.1"
+    end
+
+    def self.from_io(io, ignore_body = false, decompress = true)
+      from_io?(io, ignore_body, decompress) ||
         raise("Unexpected end of http request")
+    end
+
+    # Parses an `HTTP::Client::Response` from the given `IO`.
+    # Might return `nil` if there's no data in the `IO`,
+    # which probably means that the connection was closed.
+    def self.from_io?(io, ignore_body = false, decompress = true) : self?
+      from_io?(io, ignore_body: ignore_body, decompress: decompress) do |response|
+        if response
+          response.consume_body_io
+          return response
+        else
+          return nil
+        end
       end
     end
-  end
 
-  # Parses an `HTTP::Client::Response` from the given `IO` and yields
-  # it to the block. Might yield `nil` if there's no data in the `IO`,
-  # which probably means that the connection was closed.
-  def self.from_io?(io, ignore_body = false, decompress = true, &block)
-    line = io.gets(4096, chomp: true)
-    return yield nil unless line
-
-    pieces = line.split(3)
-    raise "Invalid HTTP response" if pieces.size < 2
-
-    http_version = pieces[0]
-    raise "Unsupported HTTP version: #{http_version}" unless HTTP::SUPPORTED_VERSIONS.includes?(http_version)
-
-    status_code = pieces[1].to_i?
-
-    unless status_code && 100 <= status_code < 1000
-      raise "Invalid HTTP status code: #{pieces[1]}"
+    def self.from_io(io, ignore_body = false, decompress = true)
+      from_io?(io, ignore_body, decompress) do |response|
+        if response
+          yield response
+        else
+          raise("Unexpected end of http request")
+        end
+      end
     end
 
-    status = HTTP::Status.new(status_code)
-    status_message = pieces[2]? ? pieces[2].chomp : ""
+    # Parses an `HTTP::Client::Response` from the given `IO` and yields
+    # it to the block. Might yield `nil` if there's no data in the `IO`,
+    # which probably means that the connection was closed.
+    def self.from_io?(io, ignore_body = false, decompress = true, &block)
+      line = io.gets(4096, chomp: true)
+      return yield nil unless line
 
-    body_type = HTTP::BodyType::OnDemand
-    body_type = HTTP::BodyType::Mandatory if mandatory_body?(status)
-    body_type = HTTP::BodyType::Prohibited if ignore_body
+      pieces = line.split(3)
+      raise "Invalid HTTP response" if pieces.size < 2
 
-    HTTP.parse_headers_and_body(io, body_type: body_type, decompress: decompress) do |headers, body|
-      return yield new status, nil, headers, status_message, http_version, body
+      http_version = pieces[0]
+      raise "Unsupported HTTP version: #{http_version}" unless HTTP::SUPPORTED_VERSIONS.includes?(http_version)
+
+      status_code = pieces[1].to_i?
+
+      unless status_code && 100 <= status_code < 1000
+        raise "Invalid HTTP status code: #{pieces[1]}"
+      end
+
+      status = HTTP::Status.new(status_code)
+      status_message = pieces[2]? ? pieces[2].chomp : ""
+
+      body_type = HTTP::BodyType::OnDemand
+      body_type = HTTP::BodyType::Mandatory if mandatory_body?(status)
+      body_type = HTTP::BodyType::Prohibited if ignore_body
+
+      HTTP.parse_headers_and_body(io, body_type: body_type, decompress: decompress) do |headers, body|
+        return yield new status, nil, headers, status_message, http_version, body
+      end
+
+      nil
     end
-
-    nil
   end
 end

--- a/src/openssl/lib_crypto.cr
+++ b/src/openssl/lib_crypto.cr
@@ -2,16 +2,8 @@
   lib LibCrypto
     {% if flag?(:win32) %}
       {% from_libressl = false %}
-      {% ssl_version = nil %}
-      {% for dir in Crystal::LIBRARY_PATH.split(';') %}
-        {% unless ssl_version %}
-          {% config_path = "#{dir.id}\\openssl_VERSION" %}
-          {% if config_version = read_file?(config_path) %}
-            {% ssl_version = config_version.chomp %}
-          {% end %}
-        {% end %}
-      {% end %}
-      {% ssl_version ||= "0.0.0" %}
+      {% ssl_version = env("CRYSTAL_OPENSSL_VERSION") %}
+      {% raise "Cannot determine OpenSSL version, make sure the environment variable `CRYSTAL_OPENSSL_VERSION` is set" unless ssl_version %}
     {% else %}
       {% from_libressl = (`hash pkg-config 2> /dev/null || printf %s false` != "false") &&
                          (`test -f $(pkg-config --silence-errors --variable=includedir libcrypto)/openssl/opensslv.h || printf %s false` != "false") &&

--- a/src/openssl/lib_crypto.cr
+++ b/src/openssl/lib_crypto.cr
@@ -14,8 +14,8 @@
       {% ssl_version ||= "0.0.0" %}
     {% else %}
       {% from_libressl = (`hash pkg-config 2> /dev/null || printf %s false` != "false") &&
-                        (`test -f $(pkg-config --silence-errors --variable=includedir libcrypto)/openssl/opensslv.h || printf %s false` != "false") &&
-                        (`printf "#include <openssl/opensslv.h>\nLIBRESSL_VERSION_NUMBER" | ${CC:-cc} $(pkg-config --cflags --silence-errors libcrypto || true) -E -`.chomp.split('\n').last != "LIBRESSL_VERSION_NUMBER") %}
+                         (`test -f $(pkg-config --silence-errors --variable=includedir libcrypto)/openssl/opensslv.h || printf %s false` != "false") &&
+                         (`printf "#include <openssl/opensslv.h>\nLIBRESSL_VERSION_NUMBER" | ${CC:-cc} $(pkg-config --cflags --silence-errors libcrypto || true) -E -`.chomp.split('\n').last != "LIBRESSL_VERSION_NUMBER") %}
       {% ssl_version = `hash pkg-config 2> /dev/null && pkg-config --silence-errors --modversion libcrypto || printf %s 0.0.0`.split.last.gsub(/[^0-9.]/, "") %}
     {% end %}
 
@@ -32,7 +32,7 @@
 {% if flag?(:win32) %}
   @[Link("crypto")]
   @[Link("crypt32")] # CertOpenStore, ...
-  @[Link("user32")] # GetProcessWindowStation, GetUserObjectInformationW, _MessageBoxW
+  @[Link("user32")]  # GetProcessWindowStation, GetUserObjectInformationW, _MessageBoxW
 {% else %}
   @[Link(ldflags: "`command -v pkg-config > /dev/null && pkg-config --libs --silence-errors libcrypto || printf %s '-lcrypto'`")]
 {% end %}

--- a/src/openssl/lib_crypto.cr
+++ b/src/openssl/lib_crypto.cr
@@ -1,9 +1,23 @@
 {% begin %}
   lib LibCrypto
-    {% from_libressl = (`hash pkg-config 2> /dev/null || printf %s false` != "false") &&
-                       (`test -f $(pkg-config --silence-errors --variable=includedir libcrypto)/openssl/opensslv.h || printf %s false` != "false") &&
-                       (`printf "#include <openssl/opensslv.h>\nLIBRESSL_VERSION_NUMBER" | ${CC:-cc} $(pkg-config --cflags --silence-errors libcrypto || true) -E -`.chomp.split('\n').last != "LIBRESSL_VERSION_NUMBER") %}
-    {% ssl_version = `hash pkg-config 2> /dev/null && pkg-config --silence-errors --modversion libcrypto || printf %s 0.0.0`.split.last.gsub(/[^0-9.]/, "") %}
+    {% if flag?(:win32) %}
+      {% from_libressl = false %}
+      {% ssl_version = nil %}
+      {% for dir in Crystal::LIBRARY_PATH.split(';') %}
+        {% unless ssl_version %}
+          {% config_path = "#{dir.id}\\openssl_VERSION" %}
+          {% if config_version = read_file?(config_path) %}
+            {% ssl_version = config_version.chomp %}
+          {% end %}
+        {% end %}
+      {% end %}
+      {% ssl_version ||= "0.0.0" %}
+    {% else %}
+      {% from_libressl = (`hash pkg-config 2> /dev/null || printf %s false` != "false") &&
+                        (`test -f $(pkg-config --silence-errors --variable=includedir libcrypto)/openssl/opensslv.h || printf %s false` != "false") &&
+                        (`printf "#include <openssl/opensslv.h>\nLIBRESSL_VERSION_NUMBER" | ${CC:-cc} $(pkg-config --cflags --silence-errors libcrypto || true) -E -`.chomp.split('\n').last != "LIBRESSL_VERSION_NUMBER") %}
+      {% ssl_version = `hash pkg-config 2> /dev/null && pkg-config --silence-errors --modversion libcrypto || printf %s 0.0.0`.split.last.gsub(/[^0-9.]/, "") %}
+    {% end %}
 
     {% if from_libressl %}
       LIBRESSL_VERSION = {{ ssl_version }}
@@ -15,7 +29,13 @@
   end
 {% end %}
 
-@[Link(ldflags: "`command -v pkg-config > /dev/null && pkg-config --libs --silence-errors libcrypto || printf %s '-lcrypto'`")]
+{% if flag?(:win32) %}
+  @[Link("crypto")]
+  @[Link("crypt32")] # CertOpenStore, ...
+  @[Link("user32")] # GetProcessWindowStation, GetUserObjectInformationW, _MessageBoxW
+{% else %}
+  @[Link(ldflags: "`command -v pkg-config > /dev/null && pkg-config --libs --silence-errors libcrypto || printf %s '-lcrypto'`")]
+{% end %}
 lib LibCrypto
   alias Char = LibC::Char
   alias Int = LibC::Int

--- a/src/openssl/lib_ssl.cr
+++ b/src/openssl/lib_ssl.cr
@@ -6,10 +6,24 @@ require "./lib_crypto"
 
 {% begin %}
   lib LibSSL
-    {% from_libressl = (`hash pkg-config 2> /dev/null || printf %s false` != "false") &&
-                       (`test -f $(pkg-config --silence-errors --variable=includedir libssl)/openssl/opensslv.h || printf %s false` != "false") &&
-                       (`printf "#include <openssl/opensslv.h>\nLIBRESSL_VERSION_NUMBER" | ${CC:-cc} $(pkg-config --cflags --silence-errors libssl || true) -E -`.chomp.split('\n').last != "LIBRESSL_VERSION_NUMBER") %}
-    {% ssl_version = `hash pkg-config 2> /dev/null && pkg-config --silence-errors --modversion libssl || printf %s 0.0.0`.split.last.gsub(/[^0-9.]/, "") %}
+    {% if flag?(:win32) %}
+      {% from_libressl = false %}
+      {% ssl_version = nil %}
+      {% for dir in Crystal::LIBRARY_PATH.split(';') %}
+        {% unless ssl_version %}
+          {% config_path = "#{dir.id}\\openssl_VERSION" %}
+          {% if config_version = read_file?(config_path) %}
+            {% ssl_version = config_version.chomp %}
+          {% end %}
+        {% end %}
+      {% end %}
+      {% ssl_version ||= "0.0.0" %}
+    {% else %}
+      {% from_libressl = (`hash pkg-config 2> /dev/null || printf %s false` != "false") &&
+                        (`test -f $(pkg-config --silence-errors --variable=includedir libssl)/openssl/opensslv.h || printf %s false` != "false") &&
+                        (`printf "#include <openssl/opensslv.h>\nLIBRESSL_VERSION_NUMBER" | ${CC:-cc} $(pkg-config --cflags --silence-errors libssl || true) -E -`.chomp.split('\n').last != "LIBRESSL_VERSION_NUMBER") %}
+      {% ssl_version = `hash pkg-config 2> /dev/null && pkg-config --silence-errors --modversion libssl || printf %s 0.0.0`.split.last.gsub(/[^0-9.]/, "") %}
+    {% end %}
 
     {% if from_libressl %}
       LIBRESSL_VERSION = {{ ssl_version }}
@@ -21,7 +35,14 @@ require "./lib_crypto"
   end
 {% end %}
 
-@[Link(ldflags: "`command -v pkg-config > /dev/null && pkg-config --libs --silence-errors libssl || printf %s '-lssl -lcrypto'`")]
+{% if flag?(:win32) %}
+  @[Link("ssl")]
+  @[Link("crypto")]
+  @[Link("crypt32")] # CertOpenStore, ...
+  @[Link("user32")] # GetProcessWindowStation, GetUserObjectInformationW, _MessageBoxW
+{% else %}
+  @[Link(ldflags: "`command -v pkg-config > /dev/null && pkg-config --libs --silence-errors libssl || printf %s '-lssl -lcrypto'`")]
+{% end %}
 lib LibSSL
   alias Int = LibC::Int
   alias Char = LibC::Char

--- a/src/openssl/lib_ssl.cr
+++ b/src/openssl/lib_ssl.cr
@@ -20,8 +20,8 @@ require "./lib_crypto"
       {% ssl_version ||= "0.0.0" %}
     {% else %}
       {% from_libressl = (`hash pkg-config 2> /dev/null || printf %s false` != "false") &&
-                        (`test -f $(pkg-config --silence-errors --variable=includedir libssl)/openssl/opensslv.h || printf %s false` != "false") &&
-                        (`printf "#include <openssl/opensslv.h>\nLIBRESSL_VERSION_NUMBER" | ${CC:-cc} $(pkg-config --cflags --silence-errors libssl || true) -E -`.chomp.split('\n').last != "LIBRESSL_VERSION_NUMBER") %}
+                         (`test -f $(pkg-config --silence-errors --variable=includedir libssl)/openssl/opensslv.h || printf %s false` != "false") &&
+                         (`printf "#include <openssl/opensslv.h>\nLIBRESSL_VERSION_NUMBER" | ${CC:-cc} $(pkg-config --cflags --silence-errors libssl || true) -E -`.chomp.split('\n').last != "LIBRESSL_VERSION_NUMBER") %}
       {% ssl_version = `hash pkg-config 2> /dev/null && pkg-config --silence-errors --modversion libssl || printf %s 0.0.0`.split.last.gsub(/[^0-9.]/, "") %}
     {% end %}
 
@@ -39,7 +39,7 @@ require "./lib_crypto"
   @[Link("ssl")]
   @[Link("crypto")]
   @[Link("crypt32")] # CertOpenStore, ...
-  @[Link("user32")] # GetProcessWindowStation, GetUserObjectInformationW, _MessageBoxW
+  @[Link("user32")]  # GetProcessWindowStation, GetUserObjectInformationW, _MessageBoxW
 {% else %}
   @[Link(ldflags: "`command -v pkg-config > /dev/null && pkg-config --libs --silence-errors libssl || printf %s '-lssl -lcrypto'`")]
 {% end %}

--- a/src/openssl/lib_ssl.cr
+++ b/src/openssl/lib_ssl.cr
@@ -8,16 +8,8 @@ require "./lib_crypto"
   lib LibSSL
     {% if flag?(:win32) %}
       {% from_libressl = false %}
-      {% ssl_version = nil %}
-      {% for dir in Crystal::LIBRARY_PATH.split(';') %}
-        {% unless ssl_version %}
-          {% config_path = "#{dir.id}\\openssl_VERSION" %}
-          {% if config_version = read_file?(config_path) %}
-            {% ssl_version = config_version.chomp %}
-          {% end %}
-        {% end %}
-      {% end %}
-      {% ssl_version ||= "0.0.0" %}
+      {% ssl_version = env("CRYSTAL_OPENSSL_VERSION") %}
+      {% raise "Cannot determine OpenSSL version, make sure the environment variable `CRYSTAL_OPENSSL_VERSION` is set" unless ssl_version %}
     {% else %}
       {% from_libressl = (`hash pkg-config 2> /dev/null || printf %s false` != "false") &&
                          (`test -f $(pkg-config --silence-errors --variable=includedir libssl)/openssl/opensslv.h || printf %s false` != "false") &&


### PR DESCRIPTION
This PR adds OpenSSL 3.0.0 to Windows CI as a static library. Unlike on Linux, we do not have `pkg-config` on Windows, but we do have full control over the exact libraries used by Crystal, so this PR simply ~~outputs the OpenSSL version number somewhere in `Crystal::LIBRARY_PATH` as part of the setup process, then uses the `read_file?` macro method to retrieve it at `LibCrypto` and `LibSSL`~~ retrieves the version number from the `CRYSTAL_OPENSSL_VERSION` environment variable.

Building OpenSSL locally in the same manner as CI requires [Strawberry Perl](https://strawberryperl.com/) and [NASM](https://www.nasm.us/). Although this PR doesn't have it, I have also tried LibreSSL myself and everything works too (that one uses CMake and the Microsoft assembler).

`OPENSSLDIR` is left intact (`C:\Program Files\Common Files\SSL`).

This enables 295 passing and 2 pending examples, such as the remaining digest algorithms, in the standard library test suite.