### PR TITLE
Remove most uses of `Symbol` variables in standard library specs

### DIFF
--- a/spec/std/array_spec.cr
+++ b/spec/std/array_spec.cr
@@ -459,7 +459,7 @@ describe "Array" do
     end
 
     it "works with mixed types" do
-      [1, "a", 1.0, :a].values_at(0, 1, 2, 3).should eq({1, "a", 1.0, :a})
+      [1, "a", 1.0, 'a'].values_at(0, 1, 2, 3).should eq({1, "a", 1.0, 'a'})
     end
   end
 
@@ -1819,9 +1819,9 @@ describe "Array" do
 
   describe "transpose" do
     it "transposes elements" do
-      [[:a, :b], [:c, :d], [:e, :f]].transpose.should eq([[:a, :c, :e], [:b, :d, :f]])
-      [[:a, :c, :e], [:b, :d, :f]].transpose.should eq([[:a, :b], [:c, :d], [:e, :f]])
-      [[:a]].transpose.should eq([[:a]])
+      [['a', 'b'], ['c', 'd'], ['e', 'f']].transpose.should eq([['a', 'c', 'e'], ['b', 'd', 'f']])
+      [['a', 'c', 'e'], ['b', 'd', 'f']].transpose.should eq([['a', 'b'], ['c', 'd'], ['e', 'f']])
+      [['a']].transpose.should eq([['a']])
     end
 
     it "transposes union of arrays" do

--- a/spec/std/deque_spec.cr
+++ b/spec/std/deque_spec.cr
@@ -149,7 +149,7 @@ describe "Deque" do
 
     it "compares other types" do
       a = Deque{1, 2, 3}
-      b = Deque{:foo, :bar}
+      b = Deque{true, false}
       c = "other type"
       (a == b).should be_false
       (b == c).should be_false

--- a/spec/std/enumerable_spec.cr
+++ b/spec/std/enumerable_spec.cr
@@ -1289,9 +1289,9 @@ describe "Enumerable" do
 
   describe "to_h" do
     it "for tuples" do
-      hash = Tuple.new({:a, 1}, {:c, 2}).to_h
-      hash.should be_a(Hash(Symbol, Int32))
-      hash.should eq({:a => 1, :c => 2})
+      hash = Tuple.new({"a", 1}, {"c", 2}).to_h
+      hash.should be_a(Hash(String, Int32))
+      hash.should eq({"a" => 1, "c" => 2})
 
       hash = Tuple.new({1, 1.0}, {'a', "aaa"}).to_h
       hash.should be_a(Hash(Int32 | Char, Float64 | String))
@@ -1299,7 +1299,7 @@ describe "Enumerable" do
     end
 
     it "for array" do
-      [[:a, :b], [:c, :d]].to_h.should eq({:a => :b, :c => :d})
+      [['a', 'b'], ['c', 'd']].to_h.should eq({'a' => 'b', 'c' => 'd'})
     end
 
     it "with block" do

--- a/spec/std/hash_spec.cr
+++ b/spec/std/hash_spec.cr
@@ -13,7 +13,7 @@ end
 private class NeverInstantiated
 end
 
-private alias RecursiveType = String | Int32 | Array(RecursiveType) | Hash(Symbol, RecursiveType)
+private alias RecursiveType = String | Int32 | Array(RecursiveType) | Hash(String, RecursiveType)
 
 private class HashWrapper(K, V)
   include Enumerable({K, V})
@@ -44,7 +44,7 @@ describe "Hash" do
   end
 
   it "gets from union" do
-    a = {1 => 2, :foo => 1.1}
+    a = {1 => 2, "foo" => 1.1}
     a[1].should eq(2)
   end
 
@@ -55,18 +55,18 @@ describe "Hash" do
   end
 
   it "gets array of keys" do
-    a = {} of Symbol => Int32
-    a.keys.should eq([] of Symbol)
-    a[:foo] = 1
-    a[:bar] = 2
-    a.keys.should eq([:foo, :bar])
+    a = {} of String => Int32
+    a.keys.should eq([] of String)
+    a["foo"] = 1
+    a["bar"] = 2
+    a.keys.should eq(["foo", "bar"])
   end
 
   it "gets array of values" do
-    a = {} of Symbol => Int32
+    a = {} of String => Int32
     a.values.should eq([] of Int32)
