### PR TITLE
Add `Enumerable#min(count)` and `#max(count)`

### DIFF
--- a/spec/std/enumerable_spec.cr
+++ b/spec/std/enumerable_spec.cr
@@ -805,14 +805,14 @@ describe "Enumerable" do
     it { [1, 2, 3].max.should eq(3) }
     it { [1, 2, 3].max(0).should eq([] of Int32) }
     it { [1, 2, 3].max(1).should eq([3]) }
-    it { [1, 2, 3].max(2).should eq([3,2]) }
-    it { [1, 2, 3].max(3).should eq([3,2,1]) }
-    it { [1, 2, 3].max(4).should eq([3,2,1]) }
+    it { [1, 2, 3].max(2).should eq([3, 2]) }
+    it { [1, 2, 3].max(3).should eq([3, 2, 1]) }
+    it { [1, 2, 3].max(4).should eq([3, 2, 1]) }
     it { ([] of Int32).max(0).should eq([] of Int32) }
     it { ([] of Int32).max(5).should eq([] of Int32) }
     it {
-      (0..1000).map { |x| (x*137+x*x*139)%5000 }.max(10).should eq([
-        4992, 4990, 4980, 4972, 4962, 4962, 4960, 4960, 4952, 4952
+      (0..1000).map { |x| (x*137 + x*x*139) % 5000 }.max(10).should eq([
+        4992, 4990, 4980, 4972, 4962, 4962, 4960, 4960, 4952, 4952,
       ])
     }
 
@@ -830,10 +830,7 @@ describe "Enumerable" do
 
     it "raises if n is negative" do
       expect_raises ArgumentError do
-        ([1,2,3] of Int32).max(-1)
-      end
-      expect_raises ArgumentError do
-        ([1,2,3] of Int32).max(-2)
+        ([1, 2, 3] of Int32).max(-1)
       end
     end
 
@@ -886,14 +883,14 @@ describe "Enumerable" do
     it { [1, 2, 3].min.should eq(1) }
     it { [1, 2, 3].min(0).should eq([] of Int32) }
     it { [1, 2, 3].min(1).should eq([1]) }
-    it { [1, 2, 3].min(2).should eq([1,2]) }
-    it { [1, 2, 3].min(3).should eq([1,2,3]) }
-    it { [1,2,3].min(4).should eq([1,2,3]) }
+    it { [1, 2, 3].min(2).should eq([1, 2]) }
+    it { [1, 2, 3].min(3).should eq([1, 2, 3]) }
+    it { [1, 2, 3].min(4).should eq([1, 2, 3]) }
     it { ([] of Int32).min(0).should eq([] of Int32) }
     it { ([] of Int32).min(1).should eq([] of Int32) }
     it {
-      (0..1000).map { |x| (x*137+x*x*139)%5000 }.min(10).should eq([
-        0, 10, 20, 26, 26, 26, 26, 30, 32, 32
+      (0..1000).map { |x| (x*137 + x*x*139) % 5000 }.min(10).should eq([
+        0, 10, 20, 26, 26, 26, 26, 30, 32, 32,
       ])
     }
 
@@ -911,10 +908,7 @@ describe "Enumerable" do
 
     it "raises if n is negative" do
       expect_raises ArgumentError do
-        ([1,2,3] of Int32).min(-1)
-      end
-      expect_raises ArgumentError do
-        ([1,2,3] of Int32).min(-2)
+        ([1, 2, 3] of Int32).min(-1)
       end
     end
 

--- a/spec/std/enumerable_spec.cr
+++ b/spec/std/enumerable_spec.cr
@@ -803,10 +803,31 @@ describe "Enumerable" do
 
   describe "max" do
     it { [1, 2, 3].max.should eq(3) }
+    it { [1, 2, 3].max(0).should eq([] of Int32) }
+    it { [1, 2, 3].max(1).should eq([3]) }
+    it { [1, 2, 3].max(2).should eq([3,2]) }
+    it { [1, 2, 3].max(3).should eq([3,2,1]) }
+    it { [1, 2, 3].max(4).should eq([3,2,1]) }
+    it { ([] of Int32).max(0).should eq([] of Int32) }
+    it { ([] of Int32).max(5).should eq([] of Int32) }
+    it {
+      (0..1000).map { |x| (x*137+x*x*139)%5000 }.max(10).should eq([
+        4992, 4990, 4980, 4972, 4962, 4962, 4960, 4960, 4952, 4952
+      ])
+    }
 
     it "raises if empty" do
       expect_raises Enumerable::EmptyError do
         ([] of Int32).max
+      end
+    end
+
+    it "raises if n is negative" do
+      expect_raises ArgumentError do
+        ([1,2,3] of Int32).max(-1)
+      end
+      expect_raises ArgumentError do
+        ([1,2,3] of Int32).max(-2)
       end
     end
 
@@ -815,11 +836,25 @@ describe "Enumerable" do
         [Float64::NAN, 1.0, 2.0, Float64::NAN].max
       end
     end
+
+    it "raises if not comparable in max(n)" do
+      expect_raises ArgumentError do
+        [Float64::NAN, 1.0, 2.0, Float64::NAN].max(2)
+      end
+    end
   end
 
   describe "max?" do
     it "returns nil if empty" do
       ([] of Int32).max?.should be_nil
+    end
+
+    it "returns nil if n is negative in max(n)" do
+      ([1,2,3] of Int32).max?(-1).should be_nil
+    end
+
+    it "returns nil if not comparable in max(n)" do
+      [Float64::NAN, 1.0, 2.0, Float64::NAN].max?(2).should be_nil
     end
   end
 
@@ -851,10 +886,31 @@ describe "Enumerable" do
 
   describe "min" do
     it { [1, 2, 3].min.should eq(1) }
+    it { [1, 2, 3].min(0).should eq([] of Int32) }
+    it { [1, 2, 3].min(1).should eq([1]) }
+    it { [1, 2, 3].min(2).should eq([1,2]) }
+    it { [1, 2, 3].min(3).should eq([1,2,3]) }
+    it { [1,2,3].min(4).should eq([1,2,3]) }
+    it { ([] of Int32).min(0).should eq([] of Int32) }
+    it { ([] of Int32).min(1).should eq([] of Int32) }
+    it {
+      (0..1000).map { |x| (x*137+x*x*139)%5000 }.min(10).should eq([
+        0, 10, 20, 26, 26, 26, 26, 30, 32, 32
+      ])
+    }
 
     it "raises if empty" do
       expect_raises Enumerable::EmptyError do
         ([] of Int32).min
+      end
+    end
+
+    it "raises if n is negative" do
+      expect_raises ArgumentError do
+        ([1,2,3] of Int32).min(-1)
+      end
+      expect_raises ArgumentError do
+        ([1,2,3] of Int32).min(-2)
       end
     end
 
@@ -863,11 +919,25 @@ describe "Enumerable" do
         [-1.0, Float64::NAN, -3.0].min
       end
     end
+
+    it "raises if not comparable in min(n)" do
+      expect_raises ArgumentError do
+        [Float64::NAN, 1.0, 2.0, Float64::NAN].min(2)
+      end
+    end
   end
 
   describe "min?" do
     it "returns nil if empty" do
       ([] of Int32).min?.should be_nil
+    end
+
+    it "returns nil if n is negative in min(n)" do
+      ([1,2,3] of Int32).min?(-1).should be_nil
+    end
+
+    it "returns nil if not comparable in min(n)" do
+      [Float64::NAN, 1.0, 2.0, Float64::NAN].min?(2).should be_nil
     end
   end
 

--- a/spec/std/enumerable_spec.cr
+++ b/spec/std/enumerable_spec.cr
@@ -854,16 +854,6 @@ describe "Enumerable" do
     it "returns nil if empty" do
       ([] of Int32).max?.should be_nil
     end
-
-    it "returns nil if n is negative in max?(n)" do
-      ([1,2,3] of Int32).max?(-1).should be_nil
-    end
-
-    it "raises if not comparable in max?(n)" do
-      expect_raises ArgumentError do
-        [Float64::NAN, 1.0, 2.0, Float64::NAN].max?(2)
-      end
-    end
   end
 
   describe "max_by" do
@@ -944,16 +934,6 @@ describe "Enumerable" do
   describe "min?" do
     it "returns nil if empty" do
       ([] of Int32).min?.should be_nil
-    end
-
-    it "returns nil if n is negative in min(n)" do
-      ([1,2,3] of Int32).min?(-1).should be_nil
-    end
-
-    it "raises if not comparable in min?(n)" do
-      expect_raises ArgumentError do
-        [Float64::NAN, 1.0, 2.0, Float64::NAN].min?(2)
-      end
     end
   end
 

--- a/spec/std/enumerable_spec.cr
+++ b/spec/std/enumerable_spec.cr
@@ -816,6 +816,12 @@ describe "Enumerable" do
       ])
     }
 
+    it "does not modify the array" do
+      xs = [7, 5, 2, 4, 9]
+      xs.max(2).should eq([9, 7])
+      xs.should eq([7, 5, 2, 4, 9])
+    end
+
     it "raises if empty" do
       expect_raises Enumerable::EmptyError do
         ([] of Int32).max
@@ -849,12 +855,14 @@ describe "Enumerable" do
       ([] of Int32).max?.should be_nil
     end
 
-    it "returns nil if n is negative in max(n)" do
+    it "returns nil if n is negative in max?(n)" do
       ([1,2,3] of Int32).max?(-1).should be_nil
     end
 
-    it "returns nil if not comparable in max(n)" do
-      [Float64::NAN, 1.0, 2.0, Float64::NAN].max?(2).should be_nil
+    it "raises if not comparable in max?(n)" do
+      expect_raises ArgumentError do
+        [Float64::NAN, 1.0, 2.0, Float64::NAN].max?(2)
+      end
     end
   end
 
@@ -899,6 +907,12 @@ describe "Enumerable" do
       ])
     }
 
