### PR TITLE
Indent playground code using spaces

### DIFF
--- a/src/compiler/crystal/tools/playground/public/session.js
+++ b/src/compiler/crystal/tools/playground/public/session.js
@@ -294,7 +294,22 @@ Playground.Session = function(options) {
     tabSize: 2,
     viewportMargin: Infinity,
     dragDrop: false, // dragDrop functionality is implemented to capture drop anywhere and replace source
-    value: options.source
+    value: options.source,
+    // indent using spaces, see https://github.com/codemirror/codemirror5/issues/988
+    extraKeys: {
+      Tab: (cm) => {
+        if (cm.getMode().name === 'null') {
+          cm.execCommand('insertTab');
+        } else {
+          if (cm.somethingSelected()) {
+            cm.execCommand('indentMore');
+          } else {
+            cm.execCommand('insertSoftTab');
+          }
+        }
+      },
+      'Shift-Tab': (cm) => cm.execCommand('indentLess')
+    }
   });
   this.editor._playgroundSession = this;
 


### PR DESCRIPTION
Update CodeMirror options as suggested by
https://github.com/codemirror/codemirror5/issues/988#issuecomment-549644684
in order to indent code using spaces instead of tabs.

Tested by running playground (`./bin/crystal play`) and updating some
code:

https://user-images.githubusercontent.com/153842/178105140-4aad0486-a937-4686-8904-5e9c0a87145b.mov

Fixes #10213 