### PR TITLE
Fix UTF-8 console input/output on Windows

### DIFF
--- a/src/crystal/system/win32/file_descriptor.cr
+++ b/src/crystal/system/win32/file_descriptor.cr
@@ -1,5 +1,7 @@
 require "c/io"
 require "c/consoleapi"
+require "c/consoleapi2"
+require "c/winnls"
 
 module Crystal::System::FileDescriptor
   @volatile_fd : Atomic(LibC::Int)
@@ -182,5 +184,18 @@ module Crystal::System::FileDescriptor
       io.flush_on_newline = true
     end
     io
+  end
+end
+
+# Enable UTF-8 console I/O for the duration of program execution
+if LibC.IsValidCodePage(LibC::CP_UTF8) != 0
+  old_input_cp = LibC.GetConsoleCP
+  if LibC.SetConsoleCP(LibC::CP_UTF8) != 0
+    at_exit { LibC.SetConsoleCP(old_input_cp) }
+  end
+
+  old_output_cp = LibC.GetConsoleOutputCP
+  if LibC.SetConsoleOutputCP(LibC::CP_UTF8) != 0
+    at_exit { LibC.SetConsoleOutputCP(old_output_cp) }
   end
 end

--- a/src/lib_c/x86_64-windows-msvc/c/consoleapi.cr
+++ b/src/lib_c/x86_64-windows-msvc/c/consoleapi.cr
@@ -2,4 +2,7 @@ require "c/winnt"
 
 lib LibC
   fun GetConsoleMode(hConsoleHandle : HANDLE, lpMode : DWORD*) : BOOL
+
+  fun GetConsoleCP : DWORD
+  fun GetConsoleOutputCP : DWORD
 end

--- a/src/lib_c/x86_64-windows-msvc/c/consoleapi2.cr
+++ b/src/lib_c/x86_64-windows-msvc/c/consoleapi2.cr
@@ -1,0 +1,4 @@
+lib LibC
+  fun SetConsoleCP(wCodePageID : DWORD) : BOOL
+  fun SetConsoleOutputCP(wCodePageID : DWORD) : BOOL
+end

--- a/src/lib_c/x86_64-windows-msvc/c/winnls.cr
+++ b/src/lib_c/x86_64-windows-msvc/c/winnls.cr
@@ -1,0 +1,5 @@
+lib LibC
+  CP_UTF8 = 65001
+
+  fun IsValidCodePage(codePage : DWORD) : BOOL
+end


### PR DESCRIPTION
Fixes #11527. Uses the `chcp 65001` approach.