+    it "does not modify the array" do
+      xs = [7, 5, 2, 4, 9]
+      xs.min(2).should eq([2, 4])
+      xs.should eq([7, 5, 2, 4, 9])
+    end
+
     it "raises if empty" do
       expect_raises Enumerable::EmptyError do
         ([] of Int32).min
@@ -936,8 +950,10 @@ describe "Enumerable" do
       ([1,2,3] of Int32).min?(-1).should be_nil
     end
 
-    it "returns nil if not comparable in min(n)" do
-      [Float64::NAN, 1.0, 2.0, Float64::NAN].min?(2).should be_nil
+    it "raises if not comparable in min?(n)" do
+      expect_raises ArgumentError do
+        [Float64::NAN, 1.0, 2.0, Float64::NAN].min?(2)
+      end
     end
   end
 

--- a/src/enumerable.cr
+++ b/src/enumerable.cr
@@ -1013,15 +1013,6 @@ module Enumerable(T)
     max_by? &.itself
   end
 
-  private def max_internal(k : Int) : Array(T)
-    data = self.is_a?(Array) ? self.dup : self.to_a
-    n = data.size
-    k = n if k > n
-    (0..k-1).map do |i|
-      qselect_internal(data, 0, n-1, n-1-i)
-    end
-  end
-
   # Returns an array of the maximum `k` elements, sorted descending.
   #
   # It compares using `<=>` so it will work for any type that supports that method.
