### PR TITLE
Check file-private types for abstract defs and recursive structs

### DIFF
--- a/spec/compiler/semantic/abstract_def_spec.cr
+++ b/spec/compiler/semantic/abstract_def_spec.cr
@@ -244,6 +244,17 @@ describe "Semantic: abstract def" do
       CR
   end
 
+  it "errors if abstract method of private type is not implemented by subclass" do
+    assert_error <<-CR, "abstract `def Foo#foo()` must be implemented by Bar"
+      private abstract class Foo
+        abstract def foo
+      end
+
+      class Bar < Foo
+      end
+      CR
+  end
+
   it "errors if abstract method is not implemented by subclass of subclass" do
     assert_error %(
       abstract class Foo
@@ -300,6 +311,18 @@ describe "Semantic: abstract def" do
 
         def foo
         end
+      end
+      CR
+  end
+
+  it "errors if abstract method of private type is not implemented by including class" do
+    assert_error <<-CR, "abstract `def Foo#foo()` must be implemented by Bar"
+      private module Foo
+        abstract def foo
+      end
+
+      class Bar
+        include Foo
       end
       CR
   end

--- a/spec/compiler/semantic/recursive_struct_check_spec.cr
+++ b/spec/compiler/semantic/recursive_struct_check_spec.cr
@@ -184,4 +184,15 @@ describe "Semantic: recursive struct check" do
 
     ex.to_s.should contain "`(Bar(Foo) | Int32)` -> `Bar(Foo)` -> `@x : Foo`"
   end
+
+  it "errors on private recursive type" do
+    assert_error <<-CR, "recursive struct Test detected"
+      private struct Test
+        def initialize(@test : Test?)
+        end
+      end
+
+      Test.new(Test.new(nil))
+      CR
+  end
 end

--- a/src/compiler/crystal/semantic/abstract_def_checker.cr
+++ b/src/compiler/crystal/semantic/abstract_def_checker.cr
@@ -29,6 +29,9 @@ class Crystal::AbstractDefChecker
 
   def run
     check_types(@program)
+    @program.file_modules.each_value do |file_module|
+      check_types(file_module)
+    end
   end
 
   def check_types(type)

--- a/src/compiler/crystal/semantic/recursive_struct_checker.cr
+++ b/src/compiler/crystal/semantic/recursive_struct_checker.cr
@@ -22,6 +22,9 @@ class Crystal::RecursiveStructChecker
 
   def run
     check_types(@program)
+    @program.file_modules.each_value do |file_module|
+      check_types(file_module)
+    end
   end
 
   def check_types(type)


### PR DESCRIPTION
Unimplemented abstract defs of file-private types do not trigger a compilation error until they are called:

```crystal
private abstract class Foo
  abstract def foo
end

class Bar < Foo
  # should not compile
end
```

Recursive value types do not trigger compilation errors at all:

```crystal
private struct Foo
  def initialize(@x : Foo?)
  end
end

Foo.new(Foo.new(nil)) # Invalid memory access (signal 11) at address 0x0
```

This happens because both `Crystal::AbstractDefChecker` and `Crystal::RecursiveStructChecker` only look at types reachable from the top-level namespace (i.e. the `Crystal::Program` instance); this PR adds checks for the namespaces associated with each file-private scope.