### PR TITLE
Allow `Enumerable(Channel)` parameter for  `Channel.send_first`, `.receive_first`

### DIFF
--- a/src/channel.cr
+++ b/src/channel.cr
@@ -384,7 +384,7 @@ class Channel(T)
     receive_first channels
   end
 
-  def self.receive_first(channels : Tuple | Array)
+  def self.receive_first(channels : Enumerable(Channel))
     _, value = self.select(channels.map(&.receive_select_action))
     value
   end
@@ -393,7 +393,7 @@ class Channel(T)
     send_first value, channels
   end
 
-  def self.send_first(value, channels : Tuple | Array) : Nil
+  def self.send_first(value, channels : Enumerable(Channel)) : Nil
     self.select(channels.map(&.send_select_action(value)))
     nil
   end


### PR DESCRIPTION
Before this change a `Deque` for instance couldn't be passed. Only `.map` is used, no need to limit it further afaik. 