### PR TITLE
Fix `Socket#tty?` to `false` on Windows

### DIFF
--- a/spec/std/socket/socket_spec.cr
+++ b/spec/std/socket/socket_spec.cr
@@ -19,6 +19,12 @@ describe Socket, tags: "network" do
     end
   end
 
+  describe "#tty?" do
+    it "with non TTY" do
+      Socket.unix.tty?.should be_false
+    end
+  end
+
   pending_win32 ".accept" do
     client_done = Channel(Nil).new
     server = Socket.new(Socket::Family::INET, Socket::Type::STREAM, Socket::Protocol::TCP)

--- a/spec/std/socket/socket_spec.cr
+++ b/spec/std/socket/socket_spec.cr
@@ -21,7 +21,7 @@ describe Socket, tags: "network" do
 
   describe "#tty?" do
     it "with non TTY" do
-      Socket.unix.tty?.should be_false
+      Socket.new(Socket::Family::INET, Socket::Type::STREAM, Socket::Protocol::TCP).tty?.should be_false
     end
   end
 

--- a/src/crystal/system/win32/socket.cr
+++ b/src/crystal/system/win32/socket.cr
@@ -335,11 +335,7 @@ module Crystal::System::Socket
   end
 
   private def system_tty?
-    file_descriptor = LibC._open_osfhandle fd, 0
-
-    return false if -1 == file_descriptor
-
-    LibC._isatty(file_descriptor) != 0
+    false
   end
 
   private def unbuffered_read(slice : Bytes)

--- a/src/crystal/system/win32/socket.cr
+++ b/src/crystal/system/win32/socket.cr
@@ -335,9 +335,11 @@ module Crystal::System::Socket
   end
 
   private def system_tty?
-    LibC._isatty(
-      LibC._open_osfhandle(fd, 0)
-    ) != 0
+    file_descriptor = LibC._open_osfhandle fd, 0
+
+    return false if -1 == file_descriptor
+
+    LibC._isatty(file_descriptor) != 0
   end
 
   private def unbuffered_read(slice : Bytes)

--- a/src/crystal/system/win32/socket.cr
+++ b/src/crystal/system/win32/socket.cr
@@ -335,7 +335,9 @@ module Crystal::System::Socket
   end
 
   private def system_tty?
-    LibC.isatty(fd) == 1
+    LibC._isatty(
+      LibC._open_osfhandle(fd, 0)
+    ) != 0
   end
 
   private def unbuffered_read(slice : Bytes)

--- a/src/lib_c/x86_64-windows-msvc/c/io.cr
+++ b/src/lib_c/x86_64-windows-msvc/c/io.cr
@@ -7,6 +7,7 @@ lib LibC
   fun _isatty(fd : Int) : Int
   fun _close(fd : Int) : Int
   fun _wopen(filename : WCHAR*, oflag : Int, ...) : Int
+  fun _open_osfhandle(osfhandle : UINT_PTR, flags : Int) : Int
   fun _waccess_s(path : WCHAR*, mode : Int) : ErrnoT
   fun _wchmod(filename : WCHAR*, pmode : Int) : Int
   fun _wunlink(filename : WCHAR*) : Int

--- a/src/lib_c/x86_64-windows-msvc/c/io.cr
+++ b/src/lib_c/x86_64-windows-msvc/c/io.cr
@@ -7,7 +7,6 @@ lib LibC
   fun _isatty(fd : Int) : Int
   fun _close(fd : Int) : Int
   fun _wopen(filename : WCHAR*, oflag : Int, ...) : Int
-  fun _open_osfhandle(osfhandle : UINT_PTR, flags : Int) : Int
   fun _waccess_s(path : WCHAR*, mode : Int) : ErrnoT
   fun _wchmod(filename : WCHAR*, pmode : Int) : Int
   fun _wunlink(filename : WCHAR*) : Int


### PR DESCRIPTION
This ended up being not as straight forward as the `FileDescriptor` context as `fd` in this case is actually a `LibC::SOCKET` not a raw `Int` like in the other context. After doing some research it seems that sockets can be treated like other windows handles and as such can pass it to `_open_osfhandle` in order to get a C file descriptor to pass to `_isatty`.

After this PR, the spec I added correctly returns `false`, tho I'm not sure if there is a case where you can get a socket to be a tty in order to test the case of it being `true`.

Fixes #13165

refs: 

* https://stackoverflow.com/a/25072414
* https://learn.microsoft.com/en-us/cpp/c-runtime-library/reference/open-osfhandle?view=msvc-170

EDIT: After reading some more I'm not so sure:

> The _open_osfhandle call transfers ownership of the Win32 file handle to the file descriptor. To close a file opened by using _open_osfhandle, call [_close](https://learn.microsoft.com/en-us/cpp/c-runtime-library/reference/close?view=msvc-170). The underlying OS file handle is also closed by a call to _close.

Transferring the ownership of the handle to the FD doesn't seem like what we want, and can't really close it w/o also closing the underlying handle?

EDIT2: Just going to try returning `false` given it doesn't seem like you can have a windows socket be a tty. Can revisit in future if this is disproven, but at least gets things compiling.