### PR TITLE
Escape filenames when running `crystal spec` with multiple files

### DIFF
--- a/src/compiler/crystal/command/spec.cr
+++ b/src/compiler/crystal/command/spec.cr
@@ -87,9 +87,9 @@ class Crystal::Command
 
     source_filename = File.expand_path("spec")
 
-    source = target_filenames.map { |filename|
-      %(require "./#{::Path[filename].relative_to(Dir.current).to_posix}")
-    }.join('\n')
+    source = target_filenames.join('\n') do |filename|
+      %(require "./#{::Path[filename].relative_to(Dir.current).to_posix.to_s.inspect_unquoted}")
+    end
     sources = [Compiler::Source.new(source_filename, source)]
 
     output_filename = Crystal.temp_executable "spec"


### PR DESCRIPTION
When `crystal spec` is run with multiple files, say `crystal spec spec/std/string` at the root of this repository, it creates a temporary source file with all the `require`s, then executes that source:

```crystal
require "./spec/std/string/grapheme_spec.cr"
require "./spec/std/string/grapheme_break_spec.cr"
require "./spec/std/string/utf16_spec.cr"
```

Those `require`s are currently not escaped. Escaping them allows `crystal spec` to pick up filenames that contain quotation marks, however unlikely, and also ensures one cannot inject arbitrary code into this temporary source.