### PR TITLE
Do not build LLVM `bitcast` instructions for opaque pointer casts

### DIFF
--- a/src/compiler/crystal/codegen/call.cr
+++ b/src/compiler/crystal/codegen/call.cr
@@ -236,8 +236,8 @@ class Crystal::CodeGenVisitor
   def codegen_direct_abi_call(call_arg_type, call_arg, abi_arg_type)
     if cast = abi_arg_type.cast
       final_value = alloca cast
-      final_value_casted = pointer_cast final_value, llvm_context.void_pointer
-      gep_call_arg = pointer_cast gep(llvm_type(call_arg_type), call_arg, 0, 0), llvm_context.void_pointer
+      final_value_casted = cast_to_void_pointer final_value
+      gep_call_arg = cast_to_void_pointer gep(llvm_type(call_arg_type), call_arg, 0, 0)
       size = @abi.size(abi_arg_type.type)
       size = @program.bits64? ? int64(size) : int32(size)
       align = @abi.align(abi_arg_type.type)
@@ -253,8 +253,8 @@ class Crystal::CodeGenVisitor
   # and *replace* the call argument by a pointer to the allocated memory
   def codegen_indirect_abi_call(call_arg, abi_arg_type)
     final_value = alloca abi_arg_type.type
-    final_value_casted = pointer_cast final_value, llvm_context.void_pointer
-    call_arg_casted = pointer_cast call_arg, llvm_context.void_pointer
+    final_value_casted = cast_to_void_pointer final_value
+    call_arg_casted = cast_to_void_pointer call_arg
     size = @abi.size(abi_arg_type.type)
     size = @program.bits64? ? int64(size) : int32(size)
     align = @abi.align(abi_arg_type.type)
@@ -513,7 +513,7 @@ class Crystal::CodeGenVisitor
     external = target_def.try &.c_calling_convention?
 
     if external && (external.type.proc? || external.type.is_a?(NilableProcType))
-      fun_ptr = pointer_cast(@last, llvm_context.void_pointer)
+      fun_ptr = cast_to_void_pointer(@last)
       ctx_ptr = llvm_context.void_pointer.null
       return @last = make_fun(external.type, fun_ptr, ctx_ptr)
     end
@@ -528,9 +528,9 @@ class Crystal::CodeGenVisitor
           if cast = abi_return.cast
             cast1 = alloca cast
             store @last, cast1
-            cast2 = pointer_cast cast1, llvm_context.void_pointer
+            cast2 = cast_to_void_pointer(cast1)
             final_value = alloca abi_return.type
-            final_value_casted = pointer_cast final_value, llvm_context.void_pointer
+            final_value_casted = cast_to_void_pointer final_value
             size = @abi.size(abi_return.type)
             size = @program.@program.bits64? ? int64(size) : int32(size)
             align = @abi.align(abi_return.type)

--- a/src/compiler/crystal/codegen/call.cr
+++ b/src/compiler/crystal/codegen/call.cr
@@ -236,8 +236,8 @@ class Crystal::CodeGenVisitor
   def codegen_direct_abi_call(call_arg_type, call_arg, abi_arg_type)
     if cast = abi_arg_type.cast
       final_value = alloca cast
-      final_value_casted = bit_cast final_value, llvm_context.void_pointer
-      gep_call_arg = bit_cast gep(llvm_type(call_arg_type), call_arg, 0, 0), llvm_context.void_pointer
+      final_value_casted = pointer_cast final_value, llvm_context.void_pointer
+      gep_call_arg = pointer_cast gep(llvm_type(call_arg_type), call_arg, 0, 0), llvm_context.void_pointer
       size = @abi.size(abi_arg_type.type)
       size = @program.bits64? ? int64(size) : int32(size)
       align = @abi.align(abi_arg_type.type)
@@ -253,8 +253,8 @@ class Crystal::CodeGenVisitor
   # and *replace* the call argument by a pointer to the allocated memory
   def codegen_indirect_abi_call(call_arg, abi_arg_type)
     final_value = alloca abi_arg_type.type
