### PR TITLE
Clean up `back\slash.txt` in `HTTP::StaticFileHandler` specs

### DIFF
--- a/spec/std/http/server/handlers/static_file_handler_spec.cr
+++ b/spec/std/http/server/handlers/static_file_handler_spec.cr
@@ -30,6 +30,8 @@ describe HTTP::StaticFileHandler do
     File.touch(Path[datapath("static_file_handler"), Path.posix("back\\slash.txt")])
     response = handle HTTP::Request.new("GET", "/back\\slash.txt"), ignore_body: false
     response.status_code.should eq 200
+  ensure
+    File.delete(Path[datapath("static_file_handler"), Path.posix("back\\slash.txt")])
   end
 
   it "adds Etag header" do


### PR DESCRIPTION
Removes the file after the spec that creates this file completes running. This ensures the working directory is clean if the standard library specs are run locally.