### PR TITLE
Fix regression for Linux older than 3.17: properly check that `getrandom` is available

### DIFF
--- a/src/crystal/system/unix/getrandom.cr
+++ b/src/crystal/system/unix/getrandom.cr
@@ -26,7 +26,7 @@ module Crystal::System::Random
   private def self.init
     @@initialized = true
 
-    if sys_getrandom(Bytes.new(16)) >= 0
+    if has_sys_getrandom
       @@getrandom_available = true
     else
       urandom = ::File.open("/dev/urandom", "r")
@@ -36,6 +36,13 @@ module Crystal::System::Random
       urandom.sync = true # don't buffer bytes
       @@urandom = urandom
     end
+  end
+
+  private def self.has_sys_getrandom
+    sys_getrandom(Bytes.new(16))
+    true
+  rescue
+    false
   end
 
   # Reads n random bytes using the Linux `getrandom(2)` syscall.


### PR DESCRIPTION
This regression was introduced by https://github.com/crystal-lang/crystal/pull/11460, which was fixing another issue about retries. The `sys_getrandom` method raises in case of error, so checking for a negative return value doesn't make sense. When running Crystal on Linux prior to 3.17 (before `getrandom` was available) it will just crash at startup.

Issue reported via Gitter: https://gitter.im/crystal-lang/crystal?at=62427a8bc61ef0178e968026