### PR TITLE
Fix `Complex.multiplicative_identity`

### DIFF
--- a/spec/std/complex_spec.cr
+++ b/spec/std/complex_spec.cr
@@ -170,11 +170,23 @@ describe "Complex" do
     c.hash.should eq(4_f64.hash)
   end
 
+  it "test zero" do
+    Complex.zero.should eq(Complex.new(0, 0))
+  end
+
   it "test zero?" do
     Complex.new(0, 0).zero?.should eq true
     Complex.new(0, 3.4).zero?.should eq false
     Complex.new(1.2, 0).zero?.should eq false
     Complex.new(1.2, 3.4).zero?.should eq false
+  end
+
+  it "test additive_identity" do
+    Complex.additive_identity.should eq(Complex.new(0, 0))
+  end
+
+  it "test multiplicative_identity" do
+    Complex.multiplicative_identity.should eq(Complex.new(1, 0))
   end
 
   it "rounds" do

--- a/src/complex.cr
+++ b/src/complex.cr
@@ -269,7 +269,7 @@ struct Complex
     zero
   end
 
-  def multiplicative_identity : self
+  def self.multiplicative_identity : self
     new 1, 0
   end
 


### PR DESCRIPTION
Fix #12050 and add spec for `Complex.zero`, `Complex.additive_identity` and `Complex.multiplicative_identity`.