### PR TITLE
Use `be_empty` expectations in more specs

### DIFF
--- a/spec/compiler/crystal/tools/doc/type_spec.cr
+++ b/spec/compiler/crystal/tools/doc/type_spec.cr
@@ -164,7 +164,7 @@ describe Doc::Type do
     generator = Doc::Generator.new program, [""]
     macros_module = program.types["Crystal"].types["Macros"]
     astnode = generator.type(macros_module.types["ASTNode"])
-    astnode.ancestors.empty?.should be_true
+    astnode.ancestors.should be_empty
     # Sanity check: subclasses of ASTNode has the right ancestors
     generator.type(macros_module.types["Arg"]).ancestors.should eq([astnode])
   end

--- a/spec/compiler/crystal/tools/format_spec.cr
+++ b/spec/compiler/crystal/tools/format_spec.cr
@@ -21,7 +21,7 @@ describe Crystal::Command::FormatCommand do
     format_command.run
     format_command.status_code.should eq(0)
     stdout.to_s.should eq("if true\n  1\nend\n")
-    stderr.to_s.empty?.should be_true
+    stderr.to_s.should be_empty
   end
 
   it "formats stdin (formatted)" do
@@ -33,7 +33,7 @@ describe Crystal::Command::FormatCommand do
     format_command.run
     format_command.status_code.should eq(0)
     stdout.to_s.should eq("if true\n  1\nend\n")
-    stderr.to_s.empty?.should be_true
+    stderr.to_s.should be_empty
   end
 
   it "formats stdin (syntax error)" do
@@ -44,7 +44,7 @@ describe Crystal::Command::FormatCommand do
     format_command = Crystal::Command::FormatCommand.new(["-"], stdin: stdin, stdout: stdout, stderr: stderr)
     format_command.run
     format_command.status_code.should eq(1)
-    stdout.to_s.empty?.should be_true
+    stdout.to_s.should be_empty
     stderr.to_s.should contain("syntax error in 'STDIN:1:3': unexpected token: EOF")
   end
 
@@ -56,7 +56,7 @@ describe Crystal::Command::FormatCommand do
     format_command = Crystal::Command::FormatCommand.new(["-"], stdin: stdin, stdout: stdout, stderr: stderr)
     format_command.run
     format_command.status_code.should eq(1)
-    stdout.to_s.empty?.should be_true
+    stdout.to_s.should be_empty
     stderr.to_s.should contain("file 'STDIN' is not a valid Crystal source file: Unexpected byte 0xff at position 1, malformed UTF-8")
   end
 
@@ -68,7 +68,7 @@ describe Crystal::Command::FormatCommand do
     format_command = BuggyFormatCommand.new(["-"], stdin: stdin, stdout: stdout, stderr: stderr)
     format_command.run
     format_command.status_code.should eq(1)
-    stdout.to_s.empty?.should be_true
+    stdout.to_s.should be_empty
     stderr.to_s.should contain("there's a bug formatting 'STDIN', to show more information, please run:\n\n  $ crystal tool format --show-backtrace -")
   end
 
@@ -80,7 +80,7 @@ describe Crystal::Command::FormatCommand do
     format_command = BuggyFormatCommand.new(["-"], show_backtrace: true, stdin: stdin, stdout: stdout, stderr: stderr)
     format_command.run
     format_command.status_code.should eq(1)
-    stdout.to_s.empty?.should be_true
+    stdout.to_s.should be_empty
     stderr.to_s.should contain("format command test")
     stderr.to_s.should contain("couldn't format 'STDIN', please report a bug including the contents of it: https://github.com/crystal-lang/crystal/issues")
   end
@@ -101,7 +101,7 @@ describe Crystal::Command::FormatCommand do
         format_command.status_code.should eq(0)
         stdout.to_s.should contain("Format #{Path[".", "format.cr"]}")
         stdout.to_s.should_not contain("Format #{Path[".", "not_format.cr"]}")
-        stderr.to_s.empty?.should be_true
+        stderr.to_s.should be_empty
 
         File.read(File.join(path, "format.cr")).should eq("if true\n  1\nend\n")
       end
@@ -126,7 +126,7 @@ describe Crystal::Command::FormatCommand do
         format_command.status_code.should eq(0)
         stdout.to_s.should contain("Format #{Path[".", "dir", "format.cr"]}")
         stdout.to_s.should_not contain("Format #{Path[".", "dir", "not_format.cr"]}")
