### PR TITLE
Resolve type of free variable on block return type mismatch

### DIFF
--- a/spec/compiler/semantic/block_spec.cr
+++ b/spec/compiler/semantic/block_spec.cr
@@ -1608,4 +1608,15 @@ describe "Block inference" do
       foo.foo
       CR
   end
+
+  it "renders expected block return type of a free variable on mismatch" do
+    assert_error(<<-CR, "expected block to return Int64, not String")
+      struct Foo
+        def bar(arg : U, &block : -> U) forall U
+        end
+      end
+
+      Foo.new.bar(1_i64) { "hi" }
+      CR
+  end
 end

--- a/src/compiler/crystal/semantic/call.cr
+++ b/src/compiler/crystal/semantic/call.cr
@@ -1041,7 +1041,7 @@ class Crystal::Call
                             when Self
                               match.context.instantiated_type
                             when Crystal::Path
-                              match.context.defining_type.lookup_path(output)
+                              match.context.defining_type.lookup_type_var(output, match.context.free_vars)
                             else
                               output
                             end


### PR DESCRIPTION
The following code snippet produces an ambiguous error.

```crystal
struct Foo
  def bar(arg : U, &block : -> U) forall U
  end
end
Foo.new.bar(1_i64) { "hi" }
```

Output:
```terminal-session
Showing last frame. Use --error-trace for full trace.

error in line 5
Error: expected block to return , not String
```

[See on carc.in](https://carc.in/#/r/e3gi)


This PR fixes the ambiguity by the inclusion of the method's free variables when resolving the expected return type of the block.