### PR TITLE
OpenSSL: use Windows' system root certificate store

### DIFF
--- a/src/crystal/system/win32/crypto.cr
+++ b/src/crystal/system/win32/crypto.cr
@@ -27,8 +27,8 @@ module Crystal::System::Crypto
         eku = eku.as(UInt8*).realloc(eku_size).as(LibC::CERT_USAGE*)
         next unless LibC.CertGetEnhancedKeyUsage(cert_context, 0, eku, pointerof(eku_size)) != 0
         next unless (0...eku.value.cUsageIdentifier).any? do |i|
-          LibC.strcmp(eku.value.rgpszUsageIdentifier[i], ServerAuthOID) == 0
-        end
+                      LibC.strcmp(eku.value.rgpszUsageIdentifier[i], ServerAuthOID) == 0
+                    end
       end
 
       encoded = Slice.new(cert_context.value.pbCertEncoded, cert_context.value.cbCertEncoded)

--- a/src/crystal/system/win32/crypto.cr
+++ b/src/crystal/system/win32/crypto.cr
@@ -1,4 +1,5 @@
 require "c/wincrypt"
+require "openssl"
 
 module Crystal::System::Crypto
   # heavily based on cURL's code for importing system certificates on Windows:
@@ -29,7 +30,8 @@ module Crystal::System::Crypto
 
       encoded = Slice.new(cert_context.value.pbCertEncoded, cert_context.value.cbCertEncoded)
       until encoded.empty?
-        cert, encoded = OpenSSL::X509::Certificate.from_der(encoded)
+        cert, encoded = OpenSSL::X509::Certificate.from_der?(encoded)
+        break unless cert
         yield cert
       end
     end

--- a/src/crystal/system/win32/crypto.cr
+++ b/src/crystal/system/win32/crypto.cr
@@ -1,0 +1,52 @@
+require "c/wincrypt"
+
+module Crystal::System::Crypto
+  # heavily based on cURL's code for importing system certificates on Windows:
+  # https://github.com/curl/curl/blob/2f17a9b654121dd1ecf4fc043c6d08a9da3522db/lib/vtls/openssl.c#L3015-L3157
+  private def self.each_system_certificate(store_name : String, &)
+    now = ::Time.utc
+
+    return unless cert_store = LibC.CertOpenSystemStoreW(nil, System.to_wstr(store_name))
+
+    cert_context = Pointer(LibC::CERT_CONTEXT).null
+    while cert_context = LibC.CertEnumCertificatesInStore(cert_store, cert_context)
+      next unless cert_context.value.dwCertEncodingType == LibC::X509_ASN_ENCODING
+
+      next if cert_context.value.pbCertEncoded.nil?
+
+      not_before = Crystal::System::Time.from_filetime(cert_context.value.pCertInfo.value.notBefore)
+      not_after = Crystal::System::Time.from_filetime(cert_context.value.pCertInfo.value.notAfter)
+      next unless not_before <= now <= not_after
+
+      # look for the serverAuth OID if extended key usage exists
+      if LibC.CertGetEnhancedKeyUsage(cert_context, 0, nil, out eku_size) != 0
+        eku = Pointer(UInt8).malloc(eku_size).as(LibC::CERT_USAGE*)
+        next unless LibC.CertGetEnhancedKeyUsage(cert_context, 0, eku, pointerof(eku_size)) != 0
+        next unless (0...eku.value.cUsageIdentifier).any? do |i|
+          String.new(eku.value.rgpszUsageIdentifier[i]) == "1.3.6.1.5.5.7.3.1"
+        end
+      end
+
+      encoded = Slice.new(cert_context.value.pbCertEncoded, cert_context.value.cbCertEncoded)
+      until encoded.empty?
+        cert, encoded = OpenSSL::X509::Certificate.from_der(encoded)
+        yield cert
+      end
+    end
+  ensure
+    LibC.CertCloseStore(cert_store, 0) if cert_store
+  end
+
+  private class_getter system_root_certificates : Array(OpenSSL::X509::Certificate) do
+    certs = [] of OpenSSL::X509::Certificate
+    each_system_certificate("ROOT") { |cert| certs << cert }
+    certs
+  end
+
+  def self.populate_system_root_certificates(ssl_context)
+    cert_store = LibSSL.ssl_ctx_get_cert_store(ssl_context)
+    system_root_certificates.each do |cert|
+      LibCrypto.x509_store_add_cert(cert_store, cert)
+    end
+  end
+end

