### PR TITLE
Fix comment indentation in `ASTNode#to_s`

### DIFF
--- a/spec/compiler/parser/to_s_spec.cr
+++ b/spec/compiler/parser/to_s_spec.cr
@@ -117,6 +117,7 @@ describe "ASTNode#to_s" do
   expect_to_s "macro foo\n\\{%@type %}\nend"
   expect_to_s "enum A : B\nend"
   expect_to_s "# doc\ndef foo\nend", emit_doc: true
+  expect_to_s "class Foo\n  # doc\n  def foo\n  end\nend", emit_doc: true
   expect_to_s "foo[x, y, a: 1, b: 2]"
   expect_to_s "foo[x, y, a: 1, b: 2] = z"
   expect_to_s %(@[Foo(1, 2, a: 1, b: 2)])

--- a/src/compiler/crystal/syntax/to_s.cr
+++ b/src/compiler/crystal/syntax/to_s.cr
@@ -25,12 +25,12 @@ module Crystal
 
     def visit_any(node)
       if @emit_doc && (doc = node.doc) && !doc.empty?
-        doc.each_line(chomp: false) do |line|
-          append_indent
+        doc.each_line(chomp: true) do |line|
           @str << "# "
           @str << line
+          newline
+          append_indent
         end
-        @str.puts
       end
 
       if (macro_expansion_pragmas = @macro_expansion_pragmas) && (loc = node.location) && (filename = loc.filename).is_a?(String)


### PR DESCRIPTION
```cr
require "compiler/crystal/syntax"

code = <<-CRYSTAL
class Foo
  # doc
  def bar
  end
end
CRYSTAL

parser = Crystal::Parser.new(code)
parser.wants_doc = true

ast = parser.parse

puts String.build { |io| ast.to_s(io, emit_doc: true) }
```

Old output:

```
class Foo
    # doc
def bar
  end
end
```

New output:

```
class Foo
  # doc
  def bar
  end
end
```