### PR TITLE
Add `#bit_reverse` and `#byte_swap` for primitive integers

### DIFF
--- a/spec/std/int_spec.cr
+++ b/spec/std/int_spec.cr
@@ -770,6 +770,29 @@ describe "Int" do
     iter.next.should be_a(Iterator::Stop)
   end
 
+  describe "#byte_swap" do
+    it { 0x12_u8.byte_swap.should eq(0x12_u8) }
+    it { 0x1234_u16.byte_swap.should eq(0x3412_u16) }
+    it { 0x12345678_u32.byte_swap.should eq(0x78563412_u32) }
+    it { 0x123456789ABCDEF0_u64.byte_swap.should eq(0xF0DEBC9A78563412_u64) }
+    it { 1.to_u128.byte_swap.should eq(1.to_u128 << 120) }
+    it { (1.to_u128 << 127).byte_swap.should eq(0x80.to_u128) }
+    it { 0x12345678.to_u128.byte_swap.should eq(0x78563412.to_u128 << 96) }
+
+    it { 0x12_i8.byte_swap.should eq(0x12_i8) }
+    it { 0x1234_i16.byte_swap.should eq(0x3412_i16) }
+    it { 0x12345678_i32.byte_swap.should eq(0x78563412_i32) }
+    it { 0x123456789ABCDEF0_i64.byte_swap.should eq(0xF0DEBC9A78563412_u64.to_i64!) }
+    it { 1.to_i128.byte_swap.should eq(1.to_i128 << 120) }
+    it { (1.to_i128 << 127).byte_swap.should eq(0x80.to_i128) }
+    it { 0x12345678.to_i128.byte_swap.should eq(0x78563412.to_i128 << 96) }
+
+    {% for width in %w(8 16 32 64 128).map(&.id) %}
+      it { 0.to_i{{width}}.byte_swap.should be_a(Int{{width}}) }
+      it { 0.to_u{{width}}.byte_swap.should be_a(UInt{{width}}) }
+    {% end %}
+  end
+
   describe "#popcount" do
     it { 5_i8.popcount.should eq(2) }
     it { 127_i8.popcount.should eq(7) }

--- a/spec/std/int_spec.cr
+++ b/spec/std/int_spec.cr
@@ -770,6 +770,29 @@ describe "Int" do
     iter.next.should be_a(Iterator::Stop)
   end
 
+  describe "#bit_reverse" do
+    it { 0x12_u8.bit_reverse.should eq(0x48_u8) }
+    it { 0x1234_u16.bit_reverse.should eq(0x2C48_u16) }
+    it { 0x12345678_u32.bit_reverse.should eq(0x1E6A2C48_u32) }
+    it { 0x123456789ABCDEF0_u64.bit_reverse.should eq(0x0F7B3D591E6A2C48_u64) }
+    it { 1.to_u128.bit_reverse.should eq(1.to_u128 << 127) }
+    it { (1.to_u128 << 127).bit_reverse.should eq(0x1.to_u128) }
+    it { 0x12345678.to_u128.bit_reverse.should eq(0x1E6A2C48.to_u128 << 96) }
+
+    it { 0x12_i8.bit_reverse.should eq(0x48_i8) }
+    it { 0x1234_i16.bit_reverse.should eq(0x2C48_i16) }
+    it { 0x12345678_i32.bit_reverse.should eq(0x1E6A2C48_i32) }
+    it { 0x123456789ABCDEF0_i64.bit_reverse.should eq(0x0F7B3D591E6A2C48_i64) }
+    it { 1.to_i128.bit_reverse.should eq(1.to_i128 << 127) }
+    it { (1.to_i128 << 127).bit_reverse.should eq(0x1.to_i128) }
+    it { 0x12345678.to_i128.bit_reverse.should eq(0x1E6A2C48.to_i128 << 96) }
+
+    {% for width in %w(8 16 32 64 128).map(&.id) %}
+      it { 0.to_i{{width}}.bit_reverse.should be_a(Int{{width}}) }
+      it { 0.to_u{{width}}.bit_reverse.should be_a(UInt{{width}}) }
+    {% end %}
+  end
+
   describe "#byte_swap" do
     it { 0x12_u8.byte_swap.should eq(0x12_u8) }
     it { 0x1234_u16.byte_swap.should eq(0x3412_u16) }

