### PR TITLE
[RFC] Better call error messages

### DIFF
--- a/spec/compiler/semantic/automatic_cast_spec.cr
+++ b/spec/compiler/semantic/automatic_cast_spec.cr
@@ -39,7 +39,7 @@ describe "Semantic: automatic cast" do
 
       foo(2147483648_i64)
       ),
-      "no overload matches"
+      "expected first argument to 'foo' to be Int32, not Int64"
   end
 
   it "casts literal integer (Int32 -> Float32)" do
@@ -208,7 +208,7 @@ describe "Semantic: automatic cast" do
 
       foo(:four)
       ),
-      "no overload matches"
+      "expected first argument to 'foo' to be Foo, not Symbol"
   end
 
   it "says ambiguous call for symbol" do
@@ -419,7 +419,8 @@ describe "Semantic: automatic cast" do
       a = 1 || Zed.new
       a + 2
       ),
-      "no overload matches", inject_primitives: true
+      "expected first argument to 'Zed#+' to be Char, not Int32",
+      inject_primitives: true
   end
 
   it "doesn't say 'ambiguous call' when there's an exact match for symbol (#6601)" do
@@ -448,7 +449,7 @@ describe "Semantic: automatic cast" do
       a = 1 || Zed.new
       a + :red
       ),
-      "no overload matches"
+      "expected first argument to 'Zed#+' to be Char, not Symbol"
   end
 
   it "can use automatic cast with `with ... yield` (#7736)" do
@@ -649,7 +650,7 @@ describe "Semantic: automatic cast" do
       x = 1_i64
       foo(x)
       ),
-      "no overload matches 'foo' with type Int64"
+      "expected first argument to 'foo' to be Int32, not Int64"
   end
 
   it "doesn't cast integer variable to larger type (not #9565)" do
@@ -661,7 +662,7 @@ describe "Semantic: automatic cast" do
       x = 1_i32
       foo(x)
       ),
-      "no overload matches 'foo' with type Int32",
+      "expected first argument to 'foo' to be Int64, not Int32",
       flags: "no_number_autocast"
   end
 

--- a/spec/compiler/semantic/automatic_cast_spec.cr
+++ b/spec/compiler/semantic/automatic_cast_spec.cr
@@ -39,7 +39,7 @@ describe "Semantic: automatic cast" do
 
       foo(2147483648_i64)
       ),
-      "expected first argument to 'foo' to be Int32, not Int64"
+      "expected argument #1 to 'foo' to be Int32, not Int64"
   end
 
   it "casts literal integer (Int32 -> Float32)" do
@@ -208,7 +208,7 @@ describe "Semantic: automatic cast" do
 
       foo(:four)
       ),
-      "expected first argument to 'foo' to be Foo, not Symbol"
+      "expected argument #1 to 'foo' to be Foo, not Symbol"
   end
 
   it "says ambiguous call for symbol" do
@@ -419,7 +419,7 @@ describe "Semantic: automatic cast" do
       a = 1 || Zed.new
       a + 2
       ),
-      "expected first argument to 'Zed#+' to be Char, not Int32",
+      "expected argument #1 to 'Zed#+' to be Char, not Int32",
       inject_primitives: true
   end
 
@@ -449,7 +449,7 @@ describe "Semantic: automatic cast" do
       a = 1 || Zed.new
       a + :red
       ),
-      "expected first argument to 'Zed#+' to be Char, not Symbol"
+      "expected argument #1 to 'Zed#+' to be Char, not Symbol"
   end
 
   it "can use automatic cast with `with ... yield` (#7736)" do
@@ -650,7 +650,7 @@ describe "Semantic: automatic cast" do
       x = 1_i64
       foo(x)
       ),
-      "expected first argument to 'foo' to be Int32, not Int64"
+      "expected argument #1 to 'foo' to be Int32, not Int64"
   end
 
   it "doesn't cast integer variable to larger type (not #9565)" do
@@ -662,7 +662,7 @@ describe "Semantic: automatic cast" do
       x = 1_i32
       foo(x)
       ),
-      "expected first argument to 'foo' to be Int64, not Int32",
+      "expected argument #1 to 'foo' to be Int64, not Int32",
       flags: "no_number_autocast"
   end
 

--- a/spec/compiler/semantic/c_struct_spec.cr
+++ b/spec/compiler/semantic/c_struct_spec.cr
@@ -379,7 +379,8 @@ describe "Semantic: struct" do
       foo = LibFoo::Foo.new
       foo.x = Foo.new
       ),
-      "no overload matches 'Int32#+' with type Char", inject_primitives: true
+      "expected first argument to 'Int32#+' to be Float32, Float64, Int128, Int16, Int32, Int64, Int8, UInt128, UInt16, UInt32, UInt64 or UInt8, not Char",
+      inject_primitives: true
   end
 
   it "errors if invoking to_unsafe and got different type" do

--- a/spec/compiler/semantic/c_struct_spec.cr
+++ b/spec/compiler/semantic/c_struct_spec.cr
@@ -379,7 +379,7 @@ describe "Semantic: struct" do
       foo = LibFoo::Foo.new
       foo.x = Foo.new
       ),
-      "expected first argument to 'Int32#+' to be Float32, Float64, Int128, Int16, Int32, Int64, Int8, UInt128, UInt16, UInt32, UInt64 or UInt8, not Char",
+      "expected argument #1 to 'Int32#+' to be Float32, Float64, Int128, Int16, Int32, Int64, Int8, UInt128, UInt16, UInt32, UInt64 or UInt8, not Char",
       inject_primitives: true
   end
 

--- a/spec/compiler/semantic/call_error_spec.cr
+++ b/spec/compiler/semantic/call_error_spec.cr
@@ -31,4 +31,24 @@ describe "Call errors" do
       ),
       "'foo' is expected to be invoked with a block, but no block was given"
   end
+
+  it "says missing named argument" do
+    assert_error %(
+      def foo(*, x)
+      end
+
+      foo
+      ),
+      "missing argument: x"
+  end
+
+  it "says missing named arguments" do
+    assert_error %(
+      def foo(*, x, y)
+      end
+
+      foo
+      ),
+      "missing arguments: x, y"
+  end
 end

