### PR TITLE
Enable multithreading specs on Windows CI

### DIFF
--- a/spec/std/thread/condition_variable_spec.cr
+++ b/spec/std/thread/condition_variable_spec.cr
@@ -1,5 +1,3 @@
-{% skip_file if flag?(:win32) %} # FIXME: enable after #11647
-
 {% if flag?(:musl) %}
   # FIXME: These thread specs occasionally fail on musl/alpine based ci, so
   # they're disabled for now to reduce noise.

--- a/spec/std/thread/mutex_spec.cr
+++ b/spec/std/thread/mutex_spec.cr
@@ -1,5 +1,3 @@
-{% skip_file if flag?(:win32) %} # FIXME: enable after #11647
-
 {% if flag?(:musl) %}
   # FIXME: These thread specs occasionally fail on musl/alpine based ci, so
   # they're disabled for now to reduce noise.

--- a/spec/std/thread_spec.cr
+++ b/spec/std/thread_spec.cr
@@ -1,5 +1,3 @@
-{% skip_file if flag?(:win32) %} # FIXME: enable after #11647
-
 require "spec"
 
 {% if flag?(:musl) %}


### PR DESCRIPTION
Those specs were explicitly disabled in #12282, and #11647 didn't add them back. This patch does that.

Let's see if CI fails again... (once again I could not reproduce the crash locally)