### PR TITLE
Parser: don't allocate memory for end location information

### DIFF
--- a/src/compiler/crystal/syntax/lexer.cr
+++ b/src/compiler/crystal/syntax/lexer.cr
@@ -17,7 +17,7 @@ module Crystal
     property wants_symbol : Bool
     @filename : String | VirtualFile | Nil
     @stacked_filename : String | VirtualFile | Nil
-    @token_end_location : Location?
+    @token_end_line_and_column : LineAndColumn?
     @string_pool : StringPool
 
     # This is an interface for storing data associated to a heredoc
@@ -1317,8 +1317,8 @@ module Crystal
       @token
     end
 
-    def token_end_location
-      @token_end_location ||= Location.new(@filename, @line_number, @column_number - 1)
+    def token_end_line_and_column
+      @token_end_line_and_column ||= LineAndColumn.new(@line_number, @column_number - 1)
     end
 
     def slash_is_regex!
@@ -2793,7 +2793,7 @@ module Crystal
       @token.passed_backslash_newline = false
       @token.doc_buffer = nil unless @token.type.space? || @token.type.newline?
       @token.invalid_escape = false
-      @token_end_location = nil
+      @token_end_line_and_column = nil
     end
 
     def next_token_skip_space

--- a/src/compiler/crystal/syntax/line_and_column.cr
+++ b/src/compiler/crystal/syntax/line_and_column.cr
@@ -1,0 +1,20 @@
+# A struct that captues line and column information.
+# The absence of line and column information is signaled
+# by having `line` be zero, as lines in a file start by 1.
+record Crystal::LineAndColumn, line : Int32, column : Int32 do
+  def empty? : Bool
+    line == 0
+  end
+
+  def or(other : LineAndColumn) : LineAndColumn
+    empty? ? other : self
+  end
+
+  def or(other : Nil) : LineAndColumn
+    self
+  end
+
+  def self.empty : LineAndColumn
+    new(0, 0)
+  end
+end


### PR DESCRIPTION
This is something I've been thinking about lately...

Every AST node has a `location` property that tells where the node starts. `location` is of type `Location`, a class, and it has file, line and column information. It's a class because using a struct would mean every node has this information inlined and each node would occupy more memory. A `Location` might be shared between many AST nodes (for example an assignment's location is the target's location.) so it further makes sense for `Location` to be a class.

Then at some points we started tracking where AST nodes end. This is mainly (even almost only) used in `crystal tool` commands like `context` or `implementations`. But when we did that we increased the size of every AST node by 8 bytes, but we also had to create a lot more `Location` instances.

There are two issues with this approach:
1. The first that I mentioned: we allocate more memory
2. The file where a node ends will **always** be the same file where it starts. There's no other way around that. However, the model allows that to not be the case.

This PR changes the "end location" information of a node to just be the line and column where the node ends. This ends up occupying 8 bytes in memory, similar to the old `Location` pointer. However, we don't need to allocate memory for it (it's inlined in the AST node.) We still have an `end_location` property that returns a `Location` on the fly when needed, based on this new line/column property.

The end result is that we need a bit less memory for compiling programs. For example for compiling the compiler we allocate 34MB less memory (out 2414MB, so about 1.5% less memory.)

I'm still not 100% convinced about the current code in this PR, so suggestions are welcome!