-    final_value_casted = bit_cast final_value, llvm_context.void_pointer
-    call_arg_casted = bit_cast call_arg, llvm_context.void_pointer
+    final_value_casted = pointer_cast final_value, llvm_context.void_pointer
+    call_arg_casted = pointer_cast call_arg, llvm_context.void_pointer
     size = @abi.size(abi_arg_type.type)
     size = @program.bits64? ? int64(size) : int32(size)
     align = @abi.align(abi_arg_type.type)
@@ -513,7 +513,7 @@ class Crystal::CodeGenVisitor
     external = target_def.try &.c_calling_convention?
 
     if external && (external.type.proc? || external.type.is_a?(NilableProcType))
-      fun_ptr = bit_cast(@last, llvm_context.void_pointer)
+      fun_ptr = pointer_cast(@last, llvm_context.void_pointer)
       ctx_ptr = llvm_context.void_pointer.null
       return @last = make_fun(external.type, fun_ptr, ctx_ptr)
     end
@@ -528,9 +528,9 @@ class Crystal::CodeGenVisitor
           if cast = abi_return.cast
             cast1 = alloca cast
             store @last, cast1
-            cast2 = bit_cast cast1, llvm_context.void_pointer
+            cast2 = pointer_cast cast1, llvm_context.void_pointer
             final_value = alloca abi_return.type
-            final_value_casted = bit_cast final_value, llvm_context.void_pointer
+            final_value_casted = pointer_cast final_value, llvm_context.void_pointer
             size = @abi.size(abi_return.type)
             size = @program.@program.bits64? ? int64(size) : int32(size)
             align = @abi.align(abi_return.type)

--- a/src/compiler/crystal/codegen/cast.cr
+++ b/src/compiler/crystal/codegen/cast.cr
@@ -339,7 +339,7 @@ class Crystal::CodeGenVisitor
 
   def downcast_distinct(value, to_type : PointerInstanceType, from_type : PointerInstanceType)
     # cast of a pointer being cast to Void*
-    bit_cast value, llvm_context.void_pointer
+    pointer_cast value, llvm_context.void_pointer
   end
 
   def downcast_distinct(value, to_type : ReferenceUnionType, from_type : ReferenceUnionType)

--- a/src/compiler/crystal/codegen/cast.cr
+++ b/src/compiler/crystal/codegen/cast.cr
@@ -339,7 +339,7 @@ class Crystal::CodeGenVisitor
 
   def downcast_distinct(value, to_type : PointerInstanceType, from_type : PointerInstanceType)
     # cast of a pointer being cast to Void*
-    pointer_cast value, llvm_context.void_pointer
+    cast_to_void_pointer value
   end
 
   def downcast_distinct(value, to_type : ReferenceUnionType, from_type : ReferenceUnionType)

--- a/src/compiler/crystal/codegen/codegen.cr
+++ b/src/compiler/crystal/codegen/codegen.cr
@@ -606,9 +606,9 @@ module Crystal
       the_fun = check_main_fun fun_literal_name, the_fun
 
       set_current_debug_location(node) if @debug.line_numbers?
-      fun_ptr = bit_cast(the_fun.func, llvm_context.void_pointer)
+      fun_ptr = pointer_cast(the_fun.func, llvm_context.void_pointer)
       if is_closure
-        ctx_ptr = bit_cast(context.closure_ptr.not_nil!, llvm_context.void_pointer)
+        ctx_ptr = pointer_cast(context.closure_ptr.not_nil!, llvm_context.void_pointer)
       else
         ctx_ptr = llvm_context.void_pointer.null
       end
@@ -655,9 +655,9 @@ module Crystal
       last_fun = target_def_fun(node.call.target_def, owner)
 
       set_current_debug_location(node) if @debug.line_numbers?
-      fun_ptr = bit_cast(last_fun.func, llvm_context.void_pointer)
+      fun_ptr = pointer_cast(last_fun.func, llvm_context.void_pointer)
       if call_self && !owner.metaclass? && !owner.is_a?(LibType)
-        ctx_ptr = bit_cast(call_self, llvm_context.void_pointer)
+        ctx_ptr = pointer_cast(call_self, llvm_context.void_pointer)
       else
         ctx_ptr = llvm_context.void_pointer.null
       end
