### PR TITLE
Fix LLDB Crystal formatters on Windows

### DIFF
--- a/etc/lldb/crystal_formatters.py
+++ b/etc/lldb/crystal_formatters.py
@@ -46,12 +46,11 @@ def CrystalString_SummaryProvider(value, dict):
     if value.TypeIsPointerType():
         value = value.Dereference()
     target = value.GetTarget()
-    process = target.GetProcess()
-    len = int(value.GetChildMemberWithName('length').value) or int(value.GetChildMemberWithName('bytesize').value)
-    strAddr = value.GetChildMemberWithName('c').load_addr
     if "x86_64-pc-windows-msvc" == target.triple:
-        # on windows, strings are prefixed by 4 bytes indicating the length
-        strAddr += 4
+      value = value.CreateValueFromAddress(value.name, value.load_addr+4, value.type)
+    process = target.GetProcess()
+    len = int(value.GetChildMemberWithName('bytesize').value) or int(value.GetChildMemberWithName('length').value) 
+    strAddr = value.GetChildMemberWithName('c').load_addr
     val = process.ReadCStringFromMemory(strAddr, len + 1, error)
     return '"%s"' % val
 

--- a/etc/lldb/crystal_formatters.py
+++ b/etc/lldb/crystal_formatters.py
@@ -51,7 +51,7 @@ def CrystalString_SummaryProvider(value, dict):
     strAddr = value.GetChildMemberWithName('c').load_addr
     if "x86_64-pc-windows-msvc" == target.triple:
         # on windows, strings are prefixed by 4 bytes indicating the length
-        strAddr = strAddr + 4
+        strAddr += 4
     val = process.ReadCStringFromMemory(strAddr, len + 1, error)
     return '"%s"' % val
 


### PR DESCRIPTION
Fixes #12112

I also changed `valobj.child[<index>]` to  `valobj.GetChildMemberWithName('<name>')` because it's easier to understand what is happening (at least for me).

I tested the script on MacOS and on Windows 10 with lldb version 14.0.0