### PR TITLE
Use `sleep` in flock wait loop

### DIFF
--- a/src/crystal/system/unix/file.cr
+++ b/src/crystal/system/unix/file.cr
@@ -257,7 +257,7 @@ module Crystal::System::File
 
     if retry
       until flock(op)
-        ::Fiber.yield
+        sleep 0.1
       end
     else
       flock(op) || raise IO::Error.from_errno("Error applying file lock: file is already locked")

--- a/src/crystal/system/win32/file.cr
+++ b/src/crystal/system/win32/file.cr
@@ -276,7 +276,7 @@ module Crystal::System::File
     handle = windows_handle
     if retry
       until lock_file(handle, flags)
-        ::Fiber.yield
+        sleep 0.1
       end
     else
       lock_file(handle, flags) || raise IO::Error.from_winerror("Error applying file lock: file is already locked")


### PR DESCRIPTION
Since #12728, when a file lock can't be attained immediately, blocking flock waits in a loop an tries again until the lock becomes available.

As commented in https://github.com/crystal-lang/crystal/pull/12728#discussion_r1053064691, the relatively tight loop with `Fiber.yield` can drive up CPU utilization.

This patch lets the fiber sleep for 100ms. That amount isn't set in stone, but it's probably a good start. I've copied it from the Ruby implementation: https://github.com/ruby/ruby/blob/5404e2fd31736af3a7477f3ec67d3f07276485d6/file.c#L5283-L5308