### PR TITLE
Make the error case uniform.

### DIFF
--- a/spec/compiler/crystal/tools/format_spec.cr
+++ b/spec/compiler/crystal/tools/format_spec.cr
@@ -57,7 +57,7 @@ describe Crystal::Command::FormatCommand do
     format_command.run
     format_command.status_code.should eq(1)
     stdout.to_s.should be_empty
-    stderr.to_s.should contain("file 'STDIN' is not a valid Crystal source file: Unexpected byte 0xff at position 1, malformed UTF-8")
+    stderr.to_s.should contain("file 'STDIN' is not a valid Crystal source file: unexpected byte 0xff at position 1, malformed UTF-8")
   end
 
   it "formats stdin (bug)" do
@@ -162,7 +162,7 @@ describe Crystal::Command::FormatCommand do
         format_command.status_code.should eq(1)
         stdout.to_s.should contain("Format #{Path[".", "format.cr"]}")
         stderr.to_s.should contain("syntax error in '#{Path[".", "syntax_error.cr"]}:1:3': unexpected token: EOF")
-        stderr.to_s.should contain("file '#{Path[".", "invalid_byte_sequence_error.cr"]}' is not a valid Crystal source file: Unexpected byte 0xff at position 1, malformed UTF-8")
+        stderr.to_s.should contain("file '#{Path[".", "invalid_byte_sequence_error.cr"]}' is not a valid Crystal source file: unexpected byte 0xff at position 1, malformed UTF-8")
 
         File.read(File.join(path, "format.cr")).should eq("if true\n  1\nend\n")
       end
@@ -226,7 +226,7 @@ describe Crystal::Command::FormatCommand do
         stderr.to_s.should_not contain("not_format.cr")
         stderr.to_s.should contain("formatting '#{Path[".", "format.cr"]}' produced changes")
         stderr.to_s.should contain("syntax error in '#{Path[".", "syntax_error.cr"]}:1:3': unexpected token: EOF")
-        stderr.to_s.should contain("file '#{Path[".", "invalid_byte_sequence_error.cr"]}' is not a valid Crystal source file: Unexpected byte 0xff at position 1, malformed UTF-8")
+        stderr.to_s.should contain("file '#{Path[".", "invalid_byte_sequence_error.cr"]}' is not a valid Crystal source file: unexpected byte 0xff at position 1, malformed UTF-8")
       end
     end
   end

--- a/spec/compiler/lexer/lexer_spec.cr
+++ b/spec/compiler/lexer/lexer_spec.cr
@@ -289,25 +289,25 @@ describe "Lexer" do
   assert_syntax_error "128_i8", "128 doesn't fit in an Int8"
   assert_syntax_error "-129_i8", "-129 doesn't fit in an Int8"
   assert_syntax_error "256_u8", "256 doesn't fit in an UInt8"
-  assert_syntax_error "-1_u8", "Invalid negative value -1 for UInt8"
+  assert_syntax_error "-1_u8", "invalid negative value -1 for UInt8"
 
   assert_syntax_error "32768_i16", "32768 doesn't fit in an Int16"
   assert_syntax_error "-32769_i16", "-32769 doesn't fit in an Int16"
   assert_syntax_error "65536_u16", "65536 doesn't fit in an UInt16"
-  assert_syntax_error "-1_u16", "Invalid negative value -1 for UInt16"
+  assert_syntax_error "-1_u16", "invalid negative value -1 for UInt16"
 
   assert_syntax_error "2147483648_i32", "2147483648 doesn't fit in an Int32"
   assert_syntax_error "-2147483649_i32", "-2147483649 doesn't fit in an Int32"
   assert_syntax_error "4294967296_u32", "4294967296 doesn't fit in an UInt32"
-  assert_syntax_error "-1_u32", "Invalid negative value -1 for UInt32"
+  assert_syntax_error "-1_u32", "invalid negative value -1 for UInt32"
 
   assert_syntax_error "9223372036854775808_i64", "9223372036854775808 doesn't fit in an Int64"
   assert_syntax_error "-9223372036854775809_i64", "-9223372036854775809 doesn't fit in an Int64"
   assert_syntax_error "118446744073709551616_u64", "118446744073709551616 doesn't fit in an UInt64"
   assert_syntax_error "18446744073709551616_u64", "18446744073709551616 doesn't fit in an UInt64"
