### PR TITLE
Improve search input a11y for generated docs

### DIFF
--- a/src/compiler/crystal/tools/doc/html/css/style.css
+++ b/src/compiler/crystal/tools/doc/html/css/style.css
@@ -84,25 +84,25 @@ body {
 }
 
 .sidebar input::-webkit-input-placeholder { /* Chrome/Opera/Safari */
-  color: #C8C8C8;
+  color: black;
   font-size: 14px;
   text-indent: 2px;
 }
 
 .sidebar input::-moz-placeholder { /* Firefox 19+ */
-  color: #C8C8C8;
+  color: black;
   font-size: 14px;
   text-indent: 2px;
 }
 
 .sidebar input:-ms-input-placeholder { /* IE 10+ */
-  color: #C8C8C8;
+  color: black;
   font-size: 14px;
   text-indent: 2px;
 }
 
 .sidebar input:-moz-placeholder { /* Firefox 18- */
-  color: #C8C8C8;
+  color: black;
   font-size: 14px;
   text-indent: 2px;
 }

--- a/src/compiler/crystal/tools/doc/html/css/style.css
+++ b/src/compiler/crystal/tools/doc/html/css/style.css
@@ -84,25 +84,25 @@ body {
 }
 
 .sidebar input::-webkit-input-placeholder { /* Chrome/Opera/Safari */
-  color: black;
+  color: #757575;
   font-size: 14px;
   text-indent: 2px;
 }
 
 .sidebar input::-moz-placeholder { /* Firefox 19+ */
-  color: black;
+  color: #757575;
   font-size: 14px;
   text-indent: 2px;
 }
 
 .sidebar input:-ms-input-placeholder { /* IE 10+ */
-  color: black;
+  color: #757575;
   font-size: 14px;
   text-indent: 2px;
 }
 
 .sidebar input:-moz-placeholder { /* Firefox 18- */
-  color: black;
+  color: #757575;
   font-size: 14px;
   text-indent: 2px;
 }


### PR DESCRIPTION
Improve color contrast of search input placeholder in docs according to the W3C's [WCAG specification](https://www.w3.org/TR/WCAG21/) color contrast recommendations.

Extant color contrast is a ratio of 1.7:1, below the minimum "WCAG A" color contrast recommendation. Notice the "Search..." placeholder is barely visible in this screenshot:
![Screenshot from 2021-12-15 18-21-12](https://user-images.githubusercontent.com/635049/146285347-5e198f3d-4f00-47ae-bba3-05db083197cc.png)