### PR TITLE
Formatter: document stdin filename argument (`-`)

### DIFF
--- a/spec/compiler/crystal/tools/format_spec.cr
+++ b/spec/compiler/crystal/tools/format_spec.cr
@@ -17,7 +17,7 @@ describe Crystal::Command::FormatCommand do
     stdout = IO::Memory.new
     stderr = IO::Memory.new
 
-    format_command = Crystal::Command::FormatCommand.new(["-"], stdin: stdin, stdout: stdout, stderr: stderr)
+    format_command = Crystal::Command::FormatCommand.new([] of String, format_stdin: true, stdin: stdin, stdout: stdout, stderr: stderr)
     format_command.run
     format_command.status_code.should eq(0)
     stdout.to_s.should eq("if true\n  1\nend\n")
@@ -29,7 +29,7 @@ describe Crystal::Command::FormatCommand do
     stdout = IO::Memory.new
     stderr = IO::Memory.new
 
-    format_command = Crystal::Command::FormatCommand.new(["-"], stdin: stdin, stdout: stdout, stderr: stderr)
+    format_command = Crystal::Command::FormatCommand.new([] of String, format_stdin: true, stdin: stdin, stdout: stdout, stderr: stderr)
     format_command.run
     format_command.status_code.should eq(0)
     stdout.to_s.should eq("if true\n  1\nend\n")
@@ -41,7 +41,7 @@ describe Crystal::Command::FormatCommand do
     stdout = IO::Memory.new
     stderr = IO::Memory.new
 
-    format_command = Crystal::Command::FormatCommand.new(["-"], stdin: stdin, stdout: stdout, stderr: stderr)
+    format_command = Crystal::Command::FormatCommand.new([] of String, format_stdin: true, stdin: stdin, stdout: stdout, stderr: stderr)
     format_command.run
     format_command.status_code.should eq(1)
     stdout.to_s.should be_empty
@@ -53,7 +53,7 @@ describe Crystal::Command::FormatCommand do
     stdout = IO::Memory.new
     stderr = IO::Memory.new
 
-    format_command = Crystal::Command::FormatCommand.new(["-"], stdin: stdin, stdout: stdout, stderr: stderr)
+    format_command = Crystal::Command::FormatCommand.new([] of String, format_stdin: true, stdin: stdin, stdout: stdout, stderr: stderr)
     format_command.run
     format_command.status_code.should eq(1)
     stdout.to_s.should be_empty
@@ -65,7 +65,7 @@ describe Crystal::Command::FormatCommand do
     stdout = IO::Memory.new
     stderr = IO::Memory.new
 
-    format_command = BuggyFormatCommand.new(["-"], stdin: stdin, stdout: stdout, stderr: stderr)
+    format_command = BuggyFormatCommand.new([] of String, format_stdin: true, stdin: stdin, stdout: stdout, stderr: stderr)
     format_command.run
     format_command.status_code.should eq(1)
     stdout.to_s.should be_empty
@@ -77,7 +77,7 @@ describe Crystal::Command::FormatCommand do
     stdout = IO::Memory.new
     stderr = IO::Memory.new
 
-    format_command = BuggyFormatCommand.new(["-"], show_backtrace: true, stdin: stdin, stdout: stdout, stderr: stderr)
+    format_command = BuggyFormatCommand.new([] of String, format_stdin: true, show_backtrace: true, stdin: stdin, stdout: stdout, stderr: stderr)
     format_command.run
     format_command.status_code.should eq(1)
     stdout.to_s.should be_empty

--- a/spec/compiler/crystal/tools/format_spec.cr
+++ b/spec/compiler/crystal/tools/format_spec.cr
@@ -17,7 +17,7 @@ describe Crystal::Command::FormatCommand do
     stdout = IO::Memory.new
     stderr = IO::Memory.new
 
