### PR TITLE
Support generic types in `Crystal::Macros::Type#is_a?`

### DIFF
--- a/spec/compiler/macro/macro_methods_spec.cr
+++ b/spec/compiler/macro/macro_methods_spec.cr
@@ -192,6 +192,10 @@ module Crystal
           assert_macro %({{ x.is_a?(ClassDef) }}), "true", {x: ClassDef.new("Foo".path)}
           assert_macro %({{ x.is_a?(ModuleDef) }}), "false", {x: ClassDef.new("Foo".path)}
         end
+
+        it "generic argument" do
+          assert_macro %({{ x.is_a?(ArrayLiteral) }}), "true", {x: ArrayLiteral.new(["Foo".path, "bar".call] of ASTNode)}
+        end
       end
     end
 
@@ -826,6 +830,24 @@ module Crystal
         assert_macro %({{[1, 2, 3].is_a?(ArrayLiteral)}}), "true"
         assert_macro %({{[1, 2, 3].is_a?(ASTNode)}}), "true"
         assert_macro %({{[1, 2, 3].is_a?(NumberLiteral)}}), "false"
+
+        assert_macro %({{[1, 2, 3].is_a?(ArrayLiteral(NumberLiteral))}}), "true"
+        assert_macro %({{[1, 2, 3].is_a?(ArrayLiteral(StringLiteral))}}), "false"
+        assert_macro %({{[1, 2, 3].is_a?(ArrayLiteral(NumberLiteral | BoolLiteral))}}), "true"
+        assert_macro %({{[1, 2, 3].is_a?(ArrayLiteral(NumberLiteral) | ArrayLiteral(BoolLiteral))}}), "true"
+        assert_macro %({{[1, 2, 3].is_a?(ArrayLiteral(NoReturn))}}), "false"
+        assert_macro %({{[1, 2, 3].is_a?(ArrayLiteral(ASTNode))}}), "true"
+
+        assert_macro %({{[1, 'a'].is_a?(ArrayLiteral(NumberLiteral))}}), "false"
+        assert_macro %({{[1, 'a'].is_a?(ArrayLiteral(CharLiteral))}}), "false"
+        assert_macro %({{[1, 'a'].is_a?(ArrayLiteral(NumberLiteral | CharLiteral))}}), "true"
+        assert_macro %({{[1, 'a'].is_a?(ArrayLiteral(NumberLiteral) | ArrayLiteral(CharLiteral))}}), "false"
+        assert_macro %({{[1, 'a'].is_a?(ArrayLiteral(NoReturn))}}), "false"
+        assert_macro %({{[1, 'a'].is_a?(ArrayLiteral(ASTNode))}}), "true"
+
+        assert_macro %({{x.is_a?(ArrayLiteral)}}), "true", {x: ArrayLiteral.new}
+        assert_macro %({{x.is_a?(ArrayLiteral(NoReturn))}}), "true", {x: ArrayLiteral.new}
+        assert_macro %({{x.is_a?(ArrayLiteral(StringLiteral))}}), "true", {x: ArrayLiteral.new}
       end
 
       it "creates an array literal with a var" do
@@ -948,6 +970,41 @@ module Crystal
         assert_macro %({{{:a => 1}.is_a?(HashLiteral)}}), "true"
         assert_macro %({{{:a => 1}.is_a?(ASTNode)}}), "true"
         assert_macro %({{{:a => 1}.is_a?(RangeLiteral)}}), "false"
