### PR TITLE
Fix `HTTP::Server::Response#close` when replaced output syncs close

### DIFF
--- a/spec/std/http/server/response_spec.cr
+++ b/spec/std/http/server/response_spec.cr
@@ -203,6 +203,18 @@ describe HTTP::Server::Response do
     end
   end
 
+  it "closes gracefully with replaced output that syncs close (#11389)" do
+    output = IO::Memory.new
+    response = HTTP::Server::Response.new(output)
+
+    response.output = IO::Stapled.new(response.output, response.output, sync_close: true)
+    response.print "some body"
+
+    response.close
+
+    output.rewind.gets_to_end.should eq "HTTP/1.1 200 OK\r\nContent-Length: 9\r\n\r\nsome body"
+  end
+
   it "flushes" do
     io = IO::Memory.new
     response = Response.new(io)

--- a/src/http/server/response.cr
+++ b/src/http/server/response.cr
@@ -160,7 +160,7 @@ class HTTP::Server
     end
 
     private def check_headers
-      check_open
+      raise IO::Error.new "Closed stream" if @original_output.closed?
       if wrote_headers?
         raise IO::Error.new("Headers already sent")
       end


### PR DESCRIPTION
This patch fixes a regression introduced in #11253 

The mechanics of the bug are described in https://github.com/crystal-lang/crystal/issues/11389#issuecomment-956119979. The fix simply replaces `check_open` (which checks `self.closed?` -> `output.closed?`) by `@original_output.closed?` which is more accurate in this case. 

`output` IO only affects the response body. We don't care about that when checking if headers can be written. The headers are part of the HTTP message and as such written directly to the underlying io (`@io`). Checking if `@io` is closed doesn't make sense because it's usually kept alive between requests. The abstraction of that part of `@io` that is attached to the response is represented by `Response::Output`, which is accessible as `@original_output`.

The overall structure of `HTTP::Server::Response` and its IOs seems a bit convoluted. I hope this can be refactored for simplicity. But that's a follow-up task.

Resolves #11389