### PR TITLE
Fix docs generator search constants id

### DIFF
--- a/src/compiler/crystal/tools/doc/html/js/_search.js
+++ b/src/compiler/crystal/tools/doc/html/js/_search.js
@@ -139,14 +139,14 @@ CrystalDocs.runQuery = function(query) {
         matches = matches.concat(typeMatches);
       }
       results.push({
-        id: constant.html_id,
+        id: constant.id,
         type: type.full_name,
         result_type: "constant",
         name: constant.name,
         full_name: type.full_name + "#" + constant.name,
         value: constant.value,
         summary: constant.summary,
-        href: type.path + "#" + constant.html_id,
+        href: type.path + "#" + constant.id,
         matched_fields: matchedFields,
         matched_terms: matches
       });


### PR DESCRIPTION
This PR fixes a regression introduced in https://github.com/crystal-lang/crystal/pull/10875.
Constants don't have a `html_id` property, [instead they have an `id` one](https://github.com/crystal-lang/crystal/blob/35afca697dad37ed75cffc4ecf581a58d8053529/src/compiler/crystal/tools/doc/constant.cr#L34).

Currently all constant anchors in search, redirect to `#undefined` (e.g. ARGV => `/toplevel.html#undefined`).