### PR TITLE
Add minimal load-time DLL support on Windows, support `dllimport` storage class

### DIFF
--- a/src/compiler/crystal/codegen/codegen.cr
+++ b/src/compiler/crystal/codegen/codegen.cr
@@ -1450,6 +1450,9 @@ module Crystal
       unless var
         var = llvm_mod.globals.add(llvm_c_return_type(type), name)
         var.linkage = LLVM::Linkage::External
+        if @program.has_flag?("win32") && @program.has_flag?("preview_dll")
+          var.dll_storage_class = LLVM::DLLStorageClass::DLLImport
+        end
         var.thread_local = thread_local
       end
       var

--- a/src/empty.cr
+++ b/src/empty.cr
@@ -1,7 +1,7 @@
 require "primitives"
 
 {% if flag?(:win32) %}
-  @[Link("libcmt")] # For `mainCRTStartup`
+  @[Link({{ flag?(:preview_dll) ? "msvcrt" : "libcmt" }})] # For `mainCRTStartup`
 {% end %}
 lib LibCrystalMain
   @[Raises]

--- a/src/lib_c.cr
+++ b/src/lib_c.cr
@@ -1,5 +1,5 @@
 {% if flag?(:win32) %}
-  @[Link("libcmt")]
+  @[Link({{ flag?(:preview_dll) ? "msvcrt" : "libcmt" }})]
 {% end %}
 lib LibC
   alias Char = UInt8

--- a/src/llvm/enums.cr
+++ b/src/llvm/enums.cr
@@ -220,13 +220,23 @@ module LLVM
     Appending
     Internal
     Private
-    DLLImport
-    DLLExport
+    DLLImport # obsolete
+    DLLExport # obsolete
     ExternalWeak
     Ghost
     Common
     LinkerPrivate
     LinkerPrivateWeak
+  end
+
+  enum DLLStorageClass
+    Default
+
+    # Function to be imported from DLL.
+    DLLImport
+
+    # Function to be accessible from DLL.
+    DLLExport
   end
 
   enum IntPredicate

--- a/src/llvm/lib_llvm.cr
+++ b/src/llvm/lib_llvm.cr
@@ -255,7 +255,6 @@ lib LibLLVM
   fun get_initializer = LLVMGetInitializer(global_var : ValueRef) : ValueRef
   fun set_linkage = LLVMSetLinkage(global : ValueRef, linkage : LLVM::Linkage)
   fun get_linkage = LLVMGetLinkage(global : ValueRef) : LLVM::Linkage
-  fun get_dll_storage_class = LLVMGetDLLStorageClass(global : ValueRef) : LLVM::DLLStorageClass
   fun set_dll_storage_class = LLVMSetDLLStorageClass(global : ValueRef, storage_class : LLVM::DLLStorageClass)
   fun set_metadata = LLVMSetMetadata(value : ValueRef, kind_id : UInt32, node : ValueRef)
   fun set_target = LLVMSetTarget(mod : ModuleRef, triple : UInt8*)

--- a/src/llvm/lib_llvm.cr
+++ b/src/llvm/lib_llvm.cr
@@ -255,6 +255,8 @@ lib LibLLVM
   fun get_initializer = LLVMGetInitializer(global_var : ValueRef) : ValueRef
   fun set_linkage = LLVMSetLinkage(global : ValueRef, linkage : LLVM::Linkage)
   fun get_linkage = LLVMGetLinkage(global : ValueRef) : LLVM::Linkage
+  fun get_dll_storage_class = LLVMGetDLLStorageClass(global : ValueRef) : LLVM::DLLStorageClass
+  fun set_dll_storage_class = LLVMSetDLLStorageClass(global : ValueRef, storage_class : LLVM::DLLStorageClass)
   fun set_metadata = LLVMSetMetadata(value : ValueRef, kind_id : UInt32, node : ValueRef)
   fun set_target = LLVMSetTarget(mod : ModuleRef, triple : UInt8*)
   fun set_thread_local = LLVMSetThreadLocal(global_var : ValueRef, is_thread_local : Int32)

