### PR TITLE
Add missing `EXPORT` in interpreter spec

### DIFF
--- a/spec/compiler/data/interpreter/sum.c
+++ b/spec/compiler/data/interpreter/sum.c
@@ -27,6 +27,6 @@ EXPORT long sum_int(int count, ...) {
   return total;
 }
 
-int simple_sum_int(int a, int b) {
+EXPORT int simple_sum_int(int a, int b) {
   return a + b;
 }


### PR DESCRIPTION
This broke the `test_interpreter` CI jobs since #12140.