### PR TITLE
Allow the EventLoop implementation to be detected at runtime

### DIFF
--- a/src/crystal/scheduler.cr
+++ b/src/crystal/scheduler.cr
@@ -12,7 +12,11 @@ require "crystal/system/thread"
 # Only the class methods are public and safe to use. Instance methods are
 # protected and must never be called directly.
 class Crystal::Scheduler
-  class_getter event_loop = Crystal::EventLoop.create
+  @event_loop = Crystal::EventLoop.create
+
+  def self.event_loop
+    Thread.current.scheduler.@event_loop
+  end
 
   def self.current_fiber : Fiber
     Thread.current.scheduler.@current
@@ -156,7 +160,7 @@ class Crystal::Scheduler
         end
         break
       else
-        @@event_loop.run_once
+        @event_loop.run_once
       end
     end
 

--- a/src/crystal/scheduler.cr
+++ b/src/crystal/scheduler.cr
@@ -12,6 +12,8 @@ require "crystal/system/thread"
 # Only the class methods are public and safe to use. Instance methods are
 # protected and must never be called directly.
 class Crystal::Scheduler
+  class_getter event_loop = Crystal::EventLoop.create
+
   def self.current_fiber : Fiber
     Thread.current.scheduler.@current
   end
@@ -154,7 +156,7 @@ class Crystal::Scheduler
         end
         break
       else
-        Crystal::EventLoop.run_once
+        @@event_loop.run_once
       end
     end
 

--- a/src/crystal/system/event_loop.cr
+++ b/src/crystal/system/event_loop.cr
@@ -11,25 +11,24 @@ abstract class Crystal::EventLoop
   {% end %}
 
   # Create a new resume event for a fiber.
-  abstract def create_resume_event(fiber : Fiber) : Crystal::Event
+  abstract def create_resume_event(fiber : Fiber) : Event
 
   # Creates a timeout_event.
-  abstract def create_timeout_event(fiber : Fiber) : Crystal::Event
+  abstract def create_timeout_event(fiber : Fiber) : Event
 
   # Creates a write event for a file descriptor.
-  abstract def create_fd_write_event(io : IO::Evented, edge_triggered : Bool = false) : Crystal::Event
+  abstract def create_fd_write_event(io : IO::Evented, edge_triggered : Bool = false) : Event
 
   # Creates a read event for a file descriptor.
-  abstract def create_fd_read_event(io : IO::Evented, edge_triggered : Bool = false) : Crystal::Event
-end
+  abstract def create_fd_read_event(io : IO::Evented, edge_triggered : Bool = false) : Event
 
-# :nodoc:
-abstract struct Crystal::Event
-  # Frees the event.
-  abstract def free : Nil
+  abstract struct Event
+    # Frees the event.
+    abstract def free : Nil
 
-  # Adds a new timeout to this event.
-  abstract def add(timeout : Time::Span?) : Nil
+    # Adds a new timeout to this event.
+    abstract def add(timeout : Time::Span?) : Nil
+  end
 end
 
 {% if flag?(:wasi) %}

--- a/src/crystal/system/event_loop.cr
+++ b/src/crystal/system/event_loop.cr
@@ -1,31 +1,35 @@
-module Crystal::EventLoop
+abstract class Crystal::EventLoop
+  # Creates an event loop instance
+  # def self.create : Crystal::EventLoop
+
   # Runs the event loop.
-  # def self.run_once : Nil
+  abstract def run_once : Nil
 
   {% unless flag?(:preview_mt) %}
     # Reinitializes the event loop after a fork.
-    # def self.after_fork : Nil
+    abstract def after_fork : Nil
   {% end %}
 
   # Create a new resume event for a fiber.
-  # def self.create_resume_event(fiber : Fiber) : Crystal::Event
+  abstract def create_resume_event(fiber : Fiber) : Crystal::Event
 
   # Creates a timeout_event.
-  # def self.create_timeout_event(fiber) : Crystal::Event
+  abstract def create_timeout_event(fiber : Fiber) : Crystal::Event
 
   # Creates a write event for a file descriptor.
-  # def self.create_fd_write_event(io : IO::Evented, edge_triggered : Bool = false) : Crystal::Event
+  abstract def create_fd_write_event(io : IO::Evented, edge_triggered : Bool = false) : Crystal::Event
 
   # Creates a read event for a file descriptor.
