### PR TITLE
Experimental: better type inference for ivars/cvars

### DIFF
--- a/spec/compiler/semantic/instance_var_spec.cr
+++ b/spec/compiler/semantic/instance_var_spec.cr
@@ -3819,6 +3819,46 @@ describe "Semantic: instance var" do
       "wrong number of arguments for 'Foo.new'"
   end
 
+  it "infers from method on integer literal, with type annotation" do
+    assert_type(%(
+      struct Int32
+        def foo : Char
+          'a'
+        end
+      end
+
+      class Foo
+        def initialize
+          @x = 1.foo
+        end
+
+        def x
+          @x
+        end
+      end
+
+      Foo.new.x
+      )) { char }
+  end
+
+  it "infers from method in generic type, with type annotation" do
+    assert_type(%(
+      class Gen(T)
+        def foo : Gen(T)
+          self
+        end
+      end
+
+      class Foo
+        def initialize
+          @x = Gen(Int32).new.foo
+        end
+      end
+
+      Foo.new.@x
+      )) { generic_class "Gen", int32 }
+  end
+
   it "guesses inside macro if" do
     assert_type(%(
       {% if true %}

--- a/spec/compiler/semantic/instance_var_spec.cr
+++ b/spec/compiler/semantic/instance_var_spec.cr
@@ -3859,6 +3859,24 @@ describe "Semantic: instance var" do
       )) { generic_class "Gen", int32 }
   end
 
+  it "infers type by removing nil from || left side" do
+    assert_type(%(
+      struct Int32
+        def foo : Int32?
+          1
+        end
+      end
+
+      class Foo
+        def initialize
+          @x = 1.foo || 2
+        end
+      end
+
+      Foo.new.@x
+      )) { int32 }
+  end
+
   it "guesses inside macro if" do
     assert_type(%(
       {% if true %}

--- a/spec/compiler/semantic/instance_var_spec.cr
+++ b/spec/compiler/semantic/instance_var_spec.cr
@@ -3877,6 +3877,36 @@ describe "Semantic: instance var" do
       )) { int32 }
   end
 
