### PR TITLE
Support typed LLVM `getelementptr` instructions

### DIFF
--- a/src/compiler/crystal/codegen/call.cr
+++ b/src/compiler/crystal/codegen/call.cr
@@ -205,7 +205,7 @@ class Crystal::CodeGenVisitor
       abi_arg_type = abi_info.arg_types[i]
       case abi_arg_type.kind
       in .direct?
-        call_arg = codegen_direct_abi_call(call_arg, abi_arg_type) unless arg.type.nil_type?
+        call_arg = codegen_direct_abi_call(arg.type, call_arg, abi_arg_type) unless arg.type.nil_type?
       in .indirect?
         call_arg = codegen_indirect_abi_call(call_arg, abi_arg_type) unless arg.type.nil_type?
       in .ignore?
@@ -233,11 +233,11 @@ class Crystal::CodeGenVisitor
     call_args
   end
 
-  def codegen_direct_abi_call(call_arg, abi_arg_type)
+  def codegen_direct_abi_call(call_arg_type, call_arg, abi_arg_type)
     if cast = abi_arg_type.cast
       final_value = alloca cast
       final_value_casted = bit_cast final_value, llvm_context.void_pointer
-      gep_call_arg = bit_cast gep(call_arg, 0, 0), llvm_context.void_pointer
+      gep_call_arg = bit_cast gep(llvm_type(call_arg_type), call_arg, 0, 0), llvm_context.void_pointer
       size = @abi.size(abi_arg_type.type)
       size = @program.bits64? ? int64(size) : int32(size)
       align = @abi.align(abi_arg_type.type)

--- a/src/compiler/crystal/codegen/llvm_builder_helper.cr
+++ b/src/compiler/crystal/codegen/llvm_builder_helper.cr
@@ -79,20 +79,36 @@ module Crystal
       builder.icmp LLVM::IntPredicate::NE, value, value.type.null
     end
 
-    def gep(ptr, index0 : Int32, name = "")
+    def gep(ptr : LLVM::Value, index0 : Int32, name = "")
       gep ptr, int32(index0), name
     end
 
-    def gep(ptr, index0 : LLVM::Value, name = "")
+    def gep(ptr : LLVM::Value, index0 : LLVM::Value, name = "")
       builder.inbounds_gep ptr, index0, name
     end
 
-    def gep(ptr, index0 : Int32, index1 : Int32, name = "")
+    def gep(ptr : LLVM::Value, index0 : Int32, index1 : Int32, name = "")
       gep ptr, int32(index0), int32(index1), name
     end
 
-    def gep(ptr, index0 : LLVM::Value, index1 : LLVM::Value, name = "")
+    def gep(ptr : LLVM::Value, index0 : LLVM::Value, index1 : LLVM::Value, name = "")
       builder.inbounds_gep ptr, index0, index1, name
+    end
+
+    def gep(type : LLVM::Type, ptr : LLVM::Value, index0 : Int32, name = "")
+      gep type, ptr, int32(index0), name
+    end
+
+    def gep(type : LLVM::Type, ptr : LLVM::Value, index0 : LLVM::Value, name = "")
+      builder.inbounds_gep type, ptr, index0, name
+    end
+
+    def gep(type : LLVM::Type, ptr : LLVM::Value, index0 : Int32, index1 : Int32, name = "")
+      gep type, ptr, int32(index0), int32(index1), name
+    end
+
+    def gep(type : LLVM::Type, ptr : LLVM::Value, index0 : LLVM::Value, index1 : LLVM::Value, name = "")
+      builder.inbounds_gep type, ptr, index0, index1, name
     end
 
     def call(func, name : String = "")

--- a/src/compiler/crystal/codegen/unions.cr
+++ b/src/compiler/crystal/codegen/unions.cr
@@ -58,48 +58,52 @@ module Crystal
     end
 
     def union_type_and_value_pointer(union_pointer, type : MixedUnionType)
-      {load(union_type_id(union_pointer)), union_value(union_pointer)}
+      struct_type = llvm_type(type)
+      {load(union_type_id(struct_type, union_pointer)), union_value(struct_type, union_pointer)}
     end
 
-    def union_type_id(union_pointer)
-      aggregate_index union_pointer, 0
+    def union_type_id(struct_type, union_pointer)
+      aggregate_index struct_type, union_pointer, 0
     end
 
-    def union_value(union_pointer)
-      aggregate_index union_pointer, 1
+    def union_value(struct_type, union_pointer)
+      aggregate_index struct_type, union_pointer, 1
     end
 
     def store_in_union(union_type, union_pointer, value_type, value)
-      store type_id(value, value_type), union_type_id(union_pointer)
-      casted_value_ptr = cast_to_pointer(union_value(union_pointer), value_type)
+      struct_type = llvm_type(union_type)
+      store type_id(value, value_type), union_type_id(struct_type, union_pointer)
+      casted_value_ptr = cast_to_pointer(union_value(struct_type, union_pointer), value_type)
       store value, casted_value_ptr
     end
 
