### PR TITLE
Add local compiler wrapper script for Windows

### DIFF
--- a/bin/crystal.bat
+++ b/bin/crystal.bat
@@ -1,2 +1,2 @@
 @echo off
-powershell.exe -NoProfile -ExecutionPolicy Bypass -Command "%~dp0crystal.ps1" -- %*
+powershell.exe -NoProfile -ExecutionPolicy Bypass -Command "%~dp0crystal.ps1" --%% %*

--- a/bin/crystal.bat
+++ b/bin/crystal.bat
@@ -1,0 +1,2 @@
+@echo off
+powershell.exe -NoProfile -ExecutionPolicy Bypass -File "%~dp0crystal.ps1" %*

--- a/bin/crystal.bat
+++ b/bin/crystal.bat
@@ -1,2 +1,2 @@
 @echo off
-powershell.exe -NoProfile -ExecutionPolicy Bypass -File "%~dp0crystal.ps1" %*
+powershell.exe -NoProfile -ExecutionPolicy Bypass -Command "%~dp0crystal.ps1" -- %*

--- a/bin/crystal.ps1
+++ b/bin/crystal.ps1
@@ -186,7 +186,12 @@ function Exec-Process {
     # here we replicate the logic for `ProcessStartInfo.ArgumentList` on .NET 5 and above
     # See also: https://github.com/PowerShell/PowerShell/issues/14747
     # (note that we must nonetheless implement it by ourselves if we support Windows Powershell 5.1)
-    $Process = Start-Process $Path -ArgumentList (Build-Arguments $Args) -NoNewWindow -PassThru
+    $EscapedArgs = Build-Arguments $Args
+    if ($EscapedArgs) {
+        $Process = Start-Process $Path -ArgumentList $EscapedArgs -NoNewWindow -PassThru
+    } else {
+        $Process = Start-Process $Path -NoNewWindow -PassThru
+    }
     Wait-Process -Id $Process.Id
     Exit $Process.ExitCode
 }