+  it "infers type from all call matches" do
+    assert_type(%(
+      class Base
+        def foo : Int32
+          1
+        end
+      end
+
+      class Sub1 < Base
+        def foo : Char
+          'a'
+        end
+      end
+
+      class Sub2 < Base
+        def foo
+          1 + 2
+        end
+      end
+
+      class Foo
+        def initialize(base : Base)
+          @x = base.foo
+        end
+      end
+
+      Foo.new(Base.new).@x
+      )) { union_of int32, char }
+  end
+
   it "guesses inside macro if" do
     assert_type(%(
       {% if true %}

--- a/src/compiler/crystal/semantic/exception.cr
+++ b/src/compiler/crystal/semantic/exception.cr
@@ -324,9 +324,7 @@ module Crystal
       msg = String.build do |str|
         str << common
         str << "\n\n"
-        str << undefined_variable_message("a class variable", node.name)
-        str << "\n\n"
-        str << common
+        str << undefined_variable_message("class variable", node.name, owner.devirtualize)
       end
       node.raise msg
     end
@@ -343,36 +341,29 @@ module Crystal
       msg = String.build do |str|
         str << common
         str << "\n\n"
-        str << undefined_variable_message("an instance variable", node.name)
-        str << "\n\n"
-        str << common
+        str << undefined_variable_message("instance variable", node.name, owner.devirtualize)
       end
       node.raise msg
     end
 
-    def undefined_variable_message(kind, example_name)
+    def undefined_variable_message(kind, example_name, owner)
+      owner_keyword =
+        if owner.module?
+          "module"
+        elsif owner.struct?
+          "struct"
+        else
+          "class"
+        end
+
       <<-MSG
-      The type of #{kind}, if not declared explicitly with
-      `#{example_name} : Type`, is inferred from assignments to it across
-      the whole program.
+      Could you add a type annotation like this
 
-      The assignments must look like this:
+          #{owner_keyword} #{owner}
+            #{example_name} : Type
+          end
 
-        1. `#{example_name} = 1` (or other literals), inferred to the literal's type
-        2. `#{example_name} = Type.new`, type is inferred to be Type
-        3. `#{example_name} = Type.method`, where `method` has a return type
-           annotation, type is inferred from it
-        4. `#{example_name} = arg`, with 'arg' being a method argument with a
-           type restriction 'Type', type is inferred to be Type
-        5. `#{example_name} = arg`, with 'arg' being a method argument with a
-           default value, type is inferred using rules 1, 2 and 3 from it
-        6. `#{example_name} = uninitialized Type`, type is inferred to be Type
-        7. `#{example_name} = LibSome.func`, and `LibSome` is a `lib`, type
-           is inferred from that fun.
-        8. `LibSome.func(out #{example_name})`, and `LibSome` is a `lib`, type
-           is inferred from that fun argument.
-
-      Other assignments have no effect on its type.
+      replacing `Type` with the expected type of `#{example_name}`?
       MSG
     end
   end

--- a/src/compiler/crystal/semantic/type_guess_visitor.cr
+++ b/src/compiler/crystal/semantic/type_guess_visitor.cr
@@ -960,7 +960,7 @@ module Crystal
     def guess_type(node : BinaryOp)
       left_type = guess_type(node.left)
       right_type = guess_type(node.right)
-      guess_from_two(left_type, right_type)
+      guess_from_two(left_type, right_type, is_or: node.is_a?(Or))
     end
 
     def guess_type(node : If)
@@ -1082,7 +1082,9 @@ module Crystal
       @program.nil
     end
 
-    def guess_from_two(type1, type2)
+    def guess_from_two(type1, type2, is_or = false)
+      type1 = TruthyFilter.instance.apply(type1) if type1 && is_or
+
       if type1
         if type2
           Type.merge!(type1, type2)

--- a/src/compiler/crystal/semantic/type_guess_visitor.cr
+++ b/src/compiler/crystal/semantic/type_guess_visitor.cr
@@ -863,13 +863,17 @@ module Crystal
       )
       matches = obj_type.lookup_matches(signature).matches
       return nil unless matches
-      return nil unless matches.size == 1
 
-      match = matches.first
-      return_type = match.def.return_type
-      return nil unless return_type
+      return_types = matches.compact_map do |match|
+        return_type = match.def.return_type
+        next unless return_type
 
-      lookup_type?(return_type, match.context.instantiated_type)
+        lookup_type?(return_type, match.context.instantiated_type)
+      end
+
+      return nil if return_types.empty?
+
+      Type.merge(return_types)
     end
 
     def guess_type(node : Cast)


### PR DESCRIPTION
This is just an experimental PR to prove that this is possible. The question is... would we want this?

This PR is inspired by https://github.com/crystal-lang/crystal/issues/11805

In that issue, the OP asks: why the compiler can't infer this?

```crystal
class Thing
  DELAY = 10.milliseconds

  @timer_countdown = DELAY # can't infer the type of instance variable '@timer_countdown' of Thing
end
```

After all, this is relatively simple to solve:
1. Note that `@timer_countdown` is assigned a constant value
2. That constant value is assigned `10.milliseconds`
3. `10` is obviously an `Int32`
4. There's a method `milliseconds` defined on `Int32` that returns `Time::Span`
5. So the type of `@timer_countdown` is guessed to be `Time::Span`!

So initially I thought:
- okay, if the receiver of a method is a literal, we can do it, assuming the method has no arguments
- actually, we can still do it if the argument types can be inferred. In a case like `@x = 1 + 2`, the compiler can easily see that this is going to be `Int32#+(Int32)` which is typed to be `Int32`

This is what this PR does.

But then I kept thinking...
- Why not just try to infer the type of the call receiver and the arguments, and then lookup a call if we have all of those?

What this enables is all of this:

```crystal
class Foo
  # Okay, this is what OP was proposing...
  @x = 10.milliseconds
end
```

```crystal
class Foo
  # This is a nested call, (2 * 3) + 4, but everything can be easily inferred
  @x = 2 * 3 + 4
end
```

```crystal
class Foo
  # The call receiver is inferred to be Array(Int32), and Array#reverse says it returns Array(T), so the compiler can easily infer this
  @x = [1, 2, 3].reverse
end
```

The above isn't very useful, but... what about this then?

```crystal
class Foo
  def initialize(array : Array(Int32))
    # `array` is correctly guessed to be Array(Int32), and, like before, reverse has a type annotation, so...
    @reversed = array.reverse
  end
end
```

I think the above is actually a bit more useful. For a human it's pretty obvious that `reverse` is going to be returning an array of the same type, so why bother them with adding a type annotation? 

This also works...

```crystal
class Foo
  def initialize(string : String)
    # All of these can be easily inferred without having to look at method bodies,
   # because they all have a return type
    @value = string.upcase.reverse + " world!"
  end
end

p Foo.new("olleh")
```

The only problem with doing this is... it maybe becomes a bit harder to know when you don't need to put a type annotation and when you do. Right now it's a lot of rules:

```
The type of an instance variable, if not declared explicitly with
`@value : Type`, is inferred from assignments to it across
the whole program.

The assignments must look like this:

  1. `@value = 1` (or other literals), inferred to the literal's type
  2. `@value = Type.new`, type is inferred to be Type
  3. `@value = Type.method`, where `method` has a return type
     annotation, type is inferred from it
  4. `@value = arg`, with 'arg' being a method argument with a
     type restriction 'Type', type is inferred to be Type
  5. `@value = arg`, with 'arg' being a method argument with a
     default value, type is inferred using rules 1, 2 and 3 from it
  6. `@value = uninitialized Type`, type is inferred to be Type
  7. `@value = LibSome.func`, and `LibSome` is a `lib`, type
     is inferred from that fun.
  8. `LibSome.func(out @value)`, and `LibSome` is a `lib`, type
     is inferred from that fun argument.

Other assignments have no effect on its type.
```

So adding more rules will make the error really long and hard to understand!

But I'm thinking we could actually change this too. I don't think there's a need to list all these rules in the error message. The error message could be something like this:

> Sorry, I can't easily infer the type of instance variable @value.
> Could you add a type annotation?
> 
> Hint: the compiler might be able to infer the type of some expressions
> without an explicit type annotation, but in some case you must put
> a type annotation. Refer to the manual for an explanation of when
> the compiler can infer these: [link to manual]

So the user would just go ahead and put a type annotation, or read the manual to understand things better. I'm also sure nobody right now reads the existing long message or remembers all those rules, it's probably always "I don't put a type annotation unless the compiler tells me to do so." So we would be reducing the amount of these occurrences, for more developer happiness, at minimal cost!

What do you think? 