### PR TITLE
Handle OpenSSL 3.0 KTLS ctrl calls

### DIFF
--- a/src/openssl/bio.cr
+++ b/src/openssl/bio.cr
@@ -57,6 +57,10 @@ struct OpenSSL::BIO
               1
             when LibCrypto::CTRL_PUSH, LibCrypto::CTRL_POP, LibCrypto::CTRL_EOF
               0
+            when LibCrypto::CTRL_SET_KTLS_SEND
+              0
+            when LibCrypto::CTRL_GET_KTLS_SEND, LibCrypto::CTRL_GET_KTLS_RECV
+              0
             else
               STDERR.puts "WARNING: Unsupported BIO ctrl call (#{cmd})"
               0

--- a/src/openssl/lib_crypto.cr
+++ b/src/openssl/lib_crypto.cr
@@ -71,10 +71,13 @@ lib LibCrypto
   EVP_MAX_KEY_LENGTH = 32
   EVP_MAX_IV_LENGTH  = 16
 
-  CTRL_EOF   =  2
-  CTRL_PUSH  =  6
-  CTRL_POP   =  7
-  CTRL_FLUSH = 11
+  CTRL_EOF           =  2
+  CTRL_PUSH          =  6
+  CTRL_POP           =  7
+  CTRL_FLUSH         = 11
+  CTRL_SET_KTLS_SEND = 72
+  CTRL_GET_KTLS_SEND = 73
+  CTRL_GET_KTLS_RECV = 76
 
   alias BioMethodWrite = (Bio*, Char*, SizeT, SizeT*) -> Int
   alias BioMethodWriteOld = (Bio*, Char*, Int) -> Int


### PR DESCRIPTION
OpenSSL 3.0 has optional support for Kernel TLS, we don't support it yet but we need to handle the BIO calls to avoid spurious warning messages.

Fixes #12025 