### PR TITLE
Keep track of function type inside `LLVM::Function`

### DIFF
--- a/src/compiler/crystal/codegen/asm.cr
+++ b/src/compiler/crystal/codegen/asm.cr
@@ -54,7 +54,7 @@ class Crystal::CodeGenVisitor
     constraints = constraints.to_s
 
     value = fun_type.inline_asm(node.text, constraints, node.volatile?, node.alignstack?, node.can_throw?)
-    value = LLVM::Function.from_value(value)
+    value = LLVM::Function.from_value(value, fun_type)
     asm_value = call value, input_values
 
     if ptrofs = node.output_ptrofs

--- a/src/compiler/crystal/codegen/codegen.cr
+++ b/src/compiler/crystal/codegen/codegen.cr
@@ -1597,7 +1597,7 @@ module Crystal
       func = @main_mod.functions[check_fun_name]? || create_check_proc_is_not_closure_fun(check_fun_name)
       func = check_main_fun check_fun_name, func
       value = call func, [value] of LLVM::Value
-      bit_cast value, llvm_proc_type(type)
+      bit_cast value, llvm_proc_type(type).pointer
     end
 
     def create_check_proc_is_not_closure_fun(fun_name)

--- a/src/compiler/crystal/codegen/llvm_typer.cr
+++ b/src/compiler/crystal/codegen/llvm_typer.cr
@@ -405,7 +405,7 @@ module Crystal
     end
 
     def llvm_embedded_c_type(type : ProcInstanceType, wants_size = false)
-      proc_type(type)
+      proc_type(type).pointer
     end
 
     def llvm_embedded_c_type(type, wants_size = false)
@@ -413,11 +413,11 @@ module Crystal
     end
 
     def llvm_c_type(type : ProcInstanceType)
-      proc_type(type)
+      proc_type(type).pointer
     end
 
     def llvm_c_type(type : NilableProcType)
-      proc_type(type.proc_type)
+      proc_type(type.proc_type).pointer
     end
 
     def llvm_c_type(type : TupleInstanceType)
@@ -461,12 +461,12 @@ module Crystal
     def closure_type(type : ProcInstanceType)
       arg_types = type.arg_types.map { |arg_type| llvm_type(arg_type) }
       arg_types.insert(0, @llvm_context.void_pointer)
-      LLVM::Type.function(arg_types, llvm_type(type.return_type)).pointer
+      LLVM::Type.function(arg_types, llvm_type(type.return_type))
     end
 
     def proc_type(type : ProcInstanceType)
       arg_types = type.arg_types.map { |arg_type| llvm_type(arg_type).as(LLVM::Type) }
-      LLVM::Type.function(arg_types, llvm_type(type.return_type)).pointer
+      LLVM::Type.function(arg_types, llvm_type(type.return_type))
     end
 
     def closure_context_type(vars, parent_llvm_type, self_type)

--- a/src/compiler/crystal/codegen/primitives.cr
+++ b/src/compiler/crystal/codegen/primitives.cr
@@ -849,7 +849,7 @@ class Crystal::CodeGenVisitor
   def union_field_ptr(union_type, field_type, pointer)
     ptr = aggregate_index llvm_type(union_type), pointer, 0
     if field_type.is_a?(ProcInstanceType)
-      bit_cast ptr, @llvm_typer.proc_type(field_type).pointer
+      bit_cast ptr, @llvm_typer.proc_type(field_type).pointer.pointer
     else
       cast_to_pointer ptr, field_type
     end
@@ -1001,7 +1001,7 @@ class Crystal::CodeGenVisitor
 
     Phi.open(self, node, @needs_value) do |phi|
       position_at_end ctx_is_null_block
-      real_fun_ptr = bit_cast fun_ptr, llvm_proc_type(context.type)
+      real_fun_ptr = bit_cast fun_ptr, llvm_proc_type(context.type).pointer
 
       # When invoking a Proc that has extern structs as arguments or return type, it's tricky:
       # closures are never generated with C ABI because C doesn't support closures.
@@ -1027,7 +1027,7 @@ class Crystal::CodeGenVisitor
       target_def.c_calling_convention = nil
 
       position_at_end ctx_is_not_null_block
-      real_fun_ptr = bit_cast fun_ptr, llvm_closure_type(context.type)
+      real_fun_ptr = bit_cast fun_ptr, llvm_closure_type(context.type).pointer
       real_fun_ptr = LLVM::Function.from_value(real_fun_ptr)
       closure_args.insert(0, ctx_ptr)
       value = codegen_call_or_invoke(node, target_def, nil, real_fun_ptr, closure_args, true, target_def.type, true, proc_type)

