### PR TITLE
Refactor: Use `TypeNode#union_types`

### DIFF
--- a/spec/std/int_spec.cr
+++ b/spec/std/int_spec.cr
@@ -566,7 +566,7 @@ describe "Int" do
 
   describe "floor division //" do
     it "preserves type of lhs" do
-      {% for type in [UInt8, UInt16, UInt32, UInt64, Int8, Int16, Int32, Int64, UInt128, Int128] %}
+      {% for type in Int::Primitive.union_types %}
         ({{type}}.new(7) // 2).should be_a({{type}})
         ({{type}}.new(7) // 2.0).should be_a({{type}})
         ({{type}}.new(7) // 2.0_f32).should be_a({{type}})

--- a/spec/std/json/serialization_spec.cr
+++ b/spec/std/json/serialization_spec.cr
@@ -414,11 +414,11 @@ describe "JSON serialization" do
       Union(Bool, Array(Int32)).from_json(%(true)).should be_true
     end
 
-    {% for type in %w(Int8 Int16 Int32 Int64 UInt8 UInt16 UInt32 UInt64).map(&.id) %}
-        it "deserializes union with {{type}} (fast path)" do
-          Union({{type}}, Array(Int32)).from_json(%(#{ {{type}}::MAX })).should eq({{type}}::MAX)
-        end
-      {% end %}
+    {% for type in Int::Primitive.union_types %}
+      it "deserializes union with {{type}} (fast path)" do
+        Union({{type}}, Array(Int32)).from_json(%(#{ {{type}}::MAX })).should eq({{type}}::MAX)
+      end
+    {% end %}
 
     it "deserializes union with Float32 (fast path)" do
       Union(Float32, Array(Int32)).from_json(%(1)).should eq(1)

--- a/spec/std/math_spec.cr
+++ b/spec/std/math_spec.cr
@@ -46,7 +46,7 @@ describe "Math" do
       Math.isqrt(9).should eq(3)
       Math.isqrt(8).should eq(2)
       Math.isqrt(4).should eq(2)
-      {% for type in [UInt8, UInt16, UInt32, UInt64, UInt128, Int8, Int16, Int32, Int64, Int128] %}
+      {% for type in Int::Primitive.union_types %}
         %val = {{type}}.new 42
         %exp = {{type}}.new 6
         Math.isqrt(%val).should eq(%exp)

--- a/src/json/from_json.cr
+++ b/src/json/from_json.cr
@@ -124,20 +124,15 @@ def Bool.new(pull : JSON::PullParser)
   pull.read_bool
 end
 
-{% for type, method in {
-                         "Int8"   => "i8",
-                         "Int16"  => "i16",
-                         "Int32"  => "i32",
-                         "Int64"  => "i64",
-                         "UInt8"  => "u8",
-                         "UInt16" => "u16",
-                         "UInt32" => "u32",
-                         "UInt64" => "u64",
-                       } %}
+{% for type in Int::Primitive.union_types %}
+  {% signedness_char = type.stringify.downcase.chars.first %}
+  {% size = type.stringify.gsub(/\D+/, "") %}
+  {% method = "#{signedness_char.id}#{size.id}" %}
+
   def {{type.id}}.new(pull : JSON::PullParser)
     location = pull.location
     value =
-      {% if type == "UInt64" %}
+      {% if type == UInt64 %}
         pull.read_raw
       {% else %}
         pull.read_int

--- a/src/json/pull_parser.cr
+++ b/src/json/pull_parser.cr
@@ -409,7 +409,7 @@ class JSON::PullParser
     read_bool if kind.bool?
   end
 
-  {% for type in [Int8, Int16, Int32, Int64, UInt8, UInt16, UInt32] %}
+  {% for type in Int::Primitive.union_types - [UInt128, Int128] %}
     # Reads an {{type}} value and returns it.
     #
     # If the value is not an integer or does not fit in a {{type}} variable, it returns `nil`.

--- a/src/json/pull_parser.cr
+++ b/src/json/pull_parser.cr
@@ -409,7 +409,7 @@ class JSON::PullParser
     read_bool if kind.bool?
   end
 
-  {% for type in Int::Primitive.union_types - [UInt128, Int128] %}
+  {% for type in Int::Primitive.union_types.reject { |t| t == UInt128 || t == Int128 } %}
     # Reads an {{type}} value and returns it.
     #
     # If the value is not an integer or does not fit in a {{type}} variable, it returns `nil`.

--- a/src/number.cr
+++ b/src/number.cr
@@ -3,8 +3,6 @@ struct Number
   include Comparable(Number)
   include Steppable
 
-  alias Primitive = Int::Primitive | Float::Primitive
-
   # Returns the value zero in the respective type.
   #
   # ```
@@ -351,4 +349,11 @@ struct Number
   def negative? : Bool
     self < 0
   end
+end
+
+require "float"
+require "int"
+
+struct Number
+  alias Primitive = Int::Primitive | Float::Primitive
 end

--- a/src/primitives.cr
+++ b/src/primitives.cr
@@ -278,13 +278,11 @@ end
 # unions.
 
 {% begin %}
-  {% ints = %w(Int8 Int16 Int32 Int64 Int128 UInt8 UInt16 UInt32 UInt64 UInt128) %}
-  {% floats = %w(Float32 Float64) %}
-  {% nums = %w(Int8 Int16 Int32 Int64 Int128 UInt8 UInt16 UInt32 UInt64 UInt128 Float32 Float64) %}
+  {% ints, floats, nums = {Int::Primitive, Float::Primitive, Number::Primitive}.map(&.union_types) %}
   {% binaries = {"+" => "adding", "-" => "subtracting", "*" => "multiplying"} %}
 
   {% for num in nums %}
-    struct {{num.id}}
+    struct {{num}}
       {% for name, type in {
                              to_i: Int32, to_u: UInt32, to_f: Float64,
                              to_i8: Int8, to_i16: Int16, to_i32: Int32, to_i64: Int64, to_i128: Int128,
@@ -321,7 +319,7 @@ end
           # Returns `true` if `self` is {{desc.id}} *other*{% if op == "!=" && (!ints.includes?(num) || !ints.includes?(num2)) %}
           # or if `self` and *other* are unordered{% end %}.
           @[::Primitive(:binary)]
-          def {{op.id}}(other : {{num2.id}}) : Bool
+          def {{op.id}}(other : {{num2}}) : Bool
           end
         {% end %}
       {% end %}
@@ -329,7 +327,7 @@ end
   {% end %}
 
   {% for int in ints %}
-    struct {{int.id}}
+    struct {{int}}
       # Returns a `Char` that has the unicode codepoint of `self`,
       # without checking if this integer is in the range valid for
       # chars (`0..0xd7ff` and `0xe000..0x10ffff`).
@@ -350,49 +348,49 @@ end
           # Raises `OverflowError` in case of overflow.
           @[::Primitive(:binary)]
           @[Raises]
-          def {{op.id}}(other : {{int2.id}}) : self
+          def {{op.id}}(other : {{int2}}) : self
           end
 
           # Returns the result of {{desc.id}} `self` and *other*.
           # In case of overflow a wrapping is performed.
           @[::Primitive(:binary)]
-          def &{{op.id}}(other : {{int2.id}}) : self
+          def &{{op.id}}(other : {{int2}}) : self
           end
         {% end %}
 
         # Returns the result of performing a bitwise OR of `self`'s and *other*'s bits.
         @[::Primitive(:binary)]
-        def |(other : {{int2.id}}) : self
+        def |(other : {{int2}}) : self
         end
 
         # Returns the result of performing a bitwise AND of `self`'s and *other*'s bits.
         @[::Primitive(:binary)]
-        def &(other : {{int2.id}}) : self
+        def &(other : {{int2}}) : self
         end
 
         # Returns the result of performing a bitwise XOR of `self`'s and *other*'s bits.
         @[::Primitive(:binary)]
-        def ^(other : {{int2.id}}) : self
+        def ^(other : {{int2}}) : self
         end
 
         # :nodoc:
         @[::Primitive(:binary)]
-        def unsafe_shl(other : {{int2.id}}) : self
+        def unsafe_shl(other : {{int2}}) : self
         end
 
         # :nodoc:
         @[::Primitive(:binary)]
-        def unsafe_shr(other : {{int2.id}}) : self
+        def unsafe_shr(other : {{int2}}) : self
         end
 
         # :nodoc:
         @[::Primitive(:binary)]
-        def unsafe_div(other : {{int2.id}}) : self
+        def unsafe_div(other : {{int2}}) : self
         end
 
         # :nodoc:
         @[::Primitive(:binary)]
-        def unsafe_mod(other : {{int2.id}}) : self
+        def unsafe_mod(other : {{int2}}) : self
         end
       {% end %}
 
@@ -400,7 +398,7 @@ end
         {% for op, desc in binaries %}
           # Returns the result of {{desc.id}} `self` and *other*.
           @[::Primitive(:binary)]
-          def {{op.id}}(other : {{float.id}}) : {{float.id}}
+          def {{op.id}}(other : {{float}}) : {{float}}
           end
         {% end %}
       {% end %}
@@ -408,24 +406,24 @@ end
   {% end %}
 
   {% for float in floats %}
-    struct {{float.id}}
+    struct {{float}}
       {% for num in nums %}
         {% for op, desc in binaries %}
           # Returns the result of {{desc.id}} `self` and *other*.
           @[::Primitive(:binary)]
-          def {{op.id}}(other : {{num.id}}) : self
+          def {{op.id}}(other : {{num}}) : self
           end
         {% end %}
 
         # Returns the float division of `self` and *other*.
         @[::Primitive(:binary)]
-        def fdiv(other : {{num.id}}) : self
+        def fdiv(other : {{num}}) : self
         end
       {% end %}
 
       # Returns the result of division `self` and *other*.
       @[::Primitive(:binary)]
-      def /(other : {{float.id}}) : {{float.id}}
+      def /(other : {{float}}) : {{float}}
       end
     end
   {% end %}

--- a/src/random/secure.cr
+++ b/src/random/secure.cr
@@ -27,7 +27,7 @@ module Random::Secure
     Crystal::System::Random.random_bytes(buf)
   end
 
-  {% for type in [UInt8, UInt16, UInt32, UInt64, UInt128] %}
+  {% for type in Int::Unsigned.union_types %}
     # Generates a random integer of a given type. The number of bytes to
     # generate can be limited; by default it will generate as many bytes as
     # needed to fill the integer size.
@@ -55,7 +55,7 @@ module Random::Secure
     end
   {% end %}
 
-  {% for type in [Int8, Int16, Int32, Int64, Int128] %}
+  {% for type in Int::Signed.union_types %}
     private def rand_type(type : {{type}}.class, needed_bytes = sizeof({{type}})) : {{type}}
       result = rand_type({{"U#{type}".id}}, needed_bytes)
       {{type}}.new!(result)

--- a/src/yaml/from_yaml.cr
+++ b/src/yaml/from_yaml.cr
@@ -56,7 +56,7 @@ def Bool.new(ctx : YAML::ParseContext, node : YAML::Nodes::Node)
   parse_scalar(ctx, node, self)
 end
 
-{% for type in %w(Int8 Int16 Int32 Int64 UInt8 UInt16 UInt32 UInt64) %}
+{% for type in Int::Primitive.union_types %}
   def {{type.id}}.new(ctx : YAML::ParseContext, node : YAML::Nodes::Node)
     {{type.id}}.new! parse_scalar(ctx, node, Int64)
   end


### PR DESCRIPTION
Now that `UInt128` and `Int128` are supported, #5018 can be merged with a few small updates.

Some slight rearrangement was required to prevent a recursive alias when declaring `Number::Primitive`.

Closes #5018