### PR TITLE
Fix: Do not consider global `Path` in def parameter restriction as free variable

### DIFF
--- a/spec/compiler/semantic/def_overload_spec.cr
+++ b/spec/compiler/semantic/def_overload_spec.cr
@@ -235,6 +235,27 @@ describe "Semantic: def overload" do
     ") { int32 }
   end
 
+  it "does not consider global paths as free variables (1)" do
+    assert_error <<-CR, "undefined constant ::Foo"
+      def foo(x : ::Foo) forall Foo
+      end
+
+      foo(1)
+      CR
+  end
+
+  it "does not consider global paths as free variables (2)" do
+    assert_error <<-CR, "no overload matches"
+      class Foo
+      end
+
+      def foo(x : ::Foo) forall Foo
+      end
+
+      foo(1)
+      CR
+  end
+
   it "prefers more specific overload than one with free variables" do
     assert_type("
       require \"prelude\"

--- a/src/compiler/crystal/semantic/abstract_def_checker.cr
+++ b/src/compiler/crystal/semantic/abstract_def_checker.cr
@@ -360,10 +360,8 @@ class Crystal::AbstractDefChecker
     end
 
     def visit(node : Path)
-      if !node.global? && node.names.size == 1
+      if name = node.single_name?
         # Check if it matches any of the generic type vars
-        name = node.names.first
-
         type_var = @generic_type.type_vars[name]?
         if type_var.is_a?(Var)
           # Check that it's actually a type parameter on the base type

--- a/src/compiler/crystal/semantic/ast.cr
+++ b/src/compiler/crystal/semantic/ast.cr
@@ -268,8 +268,8 @@ module Crystal
     def free_var?(node : Path)
       free_vars = @free_vars
       return false unless free_vars
-
-      !node.global? && node.names.size == 1 && free_vars.includes?(node.names.first)
+      name = node.single_name?
+      !name.nil? && free_vars.includes?(name)
     end
 
     def free_var?(any)

--- a/src/compiler/crystal/syntax/ast.cr
+++ b/src/compiler/crystal/syntax/ast.cr
@@ -1383,6 +1383,11 @@ module Crystal
       names.size == 1 && names.first == name
     end
 
+    # Returns this path's name if it has only one part and is not global
+    def single_name?
+      names.first if names.size == 1 && !global?
+    end
+
     def clone_without_location
       ident = Path.new(@names.clone, @global)
       ident


### PR DESCRIPTION
Given:

```crystal
def foo(x : ::T) forall T
end

foo(1) # okay?
```

`::T` is a global path, so it should always refer to the type `T` from the top-level namespace, never the free variable. The above snippet now reports `undefined constant ::T`. If `::T` were defined, then `foo`'s argument must also be of type `T`.

Defs like these are now subject to #7737.

Also includes slight refactors outside `restrictions.cr`.