### PR TITLE
Add missing fun def for `__xstat`

### DIFF
--- a/src/crystal/system/unix/file.cr
+++ b/src/crystal/system/unix/file.cr
@@ -56,7 +56,7 @@ module Crystal::System::File
 
   def self.stat(path, stat)
     {% if LibC.has_method?(:__xstat) %}
-      LibC.__xstat(1, path, stat)
+      LibC.__xstat(LibC::STAT_VER, path, stat)
     {% else %}
       LibC.stat(path, stat)
     {% end %}
@@ -64,7 +64,7 @@ module Crystal::System::File
 
   def self.fstat(path, stat)
     {% if LibC.has_method?(:__fxstat) %}
-      LibC.__fxstat(1, path, stat)
+      LibC.__fxstat(LibC::STAT_VER, path, stat)
     {% else %}
       LibC.fstat(path, stat)
     {% end %}
@@ -72,7 +72,7 @@ module Crystal::System::File
 
   def self.lstat(path, stat)
     {% if LibC.has_method?(:__lxstat) %}
-      LibC.__lxstat(1, path, stat)
+      LibC.__lxstat(LibC::STAT_VER, path, stat)
     {% else %}
       LibC.lstat(path, stat)
     {% end %}

--- a/src/lib_c/x86_64-linux-gnu/c/sys/stat.cr
+++ b/src/lib_c/x86_64-linux-gnu/c/sys/stat.cr
@@ -44,6 +44,8 @@ lib LibC
     __glibc_reserved : StaticArray(Long, 3)
   end
 
+  STAT_VER = 1
+
   fun chmod(file : Char*, mode : ModeT) : Int
   fun fstat(fd : Int, buf : Stat*) : Int
   fun __fxstat(ver : Int, fd : Int, buf : Stat*) : Int

--- a/src/lib_c/x86_64-linux-gnu/c/sys/stat.cr
+++ b/src/lib_c/x86_64-linux-gnu/c/sys/stat.cr
@@ -54,5 +54,6 @@ lib LibC
   fun mkfifo(path : Char*, mode : ModeT) : Int
   fun mknod(path : Char*, mode : ModeT, dev : DevT) : Int
   fun stat(file : Char*, buf : Stat*) : Int
+  fun __xstat(ver : Int, file : Char*, buf : Stat*) : Int
   fun umask(mask : ModeT) : ModeT
 end

--- a/src/lib_c/x86_64-linux-gnu/c/sys/stat.cr
+++ b/src/lib_c/x86_64-linux-gnu/c/sys/stat.cr
@@ -48,7 +48,6 @@ lib LibC
   fun fstat(fd : Int, buf : Stat*) : Int
   fun __fxstat(ver : Int, fd : Int, buf : Stat*) : Int
   fun lstat(file : Char*, buf : Stat*) : Int
-  fun __fxstat(ver : Int, fd : Int, buf : Stat*) : Int
   fun __lxstat(ver : Int, file : Char*, buf : Stat*) : Int
   fun mkdir(path : Char*, mode : ModeT) : Int
   fun mkfifo(path : Char*, mode : ModeT) : Int


### PR DESCRIPTION
Fixes https://github.com/crystal-lang/crystal/issues/11157#issuecomment-1093311288

Also includes two small cleanups/refactors.