### PR TITLE
Update distribution-scripts for `release/1.2`

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -121,7 +121,7 @@ jobs:
       - run: |
           git clone https://github.com/crystal-lang/distribution-scripts.git ~/distribution-scripts
           cd ~/distribution-scripts
-          git checkout 406d7d2bb371fd819b9977cc5e91e5dc58bfd5f2
+          git checkout 638d5887e7a4bff9c32ab72fe9a32395df9dc1c5
       # persist relevant information for build process
       - run: |
           cd ~/distribution-scripts


### PR DESCRIPTION
This includes the following changes from distribution-scripts:

* crystal-lang/distribution-scripts#167
* crystal-lang/distribution-scripts#168
* crystal-lang/distribution-scripts#170

The last one is relevant for #11475

This change is identical to #11514 except that it targets https://github.com/crystal-lang/crystal/tree/release/1.2. The idea is to rebuild and republish the `crystallang/crystal:1.2.2` docker images in order to include `libffi` (see https://github.com/crystal-lang/distribution-scripts/pull/170#issuecomment-972938120).