### PR TITLE
Use mutating collection methods

### DIFF
--- a/src/channel.cr
+++ b/src/channel.cr
@@ -425,8 +425,8 @@ class Channel(T)
     # This is to avoid deadlocks between concurrent `select` calls
     ops_locks = ops
       .to_a
-      .uniq(&.lock_object_id)
-      .sort_by(&.lock_object_id)
+      .uniq!(&.lock_object_id)
+      .sort_by!(&.lock_object_id)
 
     ops_locks.each &.lock
 

--- a/src/compiler/crystal/semantic/call_error.cr
+++ b/src/compiler/crystal/semantic/call_error.cr
@@ -244,7 +244,7 @@ class Crystal::Call
     return unless call_errors.all?(T)
 
     call_errors = call_errors.map &.as(T)
-    all_names = call_errors.flat_map(&.names).uniq
+    all_names = call_errors.flat_map(&.names).uniq!
     names_in_all_overloads = all_names.select do |missing_name|
       call_errors.all? &.names.includes?(missing_name)
     end
@@ -266,7 +266,7 @@ class Crystal::Call
     call_errors = call_errors.map &.as(ArgumentsTypeMismatch)
     argument_type_mismatches = call_errors.flat_map(&.errors)
 
-    all_indexes_or_names = argument_type_mismatches.map(&.index_or_name).uniq
+    all_indexes_or_names = argument_type_mismatches.map(&.index_or_name).uniq!
     indexes_or_names_in_all_overloads = all_indexes_or_names.select do |index_or_name|
       call_errors.all? &.errors.any? &.index_or_name.==(index_or_name)
     end
@@ -277,7 +277,7 @@ class Crystal::Call
     index_or_name = indexes_or_names_in_all_overloads.first
 
     mismatches = argument_type_mismatches.select(&.index_or_name.==(index_or_name))
-    expected_types = mismatches.map(&.expected_type).uniq.sort_by(&.to_s)
+    expected_types = mismatches.map(&.expected_type).uniq!.sort_by!(&.to_s)
     actual_type = mismatches.first.actual_type
 
     arg =

--- a/src/compiler/crystal/semantic/exhaustiveness_checker.cr
+++ b/src/compiler/crystal/semantic/exhaustiveness_checker.cr
@@ -395,7 +395,7 @@ struct Crystal::ExhaustivenessChecker
         gathered_missing_cases = [] of String
 
         # See if a case is missing for both false and true: show it as Bool in that case
-        missing_cases_per_bool.values.flatten.uniq.each do |missing_case|
+        missing_cases_per_bool.values.flatten.uniq!.each do |missing_case|
           if {true, false}.all? { |bool| missing_cases_per_bool[bool]?.try &.includes?(missing_case) }
             gathered_missing_cases << "Bool, #{missing_case}"
             {true, false}.each { |bool| missing_cases_per_bool[bool]?.try &.delete(missing_case) }
@@ -526,7 +526,7 @@ struct Crystal::ExhaustivenessChecker
         gathered_missing_cases = [] of String
 
         # See if a case is missing for all members: show it as the enum name in that case
-        missing_cases_per_member.values.flatten.uniq.each do |missing_case|
+        missing_cases_per_member.values.flatten.uniq!.each do |missing_case|
           if @members.all? { |member| missing_cases_per_member[member]?.try &.includes?(missing_case) }
             gathered_missing_cases << "#{@type}, #{missing_case}"
             @members.each { |member| missing_cases_per_member[member]?.try &.delete(missing_case) }

--- a/src/compiler/crystal/semantic/restrictions.cr
+++ b/src/compiler/crystal/semantic/restrictions.cr
@@ -511,7 +511,7 @@ module Crystal
 
     def required_named_arguments
       if (splat_index = self.def.splat_index) && splat_index != self.def.args.size - 1
-        self.def.args[splat_index + 1..-1].select { |arg| !arg.default_value }.sort_by &.external_name
+        self.def.args[splat_index + 1..-1].select { |arg| !arg.default_value }.sort_by! &.external_name
       else
         nil
       end
@@ -548,7 +548,7 @@ module Crystal
 
     def required_named_arguments
       if (splat_index = self.splat_index) && splat_index != args.size - 1
-        args[splat_index + 1..-1].select { |arg| !arg.default_value }.sort_by &.external_name
+        args[splat_index + 1..-1].select { |arg| !arg.default_value }.sort_by! &.external_name
       else
         nil
       end

--- a/src/http/headers.cr
+++ b/src/http/headers.cr
@@ -282,7 +282,7 @@ struct HTTP::Headers
   end
 
   def pretty_print(pp)
-    pp.list("HTTP::Headers{", @hash.keys.sort_by(&.name), "}") do |key|
+    pp.list("HTTP::Headers{", @hash.keys.sort_by!(&.name), "}") do |key|
       pp.group do
         key.name.pretty_print(pp)
         pp.text " =>"


### PR DESCRIPTION
Banged collection methods (e.g. `#sort!` and `#uniq!`)  save the allocation of an intermediate collection.

-----

This is part of a handful of small PRs, each focussing on a single style issue that is unlikely to be found in other Crystal projects as they are picked up by the widely used [ameba](https://github.com/crystal-ameba/ameba) linter.