--- a/src/llvm/value_methods.cr
+++ b/src/llvm/value_methods.cr
@@ -59,10 +59,6 @@ module LLVM::ValueMethods
     LibLLVM.set_dll_storage_class(self, storage_class)
   end
 
-  def dll_storage_class
-    LibLLVM.get_dll_storage_class(self)
-  end
-
   def call_convention=(call_convention)
     LibLLVM.set_instruction_call_convention(self, call_convention)
   end

--- a/src/llvm/value_methods.cr
+++ b/src/llvm/value_methods.cr
@@ -55,6 +55,14 @@ module LLVM::ValueMethods
     LibLLVM.get_linkage(self)
   end
 
+  def dll_storage_class=(storage_class)
+    LibLLVM.set_dll_storage_class(self, storage_class)
+  end
+
+  def dll_storage_class
+    LibLLVM.get_dll_storage_class(self)
+  end
+
   def call_convention=(call_convention)
     LibLLVM.set_instruction_call_convention(self, call_convention)
   end


### PR DESCRIPTION
This patch is required for minimal support of load-time dynamic linking on Windows. For this to work,

* Prepare a directory, distinct from the current Crystal installation's `CRYSTAL_LIBRARY_PATH`, which we will use to place the .lib and .exp files. Set `CRYSTAL_LIBRARY_PATH` to point to it;
* Build the minimal dynamic libraries needed by the runtime. Run the following in Powershell: (this is based on the CI job)
  ```powershell
  git clone --config core.autocrlf=false -b v8.2.0 https://github.com/ivmai/bdwgc bdwgc
  git clone --config core.autocrlf=false -b v7.6.10 https://github.com/ivmai/libatomic_ops bdwgc\libatomic_ops
  cd bdwgc
  cmake . -DBUILD_SHARED_LIBS=ON -Denable_large_config=ON -DCMAKE_POLICY_DEFAULT_CMP0091=NEW -DCMAKE_MSVC_RUNTIME_LIBRARY=MultiThreadedDLL -DCMAKE_FIND_USE_SYSTEM_ENVIRONMENT_PATH=OFF
  cmake --build . --config Release
  cd ..

  Invoke-WebRequest https://cs.stanford.edu/pub/exim/pcre/pcre-8.43.zip -OutFile pcre.zip
  7z x pcre.zip
  Move-Item pcre-* pcre
  cd pcre
  cmake . -DBUILD_SHARED_LIBS=ON -DPCRE_BUILD_PCREGREP=OFF -DPCRE_BUILD_TESTS=OFF -DPCRE_SUPPORT_UNICODE_PROPERTIES=ON -DPCRE_SUPPORT_JIT=ON -DCMAKE_FIND_USE_SYSTEM_ENVIRONMENT_PATH=OFF
  cmake --build . --config Release
  cd ..
  ```
* Copy `./bdwgc/Release/gc.lib` and `./pcre/Release/pcre.lib` to the `CRYSTAL_LIBRARY_PATH` we just set. Same for the associated .exp files;
* Build a test program:
  ```cmd
  > echo puts ARGV[0].match(/../) > pcretest.cr
  > crystal build pcretest.cr -Dpreview_dll -Dwithout_iconv
  ```
* Place `gc.dll` and `pcre.dll` in the same directory as the `pcretest.exe` executable;
* Run it!
  ```cmd
  > pcretest 123
  Regex::MatchData("12")
  ```

Without this patch, the compilation step would fail with:

```
_main.obj : error LNK2019: unresolved external symbol pcre_malloc referenced in function __crystal_main
_main.obj : error LNK2019: unresolved external symbol pcre_free referenced in function __crystal_main
G-C-.obj : error LNK2019: unresolved external symbol GC_stackbottom referenced in function .2A.GC.3A..3A.current_thread_stack_bottom.3A.Tuple.28.Pointer.28.Void.29..2C..20.Pointer.28.Void.29..29.
```

This PR thus adds the `dllimport` storage class to any external lib variables, through LLVM.

The `-Dpreview_dll` flag is also added because currently the compiler defaults to static builds on Windows, even without the `--static` build flag, and everything would immediately break if the current command line suddenly starts using dynamic linking. With a minimal working example we can later sort out the details for dynamic linking on Windows.