### PR TITLE
Lint: Remove useless assignments

### DIFF
--- a/samples/binary-trees.cr
+++ b/samples/binary-trees.cr
@@ -31,7 +31,6 @@ stretch_depth = max_depth + 1
 stretch_tree = bottom_up_tree(0, stretch_depth)
 
 puts "stretch tree of depth #{stretch_depth}\t check: #{item_check(stretch_tree)}"
-stretch_tree = nil
 
 long_lived_tree = bottom_up_tree(0, max_depth)
 

--- a/samples/mt_gc_test.cr
+++ b/samples/mt_gc_test.cr
@@ -110,7 +110,7 @@ class Context
     @threads_state.set(State::Wait)
 
     # spin wait for threads to finish the round
-    while (c = @threads_reached.get) < @threads
+    while @threads_reached.get < @threads
     end
     log "All threads_reached!"
   end

--- a/samples/red_black_tree.cr
+++ b/samples/red_black_tree.cr
@@ -328,10 +328,10 @@ class RedBlackTreeRunner
     @n = n
 
     random = Random.new(1234) # repeatable random seq
-    @a1 = Array(Int32).new(n) { rand(99_999) }
+    @a1 = Array(Int32).new(n) { random.rand(99_999) }
 
     random = Random.new(4321) # repeatable random seq
-    @a2 = Array(Int32).new(n) { rand(99_999) }
+    @a2 = Array(Int32).new(n) { random.rand(99_999) }
 
     @tree = RedBlackTree.new
   end

--- a/samples/wordcount.cr
+++ b/samples/wordcount.cr
@@ -50,4 +50,4 @@ end
 
 in_filenames = ARGV
 
-do_work ARGV, output_filename, ignore_case
+do_work in_filenames, output_filename, ignore_case

--- a/spec/compiler/macro/macro_methods_spec.cr
+++ b/spec/compiler/macro/macro_methods_spec.cr
@@ -3052,13 +3052,13 @@ module Crystal
       it "returns true if file exists" do
         run(%q<
           {{file_exists?("#{__DIR__}/../data/build")}} ? 10 : 20
-          >, filename = __FILE__).to_i.should eq(10)
+          >, filename: __FILE__).to_i.should eq(10)
       end
 
       it "returns false if file doesn't exist" do
         run(%q<
           {{file_exists?("#{__DIR__}/../data/build_foo")}} ? 10 : 20
-          >, filename = __FILE__).to_i.should eq(20)
+          >, filename: __FILE__).to_i.should eq(20)
       end
     end
 
@@ -3066,13 +3066,13 @@ module Crystal
       it "reads file (exists)" do
         run(%q<
           {{file_exists?("spec/compiler/data/build")}} ? 10 : 20
-          >, filename = __FILE__).to_i.should eq(10)
+          >, filename: __FILE__).to_i.should eq(10)
       end
 
       it "reads file (doesn't exist)" do
         run(%q<
           {{file_exists?("spec/compiler/data/build_foo")}} ? 10 : 20
-          >, filename = __FILE__).to_i.should eq(20)
+          >, filename: __FILE__).to_i.should eq(20)
       end
     end
   end
@@ -3082,7 +3082,7 @@ module Crystal
       it "reads file (exists)" do
         run(%q<
           {{read_file("#{__DIR__}/../data/build")}}
-          >, filename = __FILE__).to_string.should eq(File.read("#{__DIR__}/../data/build"))
+          >, filename: __FILE__).to_string.should eq(File.read("#{__DIR__}/../data/build"))
       end
 
       it "reads file (doesn't exist)" do
@@ -3097,7 +3097,7 @@ module Crystal
       it "reads file (exists)" do
         run(%q<
           {{read_file("spec/compiler/data/build")}}
-          >, filename = __FILE__).to_string.should eq(File.read("spec/compiler/data/build"))
+          >, filename: __FILE__).to_string.should eq(File.read("spec/compiler/data/build"))
       end
 
       it "reads file (doesn't exist)" do
@@ -3114,7 +3114,7 @@ module Crystal
       it "reads file (doesn't exist)" do
         run(%q<
           {{read_file?("#{__DIR__}/../data/build_foo")}} ? 10 : 20
-          >, filename = __FILE__).to_i.should eq(20)
+          >, filename: __FILE__).to_i.should eq(20)
       end
     end
 
@@ -3122,7 +3122,7 @@ module Crystal
       it "reads file (doesn't exist)" do
         run(%q<
           {{read_file?("spec/compiler/data/build_foo")}} ? 10 : 20
-          >, filename = __FILE__).to_i.should eq(20)
+          >, filename: __FILE__).to_i.should eq(20)
       end
     end
   end

