### PR TITLE
Add convenience string constants

### DIFF
--- a/spec/std/string_spec.cr
+++ b/spec/std/string_spec.cr
@@ -3,6 +3,24 @@ require "spec/helpers/iterate"
 require "../support/string"
 
 describe "String" do
+  describe "ASCII_DOWNCASE" do
+    it "returns the lowercased letters a-z" do
+      String::ASCII_DOWNCASE.should eq "abcdefghijklmnopqrstuvwxyz"
+    end
+  end
+
+  describe "ASCII_UPCASE" do
+    it "returns the upcased letters A-Z" do
+      String::ASCII_UPCASE.should eq "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
+    end
+  end
+
+  describe "ASCII_LETTERS" do
+    it "returns the letters a-z and A-Z" do
+      String::ASCII_LETTERS.should eq "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ"
+    end
+  end
+
   describe "[]" do
     it "gets with positive index" do
       c = "hello!"[1]

--- a/spec/std/string_spec.cr
+++ b/spec/std/string_spec.cr
@@ -3,15 +3,15 @@ require "spec/helpers/iterate"
 require "../support/string"
 
 describe "String" do
-  describe "ASCII_DOWNCASE" do
+  describe "ASCII_DOWNCASED" do
     it "returns the lowercased letters a-z" do
-      String::ASCII_DOWNCASE.should eq "abcdefghijklmnopqrstuvwxyz"
+      String::ASCII_DOWNCASED.should eq "abcdefghijklmnopqrstuvwxyz"
     end
   end
 
-  describe "ASCII_UPCASE" do
+  describe "ASCII_UPCASED" do
     it "returns the upcased letters A-Z" do
-      String::ASCII_UPCASE.should eq "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
+      String::ASCII_UPCASED.should eq "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
     end
   end
 

--- a/src/string.cr
+++ b/src/string.cr
@@ -141,6 +141,15 @@ class String
   # :nodoc:
   HEADER_SIZE = sizeof({Int32, Int32, Int32})
 
+  # The letters a-z.
+  ASCII_DOWNCASE = "abcdefghijklmnopqrstuvwxyz"
+
+  # The letters A-Z.
+  ASCII_UPCASE = "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
+
+  # The letters a-zA-Z.
+  ASCII_LETTERS = ASCII_DOWNCASE + ASCII_UPCASE
+
   include Comparable(self)
 
   macro inherited

--- a/src/string.cr
+++ b/src/string.cr
@@ -141,14 +141,14 @@ class String
   # :nodoc:
   HEADER_SIZE = sizeof({Int32, Int32, Int32})
 
-  # The letters a-z.
-  ASCII_DOWNCASE = "abcdefghijklmnopqrstuvwxyz"
+  # The letters abcdefghijklmnopqrstuvwxyz.
+  ASCII_DOWNCASED = "abcdefghijklmnopqrstuvwxyz"
 
-  # The letters A-Z.
-  ASCII_UPCASE = "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
+  # The letters ABCDEFGHIJKLMNOPQRSTUVWXYZ.
+  ASCII_UPCASED = "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
 
-  # The letters a-zA-Z.
-  ASCII_LETTERS = ASCII_DOWNCASE + ASCII_UPCASE
+  # The letters abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ.
+  ASCII_LETTERS = ASCII_DOWNCASED + ASCII_UPCASED
 
   include Comparable(self)
 


### PR DESCRIPTION
This PR adds a couple of convenience constants to the `String` class to get the characters a-z and A-Z. This is something I have done a couple times lately, typing "a...zA...Z", and I am aware of languages where they have constants/methods for this and I thought it would be really nice if Crystal had this feature too.
