### PR TITLE
Fix type names for generic instances with empty splat type vars

### DIFF
--- a/spec/compiler/macro/macro_methods_spec.cr
+++ b/spec/compiler/macro/macro_methods_spec.cr
@@ -1610,6 +1610,55 @@ module Crystal
           end
         end
 
+        describe "generic instance" do
+          it "prints generic type arguments" do
+            assert_macro("{{klass.name}}", "Foo(Int32, 3)") do |program|
+              generic_type = GenericClassType.new(program, program, "Foo", program.reference, ["T", "U"])
+              {klass: TypeNode.new(generic_type.instantiate([program.int32, 3.int32] of TypeVar))}
+            end
+          end
+
+          it "prints empty splat type var" do
+            assert_macro("{{klass.name}}", "Foo()") do |program|
+              generic_type = GenericClassType.new(program, program, "Foo", program.reference, ["T"])
+              generic_type.splat_index = 0
+              {klass: TypeNode.new(generic_type.instantiate([] of TypeVar))}
+            end
+          end
+
+          it "prints multiple arguments for splat type var" do
+            assert_macro("{{klass.name}}", "Foo(Int32, String)") do |program|
+              generic_type = GenericClassType.new(program, program, "Foo", program.reference, ["T"])
+              generic_type.splat_index = 0
+              {klass: TypeNode.new(generic_type.instantiate([program.int32, program.string] of TypeVar))}
+            end
+          end
+
+          it "does not print extra commas for empty splat type var (1)" do
+            assert_macro("{{klass.name}}", "Foo(Int32)") do |program|
+              generic_type = GenericClassType.new(program, program, "Foo", program.reference, ["T", "U"])
+              generic_type.splat_index = 1
+              {klass: TypeNode.new(generic_type.instantiate([program.int32] of TypeVar))}
+            end
+          end
+
+          it "does not print extra commas for empty splat type var (2)" do
+            assert_macro("{{klass.name}}", "Foo(Int32)") do |program|
+              generic_type = GenericClassType.new(program, program, "Foo", program.reference, ["T", "U"])
+              generic_type.splat_index = 0
+              {klass: TypeNode.new(generic_type.instantiate([program.int32] of TypeVar))}
+            end
+          end
+
+          it "does not print extra commas for empty splat type var (3)" do
+            assert_macro("{{klass.name}}", "Foo(Int32, String)") do |program|
+              generic_type = GenericClassType.new(program, program, "Foo", program.reference, ["T", "U", "V"])
+              generic_type.splat_index = 1
+              {klass: TypeNode.new(generic_type.instantiate([program.int32, program.string] of TypeVar))}
+            end
+          end
+        end
+
         describe :generic_args do
           describe true do
             it "includes the generic_args of the type" do

--- a/src/compiler/crystal/types.cr
+++ b/src/compiler/crystal/types.cr
@@ -2072,21 +2072,27 @@ module Crystal
       generic_type.append_full_name(io)
       if generic_args
         io << '('
-        type_vars.each_value.with_index do |type_var, i|
-          io << ", " if i > 0
+        first = true
+        type_vars.each_with_index do |(_, type_var), i|
           if type_var.is_a?(Var)
             if i == splat_index
               tuple = type_var.type.as(TupleInstanceType)
-              tuple.tuple_types.join(io, ", ") do |tuple_type|
+              tuple.tuple_types.each do |tuple_type|
+                io << ", " unless first
+                first = false
                 tuple_type = tuple_type.devirtualize unless codegen
                 tuple_type.to_s_with_options(io, codegen: codegen)
               end
             else
+              io << ", " unless first
+              first = false
               type_var_type = type_var.type
               type_var_type = type_var_type.devirtualize unless codegen
               type_var_type.to_s_with_options(io, skip_union_parens: true, codegen: codegen)
             end
           else
+            io << ", " unless first
+            first = false
             type_var.to_s(io)
           end
         end


### PR DESCRIPTION
Fixes an issue where if a generic type has at least one splat type variable and one non-splat type variable, and a generic instance has zero type arguments corresponding to the splat, that instance's type name includes an extra comma:

```crystal
module Foo(A, *B)
  {% Foo(Int32) %} # => Foo(Int32, )
end

class Bar(*A, B)
  {% Bar(Int32) %} # => Bar(, Int32)
end

class Baz(A, *B, C)
  {% Baz(Int32, String) %} # => Baz(Int32, , String)
end
```

In particular, if the splat is not the last variable of the generic type, the resulting type name is syntactically invalid. This shows up everywhere, from macro interpolations like above to `Class#name` and error messages.