### PR TITLE
Implement `IO::FileDescriptor`'s console methods on Windows

### DIFF
--- a/samples/2048.cr
+++ b/samples/2048.cr
@@ -380,4 +380,5 @@ class Game
   end
 end
 
+at_exit { STDIN.cooked! }
 Game.new.run

--- a/spec/std/io/io_spec.cr
+++ b/spec/std/io/io_spec.cr
@@ -958,8 +958,14 @@ describe IO do
     end
   end
 
-  {% unless flag?(:win32) %}
-    typeof(STDIN.cooked { })
-    typeof(STDIN.cooked!)
+  typeof(STDIN.noecho { })
+  typeof(STDIN.noecho!)
+  {% if flag?(:win32) %}
+    typeof(STDIN.echo { })
+    typeof(STDIN.echo!)
   {% end %}
+  typeof(STDIN.cooked { })
+  typeof(STDIN.cooked!)
+  typeof(STDIN.raw { })
+  typeof(STDIN.raw!)
 end

--- a/src/io/console.cr
+++ b/src/io/console.cr
@@ -1,116 +1,208 @@
-{% skip_file if flag?(:win32) %}
+{% if flag?(:win32) %}
+  class IO::FileDescriptor < IO
+    # Yields `self` to the given block, disables character echoing for the
+    # duration of the block, and returns the block's value.
+    #
+    # This will prevent displaying back to the user what they enter on the terminal.
+    #
+    # Raises `IO::Error` if this `IO` is not a terminal device.
+    #
+    # ```
+    # print "Enter password: "
+    # password = STDIN.noecho &.gets.try &.chomp
+    # puts
+    # ```
+    def noecho(& : self -> _)
+      system_echo(false) { yield self }
+    end
 
-require "termios"
+    # Yields `self` to the given block, enables character echoing for the
+    # duration of the block, and returns the block's value.
+    #
+    # This causes user input to be displayed as they are entered on the terminal.
+    #
+    # Raises `IO::Error` if this `IO` is not a terminal device.
+    def echo(& : self -> _)
+      system_echo(true) { yield self }
+    end
 
-class IO::FileDescriptor < IO
-  # Turns off character echoing for the duration of the given block.
-  # This will prevent displaying back to the user what they enter on the terminal.
-  # Only call this when this IO is a TTY, such as a not redirected stdin.
-  #
-  # ```
-  # print "Enter password: "
-  # password = STDIN.noecho &.gets.try &.chomp
-  # puts
-  # ```
-  def noecho
-    preserving_tc_mode("can't set IO#noecho") do |mode|
+    # Disables character echoing on this `IO`.
+    #
+    # This will prevent displaying back to the user what they enter on the terminal.
+    #
+    # Raises `IO::Error` if this `IO` is not a terminal device.
+    def noecho! : Nil
+      system_echo(false) { return }
+    end
+
+    # Enables character echoing on this `IO`.
+    #
+    # This causes user input to be displayed as they are entered on the terminal.
+    #
+    # Raises `IO::Error` if this `IO` is not a terminal device.
+    def echo! : Nil
+      system_echo(true) { return }
+    end
+
+    # Yields `self` to the given block, enables character processing for the
+    # duration of the block, and returns the block's value.
+    #
+    # The so called cooked mode is the standard behavior of a terminal,
+    # doing line wise editing by the terminal and only sending the input to
+    # the program on a newline.
+    #
+    # Raises `IO::Error` if this `IO` is not a terminal device.
+    def cooked(& : self -> _)
+      system_raw(false) { yield self }
+    end
+
+    # Yields `self` to the given block, enables raw mode for the duration of the
+    # block, and returns the block's value.
+    #
+    # In raw mode every keypress is directly sent to the program, no interpretation
+    # is done by the terminal. On Windows, this also enables ANSI input escape
+    # sequences.
+    #
+    # Raises `IO::Error` if this `IO` is not a terminal device.
+    def raw(& : self -> _)
+      system_raw(true) { yield self }
+    end
+
+    # Enables character processing on this `IO`.
+    #
+    # The so called cooked mode is the standard behavior of a terminal,
+    # doing line wise editing by the terminal and only sending the input to
+    # the program on a newline.
+    #
+    # Raises `IO::Error` if this `IO` is not a terminal device.
+    def cooked! : Nil
+      system_raw(false) { return }
+    end
+
+    # Enables raw mode on this `IO`.
+    #
+    # In raw mode every keypress is directly sent to the program, no interpretation
+    # is done by the terminal. On Windows, this also enables ANSI input escape
+    # sequences.
+    #
+    # Raises `IO::Error` if this `IO` is not a terminal device.
+    def raw! : Nil
+      system_raw(true) { return }
+    end
+  end
+{% else %}
+  require "termios"
+
+  class IO::FileDescriptor < IO
+    # Turns off character echoing for the duration of the given block.
+    # This will prevent displaying back to the user what they enter on the terminal.
+    # Only call this when this IO is a TTY, such as a not redirected stdin.
+    #
+    # ```
+    # print "Enter password: "
+    # password = STDIN.noecho &.gets.try &.chomp
+    # puts
+    # ```
+    def noecho
+      preserving_tc_mode("can't set IO#noecho") do |mode|
+        noecho_from_tc_mode!
+        yield self
+      end
+    end
+
+    # Turns off character echoing for this IO.
+    # This will prevent displaying back to the user what they enter on the terminal.
+    # Only call this when this IO is a TTY, such as a not redirected stdin.
+    def noecho!
+      if LibC.tcgetattr(fd, out mode) != 0
+        raise IO::Error.from_errno "can't set IO#noecho!"
+      end
       noecho_from_tc_mode!
