### PR TITLE
Improve PCRE2 match performance for JIT and interpreted

### DIFF
--- a/src/regex/lib_pcre2.cr
+++ b/src/regex/lib_pcre2.cr
@@ -172,10 +172,10 @@ lib LibPCRE2
   CONFIG_COMPILED_WIDTHS   = 14
   CONFIG_TABLES_LENGTH     = 15
 
-  type Code = Void*
-  type CompileContext = Void*
-  type MatchData = Void*
-  type GeneralContext = Void*
+  type Code = Void
+  type CompileContext = Void
+  type MatchData = Void
+  type GeneralContext = Void
 
   fun get_error_message = pcre2_get_error_message_8(errorcode : Int, buffer : UInt8*, bufflen : LibC::SizeT) : Int
 
@@ -183,7 +183,7 @@ lib LibPCRE2
   fun code_free = pcre2_code_free_8(code : Code*) : Void
 
   type MatchContext = Void*
-  fun match_context_create = pcre2_match_context_create_8(gcontext : Void*) : MatchContext
+  fun match_context_create = pcre2_match_context_create_8(gcontext : Void*) : MatchContext*
 
   JIT_COMPLETE     = 0x00000001_u32 # For full matching
   JIT_PARTIAL_SOFT = 0x00000002_u32
@@ -191,15 +191,15 @@ lib LibPCRE2
   JIT_INVALID_UTF  = 0x00000100_u32
   fun jit_compile = pcre2_jit_compile_8(code : Code*, options : UInt32) : Int
 
-  type JITStack = Void*
+  type JITStack = Void
 
-  fun jit_stack_create = pcre2_jit_stack_create_8(startsize : LibC::SizeT, maxsize : LibC::SizeT, gcontext : GeneralContext) : JITStack
-  fun jit_stack_assign = pcre2_jit_stack_assign_8(mcontext : MatchContext, callable_function : Void* -> JITStack, callable_data : Void*) : Void
+  fun jit_stack_create = pcre2_jit_stack_create_8(startsize : LibC::SizeT, maxsize : LibC::SizeT, gcontext : GeneralContext*) : JITStack*
+  fun jit_stack_assign = pcre2_jit_stack_assign_8(mcontext : MatchContext*, callable_function : Void* -> JITStack*, callable_data : Void*) : Void
 
   fun pattern_info = pcre2_pattern_info_8(code : Code*, what : UInt32, where : Void*) : Int
 
-  fun match = pcre2_match_8(code : Code*, subject : UInt8*, length : LibC::SizeT, startoffset : LibC::SizeT, options : UInt32, match_data : MatchData*, mcontext : MatchContext) : Int
-  fun match_data_create_from_pattern = pcre2_match_data_create_from_pattern_8(code : Code*, gcontext : GeneralContext) : MatchData*
+  fun match = pcre2_match_8(code : Code*, subject : UInt8*, length : LibC::SizeT, startoffset : LibC::SizeT, options : UInt32, match_data : MatchData*, mcontext : MatchContext*) : Int
+  fun match_data_create_from_pattern = pcre2_match_data_create_from_pattern_8(code : Code*, gcontext : GeneralContext*) : MatchData*
   fun match_data_free = pcre2_match_data_free_8(match_data : MatchData*) : Void
 
   fun substring_nametable_scan = pcre2_substring_nametable_scan_8(code : Code*, name : UInt8*, first : UInt8*, last : UInt8*) : Int

--- a/src/regex/lib_pcre2.cr
+++ b/src/regex/lib_pcre2.cr
@@ -207,10 +207,5 @@ lib LibPCRE2
   fun get_ovector_pointer = pcre2_get_ovector_pointer_8(match_data : MatchData*) : LibC::SizeT*
   fun get_ovector_count = pcre2_get_ovector_count_8(match_data : MatchData*) : UInt32
 
-  fun general_context_create = pcre2_general_context_create_8(
-    private_malloc : LibC::SizeT, Void* -> Void,
-    private_free : Void*, Void* -> Void,
-    memory_data : Void*
-  ) : GeneralContext
   fun config = pcre2_config_8(what : UInt32, where : Void*) : Int
 end

--- a/src/regex/lib_pcre2.cr
+++ b/src/regex/lib_pcre2.cr
@@ -194,7 +194,7 @@ lib LibPCRE2
   type JITStack = Void*
 
   fun jit_stack_create = pcre2_jit_stack_create_8(startsize : LibC::SizeT, maxsize : LibC::SizeT, gcontext : GeneralContext) : JITStack