--- a/spec/compiler/semantic/call_error_spec.cr
+++ b/spec/compiler/semantic/call_error_spec.cr
@@ -1,0 +1,13 @@
+require "../../spec_helper"
+
+describe "Call errors" do
+  it "says wrong number of arguments (to few arguments)" do
+    assert_error %(
+      def foo(x)
+      end
+
+      foo
+      ),
+      "wrong number of arguments for 'foo' (given 0, expected 1)"
+  end
+end

--- a/spec/compiler/semantic/call_error_spec.cr
+++ b/spec/compiler/semantic/call_error_spec.cr
@@ -51,4 +51,24 @@ describe "Call errors" do
       ),
       "missing arguments: x, y"
   end
+
+  it "says no parameter named" do
+    assert_error %(
+      def foo
+      end
+
+      foo(x: 1)
+      ),
+      "no parameter named 'x'"
+  end
+
+  it "says no parameters named" do
+    assert_error %(
+      def foo
+      end
+
+      foo(x: 1, y: 2)
+      ),
+      "no parameters named 'x', 'y'"
+  end
 end

--- a/spec/compiler/semantic/call_error_spec.cr
+++ b/spec/compiler/semantic/call_error_spec.cr
@@ -71,4 +71,14 @@ describe "Call errors" do
       ),
       "no parameters named 'x', 'y'"
   end
+
+  it "says argument already specified" do
+    assert_error %(
+      def foo(x)
+      end
+
+      foo(1, x: 2)
+      ),
+      "argument for parameter 'x' already specified"
+  end
 end

--- a/spec/compiler/semantic/call_error_spec.cr
+++ b/spec/compiler/semantic/call_error_spec.cr
@@ -150,4 +150,28 @@ describe "Call errors" do
       ),
       "expected argument 'y' to 'foo' to be Int32, not Char"
   end
+
+  it "replaces generic type var in positional argument" do
+    assert_error %(
+      class Foo(T)
+        def self.foo(x : T)
+        end
+      end
+
+      Foo(Int32).foo('a')
+      ),
+      "expected first argument to 'Foo(Int32).foo' to be Int32, not Char"
+  end
+
+  it "replaces generic type var in named argument" do
+    assert_error %(
+      class Foo(T)
+        def self.foo(x : T, y : T)
+        end
+      end
+
+      Foo(Int32).foo(x: 1, y: 'a')
+      ),
+      "expected argument 'y' to 'Foo(Int32).foo' to be Int32, not Char"
+  end
 end

--- a/spec/compiler/semantic/call_error_spec.cr
+++ b/spec/compiler/semantic/call_error_spec.cr
@@ -10,4 +10,25 @@ describe "Call errors" do
       ),
       "wrong number of arguments for 'foo' (given 0, expected 1)"
   end
+
+  it "says not expected to be invoked with a block" do
+    assert_error %(
+      def foo
+      end
+
+      foo {}
+      ),
+      "'foo' is not expected to be invoked with a block, but a block was given"
+  end
+
+  it "says expected to be invoked with a block" do
+    assert_error %(
+      def foo
+        yield
+      end
+
+      foo
+      ),
+      "'foo' is expected to be invoked with a block, but no block was given"
+  end
 end

--- a/spec/compiler/semantic/call_error_spec.cr
+++ b/spec/compiler/semantic/call_error_spec.cr
@@ -103,7 +103,7 @@ describe "Call errors" do
 
       foo(1, 'a')
       ),
-      "expected second argument to 'foo' to be Int32, not Char"
+      "expected argument #2 to 'foo' to be Int32, not Char"
   end
 
   it "says type mismatch for positional argument with two options" do
@@ -116,7 +116,7 @@ describe "Call errors" do
 
       foo('a')
       ),
-      "expected first argument to 'foo' to be Int32 or String, not Char"
+      "expected argument #1 to 'foo' to be Int32 or String, not Char"
   end
 
   it "says type mismatch for positional argument with three options" do
@@ -132,7 +132,7 @@ describe "Call errors" do
 
       foo('a')
       ),
-      "expected first argument to 'foo' to be Bool, Int32 or String, not Char"
+      "expected argument #1 to 'foo' to be Bool, Int32 or String, not Char"
   end
 
   it "says type mismatch for named argument " do
@@ -152,7 +152,7 @@ describe "Call errors" do
 
       foo(1, 'a')
       ),
-      "expected second argument to 'foo' to be Int32, not Char"
+      "expected argument #2 to 'foo' to be Int32, not Char"
   end
 
   it "replaces free variables in named argument" do
@@ -174,7 +174,7 @@ describe "Call errors" do
 
       Foo(Int32).foo('a')
       ),
-      "expected first argument to 'Foo(Int32).foo' to be Int32, not Char"
+      "expected argument #1 to 'Foo(Int32).foo' to be Int32, not Char"
   end
 
   it "replaces generic type var in named argument" do
@@ -202,6 +202,6 @@ describe "Call errors" do
 
       foo("hello")
       ),
-      "expected first argument to 'foo' to be Char or Int32, not String"
+      "expected argument #1 to 'foo' to be Char or Int32, not String"
   end
 end

--- a/spec/compiler/semantic/call_error_spec.cr
+++ b/spec/compiler/semantic/call_error_spec.cr
@@ -174,4 +174,20 @@ describe "Call errors" do
       ),
       "expected argument 'y' to 'Foo(Int32).foo' to be Int32, not Char"
   end
+
+  it "says type mismatch for positional argument even if there are overloads that don't match" do
+    assert_error %(
+      def foo(x : Int32)
+      end
+
+      def foo(x : Char)
+      end
+
+      def foo(x : Char, y : Int32)
+      end
+
+      foo("hello")
+      ),
+      "expected first argument to 'foo' to be Char or Int32, not String"
+  end
 end

--- a/spec/compiler/semantic/call_error_spec.cr
+++ b/spec/compiler/semantic/call_error_spec.cr
@@ -81,4 +81,53 @@ describe "Call errors" do
       ),
       "argument for parameter 'x' already specified"
   end
