### PR TITLE
Fix: Make sure to dup `Array` in `Channel.select_impl`

### DIFF
--- a/spec/std/channel_spec.cr
+++ b/spec/std/channel_spec.cr
@@ -569,6 +569,17 @@ describe Channel do
         end
       end
     end
+
+    it "returns correct index for array argument", focus: true do
+      ch = [Channel(String).new, Channel(String).new, Channel(String).new]
+      channels = [ch[0], ch[2], ch[1]] # shuffle around to get non-sequential lock_object_ids
+      spawn_and_wait(->{ channels[0].send "foo" }) do
+        i, m = Channel.non_blocking_select(channels.map(&.receive_select_action))
+
+        i.should eq(0)
+        m.should eq("foo")
+      end
+    end
   end
 end
 


### PR DESCRIPTION
This patch fixes a bug in `Channel.select_impl`. The method duplicates the incoming collection `ops` as `ops_locks` for sorting. `ops` is an `Indexable` and *can* be an `Array`. Using `#to_a` is insufficient for ensuring duplication because `Array#to_a` returns `self`.
As a result, the original `ops` would be modified through sorting if its an `Array`. This is an unintended side-effect.
Furthermore, the returned index which indicates the position of the action that was matched would correspond to the index in the sorted array and thus not correspond to the original indices.

This bug probably does not have a huge effect unless you're using the internal `Channel.select` API directly. Public uses are for the implementation of the `select` keyword, but that's using a `Tuple` type.
`Array` is typically used as a parameter to `Channel.receive_first` and `Channel.send_first`, though. Those methods do not return the index (ref #10411). The side-effect of mutating is also irrelevant because the list of actions is only created in the implementation of these methods from a list of `Channel`.

For the latter use case, there is no need to duplicate the array. So I think we could introduce an optimization to avoid that, by extracting from `select_impl` a method which receives both `ops` and `ops_locks` (which can the point to the same collection).