### PR TITLE
Fix top-level multi-assign splat variable not working in macros

### DIFF
--- a/spec/compiler/semantic/multi_assign_spec.cr
+++ b/spec/compiler/semantic/multi_assign_spec.cr
@@ -127,4 +127,21 @@ describe "Semantic: multi assign" do
         CR
     end
   end
+
+  it "can pass splat variable at top-level to macros (#11596)" do
+    assert_type(<<-CR) { tuple_of [int32, int32, int32] }
+      struct Tuple
+        def self.new(*args)
+          args
+        end
+      end
+
+      macro foo(x)
+        {{ x }}
+      end
+
+      a, *b, c = 1, 2, 3, 4, 5
+      foo(b)
+      CR
+  end
 end

--- a/src/compiler/crystal/semantic/top_level_visitor.cr
+++ b/src/compiler/crystal/semantic/top_level_visitor.cr
@@ -929,8 +929,9 @@ class Crystal::TopLevelVisitor < Crystal::SemanticVisitor
 
   def visit(node : MultiAssign)
     node.targets.each do |target|
-      if target.is_a?(Var)
-        @vars[target.name] = MetaVar.new(target.name)
+      var = target.is_a?(Splat) ? target.exp : target
+      if var.is_a?(Var)
+        @vars[var.name] = MetaVar.new(var.name)
       end
       target.accept self
     end


### PR DESCRIPTION
Fixes #11596.