### PR TITLE
Fix restriction comparison between `Metaclass` and `Path`

### DIFF
--- a/spec/compiler/semantic/restrictions_spec.cr
+++ b/spec/compiler/semantic/restrictions_spec.cr
@@ -218,33 +218,35 @@ describe "Restrictions" do
     end
 
     describe "Metaclass vs Path" do
-      it "inserts metaclass before Class" do
-        assert_type(%(
-          def foo(a : Class)
-            1
-          end
+      {% for type in [Object, Value, Class] %}
+        it "inserts metaclass before {{ type }}" do
+          assert_type(%(
+            def foo(a : {{ type }})
+              1
+            end
 
-          def foo(a : Int32.class)
-            true
-          end
+            def foo(a : Int32.class)
+              true
+            end
 
-          foo(Int32)
-          )) { bool }
-      end
+            foo(Int32)
+            )) { bool }
+        end
 
-      it "keeps metaclass before Class" do
-        assert_type(%(
-          def foo(a : Int32.class)
-            true
-          end
+        it "keeps metaclass before {{ type }}" do
+          assert_type(%(
+            def foo(a : Int32.class)
+              true
+            end
 
-          def foo(a : Class)
-            1
-          end
+            def foo(a : {{ type }})
+              1
+            end
 
-          foo(Int32)
-          )) { bool }
-      end
+            foo(Int32)
+            )) { bool }
+        end
+      {% end %}
 
       it "doesn't error if path is undefined and method is not called (1) (#12516)" do
         assert_no_errors <<-CR

--- a/spec/compiler/semantic/restrictions_spec.cr
+++ b/spec/compiler/semantic/restrictions_spec.cr
@@ -217,6 +217,56 @@ describe "Restrictions" do
       end
     end
 
+    describe "Metaclass vs Path" do
+      it "inserts metaclass before Class" do
+        assert_type(%(
+          def foo(a : Class)
+            1
+          end
+
+          def foo(a : Int32.class)
+            true
+          end
+
+          foo(Int32)
+          )) { bool }
+      end
+
+      it "keeps metaclass before Class" do
+        assert_type(%(
+          def foo(a : Int32.class)
+            true
+          end
+
+          def foo(a : Class)
+            1
+          end
+
+          foo(Int32)
+          )) { bool }
+      end
+
+      it "doesn't error if path is undefined and method is not called (1) (#12516)" do
+        assert_no_errors <<-CR
+          def foo(a : Int32.class)
+          end
+
+          def foo(a : Foo)
+          end
+          CR
+      end
+
+      it "doesn't error if path is undefined and method is not called (2) (#12516)" do
+        assert_no_errors <<-CR
+          def foo(a : Foo)
+          end
+
+          def foo(a : Int32.class)
+          end
+          CR
+      end
+    end
+
     describe "Path vs Path" do
       it "inserts typed Path before untyped Path" do
         assert_type(%(
@@ -1009,20 +1059,6 @@ describe "Restrictions" do
       foo(x, y)
       ),
       "expected argument #2 to 'foo' to be StaticArray(UInt8, 10), not StaticArray(UInt8, 11)"
-  end
-
-  it "gives precedence to T.class over Class (#7392)" do
-    assert_type(%(
-      def foo(x : Class)
-        'a'
-      end
-
-      def foo(x : Int32.class)
-        1
-      end
-
-      foo(Int32)
-      )) { int32 }
   end
 
   it "restricts aliased typedef type (#9474)" do

--- a/src/compiler/crystal/semantic/restrictions.cr
+++ b/src/compiler/crystal/semantic/restrictions.cr
@@ -702,11 +702,11 @@ module Crystal
     end
 
     def restriction_of?(other : Path, owner, self_free_vars = nil, other_free_vars = nil)
-      other_type = owner.lookup_type(other)
-
-      # Special case: when comparing Foo.class to Class, Foo.class has precedence
-      if other_type == other_type.program.class_type
-        return true
+      if other_type = owner.lookup_type?(other)
+        # Special case: when comparing Foo.class to Class, Foo.class has precedence
+        if other_type == other_type.program.class_type
+          return true
+        end
       end
 
       super

--- a/src/compiler/crystal/semantic/restrictions.cr
+++ b/src/compiler/crystal/semantic/restrictions.cr
@@ -703,8 +703,8 @@ module Crystal
 
     def restriction_of?(other : Path, owner, self_free_vars = nil, other_free_vars = nil)
       if other_type = owner.lookup_type?(other)
-        # Special case: when comparing Foo.class to Class, Foo.class has precedence
-        if other_type == other_type.program.class_type
+        # Special case: all metaclasses are subtypes of Class
+        if other_type.program.class_type.implements?(other_type)
           return true
         end
       end


### PR DESCRIPTION
Fixes #12516.

Also orders all metaclasses before superclasses of `Class`, in particular `Object` and `Value`:

```crystal
def foo(x : Object)
  1
end

def foo(x : Int32.class)
  2
end

# 1 before this PR
foo(Int32) # => 2
```
