### PR TITLE
Fix `HTTP::Client` certificate validation error on FQDN (host with trailing dot)

### DIFF
--- a/spec/manual/https_client_spec.cr
+++ b/spec/manual/https_client_spec.cr
@@ -7,6 +7,10 @@ describe "https requests" do
     HTTP::Client.get("https://google.com")
   end
 
+  it "can fetch from google.com. FQDN with trailing dot (#12777)" do
+    HTTP::Client.get("https://google.com.")
+  end
+
   it "can close request before consuming body" do
     HTTP::Client.get("https://crystal-lang.org") do
       break

--- a/spec/std/uri_spec.cr
+++ b/spec/std/uri_spec.cr
@@ -68,6 +68,10 @@ describe "URI" do
     assert_uri("http://[::1]:81/", scheme: "http", host: "[::1]", port: 81, path: "/")
     assert_uri("http://192.0.2.16:81/", scheme: "http", host: "192.0.2.16", port: 81, path: "/")
 
+    # preserves fully-qualified host with trailing dot
+    assert_uri("https://example.com./", scheme: "https", host: "example.com.", path: "/")
+    assert_uri("https://example.com.:8443/", scheme: "https", host: "example.com.", port: 8443, path: "/")
+
     # port
     it { URI.parse("http://192.168.0.2:/foo").should eq URI.new(scheme: "http", host: "192.168.0.2", path: "/foo") }
 

--- a/src/http/client.cr
+++ b/src/http/client.cr
@@ -801,7 +801,7 @@ class HTTP::Client
       if tls = @tls
         tcp_socket = io
         begin
-          io = OpenSSL::SSL::Socket::Client.new(tcp_socket, context: tls, sync_close: true, hostname: @host)
+          io = OpenSSL::SSL::Socket::Client.new(tcp_socket, context: tls, sync_close: true, hostname: @host.chomp('.'))
         rescue exc
           # don't leak the TCP socket when the SSL connection failed
           tcp_socket.close

--- a/src/http/client.cr
+++ b/src/http/client.cr
@@ -801,7 +801,7 @@ class HTTP::Client
       if tls = @tls
         tcp_socket = io
         begin
-          io = OpenSSL::SSL::Socket::Client.new(tcp_socket, context: tls, sync_close: true, hostname: @host.chomp('.'))
+          io = OpenSSL::SSL::Socket::Client.new(tcp_socket, context: tls, sync_close: true, hostname: @host.rchop('.'))
         rescue exc
           # don't leak the TCP socket when the SSL connection failed
           tcp_socket.close


### PR DESCRIPTION
Fixes https://github.com/crystal-lang/crystal/issues/12777

I have tested this change and it works for me.

The test I added to `spec/manual/https_client_spec.cr` fails without this change, and passes with it.