### PR TITLE
Interpreter: don't change compiled mode logic

### DIFF
--- a/src/compiler/crystal/interpreter/compiler.cr
+++ b/src/compiler/crystal/interpreter/compiler.cr
@@ -214,6 +214,12 @@ class Crystal::Repl::Compiler < Crystal::Visitor
       move_arg_to_closure_if_closured(node, node.block_arg.not_nil!.name)
     end
 
+    # Compiled Crystal supports a def's body being nil:
+    # it treats it as NoReturn. Here we do the same thing.
+    # In reality we should fix the compiler to avoid having
+    # nil in types, but that's a larger change and we can do
+    # it later. For now we just handle this specific case in
+    # the interpreter.
     node.body.accept self
 
     final_type = node.type
@@ -1185,6 +1191,14 @@ class Crystal::Repl::Compiler < Crystal::Visitor
   end
 
   def visit(node : If)
+    # Compiled Crystal supports an if's type being nil:
+    # it treats it as NoReturn. Here we do the same thing.
+    # In reality we should fix the compiler to avoid having
+    # nil in types, but that's a larger change and we can do
+    # it later. For now we just handle this specific case in
+    # the interpreter.
+    node.type = @context.program.no_return unless node.type?
+
     if node.truthy?
       discard_value(node.cond)
       node.then.accept self

--- a/src/compiler/crystal/semantic/fix_missing_types.cr
+++ b/src/compiler/crystal/semantic/fix_missing_types.cr
@@ -63,11 +63,6 @@ class Crystal::FixMissingTypes < Crystal::Visitor
     false
   end
 
-  def visit(node : If)
-    node.type = @program.no_return unless node.type?
-    true
-  end
-
   def end_visit(node : Call)
     if expanded = node.expanded
       expanded.accept self
@@ -82,7 +77,6 @@ class Crystal::FixMissingTypes < Crystal::Visitor
     node.target_defs.try &.each do |target_def|
       if @fixed.add?(target_def)
         target_def.type = @program.no_return unless target_def.type?
-        target_def.body.type = @program.no_return unless target_def.body.type?
         target_def.accept_children self
       end
     end


### PR DESCRIPTION
Follow up to #12230

Instead of changing types from `nil` to `NoReturn` in compiled and interpreted mode, just do it in interpreted mode to avoid changing compiled mode. It seems that broke WASI specs. This is just a test, though!