### PR TITLE
String#starts_with? and String#ends_with? with a splat parameter

### DIFF
--- a/spec/std/string_spec.cr
+++ b/spec/std/string_spec.cr
@@ -1243,6 +1243,10 @@ describe "String" do
     it { "foobar".starts_with?('g').should be_false }
     it { "よし".starts_with?('よ').should be_true }
     it { "よし!".starts_with?("よし").should be_true }
+    it { "foobar".starts_with?("foo", "bar").should be_true }
+    it { "foobar".starts_with?("foox", "bar").should be_false }
+    it { "foobar".starts_with?('f', "bar").should be_true }
+    it { "foobar".starts_with?("bar", /foo/).should be_true }
 
     it "treats first char as replacement char if invalid in an otherwise ascii string" do
       "\xEEfoo".starts_with?('\u{EE}').should be_false
@@ -1262,6 +1266,11 @@ describe "String" do
     it { "よし".ends_with?('し').should be_true }
     it { "よし".ends_with?('な').should be_false }
     it { "あいう_".ends_with?('_').should be_true }
+    it { "foobar".ends_with?("baz", "bar").should be_true }
+    it { "foobar".ends_with?("foo", "baz").should be_false }
+    it { "foobar".ends_with?('r', "baz").should be_true }
+    it { "foobar".ends_with?("foo", /bar/).should be_true }
+
 
     it "treats last char as replacement char if invalid in an otherwise ascii string" do
       "foo\xEE".ends_with?('\u{EE}').should be_false

--- a/src/string.cr
+++ b/src/string.cr
@@ -4910,6 +4910,16 @@ class String
     !!($~ = re.match_at_byte_index(self, 0, Regex::Options::ANCHORED))
   end
 
+  # Returns `true` if this string starts with one of the *prefixes* given.
+  #
+  # ```
+  # "hello".start_with?("heaven", "hell")     #=> true
+  # "hello".start_with?("heaven", "paradise") #=> false
+  #```
+  def starts_with?(*prefixes)
+    prefixes.any? { |e| self.starts_with?(e) }
+  end
+
   # Returns `true` if this string ends with the given *str*.
   #
   # ```
@@ -4958,6 +4968,16 @@ class String
   # ```
   def ends_with?(re : Regex) : Bool
     !!($~ = /#{re}\z/.match(self))
+  end
+
+  # Returns `true` if this string ends with one of the *suffixes* given.
+  #
+  # ```
+  # "hello".end_with?("heaven", "ello")     #=> true
+  # "hello".end_with?("heaven", "paradise") #=> false
+  # ```
+  def ends_with?(*suffixes)
+    suffixes.any? { |e| self.ends_with?(e) }
   end
 
   # Interpolates *other* into the string using top-level `::sprintf`.


### PR DESCRIPTION
This feature makes `String#starts_with?` and `String#ends_with?` more consistent with Ruby's implementations of [start_with?](https://apidock.com/ruby/String/start_with%3F) and [end_with?](https://apidock.com/ruby/v2_5_5/String/end_with%3F) which accepts a list of arguments.