### PR TITLE
Use enums instead of symbols for `Spec`-related types

### DIFF
--- a/spec/std/spec/context_spec.cr
+++ b/spec/std/spec/context_spec.cr
@@ -36,7 +36,7 @@ describe Spec::ExampleGroup do
 
       grand_child.report(:fail, "oops", "f.cr", 3, nil, nil)
 
-      root.@results[:fail].first.description.should eq("child grand_child oops")
+      root.results_for(:fail).first.description.should eq("child grand_child oops")
     end
   end
 end

--- a/spec/std/spec/junit_formatter_spec.cr
+++ b/spec/std/spec/junit_formatter_spec.cr
@@ -5,6 +5,9 @@ class Spec::JUnitFormatter
   property started_at
 end
 
+private class MyException < Exception
+end
+
 describe "JUnit Formatter" do
   it "reports successful results" do
     output = build_report_with_no_timestamp do |f|
@@ -59,14 +62,14 @@ describe "JUnit Formatter" do
 
   it "reports errors" do
     output = build_report_with_no_timestamp do |f|
-      f.report Spec::Result.new(:error, "should do something", "spec/some_spec.cr", 33, nil, nil)
+      f.report Spec::Result.new(:error, "should do something", "spec/some_spec.cr", 33, nil, MyException.new("foo"))
     end
 
     expected = <<-XML
                  <?xml version="1.0"?>
                  <testsuite tests="1" skipped="0" errors="1" failures="0" time="0.0" hostname="#{System.hostname}">
                    <testcase file="spec/some_spec.cr" classname="spec.some_spec" name="should do something">
-                     <error/>
+                     <error message="foo" type="MyException"></error>
                    </testcase>
                  </testsuite>
                  XML

--- a/src/spec/context.cr
+++ b/src/spec/context.cr
@@ -109,8 +109,16 @@ module Spec
   end
 
   # :nodoc:
+  enum Status
+    Success
+    Fail
+    Error
+    Pending
+  end
+
+  # :nodoc:
   record Result,
-    kind : Symbol,
+    kind : Status,
     description : String,
     file : String,
     line : Int32,
@@ -134,25 +142,26 @@ module Spec
     class_getter instance = RootContext.new
     class_getter current_context : Context = @@instance
 
+    @results : Hash(Status, Array(Result))
+
+    def results_for(status : Status)
+      @results[status]
+    end
+
     def initialize
-      @results = {
-        success: [] of Result,
-        fail:    [] of Result,
-        error:   [] of Result,
-        pending: [] of Result,
-      }
+      @results = Status.values.to_h { |status| {status, [] of Result} }
     end
 
     def run
       internal_run
     end
 
-    def report(kind, full_description, file, line, elapsed = nil, ex = nil)
-      result = Result.new(kind, full_description, file, line, elapsed, ex)
+    def report(status : Status, full_description, file, line, elapsed = nil, ex = nil)
+      result = Result.new(status, full_description, file, line, elapsed, ex)
 
       report_formatters result
 
-      @results[result.kind] << result
+      @results[status] << result
     end
 
     def report_formatters(result)
@@ -160,7 +169,7 @@ module Spec
     end
 
     def succeeded
-      @results[:fail].empty? && @results[:error].empty?
+      results_for(:fail).empty? && results_for(:error).empty?
     end
 
     def finish(elapsed_time, aborted = false)
@@ -169,7 +178,7 @@ module Spec
     end
 
     def print_results(elapsed_time, aborted = false)
-      pendings = @results[:pending]
+      pendings = results_for(:pending)
       unless pendings.empty?
         puts
         puts "Pending:"
@@ -178,8 +187,8 @@ module Spec
         end
       end
 
-      failures = @results[:fail]
-      errors = @results[:error]
+      failures = results_for(:fail)
+      errors = results_for(:error)
 
       failures_and_errors = failures + errors
       unless failures_and_errors.empty?
@@ -214,7 +223,7 @@ module Spec
 
       if Spec.slowest
         puts
