### PR TITLE
Compiler: flatten types in errors

### DIFF
--- a/spec/compiler/semantic/call_error_spec.cr
+++ b/spec/compiler/semantic/call_error_spec.cr
@@ -135,6 +135,19 @@ describe "Call errors" do
       "expected argument #1 to 'foo' to be Bool, Int32 or String, not Char"
   end
 
+  it "says type mismatch and unflattens unions" do
+    assert_error %(
+      def foo(x : Int32 | Char)
+      end
+
+      def foo(x : String | Symbol)
+      end
+
+      foo(true)
+      ),
+      "expected argument #1 to 'foo' to be Char, Int32, String or Symbol, not Bool"
+  end
+
   it "says type mismatch for named argument " do
     assert_error %(
       def foo(x : Int32, y : Int32)

--- a/src/compiler/crystal/semantic/call_error.cr
+++ b/src/compiler/crystal/semantic/call_error.cr
@@ -277,14 +277,14 @@ class Crystal::Call
     index_or_name = indexes_or_names_in_all_overloads.first
 
     mismatches = argument_type_mismatches.select(&.index_or_name.==(index_or_name))
-    expected_types = mismatches.map(&.expected_type).uniq
+    expected_types = mismatches.map(&.expected_type).uniq!
     expected_types = expected_types.flat_map do |expected_type|
       if expected_type.is_a?(UnionType)
         expected_type.union_types
       else
         expected_type
       end
-    end.uniq
+    end.uniq!
     expected_types.sort_by!(&.to_s)
     actual_type = mismatches.first.actual_type
 

--- a/src/compiler/crystal/semantic/call_error.cr
+++ b/src/compiler/crystal/semantic/call_error.cr
@@ -277,7 +277,15 @@ class Crystal::Call
     index_or_name = indexes_or_names_in_all_overloads.first
 
     mismatches = argument_type_mismatches.select(&.index_or_name.==(index_or_name))
-    expected_types = mismatches.map(&.expected_type).uniq.sort_by(&.to_s)
+    expected_types = mismatches.map(&.expected_type).uniq
+    expected_types = expected_types.flat_map do |expected_type|
+      if expected_type.is_a?(UnionType)
+        expected_type.union_types
+      else
+        expected_type
+      end
+    end.uniq
+    expected_types.sort_by!(&.to_s)
     actual_type = mismatches.first.actual_type
 
     arg =


### PR DESCRIPTION
This is a tiny follow-up to the improved error message. You can see the added spec, but I'll explain it here too.

If you have code like this:

```crystal
def foo(x : Int32 | String)
end

foo(true)
```

The error you got was:

```
In foo.cr:4:5

 4 | foo(true)
         ^
Error: expected argument #1 to 'foo' to be (Int32 | String), not Bool

Overloads are:
 - foo(x : Int32 | String)
```

Not bad, but here's how it looks with this PR:

```
In foo.cr:4:5

 4 | foo(true)
         ^
Error: expected argument #1 to 'foo' to be Int32 or String, not Bool

Overloads are:
 - foo(x : Int32 | String)
```

I think it reads better.

Also if for some reason you had code like this:

```crystal
def foo(x : Int32 | String, y : Char)
end

def foo(x : Int32 | Char, y : Int32)
end

foo(true, 'a')
```

The error you got was this:

```
In foo.cr:7:5

 7 | foo(true, 'a')
         ^
Error: expected argument #1 to 'foo' to be (Char | Int32) or (Int32 | String), not Bool

Overloads are:
 - foo(x : Int32 | String, y : Char)
 - foo(x : Int32 | Char, y : Int32)
```

You can tell it's just listing the types of each overload the way they are.

With this PR, it looks like this:

```crystal
In foo.cr:7:5

 7 | foo(true, 'a')
         ^
Error: expected argument #1 to 'foo' to be Char, Int32 or String, not Bool

Overloads are:
 - foo(x : Int32 | String, y : Char)
 - foo(x : Int32 | Char, y : Int32)
```

It makes more sense. No need for the user to flatten the types themselves (the overloads are an implementation detail.)