### PR TITLE
Rename internal `Iterator::Slice` type to not conflict with `::Slice`

### DIFF
--- a/spec/std/iterator_spec.cr
+++ b/spec/std/iterator_spec.cr
@@ -18,6 +18,20 @@ struct StructIter
   end
 end
 
+private class MockIterator
+  include Iterator(Int32)
+
+  def initialize
+    @x = 0
+    @y = Slice(Int32).new(5)
+  end
+
+  def next
+    return stop if @x >= 3
+    @x += 1
+  end
+end
+
 describe Iterator do
   describe "Iterator.of" do
     it "creates singleton" do
@@ -526,6 +540,10 @@ describe Iterator do
       iter.next.should eq([4, 5, 6])
       iter.next.should eq([7, 8])
       iter.next.should be_a(Iterator::Stop)
+    end
+
+    it "doesnt conflict with `::Slice` type" do
+      assert_iterates_iterator [1, 2, 3], MockIterator.new.each
     end
   end
 

--- a/src/iterator.cr
+++ b/src/iterator.cr
@@ -105,10 +105,10 @@ module Iterator(T)
   end
 
   def self.of(element : T)
-    Singleton(T).new(element)
+    SingletonIterator(T).new(element)
   end
 
-  private struct Singleton(T)
+  private struct SingletonIterator(T)
     include Iterator(T)
 
     def initialize(@element : T)
@@ -120,7 +120,7 @@ module Iterator(T)
   end
 
   def self.of(&block : -> T)
-    SingletonProc(typeof(without_stop(&block))).new(block)
+    SingletonProcIterator(typeof(without_stop(&block))).new(block)
   end
 
   private def self.without_stop(&block : -> T)
@@ -129,7 +129,7 @@ module Iterator(T)
     e
   end
 
-  private struct SingletonProc(T)
+  private struct SingletonProcIterator(T)
     include Iterator(T)
 
     def initialize(@proc : (-> (T | Iterator::Stop)) | (-> T))
@@ -196,7 +196,7 @@ module Iterator(T)
   # iter.next # => Iterator::Stop::INSTANCE
   # ```
   def accumulate(&block : T, T -> T)
-    Accumulate(typeof(self), T).new(self, block)
+    AccumulateIterator(typeof(self), T).new(self, block)
   end
 
   # Returns an iterator that accumulates *initial* with the original iterator's
@@ -215,10 +215,10 @@ module Iterator(T)
   # iter.next # => Iterator::Stop::INSTANCE
   # ```
   def accumulate(initial : U, &block : U, T -> U) forall U
-    AccumulateInit(typeof(self), T, U).new(self, initial, block)
+    AccumulateInitIterator(typeof(self), T, U).new(self, initial, block)
   end
 
-  private class AccumulateInit(I, T, U)
+  private class AccumulateInitIterator(I, T, U)
     include Iterator(U)
 
     @acc : U | Iterator::Stop
@@ -235,7 +235,7 @@ module Iterator(T)
     end
   end
 
-  private class Accumulate(I, T)
+  private class AccumulateIterator(I, T)
     include Iterator(T)
     include IteratorWrapper
 
@@ -266,10 +266,10 @@ module Iterator(T)
   # iter.next # => Iterator::Stop::INSTANCE
   # ```
   def chain(other : Iterator(U)) forall U
-    Chain(typeof(self), typeof(other), T, U).new(self, other)
+    ChainIterator(typeof(self), typeof(other), T, U).new(self, other)
   end
 
-  private class Chain(I1, I2, T1, T2)
+  private class ChainIterator(I1, I2, T1, T2)
     include Iterator(T1 | T2)
 
     def initialize(@iterator1 : I1, @iterator2 : I2)
@@ -302,7 +302,7 @@ module Iterator(T)
   # iter.next # => 4
   # ```
   def self.chain(iters : Iterator(Iter)) forall Iter
-    ChainsAll(Iter, typeof(iters.first.first)).new iters
+    ChainsAllIterator(Iter, typeof(iters.first.first)).new iters
   end
 
   # the same as `.chain(Iterator(Iter))`
@@ -310,7 +310,7 @@ module Iterator(T)
     chain iters.each
   end
 
-  private class ChainsAll(Iter, T)
+  private class ChainsAllIterator(Iter, T)
     include Iterator(T)
     @iterators : Iterator(Iter)
     @current : Iter | Stop
