### PR TITLE
Style: Remove explicit returns from the codebase

### DIFF
--- a/samples/spectral-norm.cr
+++ b/samples/spectral-norm.cr
@@ -1,7 +1,7 @@
 # Copied with little modifications from: https://github.com/wmoxam/Ruby-Benchmarks-Game/blob/master/benchmarks/spectral-norm.rb
 
 def eval_A(i, j)
-  return 1.0_f64 / ((i + j) * (i + j + 1.0) / 2.0 + i + 1.0)
+  1.0_f64 / ((i + j) * (i + j + 1.0) / 2.0 + i + 1.0)
 end
 
 def eval_A_times_u(u)

--- a/src/bit_array.cr
+++ b/src/bit_array.cr
@@ -54,7 +54,7 @@ struct BitArray
     # NOTE: If BitArray implements resizing, there may be more than 1 binary
     # representation and their hashes for equivalent BitArrays after a downsize as the
     # discarded bits may not have been zeroed.
-    return LibC.memcmp(@bits, other.@bits, bytesize) == 0
+    LibC.memcmp(@bits, other.@bits, bytesize) == 0
   end
 
   def unsafe_fetch(index : Int) : Bool

--- a/src/compiler/crystal/codegen/call.cr
+++ b/src/compiler/crystal/codegen/call.cr
@@ -462,7 +462,7 @@ class Crystal::CodeGenVisitor
 
         @last = self_type.passed_as_self? ? call_args.first : type_id(self_type)
         inline_call_return_value target_def, body
-        return true
+        true
       else
         false
       end

--- a/src/compiler/crystal/codegen/class_var.cr
+++ b/src/compiler/crystal/codegen/class_var.cr
@@ -210,7 +210,7 @@ class Crystal::CodeGenVisitor
     global_name = class_var_global_name(class_var)
     global = get_global global_name, class_var.type, class_var
     global = ensure_class_var_in_this_module(global, class_var)
-    return global
+    global
   end
 
   def read_virtual_class_var_ptr(class_var, owner)

--- a/src/compiler/crystal/codegen/match.cr
+++ b/src/compiler/crystal/codegen/match.cr
@@ -41,7 +41,7 @@ class Crystal::CodeGenVisitor
     match_fun_name = "~match<#{type}>"
     func = @main_mod.functions[match_fun_name]? || create_match_fun(match_fun_name, type)
     func = check_main_fun match_fun_name, func
-    return call func, [type_id] of LLVM::Value
+    call func, [type_id] of LLVM::Value
   end
 
   private def create_match_fun(name, type)

--- a/src/compiler/crystal/codegen/primitives.cr
+++ b/src/compiler/crystal/codegen/primitives.cr
@@ -100,20 +100,20 @@ class Crystal::CodeGenVisitor
 
   def codegen_binary_op(op, t1 : CharType, t2 : CharType, p1, p2)
     case op
-    when "==" then return builder.icmp LLVM::IntPredicate::EQ, p1, p2
-    when "!=" then return builder.icmp LLVM::IntPredicate::NE, p1, p2
-    when "<"  then return builder.icmp LLVM::IntPredicate::ULT, p1, p2
-    when "<=" then return builder.icmp LLVM::IntPredicate::ULE, p1, p2
-    when ">"  then return builder.icmp LLVM::IntPredicate::UGT, p1, p2
-    when ">=" then return builder.icmp LLVM::IntPredicate::UGE, p1, p2
+    when "==" then builder.icmp LLVM::IntPredicate::EQ, p1, p2
+    when "!=" then builder.icmp LLVM::IntPredicate::NE, p1, p2
+    when "<"  then builder.icmp LLVM::IntPredicate::ULT, p1, p2
+    when "<=" then builder.icmp LLVM::IntPredicate::ULE, p1, p2
+    when ">"  then builder.icmp LLVM::IntPredicate::UGT, p1, p2
+    when ">=" then builder.icmp LLVM::IntPredicate::UGE, p1, p2
     else           raise "BUG: trying to codegen #{t1} #{op} #{t2}"
     end
   end
 
   def codegen_binary_op(op, t1 : SymbolType, t2 : SymbolType, p1, p2)
     case op
-    when "==" then return builder.icmp LLVM::IntPredicate::EQ, p1, p2
-    when "!=" then return builder.icmp LLVM::IntPredicate::NE, p1, p2
+    when "==" then builder.icmp LLVM::IntPredicate::EQ, p1, p2
+    when "!=" then builder.icmp LLVM::IntPredicate::NE, p1, p2
     else           raise "BUG: trying to codegen #{t1} #{op} #{t2}"
     end
   end