+
+  it "says type mismatch for positional argument" do
+    assert_error %(
+      def foo(x : Int32, y : Int32)
+      end
+
+      foo(1, 'a')
+      ),
+      "expected second argument to 'foo' to be Int32, not Char"
+  end
+
+  it "says type mismatch for positional argument with two options" do
+    assert_error %(
+      def foo(x : Int32)
+      end
+
+      def foo(x : String)
+      end
+
+      foo('a')
+      ),
+      "expected first argument to 'foo' to be Int32 or String, not Char"
+  end
+
+  it "says type mismatch for positional argument with three options" do
+    assert_error %(
+      def foo(x : Int32)
+      end
+
+      def foo(x : String)
+      end
+
+      def foo(x : Bool)
+      end
+
+      foo('a')
+      ),
+      "expected first argument to 'foo' to be Bool, Int32 or String, not Char"
+  end
+
+  it "says type mismatch for named argument " do
+    assert_error %(
+      def foo(x : Int32, y : Int32)
+      end
+
+      foo(y: 1, x: 'a')
+      ),
+      "expected argument 'x' to 'foo' to be Int32, not Char"
+  end
 end

--- a/spec/compiler/semantic/call_error_spec.cr
+++ b/spec/compiler/semantic/call_error_spec.cr
@@ -11,6 +11,20 @@ describe "Call errors" do
       "wrong number of arguments for 'foo' (given 0, expected 1)"
   end
 
+  it "says wrong number of arguments even if other overloads don't match by block" do
+    assert_error %(
+      def foo(x)
+      end
+
+      def foo(x, y)
+        yield
+      end
+
+      foo
+      ),
+      "wrong number of arguments for 'foo' (given 0, expected 1)"
+  end
+
   it "says not expected to be invoked with a block" do
     assert_error %(
       def foo

--- a/spec/compiler/semantic/call_error_spec.cr
+++ b/spec/compiler/semantic/call_error_spec.cr
@@ -130,4 +130,24 @@ describe "Call errors" do
       ),
       "expected argument 'x' to 'foo' to be Int32, not Char"
   end
+
+  it "replaces free variables in positional argument" do
+    assert_error %(
+      def foo(x : T, y : T) forall T
+      end
+
+      foo(1, 'a')
+      ),
+      "expected second argument to 'foo' to be Int32, not Char"
+  end
+
+  it "replaces free variables in named argument" do
+    assert_error %(
+      def foo(x : T, y : T) forall T
+      end
+
+      foo(x: 1, y: 'a')
+      ),
+      "expected argument 'y' to 'foo' to be Int32, not Char"
+  end
 end

--- a/spec/compiler/semantic/class_spec.cr
+++ b/spec/compiler/semantic/class_spec.cr
@@ -833,7 +833,7 @@ describe "Semantic: class" do
 
       Foo.new 'a'
       ),
-      "no overload matches"
+      "expected first argument to 'Foo.new' to be Int32, not Char"
   end
 
   it "correctly types #680" do

--- a/spec/compiler/semantic/class_spec.cr
+++ b/spec/compiler/semantic/class_spec.cr
@@ -833,7 +833,7 @@ describe "Semantic: class" do
 
       Foo.new 'a'
       ),
-      "expected first argument to 'Foo.new' to be Int32, not Char"
+      "expected argument #1 to 'Foo.new' to be Int32, not Char"
   end
 
   it "correctly types #680" do

--- a/spec/compiler/semantic/class_var_spec.cr
+++ b/spec/compiler/semantic/class_var_spec.cr
@@ -14,7 +14,7 @@ describe "Semantic: class var" do
 
       Foo.x = true
       ),
-      "no overload matches 'Foo.x=' with type Bool"
+      "expected first argument to 'Foo.x=' to be Int32, not Bool"
   end
 
   it "declares class variable (2)" do

--- a/spec/compiler/semantic/class_var_spec.cr
+++ b/spec/compiler/semantic/class_var_spec.cr
@@ -14,7 +14,7 @@ describe "Semantic: class var" do
 
       Foo.x = true
       ),
-      "expected first argument to 'Foo.x=' to be Int32, not Bool"
+      "expected argument #1 to 'Foo.x=' to be Int32, not Bool"
   end
 
   it "declares class variable (2)" do

--- a/spec/compiler/semantic/def_overload_spec.cr
+++ b/spec/compiler/semantic/def_overload_spec.cr
@@ -245,7 +245,7 @@ describe "Semantic: def overload" do
   end
 
   it "does not consider global paths as free variables (2)" do
-    assert_error <<-CR, "expected first argument to 'foo' to be Foo, not Int32"
+    assert_error <<-CR, "expected argument #1 to 'foo' to be Foo, not Int32"
       class Foo
       end
 
@@ -563,7 +563,7 @@ describe "Semantic: def overload" do
 
       foo Foo(Int32 | Float64).new
       ",
-      "expected first argument to 'foo' to be Foo(Int32), not Foo(Float64 | Int32)"
+      "expected argument #1 to 'foo' to be Foo(Int32), not Foo(Float64 | Int32)"
   end
 
   it "gets free variable from union restriction" do
@@ -747,7 +747,7 @@ describe "Semantic: def overload" do
 
       foo({1, 2})
       ",
-      "expected first argument to 'foo' to be ::Tuple(X, Y, Z), not Tuple(Int32, Int32)"
+      "expected argument #1 to 'foo' to be ::Tuple(X, Y, Z), not Tuple(Int32, Int32)"
   end
 
   it "matches tuples of different sizes" do
@@ -799,7 +799,7 @@ describe "Semantic: def overload" do
 
       Bar.new.foo(1.5)
       ),
-      "no overload matches"
+      "expected argument #1 to 'Bar#foo' to be Int32, not Float64"
   end
 
   it "doesn't match with wrong number of type arguments (#313)" do
@@ -834,7 +834,7 @@ describe "Semantic: def overload" do
 
       Foo.new('a')
       ),
-      "expected first argument to 'Foo.new' to be Int, not Char"
+      "expected argument #1 to 'Foo.new' to be Int, not Char"
   end
 
   it "finds method after including module in generic module (#1201)" do
@@ -1033,7 +1033,7 @@ describe "Semantic: def overload" do
 
       foo(1, 'a')
       ),
-      "expected second argument to 'foo' to be Int32, not Char"
+      "expected argument #2 to 'foo' to be Int32, not Char"
   end
 
   it "errors when binding free variable to different types (2)" do
@@ -1046,7 +1046,7 @@ describe "Semantic: def overload" do
 
       foo(1, Gen(Char).new)
       ),
-      "expected second argument to 'foo' to be Gen(Int32), not Gen(Char)"
+      "expected argument #2 to 'foo' to be Gen(Int32), not Gen(Char)"
   end
 
   it "overloads with named argument (#4465)" do

