### PR TITLE
Eliminate `nil` from many predicate methods

### DIFF
--- a/src/compiler/crystal/codegen/ast.cr
+++ b/src/compiler/crystal/codegen/ast.cr
@@ -3,7 +3,7 @@ require "../syntax/ast"
 module Crystal
   class ASTNode
     def no_returns?
-      type?.try &.no_return?
+      !!type?.try &.no_return?
     end
   end
 

--- a/src/compiler/crystal/codegen/types.cr
+++ b/src/compiler/crystal/codegen/types.cr
@@ -29,9 +29,9 @@ module Crystal
       when VirtualType
         self.struct?
       when NonGenericModuleType
-        self.including_types.try &.passed_by_value?
+        !!self.including_types.try &.passed_by_value?
       when GenericModuleInstanceType
-        self.including_types.try &.passed_by_value?
+        !!self.including_types.try &.passed_by_value?
       when GenericClassInstanceType
         self.generic_type.passed_by_value?
       when TypeDefType

--- a/src/compiler/crystal/semantic/ast.cr
+++ b/src/compiler/crystal/semantic/ast.cr
@@ -34,6 +34,8 @@ module Crystal
             self_type.kind.bytesize <= 64
           when FloatType
             self_type.kind.f32?
+          else
+            false
           end
         else
           false

--- a/src/compiler/crystal/semantic/cleanup_transformer.cr
+++ b/src/compiler/crystal/semantic/cleanup_transformer.cr
@@ -434,15 +434,15 @@ module Crystal
     end
 
     private def void_lib_call?(node)
-      return unless node.is_a?(Call)
+      return false unless node.is_a?(Call)
 
       obj = node.obj
-      return unless obj.is_a?(Path)
+      return false unless obj.is_a?(Path)
 
       type = obj.type?
-      return unless type.is_a?(LibType)
+      return false unless type.is_a?(LibType)
 
-      node.type?.try &.nil_type?
+      !!node.type?.try &.nil_type?
     end
 
     def transform(node : Global)

--- a/src/compiler/crystal/semantic/conversions.cr
+++ b/src/compiler/crystal/semantic/conversions.cr
@@ -44,6 +44,6 @@ module Crystal::Conversions
   end
 
   def self.to_unsafe_lookup_failed?(ex)
-    ex.message.try(&.includes?("undefined method 'to_unsafe'"))
+    !!ex.message.try(&.includes?("undefined method 'to_unsafe'"))
   end
 end

--- a/src/compiler/crystal/semantic/restrictions.cr
+++ b/src/compiler/crystal/semantic/restrictions.cr
@@ -945,7 +945,7 @@ module Crystal
         return true
       end
 
-      parents.try &.any? &.restriction_of?(other, owner, self_free_vars, other_free_vars)
+      !!parents.try &.any? &.restriction_of?(other, owner, self_free_vars, other_free_vars)
     end
 
     def restriction_of?(other : AliasType, owner, self_free_vars = nil, other_free_vars = nil)
@@ -1055,9 +1055,9 @@ module Crystal
           # to e.g. AbstractDefChecker; generic instances shall behave like AST
           # nodes when def restrictions are considered, i.e. all generic type
           # variables are covariant.
-          return nil unless type_var.type.implements?(other_type_var.type)
+          return false unless type_var.type.implements?(other_type_var.type)
         else
-          return nil unless type_var == other_type_var
+          return false unless type_var == other_type_var
         end
       end
 
@@ -1669,7 +1669,7 @@ module Crystal
       end
 
       # Disallow casting a function to another one accepting different argument count
-      return nil if arg_types.size != other.arg_types.size
+      return false if arg_types.size != other.arg_types.size
 
       arg_types.zip(other.arg_types) do |arg_type, other_arg_type|
         return false unless arg_type == other_arg_type

--- a/src/compiler/crystal/semantic/top_level_visitor.cr
+++ b/src/compiler/crystal/semantic/top_level_visitor.cr
@@ -1057,7 +1057,7 @@ class Crystal::TopLevelVisitor < Crystal::SemanticVisitor
 
   def has_hooks?(type_with_hooks)
     hooks = type_with_hooks.as?(ModuleType).try &.hooks
-    hooks && !hooks.empty?
+    !hooks.nil? && !hooks.empty?
   end
 
   def run_hooks(type_with_hooks, current_type, kind : HookKind, node, call = nil)

--- a/src/compiler/crystal/tools/doc/generator.cr
+++ b/src/compiler/crystal/tools/doc/generator.cr
@@ -146,7 +146,7 @@ class Crystal::Doc::Generator
     # Don't include lib types or types inside a lib type
     return false if type.is_a?(Crystal::LibType) || type.namespace.is_a?(LibType)
 
