### PR TITLE
Deprecate LLVM typed pointers

### DIFF
--- a/src/llvm/builder.cr
+++ b/src/llvm/builder.cr
@@ -49,6 +49,7 @@ class LLVM::Builder
     Value.new phi_node
   end
 
+  @[Deprecated("Pass the function type of `func` as well (equal to `func.function_type`)")]
   def call(func : LLVM::Function, name : String = "")
     # check_func(func)
 
@@ -66,6 +67,7 @@ class LLVM::Builder
     Value.new LibLLVM.build_call2(self, type, func, nil, 0, name)
   end
 
+  @[Deprecated("Pass the function type of `func` as well (equal to `func.function_type`)")]
   def call(func : LLVM::Function, arg : LLVM::Value, name : String = "")
     # check_func(func)
     # check_value(arg)
@@ -87,6 +89,7 @@ class LLVM::Builder
     Value.new LibLLVM.build_call2(self, type, func, pointerof(value), 1, name)
   end
 
+  @[Deprecated("Pass the function type of `func` as well (equal to `func.function_type`)")]
   def call(func : LLVM::Function, args : Array(LLVM::Value), name : String = "", bundle : LLVM::OperandBundleDef = LLVM::OperandBundleDef.null)
     # check_func(func)
     # check_values(args)
@@ -115,6 +118,7 @@ class LLVM::Builder
     Value.new LibLLVM.build_store(self, value, ptr)
   end
 
+  @[Deprecated("Pass the pointee of `ptr` as well (equal to `ptr.type.element_type`)")]
   def load(ptr : LLVM::Value, name = "")
     # check_value(ptr)
 
@@ -149,6 +153,7 @@ class LLVM::Builder
   end
 
   {% for method_name in %w(gep inbounds_gep) %}
+    @[Deprecated("Pass the type of `value` as well (equal to `value.type`)")]
     def {{method_name.id}}(value : LLVM::Value, indices : Array(LLVM::ValueRef), name = "")
       # check_value(value)
 
@@ -170,6 +175,7 @@ class LLVM::Builder
       \{% end %}
     end
 
+    @[Deprecated("Pass the type of `value` as well (equal to `value.type`)")]
     def {{method_name.id}}(value : LLVM::Value, index : LLVM::Value, name = "")
       # check_value(value)
 
@@ -193,6 +199,7 @@ class LLVM::Builder
       \{% end %}
     end
 
+    @[Deprecated("Pass the type of `value` as well (equal to `value.type`)")]
     def {{method_name.id}}(value : LLVM::Value, index1 : LLVM::Value, index2 : LLVM::Value, name = "")
       # check_value(value)
 
@@ -307,6 +314,7 @@ class LLVM::Builder
     LibLLVMExt.build_catch_ret(self, pad, basic_block)
   end
 
+  @[Deprecated("Pass the function type of `fn` as well (equal to `fn.function_type`)")]
   def invoke(fn : LLVM::Function, args : Array(LLVM::Value), a_then, a_catch, bundle : LLVM::OperandBundleDef = LLVM::OperandBundleDef.null, name = "")
     # check_func(fn)
 

--- a/src/llvm/builder.cr
+++ b/src/llvm/builder.cr
@@ -49,7 +49,7 @@ class LLVM::Builder
     Value.new phi_node
   end
 
-  @[Deprecated("Pass the function type of `func` as well (equal to `func.function_type`)")]
+  @[Deprecated("Pass the function type of `func` as well (equal to `func.function_type`) in order to support LLVM 15+")]
   def call(func : LLVM::Function, name : String = "")
     # check_func(func)
 
@@ -67,7 +67,7 @@ class LLVM::Builder
     Value.new LibLLVM.build_call2(self, type, func, nil, 0, name)
   end
 
-  @[Deprecated("Pass the function type of `func` as well (equal to `func.function_type`)")]
+  @[Deprecated("Pass the function type of `func` as well (equal to `func.function_type`) in order to support LLVM 15+")]
   def call(func : LLVM::Function, arg : LLVM::Value, name : String = "")
     # check_func(func)
     # check_value(arg)
@@ -89,7 +89,7 @@ class LLVM::Builder
     Value.new LibLLVM.build_call2(self, type, func, pointerof(value), 1, name)
   end
 