@@ -1607,7 +1607,7 @@ module Crystal
       func = typed_fun?(@main_mod, check_fun_name) || create_check_proc_is_not_closure_fun(check_fun_name)
       func = check_main_fun check_fun_name, func
       value = call func, [value] of LLVM::Value
-      bit_cast value, llvm_proc_type(type).pointer
+      pointer_cast value, llvm_proc_type(type).pointer
     end
 
     def create_check_proc_is_not_closure_fun(fun_name)
@@ -2072,7 +2072,7 @@ module Crystal
         pointer = call_c_malloc size
       end
 
-      bit_cast pointer, type.pointer
+      pointer_cast pointer, type.pointer
     end
 
     def array_malloc(type, count)
@@ -2093,7 +2093,7 @@ module Crystal
       end
 
       memset pointer, int8(0), size
-      bit_cast pointer, type.pointer
+      pointer_cast pointer, type.pointer
     end
 
     def crystal_malloc_fun
@@ -2281,7 +2281,7 @@ module Crystal
             # For a struct we need to cast the second part of the union to the base type
             _, value_ptr = union_type_and_value_pointer(pointer, _type)
             target_type = type.base_type
-            pointer = bit_cast value_ptr, llvm_type(target_type).pointer
+            pointer = pointer_cast value_ptr, llvm_type(target_type).pointer
           else
             # Nothing, there's only one subclass so it's the struct already
           end

--- a/src/compiler/crystal/codegen/codegen.cr
+++ b/src/compiler/crystal/codegen/codegen.cr
@@ -2281,7 +2281,7 @@ module Crystal
             # For a struct we need to cast the second part of the union to the base type
             _, value_ptr = union_type_and_value_pointer(pointer, _type)
             target_type = type.base_type
-            pointer = pointer_cast value_ptr, llvm_type(target_type).pointer
+            pointer = cast_to_pointer value_ptr, target_type
           else
             # Nothing, there's only one subclass so it's the struct already
           end

--- a/src/compiler/crystal/codegen/codegen.cr
+++ b/src/compiler/crystal/codegen/codegen.cr
@@ -606,9 +606,9 @@ module Crystal
       the_fun = check_main_fun fun_literal_name, the_fun
 
       set_current_debug_location(node) if @debug.line_numbers?
-      fun_ptr = pointer_cast(the_fun.func, llvm_context.void_pointer)
+      fun_ptr = cast_to_void_pointer(the_fun.func)
       if is_closure
-        ctx_ptr = pointer_cast(context.closure_ptr.not_nil!, llvm_context.void_pointer)
+        ctx_ptr = cast_to_void_pointer(context.closure_ptr.not_nil!)
       else
         ctx_ptr = llvm_context.void_pointer.null
       end
@@ -655,9 +655,9 @@ module Crystal
       last_fun = target_def_fun(node.call.target_def, owner)
 
       set_current_debug_location(node) if @debug.line_numbers?
-      fun_ptr = pointer_cast(last_fun.func, llvm_context.void_pointer)
+      fun_ptr = cast_to_void_pointer(last_fun.func)
       if call_self && !owner.metaclass? && !owner.is_a?(LibType)
-        ctx_ptr = pointer_cast(call_self, llvm_context.void_pointer)
+        ctx_ptr = cast_to_void_pointer(call_self)
       else
         ctx_ptr = llvm_context.void_pointer.null
       end

--- a/src/compiler/crystal/codegen/cond.cr
+++ b/src/compiler/crystal/codegen/cond.cr
@@ -54,7 +54,7 @@ class Crystal::CodeGenVisitor
           next unless union_type.is_a?(PointerInstanceType)
 
           is_pointer = equal? type_id, type_id(union_type)
-          pointer_value = load(llvm_type(union_type), pointer_cast value_ptr, llvm_type(union_type).pointer)
+          pointer_value = load(llvm_type(union_type), cast_to_pointer(value_ptr, union_type))
           pointer_null = null_pointer?(pointer_value)
           cond = and cond, not(and(is_pointer, pointer_null))
         end