--- a/spec/compiler/semantic/def_overload_spec.cr
+++ b/spec/compiler/semantic/def_overload_spec.cr
@@ -245,7 +245,7 @@ describe "Semantic: def overload" do
   end
 
   it "does not consider global paths as free variables (2)" do
-    assert_error <<-CR, "no overload matches"
+    assert_error <<-CR, "expected first argument to 'foo' to be Foo, not Int32"
       class Foo
       end
 
@@ -563,7 +563,7 @@ describe "Semantic: def overload" do
 
       foo Foo(Int32 | Float64).new
       ",
-      "no overload matches"
+      "expected first argument to 'foo' to be Foo(Int32), not Foo(Float64 | Int32)"
   end
 
   it "gets free variable from union restriction" do
@@ -747,7 +747,7 @@ describe "Semantic: def overload" do
 
       foo({1, 2})
       ",
-      "no overload matches"
+      "expected first argument to 'foo' to be ::Tuple(X, Y, Z), not Tuple(Int32, Int32)"
   end
 
   it "matches tuples of different sizes" do
@@ -834,7 +834,7 @@ describe "Semantic: def overload" do
 
       Foo.new('a')
       ),
-      "no overload matches"
+      "expected first argument to 'Foo.new' to be Int, not Char"
   end
 
   it "finds method after including module in generic module (#1201)" do
@@ -1033,7 +1033,7 @@ describe "Semantic: def overload" do
 
       foo(1, 'a')
       ),
-      "no overload matches"
+      "expected second argument to 'foo' to be Int32, not Char"
   end
 
   it "errors when binding free variable to different types (2)" do
@@ -1046,7 +1046,7 @@ describe "Semantic: def overload" do
 
       foo(1, Gen(Char).new)
       ),
-      "no overload matches"
+      "expected second argument to 'foo' to be Gen(Int32), not Gen(Char)"
   end
 
   it "overloads with named argument (#4465)" do

--- a/spec/compiler/semantic/def_spec.cr
+++ b/spec/compiler/semantic/def_spec.cr
@@ -259,7 +259,9 @@ describe "Semantic: def" do
 
       a = Pointer(Node).new(0_u64)
       foo a
-      ), "no overload matches", inject_primitives: true
+      ),
+      "expected first argument to 'foo' to be Pointer(Node), not Node",
+      inject_primitives: true
   end
 
   it "says can only defined def on types and self" do
@@ -373,7 +375,7 @@ describe "Semantic: def" do
 
       Foo.bar
       ),
-      "no overload matches 'foo'"
+      "expected first argument to 'foo' to be String, not Int32"
   end
 
   it "gives correct error for methods in Class" do

--- a/spec/compiler/semantic/def_spec.cr
+++ b/spec/compiler/semantic/def_spec.cr
@@ -260,7 +260,7 @@ describe "Semantic: def" do
       a = Pointer(Node).new(0_u64)
       foo a
       ),
-      "expected first argument to 'foo' to be Pointer(Node), not Node",
+      "expected argument #1 to 'foo' to be Pointer(Node), not Node",
       inject_primitives: true
   end
 
@@ -375,7 +375,7 @@ describe "Semantic: def" do
 
       Foo.bar
       ),
-      "expected first argument to 'foo' to be String, not Int32"
+      "expected argument #1 to 'foo' to be String, not Int32"
   end
 
   it "gives correct error for methods in Class" do

--- a/spec/compiler/semantic/enum_spec.cr
+++ b/spec/compiler/semantic/enum_spec.cr
@@ -29,7 +29,8 @@ describe "Semantic: enum" do
       end
 
       foo 1
-      ), "no overload matches 'foo' with type Int32"
+      ),
+      "expected first argument to 'foo' to be Foo, not Int32"
   end
 
   it "finds method in enum type" do

--- a/spec/compiler/semantic/enum_spec.cr
+++ b/spec/compiler/semantic/enum_spec.cr
@@ -30,7 +30,7 @@ describe "Semantic: enum" do
 
       foo 1
       ),
-      "expected first argument to 'foo' to be Foo, not Int32"
+      "expected argument #1 to 'foo' to be Foo, not Int32"
   end
 
   it "finds method in enum type" do

--- a/spec/compiler/semantic/generic_class_spec.cr
+++ b/spec/compiler/semantic/generic_class_spec.cr
@@ -963,7 +963,7 @@ describe "Semantic: generic class" do
 
       Gen(3).new("a")
       ),
-      "no overload matches"
+      "expected first argument to 'Gen(3).new' to be T, not String"
   end
 
   it "doesn't crash when matching restriction against number literal (2) (#3157)" do

--- a/spec/compiler/semantic/generic_class_spec.cr
+++ b/spec/compiler/semantic/generic_class_spec.cr
@@ -963,7 +963,7 @@ describe "Semantic: generic class" do
 
       Gen(3).new("a")
       ),
-      "expected first argument to 'Gen(3).new' to be T, not String"
+      "expected argument #1 to 'Gen(3).new' to be T, not String"
   end
 
   it "doesn't crash when matching restriction against number literal (2) (#3157)" do

--- a/spec/compiler/semantic/module_spec.cr
+++ b/spec/compiler/semantic/module_spec.cr
@@ -74,7 +74,7 @@ describe "Semantic: module" do
 
       Bar.new.foo(1.5)
       ",
-      "no overload matches"
+      "expected first argument to 'Bar#foo' to be Int, not Float64"
   end
 
   it "includes module but not generic" do
@@ -143,7 +143,7 @@ describe "Semantic: module" do
 
       Bar(Int32).new.foo(1.5)
       ",
-      "no overload matches"
+      "expected first argument to 'Bar(Int32)#foo' to be Int32, not Float64"
   end
 
   it "reports can't use instance variables inside module" do
@@ -307,7 +307,8 @@ describe "Semantic: module" do
       end
 
       Baz1.new.foo Baz2.new
-      ", "no overload matches"
+      ",
+      "expected first argument to 'Baz1#foo' to be Bar(Int32), not Baz2"
   end
 
   it "includes generic module with self (check argument superclass type, success)" do
@@ -1617,7 +1618,7 @@ describe "Semantic: module" do
 
       Gen(Foo.class).foo(Moo)
       ),
-      "no overload matches"
+      "expected first argument to 'Gen(Foo.class).foo' to be Foo.class, not Moo:Module"
   end
 
   it "extends module from generic class and calls class method (#7167)" do

