### PR TITLE
Fix character mappings for Windows path conversions

### DIFF
--- a/spec/std/path_spec.cr
+++ b/spec/std/path_spec.cr
@@ -648,18 +648,18 @@ describe Path do
       it_expands_path("foo", "D:/foo", "D:foo", base: "D:")
       it_expands_path("/foo", "/foo", "D:\\foo", base: "D:")
       it_expands_path("\\foo", "D:/\\foo", "D:\\foo", base: "D:")
-      it_expands_path("foo", "D:\\/foo", "D:\\foo", base: Path.posix("D:\\"))
+      it_expands_path("foo", "D:\\/foo", "D\uF03A\uF05C\\foo", base: Path.posix("D:\\"))
       it_expands_path("foo", "D:/foo", "D:\\foo", base: Path.windows("D:\\"))
       it_expands_path("foo", "D:/foo", "D:\\foo", base: "D:/")
       it_expands_path("/foo", "/foo", "D:\\foo", base: "D:\\")
-      it_expands_path("\\foo", "D:\\/\\foo", "D:\\foo", base: Path.posix("D:\\"))
+      it_expands_path("\\foo", "D:\\/\\foo", "\\foo", base: Path.posix("D:\\"))
       it_expands_path("\\foo", "D:/\\foo", "D:\\foo", base: Path.windows("D:\\"))
       it_expands_path("/foo", "/foo", "D:\\foo", base: "D:/")
       it_expands_path("\\foo", "D:/\\foo", "D:\\foo", base: "D:/")
 
       it_expands_path("C:", "D:/C:", "C:", base: "D:")
       it_expands_path("C:", "D:/C:", "C:\\", base: "D:/")
-      it_expands_path("C:", "D:\\/C:", "C:\\", base: Path.posix("D:\\"))
+      it_expands_path("C:", "D:\\/C:", "C:D\uF03A\uF05C\\", base: Path.posix("D:\\"))
       it_expands_path("C:", "D:/C:", "C:\\", base: Path.windows("D:\\"))
       it_expands_path("C:/", "D:/C:/", "C:\\", base: "D:")
       it_expands_path("C:/", "D:/C:/", "C:\\", base: "D:/")
@@ -673,7 +673,7 @@ describe Path do
       it_expands_path("C:foo", "D:/C:foo", "C:foo", base: "D:")
       it_expands_path("C:/foo", "D:/C:/foo", "C:\\foo", base: "D:")
       it_expands_path("C:\\foo", "D:/C:\\foo", "C:\\foo", base: "D:")
-      it_expands_path("C:foo", "D:\\/C:foo", "C:\\foo", base: Path.posix("D:\\"))
+      it_expands_path("C:foo", "D:\\/C:foo", "C:D\uF03A\uF05C\\foo", base: Path.posix("D:\\"))
       it_expands_path("C:foo", "D:/C:foo", "C:\\foo", base: Path.windows("D:\\"))
       it_expands_path("C:foo", "D:/C:foo", "C:\\foo", base: "D:/")
       it_expands_path("C:/foo", "D:\\/C:/foo", "C:\\foo", base: Path.posix("D:\\"))
@@ -774,7 +774,7 @@ describe Path do
   end
 
   describe "#to_windows" do
-    assert_paths_raw("C:\\foo\\bar", Path.windows("C:\\foo\\bar"), label: "default: mappings=false", &.to_windows)
+    assert_paths_raw("C:\\foo\\bar", Path.windows("C\uF03A\uF05Cfoo\uF05Cbar"), Path.windows("C:\\foo\\bar"), label: "default: mappings=true", &.to_windows)
 
     assert_paths_raw("foo/bar", Path.windows("foo/bar"), &.to_windows(mappings: true))
     assert_paths_raw("C:\\foo\\bar", Path.windows("C\uF03A\uF05Cfoo\uF05Cbar"), Path.windows("C:\\foo\\bar"), &.to_windows(mappings: true))
@@ -786,7 +786,7 @@ describe Path do
   end
 
   describe "#to_posix" do
-    assert_paths_raw("C\uF03A\uF05Cfoo\uF05Cbar", Path.posix("C\uF03A\uF05Cfoo\uF05Cbar"), label: "default: mappings=false", &.to_posix)
+    assert_paths_raw("C\uF03A\uF05Cfoo\uF05Cbar", Path.posix("C\uF03A\uF05Cfoo\uF05Cbar"), Path.posix("C:\\foo\\bar"), label: "default: mappings=true", &.to_posix)
 
     assert_paths_raw("foo/bar", Path.posix("foo/bar"), &.to_posix(mappings: true))
     assert_paths_raw("C:\\foo\\bar", Path.posix("C:\\foo\\bar"), Path.posix("C:/foo/bar"), &.to_posix(mappings: true))