--- a/src/lib_c/x86_64-windows-msvc/c/wincrypt.cr
+++ b/src/lib_c/x86_64-windows-msvc/c/wincrypt.cr
@@ -1,0 +1,83 @@
+require "c/win_def"
+require "c/minwinbase"
+require "c/winnt"
+
+@[Link("crypt32")]
+lib LibC
+  alias HCERTSTORE = Void*
+  alias HCRYPTPROV_LEGACY = Void*
+
+  struct CERT_NAME_BLOB
+    cbData : DWORD
+    pbData : BYTE*
+  end
+
+  struct CRYPT_INTEGER_BLOB
+    cbData : DWORD
+    pbData : BYTE*
+  end
+
+  struct CRYPT_OBJID_BLOB
+    cbData : DWORD
+    pbData : BYTE*
+  end
+
+  struct CRYPT_BIT_BLOB
+    cbData : DWORD
+    pbData : BYTE*
+    cUnusedBits : DWORD
+  end
+
+  struct CRYPT_ALGORITHM_IDENTIFIER
+    pszObjId : LPSTR
+    parameters : CRYPT_OBJID_BLOB
+  end
+
+  struct CERT_PUBLIC_KEY_INFO
+    algorithm : CRYPT_ALGORITHM_IDENTIFIER
+    publicKey : CRYPT_BIT_BLOB
+  end
+
+  struct CERT_EXTENSION
+    pszObjId : LPSTR
+    fCritical : BOOL
+    value : CRYPT_OBJID_BLOB
+  end
+
+  struct CERT_INFO
+    dwVersion : DWORD
+    serialNumber : CRYPT_INTEGER_BLOB
+    signatureAlgorithm : CRYPT_ALGORITHM_IDENTIFIER
+    issuer : CERT_NAME_BLOB
+    notBefore : FILETIME
+    notAfter : FILETIME
+    subject : CERT_NAME_BLOB
+    subjectPublicKeyInfo : CERT_PUBLIC_KEY_INFO
+    issuerUniqueId : CRYPT_BIT_BLOB
+    subjectUniqueId : CRYPT_BIT_BLOB
+    cExtension : DWORD
+    rgExtension : CERT_EXTENSION*
+  end
+
+  struct CERT_USAGE
+    cUsageIdentifier : DWORD
+    rgpszUsageIdentifier : LPSTR*
+  end
+
+  X509_ASN_ENCODING   = 0x00000001
+  PKCS_7_ASN_ENCODING = 0x00010000
+
+  struct CERT_CONTEXT
+    dwCertEncodingType : DWORD
+    pbCertEncoded : BYTE*
+    cbCertEncoded : DWORD
+    pCertInfo : CERT_INFO*
+    hCertStore : HCERTSTORE
+  end
+
+  fun CertOpenSystemStoreW(hProv : HCRYPTPROV_LEGACY, szSubsystemProtocol : LPWSTR) : HCERTSTORE
+  fun CertCloseStore(hCertStore : HCERTSTORE, dwFlags : DWORD) : BOOL
+
+  fun CertEnumCertificatesInStore(hCertStore : HCERTSTORE, pPrevCertContext : CERT_CONTEXT*) : CERT_CONTEXT*
+  fun CertGetEnhancedKeyUsage(pCertContext : CERT_CONTEXT*, dwFlags : DWORD, pUsage : CERT_USAGE*, pcbUsage : DWORD*) : BOOL
+end

--- a/src/openssl/lib_crypto.cr
+++ b/src/openssl/lib_crypto.cr
@@ -48,6 +48,7 @@ lib LibCrypto
   type X509_EXTENSION = Void*
   type X509_NAME = Void*
   type X509_NAME_ENTRY = Void*
+  type X509_STORE = Void*
   type X509_STORE_CTX = Void*
 
   struct Bio
@@ -316,6 +317,7 @@ lib LibCrypto
     fun sk_value(x0 : Void*, x1 : Int) : Void*
   {% end %}
 
+  fun d2i_X509(a : X509*, ppin : UInt8**, length : Long) : X509
   fun x509_dup = X509_dup(a : X509) : X509
   fun x509_free = X509_free(a : X509)
   fun x509_get_subject_name = X509_get_subject_name(a : X509) : X509_NAME
