### PR TITLE
Add custom `message` parameter to `#not_nil!`

### DIFF
--- a/spec/std/object_spec.cr
+++ b/spec/std/object_spec.cr
@@ -513,4 +513,35 @@ describe Object do
       (x == y).should be_false
     end
   end
+
+  describe "#not_nil!" do
+    it "basic" do
+      1.not_nil!
+      expect_raises(NilAssertionError, "Nil assertion failed") do
+        nil.not_nil!
+      end
+    end
+
+    it "removes Nil type" do
+      x = TestObject.new.as(TestObject?)
+      typeof(x.not_nil!).should eq TestObject
+      x.not_nil!.should be x
+    end
+
+    it "raises NilAssertionError" do
+      x = nil.as(TestObject?)
+      typeof(x.not_nil!).should eq TestObject
+      expect_raises(NilAssertionError, "Nil assertion failed") do
+        x.not_nil!
+      end
+    end
+
+    it "with message" do
+      x = TestObject.new
+      x.not_nil!("custom message").should be x
+      expect_raises(NilAssertionError, "custom message") do
+        nil.not_nil!("custom message")
+      end
+    end
+  end
 end

--- a/src/nil.cr
+++ b/src/nil.cr
@@ -103,9 +103,15 @@ struct Nil
 
   # Raises `NilAssertionError`.
   #
+  # If *message* is given, it is forwarded as error message of `NilAssertionError`.
+  #
   # See also: `Object#not_nil!`.
-  def not_nil! : NoReturn
-    raise NilAssertionError.new
+  def not_nil!(message = nil) : NoReturn
+    if message
+      raise NilAssertionError.new(message)
+    else
+      raise NilAssertionError.new
+    end
   end
 
   # Returns `self`.

--- a/src/object.cr
+++ b/src/object.cr
@@ -228,7 +228,7 @@ class Object
   # for example using [`if var`](https://crystal-lang.org/reference/syntax_and_semantics/if_var.html).
   # `not_nil!` is only meant as a last resort when there's no other way to explain this to the compiler.
   # Either way, consider instead raising a concrete exception with a descriptive message.
-  def not_nil!
+  def not_nil!(message = nil)
     self
   end
 


### PR DESCRIPTION
This patch adds a parameter to `#not_nil!` that allows customizing the error message when raising `NilAssertionError`.

One use case for customized messages is in the `getter!` and `property!` macros (the implementation is simplified with the customization parameter, but not included in this PR).
Another use case is detailed in https://github.com/crystal-lang/crystal/issues/4776#issuecomment-1262078348