### PR TITLE
Improve error message when there are extra types

### DIFF
--- a/spec/compiler/semantic/abstract_def_spec.cr
+++ b/spec/compiler/semantic/abstract_def_spec.cr
@@ -94,12 +94,7 @@ describe "Semantic: abstract def" do
 
       Bar.new.foo(1 || 'a')
       ),
-      <<-MSG
-      Overloads are:
-       - Bar#foo(x : Int32)
-      Couldn't find overloads for these types:
-       - Bar#foo(x : Char)
-      MSG
+      "expected argument #1 to 'Bar#foo' to be Int32, not (Char | Int32)"
   end
 
   it "errors if using abstract def on non-abstract class" do

--- a/spec/compiler/semantic/call_error_spec.cr
+++ b/spec/compiler/semantic/call_error_spec.cr
@@ -281,11 +281,7 @@ describe "Call errors" do
       "expected argument #1 to 'foo' to be Char or Int32, not (Char | Int32 | Nil)"
   end
 
-  it "doesn't error on argument if actual type matches all expected types in different overloads" do
-    # This could be improved to say "expected argument #2 to 'foo' to be Int32, not (Int32 | Nil)
-    # but it's tricky or it might be misleading because the argument #2 can be nil, just not
-    # for this overload (and with a different argument type for the third position).
-    # In practice it's maybe unlikely that such oveloads actually exist.
+  it "errors on argument if argument matches in all overloads but with different types in other arguments" do
     assert_error %(
       def foo(x : String, y : Int32, w : Int32)
       end
@@ -295,6 +291,6 @@ describe "Call errors" do
 
       foo("a", 1 || nil, 1)
       ),
-      "no overload matches"
+      "expected argument #2 to 'foo' to be Int32, not (Int32 | Nil)"
   end
 end

--- a/spec/compiler/semantic/call_error_spec.cr
+++ b/spec/compiler/semantic/call_error_spec.cr
@@ -254,4 +254,17 @@ describe "Call errors" do
       ),
       "expected argument 'x' to 'foo' to match a member of enum Color.\n\nDid you mean :red?"
   end
+
+  it "errors on argument if more types are given than expected" do
+    assert_error %(
+      def foo(x : Int32)
+      end
+
+      def foo(x : Char)
+      end
+
+      foo(1 || nil)
+      ),
+      "expected argument #1 to 'foo' to be Int32, not (Int32 | Nil)"
+  end
 end

--- a/spec/compiler/semantic/call_error_spec.cr
+++ b/spec/compiler/semantic/call_error_spec.cr
@@ -280,4 +280,21 @@ describe "Call errors" do
       ),
       "expected argument #1 to 'foo' to be Char or Int32, not (Char | Int32 | Nil)"
   end
+
+  it "doesn't error on argument if actual type matches all expected types in different overloads" do
+    # This could be improved to say "expected argument #2 to 'foo' to be Int32, not (Int32 | Nil)
+    # but it's tricky or it might be misleading because the argument #2 can be nil, just not
+    # for this overload (and with a different argument type for the third position).
+    # In practice it's maybe unlikely that such oveloads actually exist.
+    assert_error %(
+      def foo(x : String, y : Int32, w : Int32)
+      end
+
+      def foo(x : String, y : Nil, w : Char)
+      end
+
+      foo("a", 1 || nil, 1)
+      ),
+      "no overload matches"
+  end
 end

--- a/spec/compiler/semantic/call_error_spec.cr
+++ b/spec/compiler/semantic/call_error_spec.cr
@@ -267,4 +267,17 @@ describe "Call errors" do
       ),
       "expected argument #1 to 'foo' to be Int32, not (Int32 | Nil)"
   end
+
+  it "errors on argument if more types are given than expected, shows all expected types" do
+    assert_error %(
+      def foo(x : Int32)
+      end
+
+      def foo(x : Char)
+      end
+
+      foo(1 ? nil : (1 || 'a'))
+      ),
+      "expected argument #1 to 'foo' to be Char or Int32, not (Char | Int32 | Nil)"
+  end
 end

--- a/spec/compiler/semantic/def_overload_spec.cr
+++ b/spec/compiler/semantic/def_overload_spec.cr
@@ -1437,7 +1437,7 @@ describe "Semantic: def overload" do
       a = 1 || nil
       f(a: a)
       ),
-      "no overload matches"
+      "expected argument 'a' to 'f' to be Int32, not (Int32 | Nil)"
   end
 
   it "errors if no overload matches on union against named arg with external param name (#10516)" do
@@ -1448,7 +1448,7 @@ describe "Semantic: def overload" do
       a = 1 || nil
       f(a: a)
       ),
-      "no overload matches"
+      "expected argument 'a' to 'f' to be Int32, not (Int32 | Nil)"
   end
 
   it "dispatches with named arg" do
@@ -1642,7 +1642,7 @@ describe "Semantic: def overload" do
       x = uninitialized Foo
       foo(x)
       ),
-      "no overload matches"
+      "expected argument #1 to 'foo' to be Bar, not Foo"
   end
 
   it "treats single splats with same restriction as equivalent (#12579)" do

--- a/spec/compiler/semantic/def_spec.cr
+++ b/spec/compiler/semantic/def_spec.cr
@@ -121,7 +121,7 @@ describe "Semantic: def" do
 
       foo 1 || 1.5
       ",
