### PR TITLE
Make the Windows compiler artifact more portable

### DIFF
--- a/.github/workflows/win.yml
+++ b/.github/workflows/win.yml
@@ -212,9 +212,10 @@ jobs:
 
       - name: Set up environment
         run: |
-          echo "CRYSTAL_PATH=$(pwd)\src" >> ${env:GITHUB_ENV}
+          echo "CRYSTAL_PATH=lib;$(pwd)\src" >> ${env:GITHUB_ENV}
           echo "CRYSTAL_LIBRARY_PATH=$(pwd)\libs" >> ${env:GITHUB_ENV}
-          echo "LIB=${env:LIB};$(pwd)\libs" >> ${env:GITHUB_ENV}
+          echo 'CRYSTAL_CONFIG_PATH=$ORIGIN\..\share\crystal\src' >> ${env:GITHUB_ENV}
+          echo 'CRYSTAL_CONFIG_LIBRARY_PATH=$ORIGIN\..\lib\crystal' >> ${env:GITHUB_ENV}
           echo "TERM=dumb" >> ${env:GITHUB_ENV}
           echo "LLVM_CONFIG=$(pwd)\llvm\bin\llvm-config.exe" >> ${env:GITHUB_ENV}
           echo "SOURCE_DATE_EPOCH=$(Get-Date -Millisecond 0 -UFormat %s)" >> ${env:GITHUB_ENV}
@@ -228,7 +229,7 @@ jobs:
           cl /MT /c src\llvm\ext\llvm_ext.cc -I llvm\include /Fosrc\llvm\ext\llvm_ext.obj
       - name: Link Crystal executable
         run: |
-          Invoke-Expression "cl crystal.obj /Fecrystal-cross src\llvm\ext\llvm_ext.obj $(llvm\bin\llvm-config.exe --libs) libs\pcre.lib libs\gc.lib WS2_32.lib advapi32.lib libcmt.lib dbghelp.lib legacy_stdio_definitions.lib /F10000000"
+          Invoke-Expression "cl crystal.obj /Fecrystal-cross src\llvm\ext\llvm_ext.obj $(llvm\bin\llvm-config.exe --libs) libs\pcre.lib libs\gc.lib WS2_32.lib advapi32.lib libcmt.lib dbghelp.lib legacy_stdio_definitions.lib /link /LIBPATH:$(pwd)\libs /STACK:10000000"
 
       - name: Re-build Crystal
         run: |
@@ -237,9 +238,13 @@ jobs:
 
       - name: Gather Crystal binaries
         run: |
-          mkdir crystal
-          cp bin/crystal.exe crystal/
-          cp libs/* crystal/
+          mkdir crystal/bin
+          mkdir crystal/lib/crystal
+          mkdir crystal/share/crystal/src
+          cp bin/crystal.exe crystal/bin/
+          cp libs/* crystal/lib/crystal/
+          cp src/* crystal/share/crystal/src -Recurse
+          rm crystal/share/crystal/src/llvm/ext/llvm_ext.obj
       - name: Upload Crystal binaries
         uses: actions/upload-artifact@v2
         with:

--- a/.github/workflows/win.yml
+++ b/.github/workflows/win.yml
@@ -243,7 +243,7 @@ jobs:
           cp bin/crystal.exe crystal/
           cp libs/* crystal/lib/
           cp src/* crystal/src -Recurse
-          rm crystal/share/crystal/src/llvm/ext/llvm_ext.obj
+          rm crystal/src/llvm/ext/llvm_ext.obj
       - name: Upload Crystal binaries
         uses: actions/upload-artifact@v2
         with:

--- a/.github/workflows/win.yml
+++ b/.github/workflows/win.yml
@@ -214,8 +214,8 @@ jobs:
         run: |
           echo "CRYSTAL_PATH=lib;$(pwd)\src" >> ${env:GITHUB_ENV}
           echo "CRYSTAL_LIBRARY_PATH=$(pwd)\libs" >> ${env:GITHUB_ENV}
-          echo 'CRYSTAL_CONFIG_PATH=$ORIGIN\..\share\crystal\src' >> ${env:GITHUB_ENV}
-          echo 'CRYSTAL_CONFIG_LIBRARY_PATH=$ORIGIN\..\lib\crystal' >> ${env:GITHUB_ENV}
+          echo 'CRYSTAL_CONFIG_PATH=$ORIGIN\src' >> ${env:GITHUB_ENV}
+          echo 'CRYSTAL_CONFIG_LIBRARY_PATH=$ORIGIN\lib' >> ${env:GITHUB_ENV}
           echo "TERM=dumb" >> ${env:GITHUB_ENV}
           echo "LLVM_CONFIG=$(pwd)\llvm\bin\llvm-config.exe" >> ${env:GITHUB_ENV}
           echo "SOURCE_DATE_EPOCH=$(Get-Date -Millisecond 0 -UFormat %s)" >> ${env:GITHUB_ENV}
@@ -238,12 +238,11 @@ jobs:
 
       - name: Gather Crystal binaries
         run: |
-          mkdir crystal/bin
-          mkdir crystal/lib/crystal
-          mkdir crystal/share/crystal/src
-          cp bin/crystal.exe crystal/bin/
-          cp libs/* crystal/lib/crystal/
-          cp src/* crystal/share/crystal/src -Recurse
+          mkdir crystal/src
+          mkdir crystal/lib
+          cp bin/crystal.exe crystal/
+          cp libs/* crystal/lib/
+          cp src/* crystal/src -Recurse
           rm crystal/share/crystal/src/llvm/ext/llvm_ext.obj
       - name: Upload Crystal binaries
         uses: actions/upload-artifact@v2


### PR DESCRIPTION
This PR sets the `CRYSTAL_CONFIG_PATH` and `CRYSTAL_CONFIG_LIBRARY_PATH` variables when building the Crystal compiler on Windows<strike>, and arranges the directory structure so that it mirrors that of the other portable packages we release</strike>.

The resulting compiler no longer needs the `LIB` and `CRYSTAL_PATH` environment variables configured prior to running, nor fetch the standard library from elsewhere. All it needs now is:

* Add the root directory to `PATH`;
* Enable the MSVC developer command prompt; (not anymore after #11495 or #11496)
* Set `CRYSTAL_OPENSSL_VERSION=3.0.0` to enable OpenSSL support.

Note that the CI still overrides `CRYSTAL_PATH` and `CRYSTAL_LIBRARY_PATH` because they are needed for the development compiler to run properly. The `bin/crystal` wrapper script for non-Windows systems also does that when running `.build/crystal`.