### PR TITLE
Fix: Read `UInt` in zip directory header

### DIFF
--- a/spec/std/compress/zip/zip_file_spec.cr
+++ b/spec/std/compress/zip/zip_file_spec.cr
@@ -131,10 +131,10 @@ describe Compress::Zip do
     io = IO::Memory.new
 
     Compress::Zip::Writer.open(io) do |zip|
-      0_u16.upto(UInt16::MAX - 1).each { |index|
+      0_u16.upto(UInt16::MAX - 1).each do |index|
         zip.add Compress::Zip::Writer::Entry.new("foo_#{index}.txt", comment: "some comment"),
           "contents of foo"
-      }
+      end
     end
 
     io.rewind

--- a/spec/std/compress/zip/zip_file_spec.cr
+++ b/spec/std/compress/zip/zip_file_spec.cr
@@ -127,7 +127,7 @@ describe Compress::Zip do
     end
   end
 
-  it "writes comment" do
+  it "writes over int16 files to make sure we can parse" do
     io = IO::Memory.new
 
     Compress::Zip::Writer.open(io) do |zip|

--- a/spec/std/compress/zip/zip_file_spec.cr
+++ b/spec/std/compress/zip/zip_file_spec.cr
@@ -127,6 +127,23 @@ describe Compress::Zip do
     end
   end
 
+  it "writes comment" do
+    io = IO::Memory.new
+
+    Compress::Zip::Writer.open(io) do |zip|
+      0_u16.upto(UInt16::MAX - 1).each { |index|
+        zip.add Compress::Zip::Writer::Entry.new("foo_#{index}.txt", comment: "some comment"),
+          "contents of foo"
+      }
+    end
+
+    io.rewind
+
+    Compress::Zip::File.open(io) do |zip|
+      zip.entries.size.should eq(UInt16::MAX)
+    end
+  end
+
   typeof(Compress::Zip::File.new("file.zip"))
   typeof(Compress::Zip::File.open("file.zip") { })
 end

--- a/src/compress/zip/file.cr
+++ b/src/compress/zip/file.cr
@@ -121,10 +121,10 @@ class Compress::Zip::File
       raise Error.new("Expected end of central directory header signature, not 0x#{signature.to_s(16)}")
     end
 
-    read Int16                     # number of this disk
-    read Int16                     # disk start
-    read Int16                     # number of entries in disk
-    entries_size = read Int16      # number of total entries
+    read UInt16                    # number of this disk
+    read UInt16                    # disk start
+    read UInt16                    # number of entries in disk
+    entries_size = read UInt16     # number of total entries
     read UInt32                    # size of the central directory
     directory_offset = read UInt32 # offset of central directory
     comment_length = read UInt16   # comment length


### PR DESCRIPTION
the writer is working correctly but can't read files with more than 32767 files due to a mismatch of int16 and uint16

