### PR TITLE
Add memory barriers on lock/unlock of SpinLock

### DIFF
--- a/src/crystal/spin_lock.cr
+++ b/src/crystal/spin_lock.cr
@@ -11,11 +11,17 @@ class Crystal::SpinLock
           Intrinsics.pause
         end
       end
+      {% if flag?(:aarch64) %}
+        Atomic::Ops.fence :sequentially_consistent, false 
+      {% end %}      
     {% end %}
   end
 
   def unlock
     {% if flag?(:preview_mt) %}
+      {% if flag?(:aarch64) %}
+        Atomic::Ops.fence :sequentially_consistent, false 
+      {% end %}
       @m.lazy_set(0)
     {% end %}
   end


### PR DESCRIPTION
Fixes #13010. Credits goes to @ggiraldez

Examples provided in https://github.com/crystal-lang/crystal/issues/13010#issue-1558654886 and https://github.com/crystal-lang/crystal/issues/13010#issuecomment-1406189312 works in aarch64-apple-darwin without problem so far.

Something I was thinking is that maybe we can use a more relaxed ordering since we are now emitting explicit memory barriers. So not using Atomic which enforces `sequentially_consistent` in the `#swap`, `#get` used in the SpinLock. But that can come later if needed. I am not sure if that would lead to performance improvement at all.