### PR TITLE
Fix socket specs when network not available

### DIFF
--- a/spec/std/socket/tcp_server_spec.cr
+++ b/spec/std/socket/tcp_server_spec.cr
@@ -88,14 +88,14 @@ describe TCPServer, tags: "network" do
         err = expect_raises(Socket::Error, "Hostname lookup for doesnotexist.example.org. failed") do
           TCPServer.new("doesnotexist.example.org.", 12345)
         end
-        err.os_error.should eq({% if flag?(:win32) %}WinError::WSAHOST_NOT_FOUND{% else %}Errno.new(LibC::EAI_NONAME){% end %})
+        [WinError::WSAHOST_NOT_FOUND, Errno.new(LibC::EAI_NONAME), Errno.new(LibC::EAI_AGAIN)].should contain err.os_error
       end
 
       it "raises (rather than segfault on darwin) when host doesn't exist and port is 0" do
         err = expect_raises(Socket::Error, "Hostname lookup for doesnotexist.example.org. failed") do
           TCPServer.new("doesnotexist.example.org.", 0)
         end
-        err.os_error.should eq({% if flag?(:win32) %}WinError::WSAHOST_NOT_FOUND{% else %}Errno.new(LibC::EAI_NONAME){% end %})
+        [WinError::WSAHOST_NOT_FOUND, Errno.new(LibC::EAI_NONAME), Errno.new(LibC::EAI_AGAIN)].should contain err.os_error
       end
     end
 

--- a/spec/std/socket/tcp_server_spec.cr
+++ b/spec/std/socket/tcp_server_spec.cr
@@ -88,14 +88,24 @@ describe TCPServer, tags: "network" do
         err = expect_raises(Socket::Error, "Hostname lookup for doesnotexist.example.org. failed") do
           TCPServer.new("doesnotexist.example.org.", 12345)
         end
-        [WinError::WSAHOST_NOT_FOUND, Errno.new(LibC::EAI_NONAME), Errno.new(LibC::EAI_AGAIN)].should contain err.os_error
+        # FIXME: Resolve special handling for win32. The error code handling should be identical.
+        {% if flag?(:win32) %}
+          [WinError::WSAHOST_NOT_FOUND, WinError::WSATRY_AGAIN].should contain err.os_error
+        {% else %}
+          [Errno.new(LibC::EAI_NONAME), Errno.new(LibC::EAI_AGAIN)].should contain err.os_error
+        {% end %}
       end
 
       it "raises (rather than segfault on darwin) when host doesn't exist and port is 0" do
         err = expect_raises(Socket::Error, "Hostname lookup for doesnotexist.example.org. failed") do
           TCPServer.new("doesnotexist.example.org.", 0)
         end
-        [WinError::WSAHOST_NOT_FOUND, Errno.new(LibC::EAI_NONAME), Errno.new(LibC::EAI_AGAIN)].should contain err.os_error
+        # FIXME: Resolve special handling for win32. The error code handling should be identical.
+        {% if flag?(:win32) %}
+          [WinError::WSAHOST_NOT_FOUND, WinError::WSATRY_AGAIN].should contain err.os_error
+        {% else %}
+          [Errno.new(LibC::EAI_NONAME), Errno.new(LibC::EAI_AGAIN)].should contain err.os_error
+        {% end %}
       end
     end
 

--- a/spec/std/socket/tcp_socket_spec.cr
+++ b/spec/std/socket/tcp_socket_spec.cr
@@ -67,14 +67,24 @@ describe TCPSocket, tags: "network" do
         error = expect_raises(Socket::Error, "Hostname lookup for doesnotexist.example.org. failed") do
           TCPSocket.new("doesnotexist.example.org.", 12345)
         end
-        [WinError::WSAHOST_NOT_FOUND, Errno.new(LibC::EAI_NONAME), Errno.new(LibC::EAI_AGAIN)].should contain error.os_error
+        # FIXME: Resolve special handling for win32. The error code handling should be identical.
+        {% if flag?(:win32) %}
+          [WinError::WSAHOST_NOT_FOUND, WinError::WSATRY_AGAIN].should contain err.os_error
+        {% else %}
+          [Errno.new(LibC::EAI_NONAME), Errno.new(LibC::EAI_AGAIN)].should contain err.os_error
+        {% end %}
       end
 
       it "raises (rather than segfault on darwin) when host doesn't exist and port is 0" do
         error = expect_raises(Socket::Error, "Hostname lookup for doesnotexist.example.org. failed") do
           TCPSocket.new("doesnotexist.example.org.", 0)
         end
