### PR TITLE
Interpreter: check upcast in nilable cast

### DIFF
--- a/spec/compiler/interpreter/casts_spec.cr
+++ b/spec/compiler/interpreter/casts_spec.cr
@@ -452,5 +452,35 @@ describe Crystal::Repl::Interpreter do
         end
       CODE
     end
+
+    it "upcasts in nilable cast (#12532)" do
+      interpret(<<-CODE).should eq(2)
+        struct Nil
+          def foo
+            0
+          end
+        end
+
+        module A
+          def foo
+            1
+          end
+        end
+
+        class B
+          include A
+
+          def foo
+            2
+          end
+        end
+
+        class C
+          include A
+        end
+
+        B.new.as?(A).foo
+        CODE
+    end
   end
 end

--- a/src/compiler/crystal/interpreter/compiler.cr
+++ b/src/compiler/crystal/interpreter/compiler.cr
@@ -1649,6 +1649,12 @@ class Crystal::Repl::Compiler < Crystal::Visitor
 
     node.obj.accept self
 
+    if node.upcast?
+      upcast node.obj, obj_type, node.non_nilable_type
+      upcast node.obj, node.non_nilable_type, node.type
+      return
+    end
+
     # Check if obj is a `to_type`
     dup aligned_sizeof_type(node.obj), node: nil
     filter_type(node, obj_type, filtered_type)


### PR DESCRIPTION
Fixes #12532

It's something that apparently I forgot to implement or check what is done in codegen.cr

For reference, here's the same logic in codegen.cr:

https://github.com/crystal-lang/crystal/blob/543acb079b5e4731644840958ac0aee65e1358ef/src/compiler/crystal/codegen/codegen.cr#L1338-L1340