### PR TITLE
Fix redundant cast in interpreter

### DIFF
--- a/spec/compiler/interpreter/primitives_spec.cr
+++ b/spec/compiler/interpreter/primitives_spec.cr
@@ -852,5 +852,23 @@ describe Crystal::Repl::Interpreter do
         !MyClass(Int32)
         CRYSTAL
     end
+
+    it "does math primitive on union" do
+      interpret(<<-CRYSTAL).should eq(3)
+        module Test; end
+
+        a = 1
+        a.as(Int32 | Test) &+ 2
+        CRYSTAL
+    end
+
+    it "does math convert on union" do
+      interpret(<<-CRYSTAL).should eq(1)
+        module Test; end
+
+        a = 1
+        a.as(Int32 | Test).to_i64!
+        CRYSTAL
+    end
   end
 end

--- a/spec/compiler/interpreter/procs_spec.cr
+++ b/spec/compiler/interpreter/procs_spec.cr
@@ -114,4 +114,14 @@ describe Crystal::Repl::Interpreter do
       ->{ 42 }.foo.call
     CRYSTAL
   end
+
+  it "calls proc primitive on union of module that has no subtypes (#12954)" do
+    interpret(<<-CRYSTAL).should eq(42)
+      module Test
+      end
+
+      proc = ->{ 42 }
+      proc.as(Proc(Int32) | Test).call
+    CRYSTAL
+  end
 end

--- a/spec/compiler/interpreter/tuple_spec.cr
+++ b/spec/compiler/interpreter/tuple_spec.cr
@@ -128,6 +128,15 @@ describe Crystal::Repl::Interpreter do
         1 + ({1, 2, 3, 4}; 2)
       CRYSTAL
     end
+
+    it "does tuple indexer on union" do
+      interpret(<<-CRYSTAL).should eq(1)
+        module Test; end
+
+        a = {1}
+        a.as(Tuple(Int32) | Test)[0]
+        CRYSTAL
+    end
   end
 end
 

--- a/src/compiler/crystal/interpreter/primitives.cr
+++ b/src/compiler/crystal/interpreter/primitives.cr
@@ -9,15 +9,14 @@ class Crystal::Repl::Compiler
   private def visit_primitive(node, body, target_def)
     owner = node.super? ? node.scope : node.target_def.owner
     obj = node.obj
-    obj_type = obj.try &.type?.try &.remove_indirection
 
     case body.name
     when "unchecked_convert"
-      primitive_convert(node, body, checked: false)
+      primitive_convert(node, body, owner, checked: false)
     when "convert"
-      primitive_convert(node, body, checked: true)
+      primitive_convert(node, body, owner, checked: true)
     when "binary"
-      primitive_binary(node, body)
+      primitive_binary(node, body, owner)
     when "pointer_new"
       accept_call_members(node)
       return false unless @wants_value
@@ -27,30 +26,28 @@ class Crystal::Repl::Compiler
       discard_value(obj) if obj
       request_value(node.args.first)
 
-      scope_type = ((obj.try &.type) || scope).instance_type
-
-      pointer_instance_type = scope_type.instance_type.as(PointerInstanceType)
+      pointer_instance_type = owner.instance_type.as(PointerInstanceType)
       element_type = pointer_instance_type.element_type
       element_size = inner_sizeof_type(element_type)
 
       pointer_malloc(element_size, node: node)
-      pop(aligned_sizeof_type(scope_type), node: nil) unless @wants_value
+      pop(aligned_sizeof_type(pointer_instance_type), node: nil) unless @wants_value
     when "pointer_realloc"
       obj ? request_value(obj) : put_self(node: node)
       request_value(node.args.first)
 
-      scope_type = (obj.try &.type) || scope
-
-      pointer_instance_type = scope_type.instance_type.as(PointerInstanceType)
+      pointer_instance_type = owner.instance_type.as(PointerInstanceType)
       element_type = pointer_instance_type.element_type
       element_size = inner_sizeof_type(element_type)
 
       pointer_realloc(element_size, node: node)
