### PR TITLE
Rotate breached credentials in CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -428,7 +428,7 @@ jobs:
       - image: manastech/s3cmd:2.2-alpine
     environment:
       <<: *env
-      AWS_ACCESS_KEY_ID: AKIA2EEIIRCJCMOSW2XH
+      AWS_ACCESS_KEY_ID: AKIA2EEIIRCJDEDGK6MQ
     steps:
       - attach_workspace:
           at: /tmp/workspace


### PR DESCRIPTION
The rest of the secrets are defined in environment variables, so we only need to update this Access Key ID here.

See https://circleci.com/blog/january-4-2023-security-alert/