### PR TITLE
Feature/add FileUtils#rm_f

### DIFF
--- a/spec/std/file_utils_spec.cr
+++ b/spec/std/file_utils_spec.cr
@@ -224,6 +224,53 @@ describe "FileUtils" do
     end
   end
 
+  describe ".rm" do
+    it "tests rm with an existing path" do
+      with_tempfile("rm") do |path|
+        test_with_string_and_path(path) do |arg|
+          File.write(path, "")
+          FileUtils.rm(arg).should be_nil
+          File.exists?(path).should be_false
+        end
+      end
+    end
+
+    it "tests rm with nonexistent path" do
+      with_tempfile("rm-nonexistent") do |path|
+        test_with_string_and_path(path) do |arg|
+          expect_raises(File::NotFoundError, "Error deleting file: '#{path.inspect_unquoted}'") do
+            FileUtils.rm(arg)
+          end
+        end
+      end
+    end
+
+    it "tests rm with multiple existing paths" do
+      with_tempfile("rm-multi1", "rm-multi2") do |path1, path2|
+        test_with_string_and_path(path1, path2) do |*args|
+          File.write(path1, "")
+          File.write(path2, "")
+          FileUtils.rm(args.to_a).should be_nil
+          File.exists?(path1).should be_false
+          File.exists?(path2).should be_false
+        end
+      end
+    end
+
+    it "tests rm with some nonexistent paths" do
+      with_tempfile("rm-nonexistent1", "rm-nonexistent2") do |path1, path2|
+        test_with_string_and_path(path1, path2) do |arg1, arg2|
+          File.write(path1, "")
+          File.write(path2, "")
+
+          expect_raises(File::NotFoundError, "Error deleting file: '#{path2.inspect_unquoted}'") do
+            FileUtils.rm([arg1, arg2, arg2])
+          end
+        end
+      end
+    end
+  end
+
   describe ".rm_r" do
     it "deletes a directory recursively" do
       with_tempfile("rm_r") do |path|
@@ -500,51 +547,6 @@ describe "FileUtils" do
     test_with_string_and_path(datapath) do |arg|
       expect_raises(File::Error, "Unable to remove directory: '#{datapath.inspect_unquoted}'") do
         FileUtils.rmdir([arg, arg])
-      end
-    end
-  end
-
-  it "tests rm with an existing path" do
-    with_tempfile("rm") do |path|
-      test_with_string_and_path(path) do |arg|
-        File.write(path, "")
-        FileUtils.rm(arg).should be_nil
-        File.exists?(path).should be_false
-      end
-    end
-  end
-
-  it "tests rm with nonexistent path" do
-    with_tempfile("rm-nonexistent") do |path|
-      test_with_string_and_path(path) do |arg|
-        expect_raises(File::NotFoundError, "Error deleting file: '#{path.inspect_unquoted}'") do
-          FileUtils.rm(arg)
-        end
-      end
-    end
-  end
-
-  it "tests rm with multiple existing paths" do
-    with_tempfile("rm-multi1", "rm-multi2") do |path1, path2|
-      test_with_string_and_path(path1, path2) do |*args|
-        File.write(path1, "")
-        File.write(path2, "")
-        FileUtils.rm(args.to_a).should be_nil
-        File.exists?(path1).should be_false
-        File.exists?(path2).should be_false
-      end
-    end
-  end
-
-  it "tests rm with some nonexistent paths" do
-    with_tempfile("rm-nonexistent1", "rm-nonexistent2") do |path1, path2|
-      test_with_string_and_path(path1, path2) do |arg1, arg2|
-        File.write(path1, "")
-        File.write(path2, "")
-
-        expect_raises(File::NotFoundError, "Error deleting file: '#{path2.inspect_unquoted}'") do
-          FileUtils.rm([arg1, arg2, arg2])
-        end
       end
     end
   end

--- a/spec/std/file_utils_spec.cr
+++ b/spec/std/file_utils_spec.cr
@@ -245,6 +245,36 @@ describe "FileUtils" do
       end
     end
 
