### PR TITLE
Compiler optimization: avoid intermediate array when matching call arg types

### DIFF
--- a/src/compiler/crystal/semantic/method_lookup.cr
+++ b/src/compiler/crystal/semantic/method_lookup.cr
@@ -250,6 +250,12 @@ module Crystal
 
         match_arg_type = arg_type.restrict(arg, context)
         if match_arg_type
+          if !named_args && !splat_arg_types && match_arg_type.same?(arg_type) && arg_types.size == 1
+            # Optimization: no need to create matched_arg_types if
+            # the call has a single argument and it exactly matches the restriction
+            break
+          end
+
           matched_arg_types ||= [] of Type
           matched_arg_types.push match_arg_type
           mandatory_args[arg_index] = true if mandatory_args


### PR DESCRIPTION
This is a tiny optimization that actually leads to a decent memory saving and maybe a slight performance improvement (it's hard to tell for me because I have an M1 and the compiler is pretty fast there.)

Anyway, compiling the compiler before this PR required 1892MB. Now it requires 1876MB. It's not much, but it's something (well, around 16MB.)

For Mint, it goes down from 976MB to 912MB.

I also checked that compile times didn't go up.