### PR TITLE
Leverage `GC.malloc_atomic` for XML

### DIFF
--- a/src/xml/libxml2.cr
+++ b/src/xml/libxml2.cr
@@ -317,7 +317,7 @@ end
 LibXML.xmlGcMemSetup(
   ->GC.free,
   ->GC.malloc(LibC::SizeT),
-  ->GC.malloc(LibC::SizeT),
+  ->GC.malloc_atomic(LibC::SizeT),
   ->GC.realloc(Void*, LibC::SizeT),
   ->(str) {
     len = LibC.strlen(str) + 1

--- a/src/xml/libxml2.cr
+++ b/src/xml/libxml2.cr
@@ -317,7 +317,12 @@ end
 LibXML.xmlGcMemSetup(
   ->GC.free,
   ->GC.malloc(LibC::SizeT),
-  ->GC.malloc_atomic(LibC::SizeT),
+  # TODO(interpreted): remove this condition
+  {% if flag?(:interpreted) %}
+    ->GC.malloc(LibC::SizeT)
+  {% else %}
+    ->GC.malloc_atomic(LibC::SizeT)
+  {% end %},
   ->GC.realloc(Void*, LibC::SizeT),
   ->(str) {
     len = LibC.strlen(str) + 1


### PR DESCRIPTION
libxml2 can be configured to use a separate allocator for atomic allocations. This PR applies the garbage collector's allocator to it.