### PR TITLE
Stricter checks for enum definitions

### DIFF
--- a/src/compiler/crystal/semantic/top_level_visitor.cr
+++ b/src/compiler/crystal/semantic/top_level_visitor.cr
@@ -619,13 +619,14 @@ class Crystal::TopLevelVisitor < Crystal::SemanticVisitor
       unless enum_base_type.is_a?(IntegerType)
         base_type.raise "enum base type must be an integer type"
       end
-    else
-      enum_base_type = @program.int32
+
+      if enum_type && enum_base_type != enum_type.base_type
+        base_type.raise "enum #{name}'s base type is #{enum_type.base_type}, not #{enum_base_type}"
+      end
     end
 
-    all_value = interpret_enum_value(NumberLiteral.new(0), enum_base_type)
     existed = !!enum_type
-    enum_type ||= EnumType.new(@program, scope, name, enum_base_type)
+    enum_type ||= EnumType.new(@program, scope, name, enum_base_type || @program.int32)
 
     enum_type.private = true if node.visibility.private?
 
@@ -638,40 +639,32 @@ class Crystal::TopLevelVisitor < Crystal::SemanticVisitor
     attach_doc enum_type, node, annotations
 
     pushing_type(enum_type) do
-      counter = enum_type.flags? ? 1 : 0
-      counter = interpret_enum_value(NumberLiteral.new(counter), enum_base_type)
-      counter, all_value, overflow = visit_enum_members(node, node.members, counter, all_value,
-        overflow: false,
-        existed: existed,
-        enum_type: enum_type,
-        enum_base_type: enum_base_type,
-        is_flags: enum_type.flags?)
-    end
-
-    num_members = enum_type.types.size
-    if num_members > 0 && enum_type.flags?
-      # skip None & All, they doesn't count as members for @[Flags] enums
-      num_members = enum_type.types.count { |(name, _)| !name.in?("None", "All") }
-    end
-
-    if num_members == 0
-      node.raise "enum #{node.name} must have at least one member"
+      visit_enum_members(node, node.members, existed, enum_type)
     end
 
     unless existed
-      if enum_type.flags?
-        unless enum_type.types["None"]?
-          none = NumberLiteral.new("0", enum_base_type.kind)
-          none.type = enum_type
-          enum_type.add_constant Arg.new("None", default_value: none)
+      num_members = enum_type.types.size
+      if num_members > 0 && enum_type.flags?
+        # skip None & All, they doesn't count as members for @[Flags] enums
+        num_members = enum_type.types.count { |(name, _)| !name.in?("None", "All") }
+      end
 
+      if num_members == 0
+        node.raise "enum #{node.name} must have at least one member"
+      end
+
+      if enum_type.flags?
+        unless enum_type.types.has_key?("None")
+          enum_type.add_constant("None", 0)
           define_enum_none_question_method(enum_type, node)
         end
 
-        unless enum_type.types["All"]?
-          all = NumberLiteral.new(all_value.to_s, enum_base_type.kind)
-          all.type = enum_type
-          enum_type.add_constant Arg.new("All", default_value: all)
+        unless enum_type.types.has_key?("All")
+          all_value = enum_type.base_type.kind.cast(0).as(Int::Primitive)
+          enum_type.types.each_value do |member|
+            all_value |= interpret_enum_value(member.as(Const).value, enum_type.base_type)
+          end
+          enum_type.add_constant("All", all_value)
         end
       end
 
@@ -681,43 +674,57 @@ class Crystal::TopLevelVisitor < Crystal::SemanticVisitor
     false
   end
 
-  def visit_enum_members(node, members, counter, all_value, overflow, **options)
-    members.each do |member|
-      counter, all_value, overflow =
-        visit_enum_member(node, member, counter, all_value, overflow, **options)
+  def visit_enum_members(node, members, existed, enum_type, previous_counter = nil)
+    members.reduce(previous_counter) do |counter, member|
+      visit_enum_member(node, member, existed, enum_type, counter)
     end
-    {counter, all_value, overflow}
   end
 
-  def visit_enum_member(node, member, counter, all_value, overflow, **options)
+  def visit_enum_member(node, member, existed, enum_type, previous_counter = nil)
     case member
     when MacroIf
       expanded = expand_inline_macro(member, mode: Parser::ParseMode::Enum, accept: false)
