### PR TITLE
Add `#rotate_left` and `#rotate_right` for primitive integers

### DIFF
--- a/spec/std/int_spec.cr
+++ b/spec/std/int_spec.cr
@@ -1,6 +1,7 @@
 require "./spec_helper"
 require "big"
 require "spec/helpers/iterate"
+require "../support/number"
 
 private macro it_converts_to_s(num, str, **opts)
   it {{ "converts #{num} to #{str}" }} do
@@ -377,6 +378,50 @@ describe "Int" do
     it { (8000 << 2).should eq(32000) }
     it { (8000 << 32).should eq(0) }
     it { (8000 << -1).should eq(4000) }
+  end
+
+  describe "#rotate_left" do
+    it { 0x87654321_u32.rotate_left(1).should eq(0x0ECA8643_u32) }
+    it { 0x87654321_u32.rotate_left(2).should eq(0x1D950C86_u32) }
+    it { 0x87654321_u32.rotate_left(-1).should eq(0xC3B2A190_u32) }
+    it { 0x87654321_u32.rotate_left(-2).should eq(0x61D950C8_u32) }
+    it { 0x87654321_u32.rotate_left(32).should eq(0x87654321_u32) }
+
+    it { -0x789ABCDF.rotate_left(1).should eq(0x0ECA8643) }
+    it { -0x789ABCDF.rotate_left(2).should eq(0x1D950C86) }
+    it { -0x789ABCDF.rotate_left(-1).should eq(-0x3C4D5E70) }
+    it { -0x789ABCDF.rotate_left(-2).should eq(0x61D950C8) }
+    it { -0x789ABCDF.rotate_left(32).should eq(-0x789ABCDF) }
+
+    {% for int in BUILTIN_INTEGER_TYPES %}
+      it do
+        x = ({{ int }}.new(1) << (sizeof({{ int }}) * 8 - 1)).rotate_left(1)
+        x.should be_a({{ int }})
+        x.should eq({{ int }}.new(1))
+      end
+    {% end %}
+  end
+
+  describe "#rotate_right" do
+    it { 0x87654321_u32.rotate_right(1).should eq(0xC3B2A190_u32) }
+    it { 0x87654321_u32.rotate_right(2).should eq(0x61D950C8_u32) }
+    it { 0x87654321_u32.rotate_right(-1).should eq(0x0ECA8643_u32) }
+    it { 0x87654321_u32.rotate_right(-2).should eq(0x1D950C86_u32) }
+    it { 0x87654321_u32.rotate_right(32).should eq(0x87654321_u32) }
+
+    it { -0x789ABCDF.rotate_right(1).should eq(-0x3C4D5E70) }
+    it { -0x789ABCDF.rotate_right(2).should eq(0x61D950C8) }
+    it { -0x789ABCDF.rotate_right(-1).should eq(0x0ECA8643) }
+    it { -0x789ABCDF.rotate_right(-2).should eq(0x1D950C86) }
+    it { -0x789ABCDF.rotate_right(32).should eq(-0x789ABCDF) }
+
+    {% for int in BUILTIN_INTEGER_TYPES %}
+      it do
+        x = {{ int }}.new(1).rotate_right(1)
+        x.should be_a({{ int }})
+        x.should eq({{ int }}.new(1) << (sizeof({{ int }}) * 8 - 1))
+      end
+    {% end %}
   end
 
   describe "to" do

--- a/src/compiler/crystal/interpreter/instructions.cr
+++ b/src/compiler/crystal/interpreter/instructions.cr
@@ -1853,6 +1853,16 @@ require "./repl"
             end
           end,
         },
+        interpreter_intrinsics_fshl{{n}}: {
+          pop_values: [a : UInt{{n}}, b : UInt{{n}}, count : UInt{{n}}],
+          push:       true,
+          code:       LibIntrinsics.fshl{{n}}(a, b, count),
+        },
+        interpreter_intrinsics_fshr{{n}}: {
+          pop_values: [a : UInt{{n}}, b : UInt{{n}}, count : UInt{{n}}],
+          push:       true,
+          code:       LibIntrinsics.fshr{{n}}(a, b, count),
+        },
       {% end %}
 
       {% for n in [16, 32, 64] %}

