### PR TITLE
Fix origin validation in playground server for localhost

### DIFF
--- a/src/compiler/crystal/tools/playground/server.cr
+++ b/src/compiler/crystal/tools/playground/server.cr
@@ -537,7 +537,7 @@ module Crystal::Playground
 
     private def accept_request?(origin)
       case @host
-      when nil
+      when nil, "localhost", "127.0.0.1"
         origin == "http://127.0.0.1:#{@port}" || origin == "http://localhost:#{@port}"
       when "0.0.0.0"
         true


### PR DESCRIPTION
This is a minimal fix for #12587 which enables `Origin` header compatibility between `localhost` and `127.0.0.1`.

It's smaller than https://github.com/crystal-lang/crystal/pull/12598 which also addresses further UX problems but opens up an opportunity for CSRF.