-  # def self.create_fd_read_event(io : IO::Evented, edge_triggered : Bool = false) : Crystal::Event
+  abstract def create_fd_read_event(io : IO::Evented, edge_triggered : Bool = false) : Crystal::Event
 end
 
-struct Crystal::Event
+# :nodoc:
+abstract struct Crystal::Event
   # Frees the event.
-  # def free : Nil
+  abstract def free : Nil
 
   # Adds a new timeout to this event.
-  # def add(time_span : Time::Span?) : Nil
+  abstract def add(timeout : Time::Span?) : Nil
 end
 
 {% if flag?(:wasi) %}

--- a/src/crystal/system/unix/event_libevent.cr
+++ b/src/crystal/system/unix/event_libevent.cr
@@ -5,7 +5,7 @@ require "./lib_event2"
 {% end %}
 
 # :nodoc:
-struct Crystal::Event
+struct Crystal::LibEventEvent < Crystal::Event
   VERSION = String.new(LibEvent2.event_get_version)
 
   def self.callback(&block : Int32, LibEvent2::EventFlags, Void* ->)
@@ -16,23 +16,19 @@ struct Crystal::Event
     @freed = false
   end
 
-  def add(timeout : LibC::Timeval? = nil)
+  def add(timeout : Time::Span?) : Nil
     if timeout
-      timeout_copy = timeout
-      LibEvent2.event_add(@event, pointerof(timeout_copy))
+      timeval = LibC::Timeval.new(
+        tv_sec: LibC::TimeT.new(timeout.total_seconds),
+        tv_usec: timeout.nanoseconds // 1_000
+      )
+      LibEvent2.event_add(@event, pointerof(timeval))
     else
       LibEvent2.event_add(@event, nil)
     end
   end
 
-  def add(timeout : Time::Span)
-    add LibC::Timeval.new(
-      tv_sec: LibC::TimeT.new(timeout.total_seconds),
-      tv_usec: timeout.nanoseconds // 1_000
-    )
-  end
-
-  def free
+  def free : Nil
     LibEvent2.event_free(@event) unless @freed
     @freed = true
   end
@@ -49,7 +45,7 @@ struct Crystal::Event
       @base = LibEvent2.event_base_new
     end
 
-    def reinit
+    def reinit : Nil
       unless LibEvent2.event_reinit(@base) == 0
         raise "Error reinitializing libevent"
       end
@@ -57,18 +53,18 @@ struct Crystal::Event
 
     def new_event(s : Int32, flags : LibEvent2::EventFlags, data, &callback : LibEvent2::Callback)
       event = LibEvent2.event_new(@base, s, flags, callback, data.as(Void*))
-      Event.new(event)
+      Crystal::LibEventEvent.new(event)
     end
 
-    def run_loop
+    def run_loop : Nil
       LibEvent2.event_base_loop(@base, LibEvent2::EventLoopFlags::None)
     end
 
-    def run_once
+    def run_once : Nil
       LibEvent2.event_base_loop(@base, LibEvent2::EventLoopFlags::Once)
     end
 
-    def loop_break
+    def loop_break : Nil
       LibEvent2.event_base_loopbreak(@base)
     end
 

--- a/src/crystal/system/unix/event_libevent.cr
+++ b/src/crystal/system/unix/event_libevent.cr
@@ -5,7 +5,7 @@ require "./lib_event2"
 {% end %}
 
 # :nodoc:
-struct Crystal::LibEventEvent < Crystal::Event
+struct Crystal::LibEvent::Event < Crystal::EventLoop::Event
   VERSION = String.new(LibEvent2.event_get_version)
 
   def self.callback(&block : Int32, LibEvent2::EventFlags, Void* ->)
@@ -53,7 +53,7 @@ struct Crystal::LibEventEvent < Crystal::Event
 
     def new_event(s : Int32, flags : LibEvent2::EventFlags, data, &callback : LibEvent2::Callback)
       event = LibEvent2.event_new(@base, s, flags, callback, data.as(Void*))
-      Crystal::LibEventEvent.new(event)
+      Crystal::LibEvent::Event.new(event)
     end
 
     def run_loop : Nil

--- a/src/crystal/system/unix/event_loop_libevent.cr
+++ b/src/crystal/system/unix/event_loop_libevent.cr
@@ -1,37 +1,37 @@
 require "./event_libevent"
 
