### PR TITLE
Disable failing specs on Windows CI

### DIFF
--- a/spec/std/http/client/client_spec.cr
+++ b/spec/std/http/client/client_spec.cr
@@ -339,7 +339,7 @@ module HTTP
       end
     end
 
-    it "tests write_timeout" do
+    pending_win32 "tests write_timeout" do
       # Here we don't want to write a response on the server side because
       # it doesn't make sense to try to write because the client will already
       # timeout on read. Writing a response could lead on an exception in
@@ -353,7 +353,7 @@ module HTTP
       end
     end
 
-    it "tests connect_timeout" do
+    pending_win32 "tests connect_timeout" do
       test_server("localhost", 0, 0) do |server|
         client = Client.new("localhost", server.local_address.port)
         client.connect_timeout = 0.5


### PR DESCRIPTION
These two specs have been consistently failing ever since GitHub upgraded its Windows image from 20220925.1 to 20221002.2.