### PR TITLE
Use enums instead of symbols for `MIME::Multipart` and `HTTP::FormData`

### DIFF
--- a/spec/std/mime/multipart/parser_spec.cr
+++ b/spec/std/mime/multipart/parser_spec.cr
@@ -144,7 +144,7 @@ describe MIME::Multipart::Parser do
       end
     end
 
-    parser.@state.should eq(:FINISHED)
+    parser.@state.finished?.should be_true
     ios.each { |io| io.closed?.should eq(true) }
   end
 end

--- a/src/http/formdata/builder.cr
+++ b/src/http/formdata/builder.cr
@@ -76,11 +76,11 @@ module HTTP::FormData
     # generated multipart message written to the IO is considered valid.
     def finish : Nil
       case @state
-      when .start?
+      in .start?
         fail "Cannot finish form-data: no body parts"
-      when .finished?
+      in .finished?
         fail "Cannot finish form-data: already finished"
-      else
+      in .field?
         @io << "\r\n--" << @boundary << "--"
         @state = State::FINISHED
       end

--- a/src/http/formdata/builder.cr
+++ b/src/http/formdata/builder.cr
@@ -15,10 +15,16 @@ module HTTP::FormData
   # io.to_s # => "--aA47\r\nContent-Disposition: form-data; name=\"name\"\r\n\r\njoe\r\n--aA47\r\nContent-Disposition: form-data; name=\"upload\"; filename=\"test.txt\"\r\n\r\nfile contents\r\n--aA47--"
   # ```
   class Builder
+    private enum State
+      START
+      FIELD
+      FINISHED
+    end
+
     # Creates a new `FormData::Builder` which writes to *io*, using the
     # multipart boundary *boundary*.
     def initialize(@io : IO, @boundary = MIME::Multipart.generate_boundary)
-      @state = :START
+      @state = State::START
     end
 
     getter boundary
@@ -48,12 +54,12 @@ module HTTP::FormData
     # Content-Disposition header for the form part. Other headers can be added
     # using *headers*.
     def file(name : String, io, metadata : FileMetadata = FileMetadata.new, headers : HTTP::Headers = HTTP::Headers.new)
-      fail "Cannot add form part: already finished" if @state == :FINISHED
+      fail "Cannot add form part: already finished" if @state.finished?
 
       headers["Content-Disposition"] = generate_content_disposition(name, metadata)
 
       # We don't add a crlf before the first boundary if this is the first body part.
-      @io << "\r\n" unless @state == :START
+      @io << "\r\n" unless @state.start?
       @io << "--" << @boundary
       headers.each do |name, values|
         values.each do |value|
@@ -63,18 +69,21 @@ module HTTP::FormData
       @io << "\r\n\r\n"
       IO.copy(io, @io)
 
-      @state = :FIELD
+      @state = State::FIELD
     end
 
     # Finalizes the multipart message, this method must be called before the
     # generated multipart message written to the IO is considered valid.
     def finish : Nil
-      fail "Cannot finish form-data: no body parts" if @state == :START
-      fail "Cannot finish form-data: already finished" if @state == :FINISHED
-
-      @io << "\r\n--" << @boundary << "--"
-
-      @state = :FINISHED
+      case @state
+      when .start?
+        fail "Cannot finish form-data: no body parts"
+      when .finished?
+        fail "Cannot finish form-data: already finished"
+      else
+        @io << "\r\n--" << @boundary << "--"
+        @state = State::FINISHED
+      end
     end
 
     private def generate_content_disposition(name, metadata)

--- a/src/mime/multipart/state.cr
+++ b/src/mime/multipart/state.cr
@@ -1,0 +1,10 @@
+module MIME::Multipart
+  private enum State
+    START
+    PREAMBLE
+    BODY_PART
+    EPILOGUE
+    FINISHED
+    ERRORED
+  end
+end


### PR DESCRIPTION
`MIME::Multipart::Parser` uses `:PART_START` instead of `:BODY_PART`; this PR also renames the former to the latter.

These enums and symbols are all internal.