### PR TITLE
Use LibC.malloc instead of GC.malloc for LibZ allocations

### DIFF
--- a/src/compress/deflate/reader.cr
+++ b/src/compress/deflate/reader.cr
@@ -22,13 +22,17 @@ class Compress::Deflate::Reader < IO
   def initialize(@io : IO, @sync_close : Bool = false, @dict : Bytes? = nil)
     @buf = uninitialized UInt8[1] # input buffer used by zlib
     @stream = LibZ::ZStream.new
-    @stream.zalloc = LibZ::AllocFunc.new { |opaque, items, size| GC.malloc(items * size) }
-    @stream.zfree = LibZ::FreeFunc.new { |opaque, address| GC.free(address) }
     ret = LibZ.inflateInit2(pointerof(@stream), -LibZ::MAX_BITS, LibZ.zlibVersion, sizeof(LibZ::ZStream))
     raise Compress::Deflate::Error.new(ret, @stream) unless ret.ok?
 
     @peek = nil
     @end = false
+  end
+
+  def finalize
+    return if closed?
+
+    close rescue nil
   end
 
   # Creates a new reader from the given *io*, yields it to the given block,

--- a/src/compress/deflate/writer.cr
+++ b/src/compress/deflate/writer.cr
@@ -20,12 +20,16 @@ class Compress::Deflate::Writer < IO
 
     @buf = uninitialized UInt8[8192] # output buffer used by zlib
     @stream = LibZ::ZStream.new
-    @stream.zalloc = LibZ::AllocFunc.new { |opaque, items, size| GC.malloc(items * size) }
-    @stream.zfree = LibZ::FreeFunc.new { |opaque, address| GC.free(address) }
     @closed = false
     ret = LibZ.deflateInit2(pointerof(@stream), level, LibZ::Z_DEFLATED, -LibZ::MAX_BITS, LibZ::DEF_MEM_LEVEL,
       strategy.value, LibZ.zlibVersion, sizeof(LibZ::ZStream))
     raise Compress::Deflate::Error.new(ret, @stream) unless ret.ok?
+  end
+
+  def finalize
+    return if closed?
+
+    close rescue nil
   end
 
   # Creates a new writer for the given *io*, yields it to the given block,


### PR DESCRIPTION
Follow-up on #12451.

This makes the memory management os LibZ manual for the stdlib. So any internal allocations are made with the system allocator, leaving less memory being managed by the GC.

Public interface is mostly unchanged, except for the fact that `Compress::Deflate::Reader` and `Compress::Deflate::Writer` are now closed on finalize.

Note: We currently don't close IOs on finalize. I think we should. `IO::Buffered`, for example, could leave unwritten data on its buffer.