--- a/src/compiler/crystal/interpreter/primitives.cr
+++ b/src/compiler/crystal/interpreter/primitives.cr
@@ -461,6 +461,36 @@ class Crystal::Repl::Compiler
     when "interpreter_intrinsics_bitreverse64"
       accept_call_args(node)
       interpreter_intrinsics_bitreverse64(node: node)
+    when "interpreter_intrinsics_fshl8"
+      accept_call_args(node)
+      interpreter_intrinsics_fshl8(node: node)
+    when "interpreter_intrinsics_fshl16"
+      accept_call_args(node)
+      interpreter_intrinsics_fshl16(node: node)
+    when "interpreter_intrinsics_fshl32"
+      accept_call_args(node)
+      interpreter_intrinsics_fshl32(node: node)
+    when "interpreter_intrinsics_fshl64"
+      accept_call_args(node)
+      interpreter_intrinsics_fshl64(node: node)
+    when "interpreter_intrinsics_fshl128"
+      accept_call_args(node)
+      interpreter_intrinsics_fshl128(node: node)
+    when "interpreter_intrinsics_fshr8"
+      accept_call_args(node)
+      interpreter_intrinsics_fshr8(node: node)
+    when "interpreter_intrinsics_fshr16"
+      accept_call_args(node)
+      interpreter_intrinsics_fshr16(node: node)
+    when "interpreter_intrinsics_fshr32"
+      accept_call_args(node)
+      interpreter_intrinsics_fshr32(node: node)
+    when "interpreter_intrinsics_fshr64"
+      accept_call_args(node)
+      interpreter_intrinsics_fshr64(node: node)
+    when "interpreter_intrinsics_fshr128"
+      accept_call_args(node)
+      interpreter_intrinsics_fshr128(node: node)
     when "interpreter_libm_ceil_f32"
       accept_call_args(node)
       libm_ceil_f32 node: node

--- a/src/crystal/digest/md5.cr
+++ b/src/crystal/digest/md5.cr
@@ -105,31 +105,27 @@ class Crystal::Digest::MD5 < ::Digest
     y ^ (x | (~z))
   end
 
-  private def rotate_left(x, n)
-    (x << n) | (x >> (32 - n))
-  end
-
   private def ff(a, b, c, d, x, s, ac)
     a &+= f(b, c, d) &+ x &+ ac.to_u32
-    a = rotate_left a, s
+    a = a.rotate_left s
     a &+= b
   end
 
   private def gg(a, b, c, d, x, s, ac)
     a &+= g(b, c, d) &+ x &+ ac.to_u32
-    a = rotate_left a, s
+    a = a.rotate_left s
     a &+= b
   end
 
   private def hh(a, b, c, d, x, s, ac)
     a &+= h(b, c, d) &+ x &+ ac.to_u32
-    a = rotate_left a, s
+    a = a.rotate_left s
     a &+= b
   end
 
   private def ii(a, b, c, d, x, s, ac)
     a &+= i(b, c, d) &+ x &+ ac.to_u32
-    a = rotate_left a, s
+    a = a.rotate_left s
     a &+= b
   end
 

--- a/src/crystal/digest/sha1.cr
+++ b/src/crystal/digest/sha1.cr
@@ -75,7 +75,7 @@ class Crystal::Digest::SHA1 < ::Digest
     {% end %}
 
     {% for t in (16...80) %}
-      w[{{t}}] = circular_shift(1, w[{{t - 3}}] ^ w[{{t - 8}}] ^ w[{{t - 14}}] ^ w[{{t - 16}}])
+      w[{{t}}] = (w[{{t - 3}}] ^ w[{{t - 8}}] ^ w[{{t - 14}}] ^ w[{{t - 16}}]).rotate_left(1)
     {% end %}
 
     a = @intermediate_hash[0]
@@ -85,39 +85,39 @@ class Crystal::Digest::SHA1 < ::Digest
     e = @intermediate_hash[4]
 
     {% for t in (0...20) %}
-      temp = circular_shift(5, a) &+
+      temp = a.rotate_left(5) &+
         ((b & c) | ((~b) & d)) &+ e &+ w[{{t}}] &+ k[0]
       e = d
       d = c
-      c = circular_shift(30, b)
+      c = b.rotate_left(30)
       b = a
       a = temp
     {% end %}
 
     {% for t in (20...40) %}
