### PR TITLE
Avoid free call in interpreted mode

### DIFF
--- a/src/regex.cr
+++ b/src/regex.cr
@@ -262,7 +262,7 @@ class Regex
     raise ArgumentError.new("#{String.new(errptr)} at #{erroffset}") if @re.null?
     @extra = LibPCRE.study(@re, LibPCRE::STUDY_JIT_COMPILE, out studyerrptr)
     if @extra.null? && studyerrptr
-      {% unless flag?(:interpreter) %}
+      {% unless flag?(:interpreted) %}
         LibPCRE.free.call @re.as(Void*)
       {% end %}
       raise ArgumentError.new("#{String.new(studyerrptr)}")
@@ -272,7 +272,7 @@ class Regex
 
   def finalize
     LibPCRE.free_study @extra
-    {% unless flag?(:interpreter) %}
+    {% unless flag?(:interpreted) %}
       LibPCRE.free.call @re.as(Void*)
     {% end %}
   end
@@ -287,7 +287,7 @@ class Regex
   def self.error?(source) : String?
     re = LibPCRE.compile(source, (Options::UTF_8 | Options::NO_UTF8_CHECK | Options::DUPNAMES), out errptr, out erroffset, nil)
     if re
-      {% unless flag?(:interpreter) %}
+      {% unless flag?(:interpreted) %}
         LibPCRE.free.call re.as(Void*)
       {% end %}
       nil

--- a/src/regex.cr
+++ b/src/regex.cr
@@ -262,7 +262,9 @@ class Regex
     raise ArgumentError.new("#{String.new(errptr)} at #{erroffset}") if @re.null?
     @extra = LibPCRE.study(@re, LibPCRE::STUDY_JIT_COMPILE, out studyerrptr)
     if @extra.null? && studyerrptr
-      LibPCRE.free.call @re.as(Void*)
+      {% unless flag?(:interpreter) %}
+        LibPCRE.free.call @re.as(Void*)
+      {% end %}
       raise ArgumentError.new("#{String.new(studyerrptr)}")
     end
     LibPCRE.full_info(@re, nil, LibPCRE::INFO_CAPTURECOUNT, out @captures)
@@ -270,7 +272,9 @@ class Regex
 
   def finalize
     LibPCRE.free_study @extra
-    LibPCRE.free.call @re.as(Void*)
+    {% unless flag?(:interpreter) %}
+      LibPCRE.free.call @re.as(Void*)
+    {% end %}
   end
 
   # Determines Regex's source validity. If it is, `nil` is returned.
@@ -283,7 +287,9 @@ class Regex
   def self.error?(source) : String?
     re = LibPCRE.compile(source, (Options::UTF_8 | Options::NO_UTF8_CHECK | Options::DUPNAMES), out errptr, out erroffset, nil)
     if re
-      LibPCRE.free.call re.as(Void*)
+      {% unless flag?(:interpreter) %}
+        LibPCRE.free.call re.as(Void*)
+      {% end %}
       nil
     else
       "#{String.new(errptr)} at #{erroffset}"


### PR DESCRIPTION
This is a workaround for an interpreter bug (#12495) and basically restores the status before #12456.