### PR TITLE
Use `Makefile.win` and wrapper script on Windows CI

### DIFF
--- a/.github/workflows/win.yml
+++ b/.github/workflows/win.yml
@@ -306,29 +306,26 @@ jobs:
 
       - name: Set up environment
         run: |
-          echo "CRYSTAL_PATH=lib;$(pwd)\src" >> ${env:GITHUB_ENV}
           echo "CRYSTAL_LIBRARY_PATH=$(pwd)\libs" >> ${env:GITHUB_ENV}
-          echo 'CRYSTAL_CONFIG_PATH=$ORIGIN\src' >> ${env:GITHUB_ENV}
-          echo 'CRYSTAL_CONFIG_LIBRARY_PATH=$ORIGIN\lib' >> ${env:GITHUB_ENV}
+          echo "CRYSTAL_SPEC_COMPILER_BIN=$(pwd)\.build\crystal.exe" >> ${env:GITHUB_ENV}
           echo "LLVM_CONFIG=$(pwd)\llvm\bin\llvm-config.exe" >> ${env:GITHUB_ENV}
-          echo "CRYSTAL_CONFIG_BUILD_COMMIT=$(git rev-parse --short=9 HEAD)" >> ${env:GITHUB_ENV}
-          echo "SOURCE_DATE_EPOCH=$(Get-Date -Millisecond 0 -UFormat %s)" >> ${env:GITHUB_ENV}
 
       - name: Download Crystal object file
         uses: actions/download-artifact@v2
         with:
           name: objs
       - name: Build LLVM extensions
-        run: |
-          cl /MT /c src\llvm\ext\llvm_ext.cc -I llvm\include /Fosrc\llvm\ext\llvm_ext.obj
+        run: make -f Makefile.win deps
       - name: Link Crystal executable
         run: |
-          Invoke-Expression "cl crystal.obj /Fecrystal-cross src\llvm\ext\llvm_ext.obj $(llvm\bin\llvm-config.exe --libs) libs\pcre.lib libs\gc.lib WS2_32.lib advapi32.lib libcmt.lib dbghelp.lib ole32.lib shell32.lib legacy_stdio_definitions.lib /link /LIBPATH:$(pwd)\libs /STACK:0x800000"
+          Invoke-Expression "cl crystal.obj /Fecrystal src\llvm\ext\llvm_ext.obj $(llvm\bin\llvm-config.exe --libs) libs\pcre.lib libs\gc.lib WS2_32.lib advapi32.lib libcmt.lib dbghelp.lib ole32.lib shell32.lib legacy_stdio_definitions.lib /link /LIBPATH:$(pwd)\libs /STACK:0x800000 /ENTRY:wmainCRTStartup"
+          mkdir .build
+          mv crystal.exe .build/
 
       - name: Re-build Crystal
         run: |
-          .\crystal-cross.exe build src/compiler/crystal.cr -Di_know_what_im_doing -Dwithout_playground -Dwithout_interpreter
-          mv crystal.exe bin/
+          bin/crystal.bat env
+          make -f Makefile.win -B
 
       - name: Download shards release
         uses: actions/checkout@v2
@@ -346,13 +343,13 @@ jobs:
 
       - name: Build shards release
         working-directory: ./shards
-        run: ../bin/crystal.exe build src/shards.cr
+        run: ../bin/crystal.bat build src/shards.cr
 
       - name: Gather Crystal binaries
         run: |
           mkdir crystal/src
           mkdir crystal/lib
-          cp bin/crystal.exe crystal/
+          cp .build/crystal.exe crystal/
           cp shards/shards.exe crystal/
           cp libs/* crystal/lib/
           cp src/* crystal/src -Recurse
@@ -364,26 +361,11 @@ jobs:
           name: crystal
           path: crystal
 
-      - name: Build stdlib specs executable
-        run: |
-          bin\crystal.exe build spec/std_spec.cr --exclude-warnings spec/std -Di_know_what_im_doing
-      - name: Run socket specs
-        run: |
-          .\std_spec.exe --verbose -e TCPSocket
       - name: Run stdlib specs
-        run: |
-          .\std_spec.exe
+        run: make -f Makefile.win std_spec
 
-      - name: Build compiler specs executable
-        run: |
-          bin\crystal.exe build spec/compiler_spec.cr --exclude-warnings spec/compiler -Dwithout_playground -Dwithout_interpreter -Di_know_what_im_doing
       - name: Run compiler specs
-        run: |
-          .\compiler_spec.exe
+        run: make -f Makefile.win compiler_spec
 
-      - name: Build primitives specs executable
-        run: |
-          bin\crystal.exe build spec/primitives_spec.cr --exclude-warnings spec/primitives -Dwithout_playground -Di_know_what_im_doing
       - name: Run primitives specs
-        run: |
-          .\primitives_spec.exe
+        run: make -f Makefile.win primitives_spec

--- a/spec/std/spec_helper.cr
+++ b/spec/std/spec_helper.cr
@@ -78,7 +78,11 @@ end
 def compile_file(source_file, *, bin_name = "executable_file", flags = %w(), file = __FILE__)
   with_temp_executable(bin_name, file: file) do |executable_file|
     compiler = ENV["CRYSTAL_SPEC_COMPILER_BIN"]? || "bin/crystal"
-    Process.run(compiler, ["build"] + flags + ["-o", executable_file, source_file])
+    Process.run(compiler, ["build"] + flags + ["-o", executable_file, source_file], env: {
+      "CRYSTAL_PATH"         => Crystal::PATH,
+      "CRYSTAL_LIBRARY_PATH" => Crystal::LIBRARY_PATH,
+      "CRYSTAL_CACHE_DIR"    => Crystal::CACHE_DIR,
+    }, error: Process::Redirect::Inherit)
     File.exists?(executable_file).should be_true
 
     yield executable_file


### PR DESCRIPTION
This PR simplifies the Windows CI workflow a bit by using the recently introduced `Makefile.win` and the `bin\crystal.ps1` script. 

Consequently, `-Dwithout_playground` is no longer used when building the compiler specs. This enables 40 new passing examples. (They stub out `HTTP::WebSocket` so no concurrency or networking capability is actually needed.)