### PR TITLE
Match Nix loader errors in compiler spec

### DIFF
--- a/spec/compiler/loader/unix_spec.cr
+++ b/spec/compiler/loader/unix_spec.cr
@@ -28,10 +28,10 @@ describe Crystal::Loader do
     end
 
     it "parses file paths" do
-      expect_raises(Crystal::Loader::LoadError, /#{Dir.current}\/foobar\.o.+(No such file or directory|image not found)|Cannot open "#{Dir.current}\/foobar\.o"/) do
+      expect_raises(Crystal::Loader::LoadError, /#{Dir.current}\/foobar\.o.+(No such file or directory|image not found|no such file)|Cannot open "#{Dir.current}\/foobar\.o"/) do
         Crystal::Loader.parse(["foobar.o"], search_paths: [] of String)
       end
-      expect_raises(Crystal::Loader::LoadError, /(#{Dir.current}\/foo\/bar\.o).+(No such file or directory|image not found)|Cannot open "#{Dir.current}\/foo\/bar\.o"/) do
+      expect_raises(Crystal::Loader::LoadError, /(#{Dir.current}\/foo\/bar\.o).+(No such file or directory|image not found|no such file)|Cannot open "#{Dir.current}\/foo\/bar\.o"/) do
         Crystal::Loader.parse(["-l", "foo/bar.o"], search_paths: [] of String)
       end
     end


### PR DESCRIPTION
As part of https://github.com/NixOS/nixpkgs/pull/195606 I noticed that the compiler loader specs fails on nix.

This PR tweaks, an already long regex, to accept one more case similar to https://github.com/crystal-lang/crystal/pull/12323

<details>
<summary>output of compiler spec failure on nix</summary>

```
  1) Crystal::Loader .parse parses file paths
     Failure/Error: expect_raises(Crystal::Loader::LoadError, /#{Dir.current}\/foobar\.o.+(No such file or directory|image not found)|Cannot open "#{Dir.current}\/foobar\.o"/) do

       Expected Crystal::Loader::LoadError with message matching /\/private\/tmp\/nix-build-crystal-1.6.2.drv-0\/source\/foobar\.o.+(No such file or directory|image not found)|Cannot open "\/private\/tmp\/nix-build-crystal-1.6.2.drv-0\/source\/foobar\.o"/, got #<Crystal::Loader::LoadError: cannot load /private/tmp/nix-build-crystal-1.6.2.drv-0/source/foobar.o (dlopen(/private/tmp/nix-build-crystal-1.6.2.drv-0/source/foobar.o, 0x0009): tried: '/private/tmp/nix-build-crystal-1.6.2.drv-0/source/foobar.o' (no such file))
       Linker arguments: foobar.o
       Search path: > with backtrace:
         # src/compiler/crystal/loader/unix.cr:84:25 in 'load_file'
         # src/compiler/crystal/loader.cr:39:7 in 'new'
         # src/compiler/crystal/loader/unix.cr:60:7 in 'parse:search_paths'
         # spec/compiler/loader/unix_spec.cr:32:9 in '->'
         # src/spec/example.cr:45:13 in 'internal_run'
         # src/spec/example.cr:33:16 in 'run'
         # src/spec/context.cr:18:23 in 'internal_run'
         # src/spec/context.cr:339:7 in 'run'
         # src/spec/context.cr:18:23 in 'internal_run'
         # src/spec/context.cr:339:7 in 'run'
         # src/spec/context.cr:18:23 in 'internal_run'
         # src/spec/context.cr:156:7 in 'run'
         # src/spec/dsl.cr:220:7 in '->'
         # src/crystal/at_exit_handlers.cr:14:19 in 'run'
         # src/crystal/main.cr:50:14 in 'exit'
         # src/crystal/main.cr:45:5 in 'main'
         # src/crystal/main.cr:127:3 in 'main'

     # spec/compiler/loader/unix_spec.cr:31
```

</details>