### PR TITLE
Update distribution-scripts

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,7 @@ parameters:
   distribution-scripts-version:
     description: "Git ref for version of https://github.com/crystal-lang/distribution-scripts/"
     type: string
-    default: "d96f97754b7b512e2f45c04ea5aea2cca074bd92"
+    default: "e9cafa1a93a487169e561759e9a2d065c35e0770"
   previous_crystal_base_url:
     description: "Prefix for URLs to Crystal bootstrap compiler"
     type: string


### PR DESCRIPTION
Updates `distribution-scripts` dependency to https://github.com/crystal-lang/distribution-scripts/commit/e9cafa1a93a487169e561759e9a2d065c35e0770

This is a fixup for #12333 which unintentionally referenced a commit on a PR branch that no longer exists.