### PR TITLE
Fix documentation for macros `system` and `run`

### DIFF
--- a/src/compiler/crystal/macros.cr
+++ b/src/compiler/crystal/macros.cr
@@ -186,7 +186,12 @@ module Crystal::Macros
   def `(command) : MacroId
   end
 
-  # :ditto:
+  # Executes a system command and returns the output as a `MacroId`.
+  # Gives a compile-time error if the command failed to execute.
+  #
+  # ```
+  # {{ system("echo hi") }} # => "hi\n"
+  # ```
   def system(command) : MacroId
   end
 
@@ -223,8 +228,8 @@ module Crystal::Macros
   #
   # The file denoted by *filename* must be a valid Crystal program.
   # This macro invocation passes *args* to the program as regular
-  # program arguments. The program must output a valid Crystal expression.
-  # This output is the result of this macro invocation, as a `MacroId`.
+  # program arguments. This output is the result of this macro invocation,
+  # as a `MacroId`.
   #
   # The `run` macro is useful when the subset of available macro methods
   # are not enough for your purposes and you need something more powerful.


### PR DESCRIPTION
The `system` macro was using the same documentation as the ` macro, but they are not the exact same.

`system` is a normal method call without special syntax.

---

I also made a small correction to the `run` macro documentation: The command doesn't have to output a valid Crystal expression, in fact, the doc example doesn't. It only needs to be a valid expression if the MacroId is used directly (which is the case of all MacroIds).