### PR TITLE
Never resolve free variables as types during overload ordering

### DIFF
--- a/spec/compiler/semantic/restrictions_spec.cr
+++ b/spec/compiler/semantic/restrictions_spec.cr
@@ -495,6 +495,76 @@ describe "Restrictions" do
           )) { tuple_of([int32, bool]) }
       end
     end
+
+    describe "free variables" do
+      it "inserts path before free variable with same name" do
+        assert_type(<<-CR) { tuple_of([char, bool]) }
+          def foo(x : Int32) forall Int32
+            true
+          end
+
+          def foo(x : Int32)
+            'a'
+          end
+
+          {foo(1), foo("")}
+          CR
+      end
+
+      it "keeps path before free variable with same name" do
+        assert_type(<<-CR) { tuple_of([char, bool]) }
+          def foo(x : Int32)
+            'a'
+          end
+
+          def foo(x : Int32) forall Int32
+            true
+          end
+
+          {foo(1), foo("")}
+          CR
+      end
+
+      it "inserts path before free variable even if free var resolves to a more specialized type" do
+        assert_type(<<-CR) { tuple_of([int32, int32, bool]) }
+          class Foo
+          end
+
+          class Bar < Foo
+          end
+
+          def foo(x : Bar) forall Bar
+            true
+          end
+
+          def foo(x : Foo)
+            1
+          end
+
+          {foo(Foo.new), foo(Bar.new), foo('a')}
+          CR
+      end
+
+      it "keeps path before free variable even if free var resolves to a more specialized type" do
+        assert_type(<<-CR) { tuple_of([int32, int32, bool]) }
+          class Foo
+          end
+
+          class Bar < Foo
+          end
+
+          def foo(x : Foo)
+            1
+          end
+
+          def foo(x : Bar) forall Bar
+            true
+          end
+
+          {foo(Foo.new), foo(Bar.new), foo('a')}
+          CR
+      end
+    end
   end
 
   it "self always matches instance type in restriction" do

--- a/src/compiler/crystal/semantic/restrictions.cr
+++ b/src/compiler/crystal/semantic/restrictions.cr
@@ -33,33 +33,33 @@ require "../types"
 
 module Crystal
   class ASTNode
-    def restriction_of?(other : Underscore, owner)
+    def restriction_of?(other : Underscore, owner, self_free_vars = nil, other_free_vars = nil)
       true
     end
 
-    def restriction_of?(other : ASTNode, owner)
+    def restriction_of?(other : ASTNode, owner, self_free_vars = nil, other_free_vars = nil)
       self == other
     end
 
-    def restriction_of?(other : Type, owner)
+    def restriction_of?(other : Type, owner, self_free_vars = nil, other_free_vars = nil)
       false
     end
 
-    def restriction_of?(other, owner)
+    def restriction_of?(other, owner, self_free_vars = nil, other_free_vars = nil)
       raise "BUG: called #{self}.restriction_of?(#{other})"
     end
   end
 
   class Self
-    def restriction_of?(type : Type, owner)
-      owner.restriction_of?(type, owner)
+    def restriction_of?(type : Type, owner, self_free_vars = nil, other_free_vars = nil)
+      owner.restriction_of?(type, owner, self_free_vars, other_free_vars)
     end
 
-    def restriction_of?(type : Self, owner)
+    def restriction_of?(type : Self, owner, self_free_vars = nil, other_free_vars = nil)
       true
     end
 
-    def restriction_of?(type : ASTNode, owner)
+    def restriction_of?(type : ASTNode, owner, self_free_vars = nil, other_free_vars = nil)
       false
     end
   end
@@ -107,6 +107,9 @@ module Crystal
         min = Math.min(max_size, other.max_size)
       end
 
+      self_free_vars = self.def.free_vars
+      other_free_vars = other.def.free_vars
+
       (0...min).each do |index|
         self_arg = self.def.args[index]
         other_arg = other.def.args[index]
@@ -118,7 +121,7 @@ module Crystal
           # If this is a splat arg and the other not, this is not stricter than the other
           return false if index == self.def.splat_index
 
