### PR TITLE
Fix call to transform windows string using `System.to_wstr`

### DIFF
--- a/src/crystal/system/win32/file.cr
+++ b/src/crystal/system/win32/file.cr
@@ -124,7 +124,7 @@ module Crystal::System::File
   end
 
   def self.executable?(path) : Bool
-    LibC.GetBinaryTypeW(to_windows_path(path), out result) != 0
+    LibC.GetBinaryTypeW(System.to_wstr(path), out result) != 0
   end
 
   private def self.accessible?(path, mode)


### PR DESCRIPTION
Fixes a cross merge conflict between #12695 (which replaced several individual `to_windows_path` helpers by a single implementation `System.to_wstr`) and #9677.