### PR TITLE
Improve `URI::Params#inspect` to use hash-like literal

### DIFF
--- a/spec/std/uri/params_spec.cr
+++ b/spec/std/uri/params_spec.cr
@@ -92,6 +92,12 @@ class URI
       end
     end
 
+    it "#inspect" do
+      URI::Params.new.inspect.should eq "URI::Params{}"
+
+      URI::Params{"foo" => ["bar", "baz"], "baz" => ["qux"]}.inspect.should eq %(URI::Params{"foo" => ["bar", "baz"], "baz" => ["qux"]})
+    end
+
     describe "#[](name)" do
       it "returns first value for provided param name" do
         params = Params.parse("foo=bar&foo=baz&baz=qux")

--- a/src/uri.cr
+++ b/src/uri.cr
@@ -265,7 +265,7 @@ class URI
   # require "uri"
   #
   # uri = URI.parse "http://foo.com?id=30&limit=5#time=1305298413"
-  # uri.query_params # => URI::Params(@raw_params={"id" => ["30"], "limit" => ["5"]})
+  # uri.query_params # => URI::Params{"id" => ["30"], "limit" => ["5"]}
   # ```
   def query_params : URI::Params
     URI::Params.parse(@query || "")

--- a/src/uri/params.cr
+++ b/src/uri/params.cr
@@ -394,6 +394,11 @@ class URI
       end
     end
 
+    def inspect(io : IO)
+      io << "URI::Params"
+      @raw_params.inspect(io)
+    end
+
     # :nodoc:
     def self.decode_one_www_form_component(query, bytesize, i, byte, char, buffer)
       URI.decode_one query, bytesize, i, byte, char, buffer, true


### PR DESCRIPTION
`URI::Params` can make good use of a hash-like literal as a concise and expressive representation for `#inspect`.