### PR TITLE
Use more efficient method to split UInt32 to bytes in Crypto::Blowfish

### DIFF
--- a/src/crypto/blowfish.cr
+++ b/src/crypto/blowfish.cr
@@ -68,11 +68,11 @@ class Crypto::Blowfish
   end
 
   @[AlwaysInline]
-  private def f(x)
-    d = x & 0xff_u32
-    c = (x >> 8) & 0xff_u32
-    b = (x >> 16) & 0xff_u32
-    a = (x >> 24) & 0xff_u32
+  private def f(x : UInt32)
+    d = x.to_u8!
+    c = (x >> 8).to_u8!
+    b = (x >> 16).to_u8!
+    a = (x >> 24).to_u8!
     ((@s.to_unsafe[a] &+ @s1[b]) ^ @s2[c]) &+ @s3[d]
   end
 


### PR DESCRIPTION
Improvement (Verifying Hash, cost 10): ~5%
Improvement (Verifying Hash, cost 15): ~5%
Improvement (Create BCrypt Hash, cost 10): ~4%

<details>
<summary>Benchmark Code</summary>

```crystal
require "benchmark"

puts "Benchmark 1: Blowfish (02a94043c2d7eb3767dbbfd5e9813d29f521a3ca)"

require "crypto/bcrypt"

class Test::Bcrypt < Crypto::Bcrypt
  class Blowfish < Crypto::Bcrypt::Blowfish
    @[AlwaysInline]
    private def f(x : UInt32)
      d = x.to_u8!
      c = (x >> 8).to_u8!
      b = (x >> 16).to_u8!
      a = (x >> 24).to_u8!
      ((@s.to_unsafe[a] &+ @s1[b]) ^ @s2[c]) &+ @s3[d]
    end
  end

  private def hash_password
    blowfish = Blowfish.new(BLOWFISH_ROUNDS)
    blowfish.enhance_key_schedule(salt, password, cost)

    cipher = CIPHER_TEXT.dup
    cdata = cipher.to_unsafe

    0.step(to: 4, by: 2) do |i|
      64.times do
        l, r = blowfish.encrypt_pair(cdata[i], cdata[i + 1])
        cdata[i], cdata[i + 1] = l, r
      end
    end

    ret = Bytes.new(cipher.size * 4)
    j = -1

    cipher.size.times do |i|
      ret[j += 1] = (cdata[i] >> 24).to_u8!
      ret[j += 1] = (cdata[i] >> 16).to_u8!
      ret[j += 1] = (cdata[i] >> 8).to_u8!
      ret[j += 1] = cdata[i].to_u8!
    end

    ret
  end
end

password = "my test password"
cost = 10

Benchmark.ips do |x|
  x.report("old") { Crypto::Bcrypt.hash_secret(password, cost).to_s }
  x.report("new") { Test::Bcrypt.hash_secret(password, cost).to_s }
end
```
</details>