### PR TITLE
Interpreter (repl): use new MainVisitor each time we need to interpret code

### DIFF
--- a/src/compiler/crystal/interpreter/interpreter.cr
+++ b/src/compiler/crystal/interpreter/interpreter.cr
@@ -1281,6 +1281,8 @@ class Crystal::Repl::Interpreter
         )
         next unless line_node
 
+        main_visitor = MainVisitor.new(from_main_visitor: main_visitor)
+
         vars_size_before_semantic = main_visitor.vars.size
 
         line_node = @context.program.normalize(line_node)

--- a/src/compiler/crystal/interpreter/repl.cr
+++ b/src/compiler/crystal/interpreter/repl.cr
@@ -95,6 +95,8 @@ class Crystal::Repl
   end
 
   private def interpret(node : ASTNode)
+    @main_visitor = MainVisitor.new(@program, from_main_visitor: @main_visitor)
+
     node = @program.normalize(node)
     node = @program.semantic(node, main_visitor: @main_visitor)
     @interpreter.interpret(node, @main_visitor.meta_vars)

--- a/src/compiler/crystal/interpreter/repl.cr
+++ b/src/compiler/crystal/interpreter/repl.cr
@@ -95,7 +95,7 @@ class Crystal::Repl
   end
 
   private def interpret(node : ASTNode)
-    @main_visitor = MainVisitor.new(@program, from_main_visitor: @main_visitor)
+    @main_visitor = MainVisitor.new(from_main_visitor: @main_visitor)
 
     node = @program.normalize(node)
     node = @program.semantic(node, main_visitor: @main_visitor)

--- a/src/compiler/crystal/semantic/main_visitor.cr
+++ b/src/compiler/crystal/semantic/main_visitor.cr
@@ -98,12 +98,13 @@ module Crystal
 
     @unreachable = false
     @is_initialize = false
+    @inside_is_a = false
     @in_type_args = 0
 
-    @while_stack : Array(While)
+    @while_stack = [] of While
     @type_filters : TypeFilters?
-    @needs_type_filters : Int32
-    @typeof_nest : Int32
+    @needs_type_filters = 0
+    @typeof_nest = 0
     @found_self_in_initialize_call : Array(ASTNode)?
     @used_ivars_in_calls_in_initialize : Hash(String, Array(ASTNode))?
     @block_context : Block?
@@ -114,16 +115,10 @@ module Crystal
 
     def initialize(program, vars = MetaVars.new, @typed_def = nil, meta_vars = nil)
       super(program, vars)
-      @while_stack = [] of While
-      @needs_type_filters = 0
-      @typeof_nest = 0
       @is_initialize = !!(typed_def && (
         typed_def.name == "initialize" ||
         typed_def.name.starts_with?("initialize:") # Because of expanded methods from named args
       ))
-      @found_self_in_initialize_call = nil
-      @used_ivars_in_calls_in_initialize = nil
-      @inside_is_a = false
 
       # We initialize meta_vars from vars given in the constructor.
       # We store those meta vars either in the typed def or in the program
@@ -142,6 +137,11 @@ module Crystal
       end
 
       @meta_vars = meta_vars
+    end
+
+    def initialize(program, *, from_main_visitor : MainVisitor)
+      super(program, from_main_visitor.@vars)
+      @meta_vars = from_main_visitor.@meta_vars
     end
 
     def visit_any(node)

--- a/src/compiler/crystal/semantic/main_visitor.cr
+++ b/src/compiler/crystal/semantic/main_visitor.cr
@@ -139,9 +139,12 @@ module Crystal
       @meta_vars = meta_vars
     end
 
-    def initialize(program, *, from_main_visitor : MainVisitor)
-      super(program, from_main_visitor.@vars)
+    def initialize(*, from_main_visitor : MainVisitor)
+      super(from_main_visitor.@program, from_main_visitor.@vars)
       @meta_vars = from_main_visitor.@meta_vars
+      @typed_def = from_main_visitor.@typed_def
+      @scope = from_main_visitor.@scope
+      @path_lookup = from_main_visitor.@path_lookup
     end
 
     def visit_any(node)


### PR DESCRIPTION
Fixes #12510

The bug happens because when we do semantic analysis with a `MainVisitor`, that visitor keeps track of some state, like "Are we inside an expression?" or "Are we inside a block?". The problem is that if an exception happens (there's a semantic error) then that state isn't reset.

In the compiler there's no need to reset that state because once there's an error there's no point continuing doing things. But in the interpreter it does make sense to recover from errors.

One way to solve this would be to change all visitors to make sure they reset their state... but that's a huge task, and it might also make things slightly slower, and it might introduce silent bugs in compiled mode.

Instead, I chose to create a few new `MainVisitor` each time we need to interpret a line in the repl (either when you do `crystal i` or when you are in a pry session.) That's much easier to do but it also shouldn't affect compiled Crystal at all.