### PR TITLE
Disallow empty exponents in number literals

### DIFF
--- a/spec/compiler/lexer/lexer_spec.cr
+++ b/spec/compiler/lexer/lexer_spec.cr
@@ -431,8 +431,13 @@ describe "Lexer" do
   assert_syntax_error ".42", ".1 style number literal is not supported, put 0 before dot"
   assert_syntax_error "-.42", ".1 style number literal is not supported, put 0 before dot"
 
-  assert_syntax_error "2e", "unexpected token: \"e\""
-  assert_syntax_error "2ef32", "unexpected token: \"ef32\""
+  assert_syntax_error "2e", "invalid decimal number exponent"
+  assert_syntax_error "2e+", "invalid decimal number exponent"
+  assert_syntax_error "2ef32", "invalid decimal number exponent"
+  assert_syntax_error "2e+@foo", "invalid decimal number exponent"
+  assert_syntax_error "2e+e", "invalid decimal number exponent"
+  assert_syntax_error "2e+f32", "invalid decimal number exponent"
+  assert_syntax_error "2e+-2", "invalid decimal number exponent"
   assert_syntax_error "2e+_2", "unexpected '_' in number"
 
   # Test for #11671

--- a/src/compiler/crystal/syntax/lexer.cr
+++ b/src/compiler/crystal/syntax/lexer.cr
@@ -1232,6 +1232,7 @@ module Crystal
       has_underscores = false
       last_is_underscore = false
       pos_after_prefix = start
+      pos_before_exponent = nil
 
       # Consume prefix
       if current_char == '0'
@@ -1268,6 +1269,10 @@ module Crystal
           last_is_underscore = false
         end
 
+        if pos_before_exponent
+          raise("invalid decimal number exponent", @token, (current_pos - start)) unless current_pos > pos_before_exponent
+        end
+
         case current_char
         when '_'
           raise("consecutive underscores in numbers aren't allowed", @token, (current_pos - start)) if last_is_underscore
@@ -1282,7 +1287,7 @@ module Crystal
           is_e_notation = is_decimal = true
           next_char if peek_next_char.in?('+', '-')
           raise("unexpected '_' in number", @token, (current_pos - start)) if peek_next_char == '_'
-          break unless peek_next_char.in?('0'..'9')
+          pos_before_exponent = current_pos + 1
         when 'i', 'u', 'f'
           if current_char == 'f' && base != 10
             case base


### PR DESCRIPTION
When the lexer encounters `/e[+-]?/` in a number literal, it emits a token immediately if the next character isn't a decimal number. This allows some literals that most certainly shouldn't compile, where every `1.2e` below implicitly has an exponent of `0`:

```crystal
class A
  @foo = 0

  def foo
    1.2e+@foo # okay?
  end
end

e = 0
f32 = 0

A.new.foo
1.2e+-2  # okay?
1.2e+f32 # okay?
1.2e+e   # okay?
```

The formatter turns the above into the following, which no longer compiles:

```crystal
class A
  @foo = 0

  def foo
    1.2e + @foo # Error: unexpected token: "e"
  end
end

e = 0
f32 = 0

A.new.foo
1.2e + -2  # Error: unexpected token: "e"
1.2e + f32 # Error: unexpected token: "e"
1.2e + e   # Error: unexpected token: "e"
```

This PR turns those literals into syntax errors; `/e[+-]?/` must be followed by `/[0-9]+/` (and possibly underscores or a type suffix afterwards).

Discovered using [oprypin/crystal-fuzzing](https://github.com/oprypin/crystal-fuzzing)