### PR TITLE
Lexer: fix global capture vars ending with zero, e.g. `$10?`

### DIFF
--- a/spec/compiler/lexer/lexer_spec.cr
+++ b/spec/compiler/lexer/lexer_spec.cr
@@ -284,7 +284,9 @@ describe "Lexer" do
                     ":^", ":~", ":**", ":>>", ":<<", ":%", ":[]", ":[]?", ":[]=", ":<=>", ":===",
                     ":&+", ":&-", ":&*", ":&**"]
 
-  it_lexes_global_match_data_index ["$1", "$10", "$1?", "$23?"]
+  it_lexes_global_match_data_index ["$1", "$10", "$1?", "$10?", "$23?"]
+  assert_syntax_error "$01", %(unexpected token: "1")
+  assert_syntax_error "$0?"
 
   it_lexes "$~", :OP_DOLLAR_TILDE
   it_lexes "$?", :OP_DOLLAR_QUESTION

--- a/src/compiler/crystal/syntax/lexer.cr
+++ b/src/compiler/crystal/syntax/lexer.cr
@@ -827,14 +827,13 @@ module Crystal
           @token.type = :OP_DOLLAR_QUESTION
         when .ascii_number?
           start = current_pos
-          char = next_char
-          if char == '0'
-            char = next_char
+          if current_char == '0'
+            next_char
           else
-            while char.ascii_number?
-              char = next_char
+            while next_char.ascii_number?
+              # Nothing to do
             end
-            char = next_char if char == '?'
+            next_char if current_char == '?'
           end
           @token.type = :GLOBAL_MATCH_DATA_INDEX
           @token.value = string_range_from_pool(start)


### PR DESCRIPTION
I'm a little surprised that this has gone unnoticed for so long, but probably very few people create regexes with more than nine captures...