+
+        assert_macro %({{ {"a" => 1, "b" => 2}.is_a?(HashLiteral(StringLiteral, NumberLiteral)) }}), "true"
+        assert_macro %({{ {"a" => 1, "b" => 2}.is_a?(HashLiteral(StringLiteral, StringLiteral)) }}), "false"
+        assert_macro %({{ {"a" => 1, "b" => 2}.is_a?(HashLiteral(StringLiteral, NumberLiteral | BoolLiteral)) }}), "true"
+        assert_macro %({{ {"a" => 1, "b" => 2}.is_a?(HashLiteral(StringLiteral, NumberLiteral) | HashLiteral(StringLiteral, BoolLiteral)) }}), "true"
+        assert_macro %({{ {"a" => 1, "b" => 2}.is_a?(HashLiteral(StringLiteral, NoReturn)) }}), "false"
+        assert_macro %({{ {"a" => 1, "b" => 2}.is_a?(HashLiteral(StringLiteral, ASTNode)) }}), "true"
+
+        assert_macro %({{ {"a" => 1, "b" => 'a'}.is_a?(HashLiteral(StringLiteral, NumberLiteral)) }}), "false"
+        assert_macro %({{ {"a" => 1, "b" => 'a'}.is_a?(HashLiteral(StringLiteral, CharLiteral)) }}), "false"
+        assert_macro %({{ {"a" => 1, "b" => 'a'}.is_a?(HashLiteral(StringLiteral, NumberLiteral | CharLiteral)) }}), "true"
+        assert_macro %({{ {"a" => 1, "b" => 'a'}.is_a?(HashLiteral(StringLiteral, NumberLiteral) | HashLiteral(StringLiteral, CharLiteral)) }}), "false"
+        assert_macro %({{ {"a" => 1, "b" => 'a'}.is_a?(HashLiteral(StringLiteral, NoReturn)) }}), "false"
+        assert_macro %({{ {"a" => 1, "b" => 'a'}.is_a?(HashLiteral(StringLiteral, ASTNode)) }}), "true"
+
+        assert_macro %({{ {1 => "a", 2 => "b"}.is_a?(HashLiteral(NumberLiteral, StringLiteral)) }}), "true"
+        assert_macro %({{ {1 => "a", 2 => "b"}.is_a?(HashLiteral(StringLiteral, StringLiteral)) }}), "false"
+        assert_macro %({{ {1 => "a", 2 => "b"}.is_a?(HashLiteral(NumberLiteral | BoolLiteral, StringLiteral)) }}), "true"
+        assert_macro %({{ {1 => "a", 2 => "b"}.is_a?(HashLiteral(NumberLiteral, StringLiteral) | HashLiteral(BoolLiteral, StringLiteral)) }}), "true"
+        assert_macro %({{ {1 => "a", 2 => "b"}.is_a?(HashLiteral(NoReturn, StringLiteral)) }}), "false"
+        assert_macro %({{ {1 => "a", 2 => "b"}.is_a?(HashLiteral(ASTNode, StringLiteral)) }}), "true"
+
+        assert_macro %({{ {1 => "a", 'a' => "b"}.is_a?(HashLiteral(NumberLiteral, StringLiteral)) }}), "false"
+        assert_macro %({{ {1 => "a", 'a' => "b"}.is_a?(HashLiteral(CharLiteral, StringLiteral)) }}), "false"
+        assert_macro %({{ {1 => "a", 'a' => "b"}.is_a?(HashLiteral(NumberLiteral | CharLiteral, StringLiteral)) }}), "true"
+        assert_macro %({{ {1 => "a", 'a' => "b"}.is_a?(HashLiteral(NumberLiteral, StringLiteral) | HashLiteral(CharLiteral, StringLiteral)) }}), "false"
+        assert_macro %({{ {1 => "a", 'a' => "b"}.is_a?(HashLiteral(NoReturn, StringLiteral)) }}), "false"
+        assert_macro %({{ {1 => "a", 'a' => "b"}.is_a?(HashLiteral(ASTNode, StringLiteral)) }}), "true"
+
+        assert_macro %({{ {1 => 'x', false => "y"}.is_a?(HashLiteral(NumberLiteral | BoolLiteral, CharLiteral | StringLiteral)) }}), "true"
+        assert_macro %({{ {1 => 'x', false => "y"}.is_a?(HashLiteral(ASTNode, ASTNode)) }}), "true"
+
+        assert_macro %({{x.is_a?(HashLiteral)}}), "true", {x: HashLiteral.new}
+        assert_macro %({{x.is_a?(HashLiteral(NoReturn, NoReturn))}}), "true", {x: HashLiteral.new}
+        assert_macro %({{x.is_a?(HashLiteral(StringLiteral, NumberLiteral))}}), "true", {x: HashLiteral.new}
       end
 
       it "executes []=" do
