### PR TITLE
Fix infinite loop for certain `StringPool` initial capacities

### DIFF
--- a/spec/std/string_pool_spec.cr
+++ b/spec/std/string_pool_spec.cr
@@ -73,4 +73,20 @@ describe StringPool do
     s1.should be(s2)
     pool.size.should eq(1)
   end
+
+  it "doesn't fail if initial capacity is too small" do
+    pool = StringPool.new(initial_capacity: 0)
+    100.times do |i|
+      pool.get(i.to_s)
+    end
+    pool.size.should eq(100)
+  end
+
+  it "doesn't fail if initial capacity is not a power of 2" do
+    pool = StringPool.new(initial_capacity: 17)
+    100.times do |i|
+      pool.get(i.to_s)
+    end
+    pool.size.should eq(100)
+  end
 end

--- a/src/string_pool.cr
+++ b/src/string_pool.cr
@@ -38,13 +38,14 @@ class StringPool
   # of the internal buffers in case of growth. If you have an estimate
   # of the maximum number of elements the pool will hold it should
   # be initialized with that capacity for improved performance.
+  # Inputs lower than 8 are ignored.
   #
   # ```
   # pool = StringPool.new(256)
   # pool.size # => 0
   # ```
   def initialize(initial_capacity = 8)
-    @capacity = initial_capacity
+    @capacity = initial_capacity >= 8 ? Math.pw2ceil(initial_capacity) : 8
     @hashes = Pointer(UInt64).malloc(@capacity, 0_u64)
     @values = Pointer(String).malloc(@capacity, "")
     @size = 0


### PR DESCRIPTION
If the initial capacity passed to `StringPool#initialize` is not a power of 2, quadratic probing will not iterate over the entire pool. In fact, due to our probing implementation:

```crystal
rehash if @size >= @capacity // 4 * 3

mask = (@capacity - 1).to_u64
index = hash & mask
next_probe_offset = 1_u64
while (h = @hashes[index]) != 0
  # ...
  index = (index + next_probe_offset) & mask
  next_probe_offset += 1_u64
end
```

if `@capacity` is 1 plus a power of 2, then only two elements are ever traversed (the first and the last), and any attempt to get more than 2 strings will lead to an infinite loop:

```crystal
pool = StringPool.new(17)
pool.get("a")
pool.get("b")
pool.get("c") # does not terminate
```

This PR ensures `@capacity` is a large enough power of 2. A similar treatment is already done for `Hash` and `IO::Memory`.