### PR TITLE
Use strings instead of symbols in `#finalize` specs

### DIFF
--- a/spec/std/object_spec.cr
+++ b/spec/std/object_spec.cr
@@ -133,13 +133,7 @@ private class DelegatedTestObject
 end
 
 private class TestObjectWithFinalize
-  property key : Symbol?
-
-  def finalize
-    if key = self.key
-      State.inc(key)
-    end
-  end
+  include FinalizeCounter
 
   def_clone
 end

--- a/spec/std/object_spec.cr
+++ b/spec/std/object_spec.cr
@@ -488,7 +488,7 @@ describe Object do
 
   it "calls #finalize on #clone'd objects" do
     obj = TestObjectWithFinalize.new
-    assert_finalizes(:clone) { obj.clone }
+    assert_finalizes("clone") { obj.clone }
   end
 
   describe "def_hash" do

--- a/spec/std/openssl/ssl/context_spec.cr
+++ b/spec/std/openssl/ssl/context_spec.cr
@@ -3,15 +3,7 @@ require "openssl"
 require "../../../support/finalize"
 
 class OpenSSL::SSL::Context
-  property key : Symbol?
-
-  def finalize
-    if key = self.key
-      State.inc(key)
-    end
-
-    previous_def
-  end
+  include FinalizeCounter
 end
 
 describe OpenSSL::SSL::Context do

--- a/spec/std/openssl/ssl/context_spec.cr
+++ b/spec/std/openssl/ssl/context_spec.cr
@@ -203,11 +203,11 @@ describe OpenSSL::SSL::Context do
   {% end %}
 
   it "calls #finalize on insecure client context" do
-    assert_finalizes(:insecure_client_ctx) { OpenSSL::SSL::Context::Client.insecure }
+    assert_finalizes("insecure_client_ctx") { OpenSSL::SSL::Context::Client.insecure }
   end
 
   it "calls #finalize on insecure server context" do
-    assert_finalizes(:insecure_server_ctx) { OpenSSL::SSL::Context::Server.insecure }
+    assert_finalizes("insecure_server_ctx") { OpenSSL::SSL::Context::Server.insecure }
   end
 
   describe ".from_hash" do

--- a/spec/std/reference_spec.cr
+++ b/spec/std/reference_spec.cr
@@ -50,13 +50,7 @@ private module ReferenceSpec
   end
 
   class TestClassWithFinalize
-    property key : Symbol?
-
-    def finalize
-      if key = self.key
-        State.inc(key)
-      end
-    end
+    include FinalizeCounter
   end
 end
 

--- a/spec/std/reference_spec.cr
+++ b/spec/std/reference_spec.cr
@@ -138,6 +138,6 @@ describe "Reference" do
 
   it "calls #finalize on #dup'ed objects" do
     obj = ReferenceSpec::TestClassWithFinalize.new
-    assert_finalizes(:clone) { obj.dup }
+    assert_finalizes("dup") { obj.dup }
   end
 end

--- a/spec/std/weak_ref_spec.cr
+++ b/spec/std/weak_ref_spec.cr
@@ -1,34 +1,17 @@
 require "spec"
 require "weak_ref"
-
-private class State
-  @@count = {} of Symbol => Int64
-
-  def self.inc(key)
-    @@count[key] = @@count.fetch(key, 0i64) + 1
-  end
-
-  def self.count(key)
-    @@count.fetch(key, 0i64)
-  end
-
-  def self.reset
-    @@count.clear
-  end
-end
+require "../support/finalize"
 
 private class Foo
-  def initialize(@key : Symbol)
-  end
+  include FinalizeCounter
 
-  def finalize
-    State.inc @key
+  def initialize(@key : String)
   end
 end
 
 describe WeakRef do
   it "should get dereferenced object" do
-    foo = Foo.new :foo
+    foo = Foo.new("foo")
     ref = WeakRef.new(foo)
     ref.should_not be_nil
     ref.value.should be(foo)
@@ -48,23 +31,23 @@ describe WeakRef do
 
   it "State counts released objects" do
     State.reset
-    State.count(:foo).should eq 0
+    State.count("foo").should eq 0
     10.times do
-      Foo.new(:foo)
+      Foo.new("foo")
     end
     GC.collect
-    State.count(:foo).should be > 0
+    State.count("foo").should be > 0
   end
 
   it "Referenced object should not be released" do
     State.reset
     instances = [] of Foo
-    State.count(:strong_foo_ref).should eq 0
+    State.count("strong_foo_ref").should eq 0
     10.times do
-      instances << Foo.new(:strong_foo_ref)
+      instances << Foo.new("strong_foo_ref")
     end
     GC.collect
-    State.count(:strong_foo_ref).should eq 0
+    State.count("strong_foo_ref").should eq 0
   end
 
   it "Weak referenced object should be released if no other reference" do
@@ -72,11 +55,11 @@ describe WeakRef do
     instances = [] of WeakRef(Foo)
     last = nil
     10.times do
-      last = Foo.new(:weak_foo_ref)
+      last = Foo.new("weak_foo_ref")
       instances << WeakRef.new(last)
     end
     GC.collect
-    State.count(:weak_foo_ref).should be > 0
+    State.count("weak_foo_ref").should be > 0
     instances.select { |wr| wr.value.nil? }.size.should be > 0
     instances[-1].value.should_not be_nil
 

--- a/spec/std/weak_ref_spec.cr
+++ b/spec/std/weak_ref_spec.cr
@@ -29,29 +29,29 @@ describe WeakRef do
     GC.collect
   end
 