-          return false unless self_type.restriction_of?(other_type, owner)
+          return false unless self_type.restriction_of?(other_type, owner, self_free_vars, other_free_vars)
         end
       end
 
@@ -131,7 +134,7 @@ module Crystal
 
           if self_restriction && other_restriction
             # If both splat have restrictions, check which one is stricter
-            return false unless self_restriction.restriction_of?(other_restriction, owner)
+            return false unless self_restriction.restriction_of?(other_restriction, owner, self_free_vars, other_free_vars)
           elsif self_restriction
             # If only self has a restriction, it's stricter than the other
             return true
@@ -165,7 +168,7 @@ module Crystal
           return false if self_restriction == nil && other_restriction != nil
 
           if self_restriction && other_restriction
-            return false unless self_restriction.restriction_of?(other_restriction, owner)
+            return false unless self_restriction.restriction_of?(other_restriction, owner, self_free_vars, other_free_vars)
           end
         end
 
@@ -182,7 +185,7 @@ module Crystal
 
       # If both double splat have restrictions, check which one is stricter
       if self_double_splat_restriction && other_double_splat_restriction
-        return false unless self_double_splat_restriction.restriction_of?(other_double_splat_restriction, owner)
+        return false unless self_double_splat_restriction.restriction_of?(other_double_splat_restriction, owner, self_free_vars, other_free_vars)
       elsif self_double_splat_restriction
         # If only self has a restriction, it's stricter than the other
         return true
@@ -241,14 +244,14 @@ module Crystal
   end
 
   class Path
-    def restriction_of?(other : Path, owner)
+    def restriction_of?(other : Path, owner, self_free_vars = nil, other_free_vars = nil)
       return true if self == other
 
       self_type = owner.lookup_path(self)
       if self_type
         other_type = owner.lookup_path(other)
         if other_type
-          return self_type.restriction_of?(other_type, owner)
+          return self_type.restriction_of?(other_type, owner, self_free_vars, other_free_vars)
         else
           return true
         end
@@ -257,17 +260,17 @@ module Crystal
       false
     end
 
-    def restriction_of?(other : Union, owner)
+    def restriction_of?(other : Union, owner, self_free_vars = nil, other_free_vars = nil)
       # `true` if this type is a restriction of any type in the union
-      other.types.any? { |o| self.restriction_of?(o, owner) }
+      other.types.any? { |o| self.restriction_of?(o, owner, self_free_vars, other_free_vars) }
     end
 
-    def restriction_of?(other : Generic, owner)
+    def restriction_of?(other : Generic, owner, self_free_vars = nil, other_free_vars = nil)
       self_type = owner.lookup_path(self)
       if self_type
         other_type = owner.lookup_type?(other)
         if other_type
-          return self_type.restriction_of?(other_type, owner)
+          return self_type.restriction_of?(other_type, owner, self_free_vars, other_free_vars)
         end
       end
 
@@ -281,23 +284,23 @@ module Crystal
       false
     end
 
-    def restriction_of?(other, owner)
+    def restriction_of?(other, owner, self_free_vars = nil, other_free_vars = nil)
       false
     end
   end
 
   class Union
-    def restriction_of?(other : Path, owner)
+    def restriction_of?(other : Path, owner, self_free_vars = nil, other_free_vars = nil)
       # For a union to be considered before a path,
       # all types in the union must be considered before
       # that path.
       # For example when using all subtypes of a parent type.
-      types.all? &.restriction_of?(other, owner)
+      types.all? &.restriction_of?(other, owner, self_free_vars, other_free_vars)
     end
   end
 
   class Generic
-    def restriction_of?(other : Path, owner)
+    def restriction_of?(other : Path, owner, self_free_vars = nil, other_free_vars = nil)
       # ```
       # def foo(param : Array(T)) forall T
       # end
@@ -312,7 +315,7 @@ module Crystal
       if self_type
         other_type = owner.lookup_path(other)
         if other_type
-          return self_type.restriction_of?(other_type, owner)
+          return self_type.restriction_of?(other_type, owner, self_free_vars, other_free_vars)
         end
       end
 
