### PR TITLE
[CI] Use Ubuntu 22.04 base image for LLVM tests

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -63,10 +63,10 @@ jobs:
         include:
         - llvm_version: 13.0.0
           llvm_url: https://github.com/llvm/llvm-project/releases/download/llvmorg-13.0.0/clang+llvm-13.0.0-x86_64-linux-gnu-ubuntu-20.04.tar.xz
-          base_image: ubuntu-20.04
+          base_image: ubuntu-22.04
         - llvm_version: 14.0.0
           llvm_url: https://github.com/llvm/llvm-project/releases/download/llvmorg-14.0.0/clang+llvm-14.0.0-x86_64-linux-gnu-ubuntu-18.04.tar.xz
-          base_image: ubuntu-18.04
+          base_image: ubuntu-22.04
     runs-on: ${{ matrix.base_image }}
     name: "Test LLVM ${{ matrix.llvm_version }} (${{ matrix.base_image }})"
     steps:


### PR DESCRIPTION
Update the base image used for LLVM tests, as an attempt to see if there are less failures on Ubuntu 22.04.
It's definitely good to update anyway.