### PR TITLE
Fix reproducibility of `--verbose` output

### DIFF
--- a/src/compiler/crystal/compiler.cr
+++ b/src/compiler/crystal/compiler.cr
@@ -421,6 +421,8 @@ module Crystal
       output_filename = File.expand_path(output_filename)
 
       @progress_tracker.stage("Codegen (linking)") do
+        # Ensures that the linking step is reproducible from verbose output.
+        print_command(%(cd "${@}"), output_dir) if verbose?
         Dir.cd(output_dir) do
           linker_command = linker_command(program, object_names, output_filename, output_dir, expand: true)
 


### PR DESCRIPTION
Adds a missing `cd` in the link step from breaking the ability to reproduce the compilation via copying the output of `crystal run --verbose [src...]`

Resolves #5523