### PR TITLE
Performance: specify string sizes in advance

### DIFF
--- a/src/http/cookie.cr
+++ b/src/http/cookie.cr
@@ -102,7 +102,7 @@ module HTTP
     end
 
     def to_cookie_header : String
-      String.build do |io|
+      String.build(@name.bytesize + @value.bytesize + 1) do |io|
         to_cookie_header(io)
       end
     end

--- a/src/uri.cr
+++ b/src/uri.cr
@@ -512,26 +512,26 @@ class URI
       end
     end
 
-    tmp = dst_path.join('/')
     # calculate
     if base_path.empty?
       if dst_path.empty?
         "./"
       elsif dst_path.first.includes?(':') # (see RFC2396 Section 5)
-        String.build do |io|
+        string_size = 1 + dst_path.sum { |path| path.bytesize } + dst_path.size
+        String.build(string_size) do |io|
           io << "./"
           dst_path.join(io, '/')
         end
       else
-        string = dst_path.join('/')
-        if string == ""
+        if dst_path.empty? || dst_path.first == ""
           "./"
         else
-          string
+          dst_path.join('/')
         end
       end
     else
-      String.build do |io|
+      string_size = 3 * base_path.size + dst_path.sum { |path| path.bytesize } + dst_path.size - 1
+      String.build(string_size) do |io|
         base_path.size.times { io << "../" }
         dst_path.join(io, '/')
       end

--- a/src/uri.cr
+++ b/src/uri.cr
@@ -221,7 +221,11 @@ class URI
   # uri.request_target # => "/?foo=bar"
   # ```
   def request_target : String
-    String.build do |str|
+    string_size = 1
+    string_size += @query ? @query.not_nil!.bytesize : -1
+    string_size += @path.empty? ? 1 : @path.bytesize
+
+    String.build(string_size) do |str|
       if @path.empty?
         str << "/" unless opaque?
       else

--- a/src/uri.cr
+++ b/src/uri.cr
@@ -221,9 +221,12 @@ class URI
   # uri.request_target # => "/?foo=bar"
   # ```
   def request_target : String
-    string_size = 1
-    string_size += @query ? @query.not_nil!.bytesize : -1
-    string_size += @path.empty? ? 1 : @path.bytesize
+    # Minimal size is 1 for an empty path (`"/"`)
+    string_size = @path.empty? ? 1 : @path.bytesize
+    if query = @query
+      # Add 1 for the query designator (`?`)
+      string_size += query.bytesize + 1
+    end
 
     String.build(string_size) do |str|
       if @path.empty?
@@ -523,7 +526,7 @@ class URI
           dst_path.join(io, '/')
         end
       else
-        if dst_path.empty? || dst_path.first == ""
+        if dst_path.empty? || dst_path.first.empty?
           "./"
         else
           dst_path.join('/')

--- a/src/uri.cr
+++ b/src/uri.cr
@@ -520,7 +520,7 @@ class URI
       if dst_path.empty?
         "./"
       elsif dst_path.first.includes?(':') # (see RFC2396 Section 5)
-        string_size = 1 + dst_path.sum { |path| path.bytesize } + dst_path.size
+        string_size = 1 + dst_path.sum(&.bytesize) + dst_path.size
         String.build(string_size) do |io|
           io << "./"
           dst_path.join(io, '/')
@@ -533,7 +533,7 @@ class URI
         end
       end
     else
-      string_size = 3 * base_path.size + dst_path.sum { |path| path.bytesize } + dst_path.size - 1
+      string_size = 3 * base_path.size + dst_path.sum(&.bytesize) + dst_path.size - 1
       String.build(string_size) do |io|
         base_path.size.times { io << "../" }
         dst_path.join(io, '/')

--- a/src/uri.cr
+++ b/src/uri.cr
@@ -434,14 +434,8 @@ class URI
       if path.empty?
         path = base
       elsif !base.empty?
-        path = String.build do |io|
-          if base.ends_with?('/')
-            io << base
-          elsif pos = base.rindex('/')
-            io << base[0..pos]
-          end
-          io << path
-        end
+        out_base = base.ends_with?('/') ? base : base[0..base.rindex('/')]
+        path = String.interpolation(out_base, path)
       end
     end
     remove_dot_segments(path)


### PR DESCRIPTION
Improves performance of multiple methods by specifying String.build capacity, or using interpolation.

<details>
<summary>Benchmark Code</summary>

