### PR TITLE
Add fallback for `Path.home` on Unix

### DIFF
--- a/spec/std/path_spec.cr
+++ b/spec/std/path_spec.cr
@@ -893,13 +893,17 @@ describe Path do
       end
     end
 
-    # TODO: check that this is the home of the current user
-    {% if flag?(:win32) %}
-      it "doesn't raise if environment variable is missing" do
-        with_env({HOME_ENV_KEY => nil}) do
-          Path.home
-        end
+    # TODO: check that the cases below return the home of the current user (via #7829)
+    it "doesn't return empty string if environment variable is empty" do
+      with_env({HOME_ENV_KEY => ""}) do
+        Path.home.should_not eq(Path.new(""))
       end
-    {% end %}
+    end
+
+    it "doesn't raise if environment variable is missing" do
+      with_env({HOME_ENV_KEY => nil}) do
+        Path.home.should be_a(Path)
+      end
+    end
   end
 end

--- a/src/crystal/system/unix/path.cr
+++ b/src/crystal/system/unix/path.cr
@@ -9,7 +9,7 @@ module Crystal::System::Path
 
       pwd = uninitialized LibC::Passwd
       pwd_pointer = pointerof(pwd)
-      ret = uninitialized LibC::Int
+      ret = nil
       System.retry_with_buffer("getpwuid_r", User::GETPW_R_SIZE_MAX) do |buf|
         ret = LibC.getpwuid_r(id, pwd_pointer, buf, buf.size, pointerof(pwd_pointer))
       end
@@ -17,7 +17,7 @@ module Crystal::System::Path
       if pwd_pointer
         String.new(pwd.pw_dir)
       else
-        raise RuntimeError.from_os_error("getpwuid_r", Errno.new(ret))
+        raise RuntimeError.from_os_error("getpwuid_r", Errno.new(ret.not_nil!))
       end
     end
   end

--- a/src/crystal/system/unix/path.cr
+++ b/src/crystal/system/unix/path.cr
@@ -1,5 +1,24 @@
+require "./user"
+
 module Crystal::System::Path
   def self.home : String
-    ENV["HOME"]
+    if home_path = ENV["HOME"]?.presence
+      home_path
+    else
+      id = LibC.getuid
+
+      pwd = uninitialized LibC::Passwd
+      pwd_pointer = pointerof(pwd)
+      ret = uninitialized LibC::Int
+      System.retry_with_buffer("getpwuid_r", User::GETPW_R_SIZE_MAX) do |buf|
+        ret = LibC.getpwuid_r(id, pwd_pointer, buf, buf.size, pointerof(pwd_pointer))
+      end
+
+      if pwd_pointer
+        String.new(pwd.pw_dir)
+      else
+        raise RuntimeError.from_os_error("getpwuid_r", Errno.new(ret))
+      end
+    end
   end
 end

--- a/src/crystal/system/unix/user.cr
+++ b/src/crystal/system/unix/user.cr
@@ -2,7 +2,7 @@ require "c/pwd"
 require "../unix"
 
 module Crystal::System::User
-  private GETPW_R_SIZE_MAX = 1024 * 16
+  GETPW_R_SIZE_MAX = 1024 * 16
 
   private def from_struct(pwd)
     user = String.new(pwd.pw_gecos).partition(',')[0]

--- a/src/crystal/system/win32/path.cr
+++ b/src/crystal/system/win32/path.cr
@@ -4,7 +4,7 @@ require "c/shlobj_core"
 
 module Crystal::System::Path
   def self.home : String
-    if home_path = ENV["USERPROFILE"]?
+    if home_path = ENV["USERPROFILE"]?.presence
       home_path
     elsif LibC.SHGetKnownFolderPath(pointerof(LibC::FOLDERID_Profile), 0, nil, out path_ptr) == 0
       home_path, _ = String.from_utf16(path_ptr)

