### PR TITLE
Fix: Interpreter `value_to_bool` for module, generic module and generic module metaclass

### DIFF
--- a/spec/compiler/interpreter/primitives_spec.cr
+++ b/spec/compiler/interpreter/primitives_spec.cr
@@ -812,5 +812,37 @@ describe Crystal::Repl::Interpreter do
         !a
         CRYSTAL
     end
+
+    it "interprets not for module (#12918)" do
+      interpret(<<-CRYSTAL).should eq(false)
+        module MyModule; end
+
+        class One
+          include MyModule
+        end
+
+        !One.new.as(MyModule)
+        CRYSTAL
+    end
+
+    it "interprets not for generic module" do
+      interpret(<<-CRYSTAL).should eq(false)
+        module MyModule(T); end
+
+        class One
+          include MyModule(Int32)
+        end
+
+        !One.new.as(MyModule(Int32))
+        CRYSTAL
+    end
+
+    it "interprets not for generic module metaclass" do
+      interpret(<<-CRYSTAL).should eq(false)
+        module MyModule(T); end
+
+        !MyModule(Int32)
+        CRYSTAL
+    end
   end
 end

--- a/spec/compiler/interpreter/primitives_spec.cr
+++ b/spec/compiler/interpreter/primitives_spec.cr
@@ -844,5 +844,13 @@ describe Crystal::Repl::Interpreter do
         !MyModule(Int32)
         CRYSTAL
     end
+
+    it "interprets not for generic class instance metaclass" do
+      interpret(<<-CRYSTAL).should eq(false)
+        class MyClass(T); end
+
+        !MyClass(Int32)
+        CRYSTAL
+    end
   end
 end

--- a/src/compiler/crystal/interpreter/to_bool.cr
+++ b/src/compiler/crystal/interpreter/to_bool.cr
@@ -33,7 +33,7 @@ class Crystal::Repl::Compiler
     union_to_bool aligned_sizeof_type(type), node: nil
   end
 
-  private def value_to_bool(node : ASTNode, type : NonGenericClassType | GenericClassInstanceType | VirtualType | MetaclassType | VirtualMetaclassType | ReferenceUnionType | IntegerType | CharType | SymbolType | FloatType | EnumType)
+  private def value_to_bool(node : ASTNode, type : NonGenericClassType | GenericClassInstanceType | VirtualType | MetaclassType | VirtualMetaclassType | ReferenceUnionType | IntegerType | CharType | SymbolType | FloatType | EnumType | NonGenericModuleType | GenericModuleInstanceType | GenericModuleInstanceMetaclassType)
     pop aligned_sizeof_type(type), node: nil
     put_true node: nil
   end

--- a/src/compiler/crystal/interpreter/to_bool.cr
+++ b/src/compiler/crystal/interpreter/to_bool.cr
@@ -33,7 +33,7 @@ class Crystal::Repl::Compiler
     union_to_bool aligned_sizeof_type(type), node: nil
   end
 
-  private def value_to_bool(node : ASTNode, type : NonGenericClassType | GenericClassInstanceType | VirtualType | MetaclassType | VirtualMetaclassType | ReferenceUnionType | IntegerType | CharType | SymbolType | FloatType | EnumType | NonGenericModuleType | GenericModuleInstanceType | GenericModuleInstanceMetaclassType)
+  private def value_to_bool(node : ASTNode, type : NonGenericClassType | GenericClassInstanceType | VirtualType | MetaclassType | VirtualMetaclassType | ReferenceUnionType | IntegerType | CharType | SymbolType | FloatType | EnumType | NonGenericModuleType | GenericModuleInstanceType | GenericModuleInstanceMetaclassType | GenericClassInstanceMetaclassType)
     pop aligned_sizeof_type(type), node: nil
     put_true node: nil
   end


### PR DESCRIPTION
Fixes #12918