### PR TITLE
Fix CI rules for building libiconv on Windows

### DIFF
--- a/.github/workflows/win.yml
+++ b/.github/workflows/win.yml
@@ -93,7 +93,22 @@ jobs:
         if: steps.cache-libs.outputs.cache-hit != 'true'
         working-directory: ./libiconv
         run: |
-          sed -i 's/MultiThreadedDLL/MultiThreaded/' libiconv.vcxproj
+          echo '<Project>
+            <PropertyGroup>
+              <ForceImportAfterCppProps>$(MsbuildThisFileDirectory)\Override.props</ForceImportAfterCppProps>
+            </PropertyGroup>
+          </Project>' > 'Directory.Build.props'
+
+          echo '<Project>
+            <ItemDefinitionGroup>
+              <ClCompile>
+                <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
+                <DebugInformationFormat>None</DebugInformationFormat>
+                <WholeProgramOptimization>false</WholeProgramOptimization>
+              </ClCompile>
+            </ItemDefinitionGroup>
+          </Project>' > 'Override.props'
+
           MSBuild.exe /p:Platform=x64 /p:Configuration=ReleaseStatic libiconv.vcxproj
       - name: Download zlib
         if: steps.cache-libs.outputs.cache-hit != 'true'

--- a/.github/workflows/win.yml
+++ b/.github/workflows/win.yml
@@ -95,7 +95,7 @@ jobs:
         run: |
           echo '<Project>
             <PropertyGroup>
-              <ForceImportAfterCppProps>$(MsbuildThisFileDirectory)\Override.props</ForceImportAfterCppProps>
+              <ForceImportAfterCppTargets>$(MsbuildThisFileDirectory)\Override.props</ForceImportAfterCppTargets>
             </PropertyGroup>
           </Project>' > 'Directory.Build.props'
 


### PR DESCRIPTION
Fixes https://github.com/crystal-lang/crystal/pull/11480#issuecomment-980469203. Alternative to #11502.

The current repository that we use to build libiconv has no potential license issues, because it references the files in `libcharset/include`, never `srclib`: https://github.com/pffang/libiconv-for-Windows/blob/9b7aba8da6e125ef33912fa4412779279f204003/libiconv.vcxproj#L62-L63

This approach is also less error-prone because we are no longer editing the .vcxproj files in-place.