-class Thread
-  # :nodoc:
-  getter(event_base) { Crystal::Event::Base.new }
+# :nodoc:
+abstract class Crystal::EventLoop
+  def self.create
+    Crystal::LibEventEventLoop.new
+  end
 end
 
 # :nodoc:
-module Crystal::EventLoop
+class Crystal::LibEventEventLoop < Crystal::EventLoop
+  private getter(event_base) { Crystal::LibEventEvent::Base.new }
+
   {% unless flag?(:preview_mt) %}
     # Reinitializes the event loop after a fork.
-    def self.after_fork : Nil
+    def after_fork : Nil
       event_base.reinit
     end
   {% end %}
 
   # Runs the event loop.
-  def self.run_once
+  def run_once : Nil
     event_base.run_once
   end
 
-  private def self.event_base
-    Thread.current.event_base
-  end
-
   # Create a new resume event for a fiber.
-  def self.create_resume_event(fiber : Fiber) : Crystal::Event
+  def create_resume_event(fiber : Fiber) : Crystal::Event
     event_base.new_event(-1, LibEvent2::EventFlags::None, fiber) do |s, flags, data|
       Crystal::Scheduler.enqueue data.as(Fiber)
     end
   end
 
   # Creates a timeout_event.
-  def self.create_timeout_event(fiber) : Crystal::Event
+  def create_timeout_event(fiber) : Crystal::Event
     event_base.new_event(-1, LibEvent2::EventFlags::None, fiber) do |s, flags, data|
       f = data.as(Fiber)
       if (select_action = f.timeout_select_action)
@@ -44,7 +44,7 @@ module Crystal::EventLoop
   end
 
   # Creates a write event for a file descriptor.
-  def self.create_fd_write_event(io : IO::Evented, edge_triggered : Bool = false) : Crystal::Event
+  def create_fd_write_event(io : IO::Evented, edge_triggered : Bool = false) : Crystal::Event
     flags = LibEvent2::EventFlags::Write
     flags |= LibEvent2::EventFlags::Persist | LibEvent2::EventFlags::ET if edge_triggered
 
@@ -59,7 +59,7 @@ module Crystal::EventLoop
   end
 
   # Creates a read event for a file descriptor.
-  def self.create_fd_read_event(io : IO::Evented, edge_triggered : Bool = false) : Crystal::Event
+  def create_fd_read_event(io : IO::Evented, edge_triggered : Bool = false) : Crystal::Event
     flags = LibEvent2::EventFlags::Read
     flags |= LibEvent2::EventFlags::Persist | LibEvent2::EventFlags::ET if edge_triggered
 

--- a/src/crystal/system/wasi/event_loop.cr
+++ b/src/crystal/system/wasi/event_loop.cr
@@ -1,39 +1,48 @@
 # :nodoc:
-module Crystal::EventLoop
-  # Runs the event loop.
-  def self.run_once
-    raise NotImplementedError.new("Crystal::EventLoop.run_once")
-  end
-
-  # Create a new resume event for a fiber.
-  def self.create_resume_event(fiber : Fiber) : Crystal::Event
-    raise NotImplementedError.new("Crystal::EventLoop.create_resume_event")
-  end
-
-  # Creates a timeout_event.
-  def self.create_timeout_event(fiber) : Crystal::Event
-    raise NotImplementedError.new("Crystal::EventLoop.create_timeout_event")
-  end
-
-  # Creates a write event for a file descriptor.
-  def self.create_fd_write_event(io : IO::Evented, edge_triggered : Bool = false) : Crystal::Event
-    raise NotImplementedError.new("Crystal::EventLoop.create_fd_write_event")
-  end
-
-  # Creates a read event for a file descriptor.
-  def self.create_fd_read_event(io : IO::Evented, edge_triggered : Bool = false) : Crystal::Event
-    raise NotImplementedError.new("Crystal::EventLoop.create_fd_read_event")
+abstract class Crystal::EventLoop
+  def self.create
+    Crystal::WasiEventLoop.new
   end
 end
 
-struct Crystal::Event
-  def add(timeout : LibC::Timeval? = nil)
+# :nodoc:
+class Crystal::WasiEventLoop < Crystal::EventLoop
+  {% unless flag?(:preview_mt) %}
+    def after_fork : Nil
+    end
+  {% end %}
+
+  # Runs the event loop.
+  def run_once : Nil
+    raise NotImplementedError.new("Crystal::WasiEventLoop.run_once")
   end
 
