### PR TITLE
Support new SI prefixes in `Number#humanize`

### DIFF
--- a/spec/std/humanize_spec.cr
+++ b/spec/std/humanize_spec.cr
@@ -12,6 +12,8 @@ private LENGTH_UNITS = ->(magnitude : Int32, number : Float64) do
   end
 end
 
+private CUSTOM_PREFIXES = [['a'], ['b', 'c', 'd']]
+
 describe Number do
   describe "#format" do
     it { assert_prints 1.format, "1" }
@@ -117,6 +119,78 @@ describe Number do
     it { assert_prints 0.123_456_78.humanize, "123m" }
     it { assert_prints 0.123_456_78.humanize(5), "123.46m" }
 
+    it { assert_prints 1.0e-35.humanize, "0.00001q" }
+    it { assert_prints 1.0e-34.humanize, "0.0001q" }
+    it { assert_prints 1.0e-33.humanize, "0.001q" }
+    it { assert_prints 1.0e-32.humanize, "0.01q" }
+    it { assert_prints 1.0e-31.humanize, "0.1q" }
+    it { assert_prints 1.0e-30.humanize, "1.0q" }
+    it { assert_prints 1.0e-29.humanize, "10.0q" }
+    it { assert_prints 1.0e-28.humanize, "100q" }
+    it { assert_prints 1.0e-27.humanize, "1.0r" }
+    it { assert_prints 1.0e-26.humanize, "10.0r" }
+    it { assert_prints 1.0e-25.humanize, "100r" }
+    it { assert_prints 1.0e-24.humanize, "1.0y" }
+    it { assert_prints 1.0e-23.humanize, "10.0y" }
+    it { assert_prints 1.0e-22.humanize, "100y" }
+    it { assert_prints 1.0e-21.humanize, "1.0z" }
+    it { assert_prints 1.0e-20.humanize, "10.0z" }
+    it { assert_prints 1.0e-19.humanize, "100z" }
+    it { assert_prints 1.0e-18.humanize, "1.0a" }
+    it { assert_prints 1.0e-17.humanize, "10.0a" }
+    it { assert_prints 1.0e-16.humanize, "100a" }
+    it { assert_prints 1.0e-15.humanize, "1.0f" }
+    it { assert_prints 1.0e-14.humanize, "10.0f" }
+    it { assert_prints 1.0e-13.humanize, "100f" }
+    it { assert_prints 1.0e-12.humanize, "1.0p" }
+    it { assert_prints 1.0e-11.humanize, "10.0p" }
+    it { assert_prints 1.0e-10.humanize, "100p" }
+    it { assert_prints 1.0e-9.humanize, "1.0n" }
+    it { assert_prints 1.0e-8.humanize, "10.0n" }
+    it { assert_prints 1.0e-7.humanize, "100n" }
+    it { assert_prints 1.0e-6.humanize, "1.0µ" }
+    it { assert_prints 1.0e-5.humanize, "10.0µ" }
+    it { assert_prints 1.0e-4.humanize, "100µ" }
+    it { assert_prints 1.0e-3.humanize, "1.0m" }
+    it { assert_prints 1.0e-2.humanize, "10.0m" }
+    it { assert_prints 1.0e-1.humanize, "100m" }
+    it { assert_prints 1.0e+0.humanize, "1.0" }
+    it { assert_prints 1.0e+1.humanize, "10.0" }
+    it { assert_prints 1.0e+2.humanize, "100" }
+    it { assert_prints 1.0e+3.humanize, "1.0k" }
+    it { assert_prints 1.0e+4.humanize, "10.0k" }
+    it { assert_prints 1.0e+5.humanize, "100k" }
+    it { assert_prints 1.0e+6.humanize, "1.0M" }
+    it { assert_prints 1.0e+7.humanize, "10.0M" }
+    it { assert_prints 1.0e+8.humanize, "100M" }
+    it { assert_prints 1.0e+9.humanize, "1.0G" }
+    it { assert_prints 1.0e+10.humanize, "10.0G" }
+    it { assert_prints 1.0e+11.humanize, "100G" }
+    it { assert_prints 1.0e+12.humanize, "1.0T" }
+    it { assert_prints 1.0e+13.humanize, "10.0T" }
+    it { assert_prints 1.0e+14.humanize, "100T" }
+    it { assert_prints 1.0e+15.humanize, "1.0P" }
+    it { assert_prints 1.0e+16.humanize, "10.0P" }
+    it { assert_prints 1.0e+17.humanize, "100P" }
+    it { assert_prints 1.0e+18.humanize, "1.0E" }
+    it { assert_prints 1.0e+19.humanize, "10.0E" }
+    it { assert_prints 1.0e+20.humanize, "100E" }
+    it { assert_prints 1.0e+21.humanize, "1.0Z" }
+    it { assert_prints 1.0e+22.humanize, "10.0Z" }
+    it { assert_prints 1.0e+23.humanize, "100Z" }
+    it { assert_prints 1.0e+24.humanize, "1.0Y" }
+    it { assert_prints 1.0e+25.humanize, "10.0Y" }
+    it { assert_prints 1.0e+26.humanize, "100Y" }
+    it { assert_prints 1.0e+27.humanize, "1.0R" }
+    it { assert_prints 1.0e+28.humanize, "10.0R" }
+    it { assert_prints 1.0e+29.humanize, "100R" }
+    it { assert_prints 1.0e+30.humanize, "1.0Q" }
+    it { assert_prints 1.0e+31.humanize, "10.0Q" }
+    it { assert_prints 1.0e+32.humanize, "100Q" }
+    it { assert_prints 1.0e+33.humanize, "1,000Q" }
+    it { assert_prints 1.0e+34.humanize, "10,000Q" }
+    it { assert_prints 1.0e+35.humanize, "100,000Q" }
+
     it { assert_prints 1_234.567_890_123.humanize(precision: 2, significant: false), "1.23k" }
     it { assert_prints 123.456_789_012_3.humanize(precision: 2, significant: false), "123.46" }
     it { assert_prints 12.345_678_901_23.humanize(precision: 2, significant: false), "12.35" }
