### PR TITLE
Add allow `Enumerable` arguments for `Hash#select` and `#reject`

### DIFF
--- a/spec/std/hash_spec.cr
+++ b/spec/std/hash_spec.cr
@@ -1110,6 +1110,7 @@ describe "Hash" do
 
   describe "reject" do
     it { {:a => 2, :b => 3}.reject(:b, :d).should eq({:a => 2}) }
+    it { {:a => 2, :b => 3}.reject(Set{:b, :d}).should eq({:a => 2}) }
     it { {:a => 2, :b => 3}.reject(:b, :a).should eq({} of Symbol => Int32) }
     it { {:a => 2, :b => 3}.reject([:b, :a]).should eq({} of Symbol => Int32) }
     it "does not change current hash" do
@@ -1121,6 +1122,7 @@ describe "Hash" do
 
   describe "reject!" do
     it { {:a => 2, :b => 3}.reject!(:b, :d).should eq({:a => 2}) }
+    it { {:a => 2, :b => 3}.reject!(Set{:b, :d}).should eq({:a => 2}) }
     it { {:a => 2, :b => 3}.reject!(:b, :a).should eq({} of Symbol => Int32) }
     it { {:a => 2, :b => 3}.reject!([:b, :a]).should eq({} of Symbol => Int32) }
     it "changes current hash" do
@@ -1135,6 +1137,7 @@ describe "Hash" do
     it { {:a => 2, :b => 3}.select.should eq({} of Symbol => Int32) }
     it { {:a => 2, :b => 3}.select(:b, :a).should eq({:a => 2, :b => 3}) }
     it { {:a => 2, :b => 3}.select([:b, :a]).should eq({:a => 2, :b => 3}) }
+    it { {:a => 2, :b => 3}.select(Set{:b, :a}).should eq({:a => 2, :b => 3}) }
     it "does not change current hash" do
       h = {:a => 3, :b => 6, :c => 9}
       h2 = h.select(:b, :c)
@@ -1147,6 +1150,7 @@ describe "Hash" do
     it { {:a => 2, :b => 3}.select!.should eq({} of Symbol => Int32) }
     it { {:a => 2, :b => 3}.select!(:b, :a).should eq({:a => 2, :b => 3}) }
     it { {:a => 2, :b => 3}.select!([:b, :a]).should eq({:a => 2, :b => 3}) }
+    it { {:a => 2, :b => 3}.select!(Set{:b, :a}).should eq({:a => 2, :b => 3}) }
     it "does change current hash" do
       h = {:a => 3, :b => 6, :c => 9}
       h.select!(:b, :c)

--- a/src/hash.cr
+++ b/src/hash.cr
@@ -1479,7 +1479,7 @@ class Hash(K, V)
   # h = {"a" => 1, "b" => 2, "c" => 3, "d" => 4}.reject!("a", "c")
   # h # => {"b" => 2, "d" => 4}
   # ```
-  def reject!(keys : Array | Tuple) : self
+  def reject!(keys : Enumerable) : self
     keys.each { |k| delete(k) }
     self
   end
@@ -1491,11 +1491,12 @@ class Hash(K, V)
   # Returns a new `Hash` with the given keys.
   #
   # ```
-  # {"a" => 1, "b" => 2, "c" => 3, "d" => 4}.select({"a", "c"}) # => {"a" => 1, "c" => 3}
-  # {"a" => 1, "b" => 2, "c" => 3, "d" => 4}.select("a", "c")   # => {"a" => 1, "c" => 3}
-  # {"a" => 1, "b" => 2, "c" => 3, "d" => 4}.select(["a", "c"]) # => {"a" => 1, "c" => 3}
+  # {"a" => 1, "b" => 2, "c" => 3, "d" => 4}.select({"a", "c"})    # => {"a" => 1, "c" => 3}
+  # {"a" => 1, "b" => 2, "c" => 3, "d" => 4}.select("a", "c")      # => {"a" => 1, "c" => 3}
+  # {"a" => 1, "b" => 2, "c" => 3, "d" => 4}.select(["a", "c"])    # => {"a" => 1, "c" => 3}
+  # {"a" => 1, "b" => 2, "c" => 3, "d" => 4}.select(Set{"a", "c"}) # => {"a" => 1, "c" => 3}
   # ```
-  def select(keys : Array | Tuple) : Hash(K, V)
+  def select(keys : Enumerable) : Hash(K, V)
     hash = {} of K => V
     keys.each { |k| hash[k] = self[k] if has_key?(k) }
     hash
@@ -1512,10 +1513,11 @@ class Hash(K, V)
   # h1 = {"a" => 1, "b" => 2, "c" => 3, "d" => 4}.select!({"a", "c"})
   # h2 = {"a" => 1, "b" => 2, "c" => 3, "d" => 4}.select!("a", "c")
   # h3 = {"a" => 1, "b" => 2, "c" => 3, "d" => 4}.select!(["a", "c"])
-  # h1 == h2 == h3 # => true
-  # h1             # => {"a" => 1, "c" => 3}
+  # h4 = {"a" => 1, "b" => 2, "c" => 3, "d" => 4}.select!(Set{"a", "c"})
+  # h1 == h2 == h3 == h4 # => true
+  # h1                   # => {"a" => 1, "c" => 3}
   # ```
-  def select!(keys : Array | Tuple) : self
+  def select!(keys : Enumerable) : self
     each { |k, v| delete(k) unless keys.includes?(k) }
     self
   end


### PR DESCRIPTION
Right now these methods accept `Array | Tuple`.
But I think it's would be nice to add `Set`.

---

I know it can be easily done with `.to_a`:

```
set = Set{:b, :d}
hash = {:a => 2, :b => 3}

p! hash.reject(set.to_a)
p! hash.select(set.to_a)
```

Let me know what is your opinion.

---

UPD:

Changed to `Enumerable`, as recommended by @straight-shoota. 