### PR TITLE
Don't use deprecated `from_winerror` overload for `flock_*`

### DIFF
--- a/src/crystal/system/win32/file.cr
+++ b/src/crystal/system/win32/file.cr
@@ -294,7 +294,7 @@ module Crystal::System::File
       if winerror == WinError::ERROR_LOCK_VIOLATION
         false
       else
-        raise IO::Error.from_winerror("LockFileEx", winerror)
+        raise IO::Error.from_os_error("LockFileEx", winerror)
       end
     end
   end


### PR DESCRIPTION
This would also be part of #13036