### PR TITLE
Formatter: add `(&)` to param-less yielding defs before comment line

### DIFF
--- a/spec/compiler/formatter/formatter_spec.cr
+++ b/spec/compiler/formatter/formatter_spec.cr
@@ -587,6 +587,18 @@ describe Crystal::Formatter do
       end
       CRYSTAL
 
+    # #13091
+    assert_format <<-CRYSTAL,
+      def foo # bar
+        yield
+      end
+      CRYSTAL
+      <<-CRYSTAL
+      def foo(&) # bar
+        yield
+      end
+      CRYSTAL
+
     assert_format <<-CRYSTAL,
       def foo(x)
         yield

--- a/src/compiler/crystal/tools/formatter.cr
+++ b/src/compiler/crystal/tools/formatter.cr
@@ -1466,6 +1466,13 @@ module Crystal
 
       indent do
         next_token
+
+        # this formats `def foo # ...` to `def foo(&) # ...` for yielding
+        # methods before consuming the comment line
+        if node.block_arity && node.args.empty? && !node.block_arg && !node.double_splat
+          write "(&)"
+        end
+
         skip_space consume_newline: false
         next_token_skip_space if @token.type.op_eq?
       end
@@ -1517,7 +1524,6 @@ module Crystal
     def format_def_args(args : Array, block_arg, splat_index, variadic, double_splat, yields)
       # If there are no args, remove extra "()"
       if args.empty? && !block_arg && !double_splat && !variadic
-        write "(&)" if yields
         if @token.type.op_lparen?
           next_token_skip_space_or_newline
           check :OP_RPAREN


### PR DESCRIPTION
Fixes #13091.