### PR TITLE
Compiler: avoid creating Set in merge_if_vars

### DIFF
--- a/src/compiler/crystal/semantic/main_visitor.cr
+++ b/src/compiler/crystal/semantic/main_visitor.cr
@@ -1894,10 +1894,9 @@ module Crystal
       end
 
       else_vars.each do |name, else_var|
-        then_var = then_vars[name]?
-        next if then_var
+        next if then_vars.has_key?(name)
 
-        merge_if_var(name, node, cond_vars, then_var, else_var, before_then_vars, before_else_vars, then_unreachable, else_unreachable)
+        merge_if_var(name, node, cond_vars, nil, else_var, before_then_vars, before_else_vars, then_unreachable, else_unreachable)
       end
     end
 


### PR DESCRIPTION
Yes another optimization in `merge_if_vars`. This one has a bit more impact: less memory allocated, and slightly better performance.

When merging `if` vars we need to traverse all vars defined in the `then` and `else` branches. We were doing this by creating a Set will all var names from both branches and then traversing that.

However, it's more efficient if we first traverse the vars in `then`. Then when traversing the vars in `else` we can skip that if we already traversed it in the `then` branch.