--- a/src/compiler/crystal/codegen/cond.cr
+++ b/src/compiler/crystal/codegen/cond.cr
@@ -44,7 +44,7 @@ class Crystal::CodeGenVisitor
       end
 
       if has_bool
-        value = load(llvm_context.int1, bit_cast value_ptr, llvm_context.int1.pointer)
+        value = load(llvm_context.int1, pointer_cast value_ptr, llvm_context.int1.pointer)
         is_bool = equal? type_id, type_id(@program.bool)
         cond = and cond, not(and(is_bool, not(value)))
       end
@@ -54,7 +54,7 @@ class Crystal::CodeGenVisitor
           next unless union_type.is_a?(PointerInstanceType)
 
           is_pointer = equal? type_id, type_id(union_type)
-          pointer_value = load(llvm_type(union_type), bit_cast value_ptr, llvm_type(union_type).pointer)
+          pointer_value = load(llvm_type(union_type), pointer_cast value_ptr, llvm_type(union_type).pointer)
           pointer_null = null_pointer?(pointer_value)
           cond = and cond, not(and(is_pointer, pointer_null))
         end

--- a/src/compiler/crystal/codegen/exception.cr
+++ b/src/compiler/crystal/codegen/exception.cr
@@ -149,8 +149,11 @@ class Crystal::CodeGenVisitor
 
         # We call __crystal_get_exception to get the actual crystal `Exception` object.
         get_exception_fun = main_fun(GET_EXCEPTION_NAME)
+        get_exception_arg_type = get_exception_fun.type.params_types.first # Void* or LibUnwind::Exception*
+        get_exception_arg = pointer_cast(unwind_ex_obj, get_exception_arg_type)
+
         set_current_debug_location node if @debug.line_numbers?
-        caught_exception_ptr = call get_exception_fun, [bit_cast(unwind_ex_obj, get_exception_fun.type.params_types.first)]
+        caught_exception_ptr = call get_exception_fun, [get_exception_arg]
         caught_exception = int2ptr caught_exception_ptr, llvm_typer.type_id_pointer
       end
 

--- a/src/compiler/crystal/codegen/exception.cr
+++ b/src/compiler/crystal/codegen/exception.cr
@@ -289,7 +289,9 @@ class Crystal::CodeGenVisitor
       unreachable
     else
       raise_fun = main_fun(RAISE_NAME)
-      codegen_call_or_invoke(node, nil, nil, raise_fun, [bit_cast(unwind_ex_obj.not_nil!, raise_fun.func.params.first.type)], true, @program.no_return)
+      raise_fun_arg_type = raise_fun.func.params.first.type # Void* or LibUnwind::Exception*
+      raise_fun_arg = pointer_cast(unwind_ex_obj.not_nil!, raise_fun_arg_type)
+      codegen_call_or_invoke(node, nil, nil, raise_fun, [raise_fun_arg], true, @program.no_return)
     end
   end
 

--- a/src/compiler/crystal/codegen/fun.cr
+++ b/src/compiler/crystal/codegen/fun.cr
@@ -569,7 +569,7 @@ class Crystal::CodeGenVisitor
           pointer = declare_debug_for_function_argument(arg.name, var_type, index + 1, pointer, location) unless target_def.naked?
 
           if fun_proc
-            fun_ptr = pointer_cast(value, llvm_context.void_pointer)
+            fun_ptr = cast_to_void_pointer(value)
             value = make_fun(var_type, fun_ptr, llvm_context.void_pointer.null)
           end
 

--- a/src/compiler/crystal/codegen/llvm_builder_helper.cr
+++ b/src/compiler/crystal/codegen/llvm_builder_helper.cr
@@ -193,7 +193,7 @@ module Crystal
       pointer_cast value, llvm_type(type).pointer
     end
 
-    def cast_to_void_pointer(pointer)
+    def cast_to_void_pointer(pointer : LLVM::ValueMethods)
       pointer_cast pointer, llvm_context.void_pointer
     end
 

--- a/src/compiler/crystal/codegen/llvm_builder_helper.cr
+++ b/src/compiler/crystal/codegen/llvm_builder_helper.cr
@@ -200,15 +200,13 @@ module Crystal
     # *type* must be a pointer type; on LLVM 15.0 or above *type* is not
     # evaluated at all and *value* is returned unchanged, because all opaque
     # pointer types (in the same context) are identical
