### PR TITLE
Ensure `HTTP::Client` closes response when breaking out of block

### DIFF
--- a/spec/std/http/client/client_spec.cr
+++ b/spec/std/http/client/client_spec.cr
@@ -180,6 +180,26 @@ module HTTP
       end
     end
 
+    it "ensures closing the response when breaking out of block" do
+      server = HTTP::Server.new {}
+      address = server.bind_unused_port "127.0.0.1"
+
+      run_server(server) do
+        client = HTTP::Client.new(address.address, address.port)
+        response = nil
+
+        exc = Exception.new("")
+        expect_raises Exception do
+          client.get("/") do |r|
+            response = r
+            raise exc
+          end
+        end.should be exc
+
+        response.try(&.body_io?.try(&.closed?)).should be_true
+      end
+    end
+
     pending_win32 "will retry a broken socket" do
       server = HTTP::Server.new do |context|
         context.response.output.print "foo"

--- a/spec/std/http/client/client_spec.cr
+++ b/spec/std/http/client/client_spec.cr
@@ -181,7 +181,7 @@ module HTTP
     end
 
     it "ensures closing the response when breaking out of block" do
-      server = HTTP::Server.new {}
+      server = HTTP::Server.new { }
       address = server.bind_unused_port "127.0.0.1"
 
       run_server(server) do

--- a/src/http/client.cr
+++ b/src/http/client.cr
@@ -664,10 +664,10 @@ class HTTP::Client
   end
 
   private def handle_response(response)
-    value = yield
+    yield
+  ensure
     response.body_io?.try &.close
     close unless response.keep_alive?
-    value
   end
 
   private def send_request(request)


### PR DESCRIPTION
The request methods of `HTTP::Client` have a yielding overload which passes the response to the block, and cleans up after the block returns (mainly closing the body IO).
This cleanup logic is skipped when the block does not come back to that scope in case execution breaks out via `raise` or `return`.

This patch puts the cleanup logic into an `ensure` block to make sure it executes even when breaking out of the block.