### PR TITLE
Update distribution-scripts

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,7 @@ parameters:
   distribution-scripts-version:
     description: "Git ref for version of https://github.com/crystal-lang/distribution-scripts/"
     type: string
-    default: "d8c44c0a2c977bfb90363923047f2c64cef3bf8e"
+    default: "b668df09ead5cbad9fdbff8ba3c5c0878fc99cbe"
   previous_crystal_base_url:
     description: "Prefix for URLs to Crystal bootstrap compiler"
     type: string


### PR DESCRIPTION
Updates `distribution-scripts` dependency to https://github.com/crystal-lang/distribution-scripts/commit/b668df09ead5cbad9fdbff8ba3c5c0878fc99cbe

This includes the following changes:

* crystal-lang/distribution-scripts#223
* crystal-lang/distribution-scripts#222
* crystal-lang/distribution-scripts#218
* crystal-lang/distribution-scripts#216
* crystal-lang/distribution-scripts#215