-    a[:foo] = 1
-    a[:bar] = 2
+    a["foo"] = 1
+    a["bar"] = 2
     a.values.should eq([1, 2])
   end
 
@@ -384,7 +384,7 @@ describe "Hash" do
     end
 
     it "works with mixed types" do
-      {1 => :a, "a" => 1, 2.0 => "a", :a => 1.0}.values_at(1, "a", 2.0, :a).should eq({:a, 1, "a", 1.0})
+      {1 => "a", "a" => 1, 2.0 => "a", "a" => 1.0}.values_at(1, "a", 2.0, "a").should eq({"a", 1, "a", 1.0})
     end
   end
 
@@ -557,7 +557,7 @@ describe "Hash" do
   end
 
   it "does to_h" do
-    h = {:a => 1}
+    h = {"a" => 1}
     h.to_h.should be(h)
   end
 
@@ -719,9 +719,9 @@ describe "Hash" do
   end
 
   it "merges recursive type (#1693)" do
-    hash = {:foo => "bar"} of Symbol => RecursiveType
-    result = hash.merge({:foobar => "foo"})
-    result.should eq({:foo => "bar", :foobar => "foo"})
+    hash = {"foo" => "bar"} of String => RecursiveType
+    result = hash.merge({"foobar" => "foo"})
+    result.should eq({"foo" => "bar", "foobar" => "foo"})
   end
 
   it "merges other type with block" do
@@ -760,10 +760,10 @@ describe "Hash" do
   end
 
   it "selects" do
-    h1 = {:a => 1, :b => 2, :c => 3}
+    h1 = {"a" => 1, "b" => 2, "c" => 3}
 
-    h2 = h1.select { |k, v| k == :b }
-    h2.should eq({:b => 2})
+    h2 = h1.select { |k, v| k == "b" }
+    h2.should eq({"b" => 2})
     h2.should_not be(h1)
   end
 
@@ -773,11 +773,11 @@ describe "Hash" do
   end
 
   it "selects!" do
-    h1 = {:a => 1, :b => 2, :c => 3}
+    h1 = {"a" => 1, "b" => 2, "c" => 3}
 
-    h2 = h1.select! { |k, v| k == :b }
-    h2.should be_a(Hash(Symbol, Int32))
-    h2.should eq({:b => 2})
+    h2 = h1.select! { |k, v| k == "b" }
+    h2.should be_a(Hash(String, Int32))
+    h2.should eq({"b" => 2})
     h2.should be(h1)
   end
 
@@ -788,10 +788,10 @@ describe "Hash" do
   end
 
   it "rejects" do
-    h1 = {:a => 1, :b => 2, :c => 3}
+    h1 = {"a" => 1, "b" => 2, "c" => 3}
 
-    h2 = h1.reject { |k, v| k == :b }
-    h2.should eq({:a => 1, :c => 3})
+    h2 = h1.reject { |k, v| k == "b" }
+    h2.should eq({"a" => 1, "c" => 3})
     h2.should_not be(h1)
   end
 
@@ -801,11 +801,11 @@ describe "Hash" do
   end
 
   it "rejects!" do
-    h1 = {:a => 1, :b => 2, :c => 3}
+    h1 = {"a" => 1, "b" => 2, "c" => 3}
 
-    h2 = h1.reject! { |k, v| k == :b }
-    h2.should be_a(Hash(Symbol, Int32))
-    h2.should eq({:a => 1, :c => 3})
+    h2 = h1.reject! { |k, v| k == "b" }
+    h2.should be_a(Hash(String, Int32))
+    h2.should eq({"a" => 1, "c" => 3})
     h2.should be(h1)
   end
 
@@ -816,31 +816,31 @@ describe "Hash" do
   end
 
   it "compacts" do
-    h1 = {:a => 1, :b => 2, :c => nil}
+    h1 = {"a" => 1, "b" => 2, "c" => nil}
 
     h2 = h1.compact
-    h2.should be_a(Hash(Symbol, Int32))
-    h2.should eq({:a => 1, :b => 2})
+    h2.should be_a(Hash(String, Int32))
+    h2.should eq({"a" => 1, "b" => 2})
   end
 
   it "compacts!" do
