### PR TITLE
Remove string allocation from `GC_set_warn_proc`

### DIFF
--- a/src/gc/boehm.cr
+++ b/src/gc/boehm.cr
@@ -132,20 +132,13 @@ module GC
     # By default the GC warns on big allocations/reallocations. This
     # is of limited use and pollutes program output with warnings.
     LibGC.set_warn_proc ->(msg, v) do
-      unless GC.starts_with?(msg, "GC Warning: Repeated allocation of very large block")
+      start = "GC Warning: Repeated allocation of very large block"
+      # This implements `String#starts_with?` without allocating a `String` (#11728)
+      format_string = Slice.new(msg, Math.min(LibC.strlen(msg), start.bytesize))
+      unless format_string == start.to_slice
         LibC.printf msg, v
       end
     end
-  end
-
-  # :nodoc:
-  # This method implements `String#starts_with?` without allocating a `String` (#11728)
-  def self.starts_with?(string_pointer, start)
-    start.to_slice.each_with_index do |chr, i|
-      return false unless chr == string_pointer[i]
-    end
-
-    true
   end
 
   def self.collect

--- a/src/gc/boehm.cr
+++ b/src/gc/boehm.cr
@@ -132,11 +132,20 @@ module GC
     # By default the GC warns on big allocations/reallocations. This
     # is of limited use and pollutes program output with warnings.
     LibGC.set_warn_proc ->(msg, v) do
-      format_string = String.new(msg)
-      unless format_string.starts_with?("GC Warning: Repeated allocation of very large block")
-        LibC.printf format_string, v
+      unless GC.starts_with?(msg, "GC Warning: Repeated allocation of very large block")
+        LibC.printf msg, v
       end
     end
+  end
+
+  # :nodoc:
+  # This method implements `String#starts_with?` without allocating a `String` (#11728)
+  def self.starts_with?(string_pointer, start)
+    start.to_slice.each_with_index do |chr, i|
+      return false unless chr == string_pointer[i]
+    end
+
+    true
   end
 
   def self.collect


### PR DESCRIPTION
#11289 introduced logic to suppress some common GC warning messages which are identified by comparing the start of the warning message.

In oder to use `String#starts_with?` from Crystal's stdlib, the C string passed to the proc needs to be converted to a `String` which requires allocating memory for the new string. This isn't mentioned in the documentation of libgc, but it's seems to be not a good idea to allocate from within an allocation warning handler.

This patch removes the `String` allocation and instead recognizes a matching message directly from the C string.

Resolves #11728

/cc #6389 which is similarly about avoiding `String` allocations when working with C strings.