### PR TITLE
Use `&.itself` instead of explicit blocks

### DIFF
--- a/samples/noise.cr
+++ b/samples/noise.cr
@@ -23,7 +23,7 @@ end
 struct Noise2DContext
   def initialize
     @rgradients = StaticArray(Vec2, 256).new { random_gradient }
-    @permutations = StaticArray(Int32, 256).new { |i| i }
+    @permutations = StaticArray(Int32, 256).new &.itself
     @permutations.shuffle!
   end
 

--- a/src/array.cr
+++ b/src/array.cr
@@ -2129,7 +2129,7 @@ class Array(T)
   end
 
   protected def to_lookup_hash
-    to_lookup_hash { |elem| elem }
+    to_lookup_hash &.itself
   end
 
   protected def to_lookup_hash(& : T -> U) forall U

--- a/src/compiler/crystal/macros/methods.cr
+++ b/src/compiler/crystal/macros/methods.cr
@@ -1259,7 +1259,7 @@ module Crystal
       case method
       when "expressions"
         interpret_check_args do
-          ArrayLiteral.map(@expressions) { |expression| expression }
+          ArrayLiteral.map(@expressions, &.itself)
         end
       else
         super
@@ -1956,7 +1956,7 @@ module Crystal
       when "named_args"
         interpret_check_args do
           if named_args = self.named_args
-            ArrayLiteral.map(named_args) { |arg| arg }
+            ArrayLiteral.map(named_args, &.itself)
           else
             Nop.new
           end

--- a/src/compiler/crystal/semantic/main_visitor.cr
+++ b/src/compiler/crystal/semantic/main_visitor.cr
@@ -2206,7 +2206,7 @@ module Crystal
     # This also applies to 'while' conditions and also
     # to the else part of an if, but with filters inverted.
     def filter_vars(filters)
-      filter_vars(filters) { |filter| filter }
+      filter_vars(filters, &.itself)
     end
 
     def filter_vars(filters)

--- a/src/compiler/crystal/semantic/type_merge.cr
+++ b/src/compiler/crystal/semantic/type_merge.cr
@@ -72,7 +72,7 @@ module Crystal
     end
 
     def compact_types(types)
-      compact_types(types) { |type| type }
+      compact_types(types, &.itself)
     end
 
     def compact_types(objects)

--- a/src/levenshtein.cr
+++ b/src/levenshtein.cr
@@ -25,7 +25,7 @@ module Levenshtein
       t_size, s_size = s_size, t_size
     end
 
-    costs = Slice(Int32).new(t_size + 1) { |i| i }
+    costs = Slice(Int32).new(t_size + 1, &.itself)
     last_cost = 0
 
     if string1.single_byte_optimizable? && string2.single_byte_optimizable?

--- a/src/socket.cr
+++ b/src/socket.cr
@@ -71,7 +71,7 @@ class Socket < IO
   # ```
   def connect(host : String, port : Int, connect_timeout = nil) : Nil
     Addrinfo.resolve(host, port, @family, @type, @protocol) do |addrinfo|
-      connect(addrinfo, timeout: connect_timeout) { |error| error }
+      connect(addrinfo, timeout: connect_timeout, &.itself)
     end
   end
 
@@ -103,7 +103,7 @@ class Socket < IO
   # ```
   def bind(host : String, port : Int) : Nil
     Addrinfo.resolve(host, port, @family, @type, @protocol) do |addrinfo|
-      system_bind(addrinfo, "#{host}:#{port}") { |errno| errno }
+      system_bind(addrinfo, "#{host}:#{port}", &.itself)
     end
   end
 
@@ -117,7 +117,7 @@ class Socket < IO
   # ```
   def bind(port : Int)
     Addrinfo.resolve("::", port, @family, @type, @protocol) do |addrinfo|
-      system_bind(addrinfo, "::#{port}") { |errno| errno }
+      system_bind(addrinfo, "::#{port}", &.itself)
     end
   end
 

--- a/src/socket/tcp_server.cr
+++ b/src/socket/tcp_server.cr
@@ -38,12 +38,12 @@ class TCPServer < TCPSocket
       self.reuse_address = true
       self.reuse_port = true if reuse_port
 
-      if errno = system_bind(addrinfo, "#{host}:#{port}") { |errno| errno }
+      if errno = system_bind(addrinfo, "#{host}:#{port}", &.itself)
         close
         next errno
       end
 
-      if errno = listen(backlog) { |errno| errno }
+      if errno = listen(backlog, &.itself)
         close
         next errno
       end


### PR DESCRIPTION
This is a tiny refactor to increase the usage of `&.itself` instead of blocks with an explicitly named variable.

I left out changes to this pattern in spec code (I can do them too if desired).