### PR TITLE
Fully consume an HTTP::Content IO when closing

### DIFF
--- a/spec/std/http/chunked_content_spec.cr
+++ b/spec/std/http/chunked_content_spec.cr
@@ -58,6 +58,15 @@ describe HTTP::ChunkedContent do
     content.gets_to_end.should eq("456")
   end
 
+  it "skips to the end when closed" do
+    mem = IO::Memory.new("4\r\n123\n\r\n3\r\n456\r\n0\r\n\r\n")
+    content = HTTP::ChunkedContent.new(mem)
+
+    content.close
+
+    mem.pos.should eq mem.bytesize
+  end
+
   it "#gets reads multiple chunks" do
     mem = IO::Memory.new("1\r\nA\r\n1\r\nB\r\n0\r\n\r\n")
     content = HTTP::ChunkedContent.new(mem)

--- a/src/http/content.cr
+++ b/src/http/content.cr
@@ -10,6 +10,7 @@ module HTTP
 
     def close
       @expects_continue = false
+      skip_to_end
       super
     end
 


### PR DESCRIPTION
The block form of `HTTP::Client` methods assume that the block will fully consume the `body_io`, but that's not always the case. When reusing the connection, this causes subsequent requests to fail. I've run into this a few times now:

- When the response body isn't useful, for example if you've sent data to a remote service and it responds with something like `OK`, so you ignore it — Honeycomb does this on its OpenTelemetry traces endpoint
- The server sends extra bytes at the end of the response which would not be picked up by something that parses the serialization format — InfluxDB sends an extra newline after the last table in the response

I figured since I've run into this so many times that I'd send in a PR. 😂 

Reproduction:

```crystal
require "http"

%w[
  https://crystal-lang.org
  https://google.com
].each do |url|
  http = HTTP::Client.new(URI.parse(url))
  2.times do
    http.get("/") do |response|
      pp response.body_io?.class
    end
  end
end
```

Add this to it and it works:

```crystal
module HTTP::Content
  def close
    @expects_continue = false
    skip_to_end
    super
  end
end
```

The Crystal and Google sites were chosen because the Crystal site serves chunked content and Google serves fixed-length content.