### PR TITLE
Interpreter: consider nodes without a type as NoReturn

### DIFF
--- a/spec/compiler/interpreter/blocks_spec.cr
+++ b/spec/compiler/interpreter/blocks_spec.cr
@@ -599,5 +599,45 @@ describe Crystal::Repl::Interpreter do
         end
       CODE
     end
+
+    it "considers block arg without type as having NoReturn type (#12270)" do
+      interpret(<<-CODE).should eq(42)
+        def bar
+          if ptr = nil
+            yield ptr
+          else
+            42
+          end
+        end
+
+        def foo
+          bar do |obj|
+            obj
+          end
+        end
+
+        foo
+      CODE
+    end
+
+    it "considers block arg without type as having NoReturn type (2) (#12270)" do
+      interpret(<<-CODE).should eq(42)
+        def bar
+          if ptr = nil
+            yield ptr
+          else
+            42
+          end
+        end
+
+        def foo
+          bar do |obj|
+            return obj
+          end
+        end
+
+        foo
+      CODE
+    end
   end
 end

--- a/src/compiler/crystal/interpreter/cast.cr
+++ b/src/compiler/crystal/interpreter/cast.cr
@@ -15,6 +15,10 @@ class Crystal::Repl::Compiler
     upcast_distinct(node, from, to)
   end
 
+  private def upcast(node : ASTNode, from : Nil, to : Type)
+    # Nothing to do when casting from nil (NoReturn), as it's NoReturn
+  end
+
   private def upcast_distinct(node : ASTNode, from : TypeDefType, to : Type)
     upcast_distinct node, from.typedef, to
   end
@@ -285,6 +289,10 @@ class Crystal::Repl::Compiler
     return if from == to
 
     downcast_distinct(node, from, to)
+  end
+
+  private def downcast(node : ASTNode, from : Type, to : Nil)
+    # Nothing to do when casting to nil (NoReturn)
   end
 
   private def downcast_distinct(node : ASTNode, from : Type, to : TypeDefType)

--- a/src/compiler/crystal/interpreter/compiler.cr
+++ b/src/compiler/crystal/interpreter/compiler.cr
@@ -167,7 +167,7 @@ class Crystal::Repl::Compiler < Crystal::Visitor
       block_var = node.vars.not_nil![arg.name]
 
       # If any block argument is closured, we need to store it in the closure
-      if block_var.type? && block_var.closure_in?(node)
+      if block_var.closure_in?(node)
         closured_var = lookup_closured_var(arg.name)
         assign_to_closured_var(closured_var, node: nil)
       else
@@ -749,7 +749,7 @@ class Crystal::Repl::Compiler < Crystal::Visitor
         get_local index, aligned_sizeof_type(type), node: node
       end
 
-      downcast node, type, node.type
+      downcast node, type, node.type?
     in ClosuredVar
       if is_self && local_var.type.passed_by_value?
         node.raise "BUG: missing interpret read closured var with self"
@@ -1322,7 +1322,7 @@ class Crystal::Repl::Compiler < Crystal::Visitor
     exp_type =
       if exp
         request_value(exp)
-        exp.type
+        exp.type?
       else
         put_nil node: node
         @context.program.nil_type
@@ -2041,7 +2041,7 @@ class Crystal::Repl::Compiler < Crystal::Visitor
         next if var.special_var?
 
         var_type = var.type?
-        next unless var_type
+        var_type ||= @context.program.nil_type
 
         if var.closure_in?(block)
           needs_closure_context = true
@@ -3287,7 +3287,7 @@ class Crystal::Repl::Compiler < Crystal::Visitor
     @context.aligned_sizeof_type(node)
   end
 
-  private def aligned_sizeof_type(type : Type) : Int32
+  private def aligned_sizeof_type(type : Type?) : Int32
     @context.aligned_sizeof_type(type)
   end
 
@@ -3295,7 +3295,7 @@ class Crystal::Repl::Compiler < Crystal::Visitor
     @context.inner_sizeof_type(node)
   end
 
-  private def inner_sizeof_type(type : Type) : Int32
+  private def inner_sizeof_type(type : Type?) : Int32
     @context.inner_sizeof_type(type)
   end
 

--- a/src/compiler/crystal/interpreter/context.cr
+++ b/src/compiler/crystal/interpreter/context.cr
@@ -292,29 +292,27 @@ class Crystal::Repl::Context
   end
 
   def aligned_sizeof_type(node : ASTNode) : Int32
-    type = node.type?
-    if type
-      aligned_sizeof_type(node.type)
-    else
-      node.raise "BUG: missing type for #{node} (#{node.class})"
-    end
+    aligned_sizeof_type(node.type?)
   end
 
   def aligned_sizeof_type(type : Type) : Int32
     align(inner_sizeof_type(type))
   end
 
+  def aligned_sizeof_type(type : Nil) : Int32
+    0
+  end
+
   def inner_sizeof_type(node : ASTNode) : Int32
-    type = node.type?
-    if type
-      inner_sizeof_type(node.type)
-    else
-      node.raise "BUG: missing type for #{node} (#{node.class})"
-    end
+    inner_sizeof_type(node.type?)
   end
 
   def inner_sizeof_type(type : Type) : Int32
     @program.size_of(type.sizeof_type).to_i32
+  end
+
+  def inner_sizeof_type(type : Nil) : Int32
+    0
   end
 
   def aligned_instance_sizeof_type(type : Type) : Int32


### PR DESCRIPTION
Fixes #12270

I was a bit cautious in the past about nodes without a type, crashing the interpreter if that happened.

However, compiled Crystal deals with nodes without a type as if they were NoReturn, or nodes whose type size is zero. This PR changes the interpreter in some places to do that.

Ideally, compiled Crystal doesn't have nodes without types, but that's a larger change and I'd like to avoid making changes to compiled Crystal for now.