--- a/spec/std/path_spec.cr
+++ b/spec/std/path_spec.cr
@@ -768,13 +768,29 @@ describe Path do
   end
 
   describe "#to_windows" do
-    assert_paths_raw("foo/bar", Path.windows("foo/bar"), &.to_windows)
-    assert_paths_raw("C:\\foo\\bar", Path.windows("C:\\foo\\bar"), &.to_windows)
+    assert_paths_raw("C:\\foo\\bar", Path.windows("C:\\foo\\bar"), label: "default: mappings=false", &.to_windows)
+
+    assert_paths_raw("foo/bar", Path.windows("foo/bar"), &.to_windows(mappings: true))
+    assert_paths_raw("C:\\foo\\bar", Path.windows("C\uF03A\uF05Cfoo\uF05Cbar"), Path.windows("C:\\foo\\bar"), &.to_windows(mappings: true))
+    assert_paths_raw(%("*/:<>?\\| ), Path.windows("\uF022\uF02A/\uF03A\uF03C\uF03E\uF03F\uF05C\uF07C\uF020"), Path.windows(%("*/:<>?\\| )), &.to_windows(mappings: true))
+
+    assert_paths_raw("foo/bar", Path.windows("foo/bar"), &.to_windows(mappings: false))
+    assert_paths_raw("C:\\foo\\bar", Path.windows("C:\\foo\\bar"), &.to_windows(mappings: false))
+    assert_paths_raw(%("*/:<>?\\| ), Path.windows(%("*/:<>?\\| )), &.to_windows(mappings: false))
   end
 
   describe "#to_posix" do
