### PR TITLE
Update distribution-scripts

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,7 @@ parameters:
   distribution-scripts-version:
     description: "Git ref for version of https://github.com/crystal-lang/distribution-scripts/"
     type: string
-    default: "e9cafa1a93a487169e561759e9a2d065c35e0770"
+    default: "1ee8983d46c594f97b6fe70a711c5dbefe83ab45"
   previous_crystal_base_url:
     description: "Prefix for URLs to Crystal bootstrap compiler"
     type: string


### PR DESCRIPTION
Updates `distribution-scripts` dependency to https://github.com/crystal-lang/distribution-scripts/commit/1ee8983d46c594f97b6fe70a711c5dbefe83ab45

This includes the following changes:

* crystal-lang/distribution-scripts#197
