### PR TITLE
Evaluate `LibLLVM::IS_LT_*` during macro expansion time

### DIFF
--- a/src/compiler/crystal/codegen/debug.cr
+++ b/src/compiler/crystal/codegen/debug.cr
@@ -36,7 +36,7 @@ module Crystal
       if @program.has_flag?("windows")
         # Windows uses CodeView instead of DWARF
         mod.add_flag(
-          LLVM::ModuleFlag::Warning,
+          LibLLVM::ModuleFlagBehavior::Warning,
           "CodeView",
           mod.context.int32.const_int(1)
         )
@@ -44,14 +44,14 @@ module Crystal
         # DebugInfo generation in LLVM by default uses a higher version of dwarf
         # than OS X currently understands. Android has the same problem.
         mod.add_flag(
-          LLVM::ModuleFlag::Warning,
+          LibLLVM::ModuleFlagBehavior::Warning,
           "Dwarf Version",
           mod.context.int32.const_int(2)
         )
       end
 
       mod.add_flag(
-        LLVM::ModuleFlag::Warning,
+        LibLLVM::ModuleFlagBehavior::Warning,
         "Debug Info Version",
         mod.context.int32.const_int(LLVM::DEBUG_METADATA_VERSION)
       )

--- a/src/llvm/enums.cr
+++ b/src/llvm/enums.cr
@@ -454,10 +454,6 @@ module LLVM
     end
   end
 
-  enum ModuleFlag : Int32
-    Warning = 2
-  end
-
   struct Metadata
     enum Type : UInt32
       Dbg                   =  0 # "dbg"

--- a/src/llvm/lib_llvm.cr
+++ b/src/llvm/lib_llvm.cr
@@ -17,8 +17,8 @@ end
   end
 {% end %}
 
-{% begin %}
-  lib LibLLVM
+lib LibLLVM
+  {% begin %}
     IS_130 = {{LibLLVM::VERSION.starts_with?("13.0")}}
     IS_120 = {{LibLLVM::VERSION.starts_with?("12.0")}}
     IS_111 = {{LibLLVM::VERSION.starts_with?("11.1")}}
@@ -33,16 +33,18 @@ end
     IS_40 = {{LibLLVM::VERSION.starts_with?("4.0")}}
     IS_39 = {{LibLLVM::VERSION.starts_with?("3.9")}}
     IS_38 = {{LibLLVM::VERSION.starts_with?("3.8")}}
+  {% end %}
 
-    IS_LT_70 = IS_38 || IS_39 || IS_40 || IS_50 || IS_60
-    IS_LT_80 = IS_LT_70 || IS_70 || IS_71
-    IS_LT_90 = IS_LT_80 || IS_80
-    IS_LT_100 = IS_LT_90 || IS_90
-    IS_LT_110 = IS_LT_100 || IS_100
-    IS_LT_120 = IS_LT_110 || IS_110 || IS_111
-    IS_LT_130 = IS_LT_120 || IS_120
-  end
-{% end %}
+  {% begin %}
+    IS_LT_70 = {{IS_38 || IS_39 || IS_40 || IS_50 || IS_60}}
+    IS_LT_80 = {{IS_38 || IS_39 || IS_40 || IS_50 || IS_60 || IS_70 || IS_71}}
+    IS_LT_90 = {{IS_38 || IS_39 || IS_40 || IS_50 || IS_60 || IS_70 || IS_71 || IS_80}}
+    IS_LT_100 = {{IS_38 || IS_39 || IS_40 || IS_50 || IS_60 || IS_70 || IS_71 || IS_80 || IS_90}}
+    IS_LT_110 = {{IS_38 || IS_39 || IS_40 || IS_50 || IS_60 || IS_70 || IS_71 || IS_80 || IS_90 || IS_100}}
+    IS_LT_120 = {{IS_38 || IS_39 || IS_40 || IS_50 || IS_60 || IS_70 || IS_71 || IS_80 || IS_90 || IS_100 || IS_110 || IS_111}}
+    IS_LT_130 = {{IS_38 || IS_39 || IS_40 || IS_50 || IS_60 || IS_70 || IS_71 || IS_80 || IS_90 || IS_100 || IS_110 || IS_111 || IS_120}}
+  {% end %}
+end
 
 lib LibLLVM
   alias Char = LibC::Char
@@ -80,13 +82,18 @@ lib LibLLVM
     end
   {% end %}
 
+  # `LLVMModuleFlagBehavior` (_not_ `LLVM::Module::ModFlagBehavior`, their values disagree)
+  enum ModuleFlagBehavior
+    Warning = 1
+  end
+
   fun add_case = LLVMAddCase(switch : ValueRef, onval : ValueRef, dest : BasicBlockRef)
   fun add_clause = LLVMAddClause(lpad : ValueRef, clause_val : ValueRef)
   fun add_function = LLVMAddFunction(module : ModuleRef, name : UInt8*, type : TypeRef) : ValueRef
   fun add_global = LLVMAddGlobal(module : ModuleRef, type : TypeRef, name : UInt8*) : ValueRef
   fun add_incoming = LLVMAddIncoming(phi_node : ValueRef, incoming_values : ValueRef*, incoming_blocks : BasicBlockRef*, count : Int32)
   {% unless LibLLVM::IS_LT_70 %}
-    fun add_module_flag = LLVMAddModuleFlag(mod : ModuleRef, behavior : ModuleFlag, key : UInt8*, len : LibC::SizeT, val : MetadataRef)
+    fun add_module_flag = LLVMAddModuleFlag(mod : ModuleRef, behavior : ModuleFlagBehavior, key : UInt8*, len : LibC::SizeT, val : MetadataRef)
   {% end %}
   fun add_named_metadata_operand = LLVMAddNamedMetadataOperand(mod : ModuleRef, name : UInt8*, val : ValueRef)
   fun add_target_dependent_function_attr = LLVMAddTargetDependentFunctionAttr(fn : ValueRef, a : LibC::Char*, v : LibC::Char*)