-      visit_enum_member(node, expanded, counter, all_value, overflow, **options)
+      visit_enum_member(node, expanded, existed, enum_type, previous_counter)
     when MacroExpression
       expanded = expand_inline_macro(member, mode: Parser::ParseMode::Enum, accept: false)
-      visit_enum_member(node, expanded, counter, all_value, overflow, **options)
+      visit_enum_member(node, expanded, existed, enum_type, previous_counter)
     when MacroFor
       expanded = expand_inline_macro(member, mode: Parser::ParseMode::Enum, accept: false)
-      visit_enum_member(node, expanded, counter, all_value, overflow, **options)
+      visit_enum_member(node, expanded, existed, enum_type, previous_counter)
     when Expressions
-      visit_enum_members(node, member.expressions, counter, all_value, overflow, **options)
+      visit_enum_members(node, member.expressions, existed, enum_type, previous_counter)
     when Arg
-      enum_type = options[:enum_type]
-      base_type = options[:enum_base_type]
-      is_flags = options[:is_flags]
-
-      if options[:existed]
+      if existed
         node.raise "can't reopen enum and add more constants to it"
       end
 
-      if default_value = member.default_value
-        counter = interpret_enum_value(default_value, base_type)
-      elsif overflow
-        member.raise "value of enum member #{member} would overflow the base type #{base_type}"
+      if enum_type.types.has_key?(member.name)
+        member.raise "enum '#{enum_type}' already contains a member named '#{member.name}'"
       end
 
-      if is_flags && !@in_lib
+      if default_value = member.default_value
+        counter = interpret_enum_value(default_value, enum_type.base_type)
+      elsif previous_counter
+        if enum_type.flags?
+          if previous_counter == 0 # In case the member is set to 0
+            counter = 1
+          else
+            counter = previous_counter &* 2
+            unless (counter <=> previous_counter).sign == previous_counter.sign
+              member.raise "value of enum member #{member} would overflow the base type #{enum_type.base_type}"
+            end
+          end
+        else
+          counter = previous_counter &+ 1
+          unless counter > previous_counter
+            member.raise "value of enum member #{member} would overflow the base type #{enum_type.base_type}"
+          end
+        end
+      else
+        counter = enum_type.base_type.kind.cast(enum_type.flags? ? 1 : 0).as(Int::Primitive)
+      end
+
+      if enum_type.flags? && !@in_lib
         if member.name == "None" && counter != 0
           member.raise "flags enum can't redefine None member to non-0"
         elsif member.name == "All"
@@ -726,22 +733,17 @@ class Crystal::TopLevelVisitor < Crystal::SemanticVisitor
       end
 
       if default_value.is_a?(Crystal::NumberLiteral)
-        enum_base_kind = base_type.kind
+        enum_base_kind = enum_type.base_type.kind
         if (enum_base_kind.i32?) && (enum_base_kind != default_value.kind)
           default_value.raise "enum value must be an Int32"
         end
       end
 
-      all_value |= counter
-      const_value = NumberLiteral.new(counter.to_s, base_type.kind)
-      member.default_value = const_value
-      if enum_type.types.has_key?(member.name)
-        member.raise "enum '#{enum_type}' already contains a member named '#{member.name}'"
-      end
+      define_enum_question_method(enum_type, member, enum_type.flags?)
 
-      define_enum_question_method(enum_type, member, is_flags)
+      const_member = enum_type.add_constant(member.name, counter)
+      member.default_value = const_member.value
 
-      const_member = enum_type.add_constant member
       const_member.doc = member.doc
       check_ditto const_member, member.location
 
@@ -749,24 +751,10 @@ class Crystal::TopLevelVisitor < Crystal::SemanticVisitor
         const_member.add_location(member_location)
       end
 
-      const_value.type = enum_type
-      if is_flags
-        if counter == 0 # In case the member is set to 0
-          new_counter = 1
-          overflow = false
-        else
-          new_counter = counter &* 2
-          overflow = !default_value && counter.sign != new_counter.sign
-        end
-      else
-        new_counter = counter &+ 1
-        overflow = !default_value && counter > 0 && new_counter < 0
-      end
-      new_counter = overflow ? counter : new_counter
-      {new_counter, all_value, overflow}
+      counter
     else
       member.accept self
-      {counter, all_value, overflow}
+      previous_counter
     end
   end
 

--- a/src/compiler/crystal/syntax/ast.cr
+++ b/src/compiler/crystal/syntax/ast.cr
@@ -263,21 +263,37 @@ module Crystal
       f32? || f64?
     end
 