-        results = @results[:success] + @results[:fail]
+        results = results_for(:success) + results_for(:fail)
         top_n = results.sort_by { |res| -res.elapsed.not_nil!.to_f }[0..Spec.slowest.not_nil!]
         top_n_time = top_n.sum &.elapsed.not_nil!.total_seconds
         percent = (top_n_time * 100) / elapsed_time.total_seconds
@@ -231,14 +240,14 @@ module Spec
 
       puts
 
-      success = @results[:success]
+      success = results_for(:success)
       total = pendings.size + failures.size + errors.size + success.size
 
       final_status = case
-                     when aborted                           then :error
-                     when (failures.size + errors.size) > 0 then :fail
-                     when pendings.size > 0                 then :pending
-                     else                                        :success
+                     when aborted                           then Status::Error
+                     when (failures.size + errors.size) > 0 then Status::Fail
+                     when pendings.size > 0                 then Status::Pending
+                     else                                        Status::Success
                      end
 
       puts "Aborted!".colorize.red if aborted
@@ -330,8 +339,8 @@ module Spec
       Spec.formatters.each(&.pop)
     end
 
-    protected def report(kind, description, file, line, elapsed = nil, ex = nil)
-      parent.report kind, "#{@description} #{description}", file, line, elapsed, ex
+    protected def report(status : Status, description, file, line, elapsed = nil, ex = nil)
+      parent.report status, "#{@description} #{description}", file, line, elapsed, ex
     end
 
     protected def run_before_each_hooks

--- a/src/spec/dsl.cr
+++ b/src/spec/dsl.cr
@@ -2,27 +2,45 @@ require "colorize"
 require "option_parser"
 
 module Spec
