### PR TITLE
Interpreter: fix `.class` for modules and unions

### DIFF
--- a/spec/compiler/interpreter/types_spec.cr
+++ b/spec/compiler/interpreter/types_spec.cr
@@ -49,6 +49,35 @@ describe Crystal::Repl::Interpreter do
         CODE
     end
 
+    it "interprets class for module type (#12203)" do
+      interpret(<<-CODE).should eq("A")
+        class Class
+          def name : String
+            {{ @type.name.stringify }}
+          end
+        end
+
+        module M
+        end
+
+        class E
+          def initialize(@base : M)
+          end
+        end
+
+        abstract class P
+          include M
+        end
+
+        class A < P
+        end
+
+        e = E.new(A.new)
+        base = e.@base
+        base.class.name
+        CODE
+    end
+
     it "interprets crystal_type_id for nil" do
       interpret("nil.crystal_type_id").should eq(0)
     end

--- a/src/compiler/crystal/interpreter/instructions.cr
+++ b/src/compiler/crystal/interpreter/instructions.cr
@@ -1248,11 +1248,11 @@ require "./repl"
         end,
       },
       put_metaclass: {
-        operands:   [size : Int32, struct_type : Bool],
+        operands:   [size : Int32, union_type : Bool],
         push:       true,
         code:       begin
           type_id =
-            if struct_type
+            if union_type
               (stack - size).as(Int32*).value
             else
               (stack - size).as(Void**).value.as(Int32*).value

--- a/src/compiler/crystal/interpreter/primitives.cr
+++ b/src/compiler/crystal/interpreter/primitives.cr
@@ -82,13 +82,19 @@ class Crystal::Repl::Compiler
       pointer_add(inner_sizeof_type(obj.not_nil!.type.as(PointerInstanceType).element_type), node: node)
     when "class"
       obj = obj.not_nil!
-      type = obj.type
+      type = obj.type.remove_indirection
 
-      if type.is_a?(VirtualType)
+      case type
+      when VirtualType
         obj.accept self
         return unless @wants_value
 
-        put_metaclass aligned_sizeof_type(type), type.struct?, node: node
+        put_metaclass aligned_sizeof_type(type), false, node: node
+      when UnionType
+        obj.accept self
+        return unless @wants_value
+
+        put_metaclass aligned_sizeof_type(type), true, node: node
       else
         discard_value obj
         return unless @wants_value


### PR DESCRIPTION
Fixes #12203