### PR TITLE
Fix parser error with semicolon + newline in parenthezied `Expressions`

### DIFF
--- a/spec/compiler/parser/parser_spec.cr
+++ b/spec/compiler/parser/parser_spec.cr
@@ -503,6 +503,7 @@ module Crystal
     it_parses "(foo bar do\nend)", Expressions.new([Call.new(nil, "foo", ["bar".call] of ASTNode, Block.new)] of ASTNode)
     it_parses "(baz; bar do\nend)", Expressions.new(["baz".call, Call.new(nil, "bar", [] of ASTNode, Block.new)] of ASTNode)
     it_parses "(bar {})", Expressions.new([Call.new(nil, "bar", [] of ASTNode, Block.new)] of ASTNode)
+    it_parses "(a;\nb)", Expressions.new([Call.new(nil, "a"), Call.new(nil, "b")] of ASTNode)
     it_parses "1.x; foo do\nend", [Call.new(1.int32, "x"), Call.new(nil, "foo", block: Block.new)] of ASTNode
     it_parses "x = 1; foo.bar x do\nend", [Assign.new("x".var, 1.int32), Call.new("foo".call, "bar", ["x".var] of ASTNode, Block.new)]
 

--- a/spec/compiler/parser/to_s_spec.cr
+++ b/spec/compiler/parser/to_s_spec.cr
@@ -24,7 +24,6 @@ private def expect_to_s(original, expected = original, emit_doc = false, file = 
 end
 
 describe "ASTNode#to_s" do
-  expect_to_s "(a=1;\nb=2)", "(a = 1\nb = 2)"
   expect_to_s "([] of T).foo"
   expect_to_s "({} of K => V).foo"
   expect_to_s "foo(bar)"

--- a/spec/compiler/parser/to_s_spec.cr
+++ b/spec/compiler/parser/to_s_spec.cr
@@ -24,6 +24,7 @@ private def expect_to_s(original, expected = original, emit_doc = false, file = 
 end
 
 describe "ASTNode#to_s" do
+  expect_to_s "(a=1;\nb=2)", "(a = 1\nb = 2)"
   expect_to_s "([] of T).foo"
   expect_to_s "({} of K => V).foo"
   expect_to_s "foo(bar)"

--- a/src/compiler/crystal/syntax/parser.cr
+++ b/src/compiler/crystal/syntax/parser.cr
@@ -1778,7 +1778,7 @@ module Crystal
           next_token_skip_space
           break
         when :NEWLINE, :";"
-          next_token_skip_space
+          next_token_skip_statement_end
           if @token.type == :")"
             @wants_regex = false
             next_token_skip_space


### PR DESCRIPTION
Re-issue of abandoned #11739

Minimal reproduction of the error:
```cr
(1; # Error: unexpected token: "NEWLINE"
2)
```
