### PR TITLE
Make Windows PDB lookup relative to running executable

### DIFF
--- a/src/compiler/crystal/compiler.cr
+++ b/src/compiler/crystal/compiler.cr
@@ -346,7 +346,12 @@ module Crystal
         object_arg = Process.quote_windows(object_names)
         output_arg = Process.quote_windows("/Fe#{output_filename}")
 
-        args = %(/nologo #{object_arg} #{output_arg} /link#{" /DEBUG:FULL" unless debug.none?} #{lib_flags} #{@link_flags}).gsub("\n", " ")
+        link_args = [] of String
+        link_args << "/DEBUG:FULL /PDBALTPATH:%_PDB%" unless debug.none?
+        link_args << lib_flags
+        @link_flags.try { |flags| link_args << flags }
+
+        args = %(/nologo #{object_arg} #{output_arg} /link #{link_args.join(' ')}).gsub("\n", " ")
         cmd = "#{CL} #{args}"
 
         if cmd.to_utf16.size > 32000

--- a/src/exception/call_stack/stackwalk.cr
+++ b/src/exception/call_stack/stackwalk.cr
@@ -23,7 +23,9 @@ struct Exception::CallStack
     # TODO: figure out if and when to call SymCleanup (it cannot be done in
     # `at_exit` because unhandled exceptions in `main_user_code` are printed
     # after those handlers)
-    if LibC.SymInitializeW(LibC.GetCurrentProcess, nil, 1) == 0
+    executable_path = Process.executable_path
+    executable_path_ptr = executable_path ? File.dirname(executable_path).to_utf16.to_unsafe : Pointer(LibC::WCHAR).null
+    if LibC.SymInitializeW(LibC.GetCurrentProcess, executable_path_ptr, 1) == 0
       raise RuntimeError.from_winerror("SymInitializeW")
     end
     LibC.SymSetOptions(LibC.SymGetOptions | LibC::SYMOPT_UNDNAME | LibC::SYMOPT_LOAD_LINES | LibC::SYMOPT_FAIL_CRITICAL_ERRORS | LibC::SYMOPT_NO_PROMPTS)


### PR DESCRIPTION
This PR makes it so that the debug database .pdb file is always searched in the same directory as the executable being run, instead of being hardcoded to the .pdb's absolute path at build time. This allows call stacks to work even when the executable is moved to a different location (**but not if it is renamed**), as long as the .pdb is also moved.