### PR TITLE
Parser: remove obsolete handling of `else` inside lib struct

### DIFF
--- a/spec/compiler/formatter/formatter_spec.cr
+++ b/spec/compiler/formatter/formatter_spec.cr
@@ -2426,4 +2426,19 @@ describe Crystal::Formatter do
       end
     end
     CRYSTAL
+
+  it do
+    expect_raises(Crystal::SyntaxException) do
+      Crystal.format <<-CRYSTAL
+        lib A
+          struct B
+            {% begin %}
+              x : Int32
+              else
+            {% end %}
+          end
+        end
+        CRYSTAL
+    end
+  end
 end

--- a/src/compiler/crystal/syntax/parser.cr
+++ b/src/compiler/crystal/syntax/parser.cr
@@ -5946,8 +5946,6 @@ module Crystal
             else
               parse_c_struct_or_union_fields exps
             end
-          when Keyword::ELSE
-            break
           when Keyword::END
             break
           else


### PR DESCRIPTION
A long time ago, [`ifdef` and `else` used to be special keywords inside lib structs and unions](https://github.com/crystal-lang/crystal/commit/06abeaf9a9bc9237bc163fde5f1f85b8760df719):

```crystal
lib LibC
  struct Foo
    ifdef some_flag
      a : Int32
    else
      a : Float64
    end
  end
end
```

Today the above would be written as:

```crystal
lib LibC
  struct Foo
    {% if flag?(:some_flag) %}
      a : Int32
    {% else %}
      a : Float64
    {% end %}
  end
end
```

So the handling for the `else` keyword in this context can be dropped. This doesn't affect the parser, but it does expose a syntax error in the top-level phase (detected only after macro interpolation) to the formatter.