### PR TITLE
Remove unused `ASTNode#unbind_all`

### DIFF
--- a/src/compiler/crystal/semantic/bindings.cr
+++ b/src/compiler/crystal/semantic/bindings.cr
@@ -152,11 +152,6 @@ module Crystal
       propagate
     end
 
-    def unbind_all
-      @dependencies.try &.each &.remove_observer(self)
-      @dependencies = nil
-    end
-
     def unbind_from(nodes : Nil)
       # Nothing to do
     end


### PR DESCRIPTION
This method is unused (maybe in the past it was used, but not anymore)