### PR TITLE
Compiler: transform Proc(*T, Void) to Proc(*T, Nil)

### DIFF
--- a/spec/compiler/semantic/instance_var_spec.cr
+++ b/spec/compiler/semantic/instance_var_spec.cr
@@ -5536,6 +5536,24 @@ describe "Semantic: instance var" do
       )) { int32 }
   end
 
+  it "inferrs Proc(Void) to Proc(Nil)" do
+    assert_type(%(
+      struct Proc
+        def self.new(&block : self)
+          block
+        end
+      end
+
+      class Foo
+        def initialize
+          @proc = Proc(Void).new { 1 }
+        end
+      end
+
+      Foo.new.@proc
+      )) { proc_of(nil_type) }
+  end
+
   describe "instance variable inherited from multiple parents" do
     context "with compatible type" do
       it "module and class, with declarations" do

--- a/spec/compiler/semantic/proc_spec.cr
+++ b/spec/compiler/semantic/proc_spec.cr
@@ -1307,6 +1307,14 @@ describe "Semantic: proc" do
       foo
     )) { union_of proc_of(string), proc_of(nil_type), nil_type }
   end
+
+  it "types Proc(*T, Void) as Proc(*T, Nil)" do
+    assert_type(%(
+      #{proc_new}
+
+      Proc(Int32, Void).new { |x| x }
+      )) { proc_of(int32, nil_type) }
+  end
 end
 
 private def proc_new

--- a/src/compiler/crystal/types.cr
+++ b/src/compiler/crystal/types.cr
@@ -2319,6 +2319,13 @@ module Crystal
         type_var
       end
       return_type = types.pop
+
+      # Transform Proc(*T, Void) to Proc(*T, Nil) as Void has
+      # only a special meaning in Pointer(Void)
+      if return_type == @program.void
+        return_type = @program.nil_type
+      end
+
       instance = ProcInstanceType.new(program, types, return_type)
       generic_types[type_vars] = instance
       instance.after_initialize


### PR DESCRIPTION
Without this, code like this:

```crystal
class Foo
  def initialize
    @proc = Proc(Nil).new { 1 }
    @proc = Proc(Void).new { 1 }
    @proc.call
  end
end
```

made `@proc` be of type `Proc(Void) | Proc(Nil)`.

To be honest, this was already the case in code like this:

```crystal
proc = Proc(Void).new { } 
typeof(proc) # => Proc(Nil)
```

but it didn't work in the "guess types" phase. But I still don't understand why or when `Proc(Void)` is turned into `Proc(Nil)` in the latter case.

I still this the fix in this PR is good.

This is related to https://github.com/crystal-lang/crystal/pull/12375#issuecomment-1214355798