-      yield self
     end
-  end
 
-  # Turns off character echoing for this IO.
-  # This will prevent displaying back to the user what they enter on the terminal.
-  # Only call this when this IO is a TTY, such as a not redirected stdin.
-  def noecho!
-    if LibC.tcgetattr(fd, out mode) != 0
-      raise IO::Error.from_errno "can't set IO#noecho!"
+    macro noecho_from_tc_mode!
+      mode.c_lflag &= ~(Termios::LocalMode.flags(ECHO, ECHOE, ECHOK, ECHONL).value)
+      LibC.tcsetattr(fd, Termios::LineControl::TCSANOW, pointerof(mode))
     end
-    noecho_from_tc_mode!
-  end
 
-  macro noecho_from_tc_mode!
-    mode.c_lflag &= ~(Termios::LocalMode.flags(ECHO, ECHOE, ECHOK, ECHONL).value)
-    LibC.tcsetattr(fd, Termios::LineControl::TCSANOW, pointerof(mode))
-  end
+    # Enables character processing for the duration of the given block.
+    # The so called cooked mode is the standard behavior of a terminal,
+    # doing line wise editing by the terminal and only sending the input to
+    # the program on a newline.
+    # Only call this when this IO is a TTY, such as a not redirected stdin.
+    def cooked
+      preserving_tc_mode("can't set IO#cooked") do |mode|
+        cooked_from_tc_mode!
+        yield self
+      end
+    end
 
-  # Enables character processing for the duration of the given block.
-  # The so called cooked mode is the standard behavior of a terminal,
-  # doing line wise editing by the terminal and only sending the input to
-  # the program on a newline.
-  # Only call this when this IO is a TTY, such as a not redirected stdin.
-  def cooked
-    preserving_tc_mode("can't set IO#cooked") do |mode|
+    # Enables character processing for this IO.
+    # The so called cooked mode is the standard behavior of a terminal,
+    # doing line wise editing by the terminal and only sending the input to
+    # the program on a newline.
+    # Only call this when this IO is a TTY, such as a not redirected stdin.
+    def cooked! : Nil
+      if LibC.tcgetattr(fd, out mode) != 0
+        raise IO::Error.from_errno "can't set IO#cooked!"
+      end
       cooked_from_tc_mode!
-      yield self
     end
-  end
 
-  # Enables character processing for this IO.
-  # The so called cooked mode is the standard behavior of a terminal,
-  # doing line wise editing by the terminal and only sending the input to
-  # the program on a newline.
-  # Only call this when this IO is a TTY, such as a not redirected stdin.
-  def cooked! : Nil
-    if LibC.tcgetattr(fd, out mode) != 0
-      raise IO::Error.from_errno "can't set IO#cooked!"
+    macro cooked_from_tc_mode!
+      mode.c_iflag |= (Termios::InputMode::BRKINT |
+                      Termios::InputMode::ISTRIP |
+                      Termios::InputMode::ICRNL  |
+                      Termios::InputMode::IXON).value
+      mode.c_oflag |= Termios::OutputMode::OPOST.value
+      mode.c_lflag |= (Termios::LocalMode::ECHO   |
+                      Termios::LocalMode::ECHOE  |
+                      Termios::LocalMode::ECHOK  |
+                      Termios::LocalMode::ECHONL |
+                      Termios::LocalMode::ICANON |
+                      Termios::LocalMode::ISIG   |
+                      Termios::LocalMode::IEXTEN).value
+      LibC.tcsetattr(fd, Termios::LineControl::TCSANOW, pointerof(mode))
     end
-    cooked_from_tc_mode!
-  end
 
