### PR TITLE
Interpreter: fix instance var offset of virtual struct

### DIFF
--- a/spec/compiler/interpreter/structs_spec.cr
+++ b/spec/compiler/interpreter/structs_spec.cr
@@ -237,5 +237,43 @@ describe Crystal::Repl::Interpreter do
         foo.x
       CODE
     end
+
+    it "sets multiple instance vars in virtual abstract struct call (#12187)" do
+      interpret(<<-CODE).should eq(6)
+        abstract struct Foo
+          @x = 0
+          @y = 0
+          @z = 0
+
+          def set
+            @x = 1
+            @y = 2
+            @z = 3
+          end
+
+          def x
+            @x
+          end
+
+          def y
+            @y
+          end
+
+          def z
+            @z
+          end
+        end
+
+        struct Bar < Foo
+        end
+
+        struct Baz < Foo
+        end
+
+        f = Bar.new || Baz.new
+        f.set
+        f.x + f.y + f.z
+      CODE
+    end
   end
 end

--- a/src/compiler/crystal/interpreter/context.cr
+++ b/src/compiler/crystal/interpreter/context.cr
@@ -335,7 +335,12 @@ class Crystal::Repl::Context
   def ivar_offset(type : Type, name : String) : Int32
     ivar_index = type.index_of_instance_var(name).not_nil!
 
-    if type.passed_by_value?
+    if type.is_a?(VirtualType) && type.struct? && type.abstract?
+      # If the type is a virtual abstract struct then the type
+      # is actually represented as {type_id, value} so the offset
+      # of the instance var is behind type_id, which is 8 bytes
+      @program.offset_of(type.base_type, ivar_index).to_i32 + 8
+    elsif type.passed_by_value?
       @program.offset_of(type.sizeof_type, ivar_index).to_i32
     else
       @program.instance_offset_of(type.sizeof_type, ivar_index).to_i32


### PR DESCRIPTION
Fixes #12187

This one was tricky to find! Luckily, as usual, the fix is just a couple of lines.