### PR TITLE
Remove relative path to vendored shard `markd`

### DIFF
--- a/src/compiler/crystal/tools/doc/generator.cr
+++ b/src/compiler/crystal/tools/doc/generator.cr
@@ -1,4 +1,4 @@
-require "../../../../../lib/markd/src/markd"
+require "markd"
 require "crystal/syntax_highlighter/html"
 
 class Crystal::Doc::Generator


### PR DESCRIPTION
Standardizes the require mechanism for vendored shards in the compiler. We don't need to spell out the path, this is handled by the path lookup.

Ref https://github.com/crystal-lang/crystal/issues/12976#issuecomment-1396837703