-  fun jit_stack_assign = pcre2_jit_stack_assign_8(mcontext : MatchContext, callable_function : Void*, callable_data : Void*) : Void
+  fun jit_stack_assign = pcre2_jit_stack_assign_8(mcontext : MatchContext, callable_function : Void* -> JITStack, callable_data : Void*) : Void
 
   fun pattern_info = pcre2_pattern_info_8(code : Code*, what : UInt32, where : Void*) : Int
 

--- a/src/regex/pcre2.cr
+++ b/src/regex/pcre2.cr
@@ -173,7 +173,7 @@ module Regex::PCRE2
   end
 
   def finalize
-    @match_data.get?.try do |match_data|
+    @match_data.consume_each do |match_data|
       LibPCRE2.match_data_free(match_data)
     end
   end

--- a/src/regex/pcre2.cr
+++ b/src/regex/pcre2.cr
@@ -142,10 +142,6 @@ module Regex::PCRE2
     end
   end
 
-  class_getter general_context do
-    LibPCRE2.general_context_create(->(size, _data) { GC.malloc(size) }, ->(pointer, _data) { GC.free(pointer) }, nil)
-  end
-
   class_getter match_context : LibPCRE2::MatchContext do
     match_context = LibPCRE2.match_context_create(nil)
     LibPCRE2.jit_stack_assign(match_context, ->(_data) { Regex::PCRE2.jit_stack }, nil)
@@ -160,7 +156,7 @@ module Regex::PCRE2
 
   def self.jit_stack
     @@jit_stack.get do
-      LibPCRE2.jit_stack_create(32_768, 1_048_576, general_context) || raise "Error allocating JIT stack"
+      LibPCRE2.jit_stack_create(32_768, 1_048_576, nil) || raise "Error allocating JIT stack"
     end
   end
 
@@ -172,7 +168,7 @@ module Regex::PCRE2
 
   private def match_data
     @match_data.get do
-      LibPCRE2.match_data_create_from_pattern(@re, Regex::PCRE2.general_context)
+      LibPCRE2.match_data_create_from_pattern(@re, nil)
     end
   end
 

--- a/src/regex/pcre2.cr
+++ b/src/regex/pcre2.cr
@@ -142,7 +142,7 @@ module Regex::PCRE2
     end
   end
 
-  class_getter match_context : LibPCRE2::MatchContext do
+  class_getter match_context : LibPCRE2::MatchContext* do
     match_context = LibPCRE2.match_context_create(nil)
     LibPCRE2.jit_stack_assign(match_context, ->(_data) { Regex::PCRE2.jit_stack }, nil)
     match_context
@@ -152,7 +152,7 @@ module Regex::PCRE2
   #
   # Only a single `match` function can run per thread at any given time, so there
   # can't be any concurrent access to the JIT stack.
-  @@jit_stack = Crystal::ThreadLocalValue(LibPCRE2::JITStack).new
+  @@jit_stack = Crystal::ThreadLocalValue(LibPCRE2::JITStack*).new
 
   def self.jit_stack
     @@jit_stack.get do


### PR DESCRIPTION
This patch contains a number of individual steps that improve performance of PCRE2 matching greatly.

* Global `MatchContext` that is allocated only once and shared between all match executions. JIT stack is assigned via a callback which returns the appropriate thread-local stack. The callback won't be called if JIT is not used. This improve JIT performance.
* Cache `MatchData` per instance and thread. This avoids re-allocating the backtracking stack which improve interpreted performance
* Now that the pointer to `MatchData` does not leak outside the local scope, there's no need to allocate it with the GC. `libpcre2` can manage its memory on its own and the `MatchData` instances are handled in the bindings. This reduces GC pressure.

Using the benchmark program from https://github.com/crystal-lang/crystal/issues/13144#issue-1607857944, I get these results:

```console
$ bin/crystal run .test/bm-pcre2.cr --release             # (master)
starts_with? 284.80k (  3.51µs) (±18.92%)  20.1kB/op   7.43× slower
    matches?   2.12M (472.51ns) (±114.77%)    128B/op        fastest
$ bin/crystal run .test/bm-pcre2.cr --release             # (performance/pcre2-match_context)
starts_with?  18.26M ( 54.77ns) (±18.56%)  0.0B/op   1.52× slower
    matches?  27.67M ( 36.14ns) (±16.79%)  0.0B/op        fastest
$ bin/crystal run .test/bm-pcre2.cr --release -Duse_pcre1 # (master)
starts_with?  19.73M ( 50.67ns) (±14.41%)  16.0B/op   2.22× slower
    matches?  43.73M ( 22.87ns) (±17.42%)   0.0B/op        fastest
```

This shows a great improvement in match performance. The PCRE1 implementation is still significantly more performant in JIT mode (`matches?`).
A factor for this could be that the PCRE1 bindings are not thread safe. I'll leave investigation into this as a follow-up and consider the main regression as resolved.

Resolves #13144