### PR TITLE
Always use `GC_set_stackbottom` on Windows

### DIFF
--- a/spec/std/concurrent/select_spec.cr
+++ b/spec/std/concurrent/select_spec.cr
@@ -191,7 +191,7 @@ describe "select" do
     x.should eq 2
   end
 
-  pending_win32 "stress select with send/receive in multiple fibers" do
+  it "stress select with send/receive in multiple fibers" do
     fibers = 4
     msg_per_sender = 1000
     ch = Array.new(fibers) { Array.new(fibers) { Channel(Int32).new } }

--- a/src/gc/boehm.cr
+++ b/src/gc/boehm.cr
@@ -91,7 +91,7 @@ lib LibGC
 
   fun push_all_eager = GC_push_all_eager(bottom : Void*, top : Void*)
 
-  {% if flag?(:preview_mt) %}
+  {% if flag?(:preview_mt) || flag?(:win32) %}
     fun get_my_stackbottom = GC_get_my_stackbottom(sb : StackBase*) : ThreadHandle
     fun set_stackbottom = GC_set_stackbottom(th : ThreadHandle, sb : StackBase*) : ThreadHandle
   {% else %}
@@ -262,7 +262,7 @@ module GC
 
   # :nodoc:
   def self.current_thread_stack_bottom
-    {% if flag?(:preview_mt) %}
+    {% if flag?(:preview_mt) || flag?(:win32) %}
       th = LibGC.get_my_stackbottom(out sb)
       {th, sb.mem_base}
     {% else %}
@@ -276,6 +276,16 @@ module GC
       sb = LibGC::StackBase.new
       sb.mem_base = stack_bottom
       LibGC.set_stackbottom(thread_handle, pointerof(sb))
+    end
+  {% elsif flag?(:win32) %}
+    # this is necessary because Boehm GC does _not_ use `GC_stackbottom` on
+    # Windows when pushing all threads' stacks; instead `GC_set_stackbottom`
+    # must be used to associate the new bottom with the running thread
+    def self.set_stackbottom(stack_bottom : Void*)
+      sb = LibGC::StackBase.new
+      sb.mem_base = stack_bottom
+      # `nil` represents the current thread (i.e. the only one)
+      LibGC.set_stackbottom(nil, pointerof(sb))
     end
   {% else %}
     def self.set_stackbottom(stack_bottom : Void*)


### PR DESCRIPTION
When the Boehm GC pushes all stacks during a collection cycle, with POSIX Threads it [uses `GC_stackbottom`](https://github.com/ivmai/bdwgc/blob/79867a5ecdb7132a63b54e880edf8b7cd40d951d/pthread_stop_world.c#L837-L848) as the bottom of the main thread's stack, but on Windows, it always uses an internal per-thread handle's [`stack_base` member](https://github.com/ivmai/bdwgc/blob/79867a5ecdb7132a63b54e880edf8b7cd40d951d/win32_threads.c#L1779). This member is [updated by `GC_set_stackbottom`](https://github.com/ivmai/bdwgc/blob/79867a5ecdb7132a63b54e880edf8b7cd40d951d/win32_threads.c#L1010-L1025). This means it is insufficient to assign directly to `LibGC.$stackbottom`, because then the GC would incorrectly collect memory reachable only from the main fiber if a different fiber is running while a collection cycle starts.

This fix gets rid of the occasional `Thread stack pointer ... out of range, pushing everything` warnings, and should also make the `select` stress test pass.