@@ -342,10 +342,10 @@ module Iterator(T)
   # iter.next # => Iterator::Stop::INSTANCE
   # ```
   def compact_map(&func : T -> _)
-    CompactMap(typeof(self), T, typeof(func.call(first).not_nil!)).new(self, func)
+    CompactMapIterator(typeof(self), T, typeof(func.call(first).not_nil!)).new(self, func)
   end
 
-  private struct CompactMap(I, T, U)
+  private struct CompactMapIterator(I, T, U)
     include Iterator(U)
     include IteratorWrapper
 
@@ -389,13 +389,13 @@ module Iterator(T)
     if reuse.nil? || reuse.is_a?(Bool)
       # we use an initial capacity of n * 2, because a second iteration would
       # have reallocated the array to that capacity anyway
-      Cons(typeof(self), T, typeof(n), Array(T)).new(self, n, Array(T).new(n * 2), reuse)
+      ConsIterator(typeof(self), T, typeof(n), Array(T)).new(self, n, Array(T).new(n * 2), reuse)
     else
-      Cons(typeof(self), T, typeof(n), typeof(reuse)).new(self, n, reuse, reuse)
+      ConsIterator(typeof(self), T, typeof(n), typeof(reuse)).new(self, n, reuse, reuse)
     end
   end
 
-  private struct Cons(I, T, N, V)
+  private struct ConsIterator(I, T, N, V)
     include Iterator(Array(T))
     include IteratorWrapper
 
@@ -435,10 +435,10 @@ module Iterator(T)
   # This method is just an optimized implementation for the special case of
   # `n == 2` to avoid heap allocations.
   def cons_pair : Iterator({T, T})
-    ConsTuple(typeof(self), T).new(self)
+    ConsTupleIterator(typeof(self), T).new(self)
   end
 
-  private struct ConsTuple(I, T)
+  private struct ConsTupleIterator(I, T)
     include Iterator({T, T})
     include IteratorWrapper
 
@@ -477,10 +477,10 @@ module Iterator(T)
   # # and so an and so on
   # ```
   def cycle
-    Cycle(typeof(self), T).new(self)
+    CycleIterator(typeof(self), T).new(self)
   end
 
-  private struct Cycle(I, T)
+  private struct CycleIterator(I, T)
     include Iterator(T)
     include IteratorWrapper
 
@@ -533,10 +533,10 @@ module Iterator(T)
   # iter.next # => Iterator::Stop::INSTANCE
   # ```
   def cycle(n : Int)
-    CycleN(typeof(self), T, typeof(n)).new(self, n)
+    CycleNIterator(typeof(self), T, typeof(n)).new(self, n)
   end
 
-  private class CycleN(I, T, N)
+  private class CycleNIterator(I, T, N)
     include Iterator(T)
     include IteratorWrapper
 
@@ -635,10 +635,10 @@ module Iterator(T)
   # iter.next # => Iterator::Stop::INSTANCE
   # ```
   def flatten
-    Flatten(typeof(Flatten.iterator_type(self)), typeof(Flatten.element_type(self))).new(self)
+    FlattenIterator(typeof(FlattenIterator.iterator_type(self)), typeof(FlattenIterator.element_type(self))).new(self)
   end
 
-  private struct Flatten(I, T)
+  private struct FlattenIterator(I, T)
     include Iterator(T)
 
     @iterator : I
@@ -715,10 +715,10 @@ module Iterator(T)
   # iter.to_a # => [1, 1, 2, 2, 3, 3]
   # ```
   def flat_map(&func : T -> _)
-    FlatMap(typeof(self), typeof(FlatMap.element_type(self, func)), typeof(FlatMap.iterator_type(self, func)), typeof(func)).new self, func
+    FlatMapIterator(typeof(self), typeof(FlatMapIterator.element_type(self, func)), typeof(FlatMapIterator.iterator_type(self, func)), typeof(func)).new self, func
   end
 
-  private class FlatMap(I0, T, I, F)
+  private class FlatMapIterator(I0, T, I, F)
     include Iterator(T)
     include IteratorWrapper
 
@@ -809,10 +809,10 @@ module Iterator(T)
   # interest is to be used in a read-only fashion.
   def in_groups_of(size : Int, filled_up_with = nil, reuse = false)
     raise ArgumentError.new("Size must be positive") if size <= 0
