### PR TITLE
Support "can't infer type parameter" error for uninstantiated generic modules

### DIFF
--- a/spec/compiler/semantic/module_spec.cr
+++ b/spec/compiler/semantic/module_spec.cr
@@ -1683,4 +1683,30 @@ describe "Semantic: module" do
       ),
       "wrong number of arguments"
   end
+
+  it "gives helpful error message when generic type var is missing" do
+    assert_error %(
+      module Foo(T)
+        def self.foo
+          T.bar
+        end
+      end
+
+      Foo.foo
+      ),
+      "can't infer the type parameter T for the generic module Foo(T). Please provide it explicitly"
+  end
+
+  it "gives helpful error message when generic type var is missing in block spec" do
+    assert_error %(
+      module Foo(T)
+        def self.foo(&block : T -> )
+          block
+        end
+      end
+
+      Foo.foo { |x| }
+      ),
+      "can't infer the type parameter T for the generic module Foo(T). Please provide it explicitly"
+  end
 end

--- a/src/compiler/crystal/semantic/type_lookup.cr
+++ b/src/compiler/crystal/semantic/type_lookup.cr
@@ -408,7 +408,7 @@ class Crystal::Type
     end
 
     def check_cant_infer_generic_type_parameter(scope, node)
-      if scope.is_a?(MetaclassType) && (instance_type = scope.instance_type).is_a?(GenericClassType)
+      if scope.is_a?(MetaclassType) && (instance_type = scope.instance_type).is_a?(GenericType)
         first_name = node.names.first
         if instance_type.type_vars.includes?(first_name)
           node.raise "can't infer the type parameter #{first_name} for the #{instance_type.type_desc} #{instance_type}. Please provide it explicitly"


### PR DESCRIPTION
This snippet:

```crystal
class Foo(T)
  def self.foo(&block : T -> )
    block
  end
end

Foo.foo { |x| } # Error: can't infer the type parameter T for the generic class Foo(T). Please provide it explicitly
```

produces a less specific error `undefined constant T` if `Foo` were a generic module instead. This PR changes that.

The same will also apply if `T` is used in `foo`'s body:

```crystal
module Foo(T)
  def self.foo
    T.bar
  end
end

Foo.foo # Error: can't infer the type parameter T for the generic module Foo(T). Please provide it explicitly
```

For classes this often happens with code like `Array.new`.