### PR TITLE
Compiler: add missing location to node on literal expander for array

### DIFF
--- a/src/compiler/crystal/semantic/literal_expander.cr
+++ b/src/compiler/crystal/semantic/literal_expander.cr
@@ -76,7 +76,7 @@ module Crystal
 
         ary_instance = Call.new(generic, "unsafe_build", args: [NumberLiteral.new(capacity).at(node)] of ASTNode).at(node)
 
-        buffer = Call.new(ary_var, "to_unsafe")
+        buffer = Call.new(ary_var, "to_unsafe").at(node)
         buffer_var = new_temp_var.at(node)
 
         exps = Array(ASTNode).new(node.elements.size + 3)


### PR DESCRIPTION
I was experimenting with something and when compiling some code in release mode I got this error:

```
Module validation failed: inlinable function call in a function with debug info must have a !dbg location
  %6 = call i8* @"*Array(UInt8)@Array(T)#to_unsafe:Pointer(UInt8)"(%"Array(UInt8)"* %5)
inlinable function call in a function with debug info must have a !dbg location
```

It was because we were not setting the location of a node on an expansion. This PR fixes that.