### PR TITLE
Makefile: refactor test recipe

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -84,7 +84,10 @@ check_llvm_config = $(eval \
 .PHONY: all
 all: crystal ## Build all files (currently crystal only) [default]
 
-.PHONY: test ## Run tests
+.PHONY: test
+test: spec ## Run tests
+
+.PHONY: spec
 test: std_spec primitives_spec compiler_spec
 
 .PHONY: std_spec

--- a/Makefile
+++ b/Makefile
@@ -10,8 +10,6 @@
 ##   $ make clean crystal
 ## Build the compiler in release mode
 ##   $ make crystal release=1
-## Run all specs in verbose mode
-##   $ make spec verbose=1
 
 CRYSTAL ?= crystal ## which previous crystal compiler use
 LLVM_CONFIG ?=     ## llvm-config command path to use
@@ -80,10 +78,6 @@ check_llvm_config = $(eval \
 .PHONY: all
 all: crystal ## Build all files (currently crystal only) [default]
 
-.PHONY: spec
-spec: $(O)/all_spec ## Run all specs
-	$(O)/all_spec $(SPEC_FLAGS)
-
 .PHONY: std_spec
 std_spec: $(O)/std_spec ## Run standard library specs
 	$(O)/std_spec $(SPEC_FLAGS)
@@ -99,6 +93,10 @@ primitives_spec: $(O)/primitives_spec ## Run primitives specs
 .PHONY: smoke_test
 smoke_test: ## Build specs as a smoke test
 smoke_test: $(O)/std_spec $(O)/compiler_spec $(O)/crystal
+
+.PHONY: all_spec
+all_spec: $(O)/all_spec ## Run all specs (note: this builds a huge program; use `std_spec` and `compiler_spec` independently for less resource usage)
+	$(O)/all_spec $(SPEC_FLAGS)
 
 .PHONY: samples
 samples: ## Build example programs

--- a/Makefile
+++ b/Makefile
@@ -88,7 +88,7 @@ all: crystal ## Build all files (currently crystal only) [default]
 test: spec ## Run tests
 
 .PHONY: spec
-test: std_spec primitives_spec compiler_spec
+spec: std_spec primitives_spec compiler_spec
 
 .PHONY: std_spec
 std_spec: $(O)/std_spec ## Run standard library specs

--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@
 ## Clean up built files then build the compiler
 ##   $ make clean crystal
 ## Build the compiler in release mode
-##   $ make crystal release=1
+##   $ make crystal release=1 interpreter=1
 ## Run tests
 ##   $ make test
 ## Run stdlib tests

--- a/Makefile
+++ b/Makefile
@@ -10,6 +10,8 @@
 ##   $ make clean crystal
 ## Build the compiler in release mode
 ##   $ make crystal release=1
+## Run tests
+##   $ make test
 ## Run stdlib tests
 ##   $ make std_spec
 ## Run compiler tests
@@ -82,6 +84,9 @@ check_llvm_config = $(eval \
 .PHONY: all
 all: crystal ## Build all files (currently crystal only) [default]
 
+.PHONY: test ## Run tests
+test: std_spec primitives_spec compiler_spec
+
 .PHONY: std_spec
 std_spec: $(O)/std_spec ## Run standard library specs
 	$(O)/std_spec $(SPEC_FLAGS)
@@ -99,7 +104,7 @@ smoke_test: ## Build specs as a smoke test
 smoke_test: $(O)/std_spec $(O)/compiler_spec $(O)/crystal
 
 .PHONY: all_spec
-all_spec: $(O)/all_spec ## Run all specs (note: this builds a huge program; use `std_spec` and `compiler_spec` independently for less resource usage)
+all_spec: $(O)/all_spec ## Run all specs (note: this builds a huge program; `test` recipe builds individual binaries and is recommended for reduced resource usage)
 	$(O)/all_spec $(SPEC_FLAGS)
 
 .PHONY: samples

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@
 ## Build the compiler
 ##   $ make
 ## Build the compiler with progress output
-##   $ make progress=true
+##   $ make progress=1
 ## Clean up built files then build the compiler
 ##   $ make clean crystal
 ## Build the compiler in release mode

--- a/Makefile
+++ b/Makefile
@@ -10,6 +10,10 @@
 ##   $ make clean crystal
 ## Build the compiler in release mode
 ##   $ make crystal release=1
+## Run stdlib tests
+##   $ make std_spec
+## Run compiler tests
+##   $ make compiler_spec
 
 CRYSTAL ?= crystal ## which previous crystal compiler use
 LLVM_CONFIG ?=     ## llvm-config command path to use

--- a/Makefile.win
+++ b/Makefile.win
@@ -9,7 +9,7 @@
 ## Clean up built files then build the compiler
 ##   $ make -f Makefile.win clean crystal
 ## Build the compiler in release mode
-##   $ make -f Makefile.win crystal release=1
+##   $ make -f Makefile.win crystal release=1 interpreter=1
 ## Run tests
 ##   $ make -f Makefile.win test
 ## Run stdlib tests

--- a/Makefile.win
+++ b/Makefile.win
@@ -10,6 +10,8 @@
 ##   $ make -f Makefile.win clean crystal
 ## Build the compiler in release mode
 ##   $ make -f Makefile.win crystal release=1
+## Run tests
+##   $ make -f Makefile.win test
 ## Run stdlib tests
 ##   $ make -f Makefile.win std_spec
 ## Run compiler tests
@@ -84,6 +86,9 @@ check_llvm_config = $(eval \
 .PHONY: all
 all: crystal ## Build all files (currently crystal only) [default]
 
+.PHONY: test ## Run tests
+test: std_spec primitives_spec compiler_spec
+
 .PHONY: std_spec
 std_spec: $(O)\std_spec.exe ## Run standard library specs
 	$(O)\std_spec $(SPEC_FLAGS)
@@ -101,7 +106,7 @@ smoke_test: ## Build specs as a smoke test
 smoke_test: $(O)\std_spec.exe $(O)\compiler_spec.exe $(O)\crystal.exe
 
 .PHONY: all_spec
-all_spec: $(O)\all_spec.exe ## Run all specs (note: this builds a huge program; use `std_spec` and `compiler_spec` independently for less resource usage)
+all_spec: $(O)\all_spec.exe ## Run all specs (note: this builds a huge program; `test` recipe builds individual binaries and is recommended for reduced resource usage)
 	$(O)\all_spec $(SPEC_FLAGS)
 
 .PHONY: samples

--- a/Makefile.win
+++ b/Makefile.win
@@ -5,7 +5,7 @@
 ## Build the compiler
 ##   $ make -f Makefile.win
 ## Build the compiler with progress output
-##   $ make -f Makefile.win progress=true
+##   $ make -f Makefile.win progress=1
 ## Clean up built files then build the compiler
 ##   $ make -f Makefile.win clean crystal
 ## Build the compiler in release mode

--- a/Makefile.win
+++ b/Makefile.win
@@ -86,8 +86,11 @@ check_llvm_config = $(eval \
 .PHONY: all
 all: crystal ## Build all files (currently crystal only) [default]
 
-.PHONY: test ## Run tests
-test: std_spec primitives_spec compiler_spec
+.PHONY: test
+test: spec ## Run tests
+
+.PHONY: spec
+spec: std_spec primitives_spec compiler_spec
 
 .PHONY: std_spec
 std_spec: $(O)\std_spec.exe ## Run standard library specs

--- a/Makefile.win
+++ b/Makefile.win
@@ -10,8 +10,6 @@
 ##   $ make -f Makefile.win clean crystal
 ## Build the compiler in release mode
 ##   $ make -f Makefile.win crystal release=1
-## Run all specs in verbose mode
-##   $ make -f Makefile.win spec verbose=1
 
 CRYSTAL ?= crystal ## which previous crystal compiler use
 LLVM_CONFIG ?=     ## llvm-config command path to use
@@ -82,10 +80,6 @@ check_llvm_config = $(eval \
 .PHONY: all
 all: crystal ## Build all files (currently crystal only) [default]
 
-.PHONY: spec
-spec: $(O)\all_spec.exe ## Run all specs
-	$(O)\all_spec $(SPEC_FLAGS)
-
 .PHONY: std_spec
 std_spec: $(O)\std_spec.exe ## Run standard library specs
 	$(O)\std_spec $(SPEC_FLAGS)
@@ -101,6 +95,10 @@ primitives_spec: $(O)\primitives_spec.exe ## Run primitives specs
 .PHONY: smoke_test
 smoke_test: ## Build specs as a smoke test
 smoke_test: $(O)\std_spec.exe $(O)\compiler_spec.exe $(O)\crystal.exe
+
+.PHONY: all_spec
+all_spec: $(O)\all_spec.exe ## Run all specs (note: this builds a huge program; use `std_spec` and `compiler_spec` independently for less resource usage)
+	$(O)\all_spec $(SPEC_FLAGS)
 
 .PHONY: samples
 samples: ## Build example programs

--- a/Makefile.win
+++ b/Makefile.win
@@ -10,6 +10,10 @@
 ##   $ make -f Makefile.win clean crystal
 ## Build the compiler in release mode
 ##   $ make -f Makefile.win crystal release=1
+## Run stdlib tests
+##   $ make -f Makefile.win std_spec
+## Run compiler tests
+##   $ make -f Makefile.win compiler_spec
 
 CRYSTAL ?= crystal ## which previous crystal compiler use
 LLVM_CONFIG ?=     ## llvm-config command path to use

--- a/spec/spec_helper.cr
+++ b/spec/spec_helper.cr
@@ -1,4 +1,4 @@
-{% raise("Please use `make spec` or `bin/crystal` when running specs, or set the i_know_what_im_doing flag if you know what you're doing") unless env("CRYSTAL_HAS_WRAPPER") || flag?("i_know_what_im_doing") %}
+{% raise("Please use `make test` or `bin/crystal` when running specs, or set the i_know_what_im_doing flag if you know what you're doing") unless env("CRYSTAL_HAS_WRAPPER") || flag?("i_know_what_im_doing") %}
 
 ENV["CRYSTAL_PATH"] = "#{__DIR__}/../src"
 


### PR DESCRIPTION
The `spec` recipe builds `spec/all_spec.cr` which combines `std_spec`, `compiler_spec` and `primitives_spec` into a single spec suite. This is huge and requires a lot of resources, both for building as well as running the specs. It can easily exhaust many build system's memory capabilities.

I don't think we're using it *anywhere* whatsoever. And it's really not recommended due to the intense resource requirements.

But since it's there and mentioned as the top test recipe, users (especially package maintainers) are likely to pick it up.

This patch includes the following changes:

* Rename `spec` to `all_spec` and add a note that it's expensive.
* Add `test` as a replacement which runs the parts (`std_spec`, `compiler_spec` and `primitives_spec`) individually.
* Update the example make commands
