### PR TITLE
[CI] Cancel in-progress jobs when another commit is pushed

### DIFF
--- a/.github/workflows/aarch64.yml
+++ b/.github/workflows/aarch64.yml
@@ -2,6 +2,10 @@ name: AArch64 CI
 
 on: [push, pull_request]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   aarch64-musl-build:
     runs-on: [linux, ARM64]

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -2,6 +2,10 @@ name: Linux CI
 
 on: [push, pull_request]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 env:
   TRAVIS_OS_NAME: linux
   SPEC_SPLIT_DOTS: 160

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -2,6 +2,10 @@ name: macOS CI
 
 on: [push, pull_request]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 env:
   SPEC_SPLIT_DOTS: 160
   CI_NIX_SHELL: true

--- a/.github/workflows/openssl.yml
+++ b/.github/workflows/openssl.yml
@@ -2,6 +2,10 @@ name: OpenSSL CI
 
 on: [push, pull_request]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   openssl3:
     runs-on: ubuntu-latest

--- a/.github/workflows/regex-engine.yml
+++ b/.github/workflows/regex-engine.yml
@@ -2,6 +2,10 @@ name: Regex Engine CI
 
 on: [push, pull_request]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   pcre:
     runs-on: ubuntu-latest

--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -30,6 +30,10 @@ name: Smoke tests
 
 on: [push, pull_request]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 env:
   TRAVIS_OS_NAME: linux
   ARCH: x86_64

--- a/.github/workflows/wasm32.yml
+++ b/.github/workflows/wasm32.yml
@@ -2,6 +2,10 @@ name: WebAssembly CI
 
 on: [push, pull_request]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 env:
   SPEC_SPLIT_DOTS: 160
 

--- a/.github/workflows/win.yml
+++ b/.github/workflows/win.yml
@@ -2,6 +2,10 @@ name: Windows CI
 
 on: [push, pull_request]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   x86_64-linux-job:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Leverages the example from https://docs.github.com/en/actions/using-jobs/using-concurrency#example-only-cancel-in-progress-jobs-or-runs-for-the-current-workflow to support canceling in progress CI workflows when another commit is pushed. I.e. CI jobs will only run on the latest ref.