### PR TITLE
Do not use `@[ThreadLocal]` for PCRE2's JIT stack

### DIFF
--- a/src/regex/pcre2.cr
+++ b/src/regex/pcre2.cr
@@ -141,13 +141,12 @@ module Regex::PCRE2
   #
   # Only a single `match` function can run per thread at any given time, so there
   # can't be any concurrent access to the JIT stack.
-  @[ThreadLocal]
-  class_getter jit_stack : LibPCRE2::JITStack do
-    jit_stack = LibPCRE2.jit_stack_create(32_768, 1_048_576, Regex::PCRE2.general_context)
-    if jit_stack.null?
-      raise "Error allocating JIT stack"
+  @@jit_stack = Crystal::ThreadLocalValue(LibPCRE2::JITStack).new
+
+  def self.jit_stack
+    @@jit_stack.get do
+      LibPCRE2.jit_stack_create(32_768, 1_048_576, general_context) || raise "Error allocating JIT stack"
     end
-    jit_stack
   end
 
   private def match_data(str, byte_index, options)

--- a/src/regex/pcre2.cr
+++ b/src/regex/pcre2.cr
@@ -1,4 +1,5 @@
 require "./lib_pcre2"
+require "crystal/thread_local_value"
 
 # :nodoc:
 module Regex::PCRE2


### PR DESCRIPTION
Fixes #13013.

Verified on an M2 and on Windows.