-  assert_syntax_error "-1_u64", "Invalid negative value -1 for UInt64"
-  assert_syntax_error "-0_u64", "Invalid negative value -0 for UInt64"
-  assert_syntax_error "-0u64", "Invalid negative value -0 for UInt64"
+  assert_syntax_error "-1_u64", "invalid negative value -1 for UInt64"
+  assert_syntax_error "-0_u64", "invalid negative value -0 for UInt64"
+  assert_syntax_error "-0u64", "invalid negative value -0 for UInt64"
 
   assert_syntax_error "18446744073709551616_i32", "18446744073709551616 doesn't fit in an Int32"
   assert_syntax_error "9999999999999999999_i32", "9999999999999999999 doesn't fit in an Int32"
@@ -339,7 +339,7 @@ describe "Lexer" do
   assert_syntax_error "0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF", "0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF doesn't fit in an UInt64, try using the suffix u128"
   assert_syntax_error "-0x80000000000000000000000000000000", "-0x80000000000000000000000000000000 doesn't fit in an Int64, try using the suffix i128"
   assert_syntax_error "-0x80000000000000000000000000000001", "-0x80000000000000000000000000000001 doesn't fit in an Int64"
-  assert_syntax_error "-1_u128", "Invalid negative value -1 for UInt128"
+  assert_syntax_error "-1_u128", "invalid negative value -1 for UInt128"
 
   assert_syntax_error "1__1", "consecutive underscores in numbers aren't allowed"
   assert_syntax_error "-3_", "trailing '_' in number"
@@ -417,8 +417,8 @@ describe "Lexer" do
   assert_syntax_error "4F64", %(unexpected token: "F64")
   assert_syntax_error "0F32", %(unexpected token: "F32")
 
-  assert_syntax_error "4.0_u32", "Invalid suffix u32 for decimal number"
-  assert_syntax_error "2e8i8", "Invalid suffix i8 for decimal number"
+  assert_syntax_error "4.0_u32", "invalid suffix u32 for decimal number"
+  assert_syntax_error "2e8i8", "invalid suffix i8 for decimal number"
 
   assert_syntax_error ".42", ".1 style number literal is not supported, put 0 before dot"
   assert_syntax_error "-.42", ".1 style number literal is not supported, put 0 before dot"
@@ -501,8 +501,8 @@ describe "Lexer" do
     token.type.should eq(t :EOF)
   end
 
-  assert_syntax_error "/foo", "Unterminated regular expression"
-  assert_syntax_error "/\\", "Unterminated regular expression"
+  assert_syntax_error "/foo", "unterminated regular expression"
+  assert_syntax_error "/\\", "unterminated regular expression"
   assert_syntax_error ":\"foo", "unterminated quoted symbol"
 
   it "lexes utf-8 char" do

--- a/spec/compiler/lexer/lexer_string_spec.cr
+++ b/spec/compiler/lexer/lexer_string_spec.cr
@@ -237,7 +237,7 @@ describe "Lexer string" do
     token = lexer.next_token
     state = token.delimiter_state
 
-    expect_raises Crystal::SyntaxException, "Unterminated heredoc" do
+    expect_raises Crystal::SyntaxException, "unterminated heredoc" do
       loop do
         token = lexer.next_string_token state
         break if token.type.delimiter_end?
@@ -256,7 +256,7 @@ describe "Lexer string" do
   it "raises on unexpected EOF while lexing heredoc" do
     lexer = Lexer.new("<<-aaa")
 
-    expect_raises Crystal::SyntaxException, "Unexpected EOF on heredoc identifier" do
+    expect_raises Crystal::SyntaxException, "unexpected EOF on heredoc identifier" do
       lexer.next_token
     end
   end

--- a/spec/compiler/macro/macro_methods_spec.cr
+++ b/spec/compiler/macro/macro_methods_spec.cr
@@ -2894,13 +2894,13 @@ module Crystal
       end
 
       it "raises on extra unparsed tokens before the type" do