@@ -1078,6 +1135,24 @@ module Crystal
         assert_macro %({{{a: 1}.is_a?(NamedTupleLiteral)}}), "true"
         assert_macro %({{{a: 1}.is_a?(ASTNode)}}), "true"
         assert_macro %({{{a: 1}.is_a?(RangeLiteral)}}), "false"
+
+        assert_macro %({{ {a: 1, b: 2}.is_a?(NamedTupleLiteral(NumberLiteral)) }}), "true"
+        assert_macro %({{ {a: 1, b: 2}.is_a?(NamedTupleLiteral(StringLiteral)) }}), "false"
+        assert_macro %({{ {a: 1, b: 2}.is_a?(NamedTupleLiteral(NumberLiteral | BoolLiteral)) }}), "true"
+        assert_macro %({{ {a: 1, b: 2}.is_a?(NamedTupleLiteral(NumberLiteral) | NamedTupleLiteral(BoolLiteral)) }}), "true"
+        assert_macro %({{ {a: 1, b: 2}.is_a?(NamedTupleLiteral(NoReturn)) }}), "false"
+        assert_macro %({{ {a: 1, b: 2}.is_a?(NamedTupleLiteral(ASTNode)) }}), "true"
+
+        assert_macro %({{ {a: 1, b: 'a'}.is_a?(NamedTupleLiteral(NumberLiteral)) }}), "false"
+        assert_macro %({{ {a: 1, b: 'a'}.is_a?(NamedTupleLiteral(CharLiteral)) }}), "false"
+        assert_macro %({{ {a: 1, b: 'a'}.is_a?(NamedTupleLiteral(NumberLiteral | CharLiteral)) }}), "true"
+        assert_macro %({{ {a: 1, b: 'a'}.is_a?(NamedTupleLiteral(NumberLiteral) | NamedTupleLiteral(CharLiteral)) }}), "false"
+        assert_macro %({{ {a: 1, b: 'a'}.is_a?(NamedTupleLiteral(NoReturn)) }}), "false"
+        assert_macro %({{ {a: 1, b: 'a'}.is_a?(NamedTupleLiteral(ASTNode)) }}), "true"
+
+        assert_macro %({{x.is_a?(NamedTupleLiteral)}}), "true", {x: NamedTupleLiteral.new}
+        assert_macro %({{x.is_a?(NamedTupleLiteral(NoReturn))}}), "true", {x: NamedTupleLiteral.new}
+        assert_macro %({{x.is_a?(NamedTupleLiteral(StringLiteral))}}), "true", {x: NamedTupleLiteral.new}
       end
 
       it "executes []=" do
@@ -1333,6 +1408,24 @@ module Crystal
         assert_macro %({{ {1, 2, 3}.is_a?(TupleLiteral) }}), "true"
         assert_macro %({{ {1, 2, 3}.is_a?(ASTNode) }}), "true"
         assert_macro %({{ {1, 2, 3}.is_a?(ArrayLiteral) }}), "false"
