### PR TITLE
Don't exit in interpreter spec & Change type from nil to NoReturn in FixMissingTypes

### DIFF
--- a/spec/compiler/interpreter/responds_to_spec.cr
+++ b/spec/compiler/interpreter/responds_to_spec.cr
@@ -42,14 +42,10 @@ describe Crystal::Repl::Interpreter do
     end
 
     it "doesn't crash if def body ends up with no type (#12219)" do
-      interpret(<<-CODE)
-        lib LibC
-          fun exit(Int32) : NoReturn
-        end
-
+      interpret(<<-CODE, prelude: "prelude").should eq("1")
         class Base
           def foo
-            LibC.exit(0)
+            raise "OH NO"
           end
         end
 
@@ -67,7 +63,12 @@ describe Crystal::Repl::Interpreter do
           include Moo
         end
 
-        Child.new.foo
+        begin
+          Child.new.foo
+          0
+        rescue
+          1
+        end
         CODE
     end
   end

--- a/src/compiler/crystal/interpreter/compiler.cr
+++ b/src/compiler/crystal/interpreter/compiler.cr
@@ -214,17 +214,6 @@ class Crystal::Repl::Compiler < Crystal::Visitor
       move_arg_to_closure_if_closured(node, node.block_arg.not_nil!.name)
     end
 
-    # Compiled Crystal supports a def's body being nil:
-    # it treats it as NoReturn. Here we do the same thing.
-    # In reality we should fix the compiler to avoid having
-    # nil in types, but that's a larger change and we can do
-    # it later. For now we just handle this specific case in
-    # the interpreter.
-    body_type = node.body.type?
-    unless body_type
-      node.body.type = @context.program.no_return
-    end
-
     node.body.accept self
 
     final_type = node.type

--- a/src/compiler/crystal/semantic/fix_missing_types.cr
+++ b/src/compiler/crystal/semantic/fix_missing_types.cr
@@ -63,6 +63,11 @@ class Crystal::FixMissingTypes < Crystal::Visitor
     false
   end
 
+  def visit(node : If)
+    node.type = @program.no_return unless node.type?
+    true
+  end
+
   def end_visit(node : Call)
     if expanded = node.expanded
       expanded.accept self
@@ -77,6 +82,7 @@ class Crystal::FixMissingTypes < Crystal::Visitor
     node.target_defs.try &.each do |target_def|
       if @fixed.add?(target_def)
         target_def.type = @program.no_return unless target_def.type?
+        target_def.body.type = @program.no_return unless target_def.body.type?
         target_def.accept_children self
       end
     end


### PR DESCRIPTION
I realized there was a `LibC.exit` in one of the specs I recently introduced, and that makes the program exit with 0. I changed that to a `raise` which is equivalent for the spec but doesn't exit the program.

Also, now that we have more time until 1.6.0 I decided to move one of the logics that's spread in compiled mode and interpreted mode to an earlier stage so that information is there in both stages when needed.