### PR TITLE
Correctly display codegen when cross-compiling

### DIFF
--- a/src/compiler/crystal/compiler.cr
+++ b/src/compiler/crystal/compiler.cr
@@ -326,11 +326,13 @@ module Crystal
       llvm_mod = unit.llvm_mod
       object_name = output_filename + program.object_extension
 
-      optimize llvm_mod if @release
+      @progress_tracker.stage("Codegen (bc+obj)") do
+        optimize llvm_mod if @release
 
-      unit.emit(@emit_targets, emit_base_filename || output_filename)
+        unit.emit(@emit_targets, emit_base_filename || output_filename)
 
-      target_machine.emit_obj_to_file llvm_mod, object_name
+        target_machine.emit_obj_to_file llvm_mod, object_name
+      end
 
       print_command(*linker_command(program, [object_name], output_filename, nil))
     end


### PR DESCRIPTION
When cross-compiling (`--cross-compile`) stats information about one codegen stage were not fully displayed.

This was inconsistent with normal compilation where "codegen (bc+obj)" was shown.

This change brings both scenarios to parity.

Fixes #12406
❤️ ❤️ ❤️ 