### PR TITLE
Interpreter: handle escaping exceptions in pry

### DIFF
--- a/src/compiler/crystal/interpreter/interpreter.cr
+++ b/src/compiler/crystal/interpreter/interpreter.cr
@@ -1267,6 +1267,9 @@ class Crystal::Repl::Interpreter
 
         value = interpreter.interpret(line_node, meta_vars)
         puts value.to_s
+      rescue ex : EscapingException
+        print "Unhandled exception: "
+        print ex
       rescue ex : Crystal::CodeError
         ex.color = true
         ex.error_trace = true


### PR DESCRIPTION
Fixes #12210

Before:

```
✗ crystal i foo.cr
From: foo.cr:6:6 <Program>#foo.cr:

    1: def foo
    2:   raise "OH NO!"
    3: end
    4:
    5: debugger
 => 6: puts "Hello world!"

pry> foo
 (Crystal::Repl::EscapingException)
  from /opt/homebrew/Cellar/crystal/1.4.1_2/libexec/crystal in 'raise<Crystal::Repl::EscapingException>:NoReturn'
  from /opt/homebrew/Cellar/crystal/1.4.1_2/libexec/crystal in 'Crystal::Repl::Interpreter#interpret<Crystal::ASTNode+, Crystal::Type+>:Crystal::Repl::Value'
  from /opt/homebrew/Cellar/crystal/1.4.1_2/libexec/crystal in 'Crystal::Repl::Interpreter#pry<Pointer(UInt8), Crystal::Repl::CompiledInstructions, Pointer(UInt8), Pointer(UInt8)>:(Pointer(UInt8) | Nil)'
  from /opt/homebrew/Cellar/crystal/1.4.1_2/libexec/crystal in 'Crystal::Repl::Interpreter#interpret<Crystal::ASTNode+, Crystal::Type+>:Crystal::Repl::Value'
  from /opt/homebrew/Cellar/crystal/1.4.1_2/libexec/crystal in 'Crystal::Repl#interpret_and_exit_on_error<Crystal::Expressions>:Crystal::Repl::Value'
  from /opt/homebrew/Cellar/crystal/1.4.1_2/libexec/crystal in 'Crystal::Command#repl:(Crystal::Repl::Value | Nil)'
  from /opt/homebrew/Cellar/crystal/1.4.1_2/libexec/crystal in '__crystal_main'
  from /opt/homebrew/Cellar/crystal/1.4.1_2/libexec/crystal in 'main'
```

After:

```
$ bin/crystal i foo.cr
Using compiled compiler at .build/crystal
From: foo.cr:6:6 <Program>#foo.cr:

    1: def foo
    2:   raise "OH NO!"
    3: end
    4:
    5: debugger
 => 6: puts "Hello world!"

pry> foo
Unhandled exception: OH NO! (Exception)
  from foo.cr:2:3 in 'foo'
  from :1:1 in 'foo.cr'
```
