### PR TITLE
Compiler: don't check ivar read forms a closure in exp.@x

### DIFF
--- a/spec/compiler/codegen/class_spec.cr
+++ b/spec/compiler/codegen/class_spec.cr
@@ -441,6 +441,22 @@ describe "Code gen: class" do
       )).to_i.should eq('a'.ord)
   end
 
+  it "never considers read instance var as closure (#12181)" do
+    codegen(%(
+      class Foo
+        @x = 1
+      end
+
+      def bug
+        ->{
+          Foo.new.@x
+        }
+      end
+
+      bug
+      ))
+  end
+
   it "runs with nilable instance var" do
     run("
       struct Nil

--- a/src/compiler/crystal/semantic/bindings.cr
+++ b/src/compiler/crystal/semantic/bindings.cr
@@ -687,8 +687,6 @@ module Crystal
   end
 
   class ReadInstanceVar
-    property! visitor : MainVisitor
-
     def update(from = nil)
       obj_type = obj.type?
       return unless obj_type
@@ -697,12 +695,21 @@ module Crystal
         if obj_type.is_a?(UnionType)
           obj_type.program.type_merge(
             obj_type.union_types.map do |union_type|
-              visitor.lookup_instance_var(self, union_type).type
+              lookup_instance_var(union_type).type
             end
           )
         else
-          visitor.lookup_instance_var(self, obj_type).type
+          lookup_instance_var(obj_type).type
         end
+    end
+
+    private def lookup_instance_var(type)
+      ivar = type.lookup_instance_var(self)
+      unless ivar
+        similar_name = type.lookup_similar_instance_var_name(name)
+        type.program.undefined_instance_variable(self, type, similar_name)
+      end
+      ivar
     end
   end
 

--- a/src/compiler/crystal/semantic/main_visitor.cr
+++ b/src/compiler/crystal/semantic/main_visitor.cr
@@ -649,7 +649,7 @@ module Crystal
     end
 
     private def lookup_instance_var(node)
-      lookup_instance_var(node, scope)
+      lookup_instance_var(node, @scope)
     end
 
     private def lookup_instance_var(node, scope)

--- a/src/compiler/crystal/semantic/main_visitor.cr
+++ b/src/compiler/crystal/semantic/main_visitor.cr
@@ -590,21 +590,8 @@ module Crystal
     end
 
     def undefined_instance_variable(owner, node)
-      similar_name = lookup_similar_instance_variable_name(node, owner)
+      similar_name = owner.lookup_similar_instance_var_name(node.name)
       program.undefined_instance_variable(node, owner, similar_name)
-    end
-
-    def lookup_similar_instance_variable_name(node, owner)
-      case owner
-      when NonGenericModuleType, GenericClassType, GenericModuleType
-        nil
-      else
-        Levenshtein.find(node.name) do |finder|
-          owner.all_instance_vars.each_key do |name|
-            finder.test(name)
-          end
-        end
-      end
     end
 
     def first_time_accessing_meta_type_var?(var)

--- a/src/compiler/crystal/types.cr
+++ b/src/compiler/crystal/types.cr
@@ -599,11 +599,11 @@ module Crystal
       end
     end
 
-    def lookup_instance_var(name)
+    def lookup_instance_var(name : String)
       lookup_instance_var?(name).not_nil!
     end
 
-    def lookup_instance_var?(name)
+    def lookup_instance_var?(name : String)
       superclass.try(&.lookup_instance_var?(name)) ||
         instance_vars[name]?
     end
@@ -634,6 +634,23 @@ module Crystal
             finder.test(name)
           end
         end
+      end
+    end
+
+    def lookup_instance_var(node : InstanceVar | ReadInstanceVar | MetaVar)
+      case self
+      when Program
+        node.raise "can't use instance variables at the top level"
+      when PrimitiveType
+        node.raise "can't use instance variables inside primitive types (at #{self})"
+      when EnumType
+        node.raise "can't use instance variables inside enums (at enum #{self})"
+      when .metaclass?
+        node.raise "@instance_vars are not yet allowed in metaclasses: use @@class_vars instead"
+      when InstanceVarContainer
+        lookup_instance_var?(node.name)
+      else
+        node.raise "BUG: #{self} is not an InstanceVarContainer"
       end
     end
 

--- a/src/compiler/crystal/types.cr
+++ b/src/compiler/crystal/types.cr
@@ -624,6 +624,19 @@ module Crystal
       (superclass.try(&.all_instance_vars_count) || 0) + instance_vars.size
     end
 
+    def lookup_similar_instance_var_name(ivar_name : String)
+      case self
+      when NonGenericModuleType, GenericClassType, GenericModuleType
+        nil
+      else
+        Levenshtein.find(ivar_name) do |finder|
+          self.all_instance_vars.each_key do |name|
+            finder.test(name)
+          end
+        end
+      end
+    end
+
     def add_subclass(subclass)
       raise "BUG: #{self} doesn't implement add_subclass"
     end


### PR DESCRIPTION
Fixes #12181

If you have code like this:

```crystal
class Foo
  @x = 1

  def foo
    ->{ @x }
  end
end
```

Then the proc in `foo` actually forms a closure over `self` because it's accessing `self` through an instance var.

This was also incorrectly done when you accessed an instance variable like this:

```crystal
class Other
  @y = 2
end

class Foo
  @x = 1

  def foo
    ->{ Other.new.@y } # Oops! This was saying a closure was formed over `self` (Foo)
  end
end
```

That's because the `ReadInstanceVar` AST node was reusing some logic from the previous case to access an object's instance var. Totally incorrect, just to avoid duplicating code!

Instead of duplicating code, though, I moved around some methods where they are more suited. There's a tiny bit of duplication (two lines) when an instance variable isn't found and we need to give an error, but that's it.