### PR TITLE
Add user-space IO.pipe

### DIFF
--- a/spec/std/file_spec.cr
+++ b/spec/std/file_spec.cr
@@ -462,7 +462,7 @@ describe "File" do
     end
 
     it "gets for pipe" do
-      IO.pipe do |r, w|
+      IO::FileDescriptor.pipe do |r, w|
         r.info.type.should eq(File::Type::Pipe)
         w.info.type.should eq(File::Type::Pipe)
       end

--- a/spec/std/io/pipe_spec.cr
+++ b/spec/std/io/pipe_spec.cr
@@ -1,0 +1,75 @@
+require "spec"
+
+describe IO::Pipe do
+  it "allows reading and writing" do
+    pipe = IO::Pipe.new
+    pipe << "Hello"
+    pipe.gets.should eq "Hello"
+  end
+
+  it "allows reading and writing more than the buffer size" do
+    pipe = IO::Pipe.new(initial_capacity: 5)
+    pipe << "Hello World"
+    pipe.gets.should eq "Hello World"
+
+    pipe << "omg it's happening"
+    pipe.gets.should eq "omg it's happening"
+  end
+
+  # Is this a good idea? I'm considering making this thing elastic to avoid
+  # leaving it huge after a giant write, but the tradeoff is that a lot of
+  # reads and writes could end up thrashing the heap with reallocs.
+  pending "shrinks back down when reading" do
+    pipe = IO::Pipe.new(initial_capacity: 5)
+    pipe << "Hello World"
+    pipe.skip_to_end
+    pipe << "omg it's happening"
+    pipe.read_string "omg it's happening".bytesize - 1
+
+    pipe.capacity.should eq 5
+  end
+
+  it "can do real-world things" do
+    pipe = IO::Pipe.new(initial_capacity: 4)
+    {
+      foo:       "bar",
+      computers: %w[what even is a computer],
+      omg:       {
+        lol: {wtf: "bbq"},
+      },
+    }.to_json pipe
+    pipe << "\n"
+    JSON.parse IO::Delimited.new(pipe, "\n")
+    {
+      foo:       "bar",
+      computers: %w[what even is a computer],
+      omg:       {
+        lol: {wtf: "bbq"},
+      },
+    }.to_json pipe
+    JSON.parse IO::Delimited.new(pipe, "\n")
+  end
+
+  it "can split into separate reader and writer" do
+    pipe = IO::Pipe.new(initial_capacity: 5)
+    read, write = pipe
+    write << "this is a message i am writing"
+    read.gets.should eq "this is a message i am writing"
+  end
+
+  it "closes the read pipe when closing writes" do
+    pipe = IO::Pipe.new(initial_capacity: 5)
+    read, write = pipe
+
+    write.puts "omg"
+    write.puts "lol"
+    write.puts "i am writing more things"
+    read.gets.should eq "omg"
+    read.gets.should eq "lol"
+    read.gets.should eq "i am writing more things"
+
+    # spawn write.close
+
+    read.gets.should eq nil
+  end
+end

--- a/src/crystal/system/unix/file_descriptor.cr
+++ b/src/crystal/system/unix/file_descriptor.cr
@@ -140,7 +140,7 @@ module Crystal::System::FileDescriptor
     end
   end
 
-  def self.pipe(read_blocking, write_blocking)
+  def self.pipe(read_blocking, write_blocking) : {IO::FileDescriptor, IO::FileDescriptor}
     pipe_fds = uninitialized StaticArray(LibC::Int, 2)
     if LibC.pipe(pipe_fds) != 0
       raise IO::Error.from_errno("Could not create pipe")

--- a/src/crystal/system/unix/process.cr
+++ b/src/crystal/system/unix/process.cr
@@ -117,7 +117,7 @@ struct Crystal::System::Process
   end
 
   def self.spawn(command_args, env, clear_env, input, output, error, chdir)
-    reader_pipe, writer_pipe = IO.pipe
+    reader_pipe, writer_pipe = IO::FileDescriptor.pipe
 
     pid = self.fork(will_exec: true)
     if !pid

--- a/src/io.cr
+++ b/src/io.cr
@@ -134,8 +134,9 @@ abstract class IO
   # reader.gets # => "hello"
   # reader.gets # => "world"
   # ```
-  def self.pipe(read_blocking = false, write_blocking = false) : {IO::FileDescriptor, IO::FileDescriptor}
-    Crystal::System::FileDescriptor.pipe(read_blocking, write_blocking)
+  def self.pipe(read_blocking = false, write_blocking = false) : {IO, IO}
+    pipe = Pipe.new(read_blocking: read_blocking, write_blocking: write_blocking)
+    {pipe.reader, pipe.writer}
   end
 
   # Creates a pair of pipe endpoints (connected to each other) and passes them

--- a/src/io/file_descriptor.cr
+++ b/src/io/file_descriptor.cr
@@ -30,6 +30,21 @@ class IO::FileDescriptor < IO
     end
   end
 
+  def self.pipe(read_blocking = false, write_blocking = false) : {IO::FileDescriptor, IO::FileDescriptor}
+    Crystal::System::FileDescriptor.pipe(read_blocking, write_blocking)
+  end
+
+  def self.pipe(read_blocking = false, write_blocking = false)
+    read, write = pipe(read_blocking, write_blocking)
+    begin
+      yield read, write
+    ensure
+      write.flush
+      read.close
+      write.close
+    end
+  end
+
   # :nodoc:
   def self.from_stdio(fd) : self
     Crystal::System::FileDescriptor.from_stdio(fd)

