### PR TITLE
Support typed LLVM `call` and `invoke` instructions

### DIFF
--- a/src/compiler/crystal/codegen/asm.cr
+++ b/src/compiler/crystal/codegen/asm.cr
@@ -55,7 +55,7 @@ class Crystal::CodeGenVisitor
 
     value = fun_type.inline_asm(node.text, constraints, node.volatile?, node.alignstack?, node.can_throw?)
     value = LLVM::Function.from_value(value)
-    asm_value = call value, input_values
+    asm_value = call LLVMTypedFunction.new(fun_type, value), input_values
 
     if ptrofs = node.output_ptrofs
       if ptrofs.size > 1

--- a/src/compiler/crystal/codegen/const.cr
+++ b/src/compiler/crystal/codegen/const.cr
@@ -128,7 +128,7 @@ class Crystal::CodeGenVisitor
     return global if const.initializer
 
     init_function_name = "~#{const.initialized_llvm_name}"
-    func = @main_mod.functions[init_function_name]? || create_initialize_const_function(init_function_name, const)
+    func = typed_fun?(@main_mod, init_function_name) || create_initialize_const_function(init_function_name, const)
     func = check_main_fun init_function_name, func
 
     set_current_debug_location const.locations.try &.first? if @debug.line_numbers?
@@ -223,7 +223,7 @@ class Crystal::CodeGenVisitor
     end
 
     read_function_name = "~#{const.llvm_name}:read"
-    func = @main_mod.functions[read_function_name]? || create_read_const_function(read_function_name, const)
+    func = typed_fun?(@main_mod, read_function_name) || create_read_const_function(read_function_name, const)
     func = check_main_fun read_function_name, func
     call func
   end

--- a/src/compiler/crystal/codegen/context.cr
+++ b/src/compiler/crystal/codegen/context.cr
@@ -3,6 +3,7 @@ require "./codegen"
 class Crystal::CodeGenVisitor
   class Context
     property fun : LLVM::Function
+    property fun_type : LLVM::Type
     property fun_debug_params = [] of LibLLVM::MetadataRef
     property type : Type
     property vars : Hash(String, LLVMVar)
@@ -20,7 +21,7 @@ class Crystal::CodeGenVisitor
     property closure_parent_context : Context?
     property closure_self : Type?
 
-    def initialize(@fun, @type, @vars = LLVMVars.new)
+    def initialize(@fun, @fun_type, @type, @vars = LLVMVars.new)
       @closure_skip_parent = false
     end
 
@@ -37,7 +38,7 @@ class Crystal::CodeGenVisitor
     end
 
     def clone
-      context = Context.new @fun, @type, @vars
+      context = Context.new @fun, @fun_type, @type, @vars
       context.return_type = @return_type
       context.return_phi = @return_phi
       context.break_phi = @break_phi

--- a/src/compiler/crystal/codegen/crystal_llvm_builder.cr
+++ b/src/compiler/crystal/codegen/crystal_llvm_builder.cr
@@ -2,7 +2,7 @@ module Crystal
   class CrystalLLVMBuilder
     property end : Bool
 
-    def initialize(@builder : LLVM::Builder, @llvm_typer : LLVMTyper, @printf : LLVM::Function)
+    def initialize(@builder : LLVM::Builder, @llvm_typer : LLVMTyper, @printf : LLVMTypedFunction)
       @end = false
     end
 

--- a/src/compiler/crystal/codegen/llvm_builder_helper.cr
+++ b/src/compiler/crystal/codegen/llvm_builder_helper.cr
@@ -113,24 +113,6 @@ module Crystal
       builder.inbounds_gep type, ptr, index0, index1, name
     end
 
-    def call(func : LLVM::Function, name : String = "")
-      call(func, [] of LLVM::Value, name)
-    end
-
-    def call(func : LLVM::Function, arg : LLVM::Value, name : String = "")
-      call(func, [arg], name)
-    end
-
-    def call(func : LLVM::Function, args : Array(LLVM::Value), name : String = "")
-      if catch_pad = @catch_pad
-        funclet = builder.build_operand_bundle_def("funclet", [catch_pad])
-      else
-        funclet = LLVM::OperandBundleDef.null
-      end
-
-      builder.call(func, args, bundle: funclet, name: name)
-    end
-
     def call(func : LLVMTypedFunction, name : String = "")
       call(func, [] of LLVM::Value, name)
     end
