### PR TITLE
Handle invalid bytes in single-byte optimizable `String`s correctly

### DIFF
--- a/spec/std/string_spec.cr
+++ b/spec/std/string_spec.cr
@@ -1249,6 +1249,11 @@ describe "String" do
     it { "よし".ends_with?('し').should be_true }
     it { "よし".ends_with?('な').should be_false }
     it { "あいう_".ends_with?('_').should be_true }
+
+    it "treats last char as replacement char if invalid in an otherwise ascii string" do
+      "foo\xEE".ends_with?('\u{EE}').should be_false
+      "foo\xEE".ends_with?(Char::REPLACEMENT).should be_true
+    end
   end
 
   describe "=~" do

--- a/spec/std/string_spec.cr
+++ b/spec/std/string_spec.cr
@@ -601,6 +601,10 @@ describe "String" do
     it { "tschüß".downcase(Unicode::CaseOptions::Fold).should eq("tschüss") }
     it { "ΣίσυφοςﬁÆ".downcase(Unicode::CaseOptions::Fold).should eq("σίσυφοσfiæ") }
 
+    it "does not touch invalid code units in an otherwise ascii string" do
+      "\xB5!\xE0\xC1\xB5?".downcase.should eq("\xB5!\xE0\xC1\xB5?")
+    end
+
     describe "with IO" do
       it { String.build { |io| "HELLO!".downcase io }.should eq "hello!" }
       it { String.build { |io| "HELLO MAN!".downcase io }.should eq "hello man!" }
@@ -626,6 +630,10 @@ describe "String" do
     it { "ﬀ".upcase.should eq("FF") }
     it { "ňž".upcase.should eq("ŇŽ") } # #7922
 
+    it "does not touch invalid code units in an otherwise ascii string" do
+      "\xB5!\xE0\xC1\xB5?".upcase.should eq("\xB5!\xE0\xC1\xB5?")
+    end
+
     describe "with IO" do
       it { String.build { |io| "hello!".upcase io }.should eq "HELLO!" }
       it { String.build { |io| "hello man!".upcase io }.should eq "HELLO MAN!" }
@@ -646,6 +654,10 @@ describe "String" do
     it { "ﬄİ".capitalize.should eq("FFLi̇") }
     it { "iO".capitalize(Unicode::CaseOptions::Turkic).should eq("İo") }
 
+    it "does not touch invalid code units in an otherwise ascii string" do
+      "\xB5!\xE0\xC1\xB5?".capitalize.should eq("\xB5!\xE0\xC1\xB5?")
+    end
+
     describe "with IO" do
       it { String.build { |io| "HELLO!".capitalize io }.should eq "Hello!" }
       it { String.build { |io| "HELLO MAN!".capitalize io }.should eq "Hello man!" }
@@ -663,6 +675,11 @@ describe "String" do
     it { "  spáçes before".titleize.should eq("  Spáçes Before") }
     it { "testá-se múitô".titleize.should eq("Testá-se Múitô") }
     it { "iO iO".titleize(Unicode::CaseOptions::Turkic).should eq("İo İo") }
+
+    it "does not touch invalid code units in an otherwise ascii string" do
+      "\xB5!\xE0\xC1\xB5?".titleize.should eq("\xB5!\xE0\xC1\xB5?")
+      "a\xA0b".titleize.should eq("A\xA0b")
+    end
 
     describe "with IO" do
       it { String.build { |io| "hEllO tAb\tworld".titleize io }.should eq "Hello Tab\tWorld" }

--- a/spec/std/string_spec.cr
+++ b/spec/std/string_spec.cr
@@ -846,6 +846,10 @@ describe "String" do
     it { "foobar".rstrip('x').should eq("foobar") }
 
     it { "foobar".rstrip { |c| c == 'a' || c == 'r' }.should eq("foob") }
+
+    it "does not touch invalid code units in an otherwise ascii string" do
+      " \xA0 ".rstrip.should eq(" \xA0")
+    end
   end
 
   describe "lstrip" do
@@ -866,6 +870,10 @@ describe "String" do
     it { "barfoo".lstrip('x').should eq("barfoo") }
 
     it { "barfoo".lstrip { |c| c == 'a' || c == 'b' }.should eq("rfoo") }
+
+    it "does not touch invalid code units in an otherwise ascii string" do
+      " \xA0 ".lstrip.should eq("\xA0 ")
+    end
   end
 
   describe "empty?" do
@@ -1235,6 +1243,11 @@ describe "String" do
     it { "foobar".starts_with?('g').should be_false }
     it { "よし".starts_with?('よ').should be_true }
     it { "よし!".starts_with?("よし").should be_true }
+
+    it "treats first char as replacement char if invalid in an otherwise ascii string" do
+      "\xEEfoo".starts_with?('\u{EE}').should be_false
+      "\xEEfoo".starts_with?(Char::REPLACEMENT).should be_true
+    end
   end
 
   describe "ends_with?" do
@@ -1290,16 +1303,23 @@ describe "String" do
     end
   end
 