@@ -203,7 +203,7 @@ class Crystal::CodeGenVisitor
     )
     codegen_raise_overflow_cond overflow
 
-    return codegen_binary_op_with_overflow("*", t1, @program.int_type(false, t2.bytes), p1, p2)
+    codegen_binary_op_with_overflow("*", t1, @program.int_type(false, t2.bytes), p1, p2)
   end
 
   def codegen_mul_signed_unsigned_with_overflow(t1, t2, p1, p2)

--- a/src/compiler/crystal/exception.cr
+++ b/src/compiler/crystal/exception.cr
@@ -30,15 +30,15 @@ module Crystal
       if filename.is_a? VirtualFile
         loc = filename.expanded_location
         if loc
-          return true_filename loc.filename
+          true_filename loc.filename
         else
-          return ""
+          ""
         end
       else
         if filename
-          return filename
+          filename
         else
-          return ""
+          ""
         end
       end
     end

--- a/src/compiler/crystal/interpreter/compiler.cr
+++ b/src/compiler/crystal/interpreter/compiler.cr
@@ -1981,7 +1981,7 @@ class Crystal::Repl::Compiler < Crystal::Visitor
       pop aligned_sizeof_type(node), node: nil
     end
 
-    return false
+    false
   end
 
   private def create_compiled_def(node : Call, target_def : Def)

--- a/src/compiler/crystal/macros/methods.cr
+++ b/src/compiler/crystal/macros/methods.cr
@@ -342,9 +342,9 @@ module Crystal
 
     def to_string(context)
       case self
-      when StringLiteral then return self.value
-      when SymbolLiteral then return self.value
-      when MacroId       then return self.value
+      when StringLiteral then self.value
+      when SymbolLiteral then self.value
+      when MacroId       then self.value
       else
         raise "expected #{context} to be a StringLiteral, SymbolLiteral or MacroId, not #{class_desc}"
       end

--- a/src/compiler/crystal/semantic/call.cr
+++ b/src/compiler/crystal/semantic/call.cr
@@ -579,7 +579,7 @@ class Crystal::Call
       if index || nilable
         indexer_def = yield instance_type, (index || -1)
         indexer_match = Match.new(indexer_def, arg_types, MatchContext.new(owner, owner))
-        return Matches.new(ZeroOneOrMany(Match).new(indexer_match), true)
+        Matches.new(ZeroOneOrMany(Match).new(indexer_match), true)
       else
         raise "missing key '#{name}' for named tuple #{owner}"
       end

--- a/src/compiler/crystal/semantic/filters.cr
+++ b/src/compiler/crystal/semantic/filters.cr
@@ -142,9 +142,9 @@ module Crystal
 
       case other
       when NilType
-        return nil
+        nil
       when UnionType
-        return Type.merge(other.union_types.reject &.nil_type?)
+        Type.merge(other.union_types.reject &.nil_type?)
       else
         other
       end

--- a/src/compiler/crystal/semantic/main_visitor.cr
+++ b/src/compiler/crystal/semantic/main_visitor.cr
@@ -1398,7 +1398,8 @@ module Crystal
       expansion.accept self
       node.expanded = expansion
       node.bind_to(expanded)
-      return false
+
+      false
     end
 
     # If it's a super or previous_def call inside an initialize we treat

--- a/src/compiler/crystal/semantic/restrictions.cr
+++ b/src/compiler/crystal/semantic/restrictions.cr
@@ -1474,7 +1474,7 @@ module Crystal
 
       restricted = typedef.restrict(other, context)
       if restricted == typedef
-        return self
+        self
       elsif restricted.is_a?(UnionType)
         program.type_merge(restricted.union_types.map { |t| t == typedef ? self : t })
       else

--- a/src/compiler/crystal/semantic/type_intersect.cr
+++ b/src/compiler/crystal/semantic/type_intersect.cr
@@ -154,7 +154,7 @@ module Crystal
 
       restricted = common_descendent(type1.typedef, type2)
       if restricted == type1.typedef
-        return type1
+        type1
       elsif restricted.is_a?(UnionType)
         type1.program.type_merge(restricted.union_types.map { |t| t == type1.typedef ? type1 : t })
       else

--- a/src/compiler/crystal/syntax/parser.cr
+++ b/src/compiler/crystal/syntax/parser.cr
@@ -3425,7 +3425,7 @@ module Crystal
       end
 
       a_then, a_else = a_else, a_then if is_unless
