### PR TITLE
Fix: Prevent eager `instance_sizeof` on structs

### DIFF
--- a/spec/compiler/semantic/sizeof_spec.cr
+++ b/spec/compiler/semantic/sizeof_spec.cr
@@ -38,6 +38,32 @@ describe "Semantic: sizeof" do
       "instance_sizeof can only be used with a class, but Foo is a struct"
   end
 
+  it "gives error if using instance_sizeof on an abstract struct (#11855)" do
+    assert_error %(
+      abstract struct Foo
+      end
+
+      instance_sizeof(Foo)
+      ),
+      "instance_sizeof can only be used with a class, but Foo is a struct"
+  end
+
+  it "gives error if using instance_sizeof on an abstract struct with multiple subtypes (#11855)" do
+    assert_error %(
+      abstract struct Foo
+      end
+
+      struct Child1 < Foo
+      end
+
+      struct Child2 < Foo
+      end
+
+      instance_sizeof(Foo)
+      ),
+      "instance_sizeof can only be used with a class, but Foo is a struct"
+  end
+
   it "gives error if using instance_sizeof on a module" do
     assert_error %(
       module Moo

--- a/src/compiler/crystal/semantic/main_visitor.cr
+++ b/src/compiler/crystal/semantic/main_visitor.cr
@@ -2547,7 +2547,7 @@ module Crystal
       # Try to resolve the instance_sizeof right now to a number literal
       # (useful for sizeof inside as a generic type argument, but also
       # to make it easier for LLVM to optimize things)
-      if type && type.devirtualize.class? && !type.metaclass? && !node.exp.is_a?(TypeOf)
+      if type && type.devirtualize.class? && !type.metaclass? && !type.struct? && !node.exp.is_a?(TypeOf)
         expanded = NumberLiteral.new(@program.instance_size_of(type.sizeof_type).to_s, :i32)
         expanded.type = @program.int32
         node.expanded = expanded


### PR DESCRIPTION
This change prevents eager instance_sizeof on structs, since it causes the compiler to crash in some cases and it is already reported as an [error in the CleanupTransformer anyway](https://github.com/crystal-lang/crystal/blob/a978a06f306428c0172b96aee72609767dc7a5ca/src/compiler/crystal/semantic/cleanup_transformer.cr#L926). This change allows the AST to make it to the CleanupTransformer, producing the expected error.

Fixes #11855