### PR TITLE
Extract internal Regex API for PCRE backend

### DIFF
--- a/src/regex.cr
+++ b/src/regex.cr
@@ -1,4 +1,5 @@
-require "./regex/*"
+require "./regex/engine"
+require "./regex/match_data"
 
 # A `Regex` represents a regular expression, a pattern that describes the
 # contents of strings. A `Regex` can determine whether or not a string matches
@@ -195,6 +196,8 @@ require "./regex/*"
 # `Hash` of `String` => `Int32`, and therefore requires named capture groups to have
 # unique names within a single `Regex`.
 class Regex
+  include Regex::Engine
+
   # List of metacharacters that need to be escaped.
   #
   # See `Regex.needs_escape?` and `Regex.escape`.
@@ -253,28 +256,8 @@ class Regex
   # options = Regex::Options::IGNORE_CASE | Regex::Options::EXTENDED
   # Regex.new("dog", options) # => /dog/ix
   # ```
-  def initialize(source : String, @options : Options = Options::None)
-    # PCRE's pattern must have their null characters escaped
-    source = source.gsub('\u{0}', "\\0")
-    @source = source
-
-    @re = LibPCRE.compile(@source, (options | Options::UTF_8 | Options::NO_UTF8_CHECK | Options::DUPNAMES | Options::UCP), out errptr, out erroffset, nil)
-    raise ArgumentError.new("#{String.new(errptr)} at #{erroffset}") if @re.null?
-    @extra = LibPCRE.study(@re, LibPCRE::STUDY_JIT_COMPILE, out studyerrptr)
-    if @extra.null? && studyerrptr
-      {% unless flag?(:interpreted) %}
-        LibPCRE.free.call @re.as(Void*)
-      {% end %}
-      raise ArgumentError.new("#{String.new(studyerrptr)}")
-    end
-    LibPCRE.full_info(@re, nil, LibPCRE::INFO_CAPTURECOUNT, out @captures)
-  end
-
-  def finalize
-    LibPCRE.free_study @extra
-    {% unless flag?(:interpreted) %}
-      LibPCRE.free.call @re.as(Void*)
-    {% end %}
+  def self.new(source : String, options : Options = Options::None)
+    new(_source: source, _options: options)
   end
 
   # Determines Regex's source validity. If it is, `nil` is returned.
@@ -285,15 +268,7 @@ class Regex
   # Regex.error?("(foo|bar")  # => "missing ) at 8"
   # ```
   def self.error?(source) : String?
-    re = LibPCRE.compile(source, (Options::UTF_8 | Options::NO_UTF8_CHECK | Options::DUPNAMES), out errptr, out erroffset, nil)
-    if re
-      {% unless flag?(:interpreted) %}
-        LibPCRE.free.call re.as(Void*)
-      {% end %}
-      nil
-    else
-      "#{String.new(errptr)} at #{erroffset}"
-    end
+    Engine.error_impl(source)
   end
 
   # Returns `true` if *char* need to be escaped, `false` otherwise.
@@ -485,12 +460,10 @@ class Regex
   # ```
   def match(str, pos = 0, options = Regex::Options::None) : MatchData?
     if byte_index = str.char_index_to_byte_index(pos)
-      match = match_at_byte_index(str, byte_index, options)
+      $~ = match_at_byte_index(str, byte_index, options)
     else
-      match = nil
+      $~ = nil
     end
-
-    $~ = match
   end
 
   # Match at byte index. Matches a regular expression against `String`
@@ -504,17 +477,11 @@ class Regex
   # /(.)(.)/.match_at_byte_index("クリスタル", 3).try &.[2] # => "ス"
   # ```
   def match_at_byte_index(str, byte_index = 0, options = Regex::Options::None) : MatchData?
-    return ($~ = nil) if byte_index > str.bytesize
-
-    ovector_size = (@captures + 1) * 3
-    ovector = Pointer(Int32).malloc(ovector_size)
-    if internal_matches?(str, byte_index, options, ovector, ovector_size)
-      match = MatchData.new(self, @re, str, byte_index, ovector, @captures)
+    if byte_index > str.bytesize
+      $~ = nil
     else
-      match = nil
+      $~ = match_impl(str, byte_index, options)
     end
-
-    $~ = match
   end
 
   # Match at character index. It behaves like `#match`, however it returns `Bool` value.
