### PR TITLE
Add `#compact` to `Enumerable`

### DIFF
--- a/spec/std/enumerable_spec.cr
+++ b/spec/std/enumerable_spec.cr
@@ -89,6 +89,10 @@ describe "Enumerable" do
     end
   end
 
+  describe "compact" do
+    it { Set{1, nil, 2, nil, 3}.compact.should eq([1, 2, 3]) }
+  end
+
   describe "compact map" do
     it { Set{1, nil, 2, nil, 3}.compact_map { |x| x.try &.+(1) }.should eq([2, 3, 4]) }
   end

--- a/spec/std/tuple_spec.cr
+++ b/spec/std/tuple_spec.cr
@@ -226,6 +226,13 @@ describe "Tuple" do
     tuple2.should eq({11, 12, 14, 15})
   end
 
+  it "does compact" do
+    tuple = {nil, "hello", nil, nil, 42, nil}
+    tuple2 = tuple.compact
+    tuple2.is_a?(Tuple).should be_true
+    tuple2.should eq({"hello", 42})
+  end
+
   it "does reverse" do
     {1, 2.5, "a", 'c'}.reverse.should eq({'c', "a", 2.5, 1})
   end

--- a/src/array.cr
+++ b/src/array.cr
@@ -719,15 +719,6 @@ class Array(T)
     {% end %}
   end
 
-  # Returns a copy of `self` with all `nil` elements removed.
-  #
-  # ```
-  # ["a", nil, "b", nil, "c", nil].compact # => ["a", "b", "c"]
-  # ```
-  def compact
-    compact_map &.itself
-  end
-
   # Removes all `nil` elements from `self` and returns `self`.
   #
   # ```

--- a/src/enumerable.cr
+++ b/src/enumerable.cr
@@ -220,6 +220,15 @@ module Enumerable(T)
     end
   end
 
+  # Returns a copy of `self` with all `nil` elements removed.
+  #
+  # ```
+  # ["a", nil, "b", nil, "c", nil].compact # => ["a", "b", "c"]
+  # ```
+  def compact
+    compact_map &.itself
+  end
+
   # Returns an `Array` with the results of running the block against each element
   # of the collection, removing `nil` values.
   #

--- a/src/tuple.cr
+++ b/src/tuple.cr
@@ -489,6 +489,24 @@ struct Tuple
     {% end %}
   end
 
+  # Returns new `Tuple` without `nil` values.
+  #
+  # ```
+  # tuple = {nil, "hello", nil, nil, 42, nil}
+  # tuple.compact # => {"hello", 42}
+  # ```
+  def compact
+    {% begin %}
+      Tuple.new(
+        {% for i in 0...T.size %}
+          {% if T[i] != Nil %}
+            self[{{i}}],
+          {% end %}
+        {% end %}
+      )
+    {% end %}
+  end
+
   # Returns a new tuple where the elements are in reverse order.
   #
   # ```


### PR DESCRIPTION
Fixes #11968 

## In this PR
First, we are moving the method `#compact` from `Array` to `Enumerable`. Then we are implementing `Tuple#compact` so that it returns a `Tuple`.

