### PR TITLE
Fix `getelementptr` usage for the `allocate` primitive

### DIFF
--- a/src/compiler/crystal/codegen/primitives.cr
+++ b/src/compiler/crystal/codegen/primitives.cr
@@ -730,11 +730,6 @@ class Crystal::CodeGenVisitor
 
     allocate_aggregate base_type
 
-    unless type.struct?
-      type_id_ptr = aggregate_index(llvm_struct_type(type), @last, 0)
-      store type_id(base_type), type_id_ptr
-    end
-
     if type.is_a?(VirtualType)
       @last = upcast(@last, type, base_type)
     end


### PR DESCRIPTION
`allocate_aggregate` returns an LLVM value whose pointee type is `llvm_struct_type(base_type)`, not `llvm_struct_type(type)`. This mismatch probably caused x86_64-darwin CI to fail. (I still have no idea why it doesn't fail on the other platforms.)

Fixes the typo while saving one call of `llvm_struct_type`.