### PR TITLE
Make `sprintf` and `String#%` ignore NaN sign bit

### DIFF
--- a/spec/std/sprintf_spec.cr
+++ b/spec/std/sprintf_spec.cr
@@ -361,8 +361,8 @@ describe "::sprintf" do
     assert_sprintf "1\u{0}%i\u{0}3", 2, "1\u00002\u00003"
   end
 
-  pending_win32 describe: "floats" do
-    it "works" do
+  describe "floats" do
+    pending_win32 "works" do
       assert_sprintf "%f", 123, "123.000000"
 
       assert_sprintf "%g", 123, "123"
@@ -394,6 +394,101 @@ describe "::sprintf" do
       assert_sprintf "%12.2f %12.2f %6.2f %.2f", [2.0, 3.0, 4.0, 5.0], "        2.00         3.00   4.00 5.00"
 
       assert_sprintf "%f", 1e15, "1000000000000000.000000"
+    end
+
+    [Float32, Float64].each do |float|
+      it "infinities" do
+        pos_inf = float.new(1) / float.new(0)
+        neg_inf = float.new(-1) / float.new(0)
+
+        assert_sprintf "%f", pos_inf, "inf"
+        assert_sprintf "%a", pos_inf, "inf"
+        assert_sprintf "%e", pos_inf, "inf"
+        assert_sprintf "%g", pos_inf, "inf"
+        assert_sprintf "%A", pos_inf, "INF"
+        assert_sprintf "%E", pos_inf, "INF"
+        assert_sprintf "%G", pos_inf, "INF"
+
+        assert_sprintf "%f", neg_inf, "-inf"
+        assert_sprintf "%G", neg_inf, "-INF"
+
+        assert_sprintf "%2f", pos_inf, "inf"
+        assert_sprintf "%4f", pos_inf, " inf"
+        assert_sprintf "%6f", pos_inf, "   inf"
+        assert_sprintf "%2f", neg_inf, "-inf"
+        assert_sprintf "%4f", neg_inf, "-inf"
+        assert_sprintf "%6f", neg_inf, "  -inf"
+
+        assert_sprintf "% f", pos_inf, " inf"
+        assert_sprintf "% 2f", pos_inf, " inf"
+        assert_sprintf "% 4f", pos_inf, " inf"
+        assert_sprintf "% 6f", pos_inf, "   inf"
+        assert_sprintf "% f", neg_inf, "-inf"
+        assert_sprintf "% 2f", neg_inf, "-inf"
+        assert_sprintf "% 4f", neg_inf, "-inf"
+        assert_sprintf "% 6f", neg_inf, "  -inf"
+
+        assert_sprintf "%+f", pos_inf, "+inf"
+        assert_sprintf "%+2f", pos_inf, "+inf"
+        assert_sprintf "%+4f", pos_inf, "+inf"
+        assert_sprintf "%+6f", pos_inf, "  +inf"
+        assert_sprintf "%+f", neg_inf, "-inf"
+        assert_sprintf "%+2f", neg_inf, "-inf"
+        assert_sprintf "%+4f", neg_inf, "-inf"
+        assert_sprintf "%+6f", neg_inf, "  -inf"
+
+        assert_sprintf "%+ f", pos_inf, "+inf"
+
+        assert_sprintf "%-4f", pos_inf, "inf "
+        assert_sprintf "%-6f", pos_inf, "inf   "
+        assert_sprintf "%-4f", neg_inf, "-inf"
+        assert_sprintf "%-6f", neg_inf, "-inf  "
+
+        assert_sprintf "% -4f", pos_inf, " inf"
+        assert_sprintf "% -6f", pos_inf, " inf  "
+        assert_sprintf "% -4f", neg_inf, "-inf"
+        assert_sprintf "% -6f", neg_inf, "-inf  "
+
+        assert_sprintf "%-+4f", pos_inf, "+inf"
+        assert_sprintf "%-+6f", pos_inf, "+inf  "
+        assert_sprintf "%-+4f", neg_inf, "-inf"
+        assert_sprintf "%-+6f", neg_inf, "-inf  "
+
+        assert_sprintf "%-+ 6f", pos_inf, "+inf  "
+
+        assert_sprintf "%06f", pos_inf, "   inf"
+        assert_sprintf "%-06f", pos_inf, "inf   "
+        assert_sprintf "%06f", neg_inf, "  -inf"
+        assert_sprintf "%-06f", neg_inf, "-inf  "
+
+        assert_sprintf "%.1f", pos_inf, "inf"
+
+        assert_sprintf "%#f", pos_inf, "inf"
+      end
+
+      it "not-a-numbers" do
+        pos_nan = Math.copysign(float.new(0) / float.new(0), 1)
+        neg_nan = Math.copysign(float.new(0) / float.new(0), -1)
+
+        assert_sprintf "%f", pos_nan, "nan"
+        assert_sprintf "%a", pos_nan, "nan"
+        assert_sprintf "%e", pos_nan, "nan"
+        assert_sprintf "%g", pos_nan, "nan"
+        assert_sprintf "%A", pos_nan, "NAN"
+        assert_sprintf "%E", pos_nan, "NAN"
+        assert_sprintf "%G", pos_nan, "NAN"
+
+        assert_sprintf "%f", neg_nan, "nan"
+        assert_sprintf "%a", neg_nan, "nan"
+        assert_sprintf "%e", neg_nan, "nan"
+        assert_sprintf "%g", neg_nan, "nan"
+        assert_sprintf "%A", neg_nan, "NAN"
+        assert_sprintf "%E", neg_nan, "NAN"
+        assert_sprintf "%G", neg_nan, "NAN"
+
+        assert_sprintf "%+f", pos_nan, "+nan"
+        assert_sprintf "%+f", neg_nan, "+nan"
+      end
     end
   end
 

