### PR TITLE
Defer overload ordering until all types are fully defined

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,7 @@ interpreter ?=  ## Enable interpreter feature
 O := .build
 SOURCES := $(shell find src -name '*.cr')
 SPEC_SOURCES := $(shell find spec -name '*.cr')
-override FLAGS += -D strict_multi_assign $(if $(release),--release )$(if $(stats),--stats )$(if $(progress),--progress )$(if $(threads),--threads $(threads) )$(if $(debug),-d )$(if $(static),--static )$(if $(LDFLAGS),--link-flags="$(LDFLAGS)" )$(if $(target),--cross-compile --target $(target) )$(if $(interpreter),,-Dwithout_interpreter )
+override FLAGS += -D strict_multi_assign -D preview_overload_order $(if $(release),--release )$(if $(stats),--stats )$(if $(progress),--progress )$(if $(threads),--threads $(threads) )$(if $(debug),-d )$(if $(static),--static )$(if $(LDFLAGS),--link-flags="$(LDFLAGS)" )$(if $(target),--cross-compile --target $(target) )$(if $(interpreter),,-Dwithout_interpreter )
 SPEC_WARNINGS_OFF := --exclude-warnings spec/std --exclude-warnings spec/compiler --exclude-warnings spec/primitives
 SPEC_FLAGS := $(if $(verbose),-v )$(if $(junit_output),--junit_output $(junit_output) )
 CRYSTAL_CONFIG_LIBRARY_PATH := '$$ORIGIN/../lib/crystal'

--- a/spec/compiler/semantic/def_overload_spec.cr
+++ b/spec/compiler/semantic/def_overload_spec.cr
@@ -1096,6 +1096,166 @@ describe "Semantic: def overload" do
       ),
       "no overload matches"
   end
+
+  describe "without `-Dpreview_overload_order`" do
+    it "orders overloads as soon as they are defined" do
+      assert_type(<<-CR) { bool }
+        class Foo
+        end
+
+        def foo(a : Bar)
+          1
+        end
+
+        def foo(a : Foo)
+          true
+        end
+
+        class Bar < Foo
+        end
+
+        foo(Bar.new)
+        CR
+    end
+
+    it "overload ordering is observable from top-level macros (1)" do
+      assert_type(<<-CR) { int32 }
+        class Foo
+        end
+
+        class Bar < Foo
+          def foo(a : Foo)
+            true
+          end
+
+          def foo(a : Bar)
+            1
+          end
+        end
+
+        {{ Bar.methods[0].body }}
+        CR
+    end
+
+    it "overload ordering is observable from top-level macros (2)" do
+      assert_type(<<-CR) { int32 }
+        module Foo
+          def foo
+            true
+          end
+
+          def foo
+            1
+          end
+        end
+
+        {{ Foo.methods[0].body }}
+        CR
+    end
+
+    it "overload ordering is observable from macro defs" do
+      assert_type(<<-CR) { int32 }
+        class Foo
+        end
+
+        class Bar < Foo
+          def foo(a : Foo)
+            true
+          end
+
+          def foo(a : Bar)
+            1
+          end
+        end
+
+        def foo
+          {{ Bar.methods[0].body }}
+        end
+
+        foo
+        CR
+    end
+  end
+
+  describe "with `-Dpreview_overload_order`" do
+    it "orders overloads after all types are defined" do
+      assert_type(<<-CR, flags: "preview_overload_order") { int32 }
+        class Foo
+        end
+
+        def foo(a : Bar)
+          1
+        end
+
+        def foo(a : Foo)
+          true
+        end
+
+        class Bar < Foo
+        end
+
+        foo(Bar.new)
+        CR
+    end
+
+    it "overload ordering is not observable from top-level macros (1)" do
+      assert_type(<<-CR, flags: "preview_overload_order") { bool }
+        class Foo
+        end
+
+        class Bar < Foo
+          def foo(a : Foo)
+            true
+          end
+
+          def foo(a : Bar)
+            1
+          end
+        end
+
+        {{ Bar.methods[0].body }}
+        CR
+    end
+
+    it "overload ordering is not observable from top-level macros (2)" do
+      assert_type(<<-CR, flags: "preview_overload_order") { bool }
+        module Foo
+          def foo
+            true
+          end
+
+          def foo
+            1
+          end
+        end
+
+        {{ Foo.methods[0].body }}
+        CR
+    end
+
+    it "overload ordering is observable from macro defs" do
+      assert_type(<<-CR, flags: "preview_overload_order") { int32 }
+        class Foo
+        end
+
+        class Bar < Foo
+          def foo(a : Foo)
+            true
+          end
+
+          def foo(a : Bar)
+            1
+          end
+        end
+
+        def foo
+          {{ Bar.methods[0].body }}
+        end
+
+        foo
+        CR
+    end
+  end
 end
 
 private def each_union_variant(t1, t2)