@@ -397,7 +404,7 @@ lib LibLLVM
   fun md_string_in_context = LLVMMDStringInContext(c : ContextRef, str : UInt8*, length : Int32) : ValueRef
 
   {% unless LibLLVM::IS_LT_70 %}
-    fun metadata_as_value = LLVMMetadataAsValue(c : ContextRef, md : MetadataRef) : ValueRef
+    fun value_as_metadata = LLVMValueAsMetadata(val : ValueRef) : MetadataRef
   {% end %}
 
   fun append_basic_block_in_context = LLVMAppendBasicBlockInContext(ctx : ContextRef, fn : ValueRef, name : UInt8*) : BasicBlockRef

--- a/src/llvm/lib_llvm.cr
+++ b/src/llvm/lib_llvm.cr
@@ -17,8 +17,8 @@ end
   end
 {% end %}
 
-lib LibLLVM
-  {% begin %}
+{% begin %}
+  lib LibLLVM
     IS_130 = {{LibLLVM::VERSION.starts_with?("13.0")}}
     IS_120 = {{LibLLVM::VERSION.starts_with?("12.0")}}
     IS_111 = {{LibLLVM::VERSION.starts_with?("11.1")}}
@@ -33,18 +33,16 @@ lib LibLLVM
     IS_40 = {{LibLLVM::VERSION.starts_with?("4.0")}}
     IS_39 = {{LibLLVM::VERSION.starts_with?("3.9")}}
     IS_38 = {{LibLLVM::VERSION.starts_with?("3.8")}}
-  {% end %}
 
-  {% begin %}
-    IS_LT_70 = {{IS_38 || IS_39 || IS_40 || IS_50 || IS_60}}
-    IS_LT_80 = {{IS_38 || IS_39 || IS_40 || IS_50 || IS_60 || IS_70 || IS_71}}
-    IS_LT_90 = {{IS_38 || IS_39 || IS_40 || IS_50 || IS_60 || IS_70 || IS_71 || IS_80}}
-    IS_LT_100 = {{IS_38 || IS_39 || IS_40 || IS_50 || IS_60 || IS_70 || IS_71 || IS_80 || IS_90}}
-    IS_LT_110 = {{IS_38 || IS_39 || IS_40 || IS_50 || IS_60 || IS_70 || IS_71 || IS_80 || IS_90 || IS_100}}
-    IS_LT_120 = {{IS_38 || IS_39 || IS_40 || IS_50 || IS_60 || IS_70 || IS_71 || IS_80 || IS_90 || IS_100 || IS_110 || IS_111}}
-    IS_LT_130 = {{IS_38 || IS_39 || IS_40 || IS_50 || IS_60 || IS_70 || IS_71 || IS_80 || IS_90 || IS_100 || IS_110 || IS_111 || IS_120}}
-  {% end %}
-end
+    IS_LT_70 = {{compare_versions(LibLLVM::VERSION, "7.0.0") < 0}}
+    IS_LT_80 = {{compare_versions(LibLLVM::VERSION, "8.0.0") < 0}}
+    IS_LT_90 = {{compare_versions(LibLLVM::VERSION, "9.0.0") < 0}}
+    IS_LT_100 = {{compare_versions(LibLLVM::VERSION, "10.0.0") < 0}}
+    IS_LT_110 = {{compare_versions(LibLLVM::VERSION, "11.0.0") < 0}}
+    IS_LT_120 = {{compare_versions(LibLLVM::VERSION, "12.0.0") < 0}}
+    IS_LT_130 = {{compare_versions(LibLLVM::VERSION, "13.0.0") < 0}}
+  end
+{% end %}
 
 lib LibLLVM
   alias Char = LibC::Char

--- a/src/llvm/module.cr
+++ b/src/llvm/module.cr
@@ -55,7 +55,7 @@ class LLVM::Module
     GlobalCollection.new(self)
   end
 
-  def add_flag(module_flag : ModuleFlag, key : String, val : Value)
+  def add_flag(module_flag : LibLLVM::ModuleFlagBehavior, key : String, val : Value)
     {% if LibLLVM::IS_LT_70 %}
       values = [
         context.int32.const_int(module_flag.value),
@@ -70,7 +70,7 @@ class LLVM::Module
         module_flag,
         key,
         key.bytesize,
-        LibLLVM.metadata_as_value(val.to_unsafe)
+        LibLLVM.value_as_metadata(val.to_unsafe)
       )
     {% end %}
   end

--- a/src/llvm/type.cr
+++ b/src/llvm/type.cr
@@ -173,7 +173,7 @@ struct LLVM::Type
           constraints.size,
           (has_side_effects ? 1 : 0),
           (is_align_stack ? 1 : 0),
-          LibLLVM::InlineAsmDialect::Intel
+          LibLLVM::InlineAsmDialect::ATT
         )
       {% else %}
         LibLLVM.get_inline_asm(
@@ -184,7 +184,7 @@ struct LLVM::Type
           constraints.size,
           (has_side_effects ? 1 : 0),
           (is_align_stack ? 1 : 0),
-          LibLLVM::InlineAsmDialect::Intel,
+          LibLLVM::InlineAsmDialect::ATT,
           (can_throw ? 1 : 0)
         )
       {% end %}


### PR DESCRIPTION
Fixes #11415.

~~The long `||` chains are deliberate. I think they look clearer when the `IS_LT_*` constants do not depend on each other.~~