### PR TITLE
Do not match expectations outside specs

### DIFF
--- a/spec/compiler/loader/spec_helper.cr
+++ b/spec/compiler/loader/spec_helper.cr
@@ -7,8 +7,10 @@ def build_c_dynlib(c_filename, target_dir = SPEC_CRYSTAL_LOADER_LIB_PATH)
 
   {% if flag?(:msvc) %}
     o_basename = o_filename.rchop(".lib")
-    `cl.exe /nologo /LD #{Process.quote(c_filename)} #{Process.quote("/Fo#{o_basename}")} #{Process.quote("/Fe#{o_basename}")}`.should be_truthy
+    `cl.exe /nologo /LD #{Process.quote(c_filename)} #{Process.quote("/Fo#{o_basename}")} #{Process.quote("/Fe#{o_basename}")}`
   {% else %}
-    `#{ENV["CC"]? || "cc"} -shared -fvisibility=hidden #{Process.quote(c_filename)} -o #{Process.quote(o_filename)}`.should be_truthy
+    `#{ENV["CC"]? || "cc"} -shared -fvisibility=hidden #{Process.quote(c_filename)} -o #{Process.quote(o_filename)}`
   {% end %}
+
+  raise "BUG: failed to compile dyanmic library" unless $?.success?
 end

--- a/spec/compiler/loader/spec_helper.cr
+++ b/spec/compiler/loader/spec_helper.cr
@@ -12,5 +12,5 @@ def build_c_dynlib(c_filename, target_dir = SPEC_CRYSTAL_LOADER_LIB_PATH)
     `#{ENV["CC"]? || "cc"} -shared -fvisibility=hidden #{Process.quote(c_filename)} -o #{Process.quote(o_filename)}`
   {% end %}
 
-  raise "BUG: failed to compile dyanmic library" unless $?.success?
+  raise "BUG: failed to compile dynamic library" unless $?.success?
 end

--- a/spec/std/math_spec.cr
+++ b/spec/std/math_spec.cr
@@ -22,8 +22,8 @@ describe "Math" do
   end
 
   describe "Order-related functions" do
-    Math.min(2.1, 2.11).should eq(2.1)
-    Math.max(3.2, 3.11).should eq(3.2)
+    it { Math.min(2.1, 2.11).should eq(2.1) }
+    it { Math.max(3.2, 3.11).should eq(3.2) }
   end
 
   pending "Functions for computing quotient and remainder" do

--- a/spec/std/number_spec.cr
+++ b/spec/std/number_spec.cr
@@ -306,45 +306,45 @@ describe "Number" do
   end
 
   describe "#round_even" do
-    -2.5.round_even.should eq -2.0
-    -1.5.round_even.should eq -2.0
-    -1.0.round_even.should eq -1.0
-    -0.9.round_even.should eq -1.0
-    -0.5.round_even.should eq -0.0
-    -0.1.round_even.should eq 0.0
-    0.0.round_even.should eq 0.0
-    0.1.round_even.should eq 0.0
-    0.5.round_even.should eq 0.0
-    0.9.round_even.should eq 1.0
-    1.0.round_even.should eq 1.0
-    1.5.round_even.should eq 2.0
-    2.5.round_even.should eq 2.0
+    it { -2.5.round_even.should eq -2.0 }
+    it { -1.5.round_even.should eq -2.0 }
+    it { -1.0.round_even.should eq -1.0 }
+    it { -0.9.round_even.should eq -1.0 }
+    it { -0.5.round_even.should eq -0.0 }
+    it { -0.1.round_even.should eq 0.0 }
+    it { 0.0.round_even.should eq 0.0 }
+    it { 0.1.round_even.should eq 0.0 }
+    it { 0.5.round_even.should eq 0.0 }
+    it { 0.9.round_even.should eq 1.0 }
+    it { 1.0.round_even.should eq 1.0 }
+    it { 1.5.round_even.should eq 2.0 }
+    it { 2.5.round_even.should eq 2.0 }
 