-  private COLORS = {
-    success: :green,
-    fail:    :red,
-    error:   :red,
-    pending: :yellow,
-    comment: :cyan,
-    focus:   :cyan,
-    order:   :cyan,
+  # :nodoc:
+  enum InfoKind
+    Comment
+    Focus
+    Order
+  end
+
+  private STATUS_COLORS = {
+    Status::Success => :green,
+    Status::Fail    => :red,
+    Status::Error   => :red,
+    Status::Pending => :yellow,
+  }
+
+  private INFO_COLORS = {
+    InfoKind::Comment => :cyan,
+    InfoKind::Focus   => :cyan,
+    InfoKind::Order   => :cyan,
   }
 
   private LETTERS = {
-    success: '.',
-    fail:    'F',
-    error:   'E',
-    pending: '*',
+    Status::Success => '.',
+    Status::Fail    => 'F',
+    Status::Error   => 'E',
+    Status::Pending => '*',
   }
 
   # :nodoc:
-  def self.color(str, status)
+  def self.color(str, status : Status)
     if use_colors?
-      str.colorize(COLORS[status])
+      str.colorize(STATUS_COLORS[status])
+    else
+      str
+    end
+  end
+
+  def self.color(str, kind : InfoKind)
+    if use_colors?
+      str.colorize(INFO_COLORS[kind])
     else
       str
     end

--- a/src/spec/dsl.cr
+++ b/src/spec/dsl.cr
@@ -38,6 +38,7 @@ module Spec
     end
   end
 
+  # :nodoc:
   def self.color(str, kind : InfoKind)
     if use_colors?
       str.colorize(INFO_COLORS[kind])

--- a/src/spec/expectations.cr
+++ b/src/spec/expectations.cr
@@ -153,37 +153,42 @@ module Spec
 
   # :nodoc:
   struct Be(T)
+    enum Relation
+      LessThan
+      LessOrEqual
+      GreaterThan
+      GreaterOrEqual
+    end
+
     def self.<(other)
-      Be.new(other, :"<")
+      Be.new(other, :less_than)
     end
 
     def self.<=(other)
-      Be.new(other, :"<=")
+      Be.new(other, :less_or_equal)
     end
 
     def self.>(other)
-      Be.new(other, :">")
+      Be.new(other, :greater_than)
     end
 
     def self.>=(other)
-      Be.new(other, :">=")
+      Be.new(other, :greater_or_equal)
     end
 
-    def initialize(@expected_value : T, @op : Symbol)
+    def initialize(@expected_value : T, @op : Relation)
     end
 
     def match(actual_value)
       case @op
-      when :"<"
+      in .less_than?
         actual_value < @expected_value
-      when :"<="
+      in .less_or_equal?
         actual_value <= @expected_value
-      when :">"
+      in .greater_than?
         actual_value > @expected_value
-      when :">="
+      in .greater_or_equal?
         actual_value >= @expected_value
-      else
-        false
       end
     end
 

--- a/src/spec/junit_formatter.cr
+++ b/src/spec/junit_formatter.cr
@@ -89,10 +89,10 @@ module Spec
 
     private def inner_content_tag(kind)
       case kind
-      when .error?   then "error"
-      when .fail?    then "failure"
-      when .pending? then "skipped"
-      else                nil
+      in .error?   then "error"
+      in .fail?    then "failure"
+      in .pending? then "skipped"
+      in .success? then nil
       end
     end
 

--- a/src/spec/junit_formatter.cr
+++ b/src/spec/junit_formatter.cr
@@ -6,7 +6,7 @@ module Spec
     @started_at = Time.utc
 
     @results = [] of Spec::Result
-    @summary = {} of Symbol => Int32
+    @summary = {} of Status => Int32
 
     def report(result)
       current = @summary[result.kind]? || 0
@@ -18,9 +18,9 @@ module Spec
       io = @io
       io.puts %(<?xml version="1.0"?>)
       io << %(<testsuite tests=") << @results.size
-      io << %(" skipped=") << (@summary[:pending]? || 0)
-      io << %(" errors=") << (@summary[:error]? || 0)
-      io << %(" failures=") << (@summary[:fail]? || 0)
+      io << %(" skipped=") << (@summary[Status::Pending]? || 0)
+      io << %(" errors=") << (@summary[Status::Error]? || 0)
+      io << %(" failures=") << (@summary[Status::Fail]? || 0)
       io << %(" time=") << elapsed_time.total_seconds
       io << %(" timestamp=") << @started_at.to_rfc3339
       io << %(" hostname=") << System.hostname
@@ -76,7 +76,7 @@ module Spec
       if tag = inner_content_tag(result.kind)
         io.puts %(">)
 
-        if (exception = result.exception) && result.kind != :pending
+        if (exception = result.exception) && !result.kind.pending?
           write_inner_content(tag, exception, io)
         else
           io << "    <" << tag << "/>\n"
@@ -89,10 +89,10 @@ module Spec
 
     private def inner_content_tag(kind)
       case kind
-      when :error   then "error"
-      when :fail    then "failure"
-      when :pending then "skipped"
-      else               nil
+      when .error?   then "error"
+      when .fail?    then "failure"
+      when .pending? then "skipped"
+      else                nil
       end
     end
 
@@ -104,7 +104,7 @@ module Spec
         HTML.escape(message, io)
         io << '"'
       end
-      if tag == :error
+      if tag == "error"
         io << %( type=")
         io << exception.class.name
         io << '"'

--- a/src/spec/tap_formatter.cr
+++ b/src/spec/tap_formatter.cr
@@ -4,20 +4,18 @@ class Spec::TAPFormatter < Spec::Formatter
 
   def report(result)
     case result.kind
-    when :success
+    in .success?
       @io << "ok"
-    when :fail, :error
+    in .fail?, .error?
       @io << "not ok"
-    when :pending
+    in .pending?
       @io << "ok"
-    else
-      # shouldn't happen (TODO: maybe turn this into an enum?)
     end
 
     @counter += 1
 
     @io << ' ' << @counter << " -"
-    if result.kind == :pending
+    if result.kind.pending?
       @io << " # SKIP"
     end
     @io << ' ' << result.description


### PR DESCRIPTION
Those types (`Spec::RootContext` and the formatters) are not part of the public API, so there are no breaking changes.