-  @[Deprecated("Pass the function type of `func` as well (equal to `func.function_type`)")]
+  @[Deprecated("Pass the function type of `func` as well (equal to `func.function_type`) in order to support LLVM 15+")]
   def call(func : LLVM::Function, args : Array(LLVM::Value), name : String = "", bundle : LLVM::OperandBundleDef = LLVM::OperandBundleDef.null)
     # check_func(func)
     # check_values(args)
@@ -118,7 +118,7 @@ class LLVM::Builder
     Value.new LibLLVM.build_store(self, value, ptr)
   end
 
-  @[Deprecated("Pass the pointee of `ptr` as well (equal to `ptr.type.element_type`)")]
+  @[Deprecated("Pass the pointee of `ptr` as well (equal to `ptr.type.element_type`) in order to support LLVM 15+")]
   def load(ptr : LLVM::Value, name = "")
     # check_value(ptr)
 
@@ -153,7 +153,7 @@ class LLVM::Builder
   end
 
   {% for method_name in %w(gep inbounds_gep) %}
-    @[Deprecated("Pass the type of `value` as well (equal to `value.type`)")]
+    @[Deprecated("Pass the type of `value` as well (equal to `value.type`) in order to support LLVM 15+")]
     def {{method_name.id}}(value : LLVM::Value, indices : Array(LLVM::ValueRef), name = "")
       # check_value(value)
 
@@ -175,7 +175,7 @@ class LLVM::Builder
       \{% end %}
     end
 
-    @[Deprecated("Pass the type of `value` as well (equal to `value.type`)")]
+    @[Deprecated("Pass the type of `value` as well (equal to `value.type`) in order to support LLVM 15+")]
     def {{method_name.id}}(value : LLVM::Value, index : LLVM::Value, name = "")
       # check_value(value)
 
@@ -199,7 +199,7 @@ class LLVM::Builder
       \{% end %}
     end
 
-    @[Deprecated("Pass the type of `value` as well (equal to `value.type`)")]
+    @[Deprecated("Pass the type of `value` as well (equal to `value.type`) in order to support LLVM 15+")]
     def {{method_name.id}}(value : LLVM::Value, index1 : LLVM::Value, index2 : LLVM::Value, name = "")
       # check_value(value)
 
@@ -314,7 +314,7 @@ class LLVM::Builder
     LibLLVMExt.build_catch_ret(self, pad, basic_block)
   end
 
-  @[Deprecated("Pass the function type of `fn` as well (equal to `fn.function_type`)")]
+  @[Deprecated("Pass the function type of `fn` as well (equal to `fn.function_type`) in order to support LLVM 15+")]
   def invoke(fn : LLVM::Function, args : Array(LLVM::Value), a_then, a_catch, bundle : LLVM::OperandBundleDef = LLVM::OperandBundleDef.null, name = "")
     # check_func(fn)
 

--- a/src/llvm/function.cr
+++ b/src/llvm/function.cr
@@ -78,16 +78,19 @@ struct LLVM::Function
     {% end %}
   end
 
+  @[Deprecated]
   def function_type
     Type.new LibLLVM.get_element_type(LibLLVM.type_of(self))
   end
 
+  @[Deprecated]
   def return_type
-    function_type.return_type
+    Type.new(LibLLVM.get_element_type(LibLLVM.type_of(self))).return_type
   end
 
+  @[Deprecated]
   def varargs?
-    function_type.varargs?
+    Type.new(LibLLVM.get_element_type(LibLLVM.type_of(self))).varargs?
   end
 
   def params

--- a/src/llvm/lib_llvm.cr
+++ b/src/llvm/lib_llvm.cr
@@ -112,10 +112,6 @@ lib LibLLVM
   fun build_atomicrmw = LLVMBuildAtomicRMW(builder : BuilderRef, op : LLVM::AtomicRMWBinOp, ptr : ValueRef, val : ValueRef, ordering : LLVM::AtomicOrdering, singlethread : Int32) : ValueRef
   fun build_bit_cast = LLVMBuildBitCast(builder : BuilderRef, value : ValueRef, type : TypeRef, name : UInt8*) : ValueRef
   fun build_br = LLVMBuildBr(builder : BuilderRef, block : BasicBlockRef) : ValueRef
-  {% if LibLLVM::IS_LT_110 %}
-    # LLVMBuildCall is deprecated in favor of LLVMBuildCall2, in preparation for opaque pointer types.
-    fun build_call = LLVMBuildCall(builder : BuilderRef, fn : ValueRef, args : ValueRef*, num_args : Int32, name : UInt8*) : ValueRef
-  {% end %}
   {% unless LibLLVM::IS_LT_80 %}
     fun build_call2 = LLVMBuildCall2(builder : BuilderRef, type : TypeRef, fn : ValueRef, args : ValueRef*, num_args : Int32, name : UInt8*) : ValueRef
   {% end %}
