### PR TITLE
Fix baked-in path in playground to resolve at runtime

### DIFF
--- a/src/compiler/crystal/tools/playground/server.cr
+++ b/src/compiler/crystal/tools/playground/server.cr
@@ -449,7 +449,7 @@ module Crystal::Playground
     end
 
     def start
-      playground_dir = File.dirname(__FILE__)
+      playground_dir = File.dirname(CrystalPath.new.find("compiler/crystal/tools/playground/server.cr").not_nil![0])
       views_dir = File.join(playground_dir, "views")
       public_dir = File.join(playground_dir, "public")
 


### PR DESCRIPTION
Partial revert of https://github.com/crystal-lang/crystal/pull/12686 which introduced this regression