### PR TITLE
Dynamic library loader: search in `-L` directories before default ones

### DIFF
--- a/spec/compiler/loader/msvc_spec.cr
+++ b/spec/compiler/loader/msvc_spec.cr
@@ -12,6 +12,11 @@ describe Crystal::Loader do
       loader.search_paths.should eq [%q(C:\foo\bar), "baz"]
     end
 
+    it "prepends directory paths before default search paths" do
+      loader = Crystal::Loader.parse(%w(/LIBPATH:foo /LIBPATH:bar), search_paths: %w(baz quux))
+      loader.search_paths.should eq %w(foo bar baz quux)
+    end
+
     it "parses file paths" do
       expect_raises(Crystal::Loader::LoadError, "cannot find foobar.lib") do
         Crystal::Loader.parse(["foobar.lib"], search_paths: [] of String)

--- a/spec/compiler/loader/unix_spec.cr
+++ b/spec/compiler/loader/unix_spec.cr
@@ -12,6 +12,11 @@ describe Crystal::Loader do
       loader.search_paths.should eq ["/foo/bar/baz", "qux"]
     end
 
+    it "prepends directory paths before default search paths" do
+      loader = Crystal::Loader.parse(%w(-Lfoo -Lbar), search_paths: %w(baz quux))
+      loader.search_paths.should eq %w(foo bar baz quux)
+    end
+
     it "parses static" do
       expect_raises(Crystal::Loader::LoadError, "static libraries are not supported by Crystal's runtime loader") do
         Crystal::Loader.parse(["-static"], search_paths: [] of String)

--- a/src/compiler/crystal/loader/msvc.cr
+++ b/src/compiler/crystal/loader/msvc.cr
@@ -23,8 +23,11 @@ class Crystal::Loader
     libnames = [] of String
     file_paths = [] of String
 
-    # NOTE: `/LIBPATH` overrides the default paths, not the other way round
+    # NOTE: `/LIBPATH`s are prepended before the default paths:
     # (https://docs.microsoft.com/en-us/cpp/build/reference/libpath-additional-libpath)
+    #
+    # > ... The linker will first search in the path specified by this option,
+    # > and then search in the path specified in the LIB environment variable.
     extra_search_paths = [] of String
 
     args.each do |arg|
@@ -35,8 +38,10 @@ class Crystal::Loader
       end
     end
 
+    search_paths = extra_search_paths + search_paths
+
     begin
-      self.new(extra_search_paths + search_paths, libnames, file_paths)
+      self.new(search_paths, libnames, file_paths)
     rescue exc : LoadError
       exc.args = args
       exc.search_paths = search_paths

--- a/src/compiler/crystal/loader/unix.cr
+++ b/src/compiler/crystal/loader/unix.cr
@@ -40,10 +40,24 @@ class Crystal::Loader
     libnames = [] of String
     file_paths = [] of String
 
+    # `man id(1)` on Linux:
+    #
+    # > -L searchdir
+    # > ... The directories are searched in the order in which they are
+    # specified on the command line. Directories specified on the command line
+    # are searched before the default directories.
+    #
+    # `man ld(1)` on macOS:
+    #
+    # > -Ldir
+    # > ... Directories specified with -L are searched in the order they appear
+    # > on the command line and before the default search path...
+    extra_search_paths = [] of String
+
     # OptionParser removes items from the args array, so we dup it here in order to produce a meaningful error message.
     OptionParser.parse(args.dup) do |parser|
       parser.on("-L DIRECTORY", "--library-path DIRECTORY", "Add DIRECTORY to library search path") do |directory|
-        search_paths << directory
+        extra_search_paths << directory
       end
       parser.on("-l LIBNAME", "--library LIBNAME", "Search for library LIBNAME") do |libname|
         libnames << libname
@@ -55,6 +69,8 @@ class Crystal::Loader
         file_paths.concat args
       end
     end
+
+    search_paths = extra_search_paths + search_paths
 
     begin
       self.new(search_paths, libnames, file_paths)

--- a/src/compiler/crystal/loader/unix.cr
+++ b/src/compiler/crystal/loader/unix.cr
@@ -40,7 +40,7 @@ class Crystal::Loader
     libnames = [] of String
     file_paths = [] of String
 
-    # `man id(1)` on Linux:
+    # `man ld(1)` on Linux:
     #
     # > -L searchdir
     # > ... The directories are searched in the order in which they are


### PR DESCRIPTION
Fixes #12214.

The link flags for OpenSSL and libcrypto already include the explicit directory returned by `pkg-config`, because at one point [we wanted to detect OpenSSL 1.0.2 and enable its new features if found](https://github.com/crystal-lang/crystal/pull/2708). The problem is that our loader always tries the default library paths before ones specified via the `-L`s from the link flags, and the first entry is `/usr/lib`, which means the system libraries are always searched first, and `/usr/lib/libcrypto.dylib` is specifically made to abort any application that attempts to load it.

That failure also happens with a plain `dlopen`, by the way:

```crystal
LibC.dlopen("/usr/lib/libcrypto.dylib", LibC::RTLD_LAZY | LibC::RTLD_GLOBAL)
LibC.dlopen("libcrypto.dylib", LibC::RTLD_LAZY | LibC::RTLD_GLOBAL)
```

The MSVC loader already searches in the directories specified via `/LIBPATH` before the default ones.