### PR TITLE
Lexer: use `Crystal::Token::Kind` enum instead of symbols

### DIFF
--- a/spec/compiler/lexer/lexer_comment_spec.cr
+++ b/spec/compiler/lexer/lexer_comment_spec.cr
@@ -1,14 +1,18 @@
 require "../../support/syntax"
 
+private def t(kind : Crystal::Token::Kind)
+  kind
+end
+
 describe "Lexer comments" do
   it "lexes without comments enabled" do
     lexer = Lexer.new(%(# Hello\n1))
 
     token = lexer.next_token
-    token.type.should eq(:NEWLINE)
+    token.type.should eq(t :NEWLINE)
 
     token = lexer.next_token
-    token.type.should eq(:NUMBER)
+    token.type.should eq(t :NUMBER)
   end
 
   it "lexes with comments enabled" do
@@ -16,14 +20,14 @@ describe "Lexer comments" do
     lexer.comments_enabled = true
 
     token = lexer.next_token
-    token.type.should eq(:COMMENT)
+    token.type.should eq(t :COMMENT)
     token.value.should eq("# Hello")
 
     token = lexer.next_token
-    token.type.should eq(:NEWLINE)
+    token.type.should eq(t :NEWLINE)
 
     token = lexer.next_token
-    token.type.should eq(:NUMBER)
+    token.type.should eq(t :NUMBER)
   end
 
   it "lexes with comments enabled (2)" do
@@ -31,17 +35,17 @@ describe "Lexer comments" do
     lexer.comments_enabled = true
 
     token = lexer.next_token
-    token.type.should eq(:NUMBER)
+    token.type.should eq(t :NUMBER)
 
     token = lexer.next_token
-    token.type.should eq(:SPACE)
+    token.type.should eq(t :SPACE)
 
     token = lexer.next_token
-    token.type.should eq(:COMMENT)
+    token.type.should eq(t :COMMENT)
     token.value.should eq("# Hello")
 
     token = lexer.next_token
-    token.type.should eq(:EOF)
+    token.type.should eq(t :EOF)
   end
 
   it "lexes correct number of spaces" do
@@ -49,16 +53,16 @@ describe "Lexer comments" do
     lexer.count_whitespace = true
 
     token = lexer.next_token
-    token.type.should eq(:NUMBER)
+    token.type.should eq(t :NUMBER)
 
     token = lexer.next_token
-    token.type.should eq(:SPACE)
+    token.type.should eq(t :SPACE)
     token.value.should eq("   ")
 
     token = lexer.next_token
-    token.type.should eq(:NUMBER)
+    token.type.should eq(t :NUMBER)
 
     token = lexer.next_token
-    token.type.should eq(:EOF)
+    token.type.should eq(t :EOF)
   end
 end

--- a/spec/compiler/lexer/lexer_doc_spec.cr
+++ b/spec/compiler/lexer/lexer_doc_spec.cr
@@ -1,12 +1,16 @@
 require "../../support/syntax"
 
+private def t(kind : Crystal::Token::Kind)
+  kind
+end
+
 describe "Lexer doc" do
   it "lexes without doc enabled" do
     lexer = Lexer.new(%(1))
     lexer.doc_enabled = true
 
     token = lexer.next_token
-    token.type.should eq(:NUMBER)
+    token.type.should eq(t :NUMBER)
     token.doc.should be_nil
   end
 
@@ -15,7 +19,7 @@ describe "Lexer doc" do
     lexer.doc_enabled = true
 
     token = lexer.next_token
-    token.type.should eq(:NUMBER)
+    token.type.should eq(t :NUMBER)
     token.doc.should be_nil
   end
 
@@ -24,11 +28,11 @@ describe "Lexer doc" do
     lexer.doc_enabled = true
 
     token = lexer.next_token
-    token.type.should eq(:NEWLINE)
+    token.type.should eq(t :NEWLINE)
     token.doc.should eq("hello")
 
     token = lexer.next_token
-    token.type.should eq(:NUMBER)
+    token.type.should eq(t :NUMBER)
     token.doc.should eq("hello")
   end
 
@@ -37,11 +41,11 @@ describe "Lexer doc" do
     lexer.doc_enabled = true
 
     token = lexer.next_token
-    token.type.should eq(:NEWLINE)
+    token.type.should eq(t :NEWLINE)
     token.doc.should eq("hello")
 
     token = lexer.next_token
-    token.type.should eq(:NEWLINE)
+    token.type.should eq(t :NEWLINE)
     token.doc.should eq("hello\nworld")
   end
 
@@ -50,19 +54,19 @@ describe "Lexer doc" do
     lexer.doc_enabled = true
 
     token = lexer.next_token
-    token.type.should eq(:NEWLINE)
+    token.type.should eq(t :NEWLINE)
     token.doc.should eq("hello")
 
     token = lexer.next_token
-    token.type.should eq(:SPACE)
+    token.type.should eq(t :SPACE)
     token.doc.should eq("hello")
 
     token = lexer.next_token
-    token.type.should eq(:NEWLINE)
+    token.type.should eq(t :NEWLINE)
     token.doc.should eq("hello\nworld")
 
     token = lexer.next_token
-    token.type.should eq(:NUMBER)
+    token.type.should eq(t :NUMBER)
     token.doc.should eq("hello\nworld")
   end
 
@@ -71,19 +75,19 @@ describe "Lexer doc" do
     lexer.doc_enabled = true
 
     token = lexer.next_token
-    token.type.should eq(:NEWLINE)
+    token.type.should eq(t :NEWLINE)
     token.doc.should be_nil
 
     token = lexer.next_token
-    token.type.should eq(:SPACE)
+    token.type.should eq(t :SPACE)
     token.doc.should be_nil
 
     token = lexer.next_token
-    token.type.should eq(:NEWLINE)
+    token.type.should eq(t :NEWLINE)
     token.doc.should eq("world")
 
     token = lexer.next_token
-    token.type.should eq(:NUMBER)
+    token.type.should eq(t :NUMBER)
     token.doc.should eq("world")
   end
 
@@ -92,19 +96,19 @@ describe "Lexer doc" do
     lexer.doc_enabled = true
 
     token = lexer.next_token
-    token.type.should eq(:NEWLINE)
+    token.type.should eq(t :NEWLINE)
     token.doc.should eq("hello")
 
     token = lexer.next_token
-    token.type.should eq(:NUMBER)
+    token.type.should eq(t :NUMBER)
     token.doc.should eq("hello")
 
     token = lexer.next_token
-    token.type.should eq(:SPACE)
+    token.type.should eq(t :SPACE)
     token.doc.should be_nil
 
     token = lexer.next_token
-    token.type.should eq(:NUMBER)
+    token.type.should eq(t :NUMBER)
     token.doc.should be_nil
   end
 end

--- a/spec/compiler/lexer/lexer_macro_spec.cr
+++ b/spec/compiler/lexer/lexer_macro_spec.cr
@@ -1,42 +1,46 @@
 require "../../support/syntax"
 
+private def t(kind : Crystal::Token::Kind)
+  kind
+end
+
 describe "Lexer macro" do
   it "lexes simple macro" do
     lexer = Lexer.new(%(hello end))
 
     token = lexer.next_macro_token(Token::MacroState.default, false)
-    token.type.should eq(:MACRO_LITERAL)
+    token.type.should eq(t :MACRO_LITERAL)
     token.value.should eq("hello ")
 
     token = lexer.next_macro_token(token.macro_state, false)
-    token.type.should eq(:MACRO_END)
+    token.type.should eq(t :MACRO_END)
   end
 
   it "lexes macro with expression" do
     lexer = Lexer.new(%(hello {{world}} end))
 
     token = lexer.next_macro_token(Token::MacroState.default, false)
-    token.type.should eq(:MACRO_LITERAL)
+    token.type.should eq(t :MACRO_LITERAL)
     token.value.should eq("hello ")
 
     token = lexer.next_macro_token(token.macro_state, false)
-    token.type.should eq(:MACRO_EXPRESSION_START)
+    token.type.should eq(t :MACRO_EXPRESSION_START)
 
     token_before_expression = token.dup
 
     token = lexer.next_token
-    token.type.should eq(:IDENT)
+    token.type.should eq(t :IDENT)
     token.value.should eq("world")
 
-    lexer.next_token.type.should eq(:"}")
-    lexer.next_token.type.should eq(:"}")
+    lexer.next_token.type.should eq(t :OP_CURLYR)
+    lexer.next_token.type.should eq(t :OP_CURLYR)
 
     token = lexer.next_macro_token(token_before_expression.macro_state, false)
-    token.type.should eq(:MACRO_LITERAL)
+    token.type.should eq(t :MACRO_LITERAL)
     token.value.should eq(" ")
 
     token = lexer.next_macro_token(token.macro_state, false)
-    token.type.should eq(:MACRO_END)
+    token.type.should eq(t :MACRO_END)
   end
 
   ["begin", "do", "if", "unless", "class", "struct", "module", "def", "while", "until", "case", "macro", "fun", "lib", "union", "annotation", "select"].each do |keyword|
@@ -44,32 +48,32 @@ describe "Lexer macro" do
       lexer = Lexer.new(%(hello\n  #{keyword} {{world}} end end))
 
       token = lexer.next_macro_token(Token::MacroState.default, false)
-      token.type.should eq(:MACRO_LITERAL)
+      token.type.should eq(t :MACRO_LITERAL)
       token.value.should eq("hello\n  #{keyword} ")
       token.macro_state.nest.should eq(1)
 
       token = lexer.next_macro_token(token.macro_state, false)
-      token.type.should eq(:MACRO_EXPRESSION_START)
+      token.type.should eq(t :MACRO_EXPRESSION_START)
 
       token_before_expression = token.dup
 
       token = lexer.next_token
-      token.type.should eq(:IDENT)
+      token.type.should eq(t :IDENT)
       token.value.should eq("world")
 
-      lexer.next_token.type.should eq(:"}")
-      lexer.next_token.type.should eq(:"}")
+      lexer.next_token.type.should eq(t :OP_CURLYR)
+      lexer.next_token.type.should eq(t :OP_CURLYR)
 
       token = lexer.next_macro_token(token_before_expression.macro_state, false)
-      token.type.should eq(:MACRO_LITERAL)
+      token.type.should eq(t :MACRO_LITERAL)
       token.value.should eq(" ")
 
       token = lexer.next_macro_token(token.macro_state, false)
-      token.type.should eq(:MACRO_LITERAL)
+      token.type.should eq(t :MACRO_LITERAL)
       token.value.should eq("end ")
 
       token = lexer.next_macro_token(token.macro_state, false)
-      token.type.should eq(:MACRO_END)
+      token.type.should eq(t :MACRO_END)
     end
   end
 
@@ -77,92 +81,92 @@ describe "Lexer macro" do
     lexer = Lexer.new(%(hello enum {{world}} end end))
 
     token = lexer.next_macro_token(Token::MacroState.default, false)
-    token.type.should eq(:MACRO_LITERAL)
+    token.type.should eq(t :MACRO_LITERAL)
     token.value.should eq("hello ")
 
     token = lexer.next_macro_token(token.macro_state, false)
-    token.type.should eq(:MACRO_LITERAL)
+    token.type.should eq(t :MACRO_LITERAL)
     token.value.should eq("enum ")
     token.macro_state.nest.should eq(1)
 
     token = lexer.next_macro_token(token.macro_state, false)
-    token.type.should eq(:MACRO_EXPRESSION_START)
+    token.type.should eq(t :MACRO_EXPRESSION_START)
 
     token_before_expression = token.dup
 
     token = lexer.next_token
-    token.type.should eq(:IDENT)
+    token.type.should eq(t :IDENT)
     token.value.should eq("world")
 
-    lexer.next_token.type.should eq(:"}")
-    lexer.next_token.type.should eq(:"}")
+    lexer.next_token.type.should eq(t :OP_CURLYR)
+    lexer.next_token.type.should eq(t :OP_CURLYR)
 
     token = lexer.next_macro_token(token_before_expression.macro_state, false)
-    token.type.should eq(:MACRO_LITERAL)
+    token.type.should eq(t :MACRO_LITERAL)
     token.value.should eq(" ")
 
     token = lexer.next_macro_token(token.macro_state, false)
-    token.type.should eq(:MACRO_LITERAL)
+    token.type.should eq(t :MACRO_LITERAL)
     token.value.should eq("end ")
 
     token = lexer.next_macro_token(token.macro_state, false)
-    token.type.should eq(:MACRO_END)
+    token.type.should eq(t :MACRO_END)
   end
 
   it "lexes macro without nested if" do
     lexer = Lexer.new(%(helloif {{world}} end))
 
     token = lexer.next_macro_token(Token::MacroState.default, false)
-    token.type.should eq(:MACRO_LITERAL)
+    token.type.should eq(t :MACRO_LITERAL)
     token.value.should eq("helloif ")
     token.macro_state.nest.should eq(0)
 
     token = lexer.next_macro_token(token.macro_state, false)
-    token.type.should eq(:MACRO_EXPRESSION_START)
+    token.type.should eq(t :MACRO_EXPRESSION_START)
 
     token_before_expression = token.dup
 
     token = lexer.next_token
-    token.type.should eq(:IDENT)
+    token.type.should eq(t :IDENT)
     token.value.should eq("world")
 
-    lexer.next_token.type.should eq(:"}")
-    lexer.next_token.type.should eq(:"}")
+    lexer.next_token.type.should eq(t :OP_CURLYR)
+    lexer.next_token.type.should eq(t :OP_CURLYR)
 
     token = lexer.next_macro_token(token_before_expression.macro_state, false)
-    token.type.should eq(:MACRO_LITERAL)
+    token.type.should eq(t :MACRO_LITERAL)
     token.value.should eq(" ")
 
     token = lexer.next_macro_token(token.macro_state, false)
-    token.type.should eq(:MACRO_END)
+    token.type.should eq(t :MACRO_END)
   end
 
   it "lexes macro with nested abstract def" do
     lexer = Lexer.new(%(hello\n  abstract def {{world}} end end))
 
     token = lexer.next_macro_token(Token::MacroState.default, false)
-    token.type.should eq(:MACRO_LITERAL)
+    token.type.should eq(t :MACRO_LITERAL)
     token.value.should eq("hello\n  abstract def ")
     token.macro_state.nest.should eq(0)
 
     token = lexer.next_macro_token(token.macro_state, false)
-    token.type.should eq(:MACRO_EXPRESSION_START)
+    token.type.should eq(t :MACRO_EXPRESSION_START)
 
     token_before_expression = token.dup
 
     token = lexer.next_token
-    token.type.should eq(:IDENT)
+    token.type.should eq(t :IDENT)
     token.value.should eq("world")
 
-    lexer.next_token.type.should eq(:"}")
-    lexer.next_token.type.should eq(:"}")
+    lexer.next_token.type.should eq(t :OP_CURLYR)
+    lexer.next_token.type.should eq(t :OP_CURLYR)
 
     token = lexer.next_macro_token(token_before_expression.macro_state, false)
-    token.type.should eq(:MACRO_LITERAL)
+    token.type.should eq(t :MACRO_LITERAL)
     token.value.should eq(" ")
 
     token = lexer.next_macro_token(token.macro_state, false)
-    token.type.should eq(:MACRO_END)
+    token.type.should eq(t :MACRO_END)
   end
 
   {"class", "struct"}.each do |keyword|
@@ -170,16 +174,16 @@ describe "Lexer macro" do
       lexer = Lexer.new(%(hello\n  abstract #{keyword} Foo; end; end))
 
       token = lexer.next_macro_token(Token::MacroState.default, false)
-      token.type.should eq(:MACRO_LITERAL)
+      token.type.should eq(t :MACRO_LITERAL)
       token.value.should eq("hello\n  abstract #{keyword} Foo; ")
       token.macro_state.nest.should eq(1)
 
       token = lexer.next_macro_token(token.macro_state, false)
-      token.type.should eq(:MACRO_LITERAL)
+      token.type.should eq(t :MACRO_LITERAL)
       token.value.should eq("end; ")
 
       token = lexer.next_macro_token(token.macro_state, false)
-      token.type.should eq(:MACRO_END)
+      token.type.should eq(t :MACRO_END)
     end
   end
 
@@ -187,58 +191,58 @@ describe "Lexer macro" do
     lexer = Lexer.new(%(fail))
 
     token = lexer.next_macro_token(Token::MacroState.default, false)
-    token.type.should eq(:MACRO_LITERAL)
+    token.type.should eq(t :MACRO_LITERAL)
     token.value.should eq("fail")
 
     token = lexer.next_macro_token(token.macro_state, false)
-    token.type.should eq(:EOF)
+    token.type.should eq(t :EOF)
   end
 
   it "keeps correct column and line numbers" do
     lexer = Lexer.new("\nfoo\nbarf{{var}}\nend")
 
     token = lexer.next_macro_token(Token::MacroState.default, false)
-    token.type.should eq(:MACRO_LITERAL)
+    token.type.should eq(t :MACRO_LITERAL)
     token.value.should eq("\nfoo\nbarf")
     token.column_number.should eq(1)
     token.line_number.should eq(1)
 
     token = lexer.next_macro_token(token.macro_state, false)
-    token.type.should eq(:MACRO_EXPRESSION_START)
+    token.type.should eq(t :MACRO_EXPRESSION_START)
 
     token = lexer.next_token
-    token.type.should eq(:IDENT)
+    token.type.should eq(t :IDENT)
     token.value.should eq("var")
     token.line_number.should eq(3)
     token.column_number.should eq(7)
 
-    lexer.next_token.type.should eq(:"}")
-    lexer.next_token.type.should eq(:"}")
+    lexer.next_token.type.should eq(t :OP_CURLYR)
+    lexer.next_token.type.should eq(t :OP_CURLYR)
 
     token = lexer.next_macro_token(Token::MacroState.default, false)
-    token.type.should eq(:MACRO_LITERAL)
+    token.type.should eq(t :MACRO_LITERAL)
     token.value.should eq("\n")
 
     token = lexer.next_macro_token(token.macro_state, false)
-    token.type.should eq(:MACRO_END)
+    token.type.should eq(t :MACRO_END)
   end
 
   it "lexes macro with control" do
     lexer = Lexer.new("foo{% if ")
 
     token = lexer.next_macro_token(Token::MacroState.default, false)
-    token.type.should eq(:MACRO_LITERAL)
+    token.type.should eq(t :MACRO_LITERAL)
     token.value.should eq("foo")
 
     token = lexer.next_macro_token(token.macro_state, false)
-    token.type.should eq(:MACRO_CONTROL_START)
+    token.type.should eq(t :MACRO_CONTROL_START)
   end
 
   it "skips whitespace" do
     lexer = Lexer.new("   \n    coco")
 
     token = lexer.next_macro_token(Token::MacroState.default, true)
-    token.type.should eq(:MACRO_LITERAL)
+    token.type.should eq(t :MACRO_LITERAL)
     token.value.should eq("coco")
   end
 
@@ -246,49 +250,49 @@ describe "Lexer macro" do
     lexer = Lexer.new(%(good " end " day end))
 
     token = lexer.next_macro_token(Token::MacroState.default, false)
-    token.type.should eq(:MACRO_LITERAL)
+    token.type.should eq(t :MACRO_LITERAL)
     token.value.should eq(%(good " end " day ))
 
     token = lexer.next_macro_token(token.macro_state, false)
-    token.type.should eq(:MACRO_END)
+    token.type.should eq(t :MACRO_END)
   end
 
   it "lexes macro with embedded string and backslash" do
     lexer = Lexer.new("good \" end \\\" \" day end")
 
     token = lexer.next_macro_token(Token::MacroState.default, false)
-    token.type.should eq(:MACRO_LITERAL)
+    token.type.should eq(t :MACRO_LITERAL)
     token.value.should eq("good \" end \\\" \" day ")
 
     token = lexer.next_macro_token(token.macro_state, false)
-    token.type.should eq(:MACRO_END)
+    token.type.should eq(t :MACRO_END)
   end
 
   it "lexes macro with embedded string and expression" do
     lexer = Lexer.new(%(good " end {{foo}} " day end))
 
     token = lexer.next_macro_token(Token::MacroState.default, false)
-    token.type.should eq(:MACRO_LITERAL)
+    token.type.should eq(t :MACRO_LITERAL)
     token.value.should eq(%(good " end ))
 
     token = lexer.next_macro_token(token.macro_state, false)
-    token.type.should eq(:MACRO_EXPRESSION_START)
+    token.type.should eq(t :MACRO_EXPRESSION_START)
 
     macro_state = token.macro_state
 
     token = lexer.next_token
-    token.type.should eq(:IDENT)
+    token.type.should eq(t :IDENT)
     token.value.should eq("foo")
 
-    lexer.next_token.type.should eq(:"}")
-    lexer.next_token.type.should eq(:"}")
+    lexer.next_token.type.should eq(t :OP_CURLYR)
+    lexer.next_token.type.should eq(t :OP_CURLYR)
 
     token = lexer.next_macro_token(macro_state, false)
-    token.type.should eq(:MACRO_LITERAL)
+    token.type.should eq(t :MACRO_LITERAL)
     token.value.should eq(%( " day ))
 
     token = lexer.next_macro_token(token.macro_state, false)
-    token.type.should eq(:MACRO_END)
+    token.type.should eq(t :MACRO_END)
   end
 
   [{"(", ")"}, {"[", "]"}, {"<", ">"}].each do |(left, right)|
@@ -296,22 +300,22 @@ describe "Lexer macro" do
       lexer = Lexer.new("good %#{left} end #{right} day end")
 
       token = lexer.next_macro_token(Token::MacroState.default, false)
-      token.type.should eq(:MACRO_LITERAL)
+      token.type.should eq(t :MACRO_LITERAL)
       token.value.should eq("good %#{left} end #{right} day ")
 
       token = lexer.next_macro_token(token.macro_state, false)
-      token.type.should eq(:MACRO_END)
+      token.type.should eq(t :MACRO_END)
     end
 
     it "lexes macro with embedded string with %#{left} ignores begin" do
       lexer = Lexer.new("good %#{left} begin #{right} day end")
 
       token = lexer.next_macro_token(Token::MacroState.default, false)
-      token.type.should eq(:MACRO_LITERAL)
+      token.type.should eq(t :MACRO_LITERAL)
       token.value.should eq("good %#{left} begin #{right} day ")
 
       token = lexer.next_macro_token(token.macro_state, false)
-      token.type.should eq(:MACRO_END)
+      token.type.should eq(t :MACRO_END)
     end
   end
 
@@ -319,33 +323,33 @@ describe "Lexer macro" do
     lexer = Lexer.new("good %( ( ) end ) day end")
 
     token = lexer.next_macro_token(Token::MacroState.default, false)
-    token.type.should eq(:MACRO_LITERAL)
+    token.type.should eq(t :MACRO_LITERAL)
     token.value.should eq("good %( ( ) end ) day ")
 
     token = lexer.next_macro_token(token.macro_state, false)
-    token.type.should eq(:MACRO_END)
+    token.type.should eq(t :MACRO_END)
   end
 
   it "lexes macro with comments" do
     lexer = Lexer.new("good # end\n day end")
 
     token = lexer.next_macro_token(Token::MacroState.default, false)
-    token.type.should eq(:MACRO_LITERAL)
+    token.type.should eq(t :MACRO_LITERAL)
     token.value.should eq("good ")
     token.line_number.should eq(1)
 
     token = lexer.next_macro_token(Token::MacroState.default, false)
-    token.type.should eq(:MACRO_LITERAL)
+    token.type.should eq(t :MACRO_LITERAL)
     token.value.should eq("# end\n")
     token.line_number.should eq(2)
 
     token = lexer.next_macro_token(Token::MacroState.default, false)
-    token.type.should eq(:MACRO_LITERAL)
+    token.type.should eq(t :MACRO_LITERAL)
     token.value.should eq(" day ")
     token.line_number.should eq(2)
 
     token = lexer.next_macro_token(token.macro_state, false)
-    token.type.should eq(:MACRO_END)
+    token.type.should eq(t :MACRO_END)
     token.line_number.should eq(2)
   end
 
@@ -353,39 +357,39 @@ describe "Lexer macro" do
     lexer = Lexer.new("good # {{name}} end\n day end")
 
     token = lexer.next_macro_token(Token::MacroState.default, false)
-    token.type.should eq(:MACRO_LITERAL)
+    token.type.should eq(t :MACRO_LITERAL)
     token.value.should eq("good ")
 
     token = lexer.next_macro_token(token.macro_state, false)
-    token.type.should eq(:MACRO_LITERAL)
+    token.type.should eq(t :MACRO_LITERAL)
     token.value.should eq("# ")
     token.macro_state.comment.should be_true
 
     token = lexer.next_macro_token(token.macro_state, false)
-    token.type.should eq(:MACRO_EXPRESSION_START)
+    token.type.should eq(t :MACRO_EXPRESSION_START)
 
     token_before_expression = token.dup
     token_before_expression.macro_state.comment.should be_true
 
     token = lexer.next_token
-    token.type.should eq(:IDENT)
+    token.type.should eq(t :IDENT)
     token.value.should eq("name")
 
-    lexer.next_token.type.should eq(:"}")
-    lexer.next_token.type.should eq(:"}")
+    lexer.next_token.type.should eq(t :OP_CURLYR)
+    lexer.next_token.type.should eq(t :OP_CURLYR)
 
     token = lexer.next_macro_token(token_before_expression.macro_state, false)
-    token.type.should eq(:MACRO_LITERAL)
+    token.type.should eq(t :MACRO_LITERAL)
     token.value.should eq(" end\n")
     token.macro_state.comment.should be_false
 
     token = lexer.next_macro_token(token.macro_state, false)
-    token.type.should eq(:MACRO_LITERAL)
+    token.type.should eq(t :MACRO_LITERAL)
     token.value.should eq(" day ")
     token.line_number.should eq(2)
 
     token = lexer.next_macro_token(token.macro_state, false)
-    token.type.should eq(:MACRO_END)
+    token.type.should eq(t :MACRO_END)
     token.line_number.should eq(2)
   end
 
@@ -393,144 +397,144 @@ describe "Lexer macro" do
     lexer = Lexer.new("good \\{{world}}\nend")
 
     token = lexer.next_macro_token(Token::MacroState.default, false)
-    token.type.should eq(:MACRO_LITERAL)
+    token.type.should eq(t :MACRO_LITERAL)
     token.value.should eq("good ")
 
     token = lexer.next_macro_token(token.macro_state, false)
-    token.type.should eq(:MACRO_LITERAL)
+    token.type.should eq(t :MACRO_LITERAL)
     token.value.should eq("{")
 
     token = lexer.next_macro_token(token.macro_state, false)
-    token.type.should eq(:MACRO_LITERAL)
+    token.type.should eq(t :MACRO_LITERAL)
     token.value.should eq("{world}}\n")
 
     token = lexer.next_macro_token(token.macro_state, false)
-    token.type.should eq(:MACRO_END)
+    token.type.should eq(t :MACRO_END)
   end
 
   it "lexes macro with if as suffix" do
     lexer = Lexer.new("foo if bar end")
 
     token = lexer.next_macro_token(Token::MacroState.default, false)
-    token.type.should eq(:MACRO_LITERAL)
+    token.type.should eq(t :MACRO_LITERAL)
     token.value.should eq("foo if bar ")
 
     token = lexer.next_macro_token(token.macro_state, false)
-    token.type.should eq(:MACRO_END)
+    token.type.should eq(t :MACRO_END)
   end
 
   it "lexes macro with if as suffix after return" do
     lexer = Lexer.new("return if @end end")
 
     token = lexer.next_macro_token(Token::MacroState.default, false)
-    token.type.should eq(:MACRO_LITERAL)
+    token.type.should eq(t :MACRO_LITERAL)
     token.value.should eq("return if @end ")
 
     token = lexer.next_macro_token(token.macro_state, false)
-    token.type.should eq(:MACRO_END)
+    token.type.should eq(t :MACRO_END)
   end
 
   it "lexes macro with semicolon before end" do
     lexer = Lexer.new(";end")
 
     token = lexer.next_macro_token(Token::MacroState.default, false)
-    token.type.should eq(:MACRO_LITERAL)
+    token.type.should eq(t :MACRO_LITERAL)
     token.value.should eq(";")
 
     token = lexer.next_macro_token(token.macro_state, false)
-    token.type.should eq(:MACRO_END)
+    token.type.should eq(t :MACRO_END)
   end
 
   it "lexes macro with if after assign" do
     lexer = Lexer.new("x = if 1; 2; else; 3; end; end")
 
     token = lexer.next_macro_token(Token::MacroState.default, false)
-    token.type.should eq(:MACRO_LITERAL)
+    token.type.should eq(t :MACRO_LITERAL)
     token.value.should eq("x = if 1; 2; ")
     token.macro_state.nest.should eq(1)
 
     token = lexer.next_macro_token(token.macro_state, false)
-    token.type.should eq(:MACRO_LITERAL)
+    token.type.should eq(t :MACRO_LITERAL)
     token.value.should eq("else; 3; ")
 
     token = lexer.next_macro_token(token.macro_state, false)
-    token.type.should eq(:MACRO_LITERAL)
+    token.type.should eq(t :MACRO_LITERAL)
     token.value.should eq("end; ")
 
     token = lexer.next_macro_token(token.macro_state, false)
-    token.type.should eq(:MACRO_END)
+    token.type.should eq(t :MACRO_END)
   end
 
   it "lexes macro var" do
     lexer = Lexer.new("x = if %var; 2; else; 3; end; end")
 
     token = lexer.next_macro_token(Token::MacroState.default, false)
-    token.type.should eq(:MACRO_LITERAL)
+    token.type.should eq(t :MACRO_LITERAL)
     token.value.should eq("x = if ")
     token.macro_state.nest.should eq(1)
 
     token = lexer.next_macro_token(token.macro_state, false)
-    token.type.should eq(:MACRO_VAR)
+    token.type.should eq(t :MACRO_VAR)
     token.value.should eq("var")
 
     token = lexer.next_macro_token(token.macro_state, false)
-    token.type.should eq(:MACRO_LITERAL)
+    token.type.should eq(t :MACRO_LITERAL)
     token.value.should eq("; 2; ")
 
     token = lexer.next_macro_token(token.macro_state, false)
-    token.type.should eq(:MACRO_LITERAL)
+    token.type.should eq(t :MACRO_LITERAL)
     token.value.should eq("else; 3; ")
 
     token = lexer.next_macro_token(token.macro_state, false)
-    token.type.should eq(:MACRO_LITERAL)
+    token.type.should eq(t :MACRO_LITERAL)
     token.value.should eq("end; ")
 
     token = lexer.next_macro_token(token.macro_state, false)
-    token.type.should eq(:MACRO_END)
+    token.type.should eq(t :MACRO_END)
   end
 
   it "doesn't lex macro var if escaped" do
     lexer = Lexer.new(%(" \\%var " end))
 
     token = lexer.next_macro_token(Token::MacroState.default, false)
-    token.type.should eq(:MACRO_LITERAL)
+    token.type.should eq(t :MACRO_LITERAL)
     token.value.should eq(%(" ))
 
     token = lexer.next_macro_token(token.macro_state, false)
-    token.type.should eq(:MACRO_LITERAL)
+    token.type.should eq(t :MACRO_LITERAL)
     token.value.should eq("%")
 
     token = lexer.next_macro_token(token.macro_state, false)
-    token.type.should eq(:MACRO_LITERAL)
+    token.type.should eq(t :MACRO_LITERAL)
     token.value.should eq(%(var " ))
 
     token = lexer.next_macro_token(token.macro_state, false)
-    token.type.should eq(:MACRO_END)
+    token.type.should eq(t :MACRO_END)
   end
 
   it "lexes macro with embedded char and sharp" do
     lexer = Lexer.new(%(good '#' day end))
 
     token = lexer.next_macro_token(Token::MacroState.default, false)
-    token.type.should eq(:MACRO_LITERAL)
+    token.type.should eq(t :MACRO_LITERAL)
     token.value.should eq(%(good '#' day ))
 
     token = lexer.next_macro_token(token.macro_state, false)
-    token.type.should eq(:MACRO_END)
+    token.type.should eq(t :MACRO_END)
   end
 
   it "lexes bug #654" do
     lexer = Lexer.new(%(l {{op}} end))
 
     token = lexer.next_macro_token(Token::MacroState.default, false)
-    token.type.should eq(:MACRO_LITERAL)
+    token.type.should eq(t :MACRO_LITERAL)
     token.value.should eq("l ")
 
     token = lexer.next_macro_token(token.macro_state, false)
-    token.type.should eq(:MACRO_EXPRESSION_START)
+    token.type.should eq(t :MACRO_EXPRESSION_START)
 
     token = lexer.next_token
-    token.type.should eq(:IDENT)
+    token.type.should eq(t :IDENT)
     token.value.should eq("op")
   end
 
@@ -538,7 +542,7 @@ describe "Lexer macro" do
     lexer = Lexer.new(%("\\"" end))
 
     token = lexer.next_macro_token(Token::MacroState.default, false)
-    token.type.should eq(:MACRO_LITERAL)
+    token.type.should eq(t :MACRO_LITERAL)
     token.value.should eq(%("\\"" ))
   end
 
@@ -546,19 +550,19 @@ describe "Lexer macro" do
     lexer = Lexer.new(%(\\{%    if true %} 2 \\{% end %} end))
 
     token = lexer.next_macro_token(Token::MacroState.default, false)
-    token.type.should eq(:MACRO_LITERAL)
+    token.type.should eq(t :MACRO_LITERAL)
     token.value.should eq("{%    if")
     token.macro_state.beginning_of_line.should be_false
     token.macro_state.nest.should eq(1)
 
     token = lexer.next_macro_token(token.macro_state, token.macro_state.beginning_of_line)
-    token.type.should eq(:MACRO_LITERAL)
+    token.type.should eq(t :MACRO_LITERAL)
     token.value.should eq(" true %} 2 ")
     token.macro_state.beginning_of_line.should be_false
     token.macro_state.nest.should eq(1)
 
     token = lexer.next_macro_token(token.macro_state, token.macro_state.beginning_of_line)
-    token.type.should eq(:MACRO_LITERAL)
+    token.type.should eq(t :MACRO_LITERAL)
     token.value.should eq("{% end")
     token.macro_state.beginning_of_line.should be_false
     token.macro_state.nest.should eq(0)
@@ -568,7 +572,7 @@ describe "Lexer macro" do
     lexer = Lexer.new(%(\\{%    for true %} 2 \\{% end %} end))
 
     token = lexer.next_macro_token(Token::MacroState.default, false)
-    token.type.should eq(:MACRO_LITERAL)
+    token.type.should eq(t :MACRO_LITERAL)
     token.value.should eq("{%    for")
     token.macro_state.beginning_of_line.should be_false
     token.macro_state.nest.should eq(1)
@@ -578,19 +582,19 @@ describe "Lexer macro" do
     lexer = Lexer.new(%(\\{%    unless true %} 2 \\{% end %} end))
 
     token = lexer.next_macro_token(Token::MacroState.default, false)
-    token.type.should eq(:MACRO_LITERAL)
+    token.type.should eq(t :MACRO_LITERAL)
     token.value.should eq("{%    unless")
     token.macro_state.beginning_of_line.should be_false
     token.macro_state.nest.should eq(1)
 
     token = lexer.next_macro_token(token.macro_state, token.macro_state.beginning_of_line)
-    token.type.should eq(:MACRO_LITERAL)
+    token.type.should eq(t :MACRO_LITERAL)
     token.value.should eq(" true %} 2 ")
     token.macro_state.beginning_of_line.should be_false
     token.macro_state.nest.should eq(1)
 
     token = lexer.next_macro_token(token.macro_state, token.macro_state.beginning_of_line)
-    token.type.should eq(:MACRO_LITERAL)
+    token.type.should eq(t :MACRO_LITERAL)
     token.value.should eq("{% end")
     token.macro_state.beginning_of_line.should be_false
     token.macro_state.nest.should eq(0)
@@ -599,11 +603,11 @@ describe "Lexer macro" do
   it "lexes begin end" do
     lexer = Lexer.new(%(begin\nend end))
     token = lexer.next_macro_token(Token::MacroState.default, false)
-    token.type.should eq(:MACRO_LITERAL)
+    token.type.should eq(t :MACRO_LITERAL)
     token.value.should eq("begin\n")
 
     token = lexer.next_macro_token(token.macro_state, token.macro_state.beginning_of_line)
-    token.type.should eq(:MACRO_LITERAL)
+    token.type.should eq(t :MACRO_LITERAL)
     token.value.should eq("end ")
     token.line_number.should eq(2)
   end
@@ -612,17 +616,17 @@ describe "Lexer macro" do
     lexer = Lexer.new(%("\#{{{1}}}"))
 
     token = lexer.next_macro_token(Token::MacroState.default, false)
-    token.type.should eq(:MACRO_LITERAL)
+    token.type.should eq(t :MACRO_LITERAL)
     token.value.should eq(%("\#{))
 
     token = lexer.next_macro_token(token.macro_state, false)
-    token.type.should eq(:MACRO_EXPRESSION_START)
+    token.type.should eq(t :MACRO_EXPRESSION_START)
   end
 
   it "keeps correct line number after lexes the part of keyword and newline (#4656)" do
     lexer = Lexer.new(%(ab\ncd)) # 'ab' means the part of 'abstract'
     token = lexer.next_macro_token(Token::MacroState.default, false)
-    token.type.should eq(:MACRO_LITERAL)
+    token.type.should eq(t :MACRO_LITERAL)
     token.value.should eq("ab\ncd")
     lexer.line_number.should eq(2)
   end

--- a/spec/compiler/lexer/lexer_objects/strings.cr
+++ b/spec/compiler/lexer/lexer_objects/strings.cr
@@ -3,6 +3,10 @@ module LexerObjects
     @lexer : Lexer
     @token : Token
 
+    private def t(kind : Token::Kind)
+      kind
+    end
+
     def initialize(@lexer)
       @token = Token.new
     end
@@ -16,10 +20,10 @@ module LexerObjects
 
     def string_should_start_correctly
       @token = lexer.next_token
-      token.type.should eq(:DELIMITER_START)
+      token.type.should eq(t :DELIMITER_START)
     end
 
-    def next_token_should_be(expected_type, expected_value = nil)
+    def next_token_should_be(expected_type : Token::Kind, expected_value = nil)
       @token = lexer.next_token
       token.type.should eq(expected_type)
       if expected_value
@@ -29,46 +33,46 @@ module LexerObjects
 
     def next_unicode_tokens_should_be(expected_unicode_codes : Array)
       @token = lexer.next_string_token(token.delimiter_state)
-      token.type.should eq(:STRING)
+      token.type.should eq(t :STRING)
       token.value.as(String).chars.map(&.ord).should eq(expected_unicode_codes)
     end
 
     def next_unicode_tokens_should_be(expected_unicode_codes)
       @token = lexer.next_string_token(token.delimiter_state)
-      token.type.should eq(:STRING)
+      token.type.should eq(t :STRING)
       token.value.as(String).char_at(0).ord.should eq(expected_unicode_codes)
     end
 
     def next_string_token_should_be(expected_string)
       @token = lexer.next_string_token(token.delimiter_state)
-      token.type.should eq(:STRING)
+      token.type.should eq(t :STRING)
       token.value.should eq(expected_string)
     end
 
     def next_string_token_should_be_opening
       @token = lexer.next_string_token(token.delimiter_state)
-      token.type.should eq(:STRING)
+      token.type.should eq(t :STRING)
       token.value.should eq(token.delimiter_state.nest.to_s)
       token.delimiter_state.open_count.should eq(1)
     end
 
     def next_string_token_should_be_closing
       @token = lexer.next_string_token(token.delimiter_state)
-      token.type.should eq(:STRING)
+      token.type.should eq(t :STRING)
       token.value.should eq(token.delimiter_state.end.to_s)
       token.delimiter_state.open_count.should eq(0)
     end
 
     def string_should_have_an_interpolation_of(interpolated_variable_name)
       @token = lexer.next_string_token(token.delimiter_state)
-      token.type.should eq(:INTERPOLATION_START)
+      token.type.should eq(t :INTERPOLATION_START)
 
       @token = lexer.next_token
-      token.type.should eq(:IDENT)
+      token.type.should eq(t :IDENT)
       token.value.should eq(interpolated_variable_name)
 
       @token = lexer.next_token
-      token.type.should eq(:"}")
+      token.type.should eq(t :OP_CURLYR)
     end
 
     def token_should_be_at(line = nil, column = nil)
@@ -83,7 +87,7 @@ module LexerObjects
 
     def string_should_end_correctly(eof = true)
       @token = lexer.next_string_token(token.delimiter_state)
-      token.type.should eq(:DELIMITER_END)
+      token.type.should eq(t :DELIMITER_END)
       if eof
         should_have_reached_eof
       end
@@ -91,7 +95,7 @@ module LexerObjects
 
     def should_have_reached_eof
       @token = lexer.next_token
-      token.type.should eq(:EOF)
+      token.type.should eq(t :EOF)
     end
 
     private getter :lexer, :token

--- a/spec/compiler/lexer/lexer_spec.cr
+++ b/spec/compiler/lexer/lexer_spec.cr
@@ -1,6 +1,10 @@
 require "../../support/syntax"
 
-private def it_lexes(string, type, *, slash_is_regex : Bool? = nil)
+private def t(kind : Crystal::Token::Kind)
+  kind
+end
+
+private def it_lexes(string, type : Token::Kind, *, slash_is_regex : Bool? = nil)
   it "lexes #{string.inspect}" do
     lexer = Lexer.new string
     unless (v = slash_is_regex).nil?
@@ -11,7 +15,7 @@ private def it_lexes(string, type, *, slash_is_regex : Bool? = nil)
   end
 end
 
-private def it_lexes(string, type, value)
+private def it_lexes(string, type : Token::Kind, value)
   it "lexes #{string.inspect}" do
     lexer = Lexer.new string
     token = lexer.next_token
@@ -20,7 +24,7 @@ private def it_lexes(string, type, value)
   end
 end
 
-private def it_lexes(string, type, value, number_kind)
+private def it_lexes(string, type : Token::Kind, value, number_kind)
   it "lexes #{string.inspect}" do
     lexer = Lexer.new string
     token = lexer.next_token
@@ -30,7 +34,7 @@ private def it_lexes(string, type, value, number_kind)
   end
 end
 
-private def it_lexes_many(values, type)
+private def it_lexes_many(values, type : Token::Kind)
   values.each do |value|
     it_lexes value, type, value
   end
@@ -84,7 +88,7 @@ private def it_lexes_char(string, value)
   it "lexes #{string}" do
     lexer = Lexer.new string
     token = lexer.next_token
-    token.type.should eq(:CHAR)
+    token.type.should eq(t :CHAR)
     token.value.as(Char).should eq(value)
   end
 end
@@ -93,7 +97,7 @@ private def it_lexes_string(string, value)
   it "lexes #{string}" do
     lexer = Lexer.new string
     token = lexer.next_token
-    token.type.should eq(:DELIMITER_START)
+    token.type.should eq(t :DELIMITER_START)
 
     token = lexer.next_string_token(token.delimiter_state)
     token.value.should eq(value)
@@ -102,7 +106,13 @@ end
 
 private def it_lexes_operators(ops)
   ops.each do |op|
-    it_lexes op.to_s, op, slash_is_regex: false
+    it "lexes #{op.inspect}" do
+      lexer = Lexer.new op
+      lexer.slash_is_regex = false
+      token = lexer.next_token
+      token.type.operator?.should be_true
+      token.type.to_s.should eq(op)
+    end
   end
 end
 
@@ -250,18 +260,18 @@ describe "Lexer" do
   it_lexes_char "'\\\\'", '\\'
   assert_syntax_error "'", "unterminated char literal"
   assert_syntax_error "'\\", "unterminated char literal"
-  it_lexes_operators [:"=", :"<", :"<=", :">", :">=", :"+", :"-", :"*", :"/", :"//", :"(", :")",
-                      :"==", :"!=", :"=~", :"!", :",", :".", :"..", :"...", :"&&", :"||",
-                      :"|", :"{", :"}", :"?", :":", :"+=", :"-=", :"*=", :"/=", :"%=", :"//=", :"&=",
-                      :"|=", :"^=", :"**=", :"<<", :">>", :"%", :"&", :"|", :"^", :"**", :"<<=",
-                      :">>=", :"~", :"[]", :"[]=", :"[", :"]", :"::", :"<=>", :"=>", :"||=",
-                      :"&&=", :"===", :";", :"->", :"[]?", :"{%", :"{{", :"%}", :"@[", :"!~",
-                      :"&+", :"&-", :"&*", :"&**", :"&+=", :"&-=", :"&*="]
-  it_lexes "!@foo", :"!"
-  it_lexes "+@foo", :"+"
-  it_lexes "-@foo", :"-"
-  it_lexes "&+@foo", :"&+"
-  it_lexes "&-@foo", :"&-"
+  it_lexes_operators ["=", "<", "<=", ">", ">=", "+", "-", "*", "/", "//", "(", ")",
+                      "==", "!=", "=~", "!", ",", ".", "..", "...", "&&", "||",
+                      "|", "{", "}", "?", ":", "+=", "-=", "*=", "/=", "%=", "//=", "&=",
+                      "|=", "^=", "**=", "<<", ">>", "%", "&", "|", "^", "**", "<<=",
+                      ">>=", "~", "[]", "[]=", "[", "]", "::", "<=>", "=>", "||=",
+                      "&&=", "===", ";", "->", "[]?", "{%", "{{", "%}", "@[", "!~",
+                      "&+", "&-", "&*", "&**", "&+=", "&-=", "&*="]
+  it_lexes "!@foo", :OP_BANG
+  it_lexes "+@foo", :OP_PLUS
+  it_lexes "-@foo", :OP_MINUS
+  it_lexes "&+@foo", :OP_AMP_PLUS
+  it_lexes "&-@foo", :OP_AMP_MINUS
   it_lexes_const "Foo"
   it_lexes_instance_var "@foo"
   it_lexes_class_var "@@foo"
@@ -273,8 +283,8 @@ describe "Lexer" do
 
   it_lexes_global_match_data_index ["$1", "$10", "$1?", "$23?"]
 
-  it_lexes "$~", :"$~"
-  it_lexes "$?", :"$?"
+  it_lexes "$~", :OP_DOLLAR_TILDE
+  it_lexes "$?", :OP_DOLLAR_QUESTION
 
   assert_syntax_error "128_i8", "128 doesn't fit in an Int8"
   assert_syntax_error "-129_i8", "-129 doesn't fit in an Int8"
@@ -397,72 +407,72 @@ describe "Lexer" do
   it "lexes not instance var" do
     lexer = Lexer.new "!@foo"
     token = lexer.next_token
-    token.type.should eq(:"!")
+    token.type.should eq(t :OP_BANG)
     token = lexer.next_token
-    token.type.should eq(:INSTANCE_VAR)
+    token.type.should eq(t :INSTANCE_VAR)
     token.value.should eq("@foo")
   end
 
   it "lexes space after keyword" do
     lexer = Lexer.new "end 1"
     token = lexer.next_token
-    token.type.should eq(:IDENT)
+    token.type.should eq(t :IDENT)
     token.value.should eq(:end)
     token = lexer.next_token
-    token.type.should eq(:SPACE)
+    token.type.should eq(t :SPACE)
   end
 
   it "lexes space after char" do
     lexer = Lexer.new "'a' "
     token = lexer.next_token
-    token.type.should eq(:CHAR)
+    token.type.should eq(t :CHAR)
     token.value.should eq('a')
     token = lexer.next_token
-    token.type.should eq(:SPACE)
+    token.type.should eq(t :SPACE)
   end
 
   it "lexes comment and token" do
     lexer = Lexer.new "# comment\n="
     token = lexer.next_token
-    token.type.should eq(:NEWLINE)
+    token.type.should eq(t :NEWLINE)
     token = lexer.next_token
-    token.type.should eq(:"=")
+    token.type.should eq(t :OP_EQ)
   end
 
   it "lexes comment at the end" do
     lexer = Lexer.new "# comment"
     token = lexer.next_token
-    token.type.should eq(:EOF)
+    token.type.should eq(t :EOF)
   end
 
   it "lexes __LINE__" do
     lexer = Lexer.new "__LINE__"
     token = lexer.next_token
-    token.type.should eq(:__LINE__)
+    token.type.should eq(t :MAGIC_LINE)
   end
 
   it "lexes __FILE__" do
     lexer = Lexer.new "__FILE__"
     lexer.filename = "foo"
     token = lexer.next_token
-    token.type.should eq(:__FILE__)
+    token.type.should eq(t :MAGIC_FILE)
   end
 
   it "lexes __DIR__" do
     lexer = Lexer.new "__DIR__"
     token = lexer.next_token
-    token.type.should eq(:__DIR__)
+    token.type.should eq(t :MAGIC_DIR)
   end
 
   it "lexes dot and ident" do
     lexer = Lexer.new ".read"
     token = lexer.next_token
-    token.type.should eq(:".")
+    token.type.should eq(t :OP_PERIOD)
     token = lexer.next_token
-    token.type.should eq(:IDENT)
+    token.type.should eq(t :IDENT)
     token.value.should eq("read")
     token = lexer.next_token
-    token.type.should eq(:EOF)
+    token.type.should eq(t :EOF)
   end
 
   assert_syntax_error "/foo", "Unterminated regular expression"
@@ -472,31 +482,31 @@ describe "Lexer" do
   it "lexes utf-8 char" do
     lexer = Lexer.new "'á'"
     token = lexer.next_token
-    token.type.should eq(:CHAR)
+    token.type.should eq(t :CHAR)
     token.value.as(Char).ord.should eq(225)
   end
 
   it "lexes utf-8 multibyte char" do
     lexer = Lexer.new "'日'"
     token = lexer.next_token
-    token.type.should eq(:CHAR)
+    token.type.should eq(t :CHAR)
     token.value.as(Char).ord.should eq(26085)
   end
 
   it "doesn't raise if slash r with slash n" do
     lexer = Lexer.new("\r\n1")
     token = lexer.next_token
-    token.type.should eq(:NEWLINE)
+    token.type.should eq(t :NEWLINE)
     token = lexer.next_token
-    token.type.should eq(:NUMBER)
+    token.type.should eq(t :NUMBER)
   end
 
   it "doesn't raise if many slash r with slash n" do
     lexer = Lexer.new("\r\n\r\n\r\n1")
     token = lexer.next_token
-    token.type.should eq(:NEWLINE)
+    token.type.should eq(t :NEWLINE)
     token = lexer.next_token
-    token.type.should eq(:NUMBER)
+    token.type.should eq(t :NUMBER)
   end
 
   assert_syntax_error "\r1", "expected '\\n' after '\\r'"
@@ -504,99 +514,99 @@ describe "Lexer" do
   it "lexes char with unicode codepoint" do
     lexer = Lexer.new "'\\uFEDA'"
     token = lexer.next_token
-    token.type.should eq(:CHAR)
+    token.type.should eq(t :CHAR)
     token.value.as(Char).ord.should eq(0xFEDA)
   end
 
   it "lexes char with unicode codepoint and curly with zeros" do
     lexer = Lexer.new "'\\u{0}'"
     token = lexer.next_token
-    token.type.should eq(:CHAR)
+    token.type.should eq(t :CHAR)
     token.value.as(Char).ord.should eq(0)
   end
 
   it "lexes char with unicode codepoint and curly" do
     lexer = Lexer.new "'\\u{A5}'"
     token = lexer.next_token
-    token.type.should eq(:CHAR)
+    token.type.should eq(t :CHAR)
     token.value.as(Char).ord.should eq(0xA5)
   end
 
   it "lexes char with unicode codepoint and curly with six hex digits" do
     lexer = Lexer.new "'\\u{10FFFF}'"
     token = lexer.next_token
-    token.type.should eq(:CHAR)
+    token.type.should eq(t :CHAR)
     token.value.as(Char).ord.should eq(0x10FFFF)
   end
 
   it "lexes float then zero (bug)" do
     lexer = Lexer.new "2.5 0"
     lexer.next_token.number_kind.should eq(:f64)
-    lexer.next_token.type.should eq(:SPACE)
+    lexer.next_token.type.should eq(t :SPACE)
     token = lexer.next_token
-    token.type.should eq(:NUMBER)
+    token.type.should eq(t :NUMBER)
     token.number_kind.should eq(:i32)
   end
 
   it "lexes symbol with quote" do
     lexer = Lexer.new %(:"\\"")
     token = lexer.next_token
-    token.type.should eq(:SYMBOL)
+    token.type.should eq(t :SYMBOL)
     token.value.should eq("\"")
   end
 
   it "lexes symbol with backslash (#2187)" do
     lexer = Lexer.new %(:"\\\\")
     token = lexer.next_token
-    token.type.should eq(:SYMBOL)
+    token.type.should eq(t :SYMBOL)
     token.value.should eq("\\")
   end
 
   it "lexes symbol followed by !=" do
     lexer = Lexer.new ":a!=:a"
     token = lexer.next_token
-    token.type.should eq(:SYMBOL)
+    token.type.should eq(t :SYMBOL)
     token.value.should eq("a")
     token = lexer.next_token
-    token.type.should eq(:"!=")
+    token.type.should eq(t :OP_BANG_EQ)
     token = lexer.next_token
-    token.type.should eq(:SYMBOL)
+    token.type.should eq(t :SYMBOL)
     token.value.should eq("a")
   end
 
   it "lexes symbol followed by ==" do
     lexer = Lexer.new ":a==:a"
     token = lexer.next_token
-    token.type.should eq(:SYMBOL)
+    token.type.should eq(t :SYMBOL)
     token.value.should eq("a")
     token = lexer.next_token
-    token.type.should eq(:"==")
+    token.type.should eq(t :OP_EQ_EQ)
     token = lexer.next_token
-    token.type.should eq(:SYMBOL)
+    token.type.should eq(t :SYMBOL)
     token.value.should eq("a")
   end
 
   it "lexes symbol followed by ===" do
     lexer = Lexer.new ":a===:a"
     token = lexer.next_token
-    token.type.should eq(:SYMBOL)
+    token.type.should eq(t :SYMBOL)
     token.value.should eq("a")
     token = lexer.next_token
-    token.type.should eq(:"===")
+    token.type.should eq(t :OP_EQ_EQ_EQ)
     token = lexer.next_token
-    token.type.should eq(:SYMBOL)
+    token.type.should eq(t :SYMBOL)
     token.value.should eq("a")
   end
 
   it "lexes != after identifier (#4815)" do
     lexer = Lexer.new("some_method!=5")
     token = lexer.next_token
-    token.type.should eq(:IDENT)
+    token.type.should eq(t :IDENT)
     token.value.should eq("some_method")
     token = lexer.next_token
-    token.type.should eq(:"!=")
+    token.type.should eq(t :OP_BANG_EQ)
     token = lexer.next_token
-    token.type.should eq(:NUMBER)
+    token.type.should eq(t :NUMBER)
   end
 
   assert_syntax_error "'\\uFEDZ'", "expected hexadecimal character in unicode escape"

--- a/spec/compiler/lexer/lexer_string_array_spec.cr
+++ b/spec/compiler/lexer/lexer_string_array_spec.cr
@@ -1,19 +1,23 @@
 require "../../support/syntax"
 
+private def t(kind : Crystal::Token::Kind)
+  kind
+end
+
 private def it_should_be_valid_string_array_lexer(lexer)
   token = lexer.next_token
-  token.type.should eq(:STRING_ARRAY_START)
+  token.type.should eq(t :STRING_ARRAY_START)
 
   token = lexer.next_string_array_token
-  token.type.should eq(:STRING)
+  token.type.should eq(t :STRING)
   token.value.should eq("one")
 
   token = lexer.next_string_array_token
-  token.type.should eq(:STRING)
+  token.type.should eq(t :STRING)
   token.value.should eq("two")
 
   token = lexer.next_string_array_token
-  token.type.should eq(:STRING_ARRAY_END)
+  token.type.should eq(t :STRING_ARRAY_END)
 end
 
 describe "Lexer string array" do
@@ -27,18 +31,18 @@ describe "Lexer string array" do
     lexer = Lexer.new("%w(one \n two)")
 
     token = lexer.next_token
-    token.type.should eq(:STRING_ARRAY_START)
+    token.type.should eq(t :STRING_ARRAY_START)
 
     token = lexer.next_string_array_token
-    token.type.should eq(:STRING)
+    token.type.should eq(t :STRING)
     token.value.should eq("one")
 
     token = lexer.next_string_array_token
-    token.type.should eq(:STRING)
+    token.type.should eq(t :STRING)
     token.value.should eq("two")
 
     token = lexer.next_string_array_token
-    token.type.should eq(:STRING_ARRAY_END)
+    token.type.should eq(t :STRING_ARRAY_END)
   end
 
   it "lexes string array with new line gives correct column for next token" do

--- a/spec/compiler/lexer/lexer_string_spec.cr
+++ b/spec/compiler/lexer/lexer_string_spec.cr
@@ -240,7 +240,7 @@ describe "Lexer string" do
     expect_raises Crystal::SyntaxException, "Unterminated heredoc" do
       loop do
         token = lexer.next_string_token state
-        break if token.type == :DELIMITER_END
+        break if token.type.delimiter_end?
       end
     end
   end

--- a/spec/compiler/lexer/location_spec.cr
+++ b/spec/compiler/lexer/location_spec.cr
@@ -1,6 +1,10 @@
 require "../../support/syntax"
 
-private def assert_token_column_number(lexer, type, column_number)
+private def t(kind : Crystal::Token::Kind)
+  kind
+end
+
+private def assert_token_column_number(lexer, type : Token::Kind, column_number)
   token = lexer.next_token
   token.type.should eq(type)
   token.column_number.should eq(column_number)
@@ -10,28 +14,28 @@ describe "Lexer: location" do
   it "stores line numbers" do
     lexer = Lexer.new "1\n2"
     token = lexer.next_token
-    token.type.should eq(:NUMBER)
+    token.type.should eq(t :NUMBER)
     token.line_number.should eq(1)
 
     token = lexer.next_token
-    token.type.should eq(:NEWLINE)
+    token.type.should eq(t :NEWLINE)
     token.line_number.should eq(1)
 
     token = lexer.next_token
-    token.type.should eq(:NUMBER)
+    token.type.should eq(t :NUMBER)
     token.line_number.should eq(2)
   end
 
   it "stores column numbers" do
     lexer = Lexer.new "1;  ident; def;\n4"
     assert_token_column_number lexer, :NUMBER, 1
-    assert_token_column_number lexer, :";", 2
+    assert_token_column_number lexer, :OP_SEMICOLON, 2
     assert_token_column_number lexer, :SPACE, 3
     assert_token_column_number lexer, :IDENT, 5
-    assert_token_column_number lexer, :";", 10
+    assert_token_column_number lexer, :OP_SEMICOLON, 10
     assert_token_column_number lexer, :SPACE, 11
     assert_token_column_number lexer, :IDENT, 12
-    assert_token_column_number lexer, :";", 15
+    assert_token_column_number lexer, :OP_SEMICOLON, 15
     assert_token_column_number lexer, :NEWLINE, 16
     assert_token_column_number lexer, :NUMBER, 1
   end
@@ -41,28 +45,28 @@ describe "Lexer: location" do
     lexer.filename = "bar"
 
     token = lexer.next_token
-    token.type.should eq(:NUMBER)
+    token.type.should eq(t :NUMBER)
     token.line_number.should eq(1)
     token.column_number.should eq(1)
     token.filename.should eq("bar")
 
     token = lexer.next_token
-    token.type.should eq(:SPACE)
+    token.type.should eq(t :SPACE)
     token.line_number.should eq(1)
     token.column_number.should eq(2)
 
     token = lexer.next_token
-    token.type.should eq(:"+")
+    token.type.should eq(t :OP_PLUS)
     token.line_number.should eq(1)
     token.column_number.should eq(3)
 
     token = lexer.next_token
-    token.type.should eq(:SPACE)
+    token.type.should eq(t :SPACE)
     token.line_number.should eq(1)
     token.column_number.should eq(4)
 
     token = lexer.next_token
-    token.type.should eq(:NUMBER)
+    token.type.should eq(t :NUMBER)
     token.line_number.should eq(12)
     token.column_number.should eq(34)
     token.filename.should eq("foo")
@@ -73,28 +77,28 @@ describe "Lexer: location" do
     lexer.filename = "bar"
 
     token = lexer.next_token
-    token.type.should eq(:NUMBER)
+    token.type.should eq(t :NUMBER)
     token.line_number.should eq(12)
     token.column_number.should eq(34)
     token.filename.should eq("foo")
 
     token = lexer.next_token
-    token.type.should eq(:SPACE)
+    token.type.should eq(t :SPACE)
     token.line_number.should eq(12)
     token.column_number.should eq(35)
 
     token = lexer.next_token
-    token.type.should eq(:"+")
+    token.type.should eq(t :OP_PLUS)
     token.line_number.should eq(12)
     token.column_number.should eq(36)
 
     token = lexer.next_token
-    token.type.should eq(:SPACE)
+    token.type.should eq(t :SPACE)
     token.line_number.should eq(12)
     token.column_number.should eq(37)
 
     token = lexer.next_token
-    token.type.should eq(:NUMBER)
+    token.type.should eq(t :NUMBER)
     token.line_number.should eq(1)
     token.column_number.should eq(44)
     token.filename.should eq("bar")
@@ -105,13 +109,13 @@ describe "Lexer: location" do
     lexer.filename = "bar"
 
     token = lexer.next_token
-    token.type.should eq(:NUMBER)
+    token.type.should eq(t :NUMBER)
     token.line_number.should eq(1)
     token.column_number.should eq(1)
     token.filename.should eq("bar")
 
     token = lexer.next_token
-    token.type.should eq(:NUMBER)
+    token.type.should eq(t :NUMBER)
     token.line_number.should eq(56)
     token.column_number.should eq(78)
     token.filename.should eq("foo")

--- a/spec/compiler/parser/parser_spec.cr
+++ b/spec/compiler/parser/parser_spec.cr
@@ -1513,11 +1513,11 @@ module Crystal
     it_parses "__FILE__", "/foo/bar/baz.cr".string
     it_parses "__DIR__", "/foo/bar".string
 
-    it_parses "def foo(x = __LINE__); end", Def.new("foo", args: [Arg.new("x", default_value: MagicConstant.new(:__LINE__))])
-    it_parses "def foo(x = __FILE__); end", Def.new("foo", args: [Arg.new("x", default_value: MagicConstant.new(:__FILE__))])
-    it_parses "def foo(x = __DIR__); end", Def.new("foo", args: [Arg.new("x", default_value: MagicConstant.new(:__DIR__))])
+    it_parses "def foo(x = __LINE__); end", Def.new("foo", args: [Arg.new("x", default_value: MagicConstant.new(:MAGIC_LINE))])
+    it_parses "def foo(x = __FILE__); end", Def.new("foo", args: [Arg.new("x", default_value: MagicConstant.new(:MAGIC_FILE))])
+    it_parses "def foo(x = __DIR__); end", Def.new("foo", args: [Arg.new("x", default_value: MagicConstant.new(:MAGIC_DIR))])
 
-    it_parses "macro foo(x = __LINE__);end", Macro.new("foo", body: Expressions.new, args: [Arg.new("x", default_value: MagicConstant.new(:__LINE__))])
+    it_parses "macro foo(x = __LINE__);end", Macro.new("foo", body: Expressions.new, args: [Arg.new("x", default_value: MagicConstant.new(:MAGIC_LINE))])
 
     it_parses "1 \\\n + 2", Call.new(1.int32, "+", 2.int32)
     it_parses "1\\\n + 2", Call.new(1.int32, "+", 2.int32)

--- a/src/compiler/crystal/codegen/call.cr
+++ b/src/compiler/crystal/codegen/call.cr
@@ -126,13 +126,13 @@ class Crystal::CodeGenVisitor
       location = node.location
       end_location = node.end_location
       case default_value.name
-      when :__LINE__
+      when .magic_line?
         call_args << int32(MagicConstant.expand_line(location))
-      when :__END_LINE__
+      when .magic_end_line?
         call_args << int32(MagicConstant.expand_line(end_location))
-      when :__FILE__
+      when .magic_file?
         call_args << build_string_constant(MagicConstant.expand_file(location))
-      when :__DIR__
+      when .magic_dir?
         call_args << build_string_constant(MagicConstant.expand_dir(location))
       else
         default_value.raise "BUG: unknown magic constant: #{default_value.name}"

--- a/src/compiler/crystal/interpreter/compiler.cr
+++ b/src/compiler/crystal/interpreter/compiler.cr
@@ -2172,15 +2172,15 @@ class Crystal::Repl::Compiler < Crystal::Visitor
       location = node.location
       end_location = node.end_location
       case default_value.name
-      when :__LINE__
+      when .magic_line?
         put_i32 MagicConstant.expand_line(location), node: node
-      when :__END_LINE__
+      when .magic_end_line?
         # TODO: not tested
         put_i32 MagicConstant.expand_line(end_location), node: node
-      when :__FILE__
+      when .magic_file?
         # TODO: not tested
         put_string MagicConstant.expand_file(location), node: node
-      when :__DIR__
+      when .magic_dir?
         # TODO: not tested
         put_string MagicConstant.expand_dir(location), node: node
       else

--- a/src/compiler/crystal/semantic/call.cr
+++ b/src/compiler/crystal/semantic/call.cr
@@ -1185,9 +1185,9 @@ class Crystal::Call
       arg = typed_def.args[index]
       default_value = arg.default_value.as(MagicConstant)
       case default_value.name
-      when :__LINE__, :__END_LINE__
+      when .magic_line?, .magic_end_line?
         type = program.int32
-      when :__FILE__, :__DIR__
+      when .magic_file?, .magic_dir?
         type = program.string
       else
         default_value.raise "BUG: unknown magic constant: #{default_value.name}"

--- a/src/compiler/crystal/semantic/method_missing.cr
+++ b/src/compiler/crystal/semantic/method_missing.cr
@@ -181,7 +181,7 @@ private def starts_with_def?(source)
   while true
     token = lexer.next_token
     return true if token.keyword?(:def)
-    break if token.type == :EOF
+    break if token.type.eof?
   end
   false
 end

--- a/src/compiler/crystal/syntax/ast.cr
+++ b/src/compiler/crystal/syntax/ast.cr
@@ -2196,9 +2196,9 @@ module Crystal
   end
 
   class MagicConstant < ASTNode
-    property name : Symbol
+    property name : Token::Kind
 
-    def initialize(@name : Symbol)
+    def initialize(@name : Token::Kind)
     end
 
     def clone_without_location
@@ -2207,13 +2207,13 @@ module Crystal
 
     def expand_node(location, end_location)
       case name
-      when :__LINE__
+      when .magic_line?
         MagicConstant.expand_line_node(location)
-      when :__END_LINE__
+      when .magic_end_line?
         MagicConstant.expand_line_node(end_location)
-      when :__FILE__
+      when .magic_file?
         MagicConstant.expand_file_node(location)
-      when :__DIR__
+      when .magic_dir?
         MagicConstant.expand_dir_node(location)
       else
         raise "BUG: unknown magic constant: #{name}"

--- a/src/compiler/crystal/syntax/lexer.cr
+++ b/src/compiler/crystal/syntax/lexer.cr
@@ -170,39 +170,39 @@ module Crystal
         when '='
           case next_char
           when '='
-            next_char :"==="
+            next_char :OP_EQ_EQ_EQ
           else
-            @token.type = :"=="
+            @token.type = :OP_EQ_EQ
           end
         when '>'
-          next_char :"=>"
+          next_char :OP_EQ_GT
         when '~'
-          next_char :"=~"
+          next_char :OP_EQ_TILDE
         else
-          @token.type = :"="
+          @token.type = :OP_EQ
         end
       when '!'
         case next_char
         when '='
-          next_char :"!="
+          next_char :OP_BANG_EQ
         when '~'
-          next_char :"!~"
+          next_char :OP_BANG_TILDE
         else
-          @token.type = :"!"
+          @token.type = :OP_BANG
         end
       when '<'
         case next_char
         when '='
           case next_char
           when '>'
-            next_char :"<=>"
+            next_char :OP_LT_EQ_GT
           else
-            @token.type = :"<="
+            @token.type = :OP_LT_EQ
           end
         when '<'
           case next_char
           when '='
-            next_char :"<<="
+            next_char :OP_LT_LT_EQ
           when '-'
             has_single_quote = false
             found_closing_single_quote = false
@@ -263,64 +263,64 @@ module Crystal
 
             delimited_pair :heredoc, here, here, start, allow_escapes: !has_single_quote, advance: false
           else
-            @token.type = :"<<"
+            @token.type = :OP_LT_LT
           end
         else
-          @token.type = :"<"
+          @token.type = :OP_LT
         end
       when '>'
         case next_char
         when '='
-          next_char :">="
+          next_char :OP_GT_EQ
         when '>'
           case next_char
           when '='
-            next_char :">>="
+            next_char :OP_GT_GT_EQ
           else
-            @token.type = :">>"
+            @token.type = :OP_GT_GT
           end
         else
-          @token.type = :">"
+          @token.type = :OP_GT
         end
       when '+'
         @token.start = start
         case next_char
         when '='
-          next_char :"+="
+          next_char :OP_PLUS_EQ
         when '0'..'9'
           scan_number start
         when '+'
           raise "postfix increment is not supported, use `exp += 1`"
         else
-          @token.type = :"+"
+          @token.type = :OP_PLUS
         end
       when '-'
         @token.start = start
         case next_char
         when '='
-          next_char :"-="
+          next_char :OP_MINUS_EQ
         when '>'
-          next_char :"->"
+          next_char :OP_MINUS_GT
         when '0'..'9'
           scan_number start, negative: true
         when '-'
           raise "postfix decrement is not supported, use `exp -= 1`"
         else
-          @token.type = :"-"
+          @token.type = :OP_MINUS
         end
       when '*'
         case next_char
         when '='
-          next_char :"*="
+          next_char :OP_STAR_EQ
         when '*'
           case next_char
           when '='
-            next_char :"**="
+            next_char :OP_STAR_STAR_EQ
           else
-            @token.type = :"**"
+            @token.type = :OP_STAR_STAR
           end
         else
-          @token.type = :"*"
+          @token.type = :OP_STAR
         end
       when '/'
         line = @line_number
@@ -329,34 +329,34 @@ module Crystal
         if (@wants_def_or_macro_name || !@slash_is_regex) && char == '/'
           case next_char
           when '='
-            next_char :"//="
+            next_char :OP_SLASH_SLASH_EQ
           else
-            @token.type = :"//"
+            @token.type = :OP_SLASH_SLASH
           end
         elsif !@slash_is_regex && char == '='
-          next_char :"/="
+          next_char :OP_SLASH_EQ
         elsif @wants_def_or_macro_name
-          @token.type = :"/"
+          @token.type = :OP_SLASH
         elsif @slash_is_regex
           @token.type = :DELIMITER_START
           @token.delimiter_state = Token::DelimiterState.new(:regex, '/', '/')
           @token.raw = "/"
         elsif char.ascii_whitespace? || char == '\0'
-          @token.type = :"/"
+          @token.type = :OP_SLASH
         elsif @wants_regex
           @token.type = :DELIMITER_START
           @token.delimiter_state = Token::DelimiterState.new(:regex, '/', '/')
           @token.raw = "/"
         else
-          @token.type = :"/"
+          @token.type = :OP_SLASH
         end
       when '%'
         if @wants_def_or_macro_name
-          next_char :"%"
+          next_char :OP_PERCENT
         else
           case next_char
           when '='
-            next_char :"%="
+            next_char :OP_PERCENT_EQ
           when '(', '[', '{', '<', '|'
             delimited_pair :string, current_char, closing_char, start
           when 'i'
@@ -367,7 +367,7 @@ module Crystal
               @token.raw = "%i#{start_char}" if @wants_raw
               @token.delimiter_state = Token::DelimiterState.new(:symbol_array, start_char, closing_char(start_char))
             else
-              @token.type = :"%"
+              @token.type = :OP_PERCENT
             end
           when 'q'
             case peek_next_char
@@ -375,7 +375,7 @@ module Crystal
               next_char
               delimited_pair :string, current_char, closing_char, start, allow_escapes: false
             else
-              @token.type = :"%"
+              @token.type = :OP_PERCENT
             end
           when 'Q'
             case peek_next_char
@@ -383,7 +383,7 @@ module Crystal
               next_char
               delimited_pair :string, current_char, closing_char, start
             else
-              @token.type = :"%"
+              @token.type = :OP_PERCENT
             end
           when 'r'
             case next_char
@@ -407,54 +407,54 @@ module Crystal
               @token.raw = "%w#{start_char}" if @wants_raw
               @token.delimiter_state = Token::DelimiterState.new(:string_array, start_char, closing_char(start_char))
             else
-              @token.type = :"%"
+              @token.type = :OP_PERCENT
             end
           when '}'
-            next_char :"%}"
+            next_char :OP_PERCENT_CURLYR
           else
-            @token.type = :"%"
+            @token.type = :OP_PERCENT
           end
         end
-      when '(' then next_char :"("
-      when ')' then next_char :")"
+      when '(' then next_char :OP_BRACKETL
+      when ')' then next_char :OP_BRACKETR
       when '{'
         char = next_char
         case char
         when '%'
-          next_char :"{%"
+          next_char :OP_CURLYL_PERCENT
         when '{'
-          next_char :"{{"
+          next_char :OP_CURLYL_CURLYL
         else
-          @token.type = :"{"
+          @token.type = :OP_CURLYL
         end
-      when '}' then next_char :"}"
+      when '}' then next_char :OP_CURLYR
       when '['
         case next_char
         when ']'
           case next_char
           when '='
-            next_char :"[]="
+            next_char :OP_SQUAREL_SQUARER_EQ
           when '?'
-            next_char :"[]?"
+            next_char :OP_SQUAREL_SQUARER_QUESTION
           else
-            @token.type = :"[]"
+            @token.type = :OP_SQUAREL_SQUARER
           end
         else
-          @token.type = :"["
+          @token.type = :OP_SQUAREL
         end
-      when ']' then next_char :"]"
-      when ',' then next_char :","
-      when '?' then next_char :"?"
+      when ']' then next_char :OP_SQUARER
+      when ',' then next_char :OP_COMMA
+      when '?' then next_char :OP_QUESTION
       when ';'
         reset_regex_flags = false
-        next_char :";"
+        next_char :OP_SEMICOLON
       when ':'
         char = next_char
 
         if @wants_symbol
           case char
           when ':'
-            next_char :"::"
+            next_char :OP_COLON_COLON
           when '+'
             next_char_and_symbol "+"
           when '-'
@@ -619,19 +619,19 @@ module Crystal
               @token.value = string_range_from_pool(start)
               set_token_raw_from_start(start - 1)
             else
-              @token.type = :":"
+              @token.type = :OP_COLON
             end
           end
         else
           case char
           when ':'
-            next_char :"::"
+            next_char :OP_COLON_COLON
           else
-            @token.type = :":"
+            @token.type = :OP_COLON
           end
         end
       when '~'
-        next_char :"~"
+        next_char :OP_TILDE
       when '.'
         line = @line_number
         column = @column_number
@@ -639,79 +639,79 @@ module Crystal
         when '.'
           case next_char
           when '.'
-            next_char :"..."
+            next_char :OP_PERIOD_PERIOD_PERIOD
           else
-            @token.type = :".."
+            @token.type = :OP_PERIOD_PERIOD
           end
         when .ascii_number?
           raise ".1 style number literal is not supported, put 0 before dot", line, column
         else
-          @token.type = :"."
+          @token.type = :OP_PERIOD
         end
       when '&'
         case next_char
         when '&'
           case next_char
           when '='
-            next_char :"&&="
+            next_char :OP_AMP_AMP_EQ
           else
-            @token.type = :"&&"
+            @token.type = :OP_AMP_AMP
           end
         when '='
-          next_char :"&="
+          next_char :OP_AMP_EQ
         when '+'
           case next_char
           when '='
-            next_char :"&+="
+            next_char :OP_AMP_PLUS_EQ
           else
-            @token.type = :"&+"
+            @token.type = :OP_AMP_PLUS
           end
         when '-'
           # Check if '>' comes after '&-', making it '&->'.
           # We want to parse that like '&(->...)',
           # so we only return '&' for now.
           if peek_next_char == '>'
-            @token.type = :"&"
+            @token.type = :OP_AMP
           else
             case next_char
             when '='
-              next_char :"&-="
+              next_char :OP_AMP_MINUS_EQ
             else
-              @token.type = :"&-"
+              @token.type = :OP_AMP_MINUS
             end
           end
         when '*'
           case next_char
           when '*'
-            next_char :"&**"
+            next_char :OP_AMP_STAR_STAR
           when '='
-            next_char :"&*="
+            next_char :OP_AMP_STAR_EQ
           else
-            @token.type = :"&*"
+            @token.type = :OP_AMP_STAR
           end
         else
-          @token.type = :"&"
+          @token.type = :OP_AMP
         end
       when '|'
         case next_char
         when '|'
           case next_char
           when '='
-            next_char :"||="
+            next_char :OP_BAR_BAR_EQ
           else
-            @token.type = :"||"
+            @token.type = :OP_BAR_BAR
           end
         when '='
-          next_char :"|="
+          next_char :OP_BAR_EQ
         else
-          @token.type = :"|"
+          @token.type = :OP_BAR
         end
       when '^'
         case next_char
         when '='
-          next_char :"^="
+          next_char :OP_CARET_EQ
         else
-          @token.type = :"^"
+          @token.type = :OP_CARET
         end
       when '\''
         start = current_pos
@@ -766,7 +766,7 @@ module Crystal
       when '"', '`'
         delimiter = current_char
         if delimiter == '`' && @wants_def_or_macro_name
-          next_char :"`"
+          next_char :OP_GRAVE
         else
           next_char
           @token.type = :DELIMITER_START
@@ -779,7 +779,7 @@ module Crystal
         start = current_pos
         case next_char
         when '['
-          next_char :"@["
+          next_char :OP_AT_SQUAREL
         else
           class_var = false
           if current_char == '@'
@@ -790,7 +790,7 @@ module Crystal
             while ident_part?(next_char)
               # Nothing to do
             end
-            @token.type = class_var ? :CLASS_VAR : :INSTANCE_VAR
+            @token.type = class_var ? Token::Kind::CLASS_VAR : Token::Kind::INSTANCE_VAR
             @token.value = string_range_from_pool(start)
           else
             unknown_token
@@ -802,10 +802,10 @@ module Crystal
         case current_char
         when '~'
           next_char
-          @token.type = :"$~"
+          @token.type = :OP_DOLLAR_TILDE
         when '?'
           next_char
-          @token.type = :"$?"
+          @token.type = :OP_DOLLAR_QUESTION
         when .ascii_number?
           start = current_pos
           char = next_char
@@ -1245,7 +1245,7 @@ module Crystal
                 scan_ident(start)
               else
                 next_char
-                @token.type = :__DIR__
+                @token.type = :MAGIC_DIR
                 return @token
               end
             end
@@ -1255,7 +1255,7 @@ module Crystal
                 scan_ident(start)
               else
                 next_char
-                @token.type = :__END_LINE__
+                @token.type = :MAGIC_END_LINE
                 return @token
               end
             end
@@ -1265,7 +1265,7 @@ module Crystal
                 scan_ident(start)
               else
                 next_char
-                @token.type = :__FILE__
+                @token.type = :MAGIC_FILE
                 return @token
               end
             end
@@ -1275,7 +1275,7 @@ module Crystal
                 scan_ident(start)
               else
                 next_char
-                @token.type = :__LINE__
+                @token.type = :MAGIC_LINE
                 return @token
               end
             end
@@ -1650,7 +1650,7 @@ module Crystal
       string_open_count = delimiter_state.open_count
 
       # For empty heredocs:
-      if @token.type == :NEWLINE && delimiter_state.kind == :heredoc
+      if @token.type.newline? && delimiter_state.kind == :heredoc
         if check_heredoc_end delimiter_state
           set_token_raw_from_start start
           return @token
@@ -2761,7 +2761,7 @@ module Crystal
       char
     end
 
-    def next_char(token_type)
+    def next_char(token_type : Token::Kind)
       next_char
       @token.type = token_type
     end
@@ -2773,7 +2773,7 @@ module Crystal
       @token.filename = @filename
       @token.location = nil
       @token.passed_backslash_newline = false
-      @token.doc_buffer = nil unless @token.type == :SPACE || @token.type == :NEWLINE
+      @token.doc_buffer = nil unless @token.type.space? || @token.type.newline?
       @token.invalid_escape = false
       @token_end_location = nil
     end
@@ -2879,19 +2879,19 @@ module Crystal
     end
 
     def skip_space
-      while @token.type == :SPACE
+      while @token.type.space?
         next_token
       end
     end
 
     def skip_space_or_newline
-      while (@token.type == :SPACE || @token.type == :NEWLINE)
+      while (@token.type.space? || @token.type.newline?)
         next_token
       end
     end
 
     def skip_statement_end
-      while (@token.type == :SPACE || @token.type == :NEWLINE || @token.type == :";")
+      while (@token.type.space? || @token.type.newline? || @token.type.op_semicolon?)
         next_token
       end
     end

--- a/src/compiler/crystal/syntax/token.cr
+++ b/src/compiler/crystal/syntax/token.cr
@@ -2,7 +2,180 @@ require "./location"
 
 module Crystal
   class Token
-    property type : Symbol
+    enum Kind
+      EOF
+      SPACE
+      NEWLINE
+
+      IDENT
+      CONST
+      INSTANCE_VAR
+      CLASS_VAR
+
+      CHAR
+      STRING
+      SYMBOL
+      NUMBER
+
+      UNDERSCORE
+      COMMENT
+
+      DELIMITER_START
+      DELIMITER_END
+
+      STRING_ARRAY_START
+      INTERPOLATION_START
+      SYMBOL_ARRAY_START
+      STRING_ARRAY_END
+
+      GLOBAL
+      GLOBAL_MATCH_DATA_INDEX
+
+      MAGIC_DIR
+      MAGIC_END_LINE
+      MAGIC_FILE
+      MAGIC_LINE
+
+      MACRO_LITERAL
+      MACRO_EXPRESSION_START
+      MACRO_CONTROL_START
+      MACRO_VAR
+      MACRO_END
+
+      # the following operator kinds should be sorted by their codepoints
+      # refer to `#to_s` for the constant names of each individual character
+
+      OP_BANG                     # !
+      OP_BANG_EQ                  # !=
+      OP_BANG_TILDE               # !~
+      OP_DOLLAR_QUESTION          # $?
+      OP_DOLLAR_TILDE             # $~
+      OP_PERCENT                  # %
+      OP_PERCENT_EQ               # %=
+      OP_PERCENT_CURLYR           # %}
+      OP_AMP                      # &
+      OP_AMP_AMP                  # &&
+      OP_AMP_AMP_EQ               # &&=
+      OP_AMP_STAR                 # &*
+      OP_AMP_STAR_STAR            # &**
+      OP_AMP_STAR_EQ              # &*=
+      OP_AMP_PLUS                 # &+
+      OP_AMP_PLUS_EQ              # &+=
+      OP_AMP_MINUS                # &-
+      OP_AMP_MINUS_EQ             # &-=
+      OP_AMP_EQ                   # &=
+      OP_BRACKETL                 # (
+      OP_BRACKETR                 # )
+      OP_STAR                     # *
+      OP_STAR_STAR                # **
+      OP_STAR_STAR_EQ             # **=
+      OP_STAR_EQ                  # *=
+      OP_PLUS                     # +
+      OP_PLUS_EQ                  # +=
+      OP_COMMA                    # ,
+      OP_MINUS                    # -
+      OP_MINUS_EQ                 # -=
+      OP_MINUS_GT                 # ->
+      OP_PERIOD                   # .
+      OP_PERIOD_PERIOD            # ..
+      OP_PERIOD_PERIOD_PERIOD     # ...
+      OP_SLASH                    # /
+      OP_SLASH_SLASH              # //
+      OP_SLASH_SLASH_EQ           # //=
+      OP_SLASH_EQ                 # /=
+      OP_COLON                    # :
+      OP_COLON_COLON              # ::
+      OP_SEMICOLON                # ;
+      OP_LT                       # <
+      OP_LT_LT                    # <<
+      OP_LT_LT_EQ                 # <<=
+      OP_LT_EQ                    # <=
+      OP_LT_EQ_GT                 # <=>
+      OP_EQ                       # =
+      OP_EQ_EQ                    # ==
+      OP_EQ_EQ_EQ                 # ===
+      OP_EQ_GT                    # =>
+      OP_EQ_TILDE                 # =~
+      OP_GT                       # >
+      OP_GT_EQ                    # >=
+      OP_GT_GT                    # >>
+      OP_GT_GT_EQ                 # >>=
+      OP_QUESTION                 # ?
+      OP_AT_SQUAREL               # @[
+      OP_SQUAREL                  # [
+      OP_SQUAREL_SQUARER          # []
+      OP_SQUAREL_SQUARER_EQ       # []=
+      OP_SQUAREL_SQUARER_QUESTION # []?
+      OP_SQUARER                  # ]
+      OP_CARET                    # ^
+      OP_CARET_EQ                 # ^=
+      OP_GRAVE                    # `
+      OP_CURLYL                   # {
+      OP_CURLYL_PERCENT           # {%
+      OP_CURLYL_CURLYL            # {{
+      OP_BAR                      # |
+      OP_BAR_EQ                   # |=
+      OP_BAR_BAR                  # ||
+      OP_BAR_BAR_EQ               # ||=
+      OP_CURLYR                   # }
+      OP_TILDE                    # ~
+
+      # non-flag enums are special since the `IO` overload relies on the
+      # `String`-returning overload instead of the other way round
+      def to_s : String
+        {% begin %}
+          {%
+            operator1 = {
+              "BANG" => "!", "DOLLAR" => "$", "PERCENT" => "%", "AMP" => "&", "BRACKETL" => "(",
+              "BRACKETR" => ")", "STAR" => "*", "PLUS" => "+", "COMMA" => ",", "MINUS" => "-",
+              "PERIOD" => ".", "SLASH" => "/", "COLON" => ":", "SEMICOLON" => ";", "LT" => "<",
+              "EQ" => "=", "GT" => ">", "QUESTION" => "?", "AT" => "@", "SQUAREL" => "[",
+              "SQUARER" => "]", "CARET" => "^", "GRAVE" => "`", "CURLYL" => "{", "BAR" => "|",
+              "CURLYR" => "}", "TILDE" => "~",
+            }
+          %}
+
+          case value
+          {% for member in @type.constants %}
+          when {{ @type.constant(member) }}
+            {% if member.starts_with?("OP_") %}
+              {% parts = member.split("_") %}
+              {{ parts.map { |ch| operator1[ch] || "" }.join("") }}
+            {% elsif member.starts_with?("MAGIC_") %}
+              {{ "__#{member[6..-1].id}__" }}
+            {% else %}
+              {{ member.stringify }}
+            {% end %}
+          {% end %}
+          else
+            value.to_s
+          end
+        {% end %}
+      end
+
+      def operator?
+        value.in?(OP_BANG.value..OP_TILDE.value)
+      end
+
+      def assignment_operator?
+        # += -= *= /= //= %= |= &= ^= **= <<= >>= ||= &&= &+= &-= &*=
+        case self
+        when .op_plus_eq?, .op_minus_eq?, .op_star_eq?, .op_slash_eq?, .op_slash_slash_eq?,
+             .op_percent_eq?, .op_bar_eq?, .op_amp_eq?, .op_caret_eq?, .op_star_star_eq?,
+             .op_lt_lt_eq?, .op_gt_gt_eq?, .op_bar_bar_eq?, .op_amp_amp_eq?, .op_amp_plus_eq?,
+             .op_amp_minus_eq?, .op_amp_star_eq?
+          true
+        else
+          false
+        end
+      end
+
+      def magic?
+        magic_dir? || magic_end_line? || magic_file? || magic_line?
+      end
+    end
+
+    property type : Kind
     property value : Char | String | Symbol | Nil
     property number_kind : Symbol
     property line_number : Int32
@@ -69,7 +242,7 @@ module Crystal
     end
 
     def initialize
-      @type = :EOF
+      @type = Kind::EOF
       @number_kind = :i32
       @line_number = 0
       @column_number = 0
@@ -95,15 +268,15 @@ module Crystal
     end
 
     def token?(token)
-      @type == :TOKEN && @value == token
+      @type.token? && @value == token
     end
 
     def keyword?
-      @type == :IDENT && @value.is_a?(Symbol)
+      @type.ident? && @value.is_a?(Symbol)
     end
 
     def keyword?(keyword)
-      @type == :IDENT && @value == keyword
+      @type.ident? && @value == keyword
     end
 
     def copy_from(other)

--- a/src/compiler/crystal/tools/formatter.cr
+++ b/src/compiler/crystal/tools/formatter.cr
@@ -137,7 +137,7 @@ module Crystal
       @doc_comments = [] of CommentInfo
       @current_doc_comment = nil
       @hash_in_same_line = Set(ASTNode).new.compare_by_identity
-      @shebang = @token.type == :COMMENT && @token.value.to_s.starts_with?("#!")
+      @shebang = @token.type.comment? && @token.value.to_s.starts_with?("#!")
       @heredoc_fixes = [] of HeredocFix
       @last_is_heredoc = false
       @last_arg_is_skip = false
@@ -166,25 +166,25 @@ module Crystal
     end
 
     def visit(node : Expressions)
-      if node.expressions.size == 1 && @token.type == :"("
+      if node.expressions.size == 1 && @token.type.op_bracketl?
         # If it's (...) with a single expression, we treat it
         # like a single expression, indenting it if needed
         write "("
         next_token_skip_space
-        if @token.type == :NEWLINE
+        if @token.type.newline?
           next_token_skip_space_or_newline
           write_line
           write_indent(@indent + 2, node.expressions.first)
           skip_space_write_line
           skip_space_or_newline
           write_indent
-          write_token :")"
+          write_token :OP_BRACKETR
           return false
         end
         skip_space_or_newline
         accept node.expressions.first
         skip_space
-        if @token.type == :NEWLINE
+        if @token.type.newline?
           skip_space_or_newline
           write_line
           write_indent(@indent + 2)
@@ -205,12 +205,12 @@ module Crystal
 
       empty_expressions = node.expressions.size == 1 && node.expressions[0].is_a?(Nop)
 
-      if node.keyword == :"(" && @token.type == :"("
+      if node.keyword == :"(" && @token.type.op_bracketl?
         write "("
         next_needs_indent = false
         has_paren = true
         wrote_newline = next_token_skip_space
-        if @token.type == :NEWLINE || wrote_newline
+        if @token.type.newline? || wrote_newline
           @indent += 2
           write_line unless wrote_newline
           next_token_skip_space_or_newline
@@ -227,7 +227,7 @@ module Crystal
         # In this case, we should not skip space because it will do in the below loop.
         unless empty_expressions
           skip_space_or_newline
-          if @token.type == :";"
+          if @token.type.op_semicolon?
             next_token_skip_space_or_newline
           end
         end
@@ -266,12 +266,12 @@ module Crystal
 
         found_comment = skip_space
 
-        if @token.type == :";"
+        if @token.type.op_semicolon?
           if needs_two_lines
             skip_semicolon_or_space_or_newline
           else
             found_comment = skip_semicolon_or_space
-            if @token.type == :NEWLINE
+            if @token.type.newline?
               write_line
               next_token_skip_space
               next_needs_indent = true
@@ -321,7 +321,7 @@ module Crystal
       end
 
       if has_paren
-        write_token :")"
+        write_token :OP_BRACKETR
       end
 
       if has_begin
@@ -447,7 +447,7 @@ module Crystal
     end
 
     def visit(node : NumberLiteral)
-      if @token.type == :__LINE__
+      if @token.type.magic_line?
         write @token.type
         next_token
         return false
@@ -463,7 +463,7 @@ module Crystal
     def visit(node : StringLiteral)
       column = @column
 
-      if @token.type == :__FILE__ || @token.type == :__DIR__
+      if @token.type.magic_file? || @token.type.magic_dir?
         write @token.type
         next_token
         return false
@@ -477,23 +477,23 @@ module Crystal
 
       while true
         case @token.type
-        when :STRING
+        when .string?
           if @token.invalid_escape
             write @token.value
           else
             write @token.raw
           end
           next_string_token
-        when :INTERPOLATION_START
+        when .interpolation_start?
           # This is the case of #{__DIR__}
           write "\#{"
           next_token_skip_space_or_newline
           indent(@column, node)
           skip_space_or_newline
-          check :"}"
+          check :OP_CURLYR
           write "}"
           next_string_token
-        when :DELIMITER_END
+        when .delimiter_end?
           break
         else
           raise "Bug: unexpected token: #{@token.type}"
@@ -553,7 +553,7 @@ module Crystal
 
       # To detect the first content of interpolation of string literal correctly,
       # we should consume the first string token if this token contains only removed indentation of heredoc.
-      if is_heredoc && @token.type == :STRING
+      if is_heredoc && @token.type.string?
         token_is_indent = @token.raw.bytesize == node.heredoc_indent && @token.raw.each_char.all? &.ascii_whitespace?
         if token_is_indent
           write @token.raw
@@ -562,7 +562,7 @@ module Crystal
       end
 
       node.expressions.each do |exp|
-        if @token.type == :DELIMITER_END
+        if @token.type.delimiter_end?
           # Heredoc cannot contain string continuation,
           # so we are done.
           break if is_heredoc
@@ -584,13 +584,13 @@ module Crystal
 
         if exp.is_a?(StringLiteral)
           # It might be #{__DIR__}, for example
-          if @token.type == :INTERPOLATION_START
+          if @token.type.interpolation_start?
             write "\#{"
             delimiter_state = @token.delimiter_state
             next_token_skip_space_or_newline
             indent(@column, exp)
             skip_space_or_newline
-            check :"}"
+            check :OP_CURLYR
             write "}"
             @token.delimiter_state = delimiter_state
             next_string_token
@@ -602,7 +602,7 @@ module Crystal
 
               # On heredoc, pieces of contents are combined due to removing indentation.
               # Thus, we should consume continuous string tokens at once.
-              break if !is_heredoc || @token.type != :STRING
+              break if !is_heredoc || !@token.type.string?
             end
           end
         else
@@ -611,7 +611,7 @@ module Crystal
           delimiter_state = @token.delimiter_state
 
           wrote_comment = next_token_skip_space
-          has_newline = wrote_comment || @token.type == :NEWLINE
+          has_newline = wrote_comment || @token.type.newline?
           skip_space_or_newline
 
           if has_newline
@@ -625,7 +625,7 @@ module Crystal
           end
 
           skip_space_or_newline
-          check :"}"
+          check :OP_CURLYR
           write "}"
           @token.delimiter_state = delimiter_state
           next_string_token
@@ -680,7 +680,7 @@ module Crystal
       # In this case, slash is tokenized on comment skipping (#4626).
       # However this slash must be a start delimiter of regex because
       # this is parsed as regex literal once before.
-      if @token.type == :"/"
+      if @token.type.op_slash?
         @lexer.reader.previous_char
         @lexer.column_number -= 1
         slash_is_regex!
@@ -747,12 +747,12 @@ module Crystal
 
     def visit(node : ArrayLiteral)
       case @token.type
-      when :"["
-        format_literal_elements node.elements, :"[", :"]"
-      when :"[]"
+      when .op_squarel?
+        format_literal_elements node.elements, :OP_SQUAREL, :OP_SQUARER
+      when .op_squarel_squarer?
         write "[]"
         next_token
-      when :STRING_ARRAY_START, :SYMBOL_ARRAY_START
+      when .string_array_start?, .symbol_array_start?
         first = true
         write @token.raw
         count = 0
@@ -768,11 +768,11 @@ module Crystal
           end
           next_string_array_token
           case @token.type
-          when :STRING
+          when .string?
             write " " unless first || has_space_newline
             write @token.raw
             first = false
-          when :STRING_ARRAY_END
+          when .string_array_end?
             write @token.raw
             next_token
             break
@@ -786,7 +786,7 @@ module Crystal
         name = node.name.not_nil!
         accept name
         skip_space
-        format_literal_elements node.elements, :"{", :"}"
+        format_literal_elements node.elements, :OP_CURLYL, :OP_CURLYR
       end
 
       if node_of = node.of
@@ -798,11 +798,11 @@ module Crystal
     end
 
     def visit(node : TupleLiteral)
-      format_literal_elements node.elements, :"{", :"}"
+      format_literal_elements node.elements, :OP_CURLYL, :OP_CURLYR
       false
     end
 
-    def format_literal_elements(elements, prefix, suffix)
+    def format_literal_elements(elements, prefix : Token::Kind, suffix : Token::Kind)
       slash_is_regex!
       write_token prefix
       has_newlines = false
@@ -813,7 +813,7 @@ module Crystal
       found_first_newline = false
 
       found_comment = skip_space
-      if found_comment || @token.type == :NEWLINE
+      if found_comment || @token.type.newline?
         # add one level of indentation for contents if a newline is present
         offset = @indent + 2
         start_column = @indent + 2
@@ -843,9 +843,9 @@ module Crystal
         end
 
         # This is to prevent writing `{{` and `{%`
-        if prefix == :"{" && i == 0 && !wrote_newline &&
-           (@token.type == :"{" || @token.type == :"{{" || @token.type == :"{%" ||
-           @token.type == :"%" || @token.raw.starts_with?("%"))
+        if prefix.op_curlyl? && i == 0 && !wrote_newline &&
+           (@token.type.op_curlyl? || @token.type.op_curlyl_curlyl? || @token.type.op_curlyl_percent? ||
+           @token.type.op_percent? || @token.raw.starts_with?("%"))
           write " "
           write_space_at_end = true
         end
@@ -864,7 +864,7 @@ module Crystal
 
         found_comment = skip_space(offset, write_comma: (last || has_heredoc_in_line) && has_newlines)
 
-        if @token.type == :","
+        if @token.type.op_comma?
           if !found_comment && (!last || has_heredoc_in_line)
             write ","
             wrote_comma = true
@@ -873,7 +873,7 @@ module Crystal
           slash_is_regex!
           next_token
           found_comment = skip_space(offset, write_comma: last && has_newlines)
-          if @token.type == :NEWLINE
+          if @token.type.newline?
             if last && !found_comment && !wrote_comma
               write ","
               found_comment = true
@@ -906,7 +906,7 @@ module Crystal
 
       old_hash = @current_hash
       @current_hash = node
-      format_literal_elements node.entries, :"{", :"}"
+      format_literal_elements node.entries, :OP_CURLYL, :OP_CURLYR
       @current_hash = old_hash
 
       if node_of = node.of
@@ -933,7 +933,7 @@ module Crystal
       accept entry.key
       skip_space_or_newline
       middle_column = @column
-      if @token.type == :":" && entry.key.is_a?(StringLiteral)
+      if @token.type.op_colon? && entry.key.is_a?(StringLiteral)
         write ": "
         slash_is_regex!
         next_token
@@ -941,7 +941,7 @@ module Crystal
         found_in_same_line ||= check_hash_info hash, entry.key, start_line, start_column, middle_column
       else
         slash_is_regex!
-        write_token " ", :"=>", " "
+        write_token " ", :OP_EQ_GT, " "
         found_in_same_line ||= check_hash_info hash, entry.key, start_line, start_column, middle_column
       end
 
@@ -956,7 +956,7 @@ module Crystal
     def visit(node : NamedTupleLiteral)
       old_hash = @current_hash
       @current_hash = node
-      format_literal_elements node.entries, :"{", :"}"
+      format_literal_elements node.entries, :OP_CURLYL, :OP_CURLYR
       @current_hash = old_hash
 
       if @hash_in_same_line.includes? node
@@ -976,7 +976,7 @@ module Crystal
       found_in_same_line = false
       format_named_argument_name(entry.key)
       slash_is_regex!
-      write_token :":", " "
+      write_token :OP_COLON, " "
       middle_column = @column
       found_in_same_line ||= check_hash_info hash, entry.key, start_line, start_column, middle_column
       skip_space_or_newline
@@ -988,7 +988,7 @@ module Crystal
     end
 
     def format_named_argument_name(name)
-      if @token.type == :DELIMITER_START
+      if @token.type.delimiter_start?
         StringLiteral.new(name).accept self
       else
         write @token
@@ -998,7 +998,7 @@ module Crystal
       end
     end
 
-    def finish_list(suffix, has_newlines, found_comment, found_first_newline, write_space_at_end)
+    def finish_list(suffix : Token::Kind, has_newlines, found_comment, found_first_newline, write_space_at_end)
       if @token.type == suffix && !found_first_newline
         if @wrote_newline
           write_indent
@@ -1044,15 +1044,15 @@ module Crystal
     def visit(node : RangeLiteral)
       accept node.from
       skip_space
-      write_token(node.exclusive? ? :"..." : :"..")
+      write_token(node.exclusive? ? Token::Kind::OP_PERIOD_PERIOD_PERIOD : Token::Kind::OP_PERIOD_PERIOD)
       skip_space
       accept node.to
       false
     end
 
     def check_open_paren
-      if @token.type == :"("
-        while @token.type == :"("
+      if @token.type.op_bracketl?
+        while @token.type.op_bracketl?
           write "("
           next_token_skip_space
           @paren_count += 1
@@ -1064,9 +1064,9 @@ module Crystal
     end
 
     def check_close_paren
-      while @token.type == :")" && @paren_count > 0
+      while @token.type.op_bracketr? && @paren_count > 0
         @paren_count -= 1
-        write_token :")"
+        write_token :OP_BRACKETR
       end
     end
 
@@ -1074,7 +1074,7 @@ module Crystal
       check_open_paren
 
       # Sometimes the :: is not present because the parser generates ::Nil, for example
-      if node.global? && @token.type == :"::"
+      if node.global? && @token.type.op_colon_colon?
         write "::"
         next_token_skip_space_or_newline
       end
@@ -1085,7 +1085,7 @@ module Crystal
         write @token.value
         next_token
         skip_space unless last?(i, node.names)
-        if @token.type == :"::"
+        if @token.type.op_colon_colon?
           write "::"
           next_token
         end
@@ -1102,7 +1102,7 @@ module Crystal
       name = node.name.as(Path)
       first_name = name.global? && name.names.size == 1 && name.names.first
 
-      if name.global? && @token.type == :"::"
+      if name.global? && @token.type.op_colon_colon?
         write "::"
         next_token_skip_space_or_newline
       end
@@ -1110,7 +1110,7 @@ module Crystal
       if node.suffix.question?
         node.type_vars[0].accept self
         skip_space
-        write_token :"?"
+        write_token :OP_QUESTION
         return false
       end
 
@@ -1129,12 +1129,12 @@ module Crystal
 
         while asterisks > 0
           skip_space
-          if @token.type == :"**" && asterisks >= 2
+          if @token.type.op_star_star? && asterisks >= 2
             write "**"
             next_token
             asterisks -= 2
           else
-            write_token :"*"
+            write_token :OP_STAR
             asterisks -= 1
           end
         end
@@ -1146,59 +1146,59 @@ module Crystal
       if node.suffix.bracket?
         accept node.type_vars[0]
         skip_space_or_newline
-        write_token :"["
+        write_token :OP_SQUAREL
         skip_space_or_newline
         accept node.type_vars[1]
         skip_space_or_newline
-        write_token :"]"
+        write_token :OP_SQUARER
         return false
       end
 
       # Check if it's {A, B} instead of Tuple(A, B)
       if first_name == "Tuple" && @token.value != "Tuple"
-        write_token :"{"
+        write_token :OP_CURLYL
         found_comment = skip_space_or_newline
         write_space_at_end = false
         node.type_vars.each_with_index do |type_var, i|
           # This is to prevent writing `{{` and `{%`
-          if i == 0 && !found_comment && (@token.type == :"{" || @token.type == :"{{" || @token.type == :"{%" || @token.type == :"%" || @token.raw.starts_with?("%"))
+          if i == 0 && !found_comment && (@token.type.op_curlyl? || @token.type.op_curlyl_curlyl? || @token.type.op_curlyl_percent? || @token.type.op_percent? || @token.raw.starts_with?("%"))
             write " "
             write_space_at_end = true
           end
           accept type_var
           skip_space_or_newline
-          if @token.type == :","
+          if @token.type.op_comma?
             write ", " unless last?(i, node.type_vars)
             next_token_skip_space_or_newline
           end
           # Write space at end when write space for preventing writing `{{` and `{%` at first.
           write " " if last?(i, node.type_vars) && write_space_at_end
         end
-        write_token :"}"
+        write_token :OP_CURLYR
         return false
       end
 
       # Check if it's {x: A, y: B} instead of NamedTuple(x: A, y: B)
       if first_name == "NamedTuple" && @token.value != "NamedTuple"
-        write_token :"{"
+        write_token :OP_CURLYL
         skip_space_or_newline
         named_args = node.named_args.not_nil!
         named_args.each_with_index do |named_arg, i|
           accept named_arg
           skip_space_or_newline
-          if @token.type == :","
+          if @token.type.op_comma?
             write ", " unless last?(i, named_args)
             next_token_skip_space_or_newline
           end
         end
-        write_token :"}"
+        write_token :OP_CURLYR
         return false
       end
 
       accept name
       skip_space_or_newline
 
-      write_token :"("
+      write_token :OP_BRACKETL
       skip_space
 
       # Given that generic type arguments are always inside parentheses
@@ -1209,7 +1209,7 @@ module Crystal
       if named_args = node.named_args
         has_newlines, _, _ = format_named_args([] of ASTNode, named_args, @indent + 2)
         # `format_named_args` doesn't skip trailing comma
-        if @paren_count == 0 && @token.type == :","
+        if @paren_count == 0 && @token.type.op_comma?
           next_token_skip_space_or_newline
           if has_newlines
             write ","
@@ -1223,7 +1223,7 @@ module Crystal
           accept type_var
           if @paren_count == 0
             skip_space_or_newline
-            if @token.type == :","
+            if @token.type.op_comma?
               write ", " unless last?(i, node.type_vars)
               next_token_skip_space_or_newline
             end
@@ -1232,7 +1232,7 @@ module Crystal
       end
 
       skip_space_or_newline if @paren_count == 0
-      write_token :")"
+      write_token :OP_BRACKETR
 
       # Restore the old parentheses count
       @paren_count = old_paren_count
@@ -1245,7 +1245,7 @@ module Crystal
     def visit(node : Union)
       check_open_paren
 
-      if @token.type == :IDENT && @token.value == "self?" && node.types.size == 2 &&
+      if @token.type.ident? && @token.value == "self?" && node.types.size == 2 &&
          node.types[0].is_a?(Self) && node.types[1].to_s == "::Nil"
         write "self?"
         next_token
@@ -1257,7 +1257,7 @@ module Crystal
       column = @column
 
       node.types.each_with_index do |type, i|
-        if @token.type == :"?"
+        if @token.type.op_question?
           # This can happen if it's a nilable type written like T?
           write "?"
           next_token
@@ -1275,15 +1275,15 @@ module Crystal
 
         while true
           case @token.type
-          when :"|"
+          when .op_bar?
             write " | "
             next_token_skip_space
-            if @token.type == :NEWLINE
+            if @token.type.newline?
               write_line
               write_indent(column)
               next_token_skip_space_or_newline
             end
-          when :")"
+          when .op_bracketr?
             if @paren_count > 0
               @paren_count -= 1
               write ")"
@@ -1306,11 +1306,11 @@ module Crystal
       if node.ternary?
         accept node.cond
         skip_space_or_newline
-        write_token " ", :"?", " "
+        write_token " ", :OP_QUESTION, " "
         skip_space_or_newline
         accept node.then
         skip_space_or_newline
-        write_token " ", :":", " "
+        write_token " ", :OP_COLON, " "
         skip_space_or_newline
         accept node.else
         return false
@@ -1419,7 +1419,7 @@ module Crystal
     def format_nested_with_end(node, column = @indent, write_end_line = true)
       skip_space(column + 2)
 
-      if @token.type == :";"
+      if @token.type.op_semicolon?
         if node.is_a?(Nop)
           skip_semicolon_or_space_or_newline
           check_end
@@ -1456,7 +1456,7 @@ module Crystal
         skip_space_or_newline
         accept receiver
         skip_space_or_newline
-        write_token :"."
+        write_token :OP_PERIOD
       end
 
       @lexer.wants_def_or_macro_name = true
@@ -1468,14 +1468,14 @@ module Crystal
       indent do
         next_token
         skip_space consume_newline: false
-        next_token_skip_space if @token.type == :"="
+        next_token_skip_space if @token.type.op_eq?
       end
 
       to_skip = format_def_args node
 
       if return_type = node.return_type
         skip_space
-        write_token " ", :":", " "
+        write_token " ", :OP_COLON, " "
         skip_space_or_newline
         accept node.return_type.not_nil!
       end
@@ -1491,7 +1491,7 @@ module Crystal
           write free_var
           next_token
           skip_space_or_newline if last_index != i
-          if @token.type == :","
+          if @token.type.op_comma?
             write ", "
             next_token_skip_space_or_newline
           end
@@ -1517,9 +1517,9 @@ module Crystal
     def format_def_args(args : Array, block_arg, splat_index, variadic, double_splat)
       # If there are no args, remove extra "()"
       if args.empty? && !block_arg && !double_splat && !variadic
-        if @token.type == :"("
+        if @token.type.op_bracketl?
           next_token_skip_space_or_newline
-          check :")"
+          check :OP_BRACKETR
           next_token
         end
         return 0
@@ -1534,11 +1534,11 @@ module Crystal
       old_indent = @indent
       @indent = @column + 1
 
-      write_token :"("
+      write_token :OP_BRACKETL
       skip_space
 
       # When "(" follows newline, it turns on two spaces indentation mode.
-      if @token.type == :NEWLINE
+      if @token.type.newline?
         @indent = old_indent + 2
         found_first_newline = true
         wrote_newline = true
@@ -1551,7 +1551,7 @@ module Crystal
         has_more = !last?(i, args) || double_splat || block_arg || variadic
         wrote_newline = format_def_arg(wrote_newline, has_more) do
           if i == splat_index
-            write_token :"*"
+            write_token :OP_STAR
             skip_space_or_newline
             next if arg.external_name.empty? # skip empty splat argument.
           end
@@ -1563,7 +1563,7 @@ module Crystal
 
       if double_splat
         wrote_newline = format_def_arg(wrote_newline, block_arg) do
-          write_token :"**"
+          write_token :OP_STAR_STAR
           skip_space_or_newline
 
           to_skip += 1 if at_skip?
@@ -1573,7 +1573,7 @@ module Crystal
 
       if block_arg
         wrote_newline = format_def_arg(wrote_newline, false) do
-          write_token :"&"
+          write_token :OP_AMP
           skip_space_or_newline
 
           to_skip += 1 if at_skip?
@@ -1583,7 +1583,7 @@ module Crystal
 
       if variadic
         wrote_newline = format_def_arg(wrote_newline, false) do
-          write_token :"..."
+          write_token :OP_PERIOD_PERIOD_PERIOD
         end
       end
 
@@ -1592,7 +1592,7 @@ module Crystal
         wrote_newline = true
       end
       write_indent(found_first_newline ? old_indent : @indent) if wrote_newline
-      write_token :")"
+      write_token :OP_BRACKETR
 
       @indent = old_indent
 
@@ -1608,7 +1608,7 @@ module Crystal
       write "," if has_more
 
       just_wrote_newline = skip_space
-      if @token.type == :NEWLINE
+      if @token.type.newline?
         if has_more
           consume_newlines
           just_wrote_newline = true
@@ -1618,11 +1618,11 @@ module Crystal
         end
       end
 
-      if @token.type == :","
+      if @token.type.op_comma?
         found_comment = next_token_skip_space
         if found_comment
           just_wrote_newline = true
-        elsif @token.type == :NEWLINE
+        elsif @token.type.newline?
           if has_more && !just_wrote_newline
             consume_newlines
             just_wrote_newline = true
@@ -1640,7 +1640,7 @@ module Crystal
     # The parser transforms `def foo(@x); end` to `def foo(x); @x = x; end` so if we
     # find an instance var we later need to skip the first expressions in the body
     def at_skip?
-      @token.type == :INSTANCE_VAR || @token.type == :CLASS_VAR
+      @token.type.instance_var? || @token.type.class_var?
     end
 
     def visit(node : FunDef)
@@ -1650,10 +1650,10 @@ module Crystal
       write node.name
       next_token_skip_space
 
-      if @token.type == :"="
+      if @token.type.op_eq?
         write " = "
         next_token_skip_space
-        if @token.type == :DELIMITER_START
+        if @token.type.delimiter_start?
           indent(@column, StringLiteral.new(node.real_name))
         else
           write node.real_name
@@ -1665,7 +1665,7 @@ module Crystal
 
       if return_type = node.return_type
         skip_space
-        write_token " ", :":", " "
+        write_token " ", :OP_COLON, " "
         skip_space_or_newline
         accept return_type
       end
@@ -1685,7 +1685,7 @@ module Crystal
       write node.name
       next_token
 
-      if @token.type == :"=" && node.name.ends_with?('=')
+      if @token.type.op_eq? && node.name.ends_with?('=')
         next_token
       end
 
@@ -1705,13 +1705,13 @@ module Crystal
 
       next_macro_token
 
-      if @token.type == :MACRO_END
+      if @token.type.macro_end?
         return format_macro_end
       end
 
       body = node.body
       if body.is_a?(Expressions) && body.expressions.empty?
-        while @token.type != :MACRO_END
+        while !@token.type.macro_end?
           next_macro_token
         end
         return format_macro_end
@@ -1756,7 +1756,7 @@ module Crystal
       if inside_macro?
         check :MACRO_CONTROL_START
       else
-        check :"{%"
+        check :OP_CURLYL_PERCENT
       end
       write "{%"
       next_token_skip_space_or_newline
@@ -1766,7 +1766,7 @@ module Crystal
       check_keyword :do
       write " do"
       next_token_skip_space
-      check :"%}"
+      check :OP_PERCENT_CURLYR
       write " %}"
 
       @macro_state.control_nest += 1
@@ -1782,7 +1782,7 @@ module Crystal
       check_keyword :end
       write " end"
       next_token_skip_space
-      check :"%}"
+      check :OP_PERCENT_CURLYR
       write " %}"
 
       if inside_macro?
@@ -1804,13 +1804,13 @@ module Crystal
         if inside_macro?
           check :MACRO_EXPRESSION_START
         else
-          check :"{{"
+          check :OP_CURLYL_CURLYL
         end
         write_macro_slashes
         write "{{"
       else
         case @token.type
-        when :MACRO_CONTROL_START, :"{%"
+        when .macro_control_start?, .op_curlyl_percent?
           # OK
         else
           check :MACRO_CONTROL_START
@@ -1821,9 +1821,9 @@ module Crystal
       macro_state = @macro_state
       next_token
 
-      has_space = @token.type == :SPACE
+      has_space = @token.type.space?
       skip_space
-      has_newline = @token.type == :NEWLINE
+      has_newline = @token.type.newline?
       skip_space_or_newline
 
       if (has_space || !node.output?) && !has_newline
@@ -1853,12 +1853,12 @@ module Crystal
           write_line
           write_indent(old_column)
         end
-        check :"}"
+        check :OP_CURLYR
         next_token
-        check :"}"
+        check :OP_CURLYR
         write "}}"
       else
-        check :"%}"
+        check :OP_PERCENT_CURLYR
         if @wrote_newline
           write_indent(old_column)
         elsif has_newline
@@ -1886,7 +1886,7 @@ module Crystal
       if inside_macro?
         check :MACRO_CONTROL_START
       else
-        check :"{%"
+        check :OP_CURLYL_PERCENT
       end
 
       write_macro_slashes
@@ -1915,7 +1915,7 @@ module Crystal
 
     def format_macro_if_epilogue(node, macro_state, check_end = true)
       skip_space_or_newline
-      check :"%}"
+      check :OP_PERCENT_CURLYR
       write " %}"
 
       @macro_state = macro_state
@@ -1940,7 +1940,7 @@ module Crystal
         else
           check_keyword :else
           next_token_skip_space_or_newline
-          check :"%}"
+          check :OP_PERCENT_CURLYR
 
           write_macro_slashes
           write "{% else %}"
@@ -1962,7 +1962,7 @@ module Crystal
 
         check_end
         next_token_skip_space_or_newline
-        check :"%}"
+        check :OP_PERCENT_CURLYR
 
         write_macro_slashes
         write "{% end %}"
@@ -1985,7 +1985,7 @@ module Crystal
       if inside_macro?
         check :MACRO_CONTROL_START
       else
-        check :"{%"
+        check :OP_CURLYL_PERCENT
       end
 
       write_macro_slashes
@@ -2001,7 +2001,7 @@ module Crystal
           no_indent var
           unless last?(i, node.vars)
             skip_space_or_newline
-            if @token.type == :","
+            if @token.type.op_comma?
               write ", "
               next_token_skip_space_or_newline
             end
@@ -2014,7 +2014,7 @@ module Crystal
       outside_macro { indent(@column, node.exp) }
       skip_space_or_newline
 
-      check :"%}"
+      check :OP_PERCENT_CURLYR
       write " %}"
 
       @macro_state.control_nest += 1
@@ -2031,7 +2031,7 @@ module Crystal
 
       check_end
       next_token_skip_space_or_newline
-      check :"%}"
+      check :OP_PERCENT_CURLYR
 
       write_macro_slashes
       write "{% end %}"
@@ -2053,18 +2053,18 @@ module Crystal
 
       if exps = node.exps
         next_token
-        write_token :"{"
+        write_token :OP_CURLYL
         skip_space_or_newline
         exps.each_with_index do |exp, i|
           indent(@column, exp)
           skip_space_or_newline
-          if @token.type == :","
+          if @token.type.op_comma?
             write ", " unless last?(i, exps)
             next_token_skip_space_or_newline
           end
         end
-        check :"}"
-        write :"}"
+        check :OP_CURLYR
+        write "}"
       end
 
       next_macro_token
@@ -2125,7 +2125,7 @@ module Crystal
         line = @line
 
         # We have to potentially skip multiple macro literal tokens
-        while @token.type == :MACRO_LITERAL
+        while @token.type.macro_literal?
           next_macro_token
         end
 
@@ -2213,7 +2213,7 @@ module Crystal
 
       if @inside_lib > 0
         # This is the case of `fun foo(Char)`
-        if @token.type != :IDENT && restriction
+        if !@token.type.ident? && restriction
           accept restriction
           return false
         end
@@ -2229,7 +2229,7 @@ module Crystal
         if !at_skip && node.external_name != node.name
           if node.external_name.empty?
             write "_"
-          elsif @token.type == :DELIMITER_START
+          elsif @token.type.delimiter_start?
             accept StringLiteral.new(node.external_name)
           else
             write @token.value
@@ -2246,7 +2246,7 @@ module Crystal
 
       if restriction
         skip_space_or_newline
-        write_token " ", :":", " "
+        write_token " ", :OP_COLON, " "
         skip_space_or_newline
         accept restriction
       end
@@ -2259,7 +2259,7 @@ module Crystal
         skip_space_or_newline
 
         check_align = check_assign_length node
-        write_token " ", :"=", " "
+        write_token " ", :OP_EQ, " "
         before_column = @column
         skip_space_or_newline
         accept default_value
@@ -2269,16 +2269,16 @@ module Crystal
       end
 
       # This is the case of an enum member
-      if @token.type == :";"
+      if @token.type.op_semicolon?
         next_token
         @lexer.skip_space
-        if @token.type == :COMMENT
+        if @token.type.comment?
           write_comment
           @exp_needs_indent = true
         else
-          write ";" if @token.type == :CONST
+          write ";" if @token.type.const?
           write " "
-          @exp_needs_indent = @token.type == :NEWLINE
+          @exp_needs_indent = @token.type.newline?
         end
       end
 
@@ -2290,14 +2290,14 @@ module Crystal
     end
 
     def visit(node : Splat)
-      visit_splat node, :"*"
+      visit_splat node, :OP_STAR
     end
 
     def visit(node : DoubleSplat)
-      visit_splat node, :"**"
+      visit_splat node, :OP_STAR_STAR
     end
 
-    def visit_splat(node, token)
+    def visit_splat(node, token : Token::Kind)
       write_token token
       skip_space_or_newline
       accept node.exp
@@ -2321,7 +2321,7 @@ module Crystal
           accept input
           if @paren_count == sub_paren_count
             skip_space_or_newline
-            if @token.type == :","
+            if @token.type.op_comma?
               write ", " unless last?(i, inputs)
               next_token_skip_space_or_newline
             end
@@ -2338,7 +2338,7 @@ module Crystal
       skip_space
 
       write " " if inputs
-      write_token :"->"
+      write_token :OP_MINUS_GT
 
       if output = node.output
         write " "
@@ -2388,7 +2388,7 @@ module Crystal
       accept node.obj
 
       skip_space_or_newline
-      write_token :"."
+      write_token :OP_PERIOD
       skip_space_or_newline
       write node.name
       next_token
@@ -2428,17 +2428,17 @@ module Crystal
       base_indent = @indent
 
       # Special case: $1, $2, ...
-      if @token.type == :GLOBAL_MATCH_DATA_INDEX && (node.name == "[]" || node.name == "[]?") && obj.is_a?(Global)
+      if @token.type.global_match_data_index? && (node.name == "[]" || node.name == "[]?") && obj.is_a?(Global)
         write "$"
         write @token.value
         next_token
         return false
       end
 
-      write_token :"::" if node.global?
+      write_token :OP_COLON_COLON if node.global?
 
       if obj
-        {:"!", :"+", :"-", :"~", :"&+", :"&-"}.each do |op|
+        {Token::Kind::OP_BANG, Token::Kind::OP_PLUS, Token::Kind::OP_MINUS, Token::Kind::OP_TILDE, Token::Kind::OP_AMP_PLUS, Token::Kind::OP_AMP_MINUS}.each do |op|
           if node.name == op.to_s && @token.type == op && node.args.empty?
             write op
             next_token_skip_space_or_newline
@@ -2452,7 +2452,7 @@ module Crystal
 
         passed_backslash_newline = @token.passed_backslash_newline
 
-        if @token.type == :SPACE
+        if @token.type.space?
           needs_space = true
         else
           needs_space = node.name != "*" && node.name != "/" && node.name != "**" && node.name != "//"
@@ -2463,15 +2463,15 @@ module Crystal
 
         # It's something like `foo.bar\n
         #                        .baz`
-        if (@token.type == :NEWLINE) || @wrote_newline
+        if (@token.type.newline?) || @wrote_newline
           base_indent = @indent + 2
           indent(base_indent) { consume_newlines }
           write_indent(base_indent)
         end
 
-        if @token.type != :"."
+        if !@token.type.op_period?
           # It's an operator
-          if @token.type == :"["
+          if @token.type.op_squarel?
             write "["
             next_token_skip_space
 
@@ -2482,7 +2482,7 @@ module Crystal
             end
 
             has_newlines, found_comment, _ = format_args args, true, node.named_args
-            if @token.type == :"," || @token.type == :NEWLINE
+            if @token.type.op_comma? || @token.type.newline?
               if has_newlines
                 write ","
                 found_comment = next_token_skip_space
@@ -2496,13 +2496,13 @@ module Crystal
               found_comment = skip_space_or_newline
               write_indent if found_comment
             end
-            write_token :"]"
+            write_token :OP_SQUARER
 
             if node.name == "[]?"
               skip_space
 
               # This might not be present in the case of `x[y] ||= z`
-              if @token.type == :"?"
+              if @token.type.op_question?
                 write "?"
                 next_token
               end
@@ -2517,13 +2517,13 @@ module Crystal
             end
 
             return false
-          elsif @token.type == :"[]"
+          elsif @token.type.op_squarel_squarer?
             write "[]"
             next_token
 
             if node.name == "[]="
               skip_space_or_newline
-              write_token " ", :"=", " "
+              write_token " ", :OP_EQ, " "
               skip_space_or_newline
               inside_call_or_assign do
                 accept node.args.last
@@ -2536,7 +2536,7 @@ module Crystal
             write node.name
 
             # This is the case of a-1 and a+1
-            if @token.type == :NUMBER
+            if @token.type.number?
               @lexer.current_pos = @token.start + 1
             end
 
@@ -2547,7 +2547,7 @@ module Crystal
           passed_backslash_newline = @token.passed_backslash_newline
           found_comment = skip_space
 
-          if found_comment || @token.type == :NEWLINE
+          if found_comment || @token.type.newline?
             if @inside_call_or_assign == 0
               next_indent = @indent + 2
             else
@@ -2572,7 +2572,7 @@ module Crystal
         next_token
         @lexer.wants_def_or_macro_name = false
         skip_space
-        if (@token.type == :NEWLINE) || @wrote_newline
+        if (@token.type.newline?) || @wrote_newline
           base_indent = @indent + 2
           indent(base_indent) { consume_newlines }
           write_indent(base_indent)
@@ -2584,23 +2584,23 @@ module Crystal
       end
 
       # This is for foo &.[bar] and &.[bar]?, or foo.[bar] and foo.[bar]?
-      if (node.name == "[]" || node.name == "[]?") && @token.type == :"["
+      if (node.name == "[]" || node.name == "[]?") && @token.type.op_squarel?
         write "["
         next_token_skip_space_or_newline
         format_call_args(node, false, base_indent)
-        write_token :"]"
-        write_token :"?" if node.name == "[]?"
+        write_token :OP_SQUARER
+        write_token :OP_QUESTION if node.name == "[]?"
         return false
       end
 
       # This is for foo.[bar] = baz
-      if node.name == "[]=" && @token.type == :"["
+      if node.name == "[]=" && @token.type.op_squarel?
         write "["
         next_token_skip_space_or_newline
         args = node.args
         last_arg = args.pop
         format_call_args(node, true, base_indent)
-        write_token :"]"
+        write_token :OP_SQUARER
         skip_space_or_newline
         write " ="
         next_token_skip_space
@@ -2609,8 +2609,8 @@ module Crystal
       end
 
       # This is for foo.[] = bar
-      if node.name == "[]=" && @token.type == :"[]"
-        write_token :"[]"
+      if node.name == "[]=" && @token.type.op_squarel_squarer?
+        write_token :OP_SQUAREL_SQUARER
         next_token_skip_space_or_newline
         write " ="
         next_token_skip_space
@@ -2633,14 +2633,14 @@ module Crystal
         skip_space
 
         next_token
-        if @token.type == :"("
+        if @token.type.op_bracketl?
           write "=("
           has_parentheses = true
           slash_is_regex!
           next_token
           format_call_args(node, true, base_indent)
           skip_space_or_newline
-          write_token :")"
+          write_token :OP_BRACKETR
         else
           write " ="
           skip_space
@@ -2672,7 +2672,7 @@ module Crystal
         skip_space
       end
 
-      if @token.type == :"("
+      if @token.type.op_bracketl?
         slash_is_regex!
         next_token
 
@@ -2681,7 +2681,7 @@ module Crystal
         # like `nil?` when there might not be a receiver.
         if (obj || special_call) && !has_args && !node.block_arg && !node.block
           skip_space_or_newline
-          check :")"
+          check :OP_BRACKETR
           next_token
           return false
         end
@@ -2690,7 +2690,7 @@ module Crystal
         has_parentheses = true
         has_newlines, found_comment, _ = format_call_args(node, true, base_indent)
         found_comment ||= skip_space
-        if @token.type == :NEWLINE
+        if @token.type.newline?
           ends_with_newline = true
         end
         skip_space_or_newline
@@ -2704,23 +2704,23 @@ module Crystal
         needs_space = !has_parentheses || has_args
         block_indent = base_indent
         skip_space
-        if has_parentheses && @token.type == :","
+        if has_parentheses && @token.type.op_comma?
           next_token
           wrote_newline = skip_space(block_indent, write_comma: true)
-          if wrote_newline || @token.type == :NEWLINE
+          if wrote_newline || @token.type.newline?
             unless wrote_newline
               next_token_skip_space_or_newline
               write ","
               write_line
             end
             needs_space = false
-            block_indent += 2 if @token.type != :")" # foo(1, ↵  &.foo) case
+            block_indent += 2 if !@token.type.op_bracketr? # foo(1, ↵  &.foo) case
             write_indent(block_indent)
           else
-            write "," if @token.type != :")" # foo(1, &.foo) case
+            write "," if !@token.type.op_bracketr? # foo(1, &.foo) case
           end
         end
-        if has_parentheses && @token.type == :")"
+        if has_parentheses && @token.type.op_bracketr?
           if ends_with_newline
             write_line unless found_comment || @wrote_newline
             write_indent
@@ -2733,7 +2733,7 @@ module Crystal
         indent(block_indent) { format_block block, needs_space }
         if has_parentheses
           skip_space
-          if @token.type == :NEWLINE
+          if @token.type.newline?
             ends_with_newline = true
           end
           skip_space_or_newline
@@ -2744,7 +2744,7 @@ module Crystal
         finish_args(has_parentheses, has_newlines, ends_with_newline, found_comment, base_indent)
       elsif has_parentheses
         skip_space_or_newline
-        write_token :")"
+        write_token :OP_BRACKETR
       end
 
       false
@@ -2781,7 +2781,7 @@ module Crystal
       has_newlines = false
       found_comment = false
 
-      if @token.type == :NEWLINE
+      if @token.type.newline?
         if do_consume_newlines
           indent(needed_indent) { consume_newlines }
           skip_space_or_newline
@@ -2802,14 +2802,14 @@ module Crystal
         end
         next_needs_indent = false
         unless last?(i, args)
-          if @last_is_heredoc && @token.type == :NEWLINE
+          if @last_is_heredoc && @token.type.newline?
             skip_space_or_newline
             write_indent
           else
             skip_space
           end
           slash_is_regex!
-          write_token :","
+          write_token :OP_COMMA
 
           if @token.passed_backslash_newline
             write_line
@@ -2820,7 +2820,7 @@ module Crystal
             if found_comment
               write_indent(needed_indent)
             else
-              if @token.type == :NEWLINE
+              if @token.type.newline?
                 indent(needed_indent) { consume_newlines }
                 next_needs_indent = true
                 has_newlines = true
@@ -2843,9 +2843,9 @@ module Crystal
 
       if args.empty?
       else
-        write_token :","
+        write_token :OP_COMMA
         found_comment = skip_space(needed_indent)
-        if found_comment || @token.type == :NEWLINE
+        if found_comment || @token.type.newline?
           write_indent(needed_indent) unless @last_is_heredoc
         else
           write " "
@@ -2857,10 +2857,10 @@ module Crystal
 
     def format_block_arg(block_arg, needed_indent)
       skip_space_or_newline
-      if @token.type == :","
+      if @token.type.op_comma?
         write ","
         next_token_skip_space
-        if @token.type == :NEWLINE
+        if @token.type.newline?
           write_line
           write_indent(needed_indent)
           has_newlines = true
@@ -2869,7 +2869,7 @@ module Crystal
         end
       end
       skip_space_or_newline
-      write_token :"&"
+      write_token :OP_AMP
       skip_space_or_newline
       accept block_arg
       has_newlines
@@ -2879,10 +2879,10 @@ module Crystal
       skip_space
 
       if has_parentheses
-        if @token.type == :","
+        if @token.type.op_comma?
           next_token
           found_comment |= skip_space(column + 2, write_comma: true)
-          if @token.type == :NEWLINE && has_newlines
+          if @token.type.newline? && has_newlines
             write ","
             write_line
             write_indent(column)
@@ -2900,7 +2900,7 @@ module Crystal
         elsif found_comment
           write_indent(column)
         end
-        check :")"
+        check :OP_BRACKETR
 
         if ends_with_newline
           write_line unless @wrote_newline
@@ -2917,7 +2917,7 @@ module Crystal
       has_newlines, found_comment, _ = format_args args, true, named_args: named_args
       skip_space
       ends_with_newline = false
-      if @token.type == :NEWLINE
+      if @token.type.newline?
         ends_with_newline = true
         next_token
       end
@@ -2927,7 +2927,7 @@ module Crystal
     def visit(node : NamedArgument)
       format_named_argument_name(node.name)
       skip_space_or_newline
-      write_token :":", " "
+      write_token :OP_COLON, " "
 
       slash_is_regex!
 
@@ -2944,10 +2944,10 @@ module Crystal
 
       comma_before_comment = false
 
-      if @token.type == :","
+      if @token.type.op_comma?
         next_token
-        next_token if @token.type == :SPACE
-        if @token.type == :COMMENT
+        next_token if @token.type.space?
+        if @token.type.comment?
           write ","
           needs_comma = false
           comma_before_comment = true
@@ -2974,13 +2974,13 @@ module Crystal
         format_nested_with_end body
         @implicit_exception_handler_indent = old_implicit_exception_handler_indent
         @indent -= 2
-      elsif @token.type == :"{"
+      elsif @token.type.op_curlyl?
         write "," if needs_comma
         write " {"
         next_token_skip_space
         body = format_block_args node.args, node
-        next_token_skip_space_or_newline if @token.type == :";"
-        if @token.type == :NEWLINE
+        next_token_skip_space_or_newline if @token.type.op_semicolon?
+        if @token.type.newline?
           format_nested body
           skip_space_or_newline
           write_indent
@@ -2992,14 +2992,14 @@ module Crystal
           skip_space_or_newline
           write " "
         end
-        write_token :"}"
+        write_token :OP_CURLYR
       else
         # It's foo &.bar
         write "," if needs_comma
         write " " if needs_space
-        write_token :"&"
+        write_token :OP_AMP
         skip_space_or_newline
-        write :"."
+        write "."
         @lexer.wants_def_or_macro_name = true
         next_token_skip_space_or_newline
         @lexer.wants_def_or_macro_name = false
@@ -3116,22 +3116,22 @@ module Crystal
 
       to_skip = 0
 
-      write_token " ", :"|"
+      write_token " ", :OP_BAR
       skip_space_or_newline
       args.each_with_index do |arg, i|
-        if @token.type == :"*"
-          write_token :"*"
+        if @token.type.op_star?
+          write_token :OP_STAR
         end
 
-        if @token.type == :"("
-          write :"("
+        if @token.type.op_bracketl?
+          write "("
           next_token_skip_space_or_newline
 
           while true
             case @token.type
-            when :IDENT
+            when .ident?
               underscore = false
-            when :UNDERSCORE
+            when .underscore?
               underscore = true
             else
               raise "expecting block parameter name, not #{@token.type}"
@@ -3145,12 +3145,12 @@ module Crystal
 
             next_token_skip_space_or_newline
             has_comma = false
-            if @token.type == :","
+            if @token.type.op_comma?
               has_comma = true
               next_token_skip_space_or_newline
             end
 
-            if @token.type == :")"
+            if @token.type.op_bracketr?
               next_token
               write ")"
               break
@@ -3163,13 +3163,13 @@ module Crystal
         end
 
         skip_space_or_newline
-        if @token.type == :","
+        if @token.type.op_comma?
           next_token_skip_space_or_newline
           write ", " unless last?(i, args)
         end
       end
       skip_space_or_newline
-      write_token :"|"
+      write_token :OP_BAR
       skip_space
 
       remove_to_skip node, to_skip
@@ -3215,14 +3215,14 @@ module Crystal
     end
 
     def visit(node : Or)
-      format_binary node, :"||", :"||="
+      format_binary node, :OP_BAR_BAR, :OP_BAR_BAR_EQ
     end
 
     def visit(node : And)
-      format_binary node, :"&&", :"&&="
+      format_binary node, :OP_AMP_AMP, :OP_AMP_AMP_EQ
     end
 
-    def format_binary(node, token, alternative)
+    def format_binary(node, token : Token::Kind, alternative : Token::Kind)
       column = @column
 
       accept node.left
@@ -3247,7 +3247,7 @@ module Crystal
 
       write_token " ", token
       found_comment = skip_space
-      if found_comment || @token.type == :NEWLINE
+      if found_comment || @token.type.newline?
         if @inside_call_or_assign == 0
           next_indent = @inside_cond == 0 ? @indent + 2 : @indent
         else
@@ -3269,17 +3269,17 @@ module Crystal
     end
 
     def visit(node : Not)
-      if @token.type == :"!"
-        write_token :"!"
+      if @token.type.op_bang?
+        write_token :OP_BANG
         skip_space_or_newline
         accept node.exp
       else
         # Can be `exp.!`
         accept node.exp
         skip_space_or_newline
-        write_token :"."
+        write_token :OP_PERIOD
         skip_space_or_newline
-        write_token :"!"
+        write_token :OP_BANG
       end
 
       false
@@ -3295,7 +3295,7 @@ module Crystal
 
       check_align = check_assign_length node.target
       slash_is_regex!
-      write_token " ", :"="
+      write_token " ", :OP_EQ
       skip_space
       accept_assign_value_after_equals node.value, check_align: check_align
 
@@ -3317,7 +3317,7 @@ module Crystal
     end
 
     def accept_assign_value_after_equals(value, check_align = false)
-      if @token.type == :NEWLINE
+      if @token.type.newline?
         next_token_skip_space_or_newline
         write_line
         write_indent(@indent + 2, value)
@@ -3404,7 +3404,7 @@ module Crystal
 
       skip_space(@indent + 2)
 
-      if @token.type == :";"
+      if @token.type.op_semicolon?
         skip_semicolon_or_space_or_newline
         check_end
         write "; end"
@@ -3432,7 +3432,7 @@ module Crystal
 
       if superclass = node.superclass
         skip_space_or_newline
-        write_token " ", :"<", " "
+        write_token " ", :OP_LT, " "
         skip_space_or_newline
         accept superclass
       end
@@ -3445,18 +3445,18 @@ module Crystal
     def format_type_vars(type_vars, splat_index)
       if type_vars
         skip_space
-        write_token :"("
+        write_token :OP_BRACKETL
         skip_space_or_newline
         type_vars.each_with_index do |type_var, i|
-          write_token :"*" if i == splat_index
+          write_token :OP_STAR if i == splat_index
           write type_var
           next_token_skip_space_or_newline
-          if @token.type == :","
+          if @token.type.op_comma?
             write ", " unless last?(i, type_vars)
             next_token_skip_space_or_newline
           end
         end
-        write_token :")"
+        write_token :OP_BRACKETR
         skip_space
       end
     end
@@ -3511,7 +3511,7 @@ module Crystal
 
       if base_type = node.base_type
         skip_space
-        write_token " ", :":", " "
+        write_token " ", :OP_COLON, " "
         skip_space_or_newline
         accept base_type
       end
@@ -3528,20 +3528,20 @@ module Crystal
       skip_space_or_newline
 
       # This is for a case like `x, y : Int32`
-      if @inside_struct_or_union && @token.type == :","
+      if @inside_struct_or_union && @token.type.op_comma?
         @exp_needs_indent = false
         write ", "
         next_token
         return false
       end
 
-      check :":"
+      check :OP_COLON
       next_token_skip_space_or_newline
       write " : "
       accept node.declared_type
       if value = node.value
         skip_space
-        check :"="
+        check :OP_EQ
         next_token_skip_space_or_newline
         write " = "
         accept value
@@ -3552,7 +3552,7 @@ module Crystal
     def visit(node : UninitializedVar)
       accept node.var
       skip_space_or_newline
-      write_token " ", :"=", " "
+      write_token " ", :OP_EQ, " "
       skip_space_or_newline
       write_keyword :"uninitialized", " "
       skip_space_or_newline
@@ -3576,7 +3576,7 @@ module Crystal
       write_keyword keyword
 
       has_parentheses = false
-      if @token.type == :"("
+      if @token.type.op_bracketl?
         has_parentheses = true
         write "("
         next_token_skip_space_or_newline
@@ -3604,7 +3604,7 @@ module Crystal
         end
       end
 
-      write_token :")" if has_parentheses
+      write_token :OP_BRACKETR if has_parentheses
 
       false
     end
@@ -3612,7 +3612,7 @@ module Crystal
     def opening_curly_brace_count
       @lexer.peek_ahead do
         count = 0
-        while @lexer.token.type == :"{"
+        while @lexer.token.type.op_curlyl?
           count += 1
           @lexer.next_token_skip_space_or_newline
         end
@@ -3639,7 +3639,7 @@ module Crystal
 
       write_keyword :yield
 
-      if @token.type == :"("
+      if @token.type.op_bracketl?
         format_parenthesized_args(node.exps)
       else
         write " " unless node.exps.empty?
@@ -3675,12 +3675,12 @@ module Crystal
         write_indent
         write_keyword :else
         found_comment = skip_space(@indent + 2)
-        if @token.type == :NEWLINE || found_comment
+        if @token.type.newline? || found_comment
           write_line unless found_comment
           format_nested(a_else)
           skip_space_or_newline(@indent + 2)
         else
-          while @token.type == :";"
+          while @token.type.op_semicolon?
             next_token_skip_space
           end
 
@@ -3717,12 +3717,12 @@ module Crystal
         next_needs_indent = false
         unless last?(i, node.conds)
           skip_space_or_newline
-          if @token.type == :","
+          if @token.type.op_comma?
             write ","
             slash_is_regex!
             next_token
             found_comment = skip_space
-            if found_comment || @token.type == :NEWLINE
+            if found_comment || @token.type.newline?
               write_line unless found_comment
               skip_space_or_newline
               next_needs_indent = true
@@ -3734,15 +3734,15 @@ module Crystal
       end
       when_column_middle = @column
       indent { skip_space }
-      if @token.type == :";" || @token.keyword?(:then)
+      if @token.type.op_semicolon? || @token.keyword?(:then)
         separator = @token.to_s
         slash_is_regex!
-        if @token.type == :";"
+        if @token.type.op_semicolon?
           skip_semicolon_or_space
         else
           next_token_skip_space
         end
-        if @token.type == :NEWLINE
+        if @token.type.newline?
           format_nested(node.body, @indent)
         else
           write " " if separator == "then"
@@ -3783,11 +3783,11 @@ module Crystal
         write " "
         a_when.condition.accept self
         found_comment = skip_space(@indent + 2)
-        if @token.type == :";" || @token.keyword?(:then)
-          sep = @token.type == :";" ? "; " : " then "
+        if @token.type.op_semicolon? || @token.keyword?(:then)
+          sep = @token.type.op_semicolon? ? "; " : " then "
           next_token
           skip_space(@indent + 2)
-          if @token.type == :NEWLINE
+          if @token.type.newline?
             write_line
             skip_space_or_newline(@indent + 2)
             needs_indent = true
@@ -3826,25 +3826,25 @@ module Crystal
     end
 
     def visit(node : Annotation)
-      write_token :"@["
+      write_token :OP_AT_SQUAREL
       skip_space_or_newline
 
       node.path.accept self
       skip_space_or_newline
 
-      if @token.type == :"("
+      if @token.type.op_bracketl?
         has_args = !node.args.empty? || node.named_args
         if has_args
           format_parenthesized_args(node.args, named_args: node.named_args)
         else
           next_token_skip_space_or_newline
-          check :")"
+          check :OP_BRACKETR
           next_token
         end
       end
 
       skip_space_or_newline
-      write_token :"]"
+      write_token :OP_SQUARER
 
       false
     end
@@ -3891,15 +3891,15 @@ module Crystal
 
         accept target
         skip_space_or_newline
-        if @token.type == :","
+        if @token.type.op_comma?
           write ", " unless last?(i, node.targets)
           next_token_skip_space_or_newline
         end
       end
 
-      write_token " ", :"="
+      write_token " ", :OP_EQ
       skip_space
-      if @token.type == :NEWLINE
+      if @token.type.newline?
         next_token_skip_space_or_newline
         write_line
         if node.values.size == 1
@@ -3925,7 +3925,7 @@ module Crystal
             accept value
             unless last?(i, values)
               skip_space_or_newline
-              if @token.type == :","
+              if @token.type.op_comma?
                 write ", "
                 next_token_skip_space_or_newline
               end
@@ -4015,7 +4015,7 @@ module Crystal
           if types = node_rescue.types
             skip_space_or_newline
             if name
-              write_token " ", :":", " "
+              write_token " ", :OP_COLON, " "
               skip_space_or_newline
             else
               write " "
@@ -4024,7 +4024,7 @@ module Crystal
               accept type
               unless last?(j, types)
                 skip_space_or_newline
-                if @token.type == :"|"
+                if @token.type.op_bar?
                   write " | "
                   next_token_skip_space_or_newline
                 end
@@ -4080,7 +4080,7 @@ module Crystal
 
       next_token_skip_space_or_newline
 
-      write_token " ", :"=", " "
+      write_token " ", :OP_EQ, " "
       skip_space_or_newline
 
       accept value
@@ -4089,26 +4089,26 @@ module Crystal
     end
 
     def visit(node : ProcPointer)
-      write_token :"->"
+      write_token :OP_MINUS_GT
       skip_space_or_newline
 
       if obj = node.obj
         accept obj
-        write_token :"."
+        write_token :OP_PERIOD
         skip_space_or_newline
       end
 
       write node.name
       next_token_skip_space
-      next_token_skip_space if @token.type == :"="
+      next_token_skip_space if @token.type.op_eq?
 
-      if @token.type == :"("
+      if @token.type.op_bracketl?
         write "(" unless node.args.empty?
         next_token_skip_space
         node.args.each_with_index do |arg, i|
           accept arg
           skip_space_or_newline
-          if @token.type == :","
+          if @token.type.op_comma?
             write ", " unless last?(i, node.args)
             next_token_skip_space_or_newline
           end
@@ -4121,31 +4121,31 @@ module Crystal
     end
 
     def visit(node : ProcLiteral)
-      write_token :"->"
+      write_token :OP_MINUS_GT
       skip_space_or_newline
 
       a_def = node.def
 
-      if @token.type == :"("
+      if @token.type.op_bracketl?
         write "(" unless a_def.args.empty?
         next_token_skip_space_or_newline
 
         a_def.args.each_with_index do |arg, i|
           accept arg
           skip_space_or_newline
-          if @token.type == :","
+          if @token.type.op_comma?
             write ", " unless last?(i, a_def.args)
             next_token_skip_space_or_newline
           end
         end
 
-        check :")"
+        check :OP_BRACKETR
         write ")" unless a_def.args.empty?
         next_token_skip_space_or_newline
       end
 
       if return_type = a_def.return_type
-        check :":"
+        check :OP_COLON
         write " : "
         next_token_skip_space_or_newline
         accept return_type
@@ -4159,11 +4159,11 @@ module Crystal
         write_keyword :do
         is_do = true
       else
-        write_token :"{"
+        write_token :OP_CURLYL
       end
       skip_space
 
-      if @token.type == :NEWLINE
+      if @token.type.newline?
         format_nested a_def.body
       else
         skip_space_or_newline
@@ -4187,7 +4187,7 @@ module Crystal
         if @wrote_newline
           write_indent
         end
-        write_token :"}"
+        write_token :OP_CURLYR
       end
 
       false
@@ -4198,14 +4198,14 @@ module Crystal
       write @token.value
       next_token_skip_space_or_newline
 
-      if @token.type == :"="
+      if @token.type.op_eq?
         write " = "
         next_token_skip_space_or_newline
         write @token.value
         next_token_skip_space_or_newline
       end
 
-      write_token " ", :":", " "
+      write_token " ", :OP_COLON, " "
       skip_space_or_newline
 
       accept node.type_spec
@@ -4224,7 +4224,7 @@ module Crystal
       accept node.name
       skip_space
 
-      write_token :"."
+      write_token :OP_PERIOD
       skip_space_or_newline
       write_keyword :class
 
@@ -4261,10 +4261,10 @@ module Crystal
       column = @column
       has_newlines = false
 
-      write_token :"("
+      write_token :OP_BRACKETL
       skip_space
 
-      if @token.type == :NEWLINE
+      if @token.type.newline?
         consume_newlines
         has_newlines = true
       end
@@ -4280,7 +4280,7 @@ module Crystal
 
       skip_space
 
-      if @token.type == :NEWLINE
+      if @token.type.newline?
         if node.outputs || node.inputs
           consume_newlines
           column += 4
@@ -4307,11 +4307,11 @@ module Crystal
 
       part_index = 0
       while part_index < expected_parts
-        if @token.type == :"::"
-          write_token :"::"
+        if @token.type.op_colon_colon?
+          write_token :OP_COLON_COLON
           part_index += 2
-        elsif @token.type == :":"
-          write_token :":"
+        elsif @token.type.op_colon?
+          write_token :OP_COLON
           part_index += 1
         end
         skip_space_or_newline
@@ -4345,7 +4345,7 @@ module Crystal
       end
 
       # Mop up any trailing unused : or ::, don't write them since they should be removed
-      while @token.type.in?(:":", :"::")
+      while @token.type.in?(Token::Kind::OP_COLON, Token::Kind::OP_COLON_COLON)
         next_token_skip_space_or_newline
       end
 
@@ -4356,7 +4356,7 @@ module Crystal
         write_indent
       end
 
-      write_token :")"
+      write_token :OP_BRACKETR
 
       false
     end
@@ -4365,11 +4365,11 @@ module Crystal
       accept StringLiteral.new(node.constraint)
 
       skip_space_or_newline
-      write_token :"("
+      write_token :OP_BRACKETL
       skip_space_or_newline
       accept node.exp
       skip_space_or_newline
-      write_token :")"
+      write_token :OP_BRACKETR
 
       false
     end
@@ -4382,15 +4382,15 @@ module Crystal
         yield part
         skip_space
 
-        if @token.type == :","
+        if @token.type.op_comma?
           write "," unless last?(i, parts)
           next_token_skip_space
         end
 
-        if @token.type == :NEWLINE
+        if @token.type.newline?
           if last?(i, parts)
             next_token_skip_space_or_newline
-            if @token.type == :":" || @token.type == :"::"
+            if @token.type.op_colon? || @token.type.op_colon_colon?
               write_line
               write_indent(colon_column)
             end
@@ -4402,7 +4402,7 @@ module Crystal
         else
           skip_space_or_newline
           if last?(i, parts)
-            if @token.type == :":" || @token.type == :"::"
+            if @token.type.op_colon? || @token.type.op_colon_colon?
               write " "
             end
           else
@@ -4423,9 +4423,9 @@ module Crystal
     def next_token
       current_line_number = @lexer.line_number
       @token = @lexer.next_token
-      if @token.type == :DELIMITER_START
+      if @token.type.delimiter_start?
         increment_lines(@lexer.line_number - current_line_number)
-      elsif @token.type == :NEWLINE
+      elsif @token.type.newline?
         if !@lexer.heredocs.empty? && !@consuming_heredocs
           write_line
           consume_heredocs
@@ -4474,7 +4474,7 @@ module Crystal
       base_column = @column
       has_space = false
 
-      if @token.type == :SPACE
+      if @token.type.space?
         if @token.passed_backslash_newline
           if write_comma
             write ", "
@@ -4487,7 +4487,7 @@ module Crystal
           write_indent
           next_token
           @passed_backslash_newline = true
-          if @token.type == :SPACE
+          if @token.type.space?
             return skip_space(write_comma, consume_newline)
           else
             return false
@@ -4498,7 +4498,7 @@ module Crystal
         has_space = true
       end
 
-      if @token.type == :COMMENT
+      if @token.type.comment?
         needs_space = has_space && base_column != 0
         if write_comma
           write ", "
@@ -4523,19 +4523,19 @@ module Crystal
       newlines = 0
       while true
         case @token.type
-        when :SPACE
+        when .space?
           has_space = true
           next_token
-        when :NEWLINE
+        when .newline?
           newlines += 1
           next_token
-        when :";"
+        when .op_semicolon?
           next_token
         else
           break
         end
       end
-      if @token.type == :COMMENT
+      if @token.type.comment?
         needs_space = has_space && newlines == 0 && base_column != 0
         if needs_space
           write " "
@@ -4575,7 +4575,7 @@ module Crystal
     end
 
     def skip_semicolon
-      while @token.type == :";"
+      while @token.type.op_semicolon?
         next_token
       end
     end
@@ -4584,9 +4584,9 @@ module Crystal
       found_comment = false
       while true
         case @token.type
-        when :";"
+        when .op_semicolon?
           next_token
-        when :SPACE
+        when .space?
           found_comment ||= skip_space
         else
           break
@@ -4598,9 +4598,9 @@ module Crystal
     def skip_semicolon_or_space_or_newline
       while true
         case @token.type
-        when :";"
+        when .op_semicolon?
           next_token
-        when :SPACE, :NEWLINE
+        when .space?, .newline?
           skip_space_or_newline
         else
           break
@@ -4615,7 +4615,7 @@ module Crystal
     end
 
     def write_comment(needs_indent = true, consume_newline = true, next_comes_end = false)
-      while @token.type == :COMMENT
+      while @token.type.comment?
         empty_line = @line_output.to_s.strip.empty?
         if empty_line
           write_indent if needs_indent
@@ -4680,11 +4680,11 @@ module Crystal
     end
 
     def consume_newlines(next_comes_end = false)
-      if @token.type == :NEWLINE
+      if @token.type.newline?
         write_line unless @wrote_newline
         next_token_skip_space
 
-        if @token.type == :NEWLINE && !next_comes_end
+        if @token.type.newline? && !next_comes_end
           write_line
           @wrote_double_newlines = true
         end
@@ -5035,23 +5035,23 @@ module Crystal
       skip_space_or_newline
     end
 
-    def write_token(type : Symbol)
+    def write_token(type : Token::Kind)
       check type
       write type
       next_token
     end
 
-    def write_token(before : String, type : Symbol)
+    def write_token(before : String, type : Token::Kind)
       write before
       write_token type
     end
 
-    def write_token(type : Symbol, after : String)
+    def write_token(type : Token::Kind, after : String)
       write_token type
       write after
     end
 
-    def write_token(before : String, type : Symbol, after : String)
+    def write_token(before : String, type : Token::Kind, after : String)
       write before
       write_token type
       write after
@@ -5061,14 +5061,14 @@ module Crystal
       raise "expecting keyword #{keywords.join " or "}, not `#{@token.type}, #{@token.value}`, at #{@token.location}" unless keywords.any? { |k| @token.keyword?(k) }
     end
 
-    def check(*token_types)
+    def check(*token_types : Token::Kind)
       unless token_types.includes? @token.type
         raise "expecting #{token_types.join " or "}, not `#{@token.type}, #{@token.value}`, at #{@token.location}"
       end
     end
 
     def check_end
-      if @token.type == :";"
+      if @token.type.op_semicolon?
         next_token_skip_space_or_newline
       end
       check_keyword :end

--- a/src/crystal/syntax_highlighter.cr
+++ b/src/crystal/syntax_highlighter.cr
@@ -77,27 +77,27 @@ abstract class Crystal::SyntaxHighlighter
       token = lexer.next_token
 
       case token.type
-      when :DELIMITER_START
+      when .delimiter_start?
         if token.delimiter_state.kind == :heredoc
           heredoc_stack << token.dup
           highlight_token token, last_is_def
         else
           highlight_delimiter_state lexer, token
         end
-      when :STRING_ARRAY_START, :SYMBOL_ARRAY_START
+      when .string_array_start?, .symbol_array_start?
         highlight_string_array lexer, token
-      when :"}"
+      when .op_curlyr?
         break if break_on_rcurly
 
         highlight_token token, last_is_def
-      when :EOF
+      when .eof?
         break
       else
         highlight_token token, last_is_def
       end
 
       case token.type
-      when :NEWLINE
+      when .newline?
         heredoc_stack.each_with_index do |token, i|
           highlight_delimiter_state lexer, token, heredoc: true
           unless i == heredoc_stack.size - 1
@@ -105,7 +105,7 @@ abstract class Crystal::SyntaxHighlighter
             token = lexer.next_token
 
             case token.type
-            when :EOF
+            when .eof?
               raise "Unterminated heredoc"
             else
               highlight_token token, last_is_def
@@ -113,13 +113,13 @@ abstract class Crystal::SyntaxHighlighter
           end
         end
         heredoc_stack.clear
-      when :IDENT
+      when .ident?
         if last_is_def
           last_is_def = false
         end
       end
 
-      unless token.type == :SPACE
+      unless token.type.space?
         last_is_def = token.keyword? :def
       end
     end
@@ -127,23 +127,23 @@ abstract class Crystal::SyntaxHighlighter
 
   private def highlight_token(token : Token, last_is_def)
     case token.type
-    when :NEWLINE
+    when .newline?
       render :NEWLINE, "\n"
-    when :SPACE
+    when .space?
       render :SPACE, token.value.to_s
-    when :COMMENT
+    when .comment?
       render :COMMENT, token.value.to_s
-    when :NUMBER
+    when .number?
       render :NUMBER, token.raw
-    when :CHAR
+    when .char?
       render :CHAR, token.raw
-    when :SYMBOL
+    when .symbol?
       render :SYMBOL, token.raw
-    when :DELIMITER_START
+    when .delimiter_start?
       render :STRING, token.raw
-    when :CONST, :"::"
+    when .const?, .op_colon_colon?
       render :CONST, token.to_s
-    when :IDENT
+    when .ident?
       if last_is_def
         render :IDENT, token.to_s
       else
@@ -165,12 +165,12 @@ abstract class Crystal::SyntaxHighlighter
           render :UNKNOWN, token.to_s
         end
       end
-    when :+, :-, :*, :&+, :&-, :&*, :/, ://,
-         :"=", :==, :<, :<=, :>, :>=, :!, :!=, :=~, :!~,
-         :&, :|, :^, :~, :**, :>>, :<<, :%,
-         :[], :[]?, :[]=, :<=>, :===
+    when .op_plus?, .op_minus?, .op_star?, .op_amp_plus?, .op_amp_minus?, .op_amp_star?, .op_slash?, .op_slash_slash?,           # + - * &+ &- &* / //
+         .op_eq?, .op_eq_eq?, .op_lt?, .op_lt_eq?, .op_gt?, .op_gt_eq?, .op_bang?, .op_bang_eq?, .op_eq_tilde?, .op_bang_tilde?, # = == < <= > >= ! != =~ !~
+         .op_amp?, .op_bar?, .op_caret?, .op_tilde?, .op_star_star?, .op_gt_gt?, .op_lt_lt?, .op_percent?,                       # & | ^ ~ ** >> << %
+         .op_squarel_squarer?, .op_squarel_squarer_question?, .op_squarel_squarer_eq?, .op_lt_eq_gt?, .op_eq_eq_eq?              # [] []? []= <=> ===
       render :OPERATOR, token.to_s
-    when :UNDERSCORE
+    when .underscore?
       render :UNDERSCORE, "_"
     else
       render :UNKNOWN, token.to_s
@@ -183,10 +183,10 @@ abstract class Crystal::SyntaxHighlighter
       while true
         token = lexer.next_string_token(token.delimiter_state)
         case token.type
-        when :DELIMITER_END
+        when .delimiter_end?
           render :DELIMITER_END, token.raw
           break
-        when :INTERPOLATION_START
+        when .interpolation_start?
           render_interpolation do
             highlight_normal_state lexer, break_on_rcurly: true
           end
@@ -204,12 +204,12 @@ abstract class Crystal::SyntaxHighlighter
         consume_space_or_newline(lexer)
         token = lexer.next_string_array_token
         case token.type
-        when :STRING
+        when .string?
           render :STRING_ARRAY_TOKEN, token.raw
-        when :STRING_ARRAY_END
+        when .string_array_end?
           render :STRING_ARRAY_END, token.raw
           break
-        when :EOF
+        when .eof?
           if token.delimiter_state.kind == :string_array
             raise "Unterminated string array literal"
           else # == :symbol_array


### PR DESCRIPTION
This PR removes one of the biggest uses of symbol variables in the compiler.

The symbol solution is attractive, but ultimately I believe it is better if we can see _all_ possible token kinds at a glance. We also gain the ability to define instance methods on `Crystal::Token::Kind`, e.g. `#assignment_operator?`, as opposed to global methods with `Symbol` arguments.