### PR TITLE
Detect `cl.exe`'s path for compiler specs requiring a C compiler

### DIFF
--- a/spec/support/tempfile.cr
+++ b/spec/support/tempfile.cr
@@ -1,4 +1,7 @@
 require "file_utils"
+{% if flag?(:msvc) %}
+  require "crystal/system/win32/visual_studio"
+{% end %}
 
 SPEC_TEMPFILE_PATH    = File.join(Dir.tempdir, "cr-spec-#{Random.new.hex(4)}")
 SPEC_TEMPFILE_CLEANUP = ENV["SPEC_TEMPFILE_CLEANUP"]? != "0"
@@ -44,14 +47,24 @@ def with_temp_executable(name, file = __FILE__)
 end
 
 def with_temp_c_object_file(c_code, *, filename = "temp_c", file = __FILE__)
-  obj_ext = {{ flag?(:win32) ? ".obj" : ".o" }}
+  obj_ext = {{ flag?(:msvc) ? ".obj" : ".o" }}
   with_tempfile("#{filename}.c", "#{filename}#{obj_ext}", file: file) do |c_filename, o_filename|
     File.write(c_filename, c_code)
 
-    {% if flag?(:win32) %}
-      `cl.exe /nologo /c #{Process.quote(c_filename)} #{Process.quote("/Fo#{o_filename}")}`.should be_truthy
+    {% if flag?(:msvc) %}
+      # following is based on `Crystal::Compiler#linker_command`
+      cl = "cl.exe"
+
+      if msvc_path = Crystal::System::VisualStudio.find_latest_msvc_path
+        # we won't be cross-compiling the specs binaries, so host and target
+        # bits are identical
+        bits = {{ flag?(:bits64) ? "x64" : "x86" }}
+        cl = Process.quote(msvc_path.join("bin", "Host#{bits}", bits, "cl.exe").to_s)
+      end
+
+      `#{cl} /nologo /c #{Process.quote(c_filename)} #{Process.quote("/Fo#{o_filename}")}`.should be_truthy
     {% else %}
-      `#{ENV["CC"]? || "cc"} #{Process.quote(c_filename)} -c -o #{Process.quote(o_filename)}`.should be_truthy
+      `#{Process.quote(ENV["CC"]? || "cc")} #{Process.quote(c_filename)} -c -o #{Process.quote(o_filename)}`.should be_truthy
     {% end %}
 
     yield o_filename

--- a/spec/support/tempfile.cr
+++ b/spec/support/tempfile.cr
@@ -64,7 +64,7 @@ def with_temp_c_object_file(c_code, *, filename = "temp_c", file = __FILE__)
 
       `#{cl} /nologo /c #{Process.quote(c_filename)} #{Process.quote("/Fo#{o_filename}")}`.should be_truthy
     {% else %}
-      `#{Process.quote(ENV["CC"]? || "cc")} #{Process.quote(c_filename)} -c -o #{Process.quote(o_filename)}`.should be_truthy
+      `#{ENV["CC"]? || "cc"} #{Process.quote(c_filename)} -c -o #{Process.quote(o_filename)}`.should be_truthy
     {% end %}
 
     yield o_filename

--- a/src/crystal/system/win32/visual_studio.cr
+++ b/src/crystal/system/win32/visual_studio.cr
@@ -13,7 +13,20 @@ module Crystal::System::VisualStudio
     # unused fields not mapped
   end
 
+  @@found_msvc = false
+
+  @@msvc_path : ::Path?
+
   def self.find_latest_msvc_path : ::Path?
+    if !@@found_msvc
+      @@found_msvc = true
+      @@msvc_path = find_latest_msvc_path_impl
+    end
+
+    @@msvc_path
+  end
+
+  private def self.find_latest_msvc_path_impl
     # ported from https://github.com/microsoft/vswhere/wiki/Find-VC
     # Copyright (C) Microsoft Corporation. All rights reserved. Licensed under the MIT license.
     if vs_installations = get_vs_installations


### PR DESCRIPTION
Similar to Crystal itself, we use `vswhere` to detect the C compiler's full path for the few compiler specs that need to build an extra C object file. This allows files like `spec/compiler/codegen/extern_spec.cr` to be run without the MSVC developer command prompt.