+
+        assert_macro %({{ {1, 2, 3}.is_a?(TupleLiteral(NumberLiteral)) }}), "true"
+        assert_macro %({{ {1, 2, 3}.is_a?(TupleLiteral(StringLiteral)) }}), "false"
+        assert_macro %({{ {1, 2, 3}.is_a?(TupleLiteral(NumberLiteral | BoolLiteral)) }}), "true"
+        assert_macro %({{ {1, 2, 3}.is_a?(TupleLiteral(NumberLiteral) | TupleLiteral(BoolLiteral)) }}), "true"
+        assert_macro %({{ {1, 2, 3}.is_a?(TupleLiteral(NoReturn)) }}), "false"
+        assert_macro %({{ {1, 2, 3}.is_a?(TupleLiteral(ASTNode)) }}), "true"
+
+        assert_macro %({{ {1, 'a'}.is_a?(TupleLiteral(NumberLiteral)) }}), "false"
+        assert_macro %({{ {1, 'a'}.is_a?(TupleLiteral(CharLiteral)) }}), "false"
+        assert_macro %({{ {1, 'a'}.is_a?(TupleLiteral(NumberLiteral | CharLiteral)) }}), "true"
+        assert_macro %({{ {1, 'a'}.is_a?(TupleLiteral(NumberLiteral) | TupleLiteral(CharLiteral)) }}), "false"
+        assert_macro %({{ {1, 'a'}.is_a?(TupleLiteral(NoReturn)) }}), "false"
+        assert_macro %({{ {1, 'a'}.is_a?(TupleLiteral(ASTNode)) }}), "true"
+
+        assert_macro %({{x.is_a?(TupleLiteral)}}), "true", {x: TupleLiteral.new([] of ASTNode)}
+        assert_macro %({{x.is_a?(TupleLiteral(NoReturn))}}), "true", {x: TupleLiteral.new([] of ASTNode)}
+        assert_macro %({{x.is_a?(TupleLiteral(StringLiteral))}}), "true", {x: TupleLiteral.new([] of ASTNode)}
       end
 
       it "creates a tuple literal with a var" do

--- a/spec/compiler/parser/parser_spec.cr
+++ b/spec/compiler/parser/parser_spec.cr
@@ -1926,6 +1926,17 @@ module Crystal
       end
     end
 
+    assert_syntax_error "{{ 1.is_a?(Foo*) }}", "cannot use `*` in macro types"
+    assert_syntax_error "{{ 1.is_a?(Foo**) }}", "cannot use `*` in macro types"
+    assert_syntax_error "{{ 1.is_a?(Foo?) }}", "cannot use `?` in macro types"
+    assert_syntax_error "{{ 1.is_a?(Foo[1]) }}", "cannot use `[]` in macro types"
+    assert_syntax_error "{{ 1.is_a?(Foo -> Bar) }}", "cannot use `->` in macro types"
+    assert_syntax_error "{{ 1.is_a?({Foo}) }}", "cannot use `{}` in macro types"
+    assert_syntax_error "{{ 1.is_a?({a: Foo}) }}", "cannot use `{}` in macro types"
+    assert_syntax_error "{{ 1.is_a?(self) }}", "cannot use `self` in macro types"
+    assert_syntax_error "{{ 1.is_a?(self?) }}", "cannot use `self` in macro types"
+    assert_syntax_error "{{ 1.is_a?(_) }}", "cannot use `_` in macro types"
+
     assert_syntax_error "Foo{one: :two, three: :four}", "can't use named tuple syntax for Hash-like literal"
     assert_syntax_error "{one: :two, three: :four} of Symbol => Symbol"
     assert_syntax_error %(Hash{"foo": 1}), "can't use named tuple syntax for Hash-like literal"

--- a/src/compiler/crystal/syntax/parser.cr
+++ b/src/compiler/crystal/syntax/parser.cr
@@ -39,6 +39,7 @@ module Crystal
       @call_args_nest = 0
       @temp_arg_count = 0
       @in_macro_expression = false
+      @in_macro_type_name = false
       @stop_on_yield = 0
       @inside_c_struct = false
       @wants_doc = false
@@ -848,21 +849,26 @@ module Crystal
     end
 
     def parse_is_a(atomic)
-      next_token_skip_space
-
-      if @token.type.op_lparen?
-        next_token_skip_space_or_newline
-        type = parse_bare_proc_type
-        skip_space_or_newline
-        check :OP_RPAREN
-        end_location = token_end_location
+      old_in_macro_type_name, @in_macro_type_name = @in_macro_type_name, @in_macro_expression
+      begin
         next_token_skip_space
-      else
-        type = parse_union_type
-        end_location = type.end_location
-      end
 
