### PR TITLE
Compiler: refactor and slightly optimize merging two types

### DIFF
--- a/src/compiler/crystal/semantic/type_declaration_processor.cr
+++ b/src/compiler/crystal/semantic/type_declaration_processor.cr
@@ -406,7 +406,7 @@ struct Crystal::TypeDeclarationProcessor
     when NonGenericModuleType
       type = type_info.type
       if nilable_instance_var?(owner, name)
-        type = Type.merge!([type, @program.nil])
+        type = Type.merge!(type, @program.nil)
       end
 
       # Same as above, only Nil makes no sense
@@ -423,7 +423,7 @@ struct Crystal::TypeDeclarationProcessor
     when GenericClassType
       type = type_info.type
       if nilable_instance_var?(owner, name)
-        type = Type.merge!([type, @program.nil])
+        type = Type.merge!(type, @program.nil)
       end
 
       # Same as above, only Nil makes no sense
@@ -442,7 +442,7 @@ struct Crystal::TypeDeclarationProcessor
     when GenericModuleType
       type = type_info.type
       if nilable_instance_var?(owner, name)
-        type = Type.merge!([type, @program.nil])
+        type = Type.merge!(type, @program.nil)
       end
 
       declare_meta_type_var(owner.instance_vars, owner, name, type, type_info.location, instance_var: true, annotations: type_info.annotations)

--- a/src/compiler/crystal/semantic/type_guess_visitor.cr
+++ b/src/compiler/crystal/semantic/type_guess_visitor.cr
@@ -419,7 +419,7 @@ module Crystal
         info.add_annotations(annotations) if annotations
         vars[name] = info
       else
-        info.type = Type.merge!([info.type, type])
+        info.type = Type.merge!(info.type, type)
         info.outside_def = true if @outside_def
         info.add_annotations(annotations) if annotations
         vars[name] = info

--- a/src/compiler/crystal/semantic/type_merge.cr
+++ b/src/compiler/crystal/semantic/type_merge.cr
@@ -48,6 +48,13 @@ module Crystal
         return first
       end
 
+      if first.no_return?
+        return second
+      end
+
+      if second.no_return?
+        return first
+      end
       if !first.is_a?(UnionType) && second.is_a?(UnionType) && second.union_types.includes?(first)
         return second
       end

--- a/src/compiler/crystal/semantic/type_merge.cr
+++ b/src/compiler/crystal/semantic/type_merge.cr
@@ -178,8 +178,8 @@ module Crystal
       merge(types_or_nodes).not_nil!
     end
 
-    def self.merge!(type1 : Type, type2 : Type)
-      merge!([type1, type2])
+    def self.merge!(type1 : Type, type2 : Type) : Type
+      type1.program.type_merge(type1, type2).not_nil!
     end
 
     # Given two non-union types T and U, returns their least common ancestor

--- a/src/compiler/crystal/semantic/type_merge.cr
+++ b/src/compiler/crystal/semantic/type_merge.cr
@@ -41,30 +41,32 @@ module Crystal
     def type_merge_two(first, second)
       if first == second
         # Same, so return any of them
-        {true, first}
-      elsif first
-        if second
-          # first and second not nil and different
-          if first.opaque_id > second.opaque_id
-            first, second = second, first
-          end
-
-          if first.nil_type?
-            if second.is_a?(UnionType) && second.union_types.includes?(first)
-              return true, second
-            end
-          end
-
-          # puts "#{first} vs. #{second}"
-          {false, nil}
-        else
-          # Second is nil, so return first
-          {true, first}
-        end
-      else
-        # First is nil, so return second
-        {true, second}
+        return {true, first}
       end
+
+      unless first
+        # First is nil, so return second
+        return {true, second}
+      end
+
+      unless second
+        # Second is nil, so return first
+        return {true, first}
+      end
+
+      # first and second not nil and different
+      if first.opaque_id > second.opaque_id
+        first, second = second, first
+      end
+
+      if first.nil_type?
+        if second.is_a?(UnionType) && second.union_types.includes?(first)
+          return true, second
+        end
+      end
+
+      # puts "#{first} vs. #{second}"
+      {false, nil}
     end
 
     def type_merge_union_of(types : Array(Type))

