### PR TITLE
Resolve non-type free variables in return type restrictions

### DIFF
--- a/spec/compiler/semantic/return_spec.cr
+++ b/spec/compiler/semantic/return_spec.cr
@@ -182,6 +182,44 @@ describe "Semantic: return" do
       ), inject_primitives: true) { float64 }
   end
 
+  it "can use non-type free var in return type (#6543)" do
+    assert_type(<<-CR) { generic_class "Foo", 1.int32 }
+      class Foo(A)
+      end
+
+      def foo(a : Foo(P)) : Foo(P) forall P
+        a
+      end
+
+      foo(Foo(1).new)
+      CR
+  end
+
+  it "can use non-type free var in return type (2) (#6543)" do
+    assert_type(<<-CR) { generic_class "Matrix", 3.int32, 4.int32 }
+      class Matrix(N, M)
+        def *(other : Matrix(M, P)) : Matrix(N, P) forall P
+          Matrix(N, P).new
+        end
+      end
+
+      Matrix(3, 2).new * Matrix(2, 4).new
+      CR
+  end
+
+  it "errors if non-type free var cannot be inferred" do
+    assert_error <<-CR, "undefined constant P"
+      class Foo(A)
+      end
+
+      def foo(a) : Foo(P) forall P
+        a
+      end
+
+      foo(Foo(1).new)
+      CR
+  end
+
   it "forms a tuple from multiple return values" do
     assert_type("def foo; return 1, 1.0; end; foo") { tuple_of([int32, float64]) }
   end

--- a/src/compiler/crystal/semantic/type_lookup.cr
+++ b/src/compiler/crystal/semantic/type_lookup.cr
@@ -250,7 +250,7 @@ class Crystal::Type
 
         # Check the case of T resolving to a number
         if type_var.is_a?(Path)
-          type = lookup_type_var?(type_var)
+          type = lookup_type_var(type_var)
           case type
           when Const
             interpreter = MathInterpreter.new(@root)
@@ -261,7 +261,7 @@ class Crystal::Type
               type_var.raise "expanding constant value for a number value", inner: ex
             end
             next
-          when ASTNode
+          when NumberLiteral
             type_vars << type
             next
           end

--- a/src/compiler/crystal/semantic/type_lookup.cr
+++ b/src/compiler/crystal/semantic/type_lookup.cr
@@ -250,7 +250,7 @@ class Crystal::Type
 
         # Check the case of T resolving to a number
         if type_var.is_a?(Path)
-          type = lookup_type_var(type_var)
+          type = in_generic_args { lookup_type_var(type_var) }
           case type
           when Const
             interpreter = MathInterpreter.new(@root)

--- a/src/compiler/crystal/semantic/type_lookup.cr
+++ b/src/compiler/crystal/semantic/type_lookup.cr
@@ -250,7 +250,7 @@ class Crystal::Type
 
         # Check the case of T resolving to a number
         if type_var.is_a?(Path)
-          type = @root.lookup_path(type_var)
+          type = lookup_type_var?(type_var)
           case type
           when Const
             interpreter = MathInterpreter.new(@root)


### PR DESCRIPTION
Resolves #6543.

The free variables are already there, only that the return type lookup skipped over them.