### PR TITLE
Explicitly treat unbound type vars in generic class methods as free variables

### DIFF
--- a/spec/compiler/semantic/restrictions_spec.cr
+++ b/spec/compiler/semantic/restrictions_spec.cr
@@ -1221,6 +1221,18 @@ describe "Restrictions" do
       CR
   end
 
+  it "sets number as unbound generic type var (#13110)" do
+    assert_type(<<-CR) { generic_class "Foo", 1.int32 }
+      class Foo(T)
+        def self.foo(x : Foo(T))
+          x
+        end
+      end
+
+      Foo.foo(Foo(1).new)
+      CR
+  end
+
   it "restricts aliased typedef type (#9474)" do
     assert_type(%(
       lib A

--- a/src/compiler/crystal/semantic/match.cr
+++ b/src/compiler/crystal/semantic/match.cr
@@ -69,7 +69,9 @@ module Crystal
 
     def has_def_free_var?(name)
       return false if get_free_var(name)
-      !!(@def_free_vars.try &.includes?(name))
+      return true if @def_free_vars.try &.includes?(name)
+
+      defining_type.metaclass? && defining_type.type_var?(name)
     end
 
     # Returns the type that corresponds to using `self` when looking


### PR DESCRIPTION
Fixes #13110.