### PR TITLE
Formatter un-align on assignments

### DIFF
--- a/spec/compiler/formatter/formatter_spec.cr
+++ b/spec/compiler/formatter/formatter_spec.cr
@@ -865,17 +865,123 @@ describe Crystal::Formatter do
   assert_format "#### ###"
   assert_format "#######"
 
-  assert_format "A = 1\nFOO = 2\n\nEX = 3", "A = 1\nFOO = 2\n\nEX = 3"
-  assert_format "FOO = 2\nA = 1", "FOO = 2\nA = 1"
-  assert_format "FOO = 2 + 3\nA = 1 - 10", "FOO = 2 + 3\nA = 1 - 10"
-  assert_format "private FOO = 2\nprivate A = 1", "private FOO = 2\nprivate A = 1"
-  assert_format "private FOO    =    2\nprivate A =   1", "private FOO = 2\nprivate A = 1"
-  assert_format "private FOO =    2\nprivate A    =1", "private FOO = 2\nprivate A = 1"
-  assert_format "private FOO    = 2\nprivate A=       1", "private FOO = 2\nprivate A = 1"
-  assert_format "private FOO=2\nprivate A =   1", "private FOO = 2\nprivate A = 1"
-  assert_format "FOO    =    2\nA  =   1","FOO = 2\nA = 1"
-  assert_format "FOO = 2\nA   = 1","FOO = 2\nA = 1"
-  assert_format "FOO = 2\nA =   1","FOO = 2\nA = 1"
+  assert_format <<-CODE
+    A = 1
+    FOO = 2
+
+    EX = 3
+    CODE
+  assert_format <<-BEFORE, <<-AFTER
+    A   = 42
+    FOO =  2
+
+    EX  =  3
+    BEFORE
+    A = 42
+    FOO = 2
+
+    EX = 3
+    AFTER
+  assert_format <<-BEFORE, <<-AFTER
+    A   = 42
+    FOO = 2
+    BEFORE
+    A = 42
+    FOO = 2
+    AFTER
+  assert_format <<-CODE
+    FOO = 2
+    A = 1
+    CODE
+  assert_format <<-CODE
+    FOO = 2 + 3
+    A = 1 - 10
+    CODE
+  assert_format <<-CODE
+    private FOO = 2
+    private A = 1
+    CODE
+  assert_format <<-BEFORE, <<-AFTER
+    private   FOO    =    2
+    private  A =   1
+    BEFORE
+    private FOO = 2
+    private A = 1
+    AFTER
+  assert_format <<-BEFORE, <<-AFTER
+    protected   FOO    =    2
+    private  A =   1
+    BEFORE
+    protected FOO = 2
+    private A = 1
+    AFTER
+  assert_format <<-BEFORE, <<-AFTER
+    private FOO=    2
+    private A    =1
+    BEFORE
+    private FOO = 2
+    private A = 1
+    AFTER
+  assert_format <<-BEFORE, <<-AFTER
+    private FOO    = 2
+    private A=       1
+    BEFORE
+    private FOO = 2
+    private A = 1
+    AFTER
+  assert_format <<-BEFORE, <<-AFTER
+      private FOO=2
+      private BAR=1
+    BEFORE
+    private FOO = 2
+    private BAR = 1
+    AFTER
+  assert_format <<-CODE
+    FOO = 2
+    A = 1
+    CODE
+  assert_format <<-BEFORE, <<-AFTER
+    FOO    =    2
+    A =   1
+    BEFORE
+    FOO = 2
+    A = 1
+    AFTER
+  assert_format <<-BEFORE, <<-AFTER
+       FOO    =    2
+         A =   1
+    BEFORE
+    FOO = 2
+    A = 1
+    AFTER
+  assert_format <<-BEFORE, <<-AFTER
+    FOO=    2
+    A    =12345
+    BEFORE
+    FOO = 2
+    A = 12345
+    AFTER
+  assert_format <<-BEFORE, <<-AFTER
+    FOO    = 2
+    A=       1
+    BEFORE
+    FOO = 2
+    A = 1
+    AFTER
+  assert_format <<-BEFORE, <<-AFTER
+    FOO=2
+    BAR=4224
+    BEFORE
+    FOO = 2
+    BAR = 4224
+    AFTER
+  assert_format <<-BEFORE, <<-AFTER
+    FOO    =    2
+    BAR    =    1
+    BEFORE
+    FOO = 2
+    BAR = 1
+    AFTER
 
   assert_format "enum Baz\nA = 1\nFOO = 2\n\nEX = 3\nend", "enum Baz\n  A   = 1\n  FOO = 2\n\n  EX = 3\nend"
   assert_format "enum Baz\nA = 1\nFOO\n\nEX = 3\nend", "enum Baz\n  A   = 1\n  FOO\n\n  EX = 3\nend"

--- a/spec/compiler/formatter/formatter_spec.cr
+++ b/spec/compiler/formatter/formatter_spec.cr
@@ -865,10 +865,18 @@ describe Crystal::Formatter do
   assert_format "#### ###"
   assert_format "#######"
 
