### PR TITLE
Playground: Fix pass bound hostname to run sessions

### DIFF
--- a/src/compiler/crystal/tools/playground/server.cr
+++ b/src/compiler/crystal/tools/playground/server.cr
@@ -471,8 +471,6 @@ module Crystal::Playground
         end
       end
 
-
-
       client_ws = PathWebSocketHandler.new "/client" do |ws, context|
         origin = context.request.headers["Origin"]
         if !accept_request?(origin)

--- a/src/compiler/crystal/tools/playground/server.cr
+++ b/src/compiler/crystal/tools/playground/server.cr
@@ -21,7 +21,6 @@ module Crystal::Playground
       instrumented = Playground::AgentInstrumentorTransformer.transform(ast).to_s
       Log.info { "Code instrumentation (session=#{session_key}, tag=#{tag}).\n#{instrumented}" }
 
-      
       prelude = %(
         require "compiler/crystal/tools/playground/agent"
 

--- a/src/compiler/crystal/tools/playground/server.cr
+++ b/src/compiler/crystal/tools/playground/server.cr
@@ -10,7 +10,7 @@ module Crystal::Playground
   class Session
     getter tag : Int32
 
-    def initialize(@ws : HTTP::WebSocket, @session_key : Int32, @port : Int32)
+    def initialize(@ws : HTTP::WebSocket, @session_key : Int32, @port : Int32, @@host : String | Nil)
       @running_process_filename = ""
       @tag = 0
     end
@@ -21,11 +21,16 @@ module Crystal::Playground
       instrumented = Playground::AgentInstrumentorTransformer.transform(ast).to_s
       Log.info { "Code instrumentation (session=#{session_key}, tag=#{tag}).\n#{instrumented}" }
 
+      
+      
+      ip = @@host
+      ip = "localhost" if ip == "127.0.0.1" || ip == "localhost" || ip == nil
+            
       prelude = %(
         require "compiler/crystal/tools/playground/agent"
 
         class Crystal::Playground::Agent
-          @@instance = Crystal::Playground::Agent.new("ws://localhost:#{port}/agent/#{session_key}/#{tag}", #{tag})
+          @@instance = Crystal::Playground::Agent.new("ws://#{ip}:#{port}/agent/#{session_key}/#{tag}", #{tag})
 
           def self.instance
             @@instance
@@ -478,7 +483,7 @@ module Crystal::Playground
           ws.close :policy_violation, "Invalid Request Origin"
         else
           @sessions_key += 1
-          @sessions[@sessions_key] = session = Session.new(ws, @sessions_key, @port)
+          @sessions[@sessions_key] = session = Session.new(ws, @sessions_key, @port, @host)
           Log.info { "/client WebSocket connected as session=#{@sessions_key}" }
 
           ws.on_message do |message|


### PR DESCRIPTION
I test crystal-1.5.0-1 and crystal-1.3.2-1 both got this bug:
  I have two servers(A and B, they both are in same local area network by one WIFI):
      A: ip 192.168.8.83, Unbuntu 18
      B:  Windows10
  when run ```crystal play  -p  3566 -b 192.168.8.83 -v``` in server A, then open http://192.168.8.83:3566/ in Chrome at server B then click start button will get this error:
```
Unhandled exception: Error connecting to 'localhost:3566': Connection refused (Socket::ConnectError)
  from /home/myth/crystal/crystal-1.3.2-1/share/crystal/src/socket/addrinfo.cr:67:17 in 'initialize'
  from /home/myth/crystal/crystal-1.3.2-1/share/crystal/src/socket/tcp_socket.cr:27:3 in 'initialize'
  from /home/myth/crystal/crystal-1.3.2-1/share/crystal/src/socket/tcp_socket.cr:27:3 in 'new'
  from /home/myth/crystal/crystal-1.3.2-1/share/crystal/src/http/web_socket/protocol.cr:275:5 in 'new'
  from /home/myth/crystal/crystal-1.3.2-1/share/crystal/src/http/web_socket/protocol.cr:326:14 in 'new'
  from /home/myth/crystal/crystal-1.3.2-1/share/crystal/src/http/web_socket.cr:37:5 in 'new'
  from /home/myth/crystal/crystal-1.3.2-1/share/crystal/src/http/web_socket.cr:36:3 in 'new'
  from /home/myth/crystal/crystal-1.3.2-1/share/crystal/src/compiler/crystal/tools/playground/agent.cr:8:11 in 'initialize'
  from /home/myth/crystal/crystal-1.3.2-1/share/crystal/src/compiler/crystal/tools/playground/agent.cr:7:3 in 'new'
  from playground_prelude:5:24 in '~Crystal::Playground::Agent::instance:init'
  from play:1:6 in '__crystal_main'
  from /home/myth/crystal/crystal-1.3.2-1/share/crystal/src/crystal/main.cr:115:5 in 'main_user_code'
  from /home/myth/crystal/crystal-1.3.2-1/share/crystal/src/crystal/main.cr:101:7 in 'main'
  from /home/myth/crystal/crystal-1.3.2-1/share/crystal/src/crystal/main.cr:127:3 in 'main'
  from /lib/x86_64-linux-gnu/libc.so.6 in '__libc_start_main'
  from /home/myth/.cache/crystal/crystal-run-play-1-1.tmp in '_start'
  from ???

exit status: 1
```

Update:
 when I change ```@@instance = Crystal::Playground::Agent.new("ws://localhost:#{port}/agent/#{session_key}/#{tag}", #{tag})``` of src/compiler/crystal/tools/playground/server.cr to ```@@instance = Crystal::Playground::Agent.new("ws://192.168.8.83:#{port}/agent/#{session_key}/#{tag}", #{tag})``` and rebuild crystal, it works ！