### PR TITLE
Remove pending spec for `Path#drive` with IPv6 UNC host names

### DIFF
--- a/spec/std/path_spec.cr
+++ b/spec/std/path_spec.cr
@@ -409,9 +409,6 @@ describe Path do
     assert_paths("\\\\%10%20\\share\\", nil, "\\\\%10%20\\share", &.drive)
     assert_paths("\\\\_.-~!$;=&'()*+,aB1\\ !-.@^_`{}~#$%&'()aB1\\", nil, "\\\\_.-~!$;=&'()*+,aB1\\ !-.@^_`{}~#$%&'()aB1", &.drive)
     assert_paths("\\\\127.0.0.1\\share\\", nil, "\\\\127.0.0.1\\share", &.drive)
-    pending do
-      assert_paths("\\\\2001:4860:4860::8888\\share\\", nil, "\\\\2001:4860:4860::8888\\share", &.drive)
-    end
   end
 
   describe "#root" do

--- a/src/path.cr
+++ b/src/path.cr
@@ -1213,9 +1213,11 @@ struct Path
     reader.next_char
 
     # 2. Consume first path component
-    # The first component is either an IP address or a hostname.
+    # The first component is either an IPv4 address or a hostname.
+    # IPv6 addresses are converted into hostnames by replacing all `:`s with
+    # `-`s, and then appending `.ipv6-literal.net`, so raw IPv6 addresses cannot
+    # appear here.
     # Hostname follows the grammar of `reg-name` in [RFC 3986](https://datatracker.ietf.org/doc/html/rfc3986).
-    # TODO: Add support for IPv6 address grammar
     return if separators.includes?(reader.current_char)
     while true
       char = reader.current_char


### PR DESCRIPTION
The given `\\2001:4860:4860::8888\share\` is an invalid UNC string, as IPv6 addresses should be represented like `\\2001-4860-4860--8888.ipv6-literal.net\share\` instead. No further action is necessary as `Path` doesn't have methods to convert the UNC host name into a `Socket::IPAddress`, even for the IPv4 case.