### PR TITLE
Enable `arc4random(3)` on all supported BSDs and macOS/Darwin

### DIFF
--- a/src/crystal/system/random.cr
+++ b/src/crystal/system/random.cr
@@ -14,7 +14,7 @@ end
   require "./wasi/random"
 {% elsif flag?(:linux) %}
   require "./unix/getrandom"
-{% elsif flag?(:bsd) %}
+{% elsif flag?(:bsd) || flag?(:darwin) %}
   require "./unix/arc4random"
 {% elsif flag?(:unix) %}
   require "./unix/urandom"

--- a/src/crystal/system/random.cr
+++ b/src/crystal/system/random.cr
@@ -14,7 +14,7 @@ end
   require "./wasi/random"
 {% elsif flag?(:linux) %}
   require "./unix/getrandom"
-{% elsif flag?(:openbsd) || flag?(:netbsd) %}
+{% elsif flag?(:bsd) %}
   require "./unix/arc4random"
 {% elsif flag?(:unix) %}
   require "./unix/urandom"

--- a/src/crystal/system/unix/arc4random.cr
+++ b/src/crystal/system/unix/arc4random.cr
@@ -1,4 +1,4 @@
-{% skip_file unless flag?(:openbsd) || flag?(:netbsd) %}
+{% skip_file unless flag?(:bsd) %}
 
 require "c/stdlib"
 

--- a/src/lib_c/x86_64-dragonfly/c/stdlib.cr
+++ b/src/lib_c/x86_64-dragonfly/c/stdlib.cr
@@ -7,6 +7,9 @@ lib LibC
     rem : Int
   end
 
+  fun arc4random : UInt32
+  fun arc4random_buf(x0 : Void*, x1 : SizeT) : Void
+  fun arc4random_uniform(x0 : UInt32T) : UInt32T
   fun atof(x0 : Char*) : Double
   fun div(x0 : Int, x1 : Int) : DivT
   fun exit(x0 : Int) : NoReturn

--- a/src/lib_c/x86_64-freebsd/c/iconv.cr
+++ b/src/lib_c/x86_64-freebsd/c/iconv.cr
@@ -3,10 +3,13 @@ require "./stddef"
 lib LibC
   type IconvT = Void*
 
-  fun iconv(x0 : IconvT, x1 : Char**, x2 : SizeT*, x3 : Char**, x4 : SizeT*) : SizeT
-  fun iconv_close(x0 : IconvT) : Int
-  fun iconv_open(x0 : Char*, x1 : Char*) : IconvT
+  # Although FreeBSD libc provides iconv_XXXX functions, they are just compatibility symbols,
+  # not directly visible via dlsym(3). Use FreeBSD-specific exported symbols so iconv also
+  # works in the interpreter.
+  fun iconv = __bsd_iconv(x0 : IconvT, x1 : Char**, x2 : SizeT*, x3 : Char**, x4 : SizeT*) : SizeT
+  fun iconv_close = __bsd_iconv_close(x0 : IconvT) : Int
+  fun iconv_open = __bsd_iconv_open(x0 : Char*, x1 : Char*) : IconvT
 
   ICONV_F_HIDE_INVALID = 0x0001
-  fun __iconv(x0 : IconvT, x1 : Char**, x2 : SizeT*, x3 : Char**, x4 : SizeT*, flags : UInt32, invalids : SizeT*) : SizeT
+  fun __iconv = __bsd___iconv(x0 : IconvT, x1 : Char**, x2 : SizeT*, x3 : Char**, x4 : SizeT*, flags : UInt32, invalids : SizeT*) : SizeT
 end

--- a/src/lib_c/x86_64-freebsd/c/stdlib.cr
+++ b/src/lib_c/x86_64-freebsd/c/stdlib.cr
@@ -7,6 +7,9 @@ lib LibC
     rem : Int
   end
 
+  fun arc4random : UInt32
+  fun arc4random_buf(x0 : Void*, x1 : SizeT) : Void
+  fun arc4random_uniform(x0 : UInt32T) : UInt32T
   fun atof(x0 : Char*) : Double
   fun div(x0 : Int, x1 : Int) : DivT
   fun exit(x0 : Int) : NoReturn

--- a/src/lib_c/x86_64-netbsd/c/stdlib.cr
+++ b/src/lib_c/x86_64-netbsd/c/stdlib.cr
@@ -9,6 +9,7 @@ lib LibC
 
   fun arc4random : UInt32
   fun arc4random_buf(x0 : Void*, x1 : SizeT) : Void
+  fun arc4random_uniform(x0 : UInt32T) : UInt32T
   fun atof(x0 : Char*) : Double
   fun div(x0 : Int, x1 : Int) : DivT
   fun exit(x0 : Int) : NoReturn

--- a/src/lib_c/x86_64-openbsd/c/stdlib.cr
+++ b/src/lib_c/x86_64-openbsd/c/stdlib.cr
@@ -9,6 +9,7 @@ lib LibC
 
   fun arc4random : UInt32
   fun arc4random_buf(x0 : Void*, x1 : SizeT) : Void
+  fun arc4random_uniform(x0 : UInt32T) : UInt32T
   fun atof(x0 : Char*) : Double
   fun div(x0 : Int, x1 : Int) : DivT
   fun exit(x0 : Int) : NoReturn

--- a/src/random/secure.cr
+++ b/src/random/secure.cr
@@ -11,7 +11,7 @@ require "crystal/system/random"
 # [1, 5, 6].shuffle(Random::Secure) # => [6, 1, 5]
 # ```
 #
-# On OpenBSD, it uses [`arc4random`](https://man.openbsd.org/arc4random),
+# On BSD-based systems, it uses [`arc4random`](https://man.openbsd.org/arc4random),
 # on Linux [`getrandom`](http://man7.org/linux/man-pages/man2/getrandom.2.html) (if the kernel supports it),
 # on Windows [`RtlGenRandom`](https://docs.microsoft.com/en-us/windows/win32/api/ntsecapi/nf-ntsecapi-rtlgenrandom),
 # and falls back to reading from `/dev/urandom` on UNIX systems.

--- a/src/random/secure.cr
+++ b/src/random/secure.cr
@@ -11,7 +11,7 @@ require "crystal/system/random"
 # [1, 5, 6].shuffle(Random::Secure) # => [6, 1, 5]
 # ```
 #
-# On BSD-based systems, it uses [`arc4random`](https://man.openbsd.org/arc4random),
+# On BSD-based systems and macOS/Darwin, it uses [`arc4random`](https://man.openbsd.org/arc4random),
 # on Linux [`getrandom`](http://man7.org/linux/man-pages/man2/getrandom.2.html) (if the kernel supports it),
 # on Windows [`RtlGenRandom`](https://docs.microsoft.com/en-us/windows/win32/api/ntsecapi/nf-ntsecapi-rtlgenrandom),
 # and falls back to reading from `/dev/urandom` on UNIX systems.


### PR DESCRIPTION
All BSD-based platforms supported by Crystal have arc4random(3), add support for it where it was missing.

Fixes #12607