--- a/src/lib_c/aarch64-darwin/c/unistd.cr
+++ b/src/lib_c/aarch64-darwin/c/unistd.cr
@@ -27,6 +27,7 @@ lib LibC
   fun getpgid(x0 : PidT) : PidT
   fun getpid : PidT
   fun getppid : PidT
+  fun getuid : UidT
   fun isatty(x0 : Int) : Int
   fun ttyname_r(fd : Int, buf : Char*, buffersize : SizeT) : Int
   fun lchown(x0 : Char*, x1 : UidT, x2 : GidT) : Int

--- a/src/lib_c/aarch64-linux-gnu/c/unistd.cr
+++ b/src/lib_c/aarch64-linux-gnu/c/unistd.cr
@@ -28,6 +28,7 @@ lib LibC
   fun getpgid(pid : PidT) : PidT
   fun getpid : PidT
   fun getppid : PidT
+  fun getuid : UidT
   fun isatty(fd : Int) : Int
   fun ttyname_r(fd : Int, buf : Char*, buffersize : SizeT) : Int
   fun lchown(file : Char*, owner : UidT, group : GidT) : Int

--- a/src/lib_c/aarch64-linux-musl/c/unistd.cr
+++ b/src/lib_c/aarch64-linux-musl/c/unistd.cr
@@ -28,6 +28,7 @@ lib LibC
   fun getpgid(x0 : PidT) : PidT
   fun getpid : PidT
   fun getppid : PidT
+  fun getuid : UidT
   fun isatty(x0 : Int) : Int
   fun ttyname_r(fd : Int, buf : Char*, buffersize : SizeT) : Int
   fun lchown(x0 : Char*, x1 : UidT, x2 : GidT) : Int

--- a/src/lib_c/arm-linux-gnueabihf/c/unistd.cr
+++ b/src/lib_c/arm-linux-gnueabihf/c/unistd.cr
@@ -28,6 +28,7 @@ lib LibC
   fun getpgid(pid : PidT) : PidT
   fun getpid : PidT
   fun getppid : PidT
+  fun getuid : UidT
   fun isatty(fd : Int) : Int
   fun ttyname_r(fd : Int, buf : Char*, buffersize : SizeT) : Int
   fun lchown(file : Char*, owner : UidT, group : GidT) : Int

--- a/src/lib_c/i386-linux-gnu/c/unistd.cr
+++ b/src/lib_c/i386-linux-gnu/c/unistd.cr
@@ -28,6 +28,7 @@ lib LibC
   fun getpgid(pid : PidT) : PidT
   fun getpid : PidT
   fun getppid : PidT
+  fun getuid : UidT
   fun isatty(fd : Int) : Int
   fun ttyname_r(fd : Int, buf : Char*, buffersize : SizeT) : Int
   fun lchown(file : Char*, owner : UidT, group : GidT) : Int

--- a/src/lib_c/i386-linux-musl/c/unistd.cr
+++ b/src/lib_c/i386-linux-musl/c/unistd.cr
@@ -28,6 +28,7 @@ lib LibC
   fun getpgid(x0 : PidT) : PidT
   fun getpid : PidT
   fun getppid : PidT
+  fun getuid : UidT
   fun isatty(x0 : Int) : Int
   fun ttyname_r(fd : Int, buf : Char*, buffersize : SizeT) : Int
   fun lchown(x0 : Char*, x1 : UidT, x2 : GidT) : Int

--- a/src/lib_c/x86_64-darwin/c/unistd.cr
+++ b/src/lib_c/x86_64-darwin/c/unistd.cr
@@ -28,6 +28,7 @@ lib LibC
   fun getpgid(x0 : PidT) : PidT
   fun getpid : PidT
   fun getppid : PidT
+  fun getuid : UidT
   fun isatty(x0 : Int) : Int
   fun ttyname_r(fd : Int, buf : Char*, buffersize : SizeT) : Int
   fun lchown(x0 : Char*, x1 : UidT, x2 : GidT) : Int

