### PR TITLE
Compiler: delegate Def#freeze_type to its return type node

### DIFF
--- a/src/compiler/crystal/semantic/ast.cr
+++ b/src/compiler/crystal/semantic/ast.cr
@@ -139,7 +139,6 @@ module Crystal
     property previous : DefWithMetadata?
     property next : Def?
     property special_vars : Set(String)?
-    property freeze_type : Type?
     property block_nest = 0
     property? raises = false
     property? closure = false
@@ -165,6 +164,10 @@ module Crystal
 
     # Used to override the meaning of `self` in restrictions
     property self_restriction_type : Type?
+
+    def freeze_type
+      return_type.try &.type?
+    end
 
     def macro_owner=(@macro_owner)
     end

--- a/src/compiler/crystal/semantic/call.cr
+++ b/src/compiler/crystal/semantic/call.cr
@@ -449,7 +449,7 @@ class Crystal::Call
   def check_return_type(typed_def, typed_def_return_type, match, match_owner)
     return_type = lookup_node_type(match.context, typed_def_return_type)
     return_type = program.nil if return_type.void?
-    typed_def.freeze_type = return_type
+    typed_def_return_type.type = return_type
     typed_def.type = return_type if return_type.no_return? || return_type.nil_type?
   end
 


### PR DESCRIPTION
Follow up to #12428

There's no need for a `Def` to have a property to hold `freeze_type`: we can set the return type node's type, and then have `freeze_type` delegate to it.

This removes 8 bytes from all `Def` nodes.

That said: a Def is a pretty big node (352 bytes! 😮) so removing 8 bytes from that won't be noticeable. But every bit counts when doing optimizations!

It also makes it more clear what's the relation between a Def and its freeze_type.