### PR TITLE
Interpreter: let local vars be seen by macros in repl and pry

### DIFF
--- a/src/compiler/crystal/interpreter/interpreter.cr
+++ b/src/compiler/crystal/interpreter/interpreter.cr
@@ -1263,8 +1263,21 @@ class Crystal::Repl::Interpreter
         )
         line_node = parser.parse
 
+        vars_size_before_semantic = main_visitor.vars.size
+
         line_node = @context.program.normalize(line_node)
         line_node = @context.program.semantic(line_node, main_visitor: main_visitor)
+
+        vars_size_after_semantic = main_visitor.vars.size
+        if vars_size_after_semantic > vars_size_before_semantic
+          # These are all temporary variables created by MainVisitor.
+          # Let's add them to local vars.
+          main_visitor.vars.each_with_index do |(name, var), index|
+            next unless index >= vars_size_before_semantic
+
+            interpreter.local_vars.declare(name, var.type)
+          end
+        end
 
         value = interpreter.interpret(line_node, meta_vars)
         puts value.to_s

--- a/src/compiler/crystal/semantic.cr
+++ b/src/compiler/crystal/semantic.cr
@@ -19,7 +19,7 @@ class Crystal::Program
   # that's typed. In the process types and methods are defined in
   # this program.
   def semantic(node : ASTNode, cleanup = true, main_visitor : MainVisitor = MainVisitor.new(self)) : ASTNode
-    node, processor = top_level_semantic(node)
+    node, processor = top_level_semantic(node, main_visitor)
 
     @progress_tracker.stage("Semantic (ivars initializers)") do
       visitor = InstanceVarsInitializerVisitor.new(self)
@@ -56,9 +56,16 @@ class Crystal::Program
   #
   # This alone is useful for some tools like doc or hierarchy
   # where a full semantic of the program is not needed.
-  def top_level_semantic(node)
+  def top_level_semantic(node, main_visitor : MainVisitor = MainVisitor.new(self))
     new_expansions = @progress_tracker.stage("Semantic (top level)") do
       visitor = TopLevelVisitor.new(self)
+
+      # This is mainly for the interpreter so that vars are populated
+      # for macro calls.
+      # For compiled Crystal this should have no effect because we always
+      # use a new MainVisitor which will have no vars.
+      visitor.vars = main_visitor.vars.dup unless main_visitor.vars.empty?
+
       node.accept visitor
       visitor.process_finished_hooks
       visitor.new_expansions

--- a/src/compiler/crystal/semantic/semantic_visitor.cr
+++ b/src/compiler/crystal/semantic/semantic_visitor.cr
@@ -12,6 +12,8 @@ abstract class Crystal::SemanticVisitor < Crystal::Visitor
   property! scope : Type
   setter scope
 
+  property vars : MetaVars
+
   @path_lookup : Type?
   @untyped_def : Def?
   @typed_def : Def?


### PR DESCRIPTION
Fixes #12233

No tests for this because there are no tests for the interactive part, nor for pry.

But you can try this:

```
$ bin/crystal i
Using compiled compiler at .build/crystal
icr:1:0> test = 1
=> 1
icr:2:0> p! test
test # => 1
=> 1
```

And with a file `foo.cr`:

```crystal
test = 1
debugger
test = 2
```

```
$ bin/crystal i foo.cr
Using compiled compiler at .build/crystal
From: foo.cr:3:8 <Program>#foo.cr:

    1: test = 1
    2: debugger
 => 3: test = 2

pry> p! test
test # => 1
1
```