### PR TITLE
Codegen: Do not always request value for `Proc#call`

### DIFF
--- a/src/compiler/crystal/codegen/primitives.cr
+++ b/src/compiler/crystal/codegen/primitives.cr
@@ -1009,10 +1009,7 @@ class Crystal::CodeGenVisitor
     ctx_is_null = equal? ctx_ptr, llvm_context.void_pointer.null
     cond ctx_is_null, ctx_is_null_block, ctx_is_not_null_block
 
-    old_needs_value = @needs_value
-    @needs_value = true
-
-    phi_value = Phi.open(self, node, @needs_value) do |phi|
+    Phi.open(self, node, @needs_value) do |phi|
       position_at_end ctx_is_null_block
       real_fun_ptr = bit_cast fun_ptr, llvm_proc_type(context.type)
 
@@ -1049,9 +1046,6 @@ class Crystal::CodeGenVisitor
       target_def.abi_info = old_abi_info
       target_def.c_calling_convention = old_c_calling_convention
     end
-
-    old_needs_value = @needs_value
-    phi_value
   end
 
   def codegen_extern_primitive_proc_call(target_def, args, fun_ptr)


### PR DESCRIPTION
Test program:

```crystal
def foo
  ->{ {2, 3, 4, 5} }.call
  1
end

foo
```

Before:

```llvm
; Function Attrs: uwtable
define internal i32 @"*foo:Int32"() #0 !dbg !17 {
alloca:
  %0 = alloca %"->", !dbg !18
  %1 = alloca %"Tuple(Int32, Int32, Int32, Int32)", !dbg !19
  %2 = alloca %"Tuple(Int32, Int32, Int32, Int32)", !dbg !19
  br label %entry

entry:                                            ; preds = %alloca
  %3 = getelementptr inbounds %"->", %"->"* %0, i32 0, i32 0, !dbg !18
  store i8* bitcast (%"Tuple(Int32, Int32, Int32, Int32)" ()* @"~procProc(Tuple(Int32, Int32, Int32, Int32))@usr/test.cr:2" to i8*), i8** %3, !dbg !18
  %4 = getelementptr inbounds %"->", %"->"* %0, i32 0, i32 1, !dbg !18
  store i8* null, i8** %4, !dbg !18
  %5 = load %"->", %"->"* %0, !dbg !18
  %6 = extractvalue %"->" %5, 0, !dbg !18
  %7 = extractvalue %"->" %5, 1, !dbg !18
  %8 = icmp eq i8* %7, null, !dbg !18
  br i1 %8, label %ctx_is_null, label %ctx_is_not_null, !dbg !18

ctx_is_null:                                      ; preds = %entry
  %9 = bitcast i8* %6 to %"Tuple(Int32, Int32, Int32, Int32)" ()*, !dbg !18
  %10 = call %"Tuple(Int32, Int32, Int32, Int32)" %9(), !dbg !19
  store %"Tuple(Int32, Int32, Int32, Int32)" %10, %"Tuple(Int32, Int32, Int32, Int32)"* %1, !dbg !19
  br label %exit, !dbg !19

ctx_is_not_null:                                  ; preds = %entry
  %11 = bitcast i8* %6 to %"Tuple(Int32, Int32, Int32, Int32)" (i8*)*, !dbg !19
  %12 = call %"Tuple(Int32, Int32, Int32, Int32)" %11(i8* %7), !dbg !19
  store %"Tuple(Int32, Int32, Int32, Int32)" %12, %"Tuple(Int32, Int32, Int32, Int32)"* %2, !dbg !19
  br label %exit, !dbg !19

exit:                                             ; preds = %ctx_is_not_null, %ctx_is_null
  %13 = phi %"Tuple(Int32, Int32, Int32, Int32)"* [ %1, %ctx_is_null ], [ %2, %ctx_is_not_null ], !dbg !19
  ret i32 1, !dbg !19
}
```

After:

```llvm
; Function Attrs: uwtable
define internal i32 @"*foo:Int32"() #0 !dbg !17 {
alloca:
  %0 = alloca %"->", align 8, !dbg !18
  br label %entry

entry:                                            ; preds = %alloca
  %1 = getelementptr inbounds %"->", %"->"* %0, i32 0, i32 0, !dbg !18
  store i8* bitcast (%"Tuple(Int32, Int32, Int32, Int32)" ()* @"~procProc(Tuple(Int32, Int32, Int32, Int32))@usr/test.cr:2" to i8*), i8** %1, align 8, !dbg !18
  %2 = getelementptr inbounds %"->", %"->"* %0, i32 0, i32 1, !dbg !18
  store i8* null, i8** %2, align 8, !dbg !18
  %3 = load %"->", %"->"* %0, align 8, !dbg !18
  %4 = extractvalue %"->" %3, 0, !dbg !18
  %5 = extractvalue %"->" %3, 1, !dbg !18
  %6 = icmp eq i8* %5, null, !dbg !18
  br i1 %6, label %ctx_is_null, label %ctx_is_not_null, !dbg !18

ctx_is_null:                                      ; preds = %entry
  %7 = bitcast i8* %4 to %"Tuple(Int32, Int32, Int32, Int32)" ()*, !dbg !18
  %8 = call %"Tuple(Int32, Int32, Int32, Int32)" %7(), !dbg !19
  br label %exit, !dbg !19

ctx_is_not_null:                                  ; preds = %entry
  %9 = bitcast i8* %4 to %"Tuple(Int32, Int32, Int32, Int32)" (i8*)*, !dbg !19
  %10 = call %"Tuple(Int32, Int32, Int32, Int32)" %9(i8* %5), !dbg !19
  br label %exit, !dbg !19

exit:                                             ; preds = %ctx_is_not_null, %ctx_is_null
  ret i32 1, !dbg !19
}
```

This was discovered in https://github.com/crystal-lang/crystal/pull/10230#pullrequestreview-568268164, but before that `Proc#call` had always placed an LLVM variable for the return value (`%13` in the above case) even when that value was unused. This PR removes that part altogether when it is deemed unnecessary (`!@needs_value`).