### PR TITLE
Do not use `TypeDeclaration`s on local variables

### DIFF
--- a/samples/mt_gc_test.cr
+++ b/samples/mt_gc_test.cr
@@ -204,7 +204,7 @@ end
 threads_num = 4
 fibers_num = 1_000
 loops_num = 20
-mode : Mode = :run
+mode = Mode::Run
 
 OptionParser.parse do |parser|
   parser.on("-i", "--ips", "Benchmark with ips") { mode = :ips }

--- a/spec/std/crystal/compiler_rt/mulodi4_spec.cr
+++ b/spec/std/crystal/compiler_rt/mulodi4_spec.cr
@@ -4,7 +4,7 @@ require "./spec_helper"
 
 private def test__mulodi4(a : Int64, b : Int64, expected : Int64, expected_overflow : Int32, file = __FILE__, line = __LINE__)
   it "passes compiler-rt builtins unit tests" do
-    actual_overflow : Int32 = 0
+    actual_overflow = 0_i32
     actual = __mulodi4(a, b, pointerof(actual_overflow))
     actual_overflow.should eq(expected_overflow), file: file, line: line
     if !expected_overflow

--- a/spec/std/crystal/compiler_rt/mulosi4_spec.cr
+++ b/spec/std/crystal/compiler_rt/mulosi4_spec.cr
@@ -4,7 +4,7 @@ require "./spec_helper"
 
 private def test__mulosi4(a : Int32, b : Int32, expected : Int32, expected_overflow : Int32, file = __FILE__, line = __LINE__)
   it "passes compiler-rt builtins unit tests" do
-    actual_overflow : Int32 = 0
+    actual_overflow = 0_i32
     actual = __mulosi4(a, b, pointerof(actual_overflow))
     actual_overflow.should eq(expected_overflow), file: file, line: line
     if !expected_overflow

--- a/spec/std/crystal/compiler_rt/muloti4_spec.cr
+++ b/spec/std/crystal/compiler_rt/muloti4_spec.cr
@@ -4,7 +4,7 @@ require "./spec_helper"
 
 private def test__muloti4(a : Int128, b : Int128, expected : Int128, expected_overflow : Int32, file = __FILE__, line = __LINE__)
   it "passes compiler-rt builtins unit tests" do
-    actual_overflow : Int32 = 0
+    actual_overflow = 0_i32
     actual = __muloti4(a, b, pointerof(actual_overflow))
     actual_overflow.should eq(expected_overflow), file: file, line: line
     if !expected_overflow

--- a/src/compiler/crystal/interpreter/interpreter.cr
+++ b/src/compiler/crystal/interpreter/interpreter.cr
@@ -272,7 +272,7 @@ class Crystal::Repl::Interpreter
       @context.class_vars_memory[index] = 1_u8
     end
 
-    instructions : CompiledInstructions = @instructions
+    instructions = @instructions
     ip = instructions.instructions.to_unsafe
     return_value = Pointer(UInt8).null
 

--- a/src/crystal/compiler_rt/divmod128.cr
+++ b/src/crystal/compiler_rt/divmod128.cr
@@ -142,7 +142,7 @@ def _u128_div_rem(duo : UInt128, div : UInt128) : Tuple(UInt128, UInt128)
 
   # Undersubtracting long division algorithm.
 
-  quo : UInt128 = 0
+  quo = UInt128.zero
   div_extra = 96 - div_lz                  # Number of lesser significant bits that aren't part of div_sig_32
   div_sig_32 = (div >> div_extra).to_u32!  # Most significant 32 bits of div
   div_sig_32_add1 = div_sig_32.to_u64! + 1 # This must be a UInt64 because this can overflow

--- a/src/llvm/abi/aarch64.cr
+++ b/src/llvm/abi/aarch64.cr
@@ -17,17 +17,17 @@ class LLVM::ABI::AArch64 < LLVM::ABI
     size(type, 8)
   end
 
-  def homogeneous_aggregate?(type)
-    homog_agg : {Type, UInt64}? = case type
-    when Type::Kind::Float
-      return {type, 1_u64}
-    when Type::Kind::Double
-      return {type, 1_u64}
-    when Type::Kind::Array
-      check_array(type)
-    when Type::Kind::Struct
-      check_struct(type)
-    end
+  def homogeneous_aggregate?(type) : {Type, UInt64}?
+    homog_agg = case type
+                when Type::Kind::Float
+                  return {type, 1_u64}
+                when Type::Kind::Double
+                  return {type, 1_u64}
+                when Type::Kind::Array
+                  check_array(type)
+                when Type::Kind::Struct
+                  check_struct(type)
+                end
 
     # Ensure we have at most four uniquely addressable members
     if homog_agg
@@ -37,7 +37,7 @@ class LLVM::ABI::AArch64 < LLVM::ABI
     end
   end
 
-  private def check_array(type)
+  private def check_array(type) : {Type, UInt64}?
     len = type.array_size.to_u64
     return if len == 0
     element = type.element_type
@@ -49,7 +49,7 @@ class LLVM::ABI::AArch64 < LLVM::ABI
     end
   end
 
-  private def check_struct(type)
+  private def check_struct(type) : {Type, UInt64}?
     elements = type.struct_element_types
     return if elements.empty?
 

--- a/src/string.cr
+++ b/src/string.cr
@@ -4035,7 +4035,7 @@ class String
     last_is_downcase = false
     last_is_upcase = false
     last_is_digit = false
-    mem : Char? = nil
+    mem = nil
 
     each_char do |char|
       digit = char.ascii_number?


### PR DESCRIPTION
These 8 uses of `TypeDeclaration`s in the repository assign a value to a local variable. They can all be expressed without that type name, which does not in fact type the initializer expression, a common source of confusion for newcomers.

There are 75 other uses of those assignments as arguments to macros like `getter` and `record`. They are acceptable because no local variables are actually created.