### PR TITLE
Internalize `Process.fork`

### DIFF
--- a/src/compiler/crystal/compiler.cr
+++ b/src/compiler/crystal/compiler.cr
@@ -489,7 +489,7 @@ module Crystal
                 end
               end
             end
-            codegen_process.wait
+            Process.new(codegen_process).wait
 
             if pipe_w = pw
               pipe_w.close

--- a/src/compiler/crystal/compiler.cr
+++ b/src/compiler/crystal/compiler.cr
@@ -453,7 +453,9 @@ module Crystal
         return all_reused
       end
 
-      {% if flag?(:preview_mt) %}
+      {% if !Crystal::System::Process.class.has_method?("fork") %}
+        raise "Cannot fork compiler. `Crystal::System::Process.fork` is not implemented on this system."
+      {% elsif flag?(:preview_mt) %}
         raise "Cannot fork compiler in multithread mode"
       {% else %}
         jobs_count = 0
@@ -477,7 +479,7 @@ module Crystal
               end
             end
 
-            codegen_process = Process.fork do
+            codegen_process = Crystal::System::Process.fork do
               pipe_w = pw
               slice.each do |unit|
                 unit.compile

--- a/src/crystal/system/process.cr
+++ b/src/crystal/system/process.cr
@@ -50,6 +50,7 @@ struct Crystal::System::Process
 
   # Duplicates the current process.
   # def self.fork : ProcessInformation
+  # def self.fork(&)
 
   # Launches a child process with the command + args.
   # def self.spawn(command_args : Args, env : Env?, clear_env : Bool, input : Stdio, output : Stdio, error : Stdio, chdir : Path | String?) : ProcessInformation

--- a/src/crystal/system/unix/process.cr
+++ b/src/crystal/system/unix/process.cr
@@ -120,21 +120,21 @@ struct Crystal::System::Process
   # Returns a `Process` representing the new child process in the current process
   # and `nil` inside the new child process.
   def self.fork(&)
-    {% raise("Process fork is unsupported with multithread mode") if flag?(:preview_mt) %}
+    {% raise("Process fork is unsupported with multithreaded mode") if flag?(:preview_mt) %}
 
     if pid = fork
-      pid
-    else
-      begin
-        yield
-        LibC._exit 0
-      rescue ex
-        ex.inspect_with_backtrace STDERR
-        STDERR.flush
-        LibC._exit 1
-      ensure
-        LibC._exit 254 # not reached
-      end
+      return pid
+    end
+
+    begin
+      yield
+      LibC._exit 0
+    rescue ex
+      ex.inspect_with_backtrace STDERR
+      STDERR.flush
+      LibC._exit 1
+    ensure
+      LibC._exit 254 # not reached
     end
   end
 

--- a/src/crystal/system/unix/process.cr
+++ b/src/crystal/system/unix/process.cr
@@ -116,6 +116,28 @@ struct Crystal::System::Process
     pid
   end
 
+  # Duplicates the current process.
+  # Returns a `Process` representing the new child process in the current process
+  # and `nil` inside the new child process.
+  def self.fork(&)
+    {% raise("Process fork is unsupported with multithread mode") if flag?(:preview_mt) %}
+
+    if pid = fork
+      pid
+    else
+      begin
+        yield
+        LibC._exit 0
+      rescue ex
+        ex.inspect_with_backtrace STDERR
+        STDERR.flush
+        LibC._exit 1
+      ensure
+        LibC._exit 254 # not reached
+      end
+    end
+  end
+
   def self.spawn(command_args, env, clear_env, input, output, error, chdir)
     reader_pipe, writer_pipe = IO.pipe
 

--- a/src/crystal/system/wasi/process.cr
+++ b/src/crystal/system/wasi/process.cr
@@ -60,6 +60,10 @@ struct Crystal::System::Process
     raise NotImplementedError.new("Process.fork")
   end
 
+  def self.fork(&)
+    raise NotImplementedError.new("Process.fork")
+  end
+
   def self.spawn(command_args, env, clear_env, input, output, error, chdir)
     raise NotImplementedError.new("Process.spawn")
   end

--- a/src/crystal/system/win32/process.cr
+++ b/src/crystal/system/win32/process.cr
@@ -100,6 +100,10 @@ struct Crystal::System::Process
     raise NotImplementedError.new("Process.fork")
   end
 
+  def self.fork(&)
+    raise NotImplementedError.new("Process.fork")
+  end
+
   private def self.handle_from_io(io : IO::FileDescriptor, parent_io)
     ret = LibC._get_osfhandle(io.fd)
     raise RuntimeError.from_winerror("_get_osfhandle") if ret == -1

--- a/src/process.cr
+++ b/src/process.cr
@@ -273,7 +273,8 @@ class Process
     end
   end
 
-  private def initialize(pid : LibC::PidT)
+  # :nodoc:
+  def initialize(pid : LibC::PidT)
     @process_info = Crystal::System::Process.new(pid)
   end
 

--- a/src/process.cr
+++ b/src/process.cr
@@ -65,21 +65,8 @@ class Process
   # returns a `Process` representing the new child process.
   #
   # Available only on Unix-like operating systems.
-  def self.fork : Process
-    if process = fork
-      process
-    else
-      begin
-        yield
-        LibC._exit 0
-      rescue ex
-        ex.inspect_with_backtrace STDERR
-        STDERR.flush
-        LibC._exit 1
-      ensure
-        LibC._exit 254 # not reached
-      end
-    end
+  def self.fork(&) : Process
+    new Crystal::System::Process.fork { yield }
   end
 
   # :nodoc:

--- a/src/process.cr
+++ b/src/process.cr
@@ -65,6 +65,7 @@ class Process
   # returns a `Process` representing the new child process.
   #
   # Available only on Unix-like operating systems.
+  @[Deprecated("Fork is no longer supported.")]
   def self.fork(&) : Process
     new Crystal::System::Process.fork { yield }
   end
@@ -76,6 +77,7 @@ class Process
   # and `nil` inside the new child process.
   #
   # Available only on Unix-like operating systems.
+  @[Deprecated("Fork is no longer supported.")]
   def self.fork : Process?
     {% raise("Process fork is unsupported with multithread mode") if flag?(:preview_mt) %}
 


### PR DESCRIPTION
This is a continuation of https://github.com/crystal-lang/crystal/pull/9136 which changed `Process.fork` to `:nodoc:`. But it still *exists* in the `Process` namespace, even if it doesn't show up in the docs.
`fork` is a system-specific implementation detail and this patch moves it into the `Crystal::System` namespace.

If you *really*, *really* want to use `fork` despite being dangerous and non-portable, you can *technically* still continue to use `Crystal::System::Process.fork`. But then it's at least clearly shows that it's not part of any public API.

Resolves https://github.com/crystal-lang/crystal/issues/6421

Ref https://forum.crystal-lang.org/t/deprecate-top-level-fork/5130/7