### PR TITLE
[docs] Create a search-optimized index.json and include JSON schema

### DIFF
--- a/src/compiler/crystal/tools/doc/generator.cr
+++ b/src/compiler/crystal/tools/doc/generator.cr
@@ -89,6 +89,7 @@ class Crystal::Doc::Generator
 
     main_index = Main.new(raw_body, Type.new(self, @program), project_info)
     File.write File.join(@output_dir, "index.json"), main_index
+    File.write File.join(@output_dir, "search-index.json"), main_index.to_json_search
     File.write File.join(@output_dir, "search-index.js"), main_index.to_jsonp
 
     File.write File.join(@output_dir, "404.html"), MainTemplate.new(Error404Template.new.to_s, types, project_info)

--- a/src/compiler/crystal/tools/doc/generator.cr
+++ b/src/compiler/crystal/tools/doc/generator.cr
@@ -92,6 +92,7 @@ class Crystal::Doc::Generator
     File.write File.join(@output_dir, "search-index.js"), main_index.to_jsonp
 
     File.write File.join(@output_dir, "404.html"), MainTemplate.new(Error404Template.new.to_s, types, project_info)
+    File.write File.join(@output_dir, "schema.json"), SchemaTemplate.new
   end
 
   def generate_sitemap(types)

--- a/src/compiler/crystal/tools/doc/html/js/_search.js
+++ b/src/compiler/crystal/tools/doc/html/js/_search.js
@@ -544,7 +544,7 @@ CrystalDocs.loadIndex = function() {
         loadScript(jsonPath);
         return;
       } else {
-        var jsonPath = script.src.replace("js/doc.js", "index.json");
+        var jsonPath = script.src.replace("js/doc.js", "search-index.json");
         loadJSON(jsonPath, parseJSON);
         return;
       }

