### PR TITLE
Add `pthread` link annotations in lib bindings

### DIFF
--- a/src/lib_c/aarch64-linux-gnu/c/pthread.cr
+++ b/src/lib_c/aarch64-linux-gnu/c/pthread.cr
@@ -6,7 +6,7 @@ require "./sys/types"
 # static libraries. So we just skip `pthread` entirely in interpreted mode.
 # The symbols are still available in the interpreter because they are loaded in the compiler.
 {% unless flag?(:interpreted) %}
-@[Link("pthread")]
+  @[Link("pthread")]
 {% end %}
 lib LibC
   PTHREAD_MUTEX_ERRORCHECK = 2

--- a/src/lib_c/aarch64-linux-gnu/c/pthread.cr
+++ b/src/lib_c/aarch64-linux-gnu/c/pthread.cr
@@ -1,5 +1,13 @@
 require "./sys/types"
 
+# Starting with glibc 2.34, `pthread` is integrated into `libc` and may not even
+# be available as a separate shared library.
+# There's always a static library for compiled mode, but `Crystal::Loader` does not support
+# static libraries. So we just skip `pthread` entirely in interpreted mode.
+# The symbols are still available in the interpreter because they are loaded in the compiler.
+{% unless flag?(:interpreted) %}
+@[Link("pthread")]
+{% end %}
 lib LibC
   PTHREAD_MUTEX_ERRORCHECK = 2
 

--- a/src/lib_c/arm-linux-gnueabihf/c/pthread.cr
+++ b/src/lib_c/arm-linux-gnueabihf/c/pthread.cr
@@ -6,7 +6,7 @@ require "./sys/types"
 # static libraries. So we just skip `pthread` entirely in interpreted mode.
 # The symbols are still available in the interpreter because they are loaded in the compiler.
 {% unless flag?(:interpreted) %}
-@[Link("pthread")]
+  @[Link("pthread")]
 {% end %}
 lib LibC
   PTHREAD_MUTEX_ERRORCHECK = 2

--- a/src/lib_c/arm-linux-gnueabihf/c/pthread.cr
+++ b/src/lib_c/arm-linux-gnueabihf/c/pthread.cr
@@ -1,5 +1,13 @@
 require "./sys/types"
 
+# Starting with glibc 2.34, `pthread` is integrated into `libc` and may not even
+# be available as a separate shared library.
+# There's always a static library for compiled mode, but `Crystal::Loader` does not support
+# static libraries. So we just skip `pthread` entirely in interpreted mode.
+# The symbols are still available in the interpreter because they are loaded in the compiler.
+{% unless flag?(:interpreted) %}
+@[Link("pthread")]
+{% end %}
 lib LibC
   PTHREAD_MUTEX_ERRORCHECK = 2
 

--- a/src/lib_c/i386-linux-gnu/c/pthread.cr
+++ b/src/lib_c/i386-linux-gnu/c/pthread.cr
@@ -6,7 +6,7 @@ require "./sys/types"
 # static libraries. So we just skip `pthread` entirely in interpreted mode.
 # The symbols are still available in the interpreter because they are loaded in the compiler.
 {% unless flag?(:interpreted) %}
-@[Link("pthread")]
+  @[Link("pthread")]
 {% end %}
 lib LibC
   PTHREAD_MUTEX_ERRORCHECK = 2

--- a/src/lib_c/i386-linux-gnu/c/pthread.cr
+++ b/src/lib_c/i386-linux-gnu/c/pthread.cr
@@ -1,5 +1,13 @@
 require "./sys/types"
 
+# Starting with glibc 2.34, `pthread` is integrated into `libc` and may not even
+# be available as a separate shared library.
+# There's always a static library for compiled mode, but `Crystal::Loader` does not support
+# static libraries. So we just skip `pthread` entirely in interpreted mode.
+# The symbols are still available in the interpreter because they are loaded in the compiler.
+{% unless flag?(:interpreted) %}
+@[Link("pthread")]
+{% end %}
 lib LibC
   PTHREAD_MUTEX_ERRORCHECK = 2
 

--- a/src/lib_c/x86_64-linux-gnu/c/pthread.cr
+++ b/src/lib_c/x86_64-linux-gnu/c/pthread.cr
@@ -6,7 +6,7 @@ require "./sys/types"
 # static libraries. So we just skip `pthread` entirely in interpreted mode.
 # The symbols are still available in the interpreter because they are loaded in the compiler.
 {% unless flag?(:interpreted) %}
-@[Link("pthread")]
+  @[Link("pthread")]
 {% end %}
 lib LibC
   PTHREAD_MUTEX_ERRORCHECK = 2

--- a/src/lib_c/x86_64-linux-gnu/c/pthread.cr
+++ b/src/lib_c/x86_64-linux-gnu/c/pthread.cr
@@ -1,5 +1,13 @@
 require "./sys/types"
 
+# Starting with glibc 2.34, `pthread` is integrated into `libc` and may not even
+# be available as a separate shared library.
+# There's always a static library for compiled mode, but `Crystal::Loader` does not support
+# static libraries. So we just skip `pthread` entirely in interpreted mode.
+# The symbols are still available in the interpreter because they are loaded in the compiler.
+{% unless flag?(:interpreted) %}
+@[Link("pthread")]
+{% end %}
 lib LibC
   PTHREAD_MUTEX_ERRORCHECK = 2
 


### PR DESCRIPTION
In older versions of glibc (< 2.34), `pthread` is a separate library and needs to be explicitly added as linker argument.

This implicitly works with programs that use the garbage collector, because a link annotation is added there to ensure proper link order: 
https://github.com/crystal-lang/crystal/blob/ef05e26d6ecb0c7d1f5f0568af76ed001896a601/src/gc/boehm.cr#L16-L17

But when using `-Dgc_none` we were missing link annotations for `pthread` since the cleanup in #11563

This patch adds the missing annotation to the glibc bindings for `pthread` symbols. Other platforms might be affected as well (BSDs?), but it's only confirmed to be an issue for GNU so far.

Resolves #11986