### PR TITLE
[CI] Drop Alpine libreSSL 3.1 test

### DIFF
--- a/.github/workflows/openssl.yml
+++ b/.github/workflows/openssl.yml
@@ -33,21 +33,6 @@ jobs:
         run: bin/crystal eval 'require "openssl"; p! LibSSL::OPENSSL_VERSION, LibSSL::LIBRESSL_VERSION'
       - name: Run OpenSSL specs
         run: bin/crystal spec spec/std/openssl/
-  libressl31:
-    runs-on: ubuntu-latest
-    name: "LibreSSL 3.1"
-    container: crystallang/crystal:1.5.0-alpine
-    steps:
-      - name: Download Crystal source
-        uses: actions/checkout@v2
-      - name: Uninstall openssl
-        run: apk del openssl-dev openssl-libs-static
-      - name: Install libressl 3.1
-        run: apk add "libressl-dev=~3.1"
-      - name: Check LibSSL version
-        run: bin/crystal eval 'require "openssl"; p! LibSSL::OPENSSL_VERSION, LibSSL::LIBRESSL_VERSION'
-      - name: Run OpenSSL specs
-        run: bin/crystal spec spec/std/openssl/
   libressl34:
     runs-on: ubuntu-latest
     name: "LibreSSL 3.4"


### PR DESCRIPTION
The base image for Crystal 1.6 changes to Alpine 3.16 which no longer supports libreSSL 3.1.

We should generally pin the repository, so changes in the base image won't affect the installability.

Alpine 3.13 is the last version with libreSSL 3.1 and it's almost EOL. We could add libreSSL 3.3 from Alpine 3.14, but I think doing the most recent two version should be good enough.
I'll add libreSSL 3.5 in a follow-up, this is just a minimal change to get green CI for https://github.com/crystal-lang/crystal/pull/12640
