### PR TITLE
Style: Use short block notation for simple one-liners

### DIFF
--- a/samples/sdl/fire.cr
+++ b/samples/sdl/fire.cr
@@ -257,7 +257,7 @@ def parse_rectangles(filename)
 
   rects = [] of Rectangle
   lines = File.read(filename)
-  lines = lines.split('\n').map { |line| line.rstrip }
+  lines = lines.split('\n').map(&.rstrip)
   lines.each_with_index do |line, y|
     x = 0
     line.each_char do |c|
@@ -294,7 +294,7 @@ class Screen
     background_intensity = intensity(@background[offset])
     color_intensity = intensity(color)
 
-    if color_intensity >= background_intensity && @rects.any? { |rect| rect.contains?(point) }
+    if color_intensity >= background_intensity && @rects.any?(&.contains?(point))
       @background[offset] = color
     end
   end

--- a/samples/sdl/tv.cr
+++ b/samples/sdl/tv.cr
@@ -98,7 +98,7 @@ end
 
 def parse_rectangles
   rects = [] of Rectangle
-  lines = File.read("#{__DIR__}/tv.txt").split('\n').map { |line| line.rstrip }
+  lines = File.read("#{__DIR__}/tv.txt").split('\n').map(&.rstrip)
   lines.each_with_index do |line, y|
     x = 0
     line.each_char do |c|
