### PR TITLE
Compiler: fix `#to_s` for empty parameters of lib funs

### DIFF
--- a/spec/compiler/parser/to_s_spec.cr
+++ b/spec/compiler/parser/to_s_spec.cr
@@ -142,6 +142,7 @@ describe "ASTNode#to_s" do
   expect_to_s "foo[x, y, a: 1, b: 2] = z"
   expect_to_s %(@[Foo(1, 2, a: 1, b: 2)])
   expect_to_s %(lib Foo\nend)
+  expect_to_s %(lib LibC\n  fun getchar(Int, Float)\nend)
   expect_to_s %(fun foo(a : Void, b : Void, ...) : Void\n\nend)
   expect_to_s %(lib Foo\n  struct Foo\n    a : Void\n    b : Void\n  end\nend)
   expect_to_s %(lib Foo\n  union Foo\n    a : Int\n    b : Int32\n  end\nend)

--- a/src/compiler/crystal/syntax/to_s.cr
+++ b/src/compiler/crystal/syntax/to_s.cr
@@ -1132,7 +1132,7 @@ module Crystal
       if node.args.size > 0
         @str << '('
         node.args.join(@str, ", ") do |arg|
-          if arg_name = arg.name
+          if arg_name = arg.name.presence
             @str << arg_name << " : "
           end
           arg.restriction.not_nil!.accept self


### PR DESCRIPTION
This ensures that macro interpolation and other things do not produce invalid code from a `LibDef`, since empty parameters are actually allowed for lib funs:

```crystal
macro foo(x)
  {% p x %}
end

foo(lib LibC
      fun getchar(Int, Float)
    end)
# => lib LibC
# =>   fun getchar( : Int,  : Float)
# => end
```