--- a/spec/compiler/semantic/module_spec.cr
+++ b/spec/compiler/semantic/module_spec.cr
@@ -74,7 +74,7 @@ describe "Semantic: module" do
 
       Bar.new.foo(1.5)
       ",
-      "expected first argument to 'Bar#foo' to be Int, not Float64"
+      "expected argument #1 to 'Bar#foo' to be Int, not Float64"
   end
 
   it "includes module but not generic" do
@@ -143,7 +143,7 @@ describe "Semantic: module" do
 
       Bar(Int32).new.foo(1.5)
       ",
-      "expected first argument to 'Bar(Int32)#foo' to be Int32, not Float64"
+      "expected argument #1 to 'Bar(Int32)#foo' to be Int32, not Float64"
   end
 
   it "reports can't use instance variables inside module" do
@@ -308,7 +308,7 @@ describe "Semantic: module" do
 
       Baz1.new.foo Baz2.new
       ",
-      "expected first argument to 'Baz1#foo' to be Bar(Int32), not Baz2"
+      "expected argument #1 to 'Baz1#foo' to be Bar(Int32), not Baz2"
   end
 
   it "includes generic module with self (check argument superclass type, success)" do
@@ -1618,7 +1618,7 @@ describe "Semantic: module" do
 
       Gen(Foo.class).foo(Moo)
       ),
-      "expected first argument to 'Gen(Foo.class).foo' to be Foo.class, not Moo:Module"
+      "expected argument #1 to 'Gen(Foo.class).foo' to be Foo.class, not Moo:Module"
   end
 
   it "extends module from generic class and calls class method (#7167)" do

--- a/spec/compiler/semantic/named_args_spec.cr
+++ b/spec/compiler/semantic/named_args_spec.cr
@@ -65,7 +65,7 @@ describe "Semantic: named args" do
 
       foo x: 1.5
       ),
-      "no overload matches"
+      "expected argument 'x' to 'foo' to be Int32, not Float64"
   end
 
   it "errors if named arg already specified but in same position" do
@@ -189,7 +189,7 @@ describe "Semantic: named args" do
 
       foo(x: 2)
       ),
-      "no overload matches"
+      "missing argument: y"
   end
 
   it "gives correct error message for missing args after *" do

--- a/spec/compiler/semantic/named_tuple_spec.cr
+++ b/spec/compiler/semantic/named_tuple_spec.cr
@@ -165,7 +165,7 @@ describe "Semantic: named tuples" do
 
       foo({x: 1, y: 'a'})
       ),
-      "expected first argument to 'foo' to be NamedTuple(x: Int32, y: Int32), not NamedTuple(x: Int32, y: Char)"
+      "expected argument #1 to 'foo' to be NamedTuple(x: Int32, y: Int32), not NamedTuple(x: Int32, y: Char)"
   end
 
   it "doesn't match type restriction with instance" do
@@ -177,7 +177,7 @@ describe "Semantic: named tuples" do
 
       Foo({a: Int32}).foo({a: 1.1})
       ),
-      "expected first argument to 'Foo(NamedTuple(a: Int32)).foo' to be NamedTuple(a: Int32), not NamedTuple(a: Float64)"
+      "expected argument #1 to 'Foo(NamedTuple(a: Int32)).foo' to be NamedTuple(a: Int32), not NamedTuple(a: Float64)"
   end
 
   it "matches in type restriction and gets free var" do

--- a/spec/compiler/semantic/named_tuple_spec.cr
+++ b/spec/compiler/semantic/named_tuple_spec.cr
@@ -165,7 +165,7 @@ describe "Semantic: named tuples" do
 
       foo({x: 1, y: 'a'})
       ),
-      "no overload matches"
+      "expected first argument to 'foo' to be NamedTuple(x: Int32, y: Int32), not NamedTuple(x: Int32, y: Char)"
   end
 
   it "doesn't match type restriction with instance" do
@@ -177,7 +177,7 @@ describe "Semantic: named tuples" do
 
       Foo({a: Int32}).foo({a: 1.1})
       ),
-      "no overload matches"
+      "expected first argument to 'Foo(NamedTuple(a: Int32)).foo' to be NamedTuple(a: Int32), not NamedTuple(a: Float64)"
   end
 
   it "matches in type restriction and gets free var" do

--- a/spec/compiler/semantic/proc_spec.cr
+++ b/spec/compiler/semantic/proc_spec.cr
@@ -164,7 +164,7 @@ describe "Semantic: proc" do
 
       foo ->(x : Int32) { x }
       ",
-      "no overload matches"
+      "expected first argument to 'foo' to be Proc(Int32, Float64), not Proc(Int32, Int32)"
   end
 
   it "has proc literal as restriction and errors if input is different" do
@@ -175,7 +175,7 @@ describe "Semantic: proc" do
 
       foo ->(x : Int64) { x.to_f }
       ",
-      "no overload matches", inject_primitives: true
+      "expected first argument to 'foo' to be Proc(Int32, Float64), not Proc(Int64, Float64)", inject_primitives: true
   end
 
   it "has proc literal as restriction and errors if sizes are different" do
@@ -186,7 +186,7 @@ describe "Semantic: proc" do
 
       foo ->(x : Int32, y : Int32) { x.to_f }
       ",
-      "no overload matches", inject_primitives: true
+      "expected first argument to 'foo' to be Proc(Int32, Float64), not Proc(Int32, Int32, Float64)", inject_primitives: true
   end
 
   it "allows passing nil as proc callback if it is a lib alias" do

--- a/spec/compiler/semantic/proc_spec.cr
+++ b/spec/compiler/semantic/proc_spec.cr
@@ -164,7 +164,7 @@ describe "Semantic: proc" do
 
       foo ->(x : Int32) { x }
       ",
-      "expected first argument to 'foo' to be Proc(Int32, Float64), not Proc(Int32, Int32)"
+      "expected argument #1 to 'foo' to be Proc(Int32, Float64), not Proc(Int32, Int32)"
   end
 
   it "has proc literal as restriction and errors if input is different" do
@@ -175,7 +175,7 @@ describe "Semantic: proc" do
 
       foo ->(x : Int64) { x.to_f }
       ",