-    h1 = {:a => 1, :b => 2, :c => nil}
+    h1 = {"a" => 1, "b" => 2, "c" => nil}
 
     h2 = h1.compact!
-    h2.should be_a(Hash(Symbol, Int32 | Nil))
-    h2.should eq({:a => 1, :b => 2})
+    h2.should be_a(Hash(String, Int32 | Nil))
+    h2.should eq({"a" => 1, "b" => 2})
     h2.should be(h1)
   end
 
   it "transforms keys" do
-    h1 = {1 => :a, 2 => :b, 3 => :c}
+    h1 = {1 => "a", 2 => "b", 3 => "c"}
 
     h2 = h1.transform_keys { |x| x + 1 }
-    h2.should eq({2 => :a, 3 => :b, 4 => :c})
+    h2.should eq({2 => "a", 3 => "b", 4 => "c"})
   end
 
   it "transforms keys with type casting" do
-    h1 = {:a => 1, :b => 2, :c => 3}
+    h1 = {"a" => 1, "b" => 2, "c" => 3}
 
     h2 = h1.transform_keys { |x| x.to_s.upcase }
     h2.should be_a(Hash(String, Int32))
@@ -848,41 +848,41 @@ describe "Hash" do
   end
 
   it "returns empty hash when transforming keys of an empty hash" do
-    h1 = {} of Int32 => Symbol
+    h1 = {} of Int32 => String
 
     h2 = h1.transform_keys { |x| x + 1 }
-    h2.should be_a(Hash(Int32, Symbol))
+    h2.should be_a(Hash(Int32, String))
     h2.should be_empty
   end
 
   it "transforms values" do
-    h1 = {:a => 1, :b => 2, :c => 3}
+    h1 = {"a" => 1, "b" => 2, "c" => 3}
 
     h2 = h1.transform_values { |x| x + 1 }
-    h2.should eq({:a => 2, :b => 3, :c => 4})
+    h2.should eq({"a" => 2, "b" => 3, "c" => 4})
   end
 
   it "transforms values with type casting values" do
-    h1 = {:a => 1, :b => 2, :c => 3}
+    h1 = {"a" => 1, "b" => 2, "c" => 3}
 
     h2 = h1.transform_values { |x| x.to_s }
-    h2.should be_a(Hash(Symbol, String))
-    h2.should eq({:a => "1", :b => "2", :c => "3"})
+    h2.should be_a(Hash(String, String))
+    h2.should eq({"a" => "1", "b" => "2", "c" => "3"})
   end
 
   it "returns empty hash when transforming values of an empty hash" do
-    h1 = {} of Symbol => Int32
+    h1 = {} of String => Int32
 
     h2 = h1.transform_values { |x| x + 1 }
-    h2.should be_a(Hash(Symbol, Int32))
+    h2.should be_a(Hash(String, Int32))
     h2.should be_empty
   end
 
   it "transform values in place" do
-    h = {:a => 1, :b => 2, :c => 3}
+    h = {"a" => 1, "b" => 2, "c" => 3}
 
     h.transform_values!(&.+(1))
-    h.should eq({:a => 2, :b => 3, :c => 4})
+    h.should eq({"a" => 2, "b" => 3, "c" => 4})
   end
 
   it "zips" do
@@ -1147,46 +1147,46 @@ describe "Hash" do
     vs.should eq([1, 2])
   end
 
-  it_iterates "#each", [{:a, 1}, {:b, 2}], {:a => 1, :b => 2}.each
-  it_iterates "#each_key", [:a, :b], {:a => 1, :b => 2}.each_key
-  it_iterates "#each_value", [1, 2], {:a => 1, :b => 2}.each_value
+  it_iterates "#each", [{"a", 1}, {"b", 2}], {"a" => 1, "b" => 2}.each
+  it_iterates "#each_key", ["a", "b"], {"a" => 1, "b" => 2}.each_key
+  it_iterates "#each_value", [1, 2], {"a" => 1, "b" => 2}.each_value
 