@@ -1038,13 +1029,12 @@ module Enumerable(T)
   # not comparable.
   def max(k : Int) : Array(T)
     raise ArgumentError.new("negative size #{k}") if k < 0
-    max_internal(k)
-  end
-
-  # Like `max(k)` but returns `nil` if `k` is negative.
-  def max?(k : Int)
-    return nil if k < 0
-    max_internal(k)
+    data = self.is_a?(Array) ? self.dup : self.to_a
+    n = data.size
+    k = n if k > n
+    (0..k-1).map do |i|
+      qselect_internal(data, 0, n-1, n-1-i)
+    end
   end
 
   # Returns the element for which the passed block returns with the maximum value.
@@ -1136,15 +1126,6 @@ module Enumerable(T)
     min_by? &.itself
   end
 
-  private def min_internal(k : Int) : Array(T)
-    data = self.is_a?(Array) ? self.dup : self.to_a
-    n = data.size
-    k = n if k > n
-    (0..k-1).map do |i|
-      qselect_internal(data, 0, n-1, i)
-    end
-  end
-
   # Returns an array of the minimum `k` elements, sorted ascending.
   #
   # It compares using `<=>` so it will work for any type that supports that method.
@@ -1161,13 +1142,12 @@ module Enumerable(T)
   # not comparable.
   def min(k : Int) : Array(T)
     raise ArgumentError.new("negative size #{k}") if k < 0
