### PR TITLE
Do not expose `Crystal::System::FileInfo` through `File::Info`

### DIFF
--- a/src/crystal/system/file_info.cr
+++ b/src/crystal/system/file_info.cr
@@ -1,7 +1,34 @@
+# :nodoc:
+module Crystal::System::FileInfo
+  # Size of the file, in bytes.
+  # def system_size : Int64
+
+  # The permissions of the file.
+  # def system_permissions : Permissions
+
+  # The type of the file.
+  # def system_type : Type
+
+  # The special flags this file has set.
+  # def system_flags : Flags
+
+  # The last time this file was modified.
+  # def system_modification_time : Time
+
+  # The user ID that the file belongs to.
+  # def system_owner_id : String
+
+  # The group ID that the file belongs to.
+  # def system_group_id : String
+
+  # Returns true if this `FileInfo` and *other* are of the same file.
+  # def system_same_file?(other : self) : Bool
+end
+
 {% if flag?(:unix) %}
   require "./unix/file_info"
 {% elsif flag?(:win32) %}
   require "./win32/file_info"
 {% else %}
-  {% raise "No Crystal::System::File implementation available" %}
+  {% raise "No Crystal::System::FileInfo implementation available" %}
 {% end %}

--- a/src/crystal/system/unix/file.cr
+++ b/src/crystal/system/unix/file.cr
@@ -40,7 +40,7 @@ module Crystal::System::File
     end
 
     if ret == 0
-      FileInfo.new(stat)
+      ::File::Info.new(stat)
     else
       if Errno.value.in?(Errno::ENOENT, Errno::ENOTDIR)
         return nil

--- a/src/crystal/system/unix/file_descriptor.cr
+++ b/src/crystal/system/unix/file_descriptor.cr
@@ -71,7 +71,7 @@ module Crystal::System::FileDescriptor
       raise IO::Error.from_errno("Unable to get info")
     end
 
-    FileInfo.new(stat)
+    ::File::Info.new(stat)
   end
 
   private def system_info

--- a/src/crystal/system/unix/file_info.cr
+++ b/src/crystal/system/unix/file_info.cr
@@ -1,16 +1,16 @@
-struct Crystal::System::FileInfo < ::File::Info
+module Crystal::System::FileInfo
   def initialize(@stat : LibC::Stat)
   end
 
-  def size : Int64
+  def system_size : Int64
     @stat.st_size.to_i64
   end
 
-  def permissions : ::File::Permissions
+  def system_permissions : ::File::Permissions
     ::File::Permissions.new((@stat.st_mode & 0o777).to_i16)
   end
 
-  def type : ::File::Type
+  def system_type : ::File::Type
     case @stat.st_mode & LibC::S_IFMT
     when LibC::S_IFBLK
       ::File::Type::BlockDevice
@@ -31,7 +31,7 @@ struct Crystal::System::FileInfo < ::File::Info
     end
   end
 
-  def flags : ::File::Flags
+  def system_flags : ::File::Flags
     flags = ::File::Flags::None
     flags |= ::File::Flags::SetUser if @stat.st_mode.bits_set? LibC::S_ISUID
     flags |= ::File::Flags::SetGroup if @stat.st_mode.bits_set? LibC::S_ISGID
@@ -39,7 +39,7 @@ struct Crystal::System::FileInfo < ::File::Info
     flags
   end
 
-  def modification_time : ::Time
+  def system_modification_time : ::Time
     {% if flag?(:darwin) %}
       ::Time.new(@stat.st_mtimespec, ::Time::Location::UTC)
     {% else %}
@@ -47,15 +47,15 @@ struct Crystal::System::FileInfo < ::File::Info
     {% end %}
   end
 
-  def owner_id : String
+  def system_owner_id : String
     @stat.st_uid.to_s
   end
 
-  def group_id : String
+  def system_group_id : String
     @stat.st_gid.to_s
   end
 
-  def same_file?(other : ::File::Info) : Bool
+  def system_same_file?(other : self) : Bool
     @stat.st_dev == other.@stat.st_dev && @stat.st_ino == other.@stat.st_ino
   end
 end

--- a/src/crystal/system/win32/file.cr
+++ b/src/crystal/system/win32/file.cr
@@ -79,7 +79,7 @@ module Crystal::System::File
         end
 
         if find_data.dwReserved0.bits_set? REPARSE_TAG_NAME_SURROGATE_MASK
-          return FileInfo.new(find_data)
+          return ::File::Info.new(find_data)
         end
       end
     end
@@ -101,7 +101,7 @@ module Crystal::System::File
         raise ::File::Error.from_winerror("Unable to get file info", file: path)
       end
 
-      FileInfo.new(file_info, LibC::FILE_TYPE_DISK)
+      ::File::Info.new(file_info, LibC::FILE_TYPE_DISK)
     ensure
       LibC.CloseHandle(handle)
     end

