### PR TITLE
Compiler: use enums instead of symbols in various places

### DIFF
--- a/src/compiler/crystal/semantic/top_level_visitor.cr
+++ b/src/compiler/crystal/semantic/top_level_visitor.cr
@@ -999,7 +999,7 @@ class Crystal::TopLevelVisitor < Crystal::SemanticVisitor
     false
   end
 
-  def include_in(current_type, node, kind)
+  def include_in(current_type, node, kind : HookKind)
     node_name = node.name
 
     type = lookup_type(node_name)
@@ -1020,7 +1020,7 @@ class Crystal::TopLevelVisitor < Crystal::SemanticVisitor
     end
   end
 
-  def run_hooks(type_with_hooks, current_type, kind, node, call = nil)
+  def run_hooks(type_with_hooks, current_type, kind : HookKind, node, call = nil)
     type_with_hooks.as?(ModuleType).try &.hooks.try &.each do |hook|
       next if hook.kind != kind
 
@@ -1035,7 +1035,7 @@ class Crystal::TopLevelVisitor < Crystal::SemanticVisitor
       node.add_hook_expansion(expansion)
     end
 
-    if kind == :inherited
+    if kind.inherited?
       # In the case of:
       #
       #    class A(X); end

--- a/src/compiler/crystal/tools/playground/server.cr
+++ b/src/compiler/crystal/tools/playground/server.cr
@@ -218,22 +218,17 @@ module Crystal::Playground
       ECR.embed "#{__DIR__}/views/layout.html.ecr", io
     end
 
-    protected def add_resource(kind : ResourceKind, src)
+    protected def add_resource(kind, src)
       @resources << Resource.new(kind, src)
     end
 
-    def each_resource(kind : ResourceKind)
+    def each_resource(kind)
       @resources.each do |res|
         yield res if res.kind == kind
       end
     end
 
-    enum ResourceKind
-      CSS
-      JS
-    end
-
-    record Resource, kind : ResourceKind, src : String
+    record Resource, kind : Symbol, src : String
   end
 
   class FileContentPage < PlaygroundPage

--- a/src/compiler/crystal/tools/playground/server.cr
+++ b/src/compiler/crystal/tools/playground/server.cr
@@ -218,17 +218,22 @@ module Crystal::Playground
       ECR.embed "#{__DIR__}/views/layout.html.ecr", io
     end
 
-    protected def add_resource(kind, src)
+    protected def add_resource(kind : ResourceKind, src)
       @resources << Resource.new(kind, src)
     end
 
-    def each_resource(kind)
+    def each_resource(kind : ResourceKind)
       @resources.each do |res|
         yield res if res.kind == kind
       end
     end
 
-    record Resource, kind : Symbol, src : String
+    enum ResourceKind
+      CSS
+      JS
+    end
+
+    record Resource, kind : ResourceKind, src : String
   end
 
   class FileContentPage < PlaygroundPage

--- a/src/compiler/crystal/tools/table_print.cr
+++ b/src/compiler/crystal/tools/table_print.cr
@@ -6,6 +6,12 @@ module Crystal
     struct Separator
     end
 
+    enum Alignment
+      Left
+      Right
+      Center
+    end
+
     class Column
       def initialize
         @max_size = 0
@@ -27,27 +33,25 @@ module Crystal
         end
 
         case cell.align
-        when :left
+        in .left?
           "%-#{available_width}s" % cell.text
-        when :right
+        in .right?
           "%+#{available_width}s" % cell.text
-        when :center
+        in .center?
           left = " " * ((available_width - cell.text.size) // 2)
           right = " " * (available_width - cell.text.size - left.size)
           "#{left}#{cell.text}#{right}"
-        else
-          raise "Unknown alignment: #{cell.align}"
         end
       end
     end
 
     class Cell
       property text : String
-      property align : Symbol
+      property align : Alignment
       property colspan : Int32
       property! column_index : Int32
 
-      def initialize(@text, @align, @colspan)
+      def initialize(@text, @align : Alignment, @colspan)
       end
     end
 
@@ -76,13 +80,13 @@ module Crystal
       with self yield
     end
 
-    def cell(text, align = :left, colspan = 1)
+    def cell(text, align : Alignment = :left, colspan = 1)
       cell = Cell.new(text, align, colspan)
       last_string_row << cell
       column_for_last_cell.will_render(cell)
     end
 
-    def cell(align = :left, colspan = 1)
+    def cell(align : Alignment = :left, colspan = 1)
       cell(String::Builder.build { |io| yield io }, align, colspan)
     end
 

--- a/src/compiler/crystal/types.cr
+++ b/src/compiler/crystal/types.cr
@@ -811,8 +811,16 @@ module Crystal
     end
   end
 
-  # A macro hook (:inherited, :included, :extended)
-  record Hook, kind : Symbol, macro : Macro
+  # Kinds of macro hooks (`method_missing` and `finished` are handled separately)
+  enum HookKind
+    Inherited
+    Included
+    Extended
+    MethodAdded
+  end
+
+  # A macro hook
+  record Hook, kind : HookKind, macro : Macro
 
   # The key by which instantiated methods are cached.
   #
@@ -921,7 +929,7 @@ module Crystal
       end
     end
 
-    def add_hook(kind, a_macro, args_size = 0)
+    def add_hook(kind : HookKind, a_macro, args_size = 0)
       check_macro_param_count(a_macro, args_size)
       hooks = @hooks ||= [] of Hook
       hooks << Hook.new(kind, a_macro)


### PR DESCRIPTION
These are the simple cases. The complex cases are the kinds of tokens (`Crystal::Token#type`) and the kinds of primitive numbers (`Crystal::NumberLiteral#kind`).