--- a/src/base64.cr
+++ b/src/base64.cr
@@ -208,7 +208,7 @@ module Base64
 
     # process bunch of full triples
     while cstr < endcstr
-      n = cstr.as(UInt32*).value.byteswap
+      n = cstr.as(UInt32*).value.byte_swap
       yield bytes[(n >> 26) & 63]
       yield bytes[(n >> 20) & 63]
       yield bytes[(n >> 14) & 63]

--- a/src/base64.cr
+++ b/src/base64.cr
@@ -208,7 +208,7 @@ module Base64
 
     # process bunch of full triples
     while cstr < endcstr
-      n = Intrinsics.bswap32(cstr.as(UInt32*).value)
+      n = cstr.as(UInt32*).value.byteswap
       yield bytes[(n >> 26) & 63]
       yield bytes[(n >> 20) & 63]
       yield bytes[(n >> 14) & 63]

--- a/src/bit_array.cr
+++ b/src/bit_array.cr
@@ -484,10 +484,10 @@ struct BitArray
     return self if size <= 1
 
     if size <= 32
-      @bits.value = Intrinsics.bitreverse32(@bits.value) >> (32 - size)
+      @bits.value = @bits.value.bit_reverse >> (32 - size)
     elsif size <= 64
       more_bits = @bits.as(UInt64*)
-      more_bits.value = Intrinsics.bitreverse64(more_bits.value) >> (64 - size)
+      more_bits.value = more_bits.value.bit_reverse >> (64 - size)
     else
       # 3 or more groups of bits
       offset = (-size) % 32
@@ -502,17 +502,17 @@ struct BitArray
         #     hgfedcba fghijklm nopqrstu
         (malloc_size - 1).downto(1) do |i|
           # fshl(a, b, count) = (a << count) | (b >> (N - count))
-          @bits[i] = Intrinsics.bitreverse32(Intrinsics.fshl32(@bits[i], @bits[i - 1], offset))
+          @bits[i] = Intrinsics.fshl32(@bits[i], @bits[i - 1], offset).bit_reverse
         end
 
         # last group:
         #
         #     edcba000 fghijklm nopqrstu
         #     000abcde fghijklm nopqrstu
-        @bits[0] = Intrinsics.bitreverse32(@bits[0] << offset)
+        @bits[0] = (@bits[0] << offset).bit_reverse
       else
         # no padding; do only the bit reverses
-        Slice.new(@bits, malloc_size).map! { |x| Intrinsics.bitreverse32(x) }
+        Slice.new(@bits, malloc_size).map! &.bit_reverse
       end
 
       # reversing all groups themselves:

--- a/src/compiler/crystal/interpreter/instructions.cr
+++ b/src/compiler/crystal/interpreter/instructions.cr
@@ -1820,22 +1820,19 @@ require "./repl"
         },
       {% end %}
 
-      interpreter_intrinsics_bswap32: {
-        pop_values: [id : UInt32],
-        push:       true,
-        code:       LibIntrinsics.bswap32(id),
-      },
-      interpreter_intrinsics_bswap16: {
-        pop_values: [id : UInt16],
-        push:       true,
-        code:       LibIntrinsics.bswap16(id),
-      },
       interpreter_intrinsics_read_cycle_counter: {
         push:       true,
         code:       LibIntrinsics.read_cycle_counter,
       },
 
       {% for n in [8, 16, 32, 64, 128] %}
+        {% unless n == 8 %}
+          interpreter_intrinsics_bswap{{n}}: {
+            pop_values: [value : UInt{{n}}],
+            push:       true,
+            code:       LibIntrinsics.bswap{{n}}(value),
+          },
+        {% end %}
         interpreter_intrinsics_popcount{{n}}: {
           pop_values: [value : Int{{n}}],
           push:       true,

--- a/src/compiler/crystal/interpreter/instructions.cr
+++ b/src/compiler/crystal/interpreter/instructions.cr
@@ -1826,6 +1826,11 @@ require "./repl"
       },
 
       {% for n in [8, 16, 32, 64, 128] %}