--- a/src/crystal/system/win32/file_descriptor.cr
+++ b/src/crystal/system/win32/file_descriptor.cr
@@ -74,9 +74,9 @@ module Crystal::System::FileDescriptor
         raise IO::Error.from_winerror("Unable to get info")
       end
 
-      FileInfo.new(file_info, file_type)
+      ::File::Info.new(file_info, file_type)
     else
-      FileInfo.new(file_type)
+      ::File::Info.new(file_type)
     end
   end
 

--- a/src/crystal/system/win32/file_info.cr
+++ b/src/crystal/system/win32/file_info.cr
@@ -1,4 +1,4 @@
-struct Crystal::System::FileInfo < ::File::Info
+module Crystal::System::FileInfo
   protected getter file_attributes
 
   def initialize(@file_attributes : LibC::BY_HANDLE_FILE_INFORMATION, @file_type : LibC::DWORD)
@@ -27,11 +27,11 @@ struct Crystal::System::FileInfo < ::File::Info
     @reparse_tag = LibC::DWORD.new(0)
   end
 
-  def size : Int64
+  def system_size : Int64
     ((@file_attributes.nFileSizeHigh.to_u64 << 32) | @file_attributes.nFileSizeLow.to_u64).to_i64
   end
 
-  def permissions : ::File::Permissions
+  def system_permissions : ::File::Permissions
     if @file_attributes.dwFileAttributes.bits_set? LibC::FILE_ATTRIBUTE_READONLY
       permissions = ::File::Permissions.new(0o444)
     else
@@ -45,7 +45,7 @@ struct Crystal::System::FileInfo < ::File::Info
     end
   end
 
-  def type : ::File::Type
+  def system_type : ::File::Type
     case @file_type
     when LibC::FILE_TYPE_PIPE
       ::File::Type::Pipe
@@ -66,23 +66,23 @@ struct Crystal::System::FileInfo < ::File::Info
     end
   end
 
-  def flags : ::File::Flags
+  def system_flags : ::File::Flags
     ::File::Flags::None
   end
 
-  def modification_time : ::Time
+  def system_modification_time : ::Time
     Time.from_filetime(@file_attributes.ftLastWriteTime)
   end
 
-  def owner_id : String
+  def system_owner_id : String
     "0"
   end
 
-  def group_id : String
+  def system_group_id : String
     "0"
   end
 
-  def same_file?(other : ::File::Info) : Bool
+  def system_same_file?(other : self) : Bool
     return false if type.symlink? || type.pipe? || type.character_device?
 
     @file_attributes.dwVolumeSerialNumber == other.file_attributes.dwVolumeSerialNumber &&

--- a/src/file/info.cr
+++ b/src/file/info.cr
@@ -1,3 +1,5 @@
+require "crystal/system/file_info"
+
 class File
   # Represents the various behaviour-altering flags which can be set on files.
   # Not all flags will be supported on all platforms.
@@ -77,33 +79,51 @@ class File
 
   # A `File::Info` contains metadata regarding a file.
   # It is returned by `File.info`, `File#info` and `File.info?`.
-  abstract struct Info
+  struct Info
+    include Crystal::System::FileInfo
+
     # Size of the file, in bytes.
-    abstract def size : Int64
+    def size : Int64
+      system_size
+    end
 
     # The permissions of the file.
-    abstract def permissions : Permissions
+    def permissions : Permissions
+      system_permissions
+    end
 
     # The type of the file.
-    abstract def type : Type
+    def type : Type
+      system_type
+    end
 
     # The special flags this file has set.
-    abstract def flags : Flags
+    def flags : Flags
+      system_flags
+    end
 
     # The last time this file was modified.
-    abstract def modification_time : Time
+    def modification_time : Time
+      system_modification_time
+    end
 
     # The user ID that the file belongs to.
-    abstract def owner_id : String
+    def owner_id : String
+      system_owner_id
+    end
 
     # The group ID that the file belongs to.
-    abstract def group_id : String
+    def group_id : String
+      system_group_id
+    end
 
     # Returns true if this `Info` and *other* are of the same file.
     #
-    # On unix, this compares device and inode fields, and will compare equal for
-    # hard linked files.
-    abstract def same_file?(other : File::Info) : Bool
+    # On Unix-like systems, this compares device and inode fields, and will
+    # compare equal for hard linked files.
+    def same_file?(other : self) : Bool
+      system_same_file?(other)
+    end
 
     # Returns true if this `Info` represents a standard file. Shortcut for
     # `type.file?`.
@@ -124,5 +144,3 @@ class File
     end
   end
 end
-
-require "crystal/system/file_info"


### PR DESCRIPTION
Supersedes #11825. Resolves #7685.

`Crystal::System::FileInfo` is now a module and `File::Info` is no longer abstract.