### PR TITLE
Add commit hash to Windows builds

### DIFF
--- a/.github/workflows/win.yml
+++ b/.github/workflows/win.yml
@@ -264,6 +264,7 @@ jobs:
           echo 'CRYSTAL_CONFIG_LIBRARY_PATH=$ORIGIN\lib' >> ${env:GITHUB_ENV}
           echo "TERM=dumb" >> ${env:GITHUB_ENV}
           echo "LLVM_CONFIG=$(pwd)\llvm\bin\llvm-config.exe" >> ${env:GITHUB_ENV}
+          echo "CRYSTAL_CONFIG_BUILD_COMMIT=$(git rev-parse --short=9 HEAD)" >> ${env:GITHUB_ENV}
           echo "SOURCE_DATE_EPOCH=$(Get-Date -Millisecond 0 -UFormat %s)" >> ${env:GITHUB_ENV}
 
       - name: Download Crystal object file


### PR DESCRIPTION
When rebuilding Crystal on Windows CI, attaches the Git commit hash like it is done in the Makefile:

```
> crystal --version
Crystal 1.3.0-dev [5636f0411] (2021-12-04)

LLVM: 10.0.0
Default target: x86_64-pc-windows-msvc
```

This also makes the constant `Crystal::BUILD_COMMIT` available.