### PR TITLE
Interpreter: fix `as?` when there's no resulting type

### DIFF
--- a/spec/compiler/interpreter/casts_spec.cr
+++ b/spec/compiler/interpreter/casts_spec.cr
@@ -345,5 +345,15 @@ describe Crystal::Repl::Interpreter do
         end
         CODE
     end
+
+    it "does as? with no resulting type, not from nil (#12327)" do
+      interpret(<<-CODE).should eq(42)
+        if 1.as?(String)
+          0
+        else
+          42
+        end
+        CODE
+    end
   end
 end

--- a/spec/compiler/interpreter/casts_spec.cr
+++ b/spec/compiler/interpreter/casts_spec.cr
@@ -335,5 +335,15 @@ describe Crystal::Repl::Interpreter do
         end
       CODE
     end
+
+    it "does as? with no resulting type (#12327)" do
+      interpret(<<-CODE).should eq(42)
+        if nil.as?(Int32)
+          0
+        else
+          42
+        end
+        CODE
+    end
   end
 end

--- a/src/compiler/crystal/interpreter/compiler.cr
+++ b/src/compiler/crystal/interpreter/compiler.cr
@@ -1606,13 +1606,13 @@ class Crystal::Repl::Compiler < Crystal::Visitor
   end
 
   def visit(node : NilableCast)
-    node.obj.accept self
-
     obj_type = node.obj.type
     to_type = node.to.type.virtual_type
 
     # TODO: check the proper conditions in codegen
     if obj_type == to_type
+      node.obj.accept self
+
       return false
     end
 
@@ -1620,9 +1620,12 @@ class Crystal::Repl::Compiler < Crystal::Visitor
     unless filtered_type
       # If .as?(...) has no resulting type we must cast
       # whatever type we have to nil.
+      discard_value node.obj
       upcast node.obj, @context.program.nil_type, node.type
       return false
     end
+
+    node.obj.accept self
 
     # Check if obj is a `to_type`
     dup aligned_sizeof_type(node.obj), node: nil

--- a/src/compiler/crystal/interpreter/compiler.cr
+++ b/src/compiler/crystal/interpreter/compiler.cr
@@ -1606,7 +1606,6 @@ class Crystal::Repl::Compiler < Crystal::Visitor
   end
 
   def visit(node : NilableCast)
-    # TODO: not tested
     node.obj.accept self
 
     obj_type = node.obj.type
@@ -1614,29 +1613,37 @@ class Crystal::Repl::Compiler < Crystal::Visitor
 
     # TODO: check the proper conditions in codegen
     if obj_type == to_type
-      nop
-    else
-      # Check if obj is a `to_type`
-      dup aligned_sizeof_type(node.obj), node: nil
-      is_a(node, obj_type, to_type)
-
-      # If so, branch
-      branch_if 0, node: nil
-      cond_jump_location = patch_location
-
-      # Otherwise it's nil
-      put_nil node: nil
-      pop aligned_sizeof_type(node.obj), node: nil
-      upcast node.obj, @context.program.nil_type, node.type
-      jump 0, node: nil
-      otherwise_jump_location = patch_location
-
-      patch_jump(cond_jump_location)
-      downcast node.obj, obj_type, to_type
-      upcast node.obj, to_type, node.type
-
-      patch_jump(otherwise_jump_location)
+      return false
     end
+
+    filtered_type = obj_type.filter_by(to_type)
+    unless filtered_type
+      # If .as?(...) has no resulting type we must cast
+      # whatever type we have to nil.
+      upcast node.obj, @context.program.nil_type, node.type
+      return false
+    end
+
+    # Check if obj is a `to_type`
+    dup aligned_sizeof_type(node.obj), node: nil
+    filter_type(node, obj_type, filtered_type)
+
+    # If so, branch
+    branch_if 0, node: nil
+    cond_jump_location = patch_location
+
+    # Otherwise it's nil
+    put_nil node: nil
+    pop aligned_sizeof_type(node.obj), node: nil
+    upcast node.obj, @context.program.nil_type, node.type
+    jump 0, node: nil
+    otherwise_jump_location = patch_location
+
+    patch_jump(cond_jump_location)
+    downcast node.obj, obj_type, to_type
+    upcast node.obj, to_type, node.type
+
+    patch_jump(otherwise_jump_location)
 
     false
   end


### PR DESCRIPTION
Fixes #12327

The code was using `is_a` which required the filtered type to be not-nil. I checked codegen.cr and for a nilable cast the filtered type can be nil, and the logic is a bit different there. So I did the same here, essentially inlining part of the `is_a` method, but first doing a special logic if the filtered type is nil.

I also changed the code a bit to do an early return.