+        interpreter_intrinsics_bitreverse{{n}}: {
+          pop_values: [value : UInt{{n}}],
+          push:       true,
+          code:       LibIntrinsics.bitreverse{{n}}(value),
+        },
         {% unless n == 8 %}
           interpreter_intrinsics_bswap{{n}}: {
             pop_values: [value : UInt{{n}}],
@@ -1869,14 +1874,6 @@ require "./repl"
           pop_values: [a : UInt{{n}}, b : UInt{{n}}, count : UInt{{n}}],
           push:       true,
           code:       LibIntrinsics.fshr{{n}}(a, b, count),
-        },
-      {% end %}
-
-      {% for n in [16, 32, 64] %}
-        interpreter_intrinsics_bitreverse{{n}}: {
-          pop_values: [value : UInt{{n}}],
-          push:       true,
-          code:       LibIntrinsics.bitreverse{{n}}(value),
         },
       {% end %}
 

--- a/src/compiler/crystal/interpreter/primitives.cr
+++ b/src/compiler/crystal/interpreter/primitives.cr
@@ -472,6 +472,9 @@ class Crystal::Repl::Compiler
     when "interpreter_intrinsics_counttrailing128"
       accept_call_args(node)
       interpreter_intrinsics_counttrailing128(node: node)
+    when "interpreter_intrinsics_bitreverse8"
+      accept_call_args(node)
+      interpreter_intrinsics_bitreverse8(node: node)
     when "interpreter_intrinsics_bitreverse16"
       accept_call_args(node)
       interpreter_intrinsics_bitreverse16(node: node)
@@ -481,6 +484,9 @@ class Crystal::Repl::Compiler
     when "interpreter_intrinsics_bitreverse64"
       accept_call_args(node)
       interpreter_intrinsics_bitreverse64(node: node)
+    when "interpreter_intrinsics_bitreverse128"
+      accept_call_args(node)
+      interpreter_intrinsics_bitreverse128(node: node)
     when "interpreter_intrinsics_fshl8"
       accept_call_args(node)
       interpreter_intrinsics_fshl8(node: node)

--- a/src/compiler/crystal/interpreter/primitives.cr
+++ b/src/compiler/crystal/interpreter/primitives.cr
@@ -274,7 +274,7 @@ class Crystal::Repl::Compiler
 
       pop(aligned_sizeof_type(node.type), node: nil) unless @wants_value
     when "load_atomic"
-      node.args.each { |arg| request_value(arg) }
+      accept_call_args(node)
 
       pointer_instance_type = node.args.first.type.as(PointerInstanceType)
       element_type = pointer_instance_type.element_type
@@ -282,7 +282,7 @@ class Crystal::Repl::Compiler
 
       load_atomic(element_size, node: node)
     when "store_atomic"
-      node.args.each { |arg| request_value(arg) }
+      accept_call_args(node)
 
       pointer_instance_type = node.args.first.type.as(PointerInstanceType)
       element_type = pointer_instance_type.element_type
@@ -290,7 +290,7 @@ class Crystal::Repl::Compiler
 
       store_atomic(element_size, node: node)
     when "atomicrmw"
-      node.args.each { |arg| request_value(arg) }
+      accept_call_args(node)
 
       pointer_instance_type = node.args[1].type.as(PointerInstanceType)
       element_type = pointer_instance_type.element_type
@@ -298,7 +298,7 @@ class Crystal::Repl::Compiler
 
       atomicrmw(element_size, node: node)
     when "cmpxchg"
-      node.args.each { |arg| request_value(arg) }
+      accept_call_args(node)
 
       pointer_instance_type = node.args[0].type.as(PointerInstanceType)
       element_type = pointer_instance_type.element_type
@@ -413,10 +413,18 @@ class Crystal::Repl::Compiler
       {% if flag?(:i386) || flag?(:x86_64) %}
         interpreter_intrinsics_pause(node: node)
       {% end %}
-    when "interpreter_intrinsics_bswap32"
-      interpreter_intrinsics_bswap32(node: node)
     when "interpreter_intrinsics_bswap16"
+      accept_call_args(node)
       interpreter_intrinsics_bswap16(node: node)
