### PR TITLE
Interpreter: don't override special vars inside block

### DIFF
--- a/spec/compiler/interpreter/special_vars_spec.cr
+++ b/spec/compiler/interpreter/special_vars_spec.cr
@@ -78,5 +78,22 @@ describe Crystal::Repl::Interpreter do
         $? || "oops"
       CODE
     end
+
+    it "sets special var inside call inside block (#12250)" do
+      interpret(<<-CODE).should eq("hey")
+        class Object; def not_nil!; self; end; end
+
+        def foo
+          $? = "hey"
+        end
+
+        def bar
+          yield
+        end
+
+        bar { foo }
+        $? || "oops"
+      CODE
+    end
   end
 end

--- a/src/compiler/crystal/interpreter/compiler.cr
+++ b/src/compiler/crystal/interpreter/compiler.cr
@@ -2002,6 +2002,9 @@ class Crystal::Repl::Compiler < Crystal::Visitor
       end
 
       block.vars.try &.each do |name, var|
+        # Special vars don't have scopes like regular block vars do
+        next if var.special_var?
+
         var_type = var.type?
         next unless var_type
 


### PR DESCRIPTION
Fixes #12250