### PR TITLE
PR template: adding a line about force-pushes

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/pull_request_template.md
+++ b/.github/PULL_REQUEST_TEMPLATE/pull_request_template.md
@@ -6,4 +6,4 @@ We thank you for helping improve Crystal. In order to ease the reviewing process
 
 3. If your change is big, consider breaking it into several smaller PRs. In general, the smaller the change, the quicker we can review it.
 
-4. ⚠️ Never force-push the branch your commit lives in. This breaks existing reviews and comments, making the work harder for review. Just merge.
+4. ⚠️ Please do not amend previous commits and force push to the PR branch. This makes reviews much harder because reference to previous state is hidden.


### PR DESCRIPTION
Making explicit in the PR template that force-pushed aren't welcomed.