### PR TITLE
Support typed LLVM `load` instructions

### DIFF
--- a/samples/llvm/brainfuck.cr
+++ b/samples/llvm/brainfuck.cr
@@ -17,10 +17,10 @@ class Increment < Instruction
     builder = program.builder
     builder.position_at_end bb
 
-    cell_index = builder.load program.cell_index_ptr, "cell_index"
+    cell_index = builder.load program.ctx.int32, program.cell_index_ptr, "cell_index"
     current_cell_ptr = builder.gep program.cell_type, program.cells_ptr, cell_index, "current_cell_ptr"
 
-    cell_val = builder.load current_cell_ptr, "cell_value"
+    cell_val = builder.load program.cell_type, current_cell_ptr, "cell_value"
     increment_amount = program.cell_type.const_int(@amount)
     new_cell_val = builder.add cell_val, increment_amount, "cell_value"
     builder.store new_cell_val, current_cell_ptr
@@ -37,7 +37,7 @@ class DataIncrement < Instruction
     builder = program.builder
     builder.position_at_end bb
 
-    cell_index = builder.load program.cell_index_ptr, "cell_index"
+    cell_index = builder.load program.ctx.int32, program.cell_index_ptr, "cell_index"
     increment_amount = program.ctx.int32.const_int(@amount)
     new_cell_index = builder.add cell_index, increment_amount, "new_cell_index"
 
@@ -52,7 +52,7 @@ class Read < Instruction
     builder = program.builder
     builder.position_at_end bb
 
-    cell_index = builder.load program.cell_index_ptr, "cell_index"
+    cell_index = builder.load program.ctx.int32, program.cell_index_ptr, "cell_index"
     current_cell_ptr = builder.gep program.cell_type, program.cells_ptr, cell_index, "current_cell_ptr"
 
     getchar = program.mod.functions["getchar"]
@@ -69,10 +69,10 @@ class Write < Instruction
     builder = program.builder
     builder.position_at_end bb
 
-    cell_index = builder.load program.cell_index_ptr, "cell_index"
+    cell_index = builder.load program.ctx.int32, program.cell_index_ptr, "cell_index"
     current_cell_ptr = builder.gep program.cell_type, program.cells_ptr, cell_index, "current_cell_ptr"
 
-    cell_val = builder.load current_cell_ptr, "cell_value"
+    cell_val = builder.load program.cell_type, current_cell_ptr, "cell_value"
     cell_val_as_char = builder.sext cell_val, program.ctx.int32, "cell_val_as_char"
 
     putchar = program.mod.functions["putchar"]
@@ -99,9 +99,9 @@ class Loop < Instruction
     loop_after = func.basic_blocks.append "loop_after"
 
     builder.position_at_end loop_header
-    cell_index = builder.load program.cell_index_ptr, "cell_index"
+    cell_index = builder.load program.ctx.int32, program.cell_index_ptr, "cell_index"
     current_cell_ptr = builder.gep program.cell_type, program.cells_ptr, cell_index, "current_cell_ptr"
-    cell_val = builder.load current_cell_ptr, "cell_value"
+    cell_val = builder.load program.cell_type, current_cell_ptr, "cell_value"
     zero = program.cell_type.const_int(0)
     cell_val_is_zero = builder.icmp LLVM::IntPredicate::EQ, cell_val, zero
 

--- a/spec/compiler/codegen/pointer_spec.cr
+++ b/spec/compiler/codegen/pointer_spec.cr
@@ -373,8 +373,6 @@ describe "Code gen: pointer" do
 
   it "can assign nil to void pointer" do
     codegen(%(
-      require "prelude"
-
       ptr = Pointer(Void).malloc(1_u64)
       ptr.value = ptr.value
       ))

--- a/src/compiler/crystal/codegen/call.cr
+++ b/src/compiler/crystal/codegen/call.cr
@@ -95,7 +95,7 @@ class Crystal::CodeGenVisitor
       # - C calling convention passing needs a separate handling of pass-by-value
       # - Primitives might need a separate handling (for example invoking a Proc)
       if arg.type.passed_by_value? && !c_calling_convention && !is_primitive
-        call_arg = load(call_arg)
+        call_arg = load(llvm_type(arg.type), call_arg)
       end
 
       call_args << call_arg