@@ -132,8 +128,6 @@ lib LibLLVM
   fun build_fpext = LLVMBuildFPExt(builder : BuilderRef, val : ValueRef, dest_ty : TypeRef, name : UInt8*) : ValueRef
   fun build_fptrunc = LLVMBuildFPTrunc(builder : BuilderRef, val : ValueRef, dest_ty : TypeRef, name : UInt8*) : ValueRef
   fun build_fsub = LLVMBuildFSub(builder : BuilderRef, lhs : ValueRef, rhs : ValueRef, name : UInt8*) : ValueRef
-  fun build_gep = LLVMBuildGEP(builder : BuilderRef, pointer : ValueRef, indices : ValueRef*, num_indices : UInt32, name : UInt8*) : ValueRef
-  fun build_inbounds_gep = LLVMBuildInBoundsGEP(builder : BuilderRef, pointer : ValueRef, indices : ValueRef*, num_indices : UInt32, name : UInt8*) : ValueRef
   {% unless LibLLVM::IS_LT_80 %}
     fun build_gep2 = LLVMBuildGEP2(builder : BuilderRef, ty : TypeRef, pointer : ValueRef, indices : ValueRef*, num_indices : UInt32, name : UInt8*) : ValueRef
     fun build_inbounds_gep2 = LLVMBuildInBoundsGEP2(builder : BuilderRef, ty : TypeRef, pointer : ValueRef, indices : ValueRef*, num_indices : UInt32, name : UInt8*) : ValueRef
@@ -141,15 +135,10 @@ lib LibLLVM
   fun build_global_string_ptr = LLVMBuildGlobalStringPtr(builder : BuilderRef, str : UInt8*, name : UInt8*) : ValueRef
   fun build_icmp = LLVMBuildICmp(builder : BuilderRef, op : LLVM::IntPredicate, lhs : ValueRef, rhs : ValueRef, name : UInt8*) : ValueRef
   fun build_int2ptr = LLVMBuildIntToPtr(builder : BuilderRef, val : ValueRef, dest_ty : TypeRef, name : UInt8*) : ValueRef
-  {% if LibLLVM::IS_LT_110 %}
-    # LLVMBuildInvoke is deprecated in favor of LLVMBuildInvoke2, in preparation for opaque pointer types.
-    fun build_invoke = LLVMBuildInvoke(builder : BuilderRef, fn : ValueRef, args : ValueRef*, num_args : UInt32, then : BasicBlockRef, catch : BasicBlockRef, name : UInt8*) : ValueRef
-  {% end %}
   {% unless LibLLVM::IS_LT_80 %}
     fun build_invoke2 = LLVMBuildInvoke2(builder : BuilderRef, ty : TypeRef, fn : ValueRef, args : ValueRef*, num_args : UInt32, then : BasicBlockRef, catch : BasicBlockRef, name : UInt8*) : ValueRef
   {% end %}
   fun build_landing_pad = LLVMBuildLandingPad(builder : BuilderRef, ty : TypeRef, pers_fn : ValueRef, num_clauses : UInt32, name : UInt8*) : ValueRef
-  fun build_load = LLVMBuildLoad(builder : BuilderRef, ptr : ValueRef, name : UInt8*) : ValueRef
   {% unless LibLLVM::IS_LT_80 %}
     fun build_load2 = LLVMBuildLoad2(builder : BuilderRef, ty : TypeRef, ptr : ValueRef, name : UInt8*) : ValueRef
   {% end %}

--- a/src/llvm/lib_llvm.cr
+++ b/src/llvm/lib_llvm.cr
@@ -112,6 +112,10 @@ lib LibLLVM
   fun build_atomicrmw = LLVMBuildAtomicRMW(builder : BuilderRef, op : LLVM::AtomicRMWBinOp, ptr : ValueRef, val : ValueRef, ordering : LLVM::AtomicOrdering, singlethread : Int32) : ValueRef
   fun build_bit_cast = LLVMBuildBitCast(builder : BuilderRef, value : ValueRef, type : TypeRef, name : UInt8*) : ValueRef
   fun build_br = LLVMBuildBr(builder : BuilderRef, block : BasicBlockRef) : ValueRef
