### PR TITLE
feat: Make Crystal::MathInterpreter work without relying on exceptions

### DIFF
--- a/src/compiler/crystal/codegen/types.cr
+++ b/src/compiler/crystal/codegen/types.cr
@@ -214,7 +214,7 @@ module Crystal
           case value.type?
           when IntegerType, EnumType
             interpreter = MathInterpreter.new(namespace, visitor)
-            @compile_time_value = interpreter.interpret(value) rescue nil
+            @compile_time_value = interpreter.interpret?(value)
           end
         end
       end

--- a/src/compiler/crystal/codegen/types.cr
+++ b/src/compiler/crystal/codegen/types.cr
@@ -214,7 +214,7 @@ module Crystal
           case value.type?
           when IntegerType, EnumType
             interpreter = MathInterpreter.new(namespace, visitor)
-            @compile_time_value = interpreter.interpret?(value)
+            @compile_time_value = interpreter.interpret(value) { nil }
           end
         end
       end

--- a/src/compiler/crystal/semantic/math_interpreter.cr
+++ b/src/compiler/crystal/semantic/math_interpreter.cr
@@ -3,48 +3,46 @@ require "./semantic_visitor"
 # Interprets math expressions like 1 + 2 for enum values and
 # constant values that are being used for the N of a StaticArray.
 struct Crystal::MathInterpreter
-  @error : {ASTNode, String}?
-
   def initialize(@path_lookup : Type, @visitor : SemanticVisitor? = nil, @target_type : IntegerType? = nil)
   end
 
-  private def fail(node, message) : Nil
-    @error = {node, message}
+  private def make_error(node, message)
+    Crystal::TypeException.for_node(node, message)
   end
 
-  def interpret?(node : NumberLiteral)
+  def interpret(node : NumberLiteral)
     case node.kind
     when :i8, :i16, :i32, :i64, :u8, :u16, :u32, :u64
       target_kind = @target_type.try(&.kind) || node.kind
       case target_kind
-      when :i8  then node.value.to_i8? || fail node, "invalid Int8: #{node.value}"
-      when :u8  then node.value.to_u8? || fail node, "invalid UInt8: #{node.value}"
-      when :i16 then node.value.to_i16? || fail node, "invalid Int16: #{node.value}"
-      when :u16 then node.value.to_u16? || fail node, "invalid UInt16: #{node.value}"
-      when :i32 then node.value.to_i32? || fail node, "invalid Int32: #{node.value}"
-      when :u32 then node.value.to_u32? || fail node, "invalid UInt32: #{node.value}"
-      when :i64 then node.value.to_i64? || fail node, "invalid Int64: #{node.value}"
-      when :u64 then node.value.to_u64? || fail node, "invalid UInt64: #{node.value}"
+      when :i8  then node.value.to_i8? || make_error node, "invalid Int8: #{node.value}"
+      when :u8  then node.value.to_u8? || make_error node, "invalid UInt8: #{node.value}"
+      when :i16 then node.value.to_i16? || make_error node, "invalid Int16: #{node.value}"
+      when :u16 then node.value.to_u16? || make_error node, "invalid UInt16: #{node.value}"
+      when :i32 then node.value.to_i32? || make_error node, "invalid Int32: #{node.value}"
+      when :u32 then node.value.to_u32? || make_error node, "invalid UInt32: #{node.value}"
+      when :i64 then node.value.to_i64? || make_error node, "invalid Int64: #{node.value}"
+      when :u64 then node.value.to_u64? || make_error node, "invalid UInt64: #{node.value}"
       else
-        fail node, "enum type must be an integer, not #{target_kind}"
+        make_error node, "enum type must be an integer, not #{target_kind}"
       end
     else
-      fail node, "constant value must be an integer, not #{node.kind}"
+      make_error node, "constant value must be an integer, not #{node.kind}"
     end
   end
 
-  def interpret?(node : Call)
+  def interpret(node : Call)
     obj = node.obj
     if obj
       if obj.is_a?(Path)
         value = interpret_call_macro?(node)
-        return value if value
+        return value unless value.is_a?(Nil | Exception)
       end
 
       case node.args.size
       when 0
-        left = interpret?(obj)
-        return unless left
+        left = interpret(obj)
+        return left if left.is_a?(Exception)
 
         case node.name
         when "+" then +left
@@ -55,17 +53,17 @@ struct Crystal::MathInterpreter
           when Int32 then -left
           when Int64 then -left
           else
-            interpret_call_macro?(node)
+            interpret_call_macro(node)
           end
         when "~" then ~left
         else
-          interpret_call_macro?(node)
+          interpret_call_macro(node)
         end
       when 1
-        left = interpret?(obj)
-        return unless left
-        right = interpret?(node.args.first)
-        return unless right
+        left = interpret(obj)
+        return left if left.is_a?(Exception)
+        right = interpret(node.args.first)
+        return right if right.is_a?(Exception)
 
         case node.name
         when "+"  then left + right