@@ -332,19 +335,19 @@ module Crystal
       true
     end
 
-    def restriction_of?(other : Generic, owner)
+    def restriction_of?(other : Generic, owner, self_free_vars = nil, other_free_vars = nil)
       return true if self == other
       return false unless name == other.name && type_vars.size == other.type_vars.size
 
       # Special case: NamedTuple against NamedTuple
       if (self_type = owner.lookup_type?(self)).is_a?(NamedTupleInstanceType)
         if (other_type = owner.lookup_type?(other)).is_a?(NamedTupleInstanceType)
-          return self_type.restriction_of?(other_type, owner)
+          return self_type.restriction_of?(other_type, owner, self_free_vars, other_free_vars)
         end
       end
 
       type_vars.zip(other.type_vars) do |type_var, other_type_var|
-        return false unless type_var.restriction_of?(other_type_var, owner)
+        return false unless type_var.restriction_of?(other_type_var, owner, self_free_vars, other_free_vars)
       end
 
       true
@@ -352,7 +355,7 @@ module Crystal
   end
 
   class GenericClassType
-    def restriction_of?(other : GenericClassInstanceType, owner)
+    def restriction_of?(other : GenericClassInstanceType, owner, self_free_vars = nil, other_free_vars = nil)
       # ```
       # def foo(param : Array)
       # end
@@ -374,7 +377,7 @@ module Crystal
   end
 
   class GenericClassInstanceType
-    def restriction_of?(other : GenericClassType, owner)
+    def restriction_of?(other : GenericClassType, owner, self_free_vars = nil, other_free_vars = nil)
       # ```
       # def foo(param : Array(Int32))
       # end
@@ -392,11 +395,11 @@ module Crystal
   end
 
   class Metaclass
-    def restriction_of?(other : Metaclass, owner)
-      name.restriction_of?(other.name, owner)
+    def restriction_of?(other : Metaclass, owner, self_free_vars = nil, other_free_vars = nil)
+      name.restriction_of?(other.name, owner, self_free_vars, other_free_vars)
     end
 
-    def restriction_of?(other : Path, owner)
+    def restriction_of?(other : Path, owner, self_free_vars = nil, other_free_vars = nil)
       other_type = owner.lookup_type(other)
 
       # Special case: when comparing Foo.class to Class, Foo.class has precedence
@@ -607,31 +610,31 @@ module Crystal
       raise "BUG: unsupported restriction: #{self} vs. #{other}"
     end
 
-    def restriction_of?(other : UnionType, owner)
-      other.union_types.any? { |subtype| restriction_of?(subtype, owner) }
+    def restriction_of?(other : UnionType, owner, self_free_vars = nil, other_free_vars = nil)
+      other.union_types.any? { |subtype| restriction_of?(subtype, owner, self_free_vars, other_free_vars) }
     end
 
-    def restriction_of?(other : VirtualType, owner)
+    def restriction_of?(other : VirtualType, owner, self_free_vars = nil, other_free_vars = nil)
       implements? other.base_type
     end
 
-    def restriction_of?(other : Type, owner)
+    def restriction_of?(other : Type, owner, self_free_vars = nil, other_free_vars = nil)
       if self == other
         return true
       end
 
-      parents.try &.any? &.restriction_of?(other, owner)
+      parents.try &.any? &.restriction_of?(other, owner, self_free_vars, other_free_vars)
     end
 
-    def restriction_of?(other : AliasType, owner)
+    def restriction_of?(other : AliasType, owner, self_free_vars = nil, other_free_vars = nil)
       if self == other
         true
       else
-        restriction_of?(other.remove_alias, owner)
+        restriction_of?(other.remove_alias, owner, self_free_vars, other_free_vars)
       end
     end
 
-    def restriction_of?(other : ASTNode, owner)
+    def restriction_of?(other : ASTNode, owner, self_free_vars = nil, other_free_vars = nil)
       raise "BUG: called #{self}.restriction_of?(#{other})"
     end
 
@@ -641,8 +644,8 @@ module Crystal
   end
 
   class UnionType
