### PR TITLE
Fix parsing semicolon plus newline between expressions in parenthesis

### DIFF
--- a/spec/compiler/parser/to_s_spec.cr
+++ b/spec/compiler/parser/to_s_spec.cr
@@ -24,6 +24,7 @@ private def expect_to_s(original, expected = original, emit_doc = false, file = 
 end
 
 describe "ASTNode#to_s" do
+  expect_to_s "(a=1;\nb=2)", "(a = 1\nb = 2)"
   expect_to_s "([] of T).foo"
   expect_to_s "({} of K => V).foo"
   expect_to_s "foo(bar)"

--- a/src/compiler/crystal/syntax/parser.cr
+++ b/src/compiler/crystal/syntax/parser.cr
@@ -1778,7 +1778,7 @@ module Crystal
           next_token_skip_space
           break
         when :NEWLINE, :";"
-          next_token_skip_space
+          next_token_skip_statement_end
           if @token.type == :")"
             @wants_regex = false
             next_token_skip_space


### PR DESCRIPTION
So statement terminators work as expected in parens.

```crystal
a = 1;
b = :a;
(
  a = 1;
  b = :a;
)
```