### PR TITLE
Fix `XML::Node#errors` to return `nil` when empty

### DIFF
--- a/spec/std/xml/xml_spec.cr
+++ b/spec/std/xml/xml_spec.cr
@@ -162,6 +162,9 @@ describe XML do
     xml = XML.parse(%(<people></foo>))
     xml.root.not_nil!.name.should eq("people")
     xml.errors.try(&.map(&.to_s)).should eq ["Opening and ending tag mismatch: people line 1 and foo"]
+
+    xml = XML.parse(%(<foo></foo>))
+    xml.errors.should be_nil
   end
 
   describe "#namespace" do

--- a/src/xml/node.cr
+++ b/src/xml/node.cr
@@ -7,7 +7,7 @@ class XML::Node
   end
 
   # :ditto:
-  def initialize(node : LibXML::Doc*, @errors = nil)
+  def initialize(node : LibXML::Doc*, @errors :  Array(XML::Error)? = nil)
     initialize(node.as(LibXML::Node*))
   end
 
@@ -578,7 +578,9 @@ class XML::Node
 
   # Returns the list of `XML::Error` found when parsing this document.
   # Returns `nil` if no errors were found.
-  getter errors : Array(XML::Error)?
+  def errors : Array(XML::Error)?
+    return @errors unless @errors.try &.empty?
+  end
 
   private def check_no_null_byte(string)
     if string.includes? Char::ZERO

--- a/src/xml/node.cr
+++ b/src/xml/node.cr
@@ -7,7 +7,7 @@ class XML::Node
   end
 
   # :ditto:
-  def initialize(node : LibXML::Doc*, @errors :  Array(XML::Error)? = nil)
+  def initialize(node : LibXML::Doc*, @errors : Array(XML::Error)? = nil)
     initialize(node.as(LibXML::Node*))
   end
 


### PR DESCRIPTION
This restores the original semantics prior to the refactoring of #12663

Ref: https://github.com/crystal-lang/crystal/pull/12663#issuecomment-1328558345