### PR TITLE
Interpreter: handle explicit return when method type is Nil

### DIFF
--- a/spec/compiler/interpreter/control_flow_spec.cr
+++ b/spec/compiler/interpreter/control_flow_spec.cr
@@ -226,6 +226,16 @@ describe Crystal::Repl::Interpreter do
       CODE
     end
 
+    it "interprets return Nil with explicit return (#12178)" do
+      interpret(<<-CODE).should be_nil
+        def foo : Nil
+          return 1
+        end
+
+        foo
+      CODE
+    end
+
     it "interprets return implicit nil and Int32" do
       interpret(<<-CODE).should eq(10)
         def foo(x)

--- a/src/compiler/crystal/interpreter/compiler.cr
+++ b/src/compiler/crystal/interpreter/compiler.cr
@@ -1318,7 +1318,13 @@ class Crystal::Repl::Compiler < Crystal::Visitor
       def_type = merge_block_break_type(def_type, compiled_block.block)
     end
 
-    upcast node, exp_type, def_type
+    # Check if it's an explicit Nil return
+    if def_type.nil_type?
+      # In that case we don't need the return value, so we just pop it
+      pop aligned_sizeof_type(exp_type), node: node
+    else
+      upcast node, exp_type, def_type
+    end
 
     if @compiling_block
       leave_def aligned_sizeof_type(def_type), node: node


### PR DESCRIPTION
Fixes #12178

A similar logic is done when an [implicit value is returned from a method](https://github.com/crystal-lang/crystal/blob/b7f3f102fd68fcf9fe4f074513c9e374ec98b492/src/compiler/crystal/interpreter/compiler.cr#L243-L246), it was just missing in the case of an explicit return.