### PR TITLE
Support `~\` for Windows paths in `Path#expand` and `File.expand_path`

### DIFF
--- a/spec/compiler/crystal/tools/init_spec.cr
+++ b/spec/compiler/crystal/tools/init_spec.cr
@@ -309,7 +309,7 @@ module Crystal
       config.expanded_dir.should eq ::Path[Dir.current, "foo", "bar"]
     end
 
-    pending_win32 "DIR (relative to home)" do
+    it "DIR (relative to home)" do
       path = ::Path["~", "foo"].to_s
       config = Crystal::Init.parse_args(["lib", path])
       config.name.should eq "foo"

--- a/spec/std/path_spec.cr
+++ b/spec/std/path_spec.cr
@@ -727,6 +727,10 @@ describe Path do
     describe "ignores name starting with ~" do
       it_expands_path("~foo.txt", "/current/~foo.txt", "\\current\\~foo.txt", base: "/current", env_home: "/")
     end
+
+    describe %q(supports ~\ for Windows paths only) do
+      it_expands_path("~\\a", {BASE_POSIX, "~\\a"}, {HOME_WINDOWS, "a"}, home: true)
+    end
   end
 
   describe "#<=>" do

--- a/src/path.cr
+++ b/src/path.cr
@@ -710,8 +710,8 @@ struct Path
     if home
       if name == "~"
         name = resolve_home(home).to_s
-      elsif name.starts_with?("~/")
-        name = resolve_home(home).join(name.byte_slice(2, name.bytesize - 2)).to_s
+      elsif sep = Path.separators(@kind).find { |sep| name.starts_with?("~#{sep}") }
+        name = resolve_home(home).join(name.byte_slice(sep.bytesize + 1, name.bytesize - sep.bytesize - 1)).to_s
       end
     end
 


### PR DESCRIPTION
`Path#expand` and `File.expand_path` are currently hardcoded to translate only paths starting with `~/` to child paths of the home directory, but `~\` should be valid for Windows paths, and Powershell for example does support `~\`. This PR adds it.

The construction `File.expand_path(File.join("~", "a"), home: true)` now produces a subdirectory of the home directory, and works on both POSIX and Windows paths.