-      temp = circular_shift(5, a) &+ (b ^ c ^ d) &+ e &+ w[{{t}}] &+ k[1]
+      temp = a.rotate_left(5) &+ (b ^ c ^ d) &+ e &+ w[{{t}}] &+ k[1]
       e = d
       d = c
-      c = circular_shift(30, b)
+      c = b.rotate_left(30)
       b = a
       a = temp
     {% end %}
 
     {% for t in (40...60) %}
-      temp = circular_shift(5, a) &+
+      temp = a.rotate_left(5) &+
         ((b & c) | (b & d) | (c & d)) &+ e &+ w[{{t}}] &+ k[2]
       e = d
       d = c
-      c = circular_shift(30, b)
+      c = b.rotate_left(30)
       b = a
       a = temp
     {% end %}
 
     {% for t in (60...80) %}
-      temp = circular_shift(5, a) &+ (b ^ c ^ d) &+ e &+ w[{{t}}] &+ k[3]
+      temp = a.rotate_left(5) &+ (b ^ c ^ d) &+ e &+ w[{{t}}] &+ k[3]
       e = d
       d = c
-      c = circular_shift(30, b)
+      c = b.rotate_left(30)
       b = a
       a = temp
     {% end %}
@@ -129,10 +129,6 @@ class Crystal::Digest::SHA1 < ::Digest
     @intermediate_hash[4] &+= e
 
     @message_block_index = 0
-  end
-
-  private def circular_shift(bits, word)
-    (word << bits) | (word >> (32 - bits))
   end
 
   private def pad_message

--- a/src/crystal/hasher.cr
+++ b/src/crystal/hasher.cr
@@ -88,13 +88,9 @@ struct Crystal::Hasher
   private C1 = 0xacd5ad43274593b9_u64
   private C2 = 0x6956abd6ed268a3d_u64
 
-  private def rotl32(v : UInt64)
-    (v << 32) | (v >> 32)
-  end
-
   private def permute(v : UInt64)
-    @a = rotl32(@a ^ v) &* C1
-    @b = (rotl32(@b) ^ v) &* C2
+    @a = (@a ^ v).rotate_left(32) &* C1
+    @b = (@b.rotate_left(32) ^ v) &* C2
     self
   end
 

--- a/src/int.cr
+++ b/src/int.cr
@@ -881,6 +881,32 @@ struct Int8
     Intrinsics.counttrailing8(self, false)
   end
 
+  # Returns the bitwise rotation of `self` *n* times in the most significant
+  # bit's direction. Negative shifts are equivalent to `rotate_right(-n)`.
+  #
+  # ```
+  # 0b01001101_u8.rotate_left(3)  # => 0b01101010
+  # 0b01001101_u8.rotate_left(8)  # => 0b01001101
+  # 0b01001101_u8.rotate_left(11) # => 0b01101010
+  # 0b01001101_u8.rotate_left(-1) # => 0b10100110
+  # ```
+  def rotate_left(n : Int) : self
+    Intrinsics.fshl8(self, self, n.to_i8!).to_i8!
+  end
+
+  # Returns the bitwise rotation of `self` *n* times in the least significant
+  # bit's direction. Negative shifts are equivalent to `rotate_left(-n)`.
+  #
+  # ```
+  # 0b01001101_u8.rotate_right(3)  # => 0b10101001
+  # 0b01001101_u8.rotate_right(8)  # => 0b01001101
+  # 0b01001101_u8.rotate_right(11) # => 0b10101001
+  # 0b01001101_u8.rotate_right(-1) # => 0b10011010
+  # ```
+  def rotate_right(n : Int) : self
+    Intrinsics.fshr8(self, self, n.to_i8!).to_i8!
+  end
+
   def clone
     self
   end
@@ -930,6 +956,32 @@ struct Int16
 
   def trailing_zeros_count
     Intrinsics.counttrailing16(self, false)
