### PR TITLE
Skip hostname spec if `hostname` command fails

### DIFF
--- a/spec/std/system_spec.cr
+++ b/spec/std/system_spec.cr
@@ -4,10 +4,9 @@ require "system"
 describe System do
   describe "hostname" do
     pending_win32 "returns current hostname" do
-      pending! "The `hostname` command is not available." if Process.find_executable("hostname").nil?
-
       shell_hostname = `hostname`.strip
-      $?.success?.should be_true
+      pending! "`hostname` command was unsuccessful" unless $?.success?
+
       hostname = System.hostname
       hostname.should eq(shell_hostname)
     end

--- a/spec/std/system_spec.cr
+++ b/spec/std/system_spec.cr
@@ -4,8 +4,10 @@ require "system"
 describe System do
   describe "hostname" do
     pending_win32 "returns current hostname" do
+      pending! "The `hostname` command is not available." if Process.find_executable("hostname").nil?
+
       shell_hostname = `hostname`.strip
-      $?.success?.should be_true # The hostname command has to be available
+      $?.success?.should be_true
       hostname = System.hostname
       hostname.should eq(shell_hostname)
     end


### PR DESCRIPTION
Avoids a spec failure if the `hostname` command is unavailable. Which apparently it's not on my machine :sweat_smile:.