+    when "interpreter_intrinsics_bswap32"
+      accept_call_args(node)
+      interpreter_intrinsics_bswap32(node: node)
+    when "interpreter_intrinsics_bswap64"
+      accept_call_args(node)
+      interpreter_intrinsics_bswap64(node: node)
+    when "interpreter_intrinsics_bswap128"
+      accept_call_args(node)
+      interpreter_intrinsics_bswap128(node: node)
     when "interpreter_intrinsics_read_cycle_counter"
       interpreter_intrinsics_read_cycle_counter(node: node)
     when "interpreter_intrinsics_popcount8"

--- a/src/int.cr
+++ b/src/int.cr
@@ -878,6 +878,17 @@ struct Int8
     Intrinsics.popcount8(self)
   end
 
+  # Reverses the bits of `self`; the least significant bit becomes the most
+  # significant, and vice-versa.
+  #
+  # ```
+  # 0b01001011_u8.bit_reverse          # => 0b11010010
+  # 0b1100100001100111_u16.bit_reverse # => 0b1110011000010011
+  # ```
+  def bit_reverse : self
+    Intrinsics.bitreverse8(self).to_i8!
+  end
+
   # Swaps the bytes of `self`; a little-endian value becomes a big-endian value,
   # and vice-versa. The bit order within each byte is unchanged.
   #
@@ -966,6 +977,17 @@ struct Int16
 
   def popcount : Int16
     Intrinsics.popcount16(self)
+  end
+
+  # Reverses the bits of `self`; the least significant bit becomes the most
+  # significant, and vice-versa.
+  #
+  # ```
+  # 0b01001011_u8.bit_reverse          # => 0b11010010
+  # 0b1100100001100111_u16.bit_reverse # => 0b1110011000010011
+  # ```
+  def bit_reverse : self
+    Intrinsics.bitreverse16(self).to_i16!
   end
 
   # Swaps the bytes of `self`; a little-endian value becomes a big-endian value,
@@ -1058,6 +1080,17 @@ struct Int32
     Intrinsics.popcount32(self)
   end
 
+  # Reverses the bits of `self`; the least significant bit becomes the most
+  # significant, and vice-versa.
+  #
+  # ```
+  # 0b01001011_u8.bit_reverse          # => 0b11010010
+  # 0b1100100001100111_u16.bit_reverse # => 0b1110011000010011
+  # ```
+  def bit_reverse : self
+    Intrinsics.bitreverse32(self).to_i32!
+  end
+
   # Swaps the bytes of `self`; a little-endian value becomes a big-endian value,
   # and vice-versa. The bit order within each byte is unchanged.
   #
@@ -1146,6 +1179,17 @@ struct Int64
 
   def popcount : Int64
     Intrinsics.popcount64(self)
+  end
+
+  # Reverses the bits of `self`; the least significant bit becomes the most
+  # significant, and vice-versa.
+  #
+  # ```
+  # 0b01001011_u8.bit_reverse          # => 0b11010010
+  # 0b1100100001100111_u16.bit_reverse # => 0b1110011000010011
+  # ```
+  def bit_reverse : self
+    Intrinsics.bitreverse64(self).to_i64!
   end
 
   # Swaps the bytes of `self`; a little-endian value becomes a big-endian value,
@@ -1238,6 +1282,17 @@ struct Int128
 
   def popcount
     Intrinsics.popcount128(self)
+  end
+
+  # Reverses the bits of `self`; the least significant bit becomes the most
+  # significant, and vice-versa.
+  #
+  # ```
+  # 0b01001011_u8.bit_reverse          # => 0b11010010
+  # 0b1100100001100111_u16.bit_reverse # => 0b1110011000010011
+  # ```
+  def bit_reverse : self
+    Intrinsics.bitreverse128(self).to_i128!
   end
 
   # Swaps the bytes of `self`; a little-endian value becomes a big-endian value,
@@ -1334,6 +1389,17 @@ struct UInt8
     Intrinsics.popcount8(self)
   end
 
+  # Reverses the bits of `self`; the least significant bit becomes the most
+  # significant, and vice-versa.
+  #
+  # ```
+  # 0b01001011_u8.bit_reverse          # => 0b11010010
+  # 0b1100100001100111_u16.bit_reverse # => 0b1110011000010011
+  # ```
+  def bit_reverse : self
+    Intrinsics.bitreverse8(self)
+  end
+
   # Swaps the bytes of `self`; a little-endian value becomes a big-endian value,
   # and vice-versa. The bit order within each byte is unchanged.
   #