+  end
+
+  # Returns the bitwise rotation of `self` *n* times in the most significant
+  # bit's direction. Negative shifts are equivalent to `rotate_right(-n)`.
+  #
+  # ```
+  # 0b01001101_u8.rotate_left(3)  # => 0b01101010
+  # 0b01001101_u8.rotate_left(8)  # => 0b01001101
+  # 0b01001101_u8.rotate_left(11) # => 0b01101010
+  # 0b01001101_u8.rotate_left(-1) # => 0b10100110
+  # ```
+  def rotate_left(n : Int) : self
+    Intrinsics.fshl16(self, self, n.to_i16!).to_i16!
+  end
+
+  # Returns the bitwise rotation of `self` *n* times in the least significant
+  # bit's direction. Negative shifts are equivalent to `rotate_left(-n)`.
+  #
+  # ```
+  # 0b01001101_u8.rotate_right(3)  # => 0b10101001
+  # 0b01001101_u8.rotate_right(8)  # => 0b01001101
+  # 0b01001101_u8.rotate_right(11) # => 0b10101001
+  # 0b01001101_u8.rotate_right(-1) # => 0b10011010
+  # ```
+  def rotate_right(n : Int) : self
+    Intrinsics.fshr16(self, self, n.to_i16!).to_i16!
   end
 
   def clone
@@ -983,6 +1035,32 @@ struct Int32
     Intrinsics.counttrailing32(self, false)
   end
 
+  # Returns the bitwise rotation of `self` *n* times in the most significant
+  # bit's direction. Negative shifts are equivalent to `rotate_right(-n)`.
+  #
+  # ```
+  # 0b01001101_u8.rotate_left(3)  # => 0b01101010
+  # 0b01001101_u8.rotate_left(8)  # => 0b01001101
+  # 0b01001101_u8.rotate_left(11) # => 0b01101010
+  # 0b01001101_u8.rotate_left(-1) # => 0b10100110
+  # ```
+  def rotate_left(n : Int) : self
+    Intrinsics.fshl32(self, self, n.to_i32!).to_i32!
+  end
+
+  # Returns the bitwise rotation of `self` *n* times in the least significant
+  # bit's direction. Negative shifts are equivalent to `rotate_left(-n)`.
+  #
+  # ```
+  # 0b01001101_u8.rotate_right(3)  # => 0b10101001
+  # 0b01001101_u8.rotate_right(8)  # => 0b01001101
+  # 0b01001101_u8.rotate_right(11) # => 0b10101001
+  # 0b01001101_u8.rotate_right(-1) # => 0b10011010
+  # ```
+  def rotate_right(n : Int) : self
+    Intrinsics.fshr32(self, self, n.to_i32!).to_i32!
+  end
+
   def clone
     self
   end
@@ -1032,6 +1110,32 @@ struct Int64
 
   def trailing_zeros_count
     Intrinsics.counttrailing64(self, false)
+  end
+
+  # Returns the bitwise rotation of `self` *n* times in the most significant
+  # bit's direction. Negative shifts are equivalent to `rotate_right(-n)`.
+  #
+  # ```
+  # 0b01001101_u8.rotate_left(3)  # => 0b01101010
+  # 0b01001101_u8.rotate_left(8)  # => 0b01001101
+  # 0b01001101_u8.rotate_left(11) # => 0b01101010
+  # 0b01001101_u8.rotate_left(-1) # => 0b10100110
+  # ```
+  def rotate_left(n : Int) : self
+    Intrinsics.fshl64(self, self, n.to_i64!).to_i64!
+  end
+
+  # Returns the bitwise rotation of `self` *n* times in the least significant
+  # bit's direction. Negative shifts are equivalent to `rotate_left(-n)`.
+  #
+  # ```
+  # 0b01001101_u8.rotate_right(3)  # => 0b10101001
+  # 0b01001101_u8.rotate_right(8)  # => 0b01001101
+  # 0b01001101_u8.rotate_right(11) # => 0b10101001
+  # 0b01001101_u8.rotate_right(-1) # => 0b10011010
+  # ```
+  def rotate_right(n : Int) : self
+    Intrinsics.fshr64(self, self, n.to_i64!).to_i64!
   end
 
   def clone
@@ -1085,6 +1189,32 @@ struct Int128
 
   def trailing_zeros_count
     Intrinsics.counttrailing128(self, false)
