### PR TITLE
Use Structs for all stdlib Iterators

### DIFF
--- a/src/hash.cr
+++ b/src/hash.cr
@@ -2043,7 +2043,7 @@ class Hash(K, V)
     end
   end
 
-  private class EntryIterator(K, V)
+  private struct EntryIterator(K, V)
     include BaseIterator
     include Iterator({K, V})
 
@@ -2055,7 +2055,7 @@ class Hash(K, V)
     end
   end
 
-  private class KeyIterator(K, V)
+  private struct KeyIterator(K, V)
     include BaseIterator
     include Iterator(K)
 
@@ -2067,7 +2067,7 @@ class Hash(K, V)
     end
   end
 
-  private class ValueIterator(K, V)
+  private struct ValueIterator(K, V)
     include BaseIterator
     include Iterator(V)
 

--- a/src/indexable.cr
+++ b/src/indexable.cr
@@ -385,7 +385,7 @@ module Indexable(T)
     CartesianProductIteratorN(typeof(indexables), typeof(Enumerable.element_type Enumerable.element_type indexables)).new(indexables, reuse)
   end
 
-  private class CartesianProductIteratorT(Is, Ts)
+  private struct CartesianProductIteratorT(Is, Ts)
     include Iterator(Ts)
 
     @indices : Array(Int32)
@@ -416,7 +416,7 @@ module Indexable(T)
     end
   end
 
-  private class CartesianProductIteratorN(Is, T)
+  private struct CartesianProductIteratorN(Is, T)
     include Iterator(Array(T))
 
     @indices : Array(Int32)
@@ -1295,7 +1295,7 @@ module Indexable(T)
     reuse
   end
 
-  private class ItemIterator(A, T)
+  private struct ItemIterator(A, T)
     include Iterator(T)
 
     def initialize(@array : A, @index = 0)
@@ -1312,7 +1312,7 @@ module Indexable(T)
     end
   end
 
-  private class ReverseItemIterator(A, T)
+  private struct ReverseItemIterator(A, T)
     include Iterator(T)
 
     def initialize(@array : A, @index : Int32 = array.size - 1)
@@ -1329,7 +1329,7 @@ module Indexable(T)
     end
   end
 
-  private class IndexIterator(A)
+  private struct IndexIterator(A)
     include Iterator(Int32)
 
     def initialize(@array : A, @index = 0)
@@ -1346,7 +1346,7 @@ module Indexable(T)
     end
   end
 
-  private class PermutationIterator(A, T)
+  private struct PermutationIterator(A, T)
     include Iterator(Array(T))
 
     @size : Int32
@@ -1396,7 +1396,7 @@ module Indexable(T)
     end
   end
 
-  private class CombinationIterator(A, T)
+  private struct CombinationIterator(A, T)
     include Iterator(Array(T))
 
     @size : Int32
@@ -1449,7 +1449,7 @@ module Indexable(T)
     end
   end
 
-  private class RepeatedCombinationIterator(A, T)
+  private struct RepeatedCombinationIterator(A, T)
     include Iterator(Array(T))
 
     @size : Int32

--- a/src/int.cr
+++ b/src/int.cr
@@ -776,7 +776,7 @@ struct Int
   # Returns the number of trailing `0`-bits.
   abstract def trailing_zeros_count
 
-  private class TimesIterator(T)
+  private struct TimesIterator(T)
     include Iterator(T)
 
     @n : T
@@ -796,7 +796,7 @@ struct Int
     end
   end
 
-  private class UptoIterator(T, N)
+  private struct UptoIterator(T, N)
     include Iterator(T)
 
     @from : T
@@ -818,7 +818,7 @@ struct Int
     end
   end
 
-  private class DowntoIterator(T, N)
+  private struct DowntoIterator(T, N)
     include Iterator(T)
 
     @from : T

--- a/src/iterator.cr
+++ b/src/iterator.cr
@@ -218,7 +218,7 @@ module Iterator(T)
     AccumulateInit(typeof(self), T, U).new(self, initial, block)
   end
 
-  private class AccumulateInit(I, T, U)
+  private struct AccumulateInit(I, T, U)
     include Iterator(U)
 
     @acc : U | Iterator::Stop
@@ -235,7 +235,7 @@ module Iterator(T)
     end
   end
 
-  private class Accumulate(I, T)
+  private struct Accumulate(I, T)
     include Iterator(T)
     include IteratorWrapper
 
@@ -269,7 +269,7 @@ module Iterator(T)
     Chain(typeof(self), typeof(other), T, U).new(self, other)
   end
 
-  private class Chain(I1, I2, T1, T2)
+  private struct Chain(I1, I2, T1, T2)
     include Iterator(T1 | T2)
 
     def initialize(@iterator1 : I1, @iterator2 : I2)
@@ -310,7 +310,7 @@ module Iterator(T)
     chain iters.each
   end
 
-  private class ChainsAll(Iter, T)
+  private struct ChainsAll(Iter, T)
     include Iterator(T)
     @iterators : Iterator(Iter)
     @current : Iter | Stop
@@ -536,7 +536,7 @@ module Iterator(T)
     CycleN(typeof(self), T, typeof(n)).new(self, n)
   end
 
-  private class CycleN(I, T, N)
+  private struct CycleN(I, T, N)
     include Iterator(T)
     include IteratorWrapper
 
@@ -718,7 +718,7 @@ module Iterator(T)
     FlatMap(typeof(self), typeof(FlatMap.element_type(self, func)), typeof(FlatMap.iterator_type(self, func)), typeof(func)).new self, func
   end
 
