### PR TITLE
Formatter: fix end indent after comment inside begin

### DIFF
--- a/spec/compiler/formatter/formatter_spec.cr
+++ b/spec/compiler/formatter/formatter_spec.cr
@@ -2416,4 +2416,14 @@ describe Crystal::Formatter do
       end
     end
     CRYSTAL
+
+  # #12964
+  assert_format <<-CRYSTAL
+    begin
+      begin
+        a
+        # b
+      end
+    end
+    CRYSTAL
 end

--- a/src/compiler/crystal/tools/formatter.cr
+++ b/src/compiler/crystal/tools/formatter.cr
@@ -319,7 +319,13 @@ module Crystal
       @indent = old_indent
 
       if has_newline && !last_found_comment && (!@wrote_newline || empty_expressions)
+        # Right after the last expression but we didn't insert a newline yet
+        # so we are still missing a newline following by an indent and the "end" keyword
         write_line
+        write_indent
+      elsif has_newline && last_found_comment && @wrote_newline
+        # Right after the last expression and we did insert a newline (because of a comment)
+        # so we are still missing an indent and the "end" keyword
         write_indent
       end
 


### PR DESCRIPTION
Fixes #12964