+  end
+
+  # Returns the bitwise rotation of `self` *n* times in the most significant
+  # bit's direction. Negative shifts are equivalent to `rotate_right(-n)`.
+  #
+  # ```
+  # 0b01001101_u8.rotate_left(3)  # => 0b01101010
+  # 0b01001101_u8.rotate_left(8)  # => 0b01001101
+  # 0b01001101_u8.rotate_left(11) # => 0b01101010
+  # 0b01001101_u8.rotate_left(-1) # => 0b10100110
+  # ```
+  def rotate_left(n : Int) : self
+    Intrinsics.fshl128(self, self, n.to_i128!).to_i128!
+  end
+
+  # Returns the bitwise rotation of `self` *n* times in the least significant
+  # bit's direction. Negative shifts are equivalent to `rotate_left(-n)`.
+  #
+  # ```
+  # 0b01001101_u8.rotate_right(3)  # => 0b10101001
+  # 0b01001101_u8.rotate_right(8)  # => 0b01001101
+  # 0b01001101_u8.rotate_right(11) # => 0b10101001
+  # 0b01001101_u8.rotate_right(-1) # => 0b10011010
+  # ```
+  def rotate_right(n : Int) : self
+    Intrinsics.fshr128(self, self, n.to_i128!).to_i128!
   end
 
   def clone
@@ -1142,6 +1272,32 @@ struct UInt8
     Intrinsics.counttrailing8(self, false)
   end
 
+  # Returns the bitwise rotation of `self` *n* times in the most significant
+  # bit's direction. Negative shifts are equivalent to `rotate_right(-n)`.
+  #
+  # ```
+  # 0b01001101_u8.rotate_left(3)  # => 0b01101010
+  # 0b01001101_u8.rotate_left(8)  # => 0b01001101
+  # 0b01001101_u8.rotate_left(11) # => 0b01101010
+  # 0b01001101_u8.rotate_left(-1) # => 0b10100110
+  # ```
+  def rotate_left(n : Int) : self
+    Intrinsics.fshl8(self, self, n.to_u8!)
+  end
+
+  # Returns the bitwise rotation of `self` *n* times in the least significant
+  # bit's direction. Negative shifts are equivalent to `rotate_left(-n)`.
+  #
+  # ```
+  # 0b01001101_u8.rotate_right(3)  # => 0b10101001
+  # 0b01001101_u8.rotate_right(8)  # => 0b01001101
+  # 0b01001101_u8.rotate_right(11) # => 0b10101001
+  # 0b01001101_u8.rotate_right(-1) # => 0b10011010
+  # ```
+  def rotate_right(n : Int) : self
+    Intrinsics.fshr8(self, self, n.to_u8!)
+  end
+
   def clone
     self
   end
@@ -1195,6 +1351,32 @@ struct UInt16
 
   def trailing_zeros_count
     Intrinsics.counttrailing16(self, false)
+  end
+
+  # Returns the bitwise rotation of `self` *n* times in the most significant
+  # bit's direction. Negative shifts are equivalent to `rotate_right(-n)`.
+  #
+  # ```
+  # 0b01001101_u8.rotate_left(3)  # => 0b01101010
+  # 0b01001101_u8.rotate_left(8)  # => 0b01001101
+  # 0b01001101_u8.rotate_left(11) # => 0b01101010
+  # 0b01001101_u8.rotate_left(-1) # => 0b10100110
+  # ```
+  def rotate_left(n : Int) : self
+    Intrinsics.fshl16(self, self, n.to_u16!)
+  end
+
+  # Returns the bitwise rotation of `self` *n* times in the least significant
+  # bit's direction. Negative shifts are equivalent to `rotate_left(-n)`.
+  #
+  # ```
+  # 0b01001101_u8.rotate_right(3)  # => 0b10101001
+  # 0b01001101_u8.rotate_right(8)  # => 0b01001101
+  # 0b01001101_u8.rotate_right(11) # => 0b10101001
+  # 0b01001101_u8.rotate_right(-1) # => 0b10011010
+  # ```
+  def rotate_right(n : Int) : self
+    Intrinsics.fshr16(self, self, n.to_u16!)
   end
 
   def clone
@@ -1252,6 +1434,32 @@ struct UInt32
     Intrinsics.counttrailing32(self, false)
   end
 
