### PR TITLE
Rename "take" to "first"

### DIFF
--- a/src/iterator.cr
+++ b/src/iterator.cr
@@ -10,8 +10,8 @@ require "./enumerable"
 # (1..10_000_000).select(&.even?).map { |x| x * 3 }.first(3) # => [6, 12, 18]
 # ```
 #
-# The above works, but creates many intermediate arrays: one for the *select* call,
-# one for the *map* call and one for the *first* call. A more efficient way is to invoke
+# The above works, but creates many intermediate arrays: one for the `select` call,
+# one for the `map` call and one for the `first` call. A more efficient way is to invoke
 # `Range#each` without a block, which gives us an `Iterator` so we can process the operations
 # lazily:
 #

--- a/src/iterator.cr
+++ b/src/iterator.cr
@@ -11,7 +11,7 @@ require "./enumerable"
 # ```
 #
 # The above works, but creates many intermediate arrays: one for the *select* call,
-# one for the *map* call and one for the *take* call. A more efficient way is to invoke
+# one for the *map* call and one for the *first* call. A more efficient way is to invoke
 # `Range#each` without a block, which gives us an `Iterator` so we can process the operations
 # lazily:
 #


### PR DESCRIPTION
The sample code was changed 6 years ago, but not the accompanying prose.