@@ -146,7 +146,7 @@ begin
 
     (height // 10).times do |h|
       (width // 10).times do |w|
-        rect = rects.find { |rect| rect.contains?(w, h) }
+        rect = rects.find(&.contains?(w, h))
         10.times do |y|
           10.times do |x|
             surface[x + 10 * w, y + 10 * h] = rect ? (rect.light? ? color_maker.light_color : color_maker.dark_color) : color_maker.black_color

--- a/samples/sudoku.cr
+++ b/samples/sudoku.cr
@@ -151,7 +151,7 @@ def solve_all(sudoku)
   sudoku.split('\n').map do |line|
     if line.size >= 81
       ret = sd_solve(mr, mc, line)
-      ret.map { |s2| s2.join }
+      ret.map(&.join)
     end
   end.compact
 end

--- a/spec/compiler/crystal/tools/context_spec.cr
+++ b/spec/compiler/crystal/tools/context_spec.cr
@@ -43,7 +43,7 @@ end
 private def assert_context_includes(code, variable, var_types)
   run_context_tool(code) do |result|
     result.contexts.should_not be_nil
-    result.contexts.not_nil!.map { |h| h[variable].to_s }.should eq(var_types)
+    result.contexts.not_nil!.map(&.[variable].to_s).should eq(var_types)
   end
 end
 

--- a/spec/std/enumerable_spec.cr
+++ b/spec/std/enumerable_spec.cr
@@ -523,8 +523,8 @@ describe "Enumerable" do
     it { [1, 2, 2, 3].group_by { |x| x == 2 }.should eq({true => [2, 2], false => [1, 3]}) }
 
     it "groups can group by size (like the doc example)" do
-      %w(Alice Bob Ary).group_by { |e| e.size }.should eq({3 => ["Bob", "Ary"],
-                                                           5 => ["Alice"]})
+      %w(Alice Bob Ary).group_by(&.size).should eq({3 => ["Bob", "Ary"],
+                                                    5 => ["Alice"]})
     end
   end
 
@@ -625,12 +625,12 @@ describe "Enumerable" do
 
   describe "index_by" do
     it "creates a hash indexed by the value returned by the block" do
-      hash = ["Anna", "Ary", "Alice"].index_by { |e| e.size }
+      hash = ["Anna", "Ary", "Alice"].index_by(&.size)
       hash.should eq({4 => "Anna", 3 => "Ary", 5 => "Alice"})
     end
 
     it "overrides values if a value is returned twice" do
-      hash = ["Anna", "Ary", "Alice", "Bob"].index_by { |e| e.size }
+      hash = ["Anna", "Ary", "Alice", "Bob"].index_by(&.size)
       hash.should eq({4 => "Anna", 3 => "Bob", 5 => "Alice"})
     end
   end
@@ -1242,7 +1242,7 @@ describe "Enumerable" do
       it "returns a hash with counts according to the value" do
         hash = {} of Char => Int32
         words = ["crystal", "ruby"]
-        words.each { |word| word.chars.tally(hash) }
+        words.each(&.chars.tally(hash))
 
         hash.should eq(
           {'c' => 1, 'r' => 2, 'y' => 2, 's' => 1, 't' => 1, 'a' => 1, 'l' => 1, 'u' => 1, 'b' => 1}
@@ -1252,7 +1252,7 @@ describe "Enumerable" do
       it "updates existing hash with counts according to the value" do
         hash = {'a' => 1, 'b' => 1, 'c' => 1, 'd' => 1}
         words = ["crystal", "ruby"]
-        words.each { |word| word.chars.tally(hash) }
+        words.each(&.chars.tally(hash))
 
         hash.should eq(
           {'a' => 2, 'b' => 2, 'c' => 2, 'd' => 1, 'r' => 2, 'y' => 2, 's' => 1, 't' => 1, 'l' => 1, 'u' => 1}
@@ -1262,7 +1262,7 @@ describe "Enumerable" do
       it "ignores the default value" do
         hash = Hash(Char, Int32).new(100)
         words = ["crystal", "ruby"]
-        words.each { |word| word.chars.tally(hash) }
+        words.each(&.chars.tally(hash))
 
         hash.should eq(
           {'c' => 1, 'r' => 2, 'y' => 2, 's' => 1, 't' => 1, 'a' => 1, 'l' => 1, 'u' => 1, 'b' => 1}
@@ -1272,7 +1272,7 @@ describe "Enumerable" do
       it "returns a hash with Int64 counts according to the value" do
         hash = {} of Char => Int64
         words = ["crystal", "ruby"]
-        words.each { |word| word.chars.tally(hash) }
+        words.each(&.chars.tally(hash))
 
         hash.should eq(
           {'c' => 1, 'r' => 2, 'y' => 2, 's' => 1, 't' => 1, 'a' => 1, 'l' => 1, 'u' => 1, 'b' => 1}

--- a/spec/std/hash_spec.cr
+++ b/spec/std/hash_spec.cr
@@ -404,12 +404,12 @@ describe "Hash" do
     describe "if block is given," do
       it "returns the first key with the given value" do
         hash = {"foo" => "bar", "baz" => "bar"}
-        hash.key_for("bar") { |value| value.upcase }.should eq("foo")
+        hash.key_for("bar", &.upcase).should eq("foo")
       end
 
       it "yields the argument if no hash key pairs with the value" do
         hash = {"foo" => "bar"}
-        hash.key_for("qux") { |value| value.upcase }.should eq("QUX")
+        hash.key_for("qux", &.upcase).should eq("QUX")
       end
     end
   end
@@ -842,7 +842,7 @@ describe "Hash" do
   it "transforms keys with type casting" do
     h1 = {"a" => 1, "b" => 2, "c" => 3}
 
-    h2 = h1.transform_keys { |x| x.to_s.upcase }
+    h2 = h1.transform_keys(&.to_s.upcase)
     h2.should be_a(Hash(String, Int32))
     h2.should eq({"A" => 1, "B" => 2, "C" => 3})
   end
@@ -865,7 +865,7 @@ describe "Hash" do
   it "transforms values with type casting values" do
     h1 = {"a" => 1, "b" => 2, "c" => 3}
 
-    h2 = h1.transform_values { |x| x.to_s }
+    h2 = h1.transform_values(&.to_s)
     h2.should be_a(Hash(String, String))
     h2.should eq({"a" => "1", "b" => "2", "c" => "3"})
   end

--- a/spec/std/http/web_socket_spec.cr
+++ b/spec/std/http/web_socket_spec.cr
@@ -588,7 +588,7 @@ describe "Websocket integration tests" do
   it "streams less than the buffer frame size" do
     integration_setup do |wsoc, bin_ch, _|
       bytes = "hello test world".to_slice
-      wsoc.stream(frame_size: 1024) { |io| io.write bytes }
+      wsoc.stream(frame_size: 1024, &.write(bytes))
       received = bin_ch.receive
       received.should eq bytes
     end
@@ -598,7 +598,7 @@ describe "Websocket integration tests" do
     integration_setup do |wsoc, bin_ch, _|
       bytes = ("hello test world" * 80).to_slice
       bytes.size.should be > 1024
-      wsoc.stream(frame_size: 1024) { |io| io.write bytes }
+      wsoc.stream(frame_size: 1024, &.write(bytes))
       received = bin_ch.receive
       received.should eq bytes
     end

--- a/spec/std/json/serialization_spec.cr
+++ b/spec/std/json/serialization_spec.cr
@@ -443,7 +443,7 @@ describe "JSON serialization" do
     it "deserializes unions of the same kind and remains stable" do
       str = [Int32::MAX, Int64::MAX].to_json
       value = Array(Int32 | Int64).from_json(str)
-      value.all? { |x| x.should be_a(Int64) }
+      value.all?(&.should(be_a(Int64)))
     end
 
     it "deserializes Time" do

--- a/spec/std/mime/multipart/parser_spec.cr
+++ b/spec/std/mime/multipart/parser_spec.cr
@@ -145,6 +145,6 @@ describe MIME::Multipart::Parser do
     end
 
     parser.@state.finished?.should be_true
-    ios.each { |io| io.closed?.should eq(true) }
+    ios.each(&.closed?.should(eq(true)))
   end
 end

--- a/src/benchmark/ips.cr
+++ b/src/benchmark/ips.cr
@@ -115,7 +115,7 @@ module Benchmark
       end
 
       private def run_comparison
-        fastest = ran_items.max_by { |i| i.mean }
+        fastest = ran_items.max_by(&.mean)
         ran_items.each do |item|
           item.slower = (fastest.mean / item.mean).to_f
         end

--- a/src/compiler/crystal/codegen/cast.cr
+++ b/src/compiler/crystal/codegen/cast.cr
@@ -380,7 +380,7 @@ class Crystal::CodeGenVisitor
       Phi.open(self, to_type, @needs_value) do |phi|
         types_needing_cast.each_with_index do |type_needing_cast, i|
           # Find compatible type
-          compatible_type = to_type.union_types.find { |ut| ut.implements?(type_needing_cast) }.not_nil!
+          compatible_type = to_type.union_types.find(&.implements?(type_needing_cast)).not_nil!
 
           matches_label, doesnt_match_label = new_blocks "matches", "doesnt_match_label"
           cmp_result = equal?(from_type_id, type_id(type_needing_cast))

--- a/src/compiler/crystal/command.cr
+++ b/src/compiler/crystal/command.cr
@@ -353,7 +353,7 @@ class Crystal::Command
 
       unless no_codegen
         valid_emit_values = Compiler::EmitTarget.names
-        valid_emit_values.map! { |v| v.gsub('_', '-').downcase }
+        valid_emit_values.map!(&.gsub('_', '-').downcase)
 
         opts.on("--emit [#{valid_emit_values.join('|')}]", "Comma separated list of types of output for the compiler to emit") do |emit_values|
           compiler.emit_targets |= validate_emit_values(emit_values.split(',').map(&.strip))

--- a/src/compiler/crystal/syntax/transformer.cr
+++ b/src/compiler/crystal/syntax/transformer.cr
@@ -598,7 +598,7 @@ module Crystal
     end
 
     def transform_many(exps)
-      exps.map! { |exp| exp.transform(self) } if exps
+      exps.map!(&.transform(self)) if exps
     end
   end
 end

--- a/src/compiler/crystal/types.cr
+++ b/src/compiler/crystal/types.cr
@@ -339,7 +339,7 @@ module Crystal
     # Returns true if `self` and *other* are in the same namespace.
     def same_namespace?(other)
       top_namespace(self) == top_namespace(other) ||
-        parents.try &.any? { |parent| parent.same_namespace?(other) }
+        parents.try &.any?(&.same_namespace?(other))
     end
 
     private def top_namespace(type)

--- a/src/crystal/system/win32/event_loop_iocp.cr
+++ b/src/crystal/system/win32/event_loop_iocp.cr
@@ -34,7 +34,7 @@ module Crystal::EventLoop
 
   # Runs the event loop.
   def self.run_once : Nil
-    next_event = @@queue.min_by { |e| e.wake_at }
+    next_event = @@queue.min_by(&.wake_at)
 
     if next_event
       now = Time.monotonic

--- a/src/http/cookie.cr
+++ b/src/http/cookie.cr
@@ -228,7 +228,7 @@ module HTTP
     # See `HTTP::Request#cookies` and `HTTP::Client::Response#cookies`.
     @[Deprecated("Use `.from_client_headers` or `.from_server_headers` instead.")]
     def self.from_headers(headers) : self
-      new.tap { |cookies| cookies.fill_from_headers(headers) }
+      new.tap(&.fill_from_headers(headers))
     end
 
     # Filling cookies by parsing the `Cookie` and `Set-Cookie`
@@ -244,7 +244,7 @@ module HTTP
     #
     # See `HTTP::Client::Response#cookies`.
     def self.from_client_headers(headers) : self
-      new.tap { |cookies| cookies.fill_from_client_headers(headers) }
+      new.tap(&.fill_from_client_headers(headers))
     end
 
     # Filling cookies by parsing the `Cookie` headers in the given `HTTP::Headers`.
@@ -261,7 +261,7 @@ module HTTP
     #
     # See `HTTP::Request#cookies`.
     def self.from_server_headers(headers) : self
-      new.tap { |cookies| cookies.fill_from_server_headers(headers) }
+      new.tap(&.fill_from_server_headers(headers))
     end
 
     # Filling cookies by parsing the `Set-Cookie` headers in the given `HTTP::Headers`.

--- a/src/io/multi_writer.cr
+++ b/src/io/multi_writer.cr
@@ -34,7 +34,7 @@ class IO::MultiWriter < IO
 
     return if slice.empty?
 
-    @writers.each { |writer| writer.write(slice) }
+    @writers.each(&.write(slice))
   end
 
   def read(slice : Bytes) : NoReturn
@@ -45,7 +45,7 @@ class IO::MultiWriter < IO
     return if @closed
     @closed = true
 
-    @writers.each { |writer| writer.close } if sync_close?
+    @writers.each(&.close) if sync_close?
   end
 
   def flush : Nil

--- a/src/mime/multipart/builder.cr
+++ b/src/mime/multipart/builder.cr
@@ -50,7 +50,7 @@ module MIME::Multipart
     #
     # Can be called multiple times to append to the preamble multiple times.
     def preamble(data : Bytes) : Nil
-      preamble { |io| io.write data }
+      preamble(&.write(data))
     end
 
     # Appends *preamble_io* to the preamble segment of the multipart message.
@@ -82,7 +82,7 @@ module MIME::Multipart
     # and *data*. Throws if `#finish` or `#epilogue` is called before this
     # method.
     def body_part(headers : HTTP::Headers, data : Bytes) : Nil
-      body_part_impl(headers) { |io| io.write data }
+      body_part_impl(headers, &.write(data))
     end
 
     # Appends a body part to the multipart message with the given *headers*
@@ -141,7 +141,7 @@ module MIME::Multipart
     #
     # Can be called multiple times to append to the epilogue multiple times.
     def epilogue(data : Bytes) : Nil
-      epilogue { |io| io.write data }
+      epilogue(&.write(data))
     end
 
     # Appends *preamble_io* to the epilogue segment of the multipart message.

--- a/src/option_parser.cr
+++ b/src/option_parser.cr
@@ -439,7 +439,7 @@ class OptionParser
           # subcommands since they are no longer valid.
           unless flag.starts_with?('-')
             @handlers.select! { |k, _| k.starts_with?('-') }
-            @flags.select! { |flag| flag.starts_with?("    -") }
+            @flags.select!(&.starts_with?("    -"))
           end
 
           handler.block.call(value || "")

--- a/src/string.cr
+++ b/src/string.cr
@@ -2833,7 +2833,7 @@ class String
   # described at `Char#in_set?`. Returns the number of characters
   # in this string that match the given set.
   def count(*sets) : Int32
-    count { |char| char.in_set?(*sets) }
+    count(&.in_set?(*sets))
   end
 
   # Yields each char in this string to the block.
@@ -2868,7 +2868,7 @@ class String
   # "aabbccdd".delete("a-c") # => "dd"
   # ```
   def delete(*sets) : String
-    delete { |char| char.in_set?(*sets) }
+    delete(&.in_set?(*sets))
   end
 
   # Yields each char in this string to the block.
@@ -2911,7 +2911,7 @@ class String
   # "a       bbb".squeeze         # => "a b"
   # ```
   def squeeze(*sets : String) : String
-    squeeze { |char| char.in_set?(*sets) }
+    squeeze(&.in_set?(*sets))
   end
 
   # Returns a new `String`, that has all characters removed,


### PR DESCRIPTION
This PR changes simple calls on the single block receiver into their short form:

```cr
%w(foo bar).map { |v| v.upcase }
# into
%w(foo bar).map(&.upcase)
```

This IMHO makes code more succinct and crystal-ish :)