--- a/src/lib_c/x86_64-dragonfly/c/unistd.cr
+++ b/src/lib_c/x86_64-dragonfly/c/unistd.cr
@@ -26,6 +26,7 @@ lib LibC
   fun getpgid(pid : PidT) : Int
   fun getpid : PidT
   fun getppid : PidT
+  fun getuid : UidT
   fun isatty(x0 : Int) : Int
   fun ttyname_r(fd : Int, buf : Char*, buffersize : SizeT) : Int
   fun lchown(x0 : Char*, x1 : UidT, x2 : GidT) : Int

--- a/src/lib_c/x86_64-freebsd/c/unistd.cr
+++ b/src/lib_c/x86_64-freebsd/c/unistd.cr
@@ -27,6 +27,7 @@ lib LibC
   fun getpgid(pid : PidT) : Int
   fun getpid : PidT
   fun getppid : PidT
+  fun getuid : UidT
   fun isatty(x0 : Int) : Int
   fun ttyname_r(fd : Int, buf : Char*, buffersize : SizeT) : Int
   fun lchown(x0 : Char*, x1 : UidT, x2 : GidT) : Int

--- a/src/lib_c/x86_64-linux-gnu/c/unistd.cr
+++ b/src/lib_c/x86_64-linux-gnu/c/unistd.cr
@@ -28,6 +28,7 @@ lib LibC
   fun getpgid(pid : PidT) : PidT
   fun getpid : PidT
   fun getppid : PidT
+  fun getuid : UidT
   fun isatty(fd : Int) : Int
   fun ttyname_r(fd : Int, buf : Char*, buffersize : SizeT) : Int
   fun lchown(file : Char*, owner : UidT, group : GidT) : Int

--- a/src/lib_c/x86_64-linux-musl/c/unistd.cr
+++ b/src/lib_c/x86_64-linux-musl/c/unistd.cr
@@ -28,6 +28,7 @@ lib LibC
   fun getpgid(x0 : PidT) : PidT
   fun getpid : PidT
   fun getppid : PidT
+  fun getuid : UidT
   fun isatty(x0 : Int) : Int
   fun ttyname_r(fd : Int, buf : Char*, buffersize : SizeT) : Int
   fun lchown(x0 : Char*, x1 : UidT, x2 : GidT) : Int

--- a/src/lib_c/x86_64-netbsd/c/unistd.cr
+++ b/src/lib_c/x86_64-netbsd/c/unistd.cr
@@ -27,6 +27,7 @@ lib LibC
   fun getpgid(x0 : PidT) : PidT
   fun getpid : PidT
   fun getppid : PidT
+  fun getuid : UidT
   fun isatty(x0 : Int) : Int
   fun ttyname_r(fd : Int, buf : Char*, buffersize : SizeT) : Int
   fun lchown = __posix_lchown(x0 : Char*, x1 : UidT, x2 : GidT) : Int

--- a/src/lib_c/x86_64-openbsd/c/unistd.cr
+++ b/src/lib_c/x86_64-openbsd/c/unistd.cr
@@ -27,6 +27,7 @@ lib LibC
   fun getpgid(x0 : PidT) : PidT
   fun getpid : PidT
   fun getppid : PidT
+  fun getuid : UidT
   fun isatty(x0 : Int) : Int
   fun ttyname_r(fd : Int, buf : Char*, buffersize : SizeT) : Int
   fun lchown(x0 : Char*, x1 : UidT, x2 : GidT) : Int


### PR DESCRIPTION
Defaults to the home directory of the real user (as opposed to effective) when `$HOME` is empty or null. This is equivalent to:

```crystal
require "system/user"

lib LibC
  fun getuid : UidT
end

Path.new(System::User.find_by(id: LibC.getuid.to_s).home_directory)
```

but without constructing a `System::User`.