### PR TITLE
Add `String#index/rindex!` methods

### DIFF
--- a/spec/std/string_spec.cr
+++ b/spec/std/string_spec.cr
@@ -981,7 +981,7 @@ describe "String" do
         it { "foobarbaz".index!('a', -4).should eq(7) }
         it do
           expect_raises(Enumerable::NotFoundError) do
-            "foo".index!('g', 1)
+            "foo".index!('f', 1)
           end
         end
         it do

--- a/spec/std/string_spec.cr
+++ b/spec/std/string_spec.cr
@@ -967,6 +967,78 @@ describe "String" do
     end
   end
 
+  describe "#index!" do
+    describe "by char" do
+      it { "foo".index!('o').should eq(1) }
+      it do
+        expect_raises(IndexError) do
+          "foo".index!('g')
+        end
+      end
+
+      describe "with offset" do
+        it { "foobarbaz".index!('a', 5).should eq(7) }
+        it { "foobarbaz".index!('a', -4).should eq(7) }
+        it do
+          expect_raises(IndexError) do
+            "foo".index!('g', 1)
+          end
+        end
+        it do
+          expect_raises(IndexError) do
+            "foo".index!('g', -20)
+          end
+        end
+      end
+    end
+
+    describe "by string" do
+      it { "foo bar".index!("o b").should eq(2) }
+      it { "foo".index!("").should eq(0) }
+      it { "foo".index!("foo").should eq(0) }
+      it do
+        expect_raises(IndexError) do
+          "foo".index!("fg")
+        end
+      end
+
+      describe "with offset" do
+        it { "foobarbaz".index!("ba", 4).should eq(6) }
+        it { "foobarbaz".index!("ba", -5).should eq(6) }
+        it do
+          expect_raises(IndexError) do
+            "foo".index!("ba", 1)
+          end
+        end
+        it do
+          expect_raises(IndexError) do
+            "foo".index!("ba", -20)
+          end
+        end
+      end
+    end
+
+    describe "by regex" do
+      it { "string 12345".index!(/\d+/).should eq(7) }
+      it { "12345".index!(/\d/).should eq(0) }
+      it do
+        expect_raises(IndexError) do
+          "Hello, world!".index!(/\d/)
+        end
+      end
+
+      describe "with offset" do
+        it { "abcDef".index!(/[A-Z]/).should eq(3) }
+        it { "foobarbaz".index!(/ba/, -5).should eq(6) }
+        it do
+          expect_raises(IndexError) do
+            "Foo".index!(/[A-Z]/, 1)
+          end
+        end
+      end
+    end
+  end
+
   describe "#rindex" do
     describe "by char" do
       it { "bbbb".rindex('b').should eq(3) }
@@ -1043,6 +1115,70 @@ describe "String" do
         it { "bbbb".rindex(/b/, -5).should be_nil }
         it { "bbbb".rindex(/b/, -4).should eq(0) }
         it { "日本語日本語".rindex(/日本/, 2).should eq(0) }
+      end
+    end
+  end
+
+  describe "#rindex!" do
+    describe "by char" do
+      it { "bbbb".rindex!('b').should eq(3) }
+      it { "foobar".rindex!('a').should eq(4) }
+      it do
+        expect_raises(IndexError) do
+          "foobar".rindex!('g')
+        end
+      end
+
+      describe "with offset" do
+        it { "bbbb".rindex!('b', 2).should eq(2) }
+        it do
+          expect_raises(IndexError) do
+            "abbbb".rindex!('b', 0)
+          end
+        end
+      end
+    end
+
+    describe "by string" do
+      it { "bbbb".rindex!("b").should eq(3) }
+      it { "foo baro baz".rindex!("o b").should eq(7) }
+      it do
+        expect_raises(IndexError) do
+          "foo baro baz".rindex!("fg")
+        end
+      end
+
+      describe "with offset" do
+        it { "bbbb".rindex!("b", 2).should eq(2) }
+        it do
+          expect_raises(IndexError) do
+            "abbbb".rindex!("b", 0)
+          end
+        end
+        it do
+          expect_raises(IndexError) do
+            "bbbb".rindex!("b", -5)
+          end
+        end
+      end
+    end
+
+    describe "by regex" do
+      it { "bbbb".rindex!(/b/).should eq(3) }
+      it { "a43b53".rindex!(/\d+/).should eq(4) }
+      it do
+        expect_raises(IndexError) do
+          "bbbb".rindex!(/\d/)
+        end
+      end
+
+      describe "with offset" do
+        it { "bbbb".rindex!(/b/, 2).should eq(2) }
+        it do
+          expect_raises(IndexError) do
+            "abbbb".rindex!(/b/, 0)
+          end
+        end
       end
     end
   end

