### PR TITLE
Build the compiler with PCRE2

### DIFF
--- a/.github/workflows/aarch64.yml
+++ b/.github/workflows/aarch64.yml
@@ -12,7 +12,7 @@ jobs:
       - name: Build Crystal
         uses: docker://jhass/crystal:1.0.0-alpine-build
         with:
-          args: make crystal PCRE1=true
+          args: make crystal
       - name: Upload Crystal executable
         uses: actions/upload-artifact@v3
         with:
@@ -63,7 +63,7 @@ jobs:
       - name: Build Crystal
         uses: docker://jhass/crystal:1.0.0-build
         with:
-          args: make crystal PCRE1=true
+          args: make crystal
       - name: Upload Crystal executable
         uses: actions/upload-artifact@v3
         with:

--- a/.github/workflows/aarch64.yml
+++ b/.github/workflows/aarch64.yml
@@ -12,7 +12,7 @@ jobs:
       - name: Build Crystal
         uses: docker://jhass/crystal:1.0.0-alpine-build
         with:
-          args: make crystal
+          args: make crystal PCRE1=true
       - name: Upload Crystal executable
         uses: actions/upload-artifact@v3
         with:
@@ -63,7 +63,7 @@ jobs:
       - name: Build Crystal
         uses: docker://jhass/crystal:1.0.0-build
         with:
-          args: make crystal
+          args: make crystal PCRE1=true
       - name: Upload Crystal executable
         uses: actions/upload-artifact@v3
         with:

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -16,15 +16,18 @@ jobs:
     strategy:
       matrix:
         crystal_bootstrap_version: [1.2.2, 1.3.2, 1.4.1, 1.5.1, 1.6.2]
-        env: ["USE_PCRE1=true"]
+        env: 
+          USE_PCRE1: true
         include:
           # libffi is only available starting from the 1.2.2 build images
           - crystal_bootstrap_version: 1.0.0
             flags: -Dwithout_ffi
-            env: USE_PCRE1=true
+            env:
+              USE_PCRE1: true
           - crystal_bootstrap_version: 1.1.1
             flags: -Dwithout_ffi
-            env: USE_PCRE1=true
+            env:
+              USE_PCRE1: true
           - crystal_bootstrap_version: 1.7.2
             env: ""
     steps:
@@ -38,7 +41,7 @@ jobs:
         run: bin/ci prepare_build
 
       - name: Test
-        run: FLAGS=${{ matrix.flags }} ${{ matrix.env}} bin/ci build
+        run: FLAGS=${{ matrix.flags }} ${{ matrix.env }} bin/ci build
 
   x86_64-musl-test:
     env:

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -15,13 +15,18 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        crystal_bootstrap_version: [1.2.2, 1.3.2, 1.4.1, 1.5.1, 1.6.2, 1.7.2]
+        crystal_bootstrap_version: [1.2.2, 1.3.2, 1.4.1, 1.5.1, 1.6.2]
+        env: ["PCRE1=true"]
         include:
           # libffi is only available starting from the 1.2.2 build images
           - crystal_bootstrap_version: 1.0.0
             flags: -Dwithout_ffi
+            env: PCRE1=true
           - crystal_bootstrap_version: 1.1.1
             flags: -Dwithout_ffi
+            env: PCRE1=true
+          - crystal_bootstrap_version: 1.7.2
+            env: ""
     steps:
       - name: Download Crystal source
         uses: actions/checkout@v3
@@ -33,7 +38,7 @@ jobs:
         run: bin/ci prepare_build
 
       - name: Test
-        run: FLAGS=${{ matrix.flags }} bin/ci build
+        run: FLAGS=${{ matrix.flags }} ${{ matrix.env}} bin/ci build
 
   x86_64-musl-test:
     env:

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -16,15 +16,15 @@ jobs:
     strategy:
       matrix:
         crystal_bootstrap_version: [1.2.2, 1.3.2, 1.4.1, 1.5.1, 1.6.2]
-        env: ["PCRE1=true"]
+        env: ["USE_PCRE1=true"]
         include:
           # libffi is only available starting from the 1.2.2 build images
           - crystal_bootstrap_version: 1.0.0
             flags: -Dwithout_ffi
-            env: PCRE1=true
+            env: USE_PCRE1=true
           - crystal_bootstrap_version: 1.1.1
             flags: -Dwithout_ffi
-            env: PCRE1=true
+            env: USE_PCRE1=true
           - crystal_bootstrap_version: 1.7.2
             env: ""
     steps:

--- a/.github/workflows/win.yml
+++ b/.github/workflows/win.yml
@@ -15,7 +15,7 @@ jobs:
           make deps
       - name: Cross-compile Crystal
         run: |
