### PR TITLE
Initialize Channel queue capacity lazily to conserve memory

### DIFF
--- a/src/channel.cr
+++ b/src/channel.cr
@@ -175,7 +175,7 @@ class Channel(T)
     @receivers = Crystal::PointerLinkedList(Receiver(T)).new
 
     if capacity > 0
-      @queue = Deque(T).new(capacity)
+      @queue = Deque(T).new
     end
   end
 


### PR DESCRIPTION
For some use cases, initializing a channel buffer eagerly (as it is currently implemented) can avoid reallocs, resulting in great performance, especially for smaller ephemeral channels that may very well use the full channel depth. Unfortunately, the tradeoff is a _lot_ of memory usage for other use cases.

For example, in [my NATS client](https://github.com/jgaskins/nats), a `Channel(NATS::Message)` is used to pipe messages off the wire to a message subscriber. The capacity of this channel must be large enough to handle spikes (if not, NATS disconnects the client). The Go client [sets the channel capacity to 512k per subscriber](https://github.com/nats-io/nats.go/blob/69f0e65fe4fd1843bf799b36b2278222637753a2/nats.go#L4430-L4431). I use [64k for the Crystal client](https://github.com/jgaskins/nats/blob/512199fca5fe4603f7f4d57200860e87b61f78b0/src/nats.cr#L294), and even that uses a lot of memory.

To illustrate, I set up 1k subscriptions (simulating duplicate subscriptions for concurrent message handling, underlying subscriptions as the implementation of higher-level messaging operations inside the client, and general sprawl of subscribers):

```crystal
require "nats"

nats = NATS::Client.new
at_exit { nats.close }

1_000.times do
  nats.subscribe "foo" do |msg|
    pp msg
  end
end
nats.flush

gets
```

It uses 4GB of RAM:

<img width="90" alt="Screenshot of Activity Monitor showing 4.34GB of memory used" src="https://user-images.githubusercontent.com/108205/172482717-752332a4-a604-409a-a593-c5ad553a8986.png">

With this patch, the same code uses 99.5% less memory:

<img width="93" alt="Screenshot of Activity Monitor showing 23 MB of memory used" src="https://user-images.githubusercontent.com/108205/172483009-07d28b7c-5ed1-4de1-9fe6-0afd53b97d48.png">

Memory will grow in size up to the high water mark as messages get buffered during normal execution, but almost none of these channels will ever be saturated and many [may never use the buffer at all](https://github.com/crystal-lang/crystal/blob/b7377c0419ae5c1ce91e8298f075b3ff15636c54/src/channel.cr#L253-L255), so fully allocating the capacity for every single channel can be extreme overkill.