### PR TITLE
`crystal tool format`

### DIFF
--- a/src/benchmark.cr
+++ b/src/benchmark.cr
@@ -3,7 +3,7 @@ require "./benchmark/**"
 # The Benchmark module provides methods for benchmarking Crystal code, giving
 # detailed reports on the time and memory taken for each task.
 #
-# NOTE: To use `Benchmark`, you must explicitly import it with `require "benchmark"` 
+# NOTE: To use `Benchmark`, you must explicitly import it with `require "benchmark"`
 #
 # ### Measure the number of iterations per second of each task
 #

--- a/src/http/web_socket.cr
+++ b/src/http/web_socket.cr
@@ -1,7 +1,6 @@
 require "./client"
 require "./headers"
 
-
 # NOTE: To use `WebSocket`, you must explicitly import it with `require "http/web_socket"`
 class HTTP::WebSocket
   getter? closed = false


### PR DESCRIPTION
#13026 was unintentionally merged with formatter issues.

I was testing out the [new merge queue feature](https://github.blog/changelog/2023-02-08-pull-request-merge-queue-public-beta/). Apparently it doesn't work as I expected it to work and merged the queued branches right away, while CI on the merge queue was still running (and the PR branch itself also had CI failures). Seems sketchy.
Anyway, this patch fixes the formatter issues in master.