### PR TITLE
Add int128 support for json

### DIFF
--- a/spec/std/json/any_spec.cr
+++ b/spec/std/json/any_spec.cr
@@ -28,6 +28,12 @@ describe JSON::Any do
       JSON.parse("true").as_i64?.should be_nil
     end
 
+    it "gets int128" do
+      JSON.parse("1701411834604692317").as_i128.should eq(1701411834604692317_i128)
+      JSON.parse("1701411834604692317").as_i128?.should eq(1701411834604692317_i128)
+      JSON.parse("true").as_i128?.should be_nil
+    end
+
     it "gets float32" do
       JSON.parse("123.45").as_f32.should eq(123.45_f32)
       expect_raises(TypeCastError) { JSON.parse("true").as_f32 }

--- a/spec/std/json/parser_spec.cr
+++ b/spec/std/json/parser_spec.cr
@@ -77,6 +77,6 @@ describe JSON::Parser do
   it "returns raw" do
     value = JSON.parse("1").raw
     value.should eq(1)
-    value.should be_a(Int64)
+    value.should be_a(Int128)
   end
 end

--- a/spec/std/json/pull_parser_spec.cr
+++ b/spec/std/json/pull_parser_spec.cr
@@ -348,6 +348,7 @@ describe JSON::PullParser do
                     [Int16, 1_i16],
                     [Int32, 1_i32],
                     [Int64, 1_i64],
+                    [Int128, 1_i128],
                     [UInt8, 1_u8],
                     [UInt16, 1_u16],
                     [UInt32, 1_u32],
@@ -387,6 +388,22 @@ describe JSON::PullParser do
     it_reads 0_i64
     it_reads 10_i64
     it_reads Int64::MAX
+
+    it_reads Int128::MIN
+    it_reads -10_i128
+    it_reads 0_i128
+    it_reads 10_i128
+    it_reads Int128::MAX
+
+    it "reads > Int128::MAX" do
+      pull = JSON::PullParser.new(Int128::MAX.to_s + "0")
+      pull.read?(Int128).should be_nil
+    end
+
+    it "reads < Int128::MIN" do
+      pull = JSON::PullParser.new(Int128::MIN.to_s + "0")
+      pull.read?(Int128).should be_nil
+    end
 
     it "reads > Int64::MAX" do
       pull = JSON::PullParser.new(Int64::MAX.to_s + "0")

--- a/src/json/any.cr
+++ b/src/json/any.cr
@@ -18,7 +18,7 @@
 # which return `nil` when the underlying value type won't match.
 struct JSON::Any
   # All possible JSON types.
-  alias Type = Nil | Bool | Int64 | Float64 | String | Array(JSON::Any) | Hash(String, JSON::Any)
+  alias Type = Nil | Bool | Int64 | Float64 | String | Array(JSON::Any) | Hash(String, JSON::Any) | Int128
 
   # Reads a `JSON::Any` value from the given pull parser.
   def self.new(pull : JSON::PullParser)
@@ -183,7 +183,19 @@ struct JSON::Any
   # Checks that the underlying value is `Int`, and returns its value as an `Int64`.
   # Returns `nil` otherwise.
   def as_i64? : Int64?
-    as_i64 if @raw.is_a?(Int64)
+    as_i64 if @raw.is_a?(Int)
+  end
+
+  # Checks that the underlying value is `Int`, and returns its value as an `Int128`.
+  # Raises otherwise.
+  def as_i128 : Int128
+    @raw.as(Int).to_i128
+  end
+
+  # Checks that the underlying value is `Int`, and returns its value as an `Int128`.
+  # Returns `nil` otherwise.
+  def as_i128? : Int128?
+    as_i128 if @raw.is_a?(Int128)
   end
 
   # Checks that the underlying value is `Float` (or `Int`), and returns its value as an `Float64`.

--- a/src/json/from_json.cr
+++ b/src/json/from_json.cr
@@ -129,6 +129,7 @@ end
                          "Int16"  => "i16",
                          "Int32"  => "i32",
                          "Int64"  => "i64",
+                         "Int128" => "i128",
                          "UInt8"  => "u8",
                          "UInt16" => "u16",
                          "UInt32" => "u32",
@@ -397,7 +398,7 @@ def Union.new(pull : JSON::PullParser)
       return pull.read_string
     {% end %}
     when .int?
-    {% type_order = [Int64, UInt64, Int32, UInt32, Int16, UInt16, Int8, UInt8, Float64, Float32] %}
+    {% type_order = [Int128, Int64, UInt64, Int32, UInt32, Int16, UInt16, Int8, UInt8, Float64, Float32] %}
     {% for type in type_order.select { |t| T.includes? t } %}
       value = pull.read?({{type}})
       return value unless value.nil?

--- a/src/json/pull_parser.cr
+++ b/src/json/pull_parser.cr
@@ -80,7 +80,7 @@ class JSON::PullParser
   getter kind : Kind
   getter bool_value : Bool
 
-  def int_value : Int64
+  def int_value : Int128
     token.int_value
   end
 
@@ -209,7 +209,7 @@ class JSON::PullParser
   end
 
   # Reads an integer value.
-  def read_int : Int64
+  def read_int : Int128
     expect_kind :int
     int_value.tap { read_next }
   end
@@ -317,7 +317,7 @@ class JSON::PullParser
   end
 
   # Reads an integer or a null value, and returns it.
-  def read_int_or_null : Int64?
+  def read_int_or_null : Int128?
     read_null_or { read_int }
   end
 
@@ -409,7 +409,7 @@ class JSON::PullParser
     read_bool if kind.bool?
   end
 
-  {% for type in [Int8, Int16, Int32, Int64, UInt8, UInt16, UInt32] %}
+  {% for type in [Int8, Int16, Int32, Int64, Int128, UInt8, UInt16, UInt32] %}
     # Reads an {{type}} value and returns it.
     #
     # If the value is not an integer or does not fit in a {{type}} variable, it returns `nil`.

--- a/src/json/token.cr
+++ b/src/json/token.cr
@@ -18,8 +18,8 @@ class JSON::Token
   property kind : Kind
   property string_value : String
 
-  def int_value : Int64
-    raw_value.to_i64
+  def int_value : Int128
+    raw_value.to_i128
   rescue exc : ArgumentError
     raise ParseException.new(exc.message, line_number, column_number)
   end


### PR DESCRIPTION
resolves #12953

My goal for this pr wasn't to do any groundbreaking changes, but just add int128 on top of the current code base. Although I would understand if json number support would need more groundbreaking code than just adding some on top of.

With that said this code can still make some current code break. Even if I have tried to minimize that of occurring.