-    type.locations.try &.any? do |type_location|
+    !!type.locations.try &.any? do |type_location|
       must_include? type_location
     end
   end
@@ -179,7 +179,7 @@ class Crystal::Doc::Generator
     return false if nodoc? const
     return true if crystal_builtin?(const)
 
-    const.locations.try &.any? { |location| must_include? location }
+    !!const.locations.try &.any? { |location| must_include? location }
   end
 
   def must_include?(location : Crystal::Location)

--- a/src/compiler/crystal/tools/doc/type.cr
+++ b/src/compiler/crystal/tools/doc/type.cr
@@ -571,7 +571,7 @@ class Crystal::Doc::Type
     return false unless node.is_a?(Path)
 
     match = lookup_path(node)
-    match && match.type == @generator.program.nil_type
+    !!match.try &.type == @generator.program.nil_type
   end
 
   def node_to_html(node, io, html : HTMLOption = :all)

--- a/src/compiler/crystal/types.cr
+++ b/src/compiler/crystal/types.cr
@@ -292,7 +292,7 @@ module Crystal
       when VirtualMetaclassType
         implements?(other_type.base_type.metaclass)
       else
-        parents.try &.any? &.implements?(other_type)
+        !!parents.try &.any? &.implements?(other_type)
       end
     end
 
@@ -339,7 +339,7 @@ module Crystal
     # Returns true if `self` and *other* are in the same namespace.
     def same_namespace?(other)
       top_namespace(self) == top_namespace(other) ||
-        parents.try &.any? { |parent| parent.same_namespace?(other) }
+        !!parents.try &.any? { |parent| parent.same_namespace?(other) }
     end
 
     private def top_namespace(type)
@@ -462,11 +462,11 @@ module Crystal
     end
 
     def has_def?(name)
-      has_def_without_parents?(name) || parents.try(&.any?(&.has_def?(name)))
+      has_def_without_parents?(name) || !!parents.try(&.any?(&.has_def?(name)))
     end
 
     def has_def_without_parents?(name)
-      defs.try(&.has_key?(name))
+      !!defs.try(&.has_key?(name))
     end
 
     record DefInMacroLookup

--- a/src/time/format/custom/http_date.cr
+++ b/src/time/format/custom/http_date.cr
@@ -94,8 +94,8 @@ struct Time::Format
       !ansi_c_format && current_char.ascii_whitespace?
     end
 
-    def http_date_short_day_name_with_comma? : Bool?
-      return unless current_char.ascii_letter?
+    def http_date_short_day_name_with_comma? : Bool
+      return false unless current_char.ascii_letter?
 
       short_day_name
 

--- a/src/time/format/custom/yaml_date.cr
+++ b/src/time/format/custom/yaml_date.cr
@@ -44,19 +44,19 @@ struct Time::Format
       if (year = consume_number?(4)) && char?('-')
         @year = year
       else
-        return nil
+        return false
       end
 
       if (month = consume_number?(2)) && char?('-')
         @month = month
       else
-        return nil
+        return false
       end
 
       if day = consume_number?(2)
         @day = day
       else
-        return nil
+        return false
       end
 
       case current_char
@@ -71,7 +71,7 @@ struct Time::Format
         end
       else
         if @reader.has_next?
-          return nil
+          return false
         end
       end
 
@@ -82,19 +82,19 @@ struct Time::Format
       if (hour = consume_number?(2)) && char?(':')
         @hour = hour
       else
-        return nil
+        return false
       end
 
       if (minute = consume_number?(2)) && char?(':')
         @minute = minute
       else
-        return nil
+        return false
       end
 
       if second = consume_number?(2)
         @second = second
       else
-        return nil
+        return false
       end
 
       second_fraction?
@@ -105,10 +105,10 @@ struct Time::Format
         begin
           time_zone_z_or_offset(force_zero_padding: false, force_minutes: false)
         rescue Time::Format::Error
-          return nil
+          return false
         end
 
-        return nil if @reader.has_next?
+        return false if @reader.has_next?
       end
 
       true

--- a/src/uri.cr
+++ b/src/uri.cr
@@ -718,6 +718,10 @@ class URI
   # Returns `true` if this URI's *port* is the default port for
   # its *scheme*.
   private def default_port?
-    (scheme = @scheme) && (port = @port) && port == URI.default_port(scheme)
+    if (scheme = @scheme) && (port = @port)
+      port == URI.default_port(scheme)
+    else
+      false
+    end
   end
 end


### PR DESCRIPTION
A lot of predicate methods are returning `Bool | Nil` when just `Bool` would suffice, most notably `Crystal::Type#implements?`. This PR removes those nils.