### PR TITLE
Refactor `etc/completion.bash`

### DIFF
--- a/etc/completion.bash
+++ b/etc/completion.bash
@@ -1,14 +1,33 @@
 # Bash completion for "crystal" command.
 # Written by Sergey Potapov <blake131313@gmail.com>.
 
-# Get list of crystal files or directories, that match $pattern
-_crystal_compgen_files(){
+# Return list of options, that match $pattern
+_crystal_compgen_options(){
+    local IFS=$' \n'
+    local options=$1
+    local pattern=$2
+    COMPREPLY=( $(compgen -W "${options}" -- "${pattern}") )
+}
+
+# Return list of crystal sources or directories, that match $pattern
+_crystal_compgen_sources(){
+    local IFS=$'\n'
     local pattern=$1
-    compgen -f -o plusdirs -X '!*.cr' -- $pattern
+    compopt -o filenames
+    COMPREPLY=( $(compgen -f -o plusdirs -X '!*.cr' -- "${pattern}") )
+}
+
+# Return list of files or directories, that match $pattern (the default action)
+_crystal_compgen_files(){
+    local IFS=$'\n'
+    local pattern=$1
+    compopt -o filenames
+    COMPREPLY=( $(compgen -o default -- "${pattern}") )
 }
 
 _crystal()
 {
+    local IFS=$' \n'
     local program=${COMP_WORDS[0]}
     local cmd=${COMP_WORDS[1]}
     local cur="${COMP_WORDS[COMP_CWORD]}"
@@ -19,61 +38,62 @@ _crystal()
     case "${cmd}" in
         init)
             if [[ "${prev}" == "init" ]] ; then
-                COMPREPLY=( $(compgen -W "app lib" -- ${cur}) )
+                local opts="app lib"
+                _crystal_compgen_options "${opts}" "${cur}"
             else
-                COMPREPLY=( $(compgen -f ${cur}) )
+                _crystal_compgen_files "${cur}"
             fi
             ;;
         build)
-            if [[ ${cur} == -* ]] ; then
+            if [[ "${cur}" == -* ]] ; then
                 local opts="--cross-compile --debug --emit --error-on-warnings --exclude-warnings --ll --link-flags --mcpu --no-color --no-codegen --prelude --release --single-module --threads --target --verbose --warnings --help"
-                COMPREPLY=( $(compgen -W "${opts}" -- ${cur}) )
+                _crystal_compgen_options "${opts}" "${cur}"
             else
-                COMPREPLY=($(_crystal_compgen_files $cur))
+                _crystal_compgen_sources "${cur}"
             fi
             ;;
         run)
-            if [[ ${cur} == -* ]] ; then
+            if [[ "${cur}" == -* ]] ; then
                 local opts="--debug --define --emit --error-on-warnings --exclude-warnings --format --help --ll --link-flags --mcpu --no-color --no-codegen --prelude --release --stats --single-module --threads --verbose --warnings"
-                COMPREPLY=( $(compgen -W "${opts}" -- ${cur}) )
+                _crystal_compgen_options "${opts}" "${cur}"
             else
-                COMPREPLY=($(_crystal_compgen_files $cur))
+                _crystal_compgen_sources "${cur}"
             fi
             ;;
         tool)
-            if [[ ${cur} == -* ]] ; then
+            if [[ "${cur}" == -* ]] ; then
                 local opts="--no-color --prelude --define --format --cursor"
-                COMPREPLY=( $(compgen -W "${opts}" -- ${cur}) )
+                _crystal_compgen_options "${opts}" "${cur}"
             else
                 if [[ "${prev}" == "tool" ]] ; then
                     local subcommands="context format hierarchy implementations types"
-                    COMPREPLY=( $(compgen -W "${subcommands}" -- ${cur}) )
+                    _crystal_compgen_options "${subcommands}" "${cur}"
                 else
-                    COMPREPLY=($(_crystal_compgen_files $cur))
+                    _crystal_compgen_sources "${cur}"
                 fi
             fi
             ;;
         play)
             if [[ ${cur} == -* ]] ; then
                 local opts="--port --binding --verbose --help"
-                COMPREPLY=( $(compgen -W "${opts}" -- ${cur}) )
+                _crystal_compgen_options "${opts}" "${cur}"
             else
-                COMPREPLY=($(_crystal_compgen_files $cur))
+                _crystal_compgen_sources "${cur}"
             fi
             ;;
         docs|eval|spec|version|help)
             # These commands do not accept any options nor subcommands
-            COMPREPLY=( $(compgen -f ${cur}) )
+            _crystal_compgen_files "${cur}"
             ;;
         *)
             # When any of subcommands matches directly
-            if [[ "${prev}" == "${program}" && $(compgen -W "${commands}" -- ${cur})  ]] ; then
-                COMPREPLY=( $(compgen -W "${commands}" -- ${cur}) )
+            if [[ "${prev}" == "${program}" && $(compgen -W "${commands}" -- "${cur}") ]] ; then
+                _crystal_compgen_options "${commands}" "${cur}"
             else
-                COMPREPLY=($(_crystal_compgen_files $cur))
+                _crystal_compgen_sources "${cur}"
             fi
     esac
     return 0
 }
 
-complete -F _crystal -o filenames crystal
+complete -F _crystal crystal


### PR DESCRIPTION
* `COMPREPLY` is now always populated using one of the helper functions, to improve readability.
* The autocompletion script now sets `-o filenames` only when necessary, to prevent commands from being interpreted as directories; for example, `crystal <Tab>` and `crystal init <Tab>` at the repository root would mistakenly return `spec/` and `lib/` respectively.
* Filenames with spaces are now supported, by using the correct `IFS`.