### PR TITLE
Allow the empty instantiation `NamedTuple()`

### DIFF
--- a/spec/compiler/formatter/formatter_spec.cr
+++ b/spec/compiler/formatter/formatter_spec.cr
@@ -146,6 +146,11 @@ describe Crystal::Formatter do
   assert_format "::Pointer(T)"
   assert_format "::StaticArray(T)"
 
+  assert_format "Tuple()"
+  assert_format "::Tuple()"
+  assert_format "NamedTuple()"
+  assert_format "::NamedTuple()"
+
   %w(if unless).each do |keyword|
     assert_format "#{keyword} a\n2\nend", "#{keyword} a\n  2\nend"
     assert_format "#{keyword} a\n2\n3\nend", "#{keyword} a\n  2\n  3\nend"

--- a/spec/compiler/semantic/named_tuple_spec.cr
+++ b/spec/compiler/semantic/named_tuple_spec.cr
@@ -104,18 +104,15 @@ describe "Semantic: named tuples" do
       "can only use named arguments with NamedTuple"
   end
 
-  it "gives error when using named args on Tuple" do
-    assert_error %(
-      Tuple(x: Int32, y: Char)
-      ),
-      "can only use named arguments with NamedTuple"
-  end
-
-  it "gives error when not using named args with NamedTuple" do
+  it "gives error when using positional args with NamedTuple" do
     assert_error %(
       NamedTuple(Int32, Char)
       ),
       "can only instantiate NamedTuple with named arguments"
+  end
+
+  it "doesn't error if NamedTuple has no args" do
+    assert_type("NamedTuple()") { named_tuple_of({} of String => Type).metaclass }
   end
 
   it "gets type at compile time" do

--- a/spec/compiler/semantic/restrictions_spec.cr
+++ b/spec/compiler/semantic/restrictions_spec.cr
@@ -916,4 +916,50 @@ describe "Restrictions" do
       foo x
       )) { int32 }
   end
+
+  it "errors if using Tuple with named args" do
+    assert_error <<-CR, "can only instantiate NamedTuple with named arguments"
+      def foo(x : Tuple(a: Int32))
+      end
+
+      foo({1})
+      CR
+  end
+
+  it "doesn't error if using Tuple with no args" do
+    assert_type(<<-CR) { tuple_of([] of Type) }
+      def foo(x : Tuple())
+        x
+      end
+
+      def bar(*args : *T) forall T
+        args
+      end
+
+      foo(bar)
+      CR
+  end
+
+  it "errors if using NamedTuple with positional args" do
+    assert_error <<-CR, "can only instantiate NamedTuple with named arguments"
+      def foo(x : NamedTuple(Int32))
+      end
+
+      foo({a: 1})
+      CR
+  end
+
+  it "doesn't error if using NamedTuple with no args" do
+    assert_type(<<-CR) { named_tuple_of({} of String => Type) }
+      def foo(x : NamedTuple())
+        x
+      end
+
+      def bar(**opts : **T) forall T
+        opts
+      end
+
+      foo(bar)
+      CR
+  end
 end

--- a/spec/compiler/semantic/tuple_spec.cr
+++ b/spec/compiler/semantic/tuple_spec.cr
@@ -318,6 +318,17 @@ describe "Semantic: tuples" do
     assert_type("Tuple(Int32, Float64)") { tuple_of([int32, float64]).metaclass }
   end
 
