### PR TITLE
Remove `LibLLVM.has_constant?(:AttributeRef)` checks

### DIFF
--- a/src/llvm/enums.cr
+++ b/src/llvm/enums.cr
@@ -1,206 +1,172 @@
 module LLVM
-  {% if LibLLVM.has_constant?(:AttributeRef) %}
-    @[Flags]
-    enum Attribute : UInt64
-      Alignment
-      AllocSize
-      AlwaysInline
-      ArgMemOnly
-      Builtin
-      ByVal
-      Cold
-      Convergent
-      Dereferenceable
-      DereferenceableOrNull
-      InAlloca
-      InReg
-      InaccessibleMemOnly
-      InaccessibleMemOrArgMemOnly
-      InlineHint
-      JumpTable
-      MinSize
-      Naked
-      Nest
-      NoAlias
-      NoBuiltin
-      NoCapture
-      NoDuplicate
-      NoFree
-      NoImplicitFloat
-      NoInline
-      NoRecurse
-      NoRedZone
-      NoReturn
-      NoSync
-      NoUnwind
-      NonLazyBind
-      NonNull
-      OptimizeForSize
-      OptimizeNone
-      ReadNone
-      ReadOnly
-      Returned
-      ImmArg
-      ReturnsTwice
-      SExt
-      SafeStack
-      SanitizeAddress
-      SanitizeMemory
-      SanitizeThread
-      StackAlignment
-      StackProtect
-      StackProtectReq
-      StackProtectStrong
-      StructRet
-      SwiftError
-      SwiftSelf
-      UWTable
-      WillReturn
-      WriteOnly
-      ZExt
+  @[Flags]
+  enum Attribute : UInt64
+    Alignment
+    AllocSize
+    AlwaysInline
+    ArgMemOnly
+    Builtin
+    ByVal
+    Cold
+    Convergent
+    Dereferenceable
+    DereferenceableOrNull
+    InAlloca
+    InReg
+    InaccessibleMemOnly
+    InaccessibleMemOrArgMemOnly
+    InlineHint
+    JumpTable
+    MinSize
+    Naked
+    Nest
+    NoAlias
+    NoBuiltin
+    NoCapture
+    NoDuplicate
+    NoFree
+    NoImplicitFloat
+    NoInline
+    NoRecurse
+    NoRedZone
+    NoReturn
+    NoSync
+    NoUnwind
+    NonLazyBind
+    NonNull
+    OptimizeForSize
+    OptimizeNone
+    ReadNone
+    ReadOnly
+    Returned
+    ImmArg
+    ReturnsTwice
+    SExt
+    SafeStack
+    SanitizeAddress
+    SanitizeMemory
+    SanitizeThread
+    StackAlignment
+    StackProtect
+    StackProtectReq
+    StackProtectStrong
+    StructRet
+    SwiftError
+    SwiftSelf
+    UWTable
+    WillReturn
+    WriteOnly
+    ZExt
 
-      @@kind_ids = load_llvm_kinds_from_names.as(Hash(Attribute, UInt32))
-      @@typed_attrs = load_llvm_typed_attributes.as(Array(Attribute))
+    @@kind_ids = load_llvm_kinds_from_names.as(Hash(Attribute, UInt32))
+    @@typed_attrs = load_llvm_typed_attributes.as(Array(Attribute))
 
