### PR TITLE
Automatically detect MSVC tools on Windows via `vswhere`

### DIFF
--- a/src/compiler/crystal/compiler.cr
+++ b/src/compiler/crystal/compiler.cr
@@ -2,6 +2,10 @@ require "option_parser"
 require "file_utils"
 require "colorize"
 require "crystal/digest/md5"
+{% if flag?(:msvc) %}
+  require "crystal/system/win32/visual_studio"
+  require "crystal/system/win32/windows_sdk"
+{% end %}
 
 module Crystal
   @[Flags]
@@ -346,8 +350,37 @@ module Crystal
         object_arg = Process.quote_windows(object_names)
         output_arg = Process.quote_windows("/Fe#{output_filename}")
 
-        args = %(/nologo #{object_arg} #{output_arg} /link#{" /DEBUG:FULL" unless debug.none?} #{lib_flags} #{@link_flags}).gsub("\n", " ")
-        cmd = "#{CL} #{args}"
+        cl = CL
+        link_args = [] of String
+
+        # if the compiler and the target both have the `msvc` flag, we are not
+        # cross-compiling and therefore we should attempt detecting MSVC's
+        # standard paths
+        {% if flag?(:msvc) %}
+          if msvc_path = Crystal::System::VisualStudio.find_latest_msvc_path
+            if win_sdk_libpath = Crystal::System::WindowsSDK.find_win10_sdk_libpath
+              host_bits = {{ flag?(:bits64) ? "Hostx64" : "Hostx86" }}
+              target_bits = program.has_flag?("bits64") ? "x64" : "x86"
+
+              # MSVC build tools and Windows SDK found; recreate `LIB` environment variable
+              # that is normally expected on the MSVC developer command prompt
+              link_args << Process.quote_windows("/LIBPATH:#{msvc_path}\\atlmfc\\lib\\#{target_bits}")
+              link_args << Process.quote_windows("/LIBPATH:#{msvc_path}\\lib\\#{target_bits}")
+              link_args << Process.quote_windows("/LIBPATH:#{win_sdk_libpath}\\ucrt\\#{target_bits}")
+              link_args << Process.quote_windows("/LIBPATH:#{win_sdk_libpath}\\um\\#{target_bits}")
+
+              # use exact path for compiler instead of relying on `PATH`
+              cl = Process.quote_windows("#{msvc_path}\\bin\\#{host_bits}\\#{target_bits}\\cl.exe")
+            end
+          end
+        {% end %}
+
+        link_args << "/DEBUG:FULL" unless debug.none?
+        link_args << lib_flags
+        @link_flags.try { |flags| link_args << flags }
+
+        args = %(/nologo #{object_arg} #{output_arg} /link #{link_args.join(' ')}).gsub("\n", " ")
+        cmd = "#{cl} #{args}"
 
         if cmd.to_utf16.size > 32000
           # The command line would be too big, pass the args through a UTF-16-encoded file instead.

--- a/src/crystal/system/win32/visual_studio.cr
+++ b/src/crystal/system/win32/visual_studio.cr
@@ -1,0 +1,55 @@
+require "json"
+
+module Crystal::System::VisualStudio
+  struct Installation
+    include JSON::Serializable
+
+    @[JSON::Field(key: "installationPath")]
+    getter directory : String
+
+    @[JSON::Field(key: "installationVersion")]
+    getter version : String
+
+    # unused fields not mapped
+  end
+
+  def self.find_latest_msvc_path : String?
+    # ported from https://github.com/microsoft/vswhere/wiki/Find-VC
+    if vs_installations = get_vs_installations
+      vs_installations.sort_by! &.version
+      vs_installations.reverse_each do |installation|
+        version_path = "#{installation.directory}\\VC\\Auxiliary\\Build\\Microsoft.VCToolsVersion.default.txt"
+        next unless ::File.exists?(version_path)
+
+        version = ::File.read(version_path).chomp
+        next if version.empty?
+
+        return ::Path["#{installation.directory}\\VC\\Tools\\MSVC\\#{version}"].normalize.to_s
+      end
+    end
+  end
+
+  private def self.get_vs_installations : Array(Installation)?
+    if vswhere_path = find_vswhere
+      vc_install_json = `#{::Process.quote(vswhere_path)} -requires Microsoft.VisualStudio.Component.VC.Tools.x86.x64 -format json`
+      return unless $?.success? && !vc_install_json.empty?
+
+      Array(Installation).from_json(vc_install_json)
+    end
+  end
+
+  private def self.find_vswhere
+    if crystal_path = ::Process.executable_path
+      vswhere_path = "#{::File.dirname(crystal_path)}\\vswhere.exe"
+      return vswhere_path if ::File.exists?(vswhere_path)
+    end
+
+    # standard path for VS2017 15.2 and later
+    if program_files = ENV["ProgramFiles(x86)"]?
+      vswhere_path = "#{program_files}\\Microsoft Visual Studio\\Installer\\vswhere.exe"
+      return vswhere_path if ::File.exists?(vswhere_path)
+    end
+
+    ::Process.find_executable("vswhere.exe")
+  end
+end

--- a/src/crystal/system/win32/windows_sdk.cr
+++ b/src/crystal/system/win32/windows_sdk.cr
@@ -1,0 +1,28 @@
+require "./windows_registry"
+
+module Crystal::System::WindowsSDK
+  REGISTRY_WIN10_SDK_64 = %q(SOFTWARE\WOW6432Node\Microsoft\Microsoft SDKs\Windows\v10.0).to_utf16
+  REGISTRY_WIN10_SDK_32 = %q(SOFTWARE\Microsoft\Microsoft SDKs\Windows\v10.0).to_utf16
+
+  InstallationFolder = "InstallationFolder".to_utf16
+  ProductVersion     = "ProductVersion".to_utf16
+
+  def self.find_win10_sdk_libpath
+    # ported from Common7\Tools\vsdevcmd\core\winsdk.bat (loaded by the MSVC
+    # developer command prompt)
+    {REGISTRY_WIN10_SDK_64, REGISTRY_WIN10_SDK_32}.each do |name|
+      {LibC::HKEY_LOCAL_MACHINE, LibC::HKEY_CURRENT_USER}.each do |hkey|
+        WindowsRegistry.open?(hkey, name) do |handle|
+          installation_folder = WindowsRegistry.get_string(handle, InstallationFolder)
+          product_version = WindowsRegistry.get_string(handle, ProductVersion)
+          next unless installation_folder && product_version
+          product_version = "#{product_version}.0"
+
+          if ::File.exists?("#{installation_folder}\\Include\\#{product_version}\\um\\winsdkver.h")
+            return ::Path["#{installation_folder}\\Lib\\#{product_version}"].normalize.to_s
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Simmilar to #11495, except it uses [`vswhere`](https://github.com/microsoft/vswhere) to detect the installation path. `vswhere` is looked up in the following sequence:

* The same directory as the compiler currently running
* The default location (`%ProgramFiles(x86)%\Microsoft Visual Studio\Installer\vswhere.exe`)
* `PATH`

This does not fall back to the COM interfaces. Everything other than retrieving the list of Visual Studio installations is exactly the same.