### PR TITLE
Error on returning a large value type from a def

### DIFF
--- a/src/compiler/crystal/semantic/bindings.cr
+++ b/src/compiler/crystal/semantic/bindings.cr
@@ -295,6 +295,13 @@ module Crystal
         type
       end
     end
+
+    def set_type(type : Type)
+      super
+
+      raise "returns a large value type: #{type}" if type.large_value_type?
+      type
+    end
   end
 
   class PointerOf

--- a/src/compiler/crystal/types.cr
+++ b/src/compiler/crystal/types.cr
@@ -737,6 +737,10 @@ module Crystal
       end
     end
 
+    def large_value_type? : Bool
+      struct? && program.size_of(sizeof_type) > 10_000
+    end
+
     def get_instance_var_initializer(name)
       nil
     end
@@ -3068,6 +3072,14 @@ module Crystal
     def union_types
       union_types = program.type_merge_union_of(concrete_types)
       union_types || base_type
+    end
+
+    def large_value_type? : Bool
+      each_concrete_type do |subtype|
+        return true if subtype.large_value_type?
+      end
+
+      false
     end
   end
 


### PR DESCRIPTION
This patch adds compiler errors when passing large value types.

It's a work in progress, currently only implemented for method return types.

Resolves #4452