### PR TITLE
Don't count failed signature matches as autocast matches

### DIFF
--- a/spec/compiler/semantic/automatic_cast_spec.cr
+++ b/spec/compiler/semantic/automatic_cast_spec.cr
@@ -106,6 +106,16 @@ describe "Semantic: automatic cast" do
       )) { int64 }
   end
 
+  it "casts literal integer through union" do
+    assert_type(%(
+      def foo(x : Int64 | String)
+        x
+      end
+
+      foo(12345)
+      )) { int64 }
+  end
+
   it "casts literal integer through alias with union" do
     assert_type(%(
       alias A = Int64 | String
@@ -115,6 +125,30 @@ describe "Semantic: automatic cast" do
       end
 
       foo(12345)
+      )) { int64 }
+  end
+
+  it "casts literal integer through self restriction" do
+    assert_type(%(
+      struct Int64
+        def self.foo(x : self)
+          x
+        end
+      end
+
+      Int64.foo(12345)
+      )) { int64 }
+  end
+
+  it "casts literal integer through generic type argument" do
+    assert_type(%(
+      class Foo(T)
+        def foo(x : T)
+          x
+        end
+      end
+
+      Foo(Int64).new.foo(12345)
       )) { int64 }
   end
 
@@ -177,7 +211,23 @@ describe "Semantic: automatic cast" do
       )) { types["Foo"] }
   end
 
