### PR TITLE
Enable or fix specs that already work on Windows

### DIFF
--- a/spec/compiler/codegen/thread_local_spec.cr
+++ b/spec/compiler/codegen/thread_local_spec.cr
@@ -3,7 +3,7 @@
 require "../../spec_helper"
 
 describe "Codegen: thread local" do
-  pending_win32 "works with class variables" do
+  it "works with class variables" do
     run(%(
     require "prelude"
 

--- a/spec/manual/string_normalize_spec.cr
+++ b/spec/manual/string_normalize_spec.cr
@@ -43,7 +43,7 @@ private macro assert_prints_codepoints(call, str, desc, *, file = __FILE__, line
     ) {{ call.block }}
   end.should %expectation, file: {{ file }}, line: {{ line }}
 
-  {% unless flag?(:win32) %}
+  {% unless flag?(:without_iconv) %}
     string_build_via_utf16 do |io|
       {% if call.receiver %}{{ call.receiver }}.{% end %}{{ call.name }}(
         io,

--- a/spec/std/file/tempfile_spec.cr
+++ b/spec/std/file/tempfile_spec.cr
@@ -110,15 +110,17 @@ describe File do
       tempfile.try &.delete
     end
 
-    pending_win32 "accepts dir argument" do
+    it "accepts dir argument" do
       file = File.tempfile(dir: datapath)
       File.dirname(file.path).should eq(datapath)
+      file.close
     ensure
       file.try &.delete
     end
 
-    pending_win32 "fails in nonwriteable folder" do
-      expect_raises(File::NotFoundError, "Error creating temporary file: '#{datapath("non-existing-folder")}/") do
+    it "fails in nonwriteable folder" do
+      err_directory = (datapath("non-existing-folder") + Path::SEPARATORS[0]).inspect_unquoted
+      expect_raises(File::NotFoundError, "Error creating temporary file: '#{err_directory}") do
         File.tempfile dir: datapath("non-existing-folder")
       end
     end

--- a/spec/std/file_spec.cr
+++ b/spec/std/file_spec.cr
@@ -1053,10 +1053,8 @@ describe "File" do
       File.writable?("foo\0bar")
     end
 
-    pending_win32 "errors on executable?" do
-      expect_raises(ArgumentError, "String contains null byte") do
-        File.executable?("foo\0bar")
-      end
+    it_raises_on_null_byte "executable?" do
+      File.executable?("foo\0bar")
     end
 
     it_raises_on_null_byte "file?" do

--- a/spec/std/file_spec.cr
+++ b/spec/std/file_spec.cr
@@ -903,7 +903,7 @@ describe "File" do
   end
 
   describe "fsync" do
-    pending_win32 "syncs OS file buffer to disk" do
+    it "syncs OS file buffer to disk" do
       with_tempfile("fsync.txt") do |path|
         File.open(path, "a") do |f|
           f.puts("333")

--- a/spec/std/http/client/client_spec.cr
+++ b/spec/std/http/client/client_spec.cr
@@ -357,7 +357,7 @@ module HTTP
       end
     end
 
-    pending_win32 "tests write_timeout" do
+    it "tests write_timeout" do
       # Here we don't want to write a response on the server side because
       # it doesn't make sense to try to write because the client will already
       # timeout on read. Writing a response could lead on an exception in
@@ -371,7 +371,7 @@ module HTTP
       end
     end
 
-    pending_win32 "tests connect_timeout" do
+    it "tests connect_timeout" do
       test_server("localhost", 0, 0) do |server|
         client = Client.new("localhost", server.local_address.port)
         client.connect_timeout = 0.5

--- a/spec/std/signal_spec.cr
+++ b/spec/std/signal_spec.cr
@@ -1,79 +1,90 @@
-{% skip_file if flag?(:win32) || flag?(:wasm32) %}
+{% skip_file if flag?(:wasm32) %}
 
 require "spec"
 require "signal"
 
 describe "Signal" do
-  typeof(Signal::PIPE.reset)
-  typeof(Signal::PIPE.ignore)
-  typeof(Signal::PIPE.trap { 1 })
+  typeof(Signal::ABRT.reset)
+  typeof(Signal::ABRT.ignore)
+  typeof(Signal::ABRT.trap { 1 })
 
-  it "runs a signal handler" do
-    ran = false
-    Signal::USR1.trap do
-      ran = true
-    end
-    Process.signal Signal::USR1, Process.pid
-    10.times do |i|
-      break if ran
-      sleep 0.1
-    end
-    ran.should be_true
+  it "has constants required by C" do
+    Signal::INT.should be_a(Signal)
+    Signal::ILL.should be_a(Signal)
+    Signal::FPE.should be_a(Signal)
+    Signal::SEGV.should be_a(Signal)
+    Signal::TERM.should be_a(Signal)
+    Signal::ABRT.should be_a(Signal)
   end
 
-  it "ignores a signal" do
-    Signal::USR2.ignore
-    Process.signal Signal::USR2, Process.pid
-  end
-
-  it "CHLD.reset sets default Crystal child handler" do
-    Signal::CHLD.reset
-    child = Process.new("true", shell: true)
-    child.wait # doesn't block forever
-  end
-
-  it "CHLD.ignore sets default Crystal child handler" do
-    Signal::CHLD.ignore
-    child = Process.new("true", shell: true)
-    child.wait # doesn't block forever
-  end
-
-  it "CHLD.trap is called after default Crystal child handler" do
-    chan = Channel(Process).new
-    existed = Channel(Bool).new
-
-    Signal::CHLD.trap do
-      child_process = chan.receive
-      existed.send(Process.exists?(child_process.pid))
+  {% unless flag?(:win32) %}
+    it "runs a signal handler" do
+      ran = false
+      Signal::USR1.trap do
+        ran = true
+      end
+      Process.signal Signal::USR1, Process.pid
+      10.times do |i|
+        break if ran
+        sleep 0.1
+      end
+      ran.should be_true
     end
 
-    child = Process.new("true", shell: true)
-    child.wait # doesn't block forever
-    chan.send(child)
-    existed.receive.should be_false
-  ensure
-    Signal::CHLD.reset
-  end
-
-  it "CHLD.reset removes previously set trap" do
-    call_count = 0
-
-    Signal::CHLD.trap do
-      call_count += 1
+    it "ignores a signal" do
+      Signal::USR2.ignore
+      Process.signal Signal::USR2, Process.pid
     end
 
-    Process.new("true", shell: true).wait
-    Fiber.yield
+    it "CHLD.reset sets default Crystal child handler" do
+      Signal::CHLD.reset
+      child = Process.new("true", shell: true)
+      child.wait # doesn't block forever
+    end
 
-    call_count.should eq(1)
+    it "CHLD.ignore sets default Crystal child handler" do
+      Signal::CHLD.ignore
+      child = Process.new("true", shell: true)
+      child.wait # doesn't block forever
+    end
 
-    Signal::CHLD.reset
+    it "CHLD.trap is called after default Crystal child handler" do
+      chan = Channel(Process).new
+      existed = Channel(Bool).new
 
-    Process.new("true", shell: true).wait
-    Fiber.yield
+      Signal::CHLD.trap do
+        child_process = chan.receive
+        existed.send(Process.exists?(child_process.pid))
+      end
 
-    call_count.should eq(1)
-  end
+      child = Process.new("true", shell: true)
+      child.wait # doesn't block forever
+      chan.send(child)
+      existed.receive.should be_false
+    ensure
+      Signal::CHLD.reset
+    end
 
-  # TODO: test Signal::X.reset
+    it "CHLD.reset removes previously set trap" do
+      call_count = 0
+
+      Signal::CHLD.trap do
+        call_count += 1
+      end
+
+      Process.new("true", shell: true).wait
+      Fiber.yield
+
+      call_count.should eq(1)
+
+      Signal::CHLD.reset
+
+      Process.new("true", shell: true).wait
+      Fiber.yield
+
+      call_count.should eq(1)
+    end
+
+    # TODO: test Signal::X.reset
+  {% end %}
 end

--- a/spec/std/socket/socket_spec.cr
+++ b/spec/std/socket/socket_spec.cr
@@ -25,7 +25,7 @@ describe Socket, tags: "network" do
     end
   end
 
-  pending_win32 ".accept" do
+  it ".accept" do
     client_done = Channel(Nil).new
     server = Socket.new(Socket::Family::INET, Socket::Type::STREAM, Socket::Protocol::TCP)
 
@@ -65,7 +65,7 @@ describe Socket, tags: "network" do
     expect_raises(IO::TimeoutError) { server.accept? }
   end
 
-  pending_win32 "sends messages" do
+  it "sends messages" do
     port = unused_local_port
     server = Socket.tcp(Socket::Family::INET)
     server.bind("127.0.0.1", port)

--- a/spec/std/sprintf_spec.cr
+++ b/spec/std/sprintf_spec.cr
@@ -1,8 +1,6 @@
 require "./spec_helper"
 require "../support/string"
-{% unless flag?(:win32) %}
-  require "big"
-{% end %}
+require "big"
 
 # use same name for `sprintf` and `IO#printf` so that `assert_prints` can be leveraged
 private def fprintf(format, *args)
@@ -368,7 +366,7 @@ describe "::sprintf" do
       assert_sprintf "%d", Int64::MIN, "-9223372036854775808"
     end
 
-    pending_win32 "works with BigInt" do
+    it "works with BigInt" do
       assert_sprintf "%d", 123.to_big_i, "123"
       assert_sprintf "%300.250d", 10.to_big_i ** 200, "#{" " * 50}#{"0" * 49}1#{"0" * 200}"
       assert_sprintf "%- #300.250X", 16.to_big_i ** 200 - 1, " 0X#{"0" * 50}#{"F" * 200}#{" " * 47}"

--- a/spec/std/system_spec.cr
+++ b/spec/std/system_spec.cr
@@ -3,7 +3,7 @@ require "system"
 
 describe System do
   describe "hostname" do
-    pending_win32 "returns current hostname" do
+    it "returns current hostname" do
       shell_hostname = `hostname`.strip
       pending! "`hostname` command was unsuccessful" unless $?.success?
 

--- a/src/crystal/system/unix/lib_event2.cr
+++ b/src/crystal/system/unix/lib_event2.cr
@@ -19,11 +19,7 @@ require "c/netdb"
 lib LibEvent2
   alias Int = LibC::Int
 
-  {% if flag?(:windows) %}
-    # TODO
-  {% else %}
-    alias EvutilSocketT = Int
-  {% end %}
+  alias EvutilSocketT = Int
 
   type EventBase = Void*
   type Event = Void*


### PR DESCRIPTION
These were found to be working while scanning over the entire repository for all uses of `pending_win32` and `flag?(:win32)`.