### PR TITLE
Use read-buffering on `urandom`

### DIFF
--- a/src/crystal/system/unix/getrandom.cr
+++ b/src/crystal/system/unix/getrandom.cr
@@ -33,7 +33,6 @@ module Crystal::System::Random
       return unless urandom.info.type.character_device?
 
       urandom.close_on_exec = true
-      urandom.sync = true # don't buffer bytes
       @@urandom = urandom
     end
   end

--- a/src/crystal/system/unix/urandom.cr
+++ b/src/crystal/system/unix/urandom.cr
@@ -11,7 +11,6 @@ module Crystal::System::Random
     return unless urandom.info.type.character_device?
 
     urandom.close_on_exec = true
-    urandom.read_buffering = false
     @@urandom = urandom
   end
 


### PR DESCRIPTION
I assume that disabling read buffering on `/dev/urandom` was intended to avoid hogging random entropy. I’m calling it an assumption because I can’t find mention of it in https://github.com/crystal-lang/crystal/pull/2959 where it was added, but playing nice with the system entropy device is a good idea, so it probably seemed reasonable. However, the computer can spare 8KB of entropy per process (it’s at most 8KB wasted per process) and anything that uses `Random::Secure` heavily ends up bottlenecked on `File#read`. And it’s a _big_ bottleneck, too — approximately 1836% slower:

Before:

    UUID.random   1.06M (939.51ns) (± 0.54%)  0.0B/op

After:

    UUID.random  19.46M ( 51.38ns) (± 1.64%)  0.0B/op

I discovered this while writing my own entropy buffer (taking 1µs for every `Random::Secure` invocation seemed like a lot longer than it should take), which defeats the purpose of not buffering. A single process-wide entropy buffer is preferable to multiple consumers of `Random:::Secure` implementing separate buffers.

---

Could we do the same for Linux, where most of us are deploying our apps anyway? I’m curious what the performance impact would be of buffering `getrandom` calls for Linux. I imagine it would be quite similar to this since it also involves jumping between user and kernel space just like `File#read` does. I’d have to try it out on a cloud VM maybe next week or so, but the buffer would look something like this (writing it in here so I don’t forget):

```crystal
module Crystal::System::Random
  GENERATOR = SecureGenerator.new

  private class SecureGenerator
    getter buffer : Bytes = Bytes.new(8192).tap { |b| sys_getrandom b }
    getter index = 0

    def bytes(bytes : Bytes) : Nil
      if (offset = bytes.bytesize - (buffer.bytesize - index)) > 0
        (buffer + index).copy_to bytes
        @index = 0
        sys_getrandom buffer
        bytes(bytes + offset)
      else
        (buffer + index).copy_to bytes.to_unsafe, bytes.bytesize
        @index += bytes.bytesize
      end
    end
  end
end
```

`sys_getrandom` is [this method](https://github.com/crystal-lang/crystal/blob/f6f92a15a8df4637ebbc29c807d56ccb995fd1a4/src/crystal/system/unix/getrandom.cr#L101-L115).