### PR TITLE
Compiler/codegen: reset `@needs_value`

### DIFF
--- a/spec/compiler/codegen/block_spec.cr
+++ b/spec/compiler/codegen/block_spec.cr
@@ -1571,4 +1571,20 @@ describe "Code gen: block" do
       end
     )).to_i.should eq(1)
   end
+
+  it "(bug) doesn't set needs_value to true on every yield (#12442)" do
+    run(%(
+      def foo
+        if true
+          yield
+        end
+
+        1
+      end
+
+      foo do
+        1
+      end
+      )).to_i.should eq(1)
+  end
 end

--- a/src/compiler/crystal/codegen/call.cr
+++ b/src/compiler/crystal/codegen/call.cr
@@ -69,9 +69,7 @@ class Crystal::CodeGenVisitor
     # Always accept obj: even if it's not passed as self this might
     # involve intermediate calls with side effects.
     if obj
-      request_value do
-        accept obj
-      end
+      request_value(obj)
     end
 
     # First self.
@@ -95,9 +93,7 @@ class Crystal::CodeGenVisitor
 
     # Then the arguments.
     node.args.zip(target_def.args) do |arg, def_arg|
-      request_value do
-        accept arg
-      end
+      request_value(arg)
 
       if arg.type.void?
         call_arg = int8(0)
@@ -184,9 +180,7 @@ class Crystal::CodeGenVisitor
           arg.raise "BUG: out argument was #{exp}"
         end
       else
-        request_value do
-          accept arg
-        end
+        request_value(arg)
 
         if arg.type.void?
           call_arg = int8(0)
@@ -320,9 +314,7 @@ class Crystal::CodeGenVisitor
           # Reset vars that are declared inside the def and are nilable
           reset_nilable_vars(target_def)
 
-          request_value do
-            accept target_def.body
-          end
+          request_value(target_def.body)
 
           phi.add @last, target_def.body.type?, last: true
         end
@@ -347,9 +339,7 @@ class Crystal::CodeGenVisitor
     # Get type_id of obj or owner
     if node_obj = node.obj
       owner = node_obj.type
-      request_value do
-        accept node_obj
-      end
+      request_value(node_obj)
       obj_type_id = @last
     elsif node.uses_with_scope? && (with_scope = node.with_scope)
       owner = with_scope
@@ -367,9 +357,7 @@ class Crystal::CodeGenVisitor
 
     # Get type if of args and create arg vars
     arg_type_ids = node.args.map_with_index do |arg, i|
-      request_value do
-        accept arg
-      end
+      request_value(arg)
       new_vars["%arg#{i}"] = LLVMVar.new(@last, arg.type, true)
       type_id(@last, arg.type)
     end

--- a/src/compiler/crystal/codegen/call.cr
+++ b/src/compiler/crystal/codegen/call.cr
@@ -69,8 +69,9 @@ class Crystal::CodeGenVisitor
     # Always accept obj: even if it's not passed as self this might
     # involve intermediate calls with side effects.
     if obj
-      @needs_value = true
-      accept obj
+      request_value do
+        accept obj
+      end
     end
 
     # First self.
@@ -94,8 +95,9 @@ class Crystal::CodeGenVisitor
 
     # Then the arguments.
     node.args.zip(target_def.args) do |arg, def_arg|
-      @needs_value = true
-      accept arg
+      request_value do
+        accept arg
+      end
 
       if arg.type.void?
         call_arg = int8(0)
@@ -182,8 +184,9 @@ class Crystal::CodeGenVisitor
           arg.raise "BUG: out argument was #{exp}"
         end
       else
-        @needs_value = true
-        accept arg
+        request_value do
+          accept arg
+        end
 
         if arg.type.void?
           call_arg = int8(0)
@@ -344,8 +347,9 @@ class Crystal::CodeGenVisitor
     # Get type_id of obj or owner
     if node_obj = node.obj
       owner = node_obj.type
-      @needs_value = true
-      accept node_obj
+      request_value do
+        accept node_obj
+      end
       obj_type_id = @last
     elsif node.uses_with_scope? && (with_scope = node.with_scope)
       owner = with_scope
