### PR TITLE
[CI] Increase `no_output_timeout` on circleci (cont.)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -47,7 +47,9 @@ jobs:
       - run: bin/ci prepare_system
       - run: echo 'export CURRENT_TAG="$CIRCLE_TAG"' >> $BASH_ENV
       - run: bin/ci prepare_build
-      - run: bin/ci build
+      - run:
+          command: bin/ci build
+          no_output_timeout: 30m
       - run:
           when: always
           command: |
@@ -89,7 +91,9 @@ jobs:
       - run: echo 'export PKG_CONFIG_PATH="$PKG_CONFIG_PATH:/usr/local/opt/openssl@1.1/lib/pkgconfig"' >> $BASH_ENV
       - run: echo 'export CURRENT_TAG="$CIRCLE_TAG"' >> $BASH_ENV
       - run: bin/ci prepare_build
-      - run: bin/ci build
+      - run:
+          command: bin/ci build
+          no_output_timeout: 30m
       - run:
           when: always
           command: |
@@ -119,7 +123,9 @@ jobs:
       - run: echo 'export CURRENT_TAG="$CIRCLE_TAG"' >> $BASH_ENV
       - run: bin/ci prepare_build
       - run: bin/ci with_build_env 'make crystal'
-      - run: bin/ci with_build_env 'CRYSTAL_WORKERS=4 make std_spec threads=1 FLAGS="-D preview_mt" junit_output=.junit/std_spec.xml'
+      - run:
+          command: bin/ci with_build_env 'CRYSTAL_WORKERS=4 make std_spec threads=1 FLAGS="-D preview_mt" junit_output=.junit/std_spec.xml'
+          no_output_timeout: 30m
       - run:
           when: always
           command: |
@@ -472,7 +478,9 @@ jobs:
       - run: bin/ci prepare_system
       - run: echo 'export CURRENT_TAG="$CIRCLE_TAG"' >> $BASH_ENV
       - run: bin/ci prepare_build
-      - run: bin/ci build
+      - run:
+          command: bin/ci build
+          no_output_timeout: 30m
 
 workflows:
   version: 2


### PR DESCRIPTION
Continuation of #13151. Increases no-output timeout to 30 minutes on all build/test jobs because since `test_alpine` was fixed, other jobs have started to fail because of this as well (e.g. https://app.circleci.com/pipelines/github/crystal-lang/crystal/11438/workflows/8210bb74-7ded-4816-9914-c32a67c00610/jobs/74914).