--- a/spec/std/string_spec.cr
+++ b/spec/std/string_spec.cr
@@ -971,7 +971,7 @@ describe "String" do
     describe "by char" do
       it { "foo".index!('o').should eq(1) }
       it do
-        expect_raises(IndexError) do
+        expect_raises(Enumerable::NotFoundError) do
           "foo".index!('g')
         end
       end
@@ -980,12 +980,12 @@ describe "String" do
         it { "foobarbaz".index!('a', 5).should eq(7) }
         it { "foobarbaz".index!('a', -4).should eq(7) }
         it do
-          expect_raises(IndexError) do
+          expect_raises(Enumerable::NotFoundError) do
             "foo".index!('g', 1)
           end
         end
         it do
-          expect_raises(IndexError) do
+          expect_raises(Enumerable::NotFoundError) do
             "foo".index!('g', -20)
           end
         end
@@ -997,7 +997,7 @@ describe "String" do
       it { "foo".index!("").should eq(0) }
       it { "foo".index!("foo").should eq(0) }
       it do
-        expect_raises(IndexError) do
+        expect_raises(Enumerable::NotFoundError) do
           "foo".index!("fg")
         end
       end
@@ -1006,12 +1006,12 @@ describe "String" do
         it { "foobarbaz".index!("ba", 4).should eq(6) }
         it { "foobarbaz".index!("ba", -5).should eq(6) }
         it do
-          expect_raises(IndexError) do
+          expect_raises(Enumerable::NotFoundError) do
             "foo".index!("ba", 1)
           end
         end
         it do
-          expect_raises(IndexError) do
+          expect_raises(Enumerable::NotFoundError) do
             "foo".index!("ba", -20)
           end
         end
@@ -1022,7 +1022,7 @@ describe "String" do
       it { "string 12345".index!(/\d+/).should eq(7) }
       it { "12345".index!(/\d/).should eq(0) }
       it do
-        expect_raises(IndexError) do
+        expect_raises(Enumerable::NotFoundError) do
           "Hello, world!".index!(/\d/)
         end
       end
@@ -1031,7 +1031,7 @@ describe "String" do
         it { "abcDef".index!(/[A-Z]/).should eq(3) }
         it { "foobarbaz".index!(/ba/, -5).should eq(6) }
         it do
-          expect_raises(IndexError) do
+          expect_raises(Enumerable::NotFoundError) do
             "Foo".index!(/[A-Z]/, 1)
           end
         end
@@ -1124,7 +1124,7 @@ describe "String" do
       it { "bbbb".rindex!('b').should eq(3) }
       it { "foobar".rindex!('a').should eq(4) }
       it do
-        expect_raises(IndexError) do
+        expect_raises(Enumerable::NotFoundError) do
           "foobar".rindex!('g')
         end
       end
@@ -1132,7 +1132,7 @@ describe "String" do
       describe "with offset" do
         it { "bbbb".rindex!('b', 2).should eq(2) }
         it do
-          expect_raises(IndexError) do
+          expect_raises(Enumerable::NotFoundError) do
             "abbbb".rindex!('b', 0)
           end
         end
@@ -1143,7 +1143,7 @@ describe "String" do
       it { "bbbb".rindex!("b").should eq(3) }
       it { "foo baro baz".rindex!("o b").should eq(7) }
       it do
-        expect_raises(IndexError) do
+        expect_raises(Enumerable::NotFoundError) do
           "foo baro baz".rindex!("fg")
         end
       end
@@ -1151,12 +1151,12 @@ describe "String" do
       describe "with offset" do
         it { "bbbb".rindex!("b", 2).should eq(2) }
         it do
-          expect_raises(IndexError) do
+          expect_raises(Enumerable::NotFoundError) do
             "abbbb".rindex!("b", 0)
           end
         end
         it do
-          expect_raises(IndexError) do
+          expect_raises(Enumerable::NotFoundError) do
             "bbbb".rindex!("b", -5)
           end
         end
@@ -1167,7 +1167,7 @@ describe "String" do
       it { "bbbb".rindex!(/b/).should eq(3) }
       it { "a43b53".rindex!(/\d+/).should eq(4) }
       it do
-        expect_raises(IndexError) do
+        expect_raises(Enumerable::NotFoundError) do
           "bbbb".rindex!(/\d/)
         end
       end
