### PR TITLE
Implement `Intrinsics.pause` for aarch64

### DIFF
--- a/src/intrinsics.cr
+++ b/src/intrinsics.cr
@@ -110,10 +110,10 @@ lib LibIntrinsics
 
   {% if flag?(:arm) %}
     {% if flag?(:interpreted) %} @[Primitive(:interpreter_intrinsics_pause)] {% end %}
-    fun arm_hint = "llvm.arm.hint"(hint : ARMHint)
+    fun arm_hint = "llvm.arm.hint"(hint : Int32)
   {% elsif flag?(:aarch64) %}
     {% if flag?(:interpreted) %} @[Primitive(:interpreter_intrinsics_pause)] {% end %}
-    fun arm_hint = "llvm.aarch64.hint"(hint : ARMHint)
+    fun arm_hint = "llvm.aarch64.hint"(hint : Int32)
   {% end %}
 end
 

--- a/src/intrinsics.cr
+++ b/src/intrinsics.cr
@@ -107,6 +107,14 @@ lib LibIntrinsics
     {% if flag?(:interpreted) %} @[Primitive(:interpreter_intrinsics_pause)] {% end %}
     fun pause = "llvm.x86.sse2.pause"
   {% end %}
+
+  {% if flag?(:arm) %}
+    {% if flag?(:interpreted) %} @[Primitive(:interpreter_intrinsics_pause)] {% end %}
+    fun arm_hint = "llvm.arm.hint"(hint : ARMHint)
+  {% elsif flag?(:aarch64) %}
+    {% if flag?(:interpreted) %} @[Primitive(:interpreter_intrinsics_pause)] {% end %}
+    fun arm_hint = "llvm.aarch64.hint"(hint : ARMHint)
+  {% end %}
 end
 
 module Intrinsics
@@ -117,6 +125,8 @@ module Intrinsics
   def self.pause
     {% if flag?(:i386) || flag?(:x86_64) %}
       LibIntrinsics.pause
+    {% elsif flag?(:arm) || flag?(:aarch64) %}
+      LibIntrinsics.arm_hint(1) # YIELD
     {% end %}
   end
 

--- a/src/intrinsics.cr
+++ b/src/intrinsics.cr
@@ -108,10 +108,7 @@ lib LibIntrinsics
     fun pause = "llvm.x86.sse2.pause"
   {% end %}
 
-  {% if flag?(:arm) %}
-    {% if flag?(:interpreted) %} @[Primitive(:interpreter_intrinsics_pause)] {% end %}
-    fun arm_hint = "llvm.arm.hint"(hint : Int32)
-  {% elsif flag?(:aarch64) %}
+  {% if flag?(:aarch64) %}
     {% if flag?(:interpreted) %} @[Primitive(:interpreter_intrinsics_pause)] {% end %}
     fun arm_hint = "llvm.aarch64.hint"(hint : Int32)
   {% end %}
@@ -125,7 +122,7 @@ module Intrinsics
   def self.pause
     {% if flag?(:i386) || flag?(:x86_64) %}
       LibIntrinsics.pause
-    {% elsif flag?(:arm) || flag?(:aarch64) %}
+    {% elsif flag?(:aarch64) %}
       LibIntrinsics.arm_hint(1) # YIELD
     {% end %}
   end


### PR DESCRIPTION
This was made by @jgaskins, full credits to him. Taken from https://forum.crystal-lang.org/t/intrinsics-pause-no-op-on-non-intel-cpus/4199.

Implements `Intrinsics.pause` for ARM. This is useful for busy loops inside a spinlock or a mutex implementation. Doesn't change correctness, but should provide some speedup in very high contention cases.

Update: Only AArch64 is supported because the plain ARM variant (`llvm.arm.hint`) seems to require ARMv7 at least and I don't see a way to select it.