### PR TITLE
Playground: fix `modalContenDom` typo

### DIFF
--- a/src/compiler/crystal/tools/playground/public/session.js
+++ b/src/compiler/crystal/tools/playground/public/session.js
@@ -39,7 +39,7 @@ function ModalDialog(options) {
 
   this.append = function() {
     for(var i = 0; i < arguments.length; i++) {
-      this.modalContenDom.append(arguments[i]);
+      this.modalContentDom.append(arguments[i]);
     }
     return this;
   }.bind(this);


### PR DESCRIPTION
This instance of the spelling mistake was not detected by #12040 for some reason, so that PR broke the playground when something fails to build.