-  def add(timeout : Time::Span)
+  # Create a new resume event for a fiber.
+  def create_resume_event(fiber : Fiber) : Crystal::Event
+    raise NotImplementedError.new("Crystal::WasiEventLoop.create_resume_event")
   end
 
-  def free
+  # Creates a timeout_event.
+  def create_timeout_event(fiber) : Crystal::Event
+    raise NotImplementedError.new("Crystal::WasiEventLoop.create_timeout_event")
+  end
+
+  # Creates a write event for a file descriptor.
+  def create_fd_write_event(io : IO::Evented, edge_triggered : Bool = false) : Crystal::Event
+    raise NotImplementedError.new("Crystal::WasiEventLoop.create_fd_write_event")
+  end
+
+  # Creates a read event for a file descriptor.
+  def create_fd_read_event(io : IO::Evented, edge_triggered : Bool = false) : Crystal::Event
+    raise NotImplementedError.new("Crystal::WasiEventLoop.create_fd_read_event")
+  end
+end
+
+struct Crystal::WasiEvent < Crystal::Event
+  def add(timeout : Time::Span?) : Nil
+  end
+
+  def free : Nil
   end
 
   def delete

--- a/src/crystal/system/wasi/event_loop.cr
+++ b/src/crystal/system/wasi/event_loop.cr
@@ -1,12 +1,12 @@
 # :nodoc:
 abstract class Crystal::EventLoop
   def self.create
-    Crystal::WasiEventLoop.new
+    Crystal::Wasi::EventLoop.new
   end
 end
 
 # :nodoc:
-class Crystal::WasiEventLoop < Crystal::EventLoop
+class Crystal::Wasi::EventLoop < Crystal::EventLoop
   {% unless flag?(:preview_mt) %}
     def after_fork : Nil
     end
@@ -14,31 +14,31 @@ class Crystal::WasiEventLoop < Crystal::EventLoop
 
   # Runs the event loop.
   def run_once : Nil
-    raise NotImplementedError.new("Crystal::WasiEventLoop.run_once")
+    raise NotImplementedError.new("Crystal::Wasi::EventLoop.run_once")
   end
 
   # Create a new resume event for a fiber.
-  def create_resume_event(fiber : Fiber) : Crystal::Event
-    raise NotImplementedError.new("Crystal::WasiEventLoop.create_resume_event")
+  def create_resume_event(fiber : Fiber) : Crystal::EventLoop::Event
+    raise NotImplementedError.new("Crystal::Wasi::EventLoop.create_resume_event")
   end
 
   # Creates a timeout_event.
-  def create_timeout_event(fiber) : Crystal::Event
-    raise NotImplementedError.new("Crystal::WasiEventLoop.create_timeout_event")
+  def create_timeout_event(fiber) : Crystal::EventLoop::Event
+    raise NotImplementedError.new("Crystal::Wasi::EventLoop.create_timeout_event")
   end
 
   # Creates a write event for a file descriptor.
-  def create_fd_write_event(io : IO::Evented, edge_triggered : Bool = false) : Crystal::Event
-    raise NotImplementedError.new("Crystal::WasiEventLoop.create_fd_write_event")
+  def create_fd_write_event(io : IO::Evented, edge_triggered : Bool = false) : Crystal::EventLoop::Event
+    raise NotImplementedError.new("Crystal::Wasi::EventLoop.create_fd_write_event")
   end
 
   # Creates a read event for a file descriptor.
-  def create_fd_read_event(io : IO::Evented, edge_triggered : Bool = false) : Crystal::Event
-    raise NotImplementedError.new("Crystal::WasiEventLoop.create_fd_read_event")
+  def create_fd_read_event(io : IO::Evented, edge_triggered : Bool = false) : Crystal::EventLoop::Event
+    raise NotImplementedError.new("Crystal::Wasi::EventLoop.create_fd_read_event")
   end
 end
 
-struct Crystal::WasiEvent < Crystal::Event
+struct Crystal::Wasi::Event < Crystal::EventLoop::Event
   def add(timeout : Time::Span?) : Nil
   end
 

--- a/src/crystal/system/win32/event_loop_iocp.cr
+++ b/src/crystal/system/win32/event_loop_iocp.cr
@@ -1,15 +1,23 @@
 require "c/ioapiset"
 require "crystal/system/print_error"
 
