### PR TITLE
Compiler: type declaration with initial value gets the value's type

### DIFF
--- a/spec/compiler/codegen/var_spec.cr
+++ b/spec/compiler/codegen/var_spec.cr
@@ -5,6 +5,10 @@ describe "Code gen: var" do
     run("a = 1; 1.5; a").to_i.should eq(1)
   end
 
+  it "codegens var with type declaration" do
+    run("a = (b : Int32 = 1); a").to_i.should eq(1)
+  end
+
   it "codegens ivar assignment when not-nil type filter applies" do
     run("
       class Foo

--- a/spec/compiler/interpreter/primitives_spec.cr
+++ b/spec/compiler/interpreter/primitives_spec.cr
@@ -114,6 +114,12 @@ describe Crystal::Repl::Interpreter do
       CRYSTAL
     end
 
+    it "interprets variable set with type restriction (#13023)" do
+      interpret(<<-CRYSTAL).should eq(1)
+      a : Int32 = 1
+      CRYSTAL
+    end
+
     it "interprets variable set and get" do
       interpret(<<-CRYSTAL).should eq(1)
       a = 1

--- a/spec/compiler/semantic/var_spec.cr
+++ b/spec/compiler/semantic/var_spec.cr
@@ -22,6 +22,10 @@ describe "Semantic: var" do
     node.type.should eq(mod.int32)
   end
 
+  it "types an assign with type declaration" do
+    assert_type("a : Int32 = 1") { int32 }
+  end
+
   it "reports undefined local variable or method" do
     assert_error "
       def foo

--- a/src/compiler/crystal/codegen/codegen.cr
+++ b/src/compiler/crystal/codegen/codegen.cr
@@ -1155,6 +1155,7 @@ module Crystal
 
         if value = node.value
           codegen_assign(var, value, node)
+          return false
         end
       when Global
         node.raise "BUG: there should be no use of global variables other than $~ and $?"

--- a/src/compiler/crystal/semantic/main_visitor.cr
+++ b/src/compiler/crystal/semantic/main_visitor.cr
@@ -424,11 +424,17 @@ module Crystal
 
         if value = node.value
           type_assign(var, value, node)
+
+          node.bind_to value
+        else
+          node.type = @program.nil
         end
       when InstanceVar
         if @untyped_def
           node.raise "declaring the type of an instance variable must be done at the class level"
         end
+
+        node.type = @program.nil
       when ClassVar
         if @untyped_def
           node.raise "declaring the type of a class variable must be done at the class level"
@@ -439,11 +445,11 @@ module Crystal
         class_var = lookup_class_var(var)
         var.var = class_var
         class_var.thread_local = true if thread_local
+
+        node.type = @program.nil
       else
         raise "Bug: unexpected var type: #{var.class}"
       end
-
-      node.type = @program.nil
 
       false
     end


### PR DESCRIPTION
Fixes #13023

This actually slightly changes the compiler's semantic.

Look at this code:

```crystal
a = (b : Int32 = 1)
p a
```

What do you expect it to print?

Well, previously it printed `nil`. Now it prints `1`. The type (and value) of a local bariable type declaration with an initial value now is the initial value's type and value.

Note: another way to have fixed this would have been to produce a `nil` for that expression, in the interpreter, just like compiled mode. But I think it makes more sense to change the semantics here.

For type declarations without an initial value the type is still nil:

```crystal
a = (b : Int32)
a # => nil
```

the reason is that `b` doesn't really have any valid value at that point.

This also should cause any breaking change because:
1. The value of such expressions was probably rarely used.
2. And if they were used, their value was nil, so unlikely to be used for something (like, say, putting things in a collection)