-    InGroupsOf(typeof(self), T, typeof(size), typeof(filled_up_with)).new(self, size, filled_up_with, reuse)
+    InGroupsOfIterator(typeof(self), T, typeof(size), typeof(filled_up_with)).new(self, size, filled_up_with, reuse)
   end
 
-  private struct InGroupsOf(I, T, N, U)
+  private struct InGroupsOfIterator(I, T, N, U)
     include Iterator(Array(T | U))
     include IteratorWrapper
 
@@ -861,10 +861,10 @@ module Iterator(T)
   # iter.next # => Iterator::Stop::INSTANCE
   # ```
   def map(&func : T -> U) forall U
-    Map(typeof(self), T, U).new(self, func)
+    MapIterator(typeof(self), T, U).new(self, func)
   end
 
-  private struct Map(I, T, U)
+  private struct MapIterator(I, T, U)
     include Iterator(U)
     include IteratorWrapper
 
@@ -886,7 +886,7 @@ module Iterator(T)
   # iter.next # => Iterator::Stop::INSTANCE
   # ```
   def reject(&func : T -> U) forall U
-    Reject(typeof(self), T, U).new(self, func)
+    RejectIterator(typeof(self), T, U).new(self, func)
   end
 
   # Returns an iterator that only returns elements
@@ -899,7 +899,7 @@ module Iterator(T)
   # iter.next # => Iterator::Stop::INSTANCE
   # ```
   def reject(type : U.class) forall U
