### PR TITLE
Add docs for `Float`, `BigFloat` rounding methods

### DIFF
--- a/src/big/big_float.cr
+++ b/src/big/big_float.cr
@@ -149,14 +149,17 @@ struct BigFloat < Float
     BigFloat.new { |mpf| LibGMP.mpf_abs(mpf, self) }
   end
 
+  # Rounds towards positive infinity.
   def ceil : BigFloat
     BigFloat.new { |mpf| LibGMP.mpf_ceil(mpf, self) }
   end
 
+  # Rounds towards negative infinity.
   def floor : BigFloat
     BigFloat.new { |mpf| LibGMP.mpf_floor(mpf, self) }
   end
 
+  # Rounds towards zero.
   def trunc : BigFloat
     BigFloat.new { |mpf| LibGMP.mpf_trunc(mpf, self) }
   end

--- a/src/float.cr
+++ b/src/float.cr
@@ -155,10 +155,12 @@ struct Float32
   Number.expand_div [Int8, UInt8, Int16, UInt16, Int32, UInt32, Int64, UInt64, Int128, UInt128], Float32
   Number.expand_div [Float64], Float64
 
+  # Rounds towards positive infinity.
   def ceil : Float32
     LibM.ceil_f32(self)
   end
 
+  # Rounds towards negative infinity.
   def floor : Float32
     LibM.floor_f32(self)
   end
@@ -177,6 +179,7 @@ struct Float32
     LibM.round_f32(self)
   end
 
+  # Rounds towards zero.
   def trunc : Float32
     LibM.trunc_f32(self)
   end


### PR DESCRIPTION
These descriptions exist for `BigDecimal` - adding them for the float methods.