### PR TITLE
Allow passing instance method or conditional expressions to option `ignore_serialize` on `JSON::Field`

### DIFF
--- a/spec/std/json/serializable_spec.cr
+++ b/spec/std/json/serializable_spec.cr
@@ -244,10 +244,10 @@ end
 class JSONAttrWithPresence
   include JSON::Serializable
 
-  @[JSON::Field(presence: true, ignore_serialize_if: ignore_first_name?, emit_null: true)]
+  @[JSON::Field(presence: true, ignore_serialize_if: ignore_first_name?)]
   property first_name : String?
 
-  @[JSON::Field(presence: true)]
+  @[JSON::Field(presence: true, ignore_serialize_if: !last_name_present?, emit_null: true)]
   property last_name : String?
 
   @[JSON::Field(ignore: true)]
@@ -816,6 +816,13 @@ describe "JSON mapping" do
 
     it "ignores field with method call" do
       json = JSONAttrWithPresence.from_json(%({"first_name": "ignore me"}))
+      json.to_json.should eq(%({}))
+    end
+
+    it "emit nulls dynamically" do
+      json = JSONAttrWithPresence.from_json(%({"last_name": null}))
+      json.to_json.should eq(%({"last_name":null}))
+      json = JSONAttrWithPresence.from_json(%({}))
       json.to_json.should eq(%({}))
     end
   end

--- a/spec/std/json/serializable_spec.cr
+++ b/spec/std/json/serializable_spec.cr
@@ -257,13 +257,13 @@ class JSONAttrWithPresence
   getter? last_name_present : Bool
 end
 
-class JSONAttrWithPresenceAndIgnoreSerializeIf
+class JSONAttrWithPresenceAndIgnoreSerialize
   include JSON::Serializable
 
-  @[JSON::Field(presence: true, ignore_serialize_if: ignore_first_name?)]
+  @[JSON::Field(presence: true, ignore_serialize: ignore_first_name?)]
   property first_name : String?
 
-  @[JSON::Field(presence: true, ignore_serialize_if: last_name.nil? && !last_name_present?, emit_null: true)]
+  @[JSON::Field(presence: true, ignore_serialize: last_name.nil? && !last_name_present?, emit_null: true)]
   property last_name : String?
 
   @[JSON::Field(ignore: true)]
@@ -834,42 +834,42 @@ describe "JSON mapping" do
     end
   end
 
-  describe "serializes JSON with presence markers and ignore_serialize_if" do
-    context "ignore_serialize_if is set to a method which returns true when value is nil or empty string" do
+  describe "serializes JSON with presence markers and ignore_serialize" do
+    context "ignore_serialize is set to a method which returns true when value is nil or empty string" do
       it "ignores field when value is empty string" do
-        json = JSONAttrWithPresenceAndIgnoreSerializeIf.from_json(%({"first_name": ""}))
+        json = JSONAttrWithPresenceAndIgnoreSerialize.from_json(%({"first_name": ""}))
         json.first_name_present?.should be_true
         json.to_json.should eq(%({}))
       end
 
       it "ignores field when value is nil" do
-        json = JSONAttrWithPresenceAndIgnoreSerializeIf.from_json(%({"first_name": null}))
+        json = JSONAttrWithPresenceAndIgnoreSerialize.from_json(%({"first_name": null}))
         json.first_name_present?.should be_true
         json.to_json.should eq(%({}))
       end
     end
 
-    context "ignore_serialize_if is set to conditional expressions 'last_name.nil? && !last_name_present?'" do
+    context "ignore_serialize is set to conditional expressions 'last_name.nil? && !last_name_present?'" do
       it "emits null when value is null and @last_name_present is true" do
-        json = JSONAttrWithPresenceAndIgnoreSerializeIf.from_json(%({"last_name": null}))
+        json = JSONAttrWithPresenceAndIgnoreSerialize.from_json(%({"last_name": null}))
         json.last_name_present?.should be_true
         json.to_json.should eq(%({"last_name":null}))
       end
 
       it "does not emit null when value is null and @last_name_present is false" do
-        json = JSONAttrWithPresenceAndIgnoreSerializeIf.from_json(%({}))
+        json = JSONAttrWithPresenceAndIgnoreSerialize.from_json(%({}))
         json.last_name_present?.should be_false
         json.to_json.should eq(%({}))
       end
 
       it "emits field when value is not nil and @last_name_present is false" do
-        json = JSONAttrWithPresenceAndIgnoreSerializeIf.new(last_name: "something")
+        json = JSONAttrWithPresenceAndIgnoreSerialize.new(last_name: "something")
         json.last_name_present?.should be_false
         json.to_json.should eq(%({"last_name":"something"}))
       end
 
       it "emits field when value is not nil and @last_name_present is true" do
-        json = JSONAttrWithPresenceAndIgnoreSerializeIf.from_json(%({"last_name":"something"}))
+        json = JSONAttrWithPresenceAndIgnoreSerialize.from_json(%({"last_name":"something"}))
         json.last_name_present?.should be_true
         json.to_json.should eq(%({"last_name":"something"}))
       end

--- a/spec/std/json/serializable_spec.cr
+++ b/spec/std/json/serializable_spec.cr
@@ -247,14 +247,17 @@ class JSONAttrWithPresence
   @[JSON::Field(presence: true, ignore_serialize_if: ignore_first_name?)]
   property first_name : String?
 
-  @[JSON::Field(presence: true, ignore_serialize_if: !last_name_present?, emit_null: true)]
+  @[JSON::Field(presence: true, ignore_serialize_if: last_name.nil? && !last_name_present?, emit_null: true)]
   property last_name : String?
 
   @[JSON::Field(ignore: true)]