-module Crystal::EventLoop
-  @@queue = Deque(Event).new
+# :nodoc:
+abstract class Crystal::EventLoop
+  def self.create
+    Crystal::IocpEventLoop.new
+  end
+end
+
+# :nodoc:
+class Crystal::IocpEventLoop < Crystal::EventLoop
+  @queue = Deque(Crystal::IocpEvent).new
 
   # Returns the base IO Completion Port
-  class_getter iocp : LibC::HANDLE do
+  getter iocp : LibC::HANDLE do
     create_completion_port(LibC::INVALID_HANDLE_VALUE, nil)
   end
 
-  def self.create_completion_port(handle : LibC::HANDLE, parent : LibC::HANDLE? = iocp)
+  def create_completion_port(handle : LibC::HANDLE, parent : LibC::HANDLE? = iocp)
     iocp = LibC.CreateIoCompletionPort(handle, parent, nil, 0)
     if iocp.null?
       raise IO::Error.from_winerror("CreateIoCompletionPort")
@@ -18,7 +26,7 @@ module Crystal::EventLoop
   end
 
   # This is a temporary stub as a stand in for fiber swapping required for concurrency
-  def self.wait_completion(timeout = nil)
+  def wait_completion(timeout = nil)
     result = LibC.GetQueuedCompletionStatusEx(iocp, out io_entry, 1, out removed, timeout, false)
     if result == 0
       error = WinError.value
@@ -33,8 +41,8 @@ module Crystal::EventLoop
   end
 
   # Runs the event loop.
-  def self.run_once : Nil
-    next_event = @@queue.min_by { |e| e.wake_at }
+  def run_once : Nil
+    next_event = @queue.min_by { |e| e.wake_at }
 
     if next_event
       now = Time.monotonic
@@ -67,40 +75,40 @@ module Crystal::EventLoop
   end
 
   # Reinitializes the event loop after a fork.
-  def self.after_fork : Nil
+  def after_fork : Nil
   end
 
-  def self.enqueue(event : Event)
-    unless @@queue.includes?(event)
-      @@queue << event
+  def enqueue(event : Crystal::IocpEvent)
+    unless @queue.includes?(event)
+      @queue << event
     end
   end
 
-  def self.dequeue(event : Event)
-    @@queue.delete(event)
+  def dequeue(event : Crystal::IocpEvent)
+    @queue.delete(event)
   end
 
   # Create a new resume event for a fiber.
-  def self.create_resume_event(fiber : Fiber) : Crystal::Event
-    Crystal::Event.new(fiber)
+  def create_resume_event(fiber : Fiber) : Crystal::Event
+    Crystal::IocpEvent.new(fiber)
   end
 
   # Creates a write event for a file descriptor.
-  def self.create_fd_write_event(io : IO::Evented, edge_triggered : Bool = false) : Crystal::Event
-    Crystal::Event.new(Fiber.current)
+  def create_fd_write_event(io : IO::Evented, edge_triggered : Bool = false) : Crystal::Event
+    Crystal::IocpEvent.new(Fiber.current)
   end
 
   # Creates a read event for a file descriptor.
-  def self.create_fd_read_event(io : IO::Evented, edge_triggered : Bool = false) : Crystal::Event
-    Crystal::Event.new(Fiber.current)
+  def create_fd_read_event(io : IO::Evented, edge_triggered : Bool = false) : Crystal::Event
+    Crystal::IocpEvent.new(Fiber.current)
   end
 
-  def self.create_timeout_event(fiber)
-    Crystal::Event.new(fiber, timeout: true)
+  def create_timeout_event(fiber) : Crystal::Event
+    Crystal::IocpEvent.new(fiber, timeout: true)
   end
 end
 
-struct Crystal::Event
+struct Crystal::IocpEvent < Crystal::Event
   getter fiber
   getter wake_at
   getter? timeout
@@ -110,15 +118,15 @@ struct Crystal::Event
 
   # Frees the event
   def free : Nil
-    Crystal::EventLoop.dequeue(self)
+    Crystal::Scheduler.event_loop.dequeue(self)
   end
 
   def delete
     free
   end
 
