### PR TITLE
Interpreter: implement mixed union cast with compatible tuple types

### DIFF
--- a/spec/compiler/interpreter/casts_spec.cr
+++ b/spec/compiler/interpreter/casts_spec.cr
@@ -371,5 +371,86 @@ describe Crystal::Repl::Interpreter do
         a.as?(B | Int32) ? 1 : 2
         CODE
     end
+
+    it "upcasts mixed union with tuple to mixed union with compatible tuple (1) (#12331)" do
+      interpret(<<-CODE).should eq(1)
+        class Foo
+          def initialize(@tuple : Tuple(Int32?) | Tuple(Int32, Int32))
+          end
+
+          def tuple
+            @tuple
+          end
+        end
+
+        a = {1} || {1, 1}
+        foo = Foo.new(a)
+        tuple = foo.tuple
+        if tuple.is_a?(Tuple(Int32?))
+          value = tuple[0]
+          if value
+            value
+          else
+            2
+          end
+        else
+          3
+        end
+      CODE
+    end
+
+    it "upcasts mixed union with tuple to mixed union with compatible tuple (2) (#12331)" do
+      interpret(<<-CODE).should eq(2)
+        class Foo
+          def initialize(@tuple : Tuple(Int32?) | Tuple(Int32, Int32))
+          end
+
+          def tuple
+            @tuple
+          end
+        end
+
+        a = {nil} || {1, 1}
+        foo = Foo.new(a)
+        tuple = foo.tuple
+        if tuple.is_a?(Tuple(Int32?))
+          value = tuple[0]
+          if value
+            value
+          else
+            2
+          end
+        else
+          3
+        end
+      CODE
+    end
+
+    it "upcasts mixed union with tuple to mixed union with compatible tuple (3) (#12331)" do
+      interpret(<<-CODE).should eq(3)
+        class Foo
+          def initialize(@tuple : Tuple(Int32?) | Tuple(Int32, Int32))
+          end
+
+          def tuple
+            @tuple
+          end
+        end
+
+        a = {1, 1} || {1}
+        foo = Foo.new(a)
+        tuple = foo.tuple
+        if tuple.is_a?(Tuple(Int32?))
+          value = tuple[0]
+          if value
+            value
+          else
+            2
+          end
+        else
+          3
+        end
+      CODE
+    end
   end
 end

--- a/src/compiler/crystal/interpreter/cast.cr
+++ b/src/compiler/crystal/interpreter/cast.cr
@@ -35,8 +35,44 @@ class Crystal::Repl::Compiler
       needs_value_cast_inside_union?(from_element, to)
     end
 
-    if needs_union_value_cast # Compute the values that need a cast
-      node.raise "BUG: missing mixed union upcast from #{from} to #{to}"
+    if needs_union_value_cast
+      # Compute the values that need a cast
+      types_needing_cast = from.union_types.select do |union_type|
+        needs_value_cast_inside_union?(union_type, to)
+      end
+
+      end_jumps = [] of Int32
+
+      types_needing_cast.each do |type_needing_cast|
+        # Find compatible type
+        compatible_type = to.union_types.find! { |union_type| type_needing_cast.implements?(union_type) }
+
+        # Get the type id of the "from" union
+        from_type_id = get_union_type_id(aligned_sizeof_type(from), node: node)
+
+        # Check if `from_type_id` is the same as `type_needing_cast`
+        put_i32 type_id(type_needing_cast), node: node
+        cmp_i32 node: node
+        cmp_eq node: node
+
+        # If they are not the same, continue
+        branch_unless 0, node: nil
+        cond_jump_location = patch_location
+
+        # We need to upcast from type_needing_cast to compatible_type
+        upcast(node, type_needing_cast, compatible_type)
+
+        # Then we need to set the correct union type id
+        put_union_type_id(type_id(compatible_type), aligned_sizeof_type(to), node: node)
+
+        # Then jump to the end
+        jump 0, node: nil
+        end_jumps << patch_location
+
+        # The unless above should jump here, which is the start
+        # of the next if, or just the end
+        patch_jump(cond_jump_location)
+      end
     end
 
     # Putting a smaller union type inside a bigger one is just extending the value
@@ -44,6 +80,15 @@ class Crystal::Repl::Compiler
 
     if difference > 0
       push_zeros(difference, node: nil)
+    end
+
+    # If needs_union_value_cast was true, we have a bunch of
+    # if .. then that need to jump to the end of everything.
+    # Here we do that.
+    if end_jumps
+      end_jumps.each do |end_jump|
+        patch_jump(end_jump)
+      end
     end
   end
 

--- a/src/compiler/crystal/interpreter/instructions.cr
+++ b/src/compiler/crystal/interpreter/instructions.cr
@@ -1285,7 +1285,7 @@ require "./repl"
       },
       # >>> Allocate (2)
 
-      # <<< Unions (5)
+      # <<< Unions (7)
       put_in_union: {
         operands:   [type_id : Int32, from_size : Int32, union_size : Int32],
         code:       begin
@@ -1369,7 +1369,17 @@ require "./repl"
           value
         end,
       },
-      # >>> Unions (5)
+      get_union_type_id: {
+        operands:   [union_size : Int32],
+        push:       true,
+        code:       (stack - union_size).as(Int32*).value,
+      },
+      put_union_type_id: {
+        operands:   [type_id : Int32, union_size : Int32],
+        push:       false,
+        code:       (stack - union_size).as(Int32*).value = type_id,
+      },
+      # >>> Unions (7)
 
       # <<< is_a? (3)
       reference_is_a: {


### PR DESCRIPTION
Fixes #12331

There's a similar TODO in the code for the case of `downcast`, but I'll do that in a separate PR once I find code to reproduce it. I also think that other case is slightly different so it might need a different code, we'll see.