### PR TITLE
Remove unused `Program#cache_dir` property

### DIFF
--- a/src/compiler/crystal/compiler.cr
+++ b/src/compiler/crystal/compiler.cr
@@ -194,7 +194,6 @@ module Crystal
       @program = program = Program.new
       program.compiler = self
       program.filename = sources.first.filename
-      program.cache_dir = CacheDir.instance.directory_for(sources)
       program.codegen_target = codegen_target
       program.target_machine = target_machine
       program.flags << "release" if release?

--- a/src/compiler/crystal/program.cr
+++ b/src/compiler/crystal/program.cr
@@ -84,9 +84,6 @@ module Crystal
     # This pool is passed to the parser, macro expander, etc.
     getter string_pool = StringPool.new
 
-    # The cache directory where temporary files are placed.
-    setter cache_dir : String?
-
     # Here we store constants, in the
     # order that they are used. They will be initialized as soon
     # as the program starts, before the main code.


### PR DESCRIPTION
This instance variable is only ever assigned, but never read. So it seems to be unused and can be removed.
https://github.com/crystal-lang/crystal/issues/9602#issuecomment-1291223289