### PR TITLE
Add `HTTP::Headers#serialize`

### DIFF
--- a/spec/std/http/headers_spec.cr
+++ b/spec/std/http/headers_spec.cr
@@ -150,6 +150,11 @@ describe HTTP::Headers do
     headers.to_s.should eq(%(HTTP::Headers{"Foo_quux" => "bar", "Baz-Quux" => ["a", "b"]}))
   end
 
+  it "#serialize" do
+    headers = HTTP::Headers{"Foo_quux" => "bar", "Baz-Quux" => ["a", "b"]}
+    headers.serialize.should eq("Foo_quux: bar\r\nBaz-Quux: a\r\nBaz-Quux: b\r\n")
+  end
+
   it "merges and return self" do
     headers = HTTP::Headers.new
     headers.should be headers.merge!({"foo" => "bar"})

--- a/src/http/common.cr
+++ b/src/http/common.cr
@@ -286,11 +286,7 @@ module HTTP
   end
 
   def self.serialize_headers(io, headers)
-    headers.each do |name, values|
-      values.each do |value|
-        io << name << ": " << value << "\r\n"
-      end
-    end
+    headers.serialize(io)
     io << "\r\n"
   end
 

--- a/src/http/common.cr
+++ b/src/http/common.cr
@@ -261,30 +261,35 @@ module HTTP
     elsif body_io
       content_length = content_length(headers)
       if content_length
-        serialize_headers(io, headers)
+        headers.serialize(io)
+        io << "\r\n"
         copied = IO.copy(body_io, io)
         if copied != content_length
           raise ArgumentError.new("Content-Length header is #{content_length} but body had #{copied} bytes")
         end
       elsif Client::Response.supports_chunked?(version)
         headers["Transfer-Encoding"] = "chunked"
-        serialize_headers(io, headers)
+        headers.serialize(io)
+        io << "\r\n"
         serialize_chunked_body(io, body_io)
       else
         body = body_io.gets_to_end
         serialize_headers_and_string_body(io, headers, body)
       end
     else
-      serialize_headers(io, headers)
+      headers.serialize(io)
+      io << "\r\n"
     end
   end
 
   def self.serialize_headers_and_string_body(io, headers, body)
     headers["Content-Length"] = body.bytesize.to_s
-    serialize_headers(io, headers)
+    headers.serialize(io)
+    io << "\r\n"
     io << body
   end
 
+  @[Deprecated("Use `HTTP::Headers#serialize` instead.")]
   def self.serialize_headers(io, headers)
     headers.serialize(io)
     io << "\r\n"

--- a/src/http/headers.cr
+++ b/src/http/headers.cr
@@ -299,7 +299,7 @@ struct HTTP::Headers
     end
   end
 
-  # Serializes headers accroding to the HTTP protocol.
+  # Serializes headers according to the HTTP protocol.
   #
   # Prints a list of HTTP header fields in the format desribed in [RFC 7230 §3.2](https://www.rfc-editor.org/rfc/rfc7230#section-3.2),
   # with each field terminated by a CRLF sequence (`"\r\n"`).

--- a/src/http/headers.cr
+++ b/src/http/headers.cr
@@ -299,6 +299,32 @@ struct HTTP::Headers
     end
   end
 
+  # Serializes headers accroding to the HTTP protocol.
+  #
+  # Prints a list of HTTP header fields in the format desribed in [RFC 7230 §3.2](https://www.rfc-editor.org/rfc/rfc7230#section-3.2),
+  # with each field terminated by a CRLF sequence (`"\r\n"`).
+  #
+  # The serialization does *not* include a double CRLF sequence at the end.
+  #
+  # ```
+  # headers = HTTP::Headers{"foo" => "bar", "baz" => %w[qux qox]})
+  # headers.serialize # => "foo: bar\r\nbaz: qux\r\nbaz: qox\r\n"
+  # ```
+  def serialize : String
+    String.build do |io|
+      serialize(io)
+    end
+  end
+
+  # :ditto:
+  def serialize(io : IO) : Nil
+    each do |name, values|
+      values.each do |value|
+        io << name << ": " << value << "\r\n"
+      end
+    end
+  end
+
   def valid_value?(value) : Bool
     invalid_value_char(value).nil?
   end


### PR DESCRIPTION
This method serializes the headers in the format used in HTTP. The implementation already existed in `HTTP.serialize_headers`, this just moves it to `HTTP::Headers`. That's a more fitting place. It's easier to find and use.

As a consequence `HTTP.serialize_headers` gets deprecated.