--- a/src/compiler/crystal/tools/doc/html/js/_search.js
+++ b/src/compiler/crystal/tools/doc/html/js/_search.js
@@ -84,7 +84,7 @@ CrystalDocs.runQuery = function(query) {
 
     if (method.args) {
       method.args.forEach(function(arg){
-        var argMatches = query.matches(arg.external_name);
+        var argMatches = query.matches(arg);
         if (argMatches) {
           matches = matches.concat(argMatches);
           matchedFields.push("args");

--- a/src/compiler/crystal/tools/doc/html/schema.json
+++ b/src/compiler/crystal/tools/doc/html/schema.json
@@ -1,0 +1,209 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$ref": "#/definitions/Crystal",
+  "definitions": {
+    "Crystal": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "repository_name": { "type": "string" },
+        "body": { "type": "string" },
+        "program": { "$ref": "#/definitions/Type" }
+      },
+      "required": ["body", "program", "repository_name"]
+    },
+    "SimpleType": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "html_id": { "type": "string" },
+        "kind": { "$ref": "#/definitions/Kind" },
+        "full_name": { "type": "string" },
+        "name": { "type": "string" }
+      },
+      "required": ["full_name", "html_id", "kind", "name"]
+    },
+    "Method": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "html_id": { "type": "string" },
+        "name": { "type": "string" },
+        "doc": { "type": "string" },
+        "summary": { "type": "string" },
+        "abstract": { "type": "boolean" },
+        "args": {
+          "type": "array",
+          "items": { "$ref": "#/definitions/Arg" }
+        },
+        "args_string": { "type": "string" },
+        "args_html": { "type": "string" },
+        "location": {
+          "$ref": "#/definitions/Location"
+        },
+        "def": { "$ref": "#/definitions/Def" }
+      },
+      "required": [
+        "abstract",
+        "def",
+        "html_id",
+        "name"
+      ]
+    },
+    "Arg": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "name": { "type": "string" },
+        "doc": { "type": "string" },
+        "default_value": { "type": "string" },
+        "external_name": { "type": "string" },
+        "restriction": { "type": "string" }
+      },
+      "required": ["external_name", "name", "restriction"]
+    },
+    "Def": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "name": { "type": "string" },
+        "args": {
+          "type": "array",
+          "items": { "$ref": "#/definitions/Arg" }
+        },
+        "double_splat": { "$ref": "#/definitions/Arg" },
+        "splat_index": { "type": "integer" },
+        "yields": { "type": "integer" },
+        "block_arg": { "$ref": "#/definitions/Arg" },
+        "return_type": { "type": "string" },
+        "visibility": { "$ref": "#/definitions/Visibility" },
+        "body": { "type": "string" }
+      },
+      "required": [
+        "body",
+        "name",
+        "visibility"
+      ]
+    },
+    "Location": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "filename": { "type": "string" },
+        "line_number": { "type": "integer" },
+        "url": { "type": "string" }
+      },
+      "required": ["filename", "line_number", "url"]
+    },
+    "Constant": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "id": { "type": "string" },
+        "name": { "type": "string" },
+        "value": { "type": "string" },
+        "doc": { "type": "string" },
+        "summary": { "type": "string" }
+      },
+      "required": ["id", "name", "value"],
+      "title": "Constant"
+    },
+    "Type": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "html_id": { "type": "string" },
+        "path": { "type": "string" },
+        "kind": { "$ref": "#/definitions/Kind" },
+        "full_name": { "type": "string" },
+        "name": { "type": "string" },
+        "abstract": { "type": "boolean" },
+        "superclass": {
+          "$ref": "#/definitions/SimpleType"
+        },
+        "ancestors": {
+          "type": "array",
+          "items": { "$ref": "#/definitions/SimpleType" }
+        },
+        "locations": {
+          "type": "array",
+          "items": { "$ref": "#/definitions/Location" }
+        },
+        "repository_name": { "type": "string" },
+        "program": { "type": "boolean" },
+        "enum": { "type": "boolean" },
+        "alias": { "type": "boolean" },
+        "aliased": { "type": "string" },
+        "aliased_html": { "type": "string" },
+        "const": { "type": "boolean" },
+        "constants": {
+          "type": "array",
+          "items": { "$ref": "#/definitions/Constant" }
+        },
+        "included_modules": {
+          "type": "array",
+          "items": { "$ref": "#/definitions/SimpleType" }
+        },
+        "extended_modules": {
+          "type": "array",
+          "items": { "$ref": "#/definitions/SimpleType" }
+        },
+        "subclasses": {
+          "type": "array",
+          "items": { "$ref": "#/definitions/SimpleType" }
+        },
+        "including_types": {
+          "type": "array",
+          "items": { "$ref": "#/definitions/SimpleType" }
+        },
+        "namespace": {
+          "$ref": "#/definitions/SimpleType"
+        },
+        "doc": { "type": "string" },
+        "summary": { "type": "string" },
+        "class_methods": {
+          "type": "array",
+          "items": { "$ref": "#/definitions/Method" }
+        },
+        "constructors": {
+          "type": "array",
+          "items": { "$ref": "#/definitions/Method" }
+        },
+        "instance_methods": {
+          "type": "array",
+          "items": { "$ref": "#/definitions/Method" }
+        },
+        "macros": {
+          "type": "array",
+          "items": { "$ref": "#/definitions/Method" }
+        },
+        "types": {
+          "type": "array",
+          "items": { "$ref": "#/definitions/Type" }
+        }
+      },
+      "required": [
+        "abstract",
+        "alias",
+        "const",
+        "enum",
+        "full_name",
+        "html_id",
+        "kind",
+        "locations",
+        "name",
+        "path",
+        "program",
+        "repository_name"
+      ]
+    },
+    "Kind": {
+      "type": "string",
+      "enum": ["module", "class", "struct", "alias", "annotation", "enum"]
+    },
+    "Visibility": {
+      "type": "string",
+      "enum": ["Public", "Protected", "Private"]
+    }
+  }
+}

