### PR TITLE
Compiler: remove duplicate instance vars once we know them all

### DIFF
--- a/spec/compiler/semantic/instance_var_spec.cr
+++ b/spec/compiler/semantic/instance_var_spec.cr
@@ -5668,7 +5668,7 @@ describe "Semantic: instance var" do
 
     context "with incompatible type" do
       it "module and class, with definitions" do
-        assert_error <<-CR, "instance variable '@a' of A must be Int32, not (Char | Int32)"
+        assert_error <<-CR, "instance variable '@a' of A, with B < A, is already declared as Int32 (trying to re-declare it in B as Char)"
           module M
             @a = 'a'
           end
@@ -5684,7 +5684,7 @@ describe "Semantic: instance var" do
       end
 
       it "module and class, with declarations" do
-        assert_error <<-CR, "instance variable '@a' of A must be Int32, not (Char | Int32)"
+        assert_error <<-CR, "instance variable '@a' of A, with B < A, is already declared as Int32 (trying to re-declare it in B as Char)"
           module M
             @a : Char = 'a'
           end

--- a/src/compiler/crystal/semantic/type_declaration_processor.cr
+++ b/src/compiler/crystal/semantic/type_declaration_processor.cr
@@ -122,9 +122,6 @@ struct Crystal::TypeDeclarationProcessor
     # of instance vars in extended modules
     @has_no_extenders = Set(Type).new
 
-    # All the types that we checked for duplicate variables
-    @duplicates_checked = Set(Type).new
-
     @type_decl_visitor = TypeDeclarationVisitor.new(@program, @explicit_instance_vars)
 
     @type_guess_visitor = TypeGuessVisitor.new(@program, @explicit_instance_vars,
@@ -625,11 +622,13 @@ struct Crystal::TypeDeclarationProcessor
   end
 
   private def remove_duplicate_instance_vars_declarations
-    remove_duplicate_instance_vars_declarations(@program)
+    # All the types that we checked for duplicate variables
+    duplicates_checked = Set(Type).new
+    remove_duplicate_instance_vars_declarations(@program, duplicates_checked)
   end
 
-  private def remove_duplicate_instance_vars_declarations(type : Type)
-    return unless @duplicates_checked.add?(type)
+  private def remove_duplicate_instance_vars_declarations(type : Type, duplicates_checked : Set(Type))
+    return unless duplicates_checked.add?(type)
 
     # If a class has an instance variable that already exists in a superclass, remove it.
     # Ideally we should process instance variables in a top-down fashion, but it's tricky
@@ -642,7 +641,7 @@ struct Crystal::TypeDeclarationProcessor
     end
 
     type.types?.try &.each_value do |nested_type|
-      remove_duplicate_instance_vars_declarations(nested_type)
+      remove_duplicate_instance_vars_declarations(nested_type, duplicates_checked)
     end
   end
 


### PR DESCRIPTION
Fixes #11673
Fixes #11994

I'll let CI run the specs because there's an XML spec that on my machine always segfaults and I still don't know why 🤷 