### PR TITLE
Use LLVM's new pass manager when possible

### DIFF
--- a/src/llvm.cr
+++ b/src/llvm.cr
@@ -130,5 +130,11 @@ module LLVM
     string
   end
 
+  {% unless LibLLVM::IS_LT_130 %}
+    def self.run_passes(module mod : Module, passes : String, target_machine : TargetMachine, options : PassBuilderOptions)
+      LibLLVM.run_passes(mod, passes, target_machine, options)
+    end
+  {% end %}
+
   DEBUG_METADATA_VERSION = 3
 end

--- a/src/llvm/lib_llvm.cr
+++ b/src/llvm/lib_llvm.cr
@@ -66,6 +66,8 @@ lib LibLLVM
   type PassManagerRef = Void*
   type PassRegistryRef = Void*
   type MemoryBufferRef = Void*
+  type PassBuilderOptionsRef = Void*
+  type ErrorRef = Void*
 
   struct JITCompilerOptions
     opt_level : UInt32
@@ -428,4 +430,10 @@ lib LibLLVM
   fun set_instr_param_alignment = LLVMSetInstrParamAlignment(instr : ValueRef, index : UInt, align : UInt)
 
   fun set_param_alignment = LLVMSetParamAlignment(arg : ValueRef, align : UInt)
+
+  {% unless LibLLVM::IS_LT_130 %}
+    fun run_passes = LLVMRunPasses(mod : ModuleRef, passes : UInt8*, tm : TargetMachineRef, options : PassBuilderOptionsRef) : ErrorRef
+    fun create_pass_builder_options = LLVMCreatePassBuilderOptions : PassBuilderOptionsRef
+    fun dispose_pass_builder_options = LLVMDisposePassBuilderOptions(options : PassBuilderOptionsRef)
+  {% end %}
 end

--- a/src/llvm/pass_builder_options.cr
+++ b/src/llvm/pass_builder_options.cr
@@ -1,0 +1,28 @@
+{% skip_file if LibLLVM::IS_LT_130 %}
+
+class LLVM::PassBuilderOptions
+  def initialize
+    @options = LibLLVM.create_pass_builder_options
+    @disposed = false
+  end
+
+  def self.new
+    options = new
+    begin
+      yield options
+    ensure
+      options.finalize
+    end
+  end
+
+  def to_unsafe
+    @options
+  end
+
+  def finalize
+    return if @disposed
+    @disposed = true
+
+    LibLLVM.dispose_pass_builder_options(self)
+  end
+end


### PR DESCRIPTION
Fixes #12115

Using [havlak](https://github.com/crystal-lang/crystal/blob/master/samples/havlak.cr) as an example:

- With the old pass manager:
  - Time that took to produce bc file and optimize it: 3.49s
  - Binary size: 372K
  - Time to execute: 4.043s
- With the new pass manager:
  - Time that took to produce bc file and optimize it: 4.81s
  - Binary size: 332K
  - Time to execute: 3.759s

So just from this example we can see that:
- it takes a bit longer to optimize
- the resulting binary is smaller
- the resulting binary is faster

But I don't think this is generally true. Well, for a "hello world" program I can also see that it takes a bit longer to optimize, and that the binary is smaller. 