### PR TITLE
Add `Enum#inspect`

### DIFF
--- a/spec/std/enum_spec.cr
+++ b/spec/std/enum_spec.cr
@@ -60,7 +60,7 @@ describe Enum do
 
     it "for flags enum" do
       assert_prints SpecEnumFlags::None.to_s, "None"
-      assert_prints SpecEnumFlags::All.to_s, "One | Two | Three"
+      assert_prints SpecEnumFlags::All.to_s, "All"
       assert_prints (SpecEnumFlags::One | SpecEnumFlags::Two).to_s, "One | Two"
       assert_prints SpecEnumFlags.new(128).to_s, "128"
       assert_prints (SpecEnumFlags::One | SpecEnumFlags.new(128)).to_s, "One | 128"

--- a/spec/std/enum_spec.cr
+++ b/spec/std/enum_spec.cr
@@ -78,6 +78,35 @@ describe Enum do
     end
   end
 
+  describe "#inspect" do
+    it "for simple enum" do
+      assert_prints SpecEnum::One.inspect, "SpecEnum::One"
+      assert_prints SpecEnum::Two.inspect, "SpecEnum::Two"
+      assert_prints SpecEnum::Three.inspect, "SpecEnum::Three"
+      assert_prints SpecEnum.new(127).inspect, "SpecEnum[127]"
+    end
+
+    it "for flags enum" do
+      assert_prints SpecEnumFlags::None.inspect, "SpecEnumFlags::None"
+      assert_prints SpecEnumFlags::All.inspect, "SpecEnumFlags::All"
+      assert_prints (SpecEnumFlags::One).inspect, "SpecEnumFlags::One"
+      assert_prints (SpecEnumFlags::One | SpecEnumFlags::Two).inspect, "SpecEnumFlags[One, Two]"
+      assert_prints SpecEnumFlags.new(128).inspect, "SpecEnumFlags[128]"
+      assert_prints (SpecEnumFlags::One | SpecEnumFlags.new(128)).inspect, "SpecEnumFlags[One, 128]"
+      assert_prints (SpecEnumFlags::One | SpecEnumFlags.new(8) | SpecEnumFlags.new(16)).inspect, "SpecEnumFlags[One, 24]"
+      assert_prints (SpecEnumFlags::One | SpecEnumFlags::Two | SpecEnumFlags.new(16)).inspect, "SpecEnumFlags[One, Two, 16]"
+    end
+
+    it "for private enum" do
+      assert_prints PrivateEnum::FOO.inspect, "PrivateEnum::FOO"
+      assert_prints PrivateFlagsEnum::FOO.inspect, "PrivateFlagsEnum::FOO"
+      assert_prints PrivateEnum::QUX.inspect, "PrivateEnum::FOO"
+      assert_prints (PrivateFlagsEnum::FOO | PrivateFlagsEnum::BAZ).inspect, "PrivateFlagsEnum[FOO, BAZ]"
+      assert_prints PrivateFlagsEnum.new(128).inspect, "PrivateFlagsEnum[128]"
+      assert_prints (PrivateFlagsEnum::FOO | PrivateFlagsEnum.new(128)).inspect, "PrivateFlagsEnum[FOO, 128]"
+    end
+  end
+
   it "creates an enum instance from an auto-casted symbol (#8573)" do
     enum_value = SpecEnum.new(:two)
     enum_value.should eq SpecEnum::Two

--- a/spec/std/file_spec.cr
+++ b/spec/std/file_spec.cr
@@ -1478,8 +1478,8 @@ describe "File" do
     it "does to_s" do
       perm = File::Permissions.flags(OwnerAll, GroupRead, GroupWrite, OtherRead)
       perm.to_s.should eq("rwxrw-r-- (0o764)")
-      perm.inspect.should eq("rwxrw-r-- (0o764)")
-      perm.pretty_inspect.should eq("rwxrw-r-- (0o764)")
+      perm.inspect.should eq("File::Permissions[OtherRead, GroupWrite, GroupRead, OwnerExecute, OwnerWrite, OwnerRead]")
+      perm.pretty_inspect.should eq("File::Permissions[OtherRead, GroupWrite, GroupRead, OwnerExecute, OwnerWrite, OwnerRead]")
     end
   end
 end

--- a/src/enum.cr
+++ b/src/enum.cr
@@ -132,6 +132,8 @@ struct Enum
     {% if @type.annotation(Flags) %}
       if value == 0
         io << "None"
+      elsif name = member_name
+        io << name
       else
         remaining_value = self.value
         {% for member in @type.constants %}

--- a/src/enum.cr
+++ b/src/enum.cr
@@ -135,20 +135,7 @@ struct Enum
       elsif name = member_name
         io << name
       else
-        remaining_value = self.value
-        {% for member in @type.constants %}
-          {% if member.stringify != "All" %}
-            if {{@type.constant(member)}} != 0 && value.bits_set? {{@type.constant(member)}}
-              io << " | " unless remaining_value == self.value
-              io << {{member.stringify}}
-              remaining_value &= ~{{@type.constant(member)}}
-            end
-          {% end %}
-        {% end %}
-        unless remaining_value.zero?
-          io << " | " unless remaining_value == self.value
-          io << remaining_value
-        end
+        stringify_names(io, " | ")
       end
     {% else %}
       io << to_s
@@ -176,6 +163,26 @@ struct Enum
     {% else %}
       member_name || value.to_s
     {% end %}
+  end
+
+  private def stringify_names(io, separator) : Nil
+    remaining_value = self.value
+    {% for member in @type.constants %}
+      {% if member.stringify != "All" %}
+        if {{@type.constant(member)}} != 0 && remaining_value.bits_set? {{@type.constant(member)}}
+          unless remaining_value == self.value
+            io << separator
+          end
+          io << {{member.stringify}}
+          remaining_value &= ~{{@type.constant(member)}}
+        end
+      {% end %}
+    {% end %}
+
+    unless remaining_value.zero?
+      io << separator unless remaining_value == self.value
+      io << remaining_value
+    end
   end
 
   private def member_name

--- a/src/enum.cr
+++ b/src/enum.cr
@@ -173,15 +173,17 @@ struct Enum
     {% if @type.annotation(Flags) %}
       String.build { |io| to_s(io) }
     {% else %}
-      # Can't use `case` here because case with duplicate values do
-      # not compile, but enums can have duplicates (such as `enum Foo; FOO = 1; BAR = 1; end`).
-      {% for member, i in @type.constants %}
-        if value == {{@type.constant(member)}}
-          return {{member.stringify}}
-        end
-      {% end %}
+      member_name || value.to_s
+    {% end %}
+  end
 
-      value.to_s
+  private def member_name
+    # Can't use `case` here because case with duplicate values do
+    # not compile, but enums can have duplicates (such as `enum Foo; FOO = 1; BAR = 1; end`).
+    {% for member in @type.constants %}
+      if value == {{@type.constant(member)}}
+        return {{member.stringify}}
+      end
     {% end %}
   end
 

--- a/src/enum.cr
+++ b/src/enum.cr
@@ -151,7 +151,6 @@ struct Enum
     {% else %}
       io << to_s
     {% end %}
-    nil
   end
 
   # Returns a `String` representation of this enum member.


### PR DESCRIPTION
Implements `Enum#inspect` with a syntax based on `Enum.[]` (https://github.com/crystal-lang/crystal/pull/12900) as proposed in #12884.

Resolves #12884