### PR TITLE
Remove `Iterator.of(Iterator.stop)` from implementations

### DIFF
--- a/spec/std/indexable_spec.cr
+++ b/spec/std/indexable_spec.cr
@@ -370,6 +370,16 @@ describe Indexable do
       iter.next.should be_a(Iterator::Stop)
     end
 
+    it "does with 1 other Indexable, without block, combined with select" do
+      iter = SafeIndexable.new(3).each_cartesian(SafeStringIndexable.new(2))
+      iter = iter.select { |(x, y)| x > 0 }
+      iter.next.should eq({1, "0"})
+      iter.next.should eq({1, "1"})
+      iter.next.should eq({2, "0"})
+      iter.next.should eq({2, "1"})
+      iter.next.should be_a(Iterator::Stop)
+    end
+
     it "does with >1 other Indexables, with block" do
       r = [] of Int32 | String
       i1 = SafeIndexable.new(2)
@@ -447,6 +457,22 @@ describe Indexable do
       iter.next.should eq([0, 0])
       iter.next.should eq([0, 1])
       iter.next.should eq([0, 2])
+      iter.next.should eq([1, 0])
+      iter.next.should eq([1, 1])
+      iter.next.should eq([1, 2])
+      iter.next.should eq([2, 0])
+      iter.next.should eq([2, 1])
+      iter.next.should eq([2, 2])
+      iter.next.should be_a(Iterator::Stop)
+
+      iter = Indexable.each_cartesian(SafeNestedIndexable.new(0, 3))
+      iter.next.should eq([] of Int32)
+      iter.next.should be_a(Iterator::Stop)
+    end
+
+    it "does with an Indexable of Indexables, without block, combined with select" do
+      iter = Indexable.each_cartesian(SafeNestedIndexable.new(2, 3))
+      iter = iter.select { |(x, y)| x > 0 }
       iter.next.should eq([1, 0])
       iter.next.should eq([1, 1])
       iter.next.should eq([1, 2])

--- a/src/indexable.cr
+++ b/src/indexable.cr
@@ -347,8 +347,6 @@ module Indexable(T)
   end
 
   protected def self.each_cartesian_impl(*indexables : *U) forall U
-    return Iterator.of(Iterator.stop) if indexables.any? &.empty?
-
     {% begin %}
       CartesianProductIteratorT(U, Tuple(
         {% for i in 0...U.size %}
@@ -384,11 +382,7 @@ module Indexable(T)
   # This can be used to prevent many memory allocations when each combination of
   # interest is to be used in a read-only fashion.
   def self.each_cartesian(indexables : Indexable(Indexable), reuse = false)
-    if indexables.any? &.empty?
-      Iterator.of(Iterator.stop)
-    else
-      CartesianProductIteratorN(typeof(indexables), typeof(Enumerable.element_type Enumerable.element_type indexables)).new(indexables, reuse)
-    end
+    CartesianProductIteratorN(typeof(indexables), typeof(Enumerable.element_type Enumerable.element_type indexables)).new(indexables, reuse)
   end
 
   private class CartesianProductIteratorT(Is, Ts)


### PR DESCRIPTION
Fixes #11612

@HertzDevil Do you think there could be issues with this? I guess `Iterator.of(Iterator.stop)` was used here only for performance reasons, but like this something stops working?