### PR TITLE
Allow use of super() for subtype overrides of Enum#parse? and Enum#from_value?

### DIFF
--- a/spec/std/enum_spec.cr
+++ b/spec/std/enum_spec.cr
@@ -49,8 +49,8 @@ private enum SpecEnumWithCaseSensitiveMembers
 end
 
 private enum SpecEnumWithMethodOverrides
-  FOO
-  BAR
+  FOO = 1
+  BAR = 2
 
   def self.parse?(string : String)
     result = super(string)
@@ -61,6 +61,23 @@ private enum SpecEnumWithMethodOverrides
         result = FOO
       when "b"
         result = BAR
+      end
+    end
+
+    result
+  end
+
+  def self.from_value?(value : Int)
+    result = super(value)
+
+    if result.nil?
+      case value
+      when 10
+        result = FOO
+      when 20
+        result = BAR
+      else
+        p! value
       end
     end
 
@@ -360,5 +377,10 @@ describe Enum do
     SpecEnumWithMethodOverrides.parse?("foo").should eq SpecEnumWithMethodOverrides::FOO
     SpecEnumWithMethodOverrides.parse?("b").should eq SpecEnumWithMethodOverrides::BAR
     SpecEnumWithMethodOverrides.parse?("bar").should eq SpecEnumWithMethodOverrides::BAR
+
+    SpecEnumWithMethodOverrides.from_value?(10).should eq SpecEnumWithMethodOverrides::FOO
+    SpecEnumWithMethodOverrides.from_value?(1).should eq SpecEnumWithMethodOverrides::FOO
+    SpecEnumWithMethodOverrides.from_value?(20).should eq SpecEnumWithMethodOverrides::BAR
+    SpecEnumWithMethodOverrides.from_value?(2).should eq SpecEnumWithMethodOverrides::BAR
   end
 end

--- a/spec/std/enum_spec.cr
+++ b/spec/std/enum_spec.cr
@@ -48,6 +48,26 @@ private enum SpecEnumWithCaseSensitiveMembers
   Foo = 2
 end
 
+private enum SpecEnumWithMethodOverrides
+  FOO
+  BAR
+
+  def self.parse?(string : String)
+    result = super(string)
+
+    if result.nil?
+      case string
+      when "f"
+        result = FOO
+      when "b"
+        result = BAR
+      end
+    end
+
+    result
+  end
+end
+
 describe Enum do
   describe "to_s" do
     it "for simple enum" do
@@ -292,6 +312,7 @@ describe Enum do
   describe "each" do
     it "iterates each member" do
       keys = [] of SpecEnum
+
       values = [] of Int8
 
       SpecEnum.each do |key, value|
@@ -332,5 +353,12 @@ describe Enum do
 
   it "different enums classes not eq always" do
     SpecEnum::One.should_not eq SpecEnum2::FortyTwo
+  end
+
+  it "allows the use of super in child methods" do
+    SpecEnumWithMethodOverrides.parse?("f").should eq SpecEnumWithMethodOverrides::FOO
+    SpecEnumWithMethodOverrides.parse?("foo").should eq SpecEnumWithMethodOverrides::FOO
+    SpecEnumWithMethodOverrides.parse?("b").should eq SpecEnumWithMethodOverrides::BAR
+    SpecEnumWithMethodOverrides.parse?("bar").should eq SpecEnumWithMethodOverrides::BAR
   end
 end

--- a/src/enum.cr
+++ b/src/enum.cr
@@ -352,7 +352,7 @@ struct Enum
   # Color.from_value?(2) # => Color::Blue
   # Color.from_value?(3) # => nil
   # ```
-  def self.from_value?(value : Int) : self?
+  def self.from_value?(value : Int)
     {% if @type.annotation(Flags) %}
       all_mask = {{@type}}::All.value
       return if all_mask & value != value

--- a/src/enum.cr
+++ b/src/enum.cr
@@ -431,7 +431,7 @@ struct Enum
   # ```
   #
   # If multiple members match the same normalized string, the first one is returned.
-  def self.parse?(string : String) : self?
+  def self.parse?(string : String)
     {% begin %}
       case string.camelcase.downcase
       # Temporarily map all constants to their normalized value in order to


### PR DESCRIPTION
Before this PR, `Enum` subtypes (i.e. enums) could not override `Enum#parse?` or `Enum#from_value?` and use `super` in the method body. The reason was that both methods return `self?`, so `super` would call them with `self` as `Enum`, leading to the error below because unions currently can't include `Enum`.

```crystal
enum Something
  Alphabet
  Numeric

  def self.parse?(string : String) : self?
    result = super string # => Error: can't use Enum in unions yet, use a more specific type

    if result.nil?
      case string
      when "abc"
        result = Alphabet
      when "123"
        result = Numeric
      end
    end

    result
  end
end

s = Something.parse? "abc"
t = Something.parse? "numeric"
```

To fix the issue, I simply removed the type restrictions on both methods. I think removing the type restrictions is the best way to fix this problem, but I do find it unsatisfying because they improve the readability of the code and the generated docs. However, the only other solution I could think of was to put `Enum#parse?` and `Enum#from_value?` inside a `macro inherited`, presumably allowing a user to access them using `previous_def` rather than `super`. I think that solution is jankier in general, and it certainly would mess with code and documentation readability more than this solution.