### PR TITLE
Add error when instance variable is inherited from module and supertype

### DIFF
--- a/spec/compiler/semantic/instance_var_spec.cr
+++ b/spec/compiler/semantic/instance_var_spec.cr
@@ -5387,4 +5387,166 @@ describe "Semantic: instance var" do
       ),
       "can't infer the type of instance variable '@x' of Foo"
   end
+
+  it "errors when overriding inherited instance variable with incompatible type" do
+    assert_error <<-CR, "instance variable '@a' of A must be Int32, not (Char | Int32)"
+      class A
+        @a = 1
+      end
+
+      class B < A
+        @a = 'a'
+      end
+      CR
+  end
+
+  it "accepts overriding inherited instance variable with compatible type" do
+    semantic <<-CR
+      class A
+        @a = 1
+      end
+
+      class B < A
+        @a = 2
+      end
+      CR
+  end
+
+  describe "instance variable inherited from multiple parents" do
+    context "with compatible type" do
+      pending "module and class, with declarations" do
+        assert_error <<-CR, "instance variable '@a' of B is already defined in A"
+          module M
+            @a : Int32 = 1
+          end
+
+          class A
+            @a : Int32 = 2
+          end
+
+          class B < A
+            include M
+          end
+          CR
+      end
+
+      pending "module and class, with definitions" do
+        assert_error <<-CR, "instance variable '@a' of B is already defined in A"
+          module M
+            @a = 1
+          end
+
+          class A
+            @a = 2
+          end
+
+          class B < A
+            include M
+          end
+          CR
+      end
+
+      it "accepts module and module, with definitions" do
+        semantic <<-CR
+          module M
+            @a = 1
+          end
+
+          module N
+            @a = 2
+          end
+
+          class B
+            include N
+            include M
+          end
+          CR
+      end
+
+      it "accepts module and module, with declarations" do
+        semantic <<-CR
+          module M
+            @a : Int32?
+          end
+
+          module N
+            @a : Int32?
+          end
+
+          class B
+            include N
+            include M
+          end
+          CR
+      end
+    end
+
+    context "with incompatible type" do
+      it "module and class, with definitions" do
+        assert_error <<-CR, "instance variable '@a' of A must be Int32, not (Char | Int32)"
+          module M
+            @a = 'a'
+          end
+
+          class A
+            @a = 1
+          end
+
+          class B < A
+            include M
+          end
+          CR
+      end
+
+      it "module and class, with declarations" do
+        assert_error <<-CR, "instance variable '@a' of A must be Int32, not (Char | Int32)"
+          module M
+            @a : Char = 'a'
+          end
+
+          class A
+            @a : Int32 = 1
+          end
+
+          class B < A
+            include M
+          end
+          CR
+      end
+
+      it "errors module and module, with definitions" do
+        assert_error <<-CR, "instance variable '@a' of B must be Char, not (Char | Int32)"
+          module M
+            @a = 'c'
+          end
+
+          module N
+            @a = 1
+          end
+
+          class B
+            include N
+            include M
+          end
+          CR
+      end
+
+      it "errors module and module, with declarations" do
+        assert_error <<-CR, "instance variable '@a' of B must be Int32, not (Char | Int32)"
+          module M
+            @a : Char = 'c'
+          end
+
+          module N
+            @a : Int32 = 1
+          end
+
+          class B
+            include N
+            include M
+          end
+          CR
+      end
+    end
+  end
 end

--- a/spec/compiler/semantic/instance_var_spec.cr
+++ b/spec/compiler/semantic/instance_var_spec.cr
@@ -5414,7 +5414,7 @@ describe "Semantic: instance var" do
 
   describe "instance variable inherited from multiple parents" do
     context "with compatible type" do
-      pending "module and class, with declarations" do
+      it "module and class, with declarations" do
         assert_error <<-CR, "instance variable '@a' of B is already defined in A"
           module M
             @a : Int32 = 1
@@ -5430,7 +5430,7 @@ describe "Semantic: instance var" do
           CR
       end
 
-      pending "module and class, with definitions" do
+      it "module and class, with definitions" do
         assert_error <<-CR, "instance variable '@a' of B is already defined in A"
           module M
             @a = 1
@@ -5483,7 +5483,7 @@ describe "Semantic: instance var" do
 
     context "with incompatible type" do
       it "module and class, with definitions" do
-        assert_error <<-CR, "instance variable '@a' of A must be Int32, not (Char | Int32)"
+        assert_error <<-CR, "instance variable '@a' of B is already defined in A"
           module M
             @a = 'a'
           end
@@ -5499,7 +5499,7 @@ describe "Semantic: instance var" do
       end
 
       it "module and class, with declarations" do
-        assert_error <<-CR, "instance variable '@a' of A must be Int32, not (Char | Int32)"
+        assert_error <<-CR, "instance variable '@a' of B is already defined in A"
           module M
             @a : Char = 'a'
           end


### PR DESCRIPTION
This patch detects the faulty state described in #11673 and raises a proper compiler error with context information.

Unfortunately, I have not been able to trace the original owner of the instance variable (module `M`). It seems this information is not accessible at that point in the semantic stage. So that could be a point for improvement. The source location is available and from there you can discover the defining type.

I'm also adding a number of additional specs for similar behaviour. This was already working as expected though, but I couldn't find specs (maybe I missed them and I'm just adding more 🤷).

