### PR TITLE
Drop FreeBSD 11 compatibility code

### DIFF
--- a/src/lib_c/x86_64-freebsd/c/dirent.cr
+++ b/src/lib_c/x86_64-freebsd/c/dirent.cr
@@ -8,21 +8,13 @@ lib LibC
   DT_LNK     = 10
 
   struct Dirent
-    {% if flag?(:freebsd11) %}
-      d_fileno : UInt
-    {% else %}
-      d_fileno : ULong
-      d_off : ULong
-    {% end %}
+    d_fileno : ULong
+    d_off : ULong
     d_reclen : UShort
     d_type : UChar
-    {% if flag?(:freebsd11) %}
-      d_namlen : UChar
-    {% else %}
-      d_pad0 : UChar
-      d_namlen : UShort
-      d_pad1 : UShort
-    {% end %}
+    d_pad0 : UChar
+    d_namlen : UShort
+    d_pad1 : UShort
     d_name : StaticArray(Char, 256)
   end
 

--- a/src/lib_c/x86_64-freebsd/c/sys/stat.cr
+++ b/src/lib_c/x86_64-freebsd/c/sys/stat.cr
@@ -31,40 +31,23 @@ lib LibC
   struct Stat
     st_dev : DevT
     st_ino : InoT
-    {% if flag?(:freebsd11) %}
-      st_mode : ModeT
-      st_nlink : NlinkT
-    {% else %}
-      st_nlink : NlinkT
-      st_mode : ModeT
-      st_pad0 : UShort
-    {% end %}
+    st_nlink : NlinkT
+    st_mode : ModeT
+    st_pad0 : UShort
     st_uid : UidT
     st_gid : GidT
-    {% if !flag?(:freebsd11) %}
-      st_pad1 : UInt
-    {% end %}
+    st_pad1 : UInt
     st_rdev : DevT
     st_atim : Timespec
     st_mtim : Timespec
     st_ctim : Timespec
-    {% if !flag?(:freebsd11) %}
-      st_birthtim : Timespec
-    {% end %}
+    st_birthtim : Timespec
     st_size : OffT
     st_blocks : BlkcntT
     st_blksize : BlksizeT
     st_flags : FflagsT
-    {% if flag?(:freebsd11) %}
-      st_gen : UInt
-      st_lspare : Int
-      st_birthtim : Timespec
-      __reserved_17 : UInt
-      __reserved_18 : UInt
-    {% else %}
-      st_gen : ULong
-      st_spare : StaticArray(ULong, 10)
-    {% end %}
+    st_gen : ULong
+    st_spare : StaticArray(ULong, 10)
   end
 
   fun chmod(x0 : Char*, x1 : ModeT) : Int

--- a/src/lib_c/x86_64-freebsd/c/sys/types.cr
+++ b/src/lib_c/x86_64-freebsd/c/sys/types.cr
@@ -9,17 +9,9 @@ lib LibC
   alias DevT = UInt
   alias GidT = UInt
   alias IdT = Long
-  {% if flag?(:freebsd11) %}
-    alias InoT = UInt
-  {% else %}
-    alias InoT = ULong
-  {% end %}
+  alias InoT = ULong
   alias ModeT = UShort
-  {% if flag?(:freebsd11) %}
-    alias NlinkT = UShort
-  {% else %}
-    alias NlinkT = ULong
-  {% end %}
+  alias NlinkT = ULong
   alias OffT = Long
   alias PidT = Int
   type PthreadAttrT = Void*


### PR DESCRIPTION
FreeBSD 11 went EOL on September 30, 2021.

Fixes #12611