### PR TITLE
Add `graceful` parameter to `Process#terminate`

### DIFF
--- a/spec/std/process_spec.cr
+++ b/spec/std/process_spec.cr
@@ -354,6 +354,8 @@ describe Process do
     process.try(&.wait)
   end
 
+  typeof(Process.new(*standing_command).terminate(graceful: false))
+
   pending_win32 ".exists?" do
     # We can't reliably check whether it ever returns false, since we can't predict
     # how PIDs are used by the system, a new process might be spawned in between

--- a/src/crystal/system/process.cr
+++ b/src/crystal/system/process.cr
@@ -21,8 +21,8 @@ struct Crystal::System::Process
   # Whether the process is still registered in the system.
   # def exists? : Bool
 
-  # Asks this process to terminate gracefully.
-  # def terminate
+  # Asks this process to terminate.
+  # def terminate(*, graceful)
 
   # Terminates the current process immediately.
   # def self.exit(status : Int)

--- a/src/crystal/system/unix/process.cr
+++ b/src/crystal/system/unix/process.cr
@@ -22,8 +22,8 @@ struct Crystal::System::Process
     !@channel.closed? && Crystal::System::Process.exists?(@pid)
   end
 
-  def terminate
-    Crystal::System::Process.signal(@pid, LibC::SIGTERM)
+  def terminate(*, graceful)
+    Crystal::System::Process.signal(@pid, graceful ? LibC::SIGTERM : LibC::SIGKILL)
   end
 
   def self.exit(status)

--- a/src/crystal/system/wasi/process.cr
+++ b/src/crystal/system/wasi/process.cr
@@ -19,7 +19,7 @@ struct Crystal::System::Process
     raise NotImplementedError.new("Process#exists?")
   end
 
-  def terminate
+  def terminate(*, graceful)
     raise NotImplementedError.new("Process#terminate")
   end
 

--- a/src/crystal/system/win32/process.cr
+++ b/src/crystal/system/win32/process.cr
@@ -50,8 +50,8 @@ struct Crystal::System::Process
     Crystal::System::Process.exists?(@pid)
   end
 
-  def terminate
-    raise NotImplementedError.new("Process.kill")
+  def terminate(*, graceful)
+    LibC.TerminateProcess(@process_handle, 1)
   end
 
   def self.exit(status)

--- a/src/lib_c/x86_64-windows-msvc/c/processthreadsapi.cr
+++ b/src/lib_c/x86_64-windows-msvc/c/processthreadsapi.cr
@@ -39,6 +39,7 @@ lib LibC
   fun GetCurrentProcessId : DWORD
   fun OpenProcess(dwDesiredAccess : DWORD, bInheritHandle : BOOL, dwProcessId : DWORD) : HANDLE
   fun GetExitCodeProcess(hProcess : HANDLE, lpExitCode : DWORD*) : BOOL
+  fun TerminateProcess(hProcess : HANDLE, uExitCode : UInt) : BOOL
   fun CreateProcessW(lpApplicationName : LPWSTR, lpCommandLine : LPWSTR,
                      lpProcessAttributes : SECURITY_ATTRIBUTES*, lpThreadAttributes : SECURITY_ATTRIBUTES*,
                      bInheritHandles : BOOL, dwCreationFlags : DWORD,

--- a/src/process.cr
+++ b/src/process.cr
@@ -343,9 +343,17 @@ class Process
     @process_info.release
   end
 
-  # Asks this process to terminate gracefully
-  def terminate : Nil
-    @process_info.terminate
+  # Asks this process to terminate.
+  #
+  # If *graceful* is true, prefers graceful termination over abrupt termination
+  # if supported by the system.
+  #
+  # * On Unix-like systems, this causes `Signal::TERM` to be sent to the process
+  #   instead of `Signal::KILL`.
+  # * On Windows, this parameter has no effect and graceful termination is
+  #   unavailable. The terminated process has an exit status of 1.
+  def terminate(*, graceful : Bool = true) : Nil
+    @process_info.terminate(graceful: graceful)
   end
 
   private def channel


### PR DESCRIPTION
This acts as the preferred platform-independent API to send `SIGTERM` or `SIGKILL` to a process. See https://github.com/crystal-lang/crystal/issues/7339#issuecomment-1178327261.

On Windows an exit status must also be supplied; 1 is chosen, as that value is consistent with `taskkill /f` or the equivalent action in Task Manager.