-  it "reverses string" do
-    "foobar".reverse.should eq("raboof")
-  end
+  describe "#reverse" do
+    it "reverses string" do
+      "foobar".reverse.should eq("raboof")
+    end
 
-  it "reverses utf-8 string" do
-    "こんにちは".reverse.should eq("はちにんこ")
-  end
+    it "reverses utf-8 string" do
+      "こんにちは".reverse.should eq("はちにんこ")
+    end
 
-  it "reverses taking grapheme clusters into account" do
-    "noël".reverse.should eq("lëon")
+    it "reverses taking grapheme clusters into account" do
+      "noël".reverse.should eq("lëon")
+    end
+
+    pending "converts invalid code units to replacement char" do
+      "!\xB0\xC2?".reverse.chars.should eq("?\uFFFD!".chars)
+      "\xC2\xB0\xB0\xC2?".reverse.chars.should eq("?\uFFFD\xC2\xB0".chars)
+    end
   end
 
   describe "sub" do

--- a/spec/std/string_spec.cr
+++ b/spec/std/string_spec.cr
@@ -2605,6 +2605,13 @@ describe "String" do
       "abc".compare("", case_insensitive: true).should eq(1)
       "abcA".compare("abca", case_insensitive: true).should eq(0)
     end
+
+    it "treats invalid code units as replacement char in an otherwise ascii string" do
+      "\xC0".compare("\xE0", case_insensitive: true).should eq(0)
+      "\xE0".compare("\xC0", case_insensitive: true).should eq(0)
+      "\xC0".compare("a", case_insensitive: true).should eq(1)
+      "a".compare("\xC0", case_insensitive: true).should eq(-1)
+    end
   end
 
   it "builds with write_byte" do

--- a/src/string.cr
+++ b/src/string.cr
@@ -4839,7 +4839,8 @@ class String
     return false unless bytesize > 0
 
     if char.ascii? || single_byte_optimizable?
-      return to_unsafe[bytesize - 1] == char.ord
+      byte = to_unsafe[bytesize - 1]
+      return byte < 0x80 ? byte == char.ord : char == Char::REPLACEMENT
     end
 
     bytes, count = String.char_bytes_and_bytesize(char)

--- a/src/string.cr
+++ b/src/string.cr
@@ -1395,9 +1395,9 @@ class String
                         byte
                       elsif i.zero?
                         byte.unsafe_chr.upcase.ord.to_u8!
-                 else
+                      else
                         byte.unsafe_chr.downcase.ord.to_u8!
-                 end
+                      end
         end
         {@bytesize, @length}
       end
@@ -1442,7 +1442,7 @@ class String
           byte = to_unsafe[i]
           if byte < 0x80
             char = byte.unsafe_chr
-          replaced_char = upcase_next ? char.upcase : char.downcase
+            replaced_char = upcase_next ? char.upcase : char.downcase
             buffer[i] = replaced_char.ord.to_u8!
             upcase_next = char.ascii_whitespace?
           else


### PR DESCRIPTION
Some methods in `String` that operate on `single_byte_optimizable?` strings do not have extra checks for invalid code units. This PR adds most of them back.

* `#upcase` etc.: In the block-less overloads, a string like `"\xEF"` is incorrectly converted to `"\xCF"`, since U+00EF `ï` becomes U+00CF `Ï`. This could turn an invalid byte sequence into a valid one, producing widely inconsistent behaviour:
  ```crystal
  str = "\xEF\x83".upcase
  str        # => "σ"
  str.upcase # => "σ"
  str.bytes  # => [0xCF, 0x83]
  str.chars  # => ['\uFFFD', '\uFFFD']
  str.dump   # => "\u03C3"

  # U+00B5 `µ` becomes U+039C `Μ`
  "\xB5".upcase # raises OverflowError
  ```
  These invalid code points are now left intact, so that the corresponding characters still produce the replacement character when accessed from outside. A similar treatment is done for downcasing.
* `#ends_with?(Char)`: A trailing invalid byte is currently treated like the code point with the same numerical value, so a `String` that physically ends with `\xEF` also "ends with" `\u{EF}`. Now those invalid bytes only match the replacement character. However this is not the case for the `String` overload yet, where invalid byte sequences can come from both the receiver and the argument.
* `#compare(case_insensitive: true)`: Case-insensitive comparisons now treat all invalid code units identically, to make this behaviour consistent with non-optimizable strings. Note that only case-insensitive comparisons check character-by-character.

The one missing method is `#reverse`:

```crystal
"\x83\xCF".reverse         # => "σ"
"\x83\xCF\xCF\x83".reverse # => "σσ"
```

Neither line is correct, because `"\x83\xCF"` is an invalid `String` that should behave like two replacement characters, and so reversing it should not form any valid byte sequences. Only the first line is single-byte optimizable. One solution is to replace those bytes with another byte that is guaranteed to be invalid, i.e. anything between `0xC0..0xC1` or `0xF5..0xFF`, but nowhere else in `String` has done this yet. The second line is not optimizable, but perhaps the same idea works there too, since each invalid grapheme cluster should consist of a single byte that is `0x80` or above.