### PR TITLE
Optimize Integer decoding from bytes

### DIFF
--- a/src/io/byte_format.cr
+++ b/src/io/byte_format.cr
@@ -134,7 +134,7 @@ module IO::ByteFormat
         def self.encode(int : {{type.id}}, bytes : Bytes)
           buffer = int.unsafe_as(StaticArray(UInt8, {{bytesize}}))
           buffer.reverse! unless SystemEndian == self
-          buffer.to_unsafe.copy_to(bytes.to_unsafe, {{bytesize}})
+          buffer.to_slice.copy_to(bytes)
         end
 
         def self.decode(type : {{type.id}}.class, io : IO)

--- a/src/io/byte_format.cr
+++ b/src/io/byte_format.cr
@@ -134,7 +134,7 @@ module IO::ByteFormat
         def self.encode(int : {{type.id}}, bytes : Bytes)
           buffer = int.unsafe_as(StaticArray(UInt8, {{bytesize}}))
           buffer.reverse! unless SystemEndian == self
-          buffer.to_slice.copy_to(bytes)
+          buffer.to_unsafe.copy_to(bytes.to_unsafe, {{bytesize}})
         end
 
         def self.decode(type : {{type.id}}.class, io : IO)
@@ -146,7 +146,7 @@ module IO::ByteFormat
 
         def self.decode(type : {{type.id}}.class, bytes : Bytes)
           buffer = uninitialized UInt8[{{bytesize}}]
-          bytes.to_slice[0, {{bytesize}}].copy_to(buffer.to_slice)
+          bytes.copy_to(buffer.to_unsafe, {{bytesize}})
           buffer.reverse! unless SystemEndian == self
           buffer.unsafe_as({{type.id}})
         end


### PR DESCRIPTION
By using `Slice#copy_to(target : Pointer(T), count)` and not (stack) allocating new slices.

# Benchmark

```crystal
require "benchmark"

module IO::ByteFormat
  {% for mod in %w(LittleEndian BigEndian) %}
    module {{mod.id}}
      {% for type, i in %w(Int8 UInt8 Int16 UInt16 Int32 UInt32 Int64 UInt64 Int128 UInt128) %}
        {% bytesize = 2 ** (i // 2) %}
        def self.decode2(type : {{type.id}}.class, bytes : Bytes)
          buffer = uninitialized UInt8[{{bytesize}}]
          bytes.copy_to(buffer.to_unsafe, {{bytesize}})
          buffer.reverse! unless SystemEndian == self
          buffer.unsafe_as({{type.id}})
        end
      {% end %}
    end
  {% end %}
end

b = Bytes.new(128) { 1u8 }

{% for mod in %w(LittleEndian BigEndian) %}
  {% for type, i in %w(Int8 UInt8 Int16 UInt16 Int32 UInt32 Int64 UInt64 Int128 UInt128) %}
    Benchmark.ips do |x|
      x.report("old decode {{mod.id}} {{ type.id }}") do
        IO::ByteFormat::{{mod.id}}.decode({{type.id}}, b)
      end
      x.report("new decode {{mod.id}} {{ type.id }}") do
        IO::ByteFormat::{{mod.id}}.decode2({{type.id}}, b)
      end
    end
  {% end %}
{% end %}
```

## Results

