### PR TITLE
Use LibC.malloc instead of GC.malloc for LibPCRE allocations

### DIFF
--- a/src/regex.cr
+++ b/src/regex.cr
@@ -261,7 +261,10 @@ class Regex
     @re = LibPCRE.compile(@source, (options | Options::UTF_8 | Options::NO_UTF8_CHECK | Options::DUPNAMES | Options::UCP), out errptr, out erroffset, nil)
     raise ArgumentError.new("#{String.new(errptr)} at #{erroffset}") if @re.null?
     @extra = LibPCRE.study(@re, LibPCRE::STUDY_JIT_COMPILE, out studyerrptr)
-    raise ArgumentError.new("#{String.new(studyerrptr)}") if @extra.null? && studyerrptr
+    if @extra.null? && studyerrptr
+      LibPCRE.free.call @re.as(Void*)
+      raise ArgumentError.new("#{String.new(studyerrptr)}")
+    end
     LibPCRE.full_info(@re, nil, LibPCRE::INFO_CAPTURECOUNT, out @captures)
   end
 

--- a/src/regex.cr
+++ b/src/regex.cr
@@ -267,7 +267,7 @@ class Regex
 
   def finalize
     LibPCRE.free_study @extra
-    LibC.free @re.as(Void*)
+    LibPCRE.free.call @re.as(Void*)
   end
 
   # Determines Regex's source validity. If it is, `nil` is returned.
@@ -280,7 +280,7 @@ class Regex
   def self.error?(source) : String?
     re = LibPCRE.compile(source, (Options::UTF_8 | Options::NO_UTF8_CHECK | Options::DUPNAMES), out errptr, out erroffset, nil)
     if re
-      LibC.free re.as(Void*)
+      LibPCRE.free.call re.as(Void*)
       nil
     else
       "#{String.new(errptr)} at #{erroffset}"

--- a/src/regex.cr
+++ b/src/regex.cr
@@ -267,6 +267,7 @@ class Regex
 
   def finalize
     LibPCRE.free_study @extra
+    LibC.free @re.as(Void*)
   end
 
   # Determines Regex's source validity. If it is, `nil` is returned.
@@ -279,6 +280,7 @@ class Regex
   def self.error?(source) : String?
     re = LibPCRE.compile(source, (Options::UTF_8 | Options::NO_UTF8_CHECK | Options::DUPNAMES), out errptr, out erroffset, nil)
     if re
+      LibC.free re.as(Void*)
       nil
     else
       "#{String.new(errptr)} at #{erroffset}"

--- a/src/regex/lib_pcre.cr
+++ b/src/regex/lib_pcre.cr
@@ -21,16 +21,4 @@ lib LibPCRE
   INFO_NAMEENTRYSIZE = 7
   INFO_NAMECOUNT     = 8
   INFO_NAMETABLE     = 9
-
-  alias Malloc = LibC::SizeT -> Void*
-  alias Free = Void* ->
-
-  $pcre_malloc : Malloc
-  $pcre_free : Free
 end
-
-# TODO(interpreted): remove this unless
-{% unless flag?(:interpreted) %}
-  LibPCRE.pcre_malloc = ->GC.malloc(LibC::SizeT)
-  LibPCRE.pcre_free = ->GC.free(Void*)
-{% end %}

--- a/src/regex/lib_pcre.cr
+++ b/src/regex/lib_pcre.cr
@@ -21,4 +21,6 @@ lib LibPCRE
   INFO_NAMEENTRYSIZE = 7
   INFO_NAMECOUNT     = 8
   INFO_NAMETABLE     = 9
+
+  $free = pcre_free : Void* ->
 end


### PR DESCRIPTION
Follow-up on #12451.

This makes the memory management os LibPCRE manual for the stdlib. So any internal allocations are made with the system allocator, leaving less memory being managed by the GC.

Public interface is unchanged.

As an adicional benefit: libpcre doesn't need to be linked anymore if the program doesn't create any regex!