### PR TITLE
Compiler: only have freeze_type in select AST nodes

### DIFF
--- a/src/compiler/crystal/semantic/ast.cr
+++ b/src/compiler/crystal/semantic/ast.cr
@@ -139,6 +139,7 @@ module Crystal
     property previous : DefWithMetadata?
     property next : Def?
     property special_vars : Set(String)?
+    property freeze_type : Type?
     property block_nest = 0
     property? raises = false
     property? closure = false
@@ -428,6 +429,8 @@ module Crystal
     # a Def or a Block.
     property context : ASTNode | NonGenericModuleType | Nil
 
+    property freeze_type : Type?
+
     # True if we need to mark this variable as nilable
     # if this variable is read.
     property? nil_if_read = false
@@ -526,6 +529,8 @@ module Crystal
     # The (optional) initial value of a class variable
     property initializer : ClassVarInitializer?
 
+    property freeze_type : Type?
+
     # Flag used during codegen to indicate the initializer is simple
     # and doesn't require a call to a function
     property? simple_initializer = false
@@ -606,6 +611,7 @@ module Crystal
     property after_vars : MetaVars?
     property context : Def | NonGenericModuleType | Nil
     property fun_literal : ASTNode?
+    property freeze_type : Type?
     property? visited = false
 
     getter(:break) { Var.new("%break") }

--- a/src/compiler/crystal/semantic/bindings.cr
+++ b/src/compiler/crystal/semantic/bindings.cr
@@ -1,28 +1,5 @@
 module Crystal
   class ASTNode
-    # A node whose type can be frozen.
-    # When frozen, trying to change the node's type to something
-    # that doesn't match `freeze_type` will produce a compilation error.
-    # This is used for checking a method's return type, a block's
-    # expected type, instance and class vars expected types,
-    # and local vars with a type declaration.
-    module Freezable
-      property freeze_type : Type?
-    end
-
-    # By default nodes don't have their type frozen.
-    def freeze_type
-      nil
-    end
-  end
-
-  {% for name in %w(Block MetaVar MetaTypeVar Def) %}
-    class {{name.id}}
-      include Freezable
-    end
-  {% end %}
-
-  class ASTNode
     property! dependencies : Array(ASTNode)
     property observers : Array(ASTNode)?
     property enclosing_call : Call?
@@ -91,6 +68,10 @@ module Crystal
       else
         ::raise ex
       end
+    end
+
+    def freeze_type
+      nil
     end
 
     def raise_frozen_type(freeze_type, invalid_type, from)


### PR DESCRIPTION
When you have code like this:

```crystal
def foo : Int32
  "hello"
end
```

the way the compiler implements this is by setting the `freeze_type` property of a `Def` to `Int32`. Then before trying to set the method's type to String it will check if there's a `freeze_type` set. If so, it will check String against Int32 and produce a compile-time error.

This `freeze_type` concept was implemented generically in all AST nodes: any node can be "frozen", and whenever its type changes we check against `freeze_type`.

The thing is, there are only four AST nodes that need this `freeze_type` property: methods, blocks, and special nodes called "meta vars" or "meta type vars" that correspond to local vars and instance/class vars respectively.

This PR makes it so that only those four nodes have a `freeze_type` instance var. All other nodes still respond to `freeze_type` by retuning `nil`.

With this, all AST nodes except those four will now take 8 bytes less in memory. The compiler creates a lot of AST nodes! And whenever a method is instantiated (its arguments get a concrete type) the entire method with all its AST nodes is cloned. So 8 bytes per nodes is a significant amount of memory.

It seems that compiling the compiler before this PR needed 2367.61MB. With this PR it goes down to 2240.64MB (and this is unrelated to the ZeroOneOrMany PR!)

Compilation times doesn't noticeably go down, at least not on my machine.

There are further optimizations to make here: instead of storing `freeze_type` for a `Def`, we could actually make `freeze_type` return the return type AST node type's. But I'd like to make that change in a separate PR. I'm trying to make each change in the smallest way possible.