### PR TITLE
Websocket: write masked data to temporary buffer before sending it

### DIFF
--- a/spec/std/http/web_socket_spec.cr
+++ b/spec/std/http/web_socket_spec.cr
@@ -182,8 +182,8 @@ describe HTTP::WebSocket do
 
   describe "send" do
     it "sends long data with correct header" do
-      size = UInt16::MAX.to_u64 + 1
-      big_string = "a" * size
+      big_string = "abcdefghijklmnopqrstuvwxyz" * (IO::DEFAULT_BUFFER_SIZE // 4)
+      size = big_string.size
       io = IO::Memory.new
       ws = HTTP::WebSocket::Protocol.new(io)
       ws.send(big_string)
@@ -194,7 +194,7 @@ describe HTTP::WebSocket do
       8.times { |i| received_size <<= 8; received_size += bytes[2 + i] }
       received_size.should eq(size)
       size.times do |i|
-        bytes[10 + i].should eq('a'.ord)
+        bytes[10 + i].should eq(big_string[i].ord)
       end
     end
 
@@ -285,8 +285,8 @@ describe HTTP::WebSocket do
     end
 
     it "sends long data with correct header" do
-      size = UInt16::MAX.to_u64 + 1
-      big_string = "a" * size
+      big_string = "abcdefghijklmnopqrstuvwxyz" * (IO::DEFAULT_BUFFER_SIZE // 4)
+      size = big_string.size
       io = IO::Memory.new
       ws = HTTP::WebSocket::Protocol.new(io, masked: true)
       ws.send(big_string)
@@ -298,7 +298,7 @@ describe HTTP::WebSocket do
       8.times { |i| received_size <<= 8; received_size += bytes[2 + i] }
       received_size.should eq(size)
       size.times do |i|
-        (bytes[14 + i] ^ bytes[10 + (i % 4)]).should eq('a'.ord)
+        (bytes[14 + i] ^ bytes[10 + (i % 4)]).should eq(big_string[i].ord)
       end
     end
   end

--- a/src/http/web_socket/protocol.cr
+++ b/src/http/web_socket/protocol.cr
@@ -152,7 +152,7 @@ class HTTP::WebSocket::Protocol
     until remaining_data.empty?
       # How much data can we write?
       # Either IO::DEFAULT_BUFFER_SIZE or whatever remains.
-      chunk_size = {remaining_data.size, IO::DEFAULT_BUFFER_SIZE}.min
+      chunk_size = Math.min(remaining_data.size, IO::DEFAULT_BUFFER_SIZE)
 
       # Mask the data
       chunk = remaining_data[0, chunk_size]

--- a/src/http/web_socket/protocol.cr
+++ b/src/http/web_socket/protocol.cr
@@ -140,9 +140,32 @@ class HTTP::WebSocket::Protocol
     mask_array = key.unsafe_as(StaticArray(UInt8, 4))
     @io.write mask_array.to_slice
 
-    data.each_with_index do |byte, index|
-      mask = mask_array[index & 0b11] # x & 0b11 == x % 4
-      @io.write_byte(byte ^ mask)
+    write_masked_data(data, mask_array)
+  end
+
+  private def write_masked_data(data, mask_array)
+    # We are going to write the data, masked, into a temporary buffer.
+    masked_data = uninitialized UInt8[IO::DEFAULT_BUFFER_SIZE]
+
+    # We'll do it by chunks of at most IO::DEFAULT_BUFFER_SIZE
+    remaining_data = data
+    until remaining_data.empty?
+      # How much data can we write?
+      # Either IO::DEFAULT_BUFFER_SIZE or whatever remains.
+      chunk_size = {remaining_data.size, IO::DEFAULT_BUFFER_SIZE}.min
+
+      # Mask the data
+      chunk = remaining_data[0, chunk_size]
+      chunk.each_with_index do |byte, index|
+        mask = mask_array[index & 0b11] # x & 0b11 == x % 4
+        masked_data[index] = byte ^ mask
+      end
+
+      # Write the masked data
+      @io.write(masked_data.to_slice[0, chunk_size])
+
+      # Discard the written data
+      remaining_data = remaining_data[chunk_size..]
     end
   end
 


### PR DESCRIPTION
Fixes #12610

I think all specs pass, but please carefully review the code. Thanks!

This might be a good candidate for 1.6.1. It's not a regression, but the old performance is far from acceptable.