--- a/src/llvm/function.cr
+++ b/src/llvm/function.cr
@@ -3,8 +3,23 @@ require "./value_methods"
 struct LLVM::Function
   include LLVM::ValueMethods
 
+  getter function_type : LLVM::Type
+
+  @[Deprecated("Pass also the type of the function")]
+  def initialize(@unwrap : LibLLVM::ValueRef)
+    @function_type = Type.new LibLLVM.get_element_type(LibLLVM.type_of(value))
+  end
+
+  def initialize(@unwrap : LibLLVM::ValueRef, @function_type : LLVM::Type)
+  end
+
+  @[Deprecated("Pass also the type of the function")]
   def self.from_value(value : LLVM::ValueMethods)
-    new(value.to_unsafe)
+    new(value.to_unsafe, Type.new LibLLVM.get_element_type(LibLLVM.type_of(value)))
+  end
+
+  def self.from_value(value : LLVM::ValueMethods, type : LLVM::Type)
+    new(value.to_unsafe, type)
   end
 
   def basic_blocks
@@ -66,10 +81,6 @@ struct LLVM::Function
         LibLLVM.get_attribute(params[index.to_i - 1])
       end
     {% end %}
-  end
-
-  def function_type
-    Type.new LibLLVM.get_element_type(LibLLVM.type_of(self))
   end
 
   def return_type

--- a/src/llvm/lib_llvm.cr
+++ b/src/llvm/lib_llvm.cr
@@ -198,7 +198,6 @@ lib LibLLVM
   fun generic_value_to_int = LLVMGenericValueToInt(value : GenericValueRef, signed : Int32) : UInt64
   fun generic_value_to_pointer = LLVMGenericValueToPointer(value : GenericValueRef) : Void*
   fun get_current_debug_location = LLVMGetCurrentDebugLocation(builder : BuilderRef) : ValueRef
-  fun get_element_type = LLVMGetElementType(ty : TypeRef) : TypeRef
   fun get_first_instruction = LLVMGetFirstInstruction(block : BasicBlockRef) : ValueRef
   fun get_first_target = LLVMGetFirstTarget : TargetRef
   fun get_first_basic_block = LLVMGetFirstBasicBlock(fn : ValueRef) : BasicBlockRef

--- a/src/llvm/value.cr
+++ b/src/llvm/value.cr
@@ -3,6 +3,9 @@ require "./value_methods"
 struct LLVM::Value
   include ValueMethods
 
+  def initialize(@unwrap : LibLLVM::ValueRef)
+  end
+
   def self.null
     LLVM::Value.new(Pointer(::Void).null.as(LibLLVM::ValueRef))
   end

--- a/src/llvm/value_methods.cr
+++ b/src/llvm/value_methods.cr
@@ -1,7 +1,4 @@
 module LLVM::ValueMethods
-  def initialize(@unwrap : LibLLVM::ValueRef)
-  end
-
   def name=(name)
     LibLLVM.set_value_name(self, name)
   end


### PR DESCRIPTION
Part of #12743.

Every LLVM function is created from the Crystal compiler, and the compiler must create also the corresponding function type (`LLVM::Type.function`). This means there is always enough information to retrieve this type without going through `LLVMGetElementType` (don't worry about its deletion, it was declared twice). This PR does that by adding the type as an instance variable of `LLVM::Function`. The old constructors of `LLVM::Function` that call `LLVMGetElementType` are marked as deprecated; this is only temporary, and Crystal itself no longer uses them.

Association between an LLVM function value and its type is done in `LLVM::FunctionCollection.@@func_types` where it is the most convenient. Although this is correct, it is rather inefficient and ugly. The next step is to add new overloads to `LLVM::Builder#call` and `#invoke` that take a separate function type argument, similar to [`#gep`](https://github.com/crystal-lang/crystal/pull/12623) and [`#load`](https://github.com/crystal-lang/crystal/pull/12973). Eventually `@@func_types` and the new instance variable will be dropped again. For example, this:

```crystal
value = LLVM::Function.from_value(value, fun_type)
asm_value = call value, input_values
```

will become:

```crystal
value = LLVM::Function.from_value(value)
asm_value = call fun_type, value, input_values
```

The benefit of this PR alone is we are now 100% sure that `LLVM::Function#function_type` must come from another object previously constructed by Crystal itself, never a fresh object from LLVM.