### PR TITLE
Experimental: restriction augmenter

### DIFF
--- a/spec/compiler/semantic/class_var_spec.cr
+++ b/spec/compiler/semantic/class_var_spec.cr
@@ -14,7 +14,7 @@ describe "Semantic: class var" do
 
       Foo.x = true
       ),
-      "class variable '@@x' of Foo must be Int32, not Bool"
+      "no overload matches 'Foo.x=' with type Bool"
   end
 
   it "declares class variable (2)" do

--- a/spec/compiler/semantic/restrictions_augmenter_spec.cr
+++ b/spec/compiler/semantic/restrictions_augmenter_spec.cr
@@ -45,6 +45,7 @@ describe "Semantic: restrictions augmenter" do
   it_augments_for_ivar "Pointer(Void)", "::Pointer(::Void)"
   it_augments_for_ivar "Char | Int32 | String", "::Char | ::Int32 | ::String"
   it_augments_for_ivar "Char | Int32 | String", "::Char | ::Int32 | ::String"
+  it_augments_for_ivar "Int32.class", "::Int32.class"
 
   it "augments relative public type" do
     before = <<-BEFORE

--- a/spec/compiler/semantic/restrictions_augmenter_spec.cr
+++ b/spec/compiler/semantic/restrictions_augmenter_spec.cr
@@ -5,8 +5,8 @@ private def expect_augment(before : String, after : String)
   result.node.to_s.should eq(after)
 end
 
-private def it_augments_for_ivar(ivar_type : String, expected_type : String)
-  it "augments #{ivar_type}" do
+private def it_augments_for_ivar(ivar_type : String, expected_type : String, file = __FILE__, line = __LINE__)
+  it "augments #{ivar_type}", file, line do
     before = <<-BEFORE
       class Foo
         @x : #{ivar_type}
@@ -155,6 +155,28 @@ describe "Semantic: restrictions augmenter" do
         @x : Array(T)
         def initialize(value : ::Array(T))
           @x = value
+        end
+      end
+      AFTER
+
+    expect_augment before, after
+  end
+
+  it "augments for class var" do
+    before = <<-BEFORE
+      class Foo
+        @@x = 1
+        def self.set(value)
+          @@x = value
+        end
+      end
+      BEFORE
+
+    after = <<-AFTER
+      class Foo
+        @@x = 1
+        def self.set(value : ::Int32)
+          @@x = value
         end
       end
       AFTER

