### PR TITLE
Fix `OpenSSL::SSL::Context::Client#alpn_protocol=`

### DIFF
--- a/src/openssl/lib_ssl.cr
+++ b/src/openssl/lib_ssl.cr
@@ -261,6 +261,7 @@ lib LibSSL
 
     fun ssl_get0_alpn_selected = SSL_get0_alpn_selected(handle : SSL, data : Char**, len : LibC::UInt*) : Void
     fun ssl_ctx_set_alpn_select_cb = SSL_CTX_set_alpn_select_cb(ctx : SSLContext, cb : ALPNCallback, arg : Void*) : Void
+    fun ssl_ctx_set_alpn_protos = SSL_CTX_set_alpn_protos(ctx : SSLContext, protos : Char*, protos_len : Int) : Int
   {% end %}
 
   {% if compare_versions(OPENSSL_VERSION, "1.0.2") >= 0 %}


### PR DESCRIPTION
Fixes #11895

The current `OpenSSL::SSL::Context#alpn_protocol=` setter calls `LibSSL.ssl_ctx_set_alpn_select_cb`, which only works for server SSL contexts. This PR moves this setter into the `Context::Server` subclass, and adds a `Context::Client#alpn_protocol=` setter that calls the correct `LibSSL.ssl_ctx_set_alpn_protos` method for client contexts.