### PR TITLE
[CI] Use `src/VERSION` for maintenance build on release branch

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -208,17 +208,25 @@ jobs:
     steps:
       - attach_workspace:
           at: /tmp/workspace
+      - checkout
       - run: |
+          case "$CIRCLE_BRANCH" in
+          release/*)
+            # In release branches, always use version from src/VERSION
+            VERSION=$(cat src/VERSION)
+            ;;
+          *)
+            # The version is based on the branch name.
+            VERSION=$CIRCLE_BRANCH
+
+            # We need to sanitize it because there are restrictions on some places
+            # where the version is use (Mac pkg names, snap branch).
+            VERSION=${VERSION//_/-}
+            VERSION=${VERSION//\//-}-dev
+            ;;
+          esac
+
           cd /tmp/workspace/distribution-scripts
-
-          # The version is based on the branch name.
-          VERSION=$CIRCLE_BRANCH
-
-          # We need to sanitize it because there are restrictions on some places
-          # where the version is use (Mac pkg names, snap branch).
-          VERSION=${VERSION/release\//}
-          VERSION=${VERSION//_/-}
-          VERSION=${VERSION//\//-}-dev
 
           export VERSION
           echo "export CRYSTAL_VERSION=$VERSION" >> build.env


### PR DESCRIPTION
In a release branch, maintenance builds should pull the version from `src/VERSION` instead of the branch name. That allows us to build package increments from a release branch. A use case example would be https://github.com/crystal-lang/distribution-scripts/pull/170: It changes the distribution package, but not the actual Crystal release. We would like to update and replace the 1.2.2 releases with this package increment.
The changes are pulled into the release branch in crystal-lang/crystal#11515. This also triggers a maintenance build, but it's tagged as a dev build. With this patch, we can directly publish the build artifacts from that maintenance build because they're properly tagged as 1.2.2.

I pushed the same commit to two different branches to show the difference:
* On `release/test`: `CRYSTAL_VERSION=1.3.0-dev` (it's not 1.2.2 because the commit is based on master, not `release/1.2`).   https://app.circleci.com/pipelines/github/crystal-lang/crystal/7508/workflows/52f74a17-2f10-4318-9182-170072bd9209/jobs/66143
* On `ci/maintenance-release-version`: `CRYSTAL_VERSION=ci-maintenance-release-version-dev` 
   https://app.circleci.com/pipelines/github/crystal-lang/crystal/7507/workflows/a53736f8-23ed-4039-a36a-8505c414808a/jobs/66142

The workflows for tagged and maintenance releases are identical except for the prepare step. So the build should be functionally identical, whether it's from a tagged commit or a non-tagged commit in a release branch.

Since the version is identical to the last tagged release, the workflow will automatically publish docker images with the respective tag. I'm not sure if we should keep it that way or use different tags for the docker images and require manual promotion to avoid accidental overrides.