### PR TITLE
`bin/crystal`: Ensure `sh` compatibility

### DIFF
--- a/bin/crystal
+++ b/bin/crystal
@@ -94,14 +94,14 @@ _canonicalize_file_path() {
 
 ##############################################################################
 
-# Based on https://stackoverflow.com/a/294025
+# Based on http://stackoverflow.com/q/370047/641451
 remove_path_item() {
   local path item
 
   path="$1"
   item="$2"
 
-  echo "$path" | tr ":" "\n" | sed "s:^$item\$::" | tr "\n" ":" | sed 's|:$||' | sed 's|^:||'
+  printf "$path" | awk -v RS=: -v ORS=: '$0 != "'$item'"' | sed 's/:$//'
 }
 
 ##############################################################################

--- a/bin/crystal
+++ b/bin/crystal
@@ -101,7 +101,7 @@ remove_path_item() {
   path="$1"
   item="$2"
 
-  printf "$path" | awk -v RS=: -v ORS=: '$0 != "'$item'"' | sed 's/:$//'
+  printf "%s" "$path" | awk -v RS=: -v ORS=: '$0 != "'$item'"' | sed 's/:$//'
 }
 
 ##############################################################################

--- a/bin/crystal
+++ b/bin/crystal
@@ -94,14 +94,14 @@ _canonicalize_file_path() {
 
 ##############################################################################
 
-# Based on http://stackoverflow.com/q/370047/641451
+# Based on https://stackoverflow.com/a/294025
 remove_path_item() {
   local path item
 
   path="$1"
   item="$2"
 
-  echo -n $path | awk -v RS=: -v ORS=: '$0 != "'$item'"' | sed 's/:$//'
+  echo "$path" | tr ":" "\n" | sed "s:^$item\$::" | tr "\n" ":" | sed 's|:$||' | sed 's|^:||'
 }
 
 ##############################################################################


### PR DESCRIPTION
From the manpage for _Bash_'s `echo(1)`:

> Some shells may provide a builtin **echo** command which is similar or identical to this utility.  Most notably, the builtin **echo** in sh(1) does not accept the **-n** option.  Consult the builtin(1) manual page.

Therefore, whenever `remove_path_item` is called, `-n` is prepended to the first element of `$PATH`, causing issues if the Crystal executable is found from that element. This PR fixes it by using a different implementation of `remove_path_item`.