### PR TITLE
Support day of year (`%j`) in `Time` parsers

### DIFF
--- a/spec/std/time/format_spec.cr
+++ b/spec/std/time/format_spec.cr
@@ -522,6 +522,37 @@ describe Time::Format do
     end
   end
 
+  it "parses day of year" do
+    parse_time("2006-001", "%Y-%j").should eq(Time.utc(2006, 1, 1))
+    parse_time("2006-032", "%Y-%j").should eq(Time.utc(2006, 2, 1))
+    parse_time("2006-059", "%Y-%j").should eq(Time.utc(2006, 2, 28))
+    parse_time("2006-060", "%Y-%j").should eq(Time.utc(2006, 3, 1))
+    parse_time("2006-200", "%Y-%j").should eq(Time.utc(2006, 7, 19))
+    parse_time("2006-365", "%Y-%j").should eq(Time.utc(2006, 12, 31))
+
+    parse_time("2004-001", "%Y-%j").should eq(Time.utc(2004, 1, 1))
+    parse_time("2004-032", "%Y-%j").should eq(Time.utc(2004, 2, 1))
+    parse_time("2004-059", "%Y-%j").should eq(Time.utc(2004, 2, 28))
+    parse_time("2004-060", "%Y-%j").should eq(Time.utc(2004, 2, 29))
+    parse_time("2004-061", "%Y-%j").should eq(Time.utc(2004, 3, 1))
+    parse_time("2004-200", "%Y-%j").should eq(Time.utc(2004, 7, 18))
+    parse_time("2004-365", "%Y-%j").should eq(Time.utc(2004, 12, 30))
+    parse_time("2004-366", "%Y-%j").should eq(Time.utc(2004, 12, 31))
+
+    expect_raises(Time::Format::Error, "Invalid day of year") do
+      parse_time("2006-000", "%Y-%j")
+    end
+    expect_raises(Time::Format::Error, "Invalid day of year") do
+      parse_time("2004-000", "%Y-%j")
+    end
+    expect_raises(Time::Format::Error, "Invalid day of year") do
+      parse_time("2006-366", "%Y-%j")
+    end
+    expect_raises(Time::Format::Error, "Invalid day of year") do
+      parse_time("2004-367", "%Y-%j")
+    end
+  end
+
   # TODO %Z
   # TODO %G
   # TODO %g


### PR DESCRIPTION
This includes `Time::Format#parse` and everything that depends on it, such as `Time.parse` and JSON deserialization.

Day of year has higher priority over month + day, but lower priority over week date (`%G` `%V` `%u`). The latter is unlikely to cause problems, since day of year and week date in the same string is very unlikely to happen.