### PR TITLE
CrystalPath: Cache `Dir.current` to avoid thousands of allocations

### DIFF
--- a/spec/compiler/crystal_path/crystal_path_spec.cr
+++ b/spec/compiler/crystal_path/crystal_path_spec.cr
@@ -4,9 +4,9 @@ require "spec/helpers/iterate"
 
 private def assert_finds(search, results, relative_to = nil, path = __DIR__, file = __FILE__, line = __LINE__)
   it "finds #{search.inspect}", file, line do
-    crystal_path = Crystal::CrystalPath.new([path])
     results = results.map { |result| ::Path[__DIR__, result].normalize.to_s }
     Dir.cd(__DIR__) do
+      crystal_path = Crystal::CrystalPath.new([path])
       matches = crystal_path.find search, relative_to: relative_to
       matches.should eq(results), file: file, line: line
     end
@@ -15,8 +15,8 @@ end
 
 private def assert_doesnt_find(search, relative_to = nil, path = __DIR__, expected_relative_to = nil, file = __FILE__, line = __LINE__)
   it "doesn't finds #{search.inspect}", file, line do
-    crystal_path = Crystal::CrystalPath.new([path])
     Dir.cd(__DIR__) do
+      crystal_path = Crystal::CrystalPath.new([path])
       error = expect_raises Crystal::CrystalPath::NotFoundError do
         crystal_path.find search, relative_to: relative_to
       end

--- a/src/compiler/crystal/crystal_path.cr
+++ b/src/compiler/crystal/crystal_path.cr
@@ -69,6 +69,7 @@ module Crystal
 
     def initialize(@entries : Array(String) = CrystalPath.default_paths, codegen_target = Config.host_target)
       add_target_path(codegen_target)
+      @current_dir = Dir.current
     end
 
     private def add_target_path(codegen_target)
@@ -118,7 +119,7 @@ module Crystal
       end
 
       each_file_expansion(filename, relative_to) do |path|
-        absolute_path = File.expand_path(path)
+        absolute_path = File.expand_path(path, dir: @current_dir)
         return absolute_path if File.exists?(absolute_path)
       end
 
@@ -190,7 +191,7 @@ module Crystal
       dirs.sort!
 
       files.each do |file|
-        files_accumulator << File.expand_path(file)
+        files_accumulator << File.expand_path(file, dir: @current_dir)
       end
 
       dirs.each do |subdir|


### PR DESCRIPTION
Saves something like 13k mallocs when compiling std_specs. I'd guess about as many string allocations on the crystal side are saved as well. Not noticable from a time perspective. 