### PR TITLE
Fix `Enum.parse` to handle case-sensitive member names

### DIFF
--- a/spec/std/enum_spec.cr
+++ b/spec/std/enum_spec.cr
@@ -43,6 +43,11 @@ enum SpecBigEnum : Int64
   TooBig = 4294967296i64 # == 2**32
 end
 
+private enum SpecEnumWithCaseSensitiveMembers
+  FOO = 1
+  Foo = 2
+end
+
 describe Enum do
   describe "to_s" do
     it "for simple enum" do
@@ -70,6 +75,10 @@ describe Enum do
   it "creates an enum instance from an auto-casted symbol (#8573)" do
     enum_value = SpecEnum.new(:two)
     enum_value.should eq SpecEnum::Two
+
+    SpecEnumWithCaseSensitiveMembers.new(:foo).should eq SpecEnumWithCaseSensitiveMembers::FOO
+    SpecEnumWithCaseSensitiveMembers.new(:Foo).should eq SpecEnumWithCaseSensitiveMembers::FOO
+    SpecEnumWithCaseSensitiveMembers.new(:FOO).should eq SpecEnumWithCaseSensitiveMembers::FOO
   end
 
   it "gets value" do
@@ -226,7 +235,7 @@ describe Enum do
     SpecEnum::Two.hash.should_not eq(SpecEnum::Three.hash)
   end
 
-  it "parses" do
+  it ".parse" do
     SpecEnum.parse("Two").should eq(SpecEnum::Two)
     SpecEnum2.parse("FortyTwo").should eq(SpecEnum2::FortyTwo)
     SpecEnum2.parse("forty_two").should eq(SpecEnum2::FortyTwo)
@@ -245,6 +254,10 @@ describe Enum do
     PrivateEnum.parse("FOO").should eq(PrivateEnum::FOO)
     PrivateEnum.parse("BAR").should eq(PrivateEnum::BAR)
     PrivateEnum.parse("QUX").should eq(PrivateEnum::QUX)
+
+    SpecEnumWithCaseSensitiveMembers.parse("foo").should eq SpecEnumWithCaseSensitiveMembers::FOO
+    SpecEnumWithCaseSensitiveMembers.parse("FOO").should eq SpecEnumWithCaseSensitiveMembers::FOO
+    SpecEnumWithCaseSensitiveMembers.parse("Foo").should eq SpecEnumWithCaseSensitiveMembers::FOO
   end
 
   it "parses?" do

--- a/spec/std/openssl/ssl/context_spec.cr
+++ b/spec/std/openssl/ssl/context_spec.cr
@@ -267,4 +267,10 @@ describe OpenSSL::SSL::Context do
       end
     end
   end
+
+  describe OpenSSL::SSL::VerifyMode do
+    it ".parse none (#7455)" do
+      OpenSSL::SSL::VerifyMode.parse("none").should eq OpenSSL::SSL::VerifyMode::NONE
+    end
+  end
 end


### PR DESCRIPTION
This patch makes sure that `Enum.parse` does not generate duplicate `when` conditions when multiple members share the same normalized form.
The ambiguity is resolved by picking the first matching member by order of definition. The identical precedence is used for symbol autocasting.
```cr
enum Foo
  Bar
  BAR
end

Foo.parse("bar") # => Foo::Bar
Foo.new(:bar)    # => Foo::Bar
```

However, there are some notable differences:
* The matching rules differ slightly from symbol autocasting. `Enum.parse` normalizes via `camelcase.downcase` while `EnumType.find_member` normalizes via `underscore`. Upper-case characters surrounded by lower-case characters normalize differently. This is a pre-existing issue (tracked in #11660).
* Enum's autogenerated predicate methods pick the *last* matching member (due to method overriding): `Foo.parse("bar").bar? # => false`. The mismatch between `.new` and predicate methods is also pre-existing (tracked in #11660). 

Picking either the first or the last member could be viable. Each would be congruent to either symbol autocasting or predicate methods. Since `None` and `All` members are implicitly defined as last members of flag enums, picking the first one is better, as that would be the expected behaviour for #7455.

This is a more generic solution than #7382, which introduces a special case for the implicitly defined `None` and `All` members.
As long as case-sensitive member names are not prohibited per se, this problem can occur with any user-defined members, thus a generic solution is better.

Resolves #7455
Closes #7382