-      def each_kind(&block)
-        return if value == 0
-        \{% for member in @type.constants %}
-          \{% if member.stringify != "All" %}
-            if includes?(\{{@type}}::\{{member}})
-              yield @@kind_ids[\{{@type}}::\{{member}}]
-            end
-          \{% end %}
-        \{% end %}
-      end
-
-      private def self.kind_for_name(name : String)
-        LibLLVM.get_enum_attribute_kind_for_name(name, name.bytesize)
-      end
-
-      private def self.load_llvm_kinds_from_names
-        kinds = {} of Attribute => UInt32
-        kinds[Alignment] = kind_for_name("align")
-        kinds[AllocSize] = kind_for_name("allocsize")
-        kinds[AlwaysInline] = kind_for_name("alwaysinline")
-        kinds[ArgMemOnly] = kind_for_name("argmemonly")
-        kinds[Builtin] = kind_for_name("builtin")
-        kinds[ByVal] = kind_for_name("byval")
-        kinds[Cold] = kind_for_name("cold")
-        kinds[Convergent] = kind_for_name("convergent")
-        kinds[Dereferenceable] = kind_for_name("dereferenceable")
-        kinds[DereferenceableOrNull] = kind_for_name("dereferenceable_or_null")
-        kinds[InAlloca] = kind_for_name("inalloca")
-        kinds[InReg] = kind_for_name("inreg")
-        kinds[InaccessibleMemOnly] = kind_for_name("inaccessiblememonly")
-        kinds[InaccessibleMemOrArgMemOnly] = kind_for_name("inaccessiblemem_or_argmemonly")
-        kinds[InlineHint] = kind_for_name("inlinehint")
-        kinds[JumpTable] = kind_for_name("jumptable")
-        kinds[MinSize] = kind_for_name("minsize")
-        kinds[Naked] = kind_for_name("naked")
-        kinds[Nest] = kind_for_name("nest")
-        kinds[NoAlias] = kind_for_name("noalias")
-        kinds[NoBuiltin] = kind_for_name("nobuiltin")
-        kinds[NoCapture] = kind_for_name("nocapture")
-        kinds[NoDuplicate] = kind_for_name("noduplicate")
-        kinds[NoFree] = kind_for_name("nofree")
-        kinds[NoImplicitFloat] = kind_for_name("noimplicitfloat")
-        kinds[NoInline] = kind_for_name("noinline")
-        kinds[NoRecurse] = kind_for_name("norecurse")
-        kinds[NoRedZone] = kind_for_name("noredzone")
-        kinds[NoReturn] = kind_for_name("noreturn")
-        kinds[NoSync] = kind_for_name("nosync")
-        kinds[NoUnwind] = kind_for_name("nounwind")
-        kinds[NonLazyBind] = kind_for_name("nonlazybind")
-        kinds[NonNull] = kind_for_name("nonnull")
-        kinds[OptimizeForSize] = kind_for_name("optsize")
-        kinds[OptimizeNone] = kind_for_name("optnone")
-        kinds[ReadNone] = kind_for_name("readnone")
-        kinds[ReadOnly] = kind_for_name("readonly")
-        kinds[Returned] = kind_for_name("returned")
-        kinds[ImmArg] = kind_for_name("immarg")
-        kinds[ReturnsTwice] = kind_for_name("returns_twice")
-        kinds[SExt] = kind_for_name("signext")
-        kinds[SafeStack] = kind_for_name("safestack")
-        kinds[SanitizeAddress] = kind_for_name("sanitize_address")
-        kinds[SanitizeMemory] = kind_for_name("sanitize_memory")
-        kinds[SanitizeThread] = kind_for_name("sanitize_thread")
-        kinds[StackAlignment] = kind_for_name("alignstack")
-        kinds[StackProtect] = kind_for_name("ssp")
-        kinds[StackProtectReq] = kind_for_name("sspreq")
-        kinds[StackProtectStrong] = kind_for_name("sspstrong")
-        kinds[StructRet] = kind_for_name("sret")
-        kinds[SwiftError] = kind_for_name("swifterror")
-        kinds[SwiftSelf] = kind_for_name("swiftself")
-        kinds[UWTable] = kind_for_name("uwtable")
-        kinds[WillReturn] = kind_for_name("willreturn")
-        kinds[WriteOnly] = kind_for_name("writeonly")
-        kinds[ZExt] = kind_for_name("zeroext")
-        kinds
-      end
-
-      private def self.load_llvm_typed_attributes
-        typed_attrs = [] of Attribute
-
-        unless LibLLVM::IS_LT_120
-          # LLVM 12 introduced mandatory type parameters for byval and sret
-          typed_attrs << ByVal
-          typed_attrs << StructRet
-        end
-
-        unless LibLLVM::IS_LT_130
-          # LLVM 13 manadates type params for inalloca
-          typed_attrs << InAlloca
-        end
-
-        typed_attrs
-      end
-
-      def self.kind_for(member)
-        @@kind_ids[member]
-      end
-
-      def self.from_kind(kind)
-        @@kind_ids.key_for(kind)
-      end
-
-      def self.requires_type?(kind)
-        member = from_kind(kind)
-        @@typed_attrs.includes?(member)
-      end
+    def each_kind(&block)
+      return if value == 0
+      {% for member in @type.constants %}
+        {% if member.stringify != "All" %}
+          if includes?({{@type}}::{{member}})
+            yield @@kind_ids[{{@type}}::{{member}}]
+          end
+        {% end %}
+      {% end %}
     end