+    it "tests rm with directory" do
+      with_tempfile("rm-directory") do |path|
+        test_with_string_and_path(path) do |arg|
+          Dir.mkdir_p(path)
+
+          expect_raises(File::Error, "Error deleting file: '#{path.inspect_unquoted}': Is a directory") do
+            FileUtils.rm(arg)
+          end
+          Dir.exists?(path).should be_true
+        end
+      end
+    end
+
+    it "tests rm with file and directory" do
+      with_tempfile("rm-multi1", "rm-multi2", "rm-dir3") do |path1, path2, path3|
+        test_with_string_and_path(path1, path2, path3) do |*args|
+          File.write(path1, "")
+          File.write(path2, "")
+          Dir.mkdir_p(path3)
+
+          expect_raises(File::Error, "Error deleting file: '#{path3.inspect_unquoted}': Is a directory") do
+            FileUtils.rm(args.to_a)
+          end
+          File.exists?(path1).should be_false
+          File.exists?(path2).should be_false
+          Dir.exists?(path3).should be_true
+        end
+      end
+    end
+
     it "tests rm with multiple existing paths" do
       with_tempfile("rm-multi1", "rm-multi2") do |path1, path2|
         test_with_string_and_path(path1, path2) do |*args|
@@ -266,6 +296,76 @@ describe "FileUtils" do
           expect_raises(File::NotFoundError, "Error deleting file: '#{path2.inspect_unquoted}'") do
             FileUtils.rm([arg1, arg2, arg2])
           end
+        end
+      end
+    end
+  end
+
+  describe ".rm_f" do
+    it "tests rm_f with an existing path" do
+      with_tempfile("rm_f") do |path|
+        test_with_string_and_path(path) do |arg|
+          File.write(path, "")
+          FileUtils.rm_f(arg).should be_nil
+          File.exists?(path).should be_false
+        end
+      end
+    end
+
+    it "tests rm_f with nonexistent path" do
+      with_tempfile("rm_f-nonexistent") do |path|
+        test_with_string_and_path(path) do |arg|
+          FileUtils.rm_f(arg)
+        end
+      end
+    end
+
+    it "tests rm_f with directory" do
+      with_tempfile("rm_f-directory") do |path|
+        test_with_string_and_path(path) do |arg|
+          Dir.mkdir_p(path)
+          FileUtils.rm_f(arg)
+          Dir.exists?(path).should be_true
+        end
+      end
+    end
+
+    it "tests rm_f with file and directory" do
+      with_tempfile("rm_f-multi1", "rm_f-multi2", "rm_f-dir3") do |path1, path2, path3|
+        test_with_string_and_path(path1, path2, path3) do |*args|
+          File.write(path1, "")
+          File.write(path2, "")
+          Dir.mkdir_p(path3)
+
+          FileUtils.rm_f(args.to_a)
+
+          File.exists?(path1).should be_false
+          File.exists?(path2).should be_false
+          Dir.exists?(path3).should be_true
+        end
+      end
+    end
+
+    it "tests rm_f with multiple existing paths" do
+      with_tempfile("rm_f-multi1", "rm_f-multi2") do |path1, path2|
+        test_with_string_and_path(path1, path2) do |*args|
+          File.write(path1, "")
+          File.write(path2, "")
+          FileUtils.rm_f(args.to_a).should be_nil
+          File.exists?(path1).should be_false
+          File.exists?(path2).should be_false
+        end
+      end
+    end
+
+    it "tests rm with some nonexistent paths" do
+      with_tempfile("rm-nonexistent1", "rm-nonexistent2") do |path1, path2|
+        test_with_string_and_path(path1, path2) do |arg1, arg2|
+          File.write(path1, "")
+          File.write(path2, "")
+          FileUtils.rm_f([arg1, arg2, arg2])
+          File.exists?(path1).should be_false
+          File.exists?(path2).should be_false
         end
       end
     end

--- a/spec/std/file_utils_spec.cr
+++ b/spec/std/file_utils_spec.cr
@@ -675,7 +675,7 @@ describe "FileUtils" do
           File.symlink?(path2).should be_true
 
           expect_raises(File::NotFoundError, "Error resolving real path: '#{path2.inspect_unquoted}'") do
-            File.real_path(path2)
+            File.realpath(path2)
           end
           FileUtils.rm_rf(path2)
         end

