### PR TITLE
Relax `ENV.fetch(key, &)`'s block restriction

### DIFF
--- a/spec/std/env_spec.cr
+++ b/spec/std/env_spec.cr
@@ -131,6 +131,7 @@ describe "ENV" do
       ENV["1"] = "2"
       ENV.fetch("1") { |k| k + "block" }.should eq("2")
       ENV.fetch("2") { |k| k + "block" }.should eq("2block")
+      ENV.fetch("3") { 4 }.should eq(4)
     ensure
       ENV.delete("1")
     end

--- a/src/env.cr
+++ b/src/env.cr
@@ -62,7 +62,7 @@ module ENV
 
   # Retrieves a value corresponding to a given *key*. Return the value of the block if
   # the *key* does not exist.
-  def self.fetch(key : String, &block : String -> String?)
+  def self.fetch(key : String, &block : String -> T) : String | T forall T
     if value = Crystal::System::Env.get(key)
       return value
     else


### PR DESCRIPTION
There is no need for the default value to be a `String?`; this is consistent with other `#fetch` methods in the standard library like `Hash#fetch` and `Indexable#fetch`.