### PR TITLE
Support `Enumerable` as argument to `File.join`

### DIFF
--- a/src/file.cr
+++ b/src/file.cr
@@ -788,7 +788,7 @@ class File < IO::FileDescriptor
   # File.join({"foo/", "/bar/", "/baz"})   # => "foo/bar/baz"
   # File.join(["/foo/", "/bar/", "/baz/"]) # => "/foo/bar/baz/"
   # ```
-  def self.join(parts : Array | Tuple) : String
+  def self.join(parts : Enumerable) : String
     Path.new(parts).to_s
   end
 


### PR DESCRIPTION
Minor fix that loosens the restriction on `File.join`'s arguments, reflecting the internally utilised `Path` initialiser type.

Inspired by #12101 