### PR TITLE
Optimize uniqueness filter in `Channel.select_impl`

### DIFF
--- a/src/channel.cr
+++ b/src/channel.cr
@@ -425,7 +425,7 @@ class Channel(T)
     # This is to avoid deadlocks between concurrent `select` calls
     ops_locks = ops
       .to_a
-      .sort_by!(&.lock_object_id)
+      .unstable_sort_by!(&.lock_object_id)
 
     each_skip_duplicates(ops_locks, &.lock)
 


### PR DESCRIPTION
In `Channel.select_impl` uses a list of locks that need to be locked before running each action and unlocked afterwards. The locks are retrieved from the `SelectAction`s (each action doubles as a lock), but some actions share the same lock (indicated by `lock_object_id`, which is usually `Channel`). Locking the same lock twice would result in a deadlock, so duplicates needs to be avoided.
This was originally implemented using `uniq!(&.lock_object_id)`.

But this method is actually relatively costly. It's `O(N²)` for cross-comparing all items. For larger sizes (`> 11` items) it would even allocate a `Hash`.

The locks also need to be iterated in a constant order to avoid deadlock between concurrent `select` actions. Thus they are sorted using `sort_by!(&.lock_object_id)` and actions with identical `lock_object_id`s are consequently ordered in a row. This allows to filter repeated ids on iteration with a cursor for tracking the previous id.
This filtering is negligible overhead. Iteration happens exactly twice, once for `lock` and once for `unlock`. For `unlock` there is probably not even a need to avoid duplicates because it doesn't block. But it's cheap enough to do regardless.
This should be a net performance improvement over `uniq!`.

(It would certainly also be more efficient to materialize uniqueness with a similar iterative approach after sorting. But since the collection needs to be iterated only twice, it should be much more efficient to filter on the fly and ensure uniqueness while iterating.)

As an additional change, `sort_by!` is replaced by `unstable_sort_by!`. There's no need for stable sort characteristics.

Ref: #12756