### PR TITLE
Compiler: don't use `with_scope` if Call has a receiver

### DIFF
--- a/spec/compiler/semantic/method_missing_spec.cr
+++ b/spec/compiler/semantic/method_missing_spec.cr
@@ -110,6 +110,7 @@ describe "Semantic: method_missing" do
       run do
         foo.bar
       end
-      ))
+      ),
+      "undefined method 'bar' for Int32")
   end
 end

--- a/spec/compiler/semantic/method_missing_spec.cr
+++ b/spec/compiler/semantic/method_missing_spec.cr
@@ -92,4 +92,24 @@ describe "Semantic: method_missing" do
       end
       )) { int32 }
   end
+
+  it "doesn't look up method_missing in with_yield_scope if call has a receiver (#12097)" do
+    assert_error(%(
+      class Foo
+        macro method_missing(method)
+          def {{method}}
+            1
+          end
+        end
+      end
+
+      def run
+        with Foo.new yield
+      end
+
+      run do
+        foo.bar
+      end
+      ))
+  end
 end

--- a/src/compiler/crystal/semantic/main_visitor.cr
+++ b/src/compiler/crystal/semantic/main_visitor.cr
@@ -1362,7 +1362,7 @@ module Crystal
       else
         node.scope = @scope || current_type.metaclass
       end
-      node.with_scope = with_scope
+      node.with_scope = with_scope unless node.obj
       node.parent_visitor = self
     end
 


### PR DESCRIPTION
Fixes #12099 
Fixes #12097
Fixes #12137

Oops! We were setting the `with_scope` attribute of a Call (the scope where we look up methods for the `with ... yield` object) on calls that had a receiver. If a call has a receiver we should never look up the method on the `with ... yield` object.

I think this was working fine, by chance, except when it interacted with `method_missing`.