### PR TITLE
Allow underscores after a leading zero in `String#to_i` (regression fix)

### DIFF
--- a/spec/compiler/lexer/lexer_spec.cr
+++ b/spec/compiler/lexer/lexer_spec.cr
@@ -430,6 +430,9 @@ describe "Lexer" do
   assert_syntax_error "2ef32", "unexpected token: \"ef32\""
   assert_syntax_error "2e+_2", "unexpected '_' in number"
 
+  # Test for #11671
+  it_lexes_i32 [["0b0_1", "1"]]
+
   it "lexes not instance var" do
     lexer = Lexer.new "!@foo"
     token = lexer.next_token

--- a/spec/std/string_spec.cr
+++ b/spec/std/string_spec.cr
@@ -295,6 +295,9 @@ describe "String" do
     it { "1z".to_i(62).should eq(97) }
     it { "ZZ".to_i(62).should eq(3843) }
 
+    # Test for #11671
+    it { "0_1".to_i(underscore: true).should eq(1) }
+
     describe "to_i8" do
       it { "127".to_i8.should eq(127) }
       it { "-128".to_i8.should eq(-128) }

--- a/src/string.cr
+++ b/src/string.cr
@@ -583,11 +583,12 @@ class String
     end
 
     found_digit = false
+    last_is_underscore = true
 
     # Check leading zero
     if ptr.value.unsafe_chr == '0'
       ptr += 1
-
+      last_is_underscore = false
       if prefix
         case ptr.value.unsafe_chr
         when 'b'
@@ -616,7 +617,6 @@ class String
 
     value = int_class.new(0)
     mul_overflow = ~(int_class.new(0)) // base
-    last_is_underscore = true
     invalid = false
 
     digits = (base == 62 ? CHAR_TO_DIGIT62 : CHAR_TO_DIGIT).to_unsafe


### PR DESCRIPTION
Allows underscores after a leading zero in `String#to_i`

Fixes #11671