+  it "gives error when using named args on Tuple" do
+    assert_error %(
+      Tuple(x: Int32, y: Char)
+      ),
+      "can only use named arguments with NamedTuple"
+  end
+
+  it "doesn't error if Tuple has no args" do
+    assert_type("Tuple()") { tuple_of([] of Type).metaclass }
+  end
+
   it "types T as a tuple of metaclasses" do
     assert_type("
       struct Tuple

--- a/src/compiler/crystal/semantic/bindings.cr
+++ b/src/compiler/crystal/semantic/bindings.cr
@@ -530,7 +530,8 @@ module Crystal
     def update(from = nil)
       instance_type = self.instance_type
       if instance_type.is_a?(NamedTupleType)
-        entries = named_args.not_nil!.map do |named_arg|
+        entries = Array(NamedArgumentType).new(named_args.try(&.size) || 0)
+        named_args.try &.each do |named_arg|
           node = named_arg.value
 
           if node.is_a?(Path) && (syntax_replacement = node.syntax_replacement)
@@ -551,7 +552,7 @@ module Crystal
           Crystal.check_type_can_be_stored(node, node_type, "can't use #{node_type} as generic type argument")
           node_type = node_type.virtual_type
 
-          NamedArgumentType.new(named_arg.name, node_type)
+          entries << NamedArgumentType.new(named_arg.name, node_type)
         end
 
         generic_type = instance_type.instantiate_named_args(entries)

--- a/src/compiler/crystal/semantic/main_visitor.cr
+++ b/src/compiler/crystal/semantic/main_visitor.cr
@@ -250,7 +250,7 @@ module Crystal
       end
 
       if instance_type.double_variadic?
-        unless node.named_args
+        unless node.type_vars.empty?
           node.raise "can only instantiate NamedTuple with named arguments"
         end
       else

--- a/src/compiler/crystal/semantic/type_lookup.cr
+++ b/src/compiler/crystal/semantic/type_lookup.cr
@@ -174,12 +174,13 @@ class Crystal::Type
 
       case instance_type
       when NamedTupleType
-        named_args = node.named_args
-        unless named_args
+        unless node.type_vars.empty?
           node.raise "can only instantiate NamedTuple with named arguments"
         end
 
-        entries = named_args.map do |named_arg|
+        named_args = node.named_args
+        entries = Array(NamedArgumentType).new(named_args.try(&.size) || 0)
+        named_args.try &.each do |named_arg|
           subnode = named_arg.value
 
           if subnode.is_a?(NumberLiteral)
@@ -191,7 +192,7 @@ class Crystal::Type
           type = type.not_nil!
 
           check_type_can_be_stored(subnode, type, "can't use #{type} as a generic type argument")
-          NamedArgumentType.new(named_arg.name, type.virtual_type)
+          entries << NamedArgumentType.new(named_arg.name, type.virtual_type)
         end
 
         begin

--- a/src/compiler/crystal/tools/formatter.cr
+++ b/src/compiler/crystal/tools/formatter.cr
@@ -1093,8 +1093,6 @@ module Crystal
       check_open_paren
 
       name = node.name.as(Path)
-      first_name = name.global? && name.names.size == 1 && name.names.first
-
       if name.global? && @token.type.op_colon_colon?
         write "::"
         next_token_skip_space_or_newline
@@ -1146,6 +1144,9 @@ module Crystal
         write_token :OP_RSQUARE
         return false
       end
+
+      # NOTE: not `name.single_name?` as this is only for the expanded tuple literals
+      first_name = name.names.first if name.global? && name.names.size == 1
 
       # Check if it's {A, B} instead of Tuple(A, B)
       if first_name == "Tuple" && @token.value != "Tuple"

--- a/src/named_tuple.cr
+++ b/src/named_tuple.cr
@@ -42,7 +42,7 @@ struct NamedTuple
       options
     {% elsif @type.name(generic_args: false) == "NamedTuple()" %}
       # special case: empty named tuple
-      # TODO: check against `NamedTuple()` directly after 1.4.0
+      # TODO: check against `NamedTuple()` directly after 1.5.0
       options
     {% else %}
       # explicitly provided type vars


### PR DESCRIPTION
Follow-up to #11906. Allows the `Generic` node `NamedTuple()` to resolve to the `NamedTuple` instantiation with no elements. `Generic` nodes will still fail to resolve if their name refers to the top-level `NamedTuple` and any positional type variables are found.