### PR TITLE
Add U/Int128 to isqrt spec

### DIFF
--- a/spec/std/math_spec.cr
+++ b/spec/std/math_spec.cr
@@ -46,7 +46,7 @@ describe "Math" do
       Math.isqrt(9).should eq(3)
       Math.isqrt(8).should eq(2)
       Math.isqrt(4).should eq(2)
-      {% for type in [UInt8, UInt16, UInt32, UInt64, Int8, Int16, Int32, Int64] %}
+      {% for type in [UInt8, UInt16, UInt32, UInt64, UInt128, Int8, Int16, Int32, Int64, Int128] %}
         %val = {{type}}.new 42
         %exp = {{type}}.new 6
         Math.isqrt(%val).should eq(%exp)


### PR DESCRIPTION
Simply adds `Int128` and `UInt128` to the `Math.isqrt` specs.