-    def self.from_number(number : Number)
+    def self.from_number(number : Number::Primitive) : self
       case number
-      when Int8    then I8
-      when Int16   then I16
-      when Int32   then I32
-      when Int64   then I64
-      when Int128  then I128
-      when UInt8   then U8
-      when UInt16  then U16
-      when UInt32  then U32
-      when UInt64  then U64
-      when UInt128 then U128
-      when Float32 then F32
-      when Float64 then F64
-      else              raise "Unsupported Number type for NumberLiteral: #{number.class}"
+      in Int8    then I8
+      in Int16   then I16
+      in Int32   then I32
+      in Int64   then I64
+      in Int128  then I128
+      in UInt8   then U8
+      in UInt16  then U16
+      in UInt32  then U32
+      in UInt64  then U64
+      in UInt128 then U128
+      in Float32 then F32
+      in Float64 then F64
+      end
+    end
+
+    def cast(number) : Number::Primitive
+      case self
+      in .i8?   then number.to_i8
+      in .i16?  then number.to_i16
+      in .i32?  then number.to_i32
+      in .i64?  then number.to_i64
+      in .i128? then number.to_i128
+      in .u8?   then number.to_u8
+      in .u16?  then number.to_u16
+      in .u32?  then number.to_u32
+      in .u64?  then number.to_u64
+      in .u128? then number.to_u128
+      in .f32?  then number.to_f32
+      in .f64?  then number.to_f64
       end
     end
   end
@@ -299,20 +315,11 @@ module Crystal
     end
 
     def integer_value
-      case kind
-      when .i8?   then value.to_i8
-      when .i16?  then value.to_i16
-      when .i32?  then value.to_i32
-      when .i64?  then value.to_i64
-      when .i128? then value.to_i128
-      when .u8?   then value.to_u8
-      when .u16?  then value.to_u16
-      when .u32?  then value.to_u32
-      when .u64?  then value.to_u64
-      when .u128? then value.to_u128
-      else
-        raise "Bug: called 'integer_value' for non-integer literal"
+      unless kind.signed_int? || kind.unsigned_int?
+        raise "BUG: called 'integer_value' for non-integer literal"
       end
+
+      kind.cast(value)
     end
 
     # Returns true if this literal is representable in the *other_type*. Used to

--- a/src/compiler/crystal/types.cr
+++ b/src/compiler/crystal/types.cr
@@ -2829,8 +2829,10 @@ module Crystal
       @parents ||= [program.enum] of Type
     end
 
-    def add_constant(constant)
-      types[constant.name] = const = Const.new(program, self, constant.name, constant.default_value.not_nil!)
+    def add_constant(name, value)
+      const_exp = NumberLiteral.new(value.to_s, base_type.kind)
+      const_exp.type = self
+      types[name] = const = Const.new(program, self, name, const_exp)
       program.const_initializers << const
       const
     end


### PR DESCRIPTION
This PR makes it an error to reopen an enum with an explicit base type that is different from its original definition:

```crystal
enum Foo; X; end
enum Foo : UInt8; end # Error: enum Foo's base type is Int32, not UInt8

enum Bar : UInt16; X; end
enum Bar : UInt32; end # Error: enum Bar's base type is UInt16, not UInt32
enum Bar; end          # okay, base type not explicitly specified
```

It also improves overflow detection so that it works immediately after an enum member with a value is declared: (previously the overflow error would trigger on the subsequent enum member afterwards, or not at all)

```crystal
enum Foo1
  A = 0x7FFFFFFF
  B # Error: value of enum member B would overflow the base type Int32
end

@[Flags]
enum Foo2
  A = 0x40000000
  B # Error: value of enum member B would overflow the base type Int32
end

@[Flags]
enum Foo3 : UInt32
  A = 0x80000000
  B # Error: value of enum member B would overflow the base type UInt32
end
```

Note that the overflow criterion for signed flags enums is the same as normal multiplication. And indeed this is the case when the overflowing member is succeeded by a valueless member:

```crystal
@[Flags]
enum Foo4
  A = 0x20000000
  B
  C # Error: value of enum member C would overflow the base type Int32
end
```

Some code in the wild might assume it is okay to have `Foo2::B == -0x80000000` here. IMO this is a bug rather than a breaking change.

Finally, `visit_enum_member`'s implementation is largely refactored, and there are fewer parameters and return values now. (It also removes one of the compiler's remaining non-forwarding uses of an `**options` parameter.)