@@ -83,19 +81,19 @@ struct Crystal::MathInterpreter
         when ">>" then left >> right
         when "%"  then left % right
         else
-          interpret_call_macro?(node)
+          interpret_call_macro(node)
         end
       else
-        fail node, "invalid constant value"
+        make_error node, "invalid constant value"
       end
     else
-      interpret_call_macro?(node)
+      interpret_call_macro(node)
     end
   end
 
-  def interpret_call_macro?(node : Call)
+  def interpret_call_macro(node : Call)
     interpret_call_macro?(node) ||
-      fail node, "invalid constant value"
+      make_error node, "invalid constant value"
   end
 
   def interpret_call_macro?(node : Call)
@@ -109,35 +107,37 @@ struct Crystal::MathInterpreter
     end
 
     if visitor.expand_macro(node, raise_on_missing_const: false, first_pass: true)
-      return interpret?(node.expanded.not_nil!)
+      return interpret(node.expanded.not_nil!)
     end
 
     nil
   end
 
-  def interpret?(node : Path)
+  def interpret(node : Path)
     type = @path_lookup.lookup_type_var(node)
     case type
     when Const
-      interpret?(type.value)
+      interpret(type.value)
     else
-      fail node, "invalid constant value"
+      make_error node, "invalid constant value"
     end
   end
 
-  def interpret?(node : Expressions)
+  def interpret(node : Expressions)
     if node.expressions.size == 1
-      interpret?(node.expressions.first)
+      interpret(node.expressions.first)
     else
-      fail node, "invalid constant value"
+      make_error node, "invalid constant value"
     end
-  end
-
-  def interpret?(node : ASTNode)
-    fail node, "invalid constant value"
   end
 
   def interpret(node : ASTNode)
-    interpret?(node) || @error.try { |(node, message)| node.raise(message) } || node.raise("invalid constant value")
+    make_error node, "invalid constant value"
+  end
+
+  def interpret(node : ASTNode)
+    result = interpret(node)
+    return yield result if result.is_a?(Exception)
+    result
   end
 end

--- a/src/compiler/crystal/semantic/math_interpreter.cr
+++ b/src/compiler/crystal/semantic/math_interpreter.cr
@@ -3,31 +3,37 @@ require "./semantic_visitor"
 # Interprets math expressions like 1 + 2 for enum values and
 # constant values that are being used for the N of a StaticArray.
 struct Crystal::MathInterpreter
+  @error : {ASTNode, String}?
+
   def initialize(@path_lookup : Type, @visitor : SemanticVisitor? = nil, @target_type : IntegerType? = nil)
   end
 
-  def interpret(node : NumberLiteral)
+  private def fail(node, message) : Nil
+    @error = {node, message}
+  end
+
+  def interpret?(node : NumberLiteral)
     case node.kind
     when :i8, :i16, :i32, :i64, :u8, :u16, :u32, :u64
       target_kind = @target_type.try(&.kind) || node.kind
       case target_kind
-      when :i8  then node.value.to_i8? || node.raise "invalid Int8: #{node.value}"
-      when :u8  then node.value.to_u8? || node.raise "invalid UInt8: #{node.value}"
-      when :i16 then node.value.to_i16? || node.raise "invalid Int16: #{node.value}"
-      when :u16 then node.value.to_u16? || node.raise "invalid UInt16: #{node.value}"
-      when :i32 then node.value.to_i32? || node.raise "invalid Int32: #{node.value}"
-      when :u32 then node.value.to_u32? || node.raise "invalid UInt32: #{node.value}"
-      when :i64 then node.value.to_i64? || node.raise "invalid Int64: #{node.value}"
-      when :u64 then node.value.to_u64? || node.raise "invalid UInt64: #{node.value}"
+      when :i8  then node.value.to_i8? || fail node, "invalid Int8: #{node.value}"
+      when :u8  then node.value.to_u8? || fail node, "invalid UInt8: #{node.value}"
+      when :i16 then node.value.to_i16? || fail node, "invalid Int16: #{node.value}"
+      when :u16 then node.value.to_u16? || fail node, "invalid UInt16: #{node.value}"
+      when :i32 then node.value.to_i32? || fail node, "invalid Int32: #{node.value}"
+      when :u32 then node.value.to_u32? || fail node, "invalid UInt32: #{node.value}"
+      when :i64 then node.value.to_i64? || fail node, "invalid Int64: #{node.value}"
+      when :u64 then node.value.to_u64? || fail node, "invalid UInt64: #{node.value}"
       else
-        node.raise "enum type must be an integer, not #{target_kind}"
+        fail node, "enum type must be an integer, not #{target_kind}"
       end
     else
-      node.raise "constant value must be an integer, not #{node.kind}"
+      fail node, "constant value must be an integer, not #{node.kind}"
     end
   end
 
