### PR TITLE
Add forward_missing_to @object to Colorize

### DIFF
--- a/spec/std/colorize_spec.cr
+++ b/spec/std/colorize_spec.cr
@@ -189,4 +189,13 @@ describe "colorize" do
   it "toggles off and on" do
     colorize("hello").toggle(false).black.toggle(true).to_s.should eq("\e[30mhello\e[0m")
   end
+
+  it "forwards missing method calls to the underlying object" do
+    color_str = "Hello, World!".colorize.red
+    color_str.size.should eq 13
+    color_str.to_s.size.should eq 22
+    just_a_string = color_str + " I am just a String."
+    just_a_string.should eq "Hello, World! I am just a String."
+    color_str.to_s.should match(/\e\[31m/)
+  end
 end

--- a/src/colorize.cr
+++ b/src/colorize.cr
@@ -333,6 +333,7 @@ end
 # A colorized object. Colors and text decorations can be modified.
 struct Colorize::Object(T)
   private COLORS = %w(default black red green yellow blue magenta cyan light_gray dark_gray light_red light_green light_yellow light_blue light_magenta light_cyan white)
+  private MODES = %w(bold bright dim underline blink reverse hidden)
 
   @fore : Color
   @back : Color
@@ -419,6 +420,18 @@ struct Colorize::Object(T)
   def mode(mode : Mode) : self
     @mode |= mode
     self
+  end
+
+  def mode(mode : Symbol) : self
+    {% begin %}
+      case mode
+      {% for name in MODES %}
+      when :{{name.id}}
+        mode(Mode::{{name.capitalize.id}})
+      {% end %}
+      end
+    {% end %}
+    return self
   end
 
   def on(color : Symbol)

--- a/src/colorize.cr
+++ b/src/colorize.cr
@@ -114,6 +114,33 @@
 # ```
 #
 # See `Colorize::Mode` for available text decorations.
+#
+# ### Method Forwarding
+#
+# In order to allow a colorized object, such as a String, to continue to generally
+# be used as its original object, `Colorize::Object(T)` uses `forward_missing_to`
+# in order to forward all method calls that aren't applicable to Colorize on to the
+# original object. This means that, for example, a method like this:
+#
+# ```
+# def initialize(label : String, action : ->)
+#   @label = label
+#   @action = action
+# end
+# ```
+#
+# Can become this:
+#
+# ```
+# def initialize(label : String | Colorize::Object(String), action : ->)
+#   @label = label
+#   @action = action
+# end
+# ```
+#
+# Whatever is consequently done with `@label`, which is expected to be a `String`, will
+# likely work with the colorized string, with no other changes required.
+#
 module Colorize
   # Objects will only be colored if this is `true`.
   #
@@ -309,6 +336,8 @@ struct Colorize::Object(T)
 
   @fore : Color
   @back : Color
+
+  forward_missing_to @object
 
   def initialize(@object : T)
     @fore = ColorANSI::Default


### PR DESCRIPTION
While working with code in a few other areas, including Benchmark::IPS, I tripped a little over the fact that a colorized String (or any other object) becomes an instance of `Colorize::Object(T)`, and can no longer be used as it's original object type.

There are many times where one may want to inject some color or mode changes into a String and still transparently use the resulting object as if it were a String.

This patch adds a `forward_missing_to @object`, which in most cases where the type signature allows it, lets a colorized object like a colorized String duck type its way through life as if it were still a String, which simplifies many things.

The patch also adds a `mode` method like the `fore` and `back` methods, because without it, `forward_missing_to` caused spec failures. I also added a basic spec to exercise the method forwarding as part of this change.