### PR TITLE
Add `from_json` for 128-bit integers

### DIFF
--- a/spec/std/json/serializable_spec.cr
+++ b/spec/std/json/serializable_spec.cr
@@ -106,6 +106,12 @@ class JSONAttrWithBigDecimal
   property value : BigDecimal
 end
 
+class JSONAttrWithInt128
+  include JSON::Serializable
+
+  property value : Int128
+end
+
 class JSONAttrWithTime
   include JSON::Serializable
 
@@ -1043,6 +1049,11 @@ describe "JSON mapping" do
       json = JSONAttrWithBigDecimal.from_json(%({"value": 0.00045808999999999997}))
       json.value.should eq(BigDecimal.new("0.00045808999999999997"))
     end
+  end
+
+  it "parses 128-bit integer" do
+    json = JSONAttrWithInt128.from_json(%({"value": 186709961001538790100634132976990}))
+    json.value.should eq 186709961001538790100634132976990_i128
   end
 
   describe "work with module and inheritance" do

--- a/spec/std/json/serializable_spec.cr
+++ b/spec/std/json/serializable_spec.cr
@@ -1052,8 +1052,8 @@ describe "JSON mapping" do
   end
 
   it "parses 128-bit integer" do
-    json = JSONAttrWithInt128.from_json(%({"value": 186709961001538790100634132976990}))
-    json.value.should eq 186709961001538790100634132976990_i128
+    json = JSONAttrWithInt128.from_json(%({"value": #{Int128::MAX}}))
+    json.value.should eq Int128::MAX
   end
 
   describe "work with module and inheritance" do

--- a/spec/std/json/serialization_spec.cr
+++ b/spec/std/json/serialization_spec.cr
@@ -40,6 +40,14 @@ describe "JSON serialization" do
       UInt64.from_json(UInt64::MAX.to_s).should eq(UInt64::MAX)
     end
 
+    it "does UInt128.from_json" do
+      UInt128.from_json(UInt128::MAX.to_s).should eq(UInt128::MAX)
+    end
+
+    it "does Int128.from_json" do
+      Int128.from_json(Int128::MAX.to_s).should eq(Int128::MAX)
+    end
+
     it "raises ParserException for overflow UInt64.from_json" do
       expect_raises(JSON::ParseException, "Can't read UInt64 at line 0, column 0") do
         UInt64.from_json("1#{UInt64::MAX}")
@@ -499,6 +507,10 @@ describe "JSON serialization" do
 
     it "does for Int32" do
       1.to_json.should eq("1")
+    end
+
+    it "does for Int128" do
+      Int128::MAX.to_json.should eq(Int128::MAX.to_s)
     end
 
     it "does for Float64" do

--- a/src/json/from_json.cr
+++ b/src/json/from_json.cr
@@ -125,19 +125,21 @@ def Bool.new(pull : JSON::PullParser)
 end
 
 {% for type, method in {
-                         "Int8"   => "i8",
-                         "Int16"  => "i16",
-                         "Int32"  => "i32",
-                         "Int64"  => "i64",
-                         "UInt8"  => "u8",
-                         "UInt16" => "u16",
-                         "UInt32" => "u32",
-                         "UInt64" => "u64",
+                         "Int8"    => "i8",
+                         "Int16"   => "i16",
+                         "Int32"   => "i32",
+                         "Int64"   => "i64",
+                         "Int128"  => "i128",
+                         "UInt8"   => "u8",
+                         "UInt16"  => "u16",
+                         "UInt32"  => "u32",
+                         "UInt64"  => "u64",
+                         "UInt128" => "u128",
                        } %}
   def {{type.id}}.new(pull : JSON::PullParser)
     location = pull.location
     value =
-      {% if type == "UInt64" %}
+      {% if type == "UInt64" || type == "UInt128" || type == "Int128" %}
         pull.read_raw
       {% else %}
         pull.read_int


### PR DESCRIPTION
This is a first step to improve serialization support for large numbers.