### PR TITLE
Macro interpolation: add `&` to yielding `Def`s without a block parameter

### DIFF
--- a/spec/compiler/normalize/def_spec.cr
+++ b/spec/compiler/normalize/def_spec.cr
@@ -98,9 +98,9 @@ module Crystal
     end
 
     it "expands with named argument and yield" do
-      a_def = parse("def foo(x = 1, y = 2); yield x + y; end").as(Def)
+      a_def = parse("def foo(x = 1, y = 2, &); yield x + y; end").as(Def)
       actual = a_def.expand_default_arguments(Program.new, 0, ["y"])
-      actual.to_s.should eq("def foo:y(y)\n  x = 1\n  yield x + y\nend")
+      actual.to_s.should eq("def foo:y(y, &)\n  x = 1\n  yield x + y\nend")
     end
 
     # Small optimizations: no need to create a separate def in these cases
@@ -147,9 +147,9 @@ module Crystal
     end
 
     it "expands with magic constant with named arg with yield" do
-      a_def = parse("def foo(x, file = __FILE__, line = __LINE__); yield x, file, line; end").as(Def)
+      a_def = parse("def foo(x, file = __FILE__, line = __LINE__, &); yield x, file, line; end").as(Def)
       other_def = a_def.expand_default_arguments(Program.new, 1, ["line"])
-      other_def.to_s.should eq("def foo:line(x, line, file = __FILE__)\n  yield x, file, line\nend")
+      other_def.to_s.should eq("def foo:line(x, line, file = __FILE__, &)\n  yield x, file, line\nend")
     end
 
     it "expands a def with double splat and no args" do

--- a/spec/compiler/parser/to_s_spec.cr
+++ b/spec/compiler/parser/to_s_spec.cr
@@ -219,4 +219,8 @@ describe "ASTNode#to_s" do
   expect_to_s "->::foo(Int32, String)"
   expect_to_s "->::Foo::Bar.foo"
   expect_to_s "yield(1)"
+  expect_to_s "def foo\n  yield\nend", "def foo(&)\n  yield\nend"
+  expect_to_s "def foo(x)\n  yield\nend", "def foo(x, &)\n  yield\nend"
+  expect_to_s "def foo(**x)\n  yield\nend", "def foo(**x, &)\n  yield\nend"
+  expect_to_s "macro foo(x)\n  yield\nend"
 end

--- a/spec/compiler/semantic/restrictions_augmenter_spec.cr
+++ b/spec/compiler/semantic/restrictions_augmenter_spec.cr
@@ -222,7 +222,7 @@ describe "Semantic: restrictions augmenter" do
 
   it "doesn't augment if assigned inside block" do
     expect_no_augment <<-CRYSTAL
-      def foo
+      def foo(&)
         yield
       end
       class Foo

--- a/src/compiler/crystal/syntax/to_s.cr
+++ b/src/compiler/crystal/syntax/to_s.cr
@@ -614,7 +614,7 @@ module Crystal
         @str << '.'
       end
       @str << node.name
-      if node.args.size > 0 || node.block_arg || node.double_splat
+      if node.args.size > 0 || node.block_arity || node.double_splat
         @str << '('
         printed_arg = false
         node.args.each_with_index do |arg, i|
@@ -633,7 +633,9 @@ module Crystal
           @current_arg_type = :block_arg
           @str << ", " if printed_arg
           block_arg.accept self
-          printed_arg = true
+        elsif node.block_arity
+          @str << ", " if printed_arg
+          @str << '&'
         end
         @str << ')'
       end


### PR DESCRIPTION
Resolves part of #8764.

Similar to #12951, but for macro interpolation.