@@ -147,16 +129,6 @@ module Crystal
       end
 
       builder.call(func.type, func.func, args, bundle: funclet, name: name)
-    end
-
-    def invoke(func : LLVM::Function, args : Array(LLVM::Value), a_then, a_catch, name : String = "")
-      if catch_pad = @catch_pad
-        funclet = builder.build_operand_bundle_def("funclet", [catch_pad])
-      else
-        funclet = LLVM::OperandBundleDef.null
-      end
-
-      builder.invoke(func, args, a_then, a_catch, bundle: funclet, name: name)
     end
 
     def invoke(func : LLVMTypedFunction, args : Array(LLVM::Value), a_then, a_catch, name : String = "")

--- a/src/compiler/crystal/codegen/llvm_typer.cr
+++ b/src/compiler/crystal/codegen/llvm_typer.cr
@@ -405,7 +405,7 @@ module Crystal
     end
 
     def llvm_embedded_c_type(type : ProcInstanceType, wants_size = false)
-      proc_type(type)
+      proc_type(type).pointer
     end
 
     def llvm_embedded_c_type(type, wants_size = false)
@@ -413,11 +413,11 @@ module Crystal
     end
 
     def llvm_c_type(type : ProcInstanceType)
-      proc_type(type)
+      proc_type(type).pointer
     end
 
     def llvm_c_type(type : NilableProcType)
-      proc_type(type.proc_type)
+      proc_type(type.proc_type).pointer
     end
 
     def llvm_c_type(type : TupleInstanceType)
@@ -461,12 +461,12 @@ module Crystal
     def closure_type(type : ProcInstanceType)
       arg_types = type.arg_types.map { |arg_type| llvm_type(arg_type) }
       arg_types.insert(0, @llvm_context.void_pointer)
-      LLVM::Type.function(arg_types, llvm_type(type.return_type)).pointer
+      LLVM::Type.function(arg_types, llvm_type(type.return_type))
     end
 
     def proc_type(type : ProcInstanceType)
       arg_types = type.arg_types.map { |arg_type| llvm_type(arg_type).as(LLVM::Type) }
-      LLVM::Type.function(arg_types, llvm_type(type.return_type)).pointer
+      LLVM::Type.function(arg_types, llvm_type(type.return_type))
     end
 
     def closure_context_type(vars, parent_llvm_type, self_type)

--- a/src/compiler/crystal/codegen/match.cr
+++ b/src/compiler/crystal/codegen/match.cr
@@ -39,7 +39,7 @@ class Crystal::CodeGenVisitor
 
   private def match_any_type_id_with_function(type, type_id)
     match_fun_name = "~match<#{type}>"
-    func = @main_mod.functions[match_fun_name]? || create_match_fun(match_fun_name, type)
+    func = typed_fun?(@main_mod, match_fun_name) || create_match_fun(match_fun_name, type)
     func = check_main_fun match_fun_name, func
     call func, [type_id] of LLVM::Value
   end

--- a/src/compiler/crystal/codegen/once.cr
+++ b/src/compiler/crystal/codegen/once.cr
@@ -4,32 +4,32 @@ class Crystal::CodeGenVisitor
   ONCE_STATE = "~ONCE_STATE"
 
   def once_init
-    if once_init_fun = @main_mod.functions[ONCE_INIT]?
+    if once_init_fun = typed_fun?(@main_mod, ONCE_INIT)
       once_init_fun = check_main_fun ONCE_INIT, once_init_fun
 
-      once_state_global = @main_mod.globals.add(once_init_fun.return_type, ONCE_STATE)
+      once_state_global = @main_mod.globals.add(once_init_fun.type.return_type, ONCE_STATE)
       once_state_global.linkage = LLVM::Linkage::Internal if @single_module
-      once_state_global.initializer = once_init_fun.return_type.null
+      once_state_global.initializer = once_init_fun.type.return_type.null
 
       state = call once_init_fun
       store state, once_state_global
     end
   end
 
