### PR TITLE
Detect `llvm-configXX` while building compiler

### DIFF
--- a/src/llvm/ext/find-llvm-config
+++ b/src/llvm/ext/find-llvm-config
@@ -7,6 +7,7 @@ if ! LLVM_CONFIG=$(command -v "$LLVM_CONFIG"); then
     command -v llvm-config-${version%.*} || \
     command -v llvm-config-$version || \
     command -v llvm-config${version%.*}${version#*.} || \
+    command -v llvm-config$version || \
     command -v llvm${version%.*}-config || \
     [ "${llvm_config_version#$version}" = "$llvm_config_version" ] || command -v llvm-config)
     [ "$LLVM_CONFIG" ] && break


### PR DESCRIPTION
FreeBSD currently uses the naming pattern `llvm-config9`, `llvm-config14` etc. for its LLVM packages (e.g. https://cgit.freebsd.org/ports/tree/devel/llvm14/pkg-plist), which `src/llvm/ext/find-llvm-config` does not currently pick up. This PR adds that pattern.