-  macro cooked_from_tc_mode!
-    mode.c_iflag |= (Termios::InputMode::BRKINT |
-                    Termios::InputMode::ISTRIP |
-                    Termios::InputMode::ICRNL  |
-                    Termios::InputMode::IXON).value
-    mode.c_oflag |= Termios::OutputMode::OPOST.value
-    mode.c_lflag |= (Termios::LocalMode::ECHO   |
-                    Termios::LocalMode::ECHOE  |
-                    Termios::LocalMode::ECHOK  |
-                    Termios::LocalMode::ECHONL |
-                    Termios::LocalMode::ICANON |
-                    Termios::LocalMode::ISIG   |
-                    Termios::LocalMode::IEXTEN).value
-    LibC.tcsetattr(fd, Termios::LineControl::TCSANOW, pointerof(mode))
-  end
+    # Enables raw mode for the duration of the given block.
+    # In raw mode every keypress is directly sent to the program, no interpretation
+    # is done by the terminal.
+    # Only call this when this IO is a TTY, such as a not redirected stdin.
+    def raw
+      preserving_tc_mode("can't set IO#raw") do |mode|
+        raw_from_tc_mode!
+        yield self
+      end
+    end
 
-  # Enables raw mode for the duration of the given block.
-  # In raw mode every keypress is directly sent to the program, no interpretation
-  # is done by the terminal.
-  # Only call this when this IO is a TTY, such as a not redirected stdin.
-  def raw
-    preserving_tc_mode("can't set IO#raw") do |mode|
+    # Enables raw mode for this IO.
+    # In raw mode every keypress is directly sent to the program, no interpretation
+    # is done by the terminal.
+    # Only call this when this IO is a TTY, such as a not redirected stdin.
+    def raw!
+      if LibC.tcgetattr(fd, out mode) != 0
+        raise IO::Error.from_errno "can't set IO#raw!"
+      end
+
       raw_from_tc_mode!
-      yield self
-    end
-  end
-
-  # Enables raw mode for this IO.
-  # In raw mode every keypress is directly sent to the program, no interpretation
-  # is done by the terminal.
-  # Only call this when this IO is a TTY, such as a not redirected stdin.
-  def raw!
-    if LibC.tcgetattr(fd, out mode) != 0
-      raise IO::Error.from_errno "can't set IO#raw!"
     end
 
-    raw_from_tc_mode!
-  end
-
-  macro raw_from_tc_mode!
-    LibC.cfmakeraw(pointerof(mode))
-    LibC.tcsetattr(fd, Termios::LineControl::TCSANOW, pointerof(mode))
-  end
-
-  private def preserving_tc_mode(msg)
-    if LibC.tcgetattr(fd, out mode) != 0
-      raise IO::Error.from_errno msg
+    macro raw_from_tc_mode!
+      LibC.cfmakeraw(pointerof(mode))
+      LibC.tcsetattr(fd, Termios::LineControl::TCSANOW, pointerof(mode))
     end
-    before = mode
-    begin
-      yield mode
-    ensure
-      LibC.tcsetattr(fd, Termios::LineControl::TCSANOW, pointerof(before))
+
+    private def preserving_tc_mode(msg)
+      if LibC.tcgetattr(fd, out mode) != 0
+        raise IO::Error.from_errno msg
+      end
+      before = mode
+      begin
+        yield mode
+      ensure
+        LibC.tcsetattr(fd, Termios::LineControl::TCSANOW, pointerof(before))
+      end
     end
   end
-end
+{% end %}

--- a/src/lib_c/x86_64-windows-msvc/c/consoleapi.cr
+++ b/src/lib_c/x86_64-windows-msvc/c/consoleapi.cr
@@ -1,6 +1,11 @@
 require "c/winnt"
 
 lib LibC
+  ENABLE_PROCESSED_INPUT        = 0x0001
+  ENABLE_LINE_INPUT             = 0x0002
+  ENABLE_ECHO_INPUT             = 0x0004
+  ENABLE_VIRTUAL_TERMINAL_INPUT = 0x0200
+
   ENABLE_VIRTUAL_TERMINAL_PROCESSING = 0x0004
 
   fun GetConsoleMode(hConsoleHandle : HANDLE, lpMode : DWORD*) : BOOL


### PR DESCRIPTION
This PR implements `IO::FileDescriptor#noecho`, `#cooked`, `#raw`, plus their bang variants on Windows. For consistency it also adds `#echo(&)` and `#echo!`.

`samples\2048.cr` will now work properly on CMD, Windows Terminal, or Visual Studio Code's integrated terminal. Try it!

The corresponding `Crystal::System::FileDescriptor#system_echo` and `#system_raw` for Unix-like systems will be added in a follow-up PR, because they involve some less related breaking changes (making some methods return `nil` and deprecating the `*_tc_mode!` macros).