### PR TITLE
Fix recursive `pointerof` detection with generic splat type variables

### DIFF
--- a/spec/compiler/semantic/pointer_spec.cr
+++ b/spec/compiler/semantic/pointer_spec.cr
@@ -98,6 +98,32 @@ describe "Semantic: pointer" do
       "recursive pointerof expansion"
   end
 
+  it "detects recursive pointerof expansion (3)" do
+    assert_error <<-CR, "recursive pointerof expansion"
+      x = {1}
+      x = pointerof(x)
+      CR
+  end
+
+  it "detects recursive pointerof expansion (4)" do
+    assert_error <<-CR, "recursive pointerof expansion"
+      x = 1
+      x = {pointerof(x)}
+      CR
+  end
+
+  it "doesn't crash if pointerof expansion type has generic splat parameter (#11808)" do
+    assert_type(<<-CR) { pointer_of(union_of int32, generic_class("Foo", string)) }
+      class Foo(*T)
+      end
+
+      x = 1
+      pointer = pointerof(x)
+      x = Foo(String).new
+      pointer
+      CR
+  end
+
   it "can assign nil to void pointer" do
     assert_type(%(
       ptr = Pointer(Void).malloc(1_u64)

--- a/src/compiler/crystal/semantic/bindings.cr
+++ b/src/compiler/crystal/semantic/bindings.cr
@@ -326,7 +326,17 @@ module Crystal
       when UnionType
         haystack.union_types.any? { |sub| type_includes?(sub, needle) }
       when GenericClassInstanceType
-        haystack.type_vars.any? { |key, sub| sub.is_a?(Var) && type_includes?(sub.type, needle) }
+        splat_index = haystack.generic_type.splat_index
+        haystack.type_vars.each_with_index do |(_, sub), index|
+          if sub.is_a?(Var)
+            if index == splat_index
+              return true if sub.type.as(TupleInstanceType).tuple_types.any? { |sub2| type_includes?(sub2, needle) }
+            else
+              return true if type_includes?(sub.type, needle)
+            end
+          end
+        end
+        false
       else
         false
       end


### PR DESCRIPTION
Fixes #11808. This happens with any generic class type that has a splat type parameter, not just `Tuple`.

```crystal
class Foo(*T); end

x = Foo(Int32).new
x = pointerof(x) # Error: recursive pointerof expansion: Pointer(Foo(Int32)), Pointer(Foo(Int32) | Pointer(Foo(Int32))), ...
```

```crystal
x = 1
x = {pointerof(x)} # Error: recursive pointerof expansion: Pointer(Int32), Pointer(Int32 | Tuple(Pointer(Int32))), ...
```

```crystal
class Foo(*T); end

x = 1
y = pointerof(x)
x = Foo(String).new # okay
```