### PR TITLE
Interpreter: Don't link `librt` and `libdl` on GNU systems

### DIFF
--- a/src/crystal/system/unix/lib_event2.cr
+++ b/src/crystal/system/unix/lib_event2.cr
@@ -1,8 +1,9 @@
 require "c/netdb"
 
-# MUSL: On musl systems, librt is empty. The entire library is already included in libc.
-# The empty library is only available for POSIX compatibility. We don't need to link it.
-{% if flag?(:linux) && !flag?(:musl) %}
+# On musl systems, librt is empty. The entire library is already included in libc.
+# On gnu systems, it's been integrated into `glibc` since 2.34 and it's not available
+# as a shared library.
+{% if flag?(:linux) && flag?(:gnu) && !flag?(:interpreted) %}
   @[Link("rt")]
 {% end %}
 

--- a/src/lib_c/aarch64-linux-gnu/c/dlfcn.cr
+++ b/src/lib_c/aarch64-linux-gnu/c/dlfcn.cr
@@ -1,4 +1,7 @@
-@[Link("dl")]
+{% unless flag?(:interpreted) %}
+  @[Link("dl")]
+{% end %}
+
 lib LibC
   RTLD_LAZY    = 0x00001
   RTLD_NOW     = 0x00002

--- a/src/lib_c/arm-linux-gnueabihf/c/dlfcn.cr
+++ b/src/lib_c/arm-linux-gnueabihf/c/dlfcn.cr
@@ -1,4 +1,7 @@
-@[Link("dl")]
+{% unless flag?(:interpreted) %}
+  @[Link("dl")]
+{% end %}
+
 lib LibC
   RTLD_LAZY    = 0x00001
   RTLD_NOW     = 0x00002

--- a/src/lib_c/i386-linux-gnu/c/dlfcn.cr
+++ b/src/lib_c/i386-linux-gnu/c/dlfcn.cr
@@ -1,4 +1,7 @@
-@[Link("dl")]
+{% unless flag?(:interpreted) %}
+  @[Link("dl")]
+{% end %}
+
 lib LibC
   RTLD_LAZY    = 0x00001
   RTLD_NOW     = 0x00002

--- a/src/lib_c/x86_64-linux-gnu/c/dlfcn.cr
+++ b/src/lib_c/x86_64-linux-gnu/c/dlfcn.cr
@@ -1,4 +1,7 @@
-@[Link("dl")]
+{% unless flag?(:interpreted) %}
+  @[Link("dl")]
+{% end %}
+
 lib LibC
   RTLD_LAZY    = 0x00001
   RTLD_NOW     = 0x00002


### PR DESCRIPTION
glibc 2.34 has merged librt and libdl into libc, so they're not
available as shared libraries. The symbols are still available to the
interpreter because they are loaded in the compiler.

Fixes #12036 