-        stderr.to_s.empty?.should be_true
+        stderr.to_s.should be_empty
 
         {stdout, stderr}.each &.clear
 
@@ -137,7 +137,7 @@ describe Crystal::Command::FormatCommand do
         stdout.to_s.should_not contain("Format #{Path[".", "not_format.cr"]}")
         stdout.to_s.should_not contain("Format #{Path[".", "dir", "format.cr"]}")
         stdout.to_s.should_not contain("Format #{Path[".", "dir", "not_format.cr"]}")
-        stderr.to_s.empty?.should be_true
+        stderr.to_s.should be_empty
 
         File.read(File.join(path, "format.cr")).should eq("if true\n  1\nend\n")
         File.read(File.join(path, "dir", "format.cr")).should eq("if true\n  1\nend\n")
@@ -222,7 +222,7 @@ describe Crystal::Command::FormatCommand do
         format_command = Crystal::Command::FormatCommand.new([] of String, check: true, color: false, stdin: stdin, stdout: stdout, stderr: stderr)
         format_command.run
         format_command.status_code.should eq(1)
-        stdout.to_s.empty?.should be_true
+        stdout.to_s.should be_empty
         stderr.to_s.should_not contain("not_format.cr")
         stderr.to_s.should contain("formatting '#{Path[".", "format.cr"]}' produced changes")
         stderr.to_s.should contain("syntax error in '#{Path[".", "syntax_error.cr"]}:1:3': unexpected token: EOF")
@@ -245,8 +245,8 @@ describe Crystal::Command::FormatCommand do
         format_command = Crystal::Command::FormatCommand.new([] of String, check: true, color: false, stdin: stdin, stdout: stdout, stderr: stderr)
         format_command.run
         format_command.status_code.should eq(0)
-        stdout.to_s.empty?.should be_true
-        stderr.to_s.empty?.should be_true
+        stdout.to_s.should be_empty
+        stderr.to_s.should be_empty
       end
     end
   end
@@ -265,8 +265,8 @@ describe Crystal::Command::FormatCommand do
         format_command = Crystal::Command::FormatCommand.new([] of String, check: true, excludes: ["format.cr"], color: false, stdin: stdin, stdout: stdout, stderr: stderr)
         format_command.run
         format_command.status_code.should eq(0)
-        stdout.to_s.empty?.should be_true
-        stderr.to_s.empty?.should be_true
+        stdout.to_s.should be_empty
+        stderr.to_s.should be_empty
       end
     end
   end
@@ -285,7 +285,7 @@ describe Crystal::Command::FormatCommand do
         format_command = Crystal::Command::FormatCommand.new([] of String, check: true, excludes: ["format.cr"], includes: ["format.cr"], color: false, stdin: stdin, stdout: stdout, stderr: stderr)
         format_command.run
         format_command.status_code.should eq(1)
-        stdout.to_s.empty?.should be_true
+        stdout.to_s.should be_empty
         stderr.to_s.should contain("formatting '#{Path[".", "format.cr"]}' produced changes")
       end
     end

--- a/spec/compiler/semantic/instance_var_spec.cr
+++ b/spec/compiler/semantic/instance_var_spec.cr
@@ -2810,7 +2810,7 @@ describe "Semantic: instance var" do
     foo.instance_vars["@x"].type.should eq(result.program.int32)
 
     bar = result.program.types["Bar"].as(NonGenericClassType)
-    bar.instance_vars.empty?.should be_true
+    bar.instance_vars.should be_empty
   end
 
   it "infers type from custom array literal" do

--- a/spec/std/array_spec.cr
+++ b/spec/std/array_spec.cr
@@ -147,8 +147,8 @@ describe "Array" do
   end
 
   it "does *" do
-    (([] of Int32) * 10).empty?.should be_true
-    ([1, 2, 3] * 0).empty?.should be_true
+    (([] of Int32) * 10).should be_empty
+    ([1, 2, 3] * 0).should be_empty
     ([1] * 3).should eq([1, 1, 1])
     ([1, 2, 3] * 3).should eq([1, 2, 3, 1, 2, 3, 1, 2, 3])
     ([1, 2] * 10).should eq([1, 2, 1, 2, 1, 2, 1, 2, 1, 2, 1, 2, 1, 2, 1, 2, 1, 2, 1, 2])
