### PR TITLE
Fix GC typedefs on Windows

### DIFF
--- a/src/gc.cr
+++ b/src/gc.cr
@@ -48,25 +48,25 @@ end
 
 module GC
   record Stats,
-    # collections : LibC::ULong,
-    # bytes_found : LibC::Long,
-    heap_size : LibC::ULong,
-    free_bytes : LibC::ULong,
-    unmapped_bytes : LibC::ULong,
-    bytes_since_gc : LibC::ULong,
-    total_bytes : LibC::ULong
+    # collections : UInt64,
+    # bytes_found : Int64,
+    heap_size : UInt64,
+    free_bytes : UInt64,
+    unmapped_bytes : UInt64,
+    bytes_since_gc : UInt64,
+    total_bytes : UInt64
 
   record ProfStats,
-    heap_size : LibC::ULong,
-    free_bytes : LibC::ULong,
-    unmapped_bytes : LibC::ULong,
-    bytes_since_gc : LibC::ULong,
-    bytes_before_gc : LibC::ULong,
-    non_gc_bytes : LibC::ULong,
-    gc_no : LibC::ULong,
-    markers_m1 : LibC::ULong,
-    bytes_reclaimed_since_gc : LibC::ULong,
-    reclaimed_bytes_before_gc : LibC::ULong
+    heap_size : UInt64,
+    free_bytes : UInt64,
+    unmapped_bytes : UInt64,
+    bytes_since_gc : UInt64,
+    bytes_before_gc : UInt64,
+    non_gc_bytes : UInt64,
+    gc_no : UInt64,
+    markers_m1 : UInt64,
+    bytes_reclaimed_since_gc : UInt64,
+    reclaimed_bytes_before_gc : UInt64
 
   # Allocates and clears *size* bytes of memory.
   #

--- a/src/gc/boehm.cr
+++ b/src/gc/boehm.cr
@@ -28,7 +28,13 @@
 lib LibGC
   alias Int = LibC::Int
   alias SizeT = LibC::SizeT
-  alias Word = LibC::ULong
+  {% if flag?(:win32) && flag?(:bits64) %}
+    alias Word = LibC::ULongLong
+    alias SignedWord = LibC::LongLong
+  {% else %}
+    alias Word = LibC::ULong
+    alias SignedWord = LibC::Long
+  {% end %}
 
   struct StackBase
     mem_base : Void*
@@ -94,8 +100,8 @@ lib LibGC
 
   fun set_on_collection_event = GC_set_on_collection_event(cb : ->)
 
-  $gc_no = GC_gc_no : LibC::ULong
-  $bytes_found = GC_bytes_found : LibC::Long
+  $gc_no = GC_gc_no : Word
+  $bytes_found = GC_bytes_found : SignedWord
   # GC_on_collection_event isn't exported.  Can't collect totals without it.
   # bytes_allocd, heap_size, unmapped_bytes are macros
 

--- a/src/gc/none.cr
+++ b/src/gc/none.cr
@@ -41,23 +41,28 @@ module GC
   end
 
   def self.stats : GC::Stats
-    zero = LibC::ULong.new(0)
-    Stats.new(zero, zero, zero, zero, zero)
+    Stats.new(
+      # collections: 0,
+      # bytes_found: 0,
+      heap_size: 0,
+      free_bytes: 0,
+      unmapped_bytes: 0,
+      bytes_since_gc: 0,
+      total_bytes: 0)
   end
 
   def self.prof_stats
-    zero = LibC::ULong.new(0)
     ProfStats.new(
-      heap_size: zero,
-      free_bytes: zero,
-      unmapped_bytes: zero,
-      bytes_since_gc: zero,
-      bytes_before_gc: zero,
-      non_gc_bytes: zero,
-      gc_no: zero,
-      markers_m1: zero,
-      bytes_reclaimed_since_gc: zero,
-      reclaimed_bytes_before_gc: zero)
+      heap_size: 0,
+      free_bytes: 0,
+      unmapped_bytes: 0,
+      bytes_since_gc: 0,
+      bytes_before_gc: 0,
+      non_gc_bytes: 0,
+      gc_no: 0,
+      markers_m1: 0,
+      bytes_reclaimed_since_gc: 0,
+      reclaimed_bytes_before_gc: 0)
   end
 
   {% unless flag?(:win32) || flag?(:wasm32) %}


### PR DESCRIPTION
[`GC_word` is `unsigned long long` on Windows](https://github.com/ivmai/bdwgc/blob/ede3066b89bdfa3a44bbecf106842fa50b2a4bc3/include/gc/gc.h#L61-L72). The current typedef produces incorrect values for `GC.stats` and `GC.prof_stats`:

```crystal
pp GC.stats
# => GC::Stats(
#     @bytes_since_gc=0,
#     @free_bytes=0,
#     @heap_size=0,
#     @total_bytes=1792,
#     @unmapped_bytes=0)
pp GC.prof_stats
# => GC::ProfStats(
#     @bytes_before_gc=0,
#     @bytes_reclaimed_since_gc=0,
#     @bytes_since_gc=0,
#     @free_bytes=0,
#     @gc_no=6096,
#     @heap_size=262144,
#     @markers_m1=0,
#     @non_gc_bytes=0,
#     @reclaimed_bytes_before_gc=0,
#     @unmapped_bytes=200704)
```

This PR fixes them:

```crystal
pp GC.stats
# => GC::Stats(
#     @bytes_since_gc=1792,
#     @free_bytes=217088,
#     @heap_size=262144,
#     @total_bytes=1792,
#     @unmapped_bytes=0)
pp GC.prof_stats
# => GC::ProfStats(
#     @bytes_before_gc=0,
#     @bytes_reclaimed_since_gc=0,
#     @bytes_since_gc=5648,
#     @free_bytes=204800,
#     @gc_no=1,
#     @heap_size=262144,
#     @markers_m1=3,
#     @non_gc_bytes=0,
#     @reclaimed_bytes_before_gc=0,
#     @unmapped_bytes=0)
```