-      pop(aligned_sizeof_type(scope_type), node: nil) unless @wants_value
+      pop(aligned_sizeof_type(pointer_instance_type), node: nil) unless @wants_value
     when "pointer_set"
       # Accept in reverse order so that it's easier for the interpreter
       obj = obj.not_nil!
-      element_type = obj.type.as(PointerInstanceType).element_type
+
+      pointer_instance_type = owner.instance_type.as(PointerInstanceType)
+      element_type = pointer_instance_type.element_type
 
       arg = node.args.first
       request_value(arg)
@@ -61,7 +58,8 @@ class Crystal::Repl::Compiler
 
       pointer_set(inner_sizeof_type(element_type), node: node)
     when "pointer_get"
-      element_type = obj.not_nil!.type.as(PointerInstanceType).element_type
+      pointer_instance_type = owner.instance_type.as(PointerInstanceType)
+      element_type = pointer_instance_type.element_type
 
       accept_call_members(node)
       return unless @wants_value
@@ -76,12 +74,18 @@ class Crystal::Repl::Compiler
       accept_call_members(node)
       return unless @wants_value
 
-      pointer_diff(inner_sizeof_type(obj.not_nil!.type.as(PointerInstanceType).element_type), node: node)
+      pointer_instance_type = owner.instance_type.as(PointerInstanceType)
+      element_type = pointer_instance_type.element_type
+
+      pointer_diff(inner_sizeof_type(element_type), node: node)
     when "pointer_add"
       accept_call_members(node)
       return unless @wants_value
 
-      pointer_add(inner_sizeof_type(obj.not_nil!.type.as(PointerInstanceType).element_type), node: node)
+      pointer_instance_type = owner.instance_type.as(PointerInstanceType)
+      element_type = pointer_instance_type.element_type
+
+      pointer_add(inner_sizeof_type(element_type), node: node)
     when "class"
       obj = obj.not_nil!
       type = obj.type.remove_indirection
@@ -104,23 +108,21 @@ class Crystal::Repl::Compiler
         put_type type, node: node
       end
     when "object_crystal_type_id"
-      type = obj.try(&.type) || scope
-
       unless @wants_value
         discard_value obj if obj
         return
       end
 
-      if type.is_a?(VirtualMetaclassType)
+      if owner.is_a?(VirtualMetaclassType)
         # For a virtual metaclass type, the value is already an int
         # that's exactly the crystal_type_id, so there's nothing else to do.
         if obj
-          obj.accept self
+          request_obj_and_cast_if_needed(obj, owner)
         else
           put_self node: node
         end
       else
-        put_i32 type_id(type), node: node
+        put_i32 type_id(owner), node: node
       end
     when "class_crystal_instance_type_id"
       type =
@@ -175,14 +177,15 @@ class Crystal::Repl::Compiler
         end
       end
     when "tuple_indexer_known_index"
-      obj = obj.not_nil!
+      unless @wants_value
+        accept_call_members(node)
+        return
+      end
 
-      type = obj.type
+      type = owner
       case type
       when TupleInstanceType
-        obj.accept self
-        return unless @wants_value
-
+        request_obj_or_self_and_cast_if_needed(node, obj, type)
         index = body.as(TupleIndexer).index
         case index
         in Int32
@@ -203,9 +206,7 @@ class Crystal::Repl::Compiler
           push_zeros(aligned_sizeof_type(element_type) - value_size, node: node)
         end
       when NamedTupleInstanceType
-        obj.accept self
-        return unless @wants_value
-
+        request_obj_or_self_and_cast_if_needed(node, obj, type)
         index = body.as(TupleIndexer).index
         case index
         when Int32
@@ -216,9 +217,7 @@ class Crystal::Repl::Compiler
           node.raise "BUG: missing handling of primitive #{body.name} with range"
         end
       else
