### PR TITLE
Add lib functions earlier so that they are visible in top-level macros

### DIFF
--- a/spec/compiler/semantic/lib_spec.cr
+++ b/spec/compiler/semantic/lib_spec.cr
@@ -962,4 +962,18 @@ describe "Semantic: lib" do
       ),
       "passing Void return value of lib fun call has no effect"
   end
+
+  it "can list lib functions at the top level (#12395)" do
+    assert_type(%(
+      lib LibFoo
+        fun foo
+      end
+
+      {% if LibFoo.methods.size == 1 %}
+        true
+      {% else %}
+        1
+      {% end %}
+      )) { bool }
+  end
 end

--- a/src/compiler/crystal/semantic/top_level_visitor.cr
+++ b/src/compiler/crystal/semantic/top_level_visitor.cr
@@ -914,7 +914,12 @@ class Crystal::TopLevelVisitor < Crystal::SemanticVisitor
 
     annotations = read_annotations
 
-    external = External.new(node.name, ([] of Arg), node.body, node.real_name).at(node)
+    # We'll resolve the external args types later, in TypeDeclarationVisitor
+    external_args = node.args.map do |arg|
+      Arg.new(arg.name).at(arg.location)
+    end
+
+    external = External.new(node.name, external_args, node.body, node.real_name).at(node)
 
     call_convention = nil
     process_def_annotations(external, annotations) do |annotation_type, ann|
@@ -946,6 +951,8 @@ class Crystal::TopLevelVisitor < Crystal::SemanticVisitor
     external.varargs = node.varargs?
     external.fun_def = node
     node.external = external
+
+    current_type.add_def(external)
 
     false
   end

--- a/src/compiler/crystal/semantic/type_declaration_visitor.cr
+++ b/src/compiler/crystal/semantic/type_declaration_visitor.cr
@@ -107,14 +107,16 @@ class Crystal::TypeDeclarationVisitor < Crystal::SemanticVisitor
   def visit(node : FunDef)
     external = node.external
 
-    node.args.each do |arg|
+    node.args.each_with_index do |arg, index|
       restriction = arg.restriction.not_nil!
       arg_type = lookup_type(restriction)
       arg_type = check_allowed_in_lib(restriction, arg_type)
       if arg_type.remove_typedef.void?
         restriction.raise "can't use Void as parameter type"
       end
-      external.args << Arg.new(arg.name, type: arg_type).at(arg.location)
+
+      # The external args were added in TopLevelVisitor
+      external.args[index].type = arg_type
     end
 
     node_return_type = node.return_type
@@ -130,8 +132,6 @@ class Crystal::TypeDeclarationVisitor < Crystal::SemanticVisitor
 
     old_external = add_external external
     old_external.dead = true if old_external
-
-    current_type.add_def(external)
 
     if current_type.is_a?(Program)
       key = DefInstanceKey.new external.object_id, external.args.map(&.type), nil, nil


### PR DESCRIPTION
Fixes #12395

CI will fail because of #12840

It turns out this was really easy to do. The previous times I tried it I got failures and I didn't want to spend time debugging it. The failures were because the `External` was created without `args` initially, and then they were added. I missed that... but once I realized that was the problem fixing it was very easy.

Note: lib types won't be solved at the top-level because that happens later on. The reason for that is to not require forward declarations. But I think that even without resolved types this is useful.