### PR TITLE
Fix: Hide `BigDecimal::ZERO` and `BigDecimal::TEN`

### DIFF
--- a/src/big/big_decimal.cr
+++ b/src/big/big_decimal.cr
@@ -15,8 +15,9 @@ end
 # The general idea and some of the arithmetic algorithms were adapted from
 # the MIT/APACHE-licensed [bigdecimal-rs](https://github.com/akubera/bigdecimal-rs).
 struct BigDecimal < Number
-  ZERO                       = BigInt.new(0)
-  TEN                        = BigInt.new(10)
+  private ZERO = BigInt.new(0)
+  private TEN  = BigInt.new(10)
+
   DEFAULT_MAX_DIV_ITERATIONS = 100_u64
 
   include Comparable(Int)
@@ -419,7 +420,7 @@ struct BigDecimal < Number
   end
 
   def to_big_r : BigRational
-    BigRational.new(self.value, BigDecimal::TEN ** self.scale)
+    BigRational.new(self.value, TEN ** self.scale)
   end
 
   # Converts to `Int64`. Truncates anything on the right side of the decimal point.


### PR DESCRIPTION
This is a breaking change but could be regarded as a bug fix.

I was writing some code with BigDecimal and at some point, I was initializing a counter to zero. I saw on the documentation that `BigDecimal::ZERO` is a thing and I immediately assumed it was a `BigDecimal.new(0)`, it isn't and my code of course failed to compile.

Both `ZERO` and `TEN` are for internal use and make no sense in the public API. The fact that they are mutable makes things even worse. Any code that is using them is most likely wrong and broken, I propose marking them as private.

Alternatively, we could `@[Deprecate]` them or just write some docs disincentivizing their use.