### PR TITLE
Makefile: Add `./scripts` to `format` recipe

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -128,7 +128,7 @@ llvm_ext: $(LLVM_EXT_OBJ)
 
 .PHONY: format
 format: ## Format sources
-	./bin/crystal tool format$(if $(check), --check) src spec samples
+	./bin/crystal tool format$(if $(check), --check) src spec samples scripts
 
 .PHONY: install
 install: $(O)/crystal man/crystal.1.gz ## Install the compiler at DESTDIR

--- a/Makefile.win
+++ b/Makefile.win
@@ -130,7 +130,7 @@ llvm_ext: $(LLVM_EXT_OBJ)
 
 .PHONY: format
 format: ## Format sources
-	.\bin\crystal tool format$(if $(check), --check) src spec samples
+	.\bin\crystal tool format$(if $(check), --check) src spec samples scripts
 
 .PHONY: install
 install: $(O)\crystal.exe ## Install the compiler at prefix

--- a/scripts/generate_unicode_data.cr
+++ b/scripts/generate_unicode_data.cr
@@ -100,7 +100,7 @@ def new_alternate_range(first_codepoint, last_codepoint)
   AlternateRange.new(first_codepoint, last_codepoint.not_nil! + 1)
 end
 
-def strides(entries, targets)
+def strides(entries, targets, &)
   strides = [] of Stride
 
   entries = entries.select { |entry| targets.includes?(yield entry) }


### PR DESCRIPTION
`./scripts` was missing from the `format` recipe but there are Crystal files in this folder.
This patch adds it and applies the latest format there.