### PR TITLE
[CI] Fix `test_dist_linux_on_docker`

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -504,7 +504,7 @@ workflows:
       - publish_docker:
           filters: *release
           requires:
-            - dist_docker
+            - test_dist_linux_on_docker
       - dist_docs:
           filters: *release
           requires:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -431,7 +431,7 @@ jobs:
       - run: |
           cd /tmp/workspace/distribution-scripts
           source ./build.env
-          gunzip -c /tmp/workspace/build/docker-${CRYSTAL_VERSION}-ubuntu-x86_64.tar.gz | docker image load
+          gunzip -c /tmp/workspace/build/docker-${CRYSTAL_VERSION}-ubuntu-x86_64-build.tar.gz | docker image load
           echo "export DOCKER_TEST_PREFIX=crystallang/crystal:${DOCKER_TAG}" >> $BASH_ENV
       - checkout
       - run: bin/ci prepare_system

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -432,7 +432,7 @@ jobs:
           cd /tmp/workspace/distribution-scripts
           source ./build.env
           gunzip -c /tmp/workspace/build/docker-${CRYSTAL_VERSION}-ubuntu-x86_64.tar.gz | docker image load
-          echo 'export DOCKER_TEST_PREFIX="crystallang/crystal:$DOCKER_TAG"' >> $BASH_ENV
+          echo "export DOCKER_TEST_PREFIX=crystallang/crystal:${DOCKER_TAG}" >> $BASH_ENV
       - checkout
       - run: bin/ci prepare_system
       - run: echo 'export CURRENT_TAG="$CIRCLE_TAG"' >> $BASH_ENV

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -432,7 +432,7 @@ jobs:
           cd /tmp/workspace/distribution-scripts
           source ./build.env
           gunzip -c /tmp/workspace/build/docker-${CRYSTAL_VERSION}-ubuntu-x86_64.tar.gz | docker image load
-          export DOCKER_TEST_PREFIX="crystallang/crystal:$DOCKER_TAG" >> $BASH_ENV
+          echo 'export DOCKER_TEST_PREFIX="crystallang/crystal:$DOCKER_TAG"' >> $BASH_ENV
       - checkout
       - run: bin/ci prepare_system
       - run: echo 'export CURRENT_TAG="$CIRCLE_TAG"' >> $BASH_ENV


### PR DESCRIPTION
The recent broken nightly release (https://github.com/crystal-lang/distribution-scripts/issues/171) has shown that the `test_dist_linux_on_docker` job does not work as it's supposed to. It should have failed do to the broken build. But it didn't. The reason is that the `DOCKER_TEST_PREFIX` was not correctly applied, so it always tested the image of the latest release (1.2.2 currently) instead of the freshly built image.

I'm also changing `dist_docker` docker to depend on successful test job. That would prevent faulty images being pushed to Docker hub (assuming they're correctly identified as being broken).