### PR TITLE
Add `Log.with_context` with kwargs

### DIFF
--- a/spec/std/log/context_spec.cr
+++ b/spec/std/log/context_spec.cr
@@ -36,6 +36,28 @@ describe "Log.context" do
     Log.context.metadata.should eq(m({a: 1, b: 2, c: 3}))
   end
 
+  it "is restored after with_context with arguments" do
+    Log.context.set a: 1
+    Log.with_context(b: 2) do
+      Log.context.set c: 3
+      Log.context.metadata.should eq(m({a: 1, b: 2, c: 3}))
+    end
+
+    Log.context.metadata.should eq(m({a: 1}))
+  end
+
+  it "is restored after with_context of Log instance with arguments" do
+    Log.context.set a: 1
+    log = Log.for("temp")
+
+    log.with_context(b: 2) do
+      log.context.set c: 3
+      log.context.metadata.should eq(m({a: 1, b: 2, c: 3}))
+    end
+
+    log.context.metadata.should eq(m({a: 1}))
+  end
+
   it "is restored after with_context" do
     Log.context.set a: 1
 

--- a/spec/std/log/context_spec.cr
+++ b/spec/std/log/context_spec.cr
@@ -5,7 +5,7 @@ private def m(value)
   Log::Metadata.build(value)
 end
 
-describe "Log.context" do
+describe Log do
   before_each do
     Log.context.clear
   end
@@ -14,102 +14,130 @@ describe "Log.context" do
     Log.context.clear
   end
 
-  it "can be set and cleared" do
-    Log.context.metadata.should eq(Log::Metadata.new)
+  describe ".context" do
+    it "can be set and cleared" do
+      Log.context.metadata.should eq(Log::Metadata.new)
 
-    Log.context.set a: 1
-    Log.context.metadata.should eq(m({a: 1}))
+      Log.context.set a: 1
+      Log.context.metadata.should eq(m({a: 1}))
 
-    Log.context.clear
-    Log.context.metadata.should eq(Log::Metadata.new)
-  end
-
-  it "is extended by set" do
-    Log.context.set a: 1
-    Log.context.set b: 2
-    Log.context.metadata.should eq(m({a: 1, b: 2}))
-  end
-
-  it "existing keys are overwritten by set" do
-    Log.context.set a: 1, b: 1
-    Log.context.set b: 2, c: 3
-    Log.context.metadata.should eq(m({a: 1, b: 2, c: 3}))
-  end
-
-  it "is restored after with_context with arguments" do
-    Log.context.set a: 1
-    Log.with_context(b: 2) do
-      Log.context.set c: 3
-      Log.context.metadata.should eq(m({a: 1, b: 2, c: 3}))
+      Log.context.clear
+      Log.context.metadata.should eq(Log::Metadata.new)
     end
 
-    Log.context.metadata.should eq(m({a: 1}))
-  end
-
-  it "is restored after with_context of Log instance with arguments" do
-    Log.context.set a: 1
-    log = Log.for("temp")
-
-    log.with_context(b: 2) do
-      log.context.set c: 3
-      log.context.metadata.should eq(m({a: 1, b: 2, c: 3}))
-    end
-
-    log.context.metadata.should eq(m({a: 1}))
-  end
-
-  it "is restored after with_context" do
-    Log.context.set a: 1
-
-    Log.with_context do
+    it "is extended by set" do
+      Log.context.set a: 1
       Log.context.set b: 2
       Log.context.metadata.should eq(m({a: 1, b: 2}))
     end
 
-    Log.context.metadata.should eq(m({a: 1}))
-  end
-
-  it "is restored after with_context of Log instance" do
-    Log.context.set a: 1
-    log = Log.for("temp")
-
-    log.with_context do
-      log.context.set b: 2
-      log.context.metadata.should eq(m({a: 1, b: 2}))
+    it "existing keys are overwritten by set" do
+      Log.context.set a: 1, b: 1
+      Log.context.set b: 2, c: 3
+      Log.context.metadata.should eq(m({a: 1, b: 2, c: 3}))
     end
 
-    log.context.metadata.should eq(m({a: 1}))
-  end
+    it "is per fiber" do
+      Log.context.set a: 1
+      done = Channel(Nil).new
 
-  it "is per fiber" do
-    Log.context.set a: 1
-    done = Channel(Nil).new
+      f = spawn do
+        Log.context.metadata.should eq(Log::Metadata.new)
+        Log.context.set b: 2
+        Log.context.metadata.should eq(m({b: 2}))
 
-    f = spawn do
-      Log.context.metadata.should eq(Log::Metadata.new)
-      Log.context.set b: 2
-      Log.context.metadata.should eq(m({b: 2}))
+        done.receive
+        done.receive
+      end
 
-      done.receive
-      done.receive
+      done.send nil
+      Log.context.metadata.should eq(m({a: 1}))
+      done.send nil
     end
 
