### PR TITLE
fix build for i386

### DIFF
--- a/src/gc.cr
+++ b/src/gc.cr
@@ -47,6 +47,16 @@ fun __crystal_realloc64(ptr : Void*, size : UInt64) : Void*
 end
 
 module GC
+{% if flag?(:i386) %}
+  record Stats,
+    # collections : UInt64,
+    # bytes_found : Int64,
+    heap_size : UInt32,
+    free_bytes : UInt32,
+    unmapped_bytes : UInt32,
+    bytes_since_gc : UInt32,
+    total_bytes : UInt32
+{% else %}
   record Stats,
     # collections : UInt64,
     # bytes_found : Int64,
@@ -55,7 +65,7 @@ module GC
     unmapped_bytes : UInt64,
     bytes_since_gc : UInt64,
     total_bytes : UInt64
-
+{% end %}
   record ProfStats,
     heap_size : UInt64,
     free_bytes : UInt64,


### PR DESCRIPTION
Here's the message, wasn't sure the best way to fix it:
```
crystal $ make FLAGS='--cross-compile --target=i386-linux-gnu'
Using /usr/bin/llvm-config-7 [version= 7.0.0]
CRYSTAL_CONFIG_BUILD_COMMIT="0fac5d5b0" CRYSTAL_CONFIG_PATH='$ORIGIN/../share/crystal/src' SOURCE_DATE_EPOCH="1665770035"  CRYSTAL_CONFIG_LIBRARY_PATH='$ORIGIN/../lib/crystal' ./bin/crystal build --cross-compile --target=i386-linux-gnu -D strict_multi_assign -Dwithout_interpreter  -o .build/crystal src/compiler/crystal.cr -D without_openssl -D without_zlib
Showing last frame. Use --error-trace for full trace.

In src/gc/boehm.cr:217:11

 217 | Stats.new(
             ^--
Error: no overload matches 'GC::Stats.new', heap_size: UInt32, free_bytes: UInt32, unmapped_bytes: UInt32, bytes_since_gc: UInt32, total_bytes: UInt32

Overloads are:
 - GC::Stats.new(heap_size : UInt64, free_bytes : UInt64, unmapped_bytes : UInt64, bytes_since_gc : UInt64, total_bytes : UInt64)
Makefile:187: recipe for target '.build/crystal' failed
make: *** [.build/crystal] Error 1
```