### PR TITLE
Fix formatter alias-def with no-space before equals

### DIFF
--- a/spec/compiler/formatter/formatter_spec.cr
+++ b/spec/compiler/formatter/formatter_spec.cr
@@ -733,7 +733,18 @@ describe Crystal::Formatter do
   assert_format "alias  Foo::Bar  =   Baz", "alias Foo::Bar = Baz"
   assert_format "alias A = (B)"
   assert_format "alias A = (B) -> C"
-
+  assert_format "alias Foo=Bar", "alias Foo = Bar"
+  assert_format "alias Foo= Bar", "alias Foo = Bar"
+  assert_format "alias Foo =Bar", "alias Foo = Bar"
+  assert_format "alias Foo::Bar=Baz", "alias Foo::Bar = Baz"
+  assert_format "alias Foo::Bar= Baz", "alias Foo::Bar = Baz"
+  assert_format "alias Foo::Bar =Baz", "alias Foo::Bar = Baz"
+  assert_format <<-BEFORE, <<-AFTER
+    alias Foo=
+    Bar
+    BEFORE
+    alias Foo = Bar
+    AFTER
   assert_format "lib Foo\nend"
   assert_format "lib Foo\ntype  Foo  =   Bar\nend", "lib Foo\n  type Foo = Bar\nend"
   assert_format "lib Foo\nfun foo\nend", "lib Foo\n  fun foo\nend"

--- a/src/compiler/crystal/tools/formatter.cr
+++ b/src/compiler/crystal/tools/formatter.cr
@@ -4065,10 +4065,10 @@ module Crystal
         accept name
       else
         write name
+        next_token
       end
 
-      next_token_skip_space_or_newline
-
+      skip_space
       write_token " ", :OP_EQ, " "
       skip_space_or_newline
 


### PR DESCRIPTION
Fixes #12042 
Related duplicate #12072 

The formatter tool was crashing when trying to define an `alias` with no space before equals.
For example:

```crystal
alias Foo= Bar
```

After this PR the formatter can handle such cases. Other example:

**input:**
```crystal
alias Foo= 
Bar
```

**output:**
```crystal
alias Foo = Bar
```