### PR TITLE
[CI] Update dependencies for windows CI

### DIFF
--- a/.github/workflows/win.yml
+++ b/.github/workflows/win.yml
@@ -25,7 +25,7 @@ jobs:
 
   x86_64-windows-job:
     needs: x86_64-linux-job
-    runs-on: windows-latest
+    runs-on: windows-2022
     steps:
       - name: Disable CRLF line ending substitution
         run: |
@@ -55,14 +55,14 @@ jobs:
         uses: actions/checkout@v3
         with:
           repository: ivmai/bdwgc
-          ref: v8.2.0
+          ref: v8.2.2
           path: bdwgc
       - name: Download libatomic_ops
         if: steps.cache-libs.outputs.cache-hit != 'true'
         uses: actions/checkout@v3
         with:
           repository: ivmai/libatomic_ops
-          ref: v7.6.10
+          ref: v7.6.14
           path: bdwgc/libatomic_ops
       - name: Build libgc
         if: steps.cache-libs.outputs.cache-hit != 'true'
@@ -88,7 +88,7 @@ jobs:
         uses: actions/checkout@v3
         with:
           repository: pffang/libiconv-for-Windows
-          ref: 9b7aba8da6e125ef33912fa4412779279f204003 # master @ 2021-08-24
+          ref: 1353455a6c4e15c9db6865fd9c2bf7203b59c0ec # master@{2022-10-11}
           path: libiconv
       - name: Build libiconv
         if: steps.cache-libs.outputs.cache-hit != 'true'
@@ -145,8 +145,8 @@ jobs:
       - name: Download zlib
         if: steps.cache-libs.outputs.cache-hit != 'true'
         run: |
-          iwr https://github.com/madler/zlib/archive/v1.2.11.zip -OutFile zlib.zip
-          (Get-FileHash -Algorithm SHA256 .\zlib.zip).hash -eq "f5cc4ab910db99b2bdbba39ebbdc225ffc2aa04b4057bc2817f1b94b6978cfc3"
+          iwr https://github.com/madler/zlib/archive/v1.2.13.zip -OutFile zlib.zip
+          (Get-FileHash -Algorithm SHA256 .\zlib.zip).hash -eq "C2856951BBF30E30861ACE3765595D86BA13F2CF01279D901F6C62258C57F4FF"
           7z x zlib.zip
           mv zlib-* zlib
       - name: Build zlib
@@ -160,7 +160,7 @@ jobs:
         uses: actions/checkout@v3
         with:
           repository: BrianGladman/mpir
-          ref: d9c9a842be6475bef74324f367ce2c5a78c55d06  # master @ 2021-10-14
+          ref: 28d01062f62de1218d511c4574da4006f92be3bd  # master@{2022-10-12}
           path: mpir
       - name: Build mpir
         if: steps.cache-libs.outputs.cache-hit != 'true'
@@ -187,8 +187,8 @@ jobs:
       - name: Download libyaml
         if: steps.cache-libs.outputs.cache-hit != 'true'
         run: |
-          iwr https://github.com/yaml/libyaml/archive/0.2.4.zip -OutFile libyaml.zip
-          (Get-FileHash -Algorithm SHA256 .\libyaml.zip).hash -eq "5882285b8265096d045ecebbee651b73bef6cead34e439b63e86bf393c936793"
+          iwr https://github.com/yaml/libyaml/archive/0.2.5.zip -OutFile libyaml.zip
+          (Get-FileHash -Algorithm SHA256 .\libyaml.zip).hash -eq "14605BAA6DFC0C4D3AB943A46A627413C0388736E453B67FE4E90C9683C8CBC8"
           7z x libyaml.zip
           mv libyaml-* libyaml
       - name: Build libyaml
@@ -202,13 +202,13 @@ jobs:
         uses: actions/checkout@v3
         with:
           repository: GNOME/libxml2
