### PR TITLE
Ignore `pax_global_header` on Windows CI

### DIFF
--- a/.github/workflows/win.yml
+++ b/.github/workflows/win.yml
@@ -224,7 +224,6 @@ jobs:
           (Get-FileHash -Algorithm SHA256 .\openssl.tar.gz).hash -eq "59eedfcb46c25214c9bd37ed6078297b4df01d012267fe9e9eee31f61bc70536"
           7z x openssl.tar.gz
           7z x openssl.tar
-          del pax_global_header
           mv openssl-* openssl
       - name: Build OpenSSL
         if: steps.cache-openssl.outputs.cache-hit != 'true'


### PR DESCRIPTION
`pax_global_header` is a part of some POSIX tar archives' extended header, which was "extracted" as a regular file on 7-Zip until version 22.00. The `windows-2022` virtual environment has now upgraded its installation of 7-Zip to this version since `20220626.1`. Thus this "file" is no longer present, and we have to ignore it to prevent CI failures.