### PR TITLE
Fix `Process` spec to wait on started processes

### DIFF
--- a/spec/std/process_spec.cr
+++ b/spec/std/process_spec.cr
@@ -321,6 +321,8 @@ describe Process do
     pending_win32 "kills a process" do
       process = Process.new(*standing_command)
       process.signal(Signal::KILL).should be_nil
+    ensure
+      process.try &.wait
     end
 
     pending_win32 "kills many process" do
@@ -328,6 +330,9 @@ describe Process do
       process2 = Process.new(*standing_command)
       process1.signal(Signal::KILL).should be_nil
       process2.signal(Signal::KILL).should be_nil
+    ensure
+      process1.try &.wait
+      process2.try &.wait
     end
   end
 
@@ -337,7 +342,8 @@ describe Process do
     process.terminated?.should be_false
 
     process.terminate
-    process.wait
+  ensure
+    process.try(&.wait)
   end
 
   pending_win32 ".exists?" do
@@ -367,6 +373,8 @@ describe Process do
     Process.pgid(process.pid).should be_a(Int64)
     process.signal(Signal::KILL)
     Process.pgid.should eq(Process.pgid(Process.pid))
+  ensure
+    process.try(&.wait)
   end
 
   {% unless flag?(:preview_mt) || flag?(:win32) %}


### PR DESCRIPTION
These lingering processes can cause interference with the `Signal::CHLD` handler specs.

We encountered a random spec failure in CI (https://github.com/crystal-lang/crystal/actions/runs/3886325401/jobs/6631288655#step:5:348) and it reproduces with the same seed locally (hooray for #12541 🎉).

```
    1) Signal CHLD.reset removes previously set trap
       Failure/Error: call_count.should eq(1)
  
         Expected: 1
              got: 3
  
       # spec/std/signal_spec.cr:66
```

Suspicious about the randomized spec order was that in this instance the failing spec was immediately preceded by specs for `Process#signal`.

These methods didn't clean up after themselves and the signal spec already started, setting up a trap before the signals for the previous child processes' termination were received.

This patch makes sure to `wait` for all processes started in `Process` specs.