### PR TITLE
Lint: Use `Object#in?` instead of multiple comparisons

### DIFF
--- a/samples/sdl/raytracer.cr
+++ b/samples/sdl/raytracer.cr
@@ -224,7 +224,7 @@ surface = SDL.set_video_mode WIDTH, HEIGHT, 32, LibSDL::DOUBLEBUF | LibSDL::HWSU
 first = true
 while true
   SDL.poll_events do |event|
-    if event.type == LibSDL::QUIT || event.type == LibSDL::KEYDOWN
+    if event.type.in?(LibSDL::QUIT, LibSDL::KEYDOWN)
       SDL.quit
       exit
     end

--- a/samples/sdl/raytracer.cr
+++ b/samples/sdl/raytracer.cr
@@ -222,19 +222,24 @@ SDL.hide_cursor
 surface = SDL.set_video_mode WIDTH, HEIGHT, 32, LibSDL::DOUBLEBUF | LibSDL::HWSURFACE | LibSDL::ASYNCBLIT
 
 first = true
-while true
-  SDL.poll_events do |event|
-    if event.type.in?(LibSDL::QUIT, LibSDL::KEYDOWN)
-      SDL.quit
-      exit
+
+begin
+  while true
+    SDL.poll_events do |event|
+      if event.type.in?(LibSDL::QUIT, LibSDL::KEYDOWN)
+        SDL.quit
+        exit
+      end
+    end
+
+    if first
+      start = SDL.ticks
+      render scene, surface
+      ms = SDL.ticks - start
+      puts "Rendered in #{ms} ms"
+      first = false
     end
   end
-
-  if first
-    start = SDL.ticks
-    render scene, surface
-    ms = SDL.ticks - start
-    puts "Rendered in #{ms} ms"
-    first = false
-  end
+ensure
+  SDL.quit
 end

--- a/samples/sdl/tv.cr
+++ b/samples/sdl/tv.cr
@@ -133,7 +133,7 @@ puts "Rects: #{rects.size}"
 begin
   while true
     SDL.poll_events do |event|
-      if event.type == LibSDL::QUIT || event.type == LibSDL::KEYDOWN
+      if event.type.in?(LibSDL::QUIT, LibSDL::KEYDOWN)
         ms = SDL.ticks - start
         puts "#{frames} frames in #{ms} ms"
         puts "Average FPS: #{frames / (ms * 0.001)}"

--- a/spec/compiler/codegen/union_type_spec.cr
+++ b/spec/compiler/codegen/union_type_spec.cr
@@ -202,7 +202,7 @@ describe "Code gen: union type" do
       a = 1 || 1.5
       foo(a)
       )).to_string
-    (str == "(Int32 | Float64)" || str == "(Float64 | Int32)").should be_true
+    str.in?("(Int32 | Float64)", "(Float64 | Int32)").should be_true
   end
 
   it "provides T as a tuple literal" do

--- a/spec/std/string_spec.cr
+++ b/spec/std/string_spec.cr
@@ -824,7 +824,7 @@ describe "String" do
     it { "bcdaaa".strip('a').should eq("bcd") }
     it { "aaabcd".strip('a').should eq("bcd") }
 
-    it { "ababcdaba".strip { |c| c == 'a' || c == 'b' }.should eq("cd") }
+    it { "ababcdaba".strip(&.in?('a', 'b')).should eq("cd") }
   end
 
   describe "rstrip" do
@@ -845,7 +845,7 @@ describe "String" do
     it { "foobarrrr".rstrip('r').should eq("fooba") }
     it { "foobar".rstrip('x').should eq("foobar") }
 
-    it { "foobar".rstrip { |c| c == 'a' || c == 'r' }.should eq("foob") }
+    it { "foobar".rstrip(&.in?('a', 'r')).should eq("foob") }
 
     it "does not touch invalid code units in an otherwise ascii string" do
       " \xA0 ".rstrip.should eq(" \xA0")
@@ -869,7 +869,7 @@ describe "String" do
     it { "bbbbarfoo".lstrip('b').should eq("arfoo") }
     it { "barfoo".lstrip('x').should eq("barfoo") }
 