-    def store_bool_in_union(union_type, union_pointer, value)
-      store type_id(value, @program.bool), union_type_id(union_pointer)
+    def store_bool_in_union(target_type, union_pointer, value)
+      struct_type = llvm_type(target_type)
+      store type_id(value, @program.bool), union_type_id(struct_type, union_pointer)
 
       # To store a boolean in a union
       # we sign-extend it to the size in bits of the union
-      union_value_type = @llvm_typer.union_value_type(union_type)
-      union_size = @llvm_typer.size_of(union_value_type)
+      union_size = @llvm_typer.size_of(struct_type.struct_element_types[1])
       int_type = llvm_context.int((union_size * 8).to_i32)
 
       bool_as_extended_int = builder.zext(value, int_type)
-      casted_value_ptr = bit_cast(union_value(union_pointer), int_type.pointer)
+      casted_value_ptr = bit_cast(union_value(struct_type, union_pointer), int_type.pointer)
       store bool_as_extended_int, casted_value_ptr
     end
 
-    def store_nil_in_union(union_pointer, target_type)
-      union_value_type = @llvm_typer.union_value_type(target_type)
+    def store_nil_in_union(target_type, union_pointer)
+      struct_type = llvm_type(target_type)
+      union_value_type = struct_type.struct_element_types[1]
       value = union_value_type.null
 
-      store type_id(value, @program.nil), union_type_id(union_pointer)
-      casted_value_ptr = bit_cast union_value(union_pointer), union_value_type.pointer
+      store type_id(value, @program.nil), union_type_id(struct_type, union_pointer)
+      casted_value_ptr = bit_cast union_value(struct_type, union_pointer), union_value_type.pointer
       store value, casted_value_ptr
     end
 
-    def store_void_in_union(union_pointer, target_type)
-      store type_id(@program.void), union_type_id(union_pointer)
+    def store_void_in_union(target_type, union_pointer)
+      struct_type = llvm_type(target_type)
+      store type_id(@program.void), union_type_id(struct_type, union_pointer)
     end
 
     def assign_distinct_union_types(target_pointer, target_type, value_type, value)

--- a/src/llvm/builder.cr
+++ b/src/llvm/builder.cr
@@ -106,26 +106,72 @@ class LLVM::Builder
   end
 
   {% for method_name in %w(gep inbounds_gep) %}
-    def {{method_name.id}}(value, indices : Array(LLVM::ValueRef), name = "")
+    def {{method_name.id}}(value : LLVM::Value, indices : Array(LLVM::ValueRef), name = "")
       # check_value(value)
 
-      Value.new LibLLVM.build_{{method_name.id}}(self, value, indices.to_unsafe.as(LibLLVM::ValueRef*), indices.size, name)
+      \{% if LibLLVM::IS_LT_80 %}
+        Value.new LibLLVM.build_{{method_name.id}}(self, value, indices.to_unsafe.as(LibLLVM::ValueRef*), indices.size, name)
+      \{% else %}
+        Value.new LibLLVM.build_{{method_name.id}}2(self, value.type, value, indices.to_unsafe.as(LibLLVM::ValueRef*), indices.size, name)
+      \{% end %}
     end
 
-    def {{method_name.id}}(value, index : LLVM::Value, name = "")
+    def {{method_name.id}}(type : LLVM::Type, value : LLVM::Value, indices : Array(LLVM::ValueRef), name = "")
+      # check_value(value)
+
+      \{% if LibLLVM::IS_LT_80 %}
+        Value.new LibLLVM.build_{{method_name.id}}(self, value, indices.to_unsafe.as(LibLLVM::ValueRef*), indices.size, name)
+      \{% else %}
+        Value.new LibLLVM.build_{{method_name.id}}2(self, type, value, indices.to_unsafe.as(LibLLVM::ValueRef*), indices.size, name)
+      \{% end %}
+    end
+
+    def {{method_name.id}}(value : LLVM::Value, index : LLVM::Value, name = "")
       # check_value(value)
 
       indices = pointerof(index).as(LibLLVM::ValueRef*)
-      Value.new LibLLVM.build_{{method_name.id}}(self, value, indices, 1, name)
+      \{% if LibLLVM::IS_LT_80 %}
+        Value.new LibLLVM.build_{{method_name.id}}(self, value, indices, 1, name)
+      \{% else %}
+        Value.new LibLLVM.build_{{method_name.id}}2(self, value.type, value, indices, 1, name)
+      \{% end %}
     end
 
