### PR TITLE
Do not check abstract def parameter names on abstract types and modules

### DIFF
--- a/spec/compiler/semantic/warnings_spec.cr
+++ b/spec/compiler/semantic/warnings_spec.cr
@@ -728,5 +728,37 @@ describe "Semantic: warnings" do
           CR
       end
     end
+
+    it "doesn't warn if current type is abstract (#12266)" do
+      warnings_result(<<-CR).should be_empty
+        class Foo
+          def foo(x); end
+        end
+
+        abstract class Bar < Foo
+          abstract def foo(y)
+        end
+
+        abstract class Baz < Bar
+        end
+        CR
+    end
+
+    it "doesn't warn if current type is a module (#12266)" do
+      warnings_result(<<-CR).should be_empty
+        module Foo
+          def foo(x); end # Warning: positional parameter 'x' corresponds to parameter 'y' of the overridden method Bar#foo(y), which has a different name and may affect named argument passing
+        end
+
+        module Bar
+          include Foo
+          abstract def foo(y)
+        end
+
+        module Baz
+          include Bar
+        end
+        CR
+    end
   end
 end

--- a/src/compiler/crystal/semantic/abstract_def_checker.cr
+++ b/src/compiler/crystal/semantic/abstract_def_checker.cr
@@ -124,8 +124,8 @@ class Crystal::AbstractDefChecker
             implemented = true
           end
 
-          unless found_param_match
-            check_positional_param_names(target_type, ancestor_type, a_def, base, method)
+          unless found_param_match || target_type.abstract? || target_type.module?
+            check_positional_param_names(a_def, base, method)
             found_param_match = true if same_parameters?(a_def, method)
           end
         end
@@ -368,7 +368,7 @@ class Crystal::AbstractDefChecker
     end
   end
 
-  def check_positional_param_names(target_type : Type, impl_type : Type, impl_method : Def, base_type : Type, base_method : Def)
+  def check_positional_param_names(impl_method : Def, base_type : Type, base_method : Def)
     impl_param_count = impl_method.splat_index || impl_method.args.size
     base_param_count = base_method.splat_index || base_method.args.size
     {impl_param_count, base_param_count}.min.times do |i|


### PR DESCRIPTION
Fixes #12266.