### PR TITLE
Interpreter: cache methods with captured block

### DIFF
--- a/spec/compiler/interpreter/blocks_spec.cr
+++ b/spec/compiler/interpreter/blocks_spec.cr
@@ -599,5 +599,23 @@ describe Crystal::Repl::Interpreter do
         end
       CODE
     end
+
+    it "caches method with captured block (#12276)" do
+      interpret(<<-CODE).should eq(42)
+        def execute(x, &block : -> Int32)
+          if x
+            execute(false) do
+              block.call
+            end
+          else
+            yield
+          end
+        end
+
+        execute(true) do
+          42
+        end
+      CODE
+    end
   end
 end

--- a/src/compiler/crystal/interpreter/compiler.cr
+++ b/src/compiler/crystal/interpreter/compiler.cr
@@ -1992,7 +1992,7 @@ class Crystal::Repl::Compiler < Crystal::Visitor
     compiled_def = CompiledDef.new(@context, target_def, owner, args_bytesize)
 
     # We don't cache defs that yield because we inline the block's contents
-    if block
+    if block && !block.fun_literal
       @context.add_gc_reference(compiled_def)
     else
       @context.defs[target_def] = compiled_def


### PR DESCRIPTION
Fixes #12276

The interpreter caches method instantiations. However, it doesn't (can't) cache them if a method has an inlined-block. But a check to see that the block wasn't actually captured was missing. So this fixes that, and it might also improve the performance (previously every call to a method that captured a block was re-compiled.) It's probably unnoticeable, not sure (I didn't benchmark anything)