@@ -1426,6 +1492,17 @@ struct UInt16
 
   def popcount : Int16
     Intrinsics.popcount16(self)
+  end
+
+  # Reverses the bits of `self`; the least significant bit becomes the most
+  # significant, and vice-versa.
+  #
+  # ```
+  # 0b01001011_u8.bit_reverse          # => 0b11010010
+  # 0b1100100001100111_u16.bit_reverse # => 0b1110011000010011
+  # ```
+  def bit_reverse : self
+    Intrinsics.bitreverse16(self)
   end
 
   # Swaps the bytes of `self`; a little-endian value becomes a big-endian value,
@@ -1522,6 +1599,17 @@ struct UInt32
     Intrinsics.popcount32(self)
   end
 
+  # Reverses the bits of `self`; the least significant bit becomes the most
+  # significant, and vice-versa.
+  #
+  # ```
+  # 0b01001011_u8.bit_reverse          # => 0b11010010
+  # 0b1100100001100111_u16.bit_reverse # => 0b1110011000010011
+  # ```
+  def bit_reverse : self
+    Intrinsics.bitreverse32(self)
+  end
+
   # Swaps the bytes of `self`; a little-endian value becomes a big-endian value,
   # and vice-versa. The bit order within each byte is unchanged.
   #
@@ -1614,6 +1702,17 @@ struct UInt64
 
   def popcount : Int64
     Intrinsics.popcount64(self)
+  end
+
+  # Reverses the bits of `self`; the least significant bit becomes the most
+  # significant, and vice-versa.
+  #
+  # ```
+  # 0b01001011_u8.bit_reverse          # => 0b11010010
+  # 0b1100100001100111_u16.bit_reverse # => 0b1110011000010011
+  # ```
+  def bit_reverse : self
+    Intrinsics.bitreverse64(self)
   end
 
   # Swaps the bytes of `self`; a little-endian value becomes a big-endian value,
@@ -1710,6 +1809,17 @@ struct UInt128
 
   def popcount
     Intrinsics.popcount128(self)
+  end
+
+  # Reverses the bits of `self`; the least significant bit becomes the most
+  # significant, and vice-versa.
+  #
+  # ```
+  # 0b01001011_u8.bit_reverse          # => 0b11010010
+  # 0b1100100001100111_u16.bit_reverse # => 0b1110011000010011
+  # ```
+  def bit_reverse : self
+    Intrinsics.bitreverse128(self)
   end
 
   # Swaps the bytes of `self`; a little-endian value becomes a big-endian value,

--- a/src/int.cr
+++ b/src/int.cr
@@ -878,6 +878,19 @@ struct Int8
     Intrinsics.popcount8(self)
   end
 
+  # Swaps the bytes of `self`; a little-endian value becomes a big-endian value,
+  # and vice-versa. The bit order within each byte is unchanged.
+  #
+  # Has no effect on 8-bit integers.
+  #
+  # ```
+  # 0x1234_u16.byte_swap     # => 0x3412
+  # 0x5678ABCD_u32.byte_swap # => 0xCDAB7856
+  # ```
+  def byte_swap : self
+    self
+  end
+
   # Returns the number of leading `0`-bits.
   def leading_zeros_count
     Intrinsics.countleading8(self, false)
@@ -953,6 +966,19 @@ struct Int16
 
   def popcount : Int16
     Intrinsics.popcount16(self)
+  end
+
+  # Swaps the bytes of `self`; a little-endian value becomes a big-endian value,
+  # and vice-versa. The bit order within each byte is unchanged.
+  #
+  # Has no effect on 8-bit integers.
+  #
+  # ```
+  # 0x1234_u16.byte_swap     # => 0x3412
+  # 0x5678ABCD_u32.byte_swap # => 0xCDAB7856
+  # ```
+  def byte_swap : self
+    Intrinsics.bswap16(self).to_i16!
   end
 
   # Returns the number of leading `0`-bits.
@@ -1032,6 +1058,19 @@ struct Int32
     Intrinsics.popcount32(self)
   end
 