--- a/spec/compiler/semantic/restrictions_augmenter_spec.cr
+++ b/spec/compiler/semantic/restrictions_augmenter_spec.cr
@@ -1,0 +1,164 @@
+require "../../spec_helper"
+
+private def expect_augment(before : String, after : String)
+  result = semantic(before)
+  result.node.to_s.should eq(after)
+end
+
+private def it_augments_for_ivar(ivar_type : String, expected_type : String)
+  it "augments #{ivar_type}" do
+    before = <<-BEFORE
+      class Foo
+        @x : #{ivar_type}
+        def initialize(value)
+          @x = value
+        end
+      end
+      BEFORE
+
+    after = <<-AFTER
+      class Foo
+        @x : #{ivar_type}
+        def initialize(value : #{expected_type})
+          @x = value
+        end
+      end
+      AFTER
+
+    expect_augment before, after
+  end
+end
+
+describe "Semantic: restrictions augmenter" do
+  it_augments_for_ivar "Nil", "::Nil"
+  it_augments_for_ivar "Bool", "::Bool"
+  it_augments_for_ivar "Char", "::Char"
+  it_augments_for_ivar "Int32", "::Int32"
+  it_augments_for_ivar "Float32", "::Float32"
+  it_augments_for_ivar "Symbol", "::Symbol"
+  it_augments_for_ivar "String", "::String"
+  it_augments_for_ivar "Array(String)", "::Array(::String)"
+  it_augments_for_ivar "Tuple(Int32, Char)", "::Tuple(::Int32, ::Char)"
+  it_augments_for_ivar "NamedTuple(a: Int32, b: Char)", "::NamedTuple(a: ::Int32, b: ::Char)"
+  it_augments_for_ivar "Proc(Int32, Char)", "::Proc(::Int32, ::Char)"
+  it_augments_for_ivar "Proc(Int32, Nil)", "::Proc(::Int32, _)"
+  it_augments_for_ivar "Pointer(Void)", "::Pointer(::Void)"
+  it_augments_for_ivar "Char | Int32 | String", "::Char | ::Int32 | ::String"
+  it_augments_for_ivar "Char | Int32 | String", "::Char | ::Int32 | ::String"
+
+  it "augments relative public type" do
+    before = <<-BEFORE
+      class Foo
+        class Bar
+          class Baz
+          end
+        end
+
+        @x : Bar:: Baz
+
+        def initialize(value)
+          @x = value
+        end
+      end
+      BEFORE
+
+    after = <<-AFTER
+      class Foo
+        class Bar
+          class Baz
+          end
+        end
+        @x : Bar::Baz
+        def initialize(value : ::Foo::Bar::Baz)
+          @x = value
+        end
+      end
+      AFTER
+
+    expect_augment before, after
+  end
+
+  it "augments relative private type" do
+    before = <<-BEFORE
+      class Foo
+        private class Bar
+          class Baz
+          end
+        end
+
+        @x : Bar:: Baz
+
+        def initialize(value)
+          @x = value
+        end
+      end
+      BEFORE
+
+    after = <<-AFTER
+      class Foo
+        private class Bar
+          class Baz
+          end
+        end
+        @x : Bar::Baz
+        def initialize(value : Bar::Baz)
+          @x = value
+        end
+      end
+      AFTER
+
+    expect_augment before, after
+  end
+
+  it "augments relative private type in same namespace" do
+    before = <<-BEFORE
+      class Foo
+        private class Bar
+        end
+        private class Baz
+          @x : Bar
+          def initialize(value)
+            @x = value
+          end
+        end
+      end
+      BEFORE
+
+    after = <<-AFTER
+      class Foo
+        private class Bar
+        end
+        private class Baz
+          @x : Bar
+          def initialize(value : Bar)
+            @x = value
+          end
+        end
+      end
+      AFTER
+
+    expect_augment before, after
+  end
+
+  it "augments generic uninstantiated type" do
+    before = <<-BEFORE
+      class Foo(T)
+        @x : Array(T)
+        def initialize(value)
+          @x = value
+        end
+      end
+      BEFORE
+
+    after = <<-AFTER
+      class Foo(T)
+        @x : Array(T)
+        def initialize(value : ::Array(T))
+          @x = value
+        end
+      end
+      AFTER
+
+    expect_augment before, after
+  end
+end

--- a/spec/compiler/semantic/restrictions_augmenter_spec.cr
+++ b/spec/compiler/semantic/restrictions_augmenter_spec.cr
@@ -235,8 +235,8 @@ describe "Semantic: restrictions augmenter" do
       CODE
   end
 
-  it "doesn't augment if the without_restrictions_augmenter flag is present" do
-    expect_no_augment <<-CODE, flags: "without_restrictions_augmenter"
+  it "doesn't augment if the no_restrictions_augmenter flag is present" do
+    expect_no_augment <<-CODE, flags: "no_restrictions_augmenter"
       class Foo
         @x : Int32
         def initialize(value)

--- a/spec/compiler/semantic/restrictions_augmenter_spec.cr
+++ b/spec/compiler/semantic/restrictions_augmenter_spec.cr
@@ -5,8 +5,8 @@ private def expect_augment(before : String, after : String)
   result.node.to_s.should eq(after)
 end
 
-private def expect_no_augment(code : String)
-  result = semantic(code)
+private def expect_no_augment(code : String, flags = nil)
+  result = semantic(code, flags: flags)
   result.node.to_s.should eq(code)
 end
 
@@ -232,6 +232,17 @@ describe "Semantic: restrictions augmenter" do
         end
       end
 
+      CODE
+  end
+
+  it "doesn't augment if the without_restrictions_augmenter flag is present" do
+    expect_no_augment <<-CODE, flags: "without_restrictions_augmenter"
+      class Foo
+        @x : Int32
+        def initialize(value)
+          @x = value
+        end
+      end
       CODE
   end
 end

--- a/spec/compiler/semantic/restrictions_augmenter_spec.cr
+++ b/spec/compiler/semantic/restrictions_augmenter_spec.cr
@@ -43,6 +43,7 @@ describe "Semantic: restrictions augmenter" do
   it_augments_for_ivar "Proc(Int32, Char)", "::Proc(::Int32, ::Char)"
   it_augments_for_ivar "Proc(Int32, Nil)", "::Proc(::Int32, _)"
   it_augments_for_ivar "Pointer(Void)", "::Pointer(::Void)"
+  it_augments_for_ivar "StaticArray(Int32, 8)", "::StaticArray(::Int32, 8)"
   it_augments_for_ivar "Char | Int32 | String", "::Char | ::Int32 | ::String"
   it_augments_for_ivar "Char | Int32 | String", "::Char | ::Int32 | ::String"
   it_augments_for_ivar "Int32.class", "::Int32.class"

--- a/src/compiler/crystal/semantic.cr
+++ b/src/compiler/crystal/semantic.cr
@@ -74,8 +74,10 @@ class Crystal::Program
       AbstractDefChecker.new(self).run
     end
 
-    @progress_tracker.stage("Semantic (restrictions augmenter)") do
-      node.accept RestrictionsAugmenter.new(self, new_expansions)
+    unless @program.has_flag?("without_restrictions_augmenter")
+      @progress_tracker.stage("Semantic (restrictions augmenter)") do
+        node.accept RestrictionsAugmenter.new(self, new_expansions)
+      end
     end
 
     {node, processor}

--- a/src/compiler/crystal/semantic.cr
+++ b/src/compiler/crystal/semantic.cr
@@ -74,7 +74,7 @@ class Crystal::Program
       AbstractDefChecker.new(self).run
     end
 
-    unless @program.has_flag?("without_restrictions_augmenter")
+    unless @program.has_flag?("no_restrictions_augmenter")
       @progress_tracker.stage("Semantic (restrictions augmenter)") do
         node.accept RestrictionsAugmenter.new(self, new_expansions)
       end

--- a/src/compiler/crystal/semantic.cr
+++ b/src/compiler/crystal/semantic.cr
@@ -74,6 +74,10 @@ class Crystal::Program
       AbstractDefChecker.new(self).run
     end
 
+    @progress_tracker.stage("Semantic (restrictions augmenter)") do
+      node.accept RestrictionsAugmenter.new(self, new_expansions)
+    end
+
     {node, processor}
   end
 end

--- a/src/compiler/crystal/semantic/new.cr
+++ b/src/compiler/crystal/semantic/new.cr
@@ -3,8 +3,8 @@ module Crystal
     def define_new_methods(new_expansions)
       # Here we complete the body of `self.new` methods
       # created from `initialize` methods.
-      new_expansions.each do |expansion|
-        expansion[:expanded].fill_body_from_initialize(expansion[:original].owner)
+      new_expansions.each do |original, expanded|
+        expanded.fill_body_from_initialize(original.owner)
       end
 
       # We also need to define empty `new` methods for types
@@ -16,8 +16,7 @@ module Crystal
 
       # Once we are done with the expansions we mark `initialize` methods
       # without an explicit visibility as `protected`.
-      new_expansions.each do |expansion|
-        original = expansion[:original]
+      new_expansions.each do |original, expanded|
         original.visibility = Visibility::Protected if original.visibility.public?
       end
     end

--- a/src/compiler/crystal/semantic/restrictions_augmenter.cr
+++ b/src/compiler/crystal/semantic/restrictions_augmenter.cr
@@ -1,0 +1,121 @@
+module Crystal
+  class RestrictionsAugmenter < Visitor
+    @args_hash : Hash(String, Arg)?
+    @current_type : Type
+    @def : Def?
+
+    # If an assignment happens conditionally we can't add a type
+    # restriction because... we can't be sure the assignment will happen!
+    @conditional_nest = 0
+
+    def initialize(@program : Program, @new_expansions : Array({original: Def, expanded: Def}))
+      @current_type = @program
+    end
+
+    def visit(node : ExpandableNode)
+      if expanded = node.expanded
+        expanded.accept self
+      end
+      false
+    end
+
+    def visit(node : ClassDef)
+      old_type = @current_type
+      @current_type = node.resolved_type
+      node.body.accept self
+      @current_type = old_type
+      false
+    end
+
+    def visit(node : Def)
+      @def = node
+      @args_hash = args_hash = {} of String => Arg
+      node.args.each do |arg|
+        next if arg.restriction
+        args_hash[arg.name] = arg
+      end
+      node.body.accept self
+      @args_hash = nil
+      @def = nil
+      false
+    end
+
+    def visit(node : If | Unless)
+      node.cond.accept self
+      @conditional_nest += 1
+      node.then.accept self
+      node.else.try &.accept self
+      @conditional_nest -= 1
+      false
+    end
+
+    def visit(node : While | Until)
+      node.cond.accept self
+      @conditional_nest += 1
+      node.body.accept self
+      @conditional_nest -= 1
+      false
+    end
+
+    def visit(node : Assign)
+      args_hash = @args_hash
+      return false unless args_hash
+
+      current_def = @def
+      return false unless current_def
+
+      target = node.target
+      value = node.value
+      current_type = @current_type
+
+      case target
+      when Var
+        args_hash.delete(target.name)
+      when InstanceVar
+        if @conditional_nest == 0
+          process_assign_instance_var(target, value, current_type, current_def, args_hash)
+        end
+      when ClassVar
+        # TODO: apply same logic but for assignments to class vars
+      end
+
+      false
+    end
+
+    def visit(node : ASTNode)
+      true
+    end
+
+    private def process_assign_instance_var(target, value, current_type, current_def, args_hash)
+      return unless current_type.is_a?(InstanceVarContainer)
+      return unless value.is_a?(Var)
+
+      arg = args_hash[value.name]?
+      return unless arg
+
+      ivar = current_type.instance_vars[target.name]?
+      return unless ivar
+
+      restriction = TypeToRestriction.convert(ivar.type)
+      return unless restriction
+
+      arg.restriction = restriction
+
+      # If this is an initialize, we can also add a type restriction to the
+      # auto-generated "new" so that it shows up in docs.
+      return unless current_def.name == "initialize"
+
+      # TODO: we should probably store the expansions as a Hash from now on
+      expansion = @new_expansions.find { |expansion| expansion[:original].same?(current_def) }
+      return unless expansion
+
+      expanded = expansion[:expanded]
+      expansion_arg = expanded.args.find do |expansion_arg|
+        expansion_arg.name == arg.name
+      end
+      return unless expansion_arg
+
+      expansion_arg.restriction = restriction.dup
+    end
+  end
+end

--- a/src/compiler/crystal/semantic/restrictions_augmenter.cr
+++ b/src/compiler/crystal/semantic/restrictions_augmenter.cr
@@ -40,7 +40,7 @@ module Crystal
       false
     end
 
-    def visit(node : If | Unless)
+    def visit(node : If)
       node.cond.accept self
       @conditional_nest += 1
       node.then.accept self
@@ -49,11 +49,24 @@ module Crystal
       false
     end
 
-    def visit(node : While | Until)
+    def visit(node : While)
       node.cond.accept self
       @conditional_nest += 1
       node.body.accept self
       @conditional_nest -= 1
+      false
+    end
+
+    def visit(node : Call)
+      node.obj.try &.accept self
+      node.args.each &.accept self
+      node.named_args.try &.each &.value.accept self
+      node.block.try do |block|
+        @conditional_nest += 1
+        block.accept self
+        @conditional_nest -= 1
+      end
+      node.block_arg.try &.accept self
       false
     end
 

--- a/src/compiler/crystal/semantic/restrictions_augmenter.cr
+++ b/src/compiler/crystal/semantic/restrictions_augmenter.cr
@@ -96,7 +96,9 @@ module Crystal
       ivar = current_type.instance_vars[target.name]?
       return unless ivar
 
-      restriction = TypeToRestriction.convert(ivar.type)
+      converter = TypeToRestriction.new(current_type)
+
+      restriction = converter.convert(ivar.type)
       return unless restriction
 
       arg.restriction = restriction

--- a/src/compiler/crystal/semantic/restrictions_augmenter.cr
+++ b/src/compiler/crystal/semantic/restrictions_augmenter.cr
@@ -8,7 +8,7 @@ module Crystal
     # restriction because... we can't be sure the assignment will happen!
     @conditional_nest = 0
 
-    def initialize(@program : Program, @new_expansions : Array({original: Def, expanded: Def}))
+    def initialize(@program : Program, @new_expansions : Hash(Def, Def))
       @current_type = @program
     end
 
@@ -128,12 +128,10 @@ module Crystal
       # auto-generated "new" so that it shows up in docs.
       return unless current_def.name == "initialize"
 
-      # TODO: we should probably store the expansions as a Hash from now on
-      expansion = @new_expansions.find { |expansion| expansion[:original].same?(current_def) }
+      expansion = @new_expansions[current_def]?
       return unless expansion
 
-      expanded = expansion[:expanded]
-      expansion_arg = expanded.args.find do |expansion_arg|
+      expansion_arg = expansion.args.find do |expansion_arg|
         expansion_arg.name == arg.name
       end
       return unless expansion_arg

--- a/src/compiler/crystal/semantic/top_level_visitor.cr
+++ b/src/compiler/crystal/semantic/top_level_visitor.cr
@@ -31,7 +31,7 @@ require "./semantic_visitor"
 # might disappear in the future and we'll make consider everything as "maybe virtual".
 class Crystal::TopLevelVisitor < Crystal::SemanticVisitor
   # These are `new` methods (values) that was created from `initialize` methods (keys)
-  getter new_expansions = ({} of Def => Def).compare_by_identity
+  getter new_expansions : Hash(Def, Def) = ({} of Def => Def).compare_by_identity
 
   # All finished hooks and their scope
   record FinishedHook, scope : ModuleType, macro : Macro

--- a/src/compiler/crystal/semantic/top_level_visitor.cr
+++ b/src/compiler/crystal/semantic/top_level_visitor.cr
@@ -30,8 +30,8 @@ require "./semantic_visitor"
 # subclasses or not and we can tag it as "virtual" (having subclasses), but that concept
 # might disappear in the future and we'll make consider everything as "maybe virtual".
 class Crystal::TopLevelVisitor < Crystal::SemanticVisitor
-  # These are `new` methods (expanded) that was created from `initialize` methods (original)
-  getter new_expansions = [] of {original: Def, expanded: Def}
+  # These are `new` methods (values) that was created from `initialize` methods (keys)
+  getter new_expansions = ({} of Def => Def).compare_by_identity
 
   # All finished hooks and their scope
   record FinishedHook, scope : ModuleType, macro : Macro
@@ -422,7 +422,7 @@ class Crystal::TopLevelVisitor < Crystal::SemanticVisitor
         target_type.metaclass.as(ModuleType).add_def(new_method)
 
         # And we register it to later complete it
-        new_expansions << {original: node, expanded: new_method}
+        new_expansions[node] = new_method
       end
 
       unless @method_added_running

--- a/src/compiler/crystal/semantic/type_to_restriction.cr
+++ b/src/compiler/crystal/semantic/type_to_restriction.cr
@@ -115,6 +115,13 @@ module Crystal
       )
     end
 
