### PR TITLE
Avoid compile-time error on empty `NamedTuple`s.

### DIFF
--- a/spec/std/json/serialization_spec.cr
+++ b/spec/std/json/serialization_spec.cr
@@ -147,6 +147,12 @@ describe "JSON serialization" do
       tuple.should be_a(NamedTuple(x: Int32, y: String))
     end
 
+    it "does for empty named tuple" do
+      tuple = typeof(NamedTuple.new).from_json(%({}))
+      tuple.should eq(NamedTuple.new)
+      tuple.should be_a(typeof(NamedTuple.new))
+    end
+
     it "does for named tuple with nilable fields (#8089)" do
       tuple = NamedTuple(x: Int32?, y: String).from_json(%({"y": "hello"}))
       tuple.should eq({x: nil, y: "hello"})

--- a/spec/std/named_tuple_spec.cr
+++ b/spec/std/named_tuple_spec.cr
@@ -381,6 +381,9 @@ describe "NamedTuple" do
 
     tup2 = {"foo bar": 1}
     tup2.clone.should eq(tup2)
+
+    tup3 = NamedTuple.new
+    tup3.clone.should eq(tup3)
   end
 
   it "does keys" do
@@ -402,6 +405,10 @@ describe "NamedTuple" do
     a = {one: 1, two: 2, three: 3, four: 4, five: 5, "im \"string": "works"}
     b = {two: "Two", three: true, "new one": "ok"}
     a.merge(b).merge(four: "Four").merge(NamedTuple.new).should eq({one: 1, two: "Two", three: true, four: "Four", five: 5, "new one": "ok", "im \"string": "works"})
+  end
+
+  it "merges two empty named tuples" do
+    NamedTuple.new.merge(NamedTuple.new).should eq(NamedTuple.new)
   end
 
   it "does types" do

--- a/spec/std/yaml/serialization_spec.cr
+++ b/spec/std/yaml/serialization_spec.cr
@@ -154,6 +154,12 @@ describe "YAML serialization" do
       tuple.should be_a(NamedTuple(x: Int32, y: String))
     end
 
+    it "does for empty named tuple" do
+      tuple = typeof(NamedTuple.new).from_yaml(%({}))
+      tuple.should eq(NamedTuple.new)
+      tuple.should be_a(typeof(NamedTuple.new))
+    end
+
     it "does for named tuple with nilable fields (#8089)" do
       tuple = NamedTuple(x: Int32?, y: String).from_yaml(%({"y": "hello"}))
       tuple.should eq({x: nil, y: "hello"})

--- a/src/json/from_json.cr
+++ b/src/json/from_json.cr
@@ -291,11 +291,11 @@ def NamedTuple.new(pull : JSON::PullParser)
       end
     {% end %}
 
-    {
+    NamedTuple.new(
       {% for key, type in T %}
         {{key.id.stringify}}: (%var{key.id}).as({{type}}),
       {% end %}
-    }
+    )
   {% end %}
 end
 

--- a/src/named_tuple.cr
+++ b/src/named_tuple.cr
@@ -237,10 +237,10 @@ struct NamedTuple
   # :ditto:
   def merge(**other : **U) forall U
     {% begin %}
-    {
+    NamedTuple.new(
       {% for k in T %} {% unless U.keys.includes?(k) %} {{k.stringify}}: self[{{k.symbolize}}],{% end %} {% end %}
       {% for k in U %} {{k.stringify}}: other[{{k.symbolize}}], {% end %}
-    }
+    )
     {% end %}
   end
 
@@ -587,11 +587,11 @@ struct NamedTuple
   # Returns a named tuple with the same keys but with cloned values, using the `clone` method.
   def clone
     {% begin %}
-      {
+      NamedTuple.new(
         {% for key in T %}
           {{key.stringify}}: self[{{key.symbolize}}].clone,
         {% end %}
-      }
+      )
     {% end %}
   end
 

--- a/src/yaml/from_yaml.cr
+++ b/src/yaml/from_yaml.cr
@@ -211,11 +211,11 @@ def NamedTuple.new(ctx : YAML::ParseContext, node : YAML::Nodes::Node)
       end
     {% end %}
 
-    {
+    NamedTuple.new(
       {% for key, type in T %}
         {{key.id.stringify}}: (%var{key.id}).as({{type}}),
       {% end %}
-    }
+    )
   {% end %}
 end
 


### PR DESCRIPTION
Fix #12006.
This PR replaces the curly brackets by `NamedTuple.new` in order to avoid compile-time errors on empty named tuples for the functions `NamedTuple#merge`, `NamedTuple#clone`, `NamedTuple#new(pull : JSON::PullParser)`, and `NamedTuple.new(ctx : YAML::ParseContext, node : YAML::Nodes::Node)`.

This is my first PR :), so tell me if I did anything wrong, if the fix is acceptable/wanted or if the spec are fine.  