### PR TITLE
Attach debug locations to splat expansions inside array-like literals

### DIFF
--- a/spec/compiler/codegen/debug_spec.cr
+++ b/spec/compiler/codegen/debug_spec.cr
@@ -246,4 +246,34 @@ describe "Code gen: debug" do
       THE_FOO = a_foo
       ), debug: Crystal::Debug::All)
   end
+
+  it "doesn't fail on splat expansions inside array-like literals" do
+    run(%(
+      require "prelude"
+
+      class Foo
+        def each
+          yield 1
+          yield 2
+          yield 3
+        end
+      end
+
+      class Bar
+        @bar = 0
+
+        def <<(value)
+          @bar = @bar &* 10 &+ value
+        end
+
+        def bar
+          @bar
+        end
+      end
+
+      x = Foo.new
+      y = Bar{*x}
+      y.bar
+      ), debug: Crystal::Debug::All).to_i.should eq(123)
+  end
 end

--- a/src/compiler/crystal/semantic/literal_expander.cr
+++ b/src/compiler/crystal/semantic/literal_expander.cr
@@ -148,8 +148,8 @@ module Crystal
       node.elements.each do |elem|
         if elem.is_a?(Splat)
           yield_var = new_temp_var
-          each_body = Call.new(temp_var.clone, "<<", yield_var.clone)
-          each_block = Block.new(args: [yield_var], body: each_body)
+          each_body = Call.new(temp_var.clone, "<<", yield_var.clone).at(node)
+          each_block = Block.new(args: [yield_var], body: each_body).at(node)
           exps << Call.new(elem.exp.clone, "each", block: each_block).at(node)
         else
           exps << Call.new(temp_var.clone, "<<", elem.clone).at(node)


### PR DESCRIPTION
Makes code like `Set{*[1]}` not break module validation when certain options like `--release` or `--emit=llvm-ir` are specified. Those literals currently fail with:

```crystal
Module validation failed: inlinable function call in a function with debug info must have a !dbg location
  %76 = call %"Set(Int32)" @"*Set(Int32)@Set(T)#<<<Int32>:Set(Int32)"(%"Set(Int32)"* %__temp_645, i32 %75)
```