### PR TITLE
Interpreter: take `with ... yield` scope into account for args bytesize

### DIFF
--- a/spec/compiler/interpreter/blocks_spec.cr
+++ b/spec/compiler/interpreter/blocks_spec.cr
@@ -532,6 +532,28 @@ describe Crystal::Repl::Interpreter do
       CODE
     end
 
+    it "counts with ... yield scope in block args bytesize (#12316)" do
+      interpret(<<-CODE).should eq(42)
+        class Object
+          def itself
+            self
+          end
+        end
+
+        def foo
+          bar(21, with 10 yield 8)
+        end
+
+        def bar(x, y)
+          x &* y
+        end
+
+        foo do |x|
+          itself &- x
+        end
+      CODE
+    end
+
     it "interprets yield with splat (1)" do
       interpret(<<-CODE).should eq((2 - 3) * 4)
         def foo

--- a/src/compiler/crystal/interpreter/compiler.cr
+++ b/src/compiler/crystal/interpreter/compiler.cr
@@ -2081,6 +2081,13 @@ class Crystal::Repl::Compiler < Crystal::Visitor
 
       block_args_bytesize = block.args.sum { |arg| aligned_sizeof_type(arg) }
 
+      # If it's `with ... yield` we pass the "with" scope
+      # as the first block argument, so we must count it too
+      # for the total blocks_args_bytesize.
+      if with_scope
+        block_args_bytesize += aligned_sizeof_type(with_scope)
+      end
+
       compiled_block = CompiledBlock.new(block,
         args_bytesize: block_args_bytesize,
         locals_bytesize_start: bytesize_before_block_local_vars,


### PR DESCRIPTION
Fixes #12316