### PR TITLE
Fix null dereference when passing empty slice to Base64.encode

### DIFF
--- a/spec/std/base64_spec.cr
+++ b/spec/std/base64_spec.cr
@@ -48,6 +48,12 @@ describe "Base64" do
     assert_prints base64_strict_encode(slice), "AQEBAQE="
   end
 
+  it "encodes empty slice" do
+    slice = Bytes.empty
+    assert_prints base64_encode(slice), ""
+    assert_prints base64_strict_encode(slice), ""
+  end
+
   it "encodes static array" do
     array = uninitialized StaticArray(UInt8, 5)
     (0...5).each { |i| array[i] = 1_u8 }

--- a/src/base64.cr
+++ b/src/base64.cr
@@ -203,6 +203,7 @@ module Base64
     bytes = chars.to_unsafe
     size = data.size
     cstr = data.to_unsafe
+    return if cstr.null? || size == 0
     endcstr = cstr + size - size % 3 - 3
 
     # process bunch of full triples


### PR DESCRIPTION
https://carc.in/#/r/dll2

minimal example:
```
Base64.encode Bytes.empty
```

output:
```
Invalid memory access (signal 11) at address 0x0
[0x56435a7490d6] *Exception::CallStack::print_backtrace:Nil +118 in /home/crystal/.cache/crystal/crystal-run-eval.tmp
[0x56435a738a96] ~procProc(Int32, Pointer(LibC::SiginfoT), Pointer(Void), Nil) +310 in /home/crystal/.cache/crystal/crystal-run-eval.tmp
[0x7f666f8848e0] ?? +140077934594272 in /usr/lib/libc.so.6
[0x56435a7b719f] *Base64 +831 in /home/crystal/.cache/crystal/crystal-run-eval.tmp
[0x56435a728ac5] __crystal_main +1189 in /home/crystal/.cache/crystal/crystal-run-eval.tmp
[0x56435a7b9616] *Crystal::main_user_code<Int32, Pointer(Pointer(UInt8))>:Nil +6 in /home/crystal/.cache/crystal/crystal-run-eval.tmp
[0x56435a7b958a] *Crystal::main<Int32, Pointer(Pointer(UInt8))>:Int32 +58 in /home/crystal/.cache/crystal/crystal-run-eval.tmp
[0x56435a735fb6] main +6 in /home/crystal/.cache/crystal/crystal-run-eval.tmp
[0x7f666f86f290] ?? +140077934506640 in /usr/lib/libc.so.6
[0x7f666f86f34a] __libc_start_main +138 in /usr/lib/libc.so.6
[0x56435a728545] _start +37 in /home/crystal/.cache/crystal/crystal-run-eval.tmp
[0x0] ???
```