@@ -242,7 +242,7 @@ class Crystal::CodeGenVisitor
       size = @program.bits64? ? int64(size) : int32(size)
       align = @abi.align(abi_arg_type.type)
       memcpy(final_value_casted, gep_call_arg, size, align, int1(0))
-      call_arg = load final_value
+      call_arg = load cast, final_value
     else
       # Keep same call arg
     end

--- a/src/compiler/crystal/codegen/codegen.cr
+++ b/src/compiler/crystal/codegen/codegen.cr
@@ -1142,9 +1142,10 @@ module Crystal
         thread_local_fun.add_attribute LLVM::Attribute::NoInline
       end
       thread_local_fun = check_main_fun(fun_name, thread_local_fun)
-      indirection_ptr = alloca llvm_type(type).pointer
+      pointer_type = llvm_type(type).pointer
+      indirection_ptr = alloca pointer_type
       call thread_local_fun, indirection_ptr
-      load indirection_ptr
+      load pointer_type, indirection_ptr
     end
 
     def visit(node : TypeDeclaration)
@@ -1203,7 +1204,7 @@ module Crystal
 
         # Special variables always have an extra pointer
         already_loaded = (node.special_var? ? false : var.already_loaded)
-        @last = downcast var.pointer, node.type, var.type, already_loaded
+        @last = downcast var.pointer, node.type, var.type, already_loaded, extern: false
       elsif node.name == "self"
         if node.type.metaclass?
           @last = type_id(node.type)
@@ -1260,7 +1261,7 @@ module Crystal
       type = type.remove_typedef
       ivar = type.lookup_instance_var(name)
       ivar_ptr = instance_var_ptr type, name, value
-      @last = downcast ivar_ptr, node_type, ivar.type, false
+      @last = downcast ivar_ptr, node_type, ivar.type, false, extern: type.extern?
       if type.extern?
         # When reading the instance variable of a C struct or union
         # we need to convert C functions to Crystal procs. This
@@ -1630,7 +1631,7 @@ module Crystal
       closure_ptr = alloca struct_type
       store fun_ptr, aggregate_index(struct_type, closure_ptr, 0)
       store ctx_ptr, aggregate_index(struct_type, closure_ptr, 1)
-      load(closure_ptr)
+      load(struct_type, closure_ptr)
     end
 
     def make_nilable_fun(type)
@@ -1869,8 +1870,7 @@ module Crystal
 
         if self_closured
           offset = parent_closure_type ? 1 : 0
-          self_value = llvm_self
-          self_value = load self_value if current_context.type.passed_by_value?
+          self_value = to_rhs(llvm_self, current_context.type)
 
           store self_value, gep(closure_type, closure_ptr, 0, closure_vars.size + offset, "self")
 
@@ -2185,11 +2185,20 @@ module Crystal
     end
 
     def to_lhs(value, type)
-      type.passed_by_value? ? value : load value
+      # `llvm_embedded_type` needed for void-like types
+      type.passed_by_value? ? value : load(llvm_embedded_type(type), value)
     end
 
     def to_rhs(value, type)
-      type.passed_by_value? ? load value : value
+      type.passed_by_value? ? load(llvm_embedded_type(type), value) : value
+    end
+
+    def extern_to_lhs(value, type)
+      type.passed_by_value? ? value : load(llvm_embedded_c_type(type), value)
+    end
+
+    def extern_to_rhs(value, type)
+      type.passed_by_value? ? load(llvm_embedded_c_type(type), value) : value
     end
 
     # *type* is the pointee type of *ptr* (not the type of the returned

--- a/src/compiler/crystal/codegen/cond.cr
+++ b/src/compiler/crystal/codegen/cond.cr
@@ -44,7 +44,7 @@ class Crystal::CodeGenVisitor
       end
 
       if has_bool
-        value = load(bit_cast value_ptr, llvm_context.int1.pointer)
+        value = load(llvm_context.int1, bit_cast value_ptr, llvm_context.int1.pointer)
         is_bool = equal? type_id, type_id(@program.bool)
         cond = and cond, not(and(is_bool, not(value)))
       end
@@ -54,7 +54,7 @@ class Crystal::CodeGenVisitor
           next unless union_type.is_a?(PointerInstanceType)
 
           is_pointer = equal? type_id, type_id(union_type)