--- a/src/io/pipe.cr
+++ b/src/io/pipe.cr
@@ -1,0 +1,81 @@
+require "deque"
+
+class IO::Pipe < IO
+  getter reader, writer
+
+  def initialize(@read_blocking = false, @write_blocking = false, initial_capacity : Int32 = 8192)
+    @buffer = Deque(UInt8).new(initial_capacity: initial_capacity)
+    # TODO: Mutex for atomic reads/writes?
+
+    @reader = uninitialized Reader
+    @writer = uninitialized Writer
+
+    @reader = Reader.new(self)
+    @writer = Writer.new(self)
+  end
+
+  def read(slice : Bytes)
+    count = 0
+    index = 0
+
+    while index < slice.size
+      # TODO: Implement read blocking
+      if byte = @buffer.shift?
+        slice[index] = byte
+        count = (index += 1)
+      else
+        break
+      end
+    end
+    count
+  end
+
+  def write(slice : Bytes) : Nil
+    # TODO: Implement write blocking
+    slice.each do |byte|
+      @buffer << byte
+    end
+  end
+
+  def peek
+    # TODO: Figure out what `closed?` even means here
+    return if closed?
+
+    bytes = Bytes.new(@buffer.size)
+    @buffer.each_with_index do |byte, index|
+      bytes[index] = byte
+    end
+
+    bytes
+  end
+
+  def [](index : Int)
+    {@reader, @writer}[index]
+  end
+
+  class Reader < IO
+    def initialize(@pipe : Pipe)
+    end
+
+    def read(slice : Bytes)
+      @pipe.read slice
+    end
+
+    def write(slice : Bytes) : Nil
+      raise Error.new("Can't write to an IO::Pipe::Reader")
+    end
+  end
+
+  class Writer < IO
+    def initialize(@pipe : Pipe)
+    end
+
+    def read(slice : Bytes)
+      raise Error.new("Can't read from an IO::Pipe::Writer")
+    end
+
+    def write(slice : Bytes) : Nil
+      @pipe.write slice
+    end
+  end
+end

--- a/src/process.cr
+++ b/src/process.cr
@@ -244,13 +244,13 @@ class Process
       stdio
     when IO
       if dst_io == STDIN
-        fork_io, process_io = IO.pipe(read_blocking: true)
+        fork_io, process_io = IO::FileDescriptor.pipe(read_blocking: true)
 
         @wait_count += 1
         ensure_channel
         spawn { copy_io(stdio, process_io, channel, close_dst: true) }
       else
-        process_io, fork_io = IO.pipe(write_blocking: true)
+        process_io, fork_io = IO::FileDescriptor.pipe(write_blocking: true)
 
         @wait_count += 1
         ensure_channel
@@ -261,11 +261,11 @@ class Process
     when Redirect::Pipe
       case dst_io
       when STDIN
-        fork_io, @input = IO.pipe(read_blocking: true)
+        fork_io, @input = IO::FileDescriptor.pipe(read_blocking: true)
       when STDOUT
-        @output, fork_io = IO.pipe(write_blocking: true)
+        @output, fork_io = IO::FileDescriptor.pipe(write_blocking: true)
       when STDERR
-        @error, fork_io = IO.pipe(write_blocking: true)
+        @error, fork_io = IO::FileDescriptor.pipe(write_blocking: true)
       else
         raise "BUG: unknown destination io #{dst_io}"
       end

--- a/src/signal.cr
+++ b/src/signal.cr
@@ -191,7 +191,7 @@ module Crystal::Signal
 
   alias Handler = ::Signal ->
 
-  @@pipe = IO.pipe(read_blocking: false, write_blocking: true)
+  @@pipe : {IO::FileDescriptor, IO::FileDescriptor} = IO::FileDescriptor.pipe(read_blocking: false, write_blocking: true)
   @@handlers = {} of ::Signal => Handler
   @@child_handler : Handler?
   @@mutex = Mutex.new(:unchecked)
@@ -269,7 +269,7 @@ module Crystal::Signal
   def self.after_fork
     @@pipe.each(&.file_descriptor_close)
   ensure
-    @@pipe = IO.pipe(read_blocking: false, write_blocking: true)
+    @@pipe = IO::FileDescriptor.pipe(read_blocking: false, write_blocking: true)
   end
 
   # Resets signal handlers to `SIG_DFL`. This avoids the child to receive


### PR DESCRIPTION
This is very much a WIP (it doesn't even compile yet for `make std_spec`), but the intent here is to implement #12238.

Since `Process` and `Signal` currently depend on the file-descriptor-based implementation, we need to keep that functionality, but for most usage of it today (in the stdlib: [`IO::Stapled`](https://github.com/crystal-lang/crystal/blob/2bce7e6eedbaacf1ddba1c1109dccefee827ecd8/src/io/stapled.cr#L111-L112) and [`Crystal::FiberChannel`](https://github.com/crystal-lang/crystal/blob/2bce7e6eedbaacf1ddba1c1109dccefee827ecd8/src/crystal/fiber_channel.cr#L12)) We already have some of the right abstractions to hook up OS-level pipes to since we have `IO::FileDescriptor`. `IO.pipe` currently returns a pair of those, so we can actually hang that on `IO::FileDescriptor` directly:

```crystal
read, write = IO::FileDescriptor.pipe # OS-level pipe
read, write = IO.pipe                 # User-space pipe
```

One nice thing is that, since `IO::FileDescriptor` inherits from `IO`, you can call `IO::FileDescriptor.pipe` _today_ and get that functionality.

Closes #12238 