### PR TITLE
Fix `libpcre2` bindings with arch-dependent types (`SizeT`)

### DIFF
--- a/.github/workflows/wasm32.yml
+++ b/.github/workflows/wasm32.yml
@@ -36,7 +36,7 @@ jobs:
           rm wasm32-wasi-libs.tar.gz
 
       - name: Build spec/wasm32_std_spec.cr
-        run: bin/crystal build spec/wasm32_std_spec.cr -o wasm32_std_spec.wasm --target wasm32-wasi
+        run: bin/crystal build spec/wasm32_std_spec.cr -o wasm32_std_spec.wasm --target wasm32-wasi -Duse_pcre
         env:
           CRYSTAL_LIBRARY_PATH: ${{ github.workspace }}/wasm32-wasi-libs
 

--- a/src/regex/lib_pcre2.cr
+++ b/src/regex/lib_pcre2.cr
@@ -179,7 +179,7 @@ lib LibPCRE2
 
   fun get_error_message = pcre2_get_error_message_8(errorcode : Int, buffer : UInt8*, bufflen : LibC::SizeT) : Int
 
-  fun compile = pcre2_compile_8(pattern : UInt8*, length : LibC::SizeT, options : UInt32, errorcode : LibC::SizeT*, erroroffset : Int*, ccontext : CompileContext*) : Code*
+  fun compile = pcre2_compile_8(pattern : UInt8*, length : LibC::SizeT, options : UInt32, errorcode : Int*, erroroffset : LibC::SizeT*, ccontext : CompileContext*) : Code*
   fun code_free = pcre2_code_free_8(code : Code*) : Void
 
   type MatchContext = Void*

--- a/src/regex/pcre2.cr
+++ b/src/regex/pcre2.cr
@@ -176,7 +176,7 @@ module Regex::PCRE2
 
   module MatchData
     # :nodoc:
-    def initialize(@regex : Regex, @code : LibPCRE2::Code*, @string : String, @pos : Int32, @ovector : UInt64*, @group_size : Int32)
+    def initialize(@regex : Regex, @code : LibPCRE2::Code*, @string : String, @pos : Int32, @ovector : LibC::SizeT*, @group_size : Int32)
     end
 
     private def byte_range(n, &)


### PR DESCRIPTION
The lib function `get_ovector_pointer` returns `LibC::SizeT`, not `UInt64`. They happen to be identical on 64-bit architectures, but not on 32-bit. This fix uses the correct type in `Regex::MatchData`.

I'm also pinning wasm32_test to use PCRE because the wasm libraries from https://github.com/lbguilherme/wasm-libs do not provide PCRE2 yet.