### PR TITLE
Add `Spec::Item#all_tags`

### DIFF
--- a/spec/std/spec/context_spec.cr
+++ b/spec/std/spec/context_spec.cr
@@ -39,4 +39,19 @@ describe Spec::ExampleGroup do
       root.results_for(:fail).first.description.should eq("child grand_child oops")
     end
   end
+
+  describe "#all_tags" do
+    it "should include ancestor tags" do
+      root = FakeRootContext.new
+      child = Spec::ExampleGroup.new(root, "child", "f.cr", 1, 10, false, Set{"A"})
+      grand_child = Spec::ExampleGroup.new(child, "grand_child", "f.cr", 2, 9, false, Set{"B"})
+      example = Spec::Example.new(grand_child, "example", "f.cr", 3, 8, false, Set{"C"}, nil)
+      other_group = Spec::ExampleGroup.new(root, "other_group", "f.cr", 11, 20, false, nil)
+
+      child.all_tags.should eq(Set{"A"})
+      grand_child.all_tags.should eq(Set{"A", "B"})
+      example.all_tags.should eq(Set{"A", "B", "C"})
+      other_group.all_tags.should be_empty
+    end
+  end
 end

--- a/src/spec/item.cr
+++ b/src/spec/item.cr
@@ -25,5 +25,20 @@ module Spec
     private def initialize_tags(tags)
       @tags = tags.is_a?(String) ? Set{tags} : tags.try(&.to_set)
     end
+
+    # All tags, including tags inherited from ancestor example groups
+    def all_tags : Set(String)
+      result = tags.nil? ? Set(String).new : tags.not_nil!.dup
+      return result if parent.is_a?(RootContext)
+
+      ancestor = parent.as(ExampleGroup)
+      loop do
+        result.concat(ancestor.tags.not_nil!) unless ancestor.tags.nil?
+
+        return result if ancestor.parent.is_a?(RootContext)
+        ancestor = ancestor.parent.as(ExampleGroup)
+      end
+      result
+    end
   end
 end

--- a/src/spec/item.cr
+++ b/src/spec/item.cr
@@ -36,7 +36,6 @@ module Spec
         end
       end
       result
-      result
     end
   end
 end

--- a/src/spec/item.cr
+++ b/src/spec/item.cr
@@ -28,16 +28,14 @@ module Spec
 
     # All tags, including tags inherited from ancestor example groups
     def all_tags : Set(String)
-      result = tags.nil? ? Set(String).new : tags.not_nil!.dup
-      return result if parent.is_a?(RootContext)
-
-      ancestor = parent.as(ExampleGroup)
-      loop do
-        result.concat(ancestor.tags.not_nil!) unless ancestor.tags.nil?
-
-        return result if ancestor.parent.is_a?(RootContext)
-        ancestor = ancestor.parent.as(ExampleGroup)
+      result = tags.try(&.dup) || Set(String).new
+      ancestor = self
+      while ancestor = ancestor.parent.as?(ExampleGroup)
+        if tags = ancestor.tags
+          result.concat(tags)
+        end
       end
+      result
       result
     end
   end


### PR DESCRIPTION
As discussed with @straight-shoota on the [forum](https://forum.crystal-lang.org/t/spec-item-tags-could-we-support-recursive-parent-tag-lookups/5233), this adds an `#all_tags` method to `Spec::Item` (included by `Spec::Example` and `Spec::ExampleGroup`).

Currently, `Spec::Example#tags` only returns the tags defined at the `Spec::Example` leaf, directly on  the `it "...", tags: ["tag_directly_on_item"]`.

This PR adds an `#all_tags` method which additionally returns tags that are defined on any enclosing `Context`. 

This new leaf-up `#all_tags` matches the existing behavior of the `Spec::RootContext#filter_by_tags` method, which descends root-down into all child contexts and examples when it is looking for any tag matches.

Furthermore, it matches `rspec` behavior with [ancestor metadata](https://github.com/rspec/rspec-core/blob/main/lib/rspec/core/metadata.rb#L55) as is commonly used in the Rails world. In RSpec, this is often something like `RSpec.configure { |config| config.before(:each, type: :request) { ... } }`, and an example can be defined with multiple tag-like metadata like `describe "...", type: [:request, :system] { ... }`.

With this PR, it will be possible to write a spec helper such as:
```crystal
Spec.around_each do |example_procsy|
  clear_db = example_procsy.example.all_tags.includes?("clear_db")

  MyDbPool.clear_db_for_testing! if clear_db
  example_procsy.run
  MyDbPool.clear_db_for_testing! if clear_db
end
```

which covers an entire context of tests with a tag such as:
```crystal
describe MyClassThatRequiresDatabase, tags: ["clear_db"] do
  it "..." do
    # this test expects a clean database state, and may mutate database,
    # so we should clean the db before and after!
  end
end
```

In my use case, there are a few of my classes I'm testing which do require database access, and I want to use a clean database state for each example. However, cleaning the database is relatively slow, so I'd like to avoid wrapping all of my non-database Crystal specs with this operation.

### Future work?

Not included in the PR, but as an idea for possible future enhancement: the `Spec#around_each` method could itself accept a `tags` argument which could be used for matching. Then, my example above would simply become:

```crystal
Spec.around_each(tags: "clear_db") do |example_procsy|
  MyDbPool.clear_db_for_testing!
  example_procsy.run
  MyDbPool.clear_db_for_testing!
end
```

Requires lots of changes under the hood / not worth making part of this PR, IMHO. :sweat_smile: 

Also, the `Spec::Example` instance could be passed into the blocks for `before_each`, `after_each` hooks. Or allow params like `before_each(tags: ...)` for matching.

This PR `#all_keys`, plus `around_each`, allows emulating any of these above ideas, so they are only syntactic sugar. And it probably isn't worth much effort to sweeten the syntactic sugar of the very niche case of spec helpers :rofl: 