### PR TITLE
Add `TypeNode#private?`, `#public?` and `#visibility`

### DIFF
--- a/spec/compiler/macro/macro_methods_spec.cr
+++ b/spec/compiler/macro/macro_methods_spec.cr
@@ -2337,6 +2337,63 @@ module Crystal
           {x: TypeNode.new(program.int32)}
         end
       end
+
+      describe "executes private?" do
+        it false do
+          assert_macro("{{x.private?}}", "false") do |program|
+            klass = GenericClassType.new(program, program, "SomeGenericType", program.reference, ["T"])
+
+            {x: TypeNode.new(klass)}
+          end
+        end
+
+        it true do
+          assert_macro("{{x.private?}}", "true") do |program|
+            klass = GenericClassType.new(program, program, "SomeGenericType", program.reference, ["T"])
+            klass.private = true
+
+            {x: TypeNode.new(klass)}
+          end
+        end
+      end
+
+      describe "public?" do
+        it false do
+          assert_macro("{{x.public?}}", "false") do |program|
+            klass = GenericClassType.new(program, program, "SomeGenericType", program.reference, ["T"])
+            klass.private = true
+
+            {x: TypeNode.new(klass)}
+          end
+        end
+
+        it true do
+          assert_macro("{{x.public?}}", "true") do |program|
+            klass = GenericClassType.new(program, program, "SomeGenericType", program.reference, ["T"])
+
+            {x: TypeNode.new(klass)}
+          end
+        end
+      end
+
+      describe "visibility" do
+        it :public do
+          assert_macro("{{x.visibility}}", ":public") do |program|
+            klass = GenericClassType.new(program, program, "SomeGenericType", program.reference, ["T"])
+
+            {x: TypeNode.new(klass)}
+          end
+        end
+
+        it :private do
+          assert_macro("{{x.visibility}}", ":private") do |program|
+            klass = GenericClassType.new(program, program, "SomeGenericType", program.reference, ["T"])
+            klass.private = true
+
+            {x: TypeNode.new(klass)}
+          end
+        end
+      end
     end
 
     describe "type declaration methods" do

--- a/src/compiler/crystal/macros.cr
+++ b/src/compiler/crystal/macros.cr
@@ -2755,6 +2755,18 @@ module Crystal::Macros
     def resolve? : TypeNode
     end
 
+    # Return `true` if `self` is private and `false` otherwise.
+    def private? : BoolLiteral
+    end
+
+    # Return `true` if `self` is public and `false` otherwise.
+    def public? : BoolLiteral
+    end
+
+    # Returns visibility of `self` as `:public` or `:private?`
+    def visibility : SymbolLiteral
+    end
+
     # Returns `true` if *other* is an ancestor of `self`.
     def <(other : TypeNode) : BoolLiteral
     end

--- a/src/compiler/crystal/macros/methods.cr
+++ b/src/compiler/crystal/macros/methods.cr
@@ -1950,9 +1950,9 @@ module Crystal
       when "visibility"
         interpret_check_args do
           if type.private? 
-            SymbolLiteral.new(:private)
+            SymbolLiteral.new("private")
           else
-            SymbolLiteral.new(:public)
+            SymbolLiteral.new("public")
           end
         end
       else

--- a/src/compiler/crystal/macros/methods.cr
+++ b/src/compiler/crystal/macros/methods.cr
@@ -1949,7 +1949,7 @@ module Crystal
         interpret_check_args { BoolLiteral.new(!type.private?) }
       when "visibility"
         interpret_check_args do
-          if type.private? 
+          if type.private?
             SymbolLiteral.new("private")
           else
             SymbolLiteral.new("public")

--- a/src/compiler/crystal/macros/methods.cr
+++ b/src/compiler/crystal/macros/methods.cr
@@ -1943,6 +1943,18 @@ module Crystal
         interpret_check_args { self }
       when "resolve?"
         interpret_check_args { self }
+      when "private?"
+        interpret_check_args { BoolLiteral.new(type.private?) }
+      when "public?"
+        interpret_check_args { BoolLiteral.new(!type.private?) }
+      when "visibility"
+        interpret_check_args do
+          if type.private? 
+            SymbolLiteral.new(:private)
+          else
+            SymbolLiteral.new(:public)
+          end
+        end
       else
         super
       end


### PR DESCRIPTION
Adds the `TypeNode#private?` method to check for the visibility of classes and modules.

This is mostly relevant for cases in which a `TypeNode` is directly available (e.g. for iterating and resolving any public elements of `TypeNode#ancestors`).

Resolves #11705