+  # Swaps the bytes of `self`; a little-endian value becomes a big-endian value,
+  # and vice-versa. The bit order within each byte is unchanged.
+  #
+  # Has no effect on 8-bit integers.
+  #
+  # ```
+  # 0x1234_u16.byte_swap     # => 0x3412
+  # 0x5678ABCD_u32.byte_swap # => 0xCDAB7856
+  # ```
+  def byte_swap : self
+    Intrinsics.bswap32(self).to_i32!
+  end
+
   # Returns the number of leading `0`-bits.
   def leading_zeros_count
     Intrinsics.countleading32(self, false)
@@ -1107,6 +1146,19 @@ struct Int64
 
   def popcount : Int64
     Intrinsics.popcount64(self)
+  end
+
+  # Swaps the bytes of `self`; a little-endian value becomes a big-endian value,
+  # and vice-versa. The bit order within each byte is unchanged.
+  #
+  # Has no effect on 8-bit integers.
+  #
+  # ```
+  # 0x1234_u16.byte_swap     # => 0x3412
+  # 0x5678ABCD_u32.byte_swap # => 0xCDAB7856
+  # ```
+  def byte_swap : self
+    Intrinsics.bswap64(self).to_i64!
   end
 
   # Returns the number of leading `0`-bits.
@@ -1186,6 +1238,19 @@ struct Int128
 
   def popcount
     Intrinsics.popcount128(self)
+  end
+
+  # Swaps the bytes of `self`; a little-endian value becomes a big-endian value,
+  # and vice-versa. The bit order within each byte is unchanged.
+  #
+  # Has no effect on 8-bit integers.
+  #
+  # ```
+  # 0x1234_u16.byte_swap     # => 0x3412
+  # 0x5678ABCD_u32.byte_swap # => 0xCDAB7856
+  # ```
+  def byte_swap : self
+    Intrinsics.bswap128(self).to_i128!
   end
 
   # Returns the number of leading `0`-bits.
@@ -1269,6 +1334,19 @@ struct UInt8
     Intrinsics.popcount8(self)
   end
 
+  # Swaps the bytes of `self`; a little-endian value becomes a big-endian value,
+  # and vice-versa. The bit order within each byte is unchanged.
+  #
+  # Has no effect on 8-bit integers.
+  #
+  # ```
+  # 0x1234_u16.byte_swap     # => 0x3412
+  # 0x5678ABCD_u32.byte_swap # => 0xCDAB7856
+  # ```
+  def byte_swap : self
+    self
+  end
+
   # Returns the number of leading `0`-bits.
   def leading_zeros_count
     Intrinsics.countleading8(self, false)
@@ -1348,6 +1426,19 @@ struct UInt16
 
   def popcount : Int16
     Intrinsics.popcount16(self)
+  end
+
+  # Swaps the bytes of `self`; a little-endian value becomes a big-endian value,
+  # and vice-versa. The bit order within each byte is unchanged.
+  #
+  # Has no effect on 8-bit integers.
+  #
+  # ```
+  # 0x1234_u16.byte_swap     # => 0x3412
+  # 0x5678ABCD_u32.byte_swap # => 0xCDAB7856
+  # ```
+  def byte_swap : self
+    Intrinsics.bswap16(self)
   end
 
   # Returns the number of leading `0`-bits.
@@ -1431,6 +1522,19 @@ struct UInt32
     Intrinsics.popcount32(self)
   end
 
+  # Swaps the bytes of `self`; a little-endian value becomes a big-endian value,
+  # and vice-versa. The bit order within each byte is unchanged.
+  #
+  # Has no effect on 8-bit integers.
+  #
+  # ```
+  # 0x1234_u16.byte_swap     # => 0x3412
+  # 0x5678ABCD_u32.byte_swap # => 0xCDAB7856
+  # ```
+  def byte_swap : self
+    Intrinsics.bswap32(self)
+  end
+
   # Returns the number of leading `0`-bits.
   def leading_zeros_count
     Intrinsics.countleading32(self, false)
@@ -1510,6 +1614,19 @@ struct UInt64
 
   def popcount : Int64
     Intrinsics.popcount64(self)