-        expect_raises(Crystal::TypeException, %(Invalid type name: "100Foo")) do
+        expect_raises(Crystal::TypeException, %(invalid type name: "100Foo")) do
           assert_macro %({{parse_type "100Foo" }}), %(nil)
         end
       end
 
       it "raises on extra unparsed tokens after the type" do
-        expect_raises(Crystal::TypeException, %(Invalid type name: "Foo(Int32)100")) do
+        expect_raises(Crystal::TypeException, %(invalid type name: "Foo(Int32)100")) do
           assert_macro %({{parse_type "Foo(Int32)100" }}), %(nil)
         end
       end

--- a/spec/compiler/parser/parser_spec.cr
+++ b/spec/compiler/parser/parser_spec.cr
@@ -192,8 +192,8 @@ module Crystal
     assert_syntax_error "1 == 2, a = 4"
     assert_syntax_error "x : String, a = 4"
     assert_syntax_error "b, 1 == 2, a = 4"
-    assert_syntax_error "a = 1, 2, 3", "Multiple assignment count mismatch"
-    assert_syntax_error "a = 1, b = 2", "Multiple assignment count mismatch"
+    assert_syntax_error "a = 1, 2, 3", "multiple assignment count mismatch"
+    assert_syntax_error "a = 1, b = 2", "multiple assignment count mismatch"
 
     assert_syntax_error "*a"
     assert_syntax_error "*a if true"
@@ -202,10 +202,10 @@ module Crystal
     assert_syntax_error "*1, a = 2"
     assert_syntax_error "*a, *b = 1", "splat assignment already specified"
 
-    assert_syntax_error "*a, b, c, d = 1, 2", "Multiple assignment count mismatch"
-    assert_syntax_error "a, b, *c, d = 1, 2", "Multiple assignment count mismatch"
-    assert_syntax_error "*a, b, c, d, e = 1, 2", "Multiple assignment count mismatch"
-    assert_syntax_error "a, b, c, d, *e = 1, 2, 3", "Multiple assignment count mismatch"
+    assert_syntax_error "*a, b, c, d = 1, 2", "multiple assignment count mismatch"
+    assert_syntax_error "a, b, *c, d = 1, 2", "multiple assignment count mismatch"
+    assert_syntax_error "*a, b, c, d, e = 1, 2", "multiple assignment count mismatch"
+    assert_syntax_error "a, b, c, d, *e = 1, 2, 3", "multiple assignment count mismatch"
 
     it_parses "def foo\n1\nend", Def.new("foo", body: 1.int32)
     it_parses "def downto(n)\n1\nend", Def.new("downto", ["n".arg], 1.int32)
@@ -1140,7 +1140,7 @@ module Crystal
     it_parses "$~ = 1", Assign.new("$~".var, 1.int32)
 
     assert_syntax_error "$2147483648"
-    assert_syntax_error "$99999999999999999999999?", "Index $99999999999999999999999 doesn't fit in an Int32"
+    assert_syntax_error "$99999999999999999999999?", "index $99999999999999999999999 doesn't fit in an Int32"
 
     it_parses "foo /a/", Call.new(nil, "foo", regex("a"))
     it_parses "foo(/a/)", Call.new(nil, "foo", regex("a"))
@@ -1593,8 +1593,8 @@ module Crystal
     it_parses "<<-EOF.x\n  foo\nEOF", Call.new("  foo".string_interpolation, "x")
     it_parses "<<-'EOF'.x\n  foo\nEOF", Call.new("  foo".string_interpolation, "x")
 
-    assert_syntax_error "<<-FOO\n1\nFOO.bar", "Unterminated heredoc: can't find \"FOO\" anywhere before the end of file"
-    assert_syntax_error "<<-FOO\n1\nFOO + 2", "Unterminated heredoc: can't find \"FOO\" anywhere before the end of file"
+    assert_syntax_error "<<-FOO\n1\nFOO.bar", "unterminated heredoc: can't find \"FOO\" anywhere before the end of file"
+    assert_syntax_error "<<-FOO\n1\nFOO + 2", "unterminated heredoc: can't find \"FOO\" anywhere before the end of file"
 
     it_parses "<<-FOO\n\t1\n\tFOO", "1".string_interpolation
     it_parses "<<-FOO\n \t1\n \tFOO", "1".string_interpolation