+  {% if LibLLVM::IS_LT_110 %}
+    # LLVMBuildCall is deprecated in favor of LLVMBuildCall2, in preparation for opaque pointer types.
+    fun build_call = LLVMBuildCall(builder : BuilderRef, fn : ValueRef, args : ValueRef*, num_args : Int32, name : UInt8*) : ValueRef
+  {% end %}
   {% unless LibLLVM::IS_LT_80 %}
     fun build_call2 = LLVMBuildCall2(builder : BuilderRef, type : TypeRef, fn : ValueRef, args : ValueRef*, num_args : Int32, name : UInt8*) : ValueRef
   {% end %}
@@ -128,6 +132,8 @@ lib LibLLVM
   fun build_fpext = LLVMBuildFPExt(builder : BuilderRef, val : ValueRef, dest_ty : TypeRef, name : UInt8*) : ValueRef
   fun build_fptrunc = LLVMBuildFPTrunc(builder : BuilderRef, val : ValueRef, dest_ty : TypeRef, name : UInt8*) : ValueRef
   fun build_fsub = LLVMBuildFSub(builder : BuilderRef, lhs : ValueRef, rhs : ValueRef, name : UInt8*) : ValueRef
+  fun build_gep = LLVMBuildGEP(builder : BuilderRef, pointer : ValueRef, indices : ValueRef*, num_indices : UInt32, name : UInt8*) : ValueRef
+  fun build_inbounds_gep = LLVMBuildInBoundsGEP(builder : BuilderRef, pointer : ValueRef, indices : ValueRef*, num_indices : UInt32, name : UInt8*) : ValueRef
   {% unless LibLLVM::IS_LT_80 %}
     fun build_gep2 = LLVMBuildGEP2(builder : BuilderRef, ty : TypeRef, pointer : ValueRef, indices : ValueRef*, num_indices : UInt32, name : UInt8*) : ValueRef
     fun build_inbounds_gep2 = LLVMBuildInBoundsGEP2(builder : BuilderRef, ty : TypeRef, pointer : ValueRef, indices : ValueRef*, num_indices : UInt32, name : UInt8*) : ValueRef
@@ -135,10 +141,15 @@ lib LibLLVM
   fun build_global_string_ptr = LLVMBuildGlobalStringPtr(builder : BuilderRef, str : UInt8*, name : UInt8*) : ValueRef
   fun build_icmp = LLVMBuildICmp(builder : BuilderRef, op : LLVM::IntPredicate, lhs : ValueRef, rhs : ValueRef, name : UInt8*) : ValueRef
   fun build_int2ptr = LLVMBuildIntToPtr(builder : BuilderRef, val : ValueRef, dest_ty : TypeRef, name : UInt8*) : ValueRef
+  {% if LibLLVM::IS_LT_110 %}
+    # LLVMBuildInvoke is deprecated in favor of LLVMBuildInvoke2, in preparation for opaque pointer types.
+    fun build_invoke = LLVMBuildInvoke(builder : BuilderRef, fn : ValueRef, args : ValueRef*, num_args : UInt32, then : BasicBlockRef, catch : BasicBlockRef, name : UInt8*) : ValueRef
+  {% end %}
   {% unless LibLLVM::IS_LT_80 %}
     fun build_invoke2 = LLVMBuildInvoke2(builder : BuilderRef, ty : TypeRef, fn : ValueRef, args : ValueRef*, num_args : UInt32, then : BasicBlockRef, catch : BasicBlockRef, name : UInt8*) : ValueRef
   {% end %}
   fun build_landing_pad = LLVMBuildLandingPad(builder : BuilderRef, ty : TypeRef, pers_fn : ValueRef, num_clauses : UInt32, name : UInt8*) : ValueRef
+  fun build_load = LLVMBuildLoad(builder : BuilderRef, ptr : ValueRef, name : UInt8*) : ValueRef
   {% unless LibLLVM::IS_LT_80 %}
     fun build_load2 = LLVMBuildLoad2(builder : BuilderRef, ty : TypeRef, ptr : ValueRef, name : UInt8*) : ValueRef
   {% end %}

--- a/src/llvm/parameter_collection.cr
+++ b/src/llvm/parameter_collection.cr
@@ -21,6 +21,6 @@ struct LLVM::ParameterCollection
   end
 
   def types
-    @function.function_type.params_types
+    to_a.map(&.type)
   end
 end


### PR DESCRIPTION
Part of #12743. This PR adds the actual deprecation notices to methods that assume the availability of typed pointers.