### PR TITLE
Compiler: better error message for symbol against enum

### DIFF
--- a/spec/compiler/semantic/call_error_spec.cr
+++ b/spec/compiler/semantic/call_error_spec.cr
@@ -205,7 +205,7 @@ describe "Call errors" do
       "expected argument #1 to 'foo' to be Char or Int32, not String"
   end
 
-  it "says type mismatch for symbol against enum" do
+  it "says type mismatch for symbol against enum (did you mean)" do
     assert_error %(
       enum Color
         Red
@@ -219,5 +219,42 @@ describe "Call errors" do
       foo(:rred)
       ),
       "expected argument #1 symbol to 'foo' to match a Color enum member.\n\nDid you mean :red?"
+  end
+
+  it "says type mismatch for symbol against enum (list all possibilities when 5 or less)" do
+    assert_error %(
+      enum Color
+        Red
+        Green
+        Blue
+        Violet
+        Purple
+      end
+
+      def foo(x : Color)
+      end
+
+      foo(:hello_world)
+      ),
+      "expected argument #1 symbol to 'foo' to match a Color enum member.\n\nOptions are: :red, :green, :blue, :violet and :purple"
+  end
+
+  it "says type mismatch for symbol against enum (list some possibilities when more than 5)" do
+    assert_error %(
+      enum Color
+        Red
+        Green
+        Blue
+        Violet
+        Purple
+        Cyan
+      end
+
+      def foo(x : Color)
+      end
+
+      foo(:hello_world)
+      ),
+      "expected argument #1 symbol to 'foo' to match a Color enum member.\n\nSome options are: :red, :green, :blue, :violet and :purple"
   end
 end

--- a/spec/compiler/semantic/call_error_spec.cr
+++ b/spec/compiler/semantic/call_error_spec.cr
@@ -218,6 +218,6 @@ describe "Call errors" do
 
       foo(:rred)
       ),
-      "expected argument #1 symbol to 'foo' to match a Color enum member."
+      "expected argument #1 symbol to 'foo' to match a Color enum member.\n\nDid you mean :red?"
   end
 end

--- a/spec/compiler/semantic/call_error_spec.cr
+++ b/spec/compiler/semantic/call_error_spec.cr
@@ -257,4 +257,20 @@ describe "Call errors" do
       ),
       "expected argument #1 symbol to 'foo' to match a Color enum member.\n\nSome options are: :red, :green, :blue, :violet and :purple"
   end
+
+  it "says type mismatch for symbol against enum, named argument case" do
+    assert_error %(
+      enum Color
+        Red
+        Green
+        Blue
+      end
+
+      def foo(x : Color)
+      end
+
+      foo(x: :rred)
+      ),
+      "expected argument 'x' symbol to 'foo' to match a Color enum member.\n\nDid you mean :red?"
+  end
 end

--- a/spec/compiler/semantic/call_error_spec.cr
+++ b/spec/compiler/semantic/call_error_spec.cr
@@ -204,4 +204,20 @@ describe "Call errors" do
       ),
       "expected argument #1 to 'foo' to be Char or Int32, not String"
   end
+
+  it "says type mismatch for symbol against enum" do
+    assert_error %(
+      enum Color
+        Red
+        Green
+        Blue
+      end
+
+      def foo(x : Color)
+      end
+
+      foo(:rred)
+      ),
+      "expected argument #1 symbol to 'foo' to match a Color enum member."
+  end
 end

--- a/src/compiler/crystal/semantic/call_error.cr
+++ b/src/compiler/crystal/semantic/call_error.cr
@@ -289,11 +289,14 @@ class Crystal::Call
       end
 
     enum_types = expected_types.select(EnumType)
-    if actual_type.is_a?(SymbolType) &&
-       arg.is_a?(SymbolLiteral) &&
-       enum_types.size == 1
-      symbol = arg.value
+    if actual_type.is_a?(SymbolType) && enum_types.size == 1
       enum_type = enum_types.first
