### PR TITLE
Mark bswap32 instrinsic with interpreter primitive annotation

### DIFF
--- a/src/intrinsics.cr
+++ b/src/intrinsics.cr
@@ -53,6 +53,7 @@ lib LibIntrinsics
   fun bitreverse32 = "llvm.bitreverse.i32"(id : UInt32) : UInt32
   fun bitreverse16 = "llvm.bitreverse.i16"(id : UInt16) : UInt16
 
+  {% if flag?(:interpreted) %} @[Primitive(:interpreter_intrinsics_bswap32)] {% end %}
   fun bswap32 = "llvm.bswap.i32"(id : UInt32) : UInt32
 
   {% if flag?(:interpreted) %} @[Primitive(:interpreter_intrinsics_bswap16)] {% end %}


### PR DESCRIPTION
Unlike bswap16 (and most other intrinsics), bswap32 wasn't marked with the Primitive annotation when in interpreted mode, [despite an instruction seemingly existing for it](https://github.com/crystal-lang/crystal/blob/c2be6220b1745a5948e8fff90ab96a30a1902c56/src/compiler/crystal/interpreter/instructions.cr#L1788-L1792)

Discovered while trying to run the compiler in interpreted mode