### PR TITLE
Basic GDB formatter support

### DIFF
--- a/etc/gdb/crystal_formatters.py
+++ b/etc/gdb/crystal_formatters.py
@@ -1,0 +1,65 @@
+import gdb
+
+class CrystalStringPrinter:
+    def __init__(self, val):
+        self.val = val
+
+    def to_string(self):
+        bytesize = self.val['bytesize']
+        buf = gdb.selected_inferior().read_memory(self.val['c'].address, bytesize)
+        return buf.tobytes().decode('utf-8', errors='backslashreplace')
+
+    def display_hint(self):
+        return 'string'
+
+class CrystalArrayPrinter:
+    def __init__(self, val):
+        self.val = val
+
+    def to_string(self):
+        type = self.val.type
+        if type.code == gdb.TYPE_CODE_PTR:
+            type = type.target()
+        return str(type)
+
+    def children(self):
+        for i in range(int(self.val['size'])):
+            yield str(i), (self.val['buffer'] + i).dereference()
+
+    def display_hint(self):
+        return 'array'
+
+class CrystalReferenceSubPrinter:
+    def __init__(self, name, cls):
+        self.name = name
+        self.enabled = True
+        self.cls = cls
+
+    def recognize(self, val):
+        type = val.type
+        if type.code == gdb.TYPE_CODE_PTR:
+            type = type.target()
+        typename = type.name
+        if typename is not None:
+            if typename == self.name:
+                return self.cls(val)
+            if typename.startswith(self.name) and typename[len(self.name)] == '(':
+                return self.cls(val)
+
+class CrystalPrettyPrinter(gdb.printing.PrettyPrinter):
+    def __init__(self):
+        super(CrystalPrettyPrinter, self).__init__("CrystalStdlib", [])
+        self.subprinters.append(CrystalReferenceSubPrinter("String", CrystalStringPrinter))
+        self.subprinters.append(CrystalReferenceSubPrinter("Array", CrystalArrayPrinter))
+
+    def __call__(self, val):
+        for subprinter in self.subprinters:
+            if subprinter.enabled:
+                instance = subprinter.recognize(val)
+                if instance is not None:
+                    return instance
+
+gdb.printing.register_pretty_printer(
+    gdb.current_objfile(),
+    CrystalPrettyPrinter(),
+    replace=True)

--- a/spec/debug/arrays.cr
+++ b/spec/debug/arrays.cr
@@ -1,0 +1,15 @@
+a = [0, 1, 4, 9, 16, 25]
+# print: *a
+# lldb-check: (Array(Int32)) $0 = ([0] = 0, [1] = 1, [2] = 4, [3] = 9, [4] = 16, [5] = 25)
+# gdb-check: $1 = Array(Int32) = {0, 1, 4, 9, 16, 25}
+debugger
+a << 36
+# print: *a
+# lldb-check: (Array(Int32)) $1 = ([0] = 0, [1] = 1, [2] = 4, [3] = 9, [4] = 16, [5] = 25, [6] = 36)
+# gdb-check: $2 = Array(Int32) = {0, 1, 4, 9, 16, 25, 36}
+debugger
+a.unshift 49
+# print: *a
+# lldb-check: (Array(Int32)) $2 = ([0] = 49, [1] = 0, [2] = 1, [3] = 4, [4] = 9, [5] = 16, [6] = 25, [7] = 36)
+# gdb-check: $3 = Array(Int32) = {49, 0, 1, 4, 9, 16, 25, 36}
+debugger

--- a/spec/debug/blocks.cr
+++ b/spec/debug/blocks.cr
@@ -1,8 +1,10 @@
 ["hello world"].each do |v|
   a = v
-  # lldb-command: print a
+  # print: a
   # lldb-check: (String *) $0 = {{0x[0-9a-f]+}} "hello world"
