### PR TITLE
Enable interpreter integration specs for `YAML`

### DIFF
--- a/spec/compiler/interpreter/integration_spec.cr
+++ b/spec/compiler/interpreter/integration_spec.cr
@@ -83,7 +83,7 @@ describe Crystal::Repl::Interpreter do
       CODE
     end
 
-    pending "does YAML" do
+    it "does YAML" do
       interpret(<<-CODE, prelude: "prelude").should eq("6")
         require "yaml"
 
@@ -97,7 +97,7 @@ describe Crystal::Repl::Interpreter do
       CODE
     end
 
-    pending "does YAML::Serializable" do
+    it "does YAML::Serializable" do
       interpret(<<-CODE, prelude: "prelude").should eq("3")
         require "yaml"
 


### PR DESCRIPTION
These specs failed on the original interpreter PR #11159 (see https://github.com/crystal-lang/crystal/pull/11159#issuecomment-988889766). They should be working now and can be enabled.