### PR TITLE
Always require semicolon or newline before method body

### DIFF
--- a/spec/compiler/parser/parser_spec.cr
+++ b/spec/compiler/parser/parser_spec.cr
@@ -1840,6 +1840,8 @@ module Crystal
     assert_syntax_error "def foo(x :Int32); end", "space required after colon in type restriction"
 
     assert_syntax_error "def f end", %(unexpected token: "end" (expected ";" or newline))
+    assert_syntax_error "def foo : Int32 1 end", %(unexpected token: "1" (expected ";" or newline))
+    assert_syntax_error "def foo(x : U) forall U end", %(unexpected token: "end" (expected ";" or newline))
 
     assert_syntax_error "fun foo\nclass", "can't define class inside fun"
     assert_syntax_error "fun foo\nFoo = 1", "dynamic constant assignment"

--- a/src/compiler/crystal/syntax/parser.cr
+++ b/src/compiler/crystal/syntax/parser.cr
@@ -3613,7 +3613,13 @@ module Crystal
         body = Nop.new
       else
         slash_is_regex!
-        skip_statement_end
+
+        case @token.type
+        when :";", :NEWLINE
+          skip_statement_end
+        else
+          unexpected_token %(expected ";" or newline)
+        end
 
         end_location = token_end_location
 


### PR DESCRIPTION
As per https://github.com/crystal-lang/crystal/issues/6191#issuecomment-401618967