### PR TITLE
[Makefile] Check for LLVM_CONFIG only when LLVM is used

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -62,7 +62,12 @@ ifeq ($(shell command -v ld.lld >/dev/null && uname -s),Linux)
   EXPORT_CC ?= CC="cc -fuse-ld=lld"
 endif
 
-colorize = $(shell tput >&2 setaf 3; echo >&2 "$1"; tput >&2 sgr0)
+ifeq ($(or $(TERM),$(TERM),dumb),dumb)
+colorize = $(shell printf >&2 "$1")
+else
+colorize = $(shell printf >&2 "\033[33m$1\033[0m\n")
+endif
+
 check_llvm_config = $(eval \
 	check_llvm_config := $(if $(LLVM_VERSION),\
 	  $(call colorize,Using $(LLVM_CONFIG) [version=$(LLVM_VERSION)]),\

--- a/Makefile
+++ b/Makefile
@@ -43,7 +43,9 @@ EXPORTS_BUILD := \
 	CRYSTAL_CONFIG_LIBRARY_PATH=$(CRYSTAL_CONFIG_LIBRARY_PATH)
 SHELL = sh
 LLVM_CONFIG := $(shell src/llvm/ext/find-llvm-config)
-LLVM_VERSION := $(shell $(LLVM_CONFIG) --version 2> /dev/null)
+ifdef $(LLVM_CONFIG)
+  LLVM_VERSION := $(shell $(LLVM_CONFIG) --version 2> /dev/null))
+endif
 LLVM_EXT_DIR = src/llvm/ext
 LLVM_EXT_OBJ = $(LLVM_EXT_DIR)/llvm_ext.o
 DEPS = $(LLVM_EXT_OBJ)

--- a/Makefile
+++ b/Makefile
@@ -43,6 +43,7 @@ EXPORTS_BUILD := \
 	CRYSTAL_CONFIG_LIBRARY_PATH=$(CRYSTAL_CONFIG_LIBRARY_PATH)
 SHELL = sh
 LLVM_CONFIG := $(shell src/llvm/ext/find-llvm-config)
+LLVM_VERSION := $(shell $(LLVM_CONFIG) --version 2> /dev/null)
 LLVM_EXT_DIR = src/llvm/ext
 LLVM_EXT_OBJ = $(LLVM_EXT_DIR)/llvm_ext.o
 DEPS = $(LLVM_EXT_OBJ)
@@ -61,11 +62,12 @@ ifeq ($(shell command -v ld.lld >/dev/null && uname -s),Linux)
   EXPORT_CC ?= CC="cc -fuse-ld=lld"
 endif
 
-ifeq (${LLVM_CONFIG},)
-  $(error Could not locate compatible llvm-config, make sure it is installed and in your PATH, or set LLVM_CONFIG. Compatible versions: $(shell cat src/llvm/ext/llvm-versions.txt))
-else
-  $(shell echo $(shell printf '\033[33m')Using $(LLVM_CONFIG) [version=$(shell $(LLVM_CONFIG) --version)]$(shell printf '\033[0m') >&2)
-endif
+colorize = $(shell tput >&2 setaf 3; echo >&2 "$1"; tput >&2 sgr0)
+check_llvm_config = $(eval \
+	check_llvm_config := $(if $(LLVM_VERSION),\
+	  $(call colorize,Using $(LLVM_CONFIG) [version=$(LLVM_VERSION)]),\
+	  $(error "Could not locate compatible llvm-config, make sure it is installed and in your PATH, or set LLVM_CONFIG. Compatible versions: $(shell cat src/llvm/ext/llvm-versions.txt)))\
+	)
 
 .PHONY: all
 all: crystal ## Build all files (currently crystal only) [default]
@@ -108,6 +110,7 @@ samples:
 
 .PHONY: docs
 docs: ## Generate standard library documentation
+	$(call check_llvm_config)
 	./bin/crystal docs src/docs_main.cr $(DOCS_OPTIONS) --project-name=Crystal --project-version=$(CRYSTAL_VERSION) --source-refname=$(CRYSTAL_CONFIG_BUILD_COMMIT)
 
 .PHONY: crystal
@@ -156,22 +159,27 @@ uninstall_docs: ## Uninstall docs from DESTDIR
 	rm -rf "$(DATADIR)/examples"
 
 $(O)/all_spec: $(DEPS) $(SOURCES) $(SPEC_SOURCES)
+	$(call check_llvm_config)
 	@mkdir -p $(O)
 	$(EXPORT_CC) $(EXPORTS) ./bin/crystal build $(FLAGS) $(SPEC_WARNINGS_OFF) -o $@ spec/all_spec.cr
 
 $(O)/std_spec: $(DEPS) $(SOURCES) $(SPEC_SOURCES)
+	$(call check_llvm_config)
 	@mkdir -p $(O)
 	$(EXPORT_CC) ./bin/crystal build $(FLAGS) $(SPEC_WARNINGS_OFF) -o $@ spec/std_spec.cr
 
 $(O)/compiler_spec: $(DEPS) $(SOURCES) $(SPEC_SOURCES)
+	$(call check_llvm_config)
 	@mkdir -p $(O)
 	$(EXPORT_CC) $(EXPORTS) ./bin/crystal build $(FLAGS) $(SPEC_WARNINGS_OFF) -o $@ spec/compiler_spec.cr
 
 $(O)/crystal: $(DEPS) $(SOURCES)
+	$(call check_llvm_config)
 	@mkdir -p $(O)
 	$(EXPORTS) $(EXPORTS_BUILD) ./bin/crystal build $(FLAGS) -o $@ src/compiler/crystal.cr -D without_openssl -D without_zlib
 
 $(LLVM_EXT_OBJ): $(LLVM_EXT_DIR)/llvm_ext.cc
+	$(call check_llvm_config)
 	$(CXX) -c $(CXXFLAGS) -o $@ $< $(shell $(LLVM_CONFIG) --cxxflags)
 
 man/%.gz: man/%

--- a/Makefile
+++ b/Makefile
@@ -43,9 +43,7 @@ EXPORTS_BUILD := \
 	CRYSTAL_CONFIG_LIBRARY_PATH=$(CRYSTAL_CONFIG_LIBRARY_PATH)
 SHELL = sh
 LLVM_CONFIG := $(shell src/llvm/ext/find-llvm-config)
-ifdef $(LLVM_CONFIG)
-  LLVM_VERSION := $(shell $(LLVM_CONFIG) --version 2> /dev/null))
-endif
+LLVM_VERSION := $(if $(LLVM_CONFIG), $(shell $(LLVM_CONFIG) --version 2> /dev/null))
 LLVM_EXT_DIR = src/llvm/ext
 LLVM_EXT_OBJ = $(LLVM_EXT_DIR)/llvm_ext.o
 DEPS = $(LLVM_EXT_OBJ)

--- a/Makefile
+++ b/Makefile
@@ -63,9 +63,9 @@ ifeq ($(shell command -v ld.lld >/dev/null && uname -s),Linux)
 endif
 
 ifeq ($(or $(TERM),$(TERM),dumb),dumb)
-colorize = $(shell printf >&2 "$1")
+  colorize = $(shell printf >&2 "$1")
 else
-colorize = $(shell printf >&2 "\033[33m$1\033[0m\n")
+  colorize = $(shell printf >&2 "\033[33m$1\033[0m\n")
 endif
 
 check_llvm_config = $(eval \


### PR DESCRIPTION
This is a re-issue of #11509 with an improved implementation of #11454 that does not use prerequisites. It adds a custom function call to every recipe that requires LLVM to be available. That function only runs once for the entire Makefile execution, so you won't get multiple `Using llvm-config` prints.

Additionally fixes some use cases around colorized output. This should now work with every shell and output only gets colorized if the terminal supports that (`tput` makes sure of that).