### PR TITLE
Add `Tuple#to_static_array`

### DIFF
--- a/spec/std/tuple_spec.cr
+++ b/spec/std/tuple_spec.cr
@@ -351,5 +351,9 @@ describe "Tuple" do
     ary = Tuple.new.to_static_array
     ary.should be_a(StaticArray(NoReturn, 0))
     ary.size.should eq(0)
+
+    ary = Tuple(String | Int32).new(1).to_static_array
+    ary.should be_a(StaticArray(String | Int32, 1))
+    ary.should eq StaticArray[1.as(String | Int32)]
   end
 end

--- a/spec/std/tuple_spec.cr
+++ b/spec/std/tuple_spec.cr
@@ -341,4 +341,15 @@ describe "Tuple" do
     ary = Tuple.new.to_a
     ary.size.should eq(0)
   end
+
+  it "#to_static_array" do
+    ary = {1, 'a', true}.to_static_array
+    ary.should be_a(StaticArray(Int32 | Char | Bool, 3))
+    ary.should eq(StaticArray[1, 'a', true])
+    ary.size.should eq(3)
+
+    ary = Tuple.new.to_static_array
+    ary.should be_a(StaticArray(NoReturn, 0))
+    ary.size.should eq(0)
+  end
 end

--- a/src/tuple.cr
+++ b/src/tuple.cr
@@ -548,6 +548,24 @@ struct Tuple
     end
   end
 
+  # Returns a `StaticArray` with the same elements.
+  #
+  # The element type is `Union(*T)`.
+  #
+  # ```
+  # {1, 'a', true}.to_static_array # => StaticArray[1, 'a', true]
+  # ```
+  @[AlwaysInline]
+  def to_static_array : StaticArray
+    {% begin %}
+      ary = uninitialized StaticArray(Union(*T), {{ T.size }})
+      each_with_index do |value, i|
+        ary.to_unsafe[i] = value
+      end
+      ary
+    {% end %}
+  end
+
   # Appends a string representation of this tuple to the given `IO`.
   #
   # ```


### PR DESCRIPTION
Adds a method to convert a `Tuple` into an equivalent `StaticArray`. 
The memory representation is similar but not necessarily identical, so this can't be a simple cast. `StaticArray` must contain type information which is already encoded by the position in a `Tuple`.

This conversion removes information, so it's rarely useful. One use case is for sorting, which just doesn't make sense for a `Tuple`. But turning it into a `StaticArray`, it can be sorted. A use case for that in stdlib is `Channel.select_impl` (#12756).
I think this method should be in stdlib because it can be generally useful, even though not very common.

