### PR TITLE
Fix formatter lib-fun declaration with newlines

### DIFF
--- a/spec/compiler/formatter/formatter_spec.cr
+++ b/spec/compiler/formatter/formatter_spec.cr
@@ -793,8 +793,38 @@ describe Crystal::Formatter do
         bar(Int32) : Int32
     end
     AFTER
+  assert_format <<-BEFORE, <<-AFTER
+    lib Foo
+      fun foo =
+        bar(Int32,
+        Int32) : Int32
+    end
+    BEFORE
+    lib Foo
+      fun foo =
+        bar(Int32,
+            Int32) : Int32
+    end
+    AFTER
   assert_format "lib Foo\n  fun foo = bar(Int32) : Int32\nend"
-  assert_format "lib Foo\n  fun foo = \"bar\"(Int32) : Int32\nend"
+  assert_format <<-CODE
+    lib Foo
+      fun foo = "bar"(Int32) : Int32
+    end
+    CODE
+  assert_format <<-CODE
+    lib Foo
+      fun foo =
+        "bar"(Int32) : Int32
+    end
+    CODE
+  assert_format <<-CODE
+    lib Foo
+      fun foo =
+        "bar"(Int32) : Int32
+      # comment
+    end
+    CODE
   assert_format "lib Foo\n  $foo  :  Int32 \nend", "lib Foo\n  $foo : Int32\nend"
   assert_format "lib Foo\n  $foo = hello  :  Int32 \nend", "lib Foo\n  $foo = hello : Int32\nend"
   assert_format "lib Foo\nalias  Foo  =  Bar -> \n$a : Int32\nend", "lib Foo\n  alias Foo = Bar ->\n  $a : Int32\nend"

--- a/spec/compiler/formatter/formatter_spec.cr
+++ b/spec/compiler/formatter/formatter_spec.cr
@@ -750,6 +750,49 @@ describe Crystal::Formatter do
   assert_format "lib Foo\n  fun foo(Int32) : Int32\nend"
   assert_format "fun foo(x : Int32) : Int32\n  1\nend"
   assert_format "fun foo(\n  x : Int32,\n  ...\n) : Int32\n  1\nend"
+  assert_format <<-CODE
+    lib Foo
+      fun foo = bar(Int32) : Int32
+    end
+    CODE
+  assert_format <<-CODE
+    lib Foo
+      fun foo =
+        bar : Void
+    end
+    CODE
+  assert_format <<-BEFORE, <<-AFTER
+    lib Foo
+      fun foo =
+
+
+        bar : Void
+    end
+    BEFORE
+    lib Foo
+      fun foo =
+        bar : Void
+    end
+    AFTER
+  assert_format <<-CODE
+    lib Foo
+      fun foo =
+        bar(Int32) : Int32
+    end
+    CODE
+  assert_format <<-BEFORE, <<-AFTER
+    lib Foo
+      fun foo =
+
+
+        bar(Int32) : Int32
+    end
+    BEFORE
+    lib Foo
+      fun foo =
+        bar(Int32) : Int32
+    end
+    AFTER
   assert_format "lib Foo\n  fun foo = bar(Int32) : Int32\nend"
   assert_format "lib Foo\n  fun foo = \"bar\"(Int32) : Int32\nend"
   assert_format "lib Foo\n  $foo  :  Int32 \nend", "lib Foo\n  $foo : Int32\nend"

--- a/src/compiler/crystal/tools/formatter.cr
+++ b/src/compiler/crystal/tools/formatter.cr
@@ -1648,8 +1648,17 @@ module Crystal
         if @token.type.delimiter_start?
           indent(@column, StringLiteral.new(node.real_name))
         else
-          write node.real_name
-          next_token_skip_space
+          if @token.type.newline?
+            write_line
+            next_token_skip_space_or_newline
+            write_indent(@indent + 2) {
+              write node.real_name
+              next_token_skip_space
+            }
+          else
+            write node.real_name
+            next_token_skip_space
+          end
         end
       end
 

--- a/src/compiler/crystal/tools/formatter.cr
+++ b/src/compiler/crystal/tools/formatter.cr
@@ -1645,20 +1645,18 @@ module Crystal
       if @token.type.op_eq?
         write " = "
         next_token_skip_space
+
+        if @token.type.newline?
+          write_line
+          next_token_skip_space_or_newline
+          write_indent(@indent + 2)
+        end
+
         if @token.type.delimiter_start?
           indent(@column, StringLiteral.new(node.real_name))
         else
-          if @token.type.newline?
-            write_line
-            next_token_skip_space_or_newline
-            write_indent(@indent + 2) {
-              write node.real_name
-              next_token_skip_space
-            }
-          else
-            write node.real_name
-            next_token_skip_space
-          end
+          write node.real_name
+          next_token_skip_space
         end
       end
 


### PR DESCRIPTION
Fixes #12070 

The formatter tool was crashing when trying to indent `lib fun` declarations with newlines. 
For example:

```crystal
lib Foo
  fun foo =
    bar : Void
end 
```

After this PR the formatter can handle such cases. Other example:

**input:**
```crystal
lib Foo
  fun foo =


    bar : Void
end
```

**output:**
```crystal
lib Foo
  fun foo =
    bar : Void
end
```