-  def run_once(flag, func)
+  def run_once(flag, func : LLVMTypedFunction)
     once_fun = main_fun(ONCE)
     once_init_fun = main_fun(ONCE_INIT)
 
     once_state_global = @llvm_mod.globals[ONCE_STATE]? || begin
-      global = @llvm_mod.globals.add(once_init_fun.return_type, ONCE_STATE)
+      global = @llvm_mod.globals.add(once_init_fun.type.return_type, ONCE_STATE)
       global.linkage = LLVM::Linkage::External
       global
     end
 
-    call main_fun(ONCE), [
-      load(once_init_fun.return_type, once_state_global),
+    call once_fun, [
+      load(once_init_fun.type.return_type, once_state_global),
       flag,
-      bit_cast(func.to_value, once_fun.params.last.type),
+      bit_cast(func.func.to_value, once_fun.func.params.last.type),
     ]
   end
 end

--- a/src/llvm/function_collection.cr
+++ b/src/llvm/function_collection.cr
@@ -4,14 +4,22 @@ struct LLVM::FunctionCollection
 
   def add(name, arg_types : Array(LLVM::Type), ret_type, varargs = false)
     # check_types_context(name, arg_types, ret_type)
+    add(name, LLVM::Type.function(arg_types, ret_type, varargs))
+  end
 
-    fun_type = LLVM::Type.function(arg_types, ret_type, varargs)
+  def add(name, arg_types : Array(LLVM::Type), ret_type, varargs = false, &)
+    func = add(name, arg_types, ret_type, varargs)
+    yield func
+    func
+  end
+
+  def add(name, fun_type : LLVM::Type)
     func = LibLLVM.add_function(@mod, name, fun_type)
     Function.new(func)
   end
 
-  def add(name, arg_types : Array(LLVM::Type), ret_type, varargs = false)
-    func = add(name, arg_types, ret_type, varargs)
+  def add(name, fun_type : LLVM::Type, &)
+    func = add(name, fun_type)
     yield func
     func
   end
@@ -26,7 +34,7 @@ struct LLVM::FunctionCollection
     func ? Function.new(func) : nil
   end
 
-  def each : Nil
+  def each(&) : Nil
     f = LibLLVM.get_first_function(@mod)
     while f
       yield LLVM::Function.new f

--- a/src/llvm/lib_llvm.cr
+++ b/src/llvm/lib_llvm.cr
@@ -201,7 +201,6 @@ lib LibLLVM
   fun generic_value_to_int = LLVMGenericValueToInt(value : GenericValueRef, signed : Int32) : UInt64
   fun generic_value_to_pointer = LLVMGenericValueToPointer(value : GenericValueRef) : Void*
   fun get_current_debug_location = LLVMGetCurrentDebugLocation(builder : BuilderRef) : ValueRef
-  fun get_element_type = LLVMGetElementType(ty : TypeRef) : TypeRef
   fun get_first_instruction = LLVMGetFirstInstruction(block : BasicBlockRef) : ValueRef
   fun get_first_target = LLVMGetFirstTarget : TargetRef
   fun get_first_basic_block = LLVMGetFirstBasicBlock(fn : ValueRef) : BasicBlockRef

--- a/src/llvm/parameter_collection.cr
+++ b/src/llvm/parameter_collection.cr
@@ -5,7 +5,7 @@ struct LLVM::ParameterCollection
   end
 
   def size
-    @function.function_type.params_size
+    LibLLVM.get_count_params(@function).to_i
   end
 
   def to_a


### PR DESCRIPTION
Part of #12743. Supersedes #13149. The core idea of this PR is taken from there; for each `LLVM::Function` we always associate an `LLVM::Type` with it on construction, except that it is now `Crystal::CodeGenVisitor#@fun_types` that keeps track of the associations, rather than a class variable.

After this PR, the Crystal compiler will no longer use any deprecated LLVM functions, although it still calls `LLVMGetElementType` when copying types between contexts. The LLVM sample now works with LLVM 15!

The PR assumes that only LLVM 8 or above is supported, even though the corresponding commit on master is not yet available here.