### PR TITLE
Samples: avoid `Symbol` variables

### DIFF
--- a/samples/degree_days.cr
+++ b/samples/degree_days.cr
@@ -1,7 +1,7 @@
 # Copied with little modifications from: https://github.com/rubinius/rubinius-benchmark/blob/master/real_world/bench_degree_days.rb
 
 class DegreeDays
-  def initialize(@daily_temperatures : Array(Array(Int32)), @options = {} of Symbol => Float64)
+  def initialize(@daily_temperatures : Array(Array(Int32)), @options = {} of String => Float64)
   end
 
   property :daily_temperatures
@@ -28,10 +28,10 @@ class DegreeDays
     end
 
     {
-      :heating      => heating,
-      :cooling      => cooling,
-      :heating_days => heating_days,
-      :cooling_days => cooling_days,
+      "heating"      => heating,
+      "cooling"      => cooling,
+      "heating_days" => heating_days,
+      "cooling_days" => cooling_days,
     }
   end
 
@@ -64,31 +64,31 @@ class DegreeDays
   end
 
   private def base_temperature
-    @options[:base_temperature]? || 65.0
+    @options["base_temperature"]? || 65.0
   end
 
   private def heating_insulation
-    @options[:heating_insulation]? || insulation_factor || 3
+    @options["heating_insulation"]? || insulation_factor || 3
   end
 
   private def cooling_insulation
-    @options[:cooling_insulation]? || insulation_factor || 0
+    @options["cooling_insulation"]? || insulation_factor || 0
   end
 
   private def insulation_factor
-    @options[:insulation_factor]?
+    @options["insulation_factor"]?
   end
 
   private def heating_threshold
-    @options[:heating_threshold]? || threshold || 6
+    @options["heating_threshold"]? || threshold || 6
   end
 
   private def cooling_threshold
-    @options[:cooling_threshold]? || threshold || 3
+    @options["cooling_threshold"]? || threshold || 3
   end
 
   private def threshold
-    @options[:threshold]?
+    @options["threshold"]?
   end
 end
 

--- a/samples/sdl/fire.cr
+++ b/samples/sdl/fire.cr
@@ -67,7 +67,13 @@ class MainPoint < Point
   MAX_TAIL_ANGLE = Math::PI / 3
   TAIL_SPEED     = 0.05
 
+  enum Direction
+    Plus
+    Minus
+  end
+
   @tail_angle : Float64
+  @tail_direction : Direction
 
   def initialize(x, y, angle, speed, color_pattern)
     super
@@ -102,7 +108,7 @@ class MainPoint < Point
     points.make(@x, @y, Math::PI + @angle + @tail_angle, @speed, @color_pattern.child)
     points.make(@x, @y, Math::PI + @angle - @tail_angle, @speed, @color_pattern.child)
 
-    if @tail_direction == :plus
+    if @tail_direction.plus?
       @tail_angle += TAIL_SPEED
       if @tail_angle >= MAX_TAIL_ANGLE
         @tail_angle = MAX_TAIL_ANGLE


### PR DESCRIPTION
`degree_days.cr` isn't really how idiomatic Crystal code works, but it seems the intent is to match the original Ruby code as closely as possible, so the `@options` `Hash` remains.