### PR TITLE
Add System::User.current_user_name

### DIFF
--- a/spec/std/system/user_spec.cr
+++ b/spec/std/system/user_spec.cr
@@ -7,6 +7,11 @@ USER_NAME = {{ `id -un`.stringify.chomp }}
 USER_ID   = {{ `id -u`.stringify.chomp }}
 
 describe System::User do
+  describe ".current_user_name" do
+    name = System::User.current_user_name
+    name.should eq(USER_NAME)
+  end
+
   describe ".find_by(*, name)" do
     it "returns a user by name" do
       user = System::User.find_by(name: USER_NAME)

--- a/src/crystal/system/unix/user.cr
+++ b/src/crystal/system/unix/user.cr
@@ -25,12 +25,31 @@ module Crystal::System::User
     id = id.to_u32?
     return unless id
 
+    pwd = getpwuid(id)
+    from_struct(pwd) if pwd
+  end
+
+  # Returns the current user's name on success, nil on failure.
+  #
+  # This deals with the passwd struct direclty to avoid creating strings
+  # for the other fields in the passwd struct for the common case of
+  # getting the current username
+  private def find_current_user_name : String?
+    pwd = getpwuid(LibC.getuid)
+    return unless pwd
+
+    String.new(pwd.pw_name)
+  end
+
+  # Returns a libc passwd struct on success, nil on failure
+  private def getpwuid(id : UInt32) : LibC::Passwd?
     pwd = uninitialized LibC::Passwd
     pwd_pointer = pointerof(pwd)
     System.retry_with_buffer("getpwuid_r", GETPW_R_SIZE_MAX) do |buf|
       LibC.getpwuid_r(id, pwd_pointer, buf, buf.size, pointerof(pwd_pointer))
     end
 
-    from_struct(pwd) if pwd_pointer
+    return unless pwd_pointer
+    pwd
   end
 end

--- a/src/crystal/system/wasi/user.cr
+++ b/src/crystal/system/wasi/user.cr
@@ -6,4 +6,8 @@ module Crystal::System::User
   private def from_id?(id : String)
     raise NotImplementedError.new("Crystal::System::User#from_id?")
   end
+
+  private def find_curent_user_name
+    raise NotImplementedError.new("Crystal::System::User#find_current_user_name")
+  end
 end

--- a/src/system/user.cr
+++ b/src/system/user.cr
@@ -40,6 +40,13 @@ class System::User
   private def initialize(@username, @id, @group_id, @name, @home_directory, @shell)
   end
 
+  # Returns the current user's name as a string
+  #
+  # Raises `NotFoundError` if the current user cannot be determined
+  def self.current_user_name : String
+    find_current_user_name || raise NotFoundError.new("Cannot determine current user")
+  end
+
   # Returns the user associated with the given username.
   #
   # Raises `NotFoundError` if no such user exists.


### PR DESCRIPTION
In discussion of #12604 we determined that a useful shortcut would be to grab the current username directly, which avoids allocating several strings out of the lib passwd struct and the System::User class if the only thing one cares about is the current user name.

Reference https://github.com/crystal-lang/crystal/issues/7738