### PR TITLE
Compiler: Add "Top 10 slowest modules" to --stats output

### DIFF
--- a/src/compiler/crystal/compiler.cr
+++ b/src/compiler/crystal/compiler.cr
@@ -470,8 +470,15 @@ module Crystal
               pr, pw = IO.pipe
               spawn do
                 pr.each_line do |line|
-                  unit = JSON.parse(line)
-                  reused << unit["name"].as_s if unit["reused"].as_bool
+                  unit_info = JSON.parse(line)
+                  reused << unit_info["name"].as_s if unit_info["reused"].as_bool
+
+                  module_idx = unit_info["idx"].as_i
+                  slice.update(module_idx) do |unit|
+                    unit.compilation_time = unit_info["time"].as_f.seconds
+                    unit
+                  end
+
                   @progress_tracker.stage_progress += 1
                 end
               end
@@ -479,10 +486,15 @@ module Crystal
 
             codegen_process = Process.fork do
               pipe_w = pw
-              slice.each do |unit|
+              slice.each_with_index do |unit, idx|
                 unit.compile
                 if pipe_w
-                  unit_json = {name: unit.name, reused: unit.reused_previous_compilation?}.to_json
+                  unit_json = {
+                    name:   unit.name,
+                    reused: unit.reused_previous_compilation?,
+                    idx:    idx,
+                    time:   unit.compilation_time.total_seconds,
+                  }.to_json
                   pipe_w.puts unit_json
                 end
               end
@@ -545,6 +557,16 @@ module Crystal
         puts "These modules were not reused:"
         not_reused.each do |unit|
           puts " - #{unit.original_name} (#{unit.name}.bc)"
+        end
+      end
+
+      if units.size != reused.size
+        puts
+        puts("Top 10 slowest modules:")
+        units.sort_by! { |u| u.compilation_time * -1 }
+        units.first(10).each do |unit|
+          time_str = unit.compilation_time.to_s.ljust(18, ' ')
+          puts " - #{unit.compilation_time} #{unit.original_name} (#{unit.name}.bc)"
         end
       end
     end
@@ -631,6 +653,7 @@ module Crystal
       getter original_name
       getter llvm_mod
       getter? reused_previous_compilation = false
+      property compilation_time : Time::Span = Time::Span::ZERO
       @object_extension : String
 
       def initialize(@compiler : Compiler, program : Program, @name : String,
@@ -661,7 +684,9 @@ module Crystal
       end
 
       def compile
-        compile_to_object
+        @compilation_time = Time.measure do
+          compile_to_object
+        end
       end
 
       private def compile_to_object

--- a/src/compiler/crystal/compiler.cr
+++ b/src/compiler/crystal/compiler.cr
@@ -565,7 +565,6 @@ module Crystal
         puts("Top 10 slowest modules:")
         units.sort_by! { |u| u.compilation_time * -1 }
         units.first(10).each do |unit|
-          time_str = unit.compilation_time.to_s.ljust(18, ' ')
           puts " - #{unit.compilation_time} #{unit.original_name} (#{unit.name}.bc)"
         end
       end


### PR DESCRIPTION
May be useful for spotting modules in large apps that may benefit from being broken up in order to improve build times, etc.

Example output:

```
Codegen (bc+obj):
 - 1757/1771 .o files were reused

These modules were not reused:
 - _main (_main.bc)
 - Process (P-rocess.bc)
 - /home/lune/git/crystal/src/compiler/crystal/macros/methods.cr (47home47lune47git-047426b817c2f879b1b5b500a3d97bbe.bc)
 - Crystal::Signal (C-rystal5858S-ignal.bc)
 - Crystal::Compiler (C-rystal5858C-ompiler.bc)
 - Hash(String, Int32) (H-ash40S-tring4432I-nt3241.bc)
 - Log::AsyncDispatcher (L-og5858A-syncD-ispatcher.bc)
 - Crystal::Command (C-rystal5858C-ommand.bc)
 - Crystal::Init (C-rystal5858I-nit.bc)
 - Crystal::Playground::Server (C-rystal5858P-layground5858S-erver.bc)
 - Crystal::Playground::Session (C-rystal5858P-layground5858S-ession.bc)
 - Crystal::Playground::PathWebSocketHandler (C-rystal5858P-lay-38c77a69c1a2ffd144caae7845092122.bc)
 - HTTP::Server (H-T-T-P-5858S-erver.bc)
 - HTTP::WebSocketHandler+ (H-T-T-P-5858W-ebS-ocketH-andler43.bc)

Top 10 slowest modules:
 - 00:00:00.794907504 _main (_main.bc)
 - 00:00:00.201288353 Crystal::Command (C-rystal5858C-ommand.bc)
 - 00:00:00.135537059 /home/lune/git/crystal/src/compiler/crystal/macros/methods.cr (47home47lune47git-047426b817c2f879b1b5b500a3d97bbe.bc)
 - 00:00:00.135338039 Crystal::Generic (C-rystal5858G-eneric.bc)
 - 00:00:00.111936502 Crystal::Compiler (C-rystal5858C-ompiler.bc)
 - 00:00:00.104652722 Crystal::ASTNode+ (C-rystal5858A-S-T-N-ode43.bc)
 - 00:00:00.091841367 Crystal::CodeGenVisitor (C-rystal5858C-odeG-enV-isitor.bc)
 - 00:00:00.083189850 Crystal::Call (C-rystal5858C-all.bc)
 - 00:00:00.075213115 Crystal::Type+ (C-rystal5858T-ype43.bc)
 - 00:00:00.066328602 Crystal::NumberLiteral (C-rystal5858N-umberL-iteral.bc)
 ```