+  end
+
+  # Swaps the bytes of `self`; a little-endian value becomes a big-endian value,
+  # and vice-versa. The bit order within each byte is unchanged.
+  #
+  # Has no effect on 8-bit integers.
+  #
+  # ```
+  # 0x1234_u16.byte_swap     # => 0x3412
+  # 0x5678ABCD_u32.byte_swap # => 0xCDAB7856
+  # ```
+  def byte_swap : self
+    Intrinsics.bswap64(self)
   end
 
   # Returns the number of leading `0`-bits.
@@ -1593,6 +1710,19 @@ struct UInt128
 
   def popcount
     Intrinsics.popcount128(self)
+  end
+
+  # Swaps the bytes of `self`; a little-endian value becomes a big-endian value,
+  # and vice-versa. The bit order within each byte is unchanged.
+  #
+  # Has no effect on 8-bit integers.
+  #
+  # ```
+  # 0x1234_u16.byte_swap     # => 0x3412
+  # 0x5678ABCD_u32.byte_swap # => 0xCDAB7856
+  # ```
+  def byte_swap : self
+    Intrinsics.bswap128(self)
   end
 
   # Returns the number of leading `0`-bits.

--- a/src/intrinsics.cr
+++ b/src/intrinsics.cr
@@ -58,11 +58,17 @@ lib LibIntrinsics
   {% if flag?(:interpreted) %} @[Primitive(:interpreter_intrinsics_bitreverse16)] {% end %}
   fun bitreverse16 = "llvm.bitreverse.i16"(id : UInt16) : UInt16
 
+  {% if flag?(:interpreted) %} @[Primitive(:interpreter_intrinsics_bswap16)] {% end %}
+  fun bswap16 = "llvm.bswap.i16"(id : UInt16) : UInt16
+
   {% if flag?(:interpreted) %} @[Primitive(:interpreter_intrinsics_bswap32)] {% end %}
   fun bswap32 = "llvm.bswap.i32"(id : UInt32) : UInt32
 
-  {% if flag?(:interpreted) %} @[Primitive(:interpreter_intrinsics_bswap16)] {% end %}
-  fun bswap16 = "llvm.bswap.i16"(id : UInt16) : UInt16
+  {% if flag?(:interpreted) %} @[Primitive(:interpreter_intrinsics_bswap64)] {% end %}
+  fun bswap64 = "llvm.bswap.i64"(id : UInt64) : UInt64
+
+  {% if flag?(:interpreted) %} @[Primitive(:interpreter_intrinsics_bswap128)] {% end %}
+  fun bswap128 = "llvm.bswap.i128"(id : UInt128) : UInt128
 
   {% if flag?(:interpreted) %} @[Primitive(:interpreter_intrinsics_popcount8)] {% end %}
   fun popcount8 = "llvm.ctpop.i8"(src : Int8) : Int8
@@ -208,12 +214,20 @@ module Intrinsics
     LibIntrinsics.bitreverse16(id)
   end
 
+  def self.bswap16(id) : UInt16
+    LibIntrinsics.bswap16(id)
+  end
+
   def self.bswap32(id) : UInt32
     LibIntrinsics.bswap32(id)
   end
 
-  def self.bswap16(id)
-    LibIntrinsics.bswap16(id)
+  def self.bswap64(id) : UInt64
+    LibIntrinsics.bswap64(id)
+  end
+
+  def self.bswap128(id) : UInt128
+    LibIntrinsics.bswap128(id)
   end
 
   def self.popcount8(src) : Int8

--- a/src/intrinsics.cr
+++ b/src/intrinsics.cr
@@ -49,14 +49,20 @@ lib LibIntrinsics
   {% if flag?(:interpreted) %} @[Primitive(:interpreter_intrinsics_read_cycle_counter)] {% end %}
   fun read_cycle_counter = "llvm.readcyclecounter" : UInt64
 
-  {% if flag?(:interpreted) %} @[Primitive(:interpreter_intrinsics_bitreverse64)] {% end %}
-  fun bitreverse64 = "llvm.bitreverse.i64"(id : UInt64) : UInt64
+  {% if flag?(:interpreted) %} @[Primitive(:interpreter_intrinsics_bitreverse8)] {% end %}
+  fun bitreverse8 = "llvm.bitreverse.i8"(id : UInt8) : UInt8
+
+  {% if flag?(:interpreted) %} @[Primitive(:interpreter_intrinsics_bitreverse16)] {% end %}
+  fun bitreverse16 = "llvm.bitreverse.i16"(id : UInt16) : UInt16
 
   {% if flag?(:interpreted) %} @[Primitive(:interpreter_intrinsics_bitreverse32)] {% end %}
   fun bitreverse32 = "llvm.bitreverse.i32"(id : UInt32) : UInt32
 
