### PR TITLE
Fix `Path` support for UNC shares

### DIFF
--- a/spec/std/path_spec.cr
+++ b/spec/std/path_spec.cr
@@ -394,6 +394,10 @@ describe Path do
     assert_paths("\\\\some$\\share\\", nil, "\\\\some$\\share", &.drive)
     assert_paths("\\\\%10%20\\share\\", nil, "\\\\%10%20\\share", &.drive)
     assert_paths("\\\\_.-~!$;=&'()*+,aB1\\ !-.@^_`{}~#$%&'()aB1\\", nil, "\\\\_.-~!$;=&'()*+,aB1\\ !-.@^_`{}~#$%&'()aB1", &.drive)
+    assert_paths("\\\\127.0.0.1\\share\\", nil, "\\\\127.0.0.1\\share", &.drive)
+    pending do
+      assert_paths("\\\\2001:4860:4860::8888\\share\\", nil, "\\\\2001:4860:4860::8888\\share", &.drive)
+    end
   end
 
   describe "#root" do

--- a/spec/std/path_spec.cr
+++ b/spec/std/path_spec.cr
@@ -390,6 +390,10 @@ describe Path do
     assert_paths("\\\\some\\share\\foo", nil, "\\\\some\\share", &.drive)
     assert_paths("\\\\\\not-a\\share", nil, nil, &.drive)
     assert_paths("\\\\not-a\\\\share", nil, nil, &.drive)
+
+    assert_paths("\\\\some$\\share\\", nil, "\\\\some$\\share", &.drive)
+    assert_paths("\\\\%10%20\\share\\", nil, "\\\\%10%20\\share", &.drive)
+    assert_paths("\\\\_.-~!$;=&'()*+,aB1\\ !-.@^_`{}~#$%&'()aB1\\", nil, "\\\\_.-~!$;=&'()*+,aB1\\ !-.@^_`{}~#$%&'()aB1", &.drive)
   end
 
   describe "#root" do
@@ -676,6 +680,11 @@ describe Path do
       it_expands_path("C:\\foo", "D:/C:\\foo", "C:\\foo", base: Path.windows("D:\\"))
       it_expands_path("C:/foo", "D:/C:/foo", "C:\\foo", base: "D:/")
       it_expands_path("C:\\foo", "D:/C:\\foo", "C:\\foo", base: "D:/")
+    end
+
+    describe "UNC path" do
+      it_expands_path("baz", "/foo/bar/baz", "\\\\foo\\bar\\baz", base: Path.windows("\\\\foo\\bar\\"))
+      it_expands_path("baz", "/foo$/bar/baz", "\\\\foo$\\bar\\baz", base: Path.windows("\\\\foo$\\bar\\"))
     end
 
     it "doesn't expand ~" do

--- a/src/path.cr
+++ b/src/path.cr
@@ -1220,6 +1220,8 @@ struct Path
     # path: //share/share
     # part: 1122222 33333
 
+    # Grammar definition: https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-dtyp/62e862f4-2a51-452e-8eeb-dc4ff5ee33cc?redirectedfrom=MSDN
+
     return unless @name.size >= 5
 
     reader = Char::Reader.new(@name)
@@ -1230,11 +1232,25 @@ struct Path
     reader.next_char
 
     # 2. Consume first path component
+    # The first component is either an IP address or a hostname.
+    # Hostname follows the grammar of `reg-name` in [RFC 3986](https://datatracker.ietf.org/doc/html/rfc3986).
+    # TODO: Add support for IPv6 address grammar
     return if separators.includes?(reader.current_char)
     while true
       char = reader.current_char
       break if separators.includes?(char)
-      return unless char.ascii_letter?
+      if char == '%'
+        # percent encoded character
+        return unless reader.has_next?
+        reader.next_char
+        return unless reader.current_char.ascii_number?
+        return unless reader.has_next?
+        reader.next_char
+        return unless reader.current_char.ascii_number?
+      else
+        # unreserved / sub-delims
+        return unless char.ascii_alphanumeric? || char.in?('_', '.', '-', '~', '!', '$', ';', '=') || char.in?('&'..',')
+      end
       return unless reader.has_next?
       reader.next_char
     end
@@ -1246,11 +1262,12 @@ struct Path
     return unless reader.has_next?
     reader.next_char
 
-    # 3. Consume second path components
+    # 3. Consume second path component
+    # `share-name` in UNC grammar
     while true
       char = reader.current_char
       break if separators.includes?(char) || !reader.has_next?
-      return unless char.ascii_letter?
+      return unless char.ascii_alphanumeric? || char.in?(' ', '!', '-', '.', '@', '^', '_', '`', '{', '}', '~') || char.in?('#'..')') || char.ord.in?(0x80..0xFF)
       reader.next_char
     end
 


### PR DESCRIPTION
The host and share name of a UNC path can contain more characters than just ASCII letters. A grammar description is available here: https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-dtyp/62e862f4-2a51-452e-8eeb-dc4ff5ee33cc?redirectedfrom=MSDN
This patch loosens the allowed grammar which fixes use cases containing special characters (for example, the UNC share for the WSL file system is `\\wsl$\Ubuntu`).