### PR TITLE
Handle formatting annotated method parameters

### DIFF
--- a/spec/compiler/formatter/formatter_spec.cr
+++ b/spec/compiler/formatter/formatter_spec.cr
@@ -260,12 +260,51 @@ describe Crystal::Formatter do
   assert_format "def foo\n  1\n  #\n\n\nrescue\nend", "def foo\n  1\n  #\nrescue\nend"
 
   assert_format "def foo(@[MyAnn] v); end"
+  assert_format "def foo(@[MyAnn] &); end"
+  assert_format "def foo(@[MyAnn] &block); end"
+  assert_format "def foo(@[MyAnn] & : String -> Nil); end"
   assert_format "def foo(  @[MyAnn]  v  ); end", "def foo(@[MyAnn] v); end"
   assert_format "def foo(@[AnnOne] @[AnnTwo] v); end"
   assert_format "def foo(@[AnnOne]   @[AnnTwo] v); end", "def foo(@[AnnOne] @[AnnTwo] v); end"
+  assert_format "def foo(@[AnnOne]   @[AnnTwo]   &  ); end", "def foo(@[AnnOne] @[AnnTwo] &); end"
+  assert_format "def foo(@[AnnOne]   @[AnnTwo]   &block : Int32 ->  ); end", "def foo(@[AnnOne] @[AnnTwo] &block : Int32 ->); end"
   assert_format <<-CRYSTAL
   def foo(
     @[MyAnn] bar
+  ); end
+  CRYSTAL
+
+  assert_format <<-CRYSTAL
+  def foo(
+    foo,
+    @[MyAnn] &block
+  ); end
+  CRYSTAL
+
+  assert_format <<-CRYSTAL
+  def foo(
+    foo,
+    @[MyAnn]
+    &block
+  ); end
+  CRYSTAL
+
+  assert_format <<-CRYSTAL
+  def foo(
+    foo,
+
+    @[MyAnn]
+    &block
+  ); end
+  CRYSTAL
+
+  assert_format <<-CRYSTAL
+  def foo(
+    foo,
+
+    @[MyAnn]
+    @[MyAnn]
+    & : Nil -> Nil
   ); end
   CRYSTAL
 

--- a/spec/compiler/formatter/formatter_spec.cr
+++ b/spec/compiler/formatter/formatter_spec.cr
@@ -1,8 +1,8 @@
 require "spec"
 require "../../../src/compiler/crystal/formatter"
 
-private def assert_format(input, output = input, strict = false, file = __FILE__, line = __LINE__, focus : Bool = false)
-  it "formats #{input.inspect}", file, line, focus: focus do
+private def assert_format(input, output = input, strict = false, file = __FILE__, line = __LINE__)
+  it "formats #{input.inspect}", file, line do
     output = "#{output}\n" unless strict
     result = Crystal.format(input)
     unless result == output

--- a/src/compiler/crystal/tools/formatter.cr
+++ b/src/compiler/crystal/tools/formatter.cr
@@ -2218,6 +2218,29 @@ module Crystal
         end
       end
 
+      if anns = node.parsed_annotations
+        anns.each do |ann|
+          ann.accept self
+
+          skip_space
+
+          if @token.type.newline?
+            write_line
+            write_indent
+          else
+            write " "
+          end
+
+          skip_space_or_newline
+        end
+
+        if @token.type.newline?
+          skip_space_or_newline
+          write_line
+          write_indent
+        end
+      end
+
       if node.name.empty?
         skip_space_or_newline
       else

--- a/src/compiler/crystal/tools/formatter.cr
+++ b/src/compiler/crystal/tools/formatter.cr
@@ -1548,7 +1548,7 @@ module Crystal
             next if arg.external_name.empty? # skip empty splat argument.
           end
 
-          self.format_parameter_annotations arg
+          format_parameter_annotations(arg)
 
           arg.accept self
           to_skip += 1 if @last_arg_is_skip
@@ -1567,7 +1567,7 @@ module Crystal
 
       if block_arg
         wrote_newline = format_def_arg(wrote_newline, false) do
-          self.format_parameter_annotations block_arg
+          format_parameter_annotations(block_arg)
           write_token :OP_AMP
           skip_space_or_newline
 

--- a/src/compiler/crystal/tools/formatter.cr
+++ b/src/compiler/crystal/tools/formatter.cr
@@ -1548,6 +1548,8 @@ module Crystal
             next if arg.external_name.empty? # skip empty splat argument.
           end
 
+          self.format_parameter_annotations arg
+
           arg.accept self
           to_skip += 1 if @last_arg_is_skip
         end
@@ -1565,6 +1567,7 @@ module Crystal
 
       if block_arg
         wrote_newline = format_def_arg(wrote_newline, false) do
+          self.format_parameter_annotations block_arg
           write_token :OP_AMP
           skip_space_or_newline
 
@@ -1589,6 +1592,31 @@ module Crystal
       @indent = old_indent
 
       to_skip
+    end
+
+    private def format_parameter_annotations(node)
+      if anns = node.parsed_annotations
+        anns.each do |ann|
+          ann.accept self
+
+          skip_space
+
+          if @token.type.newline?
+            write_line
+            write_indent
+          else
+            write " "
+          end
+
+          skip_space_or_newline
+        end
+
+        if @token.type.newline?
+          skip_space_or_newline
+          write_line
+          write_indent
+        end
+      end
     end
 
     def format_def_arg(wrote_newline, has_more)
@@ -2215,29 +2243,6 @@ module Crystal
         if !@token.type.ident? && restriction
           accept restriction
           return false
-        end
-      end
-
-      if anns = node.parsed_annotations
-        anns.each do |ann|
-          ann.accept self
-
-          skip_space
-
-          if @token.type.newline?
-            write_line
-            write_indent
-          else
-            write " "
-          end
-
-          skip_space_or_newline
-        end
-
-        if @token.type.newline?
-          skip_space_or_newline
-          write_line
-          write_indent
         end
       end
 

--- a/src/compiler/crystal/tools/formatter.cr
+++ b/src/compiler/crystal/tools/formatter.cr
@@ -1595,27 +1595,27 @@ module Crystal
     end
 
     private def format_parameter_annotations(node)
-      if anns = node.parsed_annotations
-        anns.each do |ann|
-          ann.accept self
+      return unless (anns = node.parsed_annotations)
 
-          skip_space
+      anns.each do |ann|
+        ann.accept self
 
-          if @token.type.newline?
-            write_line
-            write_indent
-          else
-            write " "
-          end
-
-          skip_space_or_newline
-        end
+        skip_space
 
         if @token.type.newline?
-          skip_space_or_newline
           write_line
           write_indent
+        else
+          write " "
         end
+
+        skip_space_or_newline
+      end
+
+      if @token.type.newline?
+        skip_space_or_newline
+        write_line
+        write_indent
       end
     end
 


### PR DESCRIPTION
Might be able to clean up the logic a bit, but this seems to cover all the specs I threw at it. So good enough for now. Also added an optional `focus` parameter to `assert_format` to make debugging a specific failure a bit easier.

Fixes formatter after https://github.com/crystal-lang/crystal/pull/12044.