### PR TITLE
Handle ARM64 MSVC paths when cross-compiling on Windows

### DIFF
--- a/.github/workflows/win.yml
+++ b/.github/workflows/win.yml
@@ -310,7 +310,7 @@ jobs:
         if: steps.cache-llvm.outputs.cache-hit != 'true'
         working-directory: ./llvm-src
         run: |
-          cmake . -Thost=x64 -DLLVM_TARGETS_TO_BUILD="X86" -DLLVM_USE_CRT_RELEASE=MT -DBUILD_SHARED_LIBS=OFF -DCMAKE_FIND_USE_SYSTEM_ENVIRONMENT_PATH=OFF
+          cmake . -Thost=x64 -DLLVM_TARGETS_TO_BUILD="X86;AArch64" -DLLVM_USE_CRT_RELEASE=MT -DBUILD_SHARED_LIBS=OFF -DCMAKE_FIND_USE_SYSTEM_ENVIRONMENT_PATH=OFF
           cmake --build . --config Release
       - name: Gather LLVM
         if: steps.cache-llvm.outputs.cache-hit != 'true'

--- a/src/compiler/crystal/compiler.cr
+++ b/src/compiler/crystal/compiler.cr
@@ -341,8 +341,8 @@ module Crystal
         {% if flag?(:msvc) %}
           if msvc_path = Crystal::System::VisualStudio.find_latest_msvc_path
             if win_sdk_libpath = Crystal::System::WindowsSDK.find_win10_sdk_libpath
-              host_bits = {{ flag?(:bits64) ? "x64" : "x86" }}
-              target_bits = program.has_flag?("bits64") ? "x64" : "x86"
+              host_bits = {{ flag?(:aarch64) ? "ARM64" : flag?(:bits64) ? "x64" : "x86" }}
+              target_bits = program.has_flag?("aarch64") ? "arm64" : program.has_flag?("bits64") ? "x64" : "x86"
 
               # MSVC build tools and Windows SDK found; recreate `LIB` environment variable
               # that is normally expected on the MSVC developer command prompt
@@ -352,6 +352,8 @@ module Crystal
               link_args << Process.quote_windows("/LIBPATH:#{win_sdk_libpath.join("um", target_bits)}")
 
               # use exact path for compiler instead of relying on `PATH`
+              # (letter case shouldn't matter in most cases but being exact doesn't hurt here)
+              target_bits = target_bits.sub("arm", "ARM")
               cl = Process.quote_windows(msvc_path.join("bin", "Host#{host_bits}", target_bits, "cl.exe").to_s)
             end
           end


### PR DESCRIPTION
Uses the proper directories for both ARM64 Windows hosts and targets, and also builds our custom LLVM with ARM64 support. These small changes allow an x86-64 Windows Crystal emulated on an ARM64 Windows machine to cross-compile to the `aarch64-windows-msvc` target, using the correct `cl.exe` and library directories in the emitted linker command. (This kind of cross-compilation is already doable on any host machine where LLVM was built with AArch64 support, except that the linker command won't include any full paths on non-Windows hosts.)

There is no `src/lib_c/aarch64-windows-msvc` in this PR, because there are definitely architecture-specific components such as stack unwinding that aren't as simple as this PR.

Those paths are verified on an ARM64 Windows 11 development virtual machine running on UTM under an Apple M2.