### PR TITLE
Improve `UUID#inspect` to return Crystal expression

### DIFF
--- a/spec/std/uuid_spec.cr
+++ b/spec/std/uuid_spec.cr
@@ -27,9 +27,8 @@ describe "UUID" do
       subject.version.should eq UUID::Version::V4
     end
 
-    it "does inspect" do
-      subject = UUID.random
-      subject.inspect.should eq "UUID(#{subject})"
+    it "#inspect" do
+      UUID.new("50a11da6-377b-4bdf-b9f0-076f9db61c93").inspect.should eq %(UUID.new("50a11da6-377b-4bdf-b9f0-076f9db61c93"))
     end
 
     it "works with variant" do

--- a/src/uuid.cr
+++ b/src/uuid.cr
@@ -134,7 +134,7 @@ struct UUID
   # Generates an empty UUID.
   #
   # ```
-  # UUID.empty # => UUID(00000000-0000-4000-0000-000000000000)
+  # UUID.empty # => UUID.new("00000000-0000-4000-0000-000000000000")
   # ```
   def self.empty : self
     new(StaticArray(UInt8, 16).new(0_u8), UUID::Variant::NCS, UUID::Version::V4)
@@ -203,9 +203,9 @@ struct UUID
 
   # Convert to `String` in literal format.
   def inspect(io : IO) : Nil
-    io << "UUID("
+    io << %<UUID.new(">
     to_s(io)
-    io << ')'
+    io << %<")>
   end
 
   def to_s(io : IO) : Nil


### PR DESCRIPTION
This patch changes `UUID#inspect` to return a string representation that is also a valid Crystal expression for creating a `UUID` instance. This serves as a convenience feature for developers. You can easily print a UUID (`p! uuid`) and use the result to re-construct the same UUID in Crystal code.
Without that, you have to manually edit the current format to form a call to `UUID.new`. Considering the diff is quite minimal, I think it's a nice treat to make this easier for users.