### PR TITLE
Remove symbol overloads of `Colorize` color methods for symbol auto-casting

### DIFF
--- a/samples/2048.cr
+++ b/samples/2048.cr
@@ -3,24 +3,26 @@
 require "colorize"
 
 module Screen
+  alias Color = Colorize::ColorANSI
+
   TILES = {
-        0 => {:white, nil},
-        2 => {:black, :white},
-        4 => {:blue, :white},
-        8 => {:black, :yellow},
-       16 => {:white, :red},
-       32 => {:black, :red},
-       64 => {:white, :magenta},
-      128 => {:red, :yellow},
-      256 => {:magenta, :yellow},
-      512 => {:white, :yellow},
-     1024 => {:white, :yellow},
-     2048 => {:white, :yellow},
-     4096 => {:white, :black},
-     8192 => {:white, :black},
-    16384 => {:white, :black},
-    32768 => {:white, :black},
-    65536 => {:white, :black},
+        0 => {Color::White, nil},
+        2 => {Color::Black, Color::White},
+        4 => {Color::Blue, Color::White},
+        8 => {Color::Black, Color::Yellow},
+       16 => {Color::White, Color::Red},
+       32 => {Color::Black, Color::Red},
+       64 => {Color::White, Color::Magenta},
+      128 => {Color::Red, Color::Yellow},
+      256 => {Color::Magenta, Color::Yellow},
+      512 => {Color::White, Color::Yellow},
+     1024 => {Color::White, Color::Yellow},
+     2048 => {Color::White, Color::Yellow},
+     4096 => {Color::White, Color::Black},
+     8192 => {Color::White, Color::Black},
+    16384 => {Color::White, Color::Black},
+    32768 => {Color::White, Color::Black},
+    65536 => {Color::White, Color::Black},
   }
 
   def self.colorize_for(tile)

--- a/spec/std/colorize_spec.cr
+++ b/spec/std/colorize_spec.cr
@@ -1,8 +1,8 @@
 require "spec"
 require "colorize"
 
-private def colorize(obj, *args)
-  obj.colorize(*args).toggle(true)
+private def colorize(obj)
+  obj.colorize.toggle(true)
 end
 
 private def with_color_wrap(*args)
@@ -99,7 +99,6 @@ describe "colorize" do
   end
 
   it "colorizes foreground with symbol" do
-    colorize("hello", :red).to_s.should eq("\e[31mhello\e[0m")
     colorize("hello").fore(:red).to_s.should eq("\e[31mhello\e[0m")
   end
 
@@ -120,7 +119,7 @@ describe "colorize" do
   end
 
   it "inspects" do
-    colorize("hello", :red).inspect.should eq("\e[31m\"hello\"\e[0m")
+    colorize("hello").fore(:red).inspect.should eq("\e[31m\"hello\"\e[0m")
   end
 
   it "colorizes with surround" do

--- a/spec/std/colorize_spec.cr
+++ b/spec/std/colorize_spec.cr
@@ -50,6 +50,7 @@ describe "colorize" do
   end
 
   it "colorizes background" do
+    colorize("hello").on(:black).to_s.should eq("\e[40mhello\e[0m")
     colorize("hello").on_black.to_s.should eq("\e[40mhello\e[0m")
     colorize("hello").on_red.to_s.should eq("\e[41mhello\e[0m")
     colorize("hello").on_green.to_s.should eq("\e[42mhello\e[0m")
@@ -104,18 +105,6 @@ describe "colorize" do
 
   it "colorizes mode with symbol" do
     colorize("hello").mode(:bold).to_s.should eq("\e[1mhello\e[0m")
-  end
-
-  it "raises on unknown foreground color" do
-    expect_raises ArgumentError, "Unknown color: brown" do
-      colorize("hello", :brown)
-    end
-  end
-
-  it "raises on unknown background color" do
-    expect_raises ArgumentError, "Unknown color: brown" do
-      colorize("hello").back(:brown)
-    end
   end
 
   it "inspects" do

--- a/src/colorize.cr
+++ b/src/colorize.cr
@@ -89,26 +89,7 @@
 # "foo".colorize(Random::DEFAULT.next_bool ? :green : :default)
 # ```
 #
-# Available colors are:
-# ```
-# :default
-# :black
-# :red
-# :green
-# :yellow
-# :blue
-# :magenta
-# :cyan
-# :light_gray
-# :dark_gray
-# :light_red
-# :light_green
-# :light_yellow
-# :light_blue
-# :light_magenta
-# :light_cyan
-# :white
-# ```
+# See `Colorize::ColorANSI` for all available colors.
 #
 # See `Colorize::Mode` for available text decorations.
 module Colorize
