### PR TITLE
Interpreter: missing `i += 1`

### DIFF
--- a/spec/compiler/interpreter/procs_spec.cr
+++ b/spec/compiler/interpreter/procs_spec.cr
@@ -54,5 +54,20 @@ describe Crystal::Repl::Interpreter do
         2
       CODE
     end
+
+    it "can downcast Proc(T) to Proc(Nil)" do
+      interpret(<<-CODE)
+        class Foo
+          def initialize(@proc : ->)
+          end
+
+          def call
+            @proc.call
+          end
+        end
+
+        Foo.new(->{ 1 }).call
+        CODE
+    end
   end
 end

--- a/src/compiler/crystal/interpreter/cast.cr
+++ b/src/compiler/crystal/interpreter/cast.cr
@@ -402,6 +402,11 @@ class Crystal::Repl::Compiler
     # Nothing to do
   end
 
+  private def downcast_distinct(node : ASTNode, from : ProcInstanceType, to : ProcInstanceType)
+    # Nothing to do
+    # This is when Proc(T) is casted to Proc(Nil)
+  end
+
   private def downcast_distinct(node : ASTNode, from : NilableProcType, to : NilType)
     # TODO: not tested
     pop 16, node: nil

--- a/src/compiler/crystal/interpreter/multidispatch.cr
+++ b/src/compiler/crystal/interpreter/multidispatch.cr
@@ -174,6 +174,7 @@ module Crystal::Repl::Multidispatch
         # If the argument was autocasted it will always match in a multidispatch
         if autocast_types.try &.[arg_index]?
           call_args << var
+          i += 1
           next
         end
 


### PR DESCRIPTION
I'm so used to doing `each` and `each_with_index` that whenever I need to manually maintain an index I always forget to increment it 😊 

No specs because this was just a regression in std/specs. If std/specs now pass with the interpreter, it means it's fixed.