### PR TITLE
add group_by_with_index and split_array

### DIFF
--- a/src/enumerable.cr
+++ b/src/enumerable.cr
@@ -588,6 +588,50 @@ module Enumerable(T)
     h
   end
 
+  # Add index for group_by
+  # ```
+  # a = (0..10).to_a
+  # a.group_by_with_index { |e, i| i//5 } # => {0 => [0, 1, 2, 3, 4], 1 => [5, 6, 7, 8, 9], 2 => [10]}
+  # ```
+  def group_by_with_index(& : T, Int32|Int64 -> U) forall U
+    h = Hash(U, Array(T)).new
+    each_with_index do |e, i|
+      v = yield e, i
+      if h.has_key?(v)
+        h[v].push(e)
+      else
+        h[v] = [e]
+      end
+    end
+    h
+  end
+
+  # Split array to n parts
+  #
+  # ```
+  # a = (0..10).to_a
+  # a.split_array(100) # => [[0], [1], [2], [3], [4], [5], [6], [7], [8], [9], [10]]
+  # a.split_array(3) # => [[0, 1, 2], [3, 4, 5], [6, 7, 8, 9, 10]]
+  # a.split_array(5) # => [[0, 1], [2, 3], [4, 5], [6, 7], [8, 9, 10]]
+  # ```
+  def split_array(n : Int) : Array(Array(T)) 
+    raise ArgumentError.new("Can't split arrat to negative number of parts") if n < 0
+    
+    block_size = size//n
+    block_size = 1 if block_size == 0
+    ary = Array(Array(T)).new(n)
+    return ary if n == 0
+
+    each_slice(block_size) do |slice|
+        ary << slice    
+    end
+    if ary.size == n+ 1
+        ary[..-3] << (ary[-2] + ary[-1])
+    else
+        ary
+    end
+  end
+
   # Returns an `Array` with chunks in the given size, eventually filled up
   # with given value or `nil`.
   #


### PR DESCRIPTION
If add this to ```src/enumerable.cr```:
```
  # split array to n parts
  #
  # ```
  # a = (0..10).to_a
  # a.split_array(100) # => [[0], [1], [2], [3], [4], [5], [6], [7], [8], [9], [10]]
  # a.split_array(3) # => [[0, 1, 2], [3, 4, 5], [6, 7, 8, 9, 10]]
  # a.split_array(5) # => [[0, 1], [2, 3], [4, 5], [6, 7], [8, 9, 10]]
  # ```
  def split_array1(n : Int) : Array(Array(T))
    raise ArgumentError.new("Can't split arrat to negative number of parts") if n < 0
    
    block_size = size//n
    block_size = 1 if block_size == 0
    a = group_by_with_index { |e, i| i//block_size } .values # [[1,2], [3,4], [5]]
    if a.size == n+ 1
        a[..-3] << (a[-2] + a[-1])
    else
        a
    end
  end

  def split_array2(n : Int) : Array(Array(T)) 
    raise ArgumentError.new("Can't split arrat to negative number of parts") if n < 0
    
    block_size = size//n
    block_size = 1 if block_size == 0
    ary = Array(Array(T)).new(n)
    return ary if n == 0

    each_slice(block_size) do |slice|
        ary << slice    
    end
    if ary.size == n+ 1
        ary[..-3] << (ary[-2] + ary[-1])
    else
        ary
    end
  end

```
then I do this bechmark for ```split_array1(use group_by_with_index )``` and ```split_array2(use each_slice)```:
```
require "benchmark"

a = (0..100000).to_a

Benchmark.ips do |x|

  x.report("split_array1:") do
    a.split_array1(3)
    a.split_array1(5)
  end

  x.report("split_array2:") do
    a.split_array2(3)
    a.split_array2(5)
  end

end

```
after```crystal build --release ``` got this:
```
split_array1: 184.69  (  5.41ms) (± 3.13%)  3.95MB/op   5.23× slower
split_array2: 965.49  (  1.04ms) (± 4.01%)  1.17MB/op        fastest
```
So I use ```each_slice``` instead of ```group_by_with_index``` for ```split_array```!
 