-      "expected first argument to 'foo' to be Proc(Int32, Float64), not Proc(Int64, Float64)", inject_primitives: true
+      "expected argument #1 to 'foo' to be Proc(Int32, Float64), not Proc(Int64, Float64)", inject_primitives: true
   end
 
   it "has proc literal as restriction and errors if sizes are different" do
@@ -186,7 +186,7 @@ describe "Semantic: proc" do
 
       foo ->(x : Int32, y : Int32) { x.to_f }
       ",
-      "expected first argument to 'foo' to be Proc(Int32, Float64), not Proc(Int32, Int32, Float64)", inject_primitives: true
+      "expected argument #1 to 'foo' to be Proc(Int32, Float64), not Proc(Int32, Int32, Float64)", inject_primitives: true
   end
 
   it "allows passing nil as proc callback if it is a lib alias" do

--- a/spec/compiler/semantic/restrictions_spec.cr
+++ b/spec/compiler/semantic/restrictions_spec.cr
@@ -841,7 +841,7 @@ describe "Restrictions" do
 
       foo GenericChild(Base).new
       ),
-      "expected first argument to 'foo' to be GenericBase(Child), not GenericChild(Base)"
+      "expected argument #1 to 'foo' to be GenericBase(Child), not GenericChild(Base)"
   end
 
   it "allows passing recursive type to free var (#1076)" do
@@ -1008,7 +1008,7 @@ describe "Restrictions" do
       y = uninitialized UInt8[11]
       foo(x, y)
       ),
-      "expected second argument to 'foo' to be StaticArray(UInt8, 10), not StaticArray(UInt8, 11)"
+      "expected argument #2 to 'foo' to be StaticArray(UInt8, 10), not StaticArray(UInt8, 11)"
   end
 
   it "gives precedence to T.class over Class (#7392)" do

--- a/spec/compiler/semantic/restrictions_spec.cr
+++ b/spec/compiler/semantic/restrictions_spec.cr
@@ -841,7 +841,7 @@ describe "Restrictions" do
 
       foo GenericChild(Base).new
       ),
-      "no overload matches"
+      "expected first argument to 'foo' to be GenericBase(Child), not GenericChild(Base)"
   end
 
   it "allows passing recursive type to free var (#1076)" do
@@ -1008,7 +1008,7 @@ describe "Restrictions" do
       y = uninitialized UInt8[11]
       foo(x, y)
       ),
-      "no overload matches"
+      "expected second argument to 'foo' to be StaticArray(UInt8, 10), not StaticArray(UInt8, 11)"
   end
 
   it "gives precedence to T.class over Class (#7392)" do

--- a/spec/compiler/semantic/splat_spec.cr
+++ b/spec/compiler/semantic/splat_spec.cr
@@ -339,7 +339,7 @@ describe "Semantic: splat" do
 
       bar 1, "a", 1.7
       ),
-      "no overload matches 'foo' with types Char, Int32, String, Float64"
+      "expected first argument to 'foo' to be Int, not Char"
   end
 
   it "doesn't crash on non-match (#2521)" do
@@ -545,7 +545,7 @@ describe "Semantic: splat" do
       foo = Foo(Int32, String).new
       method(foo)
       ),
-      "no overload matches"
+      "expected first argument to 'method' to be Foo(Tuple(Int32, String)), not Foo(Int32, String)"
   end
 
   it "matches partially instantiated generic with splat in generic type" do
@@ -746,7 +746,7 @@ describe "Semantic: splat" do
 
       foo(1)
       ),
-      "no overload matches"
+      "expected first argument to 'foo' to be Union(*T), not Int32"
   end
 
   it "matches typed before non-typed (1) (#3134)" do

--- a/spec/compiler/semantic/splat_spec.cr
+++ b/spec/compiler/semantic/splat_spec.cr
@@ -339,7 +339,7 @@ describe "Semantic: splat" do
 
       bar 1, "a", 1.7
       ),
-      "expected first argument to 'foo' to be Int, not Char"
+      "expected argument #1 to 'foo' to be Int, not Char"
   end
 
   it "doesn't crash on non-match (#2521)" do
@@ -545,7 +545,7 @@ describe "Semantic: splat" do
       foo = Foo(Int32, String).new
       method(foo)
       ),
-      "expected first argument to 'method' to be Foo(Tuple(Int32, String)), not Foo(Int32, String)"
+      "expected argument #1 to 'method' to be Foo(Tuple(Int32, String)), not Foo(Int32, String)"
   end
 
   it "matches partially instantiated generic with splat in generic type" do
@@ -746,7 +746,7 @@ describe "Semantic: splat" do
 
       foo(1)
       ),
-      "expected first argument to 'foo' to be Union(*T), not Int32"
+      "expected argument #1 to 'foo' to be Union(*T), not Int32"
   end
 
   it "matches typed before non-typed (1) (#3134)" do

--- a/spec/compiler/semantic/static_array_spec.cr
+++ b/spec/compiler/semantic/static_array_spec.cr
@@ -153,6 +153,6 @@ describe "Semantic: static array" do
       n = uninitialized StaticArray(Int32, 10)
       fn(n)
       ),
-      "expected first argument to 'fn' to be StaticArray(Int32, 11), not StaticArray(Int32, 10)"
+      "expected argument #1 to 'fn' to be StaticArray(Int32, 11), not StaticArray(Int32, 10)"
   end
 end

--- a/spec/compiler/semantic/static_array_spec.cr
+++ b/spec/compiler/semantic/static_array_spec.cr
@@ -153,6 +153,6 @@ describe "Semantic: static array" do
       n = uninitialized StaticArray(Int32, 10)
       fn(n)
       ),
-      "no overload matches"
+      "expected first argument to 'fn' to be StaticArray(Int32, 11), not StaticArray(Int32, 10)"
   end
 end

--- a/spec/compiler/semantic/super_spec.cr
+++ b/spec/compiler/semantic/super_spec.cr
@@ -309,7 +309,7 @@ describe "Semantic: super" do
 
       Bar.new(1, 2)
       ),
-      "expected first argument to 'Foo#initialize' to be Char, not Int32"
+      "expected argument #1 to 'Foo#initialize' to be Char, not Int32"
   end
 
   it "calls super in module method (1) (#556)" do

--- a/spec/compiler/semantic/super_spec.cr
+++ b/spec/compiler/semantic/super_spec.cr
@@ -309,7 +309,7 @@ describe "Semantic: super" do
 
       Bar.new(1, 2)
       ),