-    done.send nil
-    Log.context.metadata.should eq(m({a: 1}))
-    done.send nil
+    it "is assignable from a hash with symbol keys" do
+      Log.context.set a: 1
+      extra = {:b => 2}
+      Log.context.set extra
+      Log.context.metadata.should eq(m({a: 1, b: 2}))
+    end
+
+    it "is assignable from a named tuple" do
+      Log.context.set a: 1
+      extra = {b: 2}
+      Log.context.set extra
+      Log.context.metadata.should eq(m({a: 1, b: 2}))
+    end
   end
 
-  it "is assignable from a hash with symbol keys" do
-    Log.context.set a: 1
-    extra = {:b => 2}
-    Log.context.set extra
-    Log.context.metadata.should eq(m({a: 1, b: 2}))
+  describe "#with_context" do
+    it "with arguments restores context after the block" do
+      Log.context.set a: 1
+      log = Log.for("temp")
+
+      log.with_context(b: 2) do
+        log.context.set c: 3
+        log.context.metadata.should eq(m({a: 1, b: 2, c: 3}))
+      end
+
+      log.context.metadata.should eq(m({a: 1}))
+    end
+
+    it "restores context after the block" do
+      Log.context.set a: 1
+      log = Log.for("temp")
+
+      log.with_context do
+        log.context.set b: 2
+        log.context.metadata.should eq(m({a: 1, b: 2}))
+      end
+
+      log.context.metadata.should eq(m({a: 1}))
+    end
   end
 
-  it "is assignable from a named tuple" do
-    Log.context.set a: 1
-    extra = {b: 2}
-    Log.context.set extra
-    Log.context.metadata.should eq(m({a: 1, b: 2}))
+  describe ".with_context" do
+    it "with arguments restores context after the block" do
+      Log.context.set a: 1
+      Log.with_context(b: 2) do
+        Log.context.set c: 3
+        Log.context.metadata.should eq(m({a: 1, b: 2, c: 3}))
+      end
+
+      Log.context.metadata.should eq(m({a: 1}))
+    end
+
+    it "restores context after the block" do
+      Log.context.set a: 1
+
+      Log.with_context do
+        Log.context.set b: 2
+        Log.context.metadata.should eq(m({a: 1, b: 2}))
+      end
+
+      Log.context.metadata.should eq(m({a: 1}))
+    end
+
+    it "assigns context via a hash with symbol keys" do
+      Log.context.set a: 1
+      extra = {:b => 2}
+      Log.with_context(extra) do
+        Log.context.set c: 3
+        Log.context.metadata.should eq(m({a: 1, b: 2, c: 3}))
+      end
+
+      Log.context.metadata.should eq(m({a: 1}))
+    end
+
+    it "assigns context via a named tuple" do
+      Log.context.set a: 1
+      extra = {b: 2}
+      Log.with_context(extra) do
+        Log.context.set c: 3
+        Log.context.metadata.should eq(m({a: 1, b: 2, c: 3}))
+      end
+
+      Log.context.metadata.should eq(m({a: 1}))
+    end
   end
 end

--- a/src/log/main.cr
+++ b/src/log/main.cr
@@ -104,8 +104,26 @@ class Log
   end
 
   # :ditto:
+  def self.with_context(values)
+    previous = Log.context
+    Log.context.set(values) unless values.empty?
+    begin
+      yield
+    ensure
+      Log.context = previous
+    end
+  end
+
+  # :ditto:
   def with_context(**kwargs)
     self.class.with_context(**kwargs) do
+      yield
+    end
+  end
+
+  # :ditto:
+  def with_context(values)
+    self.class.with_context(values) do
       yield
     end
   end

--- a/src/log/main.cr
+++ b/src/log/main.cr
@@ -82,18 +82,20 @@ class Log
   end
 
   # Method to save and restore the current logging context.
+  # You can add temporary context via arguments
   #
   # ```
   # Log.context.set a: 1
   # Log.info { %(message with {"a" => 1} context) }
-  # Log.with_context do
-  #   Log.context.set b: 2
-  #   Log.info { %(message with {"a" => 1, "b" => 2} context) }
+  # Log.with_context(b: 2) do
+  #   Log.context.set c: 3
+  #   Log.info { %(message with {"a" => 1, "b" => 2, "c" => 3} context) }
   # end
   # Log.info { %(message with {"a" => 1} context) }
   # ```
-  def self.with_context
+  def self.with_context(**kwargs)
     previous = Log.context
+    Log.context.set(**kwargs) unless kwargs.empty?
     begin
       yield
     ensure
@@ -102,8 +104,8 @@ class Log
   end
 
   # :ditto:
-  def with_context
-    self.class.with_context do
+  def with_context(**kwargs)
+    self.class.with_context(**kwargs) do
       yield
     end
   end

--- a/src/log/main.cr
+++ b/src/log/main.cr
@@ -82,7 +82,7 @@ class Log
   end
 
   # Method to save and restore the current logging context.
-  # You can add temporary context via arguments
+  # Temporary context for the duration of the block can be set via arguments.
   #
   # ```
   # Log.context.set a: 1


### PR DESCRIPTION
This allows for temporary context to be set via `Log.with_context(**context, &block)`.

EDIT: Added support for `Log.with_context(value, &block)`, thanks for catching that @Sija 

Closes #11347 