### PR TITLE
Remove redundant check for EOF on Crystal::Parser

### DIFF
--- a/src/compiler/crystal/syntax/parser.cr
+++ b/src/compiler/crystal/syntax/parser.cr
@@ -80,11 +80,7 @@ module Crystal
     def parse
       next_token_skip_statement_end
 
-      expressions = parse_expressions.tap { check :EOF }
-
-      check :EOF
-
-      expressions
+      parse_expressions.tap { check :EOF }
     end
 
     def parse(mode : ParseMode)


### PR DESCRIPTION
Just a nitpick, but EOF is being checked twice on `Parser#parse` for no apparent reason.