--- a/bin/crystal.ps1
+++ b/bin/crystal.ps1
@@ -1,0 +1,238 @@
+param(
+    [Parameter(Position = 0, ValueFromRemainingArguments)] [string[]] $CrystalArgs
+)
+
+# https://www.powershellgallery.com/packages/PowerGit/0.6.1/Content/Functions%5CResolve-RealPath.ps1
+function Resolve-RealPath {
+    <#
+        .SYNOPSIS
+        Implementation of Unix realpath().
+
+        .PARAMETER Path
+        Must exist
+    #>
+    [CmdletBinding()]
+    [OutputType([string])]
+    param(
+        [Parameter(Position = 0, Mandatory, ValueFromPipeline, ValueFromPipelineByPropertyName)]
+        [Alias('FullName')]
+        [string] $Path
+    )
+
+    if ($PSVersionTable.PSVersion.Major -lt 6 -or $IsWindows) {
+        return [IO.Path]::GetFullPath($Path)
+    }
+
+    [string[]] $parts = ($Path.TrimStart([IO.Path]::DirectorySeparatorChar).Split([IO.Path]::DirectorySeparatorChar))
+    [string] $realPath = ''
+    foreach ($part in $parts) {
+        $realPath += [string] ([IO.Path]::DirectorySeparatorChar + $part)
+        $item = Get-Item $realPath
+        if ($item.Target) {
+            $realPath = $item.Target
+        }
+    }
+    $realPath
+}
+
+# https://stackoverflow.com/a/43030126
+function Invoke-WithEnvironment {
+<#
+.SYNOPSIS
+Invokes commands with a temporarily modified environment.
+
+.DESCRIPTION
+Modifies environment variables temporarily based on a hashtable of values,
+invokes the specified script block, then restores the previous environment.
+
+.PARAMETER Environment
+A hashtable that defines the temporary environment-variable values.
+Assign $null to (temporarily) remove an environment variable that is
+currently set.
+
+.PARAMETER ScriptBlock
+The command(s) to execute with the temporarily modified environment.
+
+.EXAMPLE
+> Invoke-WithEnvironment @{ PORT=8080 } { node index.js }
+
+Runs node with environment variable PORT temporarily set to 8080, with its
+previous value, if any 
+#>
+    param(
+        [Parameter(Mandatory)] [System.Collections.IDictionary] $Environment,
+        [Parameter(Mandatory)] [scriptblock] $ScriptBlock
+    )
+    # Modify the environment based on the hashtable and save the original 
+    # one for later restoration.
+    $htOrgEnv = @{}
+    foreach ($kv in $Environment.GetEnumerator()) {
+        $htOrgEnv[$kv.Key] = (Get-Item -EA SilentlyContinue "env:$($kv.Key)").Value
+        Set-Item "env:$($kv.Key)" $kv.Value
+    }
+    # Invoke the script block
+    try {
+        & $ScriptBlock
+    } finally {
+        # Restore the original environment.
+        foreach ($kv in $Environment.GetEnumerator()) {
+            # Note: setting an environment var. to $null or '' *removes* it.
+            Set-Item "env:$($kv.Key)" $htOrgEnv[$kv.Key]
+        }
+    }
+}
+
+# Code ported from:
+# https://source.dot.net/#System.Diagnostics.Process/System/Diagnostics/ProcessStartInfo.cs
+# https://source.dot.net/#System.Diagnostics.Process/PasteArguments.cs
+# Licensed to the .NET Foundation under one or more agreements.
+# The .NET Foundation licenses this file to you under the MIT license.
+function Append-Argument {
+    param(
+        [Parameter(Mandatory)] [Text.StringBuilder] $Builder,
+        [Parameter(Mandatory)] [AllowEmptyString()] [string] $Arg
+    )
+
+    if (-not $Builder.Length -eq 0) {
+        [void]$Builder.Append(' ')
+    }
+
+    # Parsing rules for non-argv[0] arguments:
+    #   - Backslash is a normal character except followed by a quote.
+    #   - 2N backslashes followed by a quote ==> N literal backslashes followed by unescaped quote
+    #   - 2N+1 backslashes followed by a quote ==> N literal backslashes followed by a literal quote
+    #   - Parsing stops at first whitespace outside of quoted region.
+    #   - (post 2008 rule): A closing quote followed by another quote ==> literal quote, and parsing remains in quoting mode.
+    if ((-not $Builder.Length -eq 0) -and (ContainsNoWhitespaceOrQuotes $Arg)) {
+        # Simple case - no quoting or changes needed.
+        [void]$Builder.Append($Arg)
+    } else {
+        [void]$Builder.Append('"')
+        $idx = 0
+        while ($idx -lt $Arg.Length) {
+            $c = $Arg[$idx++]
+            if ($c -eq '\') {
+                $numBackSlash = 1
+                while (($idx -lt $Arg.Length) -and ($Arg[$idx] -eq '\')) {
+                    $idx++
+                    $numBackslash++
+                }
+
+                if ($idx -eq $Arg.Length) {
+                    # We'll emit an end quote after this so must double the number of backslashes.
+                    [void]$Builder.Append('\', $numBackSlash * 2)
+                } elseif ($Arg[$idx] -eq '"') {
+                    # Backslashes will be followed by a quote. Must double the number of backslashes.
+                    [void]$Builder.Append('\', $numBackSlash * 2 + 1)
+                    [void]$Builder.Append('"')
+                    $idx++
+                } else {
+                    # Backslash will not be followed by a quote, so emit as normal characters.
+                    [void]$Builder.Append('\', $numBackSlash)
+                }
+
+                continue
+            }
+
+            if ($c -eq '"') {
+                # Escape the quote so it appears as a literal. This also guarantees that we won't end up generating a closing quote followed
+                # by another quote (which parses differently pre-2008 vs. post-2008.)
+                [void]$Builder.Append('\')
+                [void]$Builder.Append('"')
+                continue
+            }
+
+            [void]$Builder.Append($c)
+        }
+
+        [void]$Builder.Append('"')
+    }
+}
+
+function ContainsNoWhitespaceOrQuotes {
+    param(
+        [Parameter(Mandatory)] [AllowEmptyString()] [string] $s
+    )
+
+    for ($i = 0; $i -lt $s.Length; $i += 1) {
+        $c = $s[$i]
+        if ([char]::IsWhiteSpace($c) -or ($c -eq '"')) {
+            return $False
+        }
+    }
+
+    $True
+}
+
+function Build-Arguments {
+    param(
+        [Parameter(Mandatory)] [AllowEmptyString()] [AllowNull()] [string[]] $Args
+    )
+
+    if ($Args.count -eq 0) { return '' }
+
+    $Builder = [Text.StringBuilder]::new()
+    $Args | Foreach-Object { Append-Argument $Builder $_ }
+    $Builder.ToString()
+}
+
+function Exec-Process {
+    param(
+        [Parameter(Mandatory)] [string] $Path,
+        [Parameter(Mandatory)] [AllowEmptyString()] [AllowNull()] [string[]] $Args
+    )
+
+    # `Start-Process` simply joins all arguments without escaping and passes it to `ProcessStartInfo.Arguments`;
+    # here we replicate the logic for `ProcessStartInfo.ArgumentList` on .NET 5 and above
+    # See also: https://github.com/PowerShell/PowerShell/issues/14747
+    # (note that we must nonetheless implement it by ourselves if we support Windows Powershell 5.1)
+    $Process = Start-Process $Path -ArgumentList (Build-Arguments $Args) -NoNewWindow -PassThru
+    Wait-Process -Id $Process.Id
+    Exit $Process.ExitCode
+}
+
+$ScriptPath = Resolve-RealPath $PSCommandPath
+$ScriptRoot = Split-Path -Path $ScriptPath -Parent
+$CrystalRoot = Split-Path -Path $ScriptRoot -Parent
+$CrystalDir = "$CrystalRoot\.build"
+
+Invoke-WithEnvironment @{
+    CRYSTAL_PATH = if ($env:CRYSTAL_PATH) { $env:CRYSTAL_PATH } else { "lib;$CrystalRoot\src" }
+    CRYSTAL_HAS_WRAPPER = "true"
+    CRYSTAL = if ($env:CRYSTAL) { $env:CRYSTAL } else { "crystal" }
+    CRYSTAL_CONFIG_LIBRARY_PATH = $env:CRYSTAL_CONFIG_LIBRARY_PATH
+    CRYSTAL_LIBRARY_PATH = $env:CRYSTAL_LIBRARY_PATH
+} {
+    if (!$env:CRYSTAL_PATH.Contains("$CrystalRoot\src")) {
+        Write-Host "CRYSTAL_PATH env variable does not contain $CrystalRoot\src" -ForegroundColor DarkYellow
+    }
+
+    if (!$env:CRYSTAL_CONFIG_LIBRARY_PATH -or !$env:CRYSTAL_LIBRARY_PATH) {
+        Invoke-WithEnvironment @{ PATH = $env:PATH.Split(';') -ne $ScriptRoot -ne "bin" -join ';' } {
+            $CrystalInstalled = Get-Command "crystal" -CommandType ExternalScript, Application -ErrorAction SilentlyContinue
+            $CrystalInstalledLibraryPath = if ($CrystalInstalled) { crystal env CRYSTAL_LIBRARY_PATH } else { $null }
+            if (!$env:CRYSTAL_CONFIG_LIBRARY_PATH) { $env:CRYSTAL_CONFIG_LIBRARY_PATH = $CrystalInstalledLibraryPath }
+            if (!$env:CRYSTAL_LIBRARY_PATH) { $env:CRYSTAL_LIBRARY_PATH = $CrystalInstalledLibraryPath }
+        }
+    }
+
+    if (Test-Path -Path "$CrystalDir/crystal.exe" -PathType Leaf) {
+        Write-Host "Using compiled compiler at $($CrystalDir.Replace($pwd, "."))\crystal.exe" -ForegroundColor DarkYellow
+        Exec-Process "$CrystalDir/crystal.exe" $CrystalArgs
+    } else {
+        $CrystalCmd = Get-Command $env:CRYSTAL -CommandType ExternalScript, Application -ErrorAction SilentlyContinue
+        if (!$CrystalCmd) {
+            Write-Host 'You need to have a crystal executable in your path! or set CRYSTAL env variable' -ForegroundColor Red
+            Exit 1
+        } else {
+            $CrystalInstalledDir = Split-Path -Path $CrystalCmd.Path -Parent
+            if ($CrystalInstalledDir -eq $ScriptRoot -or $CrystalInstalledDir -eq "bin") {
+                Invoke-WithEnvironment @{ PATH = $env:PATH.Split(';') -ne $ScriptRoot -ne "bin" -join ';' } {
+                    Exec-Process $ScriptPath $CrystalArgs
+                }
+            } else {
+                Exec-Process $CrystalCmd.Path $CrystalArgs
+            }
+        }
+    }
+}


### PR DESCRIPTION
This PR adds a Powershell script for local development on Windows. It is more or less a direct port of `bin/crystal`. There is also a batch script wrapper that simplifies invocation from the Windows command prompt.

```cmd
> bin\crystal eval \"puts 1 + 2, \\\"1 + 2\\\", \\\"'\\\\\\\"\\\"\"
```

```powershell
PS> .\bin\crystal.ps1 -- eval 'puts 1 + 2, "1 + 2", "''\""'
PS> .\bin\crystal.ps1 -- eval "puts 1 + 2, `"1 + 2`", `"'\`"`""
PS> .\bin\crystal.ps1 --% eval "puts 1 + 2, \"1 + 2\", \"'\\\"\""
```

These all produce:

```
Using compiled compiler at .\.build\crystal.exe
3
1 + 2
'"
```

Building a local compiler, with debug info, can then be achieved on the MSVC developer prompt with the following, regardless of whether one has been built before, assuming that a prior installation of Crystal is present:

```cmd
for /f "usebackq tokens=*" %%i in (`%LLVM_CONFIG% --includedir`) do (
  cl /MT /c src\llvm\ext\llvm_ext.cc -I "%%i" /Fosrc\llvm\ext\llvm_ext.obj
)
bin\crystal build -o .build\crystal-next.exe src\compiler\crystal.cr -Dwithout_playground --link-flags=/STACK:10000000 --link-flags=/PDBALTPATH:crystal.pdb
move /Y .build\crystal-next.exe .build\crystal.exe
move /Y .build\crystal-next.pdb .build\crystal.pdb
```