### PR TITLE
Add `Grapheme#==(String)`

### DIFF
--- a/spec/std/string/grapheme_spec.cr
+++ b/spec/std/string/grapheme_spec.cr
@@ -38,10 +38,24 @@ describe String::Grapheme do
     String::Grapheme.new('🙂').bytesize.should eq 4
   end
 
-  it "#==" do
-    String::Grapheme.new('f').should eq String::Grapheme.new('f')
-    String::Grapheme.new('f').should_not eq String::Grapheme.new("f")
-    String::Grapheme.new("foo").should eq String::Grapheme.new("foo")
+  describe "#==" do
+    it "Grapheme" do
+      String::Grapheme.new('f').should eq String::Grapheme.new('f')
+      String::Grapheme.new('f').should_not eq String::Grapheme.new('g')
+      String::Grapheme.new('f').should_not eq String::Grapheme.new("f")
+      String::Grapheme.new("foo").should eq String::Grapheme.new("foo")
+      String::Grapheme.new("foo").should_not eq String::Grapheme.new("goo")
+      String::Grapheme.new('🙂').should eq String::Grapheme.new('🙂')
+    end
+
+    it "String" do
+      String::Grapheme.new('f').should eq "f"
+      String::Grapheme.new('f').should_not eq "g"
+      String::Grapheme.new('f').should_not eq "fo"
+      String::Grapheme.new("foo").should eq "foo"
+      String::Grapheme.new("foo").should_not eq "goo"
+      String::Grapheme.new('🙂').should eq "🙂"
+    end
   end
 
   it ".break?" do

--- a/src/string.cr
+++ b/src/string.cr
@@ -2859,6 +2859,13 @@ class String
     to_unsafe.memcmp(other.to_unsafe, bytesize) == 0
   end
 
+  # Returns `true` if *grapheme* is equivalent to `self`.
+  #
+  # A string and a grapheme are eqivalent if they contain the same sequence of codepoints.
+  def ==(grapheme : Grapheme) : Bool
+    grapheme == self
+  end
+
   # The comparison operator.
   #
   # Compares this string with *other*, returning `-1`, `0` or `1` depending on whether

--- a/src/string/grapheme/grapheme.cr
+++ b/src/string/grapheme/grapheme.cr
@@ -173,6 +173,20 @@ class String
       @cluster == other.@cluster
     end
 
+    # Returns `true` if *string* is equivalent to `self`.
+    #
+    # A string and a grapheme are equivalent if they contain the same sequence of codepoints.
+    def ==(string : String) : Bool
+      return false unless string.bytesize == bytesize
+
+      case cluster = @cluster
+      in Char
+        cluster == string[0]
+      in String
+        cluster == string
+      end
+    end
+
     # :nodoc:
     def self.break?(c1 : Char, c2 : Char) : Bool
       break?(Property.from(c1), Property.from(c2))


### PR DESCRIPTION
`String::Grapheme` is a helper data type used by `String#each_grapheme` (etc.). It is semantically equivalent to `String` as it describes a sequence of codepoints/characters. Using a dedicated data type is mostly for performance (avoid heap allocation for single-char graphemes).

It is not intended to be directly instantiated, so checking for equality with an arbitrary sequence of codepoints (i.e. `String`) is a bit difficult. You *could* do something like `"X".graphemes[0]` to construct a `Grapheme` instance that can be passed to `Grapheme#==(Grapheme)`.

This patch adds direct comparison with `String` via `Grapheme#==(String)`. If the compared string is not a valid grapheme cluster, doesn't matter - the result will just be negative.

We could consider adding a similar overload for `Char`, although I see it as less useful because `String` should already cover most use cases. So I'm leaving that out here.