### PR TITLE
Fix `YAML::Any` deserialize with alias

### DIFF
--- a/spec/std/yaml/any_spec.cr
+++ b/spec/std/yaml/any_spec.cr
@@ -107,6 +107,25 @@ describe YAML::Any do
       value = YAML.parse("1").as_bytes?
       value.should be_nil
     end
+
+    it "gets anchor" do
+      value = YAML.parse("&foo bar").as_s
+      value.should eq "bar"
+
+      value = YAML.parse("- &foo bar\n- *foo").as_a.map(&.as_s)
+      value.should eq ["bar", "bar"]
+
+      value = YAML.parse("foo: &foo\n  bar: *foo").as_h
+      foo = {YAML::Any.new("bar") => YAML::Any.new(nil)}
+      foo[YAML::Any.new("bar")] = YAML::Any.new(foo)
+      hash = YAML::Any.new({YAML::Any.new("foo") => YAML::Any.new(foo)})
+      # FIXME: Using to_s here because comparison of recursive YAML structures seems to be broken.
+      value.to_s.should eq hash.to_s
+
+      expect_raises YAML::ParseException, "Unknown anchor 'foo' at line 1, column 1" do
+        YAML.parse("*foo")
+      end
+    end
   end
 
   describe "#size" do

--- a/spec/std/yaml/serializable_spec.cr
+++ b/spec/std/yaml/serializable_spec.cr
@@ -642,6 +642,13 @@ describe "YAML::Serializable" do
 
     yaml = YAMLAttrWithAny.from_yaml({:obj => {:foo => :bar}}.to_yaml)
     yaml.obj["foo"].as_s.should eq("bar")
+
+    yaml = YAMLAttrWithAny.from_yaml("extra: &foo hello\nobj: *foo")
+    yaml.obj.as_s.should eq("hello")
+
+    expect_raises YAML::ParseException, "Unknown anchor 'foo' at line 1, column 6" do
+      YAMLAttrWithAny.from_yaml("obj: *foo")
+    end
   end
 
   it "parses yaml with problematic keys" do

--- a/src/yaml/any.cr
+++ b/src/yaml/any.cr
@@ -62,7 +62,15 @@ struct YAML::Any
 
       new hash
     when YAML::Nodes::Alias
-      anchors[node.anchor]
+      if value = node.value
+        convert(value, anchors)
+      elsif anchor = node.anchor
+        anchors.fetch(anchor) do
+          raise YAML::ParseException.new("Unknown anchor '#{anchor.inspect}'", *node.location)
+        end
+      else
+        raise "YAML::Nodes::Alias misses anchor value"
+      end
     else
       raise "Unknown node: #{node.class}"
     end


### PR DESCRIPTION
The deserialization implementation for `YAML::Any` ignores aliases for anchors defined outside the scope of the current context.

`YAMLAttrWithAny.from_yaml("extra: &foo hello\nobj: *foo")` failed because the anchor `foo` was defined on the context of `YAMLAttrWithAny`, but `YAML::Any` only looks at the `obj` key.

This patch fixes that and makes `YAML::Any` use the alias value (which is already available from the parser anyway).
I'm also adding a couple more specs for aliases with `YAML::Any`.

<del>I'm not entirely sure why we even need the custom anchor collection in `YAML::Any.convert`, but for now I've kept with that.</del>
The second commit is a refactoring that  remove anchor handling from YAML::Any constructor. Anchors are already handled in the YAML parser. The removed code actually has no effect.