### PR TITLE
Fix building Wasm32 on Crystal 1.6 (Regression)

### DIFF
--- a/src/crystal/system/wasi/file_descriptor.cr
+++ b/src/crystal/system/wasi/file_descriptor.cr
@@ -11,10 +11,6 @@ module Crystal::System::FileDescriptor
     raise NotImplementedError.new "Crystal::System::FileDescriptor.pipe"
   end
 
-  def self.system_info(fd)
-    raise NotImplementedError.new "Crystal::System::FileDescriptor.system_info"
-  end
-
   private def system_reopen(other : IO::FileDescriptor)
     raise NotImplementedError.new "Crystal::System::FileDescriptor#system_reopen"
   end


### PR DESCRIPTION
The PR #11991 redefined `Crystal::System::FileDescriptor.system_info` such that it would always fail with `NotImplementedError`. The original definition from "../unix/file_descriptor" works correcly and there is no need to disable this funcionality.

In fact, this change prevents STDOUT, STDERR and STDIN from been created and prevent any Wasm32 program from running 😱.

I already included this particular fix on #12571, and merging that will also prevent errors such as this from happening again. But I'm opening this PR as a regression fix in hope that this can be released as 1.6.1, otherwise WebAssembly will be unusable until 1.7.