-    it { "barfoo".lstrip { |c| c == 'a' || c == 'b' }.should eq("rfoo") }
+    it { "barfoo".lstrip(&.in?('a', 'b')).should eq("rfoo") }
 
     it "does not touch invalid code units in an otherwise ascii string" do
       " \xA0 ".lstrip.should eq("\xA0 ")

--- a/src/base64.cr
+++ b/src/base64.cr
@@ -252,7 +252,7 @@ module Base64
     bytes_begin = bytes
 
     # Get the position of the last valid base64 character (rstrip '\n', '\r' and '=')
-    while (size > 0) && (sym = bytes[size - 1]) && (sym == NL || sym == NR || sym == PAD)
+    while (size > 0) && (sym = bytes[size - 1]) && sym.in?(NL, NR, PAD)
       size -= 1
     end
 

--- a/src/compiler/crystal/command.cr
+++ b/src/compiler/crystal/command.cr
@@ -95,7 +95,7 @@ class Crystal::Command
     when command == "eval"
       options.shift
       eval
-    when command == "i" || command == "interactive"
+    when command.in?("i", "interactive")
       options.shift
       {% if flag?(:without_interpreter) %}
         STDERR.puts "Crystal was compiled without interpreter support"

--- a/src/compiler/crystal/semantic/call.cr
+++ b/src/compiler/crystal/semantic/call.cr
@@ -1167,7 +1167,7 @@ class Crystal::Call
       args["self"] = MetaVar.new("self", self_type)
     end
 
-    strict_check = body.is_a?(Primitive) && (body.name == "proc_call" || body.name == "pointer_set")
+    strict_check = body.is_a?(Primitive) && body.name.in?("proc_call", "pointer_set")
 
     arg_types.each_index do |index|
       arg = typed_def.args[index]

--- a/src/compiler/crystal/semantic/call_error.cr
+++ b/src/compiler/crystal/semantic/call_error.cr
@@ -67,7 +67,7 @@ class Crystal::Call
     # Another special case: `new` and `initialize` are only looked up one level,
     # so we must find the first one defined.
     new_owner = owner
-    while defs.empty? && (def_name == "initialize" || def_name == "new")
+    while defs.empty? && def_name.in?("initialize", "new")
       new_owner = new_owner.superclass
       if new_owner
         defs = new_owner.lookup_defs(def_name)
@@ -106,7 +106,7 @@ class Crystal::Call
     end
 
     # If it's on an initialize method and there's a similar method name, it's probably a typo
-    if (def_name == "initialize" || def_name == "new") && (similar_def = owner.instance_type.lookup_similar_def("initialize", self.args.size, block))
+    if def_name.in?("initialize", "new") && (similar_def = owner.instance_type.lookup_similar_def("initialize", self.args.size, block))
       inner_msg = colorize("do you maybe have a typo in this '#{similar_def.name}' method?").yellow.bold.to_s
       inner_exception = TypeException.for_node(similar_def, inner_msg)
     end

--- a/src/compiler/crystal/semantic/type_guess_visitor.cr
+++ b/src/compiler/crystal/semantic/type_guess_visitor.cr
@@ -667,7 +667,7 @@ module Crystal
       # If it's Pointer(T).malloc or Pointer(T).null, guess it to Pointer(T)
       if obj.is_a?(Generic) &&
          (name = obj.name).is_a?(Path) && name.single?("Pointer") &&
-         (node.name == "malloc" || node.name == "null")
+         node.name.in?("malloc", "null")
         type = lookup_type?(obj)
         return type if type.is_a?(PointerInstanceType)
       end

--- a/src/compiler/crystal/syntax/ast.cr
+++ b/src/compiler/crystal/syntax/ast.cr
@@ -295,7 +295,7 @@ module Crystal
     end
 
     def has_sign?
-      @value[0] == '+' || @value[0] == '-'
+      @value[0].in?('+', '-')
     end
 
     def integer_value

--- a/src/compiler/crystal/syntax/lexer.cr
+++ b/src/compiler/crystal/syntax/lexer.cr
@@ -630,7 +630,7 @@ module Crystal
               while ident_part?(next_char)
                 # Nothing to do
               end