@@ -144,6 +218,25 @@ describe Number do
       it { assert_prints 0.001.humanize(prefixes: LENGTH_UNITS), "1.0 mm" }
       it { assert_prints 0.000_01.humanize(prefixes: LENGTH_UNITS), "10.0 µm" }
       it { assert_prints 0.000_000_001.humanize(prefixes: LENGTH_UNITS), "1.0 nm" }
+
+      it { assert_prints 1.0e-7.humanize(prefixes: CUSTOM_PREFIXES), "0.0001a" }
+      it { assert_prints 1.0e-6.humanize(prefixes: CUSTOM_PREFIXES), "0.001a" }
+      it { assert_prints 1.0e-5.humanize(prefixes: CUSTOM_PREFIXES), "0.01a" }
+      it { assert_prints 1.0e-4.humanize(prefixes: CUSTOM_PREFIXES), "0.1a" }
+      it { assert_prints 1.0e-3.humanize(prefixes: CUSTOM_PREFIXES), "1.0a" }
+      it { assert_prints 1.0e-2.humanize(prefixes: CUSTOM_PREFIXES), "10.0a" }
+      it { assert_prints 1.0e-1.humanize(prefixes: CUSTOM_PREFIXES), "100a" }
+      it { assert_prints 1.0e+0.humanize(prefixes: CUSTOM_PREFIXES), "1.0b" }
+      it { assert_prints 1.0e+1.humanize(prefixes: CUSTOM_PREFIXES), "10.0b" }
+      it { assert_prints 1.0e+2.humanize(prefixes: CUSTOM_PREFIXES), "100b" }
+      it { assert_prints 1.0e+3.humanize(prefixes: CUSTOM_PREFIXES), "1.0c" }
+      it { assert_prints 1.0e+4.humanize(prefixes: CUSTOM_PREFIXES), "10.0c" }
+      it { assert_prints 1.0e+5.humanize(prefixes: CUSTOM_PREFIXES), "100c" }
+      it { assert_prints 1.0e+6.humanize(prefixes: CUSTOM_PREFIXES), "1.0d" }
+      it { assert_prints 1.0e+7.humanize(prefixes: CUSTOM_PREFIXES), "10.0d" }
+      it { assert_prints 1.0e+8.humanize(prefixes: CUSTOM_PREFIXES), "100d" }
+      it { assert_prints 1.0e+9.humanize(prefixes: CUSTOM_PREFIXES), "1,000d" }
+      it { assert_prints 1.0e+10.humanize(prefixes: CUSTOM_PREFIXES), "10,000d" }
     end
   end
 end

--- a/src/humanize.cr
+++ b/src/humanize.cr
@@ -96,7 +96,7 @@ struct Number
   end
 
   # Default SI prefixes ordered by magnitude.
-  SI_PREFIXES = { {'y', 'z', 'a', 'f', 'p', 'n', 'µ', 'm'}, {nil, 'k', 'M', 'G', 'T', 'P', 'E', 'Z', 'Y'} }
+  SI_PREFIXES = { {'q', 'r', 'y', 'z', 'a', 'f', 'p', 'n', 'µ', 'm'}, {nil, 'k', 'M', 'G', 'T', 'P', 'E', 'Z', 'Y', 'R', 'Q'} }
 
   # SI prefixes used by `#humanize`. Equal to `SI_PREFIXES` but prepends the
   # prefix with a space character.