-    min_internal(k)
-  end
-
-  # Like `min(k)` but returns `nil` if `k` is negative.
-  def min?(k : Int)
-    return nil if k < 0
-    min_internal(k)
+    data = self.is_a?(Array) ? self.dup : self.to_a
+    n = data.size
+    k = n if k > n
+    (0..k-1).map do |i|
+      qselect_internal(data, 0, n-1, i)
+    end
   end
 
   # Returns the element for which the passed block returns with the minimum value.

--- a/src/enumerable.cr
+++ b/src/enumerable.cr
@@ -965,11 +965,11 @@ module Enumerable(T)
     ary
   end
 
-  private def qselect_internal(data : Array(T), left : Int, right : Int, k : Int) : T
+  private def quickselect_internal(data : Array(T), left : Int, right : Int, k : Int) : T
     loop do
       return data[left] if left == right
-      pivot_index = left + (right-left)//2
-      pivot_index = qselect_partition_internal(data, left, right, pivot_index)
+      pivot_index = left + (right - left)//2
+      pivot_index = quickselect_partition_internal(data, left, right, pivot_index)
       if k == pivot_index
         return data[k]
       elsif k < pivot_index
@@ -980,11 +980,11 @@ module Enumerable(T)
     end
   end
 
-  private def qselect_partition_internal(data : Array(T), left : Int, right : Int, pivot_index : Int) : Int
+  private def quickselect_partition_internal(data : Array(T), left : Int, right : Int, pivot_index : Int) : Int
     pivot_value = data[pivot_index]
     data.swap(pivot_index, right)
     store_index = left
-    (left..right).each do |i|
+    (left..(right - 1)).each do |i|
       if compare_or_raise(data[i], pivot_value) < 0
         data.swap(store_index, i)
         store_index += 1
@@ -1013,27 +1013,27 @@ module Enumerable(T)
     max_by? &.itself
   end
 
-  # Returns an array of the maximum `k` elements, sorted descending.
+  # Returns an array of the maximum *count* elements, sorted descending.
   #
   # It compares using `<=>` so it will work for any type that supports that method.
   #
   # ```
-  # [7, 5, 2, 4, 9].max(3) # => [9, 7, 5]
+  # [7, 5, 2, 4, 9].max(3)                             # => [9, 7, 5]
   # ["Eve", "Alice", "Bob", "Mallory", "Carol"].max(2) # => ["Mallory", "Eve"]
   # ```
   #
-  # Returns all elements sorted descending if `k` is greater than the number of
-  # elements in the source.
+  # Returns all elements sorted descending if *count* is greater than the number
+  # of elements in the source.
   #
-  # Raises `Enumerable::ArgumentError` if `k` is negative or if any elements are
-  # not comparable.
-  def max(k : Int) : Array(T)
-    raise ArgumentError.new("negative size #{k}") if k < 0
+  # Raises `Enumerable::ArgumentError` if *count* is negative or if any elements
+  # are not comparable.
+  def max(count : Int) : Array(T)
+    raise ArgumentError.new("Count must be positive") if count < 0
     data = self.is_a?(Array) ? self.dup : self.to_a
     n = data.size
