### PR TITLE
Macros: Test addition between `ArrayLiteral` and `TupleLiteral`

### DIFF
--- a/spec/compiler/macro/macro_methods_spec.cr
+++ b/spec/compiler/macro/macro_methods_spec.cr
@@ -865,8 +865,18 @@ module Crystal
         assert_macro %({{ [1, 2, 3].includes?(4) }}), %(false)
       end
 
-      it "executes +" do
-        assert_macro %({{ [1, 2] + [3, 4, 5] }}), %([1, 2, 3, 4, 5])
+      describe "#+" do
+        context "with TupleLiteral argument" do
+          it "concatenates the literals into an ArrayLiteral" do
+            assert_macro %({{ [1, 2] + {3, 4, 5} }}), %([1, 2, 3, 4, 5])
+          end
+        end
+
+        context "with ArrayLiteral argument" do
+          it "concatenates the literals into an ArrayLiteral" do
+            assert_macro %({{ [1, 2] + [3, 4, 5] }}), %([1, 2, 3, 4, 5])
+          end
+        end
       end
 
       it "executes [] with range" do
@@ -1372,8 +1382,18 @@ module Crystal
         assert_macro %({{ {1, 2, 3}.includes?(4) }}), %(false)
       end
 
-      it "executes +" do
-        assert_macro %({{ {1, 2} + {3, 4, 5} }}), %({1, 2, 3, 4, 5})
+      describe "#+" do
+        context "with TupleLiteral argument" do
+          it "concatenates the literals into a TupleLiteral" do
+            assert_macro %({{ {1, 2} + {3, 4, 5} }}), %({1, 2, 3, 4, 5})
+          end
+        end
+
+        context "with ArrayLiteral argument" do
+          it "concatenates the literals into a TupleLiteral" do
+            assert_macro %({{ {1, 2} + [3, 4, 5] }}), %({1, 2, 3, 4, 5})
+          end
+        end
       end
     end
 


### PR DESCRIPTION
Adds a few missing tests of the behaviour of addition between `ArrayLiteral`s and `TupleLiteral`s.

[The following behaviour is tested...](https://carc.in/#/r/dxas)

```crystal
{%
  a = [1, 2, 3, 4]
  b = {3, 4, 5, 6}
  c = a + b
  d = b + a
  puts c # => [1, 2, 3, 4, 3, 4, 5, 6]
  puts d # => {3, 4, 5, 6, 1, 2, 3, 4}
%}
```