### PR TITLE
Compiler: fix is_a? from generic class against generic class instance type

### DIFF
--- a/spec/compiler/codegen/is_a_spec.cr
+++ b/spec/compiler/codegen/is_a_spec.cr
@@ -905,4 +905,21 @@ describe "Codegen: is_a?" do
       end
     )).to_i.should eq(2)
   end
+
+  it "does is_a? for generic type against generic class instance type (#12304)" do
+    run(%(
+      require "prelude"
+
+      class A
+      end
+
+      class B(T) < A
+      end
+
+      a = B(Int32).new.as(A)
+      b = a.as(B)
+
+      b.is_a?(B(Int32))
+    )).to_b.should be_true
+  end
 end

--- a/src/compiler/crystal/semantic/type_intersect.cr
+++ b/src/compiler/crystal/semantic/type_intersect.cr
@@ -2,21 +2,6 @@ require "../program"
 
 module Crystal
   class Type
-    # Given two types T and U, returns a common descendent V such that V <= T
-    # and V <= U. This is the same as:
-    #
-    # ```
-    # typeof(begin
-    #   x = uninitialized T
-    #   x.is_a?(U) ? x : raise ""
-    # end)
-    # ```
-    #
-    # except that `nil` is returned if the above produces `NoReturn`.
-    def self.common_descendent(type1 : Type, type2 : Type)
-      common_descendent_base(type1, type2)
-    end
-
     def self.common_descendent(type1 : TupleInstanceType, type2 : TupleInstanceType)
       type1.implements?(type2) ? type1 : nil
     end
@@ -207,6 +192,14 @@ module Crystal
       type1
     end
 
+    def self.common_descendent(type1 : GenericType, type2 : GenericInstanceType)
+      type2.implements?(type1) ? type2 : type1
+    end
+
+    def self.common_descendent(type1 : GenericInstanceType, type2 : GenericType)
+      common_descendent(type2, type1)
+    end
+
     def self.common_descendent(type1 : GenericClassType, type2 : GenericClassType)
       return type1 if type1 == type2
 
@@ -229,6 +222,21 @@ module Crystal
 
     def self.common_descendent(type1 : Type, type2 : GenericClassType)
       common_descendent_instance_and_generic(type1, type2)
+    end
+
+    # Given two types T and U, returns a common descendent V such that V <= T
+    # and V <= U. This is the same as:
+    #
+    # ```
+    # typeof(begin
+    #   x = uninitialized T
+    #   x.is_a?(U) ? x : raise ""
+    # end)
+    # ```
+    #
+    # except that `nil` is returned if the above produces `NoReturn`.
+    def self.common_descendent(type1 : Type, type2 : Type)
+      common_descendent_base(type1, type2)
     end
 
     private def self.common_descendent_base(type1, type2)


### PR DESCRIPTION
Fixes #12304

I moved `common_descendent(Type, Type)` to the bottom because otherwise it would catch types that I didn't want it to catch. This will probably be fixed once we sort methods after they've been defined, but right now it doesn't seem to work quite well (not that PR, just master.)

I'm also not sure I'm doing things correctly... every time I add an overload for `common_descendent(A, B)` I also add one for `common_descendent(B, A)` delegating to the other one. But I don't see that logic between every two types, so I'm not sure how it's currently working for every type 🤔 