-  def add(time_span : Time::Span) : Nil
-    @wake_at = Time.monotonic + time_span
-    Crystal::EventLoop.enqueue(self)
+  def add(timeout : Time::Span?) : Nil
+    @wake_at = timeout ? Time.monotonic + timeout : Time.monotonic
+    Crystal::Scheduler.event_loop.enqueue(self)
   end
 end

--- a/src/crystal/system/win32/event_loop_iocp.cr
+++ b/src/crystal/system/win32/event_loop_iocp.cr
@@ -4,13 +4,13 @@ require "crystal/system/print_error"
 # :nodoc:
 abstract class Crystal::EventLoop
   def self.create
-    Crystal::IocpEventLoop.new
+    Crystal::Iocp::EventLoop.new
   end
 end
 
 # :nodoc:
-class Crystal::IocpEventLoop < Crystal::EventLoop
-  @queue = Deque(Crystal::IocpEvent).new
+class Crystal::Iocp::EventLoop < Crystal::EventLoop
+  @queue = Deque(Crystal::Iocp::Event).new
 
   # Returns the base IO Completion Port
   getter iocp : LibC::HANDLE do
@@ -78,37 +78,37 @@ class Crystal::IocpEventLoop < Crystal::EventLoop
   def after_fork : Nil
   end
 
-  def enqueue(event : Crystal::IocpEvent)
+  def enqueue(event : Crystal::Iocp::Event)
     unless @queue.includes?(event)
       @queue << event
     end
   end
 
-  def dequeue(event : Crystal::IocpEvent)
+  def dequeue(event : Crystal::Iocp::Event)
     @queue.delete(event)
   end
 
   # Create a new resume event for a fiber.
-  def create_resume_event(fiber : Fiber) : Crystal::Event
-    Crystal::IocpEvent.new(fiber)
+  def create_resume_event(fiber : Fiber) : Crystal::EventLoop::Event
+    Crystal::Iocp::Event.new(fiber)
   end
 
   # Creates a write event for a file descriptor.
-  def create_fd_write_event(io : IO::Evented, edge_triggered : Bool = false) : Crystal::Event
-    Crystal::IocpEvent.new(Fiber.current)
+  def create_fd_write_event(io : IO::Evented, edge_triggered : Bool = false) : Crystal::EventLoop::Event
+    Crystal::Iocp::Event.new(Fiber.current)
   end
 
   # Creates a read event for a file descriptor.
-  def create_fd_read_event(io : IO::Evented, edge_triggered : Bool = false) : Crystal::Event
-    Crystal::IocpEvent.new(Fiber.current)
+  def create_fd_read_event(io : IO::Evented, edge_triggered : Bool = false) : Crystal::EventLoop::Event
+    Crystal::Iocp::Event.new(Fiber.current)
   end
 
-  def create_timeout_event(fiber) : Crystal::Event
-    Crystal::IocpEvent.new(fiber, timeout: true)
+  def create_timeout_event(fiber) : Crystal::EventLoop::Event
+    Crystal::Iocp::Event.new(fiber, timeout: true)
   end
 end
 
-struct Crystal::IocpEvent < Crystal::Event
+struct Crystal::Iocp::Event < Crystal::EventLoop::Event
   getter fiber
   getter wake_at
   getter? timeout

--- a/src/crystal/system/win32/socket.cr
+++ b/src/crystal/system/win32/socket.cr
@@ -79,7 +79,7 @@ module Crystal::System::Socket
       raise ::Socket::Error.from_wsa_error("WSASocketW")
     end
 
-    Crystal::EventLoop.create_completion_port LibC::HANDLE.new(socket)
+    Crystal::Scheduler.event_loop.create_completion_port LibC::HANDLE.new(socket)
 
     socket
   end

--- a/src/fiber.cr
+++ b/src/fiber.cr
@@ -52,8 +52,8 @@ class Fiber
 
   @context : Context
   @stack : Void*
-  @resume_event : Crystal::Event?
-  @timeout_event : Crystal::Event?
+  @resume_event : Crystal::EventLoop::Event?
+  @timeout_event : Crystal::EventLoop::Event?
   # :nodoc:
   property timeout_select_action : Channel::TimeoutAction?
   protected property stack_bottom : Void*
@@ -224,12 +224,12 @@ class Fiber
   end
 
   # :nodoc:
-  def resume_event : Crystal::Event
+  def resume_event : Crystal::EventLoop::Event
     @resume_event ||= Crystal::Scheduler.event_loop.create_resume_event(self)
   end
 
   # :nodoc:
