### PR TITLE
Fix `VirtualMetaclassType#implements?` to ignore base_type

### DIFF
--- a/spec/compiler/codegen/cast_spec.cr
+++ b/spec/compiler/codegen/cast_spec.cr
@@ -425,14 +425,14 @@ describe "Code gen: cast" do
   end
 
   it "cast virtual metaclass type to nilable virtual instance type (#12628)" do
-    run(<<-CR).to_s.should eq "nil"
+    run(<<-CR).to_b.should be_true
       abstract struct Base
       end
 
       struct Impl < Base
       end
 
-      Base.as(Base | Base.class).as?(Base | Impl)
+      Base.as(Base | Base.class).as?(Base | Impl).nil?
       CR
   end
 end

--- a/spec/compiler/codegen/cast_spec.cr
+++ b/spec/compiler/codegen/cast_spec.cr
@@ -423,4 +423,16 @@ describe "Code gen: cast" do
       A.as(A.class)
       ))
   end
+
+  it "cast virtual metaclass type to nilable virtual instance type (#12628)" do
+    run(<<-CR).to_s.should eq "nil"
+      abstract struct Base
+      end
+
+      struct Impl < Base
+      end
+
+      Base.as(Base | Base.class).as?(Base | Impl)
+      CR
+  end
 end

--- a/spec/compiler/codegen/is_a_spec.cr
+++ b/spec/compiler/codegen/is_a_spec.cr
@@ -922,4 +922,16 @@ describe "Codegen: is_a?" do
       b.is_a?(B(Int32))
     )).to_b.should be_true
   end
+
+  it "virtual metaclass type is not virtual instance type (#12628)" do
+    run(<<-CR).to_b.should be_false
+      abstract struct Base
+      end
+
+      struct Impl < Base
+      end
+
+      Base.as(Base | Base.class).is_a?(Base | Impl)
+      CR
+  end
 end

--- a/spec/compiler/semantic/metaclass_spec.cr
+++ b/spec/compiler/semantic/metaclass_spec.cr
@@ -134,6 +134,16 @@ describe "Semantic: metaclass" do
       bar_class.should be_a_proper_subtype_of(foo_class)
     end
 
+    it "virtual metaclass type with virtual type (#12628)" do
+      mod = semantic(%(
+        class Base; end
+        class Impl < Base; end
+        )).program
+
+      base = mod.types["Base"]
+      base.virtual_type!.metaclass.implements?(base).should be_false
+    end
+
     it "generic classes (1)" do
       mod = semantic(%(
         class Foo(T); end

--- a/spec/compiler/semantic/metaclass_spec.cr
+++ b/spec/compiler/semantic/metaclass_spec.cr
@@ -142,6 +142,8 @@ describe "Semantic: metaclass" do
 
       base = mod.types["Base"]
       base.virtual_type!.metaclass.implements?(base).should be_false
+      base.virtual_type!.metaclass.implements?(base.metaclass).should be_true
+      base.virtual_type!.metaclass.implements?(base.metaclass.virtual_type!).should be_true
     end
 
     it "generic classes (1)" do

--- a/src/compiler/crystal/types.cr
+++ b/src/compiler/crystal/types.cr
@@ -3512,10 +3512,6 @@ module Crystal
       nil
     end
 
-    def implements?(other_type)
-      super || base_type.implements?(other_type)
-    end
-
     def to_s_with_options(io : IO, skip_union_parens : Bool = false, generic_args : Bool = true, codegen : Bool = false) : Nil
       instance_type.to_s_with_options(io, codegen: codegen)
       io << ".class"

--- a/src/compiler/crystal/types.cr
+++ b/src/compiler/crystal/types.cr
@@ -3512,6 +3512,10 @@ module Crystal
       nil
     end
 
+    def implements?(other_type)
+      base_type.metaclass.implements?(other_type)
+    end
+
     def to_s_with_options(io : IO, skip_union_parens : Bool = false, generic_args : Bool = true, codegen : Bool = false) : Nil
       instance_type.to_s_with_options(io, codegen: codegen)
       io << ".class"


### PR DESCRIPTION
This method override was plainly incorrect. Removing it defaults to the super implementation which is all that we want.

Fixes #12628