### PR TITLE
[CI] Pin version of ubuntu base image for circleci jobs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -32,7 +32,8 @@ defaults:
 
 jobs:
   test_linux:
-    machine: true
+    machine:
+      image: ubuntu-2004:202201-02
     environment:
       <<: *env
       TRAVIS_OS_NAME: linux
@@ -60,7 +61,8 @@ jobs:
             - docs
 
   test_alpine:
-    machine: true
+    machine:
+      image: ubuntu-2004:202201-02
     environment:
       <<: *env
       TRAVIS_OS_NAME: linux
@@ -102,7 +104,8 @@ jobs:
             - ~/Library/Caches/Homebrew/downloads
 
   test_preview_mt:
-    machine: true
+    machine:
+      image: ubuntu-2004:202201-02
     environment:
       <<: *env
       TRAVIS_OS_NAME: linux
@@ -247,7 +250,8 @@ jobs:
             - distribution-scripts
 
   dist_linux:
-    machine: true
+    machine:
+      image: ubuntu-2004:202201-02
     steps:
       - attach_workspace:
           at: /tmp/workspace
@@ -329,7 +333,8 @@ jobs:
                 /tmp/workspace/build/crystal-*-docs.tar.gz
 
   dist_docker:
-    machine: true
+    machine:
+      image: ubuntu-2004:202201-02
     steps:
       - attach_workspace:
           at: /tmp/workspace
@@ -344,7 +349,8 @@ jobs:
             - build
 
   publish_docker:
-    machine: true
+    machine:
+      image: ubuntu-2004:202201-02
     steps:
       - attach_workspace:
           at: /tmp/workspace
@@ -398,7 +404,8 @@ jobs:
             snapcraft push /tmp/workspace/build/*.snap --release=$SNAP_CHANNEL
 
   dist_docs:
-    machine: true
+    machine:
+      image: ubuntu-2004:202201-02
     steps:
       - attach_workspace:
           at: /tmp/workspace
@@ -443,7 +450,8 @@ jobs:
           destination: dist_packages
 
   test_dist_linux_on_docker:
-    machine: true
+    machine:
+      image: ubuntu-2004:202201-02
     environment:
       <<: *env
       TRAVIS_OS_NAME: linux


### PR DESCRIPTION
`machine: true` uses the 14.04 image which is being phased out by circleci.

https://circleci.com/blog/ubuntu-14-16-image-deprecation/