### PR TITLE
Enable `Mutex` on Windows

### DIFF
--- a/spec/win32_std_spec.cr
+++ b/spec/win32_std_spec.cr
@@ -152,7 +152,7 @@ require "./std/mime/multipart/builder_spec.cr"
 require "./std/mime/multipart/parser_spec.cr"
 require "./std/mime/multipart_spec.cr"
 require "./std/mime_spec.cr"
-# require "./std/mutex_spec.cr" (failed codegen)
+require "./std/mutex_spec.cr"
 require "./std/named_tuple_spec.cr"
 require "./std/number_spec.cr"
 require "./std/oauth/access_token_spec.cr"

--- a/src/crystal/system/win32/process.cr
+++ b/src/crystal/system/win32/process.cr
@@ -1,5 +1,6 @@
 require "c/processthreadsapi"
 require "c/handleapi"
+require "c/synchapi"
 require "process/shell"
 
 struct Crystal::System::Process

--- a/src/prelude.cr
+++ b/src/prelude.cr
@@ -55,9 +55,7 @@ require "intrinsics"
 require "io"
 require "kernel"
 require "math/math"
-{% unless flag?(:win32) %}
-  require "mutex"
-{% end %}
+require "mutex"
 require "named_tuple"
 require "nil"
 require "humanize"

--- a/src/windows_stubs.cr
+++ b/src/windows_stubs.cr
@@ -1,31 +1,3 @@
-require "c/synchapi"
-
-class Mutex
-  enum Protection
-    Checked
-    Reentrant
-    Unchecked
-  end
-
-  def initialize(@protection : Protection = :checked)
-  end
-
-  def lock
-  end
-
-  def unlock
-  end
-
-  def synchronize
-    lock
-    begin
-      yield
-    ensure
-      unlock
-    end
-  end
-end
-
 enum Signal
   KILL = 0
 end


### PR DESCRIPTION
This enables the fiber-safe `Mutex` on Windows and removes the stub implementation. It is mostly unrelated to [`Thread::Mutex`](https://github.com/crystal-lang/crystal/pull/11647).

The standard library uses `Mutex` in `Log::SyncDispatcher`; it does not seem to break. (On the other hand, the specs for `Log::AsyncDispatcher` require non-blocking pipes, which are not available yet.)

Related: #5430