### PR TITLE
remove duplicate word in documentation

### DIFF
--- a/src/spec/dsl.cr
+++ b/src/spec/dsl.cr
@@ -130,7 +130,7 @@ module Spec
   end
 
   # Instructs the spec runner to execute the given block
-  # after each spec spec in the spec suite.
+  # after each spec in the spec suite.
   #
   # If multiple blocks are registered they run in the reversed
   # order that they are given.


### PR DESCRIPTION
change "spec spec" to "spec"