-        discard_value obj
-        return unless @wants_value
-
+        discard_value obj if obj
         type = type.instance_type
         case type
         when TupleInstanceType
@@ -271,10 +270,7 @@ class Crystal::Repl::Compiler
       end
 
       if obj
-        request_value(obj)
-        if obj_type && obj_type != proc_type
-          downcast(node, obj_type, proc_type)
-        end
+        request_obj_and_cast_if_needed(obj, owner)
       else
         put_self(node: node)
       end
@@ -643,21 +639,16 @@ class Crystal::Repl::Compiler
     node.args.each { |arg| request_value(arg) }
   end
 
-  private def primitive_convert(node : ASTNode, body : Primitive, checked : Bool)
+  private def primitive_convert(node : ASTNode, body : Primitive, owner : Type, checked : Bool)
     obj = node.obj
 
-    return false if !obj && !@wants_value
+    unless @wants_value
+      discard_value(obj) if obj
+      return
+    end
 
-    obj_type =
-      if obj
-        obj.accept self
-        obj.type
-      else
-        put_self(node: node)
-        scope
-      end
-
-    return false unless @wants_value
+    obj_type = owner
+    request_obj_or_self_and_cast_if_needed(node, obj, obj_type)
 
     target_type = body.type
 
@@ -844,30 +835,29 @@ class Crystal::Repl::Compiler
     end
   end
 
-  private def primitive_binary(node, body)
+  private def primitive_binary(node, body, owner)
     unless @wants_value
-      node.obj.try &.accept self
-      node.args.each &.accept self
+      accept_call_members(node)
       return
     end
 
     case node.name
     when "+", "&+", "-", "&-", "*", "&*", "^", "|", "&", "unsafe_shl", "unsafe_shr", "unsafe_div", "unsafe_mod"
-      primitive_binary_op_math(node, body, node.name)
+      primitive_binary_op_math(node, body, owner, node.name)
     when "<", "<=", ">", ">=", "==", "!="
-      primitive_binary_op_cmp(node, body, node.name)
+      primitive_binary_op_cmp(node, body, owner, node.name)
     when "/", "fdiv"
-      primitive_binary_float_div(node, body)
+      primitive_binary_float_div(node, body, owner)
     else
       node.raise "BUG: missing handling of binary op #{node.name}"
     end
   end
 
-  private def primitive_binary_op_math(node : ASTNode, body : Primitive, op : String)
+  private def primitive_binary_op_math(node : ASTNode, body : Primitive, owner : Type, op : String)
     obj = node.obj
     arg = node.args.first
 
-    obj_type = obj.try(&.type) || scope
+    obj_type = owner
     arg_type = arg.type
 
     primitive_binary_op_math(obj_type, arg_type, obj, arg, node, op)
@@ -880,7 +870,7 @@ class Crystal::Repl::Compiler
       in .mixed64?
         if left_type.rank > right_type.rank
           # It's UInt64 op X where X is a signed integer
-          left_node ? left_node.accept(self) : put_self(node: node)
+          request_obj_or_self_and_cast_if_needed(node, left_node, left_type)
           right_node.accept self
 
           # TODO: do we need to check for overflow here?
@@ -907,7 +897,7 @@ class Crystal::Repl::Compiler
           kind = NumberKind::U64
         else
           # It's X op UInt64 where X is a signed integer
-          left_node ? left_node.accept(self) : put_self(node: node)
+          request_obj_or_self_and_cast_if_needed(node, left_node, left_type)
 
           # TODO: do we need to check for overflow here?
           primitive_convert(node, left_type.kind, :i64, checked: false)
@@ -936,7 +926,7 @@ class Crystal::Repl::Compiler
       in .mixed128?
         if left_type.rank > right_type.rank
           # It's UInt128 op X where X is a signed integer
-          left_node ? left_node.accept(self) : put_self(node: node)
+          request_obj_or_self_and_cast_if_needed(node, left_node, left_type)
           right_node.accept self
 
           # TODO: do we need to check for overflow here?
