### PR TITLE
Improve error for incompatible generic arguments for `WeakRef`

### DIFF
--- a/spec/std/weak_ref_spec.cr
+++ b/spec/std/weak_ref_spec.cr
@@ -1,5 +1,6 @@
 require "spec"
 require "weak_ref"
+require "../spec_helper"
 require "../support/finalize"
 
 private class Foo
@@ -65,5 +66,20 @@ describe WeakRef do
 
     # Use `last` to stop the variable from being optimised away in release mode.
     last.to_s
+  end
+
+  it "errors if weak referenced object is a module" do
+    assert_error %(
+      require "prelude"
+      require "weak_ref"
+      module M; end
+      class A; include M; end
+      class B
+        @foo : WeakRef(M)
+        def initialize(thing); @foo = WeakRef.new(thing.as(M)); end
+      end
+      B.new(A.new)
+      ),
+      "Cannot create a WeakRef of a module"
   end
 end

--- a/spec/std/weak_ref_spec.cr
+++ b/spec/std/weak_ref_spec.cr
@@ -1,6 +1,5 @@
 require "spec"
 require "weak_ref"
-require "../spec_helper"
 require "../support/finalize"
 
 private class Foo
@@ -66,20 +65,5 @@ describe WeakRef do
 
     # Use `last` to stop the variable from being optimised away in release mode.
     last.to_s
-  end
-
-  it "errors if weak referenced object is a module" do
-    assert_error %(
-      require "prelude"
-      require "weak_ref"
-      module M; end
-      class A; include M; end
-      class B
-        @foo : WeakRef(M)
-        def initialize(thing); @foo = WeakRef.new(thing.as(M)); end
-      end
-      B.new(A.new)
-      ),
-      "Cannot create a WeakRef of a module"
   end
 end

--- a/src/weak_ref.cr
+++ b/src/weak_ref.cr
@@ -1,5 +1,7 @@
 # Weak Reference class that allows a referenced object to be garbage-collected.
 #
+# WARNING: The referenced object cannot be a module.
+#
 # ```
 # require "weak_ref"
 #
@@ -12,6 +14,8 @@ class WeakRef(T)
   @target : Void*
 
   def initialize(target : T)
+    {% raise "Cannot create a WeakRef of a module" if T.module? %}
+
     @target = target.as(Void*)
     if GC.is_heap_ptr(@target)
       GC.register_disappearing_link(pointerof(@target))


### PR DESCRIPTION
This is a re-issue of #11836 with the faulty spec removed (https://github.com/crystal-lang/crystal/pull/11836#issuecomment-1055644403).
We can live without this spec for a trivial feature.

Resolves #11833
The original change was reverted in https://github.com/crystal-lang/crystal/pull/11863