-    k = n if k > n
-    (0..k-1).map do |i|
-      qselect_internal(data, 0, n-1, n-1-i)
+    count = n if count > n
+    (0..count - 1).map do |i|
+      quickselect_internal(data, 0, n - 1, n - 1 - i)
     end
   end
 
@@ -1126,27 +1126,27 @@ module Enumerable(T)
     min_by? &.itself
   end
 
-  # Returns an array of the minimum `k` elements, sorted ascending.
+  # Returns an array of the minimum *count* elements, sorted ascending.
   #
   # It compares using `<=>` so it will work for any type that supports that method.
   #
   # ```
-  # [7, 5, 2, 4, 9].min(3) # => [2, 4, 5]
+  # [7, 5, 2, 4, 9].min(3)                             # => [2, 4, 5]
   # ["Eve", "Alice", "Bob", "Mallory", "Carol"].min(2) # => ["Alice", "Bob"]
   # ```
   #
-  # Returns all elements sorted ascending if `k` is greater than the number of
-  # elements in the source.
+  # Returns all elements sorted ascending if *count* is greater than the number
+  # of elements in the source.
   #
-  # Raises `Enumerable::ArgumentError` if `k` is negative or if any elements are
-  # not comparable.
-  def min(k : Int) : Array(T)
-    raise ArgumentError.new("negative size #{k}") if k < 0
+  # Raises `Enumerable::ArgumentError` if *count* is negative or if any elements
+  # are not comparable.
+  def min(count : Int) : Array(T)
+    raise ArgumentError.new("Count must be positive") if count < 0
     data = self.is_a?(Array) ? self.dup : self.to_a
     n = data.size
-    k = n if k > n
-    (0..k-1).map do |i|
-      qselect_internal(data, 0, n-1, i)
+    count = n if count > n
+    (0..count - 1).map do |i|
+      quickselect_internal(data, 0, n - 1, i)
     end
   end
 

--- a/src/enumerable.cr
+++ b/src/enumerable.cr
@@ -984,7 +984,7 @@ module Enumerable(T)
     pivot_value = data[pivot_index]
     data.swap(pivot_index, right)
     store_index = left
-    (left..(right - 1)).each do |i|
+    (left...right).each do |i|
       if compare_or_raise(data[i], pivot_value) < 0
         data.swap(store_index, i)
         store_index += 1
@@ -1018,8 +1018,8 @@ module Enumerable(T)
   # It compares using `<=>` so it will work for any type that supports that method.
   #
   # ```
-  # [7, 5, 2, 4, 9].max(3)                             # => [9, 7, 5]
-  # ["Eve", "Alice", "Bob", "Mallory", "Carol"].max(2) # => ["Mallory", "Eve"]
+  # [7, 5, 2, 4, 9].max(3)                 # => [9, 7, 5]
+  # %w[Eve Alice Bob Mallory Carol].max(2) # => ["Mallory", "Eve"]
   # ```
   #
   # Returns all elements sorted descending if *count* is greater than the number
@@ -1032,7 +1032,7 @@ module Enumerable(T)
     data = self.is_a?(Array) ? self.dup : self.to_a
     n = data.size
     count = n if count > n
-    (0..count - 1).map do |i|
+    (0...count).map do |i|
       quickselect_internal(data, 0, n - 1, n - 1 - i)
     end
   end
@@ -1131,8 +1131,8 @@ module Enumerable(T)
   # It compares using `<=>` so it will work for any type that supports that method.
   #
   # ```
-  # [7, 5, 2, 4, 9].min(3)                             # => [2, 4, 5]
-  # ["Eve", "Alice", "Bob", "Mallory", "Carol"].min(2) # => ["Alice", "Bob"]
+  # [7, 5, 2, 4, 9].min(3)                 # => [2, 4, 5]
+  # %w[Eve Alice Bob Mallory Carol].min(2) # => ["Alice", "Bob"]
   # ```
   #
   # Returns all elements sorted ascending if *count* is greater than the number
