### PR TITLE
Expose additional GC prof stats fields

### DIFF
--- a/src/gc.cr
+++ b/src/gc.cr
@@ -66,7 +66,9 @@ module GC
     gc_no : LibC::ULong,
     markers_m1 : LibC::ULong,
     bytes_reclaimed_since_gc : LibC::ULong,
-    reclaimed_bytes_before_gc : LibC::ULong
+    reclaimed_bytes_before_gc : LibC::ULong,
+    explicitly_freed_bytes_since_gc : LibC::ULong,
+    obtained_from_os_bytes : LibC::ULong
 
   # Allocates and clears *size* bytes of memory.
   #

--- a/src/gc/boehm.cr
+++ b/src/gc/boehm.cr
@@ -48,6 +48,8 @@ lib LibGC
     markers_m1 : Word
     bytes_reclaimed_since_gc : Word
     reclaimed_bytes_before_gc : Word
+    explicitly_freed_bytes_since_gc : Word
+    obtained_from_os_bytes : Word
   end
 
   fun init = GC_init
@@ -232,7 +234,9 @@ module GC
       gc_no: stats.gc_no,
       markers_m1: stats.markers_m1,
       bytes_reclaimed_since_gc: stats.bytes_reclaimed_since_gc,
-      reclaimed_bytes_before_gc: stats.reclaimed_bytes_before_gc)
+      reclaimed_bytes_before_gc: stats.reclaimed_bytes_before_gc,
+      explicitly_freed_bytes_since_gc: stats.explicitly_freed_bytes_since_gc,
+      obtained_from_os_bytes: stats.obtained_from_os_bytes)
   end
 
   {% unless flag?(:win32) %}


### PR DESCRIPTION
In bdwgc 8.2.0, there are two additional prof_stats fields.
This updates the mapped crystal types to include these fields.

https://github.com/ivmai/bdwgc/blob/v8.2.0/include/gc.h#L812-L816

Example output:

    GC::ProfStats(
     @bytes_before_gc=844434288,
     @bytes_reclaimed_since_gc=1008096,
     @bytes_since_gc=825040,
     # new
     @explicitly_freed_bytes_since_gc=123808,
     @free_bytes=864256,
     @gc_no=1224,
     @heap_size=1695744,
     @markers_m1=3,
     @non_gc_bytes=0,
     # new
     @obtained_from_os_bytes=2088960,
     @reclaimed_bytes_before_gc=653709120,
     @unmapped_bytes=442368)