### PR TITLE
Refactor `Log::BroadcastBackend#single_backend?`

### DIFF
--- a/src/log/broadcast_backend.cr
+++ b/src/log/broadcast_backend.cr
@@ -37,7 +37,7 @@ class Log::BroadcastBackend < Log::Backend
   # :nodoc:
   def single_backend?
     if @backends.size == 1
-      {@backends.first_key, @backends.first_value}
+      @backends.first
     end
   end
 

--- a/src/log/broadcast_backend.cr
+++ b/src/log/broadcast_backend.cr
@@ -36,13 +36,8 @@ class Log::BroadcastBackend < Log::Backend
 
   # :nodoc:
   def single_backend?
-    first_backend = @backends.first_key?
-    first_level = @backends[first_backend]
-
-    if first_backend && @backends.size == 1
-      {first_backend, first_level}
-    else
-      nil
+    if @backends.size == 1
+      {@backends.first_key, @backends.first_value}
     end
   end
 


### PR DESCRIPTION
Simplifies the implementation.

I needed to wrap my head around to understand how the method was implemented. This patch makes it very concise.