-  {% else %}
-    @[Flags]
-    enum Attribute : UInt32
-      ZExt            = 1 << 0
-      SExt            = 1 << 1
-      NoReturn        = 1 << 2
-      InReg           = 1 << 3
-      StructRet       = 1 << 4
-      NoUnwind        = 1 << 5
-      NoAlias         = 1 << 6
-      ByVal           = 1 << 7
-      Nest            = 1 << 8
-      ReadNone        = 1 << 9
-      ReadOnly        = 1 << 10
-      NoInline        = 1 << 11
-      AlwaysInline    = 1 << 12
-      OptimizeForSize = 1 << 13
-      StackProtect    = 1 << 14
-      StackProtectReq = 1 << 15
-      Alignment       = 31 << 16
-      NoCapture       = 1 << 21
-      NoRedZone       = 1 << 22
-      NoImplicitFloat = 1 << 23
-      Naked           = 1 << 24
-      InlineHint      = 1 << 25
-      StackAlignment  = 7 << 26
-      ReturnsTwice    = 1 << 29
-      UWTable         = 1 << 30
-      NonLazyBind     = 1 << 31
-      # AddressSafety = 1_u64 << 32,
-      # StackProtectStrong = 1_u64 << 33
+
+    private def self.kind_for_name(name : String)
+      LibLLVM.get_enum_attribute_kind_for_name(name, name.bytesize)
     end
