### PR TITLE
Lint: Use `Enumerable#find!/#index!` variants

### DIFF
--- a/spec/std/xml/html_spec.cr
+++ b/spec/std/xml/html_spec.cr
@@ -18,15 +18,15 @@ describe XML do
     html = doc.children[1]
     html.name.should eq("html")
 
-    head = html.children.find { |node| node.name == "head" }.not_nil!
+    head = html.children.find! { |node| node.name == "head" }
     head.name.should eq("head")
 
-    title = head.children.find { |node| node.name == "title" }.not_nil!
+    title = head.children.find! { |node| node.name == "title" }
     title.text.should eq("Samantha")
 
-    body = html.children.find { |node| node.name == "body" }.not_nil!
+    body = html.children.find! { |node| node.name == "body" }
 
-    h1 = body.children.find { |node| node.name == "h1" }.not_nil!
+    h1 = body.children.find! { |node| node.name == "h1" }
 
     attrs = h1.attributes
     attrs.should_not be_empty

--- a/spec/std/xml/xml_spec.cr
+++ b/spec/std/xml/xml_spec.cr
@@ -71,7 +71,7 @@ describe XML do
     person["id3"]?.should be_nil
     expect_raises(KeyError) { person["id3"] }
 
-    name = person.children.find { |node| node.name == "name" }.not_nil!
+    name = person.children.find! { |node| node.name == "name" }
     name.content.should eq("John")
 
     name.parent.should eq(person)
@@ -92,8 +92,8 @@ describe XML do
     doc.document.should eq(doc)
     doc.name.should eq("document")
 
-    people = doc.children.find { |node| node.name == "people" }.not_nil!
-    person = people.children.find { |node| node.name == "person" }.not_nil!
+    people = doc.children.find! { |node| node.name == "people" }
+    person = people.children.find! { |node| node.name == "person" }
     person["id"].should eq("1")
   end
 

--- a/src/compiler/crystal/codegen/cast.cr
+++ b/src/compiler/crystal/codegen/cast.cr
@@ -125,7 +125,7 @@ class Crystal::CodeGenVisitor
 
       types_needing_cast.each_with_index do |type_needing_cast, i|
         # Find compatible type
-        compatible_type = target_type.union_types.find { |ut| type_needing_cast.implements?(ut) }.not_nil!
+        compatible_type = target_type.union_types.find! { |ut| type_needing_cast.implements?(ut) }
 
         matches_label, doesnt_match_label = new_blocks "matches", "doesnt_match_label"
         cmp_result = equal?(value_type_id, type_id(type_needing_cast))
@@ -184,7 +184,7 @@ class Crystal::CodeGenVisitor
       # It might happen that `value_type` is not of the union but it's compatible with one of them.
       # We need to first cast the value to the compatible type and then store it in the value.
       unless target_type.union_types.any? &.==(value_type)
-        compatible_type = target_type.union_types.find { |ut| value_type.implements?(ut) }.not_nil!
+        compatible_type = target_type.union_types.find! { |ut| value_type.implements?(ut) }
         value = upcast(value, compatible_type, value_type)
         return assign(target_pointer, target_type, compatible_type, value)
       end
@@ -380,7 +380,7 @@ class Crystal::CodeGenVisitor
       Phi.open(self, to_type, @needs_value) do |phi|
         types_needing_cast.each_with_index do |type_needing_cast, i|
           # Find compatible type
-          compatible_type = to_type.union_types.find { |ut| ut.implements?(type_needing_cast) }.not_nil!
+          compatible_type = to_type.union_types.find! { |ut| ut.implements?(type_needing_cast) }
 
           matches_label, doesnt_match_label = new_blocks "matches", "doesnt_match_label"
           cmp_result = equal?(from_type_id, type_id(type_needing_cast))
@@ -422,7 +422,7 @@ class Crystal::CodeGenVisitor
     case to_type
     when TupleInstanceType, NamedTupleInstanceType
       unless from_type.union_types.any? &.==(to_type)
-        compatible_type = from_type.union_types.find { |ut| to_type.implements?(ut) }.not_nil!
+        compatible_type = from_type.union_types.find! { |ut| to_type.implements?(ut) }
         value = downcast(value, compatible_type, from_type, true)
         value = downcast(value, to_type, compatible_type, true)
         return value
@@ -577,7 +577,7 @@ class Crystal::CodeGenVisitor
       Phi.open(self, to_type, @needs_value) do |phi|
         types_needing_cast.each_with_index do |type_needing_cast, i|
           # Find compatible type
-          compatible_type = to_type.union_types.find { |ut| type_needing_cast.implements?(ut) }.not_nil!
+          compatible_type = to_type.union_types.find! { |ut| type_needing_cast.implements?(ut) }
 
           matches_label, doesnt_match_label = new_blocks "matches", "doesnt_match_label"
           cmp_result = equal?(from_type_id, type_id(type_needing_cast))