-          pointer_value = load(bit_cast value_ptr, llvm_type(union_type).pointer)
+          pointer_value = load(llvm_type(union_type), bit_cast value_ptr, llvm_type(union_type).pointer)
           pointer_null = null_pointer?(pointer_value)
           cond = and cond, not(and(is_pointer, pointer_null))
         end

--- a/src/compiler/crystal/codegen/const.cr
+++ b/src/compiler/crystal/codegen/const.cr
@@ -79,7 +79,7 @@ class Crystal::CodeGenVisitor
 
     const_type = const.value.type
     if const_type.passed_by_value?
-      @last = load @last
+      @last = load llvm_type(const_type), @last
     end
 
     global.initializer = @last
@@ -108,7 +108,7 @@ class Crystal::CodeGenVisitor
 
     const_type = const.value.type
     if const_type.passed_by_value?
-      @last = load @last
+      @last = load llvm_type(const_type), @last
     end
 
     store @last, global
@@ -159,21 +159,21 @@ class Crystal::CodeGenVisitor
 
           request_value(const.value)
 
-          if const.value.type.passed_by_value?
-            @last = load @last
+          const_type = const.value.type
+          if const_type.passed_by_value?
+            @last = load llvm_type(const_type), @last
           end
 
           if @last.constant?
             global.initializer = @last
             global.global_constant = true
 
-            const_type = const.value.type
             if const_type.is_a?(PrimitiveType) || const_type.is_a?(EnumType)
               const.initializer = @last
             end
           else
-            global.initializer = llvm_type(const.value.type).null
-            unless const.value.type.nil_type? || const.value.type.void?
+            global.initializer = llvm_type(const_type).null
+            unless const_type.nil_type? || const_type.void?
               store @last, global
             end
           end

--- a/src/compiler/crystal/codegen/debug.cr
+++ b/src/compiler/crystal/codegen/debug.cr
@@ -492,7 +492,7 @@ module Crystal
       debug_alloca = alloca alloca.type, "dbg.#{arg_name}"
       store alloca, debug_alloca
       declare_parameter(arg_name, arg_type, arg_no, debug_alloca, location)
-      alloca = load debug_alloca
+      alloca = load alloca.type, debug_alloca
       set_current_debug_location old_debug_location
       alloca
     end

--- a/src/compiler/crystal/codegen/exception.cr
+++ b/src/compiler/crystal/codegen/exception.cr
@@ -122,7 +122,9 @@ class Crystal::CodeGenVisitor
         position_at_end catch_body
 
         # Allocate space for the caught exception
-        caught_exception_ptr = alloca llvm_type(@program.exception.virtual_type)
+        exception_type = @program.exception.virtual_type
+        exception_llvm_type = llvm_type(exception_type)
+        caught_exception_ptr = alloca exception_llvm_type
 
         # The catchpad instruction dictates which types of exceptions this block handles,
         # we want all of them, so we rescue all void* by passing the void_ptr_type_descriptor.
@@ -133,8 +135,8 @@ class Crystal::CodeGenVisitor
 
         # builder.printf("catchpad entered #{node.location}\n", catch_pad: @catch_pad)
 
-        caught_exception = load caught_exception_ptr
-        exception_type_id = type_id(caught_exception, @program.exception.virtual_type)
+        caught_exception = load exception_llvm_type, caught_exception_ptr
+        exception_type_id = type_id(caught_exception, exception_type)
       else
         # Unwind exception handling code - used on non-windows platforms - is a lot simpler.
         # First we generate the landing pad instruction, this returns a tuple of the libunwind

--- a/src/compiler/crystal/codegen/llvm_builder_helper.cr
+++ b/src/compiler/crystal/codegen/llvm_builder_helper.cr
@@ -196,7 +196,7 @@ module Crystal
     end
 
     delegate llvm_type, llvm_struct_type, llvm_arg_type, llvm_embedded_type,
-      llvm_c_type, llvm_c_return_type, llvm_return_type, to: llvm_typer
+      llvm_c_type, llvm_c_return_type, llvm_return_type, llvm_embedded_c_type, to: llvm_typer
 
     def llvm_proc_type(type)
       llvm_typer.proc_type(type.as(ProcInstanceType))

--- a/src/compiler/crystal/codegen/once.cr
+++ b/src/compiler/crystal/codegen/once.cr
@@ -18,16 +18,16 @@ class Crystal::CodeGenVisitor
 
   def run_once(flag, func)
     once_fun = main_fun(ONCE)
