### PR TITLE
Disallow static array with N > 10000

### DIFF
--- a/spec/compiler/semantic/static_array_spec.cr
+++ b/spec/compiler/semantic/static_array_spec.cr
@@ -155,4 +155,13 @@ describe "Semantic: static array" do
       ),
       "expected argument #1 to 'fn' to be StaticArray(Int32, 11), not StaticArray(Int32, 10)"
   end
+
+  it "disallows large static array" do
+    assert_error(<<-CR, "can't instantiate StaticArray(T, N) with N = 10001 (N must be <= 10000)")
+      n = uninitialized StaticArray(Int32, 10001)
+      CR
+    assert_type(<<-CR) { static_array_of(int32, 10000)}
+      n = uninitialized StaticArray(Int32, 10000)
+      CR
+  end
 end

--- a/src/compiler/crystal/types.cr
+++ b/src/compiler/crystal/types.cr
@@ -2282,6 +2282,10 @@ module Crystal
         if value < 0
           raise TypeException.new "can't instantiate StaticArray(T, N) with N = #{value} (N must be positive)"
         end
+
+        if value > 10000
+          raise TypeException.new "can't instantiate StaticArray(T, N) with N = #{value} (N must be <= 10000)"
+        end
       end
 
       StaticArrayInstanceType.new program, generic_type, program.struct, type_vars


### PR DESCRIPTION
Code generation of large static arrays is very inefficient. There's no reason to use them instead of a regular array.

Resolves #4452