+  # Returns the bitwise rotation of `self` *n* times in the most significant
+  # bit's direction. Negative shifts are equivalent to `rotate_right(-n)`.
+  #
+  # ```
+  # 0b01001101_u8.rotate_left(3)  # => 0b01101010
+  # 0b01001101_u8.rotate_left(8)  # => 0b01001101
+  # 0b01001101_u8.rotate_left(11) # => 0b01101010
+  # 0b01001101_u8.rotate_left(-1) # => 0b10100110
+  # ```
+  def rotate_left(n : Int) : self
+    Intrinsics.fshl32(self, self, n.to_u32!)
+  end
+
+  # Returns the bitwise rotation of `self` *n* times in the least significant
+  # bit's direction. Negative shifts are equivalent to `rotate_left(-n)`.
+  #
+  # ```
+  # 0b01001101_u8.rotate_right(3)  # => 0b10101001
+  # 0b01001101_u8.rotate_right(8)  # => 0b01001101
+  # 0b01001101_u8.rotate_right(11) # => 0b10101001
+  # 0b01001101_u8.rotate_right(-1) # => 0b10011010
+  # ```
+  def rotate_right(n : Int) : self
+    Intrinsics.fshr32(self, self, n.to_u32!)
+  end
+
   def clone
     self
   end
@@ -1305,6 +1513,32 @@ struct UInt64
 
   def trailing_zeros_count
     Intrinsics.counttrailing64(self, false)
+  end
+
+  # Returns the bitwise rotation of `self` *n* times in the most significant
+  # bit's direction. Negative shifts are equivalent to `rotate_right(-n)`.
+  #
+  # ```
+  # 0b01001101_u8.rotate_left(3)  # => 0b01101010
+  # 0b01001101_u8.rotate_left(8)  # => 0b01001101
+  # 0b01001101_u8.rotate_left(11) # => 0b01101010
+  # 0b01001101_u8.rotate_left(-1) # => 0b10100110
+  # ```
+  def rotate_left(n : Int) : self
+    Intrinsics.fshl64(self, self, n.to_u64!)
+  end
+
+  # Returns the bitwise rotation of `self` *n* times in the least significant
+  # bit's direction. Negative shifts are equivalent to `rotate_left(-n)`.
+  #
+  # ```
+  # 0b01001101_u8.rotate_right(3)  # => 0b10101001
+  # 0b01001101_u8.rotate_right(8)  # => 0b01001101
+  # 0b01001101_u8.rotate_right(11) # => 0b10101001
+  # 0b01001101_u8.rotate_right(-1) # => 0b10011010
+  # ```
+  def rotate_right(n : Int) : self
+    Intrinsics.fshr64(self, self, n.to_u64!)
   end
 
   def clone
@@ -1362,6 +1596,32 @@ struct UInt128
 
   def trailing_zeros_count
     Intrinsics.counttrailing128(self, false)
+  end
+
+  # Returns the bitwise rotation of `self` *n* times in the most significant
+  # bit's direction. Negative shifts are equivalent to `rotate_right(-n)`.
+  #
+  # ```
+  # 0b01001101_u8.rotate_left(3)  # => 0b01101010
+  # 0b01001101_u8.rotate_left(8)  # => 0b01001101
+  # 0b01001101_u8.rotate_left(11) # => 0b01101010
+  # 0b01001101_u8.rotate_left(-1) # => 0b10100110
+  # ```
+  def rotate_left(n : Int) : self
+    Intrinsics.fshl128(self, self, n.to_u128!)
+  end
+
+  # Returns the bitwise rotation of `self` *n* times in the least significant
+  # bit's direction. Negative shifts are equivalent to `rotate_left(-n)`.
+  #
+  # ```
+  # 0b01001101_u8.rotate_right(3)  # => 0b10101001
+  # 0b01001101_u8.rotate_right(8)  # => 0b01001101
+  # 0b01001101_u8.rotate_right(11) # => 0b10101001
+  # 0b01001101_u8.rotate_right(-1) # => 0b10011010
+  # ```
+  def rotate_right(n : Int) : self
+    Intrinsics.fshr128(self, self, n.to_u128!)
   end
 
   def clone

--- a/src/intrinsics.cr
+++ b/src/intrinsics.cr
@@ -109,6 +109,20 @@ lib LibIntrinsics
   {% if flag?(:interpreted) %} @[Primitive(:interpreter_intrinsics_counttrailing128)] {% end %}
   fun counttrailing128 = "llvm.cttz.i128"(src : Int128, zero_is_undef : Bool) : Int128
 
