### PR TITLE
Validate `URI` path

### DIFF
--- a/spec/std/uri_spec.cr
+++ b/spec/std/uri_spec.cr
@@ -164,7 +164,7 @@ describe "URI" do
 
   describe "#hostname" do
     it { URI.new("http", "www.example.com", path: "/foo").hostname.should eq("www.example.com") }
-    it { URI.new("http", "[::1]", path: "foo").hostname.should eq("::1") }
+    it { URI.new("http", "[::1]", path: "/foo").hostname.should eq("::1") }
     it { URI.new(path: "/foo").hostname.should be_nil }
   end
 
@@ -192,7 +192,7 @@ describe "URI" do
     it { URI.new(scheme: "scheme", path: "opaque").request_target.should eq "opaque" }
     it { URI.new(scheme: "scheme", query: "foo=bar&foo=baz").request_target.should eq "?foo=bar&foo=baz" }
 
-    it { URI.new(path: "//foo").request_target.should eq("//foo") }
+    it { URI.new(path: "/.//foo").request_target.should eq("/.//foo") }
     it { URI.new(path: "/foo", query: "q=1").request_target.should eq("/foo?q=1") }
     it { URI.new(path: "/", query: "q=1").request_target.should eq("/?q=1") }
     it { URI.new(query: "q=1").request_target.should eq("/?q=1") }
@@ -304,8 +304,8 @@ describe "URI" do
     it { assert_prints URI.new("mailto", path: "foo@example.com").to_s, "mailto:foo@example.com" }
     it { assert_prints URI.new("file", path: "/foo.html").to_s, "file:/foo.html" }
     it { assert_prints URI.new("file", path: "foo.html").to_s, "file:foo.html" }
-    it { assert_prints URI.new("file", host: "host", path: "foo.html").to_s, "file://host/foo.html" }
-    it { assert_prints URI.new(path: "//foo").to_s, "/.//foo" }
+    it { assert_prints URI.new("file", host: "host", path: "/foo.html").to_s, "file://host/foo.html" }
+    it { assert_prints URI.new(path: "/.//foo").to_s, "/.//foo" }
     it { assert_prints URI.new(host: "host", path: "//foo").to_s, "//host//foo" }
 
     it "preserves non-default port" do

--- a/src/uri.cr
+++ b/src/uri.cr
@@ -97,7 +97,9 @@ class URI
   getter host : String?
 
   # Sets the host component of the URI.
-  setter host : String?
+  def host=(@host : String?)
+    validate_path
+  end
 
   # Returns the port component of the URI.
   #
@@ -109,7 +111,9 @@ class URI
   getter port : Int32?
 
   # Sets the port component of the URI.
-  setter port : Int32?
+  def port=(@port : Int32?)
+    validate_path
+  end
 
   # Returns the path component of the URI.
   #
@@ -121,7 +125,9 @@ class URI
   getter path : String
 
   # Sets the path component of the URI.
-  setter path : String
+  def path=(@path : String)
+    validate_path
+  end
 
   # Returns the query component of the URI.
   #
@@ -175,6 +181,23 @@ class URI
 
   def initialize(@scheme = nil, @host = nil, @port = nil, @path = "", query : String | Params | Nil = nil, @user = nil, @password = nil, @fragment = nil)
     @query = query.try(&.to_s)
+    validate_path
+  end
+
+  private def validate_path
+    if has_authority?
+      unless path.empty? || path.starts_with?("/")
+        raise ArgumentError.new("Invalid URI component: when there is an authority component, path must not start with a slash (`/`)")
+      end
+    else
+      if path.starts_with?("//")
+        raise ArgumentError.new("Invalid URI component: when there is no authority component, path may not start with a double slash (`//`)")
+      end
+    end
+  end
+
+  private def has_authority?
+    @host || @user || @port
   end
 
   # Returns the host part of the URI and unwrap brackets for IPv6 addresses.
@@ -331,17 +354,9 @@ class URI
       io << ':'
     end
 
-    has_authority = @host || @user || @port
-    io << "//" if has_authority
+    io << "//" if has_authority?
     authority(io)
 
-    if has_authority
-      if !@path.empty? && !@path.starts_with?('/')
-        io << '/'
-      end
-    elsif @path.starts_with?("//")
-      io << "/."
-    end
     io << @path
 
     if query
@@ -413,10 +428,6 @@ class URI
     target.scheme = scheme
 
     unless target.host || target.user
-      target.host = host
-      target.port = port
-      target.user = user
-      target.password = password
       if target.path.empty?
         target.path = remove_dot_segments(path)
         target.query ||= query
@@ -427,6 +438,10 @@ class URI
         end
         target.path = resolve_path(target.path, base: base)
       end
+      target.host = host
+      target.port = port
+      target.user = user
+      target.password = password
     end
 
     target


### PR DESCRIPTION
Resolves #12798

Validates `URI#path` and raises an error if it's invalid.

* If an `authority` (`host`, `user`, `port`) is given, `path` *must* begin with a slash (`/`).
* If no `authority` is given, `path` must not begin with a double slash (`//`).

This is a **breaking change** in behaviour. Previously, such invalid URIs were accepted and `#to_s` would implicitly fix them by prepending `/` or `./`, respectively.
But this very quirky and leads to unexpected behaviour when instead of `to_s`, only parts of the URI are used (see #12798).