-          ref: a230b728f1289dd24c1666856ac4fb55579c6dfb  # master @ 2020-05-04
+          ref: f507d167f1755b7eaea09fb1a44d29aab828b6d1  # v2.10.3
           path: libxml2
       - name: Build libxml2
         if: steps.cache-libs.outputs.cache-hit != 'true'
         working-directory: ./libxml2
         run: |
-          cmake . -DBUILD_SHARED_LIBS=OFF -DLIBXML2_WITH_PROGRAMS=OFF -DLIBXML2_WITH_HTTP=OFF -DLIBXML2_WITH_FTP=OFF -DLIBXML2_WITH_TESTS=OFF -DCMAKE_POLICY_DEFAULT_CMP0091=NEW -DCMAKE_MSVC_RUNTIME_LIBRARY=MultiThreaded -DCMAKE_FIND_USE_SYSTEM_ENVIRONMENT_PATH=OFF
+          cmake . -DBUILD_SHARED_LIBS=OFF -DLIBXML2_WITH_PROGRAMS=OFF -DLIBXML2_WITH_HTTP=OFF -DLIBXML2_WITH_FTP=OFF -DLIBXML2_WITH_TESTS=OFF -DCMAKE_POLICY_DEFAULT_CMP0091=NEW -DCMAKE_MSVC_RUNTIME_LIBRARY=MultiThreaded -DCMAKE_FIND_USE_SYSTEM_ENVIRONMENT_PATH=OFF -DLIBXML2_WITH_ICONV=OFF -DLIBXML2_WITH_LZMA=OFF -DLIBXML2_WITH_PYTHON=OFF -DLIBXML2_WITH_ZLIB=OFF
 
           echo '<Project>
             <PropertyGroup>
@@ -230,7 +230,7 @@ jobs:
         run: |
           mkdir libs
           mv pcre/Release/pcre.lib libs/
-          mv libiconv/lib64/libiconvStatic.lib libs/iconv.lib
+          mv libiconv/output/x64/ReleaseStatic/libiconvStatic.lib libs/iconv.lib
           mv bdwgc/Release/gc.lib libs/
           mv libffi/win32/vs16_x64/x64/Release/libffi.lib libs/ffi.lib
           mv zlib/Release/zlibstatic.lib libs/z.lib
@@ -278,12 +278,12 @@ jobs:
         uses: actions/cache@v3
         with:
           path: llvm
-          key: llvm-libs-13.0.0-msvc-${{ env.VSCMD_VER }}
+          key: llvm-libs-13.0.1-msvc-${{ env.VSCMD_VER }}
       - name: Download LLVM
         if: steps.cache-llvm.outputs.cache-hit != 'true'
         run: |
-          iwr https://github.com/llvm/llvm-project/releases/download/llvmorg-13.0.0/llvm-13.0.0.src.tar.xz -OutFile llvm.tar.xz
-          (Get-FileHash -Algorithm SHA256 .\llvm.tar.xz).hash -eq "408d11708643ea826f519ff79761fcdfc12d641a2510229eec459e72f8163020"
+          iwr https://github.com/llvm/llvm-project/releases/download/llvmorg-13.0.1/llvm-13.0.1.src.tar.xz -OutFile llvm.tar.xz
+          (Get-FileHash -Algorithm SHA256 .\llvm.tar.xz).hash -eq "EC6B80D82C384ACAD2DC192903A6CF2CDBAFFB889B84BFB98DA9D71E630FC834"
           7z x llvm.tar.xz
           7z x llvm.tar
           mv llvm-* llvm-src
@@ -331,7 +331,7 @@ jobs:
         uses: actions/checkout@v3
         with:
           repository: crystal-lang/shards
-          ref: v0.17.0
+          ref: v0.17.1
           path: shards
 
       - name: Download molinillo release


### PR DESCRIPTION
Updates several dependencies in GitHub Actions' `win.yml` workflow.

The updates are always to the latest release or current HEAD (if there are not releases), except for LLVM which stays on version 13. Upgrading that should be a follow-up.