### PR TITLE
Expose OAuth2::Client#get_access_token

### DIFF
--- a/spec/std/oauth2/client_spec.cr
+++ b/spec/std/oauth2/client_spec.cr
@@ -128,6 +128,31 @@ describe OAuth2::Client do
           token.access_token.should eq "access_token"
         end
       end
+
+      it "#get_access_token" do
+        handler = HTTP::Handler::HandlerProc.new do |context|
+          body = context.request.body.not_nil!.gets_to_end
+          dpop = context.request.headers.get?("DPoP")
+          response = {access_token: "access_token", body: body, dpop: dpop}
+          context.response.print response.to_json
+        end
+
+        run_handler(handler) do |http_client|
+          client = OAuth2::Client.new "127.0.0.1", "client_id", "client_secret", scheme: "http"
+          client.http_client = http_client
+
+          token = client.get_access_token(HTTP::Headers{"DPoP" => "a_DPoP_jwt_token"}) do |form|
+            form.add("redirect_uri", client.redirect_uri)
+            form.add("grant_type", "authorization_code")
+            form.add("code", "some_authorization_code")
+            form.add("code_verifier", "a_code_verifier")
+            form.add("nonce", "a_nonce")
+          end
+          token.extra.not_nil!["body"].should eq %("redirect_uri=&grant_type=authorization_code&code=some_authorization_code&code_verifier=a_code_verifier&nonce=a_nonce")
+          token.extra.not_nil!["dpop"].should eq %(["a_DPoP_jwt_token"])
+          token.access_token.should eq "access_token"
+        end
+      end
     end
     describe "using Request Body to pass credentials" do
       it "#get_access_token_using_authorization_code" do
@@ -194,6 +219,30 @@ describe OAuth2::Client do
 
           token = client.get_access_token_using_refresh_token(scope: "read_posts", refresh_token: "some_refresh_token")
           token.extra.not_nil!["body"].should eq %("client_id=client_id&client_secret=client_secret&grant_type=refresh_token&refresh_token=some_refresh_token&scope=read_posts")
+          token.access_token.should eq "access_token"
+        end
+      end
+
+      it "#get_access_token" do
+        handler = HTTP::Handler::HandlerProc.new do |context|
+          body = context.request.body.not_nil!.gets_to_end
+          dpop = context.request.headers.get?("DPoP")
+          response = {access_token: "access_token", body: body, dpop: dpop}
+          context.response.print response.to_json
+        end
+
+        run_handler(handler) do |http_client|
+          client = OAuth2::Client.new "127.0.0.1", "client_id", "client_secret", scheme: "http", auth_scheme: OAuth2::AuthScheme::RequestBody
+          client.http_client = http_client
+
+          token = client.get_access_token(HTTP::Headers{"DPoP" => "a_DPoP_jwt_token"}) do |form|
+            form.add("grant_type", "refresh_token")
+            form.add("refresh_token", "some_refresh_token")
+            form.add("scope", "read_posts")
+            form.add("nonce", "a_nonce")
+          end
+          token.extra.not_nil!["body"].should eq %("client_id=client_id&client_secret=client_secret&grant_type=refresh_token&refresh_token=some_refresh_token&scope=read_posts&nonce=a_nonce")
+          token.extra.not_nil!["dpop"].should eq %(["a_DPoP_jwt_token"])
           token.access_token.should eq "access_token"
         end
       end

--- a/src/oauth2/client.cr
+++ b/src/oauth2/client.cr
@@ -54,8 +54,16 @@
 # You can also use an `OAuth2::Session` to automatically refresh expired
 # tokens before each request.
 class OAuth2::Client
+  DEFAULT_HEADERS = HTTP::Headers{
+    "Accept"       => "application/json",
+    "Content-Type" => "application/x-www-form-urlencoded",
+  }
+
   # Sets the `HTTP::Client` to use with this client.
   setter http_client : HTTP::Client?
+
+  # Gets the redirect_uri
+  getter redirect_uri : String?
 
   # Returns the `HTTP::Client` to use with this client.
   #
@@ -159,12 +167,9 @@ class OAuth2::Client
     end
   end
 
-  private def get_access_token : AccessToken
-    headers = HTTP::Headers{
-      "Accept"       => "application/json",
-      "Content-Type" => "application/x-www-form-urlencoded",
-    }
-
+  # Gets an access token with custom headers and form fields
+  def get_access_token(headers : HTTP::Headers = HTTP::Headers.new, &block : URI::Params::Builder ->) : AccessToken
+    headers.merge!(DEFAULT_HEADERS)
     body = URI::Params.build do |form|
       case @auth_scheme
       when .request_body?

--- a/src/oauth2/client.cr
+++ b/src/oauth2/client.cr
@@ -113,13 +113,13 @@ class OAuth2::Client
     end
 
     uri.query = URI::Params.build do |form|
-      form.add "client_id", @client_id
-      form.add "redirect_uri", @redirect_uri
-      form.add "response_type", "code"
-      form.add "scope", scope unless scope.nil?
-      form.add "state", state unless state.nil?
+      form.add("client_id", @client_id)
+      form.add("redirect_uri", @redirect_uri)
+      form.add("response_type", "code")
+      form.add("scope", scope) unless scope.nil?
+      form.add("state", state) unless state.nil?
       uri.query_params.each do |key, value|
-        form.add key, value
+        form.add(key, value)
       end
       yield form
     end
@@ -163,7 +163,7 @@ class OAuth2::Client
     get_access_token do |form|
       form.add("grant_type", "refresh_token")
       form.add("refresh_token", refresh_token)
-      form.add "scope", scope unless scope.nil?
+      form.add("scope", scope) unless scope.nil?
     end
   end
 


### PR DESCRIPTION
Make OAuth2::Client#get_access_token a public method

So that one can pass custom headers and form params