--- a/spec/compiler/semantic/method_missing_spec.cr
+++ b/spec/compiler/semantic/method_missing_spec.cr
@@ -92,4 +92,42 @@ describe "Semantic: method_missing" do
       end
       )) { int32 }
   end
+
+  it "reorders expanded def immediately" do
+    assert_type(<<-CR) { int32 }
+      class Foo
+        macro method_missing(call)
+          def foo(y : Int32)
+            1
+          end
+        end
+
+        def foo(x : Int32 | String)
+          true
+        end
+      end
+
+      Foo.new.foo(y: 1)
+      Foo.new.foo(1)
+      CR
+  end
+
+  it "reorders expanded def immediately, even if overload ordering is deferred" do
+    assert_type(<<-CR, flags: "preview_overload_order") { int32 }
+      class Foo
+        macro method_missing(call)
+          def foo(y : Int32)
+            1
+          end
+        end
+
+        def foo(x : Int32 | String)
+          true
+        end
+      end
+
+      Foo.new.foo(y: 1)
+      Foo.new.foo(1)
+      CR
+  end
 end

--- a/spec/compiler/semantic/previous_def_spec.cr
+++ b/spec/compiler/semantic/previous_def_spec.cr
@@ -25,6 +25,20 @@ describe "Semantic: previous_def" do
       )) { int32 }
   end
 
