### PR TITLE
Fix buffer overflow in `String#index`

### DIFF
--- a/spec/std/string_spec.cr
+++ b/spec/std/string_spec.cr
@@ -900,6 +900,7 @@ describe "String" do
       it { "日本語日本語".index("本語").should eq(1) }
       it { "\xFF\xFFcrystal".index("crystal").should eq(2) }
       it { "\xFD\x9A\xAD\x50NG".index("PNG").should eq(3) }
+      it { "🧲$".index("✅").should be_nil } # #11745
 
       describe "with offset" do
         it { "foobarbaz".index("ba", 4).should eq(6) }

--- a/src/string.cr
+++ b/src/string.cr
@@ -3132,10 +3132,9 @@ class String
         return char_index
       end
 
-      return if pointer >= end_pointer
-
       byte = head_pointer.value
       char_bytesize = String.char_bytesize_at(head_pointer)
+      return if pointer + char_bytesize > end_pointer
       case char_bytesize
       when 1 then update_hash 1
       when 2 then update_hash 2


### PR DESCRIPTION
`String#char_bytesize_at` calculates the size at `head_pointer` and both `head_pointer` and `pointer` advance by the number of bytes in `update_hash`. That can move `pointer` beyond `end_pointer`, outside the valid range.

This fix moves the limit check to the right location, directly before advancing any pointers and taking the current char's bytesize into account.

Resolves #11745