-      return MacroIf.new(cond, a_then, a_else).at_end(token_end_location)
+      MacroIf.new(cond, a_then, a_else).at_end(token_end_location)
     end
 
     def parse_expression_inside_macro
@@ -4653,7 +4653,7 @@ module Crystal
       else
         skip_space
       end
-      return CallArgs.new args, nil, nil, named_args, false, end_location, has_parentheses: allow_newline
+      CallArgs.new args, nil, nil, named_args, false, end_location, has_parentheses: allow_newline
     end
 
     def parse_named_args(location, first_name = nil, allow_newline = false)

--- a/src/compiler/crystal/tools/context.cr
+++ b/src/compiler/crystal/tools/context.cr
@@ -161,14 +161,14 @@ module Crystal
 
       if @contexts.empty?
         if @found_untyped_def
-          return ContextResult.new("failed", "no context information found (methods which are never called don't have a context)")
+          ContextResult.new("failed", "no context information found (methods which are never called don't have a context)")
         else
-          return ContextResult.new("failed", "no context information found")
+          ContextResult.new("failed", "no context information found")
         end
       else
         res = ContextResult.new("ok", "#{@contexts.size} possible context#{@contexts.size > 1 ? "s" : ""} found")
         res.contexts = @contexts
-        return res
+        res
       end
     end
 

--- a/src/compiler/crystal/tools/expand.cr
+++ b/src/compiler/crystal/tools/expand.cr
@@ -116,11 +116,11 @@ module Crystal
       result.node.accept(self)
 
       if @found_nodes.empty?
-        return ExpandResult.new("failed", @message)
+        ExpandResult.new("failed", @message)
       else
         res = ExpandResult.new("ok", "#{@found_nodes.size} expansion#{@found_nodes.size > 1 ? "s" : ""} found")
         res.expansions = @found_nodes.map { |node| ExpandResult::Expansion.build(node) }
-        return res
+        res
       end
     end
 

--- a/src/compiler/crystal/tools/formatter.cr
+++ b/src/compiler/crystal/tools/formatter.cr
@@ -1807,7 +1807,7 @@ module Crystal
       write_indent
       write "end"
       next_token
-      return false
+      false
     end
 
     def visit(node : MacroLiteral)
@@ -3489,18 +3489,15 @@ module Crystal
         skip_semicolon_or_space_or_newline
         check_end
         write "; end"
-        next_token
-        return false
       else
         skip_space_or_newline
         check_end
         write_line
         write_indent
         write "end"
-        next_token
-        return false
       end
 
+      next_token
       false
     end
 
@@ -4319,25 +4316,25 @@ module Crystal
 
     def visit(node : Block)
       # Handled in format_block
-      return false
+      false
     end
 
     def visit(node : When)
       # Handled in format_when
-      return false
+      false
     end
 
     def visit(node : Rescue)
       # Handled in visit(node : ExceptionHandler)
-      return false
+      false
     end
 
     def visit(node : MacroId)
-      return false
+      false
     end
 
     def visit(node : MetaVar)
-      return false
+      false
     end
 
     def visit(node : Asm)

--- a/src/compiler/crystal/tools/git.cr
+++ b/src/compiler/crystal/tools/git.cr
@@ -4,8 +4,7 @@ module Crystal::Git
   # Tries to run git command with args.
   # Yields block if exec fails or process status is not success.
   def self.git_command(args, output : Process::Stdio = Process::Redirect::Close)
-    status = Process.run(executable, args, output: output)
-    return status.success?
+    Process.run(executable, args, output: output).success?
   rescue IO::Error
     false
   end

--- a/src/compiler/crystal/tools/implementations.cr
+++ b/src/compiler/crystal/tools/implementations.cr
@@ -98,11 +98,11 @@ module Crystal
       result.node.accept(self)
 
       if @locations.empty?
-        return ImplementationResult.new("failed", "no implementations or method call found")
+        ImplementationResult.new("failed", "no implementations or method call found")
       else
         res = ImplementationResult.new("ok", "#{@locations.size} implementation#{@locations.size > 1 ? "s" : ""} found")
         res.implementations = @locations.map { |loc| ImplementationTrace.build(loc) }
-        return res
+        res
       end
     end
 

--- a/src/crystal/system/unix/file.cr
+++ b/src/crystal/system/unix/file.cr
@@ -43,7 +43,7 @@ module Crystal::System::File
       ::File::Info.new(stat)
     else
       if Errno.value.in?(Errno::ENOENT, Errno::ENOTDIR)
-        return nil
+        nil
       else
         raise ::File::Error.from_errno("Unable to get file info", file: path)
       end