+  it "types previous def even if overload ordering is deferred" do
+    assert_type(<<-CR, flags: "preview_overload_order") { int32 }
+      def foo
+        1
+      end
+
+      def foo
+        previous_def
+      end
+
+      foo
+      CR
+  end
+
   it "types previous def in generic class" do
     assert_type(%(
       class Foo(T)

--- a/src/big.cr
+++ b/src/big.cr
@@ -1,15 +1,17 @@
-# :nodoc: Forward declarations
-struct BigInt < Int
-end
+{% unless flag?(:preview_overload_order) %}
+  # :nodoc: Forward declarations
+  struct BigInt < Int
+  end
 
-struct BigFloat < Float
-end
+  struct BigFloat < Float
+  end
 
-struct BigRational < Number
-end
+  struct BigRational < Number
+  end
 
-struct BigDecimal < Number
-end
+  struct BigDecimal < Number
+  end
+{% end %}
 
 require "./big/lib_gmp"
 require "./big/big_int"

--- a/src/compiler/crystal/semantic/new.cr
+++ b/src/compiler/crystal/semantic/new.cr
@@ -43,6 +43,7 @@ module Crystal
 
       if check
         type = type.as(ModuleType)
+        defer_overload_order = @program.has_flag?("preview_overload_order")
 
         self_initialize_methods = type.lookup_defs_without_parents("initialize")
         self_new_methods = type.metaclass.lookup_defs_without_parents("new")
@@ -55,11 +56,11 @@ module Crystal
         if !has_new_or_initialize
           # Add self.new
           new_method = Def.argless_new(type)
-          type.metaclass.as(ModuleType).add_def(new_method)
+          type.metaclass.as(ModuleType).add_def(new_method, ordered: !defer_overload_order)
 
           # Also add `initialize`, so `super` in a subclass
           # inside an `initialize` will find this one
-          type.add_def Def.argless_initialize(type)
+          type.add_def Def.argless_initialize(type), ordered: !defer_overload_order
         end
 
         # Check to see if a type doesn't define `initialize`
@@ -85,8 +86,8 @@ module Crystal
             if initialize_methods.empty?
               # If the type has `self.new()`, don't override it
               unless has_default_self_new
-                type.metaclass.as(ModuleType).add_def(Def.argless_new(type))
-                type.add_def(Def.argless_initialize(type))
+                type.metaclass.as(ModuleType).add_def(Def.argless_new(type), ordered: !defer_overload_order)
+                type.add_def(Def.argless_initialize(type), ordered: !defer_overload_order)
               end
             else
               initialize_owner = nil
@@ -105,14 +106,14 @@ module Crystal
                 initialize_owner = initialize.owner
 
                 new_method = initialize.expand_new_from_initialize(type)
-                type.metaclass.as(ModuleType).add_def(new_method)
+                type.metaclass.as(ModuleType).add_def(new_method, ordered: !defer_overload_order)
               end
 
               # Copy non-generated `new` methods from parent to child
               new_methods.each do |new_method|
                 next if new_method.new?
 
-                type.metaclass.as(ModuleType).add_def(new_method.clone)
+                type.metaclass.as(ModuleType).add_def(new_method.clone, ordered: !defer_overload_order)
               end
             end
           else

--- a/src/compiler/crystal/semantic/overload_order_processor.cr
+++ b/src/compiler/crystal/semantic/overload_order_processor.cr
@@ -1,0 +1,82 @@
+# Reorders overloads so that more specific overloads come before less specific
+# ones, according to `Crystal::DefWithMetadata#restriction_of?`. Also assigns
+# the correct `previous_def`s for redefinitions.
+#
+# This processor is used only if `-Dpreview_overload_order` is specified;
+# otherwise, every new def is ordered as soon as it is defined, which could
+# cause problems because type definitions may not be complete yet:
+#
+# ```
+# class Foo
+# end
+#
+# module Bar
+# end
+#
+# def foo(a : Bar)
+#   1
+# end
+#
+# # requests the definitions of `Foo` and `Bar` to determine the overload order;
+# # at this point `Foo < Bar` does not hold, so the `Bar` overload is still
+# # considered first
+# def foo(a : Foo)
+#   2
+# end
+#
+# class Foo
+#   include Bar
+# end
+#
+# foo(Foo.new) # => 1
+# ```
+#
+# A consequence of deferring overload ordering is that top-level macros can no
+# longer observe intermediate overload orders via `TypeNode#methods`.
+#
+# Defs added after this processor runs must still be ordered on definition (e.g.
+# those from `method_missing`).
+class Crystal::OverloadOrderingProcessor
+  def initialize(@program : Program)
+    @all_checked = Set(Type).new
+  end
+
+  def run
+    check_type(@program)
+    @program.file_modules.each_value do |file_module|
+      check_type(file_module)
+    end
+  end
+
+  def check_type(type)
+    return if @all_checked.includes?(type)
+    @all_checked << type
+
+    check_single(type)
+
+    type.types?.try &.each_value do |type|
+      check_type(type)
+    end
+  end
+
+  def check_single(type)
+    if type.is_a?(ModuleType)
+      reorder_overloads(type)
+      reorder_overloads(type.metaclass.as(ModuleType))
+    end
+  end
+
+  def reorder_overloads(type)
+    type.defs.try &.each do |method, overloads|
+      next unless overloads.size > 1
+
+      # simply re-add all overloads one by one (if the overload order is
+      # transitive we could sort the overloads in-place, see #10711)
+      unordered = overloads.dup
+      overloads.clear
+      unordered.each do |item|
+        type.add_def(item.def, ordered: true)
+      end
+    end
+  end
+end

--- a/src/compiler/crystal/semantic/top_level_visitor.cr
+++ b/src/compiler/crystal/semantic/top_level_visitor.cr
@@ -407,7 +407,8 @@ class Crystal::TopLevelVisitor < Crystal::SemanticVisitor
       node.raise "enums can't define an `initialize` method, try using `def self.new`"
     end
 
-    target_type.add_def node
+    defer_overload_order = @program.has_flag?("preview_overload_order")
+    target_type.add_def node, ordered: !defer_overload_order
 
     node.set_type @program.nil
 
@@ -419,7 +420,7 @@ class Crystal::TopLevelVisitor < Crystal::SemanticVisitor
       # to find this method.
       if node.name == "initialize"
         new_method = node.expand_new_signature_from_initialize(target_type)
-        target_type.metaclass.as(ModuleType).add_def(new_method)
+        target_type.metaclass.as(ModuleType).add_def(new_method, ordered: !defer_overload_order)
 
         # And we register it to later complete it
         new_expansions << {original: node, expanded: new_method}

--- a/src/compiler/crystal/semantic/type_declaration_processor.cr
+++ b/src/compiler/crystal/semantic/type_declaration_processor.cr
@@ -132,6 +132,12 @@ struct Crystal::TypeDeclarationProcessor
     # First check type declarations
     @program.visit_with_finished_hooks(node, type_decl_visitor)
 
+    # If overload ordering has been deferred, do it now since all types are
+    # fully defined
+    if @program.has_flag?("preview_overload_order")
+      OverloadOrderingProcessor.new(@program).run
+    end
+
     # Use the last type found for class variables to declare them
     type_decl_visitor.class_vars.each do |owner, vars|
       vars.each do |name, type|

--- a/src/compiler/crystal/semantic/type_declaration_visitor.cr
+++ b/src/compiler/crystal/semantic/type_declaration_visitor.cr
@@ -131,6 +131,9 @@ class Crystal::TypeDeclarationVisitor < Crystal::SemanticVisitor
     old_external = add_external external
     old_external.dead = true if old_external
 
+    # C funs cannot overload, so overload order shouldn't matter here
+    # TODO: top-level funs can still overload with top-level defs (#4761),
+    # they should be disallowed
     current_type.add_def(external)
 
     if current_type.is_a?(Program)
@@ -193,6 +196,8 @@ class Crystal::TypeDeclarationVisitor < Crystal::SemanticVisitor
 
   def declare_c_struct_or_union_field(type, field_name, var, location)
     type.instance_vars[var.name] = var
+    # even on `-Dpreview_overload_order` these methods should never be defined
+    # on the type before, because field names cannot repeat
     type.add_def Def.new("#{field_name}=", [Arg.new("value")], Primitive.new("struct_or_union_set").at(location))
     type.add_def Def.new(field_name, body: InstanceVar.new(var.name))
   end


### PR DESCRIPTION
Closes #11692. The new semantics are only available if `-Dpreview_overload_order` is defined. This conflicts with the flag used for #10711, so suggestions are welcome. I was thinking about an _opt-out_ `-Dno_defer_overload_order` flag, but I am not too confortable about that. This phase is done as part of the "type declarations" semantic stage; building an empty file and the standard library specs took about +0.08s and +0.2s respectively.

Fixes #4897. Suppose the forward declarations in `src/big.cr` are removed. Before:

```crystal
require "big"

BigFloat.new(1, 2, 3) # Error: wrong number of arguments for 'BigFloat.new' (given 3, expected 0..2)

# Overloads are:
#  - BigFloat.new(num : Float, precision : Int)
#  - BigFloat.new(str : String)
#  - BigFloat.new(num : BigInt)
#  - BigFloat.new(num : BigFloat)
#  - BigFloat.new(num : Int8 | Int16 | Int32)
#  - BigFloat.new(num : UInt8 | UInt16 | UInt32)
#  - BigFloat.new(num : Int64)
#  - BigFloat.new(num : UInt64)
#  - BigFloat.new(num : Number)
#  - BigFloat.new(mpf : LibGMP::MPF)
#  - BigFloat.new(num : BigRational)
#  - BigFloat.new()
#  - BigFloat.new(&)
```

After: (the `BigRational` overload is at the correct location)

```crystal
# Overloads are:
#  - BigFloat.new(num : Float, precision : Int)
#  - BigFloat.new(str : String)
#  - BigFloat.new(num : BigInt)
#  - BigFloat.new(num : BigRational)
#  - BigFloat.new(num : BigFloat)
#  - BigFloat.new(num : Int8 | Int16 | Int32)
#  - BigFloat.new(num : UInt8 | UInt16 | UInt32)
#  - BigFloat.new(num : Int64)
#  - BigFloat.new(num : UInt64)
#  - BigFloat.new(num : Number)
#  - BigFloat.new(mpf : LibGMP::MPF)
#  - BigFloat.new()
#  - BigFloat.new(&)
```

Fixes #7579:

```crystal
class Base; end

def foo(a : Derive); 1; end
def foo(a : Base); true; end

class Derive < Base; end

# `true` before this patch
foo(Derive.new) # => 1
```

Fixes #10518:

```crystal
puts (0..0).as(Enumerable(Int32)) # => 0..0
```

Fixes #11678:

```crystal
class Foo1; end
class Foo2 < Foo1; end
class Foo3 < Foo1; end

class Foo1
  alias Bar = Foo2::Bar | Foo3::Bar
end

class Foo2 < Foo1
  class Bar; end
  def foo(other : Foo1::Bar); end
  def foo(other : String); end
end

class Foo3 < Foo1
  class Bar; end
end

# infinite recursive definition before this patch
Foo1::Bar # => (Foo2::Bar | Foo3::Bar)
```

For [this example](https://github.com/crystal-lang/crystal/issues/4897#issuecomment-820187268), `A` and `B` will be printed regardless of the declaration order of `Foo#foo`'s overloads.

Again, all these examples work only if `-Dpreview_overload_order` is specified during compilation.