### PR TITLE
Introduce `IO::DEFAULT_BUFFER_SIZE`

### DIFF
--- a/spec/std/http/server/response_spec.cr
+++ b/spec/std/http/server/response_spec.cr
@@ -96,7 +96,7 @@ describe HTTP::Server::Response do
     io = IO::Memory.new
     response = Response.new(io)
     str = "1234567890"
-    slices = (8192 // 10)
+    slices = (IO::DEFAULT_BUFFER_SIZE // 10)
     slices.times do
       response.print(str)
     end

--- a/spec/std/http/server/response_spec.cr
+++ b/spec/std/http/server/response_spec.cr
@@ -96,13 +96,15 @@ describe HTTP::Server::Response do
     io = IO::Memory.new
     response = Response.new(io)
     str = "1234567890"
-    1000.times do
+    slices = (8192 // 10)
+    slices.times do
       response.print(str)
     end
+    response.print(str)
     response.close
-    first_chunk = str * 819
-    second_chunk = str * 181
-    io.to_s.should eq("HTTP/1.1 200 OK\r\nTransfer-Encoding: chunked\r\n\r\n1ffe\r\n#{first_chunk}\r\n712\r\n#{second_chunk}\r\n0\r\n\r\n")
+    first_chunk = str * slices
+    second_chunk = str
+    io.to_s.should eq("HTTP/1.1 200 OK\r\nTransfer-Encoding: chunked\r\n\r\n#{(first_chunk.bytesize).to_s(16)}\r\n#{first_chunk}\r\n#{(second_chunk.bytesize).to_s(16)}\r\n#{second_chunk}\r\n0\r\n\r\n")
   end
 
   it "prints with content length" do

--- a/spec/std/socket/unix_socket_spec.cr
+++ b/spec/std/socket/unix_socket_spec.cr
@@ -76,7 +76,7 @@ describe UNIXSocket do
       # BUG: shrink the socket buffers first
       left.write_timeout = 0.0001
       right.read_timeout = 0.0001
-      buf = ("a" * 4096).to_slice
+      buf = ("a" * IO::DEFAULT_BUFFER_SIZE).to_slice
 
       expect_raises(IO::TimeoutError, "Write timed out") do
         loop { left.write buf }

--- a/src/io.cr
+++ b/src/io.cr
@@ -58,6 +58,9 @@ require "c/errno"
 # avoided, as string operations might need to read extra bytes in order to get characters
 # in the given encoding.
 abstract class IO
+  # Default size used for generic stream buffers.
+  DEFAULT_BUFFER_SIZE = 4096
+
   # Argument to a `seek` operation.
   enum Seek
     # Seeks to an absolute location
@@ -558,7 +561,7 @@ abstract class IO
           decoder.write(str)
         end
       else
-        buffer = uninitialized UInt8[4096]
+        buffer = uninitialized UInt8[DEFAULT_BUFFER_SIZE]
         while (read_bytes = read(buffer.to_slice)) > 0
           str.write buffer.to_slice[0, read_bytes]
         end
@@ -848,9 +851,9 @@ abstract class IO
   # io.skip(1) # raises IO::EOFError
   # ```
   def skip(bytes_count : Int) : Nil
-    buffer = uninitialized UInt8[4096]
+    buffer = uninitialized UInt8[DEFAULT_BUFFER_SIZE]
     while bytes_count > 0
-      read_count = read(buffer.to_slice[0, Math.min(bytes_count, 4096)])
+      read_count = read(buffer.to_slice[0, Math.min(bytes_count, buffer.size)])
       raise IO::EOFError.new if read_count == 0
 
       bytes_count -= read_count
@@ -860,7 +863,7 @@ abstract class IO
   # Reads and discards bytes from `self` until there
   # are no more bytes.
   def skip_to_end : Nil
-    buffer = uninitialized UInt8[4096]
+    buffer = uninitialized UInt8[DEFAULT_BUFFER_SIZE]
     while read(buffer.to_slice) > 0
     end
   end
@@ -1152,7 +1155,7 @@ abstract class IO
   # io2.to_s # => "hello"
   # ```
   def self.copy(src, dst) : Int64
-    buffer = uninitialized UInt8[4096]
+    buffer = uninitialized UInt8[DEFAULT_BUFFER_SIZE]
     count = 0_i64
     while (len = src.read(buffer.to_slice).to_i32) > 0
       dst.write buffer.to_slice[0, len]
@@ -1176,7 +1179,7 @@ abstract class IO
 
     limit = limit.to_i64
 
-    buffer = uninitialized UInt8[4096]
+    buffer = uninitialized UInt8[DEFAULT_BUFFER_SIZE]
     remaining = limit
     while (len = src.read(buffer.to_slice[0, Math.min(buffer.size, Math.max(remaining, 0))])) > 0
       dst.write buffer.to_slice[0, len]

--- a/src/io.cr
+++ b/src/io.cr
@@ -59,7 +59,7 @@ require "c/errno"
 # in the given encoding.
 abstract class IO
   # Default size used for generic stream buffers.
-  DEFAULT_BUFFER_SIZE = 4096
+  DEFAULT_BUFFER_SIZE = 32768
 
   # Argument to a `seek` operation.
   enum Seek

--- a/src/io/buffered.cr
+++ b/src/io/buffered.cr
@@ -11,7 +11,7 @@ module IO::Buffered
   @sync = false
   @read_buffering = true
   @flush_on_newline = false
-  @buffer_size = 8192
+  @buffer_size = IO::DEFAULT_BUFFER_SIZE
 
   # Reads at most *slice.size* bytes from the wrapped `IO` into *slice*.
   # Returns the number of bytes read.


### PR DESCRIPTION
As a result of the discussion in https://forum.crystal-lang.org/t/io-copy-buffer-too-small/1873, this patch introduces a constant `IO::DEFAULT_BUFFER_SIZE` which holds the default size of a generic stream buffer.
This size is also increased from 4K (most IO operations) and 8K (`IO::Buffered`) to 32K which should be a good default for modern machines.