### PR TITLE
Add examples to `Time::Format` methods

### DIFF
--- a/src/time.cr
+++ b/src/time.cr
@@ -1119,7 +1119,6 @@ struct Time
 
   # Parse time format specified by [RFC 3339](https://tools.ietf.org/html/rfc3339) ([ISO 8601](http://xml.coverpages.org/ISO-FDIS-8601.pdf) profile).
   #
-  # Example:
   # ```
   # Time.parse_rfc3339("2016-02-15T04:35:50Z") # => 2016-02-15 04:35:50.0 UTC
   # ```
@@ -1134,7 +1133,6 @@ struct Time
   #
   # Use `#to_rfc3339` to format a `Time` according to .
   #
-  # Example:
   # ```
   # Time.parse_iso8601("2016-02-15T04:35:50Z") # => 2016-02-15 04:35:50.0 UTC
   # ```
@@ -1165,7 +1163,6 @@ struct Time
   #
   # This is also compatible to [RFC 882](https://tools.ietf.org/html/rfc882) and [RFC 1123](https://tools.ietf.org/html/rfc1123#page-55).
   #
-  # Example:
   # ```
   # Time.parse_rfc2822("Mon, 15 Feb 2016 04:35:50 UTC") # => 2016-02-15 04:35:50.0 UTC
   # ```

--- a/src/time.cr
+++ b/src/time.cr
@@ -1118,6 +1118,11 @@ struct Time
   end
 
   # Parse time format specified by [RFC 3339](https://tools.ietf.org/html/rfc3339) ([ISO 8601](http://xml.coverpages.org/ISO-FDIS-8601.pdf) profile).
+  #
+  # Example:
+  # ```
+  # Time.parse_rfc3339("2016-02-15T04:35:50Z") # => 2016-02-15 04:35:50.0 UTC
+  # ```
   def self.parse_rfc3339(time : String) : self
     Format::RFC_3339.parse(time)
   end
@@ -1128,6 +1133,11 @@ struct Time
   # In ISO 8601 for examples, field delimiters (`-`, `:`) are optional.
   #
   # Use `#to_rfc3339` to format a `Time` according to .
+  #
+  # Example:
+  # ```
+  # Time.parse_iso8601("2016-02-15T04:35:50Z") # => 2016-02-15 04:35:50.0 UTC
+  # ```
   def self.parse_iso8601(time : String)
     Format::ISO_8601_DATE_TIME.parse(time)
   end
@@ -1154,6 +1164,11 @@ struct Time
   # Parse time format specified by [RFC 2822](https://www.ietf.org/rfc/rfc2822.txt).
   #
   # This is also compatible to [RFC 882](https://tools.ietf.org/html/rfc882) and [RFC 1123](https://tools.ietf.org/html/rfc1123#page-55).
+  #
+  # Example:
+  # ```
+  # Time.parse_rfc2822("Mon, 15 Feb 2016 04:35:50 UTC") # => 2016-02-15 04:35:50.0 UTC
+  # ```
   def self.parse_rfc2822(time : String) : self
     Format::RFC_2822.parse(time)
   end

--- a/src/time/format/custom/iso_8601.cr
+++ b/src/time/format/custom/iso_8601.cr
@@ -117,10 +117,8 @@ struct Time::Format
 
   # The ISO 8601 date format.
   #
-  # Example:
   # ```
-  # Time::Format::ISO_8601_DATE.parse("2016-02-15") # => 2016-02-15 00:00:00.0 UTC
-  #
+  # Time::Format::ISO_8601_DATE.parse("2016-02-15")                      # => 2016-02-15 00:00:00.0 UTC
   # Time::Format::ISO_8601_DATE.format(Time.utc(2016, 2, 15, 4, 35, 50)) # => "2016-02-15"
   # ```
   module ISO_8601_DATE
@@ -148,11 +146,9 @@ struct Time::Format
 
   # The ISO 8601 date time format.
   #
-  # Example:
   # ```
   # Time::Format::ISO_8601_DATE_TIME.format(Time.utc(2016, 2, 15, 4, 35, 50)) # => "2016-02-15T04:35:50Z"
-  #
-  # Time::Format::ISO_8601_DATE_TIME.parse("2016-02-15T04:35:50Z") # => 2016-02-15 04:35:50.0 UTC
+  # Time::Format::ISO_8601_DATE_TIME.parse("2016-02-15T04:35:50Z")            # => 2016-02-15 04:35:50.0 UTC
   # ```
   module ISO_8601_DATE_TIME
     # Parses a string into a `Time`.
@@ -179,11 +175,9 @@ struct Time::Format
 
   # The ISO 8601 time format.
   #
-  # Example:
   # ```
   # Time::Format::ISO_8601_TIME.format(Time.utc(2016, 2, 15, 4, 35, 50)) # => "04:35:50Z"
-  #
-  # Time::Format::ISO_8601_TIME.parse("04:35:50Z") # => 0001-01-01 04:35:50.0 UTC
+  # Time::Format::ISO_8601_TIME.parse("04:35:50Z")                       # => 0001-01-01 04:35:50.0 UTC
   # ```
   module ISO_8601_TIME
     # Parses a string into a `Time`.

--- a/src/time/format/custom/iso_8601.cr
+++ b/src/time/format/custom/iso_8601.cr
@@ -116,6 +116,13 @@ struct Time::Format
   end
 
   # The ISO 8601 date format.
+  #
+  # Example:
+  # ```
+  # Time::Format::ISO_8601_DATE.parse("2016-02-15") # => 2016-02-15 00:00:00.0 UTC
+  #
+  # Time::Format::ISO_8601_DATE.format(Time.utc(2016, 2, 15, 4, 35, 50)) # => "2016-02-15"
+  # ```
   module ISO_8601_DATE
     # Parses a string into a `Time`.
     def self.parse(string, location : Time::Location? = Time::Location::UTC) : Time
