### PR TITLE
Compiler: include is now a macro

### DIFF
--- a/spec/compiler/parser/parser_spec.cr
+++ b/spec/compiler/parser/parser_spec.cr
@@ -237,7 +237,7 @@ module Crystal
     # #5895, #6042, #5997
     %w(
       begin nil true false yield with abstract
-      def macro require case select if unless include
+      def macro require case select if unless
       extend class struct module enum while until return
       next break lib fun alias pointerof sizeof
       instance_sizeof offsetof typeof private protected asm out
@@ -560,8 +560,6 @@ module Crystal
     it_parses "if foo\n1\nelse\n2\nend", If.new("foo".call, 1.int32, 2.int32)
     it_parses "if foo; 1; elsif bar; 2; else 3; end", If.new("foo".call, 1.int32, If.new("bar".call, 2.int32, 3.int32))
 
-    it_parses "include Foo", Include.new("Foo".path)
-    it_parses "include Foo\nif true; end", [Include.new("Foo".path), If.new(true.bool)]
     it_parses "extend Foo", Extend.new("Foo".path)
     it_parses "extend Foo\nif true; end", [Extend.new("Foo".path), If.new(true.bool)]
     it_parses "extend self", Extend.new(Self.new)
@@ -1726,7 +1724,7 @@ module Crystal
 
     assert_syntax_error "return do\nend", %(unexpected token: "do")
 
-    %w(def macro class struct module fun alias abstract include extend lib).each do |keyword|
+    %w(def macro class struct module fun alias abstract extend lib).each do |keyword|
       assert_syntax_error "def foo\n#{keyword}\nend"
     end
 

--- a/spec/compiler/semantic/module_spec.cr
+++ b/spec/compiler/semantic/module_spec.cr
@@ -1690,4 +1690,12 @@ describe "Semantic: module" do
       ),
       "argument to `include` must be a type or `self`, not NumberLiteral"
   end
+
+  it "can't include non-self var" do
+    assert_error %(
+      a = 1
+      include a
+      ),
+      "argument to `include` must be a type or `self`, not Var"
+  end
 end

--- a/spec/compiler/semantic/module_spec.cr
+++ b/spec/compiler/semantic/module_spec.cr
@@ -1683,4 +1683,11 @@ describe "Semantic: module" do
       ),
       "wrong number of arguments"
   end
+
+  it "can't include non-type" do
+    assert_error %(
+      include 1
+      ),
+      "argument to `include` must be a type or `self`, not NumberLiteral"
+  end
 end

--- a/src/compiler/crystal/program.cr
+++ b/src/compiler/crystal/program.cr
@@ -241,6 +241,8 @@ module Crystal
       types["Deprecated"] = @deprecated_annotation = AnnotationType.new self, self, "Deprecated"
       types["Experimental"] = @experimental_annotation = AnnotationType.new self, self, "Experimental"
 
+      add_macro Macro.new("include", [Arg.new("type")], Primitive.new("include"))
+
       define_crystal_constants
     end
 

--- a/src/compiler/crystal/semantic/top_level_visitor.cr
+++ b/src/compiler/crystal/semantic/top_level_visitor.cr
@@ -455,6 +455,19 @@ class Crystal::TopLevelVisitor < Crystal::SemanticVisitor
 
   def visit(node : Include)
     check_outside_exp node, "include"
+
+    node_name = node.name
+    case node_name
+    when Path, Generic
+      # Okay
+    when Var
+      if node_name.name == "self"
+        node.name = Self.new.at(node_name)
+      end
+    else
+      node.name.raise "argument to `include` must be a type or `self`, not #{node.name.class_desc}"
+    end
+
     include_in current_type, node, :included
     false
   end

--- a/src/compiler/crystal/semantic/top_level_visitor.cr
+++ b/src/compiler/crystal/semantic/top_level_visitor.cr
@@ -455,21 +455,25 @@ class Crystal::TopLevelVisitor < Crystal::SemanticVisitor
 
   def visit(node : Include)
     check_outside_exp node, "include"
+    validate_include node
+    include_in current_type, node, :included
+    false
+  end
 
+  private def validate_include(node)
     node_name = node.name
     case node_name
     when Path, Generic
       # Okay
+      return
     when Var
       if node_name.name == "self"
         node.name = Self.new.at(node_name)
+        return
       end
-    else
-      node.name.raise "argument to `include` must be a type or `self`, not #{node.name.class_desc}"
     end
 
-    include_in current_type, node, :included
-    false
+    node.name.raise "argument to `include` must be a type or `self`, not #{node.name.class_desc}"
   end
 
   def visit(node : Extend)

--- a/src/compiler/crystal/syntax/parser.cr
+++ b/src/compiler/crystal/syntax/parser.cr
@@ -1074,12 +1074,6 @@ module Crystal
           check_type_declaration { parse_if }
         when :unless
           check_type_declaration { parse_unless }
-        when :include
-          check_type_declaration do
-            check_not_inside_def("can't include") do
-              parse_include
-            end
-          end
         when :extend
           check_type_declaration do
             check_not_inside_def("can't extend") do
@@ -3979,7 +3973,7 @@ module Crystal
         # We cannot assign value into them and never reference them,
         # so they are invalid internal name.
         when :begin, :nil, :true, :false, :yield, :with, :abstract,
-             :def, :macro, :require, :case, :select, :if, :unless, :include,
+             :def, :macro, :require, :case, :select, :if, :unless,
              :extend, :class, :struct, :module, :enum, :while, :until, :return,
              :next, :break, :lib, :fun, :alias, :pointerof, :sizeof, :offsetof,
              :instance_sizeof, :typeof, :private, :protected, :asm, :out,


### PR DESCRIPTION
This is a proof-of-concept for https://forum.crystal-lang.org/t/rfc-let-include-extend-and-require-be-macros/4422

Instead of `include` being a keyword, it's now a macro. The exception is the macro code lies in the compiler, there's no way a user can write this. But it being a macro makes the language a bit more flexible. In particular, all of these failed to compile before and now they work fine:

```crystal
class Foo
  # Now you can define a method called `include`, and call it.
  # Because this is an instance method, it will be find fist before
  # the top-level macro. You can still use include at the class level!
  def include(value)
    puts value
  end

  def bar
    include "Hello"
  end
end
```

```crystal
# There's nothing special about `include` anymore, except that there's
# a top-level macro named like that. But we can use local variables with that
# name just fine!
def foo(include)
  puts include
end
```

This PR for now only does this for `include`, but we could do the same with `extend` and `require`. I'm even thinking we could do the same with `typeof`, `pointerof`, `sizeof` and `instance_sizeof`. After all they all operate at compile-time, just like macros do.

To be honest, the flexibility or additional things we get aren't many. But in my opinion it makes the language simpler: less hardcoded things. And adding more features in the future, like `compiles?` or `compiler_error` could be done with special macros as well.