### PR TITLE
Workaround for GC issues in interpreter specs

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -75,7 +75,6 @@ jobs:
         run: bin/ci with_build_env 'CRYSTAL_WORKERS=4 make std_spec threads=1 FLAGS="-D preview_mt"'
 
   test_interpreter:
-    if: false
     env:
       ARCH: ${{ matrix.arch }}
       ARCH_CMD: linux64

--- a/spec/compiler/interpreter/bugs_spec.cr
+++ b/spec/compiler/interpreter/bugs_spec.cr
@@ -96,7 +96,7 @@ describe Crystal::Repl::Interpreter do
     end
 
     it "doesn't incorrectly consider a non-closure as closure" do
-      interpret(<<-CODE, prelude: "prelude").should eq(false)
+      interpret(<<-CODE, prelude: "prelude").should eq("false")
         c = 0
         ->{
           c
@@ -130,7 +130,7 @@ describe Crystal::Repl::Interpreter do
     end
 
     it "does leading zeros" do
-      interpret(<<-CODE, prelude: "prelude").should eq(8)
+      interpret(<<-CODE, prelude: "prelude").should eq("8")
         0_i8.leading_zeros_count
       CODE
     end

--- a/spec/compiler/interpreter/casts_spec.cr
+++ b/spec/compiler/interpreter/casts_spec.cr
@@ -58,7 +58,7 @@ describe Crystal::Repl::Interpreter do
     end
 
     it "casts from mixed union type to primitive type" do
-      interpret(<<-CODE, prelude: "prelude").should eq(2)
+      interpret(<<-CODE, prelude: "prelude").should eq("2")
         x = 1 == 1 ? 2 : nil
         x.as(Int32)
       CODE
@@ -81,7 +81,7 @@ describe Crystal::Repl::Interpreter do
     end
 
     it "upcasts between tuple types" do
-      interpret(<<-CODE, prelude: "prelude").should eq(1 + 'a'.ord)
+      interpret(<<-CODE, prelude: "prelude").should eq((1 + 'a'.ord).to_s)
         a =
           if 1 == 1
             {1, 'a'}
@@ -94,7 +94,7 @@ describe Crystal::Repl::Interpreter do
     end
 
     it "upcasts between named tuple types, same order" do
-      interpret(<<-CODE, prelude: "prelude").should eq(1 + 'a'.ord)
+      interpret(<<-CODE, prelude: "prelude").should eq((1 + 'a'.ord).to_s)
         a =
           if 1 == 1
             {a: 1, b: 'a'}
@@ -107,7 +107,7 @@ describe Crystal::Repl::Interpreter do
     end
 
     it "upcasts between named tuple types, different order" do
-      interpret(<<-CODE, prelude: "prelude").should eq(1 + 'a'.ord)
+      interpret(<<-CODE, prelude: "prelude").should eq((1 + 'a'.ord).to_s)
         a =
           if 1 == 1
             {a: 1, b: 'a'}
@@ -214,7 +214,7 @@ describe Crystal::Repl::Interpreter do
     end
 
     it "discards cast" do
-      interpret(<<-CODE, prelude: "prelude").should eq(10)
+      interpret(<<-CODE, prelude: "prelude").should eq("10")
         x = 1 || 'a'
         x.as(Int32)
         10
@@ -234,7 +234,7 @@ describe Crystal::Repl::Interpreter do
     end
 
     it "casts to filtered type, not type in as(...)" do
-      interpret(<<-CODE, prelude: "prelude").should eq(1)
+      interpret(<<-CODE, prelude: "prelude").should eq("1")
         ({1} || 2).as(Tuple)[0]
       CODE
     end

--- a/spec/compiler/interpreter/exceptions_spec.cr
+++ b/spec/compiler/interpreter/exceptions_spec.cr
@@ -33,7 +33,7 @@ describe Crystal::Repl::Interpreter do
     end
 
     it "raises and rescues anything" do
-      interpret(<<-CODE, prelude: "prelude").should eq(2)
+      interpret(<<-CODE, prelude: "prelude").should eq("2")
           a = begin
             if 1 == 1
               raise "OH NO"
@@ -53,7 +53,7 @@ describe Crystal::Repl::Interpreter do
     end
 
     it "raises and rescues anything, does ensure when an exception is rescued" do
-      interpret(<<-CODE, prelude: "prelude").should eq(3)
+      interpret(<<-CODE, prelude: "prelude").should eq("3")
           a = 0
           b = 0
 
@@ -70,7 +70,7 @@ describe Crystal::Repl::Interpreter do
     end
 
     it "raises and rescues specific exception type" do
-      interpret(<<-CODE, prelude: "prelude").should eq(2)
+      interpret(<<-CODE, prelude: "prelude").should eq("2")
           class Ex1 < Exception; end
           class Ex2 < Exception; end
 
@@ -89,7 +89,7 @@ describe Crystal::Repl::Interpreter do
     end
 
     it "captures exception in variable" do
-      interpret(<<-CODE, prelude: "prelude").should eq(10)
+      interpret(<<-CODE, prelude: "prelude").should eq("10")
           class Ex1 < Exception
             getter value
 
@@ -110,7 +110,7 @@ describe Crystal::Repl::Interpreter do
     end
 
     it "excutes ensure when exception is raised in body" do
-      interpret(<<-CODE, prelude: "prelude").should eq(10)
+      interpret(<<-CODE, prelude: "prelude").should eq("10")
           a = 0
 
           begin
@@ -127,7 +127,7 @@ describe Crystal::Repl::Interpreter do
     end
 
     it "excutes ensure when exception is raised in rescue" do
-      interpret(<<-CODE, prelude: "prelude").should eq(10)
+      interpret(<<-CODE, prelude: "prelude").should eq("10")
           a = 0
 
           begin
@@ -181,7 +181,7 @@ describe Crystal::Repl::Interpreter do
     end
 
     it "does ensure for else when else raises" do
-      interpret(<<-CODE, prelude: "prelude").should eq(2)
+      interpret(<<-CODE, prelude: "prelude").should eq("2")
           x = 1
 
           begin
@@ -352,7 +352,7 @@ describe Crystal::Repl::Interpreter do
     end
 
     it "excutes ensure when returning a big value from a block" do
-      interpret(<<-CODE, prelude: "prelude").should eq(32405)
+      interpret(<<-CODE, prelude: "prelude").should eq("32405")
         module Global
           @@property = 0
 

--- a/spec/compiler/interpreter/integration_spec.cr
+++ b/spec/compiler/interpreter/integration_spec.cr
@@ -4,31 +4,31 @@ require "./spec_helper"
 describe Crystal::Repl::Interpreter do
   context "integration" do
     it "does Int32#to_s" do
-      interpret(<<-CODE, prelude: "prelude").should eq("123456789")
+      interpret(<<-CODE, prelude: "prelude").should eq(%("123456789"))
         123456789.to_s
       CODE
     end
 
     it "does Float64#to_s (simple)" do
-      interpret(<<-CODE, prelude: "prelude").should eq("1.5")
+      interpret(<<-CODE, prelude: "prelude").should eq(%("1.5"))
         1.5.to_s
       CODE
     end
 
     it "does Float64#to_s (complex)" do
-      interpret(<<-CODE, prelude: "prelude").should eq("123456789.12345")
+      interpret(<<-CODE, prelude: "prelude").should eq(%("123456789.12345"))
         123456789.12345.to_s
       CODE
     end
 
     it "does Range#to_a, Array#to_s" do
-      interpret(<<-CODE, prelude: "prelude").should eq("[1, 2, 3, 4, 5]")
+      interpret(<<-CODE, prelude: "prelude").should eq(%("[1, 2, 3, 4, 5]"))
         (1..5).to_a.to_s
       CODE
     end
 
     it "does some Hash methods" do
-      interpret(<<-CODE, prelude: "prelude").should eq(90)
+      interpret(<<-CODE, prelude: "prelude").should eq("90")
         h = {} of Int32 => Int32
         10.times do |i|
           h[i] = i * 2
@@ -38,7 +38,7 @@ describe Crystal::Repl::Interpreter do
     end
 
     it "does CSV" do
-      interpret(<<-CODE, prelude: "prelude").should eq((1..6).sum)
+      interpret(<<-CODE, prelude: "prelude").should eq((1..6).sum.to_s)
         require "csv"
 
         csv = CSV.new <<-CSV, headers: true
@@ -58,7 +58,7 @@ describe Crystal::Repl::Interpreter do
     end
 
     it "does JSON" do
-      interpret(<<-CODE, prelude: "prelude").should eq(6)
+      interpret(<<-CODE, prelude: "prelude").should eq("6")
         require "json"
 
         json = JSON.parse <<-JSON
@@ -69,7 +69,7 @@ describe Crystal::Repl::Interpreter do
     end
 
     it "does JSON::Serializable" do
-      interpret(<<-CODE, prelude: "prelude").should eq(3)
+      interpret(<<-CODE, prelude: "prelude").should eq("3")
         require "json"
 
         record Point, x : Int32, y : Int32 do
@@ -84,7 +84,7 @@ describe Crystal::Repl::Interpreter do
     end
 
     pending "does YAML" do
-      interpret(<<-CODE, prelude: "prelude").should eq(6)
+      interpret(<<-CODE, prelude: "prelude").should eq("6")
         require "yaml"
 
         yaml = YAML.parse <<-YAML
@@ -98,7 +98,7 @@ describe Crystal::Repl::Interpreter do
     end
 
     pending "does YAML::Serializable" do
-      interpret(<<-CODE, prelude: "prelude").should eq(3)
+      interpret(<<-CODE, prelude: "prelude").should eq("3")
         require "yaml"
 
         record Point, x : Int32, y : Int32 do
@@ -114,7 +114,7 @@ describe Crystal::Repl::Interpreter do
     end
 
     pending "does XML" do
-      interpret(<<-CODE, prelude: "prelude").should eq(3)
+      interpret(<<-CODE, prelude: "prelude").should eq("3")
         require "xml"
 
         doc = XML.parse(<<-XML
@@ -134,7 +134,7 @@ describe Crystal::Repl::Interpreter do
     end
 
     it "does String#includes?" do
-      interpret(<<-CODE, prelude: "prelude").should be_true
+      interpret(<<-CODE, prelude: "prelude").should eq("true")
         a = "Negative array size: -1"
         b = "Negative array size"
         a.includes?(b)
@@ -142,7 +142,7 @@ describe Crystal::Repl::Interpreter do
     end
 
     it "does IO.pipe (checks that StaticArray is passed correctly to C calls)" do
-      interpret(<<-CODE, prelude: "prelude").should eq("hello")
+      interpret(<<-CODE, prelude: "prelude").should eq(%("hello"))
         IO.pipe do |r, w|
           w.puts "hello"
           r.gets.not_nil!

--- a/spec/compiler/interpreter/spec_helper.cr
+++ b/spec/compiler/interpreter/spec_helper.cr
@@ -2,12 +2,12 @@
 require "../spec_helper"
 require "compiler/crystal/interpreter/*"
 
-def interpret(code, *, prelude = "primitives")
+def interpret(code, *, prelude = "primitives", file = __FILE__, line = __LINE__)
   if prelude == "primitives"
     context, value = interpret_with_context(code)
     value.value
   else
-    interpret_in_separate_process(code, prelude)
+    interpret_in_separate_process(code, prelude, file: file, line: line)
   end
 end
 
@@ -37,7 +37,7 @@ def Spec.option_parser
   option_parser
 end
 
-def interpret_in_separate_process(code, prelude)
+def interpret_in_separate_process(code, prelude, file = __FILE__, line = __LINE__)
   input = IO::Memory.new(code)
   output = IO::Memory.new
   error = IO::Memory.new
@@ -46,7 +46,7 @@ def interpret_in_separate_process(code, prelude)
 
   status = process.wait
   unless status.success?
-    fail error.rewind.gets_to_end + output.rewind.gets_to_end
+    fail error.rewind.gets_to_end + output.rewind.gets_to_end, file: file, line: line
   end
 
   output.rewind.gets_to_end

--- a/spec/compiler/interpreter/spec_helper.cr
+++ b/spec/compiler/interpreter/spec_helper.cr
@@ -20,6 +20,9 @@ def interpret_with_context(code, prelude = "primitives")
 end
 
 # FIXME: The following is a dirty hack to work around GC issues in interpreted programs. https://github.com/crystal-lang/crystal/issues/11602
+# In a nutshell, `interpret_in_separate_process` below calls this same process with an extra option that causes
+# the interpretation of the code from stdin, reading the output from stdout. That string is used as the result of
+# the program being tested.
 def Spec.option_parser
   option_parser = previous_def
   option_parser.on("", "--interpret-code PRELUDE", "Execute interpreted code") do |prelude|

--- a/spec/compiler/interpreter/spec_helper.cr
+++ b/spec/compiler/interpreter/spec_helper.cr
@@ -29,7 +29,7 @@ def Spec.option_parser
     code = STDIN.gets_to_end
 
     repl = Crystal::Repl.new
-    repl.prelude = "primitives"
+    repl.prelude = prelude
 
     print repl.run_code(code)
     exit

--- a/spec/compiler/interpreter/spec_helper.cr
+++ b/spec/compiler/interpreter/spec_helper.cr
@@ -4,16 +4,16 @@ require "compiler/crystal/interpreter/*"
 
 def interpret(code, *, prelude = "primitives")
   if prelude == "primitives"
-    context, value = interpret_with_context(code, prelude)
+    context, value = interpret_with_context(code)
     value.value
   else
     interpret_in_separate_process(code, prelude)
   end
 end
 
-def interpret_with_context(code, prelude = "primitives")
+def interpret_with_context(code)
   repl = Crystal::Repl.new
-  repl.prelude = prelude
+  repl.prelude = "primitives"
 
   value = repl.run_code(code)
   {repl.context, value}

--- a/spec/compiler/interpreter/spec_helper.cr
+++ b/spec/compiler/interpreter/spec_helper.cr
@@ -27,8 +27,11 @@ def Spec.option_parser
   option_parser = previous_def
   option_parser.on("", "--interpret-code PRELUDE", "Execute interpreted code") do |prelude|
     code = STDIN.gets_to_end
-    _, value = interpret_with_context(code, prelude)
-    print value
+
+    repl = Crystal::Repl.new
+    repl.prelude = "primitives"
+
+    print repl.run_code(code)
     exit
   end
   option_parser

--- a/spec/compiler/interpreter/typeof_spec.cr
+++ b/spec/compiler/interpreter/typeof_spec.cr
@@ -14,7 +14,7 @@ describe Crystal::Repl::Interpreter do
     end
 
     it "interprets typeof virtual type" do
-      interpret(<<-CODE, prelude: "prelude").should eq("Foo")
+      interpret(<<-CODE, prelude: "prelude").should eq(%("Foo"))
         abstract class Foo
         end
 

--- a/spec/compiler/interpreter/types_spec.cr
+++ b/spec/compiler/interpreter/types_spec.cr
@@ -18,7 +18,7 @@ describe Crystal::Repl::Interpreter do
     end
 
     it "interprets class for virtual_type type" do
-      interpret(<<-CODE, prelude: "prelude").should eq("Bar")
+      interpret(<<-CODE, prelude: "prelude").should eq(%("Bar"))
           class Foo; end
           class Bar < Foo; end
 
@@ -28,7 +28,7 @@ describe Crystal::Repl::Interpreter do
     end
 
     it "interprets class for virtual_type type (struct)" do
-      interpret(<<-CODE, prelude: "prelude").should eq("Baz")
+      interpret(<<-CODE, prelude: "prelude").should eq(%("Baz"))
           abstract struct Foo; end
           struct Bar < Foo; end
           struct Baz < Foo; end
@@ -59,7 +59,7 @@ describe Crystal::Repl::Interpreter do
     end
 
     it "interprets class_crystal_instance_type_id" do
-      interpret(<<-CODE, prelude: "prelude").should be_true
+      interpret(<<-CODE, prelude: "prelude").should eq("true")
         class Foo
         end
 


### PR DESCRIPTION
This patch prevents the GC issues in interpeter specs (#11580) as suggested as second option in #11602

The implementation hooks into `Spec`s option parser in order to add an alternative operation mode for the spec executable which works as an interpreter implementation that meets the specific needs of spec execution. This is a bit dirty, but I think it's acceptable as a temporary solution. It's definitely the fastest solution because it doesn't require an extra compiler build (neither explicitly nor implicitly). Everything necessary is already available in the spec executable, it just needs a way to expose that so it can be called externally.

Now the interpreter specs execute in 2:22 minutes (on my machine) and takes about 3.3 GB of memory. Previously, it took forever and claimed all the memory 😈 

With this change (<del>and #11624</del><ins>merged by now</ins>), the `test_interpreter` job in CI should succeed again. I'm merging that and enabling CI in this branch to verify that. But it doesn't need to be merged with it. #11624 should obviously be merged on its own. I don't see a reason to delay enabling CI, but we might want to merge an explicit revert of #11623.

Resolves #11602
Reverts #11623