### PR TITLE
Document `Crystal::Macros::Self` and `Underscore`

### DIFF
--- a/src/compiler/crystal/macros.cr
+++ b/src/compiler/crystal/macros.cr
@@ -1586,8 +1586,10 @@ module Crystal::Macros
     end
   end
 
-  # class Self < ASTNode
-  # end
+  # The `self` expression. May appear in code, such as in an instance method,
+  # and in type names.
+  class Self < ASTNode
+  end
 
   # The base class of control expressions.
   abstract class ControlExpression < ASTNode
@@ -1717,8 +1719,10 @@ module Crystal::Macros
   # class MacroFor < ASTNode
   # end
 
-  # class Underscore < ASTNode
-  # end
+  # The `_` expression. May appear in code, such as an assignment target, and in
+  # type names.
+  class Underscore < ASTNode
+  end
 
   # class MagicConstant < ASTNode
   # end


### PR DESCRIPTION
As per https://github.com/crystal-lang/crystal/issues/3274#issuecomment-860092436, `self` and `_` have no further introspection methods so all that's left is documenting them publicly.