### PR TITLE
Use `Crystal::System.print_error` instead of `LibC.printf`

### DIFF
--- a/src/gc/boehm.cr
+++ b/src/gc/boehm.cr
@@ -158,7 +158,7 @@ module GC
       # This implements `String#starts_with?` without allocating a `String` (#11728)
       format_string = Slice.new(msg, Math.min(LibC.strlen(msg), start.bytesize))
       unless format_string == start.to_slice
-        LibC.printf msg, v
+        Crystal::System.print_error msg, v
       end
     end
   end

--- a/src/raise.cr
+++ b/src/raise.cr
@@ -105,7 +105,7 @@ end
   # :nodoc:
   @[Raises]
   fun __crystal_raise(unwind_ex : LibUnwind::Exception*) : NoReturn
-    LibC.printf("EXITING: __crystal_raise called")
+    Crystal::System.print_error "EXITING: __crystal_raise called"
     LibC.exit(1)
   end
 {% elsif flag?(:arm) %}
@@ -160,20 +160,20 @@ end
 {% elsif flag?(:wasm32) %}
   # :nodoc:
   fun __crystal_personality
-    LibC.printf("EXITING: __crystal_personality called")
+    Crystal::System.print_error "EXITING: __crystal_personality called"
     LibC.exit(1)
   end
 
   # :nodoc:
   @[Raises]
   fun __crystal_raise(ex : Void*) : NoReturn
-    LibC.printf("EXITING: __crystal_raise called")
+    Crystal::System.print_error "EXITING: __crystal_raise called"
     LibC.exit(1)
   end
 
   # :nodoc:
   fun __crystal_get_exception(ex : Void*) : UInt64
-    LibC.printf("EXITING: __crystal_get_exception called")
+    Crystal::System.print_error "EXITING: __crystal_get_exception called"
     LibC.exit(1)
     0u64
   end
@@ -215,7 +215,7 @@ end
 
 {% if flag?(:wasm32) %}
   def raise(exception : Exception) : NoReturn
-    LibC.printf("EXITING: Attempting to raise:\n#{exception.inspect_with_backtrace}")
+    Crystal::System.print_error "EXITING: Attempting to raise:\n#{exception.inspect_with_backtrace}"
     LibIntrinsics.debugtrap
     LibC.exit(1)
   end


### PR DESCRIPTION
`LibC.printf` is currently only used for GC warnings and fatal errors; it is more appropriate to print them to the standard error stream instead of the standard output. This PR switches them to `Crystal::System.print_error` which is also backed by a `printf`-like function.