### PR TITLE
[CI] Remove `verbose=1` in `test_llvm`

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -83,7 +83,7 @@ jobs:
         run: mkdir -p llvm && curl -L ${{ matrix.llvm_url }} > llvm.tar.xz && tar x --xz -C llvm --strip-components=1 -f llvm.tar.xz
 
       - name: Test
-        run: bin/ci with_build_env "make clean deps compiler_spec crystal std_spec LLVM_CONFIG=\$(pwd)/llvm/bin/llvm-config threads=1 verbose=1 junit_output=.junit/spec.xml"
+        run: bin/ci with_build_env "make clean deps compiler_spec crystal std_spec LLVM_CONFIG=\$(pwd)/llvm/bin/llvm-config threads=1 junit_output=.junit/spec.xml"
 
   x86_64-gnu-test-preview_mt:
     env:


### PR DESCRIPTION
This seems to be a debugging artifact. There's way too much output to be useful for anything.