--- a/src/compiler/crystal/tools/doc/html/search-schema.json
+++ b/src/compiler/crystal/tools/doc/html/search-schema.json
@@ -1,0 +1,177 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$ref": "#/definitions/Crystal",
+  "definitions": {
+    "Crystal": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "repository_name": { "type": "string" },
+        "body": { "type": "string" },
+        "program": { "$ref": "#/definitions/Type" }
+      },
+      "required": ["body", "program", "repository_name"]
+    },
+    "SimpleType": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "html_id": { "type": "string" },
+        "kind": { "$ref": "#/definitions/Kind" },
+        "full_name": { "type": "string" },
+        "name": { "type": "string" }
+      },
+      "required": ["full_name", "html_id", "kind", "name"]
+    },
+    "Method": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "html_id": { "type": "string" },
+        "name": { "type": "string" },
+        "doc": { "type": "string" },
+        "summary": { "type": "string" },
+        "args": {
+          "type": "array",
+          "items": { "$ref": "#/definitions/Arg" }
+        },
+        "args_string": { "type": "string" },
+        "def": { "$ref": "#/definitions/Def" }
+      },
+      "required": [
+        "def",
+        "html_id",
+        "name"
+      ]
+    },
+    "Arg": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "name": { "type": "string" },
+        "doc": { "type": "string" },
+        "default_value": { "type": "string" },
+        "external_name": { "type": "string" },
+        "restriction": { "type": "string" }
+      },
+      "required": ["external_name", "name", "restriction"]
+    },
+    "Def": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "name": { "type": "string" },
+        "args": {
+          "type": "array",
+          "items": { "$ref": "#/definitions/Arg" }
+        },
+        "double_splat": { "$ref": "#/definitions/Arg" },
+        "splat_index": { "type": "integer" },
+        "yields": { "type": "integer" },
+        "block_arg": { "$ref": "#/definitions/Arg" },
+        "return_type": { "type": "string" },
+        "visibility": { "$ref": "#/definitions/Visibility" },
+        "body": { "type": "string" }
+      },
+      "required": [
+        "body",
+        "name",
+        "visibility"
+      ]
+    },
+    "Location": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "filename": { "type": "string" },
+        "line_number": { "type": "integer" },
+        "url": { "type": "string" }
+      },
+      "required": ["filename", "line_number", "url"]
+    },
+    "Constant": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "id": { "type": "string" },
+        "name": { "type": "string" },
+        "value": { "type": "string" },
+        "doc": { "type": "string" },
+        "summary": { "type": "string" }
+      },
+      "required": ["id", "name", "value"],
+      "title": "Constant"
+    },
+    "Type": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "html_id": { "type": "string" },
+        "path": { "type": "string" },
+        "kind": { "$ref": "#/definitions/Kind" },
+        "full_name": { "type": "string" },
+        "name": { "type": "string" },
+        "constants": {
+          "type": "array",
+          "items": { "$ref": "#/definitions/Constant" }
+        },
+        "included_modules": {
+          "type": "array",
+          "items": { "$ref": "#/definitions/SimpleType" }
+        },
+        "extended_modules": {
+          "type": "array",
+          "items": { "$ref": "#/definitions/SimpleType" }
+        },
+        "subclasses": {
+          "type": "array",
+          "items": { "$ref": "#/definitions/SimpleType" }
+        },
+        "including_types": {
+          "type": "array",
+          "items": { "$ref": "#/definitions/SimpleType" }
+        },
+        "namespace": {
+          "$ref": "#/definitions/SimpleType"
+        },
+        "doc": { "type": "string" },
+        "summary": { "type": "string" },
+        "class_methods": {
+          "type": "array",
+          "items": { "$ref": "#/definitions/Method" }
+        },
+        "constructors": {
+          "type": "array",
+          "items": { "$ref": "#/definitions/Method" }
+        },
+        "instance_methods": {
+          "type": "array",
+          "items": { "$ref": "#/definitions/Method" }
+        },
+        "macros": {
+          "type": "array",
+          "items": { "$ref": "#/definitions/Method" }
+        },
+        "types": {
+          "type": "array",
+          "items": { "$ref": "#/definitions/Type" }
+        }
+      },
+      "required": [
+        "full_name",
+        "html_id",
+        "kind",
+        "name",
+        "path"
+      ]
+    },
+    "Kind": {
+      "type": "string",
+      "enum": ["module", "class", "struct", "alias", "annotation", "enum"]
+    },
+    "Visibility": {
+      "type": "string",
+      "enum": ["Public", "Protected", "Private"]
+    }
+  }
+}

--- a/src/compiler/crystal/tools/doc/html/search-schema.json
+++ b/src/compiler/crystal/tools/doc/html/search-schema.json
@@ -115,22 +115,6 @@
           "type": "array",
           "items": { "$ref": "#/definitions/Constant" }
         },
-        "included_modules": {
-          "type": "array",
-          "items": { "$ref": "#/definitions/SimpleType" }
-        },
-        "extended_modules": {
-          "type": "array",
-          "items": { "$ref": "#/definitions/SimpleType" }
-        },
-        "subclasses": {
-          "type": "array",
-          "items": { "$ref": "#/definitions/SimpleType" }
-        },
-        "including_types": {
-          "type": "array",
-          "items": { "$ref": "#/definitions/SimpleType" }
-        },
         "namespace": {
           "$ref": "#/definitions/SimpleType"
         },

