### PR TITLE
Replace deprecated `Socket.ip?` with `IPAddress.valid?`

### DIFF
--- a/src/openssl/ssl/hostname_validation.cr
+++ b/src/openssl/ssl/hostname_validation.cr
@@ -135,7 +135,7 @@ module OpenSSL::SSL::HostnameValidation
     end
 
     # fail match when hostname is an IP address
-    if ::Socket.ip?(hostname)
+    if ::Socket::IPAddress.valid?(hostname)
       return false
     end
 

--- a/src/openssl/ssl/socket.cr
+++ b/src/openssl/ssl/socket.cr
@@ -15,7 +15,7 @@ abstract class OpenSSL::SSL::Socket < IO
           {% if LibSSL.has_method?(:ssl_get0_param) %}
             param = LibSSL.ssl_get0_param(@ssl)
 
-            if ::Socket.ip?(hostname)
+            if ::Socket::IPAddress.valid?(hostname)
               unless LibCrypto.x509_verify_param_set1_ip_asc(param, hostname) == 1
                 raise OpenSSL::Error.new("X509_VERIFY_PARAM_set1_ip_asc")
               end


### PR DESCRIPTION
Follow-up on #10492 (ref: https://github.com/crystal-lang/crystal/pull/10492#issuecomment-1250014965)