### PR TITLE
Mention `#value` explicitly in `Pointer` overview.

### DIFF
--- a/src/pointer.cr
+++ b/src/pointer.cr
@@ -8,7 +8,7 @@ require "c/string"
 # to implement efficient data structures. For example, both `Array` and `Hash` are
 # implemented using pointers.
 #
-# You can obtain pointers in four ways: `#new`, `#malloc`, `pointerof` and by calling a C
+# You can obtain pointers in four ways: `#new`, `#malloc`, `pointerof`, or by calling a C
 # function that returns a pointer.
 #
 # `pointerof(x)`, where *x* is a variable or an instance variable, returns a pointer to
@@ -20,6 +20,8 @@ require "c/string"
 # ptr.value = 2
 # x # => 2
 # ```
+#
+# Use `#value` to dereference the pointer.
 #
 # Note that a pointer is *falsey* if it's null (if its address is zero).
 #


### PR DESCRIPTION
This information is already in the method documentation, and is in the example code. But it would be clearer to mention it specifically.

Also a minor grammar change.