--- a/src/compiler/crystal/tools/doc/html/search-schema.json
+++ b/src/compiler/crystal/tools/doc/html/search-schema.json
@@ -35,11 +35,9 @@
           "type": "array",
           "items": { "$ref": "#/definitions/Arg" }
         },
-        "args_string": { "type": "string" },
-        "def": { "$ref": "#/definitions/Def" }
+        "args_string": { "type": "string" }
       },
       "required": [
-        "def",
         "html_id",
         "name"
       ]
@@ -49,45 +47,9 @@
       "additionalProperties": false,
       "properties": {
         "name": { "type": "string" },
-        "doc": { "type": "string" },
-        "default_value": { "type": "string" },
-        "external_name": { "type": "string" },
-        "restriction": { "type": "string" }
+        "external_name": { "type": "string" }
       },
-      "required": ["external_name", "name", "restriction"]
-    },
-    "Def": {
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "name": { "type": "string" },
-        "args": {
-          "type": "array",
-          "items": { "$ref": "#/definitions/Arg" }
-        },
-        "double_splat": { "$ref": "#/definitions/Arg" },
-        "splat_index": { "type": "integer" },
-        "yields": { "type": "integer" },
-        "block_arg": { "$ref": "#/definitions/Arg" },
-        "return_type": { "type": "string" },
-        "visibility": { "$ref": "#/definitions/Visibility" },
-        "body": { "type": "string" }
-      },
-      "required": [
-        "body",
-        "name",
-        "visibility"
-      ]
-    },
-    "Location": {
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "filename": { "type": "string" },
-        "line_number": { "type": "integer" },
-        "url": { "type": "string" }
-      },
-      "required": ["filename", "line_number", "url"]
+      "required": ["external_name", "name"]
     },
     "Constant": {
       "type": "object",
@@ -152,10 +114,6 @@
     "Kind": {
       "type": "string",
       "enum": ["module", "class", "struct", "alias", "annotation", "enum"]
-    },
-    "Visibility": {
-      "type": "string",
-      "enum": ["Public", "Protected", "Private"]
     }
   }
 }

--- a/src/compiler/crystal/tools/doc/html/search-schema.json
+++ b/src/compiler/crystal/tools/doc/html/search-schema.json
@@ -33,7 +33,7 @@
         "summary": { "type": "string" },
         "args": {
           "type": "array",
-          "items": { "$ref": "#/definitions/Arg" }
+          "items": { "type": "string" }
         },
         "args_string": { "type": "string" }
       },
@@ -41,16 +41,6 @@
         "html_id",
         "name"
       ]
-    },
-    "Arg": {
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "name": { "type": "string" },
-        "doc": { "type": "string" },
-        "external_name": { "type": "string" }
-      },
-      "required": ["external_name", "name"]
     },
     "Constant": {
       "type": "object",

--- a/src/compiler/crystal/tools/doc/html/search-schema.json
+++ b/src/compiler/crystal/tools/doc/html/search-schema.json
@@ -12,17 +12,6 @@
       },
       "required": ["body", "program", "repository_name"]
     },