@@ -1319,7 +1319,7 @@ describe "Array" do
     it "truncates with index and count == 0" do
       a = [0, 1, 4, 9, 16, 25]
       a.truncate(2, 0).should be(a)
-      a.empty?.should be_true
+      a.should be_empty
     end
 
     it "truncates with index and count, not enough elements" do
@@ -1331,7 +1331,7 @@ describe "Array" do
     it "truncates with index == size and count" do
       a = [0, 1, 4, 9, 16, 25]
       a.truncate(6, 1).should be(a)
-      a.empty?.should be_true
+      a.should be_empty
     end
 
     it "truncates with index < 0 and count" do
@@ -1825,9 +1825,9 @@ describe "Array" do
 
     it "transposes empty array" do
       e = [] of Array(Int32)
-      e.transpose.empty?.should be_true
-      [e].transpose.empty?.should be_true
-      [e, e, e].transpose.empty?.should be_true
+      e.transpose.should be_empty
+      [e].transpose.should be_empty
+      [e, e, e].transpose.should be_empty
     end
 
     it "raises IndexError error when size of element is invalid" do

--- a/spec/std/compress/zip/zip_spec.cr
+++ b/spec/std/compress/zip/zip_spec.cr
@@ -21,7 +21,7 @@ describe Compress::Zip do
       entry.crc32.should eq(0)
       entry.compressed_size.should eq(0)
       entry.uncompressed_size.should eq(0)
-      entry.extra.empty?.should be_true
+      entry.extra.should be_empty
       entry.io.gets_to_end.should eq("contents of foo")
 
       entry = zip.next_entry.not_nil!

--- a/spec/std/csv/csv_spec.cr
+++ b/spec/std/csv/csv_spec.cr
@@ -13,7 +13,7 @@ describe CSV do
 
   it "works without headers" do
     csv = CSV.new("", headers: true)
-    csv.headers.empty?.should be_true
+    csv.headers.should be_empty
   end
 
   it "raises if trying to access before first row" do

--- a/spec/std/exception/call_stack_spec.cr
+++ b/spec/std/exception/call_stack_spec.cr
@@ -51,7 +51,7 @@ describe "Backtrace" do
 
     _, output, error = compile_and_run_file(sample)
 
-    output.to_s.empty?.should be_true
+    output.to_s.should be_empty
     error.to_s.should contain("IndexError")
   end
 
@@ -60,7 +60,7 @@ describe "Backtrace" do
 
     _, output, error = compile_and_run_file(sample)
 
-    output.to_s.empty?.should be_true
+    output.to_s.should be_empty
     error.to_s.should contain("Invalid memory access")
   end
 

--- a/spec/std/exception_spec.cr
+++ b/spec/std/exception_spec.cr
@@ -40,7 +40,7 @@ describe "Exception" do
 
     _, output, error = compile_and_run_file(sample, ["--release"])
 
-    output.to_s.empty?.should be_true
+    output.to_s.should be_empty
     error.to_s.should contain("Unhandled exception: Oh no! (Exception)")
     error.to_s.should_not contain("Invalid memory access")
     error.to_s.should_not contain("Illegal instruction")

--- a/spec/std/file_spec.cr
+++ b/spec/std/file_spec.cr
@@ -55,7 +55,7 @@ describe "File" do
     it "reads entire file from proc virtual filesystem" do
       str1 = File.open "/proc/self/cmdline", &.gets_to_end
       str2 = File.read "/proc/self/cmdline"
-      str2.empty?.should be_false
+      str2.should_not be_empty
       str2.should eq(str1)
     end
   {% end %}

--- a/spec/std/hash_spec.cr
+++ b/spec/std/hash_spec.cr
@@ -572,7 +572,7 @@ describe "Hash" do
     it "clones empty hash" do
       h1 = {} of Int32 => Int32
       h2 = h1.clone
-      h2.empty?.should be_true
+      h2.should be_empty
     end
 
     it "clones small hash" do
@@ -631,7 +631,7 @@ describe "Hash" do
     it "dups empty hash" do
       h1 = {} of Int32 => Int32
       h2 = h1.dup