@@ -1835,7 +1835,7 @@ module Crystal
     assert_syntax_error "self += 1",
       "can't change the value of self"
     assert_syntax_error "FOO, BAR = 1, 2",
-      "Multiple assignment is not allowed for constants"
+      "multiple assignment is not allowed for constants"
     assert_syntax_error "self, x = 1, 2",
       "can't change the value of self"
     assert_syntax_error "x, self = 1, 2",
@@ -2089,18 +2089,18 @@ module Crystal
       it_parses "%i(foo(bar) baz)", (["foo(bar)".symbol, "baz".symbol] of ASTNode).array_of(Path.global("Symbol"))
       it_parses "%i{foo\\nbar baz}", (["foo\\nbar".symbol, "baz".symbol] of ASTNode).array_of(Path.global("Symbol"))
 
-      assert_syntax_error "%w(", "Unterminated string array literal"
+      assert_syntax_error "%w(", "unterminated string array literal"
       assert_syntax_error "%w{one}}", "expecting token 'EOF', not '}'"
-      assert_syntax_error "%w{{one}", "Unterminated string array literal"
-      assert_syntax_error "%i(", "Unterminated symbol array literal"
+      assert_syntax_error "%w{{one}", "unterminated string array literal"
+      assert_syntax_error "%i(", "unterminated symbol array literal"
       assert_syntax_error "%i{one}}", "expecting token 'EOF', not '}'"
-      assert_syntax_error "%i{{one}", "Unterminated symbol array literal"
-      assert_syntax_error "%x(", "Unterminated command literal"
-      assert_syntax_error "%r(", "Unterminated regular expression"
-      assert_syntax_error "%q(", "Unterminated string literal"
-      assert_syntax_error "%Q(", "Unterminated string literal"
-      assert_syntax_error "<<-HEREDOC", "Unexpected EOF on heredoc identifier"
-      assert_syntax_error "<<-HEREDOC\n", "Unterminated heredoc"
+      assert_syntax_error "%i{{one}", "unterminated symbol array literal"
+      assert_syntax_error "%x(", "unterminated command literal"
+      assert_syntax_error "%r(", "unterminated regular expression"
+      assert_syntax_error "%q(", "unterminated string literal"
+      assert_syntax_error "%Q(", "unterminated string literal"
+      assert_syntax_error "<<-HEREDOC", "unexpected EOF on heredoc identifier"
+      assert_syntax_error "<<-HEREDOC\n", "unterminated heredoc"
 
       assert_syntax_error "[1\n,2]", "expecting token ']', not ','"
       assert_syntax_error "{1\n,2}", "expecting token '}', not ','"

--- a/src/compiler/crystal/codegen/cast.cr
+++ b/src/compiler/crystal/codegen/cast.cr
@@ -506,7 +506,7 @@ class Crystal::CodeGenVisitor
       end
     end
 
-    raise "Bug: expected to find enum member of #{to_type} matching symbol #{symbol}"
+    raise "BUG: expected to find enum member of #{to_type} matching symbol #{symbol}"
   end
 
   def downcast_distinct(value, to_type : Type, from_type : Type)

--- a/src/compiler/crystal/codegen/codegen.cr
+++ b/src/compiler/crystal/codegen/codegen.cr
@@ -1059,7 +1059,7 @@ module Crystal
                 target.raise "BUG: missing var #{target}"
               end
             else
-              node.raise "Unknown assign target in codegen: #{target}"
+              node.raise "unknown assign target in codegen: #{target}"
             end
 
       @last = last

--- a/src/compiler/crystal/codegen/llvm_builder_helper.cr
+++ b/src/compiler/crystal/codegen/llvm_builder_helper.cr
@@ -47,7 +47,7 @@ module Crystal
       when .f64?
         float64(value.to_f64)
       else
