### PR TITLE
Compiler refactor: extract `type_from_dependencies`

### DIFF
--- a/src/compiler/crystal/semantic/bindings.cr
+++ b/src/compiler/crystal/semantic/bindings.cr
@@ -106,21 +106,19 @@ module Crystal
       @type
     end
 
-    def bind_to(node : ASTNode)
+    def bind_to(node : ASTNode) : Nil
       bind(node) do |dependencies|
         dependencies.push node
         node.add_observer self
-        node
       end
     end
 
-    def bind_to(nodes : Indexable)
+    def bind_to(nodes : Indexable) : Nil
       return if nodes.empty?
 
       bind do |dependencies|
         dependencies.concat nodes
         nodes.each &.add_observer self
-        nodes.first
       end
     end
 
@@ -134,7 +132,7 @@ module Crystal
 
       dependencies = @dependencies ||= [] of ASTNode
 
-      node = yield dependencies
+      yield dependencies
 
       new_type = type_from_dependencies
       new_type = map_type(new_type) if new_type

--- a/src/compiler/crystal/semantic/bindings.cr
+++ b/src/compiler/crystal/semantic/bindings.cr
@@ -136,11 +136,7 @@ module Crystal
 
       node = yield dependencies
 
-      if dependencies.size == 1
-        new_type = node.type?
-      else
-        new_type = Type.merge dependencies
-      end
+      new_type = type_from_dependencies
       new_type = map_type(new_type) if new_type
 
       if new_type && (freeze_type = self.freeze_type)
@@ -153,6 +149,10 @@ module Crystal
       set_type_from(new_type, from)
       @dirty = true
       propagate
+    end
+
+    def type_from_dependencies : Type?
+      Type.merge dependencies
     end
 
     def unbind_from(nodes : Nil)
@@ -206,7 +206,7 @@ module Crystal
     def update(from = nil)
       return if @type && @type.same? from.try &.type?
 
-      new_type = Type.merge dependencies
+      new_type = type_from_dependencies
       new_type = map_type(new_type) if new_type
 
       if new_type && (freeze_type = self.freeze_type)


### PR DESCRIPTION
Two places in the code had a similar logic: computing a node's type from its dependencies. One of the branches actually involved a bit of duplicate logic: checking for the dependencies size first, but then `Type.merge(...)` also checks for the size again.

This PR moves that logic to a helper method: `type_from_dependencies`. We could simply call `Type.merge(dependencies)` instead, but for later refactors I have in mind overriding `type_from_dependencies` for some specific AST nodes. For example, an `if` node is currently bound to its `then` and `else` nodes, putting them in the `dependencies` array. But that's not needed: we could override `type_from_dependencies` for `If` to return the type union of the `then` and `else` node. That way we don't need to store an array of two elements in `dependencies` for every `if` in the program.

However, I'd like to do those optimizations in a separate PR to keep things small and easier to review.