@@ -540,14 +507,7 @@ class Regex
   def matches_at_byte_index?(str, byte_index = 0, options = Regex::Options::None) : Bool
     return false if byte_index > str.bytesize
 
-    internal_matches?(str, byte_index, options, nil, 0)
-  end
-
-  # Calls `pcre_exec` C function, and handles returning value.
-  private def internal_matches?(str, byte_index, options, ovector, ovector_size)
-    ret = LibPCRE.exec(@re, @extra, str, str.bytesize, byte_index, (options | Options::NO_UTF8_CHECK), ovector, ovector_size)
-    # TODO: when `ret < -1`, it means PCRE error. It should handle correctly.
-    ret >= 0
+    matches_impl(str, byte_index, options)
   end
 
   # Returns a `Hash` where the values are the names of capture groups and the
@@ -561,26 +521,7 @@ class Regex
   # /(.)(?<foo>.)(.)(?<bar>.)(.)/.name_table # => {4 => "bar", 2 => "foo"}
   # ```
   def name_table : Hash(Int32, String)
-    LibPCRE.full_info(@re, @extra, LibPCRE::INFO_NAMECOUNT, out name_count)
-    LibPCRE.full_info(@re, @extra, LibPCRE::INFO_NAMEENTRYSIZE, out name_entry_size)
-    table_pointer = Pointer(UInt8).null
-    LibPCRE.full_info(@re, @extra, LibPCRE::INFO_NAMETABLE, pointerof(table_pointer).as(Pointer(Int32)))
-    name_table = table_pointer.to_slice(name_entry_size*name_count)
-
-    lookup = Hash(Int32, String).new
-
-    name_count.times do |i|
-      capture_offset = i * name_entry_size
-      capture_number = ((name_table[capture_offset].to_u16 << 8)).to_i32 | name_table[capture_offset + 1]
-
-      name_offset = capture_offset + 2
-      checked = name_table[name_offset, name_entry_size - 3]
-      name = String.new(checked.to_unsafe)
-
-      lookup[capture_number] = name
-    end
-
-    lookup
+    name_table_impl
   end
 
   # Returns the number of (named & non-named) capture groups.
@@ -592,8 +533,7 @@ class Regex
   # /(.)|(.)/.capture_count    # => 2
   # ```
   def capture_count : Int32
-    LibPCRE.full_info(@re, @extra, LibPCRE::INFO_CAPTURECOUNT, out capture_count)
-    capture_count
+    capture_count_impl
   end
 
   # Convert to `String` in subpattern format. Produces a `String` which can be

--- a/src/regex/engine.cr
+++ b/src/regex/engine.cr
@@ -1,0 +1,4 @@
+require "./pcre"
+
+# :nodoc:
+alias Regex::Engine = PCRE

--- a/src/regex/lib_pcre.cr
+++ b/src/regex/lib_pcre.cr
@@ -2,6 +2,16 @@
 lib LibPCRE
   alias Int = LibC::Int
 
+  CASELESS      = 0x00000001
+  MULTILINE     = 0x00000002
+  DOTALL        = 0x00000004
+  EXTENDED      = 0x00000008
+  ANCHORED      = 0x00000010
+  UTF8          = 0x00000800
+  NO_UTF8_CHECK = 0x00002000
+  DUPNAMES      = 0x00080000
+  UCP           = 0x20000000
+
   type Pcre = Void*
   type PcreExtra = Void*
   fun compile = pcre_compile(pattern : UInt8*, options : Int, errptr : UInt8**, erroffset : Int*, tableptr : Void*) : Pcre

--- a/src/regex/pcre.cr
+++ b/src/regex/pcre.cr
@@ -2,8 +2,7 @@ require "./lib_pcre"
 
 # :nodoc:
 module Regex::PCRE
-  # :nodoc:
-  def initialize(*, _source source, _options @options)
+  private def initialize(*, _source source, _options @options)
     # PCRE's pattern must have their null characters escaped
     source = source.gsub('\u{0}', "\\0")
     @source = source

