### PR TITLE
Order `_` after any other `Path` when comparing overloads

### DIFF
--- a/spec/compiler/semantic/restrictions_spec.cr
+++ b/spec/compiler/semantic/restrictions_spec.cr
@@ -748,6 +748,63 @@ describe "Restrictions" do
           CRYSTAL
       end
     end
+
+    describe "Underscore vs Path" do
+      it "inserts Path before underscore (#12854)" do
+        assert_type(<<-CRYSTAL) { bool }
+          class Foo
+          end
+
+          def foo(x : _)
+            'a'
+          end
+
+          def foo(x : Foo)
+            true
+          end
+
+          foo(Foo.new)
+          CRYSTAL
+      end
+
+      it "keeps underscore after Path (#12854)" do
+        assert_type(<<-CRYSTAL) { bool }
+          class Foo
+          end
+
+          def foo(x : Foo)
+            true
+          end
+
+          def foo(x : _)
+            'a'
+          end
+
+          foo(Foo.new)
+          CRYSTAL
+      end
+
+      it "works with splats and modules, under -Dpreview_overload_order (#12854)" do
+        assert_type(<<-CRYSTAL, flags: "preview_overload_order") { bool }
+          module Foo
+          end
+
+          class Bar
+            include Foo
+          end
+
+          def foo(*x : _)
+            'a'
+          end
+
+          def foo(x : Foo)
+            true
+          end
+
+          foo(Bar.new)
+          CRYSTAL
+      end
+    end
   end
 
   it "self always matches instance type in restriction" do

--- a/src/compiler/crystal/semantic/restrictions.cr
+++ b/src/compiler/crystal/semantic/restrictions.cr
@@ -629,6 +629,10 @@ module Crystal
       end
     end
 
+    def restriction_of?(other : Underscore, owner, self_free_vars = nil, other_free_vars = nil)
+      true
+    end
+
     def restriction_of?(other, owner, self_free_vars = nil, other_free_vars = nil)
       false
     end
@@ -659,6 +663,10 @@ module Crystal
   end
 
   class Union
+    def restriction_of?(other : Underscore, owner, self_free_vars = nil, other_free_vars = nil)
+      true
+    end
+
     def restriction_of?(other, owner, self_free_vars = nil, other_free_vars = nil)
       # For a union to be considered before another restriction,
       # all types in the union must be considered before
@@ -1473,6 +1481,10 @@ module Crystal
   end
 
   class AliasType
+    def restriction_of?(other : Underscore, owner, self_free_vars = nil, other_free_vars = nil)
+      true
+    end
+
     def restriction_of?(other, owner, self_free_vars = nil, other_free_vars = nil)
       return true if self == other
 


### PR DESCRIPTION
Fixes #12854. The snippet there now produces the same overload order whether `-Dpreview_overload_order` is defined or not (but as shown there this bugfix isn't limited to the behavior of that flag).

This happens because `Crystal::Path#restriction_of?(other, ...)` incorrectly overrides `Crystal::ASTNode#restriction_of?(other : Underscore, ...)`; the PR adds the corresponding overloads in `Path` and other node types that do the same thing.