### PR TITLE
Update distribution-scripts

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,7 @@ parameters:
   distribution-scripts-version:
     description: "Git ref for version of https://github.com/crystal-lang/distribution-scripts/"
     type: string
-    default: "d8c44c0a2c977bfb90363923047f2c64cef3bf8e"
+    default: "2d85f415fd767f8680b14e94de5c382cb9a03ac1"
   previous_crystal_base_url:
     description: "Prefix for URLs to Crystal bootstrap compiler"
     type: string


### PR DESCRIPTION
Updates `distribution-scripts` dependency to https://github.com/crystal-lang/distribution-scripts/commit/2d85f415fd767f8680b14e94de5c382cb9a03ac1

This includes the following changes:

* crystal-lang/distribution-scripts#219
* crystal-lang/distribution-scripts#223
* crystal-lang/distribution-scripts#222
* crystal-lang/distribution-scripts#218
* crystal-lang/distribution-scripts#216
* crystal-lang/distribution-scripts#215

The important change is crystal-lang/distribution-scripts#219 because we want 1.7 build images to include libpcre2 so that they can be used in CI (see https://github.com/crystal-lang/crystal/pull/13167#issuecomment-1468609324).