-  {% if flag?(:interpreted) %} @[Primitive(:interpreter_intrinsics_bitreverse16)] {% end %}
-  fun bitreverse16 = "llvm.bitreverse.i16"(id : UInt16) : UInt16
+  {% if flag?(:interpreted) %} @[Primitive(:interpreter_intrinsics_bitreverse64)] {% end %}
+  fun bitreverse64 = "llvm.bitreverse.i64"(id : UInt64) : UInt64
+
+  {% if flag?(:interpreted) %} @[Primitive(:interpreter_intrinsics_bitreverse128)] {% end %}
+  fun bitreverse128 = "llvm.bitreverse.i128"(id : UInt128) : UInt128
 
   {% if flag?(:interpreted) %} @[Primitive(:interpreter_intrinsics_bswap16)] {% end %}
   fun bswap16 = "llvm.bswap.i16"(id : UInt16) : UInt16
@@ -202,16 +208,24 @@ module Intrinsics
     LibIntrinsics.read_cycle_counter
   end
 
-  def self.bitreverse64(id) : UInt64
-    LibIntrinsics.bitreverse64(id)
+  def self.bitreverse8(id) : UInt8
+    LibIntrinsics.bitreverse8(id)
+  end
+
+  def self.bitreverse16(id) : UInt16
+    LibIntrinsics.bitreverse16(id)
   end
 
   def self.bitreverse32(id) : UInt32
     LibIntrinsics.bitreverse32(id)
   end
 
-  def self.bitreverse16(id) : UInt16
-    LibIntrinsics.bitreverse16(id)
+  def self.bitreverse64(id) : UInt64
+    LibIntrinsics.bitreverse64(id)
+  end
+
+  def self.bitreverse128(id) : UInt128
+    LibIntrinsics.bitreverse128(id)
   end
 
   def self.bswap16(id) : UInt16

--- a/src/socket/address.cr
+++ b/src/socket/address.cr
@@ -147,7 +147,7 @@ class Socket
       @addr = sockaddr.value.sin6_addr
       @port =
         {% if flag?(:dragonfly) %}
-          Intrinsics.bswap16(sockaddr.value.sin6_port).to_i
+          sockaddr.value.sin6_port.byte_swap.to_i
         {% else %}
           LibC.ntohs(sockaddr.value.sin6_port).to_i
         {% end %}
@@ -158,7 +158,7 @@ class Socket
       @addr = sockaddr.value.sin_addr
       @port =
         {% if flag?(:dragonfly) %}
-          Intrinsics.bswap16(sockaddr.value.sin_port).to_i
+          sockaddr.value.sin_port.byte_swap.to_i
         {% else %}
           LibC.ntohs(sockaddr.value.sin_port).to_i
         {% end %}
@@ -305,7 +305,7 @@ class Socket
       sockaddr = Pointer(LibC::SockaddrIn6).malloc
       sockaddr.value.sin6_family = family
       {% if flag?(:dragonfly) %}
-        sockaddr.value.sin6_port = Intrinsics.bswap16(port)
+        sockaddr.value.sin6_port = port.byte_swap
       {% else %}
         sockaddr.value.sin6_port = LibC.htons(port)
       {% end %}
@@ -317,7 +317,7 @@ class Socket
       sockaddr = Pointer(LibC::SockaddrIn).malloc
       sockaddr.value.sin_family = family
       {% if flag?(:dragonfly) %}
-        sockaddr.value.sin_port = Intrinsics.bswap16(port)
+        sockaddr.value.sin_port = port.byte_swap
       {% else %}
         sockaddr.value.sin_port = LibC.htons(port)
       {% end %}


### PR DESCRIPTION
Resolves #12828.

The standard library uses these new methods immediately; this shouldn't break the interpreter in 1.6 because no new primitives are used. `IO::ByteFormat` might also leverage `#byte_swap`, but that must wait until after 1.7 is released so as not to break interpreted code.