### PR TITLE
Fix `address_spec` expectation for Windows Server 2022

### DIFF
--- a/spec/std/socket/address_spec.cr
+++ b/spec/std/socket/address_spec.cr
@@ -276,9 +276,8 @@ describe Socket do
     Socket.ip?("1:2:3:4:5:6:7:8::").should be_false
     Socket.ip?("1:2:3:4:5:6:7::9").should be_false
     Socket.ip?("::1:2:3:4:5:6").should be_true
-    {% if flag?(:win32) %}
-      Socket.ip?("::1:2:3:4:5:6:7").should be_false
-    {% else %}
+    # FIXME: On older Windows versions, this returned `false`. It was apparently fixed in Windows Server 2022.
+    {% unless flag?(:win32) %}
       Socket.ip?("::1:2:3:4:5:6:7").should be_true
     {% end %}
     Socket.ip?("::1:2:3:4:5:6:7:8").should be_false


### PR DESCRIPTION
This is currently breaking Windows CI because `windows-latest` was updated to Windows Server 2022.

/cc https://github.com/crystal-lang/crystal/pull/10610#discussion_r798180427