### PR TITLE
Fix Number comparison operator docs

### DIFF
--- a/src/number.cr
+++ b/src/number.cr
@@ -195,7 +195,7 @@ struct Number
   # Returns:
   # - `-1` if `self` is less than *other*
   # - `0` if `self` is equal to *other*
-  # - `-1` if `self` is greater than *other*
+  # - `1` if `self` is greater than *other*
   # - `nil` if `self` is `NaN` or *other* is `NaN`, because `NaN` values are not comparable
   def <=>(other) : Int32?
     # NaN can't be compared to other numbers


### PR DESCRIPTION
I noticed the [docs for `<=>` method](https://crystal-lang.org/api/1.6.2/Number.html#%3C%3D%3E%28other%29%3AInt32%3F-instance-method) mentioned the operator returns `-1` in scenarios `self > other` and `self < other`. Hope this fix is right 🙂 