### PR TITLE
Use `Slice#unsafe_slice_of` and `#to_unsafe_bytes` in the standard library and compiler

### DIFF
--- a/spec/std/io/memory_spec.cr
+++ b/spec/std/io/memory_spec.cr
@@ -84,7 +84,7 @@ describe IO::Memory do
           io1.write_string "abc😂".to_slice
           io1.to_s io2
           byte_slice = io2.to_slice
-          utf16_slice = Slice.new(byte_slice.to_unsafe.unsafe_as(Pointer(UInt16)), byte_slice.size // sizeof(UInt16))
+          utf16_slice = byte_slice.unsafe_slice_of(UInt16)
 
           String.from_utf16(utf16_slice).should eq "abc😂"
           byte_slice.should eq Bytes[0x61, 0, 0x62, 0, 0x63, 0, 0x3D, 0xD8, 0x02, 0xDE]

--- a/spec/support/string.cr
+++ b/spec/support/string.cr
@@ -14,7 +14,7 @@ def string_build_via_utf16(& : IO -> _)
     io.set_encoding(IO::ByteFormat::SystemEndian == IO::ByteFormat::LittleEndian ? "UTF-16LE" : "UTF-16BE")
     yield io
     byte_slice = io.to_slice
-    utf16_slice = Slice.new(byte_slice.to_unsafe.unsafe_as(Pointer(UInt16)), byte_slice.size // sizeof(UInt16))
+    utf16_slice = byte_slice.unsafe_slice_of(UInt16)
     String.from_utf16(utf16_slice)
   {% end %}
 end

--- a/src/compiler/crystal/compiler.cr
+++ b/src/compiler/crystal/compiler.cr
@@ -386,7 +386,7 @@ module Crystal
           # TODO: Use a proper way to write encoded text to a file when that's supported.
           # The first character is the BOM; it will be converted in the same endianness as the rest.
           args_16 = "\ufeff#{args}".to_utf16
-          args_bytes = args_16.to_unsafe.as(UInt8*).to_slice(args_16.bytesize)
+          args_bytes = args_16.to_unsafe_bytes
 
           args_filename = "#{output_dir}/linker_args.txt"
           File.write(args_filename, args_bytes)

--- a/src/crystal/hasher.cr
+++ b/src/crystal/hasher.cr
@@ -80,7 +80,7 @@ struct Crystal::Hasher
   private HASH_INF_MINUS = (-314159_i64).unsafe_as(UInt64)
 
   @@seed = uninitialized UInt64[2]
-  Crystal::System::Random.random_bytes(Slice.new(pointerof(@@seed).as(UInt8*), sizeof(typeof(@@seed))))
+  Crystal::System::Random.random_bytes(@@seed.to_slice.to_unsafe_bytes)
 
   def initialize(@a : UInt64 = @@seed[0], @b : UInt64 = @@seed[1])
   end

--- a/src/crystal/system/win32/windows_registry.cr
+++ b/src/crystal/system/win32/windows_registry.cr
@@ -72,7 +72,7 @@ module Crystal::System::WindowsRegistry
   # Reads a raw value into a buffer and creates a string from it.
   def self.get_string(handle : LibC::HKEY, name : Slice(UInt16))
     Crystal::System.retry_wstr_buffer do |buffer, small_buf|
-      raw = get_raw(handle, name, Bytes.new(buffer.to_unsafe.as(UInt8*), buffer.bytesize)) || return
+      raw = get_raw(handle, name, buffer.to_unsafe_bytes) || return
       _, length = raw
 
       if 0 <= length <= buffer.size


### PR DESCRIPTION
Minor refactor.

While doing this I noticed a rather similar use of `Slice`:

https://github.com/crystal-lang/crystal/blob/f949d2dfd10fbeffa24f73345d93ee3f81072ef5/src/crystal/hasher.cr#L250-L255

Essentially, a byte view over a single object is to be produced. Such a `Bytes` can be expressed in terms of `#to_unsafe_bytes` as:

```crystal
t4 = uninitialized UInt32
Slice.new(pointerof(t4), 1).to_unsafe_bytes
```

```crystal
t4 = uninitialized UInt32[1]
t4.to_slice.to_unsafe_bytes
```

But I wonder if this would actually warrant another convenience method, so this refactor doesn't cover those uses.