### PR TITLE
Refactor target clauses for system implementations

### DIFF
--- a/src/crystal/system/env.cr
+++ b/src/crystal/system/env.cr
@@ -12,8 +12,10 @@ module Crystal::System::Env
   # def self.each(&block : String, String ->)
 end
 
-{% if flag?(:win32) %}
+{% if flag?(:unix) %}
+  require "./unix/env"
+{% elsif flag?(:win32) %}
   require "./win32/env"
 {% else %}
-  require "./unix/env"
+  {% raise "No implementation of Crystal::System::Env available" %}
 {% end %}

--- a/src/crystal/system/env.cr
+++ b/src/crystal/system/env.cr
@@ -17,5 +17,5 @@ end
 {% elsif flag?(:win32) %}
   require "./win32/env"
 {% else %}
-  {% raise "No implementation of Crystal::System::Env available" %}
+  {% raise "No Crystal::System::Env implementation available" %}
 {% end %}

--- a/src/crystal/system/file_descriptor.cr
+++ b/src/crystal/system/file_descriptor.cr
@@ -1,5 +1,7 @@
-{% if flag?(:win32) %}
+{% if flag?(:unix) %}
+  require "./unix/file_descriptor"
+{% elsif flag?(:win32) %}
   require "./win32/file_descriptor"
 {% else %}
-  require "./unix/file_descriptor"
+  {% raise "No Crystal::System::FileDescriptor implementation available" %}
 {% end %}

--- a/src/crystal/system/time.cr
+++ b/src/crystal/system/time.cr
@@ -12,8 +12,10 @@ module Crystal::System::Time
   # def self.load_localtime : ::Time::Location?
 end
 
-{% if flag?(:win32) %}
+{% if flag?(:unix) %}
+  require "./unix/time"
+{% elsif flag?(:win32) %}
   require "./win32/time"
 {% else %}
-  require "./unix/time"
+  {% raise "No implementation of Crystal::System::Time available" %}
 {% end %}

--- a/src/crystal/system/time.cr
+++ b/src/crystal/system/time.cr
@@ -17,5 +17,5 @@ end
 {% elsif flag?(:win32) %}
   require "./win32/time"
 {% else %}
-  {% raise "No implementation of Crystal::System::Time available" %}
+  {% raise "No Crystal::System::Time implementation available" %}
 {% end %}


### PR DESCRIPTION
This is a tiny refactor to adjust the require clauses for system implementations to have a branch for each platform and raise if none matches. This is already used in all other similar places.

Cherry-picked from #10870 because it's a unrelated change to adding WebAssembly.