--- a/src/crystal/system/unix/socket.cr
+++ b/src/crystal/system/unix/socket.cr
@@ -126,7 +126,7 @@ module Crystal::System::Socket
     end
 
     if Errno.value == Errno::ENOPROTOOPT
-      return false
+      false
     else
       raise ::Socket::Error.from_errno("getsockopt")
     end

--- a/src/crystal/system/win32/dir.cr
+++ b/src/crystal/system/win32/dir.cr
@@ -27,11 +27,11 @@ module Crystal::System::Dir
       handle = LibC.FindFirstFileW(dir.query, out data)
       if handle != LibC::INVALID_HANDLE_VALUE
         dir.handle = handle
-        return data_to_entry(data)
+        data_to_entry(data)
       else
         error = WinError.value
         if error == WinError::ERROR_FILE_NOT_FOUND
-          return nil
+          nil
         else
           raise ::File::Error.from_os_error("Error reading directory entries", error, file: path)
         end
@@ -39,11 +39,11 @@ module Crystal::System::Dir
     else
       # Use FindNextFile
       if LibC.FindNextFileW(dir.handle, out data_) != 0
-        return data_to_entry(data_)
+        data_to_entry(data_)
       else
         error = WinError.value
         if error == WinError::ERROR_NO_MORE_FILES
-          return nil
+          nil
         else
           raise ::File::Error.from_os_error("Error reading directory entries", error, file: path)
         end

--- a/src/crystal/system/win32/file.cr
+++ b/src/crystal/system/win32/file.cr
@@ -50,7 +50,7 @@ module Crystal::System::File
   private def self.check_not_found_error(message, path)
     error = WinError.value
     if NOT_FOUND_ERRORS.includes? error
-      return nil
+      nil
     else
       raise ::File::Error.from_os_error(message, error, file: path)
     end

--- a/src/env.cr
+++ b/src/env.cr
@@ -64,7 +64,7 @@ module ENV
   # the *key* does not exist.
   def self.fetch(key : String, &block : String -> T) : String | T forall T
     if value = Crystal::System::Env.get(key)
-      return value
+      value
     else
       yield key
     end

--- a/src/float/printer/grisu3.cr
+++ b/src/float/printer/grisu3.cr
@@ -156,7 +156,7 @@ module Float::Printer::Grisu3
     #   Since too_low = too_high - unsafe_interval this is equivalent to
     #      [too_high - unsafe_interval + 4 ulp; too_high - 2 ulp]
     #   Conceptually we have: rest ~= too_high - buffer
-    return (2 &* unit <= rest) && (rest <= unsafe_interval &- 4 &* unit)
+    (2 &* unit <= rest) && (rest <= unsafe_interval &- 4 &* unit)
   end
 
   # Generates the digits of input number *w*.

--- a/src/float/printer/ieee.cr
+++ b/src/float/printer/ieee.cr
@@ -120,7 +120,7 @@ module Float::Printer::IEEE
              {(w.frac << 1) - 1, w.exp - 1}
            end
     m_minus = DiyFP.new(f << (e - m_plus.exp), m_plus.exp)
-    return {minus: m_minus, plus: m_plus}
+    {minus: m_minus, plus: m_plus}
   end
 
   def normalized_boundaries(v : Float32) : {minus: DiyFP, plus: DiyFP}
@@ -139,7 +139,7 @@ module Float::Printer::IEEE
              {(w.frac << 1) - 1, w.exp - 1}
            end
     m_minus = DiyFP.new(f << (e - m_plus.exp), m_plus.exp)
-    return {minus: m_minus, plus: m_plus}
+    {minus: m_minus, plus: m_plus}
   end
 
   def frac_and_exp(v : Float64) : {UInt64, Int32}

--- a/src/http/common.cr
+++ b/src/http/common.cr
@@ -128,7 +128,7 @@ module HTTP
     end
 
     name, value = parse_header(line)
-    return HeaderLine.new name: name, value: value, bytesize: line.bytesize
+    HeaderLine.new name: name, value: value, bytesize: line.bytesize
   end
 
   private def self.check_content_type_charset(body, headers)

--- a/src/http/headers.cr
+++ b/src/http/headers.cr
@@ -300,7 +300,7 @@ struct HTTP::Headers
   end
 
   def valid_value?(value) : Bool
-    return invalid_value_char(value).nil?
+    invalid_value_char(value).nil?
   end
 
   forward_missing_to @hash

--- a/src/log/spec.cr
+++ b/src/log/spec.cr
@@ -112,7 +112,7 @@ class Log
         matches = yield entry
         if matches
           @entry = entry
