### PR TITLE
Fix: Shell expansion in Interpreter ldflags

### DIFF
--- a/spec/compiler/interpreter/lib_spec.cr
+++ b/spec/compiler/interpreter/lib_spec.cr
@@ -50,6 +50,17 @@ describe Crystal::Repl::Interpreter do
         CR
     end
 
+    it "provides shell expansion to ldflags" do
+      interpret(<<-CR).should eq 5
+        @[Link(ldflags: "`echo '-L#{SPEC_CRYSTAL_LOADER_LIB_PATH}'` -lsum")]
+        lib LibSum
+          fun sum_int(count : Int32, ...) : Int32
+        end
+
+        LibSum.sum_int(2, 1_u8, 4_i16)
+        CR
+    end
+
     after_all do
       FileUtils.rm_rf(SPEC_CRYSTAL_LOADER_LIB_PATH)
     end

--- a/src/compiler/crystal/interpreter/context.cr
+++ b/src/compiler/crystal/interpreter/context.cr
@@ -357,7 +357,10 @@ class Crystal::Repl::Context
   end
 
   getter(loader : Loader) {
-    args = Process.parse_arguments(program.lib_flags)
+    lib_flags = program.lib_flags
+    lib_flags = lib_flags.gsub(/`(.*?)`/) { `#{$1}` }
+
+    args = Process.parse_arguments(lib_flags)
     # FIXME: Part 1: This is a workaround for initial integration of the interpreter:
     # The loader can't handle the static libgc.a usually shipped with crystal and loading as a shared library conflicts
     # with the compiler's own GC.


### PR DESCRIPTION
#12061
I tried following what the compiler does, and saw Windows does this too (https://github.com/crystal-lang/crystal/blob/master/src/compiler/crystal/compiler.cr#L346), so I think this will work now.
However, I get this error on an Intel Mac when trying to run the test file from the issue:
<img width="819" alt="image" src="https://user-images.githubusercontent.com/13472976/172054599-24527527-cce4-4c67-a1dc-a3bed2196903.png">
But it seems that might just be an issue with BigSur and/or openssl? The spec seems to properly expand now and that passed locally, so maybe its just an issue with my machine?
