### PR TITLE
Add Visual Studio formatters for `String`, `Array`, and `Hash`

### DIFF
--- a/etc/msvc/crystal.natvis
+++ b/etc/msvc/crystal.natvis
@@ -23,7 +23,7 @@
             <CustomListItems MaxItemsPerView="5000">
                 <Variable Name="i" InitialValue="first"/>
                 <Loop>
-                    <Break Condition="i >= size + deleted_count"/>
+                    <Break Condition="i &gt;= size + deleted_count"/>
                     <If Condition="entries[i].hash != 0">
                         <Item>entries[i]</Item>
                     </If>

--- a/etc/msvc/crystal.natvis
+++ b/etc/msvc/crystal.natvis
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="utf-8"?>
+<AutoVisualizer xmlns="http://schemas.microsoft.com/vstudio/debugger/natvis/2010">
+    <Type Name="String">
+        <DisplayString>{&amp;c,[bytesize]s8}</DisplayString>
+        <StringView>&amp;c,[bytesize]s8</StringView>
+    </Type>
+
+    <Type Name="Array(*)">
+        <DisplayString>{{ size={size} }}</DisplayString>
+        <Expand>
+            <Item Name="[root_buffer]">buffer - offset_to_buffer</Item>
+            <Item Name="[remaining_capacity]">capacity - offset_to_buffer</Item>
+            <ArrayItems>
+                <Size>size</Size>
+                <ValuePointer>buffer</ValuePointer>
+            </ArrayItems>
+        </Expand>
+    </Type>
+
+    <Type Name="Hash(*,*)">
+        <DisplayString>{{ size={size} }}</DisplayString>
+        <Expand>
+            <CustomListItems MaxItemsPerView="5000">
+                <Variable Name="i" InitialValue="first"/>
+                <Loop>
+                    <Break Condition="i >= size + deleted_count"/>
+                    <If Condition="entries[i].hash != 0">
+                        <Item>entries[i]</Item>
+                    </If>
+                    <Exec>i += 1</Exec>
+                </Loop>
+            </CustomListItems>
+        </Expand>
+    </Type>
+</AutoVisualizer>


### PR DESCRIPTION
This patch provides Natvis formatter definitions for `String`, `Array`, and `Hash`:

![image](https://user-images.githubusercontent.com/1361918/177602770-717eb75e-ee73-4cf0-bc85-43070fa3a7ca.png)

Without the formatters:

![image](https://user-images.githubusercontent.com/1361918/177603116-6353d0c9-2274-4866-827e-64da833e0c84.png)

System-wide Natvis files are only suitable for languages supported by Visual Studio itself, and Crystal isn't one of them, so the best way to use the formatters is by embedding them directly into the PDB file during a debug build:

```
> crystal build main.cr --debug --link-flags=/NATVIS:...\etc\msvc\crystal.natvis
```

The path to `crystal.natvis` **must** be an absolute path, because linking takes place inside the cache directory, not from the current working directory.

Perhaps eventually the compiler itself could be responsible for emitting the Natvis file itself? Related: #12112
