### PR TITLE
Revert "[Makefile] Make LLVM_CONFIG check conditional based on usage"

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -61,12 +61,11 @@ ifeq ($(shell command -v ld.lld >/dev/null && uname -s),Linux)
   EXPORT_CC ?= CC="cc -fuse-ld=lld"
 endif
 
-.PHONY: LLVM_CONFIG
-LLVM_CONFIG:
-	@test ! -z "$(LLVM_CONFIG)" -a ! -z "$$($(LLVM_CONFIG) --version 2> /dev/null)" || \
-		(echo >&2 "\033[33mCould not locate compatible llvm-config, make sure it is installed and in your PATH, or set LLVM_CONFIG. Compatible versions: $(shell cat src/llvm/ext/llvm-versions.txt)\033[0m" && false)
-
-	@echo >&2 "\033[33mUsing $(LLVM_CONFIG) [version=$$($(LLVM_CONFIG) --version)]\033[0m"
+ifeq (${LLVM_CONFIG},)
+  $(error Could not locate compatible llvm-config, make sure it is installed and in your PATH, or set LLVM_CONFIG. Compatible versions: $(shell cat src/llvm/ext/llvm-versions.txt))
+else
+  $(shell echo $(shell printf '\033[33m')Using $(LLVM_CONFIG) [version=$(shell $(LLVM_CONFIG) --version)]$(shell printf '\033[0m') >&2)
+endif
 
 .PHONY: all
 all: crystal ## Build all files (currently crystal only) [default]
@@ -108,7 +107,7 @@ samples:
 	$(MAKE) -C samples
 
 .PHONY: docs
-docs: LLVM_CONFIG ## Generate standard library documentation
+docs: ## Generate standard library documentation
 	./bin/crystal docs src/docs_main.cr $(DOCS_OPTIONS) --project-name=Crystal --project-version=$(CRYSTAL_VERSION) --source-refname=$(CRYSTAL_CONFIG_BUILD_COMMIT)
 
 .PHONY: crystal
@@ -156,23 +155,23 @@ uninstall_docs: ## Uninstall docs from DESTDIR
 	rm -rf "$(DATADIR)/docs"
 	rm -rf "$(DATADIR)/examples"
 
-$(O)/all_spec: $(DEPS) $(SOURCES) $(SPEC_SOURCES) LLVM_CONFIG
+$(O)/all_spec: $(DEPS) $(SOURCES) $(SPEC_SOURCES)
 	@mkdir -p $(O)
 	$(EXPORT_CC) $(EXPORTS) ./bin/crystal build $(FLAGS) $(SPEC_WARNINGS_OFF) -o $@ spec/all_spec.cr
 
-$(O)/std_spec: $(DEPS) $(SOURCES) $(SPEC_SOURCES) LLVM_CONFIG
+$(O)/std_spec: $(DEPS) $(SOURCES) $(SPEC_SOURCES)
 	@mkdir -p $(O)
 	$(EXPORT_CC) ./bin/crystal build $(FLAGS) $(SPEC_WARNINGS_OFF) -o $@ spec/std_spec.cr
 
-$(O)/compiler_spec: $(DEPS) $(SOURCES) $(SPEC_SOURCES) LLVM_CONFIG
+$(O)/compiler_spec: $(DEPS) $(SOURCES) $(SPEC_SOURCES)
 	@mkdir -p $(O)
 	$(EXPORT_CC) $(EXPORTS) ./bin/crystal build $(FLAGS) $(SPEC_WARNINGS_OFF) -o $@ spec/compiler_spec.cr
 
-$(O)/crystal: $(DEPS) $(SOURCES) LLVM_CONFIG
+$(O)/crystal: $(DEPS) $(SOURCES)
 	@mkdir -p $(O)
 	$(EXPORTS) $(EXPORTS_BUILD) ./bin/crystal build $(FLAGS) -o $@ src/compiler/crystal.cr -D without_openssl -D without_zlib
 
-$(LLVM_EXT_OBJ): $(LLVM_EXT_DIR)/llvm_ext.cc LLVM_CONFIG
+$(LLVM_EXT_OBJ): $(LLVM_EXT_DIR)/llvm_ext.cc
 	$(CXX) -c $(CXXFLAGS) -o $@ $< $(shell $(LLVM_CONFIG) --cxxflags)
 
 man/%.gz: man/%


### PR DESCRIPTION
Reverts crystal-lang/crystal#11454

https://github.com/crystal-lang/crystal/pull/11454/files was wrong in making `LLVM_CONFIG` a phony prerequisite because that means it triggers all dependent targets every time. This even causes nightly builds to fail (https://github.com/crystal-lang/distribution-scripts/issues/171).

As suggested in https://github.com/crystal-lang/crystal/pull/11509#issuecomment-982969454, it's better to simply revert the faulty commit.

https://github.com/crystal-lang/crystal/pull/11509 already proposes a fixed implementation.

Resolves crystal-lang/distribution-scripts#171
Resolves https://github.com/crystal-lang/crystal/issues/11511