-        raise "Unsupported float type"
+        raise "unsupported float type"
       end
     end
 

--- a/src/compiler/crystal/interpreter/compiler.cr
+++ b/src/compiler/crystal/interpreter/compiler.cr
@@ -892,7 +892,7 @@ class Crystal::Repl::Compiler < Crystal::Visitor
       end
 
       unless parent_index
-        raise "Can't find parent closure index"
+        raise "can't find parent closure index"
       end
 
       get_local parent_index, sizeof(Void*), node: nil

--- a/src/compiler/crystal/macros/methods.cr
+++ b/src/compiler/crystal/macros/methods.cr
@@ -152,7 +152,7 @@ module Crystal
                 when "host_flag?"
                   @program.host_flags
                 else
-                  raise "Bug: unexpected macro method #{node.name}"
+                  raise "BUG: unexpected macro method #{node.name}"
                 end
         @last = BoolLiteral.new(flags.includes?(flag_name))
       end
@@ -176,7 +176,7 @@ module Crystal
           parser.check :EOF
           @last = type
         rescue ex : Crystal::SyntaxException
-          arg.raise "Invalid type name: #{type_name.inspect}"
+          arg.raise "invalid type name: #{type_name.inspect}"
         end
       end
     end
@@ -620,7 +620,7 @@ module Crystal
           when StringLiteral, MacroId
             return BoolLiteral.new(interpret_compare(arg) > 0)
           else
-            raise "Can't compare StringLiteral with #{arg.class_desc}"
+            raise "can't compare StringLiteral with #{arg.class_desc}"
           end
         end
       when "<"
@@ -629,7 +629,7 @@ module Crystal
           when StringLiteral, MacroId
             return BoolLiteral.new(interpret_compare(arg) < 0)
           else
-            raise "Can't compare StringLiteral with #{arg.class_desc}"
+            raise "can't compare StringLiteral with #{arg.class_desc}"
           end
         end
       when "+"

--- a/src/compiler/crystal/program.cr
+++ b/src/compiler/crystal/program.cr
@@ -500,7 +500,7 @@ module Crystal
         when  8 then int64
         when 16 then int128
         else
-          raise "BUG: Invalid int size: #{size}"
+          raise "BUG: invalid int size: #{size}"
         end
       else
         case size
@@ -510,7 +510,7 @@ module Crystal
         when  8 then uint64
         when 16 then uint128
         else
-          raise "BUG: Invalid int size: #{size}"
+          raise "BUG: invalid int size: #{size}"
         end
       end
     end

--- a/src/compiler/crystal/semantic/call.cr
+++ b/src/compiler/crystal/semantic/call.cr
@@ -29,7 +29,7 @@ class Crystal::Call
       end
     end
 
-    ::raise "Zero target defs for #{self}"
+    ::raise "zero target defs for #{self}"
   end
 
   def recalculate

--- a/src/compiler/crystal/semantic/exhaustiveness_checker.cr
+++ b/src/compiler/crystal/semantic/exhaustiveness_checker.cr
@@ -241,7 +241,7 @@ struct Crystal::ExhaustivenessChecker
       elsif obj.is_a?(Generic) && when_cond.name == "class"
         TypePattern.new(obj.type.metaclass.devirtualize)
       else
-        raise "Bug: unknown pattern in exhaustive case"
+        raise "BUG: unknown pattern in exhaustive case"
       end
     when BoolLiteral
       BoolPattern.new(when_cond.value)
@@ -250,7 +250,7 @@ struct Crystal::ExhaustivenessChecker
     when Underscore
       UnderscorePattern.new
     else
-      raise "Bug: unknown pattern in exhaustive case"
+      raise "BUG: unknown pattern in exhaustive case"
     end
   end
 

--- a/src/compiler/crystal/semantic/main_visitor.cr
+++ b/src/compiler/crystal/semantic/main_visitor.cr
@@ -437,7 +437,7 @@ module Crystal
         var.var = class_var
         class_var.thread_local = true if thread_local
       else
-        raise "Bug: unexpected var type: #{var.class}"
+        raise "BUG: unexpected var type: #{var.class}"
       end
 
       node.type = @program.nil