-              if current_char == '?' || ((current_char == '!' || current_char == '=') && peek_next_char != '=')
+              if current_char == '?' || (current_char.in?('!', '=') && peek_next_char != '=')
                 next_char
               end
               @token.type = :SYMBOL
@@ -1450,7 +1450,7 @@ module Crystal
       while ident_part?(current_char)
         next_char
       end
-      if (current_char == '?' || current_char == '!') && peek_next_char != '='
+      if current_char.in?('?', '!') && peek_next_char != '='
         next_char
       end
       @token.type = :IDENT
@@ -1896,7 +1896,7 @@ module Crystal
         end
 
         if reached_end &&
-           (current_char == '\n' || current_char == '\0' ||
+           (current_char.in?('\n', '\0') ||
            (current_char == '\r' && peek_next_char == '\n' && next_char))
           @token.type = :DELIMITER_END
           @token.delimiter_state = delimiter_state.with_heredoc_indent(indent)
@@ -2251,7 +2251,7 @@ module Crystal
               whitespace = false
               beginning_of_line = true
             else
-              whitespace = char.ascii_whitespace? || char == ';' || char == '(' || char == '[' || char == '{'
+              whitespace = char.ascii_whitespace? || char.in?(';', '(', '[', '{')
               if beginning_of_line && !whitespace
                 beginning_of_line = false
               end
@@ -2907,7 +2907,7 @@ module Crystal
     private delegate ident_start?, ident_part?, to: Lexer
 
     def ident_part_or_end?(char)
-      ident_part?(char) || char == '?' || char == '!'
+      ident_part?(char) || char.in?('?', '!')
     end
 
     def peek_not_ident_part_or_end_next_char

--- a/src/compiler/crystal/syntax/parser.cr
+++ b/src/compiler/crystal/syntax/parser.cr
@@ -241,7 +241,7 @@ module Crystal
         !exp.has_parentheses? && (
           (exp.args.empty? && !exp.named_args) ||
             Lexer.setter?(exp.name) ||
-            exp.name == "[]" || exp.name == "[]="
+            exp.name.in?("[]", "[]=")
         )
       else
         false
@@ -2218,7 +2218,7 @@ module Crystal
         this_piece_is_in_new_line = line_number != previous_line_number
         next_piece_is_in_new_line = i == pieces.size - 1 || pieces[i + 1].line_number != line_number
         if value.is_a?(String)
-          if value == "\n" || value == "\r\n"
+          if value.in?("\n", "\r\n")
             current_line << value
             if this_piece_is_in_new_line || next_piece_is_in_new_line
               line = current_line.to_s
@@ -4298,7 +4298,7 @@ module Crystal
       while current_char.ascii_whitespace?
         next_char_no_column_increment
       end
-      comes_plus_or_minus = current_char == '+' || current_char == '-'
+      comes_plus_or_minus = current_char.in?('+', '-')
       self.current_pos = pos
       comes_plus_or_minus
     end

--- a/src/compiler/crystal/syntax/to_s.cr
+++ b/src/compiler/crystal/syntax/to_s.cr
@@ -73,9 +73,7 @@ module Crystal
         # If there's no '.' nor 'e', for example in `1_f64`,
         # we need to include it (#3315)
         node.value.each_char do |char|
-          if char == '.' || char == 'e'
-            return false
-          end
+          return false if char.in?('.', 'e')
         end
 
         true
@@ -347,7 +345,7 @@ module Crystal
         node_obj = nil
       end
 
-      if node_obj && (node.name == "[]" || node.name == "[]?") && !block
+      if node_obj && node.name.in?("[]", "[]?") && !block
         in_parenthesis(need_parens, node_obj)
 
         @str << "["

--- a/src/compiler/crystal/tools/formatter.cr
+++ b/src/compiler/crystal/tools/formatter.cr
@@ -2508,7 +2508,7 @@ module Crystal
       base_indent = @indent
 
       # Special case: $1, $2, ...
-      if @token.type.global_match_data_index? && (node.name == "[]" || node.name == "[]?") && obj.is_a?(Global)
+      if @token.type.global_match_data_index? && node.name.in?("[]", "[]?") && obj.is_a?(Global)
         write "$"
         write @token.value
         next_token
@@ -2663,7 +2663,7 @@ module Crystal
       end
 
       # This is for foo &.[bar] and &.[bar]?, or foo.[bar] and foo.[bar]?
-      if (node.name == "[]" || node.name == "[]?") && @token.type.op_lsquare?
+      if node.name.in?("[]", "[]?") && @token.type.op_lsquare?
         write "["
         next_token_skip_space_or_newline
         format_call_args(node, false, base_indent)
@@ -4741,7 +4741,7 @@ module Crystal
               @current_doc_comment = nil
             else
               # Normalize crystal language tag
-              if language == "cr" || language == "crystal"
+              if language.in?("cr", "crystal")
                 value = value.rchop(language)
                 language = ""
               end

--- a/src/compiler/crystal/tools/init.cr
+++ b/src/compiler/crystal/tools/init.cr
@@ -130,7 +130,7 @@ module Crystal
       when !name[0].ascii_letter?            then raise Error.new("NAME must start with a letter")
       when name.index("--")                  then raise Error.new("NAME must not have consecutive dashes")
       when name.index("__")                  then raise Error.new("NAME must not have consecutive underscores")
-      when !name.each_char.all? { |c| c.alphanumeric? || c == '-' || c == '_' }
+      when !name.each_char.all? { |c| c.alphanumeric? || c.in?('-', '_') }
         raise Error.new("NAME must only contain alphanumerical characters, underscores or dashes")
       else
         # name is valid

--- a/src/compiler/crystal/tools/playground/server.cr
+++ b/src/compiler/crystal/tools/playground/server.cr
@@ -534,7 +534,7 @@ module Crystal::Playground
     private def accept_request?(origin)
       case @host
       when nil, "localhost", "127.0.0.1"
-        origin.in?("http://127.0.0.1:#{@port}", "http://localhost:#{@port}")
+        origin.in?("http://localhost:#{@port}", "http://127.0.0.1:#{@port}")
       when "0.0.0.0"
         true
       else

--- a/src/compiler/crystal/tools/playground/server.cr
+++ b/src/compiler/crystal/tools/playground/server.cr
@@ -231,7 +231,7 @@ module Crystal::Playground
                   File.read(@filename)
                 end
 
-      if extname == ".md" || extname == ".cr"
+      if extname.in?(".md", ".cr")
         content = Markd.to_html(content)
       end
       content
@@ -534,7 +534,7 @@ module Crystal::Playground
     private def accept_request?(origin)
       case @host
       when nil, "localhost", "127.0.0.1"
-        origin == "http://127.0.0.1:#{@port}" || origin == "http://localhost:#{@port}"
+        origin.in?("http://127.0.0.1:#{@port}", "http://localhost:#{@port}")
       when "0.0.0.0"
         true
       else

--- a/src/crystal/mach_o.cr
+++ b/src/crystal/mach_o.cr
@@ -112,7 +112,7 @@ module Crystal
 
     private def read_magic
       magic = @io.read_bytes(UInt32)
-      unless magic == MAGIC_64 || magic == CIGAM_64 || magic == MAGIC || magic == CIGAM
+      unless magic.in?(MAGIC_64, CIGAM_64, MAGIC, CIGAM)
         raise Error.new("Invalid magic number")
       end
       magic
@@ -123,7 +123,7 @@ module Crystal
     end
 
     def endianness
-      if @magic == MAGIC_64 || @magic == MAGIC
+      if @magic.in?(MAGIC_64, MAGIC)
         IO::ByteFormat::SystemEndian
       elsif IO::ByteFormat::SystemEndian == IO::ByteFormat::LittleEndian
         IO::ByteFormat::BigEndian

--- a/src/crystal/system/unix/getrandom.cr
+++ b/src/crystal/system/unix/getrandom.cr
@@ -103,7 +103,7 @@ module Crystal::System::Random
       read_bytes = Syscall.getrandom(buf.to_unsafe, LibC::SizeT.new(buf.size), Syscall::GRND_NONBLOCK)
       if read_bytes < 0
         err = Errno.new(-read_bytes.to_i)
-        if err == Errno::EINTR || err == Errno::EAGAIN
+        if err.in?(Errno::EINTR, Errno::EAGAIN)
           ::Fiber.yield
         else
           raise RuntimeError.from_os_error("getrandom", err)

--- a/src/csv/lexer.cr
+++ b/src/csv/lexer.cr
@@ -138,7 +138,7 @@ abstract class CSV::Lexer
   private def next_char
     @column_number += 1
     char = next_char_no_column_increment
-    if char == '\n' || char == '\r'
+    if char.in?('\n', '\r')
       @column_number = 0
       @line_number += 1
     end

--- a/src/dir/glob.cr
+++ b/src/dir/glob.cr
@@ -147,7 +147,7 @@ class Dir
 
     private def self.constant_entry?(file)
       file.each_char do |char|
-        return false if char == '*' || char == '?'
+        return false if char.in?('*', '?')
       end
 
       true
@@ -325,7 +325,7 @@ class Dir
     private def self.each_child(path)
       Dir.open(path || Dir.current) do |dir|
         while entry = read_entry(dir)
-          next if entry.name == "." || entry.name == ".."
+          next if entry.name.in?(".", "..")
           yield entry
         end
       end

--- a/src/enumerable.cr
+++ b/src/enumerable.cr
@@ -190,7 +190,7 @@ module Enumerable(T)
 
       def same_as?(key) : Bool
         return false unless @initialized
-        return false if key == Alone || key == Drop
+        return false if key.in?(Alone, Drop)
         @key == key
       end
 

--- a/src/http/request.cr
+++ b/src/http/request.cr
@@ -113,7 +113,7 @@ class HTTP::Request
   end
 
   def body=(@body : Nil)
-    @headers["Content-Length"] = "0" if @method == "POST" || @method == "PUT"
+    @headers["Content-Length"] = "0" if @method.in?("POST", "PUT")
   end
 
   def to_io(io)

--- a/src/json/lexer.cr
+++ b/src/json/lexer.cr
@@ -275,7 +275,7 @@ abstract class JSON::Lexer
       char = next_char
     end
 
-    if char == 'e' || char == 'E'
+    if char.in?('e', 'E')
       consume_exponent
     else
       @token.kind = :float

--- a/src/llvm/abi/x86_64.cr
+++ b/src/llvm/abi/x86_64.cr
@@ -89,7 +89,7 @@ class LLVM::ABI::X86_64 < LLVM::ABI
     return false if cls.empty?
 
     cl = cls.first
-    cl == RegClass::Memory || cl == RegClass::X87 || cl == RegClass::ComplexX87
+    cl.in?(RegClass::Memory, RegClass::X87, RegClass::ComplexX87)
   end
 
   def sret?(cls) : Bool
@@ -161,7 +161,7 @@ class LLVM::ABI::X86_64 < LLVM::ABI
     i = 0
     ty_kind = ty.kind
     e = cls.size
-    if e > 2 && (ty_kind == Type::Kind::Struct || ty_kind == Type::Kind::Array)
+    if e > 2 && ty_kind.in?(Type::Kind::Struct, Type::Kind::Array)
       if cls[i].sse?
         i += 1
         while i < e

--- a/src/mime/multipart/parser.cr
+++ b/src/mime/multipart/parser.cr
@@ -115,7 +115,7 @@ module MIME::Multipart
 
         0.upto(transport_padding_crlf.bytesize - 3) do |i| # 3 constant to ignore "\r\n" at end
           byte = transport_padding_crlf.to_unsafe[i]
-          fail("padding contained non-whitespace character") unless byte == ' '.ord || byte == '\t'.ord
+          fail("padding contained non-whitespace character") unless byte.in?(' '.ord, '\t'.ord)
         end
       end
 

--- a/src/process.cr
+++ b/src/process.cr
@@ -229,9 +229,9 @@ class Process
     pid = Crystal::System::Process.spawn(command_args, env, clear_env, fork_input, fork_output, fork_error, chdir)
     @process_info = Crystal::System::Process.new(pid)
 
-    fork_input.close unless fork_input == input || fork_input == STDIN
-    fork_output.close unless fork_output == output || fork_output == STDOUT
-    fork_error.close unless fork_error == error || fork_error == STDERR
+    fork_input.close unless fork_input.in?(input, STDIN)
+    fork_output.close unless fork_output.in?(output, STDOUT)
+    fork_error.close unless fork_error.in?(error, STDERR)
   end
 
   def finalize

--- a/src/socket/addrinfo.cr
+++ b/src/socket/addrinfo.cr
@@ -151,7 +151,7 @@ class Socket
         # On OS X < 10.12, the libsystem implementation of getaddrinfo segfaults
         # if AI_NUMERICSERV is set, and servname is NULL or 0.
         {% if flag?(:darwin) %}
-          if (service == 0 || service == nil) && (hints.ai_flags & LibC::AI_NUMERICSERV)
+          if service.in?(0, nil) && (hints.ai_flags & LibC::AI_NUMERICSERV)
             hints.ai_flags |= LibC::AI_NUMERICSERV
             service = "00"
           end

--- a/src/spec/cli.cr
+++ b/src/spec/cli.cr
@@ -88,7 +88,7 @@ module Spec
         Spec.add_tag tag
       end
       opts.on("--order MODE", "run examples in random order by passing MODE as 'random' or to a specific seed by passing MODE as the seed value") do |mode|
-        if mode == "default" || mode == "random"
+        if mode.in?("default", "random")
           Spec.order = mode
         elsif seed = mode.to_u64?
           Spec.order = seed

--- a/src/string.cr
+++ b/src/string.cr
@@ -736,7 +736,7 @@ class String
   end
 
   private def to_f_impl(whitespace : Bool = true, strict : Bool = true)
-    return unless whitespace || '0' <= self[0] <= '9' || self[0] == '-' || self[0] == '+'
+    return unless whitespace || '0' <= self[0] <= '9' || self[0].in?('-', '+')
 
     v, endptr = yield
 

--- a/src/time/format/custom/iso_8601.cr
+++ b/src/time/format/custom/iso_8601.cr
@@ -77,7 +77,7 @@ struct Time::Format
 
           second
 
-          if current_char == '.' || current_char == ','
+          if current_char.in?('.', ',')
             next_char
             second_fraction
           end
@@ -86,7 +86,7 @@ struct Time::Format
         end
       end
 
-      if current_char == '.' || current_char == ','
+      if current_char.in?('.', ',')
         next_char
 
         pos = @reader.pos

--- a/src/time/format/formatter.cr
+++ b/src/time/format/formatter.cr
@@ -211,7 +211,7 @@ struct Time::Format
     end
 
     def time_zone_gmt_or_rfc2822(**options) : Nil
-      if time.utc? || time.location.name == "UT" || time.location.name == "GMT"
+      if time.utc? || time.location.name.in?("UT", "GMT")
         time_zone_gmt
       else
         time_zone_rfc2822

--- a/src/uri.cr
+++ b/src/uri.cr
@@ -608,7 +608,7 @@ class URI
         result.pop if result.size > 0
         # D.  if the input buffer consists only of "." or "..", then remove
         #     that from the input buffer; otherwise,
-      elsif path == ".." || path == "."
+      elsif path.in?("..", ".")
         path = ""
         # E.  move the first path segment in the input buffer to the end of
         #     the output buffer, including the initial "/" character (if

--- a/src/xml/builder.cr
+++ b/src/xml/builder.cr
@@ -275,7 +275,7 @@ class XML::Builder
 
   # Sets the quote char to use, either `'` or `"`.
   def quote_char=(char : Char)
-    unless char == '\'' || char == '"'
+    unless char.in?('\'', '"')
       raise ArgumentError.new("Quote char must be ' or \", not #{char}")
     end
 


### PR DESCRIPTION
This one is arguably more subjective, and (given foreknowledge/sensing of what `Object#in?` does) makes code more terse and natural to read. Followup to #8723.

\+ raytracer sample bugfix