### PR TITLE
Add missing override for `Nil::same?`

### DIFF
--- a/src/nil.cr
+++ b/src/nil.cr
@@ -65,7 +65,7 @@ struct Nil
   end
 
   # Returns `false`.
-  def same?(other : Reference) : Bool
+  def same?(other : Object) : Bool
     false
   end
 


### PR DESCRIPTION
I was trying to match a value that can be `Set(T) | Nil` with `nil`
and was getting the error:

```
In src/spec/expectations.cr:64:20

 64 | actual_value.same? @expected_value
                   ^----
Error: no overload matches 'Nil#same?' with type Set(Int32)

Overloads are:
 - Nil#same?(other : Nil)
 - Nil#same?(other : Reference)
```

I guess the issue is values of type `Set(T)`, that is a struct, are
not a `Reference` nor a `Nil`, so I updated one of the definitions
of `same?` to accept `Object` rather than the more specific
`Reference`.

Note: initially I added a new definition of `same?` that works with
values of type `Value`, but I think this approach is better because
it reduces the number of `same?` overrides.