+    once_init_fun = main_fun(ONCE_INIT)
 
     once_state_global = @llvm_mod.globals[ONCE_STATE]? || begin
-      once_init_fun = main_fun(ONCE_INIT)
       global = @llvm_mod.globals.add(once_init_fun.return_type, ONCE_STATE)
       global.linkage = LLVM::Linkage::External
       global
     end
 
     call main_fun(ONCE), [
-      load(once_state_global),
+      load(once_init_fun.return_type, once_state_global),
       flag,
       bit_cast(func.to_value, once_fun.params.last.type),
     ]

--- a/src/compiler/crystal/codegen/primitives.cr
+++ b/src/compiler/crystal/codegen/primitives.cr
@@ -865,11 +865,7 @@ class Crystal::CodeGenVisitor
     name = external.real_name
     var = declare_lib_var name, node.type, external.thread_local?
 
-    @last = call_args[0]
-
-    if external.type.passed_by_value?
-      @last = load @last
-    end
+    @last = extern_to_rhs(call_args[0], external.type)
 
     store @last, var
 
@@ -882,11 +878,7 @@ class Crystal::CodeGenVisitor
     external = target_def.as(External)
     var = get_external_var(external)
 
-    if external.type.passed_by_value?
-      @last = var
-    else
-      @last = load var
-    end
+    @last = extern_to_lhs(var, external.type)
 
     @last = check_c_fun node.type, @last
 
@@ -915,7 +907,10 @@ class Crystal::CodeGenVisitor
   end
 
   def codegen_primitive_symbol_to_s(node, target_def, call_args)
-    load(gep @llvm_typer.llvm_type(@program.string).array(@symbol_table_values.size), @llvm_mod.globals[SYMBOL_TABLE_NAME], int(0), call_args[0])
+    string = llvm_type(@program.string)
+    table_type = string.array(@symbol_table_values.size)
+    string_ptr = gep table_type, @llvm_mod.globals[SYMBOL_TABLE_NAME], int(0), call_args[0]
+    load(string, string_ptr)
   end
 
   def codegen_primitive_class(node, target_def, call_args)
@@ -984,15 +979,10 @@ class Crystal::CodeGenVisitor
 
     proc_type = context.type.as(ProcInstanceType)
     target_def.args.size.times do |i|
-      arg = args[i]
       proc_arg_type = proc_type.arg_types[i]
       target_def_arg_type = target_def.args[i].type
-      args[i] = upcast arg, proc_arg_type, target_def_arg_type
-      if proc_arg_type.passed_by_value?
-        closure_args << load(args[i])
-      else
-        closure_args << args[i]
-      end
+      args[i] = arg = upcast args[i], proc_arg_type, target_def_arg_type
+      closure_args << to_rhs(arg, proc_arg_type)
     end
 
     fun_ptr = builder.extract_value closure_ptr, 0
@@ -1201,7 +1191,7 @@ class Crystal::CodeGenVisitor
     ordering = atomic_ordering_get_const(call.args[-2], ordering)
     volatile = bool_from_bool_literal(call.args[-1])
 
-    inst = builder.load(ptr)
+    inst = builder.load(llvm_type(node.type), ptr)
     inst.ordering = ordering
     inst.volatile = true if volatile
     set_alignment inst, node.type

--- a/src/compiler/crystal/codegen/type_id.cr
+++ b/src/compiler/crystal/codegen/type_id.cr
@@ -14,11 +14,11 @@ class Crystal::CodeGenVisitor
   end
 
   private def type_id_impl(value, type : ReferenceUnionType)
-    load(value)
+    load(llvm_context.int32, value)
   end
 
   private def type_id_impl(value, type : VirtualType)
-    load(value)
+    load(llvm_context.int32, value)
   end
 
   private def type_id_impl(value, type : NilableReferenceUnionType)
@@ -32,7 +32,7 @@ class Crystal::CodeGenVisitor
     br exit_block
 
     position_at_end not_nil_block
-    phi_table.add insert_block, load(value)
+    phi_table.add insert_block, load(llvm_context.int32, value)
     br exit_block
 
     position_at_end exit_block

--- a/src/compiler/crystal/codegen/unions.cr
+++ b/src/compiler/crystal/codegen/unions.cr
@@ -59,7 +59,10 @@ module Crystal
 
     def union_type_and_value_pointer(union_pointer, type : MixedUnionType)
       struct_type = llvm_type(type)
