### PR TITLE
Fix `Class#nilable?` for recursive unions and root types

### DIFF
--- a/spec/std/class_spec.cr
+++ b/spec/std/class_spec.cr
@@ -18,6 +18,8 @@ private class ClassWithRedefinedName
   end
 end
 
+private alias RecursiveNilableType = Array(RecursiveNilableType)?
+
 describe Class do
   it "does ===" do
     (Int32 === 1).should be_true
@@ -49,11 +51,17 @@ describe Class do
     Int32.clone.should eq(Int32)
   end
 
-  it "#nilable" do
+  it "#nilable?" do
     Int32.nilable?.should be_false
     Nil.nilable?.should be_true
     (Int32 | String).nilable?.should be_false
     Int32?.nilable?.should be_true
+    NoReturn.nilable?.should be_false
+    Reference.nilable?.should be_false
+    Value.nilable?.should be_true
+    Class.nilable?.should be_false
+    Object.nilable?.should be_true
+    RecursiveNilableType.nilable?.should be_true
   end
 
   it "does to_s" do

--- a/src/class.cr
+++ b/src/class.cr
@@ -135,14 +135,18 @@ class Class
     typeof(t, u)
   end
 
-  # Returns `true` if this class is `Nil`.
+  # Returns `true` if `nil` is an instance of this type.
   #
   # ```
-  # Int32.nilable? # => false
-  # Nil.nilable?   # => true
+  # Int32.nilable?            # => false
+  # Nil.nilable?              # => true
+  # (Int32 | String).nilable? # => false
+  # (Int32 | Nil).nilable?    # => true
+  # NoReturn.nilable?         # => false
+  # Value.nilable?            # => true
   # ```
   def nilable? : Bool
-    self == ::Nil
+    {{ @type >= Nil }}
   end
 
   def to_s(io : IO) : Nil

--- a/src/union.cr
+++ b/src/union.cr
@@ -17,13 +17,4 @@
 # Union(Int32, Int32, Int32) # => Int32
 # ```
 struct Union
-  # Returns `true` if this union includes the `Nil` type.
-  #
-  # ```
-  # (Int32 | String).nilable? # => false
-  # (Int32 | Nil).nilable?    # => true
-  # ```
-  def self.nilable?
-    {{ T.any? &.==(::Nil) }}
-  end
 end


### PR DESCRIPTION
Fixes #6447. Does not affect the macro method `TypeNode#nilable?`. Also does not affect the compiler's notion of a nilable type (which uses instead `Type#includes_type?(NilType)`).