--- a/src/string/formatter.cr
+++ b/src/string/formatter.cr
@@ -290,16 +290,36 @@ struct String::Formatter(A)
     if arg.responds_to?(:to_f64)
       float = arg.is_a?(Float64) ? arg : arg.to_f64
 
-      format_buf = recreate_float_format_string(flags)
+      if sign = float.infinite?
+        float_special("inf", sign, flags)
+      elsif float.nan?
+        float_special("nan", 1, flags)
+      else
+        format_buf = recreate_float_format_string(flags)
 
-      len = LibC.snprintf(nil, 0, format_buf, float) + 1
-      temp_buf = temp_buf(len)
-      LibC.snprintf(temp_buf, len, format_buf, float)
+        len = LibC.snprintf(nil, 0, format_buf, float) + 1
+        temp_buf = temp_buf(len)
+        LibC.snprintf(temp_buf, len, format_buf, float)
 
-      @io.write_string Slice.new(temp_buf, len - 1)
+        @io.write_string Slice.new(temp_buf, len - 1)
+      end
     else
       raise ArgumentError.new("Expected a float, not #{arg.inspect}")
     end
+  end
+
+  # Formats infinities and not-a-numbers
+  private def float_special(str, sign, flags)
+    str = str.upcase if flags.type.in?('A', 'E', 'G')
+    str_size = str.bytesize
+    str_size += 1 if sign < 0 || (flags.plus || flags.space)
+
+    flags.zero = false
+    pad(str_size, flags) if flags.left_padding?
+    write_plus_or_space(sign, flags)
+    @io << '-' if sign < 0
+    @io << str
+    pad(str_size, flags) if flags.right_padding?
   end
 
   # Here we rebuild the original format string, like %f or %.2g and use snprintf


### PR DESCRIPTION
Fixes #12382.

This actually implements `%f` and friends in `String::Formatter` itself so that NaNs and infinities do not use `LibC.snprintf`.

Note that `BigFloat`s are not supported yet, and even if they were, they are always finite unless #11410 is implemented.