### PR TITLE
Document `after_initialize` method for `yaml` and `json` serializers

### DIFF
--- a/src/json/serialization.cr
+++ b/src/json/serialization.cr
@@ -129,7 +129,7 @@ module JSON
   #
   # ### `after_initialize` method
   #
-  # after_initialize is a method that runs after initialization and can be used
+  # `#after_initialize` is a method that runs after initialization and can be used
   # as a hook to post-process the initialized object.
   #
   # Example:
@@ -138,14 +138,15 @@ module JSON
   #
   # class Person
   #   include JSON::Serializable
-  #   @name : String
+  #   getter name : String
   #
   #   def after_initialize
   #     @name = @name.upcase
   #   end
   # end
   #
-  # pp Person.from_json %({"name": "Jane"}) # => #<Person:0x7f630cb92e80 @name="JANE">
+  # person = Person.from_json %({"name": "Jane"})
+  # person.name # => "JANE"
   # ```
   module Serializable
     annotation Options

--- a/src/json/serialization.cr
+++ b/src/json/serialization.cr
@@ -129,8 +129,8 @@ module JSON
   #
   # ### `after_initialize` method
   #
-  # `#after_initialize` is a method that runs after initialization and can be used
-  # as a hook to post-process the initialized object.
+  # `#after_initialize` is a method that runs after an instance is deserialized
+  # from JSON. It can be used as a hook to post-process the initialized object.
   #
   # Example:
   # ```

--- a/src/json/serialization.cr
+++ b/src/json/serialization.cr
@@ -126,6 +126,27 @@ module JSON
   # field, and the rest of the fields, and their meaning, depend on its value.
   #
   # You can use `JSON::Serializable.use_json_discriminator` for this use case.
+  #
+  # ### `after_initialize` method
+  #
+  # after_initialize is a method that runs after initialization and can be used
+  # as a hook to post-process the initialized object.
+  #
+  # Example:
+  # ```
+  # require "json"
+  #
+  # class Person
+  #   include JSON::Serializable
+  #   @name : String
+  #
+  #   def after_initialize
+  #     @name = @name.upcase
+  #   end
+  # end
+  #
+  # pp Person.from_json %({"name": "Jane"}) # => #<Person:0x7f630cb92e80 @name="JANE">
+  # ```
   module Serializable
     annotation Options
     end

--- a/src/yaml/serialization.cr
+++ b/src/yaml/serialization.cr
@@ -128,8 +128,8 @@ module YAML
   #
   # ### `after_initialize` method
   #
-  # `#after_initialize` is a method that runs after initialization and can be used
-  # as a hook to post-process the initialized object.
+  # `#after_initialize` is a method that runs after an instance is deserialized
+  # from YAML. It can be used as a hook to post-process the initialized object.
   #
   # Example:
   # ```

--- a/src/yaml/serialization.cr
+++ b/src/yaml/serialization.cr
@@ -128,7 +128,7 @@ module YAML
   #
   # ### `after_initialize` method
   #
-  # after_initialize is a method that runs after initialization and can be used
+  # `#after_initialize` is a method that runs after initialization and can be used
   # as a hook to post-process the initialized object.
   #
   # Example:
@@ -137,14 +137,15 @@ module YAML
   #
   # class Person
   #   include YAML::Serializable
-  #   @name : String
+  #   getter name : String
   #
   #   def after_initialize
   #     @name = @name.upcase
   #   end
   # end
   #
-  # pp Person.from_yaml("---\nname: Jane\n") # => #<Person:0x7f630cb92e80 @name="JANE">
+  # person = Person.from_yaml "---\nname: Jane\n"
+  # person.name # => "JANE"
   # ```
   module Serializable
     annotation Options

--- a/src/yaml/serialization.cr
+++ b/src/yaml/serialization.cr
@@ -125,6 +125,27 @@ module YAML
   # field, and the rest of the fields, and their meaning, depend on its value.
   #
   # You can use `YAML::Serializable.use_yaml_discriminator` for this use case.
+  #
+  # ### `after_initialize` method
+  #
+  # after_initialize is a method that runs after initialization and can be used
+  # as a hook to post-process the initialized object.
+  #
+  # Example:
+  # ```
+  # require "yaml"
+  #
+  # class Person
+  #   include YAML::Serializable
+  #   @name : String
+  #
+  #   def after_initialize
+  #     @name = @name.upcase
+  #   end
+  # end
+  #
+  # pp Person.from_yaml("---\nname: Jane\n") # => #<Person:0x7f630cb92e80 @name="JANE">
+  # ```
   module Serializable
     annotation Options
     end


### PR DESCRIPTION
This documents the usage of `post_serialize` method both in `json` and `yaml` serializers.

Ref: #12048 

It's my first pull request and I've tried to follow other documentation examples from the std library in terms of prose and formatting. However, I'm not entirely certain about the _placement_ of the documentation snippet. The referred issue is about documenting a method which is `protected`, so I couldn't just place the snippet on top of the method since it won't show up in the API docs. I'm ready to adjust things based on feedback.