### PR TITLE
Let ZeroOneOrMany be mutable

### DIFF
--- a/spec/compiler/crystal/zero_one_or_many_spec.cr
+++ b/spec/compiler/crystal/zero_one_or_many_spec.cr
@@ -32,7 +32,7 @@ describe Crystal::ZeroOneOrMany do
 
     it "when there's two values" do
       ary = Crystal::ZeroOneOrMany(Int32).new
-      ary += [1, 2]
+      ary.concat([1, 2])
       ary[0].should eq(1)
       ary[1].should eq(2)
       expect_raises(IndexError) { ary[2] }
@@ -52,28 +52,29 @@ describe Crystal::ZeroOneOrMany do
 
     it "when there's two values" do
       ary = Crystal::ZeroOneOrMany(Int32).new
-      ary += [1, 2]
+      ary.concat([1, 2])
       ary.sum.should eq(3)
     end
   end
 
-  describe "#+ element" do
+  describe "#push element" do
     it "when there's no value" do
       ary = Crystal::ZeroOneOrMany(Int32).new
-      ary += 1
+      ary.push 1
       ary.to_a.should eq([1])
     end
 
     it "when there's a single value" do
       ary = Crystal::ZeroOneOrMany.new(1)
-      ary += 2
+      ary.push 2
       ary.to_a.should eq([1, 2])
     end
 
     it "when there's two values" do
       ary = Crystal::ZeroOneOrMany(Int32).new
-      ary += [1, 2]
-      ary += 3
+      ary.push 1
+      ary << 2
+      ary.push 3
       ary.to_a.should eq([1, 2, 3])
     end
   end
@@ -81,36 +82,36 @@ describe Crystal::ZeroOneOrMany do
   describe "#+ elements" do
     it "when there's no value and elements is empty" do
       ary = Crystal::ZeroOneOrMany(Int32).new
-      ary += [] of Int32
+      ary.concat([] of Int32)
       ary.empty?.should be_true
       ary.value.should be_nil
     end
 
     it "when there's no value and elements has a single value" do
       ary = Crystal::ZeroOneOrMany(Int32).new
-      ary += [1]
+      ary.concat([1])
       ary.to_a.should eq([1])
       ary.value.should be_a(Int32)
     end
 
     it "when there's no value and elements has more than one value" do
       ary = Crystal::ZeroOneOrMany(Int32).new
-      ary += [1, 2]
+      ary.concat([1, 2])
       ary.to_a.should eq([1, 2])
       ary.value.should be_a(Array(Int32))
     end
 
     it "when there's a single value" do
       ary = Crystal::ZeroOneOrMany.new(1)
-      ary += [2, 3]
+      ary.concat([2, 3])
       ary.to_a.should eq([1, 2, 3])
       ary.value.should be_a(Array(Int32))
     end
 
     it "when there's two values" do
       ary = Crystal::ZeroOneOrMany(Int32).new
-      ary += [1, 2]
-      ary += [3, 4]
+      ary.concat([1, 2])
+      ary.concat([3, 4])
       ary.to_a.should eq([1, 2, 3, 4])
       ary.value.should be_a(Array(Int32))
     end
@@ -119,45 +120,45 @@ describe Crystal::ZeroOneOrMany do
   describe "#reject" do
     it "when there's no value" do
       ary = Crystal::ZeroOneOrMany(Int32).new
-      ary = ary.reject { true }
+      ary.reject! { true }
       ary.empty?.should be_true
       ary.value.should be_nil
     end
 
     it "when there's a single value and it matches" do
       ary = Crystal::ZeroOneOrMany(Int32).new(1)
-      ary = ary.reject { |x| x == 1 }
+      ary.reject! { |x| x == 1 }
       ary.empty?.should be_true
       ary.value.should be_nil
     end
 
     it "when there's a single value and it doesn't match" do
       ary = Crystal::ZeroOneOrMany(Int32).new(1)
-      ary = ary.reject { |x| x == 2 }
+      ary.reject! { |x| x == 2 }
       ary.to_a.should eq([1])
       ary.value.should be_a(Int32)
     end
 
     it "when there are three values and none matches" do
       ary = Crystal::ZeroOneOrMany(Int32).new
-      ary += [1, 2, 3]
-      ary = ary.reject { |x| x == 4 }
+      ary.concat([1, 2, 3])
+      ary.reject! { |x| x == 4 }
       ary.to_a.should eq([1, 2, 3])
       ary.value.should be_a(Array(Int32))
     end
 
     it "when there are three values and two match" do
       ary = Crystal::ZeroOneOrMany(Int32).new
-      ary += [1, 2, 3]
-      ary = ary.reject { |x| x < 3 }
+      ary.concat([1, 2, 3])
+      ary.reject! { |x| x < 3 }
       ary.to_a.should eq([3])
       ary.value.should be_a(Int32)
     end
 
     it "when there are three values and all match" do
       ary = Crystal::ZeroOneOrMany(Int32).new