-    format_command = Crystal::Command::FormatCommand.new([] of String, format_stdin: true, stdin: stdin, stdout: stdout, stderr: stderr)
+    format_command = Crystal::Command::FormatCommand.new(["-"], stdin: stdin, stdout: stdout, stderr: stderr)
     format_command.run
     format_command.status_code.should eq(0)
     stdout.to_s.should eq("if true\n  1\nend\n")
@@ -29,7 +29,7 @@ describe Crystal::Command::FormatCommand do
     stdout = IO::Memory.new
     stderr = IO::Memory.new
 
-    format_command = Crystal::Command::FormatCommand.new([] of String, format_stdin: true, stdin: stdin, stdout: stdout, stderr: stderr)
+    format_command = Crystal::Command::FormatCommand.new(["-"], stdin: stdin, stdout: stdout, stderr: stderr)
     format_command.run
     format_command.status_code.should eq(0)
     stdout.to_s.should eq("if true\n  1\nend\n")
@@ -41,7 +41,7 @@ describe Crystal::Command::FormatCommand do
     stdout = IO::Memory.new
     stderr = IO::Memory.new
 
-    format_command = Crystal::Command::FormatCommand.new([] of String, format_stdin: true, stdin: stdin, stdout: stdout, stderr: stderr)
+    format_command = Crystal::Command::FormatCommand.new(["-"], stdin: stdin, stdout: stdout, stderr: stderr)
     format_command.run
     format_command.status_code.should eq(1)
     stdout.to_s.should be_empty
@@ -53,7 +53,7 @@ describe Crystal::Command::FormatCommand do
     stdout = IO::Memory.new
     stderr = IO::Memory.new
 
-    format_command = Crystal::Command::FormatCommand.new([] of String, format_stdin: true, stdin: stdin, stdout: stdout, stderr: stderr)
+    format_command = Crystal::Command::FormatCommand.new(["-"], stdin: stdin, stdout: stdout, stderr: stderr)
     format_command.run
     format_command.status_code.should eq(1)
     stdout.to_s.should be_empty
@@ -65,7 +65,7 @@ describe Crystal::Command::FormatCommand do
     stdout = IO::Memory.new
     stderr = IO::Memory.new
 
-    format_command = BuggyFormatCommand.new([] of String, format_stdin: true, stdin: stdin, stdout: stdout, stderr: stderr)
+    format_command = BuggyFormatCommand.new(["-"], stdin: stdin, stdout: stdout, stderr: stderr)
     format_command.run
     format_command.status_code.should eq(1)
     stdout.to_s.should be_empty
@@ -77,7 +77,7 @@ describe Crystal::Command::FormatCommand do
     stdout = IO::Memory.new
     stderr = IO::Memory.new
 
-    format_command = BuggyFormatCommand.new([] of String, format_stdin: true, show_backtrace: true, stdin: stdin, stdout: stdout, stderr: stderr)
+    format_command = BuggyFormatCommand.new(["-"], show_backtrace: true, stdin: stdin, stdout: stdout, stderr: stderr)
     format_command.run
     format_command.status_code.should eq(1)
     stdout.to_s.should be_empty

--- a/src/compiler/crystal/command/format.cr
+++ b/src/compiler/crystal/command/format.cr
@@ -12,14 +12,14 @@ class Crystal::Command
 
     OptionParser.parse(@options) do |opts|
       opts.banner = <<-USAGE
-        Usage: crystal tool format [options] [file or directory ...]
+        Usage: crystal tool format [options] [- | file or directory ...]
 
         Formats Crystal code in place.
 
         If a file or directory is omitted,
         Crystal source files beneath the working directory are formatted.
 
-        Use '-' in place of a file or directory to format STDIN to STDOUT.
+        To format STDIN to STDOUT, use '-' in place of any path arguments.
 
         Options:
         USAGE

--- a/src/compiler/crystal/command/format.cr
+++ b/src/compiler/crystal/command/format.cr
@@ -11,7 +11,18 @@ class Crystal::Command
     show_backtrace = false
 
     OptionParser.parse(@options) do |opts|
