### PR TITLE
Fix wrong default address when binding sockets

### DIFF
--- a/spec/std/socket/socket_spec.cr
+++ b/spec/std/socket/socket_spec.cr
@@ -12,6 +12,10 @@ describe Socket, tags: "network" do
 
       sock = Socket.unix(Socket::Type::DGRAM)
       sock.type.should eq(Socket::Type::DGRAM)
+
+      expect_raises Socket::Error, "Protocol not supported" do
+        socket = TCPSocket.new(family: :unix)
+      end
     end
   end
 
@@ -115,6 +119,22 @@ describe Socket, tags: "network" do
         address.port.should be > 0
       ensure
         socket.try &.close
+      end
+
+      it "binds to port using default IP" do
+        socket = TCPSocket.new family
+        socket.bind unused_local_port
+        socket.listen
+
+        address = socket.local_address.as(Socket::IPAddress)
+        address.address.should eq(any_address)
+        address.port.should be > 0
+
+        socket.close
+
+        socket = UDPSocket.new family
+        socket.bind unused_local_port
+        socket.close
       end
     end
   end

--- a/spec/std/socket/socket_spec.cr
+++ b/spec/std/socket/socket_spec.cr
@@ -14,7 +14,7 @@ describe Socket, tags: "network" do
       sock.type.should eq(Socket::Type::DGRAM)
 
       expect_raises Socket::Error, "Protocol not supported" do
-        socket = TCPSocket.new(family: :unix)
+        TCPSocket.new(family: :unix)
       end
     end
   end

--- a/src/socket.cr
+++ b/src/socket.cr
@@ -116,11 +116,16 @@ class Socket < IO
   # sock.bind 1234
   # ```
   def bind(port : Int)
-    domain = @family.inet? ? "0.0.0.0" : "::"
-    domain_and_port = @family.inet? ? "0.0.0.0:#{port}" : "::#{port}"
+    if family.inet?
+      address = "0.0.0.0"
+      address_and_port = "0.0.0.0#{port}"
+    else
+      address = "::"
+      address_and_port = "::#{port}"
+    end
 
-    Addrinfo.resolve(domain, port, @family, @type, @protocol) do |addrinfo|
-      system_bind(addrinfo, domain_and_port) { |errno| errno }
+    Addrinfo.resolve(address, port, @family, @type, @protocol) do |addrinfo|
+      system_bind(addrinfo, address_and_port) { |errno| errno }
     end
   end
 

--- a/src/socket.cr
+++ b/src/socket.cr
@@ -118,10 +118,10 @@ class Socket < IO
   def bind(port : Int)
     if family.inet?
       address = "0.0.0.0"
-      address_and_port = "0.0.0.0#{port}"
+      address_and_port = "0.0.0.0:#{port}"
     else
       address = "::"
-      address_and_port = "::#{port}"
+      address_and_port = "[::]:#{port}"
     end
 
     Addrinfo.resolve(address, port, @family, @type, @protocol) do |addrinfo|

--- a/src/socket.cr
+++ b/src/socket.cr
@@ -116,8 +116,11 @@ class Socket < IO
   # sock.bind 1234
   # ```
   def bind(port : Int)
-    Addrinfo.resolve("::", port, @family, @type, @protocol) do |addrinfo|
-      system_bind(addrinfo, "::#{port}") { |errno| errno }
+    domain = @family.inet? ? "0.0.0.0" : "::"
+    domain_and_port = @family.inet? ? "0.0.0.0:#{port}" : "::#{port}"
+
+    Addrinfo.resolve(domain, port, @family, @type, @protocol) do |addrinfo|
+      system_bind(addrinfo, domain_and_port) { |errno| errno }
     end
   end
 


### PR DESCRIPTION
Hello! This is my first PR!

The following code would crash on my laptop:

```cr
require "socket"

entry = TCPSocket.new
entry.bind(1234)
```

With the stacktrace
```
Unhandled exception: Hostname lookup for :: failed: No address found (Socket::Addrinfo::Error)
  from /opt/homebrew/Cellar/crystal/1.7.2/share/crystal/src/socket/addrinfo.cr:132:7 in 'bind'
  from /opt/homebrew/Cellar/crystal/1.7.2/share/crystal/src/socket/ip_socket.cr:23:5 in 'bind'
  from smth.cr:4:1 in '__crystal_main'
```

Because it tries to resolve the address `::` when the Family is INET.

I am unsure on raising an exception because that case should never hit since you cannot initiate an unix socket by only assigning a port, advice is welcomed!