@@ -963,7 +953,7 @@ class Crystal::Repl::Compiler
           kind = NumberKind::U128
         else
           # It's X op UInt128 where X is a signed integer
-          left_node ? left_node.accept(self) : put_self(node: node)
+          request_obj_or_self_and_cast_if_needed(node, left_node, left_type)
 
           # TODO: do we need to check for overflow here?
           primitive_convert(node, left_type.kind, :i128, checked: false)
@@ -1004,7 +994,7 @@ class Crystal::Repl::Compiler
   end
 
   private def primitive_binary_op_math(left_type : IntegerType, right_type : FloatType, left_node : ASTNode?, right_node : ASTNode, node : ASTNode, op : String)
-    left_node ? left_node.accept(self) : put_self(node: node)
+    request_obj_or_self_and_cast_if_needed(node, left_node, left_type)
     primitive_convert node, left_type.kind, right_type.kind, checked: false
     right_node.accept self
 
@@ -1012,7 +1002,7 @@ class Crystal::Repl::Compiler
   end
 
   private def primitive_binary_op_math(left_type : FloatType, right_type : IntegerType, left_node : ASTNode?, right_node : ASTNode, node : ASTNode, op : String)
-    left_node ? left_node.accept(self) : put_self(node: node)
+    request_obj_or_self_and_cast_if_needed(node, left_node, left_type)
     right_node.accept self
     primitive_convert right_node, right_type.kind, left_type.kind, checked: false
 
@@ -1021,18 +1011,18 @@ class Crystal::Repl::Compiler
 
   private def primitive_binary_op_math(left_type : FloatType, right_type : FloatType, left_node : ASTNode?, right_node : ASTNode, node : ASTNode, op : String)
     if left_type == right_type
-      left_node ? left_node.accept(self) : put_self(node: node)
+      request_obj_or_self_and_cast_if_needed(node, left_node, left_type)
       right_node.accept self
       kind = left_type.kind
     elsif left_type.rank < right_type.rank
       # TODO: not tested
-      left_node ? left_node.accept(self) : put_self(node: node)
+      request_obj_or_self_and_cast_if_needed(node, left_node, left_type)
       primitive_convert node, left_type.kind, right_type.kind, checked: false
       right_node.accept self
       kind = right_type.kind
     else
       # TODO: not tested
-      left_node ? left_node.accept(self) : put_self(node: node)
+      request_obj_or_self_and_cast_if_needed(node, left_node, left_type)
       right_node.accept self
       primitive_convert right_node, right_type.kind, left_type.kind, checked: false
       kind = left_type.kind
@@ -1181,11 +1171,11 @@ class Crystal::Repl::Compiler
     node.raise "BUG: primitive_binary_op_math called with #{left_type} #{op} #{right_type}"
   end
 
-  private def primitive_binary_op_cmp(node : ASTNode, body : Primitive, op : String)
+  private def primitive_binary_op_cmp(node : ASTNode, body : Primitive, owner : Type, op : String)
     obj = node.obj.not_nil!
     arg = node.args.first
 
-    obj_type = obj.type
+    obj_type = owner
     arg_type = arg.type
 
     primitive_binary_op_cmp(obj_type, arg_type, obj, arg, node, op)
@@ -1365,7 +1355,7 @@ class Crystal::Repl::Compiler
     if left_type.rank <= 5 && right_type.rank <= 5
       # If both fit in an Int32
       # Convert them to Int32 first, then do the comparison
-      left_node ? left_node.accept(self) : put_self(node: node)
+      request_obj_or_self_and_cast_if_needed(node, left_node, left_type)
       primitive_convert(left_node || right_node, left_type.kind, :i32, checked: false) if left_type.rank < 5
 
       right_node.accept self
