### PR TITLE
Improve specs by removing absolute path references

### DIFF
--- a/spec/std/file_spec.cr
+++ b/spec/std/file_spec.cr
@@ -586,7 +586,7 @@ describe "File" do
 
     it "raises if file doesn't exist" do
       path = datapath("doesnotexist")
-      expect_raises(File::NotFoundError, "Error resolving real path: '#{path}'") do
+      expect_raises(File::NotFoundError, "Error resolving real path: '#{path.inspect_unquoted}'") do
         File.realpath(path)
       end
     end
@@ -1300,7 +1300,7 @@ describe "File" do
     it "raises if file cannot be accessed" do
       # This path is invalid because it represents a file path as a directory path
       path = File.join(datapath("test_file.txt"), "doesnotexist")
-      expect_raises(File::Error, path.to_s) do
+      expect_raises(File::Error, path.inspect_unquoted) do
         File.touch(path)
       end
     end

--- a/spec/std/file_spec.cr
+++ b/spec/std/file_spec.cr
@@ -1297,10 +1297,11 @@ describe "File" do
       end
     end
 
-    # TODO: there is no file which is reliably nonwriteable on windows
-    pending_win32 "raises if file cannot be accessed" do
-      expect_raises(File::Error, "Error setting time on file: '/bin/ls'") do
-        File.touch("/bin/ls")
+    it "raises if file cannot be accessed" do
+      # This path is invalid because it represents a file path as a directory path
+      path = File.join(datapath("test_file.txt"), "doesnotexist")
+      expect_raises(File::Error, path.to_s) do
+        File.touch(path)
       end
     end
   end

--- a/spec/std/file_spec.cr
+++ b/spec/std/file_spec.cr
@@ -1,24 +1,5 @@
 require "./spec_helper"
 
-private def base
-  Dir.current
-end
-
-private def tmpdir
-  "/tmp"
-end
-
-private def rootdir
-  "/"
-end
-
-private def home
-  home = ENV["HOME"]
-  return home if home == "/"
-
-  home.chomp('/')
-end
-
 private def it_raises_on_null_byte(operation, file = __FILE__, line = __LINE__, end_line = __END_LINE__, &block)
   it "errors on #{operation}", file, line, end_line do
     expect_raises(ArgumentError, "String contains null byte") do

--- a/spec/std/process_spec.cr
+++ b/spec/std/process_spec.cr
@@ -166,19 +166,21 @@ describe Process do
     $?.exit_code.should eq(0)
   end
 
-  pending_win32 "chroot raises when unprivileged" do
-    status, output, _ = compile_and_run_source <<-'CODE'
-      begin
-        Process.chroot("/usr")
-        puts "FAIL"
-      rescue ex
-        puts ex.inspect
-      end
-    CODE
+  {% if flag?(:unix) %}
+    it "chroot raises when unprivileged" do
+      status, output, _ = compile_and_run_source <<-'CODE'
+        begin
+          Process.chroot(".")
+          puts "FAIL"
+        rescue ex
+          puts ex.inspect
+        end
+      CODE
 
-    status.success?.should be_true
-    output.should eq("#<RuntimeError:Failed to chroot: Operation not permitted>\n")
-  end
+      status.success?.should be_true
+      output.should eq("#<RuntimeError:Failed to chroot: Operation not permitted>\n")
+    end
+  {% end %}
 
   it "sets working directory" do
     parent = File.dirname(Dir.current)


### PR DESCRIPTION
This patch makes stdlib specs more portable by removing absolute paths.

We can just use paths that are explicitly known (form the data directory) instead of relying on paths in the system.

Also includes cleanup of unused helpers.

See #12775 for some context.