### PR TITLE
Fix interpreter when shared library `pthread` is missing

### DIFF
--- a/src/gc/boehm.cr
+++ b/src/gc/boehm.cr
@@ -5,9 +5,15 @@
 # MUSL: On musl systems, libpthread is empty. The entire library is already included in libc.
 # The empty library is only available for POSIX compatibility. We don't need to link it.
 #
+# Interpreter: Starting with glibc 2.34, `pthread` is integrated into `libc`
+# and may not even be available as a separate shared library.
+# There's always a static library for compiled mode, but `Crystal::Loader` does not support
+# static libraries. So we just skip `pthread` entirely. The symbols are still
+# available in the interpreter because they are loaded in the compiler.
+#
 # OTHERS: On other systems, we add the linker annotation here to make sure libpthread is loaded
 # before libgc which looks up symbols from libpthread.
-{% unless flag?(:win32) || flag?(:musl) %}
+{% unless flag?(:win32) || flag?(:musl) || (flag?(:interpreter) && flag?(:gnu)) %}
   @[Link("pthread")]
 {% end %}
 

--- a/src/gc/boehm.cr
+++ b/src/gc/boehm.cr
@@ -13,7 +13,7 @@
 #
 # OTHERS: On other systems, we add the linker annotation here to make sure libpthread is loaded
 # before libgc which looks up symbols from libpthread.
-{% unless flag?(:win32) || flag?(:musl) || (flag?(:interpreter) && flag?(:gnu)) %}
+{% unless flag?(:win32) || flag?(:musl) || (flag?(:interpreted) && flag?(:gnu)) %}
   @[Link("pthread")]
 {% end %}
 

--- a/src/gc/boehm.cr
+++ b/src/gc/boehm.cr
@@ -5,6 +5,8 @@
 # MUSL: On musl systems, libpthread is empty. The entire library is already included in libc.
 # The empty library is only available for POSIX compatibility. We don't need to link it.
 #
+# Darwin: `libpthread` is provided as part of `libsystem`. There's no reason to link it explicitly.
+#
 # Interpreter: Starting with glibc 2.34, `pthread` is integrated into `libc`
 # and may not even be available as a separate shared library.
 # There's always a static library for compiled mode, but `Crystal::Loader` does not support
@@ -13,7 +15,7 @@
 #
 # OTHERS: On other systems, we add the linker annotation here to make sure libpthread is loaded
 # before libgc which looks up symbols from libpthread.
-{% unless flag?(:win32) || flag?(:musl) || (flag?(:interpreted) && flag?(:gnu)) %}
+{% unless flag?(:win32) || flag?(:musl) || flag?(:darwin) || (flag?(:interpreted) && flag?(:gnu)) %}
   @[Link("pthread")]
 {% end %}
 

--- a/src/lib_c/aarch64-darwin/c/dlfcn.cr
+++ b/src/lib_c/aarch64-darwin/c/dlfcn.cr
@@ -1,4 +1,3 @@
-@[Link("dl")]
 lib LibC
   RTLD_LAZY    = 0x1
   RTLD_NOW     = 0x2

--- a/src/lib_c/x86_64-darwin/c/dlfcn.cr
+++ b/src/lib_c/x86_64-darwin/c/dlfcn.cr
@@ -1,4 +1,3 @@
-@[Link("dl")]
 lib LibC
   RTLD_LAZY    = 0x1
   RTLD_NOW     = 0x2


### PR DESCRIPTION
Resolves #11792