### PR TITLE
Fix formatter empty array literal with comment on extra line

### DIFF
--- a/spec/compiler/formatter/formatter_spec.cr
+++ b/spec/compiler/formatter/formatter_spec.cr
@@ -102,6 +102,8 @@ describe Crystal::Formatter do
   assert_format "Set{ # foo\n  1,\n}"
   assert_format "begin\n  array[\n    0 # Zero\n  ]\nend"
   assert_format "begin\n  array[\n    0, # Zero\n  ]\nend"
+  assert_format "[\n  # foo\n] of String"
+  assert_format "[\n# foo\n] of String", "[\n  # foo\n] of String"
 
   assert_format "{1, 2, 3}"
   assert_format "{ {1, 2, 3} }"

--- a/src/compiler/crystal/tools/formatter.cr
+++ b/src/compiler/crystal/tools/formatter.cr
@@ -821,7 +821,7 @@ module Crystal
         start_column = @indent + 2
 
         if elements.empty?
-          skip_space_or_newline
+          skip_space_or_newline(offset, last: true, at_least_one: true)
           write_token suffix
           return false
         end


### PR DESCRIPTION
Fixes #12841