### PR TITLE
Add more specs for `YAML::Any#[]` and `#[]?`

### DIFF
--- a/spec/std/yaml/any_spec.cr
+++ b/spec/std/yaml/any_spec.cr
@@ -286,41 +286,15 @@ describe YAML::Any do
 
       any[1i64].raw.should eq("bar")
 
-      expect_raises(Exception, %(Expected int key for Array#[], not Array(YAML::Any))) do
-        any[nil]
-      end
-
-      expect_raises(Exception, %(Expected int key for Array#[], not Array(YAML::Any))) do
-        any[YAML::Any.new(nil)]
-      end
-
-      expect_raises(Exception, %(Expected int key for Array#[], not Array(YAML::Any))) do
-        any["fox"]
-      end
-
-      expect_raises(Exception, %(Expected int key for Array#[], not Array(YAML::Any))) do
-        any[YAML::Any.new("fox")]
-      end
-
-      expect_raises(IndexError, %(Index out of bounds)) do
-        any[2]
-      end
-
-      expect_raises(Exception, %(Expected int key for Array#[], not Array(YAML::Any))) do
-        any[YAML::Any.new(2i64)]
-      end
-
-      expect_raises(Exception, %(Expected int key for Array#[], not Array(YAML::Any))) do
-        any[2.0]
-      end
-
-      expect_raises(Exception, %(Expected int key for Array#[], not Array(YAML::Any))) do
-        any[YAML::Any.new(2.0)]
-      end
-
-      expect_raises(Exception, %(Expected int key for Array#[], not Array(YAML::Any))) do
-        any['c']
-      end
+      any[nil]?.should be_nil
+      any[YAML::Any.new(nil)]?.should be_nil
+      any["fox"]?.should be_nil
+      any[YAML::Any.new("fox")]?.should be_nil
+      any[2]?.should be_nil
+      any[YAML::Any.new(2i64)]?.should be_nil
+      any[2.0]?.should be_nil
+      any[YAML::Any.new(2.0)]?.should be_nil
+      any['c']?.should be_nil
     end
 
     it "of hash" do


### PR DESCRIPTION
This patch just adds some specs for `Any#[]` and `Any#[]?` which test with all YAML types as keys/indices.

Note: This just describes the current behaviour which has some shady edges. I'd like to merge this first and then work on several individual enhancements.