-      {load(union_type_id(struct_type, union_pointer)), union_value(struct_type, union_pointer)}
+      {
+        load(llvm_context.int32, union_type_id(struct_type, union_pointer)),
+        union_value(struct_type, union_pointer),
+      }
     end
 
     def union_type_id(struct_type, union_pointer)
@@ -118,7 +121,7 @@ module Crystal
       # - cast the target pointer to Pointer(A | B)
       # - store the A | B from the first pointer into the casted target pointer
       casted_target_pointer = cast_to_pointer target_pointer, value_type
-      store load(value), casted_target_pointer
+      store load(llvm_type(value_type), value), casted_target_pointer
     end
 
     def downcast_distinct_union_types(value, to_type : MixedUnionType, from_type : MixedUnionType)

--- a/src/llvm/builder.cr
+++ b/src/llvm/builder.cr
@@ -91,18 +91,37 @@ class LLVM::Builder
     Value.new LibLLVM.build_store(self, value, ptr)
   end
 
-  def load(ptr, name = "")
+  def load(ptr : LLVM::Value, name = "")
     # check_value(ptr)
 
-    Value.new LibLLVM.build_load(self, ptr, name)
+    {% if LibLLVM::IS_LT_80 %}
+      Value.new LibLLVM.build_load(self, ptr, name)
+    {% else %}
+      Value.new LibLLVM.build_load2(self, ptr.type.element_type, ptr, name)
+    {% end %}
+  end
+
+  def load(type : LLVM::Type, ptr : LLVM::Value, name = "")
+    # check_type("load", type)
+    # check_value(ptr)
+
+    {% if LibLLVM::IS_LT_80 %}
+      Value.new LibLLVM.build_load(self, ptr, name)
+    {% else %}
+      Value.new LibLLVM.build_load2(self, type, ptr, name)
+    {% end %}
   end
 
   def store_volatile(value, ptr)
     store(value, ptr).tap { |v| v.volatile = true }
   end
 
-  def load_volatile(ptr, name = "")
+  def load_volatile(ptr : LLVM::Value, name = "")
     load(ptr, name).tap { |v| v.volatile = true }
+  end
+
+  def load_volatile(type : LLVM::Type, ptr : LLVM::Value, name = "")
+    load(type, ptr, name).tap { |v| v.volatile = true }
   end
 
   {% for method_name in %w(gep inbounds_gep) %}

--- a/src/llvm/lib_llvm.cr
+++ b/src/llvm/lib_llvm.cr
@@ -147,6 +147,9 @@ lib LibLLVM
   {% end %}
   fun build_landing_pad = LLVMBuildLandingPad(builder : BuilderRef, ty : TypeRef, pers_fn : ValueRef, num_clauses : UInt32, name : UInt8*) : ValueRef
   fun build_load = LLVMBuildLoad(builder : BuilderRef, ptr : ValueRef, name : UInt8*) : ValueRef
+  {% unless LibLLVM::IS_LT_80 %}
+    fun build_load2 = LLVMBuildLoad2(builder : BuilderRef, ty : TypeRef, ptr : ValueRef, name : UInt8*) : ValueRef
+  {% end %}
   fun build_lshr = LLVMBuildLShr(builder : BuilderRef, lhs : ValueRef, rhs : ValueRef, name : UInt8*) : ValueRef
   fun build_malloc = LLVMBuildMalloc(builder : BuilderRef, type : TypeRef, name : UInt8*) : ValueRef
   fun build_mul = LLVMBuildMul(builder : BuilderRef, lhs : ValueRef, rhs : ValueRef, name : UInt8*) : ValueRef


### PR DESCRIPTION
Part of #12743. The treatment here is very similar to #12623, but for `load` / `LLVMBuildLoad2` instructions.

Known to work locally for LLVM 7 to 14 on aarch64-apple-darwin with `make clean deps && bin/crystal spec spec/compiler/codegen --order=random --fail-fast && bin/crystal src/compiler/crystal.cr spec spec/std_spec.cr spec/primitives_spec.cr`.

~~It seems [x86_64-darwin no longer fails](https://github.com/HertzDevil/crystal/actions/runs/3949540174/jobs/6760882311)...?~~