### PR TITLE
src/compiler/crystal/compiler.cr: allow LLVM on Windows

### DIFF
--- a/src/compiler/crystal/compiler.cr
+++ b/src/compiler/crystal/compiler.cr
@@ -21,7 +21,7 @@ module Crystal
   # optionally generates an executable.
   class Compiler
     CC = ENV["CC"]? || "cc"
-    CL = "cl.exe"
+    CL = ENV["CL"]? || "cl.exe"
 
     # A source to the compiler: its filename and source code.
     record Source,


### PR DESCRIPTION
Current `CL` variable is hardcoded to `cl.exe`, which prevents other backends
with Windows.