### PR TITLE
Fix codegen when instantiating class methods of typedefs

### DIFF
--- a/spec/compiler/codegen/pointer_spec.cr
+++ b/spec/compiler/codegen/pointer_spec.cr
@@ -438,6 +438,24 @@ describe "Code gen: pointer" do
       ))
   end
 
+  it "passes arguments correctly for typedef metaclass (#8544)" do
+    run <<-CR
+      lib LibFoo
+        type Foo = Void*
+      end
+
+      class Class
+        def foo(x)
+          x
+        end
+      end
+
+      x = 1
+      LibFoo::Foo.foo(x)
+      Pointer(Void).foo(x)
+      CR
+  end
+
   it "generates correct code for Pointer.malloc(0) (#2905)" do
     run(%(
       require "prelude"

--- a/src/compiler/crystal/codegen/types.cr
+++ b/src/compiler/crystal/codegen/types.cr
@@ -2,11 +2,17 @@ module Crystal
   class Type
     # Returns `true` if this type is passed as a `self` argument
     # in the codegen phase. For example a method whose receiver is
-    # the Program, or a Metaclass, doesn't have a `self` argument.
+    # the Program, or a non-generic metaclass, doesn't have a `self` argument.
     def passed_as_self?
       case self
-      when Program, FileModule, LibType, MetaclassType
+      when Program, FileModule, LibType
         false
+      when MetaclassType
+        # Given `type T = Void*`, `T.class` is not necessarily a non-generic
+        # metaclass, so we must resolve any typedefs here (we don't need to
+        # check for the cases above because `#remove_typedef` must return a
+        # metaclass)
+        !self.remove_typedef.is_a?(MetaclassType)
       else
         true
       end


### PR DESCRIPTION
Adds a `%self` parameter to the generated LLVM function if a method's receiver is of type `T.class` where `T` is a typedef of a generic instance (almost always `Void*`). Fixes #8544.

It appears the interpreter also uses `Crystal::Type#passed_as_self?`. I don't know what effects this PR would have on it.