### PR TITLE
Fix fiber clean loop on Windows

### DIFF
--- a/src/crystal/system/win32/fiber.cr
+++ b/src/crystal/system/win32/fiber.cr
@@ -13,7 +13,7 @@ module Crystal::System::Fiber
   end
 
   def self.free_stack(stack : Void*, stack_size) : Nil
-    if LibC.VirtualFree(stack, stack_size, LibC::MEM_RELEASE) == 0
+    if LibC.VirtualFree(stack, 0, LibC::MEM_RELEASE) == 0
       raise RuntimeError.from_winerror("VirtualFree")
     end
   end


### PR DESCRIPTION
Follow-up to #12281. This exception shows up when an unused fiber stack is collected:

```
Unhandled exception in spawn(name: Fiber Clean Loop): VirtualFree: The parameter is incorrect. (RuntimeError)
  from src\crystal\system\win32\fiber.cr:17 in 'free_stack'
  from src\fiber\stack_pool.cr:18 in 'collect'
  from src\fiber\stack_pool.cr:15 in 'collect'
  from src\kernel.cr:526 in '->'
  from src\fiber.cr:146 in 'run'
  from src\fiber.cr:98 in '->'
```

According to the documentation for [`VirtualFree`](https://docs.microsoft.com/en-us/windows/win32/api/memoryapi/nf-memoryapi-virtualfree), the `dwSize` argument must be 0.