-          return self
+          self
         else
           fail("No matching entries found, expected #{description}, but got #{entry.severity} with #{entry.message.inspect}", file, line)
         end

--- a/src/named_tuple.cr
+++ b/src/named_tuple.cr
@@ -676,8 +676,7 @@ struct NamedTuple
     {% for key in T %}
       return false unless self[{{key.symbolize}}] == other[{{key.symbolize}}]?
     {% end %}
-
-    return true
+    true
   end
 
   # Returns a named tuple with the same keys but with cloned values, using the `clone` method.

--- a/src/path.cr
+++ b/src/path.cr
@@ -623,7 +623,7 @@ struct Path
       end
 
       @reader = reader
-      return 0
+      0
     end
   end
 
@@ -1031,7 +1031,7 @@ struct Path
       end
     end
 
-    return path
+    path
   end
 
   # :ditto:

--- a/src/raise.cr
+++ b/src/raise.cr
@@ -86,7 +86,7 @@ private def traverse_eh_table(leb, start, ip, actions)
     end
   end
 
-  return nil
+  nil
 end
 
 {% if flag?(:interpreted) %}

--- a/src/random/pcg32.cr
+++ b/src/random/pcg32.cr
@@ -67,7 +67,7 @@ class Random::PCG32
     @state = oldstate &* PCG_DEFAULT_MULTIPLIER_64 &+ @inc
     xorshifted = UInt32.new!(((oldstate >> 18) ^ oldstate) >> 27)
     rot = UInt32.new!(oldstate >> 59)
-    return UInt32.new!(xorshifted.rotate_right(rot))
+    UInt32.new!(xorshifted.rotate_right(rot))
   end
 
   def jump(delta)

--- a/src/range.cr
+++ b/src/range.cr
@@ -507,7 +507,7 @@ struct Range(B, E)
       begin_value = @range.begin
 
       return stop if !begin_value.nil? && @current <= begin_value
-      return @current = @current.pred
+      @current = @current.pred
     end
   end
 

--- a/src/regex/match_data.cr
+++ b/src/regex/match_data.cr
@@ -397,7 +397,7 @@ class Regex
       return false unless regex == other.regex
       return false unless string == other.string
 
-      return @ovector.memcmp(other.@ovector, size * 2) == 0
+      @ovector.memcmp(other.@ovector, size * 2) == 0
     end
 
     # See `Object#hash(hasher)`

--- a/src/spec/expectations.cr
+++ b/src/spec/expectations.cr
@@ -35,10 +35,10 @@ module Spec
             MSG
         end
 
-        return <<-MSG
-          Expected size: #{expected_value.size}
-               got size: #{actual_value.size}
-          MSG
+        <<-MSG
+        Expected size: #{expected_value.size}
+              got size: #{actual_value.size}
+        MSG
       else
         expected = expected_value.inspect
         got = actual_value.inspect

--- a/src/string.cr
+++ b/src/string.cr
@@ -987,8 +987,7 @@ class String
 
     byte_index = char_index_to_byte_index(index)
     if byte_index && byte_index < @bytesize
-      reader = Char::Reader.new(self, pos: byte_index)
-      return reader.current_char
+      Char::Reader.new(self, pos: byte_index).current_char
     else
       yield
     end
@@ -1088,9 +1087,9 @@ class String
 
     case count
     when 0
-      return self
+      self
     when size
-      return ""
+      ""
     else
       if single_byte_optimizable?
         byte_delete_at(start, count, count)

--- a/src/struct.cr
+++ b/src/struct.cr
@@ -69,9 +69,9 @@ struct Struct
       {% for ivar in @type.instance_vars %}
         return false unless @{{ivar.id}} == other.@{{ivar.id}}
       {% end %}
-      return true
+      true
     else
-      return false
+      false
     end
   end
 

--- a/src/time/location/loader.cr
+++ b/src/time/location/loader.cr
@@ -46,7 +46,7 @@ class Time::Location
 
     mtime = File.info(path).modification_time
     if (cache = @@location_cache[name]?) && cache[:time] == mtime
-      return cache[:location]
+      cache[:location]
     else
       File.open(path) do |file|
         location = yield file


### PR DESCRIPTION
Removes explicit returns from the codebase.

One small step towards making the codebase linter friendly.
Also harmless to keep them in.

---------

This is part of a handful of small PRs, each focussing on a single style issue that is unlikely to be found in other Crystal projects as they are picked up by the widely used [ameba](https://github.com/crystal-ameba/ameba) linter