-  it_iterates "#each_with_index", [{ {:a, 1}, 0 }, { {:b, 2}, 1 }], {:a => 1, :b => 2}.each_with_index, tuple: true
-  it_iterates "#each_with_index(offset)", [{ {:a, 1}, 2 }, { {:b, 2}, 3 }], {:a => 1, :b => 2}.each_with_index(2), tuple: true
+  it_iterates "#each_with_index", [{ {"a", 1}, 0 }, { {"b", 2}, 1 }], {"a" => 1, "b" => 2}.each_with_index, tuple: true
+  it_iterates "#each_with_index(offset)", [{ {"a", 1}, 2 }, { {"b", 2}, 3 }], {"a" => 1, "b" => 2}.each_with_index(2), tuple: true
 
   describe "#each_with_object" do
-    it_iterates "passes memo, key and value into block", [{ {:a, 1}, :memo }, { {:b, 2}, :memo }], {:a => 1, :b => 2}.each_with_object(:memo), tuple: true
+    it_iterates "passes memo, key and value into block", [{ {"a", 1}, "memo" }, { {"b", 2}, "memo" }], {"a" => 1, "b" => 2}.each_with_object("memo"), tuple: true
 
     it "reduces the hash to the accumulated value of memo" do
-      hash = {:a => 'b', :c => 'd', :e => 'f'}
-      result = {} of Char => Symbol
+      hash = {"a" => 'b', "c" => 'd', "e" => 'f'}
+      result = {} of Char => String
       hash.each_with_object(result) do |(k, v), memo|
         memo[v] = k
       end.should be(result)
-      result.should eq({'b' => :a, 'd' => :c, 'f' => :e})
+      result.should eq({'b' => "a", 'd' => "c", 'f' => "e"})
     end
   end
 
   describe "all?" do
     it "passes key and value into block" do
-      hash = {:a => 'b'}
+      hash = {"a" => 'b'}
       hash.all? do |k, v|
-        k.should eq(:a)
+        k.should eq("a")
         v.should eq('b')
       end
     end
 
     it "returns true if the block evaluates truthy for every kv pair" do
-      hash = {:a => 'b', :c => 'd'}
+      hash = {"a" => 'b', "c" => 'd'}
       result = hash.all? { |k, v| v < 'e' ? "truthy" : nil }
       result.should be_true
-      hash[:d] = 'e'
+      hash["d"] = 'e'
       result = hash.all? { |k, v| v < 'e' ? "truthy" : nil }
       result.should be_false
     end
 
     it "evaluates the block for only for as many kv pairs as necessary" do
-      hash = {:a => 'b', :c => 'd'}
+      hash = {"a" => 'b', "c" => 'd'}
       hash.all? do |k, v|
         raise Exception.new("continued iterating") if v == 'd'
         v == 'a' # this is false for the first kv pair
@@ -1196,24 +1196,24 @@ describe "Hash" do
 
   describe "any?" do
     it "passes key and value into block" do
-      hash = {:a => 'b'}
+      hash = {"a" => 'b'}
       hash.any? do |k, v|
-        k.should eq(:a)
+        k.should eq("a")
         v.should eq('b')
       end
     end
 
     it "returns true if the block evaluates truthy for at least one kv pair" do
-      hash = {:a => 'b', :c => 'd'}
+      hash = {"a" => 'b', "c" => 'd'}
       result = hash.any? { |k, v| v > 'b' ? "truthy" : nil }
       result.should be_true
-      hash[:d] = 'e'
+      hash["d"] = 'e'
       result = hash.any? { |k, v| v > 'e' ? "truthy" : nil }
       result.should be_false
     end
 
     it "evaluates the block for only for as many kv pairs as necessary" do
-      hash = {:a => 'b', :c => 'd'}
+      hash = {"a" => 'b', "c" => 'd'}
       hash.any? do |k, v|
         raise Exception.new("continued iterating") if v == 'd'
         v == 'b' # this is true for the first kv pair
@@ -1221,11 +1221,11 @@ describe "Hash" do
     end
 
     it "returns true if the hash contains at least one kv pair and no block is given" do
-      hash = {:a => 'b'}
+      hash = {"a" => 'b'}
       result = hash.any?
       result.should be_true
 
-      hash = {} of Symbol => Char
+      hash = {} of String => Char
       result = hash.any?
       result.should be_false
     end
@@ -1233,16 +1233,16 @@ describe "Hash" do
 
   describe "reduce" do
     it "passes memo, key and value into block" do
