### PR TITLE
Add support for Bcrypt algorithm version 2y

### DIFF
--- a/spec/std/crypto/bcrypt/password_spec.cr
+++ b/spec/std/crypto/bcrypt/password_spec.cr
@@ -55,6 +55,7 @@ describe "Crypto::Bcrypt::Password" do
     password2 = Crypto::Bcrypt::Password.new("$2$04$ZsHrsVlj.dsmn74Az1rjmeE/21nYRC0vB5LPjG7ySBfi6lRaO/P22")
     password2a = Crypto::Bcrypt::Password.new("$2a$04$ZsHrsVlj.dsmn74Az1rjmeE/21nYRC0vB5LPjG7ySBfi6lRaO/P22")
     password2b = Crypto::Bcrypt::Password.new("$2b$04$ZsHrsVlj.dsmn74Az1rjmeE/21nYRC0vB5LPjG7ySBfi6lRaO/P22")
+    password2y = Crypto::Bcrypt::Password.new("$2y$04$ZsHrsVlj.dsmn74Az1rjmeE/21nYRC0vB5LPjG7ySBfi6lRaO/P22")
 
     it "verifies password is incorrect" do
       (password.verify "wrong").should be_false
@@ -72,6 +73,9 @@ describe "Crypto::Bcrypt::Password" do
     end
     it "verifies password version 2b is correct (#11584)" do
       (password2b.verify "secret").should be_true
+    end
+    it "verifies password version 2y is correct" do
+      (password2y.verify "secret").should be_true
     end
   end
 end

--- a/src/crypto/bcrypt/password.cr
+++ b/src/crypto/bcrypt/password.cr
@@ -15,7 +15,7 @@ require "../subtle"
 #
 # See `Crypto::Bcrypt` for hints to select the cost when generating hashes.
 class Crypto::Bcrypt::Password
-  private SUPPORTED_VERSIONS = ["2", "2a", "2b"]
+  private SUPPORTED_VERSIONS = ["2", "2a", "2b", "2y"]
 
   # Hashes a password.
   #


### PR DESCRIPTION
This is related to #11595 and the suggestion from @Blacksmoke16 to
also add support for version 2y.

As per https://en.wikipedia.org/wiki/Bcrypt, it seems 2y is limited
to hashes generated by the fixed PHP algorithm.