-    1.round_even.should eq 1
-    1.round_even.should be_a(Int32)
-    1_u8.round_even.should be_a(UInt8)
-    1_f32.round_even.should be_a(Float32)
+    it { 1.round_even.should eq 1 }
+    it { 1.round_even.should be_a(Int32) }
+    it { 1_u8.round_even.should be_a(UInt8) }
+    it { 1_f32.round_even.should be_a(Float32) }
   end
 
   describe "#round_away" do
-    -2.5.round_away.should eq -3.0
-    -1.5.round_away.should eq -2.0
-    -1.0.round_away.should eq -1.0
-    -0.9.round_away.should eq -1.0
-    -0.5.round_away.should eq -1.0
-    -0.1.round_away.should eq 0.0
-    0.0.round_away.should eq 0.0
-    0.1.round_away.should eq 0.0
-    0.5.round_away.should eq 1.0
-    0.9.round_away.should eq 1.0
-    1.0.round_away.should eq 1.0
-    1.5.round_away.should eq 2.0
-    2.5.round_away.should eq 3.0
+    it { -2.5.round_away.should eq -3.0 }
+    it { -1.5.round_away.should eq -2.0 }
+    it { -1.0.round_away.should eq -1.0 }
+    it { -0.9.round_away.should eq -1.0 }
+    it { -0.5.round_away.should eq -1.0 }
+    it { -0.1.round_away.should eq 0.0 }
+    it { 0.0.round_away.should eq 0.0 }
+    it { 0.1.round_away.should eq 0.0 }
+    it { 0.5.round_away.should eq 1.0 }
+    it { 0.9.round_away.should eq 1.0 }
+    it { 1.0.round_away.should eq 1.0 }
+    it { 1.5.round_away.should eq 2.0 }
+    it { 2.5.round_away.should eq 3.0 }
 
-    1.round_away.should eq 1
-    1.round_away.should be_a(Int32)
-    1_u8.round_away.should be_a(UInt8)
-    1_f32.round_away.should be_a(Float32)
+    it { 1.round_away.should eq 1 }
+    it { 1.round_away.should be_a(Int32) }
+    it { 1_u8.round_away.should be_a(UInt8) }
+    it { 1_f32.round_away.should be_a(Float32) }
   end
 
   it "gives the absolute value" do

--- a/spec/std/signal_spec.cr
+++ b/spec/std/signal_spec.cr
@@ -40,15 +40,17 @@ describe "Signal" do
 
   it "CHLD.trap is called after default Crystal child handler" do
     chan = Channel(Process).new
+    existed = Channel(Bool).new
 
     Signal::CHLD.trap do
       child_process = chan.receive
-      Process.exists?(child_process.pid).should be_false
+      existed.send(Process.exists?(child_process.pid))
     end
 
     child = Process.new("true", shell: true)
     child.wait # doesn't block forever
     chan.send(child)
+    existed.receive.should be_false
   ensure
     Signal::CHLD.reset
   end

--- a/spec/std/uri/params_spec.cr
+++ b/spec/std/uri/params_spec.cr
@@ -4,7 +4,7 @@ require "uri/params"
 class URI
   describe Params do
     describe ".new" do
-      Params.new.should eq(Params.parse(""))
+      it { Params.new.should eq(Params.parse("")) }
     end
 
     describe ".parse" do


### PR DESCRIPTION
Some calls of `#should` are done outside spec examples (more specifically, an `it` or `before_each`), which means if the expectation does not match, the `Spec::AssertionFailed` exception is not handled and will stop any subsequent specs from being added and run. This PR fixes those occurrences.

They are detected by monkeypatching `Spec`:

```crystal
module Spec
  class_property? running_spec = false

  module ObjectExtensions
    def should(expectation, ...)
      STDERR.puts "expectation outside spec! #{file}:#{line}" unless Spec.running_spec?
      # ...
    end

    # ditto for the other 4 overloads of `#should` and `#should_not`
  end
end

Spec.before_each { Spec.running_spec = true }
Spec.after_each { Spec.running_spec = false }
```
