### PR TITLE
Compiler: bind to tuple, not array

### DIFF
--- a/src/compiler/crystal/semantic/bindings.cr
+++ b/src/compiler/crystal/semantic/bindings.cr
@@ -111,7 +111,7 @@ module Crystal
       end
     end
 
-    def bind_to(nodes : Array)
+    def bind_to(nodes : Indexable)
       return if nodes.empty?
 
       bind do |dependencies|

--- a/src/compiler/crystal/semantic/main_visitor.cr
+++ b/src/compiler/crystal/semantic/main_visitor.cr
@@ -1873,7 +1873,7 @@ module Crystal
 
       @unreachable = then_unreachable && else_unreachable
 
-      node.bind_to [node.then, node.else]
+      node.bind_to({node.then, node.else})
 
       false
     end


### PR DESCRIPTION
This is a very tiny optimization that probably has no effect on perceived memory or time: we are creating an intermediate array every time there's an `if` in the code. In the compiler's source code that happens around 100K times. So with this change we are allocating 100K less arrays.

Starting from today I'll be sending small and medium PRs to try to optimize the compiler's performance. They won't be as drastic as something like incremental or modular compilation, but I believe these can still help reduce the overall memory and time used.

I also won't overflow this repo with these small PRs: I'll wait for one to be merged before sending the next one.