-        [WinError::WSAHOST_NOT_FOUND, Errno.new(LibC::EAI_NONAME), Errno.new(LibC::EAI_AGAIN)].should contain error.os_error
+        # FIXME: Resolve special handling for win32. The error code handling should be identical.
+        {% if flag?(:win32) %}
+          [WinError::WSAHOST_NOT_FOUND, WinError::WSATRY_AGAIN].should contain err.os_error
+        {% else %}
+          [Errno.new(LibC::EAI_NONAME), Errno.new(LibC::EAI_AGAIN)].should contain err.os_error
+        {% end %}
       end
     end
 

--- a/spec/std/socket/tcp_socket_spec.cr
+++ b/spec/std/socket/tcp_socket_spec.cr
@@ -64,7 +64,7 @@ describe TCPSocket, tags: "network" do
       end
 
       it "raises when host doesn't exist" do
-        error = expect_raises(Socket::Error, "Hostname lookup for doesnotexist.example.org. failed") do
+        err = expect_raises(Socket::Error, "Hostname lookup for doesnotexist.example.org. failed") do
           TCPSocket.new("doesnotexist.example.org.", 12345)
         end
         # FIXME: Resolve special handling for win32. The error code handling should be identical.
@@ -76,7 +76,7 @@ describe TCPSocket, tags: "network" do
       end
 
       it "raises (rather than segfault on darwin) when host doesn't exist and port is 0" do
-        error = expect_raises(Socket::Error, "Hostname lookup for doesnotexist.example.org. failed") do
+        err = expect_raises(Socket::Error, "Hostname lookup for doesnotexist.example.org. failed") do
           TCPSocket.new("doesnotexist.example.org.", 0)
         end
         # FIXME: Resolve special handling for win32. The error code handling should be identical.

--- a/spec/std/socket/tcp_socket_spec.cr
+++ b/spec/std/socket/tcp_socket_spec.cr
@@ -67,14 +67,14 @@ describe TCPSocket, tags: "network" do
         error = expect_raises(Socket::Error, "Hostname lookup for doesnotexist.example.org. failed") do
           TCPSocket.new("doesnotexist.example.org.", 12345)
         end
-        error.os_error.should eq({% if flag?(:win32) %}WinError::WSAHOST_NOT_FOUND{% else %}Errno.new(LibC::EAI_NONAME){% end %})
+        [WinError::WSAHOST_NOT_FOUND, Errno.new(LibC::EAI_NONAME), Errno.new(LibC::EAI_AGAIN)].should contain error.os_error
       end
 
       it "raises (rather than segfault on darwin) when host doesn't exist and port is 0" do
         error = expect_raises(Socket::Error, "Hostname lookup for doesnotexist.example.org. failed") do
           TCPSocket.new("doesnotexist.example.org.", 0)
         end
-        error.os_error.should eq({% if flag?(:win32) %}WinError::WSAHOST_NOT_FOUND{% else %}Errno.new(LibC::EAI_NONAME){% end %})
+        [WinError::WSAHOST_NOT_FOUND, Errno.new(LibC::EAI_NONAME), Errno.new(LibC::EAI_AGAIN)].should contain error.os_error
       end
     end
 

--- a/spec/std/socket/udp_socket_spec.cr
+++ b/spec/std/socket/udp_socket_spec.cr
@@ -130,7 +130,16 @@ describe UDPSocket, tags: "network" do
                  raise "Unsupported IP address family: #{family}"
                end
 
-        udp.join_group(addr)
+        begin
+          udp.join_group(addr)
+        rescue e : Socket::Error
+          if e.os_error == Errno::ENODEV
+            pending!("Multicast device selection not available on this host")
+          else
+            raise e
+          end
+        end
+
         udp.multicast_loopback = true
         udp.multicast_loopback?.should eq(true)
 


### PR DESCRIPTION
Socket specs were failing when running on a system with no network.

UDP multicast specs are already pretty fragile and handle many points of failure as acceptable because the host system/network might not support UDP multicast. This patch just adds code for another failure type.

Then there are a couple of specs which initiate a DNS lookup to a non-existent domain (`doesnotexist.example.org.`). When no DNS server is available, `getaddrinfo` apparently returns `EAI_AGAIN` to try again later (which of course won't help anything when there's simply no network to reach an upstream DNS server).
I'm not entirely sure if simply accepting `EAI_AGAIN` is the best way to fix this. The spec could also be marked as pending in that case. But I think success is fine.
Also, I'm wondering if `EAI_AGAIN` should be handled somewhere in `Addrinfo`, retrying and finally raise a more specific error.
But that's a whole different story. For now I think these changes should be good to make the spec suite work on isolated machines (a use case for that is the build environment on build.opensuse.org/).

If you want to run specs without network access, I found the easiest way is a docker container with `--network none`.