### PR TITLE
Interpreter: inline ivar access for virtual call with a single child

### DIFF
--- a/spec/compiler/interpreter/classes_spec.cr
+++ b/spec/compiler/interpreter/classes_spec.cr
@@ -127,4 +127,36 @@ describe Crystal::Repl::Interpreter do
       CODE
     end
   end
+
+  it "inlines instance var access from virtual type with a single type (#39520)" do
+    interpret(<<-CODE).should eq(1)
+        struct Int32
+          def foo
+            1
+          end
+        end
+
+        struct Char
+          def foo
+            2
+          end
+        end
+
+        abstract class Expression
+        end
+
+        class ValueExpression < Expression
+          def initialize
+            @value = 1 || 'a'
+          end
+
+          def value
+            @value
+          end
+        end
+
+        expression = ValueExpression.new.as(Expression)
+        expression.value.foo
+      CODE
+  end
 end


### PR DESCRIPTION
Fixes #12320