### PR TITLE
Expand `select` actions to `StaticArray`

### DIFF
--- a/spec/compiler/normalize/select_spec.cr
+++ b/spec/compiler/normalize/select_spec.cr
@@ -3,7 +3,7 @@ require "../../spec_helper"
 describe "Normalize: case" do
   it "normalizes select with call" do
     assert_expand "select; when foo; body; when bar; baz; end", <<-CODE
-      __temp_1, __temp_2 = ::Channel.select({foo_select_action, bar_select_action})
+      __temp_1, __temp_2 = ::Channel.select(::StaticArray[foo_select_action, bar_select_action])
       case __temp_1
       when 0
         body
@@ -17,7 +17,7 @@ describe "Normalize: case" do
 
   it "normalizes select with assign" do
     assert_expand "select; when x = foo; x + 1; end", <<-CODE
-      __temp_1, __temp_2 = ::Channel.select({foo_select_action})
+      __temp_1, __temp_2 = ::Channel.select(::StaticArray[foo_select_action])
       case __temp_1
       when 0
         x = __temp_2.as(typeof(foo))
@@ -30,7 +30,7 @@ describe "Normalize: case" do
 
   it "normalizes select with else" do
     assert_expand "select; when foo; body; else; baz; end", <<-CODE
-      __temp_1, __temp_2 = ::Channel.non_blocking_select({foo_select_action})
+      __temp_1, __temp_2 = ::Channel.non_blocking_select(::StaticArray[foo_select_action])
       case __temp_1
       when 0
         body
@@ -42,7 +42,7 @@ describe "Normalize: case" do
 
   it "normalizes select with assign and question method" do
     assert_expand "select; when x = foo?; x + 1; end", <<-CODE
-      __temp_1, __temp_2 = ::Channel.select({foo_select_action?})
+      __temp_1, __temp_2 = ::Channel.select(::StaticArray[foo_select_action?])
       case __temp_1
       when 0
         x = __temp_2.as(typeof(foo?))
@@ -55,7 +55,7 @@ describe "Normalize: case" do
 
   it "normalizes select with assign and bang method" do
     assert_expand "select; when x = foo!; x + 1; end", <<-CODE
-      __temp_1, __temp_2 = ::Channel.select({foo_select_action!})
+      __temp_1, __temp_2 = ::Channel.select(::StaticArray[foo_select_action!])
       case __temp_1
       when 0
         x = __temp_2.as(typeof(foo!))

--- a/src/compiler/crystal/semantic/literal_expander.cr
+++ b/src/compiler/crystal/semantic/literal_expander.cr
@@ -642,7 +642,7 @@ module Crystal
     #
     # To:
     #
-    #     %index, %value = ::Channel.select({foo_select_action, bar_select_action})
+    #     %index, %value = ::Channel.select(::StaticArray[foo_select_action, bar_select_action])
     #     case %index
     #     when 0
     #       body
@@ -665,7 +665,7 @@ module Crystal
     #
     # To:
     #
-    #     %index, %value = ::Channel.select({foo_select_action})
+    #     %index, %value = ::Channel.select(::StaticArray[foo_select_action])
     #     case %index
     #     when 0
     #       body
@@ -716,7 +716,7 @@ module Crystal
       call = Call.new(
         channel,
         node.else ? "non_blocking_select" : "select",
-        TupleLiteral.new(tuple_values).at(node),
+        Call.new(Path.global("StaticArray"), "[]", tuple_values).at(node)
       ).at(node)
       multi = MultiAssign.new(targets, [call] of ASTNode)
       case_cond = Var.new(index_name).at(node)

--- a/src/compiler/crystal/semantic/literal_expander.cr
+++ b/src/compiler/crystal/semantic/literal_expander.cr
@@ -631,6 +631,48 @@ module Crystal
       final_exp
     end
 
+    # Convert a `select` statement into a `case` statement based on `Channel.select`
+    #
+    # From:
+    #
+    #     select
+    #     when foo then body
+    #     when x = bar then x.baz
+    #     end
+    #
+    # To:
+    #
+    #     %index, %value = ::Channel.select({foo_select_action, bar_select_action})
+    #     case %index
+    #     when 0
+    #       body
+    #     when 1
+    #       x = %value.as(typeof(foo))
+    #       x.baz
+    #     else
+    #       ::raise("BUG: invalid select index")
+    #     end
+    #
+    #
+    # If there's a `else` branch, use `Channel.non_blocking_select`.
+    #
+    # From:
+    #
+    #     select
+    #     when foo then body
+    #     else qux
+    #     end
+    #
+    # To:
+    #
+    #     %index, %value = ::Channel.select({foo_select_action})
+    #     case %index
+    #     when 0
+    #       body
+    #     else
+    #       qux
+    #     end
+    #
     def expand(node : Select)
       index_name = @program.new_temp_var_name
       value_name = @program.new_temp_var_name


### PR DESCRIPTION
This patch changes the collection which the compiler emits when expanding a `select` clause to `StaticArray`. Previously, it was `Tuple`.
That enables to mutate the collection in the stdlib implementation of `Channel.select`. The stdlib patch is a separate PR though. Both changes can be implemented on their own. But only together they really have an impact in avoiding heap allocations in `Channel.select`.

I think this introduces a new dependency of compiler-generated code on the macro `StaticArray.[]`. We could also implement that in the compiler, but it would make the code more complicated.

Ref: #12756