### PR TITLE
Add missing code blocks for `self` in documentation

### DIFF
--- a/src/array.cr
+++ b/src/array.cr
@@ -676,7 +676,7 @@ class Array(T)
     @buffer[index] = value
   end
 
-  # Removes all elements from self.
+  # Removes all elements from `self`.
   #
   # ```
   # a = ["a", "b", "c", "d", "e"]

--- a/src/bit_array.cr
+++ b/src/bit_array.cr
@@ -379,7 +379,7 @@ struct BitArray
     self
   end
 
-  # Creates a string representation of self.
+  # Creates a string representation of `self`.
   #
   # ```
   # require "bit_array"

--- a/src/log/builder.cr
+++ b/src/log/builder.cr
@@ -61,7 +61,7 @@ class Log::Builder
   end
 
   # Returns a `Log` for the given *source* with a severity level and
-  # backend according to the bindings in *self*.
+  # backend according to the bindings in `self`.
   # If new bindings are applied, the existing `Log` instances will be
   # reconfigured.
   # Calling this method multiple times with the same value will return

--- a/src/log/metadata.cr
+++ b/src/log/metadata.cr
@@ -65,7 +65,7 @@ class Log::Metadata
     value
   end
 
-  # Returns a `Log::Metadata` with all the entries of *self*
+  # Returns a `Log::Metadata` with all the entries of `self`
   # and *other*. If a key is defined in both, the values in *other* are used.
   def extend(other : NamedTuple | Hash) : Metadata
     return Metadata.build(other) if self.empty?
@@ -80,8 +80,8 @@ class Log::Metadata
     @size == 0 && (parent.nil? || parent.empty?)
   end
 
-  # Removes the reference to *parent*. Flattening the entries from it into *self*.
-  # *self* was originally allocated with enough entries to perform this action.
+  # Removes the reference to *parent*. Flattening the entries from it into `self`.
+  # `self` was originally allocated with enough entries to perform this action.
   #
   # If multiple threads execute defrag concurrently, the entries
   # will be recomputed, but the result should be the same.

--- a/src/number.cr
+++ b/src/number.cr
@@ -39,7 +39,7 @@ struct Number
     new(1)
   end
 
-  # Returns self.
+  # Returns `self`.
   def +
     self
   end
@@ -196,7 +196,7 @@ struct Number
   # - `-1` if `self` is less than *other*
   # - `0` if `self` is equal to *other*
   # - `-1` if `self` is greater than *other*
-  # - `nil` if self is `NaN` or *other* is `NaN`, because `NaN` values are not comparable
+  # - `nil` if `self` is `NaN` or *other* is `NaN`, because `NaN` values are not comparable
   def <=>(other) : Int32?
     # NaN can't be compared to other numbers
     return nil if self.is_a?(Float) && self.nan?

--- a/src/slice.cr
+++ b/src/slice.cr
@@ -461,7 +461,7 @@ struct Slice(T)
   # Copies the contents of this slice into *target*.
   #
   # Raises `IndexError` if the destination slice cannot fit the data being transferred
-  # e.g. dest.size < self.size.
+  # e.g. `dest.size < self.size`.
   #
   # ```
   # src = Slice['a', 'a', 'a']

--- a/src/xml/node.cr
+++ b/src/xml/node.cr
@@ -294,7 +294,7 @@ class XML::Node
     end
   end
 
-  # Returns namespaces defined on self element directly.
+  # Returns namespaces defined on this node directly.
   def namespace_definitions : Array(Namespace)
     namespaces = [] of Namespace
 
@@ -307,11 +307,11 @@ class XML::Node
     namespaces
   end
 
-  # Returns namespaces in scope for self – those defined on self element
+  # Returns namespaces in scope for this node – those defined on this node
   # directly or any ancestor node – as an `Array` of `XML::Namespace` objects.
   #
-  # Default namespaces (`"xmlns="` style) for self are included in this array;
-  # Default namespaces for ancestors, however, are not.
+  # Default namespaces (`"xmlns="` style) for this node are included in this
+  # array; default namespaces for ancestors, however, are not.
   #
   # See also `#namespaces`
   def namespace_scopes : Array(Namespace)
@@ -329,7 +329,7 @@ class XML::Node
   #
   # This method returns the same namespaces as `#namespace_scopes`.
   #
-  # Returns namespaces in scope for self – those defined on self element
+  # Returns namespaces in scope for this node – those defined on this node
   # directly or any ancestor node – as a `Hash` of attribute-name/value pairs.
   #
   # NOTE: Note that the keys in this hash XML attributes that would be used to


### PR DESCRIPTION
The changed docs in `XML::Node` do not use `self` because they seem to have a better flow without it.