### PR TITLE
Compiler: don't eagerly check cast type

### DIFF
--- a/spec/compiler/semantic/cast_spec.cr
+++ b/spec/compiler/semantic/cast_spec.cr
@@ -396,4 +396,15 @@ describe "Semantic: cast" do
       end
       )) { nilable types["Bar"] }
   end
+
+  it "doesn't eagerly try to check cast type (#12268)" do
+    assert_type(%(
+      bar = 1
+      if bar.is_a?(Char)
+        pointerof(bar).as(Pointer(typeof(bar)))
+      else
+        bar
+      end
+      )) { int32 }
+  end
 end

--- a/src/compiler/crystal/semantic/bindings.cr
+++ b/src/compiler/crystal/semantic/bindings.cr
@@ -394,7 +394,25 @@ module Crystal
       to_type = to.type?
       return unless to_type
 
+      program = to_type.program
+
+      case to_type
+      when program.object
+        raise "can't cast to Object yet"
+      when program.reference
+        raise "can't cast to Reference yet"
+      when program.class_type
+        raise "can't cast to Class yet"
+      end
+
       obj_type = obj.type?
+
+      if obj_type.is_a?(PointerInstanceType)
+        to_type_instance_type = to_type.instance_type
+        if to_type_instance_type.is_a?(GenericType)
+          raise "can't cast #{obj_type} to #{to_type_instance_type}"
+        end
+      end
 
       @upcast = false
 
@@ -433,7 +451,25 @@ module Crystal
       to_type = to.type?
       return unless to_type
 
+      program = to_type.program
+
+      case to_type
+      when program.object
+        raise "can't cast to Object yet"
+      when program.reference
+        raise "can't cast to Reference yet"
+      when program.class_type
+        raise "can't cast to Class yet"
+      end
+
       obj_type = obj.type?
+
+      if obj_type.is_a?(PointerInstanceType)
+        to_type_instance_type = to_type.instance_type
+        if to_type_instance_type.is_a?(GenericType)
+          raise "can't cast #{obj_type} to #{to_type_instance_type}"
+        end
+      end
 
       @upcast = false
 

--- a/src/compiler/crystal/semantic/main_visitor.cr
+++ b/src/compiler/crystal/semantic/main_visitor.cr
@@ -1779,23 +1779,6 @@ module Crystal
       node.to.accept self
       @in_type_args -= 1
 
-      case node.to.type?
-      when @program.object
-        node.raise "can't cast to Object yet"
-      when @program.reference
-        node.raise "can't cast to Reference yet"
-      when @program.class_type
-        node.raise "can't cast to Class yet"
-      end
-
-      obj_type = node.obj.type?
-      if obj_type.is_a?(PointerInstanceType)
-        to_type = node.to.type.instance_type
-        if to_type.is_a?(GenericType)
-          node.raise "can't cast #{obj_type} to #{to_type}"
-        end
-      end
-
       node.obj.add_observer node
       node.update
 


### PR DESCRIPTION
Fixes #12268

Many parts of the compiler still try to eagerly check things. In this case `.as(...)` was trying to eagerly check the type inside `as` but sometimes there's no type there, and that would fail.

We've been slowly moving things towards lazily checking things (this is what "bindings" are) but this was missing here. So the logic is moved to bindings now.

There's a small duplication between `Cast` and `NilableCast`, but I think it's fine.