-  getter? first_name_present : Bool
+  getter? first_name_present : Bool = false
 
   @[JSON::Field(ignore: true)]
-  getter? last_name_present : Bool
+  getter? last_name_present : Bool = false
+
+  def initialize(@first_name : String? = nil, @last_name : String? = nil)
+  end
 
   def ignore_first_name?
     first_name.to_s == "ignore me"
@@ -822,6 +825,8 @@ describe "JSON mapping" do
     it "emit nulls dynamically" do
       json = JSONAttrWithPresence.from_json(%({"last_name": null}))
       json.to_json.should eq(%({"last_name":null}))
+      json = JSONAttrWithPresence.new(last_name: "something")
+      json.to_json.should eq(%({"last_name":"something"}))
       json = JSONAttrWithPresence.from_json(%({}))
       json.to_json.should eq(%({}))
     end

--- a/spec/std/json/serializable_spec.cr
+++ b/spec/std/json/serializable_spec.cr
@@ -244,7 +244,7 @@ end
 class JSONAttrWithPresence
   include JSON::Serializable
 
-  @[JSON::Field(presence: true)]
+  @[JSON::Field(presence: true, ignore_serialize_if: ignore_first_name?, emit_null: true)]
   property first_name : String?
 
   @[JSON::Field(presence: true)]
@@ -255,6 +255,10 @@ class JSONAttrWithPresence
 
   @[JSON::Field(ignore: true)]
   getter? last_name_present : Bool
+
+  def ignore_first_name?
+    first_name.to_s == "ignore me"
+  end
 end
 
 class JSONAttrWithQueryAttributes
@@ -808,6 +812,11 @@ describe "JSON mapping" do
       json.first_name_present?.should be_true
       json.last_name.should be_nil
       json.last_name_present?.should be_false
+    end
+
+    it "ignores field with method call" do
+      json = JSONAttrWithPresence.from_json(%({"first_name": "ignore me"}))
+      json.to_json.should eq(%({}))
     end
   end
 

--- a/src/json/serialization.cr
+++ b/src/json/serialization.cr
@@ -61,6 +61,7 @@ module JSON
   # `JSON::Field` properties:
   # * **ignore**: if `true` skip this field in serialization and deserialization (by default false)
   # * **ignore_serialize**: if `true` skip this field in serialization (by default false)
+  # * **ignore_serialize_if**: an instance method name or conditional expressions returning Bool, skips this field in serialization if it returns `true` after evaluation
   # * **ignore_deserialize**: if `true` skip this field in deserialization (by default false)
   # * **key**: the value of the key in the json object (by default the name of the instance variable)
   # * **root**: assume the value is inside a JSON object with a given key (see `Object.from_json(string_or_io, root)`)

--- a/src/json/serialization.cr
+++ b/src/json/serialization.cr
@@ -60,7 +60,7 @@ module JSON
   #
   # `JSON::Field` properties:
   # * **ignore**: if `true` skip this field in serialization and deserialization (by default false)
-  # * **ignore_serialize**: If truthy, skip this field in serialization (default: `false`). The value can be any Crystal expression and is evaluated within the instance scope at runtime
+  # * **ignore_serialize**: If truthy, skip this field in serialization (default: `false`). The value can be any Crystal expression and is evaluated at runtime
   # * **ignore_deserialize**: if `true` skip this field in deserialization (by default false)
   # * **key**: the value of the key in the json object (by default the name of the instance variable)
   # * **root**: assume the value is inside a JSON object with a given key (see `Object.from_json(string_or_io, root)`)

--- a/src/json/serialization.cr
+++ b/src/json/serialization.cr
@@ -60,7 +60,7 @@ module JSON
   #
   # `JSON::Field` properties:
   # * **ignore**: if `true` skip this field in serialization and deserialization (by default false)
-  # * **ignore_serialize**: If truthy, skip this field in serialization (default: `false`). The value can be any Crystal expression and is evaluated at runtime
+  # * **ignore_serialize**: If truthy, skip this field in serialization (default: `false`). The value can be any Crystal expression and is evaluated at runtime.
   # * **ignore_deserialize**: if `true` skip this field in deserialization (by default false)
   # * **key**: the value of the key in the json object (by default the name of the instance variable)
   # * **root**: assume the value is inside a JSON object with a given key (see `Object.from_json(string_or_io, root)`)

--- a/src/json/serialization.cr
+++ b/src/json/serialization.cr
@@ -60,7 +60,7 @@ module JSON
   #
   # `JSON::Field` properties:
   # * **ignore**: if `true` skip this field in serialization and deserialization (by default false)
-  # * **ignore_serialize**: a Bool literal or instance method returning Bool or conditional expressions, skip this field in serialization if it is `true` after evaluation (by default false)
+  # * **ignore_serialize**: If truthy, skip this field in serialization (default: `false`). The value can be any Crystal expression and is evaluated within the instance scope at runtime
   # * **ignore_deserialize**: if `true` skip this field in deserialization (by default false)
   # * **key**: the value of the key in the json object (by default the name of the instance variable)
   # * **root**: assume the value is inside a JSON object with a given key (see `Object.from_json(string_or_io, root)`)


### PR DESCRIPTION
Closes #11803

Allow passing instance method or conditional expressions to option ignore_serialize on JSON::Field from #11803.

It seems to be trivial to implement since the compiler and stdlib are written in crystal itself.

The new specs provide example usages:
- Use an instance method to decide whether to ignore the field
- Dynamically emit nulls based on @{{key}}_present