### PR TITLE
Fix debug location of inlined `Proc#call` body

### DIFF
--- a/spec/llvm-ir/proc-call-debug-loc.cr
+++ b/spec/llvm-ir/proc-call-debug-loc.cr
@@ -1,0 +1,13 @@
+x = ->{}
+x.call
+# CHECK:      extractvalue %"->" %{{[0-9]+}}, 0
+# CHECK-SAME: !dbg [[LOC:![0-9]+]]
+# CHECK:      ctx_is_null:
+# CHECK:      call %Nil
+# CHECK-SAME: !dbg [[LOC]]
+# CHECK:      ctx_is_not_null:
+# CHECK:      call %Nil
+# CHECK-SAME: !dbg [[LOC]]
+# CHECK:      [[LOC]] = !DILocation
+# CHECK-SAME: line: 2
+# CHECK-SAME: column: 3

--- a/spec/llvm-ir/test.sh
+++ b/spec/llvm-ir/test.sh
@@ -33,6 +33,7 @@ function test() {
 pushd $BUILD_DIR >/dev/null
 
 test argless-initialize-debug-loc.cr "--cross-compile --target x86_64-unknown-linux-gnu --prelude=empty"
+test proc-call-debug-loc.cr "--cross-compile --target x86_64-unknown-linux-gnu --prelude=empty"
 test proc-pointer-debug-loc.cr "--cross-compile --target x86_64-unknown-linux-gnu --prelude=empty"
 test pass-closure-to-c-debug-loc.cr "--cross-compile --target x86_64-unknown-linux-gnu --prelude=empty"
 
@@ -54,4 +55,3 @@ test cast-unions.cr "--cross-compile --target x86_64-apple-darwin --prelude=empt
 test assign-unions.cr "--cross-compile --target x86_64-apple-darwin --prelude=empty --no-debug" X64
 
 popd >/dev/null
-

--- a/src/compiler/crystal/codegen/call.cr
+++ b/src/compiler/crystal/codegen/call.cr
@@ -503,7 +503,11 @@ class Crystal::CodeGenVisitor
   end
 
   def codegen_call_or_invoke(node, target_def, self_type, func, call_args, raises, type, is_closure = false, fun_type = nil)
-    set_current_debug_location node if @debug.line_numbers?
+    # If *fun_type* is not nil, then this method is being called from
+    # `codegen_primitive_proc_call` and *node* is simply `Proc#call`'s "body";
+    # in that case do not replace line numbers so that call stacks will continue
+    # using the original invocation
+    set_current_debug_location node if @debug.line_numbers? && fun_type.nil?
 
     if raises && (rescue_block = @rescue_block)
       invoke_out_block = new_block "invoke_out"

--- a/src/compiler/crystal/codegen/primitives.cr
+++ b/src/compiler/crystal/codegen/primitives.cr
@@ -977,6 +977,9 @@ class Crystal::CodeGenVisitor
   end
 
   def codegen_primitive_proc_call(node, target_def, call_args)
+    location = @call_location
+    set_current_debug_location(location) if location && @debug.line_numbers?
+
     closure_ptr = call_args[0]
 
     # For non-closure args we use byval attribute and other things


### PR DESCRIPTION
Fixes #10449.

```crystal
->do
  raise "foo"
end.call

# Unhandled exception: foo (Exception)
#   from test.cr:2:3 in '->'
#   from test.cr:3:5 in '__crystal_main'
#   from src/crystal/main.cr:115:5 in 'main_user_code'
# ...
```

The entire inlined body of `Proc#call` now uses the same location as the invocation of `#call` itself, rather than that of the `Proc#call`'s body node. Minimal example:

```crystal
x = ->{ 1 }
y = x.call
```

Before:

```llvm
; ...
  %5 = extractvalue %"->" %4, 0, !dbg !9
  %6 = extractvalue %"->" %4, 1, !dbg !9
  %7 = icmp eq i8* %6, null, !dbg !9
  br i1 %7, label %ctx_is_null, label %ctx_is_not_null, !dbg !9

ctx_is_null:                                      ; preds = %entry
  %8 = bitcast i8* %5 to i32 ()*, !dbg !9
  %9 = call i32 %8(), !dbg !15
  br label %exit, !dbg !15

ctx_is_not_null:                                  ; preds = %entry
  %10 = bitcast i8* %5 to i32 (i8*)*, !dbg !15
  %11 = call i32 %10(i8* %6), !dbg !15
  br label %exit, !dbg !15

exit:                                             ; preds = %ctx_is_not_null, %ctx_is_null
  %12 = phi i32 [ %9, %ctx_is_null ], [ %11, %ctx_is_not_null ], !dbg !15
; ...

!9 = !DILocation(line: 1, column: 1, scope: !10)
!15 = !DILocation(line: 266, column: 3, scope: !16)
!16 = distinct !DILexicalBlock(scope: !4, file: !17, line: 1, column: 1)
!17 = !DIFile(filename: "primitives.cr", directory: "/usr/share/crystal/src")
```

After:

```llvm
; ...
  %5 = extractvalue %"->" %4, 0, !dbg !15
  %6 = extractvalue %"->" %4, 1, !dbg !15
  %7 = icmp eq i8* %6, null, !dbg !15
  br i1 %7, label %ctx_is_null, label %ctx_is_not_null, !dbg !15

ctx_is_null:                                      ; preds = %entry
  %8 = bitcast i8* %5 to i32 ()*, !dbg !15
  %9 = call i32 %8(), !dbg !15
  br label %exit, !dbg !15

ctx_is_not_null:                                  ; preds = %entry
  %10 = bitcast i8* %5 to i32 (i8*)*, !dbg !15
  %11 = call i32 %10(i8* %6), !dbg !15
  br label %exit, !dbg !15

exit:                                             ; preds = %ctx_is_not_null, %ctx_is_null
  %12 = phi i32 [ %9, %ctx_is_null ], [ %11, %ctx_is_not_null ], !dbg !15
; ...

!15 = !DILocation(line: 2, column: 7, scope: !10)
```