### PR TITLE
Define `LIBXML_STATIC` when building xml2.lib on Windows

### DIFF
--- a/.github/workflows/win.yml
+++ b/.github/workflows/win.yml
@@ -176,7 +176,22 @@ jobs:
         if: steps.cache-libs.outputs.cache-hit != 'true'
         working-directory: ./libxml2
         run: |
-          cmake . -DBUILD_SHARED_LIBS=OFF -DLIBXML2_WITH_HTTP=OFF -DLIBXML2_WITH_FTP=OFF -DLIBXML2_WITH_TESTS=OFF -DCMAKE_POLICY_DEFAULT_CMP0091=NEW -DCMAKE_MSVC_RUNTIME_LIBRARY=MultiThreaded -DCMAKE_FIND_USE_SYSTEM_ENVIRONMENT_PATH=OFF
+          cmake . -DBUILD_SHARED_LIBS=OFF -DLIBXML2_WITH_PROGRAMS=OFF -DLIBXML2_WITH_HTTP=OFF -DLIBXML2_WITH_FTP=OFF -DLIBXML2_WITH_TESTS=OFF -DCMAKE_POLICY_DEFAULT_CMP0091=NEW -DCMAKE_MSVC_RUNTIME_LIBRARY=MultiThreaded -DCMAKE_FIND_USE_SYSTEM_ENVIRONMENT_PATH=OFF
+          
+          echo '<Project>
+            <PropertyGroup>
+              <ForceImportAfterCppTargets>$(MsbuildThisFileDirectory)\Override.props</ForceImportAfterCppTargets>
+            </PropertyGroup>
+          </Project>' > 'Directory.Build.props'
+
+          echo '<Project>
+            <ItemDefinitionGroup>
+              <ClCompile>
+                <PreprocessorDefinitions>LIBXML_STATIC;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+              </ClCompile>
+            </ItemDefinitionGroup>
+          </Project>' > 'Override.props'
+
           cmake --build . --config Release
       - name: Gather libraries
         if: steps.cache-libs.outputs.cache-hit != 'true'


### PR DESCRIPTION
The `CMakeLists.txt` file doesn't appear to define the `LIBXML_STATIC` preprocessor variable when building static libraries, causing hundreds of libxml2 symbols to be incorrectly declared with `__declspec(dllexport)` on Windows. This means whenever a Crystal program requires any part of the `XML` library, such as the standard library test suite, these symbols are [_exported_ by the resulting .exe file](https://github.com/crystal-lang/crystal/runs/4489466879?check_suite_focus=true#step:39:35):

> Creating library D:\a\crystal\crystal\std_spec.lib and object D:\a\crystal\crystal\std_spec.exp

This PR adds it back with the usual MSBuild override trick.