### PR TITLE
Interpreter: fix caller

### DIFF
--- a/spec/compiler/interpreter/integration_spec.cr
+++ b/spec/compiler/interpreter/integration_spec.cr
@@ -149,5 +149,19 @@ describe Crystal::Repl::Interpreter do
         end
       CODE
     end
+
+    it "does caller" do
+      interpret(<<-CODE, prelude: "prelude").should eq(%(":6:5 in 'bar'"))
+        def foo
+          bar
+        end
+
+        def bar
+          caller[0]
+        end
+
+        foo
+      CODE
+    end
   end
 end

--- a/src/exception/call_stack/interpreter.cr
+++ b/src/exception/call_stack/interpreter.cr
@@ -17,7 +17,7 @@ struct Exception::CallStack
 
   def self.decode_line_number(pc)
     _, line, column, file = pc
-    {line, column, file}
+    {file, line, column}
   end
 
   def self.decode_function_name(pc)


### PR DESCRIPTION
With this file:

```crystal
def foo
  bar
end

def bar
  puts caller[0]
end

foo
```

Interpreting it...

Before:

```
14:3:/Users/aryborenszweig/Projects/crystal/src/exception/call_stack.cr in 'caller'
6:8:foo.cr in 'bar'
2:3:foo.cr in 'foo'
9:1:foo.cr in 'foo.cr'
```

After:

```
foo.cr:6:8 in 'bar'
foo.cr:2:3 in 'foo'
foo.cr:9:1 in 'foo.cr
```