### PR TITLE
Support `Generic` nodes with no type variables

### DIFF
--- a/spec/compiler/codegen/multi_assign_spec.cr
+++ b/spec/compiler/codegen/multi_assign_spec.cr
@@ -106,7 +106,7 @@ describe "Code gen: multi assign" do
       #{tuple_new}
 
       _, *x, _ = 1, 2
-      x.is_a?(Tuple(*typeof(Tuple.new)))
+      x.is_a?(Tuple())
       CR
   end
 
@@ -115,7 +115,7 @@ describe "Code gen: multi assign" do
       #{tuple_new}
 
       *x, _, _ = 1, 2
-      x.is_a?(Tuple(*typeof(Tuple.new)))
+      x.is_a?(Tuple())
       CR
   end
 
@@ -124,7 +124,7 @@ describe "Code gen: multi assign" do
       #{tuple_new}
 
       _, _, *x = 1, 2
-      x.is_a?(Tuple(*typeof(Tuple.new)))
+      x.is_a?(Tuple())
       CR
   end
 
@@ -162,7 +162,7 @@ describe "Code gen: multi assign" do
       require "prelude"
 
       _, *x, _ = {1, 2}
-      x.is_a?(Tuple(*typeof(Tuple.new)))
+      x.is_a?(Tuple())
       CR
   end
 
@@ -173,7 +173,7 @@ describe "Code gen: multi assign" do
       #{include_indexable}
 
       *x, _, _ = {1, 2}
-      x.is_a?(Tuple(*typeof(Tuple.new)))
+      x.is_a?(Tuple())
       CR
   end
 
@@ -184,7 +184,7 @@ describe "Code gen: multi assign" do
       #{include_indexable}
 
       _, _, *x = {1, 2}
-      x.is_a?(Tuple(*typeof(Tuple.new)))
+      x.is_a?(Tuple())
       CR
   end
 

--- a/spec/compiler/formatter/formatter_spec.cr
+++ b/spec/compiler/formatter/formatter_spec.cr
@@ -129,10 +129,12 @@ describe Crystal::Formatter do
   assert_format "Foo:: Bar", "Foo::Bar"
   assert_format "Foo:: Bar", "Foo::Bar"
   assert_format "::Foo:: Bar", "::Foo::Bar"
+  assert_format "Foo(  )", "Foo()"
   assert_format "Foo( A , 1 )", "Foo(A, 1)"
   assert_format "Foo( x:  Int32  )", "Foo(x: Int32)"
   assert_format "Foo( x:  Int32  ,  y: Float64 )", "Foo(x: Int32, y: Float64)"
   assert_format "Foo(  * T, { * A  ,*\n  B } )", "Foo(*T, {*A, *B})"
+  assert_format "Foo( Bar(  ) )", "Foo(Bar())"
 
   assert_format "NamedTuple(a: Int32,)", "NamedTuple(a: Int32)"
   assert_format "NamedTuple(\n  a: Int32,\n)"

--- a/spec/compiler/macro/macro_methods_spec.cr
+++ b/spec/compiler/macro/macro_methods_spec.cr
@@ -1645,6 +1645,20 @@ module Crystal
         assert_macro("{{x.type_vars.map &.stringify}}", %(["A", "B"])) do |program|
           {x: TypeNode.new(GenericClassType.new(program, program, "SomeType", program.object, ["A", "B"]))}
         end
+        assert_macro("{{x.type_vars.map &.stringify}}", %(["Int32", "String"])) do |program|
+          generic_class = GenericClassType.new(program, program, "SomeType", program.object, ["A", "B"])
+          {x: TypeNode.new(generic_class.instantiate([program.int32, program.string] of TypeVar))}
+        end
+        assert_macro("{{x.type_vars.map &.stringify}}", %(["Tuple(Int32, String)"])) do |program|
+          generic_class = GenericClassType.new(program, program, "SomeType", program.object, ["T"])
+          generic_class.splat_index = 0
+          {x: TypeNode.new(generic_class.instantiate([program.int32, program.string] of TypeVar))}
+        end
+        assert_macro("{{x.type_vars.map &.stringify}}", %(["Tuple()"])) do |program|
+          generic_class = GenericClassType.new(program, program, "SomeType", program.object, ["T"])
+          generic_class.splat_index = 0
+          {x: TypeNode.new(generic_class.instantiate([] of TypeVar))}
+        end
       end
 
       it "executes class" do