@@ -1374,16 +1364,16 @@ class Crystal::Repl::Compiler
       NumberKind::I32
     elsif left_type.signed? == right_type.signed?
       if left_type.rank == right_type.rank
-        left_node ? left_node.accept(self) : put_self(node: node)
+        request_obj_or_self_and_cast_if_needed(node, left_node, left_type)
         right_node.accept self
         left_type.kind
       elsif left_type.rank < right_type.rank
-        left_node ? left_node.accept(self) : put_self(node: node)
+        request_obj_or_self_and_cast_if_needed(node, left_node, left_type)
         primitive_convert(left_node || right_node, left_type.kind, right_type.kind, checked: false)
         right_node.accept self
         right_type.kind
       else
-        left_node ? left_node.accept(self) : put_self(node: node)
+        request_obj_or_self_and_cast_if_needed(node, left_node, left_type)
         right_node.accept self
         primitive_convert(right_node, right_type.kind, left_type.kind, checked: false)
         left_type.kind
@@ -1391,7 +1381,7 @@ class Crystal::Repl::Compiler
     elsif left_type.rank <= 7 && right_type.rank <= 7
       # If both fit in an Int64
       # Convert them to Int64 first, then do the comparison
-      left_node ? left_node.accept(self) : put_self(node: node)
+      request_obj_or_self_and_cast_if_needed(node, left_node, left_type)
       primitive_convert(left_node || right_node, left_type.kind, :i64, checked: false) if left_type.rank < 7
 
       right_node.accept self
@@ -1403,7 +1393,7 @@ class Crystal::Repl::Compiler
     elsif left_type.rank <= 9 && right_type.rank <= 9
       # If both fit in an Int128
       # Convert them to Int128 first, then do the comparison
-      left_node ? left_node.accept(self) : put_self(node: node)
+      request_obj_or_self_and_cast_if_needed(node, left_node, left_type)
       primitive_convert(left_node || right_node, left_type.kind, :i128, checked: false) if left_type.rank < 9
 
       right_node.accept self
@@ -1415,12 +1405,12 @@ class Crystal::Repl::Compiler
     end
   end
 
-  private def primitive_binary_float_div(node : ASTNode, body)
+  private def primitive_binary_float_div(node : ASTNode, body, owner : Type)
     # TODO: don't assume Float64 op Float64
     obj = node.obj.not_nil!
     arg = node.args.first
 
-    obj_type = obj.type
+    obj_type = owner
     arg_type = arg.type
 
     obj_kind = integer_or_float_kind(obj_type).not_nil!
@@ -1462,6 +1452,23 @@ class Crystal::Repl::Compiler
       type.kind
     else
       nil
+    end
+  end
+
+  private def request_obj_and_cast_if_needed(obj, owner)
+    request_value(obj)
+
+    obj_type = obj.try &.type?.try &.remove_indirection
+    if obj_type && obj_type != owner
+      downcast(obj, obj_type, owner)
+    end
+  end
+
+  private def request_obj_or_self_and_cast_if_needed(node, obj, owner)
+    if obj
+      request_obj_and_cast_if_needed(obj, owner)
+    else
+      put_self(node: node)
     end
   end
 end


### PR DESCRIPTION
Fixes #12954

The original failing code in interpreted mode works fine in compiled mode. In compiled mode the type of the primitive call receiver (an int, a proc, etc.) is computed from the `node` itself. This wasn't done in interpreted mode only because I forgot to check how it's done in compiled mode.

Then, once we correctly pinned the receiver type, it can still happen that the receiver is a union type. For example in this case:

```crystal
module Test
end

a = 1
a.as(Int32 | Test) &+ 2
```

the receiver is `Int32 | Test`. However, `Test` has no subtypes so it's okay to "cast" the receiver from that union to `Int32` because it's impossible for it to have the value `Test`. This is the second change introduced in this PR.

Note that if `Test` had includers then the above method could would have gone through a normal dispatch, and the primitive call would have gotten the int already extracted from the union. So this PR is just fixing that special case.