### PR TITLE
Add `Grapheme#each_char` and `#each_byte`

### DIFF
--- a/spec/std/string/grapheme_spec.cr
+++ b/spec/std/string/grapheme_spec.cr
@@ -1,4 +1,5 @@
 require "./spec_helper"
+require "spec/helpers/iterate"
 
 describe String::Grapheme do
   it ".new" do
@@ -17,6 +18,20 @@ describe String::Grapheme do
     String.build do |io|
       String::Grapheme.new('f').to_s(io)
     end.should eq "f"
+  end
+
+  describe "#each_char" do
+    it_iterates "string", ['f', 'o', 'o'], String::Grapheme.new("foo").each_char
+    it_iterates "string", ['🙂', '🙂'], String::Grapheme.new("🙂🙂").each_char
+    it_iterates "char", ['f'], String::Grapheme.new('f').each_char
+    it_iterates "char", ['🙂'], String::Grapheme.new('🙂').each_char
+  end
+
+  describe "#each_byte" do
+    it_iterates "string", ['f', 'o', 'o'], String::Grapheme.new("foo").each_char
+    it_iterates "string", ['🙂', '🙂'], String::Grapheme.new("🙂🙂").each_char
+    it_iterates "char", ['f'], String::Grapheme.new('f').each_char
+    it_iterates "char", ['🙂'], String::Grapheme.new('🙂').each_char
   end
 
   it "#inspect" do

--- a/src/string/grapheme/grapheme.cr
+++ b/src/string/grapheme/grapheme.cr
@@ -143,6 +143,48 @@ class String
       end
     end
 
+    # Yields each character of this grapheme.
+    #
+    # Equivalent to `String#each_char`.
+    def each_char(& : Char -> Nil) : Nil
+      case cluster = @cluster
+      in Char
+        yield cluster
+      in String
+        cluster.each_char do |char|
+          yield char
+        end
+      end
+    end
+
+    # Returns an `Iterator` over each character of this grapheme.
+    #
+    # Equivalent to `String#each_char(&)`.
+    def each_char : Iterator(Char)
+      case cluster = @cluster
+      in Char
+        {cluster}.each
+      in String
+        cluster.each_char
+      end
+    end
+
+    # Yields each byte of this grapheme in UTF-8 encoding.
+    #
+    # Equivalent to `String#each_byte`.
+    def each_byte(& : UInt8 -> Nil) : Nil
+      cluster.each_byte do |byte|
+        yield byte
+      end
+    end
+
+    # Returns an `Iterator` over each byte of this grapheme in UTF-8 encoding.
+    #
+    # Equivalent to `String#each_byte(&)`.
+    def each_byte : Iterator(UInt8)
+      cluster.each_byte
+    end
+
     # Appends a representation of this grapheme cluster to *io*.
     def inspect(io : IO) : Nil
       io << "String::Grapheme("


### PR DESCRIPTION
This patch adds two iteration methods to `String::Grapheme`. They delegate to the respective implementations of `Char` and `String`.