-    assert_paths_raw("foo/bar", Path.posix("foo/bar"), &.to_posix)
-    assert_paths_raw("C:\\foo\\bar", Path.posix("C:\\foo\\bar"), Path.posix("C:/foo/bar"), &.to_posix)
+    assert_paths_raw("C\uF03A\uF05Cfoo\uF05Cbar", Path.posix("C\uF03A\uF05Cfoo\uF05Cbar"), label: "default: mappings=false", &.to_posix)
+
+    assert_paths_raw("foo/bar", Path.posix("foo/bar"), &.to_posix(mappings: true))
+    assert_paths_raw("C:\\foo\\bar", Path.posix("C:\\foo\\bar"), Path.posix("C:/foo/bar"), &.to_posix(mappings: true))
+    assert_paths_raw("C\uF03A\uF05Cfoo\uF05Cbar", Path.posix("C\uF03A\uF05Cfoo\uF05Cbar"), Path.posix("C:\\foo\\bar"), &.to_posix(mappings: true))
+    assert_paths_raw("\uF022\uF02A/\uF03A\uF03C\uF03E\uF03F\uF05C\uF07C\uF020", Path.posix("\uF022\uF02A/\uF03A\uF03C\uF03E\uF03F\uF05C\uF07C\uF020"), Path.posix(%("*/:<>?\\| )), &.to_posix(mappings: true))
+
+    assert_paths_raw("foo/bar", Path.posix("foo/bar"), &.to_posix(mappings: false))
+    assert_paths_raw("C:\\foo\\bar", Path.posix("C:\\foo\\bar"), Path.posix("C:/foo/bar"), &.to_posix(mappings: false))
+    assert_paths_raw("C\uF03A\uF05Cfoo\uF05Cbar", Path.posix("C\uF03A\uF05Cfoo\uF05Cbar"), &.to_posix(mappings: false))
+    assert_paths_raw("\uF022\uF02A/\uF03A\uF03C\uF03E\uF03F\uF05C\uF07C\uF020", Path.posix("\uF022\uF02A/\uF03A\uF03C\uF03E\uF03F\uF05C\uF07C\uF020"), &.to_posix(mappings: false))
   end
 
   describe "#relative_to?" do

--- a/spec/std/path_spec.cr
+++ b/spec/std/path_spec.cr
@@ -14,9 +14,15 @@ end
 
 private def it_expands_path(path, posix, windows = posix, *, base = nil, env_home = nil, expand_base = false, home = false, file = __FILE__, line = __LINE__)
   assert_paths(path, posix, windows, %((base: "#{base}")), file, line) do |path|
-    with_env({HOME_ENV_KEY => env_home || (path.windows? ? HOME_WINDOWS : HOME_POSIX)}) do
+    with_env({HOME_ENV_KEY => env_home}) do
       base_arg = base || (path.windows? ? BASE_WINDOWS : BASE_POSIX)
-      path.expand(base_arg.not_nil!, expand_base: !!expand_base, home: home)
+      base_arg = path.windows? ? Path.windows(base_arg) : Path.posix(base_arg) unless base_arg.is_a?(Path)
+      if home == true && env_home.nil?
+        myhome = path.windows? ? Path.windows(HOME_WINDOWS) : Path.posix(HOME_POSIX)
+      else
+        myhome = home
+      end
+      path.expand(base_arg, expand_base: !!expand_base, home: myhome)
     end
   end
 end

--- a/src/path.cr
+++ b/src/path.cr
@@ -648,7 +648,7 @@ struct Path
   # Path.windows("foo/bar").to_windows # => Path.windows("foo/bar")
   # ```
   #
-  # When *mappings* is `true`, forbidden characters in Windows paths are
+  # When *mappings* is `true` (default), forbidden characters in Windows paths are
   # substituted by replacement characters when converting from a POSIX path.
   # Replacements are calculated by adding `0xF000` to their codepoint.
   # For example, the backslash character `U+005C` becomes `U+F05C`.
@@ -660,7 +660,7 @@ struct Path
   #
   # * `#to_posix` performs the inverse conversion.
   # * `#to_kind` performs a configurable conversion.
-  def to_windows(*, mappings : Bool = false) : Path
+  def to_windows(*, mappings : Bool = true) : Path
     name = @name
     if posix? && mappings
       name = name.tr(WINDOWS_ESCAPE_CHARACTERS, WINDOWS_ESCAPED_CHARACTERS)
@@ -684,7 +684,7 @@ struct Path
   # Path.posix("foo/bar\\baz").to_posix   # => Path.posix("foo/bar\\baz")
   # ```
   #
-  # When *mappings* is `true`, replacements  for forbidden characters in Windows
+  # When *mappings* is `true` (default), replacements  for forbidden characters in Windows
   # paths are substituted by the original characters when converting to a POSIX path.
   # Originals are calculated by subtracting `0xF000` from the replacement codepoint.
   # For example, the `U+F05C` becomes `U+005C`, the backslash character.
@@ -696,7 +696,7 @@ struct Path
   #
   # * `#to_windows` performs the inverse conversion.
   # * `#to_kind` performs a configurable conversion.
-  def to_posix(*, mappings : Bool = false) : Path
+  def to_posix(*, mappings : Bool = true) : Path
     name = @name
     if windows?
       name = name.gsub('\\', '/')
@@ -712,7 +712,7 @@ struct Path
   # See `#to_windows` and `#to_posix` for details.
   #
   # * `#to_native` converts to the native path semantics.
-  def to_kind(kind, *, mappings : Bool = false) : Path
+  def to_kind(kind, *, mappings : Bool = true) : Path
     if kind.posix?
       to_posix(mappings: mappings)
     else

--- a/src/path.cr
+++ b/src/path.cr
@@ -632,50 +632,91 @@ struct Path
   end
 
   # Converts this path to a native path.
+  #
+  # * `#to_kind` performs a configurable conversion.
   def to_native : Path
     to_kind(Kind.native)
   end
 
   # Converts this path to a Windows path.
   #
+  # This creates a new instance with the same string representation but with
+  # `Kind::WINDOWS`. If `#windows?` is true, this is a no-op.
+  #
   # ```
   # Path.posix("foo/bar").to_windows   # => Path.windows("foo/bar")
   # Path.windows("foo/bar").to_windows # => Path.windows("foo/bar")
   # ```
   #
-  # This creates a new instance with the same string representation but with
-  # `Kind::WINDOWS`.
-  def to_windows : Path
-    new_instance(@name, Kind::WINDOWS)
+  # When *mappings* is `true`, forbidden characters in Windows paths are
+  # substituted by replacement characters when converting from a POSIX path.
+  # Replacements are calculated by adding `0xF000` to their codepoint.
+  # For example, the backslash character `U+005C` becomes `U+F05C`.
+  #
+  # ```
+  # Path.posix("foo\\bar").to_windows(mappings: true)  # => Path.windows("foo\uF05Cbar")
+  # Path.posix("foo\\bar").to_windows(mappings: false) # => Path.windows("foo\\bar")
+  # ```
+  #
+  # * `#to_posix` performs the inverse conversion.
+  # * `#to_kind` performs a configurable conversion.
+  def to_windows(*, mappings : Bool = false) : Path
+    name = @name
+    if posix? && mappings
+      name = name.tr(WINDOWS_ESCAPE_CHARACTERS, WINDOWS_ESCAPED_CHARACTERS)
+    end
+    new_instance(name, Kind::WINDOWS)
   end
+
+  # :nodoc:
+  WINDOWS_ESCAPE_CHARACTERS = %("*:<>?\\| )
+  # :nodoc:
+  WINDOWS_ESCAPED_CHARACTERS = "\uF022\uF02A\uF03A\uF03C\uF03E\uF03F\uF05C\uF07C\uF020"
 
   # Converts this path to a POSIX path.
   #
+  # It returns a new instance with `Kind::POSIX` and all occurrences of Windows'
+  # backslash file separators (`\\`) replaced by forward slash (`/`).
+  # If `#posix?` is true, this is a no-op.
+  #
   # ```
   # Path.windows("foo/bar\\baz").to_posix # => Path.posix("foo/bar/baz")
-  # Path.posix("foo/bar").to_posix        # => Path.posix("foo/bar")
   # Path.posix("foo/bar\\baz").to_posix   # => Path.posix("foo/bar\\baz")
   # ```
   #
-  # It returns a copy of this instance if it already has POSIX kind. Otherwise
-  # a new instance is created with `Kind::POSIX` and all occurrences of
-  # backslash file separators (`\\`) replaced by forward slash (`/`).
-  def to_posix : Path
-    if posix?
-      new_instance(@name, Kind::POSIX)
-    else
-      new_instance(@name.gsub(Path.separators(Kind::WINDOWS)[0], Path.separators(Kind::POSIX)[0]), Kind::POSIX)
+  # When *mappings* is `true`, replacements  for forbidden characters in Windows
+  # paths are substituted by the original characters when converting to a POSIX path.
+  # Originals are calculated by subtracting `0xF000` from the replacement codepoint.
+  # For example, the `U+F05C` becomes `U+005C`, the backslash character.
+  #
+  # ```
+  # Path.windows("foo\uF05Cbar").to_posix(mappings: true)  # => Path.posix("foo\\bar")
+  # Path.windows("foo\uF05Cbar").to_posix(mappings: false) # => Path.posix("foo\uF05Cbar")
+  # ```
+  #
+  # * `#to_windows` performs the inverse conversion.
+  # * `#to_kind` performs a configurable conversion.
+  def to_posix(*, mappings : Bool = false) : Path
+    name = @name
+    if windows?
+      name = name.gsub('\\', '/')
+      if mappings
+        name = name.tr(WINDOWS_ESCAPED_CHARACTERS, WINDOWS_ESCAPE_CHARACTERS)
+      end
     end
+    new_instance(name, Kind::POSIX)
   end
 
   # Converts this path to the given *kind*.
   #
   # See `#to_windows` and `#to_posix` for details.
-  def to_kind(kind) : Path
+  #
+  # * `#to_native` converts to the native path semantics.
+  def to_kind(kind, *, mappings : Bool = false) : Path
     if kind.posix?
-      to_posix
+      to_posix(mappings: mappings)
     else
-      to_windows
+      to_windows(mappings: mappings)
     end
   end
 


### PR DESCRIPTION
Paths have slightly different semantics on Windows and Unix-like platforms. The most obvious one is the significance of the backslash character `\`: On Windows, it's a directory separator (alongside forward slash `/`). On Unix-like systems, it's just an ordinary character as part of a file name.

Thus, the path `foo\bar` on Windows refers to a file `bar` in directory `foo`, while on Unix-like systems it's a file called `foo\bar`.

Crystal's `Path` type supports both flavours of paths and offers conversions between them. So what happens when a posix path `foo\bar` is converted to a Windows path?

Currently it's this:
```cr
Path.posix("foo\\bar").to_windows # => Path.windows("foo\\bar")
```

This conversion however changes the semantics. The path represents different structures depending on the platform.

That is dangerous behaviour as we can see in #11826 for example.

With this patch we make sure that this doesn't happen. Characters with special meanings in Windows paths are now substituted by replacement characters. These replacements are recognized in Windows, so the meaning really doesn't change. When there's a file called `foo\bar`, it's referred to on Windows natively as `foobar` (the replacement character is `U+F05C`).

```console
C:\Users\Johannes\test>dir /B
foobar
```

```console
$ ls /mnt/c/Users/Johannes/test
'foo\bar'
```

The conversion also works in the opposite direction:
```cr
Path.posix("foo\\bar")).to_windows          # => Path.windows("foo\uF05Cbar")
Path.posix("foo\\bar")).to_windows.to_posix # => Path.posix("foo\\bar")
```

This is technically a breaking change, but I think it's a necessary bug fix. There's still an option to get the original behaviour by passing `mapping: false` to the conversion methods. At least for now. I'm not sure if there's a good use case for that, so we might want to remove that option and only provide the mapping semantics in the future.

This technically serves as a fix for #11826, but I'm not linking it because we're still missing specs for the static file handler. I'll add them in a subsequent PR.