### PR TITLE
Re-export `LibC.printf` and `snprintf` for Windows interpreter

### DIFF
--- a/etc/msvc/win32_interpreter_stub.c
+++ b/etc/msvc/win32_interpreter_stub.c
@@ -1,0 +1,24 @@
+/*
+ * Compile with `cl.exe /LD win32_interpreter_stub.c`
+ * FIXME: implement fixed-precision float printing in pure Crystal so that
+ * we don't need these two functions at all (Ryu-printf or jk-jeon/floff)
+ */
+
+#include <stdio.h>
+#include <stdarg.h>
+
+__declspec(dllexport) int __crystal_printf(const char *format, ...) {
+    va_list args;
+    va_start(args, format);
+    int result = vprintf(format, args);
+    va_end(args);
+    return result;
+}
+
+__declspec(dllexport) int __crystal_snprintf(char *buffer, size_t count, const char *format, ...) {
+    va_list args;
+    va_start(args, format);
+    int result = vsnprintf(buffer, count, format, args);
+    va_end(args);
+    return result;
+}

--- a/src/compiler/crystal/loader/msvc.cr
+++ b/src/compiler/crystal/loader/msvc.cr
@@ -5,9 +5,10 @@ require "crystal/system/win32/library_archive"
 # `link.exe`, using the Win32 DLL API.
 #
 # * Only dynamic libraries can be loaded. Static libraries and object files
-#   are unsupported. in particular, `LibC.printf` and `LibC.snprintf`are inline
-#   functions in `legacy-stdio_definitions.lib` since VS2015, so they are never
-#   found by the loader.
+#   are unsupported. in particular, `LibC.printf` and `LibC.snprintf` are inline
+#   functions in `legacy_stdio_definitions.lib` since VS2015, so they are never
+#   found by the loader. As a temporary workaround, we re-export these two
+#   functions via `etc/msvc/win32_interpreter_stub.c`.
 # * Unlike the Unix counterpart, symbols in the current module do not clash with
 #   the ones in DLLs or their corresponding import libraries.
 

--- a/src/crystal/system/win32/path.cr
+++ b/src/crystal/system/win32/path.cr
@@ -6,12 +6,15 @@ module Crystal::System::Path
   def self.home : String
     if home_path = ENV["USERPROFILE"]?.presence
       home_path
-    elsif LibC.SHGetKnownFolderPath(pointerof(LibC::FOLDERID_Profile), 0, nil, out path_ptr) == 0
-      home_path, _ = String.from_utf16(path_ptr)
-      LibC.CoTaskMemFree(path_ptr)
-      home_path
     else
-      raise RuntimeError.from_winerror("SHGetKnownFolderPath")
+      uuid = LibC::FOLDERID_Profile
+      if LibC.SHGetKnownFolderPath(pointerof(uuid), 0, nil, out path_ptr) == 0
+        home_path, _ = String.from_utf16(path_ptr)
+        LibC.CoTaskMemFree(path_ptr)
+        home_path
+      else
+        raise RuntimeError.from_winerror("SHGetKnownFolderPath")
+      end
     end
   end
 end

--- a/src/lib_c/x86_64-windows-msvc/c/stdio.cr
+++ b/src/lib_c/x86_64-windows-msvc/c/stdio.cr
@@ -1,8 +1,19 @@
 require "./stddef"
 
-@[Link("legacy_stdio_definitions")]
+{% if flag?(:interpreted) %}
+  @[Link("win32_interpreter_stub")]
+  lib LibC
+    fun printf = __crystal_printf(format : Char*, ...) : Int
+    fun snprintf = __crystal_snprintf(buffer : Char*, count : SizeT, format : Char*, ...) : Int
+  end
+{% else %}
+  @[Link("legacy_stdio_definitions")]
+  lib LibC
+    fun printf(format : Char*, ...) : Int
+    fun snprintf(buffer : Char*, count : SizeT, format : Char*, ...) : Int
+  end
+{% end %}
+
 lib LibC
-  fun printf(format : Char*, ...) : Int
   fun rename(old : Char*, new : Char*) : Int
-  fun snprintf(buffer : Char*, count : SizeT, format : Char*, ...) : Int
 end


### PR DESCRIPTION
This simple hack allows more things to run on an interpreter built on Windows.

Build the new stub with `cl.exe /LD etc\msvc\win32_interpreter_stub.c`, then copy the resulting `win32_interpreter_stub.lib` and `win32_interpreter_stub.dll` files to the appropriate locations (those you set up according to #11573 or #12397). Now things like `bin\crystal i spec\std\int_spec.cr` will work even on Windows.

Two other alternatives to this hack are:

* Finish #12473 (or even [jk-jeon/floff](https://github.com/jk-jeon/floff)) and incorporate it into `String::Formatter`, so that we don't need these functions at all
* Define `printf` and `snprintf` as variadic interpreter primitives, which allows the interpreted program to reuse the interpreter binary's own `printf` and `snprintf`

Also includes a necessary workaround for the `pointerof` described in #12396.