-      hash = {:a => 'b'}
-      hash.reduce(:memo) do |memo, (k, v)|
-        memo.should eq(:memo)
-        k.should eq(:a)
+      hash = {"a" => 'b'}
+      hash.reduce("") do |memo, (k, v)|
+        memo.should eq("")
+        k.should eq("a")
         v.should eq('b')
       end
     end
 
     it "reduces the hash to the accumulated value of memo" do
-      hash = {:a => 'b', :c => 'd', :e => 'f'}
+      hash = {"a" => 'b', "c" => 'd', "e" => 'f'}
       result = hash.reduce("") do |memo, (k, v)|
         memo + v
       end
@@ -1251,52 +1251,52 @@ describe "Hash" do
   end
 
   describe "reject" do
-    it { {:a => 2, :b => 3}.reject(:b, :d).should eq({:a => 2}) }
-    it { {:a => 2, :b => 3}.reject(Set{:b, :d}).should eq({:a => 2}) }
-    it { {:a => 2, :b => 3}.reject(:b, :a).should eq({} of Symbol => Int32) }
-    it { {:a => 2, :b => 3}.reject([:b, :a]).should eq({} of Symbol => Int32) }
+    it { {"a" => 2, "b" => 3}.reject("b", "d").should eq({"a" => 2}) }
+    it { {"a" => 2, "b" => 3}.reject(Set{"b", "d"}).should eq({"a" => 2}) }
+    it { {"a" => 2, "b" => 3}.reject("b", "a").should eq({} of String => Int32) }
+    it { {"a" => 2, "b" => 3}.reject(["b", "a"]).should eq({} of String => Int32) }
     it "does not change current hash" do
-      h = {:a => 3, :b => 6, :c => 9}
-      h2 = h.reject(:b, :c)
-      h.should eq({:a => 3, :b => 6, :c => 9})
+      h = {"a" => 3, "b" => 6, "c" => 9}
+      h2 = h.reject("b", "c")
+      h.should eq({"a" => 3, "b" => 6, "c" => 9})
     end
   end
 
   describe "reject!" do
-    it { {:a => 2, :b => 3}.reject!(:b, :d).should eq({:a => 2}) }
-    it { {:a => 2, :b => 3}.reject!(Set{:b, :d}).should eq({:a => 2}) }
-    it { {:a => 2, :b => 3}.reject!(:b, :a).should eq({} of Symbol => Int32) }
-    it { {:a => 2, :b => 3}.reject!([:b, :a]).should eq({} of Symbol => Int32) }
+    it { {"a" => 2, "b" => 3}.reject!("b", "d").should eq({"a" => 2}) }
+    it { {"a" => 2, "b" => 3}.reject!(Set{"b", "d"}).should eq({"a" => 2}) }
+    it { {"a" => 2, "b" => 3}.reject!("b", "a").should eq({} of String => Int32) }
+    it { {"a" => 2, "b" => 3}.reject!(["b", "a"]).should eq({} of String => Int32) }
     it "changes current hash" do
-      h = {:a => 3, :b => 6, :c => 9}
-      h.reject!(:b, :c)
-      h.should eq({:a => 3})
+      h = {"a" => 3, "b" => 6, "c" => 9}
+      h.reject!("b", "c")
+      h.should eq({"a" => 3})
     end
   end
 
   describe "select" do
-    it { {:a => 2, :b => 3}.select(:b, :d).should eq({:b => 3}) }
-    it { {:a => 2, :b => 3}.select.should eq({} of Symbol => Int32) }
-    it { {:a => 2, :b => 3}.select(:b, :a).should eq({:a => 2, :b => 3}) }
-    it { {:a => 2, :b => 3}.select([:b, :a]).should eq({:a => 2, :b => 3}) }
-    it { {:a => 2, :b => 3}.select(Set{:b, :a}).should eq({:a => 2, :b => 3}) }
+    it { {"a" => 2, "b" => 3}.select("b", "d").should eq({"b" => 3}) }
+    it { {"a" => 2, "b" => 3}.select.should eq({} of String => Int32) }
+    it { {"a" => 2, "b" => 3}.select("b", "a").should eq({"a" => 2, "b" => 3}) }
+    it { {"a" => 2, "b" => 3}.select(["b", "a"]).should eq({"a" => 2, "b" => 3}) }
+    it { {"a" => 2, "b" => 3}.select(Set{"b", "a"}).should eq({"a" => 2, "b" => 3}) }
     it "does not change current hash" do
