### PR TITLE
Ignore `CRYSTAL_OPTS` on non-compiler commands

### DIFF
--- a/src/compiler/crystal/command/docs.cr
+++ b/src/compiler/crystal/command/docs.cr
@@ -16,7 +16,7 @@ class Crystal::Command
 
     compiler = new_compiler
 
-    parse_with_crystal_opts do |opts|
+    OptionParser.parse(@options) do |opts|
       opts.banner = <<-'BANNER'
         Usage: crystal docs [options]
 

--- a/src/compiler/crystal/command/env.cr
+++ b/src/compiler/crystal/command/env.cr
@@ -4,7 +4,7 @@ class Crystal::Command
   private def env
     var_names = [] of String
 
-    parse_with_crystal_opts do |opts|
+    OptionParser.parse(@options) do |opts|
       opts.banner = env_usage
 
       opts.on("-h", "--help", "Show this message") do

--- a/src/compiler/crystal/command/format.cr
+++ b/src/compiler/crystal/command/format.cr
@@ -10,7 +10,7 @@ class Crystal::Command
     check = false
     show_backtrace = false
 
-    parse_with_crystal_opts do |opts|
+    OptionParser.parse(@options) do |opts|
       opts.banner = "Usage: crystal tool format [options] [file or directory]\n\nOptions:"
 
       opts.on("--check", "Checks that formatting code produces no changes") do |f|

--- a/src/compiler/crystal/command/playground.cr
+++ b/src/compiler/crystal/command/playground.cr
@@ -7,7 +7,7 @@ class Crystal::Command
   private def playground
     server = Playground::Server.new
 
-    parse_with_crystal_opts do |opts|
+    OptionParser.parse(@options) do |opts|
       opts.banner = "Usage: crystal play [options] [file]\n\nOptions:"
 
       opts.on("-p PORT", "--port PORT", "Runs the playground on the specified port") do |port|

--- a/src/compiler/crystal/tools/init.cr
+++ b/src/compiler/crystal/tools/init.cr
@@ -41,7 +41,7 @@ module Crystal
     def self.parse_args(args)
       config = Config.new
 
-      Crystal::Command.parse_with_crystal_opts(args) do |opts|
+      OptionParser.parse(args) do |opts|
         opts.banner = <<-USAGE
           Usage: crystal init TYPE (DIR | NAME DIR)
 


### PR DESCRIPTION
Resolves #11919.

Tools (except `format`) are still considered compiler commands, so they will continue to parse `CRYSTAL_OPTS`.