+
+      if arg.is_a?(SymbolLiteral)
+        symbol = arg.value
+      elsif arg.is_a?(NamedArgument) && (named_arg_value = arg.value).is_a?(SymbolLiteral)
+        symbol = named_arg_value.value
+      end
     end
 
     raise_no_overload_matches(arg || self, defs, arg_types, inner_exception) do |str|

--- a/src/compiler/crystal/semantic/call_error.cr
+++ b/src/compiler/crystal/semantic/call_error.cr
@@ -307,6 +307,13 @@ class Crystal::Call
 
       if symbol && enum_type
         str << "expected argument #{argument_description} symbol to '#{full_name(owner, def_name)}' to match a #{enum_type} enum member."
+
+        similar_name = Levenshtein.find(symbol.underscore, enum_type.types.map(&.[1].name.underscore))
+        if similar_name
+          str.puts
+          str.puts
+          str << "Did you mean :#{similar_name}?"
+        end
       else
         str << "expected argument #{argument_description} to '#{full_name(owner, def_name)}' to be "
         to_sentence(str, expected_types, " or ")

--- a/src/compiler/crystal/semantic/call_error.cr
+++ b/src/compiler/crystal/semantic/call_error.cr
@@ -307,12 +307,20 @@ class Crystal::Call
 
       if symbol && enum_type
         str << "expected argument #{argument_description} symbol to '#{full_name(owner, def_name)}' to match a #{enum_type} enum member."
+        str.puts
+        str.puts
 
-        similar_name = Levenshtein.find(symbol.underscore, enum_type.types.map(&.[1].name.underscore))
+        options = enum_type.types.map(&.[1].name.underscore)
+        similar_name = Levenshtein.find(symbol.underscore, options)
         if similar_name
-          str.puts
-          str.puts
           str << "Did you mean :#{similar_name}?"
+        else
+          if options.size <= 5
+            str << "Options are: "
+          else
+            str << "Some options are: "
+          end
+          to_sentence(str, options.first(5).map { |o| ":#{o}" }, " and ")
         end
       else
         str << "expected argument #{argument_description} to '#{full_name(owner, def_name)}' to be "


### PR DESCRIPTION
Another follow-up to the improved error messages.

If you have code like this:

```crystal
enum Color
  Red
  Green
  Blue
end

def foo(x : Color)
end

foo(:redd)
```

Before this PR this was the error (I won't list "all overloads" because they are always shown):

```
In foo.cr:10:5

 10 | foo(:rred)
          ^
Error: expected argument #1 to 'foo' to be Color, not Symbol
```

With this PR:

```crystal
In foo.cr:10:5

 10 | foo(:rred)
          ^
Error: expected argument #1 symbol to 'foo' to match a Color enum member.

Did you mean :red?
```

Much better, don't you think?

Here the name was similar but what if it isn't? Let's try it:

```crystal
enum Color
  Red
  Green
  Blue
end

def foo(x : Color)
end

foo(:hello_world)
```

We get this error:

```
In foo.cr:10:5

 10 | foo(:hello_world)
          ^
Error: expected argument #1 symbol to 'foo' to match a Color enum member.

Options are: :red, :green and :blue
```

Cool!

What if the enum member has a lot of options? Let's try it:

```crystal
enum Color
  Red
  Green
  Blue
  Cyan
  Magenta
  Yellow
end

def foo(x : Color)
end

foo(:hello_world)
```

We get:

```
In foo.cr:13:5

 13 | foo(:hello_world)
          ^
Error: expected argument #1 symbol to 'foo' to match a Color enum member.

Some options are: :red, :green, :blue, :cyan and :magenta
```

Note that it says "Some options" instead of "Options". I chose to limit it to at most five suggestions, but let me know if we should show more or less options. In most cases I think the error will hit a "did you mean" because if you are passing a symbol literal you might know which members you have available.