-      h2.empty?.should be_true
+      h2.should be_empty
     end
 
     it "dups small hash" do
@@ -830,7 +830,7 @@ describe "Hash" do
 
     h2 = h1.transform_keys { |x| x + 1 }
     h2.should be_a(Hash(Int32, Symbol))
-    h2.empty?.should be_true
+    h2.should be_empty
   end
 
   it "transforms values" do
@@ -853,7 +853,7 @@ describe "Hash" do
 
     h2 = h1.transform_values { |x| x + 1 }
     h2.should be_a(Hash(Symbol, Int32))
-    h2.empty?.should be_true
+    h2.should be_empty
   end
 
   it "transform values in place" do
@@ -966,7 +966,7 @@ describe "Hash" do
     h.each_value.to_a.should eq([4])
 
     h.shift.should eq({3, 4})
-    h.empty?.should be_true
+    h.should be_empty
 
     expect_raises(IndexError) do
       h.shift
@@ -980,7 +980,7 @@ describe "Hash" do
     20.times do |i|
       h.shift.should eq({i, i})
     end
-    h.empty?.should be_true
+    h.should be_empty
   end
 
   it "shifts: delete elements in the middle position and then in the first position" do
@@ -996,7 +996,7 @@ describe "Hash" do
   it "shifts?" do
     h = {1 => 2}
     h.shift?.should eq({1, 2})
-    h.empty?.should be_true
+    h.should be_empty
     h.shift?.should be_nil
   end
 
@@ -1046,7 +1046,7 @@ describe "Hash" do
   it "clears" do
     h = {1 => 2, 3 => 4}
     h.clear
-    h.empty?.should be_true
+    h.should be_empty
     h.to_a.size.should eq(0)
   end
 
@@ -1054,10 +1054,10 @@ describe "Hash" do
     h = {1 => 2, 3 => 4}
     h.shift
     h.clear
-    h.empty?.should be_true
+    h.should be_empty
     h.to_a.size.should eq(0)
     h[5] = 6
-    h.empty?.should be_false
+    h.should_not be_empty
     h[5].should eq(6)
     h.should eq({5 => 6})
   end

--- a/spec/std/http/chunked_content_spec.cr
+++ b/spec/std/http/chunked_content_spec.cr
@@ -198,7 +198,7 @@ describe HTTP::ChunkedContent do
       expect_raises(IO::Error, "Trailing headers too long") do
         chunked.gets
       end
-      chunked.headers.empty?.should be_true
+      chunked.headers.should be_empty
     end
 
     it "fails for long combined headers" do

--- a/spec/std/http/headers_spec.cr
+++ b/spec/std/http/headers_spec.cr
@@ -68,7 +68,7 @@ describe HTTP::Headers do
   it "deletes" do
     headers = HTTP::Headers{"Foo" => "bar"}
     headers.delete("foo").should eq("bar")
-    headers.empty?.should be_true
+    headers.should be_empty
   end
 
   describe "#==" do

--- a/spec/std/http/server/request_processor_spec.cr
+++ b/spec/std/http/server/request_processor_spec.cr
@@ -237,7 +237,7 @@ describe HTTP::Server::RequestProcessor do
     input = RaiseIOError.new
     output = IO::Memory.new
     processor.process(input, output)
-    output.rewind.gets_to_end.empty?.should be_true
+    output.rewind.gets_to_end.should be_empty
   end
 
   it "handles IO::Error while writing" do

--- a/spec/std/http/server/response_spec.cr
+++ b/spec/std/http/server/response_spec.cr
@@ -248,8 +248,8 @@ describe HTTP::Server::Response do
     response.headers["Foo"] = "Bar"
     response.cookies["Bar"] = "Foo"
     response.reset
-    response.headers.empty?.should be_true
-    response.cookies.empty?.should be_true
+    response.headers.should be_empty
+    response.cookies.should be_empty
   end
 
   it "writes cookie headers" do

--- a/spec/std/indexable_spec.cr
+++ b/spec/std/indexable_spec.cr
@@ -304,10 +304,10 @@ describe Indexable do
       elems.should eq([{0, 0}, {0, 1}, {0, 2}, {1, 0}, {1, 1}, {1, 2}])
 
       elems = SafeIndexable.new(2).cartesian_product(SafeIndexable.new(0))