-          LLVM_TARGETS=X86 bin/crystal build --cross-compile --target x86_64-pc-windows-msvc src/compiler/crystal.cr -Dwithout_playground -Dwithout_iconv -Dwithout_interpreter -Duse_pcre
+          LLVM_TARGETS=X86 bin/crystal build --cross-compile --target x86_64-pc-windows-msvc src/compiler/crystal.cr -Dwithout_playground -Dwithout_iconv -Dwithout_interpreter -Duse_pcre2
 
       - name: Upload Crystal object file
         uses: actions/upload-artifact@v3
@@ -333,7 +333,7 @@ jobs:
         run: make -f Makefile.win deps
       - name: Link Crystal executable
         run: |
-          Invoke-Expression "cl crystal.obj /Fecrystal src\llvm\ext\llvm_ext.obj $(llvm\bin\llvm-config.exe --libs) libs\pcre.lib libs\gc.lib WS2_32.lib advapi32.lib libcmt.lib dbghelp.lib ole32.lib shell32.lib legacy_stdio_definitions.lib /link /LIBPATH:$(pwd)\libs /STACK:0x800000 /ENTRY:wmainCRTStartup"
+          Invoke-Expression "cl crystal.obj /Fecrystal src\llvm\ext\llvm_ext.obj $(llvm\bin\llvm-config.exe --libs) libs\pcre2-8.lib libs\gc.lib WS2_32.lib advapi32.lib libcmt.lib dbghelp.lib ole32.lib shell32.lib legacy_stdio_definitions.lib /link /LIBPATH:$(pwd)\libs /STACK:0x800000 /ENTRY:wmainCRTStartup"
           mkdir .build
           mv crystal.exe .build/
 

--- a/Makefile
+++ b/Makefile
@@ -197,7 +197,7 @@ $(O)/primitives_spec: $(O)/crystal $(DEPS) $(SOURCES) $(SPEC_SOURCES)
 $(O)/crystal: $(DEPS) $(SOURCES)
 	$(call check_llvm_config)
 	@mkdir -p $(O)
-	$(EXPORTS) $(EXPORTS_BUILD) ./bin/crystal build $(FLAGS) -o $@ src/compiler/crystal.cr -D without_openssl -D without_zlib -D use_pcre
+	$(EXPORTS) $(EXPORTS_BUILD) ./bin/crystal build $(FLAGS) -o $@ src/compiler/crystal.cr -D without_openssl -D without_zlib -D use_pcre2
 
 $(LLVM_EXT_OBJ): $(LLVM_EXT_DIR)/llvm_ext.cc
 	$(call check_llvm_config)

--- a/Makefile
+++ b/Makefile
@@ -197,7 +197,9 @@ $(O)/primitives_spec: $(O)/crystal $(DEPS) $(SOURCES) $(SPEC_SOURCES)
 $(O)/crystal: $(DEPS) $(SOURCES)
 	$(call check_llvm_config)
 	@mkdir -p $(O)
-	$(EXPORTS) $(EXPORTS_BUILD) ./bin/crystal build $(FLAGS) -o $@ src/compiler/crystal.cr -D without_openssl -D without_zlib $(if $(PCRE1),-D use_pcre,-D use_pcre2)
+	# NOTE: USE_PCRE1 is only used for testing compatibility with legacy environments that don't provide libpcre2.
+	# Newly built compilers should never be distributed with libpcre to ensure syntax consistency.
+	$(EXPORTS) $(EXPORTS_BUILD) ./bin/crystal build $(FLAGS) -o $@ src/compiler/crystal.cr -D without_openssl -D without_zlib $(if $(USE_PCRE1),-D use_pcre,-D use_pcre2)
 
 $(LLVM_EXT_OBJ): $(LLVM_EXT_DIR)/llvm_ext.cc
 	$(call check_llvm_config)

--- a/Makefile
+++ b/Makefile
@@ -197,7 +197,7 @@ $(O)/primitives_spec: $(O)/crystal $(DEPS) $(SOURCES) $(SPEC_SOURCES)
 $(O)/crystal: $(DEPS) $(SOURCES)
 	$(call check_llvm_config)
 	@mkdir -p $(O)
-	$(EXPORTS) $(EXPORTS_BUILD) ./bin/crystal build $(FLAGS) -o $@ src/compiler/crystal.cr -D without_openssl -D without_zlib -D use_pcre2
+	$(EXPORTS) $(EXPORTS_BUILD) ./bin/crystal build $(FLAGS) -o $@ src/compiler/crystal.cr -D without_openssl -D without_zlib $(if $(PCRE1),-D use_pcre,-D use_pcre2)
 
 $(LLVM_EXT_OBJ): $(LLVM_EXT_DIR)/llvm_ext.cc
 	$(call check_llvm_config)

--- a/Makefile.win
+++ b/Makefile.win
@@ -190,7 +190,7 @@ $(O)\crystal.exe: $(DEPS) $(SOURCES) $(O)\crystal.res
 	@$(call MKDIR,"$(O)")
 	$(call export_vars)
 	$(call export_build_vars)
