### PR TITLE
Formatter: Escape non-printable characters in literals

### DIFF
--- a/spec/compiler/formatter/formatter_spec.cr
+++ b/spec/compiler/formatter/formatter_spec.cr
@@ -450,10 +450,49 @@ describe Crystal::Formatter do
   assert_format "__DIR__", "__DIR__"
   assert_format "__LINE__", "__LINE__"
 
-  assert_format %q("\\\"\#\a\b\n\r\t\v\f\e")
+  assert_format %("\\0\\"\#\a\b\r\n\t\v\f\e\\xFF"), %("\\0\\"\#\\a\\b\\r\n\t\\v\\f\\e\\xFF")
+  assert_format %("\u00AD\uF8FF\u202A"), %("\\u00AD\\uF8FF\\u202A")
+  assert_format %("\\0\\"\#\a\b\r\n\t\v\f\e\\xFF\#{nil}"), %("\\0\\"\#\\a\\b\\r\n\t\\v\\f\\e\\xFF\#{nil}")
+  assert_format %("\u00AD\uF8FF\u202A\#{nil}"), %("\\u00AD\\uF8FF\\u202A\#{nil}")
+  assert_format %(:"\\0\\"\#\a\b\r\n\t\v\f\e\\xFF"), %(:"\\0\\"\#\\a\\b\\r\n\t\\v\\f\\e\\xFF")
+  assert_format %(:"\u00AD\uF8FF\u202A"), %(:"\\u00AD\\uF8FF\\u202A")
+  assert_format %(<<-HERE\n\\0"\#\a\b\r\n\t\v\f\e\\xFF\nHERE), %(<<-HERE\n\\0"\#\\a\\b\\r\n\t\\v\\f\\e\\xFF\nHERE)
+  assert_format %(<<-HERE\n\u00AD\uF8FF\u202A\nHERE), %(<<-HERE\n\\u00AD\\uF8FF\\u202A\nHERE)
+  assert_format %q("\\0\\\"\#\a\b\n\r\t\v\f\e\\xFF")
   assert_format %q("\a\c\b\d"), %q("\ac\bd")
-  assert_format %q("\\\"\#\a\b\n\r\t#{foo}\v\f\e")
+  assert_format %q("\\0\\\"\#\a\b\n\r\t#{foo}\v\f\e\\xFF")
   assert_format %q("\a\c#{foo}\b\d"), %q("\ac#{foo}\bd")
+  assert_format %(%w(\\0\\"\#\a\b\r\n\t\v\f\e\\xFF)), %(%w(\\0\\"\#\\a\\b \\e\\xFF))
+  assert_format %(%w(\u00AD\uF8FF\u202A)), %(%w(\\u00AD\\uF8FF\\u202A))
+  assert_format %(%i(\\0\\"\#\a\b\r\n\t\v\f\e\\xFF)), %(%i(\\0\\"\#\\a\\b \\e\\xFF))
+  assert_format %(%i(\u00AD\uF8FF\u202A)), %(%i(\\u00AD\\uF8FF\\u202A))
+
+  assert_format %("\\u0061\\u{61}\\u0009\\u{9}")
+
+  assert_format "'\\''"
+  assert_format "'\\0'"
+  assert_format "'\\u0000'"
+  assert_format "'\\\\'"
+  assert_format "'\a'", "'\\a'"
+  assert_format "'\b'", "'\\b'"
+  assert_format "'\r'", "'\\r'"
+  assert_format "'\n'", "'\\n'"
+  assert_format "'\t'", "'\\t'"
+  assert_format "'\v'", "'\\v'"
+  assert_format "'\f'", "'\\f'"
+  assert_format "'\e'", "'\\e'"
+  assert_format "'\u00AD'", "'\\u00AD'"
+  assert_format "'\uF8FF'", "'\\uF8FF'"
+  assert_format "'\u202A'", "'\\u202A'"
+  assert_format "'青'"
+  assert_format "'\\u9752'"
+  assert_format "'\\u9752'"
+  assert_format "'\u{110BD}'", "'\\u{110BD}'"
+  assert_format "'\u{1F48E}'", "'\u{1F48E}'"
+  assert_format "'\\u0061'"
+  assert_format "'\\u{61}'"
+  assert_format "'\\u0009'"
+  assert_format "'\\u{9}'"
 
   assert_format %("\#{foo = 1\n}"), %("\#{foo = 1}")
   assert_format %("\#{\n  foo = 1\n}")


### PR DESCRIPTION
With this patch, the formatter escapes all non-printable characters in string, char, and symbol literals. 

Non-printable characters in source code are confusing because they typically don't show up in the editor or other displays. This can lead to misunderstanding of the code and can be actively exploited to plant malicious code that gets unnoticed in review (see #11392 for example).

Ideally, editors and source code viewers could take care of this and make sure to indicate non-printable characters. There have been some improvements to that lately. But it's probably impossible or at least very hard to cover ever angle. So it's a good idea to mitigate any issues by making non-printable characters more explicit in source code.

In Crystals grammar (and after #11508 is merged), non-printable characters should technically only be valid inside literals or doc comments. We can easily replace any character in a literal by an equivalent escape sequence without changing the semantics.

This patch implements that. The only exception is that the non-printable characters `\n` and `\t` are allowed in string and symbol literals in order to avoid messing up the line format. I don't think that makes any sense for symbol literals, but they share the implementation with strings 🤷 Not sure it's worth making a special case.

For demonstration, the two examples from #11392 format like this now:
```cr
access_level = "user"
if access_level != "user\u202E \u2066# Check if admin\u2069 \u2066"
  puts "You are an admin!"
end
```
```cr
access_level = "user"
if access_level != "none\u202E\u2066" # Check if admin⁩⁦" && access_level != "user
  puts "You are an admin!"
end
```

That's the first step of #11478. A follow up could make the parser reject non-printables, but that's up for debate.

Some non-printables such as BIDI control characters could be considered to be allowed if we implement a BIDI algorithm in the parser that restricts the context for such controls to the boundaries of the literal.