-      "no overload matches 'Foo#initialize'"
+      "expected first argument to 'Foo#initialize' to be Char, not Int32"
   end
 
   it "calls super in module method (1) (#556)" do

--- a/src/compiler/crystal/semantic/call_error.cr
+++ b/src/compiler/crystal/semantic/call_error.cr
@@ -245,11 +245,11 @@ class Crystal::Call
 
     call_errors = call_errors.map &.as(T)
     all_names = call_errors.flat_map(&.names).uniq
-    all_names.select do |missing_name|
+    names_in_all_overloads = all_names.select do |missing_name|
       call_errors.all? &.names.includes?(missing_name)
     end
-    unless all_names.empty?
-      yield call_errors, all_names
+    unless names_in_all_overloads.empty?
+      yield call_errors, names_in_all_overloads
     end
   end
 

--- a/src/compiler/crystal/semantic/call_error.cr
+++ b/src/compiler/crystal/semantic/call_error.cr
@@ -451,9 +451,18 @@ class Crystal::Call
 
       restricted = arg_type.restrict(def_arg, match_context)
       unless restricted
+        expected_type = def_arg.type?
+        unless expected_type
+          restriction = def_arg.restriction
+          if restriction
+            expected_type = a_def_owner.lookup_type?(restriction, free_vars: match_context.free_vars)
+          end
+        end
+        expected_type ||= def_arg.restriction.not_nil!
+
         arguments_type_mismatch << ArgumentTypeMismatch.new(
           index_or_name: i,
-          expected_type: def_arg.type? || def_arg.restriction.not_nil!,
+          expected_type: expected_type,
           actual_type: arg_type,
         )
       end
@@ -465,9 +474,18 @@ class Crystal::Call
 
       restricted = named_arg.type.restrict(def_arg, match_context)
       unless restricted
+        expected_type = def_arg.type?
+        unless expected_type
+          restriction = def_arg.restriction
+          if restriction
+            expected_type = a_def_owner.lookup_type?(restriction, free_vars: match_context.free_vars)
+          end
+        end
+        expected_type ||= def_arg.restriction.not_nil!
+
         arguments_type_mismatch << ArgumentTypeMismatch.new(
           index_or_name: named_arg.name,
-          expected_type: def_arg.type? || def_arg.restriction.not_nil!,
+          expected_type: expected_type,
           actual_type: named_arg.type,
         )
       end

--- a/src/compiler/crystal/semantic/call_error.cr
+++ b/src/compiler/crystal/semantic/call_error.cr
@@ -439,7 +439,7 @@ class Crystal::Call
 
     match_context = MatchContext.new(
       instantiated_type: instantiated_owner,
-      defining_type: a_def.owner,
+      defining_type: instantiated_owner,
       def_free_vars: a_def.free_vars,
     )
 
@@ -455,7 +455,7 @@ class Crystal::Call
         unless expected_type
           restriction = def_arg.restriction
           if restriction
-            expected_type = a_def_owner.lookup_type?(restriction, free_vars: match_context.free_vars)
+            expected_type = instantiated_owner.lookup_type?(restriction, free_vars: match_context.free_vars)
           end
         end
         expected_type ||= def_arg.restriction.not_nil!
@@ -478,7 +478,7 @@ class Crystal::Call
         unless expected_type
           restriction = def_arg.restriction
           if restriction
-            expected_type = a_def_owner.lookup_type?(restriction, free_vars: match_context.free_vars)
+            expected_type = instantiated_owner.lookup_type?(restriction, free_vars: match_context.free_vars)
           end
         end
         expected_type ||= def_arg.restriction.not_nil!

--- a/src/compiler/crystal/semantic/call_error.cr
+++ b/src/compiler/crystal/semantic/call_error.cr
@@ -117,6 +117,8 @@ class Crystal::Call
     end
 
     check_block_mismatch(call_errors, owner, def_name)
+    call_errors.reject!(BlockMismatch)
+
     check_missing_named_arguments(call_errors, owner, defs, arg_types, inner_exception)
     check_extra_named_arguments(call_errors, owner, defs, arg_types, inner_exception)
     check_arguments_already_specified(call_errors, owner, defs, arg_types, inner_exception)
@@ -588,6 +590,8 @@ class Crystal::Call
     all_arguments_sizes = [] of Int32
     min_splat = Int32::MAX
     defs.each do |a_def|
+      next if (block && !a_def.yields) || (!block && a_def.yields)
+
       min_size, max_size = a_def.min_max_args_sizes
       if max_size == Int32::MAX
         min_splat = Math.min(min_size, min_splat)

--- a/src/compiler/crystal/semantic/call_error.cr
+++ b/src/compiler/crystal/semantic/call_error.cr
@@ -305,25 +305,20 @@ class Crystal::Call
           "'#{index_or_name}'"
         end
 
-      str << "expected argument "
-      str << argument_description
-      str << " to '"
-      str << full_name(owner, def_name)
-      str << "' to be "
-      if expected_types.size == 1
-        str << expected_types.first
-      else
-        expected_types.each_with_index do |expected_type, i|
-          if i == expected_types.size - 1
-            str << " or "
-          elsif i > 0
-            str << ", "
-          end
-          str << expected_type
-        end
+      str << "expected argument #{argument_description} to '#{full_name(owner, def_name)}' to be "
+      to_sentence(str, expected_types, " or ")
+      str << ", not #{actual_type}"
+    end
+  end
+
+  private def to_sentence(str : IO, elements : Array, last_connector : String)
+    elements.each_with_index do |element, i|
+      if i == elements.size - 1 && elements.size > 1
+        str << last_connector
+      elsif i > 0
+        str << ", "
       end
-      str << ", not "
-      str << actual_type
+      str << element
     end
   end
 

--- a/src/compiler/crystal/semantic/call_error.cr
+++ b/src/compiler/crystal/semantic/call_error.cr
@@ -317,25 +317,16 @@ class Crystal::Call
       end
 
     error_message = String.build do |str|
-      argument_name =
+      argument_description =
         case index_or_name
         in Int32
-          case index_or_name
-          when 0 then "first argument"
-          when 1 then "second argument"
-          when 2 then "third argument"
-          when 3 then "fourth argument"
-          when 4 then "fifth argument"
-          when 5 then "sixth argument"
-          when 6 then "seventh argument"
-          else        "argument #{index_or_name + 1}"
-          end
+          "##{index_or_name + 1}"
         in String