@@ -518,7 +518,7 @@ module Crystal
         class_var = visit_class_var var
         class_var.thread_local = true if thread_local
       else
-        raise "Bug: unexpected var type: #{var.class}"
+        raise "BUG: unexpected var type: #{var.class}"
       end
 
       node.type = @program.nil unless node.type?

--- a/src/compiler/crystal/semantic/top_level_visitor.cr
+++ b/src/compiler/crystal/semantic/top_level_visitor.cr
@@ -157,7 +157,7 @@ class Crystal::TopLevelVisitor < Crystal::SemanticVisitor
           end
 
           unless ann.args.empty?
-            ann.raise "Extern annotation can't have positional arguments, only named arguments: 'union'"
+            ann.raise "extern annotation can't have positional arguments, only named arguments: 'union'"
           end
 
           ann.named_args.try &.each do |named_arg|
@@ -167,7 +167,7 @@ class Crystal::TopLevelVisitor < Crystal::SemanticVisitor
               if value.is_a?(BoolLiteral)
                 type.extern_union = value.value
               else
-                value.raise "Extern 'union' annotation must be a boolean, not #{value.class_desc}"
+                value.raise "extern 'union' annotation must be a boolean, not #{value.class_desc}"
               end
             else
               named_arg.raise "unknown Extern named argument, valid arguments are: 'union'"

--- a/src/compiler/crystal/semantic/type_declaration_visitor.cr
+++ b/src/compiler/crystal/semantic/type_declaration_visitor.cr
@@ -152,7 +152,7 @@ class Crystal::TypeDeclarationVisitor < Crystal::SemanticVisitor
     when ClassVar
       declare_class_var(node, var, false)
     else
-      raise "Unexpected TypeDeclaration var type: #{var.class}"
+      raise "unexpected TypeDeclaration var type: #{var.class}"
     end
 
     false

--- a/src/compiler/crystal/syntax/ast.cr
+++ b/src/compiler/crystal/syntax/ast.cr
@@ -298,7 +298,7 @@ module Crystal
       when UInt128 then U128
       when Float32 then F32
       when Float64 then F64
-      else              raise "Unsupported Number type for NumberLiteral: #{number.class}"
+      else              raise "unsupported Number type for NumberLiteral: #{number.class}"
       end
     end
   end
@@ -332,7 +332,7 @@ module Crystal
       when .u64?  then value.to_u64
       when .u128? then value.to_u128
       else
-        raise "Bug: called 'integer_value' for non-integer literal"
+        raise "BUG: called 'integer_value' for non-integer literal"
       end
     end
 

--- a/src/compiler/crystal/syntax/lexer.cr
+++ b/src/compiler/crystal/syntax/lexer.cr
@@ -241,7 +241,7 @@ module Crystal
               when ident_part?(char)
                 # ok
               when char == '\0'
-                raise "Unexpected EOF on heredoc identifier"
+                raise "unexpected EOF on heredoc identifier"
               else
                 if char == '\'' && has_single_quote
                   found_closing_single_quote = true
@@ -1457,7 +1457,7 @@ module Crystal
 
     macro gen_check_int_fits_in_size(type, method, size, number_size, raw_number_string, start, pos_before_suffix, negative)
       {% if type.stringify.starts_with? "U" %}
-        raise "Invalid negative value #{string_range({{start}}, {{pos_before_suffix}})} for {{type}}", @token, (current_pos - {{start}}) if {{negative}}
+        raise "invalid negative value #{string_range({{start}}, {{pos_before_suffix}})} for {{type}}", @token, (current_pos - {{start}}) if {{negative}}
       {% end %}
 
       if !@token.value || {{number_size}} > {{size}} || ({{number_size}} == {{size}} && {{raw_number_string}}.to_{{method.id}}? == nil)
@@ -1567,7 +1567,7 @@ module Crystal
 
       if is_decimal
         @token.number_kind = NumberKind::F64 if suffix_size == 0
