### PR TITLE
Use instantiated type as `self` when inferring instance variable types

### DIFF
--- a/spec/compiler/semantic/instance_var_spec.cr
+++ b/spec/compiler/semantic/instance_var_spec.cr
@@ -5536,6 +5536,31 @@ describe "Semantic: instance var" do
       )) { int32 }
   end
 
+  it "looks up self restriction in instantiated type, not defined type" do
+    assert_type(<<-CR) { types["Foo2"] }
+      class Foo1
+        def foo : self
+          self
+        end
+      end
+
+      class Foo2 < Foo1
+      end
+
+      class Bar
+        def initialize
+          @x = Foo2.new
+        end
+
+        def bar
+          @x = @x.foo
+        end
+      end
+
+      Bar.new.bar
+      CR
+  end
+
   it "inferrs Proc(Void) to Proc(Nil)" do
     assert_type(%(
       struct Proc

--- a/src/compiler/crystal/semantic/type_guess_visitor.cr
+++ b/src/compiler/crystal/semantic/type_guess_visitor.cr
@@ -868,7 +868,7 @@ module Crystal
         return_type = match.def.return_type
         next unless return_type
 
-        lookup_type?(return_type, match.context.defining_type)
+        lookup_type?(return_type, match.context.defining_type, match.context.instantiated_type.instance_type)
       end
 
       return nil if return_types.empty?
@@ -1116,7 +1116,7 @@ module Crystal
       @found_self = true if node.name == "self"
     end
 
-    def lookup_type?(node, root = nil)
+    def lookup_type?(node, root = nil, self_type = nil)
       find_root_generic_type_parameters =
         @dont_find_root_generic_type_parameters == 0
 
@@ -1158,6 +1158,7 @@ module Crystal
 
       type = root.lookup_type?(
         node,
+        self_type: self_type || root.instance_type,
         allow_typeof: false,
         find_root_generic_type_parameters: find_root_generic_type_parameters
       )


### PR DESCRIPTION
This was discovered while trying to work on #11771. In the following:

```crystal
class Foo1
  def foo : self
    self
  end
end

class Foo2 < Foo1
end

class Bar
  def initialize
    @x = Foo2.new
  end

  def bar
    @x = @x.foo
  end
end

typeof(Bar.new.@x) # => Foo1
```

`@x.foo`'s type is inferred to be `Foo1` instead of `Foo2` since #11962, because the defining type is `Foo1`, but the instantiated type is `Foo2`, and that is what the return value restriction in the def should resolve to.