### PR TITLE
Deprecate `Termios`

### DIFF
--- a/src/termios.cr
+++ b/src/termios.cr
@@ -1,6 +1,8 @@
 require "c/termios"
 
+@[Deprecated]
 module Termios
+  @[Deprecated]
   @[Flags]
   enum InputMode
     BRKINT = LibC::BRKINT
@@ -18,6 +20,7 @@ module Termios
   end
 
   {% if flag?(:freebsd) %}
+    @[Deprecated]
     @[Flags]
     enum OutputMode
       OPOST  = LibC::OPOST
@@ -31,6 +34,7 @@ module Termios
     end
   {% elsif flag?(:dragonfly) %}
     # FIXME: Verify
+    @[Deprecated]
     @[Flags]
     enum OutputMode
       OPOST  = LibC::OPOST
@@ -43,6 +47,7 @@ module Termios
       TAB3   = LibC::TAB3
     end
   {% elsif flag?(:netbsd) || flag?(:openbsd) %}
+    @[Deprecated]
     @[Flags]
     enum OutputMode
       OPOST  = LibC::OPOST
@@ -52,6 +57,7 @@ module Termios
       ONLRET = LibC::ONLRET
     end
   {% else %}
+    @[Deprecated]
     @[Flags]
     enum OutputMode
       OPOST  = LibC::OPOST
@@ -86,6 +92,7 @@ module Termios
     end
   {% end %}
 
+  @[Deprecated]
   enum BaudRate
     B0     = LibC::B0
     B50    = LibC::B50
@@ -105,6 +112,7 @@ module Termios
     B38400 = LibC::B38400
   end
 
+  @[Deprecated]
   enum ControlMode
     CSIZE  = LibC::CSIZE
     CS5    = LibC::CS5
@@ -119,6 +127,7 @@ module Termios
     CLOCAL = LibC::CLOCAL
   end
 
+  @[Deprecated]
   @[Flags]
   enum LocalMode : Int64
     ECHO   = LibC::ECHO
@@ -132,6 +141,7 @@ module Termios
     TOSTOP = LibC::TOSTOP
   end
 
+  @[Deprecated]
   @[Flags]
   enum AttributeSelection
     TCSANOW   = LibC::TCSANOW
@@ -139,6 +149,7 @@ module Termios
     TCSAFLUSH = LibC::TCSAFLUSH
   end
 
+  @[Deprecated]
   enum LineControl
     TCSANOW   = LibC::TCSANOW
     TCSADRAIN = LibC::TCSADRAIN


### PR DESCRIPTION
Follow-up to #12352.

The top-level `Termios` solely exists to turn the C enum values used by the few console methods on `IO::FileDescriptor` into Crystal enums; it is very platform-specific, the vast majority of those constants are unused anywhere else, and `Termios::OutputMode` doesn't even have the same members on all platforms (contrast with signals and `Errno`). This PR deprecates `Termios` and all of its enums.

The deprecations don't actually do anything yet, until #12939 is implemented. Also the constants inside `LibC` are untouched, because technically `Termios` still depends on them.