-      h = {:a => 3, :b => 6, :c => 9}
-      h2 = h.select(:b, :c)
-      h.should eq({:a => 3, :b => 6, :c => 9})
+      h = {"a" => 3, "b" => 6, "c" => 9}
+      h2 = h.select("b", "c")
+      h.should eq({"a" => 3, "b" => 6, "c" => 9})
     end
   end
 
   describe "select!" do
-    it { {:a => 2, :b => 3}.select!(:b, :d).should eq({:b => 3}) }
-    it { {:a => 2, :b => 3}.select!.should eq({} of Symbol => Int32) }
-    it { {:a => 2, :b => 3}.select!(:b, :a).should eq({:a => 2, :b => 3}) }
-    it { {:a => 2, :b => 3}.select!([:b, :a]).should eq({:a => 2, :b => 3}) }
-    it { {:a => 2, :b => 3}.select!(Set{:b, :a}).should eq({:a => 2, :b => 3}) }
+    it { {"a" => 2, "b" => 3}.select!("b", "d").should eq({"b" => 3}) }
+    it { {"a" => 2, "b" => 3}.select!.should eq({} of String => Int32) }
+    it { {"a" => 2, "b" => 3}.select!("b", "a").should eq({"a" => 2, "b" => 3}) }
+    it { {"a" => 2, "b" => 3}.select!(["b", "a"]).should eq({"a" => 2, "b" => 3}) }
+    it { {"a" => 2, "b" => 3}.select!(Set{"b", "a"}).should eq({"a" => 2, "b" => 3}) }
     it "does change current hash" do
-      h = {:a => 3, :b => 6, :c => 9}
-      h.select!(:b, :c)
-      h.should eq({:b => 6, :c => 9})
+      h = {"a" => 3, "b" => 6, "c" => 9}
+      h.select!("b", "c")
+      h.should eq({"b" => 6, "c" => 9})
     end
   end
 

--- a/spec/std/http/server/server_spec.cr
+++ b/spec/std/http/server/server_spec.cr
@@ -56,7 +56,7 @@ describe HTTP::Server do
   it "closes the server" do
     server = HTTP::Server.new { }
     address = server.bind_unused_port
-    ch = Channel(Symbol).new
+    ch = Channel(SpecChannelStatus).new
 
     spawn do
       server.listen
@@ -78,7 +78,7 @@ describe HTTP::Server do
     sleep 0.1
     server.close
 
-    ch.receive.should eq(:end)
+    ch.receive.end?.should be_true
   end
 
   pending_win32 "reuses the TCP port (SO_REUSEPORT)" do

--- a/spec/std/io/io_spec.cr
+++ b/spec/std/io/io_spec.cr
@@ -922,11 +922,11 @@ describe IO do
 
   pending_win32 describe: "#close" do
     it "aborts 'read' in a different thread" do
-      ch = Channel(Symbol).new(1)
+      ch = Channel(SpecChannelStatus).new(1)
 
       IO.pipe do |read, write|
         f = spawn do
-          ch.send :start
+          ch.send :begin
           read.gets
         rescue
           ch.send :end
@@ -934,20 +934,20 @@ describe IO do
 
         schedule_timeout ch
 
-        ch.receive.should eq(:start)
+        ch.receive.begin?.should be_true
         wait_until_blocked f
 
         read.close
-        ch.receive.should eq(:end)
+        ch.receive.end?.should be_true
       end
     end
 
     it "aborts 'write' in a different thread" do
-      ch = Channel(Symbol).new(1)
+      ch = Channel(SpecChannelStatus).new(1)
 
       IO.pipe do |read, write|
         f = spawn do
-          ch.send :start
+          ch.send :begin
           loop do
             write.puts "some line"
           end
@@ -957,11 +957,11 @@ describe IO do
 
         schedule_timeout ch
 
-        ch.receive.should eq(:start)
+        ch.receive.begin?.should be_true
         wait_until_blocked f
 
         write.close
-        ch.receive.should eq(:end)
+        ch.receive.end?.should be_true
       end
     end
   end

--- a/spec/std/iterator_spec.cr
+++ b/spec/std/iterator_spec.cr
@@ -738,13 +738,13 @@ describe Iterator do
 
   describe "flatten" do
     it "flattens an iterator of mixed-type iterators" do
