### PR TITLE
Interpreter: workaround for virtual struct allocate

### DIFF
--- a/spec/compiler/interpreter/integration_spec.cr
+++ b/spec/compiler/interpreter/integration_spec.cr
@@ -149,5 +149,25 @@ describe Crystal::Repl::Interpreter do
         end
       CODE
     end
+
+    it "doesn't crash on virtual struct allocate (#12123)" do
+      interpret(<<-CODE, prelude: "prelude").should eq("nil")
+        require "log"
+
+        abstract struct Parent
+          extend Log::Formatter
+
+          def self.format(entry, io) : Nil
+            new
+          end
+        end
+
+        struct Child1 < Parent
+        end
+
+        struct Child2 < Parent
+        end
+      CODE
+    end
   end
 end


### PR DESCRIPTION
Fixes #12123

This actually makes the code work, but the solution is not the correct one. But it's better than having the program crash.

To explain a bit more:
- This is related to #3835 where it turns out we can instantiate abstract types.
- Abstract types are always represented as virtual types
- When we produce "allocate" for a virtual type, we treat it as allocating the non-virtual type... which makes sense if the type is not abstract, but doesn't make sense if the type is abstract
- Because parent structs are always abstract, virtual structs are always abstract too, so it's always the case that we should produce a runtime error when doing "allocate" on them.

So the correct solution is to produce a runtime error for #3835 . But I can't do that right now because we need to discuss exactly how to do it (what exception that is? what's the message? etc.)

So this is a workaround, and it will produce "wrong" interpreter code, but only if you abuse the fact that you can create abstract types. If you don't do that (and you normally don't, unless you are trying to do something wrong on purpose) then everything should be fine.

But let me know if you'd like not to merge this and instead do a proper fix for #3835 (which would also apply to the interpreter)