```crystal
require "benchmark"

puts "Benchmark 2: URI#request_target (9095f9bc670b693bc3eabb665ddfd31eefbdfea1)"

require "uri"

class URI
  def new_request_target : String
    string_size = 1
    string_size += @query ? @query.not_nil!.bytesize : -1
    string_size += @path.empty? ? 1 : @path.bytesize

    String.build(string_size) do |str|
      if @path.empty?
        str << "/" unless opaque?
      else
        str << @path
      end

      if (query = @query) && !query.empty?
        str << '?' << query
      end
    end
  end
end

uri = URI.parse "http://example.com/posts?id=30&limit=5#time=1305298413"

Benchmark.ips do |x|
  x.report("old") { uri.request_target }
  x.report("new") { uri.new_request_target }
end

puts "Benchmark 3: URI#resolve_path (e91ac9742385260fbdbc02b61ba24720792be775)"

require "uri"

class URI
  def new_resolve(uri : URI | String) : URI
    if uri.is_a?(URI)
      target = uri.dup
    else
      target = URI.parse(uri)
    end

    if target.absolute? || opaque?
      return target
    end

    target.scheme = scheme

    unless target.host || target.user
      target.host = host
      target.port = port
      target.user = user
      target.password = password
      if target.path.empty?
        target.path = remove_dot_segments(path)
        target.query ||= query
      else
        base = path
        if base.empty? && target.absolute?
          base = "/"
        end
        target.path = new_resolve_path(target.path, base: base)
      end
    end

    target
  end

  private def new_resolve_path(path : String, base : String) : String
    unless path.starts_with?('/')
      if path.empty?
        path = base
      elsif !base.empty?
        out_base = base.ends_with?('/') ? base : base[0..base.rindex('/')]
        path = String.interpolation(out_base, path)
      end
    end
    remove_dot_segments(path)
  end
end

uri_base = URI.parse "http://example.com/posts?id=30&limit=5#time=1305298413"
uri_target = URI.parse "../posts/comments/12?id=30&limit=5#time=1305298413"

Benchmark.ips do |x|
  x.report("old") { uri_base.resolve(uri_target) }
  x.report("new") { uri_base.new_resolve(uri_target) }
end

puts "Benchmark 4: URI#relativize_path (341d74943ab0b0f363284a395bb385f87e92d0a5)"

require "uri"

class URI
  def new_relativize(uri : URI | String) : URI
    if uri.is_a?(URI)
      uri = uri.dup
    else
      uri = URI.parse(uri)
    end

    if uri.opaque? || opaque? || uri.scheme.try &.downcase != @scheme.try &.downcase ||
       uri.host.try &.downcase != @host.try &.downcase || uri.port != @port || uri.user != @user ||
       uri.password != @password
      return uri
    end

    query = uri.query
    query = nil if query == @query
    fragment = uri.fragment

    path = new_relativize_path(@path, uri.path)

    URI.new(path: path, query: query, fragment: uri.fragment)
  end

  private def new_relativize_path(base : String, dst : String) : String
    return "" if base == dst

    if base =~ %r{(?:\A|/)\.\.?(?:/|\z)} && dst.starts_with?('/')
      # dst has abnormal absolute path,
      # like "/./", "/../", "/x/../", ...
      return dst
    end

    base_path = base.split('/', remove_empty: true)
    dst_path = dst.split('/', remove_empty: true)

    dst_path << "" if dst.ends_with?('/')
    base_path.pop? unless base.ends_with?('/')

    # discard same parts
    while !dst_path.empty? && !base_path.empty?
      dst = dst_path.first
      base = base_path.first
      if dst == base
        base_path.shift
        dst_path.shift
      elsif dst == "."
        dst_path.shift
      elsif base == "."
        base_path.shift
      else
        break
      end
    end

    # calculate
    if base_path.empty?
      if dst_path.empty?
        "./"
      elsif dst_path.first.includes?(':') # (see RFC2396 Section 5)
        string_size = 1 + dst_path.sum { |path| path.bytesize } + dst_path.size
        String.build(string_size) do |io|
          io << "./"
          dst_path.join(io, '/')
        end
      else
        if dst_path.empty? || dst_path.first == ""
          "./"
        else
          dst_path.join('/')
        end
      end
    else
      string_size = 3 * base_path.size + dst_path.sum { |path| path.bytesize } + dst_path.size - 1
      String.build(string_size) do |io|
        base_path.size.times { io << "../" }
        dst_path.join(io, '/')
      end
    end
  end
end

uri_base = URI.parse "http://example.com/posts?id=30&limit=5#time=1305298413"
uri_target = URI.parse "http://example.com/posts/my_good_post/my_title/comments?hi=true"

Benchmark.ips do |x|
  x.report("old") { uri_base.relativize(uri_target) }
  x.report("new") { uri_base.new_relativize(uri_target) }
end

puts "Benchmark 6: HTTP::Cookie#to_cookie_header (0877acf7c72c7c17a3818ae37a9ebfeb6f7037dc)"

require "http/cookie"

class HTTP::Cookie
  def new_to_cookie_header : String
    String.build(@name.bytesize + @value.bytesize + 1) do |io|
      to_cookie_header(io)
    end
  end
end

cookie = HTTP::Cookie.new("my_key", "my_value")

Benchmark.ips do |x|
  x.report("old") { cookie.to_cookie_header }
  x.report("new") { cookie.new_to_cookie_header }
end
```
</details>