### PR TITLE
Add Makefile for Windows

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -111,11 +111,11 @@ compiler_spec: $(O)/compiler_spec ## Run compiler specs
 primitives_spec: $(O)/primitives_spec ## Run primitives specs
 	$(O)/primitives_spec $(SPEC_FLAGS)
 
-.PHONY: smoke_test ## Build specs as a smoke test
-smoke_test: $(O)/std_spec $(O)/compiler_spec $(O)/crystal
+.PHONY: smoke_test
+smoke_test: $(O)/std_spec $(O)/compiler_spec $(O)/crystal ## Build specs as a smoke test
 
-.PHONY: samples ## Build example programs
-samples:
+.PHONY: samples
+samples: ## Build example programs
 	$(MAKE) -C samples
 
 .PHONY: docs

--- a/Makefile
+++ b/Makefile
@@ -78,23 +78,6 @@ check_llvm_config = $(eval \
 .PHONY: all
 all: crystal ## Build all files (currently crystal only) [default]
 
-.PHONY: help
-help: ## Show this help
-	@echo
-	@printf '\033[34mtargets:\033[0m\n'
-	@grep -hE '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) |\
-		sort |\
-		awk 'BEGIN {FS = ":.*?## "}; {printf "  \033[36m%-15s\033[0m %s\n", $$1, $$2}'
-	@echo
-	@printf '\033[34moptional variables:\033[0m\n'
-	@grep -hE '^[a-zA-Z_-]+ \?=.*?## .*$$' $(MAKEFILE_LIST) |\
-		sort |\
-		awk 'BEGIN {FS = " \\?=.*?## "}; {printf "  \033[36m%-15s\033[0m %s\n", $$1, $$2}'
-	@echo
-	@printf '\033[34mrecipes:\033[0m\n'
-	@grep -hE '^##.*$$' $(MAKEFILE_LIST) |\
-		awk 'BEGIN {FS = "## "}; /^## [a-zA-Z_-]/ {printf "  \033[36m%s\033[0m\n", $$2}; /^##  / {printf "  %s\n", $$2}'
-
 .PHONY: spec
 spec: $(O)/all_spec ## Run all specs
 	$(O)/all_spec $(SPEC_FLAGS)
@@ -211,3 +194,20 @@ clean_crystal: ## Clean up crystal built files
 .PHONY: clean_cache
 clean_cache: ## Clean up CRYSTAL_CACHE_DIR files
 	rm -rf $(shell ./bin/crystal env CRYSTAL_CACHE_DIR)
+
+.PHONY: help
+help: ## Show this help
+	@echo
+	@printf '\033[34mtargets:\033[0m\n'
+	@grep -hE '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) |\
+		sort |\
+		awk 'BEGIN {FS = ":.*?## "}; {printf "  \033[36m%-15s\033[0m %s\n", $$1, $$2}'
+	@echo
+	@printf '\033[34moptional variables:\033[0m\n'
+	@grep -hE '^[a-zA-Z_-]+ \?=.*?## .*$$' $(MAKEFILE_LIST) |\
+		sort |\
+		awk 'BEGIN {FS = " \\?=.*?## "}; {printf "  \033[36m%-15s\033[0m %s\n", $$1, $$2}'
+	@echo
+	@printf '\033[34mrecipes:\033[0m\n'
+	@grep -hE '^##.*$$' $(MAKEFILE_LIST) |\
+		awk 'BEGIN {FS = "## "}; /^## [a-zA-Z_-]/ {printf "  \033[36m%s\033[0m\n", $$2}; /^##  / {printf "  %s\n", $$2}'

--- a/Makefile
+++ b/Makefile
@@ -95,7 +95,8 @@ primitives_spec: $(O)/primitives_spec ## Run primitives specs
 	$(O)/primitives_spec $(SPEC_FLAGS)
 
 .PHONY: smoke_test
-smoke_test: $(O)/std_spec $(O)/compiler_spec $(O)/crystal ## Build specs as a smoke test
+smoke_test: ## Build specs as a smoke test
+smoke_test: $(O)/std_spec $(O)/compiler_spec $(O)/crystal
 
 .PHONY: samples
 samples: ## Build example programs

--- a/Makefile.win
+++ b/Makefile.win
@@ -63,7 +63,23 @@ CXXFLAGS += $(if $(debug),/MTd /Od,/MT)
 CRYSTAL_VERSION ?= $(shell type src\VERSION)
 
 DESTDIR ?=
-prefix ?= $(if $(ProgramW6432),$(ProgramW6432),$(ProgramFiles))\crystal
+prefix ?= $(or $(ProgramW6432),$(ProgramFiles))\crystal
+
+# if both `DESTDIR` and `prefix` have a drive letter, the former takes precedence and we remove the drive letter in `prefix`
+space := 
+space +=
+__letters := A B C D E F G H I J K L M N O P Q R S T U V W X Y Z a b c d e f g h i j k l m n o p q r s t u v w x y z
+__temp := $(subst :,$(space):$(space),$(DESTDIR))
+__drive := $(firstword $(__temp))
+ifeq ($(word 2,$(__temp)),:)
+	__temp := $(subst :,$(space):$(space),$(prefix))
+	__drive := $(firstword $(__temp))
+	ifeq ($(word 2,$(__temp)),:)
+		prefix_drive := $(if $(findstring $(__drive),$(__letters)),$(__drive):)
+		override prefix := $(subst :$(__drive) :$(space),,:$(__temp))
+	endif
+endif
+
 BINDIR ?= $(DESTDIR)$(prefix)
 LIBDIR ?= $(DESTDIR)$(prefix)\lib
 SRCDIR ?= $(DESTDIR)$(prefix)\src

--- a/Makefile.win
+++ b/Makefile.win
@@ -3,15 +3,15 @@
 # Recipes for this Makefile
 
 ## Build the compiler
-##   $ make
+##   $ make -f Makefile.win
 ## Build the compiler with progress output
-##   $ make progress=true
+##   $ make -f Makefile.win progress=true
 ## Clean up built files then build the compiler
-##   $ make clean crystal
+##   $ make -f Makefile.win clean crystal
 ## Build the compiler in release mode
-##   $ make crystal release=1
+##   $ make -f Makefile.win crystal release=1
 ## Run all specs in verbose mode
-##   $ make spec verbose=1
+##   $ make -f Makefile.win spec verbose=1
 
 CRYSTAL ?= crystal ## which previous crystal compiler use
 LLVM_CONFIG ?=     ## llvm-config command path to use
@@ -79,44 +79,6 @@ check_llvm_config = $(eval \
 
 .PHONY: all
 all: crystal ## Build all files (currently crystal only) [default]
-
-define SP
-  
-endef
-
-.PHONY: help
-help: ## Show this help
-	@setlocal EnableDelayedExpansion &\
-	echo. &\
-	echo targets: &\
-	(for /F "usebackq tokens=1* delims=:" %%g in ($(MAKEFILE_LIST)) do (\
-		if not "%%h" == "" (\
-			set "_line=%%g                " &\
-			set "_rest=%%h" &\
-			set "_comment=!_rest:* ## =!" &\
-			if not "!_comment!" == "!_rest!"\
-				if "!_line:_rest=!" == "!_line!"\
-					echo   !_line:~0,16!!_comment!\
-		)\
-	)) &\
-	echo. &\
-	echo optional variables: &\
-	(for /F "usebackq tokens=1,3 delims=?#" %%g in ($(MAKEFILE_LIST)) do (\
-		if not "%%h" == "" (\
-			set "_var=%%g              " &\
-			echo   !_var:~0,14! %%h\
-		)\
-	)) &\
-	echo. &\
-	echo recipes: &\
-	(for /F "usebackq tokens=* delims=" %%g in ($(MAKEFILE_LIST)) do (\
-		set "_line=%%g" &\
-		if "!_line:~0,7!" == "##   $$ " (\
-			echo !_name! &\
-			echo  !_line:~2!\
-		) else if "!_line:~0,3!" == "## "\
-			set "_name=  !_line:~3!"\
-	))
 
 .PHONY: spec
 spec: $(O)\all_spec.exe ## Run all specs
@@ -231,3 +193,37 @@ clean_crystal: ## Clean up crystal built files
 .PHONY: clean_cache
 clean_cache: ## Clean up CRYSTAL_CACHE_DIR files
 	$(call RMDIR,"$(shell .\bin\crystal env CRYSTAL_CACHE_DIR)")
+
+.PHONY: help
+help: ## Show this help
+	@setlocal EnableDelayedExpansion &\
+	echo. &\
+	echo targets: &\
+	(for /F "usebackq tokens=1* delims=:" %%g in ($(MAKEFILE_LIST)) do (\
+		if not "%%h" == "" (\
+			set "_line=%%g                " &\
+			set "_rest=%%h" &\
+			set "_comment=!_rest:* ## =!" &\
+			if not "!_comment!" == "!_rest!"\
+				if "!_line:_rest=!" == "!_line!"\
+					echo   !_line:~0,16!!_comment!\
+		)\
+	)) &\
+	echo. &\
+	echo optional variables: &\
+	(for /F "usebackq tokens=1,3 delims=?#" %%g in ($(MAKEFILE_LIST)) do (\
+		if not "%%h" == "" (\
+			set "_var=%%g              " &\
+			echo   !_var:~0,14! %%h\
+		)\
+	)) &\
+	echo. &\
+	echo recipes: &\
+	(for /F "usebackq tokens=* delims=" %%g in ($(MAKEFILE_LIST)) do (\
+		set "_line=%%g" &\
+		if "!_line:~0,7!" == "##   $$ " (\
+			echo !_name! &\
+			echo  !_line:~2!\
+		) else if "!_line:~0,3!" == "## "\
+			set "_name=  !_line:~3!"\
+	))

--- a/Makefile.win
+++ b/Makefile.win
@@ -62,41 +62,11 @@ DEPS = $(LLVM_EXT_OBJ)
 CXXFLAGS += $(if $(debug),/MTd /Od,/MT)
 CRYSTAL_VERSION ?= $(shell type src\VERSION)
 
-DESTDIR ?=
 prefix ?= $(or $(ProgramW6432),$(ProgramFiles))\crystal
-
-# if both `DESTDIR` and `prefix` have a drive letter, the former takes precedence
-space := 
-space +=
-__letters := A B C D E F G H I J K L M N O P Q R S T U V W X Y Z a b c d e f g h i j k l m n o p q r s t u v w x y z
-
-__temp := $(subst :,$(space):$(space),$(DESTDIR))
-__drive := $(firstword $(__temp))
-DESTDIR_rest := $(DESTDIR)
-ifeq ($(word 2,$(__temp)),:)
-	ifneq ($(findstring $(__drive),$(__letters)),)
-		DESTDIR_drive := $(__drive):
-		DESTDIR_rest := $(subst :$(__drive) :$(space),,:$(__temp))
-	endif
-endif
-
-__temp := $(subst :,$(space):$(space),$(prefix))
-__drive := $(firstword $(__temp))
-prefix_rest := $(prefix)
-ifeq ($(word 2,$(__temp)),:)
-	ifneq ($(findstring $(__drive),$(__letters)),)
-		prefix_drive := $(__drive):
-		prefix_rest := $(subst :$(__drive) :$(space),,:$(__temp))
-	endif
-endif
-
-override DESTDIR := $(or $(DESTDIR_drive),$(prefix_drive))$(DESTDIR_rest)
-override prefix := $(prefix_rest)
-
-BINDIR ?= $(DESTDIR)$(prefix)
-LIBDIR ?= $(DESTDIR)$(prefix)\lib
-SRCDIR ?= $(DESTDIR)$(prefix)\src
-DATADIR ?= $(DESTDIR)$(prefix)
+BINDIR ?= $(prefix)
+LIBDIR ?= $(prefix)\lib
+SRCDIR ?= $(prefix)\src
+DATADIR ?= $(prefix)
 
 colorize = $1
 
@@ -145,7 +115,7 @@ deps: $(DEPS) ## Build dependencies
 llvm_ext: $(LLVM_EXT_OBJ)
 
 .PHONY: install
-install: $(O)\crystal.exe ## Install the compiler at DESTDIR
+install: $(O)\crystal.exe ## Install the compiler at prefix
 	$(call MKDIR,"$(BINDIR)")
 	$(call INSTALL,"$(O)\crystal.exe","$(BINDIR)\crystal.exe")
 	$(call INSTALL,"$(O)\crystal.pdb","$(BINDIR)\crystal.pdb")
@@ -157,7 +127,7 @@ install: $(O)\crystal.exe ## Install the compiler at DESTDIR
 	$(call INSTALL,LICENSE,"$(DATADIR)\LICENSE.txt")
 
 .PHONY: uninstall
-uninstall: ## Uninstall the compiler from DESTDIR
+uninstall: ## Uninstall the compiler from prefix
 	$(call RM,"$(DATADIR)\LICENSE.txt")
 
 	$(call RMDIR,"$(DATADIR)\src")
@@ -166,13 +136,13 @@ uninstall: ## Uninstall the compiler from DESTDIR
 	$(call RM,"$(BINDIR)\crystal.pdb")
 
 .PHONY: install_docs
-install_docs: docs ## Install docs at DESTDIR
+install_docs: docs ## Install docs at prefix
 	$(call MKDIR,"$(DATADIR)")
 	$(call INSTALLDIR,docs,"$(DATADIR)\docs")
 	$(call INSTALLDIR,samples,"$(DATADIR)\examples")
 
 .PHONY: uninstall_docs
-uninstall_docs: ## Uninstall docs from DESTDIR
+uninstall_docs: ## Uninstall docs from prefix
 	$(call RMDIR,"$(DATADIR)\docs")
 	$(call RMDIR,"$(DATADIR)\examples")
 

--- a/Makefile.win
+++ b/Makefile.win
@@ -65,25 +65,40 @@ CRYSTAL_VERSION ?= $(shell type src\VERSION)
 DESTDIR ?=
 prefix ?= $(or $(ProgramW6432),$(ProgramFiles))\crystal
 
-# if both `DESTDIR` and `prefix` have a drive letter, the former takes precedence and we remove the drive letter in `prefix`
+# if both `DESTDIR` and `prefix` have a drive letter, the former takes precedence
 space := 
 space +=
 __letters := A B C D E F G H I J K L M N O P Q R S T U V W X Y Z a b c d e f g h i j k l m n o p q r s t u v w x y z
+
 __temp := $(subst :,$(space):$(space),$(DESTDIR))
 __drive := $(firstword $(__temp))
+DESTDIR_rest := $(DESTDIR)
 ifeq ($(word 2,$(__temp)),:)
-	__temp := $(subst :,$(space):$(space),$(prefix))
-	__drive := $(firstword $(__temp))
-	ifeq ($(word 2,$(__temp)),:)
-		prefix_drive := $(if $(findstring $(__drive),$(__letters)),$(__drive):)
-		override prefix := $(subst :$(__drive) :$(space),,:$(__temp))
+	ifneq ($(findstring $(__drive),$(__letters)),)
+		DESTDIR_drive := $(__drive):
+		DESTDIR_rest := $(subst :$(__drive) :$(space),,:$(__temp))
 	endif
 endif
+
+__temp := $(subst :,$(space):$(space),$(prefix))
+__drive := $(firstword $(__temp))
+prefix_rest := $(prefix)
+ifeq ($(word 2,$(__temp)),:)
+	ifneq ($(findstring $(__drive),$(__letters)),)
+		prefix_drive := $(__drive):
+		prefix_rest := $(subst :$(__drive) :$(space),,:$(__temp))
+	endif
+endif
+
+override DESTDIR := $(or $(DESTDIR_drive),$(prefix_drive))$(DESTDIR_rest)
+override prefix := $(prefix_rest)
 
 BINDIR ?= $(DESTDIR)$(prefix)
 LIBDIR ?= $(DESTDIR)$(prefix)\lib
 SRCDIR ?= $(DESTDIR)$(prefix)\src
 DATADIR ?= $(DESTDIR)$(prefix)
+$(info $(BINDIR))
+$(error a)
 
 colorize = $1
 

--- a/Makefile.win
+++ b/Makefile.win
@@ -1,4 +1,4 @@
--include Makefile.local # for optional local options e.g. threads
+-include Makefile.win.local # for optional local options e.g. threads
 
 # Recipes for this Makefile
 
@@ -96,7 +96,8 @@ primitives_spec: $(O)\primitives_spec.exe ## Run primitives specs
 	$(O)\primitives_spec $(SPEC_FLAGS)
 
 .PHONY: smoke_test
-smoke_test: $(O)\std_spec.exe $(O)\compiler_spec.exe $(O)\crystal.exe ## Build specs as a smoke test
+smoke_test: ## Build specs as a smoke test
+smoke_test: $(O)\std_spec.exe $(O)\compiler_spec.exe $(O)\crystal.exe
 
 .PHONY: samples
 samples: ## Build example programs

--- a/Makefile.win
+++ b/Makefile.win
@@ -1,0 +1,233 @@
+-include Makefile.local # for optional local options e.g. threads
+
+# Recipes for this Makefile
+
+## Build the compiler
+##   $ make
+## Build the compiler with progress output
+##   $ make progress=true
+## Clean up built files then build the compiler
+##   $ make clean crystal
+## Build the compiler in release mode
+##   $ make crystal release=1
+## Run all specs in verbose mode
+##   $ make spec verbose=1
+
+CRYSTAL ?= crystal ## which previous crystal compiler use
+LLVM_CONFIG ?=     ## llvm-config command path to use
+
+release ?=      ## Compile in release mode
+stats ?=        ## Enable statistics output
+progress ?=     ## Enable progress output
+threads ?=      ## Maximum number of threads to use
+debug ?=        ## Add symbolic debug info
+verbose ?=      ## Run specs in verbose mode
+junit_output ?= ## Path to output junit results
+static ?=       ## Enable static linking
+interpreter ?=  ## Enable interpreter feature
+
+MAKEFLAGS += --no-builtin-rules
+.SUFFIXES:
+
+SHELL := cmd.exe
+CXX := cl.exe
+
+GLOB = $(shell dir $1 /B /S)
+MKDIR = if not exist $1 mkdir $1
+CP = copy /B /Y $1 $2
+CPDIR = robocopy /E /NJH /NJS $1 $2 & if %%ERRORLEVEL%% GEQ 8 exit /B 1
+INSTALL = copy /B /Y $1 $2
+INSTALLDIR = robocopy /E /NJH /NJS $1 $2 & if %%ERRORLEVEL%% GEQ 8 exit /B 1
+MV = move /Y $1 $2
+RM = if exist $1 del /F /Q $1
+RMDIR = if exist $1 rd /S /Q $1
+
+O := .build
+SOURCES := $(call GLOB,src\\*.cr)
+SPEC_SOURCES := $(call GLOB,spec\\*.cr)
+override FLAGS += -D strict_multi_assign $(if $(release),--release )$(if $(stats),--stats )$(if $(progress),--progress )$(if $(threads),--threads $(threads) )$(if $(debug),-d )$(if $(static),--static )$(if $(LDFLAGS),--link-flags="$(LDFLAGS)" )$(if $(target),--cross-compile --target $(target) )$(if $(interpreter),,-Dwithout_interpreter )
+SPEC_WARNINGS_OFF := --exclude-warnings spec\std --exclude-warnings spec\compiler --exclude-warnings spec\primitives
+SPEC_FLAGS := $(if $(verbose),-v )$(if $(junit_output),--junit_output $(junit_output) )
+CRYSTAL_CONFIG_LIBRARY_PATH := $$ORIGIN\lib
+CRYSTAL_CONFIG_BUILD_COMMIT := $(shell git rev-parse --short HEAD)
+CRYSTAL_CONFIG_PATH := $$ORIGIN\src
+SOURCE_DATE_EPOCH := $(shell git show -s --format=%ct HEAD)
+export_vars = $(eval export CRYSTAL_CONFIG_BUILD_COMMIT CRYSTAL_CONFIG_PATH SOURCE_DATE_EPOCH)
+export_build_vars = $(eval export CRYSTAL_CONFIG_LIBRARY_PATH)
+LLVM_CONFIG ?=
+LLVM_VERSION := $(if $(LLVM_CONFIG),$(shell $(LLVM_CONFIG) --version))
+LLVM_EXT_DIR = src\llvm\ext
+LLVM_EXT_OBJ = $(LLVM_EXT_DIR)\llvm_ext.obj
+DEPS = $(LLVM_EXT_OBJ)
+CXXFLAGS += $(if $(debug),/MTd /Od,/MT)
+CRYSTAL_VERSION ?= $(shell type src\VERSION)
+
+DESTDIR ?=
+prefix ?= $(if $(ProgramW6432),$(ProgramW6432),$(ProgramFiles))\crystal
+BINDIR ?= $(DESTDIR)$(prefix)
+LIBDIR ?= $(DESTDIR)$(prefix)\lib
+SRCDIR ?= $(DESTDIR)$(prefix)\src
+DATADIR ?= $(DESTDIR)$(prefix)
+
+colorize = $1
+
+check_llvm_config = $(eval \
+	check_llvm_config := $(if $(LLVM_VERSION),\
+		$(info $(call colorize,Using $(LLVM_CONFIG) [version=$(LLVM_VERSION)])),\
+		$(error "Could not locate compatible llvm-config, make sure it is installed and in your PATH, or set LLVM_CONFIG. Compatible versions: $(shell type src\llvm\ext\llvm-versions.txt)))\
+	)
+
+.PHONY: all
+all: crystal ## Build all files (currently crystal only) [default]
+
+define SP
+  
+endef
+
+.PHONY: help
+help: ## Show this help
+	@setlocal EnableDelayedExpansion &\
+	echo. &\
+	echo targets: &\
+	(for /F "usebackq tokens=1* delims=:" %%g in ($(MAKEFILE_LIST)) do (\
+		if not "%%h" == "" (\
+			set "_line=%%g                " &\
+			set "_rest=%%h" &\
+			set "_comment=!_rest:* ## =!" &\
+			if not "!_comment!" == "!_rest!"\
+				if "!_line:_rest=!" == "!_line!"\
+					echo   !_line:~0,16!!_comment!\
+		)\
+	)) &\
+	echo. &\
+	echo optional variables: &\
+	(for /F "usebackq tokens=1,3 delims=?#" %%g in ($(MAKEFILE_LIST)) do (\
+		if not "%%h" == "" (\
+			set "_var=%%g              " &\
+			echo   !_var:~0,14! %%h\
+		)\
+	)) &\
+	echo. &\
+	echo recipes: &\
+	(for /F "usebackq tokens=* delims=" %%g in ($(MAKEFILE_LIST)) do (\
+		set "_line=%%g" &\
+		if "!_line:~0,7!" == "##   $$ " (\
+			echo !_name! &\
+			echo  !_line:~2!\
+		) else if "!_line:~0,3!" == "## "\
+			set "_name=  !_line:~3!"\
+	))
+
+.PHONY: spec
+spec: $(O)\all_spec.exe ## Run all specs
+	$(O)\all_spec $(SPEC_FLAGS)
+
+.PHONY: std_spec
+std_spec: $(O)\std_spec.exe ## Run standard library specs
+	$(O)\std_spec $(SPEC_FLAGS)
+
+.PHONY: compiler_spec
+compiler_spec: $(O)\compiler_spec.exe ## Run compiler specs
+	$(O)\compiler_spec $(SPEC_FLAGS)
+
+.PHONY: primitives_spec
+primitives_spec: $(O)\primitives_spec.exe ## Run primitives specs
+	$(O)\primitives_spec $(SPEC_FLAGS)
+
+.PHONY: smoke_test
+smoke_test: $(O)\std_spec.exe $(O)\compiler_spec.exe $(O)\crystal.exe ## Build specs as a smoke test
+
+.PHONY: samples
+samples: ## Build example programs
+	$(MAKE) -C samples -f $(MAKEFILE_LIST)
+
+.PHONY: docs
+docs: ## Generate standard library documentation
+	$(call check_llvm_config)
+	.\bin\crystal docs src\docs_main.cr $(DOCS_OPTIONS) --project-name=Crystal --project-version=$(CRYSTAL_VERSION) --source-refname=$(CRYSTAL_CONFIG_BUILD_COMMIT)
+
+.PHONY: crystal
+crystal: $(O)\crystal.exe ## Build the compiler
+
+.PHONY: deps llvm_ext
+deps: $(DEPS) ## Build dependencies
+llvm_ext: $(LLVM_EXT_OBJ)
+
+.PHONY: install
+install: $(O)\crystal.exe ## Install the compiler at DESTDIR
+	$(call MKDIR,"$(BINDIR)")
+	$(call INSTALL,"$(O)\crystal.exe","$(BINDIR)\crystal.exe")
+	$(call INSTALL,"$(O)\crystal.pdb","$(BINDIR)\crystal.pdb")
+
+	$(call MKDIR,"$(DATADIR)")
+	$(call INSTALLDIR,src,"$(DATADIR)\src")
+	$(call RM,"$(DATADIR)\$(LLVM_EXT_OBJ)")
+
+	$(call INSTALL,LICENSE,"$(DATADIR)\LICENSE.txt")
+
+.PHONY: uninstall
+uninstall: ## Uninstall the compiler from DESTDIR
+	$(call RM,"$(DATADIR)\LICENSE.txt")
+
+	$(call RMDIR,"$(DATADIR)\src")
+
+	$(call RM,"$(BINDIR)\crystal.exe")
+	$(call RM,"$(BINDIR)\crystal.pdb")
+
+.PHONY: install_docs
+install_docs: docs ## Install docs at DESTDIR
+	$(call MKDIR,"$(DATADIR)")
+	$(call INSTALLDIR,docs,"$(DATADIR)\docs")
+	$(call INSTALLDIR,samples,"$(DATADIR)\examples")
+
+.PHONY: uninstall_docs
+uninstall_docs: ## Uninstall docs from DESTDIR
+	$(call RMDIR,"$(DATADIR)\docs")
+	$(call RMDIR,"$(DATADIR)\examples")
+
+$(O)\all_spec.exe: $(DEPS) $(SOURCES) $(SPEC_SOURCES)
+	$(call check_llvm_config)
+	@$(call MKDIR,"$(O)")
+	$(call export_vars)
+	.\bin\crystal build $(FLAGS) $(SPEC_WARNINGS_OFF) -o "$@" spec\all_spec.cr
+
+$(O)\std_spec.exe: $(DEPS) $(SOURCES) $(SPEC_SOURCES)
+	$(call check_llvm_config)
+	@$(call MKDIR,"$(O)")
+	.\bin\crystal build $(FLAGS) $(SPEC_WARNINGS_OFF) -o "$@" spec\std_spec.cr
+
+$(O)\compiler_spec.exe: $(DEPS) $(SOURCES) $(SPEC_SOURCES)
+	$(call check_llvm_config)
+	@$(call MKDIR,"$(O)")
+	$(call export_vars)
+	.\bin\crystal build $(FLAGS) $(SPEC_WARNINGS_OFF) -o "$@" spec\compiler_spec.cr
+
+$(O)\primitives_spec.exe: $(O)\crystal.exe $(DEPS) $(SOURCES) $(SPEC_SOURCES)
+	@$(call MKDIR,"$(O)")
+	.\bin\crystal build $(FLAGS) $(SPEC_WARNINGS_OFF) -o "$@" spec\primitives_spec.cr
+
+$(O)\crystal.exe: $(DEPS) $(SOURCES)
+	$(call check_llvm_config)
+	@$(call MKDIR,"$(O)")
+	$(call export_vars)
+	$(call export_build_vars)
+	.\bin\crystal build $(FLAGS) -o "$(O)\crystal-next.exe" src\compiler\crystal.cr -D without_openssl -D without_zlib -D without_playground --link-flags=/PDBALTPATH:crystal.pdb
+	$(call MV,"$(O)\crystal-next.exe","$@")
+	$(call MV,"$(O)\crystal-next.pdb","$(O)\crystal.pdb")
+
+$(LLVM_EXT_OBJ): $(LLVM_EXT_DIR)\llvm_ext.cc
+	$(call check_llvm_config)
+	$(CXX) /c $(CXXFLAGS) "/Fo$@" "$<" $(shell $(LLVM_CONFIG) --cxxflags)
+
+.PHONY: clean
+clean: clean_crystal ## Clean up built directories and files
+	$(call RM,"$(LLVM_EXT_OBJ)")
+
+.PHONY: clean_crystal
+clean_crystal: ## Clean up crystal built files
+	$(call RMDIR,"$(O)")
+	$(call RMDIR,docs)
+
+.PHONY: clean_cache
+clean_cache: ## Clean up CRYSTAL_CACHE_DIR files
+	$(call RMDIR,"$(shell .\bin\crystal env CRYSTAL_CACHE_DIR)")

--- a/Makefile.win
+++ b/Makefile.win
@@ -97,8 +97,6 @@ BINDIR ?= $(DESTDIR)$(prefix)
 LIBDIR ?= $(DESTDIR)$(prefix)\lib
 SRCDIR ?= $(DESTDIR)$(prefix)\src
 DATADIR ?= $(DESTDIR)$(prefix)
-$(info $(BINDIR))
-$(error a)
 
 colorize = $1
 

--- a/bin/crystal.ps1
+++ b/bin/crystal.ps1
@@ -203,6 +203,8 @@ function Exec-Process {
         }
     }
 
+    # workaround to obtain the exit status properly: https://stackoverflow.com/a/23797762
+    $hnd = $Process.Handle
     Wait-Process -Id $Process.Id
     Exit $Process.ExitCode
 }

--- a/samples/Makefile.win
+++ b/samples/Makefile.win
@@ -1,0 +1,63 @@
+MKDIR = if not exist $1 mkdir $1
+RMDIR = if exist $1 rd /S /Q $1
+
+CRYSTAL := ../bin/crystal# Crystal compiler to use
+O := .build# Output directory
+
+BUILDABLE_SOURCES := $(wildcard *.cr llvm/*.cr compiler/*.cr)
+NONLINK_SOURCES := $(wildcard sdl/*.cr)
+
+BUILDABLE_BINARIES := $(patsubst %.cr,$(O)/%.exe,$(BUILDABLE_SOURCES))
+NONLINK_BINARIES := $(patsubst %.cr,$(O)/%.obj,$(NONLINK_SOURCES))
+
+.PHONY: all
+all: build
+
+.PHONY: build
+build: $(BUILDABLE_BINARIES) $(NONLINK_BINARIES) ## Build sample binaries
+
+$(O)/%.exe: %.cr
+	$(call MKDIR,"$(dir $@)")
+	$(CRYSTAL) build "$<" -o "$@"
+
+$(O)/%.obj: %.cr
+	$(call MKDIR,"$(dir $@)")
+	$(CRYSTAL) build --cross-compile "$<" -o "$(patsubst %.obj,%,$@)"
+
+.PHONY: clean
+clean: ## Remove build artifacts
+	$(call RMDIR,"$(O)")
+
+.PHONY: help
+help: ## Show this help
+	@setlocal EnableDelayedExpansion &\
+	echo. &\
+	echo targets: &\
+	(for /F "usebackq tokens=1* delims=:" %%g in ($(MAKEFILE_LIST)) do (\
+		if not "%%h" == "" (\
+			set "_line=%%g                " &\
+			set "_rest=%%h" &\
+			set "_comment=!_rest:* ## =!" &\
+			if not "!_comment!" == "!_rest!"\
+				if "!_line:_rest=!" == "!_line!"\
+					echo   !_line:~0,16!!_comment!\
+		)\
+	)) &\
+	echo. &\
+	echo optional variables: &\
+	(for /F "usebackq tokens=1,3 delims=?#" %%g in ($(MAKEFILE_LIST)) do (\
+		if not "%%h" == "" (\
+			set "_var=%%g              " &\
+			echo   !_var:~0,14! %%h\
+		)\
+	)) &\
+	echo. &\
+	echo recipes: &\
+	(for /F "usebackq tokens=* delims=" %%g in ($(MAKEFILE_LIST)) do (\
+		set "_line=%%g" &\
+		if "!_line:~0,7!" == "##   $$ " (\
+			echo !_name! &\
+			echo  !_line:~2!\
+		) else if "!_line:~0,3!" == "## "\
+			set "_name=  !_line:~3!"\
+	))

--- a/src/docs_main.cr
+++ b/src/docs_main.cr
@@ -47,7 +47,9 @@ require "./option_parser"
 require "./path"
 require "./random/**"
 require "./semantic_version"
-require "./signal"
+{% unless flag?(:win32) %}
+  require "./signal"
+{% end %}
 require "./string_pool"
 require "./string_scanner"
 require "./unicode/unicode"
@@ -55,5 +57,7 @@ require "./uri"
 require "./uuid"
 require "./uuid/json"
 require "./syscall"
-require "./system/*"
+{% unless flag?(:win32) %}
+  require "./system/*"
+{% end %}
 require "./docs_pseudo_methods"


### PR DESCRIPTION
Resolves #11732. Requires #11524 for the `bin\crystal` wrapper script.

Can be invoked like `make -f Makefile.win clean crystal progress=1`. This is tested on the command prompt with GNU Make 3.81 installed via `winget install GnuWin32.Make`. Some notes:

* Most system commands are abstracted into functions (e.g. `CP = copy /B /Y $1 $2`), so that we can easily combine this Makefile with the Unix one later if we want to.
* All paths use `\` as the directory separator, because some MS-DOS commands straight up don't accept `/`, for example `copy`.
* `make help` is still fully automated from Makefile.win itself, apart from a lack of sorting and coloration.
* `make install` follows the same directory structure as the CI builds we distribute, except `crystal.pdb` and `LICENSE.txt` are also packaged in. The default `prefix` is `C:\Program Files\crystal`, and can be overridden with something like `"prefix=%USERPROFILE%\crystal"` for a per-user installation. ~~Mixing `DESTDIR` and `prefix` might not work because of drive letters.~~ `DESTDIR` is not supported. Symlinks (e.g. under `src/lib_c`) are not preserved. On Windows the static library dependencies must be manually placed under `$ORIGIN\lib` for a complete installation.
* Minimal flag checks are added to `src/docs_main.cr` in order to make `make docs` work.
* `make samples` is also supported here. Here are the remaining compilation errors for those who wonder: (the middle one goes away with #11647)
  ```
  In 2048.cr:40:11

   40 | STDIN.raw do |io|
              ^--
  Error: undefined method 'raw' for IO::FileDescriptor
  ```
  ```
  In mt_gc_test.cr:143:12

   143 | Thread.new do
                ^--
  Error: 'Thread.new' is not expected to be invoked with a block, but a block was given
  ```
  ```
  In sdl\raytracer.cr:205:1

   205 | Signal::INT.trap { exit }
         ^----------
  Error: undefined constant Signal::INT
  ```
* `%LLVM_CONFIG%` must be present for the targets that require it. There is no detection mechanism yet.
* Testing on CI is not done yet.