### PR TITLE
Fix sed command in `scripts/update-distribution-scripts.cr`

### DIFF
--- a/scripts/update-distribution-scripts.sh
+++ b/scripts/update-distribution-scripts.sh
@@ -42,7 +42,7 @@ sed -i -E "/distribution-scripts-version:/{n;n;n;s/default: \".*\"/default: \"$r
 git add .circleci/config.yml
 
 message="Updates \`distribution-scripts\` dependency to https://github.com/crystal-lang/distribution-scripts/commit/$reference"
-log=$($GIT_DS log $old_reference..$reference --format="%s" | sed "s/.*(/crystal-lang\/distribution-scripts/;s/^/* /;s/.$//")
+log=$($GIT_DS log $old_reference..$reference --format="%s" | sed "s/.*(/crystal-lang\/distribution-scripts/;s/^/* /;")
 message=$(printf "%s\n\nThis includes the following changes:\n\n%s" "$message" "$log")
 
 git commit -m "Update distribution-scripts" -m "$message"


### PR DESCRIPTION
Addresses a bug in the sed script described in https://github.com/crystal-lang/crystal/pull/13068#issuecomment-1427940741 f.

Fixup for https://github.com/crystal-lang/crystal/pull/12503