@@ -363,8 +367,9 @@ class Crystal::CodeGenVisitor
 
     # Get type if of args and create arg vars
     arg_type_ids = node.args.map_with_index do |arg, i|
-      @needs_value = true
-      accept arg
+      request_value do
+        accept arg
+      end
       new_vars["%arg#{i}"] = LLVMVar.new(@last, arg.type, true)
       type_id(@last, arg.type)
     end

--- a/src/compiler/crystal/codegen/class_var.cr
+++ b/src/compiler/crystal/codegen/class_var.cr
@@ -133,9 +133,7 @@ class Crystal::CodeGenVisitor
 
             alloca_vars initializer.meta_vars
 
-            request_value do
-              accept node
-            end
+            request_value(node)
 
             node_type = node.type
 

--- a/src/compiler/crystal/codegen/codegen.cr
+++ b/src/compiler/crystal/codegen/codegen.cr
@@ -1590,10 +1590,11 @@ module Crystal
           context.next_phi = phi
           context.closure_parent_context = block_context.closure_parent_context
 
-          @needs_value = true
-          set_ensure_exception_handler(block)
+          request_value do
+            set_ensure_exception_handler(block)
 
-          accept block.body
+            accept block.body
+          end
         end
 
         phi.add @last, block.body.type?, last: true

--- a/src/compiler/crystal/codegen/codegen.cr
+++ b/src/compiler/crystal/codegen/codegen.cr
@@ -859,9 +859,7 @@ module Crystal
 
             position_at_end while_block
 
-            request_value(false) do
-              accept node.body
-            end
+            discard_value(node.body)
             br while_block
           end
         else
@@ -883,9 +881,7 @@ module Crystal
 
             position_at_end body_block
 
-            request_value(false) do
-              accept node.body
-            end
+            discard_value(node.body)
             br while_block
 
             position_at_end fail_block
@@ -2262,6 +2258,12 @@ module Crystal
 
     def request_value(node : ASTNode)
       request_value do
+        accept node
+      end
+    end
+
+    def discard_value(node : ASTNode)
+      request_value(false) do
         accept node
       end
     end

--- a/src/compiler/crystal/codegen/const.cr
+++ b/src/compiler/crystal/codegen/const.cr
@@ -75,9 +75,7 @@ class Crystal::CodeGenVisitor
     set_current_debug_location const.locations.try &.first? if @debug.line_numbers?
 
     global = declare_const(const)
-    request_value do
-      accept const.value
-    end
+    request_value(const.value)
 
     const_type = const.value.type
     if const_type.passed_by_value?
@@ -105,9 +103,7 @@ class Crystal::CodeGenVisitor
       set_current_debug_location const.locations.try &.first? if @debug.line_numbers?
 
       alloca_vars const.fake_def.try(&.vars), const.fake_def
-      request_value do
-        accept const.value
-      end
+      request_value(const.value)
     end
 
     const_type = const.value.type
@@ -161,9 +157,7 @@ class Crystal::CodeGenVisitor
 
           alloca_vars const.fake_def.try(&.vars), const.fake_def
 
-          request_value do
-            accept const.value
-          end
+          request_value(const.value)
 
           if const.value.type.passed_by_value?
             @last = load @last

--- a/src/compiler/crystal/codegen/primitives.cr
+++ b/src/compiler/crystal/codegen/primitives.cr
@@ -826,7 +826,7 @@ class Crystal::CodeGenVisitor
     if (extra = node.extra)
       existing_value = context.vars["value"]?
       context.vars["value"] = LLVMVar.new(call_arg, node.type, true)
-      request_value { accept extra }
+      request_value(extra)
       call_arg = @last
       context.vars["value"] = existing_value if existing_value
     end


### PR DESCRIPTION
Fixes #12442

The first commit fixes the bug. The other commits are more similar fixes and refactors to make sure that `@needs_value` is always reset after changing it. And then a couple more commits that extract a pattern.