@@ -1175,7 +1175,7 @@ describe "String" do
       describe "with offset" do
         it { "bbbb".rindex!(/b/, 2).should eq(2) }
         it do
-          expect_raises(IndexError) do
+          expect_raises(Enumerable::NotFoundError) do
             "abbbb".rindex!(/b/, 0)
           end
         end

--- a/src/string.cr
+++ b/src/string.cr
@@ -3282,6 +3282,13 @@ class String
     self.match(search, offset).try &.begin
   end
 
+  # :ditto:
+  #
+  # Raises `IndexError` if there is no *search* occurence in `self`.
+  def index!(search, offset = 0) : Int32
+    index(search, offset) || raise IndexError.new
+  end
+
   # Returns the index of the _last_ appearance of *search* in the string,
   # If *offset* is present, it defines the position to _end_ the search
   # (characters beyond this point are ignored).
@@ -3386,6 +3393,27 @@ class String
     end
 
     match_result.try &.begin
+  end
+
+  # :ditto:
+  #
+  # Raises `IndexError` if there is no *search* occurence in `self`.
+  def rindex!(search : Regex, offset = size) : Int32
+    rindex(search, offset) || raise IndexError.new
+  end
+
+  # :ditto:
+  #
+  # Raises `IndexError` if there is no *search* occurence in `self`.
+  def rindex!(search : String, offset = size - search.size) : Int32
+    rindex(search, offset) || raise IndexError.new
+  end
+
+  # :ditto:
+  #
+  # Raises `IndexError` if there is no *search* occurence in `self`.
+  def rindex!(search : Char, offset = size - 1) : Int32
+    rindex(search, offset) || raise IndexError.new
   end
 
   # Searches separator or pattern (`Regex`) in the string, and returns

--- a/src/string.cr
+++ b/src/string.cr
@@ -3286,7 +3286,7 @@ class String
   #
   # Raises `IndexError` if there is no *search* occurence in `self`.
   def index!(search, offset = 0) : Int32
-    index(search, offset) || raise IndexError.new
+    index(search, offset) || raise Enumerable::NotFoundError.new
   end
 
   # Returns the index of the _last_ appearance of *search* in the string,
@@ -3399,21 +3399,21 @@ class String
   #
   # Raises `IndexError` if there is no *search* occurence in `self`.
   def rindex!(search : Regex, offset = size) : Int32
-    rindex(search, offset) || raise IndexError.new
+    rindex(search, offset) || raise Enumerable::NotFoundError.new
   end
 
   # :ditto:
   #
   # Raises `IndexError` if there is no *search* occurence in `self`.
   def rindex!(search : String, offset = size - search.size) : Int32
-    rindex(search, offset) || raise IndexError.new
+    rindex(search, offset) || raise Enumerable::NotFoundError.new
   end
 
   # :ditto:
   #
   # Raises `IndexError` if there is no *search* occurence in `self`.
   def rindex!(search : Char, offset = size - 1) : Int32
-    rindex(search, offset) || raise IndexError.new
+    rindex(search, offset) || raise Enumerable::NotFoundError.new
   end
 
   # Searches separator or pattern (`Regex`) in the string, and returns

--- a/src/string.cr
+++ b/src/string.cr
@@ -3284,7 +3284,7 @@ class String
 
   # :ditto:
   #
-  # Raises `IndexError` if there is no *search* occurence in `self`.
+  # Raises `Enumerable::NotFoundError` if *search* does not occur in `self`.
   def index!(search, offset = 0) : Int32
     index(search, offset) || raise Enumerable::NotFoundError.new
   end
@@ -3397,21 +3397,17 @@ class String
 
   # :ditto:
   #
-  # Raises `IndexError` if there is no *search* occurence in `self`.
+  # Raises `Enumerable::NotFoundError` if *search* does not occur in `self`.
   def rindex!(search : Regex, offset = size) : Int32
     rindex(search, offset) || raise Enumerable::NotFoundError.new
   end
 
   # :ditto:
-  #
-  # Raises `IndexError` if there is no *search* occurence in `self`.
   def rindex!(search : String, offset = size - search.size) : Int32
     rindex(search, offset) || raise Enumerable::NotFoundError.new
   end
 
   # :ditto:
-  #
-  # Raises `IndexError` if there is no *search* occurence in `self`.
   def rindex!(search : Char, offset = size - 1) : Int32
     rindex(search, offset) || raise Enumerable::NotFoundError.new
   end


### PR DESCRIPTION
Adds `String#index!` and `String#index!` methods, similar to the ones found in `Enumerable`.

Supersedes/closes #12729