### PR TITLE
Allow System::User.find(id:) to take UInt32

### DIFF
--- a/spec/std/system/user_spec.cr
+++ b/spec/std/system/user_spec.cr
@@ -24,8 +24,16 @@ describe System::User do
   end
 
   describe ".find_by(*, id)" do
-    it "returns a user by id" do
+    it "returns a user by id when given a string id" do
       user = System::User.find_by(id: USER_ID)
+
+      user.should be_a(System::User)
+      user.id.should eq(USER_ID)
+      user.username.should eq(USER_NAME)
+    end
+
+    it "returns a user by id when given a UInt32 id" do
+      user = System::User.find_by(id: USER_ID.to_u32)
 
       user.should be_a(System::User)
       user.id.should eq(USER_ID)

--- a/src/system/user.cr
+++ b/src/system/user.cr
@@ -57,14 +57,14 @@ class System::User
   # Returns the user associated with the given ID.
   #
   # Raises `NotFoundError` if no such user exists.
-  def self.find_by(*, id : String) : System::User
+  def self.find_by(*, id : String | UInt32) : System::User
     find_by?(id: id) || raise NotFoundError.new("No such user: #{id}")
   end
 
   # Returns the user associated with the given ID.
   #
   # Returns `nil` if no such user exists.
-  def self.find_by?(*, id : String) : System::User?
+  def self.find_by?(*, id : String | UInt32) : System::User?
     from_id?(id)
   end
 


### PR DESCRIPTION
This is broken out of the original pr https://github.com/crystal-lang/crystal/pull/12595 and references https://github.com/crystal-lang/crystal/issues/7738

However it relies on a method that #12595 introduces, which I have not duplicated here yet, so I'm keeping this as a draft until the fate of #12595 is decided.

On platforms where user ids are actually UInt32 (all posix as far as I know), it any system call that gets you a userid will be a UInt32, and it feels wasteful to translate that into a string just for the System::User code to again immediately parse that string into an integer to look up user details. I think having this as a union of UInt32 and String doesn't foreclose any ability for strings to be used in the lowest common denominator across different systems, while allowing it to be more efficient when bouncing to and from a string isn't necessary .