### PR TITLE
Define equality for `Process::Status` and `OAuth::RequestToken`

### DIFF
--- a/spec/std/oauth/request_token_spec.cr
+++ b/spec/std/oauth/request_token_spec.cr
@@ -7,4 +7,40 @@ describe OAuth::RequestToken do
     token.secret.should eq("p58A6bzyGaT8PR54gM0S4ZesOVC2ManiTmwHcho8")
     token.token.should eq("qyprd6Pe2PbnSxUcyHcWz0VnTF8bg1rxsBbUwOpkQ6bSQEyK")
   end
+
+  describe "equality" do
+    it "checks token" do
+      foo1 = OAuth::RequestToken.new("foo", "secret")
+      foo2 = OAuth::RequestToken.new("foo", "secret")
+      bar1 = OAuth::RequestToken.new("bar", "secret")
+      bar2 = OAuth::RequestToken.new("bar", "secret")
+
+      foo1.should eq(foo2)
+      foo1.should_not eq(bar2)
+      bar1.should_not eq(foo2)
+      bar1.should eq(bar2)
+
+      foo1.hash.should eq(foo2.hash)
+      foo1.hash.should_not eq(bar2.hash)
+      bar1.hash.should_not eq(foo2.hash)
+      bar1.hash.should eq(bar2.hash)
+    end
+
+    it "checks secret" do
+      foo1 = OAuth::RequestToken.new("token", "foo")
+      foo2 = OAuth::RequestToken.new("token", "foo")
+      bar1 = OAuth::RequestToken.new("token", "bar")
+      bar2 = OAuth::RequestToken.new("token", "bar")
+
+      foo1.should eq(foo2)
+      foo1.should_not eq(bar2)
+      bar1.should_not eq(foo2)
+      bar1.should eq(bar2)
+
+      foo1.hash.should eq(foo2.hash)
+      foo1.hash.should_not eq(bar2.hash)
+      bar1.hash.should_not eq(foo2.hash)
+      bar1.hash.should eq(bar2.hash)
+    end
+  end
 end

--- a/spec/std/process/status_spec.cr
+++ b/spec/std/process/status_spec.cr
@@ -41,6 +41,23 @@ describe Process::Status do
     Process::Status.new(exit_status(255)).signal_exit?.should be_false
   end
 
+  it "equality" do
+    ok1 = Process::Status.new(exit_status(0))
+    ok2 = Process::Status.new(exit_status(0))
+    err1 = Process::Status.new(exit_status(1))
+    err2 = Process::Status.new(exit_status(1))
+
+    ok1.should eq(ok2)
+    ok1.should_not eq(err2)
+    err1.should_not eq(ok2)
+    err1.should eq(err2)
+
+    ok1.hash.should eq(ok2.hash)
+    ok1.hash.should_not eq(err2.hash)
+    err1.hash.should_not eq(ok2.hash)
+    err1.hash.should eq(err2.hash)
+  end
+
   {% if flag?(:unix) && !flag?(:wasi) %}
     it "#exit_signal" do
       Process::Status.new(Signal::HUP.value).exit_signal.should eq Signal::HUP

--- a/src/oauth/request_token.cr
+++ b/src/oauth/request_token.cr
@@ -20,4 +20,6 @@ class OAuth::RequestToken
 
     new token.not_nil!, secret.not_nil!
   end
+
+  def_equals_and_hash @token, @secret
 end

--- a/src/process/status.cr
+++ b/src/process/status.cr
@@ -74,4 +74,6 @@ class Process::Status
     # define __WTERMSIG(status) ((status) & 0x7f)
     @exit_status & 0x7f
   end
+
+  def_equals_and_hash @exit_status
 end


### PR DESCRIPTION
In #8226 it was agreed that these two types are value objects and would have been structs if doing so didn't produce a breaking change. This PR implements a weaker alternative where `#==` and `#hash` respect value equality for different instances.