### PR TITLE
Revert "Parser: Fix restrict grammar for name and supertype in type def (#12622)"

### DIFF
--- a/spec/compiler/parser/parser_spec.cr
+++ b/spec/compiler/parser/parser_spec.cr
@@ -273,17 +273,6 @@ module Crystal
       assert_syntax_error "foo { |(#{kw})| }", "cannot use '#{kw}' as a block parameter name", 1, 9
     end
 
-    describe "literals in class definitions" do
-      # #11209
-      %w("a" 'a' [1] {1} {|a|a} ->{} ->(x : Bar){} :Bar :bar %x() %w() %()).each do |invalid|
-        assert_syntax_error "class Foo#{invalid}; end"
-        assert_syntax_error "class Foo#{invalid} < Baz; end"
-        assert_syntax_error "class Foo#{invalid} < self; end"
-        assert_syntax_error "class Foo < Baz#{invalid}; end"
-        assert_syntax_error "class Foo < self#{invalid}; end"
-      end
-    end
-
     it_parses "def self.foo\n1\nend", Def.new("foo", body: 1.int32, receiver: "self".var)
     it_parses "def self.foo()\n1\nend", Def.new("foo", body: 1.int32, receiver: "self".var)
     it_parses "def self.foo=\n1\nend", Def.new("foo=", body: 1.int32, receiver: "self".var)

--- a/src/compiler/crystal/syntax/parser.cr
+++ b/src/compiler/crystal/syntax/parser.cr
@@ -1685,10 +1685,6 @@ module Crystal
       name = parse_path
       skip_space
 
-      unexpected_token unless @token.type.op_lt? ||     # Inheritance
-                              @token.type.op_lparen? || # Generic Arguments
-                              is_statement_end?
-
       type_vars, splat_index = parse_type_vars
 
       superclass = nil
@@ -1701,8 +1697,6 @@ module Crystal
         else
           superclass = parse_generic
         end
-
-        unexpected_token unless @token.type.space? || is_statement_end?
       end
       skip_statement_end
 
@@ -1720,10 +1714,6 @@ module Crystal
       class_def.end_location = end_location
       set_visibility class_def
       class_def
-    end
-
-    def is_statement_end?
-      @token.type.newline? || @token.type.op_semicolon? || @token.keyword?(:end)
     end
 
     def parse_type_vars


### PR DESCRIPTION
Reverts a change that caused unintended breakage of existing code.

This syntax refinement is non-essential. Reverting it should have no negative side effects.

Resolves #12974