### PR TITLE
Run compiler specs in release mode

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -188,7 +188,7 @@ $(O)/std_spec: $(DEPS) $(SOURCES) $(SPEC_SOURCES)
 $(O)/compiler_spec: $(DEPS) $(SOURCES) $(SPEC_SOURCES)
 	$(call check_llvm_config)
 	@mkdir -p $(O)
-	$(EXPORT_CC) $(EXPORTS) ./bin/crystal build $(FLAGS) $(SPEC_WARNINGS_OFF) -o $@ spec/compiler_spec.cr
+	$(EXPORT_CC) $(EXPORTS) ./bin/crystal build $(FLAGS) $(SPEC_WARNINGS_OFF) -o $@ spec/compiler_spec.cr --release
 
 $(O)/primitives_spec: $(O)/crystal $(DEPS) $(SOURCES) $(SPEC_SOURCES)
 	@mkdir -p $(O)

--- a/Makefile.win
+++ b/Makefile.win
@@ -179,7 +179,7 @@ $(O)\compiler_spec.exe: $(DEPS) $(SOURCES) $(SPEC_SOURCES)
 	$(call check_llvm_config)
 	@$(call MKDIR,"$(O)")
 	$(call export_vars)
-	.\bin\crystal build $(FLAGS) $(SPEC_WARNINGS_OFF) -o "$@" spec\compiler_spec.cr
+	.\bin\crystal build $(FLAGS) $(SPEC_WARNINGS_OFF) -o "$@" spec\compiler_spec.cr --release
 
 $(O)\primitives_spec.exe: $(O)\crystal.exe $(DEPS) $(SOURCES) $(SPEC_SOURCES)
 	@$(call MKDIR,"$(O)")


### PR DESCRIPTION
Building the compiler (or compiler specs in this case) in release mode has a hefty upfront cost, but it improves execution speed of the compiler a lot. The extra overhead is not worth it if you only use the compiler a couple of times, but when you use it a lot, it makes sense to build in release mode.

The compiler specs are pretty huge and thus use the compiler a lot. So I figured, why not try build `compiler_spec` in release mode to speed up the execution? Compiler specs are a huge portion of CI job runtime, so maybe we can speed things up a bit.

So I did that in this branch and compared the runtimes with previous runs on `master`.
The duration of spec runs varies quite a bit, actually. So it must be taken with a grain of salt. I did only one CI run in release mode yet.
But there's a clear tendency: Each individual CI job which runs `compiler_spec` finished more quickly in release mode than in previous runs. The speed up is typically between 3-10 minutes.

As an example, this is the comparison of the `x86_64-gnu-test` jobs in `Linux CI`:

| This branch | #13079 |
|-|-|
| 35:59 | 45:13 |
| 42:57 | 49:32 |
| 35:26 | 46:01 |
| 43:40 | 55:58 |
| 45:27 | 48:42 |
| 35:45 | 45:16 |
| 34:49 | 46:18 |
| 40:05 | 45:27 |

The total sum of durations dropeed from 6:22:27 to 5:14:08.

So running specs in release mode seems to bring quite a noticable performance improvement.

