### PR TITLE
Fix `Char#ascii_control?` restrict to ASCII characters

### DIFF
--- a/spec/std/char_spec.cr
+++ b/spec/std/char_spec.cr
@@ -435,10 +435,12 @@ describe "Char" do
     'a'.number?.should be_false
   end
 
-  it "does ascii_control?" do
+  it "#ascii_control?" do
     'ù'.ascii_control?.should be_false
     'a'.ascii_control?.should be_false
     '\u0019'.ascii_control?.should be_true
+    '\u007F'.ascii_control?.should be_true
+    '\u0080'.ascii_control?.should be_false
   end
 
   it "does mark?" do

--- a/src/char.cr
+++ b/src/char.cr
@@ -474,6 +474,9 @@ struct Char
 
   # Returns `true` if this char is an ASCII control character.
   #
+  # This includes the *C0 control codes* (`U+0000` through `U+001F`) and the
+  # *Delete* character (`U+007F`).
+  #
   # ```
   # ('\u0000'..'\u0019').each do |char|
   #   char.control? # => true
@@ -484,7 +487,7 @@ struct Char
   # end
   # ```
   def ascii_control? : Bool
-    ord < 0x20 || (0x7F <= ord <= 0x9F)
+    ord < 0x20 || ord == 0x7F
   end
 
   # Returns `true` if this char is a control character according to unicode.


### PR DESCRIPTION
This method identified C1 control codes in the *Latin-1 Supplement* block (`U+008A` through `U+009F`) as ASCII control. The characters in this block are however not part of ASCII.

While this is technically a breaking change, it's practical impact should be negligible. I doubt there is much relevant use of C1 control codes.
We could consider just documenting that `#ascii_control?` returns `true` if the char is either a C0 or C1 control code. But I think it would be confusing if an `ascii_*` predicate applies to chars where `#ascii?` does not.