### PR TITLE
Enable `kernel_spec.cr` on Windows CI

### DIFF
--- a/spec/std/kernel_spec.cr
+++ b/spec/std/kernel_spec.cr
@@ -18,116 +18,102 @@ describe "at_exit" do
   it "runs handlers on normal program ending" do
     status, output, _ = compile_and_run_source <<-CODE
       at_exit do
-        puts "handler code"
+        print "handler code."
       end
     CODE
 
     status.success?.should be_true
-    output.should eq("handler code\n")
+    output.should eq("handler code.")
   end
 
   it "runs handlers on explicit program ending" do
     status, output, _ = compile_and_run_source <<-'CODE'
       at_exit do |exit_code|
-        puts "handler code, exit code: #{exit_code}"
+        print "handler code, exit code: #{exit_code}."
       end
 
       exit 42
     CODE
 
     status.exit_code.should eq(42)
-    output.should eq("handler code, exit code: 42\n")
+    output.should eq("handler code, exit code: 42.")
   end
 
   it "runs handlers in reverse order" do
     status, output, _ = compile_and_run_source <<-CODE
       at_exit do
-        puts "first handler code"
+        print "first handler code."
       end
 
       at_exit do
-        puts "second handler code"
+        print "second handler code."
       end
     CODE
 
     status.success?.should be_true
-    output.should eq <<-OUTPUT
-                       second handler code
-                       first handler code
-
-                       OUTPUT
+    output.should eq("second handler code.first handler code.")
   end
 
   it "runs all handlers maximum once" do
     status, output, _ = compile_and_run_source <<-CODE
       at_exit do
-        puts "first handler code"
+        print "first handler code."
       end
 
       at_exit do
-        puts "second handler code, explicit exit!"
+        print "second handler code, explicit exit!"
         exit
 
-        puts "not executed"
+        print "not executed."
       end
 
       at_exit do
-        puts "third handler code"
+        print "third handler code."
       end
     CODE
 
     status.success?.should be_true
-    output.should eq <<-OUTPUT
-                       third handler code
-                       second handler code, explicit exit!
-                       first handler code
-
-                       OUTPUT
+    output.should eq("third handler code.second handler code, explicit exit!first handler code.")
   end
 
   it "allows handlers to change the exit code with explicit `exit` call" do
     status, output, _ = compile_and_run_source <<-'CODE'
       at_exit do |exit_code|
-        puts "first handler code, exit code: #{exit_code}"
+        print "first handler code, exit code: #{exit_code}."
       end
 
       at_exit do
-        puts "second handler code, re-exiting"
+        print "second handler code, re-exiting."
         exit 42
 
-        puts "not executed"
+        print "not executed."
       end
 
       at_exit do |exit_code|
-        puts "third handler code, exit code: #{exit_code}"
+        print "third handler code, exit code: #{exit_code}."
       end
     CODE
 
     status.success?.should be_false
     status.exit_code.should eq(42)
-    output.should eq <<-OUTPUT
-                       third handler code, exit code: 0
-                       second handler code, re-exiting
-                       first handler code, exit code: 42
-
-                       OUTPUT
+    output.should eq("third handler code, exit code: 0.second handler code, re-exiting.first handler code, exit code: 42.")
   end
 
   it "allows handlers to change the exit code with explicit `exit` call (2)" do
     status, output, _ = compile_and_run_source <<-'CODE'
       at_exit do |exit_code|
-        puts "first handler code, exit code: #{exit_code}"
+        print "first handler code, exit code: #{exit_code}."
       end
 
       at_exit do
-        puts "second handler code, re-exiting"
+        print "second handler code, re-exiting."
         exit 42
 
-        puts "not executed"
+        print "not executed."
       end
 
       at_exit do |exit_code|
-        puts "third handler code, exit code: #{exit_code}"
+        print "third handler code, exit code: #{exit_code}."
       end
 
       exit 21
@@ -135,99 +121,82 @@ describe "at_exit" do
 
     status.success?.should be_false
     status.exit_code.should eq(42)
