### PR TITLE
Optimize BitArray#fill

### DIFF
--- a/spec/std/bit_array_spec.cr
+++ b/spec/std/bit_array_spec.cr
@@ -538,4 +538,26 @@ describe "BitArray" do
     a[0].should be_false
     b[0].should be_true
   end
+
+  describe "#fill" do
+    it "sets all elements to the same value" do
+      ba = BitArray.new 3, true
+      ba.fill(false)
+      ba.to_a.should eq([false, false, false])
+      ba.fill(false)
+      ba.to_a.should eq([false, false, false])
+      ba[1] = true
+      ba.fill(false)
+      ba.to_a.should eq([false, false, false])
+
+      ba = BitArray.new 3, false
+      ba.fill(true)
+      ba.to_a.should eq([true, true, true])
+      ba.fill(true)
+      ba.to_a.should eq([true, true, true])
+      ba[2] = false
+      ba.fill(true)
+      ba.to_a.should eq([true, true, true])
+    end
+  end
 end

--- a/src/bit_array.cr
+++ b/src/bit_array.cr
@@ -334,6 +334,12 @@ struct BitArray
     self
   end
 
+  # :inherit:
+  def fill(value : Bool) : self
+    Intrinsics.memset(@bits, (value ? ~0u8 : 0u8), bytesize, false)
+    self
+  end
+
   # Creates a string representation of self.
   #
   # ```


### PR DESCRIPTION
## Purpose
This PR optimizes `BitArray#fill` by adding a specialized method in `bit_array.cr` that fills the `@bits` pointer directly instead of changing every bit individually like the `Indexable::Mutable#fill` implementation does. I also added a spec for the specialized method.

## Performance
I've benchmarked this on my own machine, using [this code](https://gist.github.com/RespiteSage/95b0182a9fa6d9961766faa6ef8faf4a), and in all my tests this method was ~300 times faster than the existing implementation (which makes sense, really).

## Notes
I suspect that there may be a bit of room for improvement but that I'm missing some information that would show me how to reach it. I did test whether replacing `(value ? ~0u8 : 0u8)` with `(value.to_unsafe << 8)` would make any difference, but they came out to about the same speed on average, so I went with the solution I thought was more readable.