### PR TITLE
Fix std/dir_spec.cr when current path contains symlinks.

### DIFF
--- a/spec/std/dir_spec.cr
+++ b/spec/std/dir_spec.cr
@@ -508,7 +508,7 @@ describe "Dir" do
   end
 
   it ".current" do
-    Dir.current.should eq(`#{{{ flag?(:win32) ? "cmd /c cd" : "pwd" }}}`.chomp)
+    Dir.current.should eq(`#{{{ flag?(:win32) ? "cmd /c cd" : "env pwd -P" }}}`.chomp)
   end
 
   describe ".tempdir" do


### PR DESCRIPTION
getcwd(3) always returns path with all symlinks resolved, but the spec calls
`pwd` shell builtin that returns a "logical" path that may contain
symlinks. Call `pwd` utility instead and pass "-P" to make sure that it
resolves symlinks and returns a "physical" path.

Fixes #12325