### PR TITLE
Propagate exit code correctly in Windows wrapper batch script

### DIFF
--- a/bin/crystal.ps1
+++ b/bin/crystal.ps1
@@ -206,6 +206,9 @@ function Exec-Process {
     # workaround to obtain the exit status properly: https://stackoverflow.com/a/23797762
     $hnd = $Process.Handle
     Wait-Process -Id $Process.Id
+
+    # and return it properly too: https://stackoverflow.com/a/50202663
+    $host.SetShouldExit($Process.ExitCode)
     Exit $Process.ExitCode
 }
 


### PR DESCRIPTION
On Windows, the `bin\crystal.ps1` wrapper script already writes the compiler's exit code to `$LASTEXITCODE` inside a PowerShell session. The `bin\crystal.bat` wrapper script, on the other hand, invokes the PowerShell script through the `-Command` command-line argument, in which case PowerShell exits with status 0 or 1 by default. This PR ensures that `%ERRORLEVEL%` is also correctly set inside a command prompt session.