### PR TITLE
Interpreter: implement Int128/UInt128 intrinsics

### DIFF
--- a/src/compiler/crystal/interpreter/instructions.cr
+++ b/src/compiler/crystal/interpreter/instructions.cr
@@ -1803,114 +1803,36 @@ require "./repl"
         push:       true,
         code:       LibIntrinsics.read_cycle_counter,
       },
-      interpreter_intrinsics_popcount8: {
-        pop_values: [value : Int8],
-        push:       true,
-        code:       LibIntrinsics.popcount8(value),
-      },
-      interpreter_intrinsics_popcount16: {
-        pop_values: [value : Int16],
-        push:       true,
-        code:       LibIntrinsics.popcount16(value),
-      },
-      interpreter_intrinsics_popcount32: {
-        pop_values: [value : Int32],
-        push:       true,
-        code:       LibIntrinsics.popcount32(value),
-      },
-      interpreter_intrinsics_popcount64: {
-        pop_values: [value : Int64],
-        push:       true,
-        code:       LibIntrinsics.popcount64(value),
-      },
-      interpreter_intrinsics_countleading8: {
-        pop_values: [src : Int8, zero_is_undef : Bool],
-        push:       true,
-        code:       begin
-          if zero_is_undef
-            LibIntrinsics.countleading8(src, true)
-          else
-            LibIntrinsics.countleading8(src, false)
-          end
-        end,
-      },
-      interpreter_intrinsics_countleading16: {
-        pop_values: [src : Int16, zero_is_undef : Bool],
-        push:       true,
-        code:       begin
-          if zero_is_undef
-            LibIntrinsics.countleading16(src, true)
-          else
-            LibIntrinsics.countleading16(src, false)
-          end
-        end,
-      },
-      interpreter_intrinsics_countleading32: {
-        pop_values: [src : Int32, zero_is_undef : Bool],
-        push:       true,
-        code:       begin
-          if zero_is_undef
-            LibIntrinsics.countleading32(src, true)
-          else
-            LibIntrinsics.countleading32(src, false)
-          end
-        end,
-      },
-      interpreter_intrinsics_countleading64: {
-        pop_values: [src : Int64, zero_is_undef : Bool],
-        push:       true,
-        code:       begin
-          if zero_is_undef
-            LibIntrinsics.countleading64(src, true)
-          else
-            LibIntrinsics.countleading64(src, false)
-          end
-        end,
-      },
-      interpreter_intrinsics_counttrailing8: {
-        pop_values: [src : Int8, zero_is_undef : Bool],
-        push:       true,
-        code:       begin
-          if zero_is_undef
-            LibIntrinsics.counttrailing8(src, true)
-          else
-            LibIntrinsics.counttrailing8(src, false)
-          end
-        end,
-      },
-      interpreter_intrinsics_counttrailing16: {
-        pop_values: [src : Int16, zero_is_undef : Bool],
-        push:       true,
-        code:       begin
-          if zero_is_undef
-            LibIntrinsics.counttrailing16(src, true)
-          else
-            LibIntrinsics.counttrailing16(src, false)
-          end
-        end,
-      },
-      interpreter_intrinsics_counttrailing32: {
-        pop_values: [src : Int32, zero_is_undef : Bool],
-        push:       true,
-        code:       begin
-          if zero_is_undef
-            LibIntrinsics.counttrailing32(src, true)
-          else
-            LibIntrinsics.counttrailing32(src, false)
-          end
-        end,
-      },
-      interpreter_intrinsics_counttrailing64: {
-        pop_values: [src : Int64, zero_is_undef : Bool],
-        push:       true,
-        code:       begin
-          if zero_is_undef
-            LibIntrinsics.counttrailing64(src, true)
-          else
-            LibIntrinsics.counttrailing64(src, false)
-          end
-        end,
-      },
+
+      {% for n in [8, 16, 32, 64, 128] %}
+        interpreter_intrinsics_popcount{{n}}: {
+          pop_values: [value : Int{{n}}],
+          push:       true,
+          code:       LibIntrinsics.popcount{{n}}(value),
+        },
+        interpreter_intrinsics_countleading{{n}}: {
+          pop_values: [src : Int{{n}}, zero_is_undef : Bool],
+          push:       true,
+          code:       begin
+            if zero_is_undef
+              LibIntrinsics.countleading{{n}}(src, true)
+            else
+              LibIntrinsics.countleading{{n}}(src, false)
+            end
+          end,
+        },
+        interpreter_intrinsics_counttrailing{{n}}: {
+          pop_values: [src : Int{{n}}, zero_is_undef : Bool],
+          push:       true,
+          code:       begin
+            if zero_is_undef
+              LibIntrinsics.counttrailing{{n}}(src, true)
+            else
+              LibIntrinsics.counttrailing{{n}}(src, false)
+            end
+          end,
+        },
+      {% end %}
       libm_ceil_f32: {
         pop_values: [value : Float32],
         push:       true,

--- a/src/compiler/crystal/interpreter/primitives.cr
+++ b/src/compiler/crystal/interpreter/primitives.cr
@@ -419,6 +419,9 @@ class Crystal::Repl::Compiler
     when "interpreter_intrinsics_popcount64"
       accept_call_args(node)
       interpreter_intrinsics_popcount64(node: node)
+    when "interpreter_intrinsics_popcount128"
+      accept_call_args(node)
+      interpreter_intrinsics_popcount128(node: node)
     when "interpreter_intrinsics_countleading8"
       accept_call_args(node)
       interpreter_intrinsics_countleading8(node: node)
@@ -431,6 +434,9 @@ class Crystal::Repl::Compiler
     when "interpreter_intrinsics_countleading64"
       accept_call_args(node)
       interpreter_intrinsics_countleading64(node: node)
+    when "interpreter_intrinsics_countleading128"
+      accept_call_args(node)
+      interpreter_intrinsics_countleading128(node: node)
     when "interpreter_intrinsics_counttrailing8"
       accept_call_args(node)
       interpreter_intrinsics_counttrailing8(node: node)
@@ -443,6 +449,9 @@ class Crystal::Repl::Compiler
     when "interpreter_intrinsics_counttrailing64"
       accept_call_args(node)
       interpreter_intrinsics_counttrailing64(node: node)
+    when "interpreter_intrinsics_counttrailing128"
+      accept_call_args(node)
+      interpreter_intrinsics_counttrailing128(node: node)
     when "interpreter_libm_ceil_f32"
       accept_call_args(node)
       libm_ceil_f32 node: node

--- a/src/intrinsics.cr
+++ b/src/intrinsics.cr
@@ -71,6 +71,7 @@ lib LibIntrinsics
   {% if flag?(:interpreted) %} @[Primitive(:interpreter_intrinsics_popcount64)] {% end %}
   fun popcount64 = "llvm.ctpop.i64"(src : Int64) : Int64
 
+  {% if flag?(:interpreted) %} @[Primitive(:interpreter_intrinsics_popcount128)] {% end %}
   fun popcount128 = "llvm.ctpop.i128"(src : Int128) : Int128
 
   {% if flag?(:interpreted) %} @[Primitive(:interpreter_intrinsics_countleading8)] {% end %}
@@ -85,6 +86,7 @@ lib LibIntrinsics
   {% if flag?(:interpreted) %} @[Primitive(:interpreter_intrinsics_countleading64)] {% end %}
   fun countleading64 = "llvm.ctlz.i64"(src : Int64, zero_is_undef : Bool) : Int64
 
+  {% if flag?(:interpreted) %} @[Primitive(:interpreter_intrinsics_countleading128)] {% end %}
   fun countleading128 = "llvm.ctlz.i128"(src : Int128, zero_is_undef : Bool) : Int128
 
   {% if flag?(:interpreted) %} @[Primitive(:interpreter_intrinsics_counttrailing8)] {% end %}
@@ -98,6 +100,8 @@ lib LibIntrinsics
 
   {% if flag?(:interpreted) %} @[Primitive(:interpreter_intrinsics_counttrailing64)] {% end %}
   fun counttrailing64 = "llvm.cttz.i64"(src : Int64, zero_is_undef : Bool) : Int64
+
+  {% if flag?(:interpreted) %} @[Primitive(:interpreter_intrinsics_counttrailing128)] {% end %}
   fun counttrailing128 = "llvm.cttz.i128"(src : Int128, zero_is_undef : Bool) : Int128
 
   fun va_start = "llvm.va_start"(ap : Void*)


### PR DESCRIPTION
Fixes #12256

I didn't include specs for these because... I didn't include specs for the other popcount, etc., methods in the first place. The reason is that I tested it in the past by running `bin/crystal i spec/std/int_spec.cr`, which already checks a lot of these things. With this PR that spec file runs fine through the interpreter.

I'm thinking that we could do one of two things:
1. Add specs to the interpreter itself for this
2. Or, add a `bin/crystal i spec/std/int_spec.cr` as a CI check (together with some other specs and/or samples) to make sure interpreted mode works fine.

In any case, I'd leave that decision to the future, to another PR. The changes here are straight-forward and I even reduced a bit of code duplication and error prone-ness when defining these instructions.