### PR TITLE
Fix FFI bindings for libffi >= 3.4

### DIFF
--- a/src/compiler/crystal/ffi/closure.cr
+++ b/src/compiler/crystal/ffi/closure.cr
@@ -3,7 +3,7 @@ require "./ffi"
 module Crystal::FFI
   struct Closure
     def initialize(call_interface : CallInterface, closure_fun : LibFFI::ClosureFun, user_data : Void*)
-      @closure = LibFFI.closure_alloc(sizeof(LibFFI::Closure), out @code)
+      @closure = LibFFI.closure_alloc(LibFFI::SIZEOF_CLOSURE, out @code)
       unless @closure
         raise "Error on LibFFI.closure_alloc"
       end

--- a/src/compiler/crystal/ffi/lib_ffi.cr
+++ b/src/compiler/crystal/ffi/lib_ffi.cr
@@ -121,30 +121,23 @@ module Crystal
     $ffi_type_double : Type
     $ffi_type_pointer : Type
 
-    # TODO: this is 12 for non-x
+    # We're treating ffi_closure as an opaque type because we do not need to interact
+    # with it directly and only pass a pointer around. We only need to allocate
+    # the memory, but the memory size differs based on target and ABI version (https://github.com/libffi/libffi/pull/540)
+    # We define the maximum possible size for each target and allocate that amount
+    # of memory, even if less would suffice. Overallocating a couple of bytes should
+    # not cause any issues
+    # https://github.com/crystal-lang/crystal/pull/12192#issuecomment-1173993292
+    # https://github.com/libffi/libffi/blob/ddc6764386b29449d941b2b18d000f2987a9d848/doc/libffi.texi#L815
+    type Closure = Void
 
-    {% if compare_versions(`hash pkg-config 2> /dev/null && pkg-config --modversion libffi`.chomp, "3.4.0") >= 0 %}
-      {% if flag?(:bits64) %}
-        FFI_TRAMPOLINE_SIZE = 32
-      {% else %}
-        FFI_TRAMPOLINE_SIZE = 16
-      {% end %}
+    {% if flag?(:bits64) %}
+      SIZEOF_CLOSURE = 56
     {% else %}
-      {% if flag?(:bits64) %}
-        FFI_TRAMPOLINE_SIZE = 24
-      {% else %}
-        FFI_TRAMPOLINE_SIZE = 12
-      {% end %}
+      SIZEOF_CLOSURE = 40
     {% end %}
 
     alias ClosureFun = Cif*, Void*, Void**, Void* -> Void
-
-    struct Closure
-      tramp : LibC::Char[FFI_TRAMPOLINE_SIZE]
-      cif : Cif*
-      fun : ClosureFun
-      user_data : Void*
-    end
 
     fun prep_cif = ffi_prep_cif(
       cif : Cif*,

--- a/src/compiler/crystal/ffi/lib_ffi.cr
+++ b/src/compiler/crystal/ffi/lib_ffi.cr
@@ -123,10 +123,18 @@ module Crystal
 
     # TODO: this is 12 for non-x
 
-    {% if flag?(:bits64) %}
-      FFI_TRAMPOLINE_SIZE = 24
+    {% if compare_versions(`hash pkg-config 2> /dev/null && pkg-config --modversion libffi`.chomp, "3.4.0") >= 0 %}
+      {% if flag?(:bits64) %}
+        FFI_TRAMPOLINE_SIZE = 32
+      {% else %}
+        FFI_TRAMPOLINE_SIZE = 16
+      {% end %}
     {% else %}
-      FFI_TRAMPOLINE_SIZE = 12
+      {% if flag?(:bits64) %}
+        FFI_TRAMPOLINE_SIZE = 24
+      {% else %}
+        FFI_TRAMPOLINE_SIZE = 12
+      {% end %}
     {% end %}
 
     alias ClosureFun = Cif*, Void*, Void**, Void* -> Void


### PR DESCRIPTION
Resolves #11802

https://github.com/libffi/libffi/pull/540 changed the memory layout of `ffi_closure` (`LibFFI::Closure`) between libffi 3.3 and 3.4 (which equates to libffi7 and libffi8 packages).
When linking against libffi 3.4 the constant `FFI_TRAMPOLINE_SIZE` is 32 instead of 24 (16 instead of 12 on 32-bit).