### PR TITLE
Improve performance of Char#to_s

### DIFF
--- a/src/char.cr
+++ b/src/char.cr
@@ -876,7 +876,7 @@ struct Char
     bytesize = self.bytesize
     String.new(bytesize) do |pointer|
       i = 0
-      self.each_byte do |byte|        
+      each_byte do |byte|
         pointer[i] = byte
         i += 1
       end

--- a/src/char.cr
+++ b/src/char.cr
@@ -875,11 +875,8 @@ struct Char
   def to_s : String
     bytesize = self.bytesize
     String.new(bytesize) do |pointer|
-      i = 0
-      each_byte do |byte|
-        pointer[i] = byte
-        i += 1
-      end
+      appender = buffer.appender
+      each_byte { |byte| appender << byte }
       {bytesize, 1}
     end
   end

--- a/src/char.cr
+++ b/src/char.cr
@@ -873,37 +873,14 @@ struct Char
   # 'あ'.to_s # => "あ"
   # ```
   def to_s : String
-    c = ord
-    if c < 0x80
-      # 0xxxxxxx
-      String.new(1) do |pointer|
-        pointer[0] = c.to_u8
-        {1, 1}
+    bytesize = self.bytesize
+    String.new(bytesize) do |pointer|
+      i = 0
+      self.each_byte do |byte|        
+        pointer[i] = byte
+        i += 1
       end
-    elsif c <= 0x7ff
-      # 110xxxxx  10xxxxxx
-      String.new(2) do |pointer|
-        pointer[0] = (0xc0 | c >> 6).to_u8
-        pointer[1] = (0x80 | c & 0x3f).to_u8
-        {2, 1}
-      end
-    elsif c <= 0xffff
-      # 1110xxxx  10xxxxxx  10xxxxxx
-      String.new(3) do |pointer|
-        pointer[0] = (0xe0 | (c >> 12)).to_u8
-        pointer[1] = (0x80 | ((c >> 6) & 0x3f)).to_u8
-        pointer[2] = (0x80 | (c & 0x3f)).to_u8
-        {3, 1}
-      end
-    else
-      # 11110xxx  10xxxxxx  10xxxxxx  10xxxxxx
-      String.new(4) do |pointer|
-        pointer[0] = (0xf0 | (c >> 18)).to_u8
-        pointer[1] = (0x80 | ((c >> 12) & 0x3f)).to_u8
-        pointer[2] = (0x80 | ((c >> 6) & 0x3f)).to_u8
-        pointer[3] = (0x80 | (c & 0x3f)).to_u8
-        {4, 1}
-      end
+      {bytesize, 1}
     end
   end
 

--- a/src/char.cr
+++ b/src/char.cr
@@ -874,7 +874,7 @@ struct Char
   # ```
   def to_s : String
     bytesize = self.bytesize
-    String.new(bytesize) do |pointer|
+    String.new(bytesize) do |buffer|
       appender = buffer.appender
       each_byte { |byte| appender << byte }
       {bytesize, 1}


### PR DESCRIPTION
I already posted this on 24th July in #7393 as an alternative implementation
I basically just glued String.new together with String#each_byte
Replaces #7393

Improvement: ~200% (One-byte characters)

<details>
<summary>Benchmark code</summary>

```crystal
require "benchmark"

puts "Benchmark 5: Char#to_s (99f8cd6326a98f40c49b32e39cd8a0cb3359508e)"

struct Char
  def new_to_s : String
    c = ord
    if c < 0x80
      # 0xxxxxxx
      String.new(1) do |pointer|
        pointer[0] = c.to_u8
        {1, 1}
      end
    elsif c <= 0x7ff
      # 110xxxxx  10xxxxxx
      String.new(2) do |pointer|
        pointer[0] = (0xc0 | c >> 6).to_u8
        pointer[1] = (0x80 | c & 0x3f).to_u8
        {2, 1}
      end
    elsif c <= 0xffff
      # 1110xxxx  10xxxxxx  10xxxxxx
      String.new(3) do |pointer|
        pointer[0] = (0xe0 | (c >> 12)).to_u8
        pointer[1] = (0x80 | ((c >> 6) & 0x3f)).to_u8
        pointer[2] = (0x80 | (c & 0x3f)).to_u8
        {3, 1}
      end
    else
      # 11110xxx  10xxxxxx  10xxxxxx  10xxxxxx
      String.new(4) do |pointer|
        pointer[0] = (0xf0 | (c >> 18)).to_u8
        pointer[1] = (0x80 | ((c >> 12) & 0x3f)).to_u8
        pointer[2] = (0x80 | ((c >> 6) & 0x3f)).to_u8
        pointer[3] = (0x80 | (c & 0x3f)).to_u8
        {4, 1}
      end
    end
  end
end

char = 'a'
puts char

Benchmark.ips do |x|
  x.report("old") { char.to_s }
  x.report("new") { char.new_to_s }
end

char = 'μ'
puts char

Benchmark.ips do |x|
  x.report("old") { char.to_s }
  x.report("new") { char.new_to_s }
end

char = '😀'
puts char

Benchmark.ips do |x|
  x.report("old") { char.to_s }
  x.report("new") { char.new_to_s }
end
```
</details>