### PR TITLE
Compiler optimization: don't create call for hook unless needed

### DIFF
--- a/src/compiler/crystal/semantic/top_level_visitor.cr
+++ b/src/compiler/crystal/semantic/top_level_visitor.cr
@@ -443,7 +443,7 @@ class Crystal::TopLevelVisitor < Crystal::SemanticVisitor
         new_expansions[node] = new_method
       end
 
-      unless @method_added_running
+      if !@method_added_running && has_hooks?(target_type.metaclass)
         @method_added_running = true
         run_hooks target_type.metaclass, target_type, :method_added, node, Call.new(nil, "method_added", node).at(node.location)
         @method_added_running = false
@@ -1041,6 +1041,11 @@ class Crystal::TopLevelVisitor < Crystal::SemanticVisitor
     rescue ex : TypeException
       node.raise "at '#{kind}' hook", ex
     end
+  end
+
+  def has_hooks?(type_with_hooks)
+    hooks = type_with_hooks.as?(ModuleType).try &.hooks
+    hooks && !hooks.empty?
   end
 
   def run_hooks(type_with_hooks, current_type, kind : HookKind, node, call = nil)


### PR DESCRIPTION
This is a tiny optimization: a `Call` node was created to run hook for every method, but not every types have a hook. This avoids creating some `Call` nodes for nothing. For compiling the compiler, this is avoiding creating 16318 nodes for nothing (it probably doesn't make a significant difference, but this change is very small and it's always better to not allocate memory when possible.)