@@ -170,7 +151,7 @@ module Colorize::ObjectExtensions
   end
 
   # Turns `self` into a `Colorize::Object` and colors it with a color.
-  def colorize(fore)
+  def colorize(fore : Color)
     Colorize::Object.new(self).fore(fore)
   end
 end
@@ -283,8 +264,6 @@ end
 
 # A colorized object. Colors and text decorations can be modified.
 struct Colorize::Object(T)
-  private COLORS = %w(default black red green yellow blue magenta cyan light_gray dark_gray light_red light_green light_yellow light_blue light_magenta light_cyan white)
-
   @fore : Color
   @back : Color
 
@@ -295,14 +274,14 @@ struct Colorize::Object(T)
     @enabled = Colorize.enabled?
   end
 
-  {% for name in COLORS %}
-    def {{name.id}}
-      @fore = ColorANSI::{{name.camelcase.id}}
+  {% for color in ColorANSI.constants.reject { |constant| constant == "All" || constant == "None" } %}
+    def {{color.underscore.id}}
+      @fore = ColorANSI::{{color.id}}
       self
     end
 
-    def on_{{name.id}}
-      @back = ColorANSI::{{name.camelcase.id}}
+    def on_{{color.underscore.id}}
+      @back = ColorANSI::{{color.id}}
       self
     end
   {% end %}
@@ -314,30 +293,8 @@ struct Colorize::Object(T)
     end
   {% end %}
 
-  def fore(color : Symbol) : self
-    {% for name in COLORS %}
-      if color == :{{name.id}}
-        @fore = ColorANSI::{{name.camelcase.id}}
-        return self
-      end
-    {% end %}
-
-    raise ArgumentError.new "Unknown color: #{color}"
-  end
-
   def fore(@fore : Color) : self
     self
-  end
-
-  def back(color : Symbol) : self
-    {% for name in COLORS %}
-      if color == :{{name.id}}
-        @back = ColorANSI::{{name.camelcase.id}}
-        return self
-      end
-    {% end %}
-
-    raise ArgumentError.new "Unknown color: #{color}"
   end
 
   def back(@back : Color) : self
@@ -350,7 +307,7 @@ struct Colorize::Object(T)
     self
   end
 
-  def on(color : Symbol)
+  def on(color : Color)
     back color
   end
 

--- a/src/spec/dsl.cr
+++ b/src/spec/dsl.cr
@@ -10,16 +10,16 @@ module Spec
   end
 
   private STATUS_COLORS = {
-    Status::Success => :green,
-    Status::Fail    => :red,
-    Status::Error   => :red,
-    Status::Pending => :yellow,
+    Status::Success => Colorize::ColorANSI::Green,
+    Status::Fail    => Colorize::ColorANSI::Red,
+    Status::Error   => Colorize::ColorANSI::Red,
+    Status::Pending => Colorize::ColorANSI::Yellow,
   }
 
   private INFO_COLORS = {
-    InfoKind::Comment => :cyan,
-    InfoKind::Focus   => :cyan,
-    InfoKind::Order   => :cyan,
+    InfoKind::Comment => Colorize::ColorANSI::Cyan,
+    InfoKind::Focus   => Colorize::ColorANSI::Cyan,
+    InfoKind::Order   => Colorize::ColorANSI::Cyan,
   }
 
   private LETTERS = {


### PR DESCRIPTION
`Colorize` methods receiving a color (`#fore` and `#back`) have overloads receiving a `Symbol` parameter which is manually mapped to values of `ColorANSI`. This implementation predates the symbol auto-casting of enum values.

This patch removes the overloads with `Symbol` typed parameters which leaves the overloads receiving a `Color` parameter. This type is a union including the enum `ColorANSI` which enables symbol auto-casting for color values.

The problem is: it's a breaking change. If the API is used with symbols that are not directly created from literals, there will be a compile time error. This is good and intended because it adds type safety (you can know at compile time whether a value is valid). But it's still a breaking change that destroys valid use cases which would require changes to user code (as demonstrated by the changes in `samples/2048.cr` and ` src/spec/dsl.cr` for example). So I believe we can't merge it just like that.
The only option is to leave the removed overloads in with a deprecation notice. That's not ideal though because the deprecation warning even triggers for usages that are compatible with the auto-casting method. But the symbol overload takes precedence over auto-casting. The only way to deactivate deprecation warnings is using a named argument: `fore(fore: :green)`.

Are there any other ideas? We could use a feature flag but I think would be silly for such a minor thing.

This patch has been extracted from #7690.