### PR TITLE
Fix `HTTP::Client#exec` to abort retry when client was closed

### DIFF
--- a/src/http/client.cr
+++ b/src/http/client.cr
@@ -585,12 +585,13 @@ class HTTP::Client
   private def exec_internal(request)
     begin
       response = exec_internal_single(request)
-    rescue IO::Error
+    rescue exc : IO::Error
+      raise exc if @io.nil? # do not retry if client was closed
       response = nil
     end
     return handle_response(response) if response
 
-    # Server probably closed the connection, so retry one
+    # Server probably closed the connection, so retry once
     close
     request.body.try &.rewind
     response = exec_internal_single(request)
@@ -650,7 +651,7 @@ class HTTP::Client
     begin
       decompress = send_request(request)
     rescue ex : IO::Error
-      return yield nil if ignore_io_error
+      return yield nil if ignore_io_error && !@io.nil? # ignore_io_error only if client was not closed
       raise ex
     end
     HTTP::Client::Response.from_io?(io, ignore_body: request.ignore_body?, decompress: decompress) do |response|


### PR DESCRIPTION
Resolves  #12464