-  def interpret(node : Call)
+  def interpret?(node : Call)
     obj = node.obj
     if obj
       if obj.is_a?(Path)
@@ -37,7 +43,8 @@ struct Crystal::MathInterpreter
 
       case node.args.size
       when 0
-        left = interpret(obj)
+        left = interpret?(obj)
+        return unless left
 
         case node.name
         when "+" then +left
@@ -48,15 +55,17 @@ struct Crystal::MathInterpreter
           when Int32 then -left
           when Int64 then -left
           else
-            interpret_call_macro(node)
+            interpret_call_macro?(node)
           end
         when "~" then ~left
         else
-          interpret_call_macro(node)
+          interpret_call_macro?(node)
         end
       when 1
-        left = interpret(obj)
-        right = interpret(node.args.first)
+        left = interpret?(obj)
+        return unless left
+        right = interpret?(node.args.first)
+        return unless right
 
         case node.name
         when "+"  then left + right
@@ -74,19 +83,19 @@ struct Crystal::MathInterpreter
         when ">>" then left >> right
         when "%"  then left % right
         else
-          interpret_call_macro(node)
+          interpret_call_macro?(node)
         end
       else
-        node.raise "invalid constant value"
+        fail node, "invalid constant value"
       end
     else
-      interpret_call_macro(node)
+      interpret_call_macro?(node)
     end
   end
 
-  def interpret_call_macro(node : Call)
+  def interpret_call_macro?(node : Call)
     interpret_call_macro?(node) ||
-      node.raise("invalid constant value")
+      fail node, "invalid constant value"
   end
 
   def interpret_call_macro?(node : Call)
@@ -100,31 +109,35 @@ struct Crystal::MathInterpreter
     end
 
     if visitor.expand_macro(node, raise_on_missing_const: false, first_pass: true)
-      return interpret(node.expanded.not_nil!)
+      return interpret?(node.expanded.not_nil!)
     end
 
     nil
   end
 
-  def interpret(node : Path)
+  def interpret?(node : Path)
     type = @path_lookup.lookup_type_var(node)
     case type
     when Const
-      interpret(type.value)
+      interpret?(type.value)
     else
-      node.raise "invalid constant value"
+      fail node, "invalid constant value"
     end
   end
 
-  def interpret(node : Expressions)
+  def interpret?(node : Expressions)
     if node.expressions.size == 1
-      interpret(node.expressions.first)
+      interpret?(node.expressions.first)
     else
-      node.raise "invalid constant value"
+      fail node, "invalid constant value"
     end
+  end
+
+  def interpret?(node : ASTNode)
+    fail node, "invalid constant value"
   end
 
   def interpret(node : ASTNode)
-    node.raise "invalid constant value"
+    interpret?(node) || @error.try { |(node, message)| node.raise(message) } || node.raise("invalid constant value")
   end
 end

--- a/src/compiler/crystal/semantic/semantic_visitor.cr
+++ b/src/compiler/crystal/semantic/semantic_visitor.cr
@@ -547,7 +547,7 @@ abstract class Crystal::SemanticVisitor < Crystal::Visitor
   def interpret_enum_value(node : ASTNode, target_type : IntegerType? = nil)
     MathInterpreter
       .new(current_type, self, target_type)
-      .interpret(node)
+      .interpret(node) { |error| raise error }
   end
 
   def inside_exp?

--- a/src/compiler/crystal/semantic/type_lookup.cr
+++ b/src/compiler/crystal/semantic/type_lookup.cr
@@ -254,12 +254,10 @@ class Crystal::Type
           case type
           when Const
             interpreter = MathInterpreter.new(@root)
-            begin
-              num = interpreter.interpret(type.value)
-              type_vars << NumberLiteral.new(num)
-            rescue ex : Crystal::CodeError
-              type_var.raise "expanding constant value for a number value", inner: ex
+            num = interpreter.interpret(type.value) do |error|
+              type_var.raise "expanding constant value for a number value", inner: error
             end
+            type_vars << NumberLiteral.new(num)
             next
           when ASTNode
             type_vars << type


### PR DESCRIPTION
See #11658.

Currently, the compiler needs exceptions in order to successfully compile some code. Maybe this is fine, maybe this isn't. There are a few places where this happens, but there is a single case that happens every time, even when compiling an empty file without a prelude: the MathInterpreter. It is used to **try** to optimize an integer or boolean constant by computing its value at compile time and storing the result instead of leaving the computation as is. It will always fail for the built-in constant `ARGC_UNSAFE`, an integer that can't be computed at compile time.

This patch modifies the MathInterpreter class so that it has a `interpret?` and a `interpret` method. The former returns `nil` when it can't compute the expression and the latter raises at the offending AST node.

This change was required to make a working basic compiler for WebAssembly, see https://github.com/crystal-lang/crystal/pull/10870#issuecomment-1002166391. I hope this can be merged even regardless of the direction #11658 takes as it makes porting Crystal to new targets ~much easier~ less hard.