### PR TITLE
Improve IO performance for single threaded applications

### DIFF
--- a/src/crystal/thread_local_value.cr
+++ b/src/crystal/thread_local_value.cr
@@ -1,56 +1,56 @@
 # :nodoc:
 {% if flag?(:preview_mt) %}
-struct Crystal::ThreadLocalValue(T)
-  @values = Hash(Thread, T).new
-  @mutex = Crystal::SpinLock.new
+  struct Crystal::ThreadLocalValue(T)
+    @values = Hash(Thread, T).new
+    @mutex = Crystal::SpinLock.new
 
-  def get(&block : -> T)
-    th = Thread.current
-    @mutex.sync do
-      @values.fetch(th) do
-        @values[th] = yield
+    def get(&block : -> T)
+      th = Thread.current
+      @mutex.sync do
+        @values.fetch(th) do
+          @values[th] = yield
+        end
+      end
+    end
+
+    def get?
+      @mutex.sync do
+        @values[Thread.current]?
+      end
+    end
+
+    def set(value : T)
+      @mutex.sync do
+        @values[Thread.current] = value
+      end
+    end
+
+    def consume_each
+      @mutex.sync do
+        @values.each_value { |t| yield t }
+        @values.clear
       end
     end
   end
-
-  def get?
-    @mutex.sync do
-      @values[Thread.current]?
-    end
-  end
-
-  def set(value : T)
-    @mutex.sync do
-      @values[Thread.current] = value
-    end
-  end
-
-  def consume_each
-    @mutex.sync do
-      @values.each_value { |t| yield t }
-      @values.clear
-    end
-  end
-end
 {% else %}
-struct Crystal::ThreadLocalValue(T)
-  @value : T? = nil
+  struct Crystal::ThreadLocalValue(T)
+    @value : T? = nil
 
-  def get(&block : -> T)
-    @value ||= yield
-  end
+    def get(&block : -> T)
+      @value ||= yield
+    end
 
-  def get?
-    @value
-  end
+    def get?
+      @value
+    end
 
-  def set(value : T)
-    @value = value
-  end
+    def set(value : T)
+      @value = value
+    end
 
-  def consume_each
-    @value.try { |v| yield v }
-    @value = nil
+    def consume_each
+      @value.try { |v| yield v }
+      @value = nil
+    end
   end
-end
 {% end %}

--- a/src/crystal/thread_local_value.cr
+++ b/src/crystal/thread_local_value.cr
@@ -1,4 +1,5 @@
 # :nodoc:
+{% if flag?(:preview_mt) %}
 struct Crystal::ThreadLocalValue(T)
   @values = Hash(Thread, T).new
   @mutex = Crystal::SpinLock.new
@@ -31,3 +32,25 @@ struct Crystal::ThreadLocalValue(T)
     end
   end
 end
+{% else %}
+struct Crystal::ThreadLocalValue(T)
+  @value : T? = nil
+
+  def get(&block : -> T)
+    @value ||= yield
+  end
+
+  def get?
+    @value
+  end
+
+  def set(value : T)
+    @value = value
+  end
+
+  def consume_each
+    @value.try { |v| yield v }
+    @value = nil
+  end
+end
+{% end %}

--- a/src/reference.cr
+++ b/src/reference.cr
@@ -137,18 +137,10 @@ class Reference
   module ExecRecursive
     alias Registry = Hash({UInt64, Symbol}, Bool)
 
-    {% if flag?(:preview_mt) %}
-      @@exec_recursive = Crystal::ThreadLocalValue(Registry).new
-    {% else %}
-      @@exec_recursive = Registry.new
-    {% end %}
+    @@exec_recursive : Crystal::ThreadLocalValue(Registry) = Crystal::ThreadLocalValue(Registry).new
 
     def self.hash
-      {% if flag?(:preview_mt) %}
-        @@exec_recursive.get { Registry.new }
-      {% else %}
-        @@exec_recursive
-      {% end %}
+      @@exec_recursive.get { Registry.new }
     end
   end
 
@@ -169,18 +161,10 @@ class Reference
   module ExecRecursiveClone
     alias Registry = Hash(UInt64, UInt64)
 
-    {% if flag?(:preview_mt) %}
-      @@exec_recursive = Crystal::ThreadLocalValue(Registry).new
-    {% else %}
-      @@exec_recursive = Registry.new
-    {% end %}
-
+    @@exec_recursive : Crystal::ThreadLocalValue(Registry) = Crystal::ThreadLocalValue(Registry).new
+ 
     def self.hash