-  it "casts literal integer through alias with union" do
+  it "casts symbol literal through union" do
+    assert_type(%(
+      enum Foo
+        One
+        Two
+        Three
+      end
+
+      def foo(x : Foo | String)
+        x
+      end
+
+      foo(:two)
+      )) { types["Foo"] }
+  end
+
+  it "casts symbol literal through alias with union" do
     assert_type(%(
       enum Foo
         One
@@ -449,6 +499,62 @@ describe "Semantic: automatic cast" do
       a + :red
       ),
       "no overload matches"
+  end
+
+  it "doesn't say 'ambiguous call' when only one exact match exists" do
+    assert_type(%(
+      def foo(x : Int8, y : Char)
+        true
+      end
+
+      def foo(x : UInt8, y : String)
+        1.5
+      end
+
+      foo(1, 'a')
+      )) { bool }
+  end
+
+  it "doesn't say 'ambiguous call' when only one exact match exists (2)" do
+    assert_type(%(
+      def foo(x : Char, y : Int8)
+        true
+      end
+
+      def foo(x : String, y : UInt8)
+        1.5
+      end
+
+      foo('a', 1)
+      )) { bool }
+  end
+
+  it "doesn't say 'ambiguous call' when only one exact match exists (3)" do
+    assert_type(%(
+      def foo(x : Int8, y : Char)
+        true
+      end
+
+      def foo(x : UInt8, y : String)
+        1.5
+      end
+
+      foo(y: 'a', x: 1)
+      )) { bool }
+  end
+
+  it "doesn't say 'ambiguous call' when only one exact match exists (4)" do
+    assert_type(%(
+      def foo(x : Char, y : Int8)
+        true
+      end
+
+      def foo(x : String, y : UInt8)
+        1.5
+      end
+
+      foo(y: 1, x: 'a')
+      )) { bool }
   end
 
   it "can use automatic cast with `with ... yield` (#7736)" do

--- a/src/compiler/crystal/semantic/main_visitor.cr
+++ b/src/compiler/crystal/semantic/main_visitor.cr
@@ -911,7 +911,13 @@ module Crystal
     def self.check_automatic_cast(program, value, var_type, assign = nil)
       if value.is_a?(NumberLiteral) && value.type != var_type
         literal_type = NumberAutocastType.new(program, value)
-        restricted = literal_type.restrict(var_type, MatchContext.new(value.type, value.type))
+        context = MatchContext.new(value.type, value.type, autocast_allowed: true)
+        restricted = literal_type.restrict(var_type, context)
+        if restricted && var_type
+          literal_type.add_autocast_matches(var_type, context)
+          restricted = literal_type.match || restricted
+        end
+
         if restricted.is_a?(IntegerType) || restricted.is_a?(FloatType)
           value.type = restricted
           value.kind = restricted.kind
@@ -920,7 +926,13 @@ module Crystal
         end
       elsif value.is_a?(SymbolLiteral) && value.type != var_type
         literal_type = SymbolAutocastType.new(program, value)
-        restricted = literal_type.restrict(var_type, MatchContext.new(value.type, value.type))
+        context = MatchContext.new(value.type, value.type, autocast_allowed: true)
+        restricted = literal_type.restrict(var_type, context)
+        if restricted && var_type
+          literal_type.add_autocast_matches(var_type, context)
+          restricted = literal_type.match || restricted
+        end
+
         if restricted.is_a?(EnumType)
           member = restricted.find_member(value.value).not_nil!
           path = Path.new(member.name)

--- a/src/compiler/crystal/semantic/match.cr
+++ b/src/compiler/crystal/semantic/match.cr
@@ -49,7 +49,9 @@ module Crystal
     # Def free variables, unbound (`def (X, Y) ...`)
     property def_free_vars : Array(String)?
 
-    def initialize(@instantiated_type, @defining_type, @free_vars = nil, @def_free_vars = nil)
+    getter? autocast_allowed : Bool
+
+    def initialize(@instantiated_type, @defining_type, @free_vars = nil, @def_free_vars = nil, @autocast_allowed = false)
     end
 
     def get_free_var(name)
@@ -91,7 +93,7 @@ module Crystal
     end
 
     def clone
-      MatchContext.new(@instantiated_type, @defining_type, @free_vars.dup, @def_free_vars.dup)
+      MatchContext.new(@instantiated_type, @defining_type, @free_vars.dup, @def_free_vars.dup, @autocast_allowed)
     end
   end
 

--- a/src/compiler/crystal/semantic/restrictions.cr
+++ b/src/compiler/crystal/semantic/restrictions.cr
@@ -1367,30 +1367,146 @@ module Crystal
       false
     end
 
+    def compatible_with?(type)
+      matches_exactly?(type) || matches_partially?(type)
+    end
+
     def restrict(other, context)
-      if other.is_a?(Type)
-        if matches_exactly?(other)
-          set_exact_match(other)
-          return other
-        elsif !exact_match? && matches_partially?(other)
-          add_match(other)
-          return other
+      if restricted = literal.type.restrict(other, context)
+        return restricted.remove_literal
+      end
+
+      return nil unless context.autocast_allowed?
+      restricted, _ = restrict_with_autocast(other, context)
+      restricted.try(&.remove_literal)
+    end
+
+    # Returns two values: the result of restricting `self` against the given AST
+    # node or type, and whether the result is an exact match. An exact match has
+    # higher priority over partial matches.
+    # Note that at this point we don't need to consider non-autocasting matches.
+    private def restrict_with_autocast(other : ASTNode, context)
+      {nil, false}
+    end
+
+    private def restrict_with_autocast(other : Type, context)
+      if matches_exactly?(other)
+        {other, true}
+      elsif matches_partially?(other)
+        {other, false}
+      else
+        {nil, false}
+      end
+    end
+
+    private def restrict_with_autocast(other : Nil, context)
+      # lack of restrictions
+      {literal.type, false}
+    end
+
+    private def restrict_with_autocast(other : Self, context)
+      restrict_with_autocast(context.instantiated_type.instance_type, context)
+    end
+
+    private def restrict_with_autocast(other : Path, context)
+      if type = context.defining_type.lookup_path(other)
+        restrict_with_autocast(type, context)
+      else
+        {nil, false}
+      end
+    end
+
+    private def restrict_with_autocast(other : Arg, context)
+      restrict_with_autocast(other.type? || other.restriction, context)
+    end
+
+    # Given `x : T | U | ...`, if one of these variant types produces an exact
+    # match, we ignore the other variant types
+    private def restrict_with_autocast(other : Union, context)
+      types = [] of Type
+
+      other.types.each do |union_type|
+        restricted, exact = restrict_with_autocast(union_type, context)
+        if restricted
+          return {restricted, true} if exact
+          types << restricted
         end
       end
 
-      literal_type = literal.type?
-      type = literal_type.try(&.restrict(other, context)) || super(other, context)
-      if type == self
-        # if *other* is an AST node (e.g. `Path`) or a complex type (e.g.
-        # `UnionType`), `@match` may be set from recursive calls to `#restrict`,
-        # so we propagate any exact matches found during those calls
-        type = @match || literal_type
-      end
-      type
+      {types.size > 0 ? program.type_merge_union_of(types) : nil, false}
     end
 
-    def compatible_with?(type)
-      matches_exactly?(type) || matches_partially?(type)
+    private def restrict_with_autocast(other : UnionType, context)
+      types = [] of Type
+
+      other.union_types.each do |union_type|
+        restricted, exact = restrict_with_autocast(union_type, context)
+        if restricted
+          return {restricted, true} if exact
+          types << restricted
+        end
+      end
+
+      {types.size > 0 ? program.type_merge_union_of(types) : nil, false}
+    end
+
+    private def restrict_with_autocast(other : AliasType, context)
+      aliased_type = other.remove_alias
+      if aliased_type != other
+        restrict_with_autocast(aliased_type, context)
+      else
+        # recursive alias
+        {nil, false}
+      end
+    end
+
+    # Updates `self` to indicate that an exact or partial autocast match has
+    # been found.
+    #
+    # This used to be part of `#restrict`; it is now called separately on all
+    # autocast call arguments after the entire call matches.
+    def add_autocast_matches(other : Type, context)
+      if matches_exactly?(other)
+        set_exact_match(other)
+      elsif !exact_match? && matches_partially?(other)
+        add_match(other)
+      end
+    end
+
+    def add_autocast_matches(other : ASTNode, context)
+    end
+
+    def add_autocast_matches(other : Self, context)
+      add_autocast_matches(context.instantiated_type.instance_type, context)
+    end
+
+    def add_autocast_matches(other : Path, context)
+      if type = context.defining_type.lookup_path(other)
+        add_autocast_matches(type, context)
+      end
+    end
+
+    def add_autocast_matches(other : Arg, context)
+      if restriction = other.type? || other.restriction
+        add_autocast_matches(restriction, context)
+      end
+    end
+
+    def add_autocast_matches(other : Union, context)
+      other.types.each do |union_type|
+        add_autocast_matches(union_type, context)
+      end
+    end
+
+    def add_autocast_matches(other : UnionType, context)
+      other.union_types.each do |union_type|
+        add_autocast_matches(union_type, context)
+      end
+    end
+
+    def add_autocast_matches(other : AliasType, context)
+      aliased_type = other.remove_alias
+      add_autocast_matches(aliased_type, context) unless aliased_type == other
     end
   end
 


### PR DESCRIPTION
Supersedes #10701. The following description is adopted from that PR.

Consider the following:

```crystal
def foo(x : Int8, y : Char); end
def foo(x : UInt8, y : String); end

foo(1, 'a')       # Error: ambiguous call, implicit cast of 1 matches all of Int8, UInt8
foo(y: 'a', x: 1) # okay

def bar(x : Char, y : Int8); end
def bar(x : String, y : UInt8); end

bar('a', 1)       # okay
bar(y: 1, x: 'a') # Error: ambiguous call, implicit cast of 1 matches all of Int8, UInt8
```

Each overload set is checked in that order, because neither overload is more restricted than the other. What happens here is:

* Neither overload matches when autocasting is disabled.
* Method lookup is repeated with autocasting enabled, and proceeds to check argument compatibility following argument order.
* `1` successfully matches `Int8` because `1` is within `Int8`'s range. The compiler adds this to a list of partial autocast matches.
* `'a'` successfully matches `Char`, so there is a successful signature match. But the compiler must also check other defs to detect ambiguous autocasts.
* `1` successfully matches `UInt8` because `1` is within `UInt8`'s range. The partial autocast match list now contains both integer types.
* `'a'` does not match `String`, so this signature match fails, but the compiler does not reset the list of partial autocast matches. Thus `1` is considered to be ambiguous, even though the `UInt8` autocast match is associated with a call that fails.

This PR makes it so that autocast matches are added only after a signature match succeeds completely (with `AutocastType#add_autocast_matches`). Thus the autocasting behavior is no longer dependent on the argument order, and both error calls above become unambiguous:

```crystal
def foo(x : Int8, y : Char); end
def foo(x : UInt8, y : String); end

foo(1, 'a') # okay, matches first overload

def bar(x : Char, y : Int8); end
def bar(x : String, y : UInt8); end

bar('a', 1) # okay, matches first overload
```

Does not fix https://github.com/crystal-lang/crystal/pull/8600#pullrequestreview-334682026, since in that case all signature matches succeed.

Note that splat restrictions never autocast:

```crystal
def foo(*x : *{Int8}); end

foo(1) # Error: no overload matches
```

So two of the calls to `Crystal::Type#restrict` inside `Crystal::CallSignature#match` are not associated with any autocast checks.