### PR TITLE
Fix: Unwrap nested errors in error handler for `Crystal::Error`

### DIFF
--- a/src/compiler/crystal/command.cr
+++ b/src/compiler/crystal/command.cr
@@ -141,6 +141,14 @@ class Crystal::Command
   rescue ex : Crystal::Error
     report_warnings
 
+    # This unwraps nested errors which could be caused by `require` which wraps
+    # errors in order to trace the require path. The causes are listed similarly
+    # to `#inspect_with_backtrace` but without the backtrace.
+    while cause = ex.cause
+      error ex.message, exit_code: nil
+      ex = cause
+    end
+
     error ex.message
   rescue ex : OptionParser::Exception
     error ex.message


### PR DESCRIPTION
This addresses number 2. of #12874 to make sure information about the original error is not being hidden.

```console
$ echo 'require "bar"' > foo.cr
$ echo '{% `filedoesnotexist` %}' > bar.cr
$ crystal build foo.cr
Error: while requiring "./bar"
$ bin\crystal build foo.cr
Error: while requiring "./bar"
Error: Error executing process: 'filedoesnotexist': The system cannot find the file specified.
```

This is a very simple implementation and probably not the best finished solution that we could find. But it does the job and it enables a basic requirement. Without this change, unexpected errors (such as the `File::NotFoundError` when a system command fails on Windows, #12874) are basically impossible to debug.