-    "SimpleType": {
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "html_id": { "type": "string" },
-        "kind": { "$ref": "#/definitions/Kind" },
-        "full_name": { "type": "string" },
-        "name": { "type": "string" }
-      },
-      "required": ["full_name", "html_id", "kind", "name"]
-    },
     "Method": {
       "type": "object",
       "additionalProperties": false,
@@ -67,9 +56,6 @@
         "constants": {
           "type": "array",
           "items": { "$ref": "#/definitions/Constant" }
-        },
-        "namespace": {
-          "$ref": "#/definitions/SimpleType"
         },
         "doc": { "type": "string" },
         "summary": { "type": "string" },

--- a/src/compiler/crystal/tools/doc/html/search-schema.json
+++ b/src/compiler/crystal/tools/doc/html/search-schema.json
@@ -47,6 +47,7 @@
       "additionalProperties": false,
       "properties": {
         "name": { "type": "string" },
+        "doc": { "type": "string" },
         "external_name": { "type": "string" }
       },
       "required": ["external_name", "name"]

--- a/src/compiler/crystal/tools/doc/macro.cr
+++ b/src/compiler/crystal/tools/doc/macro.cr
@@ -165,7 +165,15 @@ class Crystal::Doc::Macro
       builder.field "name", name
       builder.field "doc", doc unless doc.nil?
       builder.field "summary", formatted_summary unless formatted_summary.nil?
-      builder.field "args", args unless args.empty?
+
+      unless args.empty?
+        builder.field "args" do
+          builder.array do
+            args.each &.to_json_search(builder)
+          end
+        end
+      end
+
       builder.field "args_string", args_to_s unless args.empty?
     end
   end

--- a/src/compiler/crystal/tools/doc/macro.cr
+++ b/src/compiler/crystal/tools/doc/macro.cr
@@ -165,15 +165,7 @@ class Crystal::Doc::Macro
       builder.field "name", name
       builder.field "doc", doc unless doc.nil?
       builder.field "summary", formatted_summary unless formatted_summary.nil?
-
-      unless args.empty?
-        builder.field "args" do
-          builder.array do
-            args.each &.to_json_search(builder)
-          end
-        end
-      end
-
+      builder.field "args", args.map &.external_name unless args.empty?
       builder.field "args_string", args_to_s unless args.empty?
     end
   end

--- a/src/compiler/crystal/tools/doc/macro.cr
+++ b/src/compiler/crystal/tools/doc/macro.cr
@@ -159,6 +159,17 @@ class Crystal::Doc::Macro
     end
   end
 
+  def to_json_search(builder : JSON::Builder)
+    builder.object do
+      builder.field "html_id", id
+      builder.field "name", name
+      builder.field "doc", doc unless doc.nil?
+      builder.field "summary", formatted_summary unless formatted_summary.nil?
+      builder.field "args", args unless args.empty?
+      builder.field "args_string", args_to_s unless args.empty?
+    end
+  end
+
   def annotations(annotation_type)
     @macro.annotations(annotation_type)
   end

--- a/src/compiler/crystal/tools/doc/main.cr
+++ b/src/compiler/crystal/tools/doc/main.cr
@@ -12,7 +12,7 @@ module Crystal::Doc
 
     def to_jsonp(io : IO)
       io << "crystal_doc_search_index_callback("
-      to_json(io)
+      JSON.build(io) { |json| to_json_search json }
       io << ')'
     end
 
@@ -22,6 +22,18 @@ module Crystal::Doc
         builder.field "body", body
         builder.field "program", program
       end
+    end
+
+    def to_json_search(builder : JSON::Builder)
+      builder.object do
+        builder.field "repository_name", project_info.name
+        builder.field "body", body
+        builder.field "program" { program.to_json_search builder }
+      end
+    end
+
+    def to_json_search
+      JSON.build { |json| to_json_search json }
     end
   end
 end

--- a/src/compiler/crystal/tools/doc/method.cr
+++ b/src/compiler/crystal/tools/doc/method.cr
@@ -333,6 +333,21 @@ class Crystal::Doc::Method
     end
   end
 
+  def to_json_search(builder : JSON::Builder)
+    builder.object do
+      builder.field "html_id", id
+      builder.field "name", name
+      builder.field "doc", doc unless doc.nil?
+      builder.field "summary", formatted_summary unless formatted_summary.nil?
+      builder.field "abstract", abstract?
+      builder.field "args", args unless args.empty?
+      builder.field "args_string", args_to_s unless args.empty?
+      builder.field "args_html", args_to_html unless args.empty?
+      builder.field "location", location unless location.nil?
+      builder.field "def", self.def
+    end
+  end
+
   def annotations(annotation_type)
     @def.annotations(annotation_type)
   end

--- a/src/compiler/crystal/tools/doc/method.cr
+++ b/src/compiler/crystal/tools/doc/method.cr
@@ -339,15 +339,7 @@ class Crystal::Doc::Method
       builder.field "name", name
       builder.field "doc", doc unless doc.nil?
       builder.field "summary", formatted_summary unless formatted_summary.nil?
-
-      unless args.empty?
-        builder.field "args" do
-          builder.array do
-            args.each &.to_json_search(builder)
-          end
-        end
-      end
-
+      builder.field "args", args.map &.external_name unless args.empty?
       builder.field "args_string", args_to_s unless args.empty?
     end
   end

--- a/src/compiler/crystal/tools/doc/method.cr
+++ b/src/compiler/crystal/tools/doc/method.cr
@@ -339,7 +339,15 @@ class Crystal::Doc::Method
       builder.field "name", name
       builder.field "doc", doc unless doc.nil?
       builder.field "summary", formatted_summary unless formatted_summary.nil?
-      builder.field "args", args unless args.empty?
+
+      unless args.empty?
+        builder.field "args" do
+          builder.array do
+            args.each &.to_json_search(builder)
+          end
+        end
+      end
+
       builder.field "args_string", args_to_s unless args.empty?
     end
   end

--- a/src/compiler/crystal/tools/doc/method.cr
+++ b/src/compiler/crystal/tools/doc/method.cr
@@ -339,11 +339,8 @@ class Crystal::Doc::Method
       builder.field "name", name
       builder.field "doc", doc unless doc.nil?
       builder.field "summary", formatted_summary unless formatted_summary.nil?
-      builder.field "abstract", abstract?
       builder.field "args", args unless args.empty?
       builder.field "args_string", args_to_s unless args.empty?
-      builder.field "args_html", args_to_html unless args.empty?
-      builder.field "location", location unless location.nil?
       builder.field "def", self.def
     end
   end

--- a/src/compiler/crystal/tools/doc/method.cr
+++ b/src/compiler/crystal/tools/doc/method.cr
@@ -341,7 +341,6 @@ class Crystal::Doc::Method
       builder.field "summary", formatted_summary unless formatted_summary.nil?
       builder.field "args", args unless args.empty?
       builder.field "args_string", args_to_s unless args.empty?
-      builder.field "def", self.def
     end
   end
 

--- a/src/compiler/crystal/tools/doc/templates.cr
+++ b/src/compiler/crystal/tools/doc/templates.cr
@@ -96,4 +96,8 @@ module Crystal::Doc
   record SitemapTemplate, types : Array(Type), base_url : String, priority : String, changefreq : String do
     ECR.def_to_s "#{__DIR__}/html/sitemap.xml"
   end
+
+  struct SchemaTemplate
+    ECR.def_to_s "#{__DIR__}/html/schema.json"
+  end
 end

--- a/src/compiler/crystal/tools/doc/to_json.cr
+++ b/src/compiler/crystal/tools/doc/to_json.cr
@@ -4,7 +4,7 @@ class Crystal::Arg
       builder.field "name", name
       builder.field "doc", doc unless doc.nil?
       builder.field "default_value", default_value.to_s unless default_value.nil?
-      builder.field "external_name", external_name.to_s
+      builder.field "external_name", external_name unless external_name == name
       builder.field "restriction", restriction.to_s
     end
   end

--- a/src/compiler/crystal/tools/doc/to_json.cr
+++ b/src/compiler/crystal/tools/doc/to_json.cr
@@ -8,6 +8,14 @@ class Crystal::Arg
       builder.field "restriction", restriction.to_s
     end
   end
+
+  def to_json_search(builder : JSON::Builder)
+    builder.object do
+      builder.field "name", name
+      builder.field "doc", doc unless doc.nil?
+      builder.field "external_name", external_name.to_s
+    end
+  end
 end
 
 class Crystal::Def

--- a/src/compiler/crystal/tools/doc/to_json.cr
+++ b/src/compiler/crystal/tools/doc/to_json.cr
@@ -4,7 +4,7 @@ class Crystal::Arg
       builder.field "name", name
       builder.field "doc", doc unless doc.nil?
       builder.field "default_value", default_value.to_s unless default_value.nil?
-      builder.field "external_name", external_name unless external_name == name
+      builder.field "external_name", external_name.to_s
       builder.field "restriction", restriction.to_s
     end
   end

--- a/src/compiler/crystal/tools/doc/to_json.cr
+++ b/src/compiler/crystal/tools/doc/to_json.cr
@@ -8,14 +8,6 @@ class Crystal::Arg
       builder.field "restriction", restriction.to_s
     end
   end
-
-  def to_json_search(builder : JSON::Builder)
-    builder.object do
-      builder.field "name", name
-      builder.field "doc", doc unless doc.nil?
-      builder.field "external_name", external_name.to_s
-    end
-  end
 end
 
 class Crystal::Def

--- a/src/compiler/crystal/tools/doc/type.cr
+++ b/src/compiler/crystal/tools/doc/type.cr
@@ -860,13 +860,6 @@ class Crystal::Doc::Type
       builder.field "full_name", full_name
       builder.field "name", name
       builder.field "constants", constants unless constants.empty?
-      unless included_modules.empty?
-        builder.field "included_modules" do
-          builder.array do
-            included_modules.each &.to_json_simple(builder)
-          end
-        end
-      end
 
       unless instance_methods.empty?
         builder.field "instance_methods" do

--- a/src/compiler/crystal/tools/doc/type.cr
+++ b/src/compiler/crystal/tools/doc/type.cr
@@ -793,7 +793,7 @@ class Crystal::Doc::Type
             ancestors.each &.to_json_simple(builder)
           end
         end
-      end unless ancestors.empty?
+      end
       builder.field "locations", locations
       builder.field "repository_name", @generator.project_info.name
       builder.field "program", program?

--- a/src/compiler/crystal/tools/doc/type.cr
+++ b/src/compiler/crystal/tools/doc/type.cr
@@ -851,6 +851,97 @@ class Crystal::Doc::Type
     end
   end
 
+
+  def to_json_search(builder : JSON::Builder)
+    builder.object do
+      builder.field "html_id", html_id
+      builder.field "path", path
+      builder.field "kind", kind
+      builder.field "full_name", full_name
+      builder.field "name", name
+      builder.field "abstract", abstract?
+      builder.field "superclass" { superclass.try &.to_json_simple(builder) } unless superclass.nil?
+      unless ancestors.empty?
+        builder.field "ancestors" do
+          builder.array do
+            ancestors.each &.to_json_simple(builder)
+          end
+        end
+      end
+
+      builder.field "locations", locations
+      builder.field "repository_name", @generator.project_info.name
+      builder.field "program", program?
+      builder.field "enum", enum?
+      builder.field "alias", alias?
+      builder.field "aliased", alias_definition.to_s if alias?
+      builder.field "aliased_html", formatted_alias_definition if alias?
+      builder.field "const", const?
+      builder.field "constants", constants unless constants.empty?
+      unless included_modules.empty?
+        builder.field "included_modules" do
+          builder.array do
+            included_modules.each &.to_json_simple(builder)
+          end
+        end
+      end
+
+      unless extended_modules.empty?
+        builder.field "extended_modules" do
+          builder.array do
+            extended_modules.each &.to_json_simple(builder)
+          end
+        end
+      end
+
+      unless subclasses.empty?
+        builder.field "subclasses" do
+          builder.array do
+            subclasses.each &.to_json_simple(builder)
+          end
+        end
+      end
+
+      unless including_types.empty?
+        builder.field "including_types" do
+          builder.array do
+            including_types.each &.to_json_simple(builder)
+          end
+        end
+      end
+
+      unless instance_methods.empty?
+        builder.field "instance_methods" do
+          builder.array do
+            instance_methods.each &.to_json_search(builder)
+          end
+        end
+      end
+
+      unless constructors.empty?
+        builder.field "constructors" do
+          builder.array do
+            constructors.each &.to_json_search(builder)
+          end
+        end
+      end
+
+      unless class_methods.empty?
+        builder.field "class_methods" do
+          builder.array do
+            class_methods.each &.to_json_search(builder)
+          end
+        end
+      end
+
+      builder.field "namespace" { namespace.try &.to_json_simple(builder) } unless namespace.nil?
+      builder.field "doc", doc unless doc.nil?
+      builder.field "summary", formatted_summary unless formatted_summary.nil?
+      builder.field "macros", macros unless macros.empty?
+      builder.field "types", types unless types.empty?
+    end
+  end
+
   def annotations(annotation_type)
     @type.annotations(annotation_type)
   end

--- a/src/compiler/crystal/tools/doc/type.cr
+++ b/src/compiler/crystal/tools/doc/type.cr
@@ -793,7 +793,7 @@ class Crystal::Doc::Type
             ancestors.each &.to_json_simple(builder)
           end
         end
-      end
+      end unless ancestors.empty?
       builder.field "locations", locations
       builder.field "repository_name", @generator.project_info.name
       builder.field "program", program?

--- a/src/compiler/crystal/tools/doc/type.cr
+++ b/src/compiler/crystal/tools/doc/type.cr
@@ -859,53 +859,11 @@ class Crystal::Doc::Type
       builder.field "kind", kind
       builder.field "full_name", full_name
       builder.field "name", name
-      builder.field "abstract", abstract?
-      builder.field "superclass" { superclass.try &.to_json_simple(builder) } unless superclass.nil?
-      unless ancestors.empty?
-        builder.field "ancestors" do
-          builder.array do
-            ancestors.each &.to_json_simple(builder)
-          end
-        end
-      end
-
-      builder.field "locations", locations
-      builder.field "repository_name", @generator.project_info.name
-      builder.field "program", program?
-      builder.field "enum", enum?
-      builder.field "alias", alias?
-      builder.field "aliased", alias_definition.to_s if alias?
-      builder.field "aliased_html", formatted_alias_definition if alias?
-      builder.field "const", const?
       builder.field "constants", constants unless constants.empty?
       unless included_modules.empty?
         builder.field "included_modules" do
           builder.array do
             included_modules.each &.to_json_simple(builder)
-          end
-        end
-      end
-
-      unless extended_modules.empty?
-        builder.field "extended_modules" do
-          builder.array do
-            extended_modules.each &.to_json_simple(builder)
-          end
-        end
-      end
-
-      unless subclasses.empty?
-        builder.field "subclasses" do
-          builder.array do
-            subclasses.each &.to_json_simple(builder)
-          end
-        end
-      end
-
-      unless including_types.empty?
-        builder.field "including_types" do
-          builder.array do
-            including_types.each &.to_json_simple(builder)
           end
         end
       end

--- a/src/compiler/crystal/tools/doc/type.cr
+++ b/src/compiler/crystal/tools/doc/type.cr
@@ -900,7 +900,6 @@ class Crystal::Doc::Type
         end
       end
 
-      builder.field "namespace" { namespace.try &.to_json_simple(builder) } unless namespace.nil?
       builder.field "doc", doc unless doc.nil?
       builder.field "summary", formatted_summary unless formatted_summary.nil?
     end

--- a/src/compiler/crystal/tools/doc/type.cr
+++ b/src/compiler/crystal/tools/doc/type.cr
@@ -885,11 +885,18 @@ class Crystal::Doc::Type
         end
       end
 
+      unless types.empty?
+        builder.field "types" do
+          builder.array do
+            types.each &.to_json_search(builder)
+          end
+        end
+      end
+
       builder.field "namespace" { namespace.try &.to_json_simple(builder) } unless namespace.nil?
       builder.field "doc", doc unless doc.nil?
       builder.field "summary", formatted_summary unless formatted_summary.nil?
       builder.field "macros", macros unless macros.empty?
-      builder.field "types", types unless types.empty?
     end
   end
 

--- a/src/compiler/crystal/tools/doc/type.cr
+++ b/src/compiler/crystal/tools/doc/type.cr
@@ -851,7 +851,6 @@ class Crystal::Doc::Type
     end
   end
 
-
   def to_json_search(builder : JSON::Builder)
     builder.object do
       builder.field "html_id", html_id
@@ -893,10 +892,17 @@ class Crystal::Doc::Type
         end
       end
 
+      unless macros.empty?
+        builder.field "macros" do
+          builder.array do
+            macros.each &.to_json_search(builder)
+          end
+        end
+      end
+
       builder.field "namespace" { namespace.try &.to_json_simple(builder) } unless namespace.nil?
       builder.field "doc", doc unless doc.nil?
       builder.field "summary", formatted_summary unless formatted_summary.nil?
-      builder.field "macros", macros unless macros.empty?
     end
   end
 


### PR DESCRIPTION
This is a (rebased) continuation of #11438, further addressing #11427 by creating a separate `search-index.json` optimized *just* for what the search functionality needs, while keeping the "full" `index.json` exactly as it was after #11438.
With this, the `search-index.json` file is around **3.6 MB**, nearly three times smaller than the full `index.json` one.

Also included is two [JSON schema](https://json-schema.org/) files, one for `index.json` and one for `search-index.json`, which have been validated for the output of the output of the stdlib docs using [ajv](https://ajv.js.org/).
![image](https://user-images.githubusercontent.com/53803019/148763136-34542e5f-3e95-4b4e-873d-41db2503c338.png)
