### PR TITLE
[Docs] Adjust method sort order to sort all operators first

### DIFF
--- a/spec/compiler/crystal/tools/doc/type_spec.cr
+++ b/spec/compiler/crystal/tools/doc/type_spec.cr
@@ -168,4 +168,52 @@ describe Doc::Type do
     # Sanity check: subclasses of ASTNode has the right ancestors
     generator.type(macros_module.types["Arg"]).ancestors.should eq([astnode])
   end
+
+  describe "#instance_methods" do
+    it "sorts operators first" do
+      program = semantic(<<-CODE).program
+        class Foo
+          def foo; end
+          def ~; end
+          def +; end
+        end
+        CODE
+
+      generator = Doc::Generator.new program, [""]
+      type = generator.type(program.types["Foo"])
+      type.instance_methods.map(&.name).should eq ["+", "~", "foo"]
+    end
+  end
+
+  describe "#class_methods" do
+    it "sorts operators first" do
+      program = semantic(<<-CODE).program
+        class Foo
+          def self.foo; end
+          def self.~; end
+          def self.+; end
+        end
+        CODE
+
+      generator = Doc::Generator.new program, [""]
+      type = generator.type(program.types["Foo"])
+      type.class_methods.map(&.name).should eq ["+", "~", "foo"]
+    end
+  end
+
+  describe "#macros" do
+    it "sorts operators first" do
+      program = semantic(<<-CODE).program
+        class Foo
+          macro foo; end
+          macro ~; end
+          macro +; end
+        end
+        CODE
+
+      generator = Doc::Generator.new program, [""]
+      type = generator.type(program.types["Foo"])
+      type.macros.map(&.name).should eq ["+", "~", "foo"]
+    end
+  end
 end

--- a/src/compiler/crystal/tools/doc/type.cr
+++ b/src/compiler/crystal/tools/doc/type.cr
@@ -176,22 +176,14 @@ class Crystal::Doc::Type
             defs << method(def_with_metadata.def, false)
           end
         end
-        defs.sort! do |a, b|
-          compare_strings(a.name, b.name)
-        end
+        defs.sort_by! { |x| sort_order(x) }
       end
     end
   end
 
-  def compare_strings(a, b)
-    case {a[0].alphanumeric?, b[0].alphanumeric?}
-    when {true, false}
-      1
-    when {false, true}
-      -1
-    else
-      a.compare(b, case_insensitive: true)
-    end
+  private def sort_order(item)
+    # Sort operators first, then alphanumeric (case-insensitive).
+    {item.name[0].alphanumeric? ? 1 : 0, item.name.downcase}
   end
 
   @class_methods : Array(Method)?
@@ -214,9 +206,7 @@ class Crystal::Doc::Type
           end
         end
       end
-      class_methods.sort! do |a, b|
-        compare_strings(a.name, b.name)
-      end
+      class_methods.sort_by! { |x| sort_order(x) }
     end
   end
 
@@ -240,9 +230,7 @@ class Crystal::Doc::Type
           end
         end
       end
-      macros.sort! do |a, b|
-        compare_strings(a.name, b.name)
-      end
+      macros.sort_by! { |x| sort_order(x) }
     end
   end
 

--- a/src/compiler/crystal/tools/doc/type.cr
+++ b/src/compiler/crystal/tools/doc/type.cr
@@ -176,8 +176,21 @@ class Crystal::Doc::Type
             defs << method(def_with_metadata.def, false)
           end
         end
-        defs.sort_by!(&.name.downcase)
+        defs.sort! do |a, b|
+          compare_strings(a.name, b.name)
+        end
       end
+    end
+  end
+
+  def compare_strings(a, b)
+    case {a[0].alphanumeric?, b[0].alphanumeric?}
+    when {true, false}
+      1
+    when {false, true}
+      -1
+    else
+      a.compare(b, case_insensitive: true)
     end
   end
 
@@ -201,7 +214,9 @@ class Crystal::Doc::Type
           end
         end
       end
-      class_methods.sort_by!(&.name.downcase)
+      class_methods.sort! do |a, b|
+        compare_strings(a.name, b.name)
+      end
     end
   end
 
@@ -225,7 +240,9 @@ class Crystal::Doc::Type
           end
         end
       end
-      macros.sort_by!(&.name.downcase)
+      macros.sort! do |a, b|
+        compare_strings(a.name, b.name)
+      end
     end
   end
 


### PR DESCRIPTION
When using purely lexicographic order, some operators sort before letters (which make non-operator method names), others after. 

It feels weird when some operators such as `|` or `~` are detached from the rest of the operators, being placed at the other end of the non-operator methods (example: https://crystal-lang.org/api/1.4.1/Enum.html).

This change ensures that operators are always sorted before non-operators.