-        raise("Invalid suffix #{@token.number_kind} for decimal number", @token, (current_pos - start)) unless @token.number_kind.float?
+        raise("invalid suffix #{@token.number_kind} for decimal number", @token, (current_pos - start)) unless @token.number_kind.float?
         return
       end
 
@@ -1885,11 +1885,11 @@ module Crystal
 
     def raise_unterminated_quoted(delimiter_state)
       msg = case delimiter_state.kind
-            when .command? then "Unterminated command literal"
-            when .regex?   then "Unterminated regular expression"
+            when .command? then "unterminated command literal"
+            when .regex?   then "unterminated regular expression"
             when .heredoc?
-              "Unterminated heredoc: can't find \"#{delimiter_state.end}\" anywhere before the end of file"
-            when .string? then "Unterminated string literal"
+              "unterminated heredoc: can't find \"#{delimiter_state.end}\" anywhere before the end of file"
+            when .string? then "unterminated string literal"
             else
               ::raise "unreachable"
             end
@@ -2753,7 +2753,7 @@ module Crystal
     def next_char_no_column_increment
       char = @reader.next_char
       if error = @reader.error
-        ::raise InvalidByteSequenceError.new("Unexpected byte 0x#{error.to_s(16)} at position #{@reader.pos}, malformed UTF-8")
+        ::raise InvalidByteSequenceError.new("unexpected byte 0x#{error.to_s(16)} at position #{@reader.pos}, malformed UTF-8")
       end
       char
     end

--- a/src/compiler/crystal/syntax/parser.cr
+++ b/src/compiler/crystal/syntax/parser.cr
@@ -147,7 +147,7 @@ module Crystal
       when .op_comma?
         unless last_is_target
           unexpected_token if lhs_splat_index
-          raise "Multiple assignment is not allowed for constants" if last.is_a?(Path)
+          raise "multiple assignment is not allowed for constants" if last.is_a?(Path)
           unexpected_token
         end
       when .newline?, .op_semicolon?
@@ -223,9 +223,9 @@ module Crystal
       values.concat exps[assign_index + 1..-1]
       if values.size != 1
         if lhs_splat_index
-          raise "Multiple assignment count mismatch", location if targets.size - 1 > values.size
+          raise "multiple assignment count mismatch", location if targets.size - 1 > values.size
         else
-          raise "Multiple assignment count mismatch", location if targets.size != values.size
+          raise "multiple assignment count mismatch", location if targets.size != values.size
         end
       end
 
@@ -1005,7 +1005,7 @@ module Crystal
         end
         location = @token.location
         index = value.to_i?
-        raise "Index $#{value} doesn't fit in an Int32" unless index
+        raise "index $#{value} doesn't fit in an Int32" unless index
         node_and_next_token Call.new(Global.new("$~").at(location), method, NumberLiteral.new(index))
       when .magic_line?
         node_and_next_token MagicConstant.expand_line_node(@token.location)
@@ -2099,13 +2099,13 @@ module Crystal
         when .eof?
           case delimiter_state.kind
           when .command?
-            raise "Unterminated command"
+            raise "unterminated command"
           when .regex?
-            raise "Unterminated regular expression"
+            raise "unterminated regular expression"
           when .heredoc?
-            raise "Unterminated heredoc"
+            raise "unterminated heredoc"
           else
-            raise "Unterminated string literal"
+            raise "unterminated string literal"
           end
         else
           line_number = @token.line_number
@@ -2126,7 +2126,7 @@ module Crystal
 
           skip_space_or_newline
           if !@token.type.op_rcurly?
-            raise "Unterminated string interpolation"
+            raise "unterminated string interpolation"
           end
 
           @token.delimiter_state = delimiter_state
@@ -2328,7 +2328,7 @@ module Crystal
           next_token
           break
         else
-          raise "Unterminated #{elements_type.downcase} array literal"
+          raise "unterminated #{elements_type.downcase} array literal"
         end
       end
 

--- a/src/compiler/crystal/syntax/to_s.cr
+++ b/src/compiler/crystal/syntax/to_s.cr
@@ -505,7 +505,7 @@ module Crystal
       when StringInterpolation
         visit_interpolation exp, &.inspect_unquoted.gsub('`', "\\`")
       else
