### PR TITLE
Upload build artifacts to S3 bucket

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -534,10 +534,6 @@ workflows:
           filters: *release
           requires:
             - dist_docker
-      - publish_nightly_artifacts:
-          requires:
-            - dist_linux
-            - dist_darwin
       - dist_artifacts:
           filters: *release
           requires:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -425,7 +425,12 @@ jobs:
     steps:
       - attach_workspace:
           at: /tmp/workspace
-      - run: s3cmd put --recursive /tmp/workspace/* s3://artifacts.crystal-lang.org/dist/
+      - run: |
+          mkdir -p /tmp/upload
+          cd /tmp/workspace/build
+          cp crystal-*-darwin-universal.tar.gz /tmp/upload/crystal-nightly-darwin-universal.tar.gz
+          cp crystal-*-linux-x86_64.tar.gz /tmp/upload/crystal-nightly-linux-x86_64.tar.gz
+      - run: s3cmd put --recursive /tmp/upload s3://artifacts.crystal-lang.org/dist/
 
   dist_artifacts:
     docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -430,7 +430,7 @@ jobs:
           cd /tmp/workspace/build
           cp crystal-*-darwin-universal.tar.gz /tmp/upload/crystal-nightly-darwin-universal.tar.gz
           cp crystal-*-linux-x86_64.tar.gz /tmp/upload/crystal-nightly-linux-x86_64.tar.gz
-      - run: s3cmd put --recursive /tmp/upload s3://artifacts.crystal-lang.org/dist/
+      - run: s3cmd put --recursive /tmp/upload/* s3://artifacts.crystal-lang.org/dist/
 
   dist_artifacts:
     docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -416,7 +416,7 @@ jobs:
           paths:
             - build
 
-  dist_artifacts:
+  publish_nightly_artifacts:
     docker:
       - image: manastech/s3cmd:2.2-alpine
     environment:
@@ -426,6 +426,16 @@ jobs:
       - attach_workspace:
           at: /tmp/workspace
       - run: s3cmd put --recursive /tmp/workspace/* s3://artifacts.crystal-lang.org/dist/
+
+  dist_artifacts:
+    docker:
+      - image: buildpack-deps:xenial
+    steps:
+      - attach_workspace:
+          at: /tmp/workspace
+      - store_artifacts:
+          path: /tmp/workspace/build
+          destination: dist_packages
 
   test_dist_linux_on_docker:
     machine: true
@@ -572,6 +582,10 @@ workflows:
       - dist_docs:
           requires:
             - dist_docker
+      - publish_nightly_artifacts:
+          requires:
+            - dist_linux
+            - dist_darwin
       - dist_artifacts:
           requires:
             - dist_linux

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -418,13 +418,14 @@ jobs:
 
   dist_artifacts:
     docker:
-      - image: buildpack-deps:xenial
+      - image: manastech/s3cmd:2.2-alpine
+    environment:
+      <<: *env
+      AWS_ACCESS_KEY_ID: AKIA2EEIIRCJCMOSW2XH
     steps:
       - attach_workspace:
           at: /tmp/workspace
-      - store_artifacts:
-          path: /tmp/workspace/build
-          destination: dist_packages
+      - run: s3cmd put --recursive /tmp/workspace/* s3://artifacts.crystal-lang.org/dist/
 
   test_dist_linux_on_docker:
     machine: true

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -534,6 +534,10 @@ workflows:
           filters: *release
           requires:
             - dist_docker
+      - publish_nightly_artifacts:
+          requires:
+            - dist_linux
+            - dist_darwin
       - dist_artifacts:
           filters: *release
           requires:


### PR DESCRIPTION
We were previously (ab)using CircleCI's artifacts, which shouldn't (and now can't) be accessed from other services. This is breaking _at least_ the crystal-lang/install-crystal Github Action.

See https://github.com/crystal-lang/install-crystal/runs/5549091691?check_suite_focus=true