-      "no overload matches"
+      "expected argument #1 to 'foo' to be Int, not (Float64 | Int32)"
   end
 
   it "reports no overload matches 2" do
@@ -134,7 +134,7 @@ describe "Semantic: def" do
 
       foo(1 || 'a', 1 || 1.5)
       ",
-      "no overload matches"
+      "expected argument #1 to 'foo' to be Int, not (Char | Int32)"
   end
 
   it "reports no block given" do

--- a/spec/compiler/semantic/initialize_spec.cr
+++ b/spec/compiler/semantic/initialize_spec.cr
@@ -640,7 +640,8 @@ describe "Semantic: initialize" do
       a = 1 > 0 ? nil : 1
       Foo.new(a)
       ",
-      "no overload matches", inject_primitives: true
+      "expected argument #1 to 'Foo.new' to be Int32, not (Int32 | Nil)",
+      inject_primitives: true
   end
 
   it "doesn't mark instance variable as nilable when using self.class" do

--- a/spec/compiler/semantic/restrictions_spec.cr
+++ b/spec/compiler/semantic/restrictions_spec.cr
@@ -750,7 +750,7 @@ describe "Restrictions" do
 
       bar(1 || "")
       ),
-      "no overload matches"
+      "expected argument #1 to 'bar' to be String, not (Int32 | String)"
   end
 
   it "errors on T::Type that's union when used from type restriction" do

--- a/spec/compiler/semantic/virtual_spec.cr
+++ b/spec/compiler/semantic/virtual_spec.cr
@@ -384,7 +384,7 @@ describe "Semantic: virtual" do
       f = Bar1.new || Bar2.new || Baz.new
       foo(f)
       ",
-      "no overload matches"
+      "expected argument #1 to 'foo' to be Bar1 or Baz, not Foo"
   end
 
   it "checks cover in every concrete subclass" do
@@ -446,7 +446,7 @@ describe "Semantic: virtual" do
       f = Bar1.new || Bar2.new || Baz.new
       f.foo(f)
       ",
-      "no overload matches"
+      "expected argument #1 to 'Baz#foo' to be Bar1 or Baz, not Foo"
   end
 
   it "checks cover in every concrete subclass 3" do

--- a/src/compiler/crystal/semantic/call_error.cr
+++ b/src/compiler/crystal/semantic/call_error.cr
@@ -363,7 +363,7 @@ class Crystal::Call
       else
         str << "expected argument #{argument_description} to '#{full_name(owner, def_name)}' to be "
         to_sentence(str, expected_types, " or ")
-        str << ", not #{actual_type}"
+        str << ", not #{actual_type.devirtualize}"
       end
     end
   end

--- a/src/compiler/crystal/semantic/call_error.cr
+++ b/src/compiler/crystal/semantic/call_error.cr
@@ -125,6 +125,9 @@ class Crystal::Call
     check_wrong_number_of_arguments(call_errors, owner, defs, def_name, arg_types, named_args_types, inner_exception)
 
     has_extra_types = check_extra_types_arguments_mismatch(call_errors, owner, defs, def_name, arg_types, named_args_types, inner_exception)
+
+    # Give a general "no overload matches" error if more types than expected were given to some arguments
+    # (doing otherwise has led to some misleading errors)
     unless has_extra_types
       check_arguments_type_mismatch(call_errors, owner, defs, def_name, arg_types, named_args_types, inner_exception)
     end


### PR DESCRIPTION
Fixes #12720

At least this fixes the errors mentioned here:
- https://forum.crystal-lang.org/t/misleading-error-message-when-type-is-not-match/5075
- https://forum.crystal-lang.org/t/error-expected-argument-1-to-array-uint128-to-be-range-b-e-not-uint8-nil-https-forum-crystal-lang-org-t-custom-prng-binary-output-5028/5107

The main problem with the old code is that when you gave `Int32 | Nil` to something that expected `Int32` that wasn't considered an error, because it's a partial match (restricting `Int32 | Nil` to `Int32` gives `Int32`).

Of course it's not always right to say that `Int32 | Nil` doesn't match `Int32` because there might be another overload that does cover `Nil`. This PR tries to take care of that too.

The error messages could still be improved, but at least now, I _think_, they won't be misleading in some cases.

All tests pass. And here's the new output for the errors mentioned in the forums.

For:

```crystal
require "socket"

struct Test
  getter host : String?
  getter port : Int32?

  def initialize(@host, @port)
  end
end

test = Test.new("127.0.0.1", 3005)

TCPServer.new(test.host.not_nil!, test.port)
```

Old error:
```
In foo.cr:13:25

 13 | TCPServer.new(test.host.not_nil!, test.port)
                              ^-------
Error: expected argument #1 to 'TCPServer.new' to be Int, not String
```

New error:

```
In foo.cr:13:40

 13 | TCPServer.new(test.host.not_nil!, test.port)
                                             ^---
Error: expected argument #2 to 'TCPServer.new' to be Int, not (Int32 | Nil)
```

For:

```crystal
a = Array(UInt128).new(256)

10.times do
  char = STDIN.raw &.read_byte
  a[char] += 1
end
```

Old error:

```
Error: expected argument #1 to 'Array(UInt128)#[]' to be Range(B, E), not (UInt8 | Nil)
```

New error:

```
Error: expected argument #1 to 'Array(UInt128)#[]' to be Int, not (UInt8 | Nil)
```