--- a/spec/compiler/parser/warnings_spec.cr
+++ b/spec/compiler/parser/warnings_spec.cr
@@ -3,7 +3,7 @@ require "../../support/syntax"
 private def assert_parser_warning(source, message, *, file = __FILE__, line = __LINE__)
   parser = Parser.new(source)
   parser.filename = "/foo/bar/baz.cr"
-  node = parser.parse
+  parser.parse
 
   warnings = parser.warnings.infos
   warnings.size.should eq(1), file: file, line: line

--- a/spec/compiler/semantic/class_spec.cr
+++ b/spec/compiler/semantic/class_spec.cr
@@ -35,7 +35,7 @@ describe "Semantic: class" do
   end
 
   it "types generic of generic type" do
-    result = assert_type("
+    assert_type("
       class Foo(T)
         def set
           @coco = 2

--- a/spec/compiler/semantic/instance_var_spec.cr
+++ b/spec/compiler/semantic/instance_var_spec.cr
@@ -4367,7 +4367,7 @@ describe "Semantic: instance var" do
   end
 
   it "declares instance var of generic class" do
-    result = assert_type("
+    assert_type("
       class Foo(T)
         @x : T
 
@@ -4385,7 +4385,7 @@ describe "Semantic: instance var" do
   end
 
   it "declares instance var of generic class after reopen" do
-    result = assert_type("
+    assert_type("
       class Foo(T)
       end
 

--- a/spec/compiler/semantic/virtual_spec.cr
+++ b/spec/compiler/semantic/virtual_spec.cr
@@ -607,7 +607,7 @@ describe "Semantic: virtual" do
   end
 
   it "uses virtual type as generic type if class is abstract" do
-    result = assert_type("
+    assert_type("
       abstract class Foo
       end
 
@@ -619,7 +619,7 @@ describe "Semantic: virtual" do
   end
 
   it "uses virtual type as generic type if class is abstract even in union" do
-    result = assert_type("
+    assert_type("
       abstract class Foo
       end
 

--- a/spec/compiler/semantic/warnings_spec.cr
+++ b/spec/compiler/semantic/warnings_spec.cr
@@ -230,7 +230,7 @@ describe "Semantic: warnings" do
           compiler.warnings.level = :all
           compiler.warnings.exclude_lib_path = true
           compiler.prelude = "empty"
-          result = compiler.compile Compiler::Source.new(main_filename, File.read(main_filename)), output_filename
+          compiler.compile Compiler::Source.new(main_filename, File.read(main_filename)), output_filename
 
           compiler.warnings.infos.size.should eq(1)
         end
@@ -399,7 +399,7 @@ describe "Semantic: warnings" do
           compiler.warnings.level = :all
           compiler.warnings.exclude_lib_path = true
           compiler.prelude = "empty"
-          result = compiler.compile Compiler::Source.new(main_filename, File.read(main_filename)), output_filename
+          compiler.compile Compiler::Source.new(main_filename, File.read(main_filename)), output_filename
 
           compiler.warnings.infos.size.should eq(1)
         end

--- a/spec/spec_helper.cr
+++ b/spec/spec_helper.cr
@@ -80,7 +80,6 @@ end
 def assert_normalize(from, to, flags = nil, *, file = __FILE__, line = __LINE__)
   program = new_program
   program.flags.concat(flags.split) if flags
-  normalizer = Normalizer.new(program)
   from_nodes = Parser.parse(from)
   to_nodes = program.normalize(from_nodes)
   to_nodes.to_s.strip.should eq(to.strip), file: file, line: line

--- a/spec/std/deque_spec.cr
+++ b/spec/std/deque_spec.cr
@@ -637,7 +637,7 @@ describe "Deque" do
       a = Deque{1, 2, 3}
       count = 0
       it = a.each_index
-      a.each_index.each do
+      it.each do
         count += 1
         a.clear
       end

--- a/spec/std/hash_spec.cr
+++ b/spec/std/hash_spec.cr
@@ -1257,7 +1257,7 @@ describe "Hash" do
     it { {"a" => 2, "b" => 3}.reject(["b", "a"]).should eq({} of String => Int32) }
     it "does not change current hash" do
       h = {"a" => 3, "b" => 6, "c" => 9}
-      h2 = h.reject("b", "c")
+      h.reject("b", "c")
       h.should eq({"a" => 3, "b" => 6, "c" => 9})
     end
   end
@@ -1282,7 +1282,7 @@ describe "Hash" do
     it { {"a" => 2, "b" => 3}.select(Set{"b", "a"}).should eq({"a" => 2, "b" => 3}) }
     it "does not change current hash" do
       h = {"a" => 3, "b" => 6, "c" => 9}
-      h2 = h.select("b", "c")
+      h.select("b", "c")
       h.should eq({"a" => 3, "b" => 6, "c" => 9})
     end
   end

--- a/spec/std/http/client/client_spec.cr
+++ b/spec/std/http/client/client_spec.cr
@@ -240,7 +240,6 @@ module HTTP
 
     it "will not retry when closed (non-block) (#12464)" do
       requests = 0
-      server_channel = Channel(Nil).new
 
       client = HTTP::Client.new("127.0.0.1", 0)
       client.before_request do
@@ -256,7 +255,6 @@ module HTTP
 
     it "will not retry when closed (block) (#12464)" do
       requests = 0
-      server_channel = Channel(Nil).new
 
       client = HTTP::Client.new("127.0.0.1", 0)
       client.before_request do

--- a/spec/std/http/headers_spec.cr
+++ b/spec/std/http/headers_spec.cr
@@ -20,7 +20,7 @@ describe HTTP::Headers do
 
   it "raises an error if header value contains invalid character" do
     expect_raises ArgumentError do
-      headers = HTTP::Headers{"invalid-header" => "\r\nLocation: http://example.com"}
+      HTTP::Headers{"invalid-header" => "\r\nLocation: http://example.com"}
     end
   end
 

--- a/spec/std/log/context_spec.cr
+++ b/spec/std/log/context_spec.cr
@@ -41,7 +41,7 @@ describe Log do
       Log.context.set a: 1
       done = Channel(Nil).new
 
-      f = spawn do
+      spawn do
         Log.context.metadata.should eq(Log::Metadata.new)
         Log.context.set b: 2
         Log.context.metadata.should eq(m({b: 2}))

--- a/spec/std/log/dispatch_spec.cr
+++ b/spec/std/log/dispatch_spec.cr
@@ -15,7 +15,7 @@ class Log
     it "dispatches entry" do
       backend = Log::MemoryBackend.new
       backend.dispatcher = DirectDispatcher
-      backend.dispatch entry = Entry.new("source", :info, "message", Log::Metadata.empty, nil)
+      backend.dispatch Entry.new("source", :info, "message", Log::Metadata.empty, nil)
       backend.entries.size.should eq(1)
     end
   end
@@ -24,7 +24,7 @@ class Log
     it "dispatches entry" do
       backend = Log::MemoryBackend.new
       backend.dispatcher = SyncDispatcher.new
-      backend.dispatch entry = Entry.new("source", :info, "message", Log::Metadata.empty, nil)
+      backend.dispatch Entry.new("source", :info, "message", Log::Metadata.empty, nil)
       backend.entries.size.should eq(1)
     end
   end
@@ -33,14 +33,14 @@ class Log
     it "dispatches entry" do
       backend = Log::MemoryBackend.new
       backend.dispatcher = AsyncDispatcher.new
-      backend.dispatch entry = Entry.new("source", :info, "message", Log::Metadata.empty, nil)
+      backend.dispatch Entry.new("source", :info, "message", Log::Metadata.empty, nil)
       retry { backend.entries.size.should eq(1) }
     end
 
     it "wait for entries to flush before closing" do
       backend = Log::MemoryBackend.new
       backend.dispatcher = AsyncDispatcher.new
-      backend.dispatch entry = Entry.new("source", :info, "message", Log::Metadata.empty, nil)
+      backend.dispatch Entry.new("source", :info, "message", Log::Metadata.empty, nil)
       backend.close
       backend.entries.size.should eq(1)
     end
@@ -48,7 +48,7 @@ class Log
     it "can be closed twice" do
       backend = Log::MemoryBackend.new
       backend.dispatcher = AsyncDispatcher.new
-      backend.dispatch entry = Entry.new("source", :info, "message", Log::Metadata.empty, nil)
+      backend.dispatch Entry.new("source", :info, "message", Log::Metadata.empty, nil)
       backend.close
       backend.close
       backend.entries.size.should eq(1)

--- a/spec/std/oauth2/session_spec.cr
+++ b/spec/std/oauth2/session_spec.cr
@@ -5,8 +5,8 @@ module OAuth2
   typeof(begin
     client = Client.new "localhost", "client_id", "client_secret", redirect_uri: "uri", authorize_uri: "/baz"
     token = OAuth2::AccessToken::Bearer.new("token", 3600)
-    session = Session.new(client, token) { |s| }
-    session = Session.new(client, token, Time.utc) { |s| }
+    session = Session.new(client, token) { |_| }
+    session = Session.new(client, token, Time.utc) { |_| }
     session.authenticate(HTTP::Client.new("localhost"))
   end)
 end

--- a/spec/std/proc_spec.cr
+++ b/spec/std/proc_spec.cr
@@ -17,13 +17,11 @@ describe "Proc" do
   end
 
   it "does to_s" do
-    str = IO::Memory.new
     f = ->(x : Int32) { x.to_f }
     f.to_s.should eq("#<Proc(Int32, Float64):0x#{f.pointer.address.to_s(16)}>")
   end
 
   it "does to_s when closured" do
-    str = IO::Memory.new
     a = 1.5
     f = ->(x : Int32) { x + a }
     f.to_s.should eq("#<Proc(Int32, Float64):0x#{f.pointer.address.to_s(16)}:closure>")

--- a/spec/std/socket/tcp_socket_spec.cr
+++ b/spec/std/socket/tcp_socket_spec.cr
@@ -58,7 +58,7 @@ describe TCPSocket, tags: "network" do
 
         TCPServer.open("localhost", port) do |server|
           TCPSocket.open("localhost", port) do |client|
-            sock = server.accept
+            server.accept
           end
         end
       end

--- a/spec/std/string_spec.cr
+++ b/spec/std/string_spec.cr
@@ -1332,7 +1332,7 @@ describe "String" do
     end
 
     it "subs char with string" do
-      replaced = "foobar".sub do |char|
+      "foobar".sub do |char|
         char.should eq 'f'
         "some"
       end.should eq("someoobar")

--- a/src/compiler/crystal/codegen/codegen.cr
+++ b/src/compiler/crystal/codegen/codegen.cr
@@ -1499,7 +1499,6 @@ module Crystal
       end
 
       # First accept all yield expressions and assign them to block vars
-      i = 0
       unless node.exps.empty?
         exp_values = Array({LLVM::Value, Type}).new(node.exps.size)
 

--- a/src/compiler/crystal/codegen/fun.cr
+++ b/src/compiler/crystal/codegen/fun.cr
@@ -38,8 +38,6 @@ class Crystal::CodeGenVisitor
       func.varargs?
     )
 
-    p2 = new_fun.params.to_a
-
     func.params.to_a.each_with_index do |p1, index|
       attrs = new_fun.attributes(index + 1)
       new_fun.add_attribute(attrs, index + 1) unless attrs.value == 0
@@ -125,7 +123,6 @@ class Crystal::CodeGenVisitor
 
         if @debug.variables? && !target_def.naked?
           in_alloca_block do
-            args_offset = !is_fun_literal && self_type.passed_as_self? ? 2 : 1
             location = target_def.location
             context.vars.each do |name, var|
               next if var.debug_variable_created

--- a/src/compiler/crystal/codegen/primitives.cr
+++ b/src/compiler/crystal/codegen/primitives.cr
@@ -748,7 +748,7 @@ class Crystal::CodeGenVisitor
 
     old_debug_location = @current_debug_location
     if @debug.line_numbers? && (location = node.location)
-      set_current_debug_location(node.location)
+      set_current_debug_location(location)
     end
 
     if type.element_type.has_inner_pointers?

--- a/src/compiler/crystal/command.cr
+++ b/src/compiler/crystal/command.cr
@@ -210,7 +210,7 @@ class Crystal::Command
 
     output_filename = Crystal.temp_executable(config.output_filename)
 
-    result = config.compile output_filename
+    config.compile output_filename
 
     unless config.compiler.no_codegen?
       report_warnings

--- a/src/compiler/crystal/command/cursor.cr
+++ b/src/compiler/crystal/command/cursor.cr
@@ -7,30 +7,29 @@
 class Crystal::Command
   private def implementations
     cursor_command("tool implementations") do |location, config, result|
-      result = ImplementationsVisitor.new(location).process(result)
+      ImplementationsVisitor.new(location).process(result)
     end
   end
 
   private def context
     cursor_command("tool context") do |location, config, result|
-      result = ContextVisitor.new(location).process(result)
+      ContextVisitor.new(location).process(result)
     end
   end
 
   private def expand
     cursor_command("tool expand", no_cleanup: true, wants_doc: true) do |location, config, result|
-      result = ExpandVisitor.new(location).process(result)
+      ExpandVisitor.new(location).process(result)
     end
   end
 
   private def cursor_command(command, no_cleanup = false, wants_doc = false)
-    config, result = compile_no_codegen command, cursor_command: true, no_cleanup: no_cleanup, wants_doc: wants_doc
+    config, result = compile_no_codegen command,
+      cursor_command: true,
+      no_cleanup: no_cleanup,
+      wants_doc: wants_doc
 
     format = config.output_format
-
-    file = ""
-    line = ""
-    col = ""
 
     loc = config.cursor_location.not_nil!.split(':')
     if loc.size != 3

--- a/src/compiler/crystal/command/repl.cr
+++ b/src/compiler/crystal/command/repl.cr
@@ -7,7 +7,7 @@ class Crystal::Command
   private def repl
     repl = Repl.new
 
-    option_parser = parse_with_crystal_opts do |opts|
+    parse_with_crystal_opts do |opts|
       opts.banner = "Usage: crystal i [options] [programfile] [arguments]\n\nOptions:"
 
       opts.on("-D FLAG", "--define FLAG", "Define a compile-time flag") do |flag|

--- a/src/compiler/crystal/command/spec.cr
+++ b/src/compiler/crystal/command/spec.cr
@@ -95,7 +95,7 @@ class Crystal::Command
     output_filename = Crystal.temp_executable "spec"
 
     ENV["CRYSTAL_SPEC_COMPILER_BIN"] ||= Process.executable_path
-    result = compiler.compile sources, output_filename
+    compiler.compile sources, output_filename
     report_warnings
     execute output_filename, options, compiler, error_on_exit: warnings_fail_on_exit?
   end

--- a/src/compiler/crystal/exception.cr
+++ b/src/compiler/crystal/exception.cr
@@ -261,7 +261,7 @@ module Crystal
         source_slice = source.lines[from_index...to_index]
         source_slice, spaces_removed = minimize_indentation(source_slice)
 
-        io << Crystal.with_line_numbers(source_slice, line_number, @color, line_number_start = from_index + 1)
+        io << Crystal.with_line_numbers(source_slice, line_number, @color, from_index + 1)
         offset = OFFSET_FROM_LINE_NUMBER_DECORATOR + line_number.to_s.chars.size - spaces_removed
         append_error_indicator(io, offset, @column_number, @size)
       end

--- a/src/compiler/crystal/interpreter/compiler.cr
+++ b/src/compiler/crystal/interpreter/compiler.cr
@@ -981,7 +981,7 @@ class Crystal::Repl::Compiler < Crystal::Visitor
   end
 
   private def read_closured_var_pointer(closured_var : ClosuredVar, *, node : ASTNode?)
-    indexes, type = closured_var.indexes, closured_var.type
+    indexes = closured_var.indexes
 
     # First load the closure pointer
     closure_var_index = get_closure_var_index
@@ -2474,9 +2474,6 @@ class Crystal::Repl::Compiler < Crystal::Visitor
       # We don't want pointer.value to return a copy of something
       # if we are calling through it
       call_obj = call_obj.not_nil!
-
-      element_type = call_obj.type.as(PointerInstanceType).element_type
-
       request_value(call_obj)
       return
     end
@@ -2687,8 +2684,7 @@ class Crystal::Repl::Compiler < Crystal::Visitor
       local_var = lookup_local_var_or_closured_var(exp.name)
       case local_var
       in LocalVar
-        index, type = local_var.index, local_var.type
-        pointerof_var(index, node: node)
+        pointerof_var(local_var.index, node: node)
       in ClosuredVar
         node.raise "BUG: missing interpreter out closured var"
       end
@@ -2753,8 +2749,6 @@ class Crystal::Repl::Compiler < Crystal::Visitor
 
       compiled_def.local_vars.declare(arg.name, var_type)
     end
-
-    a_def = @def
 
     needs_closure_context = (target_def.vars.try &.any? { |name, var| var.type? && var.closure_in?(target_def) })
 

--- a/src/compiler/crystal/macros/methods.cr
+++ b/src/compiler/crystal/macros/methods.cr
@@ -2500,7 +2500,7 @@ private def interpret_array_or_tuple_method(object, klass, method, args, named_a
         case arg = from
         when Crystal::NumberLiteral
           index = arg.to_number.to_i
-          value = object.elements[index]? || Crystal::NilLiteral.new
+          object.elements[index]? || Crystal::NilLiteral.new
         when Crystal::RangeLiteral
           range = arg.interpret_to_nilable_range(interpreter)
           begin

--- a/src/compiler/crystal/program.cr
+++ b/src/compiler/crystal/program.cr
@@ -141,7 +141,7 @@ module Crystal
 
       types["NoReturn"] = @no_return = NoReturnType.new self, self, "NoReturn"
       types["Void"] = @void = VoidType.new self, self, "Void"
-      types["Nil"] = nil_t = @nil = NilType.new self, self, "Nil", value, 1
+      types["Nil"] = @nil = NilType.new self, self, "Nil", value, 1
       types["Bool"] = @bool = BoolType.new self, self, "Bool", value, 1
       types["Char"] = @char = CharType.new self, self, "Char", value, 4
 

--- a/src/compiler/crystal/semantic/ast.cr
+++ b/src/compiler/crystal/semantic/ast.cr
@@ -471,7 +471,6 @@ module Crystal
       # bind all previously related local vars to it so that
       # they get all types assigned to it.
       local_vars.each &.bind_to self
-      local_vars = nil
     end
 
     # True if this variable belongs to the given context

--- a/src/compiler/crystal/semantic/bindings.cr
+++ b/src/compiler/crystal/semantic/bindings.cr
@@ -576,7 +576,7 @@ module Crystal
           node_type = node.type?
           return unless node_type
 
-          if node.is_a?(Path) && (target_const = node.target_const)
+          if node.is_a?(Path) && node.target_const
             node.raise "can't use constant as type for NamedTuple"
           end
 

--- a/src/compiler/crystal/semantic/call_error.cr
+++ b/src/compiler/crystal/semantic/call_error.cr
@@ -730,7 +730,7 @@ class Crystal::Call
   end
 
   def def_full_name(owner, a_def, arg_types = nil)
-    Call.def_full_name(owner, a_def, arg_types = nil)
+    Call.def_full_name(owner, a_def, arg_types)
   end
 
   def self.def_full_name(owner, a_def, arg_types = nil)
@@ -778,7 +778,7 @@ class Crystal::Call
       end
       if arg_default = arg.default_value
         str << " = "
-        str << arg.default_value
+        str << arg_default
       end
       printed = true
     end

--- a/src/compiler/crystal/semantic/call_error.cr
+++ b/src/compiler/crystal/semantic/call_error.cr
@@ -805,8 +805,6 @@ class Crystal::Call
   end
 
   def raise_matches_not_found_for_virtual_metaclass_new(owner)
-    arg_types = args.map &.type
-
     owner.each_concrete_type do |concrete_type|
       defs = concrete_type.instance_type.lookup_defs_with_modules("initialize")
       defs = defs.select { |a_def| a_def.args.size != args.size }
@@ -819,8 +817,7 @@ class Crystal::Call
   end
 
   def check_macro_wrong_number_of_arguments(def_name)
-    obj = self.obj
-    return if obj && !obj.is_a?(Path)
+    return if (obj = self.obj) && !obj.is_a?(Path)
 
     macros = in_macro_target &.lookup_macros(def_name)
     return unless macros.is_a?(Array(Macro))

--- a/src/compiler/crystal/semantic/exception.cr
+++ b/src/compiler/crystal/semantic/exception.cr
@@ -140,7 +140,7 @@ module Crystal
 
     def default_message
       if line_number = @line_number
-        "#{@warning ? "warning" : "error"} in line #{@line_number}"
+        "#{@warning ? "warning" : "error"} in line #{line_number}"
       end
     end
 

--- a/src/compiler/crystal/semantic/main_visitor.cr
+++ b/src/compiler/crystal/semantic/main_visitor.cr
@@ -934,7 +934,7 @@ module Crystal
         node.raise "can't use `yield` outside a method"
       end
 
-      if ctx = @fun_literal_context
+      if @fun_literal_context
         node.raise <<-MSG
           can't use `yield` inside a proc literal or captured block
 

--- a/src/compiler/crystal/semantic/restrictions.cr
+++ b/src/compiler/crystal/semantic/restrictions.cr
@@ -1537,7 +1537,7 @@ module Crystal
       output = other.output
 
       # Consider the case of a splat in the type vars
-      if inputs && (splat_given = inputs.any?(Splat))
+      if inputs && inputs.any?(Splat)
         i = 0
         inputs.each do |input|
           if input.is_a?(Splat)

--- a/src/compiler/crystal/semantic/top_level_visitor.cr
+++ b/src/compiler/crystal/semantic/top_level_visitor.cr
@@ -857,7 +857,7 @@ class Crystal::TopLevelVisitor < Crystal::SemanticVisitor
         node.raise "can only use 'private' for types"
       end
     when Assign
-      if (target = exp.target).is_a?(Path)
+      if exp.target.is_a?(Path)
         if node.modifier.private?
           return false
         else

--- a/src/compiler/crystal/semantic/type_declaration_processor.cr
+++ b/src/compiler/crystal/semantic/type_declaration_processor.cr
@@ -561,7 +561,6 @@ struct Crystal::TypeDeclarationProcessor
         next if info.def.calls_super? && ancestor_non_nilable.try(&.includes?(instance_var))
 
         unless info.try(&.instance_vars.try(&.includes?(instance_var)))
-          all_assigned = false
           # Remember that this variable wasn't initialized here, and later error
           # if it turns out to be non-nilable
           nilable_vars = @nilable_instance_vars[owner] ||= {} of String => InitializeInfo

--- a/src/compiler/crystal/semantic/type_guess_visitor.cr
+++ b/src/compiler/crystal/semantic/type_guess_visitor.cr
@@ -813,7 +813,6 @@ module Crystal
 
       # Try to guess from the method's body, but now
       # the current lookup type is obj_type
-      type = nil
       old_type_override = @type_override
       @type_override = obj_type
 

--- a/src/compiler/crystal/semantic/type_to_restriction.cr
+++ b/src/compiler/crystal/semantic/type_to_restriction.cr
@@ -93,7 +93,6 @@ module Crystal
     end
 
     def convert(type : GenericInstanceType)
-      generic_type = type.generic_type
       path = type_to_path(type.generic_type)
       type_vars = type.type_vars.map do |name, type_var|
         if type_var.is_a?(NumberLiteral)

--- a/src/compiler/crystal/syntax/lexer.cr
+++ b/src/compiler/crystal/syntax/lexer.cr
@@ -2293,10 +2293,8 @@ module Crystal
     def skip_macro_whitespace
       start = current_pos
       while current_char.ascii_whitespace?
-        whitespace = true
         if current_char == '\n'
           incr_line_number 0
-          beginning_of_line = true
         end
         next_char
       end

--- a/src/compiler/crystal/syntax/parser.cr
+++ b/src/compiler/crystal/syntax/parser.cr
@@ -701,7 +701,6 @@ module Crystal
             end_location = token_end_location
 
             @wants_regex = false
-            has_parentheses = false
             next_token
 
             space_consumed = false
@@ -2607,8 +2606,6 @@ module Crystal
       first_value = parse_op_assign
       skip_space_or_newline
 
-      end_location = nil
-
       entries = [] of NamedTupleLiteral::Entry
       entries << NamedTupleLiteral::Entry.new(first_key, first_value)
 
@@ -3483,7 +3480,6 @@ module Crystal
 
       receiver = nil
       @yields = nil
-      name_line_number = @token.line_number
       name_location = @token.location
       receiver_location = @token.location
       end_location = token_end_location
@@ -3775,7 +3771,6 @@ module Crystal
 
       if splat && (@token.type.op_comma? || @token.type.op_rparen?)
         param_name = ""
-        uses_param = false
         allow_restrictions = false
       else
         param_location = @token.location
@@ -3876,9 +3871,6 @@ module Crystal
         param_name, external_name, found_space, uses_param = parse_param_name(name_location, extra_assigns, allow_external_name: false)
         @uses_block_arg = true if uses_param
       end
-
-      inputs = nil
-      output = nil
 
       if @token.type.op_colon?
         next_token_skip_space_or_newline

--- a/src/compiler/crystal/tools/formatter.cr
+++ b/src/compiler/crystal/tools/formatter.cr
@@ -202,7 +202,6 @@ module Crystal
       end
 
       old_indent = @indent
-      base_indent = old_indent
       next_needs_indent = false
 
       has_newline = false
@@ -220,7 +219,6 @@ module Crystal
           @indent += 2
           write_line unless wrote_newline
           next_token_skip_space_or_newline
-          base_indent = @indent
           next_needs_indent = true
           has_newline = true
         end
@@ -238,7 +236,6 @@ module Crystal
           end
         end
         has_begin = true
-        base_indent = @indent
         next_needs_indent = true
         has_newline = true
       end
@@ -555,7 +552,6 @@ module Crystal
       @last_is_heredoc = is_heredoc
 
       heredoc_line = @line
-      heredoc_end = @line
 
       # To detect the first content of interpolation of string literal correctly,
       # we should consume the first string token if this token contains only removed indentation of heredoc.
@@ -851,7 +847,6 @@ module Crystal
           write_space_at_end = true
         end
 
-        start_line = @line
         if next_needs_indent
           write_indent(offset, element)
         else
@@ -1475,7 +1470,7 @@ module Crystal
         skip_space
         write_token " ", :OP_COLON, " "
         skip_space_or_newline
-        accept node.return_type.not_nil!
+        accept return_type
       end
 
       if free_vars = node.free_vars
@@ -2073,7 +2068,6 @@ module Crystal
       write_macro_slashes
       write "{% "
 
-      macro_state = @macro_state
       next_token_skip_space_or_newline
 
       write_keyword :for, " "
@@ -2716,7 +2710,6 @@ module Crystal
         next_token
         if @token.type.op_lparen?
           write "=("
-          has_parentheses = true
           slash_is_regex!
           next_token
           format_call_args(node, true, base_indent)
@@ -2735,7 +2728,6 @@ module Crystal
       ends_with_newline = false
       has_args = !node.args.empty? || node.named_args
 
-      column = @indent
       has_newlines = false
       found_comment = false
 

--- a/src/exception/call_stack/stackwalk.cr
+++ b/src/exception/call_stack/stackwalk.cr
@@ -34,7 +34,7 @@ struct Exception::CallStack
 
   def self.setup_crash_handler
     LibC.AddVectoredExceptionHandler(1, ->(exception_info) do
-      case status = exception_info.value.exceptionRecord.value.exceptionCode
+      case exception_info.value.exceptionRecord.value.exceptionCode
       when LibC::EXCEPTION_ACCESS_VIOLATION
         addr = exception_info.value.exceptionRecord.value.exceptionInformation[1]
         Crystal::System.print_error "Invalid memory access (C0000005) at address 0x%llx\n", addr

--- a/src/float/printer/grisu3.cr
+++ b/src/float/printer/grisu3.cr
@@ -315,8 +315,6 @@ module Float::Printer::Grisu3
   # digits might correctly yield *v* when read again, the closest will be
   # computed.
   def grisu3(v : Float64 | Float32, buffer_p) : {Bool, Int32, Int32}
-    buffer = buffer_p.to_slice(128)
-
     w = DiyFP.from_f_normalized(v)
 
     # boundary_minus and boundary_plus are the boundaries between v and its

--- a/src/float/printer/ieee.cr
+++ b/src/float/printer/ieee.cr
@@ -113,7 +113,6 @@ module Float::Printer::IEEE
     physical_significand_is_zero = (d64 & SIGNIFICAND_MASK_64) == 0
 
     lower_bound_closer = physical_significand_is_zero && (exponent(d64) != DENORMAL_EXPONENT_64)
-    calc_denormal = denormal?(d64)
     f, e = if lower_bound_closer
              {(w.frac << 2) - 1, w.exp - 2}
            else
@@ -132,7 +131,6 @@ module Float::Printer::IEEE
     physical_significand_is_zero = (d32 & SIGNIFICAND_MASK_32) == 0
 
     lower_bound_closer = physical_significand_is_zero && (exponent(d32) != DENORMAL_EXPONENT_32)
-    calc_denormal = denormal?(d32)
     f, e = if lower_bound_closer
              {(w.frac << 2) - 1, w.exp - 2}
            else

--- a/src/iterator.cr
+++ b/src/iterator.cr
@@ -456,7 +456,7 @@ module Iterator(T)
         self.next
       else
         value = {last_elem, elem}
-        @last_elem, elem = elem, @last_elem
+        @last_elem = elem
         value
       end
     end

--- a/src/llvm/abi/x86.cr
+++ b/src/llvm/abi/x86.cr
@@ -30,11 +30,11 @@ class LLVM::ABI::X86 < LLVM::ABI
 
       if osx? || windows?
         case target_data.abi_size(rty)
-        when 1 then ret_ty = ret_value(rty, context.int8)
-        when 2 then ret_ty = ret_value(rty, context.int16)
-        when 4 then ret_ty = ret_value(rty, context.int32)
-        when 8 then ret_ty = ret_value(rty, context.int64)
-        else        ret_ty = ret_pointer(rty)
+        when 1 then ret_value(rty, context.int8)
+        when 2 then ret_value(rty, context.int16)
+        when 4 then ret_value(rty, context.int32)
+        when 8 then ret_value(rty, context.int64)
+        else        ret_pointer(rty)
         end
       else
         ret_pointer(rty)

--- a/src/llvm/abi/x86_64.cr
+++ b/src/llvm/abi/x86_64.cr
@@ -23,7 +23,6 @@ class LLVM::ABI::X86_64 < LLVM::ABI
       ret_ty = ArgType.direct(context.void)
     end
 
-    arg_tys = Array(LLVM::Type).new(atys.size)
     arg_tys = atys.map do |arg_type|
       abi_type, needed_int_regs, needed_sse_regs = x86_64_type(arg_type, Attribute::ByVal, context) { |cls| pass_by_val?(cls) }
       if available_int_regs >= needed_int_regs && available_sse_regs >= needed_sse_regs

--- a/src/path.cr
+++ b/src/path.cr
@@ -225,7 +225,9 @@ struct Path
       "."
     else # Path has a parent (ex. "a/a", "/home/user//", "C://Users/mmm")
       return String.new(slice[0, 1]) if pos == -1
-      return anchor.to_s if windows? && pos == 1 && slice.unsafe_fetch(pos) === ':' && (anchor = self.anchor)
+      if windows? && pos == 1 && slice.unsafe_fetch(pos) === ':' && (anchor = self.anchor)
+        return anchor.to_s
+      end
       String.new(slice[0, pos + 1])
     end
   end


### PR DESCRIPTION
This PR removes useless assignments found throughout the codebase.

From what I've (or rather [ameba](https://github.com/crystal-ameba/ameba)) found, they fall into 2 categories:
1. human errors - like forgetting to use the declared variable
2. leftovers or others

I've separated the commits based on the above, to ease the review process.