-      ary += [1, 2, 3]
-      ary = ary.reject { |x| x < 4 }
+      ary.concat([1, 2, 3])
+      ary.reject! { |x| x < 4 }
       ary.empty?.should be_true
       ary.value.should be_nil
     end

--- a/src/compiler/crystal/semantic/bindings.cr
+++ b/src/compiler/crystal/semantic/bindings.cr
@@ -105,19 +105,9 @@ module Crystal
 
     def bind_to(node : ASTNode)
       bind(node) do
-        @dependencies += node
+        @dependencies.push node
         node.add_observer self
         node
-      end
-    end
-
-    def bind_to(node1 : ASTNode, node2 : ASTNode)
-      bind do
-        @dependencies += node1
-        @dependencies += node2
-        node1.add_observer self
-        node2.add_observer self
-        node1
       end
     end
 
@@ -125,7 +115,7 @@ module Crystal
       return if nodes.empty?
 
       bind do
-        @dependencies += nodes
+        @dependencies.concat nodes
         nodes.each &.add_observer self
         nodes.first
       end
@@ -157,12 +147,12 @@ module Crystal
     end
 
     def unbind_from(node : ASTNode) : Nil
-      @dependencies = @dependencies.reject &.same?(node)
+      @dependencies.reject! &.same?(node)
       node.remove_observer self
     end
 
     def unbind_from(nodes : Enumerable(ASTNode)) : Nil
-      @dependencies = @dependencies.reject { |dependency|
+      @dependencies.reject! { |dependency|
         nodes.any? &.same?(dependency)
       }
       nodes.each &.remove_observer self
@@ -181,11 +171,11 @@ module Crystal
     end
 
     def add_observer(observer : ASTNode) : Nil
-      @observers += observer
+      @observers.push observer
     end
 
     def remove_observer(observer : ASTNode) : Nil
-      @observers = @observers.reject &.same?(observer)
+      @observers.reject! &.same?(observer)
     end
 
     def set_enclosing_call(enclosing_call)

--- a/src/compiler/crystal/semantic/call.cr
+++ b/src/compiler/crystal/semantic/call.cr
@@ -205,7 +205,7 @@ class Crystal::Call
   def lookup_matches_in(owner : UnionType, arg_types, named_args_types, self_type = nil, def_name = self.name, search_in_parents = true, with_autocast = false) : ZeroOneOrMany(Def)
     matches = ZeroOneOrMany(Def).new
     owner.union_types.each { |type|
-      matches += lookup_matches_in(type, arg_types, named_args_types, search_in_parents: search_in_parents, with_autocast: with_autocast)
+      matches.concat lookup_matches_in(type, arg_types, named_args_types, search_in_parents: search_in_parents, with_autocast: with_autocast)
     }
     matches
   end
@@ -434,7 +434,7 @@ class Crystal::Call
         end
       end
 
-      typed_defs += typed_def
+      typed_defs << typed_def
     end
 
     typed_defs

--- a/src/compiler/crystal/semantic/main_visitor.cr
+++ b/src/compiler/crystal/semantic/main_visitor.cr
@@ -1863,7 +1863,7 @@ module Crystal
 
       @unreachable = then_unreachable && else_unreachable
 
-      node.bind_to(node.then, node.else)
+      node.bind_to({node.then, node.else})
 
       false
     end

--- a/src/compiler/crystal/semantic/method_lookup.cr
+++ b/src/compiler/crystal/semantic/method_lookup.cr
@@ -129,7 +129,7 @@ module Crystal
           next if exact_match
 
           if match
-            matches_array += match
+            matches_array.push match
 
             # If the argument types are compatible with the match's argument types,
             # we are done. We don't just compare types with ==, there is a special case:
@@ -473,7 +473,7 @@ module Crystal
                   changes << Change.new(change_owner, cloned_def)
                 end
 
-                new_subtype_matches += Match.new(cloned_def, full_subtype_match.arg_types, MatchContext.new(subtype_lookup, full_subtype_match.context.defining_type, full_subtype_match.context.free_vars), full_subtype_match.named_arg_types)
+                new_subtype_matches.push Match.new(cloned_def, full_subtype_match.arg_types, MatchContext.new(subtype_lookup, full_subtype_match.context.defining_type, full_subtype_match.context.free_vars), full_subtype_match.named_arg_types)
               end
 
               # Reset the `self` restriction override
@@ -506,7 +506,7 @@ module Crystal
             # We need to insert the matches before the previous ones
             # because subtypes are more specific matches
             if matches
-              subtype_matches_matches += matches
+              subtype_matches_matches.concat matches
             end
             matches = subtype_matches_matches
           end


### PR DESCRIPTION
An alternative way to implementing #12405 where `ZeroOneOrMany` has almost the same interface as `Array` and it's mutable. Less surprises than the base branch. However, the type is still a struct so there might be the usual "struct surprises".