### PR TITLE
Fix: Instance vars should not be allowed on `Class`, `Tuple`, `NamedTuple`, `Enum`, `Pointer` , `Proc`, `StaticArray` and `Union`.

### DIFF
--- a/spec/compiler/semantic/instance_var_spec.cr
+++ b/spec/compiler/semantic/instance_var_spec.cr
@@ -4237,7 +4237,7 @@ describe "Semantic: instance var" do
       )) { generic_class "Bar", int32 }
   end
 
-  %w(Object Reference).each do |type|
+  %w(Object Reference Class).each do |type|
     it "errors if declaring var in #{type}" do
       assert_error %(
         class #{type}
@@ -4248,7 +4248,12 @@ describe "Semantic: instance var" do
     end
   end
 
-  %w(Value Number Int Float Int32).each do |type|
+  [
+    "Value", "Number", "Int", "Float", "Int32",
+    "Tuple(*T)", "NamedTuple(T)", "Enum",
+    "Pointer(T)", "StaticArray(T, N)",
+    "Proc(*T, R)", "Union(*T)",
+  ].each do |type|
     it "errors if declaring var in #{type}" do
       assert_error %(
         struct #{type}

--- a/src/compiler/crystal/types.cr
+++ b/src/compiler/crystal/types.cr
@@ -548,8 +548,12 @@ module Crystal
     def allows_instance_vars?
       case self
       when program.object, program.value, program.struct,
+           program.reference, program.class_type,
            program.number, program.int, program.float,
-           PrimitiveType, program.reference
+           program.tuple, program.named_tuple,
+           program.pointer, program.static_array,
+           program.union, program.enum, program.proc,
+           PrimitiveType
         false
       else
         true


### PR DESCRIPTION
Fix #12159. 

The compiler now produce an error when user define an ivar on these type:  `Class`, `Tuple`, `NamedTuple`, `Enum`, `Pointer` , `Proc`, `StaticArray` and `Union`. 
```crystal
class Class
  @x = 42
end
# => Error: can't declare instance variables in Class
```

(similar to previously triggered error on forbidden type on `Int32` `Number`, `Object`...)


Note that `TupleInstanceType` or `NamedTupleInstanceType` still inherit from module `InstanceVarContainer` through `GenericClassInstanceType`, but couldn't touch that because `GenericClassInstanceType` is used by every generic class.