-      elems.empty?.should be_true
+      elems.should be_empty
 
       elems = SafeIndexable.new(0).cartesian_product(SafeIndexable.new(3))
-      elems.empty?.should be_true
+      elems.should be_empty
     end
 
     it "does with >1 other Indexables" do
@@ -325,7 +325,7 @@ describe Indexable do
       elems.should eq([[0, 0], [0, 1], [0, 2], [1, 0], [1, 1], [1, 2], [2, 0], [2, 1], [2, 2]])
 
       elems = Indexable.cartesian_product(SafeNestedIndexable.new(2, 0))
-      elems.empty?.should be_true
+      elems.should be_empty
 
       elems = Indexable.cartesian_product(SafeNestedIndexable.new(0, 3))
       elems.should eq([[] of Int32])
@@ -351,12 +351,12 @@ describe Indexable do
       r = [] of Int32 | String
       indexable = SafeIndexable.new(3)
       indexable.each_cartesian(SafeStringIndexable.new(0)) { |a, b| r << a; r << b }
-      r.empty?.should be_true
+      r.should be_empty
 
       r = [] of Int32 | String
       indexable = SafeIndexable.new(0)
       indexable.each_cartesian(SafeStringIndexable.new(2)) { |a, b| r << a; r << b }
-      r.empty?.should be_true
+      r.should be_empty
     end
 
     it "does with 1 other Indexable, without block" do
@@ -414,15 +414,15 @@ describe Indexable do
 
       r = [] of Int32
       Indexable.each_cartesian(SafeNestedIndexable.new(3, 0)) { |v| r.concat(v) }
-      r.empty?.should be_true
+      r.should be_empty
 
       r = [] of Int32
       Indexable.each_cartesian(SafeNestedIndexable.new(0, 2)) { |v| r.concat(v) }
-      r.empty?.should be_true
+      r.should be_empty
 
       r = [] of Int32
       Indexable.each_cartesian(SafeNestedIndexable.new(0, 0)) { |v| r.concat(v) }
-      r.empty?.should be_true
+      r.should be_empty
     end
 
     it "does with reuse = true, with block" do

--- a/spec/std/io/argf_spec.cr
+++ b/spec/std/io/argf_spec.cr
@@ -29,7 +29,7 @@ describe IO::ARGF do
     str = argf.gets_to_end
     str.should eq("\n67890\n")
 
-    argv.empty?.should be_true
+    argv.should be_empty
 
     argf.read_byte.should be_nil
 
@@ -84,7 +84,7 @@ describe IO::ARGF do
       argv.should eq([path2])
 
       argf.gets(chomp: false).should eq("67890\n")
-      argv.empty?.should be_true
+      argv.should be_empty
 
       argf.gets(chomp: false).should be_nil
 

--- a/spec/std/iterator_spec.cr
+++ b/spec/std/iterator_spec.cr
@@ -296,7 +296,7 @@ describe Iterator do
     it "cycles an empty array" do
       ary = [] of Int32
       values = ary.each.cycle.to_a
-      values.empty?.should be_true
+      values.should be_empty
     end
 
     it "cycles N times" do

--- a/spec/std/range_spec.cr
+++ b/spec/std/range_spec.cr
@@ -92,11 +92,11 @@ describe "Range" do
   end
 
   it "is empty with .. and begin > end" do
-    (1..0).to_a.empty?.should be_true
+    (1..0).to_a.should be_empty
   end
 
   it "is empty with ... and begin > end" do
-    (1...0).to_a.empty?.should be_true
+    (1...0).to_a.should be_empty
   end
 
   it "is not empty with .. and begin == end" do
@@ -328,11 +328,11 @@ describe "Range" do
     end
 
     it "is empty with .. and begin > end" do
-      (1..0).each.to_a.empty?.should be_true
+      (1..0).each.to_a.should be_empty
     end
 
     it "is empty with ... and begin > end" do
-      (1...0).each.to_a.empty?.should be_true
+      (1...0).each.to_a.should be_empty
     end
 
     it "is not empty with .. and begin == end" do
@@ -376,11 +376,11 @@ describe "Range" do
     end
 
     it "is empty with .. and begin > end" do
-      (1..0).reverse_each.to_a.empty?.should be_true
+      (1..0).reverse_each.to_a.should be_empty
     end
 
     it "is empty with ... and begin > end" do
