### PR TITLE
Use `OptionParser` in `crystal env`

### DIFF
--- a/src/compiler/crystal/command/env.cr
+++ b/src/compiler/crystal/command/env.cr
@@ -2,8 +2,19 @@
 
 class Crystal::Command
   private def env
-    if ARGV.size == 1 && ARGV[0].in?("--help", "-h")
-      env_usage
+    var_names = [] of String
+
+    OptionParser.parse(@options) do |opts|
+      opts.banner = env_usage
+
+      opts.on("-h", "--help", "Show this message") do
+        puts opts
+        exit
+      end
+
+      opts.unknown_args do |before, after|
+        var_names = before
+      end
     end
 
     vars = {
@@ -14,19 +25,19 @@ class Crystal::Command
       "CRYSTAL_OPTS"         => ENV.fetch("CRYSTAL_OPTS", ""),
     }
 
-    if ARGV.empty?
+    if var_names.empty?
       vars.each do |key, value|
         puts "#{key}=#{Process.quote(value)}"
       end
     else
-      ARGV.each do |key|
+      var_names.each do |key|
         puts vars[key]?
       end
     end
   end
 
   private def env_usage
-    puts <<-USAGE
+    <<-USAGE
     Usage: crystal env [var ...]
 
     Prints Crystal environment information.
@@ -34,8 +45,8 @@ class Crystal::Command
     By default it prints information as a shell script.
     If one or more variable names is given as arguments,
     it prints the value of each named variable on its own line.
-    USAGE
 
-    exit
+    Options:
+    USAGE
   end
 end


### PR DESCRIPTION
Prepares `crystal env` for option flags, and also makes `--help` work regardless of where it appears on the command line (see https://github.com/crystal-lang/crystal/issues/11164#issuecomment-913463901, although it was probably referring to `eval` instead).

Any other command-line arguments starting with a `-` are now considered invalid options. This is unlikely to break anything since none of the defined keys also start with a `-`.