### PR TITLE
Interpreter: support `Tuple#[]` with range literals

### DIFF
--- a/spec/compiler/interpreter/tuple_spec.cr
+++ b/spec/compiler/interpreter/tuple_spec.cr
@@ -10,6 +10,26 @@ describe Crystal::Repl::Interpreter do
       CODE
     end
 
+    it "interprets tuple range indexer" do
+      interpret(<<-CODE).should eq(6)
+        #{range_new}
+
+        a = {1, 2, 4, 8, 16}
+        b = a[1...-2]
+        b[0] + b[1]
+      CODE
+    end
+
+    it "interprets tuple range indexer (2)" do
+      interpret(<<-CODE).should eq(24)
+        #{range_new}
+
+        a = {1_i8, 2_i8, 4_i8, 8_i8, 16_i32}
+        b = a[3..]
+        b[1] + b[0]
+      CODE
+    end
+
     it "interprets tuple literal of different types (1)" do
       interpret(<<-CODE).should eq(3)
         a = {1, true}
@@ -80,5 +100,36 @@ describe Crystal::Repl::Interpreter do
         a.class[0].foo
       CODE
     end
+
+    it "interprets tuple metaclass range indexer" do
+      interpret(<<-CODE).should eq(3)
+        #{range_new}
+
+        struct Int32
+          def self.foo
+            1
+          end
+        end
+
+        class String
+          def self.bar
+            2
+          end
+        end
+
+        a = {true, 1, "a", 'a', 1.0}
+        b = a.class[1...-2]
+        b[0].foo + b[1].bar
+      CODE
+    end
   end
+end
+
+private def range_new
+  %(
+    struct Range(B, E)
+      def initialize(@begin : B, @end : E, @exclusive : Bool = false)
+      end
+    end
+  )
 end

--- a/src/compiler/crystal/interpreter/instructions.cr
+++ b/src/compiler/crystal/interpreter/instructions.cr
@@ -1409,7 +1409,7 @@ require "./repl"
       },
       # >>> is_a? (3)
 
-      # <<< Tuples (1)
+      # <<< Tuples (3)
       tuple_indexer_known_index: {
         operands:   [tuple_size : Int32, offset : Int32, value_size : Int32],
         code:       begin
@@ -1423,7 +1423,11 @@ require "./repl"
         operands:   [offset : Int32, size : Int32],
         code:       stack_move_from(stack - offset, size),
       },
-      # >>> Tuples (1)
+      tuple_copy_element: {
+        operands:   [tuple_size : Int32, old_offset : Int32, new_offset : Int32, element_size : Int32],
+        code:       (stack - tuple_size + new_offset).copy_from(stack - tuple_size + old_offset, element_size),
+      },
+      # >>> Tuples (3)
 
       # <<< Symbol (1)
       symbol_to_s: {

--- a/src/compiler/crystal/interpreter/primitives.cr
+++ b/src/compiler/crystal/interpreter/primitives.cr
@@ -170,12 +170,22 @@ class Crystal::Repl::Compiler
 
         index = body.as(TupleIndexer).index
         case index
-        when Int32
+        in Int32
           element_type = type.tuple_types[index]
           offset = @context.offset_of(type, index)
           tuple_indexer_known_index(aligned_sizeof_type(type), offset, inner_sizeof_type(element_type), node: node)
-        else
-          node.raise "BUG: missing handling of primitive #{body.name} with range"
+        in Range
+          element_type = @context.program.tuple_of(type.tuple_types[index].map &.as(Type))
+          tuple_size = aligned_sizeof_type(type)
+          index.each do |i|
+            old_offset = @context.offset_of(type, i)
+            new_offset = @context.offset_of(element_type, i - index.begin)
+            element_size = inner_sizeof_type(type.tuple_types[i])
+            tuple_copy_element(tuple_size, old_offset, new_offset, element_size, node: node)
+          end
+          value_size = inner_sizeof_type(element_type)
+          pop(tuple_size - value_size, node: node)
+          push_zeros(aligned_sizeof_type(element_type) - value_size, node: node)
         end
       when NamedTupleInstanceType
         obj.accept self
@@ -199,10 +209,10 @@ class Crystal::Repl::Compiler
         when TupleInstanceType
           index = body.as(TupleIndexer).index
           case index
-          when Int32
+          in Int32
             put_type(type.tuple_types[index].as(Type).metaclass, node: node)
-          else
-            node.raise "BUG: missing handling of primitive #{body.name} with range"
+          in Range
+            put_type(@context.program.tuple_of(type.tuple_types[index].map &.as(Type)), node: node)
           end
         when NamedTupleInstanceType
           index = body.as(TupleIndexer).index


### PR DESCRIPTION
This is necessary to compile (not run) most of the specs because `Spec` depends on the methods in `src/humanize.cr` where this feature is used. I am not very satisfied with the way the indexer on non-metaclass tuples works, but the offset calculations are necessary because of alignment issues. Given:

```crystal
a = {1_i8, 2_i8, 4_i8, 8_i8, 16_i32}
b = a[3..] # => {8_i8, 16_i32}
```

here we cannot simply move `a`'s last 5 bytes to the beginning, because there must be padding between `b`'s two elements.