### PR TITLE
Interpreter: set correct scope for class var initializer

### DIFF
--- a/spec/compiler/interpreter/class_vars_spec.cr
+++ b/spec/compiler/interpreter/class_vars_spec.cr
@@ -126,5 +126,23 @@ describe Crystal::Repl::Interpreter do
         a
       CODE
     end
+
+    it "finds self in class var initializer (#12439)" do
+      interpret(<<-CODE).should eq(42)
+        class Foo
+          @@value : Int32 = self.int
+
+          def self.value
+            @@value
+          end
+
+          def self.int
+            42
+          end
+        end
+
+        Foo.value
+      CODE
+    end
   end
 end

--- a/src/compiler/crystal/interpreter/compiler.cr
+++ b/src/compiler/crystal/interpreter/compiler.cr
@@ -1153,7 +1153,7 @@ class Crystal::Repl::Compiler < Crystal::Visitor
       def_name = "#{var.owner}::#{var.name}"
 
       fake_def = Def.new(def_name)
-      fake_def.owner = var.owner
+      fake_def.owner = var.owner.metaclass
       fake_def.vars = initializer.meta_vars
       fake_def.body = value
       fake_def.bind_to(value)
@@ -1164,7 +1164,7 @@ class Crystal::Repl::Compiler < Crystal::Visitor
       # program, but this needs to be fixed in the main compiler first
       declare_local_vars(fake_def, compiled_def.local_vars, @context.program)
 
-      compiler = Compiler.new(@context, compiled_def, top_level: true)
+      compiler = Compiler.new(@context, compiled_def, scope: fake_def.owner, top_level: true)
       compiler.compile_def(compiled_def, closure_owner: @context.program)
 
       {% if Debug::DECOMPILE %}


### PR DESCRIPTION
Fixes #12439