### PR TITLE
[CI] Use PCRE where `libpcre2` is not yet available in the build environment

### DIFF
--- a/.github/workflows/aarch64.yml
+++ b/.github/workflows/aarch64.yml
@@ -12,7 +12,7 @@ jobs:
       - name: Build Crystal
         uses: docker://jhass/crystal:1.0.0-alpine-build
         with:
-          args: make crystal
+          args: make crystal FLAGS=-Duse_pcre
       - name: Upload Crystal executable
         uses: actions/upload-artifact@v3
         with:
@@ -36,7 +36,7 @@ jobs:
       - name: Run stdlib specs
         uses: docker://jhass/crystal:1.0.0-alpine-build
         with:
-          args: make std_spec
+          args: make std_spec FLAGS=-Duse_pcre
   aarch64-musl-test-compiler:
     needs: aarch64-musl-build
     runs-on: [linux, ARM64]
@@ -53,7 +53,7 @@ jobs:
       - name: Run compiler specs
         uses: docker://jhass/crystal:1.0.0-alpine-build
         with:
-          args: make primitives_spec compiler_spec FLAGS=-Dwithout_ffi
+          args: make primitives_spec compiler_spec FLAGS="-Dwithout_ffi -Duse_pcre"
   aarch64-gnu-build:
     runs-on: [linux, ARM64]
     if: github.repository == 'crystal-lang/crystal'
@@ -87,7 +87,7 @@ jobs:
       - name: Run stdlib specs
         uses: docker://jhass/crystal:1.0.0-build
         with:
-          args: make std_spec
+          args: make std_spec FLAGS=-Duse_pcre
   aarch64-gnu-test-compiler:
     needs: aarch64-gnu-build
     runs-on: [linux, ARM64]
@@ -104,4 +104,4 @@ jobs:
       - name: Run compiler specs
         uses: docker://jhass/crystal:1.0.0-build
         with:
-          args: make primitives_spec compiler_spec
+          args: make primitives_spec compiler_spec FLAGS=-Duse_pcre

--- a/.github/workflows/wasm32.yml
+++ b/.github/workflows/wasm32.yml
@@ -36,7 +36,7 @@ jobs:
           rm wasm32-wasi-libs.tar.gz
 
       - name: Build spec/wasm32_std_spec.cr
-        run: bin/crystal build spec/wasm32_std_spec.cr -o wasm32_std_spec.wasm --target wasm32-wasi
+        run: bin/crystal build spec/wasm32_std_spec.cr -o wasm32_std_spec.wasm --target wasm32-wasi -Duse_pcre
         env:
           CRYSTAL_LIBRARY_PATH: ${{ github.workspace }}/wasm32-wasi-libs
 


### PR DESCRIPTION
Fixup for #12978