@@ -113,12 +113,13 @@ struct Number
   def self.si_prefix(magnitude : Int, prefixes = SI_PREFIXES) : Char?
     index = (magnitude // 3)
     prefixes = prefixes[magnitude < 0 ? 0 : 1]
-    prefixes[index.clamp((-prefixes.size + 1)..(prefixes.size - 1))]
+    prefixes[index.clamp((-prefixes.size)..(prefixes.size - 1))]
   end
 
   # :nodoc:
-  def self.prefix_index(i : Int32, group : Int32 = 3) : Int32
-    ((i - (i > 0 ? 1 : 0)) // group) * group
+  def self.prefix_index(i : Int32, *, group : Int32 = 3, prefixes = SI_PREFIXES) : Int32
+    prefixes = prefixes[i < 0 ? 0 : 1]
+    ((i - (i > 0 ? 1 : 0)) // group).clamp((-prefixes.size)..(prefixes.size - 1)) * group
   end
 
   # Pretty prints this number as a `String` in a human-readable format.
@@ -150,7 +151,7 @@ struct Number
   # See `Int#humanize_bytes` to format a file size.
   def humanize(io : IO, precision = 3, separator = '.', delimiter = ',', *, base = 10 ** 3, significant = true, prefixes : Indexable = SI_PREFIXES) : Nil
     humanize(io, precision, separator, delimiter, base: base, significant: significant) do |magnitude, _|
-      magnitude = Number.prefix_index(magnitude)
+      magnitude = Number.prefix_index(magnitude, prefixes: prefixes)
       {magnitude, Number.si_prefix(magnitude, prefixes)}
     end
   end
@@ -284,13 +285,13 @@ end
 
 struct Int
   enum BinaryPrefixFormat
-    # The IEC standard prefixes (`Ki`, `Mi`, `Gi`, `Ti`, `Pi`, `Ei`, `Zi`, `Yi`)
+    # The IEC standard prefixes (`Ki`, `Mi`, `Gi`, `Ti`, `Pi`, `Ei`, `Zi`, `Yi`, `Ri`, `Qi`)
     # based on powers of 1000.
     IEC
 
-    # Extended range of the JEDEC units (`K`, `M`, `G`, `T`, `P`, `E`, `Z`, `Y`) which equals to
-    # the prefixes of the SI system except for uppercase `K` and is based on
-    # powers of 1024.
+    # Extended range of the JEDEC units (`K`, `M`, `G`, `T`, `P`, `E`, `Z`, `Y`, `R`, `Q`)
+    # which equals to the prefixes of the SI system except for uppercase `K` and
+    # is based on powers of 1024.
     JEDEC
   end
 
@@ -300,12 +301,12 @@ struct Int
   # Values with binary measurements such as computer storage (e.g. RAM size) are
   # typically expressed using unit prefixes based on 1024 (instead of multiples
   # of 1000 as per SI standard). This method by default uses the IEC standard
-  # prefixes (`Ki`, `Mi`, `Gi`, `Ti`, `Pi`, `Ei`, `Zi`, `Yi`) based on powers of
-  # 1000 (see `BinaryPrefixFormat::IEC`).
+  # prefixes (`Ki`, `Mi`, `Gi`, `Ti`, `Pi`, `Ei`, `Zi`, `Yi`, `Ri`, `Qi`) based
+  # on powers of 1000 (see `BinaryPrefixFormat::IEC`).
   #
   # *format* can be set to use the extended range of JEDEC units (`K`, `M`, `G`,
-  # `T`, `P`, `E`, `Z`, `Y`) which equals to the prefixes of the SI system
-  # except for uppercase `K` and is based on powers of 1024 (see
+  # `T`, `P`, `E`, `Z`, `Y`, `R`, `Q`) which equals to the prefixes of the SI
+  # system except for uppercase `K` and is based on powers of 1024 (see
   # `BinaryPrefixFormat::JEDEC`).
   #
   # ```


### PR DESCRIPTION
Adds support for ronna- (10<sup>27</sup>), quetta- (10<sup>30</sup>), ronto- (10<sup>-27</sup>), and quecto- (10<sup>-30</sup>), which were officially added at the [27th meeting of the CGPM](https://www.bipm.org/documents/20126/77765681/Resolutions-2022.pdf/281f3160-fc56-3e63-dbf7-77b76500990f).

`#humanize_bytes` implicitly supports `R`, `Ri`, `Q`, and `Qi`. Technically they are from a different standard but there is little reason to believe the new prefixes would deviate from the SI ones.

Also fixes #12760.