### PR TITLE
Add compile time string interpolation for char/num/bool constants

### DIFF
--- a/spec/compiler/normalize/string_interpolation_spec.cr
+++ b/spec/compiler/normalize/string_interpolation_spec.cr
@@ -52,4 +52,43 @@ describe "Normalize: string interpolation" do
     string = node.should be_a(StringLiteral)
     string.value.should eq("hello world")
   end
+
+  it "replaces char constant" do
+    result = semantic(%(
+      def String.interpolation(*args); ""; end
+
+      OBJ = 'l'
+
+      "hello wor\#{OBJ}d"
+    ))
+    node = result.node.as(Expressions).last
+    string = node.should be_a(StringLiteral)
+    string.value.should eq("hello world")
+  end
+
+  it "replaces number constant" do
+    result = semantic(%(
+      def String.interpolation(*args); ""; end
+
+      OBJ = 9_f32
+
+      "nine as a float: \#{OBJ}"
+    ))
+    node = result.node.as(Expressions).last
+    string = node.should be_a(StringLiteral)
+    string.value.should eq("nine as a float: 9.0")
+  end
+
+  it "replaces boolean constant" do
+    result = semantic(%(
+      def String.interpolation(*args); ""; end
+
+      OBJ = false
+
+      "boolean false: \#{OBJ}"
+    ))
+    node = result.node.as(Expressions).last
+    string = node.should be_a(StringLiteral)
+    string.value.should eq("boolean false: false")
+  end
 end

--- a/src/compiler/crystal/semantic/cleanup_transformer.cr
+++ b/src/compiler/crystal/semantic/cleanup_transformer.cr
@@ -253,7 +253,7 @@ module Crystal
       string = node.expressions.join do |exp|
         if !(transformed_piece = solve_string_interpolation_expression(exp)).nil?
           # Valid piece, continue joining
-          transformed_piece
+          next transformed_piece
         elsif expanded = node.expanded
           # Invalid piece, transform expansion and exit early
           return expanded.transform(self)

--- a/src/compiler/crystal/semantic/cleanup_transformer.cr
+++ b/src/compiler/crystal/semantic/cleanup_transformer.cr
@@ -250,35 +250,28 @@ module Crystal
     end
 
     def transform(node : StringInterpolation)
-      # See if we can solve all the pieces to string literals.
-      # If that's the case, we can replace the entire interpolation
-      # with a single string literal.
-      pieces = node.expressions.dup
-      solve_string_interpolation_expressions(pieces)
-
-      if pieces.all?(StringLiteral)
-        string = pieces.join(&.as(StringLiteral).value)
-        string_literal = StringLiteral.new(string).at(node)
-        string_literal.type = @program.string
-        return string_literal
+      string = node.expressions.join do |exp|
+        if !(transformed_piece = solve_string_interpolation_expression(exp)).nil?
+          # Valid piece, continue joining
+          transformed_piece
+        elsif expanded = node.expanded
+          # Invalid piece, transform expansion and exit early
+          return expanded.transform(self)
+        else
+          # No expansion, return self
+          return node
+        end
       end
-
-      if expanded = node.expanded
-        return expanded.transform(self)
-      end
-      node
+      string_literal = StringLiteral.new(string).at(node)
+      string_literal.type = @program.string
+      string_literal
     end
 
-    private def solve_string_interpolation_expressions(pieces : Array(ASTNode))
-      pieces.each_with_index do |piece, i|
-        replacement = solve_string_interpolation_expression(piece)
-        next unless replacement
-
-        pieces[i] = replacement
-      end
-    end
-
-    private def solve_string_interpolation_expression(piece : ASTNode) : StringLiteral?
+    # Returns the solved piece for string interpolation, if it can find one.
+    # For example, this returns a String when given a StringLiteral.
+    private def solve_string_interpolation_expression(piece : ASTNode) : String | Char | Number::Primitive | Bool | Nil
+      # Check for ExpandableNode happens first in case any nodes below are
+      # updated to be ExpandableNodes themselves.
       if piece.is_a?(ExpandableNode)
         if expanded = piece.expanded
           return solve_string_interpolation_expression(expanded)
@@ -288,13 +281,13 @@ module Crystal
       case piece
       when Path
         if target_const = piece.target_const
-          return solve_string_interpolation_expression(target_const.value)
+          solve_string_interpolation_expression(target_const.value)
         end
-      when StringLiteral
-        return piece
+      when StringLiteral then piece.value
+      when CharLiteral   then piece.value
+      when NumberLiteral then piece.to_number
+      when BoolLiteral   then piece.value
       end
-
-      nil
     end
 
     def transform(node : ExpandableNode)


### PR DESCRIPTION
This updates the approach for compile-time string interpolation, as well as adds the ability to interpolate CharLiteral, NumberLiteral, and BoolLiteral.

Resolves #12521