### PR TITLE
Lint: Remove comparisons with boolean literals

### DIFF
--- a/src/compiler/crystal/semantic/call_error.cr
+++ b/src/compiler/crystal/semantic/call_error.cr
@@ -100,7 +100,7 @@ class Crystal::Call
 
     # If we made a lookup without the special rule for literals,
     # and we have literals in the call, try again with that special rule.
-    if with_autocast == false && (args.any?(&.supports_autocast? number_autocast) ||
+    if !with_autocast && (args.any?(&.supports_autocast? number_autocast) ||
        named_args.try &.any? &.value.supports_autocast? number_autocast)
       ::raise RetryLookupWithLiterals.new
     end

--- a/src/fiber.cr
+++ b/src/fiber.cr
@@ -193,7 +193,7 @@ class Fiber
   # The fiber's proc has terminated, and the fiber is now considered dead. The
   # fiber is impossible to resume, ever.
   def dead? : Bool
-    @alive == false
+    !@alive
   end
 
   # Immediately resumes execution of this fiber.

--- a/src/iterator.cr
+++ b/src/iterator.cr
@@ -1065,7 +1065,7 @@ module Iterator(T)
     def next
       while true
         value = wrapped_next
-        return value if @returned_false == true
+        return value if @returned_false
         unless @func.call(value)
           @returned_false = true
           return value
@@ -1209,7 +1209,7 @@ module Iterator(T)
     end
 
     def next
-      return stop if @returned_false == true
+      return stop if @returned_false
       value = wrapped_next
       if @func.call(value)
         value


### PR DESCRIPTION
All of these are redundant, since the values could be used directly, or negated.