### PR TITLE
Disable incremental linking on MSVC

### DIFF
--- a/src/compiler/crystal/compiler.cr
+++ b/src/compiler/crystal/compiler.cr
@@ -376,6 +376,7 @@ module Crystal
         {% end %}
 
         link_args << "/DEBUG:FULL /PDBALTPATH:%_PDB%" unless debug.none?
+        link_args << "/INCREMENTAL:NO"
         link_args << lib_flags
         @link_flags.try { |flags| link_args << flags }
 


### PR DESCRIPTION
Incremental linking does not make sense for temporary executables (`crystal eval`, `run`, `spec`, `play`, specs that invoke the compiler program), because a full link is performed if the output is missing, and Crystal always deletes those executables after finishing; all we get is a padded executable, an .ilk file that never gets used, and this warning message:

> C:\Users\RUNNER~1\AppData\Local\Temp\cr-spec-08887e17\warnings\crystal-spec-output.exe not found or not built by the last incremental link; performing full link

Even for `crystal build`, MSVC performs a full link whenever the link command line changes. The way Crystal programs are written can cause frequent changes to the command line, so incremental linking is now disabled by default. It can still be explicitly enabled with `--link=flags=/INCREMENTAL` (MSVC generates no warnings if multiple conflicting `/INCREMENTAL` options are specified, the last one takes effect).