### PR TITLE
Improve the LLDB spec driver script

### DIFF
--- a/spec/debug/blocks.cr
+++ b/spec/debug/blocks.cr
@@ -1,8 +1,8 @@
 ["hello world"].each do |v|
   a = v
-  b = 0 # break
   # lldb-command: print a
   # lldb-check: (String *) $0 = {{0x[0-9a-f]+}} "hello world"
   # lldb-command: print v
   # lldb-check: (String *) $1 = {{0x[0-9a-f]+}} "hello world"
+  debugger
 end

--- a/spec/debug/driver.cr
+++ b/spec/debug/driver.cr
@@ -1,9 +1,3 @@
-def each_line1(file)
-  File.read_lines(file).each_with_index do |line, index0|
-    yield line, index0 + 1
-  end
-end
-
 repo_base_dir = "#{__DIR__}/../../"
 tmp_build_dir = File.join(repo_base_dir, ".build")
 Dir.mkdir_p(tmp_build_dir)
@@ -12,25 +6,25 @@ input = ARGV[0]
 
 bin = File.join(tmp_build_dir, "debug_test_case")
 debugger_script = File.join(tmp_build_dir, "./debugger.script")
+lldb_crystal_formatters = File.expand_path(File.join(repo_base_dir, "etc", "lldb", "crystal_formatters.py"))
 
 Process.run(ENV["CRYSTAL_SPEC_COMPILER_BIN"]? || "#{repo_base_dir}/bin/crystal", ["build", "--debug", input, "-o", bin])
 
 File.open(debugger_script, "w") do |script|
-  lldb_crystal_formatters = File.expand_path(File.join(repo_base_dir, "etc", "lldb", "crystal_formatters.py"))
   script.puts "version"
   script.puts "command script import #{lldb_crystal_formatters}"
 
-  each_line1(input) do |line, line_number|
-    if line.match(/# break\b/)
-      script.puts "breakpoint set --file #{input} --line #{line_number}"
-    end
-  end
+  # skip signals intentionally raised during GC initialization: https://hboehm.info/gc/debugging.html
+  script.puts "breakpoint set -n main -G true -o true -C 'process handle -s false -n false SIGSEGV SIGBUS'"
+  script.puts "breakpoint set -n __crystal_main -G true -o true -C 'process handle -s true -n true SIGSEGV SIGBUS'"
 
   script.puts "run"
 
-  each_line1(input) do |line|
+  File.each_line(input) do |line|
     if md = line.match(/# lldb-command: (.*)/)
       script.puts md[1]
+    elsif line.matches?(/\bdebugger\b/)
+      script.puts "c"
     end
   end
 end
@@ -42,7 +36,7 @@ session_log = File.join(session_output_dir, File.basename(input, File.extname(in
 session_assert = File.join(session_output_dir, File.basename(input, File.extname(input)) + ".lldb-assert")
 
 File.open(session_assert, "w") do |assert|
-  each_line1(input) do |line|
+  File.each_line(input) do |line|
     if md = line.match(/# lldb-command: (.*)/)
       assert.puts "CHECK: (lldb) #{md[1]}"
     elsif md = line.match(/# lldb-check: (.*)/)
@@ -51,8 +45,9 @@ File.open(session_assert, "w") do |assert|
   end
 end
 
-`/usr/bin/lldb -b --source #{debugger_script} #{bin} > #{session_log}`
+`lldb -b --source #{debugger_script} #{bin} > #{session_log}`
 
-`FileCheck #{session_assert} < #{session_log}`
+llvm_version_suffix = File.basename(`#{__DIR__}/../../src/llvm/ext/find-llvm-config`).lchop("llvm-config")
+`FileCheck#{llvm_version_suffix} #{session_assert} < #{session_log}`
 
 exit $?.exit_code

--- a/spec/debug/strings.cr
+++ b/spec/debug/strings.cr
@@ -1,6 +1,4 @@
-# NOTE: breakpoint on line 1 + next does not work
-a = "hello world" # break
-# lldb-command: n
+a = "hello world"
 # lldb-command: print a
 # lldb-check: (String *) $0 = {{0x[0-9a-f]+}} "hello world"
-b = 0
+debugger

--- a/spec/debug/test.sh
+++ b/spec/debug/test.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 # This file can be executed from the root of the working copy
 #
@@ -14,10 +14,11 @@
 #
 # The magic comments interpreted by the driver are:
 #
-#   * # break
 #   * # lldb-command:
 #   * # lldb-check:
 #
+# These comments should then be followed by a call to `debugger` which sets up
+# the actual breakpoint.
 
 set -euo pipefail
 

--- a/spec/debug/top_level.cr
+++ b/spec/debug/top_level.cr
@@ -1,8 +1,7 @@
-# NOTE: breakpoint on line 1 + next does not work
-a = 42 # break
 # lldb-command: print a
 # lldb-check: (int) $0 = 0
-# lldb-command: n
+debugger
+a = 42
 # lldb-command: print a
 # lldb-check: (int) $1 = 42
-b = 0
+debugger


### PR DESCRIPTION
* Uses `bash` instead of `sh`, since `set -o` is unavailable in the latter.
* Uses the `debugger` intrinsic instead of setting breakpoints manually in the LLDB script. This actually also ensures all the processes eventually terminate inside the debugger.
* Detects the LLVM version using the `find-llvm-config` script, required for FileCheck. Note that the LLDB and the LLVM versions need not agree, so the version suffix is not applied to the former.
* Adds a workaround for #11589 where GC initialization could emit a SIGSEGV intentionally.
