### PR TITLE
Interpreter: fix `with ... yield` with extra arguments

### DIFF
--- a/spec/compiler/interpreter/blocks_spec.cr
+++ b/spec/compiler/interpreter/blocks_spec.cr
@@ -514,6 +514,24 @@ describe Crystal::Repl::Interpreter do
       CODE
     end
 
+    it "interprets with ... yield with extra arguments (#12296)" do
+      interpret(<<-CODE).should eq(1)
+        class Object
+          def itself
+            self
+          end
+        end
+
+        def build
+          with 1 yield 2
+        end
+
+        build do |t|
+          itself
+        end
+      CODE
+    end
+
     it "interprets yield with splat (1)" do
       interpret(<<-CODE).should eq((2 - 3) * 4)
         def foo


### PR DESCRIPTION
Fixes #12296

When you have code like this:

```crystal
def foo
  yield 1, 2, 3
end

foo do |x, y, z|
  puts x, y, z
end
```

The intepreter will push the values 1, 2 and 3 in order for the block. When entering the block, the arguments are popped in reverse order, so first we pop 3 and assign it to z, then we pop 2 and assign it to y, etc.

When we do `with ... yield` there's an extra argument passed to the block that's what's between `with` and `yield`. That argument is pushed first. However, the code incorrectly popped it first. It should be popped at the end!