### PR TITLE
Add spec for `Array#-` with different generic type arguments

### DIFF
--- a/spec/std/array_spec.cr
+++ b/spec/std/array_spec.cr
@@ -144,6 +144,16 @@ describe "Array" do
     it "does with even larger arrays" do
       ((1..64).to_a - (1..32).to_a).should eq((33..64).to_a)
     end
+
+    context "with different types" do
+      it "small array)" do
+        ([1, 2, 3, 'c'] - [2, nil]).should eq [1, 3]
+      end
+
+      it "big array)" do
+        (((1..64).to_a + 'c') - ((2..63).to_a + [nil])).should eq [1, 64]
+      end
+    end
   end
 
   it "does *" do

--- a/spec/std/array_spec.cr
+++ b/spec/std/array_spec.cr
@@ -151,7 +151,7 @@ describe "Array" do
       end
 
       it "big array)" do
-        (((1..64).to_a + 'c') - ((2..63).to_a + [nil])).should eq [1, 64]
+        (((1..64).to_a + ['c']) - ((2..63).to_a + [nil])).should eq [1, 64]
       end
     end
   end

--- a/spec/std/array_spec.cr
+++ b/spec/std/array_spec.cr
@@ -147,11 +147,11 @@ describe "Array" do
 
     context "with different types" do
       it "small array)" do
-        ([1, 2, 3, 'c'] - [2, nil]).should eq [1, 3]
+        ([1, 2, 3, 'c'] - [2, nil]).should eq [1, 3, 'c']
       end
 
       it "big array)" do
-        (((1..64).to_a + ['c']) - ((2..63).to_a + [nil])).should eq [1, 64]
+        (((1..64).to_a + ['c']) - ((2..63).to_a + [nil])).should eq [1, 64, 'c']
       end
     end
   end

--- a/spec/std/array_spec.cr
+++ b/spec/std/array_spec.cr
@@ -146,11 +146,11 @@ describe "Array" do
     end
 
     context "with different types" do
-      it "small array)" do
+      it "small array" do
         ([1, 2, 3, 'c'] - [2, nil]).should eq [1, 3, 'c']
       end
 
-      it "big array)" do
+      it "big array" do
         (((1..64).to_a + ['c']) - ((2..63).to_a + [nil])).should eq [1, 64, 'c']
       end
     end


### PR DESCRIPTION
The specs only covered cases where receiver and argument both have the same generic type arguments. This adds some missing specs covering different types.

This is relevant in the context of #8893. Adding these specs makes sense whatever comes out of that, though.