### PR TITLE
Update distribution-scripts

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,7 @@ parameters:
   distribution-scripts-version:
     description: "Git ref for version of https://github.com/crystal-lang/distribution-scripts/"
     type: string
-    default: "f567925d4d36be64b7e211d0c166af9bdd92c75f"
+    default: "d8c44c0a2c977bfb90363923047f2c64cef3bf8e"
   previous_crystal_base_url:
     description: "Prefix for URLs to Crystal bootstrap compiler"
     type: string


### PR DESCRIPTION
Updates `distribution-scripts` dependency to https://github.com/crystal-lang/distribution-scripts/commit/d8c44c0a2c977bfb90363923047f2c64cef3bf8e

This includes the following changes:

* crystal-lang/distribution-scripts#214
* crystal-lang/distribution-scripts#210
* crystal-lang/distribution-scripts#205
* crystal-lang/distribution-scripts#202