### PR TITLE
Add compatibility profiles for CI

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -96,6 +96,31 @@ jobs:
       - name: Test interpreter
         run: bin/ci with_build_env 'make deps && bin/crystal build -o interpreter_spec spec/compiler/interpreter_spec.cr && ./interpreter_spec'
 
+  test_compatibility:
+    env:
+      ARCH: ${{ matrix.arch }}
+      ARCH_CMD: linux64
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        arch:
+          - x86_64
+        profile:
+          - current
+          - legacy
+    steps:
+      - name: Download Crystal source
+        uses: actions/checkout@v2
+
+      - name: Prepare System
+        run: bin/ci prepare_system
+
+      - name: Prepare Build
+        run: bin/ci prepare_build
+
+      - name: Test
+        run: bin/ci with_build_env 'make crystal std_spec primitives_spec samples profile=${{ matrix.profile }}'
+
   check_format:
     env:
       ARCH: x86_64

--- a/Makefile
+++ b/Makefile
@@ -16,20 +16,29 @@
 CRYSTAL ?= crystal ## which previous crystal compiler use
 LLVM_CONFIG ?=     ## llvm-config command path to use
 
-release ?=      ## Compile in release mode
-stats ?=        ## Enable statistics output
-progress ?=     ## Enable progress output
-threads ?=      ## Maximum number of threads to use
-debug ?=        ## Add symbolic debug info
-verbose ?=      ## Run specs in verbose mode
-junit_output ?= ## Path to output junit results
-static ?=       ## Enable static linking
-interpreter ?=  ## Enable interpreter feature
+release ?=       ## Compile in release mode
+stats ?=         ## Enable statistics output
+progress ?=      ## Enable progress output
+threads ?=       ## Maximum number of threads to use
+debug ?=         ## Add symbolic debug info
+verbose ?=       ## Run specs in verbose mode
+junit_output ?=  ## Path to output junit results
+static ?=        ## Enable static linking
+interpreter ?=   ## Enable interpreter feature
+profile ?= future## Compatibility profile (future|current|legacy)
+
+ifeq ($(profile),future)
+  LANG_FLAGS := -Dstrict_multi_assign
+else ifeq ($(profile),legacy)
+  LANG_FLAGS := -Dno_number_autocast
+else ifneq ($(profile),current)
+  $(error Expected profile to be one of 'future', 'current', or 'legacy', got: $(profile))
+endif
 
 O := .build
 SOURCES := $(shell find src -name '*.cr')
 SPEC_SOURCES := $(shell find spec -name '*.cr')
-override FLAGS += -D strict_multi_assign $(if $(release),--release )$(if $(stats),--stats )$(if $(progress),--progress )$(if $(threads),--threads $(threads) )$(if $(debug),-d )$(if $(static),--static )$(if $(LDFLAGS),--link-flags="$(LDFLAGS)" )$(if $(target),--cross-compile --target $(target) )$(if $(interpreter),,-Dwithout_interpreter )
+override FLAGS += $(LANG_FLAGS) $(if $(release),--release )$(if $(stats),--stats )$(if $(progress),--progress )$(if $(threads),--threads $(threads) )$(if $(debug),-d )$(if $(static),--static )$(if $(LDFLAGS),--link-flags="$(LDFLAGS)" )$(if $(target),--cross-compile --target $(target) )$(if $(interpreter),,-Dwithout_interpreter )
 SPEC_WARNINGS_OFF := --exclude-warnings spec/std --exclude-warnings spec/compiler --exclude-warnings spec/primitives
 SPEC_FLAGS := $(if $(verbose),-v )$(if $(junit_output),--junit_output $(junit_output) )
 CRYSTAL_CONFIG_LIBRARY_PATH := '$$ORIGIN/../lib/crystal'
@@ -116,7 +125,7 @@ smoke_test: $(O)/std_spec $(O)/compiler_spec $(O)/crystal
 
 .PHONY: samples ## Build example programs
 samples:
-	$(MAKE) -C samples
+	$(MAKE) -C samples FLAGS=$(LANG_FLAGS)
 
 .PHONY: docs
 docs: ## Generate standard library documentation

--- a/samples/Makefile
+++ b/samples/Makefile
@@ -1,5 +1,6 @@
 CRYSTAL := ../bin/crystal## Crystal compiler to use
 O := .build## Output directory
+FLAGS ?=## Additional compiler flags
 
 BUILDABLE_SOURCES := $(wildcard *.cr llvm/*.cr compiler/*.cr)
 NONLINK_SOURCES := $(wildcard sdl/*.cr)
@@ -15,11 +16,11 @@ build: $(BUILDABLE_BINARIES) $(NONLINK_BINARIES) ## Build sample binaries
 
 $(O)/%: %.cr
 	mkdir -p $(shell dirname $@)
-	$(CRYSTAL) build $< -o $@
+	$(CRYSTAL) build $(FLAGS) $< -o $@
 
 $(O)/%.o: %.cr
 	mkdir -p $(shell dirname $@)
-	$(CRYSTAL) build --cross-compile $< -o $(patsubst %.o,%,$@)
+	$(CRYSTAL) build $(FLAGS) --cross-compile $< -o $(patsubst %.o,%,$@)
 
 .PHONY: clean
 clean: ## Remove build artifacts


### PR DESCRIPTION
Adds CI tests for the different profiles described in #11706.

The three profiles are now called `future`, `current`, and `legacy`. The default profile for the Makefile is still `future`; I think it captures the intent better than either `latest` or `strict`.