### PR TITLE
Refactor some type restrictions in the compiler

### DIFF
--- a/spec/compiler/semantic/doc_spec.cr
+++ b/spec/compiler/semantic/doc_spec.cr
@@ -305,7 +305,7 @@ describe "Semantic: doc" do
       end
     ), wants_doc: true
     program = result.program
-    ann = program.types["Flags"]
+    ann = program.types["Flags"].as(Crystal::AnnotationType)
     foo = program.types["Foo"]
     foo.annotation(ann).should_not be_nil
     foo.doc.should eq("Hello")

--- a/src/compiler/crystal/annotatable.cr
+++ b/src/compiler/crystal/annotatable.cr
@@ -11,12 +11,12 @@ module Crystal
     end
 
     # Returns the last defined annotation with the given type, if any, or `nil` otherwise
-    def annotation(annotation_type) : Annotation?
+    def annotation(annotation_type : AnnotationType) : Annotation?
       @annotations.try &.[annotation_type]?.try &.last?
     end
 
     # Returns all annotations with the given type, if any, or `nil` otherwise
-    def annotations(annotation_type) : Array(Annotation)?
+    def annotations(annotation_type : AnnotationType) : Array(Annotation)?
       @annotations.try &.[annotation_type]?
     end
   end

--- a/src/compiler/crystal/semantic/type_declaration_processor.cr
+++ b/src/compiler/crystal/semantic/type_declaration_processor.cr
@@ -503,9 +503,8 @@ struct Crystal::TypeDeclarationProcessor
 
   private def compute_non_nilable_instance_vars_multi(owner, infos)
     # Get ancestor's non-nilable variables
-    ancestor = owner.ancestors.first?
-    ancestor = uninstantiate(ancestor)
-    if ancestor
+    if ancestor = owner.ancestors.first?
+      ancestor = uninstantiate(ancestor)
       ancestor_non_nilable = @non_nilable_instance_vars[ancestor]?
     end
 
@@ -758,9 +757,9 @@ struct Crystal::TypeDeclarationProcessor
     end
   end
 
-  private def uninstantiate(type)
+  private def uninstantiate(type) : Type
     if type.is_a?(GenericInstanceType)
-      type.generic_type
+      type.generic_type.as(Type)
     else
       type
     end

--- a/src/compiler/crystal/tools/playground/server.cr
+++ b/src/compiler/crystal/tools/playground/server.cr
@@ -469,8 +469,8 @@ module Crystal::Playground
 
       agent_ws = PathWebSocketHandler.new "/agent" do |ws, context|
         match_data = context.request.path.not_nil!.match(/\/(\d+)\/(\d+)$/).not_nil!
-        session_key = match_data[1]?.try(&.to_i)
-        tag = match_data[2]?.try(&.to_i)
+        session_key = match_data[1].to_i
+        tag = match_data[2].to_i
         Log.info { "#{context.request.path} WebSocket connected (session=#{session_key}, tag=#{tag})" }
 
         session = @sessions[session_key]

--- a/src/compiler/crystal/tools/typed_def_processor.cr
+++ b/src/compiler/crystal/tools/typed_def_processor.cr
@@ -11,7 +11,7 @@ module Crystal::TypedDefProcessor
 
   private def process_result(result : Compiler::Result)
     process_type result.program
-    if file_module = result.program.file_module? target_location.original_filename
+    if (filename = target_location.original_filename) && (file_module = result.program.file_module?(filename))
       process_type file_module
     end
   end


### PR DESCRIPTION
This patch applies a couple small refactorings that remove unintended type unions. In the case of `Annotatable` it restricts the interface to allow only meaningful types.