-  {% end %}
+
+    private def self.load_llvm_kinds_from_names
+      kinds = {} of Attribute => UInt32
+      kinds[Alignment] = kind_for_name("align")
+      kinds[AllocSize] = kind_for_name("allocsize")
+      kinds[AlwaysInline] = kind_for_name("alwaysinline")
+      kinds[ArgMemOnly] = kind_for_name("argmemonly")
+      kinds[Builtin] = kind_for_name("builtin")
+      kinds[ByVal] = kind_for_name("byval")
+      kinds[Cold] = kind_for_name("cold")
+      kinds[Convergent] = kind_for_name("convergent")
+      kinds[Dereferenceable] = kind_for_name("dereferenceable")
+      kinds[DereferenceableOrNull] = kind_for_name("dereferenceable_or_null")
+      kinds[InAlloca] = kind_for_name("inalloca")
+      kinds[InReg] = kind_for_name("inreg")
+      kinds[InaccessibleMemOnly] = kind_for_name("inaccessiblememonly")
+      kinds[InaccessibleMemOrArgMemOnly] = kind_for_name("inaccessiblemem_or_argmemonly")
+      kinds[InlineHint] = kind_for_name("inlinehint")
+      kinds[JumpTable] = kind_for_name("jumptable")
+      kinds[MinSize] = kind_for_name("minsize")
+      kinds[Naked] = kind_for_name("naked")
+      kinds[Nest] = kind_for_name("nest")
+      kinds[NoAlias] = kind_for_name("noalias")
+      kinds[NoBuiltin] = kind_for_name("nobuiltin")
+      kinds[NoCapture] = kind_for_name("nocapture")
+      kinds[NoDuplicate] = kind_for_name("noduplicate")
+      kinds[NoFree] = kind_for_name("nofree")
+      kinds[NoImplicitFloat] = kind_for_name("noimplicitfloat")
+      kinds[NoInline] = kind_for_name("noinline")
+      kinds[NoRecurse] = kind_for_name("norecurse")
+      kinds[NoRedZone] = kind_for_name("noredzone")
+      kinds[NoReturn] = kind_for_name("noreturn")
+      kinds[NoSync] = kind_for_name("nosync")
+      kinds[NoUnwind] = kind_for_name("nounwind")
+      kinds[NonLazyBind] = kind_for_name("nonlazybind")
+      kinds[NonNull] = kind_for_name("nonnull")
+      kinds[OptimizeForSize] = kind_for_name("optsize")
+      kinds[OptimizeNone] = kind_for_name("optnone")
+      kinds[ReadNone] = kind_for_name("readnone")
+      kinds[ReadOnly] = kind_for_name("readonly")
+      kinds[Returned] = kind_for_name("returned")
+      kinds[ImmArg] = kind_for_name("immarg")
+      kinds[ReturnsTwice] = kind_for_name("returns_twice")
+      kinds[SExt] = kind_for_name("signext")
+      kinds[SafeStack] = kind_for_name("safestack")
+      kinds[SanitizeAddress] = kind_for_name("sanitize_address")
+      kinds[SanitizeMemory] = kind_for_name("sanitize_memory")
+      kinds[SanitizeThread] = kind_for_name("sanitize_thread")
+      kinds[StackAlignment] = kind_for_name("alignstack")
+      kinds[StackProtect] = kind_for_name("ssp")
+      kinds[StackProtectReq] = kind_for_name("sspreq")
+      kinds[StackProtectStrong] = kind_for_name("sspstrong")
+      kinds[StructRet] = kind_for_name("sret")
+      kinds[SwiftError] = kind_for_name("swifterror")
+      kinds[SwiftSelf] = kind_for_name("swiftself")
+      kinds[UWTable] = kind_for_name("uwtable")
+      kinds[WillReturn] = kind_for_name("willreturn")
+      kinds[WriteOnly] = kind_for_name("writeonly")
+      kinds[ZExt] = kind_for_name("zeroext")
+      kinds
+    end
+
+    private def self.load_llvm_typed_attributes
+      typed_attrs = [] of Attribute
+
+      unless LibLLVM::IS_LT_120
+        # LLVM 12 introduced mandatory type parameters for byval and sret
+        typed_attrs << ByVal
+        typed_attrs << StructRet
+      end
+
+      unless LibLLVM::IS_LT_130
+        # LLVM 13 manadates type params for inalloca
+        typed_attrs << InAlloca
+      end
+
+      typed_attrs
+    end
+
+    def self.kind_for(member)
+      @@kind_ids[member]
+    end
+
+    def self.from_kind(kind)
+      @@kind_ids.key_for(kind)
+    end
+
+    def self.requires_type?(kind)
+      member = from_kind(kind)
+      @@typed_attrs.includes?(member)
+    end
+  end
 
   # Attribute index are either ReturnIndex (0), FunctionIndex (-1) or a
   # parameter number ranging from 1 to N.

--- a/src/llvm/function.cr
+++ b/src/llvm/function.cr
@@ -21,26 +21,16 @@ struct LLVM::Function
 
   def add_attribute(attribute : Attribute, index = AttributeIndex::FunctionIndex, type : Type? = nil)
     return if attribute.value == 0
