### PR TITLE
Support BuildTools and other VS variants in vswhere detection

### DIFF
--- a/src/crystal/system/win32/visual_studio.cr
+++ b/src/crystal/system/win32/visual_studio.cr
@@ -31,7 +31,7 @@ module Crystal::System::VisualStudio
 
   private def self.get_vs_installations : Array(Installation)?
     if vswhere_path = find_vswhere
-      vc_install_json = `#{::Process.quote(vswhere_path)} -requires Microsoft.VisualStudio.Component.VC.Tools.x86.x64 -sort -format json`.chomp
+      vc_install_json = `#{::Process.quote(vswhere_path)} -requires Microsoft.VisualStudio.Component.VC.Tools.x86.x64 -products * -sort -format json`.chomp
       return if !$?.success? || vc_install_json.empty?
 
       Array(Installation).from_json(vc_install_json)


### PR DESCRIPTION
I did not notice this in the initial PR, but the baked in vswhere detection only works for a full VS installation, you must specify `-products *` to include BuildTools in the search. The shim I originally wrote as apart of scoop install would detect either type of installation.