### PR TITLE
Interpreter: Promote arguments of variadic function calls

### DIFF
--- a/spec/compiler/data/interpreter/sum.c
+++ b/spec/compiler/data/interpreter/sum.c
@@ -1,0 +1,27 @@
+#include <stdarg.h>
+
+float sum_float(int count, ...) {
+  va_list args;
+  float total = 0;
+
+  va_start(args, count);
+  for (int i = 0; i < count; i++) {
+    total += va_arg(args, double);
+  }
+  va_end(args);
+
+  return total;
+}
+
+long sum_int(int count, ...) {
+  va_list args;
+  long total = 0;
+
+  va_start(args, count);
+  for (int i = 0; i < count; i++) {
+    total += va_arg(args, long);
+  }
+  va_end(args);
+
+  return total;
+}

--- a/spec/compiler/interpreter/lib_spec.cr
+++ b/spec/compiler/interpreter/lib_spec.cr
@@ -22,7 +22,7 @@ describe Crystal::Repl::Interpreter do
 
     it "promotes int" do
       interpret(<<-CR).should eq 5
-        @[Link("#{SPEC_CRYSTAL_LOADER_LIB_PATH}/libsum.so")]
+        @[Link(ldflags: "-L#{SPEC_CRYSTAL_LOADER_LIB_PATH} -lsum")]
         lib LibSum
           fun sum_int(count : Int32, ...) : Int32
         end
@@ -33,7 +33,7 @@ describe Crystal::Repl::Interpreter do
 
     it "promotes enum" do
       interpret(<<-CR).should eq 5
-        @[Link("#{SPEC_CRYSTAL_LOADER_LIB_PATH}/libsum.so")]
+        @[Link(ldflags: "-L#{SPEC_CRYSTAL_LOADER_LIB_PATH} -lsum")]
         lib LibSum
           fun sum_int(count : Int32, ...) : Int32
         end

--- a/spec/compiler/interpreter/lib_spec.cr
+++ b/spec/compiler/interpreter/lib_spec.cr
@@ -1,0 +1,57 @@
+{% skip_file if flag?(:without_interpreter) %}
+require "./spec_helper"
+require "../loader/spec_helper"
+
+describe Crystal::Repl::Interpreter do
+  context "variadic calls" do
+    before_all do
+      FileUtils.mkdir_p(SPEC_CRYSTAL_LOADER_LIB_PATH)
+      build_c_dynlib(compiler_datapath("interpreter", "sum.c"))
+    end
+
+    it "promotes float" do
+      interpret(<<-CR).should eq 3.5
+        @[Link(ldflags: "-L#{SPEC_CRYSTAL_LOADER_LIB_PATH} -lsum")]
+        lib LibSum
+          fun sum_float(count : Int32, ...) : Float32
+        end
+
+        LibSum.sum_float(2, 1.2_f32, 2.3_f32)
+        CR
+    end
+
+    it "promotes int" do
+      interpret(<<-CR).should eq 5
+        @[Link("#{SPEC_CRYSTAL_LOADER_LIB_PATH}/libsum.so")]
+        lib LibSum
+          fun sum_int(count : Int32, ...) : Int32
+        end
+
+        LibSum.sum_int(2, 1_u8, 4_i16)
+        CR
+    end
+
+    it "promotes enum" do
+      interpret(<<-CR).should eq 5
+        @[Link("#{SPEC_CRYSTAL_LOADER_LIB_PATH}/libsum.so")]
+        lib LibSum
+          fun sum_int(count : Int32, ...) : Int32
+        end
+
+        enum E : Int8
+          ONE = 1
+        end
+
+        enum F : UInt16
+          FOUR = 4
+        end
+
+        LibSum.sum_int(2, E::ONE, F::FOUR)
+        CR
+    end
+
+    after_all do
+      FileUtils.rm_rf(SPEC_CRYSTAL_LOADER_LIB_PATH)
+    end
+  end
+end

--- a/src/compiler/crystal/interpreter/compiler.cr
+++ b/src/compiler/crystal/interpreter/compiler.cr
@@ -1837,7 +1837,7 @@ class Crystal::Repl::Compiler < Crystal::Visitor
           args_ffi_types << FFI::Type.pointer
         else
           args_bytesizes << aligned_sizeof_type(arg)
