### PR TITLE
Fix `MatchData#[]` named capture with identical prefix

### DIFF
--- a/spec/std/regex/match_data_spec.cr
+++ b/spec/std/regex/match_data_spec.cr
@@ -213,6 +213,12 @@ describe "Regex::MatchData" do
         matchdata(re, "barfoo")["g1"].should eq("foo")
       end
 
+      it "named groups with same prefix" do
+        md = matchdata(/KEY_(?<key>\w+)\s+(?<keycode>.*)/, "KEY_POWER 116")
+        md["key"].should eq "POWER"
+        md["keycode"].should eq "116"
+      end
+
       it "raises exception when named group doesn't exist" do
         md = matchdata(/foo/, "foo")
         expect_raises(KeyError, "Capture group 'group' does not exist") { md["group"] }

--- a/src/regex/pcre2.cr
+++ b/src/regex/pcre2.cr
@@ -196,7 +196,7 @@ module Regex::PCRE2
       selected_range = nil
       exists = false
       @regex.each_capture_group do |number, name_entry|
-        if name_entry[2, group_name.bytesize]? == group_name.to_slice
+        if name_entry[2, group_name.bytesize]? == group_name.to_slice && name_entry[2 + group_name.bytesize].zero?
           exists = true
           range = byte_range(number) { nil }
           if (range && selected_range && range.begin > selected_range.begin) || !selected_range


### PR DESCRIPTION
Resolves #13145