### PR TITLE
Fix `libpcre2` bindings function pointers

### DIFF
--- a/src/regex/lib_pcre2.cr
+++ b/src/regex/lib_pcre2.cr
@@ -207,8 +207,10 @@ lib LibPCRE2
   fun get_ovector_pointer = pcre2_get_ovector_pointer_8(match_data : MatchData*) : LibC::SizeT*
   fun get_ovector_count = pcre2_get_ovector_count_8(match_data : MatchData*) : UInt32
 
-  # void *private_malloc(Int, void *);
-  # void  private_free(void *, void *);
-  fun general_context_create = pcre2_general_context_create_8(private_malloc : Void*, private_free : Void*, memory_data : Void*) : GeneralContext
+  fun general_context_create = pcre2_general_context_create_8(
+    private_malloc : LibC::SizeT, Void* -> Void,
+    private_free : Void*, Void* -> Void,
+    memory_data : Void*
+  ) : GeneralContext
   fun config = pcre2_config_8(what : UInt32, where : Void*) : Int
 end

--- a/src/regex/pcre2.cr
+++ b/src/regex/pcre2.cr
@@ -135,7 +135,7 @@ module Regex::PCRE2
   end
 
   class_getter general_context do
-    LibPCRE2.general_context_create(->(size : LibC::Int, data : Void*) { GC.malloc(size) }.pointer, ->(pointer : Void*, data : Void*) { GC.free(pointer) }.pointer, nil)
+    LibPCRE2.general_context_create(->(size, _data) { GC.malloc(size) }, ->(pointer, _data) { GC.free(pointer) }, nil)
   end
 
   # Returns a JIT stack that's shared in the current thread.


### PR DESCRIPTION
The function binding for `pcre2_general_context_create` receives two function pointers.
They're typed as void pointers instead of a proc type.
The problem is that at the call site the argument type of one of the callback functions is incorrectly declared as `LibC::Int`, but it should actually be `LibC::SizeT`. The function definition mentioned the expected callback type, but it also incorrectly used `Int`.
This puts it in the same error class as crystal-lang/crystal#13088. 

It sometimes worked - including on all platforms where the original PCRE2 implementation was tested, so it wasn't noticed.

Crystal's lib bindings actually has special syntax for function pointers as detailed in https://crystal-lang.org/reference/1.7/syntax_and_semantics/c_bindings/callbacks.html

Function pointers can be expressed as `Proc` type. And when using proc literals at call site, you can even skip the argument types because they're inferred from the function binding.
So yay, with this patch the code is safer and more concise.

