### PR TITLE
[CI] Increase `no_output_timeout` on circleci

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,7 +19,9 @@ defaults:
     - run: bin/ci prepare_system
     - run: echo 'export CURRENT_TAG="$CIRCLE_TAG"' >> $BASH_ENV
     - run: bin/ci prepare_build
-    - run: bin/ci build
+    - run:
+        command: bin/ci build
+        no_output_timeout: 30m
     - run:
         when: always
         command: |


### PR DESCRIPTION
The `test_alpine` job in the release workflow on circle CI is failing since #13122. It exceeds 10 minutes without any output in the LLVM codegen phase of `compiler_spec`.
This patch increases the timeout to 30 minutes and the job succeeds again. https://app.circleci.com/pipelines/github/crystal-lang/crystal/11368/workflows/a13472f5-f489-4837-a59a-7e3fd2021d12

So far this is only necessary for `test_alpine`, all other jobs finish quick enough. `test_linux` runs 20% faster, so there should be some leeway. Anyway these tests are mostly informational and a failure is not catastrophic (the release workflow itself still continues despite failures), so we can wait to see if that ever happens.