### PR TITLE
Unbreak the interpreter on FreeBSD

### DIFF
--- a/src/lib_c/x86_64-freebsd/c/iconv.cr
+++ b/src/lib_c/x86_64-freebsd/c/iconv.cr
@@ -3,10 +3,13 @@ require "./stddef"
 lib LibC
   type IconvT = Void*
 
-  fun iconv(x0 : IconvT, x1 : Char**, x2 : SizeT*, x3 : Char**, x4 : SizeT*) : SizeT
-  fun iconv_close(x0 : IconvT) : Int
-  fun iconv_open(x0 : Char*, x1 : Char*) : IconvT
+  # Although FreeBSD libc provides iconv_XXXX functions, they are just compatibility symbols,
+  # not directly visible via dlsym(3). Use FreeBSD-specific exported symbols so iconv also
+  # works in the interpreter.
+  fun iconv = __bsd_iconv(x0 : IconvT, x1 : Char**, x2 : SizeT*, x3 : Char**, x4 : SizeT*) : SizeT
+  fun iconv_close = __bsd_iconv_close(x0 : IconvT) : Int
+  fun iconv_open = __bsd_iconv_open(x0 : Char*, x1 : Char*) : IconvT
 
   ICONV_F_HIDE_INVALID = 0x0001
-  fun __iconv(x0 : IconvT, x1 : Char**, x2 : SizeT*, x3 : Char**, x4 : SizeT*, flags : UInt32, invalids : SizeT*) : SizeT
+  fun __iconv = __bsd___iconv(x0 : IconvT, x1 : Char**, x2 : SizeT*, x3 : Char**, x4 : SizeT*, flags : UInt32, invalids : SizeT*) : SizeT
 end


### PR DESCRIPTION
iconv_XXXX are compatibility symbols in FreeBSD libc, not directly visible via dlsym(3). Use FreeBSD-specific exported symbols for LibC definitions.

Fixes #12597