+  {% if compare_versions(Crystal::LLVM_VERSION, "7.0.0") >= 0 %}
+    fun fshl8 = "llvm.fshl.i8"(a : UInt8, b : UInt8, count : UInt8) : UInt8
+    fun fshl16 = "llvm.fshl.i16"(a : UInt16, b : UInt16, count : UInt16) : UInt16
+    fun fshl32 = "llvm.fshl.i32"(a : UInt32, b : UInt32, count : UInt32) : UInt32
+    fun fshl64 = "llvm.fshl.i64"(a : UInt64, b : UInt64, count : UInt64) : UInt64
+    fun fshl128 = "llvm.fshl.i128"(a : UInt128, b : UInt128, count : UInt128) : UInt128
+
+    fun fshr8 = "llvm.fshr.i8"(a : UInt8, b : UInt8, count : UInt8) : UInt8
+    fun fshr16 = "llvm.fshr.i16"(a : UInt16, b : UInt16, count : UInt16) : UInt16
+    fun fshr32 = "llvm.fshr.i32"(a : UInt32, b : UInt32, count : UInt32) : UInt32
+    fun fshr64 = "llvm.fshr.i64"(a : UInt64, b : UInt64, count : UInt64) : UInt64
+    fun fshr128 = "llvm.fshr.i128"(a : UInt128, b : UInt128, count : UInt128) : UInt128
+  {% end %}
+
   fun va_start = "llvm.va_start"(ap : Void*)
   fun va_end = "llvm.va_end"(ap : Void*)
 
@@ -242,6 +256,86 @@ module Intrinsics
 
   macro counttrailing128(src, zero_is_undef)
     LibIntrinsics.counttrailing128({{src}}, {{zero_is_undef}})
+  end
+
+  def self.fshl8(a, b, count) : UInt8
+    {% if compare_versions(Crystal::LLVM_VERSION, "7.0.0") < 0 %}
+      a.unsafe_shl(count) | b.unsafe_shr((~count &+ 1) & 7)
+    {% else %}
+      LibIntrinsics.fshl8(a, b, count)
+    {% end %}
+  end
+
+  def self.fshl16(a, b, count) : UInt16
+    {% if compare_versions(Crystal::LLVM_VERSION, "7.0.0") < 0 %}
+      a.unsafe_shl(count) | b.unsafe_shr((~count &+ 1) & 15)
+    {% else %}
+      LibIntrinsics.fshl16(a, b, count)
+    {% end %}
+  end
+
+  def self.fshl32(a, b, count) : UInt32
+    {% if compare_versions(Crystal::LLVM_VERSION, "7.0.0") < 0 %}
+      a.unsafe_shl(count) | b.unsafe_shr((~count &+ 1) & 31)
+    {% else %}
+      LibIntrinsics.fshl32(a, b, count)
+    {% end %}
+  end
+
+  def self.fshl64(a, b, count) : UInt64
+    {% if compare_versions(Crystal::LLVM_VERSION, "7.0.0") < 0 %}
+      a.unsafe_shl(count) | b.unsafe_shr((~count &+ 1) & 63)
+    {% else %}
+      LibIntrinsics.fshl64(a, b, count)
+    {% end %}
+  end
+
+  def self.fshl128(a, b, count) : UInt128
+    {% if compare_versions(Crystal::LLVM_VERSION, "7.0.0") < 0 %}
+      a.unsafe_shl(count) | b.unsafe_shr((~count &+ 1) & 127)
+    {% else %}
+      LibIntrinsics.fshl128(a, b, count)
+    {% end %}
+  end
+
+  def self.fshr8(a, b, count) : UInt8
+    {% if compare_versions(Crystal::LLVM_VERSION, "7.0.0") < 0 %}
+      b.unsafe_shr(count) | a.unsafe_shl((~count &+ 1) & 7)
+    {% else %}
+      LibIntrinsics.fshr8(a, b, count)
+    {% end %}
+  end
+
+  def self.fshr16(a, b, count) : UInt16
+    {% if compare_versions(Crystal::LLVM_VERSION, "7.0.0") < 0 %}
+      b.unsafe_shr(count) | a.unsafe_shl((~count &+ 1) & 15)
+    {% else %}
+      LibIntrinsics.fshr16(a, b, count)
+    {% end %}
+  end
+
+  def self.fshr32(a, b, count) : UInt32
+    {% if compare_versions(Crystal::LLVM_VERSION, "7.0.0") < 0 %}
+      b.unsafe_shr(count) | a.unsafe_shl((~count &+ 1) & 31)
+    {% else %}
+      LibIntrinsics.fshr32(a, b, count)
+    {% end %}
+  end
+
+  def self.fshr64(a, b, count) : UInt64
+    {% if compare_versions(Crystal::LLVM_VERSION, "7.0.0") < 0 %}
+      b.unsafe_shr(count) | a.unsafe_shl((~count &+ 1) & 63)
+    {% else %}
+      LibIntrinsics.fshr64(a, b, count)
+    {% end %}
+  end
+
+  def self.fshr128(a, b, count) : UInt128
+    {% if compare_versions(Crystal::LLVM_VERSION, "7.0.0") < 0 %}
+      b.unsafe_shr(count) | a.unsafe_shl((~count &+ 1) & 127)
+    {% else %}
+      LibIntrinsics.fshr128(a, b, count)
+    {% end %}
   end
 
   macro va_start(ap)

