### PR TITLE
Introduce `Tuple.element_type` and `NamedTuple.element_type`

### DIFF
--- a/src/named_tuple.cr
+++ b/src/named_tuple.cr
@@ -49,10 +49,7 @@ struct NamedTuple
       {% begin %}
         {
           {% for key in T %}
-            {{ key.stringify }}: options[{{ key.symbolize }}].as(typeof(begin
-              x = uninitialized self
-              x[{{ key.symbolize }}]
-            end)),
+            {{ key.stringify }}: options[{{ key.symbolize }}].as(typeof(element_type({{ key }}))),
           {% end %}
         }
       {% end %}
@@ -603,5 +600,19 @@ struct NamedTuple
   private def first_value_internal
     i = 0
     values[i]
+  end
+
+  # Returns a value with the same type as the value for the given *key* of an
+  # instance of `self`. *key* must be a symbol or string literal known at
+  # compile-time.
+  #
+  # The most common usage of this macro is to extract the appropriate element
+  # type in `NamedTuple`'s class methods. This macro works even if the
+  # corresponding element type is private.
+  #
+  # NOTE: there should never be a need to call this method outside the standard library.
+  private macro element_type(key)
+    x = uninitialized self
+    x[{{ key.symbolize }}]
   end
 end

--- a/src/tuple.cr
+++ b/src/tuple.cr
@@ -101,10 +101,7 @@ struct Tuple
       {% begin %}
         {
           {% for i in 0...@type.size %}
-            args[{{ i }}].as(typeof(begin
-              x = uninitialized self
-              x[{{ i }}]
-            end)),
+            args[{{ i }}].as(typeof(element_type({{ i }}))),
           {% end %}
         }
       {% end %}
@@ -617,5 +614,19 @@ struct Tuple
     {% else %}
       self[{{T.size - 1}}]
     {% end %}
+  end
+
+  # Returns a value with the same type as the element at the given *index* of
+  # an instance of `self`. *index* must be an integer or range literal known at
+  # compile-time.
+  #
+  # The most common usage of this macro is to extract the appropriate element
+  # type in `Tuple`'s class methods. This macro works even if the corresponding
+  # element type is private.
+  #
+  # NOTE: there should never be a need to call this method outside the standard library.
+  private macro element_type(index)
+    x = uninitialized self
+    x[{{ index }}]
   end
 end


### PR DESCRIPTION
These macros act as compile-time equivalents of `Enumerable.element_type`, and encapsulate the `typeof(begin; ...; end)` pattern found in e.g. #11834 and #12008.

Due to syntax limitations, the line below will not work:

```crystal
Tuple(Int32, String).element_type(1) # Error: undefined method 'element_type' for Tuple(Int32, String).class
```

For some reason it doesn't work even on aliases of `Tuple` instances, so these macros are private for now; the currently use cases do not require this macro to be public or protected. Also note that `Enumerable` is a module, so `Enumerable.element_type` is not inherited by `Tuple` and `NamedTuple`.