### PR TITLE
Compiler (fix): lookup return type in defining type

### DIFF
--- a/spec/compiler/semantic/instance_var_spec.cr
+++ b/spec/compiler/semantic/instance_var_spec.cr
@@ -5500,6 +5500,37 @@ describe "Semantic: instance var" do
       CR
   end
 
+  it "looks up return type restriction in defining type, not instantiated type (#11961)" do
+    assert_type(%(
+      module Foo(T)
+        def foo : T
+          x = uninitialized T
+          x
+        end
+      end
+
+      module Bar(T)
+        include Foo(T)
+      end
+
+      struct Tuple
+        include Bar(Union(*T))
+      end
+
+      class Test
+        def initialize
+          @foo = 0
+        end
+
+        def test
+          @foo = {@foo, 0}.foo
+        end
+      end
+
+      Test.new.@foo
+      )) { int32 }
+  end
+
   describe "instance variable inherited from multiple parents" do
     context "with compatible type" do
       it "module and class, with declarations" do

--- a/src/compiler/crystal/semantic/type_guess_visitor.cr
+++ b/src/compiler/crystal/semantic/type_guess_visitor.cr
@@ -868,7 +868,7 @@ module Crystal
         return_type = match.def.return_type
         next unless return_type
 
-        lookup_type?(return_type, match.context.instantiated_type)
+        lookup_type?(return_type, match.context.defining_type)
       end
 
       return nil if return_types.empty?


### PR DESCRIPTION
Fixes #11961

We (me? :-P) were incorrectly looking the return type on the instantiated type instead of the defining type.

For `Enumerable#max` the return type is `T`. That's correctly `Int32` in the failing example, but it's `Tuple(Int32, Int32)` in the context of `Tuple`.