-  # lldb-command: print v
+  # gdb-check: $1 = "hello world"
+  # print: v
   # lldb-check: (String *) $1 = {{0x[0-9a-f]+}} "hello world"
+  # gdb-check: $2 = "hello world"
   debugger
 end

--- a/spec/debug/strings.cr
+++ b/spec/debug/strings.cr
@@ -1,4 +1,9 @@
 a = "hello world"
-# lldb-command: print a
+b = "abcσdeσf"
+# print: a
 # lldb-check: (String *) $0 = {{0x[0-9a-f]+}} "hello world"
+# gdb-check: $1 = "hello world"
+# print: b
+# lldb-check: (String *) $1 = {{0x[0-9a-f]+}} "abcσdeσf"
+# gdb-check: $2 = "abcσdeσf"
 debugger

--- a/spec/debug/test.sh
+++ b/spec/debug/test.sh
@@ -2,23 +2,30 @@
 
 # This file can be executed from the root of the working copy
 #
-# $ ./spec/debug/test.sh
+# $ ./spec/debug/test.sh [lldb|gdb]
+#
+# The argument selects one of the debuggers, defaulting to LLDB.
 #
 # It will use the ./spec/debug/driver.cr program to execute
 # the files explicitly listed at the end of this file.
 #
-# Those files have magic comments to build a script for an lldb session
+# Those files have magic comments to build a script for a debugger session
 # and a FileCheck file with assertions over that session.
-#
-# In ./tmp/debug you can find a dump of the session and the assertion file.
 #
 # The magic comments interpreted by the driver are:
 #
-#   * # lldb-command:
-#   * # lldb-check:
+# * `# print: expr`
+#   Prints the given expression in the debugger, e.g. a variable.
+# * `# check: pattern`
+#   Asserts that the debugger output matches the given FileCheck pattern.
+# * `# xxx-check: pattern`
+#   Like above, but only effective if `xxx` matches the debugger name. Has no
+#   effect for the other debuggers.
 #
 # These comments should then be followed by a call to `debugger` which sets up
 # the actual breakpoint.
+#
+# In ./tmp/debug you can find a dump of the session and the assertion file.
 
 set -euo pipefail
 
@@ -27,10 +34,12 @@ SCRIPT_ROOT="$(dirname "$SCRIPT_PATH")"
 
 BUILD_DIR=$SCRIPT_ROOT/../../.build
 crystal=${CRYSTAL_SPEC_COMPILER_BIN:-$SCRIPT_ROOT/../../bin/crystal}
+debugger=${1:-lldb}
 driver=$BUILD_DIR/debug_driver
 mkdir -p $BUILD_DIR
 "$crystal" build $SCRIPT_ROOT/driver.cr -o $driver
 
-$driver $SCRIPT_ROOT/top_level.cr
-$driver $SCRIPT_ROOT/strings.cr
-$driver $SCRIPT_ROOT/blocks.cr
+$driver $SCRIPT_ROOT/top_level.cr $debugger
+$driver $SCRIPT_ROOT/strings.cr $debugger
+$driver $SCRIPT_ROOT/arrays.cr $debugger
+$driver $SCRIPT_ROOT/blocks.cr $debugger

--- a/spec/debug/top_level.cr
+++ b/spec/debug/top_level.cr
@@ -1,7 +1,9 @@
-# lldb-command: print a
+# print: a
 # lldb-check: (int) $0 = 0
+# gdb-check: $1 = 0
 debugger
 a = 42
-# lldb-command: print a
+# print: a
 # lldb-check: (int) $1 = 42
+# gdb-check: $2 = 42
 debugger


### PR DESCRIPTION
This PR adds `String` and `Array` formatters for GDB, allowing it to be used as an alternative to LLDB. The formatters can be imported into a GDB session by `source etc/gdb/crystal_formatters.py`.

The spec driver has been almost completely rewritten to support testing multiple debuggers from a single spec file. Those specs are meant to support the Crystal interpreter eventually.