### PR TITLE
Deprecate `Channel.select` splat overloads

### DIFF
--- a/src/channel.cr
+++ b/src/channel.cr
@@ -399,6 +399,7 @@ class Channel(T)
   end
 
   # :nodoc:
+  @[Deprecated("Use `Channel.select(Indexable(SelectAction)` instead.")]
   def self.select(*ops : SelectAction)
     self.select ops
   end
@@ -411,6 +412,7 @@ class Channel(T)
   end
 
   # :nodoc:
+  @[Deprecated("Use `Channel.non_blocking_select(Indexable(SelectAction)` instead.")]
   def self.non_blocking_select(*ops : SelectAction)
     self.non_blocking_select ops
   end


### PR DESCRIPTION
The splat-receiving overloads of `Channel.select` and `Channel.blocking_select` are internal methods (`:nodoc:`) but never used internally. They can be removed. This patch only adds a deprecation, but it would probably be fine to just drop them entirely.

They used to be part of the public select API. After the introduction of the `select` keyword in #3130 they remained visible, but became nodoc in #9564.