```
old decode LittleEndian Int8 481.42M (  2.08ns) (± 3.63%)  0.0B/op   1.80× slower
new decode LittleEndian Int8 865.40M (  1.16ns) (± 1.36%)  0.0B/op        fastest
old decode LittleEndian UInt8 532.87M (  1.88ns) (± 3.58%)  0.0B/op   1.65× slower
new decode LittleEndian UInt8 877.89M (  1.14ns) (± 3.18%)  0.0B/op        fastest
old decode LittleEndian Int16 492.96M (  2.03ns) (± 3.21%)  0.0B/op   1.79× slower
new decode LittleEndian Int16 881.37M (  1.13ns) (± 3.86%)  0.0B/op        fastest
old decode LittleEndian UInt16 468.77M (  2.13ns) (± 4.01%)  0.0B/op   1.84× slower
new decode LittleEndian UInt16 864.24M (  1.16ns) (± 1.69%)  0.0B/op        fastest
old decode LittleEndian Int32 491.97M (  2.03ns) (± 5.36%)  0.0B/op   1.85× slower
new decode LittleEndian Int32 911.73M (  1.10ns) (± 4.76%)  0.0B/op        fastest
old decode LittleEndian UInt32 492.52M (  2.03ns) (± 4.21%)  0.0B/op   1.75× slower
new decode LittleEndian UInt32 863.92M (  1.16ns) (± 2.46%)  0.0B/op        fastest
old decode LittleEndian Int64 481.59M (  2.08ns) (± 2.89%)  0.0B/op   1.92× slower
new decode LittleEndian Int64 925.13M (  1.08ns) (± 4.13%)  0.0B/op        fastest
old decode LittleEndian UInt64 474.08M (  2.11ns) (± 3.60%)  0.0B/op   1.83× slower
new decode LittleEndian UInt64 865.81M (  1.15ns) (± 1.47%)  0.0B/op        fastest
old decode LittleEndian Int128 479.22M (  2.09ns) (± 2.60%)  0.0B/op   1.80× slower
new decode LittleEndian Int128 861.06M (  1.16ns) (± 2.56%)  0.0B/op        fastest
old decode LittleEndian UInt128 478.12M (  2.09ns) (± 3.83%)  0.0B/op   1.85× slower
new decode LittleEndian UInt128 885.39M (  1.13ns) (± 3.43%)  0.0B/op        fastest
old decode BigEndian Int8 508.86M (  1.97ns) (± 2.52%)  0.0B/op   1.73× slower
new decode BigEndian Int8 882.45M (  1.13ns) (± 3.30%)  0.0B/op        fastest
old decode BigEndian UInt8 399.35M (  2.50ns) (±14.63%)  0.0B/op   2.18× slower
new decode BigEndian UInt8 871.88M (  1.15ns) (± 2.95%)  0.0B/op        fastest
old decode BigEndian Int16 520.54M (  1.92ns) (± 4.86%)  0.0B/op   1.76× slower
new decode BigEndian Int16 916.68M (  1.09ns) (± 5.12%)  0.0B/op        fastest
old decode BigEndian UInt16 493.51M (  2.03ns) (± 3.94%)  0.0B/op   1.75× slower
new decode BigEndian UInt16 863.52M (  1.16ns) (± 4.39%)  0.0B/op        fastest
old decode BigEndian Int32 144.54M (  6.92ns) (± 2.27%)  0.0B/op   1.20× slower
new decode BigEndian Int32 172.98M (  5.78ns) (± 2.75%)  0.0B/op        fastest
old decode BigEndian UInt32 144.65M (  6.91ns) (± 2.09%)  0.0B/op   1.19× slower
new decode BigEndian UInt32 172.56M (  5.80ns) (± 2.49%)  0.0B/op        fastest
old decode BigEndian Int64 172.93M (  5.78ns) (± 2.60%)  0.0B/op        fastest
new decode BigEndian Int64 150.70M (  6.64ns) (± 4.02%)  0.0B/op   1.15× slower
old decode BigEndian UInt64 175.44M (  5.70ns) (± 3.70%)  0.0B/op        fastest
new decode BigEndian UInt64 150.72M (  6.63ns) (± 3.56%)  0.0B/op   1.16× slower
old decode BigEndian Int128 123.75M (  8.08ns) (± 2.76%)  0.0B/op   1.32× slower
new decode BigEndian Int128 163.88M (  6.10ns) (± 5.83%)  0.0B/op        fastest
old decode BigEndian UInt128 132.80M (  7.53ns) (± 2.45%)  0.0B/op   1.21× slower
new decode BigEndian UInt128 161.01M (  6.21ns) (± 1.47%)  0.0B/op        fastest
```

## Discussion
Decoding is about 80% faster with the notable of exception BigEndian (U)Int64, which becomes 15% slower. 