### PR TITLE
Fix: Add `Nil` return type restrictions to `load_debug_info`

### DIFF
--- a/src/exception/call_stack/dwarf.cr
+++ b/src/exception/call_stack/dwarf.cr
@@ -11,7 +11,7 @@ struct Exception::CallStack
   @@dwarf_function_names : Array(Tuple(LibC::SizeT, LibC::SizeT, String))?
 
   # :nodoc:
-  def self.load_debug_info
+  def self.load_debug_info : Nil
     return if ENV["CRYSTAL_LOAD_DEBUG_INFO"]? == "0"
 
     unless @@dwarf_loaded

--- a/src/exception/call_stack/elf.cr
+++ b/src/exception/call_stack/elf.cr
@@ -4,7 +4,7 @@ require "crystal/elf"
 {% end %}
 
 struct Exception::CallStack
-  protected def self.load_debug_info_impl
+  protected def self.load_debug_info_impl : Nil
     base_address : LibC::Elf_Addr = 0
     phdr_callback = LibC::DlPhdrCallback.new do |info, size, data|
       # The first entry is the header for the current program.

--- a/src/exception/call_stack/mach_o.cr
+++ b/src/exception/call_stack/mach_o.cr
@@ -9,11 +9,11 @@ end
 struct Exception::CallStack
   @@image_slide : LibC::Long?
 
-  protected def self.load_debug_info_impl
+  protected def self.load_debug_info_impl : Nil
     read_dwarf_sections
   end
 
-  protected def self.read_dwarf_sections
+  protected def self.read_dwarf_sections : Nil
     locate_dsym_bundle do |mach_o|
       line_strings = mach_o.read_section?("__debug_line_str") do |sh, io|
         Crystal::DWARF::Strings.new(io, sh.offset, sh.size)

--- a/src/exception/call_stack/stackwalk.cr
+++ b/src/exception/call_stack/stackwalk.cr
@@ -7,7 +7,7 @@ struct Exception::CallStack
 
   @@sym_loaded = false
 
-  def self.load_debug_info
+  def self.load_debug_info : Nil
     return if ENV["CRYSTAL_LOAD_DEBUG_INFO"]? == "0"
 
     unless @@sym_loaded
@@ -20,7 +20,7 @@ struct Exception::CallStack
     end
   end
 
-  private def self.load_debug_info_impl
+  private def self.load_debug_info_impl : Nil
     # TODO: figure out if and when to call SymCleanup (it cannot be done in
     # `at_exit` because unhandled exceptions in `main_user_code` are printed
     # after those handlers)


### PR DESCRIPTION
This is a workaround to fix the immediate effect of #12982.

Ref https://github.com/crystal-lang/crystal/issues/12982#issuecomment-1398420649