### PR TITLE
Fix `Array#unshift` for large arrays

### DIFF
--- a/spec/std/array_spec.cr
+++ b/spec/std/array_spec.cr
@@ -1497,6 +1497,14 @@ describe "Array" do
       end
       a.@capacity.should eq(3)
     end
+
+    it "unshift of large array does not corrupt elements" do
+      a = Array.new(300, &.itself)
+      a.@capacity.should eq(300)
+      a.unshift 1
+      a.@capacity.should be > 300
+      a[-1].should eq(299)
+    end
   end
 
   it "does update" do

--- a/src/array.cr
+++ b/src/array.cr
@@ -2058,7 +2058,7 @@ class Array(T)
     end
   end
 
-  # Similar to double capacity, except that after reallocating the buffer
+  # Similar to `increase_capacity`, except that after reallocating the buffer
   # we point it to the middle of the buffer in case more unshifts come right away.
   # This assumes @offset_to_buffer is zero.
   private def increase_capacity_for_unshift
@@ -2066,18 +2066,18 @@ class Array(T)
   end
 
   private def resize_to_capacity_for_unshift(capacity)
-    @capacity = capacity
-    half = @capacity // 2
+    old_capacity, @capacity = @capacity, capacity
+    offset = @capacity - old_capacity
 
     if @buffer
       @buffer = root_buffer.realloc(@capacity)
-      @buffer.move_to(@buffer + half, @capacity - half)
-      @buffer.clear(half)
+      @buffer.move_to(@buffer + offset, old_capacity)
+      @buffer.clear(offset)
     else
       @buffer = Pointer(T).malloc(@capacity)
     end
 
-    shift_buffer_by(half)
+    shift_buffer_by(offset)
   end
 
   private def resize_if_cant_insert(insert_size)


### PR DESCRIPTION
`#unshift` still assumes the new capacity is exactly twice the old one whenever a reallocation is needed, which is no longer true for large arrays after #11482, so everything past around the first `new_capacity / 2` elements would be referring to invalid storage, leading to potential heap corruption:

```crystal
x = Array.new(300, &.itself)
x.@capacity # => 300
x           # => [0, 1, 2, ..., 282, 283, 284, 285, ..., 298, 299]

x.unshift 1000
x.@capacity # => 567
x           # => [1000, 0, 1, 2, ..., 282, 283, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]

x = Array.new(300) { [] of Int32 }
x.unshift [1]
x # => [[1], [], [], ..., [Invalid memory access (signal 11) at address 0x4
```

Pushes will also no longer reallocate:

```crystal
x = Array.new(300, &.itself)
x.@capacity # => 300
x.size      # => 300
x.unshift 1000
x.@capacity # => 567
x.size      # => 301
50000.times { x << 2000 }
x.@capacity # => 567
x.size      # => 50301
```

This PR fixes it.