### PR TITLE
Update distribution-scripts

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,7 @@ parameters:
   distribution-scripts-version:
     description: "Git ref for version of https://github.com/crystal-lang/distribution-scripts/"
     type: string
-    default: "b421c5a3f857247ed88251d0c6dbcca7337c4648"
+    default: "26cd7ec1a7a6a71368e3299e3bffed9b5f79ea67"
   previous_crystal_base_url:
     description: "Prefix for URLs to Crystal bootstrap compiler"
     type: string


### PR DESCRIPTION
Updates `distribution-scripts` dependency to https://github.com/crystal-lang/distribution-scripts/commit/26cd7ec1a7a6a71368e3299e3bffed9b5f79ea67

This includes the following changes:

* crystal-lang/distribution-scripts#191
* crystal-lang/distribution-scripts#187