### PR TITLE
Allow explicit usage of libiconv

### DIFF
--- a/src/crystal/iconv.cr
+++ b/src/crystal/iconv.cr
@@ -1,4 +1,4 @@
-{% if flag?(:win32) %}
+{% if flag?(:use_libiconv) || flag?(:win32) %}
   require "./lib_iconv"
   private USE_LIBICONV = true
 {% else %}


### PR DESCRIPTION
Allow developers to opt for libiconv variant instead of the built-in iconv support of their platform.

This helps with cross-compilation of binaries to platforms like macOS, which requires bulky SDK being installed in order to support linking to their bundled `iconv` library.

Alternatively, developer should be able to build a static version of iconv (`libiconv`) and be able to link with it by forcing its usage with `-Duse_libiconv`:

```console
$ crystal build app.cr --cross-compile --target x86_64-apple-darwin -Duse_libiconv
```

Relevant links:
- https://forum.crystal-lang.org/t/macos-compilation-and-libiconv-support/4439
- https://github.com/ziglang/zig/issues/10485#issuecomment-1013723542