-    {% if LibLLVM.has_constant?(:AttributeRef) %}
-      context = LibLLVM.get_module_context(LibLLVM.get_global_parent(self))
-      attribute.each_kind do |kind|
-        if type && LLVM::Attribute.requires_type?(kind)
-          attribute_ref = LibLLVMExt.create_type_attribute(context, kind, type)
-        else
-          attribute_ref = LibLLVM.create_enum_attribute(context, kind, 0)
-        end
-        LibLLVM.add_attribute_at_index(self, index, attribute_ref)
-      end
-    {% else %}
-      case index
-      when AttributeIndex::FunctionIndex
-        LibLLVM.add_function_attr(self, attribute)
-      when AttributeIndex::ReturnIndex
-        raise "Unsupported: can't set attributes on function return type in LLVM < 3.9"
+
+    context = LibLLVM.get_module_context(LibLLVM.get_global_parent(self))
+    attribute.each_kind do |kind|
+      if type && LLVM::Attribute.requires_type?(kind)
+        attribute_ref = LibLLVMExt.create_type_attribute(context, kind, type)
       else
-        LibLLVM.add_attribute(params[index.to_i - 1], attribute)
+        attribute_ref = LibLLVM.create_enum_attribute(context, kind, 0)
       end
-    {% end %}
+      LibLLVM.add_attribute_at_index(self, index, attribute_ref)
+    end
   end
 
   def add_target_dependent_attribute(name, value)
@@ -48,24 +38,13 @@ struct LLVM::Function
   end
 
   def attributes(index = AttributeIndex::FunctionIndex)
-    {% if LibLLVM.has_constant?(:AttributeRef) %}
-      attrs = Attribute::None
-      0.upto(LibLLVM.get_last_enum_attribute_kind) do |kind|
-        if LibLLVM.get_enum_attribute_at_index(self, index, kind)
-          attrs |= Attribute.from_kind(kind)
-        end
+    attrs = Attribute::None
+    0.upto(LibLLVM.get_last_enum_attribute_kind) do |kind|
+      if LibLLVM.get_enum_attribute_at_index(self, index, kind)
+        attrs |= Attribute.from_kind(kind)
       end
-      attrs
-    {% else %}
-      case index
-      when AttributeIndex::FunctionIndex
-        LibLLVM.get_function_attr(self)
-      when AttributeIndex::ReturnIndex
-        raise "Unsupported: can't get attributes from function return type in LLVM < 3.9"
-      else
-        LibLLVM.get_attribute(params[index.to_i - 1])
-      end
-    {% end %}
+    end
+    attrs
   end
 
   def function_type

--- a/src/llvm/value_methods.cr
+++ b/src/llvm/value_methods.cr
@@ -16,19 +16,16 @@ module LLVM::ValueMethods
 
   def add_instruction_attribute(index : Int, attribute : LLVM::Attribute, context : LLVM::Context, type : LLVM::Type? = nil)
     return if attribute.value == 0
-    {% if LibLLVM.has_constant?(:AttributeRef) %}
-      attribute.each_kind do |kind|
-        if type && LLVM::Attribute.requires_type?(kind)
-          attribute_ref = LibLLVMExt.create_type_attribute(context, kind, type)
-        else
-          attribute_ref = LibLLVM.create_enum_attribute(context, kind, 0)
-        end
 
-        LibLLVM.add_call_site_attribute(self, index, attribute_ref)
+    attribute.each_kind do |kind|
+      if type && LLVM::Attribute.requires_type?(kind)
+        attribute_ref = LibLLVMExt.create_type_attribute(context, kind, type)
+      else
+        attribute_ref = LibLLVM.create_enum_attribute(context, kind, 0)
       end
-    {% else %}
-      LibLLVM.add_instr_attribute(self, index, attribute)
-    {% end %}
+
+      LibLLVM.add_call_site_attribute(self, index, attribute_ref)
+    end
   end
 
   def constant?


### PR DESCRIPTION
`LibLLVM::AttributeRef` was introduced in LLVM 3.9, and is now unconditionally available due to #12906, so this check isn't needed.