--- a/src/compiler/crystal/semantic/type_merge.cr
+++ b/src/compiler/crystal/semantic/type_merge.cr
@@ -54,15 +54,12 @@ module Crystal
         return {true, first}
       end
 
-      # first and second not nil and different
-      if first.opaque_id > second.opaque_id
-        first, second = second, first
+      if first.nil_type? && second.is_a?(UnionType) && second.union_types.includes?(first)
+        return true, second
       end
 
-      if first.nil_type?
-        if second.is_a?(UnionType) && second.union_types.includes?(first)
-          return true, second
-        end
+      if second.nil_type? && first.is_a?(UnionType) && first.union_types.includes?(second)
+        return true, first
       end
 
       # puts "#{first} vs. #{second}"

--- a/src/compiler/crystal/semantic/type_merge.cr
+++ b/src/compiler/crystal/semantic/type_merge.cr
@@ -11,7 +11,7 @@ module Crystal
       when 2
         # Merging two types is the most common case, so we optimize it
         first, second = types
-        type_merge_two(first, second)
+        type_merge(first, second)
       else
         combined_union_of compact_types(types)
       end
@@ -26,13 +26,13 @@ module Crystal
       when 2
         # Merging two types is the most common case, so we optimize it
         first, second = nodes
-        type_merge_two(first.type?, second.type?)
+        type_merge(first.type?, second.type?)
       else
         combined_union_of compact_types(nodes, &.type?)
       end
     end
 
-    def type_merge_two(first : Type?, second : Type?) : Type?
+    def type_merge(first : Type?, second : Type?) : Type?
       if first == second
         # Same, so return any of them
         return first

--- a/src/compiler/crystal/semantic/type_merge.cr
+++ b/src/compiler/crystal/semantic/type_merge.cr
@@ -162,11 +162,11 @@ module Crystal
   end
 
   class Type
-    def self.merge(nodes : Array(ASTNode))
+    def self.merge(nodes : Array(ASTNode)) : Type?
       nodes.find(&.type?).try &.type.program.type_merge(nodes)
     end
 
-    def self.merge(types : Array(Type))
+    def self.merge(types : Array(Type)) : Type?
       if types.size == 0
         nil
       else
@@ -174,7 +174,7 @@ module Crystal
       end
     end
 
-    def self.merge!(types_or_nodes)
+    def self.merge!(types_or_nodes) : Type
       merge(types_or_nodes).not_nil!
     end
 

--- a/src/compiler/crystal/semantic/type_merge.cr
+++ b/src/compiler/crystal/semantic/type_merge.cr
@@ -33,28 +33,20 @@ module Crystal
     end
 
     def type_merge(first : Type?, second : Type?) : Type?
-      if first == second
-        # Same, so return any of them
-        return first
-      end
+      # Same, so return any of them
+      return first if first == second
 
-      unless first
-        # First is nil, so return second
-        return second
-      end
+      # First is nil, so return second
+      return second unless first
 
-      unless second
-        # Second is nil, so return first
-        return first
-      end
+      # Second is nil, so return first
+      return first unless second
 
-      if first.no_return?
-        return second
-      end
+      # NoReturn is removed from unions
+      return second if first.no_return?
+      return first if second.no_return?
 
-      if second.no_return?
-        return first
-      end
+      # Check if a non-union type is part of a union type
       if !first.is_a?(UnionType) && second.is_a?(UnionType) && second.union_types.includes?(first)
         return second
       end
@@ -63,6 +55,7 @@ module Crystal
         return first
       end
 
+      # General case
       combined_union_of compact_types({first, second})
     end
 

--- a/src/compiler/crystal/semantic/type_merge.cr
+++ b/src/compiler/crystal/semantic/type_merge.cr
@@ -2,7 +2,7 @@ require "../program"
 
 module Crystal
   class Program
-    def type_merge(types : Array(Type?))
+    def type_merge(types : Array(Type?)) : Type?
       case types.size
       when 0
         nil
@@ -17,7 +17,7 @@ module Crystal
       end
     end
 