@@ -2668,6 +2682,7 @@ module Crystal
 
       it "executes type_vars" do
         assert_macro %({{x.type_vars}}), "[T, U]", {x: Generic.new("Foo".path, ["T".path, "U".path] of ASTNode)}
+        assert_macro %({{x.type_vars}}), "[]", {x: Generic.new("Foo".path, [] of ASTNode)}
       end
 
       it "executes named_args" do

--- a/spec/compiler/parser/parser_spec.cr
+++ b/spec/compiler/parser/parser_spec.cr
@@ -578,6 +578,7 @@ module Crystal
     it_parses "class Foo(Type); end", ClassDef.new("Foo".path, type_vars: ["Type"])
     it_parses "abstract class Foo; end", ClassDef.new("Foo".path, abstract: true)
     it_parses "abstract struct Foo; end", ClassDef.new("Foo".path, abstract: true, struct: true)
+    assert_syntax_error "class Foo(); end", "must specify at least one type var"
 
     it_parses "class Foo < self; end", ClassDef.new("Foo".path, superclass: Self.new)
 
@@ -592,9 +593,11 @@ module Crystal
 
     it_parses "struct Foo; end", ClassDef.new("Foo".path, struct: true)
 
+    it_parses "Foo()", Generic.new("Foo".path, [] of ASTNode)
     it_parses "Foo(T)", Generic.new("Foo".path, ["T".path] of ASTNode)
     it_parses "Foo(T | U)", Generic.new("Foo".path, [Crystal::Union.new(["T".path, "U".path] of ASTNode)] of ASTNode)
     it_parses "Foo(Bar(T | U))", Generic.new("Foo".path, [Generic.new("Bar".path, [Crystal::Union.new(["T".path, "U".path] of ASTNode)] of ASTNode)] of ASTNode)
+    it_parses "Foo(Bar())", Generic.new("Foo".path, [Generic.new("Bar".path, [] of ASTNode)] of ASTNode)
     it_parses "Foo(T?)", Generic.new("Foo".path, [Crystal::Union.new(["T".path, Path.global("Nil")] of ASTNode)] of ASTNode)
     it_parses "Foo(1)", Generic.new("Foo".path, [1.int32] of ASTNode)
     it_parses "Foo(T, 1)", Generic.new("Foo".path, ["T".path, 1.int32] of ASTNode)
@@ -639,6 +642,7 @@ module Crystal
     it_parses "Foo(X, instance_sizeof(Int32))", Generic.new("Foo".path, ["X".path, InstanceSizeOf.new("Int32".path)] of ASTNode)
     it_parses "Foo(X, offsetof(Foo, @a))", Generic.new("Foo".path, ["X".path, OffsetOf.new("Foo".path, "@a".instance_var)] of ASTNode)
 
+    it_parses "Foo(\n)", Generic.new("Foo".path, [] of ASTNode)
     it_parses "Foo(\nT\n)", Generic.new("Foo".path, ["T".path] of ASTNode)
     it_parses "Foo(\nT,\nU,\n)", Generic.new("Foo".path, ["T".path, "U".path] of ASTNode)
     it_parses "Foo(\nx:\nT,\ny:\nU,\n)", Generic.new("Foo".path, [] of ASTNode, named_args: [NamedArgument.new("x", "T".path), NamedArgument.new("y", "U".path)])
@@ -1273,6 +1277,10 @@ module Crystal
     it_parses "a : Foo*", TypeDeclaration.new("a".var, Generic.new("Pointer".path(global: true), ["Foo".path] of ASTNode, suffix: Generic::Suffix::Asterisk))
     it_parses "a : Foo[12]", TypeDeclaration.new("a".var, Generic.new("StaticArray".path(global: true), ["Foo".path, 12.int32] of ASTNode, suffix: Generic::Suffix::Bracket))
 
+    it_parses "Foo()?", Generic.new("Union".path(global: true), [Generic.new("Foo".path, [] of ASTNode), "Nil".path(global: true)] of ASTNode)
+    it_parses "a : Foo()*", TypeDeclaration.new("a".var, Generic.new("Pointer".path(global: true), [Generic.new("Foo".path, [] of ASTNode)] of ASTNode, suffix: Generic::Suffix::Asterisk))
+    it_parses "a : Foo()[12]", TypeDeclaration.new("a".var, Generic.new("StaticArray".path(global: true), [Generic.new("Foo".path, [] of ASTNode), 12.int32] of ASTNode, suffix: Generic::Suffix::Bracket))
+
     it_parses "a = uninitialized Foo; a", [UninitializedVar.new("a".var, "Foo".path), "a".var]
     it_parses "@a = uninitialized Foo", UninitializedVar.new("@a".instance_var, "Foo".path)
     it_parses "@@a = uninitialized Foo", UninitializedVar.new("@@a".class_var, "Foo".path)
