### PR TITLE
Change System::User from class to struct

### DIFF
--- a/src/system/user.cr
+++ b/src/system/user.cr
@@ -10,7 +10,7 @@ require "crystal/system/user"
 # System::User.find_by name: "root"
 # System::User.find_by id: "0"
 # ```
-class System::User
+struct System::User
   # Raised on user lookup failure.
   class NotFoundError < Exception
   end


### PR DESCRIPTION
This is broken out of the original pr #12595 and references https://github.com/crystal-lang/crystal/issues/7738

The System::User class doesn't need to be a class, no modifications ever happen, so it is wasteful to have this add GC pressure by allocating on the heap for no benefit.