### PR TITLE
Fix overflow for `rand(Range(Int, Int))` when signed span is too large

### DIFF
--- a/spec/std/random_spec.cr
+++ b/spec/std/random_spec.cr
@@ -255,6 +255,11 @@ describe "Random" do
     end
   end
 
+  it "works with span exceeding int type's range" do
+    rng = TestRNG.new(RNG_DATA_8)
+    rng.rand(-100_i8..100_i8).should eq(53_i8)
+  end
+
   it "works using U/Int128" do
     rng = TestRNG.new(RNG_DATA_128)
     RNG_DATA_128.each do |a|

--- a/src/random.cr
+++ b/src/random.cr
@@ -226,7 +226,9 @@ module Random
           end
           span += 1
         end
-        range.begin + {{type}}.new!(rand_int(span))
+        # this addition never overflows because `rand_int` is unsigned and
+        # `rand_int <= range.end - range.begin <= type::MAX - range.begin`
+        range.begin &+ rand_int(span)
       end
 
       # Generates a random integer in range `{{type}}::MIN..{{type}}::MAX`.


### PR DESCRIPTION
Given `(a..b) : Range(T, T)` for some signed integer type `T`, and `U` is the corresponding unsigned type for `T`, then `rand(a..b)` is calculated by `a + T.new!(x)` where `x : U` is random and `0 <= x <= U.new!(b - a)`. If `b - a` is larger than `T::MAX` then it could happen that `T.new!(x)` is negative, so adding it to `a` underflows. A concrete sample:

```crystal
alias T = Int8
alias U = UInt8

a = -100_i8
b = 100_i8

# 0 <= x <= 200
# but note that 200 > Int8::MAX
x = 153_u8
T.new!(x)     # => -103_i8
a + T.new!(x) # raises OverflowError
```

The cast to `T` and the safe addition are both unnecessary here; `a &+ x` is guaranteed to never underflow.