### PR TITLE
Improve `BitArray`'s constructors

### DIFF
--- a/spec/std/bit_array_spec.cr
+++ b/spec/std/bit_array_spec.cr
@@ -28,6 +28,46 @@ private def assert_rotates!(from : BitArray, to : BitArray, *, file = __FILE__, 
 end
 
 describe "BitArray" do
+  describe ".new" do
+    context "without block" do
+      it "initializes with initial value" do
+        ary = BitArray.new(64, false)
+        ary.size.times { |i| ary[i].should be_false }
+
+        ary = BitArray.new(64, true)
+        ary.size.times { |i| ary[i].should be_true }
+      end
+
+      it "initializes with false by default" do
+        ary = BitArray.new(64)
+        ary.size.times { |i| ary[i].should be_false }
+      end
+
+      it "initializes with non-Int32 size" do
+        BitArray.new(5_i8).size.should eq(5)
+        BitArray.new(5_u64).size.should eq(5)
+      end
+
+      it "initializes with unused bits cleared" do
+        ary = BitArray.new(3, true)
+        assert_no_unused_bits ary
+      end
+    end
+
+    context "with block" do
+      it "initializes elements with block" do
+        BitArray.new(5) { |i| i >= 3 }.should eq(from_int(5, 0b00011))
+        BitArray.new(6) { |i| i < 2 ? "" : nil }.should eq(from_int(6, 0b110000))
+        BitArray.new(7_i64, &.even?).should eq(from_int(7, 0b1010101))
+      end
+    end
+
+    it "raises if size is negative" do
+      expect_raises(ArgumentError) { BitArray.new(-1) }
+      expect_raises(ArgumentError) { BitArray.new(-2) { true } }
+    end
+  end
+
   it "has size" do
     ary = BitArray.new(100)
     ary.size.should eq(100)
@@ -806,16 +846,6 @@ describe "BitArray" do
     ary[4] = true
     ary.to_s.should eq("BitArray[10101000]")
     ary.inspect.should eq("BitArray[10101000]")
-  end
-
-  it "initializes with true by default" do
-    ary = BitArray.new(64, true)
-    ary.size.times { |i| ary[i].should be_true }
-  end
-
-  it "initializes with unused bits cleared" do
-    ary = BitArray.new(3, true)
-    assert_no_unused_bits ary
   end
 
   it "reads bits from slice" do

--- a/spec/std/bit_array_spec.cr
+++ b/spec/std/bit_array_spec.cr
@@ -3,9 +3,7 @@ require "bit_array"
 require "spec/helpers/iterate"
 
 private def from_int(size : Int32, int : Int)
-  ba = BitArray.new(size)
-  (0).upto(size - 1) { |i| ba[i] = int.bit(size - i - 1) > 0 }
-  ba
+  BitArray.new(size) { |i| int.bit(size - i - 1) > 0 }
 end
 
 private def assert_no_unused_bits(ba : BitArray, *, file = __FILE__, line = __LINE__)
@@ -56,9 +54,9 @@ describe "BitArray" do
 
     context "with block" do
       it "initializes elements with block" do
-        BitArray.new(5) { |i| i >= 3 }.should eq(from_int(5, 0b00011))
-        BitArray.new(6) { |i| i < 2 ? "" : nil }.should eq(from_int(6, 0b110000))
-        BitArray.new(7_i64, &.even?).should eq(from_int(7, 0b1010101))
+        BitArray.new(5) { |i| i >= 3 }.to_a.should eq([false, false, false, true, true])
+        BitArray.new(6) { |i| i < 2 ? "" : nil }.to_a.should eq([true, true, false, false, false, false])
+        BitArray.new(7_i64, &.even?).to_a.should eq([true, false, true, false, true, false, true])
       end
     end
 

--- a/src/bit_array.cr
+++ b/src/bit_array.cr
@@ -42,7 +42,11 @@ struct BitArray
   # BitArray.new(6) { |i| i if i < 2 } # => BitArray[110000]
   # ```
   def self.new(size : Int, & : Int32 -> _)
-    new(size).fill { |i| !!yield i }
+    arr = new(size)
+    size.to_i.times do |i|
+      arr.unsafe_put(i, true) if yield i
+    end
+    arr
   end
 
   def ==(other : BitArray)

--- a/src/bit_array.cr
+++ b/src/bit_array.cr
@@ -25,10 +25,24 @@ struct BitArray
   #
   # *initial* optionally sets the starting value, `true` or `false`, for all bits
   # in the array.
-  def initialize(@size, initial : Bool = false)
+  def initialize(size : Int, initial : Bool = false)
+    raise ArgumentError.new("Negative bit array size: #{size}") if size < 0
+    @size = size.to_i
     value = initial ? UInt32::MAX : UInt32::MIN
     @bits = Pointer(UInt32).malloc(malloc_size, value)
     clear_unused_bits if initial
+  end
+
+  # Creates a new `BitArray` of *size* bits and invokes the given block once
+  # for each index of `self`, setting the bit at that index to `true` if the
+  # block is truthy.
+  #
+  # ```
+  # BitArray.new(5) { |i| i >= 3 }     # => BitArray[00011]
+  # BitArray.new(6) { |i| i if i < 2 } # => BitArray[110000]
+  # ```
+  def self.new(size : Int, & : Int32 -> _)
+    new(size).fill { |i| !!yield i }
   end
 
   def ==(other : BitArray)


### PR DESCRIPTION
* Adds a block-accepting overload, similar to other containers: `BitArray.new(7, &.even?) # => BitArray[1010101]`
* Allows non-`Int32` size arguments, also similar to other containers. The size is converted within the constructor. The added `Int` restriction is not a breaking change because `size` was previously used to initialize an `Int32` instance variable directly.
* Raises if the size argument is negative, instead of silently returning an empty `BitArray` for sizes within `-31..-1`.

I avoided [`BitArray.[]`](https://github.com/crystal-lang/crystal/pull/11879#issuecomment-1061746354) because it could be interpreted in two ways, a variadic literal-like constructor (which requires changes to `#inspect`'s format), and an integer-to-bits constructor (similar to the `from_int` spec helper method).