-      (1...0).reverse_each.to_a.empty?.should be_true
+      (1...0).reverse_each.to_a.should be_empty
     end
 
     it "is not empty with .. and begin == end" do

--- a/spec/std/slice_spec.cr
+++ b/spec/std/slice_spec.cr
@@ -492,7 +492,7 @@ describe "Slice" do
   it "does Bytes[]" do
     slice = Bytes[]
     slice.should be_a(Bytes)
-    slice.empty?.should be_true
+    slice.should be_empty
   end
 
   it "uses percent vars in [] macro (#2954)" do
@@ -598,7 +598,7 @@ describe "Slice" do
 
   it "creates empty slice" do
     slice = Slice(Int32).empty
-    slice.empty?.should be_true
+    slice.should be_empty
   end
 
   it "creates read-only slice" do

--- a/spec/std/winerror_spec.cr
+++ b/spec/std/winerror_spec.cr
@@ -38,7 +38,7 @@ describe WinError do
     {% if flag?(:win32) %}
       # Not testing for specific content because the result is locale-specific
       # and currently the message uses only default `LANGID`.
-      message.empty?.should be_false
+      message.should_not be_empty
     {% else %}
       message.should eq ""
     {% end %}

--- a/spec/std/xml/html_spec.cr
+++ b/spec/std/xml/html_spec.cr
@@ -29,7 +29,7 @@ describe XML do
     h1 = body.children.find { |node| node.name == "h1" }.not_nil!
 
     attrs = h1.attributes
-    attrs.empty?.should be_false
+    attrs.should_not be_empty
     attrs.size.should eq(1)
 
     attr = attrs[0]

--- a/spec/std/xml/xml_spec.cr
+++ b/spec/std/xml/xml_spec.cr
@@ -15,18 +15,18 @@ describe XML do
     )
     doc.document.should eq(doc)
     doc.name.should eq("document")
-    doc.attributes.empty?.should be_true
+    doc.attributes.should be_empty
     doc.namespace.should be_nil
 
     people = doc.root.not_nil!
     people.name.should eq("people")
     people.type.should eq(XML::Node::Type::ELEMENT_NODE)
 
-    people.attributes.empty?.should be_true
+    people.attributes.should be_empty
 
     children = doc.children
     children.size.should eq(1)
-    children.empty?.should be_false
+    children.should_not be_empty
 
     people = children[0]
     people.name.should eq("people")
@@ -47,7 +47,7 @@ describe XML do
     text.content.should eq("\n")
 
     attrs = person.attributes
-    attrs.empty?.should be_false
+    attrs.should_not be_empty
     attrs.size.should eq(2)
 
     attr = attrs[0]


### PR DESCRIPTION
This patch replaces most usages of `empty?.should be_true` with `should be_empty`, and `empty?.should be_false` with `should_not be_empty`, because `be_empty`'s failure message is more descriptive:

```crystal
require "spec"

it { "".should_not be_empty } # preferred
it { "".empty?.should be_false }
it { "".empty?.should_not be_true }
it { "a".should be_empty } # preferred
it { "a".empty?.should be_true }
it { "a".empty?.should_not be_false }
```

```
FFFFFF

Failures:

  1) assert
     Failure/Error: it { "".should_not be_empty }

       Expected: "" not to be empty

     # test.cr:3

  2) assert
     Failure/Error: it { "".empty?.should be_false }

       Expected: false
            got: true

     # test.cr:4

  3) assert
     Failure/Error: it { "".empty?.should_not be_true }

       Expected: actual_value != true
            got: true

     # test.cr:5

  4) assert
     Failure/Error: it { "a".should be_empty }

       Expected: "a" to be empty

     # test.cr:6

  5) assert
     Failure/Error: it { "a".empty?.should be_true }

       Expected: true
            got: false

     # test.cr:7

  6) assert
     Failure/Error: it { "a".empty?.should_not be_false }

       Expected: actual_value != false
            got: false

     # test.cr:8
```

The only exceptions are specs testing the `#empty?` method itself. Specs like these are preserved:

https://github.com/crystal-lang/crystal/blob/458595ff8f601861cda4cc1e98f7d308852de78b/spec/std/uri/params_spec.cr#L299-L305