### PR TITLE
Compiler: simpler way to compute `Def#raises?`

### DIFF
--- a/spec/compiler/semantic/exception_spec.cr
+++ b/spec/compiler/semantic/exception_spec.cr
@@ -265,6 +265,29 @@ describe "Semantic: exception" do
     a_def.not_nil!.raises?.should be_true
   end
 
+  it "marks method that calls another method that raises as raises, recursively" do
+    result = assert_type(%(
+      @[Raises]
+      def foo
+        1
+      end
+
+      def bar
+        foo
+      end
+
+      def baz
+        bar
+      end
+
+      foo
+      bar
+      baz
+      )) { int32 }
+    call = result.node.as(Expressions).expressions.last.as(Call)
+    call.target_defs.not_nil!.first.raises?.should be_true
+  end
+
   it "marks proc literal as raises" do
     result = assert_type("->{ 1 }.call", inject_primitives: true) { int32 }
     call = result.node.as(Expressions).last.as(Call)

--- a/src/compiler/crystal/semantic/ast.cr
+++ b/src/compiler/crystal/semantic/ast.cr
@@ -147,7 +147,7 @@ module Crystal
     property next : Def?
     property special_vars : Set(String)?
     property block_nest = 0
-    getter? raises = false
+    property? raises = false
     property? closure = false
     property? self_closured = false
     property? captured_block = false
@@ -183,17 +183,6 @@ module Crystal
     def add_special_var(name)
       special_vars = @special_vars ||= Set(String).new
       special_vars << name
-    end
-
-    def raises=(value)
-      if value != @raises
-        @raises = value
-        @observers.try &.each do |obs|
-          if obs.is_a?(Call)
-            obs.raises = value
-          end
-        end
-      end
     end
 
     # Returns the minimum and maximum number of arguments that must

--- a/src/compiler/crystal/semantic/call.cr
+++ b/src/compiler/crystal/semantic/call.cr
@@ -11,7 +11,6 @@ class Crystal::Call
   property expanded : ASTNode?
   property expanded_macro : Macro?
   property? uses_with_scope = false
-  getter? raises = false
 
   class RetryLookupWithLiterals < ::Exception
   end
@@ -101,11 +100,6 @@ class Crystal::Call
     bind_to block.break if block
 
     if (parent_visitor = @parent_visitor) && matches
-      if parent_visitor.typed_def? && matches.any?(&.raises?)
-        @raises = true
-        parent_visitor.typed_def.raises = true
-      end
-
       matches.each do |match|
         match.special_vars.try &.each do |special_var_name|
           special_var = match.vars.not_nil![special_var_name]
@@ -1248,16 +1242,6 @@ class Crystal::Call
 
     type.as(SubclassObservable).add_subclass_observer(self)
     @subclass_notifier = type
-  end
-
-  def raises=(value)
-    if @raises != value
-      @raises = value
-      typed_def = parent_visitor.typed_def?
-      if typed_def
-        typed_def.raises = value
-      end
-    end
   end
 
   def super?

--- a/src/compiler/crystal/semantic/cleanup_transformer.cr
+++ b/src/compiler/crystal/semantic/cleanup_transformer.cr
@@ -66,6 +66,9 @@ module Crystal
   class CleanupTransformer < Transformer
     @transformed : Set(Def)
 
+    # The current method we are processing
+    @current_def : Def?
+
     def initialize(@program : Program)
       @transformed = Set(Def).new.compare_by_identity
       @exhaustiveness_checker = ExhaustivenessChecker.new(@program)
@@ -514,14 +517,22 @@ module Crystal
           end
         end
 
+        current_def = @current_def
+
         target_defs.each do |target_def|
           if @transformed.add?(target_def)
             node.bubbling_exception do
+              @current_def = target_def
               @def_nest_count += 1
               target_def.body = target_def.body.transform(self)
               @def_nest_count -= 1
+              @current_def = current_def
             end
           end
+
+          # If the current call targets a method that raises, the method
+          # where the call happens also raises.
+          current_def.raises = true if current_def && target_def.raises?
         end
 
         if node.target_defs.not_nil!.empty?

--- a/src/compiler/crystal/semantic/lib.cr
+++ b/src/compiler/crystal/semantic/lib.cr
@@ -28,10 +28,6 @@ class Crystal::Call
 
     self.unbind_from old_target_defs if old_target_defs
     self.bind_to untyped_defs
-
-    if (parent_visitor = @parent_visitor) && (ptyped_def = parent_visitor.typed_def?) && untyped_defs.try(&.any?(&.raises?))
-      ptyped_def.raises = true
-    end
   end
 
   def check_lib_call_named_args(external)


### PR DESCRIPTION
When doing a Call's codegen we need to know if the target method can possibly raise. In that case we do an LLVM's `invoke` instruction instead of a `call`.

The logic to compute that, before this PR, was very complex:
- after computing a Call's target methods, we would mark the enclosing Def as "raises"
- when a Def was marked as "raises" we would check which calls depended on this method, and mark them as "raises"
- this would then happen recursively

However, there's no need to eagerly compute this information whenever we finish analyzing each call. Instead, we can do this at the very end of the semantic phase: as we "clean up" everything and traverse the entire code, we keep track of the methods we are analyzing. If a call ends up calling a method that raises, we mark the current method as "raises", and so on.

With this, there's also no need to keep track of a `@raises` variable in `Call`.