### PR TITLE
Interpreter: use non_nilable_type in NilableCast

### DIFF
--- a/spec/compiler/interpreter/casts_spec.cr
+++ b/spec/compiler/interpreter/casts_spec.cr
@@ -355,5 +355,21 @@ describe Crystal::Repl::Interpreter do
         end
         CODE
     end
+
+    it "does as? with a type that can't match (#12346)" do
+      interpret(<<-CODE).should eq(1)
+        abstract class A
+        end
+
+        class B < A
+        end
+
+        class C < A
+        end
+
+        a = B.new || C.new
+        a.as?(B | Int32) ? 1 : 2
+        CODE
+    end
   end
 end

--- a/src/compiler/crystal/interpreter/compiler.cr
+++ b/src/compiler/crystal/interpreter/compiler.cr
@@ -1641,8 +1641,8 @@ class Crystal::Repl::Compiler < Crystal::Visitor
     otherwise_jump_location = patch_location
 
     patch_jump(cond_jump_location)
-    downcast node.obj, obj_type, to_type
-    upcast node.obj, to_type, node.type
+    downcast node.obj, obj_type, node.non_nilable_type
+    upcast node.obj, node.non_nilable_type, node.type
 
     patch_jump(otherwise_jump_location)
 


### PR DESCRIPTION
Fixes #12346

I forgot `NilableCast` has a `non_nilable_type` property that's currently used in codegen, but not in the interpreter. This makes the interpreter use it.

Essentially, the in a code like this:

```crystal
(1 || "a").as?(Int32 | Char)
```

we have these types:
- (Int32 | String) is the type of (1 || "a")
- (Int32 | Char) is the type of the restriction
- (Int32 | Nil) is the resulting type

The type `Int32 | Char` doesn't appear at all in the resulting code. What we need to do is go from `Int32 | String` to `Int32` (this is non-nilable type), then go from `Int32` to `Int32 | Nil`.