-  assert_format "A = 1\nFOO = 2\n\nEX = 3", "A   = 1\nFOO = 2\n\nEX = 3"
-  assert_format "FOO = 2\nA = 1", "FOO = 2\nA   = 1"
-  assert_format "FOO = 2 + 3\nA = 1 - 10", "FOO = 2 + 3\nA   = 1 - 10"
-  assert_format "private FOO = 2\nprivate A = 1", "private FOO = 2\nprivate A   = 1"
+  assert_format "A = 1\nFOO = 2\n\nEX = 3", "A = 1\nFOO = 2\n\nEX = 3"
+  assert_format "FOO = 2\nA = 1", "FOO = 2\nA = 1"
+  assert_format "FOO = 2 + 3\nA = 1 - 10", "FOO = 2 + 3\nA = 1 - 10"
+  assert_format "private FOO = 2\nprivate A = 1", "private FOO = 2\nprivate A = 1"
+  assert_format "private FOO    =    2\nprivate A =   1", "private FOO = 2\nprivate A = 1"
+  assert_format "private FOO =    2\nprivate A    =1", "private FOO = 2\nprivate A = 1"
+  assert_format "private FOO    = 2\nprivate A=       1", "private FOO = 2\nprivate A = 1"
+  assert_format "private FOO=2\nprivate A =   1", "private FOO = 2\nprivate A = 1"
+  assert_format "FOO    =    2\nA  =   1","FOO = 2\nA = 1"
+  assert_format "FOO = 2\nA   = 1","FOO = 2\nA = 1"
+  assert_format "FOO = 2\nA =   1","FOO = 2\nA = 1"
+
   assert_format "enum Baz\nA = 1\nFOO = 2\n\nEX = 3\nend", "enum Baz\n  A   = 1\n  FOO = 2\n\n  EX = 3\nend"
   assert_format "enum Baz\nA = 1\nFOO\n\nEX = 3\nend", "enum Baz\n  A   = 1\n  FOO\n\n  EX = 3\nend"
 
@@ -1029,7 +1037,8 @@ describe Crystal::Formatter do
   assert_format "p = Foo[\n  1, 2, 3,\n  4, 5, 6\n]\n", "p = Foo[\n  1, 2, 3,\n  4, 5, 6,\n]"
   assert_format "[1, 2,\n  3, 4]\n", "[1, 2,\n 3, 4]"
   assert_format "{1 => 2,\n  3 => 4, # lala\n}\n", "{1 => 2,\n 3 => 4, # lala\n}"
-  assert_format "A = 10\nFOO = 123\nBARBAZ = 1234\n", "A      =   10\nFOO    =  123\nBARBAZ = 1234"
+  assert_format "A = 10\nFOO = 123\nBARBAZ = 1234\n", "A = 10\nFOO = 123\nBARBAZ = 1234"
+  assert_format "A = 10\nFOO =      123\nBARBAZ       = 1234\n", "A = 10\nFOO = 123\nBARBAZ = 1234"
   assert_format "enum Foo\n  A      =   10\n  FOO    =  123\n  BARBAZ = 1234\nend\n", "enum Foo\n  A      =   10\n  FOO    =  123\n  BARBAZ = 1234\nend"
   assert_format "1\n# hello\n\n\n", "1\n# hello"
   assert_format "def foo\n  a = 1; # foo\n  a = 2; # bar\nend\n", "def foo\n  a = 1 # foo\n  a = 2 # bar\nend"
@@ -1663,7 +1672,9 @@ describe Crystal::Formatter do
     end
     CODE
 
-  assert_format <<-CODE
+  # assert_format "def foo(x)\n  {% if true %}\n    # comment\n    Foo = 1\n    B   = 2\n  {% end %}\nend", "def foo(x)\n  {% if true %}\n    # comment\n    Foo = 1\n    B = 2\n  {% end %}\nend"
+
+  assert_format <<-BEFORE,
     def foo(x)
       {% if true %}
         # comment
@@ -1671,7 +1682,16 @@ describe Crystal::Formatter do
         B   = 2
       {% end %}
     end
-    CODE
+    BEFORE
+    <<-AFTER
+    def foo(x)
+      {% if true %}
+        # comment
+        Foo = 1
+        B = 2
+      {% end %}
+    end
+    AFTER
 
   assert_format <<-CODE
     def foo(x)

--- a/src/compiler/crystal/tools/formatter.cr
+++ b/src/compiler/crystal/tools/formatter.cr
@@ -3282,11 +3282,10 @@ module Crystal
       accept target
       skip_space_or_newline
 
-      check_align = check_assign_length node.target
       slash_is_regex!
       write_token " ", :OP_EQ
       skip_space
-      accept_assign_value_after_equals node.value, check_align: check_align
+      accept_assign_value_after_equals node.value
 
       false
     end


### PR DESCRIPTION
Related #11949
Fixes #11819 

## Context

Reading RFC https://github.com/crystal-lang/crystal/issues/11949 it looks like there are two options when we talk about alignment: un-align vs "leave as it is".
- Un-align will add/remove spaces so the code is readable. So for example:
`a= 42` will be formatted as `a = 42`.
- "Leave as it is" will just leave the code as the programmer wrote it. (PR #12068)

## In this PR
In this PR we've implemented **un-align option** (and only on assignments so to fix issue https://github.com/crystal-lang/crystal/issues/11819).

### Example
Here is an example that the formatter will un-align. More examples can be found in `formatter_spec.cr`.

**input**
```crystal
A   = 42
FOO =  2

EX  =  3
```

**old output** (just aligns last assignment)
```crystal
A   = 42
FOO =  2

EX = 3
```

**new output**
```crystal
A = 42
FOO = 2

EX = 3
```
