### PR TITLE
Missing quotes in Wrapper Script

### DIFF
--- a/bin/crystal
+++ b/bin/crystal
@@ -101,7 +101,7 @@ remove_path_item() {
   path="$1"
   item="$2"
 
-  printf "%s" "$path" | awk -v RS=: -v ORS=: '$0 != "'$item'"' | sed 's/:$//'
+  printf "%s" "$path" | awk -v RS=: -v ORS=: '$0 != "'"$item"'"' | sed 's/:$//'
 }
 
 ##############################################################################

--- a/bin/crystal
+++ b/bin/crystal
@@ -99,9 +99,8 @@ remove_path_item() {
   local path item
 
   path="$1"
-  item="$2"
 
-  printf "%s" "$path" | awk -v RS=: -v ORS=: '$0 != "'"$item"'"' | sed 's/:$//'
+  printf "%s" "$path" | awk -v item="$2" -v RS=: -v ORS=: '$0 != item' | sed 's/:$//'
 }
 
 ##############################################################################


### PR DESCRIPTION
For issue when installation root has spaces in path (e.g. `/home/user/Crystal Build`. May be other issues in this file; haven't checked thoroughly but the interpreter runs for me.
```
$ /usr/local/bin/crystal i
awk: cmd. line:1: $0 != "/home/user/Software/Crystal
awk: cmd. line:1:       ^ unterminated string
awk: cmd. line:1: $0 != "/home/user/Software/Crystal
awk: cmd. line:1:       ^ syntax error
/usr/local/bin/crystal: 153: crystal: not found
```