@@ -140,6 +147,13 @@ struct Time::Format
   end
 
   # The ISO 8601 date time format.
+  #
+  # Example:
+  # ```
+  # Time::Format::ISO_8601_DATE_TIME.format(Time.utc(2016, 2, 15, 4, 35, 50)) # => "2016-02-15T04:35:50Z"
+  #
+  # Time::Format::ISO_8601_DATE_TIME.parse("2016-02-15T04:35:50Z") # => 2016-02-15 04:35:50.0 UTC
+  # ```
   module ISO_8601_DATE_TIME
     # Parses a string into a `Time`.
     def self.parse(string, location : Time::Location? = Time::Location::UTC) : Time
@@ -164,6 +178,13 @@ struct Time::Format
   end
 
   # The ISO 8601 time format.
+  #
+  # Example:
+  # ```
+  # Time::Format::ISO_8601_TIME.format(Time.utc(2016, 2, 15, 4, 35, 50)) # => "04:35:50Z"
+  #
+  # Time::Format::ISO_8601_TIME.parse("04:35:50Z") # => 0001-01-01 04:35:50.0 UTC
+  # ```
   module ISO_8601_TIME
     # Parses a string into a `Time`.
     def self.parse(string, location : Time::Location? = Time::Location::UTC) : Time

--- a/src/time/format/custom/rfc_2822.cr
+++ b/src/time/format/custom/rfc_2822.cr
@@ -2,6 +2,14 @@ struct Time::Format
   # The [RFC 2822](https://tools.ietf.org/html/rfc2822) datetime format.
   #
   # This is also compatible to [RFC 882](https://tools.ietf.org/html/rfc882) and [RFC 1123](https://tools.ietf.org/html/rfc1123#page-55).
+  #
+  # Example:
+  # ```
+  # Time::Format::RFC_2822.format(Time.utc(2016, 2, 15, 4, 35, 50)) # => "Mon, 15 Feb 2016 04:35:50 +0000"
+  #
+  # Time::Format::RFC_2822.parse("Mon, 15 Feb 2016 04:35:50 +0000") # => 2016-02-15 04:35:50.0 +00:00
+  # Time::Format::RFC_2822.parse("Mon, 15 Feb 2016 04:35:50 UTC") # => 2016-02-15 04:35:50.0 UTC
+  # ```
   module RFC_2822
     # Parses a string into a `Time`.
     def self.parse(string, kind = Time::Location::UTC) : Time

--- a/src/time/format/custom/rfc_2822.cr
+++ b/src/time/format/custom/rfc_2822.cr
@@ -8,7 +8,7 @@ struct Time::Format
   # Time::Format::RFC_2822.format(Time.utc(2016, 2, 15, 4, 35, 50)) # => "Mon, 15 Feb 2016 04:35:50 +0000"
   #
   # Time::Format::RFC_2822.parse("Mon, 15 Feb 2016 04:35:50 +0000") # => 2016-02-15 04:35:50.0 +00:00
-  # Time::Format::RFC_2822.parse("Mon, 15 Feb 2016 04:35:50 UTC") # => 2016-02-15 04:35:50.0 UTC
+  # Time::Format::RFC_2822.parse("Mon, 15 Feb 2016 04:35:50 UTC")   # => 2016-02-15 04:35:50.0 UTC
   # ```
   module RFC_2822
     # Parses a string into a `Time`.

--- a/src/time/format/custom/rfc_2822.cr
+++ b/src/time/format/custom/rfc_2822.cr
@@ -3,7 +3,6 @@ struct Time::Format
   #
   # This is also compatible to [RFC 882](https://tools.ietf.org/html/rfc882) and [RFC 1123](https://tools.ietf.org/html/rfc1123#page-55).
   #
-  # Example:
   # ```
   # Time::Format::RFC_2822.format(Time.utc(2016, 2, 15, 4, 35, 50)) # => "Mon, 15 Feb 2016 04:35:50 +0000"
   #

--- a/src/time/format/custom/rfc_3339.cr
+++ b/src/time/format/custom/rfc_3339.cr
@@ -1,5 +1,13 @@
 struct Time::Format
   # The [RFC 3339](https://tools.ietf.org/html/rfc3339) datetime format ([ISO 8601](http://xml.coverpages.org/ISO-FDIS-8601.pdf) profile).
+  #
+  # Example:
+  # ```
+  # Time::Format::RFC_3339.format(Time.utc(2016, 2, 15, 4, 35, 50)) # => "2016-02-15T04:35:50Z"
+  #
+  # Time::Format::RFC_3339.parse("2016-02-15T04:35:50Z") # => 2016-02-15 04:35:50.0 UTC
+  # Time::Format::RFC_3339.parse("2016-02-15 04:35:50Z") # => 2016-02-15 04:35:50.0 UTC
+  # ```
   module RFC_3339
     # Parses a string into a `Time`.
     def self.parse(string, location = Time::Location::UTC) : Time

--- a/src/time/format/custom/rfc_3339.cr
+++ b/src/time/format/custom/rfc_3339.cr
@@ -1,7 +1,6 @@
 struct Time::Format
   # The [RFC 3339](https://tools.ietf.org/html/rfc3339) datetime format ([ISO 8601](http://xml.coverpages.org/ISO-FDIS-8601.pdf) profile).
   #
-  # Example:
   # ```
   # Time::Format::RFC_3339.format(Time.utc(2016, 2, 15, 4, 35, 50)) # => "2016-02-15T04:35:50Z"
   #


### PR DESCRIPTION
I've added examples of the different time formats to the formatters and the `Time#parse_*` functions.

If I can improve something let me know!

Fixes #7472