### PR TITLE
Use `#not_nil!` in `property!` macro

### DIFF
--- a/src/object.cr
+++ b/src/object.cr
@@ -550,11 +550,7 @@ class Object
           end
 
           def {{method_prefix}}\{{name.var.id}} : \{{name.type}}
-            if (value = {{var_prefix}}\{{name.var.id}}).nil?
-              ::raise NilAssertionError.new("\{{@type}}\{{"{{doc_prefix}}".id}}\{{name.var.id}} cannot be nil")
-            else
-              value
-            end
+            {{var_prefix}}\{{name.var.id}}.not_nil!("\{{@type}}\{{"{{doc_prefix}}".id}}\{{name.var.id}} cannot be nil")
           end
         \{% else %}
           def {{method_prefix}}\{{name.id}}?
@@ -562,11 +558,7 @@ class Object
           end
 
           def {{method_prefix}}\{{name.id}}
-            if (value = {{var_prefix}}\{{name.id}}).nil?
-              ::raise NilAssertionError.new("\{{@type}}\{{"{{doc_prefix}}".id}}\{{name.id}} cannot be nil")
-            else
-              value
-            end
+            {{var_prefix}}\{{name.id}}.not_nil!("\{{@type}}\{{"{{doc_prefix}}".id}}\{{name.id}} cannot be nil")
           end
         \{% end %}
       \{% end %}


### PR DESCRIPTION
Refactor custom error messages non-nilable getters defined by `property!` and `getter!` macros, using `#not_nil!(message)` (introduced in #12797).