-          "argument '#{index_or_name}'"
+          "'#{index_or_name}'"
         end
 
-      str << "expected "
-      str << argument_name
+      str << "expected argument "
+      str << argument_description
       str << " to '"
       str << full_name(owner, def_name)
       str << "' to be "

--- a/src/compiler/crystal/semantic/call_error.cr
+++ b/src/compiler/crystal/semantic/call_error.cr
@@ -459,6 +459,7 @@ class Crystal::Call
           end
         end
         expected_type ||= def_arg.restriction.not_nil!
+        expected_type = expected_type.devirtualize if expected_type.is_a?(Type)
 
         arguments_type_mismatch << ArgumentTypeMismatch.new(
           index_or_name: i,
@@ -482,6 +483,7 @@ class Crystal::Call
           end
         end
         expected_type ||= def_arg.restriction.not_nil!
+        expected_type = expected_type.devirtualize if expected_type.is_a?(Type)
 
         arguments_type_mismatch << ArgumentTypeMismatch.new(
           index_or_name: named_arg.name,

--- a/src/compiler/crystal/semantic/call_error.cr
+++ b/src/compiler/crystal/semantic/call_error.cr
@@ -286,7 +286,8 @@ class Crystal::Call
   end
 
   private def check_arguments_type_mismatch(call_errors, owner, defs, def_name, arg_types, named_args_types, inner_exception)
-    return unless call_errors.all?(ArgumentsTypeMismatch)
+    call_errors = call_errors.select(ArgumentsTypeMismatch)
+    return if call_errors.empty?
 
     call_errors = call_errors.map &.as(ArgumentsTypeMismatch)
     argument_type_mismatches = call_errors.flat_map(&.errors)


### PR DESCRIPTION
# Intro

I think the number one wish for Crystal is to get faster compile times, incremental compilation or modular compilation.

And _I think_ the second one is better error messages. This PR tries to tackle this.

# Why

Right now the compiler does a minimum effort to give a better error message when for example the number of arguments is wrong, or a method expects a block but it wasn't invoked with one. But that logic isn't complete, and the messages could be much better.

# What

This PR improves the error message when a call can't compile, in these ways:
- It goes over each overload and tries to see why that overload didn't match
- If all overloads didn't match because of a block mismatch (either all overloads take a block and none was given, or all overloads don't take a block and one was given), an error is shown accordingly
- Check if in all overloads there were missing named arguments, or extra named arguments. Before this PR this was only done if there was only one overload to consider
- Check for wrong number of arguments, but only consider those where there's no block mismatch
- **Check if a positional or named argument doesn't match in any of the overloads**

The last point is the one that, I think, improves error messages by a lot.

You can take a look at the changed specs to see how error messages are improved.

For example, consider this code:

```crystal
def foo(x : Int32)
end

foo 'a'
```

Before this PR, this is the error shown:

```
In foo.cr:4:1

 4 | foo 'a'
     ^--
Error: no overload matches 'foo' with type Char

Overloads are:
 - foo(x : Int32)
```

What you have to do is compare `Char` in the error message with `Int32` to notice the mistake.

With this PR, this is the error you get:

```
In foo.cr:4:5

 4 | foo 'a'
         ^
Error: expected first argument to 'foo' to be Int32, not Char

Overloads are:
 - foo(x : Int32)
```

(Note: I'd like the entire argument to be underlined but I didn't get to it yet)

But note that this works even if there are overloads. Consider this code:

```crystal
def foo(x : Int32, y : Int32)
end

def foo(x : Int32, y : Int32, z : Char)
end

def foo(x : Int32, y : Int32, z : String)
end

foo 1, 'a'
```

The error you get before this PR is:

```
In foo.cr:10:1

 10 | foo 1, 'a'
      ^--
Error: no overload matches 'foo' with types Int32, Char

Overloads are:
 - foo(x : Int32, y : Int32, z : Char)
 - foo(x : Int32, y : Int32, z : String)
 - foo(x : Int32, y : Int32)
```

What can I do as a user when I see that error? Manually compare the given types with the overload types. It takes a lot of time and effort!

What's the error message with this PR?

```
In foo.cr:10:8

 10 | foo 1, 'a'
             ^
Error: expected second argument to 'foo' to be Int32, not Char

Overloads are:
 - foo(x : Int32, y : Int32, z : Char)
 - foo(x : Int32, y : Int32, z : String)
 - foo(x : Int32, y : Int32)
```

Because all overloads expect an `Int32` as a second argument, and I gave it a `Char`, that's what's wrong! The compiler did the job the user had to manually do.

But there's more! The error message will replace type parameters and free variables. Consider this:

```crystal
a = [1]
a << 'a'
```

Old error message:

```
In foo.cr:2:3

 2 | a << 'a'
       ^-
Error: no overload matches 'Array(Int32)#<<' with type Char

Overloads are:
 - Array(T)#<<(value : T)
```

New error message:

```
In foo.cr:2:6

 2 | a << 'a'
          ^
Error: expected first argument to 'Array(Int32)#<<' to be Int32, not Char

Overloads are:
 - Array(T)#<<(value : T)
```

# Is this PR finished?

Almost! I'd like to get feedback early instead of continuing to work on this before knowing if this is desired. I hope it is!

As a reviewer, if you remember cryptic error messages you could try to reproduce them with `master` and this PR to see what's the difference, and whether the new error messages are better.

Oh, and another thing I'd like to do is... if there isn't a succinct message to show, like for example in this case:

```crystal
def foo(x : Int32, y : Char)
end

def foo(x : Char, y : Int32)
end

foo(1, 2)
```

We get this before and with this PR:

```
In foo.cr:7:1

 7 | foo(1, 2)
     ^--
Error: no overload matches 'foo' with types Int32, Int32

Overloads are:
 - foo(x : Int32, y : Char)
 - foo(x : Char, y : Int32)
```

In that case, I'd like each overload to show why it failed. For example:

```
In foo.cr:7:1

 7 | foo(1, 2)
     ^--
Error: no overload matches 'foo' with types Int32, Int32

Overloads are:
 - foo(x : Int32, y : Char)
 # expected second argument to be Char, not Int32
 - foo(x : Char, y : Int32)
 # expected first argument to be Char, not Int32
```

But of course I won't do that unless there's a desire to move in this direction. And also that could be done as a separate PR.