### PR TITLE
Re-organize and enhance specs for `Regex`

### DIFF
--- a/spec/std/regex_spec.cr
+++ b/spec/std/regex_spec.cr
@@ -1,106 +1,80 @@
 require "./spec_helper"
 
 describe "Regex" do
-  it "compare to other instances" do
-    Regex.new("foo").should eq(Regex.new("foo"))
-    Regex.new("foo").should_not eq(Regex.new("bar"))
+  describe ".new" do
+    it "doesn't crash when PCRE tries to free some memory (#771)" do
+      expect_raises(ArgumentError) { Regex.new("foo)") }
+    end
+
+    it "raises exception with invalid regex" do
+      expect_raises(ArgumentError) { Regex.new("+") }
+    end
   end
 
-  it "does =~" do
-    (/foo/ =~ "bar foo baz").should eq(4)
-    $~.group_size.should eq(0)
+  describe "#match" do
+    it "returns matchdata" do
+      md = "Crystal".match(/(?<bar>.)#{/(?<foo>.)/}/).not_nil!
+      md[0].should eq("Cr")
+      md["bar"].should eq("C")
+      md["foo"].should eq("r")
+    end
+
+    it "matches unicode char against [[:alnum:]] (#4704)" do
+      /[[:alnum:]]/x.match("à").should_not be_nil
+    end
   end
 
-  it "does inspect" do
-    /foo/.inspect.should eq("/foo/")
-    /foo/.inspect.should eq("/foo/")
-    /foo/imx.inspect.should eq("/foo/imx")
+  describe "#===" do
+    it "assigns captures" do
+      "foo" =~ /foo/
+      (/f(o+)(bar?)/ === "fooba").should be_true
+      $~.group_size.should eq(2)
+      $1.should eq("oo")
+      $2.should eq("ba")
+    end
   end
 
-  it "does to_s" do
-    /foo/.to_s.should eq("(?-imsx:foo)")
-    /foo/im.to_s.should eq("(?ims-x:foo)")
-    /foo/imx.to_s.should eq("(?imsx-:foo)")
+  describe "#=~" do
+    it "returns match index" do
+      (/foo/ =~ "bar foo baz").should eq(4)
+      $~.group_size.should eq(0)
+    end
 
-    "Crystal".match(/(?<bar>C)#{/(?<foo>R)/i}/).should be_truthy
-    "Crystal".match(/(?<bar>C)#{/(?<foo>R)/}/i).should be_falsey
+    it "matches ignore case" do
+      ("HeLlO" =~ /hello/).should be_nil
+      ("HeLlO" =~ /hello/i).should eq(0)
+    end
 
-    md = "Crystal".match(/(?<bar>.)#{/(?<foo>.)/}/).not_nil!
-    md[0].should eq("Cr")
-    md["bar"].should eq("C")
-    md["foo"].should eq("r")
-  end
+    it "matches lines beginnings on ^ in multiline mode" do
+      ("foo\nbar" =~ /^bar/).should be_nil
+      ("foo\nbar" =~ /^bar/m).should eq(4)
+    end
 
-  it "does inspect with slash" do
-    %r(/).inspect.should eq("/\\//")
-    %r(\/).inspect.should eq("/\\//")
-  end
+    it "matches multiline" do
+      ("foo\n<bar\n>baz" =~ /<bar.*?>/).should be_nil
+      ("foo\n<bar\n>baz" =~ /<bar.*?>/m).should eq(4)
+    end
 
-  it "does to_s with slash" do
-    %r(/).to_s.should eq("(?-imsx:\\/)")
-    %r(\/).to_s.should eq("(?-imsx:\\/)")
-  end
+    it "matches unicode char against [[:print:]] (#11262)" do
+      ("\n☃" =~ /[[:print:]]/).should eq(1)
+    end
 
-  it "doesn't crash when PCRE tries to free some memory (#771)" do
-    expect_raises(ArgumentError) { Regex.new("foo)") }
-  end
+    it "matches with =~ and captures" do
+      ("fooba" =~ /f(o+)(bar?)/).should eq(0)
+      $~.group_size.should eq(2)
+      $1.should eq("oo")
+      $2.should eq("ba")
+    end
 
-  it "checks if Char need to be escaped" do
-    Regex.needs_escape?('*').should be_true
-    Regex.needs_escape?('|').should be_true
-    Regex.needs_escape?('@').should be_false
-  end
+    it "matches with =~ and gets utf-8 codepoint index" do
+      index = "こんに" =~ /ん/
+      index.should eq(1)
+    end
 
-  it "checks if String need to be escaped" do
-    Regex.needs_escape?("10$").should be_true
-    Regex.needs_escape?("foo").should be_false
-  end
-
-  it "escapes" do
-    Regex.escape(" .\\+*?[^]$(){}=!<>|:-hello").should eq("\\ \\.\\\\\\+\\*\\?\\[\\^\\]\\$\\(\\)\\{\\}\\=\\!\\<\\>\\|\\:\\-hello")
-  end
-
-  it "matches ignore case" do
-    ("HeLlO" =~ /hello/).should be_nil
-    ("HeLlO" =~ /hello/i).should eq(0)
-  end
-
-  it "matches lines beginnings on ^ in multiline mode" do
-    ("foo\nbar" =~ /^bar/).should be_nil
-    ("foo\nbar" =~ /^bar/m).should eq(4)
-  end
-
-  it "matches multiline" do
-    ("foo\n<bar\n>baz" =~ /<bar.*?>/).should be_nil
-    ("foo\n<bar\n>baz" =~ /<bar.*?>/m).should eq(4)
-  end
-
-  it "matches unicode char against [[:print:]] (#11262)" do
-    ("\n☃" =~ /[[:print:]]/).should eq(1)
-  end
-
-  it "matches unicode char against [[:alnum:]] (#4704)" do
-    /[[:alnum:]]/x.match("à").should_not be_nil
-  end
-
-  it "matches with =~ and captures" do
-    ("fooba" =~ /f(o+)(bar?)/).should eq(0)
-    $~.group_size.should eq(2)
-    $1.should eq("oo")
-    $2.should eq("ba")
-  end
-
-  it "matches with =~ and gets utf-8 codepoint index" do
-    index = "こんに" =~ /ん/
-    index.should eq(1)
-  end
-
-  it "matches with === and captures" do
-    "foo" =~ /foo/
-    (/f(o+)(bar?)/ === "fooba").should be_true
-    $~.group_size.should eq(2)
-    $1.should eq("oo")
-    $2.should eq("ba")
+    it "raises if outside match range with []" do
+      "foo" =~ /foo/
+      expect_raises(IndexError) { $1 }
+    end
   end
 
   describe "#matches?" do
@@ -122,7 +96,7 @@ describe "Regex" do
     end
   end
 
-  describe "name_table" do
+  describe "#name_table" do
     it "is a map of capture group number to name" do
       table = (/(?<date> (?<year>(\d\d)?\d\d) - (?<month>\d\d) - (?<day>\d\d) )/x).name_table
       table[1].should eq("date")
@@ -133,22 +107,85 @@ describe "Regex" do
     end
   end
 
-  describe "capture_count" do
-    it "returns the number of (named & non-named) capture groups" do
-      /(?:.)/x.capture_count.should eq(0)
-      /(?<foo>.+)/.capture_count.should eq(1)
-      /(.)?/x.capture_count.should eq(1)
-      /(.)|(.)/x.capture_count.should eq(2)
+  it "#capture_count" do
+    /(?:.)/x.capture_count.should eq(0)
+    /(?<foo>.+)/.capture_count.should eq(1)
+    /(.)?/x.capture_count.should eq(1)
+    /(.)|(.)/x.capture_count.should eq(2)
+  end
+
+  describe "#inspect" do
+    it "with options" do
+      /foo/.inspect.should eq("/foo/")
+      /foo/.inspect.should eq("/foo/")
+      /foo/imx.inspect.should eq("/foo/imx")
+    end
+
+    it "with slash" do
+      %r(/).inspect.should eq("/\\//")
+      %r(\/).inspect.should eq("/\\//")
     end
   end
 
-  it "raises exception with invalid regex" do
-    expect_raises(ArgumentError) { Regex.new("+") }
+  describe "#to_s" do
+    it "with options" do
+      /foo/.to_s.should eq("(?-imsx:foo)")
+      /foo/im.to_s.should eq("(?ims-x:foo)")
+      /foo/imx.to_s.should eq("(?imsx-:foo)")
+    end
+
+    it "escapes" do
+      "Crystal".match(/(?<bar>C)#{/(?<foo>R)/i}/).should be_truthy
+      "Crystal".match(/(?<bar>C)#{/(?<foo>R)/}/i).should be_falsey
+    end
+
+    it "with slash" do
+      %r(/).to_s.should eq("(?-imsx:\\/)")
+      %r(\/).to_s.should eq("(?-imsx:\\/)")
+    end
   end
 
-  it "raises if outside match range with []" do
-    "foo" =~ /foo/
-    expect_raises(IndexError) { $1 }
+  it "#==" do
+    regex = Regex.new("foo", Regex::Options::IGNORE_CASE)
+    (regex == Regex.new("foo", Regex::Options::IGNORE_CASE)).should be_true
+    (regex == Regex.new("foo")).should be_false
+    (regex == Regex.new("bar", Regex::Options::IGNORE_CASE)).should be_false
+    (regex == Regex.new("bar")).should be_false
+  end
+
+  it "#hash" do
+    hash = Regex.new("foo", Regex::Options::IGNORE_CASE).hash
+    hash.should eq(Regex.new("foo", Regex::Options::IGNORE_CASE).hash)
+    hash.should_not eq(Regex.new("foo").hash)
+    hash.should_not eq(Regex.new("bar", Regex::Options::IGNORE_CASE).hash)
+    hash.should_not eq(Regex.new("bar").hash)
+  end
+
+  it "#dup" do
+    regex = /foo/
+    regex.dup.should be(regex)
+  end
+
+  it "#clone" do
+    regex = /foo/
+    regex.clone.should be(regex)
+  end
+
+  describe ".needs_escape?" do
+    it "Char" do
+      Regex.needs_escape?('*').should be_true
+      Regex.needs_escape?('|').should be_true
+      Regex.needs_escape?('@').should be_false
+    end
+
+    it "String" do
+      Regex.needs_escape?("10$").should be_true
+      Regex.needs_escape?("foo").should be_false
+    end
+  end
+
+  it ".escape" do
+    Regex.escape(" .\\+*?[^]$(){}=!<>|:-hello").should eq("\\ \\.\\\\\\+\\*\\?\\[\\^\\]\\$\\(\\)\\{\\}\\=\\!\\<\\>\\|\\:\\-hello")
   end
 
   describe ".union" do
@@ -187,31 +224,5 @@ describe "Regex" do
     it "combines Regex objects in the same way as Regex#+" do
       Regex.union(/skiing/i, /sledding/).should eq(/skiing/i + /sledding/)
     end
-  end
-
-  it "dups" do
-    regex = /foo/
-    regex.dup.should be(regex)
-  end
-
-  it "clones" do
-    regex = /foo/
-    regex.clone.should be(regex)
-  end
-
-  it "checks equality by ==" do
-    regex = Regex.new("foo", Regex::Options::IGNORE_CASE)
-    (regex == Regex.new("foo", Regex::Options::IGNORE_CASE)).should be_true
-    (regex == Regex.new("foo")).should be_false
-    (regex == Regex.new("bar", Regex::Options::IGNORE_CASE)).should be_false
-    (regex == Regex.new("bar")).should be_false
-  end
-
-  it "hashes" do
-    hash = Regex.new("foo", Regex::Options::IGNORE_CASE).hash
-    hash.should eq(Regex.new("foo", Regex::Options::IGNORE_CASE).hash)
-    hash.should_not eq(Regex.new("foo").hash)
-    hash.should_not eq(Regex.new("bar", Regex::Options::IGNORE_CASE).hash)
-    hash.should_not eq(Regex.new("bar").hash)
   end
 end

--- a/spec/std/regex_spec.cr
+++ b/spec/std/regex_spec.cr
@@ -275,12 +275,20 @@ describe "Regex" do
 
   describe "#name_table" do
     it "is a map of capture group number to name" do
-      table = (/(?<date> (?<year>(\d\d)?\d\d) - (?<month>\d\d) - (?<day>\d\d) )/x).name_table
-      table[1].should eq("date")
-      table[2].should eq("year")
-      table[3]?.should be_nil
-      table[4].should eq("month")
-      table[5].should eq("day")
+      (/(?<date> (?<year>(\d\d)?\d\d) - (?<month>\d\d) - (?<day>\d\d) )/x).name_table.should eq({
+        1 => "date",
+        2 => "year",
+        4 => "month",
+        5 => "day",
+      })
+    end
+
+    it "alpanumeric" do
+      /(?<f1>)/.name_table.should eq({1 => "f1"})
+    end
+
+    it "duplicate name" do
+      /(?<foo>)(?<foo>)/.name_table.should eq({1 => "foo", 2 => "foo"})
     end
   end
 

--- a/spec/std/regex_spec.cr
+++ b/spec/std/regex_spec.cr
@@ -80,6 +80,9 @@ describe "Regex" do
     end
   end
 
+  describe "#match_at_byte_index" do
+  end
+
   describe "#matches?" do
     it "matches but create no MatchData" do
       /f(o+)(bar?)/.matches?("fooba").should be_true

--- a/spec/std/regex_spec.cr
+++ b/spec/std/regex_spec.cr
@@ -35,84 +35,166 @@ describe "Regex" do
 
   describe "#match" do
     it "returns matchdata" do
-      md = "Crystal".match(/(?<bar>.)#{/(?<foo>.)/}/).not_nil!
-      md[0].should eq("Cr")
-      md["bar"].should eq("C")
-      md["foo"].should eq("r")
-    end
-
-    it "matches unicode char against [[:alnum:]] (#4704)" do
-      /[[:alnum:]]/x.match("à").should_not be_nil
-    end
-  end
-
-  describe "#===" do
-    it "basic" do
-      (/f(o+)(bar?)/ === "fooba").should be_true
-      (/f(o+)(bar?)/ === "pooba").should be_false
+      md = /(?<bar>.)(?<foo>.)/.match("Crystal").should_not be_nil
+      md[0].should eq "Cr"
+      md.captures.should eq [] of String
+      md.named_captures.should eq({"bar" => "C", "foo" => "r"})
     end
 
     it "assigns captures" do
-      (/f(o+)(bar?)/ === "fooba").should be_true
-      $~.group_size.should eq(2)
-      $1.should eq("oo")
-      $2.should eq("ba")
-    end
-  end
+      matchdata = /foo/.match("foo")
+      $~.should eq(matchdata)
 
-  describe "#=~" do
-    it "returns match index" do
-      (/foo/ =~ "bar foo baz").should eq(4)
-      $~.group_size.should eq(0)
+      /foo/.match("bar")
+      expect_raises(NilAssertionError) { $~ }
     end
 
-    it "ignore case" do
-      ("HeLlO" =~ /hello/).should be_nil
-      ("HeLlO" =~ /hello/i).should eq(0)
+    it "returns nil on non-match" do
+      /Crystal/.match("foo").should be_nil
     end
 
-    it "multiline anchor" do
-      ("foo\nbar" =~ /^bar/).should be_nil
-      ("foo\nbar" =~ /^bar/m).should eq(4)
+    describe "with pos" do
+      it "positive" do
+        /foo/.match("foo", 0).should_not be_nil
+        /foo/.match("foo", 1).should be_nil
+        /foo/.match(".foo", 1).should_not be_nil
+        /foo/.match("..foo", 1).should_not be_nil
+
+        /foo/.match("bar", 0).should be_nil
+        /foo/.match("bar", 1).should be_nil
+      end
+
+      it "char index" do
+        /foo/.match("öfoo", 1).should_not be_nil
+      end
+
+      pending "negative" do
+        /foo/.match("..foo", -3).should_not be_nil
+        /foo/.match("..foo", -2).should be_nil
+      end
     end
 
-    it "multiline span" do
-      ("foo\n<bar\n>baz" =~ /<bar.*?>/).should be_nil
-      ("foo\n<bar\n>baz" =~ /<bar.*?>/m).should eq(4)
-    end
-
-    it "matches unicode char against [[:print:]] (#11262)" do
-      ("\n☃" =~ /[[:print:]]/).should eq(1)
-    end
-
-    it "assigns captures" do
-      ("fooba" =~ /f(o+)(bar?)/).should eq(0)
-      $~.group_size.should eq(2)
-      $1.should eq("oo")
-      $2.should eq("ba")
-    end
-
-    it "utf-8 support" do
-      ("こんに" =~ /ん/).should eq(1)
-    end
-
-    it "raises if outside match range with []" do
-      "foo" =~ /foo/
-      expect_raises(IndexError) { $1 }
+    it "with options" do
+      /foo/.match(".foo", options: Regex::Options::ANCHORED).should be_nil
     end
   end
 
   describe "#match_at_byte_index" do
+    it "assigns captures" do
+      matchdata = /foo/.match_at_byte_index("..foo", 1)
+      $~.should eq(matchdata)
+
+      /foo/.match_at_byte_index("foo", 1)
+      expect_raises(NilAssertionError) { $~ }
+
+      /foo/.match("foo") # make sure $~ is assigned
+      $~.should_not be_nil
+
+      /foo/.match_at_byte_index("foo", 5)
+      expect_raises(NilAssertionError) { $~ }
+    end
+
+    it "positive index" do
+      md = /foo/.match_at_byte_index("foo", 0).should_not be_nil
+      md.begin.should eq 0
+      /foo/.match_at_byte_index("foo", 1).should be_nil
+      md = /foo/.match_at_byte_index(".foo", 1).should_not be_nil
+      md.begin.should eq 1
+      md = /foo/.match_at_byte_index("..foo", 1).should_not be_nil
+      md.begin.should eq 2
+      /foo/.match_at_byte_index("foo", 5).should be_nil
+
+      /foo/.match_at_byte_index("bar", 0).should be_nil
+      /foo/.match_at_byte_index("bar", 1).should be_nil
+    end
+
+    it "multibyte index" do
+      md = /foo/.match_at_byte_index("öfoo", 1).should_not be_nil
+      md.begin.should eq 1
+      md.byte_begin.should eq 2
+
+      md = /foo/.match_at_byte_index("öfoo", 2).should_not be_nil
+      md.begin.should eq 1
+      md.byte_begin.should eq 2
+    end
+
+    pending "negative" do
+      md = /foo/.match_at_byte_index("..foo", -3).should_not be_nil
+      md.begin.should eq 0
+      /foo/.match_at_byte_index("..foo", -2).should be_nil
+    end
+
+    it "with options" do
+      /foo/.match_at_byte_index("..foo", 1, options: Regex::Options::ANCHORED).should be_nil
+    end
   end
 
   describe "#matches?" do
-    it "matches but create no MatchData" do
-      /f(o+)(bar?)/.matches?("fooba").should be_true
-      /f(o+)(bar?)/.matches?("barfo").should be_false
+    it "basic" do
+      /foo/.matches?("foo").should be_true
+      expect_raises(NilAssertionError) { $~ }
+      /foo/.matches?("bar").should be_false
+      expect_raises(NilAssertionError) { $~ }
     end
 
-    it "can specify initial position of matching" do
-      /f(o+)(bar?)/.matches?("fooba", 1).should be_false
+    describe "options" do
+      it "ignore case" do
+        /hello/.matches?("HeLlO").should be_false
+        /hello/i.matches?("HeLlO").should be_true
+      end
+
+      describe "multiline" do
+        it "anchor" do
+          /^bar/.matches?("foo\nbar").should be_false
+          /^bar/m.matches?("foo\nbar").should be_true
+        end
+
+        it "span" do
+          /<bar.*?>/.matches?("foo\n<bar\n>baz").should be_false
+          /<bar.*?>/m.matches?("foo\n<bar\n>baz").should be_true
+        end
+      end
+
+      describe "extended" do
+        it "ignores white space" do
+          /foo   bar/.matches?("foobar").should be_false
+          /foo   bar/x.matches?("foobar").should be_true
+        end
+
+        it "ignores comments" do
+          /foo#comment\nbar/.matches?("foobar").should be_false
+          /foo#comment\nbar/x.matches?("foobar").should be_true
+        end
+      end
+
+      it "anchored" do
+        Regex.new("foo", Regex::Options::ANCHORED).matches?("foo").should be_true
+        Regex.new("foo", Regex::Options::ANCHORED).matches?(".foo").should be_false
+      end
+    end
+
+    describe "unicode" do
+      it "unicode support" do
+        /ん/.matches?("こんに").should be_true
+      end
+
+      it "matches unicode char against [[:alnum:]] (#4704)" do
+        /[[:alnum:]]/.matches?("à").should be_true
+      end
+
+      it "matches unicode char against [[:print:]] (#11262)" do
+        /[[:print:]]/.matches?("\n☃").should be_true
+      end
+
+      it "invalid codepoint" do
+        /foo/.matches?("f\x96o").should be_false
+        /f\x96o/.matches?("f\x96o").should be_false
+        /f.o/.matches?("f\x96o").should be_true
+      end
+    end
+
+    it "with options" do
+      /foo/.matches?(".foo", options: Regex::Options::ANCHORED).should be_false
     end
 
     it "matches a large single line string" do
@@ -125,6 +207,70 @@ describe "Regex" do
   end
 
   describe "#matches_at_byte_index?" do
+    it "positive index" do
+      /foo/.matches_at_byte_index?("foo", 0).should be_true
+      /foo/.matches_at_byte_index?("foo", 1).should be_false
+      /foo/.matches_at_byte_index?(".foo", 1).should be_true
+      /foo/.matches_at_byte_index?("..foo", 1).should be_true
+      /foo/.matches_at_byte_index?("foo", 5).should be_false
+
+      /foo/.matches_at_byte_index?("bar", 0).should be_false
+      /foo/.matches_at_byte_index?("bar", 1).should be_false
+    end
+
+    it "multibyte index" do
+      /foo/.matches_at_byte_index?("öfoo", 1).should be_true
+    end
+
+    pending "negative" do
+      /foo/.matches_at_byte_index?("..foo", -3).should be_true
+      /foo/.matches_at_byte_index?("..foo", -2).should be_false
+    end
+
+    it "with options" do
+      /foo/.matches_at_byte_index?("..foo", 1, options: Regex::Options::ANCHORED).should be_false
+    end
+  end
+
+  describe "#===" do
+    it "basic" do
+      (/f(o+)(bar?)/ === "fooba").should be_true
+      (/f(o+)(bar?)/ === "pooba").should be_false
+    end
+
+    it "assigns captures" do
+      /f(o+)(bar?)/ === "fooba"
+      $~.group_size.should eq(2)
+      $1.should eq("oo")
+      $2.should eq("ba")
+
+      /f(o+)(bar?)/ === "pooba"
+      expect_raises(NilAssertionError) { $~ }
+    end
+  end
+
+  describe "#=~" do
+    it "returns match index or nil" do
+      (/foo/ =~ "bar foo baz").should eq(4)
+      (/foo/ =~ "bar boo baz").should be_nil
+    end
+
+    it "assigns captures" do
+      "fooba" =~ /f(o+)(bar?)/
+      $~.group_size.should eq(2)
+      $1.should eq("oo")
+      $2.should eq("ba")
+
+      /foo/ =~ "bar boo baz"
+      expect_raises(NilAssertionError) { $~ }
+    end
+
+    it "accepts any type" do
+      (/foo/ =~ nil).should be_nil
+      (/foo/ =~ 1).should be_nil
+      (/foo/ =~ [1, 2]).should be_nil
+      (/foo/ =~ true).should be_nil
+    end
   end
 
   describe "#name_table" do

--- a/spec/std/regex_spec.cr
+++ b/spec/std/regex_spec.cr
@@ -102,6 +102,9 @@ describe "Regex" do
     end
   end
 
+  describe "#matches_at_byte_index?" do
+  end
+
   describe "#name_table" do
     it "is a map of capture group number to name" do
       table = (/(?<date> (?<year>(\d\d)?\d\d) - (?<month>\d\d) - (?<day>\d\d) )/x).name_table

--- a/spec/std/regex_spec.cr
+++ b/spec/std/regex_spec.cr
@@ -225,4 +225,8 @@ describe "Regex" do
       Regex.union(/skiing/i, /sledding/).should eq(/skiing/i + /sledding/)
     end
   end
+
+  it "#+" do
+    (/dogs/ + /cats/i).should eq /(?-imsx:dogs)|(?i-msx:cats)/
+  end
 end

--- a/spec/std/regex_spec.cr
+++ b/spec/std/regex_spec.cr
@@ -25,8 +25,12 @@ describe "Regex" do
   end
 
   describe "#===" do
+    it "basic" do
+      (/f(o+)(bar?)/ === "fooba").should be_true
+      (/f(o+)(bar?)/ === "pooba").should be_false
+    end
+
     it "assigns captures" do
-      "foo" =~ /foo/
       (/f(o+)(bar?)/ === "fooba").should be_true
       $~.group_size.should eq(2)
       $1.should eq("oo")
@@ -40,17 +44,17 @@ describe "Regex" do
       $~.group_size.should eq(0)
     end
 
-    it "matches ignore case" do
+    it "ignore case" do
       ("HeLlO" =~ /hello/).should be_nil
       ("HeLlO" =~ /hello/i).should eq(0)
     end
 
-    it "matches lines beginnings on ^ in multiline mode" do
+    it "multiline anchor" do
       ("foo\nbar" =~ /^bar/).should be_nil
       ("foo\nbar" =~ /^bar/m).should eq(4)
     end
 
-    it "matches multiline" do
+    it "multiline span" do
       ("foo\n<bar\n>baz" =~ /<bar.*?>/).should be_nil
       ("foo\n<bar\n>baz" =~ /<bar.*?>/m).should eq(4)
     end
@@ -59,16 +63,15 @@ describe "Regex" do
       ("\n☃" =~ /[[:print:]]/).should eq(1)
     end
 
-    it "matches with =~ and captures" do
+    it "assigns captures" do
       ("fooba" =~ /f(o+)(bar?)/).should eq(0)
       $~.group_size.should eq(2)
       $1.should eq("oo")
       $2.should eq("ba")
     end
 
-    it "matches with =~ and gets utf-8 codepoint index" do
-      index = "こんに" =~ /ん/
-      index.should eq(1)
+    it "utf-8 support" do
+      ("こんに" =~ /ん/).should eq(1)
     end
 
     it "raises if outside match range with []" do

--- a/spec/std/regex_spec.cr
+++ b/spec/std/regex_spec.cr
@@ -26,6 +26,13 @@ describe "Regex" do
     /cat/xi.options.multiline?.should be_false
   end
 
+  it "#source" do
+    /foo/.source.should eq "foo"
+    /(foo|bar)*/.source.should eq "(foo|bar)*"
+    /foo\x96/.source.should eq "foo\\x96"
+    Regex.new("").source.should eq ""
+  end
+
   describe "#match" do
     it "returns matchdata" do
       md = "Crystal".match(/(?<bar>.)#{/(?<foo>.)/}/).not_nil!

--- a/spec/std/regex_spec.cr
+++ b/spec/std/regex_spec.cr
@@ -229,4 +229,9 @@ describe "Regex" do
   it "#+" do
     (/dogs/ + /cats/i).should eq /(?-imsx:dogs)|(?i-msx:cats)/
   end
+
+  it ".error?" do
+    Regex.error?("(foo|bar)").should be_nil
+    Regex.error?("(foo|bar").should eq "missing ) at 8"
+  end
 end

--- a/spec/std/regex_spec.cr
+++ b/spec/std/regex_spec.cr
@@ -11,6 +11,21 @@ describe "Regex" do
     end
   end
 
+  it "#options" do
+    /cat/.options.ignore_case?.should be_false
+    /cat/i.options.ignore_case?.should be_true
+    /cat/.options.multiline?.should be_false
+    /cat/m.options.multiline?.should be_true
+    /cat/.options.extended?.should be_false
+    /cat/x.options.extended?.should be_true
+    /cat/mx.options.multiline?.should be_true
+    /cat/mx.options.extended?.should be_true
+    /cat/mx.options.ignore_case?.should be_false
+    /cat/xi.options.ignore_case?.should be_true
+    /cat/xi.options.extended?.should be_true
+    /cat/xi.options.multiline?.should be_false
+  end
+
   describe "#match" do
     it "returns matchdata" do
       md = "Crystal".match(/(?<bar>.)#{/(?<foo>.)/}/).not_nil!

--- a/spec/std/regex_spec.cr
+++ b/spec/std/regex_spec.cr
@@ -302,11 +302,11 @@ describe "Regex" do
   describe "#inspect" do
     it "with options" do
       /foo/.inspect.should eq("/foo/")
-      /foo/.inspect.should eq("/foo/")
+      /foo/im.inspect.should eq("/foo/im")
       /foo/imx.inspect.should eq("/foo/imx")
     end
 
-    it "with slash" do
+    it "escapes" do
       %r(/).inspect.should eq("/\\//")
       %r(\/).inspect.should eq("/\\//")
     end
@@ -319,14 +319,15 @@ describe "Regex" do
       /foo/imx.to_s.should eq("(?imsx-:foo)")
     end
 
-    it "escapes" do
-      "Crystal".match(/(?<bar>C)#{/(?<foo>R)/i}/).should be_truthy
-      "Crystal".match(/(?<bar>C)#{/(?<foo>R)/}/i).should be_falsey
-    end
-
     it "with slash" do
       %r(/).to_s.should eq("(?-imsx:\\/)")
       %r(\/).to_s.should eq("(?-imsx:\\/)")
+    end
+
+    it "interpolation" do
+      regex = /(?<foo>R)/i
+      /(?<bar>C)#{regex}/.should eq /(?<bar>C)(?i-msx:(?<foo>R))/
+      /(?<bar>C)#{regex}/i.should eq /(?<bar>C)(?i-msx:(?<foo>R))/i
     end
   end
 


### PR DESCRIPTION
This patch is a big overhaul of `Regex` specs, improving both the structure of the tests as well as adding some specs for previously untested behaviour.

The changes affect nearly all lines, but following the individual commits should make it easy to understand each set of changes. The first commit (https://github.com/crystal-lang/crystal/commit/cba37beb1b107a813b616aa0498dd5b4d59c5f9c) moves stuff around, but does not change any spec code by itself.

See #12789 for similar changes for `Regex::MatchData` specs.