### PR TITLE
Allow `Bytes[]` to construct an empty `Bytes`

### DIFF
--- a/spec/std/io/buffered_spec.cr
+++ b/spec/std/io/buffered_spec.cr
@@ -409,7 +409,7 @@ describe "IO::Buffered" do
   it "shouldn't call unbuffered read if reading to an empty slice" do
     str = IO::Memory.new("foo")
     io = BufferedWrapper.new(str)
-    io.read(Bytes.new(0))
+    io.read(Bytes[])
     io.called_unbuffered_read.should be_false
   end
 

--- a/spec/std/io/io_spec.cr
+++ b/spec/std/io/io_spec.cr
@@ -281,7 +281,7 @@ describe IO do
     it "reads all remaining content as bytes" do
       io = SimpleIOMemory.new(Bytes[0, 1, 3, 6, 10, 15])
       io.getb_to_end.should eq(Bytes[0, 1, 3, 6, 10, 15])
-      io.getb_to_end.should eq(Bytes.new(0))
+      io.getb_to_end.should eq(Bytes[])
       io.rewind
       bytes = io.getb_to_end
       bytes.should eq(Bytes[0, 1, 3, 6, 10, 15])

--- a/spec/std/io/memory_spec.cr
+++ b/spec/std/io/memory_spec.cr
@@ -361,7 +361,7 @@ describe IO::Memory do
   it "consumes with getb_to_end" do
     io = IO::Memory.new(Bytes[0, 1, 3, 6, 10, 15])
     io.getb_to_end.should eq(Bytes[0, 1, 3, 6, 10, 15])
-    io.getb_to_end.should eq(Bytes.new(0))
+    io.getb_to_end.should eq(Bytes[])
     io.seek(3)
     bytes = io.getb_to_end
     bytes.should eq(Bytes[6, 10, 15])
@@ -372,7 +372,7 @@ describe IO::Memory do
     bytes.should eq(Bytes[6, 10, 15])
 
     io.seek(10)
-    io.getb_to_end.should eq(Bytes.new(0))
+    io.getb_to_end.should eq(Bytes[])
   end
 
   it "peeks" do

--- a/spec/std/random_spec.cr
+++ b/spec/std/random_spec.cr
@@ -253,7 +253,7 @@ describe "Random" do
       rng.random_bytes(1).should eq Bytes[0x3e]
       rng.random_bytes(4).should eq Bytes[1, 0, 0, 0]
       rng.random_bytes(3).should eq Bytes[0x78, 0x56, 0x34]
-      rng.random_bytes(0).should eq Bytes.new(0)
+      rng.random_bytes(0).should eq Bytes[]
 
       rng = TestRNG.new([12u8, 255u8, 11u8, 5u8, 122u8, 200u8, 192u8])
       rng.random_bytes(7).should eq Bytes[12, 255, 11, 5, 122, 200, 192]

--- a/spec/std/slice_spec.cr
+++ b/spec/std/slice_spec.cr
@@ -489,6 +489,12 @@ describe "Slice" do
     slice.to_a.should eq([1, 2, 3])
   end
 
+  it "does Bytes[]" do
+    slice = Bytes[]
+    slice.should be_a(Bytes)
+    slice.empty?.should be_true
+  end
+
   it "uses percent vars in [] macro (#2954)" do
     slices = itself(Slice[1, 2], Slice[3])
     slices[0].to_a.should eq([1, 2])

--- a/src/io/memory.cr
+++ b/src/io/memory.cr
@@ -227,7 +227,7 @@ class IO::Memory < IO
     check_open
 
     if @pos >= @bytesize
-      Bytes.new(0)
+      Bytes[]
     else
       bytes = Slice.new(@buffer + @pos, @bytesize - @pos).dup
       @pos = @bytesize

--- a/src/slice.cr
+++ b/src/slice.cr
@@ -34,7 +34,7 @@ struct Slice(T)
     # TODO: there should be a better way to check this, probably
     # asking if @type was instantiated or if T is defined
     {% if @type.name != "Slice(T)" && T < Number %}
-      {{T}}.slice({{*args}}, read_only: {{read_only}})
+      {{T}}.slice({{args.splat(", ")}}read_only: {{read_only}})
     {% else %}
       %ptr = Pointer(typeof({{*args}})).malloc({{args.size}})
       {% for arg, i in args %}


### PR DESCRIPTION
`Bytes[]` in normal code fails to compile:

```
There was a problem expanding macro '[]'

Code in test.cr:1:1

 1 | Bytes[]
     ^
Called macro defined in src/slice.cr:33:3

 33 | macro [](*args, read_only = false)

Which expanded to:

 > 2 |     # asking if @type was instantiated or if T is defined
 > 3 |     
 > 4 |       UInt8.slice(, read_only: false)
                        ^
Error: unterminated call
```

But `Bytes` fully specifies the type of the constructed object, so allowing `Bytes[]` should not be problematic. This is similar to #10192 and also related to #11879 because `inspect`ing an empty `Bytes` produces `Bytes[]`.

`Slice[]` is still disallowed because the element type could not be inferred (it is technically `NoReturn`, which is not very useful either).