@@ -351,6 +353,8 @@ lib LibCrypto
   fun x509_extension_create_by_nid = X509_EXTENSION_create_by_NID(ex : X509_EXTENSION, nid : Int, crit : Int, data : ASN1_STRING) : X509_EXTENSION
   fun x509v3_ext_nconf_nid = X509V3_EXT_nconf_nid(conf : Void*, ctx : Void*, ext_nid : Int, value : Char*) : X509_EXTENSION
   fun x509v3_ext_print = X509V3_EXT_print(out : Bio*, ext : X509_EXTENSION, flag : Int, indent : Int) : Int
+
+  fun x509_store_add_cert = X509_STORE_add_cert(ctx : X509_STORE, x : X509) : Int
 
   {% unless compare_versions(OPENSSL_VERSION, "1.1.0") >= 0 %}
     fun err_load_crypto_strings = ERR_load_crypto_strings

--- a/src/openssl/lib_ssl.cr
+++ b/src/openssl/lib_ssl.cr
@@ -221,6 +221,7 @@ lib LibSSL
   fun ssl_ctx_get_verify_mode = SSL_CTX_get_verify_mode(ctx : SSLContext) : VerifyMode
   fun ssl_ctx_set_verify = SSL_CTX_set_verify(ctx : SSLContext, mode : VerifyMode, callback : VerifyCallback)
   fun ssl_ctx_set_default_verify_paths = SSL_CTX_set_default_verify_paths(ctx : SSLContext) : Int
+  fun ssl_ctx_get_cert_store = SSL_CTX_get_cert_store(ctx : SSLContext) : LibCrypto::X509_STORE
   fun ssl_ctx_ctrl = SSL_CTX_ctrl(ctx : SSLContext, cmd : Int, larg : ULong, parg : Void*) : ULong
 
   {% if compare_versions(OPENSSL_VERSION, "3.0.0") >= 0 %}

--- a/src/openssl/ssl/context.cr
+++ b/src/openssl/ssl/context.cr
@@ -227,6 +227,8 @@ abstract class OpenSSL::SSL::Context
 
     add_modes(OpenSSL::SSL::Modes.flags(AUTO_RETRY, RELEASE_BUFFERS))
 
+    # OpenSSL does not support reading from the system root certificate store on
+    # Windows, so we have to import them ourselves
     {% if flag?(:win32) %}
       Crystal::System::Crypto.populate_system_root_certificates(self)
     {% end %}

--- a/src/openssl/x509/certificate.cr
+++ b/src/openssl/x509/certificate.cr
@@ -28,13 +28,17 @@ module OpenSSL::X509
       @cert
     end
 
-    # Decodes an ASN.1/DER-encoded certificate from *bytes*. Returns the decoded
-    # certificate and the remaining bytes.
-    def self.from_der(bytes : Bytes) : {self, Bytes}
+    # Attempts to decode an ASN.1/DER-encoded certificate from *bytes*.
+    #
+    # Returns the decoded certificate and the remaining bytes on success.
+    # Returns `nil` and *bytes* unchanged on failure.
+    def self.from_der?(bytes : Bytes) : {self?, Bytes}
       ptr = bytes.to_unsafe
-      x509 = LibCrypto.d2i_X509(nil, pointerof(ptr), bytes.size)
-      raise OpenSSL::Error.new("d2i_X509") unless x509
-      {new(x509), bytes[ptr - bytes.to_unsafe..]}
+      if x509 = LibCrypto.d2i_X509(nil, pointerof(ptr), bytes.size)
+        {new(x509), bytes[ptr - bytes.to_unsafe..]}
+      else
+        {nil, bytes}
+      end
     end
 
     def subject : X509::Name

--- a/src/openssl/x509/certificate.cr
+++ b/src/openssl/x509/certificate.cr
@@ -28,6 +28,15 @@ module OpenSSL::X509
       @cert
     end
 
+    # Decodes an ASN.1/DER-encoded certificate from *bytes*. Returns the decoded
+    # certificate and the remaining bytes.
+    def self.from_der(bytes : Bytes) : {self, Bytes}
+      ptr = bytes.to_unsafe
+      x509 = LibCrypto.d2i_X509(nil, pointerof(ptr), bytes.size)
+      raise OpenSSL::Error.new("d2i_X509") unless x509
+      {new(x509), bytes[ptr - bytes.to_unsafe..]}
+    end
+
     def subject : X509::Name
       subject = LibCrypto.x509_get_subject_name(@cert)
       raise Error.new("X509_get_subject_name") if subject.null?


### PR DESCRIPTION
Resolves #12476. This makes things like `HTTP::Client.get("https://example.com")` work on Windows without any user configuration at all. (The problem technically still exists for non-system certificates, but then non-Windows systems have to face the same problem too.)