### PR TITLE
Fix `homogeneous_aggregate?` check for aarch64 types

### DIFF
--- a/spec/std/llvm/aarch64_spec.cr
+++ b/spec/std/llvm/aarch64_spec.cr
@@ -144,6 +144,18 @@ class LLVM::ABI
           info.arg_types[0].should eq(ArgType.indirect(str, nil))
           info.return_type.should eq(ArgType.indirect(str, Attribute::StructRet))
         end
+
+        test "does with homogeneous structs" do |abi, ctx|
+          str = ctx.struct([ctx.float, ctx.float, ctx.float, ctx.float])
+          arg_types = [str]
+          return_type = str
+
+          info = abi.abi_info(arg_types, return_type, true, ctx)
+          info.arg_types.size.should eq(1)
+
+          info.arg_types[0].should eq(ArgType.direct(str, ctx.float.array(4)))
+          info.return_type.should eq(ArgType.direct(str, ctx.float.array(4)))
+        end
       end
     {% end %}
   end

--- a/src/llvm/abi/aarch64.cr
+++ b/src/llvm/abi/aarch64.cr
@@ -18,7 +18,7 @@ class LLVM::ABI::AArch64 < LLVM::ABI
   end
 
   def homogeneous_aggregate?(type)
-    homog_agg : {Type, UInt64}? = case type
+    homog_agg : {Type, UInt64}? = case type.kind
     when Type::Kind::Float
       return {type, 1_u64}
     when Type::Kind::Double


### PR DESCRIPTION
Previously we recorded all return and arg types as though they weren't homogeneous aggregates. This minor changes fixes #12407

<details>
<summary>Side note: This also fixes the ImGui bindings from my emulator :)</summary>

![image](https://user-images.githubusercontent.com/22065329/188329701-3dcd5e61-e7dd-4fc6-a76e-3932e6b65a6b.png)
</details>