+    def convert(type : MetaclassType)
+      restriction = convert(type.instance_type)
+      return unless restriction
+
+      Metaclass.new(restriction)
+    end
+
     def convert(type : TypeParameter)
       Path.new(type.name)
     end

--- a/src/compiler/crystal/semantic/type_to_restriction.cr
+++ b/src/compiler/crystal/semantic/type_to_restriction.cr
@@ -1,0 +1,124 @@
+require "../types"
+
+module Crystal
+  module TypeToRestriction
+    def self.convert(type : NilType)
+      Path.global("Nil")
+    end
+
+    def self.convert(type : BoolType)
+      Path.global("Bool")
+    end
+
+    def self.convert(type : CharType)
+      Path.global("Char")
+    end
+
+    def self.convert(type : SymbolType)
+      Path.global("Symbol")
+    end
+
+    def self.convert(type : IntegerType | FloatType)
+      case type.kind
+      in NumberKind::I8   then Path.global("Int8")
+      in NumberKind::I16  then Path.global("Int16")
+      in NumberKind::I32  then Path.global("Int32")
+      in NumberKind::I64  then Path.global("Int64")
+      in NumberKind::I128 then Path.global("Int128")
+      in NumberKind::U8   then Path.global("UInt8")
+      in NumberKind::U16  then Path.global("UInt16")
+      in NumberKind::U32  then Path.global("UInt32")
+      in NumberKind::U64  then Path.global("UInt64")
+      in NumberKind::U128 then Path.global("UInt128")
+      in NumberKind::F32  then Path.global("Float32")
+      in NumberKind::F64  then Path.global("Float64")
+      end
+    end
+
+    def self.convert(type : NonGenericClassType | NonGenericModuleType | EnumType)
+      return nil if type.private?
+
+      names = [] of String
+      append_namespace(type, names)
+      names << type.name
+      Path.global(names)
+    end
+
+    def self.convert(type : TupleInstanceType)
+      Generic.new(
+        Path.global("Tuple"),
+        type.tuple_types.map do |tuple_type|
+          convert(tuple_type) || Underscore.new
+        end
+      )
+    end
+
+    def self.convert(type : NamedTupleInstanceType)
+      Generic.new(
+        Path.global("NamedTuple"),
+        type_vars: [] of ASTNode,
+        named_args: type.entries.map do |entry|
+          NamedArgument.new(
+            entry.name,
+            convert(entry.type) || Underscore.new,
+          )
+        end
+      )
+    end
+
+    def self.convert(type : ProcInstanceType)
+      type_vars = Array(ASTNode).new(type.arg_types.size + 1)
+      type.arg_types.each do |arg_type|
+        type_vars.push(convert(arg_type) || Underscore.new)
+      end
+      type_vars.push(convert(type.return_type) || Underscore.new)
+
+      Generic.new(
+        Path.global("Proc"),
+        type_vars: type_vars,
+      )
+    end
+
+    def self.convert(type : GenericInstanceType)
+      return nil if type.private?
+
+      generic_type = type.generic_type
+      names = [] of String
+      append_namespace(generic_type, names)
+      names << generic_type.name
+      path = Path.global(names)
+      type_vars = type.type_vars.map do |name, type_var|
+        type_var_type = type_var.type?
+        if type_var_type
+          convert(type_var_type) || Underscore.new
+        else
+          Underscore.new
+        end
+      end
+      Generic.new(path, type_vars)
+    end
+
+    def self.convert(type : UnionType)
+      Union.new(
+        type.union_types.map do |union_type|
+          restriction = convert(union_type)
+          return unless restriction
+
+          restriction.as(ASTNode)
+        end
+      )
+    end
+
+    def self.convert(type : Type)
+      nil
+    end
+
+    private def self.append_namespace(type, names)
+      namespace = type.namespace
+      return if namespace.is_a?(Program)
+
+      append_namespace(namespace, names)
+      names << namespace.name
+    end
+  end
+end

