### PR TITLE
Interpreter: fix some conversion primitives

### DIFF
--- a/src/compiler/crystal/interpreter/instructions.cr
+++ b/src/compiler/crystal/interpreter/instructions.cr
@@ -290,6 +290,16 @@ require "./repl"
         push:       true,
         code:       value.to_f64,
       },
+      f32_to_u32_bang: {
+        pop_values: [value : Float32],
+        push:       true,
+        code:       value.to_u32!,
+      },
+      f32_to_u64_bang: {
+        pop_values: [value : Float32],
+        push:       true,
+        code:       value.to_u64!,
+      },
       f64_to_i8: {
         pop_values: [value : Float64],
         push:       true,
@@ -349,6 +359,12 @@ require "./repl"
         overflow:   true,
         code:       value.to_u32,
       },
+      f64_to_u32_bang: {
+        pop_values: [value : Float64],
+        push:       true,
+        overflow:   false,
+        code:       value.to_u32!,
+      },
       f64_to_u64: {
         pop_values: [value : Float64],
         push:       true,
@@ -359,6 +375,11 @@ require "./repl"
         pop_values: [value : Float64],
         push:       true,
         code:       value.to_i64!,
+      },
+      f64_to_u64_bang: {
+        pop_values: [value : Float64],
+        push:       true,
+        code:       value.to_u64!,
       },
       f64_to_f32: {
         pop_values: [value : Float64],

--- a/src/compiler/crystal/interpreter/primitives.cr
+++ b/src/compiler/crystal/interpreter/primitives.cr
@@ -741,8 +741,8 @@ class Crystal::Repl::Compiler
     in {.f32?, .i128?}  then f32_to_f64(node: node); checked ? f64_to_i128(node: node) : f64_to_i128_bang(node: node)
     in {.f32?, .u8?}    then f32_to_f64(node: node); checked ? f64_to_u8(node: node) : f64_to_i64_bang(node: node)
     in {.f32?, .u16?}   then f32_to_f64(node: node); checked ? f64_to_u16(node: node) : f64_to_i64_bang(node: node)
-    in {.f32?, .u32?}   then f32_to_f64(node: node); checked ? f64_to_u32(node: node) : f64_to_i64_bang(node: node)
-    in {.f32?, .u64?}   then f32_to_f64(node: node); checked ? f64_to_u64(node: node) : f64_to_i64_bang(node: node)
+    in {.f32?, .u32?}   then checked ? (f32_to_f64(node: node); f64_to_u32(node: node)) : f32_to_u32_bang(node: node)
+    in {.f32?, .u64?}   then checked ? (f32_to_f64(node: node); f64_to_u64(node: node)) : f32_to_u64_bang(node: node)
     in {.f32?, .u128?}  then f32_to_f64(node: node); checked ? f64_to_u128(node: node) : f64_to_i128_bang(node: node)
     in {.f32?, .f32?}   then nop
     in {.f32?, .f64?}   then f32_to_f64(node: node)
@@ -753,8 +753,8 @@ class Crystal::Repl::Compiler
     in {.f64?, .i128?}  then checked ? f64_to_i128(node: node) : f64_to_i128_bang(node: node)
     in {.f64?, .u8?}    then checked ? f64_to_u8(node: node) : f64_to_i64_bang(node: node)
     in {.f64?, .u16?}   then checked ? f64_to_u16(node: node) : f64_to_i64_bang(node: node)
-    in {.f64?, .u32?}   then checked ? f64_to_u32(node: node) : f64_to_i64_bang(node: node)
-    in {.f64?, .u64?}   then checked ? f64_to_u64(node: node) : f64_to_i64_bang(node: node)
+    in {.f64?, .u32?}   then checked ? f64_to_u32(node: node) : f64_to_u32_bang(node: node)
+    in {.f64?, .u64?}   then checked ? f64_to_u64(node: node) : f64_to_u64_bang(node: node)
     in {.f64?, .u128?}  then checked ? f64_to_u128(node: node) : f64_to_i128_bang(node: node)
     in {.f64?, .f32?}   then checked ? f64_to_f32(node: node) : f64_to_f32_bang(node: node)
     in {.f64?, .f64?}   then nop


### PR DESCRIPTION
For some reason 6 specs were failing locally on my machine. I don't know why these didn't fail on CI, but from my side it was a bit annoying. And thinking about it, it was done in an incorrect way.

This fixes them by introducing specialized primitives that don't perform intermediate conversions.