### PR TITLE
Interpreter: allow some options, and colorize whereami

### DIFF
--- a/src/compiler/crystal/command/repl.cr
+++ b/src/compiler/crystal/command/repl.cr
@@ -6,6 +6,29 @@ class Crystal::Command
   private def repl
     repl = Repl.new
 
+    option_parser = parse_with_crystal_opts do |opts|
+      opts.banner = "Usage: crystal i [options] [programfile] [arguments]\n\nOptions:"
+
+      opts.on("-D FLAG", "--define FLAG", "Define a compile-time flag") do |flag|
+        repl.program.flags << flag
+      end
+
+      opts.on("--error-trace", "Show full error trace") do
+        repl.program.show_error_trace = true
+        @error_trace = true
+      end
+
+      opts.on("-h", "--help", "Show this message") do
+        puts opts
+        exit
+      end
+
+      opts.on("--no-color", "Disable colored output") do
+        @color = false
+        repl.program.color = false
+      end
+    end
+
     if options.empty?
       repl.run
     else

--- a/src/compiler/crystal/interpreter/interpreter.cr
+++ b/src/compiler/crystal/interpreter/interpreter.cr
@@ -1,6 +1,7 @@
 require "./repl"
 require "../ffi"
 require "colorize"
+require "../../../crystal/syntax_highlighter/colorize"
 
 # The ones that understands Crystal bytecode.
 class Crystal::Repl::Interpreter
@@ -1278,17 +1279,34 @@ class Crystal::Repl::Interpreter
 
     puts
 
-    lines =
+    source =
       case filename
       in String
-        File.read_lines(filename)
+        File.read(filename)
       in VirtualFile
-        filename.source.lines.to_a
+        filename.source
       in Nil
         nil
       end
 
-    return unless lines
+    return unless source
+
+    if @context.program.color?
+      begin
+        # We highlight the entire file. We could try highlighting each
+        # individual line but that won't work well for heredocs and other
+        # constructs. Also, highlighting is pretty fast so it won't be noticeable.
+        #
+        # TODO: in reality if the heredoc starts way before the lines we show,
+        # we lose the command that flips the color on. We should probably do
+        # something better here, but for now this is good enough.
+        source = Crystal::SyntaxHighlighter::Colorize.highlight(source)
+      rescue
+        # Ignore highlight errors
+      end
+    end
+
+    lines = source.lines
 
     min_line_number = {location.line_number - 5, 1}.max
     max_line_number = {location.line_number + 5, lines.size}.min


### PR DESCRIPTION
This PR allows passing the following options to the interpreter:
- `-D FLAG`
- `--error-trace`
- `-h`
- `--no-color`