-      IsA.new(atomic, type).at_end(end_location)
+        if @token.type.op_lparen?
+          next_token_skip_space_or_newline
+          type = parse_bare_proc_type
+          skip_space_or_newline
+          check :OP_RPAREN
+          end_location = token_end_location
+          next_token_skip_space
+        else
+          type = parse_union_type
+          end_location = type.end_location
+        end
+
+        IsA.new(atomic, type).at_end(end_location)
+      ensure
+        @in_macro_type_name = old_in_macro_type_name
+      end
     end
 
     def parse_as(atomic, klass = Cast)
@@ -4863,17 +4869,21 @@ module Crystal
       when .ident?
         case @token.value
         when :self
+          raise "cannot use `self` in macro types" if @in_macro_type_name
           next_token_skip_space
           Self.new.at(location)
         when "self?"
+          raise "cannot use `self` in macro types" if @in_macro_type_name
           next_token_skip_space
           make_nilable_type Self.new.at(location)
         when :typeof
+          raise "cannot use `typeof` in macro types" if @in_macro_type_name
           parse_typeof
         else
           unexpected_token
         end
       when .underscore?
+        raise "cannot use `_` in macro types" if @in_macro_type_name
         next_token_skip_space
         Underscore.new.at(location)
       when .const?, .op_colon_colon?
@@ -5139,6 +5149,7 @@ module Crystal
     end
 
     def parse_proc_type_output(input_types, location)
+      raise "cannot use `->` in macro types" if @in_macro_type_name
       has_output_type = type_start?(consume_newlines: false)
 
       check :OP_MINUS_GT
@@ -5153,6 +5164,7 @@ module Crystal
     end
 
     def make_nilable_type(type)
+      raise "cannot use `?` in macro types" if @in_macro_type_name
       Union.new([type, Path.global("Nil").at(type)]).at(type)
     end
 
@@ -5163,22 +5175,26 @@ module Crystal
     end
 
     def make_pointer_type(type)
+      raise "cannot use `*` in macro types" if @in_macro_type_name
       type = Generic.new(Path.global("Pointer").at(type), [type] of ASTNode).at(type)
       type.suffix = :asterisk
       type
     end
 
     def make_static_array_type(type, size)
+      raise "cannot use `[]` in macro types" if @in_macro_type_name
       type = Generic.new(Path.global("StaticArray").at(type), [type, size] of ASTNode).at(type)
       type.suffix = :bracket
       type
     end
 
     def make_tuple_type(types)
+      raise "cannot use `{}` in macro types" if @in_macro_type_name
       Generic.new(Path.global("Tuple"), types)
     end
 
     def make_named_tuple_type(named_args)
+      raise "cannot use `{}` in macro types" if @in_macro_type_name
       Generic.new(Path.global("NamedTuple"), [] of ASTNode, named_args: named_args)
     end
 


### PR DESCRIPTION
Resolves #11981. With this, all the type names used in the macro method docs will actually mean something (even if they aren't used yet).

This PR makes the following macro types generic:

```crystal
class ArrayLiteral(T); end      # T = union of element types
class HashLiteral(K, V); end    # K = union of key types, V = union of value types
class TupleLiteral(T); end      # T = union of element types
class NamedTupleLiteral(V); end # V = union of value types
```

But see https://github.com/crystal-lang/crystal/issues/11981#issuecomment-1153299472 on whether the last two should become variadic.

The second commit forbids all of the short forms that are previously allowed in arguments to the macro `#is_a?`. As mentioned in #11981, they never worked in the first place, because no AST node's `#class_name` ever contains those short forms or the type names they expand to:

```crystal
x = 1
x.is_a?(NumberLiteral?)   # => false
nil.is_a?(NumberLiteral?) # => false

# after #12086
x = 1
x.is_a?(NumberLiteral?)   # => true
nil.is_a?(NumberLiteral?) # => false

# after this PR
x = 1
x.is_a?(NumberLiteral?)   # Error: cannot use `?` in macro types
nil.is_a?(NumberLiteral?) # Error: cannot use `?` in macro types
```

A corresponding PR for the reference manual will follow shortly.