### PR TITLE
Do not expose `Crystal::System::FileInfo` in `File.info?`

### DIFF
--- a/src/crystal/system/file_info.cr
+++ b/src/crystal/system/file_info.cr
@@ -1,3 +1,29 @@
+struct Crystal::System::FileInfo
+  # Size of the file, in bytes.
+  # def size : Int64
+
+  # The permissions of the file.
+  # def permissions : Permissions
+
+  # The type of the file.
+  # def type : Type
+
+  # The special flags this file has set.
+  # def flags : Flags
+
+  # The last time this file was modified.
+  # def modification_time : Time
+
+  # The user ID that the file belongs to.
+  # def owner_id : String
+
+  # The group ID that the file belongs to.
+  # def group_id : String
+
+  # Returns true if this `FileInfo` and *other* are of the same file.
+  # def same_file?(other : self) : Bool
+end
+
 {% if flag?(:unix) %}
   require "./unix/file_info"
 {% elsif flag?(:win32) %}

--- a/src/crystal/system/unix/file.cr
+++ b/src/crystal/system/unix/file.cr
@@ -36,7 +36,7 @@ module Crystal::System::File
     end
 
     if ret == 0
-      FileInfo.new(stat)
+      ::File::Info.new(FileInfo.new(stat))
     else
       if Errno.value.in?(Errno::ENOENT, Errno::ENOTDIR)
         return nil

--- a/src/crystal/system/unix/file_info.cr
+++ b/src/crystal/system/unix/file_info.cr
@@ -1,4 +1,4 @@
-struct Crystal::System::FileInfo < ::File::Info
+struct Crystal::System::FileInfo
   def initialize(@stat : LibC::Stat)
   end
 
@@ -55,7 +55,7 @@ struct Crystal::System::FileInfo < ::File::Info
     @stat.st_gid.to_s
   end
 
-  def same_file?(other : ::File::Info) : Bool
+  def same_file?(other : self) : Bool
     @stat.st_dev == other.@stat.st_dev && @stat.st_ino == other.@stat.st_ino
   end
 end

--- a/src/crystal/system/win32/file_info.cr
+++ b/src/crystal/system/win32/file_info.cr
@@ -1,4 +1,4 @@
-struct Crystal::System::FileInfo < ::File::Info
+struct Crystal::System::FileInfo
   protected getter file_attributes
 
   def initialize(@file_attributes : LibC::BY_HANDLE_FILE_INFORMATION, @file_type : LibC::DWORD)
@@ -82,7 +82,7 @@ struct Crystal::System::FileInfo < ::File::Info
     "0"
   end
 
-  def same_file?(other : ::File::Info) : Bool
+  def same_file?(other : self) : Bool
     return false if type.symlink? || type.pipe? || type.character_device?
 
     @file_attributes.dwVolumeSerialNumber == other.file_attributes.dwVolumeSerialNumber &&

--- a/src/file/info.cr
+++ b/src/file/info.cr
@@ -77,33 +77,53 @@ class File
 
   # A `File::Info` contains metadata regarding a file.
   # It is returned by `File.info`, `File#info` and `File.info?`.
-  abstract struct Info
+  struct Info
+    # :nodoc:
+    def initialize(@data : Crystal::System::FileInfo)
+    end
+
     # Size of the file, in bytes.
-    abstract def size : Int64
+    def size : Int64
+      @data.size
+    end
 
     # The permissions of the file.
-    abstract def permissions : Permissions
+    def permissions : Permissions
+      @data.permissions
+    end
 
     # The type of the file.
-    abstract def type : Type
+    def type : Type
+      @data.type
+    end
 
     # The special flags this file has set.
-    abstract def flags : Flags
+    def flags : Flags
+      @data.flags
+    end
 
     # The last time this file was modified.
-    abstract def modification_time : Time
+    def modification_time : Time
+      @data.modification_time
+    end
 
     # The user ID that the file belongs to.
-    abstract def owner_id : String
+    def owner_id : String
+      @data.owner_id
+    end
 
     # The group ID that the file belongs to.
-    abstract def group_id : String
+    def group_id : String
+      @data.group_id
+    end
 
     # Returns true if this `Info` and *other* are of the same file.
     #
     # On unix, this compares device and inode fields, and will compare equal for
     # hard linked files.
-    abstract def same_file?(other : File::Info) : Bool
+    def same_file?(other : File::Info) : Bool
+      @data.same_file?(other.@data)
+    end
 
     # Returns true if this `Info` represents a standard file. Shortcut for
     # `type.file?`.


### PR DESCRIPTION
Resolves #7685.