### PR TITLE
test multiline ECR on Windows

### DIFF
--- a/spec/std/data/test_template7.ecr
+++ b/spec/std/data/test_template7.ecr
@@ -1,0 +1,5 @@
+<%
+  string = "string"
+-%>
+
+<%-= string -%>

--- a/spec/std/ecr/ecr_spec.cr
+++ b/spec/std/ecr/ecr_spec.cr
@@ -65,6 +65,12 @@ describe "ECR" do
     io.to_s.should eq("string with -%")
   end
 
+  it "does not raise an error: expected '\n' after '\r' on Windows" do
+    io = IO::Memory.new
+    ECR.embed "#{__DIR__}/../data/test_template7.ecr", io
+    io.to_s.should eq("\nstring")
+  end
+
   it ".render" do
     ECR.render("#{__DIR__}/../data/test_template2.ecr").should eq("123")
   end


### PR DESCRIPTION
Nothing to see here.

I just want to test is this is an issue with Crystal on Windows

![image](https://user-images.githubusercontent.com/61285/197739975-88a7d4f9-06d6-4784-8500-4900d6540dc5.png)
