### PR TITLE
Fix ensure PCRE JIT mode is available before running spec

### DIFF
--- a/spec/std/regex_spec.cr
+++ b/spec/std/regex_spec.cr
@@ -114,6 +114,8 @@ describe "Regex" do
     end
 
     it "matches a large single line string" do
+      pending! "PCRE JIT mode not available." unless LibPCRE::JIT_ENABLED
+
       str = File.read(datapath("large_single_line_string.txt"))
       str.matches?(/^(?:[A-Za-z0-9+\/]{4})*(?:[A-Za-z0-9+\/]{2}==|[A-Za-z0-9+\/]{3}=)?$/).should be_false
     end

--- a/spec/std/regex_spec.cr
+++ b/spec/std/regex_spec.cr
@@ -114,7 +114,8 @@ describe "Regex" do
     end
 
     it "matches a large single line string" do
-      pending! "PCRE JIT mode not available." unless LibPCRE::JIT_ENABLED
+      LibPCRE.config LibPCRE::CONFIG_JIT, out jit_enabled
+      pending! "PCRE JIT mode not available." unless 1 == jit_enabled
 
       str = File.read(datapath("large_single_line_string.txt"))
       str.matches?(/^(?:[A-Za-z0-9+\/]{4})*(?:[A-Za-z0-9+\/]{2}==|[A-Za-z0-9+\/]{3}=)?$/).should be_false

--- a/src/regex/lib_pcre.cr
+++ b/src/regex/lib_pcre.cr
@@ -1,16 +1,24 @@
 @[Link("pcre")]
 lib LibPCRE
+  JIT_ENABLED = begin
+    LibPCRE.config CONFIG_JIT, out enabled
+    1 == enabled
+  end
+
   alias Int = LibC::Int
 
   type Pcre = Void*
   type PcreExtra = Void*
   fun compile = pcre_compile(pattern : UInt8*, options : Int, errptr : UInt8**, erroffset : Int*, tableptr : Void*) : Pcre
+  fun config = pcre_config(what : Int, where : Int*) : Int
   fun exec = pcre_exec(code : Pcre, extra : PcreExtra, subject : UInt8*, length : Int, offset : Int, options : Int, ovector : Int*, ovecsize : Int) : Int
   fun study = pcre_study(code : Pcre, options : Int, errptr : UInt8**) : PcreExtra
   fun free_study = pcre_free_study(extra : PcreExtra) : Void
   fun full_info = pcre_fullinfo(code : Pcre, extra : PcreExtra, what : Int, where : Int*) : Int
   fun get_stringnumber = pcre_get_stringnumber(code : Pcre, string_name : UInt8*) : Int
   fun get_stringtable_entries = pcre_get_stringtable_entries(code : Pcre, name : UInt8*, first : UInt8**, last : UInt8**) : Int
+
+  CONFIG_JIT = 9
 
   STUDY_JIT_COMPILE = 0x0001
 

--- a/src/regex/lib_pcre.cr
+++ b/src/regex/lib_pcre.cr
@@ -1,10 +1,5 @@
 @[Link("pcre")]
 lib LibPCRE
-  JIT_ENABLED = begin
-    LibPCRE.config CONFIG_JIT, out enabled
-    1 == enabled
-  end
-
   alias Int = LibC::Int
 
   type Pcre = Void*


### PR DESCRIPTION
Currently fails when `pcre` was installed on linux via brew due to https://github.com/Homebrew/homebrew-core/blob/45b136583f6e3c0c09337b947b1101728834a5aa/Formula/pcre.rb#L58. This PR will skip that spec if JIT mode is not available.