### PR TITLE
Add docs for `Int#downto`

### DIFF
--- a/src/int.cr
+++ b/src/int.cr
@@ -561,9 +561,9 @@ struct Int
     end
   end
 
-  # Get an iterator for counting down from self to limit
-  def downto(limit)
-    DowntoIterator(typeof(self), typeof(limit)).new(self, limit)
+  # Get an iterator for counting down from self to `to`
+  def downto(to)
+    DowntoIterator(typeof(self), typeof(to)).new(self, to)
   end
 
   def to(to, &block : self ->) : Nil

--- a/src/int.cr
+++ b/src/int.cr
@@ -561,7 +561,7 @@ struct Int
     end
   end
 
-  # Get an iterator for counting down from self to `to`
+  # Get an iterator for counting down from self to `to`.
   def downto(to)
     DowntoIterator(typeof(self), typeof(to)).new(self, to)
   end

--- a/src/int.cr
+++ b/src/int.cr
@@ -550,7 +550,7 @@ struct Int
     UptoIterator(typeof(self), typeof(to)).new(self, to)
   end
 
-  # Calls the given block with each integer value from self down to `to`;
+  # Calls the given block with each integer value from self down to `to`
   def downto(to, &block : self ->) : Nil
     return unless self >= to
     x = self
@@ -561,9 +561,9 @@ struct Int
     end
   end
 
-  # Get an iterator for counting down from self to `to`
-  def downto(to)
-    DowntoIterator(typeof(self), typeof(to)).new(self, to)
+  # Get an iterator for counting down from self to limit
+  def downto(limit)
+    DowntoIterator(typeof(self), typeof(limit)).new(self, limit)
   end
 
   def to(to, &block : self ->) : Nil
@@ -822,19 +822,19 @@ struct Int
     include Iterator(T)
 
     @from : T
-    @to : N
+    @limit : N
     @current : T
     @done : Bool
 
-    def initialize(@from : T, @to : N)
+    def initialize(@from : T, @limit : N)
       @current = @from
-      @done = !(@from >= @to)
+      @done = !(@from >= @limit)
     end
 
     def next
       return stop if @done
       value = @current
-      @done = @current == @to
+      @done = @current == @limit
       @current -= 1 unless @done
       value
     end

--- a/src/int.cr
+++ b/src/int.cr
@@ -550,7 +550,7 @@ struct Int
     UptoIterator(typeof(self), typeof(to)).new(self, to)
   end
 
-  # Calls the given block with each integer value from self down to `to`
+  # Calls the given block with each integer value from self down to `to`.
   def downto(to, &block : self ->) : Nil
     return unless self >= to
     x = self

--- a/src/int.cr
+++ b/src/int.cr
@@ -550,20 +550,20 @@ struct Int
     UptoIterator(typeof(self), typeof(to)).new(self, to)
   end
 
-  # Calls the given block with each integer value from self down to limit;
-  def downto(limit, &block : self ->) : Nil
-    return unless self >= limit
+  # Calls the given block with each integer value from self down to `to`;
+  def downto(to, &block : self ->) : Nil
+    return unless self >= to
     x = self
     while true
       yield x
-      return if x == limit
+      return if x == to
       x -= 1
     end
   end
 
-  # Get an iterator for counting down from self to limit
-  def downto(limit)
-    DowntoIterator(typeof(self), typeof(limit)).new(self, limit)
+  # Get an iterator for counting down from self to `to`
+  def downto(to)
+    DowntoIterator(typeof(self), typeof(to)).new(self, to)
   end
 
   def to(to, &block : self ->) : Nil
@@ -822,19 +822,19 @@ struct Int
     include Iterator(T)
 
     @from : T
-    @limit : N
+    @to : N
     @current : T
     @done : Bool
 
-    def initialize(@from : T, @limit : N)
+    def initialize(@from : T, @to : N)
       @current = @from
-      @done = !(@from >= @limit)
+      @done = !(@from >= @to)
     end
 
     def next
       return stop if @done
       value = @current
-      @done = @current == @limit
+      @done = @current == @to
       @current -= 1 unless @done
       value
     end

--- a/src/int.cr
+++ b/src/int.cr
@@ -822,19 +822,19 @@ struct Int
     include Iterator(T)
 
     @from : T
-    @limit : N
+    @to : N
     @current : T
     @done : Bool
 
-    def initialize(@from : T, @limit : N)
+    def initialize(@from : T, @to : N)
       @current = @from
-      @done = !(@from >= @limit)
+      @done = !(@from >= @to)
     end
 
     def next
       return stop if @done
       value = @current
-      @done = @current == @limit
+      @done = @current == @to
       @current -= 1 unless @done
       value
     end

--- a/src/int.cr
+++ b/src/int.cr
@@ -550,18 +550,20 @@ struct Int
     UptoIterator(typeof(self), typeof(to)).new(self, to)
   end
 
-  def downto(to, &block : self ->) : Nil
-    return unless self >= to
+  # Calls the given block with each integer value from self down to limit;
+  def downto(limit, &block : self ->) : Nil
+    return unless self >= limit
     x = self
     while true
       yield x
-      return if x == to
+      return if x == limit
       x -= 1
     end
   end
 
-  def downto(to)
-    DowntoIterator(typeof(self), typeof(to)).new(self, to)
+  # Get an iterator for counting down from self to limit
+  def downto(limit)
+    DowntoIterator(typeof(self), typeof(limit)).new(self, limit)
   end
 
   def to(to, &block : self ->) : Nil
@@ -820,19 +822,19 @@ struct Int
     include Iterator(T)
 
     @from : T
-    @to : N
+    @limit : N
     @current : T
     @done : Bool
 
-    def initialize(@from : T, @to : N)
+    def initialize(@from : T, @limit : N)
       @current = @from
-      @done = !(@from >= @to)
+      @done = !(@from >= @limit)
     end
 
     def next
       return stop if @done
       value = @current
-      @done = @current == @to
+      @done = @current == @limit
       @current -= 1 unless @done
       value
     end


### PR DESCRIPTION
Update the iterator's related var name for consistency.

Did this because it only had bare signature for docs, and the `to` argument reads badly.