### PR TITLE
expanding json parsing to json objects larger than Int32 bytes

### DIFF
--- a/src/json.cr
+++ b/src/json.cr
@@ -119,13 +119,13 @@ module JSON
   # Exception thrown on a JSON parse error.
   class ParseException < Error
     getter line_number : Int32
-    getter column_number : Int32
+    getter column_number : UInt64
 
     def initialize(message, @line_number, @column_number, cause = nil)
       super "#{message} at line #{@line_number}, column #{@column_number}", cause
     end
 
-    def location : {Int32, Int32}
+    def location : {Int32, UInt64}
       {line_number, column_number}
     end
   end

--- a/src/json/lexer.cr
+++ b/src/json/lexer.cr
@@ -15,7 +15,7 @@ abstract class JSON::Lexer
   def initialize
     @token = Token.new
     @line_number = 1
-    @column_number = 1
+    @column_number = 1_u64
     @buffer = IO::Memory.new
     @string_pool = StringPool.new
     @skip = false
@@ -80,7 +80,7 @@ abstract class JSON::Lexer
     while whitespace?(current_char)
       if current_char == '\n'
         @line_number += 1
-        @column_number = 0
+        @column_number = 0_u64
       end
       next_char
     end

--- a/src/json/pull_parser.cr
+++ b/src/json/pull_parser.cr
@@ -104,7 +104,7 @@ class JSON::PullParser
     @raw_value = ""
     @object_stack = [] of ObjectStackKind
     @skip_count = 0
-    @location = {0, 0}
+    @location = {0, 0_u64}
 
     next_token
     case token.kind
@@ -580,7 +580,7 @@ class JSON::PullParser
   # Returns the current location.
   #
   # The location is a tuple `{line number, column number}`.
-  def location : Tuple(Int32, Int32)
+  def location : Tuple(Int32, UInt64)
     @location
   end
 

--- a/src/json/serialization.cr
+++ b/src/json/serialization.cr
@@ -490,7 +490,7 @@ module JSON
     getter klass : String
     getter attribute : String?
 
-    def initialize(message : String?, @klass : String, @attribute : String?, line_number : Int32, column_number : Int32, cause)
+    def initialize(message : String?, @klass : String, @attribute : String?, line_number : Int32, column_number : UInt64, cause)
       message = String.build do |io|
         io << message
         io << "\n  parsing "

--- a/src/json/token.cr
+++ b/src/json/token.cr
@@ -31,13 +31,13 @@ class JSON::Token
   end
 
   property line_number : Int32
-  property column_number : Int32
+  property column_number : UInt64
   property raw_value : String
 
   def initialize
     @kind = :EOF
     @line_number = 0
-    @column_number = 0
+    @column_number = 0_u64
     @string_value = ""
     @raw_value = ""
   end


### PR DESCRIPTION
Ran into an issue with a large json object.   the column_count was stored as an int32 and raised an exception once it hit 2,147,483,647 bytes

line number should potentially be changed as well but may be harder to hit 