### PR TITLE
Pin alpine repo for ssl libs to 3.15

### DIFF
--- a/.github/workflows/openssl.yml
+++ b/.github/workflows/openssl.yml
@@ -13,7 +13,7 @@ jobs:
       - name: Uninstall openssl 1.1
         run: apk del openssl-dev
       - name: Install openssl 3.0
-        run: apk add "openssl3-dev" --repository=http://dl-cdn.alpinelinux.org/alpine/edge/main
+        run: apk add "openssl3-dev" --repository=http://dl-cdn.alpinelinux.org/alpine/v3.15/main
       - name: Check LibSSL version
         run: bin/crystal eval 'require "openssl"; p! LibSSL::OPENSSL_VERSION, LibSSL::LIBRESSL_VERSION'
       - name: Run OpenSSL specs
@@ -56,10 +56,10 @@ jobs:
       - name: Uninstall openssl
         run: apk del openssl-dev openssl-libs-static
       - name: Install libressl 3.4
-        run: apk add "libressl-dev=~3.4" --repository=http://dl-cdn.alpinelinux.org/alpine/edge/community
+        run: apk add "libressl-dev=~3.4" --repository=http://dl-cdn.alpinelinux.org/alpine/v3.15/community
       # We need a recent libc which include reallocarray
       - name: Upgrade musl-dev
-        run: apk add "musl-dev=~1.2" --repository=http://dl-cdn.alpinelinux.org/alpine/v3.14/main
+        run: apk add "musl-dev=~1.2" --repository=http://dl-cdn.alpinelinux.org/alpine/v3.15/main
       - name: Check LibSSL version
         run: bin/crystal eval 'require "openssl"; p! LibSSL::OPENSSL_VERSION, LibSSL::LIBRESSL_VERSION'
       - name: Run OpenSSL specs

--- a/.github/workflows/openssl.yml
+++ b/.github/workflows/openssl.yml
@@ -12,6 +12,8 @@ jobs:
         uses: actions/checkout@v2
       - name: Uninstall openssl 1.1
         run: apk del openssl-dev
+      - name: Upgrade alpine-keys
+        run: apk upgrade alpine-keys
       - name: Install openssl 3.0
         run: apk add "openssl3-dev" --repository=http://dl-cdn.alpinelinux.org/alpine/v3.15/main
       - name: Check LibSSL version
@@ -55,6 +57,8 @@ jobs:
         uses: actions/checkout@v2
       - name: Uninstall openssl
         run: apk del openssl-dev openssl-libs-static
+      - name: Upgrade alpine-keys
+        run: apk upgrade alpine-keys
       - name: Install libressl 3.4
         run: apk add "libressl-dev=~3.4" --repository=http://dl-cdn.alpinelinux.org/alpine/v3.15/community
       # We need a recent libc which include reallocarray


### PR DESCRIPTION
Alpine 3.15 has been released and is the first stable release with openssl3 package. We should use that instead of edge in the openssl CI workflow for reproducability.