-      opts.banner = "Usage: crystal tool format [options] [file or directory]\n\nOptions:"
+      opts.banner = <<-USAGE
+        Usage: crystal tool format [options] [file or directory ...]
+
+        Formats Crystal code in place.
+
+        If a file or directory is omitted,
+        Crystal source files beneath the working directory are formatted.
+
+        Use '-' in place of a file or directory to format STDIN to STDOUT.
+
+        Options:
+        USAGE
 
       opts.on("--check", "Checks that formatting code produces no changes") do |f|
         check = true

--- a/src/compiler/crystal/command/format.cr
+++ b/src/compiler/crystal/command/format.cr
@@ -9,12 +9,17 @@ class Crystal::Command
     includes = [] of String
     check = false
     show_backtrace = false
+    format_stdin = false
 
     OptionParser.parse(@options) do |opts|
-      opts.banner = "Usage: crystal tool format [options] [file or directory]\n\nOptions:"
+      opts.banner = "Usage: crystal tool format [options] [file or directory]...\n\nOptions:"
 
       opts.on("--check", "Checks that formatting code produces no changes") do |f|
         check = true
+      end
+
+      opts.on("-", "--stdin", "Format STDIN to STDOUT") do
+        format_stdin = true
       end
 
       opts.on("-i <path>", "--include <path>", "Include path") do |f|
@@ -47,8 +52,10 @@ class Crystal::Command
       excludes,
       check,
       show_backtrace,
+      format_stdin,
       @color,
     )
+
     format_command.run
     exit format_command.status_code
   end
@@ -65,12 +72,11 @@ class Crystal::Command
       includes = [] of String, excludes = [] of String,
       @check : Bool = false,
       @show_backtrace : Bool = false,
+      @format_stdin : Bool = false,
       @color : Bool = true,
       # stdio is injectable for testing
       @stdin : IO = STDIN, @stdout : IO = STDOUT, @stderr : IO = STDERR
     )
-      @format_stdin = files.size == 1 && files[0] == "-"
-
       includes.map! { |p| Crystal.normalize_path p }
       excludes.map! { |p| Crystal.normalize_path p }
       excludes = excludes - includes

--- a/src/compiler/crystal/command/format.cr
+++ b/src/compiler/crystal/command/format.cr
@@ -9,17 +9,12 @@ class Crystal::Command
     includes = [] of String
     check = false
     show_backtrace = false
-    format_stdin = false
 
     OptionParser.parse(@options) do |opts|
-      opts.banner = "Usage: crystal tool format [options] [file or directory]...\n\nOptions:"
+      opts.banner = "Usage: crystal tool format [options] [file or directory]\n\nOptions:"
 
       opts.on("--check", "Checks that formatting code produces no changes") do |f|
         check = true
-      end
-
-      opts.on("-", "--stdin", "Format STDIN to STDOUT") do
-        format_stdin = true
       end
 
       opts.on("-i <path>", "--include <path>", "Include path") do |f|
@@ -52,10 +47,8 @@ class Crystal::Command
       excludes,
       check,
       show_backtrace,
-      format_stdin,
       @color,
     )
-
     format_command.run
     exit format_command.status_code
   end
@@ -72,11 +65,12 @@ class Crystal::Command
       includes = [] of String, excludes = [] of String,
       @check : Bool = false,
       @show_backtrace : Bool = false,
-      @format_stdin : Bool = false,
       @color : Bool = true,
       # stdio is injectable for testing
       @stdin : IO = STDIN, @stdout : IO = STDOUT, @stderr : IO = STDERR
     )
+      @format_stdin = files.size == 1 && files[0] == "-"
+
       includes.map! { |p| Crystal.normalize_path p }
       excludes.map! { |p| Crystal.normalize_path p }
       excludes = excludes - includes


### PR DESCRIPTION
The behaviour of taking `-` as a filename to imply formatting STDIN to STDOUT was previously undocumented.

Previously, STDIN would be read if the only path passed was `-`.
The behaviour of this PR is to ignore additional files if `-` or `--stdin` are passed.

Closes #12615