### PR TITLE
Update distribution-scripts

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,7 @@ parameters:
   distribution-scripts-version:
     description: "Git ref for version of https://github.com/crystal-lang/distribution-scripts/"
     type: string
-    default: "1ee8983d46c594f97b6fe70a711c5dbefe83ab45"
+    default: "f567925d4d36be64b7e211d0c166af9bdd92c75f"
   previous_crystal_base_url:
     description: "Prefix for URLs to Crystal bootstrap compiler"
     type: string


### PR DESCRIPTION
Updates `distribution-scripts` dependency to https://github.com/crystal-lang/distribution-scripts/commit/f567925d4d36be64b7e211d0c166af9bdd92c75f

This includes the following changes:

* crystal-lang/distribution-scripts#199
* crystal-lang/distribution-scripts#160