### PR TITLE
Support building the interpreter on Windows

### DIFF
--- a/src/compiler/crystal/interpreter/context.cr
+++ b/src/compiler/crystal/interpreter/context.cr
@@ -365,6 +365,7 @@ class Crystal::Repl::Context
     # FIXME: Part 1: This is a workaround for initial integration of the interpreter:
     # The loader can't handle the static libgc.a usually shipped with crystal and loading as a shared library conflicts
     # with the compiler's own GC.
+    # (MSVC doesn't seem to have this issue)
     args.delete("-lgc")
 
     Crystal::Loader.parse(args).tap do |loader|

--- a/src/compiler/crystal/interpreter/instructions.cr
+++ b/src/compiler/crystal/interpreter/instructions.cr
@@ -2016,12 +2016,12 @@ require "./repl"
       libm_powi_f32: {
         pop_values: [value : Float32, power : Int32],
         push:       true,
-        code:       LibM.powi_f32(value, power),
+        code:       {% if flag?(:win32) %} LibM.pow_f32(value, power.to_f32) {% else %} LibM.powi_f32(value, power) {% end %},
       },
       libm_powi_f64: {
         pop_values: [value : Float64, power : Int32],
         push:       true,
-        code:       LibM.powi_f64(value, power),
+        code:       {% if flag?(:win32) %} LibM.pow_f64(value, power.to_f64) {% else %} LibM.powi_f64(value, power) {% end %},
       },
       libm_min_f32: {
         pop_values: [value1 : Float32, value2 : Float32],

--- a/src/compiler/crystal/loader/msvc.cr
+++ b/src/compiler/crystal/loader/msvc.cr
@@ -60,6 +60,8 @@ class Crystal::Loader
   end
 
   def load_file?(path : String | ::Path) : Bool
+    return false unless File.file?(path)
+
     # On Windows, each `.lib` import library may reference any number of `.dll`
     # files, whose base names may not match the library's. Thus it is necessary
     # to extract this information from the library archive itself.

--- a/src/crystal/system/win32/file_descriptor.cr
+++ b/src/crystal/system/win32/file_descriptor.cr
@@ -175,7 +175,9 @@ module Crystal::System::FileDescriptor
     handle = LibC._get_osfhandle(fd)
     if handle != -1
       handle = LibC::HANDLE.new(handle)
-      if LibC.GetConsoleMode(handle, out old_mode) != 0
+      # TODO: use `out old_mode` after implementing interpreter out closured var
+      old_mode = uninitialized LibC::DWORD
+      if LibC.GetConsoleMode(handle, pointerof(old_mode)) != 0
         console_handle = true
         if fd == 1 || fd == 2 # STDOUT or STDERR
           if LibC.SetConsoleMode(handle, old_mode | LibC::ENABLE_VIRTUAL_TERMINAL_PROCESSING) != 0

--- a/src/crystal/system/win32/wmain.cr
+++ b/src/crystal/system/win32/wmain.cr
@@ -2,8 +2,10 @@ require "c/stringapiset"
 require "c/winnls"
 require "c/stdlib"
 
-# we have both `main` and `wmain`, so we must choose an unambiguous entry point
-@[Link(ldflags: "/ENTRY:wmainCRTStartup")]
+{% begin %}
+  # we have both `main` and `wmain`, so we must choose an unambiguous entry point
+  @[Link({{ flag?(:preview_dll) ? "msvcrt" : "libcmt" }}, ldflags: "/ENTRY:wmainCRTStartup")]
+{% end %}
 lib LibCrystalMain
 end
 

--- a/src/exception/call_stack.cr
+++ b/src/exception/call_stack.cr
@@ -1,7 +1,7 @@
-{% if flag?(:win32) %}
-  require "./call_stack/stackwalk"
-{% elsif flag?(:interpreted) %}
+{% if flag?(:interpreted) %}
   require "./call_stack/interpreter"
+{% elsif flag?(:win32) %}
+  require "./call_stack/stackwalk"
 {% elsif flag?(:wasm32) %}
   require "./call_stack/null"
 {% else %}

--- a/src/exception/call_stack/interpreter.cr
+++ b/src/exception/call_stack/interpreter.cr
@@ -1,7 +1,4 @@
-require "c/dlfcn"
-require "c/stdio"
-require "c/string"
-require "../lib_unwind"
+require "../../crystal/system/print_error"
 
 # :nodoc:
 struct Exception::CallStack

--- a/src/lib_c.cr
+++ b/src/lib_c.cr
@@ -1,5 +1,5 @@
 {% if flag?(:win32) %}
-  @[Link({{ flag?(:preview_dll) ? "msvcrt" : "libcmt" }})]
+  @[Link({{ flag?(:preview_dll) ? "ucrt" : "libucrt" }})]
 {% end %}
 lib LibC
   alias Char = UInt8

--- a/src/lib_c/x86_64-windows-msvc/c/processenv.cr
+++ b/src/lib_c/x86_64-windows-msvc/c/processenv.cr
@@ -1,5 +1,6 @@
 require "c/winnt"
 
+@[Link("kernel32")]
 lib LibC
   fun GetCurrentDirectoryW(nBufferLength : DWORD, lpBuffer : LPWSTR) : DWORD
   fun SetCurrentDirectoryW(lpPathname : LPWSTR) : BOOL


### PR DESCRIPTION
This PR includes the final bits necessary to enable interpreter builds on Windows MSVC. To set up:

* Ensure your pre-existing Crystal installation is new enough by verifying that `ffi.lib` exists in `CRYSTAL_LIBRARY_PATH` (it was added after 1.5.0, so you might have to build it yourself).
* Create the alternate `CRYSTAL_LIBRARY_PATH` DLL directory with `gc.dll` and `pcre.dll` according to the first 3 steps [here](https://github.com/crystal-lang/crystal/pull/11573). Do not set `CRYSTAL_LIBRARY_PATH` in the terminal that rebuilds the compiler.
* (Optional) Build also `libiconv.dll` and the `iconv.lib` import library:
  * Following [these workflow steps](https://github.com/crystal-lang/crystal/blob/f160040b7f073f6cb56f2c440b2be521f84a5003/.github/workflows/win.yml#L86-L113), except that this time `MultiThreaded` becomes `MultiThreadedDLL` and `/p:Configuration=ReleaseStatic` becomes `/p:Configuration=Release`.
  * Copy `lib64\libiconv.lib` to `iconv.lib` inside the DLL directory.
  * Copy `lib64\libiconv.dll` to `libiconv.dll` inside the DLL directory. **Do not** rename the DLL - the base name is hardcoded in the import library.
* Run `make -fMakefile.win interpreter=1`.
* In a separate terminal, point `CRYSTAL_LIBRARY_PATH` to the DLL directory, and also `set CRYSTAL_OPTS=-Dpreview_dll`. You will have to add `-Dwithout_iconv` unless you did the optional steps above.
* Now `bin\crystal i` should start an interpreter REPL session. `set CRYSTAL_INTERPRETER_LOADER_INFO=1` also works on Windows.

The main outstanding issues are tracked in #12396.