### PR TITLE
[CI] Remove `libatomic_ops`

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -123,7 +123,7 @@ jobs:
       - run: |
           git clone https://github.com/crystal-lang/distribution-scripts.git ~/distribution-scripts
           cd ~/distribution-scripts
-          git checkout 638d5887e7a4bff9c32ab72fe9a32395df9dc1c5
+          git checkout 8328ae59292c05cf8c830a34b5b39ac46c43813e
       # persist relevant information for build process
       - run: |
           cd ~/distribution-scripts

--- a/.github/workflows/win.yml
+++ b/.github/workflows/win.yml
@@ -60,8 +60,8 @@ jobs:
         if: steps.cache-libs.outputs.cache-hit != 'true'
         working-directory: ./bdwgc
         run: |
-          cmake . -DBUILD_SHARED_LIBS=OFF -Denable_large_config=ON -DCMAKE_POLICY_DEFAULT_CMP0091=NEW -DCMAKE_MSVC_RUNTIME_LIBRARY=MultiThreaded -DCMAKE_FIND_USE_SYSTEM_ENVIRONMENT_PATH=OFF -Dwithout_libatomic_ops=ON
-          cmake --build . --config Release
+          cmake . -DBUILD_SHARED_LIBS=OFF -Denable_large_config=ON -DCMAKE_POLICY_DEFAULT_CMP0091=NEW -DCMAKE_MSVC_RUNTIME_LIBRARY=MultiThreaded -DCMAKE_FIND_USE_SYSTEM_ENVIRONMENT_PATH=OFF
+          cmake --build . --config Release -Dwithout_libatomic_ops=ON
       - name: Download libpcre
         if: steps.cache-libs.outputs.cache-hit != 'true'
         run: |

--- a/.github/workflows/win.yml
+++ b/.github/workflows/win.yml
@@ -56,12 +56,19 @@ jobs:
           repository: ivmai/bdwgc
           ref: v8.2.0
           path: bdwgc
+      - name: Download libatomic_ops
+        if: steps.cache-libs.outputs.cache-hit != 'true'
+        uses: actions/checkout@v2
+        with:
+          repository: ivmai/libatomic_ops
+          ref: v7.6.10
+          path: bdwgc/libatomic_ops
       - name: Build libgc
         if: steps.cache-libs.outputs.cache-hit != 'true'
         working-directory: ./bdwgc
         run: |
           cmake . -DBUILD_SHARED_LIBS=OFF -Denable_large_config=ON -DCMAKE_POLICY_DEFAULT_CMP0091=NEW -DCMAKE_MSVC_RUNTIME_LIBRARY=MultiThreaded -DCMAKE_FIND_USE_SYSTEM_ENVIRONMENT_PATH=OFF
-          cmake --build . --config Release -Dwithout_libatomic_ops=ON
+          cmake --build . --config Release
       - name: Download libpcre
         if: steps.cache-libs.outputs.cache-hit != 'true'
         run: |

--- a/.github/workflows/win.yml
+++ b/.github/workflows/win.yml
@@ -60,7 +60,7 @@ jobs:
         if: steps.cache-libs.outputs.cache-hit != 'true'
         working-directory: ./bdwgc
         run: |
-          cmake . -DBUILD_SHARED_LIBS=OFF -Denable_large_config=ON -DCMAKE_POLICY_DEFAULT_CMP0091=NEW -DCMAKE_MSVC_RUNTIME_LIBRARY=MultiThreaded -DCMAKE_FIND_USE_SYSTEM_ENVIRONMENT_PATH=OFF
+          cmake . -DBUILD_SHARED_LIBS=OFF -Denable_large_config=ON -DCMAKE_POLICY_DEFAULT_CMP0091=NEW -DCMAKE_MSVC_RUNTIME_LIBRARY=MultiThreaded -DCMAKE_FIND_USE_SYSTEM_ENVIRONMENT_PATH=OFF -Dwithout_libatomic_ops=ON
           cmake --build . --config Release
       - name: Download libpcre
         if: steps.cache-libs.outputs.cache-hit != 'true'

--- a/.github/workflows/win.yml
+++ b/.github/workflows/win.yml
@@ -56,13 +56,6 @@ jobs:
           repository: ivmai/bdwgc
           ref: v8.2.0
           path: bdwgc
-      - name: Download libatomic_ops
-        if: steps.cache-libs.outputs.cache-hit != 'true'
-        uses: actions/checkout@v2
-        with:
-          repository: ivmai/libatomic_ops
-          ref: v7.6.10
-          path: bdwgc/libatomic_ops
       - name: Build libgc
         if: steps.cache-libs.outputs.cache-hit != 'true'
         working-directory: ./bdwgc

--- a/shell.nix
+++ b/shell.nix
@@ -93,7 +93,7 @@ let
 
     src = builtins.fetchTarball {
       url = "https://github.com/ivmai/bdwgc/releases/download/v${version}/gc-${version}.tar.gz";
-      sha256 = "16ic5dwfw51r5lcl88vx3qrkg3g2iynblazkri3sl9brnqiyzjk7";
+      sha256 = "13zddy2xk5744vnx9mqz6sbdgvb6l0w6sv1jfmdnqkxpdhszfh15";
     };
 
     configureFlags = [

--- a/shell.nix
+++ b/shell.nix
@@ -87,31 +87,14 @@ let
     };
   }."llvm_${toString llvm}");
 
-  libatomic_ops = builtins.fetchurl {
-    url = "https://github.com/ivmai/libatomic_ops/releases/download/v7.6.10/libatomic_ops-7.6.10.tar.gz";
-    sha256 = "1bwry043f62pc4mgdd37zx3fif19qyrs8f5bw7qxlmkzh5hdyzjq";
-  };
-
   boehmgc = pkgs.stdenv.mkDerivation rec {
     pname = "boehm-gc";
-    version = "8.0.4";
+    version = "8.2.0";
 
     src = builtins.fetchTarball {
       url = "https://github.com/ivmai/bdwgc/releases/download/v${version}/gc-${version}.tar.gz";
       sha256 = "16ic5dwfw51r5lcl88vx3qrkg3g2iynblazkri3sl9brnqiyzjk7";
     };
-
-    patches = [
-      (pkgs.fetchpatch {
-        url = "https://github.com/ivmai/bdwgc/commit/5668de71107022a316ee967162bc16c10754b9ce.patch";
-        sha256 = "02f0rlxl4fsqk1xiq0pabkhwydnmyiqdik2llygkc6ixhxbii8xw";
-      })
-    ];
-
-    postUnpack = ''
-      mkdir $sourceRoot/libatomic_ops
-      tar -xzf ${libatomic_ops} -C $sourceRoot/libatomic_ops --strip-components 1
-    '';
 
     configureFlags = [
       "--disable-debug"

--- a/shell.nix
+++ b/shell.nix
@@ -93,7 +93,7 @@ let
 
     src = builtins.fetchTarball {
       url = "https://github.com/ivmai/bdwgc/releases/download/v${version}/gc-${version}.tar.gz";
-      sha256 = "13zddy2xk5744vnx9mqz6sbdgvb6l0w6sv1jfmdnqkxpdhszfh15";
+      sha256 = "0f3m27sfc4wssdvk32vivdg64b04ydw0slxm45zdv23qddrihxq4";
     };
 
     configureFlags = [


### PR DESCRIPTION
libatomic_ops is no longer required for building bdwgc starting with 8.0.0. We're using newer versions now, so there's no need to pull in libatomic_ops.

Updates distribution-scripts to include the following:

* crystal-lang/distribution-scripts#143