### PR TITLE
Automatically detect MSVC tools on Windows

### DIFF
--- a/.github/workflows/win.yml
+++ b/.github/workflows/win.yml
@@ -228,7 +228,7 @@ jobs:
           cl /MT /c src\llvm\ext\llvm_ext.cc -I llvm\include /Fosrc\llvm\ext\llvm_ext.obj
       - name: Link Crystal executable
         run: |
-          Invoke-Expression "cl crystal.obj /Fecrystal-cross src\llvm\ext\llvm_ext.obj $(llvm\bin\llvm-config.exe --libs) libs\pcre.lib libs\gc.lib WS2_32.lib advapi32.lib libcmt.lib dbghelp.lib legacy_stdio_definitions.lib /F10000000"
+          Invoke-Expression "cl crystal.obj /Fecrystal-cross src\llvm\ext\llvm_ext.obj $(llvm\bin\llvm-config.exe --libs) libs\pcre.lib libs\gc.lib WS2_32.lib advapi32.lib libcmt.lib dbghelp.lib oleaut32.lib legacy_stdio_definitions.lib /F10000000"
 
       - name: Re-build Crystal
         run: |

--- a/src/compiler/crystal/compiler.cr
+++ b/src/compiler/crystal/compiler.cr
@@ -2,6 +2,10 @@ require "option_parser"
 require "file_utils"
 require "colorize"
 require "crystal/digest/md5"
+{% if flag?(:msvc) %}
+  require "crystal/system/win32/visual_studio"
+  require "crystal/system/win32/windows_sdk"
+{% end %}
 
 module Crystal
   @[Flags]
@@ -346,8 +350,37 @@ module Crystal
         object_arg = Process.quote_windows(object_names)
         output_arg = Process.quote_windows("/Fe#{output_filename}")
 