-	.\bin\crystal build $(FLAGS) -o "$(O)\crystal-next.exe" src\compiler\crystal.cr -D without_openssl -D without_zlib -D without_playground $(if $(PCRE1),-D use_pcre,-D use_pcre2) --link-flags=/PDBALTPATH:crystal.pdb "--link-flags=$(realpath $(O)\crystal.res)"
+	.\bin\crystal build $(FLAGS) -o "$(O)\crystal-next.exe" src\compiler\crystal.cr -D without_openssl -D without_zlib -D without_playground $(if $(USE_PCRE1),-D use_pcre,-D use_pcre2) --link-flags=/PDBALTPATH:crystal.pdb "--link-flags=$(realpath $(O)\crystal.res)"
 	$(call MV,"$(O)\crystal-next.exe","$@")
 	$(call MV,"$(O)\crystal-next.pdb","$(O)\crystal.pdb")
 

--- a/Makefile.win
+++ b/Makefile.win
@@ -190,7 +190,7 @@ $(O)\crystal.exe: $(DEPS) $(SOURCES) $(O)\crystal.res
 	@$(call MKDIR,"$(O)")
 	$(call export_vars)
 	$(call export_build_vars)
-	.\bin\crystal build $(FLAGS) -o "$(O)\crystal-next.exe" src\compiler\crystal.cr -D without_openssl -D without_zlib -D without_playground -D use_pcre --link-flags=/PDBALTPATH:crystal.pdb "--link-flags=$(realpath $(O)\crystal.res)"
+	.\bin\crystal build $(FLAGS) -o "$(O)\crystal-next.exe" src\compiler\crystal.cr -D without_openssl -D without_zlib -D without_playground -D use_pcre2 --link-flags=/PDBALTPATH:crystal.pdb "--link-flags=$(realpath $(O)\crystal.res)"
 	$(call MV,"$(O)\crystal-next.exe","$@")
 	$(call MV,"$(O)\crystal-next.pdb","$(O)\crystal.pdb")
 

--- a/Makefile.win
+++ b/Makefile.win
@@ -190,7 +190,7 @@ $(O)\crystal.exe: $(DEPS) $(SOURCES) $(O)\crystal.res
 	@$(call MKDIR,"$(O)")
 	$(call export_vars)
 	$(call export_build_vars)
-	.\bin\crystal build $(FLAGS) -o "$(O)\crystal-next.exe" src\compiler\crystal.cr -D without_openssl -D without_zlib -D without_playground -D use_pcre2 --link-flags=/PDBALTPATH:crystal.pdb "--link-flags=$(realpath $(O)\crystal.res)"
+	.\bin\crystal build $(FLAGS) -o "$(O)\crystal-next.exe" src\compiler\crystal.cr -D without_openssl -D without_zlib -D without_playground $(if $(PCRE1),-D use_pcre,-D use_pcre2) --link-flags=/PDBALTPATH:crystal.pdb "--link-flags=$(realpath $(O)\crystal.res)"
 	$(call MV,"$(O)\crystal-next.exe","$@")
 	$(call MV,"$(O)\crystal-next.pdb","$(O)\crystal.pdb")
 

--- a/bin/ci
+++ b/bin/ci
@@ -211,6 +211,7 @@ with_build_env() {
     -w /mnt \
     -e CRYSTAL_CACHE_DIR="/tmp/crystal" \
     -e SPEC_SPLIT_DOTS \
+    -e PCRE1 \
     "$DOCKER_TEST_IMAGE" \
     "$ARCH_CMD" /bin/sh -c "'$command'"
 

--- a/bin/ci
+++ b/bin/ci
@@ -211,7 +211,7 @@ with_build_env() {
     -w /mnt \
     -e CRYSTAL_CACHE_DIR="/tmp/crystal" \
     -e SPEC_SPLIT_DOTS \
-    -e PCRE1 \
+    -e USE_PCRE1 \
     "$DOCKER_TEST_IMAGE" \
     "$ARCH_CMD" /bin/sh -c "'$command'"
 

--- a/shell.nix
+++ b/shell.nix
@@ -128,7 +128,7 @@ let
   };
 
   stdLibDeps = with pkgs; [
-      boehmgc gmp libevent libiconv libxml2 libyaml openssl pcre zlib
+      boehmgc gmp libevent libiconv libxml2 libyaml openssl pcre2 zlib
     ] ++ lib.optionals stdenv.isDarwin [ libiconv ];
 
   tools = [ pkgs.hostname pkgs.git llvm_suite.extra ];


### PR DESCRIPTION
The explicit selection of PCRE2 via `-D use_pcre2` is intentional. We want the compiler to built with PCRE2 and not silently fall back to PCRE.