### PR TITLE
Include shards with Windows build artifacts

### DIFF
--- a/.github/workflows/win.yml
+++ b/.github/workflows/win.yml
@@ -292,6 +292,25 @@ jobs:
           cp libs/* crystal/lib/
           cp src/* crystal/src -Recurse
           rm crystal/src/llvm/ext/llvm_ext.obj
+          echo "$(pwd)\crystal" >> $env:GITHUB_PATH
+
+      - name: Get latest shards release
+        run: |
+          echo "SHARDS_RELEASE_TAG=$(Invoke-RestMethod https://api.github.com/repos/crystal-lang/shards/releases/latest | Select-Object -ExpandProperty tag_name)" >> ${env:GITHUB_ENV}
+
+      - name: Download latest shards release
+        uses: actions/checkout@v2
+        with:
+          repository: crystal-lang/shards
+          ref: ${{ env.SHARDS_RELEASE_TAG }}
+          path: shards
+
+      - name: Build latest shards release
+        working-directory: ./shards
+        run: |
+          make
+          cp bin/shards.exe ../crystal/
+
       - name: Upload Crystal binaries
         uses: actions/upload-artifact@v2
         with:


### PR DESCRIPTION
I modified the GitHub actions file to build shards from source and include it in the [artifact drop](https://github.com/neatorobito/crystal/actions/runs/1546765866). I tested the binary by looking up a few libraries and adding them as dependencies to a blank project.