-    def restriction_of?(type, owner)
-      self == type || union_types.all? &.restriction_of?(type, owner)
+    def restriction_of?(type, owner, self_free_vars = nil, other_free_vars = nil)
+      self == type || union_types.all? &.restriction_of?(type, owner, self_free_vars, other_free_vars)
     end
 
     def restrict(other : Union, context)
@@ -715,12 +718,12 @@ module Crystal
   end
 
   class GenericInstanceType
-    def restriction_of?(other : GenericType, owner)
+    def restriction_of?(other : GenericType, owner, self_free_vars = nil, other_free_vars = nil)
       return true if generic_type == other
       super
     end
 
-    def restriction_of?(other : GenericInstanceType, owner)
+    def restriction_of?(other : GenericInstanceType, owner, self_free_vars = nil, other_free_vars = nil)
       return super unless generic_type == other.generic_type
 
       type_vars.each do |name, type_var|
@@ -901,7 +904,7 @@ module Crystal
   end
 
   class TupleInstanceType
-    def restriction_of?(other : TupleInstanceType, owner)
+    def restriction_of?(other : TupleInstanceType, owner, self_free_vars = nil, other_free_vars = nil)
       return true if self == other || self.implements?(other)
 
       false
@@ -961,7 +964,7 @@ module Crystal
   end
 
   class NamedTupleInstanceType
-    def restriction_of?(other : NamedTupleInstanceType, owner)
+    def restriction_of?(other : NamedTupleInstanceType, owner, self_free_vars = nil, other_free_vars = nil)
       return true if self == other || self.implements?(other)
 
       false
@@ -1000,7 +1003,7 @@ module Crystal
   end
 
   class VirtualType
-    def restriction_of?(other : Type, owner)
+    def restriction_of?(other : Type, owner, self_free_vars = nil, other_free_vars = nil)
       other = other.base_type if other.is_a?(VirtualType)
       base_type.implements?(other) || other.implements?(base_type)
     end
@@ -1078,10 +1081,10 @@ module Crystal
   end
 
   class AliasType
-    def restriction_of?(other, owner)
+    def restriction_of?(other, owner, self_free_vars = nil, other_free_vars = nil)
       return true if self == other
 
-      remove_alias.restriction_of?(other, owner)
+      remove_alias.restriction_of?(other, owner, self_free_vars, other_free_vars)
     end
 
     def restrict(other : Path, context)
@@ -1165,8 +1168,8 @@ module Crystal
       restricted ? self : nil
     end
 
-    def restriction_of?(other : VirtualMetaclassType, owner)
-      restriction_of?(other.base_type.metaclass, owner)
+    def restriction_of?(other : VirtualMetaclassType, owner, self_free_vars = nil, other_free_vars = nil)
+      restriction_of?(other.base_type.metaclass, owner, self_free_vars, other_free_vars)
     end
   end
 


### PR DESCRIPTION
In the following snippet, `Bar` is resolved as a type even though it is specified as a free variable, and since `Bar < Foo`, the `Bar` overload is ordered first:

```crystal
class Foo; end
class Bar < Foo; end

def foo(x : Foo); 1; end
def foo(x : Bar) forall Bar; end

foo(Foo.new) # => nil
```

`Bar forall Bar` accepts types that are not subtypes of `Foo`, so the overload order should be untouched here.

Similarly, in the following snippet, the two defs are redefinitions because the restrictions have the same name, even though only one of them is a free variable and the two are definitely distinguishable:

```crystal
class Foo; end

def foo(x : Foo) forall Foo; end
def foo(x : Foo); end

foo(3) # Error: no overload matches 'foo' with type Int32
```

This PR makes it so that those free variables are never resolved as types; for the purposes of overload ordering, they are considered undefined types, and the non-free `Path`s come first. Most free variables have only one letter and most type names don't, so the impact should be very small in practice.

The first commit here is also necessary when we eventually deal with [bounded free variables](https://github.com/crystal-lang/crystal/issues/11908).

Nothing changes if both `Path`s are free variables (they are already somewhat broken before and nobody really knows how to fix them yet, for example #10042).