-    def type_merge(nodes : Array(ASTNode))
+    def type_merge(nodes : Array(ASTNode)) : Type?
       case nodes.size
       when 0
         nil
@@ -32,7 +32,7 @@ module Crystal
       end
     end
 
-    def type_merge_two(first, second)
+    def type_merge_two(first : Type?, second : Type?) : Type?
       if first == second
         # Same, so return any of them
         return first
@@ -59,15 +59,15 @@ module Crystal
       combined_union_of compact_types({first, second})
     end
 
-    def type_merge_union_of(types : Array(Type))
+    def type_merge_union_of(types : Array(Type)) : Type?
       union_of compact_types(types)
     end
 
-    def compact_types(types)
+    def compact_types(types) : Array(Type)
       compact_types(types) { |type| type }
     end
 
-    def compact_types(objects)
+    def compact_types(objects) : Array(Type)
       all_types = Array(Type).new(objects.size)
       objects.each { |obj| add_type all_types, yield(obj) }
       all_types.reject! &.no_return? if all_types.size > 1

--- a/src/compiler/crystal/semantic/type_merge.cr
+++ b/src/compiler/crystal/semantic/type_merge.cr
@@ -5,65 +5,58 @@ module Crystal
     def type_merge(types : Array(Type?))
       case types.size
       when 0
-        return nil
+        nil
       when 1
-        return types.first
+        types.first
       when 2
         # Merging two types is the most common case, so we optimize it
         first, second = types
-        did_merge, merged_type = type_merge_two(first, second)
-        return merged_type if did_merge
+        type_merge_two(first, second)
       else
-        # combined_union_of
+        combined_union_of compact_types(types)
       end
-
-      combined_union_of compact_types(types)
     end
 
     def type_merge(nodes : Array(ASTNode))
       case nodes.size
       when 0
-        return nil
+        nil
       when 1
-        return nodes.first.type?
+        nodes.first.type?
       when 2
         # Merging two types is the most common case, so we optimize it
         first, second = nodes
-        did_merge, merged_type = type_merge_two(first.type?, second.type?)
-        return merged_type if did_merge
+        type_merge_two(first.type?, second.type?)
       else
-        # combined_union_of
+        combined_union_of compact_types(nodes, &.type?)
       end
-
-      combined_union_of compact_types(nodes, &.type?)
     end
 
     def type_merge_two(first, second)
       if first == second
         # Same, so return any of them
-        return {true, first}
+        return first
       end
 
       unless first
         # First is nil, so return second
-        return {true, second}
+        return second
       end
 
       unless second
         # Second is nil, so return first
-        return {true, first}
+        return first
       end
 
       if first.nil_type? && second.is_a?(UnionType) && second.union_types.includes?(first)
-        return true, second
+        return second
       end
 
       if second.nil_type? && first.is_a?(UnionType) && first.union_types.includes?(second)
-        return true, first
+        return first
       end
 
-      # puts "#{first} vs. #{second}"
-      {false, nil}
+      combined_union_of compact_types({first, second})
     end
 
     def type_merge_union_of(types : Array(Type))

--- a/src/compiler/crystal/semantic/type_merge.cr
+++ b/src/compiler/crystal/semantic/type_merge.cr
@@ -48,11 +48,11 @@ module Crystal
         return first
       end
 
-      if first.nil_type? && second.is_a?(UnionType) && second.union_types.includes?(first)
+      if !first.is_a?(UnionType) && second.is_a?(UnionType) && second.union_types.includes?(first)
         return second
       end
 
-      if second.nil_type? && first.is_a?(UnionType) && first.union_types.includes?(second)
+      if !second.is_a?(UnionType) && first.is_a?(UnionType) && first.union_types.includes?(second)
         return first
       end
 


### PR DESCRIPTION
This is mainly a refactor so that two types can be merged without creating intermediate arrays in most cases. I need this refactor for some other things I have in mind.

It also includes some small optimizations to avoid creating intermediate arrays in some cases, but they aren't significant. Well, when compiling the compiler it seems this reduces the total amount of memory by 10MB, so I guess that's good 😄 