### PR TITLE
Update FreeBSD LibC types

### DIFF
--- a/src/lib_c/x86_64-freebsd/c/dirent.cr
+++ b/src/lib_c/x86_64-freebsd/c/dirent.cr
@@ -8,8 +8,8 @@ lib LibC
   DT_LNK     = 10
 
   struct Dirent
-    d_fileno : ULong
-    d_off : ULong
+    d_fileno : InoT
+    d_off : OffT
     d_reclen : UShort
     d_type : UChar
     d_pad0 : UChar

--- a/src/lib_c/x86_64-freebsd/c/sys/types.cr
+++ b/src/lib_c/x86_64-freebsd/c/sys/types.cr
@@ -3,10 +3,10 @@ require "../stdint"
 
 lib LibC
   alias BlkcntT = Long
-  alias BlksizeT = UInt
+  alias BlksizeT = Int
   alias ClockT = Int
   alias ClockidT = Int
-  alias DevT = UInt
+  alias DevT = ULong
   alias GidT = UInt
   alias IdT = Long
   alias InoT = ULong

--- a/src/lib_c/x86_64-freebsd/c/sys/un.cr
+++ b/src/lib_c/x86_64-freebsd/c/sys/un.cr
@@ -2,7 +2,7 @@ require "./socket"
 
 lib LibC
   struct SockaddrUn
-    sun_len : Char
+    sun_len : UChar
     sun_family : SaFamilyT
     sun_path : StaticArray(Char, 104)
   end


### PR DESCRIPTION
Some system types changed in FreeBSD 12 and later, update Crystal definitions.

Fixes #12650