--- a/src/crystal/system/unix/file.cr
+++ b/src/crystal/system/unix/file.cr
@@ -132,11 +132,13 @@ module Crystal::System::File
     end
   end
 
-  def self.delete(path, *, raise_on_missing : Bool) : Bool
+  def self.delete(path, *, raise_on_missing : Bool, raise_on_directory : Bool) : Bool
     err = LibC.unlink(path.check_no_null_byte)
     if err != -1
       true
     elsif !raise_on_missing && Errno.value == Errno::ENOENT
+      false
+    elsif !raise_on_directory && Errno.value == Errno::EISDIR
       false
     else
       raise ::File::Error.from_errno("Error deleting file", file: path)

--- a/src/file.cr
+++ b/src/file.cr
@@ -360,7 +360,11 @@ class File < IO::FileDescriptor
   # File.delete("./bar") # raises File::NotFoundError (No such file or directory)
   # ```
   def self.delete(path : Path | String) : Nil
-    Crystal::System::File.delete(path.to_s, raise_on_missing: true)
+    Crystal::System::File.delete(
+      path.to_s,
+      raise_on_missing: true,
+      raise_on_directory: true
+    )
   end
 
   # Deletes the file at *path*.
@@ -372,7 +376,11 @@ class File < IO::FileDescriptor
   # File.delete?("./bar") # => false
   # ```
   def self.delete?(path : Path | String) : Bool
-    Crystal::System::File.delete(path.to_s, raise_on_missing: false)
+    Crystal::System::File.delete(
+      path.to_s,
+      raise_on_missing: false,
+      raise_on_directory: false
+    )
   end
 
   # Returns *filename*'s extension, or an empty string if it has no extension.

--- a/src/file_utils.cr
+++ b/src/file_utils.cr
@@ -352,7 +352,7 @@ module FileUtils
     Dir.current
   end
 
-  # Deletes the *path* file given.
+  # Deletes the *path* file given, raised if path is a directory or not exists.
   #
   # ```
   # require "file_utils"
@@ -365,7 +365,7 @@ module FileUtils
     File.delete(path)
   end
 
-  # Deletes all *paths* file given.
+  # Deletes all *paths* file given, raised if one path is a directory or not exists.
   #
   # ```
   # require "file_utils"
@@ -375,6 +375,32 @@ module FileUtils
   def rm(paths : Enumerable(Path | String)) : Nil
     paths.each do |path|
       File.delete(path)
+    end
+  end
+
+  # Deletes the *path* file given, ignored if path is a directory or not exists.
+  #
+  # ```
+  # require "file_utils"
+  #
+  # FileUtils.rm_f("afile.cr")
+  # ```
+  #
+  # NOTE: Alias of `File.delete?`
+  def rm_f(path : Path | String) : Nil
+    File.delete?(path)
+  end
+
+  # Deletes all *paths* file given, ignored if one path is a directory or not exists.
+  #
+  # ```
+  # require "file_utils"
+  #
+  # FileUtils.rm_f(["dir/afile", "afile_copy"])
+  # ```
+  def rm_f(paths : Enumerable(Path | String)) : Nil
+    paths.each do |path|
+      rm_f(path)
     end
   end
 

--- a/src/file_utils.cr
+++ b/src/file_utils.cr
@@ -455,7 +455,7 @@ module FileUtils
   # FileUtils.rmdir("baz")
   # ```
   #
-  # NOTE: Alias of `Dir.rmdir`
+  # NOTE: Alias of `Dir.delete`
   def rmdir(path : Path | String) : Nil
     Dir.delete(path)
   end


### PR DESCRIPTION
Add a FileUtils.rm_f method, fix #12715.

Basically, FileUtils.rm_f  and FileUtils.rm different in the following way:

1. `FileUtils.rm` delete on directory should raise(this is how it used to do), `FileUtils.rm_f` just ignored silently.
2. `FileUtils.rm` delete on file list, when delete to a directory, should raise(this is how it used to do), `Fileutils.rm_f` ignored in this case too.

Check more on spec.

I also fixed a documentation error, `Dir.rmdir` to `Dir.delete`

Thanks.