-  private class FlatMap(I0, T, I, F)
+  private struct FlatMap(I0, T, I, F)
     include Iterator(T)
     include IteratorWrapper
 
@@ -1023,7 +1023,7 @@ module Iterator(T)
     Skip(typeof(self), T, typeof(n)).new(self, n)
   end
 
-  private class Skip(I, T, N)
+  private struct Skip(I, T, N)
     include Iterator(T)
     include IteratorWrapper
 
@@ -1054,7 +1054,7 @@ module Iterator(T)
     SkipWhile(typeof(self), T, U).new(self, func)
   end
 
-  private class SkipWhile(I, T, U)
+  private struct SkipWhile(I, T, U)
     include Iterator(T)
     include IteratorWrapper
 
@@ -1169,7 +1169,7 @@ module Iterator(T)
     First(typeof(self), T, typeof(n)).new(self, n)
   end
 
-  private class First(I, T, N)
+  private struct First(I, T, N)
     include Iterator(T)
     include IteratorWrapper
 
@@ -1200,7 +1200,7 @@ module Iterator(T)
     TakeWhile(typeof(self), T, U).new(self, func)
   end
 
-  private class TakeWhile(I, T, U)
+  private struct TakeWhile(I, T, U)
     include Iterator(T)
     include IteratorWrapper
 
@@ -1322,7 +1322,7 @@ module Iterator(T)
     end
   end
 
-  private class WithIndex(I, T, O)
+  private struct WithIndex(I, T, O)
     include Iterator({T, Int32})
     include IteratorWrapper
 
@@ -1460,7 +1460,7 @@ module Iterator(T)
   end
 
   # :nodoc:
-  class Chunk(I, T, U)
+  struct Chunk(I, T, U)
     include Iterator(Tuple(U, Array(T)))
     @iterator : I
     @init : {U, T}?
@@ -1560,7 +1560,7 @@ module Iterator(T)
   end
 
   # :nodoc:
-  class SliceAfter(I, T, B)
+  struct SliceAfter(I, T, B)
     include Iterator(Array(T))
 
     def initialize(@iterator : I, @block : T -> B, reuse)
@@ -1666,7 +1666,7 @@ module Iterator(T)
   end
 
   # :nodoc:
-  class SliceBefore(I, T, B)
+  struct SliceBefore(I, T, B)
     include Iterator(Array(T))
 
     @has_value_to_add = false
@@ -1782,7 +1782,7 @@ module Iterator(T)
   end
 
   # :nodoc:
-  class SliceWhen(I, T, B)
+  struct SliceWhen(I, T, B)
     include Iterator(Array(T))
 
     @has_previous_value = false

--- a/src/json/from_json.cr
+++ b/src/json/from_json.cr
@@ -94,7 +94,7 @@ module Iterator(T)
     FromJson(T).new(pull)
   end
 
-  private class FromJson(T)
+  private struct FromJson(T)
     include Iterator(T)
 
     def initialize(@pull : JSON::PullParser)

--- a/src/path.cr
+++ b/src/path.cr
@@ -578,7 +578,7 @@ struct Path
   end
 
   # :nodoc:
-  class PartIterator
+  struct PartIterator
     include Iterator(String)
 
     def initialize(@path : Path)

--- a/src/range.cr
+++ b/src/range.cr
@@ -527,7 +527,7 @@ struct Range(B, E)
     end
   end
 
-  private class ItemIterator(B, E)
+  private struct ItemIterator(B, E)
     include Iterator(B)
 
     @range : Range(B, E)
@@ -558,7 +558,7 @@ struct Range(B, E)
     end
   end
 
-  private class ReverseIterator(B, E)
+  private struct ReverseIterator(B, E)
     include Iterator(E)
 
     @range : Range(B, E)
@@ -580,7 +580,7 @@ struct Range(B, E)
     end
   end
 
-  private class StepIterator(R, B, N)
+  private struct StepIterator(R, B, N)
     include Iterator(B)
 
     @range : R

--- a/src/steppable.cr
+++ b/src/steppable.cr
@@ -76,7 +76,7 @@ module Steppable
     StepIterator.new(self + (step - step), limit, step, exclusive: exclusive)
   end
 
-  class StepIterator(T, L, B)
+  struct StepIterator(T, L, B)
     include Iterator(T)
 
     @current : T

--- a/src/string.cr
+++ b/src/string.cr
@@ -5319,7 +5319,7 @@ class String
     end
   end
 
-  private class CharIterator
+  private struct CharIterator
     include Iterator(Char)
 
     @reader : Char::Reader
@@ -5344,7 +5344,7 @@ class String
     end
   end
 
-  private class LineIterator
+  private struct LineIterator
     include Iterator(String)
 
     def initialize(@string : String, @chomp : Bool)

--- a/src/string/grapheme/grapheme.cr
+++ b/src/string/grapheme/grapheme.cr
@@ -34,7 +34,7 @@ class String
   end
 
   # :nodoc:
-  class GraphemeIterator
+  struct GraphemeIterator
     include Iterator(Grapheme)
 
     @last_char : Char


### PR DESCRIPTION
This change moves all stdlib Iterators to structs instead of classes. It's unclear to me whether we'd call this a breaking change, since technically somebody could take one of these Iterators, iterate it in once context, and expect it to exist in its iterated state elsewhere. This seems like unlikely to me, though. That said, the case in which this is beneficial also seems unlikely.