### PR TITLE
Fix: Remove `focus: true`

### DIFF
--- a/spec/std/channel_spec.cr
+++ b/spec/std/channel_spec.cr
@@ -570,7 +570,7 @@ describe Channel do
       end
     end
 
-    it "returns correct index for array argument", focus: true do
+    it "returns correct index for array argument" do
       ch = [Channel(String).new, Channel(String).new, Channel(String).new]
       channels = [ch[0], ch[2], ch[1]] # shuffle around to get non-sequential lock_object_ids
       spawn_and_wait(->{ channels[0].send "foo" }) do


### PR DESCRIPTION
#12827 unintentionally added a `focus: true`, which skips the rest of the spec suite 🙈 