### PR TITLE
Implement compiler-rt `__multi3` for arm

### DIFF
--- a/spec/std/crystal/compiler_rt/multi3_spec.cr
+++ b/spec/std/crystal/compiler_rt/multi3_spec.cr
@@ -3,17 +3,6 @@ require "crystal/compiler_rt/multi3"
 
 # Ported from https://github.com/llvm/llvm-project/blob/ce59ccd04023cab3a837da14079ca2dcbfebb70c/compiler-rt/test/builtins/Unit/multi3_test.c
 
-private def test__mulodi4(a : Int64, b : Int64, expected : Int64, expected_overflow : Int32, file = __FILE__, line = __LINE__)
-  it "passes compiler-rt builtins unit tests" do
-    actual_overflow : Int32 = 0
-    actual = __mulodi4(a, b, pointerof(actual_overflow))
-    actual_overflow.should eq(expected_overflow), file: file, line: line
-    if !expected_overflow
-      actual.should eq(expected), file: file, line: line
-    end
-  end
-end
-
 # TODO: Replace helper methods with literals once possible
 
 private def make_ti(a : Int128, b : Int128)

--- a/spec/std/crystal/compiler_rt/multi3_spec.cr
+++ b/spec/std/crystal/compiler_rt/multi3_spec.cr
@@ -1,0 +1,63 @@
+require "spec"
+require "crystal/compiler_rt/multi3"
+
+# Ported from https://github.com/llvm/llvm-project/blob/ce59ccd04023cab3a837da14079ca2dcbfebb70c/compiler-rt/test/builtins/Unit/multi3_test.c
+
+private def test__mulodi4(a : Int64, b : Int64, expected : Int64, expected_overflow : Int32, file = __FILE__, line = __LINE__)
+  it "passes compiler-rt builtins unit tests" do
+    actual_overflow : Int32 = 0
+    actual = __mulodi4(a, b, pointerof(actual_overflow))
+    actual_overflow.should eq(expected_overflow), file: file, line: line
+    if !expected_overflow
+      actual.should eq(expected), file: file, line: line
+    end
+  end
+end
+
+# TODO: Replace helper methods with literals once possible
+
+private def make_ti(a : Int128, b : Int128)
+  (a << 64) + b
+end
+
+it ".__multi3" do
+  __multi3(0, 0).should eq 0
+  __multi3(0, 1).should eq 0
+  __multi3(1, 0).should eq 0
+  __multi3(0, 10).should eq 0
+  __multi3(10, 0).should eq 0
+  __multi3(0, 81985529216486895).should eq 0
+  __multi3(81985529216486895, 0).should eq 0
+  __multi3(0, -1).should eq 0
+  __multi3(-1, 0).should eq 0
+  __multi3(0, -10).should eq 0
+  __multi3(-10, 0).should eq 0
+  __multi3(0, -81985529216486895).should eq 0
+  __multi3(-81985529216486895, 0).should eq 0
+  __multi3(1, 1).should eq 1
+  __multi3(1, 10).should eq 10
+  __multi3(10, 1).should eq 10
+  __multi3(1, 81985529216486895).should eq 81985529216486895
+  __multi3(81985529216486895, 1).should eq 81985529216486895
+  __multi3(1, -1).should eq -1
+  __multi3(1, -10).should eq -10
+  __multi3(-10, 1).should eq -10
+  __multi3(1, -81985529216486895).should eq -81985529216486895
+  __multi3(-81985529216486895, 1).should eq -81985529216486895
+  __multi3(3037000499, 3037000499).should eq 9223372030926249001
+  __multi3(-3037000499, 3037000499).should eq -9223372030926249001
+  __multi3(3037000499, -3037000499).should eq -9223372030926249001
+  __multi3(-3037000499, -3037000499).should eq 9223372030926249001
+  __multi3(4398046511103, 2097152).should eq 9223372036852678656
+  __multi3(-4398046511103, 2097152).should eq -9223372036852678656
+  __multi3(4398046511103, -2097152).should eq -9223372036852678656
+  __multi3(-4398046511103, -2097152).should eq 9223372036852678656
+  __multi3(2097152, 4398046511103).should eq 9223372036852678656
+  __multi3(-2097152, 4398046511103).should eq -9223372036852678656
+  __multi3(2097152, -4398046511103).should eq -9223372036852678656
+  __multi3(-2097152, -4398046511103).should eq 9223372036852678656
+  __multi3(
+    make_ti(0x00000000000000B5, 0x04F333F9DE5BE000),
+    make_ti(0x0000000000000000, 0x00B504F333F9DE5B)
+  ).should eq make_ti(0x7FFFFFFFFFFFF328, 0xDF915DA296E8A000)
+end

--- a/src/crystal/compiler_rt.cr
+++ b/src/crystal/compiler_rt.cr
@@ -2,3 +2,8 @@
 
 require "./compiler_rt/mul.cr"
 require "./compiler_rt/divmod128.cr"
+
+{% if flag?(:arm) %}
+  # __multi3 was only missing on arm
+  require "./compiler_rt/multi3.cr"
+{% end %}

--- a/src/crystal/compiler_rt/multi3.cr
+++ b/src/crystal/compiler_rt/multi3.cr
@@ -1,0 +1,32 @@
+private def __mulddi3(a : UInt64, b : UInt64) : Int128
+  bits_in_dword_2 = (sizeof(Int64) &* 8) // 2
+  lower_mask = ~0_u64 >> bits_in_dword_2
+
+  low = (a & lower_mask) &* (b & lower_mask)
+  t = low >> bits_in_dword_2
+  low &= lower_mask
+  t &+= (a >> bits_in_dword_2) &* (b & lower_mask)
+  low &+= (t & lower_mask) << bits_in_dword_2
+  high = t >> bits_in_dword_2
+  t = low >> bits_in_dword_2
+  low &= lower_mask
+  t &+= (b >> bits_in_dword_2) &* (a & lower_mask)
+  low &+= (t & lower_mask) << bits_in_dword_2
+  high &+= t >> bits_in_dword_2
+  high &+= (a >> bits_in_dword_2) &* (b >> bits_in_dword_2)
+
+  (high.to_i128! << 64) &+ low
+end
+
+# :nodoc:
+# Ported from https://github.com/llvm/llvm-project/blob/ce59ccd04023cab3a837da14079ca2dcbfebb70c/compiler-rt/lib/builtins/multi3.c
+fun __multi3(a : Int128, b : Int128) : Int128
+  a_low = (a & ~0_u64).to_u64!
+  a_high = (a >> 64).to_i64!
+  b_low = (b & ~0_u64).to_u64!
+  b_high = (b >> 64).to_i64!
+
+  result = __mulddi3(a_low, b_low)
+  result &+= ((a_high &* b_low) &+ (a_low &* b_high)).to_i128! << 64
+  result
+end


### PR DESCRIPTION
This patch implements compiler-rt's `__multi3` (multiplication of 128-bit integers). This fill-in is apparently only necessary on arm, on all other platforms, the function is available.

Resolves #11497