### PR TITLE
Fix getrandom for interpreter

### DIFF
--- a/src/crystal/system/unix/getrandom.cr
+++ b/src/crystal/system/unix/getrandom.cr
@@ -9,6 +9,8 @@ require "./syscall"
   end
 
   module Crystal::System::Syscall
+    GRND_NONBLOCK = 1u32
+
     # TODO: Implement syscall for interpreter
     def self.getrandom(buf : UInt8*, buflen : LibC::SizeT, flags : UInt32) : LibC::SSizeT
       LibC.getrandom(buf, buflen, flags)


### PR DESCRIPTION
The workaround for the interpreter was broken by https://github.com/crystal-lang/crystal/pull/11460