### PR TITLE
Compiler: ignore type filters when accepting cast obj and to

### DIFF
--- a/spec/compiler/semantic/nilable_cast_spec.cr
+++ b/spec/compiler/semantic/nilable_cast_spec.cr
@@ -74,4 +74,16 @@ describe "Semantic: nilable cast" do
       base.as?(Moo)
       )) { union_of([types["Foo"], types["Bar"], nil_type] of Type) }
   end
+
+  it "doesn't introduce type filter for nilable cast object (#12661)" do
+    assert_type(%(
+      val = 1 || false
+
+      if val.as?(Char)
+        true
+      else
+        val
+      end
+      )) { union_of(int32, bool) }
+  end
 end

--- a/src/compiler/crystal/semantic/main_visitor.cr
+++ b/src/compiler/crystal/semantic/main_visitor.cr
@@ -1766,10 +1766,14 @@ module Crystal
         typed_def.raises = true
       end
 
-      node.obj.accept self
+      ignoring_type_filters do
+        node.obj.accept self
+      end
 
       @in_type_args += 1
-      node.to.accept self
+      ignoring_type_filters do
+        node.to.accept self
+      end
       @in_type_args -= 1
 
       node.obj.add_observer node


### PR DESCRIPTION
Fixes #12661