### PR TITLE
Use full name for private types' class variables during codegen

### DIFF
--- a/spec/compiler/codegen/private_spec.cr
+++ b/spec/compiler/codegen/private_spec.cr
@@ -42,6 +42,46 @@ describe "Codegen: private" do
     end
   end
 
+  it "codegens class var of private type with same name as public type (#11620)" do
+    src1 = Compiler::Source.new("foo.cr", <<-CR)
+      module Foo
+        @@x = true
+      end
+      CR
+
+    src2 = Compiler::Source.new("foo_private.cr", <<-CR)
+      private module Foo
+        @@x = 1
+      end
+      CR
+
+    compiler = create_spec_compiler
+    compiler.prelude = "empty"
+    with_temp_executable "crystal-spec-output" do |output_filename|
+      compiler.compile [src1, src2], output_filename
+    end
+  end
+
+  it "codegens class vars of private types with same name (#11620)" do
+    src1 = Compiler::Source.new("foo1.cr", <<-CR)
+      private module Foo
+        @@x = true
+      end
+      CR
+
+    src2 = Compiler::Source.new("foo2.cr", <<-CR)
+      private module Foo
+        @@x = 1
+      end
+      CR
+
+    compiler = create_spec_compiler
+    compiler.prelude = "empty"
+    with_temp_executable "crystal-spec-output" do |output_filename|
+      compiler.compile [src1, src2], output_filename
+    end
+  end
+
   it "doesn't include filename for private types" do
     run(%(
       private class Foo

--- a/src/compiler/crystal/codegen/class_var.cr
+++ b/src/compiler/crystal/codegen/class_var.cr
@@ -329,10 +329,10 @@ class Crystal::CodeGenVisitor
   end
 
   def class_var_global_name(class_var : MetaTypeVar)
-    "#{class_var.owner}#{class_var.name.gsub('@', ':')}"
+    "#{class_var.owner.llvm_name}#{class_var.name.gsub('@', ':')}"
   end
 
   def class_var_global_initialized_name(class_var : MetaTypeVar)
-    "#{class_var.owner}#{class_var.name.gsub('@', ':')}:init"
+    "#{class_var.owner.llvm_name}#{class_var.name.gsub('@', ':')}:init"
   end
 end


### PR DESCRIPTION
Fixes #11620.

An example of a class getter before this PR:

```crystal
# /home/quinton/crystal/crystal/usr/test.cr:
private class Foo
  class_getter foo = 1
end
```

```llvm
; Function Attrs: uwtable
define i32 @"*/home/quinton/crystal/crystal/usr/test.cr::Foo::x:Int32"() #0 {
entry:
  %0 = load i32, i32* @"Foo::x", align 4
  ret i32 %0
}
```

After:

```llvm
; Function Attrs: uwtable
define i32 @"*/home/quinton/crystal/crystal/usr/test.cr::Foo::x:Int32"() #0 {
entry:
  %0 = load i32, i32* @"/home/quinton/crystal/crystal/usr/test.cr::Foo::x", align 4
  ret i32 %0
}
```