-          args_ffi_types << arg.type.ffi_type
+          args_ffi_types << arg.type.ffi_arg_type
         end
       end
     end

--- a/src/compiler/crystal/interpreter/compiler.cr
+++ b/src/compiler/crystal/interpreter/compiler.cr
@@ -1809,7 +1809,7 @@ class Crystal::Repl::Compiler < Crystal::Visitor
         put_i64 0, node: arg
       when StaticArrayInstanceType
         # Static arrays are passed as pointers to C
-        compile_pointerof_node(arg, arg.type)
+        compile_pointerof_node(arg, arg_type)
       else
         request_value(arg)
       end
@@ -1836,8 +1836,8 @@ class Crystal::Repl::Compiler < Crystal::Visitor
           args_bytesizes << sizeof(Pointer(Void))
           args_ffi_types << FFI::Type.pointer
         else
-          args_bytesizes << aligned_sizeof_type(arg)
-          args_ffi_types << arg.type.ffi_arg_type
+          args_bytesizes << aligned_sizeof_type(arg_type)
+          args_ffi_types << arg_type.ffi_arg_type
         end
       end
     end

--- a/src/compiler/crystal/interpreter/compiler.cr
+++ b/src/compiler/crystal/interpreter/compiler.cr
@@ -1836,6 +1836,29 @@ class Crystal::Repl::Compiler < Crystal::Visitor
           args_bytesizes << sizeof(Pointer(Void))
           args_ffi_types << FFI::Type.pointer
         else
+          if external.varargs?
+            # Apply default promotions to certain types used as variadic arguments in C function calls.
+
+            # Resolve EnumType to its base type because that's the type that gets promoted
+            if arg_type.is_a?(EnumType)
+              arg_type = arg_type.base_type
+            end
+
+            if arg_type.is_a?(FloatType) && arg_type.bytes < 8
+              # Arguments of type float are promoted to double
+              promoted_type = @context.program.float64
+              primitive_convert node, arg_type, promoted_type, true
+
+              arg_type = promoted_type
+            elsif arg_type.is_a?(IntegerType) && arg_type.bytes < 4
+              # Integer argument types smaller than 4 bytes are promoted to 4 bytes
+              promoted_type = arg_type.signed? ? @context.program.int32 : @context.program.uint32
+              primitive_convert node, arg_type, promoted_type, true
+
+              arg_type = promoted_type
+            end
+          end
+
           args_bytesizes << aligned_sizeof_type(arg_type)
           args_ffi_types << arg_type.ffi_arg_type
         end

--- a/src/crystal/system/unix/file.cr
+++ b/src/crystal/system/unix/file.cr
@@ -6,11 +6,7 @@ module Crystal::System::File
   def self.open(filename, mode, perm)
     oflag = open_flag(mode) | LibC::O_CLOEXEC
 
-    if perm.is_a?(::File::Permissions)
-      perm = perm.value
-    end
-
-    fd = LibC.open(filename.check_no_null_byte, oflag, LibC::ModeT.new(perm))
+    fd = LibC.open(filename.check_no_null_byte, oflag, perm)
     if fd < 0
       raise ::File::Error.from_errno("Error opening file with mode '#{mode}'", file: filename)
     end


### PR DESCRIPTION
There are some limitations on the types that can be used in variadic arguments. Integer types must be at least 4 bytes and floating point types at least 8 bytes. Smaller types must be promoted to the minimum size.

This patch adds these promotions to the interpreter. We're already doing the same in LLVM codegen:

https://github.com/crystal-lang/crystal/blob/76ec0c765d7045311d4943d998a81262ccc80074/src/compiler/crystal/codegen/call.cr#L229-L239

The final commits reverts a part of #11159 which was only added as workaround for this bug and won't be needed anymore (
[`34f7908` (#11159)](https://github.com/crystal-lang/crystal/pull/11159/commits/34f790860876d3cfc9eeb396fe1f3869a37d52d8)).

/cc https://github.com/crystal-lang/crystal/pull/11159#discussion_r765127549