### PR TITLE
Fix `make install` for BSD

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -132,17 +132,22 @@ llvm_ext: $(LLVM_EXT_OBJ)
 
 .PHONY: install
 install: $(O)/crystal man/crystal.1.gz ## Install the compiler at DESTDIR
-	$(INSTALL) -D -m 0755 "$(O)/crystal" "$(BINDIR)/crystal"
+	$(INSTALL) -d -m 0755 "$(BINDIR)/"
+	$(INSTALL) -m 0755 "$(O)/crystal" "$(BINDIR)/crystal"
 
 	$(INSTALL) -d -m 0755 $(DATADIR)
 	cp -av src "$(DATADIR)/src"
 	rm -rf "$(DATADIR)/$(LLVM_EXT_OBJ)" # Don't install llvm_ext.o
 
-	$(INSTALL) -D -m 644 man/crystal.1.gz "$(MANDIR)/man1/crystal.1.gz"
-	$(INSTALL) -D -m 644 LICENSE "$(DESTDIR)$(PREFIX)/share/licenses/crystal/LICENSE"
+	$(INSTALL) -d -m 0755 "$(MANDIR)/man1/"
+	$(INSTALL) -m 644 man/crystal.1.gz "$(MANDIR)/man1/crystal.1.gz"
+	$(INSTALL) -d -m 0755 "$(DESTDIR)$(PREFIX)/share/licenses/crystal/"
+	$(INSTALL) -m 644 LICENSE "$(DESTDIR)$(PREFIX)/share/licenses/crystal/LICENSE"
 
-	$(INSTALL) -D -m 644 etc/completion.bash "$(DESTDIR)$(PREFIX)/share/bash-completion/completions/crystal"
-	$(INSTALL) -D -m 644 etc/completion.zsh "$(DESTDIR)$(PREFIX)/share/zsh/site-functions/_crystal"
+	$(INSTALL) -d -m 0755 "$(DESTDIR)$(PREFIX)/share/bash-completion/completions/"
+	$(INSTALL) -m 644 etc/completion.bash "$(DESTDIR)$(PREFIX)/share/bash-completion/completions/crystal"
+	$(INSTALL) -d -m 0755 "$(DESTDIR)$(PREFIX)/share/zsh/site-functions/"
+	$(INSTALL) -m 644 etc/completion.zsh "$(DESTDIR)$(PREFIX)/share/zsh/site-functions/_crystal"
 
 .PHONY: uninstall
 uninstall: ## Uninstall the compiler from DESTDIR


### PR DESCRIPTION
The BSD variant of the `install` command doesn't have a `-D` option, so we must create the parent directories explicitly.

Fixes #11757 