### PR TITLE
Update nixpkgs 22.05 and LLVM 11

### DIFF
--- a/shell.nix
+++ b/shell.nix
@@ -127,7 +127,7 @@ pkgs.stdenv.mkDerivation rec {
     pkgs.libffi
   ];
 
-  LLVM_CONFIG = "${llvm_suite.llvm}/bin/llvm-config";
+  LLVM_CONFIG = "${llvm_suite.llvm.dev}/bin/llvm-config";
 
   MACOSX_DEPLOYMENT_TARGET = "10.11";
 }

--- a/shell.nix
+++ b/shell.nix
@@ -19,13 +19,13 @@
 # $ nix-shell --pure --arg musl true
 #
 
-{llvm ? 10, musl ? false, system ? builtins.currentSystem}:
+{llvm ? 11, musl ? false, system ? builtins.currentSystem}:
 
 let
   nixpkgs = import (builtins.fetchTarball {
-    name = "nixpkgs-20.03";
-    url = "https://github.com/NixOS/nixpkgs/archive/2d580cd2793a7b5f4b8b6b88fb2ccec700ee1ae6.tar.gz";
-    sha256 = "1nbanzrir1y0yi2mv70h60sars9scwmm0hsxnify2ldpczir9n37";
+    name = "nixpkgs-22.05";
+    url = "https://github.com/NixOS/nixpkgs/archive/22.05.tar.gz";
+    sha256 = "0d643wp3l77hv2pmg2fi7vyxn4rwy0iyr8djcw1h5x72315ck9ik";
   }) {
     inherit system;
   };
@@ -65,6 +65,10 @@ let
   pkgconfig = pkgs.pkgconfig;
 
   llvm_suite = ({
+    llvm_11 = {
+      llvm = pkgs.llvm_11;
+      extra = [ pkgs.lld_11 pkgs.lldb_11 ];
+    };
     llvm_10 = {
       llvm = pkgs.llvm_10;
       extra = [ pkgs.lld_10 pkgs.lldb_10 ];
@@ -108,7 +112,7 @@ let
 
   stdLibDeps = with pkgs; [
       boehmgc gmp libevent libiconv libxml2 libyaml openssl pcre zlib
-    ] ++ stdenv.lib.optionals stdenv.isDarwin [ libiconv ];
+    ] ++ lib.optionals stdenv.isDarwin [ libiconv ];
 
   tools = [ pkgs.hostname pkgs.git llvm_suite.extra ];
 in

--- a/spec/std/kernel_spec.cr
+++ b/spec/std/kernel_spec.cr
@@ -4,6 +4,10 @@ require "./spec_helper"
 describe "PROGRAM_NAME" do
   it "works for UTF-8 name" do
     with_tempfile("source_file") do |source_file|
+      if ENV["IN_NIX_SHELL"]?
+        pending! "Example is broken in Nix shell (#12332)"
+      end
+
       File.write(source_file, "File.basename(PROGRAM_NAME).inspect(STDOUT)")
 
       compile_file(source_file, bin_name: "×‽😂") do |executable_file|


### PR DESCRIPTION
This is a general update and a preparation step for upgrading the macos image in CI (#12332).

I tried upgrading to even newer LLVM versions but apparently they're marked as broken in nixpkgs. Not sure what this is about. But 11 should be fine for now.