### PR TITLE
Fix error handling in macro system method when execution fails

### DIFF
--- a/spec/compiler/macro/macro_methods_spec.cr
+++ b/spec/compiler/macro/macro_methods_spec.cr
@@ -3208,13 +3208,7 @@ module Crystal
 
   describe ".system" do
     it "command does not exist" do
-      # FIXME: This inconsistency between Windows and POSIX is tracked in #12873
-      expect_raises(
-        {{ flag?(:win32) ? File::NotFoundError : Crystal::TypeException }},
-        {{ flag?(:win32) ? "Error executing process: 'commanddoesnotexist'" : "error executing command: commanddoesnotexist" }}
-      ) do
-        semantic %({{ `commanddoesnotexist` }})
-      end
+      assert_error %({{ `commanddoesnotexist` }}), "error executing command: commanddoesnotexist"
     end
 
     it "successful command" do

--- a/src/compiler/crystal/macros/methods.cr
+++ b/src/compiler/crystal/macros/methods.cr
@@ -232,7 +232,14 @@ module Crystal
       end
       cmd = cmd.join " "
 
-      result = `#{cmd}`
+      begin
+        result = `#{cmd}`
+      rescue exc
+        # Taking the os_error message to avoid duplicating the "error executing process: "
+        # prefix of the error message and ensure uniqueness between all error messages.
+        node.raise "error executing command: #{cmd}: #{exc.os_error.try(&.message) || exc.message}"
+      end
+
       if $?.success?
         @last = MacroId.new(result)
       elsif result.empty?

--- a/src/compiler/crystal/macros/methods.cr
+++ b/src/compiler/crystal/macros/methods.cr
@@ -234,10 +234,12 @@ module Crystal
 
       begin
         result = `#{cmd}`
-      rescue exc
+      rescue exc : File::Error | IO::Error
         # Taking the os_error message to avoid duplicating the "error executing process: "
         # prefix of the error message and ensure uniqueness between all error messages.
         node.raise "error executing command: #{cmd}: #{exc.os_error.try(&.message) || exc.message}"
+      rescue exc
+        node.raise "error executing command: #{cmd}: #{exc.message}"
       end
 
       if $?.success?


### PR DESCRIPTION
`Process.run` raises on Windows when the executable is not found (#12873). The error was not properly handled in the implementation of the `system` macro method which resulted in bubbling up to the global error handler and a reduced developer experience (#12874).
This patch rescues any errors from `Process.run` and raises a `Crystal::CodeError` instead which is then properly handled in the compiler and associated with the specific code location.