### PR TITLE
Compiler: a generic class type can also be reference-like

### DIFF
--- a/src/compiler/crystal/codegen/cast.cr
+++ b/src/compiler/crystal/codegen/cast.cr
@@ -301,14 +301,6 @@ class Crystal::CodeGenVisitor
     value
   end
 
-  def downcast_distinct(value, to_type : MixedUnionType, from_type : VirtualType)
-    # This happens if the restriction is a union:
-    # we keep each of the union types as the result, we don't fully merge
-    union_ptr = alloca llvm_type(to_type)
-    store_in_union to_type, union_ptr, from_type, value
-    union_ptr
-  end
-
   def downcast_distinct(value, to_type : ReferenceUnionType, from_type : VirtualType)
     # This happens if the restriction is a union:
     # we keep each of the union types as the result, we don't fully merge

--- a/src/compiler/crystal/types.cr
+++ b/src/compiler/crystal/types.cr
@@ -96,6 +96,8 @@ module Crystal
         true
       when NonGenericClassType
         !self.struct?
+      when GenericClassType
+        !self.struct?
       when GenericClassInstanceType
         !self.struct?
       when VirtualType

--- a/src/compiler/crystal/types.cr
+++ b/src/compiler/crystal/types.cr
@@ -2686,7 +2686,7 @@ module Crystal
     end
 
     delegate remove_typedef, pointer?, defs,
-      macros, reference_link?, parents, to: typedef
+      macros, reference_like?, parents, to: typedef
 
     def remove_indirection
       self


### PR DESCRIPTION
This fixes #12342 . I couldn't reduce the example, but I noticed that something in the compiler didn't make sense.

There's the concept of "cast" or "downcast". For example, if we have a variable of type `Int32 | String` and we do `if x.is_a?(Int32); x + 1; end` what happens is that the type is narrowed down from a union type to another type.

What happened in the example above is that for some reason a virtual class type was downcast to a mixed union type. A mixed union type is a union where at least one of the members isn't a reference type. There's also `ReferenceUnionType` when all of the members are reference types.

But going from a virtual class type to something that's not all reference-like type doesn't make sense. The reason was that a case was missing: considering uninstantiated generic types as reference-like types, if they were defined using the `class` keyword.

But we'll see. My hope is that CI will be green with this change. As an added benefit, this should be a bit more optimal in some cases.

If CI is red... I'll check what went wrong.