@@ -1145,7 +1145,7 @@ module Enumerable(T)
     data = self.is_a?(Array) ? self.dup : self.to_a
     n = data.size
     count = n if count > n
-    (0..count - 1).map do |i|
+    (0...count).map do |i|
       quickselect_internal(data, 0, n - 1, i)
     end
   end


### PR DESCRIPTION
This patch adds `max(k)`, `min(k)`, `max?(k)`, and `min?(k)` support as requested in #12817.

``` crystal
puts [7, 5, 2, 4, 9].max(3) # => [9, 7, 5]
puts ["Eve", "Alice", "Bob", "Mallory", "Carol"].max(2) # => ["Mallory", "Eve"]
puts [7, 5, 2, 4, 9].min(3) # => [2, 4, 5]
puts ["Eve", "Alice", "Bob", "Mallory", "Carol"].min(2) # => ["Alice", "Bob"]
```

Like ruby core, this patch uses an internal quickselect implementation which empirically has much better performance than full sorting when `k` is small. However, when `k` is large, the performance is also poor, but that is also the case in ruby core.

Here is a little benchmark script comparing `max(k)` with `sort()`:

``` crystal
[100,10_000,1_000_000].each do |n|
  data = (0..n-1).map { |i| Random.rand(4_000_000) }
  [3,10,20,n//3].each do |k|
    s_elapsed = Time.measure do
      data.sort { |a,b| b-a }
    end
    puts "n=#{n} k=#{k} sort() elapsed=#{s_elapsed}"

    max_elapsed = Time.measure do
      data.max(k)
    end
    puts "n=#{n} k=#{k} max(k) elapsed=#{max_elapsed}"
  end
end
```

It runs but hangs for quite a while on the last `max(k)`:

```
n=100 k=3 sort() elapsed=00:00:00.000020394
n=100 k=3 max(k) elapsed=00:00:00.000005727
n=100 k=10 sort() elapsed=00:00:00.000005727
n=100 k=10 max(k) elapsed=00:00:00.000012572
n=100 k=20 sort() elapsed=00:00:00.000007124
n=100 k=20 max(k) elapsed=00:00:00.000025353
n=100 k=33 sort() elapsed=00:00:00.000007263
n=100 k=33 max(k) elapsed=00:00:00.000025842
n=10000 k=3 sort() elapsed=00:00:00.000938610
n=10000 k=3 max(k) elapsed=00:00:00.000291731
n=10000 k=10 sort() elapsed=00:00:00.000866812
n=10000 k=10 max(k) elapsed=00:00:00.000707782
n=10000 k=20 sort() elapsed=00:00:00.000919264
n=10000 k=20 max(k) elapsed=00:00:00.000897054
n=10000 k=3333 sort() elapsed=00:00:00.000617336
n=10000 k=3333 max(k) elapsed=00:00:00.116306633
n=1000000 k=3 sort() elapsed=00:00:00.108918789
n=1000000 k=3 max(k) elapsed=00:00:00.024309854
n=1000000 k=10 sort() elapsed=00:00:00.091967585
n=1000000 k=10 max(k) elapsed=00:00:00.036159780
n=1000000 k=20 sort() elapsed=00:00:00.091330064
n=1000000 k=20 max(k) elapsed=00:00:00.069409304
n=1000000 k=333333 sort() elapsed=00:00:00.090361980
^C
```

but that is exactly what ruby does:

```
$ irb
irb(main):001:0> (0..1_000_000).map { |i| Random.rand(4_000_000) }.max(3)
=> [3999995, 3999991, 3999988]
irb(main):002:0> (0..1_000_000).map { |i| Random.rand(4_000_000) }.max(300_000)
^C
```

It might be worth pointing out these performance characteristics in the docs, but ruby doesn't do that so I decided not to in this patch.

I tried to preserve the other quirks from the ruby implementation such as `k > array.size` truncating results instead of raising an exception. And raising an exception when `k < 0`.