### PR TITLE
[Experimental] Compiler: try to solve string interpolation exps at compile time

### DIFF
--- a/spec/compiler/normalize/string_interpolation_spec.cr
+++ b/spec/compiler/normalize/string_interpolation_spec.cr
@@ -12,4 +12,38 @@ describe "Normalize: string interpolation" do
   it "normalizes heredoc" do
     assert_normalize "<<-FOO\nhello\nFOO", %("hello")
   end
+
+  it "replaces string constant" do
+    result = semantic(%(
+      OBJ = "world"
+
+      "hello \#{OBJ}"
+    ))
+    node = result.node.as(Expressions).last
+    string = node.should be_a(StringLiteral)
+    string.value.should eq("hello world")
+  end
+
+  it "replaces string constant that results from macro expansion" do
+    result = semantic(%(
+      OBJ = {% if 1 + 1 == 2 %} "world" {% else %} "bug" {% end %}
+
+      "hello \#{OBJ}"
+    ))
+    node = result.node.as(Expressions).last
+    string = node.should be_a(StringLiteral)
+    string.value.should eq("hello world")
+  end
+
+  it "replaces through multiple levels" do
+    result = semantic(%(
+      OBJ1 = "ld"
+      OBJ2 = "wor\#{OBJ1}"
+
+      "hello \#{OBJ2}"
+    ))
+    node = result.node.as(Expressions).last
+    string = node.should be_a(StringLiteral)
+    string.value.should eq("hello world")
+  end
 end

--- a/src/compiler/crystal/semantic/literal_expander.cr
+++ b/src/compiler/crystal/semantic/literal_expander.cr
@@ -447,8 +447,48 @@ module Crystal
       # and having pieces in a different representation but same end
       # result is just fine.
       pieces = node.expressions
+      solve_string_interpolation_expressions(pieces)
       combine_contiguous_string_literals(pieces)
+
+      # If we are left with a single string literal, expand to that.
+      if pieces.size == 1 && pieces.all?(StringLiteral)
+        return pieces.first
+      end
+
       Call.new(Path.global("String").at(node), "interpolation", pieces).at(node)
+    end
+
+    private def solve_string_interpolation_expressions(pieces : Array(ASTNode))
+      pieces.each_with_index do |piece, i|
+        replacement = solve_string_interpolation_expression(piece)
+        next unless replacement
+
+        pieces[i] = replacement
+      end
+    end
+
+    # Check if a string interpolation piece resolves at compile-time
+    # to a string literal, or something that can be turned into a string
+    # literal.
+    private def solve_string_interpolation_expression(piece : ASTNode) : StringLiteral?
+      if piece.is_a?(ExpandableNode)
+        expanded = piece.expanded
+        if expanded
+          return solve_string_interpolation_expression(expanded)
+        end
+      end
+
+      case piece
+      when Path
+        target_const = piece.target_const
+        if target_const
+          return solve_string_interpolation_expression(target_const.value)
+        end
+      when StringLiteral
+        return piece
+      end
+
+      nil
     end
 
     private def combine_contiguous_string_literals(pieces)

--- a/src/compiler/crystal/semantic/main_visitor.cr
+++ b/src/compiler/crystal/semantic/main_visitor.cr
@@ -169,6 +169,8 @@ module Crystal
     end
 
     def visit(node : Path)
+      return if node.type?
+
       lookup_scope = @path_lookup || @scope || @current_type
 
       # If the lookup scope is a generic type, like Foo(T), we don't
@@ -2943,6 +2945,12 @@ module Crystal
     end
 
     def visit(node : StringInterpolation)
+      # Eagerly solve Paths before expansion to see if
+      # we can inline some content.
+      node.expressions.each do |exp|
+        exp.accept self if exp.is_a?(Path)
+      end
+
       expand(node)
 
       # This allows some methods to be resolved even if the interpolated expressions doesn't


### PR DESCRIPTION
Implements #12521

The idea here is very simple. If we have a code like this:

```crystal
OBJ = "world"

"hello #{OBJ}"
```

when we analyze the string interpolation we try to see if we can solve each interpolated content into a string literal that's known at compile time.

In the above case `OBJ`'s value is a string literal. In the end, the entire interpolation consists of static content, or interpolated string literals, which are also static content. If everything's a static content, we replace the interpolation with a string literal. Super efficient!

This also works if the constant's object isn't directly a string literal but it _expands_ to a string literal. For example:

```crystal
OBJ = {% if env?("FOO") %} "one" {% else %} "two" {% end %}

"hello #{OBJ}"
```

In the above case `OBJ` is a `MacroIf` that, at compile-time, expands to either "one" or "two" depending on the value of an env var. This PR accounts for that scenario (and for other scenarios where a node might expand to some other value.)

We could extend this logic to other nodes. For example:

```crystal
N = 10

"n = #{N}"
```

In the above case we could replace the string interpolation with "n = 10". Same for other literals like char and symbol. But for now I decided to keep things simple and only expand string literals.