-    {% if LibLLVM::IS_LT_150 %}
-      def pointer_cast(value : LLVM::ValueMethods, type : LLVM::Type)
-        bit_cast(value, type)
-      end
-    {% else %}
-      macro pointer_cast(value, type)
-        \{{ value }}
-      end
-    {% end %}
+    macro pointer_cast(value, type)
+      {% if LibLLVM::IS_LT_150 %}
+        bit_cast({{ value }}, {{ type }})
+      {% else %}
+        {{ value }}
+      {% end %}
+    end
 
     delegate llvm_type, llvm_struct_type, llvm_arg_type, llvm_embedded_type,
       llvm_c_type, llvm_c_return_type, llvm_return_type, llvm_embedded_c_type,

--- a/src/compiler/crystal/codegen/llvm_builder_helper.cr
+++ b/src/compiler/crystal/codegen/llvm_builder_helper.cr
@@ -157,10 +157,6 @@ module Crystal
       builder.ret value
     end
 
-    def cast_to_void_pointer(pointer)
-      bit_cast pointer, llvm_context.void_pointer
-    end
-
     def extend_int(from_type, to_type, value)
       from_type.signed? ? builder.sext(value, llvm_type(to_type)) : builder.zext(value, llvm_type(to_type))
     end
@@ -194,8 +190,25 @@ module Crystal
     end
 
     def cast_to_pointer(value, type)
-      bit_cast value, llvm_type(type).pointer
+      pointer_cast value, llvm_type(type).pointer
     end
+
+    def cast_to_void_pointer(pointer)
+      pointer_cast pointer, llvm_context.void_pointer
+    end
+
+    # *type* must be a pointer type; on LLVM 15.0 or above *type* is not
+    # evaluated at all and *value* is returned unchanged, because all opaque
+    # pointer types (in the same context) are identical
+    {% if LibLLVM::IS_LT_150 %}
+      def pointer_cast(value : LLVM::ValueMethods, type : LLVM::Type)
+        bit_cast(value, type)
+      end
+    {% else %}
+      macro pointer_cast(value, type)
+        \{{ value }}
+      end
+    {% end %}
 
     delegate llvm_type, llvm_struct_type, llvm_arg_type, llvm_embedded_type,
       llvm_c_type, llvm_c_return_type, llvm_return_type, llvm_embedded_c_type,

--- a/src/compiler/crystal/codegen/llvm_builder_helper.cr
+++ b/src/compiler/crystal/codegen/llvm_builder_helper.cr
@@ -185,11 +185,11 @@ module Crystal
       end
     end
 
-    def cast_to(value, type)
-      bit_cast value, llvm_type(type)
+    def cast_to(value : LLVM::ValueMethods, type : Type)
+      pointer_cast value, llvm_type(type)
     end
 
-    def cast_to_pointer(value, type)
+    def cast_to_pointer(value : LLVM::ValueMethods, type : Type)
       pointer_cast value, llvm_type(type).pointer
     end
 

--- a/src/compiler/crystal/codegen/primitives.cr
+++ b/src/compiler/crystal/codegen/primitives.cr
@@ -74,7 +74,7 @@ class Crystal::CodeGenVisitor
             when "store_atomic"
               codegen_primitive_store_atomic call, node, target_def, call_args
             when "throw_info"
-              cast_to void_ptr_throwinfo, @program.pointer_of(@program.void)
+              cast_to_void_pointer void_ptr_throwinfo
             when "va_arg"
               codegen_va_arg call, node, target_def, call_args
             else

--- a/src/compiler/crystal/codegen/primitives.cr
+++ b/src/compiler/crystal/codegen/primitives.cr
@@ -852,7 +852,7 @@ class Crystal::CodeGenVisitor
   def union_field_ptr(union_type, field_type, pointer)
     ptr = aggregate_index llvm_type(union_type), pointer, 0
     if field_type.is_a?(ProcInstanceType)
