### PR TITLE
Correct HTTP::WebSocket#on_close doc

### DIFF
--- a/src/http/web_socket.cr
+++ b/src/http/web_socket.cr
@@ -67,7 +67,7 @@ class HTTP::WebSocket
   def on_binary(&@on_binary : Bytes ->)
   end
 
-  # Called when the server closes a client's connection.
+  # Called when the client closes the connection.
   def on_close(&@on_close : CloseCode, String ->)
   end
 


### PR DESCRIPTION
The proc will called when the connection is closed, regardless if done by the client or the server.