### PR TITLE
Use LibC.malloc instead of GC.malloc for external memory allocators

### DIFF
--- a/src/big/lib_gmp.cr
+++ b/src/big/lib_gmp.cr
@@ -240,7 +240,7 @@ lib LibGMP
 end
 
 LibGMP.set_memory_functions(
-  ->(size) { GC.malloc(size) },
-  ->(ptr, old_size, new_size) { GC.realloc(ptr, new_size) },
-  ->(ptr, size) { GC.free(ptr) }
+  ->(size) { LibC.malloc(size) },
+  ->(ptr, old_size, new_size) { LibC.realloc(ptr, new_size) },
+  ->(ptr, size) { LibC.free(ptr) }
 )

--- a/src/compress/deflate/writer.cr
+++ b/src/compress/deflate/writer.cr
@@ -20,8 +20,8 @@ class Compress::Deflate::Writer < IO
 
     @buf = uninitialized UInt8[8192] # output buffer used by zlib
     @stream = LibZ::ZStream.new
-    @stream.zalloc = LibZ::AllocFunc.new { |opaque, items, size| GC.malloc(items * size) }
-    @stream.zfree = LibZ::FreeFunc.new { |opaque, address| GC.free(address) }
+    @stream.zalloc = LibZ::AllocFunc.new { |opaque, items, size| LibC.malloc(items * size) }
+    @stream.zfree = LibZ::FreeFunc.new { |opaque, address| LibC.free(address) }
     @closed = false
     ret = LibZ.deflateInit2(pointerof(@stream), level, LibZ::Z_DEFLATED, -LibZ::MAX_BITS, LibZ::DEF_MEM_LEVEL,
       strategy.value, LibZ.zlibVersion, sizeof(LibZ::ZStream))

--- a/src/regex/lib_pcre.cr
+++ b/src/regex/lib_pcre.cr
@@ -31,6 +31,6 @@ end
 
 # TODO(interpreted): remove this unless
 {% unless flag?(:interpreted) %}
-  LibPCRE.pcre_malloc = ->GC.malloc(LibC::SizeT)
-  LibPCRE.pcre_free = ->GC.free(Void*)
+  LibPCRE.pcre_malloc = ->(size) { LibC.malloc(size) }
+  LibPCRE.pcre_free = ->(ptr) { LibC.free(ptr) }
 {% end %}

--- a/src/xml/libxml2.cr
+++ b/src/xml/libxml2.cr
@@ -315,10 +315,10 @@ lib LibXML
 end
 
 LibXML.xmlGcMemSetup(
-  ->GC.free,
-  ->GC.malloc(LibC::SizeT),
-  ->GC.malloc(LibC::SizeT),
-  ->GC.realloc(Void*, LibC::SizeT),
+  ->(ptr) { GC.free(ptr) },
+  ->(size) { GC.malloc(size) },
+  ->(size) { GC.malloc(size) },
+  ->(ptr, size) { GC.realloc(ptr, size) },
   ->(str) {
     len = LibC.strlen(str) + 1
     copy = Pointer(UInt8).malloc(len)

--- a/src/xml/libxml2.cr
+++ b/src/xml/libxml2.cr
@@ -315,10 +315,10 @@ lib LibXML
 end
 
 LibXML.xmlGcMemSetup(
-  ->(ptr) { GC.free(ptr) },
-  ->(size) { GC.malloc(size) },
-  ->(size) { GC.malloc(size) },
-  ->(ptr, size) { GC.realloc(ptr, size) },
+  ->(ptr) { LibC.free(ptr) },
+  ->(size) { LibC.malloc(size) },
+  ->(size) { LibC.malloc(size) },
+  ->(ptr, size) { LibC.realloc(ptr, size) },
   ->(str) {
     len = LibC.strlen(str) + 1
     copy = Pointer(UInt8).malloc(len)


### PR DESCRIPTION
Fixes #11614

There's no need to involve the GC when deciding how memory should be allocated and de-allocated for external libraries. If we use the GC it means that on a GC collect cycle that memory will have to be scanned for pointers... but that memory should never be automatically freed! So it's always better to allocate that memory outside of the GC's knowledge.