### PR TITLE
Allow `Union` restrictions to be ordered before all other restrictions

### DIFF
--- a/spec/compiler/semantic/restrictions_spec.cr
+++ b/spec/compiler/semantic/restrictions_spec.cr
@@ -495,6 +495,61 @@ describe "Restrictions" do
           )) { tuple_of([int32, bool]) }
       end
     end
+
+    describe "Union" do
+      it "handles redefinitions (1) (#12330)" do
+        assert_type(<<-CR) { bool }
+          def foo(x : Int32 | String)
+            'a'
+          end
+
+          def foo(x : ::Int32 | String)
+            true
+          end
+
+          foo(1)
+          CR
+      end
+
+      it "handles redefinitions (2) (#12330)" do
+        assert_type(<<-CR) { bool }
+          def foo(x : Int32 | String)
+            'a'
+          end
+
+          def foo(x : String | Int32)
+            true
+          end
+
+          foo(1)
+          CR
+      end
+
+      it "orders union before generic (#12330)" do
+        assert_type(<<-CR) { bool }
+          module Foo(T)
+          end
+
+          class Bar1
+            include Foo(Int32)
+          end
+
+          class Bar2
+            include Foo(Int32)
+          end
+
+          def foo(x : Foo(Int32))
+            'a'
+          end
+
+          def foo(x : Bar1 | Bar2)
+            true
+          end
+
+          foo(Bar1.new)
+          CR
+      end
+    end
   end
 
   it "self always matches instance type in restriction" do

--- a/src/compiler/crystal/semantic/restrictions.cr
+++ b/src/compiler/crystal/semantic/restrictions.cr
@@ -287,10 +287,10 @@ module Crystal
   end
 
   class Union
-    def restriction_of?(other : Path, owner)
-      # For a union to be considered before a path,
+    def restriction_of?(other, owner)
+      # For a union to be considered before another restriction,
       # all types in the union must be considered before
-      # that path.
+      # that restriction.
       # For example when using all subtypes of a parent type.
       types.all? &.restriction_of?(other, owner)
     end


### PR DESCRIPTION
Fixes #12330.

A `Union` restriction is ordered before a `Path` restriction if all union members are ordered before that `Path`, and always ordered before the `_` restriction, otherwise the compiler falls back to syntactic identity. This means in each of the following pairs, the second overload is currently not ordered before the first overload:

```crystal
# original issue
# note: also redefinition
def foo(x : Int32 | String); end
def foo(x : ::Int32 | String); end

# note: also redefinition
def foo(x : Int32 | String); end
def foo(x : String | Int32); end

def foo(x : Int | String); end
def foo(x : Int32 | String); end

def foo(x : Enumerable(Int32)); end
def foo(x : Array(Int32) | Slice(Int32)); end

def foo(x : Reference.class); end
def foo(x : String.class | Regex.class); end
```

Those overload sets will be correct after this PR.