-      {% if flag?(:preview_mt) %}
-        @@exec_recursive.get { Registry.new }
-      {% else %}
-        @@exec_recursive
-      {% end %}
+      @@exec_recursive.get { Registry.new } 
     end
   end
 

--- a/src/reference.cr
+++ b/src/reference.cr
@@ -1,3 +1,5 @@
+require "./crystal/thread_local_value"
+
 # `Reference` is the base class of classes you define in your program.
 # It is set as a class' superclass when you don't specify one:
 #
@@ -137,18 +139,10 @@ class Reference
   module ExecRecursive
     alias Registry = Hash({UInt64, Symbol}, Bool)
 
-    {% if flag?(:preview_mt) %}
-      @@exec_recursive = Crystal::ThreadLocalValue(Registry).new
-    {% else %}
-      @@exec_recursive = Registry.new
-    {% end %}
+    @@exec_recursive = Crystal::ThreadLocalValue(Registry).new
 
     def self.hash
-      {% if flag?(:preview_mt) %}
-        @@exec_recursive.get { Registry.new }
-      {% else %}
-        @@exec_recursive
-      {% end %}
+      @@exec_recursive.get { Registry.new }
     end
   end
 
@@ -169,18 +163,10 @@ class Reference
   module ExecRecursiveClone
     alias Registry = Hash(UInt64, UInt64)
 
-    {% if flag?(:preview_mt) %}
-      @@exec_recursive = Crystal::ThreadLocalValue(Registry).new
-    {% else %}
-      @@exec_recursive = Registry.new
-    {% end %}
+    @@exec_recursive = Crystal::ThreadLocalValue(Registry).new
 
     def self.hash
-      {% if flag?(:preview_mt) %}
-        @@exec_recursive.get { Registry.new }
-      {% else %}
-        @@exec_recursive
-      {% end %}
+      @@exec_recursive.get { Registry.new }
     end
   end
 

--- a/src/reference.cr
+++ b/src/reference.cr
@@ -137,10 +137,18 @@ class Reference
   module ExecRecursive
     alias Registry = Hash({UInt64, Symbol}, Bool)
 
-    @@exec_recursive : Crystal::ThreadLocalValue(Registry) = Crystal::ThreadLocalValue(Registry).new
+    {% if flag?(:preview_mt) %}
+      @@exec_recursive = Crystal::ThreadLocalValue(Registry).new
+    {% else %}
+      @@exec_recursive = Registry.new
+    {% end %}
 
     def self.hash
-      @@exec_recursive.get { Registry.new }
+      {% if flag?(:preview_mt) %}
+        @@exec_recursive.get { Registry.new }
+      {% else %}
+        @@exec_recursive
+      {% end %}
     end
   end
 
@@ -161,10 +169,18 @@ class Reference
   module ExecRecursiveClone
     alias Registry = Hash(UInt64, UInt64)
 
-    @@exec_recursive : Crystal::ThreadLocalValue(Registry) = Crystal::ThreadLocalValue(Registry).new
- 
+    {% if flag?(:preview_mt) %}
+      @@exec_recursive = Crystal::ThreadLocalValue(Registry).new
+    {% else %}
+      @@exec_recursive = Registry.new
+    {% end %}
+
     def self.hash
-      @@exec_recursive.get { Registry.new } 
+      {% if flag?(:preview_mt) %}
+        @@exec_recursive.get { Registry.new }
+      {% else %}
+        @@exec_recursive
+      {% end %}
     end
   end
 


### PR DESCRIPTION
I wrote a quite simple HTTP server in crystal and tried to improve the performance. I used `sample` on my Mac M1 Max to find out what could be improved. It was obvious that the functions of hash table in `Crystal::ThreadLocalValue` were quite often visible on the stack.

For that, I simplified `Crystal::ThreadLocalValue` for the single threaded case.

I used [apib](https://github.com/apigee/apib)`apib -d 60 -c 10  http://127.0.0.1:3000` to measure the performance. It turned out that the change improved the performance by 5% in my case (from 121000 req/s to 128000 req/s).

Since `Crystal::ThreadLocalValue` has now only minimal overhead in the single threaded case, I also removed the `{% if flag?(:preview_mt) %}` condition in `src/reference.cr`