-    def {{method_name.id}}(value, index1 : LLVM::Value, index2 : LLVM::Value, name = "")
+    def {{method_name.id}}(type : LLVM::Type, value : LLVM::Value, index : LLVM::Value, name = "")
+      # check_value(value)
+
+      indices = pointerof(index).as(LibLLVM::ValueRef*)
+      \{% if LibLLVM::IS_LT_80 %}
+        Value.new LibLLVM.build_{{method_name.id}}(self, value, indices, 1, name)
+      \{% else %}
+        Value.new LibLLVM.build_{{method_name.id}}2(self, type, value, indices, 1, name)
+      \{% end %}
+    end
+
+    def {{method_name.id}}(value : LLVM::Value, index1 : LLVM::Value, index2 : LLVM::Value, name = "")
       # check_value(value)
 
       indices = uninitialized LLVM::Value[2]
       indices[0] = index1
       indices[1] = index2
-      Value.new LibLLVM.build_{{method_name.id}}(self, value, indices.to_unsafe.as(LibLLVM::ValueRef*), 2, name)
+      \{% if LibLLVM::IS_LT_80 %}
+        Value.new LibLLVM.build_{{method_name.id}}(self, value, indices.to_unsafe.as(LibLLVM::ValueRef*), 2, name)
+      \{% else %}
+        Value.new LibLLVM.build_{{method_name.id}}2(self, value.type, value, indices.to_unsafe.as(LibLLVM::ValueRef*), 2, name)
+      \{% end %}
+    end
+
+    def {{method_name.id}}(type : LLVM::Type, value : LLVM::Value, index1 : LLVM::Value, index2 : LLVM::Value, name = "")
+      # check_value(value)
+
+      indices = uninitialized LLVM::Value[2]
+      indices[0] = index1
+      indices[1] = index2
+      \{% if LibLLVM::IS_LT_80 %}
+        Value.new LibLLVM.build_{{method_name.id}}(self, value, indices.to_unsafe.as(LibLLVM::ValueRef*), 2, name)
+      \{% else %}
+        Value.new LibLLVM.build_{{method_name.id}}2(self, type, value, indices.to_unsafe.as(LibLLVM::ValueRef*), 2, name)
+      \{% end %}
     end
   {% end %}
 

--- a/src/llvm/lib_llvm.cr
+++ b/src/llvm/lib_llvm.cr
@@ -131,6 +131,10 @@ lib LibLLVM
   fun build_fsub = LLVMBuildFSub(builder : BuilderRef, lhs : ValueRef, rhs : ValueRef, name : UInt8*) : ValueRef
   fun build_gep = LLVMBuildGEP(builder : BuilderRef, pointer : ValueRef, indices : ValueRef*, num_indices : UInt32, name : UInt8*) : ValueRef
   fun build_inbounds_gep = LLVMBuildInBoundsGEP(builder : BuilderRef, pointer : ValueRef, indices : ValueRef*, num_indices : UInt32, name : UInt8*) : ValueRef
+  {% unless LibLLVM::IS_LT_80 %}
+    fun build_gep2 = LLVMBuildGEP2(builder : BuilderRef, ty : TypeRef, pointer : ValueRef, indices : ValueRef*, num_indices : UInt32, name : UInt8*) : ValueRef
+    fun build_inbounds_gep2 = LLVMBuildInBoundsGEP2(builder : BuilderRef, ty : TypeRef, pointer : ValueRef, indices : ValueRef*, num_indices : UInt32, name : UInt8*) : ValueRef
+  {% end %}
   fun build_global_string_ptr = LLVMBuildGlobalStringPtr(builder : BuilderRef, str : UInt8*, name : UInt8*) : ValueRef
   fun build_icmp = LLVMBuildICmp(builder : BuilderRef, op : LLVM::IntPredicate, lhs : ValueRef, rhs : ValueRef, name : UInt8*) : ValueRef
   fun build_int2ptr = LLVMBuildIntToPtr(builder : BuilderRef, val : ValueRef, dest_ty : TypeRef, name : UInt8*) : ValueRef


### PR DESCRIPTION
This implements part of #12484 by allowing `LLVM::Builder#gep` and `#inbounds_gep` to accept an optional `type` argument. Given an LLVM instruction like:

```llvm
%1 = getelementptr %T, %U* %0, i64 7
```

To maintain the same semantics before this change, `%T` and `%U` should remain identical types from the same context. There are now four possible scenarios:

* `type` is given, LLVM ≥ 8.0: `%T` is `type`, `%U` comes from `value`;
* `type` is omitted, LLVM ≥ 8.0: `%T` is `value.type`, `%U` comes from `value`;
* `type` is given, LLVM < 8.0: `%T` and `%U` come from `value`. **The `type` argument is silently ignored**;
* `type` is omitted, LLVM < 8.0: `%T` and `%U` come from `value`.

The compiler itself provides the `type` argument in all cases. The builder now always uses `LLVMBuildGEP2` / `LLVMBuildInBoundsGEP2` instead of the deprecated methods if LLVM 8.0 or above is detected. There are no breaking changes in this patch, and all the codegen specs have been locally tested on Nix shells for LLVM 7 and 14 on aarch64-apple-darwin.

Later a similar migration has to be done for `#load` / `LLVMBuildLoad` too.