--- a/src/compiler/crystal/semantic/type_to_restriction.cr
+++ b/src/compiler/crystal/semantic/type_to_restriction.cr
@@ -71,7 +71,14 @@ module Crystal
       type.arg_types.each do |arg_type|
         type_vars.push(convert(arg_type) || Underscore.new)
       end
-      type_vars.push(convert(type.return_type) || Underscore.new)
+
+      if type.return_type.is_a?(NilType)
+        # Because there's some strange autocasting for Procs that return Nil,
+        # it's better if we don't do anything fancy here.
+        type_vars.push(Underscore.new)
+      else
+        type_vars.push(convert(type.return_type) || Underscore.new)
+      end
 
       Generic.new(
         Path.global("Proc"),

--- a/src/compiler/crystal/semantic/type_to_restriction.cr
+++ b/src/compiler/crystal/semantic/type_to_restriction.cr
@@ -94,8 +94,9 @@ module Crystal
       generic_type = type.generic_type
       path = type_to_path(type.generic_type)
       type_vars = type.type_vars.map do |name, type_var|
-        type_var_type = type_var.type?
-        if type_var_type
+        if type_var.is_a?(NumberLiteral)
+          type_var.clone
+        elsif type_var_type = type_var.type?
           convert(type_var_type) || Underscore.new
         else
           Underscore.new


### PR DESCRIPTION
This is a proof of concept for this forum topic: https://forum.crystal-lang.org/t/questions-about-autocasting-and-method-signature/4665

The gist is that if you assign a method argument to an instance variable, but that method argument doesn't have a type restriction, to automatically add it. After all, if we are going to assign that value to the instance var, the type must fit in the instance variable's type.

This isn't always possible to do:
- If the method argument is assigned some other value before it's assigned to the instance var, we can't assume its type must match that of the instance var

What are the benefits? All of these!

# Better error messages

Consider this code:

```crystal
class Foo
  @x : Int32

  def initialize(x)
    @x = x
  end
end

Foo.new('a')
```

Before this PR you get this error:

```
In foo.cr:5:5

 5 | @x = x
     ^-
Error: instance variable '@x' of Foo must be Int32, not Char
```

With this PR you get this error:

```
In foo.cr:9:5

 9 | Foo.new('a')
         ^--
Error: no overload matches 'Foo.new' with type Char

Overloads are:
 - Foo.new(x : ::Int32)
 ```

# Better docs

The added types will appear in docs.

Before:

![image](https://user-images.githubusercontent.com/209371/172627295-d0a70308-e3f9-44be-abab-7d83f5af12a0.png)

After:

![image](https://user-images.githubusercontent.com/209371/172627383-50f341a7-7639-4fed-a026-211466fca99d.png)

# Autocasting works

This code:

```crystal
class Foo
  @x : Int64

  def initialize(x)
    @x = x
  end
end

Foo.new(1)
```

Before this PR it gives an error:

```
In foo.cr:5:5

 5 | @x = x
     ^-
Error: instance variable '@x' of Foo must be Int64, not Int32
```

With this PR it just compiles ®️ 

# Is this worth it?

I don't know. I think it just makes sense to do this. Maybe the exact examples above aren't common. But for example this:

```crystal
class Foo
  def initialize(@some_bool = false)
  end
end

Foo.new(1)
```

Before this PR you get this error:

```
In foo.cr:2:18

 2 | def initialize(@some_bool = false)
                    ^---------
Error: instance variable '@some_bool' of Foo must be Bool, not Int32
```

With this PR:

```
In foo.cr:6:5

 6 | Foo.new(1)
         ^--
Error: no overload matches 'Foo.new' with type Int32

Overloads are:
 - Foo.new(some_bool : ::Bool = false)
```

The error is much better, and points to the actual place where the mistake happened.

# Is there a way to disable this behavior?

Yes! If you compile your program with `-Dno_restrictions_augmenter` then this logic isn't applied. The idea is to have this flag as an escape hatch in case it's not working properly. If everything goes well we can remove the special `no_restrictions_augmenter` flag.
