### PR TITLE
Add error handling to compiler when linker is unavailable

### DIFF
--- a/src/compiler/crystal/compiler.cr
+++ b/src/compiler/crystal/compiler.cr
@@ -597,12 +597,7 @@ module Crystal
       begin
         Process.run(command, args, shell: true,
           input: Process::Redirect::Close, output: Process::Redirect::Inherit, error: Process::Redirect::Pipe) do |process|
-          first_line = true
           process.error.each_line(chomp: false) do |line|
-            # Skip error output from shell if linker command was not found
-            next if first_line && !verbose? && line.matches?(/^--: 1: .*: not found$/)
-            first_line = false
-
             hint_string = colorize("(this usually means you need to install the development package for lib\\1)").yellow.bold
             line = line.gsub(/cannot find -l(\S+)\b/, "cannot find -l\\1 #{hint_string}")
             line = line.gsub(/unable to find library -l(\S+)\b/, "unable to find library -l\\1 #{hint_string}")

--- a/src/compiler/crystal/compiler.cr
+++ b/src/compiler/crystal/compiler.cr
@@ -591,7 +591,9 @@ module Crystal
     end
 
     private def run_linker(command, args)
-      process_wrapper(command, args) do |command, args|
+      print_command(command, args) if verbose?
+
+      begin
         Process.run(command, args, shell: true,
           input: Process::Redirect::Close, output: Process::Redirect::Inherit, error: Process::Redirect::Pipe) do |process|
           process.error.each_line(chomp: false) do |line|
@@ -604,13 +606,8 @@ module Crystal
         end
         $?
       end
-    end
 
-    private def process_wrapper(command, args = nil)
-      print_command(command, args) if verbose?
-
-      status = yield command, args
-
+      status = $?
       unless status.success?
         msg = status.normal_exit? ? "code: #{status.exit_code}" : "signal: #{status.exit_signal} (#{status.exit_signal.value})"
         code = status.normal_exit? ? status.exit_code : 1

--- a/src/compiler/crystal/compiler.cr
+++ b/src/compiler/crystal/compiler.cr
@@ -626,11 +626,12 @@ module Crystal
     end
 
     private def linker_not_found(exc_class, linker_name)
+      verbose_info = "\nRun with `--verbose` to print the full linker command." unless verbose?
       case exc_class
       when File::AccessDeniedError
-        error "Could not execute linker: `#{linker_name}`: Permission denied\nRun with `--verbose` to print the full linker command."
+        error "Could not execute linker: `#{linker_name}`: Permission denied#{verbose_info}"
       else
-        error "Could not execute linker: `#{linker_name}`: File not found\nRun with `--verbose` to print the full linker command."
+        error "Could not execute linker: `#{linker_name}`: File not found#{verbose_info}"
       end
     end
 

--- a/src/compiler/crystal/compiler.cr
+++ b/src/compiler/crystal/compiler.cr
@@ -315,7 +315,8 @@ module Crystal
         target_machine.emit_obj_to_file llvm_mod, object_name
       end
 
-      print_command(*linker_command(program, [object_name], output_filename, nil))
+      _, command, args = linker_command(program, [object_name], output_filename, nil)
+      print_command(command, args)
     end
 
     private def print_command(command, args)
@@ -376,15 +377,15 @@ module Crystal
           cmd = "#{cl} #{Process.quote_windows("@" + args_filename)}"
         end
 
-        {cmd, nil}
+        {cl, cmd, nil}
       elsif program.has_flag? "wasm32"
         link_flags = @link_flags || ""
-        { %(wasm-ld "${@}" -o #{Process.quote_posix(output_filename)} #{link_flags} -lc #{program.lib_flags}), object_names }
+        {"wasm-ld", %(wasm-ld "${@}" -o #{Process.quote_posix(output_filename)} #{link_flags} -lc #{program.lib_flags}), object_names}
       else
         link_flags = @link_flags || ""
         link_flags += " -rdynamic"
 
-        { %(#{CC} "${@}" -o #{Process.quote_posix(output_filename)} #{link_flags} #{program.lib_flags}), object_names }
+        {CC, %(#{CC} "${@}" -o #{Process.quote_posix(output_filename)} #{link_flags} #{program.lib_flags}), object_names}
       end
     end
 
@@ -590,7 +591,7 @@ module Crystal
       end
     end
 
-    private def run_linker(command, args)
+    private def run_linker(linker_name, command, args)
       print_command(command, args) if verbose?
 
       begin

--- a/src/compiler/crystal/compiler.cr
+++ b/src/compiler/crystal/compiler.cr
@@ -598,6 +598,7 @@ module Crystal
         Process.run(command, args, shell: true,
           input: Process::Redirect::Close, output: Process::Redirect::Inherit, error: Process::Redirect::Pipe) do |process|
           process.error.each_line(chomp: false) do |line|
+            next if line.matches?(/^--: 1: .*: not found$/)
             hint_string = colorize("(this usually means you need to install the development package for lib\\1)").yellow.bold
             line = line.gsub(/cannot find -l(\S+)\b/, "cannot find -l\\1 #{hint_string}")
             line = line.gsub(/unable to find library -l(\S+)\b/, "unable to find library -l\\1 #{hint_string}")

--- a/src/compiler/crystal/compiler.cr
+++ b/src/compiler/crystal/compiler.cr
@@ -597,8 +597,12 @@ module Crystal
       begin
         Process.run(command, args, shell: true,
           input: Process::Redirect::Close, output: Process::Redirect::Inherit, error: Process::Redirect::Pipe) do |process|
+          first_line = true
           process.error.each_line(chomp: false) do |line|
-            next if line.matches?(/^--: 1: .*: not found$/)
+            # Skip error output from shell if linker command was not found
+            next if first_line && !verbose? && line.matches?(/^--: 1: .*: not found$/)
+            first_line = false
+
             hint_string = colorize("(this usually means you need to install the development package for lib\\1)").yellow.bold
             line = line.gsub(/cannot find -l(\S+)\b/, "cannot find -l\\1 #{hint_string}")
             line = line.gsub(/unable to find library -l(\S+)\b/, "unable to find library -l\\1 #{hint_string}")


### PR DESCRIPTION
Fixes #12839

The first two commits are simply refactoring to drop the `process_wrapper` helper method which is unnecessary and only complicates control flow.

The third commit introduces a short name in `linker_command` which refers to the command itself without the additional autogenerated arguments (which can be quite a lot).
Alternatively, we could also use `parse_arguments` to extract the name from the final command. But the original value is already available anyway, and it's easy to just forward it.

The fourth commit then implements the actual error handling. Due to https://github.com/crystal-lang/crystal/issues/12873 it covers errors indicated by exceptions as well as exit status.