### PR TITLE
Fix: Accept only option flags in `CRYSTAL_OPTS`

### DIFF
--- a/src/compiler/crystal/command/docs.cr
+++ b/src/compiler/crystal/command/docs.cr
@@ -16,7 +16,7 @@ class Crystal::Command
 
     compiler = new_compiler
 
-    OptionParser.parse(options) do |opts|
+    parse_with_crystal_opts do |opts|
       opts.banner = <<-'BANNER'
         Usage: crystal docs [options]
 

--- a/src/compiler/crystal/command/env.cr
+++ b/src/compiler/crystal/command/env.cr
@@ -4,7 +4,7 @@ class Crystal::Command
   private def env
     var_names = [] of String
 
-    OptionParser.parse(@options) do |opts|
+    parse_with_crystal_opts do |opts|
       opts.banner = env_usage
 
       opts.on("-h", "--help", "Show this message") do

--- a/src/compiler/crystal/command/eval.cr
+++ b/src/compiler/crystal/command/eval.cr
@@ -3,7 +3,7 @@
 class Crystal::Command
   private def eval
     compiler = new_compiler
-    OptionParser.parse(options) do |opts|
+    parse_with_crystal_opts do |opts|
       opts.banner = "Usage: crystal eval [options] [source]\n\nOptions:"
       setup_simple_compiler_options compiler, opts
     end

--- a/src/compiler/crystal/command/format.cr
+++ b/src/compiler/crystal/command/format.cr
@@ -10,35 +10,34 @@ class Crystal::Command
     check = false
     show_backtrace = false
 
-    option_parser =
-      OptionParser.parse(options) do |opts|
-        opts.banner = "Usage: crystal tool format [options] [file or directory]\n\nOptions:"
+    parse_with_crystal_opts do |opts|
+      opts.banner = "Usage: crystal tool format [options] [file or directory]\n\nOptions:"
 
-        opts.on("--check", "Checks that formatting code produces no changes") do |f|
-          check = true
-        end
-
-        opts.on("-i <path>", "--include <path>", "Include path") do |f|
-          includes << f
-        end
-
-        opts.on("-e <path>", "--exclude <path>", "Exclude path (default: lib)") do |f|
-          excludes << f
-        end
-
-        opts.on("-h", "--help", "Show this message") do
-          puts opts
-          exit
-        end
-
-        opts.on("--no-color", "Disable colored output") do
-          @color = false
-        end
-
-        opts.on("--show-backtrace", "Show backtrace on a bug (used only for debugging)") do
-          show_backtrace = true
-        end
+      opts.on("--check", "Checks that formatting code produces no changes") do |f|
+        check = true
       end
+
+      opts.on("-i <path>", "--include <path>", "Include path") do |f|
+        includes << f
+      end
+
+      opts.on("-e <path>", "--exclude <path>", "Exclude path (default: lib)") do |f|
+        excludes << f
+      end
+
+      opts.on("-h", "--help", "Show this message") do
+        puts opts
+        exit
+      end
+
+      opts.on("--no-color", "Disable colored output") do
+        @color = false
+      end
+
+      opts.on("--show-backtrace", "Show backtrace on a bug (used only for debugging)") do
+        show_backtrace = true
+      end
+    end
 
     files = options
 

--- a/src/compiler/crystal/command/playground.cr
+++ b/src/compiler/crystal/command/playground.cr
@@ -7,7 +7,7 @@ class Crystal::Command
   private def playground
     server = Playground::Server.new
 
-    OptionParser.parse(options) do |opts|
+    parse_with_crystal_opts do |opts|
       opts.banner = "Usage: crystal play [options] [file]\n\nOptions:"
 
       opts.on("-p PORT", "--port PORT", "Runs the playground on the specified port") do |port|

--- a/src/compiler/crystal/command/spec.cr
+++ b/src/compiler/crystal/command/spec.cr
@@ -16,7 +16,7 @@ class Crystal::Command
   private def spec
     compiler = new_compiler
     link_flags = [] of String
-    OptionParser.parse(options) do |opts|
+    parse_with_crystal_opts do |opts|
       opts.banner = "Usage: crystal spec [options] [files] [runtime_options]\n\nOptions:"
       setup_simple_compiler_options compiler, opts
 

--- a/src/compiler/crystal/tools/init.cr
+++ b/src/compiler/crystal/tools/init.cr
@@ -41,7 +41,7 @@ module Crystal
     def self.parse_args(args)
       config = Config.new
 
-      OptionParser.parse(args) do |opts|
+      Crystal::Command.parse_with_crystal_opts(args) do |opts|
         opts.banner = <<-USAGE
           Usage: crystal init TYPE (DIR | NAME DIR)
 


### PR DESCRIPTION
Fixes #11164. `CRYSTAL_OPTS` is processed before the command-line arguments, the two sets of options more or less sharing the same `OptionParser`. Note however that `crystal eval` has never supported the full set of compiler options (e.g. `CRYSTAL_OPTS=--prelude=empty crystal eval` will not work).

With this patch `CRYSTAL_OPTS` never interferes with the original command line, so they can be safely applied to every compiler command backed by an `OptionParser`. ~~The exceptions are `crystal env` (a parser is added in #11720) and~~ The only exception is `crystal interactive`.