### PR TITLE
Optimize String#downcase and String#upcase for single byte optimizabl…

### DIFF
--- a/src/string.cr
+++ b/src/string.cr
@@ -1317,7 +1317,7 @@ class String
       return String.new(bytesize) do |buffer|
         bytesize.times do |i|
           byte = to_unsafe[i]
-          buffer[i] = byte < 0x80 ? byte.unsafe_chr.downcase.ord.to_u8! : byte
+          buffer[i] = 'A'.ord <= byte <= 'Z'.ord ? byte + 32 : byte
         end
         {@bytesize, @length}
       end
@@ -1353,7 +1353,7 @@ class String
       return String.new(bytesize) do |buffer|
         bytesize.times do |i|
           byte = to_unsafe[i]
-          buffer[i] = byte < 0x80 ? byte.unsafe_chr.upcase.ord.to_u8! : byte
+          buffer[i] = 'a'.ord <= byte <= 'z'.ord ? byte - 32 : byte
         end
         {@bytesize, @length}
       end


### PR DESCRIPTION
…e case

This is a very simple change that leads to a pretty good performance boost.

Here's the benchmark:

```crystal
require "benchmark"

string = "hEllO WoRlD!." * 10

Benchmark.ips do |x|
  x.report("downcase") do
    string.downcase
  end
  x.report("upcase") do
    string.upcase
  end
end
```

Before:

```
downcase   7.73M (129.38ns) (± 1.92%)  144B/op        fastest
  upcase   7.68M (130.15ns) (± 2.50%)  144B/op   1.01× slower
```

After:

```
downcase  42.20M ( 23.69ns) (± 3.39%)  144B/op        fastest
  upcase  41.84M ( 23.90ns) (± 3.83%)  144B/op   1.01× slower
```