--- a/src/regex/pcre.cr
+++ b/src/regex/pcre.cr
@@ -1,0 +1,88 @@
+require "./lib_pcre"
+
+# :nodoc:
+module Regex::PCRE
+  # :nodoc:
+  def initialize(*, _source source, _options @options)
+    # PCRE's pattern must have their null characters escaped
+    source = source.gsub('\u{0}', "\\0")
+    @source = source
+
+    @re = LibPCRE.compile(@source, (options | ::Regex::Options::UTF_8 | ::Regex::Options::NO_UTF8_CHECK | ::Regex::Options::DUPNAMES | ::Regex::Options::UCP), out errptr, out erroffset, nil)
+    raise ArgumentError.new("#{String.new(errptr)} at #{erroffset}") if @re.null?
+    @extra = LibPCRE.study(@re, LibPCRE::STUDY_JIT_COMPILE, out studyerrptr)
+    if @extra.null? && studyerrptr
+      {% unless flag?(:interpreted) %}
+        LibPCRE.free.call @re.as(Void*)
+      {% end %}
+      raise ArgumentError.new("#{String.new(studyerrptr)}")
+    end
+    LibPCRE.full_info(@re, nil, LibPCRE::INFO_CAPTURECOUNT, out @captures)
+  end
+
+  def finalize
+    LibPCRE.free_study @extra
+    {% unless flag?(:interpreted) %}
+      LibPCRE.free.call @re.as(Void*)
+    {% end %}
+  end
+
+  protected def self.error_impl(source)
+    re = LibPCRE.compile(source, (Options::UTF_8 | Options::NO_UTF8_CHECK | Options::DUPNAMES), out errptr, out erroffset, nil)
+    if re
+      {% unless flag?(:interpreted) %}
+        LibPCRE.free.call re.as(Void*)
+      {% end %}
+      nil
+    else
+      "#{String.new(errptr)} at #{erroffset}"
+    end
+  end
+
+  private def name_table_impl
+    LibPCRE.full_info(@re, @extra, LibPCRE::INFO_NAMECOUNT, out name_count)
+    LibPCRE.full_info(@re, @extra, LibPCRE::INFO_NAMEENTRYSIZE, out name_entry_size)
+    table_pointer = Pointer(UInt8).null
+    LibPCRE.full_info(@re, @extra, LibPCRE::INFO_NAMETABLE, pointerof(table_pointer).as(Pointer(Int32)))
+    name_table = table_pointer.to_slice(name_entry_size*name_count)
+
+    lookup = Hash(Int32, String).new
+
+    name_count.times do |i|
+      capture_offset = i * name_entry_size
+      capture_number = ((name_table[capture_offset].to_u16 << 8)).to_i32 | name_table[capture_offset + 1]
+
+      name_offset = capture_offset + 2
+      checked = name_table[name_offset, name_entry_size - 3]
+      name = String.new(checked.to_unsafe)
+
+      lookup[capture_number] = name
+    end
+
+    lookup
+  end
+
+  private def capture_count_impl
+    LibPCRE.full_info(@re, @extra, LibPCRE::INFO_CAPTURECOUNT, out capture_count)
+    capture_count
+  end
+
+  private def match_impl(str, byte_index, options)
+    ovector_size = (@captures + 1) * 3
+    ovector = Pointer(Int32).malloc(ovector_size)
+    if internal_matches?(str, byte_index, options, ovector, ovector_size)
+      MatchData.new(self, @re, str, byte_index, ovector, @captures)
+    end
+  end
+
+  private def matches_impl(str, byte_index, options)
+    internal_matches?(str, byte_index, options, nil, 0)
+  end
+
+  # Calls `pcre_exec` C function, and handles returning value.
+  private def internal_matches?(str, byte_index, options, ovector, ovector_size)
+    ret = LibPCRE.exec(@re, @extra, str, str.bytesize, byte_index, (options | ::Regex::Options::NO_UTF8_CHECK), ovector, ovector_size)
+    # TODO: when `ret < -1`, it means PCRE error. It should handle correctly.
+    ret >= 0
+  end
+end


### PR DESCRIPTION
This patch extracts code that relates directly to implementation details of the libpcre backend from `Regex` and `Regex::MatchData` and puts it into a module `Regex::PCRE`. 

This abstraction is then to be used for an alternative engine using PCRE2 (#12790).

<del>The first two commits are an separate change submitted in #12810.</del>

Commit <del>three and four</del><ins>one and two</ins> are general refactors which are useful on their own and make the extraction easier.