-      bit_cast ptr, @llvm_typer.proc_type(field_type).pointer.pointer
+      pointer_cast ptr, @llvm_typer.proc_type(field_type).pointer.pointer
     else
       cast_to_pointer ptr, field_type
     end
@@ -995,7 +995,7 @@ class Crystal::CodeGenVisitor
     Phi.open(self, node, @needs_value) do |phi|
       position_at_end ctx_is_null_block
       real_fun_llvm_type = llvm_proc_type(context.type)
-      real_fun_ptr = bit_cast fun_ptr, real_fun_llvm_type.pointer
+      real_fun_ptr = pointer_cast fun_ptr, real_fun_llvm_type.pointer
 
       # When invoking a Proc that has extern structs as arguments or return type, it's tricky:
       # closures are never generated with C ABI because C doesn't support closures.
@@ -1022,7 +1022,7 @@ class Crystal::CodeGenVisitor
 
       position_at_end ctx_is_not_null_block
       real_fun_llvm_type = llvm_closure_type(context.type)
-      real_fun_ptr = bit_cast fun_ptr, real_fun_llvm_type.pointer
+      real_fun_ptr = pointer_cast fun_ptr, real_fun_llvm_type.pointer
       real_fun = LLVMTypedFunction.new(real_fun_llvm_type, LLVM::Function.from_value(real_fun_ptr))
       closure_args.insert(0, ctx_ptr)
       value = codegen_call_or_invoke(node, target_def, nil, real_fun, closure_args, true, target_def.type, true, proc_type)
@@ -1075,7 +1075,7 @@ class Crystal::CodeGenVisitor
     end
 
     null_fun_llvm_type = LLVM::Type.function(null_fun_types, null_fun_return_type)
-    null_fun_ptr = bit_cast fun_ptr, null_fun_llvm_type.pointer
+    null_fun_ptr = pointer_cast fun_ptr, null_fun_llvm_type.pointer
     target_def.c_calling_convention = true
 
     {null_fun_ptr, null_fun_llvm_type, null_args}
@@ -1140,7 +1140,7 @@ class Crystal::CodeGenVisitor
 
   def check_c_fun(type, value)
     if type.proc?
-      make_fun(type, bit_cast(value, llvm_context.void_pointer), llvm_context.void_pointer.null)
+      make_fun(type, pointer_cast(value, llvm_context.void_pointer), llvm_context.void_pointer.null)
     else
       value
     end

--- a/src/compiler/crystal/codegen/primitives.cr
+++ b/src/compiler/crystal/codegen/primitives.cr
@@ -1140,7 +1140,7 @@ class Crystal::CodeGenVisitor
 
   def check_c_fun(type, value)
     if type.proc?
-      make_fun(type, pointer_cast(value, llvm_context.void_pointer), llvm_context.void_pointer.null)
+      make_fun(type, cast_to_void_pointer(value), llvm_context.void_pointer.null)
     else
       value
     end

--- a/src/compiler/crystal/codegen/unions.cr
+++ b/src/compiler/crystal/codegen/unions.cr
@@ -90,7 +90,7 @@ module Crystal
       int_type = llvm_context.int((union_size * 8).to_i32)
 
       bool_as_extended_int = builder.zext(value, int_type)
-      casted_value_ptr = bit_cast(union_value(struct_type, union_pointer), int_type.pointer)
+      casted_value_ptr = pointer_cast(union_value(struct_type, union_pointer), int_type.pointer)
       store bool_as_extended_int, casted_value_ptr
     end
 
@@ -100,7 +100,7 @@ module Crystal
       value = union_value_type.null
 
       store type_id(value, @program.nil), union_type_id(struct_type, union_pointer)
-      casted_value_ptr = bit_cast union_value(struct_type, union_pointer), union_value_type.pointer
+      casted_value_ptr = pointer_cast union_value(struct_type, union_pointer), union_value_type.pointer
       store value, casted_value_ptr
     end
 


### PR DESCRIPTION
Part of #12743. When opaque pointers are available, casts between pointers (in the same address space) are always no-ops in LLVM, but this alone doesn't prevent Crystal from computing the pointee type. This PR does that by not evaluating the type argument at all for LLVM 15+. Note that _all_ uses of `bitcast` in Crystal are for pointer casts.