@@ -1478,6 +1486,7 @@ module Crystal
     it_parses "def foo(bar = 1\n); 2; end", Def.new("foo", [Arg.new("bar", default_value: 1.int32)], 2.int32)
 
     it_parses "Set {1, 2, 3}", ArrayLiteral.new([1.int32, 2.int32, 3.int32] of ASTNode, name: "Set".path)
+    it_parses "Set() {1, 2, 3}", ArrayLiteral.new([1.int32, 2.int32, 3.int32] of ASTNode, name: Generic.new("Set".path, [] of ASTNode))
     it_parses "Set(Int32) {1, 2, 3}", ArrayLiteral.new([1.int32, 2.int32, 3.int32] of ASTNode, name: Generic.new("Set".path, ["Int32".path] of ASTNode))
 
     describe "single splats inside container literals" do

--- a/spec/compiler/parser/to_s_spec.cr
+++ b/spec/compiler/parser/to_s_spec.cr
@@ -100,6 +100,7 @@ describe "ASTNode#to_s" do
   expect_to_s "def foo(x y)\nend"
   expect_to_s %(foo("bar baz": 2))
   expect_to_s %(Foo("bar baz": Int32))
+  expect_to_s %(Foo())
   expect_to_s %({"foo bar": 1})
   expect_to_s %(def foo("bar baz" qux)\nend)
   expect_to_s "foo()"

--- a/src/compiler/crystal/syntax/parser.cr
+++ b/src/compiler/crystal/syntax/parser.cr
@@ -4994,7 +4994,7 @@ module Crystal
       args = [] of ASTNode
       if named_tuple_start? || string_literal_start?
         named_args = parse_named_type_args(:OP_RPAREN)
-      else
+      elsif !@token.type.op_rparen?
         args << parse_type_splat { parse_type_arg }
         while @token.type.op_comma?
           next_token_skip_space_or_newline

--- a/src/named_tuple.cr
+++ b/src/named_tuple.cr
@@ -42,6 +42,7 @@ struct NamedTuple
       options
     {% elsif @type.name(generic_args: false) == "NamedTuple()" %}
       # special case: empty named tuple
+      # TODO: check against `NamedTuple()` directly after 1.4.0
       options
     {% else %}
       # explicitly provided type vars

--- a/src/tuple.cr
+++ b/src/tuple.cr
@@ -94,6 +94,7 @@ struct Tuple
       args
     {% elsif @type.name(generic_args: false) == "Tuple()" %}
       # special case: empty tuple
+      # TODO: check against `Tuple()` directly after 1.4.0
       args
     {% else %}
       # explicitly provided type vars


### PR DESCRIPTION
Resolves #10204.

This is purely a syntax enhancement and requires no changes outside the parser. It is already possible to obtain generic instances that have no type variables even before this PR, such as via `Tuple.new`; even for `Generic` nodes, all instantiations of `NamedTuple` return an empty array in `#type_vars`. (In contrast, `resolve.type_vars` returns a 1-array of the `NamedTuple` or `Tuple` itself.)

At the lexical level, a constant followed by a pair of empty parentheses can currently appear only in the following places:

```crystal
lib Foo
  fun Foo() # lib fun definition
end

Foo.Foo() # lib fun call

fun bar = Bar() # global fun definition
end

annotation Ann; end

@[Ann()] # annotation with no arguments
def ann; end
```

The formatter removes the parentheses in all these cases. However, if we look at all empty parentheses in general, then we can see that this is not done for `Call`s because they could be incorrectly turned into `Var`s. In this PR the formatter never removes the parentheses in a `Generic` without type variables. Also note that in the following example:

```crystal
class Foo(); end # Error: must specify at least one type var
```

the compiler never materializes any `Generic`, because the parser handles this separately in `#parse_type_vars` and the corresponding `ClassDef` / `ModuleDef` stores the formal parameters outside the type name.