-    output.should eq <<-OUTPUT
-                       third handler code, exit code: 21
-                       second handler code, re-exiting
-                       first handler code, exit code: 42
-
-                       OUTPUT
+    output.should eq("third handler code, exit code: 21.second handler code, re-exiting.first handler code, exit code: 42.")
   end
 
   it "changes final exit code when an handler raises an error" do
     status, output, error = compile_and_run_source <<-'CODE'
       at_exit do |exit_code|
-        puts "first handler code, exit code: #{exit_code}"
+        print "first handler code, exit code: #{exit_code}."
       end
 
       at_exit do
-        puts "second handler code, raising"
+        print "second handler code, raising."
         raise "Raised from at_exit handler!"
 
-        puts "not executed"
+        print "not executed."
       end
 
       at_exit do |exit_code|
-        puts "third handler code, exit code: #{exit_code}"
+        print "third handler code, exit code: #{exit_code}."
       end
     CODE
 
     status.success?.should be_false
     status.exit_code.should eq(1)
-    output.should eq <<-OUTPUT
-                       third handler code, exit code: 0
-                       second handler code, raising
-                       first handler code, exit code: 1
-
-                       OUTPUT
-    error.should eq "Error running at_exit handler: Raised from at_exit handler!\n"
+    output.should eq("third handler code, exit code: 0.second handler code, raising.first handler code, exit code: 1.")
+    error.should contain("Error running at_exit handler: Raised from at_exit handler!")
   end
 
   it "shows unhandled exceptions after at_exit handlers" do
     status, _, error = compile_and_run_source <<-CODE
       at_exit do
-        STDERR.puts "first handler code"
+        STDERR.print "first handler code."
       end
 
       at_exit do
-        STDERR.puts "second handler code"
+        STDERR.print "second handler code."
       end
 
       raise "Kaboom!"
     CODE
 
     status.success?.should be_false
-    error.should contain <<-OUTPUT
-                           second handler code
-                           first handler code
-                           Unhandled exception: Kaboom!
-                           OUTPUT
+    error.should contain("second handler code.first handler code.Unhandled exception: Kaboom!")
   end
 
   it "can get unhandled exception in at_exit handler" do
     status, _, error = compile_and_run_source <<-CODE
       at_exit do |_, ex|
-        STDERR.puts ex.try &.message
+        STDERR.print ex.try &.message
       end
 
       raise "Kaboom!"
     CODE
 
     status.success?.should be_false
-    error.should contain <<-OUTPUT
-                           Kaboom!
-                           Unhandled exception: Kaboom!
-                           OUTPUT
+    error.should contain("Kaboom!Unhandled exception: Kaboom!")
   end
 
   it "allows at_exit inside at_exit" do
     status, output, _ = compile_and_run_source <<-CODE
       at_exit do
-        puts "1"
+        print "1"
         at_exit do
-          puts "2"
+          print "2"
         end
       end
 
       at_exit do
-        puts "3"
+        print "3"
         at_exit do
-          puts "4"
+          print "4"
         end
       end
     CODE
 
     status.success?.should be_true
-    output.should eq("3\n4\n1\n2\n")
+    output.should eq("3412")
   end
 
   it "prints unhandled exception with cause" do
@@ -241,7 +210,7 @@ describe "at_exit" do
   end
 end
 
-describe "seg fault" do
+pending_win32 describe: "seg fault" do
   it "reports SIGSEGV" do
     status, _, error = compile_and_run_source <<-'CODE'
       puts Pointer(Int64).null.value

--- a/spec/win32_std_spec.cr
+++ b/spec/win32_std_spec.cr
@@ -121,7 +121,7 @@ require "./std/json/parser_spec.cr"
 require "./std/json/pull_parser_spec.cr"
 require "./std/json/serializable_spec.cr"
 require "./std/json/serialization_spec.cr"
-# require "./std/kernel_spec.cr" (failed codegen)
+require "./std/kernel_spec.cr"
 require "./std/levenshtein_spec.cr"
 # require "./std/llvm/aarch64_spec.cr" (failed linking)
 # require "./std/llvm/arm_abi_spec.cr" (failed linking)


### PR DESCRIPTION
Enables specs for `::#exit` and `::#at_exit`. The segmentation fault (access violation) specs are now pending.

This isn't the best place to test for system-dependent newlines, so `puts` calls within those specs are replaced with `print`.