### PR TITLE
Interpreter: handle missing upcast from GenericClassInstanceMetaclassType to VirtualMetaclassType

### DIFF
--- a/spec/compiler/interpreter/casts_spec.cr
+++ b/spec/compiler/interpreter/casts_spec.cr
@@ -482,5 +482,19 @@ describe Crystal::Repl::Interpreter do
         B.new.as?(A).foo
         CODE
     end
+
+    it "upcasts GenericClassInstanceMetaclassType to VirtualMetaclassType" do
+      interpret(<<-CODE).should eq(2)
+        class Foo
+          def self.foo; 1; end
+        end
+
+        class Gen(T) < Foo
+          def self.foo; 2; end
+        end
+
+        Gen(Int32).as(Foo.class).foo
+        CODE
+    end
   end
 end

--- a/src/compiler/crystal/interpreter/cast.cr
+++ b/src/compiler/crystal/interpreter/cast.cr
@@ -315,12 +315,7 @@ class Crystal::Repl::Compiler
     # Nothing to do
   end
 
-  private def upcast_distinct(node : ASTNode, from : MetaclassType, to : VirtualMetaclassType)
-    # TODO: not tested
-  end
-
-  private def upcast_distinct(node : ASTNode, from : VirtualMetaclassType, to : VirtualMetaclassType)
-    # TODO: not tested
+  private def upcast_distinct(node : ASTNode, from : MetaclassType | VirtualMetaclassType | GenericClassInstanceMetaclassType, to : VirtualMetaclassType)
   end
 
   private def upcast_distinct(node : ASTNode, from : Type, to : Type)


### PR DESCRIPTION
…Type to VirtualMetaclassType

Fixes #12561

Another good candidate for 1.6