### PR TITLE
macOS: Fix call stack when executable path contains symlinks

### DIFF
--- a/src/exception/call_stack/mach_o.cr
+++ b/src/exception/call_stack/mach_o.cr
@@ -104,7 +104,7 @@ struct Exception::CallStack
     program = File.real_path(String.new(buffer))
 
     LibC._dyld_image_count.times do |i|
-      if program == String.new(LibC._dyld_get_image_name(i))
+      if program == File.real_path(String.new(LibC._dyld_get_image_name(i)))
         return LibC._dyld_get_image_vmaddr_slide(i)
       end
     end

--- a/src/exception/call_stack/mach_o.cr
+++ b/src/exception/call_stack/mach_o.cr
@@ -101,7 +101,7 @@ struct Exception::CallStack
       end
     end
 
-    program = String.new(buffer)
+    program = File.real_path(String.new(buffer))
 
     LibC._dyld_image_count.times do |i|
       if program == String.new(LibC._dyld_get_image_name(i))


### PR DESCRIPTION
This fixes call stacks on newer macOS releases for commands like `crystal run`. See https://github.com/crystal-lang/crystal/issues/12332#issuecomment-1248718157.