### PR TITLE
Support read-write + binary file modes in `File.open`

### DIFF
--- a/spec/std/file_spec.cr
+++ b/spec/std/file_spec.cr
@@ -683,6 +683,45 @@ describe "File" do
     end
   end
 
+  it "supports binary modes" do
+    with_tempfile("binary-modes.txt") do |path|
+      File.open(path, "wb") do |f|
+        f.write(Bytes[1, 3, 6, 10])
+      end
+      File.open(path, "rb") do |f|
+        bytes = Bytes.new(4)
+        f.read(bytes)
+        bytes.should eq(Bytes[1, 3, 6, 10])
+      end
+      File.open(path, "ab") do |f|
+        f.size.should eq(4)
+      end
+
+      File.open(path, "r+b") do |f|
+        bytes = Bytes.new(4)
+        f.read(bytes)
+        bytes.should eq(Bytes[1, 3, 6, 10])
+        f.seek(0)
+        f.write(Bytes[1, 3, 6, 10])
+      end
+      File.open(path, "a+b") do |f|
+        f.write(Bytes[13, 13, 10])
+        f.flush
+        f.seek(0)
+        bytes = Bytes.new(7)
+        f.read(bytes)
+        bytes.should eq(Bytes[1, 3, 6, 10, 13, 13, 10])
+      end
+      File.open(path, "w+b") do |f|
+        f.size.should eq(0)
+      end
+
+      File.open(path, "rb+") { }
+      File.open(path, "wb+") { }
+      File.open(path, "ab+") { }
+    end
+  end
+
   it "opens with perm (int)" do
     with_tempfile("write_with_perm-int.txt") do |path|
       perm = 0o600

--- a/src/crystal/system/file.cr
+++ b/src/crystal/system/file.cr
@@ -34,6 +34,12 @@ module Crystal::System::File
       else
         raise "Invalid file open mode: '#{mode}'"
       end
+    when 3
+      # POSIX allows both `+b` and `b+`: https://pubs.opengroup.org/onlinepubs/9699919799/functions/fopen.html
+      unless mode.ends_with?("+b") || mode.ends_with?("b+")
+        raise "Invalid file open mode: '#{mode}'"
+      end
+      m = LibC::O_RDWR
     else
       raise "Invalid file open mode: '#{mode}'"
     end

--- a/src/file.cr
+++ b/src/file.cr
@@ -88,21 +88,24 @@ class File < IO::FileDescriptor
   # *mode* must be one of the following file open modes:
   #
   # ```text
-  # Mode | Description
-  # -----+------------------------------------------------------
-  # r    | Read-only, starts at the beginning of the file.
-  # r+   | Read-write, starts at the beginning of the file.
-  # w    | Write-only, truncates existing file to zero length or
-  #      | creates a new file if the file doesn't exist.
-  # w+   | Read-write, truncates existing file to zero length or
-  #      | creates a new file if the file doesn't exist.
-  # a    | Write-only, starts at the end of the file,
-  #      | creates a new file if the file doesn't exist.
-  # a+   | Read-write, starts at the end of the file,
-  #      | creates a new file if the file doesn't exist.
-  # rb   | Same as 'r' but in binary file mode.
-  # wb   | Same as 'w' but in binary file mode.
-  # ab   | Same as 'a' but in binary file mode.
+  # Mode    | Description
+  # --------+------------------------------------------------------
+  # r       | Read-only, starts at the beginning of the file.
+  # r+      | Read-write, starts at the beginning of the file.
+  # w       | Write-only, truncates existing file to zero length or
+  #         | creates a new file if the file doesn't exist.
+  # w+      | Read-write, truncates existing file to zero length or
+  #         | creates a new file if the file doesn't exist.
+  # a       | Write-only, all writes seek to the end of the file,
+  #         | creates a new file if the file doesn't exist.
+  # a+      | Read-write, all writes seek to the end of the file,
+  #         | creates a new file if the file doesn't exist.
+  # rb      | Same as 'r' but in binary file mode.
+  # r+b rb+ | Same as 'r+' but in binary file mode.
+  # wb      | Same as 'w' but in binary file mode.
+  # w+b wb+ | Same as 'w+' but in binary file mode.
+  # ab      | Same as 'a' but in binary file mode.
+  # a+b ab+ | Same as 'a+' but in binary file mode.
   # ```
   #
   # In binary file mode, line endings are not converted to CRLF on Windows.


### PR DESCRIPTION
Allows `+` and `b` to be used together. Currently the two flags cannot both appear in the mode string, but this is allowed by POSIX:

```crystal
File.open("foo", "r+b") # Invalid file open mode: 'r+b' (Exception)
```

The behaviour of the lack of `b` on Windows is not tested here, see https://github.com/crystal-lang/crystal/issues/11586#issuecomment-993537371.