### PR TITLE
Error when `find-llvm-config` is unsuccessful

### DIFF
--- a/src/llvm/ext/find-llvm-config
+++ b/src/llvm/ext/find-llvm-config
@@ -19,6 +19,6 @@ if [ "$LLVM_CONFIG" ]; then
   printf "$LLVM_CONFIG"
 else
   printf "Error: Could not find location of llvm-config. Please specify path in environment variable LLVM_CONFIG.\n" >&2
-  printf "Supported versions: $(cat "$(dirname $0)/llvm-versions.txt" | sed 's/\.0//g')\n" >&2
+  printf "Supported LLVM versions: $(cat "$(dirname $0)/llvm-versions.txt" | sed 's/\.0//g')\n" >&2
   exit 1
 fi

--- a/src/llvm/ext/find-llvm-config
+++ b/src/llvm/ext/find-llvm-config
@@ -14,4 +14,10 @@ if ! LLVM_CONFIG=$(command -v "$LLVM_CONFIG"); then
     [ "$LLVM_CONFIG" ] && break
   done
 fi
-printf "$LLVM_CONFIG"
+
+if [ "$LLVM_CONFIG" ]; then
+  printf "$LLVM_CONFIG"
+else
+  printf "Error: Could not find location of llvm-config. Please specify path in environment variable LLVM_CONFIG.\n" >&2
+  exit 1
+fi

--- a/src/llvm/ext/find-llvm-config
+++ b/src/llvm/ext/find-llvm-config
@@ -19,5 +19,6 @@ if [ "$LLVM_CONFIG" ]; then
   printf "$LLVM_CONFIG"
 else
   printf "Error: Could not find location of llvm-config. Please specify path in environment variable LLVM_CONFIG.\n" >&2
+  printf "Supported versions: $(cat "$(dirname $0)/llvm-versions.txt" | sed 's/\.0//g')\n" >&2
   exit 1
 fi


### PR DESCRIPTION
If `find-llvm-config` can't find an LLVM installation, it silent about it, print nothing and exiting as success. This results in undecipherable errors later on when `LibLLVM::LLVM_CONFIG` is called.

This patch changes the helper to error with status 1 and print an informative message to stderr if `LLVM_CONFIG` was not found.

Before:

```console
$ bin/crystal spec spec/std/llvm/
--: line 0: : Permission denied
Showing last frame. Use --error-trace for full trace.

In src/llvm/lib_llvm.cr:13:17

 13 | VERSION = {{`#{LibLLVM::LLVM_CONFIG} --version`.chomp.stringify}}
                  ^
Error: error executing command: "" --version, got exit status 127
```

After:

```console
$ bin/crystal spec spec/std/llvm/
Error: Could not find location of llvm-config. Please specify path in environment variable LLVM_CONFIG.
Supported LLVM versions: 14 13 12 11.1 11 10 9 8
Showing last frame. Use --error-trace for full trace.

In src/llvm/lib_llvm.cr:3:42

 3 | LLVM_CONFIG = {{ env("LLVM_CONFIG") || `#{__DIR__}/ext/find-llvm-config`.stringify }}
                                            ^
Error: error executing command: /app/src/llvm/ext/find-llvm-config, got exit status 1
```

Resolves https://forum.crystal-lang.org/t/problem-compiling-crystalline-for-the-vscode-plugin/5316