-  def timeout_event : Crystal::Event
+  def timeout_event : Crystal::EventLoop::Event
     @timeout_event ||= Crystal::Scheduler.event_loop.create_timeout_event(self)
   end
 

--- a/src/fiber.cr
+++ b/src/fiber.cr
@@ -225,12 +225,12 @@ class Fiber
 
   # :nodoc:
   def resume_event : Crystal::Event
-    @resume_event ||= Crystal::EventLoop.create_resume_event(self)
+    @resume_event ||= Crystal::Scheduler.event_loop.create_resume_event(self)
   end
 
   # :nodoc:
   def timeout_event : Crystal::Event
-    @timeout_event ||= Crystal::EventLoop.create_timeout_event(self)
+    @timeout_event ||= Crystal::Scheduler.event_loop.create_timeout_event(self)
   end
 
   # :nodoc:

--- a/src/io/evented.cr
+++ b/src/io/evented.cr
@@ -136,7 +136,7 @@ module IO::Evented
   end
 
   private def add_read_event(timeout = @read_timeout) : Nil
-    event = @read_event.get { Crystal::EventLoop.create_fd_read_event(self) }
+    event = @read_event.get { Crystal::Scheduler.event_loop.create_fd_read_event(self) }
     event.add timeout
   end
 
@@ -161,7 +161,7 @@ module IO::Evented
   end
 
   private def add_write_event(timeout = @write_timeout) : Nil
-    event = @write_event.get { Crystal::EventLoop.create_fd_write_event(self) }
+    event = @write_event.get { Crystal::Scheduler.event_loop.create_fd_write_event(self) }
     event.add timeout
   end
 

--- a/src/io/evented.cr
+++ b/src/io/evented.cr
@@ -12,8 +12,8 @@ module IO::Evented
   @readers = Crystal::ThreadLocalValue(Deque(Fiber)).new
   @writers = Crystal::ThreadLocalValue(Deque(Fiber)).new
 
-  @read_event = Crystal::ThreadLocalValue(Crystal::Event).new
-  @write_event = Crystal::ThreadLocalValue(Crystal::Event).new
+  @read_event = Crystal::ThreadLocalValue(Crystal::EventLoop::Event).new
+  @write_event = Crystal::ThreadLocalValue(Crystal::EventLoop::Event).new
 
   # Returns the time to wait when reading before raising an `IO::TimeoutError`.
   def read_timeout : Time::Span?

--- a/src/io/overlapped.cr
+++ b/src/io/overlapped.cr
@@ -158,10 +158,10 @@ module IO::Overlapped
   # Returns `false` if the operation timed out.
   def schedule_overlapped(timeout : Time::Span?, line = __LINE__) : Bool
     if timeout
-      timeout_event = Crystal::IocpEvent.new(Fiber.current)
+      timeout_event = Crystal::Iocp::Event.new(Fiber.current)
       timeout_event.add(timeout)
     else
-      timeout_event = Crystal::IocpEvent.new(Fiber.current, Time::Span::MAX)
+      timeout_event = Crystal::Iocp::Event.new(Fiber.current, Time::Span::MAX)
     end
     Crystal::Scheduler.event_loop.enqueue(timeout_event)
 

--- a/src/kernel.cr
+++ b/src/kernel.cr
@@ -540,7 +540,7 @@ end
         ->Crystal::SignalChildHandler.after_fork,
 
         # reinit event loop:
-        ->Crystal::EventLoop.after_fork,
+        ->{ Crystal::Scheduler.event_loop.after_fork },
 
         # more clean ups (may depend on event loop):
         ->Random::DEFAULT.new_seed,


### PR DESCRIPTION
This is a part of #10740 / #10768.

Currently each target must implement [the event loop interface](https://github.com/crystal-lang/crystal/blob/c60bccac221d4e14af75cc256026caec8b3f5cda/src/crystal/system/event_loop.cr), which is a module with static methods. This PR changes the module to be an abstract class instead. The goal is to support systems where multiple event loops are available and can be selected at runtime (Linux with io_uring, for example). No additional event loop implementation is introduced here.

The event loop instance is held by an instance variable at `Crystal::Scheduler` (one per thread) and can be accessed with `Crystal::Scheduler.event_loop`. This is not a public API!

#10768 will later be refactored on top of this PR.