### PR TITLE
Implement `Crystal::Loader` for MSVC

### DIFF
--- a/spec/compiler/data/ffi/sum.c
+++ b/spec/compiler/data/ffi/sum.c
@@ -1,16 +1,17 @@
 #include <stdarg.h>
+#include "../visibility.h"
 
-int answer()
+EXPORT int answer()
 {
     return 42;
 }
 
-int sum(int a, int b, int c)
+EXPORT int sum(int a, int b, int c)
 {
     return a + b + c;
 }
 
-void sum_primitive_types(
+EXPORT void sum_primitive_types(
     unsigned char a, signed char b,
     unsigned short c, signed short d,
     unsigned long e, signed long f,
@@ -32,13 +33,13 @@ struct test_struct
     int *p;
 };
 
-int sum_struct(struct test_struct s)
+EXPORT int sum_struct(struct test_struct s)
 {
     *s.p = s.b + s.s + s.i + s.j + s.f + s.d + *(s.p);
     return *s.p;
 }
 
-int sum_array(int ary[4])
+EXPORT int sum_array(int ary[4])
 {
     int sum = 0;
     for (int i = 0; i < 4; i++)
@@ -48,7 +49,7 @@ int sum_array(int ary[4])
     return sum;
 }
 
-int sum_variadic(int count, ...)
+EXPORT int sum_variadic(int count, ...)
 {
     va_list ap;
     int j;
@@ -64,7 +65,7 @@ int sum_variadic(int count, ...)
     return sum;
 }
 
-struct test_struct make_struct(char b, short s, int i, long long j, float f, double d, void *p)
+EXPORT struct test_struct make_struct(char b, short s, int i, long long j, float f, double d, void *p)
 {
     struct test_struct t;
     t.b = b;

--- a/spec/compiler/data/interpreter/sum.c
+++ b/spec/compiler/data/interpreter/sum.c
@@ -1,6 +1,7 @@
 #include <stdarg.h>
+#include "../visibility.h"
 
-float sum_float(int count, ...) {
+EXPORT float sum_float(int count, ...) {
   va_list args;
   float total = 0;
 
@@ -13,7 +14,7 @@ float sum_float(int count, ...) {
   return total;
 }
 
-long sum_int(int count, ...) {
+EXPORT long sum_int(int count, ...) {
   va_list args;
   long total = 0;
 

--- a/spec/compiler/data/loader/bar.c
+++ b/spec/compiler/data/loader/bar.c
@@ -1,5 +1,9 @@
-int foo();
+#include "../visibility.h"
 
-int bar() {
+LOCAL int foo() {
+  return 42;
+}
+
+EXPORT int bar() {
   return foo() + 100;
 }

--- a/spec/compiler/data/loader/foo.c
+++ b/spec/compiler/data/loader/foo.c
@@ -1,3 +1,5 @@
-int foo() {
+#include "../visibility.h"
+
+EXPORT int foo() {
   return 12;
 }

--- a/spec/compiler/data/loader/foo2.c
+++ b/spec/compiler/data/loader/foo2.c
@@ -1,7 +1,9 @@
-int a() {
+#include "../visibility.h"
+
+LOCAL int a() {
   return 41;
 }
 
-int foo() {
+EXPORT int foo() {
   return 42;
 }

--- a/spec/compiler/data/visibility.h
+++ b/spec/compiler/data/visibility.h
@@ -1,0 +1,7 @@
+#ifdef _WIN32
+  #define EXPORT __declspec(dllexport)
+  #define LOCAL
+#else
+  #define EXPORT __attribute__ ((visibility ("default")))
+  #define LOCAL __attribute__ ((visibility ("hidden")))
+#endif

--- a/spec/compiler/loader/msvc_spec.cr
+++ b/spec/compiler/loader/msvc_spec.cr
@@ -1,4 +1,4 @@
-{% skip_file if !flag?(:unix) || flag?(:wasm32) %}
+{% skip_file if !flag?(:msvc) %}
 
 require "./spec_helper"
 require "../spec_helper"
@@ -8,79 +8,27 @@ require "compiler/crystal/loader"
 describe Crystal::Loader do
   describe ".parse" do
     it "parses directory paths" do
-      loader = Crystal::Loader.parse(["-L", "/foo/bar/baz", "--library-path", "qux"], search_paths: [] of String)
-      loader.search_paths.should eq ["/foo/bar/baz", "qux"]
-    end
-
-    it "parses static" do
-      expect_raises(Crystal::Loader::LoadError, "static libraries are not supported by Crystal's runtime loader") do
-        Crystal::Loader.parse(["-static"], search_paths: [] of String)
-      end
-    end
-
-    it "parses library names" do
-      expect_raises(Crystal::Loader::LoadError, "cannot find -lfoobar") do
-        Crystal::Loader.parse(["-l", "foobar"], search_paths: [] of String)
-      end
-      expect_raises(Crystal::Loader::LoadError, "cannot find -lfoobar") do
-        Crystal::Loader.parse(["--library", "foobar"], search_paths: [] of String)
-      end
+      loader = Crystal::Loader.parse([%q(/LIBPATH:C:\foo\bar), "/LIBPATH:baz"], search_paths: [] of String)
+      loader.search_paths.should eq [%q(C:\foo\bar), "baz"]
     end
 
     it "parses file paths" do
-      expect_raises(Crystal::Loader::LoadError, /#{Dir.current}\/foobar\.o.+(No such file or directory|image not found)/) do
-        Crystal::Loader.parse(["foobar.o"], search_paths: [] of String)
-      end
-      expect_raises(Crystal::Loader::LoadError, /#{Dir.current}\/foo\/bar\.o.+(No such file or directory|image not found)/) do
-        Crystal::Loader.parse(["-l", "foo/bar.o"], search_paths: [] of String)
+      expect_raises(Crystal::Loader::LoadError, "cannot find foobar.lib") do
+        Crystal::Loader.parse(["foobar.lib"], search_paths: [] of String)
       end
     end
   end
 
   describe ".default_search_paths" do
-    it "LD_LIBRARY_PATH" do
-      with_env "LD_LIBRARY_PATH": "ld1::ld2", "DYLD_LIBRARY_PATH": nil do
+    it "LIB" do
+      with_env "LIB": "foo;;bar" do
         search_paths = Crystal::Loader.default_search_paths
-        {% if flag?(:darwin) %}
-          search_paths.should eq ["/usr/lib", "/usr/local/lib"]
-        {% else %}
-          search_paths[0, 2].should eq ["ld1", "ld2"]
-          search_paths[-2..].should eq ["/lib", "/usr/lib"]
-        {% end %}
-      end
-    end
-
-    it "DYLD_LIBRARY_PATH" do
-      with_env "DYLD_LIBRARY_PATH": "ld1::ld2", "LD_LIBRARY_PATH": nil do
-        search_paths = Crystal::Loader.default_search_paths
-        {% if flag?(:darwin) %}
-          search_paths[0, 2].should eq ["ld1", "ld2"]
-          search_paths[-2..].should eq ["/usr/lib", "/usr/local/lib"]
-        {% else %}
-          search_paths[-2..].should eq ["/lib", "/usr/lib"]
-        {% end %}
+        search_paths.should eq ["foo", "bar"]
       end
     end
   end
 
-  describe ".read_ld_conf" do
-    it "basic" do
-      ary = [] of String
-      Crystal::Loader.read_ld_conf(ary, compiler_datapath("loader/ld.so/basic.conf"))
-      ary.should eq ["foo/bar", "baz/qux"]
-    end
-
-    it "with include" do
-      ary = [] of String
-      Crystal::Loader.read_ld_conf(ary, compiler_datapath("loader/ld.so/include.conf"))
-      ary[0].should eq "include/before"
-      ary[-1].should eq "include/after"
-      # the order between basic.conf and basic2.conf is system-dependent
-      ary[1..-2].sort.should eq ["baz/qux", "foo/bar", "foobar"]
-    end
-  end
-
-  describe "dynlib" do
+  describe "dll" do
     before_all do
       FileUtils.mkdir_p(SPEC_CRYSTAL_LOADER_LIB_PATH)
       build_c_dynlib(compiler_datapath("loader", "foo.c"))
@@ -117,18 +65,15 @@ describe Crystal::Loader do
         loader.close_all if loader
       end
 
-      {% unless flag?(:darwin) %}
-        # FIXME: bar.c doesn't compile on darwin
-        it "does not implicitly find dependencies" do
-          build_c_dynlib(compiler_datapath("loader", "bar.c"))
-          loader = Crystal::Loader.new([SPEC_CRYSTAL_LOADER_LIB_PATH] of String)
-          loader.load_library?("bar").should be_true
-          loader.find_symbol?("bar").should_not be_nil
-          loader.find_symbol?("foo").should be_nil
-        ensure
-          loader.close_all if loader
-        end
-      {% end %}
+      it "does not implicitly find dependencies" do
+        build_c_dynlib(compiler_datapath("loader", "bar.c"))
+        loader = Crystal::Loader.new([SPEC_CRYSTAL_LOADER_LIB_PATH] of String)
+        loader.load_library?("bar").should be_true
+        loader.find_symbol?("bar").should_not be_nil
+        loader.find_symbol?("foo").should be_nil
+      ensure
+        loader.close_all if loader
+      end
 
       it "lookup in order" do
         build_c_dynlib(compiler_datapath("loader", "foo2.c"))

--- a/spec/compiler/loader/spec_helper.cr
+++ b/spec/compiler/loader/spec_helper.cr
@@ -3,8 +3,7 @@ require "spec"
 SPEC_CRYSTAL_LOADER_LIB_PATH = File.join(SPEC_TEMPFILE_PATH, "loader")
 
 def build_c_dynlib(c_filename, target_dir = SPEC_CRYSTAL_LOADER_LIB_PATH)
-  obj_ext = Crystal::Loader::SHARED_LIBRARY_EXTENSION
-  o_filename = File.join(target_dir, "lib#{File.basename(c_filename).rchop(".c")}#{obj_ext}")
+  o_filename = File.join(target_dir, Crystal::Loader.library_filename(File.basename(c_filename).rchop(".c")))
 
   {% if flag?(:msvc) %}
     `cl.exe /nologo /LD #{Process.quote(c_filename)} #{Process.quote("/Fo#{o_filename}")}`.should be_truthy

--- a/spec/compiler/loader/spec_helper.cr
+++ b/spec/compiler/loader/spec_helper.cr
@@ -3,11 +3,12 @@ require "spec"
 SPEC_CRYSTAL_LOADER_LIB_PATH = File.join(SPEC_TEMPFILE_PATH, "loader")
 
 def build_c_dynlib(c_filename, target_dir = SPEC_CRYSTAL_LOADER_LIB_PATH)
-  o_filename = File.join(target_dir, Crystal::Loader.library_filename(File.basename(c_filename).rchop(".c")))
+  o_filename = File.join(target_dir, Crystal::Loader.library_filename(File.basename(c_filename, ".c")))
 
   {% if flag?(:msvc) %}
-    `cl.exe /nologo /LD #{Process.quote(c_filename)} #{Process.quote("/Fo#{o_filename}")}`.should be_truthy
+    o_basename = o_filename.rchop(".lib")
+    `cl.exe /nologo /LD #{Process.quote(c_filename)} #{Process.quote("/Fo#{o_basename}")} #{Process.quote("/Fe#{o_basename}")}`.should be_truthy
   {% else %}
-    `#{ENV["CC"]? || "cc"} -shared #{Process.quote(c_filename)} -o #{Process.quote(o_filename)}`.should be_truthy
+    `#{ENV["CC"]? || "cc"} -shared -fvisibility=hidden #{Process.quote(c_filename)} -o #{Process.quote(o_filename)}`.should be_truthy
   {% end %}
 end

--- a/spec/compiler/loader/unix_spec.cr
+++ b/spec/compiler/loader/unix_spec.cr
@@ -93,7 +93,7 @@ describe Crystal::Loader do
     describe "#load_file" do
       it "finds function symbol" do
         loader = Crystal::Loader.new([] of String)
-        lib_handle = loader.load_file(File.join(SPEC_CRYSTAL_LOADER_LIB_PATH, "libfoo#{Crystal::Loader::SHARED_LIBRARY_EXTENSION}"))
+        lib_handle = loader.load_file(File.join(SPEC_CRYSTAL_LOADER_LIB_PATH, Crystal::Loader.library_filename("foo")))
         lib_handle.should_not be_nil
         loader.find_symbol?("foo").should_not be_nil
       ensure
@@ -113,7 +113,7 @@ describe Crystal::Loader do
 
       it "full path" do
         loader = Crystal::Loader.new([] of String)
-        lib_handle = loader.load_library(File.join(SPEC_CRYSTAL_LOADER_LIB_PATH, "libfoo#{Crystal::Loader::SHARED_LIBRARY_EXTENSION}"))
+        lib_handle = loader.load_library(File.join(SPEC_CRYSTAL_LOADER_LIB_PATH, Crystal::Loader.library_filename("foo")))
         lib_handle.should_not be_nil
         loader.find_symbol?("foo").should_not be_nil
       ensure

--- a/src/compiler/crystal/loader.cr
+++ b/src/compiler/crystal/loader.cr
@@ -50,6 +50,10 @@ class Crystal::Loader
     @handles = [] of Handle
   end
 
+  # def self.library_filename(libname : String) : String
+  #   raise NotImplementedError.new("library_filename")
+  # end
+
   # def find_symbol?(name : String) : Handle?
   #   raise NotImplementedError.new("find_symbol?")
   # end
@@ -79,7 +83,8 @@ class Crystal::Loader
       return load_file(::Path[libname].expand)
     end
 
-    each_library_path(libname) do |library_path|
+    @search_paths.each do |directory|
+      library_path = File.join(directory, Loader.library_filename(libname))
       handle = load_file?(library_path)
       return handle if handle
     end
@@ -93,12 +98,6 @@ class Crystal::Loader
 
     @handles << handle
     handle
-  end
-
-  private def each_library_path(libname)
-    @search_paths.each do |directory|
-      yield "#{directory}/lib#{libname}#{SHARED_LIBRARY_EXTENSION}"
-    end
   end
 
   def close_all : Nil

--- a/src/compiler/crystal/loader/msvc.cr
+++ b/src/compiler/crystal/loader/msvc.cr
@@ -1,0 +1,119 @@
+{% skip_file unless flag?(:msvc) %}
+require "crystal/system/win32/library_archive"
+
+# On Windows with the MSVC toolset, the loader tries to imitate the behaviour of
+# `link.exe`, using the Win32 DLL API.
+#
+# * Only dynamic libraries can be loaded. Static libraries and object files
+#   are unsupported. in particular, `LibC.printf` and `LibC.snprintf`are inline
+#   functions in `legacy-stdio_definitions.lib` since VS2015, so they are never
+#   found by the loader.
+# * Unlike the Unix counterpart, symbols in the current module do not clash with
+#   the ones in DLLs or their corresponding import libraries.
+
+class Crystal::Loader
+  alias Handle = Void*
+
+  class LoadError
+    include SystemError
+  end
+
+  # Parses linker arguments in the style of `link.exe`.
+  def self.parse(args : Array(String), *, search_paths : Array(String) = default_search_paths) : self
+    libnames = [] of String
+    file_paths = [] of String
+
+    # NOTE: `/LIBPATH` overrides the default paths, not the other way round
+    # (https://docs.microsoft.com/en-us/cpp/build/reference/libpath-additional-libpath)
+    extra_search_paths = [] of String
+
+    args.each do |arg|
+      if arg.starts_with?("/LIBPATH:")
+        extra_search_paths << arg[9..]
+      elsif !arg.starts_with?('/') && arg.ends_with?(".lib")
+        libnames << arg[...-4]
+      end
+    end
+
+    begin
+      self.new(extra_search_paths + search_paths, libnames, file_paths)
+    rescue exc : LoadError
+      exc.args = args
+      exc.search_paths = search_paths
+      raise exc
+    end
+  end
+
+  def self.library_filename(libname : String) : String
+    "#{libname}.lib"
+  end
+
+  def find_symbol?(name : String) : Handle?
+    @handles.each do |handle|
+      address = LibC.GetProcAddress(handle, name.check_no_null_byte)
+      return address if address
+    end
+  end
+
+  def load_file(path : String | ::Path) : Nil
+    load_file?(path) || raise LoadError.from_winerror "cannot load #{path}"
+  end
+
+  def load_file?(path : String | ::Path) : Bool
+    # On Windows, each `.lib` import library may reference any number of `.dll`
+    # files, whose base names may not match the library's. Thus it is necessary
+    # to extract this information from the library archive itself.
+    System::LibraryArchive.imported_dlls(path).each do |dll|
+      # always consider the `.dll` in the same directory as the `.lib` first,
+      # regardless of the search order
+      first_path = File.join(File.dirname(path), dll)
+      dll = first_path if File.file?(first_path)
+
+      # TODO: `dll` is an unqualified name, e.g. `SHELL32.dll`, so the default
+      # DLL search order is used; consider getting rid of the cwd
+      # (https://docs.microsoft.com/en-us/windows/win32/dlls/dynamic-link-library-search-order)
+      handle = open_library(dll)
+      return false unless handle
+      @handles << handle
+    end
+
+    true
+  end
+
+  def load_library(libname : String) : Nil
+    load_library?(libname) || raise LoadError.from_winerror "cannot find #{Loader.library_filename(libname)}"
+  end
+
+  private def open_library(path : String)
+    LibC.LoadLibraryExW(path.check_no_null_byte.to_utf16, nil, 0)
+  end
+
+  def load_current_program_handle
+    if LibC.GetModuleHandleExW(0, nil, out hmodule) != 0
+      @handles << hmodule
+    end
+  end
+
+  def close_all : Nil
+    @handles.each do |handle|
+      LibC.FreeLibrary(handle)
+    end
+    @handles.clear
+  end
+
+  # Returns a list of directories used as the default search paths.
+  #
+  # For MSVC this is simply the contents of the `LIB` environment variable,
+  # usually pre-populated by the developer prompt. (If a normal prompt is used
+  # but an MSVC installation is available, Crystal injects a replica of `LIB`'s
+  # default contents through `/LIBPATH` linker arguments.)
+  #
+  # This is _not_ the same thing as the default search paths for `.dll` files.
+  def self.default_search_paths : Array(String)
+    if env_lib = ENV["LIB"]?
+      env_lib.split(Process::PATH_DELIMITER, remove_empty: true)
+    else
+      [] of String
+    end
+  end
+end

--- a/src/compiler/crystal/loader/msvc.cr
+++ b/src/compiler/crystal/loader/msvc.cr
@@ -28,10 +28,10 @@ class Crystal::Loader
     extra_search_paths = [] of String
 
     args.each do |arg|
-      if arg.starts_with?("/LIBPATH:")
-        extra_search_paths << arg[9..]
-      elsif !arg.starts_with?('/') && arg.ends_with?(".lib")
-        libnames << arg[...-4]
+      if lib_path = arg.lchop?("/LIBPATH:")
+        extra_search_paths << lib_path
+      elsif !arg.starts_with?('/') && (name = arg.rchop?(".lib"))
+        libnames << name
       end
     end
 

--- a/src/compiler/crystal/loader/unix.cr
+++ b/src/compiler/crystal/loader/unix.cr
@@ -35,12 +35,6 @@ class Crystal::Loader
     end
   end
 
-  SHARED_LIBRARY_EXTENSION = {% if flag?(:darwin) %}
-                               ".dylib"
-                             {% else %}
-                               ".so"
-                             {% end %}
-
   # Parses linker arguments in the style of `ld`.
   def self.parse(args : Array(String), *, search_paths : Array(String) = default_search_paths) : self
     libnames = [] of String
@@ -69,6 +63,14 @@ class Crystal::Loader
       exc.search_paths = search_paths
       raise exc
     end
+  end
+
+  def self.library_filename(libname : String) : String
+    {% if flag?(:darwin) %}
+      "lib#{libname}.dylib"
+    {% else %}
+      "lib#{libname}.so"
+    {% end %}
   end
 
   def find_symbol?(name : String) : Handle?

--- a/src/compiler/crystal/loader/unix.cr
+++ b/src/compiler/crystal/loader/unix.cr
@@ -80,11 +80,19 @@ class Crystal::Loader
     end
   end
 
-  def load_file(path : String | ::Path) : Handle
+  def load_file(path : String | ::Path) : Nil
     load_file?(path) || raise LoadError.new_dl_error "cannot load #{path}"
   end
 
-  def load_library(libname : String) : Handle
+  def load_file?(path : String | ::Path) : Bool
+    handle = open_library(path.to_s)
+    return false unless handle
+
+    @handles << handle
+    true
+  end
+
+  def load_library(libname : String) : Nil
     load_library?(libname) || raise LoadError.new_dl_error "cannot find -l#{libname}"
   end
 

--- a/src/crystal/system/win32/library_archive.cr
+++ b/src/crystal/system/win32/library_archive.cr
@@ -1,0 +1,85 @@
+# This module provides functions for operating with Windows library archives.
+# Implementation based on: https://docs.microsoft.com/en-us/windows/win32/debug/pe-format
+module Crystal::System::LibraryArchive
+  # Returns the list of DLL filenames imported by the .lib archive at the given
+  # *path*.
+  def self.imported_dlls(path : ::Path | String) : Set(String)
+    return Set(String).new unless ::File.file?(path)
+    ::File.open(path, "r") do |f|
+      reader = COFFReader.new(f)
+      reader.run
+      reader.dlls
+    end
+  end
+
+  # Minimal implementation of a Microsoft COFF archive reader. All unused fields
+  # are ignored.
+  private struct COFFReader
+    getter dlls = Set(String).new
+
+    def initialize(@ar : ::File)
+    end
+
+    # Attempts to collect all DLL imports found in an import library. Should not
+    # raise if the library is not an import library. Might raise if `@ar` is not
+    # a library at all.
+    def run
+      file_size = @ar.size
+
+      # magic number
+      return unless @ar.read_string(8) == "!<arch>\n"
+
+      # first linker member
+      return unless read_member { |filename, _| return unless filename == "/" }
+
+      # second linker member
+      return unless read_member { |filename, _| return unless filename == "/" }
+
+      # longnames member (optional)
+      return if @ar.pos == file_size
+      return unless read_member { |filename, io| handle_standard_member(io) unless filename == "//" }
+
+      # standard members
+      until @ar.pos == file_size
+        return unless read_member { |_, io| handle_standard_member(io) }
+      end
+    end
+
+    private def read_member(& : String ->)
+      filename = @ar.read_string(16).rstrip(' ')
+
+      # time(12) + uid(6) + gid(6) + mode(8)
+      @ar.skip(32)
+
+      size = @ar.read_string(10).rstrip(' ').to_u32
+
+      # end of header
+      return false unless @ar.read_string(2) == "`\n"
+
+      new_pos = @ar.pos + size + (size.odd? ? 1 : 0)
+      yield filename, IO::Sized.new(@ar, read_size: size)
+      @ar.seek(new_pos)
+
+      true
+    end
+
+    private def handle_standard_member(io)
+      sig1 = io.read_bytes(UInt16, IO::ByteFormat::LittleEndian)
+      return unless sig1 == 0x0000 # IMAGE_FILE_MACHINE_UNKNOWN
+
+      sig2 = io.read_bytes(UInt16, IO::ByteFormat::LittleEndian)
+      return unless sig2 == 0xFFFF
+
+      # version(2) + machine(2) + time(4) + size(4) + ordinal/hint(2) + flags(2)
+      io.skip(16)
+
+      # TODO: is there a way to do this without constructing a temporary string,
+      # but with the optimizations present in `IO#gets`?
+      return unless io.gets('\0') # symbol name
+
+      if dll_name = io.gets('\0', chomp: true)
+        @dlls << dll_name
+      end
+    end
+  end
+end

--- a/src/lib_c/x86_64-windows-msvc/c/libloaderapi.cr
+++ b/src/lib_c/x86_64-windows-msvc/c/libloaderapi.cr
@@ -1,5 +1,15 @@
 require "c/winnt"
 
+@[Link("Kernel32")]
 lib LibC
+  alias FARPROC = Void*
+
+  fun LoadLibraryExW(lpLibFileName : LPWSTR, hFile : HANDLE, dwFlags : DWORD) : HMODULE
+  fun FreeLibrary(hLibModule : HMODULE) : BOOL
+
+  fun GetModuleHandleExW(dwFlags : DWORD, lpModuleName : LPWSTR, phModule : HMODULE*) : BOOL
+
+  fun GetProcAddress(hModule : HMODULE, lpProcName : LPSTR) : FARPROC
+
   fun GetModuleFileNameW(hModule : HMODULE, lpFilename : LPWSTR, nSize : DWORD) : DWORD
 end


### PR DESCRIPTION
This PR adds an implementation of `Crystal::Loader` that imitates the MSVC linker. The end goal here is to get the interpreter compiling on Windows. The loader can be used stand-alone:

```crystal
require "compiler/crystal/loader"

# these are obtained from running a blank source with `crystal run file.cr --verbose`
# and taking everything after `/link`
args = [
  %q(/LIBPATH:C:\Program Files\Microsoft Visual Studio\2022\Community\VC\Tools\MSVC\14.31.31103\atlmfc\lib\x64),
  %q(/LIBPATH:C:\Program Files\Microsoft Visual Studio\2022\Community\VC\Tools\MSVC\14.31.31103\lib\x64),
  %q(/LIBPATH:C:\Program Files (x86)\Windows Kits\10\Lib\10.0.19041.0\ucrt\x64),
  %q(/LIBPATH:C:\Program Files (x86)\Windows Kits\10\Lib\10.0.19041.0\um\x64),
  %q(/DEBUG:FULL),
  %q(/PDBALTPATH:%_PDB%),
  %q(/INCREMENTAL:NO),
  %q(/STACK:0x800000),
  %q(/LIBPATH:C:\crystal\lib),
  %q(pcre.lib),
  %q(gc.lib),
  %q(/ENTRY:wmainCRTStartup),
  %q(iconv.lib),
  %q(advapi32.lib),
  %q(Kernel32.lib),
  %q(shell32.lib),
  %q(ole32.lib),
  %q(WS2_32.lib),
  %q(legacy_stdio_definitions.lib),
  %q(DbgHelp.lib),
  %q(libcmt.lib),
]

loader = Crystal::Loader.parse(args) # => #<Crystal::Loader:0x2e0746c0dc0 ...>
loader.find_symbol("GetProcAddress") # => Pointer(Void)@0x7fff07f3aec0
```

It implements a minimal COFF archive reader to extract the DLLs imported by a `.lib` file. Note that a single library may import zero DLLs, such as static libraries, or multiple, such as `ucrt.lib`.

We have the opportunity to customize the whole search order by only passing absolute paths to `LibC.LoadLibraryEx`. Here the loader prefers DLLs stored alongside the import libraries, then uses the [standard DLL search order](https://docs.microsoft.com/en-us/windows/win32/dlls/dynamic-link-library-search-order); on my setup this is necessary to select the correct `libiconv.dll`. Whatever we do, this search order should eventually coincide with the one for binaries compiled with load-time dynamic linking.

Related: #11555