### PR TITLE
Http proxy

### DIFF
--- a/src/http/client.cr
+++ b/src/http/client.cr
@@ -109,7 +109,7 @@ class HTTP::Client
     getter! tls : Nil
     alias TLSContext = Bool | Nil
   {% else %}
-    getter! tls : OpenSSL::SSL::Context::Client
+    getter! tls : OpenSSL::SSL::Context::Client | Bool
     alias TLSContext = OpenSSL::SSL::Context::Client | Bool | Nil
   {% end %}
 
@@ -128,24 +128,8 @@ class HTTP::Client
   # be used depending on the *tls* arguments: 80 for if *tls* is `false`,
   # 443 if *tls* is truthy. If *tls* is `true` a new `OpenSSL::SSL::Context::Client` will
   # be used, else the given one. In any case the active context can be accessed through `tls`.
-  def initialize(@host : String, port = nil, tls : TLSContext = nil)
+  def initialize(@host : String, port = nil, @tls : TLSContext = nil)
     check_host_only(@host)
-
-    {% if flag?(:without_openssl) %}
-      if tls
-        raise "HTTP::Client TLS is disabled because `-D without_openssl` was passed at compile time"
-      end
-      @tls = nil
-    {% else %}
-      @tls = case tls
-             when true
-               OpenSSL::SSL::Context::Client.new
-             when OpenSSL::SSL::Context::Client
-               tls
-             when false, nil
-               nil
-             end
-    {% end %}
 
     @port = (port || (@tls ? 443 : 80)).to_i
   end
@@ -791,26 +775,49 @@ class HTTP::Client
       raise "This HTTP::Client cannot be reconnected"
     end
 
-    hostname = @host.starts_with?('[') && @host.ends_with?(']') ? @host[1..-2] : @host
-    io = TCPSocket.new hostname, @port, @dns_timeout, @connect_timeout
+    @io = create_proxy_io || create_io(host, port, @tls)
+  end
+
+  private def create_io(host, port, tls)
+    hostname = host.starts_with?('[') && host.ends_with?(']') ? host[1..-2] : host
+    io = TCPSocket.new hostname, port, @dns_timeout, @connect_timeout
     io.read_timeout = @read_timeout if @read_timeout
     io.write_timeout = @write_timeout if @write_timeout
     io.sync = false
+    tls ? create_tls(io, host, tls) : io
+  end
 
-    {% if !flag?(:without_openssl) %}
-      if tls = @tls
-        tcp_socket = io
-        begin
-          io = OpenSSL::SSL::Socket::Client.new(tcp_socket, context: tls, sync_close: true, hostname: @host.rchop('.'))
-        rescue exc
-          # don't leak the TCP socket when the SSL connection failed
-          tcp_socket.close
-          raise exc
-        end
+  private def create_proxy_io
+    return unless proxy = find_proxy
+
+    proxy_uri = URI.parse(proxy)
+    tls = HTTP::Client.tls_flag(proxy_uri, nil)
+    proxy_port = proxy_uri.port || (tls ? 443 : 80)
+    host = HTTP::Client.validate_host(proxy_uri)
+
+    create_io(host, proxy_port, tls)
+  end
+
+  private def create_tls(io, host, tls)
+    {% if flag?(:without_openssl) %}
+      raise "HTTP::Client TLS is disabled because `-D without_openssl` was passed at compile time"
+    {% else %}
+      tcp_socket = io
+      begin
+        tls = tls.is_a?(OpenSSL::SSL::Context::Client) ? tls : OpenSSL::SSL::Context::Client.new
+        OpenSSL::SSL::Socket::Client.new(tcp_socket, context: tls, sync_close: true, hostname: host.rchop('.'))
+      rescue exc
+        # don't leak the TCP socket when the SSL connection failed
+        tcp_socket.close
+        raise exc
       end
     {% end %}
+  end
 
-    @io = io
+  private def find_proxy
+    return unless ENV.has_key?("http_proxy")
+
+    ENV["http_proxy"]
   end
 
   private def host_header


### PR DESCRIPTION
Implementation for #2963

Basic support for HTTP and HTTPS client proxies via environment variables. 

Not sure what the standard method for setting the proxy URLs would be from within Crystal. Maybe #set_proxy at the class and instance level? 