### PR TITLE
Fix `Regex::Option` behaviour for unnamed members

### DIFF
--- a/spec/std/regex_spec.cr
+++ b/spec/std/regex_spec.cr
@@ -9,6 +9,22 @@ describe "Regex" do
     it "raises exception with invalid regex" do
       expect_raises(ArgumentError) { Regex.new("+") }
     end
+
+    describe "options" do
+      it "regular" do
+        Regex.new("", Regex::Options::ANCHORED).options.anchored?.should be_true
+      end
+
+      it "unnamed option" do
+        {% if Regex::Engine.resolve.name == "Regex::PCRE" %}
+          Regex.new("^/foo$", Regex::Options.new(0x00000020)).matches?("/foo\n").should be_false
+        {% else %}
+          expect_raises ArgumentError, "Unknown Regex::Option value: 32" do
+            Regex.new("", Regex::Options.new(32))
+          end
+        {% end %}
+      end
+    end
   end
 
   it "#options" do

--- a/src/regex/pcre.cr
+++ b/src/regex/pcre.cr
@@ -35,7 +35,7 @@ module Regex::PCRE
                 else
                   raise "unreachable"
                 end
-        options ^= option
+        options &= ~option
       end
     end
 

--- a/src/regex/pcre.cr
+++ b/src/regex/pcre.cr
@@ -21,21 +21,27 @@ module Regex::PCRE
 
   private def pcre_options(options)
     flag = 0
-    options.each do |option|
-      flag |= case option
-              when .ignore_case?   then LibPCRE::CASELESS
-              when .multiline?     then LibPCRE::DOTALL | LibPCRE::MULTILINE
-              when .extended?      then LibPCRE::EXTENDED
-              when .anchored?      then LibPCRE::ANCHORED
-              when .utf_8?         then LibPCRE::UTF8
-              when .no_utf8_check? then LibPCRE::NO_UTF8_CHECK
-              when .dupnames?      then LibPCRE::DUPNAMES
-              when .ucp?           then LibPCRE::UCP
-              else
-                # Unnamed values are explicitly used PCRE options, just pass them through:
-                option.value
-              end
+    Regex::Options.each do |option|
+      if options.includes?(option)
+        flag |= case option
+                when .ignore_case?   then LibPCRE::CASELESS
+                when .multiline?     then LibPCRE::DOTALL | LibPCRE::MULTILINE
+                when .extended?      then LibPCRE::EXTENDED
+                when .anchored?      then LibPCRE::ANCHORED
+                when .utf_8?         then LibPCRE::UTF8
+                when .no_utf8_check? then LibPCRE::NO_UTF8_CHECK
+                when .dupnames?      then LibPCRE::DUPNAMES
+                when .ucp?           then LibPCRE::UCP
+                else
+                  raise "unreachable"
+                end
+        options ^= option
+      end
     end
+
+    # Unnamed values are explicitly used PCRE options, just pass them through:
+    flag |= options.value
+
     flag
   end
 

--- a/src/regex/pcre2.cr
+++ b/src/regex/pcre2.cr
@@ -43,19 +43,25 @@ module Regex::PCRE2
 
   private def pcre2_options(options)
     flag = 0
-    options.each do |option|
-      flag |= case option
-              when .ignore_case?   then LibPCRE2::CASELESS
-              when .multiline?     then LibPCRE2::DOTALL | LibPCRE2::MULTILINE
-              when .extended?      then LibPCRE2::EXTENDED
-              when .anchored?      then LibPCRE2::ANCHORED
-              when .utf_8?         then LibPCRE2::UTF
-              when .no_utf8_check? then LibPCRE2::NO_UTF_CHECK
-              when .dupnames?      then LibPCRE2::DUPNAMES
-              when .ucp?           then LibPCRE2::UCP
-              else
-                raise "unreachable"
-              end
+    Regex::Options.each do |option|
+      if options.includes?(option)
+        flag |= case option
+                when .ignore_case?   then LibPCRE2::CASELESS
+                when .multiline?     then LibPCRE2::DOTALL | LibPCRE2::MULTILINE
+                when .extended?      then LibPCRE2::EXTENDED
+                when .anchored?      then LibPCRE2::ANCHORED
+                when .utf_8?         then LibPCRE2::UTF
+                when .no_utf8_check? then LibPCRE2::NO_UTF_CHECK
+                when .dupnames?      then LibPCRE2::DUPNAMES
+                when .ucp?           then LibPCRE2::UCP
+                else
+                  raise "unreachable"
+                end
+        options ^= option
+      end
+    end
+    unless options.none?
+      raise ArgumentError.new("Unknown Regex::Option value: #{options}")
     end
     flag
   end

--- a/src/regex/pcre2.cr
+++ b/src/regex/pcre2.cr
@@ -57,7 +57,7 @@ module Regex::PCRE2
                 else
                   raise "unreachable"
                 end
-        options ^= option
+        options &= ~option
       end
     end
     unless options.none?


### PR DESCRIPTION
The process of decoupling `Regex::Option` from specific lib values caused an unintended behavioural change with regards to unnamed members.

The intention was that unnamed members should continue to function for PCRE, but raise on PCRE2 as a safety mechanism to avoid unintended effects because both library versions use different option values.
More explanation in https://github.com/crystal-lang/crystal/issues/13152#issuecomment-1454908366

This was originally implemented in https://github.com/crystal-lang/crystal/pull/12802 for the original PCRE bindings and subsequently for the PCRE2 bindings in #12856. Both implementations use `Enum#each` to iterate the flag enum members, but that only accounts for named members and excess flag values would be ignored.

This patch fixes that to the intended behaviour and adds a spec for it.

The general subject is due to further discussion in #13152, though.