### PR TITLE
fix: LLVMExtDIBuilderCreateArrayType: argument alignInBits should be UInt64

### DIFF
--- a/src/llvm/lib_llvm_ext.cr
+++ b/src/llvm/lib_llvm_ext.cr
@@ -85,7 +85,7 @@ lib LibLLVMExt
                                                                      align_in_bits : UInt64, flags : LLVM::DIFlags, element_types : LibLLVM::MetadataRef) : LibLLVM::MetadataRef
 
   fun di_builder_create_array_type = LLVMExtDIBuilderCreateArrayType(builder : DIBuilder, size : UInt64,
-                                                                     alignInBits : UInt32, ty : LibLLVM::MetadataRef,
+                                                                     alignInBits : UInt64, ty : LibLLVM::MetadataRef,
                                                                      subscripts : LibLLVM::MetadataRef) : LibLLVM::MetadataRef
 
   fun di_builder_create_member_type = LLVMExtDIBuilderCreateMemberType(builder : DIBuilder,


### PR DESCRIPTION
The `LLVMExtDIBuilderCreateArrayType` is defined as this on llvm_ext.cc:

```c++
LLVMMetadataRef LLVMExtDIBuilderCreateArrayType(
    DIBuilderRef Dref, uint64_t Size, uint64_t AlignInBits,
    LLVMMetadataRef Type, LLVMMetadataRef Subs) {
      return wrap(Dref->createArrayType(Size, AlignInBits, unwrapDI<DIType>(Type), DINodeArray(unwrapDI<MDTuple>(Subs))));
}
```

But is then imported as this:

```crystal
  fun di_builder_create_array_type = LLVMExtDIBuilderCreateArrayType(builder : DIBuilder, size : UInt64,
                                                                     alignInBits : UInt32, ty : LibLLVM::MetadataRef,
                                                                     subscripts : LibLLVM::MetadataRef) : LibLLVM::MetadataRef
```

There is a mismatch in the type of the `alignInBits` argument.