### PR TITLE
Spec: Add `--color` option to spec runner

### DIFF
--- a/spec/std/spec_spec.cr
+++ b/spec/std/spec_spec.cr
@@ -133,19 +133,3 @@ describe "Spec matchers" do
     end
   end
 end
-
-describe "Spec" do
-  describe "use_colors?" do
-    it "returns if output is colored or not" do
-      saved = Spec.use_colors?
-      begin
-        Spec.use_colors = false
-        Spec.use_colors?.should be_false
-        Spec.use_colors = true
-        Spec.use_colors?.should be_true
-      ensure
-        Spec.use_colors = saved
-      end
-    end
-  end
-end

--- a/src/spec/cli.cr
+++ b/src/spec/cli.cr
@@ -5,9 +5,6 @@ require "option_parser"
 
 module Spec
   # :nodoc:
-  class_property? use_colors = true
-
-  # :nodoc:
   class_property pattern : Regex?
 
   # :nodoc:
@@ -110,7 +107,7 @@ module Spec
         configure_formatter("tap")
       end
       opts.on("--no-color", "Disable colored output") do
-        Spec.use_colors = false
+        Colorize.enabled = false
       end
       opts.unknown_args do |args|
       end

--- a/src/spec/cli.cr
+++ b/src/spec/cli.cr
@@ -106,7 +106,10 @@ module Spec
       opts.on("--tap", "Generate TAP output (Test Anything Protocol)") do
         configure_formatter("tap")
       end
-      opts.on("--no-color", "Disable colored output") do
+      opts.on("--color", "Enabled ANSI colored output") do
+        Colorize.enabled = true
+      end
+      opts.on("--no-color", "Disable ANSI colored output") do
         Colorize.enabled = false
       end
       opts.unknown_args do |args|

--- a/src/spec/context.cr
+++ b/src/spec/context.cr
@@ -233,10 +233,7 @@ module Spec
         top_n.each do |res|
           puts "  #{res.description}"
           res_elapsed = res.elapsed.not_nil!.total_seconds.humanize
-          if Spec.use_colors?
-            res_elapsed = res_elapsed.colorize.bold
-          end
-          puts "    #{res_elapsed} seconds #{Spec.relative_file(res.file)}:#{res.line}"
+          puts "    #{res_elapsed.colorize.bold} seconds #{Spec.relative_file(res.file)}:#{res.line}"
         end
       end
 

--- a/src/spec/dsl.cr
+++ b/src/spec/dsl.cr
@@ -31,20 +31,12 @@ module Spec
 
   # :nodoc:
   def self.color(str, status : Status)
-    if use_colors?
-      str.colorize(STATUS_COLORS[status])
-    else
-      str
-    end
+    str.colorize(STATUS_COLORS[status])
   end
 
   # :nodoc:
   def self.color(str, kind : InfoKind)
-    if use_colors?
-      str.colorize(INFO_COLORS[kind])
-    else
-      str
-    end
+    str.colorize(INFO_COLORS[kind])
   end
 
   # :nodoc:


### PR DESCRIPTION
This includes a minor refactor to use `Colorize.enabled` as configuration storage instead of a separate `Spec.use_colors` which simplifies the code a bit.