### PR TITLE
Fix Crystal tool cursor parsing for filenames containing `:`

### DIFF
--- a/spec/compiler/lexer/location_spec.cr
+++ b/spec/compiler/lexer/location_spec.cr
@@ -174,4 +174,35 @@ describe "Lexer: location" do
     (loc1 < loc2).should be_false
     (loc2 < loc1).should be_false
   end
+
+  describe "Location.parse" do
+    it "parses location from string" do
+      Location.parse("foo:1:2").should eq(Location.new("foo", 1, 2))
+      Location.parse("foo:bar/baz:345:6789").should eq(Location.new("foo:bar/baz", 345, 6789))
+      Location.parse(%q(C:\foo\bar:1:2)).should eq(Location.new(%q(C:\foo\bar), 1, 2))
+    end
+
+    it "raises ArgumentError if missing colon" do
+      expect_raises(ArgumentError, "cursor location must be file:line:column") { Location.parse("foo") }
+      expect_raises(ArgumentError, "cursor location must be file:line:column") { Location.parse("foo:1") }
+    end
+
+    it "raises ArgumentError if missing part" do
+      expect_raises(ArgumentError, "cursor location must be file:line:column") { Location.parse(":1:2") }
+      expect_raises(ArgumentError, "cursor location must be file:line:column") { Location.parse("foo::2") }
+      expect_raises(ArgumentError, "cursor location must be file:line:column") { Location.parse("foo:1:") }
+    end
+
+    it "raises ArgumentError if line number is invalid" do
+      expect_raises(ArgumentError, "line must be a positive integer, not a") { Location.parse("foo:a:2") }
+      expect_raises(ArgumentError, "line must be a positive integer, not 0") { Location.parse("foo:0:2") }
+      expect_raises(ArgumentError, "line must be a positive integer, not -1") { Location.parse("foo:-1:2") }
+    end
+
+    it "raises ArgumentError if column number is invalid" do
+      expect_raises(ArgumentError, "column must be a positive integer, not a") { Location.parse("foo:2:a") }
+      expect_raises(ArgumentError, "column must be a positive integer, not 0") { Location.parse("foo:2:0") }
+      expect_raises(ArgumentError, "column must be a positive integer, not -1") { Location.parse("foo:2:-1") }
+    end
+  end
 end

--- a/src/compiler/crystal/command/cursor.cr
+++ b/src/compiler/crystal/command/cursor.cr
@@ -31,27 +31,14 @@ class Crystal::Command
 
     format = config.output_format
 
-    loc = config.cursor_location.not_nil!.split(':')
-    if loc.size != 3
-      error "cursor location must be file:line:column"
+    begin
+      loc = Location.parse(config.cursor_location.not_nil!, expand: true)
+    rescue ex : ArgumentError
+      error ex.message
     end
-
-    file, line, col = loc
-
-    line_number = line.to_i? || 0
-    if line_number <= 0
-      error "line must be a positive integer, not #{line}"
-    end
-
-    column_number = col.to_i? || 0
-    if column_number <= 0
-      error "column must be a positive integer, not #{col}"
-    end
-
-    file = File.expand_path(file)
 
     result = @progress_tracker.stage("Tool (#{command.split(' ')[1]})") do
-      yield Location.new(file, line_number, column_number), config, result
+      yield loc, config, result
     end
 
     case format

--- a/src/compiler/crystal/syntax/location.cr
+++ b/src/compiler/crystal/syntax/location.cr
@@ -9,6 +9,32 @@ class Crystal::Location
   def initialize(@filename : String | VirtualFile | Nil, @line_number : Int32, @column_number : Int32)
   end
 
+  # Returns a location from a string representation. Used by compiler tools like
+  # `context` and `implementations`.
+  def self.parse(cursor : String, *, expand : Bool = false) : self
+    file_and_line, colon, col = cursor.rpartition(':')
+    raise ArgumentError.new "cursor location must be file:line:column" if colon.empty?
+
+    file, colon, line = file_and_line.rpartition(':')
+    raise ArgumentError.new "cursor location must be file:line:column" if colon.empty?
+
+    raise ArgumentError.new "cursor location must be file:line:column" if file.empty? || line.empty? || col.empty?
+
+    file = File.expand_path(file) if expand
+
+    line_number = line.to_i? || 0
+    if line_number <= 0
+      raise ArgumentError.new "line must be a positive integer, not #{line}"
+    end
+
+    column_number = col.to_i? || 0
+    if column_number <= 0
+      raise ArgumentError.new "column must be a positive integer, not #{col}"
+    end
+
+    new(file, line_number, column_number)
+  end
+
   # Returns the directory name of this location's filename. If
   # the filename is a VirtualFile, this is invoked on its expanded
   # location.

--- a/src/compiler/crystal/util.cr
+++ b/src/compiler/crystal/util.cr
@@ -15,10 +15,14 @@ module Crystal
     filename
   end
 
-  def self.error(msg, color, exit_code = 1, stderr = STDERR, leading_error = true)
+  def self.error(msg, color, exit_code : Int = 1, stderr = STDERR, leading_error = true) : NoReturn
+    error(msg, color, nil, stderr, leading_error)
+    exit(exit_code)
+  end
+
+  def self.error(msg, color, exit_code : Nil, stderr = STDERR, leading_error = true)
     stderr.print "Error: ".colorize.toggle(color).red.bold if leading_error
     stderr.puts msg.colorize.toggle(color).bright
-    exit(exit_code) if exit_code
   end
 
   def self.tempfile(basename)


### PR DESCRIPTION
Fixes #13086.