### PR TITLE
Fix previous errors leaking into `XML.parse` & co

### DIFF
--- a/spec/std/xml/xml_spec.cr
+++ b/spec/std/xml/xml_spec.cr
@@ -169,6 +169,19 @@ describe XML do
     errors[0].to_s.should eq("Opening and ending tag mismatch: people line 1 and foo")
   end
 
+  it "resets errors" do
+    reader = XML::Reader.new(%{<foo></bar>}) # Invalid XML
+    reader.read
+    reader.expand?
+    # At this point, `XML::Error.errors` contains the errors from the reader. They should not leak into `XML.parse`.
+    XML::Error.errors.try(&.map(&.to_s)).should eq ["Opening and ending tag mismatch: foo line 1 and bar"]
+
+    xml = XML.parse(%(<people></people>))
+    xml.errors.should be_nil
+
+    XML::Error.errors.try(&.map(&.to_s)).should eq ["Opening and ending tag mismatch: foo line 1 and bar"]
+  end
+
   describe "#namespace" do
     describe "when the node has a namespace" do
       describe "with a prefix" do

--- a/src/xml/error.cr
+++ b/src/xml/error.cr
@@ -49,7 +49,7 @@ class XML::Error < Exception
     ensure
       # This class var is an optimization. It avoids allocation of an empty error array
       # in the happy case that there are no errors.
-      if @@empty_errors.any?
+      if !@@empty_errors.empty?
         @@empty_errors = [] of XML::Error
       end
       @@errors = old_errors


### PR DESCRIPTION
Isolates libXML errors for `XML.parse` and its sister methods. Before going into libXML, they swap in an empty array for collecting errors. Once complete, the original error array is swapped back in.
This isolates `XML.parse` & co from any `XML::Reader` scope which has not been cleaned up.

Resolves #12649