### PR TITLE
Fix positional parameter warnings in specs

### DIFF
--- a/spec/std/indexable/mutable_spec.cr
+++ b/spec/std/indexable/mutable_spec.cr
@@ -12,14 +12,14 @@ private class SafeIndexableMutable
     @values = Array.new(size) { |i| [i + offset] }
   end
 
-  def unsafe_fetch(i)
-    raise IndexError.new unless 0 <= i < size
-    @values[i][0]
+  def unsafe_fetch(index)
+    raise IndexError.new unless 0 <= index < size
+    @values[index][0]
   end
 
-  def unsafe_put(i, value : Int32)
-    raise IndexError.new unless 0 <= i < size
-    @values[i] = [value]
+  def unsafe_put(index, value : Int32)
+    raise IndexError.new unless 0 <= index < size
+    @values[index] = [value]
   end
 end
 
@@ -37,14 +37,14 @@ private class SafeIndexableMutableFoo
     @values = Array.new(size) { [Foo.new] }
   end
 
-  def unsafe_fetch(i)
-    raise IndexError.new unless 0 <= i < size
-    @values[i][0]
+  def unsafe_fetch(index)
+    raise IndexError.new unless 0 <= index < size
+    @values[index][0]
   end
 
-  def unsafe_put(i, value : Foo)
-    raise IndexError.new unless 0 <= i < size
-    @values[i] = [value]
+  def unsafe_put(index, value : Foo)
+    raise IndexError.new unless 0 <= index < size
+    @values[index] = [value]
   end
 end
 

--- a/spec/std/indexable_spec.cr
+++ b/spec/std/indexable_spec.cr
@@ -8,9 +8,9 @@ private class SafeIndexable
   def initialize(@size : Int32, @offset = 0_i32)
   end
 
-  def unsafe_fetch(i) : Int32
-    raise IndexError.new unless 0 <= i < size
-    (i + @offset).to_i
+  def unsafe_fetch(index) : Int32
+    raise IndexError.new unless 0 <= index < size
+    (index + @offset).to_i
   end
 end
 
@@ -22,8 +22,8 @@ private class SafeNestedIndexable
   def initialize(@size : Int32, @inner_size : Int32)
   end
 
-  def unsafe_fetch(i)
-    raise IndexError.new unless 0 <= i < size
+  def unsafe_fetch(index)
+    raise IndexError.new unless 0 <= index < size
     SafeIndexable.new(@inner_size)
   end
 end
@@ -36,9 +36,9 @@ private class SafeStringIndexable
   def initialize(@size : Int32)
   end
 
-  def unsafe_fetch(i) : String
-    raise IndexError.new unless 0 <= i < size
-    i.to_s
+  def unsafe_fetch(index) : String
+    raise IndexError.new unless 0 <= index < size
+    index.to_s
   end
 end
 
@@ -50,9 +50,9 @@ private class SafeMixedIndexable
   def initialize(@size : Int32)
   end
 
-  def unsafe_fetch(i) : String | Int32
-    raise IndexError.new unless 0 <= i < size
-    i.to_s
+  def unsafe_fetch(index) : String | Int32
+    raise IndexError.new unless 0 <= index < size
+    index.to_s
   end
 end
 
@@ -64,12 +64,12 @@ private class SafeRecursiveIndexable
   def initialize(@size : Int32)
   end
 
-  def unsafe_fetch(i) : SafeRecursiveIndexable | Int32
-    raise IndexError.new unless 0 <= i < size
-    if (i % 2) == 0
-      SafeRecursiveIndexable.new(i)
+  def unsafe_fetch(index) : SafeRecursiveIndexable | Int32
+    raise IndexError.new unless 0 <= index < size
+    if (index % 2) == 0
+      SafeRecursiveIndexable.new(index)
     else
-      i
+      index
     end
   end
 end

--- a/spec/std/io/memory_spec.cr
+++ b/spec/std/io/memory_spec.cr
@@ -81,7 +81,7 @@ describe IO::Memory do
           io2 = IO::Memory.new
           io2.set_encoding "UTF-16LE"
 
-          io1.write_utf8 "abc😂".to_slice
+          io1.write_string "abc😂".to_slice
           io1.to_s io2
           byte_slice = io2.to_slice
           utf16_slice = Slice.new(byte_slice.to_unsafe.unsafe_as(Pointer(UInt16)), byte_slice.size // sizeof(UInt16))

--- a/spec/std/io/sized_spec.cr
+++ b/spec/std/io/sized_spec.cr
@@ -1,11 +1,11 @@
 require "spec"
 
 private class NoPeekIO < IO
-  def read(bytes : Bytes)
+  def read(slice : Bytes)
     0
   end
 
-  def write(bytes : Bytes) : Nil
+  def write(slice : Bytes) : Nil
   end
 
   def peek

--- a/spec/std/json/serialization_spec.cr
+++ b/spec/std/json/serialization_spec.cr
@@ -1,4 +1,5 @@
 require "../spec_helper"
+require "spec/helpers/iterate"
 require "json"
 require "big"
 require "big/json"


### PR DESCRIPTION
This is a follow-up on #11915, fixing some leftover positional parameter warnings in stdlib specs.