-        args = %(/nologo #{object_arg} #{output_arg} /link#{" /DEBUG:FULL" unless debug.none?} #{lib_flags} #{@link_flags}).gsub("\n", " ")
-        cmd = "#{CL} #{args}"
+        cl = CL
+        link_args = [] of String
+
+        # if the compiler and the target both have the `msvc` flag, we are not
+        # cross-compiling and therefore we should attempt detecting MSVC's
+        # standard paths
+        {% if flag?(:msvc) %}
+          if msvc_path = Crystal::System::VisualStudio.find_latest_msvc_path
+            if win_sdk_libpath = Crystal::System::WindowsSDK.find_win10_sdk_libpath
+              host_bits = {{ flag?(:bits64) ? "Hostx64" : "Hostx86" }}
+              target_bits = program.has_flag?("bits64") ? "x64" : "x86"
+
+              # MSVC build tools and Windows SDK found; recreate `LIB` environment variable
+              # that is normally expected on the MSVC developer command prompt
+              link_args << Process.quote_windows("/LIBPATH:#{msvc_path}\\atlmfc\\lib\\#{target_bits}")
+              link_args << Process.quote_windows("/LIBPATH:#{msvc_path}\\lib\\#{target_bits}")
+              link_args << Process.quote_windows("/LIBPATH:#{win_sdk_libpath}\\ucrt\\#{target_bits}")
+              link_args << Process.quote_windows("/LIBPATH:#{win_sdk_libpath}\\um\\#{target_bits}")
+
+              # use exact path for compiler instead of relying on `PATH`
+              cl = Process.quote_windows("#{msvc_path}\\bin\\#{host_bits}\\#{target_bits}\\cl.exe")
+            end
+          end
+        {% end %}
+
+        link_args << "/DEBUG:FULL" unless debug.none?
+        link_args << lib_flags
+        @link_flags.try { |flags| link_args << flags }
+
+        args = %(/nologo #{object_arg} #{output_arg} /link #{link_args.join(' ')}).gsub("\n", " ")
+        cmd = "#{cl} #{args}"
 
         if cmd.to_utf16.size > 32000
           # The command line would be too big, pass the args through a UTF-16-encoded file instead.

--- a/src/crystal/system/win32/visual_studio.cr
+++ b/src/crystal/system/win32/visual_studio.cr
@@ -1,0 +1,148 @@
+require "c/combaseapi"
+
+lib LibC
+  # Code taken from https://www.nuget.org/packages/Microsoft.VisualStudio.Setup.Configuration.Native/
+  # The following is their license:
+  #
+  # The MIT License(MIT)
+  # Copyright(C) Microsoft Corporation.All rights reserved.
+  #
+  # Permission is hereby granted, free of charge, to any person obtaining a copy
+  # of this software and associated documentation files(the "Software"), to deal
+  # in the Software without restriction, including without limitation the rights
+  # to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+  # copies of the Software, and to permit persons to whom the Software is
+  # furnished to do so, subject to the following conditions :
+  #
+  # The above copyright notice and this permission notice shall be included in
+  # all copies or substantial portions of the Software.
+  #
+  # THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  # IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  # FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.IN NO EVENT SHALL THE
+  # AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  # LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+  # FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+  # IN THE SOFTWARE.
+
+  struct ISetupInstanceVtbl
+    queryInterface : ISetupInstance*, REFIID, Void** -> DWORD
+    addRef : ISetupInstance* -> DWORD
+    release : ISetupInstance* -> DWORD
+
+    getInstanceId : ISetupInstance* -> DWORD
+    getInstallDate : ISetupInstance*, FILETIME* -> DWORD
+    getInstallationName : ISetupInstance*, BSTR* -> DWORD
+    getInstallationPath : ISetupInstance*, BSTR* -> DWORD
+    getInstallationVersion : ISetupInstance*, BSTR* -> DWORD
+    getDisplayName : ISetupInstance*, LCID, BSTR* -> DWORD
+    getDescription : ISetupInstance*, LCID, BSTR* -> DWORD
+    resolvePath : ISetupInstance*, LPCOLESTR, BSTR* -> DWORD
+  end
+
+  struct ISetupInstance
+    lpVtbl : ISetupInstanceVtbl*
+  end
+
+  struct IEnumSetupInstancesVtbl
+    queryInterface : IEnumSetupInstances*, REFIID, Void** -> DWORD
+    addRef : IEnumSetupInstances* -> DWORD
+    release : IEnumSetupInstances* -> DWORD
+
+    next : IEnumSetupInstances*, DWORD, ISetupInstance**, DWORD* -> DWORD
+    skip : IEnumSetupInstances*, DWORD -> DWORD
+    reset : IEnumSetupInstances* -> DWORD
+    clone : IEnumSetupInstances*, IEnumSetupInstances** -> DWORD
+  end
+
+  struct IEnumSetupInstances
+    lpVtbl : IEnumSetupInstancesVtbl*
+  end
+
+  struct ISetupConfigurationVtbl
+    queryInterface : ISetupConfiguration*, REFIID, Void** -> DWORD
+    addRef : ISetupConfiguration* -> DWORD
+    release : ISetupConfiguration* -> DWORD
+
+    enumInstances : ISetupConfiguration*, IEnumSetupInstances** -> DWORD
+    getInstanceForCurrentProcess : ISetupConfiguration*, ISetupInstance** -> DWORD
+    getInstanceForPath : ISetupConfiguration*, WCHAR*, ISetupInstance** -> DWORD
+  end
+
+  struct ISetupConfiguration
+    lpVtbl : ISetupConfigurationVtbl*
+  end
+
+  CLSID_SetupConfiguration = GUID.new(0x177F0C4A, 0x1CD3, 0x4DE7, UInt8.static_array(0xA3, 0x2C, 0x71, 0xDB, 0xBB, 0x9F, 0xA3, 0x6D))
+  IID_ISetupConfiguration  = GUID.new(0x42843719, 0xDB4C, 0x46C2, UInt8.static_array(0x8E, 0x7C, 0x64, 0xF1, 0x81, 0x6E, 0xFD, 0x5B))
+end
+
+private macro com_call(call)
+  {{ call.receiver }}.value.lpVtbl.value.{{ call.name }}.call(
+    {{ call.receiver }},
+    {% for arg in call.args %} {{ arg }}, {% end %}
+  )
+end
+
+module Crystal::System::VisualStudio
+  record Installation, directory : String, version : Array(Int32)
+
+  def self.find_latest_msvc_path : String?
+    if vs_installations = get_vs_installations
+      vs_installations.sort_by! &.version
+      vs_installations.reverse_each do |installation|
+        version_path = "#{installation.directory}\\VC\\Auxiliary\\Build\\Microsoft.VCToolsVersion.default.txt"
+        next unless ::File.exists?(version_path)
+
+        version = ::File.read(version_path).chomp
+        next if version.empty?
+
+        return ::Path["#{installation.directory}\\VC\\Tools\\MSVC\\#{version}"].normalize.to_s
+      end
+    end
+  end
+
+  private def self.get_vs_installations : Array(Installation)?
+    # inspired from https://github.com/ziglang/zig/blob/c9352ef9d6d9f1bca94c25710e11de0ae171605f/src/windows_sdk.cpp
+    hr = LibC.CoInitializeEx(nil, LibC::COINIT_MULTITHREADED)
+    return if hr != 0 && hr != 1
+
+    hr = LibC.CoCreateInstance(pointerof(LibC::CLSID_SetupConfiguration), nil, LibC::CLSCTX_INPROC_SERVER, pointerof(LibC::IID_ISetupConfiguration), out setup_config)
+    return if hr != 0
+
+    installations = nil
+
+    setup_config = setup_config.as(LibC::ISetupConfiguration*)
+    begin
+      all_instances = uninitialized LibC::IEnumSetupInstances*
+      return unless com_call(setup_config.enumInstances(pointerof(all_instances))) == 0
+
+      begin
+        curr_instance = uninitialized LibC::ISetupInstance*
+        while com_call(all_instances.next(1_u32, pointerof(curr_instance), Pointer(LibC::DWORD).null)) == 0
+          begin
+            bstr = uninitialized LibC::BSTR
+            next unless com_call(curr_instance.getInstallationPath(pointerof(bstr))) == 0
+            directory = String.from_utf16(bstr)[0]
+            LibC.SysFreeString(bstr)
+
+            next unless com_call(curr_instance.getInstallationVersion(pointerof(bstr))) == 0
+            version = String.from_utf16(bstr)[0].split('.').map(&.to_i)
+            LibC.SysFreeString(bstr)
+
+            installations ||= [] of Installation
+            installations << Installation.new(directory, version)
+          ensure
+            com_call curr_instance.release
+          end
+        end
+      ensure
+        com_call all_instances.release
+      end
+    ensure
+      com_call setup_config.release
+    end
+
+    installations
+  end
+end

--- a/src/crystal/system/win32/windows_sdk.cr
+++ b/src/crystal/system/win32/windows_sdk.cr
@@ -1,0 +1,28 @@
+require "./windows_registry"
+
+module Crystal::System::WindowsSDK
+  REGISTRY_WIN10_SDK_64 = %q(SOFTWARE\WOW6432Node\Microsoft\Microsoft SDKs\Windows\v10.0).to_utf16
+  REGISTRY_WIN10_SDK_32 = %q(SOFTWARE\Microsoft\Microsoft SDKs\Windows\v10.0).to_utf16
+
+  InstallationFolder = "InstallationFolder".to_utf16
+  ProductVersion     = "ProductVersion".to_utf16
+
+  def self.find_win10_sdk_libpath
+    # ported from Common7\Tools\vsdevcmd\core\winsdk.bat (loaded by the MSVC
+    # developer command prompt)
+    {REGISTRY_WIN10_SDK_64, REGISTRY_WIN10_SDK_32}.each do |name|
+      {LibC::HKEY_LOCAL_MACHINE, LibC::HKEY_CURRENT_USER}.each do |hkey|
+        WindowsRegistry.open?(hkey, name) do |handle|
+          installation_folder = WindowsRegistry.get_string(handle, InstallationFolder)
+          product_version = WindowsRegistry.get_string(handle, ProductVersion)
+          next unless installation_folder && product_version
+          product_version = "#{product_version}.0"
+
+          if ::File.exists?("#{installation_folder}\\Include\\#{product_version}\\um\\winsdkver.h")
+            return ::Path["#{installation_folder}\\Lib\\#{product_version}"].normalize.to_s
+          end
+        end
+      end
+    end
+  end
+end

--- a/src/lib_c/x86_64-windows-msvc/c/combaseapi.cr
+++ b/src/lib_c/x86_64-windows-msvc/c/combaseapi.cr
@@ -5,8 +5,8 @@ lib LibC
   COINIT_MULTITHREADED = 0
   CLSCTX_INPROC_SERVER = 1
 
-  alias REFIID    = GUID*
-  alias LCID      = DWORD
+  alias REFIID = GUID*
+  alias LCID = DWORD
   alias LPCOLESTR = WCHAR*
 
   alias IUnknown = Void # unused

--- a/src/lib_c/x86_64-windows-msvc/c/combaseapi.cr
+++ b/src/lib_c/x86_64-windows-msvc/c/combaseapi.cr
@@ -1,0 +1,16 @@
+require "c/oleauto"
+
+@[Link("ole32")]
+lib LibC
+  COINIT_MULTITHREADED = 0
+  CLSCTX_INPROC_SERVER = 1
+
+  alias REFIID    = GUID*
+  alias LCID      = DWORD
+  alias LPCOLESTR = WCHAR*
+
+  alias IUnknown = Void # unused
+
+  fun CoInitializeEx(pvReserved : Void*, dwCoInit : DWORD) : DWORD
+  fun CoCreateInstance(rclsid : GUID*, pUnkOuter : IUnknown*, dwClsContext : DWORD, riid : REFIID, ppv : Void**) : DWORD
+end

--- a/src/lib_c/x86_64-windows-msvc/c/oleauto.cr
+++ b/src/lib_c/x86_64-windows-msvc/c/oleauto.cr
@@ -3,4 +3,5 @@ lib LibC
   alias BSTR = WCHAR*
 
   fun SysFreeString(bstrString : BSTR)
+  fun SysStringLen(pbstr : BSTR) : DWORD
 end

--- a/src/lib_c/x86_64-windows-msvc/c/oleauto.cr
+++ b/src/lib_c/x86_64-windows-msvc/c/oleauto.cr
@@ -1,0 +1,6 @@
+@[Link("oleaut32")]
+lib LibC
+  alias BSTR = WCHAR*
+
+  fun SysFreeString(bstrString : BSTR)
+end


### PR DESCRIPTION
Infers the MSVC compiler / library paths from the Visual Studio COM interfaces, and the Windows SDK library paths from the registry. The library paths are passed to a fully qualified `cl.exe` using the `/LIBPATH` option directly. This allows the Crystal compiler to build programs outside the MSVC developer command prompt.

This only happens if both the host compiler and the target have the MSVC flag set. If the host isn't, we cannot assume we are on Windows, and if the target isn't, we cannot query anything so the outputted linker command is still only valid under the MSVC prompt.

The files `visual_studio.cr` and `windows_sdk.cr` can probably be placed somewhere inside `compiler/crystal`, instead of `crystal/system/win32`. I don't have a better idea yet. (The Win32 bindings rightfully stay in `lib_c/x86_64-windows-msvc/c`, even if no non-compiler files use them.)

The code is heavily inspired from https://gist.github.com/Kalinovcic/b4d9cc55a37f929cb62320763e8fbb47 and https://github.com/ziglang/zig/blob/master/src/windows_sdk.cpp; unlike https://github.com/crystal-lang/crystal/issues/5430#issuecomment-976574952, it does not fall back to `vswhere`. **Only the Windows 10 SDK is supported at the moment.** If there is demand then Windows 8.1 could be added too (but I won't be able to test it). Same goes for Windows 11.