-    SelectType(typeof(self), typeof(begin
+    SelectTypeIterator(typeof(self), typeof(begin
       e = first
       e.is_a?(U) ? raise("") : e
     end)).new(self)
@@ -919,7 +919,7 @@ module Iterator(T)
     reject { |elem| pattern === elem }
   end
 
-  private struct Reject(I, T, B)
+  private struct RejectIterator(I, T, B)
     include Iterator(T)
     include IteratorWrapper
 
@@ -946,7 +946,7 @@ module Iterator(T)
   # iter.next # => Iterator::Stop::INSTANCE
   # ```
   def select(&func : T -> U) forall U
-    Select(typeof(self), T, U).new(self, func)
+    SelectIterator(typeof(self), T, U).new(self, func)
   end
 
   # Returns an iterator that only returns elements
@@ -959,7 +959,7 @@ module Iterator(T)
   # iter.next # => Iterator::Stop::INSTANCE
   # ```
   def select(type : U.class) forall U
-    SelectType(typeof(self), U).new(self)
+    SelectTypeIterator(typeof(self), U).new(self)
   end
 
   # Returns an iterator that only returns elements
@@ -976,7 +976,7 @@ module Iterator(T)
     self.select { |elem| pattern === elem }
   end
 
-  private struct Select(I, T, B)
+  private struct SelectIterator(I, T, B)
     include Iterator(T)
     include IteratorWrapper
 
@@ -993,7 +993,7 @@ module Iterator(T)
     end
   end
 
-  private struct SelectType(I, T)
+  private struct SelectTypeIterator(I, T)
     include Iterator(T)
     include IteratorWrapper
 
@@ -1020,10 +1020,10 @@ module Iterator(T)
   # ```
   def skip(n : Int)
     raise ArgumentError.new "Attempted to skip negative size: #{n}" if n < 0
-    Skip(typeof(self), T, typeof(n)).new(self, n)
+    SkipIterator(typeof(self), T, typeof(n)).new(self, n)
   end
 
-  private class Skip(I, T, N)
+  private class SkipIterator(I, T, N)
     include Iterator(T)
     include IteratorWrapper
 
@@ -1051,10 +1051,10 @@ module Iterator(T)
   # iter.next # => Iterator::Stop::INSTANCE
   # ```
   def skip_while(&func : T -> U) forall U
-    SkipWhile(typeof(self), T, U).new(self, func)
+    SkipWhileIterator(typeof(self), T, U).new(self, func)
   end
 
-  private class SkipWhile(I, T, U)
+  private class SkipWhileIterator(I, T, U)
     include Iterator(T)
     include IteratorWrapper
 
@@ -1132,10 +1132,10 @@ module Iterator(T)
   # iter.next # => Iterator::Stop::INSTANCE
   # ```
   def step(n : Int)
-    Step(self, T, typeof(n)).new(self, n)
+    StepIterator(self, T, typeof(n)).new(self, n)
   end
 
-  private struct Step(I, T, N)
+  private struct StepIterator(I, T, N)
     include Iterator(T)
     include IteratorWrapper
 
@@ -1166,10 +1166,10 @@ module Iterator(T)
   # ```
   def first(n : Int)
     raise ArgumentError.new "Attempted to take negative size: #{n}" if n < 0
-    First(typeof(self), T, typeof(n)).new(self, n)
+    FirstIterator(typeof(self), T, typeof(n)).new(self, n)
   end
 
-  private class First(I, T, N)
+  private class FirstIterator(I, T, N)
     include Iterator(T)
     include IteratorWrapper
 
@@ -1197,10 +1197,10 @@ module Iterator(T)
   # iter.next # => Iterator::Stop::INSTANCE
   # ```
   def take_while(&func : T -> U) forall U
-    TakeWhile(typeof(self), T, U).new(self, func)
+    TakeWhileIterator(typeof(self), T, U).new(self, func)
   end
 
-  private class TakeWhile(I, T, U)
+  private class TakeWhileIterator(I, T, U)
     include Iterator(T)
     include IteratorWrapper
 
@@ -1235,10 +1235,10 @@ module Iterator(T)
   # iter.next # => Iterator::Stop::INSTANCE
   # ```
   def tap(&block : T ->)
-    Tap(typeof(self), T).new(self, block)
+    TapIterator(typeof(self), T).new(self, block)
   end
 
-  private struct Tap(I, T)
+  private struct TapIterator(I, T)
     include Iterator(T)
     include IteratorWrapper
 
@@ -1276,10 +1276,10 @@ module Iterator(T)
   # iter.next # => Iterator::Stop::INSTANCE
   # ```
   def uniq(&func : T -> U) forall U
-    Uniq(typeof(self), T, U).new(self, func)
+    UniqIterator(typeof(self), T, U).new(self, func)
   end
 
-  private struct Uniq(I, T, U)
+  private struct UniqIterator(I, T, U)
     include Iterator(T)
     include IteratorWrapper
 
@@ -1310,7 +1310,7 @@ module Iterator(T)
   # iter.next # => Iterator::Stop::INSTANCE
   # ```
   def with_index(offset : Int = 0)
-    WithIndex(typeof(self), T, typeof(offset)).new(self, offset)
+    WithIndexIterator(typeof(self), T, typeof(offset)).new(self, offset)
   end
 
   # Yields each element in this iterator together with its index.
@@ -1322,7 +1322,7 @@ module Iterator(T)
     end
   end
 
-  private class WithIndex(I, T, O)
+  private class WithIndexIterator(I, T, O)
     include Iterator({T, Int32})
     include IteratorWrapper
 
@@ -1347,7 +1347,7 @@ module Iterator(T)
   # iter.next # => Iterator::Stop::INSTANCE
   # ```
   def with_object(obj)
-    WithObject(typeof(self), T, typeof(obj)).new(self, obj)
+    WithObjectIterator(typeof(self), T, typeof(obj)).new(self, obj)
   end
 
   # Yields each element in this iterator together with *obj*. Returns that object.
@@ -1358,7 +1358,7 @@ module Iterator(T)
     obj
   end
 
-  private struct WithObject(I, T, O)
+  private struct WithObjectIterator(I, T, O)
     include Iterator({T, O})
     include IteratorWrapper
 
@@ -1392,7 +1392,7 @@ module Iterator(T)
 
   protected def self.zip_impl(*iterators : *U) forall U
     {% begin %}
-      Zip(U, Tuple(
+      ZipIterator(U, Tuple(
         {% for i in 0...U.size %}
           typeof(iterators[{{ i }}].first),
         {% end %}
@@ -1400,7 +1400,7 @@ module Iterator(T)
     {% end %}
   end
 
-  private struct Zip(Is, Ts)
+  private struct ZipIterator(Is, Ts)
     include Iterator(Ts)
 
     def initialize(@iterators : Is)
@@ -1456,11 +1456,10 @@ module Iterator(T)
   #
   # See also: `Enumerable#chunks`.
   def chunk(reuse = false, &block : T -> U) forall T, U
-    Chunk(typeof(self), T, U).new(self, reuse, &block)
+    ChunkIterator(typeof(self), T, U).new(self, reuse, &block)
   end
 
-  # :nodoc:
-  class Chunk(I, T, U)
+  private class ChunkIterator(I, T, U)
     include Iterator(Tuple(U, Array(T)))
     @iterator : I
     @init : {U, T}?
@@ -1528,7 +1527,7 @@ module Iterator(T)
   # This can be used to prevent many memory allocations when each slice of
   # interest is to be used in a read-only fashion.
   def slice_after(reuse : Bool | Array(T) = false, &block : T -> B) forall B
-    SliceAfter(typeof(self), T, B).new(self, block, reuse)
+    SliceAfterIterator(typeof(self), T, B).new(self, block, reuse)
   end
 
   # Returns an iterator over chunks of elements, where each
@@ -1559,8 +1558,7 @@ module Iterator(T)
     slice_after(reuse) { |elem| pattern === elem }
   end
 
-  # :nodoc:
-  class SliceAfter(I, T, B)
+  private class SliceAfterIterator(I, T, B)
     include Iterator(Array(T))
 
     def initialize(@iterator : I, @block : T -> B, reuse)
@@ -1634,7 +1632,7 @@ module Iterator(T)
   # This can be used to prevent many memory allocations when each slice of
   # interest is to be used in a read-only fashion.
   def slice_before(reuse : Bool | Array(T) = false, &block : T -> B) forall B
-    SliceBefore(typeof(self), T, B).new(self, block, reuse)
+    SliceBeforeIterator(typeof(self), T, B).new(self, block, reuse)
   end
 
   # Returns an iterator over chunks of elements, where each
@@ -1665,8 +1663,7 @@ module Iterator(T)
     slice_before(reuse) { |elem| pattern === elem }
   end
 
-  # :nodoc:
-  class SliceBefore(I, T, B)
+  private class SliceBeforeIterator(I, T, B)
     include Iterator(Array(T))
 
     @has_value_to_add = false
@@ -1748,7 +1745,7 @@ module Iterator(T)
   #
   # See also `#chunk_while`, which works similarly but the block's condition is inverted.
   def slice_when(reuse : Bool | Array(T) = false, &block : T, T -> B) forall B
-    SliceWhen(typeof(self), T, B).new(self, block, reuse)
+    SliceWhenIterator(typeof(self), T, B).new(self, block, reuse)
   end
 
   # Returns an iterator for each chunked elements where elements
@@ -1778,11 +1775,10 @@ module Iterator(T)
   #
   # See also `#slice_when`, which works similarly but the block's condition is inverted.
   def chunk_while(reuse : Bool | Array(T) = false, &block : T, T -> B) forall B
-    SliceWhen(typeof(self), T, B).new(self, block, reuse, negate: true)
+    SliceWhenIterator(typeof(self), T, B).new(self, block, reuse, negate: true)
   end
 
-  # :nodoc:
-  class SliceWhen(I, T, B)
+  private class SliceWhenIterator(I, T, B)
     include Iterator(Array(T))
 
     @has_previous_value = false

--- a/src/iterator.cr
+++ b/src/iterator.cr
@@ -1077,10 +1077,10 @@ module Iterator(T)
   # Alias of `each_slice`.
   def slice(n : Int, reuse = false)
     raise ArgumentError.new "Invalid slice size: #{n}" if n <= 0
-    Slice(typeof(self), T, typeof(n)).new(self, n, reuse)
+    SliceIterator(typeof(self), T, typeof(n)).new(self, n, reuse)
   end
 
-  private struct Slice(I, T, N)
+  private struct SliceIterator(I, T, N)
     include Iterator(Array(T))
     include IteratorWrapper
 

--- a/src/iterator.cr
+++ b/src/iterator.cr
@@ -1132,10 +1132,10 @@ module Iterator(T)
   # iter.next # => Iterator::Stop::INSTANCE
   # ```
   def step(n : Int)
-    StepIterator(self, T, typeof(n)).new(self, n)
+    StepByIterator(self, T, typeof(n)).new(self, n)
   end
 
-  private struct StepIterator(I, T, N)
+  private struct StepByIterator(I, T, N)
     include Iterator(T)
     include IteratorWrapper
 


### PR DESCRIPTION
Ref: https://forum.crystal-lang.org/t/compilation-error-iterator-bug/5276