### PR TITLE
Encode OpenSSL version on Windows

### DIFF
--- a/.github/workflows/win.yml
+++ b/.github/workflows/win.yml
@@ -199,6 +199,7 @@ jobs:
         if: steps.cache-openssl.outputs.cache-hit != 'true'
         working-directory: ./openssl
         run: |
+          sed -i 's|/Zi /Fd.*\.pdb||' Configurations/10-main.conf
           sed -i 's|/debug|/debug:none|' Configurations/10-main.conf
           perl Configure VC-WIN64A /MT -static no-tests --with-zlib-lib=..\zlib\Release --with-zlib-include=..\zlib
           nmake

--- a/.github/workflows/win.yml
+++ b/.github/workflows/win.yml
@@ -181,6 +181,7 @@ jobs:
           path: |
             libs/crypto.lib
             libs/ssl.lib
+            libs/openssl_VERSION
           key: win-openssl-libs-3.0.0
       - name: Set up NASM
         if: steps.cache-openssl.outputs.cache-hit != 'true'
@@ -198,6 +199,7 @@ jobs:
         if: steps.cache-openssl.outputs.cache-hit != 'true'
         working-directory: ./openssl
         run: |
+          sed -i 's|/debug|/debug:none|' Configurations/10-main.conf
           perl Configure VC-WIN64A /MT -static no-tests --with-zlib-lib=..\zlib\Release --with-zlib-include=..\zlib
           nmake
       - name: Gather OpenSSL
@@ -205,9 +207,7 @@ jobs:
         run: |
           cp openssl/libcrypto.lib libs/crypto.lib
           cp openssl/libssl.lib libs/ssl.lib
-      - name: Set OpenSSL version
-        run: |
-          echo "CRYSTAL_OPENSSL_VERSION=3.0.0" >> ${env:GITHUB_ENV}
+          [IO.File]::WriteAllLines("libs/openssl_VERSION", "3.0.0")
 
       - name: Cache LLVM
         id: cache-llvm

--- a/src/openssl/lib_crypto.cr
+++ b/src/openssl/lib_crypto.cr
@@ -2,8 +2,16 @@
   lib LibCrypto
     {% if flag?(:win32) %}
       {% from_libressl = false %}
-      {% ssl_version = env("CRYSTAL_OPENSSL_VERSION") %}
-      {% raise "Cannot determine OpenSSL version, make sure the environment variable `CRYSTAL_OPENSSL_VERSION` is set" unless ssl_version %}
+      {% ssl_version = nil %}
+      {% for dir in Crystal::LIBRARY_PATH.split(';') %}
+        {% unless ssl_version %}
+          {% config_path = "#{dir.id}\\openssl_VERSION" %}
+          {% if config_version = read_file?(config_path) %}
+            {% ssl_version = config_version.chomp %}
+          {% end %}
+        {% end %}
+      {% end %}
+      {% ssl_version ||= "0.0.0" %}
     {% else %}
       {% from_libressl = (`hash pkg-config 2> /dev/null || printf %s false` != "false") &&
                          (`test -f $(pkg-config --silence-errors --variable=includedir libcrypto)/openssl/opensslv.h || printf %s false` != "false") &&

--- a/src/openssl/lib_ssl.cr
+++ b/src/openssl/lib_ssl.cr
@@ -8,8 +8,16 @@ require "./lib_crypto"
   lib LibSSL
     {% if flag?(:win32) %}
       {% from_libressl = false %}
-      {% ssl_version = env("CRYSTAL_OPENSSL_VERSION") %}
-      {% raise "Cannot determine OpenSSL version, make sure the environment variable `CRYSTAL_OPENSSL_VERSION` is set" unless ssl_version %}
+      {% ssl_version = nil %}
+      {% for dir in Crystal::LIBRARY_PATH.split(';') %}
+        {% unless ssl_version %}
+          {% config_path = "#{dir.id}\\openssl_VERSION" %}
+          {% if config_version = read_file?(config_path) %}
+            {% ssl_version = config_version.chomp %}
+          {% end %}
+        {% end %}
+      {% end %}
+      {% ssl_version ||= "0.0.0" %}
     {% else %}
       {% from_libressl = (`hash pkg-config 2> /dev/null || printf %s false` != "false") &&
                          (`test -f $(pkg-config --silence-errors --variable=includedir libssl)/openssl/opensslv.h || printf %s false` != "false") &&


### PR DESCRIPTION
Fixes #11492.

Also makes sure the OpenSSL libraries do not have debug symbols (from `ossl_static.pdb`), similar to libiconv a while ago.