### PR TITLE
Unset `CRYSTAL` variable if points to wrapper script

### DIFF
--- a/bin/crystal
+++ b/bin/crystal
@@ -144,6 +144,12 @@ fi
 
 export CRYSTAL_HAS_WRAPPER=true
 
+# In case the CRYSTAL variable is set to point to this wrapper script unset it to
+# use the default.
+if [ "$(realpath $CRYSTAL)" = "$SCRIPT_PATH" ]; then
+  unset CRYSTAL
+fi
+
 export CRYSTAL="${CRYSTAL:-"crystal"}"
 
 # check if the crystal command refers to this script


### PR DESCRIPTION
Prevents a bug that first appeared after https://github.com/crystal-lang/crystal/pull/11712#issuecomment-1408726426 was introduced: If the wrapper script is called with the `CRYSTAL` variable set to point to the wrapper script itself, it errors.
It's unclear why this worked before this change because from all I can tell it should have never worked to call it like `CRYSTAL=bin/crystal bin/crystal`.
This patch unsets `CRYSTAL` if it points to the wrapper script itself.
