### PR TITLE
Add missing fields to `LibC::Passwd` on FreeBSD

### DIFF
--- a/src/lib_c/x86_64-freebsd/c/pwd.cr
+++ b/src/lib_c/x86_64-freebsd/c/pwd.cr
@@ -4,9 +4,13 @@ lib LibC
     pw_passwd : Char*
     pw_uid : UidT
     pw_gid : GidT
+    pw_change : TimeT
+    pw_class : Char*
     pw_gecos : Char*
     pw_dir : Char*
     pw_shell : Char*
+    pw_expire : TimeT
+    pw_fields : Int
   end
 
   fun getpwnam_r(login : Char*, pwstore : Passwd*, buf : Char*, bufsize : SizeT, result : Passwd**) : Int


### PR DESCRIPTION
Add missing fields and fix failing spec/std/path_spec.cr spec.

Fixes #12314