### PR TITLE
Grow large arrays more slowly

### DIFF
--- a/spec/std/array_spec.cr
+++ b/spec/std/array_spec.cr
@@ -2041,4 +2041,30 @@ describe "Array" do
       ary.skip(-1)
     end
   end
+
+  describe "capacity re-sizing" do
+    it "initializes an array capacity to INITIAL_CAPACITY" do
+      a = [] of Int32
+      a.push(1)
+      a.@capacity.should eq(3)
+    end
+
+    it "doubles capacity for arrays smaller than CAPACITY_THRESHOLD" do
+      a = Array.new(255, 1)
+      a.push(1)
+      a.@capacity.should eq(255 * 2)
+    end
+
+    it "uses slow growth heuristic for arrays larger than CAPACITY_THRESHOLD" do
+      a = Array.new(512, 1)
+      a.push(1)
+      # ~63% larger
+      a.@capacity.should eq(832)
+
+      b = Array.new(4096, 1)
+      b.push(1)
+      # ~30% larger, starts converging toward 25%
+      b.@capacity.should eq(5312)
+    end
+  end
 end

--- a/src/array.cr
+++ b/src/array.cr
@@ -2033,14 +2033,12 @@ class Array(T)
   end
 
   private def calculate_new_capacity
-    if @capacity == 0
-      3
+    return 3 if @capacity == 0
+
+    if @capacity < CAPACITY_THRESHOLD
+      @capacity * 2
     else
-      if @capacity < CAPACITY_THRESHOLD
-        @capacity * 2
-      else
-        (@capacity + 3 * CAPACITY_THRESHOLD) // 4
-      end
+      @capacity + (@capacity + 3 * CAPACITY_THRESHOLD) // 4
     end
   end
 

--- a/src/array.cr
+++ b/src/array.cr
@@ -52,6 +52,9 @@ class Array(T)
   # Size of an Array that we consider small to do linear scans or other optimizations.
   private SMALL_ARRAY_SIZE = 16
 
+  # The initial capacity reserved for new arrays; just a lucky number
+  private INITIAL_CAPACITY = 3
+
   # The capacity threshold before we stop doubling array during resize.
   private CAPACITY_THRESHOLD = 256
 
@@ -2033,7 +2036,7 @@ class Array(T)
   end
 
   private def calculate_new_capacity
-    return 3 if @capacity == 0
+    return INITIAL_CAPACITY if @capacity == 0
 
     if @capacity < CAPACITY_THRESHOLD
       @capacity * 2

--- a/src/array.cr
+++ b/src/array.cr
@@ -52,6 +52,9 @@ class Array(T)
   # Size of an Array that we consider small to do linear scans or other optimizations.
   private SMALL_ARRAY_SIZE = 16
 
+  # The capacity threshold before we stop doubling array during resize.
+  private CAPACITY_THRESHOLD = 256
+
   # The size of this array.
   @size : Int32
 
@@ -759,7 +762,7 @@ class Array(T)
     buf = @buffer + len
     other.each do |elem|
       if left_before_resize == 0
-        double_capacity
+        increase_capacity
         left_before_resize = remaining_capacity - len
         buf = @buffer + len
       end
@@ -1989,7 +1992,7 @@ class Array(T)
       # and now we don't have any offset to the root buffer
       reset_buffer_to_root_buffer
     else
-      double_capacity
+      increase_capacity
     end
   end
 
@@ -2021,7 +2024,7 @@ class Array(T)
       # `[-, -, -, 'c', 'd', -]`
       shift_buffer_by(half_capacity)
     else
-      double_capacity_for_unshift
+      increase_capacity_for_unshift
     end
   end
 
@@ -2029,8 +2032,20 @@ class Array(T)
     @capacity - @offset_to_buffer
   end
 
-  private def double_capacity
-    resize_to_capacity(@capacity == 0 ? 3 : (@capacity * 2))
+  private def calculate_new_capacity
+    if @capacity == 0
+      3
+    else
+      if @capacity < CAPACITY_THRESHOLD
+        @capacity * 2
+      else
+        (@capacity + 3 * CAPACITY_THRESHOLD) // 4
+      end
+    end
+  end
+
+  private def increase_capacity
+    resize_to_capacity(calculate_new_capacity)
   end
 
   private def resize_to_capacity(capacity)
@@ -2045,8 +2060,8 @@ class Array(T)
   # Similar to double capacity, except that after reallocating the buffer
   # we point it to the middle of the buffer in case more unshifts come right away.
   # This assumes @offset_to_buffer is zero.
-  private def double_capacity_for_unshift
-    resize_to_capacity_for_unshift(@capacity == 0 ? 3 : (@capacity * 2))
+  private def increase_capacity_for_unshift
+    resize_to_capacity_for_unshift(calculate_new_capacity)
   end
 
   private def resize_to_capacity_for_unshift(capacity)


### PR DESCRIPTION
Fixes #11445

This introduces the heuristic found in Go for re-sizing arrays. For arrays < 256 elements, the heuristic doubles array capacities as before. For arrays >= 256, it starts to limit the growth of re-sizes. It does so in a linear fashion until around ~20k elements at which it limits array growth to ~25%.

I've included a couple specs showing the progression of the array growth with the new heuristic, but let me know if we should include more progressions. I was just concerned about memory usage.

Progression examples:

| Initial Capacity  | Re-sized Capacity | Delta % |
| ----------------  | ----------------- | ------- |
| 512               | 832               | 62.5%   |
| 1024              | 1472              | 43.8%   |
| 2048              | 2752              | 34.4%   |
| 4096              | 5312              | 29.7%   |
| 8192              | 10432             | 27.3%   |
| 16384             | 20672             | 26.2%   |
| 32768             | 41152             | 25.6%   |
| 65536             | 82112             | 25.3%   |