-      iter = [(1..2).each, ('a'..'b').each, {:c => 3}.each].each.flatten
+      iter = [(1..2).each, ('a'..'b').each, {"c" => 3}.each].each.flatten
 
       iter.next.should eq(1)
       iter.next.should eq(2)
       iter.next.should eq('a')
       iter.next.should eq('b')
-      iter.next.should eq({:c, 3})
+      iter.next.should eq({"c", 3})
 
       iter.next.should be_a(Iterator::Stop)
     end

--- a/spec/std/object_spec.cr
+++ b/spec/std/object_spec.cr
@@ -464,14 +464,14 @@ describe Object do
 
   describe "#in?" do
     it "works with Enumerable-s" do
-      :foo.in?([:foo, :bar]).should be_true
-      :bar.in?({:foo, :baz}).should be_false
+      "foo".in?(["foo", "bar"]).should be_true
+      "bar".in?({"foo", "baz"}).should be_false
       42.in?(0..100).should be_true
       4242.in?(0..100).should be_false
     end
 
     it "works with splatted arguments" do
-      :baz.in?(:foo, :bar).should be_false
+      "baz".in?("foo", "bar").should be_false
       1.in?(1, 10, 100).should be_true
     end
 

--- a/spec/std/socket/unix_server_spec.cr
+++ b/spec/std/socket/unix_server_spec.cr
@@ -80,7 +80,7 @@ describe UNIXServer do
     it "raises when server is closed" do
       with_tempfile("unix_server-closed.sock") do |path|
         server = UNIXServer.new(path)
-        ch = Channel(Symbol).new(1)
+        ch = Channel(SpecChannelStatus).new(1)
         exception = nil
 
         schedule_timeout ch
@@ -95,13 +95,13 @@ describe UNIXServer do
           ch.send(:end)
         end
 
-        ch.receive.should eq(:begin)
+        ch.receive.begin?.should be_true
 
         # wait for the server to call accept
         wait_until_blocked f
 
         server.close
-        ch.receive.should eq(:end)
+        ch.receive.end?.should be_true
 
         exception.should be_a(IO::Error)
         exception.try(&.message).should eq("Closed stream")
@@ -125,8 +125,8 @@ describe UNIXServer do
     it "returns nil when server is closed" do
       with_tempfile("unix_server-accept2.sock") do |path|
         server = UNIXServer.new(path)
-        ch = Channel(Symbol).new(1)
-        ret = :initial
+        ch = Channel(SpecChannelStatus).new(1)
+        ret = "initial"
 
         schedule_timeout ch
 
@@ -136,13 +136,13 @@ describe UNIXServer do
           ch.send :end
         end
 
-        ch.receive.should eq(:begin)
+        ch.receive.begin?.should be_true
 
         # wait for the server to call accept
         wait_until_blocked f
 
         server.close
-        ch.receive.should eq(:end)
+        ch.receive.end?.should be_true
 
         ret.should be_nil
       end

--- a/spec/std/tuple_spec.cr
+++ b/spec/std/tuple_spec.cr
@@ -123,7 +123,7 @@ describe "Tuple" do
     end
 
     it "works with mixed types" do
-      {1, "a", 1.0, :a}.values_at(0, 1, 2, 3).should eq({1, "a", 1.0, :a})
+      {1, "a", 1.0, false}.values_at(0, 1, 2, 3).should eq({1, "a", 1.0, false})
     end
   end
 

--- a/spec/support/channel.cr
+++ b/spec/support/channel.cr
@@ -1,4 +1,10 @@
-def schedule_timeout(c : Channel(Symbol))
+enum SpecChannelStatus
+  Begin
+  End
+  Timeout
+end
+
+def schedule_timeout(c : Channel(SpecChannelStatus))
   spawn do
     {% if flag?(:interpreted) %}
       # TODO: it's not clear why some interpreter specs
@@ -8,6 +14,6 @@ def schedule_timeout(c : Channel(Symbol))
     {% else %}
       sleep 1
     {% end %}
-    c.send(:timeout)
+    c.send(SpecChannelStatus::Timeout)
   end
 end


### PR DESCRIPTION
This is by no means exhaustive. The biggest remaining uses are `Symbol` itself, `NamedTuple`, `Log::Metadata`, and serialization specs.