### PR TITLE
Remove useless variable declarations in trailing position

### DIFF
--- a/spec/compiler/crystal/tools/playground_spec.cr
+++ b/spec/compiler/crystal/tools/playground_spec.cr
@@ -581,7 +581,7 @@ private def assert_compile(source)
   sources = Playground::Session.instrument_and_prelude("", "", 0, source)
   compiler = Compiler.new
   compiler.no_codegen = true
-  result = compiler.compile sources, "fake-no-build"
+  compiler.compile sources, "fake-no-build"
 end
 
 describe Playground::Session do

--- a/src/compiler/crystal/codegen/codegen.cr
+++ b/src/compiler/crystal/codegen/codegen.cr
@@ -1154,7 +1154,7 @@ module Crystal
       thread_local_fun = check_main_fun(fun_name, thread_local_fun)
       indirection_ptr = alloca llvm_type(type).pointer
       call thread_local_fun, indirection_ptr
-      ptr = load indirection_ptr
+      load indirection_ptr
     end
 
     def visit(node : TypeDeclaration)

--- a/src/compiler/crystal/command/format.cr
+++ b/src/compiler/crystal/command/format.cr
@@ -156,7 +156,7 @@ class Crystal::Command
 
     # This method is for mocking `Crystal.format` in test.
     private def format(filename, source)
-      result = Crystal.format(source, filename: filename)
+      Crystal.format(source, filename: filename)
     end
 
     private def error(msg)

--- a/src/compiler/crystal/util.cr
+++ b/src/compiler/crystal/util.cr
@@ -41,7 +41,7 @@ module Crystal
   )
     source = source.lines if source.is_a? String
     line_number_padding = (source.size + line_number_start).to_s.chars.size
-    lines_with_numbers = source.map_with_index do |line, i|
+    source.map_with_index do |line, i|
       line = line.to_s.chomp
       line_number = "%#{line_number_padding}d" % (i + line_number_start)
       target = i + line_number_start == highlight_line_number

--- a/src/crystal/system/file.cr
+++ b/src/crystal/system/file.cr
@@ -38,7 +38,7 @@ module Crystal::System::File
       raise "Invalid file open mode: '#{mode}'"
     end
 
-    oflag = m | o
+    m | o
   end
 
   # Closes the internal file descriptor without notifying libevent.

--- a/src/socket.cr
+++ b/src/socket.cr
@@ -369,7 +369,7 @@ class Socket < IO
   end
 
   def close_on_exec=(arg : Bool)
-    system_close_on_exec = arg
+    self.system_close_on_exec = arg
   end
 
   def self.fcntl(fd, cmd, arg = 0)


### PR DESCRIPTION
This is a very small subset of #6055 concerned with new variables that become out of scope as soon as they are declared.

There is one behaviour change here: `Socket#close_on_exec=` now actually calls `Crystal::System::Socket#system_close_on_exec=`. The standard library doesn't use this method, but this fix seems correct because `IO::FileDescriptor` does the same.