### PR TITLE
Compiler: raise when allocating an abstract virtual type

### DIFF
--- a/spec/compiler/codegen/struct_spec.cr
+++ b/spec/compiler/codegen/struct_spec.cr
@@ -460,6 +460,8 @@ describe "Code gen: struct" do
 
   it "codegens virtual struct metaclass (#2551) (4)" do
     run(%(
+      require "prelude"
+
       abstract struct Foo
         def initialize
           @x = 21
@@ -631,6 +633,8 @@ describe "Code gen: struct" do
 
   it "can call new on abstract struct with single child (#7309)" do
     codegen(%(
+      require "prelude"
+
       abstract struct Foo
         @x = 1
       end

--- a/spec/compiler/codegen/virtual_spec.cr
+++ b/spec/compiler/codegen/virtual_spec.cr
@@ -651,6 +651,8 @@ describe "Code gen: virtual type" do
 
   it "codegens new for virtual class with one type" do
     run(%(
+      require "prelude"
+
       abstract class Foo
       end
 
@@ -668,6 +670,8 @@ describe "Code gen: virtual type" do
 
   it "codegens new for virtual class with two types" do
     run(%(
+      require "prelude"
+
       abstract class Foo
       end
 
@@ -688,6 +692,28 @@ describe "Code gen: virtual type" do
       p.value = Baz
       p.value.new.foo
       )).to_i.should eq(456)
+  end
+
+  it "codegens new for new on virtual abstract class (#3835)" do
+    run(%(
+      require "prelude"
+
+      abstract class Foo
+      end
+
+      class Bar < Foo
+        def foo
+          123
+        end
+      end
+
+      begin
+        (Foo || Bar).new
+        ""
+      rescue ex
+        ex.message.not_nil!
+      end
+      )).to_string.should eq("Can't instantiate abstract class Foo")
   end
 
   it "casts metaclass union type to virtual metaclass type (#6298)" do

--- a/spec/compiler/semantic/virtual_metaclass_spec.cr
+++ b/spec/compiler/semantic/virtual_metaclass_spec.cr
@@ -34,7 +34,9 @@ describe "Semantic: virtual metaclass" do
   end
 
   it "allows allocating virtual type when base class is abstract" do
-    assert_type("
+    assert_type(%(
+      require "prelude"
+
       abstract class Foo
       end
 
@@ -46,7 +48,7 @@ describe "Semantic: virtual metaclass" do
 
       bar = Bar.new || Baz.new
       baz = bar.class.allocate
-      ", inject_primitives: true) { types["Foo"].virtual_type }
+      )) { types["Foo"].virtual_type }
   end
 
   it "yields virtual type in block arg if class is abstract" do

--- a/src/compiler/crystal/codegen/primitives.cr
+++ b/src/compiler/crystal/codegen/primitives.cr
@@ -726,17 +726,6 @@ class Crystal::CodeGenVisitor
   def codegen_primitive_allocate(node, target_def, call_args)
     type = node.type
 
-    # Edge case: if a virtual struct has only one concrete subclass, its
-    # type indirection (how we represent it for codegen) turns out not to be
-    # a union type but just a single type. In that case we just need to create
-    # this concrete type, without creating the base type and then casting it back.
-    if type.is_a?(VirtualType) && type.struct?
-      indirect_type = type.remove_indirection
-      if !indirect_type.is_a?(UnionType)
-        return @last = allocate_aggregate indirect_type
-      end
-    end
-
     base_type = type.is_a?(VirtualType) ? type.base_type : type
 
     allocate_aggregate base_type

--- a/src/compiler/crystal/semantic/cleanup_transformer.cr
+++ b/src/compiler/crystal/semantic/cleanup_transformer.cr
@@ -997,9 +997,17 @@ module Crystal
     end
 
     def transform(node : Primitive)
-      if extra = node.extra
-        node.extra = extra.transform(self)
+      extra = node.extra
+      extra = extra.transform(self) if extra
+
+      # For `allocate` on a virtual abstract type we make `extra`
+      # be a call to `raise` at runtime. Here we just replace the
+      # "allocate" primitive with that raise call.
+      if node.name == "allocate" && extra
+        return extra
       end
+
+      node.extra = extra
       node
     end
 


### PR DESCRIPTION
Fixes #3835
Fixes #12123

Consider this code:

```crystal
abstract class Foo
end

class Bar < Foo
end

class Baz < Foo
end

a = [] of Foo.class

# Maybe these are read from a configuration file!
a << Bar
a << Baz

instances = a.map(&.new)
```

So far, so good.

The idea is to support the scenario of having an array of types, being able to fill that with some classes, and eventually instantiate them all.

The problem comes when we put a `Foo` in that array:

```crystal
a << Foo

a.map(&.new) # Oops!
```

Previously, the compiler would actually create an instance of `Foo`, which didn't make sense because `Foo` is abstract.

So now in this PR when you do that, you get a **runtime error** when you call `new` on `Foo` **when the compiler doesn't know which of the types there are there** (in the hierarchy.), like in the example above.

Note that if you do:

```crystal
Foo.new
```

the compiler absolutely knows that `Foo` is the receiver, and will produce a **compile-time** error instead.

Alternatively, we could disallow calling `new` on a type that's "an abstract class or any of its sublclasses" but I think that can limit some use cases or scenarios.