### PR TITLE
Refactor `PlaygroundPage` resources list

### DIFF
--- a/src/compiler/crystal/tools/playground/server.cr
+++ b/src/compiler/crystal/tools/playground/server.cr
@@ -350,10 +350,10 @@ module Crystal::Playground
 
     def load_resources(page : PlaygroundPage)
       Dir["playground/resources/*.css"].each do |file|
-        page.styles.add "/workbook/#{file}"
+        page.styles << "/workbook/#{file}"
       end
       Dir["playground/resources/*.js"].each do |file|
-        page.scripts.add "/workbook/#{file}"
+        page.scripts << "/workbook/#{file}"
       end
     end
   end

--- a/src/compiler/crystal/tools/playground/server.cr
+++ b/src/compiler/crystal/tools/playground/server.cr
@@ -212,23 +212,12 @@ module Crystal::Playground
   end
 
   abstract class PlaygroundPage
-    @resources = [] of Resource
+    getter styles = [] of String
+    getter scripts = [] of String
 
     def render_with_layout(io, &block)
       ECR.embed "#{__DIR__}/views/layout.html.ecr", io
     end
-
-    protected def add_resource(kind, src)
-      @resources << Resource.new(kind, src)
-    end
-
-    def each_resource(kind)
-      @resources.each do |res|
-        yield res if res.kind == kind
-      end
-    end
-
-    record Resource, kind : Symbol, src : String
   end
 
   class FileContentPage < PlaygroundPage
@@ -361,10 +350,10 @@ module Crystal::Playground
 
     def load_resources(page : PlaygroundPage)
       Dir["playground/resources/*.css"].each do |file|
-        page.add_resource :css, "/workbook/#{file}"
+        page.styles.add "/workbook/#{file}"
       end
       Dir["playground/resources/*.js"].each do |file|
-        page.add_resource :js, "/workbook/#{file}"
+        page.scripts.add "/workbook/#{file}"
       end
     end
   end

--- a/src/compiler/crystal/tools/playground/views/layout.html.ecr
+++ b/src/compiler/crystal/tools/playground/views/layout.html.ecr
@@ -8,8 +8,8 @@
     <link rel="stylesheet" href="/vendor/octicons-3.5.0/octicons.css">
     <link rel="stylesheet" href="/vendor/ansi_up-1.3.0/theme.css">
     <link rel="stylesheet" type="text/css" href="/application.css">
-    <% each_resource(:css) do |res| %>
-      <link rel="stylesheet" type="text/css" href="<%= res.src %>">
+    <% styles.each do |path| %>
+      <link rel="stylesheet" type="text/css" href="<%= path %>">
     <% end %>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
 
@@ -59,8 +59,8 @@
     <script type="text/javascript" src="/settings.js"></script>
     <script type="text/javascript" src="/session.js"></script>
     <script type="text/javascript" src="/application.js"></script>
-    <% each_resource(:js) do |res| %>
-      <script type="text/javascript" src="<%= res.src %>"></script>
+    <% scripts.each do |path| %>
+      <script type="text/javascript" src="<%= path %>"></script>
     <% end %>
   </body>
 </html>


### PR DESCRIPTION
Split the single resources list into separate lists for scripts and styles.

ref: https://github.com/crystal-lang/crystal/pull/11607#issuecomment-996638764