### PR TITLE
Clarify WebSocket documentation

### DIFF
--- a/src/http/web_socket.cr
+++ b/src/http/web_socket.cr
@@ -85,7 +85,7 @@ class HTTP::WebSocket
 
   # Sends a PING frame. Received pings will call `#on_ping`.
   #
-  # It's possible to send a PING frame, which the other party must respond to with a PONG.
+  # The receiving party must respond with a PONG.
   def ping(message = nil)
     check_open
     @ws.ping(message)

--- a/src/http/web_socket.cr
+++ b/src/http/web_socket.cr
@@ -51,23 +51,25 @@ class HTTP::WebSocket
     new(Protocol.new(host, path, port, tls, headers))
   end
 
-  # Called when the server sends a ping to a client.
+  # Called when a PING frame is received.
   def on_ping(&@on_ping : String ->)
   end
 
-  # Called when the server receives a pong from a client.
+  # Called when a PONG frame is received.
+  #
+  # An unsolicited PONG frame should not be responded to.
   def on_pong(&@on_pong : String ->)
   end
 
-  # Called when the server receives a text message from a client.
+  # Called when a text message is received.
   def on_message(&@on_message : String ->)
   end
 
-  # Called when the server receives a binary message from a client.
+  # Called when a binary message is received.
   def on_binary(&@on_binary : Bytes ->)
   end
 
-  # Called when the server closes a client's connection.
+  # Called the connection is closed by the other party.
   def on_close(&@on_close : CloseCode, String ->)
   end
 
@@ -75,25 +77,21 @@ class HTTP::WebSocket
     raise IO::Error.new "Closed socket" if closed?
   end
 
-  # Sends a message payload (message) to the client.
+  # Sends a message payload (message).
   def send(message) : Nil
     check_open
     @ws.send(message)
   end
 
-  # It's possible to send a PING frame, which the client must respond to
-  # with a PONG, or the server can send an unsolicited PONG frame
-  # which the client should not respond to.
+  # Sends a PING frame. Received pings will call `#on_ping`.
   #
-  # See `#pong`.
+  # It's possible to send a PING frame, which the other party must respond to with a PONG.
   def ping(message = nil)
     check_open
     @ws.ping(message)
   end
 
-  # Server can send an unsolicited PONG frame which the client should not respond to.
-  #
-  # See `#ping`.
+  # Sends a PONG frame, which must be in response to a previously received PING frame from `#on_ping`.
   def pong(message = nil) : Nil
     check_open
     @ws.pong(message)
@@ -106,7 +104,7 @@ class HTTP::WebSocket
     end
   end
 
-  # Sends a close frame to the client, and closes the connection.
+  # Sends a close frame, and closes the connection.
   # The close frame may contain a body (message) that indicates the reason for closing.
   def close(code : CloseCode | Int? = nil, message = nil) : Nil
     return if closed?

--- a/src/http/web_socket.cr
+++ b/src/http/web_socket.cr
@@ -69,7 +69,7 @@ class HTTP::WebSocket
   def on_binary(&@on_binary : Bytes ->)
   end
 
-  # Called the connection is closed by the other party.
+  # Called when the connection is closed by the other party.
   def on_close(&@on_close : CloseCode, String ->)
   end
 


### PR DESCRIPTION
Server and client wording is ambiguous, `HTTP::WebSocket` can be used by both.

Follow up of #13077.