### PR TITLE
Changelog helper: Report error from HTTP request

### DIFF
--- a/scripts/github-changelog.cr
+++ b/scripts/github-changelog.cr
@@ -65,6 +65,9 @@ response = HTTP::Client.post("https://api.github.com/graphql",
     "Authorization" => "bearer #{api_token}",
   }
 )
+unless response.success?
+  abort "GitHub API response: #{response.status}\n#{response.body}"
+end
 
 module LabelNameConverter
   def self.from_json(pull : JSON::PullParser)


### PR DESCRIPTION
Adds a simple error handler in case the GitHub API request failed.