### PR TITLE
Fix: Parse DWARF5 Data16 values

### DIFF
--- a/src/crystal/dwarf/info.cr
+++ b/src/crystal/dwarf/info.cr
@@ -48,7 +48,7 @@ module Crystal
         end
       end
 
-      alias Value = Bool | Int32 | Int64 | Slice(UInt8) | String | UInt16 | UInt32 | UInt64 | UInt8
+      alias Value = Bool | Int32 | Int64 | Slice(UInt8) | String | UInt16 | UInt32 | UInt64 | UInt8 | UInt128
 
       def read_abbreviations(io)
         @abbreviations = Abbrev.read(io, debug_abbrev_offset)
@@ -106,6 +106,8 @@ module Crystal
           @io.read_bytes(UInt32)
         when FORM::Data8
           @io.read_bytes(UInt64)
+        when FORM::Data16
+          @io.read_bytes(UInt128)
         when FORM::Sdata
           DWARF.read_signed_leb128(@io)
         when FORM::Udata


### PR DESCRIPTION
resolves crashes when raising errors on static MUSL crystal apps built on alpine:3.16