-  it "State counts released objects" do
-    State.reset
-    State.count("foo").should eq 0
+  it "FinalizeState counts released objects" do
+    FinalizeState.reset
+    FinalizeState.count("foo").should eq 0
     10.times do
       Foo.new("foo")
     end
     GC.collect
-    State.count("foo").should be > 0
+    FinalizeState.count("foo").should be > 0
   end
 
   it "Referenced object should not be released" do
-    State.reset
+    FinalizeState.reset
     instances = [] of Foo
-    State.count("strong_foo_ref").should eq 0
+    FinalizeState.count("strong_foo_ref").should eq 0
     10.times do
       instances << Foo.new("strong_foo_ref")
     end
     GC.collect
-    State.count("strong_foo_ref").should eq 0
+    FinalizeState.count("strong_foo_ref").should eq 0
   end
 
   it "Weak referenced object should be released if no other reference" do
-    State.reset
+    FinalizeState.reset
     instances = [] of WeakRef(Foo)
     last = nil
     10.times do
@@ -59,7 +59,7 @@ describe WeakRef do
       instances << WeakRef.new(last)
     end
     GC.collect
-    State.count("weak_foo_ref").should be > 0
+    FinalizeState.count("weak_foo_ref").should be > 0
     instances.select { |wr| wr.value.nil? }.size.should be > 0
     instances[-1].value.should_not be_nil
 

--- a/spec/std/yaml/serializable_spec.cr
+++ b/spec/std/yaml/serializable_spec.cr
@@ -260,16 +260,12 @@ end
 
 private class YAMLAttrWithFinalize
   include YAML::Serializable
+  include FinalizeCounter
+
   property value : YAML::Any
 
   @[YAML::Field(ignore: true)]
   property key : Symbol?
-
-  def finalize
-    if key = self.key
-      State.inc(key)
-    end
-  end
 end
 
 module YAMLAttrModule

--- a/spec/std/yaml/serializable_spec.cr
+++ b/spec/std/yaml/serializable_spec.cr
@@ -265,7 +265,7 @@ private class YAMLAttrWithFinalize
   property value : YAML::Any
 
   @[YAML::Field(ignore: true)]
-  property key : Symbol?
+  property key : String?
 end
 
 module YAMLAttrModule
@@ -896,7 +896,7 @@ describe "YAML::Serializable" do
   end
 
   it "calls #finalize" do
-    assert_finalizes(:yaml) { YAMLAttrWithFinalize.from_yaml("---\nvalue: 1\n") }
+    assert_finalizes("yaml") { YAMLAttrWithFinalize.from_yaml("---\nvalue: 1\n") }
   end
 
   describe "work with module and inheritance" do

--- a/spec/support/finalize.cr
+++ b/spec/support/finalize.cr
@@ -1,5 +1,5 @@
 class State
-  @@count = {} of Symbol => Int64
+  @@count = {} of String => Int64
 
   def self.inc(key)
     @@count[key] = @@count.fetch(key, 0i64) + 1
@@ -16,7 +16,7 @@ end
 
 module FinalizeCounter
   macro included
-    property key : Symbol?
+    property key : String?
 
     def finalize
       if key = self.key

--- a/spec/support/finalize.cr
+++ b/spec/support/finalize.cr
@@ -1,11 +1,11 @@
 class State
   @@count = {} of String => Int64
 
-  def self.inc(key)
+  def self.inc(key : String)
     @@count[key] = @@count.fetch(key, 0i64) + 1
   end
 
-  def self.count(key)
+  def self.count(key : String)
     @@count.fetch(key, 0i64)
   end
 
@@ -19,7 +19,7 @@ module FinalizeCounter
     property key : String?
 
     def finalize
-      if key = self.key
+      if key = @key
         State.inc(key)
       end
 
@@ -30,7 +30,7 @@ module FinalizeCounter
   end
 end
 
-def assert_finalizes(key)
+def assert_finalizes(key : String)
   State.reset
   State.count(key).should eq(0)
 

--- a/spec/support/finalize.cr
+++ b/spec/support/finalize.cr
@@ -14,6 +14,22 @@ class State
   end
 end
 
+module FinalizeCounter
+  macro included
+    property key : Symbol?
+
+    def finalize
+      if key = self.key
+        State.inc(key)
+      end
+
+      {% if @type.has_method?(:finalize) %}
+        previous_def
+      {% end %}
+    end
+  end
+end
+
 def assert_finalizes(key)
   State.reset
   State.count(key).should eq(0)

--- a/spec/support/finalize.cr
+++ b/spec/support/finalize.cr
@@ -1,4 +1,4 @@
-class State
+module FinalizeState
   @@count = {} of String => Int64
 
   def self.inc(key : String)
@@ -20,7 +20,7 @@ module FinalizeCounter
 
     def finalize
       if key = @key
-        State.inc(key)
+        FinalizeState.inc(key)
       end
 
       {% if @type.has_method?(:finalize) %}
@@ -31,8 +31,8 @@ module FinalizeCounter
 end
 
 def assert_finalizes(key : String)
-  State.reset
-  State.count(key).should eq(0)
+  FinalizeState.reset
+  FinalizeState.count(key).should eq(0)
 
   10.times do
     obj = yield
@@ -41,5 +41,5 @@ def assert_finalizes(key : String)
 
   GC.collect
 
-  State.count(key).should be > 0
+  FinalizeState.count(key).should be > 0
 end


### PR DESCRIPTION
Also extracts the common logic into a support module.