### PR TITLE
Enable miscellaneous parts of the standard library on Windows

### DIFF
--- a/src/crystal/scheduler.cr
+++ b/src/crystal/scheduler.cr
@@ -130,11 +130,7 @@ class Crystal::Scheduler
 
   private def fatal_resume_error(fiber, message)
     Crystal::System.print_error "\nFATAL: #{message}: #{fiber}\n"
-    {% unless flag?(:win32) %}
-      # FIXME: Enable when caller is supported on win32
-      caller.each { |line| Crystal::System.print_error "  from #{line}\n" }
-    {% end %}
-
+    caller.each { |line| Crystal::System.print_error "  from #{line}\n" }
     exit 1
   end
 

--- a/src/file/tempfile.cr
+++ b/src/file/tempfile.cr
@@ -23,11 +23,8 @@ class File
       io << Time.local.to_s("%Y%m%d")
       io << '-'
 
-      {% unless flag?(:win32) %}
-        # TODO: Remove this once Process is implemented
-        io << Process.pid
-        io << '-'
-      {% end %}
+      io << Process.pid
+      io << '-'
 
       io << Random.rand(0x100000000).to_s(36)
 

--- a/src/http.cr
+++ b/src/http.cr
@@ -1,9 +1,7 @@
 require "uri"
-{% unless flag?(:win32) %}
-  require "./http/client"
-  require "./http/server"
-  require "./http/log"
-{% end %}
+require "./http/client"
+require "./http/server"
+require "./http/log"
 require "./http/common"
 
 # The HTTP module contains `HTTP::Client`, `HTTP::Server` and `HTTP::WebSocket` implementations.

--- a/src/kernel.cr
+++ b/src/kernel.cr
@@ -524,15 +524,15 @@ end
 {% end %}
 
 {% unless flag?(:interpreted) || flag?(:wasm32) %}
-  {% unless flag?(:win32) %}
-    # Background loop to cleanup unused fiber stacks.
-    spawn(name: "Fiber Clean Loop") do
-      loop do
-        sleep 5
-        Fiber.stack_pool.collect
-      end
+  # Background loop to cleanup unused fiber stacks.
+  spawn(name: "Fiber Clean Loop") do
+    loop do
+      sleep 5
+      Fiber.stack_pool.collect
     end
+  end
 
+  {% unless flag?(:win32) %}
     Signal.setup_default_handlers
   {% end %}
 


### PR DESCRIPTION
* Fatal failure to resume a fiber now prints the stack trace before exiting.
* `File.tempname` now includes the running process's ID.
* `require "http"` now pulls in the same files as it does on non-Windows systems.
* Unused fiber stacks are now routinely cleaned up.