--- a/src/intrinsics.cr
+++ b/src/intrinsics.cr
@@ -110,16 +110,34 @@ lib LibIntrinsics
   fun counttrailing128 = "llvm.cttz.i128"(src : Int128, zero_is_undef : Bool) : Int128
 
   {% if compare_versions(Crystal::LLVM_VERSION, "7.0.0") >= 0 %}
+    {% if flag?(:interpreted) %} @[Primitive(:interpreter_intrinsics_fshl8)] {% end %}
     fun fshl8 = "llvm.fshl.i8"(a : UInt8, b : UInt8, count : UInt8) : UInt8
+
+    {% if flag?(:interpreted) %} @[Primitive(:interpreter_intrinsics_fshl16)] {% end %}
     fun fshl16 = "llvm.fshl.i16"(a : UInt16, b : UInt16, count : UInt16) : UInt16
+
+    {% if flag?(:interpreted) %} @[Primitive(:interpreter_intrinsics_fshl32)] {% end %}
     fun fshl32 = "llvm.fshl.i32"(a : UInt32, b : UInt32, count : UInt32) : UInt32
+
+    {% if flag?(:interpreted) %} @[Primitive(:interpreter_intrinsics_fshl64)] {% end %}
     fun fshl64 = "llvm.fshl.i64"(a : UInt64, b : UInt64, count : UInt64) : UInt64
+
+    {% if flag?(:interpreted) %} @[Primitive(:interpreter_intrinsics_fshl128)] {% end %}
     fun fshl128 = "llvm.fshl.i128"(a : UInt128, b : UInt128, count : UInt128) : UInt128
 
+    {% if flag?(:interpreted) %} @[Primitive(:interpreter_intrinsics_fshr8)] {% end %}
     fun fshr8 = "llvm.fshr.i8"(a : UInt8, b : UInt8, count : UInt8) : UInt8
+
+    {% if flag?(:interpreted) %} @[Primitive(:interpreter_intrinsics_fshr16)] {% end %}
     fun fshr16 = "llvm.fshr.i16"(a : UInt16, b : UInt16, count : UInt16) : UInt16
+
+    {% if flag?(:interpreted) %} @[Primitive(:interpreter_intrinsics_fshr32)] {% end %}
     fun fshr32 = "llvm.fshr.i32"(a : UInt32, b : UInt32, count : UInt32) : UInt32
+
+    {% if flag?(:interpreted) %} @[Primitive(:interpreter_intrinsics_fshr64)] {% end %}
     fun fshr64 = "llvm.fshr.i64"(a : UInt64, b : UInt64, count : UInt64) : UInt64
+
+    {% if flag?(:interpreted) %} @[Primitive(:interpreter_intrinsics_fshr128)] {% end %}
     fun fshr128 = "llvm.fshr.i128"(a : UInt128, b : UInt128, count : UInt128) : UInt128
   {% end %}
 

--- a/src/random/pcg32.cr
+++ b/src/random/pcg32.cr
@@ -67,7 +67,7 @@ class Random::PCG32
     @state = oldstate &* PCG_DEFAULT_MULTIPLIER_64 &+ @inc
     xorshifted = UInt32.new!(((oldstate >> 18) ^ oldstate) >> 27)
     rot = UInt32.new!(oldstate >> 59)
-    return UInt32.new!((xorshifted >> rot) | (xorshifted << ((~rot &+ 1) & 31)))
+    return UInt32.new!(xorshifted.rotate_right(rot))
   end
 
   def jump(delta)


### PR DESCRIPTION
Resolves #11841. Note that `BigInt`s cannot rotate because they don't have a maximum magnitude.

IIRC this makes `Random.rand` approximately 30% faster.