@@ -625,7 +625,7 @@ class Crystal::CodeGenVisitor
     case from_type
     when TupleInstanceType, NamedTupleInstanceType
       unless to_type.union_types.any? &.==(from_type)
-        compatible_type = to_type.union_types.find { |ut| from_type.implements?(ut) }.not_nil!
+        compatible_type = to_type.union_types.find! { |ut| from_type.implements?(ut) }
         value = upcast(value, compatible_type, from_type)
         return upcast(value, to_type, compatible_type)
       end

--- a/src/compiler/crystal/crystal_path.cr
+++ b/src/compiler/crystal/crystal_path.cr
@@ -84,7 +84,7 @@ module Crystal
       end
     end
 
-    def find(filename, relative_to = nil) : Array(String)?
+    def find(filename, relative_to = nil) : Array(String)
       relative_to = File.dirname(relative_to) if relative_to.is_a?(String)
 
       if filename.starts_with? '.'

--- a/src/compiler/crystal/semantic/call.cr
+++ b/src/compiler/crystal/semantic/call.cr
@@ -665,11 +665,11 @@ class Crystal::Call
       parents = lookup.base_type.ancestors
     when NonGenericModuleType
       ancestors = parent_visitor.scope.ancestors
-      index_of_ancestor = ancestors.index(lookup).not_nil!
+      index_of_ancestor = ancestors.index!(lookup)
       parents = ancestors[index_of_ancestor + 1..-1]
     when GenericModuleType
       ancestors = parent_visitor.scope.ancestors
-      index_of_ancestor = ancestors.index { |ancestor| ancestor.is_a?(GenericModuleInstanceType) && ancestor.generic_type == lookup }.not_nil!
+      index_of_ancestor = ancestors.index! { |ancestor| ancestor.is_a?(GenericModuleInstanceType) && ancestor.generic_type == lookup }
       parents = ancestors[index_of_ancestor + 1..-1]
     when GenericType
       ancestors = parent_visitor.scope.ancestors

--- a/src/compiler/crystal/semantic/call.cr
+++ b/src/compiler/crystal/semantic/call.cr
@@ -1216,7 +1216,7 @@ class Crystal::Call
     end
 
     named_args_types.try &.each do |named_arg|
-      arg = typed_def.args.find { |arg| arg.external_name == named_arg.name }.not_nil!
+      arg = typed_def.args.find! { |arg| arg.external_name == named_arg.name }
 
       type = named_arg.type
       var = MetaVar.new(arg.name, type)

--- a/src/compiler/crystal/semantic/call_error.cr
+++ b/src/compiler/crystal/semantic/call_error.cr
@@ -215,7 +215,7 @@ class Crystal::Call
         # Show did you mean for the simplest case for now
         if names.size == 1 && call_errors.size == 1
           extra_name = names.first
-          name_index = call_errors.first.names.index(extra_name).not_nil!
+          name_index = call_errors.first.names.index!(extra_name)
           similar_name = call_errors.first.similar_names[name_index]
           if similar_name
             str.puts

--- a/src/compiler/crystal/tools/playground/server.cr
+++ b/src/compiler/crystal/tools/playground/server.cr
@@ -22,7 +22,7 @@ module Crystal::Playground
       instrumented = Playground::AgentInstrumentorTransformer.transform(ast).to_s
       Log.info { "Code instrumentation (session=#{session_key}, tag=#{tag}).\n#{instrumented}" }
 
-      prelude = %(
+      prelude = <<-CR
         require "compiler/crystal/tools/playground/agent"
 
         class Crystal::Playground::Agent
@@ -36,7 +36,7 @@ module Crystal::Playground
         def _p
           Crystal::Playground::Agent.instance
         end
-        )
+        CR
 
       [
         Compiler::Source.new("playground_prelude", prelude),
@@ -447,7 +447,7 @@ module Crystal::Playground
     end
 
     def start
-      playground_dir = File.dirname(CrystalPath.new.find("compiler/crystal/tools/playground/server.cr").not_nil![0])
+      playground_dir = File.dirname(__FILE__)
       views_dir = File.join(playground_dir, "views")
       public_dir = File.join(playground_dir, "public")
 

--- a/src/compiler/crystal/types.cr
+++ b/src/compiler/crystal/types.cr
@@ -2559,7 +2559,7 @@ module Crystal
     end
 
     def name_type(name)
-      @entries.find(&.name.==(name)).not_nil!.type
+      @entries.find!(&.name.==(name)).type
     end
 
     def tuple_indexer(index)

--- a/src/compiler/crystal/types.cr
+++ b/src/compiler/crystal/types.cr
@@ -2555,7 +2555,7 @@ module Crystal
     end
 
     def name_index(name)
-      @entries.index &.name.==(name)
+      @entries.index(&.name.==(name))
     end
 
     def name_type(name)


### PR DESCRIPTION
This PR removes many of the `Enumerable#select/index(&)#not_nil!` usages by utilising the bang variant of said methods.

Plus a small refactor in `Crystal::Playground::Server`.