### PR TITLE
Fix constants starting with non-ascii uppercase letter

### DIFF
--- a/spec/compiler/interpreter/constants_spec.cr
+++ b/spec/compiler/interpreter/constants_spec.cr
@@ -58,6 +58,24 @@ describe Crystal::Repl::Interpreter do
         Foo::X
       CODE
     end
+
+    it "does not allow value assignment to already initialized constant" do
+      expect_raises(Crystal::TypeException, "already initialized constant A") do
+        interpret(<<-CODE)
+          A = 1
+          A = 2
+        CODE
+      end
+    end
+
+    it "recognizes constant which starts with unicode uppercase letter" do
+      expect_raises(Crystal::TypeException, "already initialized constant Á") do
+        interpret(<<-CODE)
+          Á = 1
+          Á = 2
+        CODE
+      end
+    end
   end
 
   context "magic constants" do

--- a/spec/compiler/parser/parser_spec.cr
+++ b/spec/compiler/parser/parser_spec.cr
@@ -1787,6 +1787,14 @@ module Crystal
       end
     ), ClassDef.new("Foo".path, Def.new("bar", body: Call.new(nil, "print", Cast.new(Var.new("self"), "Foo".path))))
 
+    it_parses %(
+      class ÁrvíztűrőTükörfúrógép
+        def árvíztűrő_tükörfúrógép
+          print as ÁrvíztűrőTükörfúrógép
+        end
+      end
+    ), ClassDef.new("ÁrvíztűrőTükörfúrógép".path, Def.new("árvíztűrő_tükörfúrógép", body: Call.new(nil, "print", Cast.new(Var.new("self"), "ÁrvíztűrőTükörfúrógép".path))))
+
     assert_syntax_error "a = a", "can't use variable name 'a' inside assignment to variable 'a'"
 
     assert_syntax_error "{{ {{ 1 }} }}", "can't nest macro expressions"

--- a/src/compiler/crystal/syntax/lexer.cr
+++ b/src/compiler/crystal/syntax/lexer.cr
@@ -1042,7 +1042,7 @@ module Crystal
 
         scan_ident(start)
       else
-        if current_char.ascii_uppercase?
+        if current_char.uppercase?
           start = current_pos
           while ident_part?(next_char)
             # Nothing to do


### PR DESCRIPTION
treat names starting with any uppercase letter as constant
not only ascii uppercase letters (A-Z)
for example Á (Latin Capital Letter A with Acute)

Fixes #12791