-        raise "Bug: shouldn't happen"
+        raise "BUG: shouldn't happen"
       end
       @str << '`'
       false
@@ -967,7 +967,7 @@ module Crystal
           @str << '\\' if exp.expressions.first?.as?(StringLiteral).try &.value[0]?.try &.ascii_whitespace?
           visit_interpolation(exp) { |s| Regex.append_source s, @str }
         else
-          raise "Bug: shouldn't happen"
+          raise "BUG: shouldn't happen"
         end
         @str << '/'
       end

--- a/src/compiler/crystal/tools/formatter.cr
+++ b/src/compiler/crystal/tools/formatter.cr
@@ -496,7 +496,7 @@ module Crystal
         when .delimiter_end?
           break
         else
-          raise "Bug: unexpected token: #{@token.type}"
+          raise "BUG: unexpected token: #{@token.type}"
         end
       end
 
@@ -777,7 +777,7 @@ module Crystal
             next_token
             break
           else
-            raise "Bug: unexpected token #{@token.type}"
+            raise "BUG: unexpected token #{@token.type}"
           end
           count += 1
         end

--- a/src/compiler/crystal/types.cr
+++ b/src/compiler/crystal/types.cr
@@ -1333,7 +1333,7 @@ module Crystal
       when .u128?
         {UInt128::MIN, UInt128::MAX}
       else
-        raise "Bug: called 'range' for non-integer literal"
+        raise "BUG: called 'range' for non-integer literal"
       end
     end
 
@@ -1381,7 +1381,7 @@ module Crystal
       when .f64?
         {Float64::MIN, Float64::MAX}
       else
-        raise "Bug: called 'range' for non-float literal"
+        raise "BUG: called 'range' for non-float literal"
       end
     end
 

--- a/src/crystal/syntax_highlighter.cr
+++ b/src/crystal/syntax_highlighter.cr
@@ -106,7 +106,7 @@ abstract class Crystal::SyntaxHighlighter
 
             case token.type
             when .eof?
-              raise "Unterminated heredoc"
+              raise "unterminated heredoc"
             else
               highlight_token token, last_is_def
             end
@@ -211,9 +211,9 @@ abstract class Crystal::SyntaxHighlighter
           break
         when .eof?
           if token.delimiter_state.kind.string_array?
-            raise "Unterminated string array literal"
+            raise "unterminated string array literal"
           else # .symbol_array?
-            raise "Unterminated symbol array literal"
+            raise "unterminated symbol array literal"
           end
         else
           raise "Bug: shouldn't happen"

--- a/src/json/lexer.cr
+++ b/src/json/lexer.cr
@@ -128,7 +128,7 @@ abstract class JSON::Lexer
     while true
       case next_char
       when '\0'
-        raise "Unterminated string"
+        raise "unterminated string"
       when '\\'
         consume_string_escape_sequence
       when '"'
@@ -152,7 +152,7 @@ abstract class JSON::Lexer
     while true
       case char = next_char
       when '\0'
-        raise "Unterminated string"
+        raise "unterminated string"
       when '\\'
         @buffer << consume_string_escape_sequence
       when '"'
@@ -193,7 +193,7 @@ abstract class JSON::Lexer
         hexnum1.unsafe_chr
       elsif hexnum1 < 0xdc00
         if next_char != '\\' || next_char != 'u'
-          raise "Unterminated UTF-16 sequence"
+          raise "unterminated UTF-16 sequence"
         end
         hexnum2 = read_hex_number
         unless 0xdc00 <= hexnum2 <= 0xdfff

--- a/src/json/lexer/string_based.cr
+++ b/src/json/lexer/string_based.cr
@@ -17,7 +17,7 @@ class JSON::Lexer::StringBased < JSON::Lexer
     while true
       case next_char
       when '\0'
-        raise "Unterminated string"
+        raise "unterminated string"
       when '\\'
         return consume_string_slow_path start_pos
       when '"'


### PR DESCRIPTION
Hello, here is a proposal for #12031: Make the error case uniform. (Always start by a lower case letter, + always write 'BUG' in upper case).