### PR TITLE
Lint: Remove redundant `next` calls

### DIFF
--- a/src/crystal/system/win32/dir.cr
+++ b/src/crystal/system/win32/dir.cr
@@ -93,7 +93,7 @@ module Crystal::System::Dir
       if 0 < len < buffer.size
         return String.from_utf16(buffer[0, len])
       elsif small_buf && len > 0
-        next len
+        len
       else
         raise ::File::Error.from_winerror("Error getting current directory", file: "./")
       end
@@ -114,7 +114,7 @@ module Crystal::System::Dir
       if 0 < len < buffer.size
         break String.from_utf16(buffer[0, len])
       elsif small_buf && len > 0
-        next len
+        len
       else
         raise RuntimeError.from_winerror("Error getting temporary directory")
       end

--- a/src/crystal/system/win32/env.cr
+++ b/src/crystal/system/win32/env.cr
@@ -36,7 +36,7 @@ module Crystal::System::Env
       if 0 < length < buffer.size
         return String.from_utf16(buffer[0, length])
       elsif small_buf && length > 0
-        next length
+        length
       else
         case last_error = WinError.value
         when WinError::ERROR_SUCCESS

--- a/src/crystal/system/win32/file.cr
+++ b/src/crystal/system/win32/file.cr
@@ -186,7 +186,7 @@ module Crystal::System::File
       if 0 < len < buffer.size
         break String.from_utf16(buffer[0, len])
       elsif small_buf && len > 0
-        next len
+        len
       else
         raise ::File::Error.from_winerror("Error resolving real path", file: path)
       end

--- a/src/crystal/system/win32/hostname.cr
+++ b/src/crystal/system/win32/hostname.cr
@@ -7,7 +7,7 @@ module Crystal::System
       if LibC.GetComputerNameExW(LibC::COMPUTER_NAME_FORMAT::ComputerNameDnsHostname, buffer, pointerof(name_size)) != 0
         break String.from_utf16(buffer[0, name_size])
       elsif small_buf && name_size > 0
-        next name_size
+        name_size
       else
         raise RuntimeError.from_winerror("Could not get hostname")
       end

--- a/src/crystal/system/win32/windows_registry.cr
+++ b/src/crystal/system/win32/windows_registry.cr
@@ -78,7 +78,7 @@ module Crystal::System::WindowsRegistry
       if 0 <= length <= buffer.size
         return String.from_utf16(buffer[0, length // 2 - 1])
       elsif small_buf && length > 0
-        next length
+        length
       else
         raise RuntimeError.new("RegQueryValueExW retry buffer")
       end


### PR DESCRIPTION
Another PR aimed at small refactors, this time - removing needless `next` calls.