### PR TITLE
Add `Socket::IPAddress#link_local?`

### DIFF
--- a/spec/std/socket/address_spec.cr
+++ b/spec/std/socket/address_spec.cr
@@ -184,6 +184,23 @@ describe Socket::IPAddress do
     Socket::IPAddress.new("2001:4860:4860::8888", 0).private?.should be_false
   end
 
+  it "#link_local?" do
+    Socket::IPAddress.new("0.0.0.0", 0).link_local?.should be_false
+    Socket::IPAddress.new("127.0.0.1", 0).link_local?.should be_false
+    Socket::IPAddress.new("10.0.0.0", 0).link_local?.should be_false
+    Socket::IPAddress.new("172.16.0.0", 0).link_local?.should be_false
+    Socket::IPAddress.new("192.168.0.0", 0).link_local?.should be_false
+
+    Socket::IPAddress.new("169.254.1.1", 0).link_local?.should be_true
+    Socket::IPAddress.new("169.254.254.255", 0).link_local?.should be_true
+
+    Socket::IPAddress.new("::1", 0).link_local?.should be_false
+    Socket::IPAddress.new("::", 0).link_local?.should be_false
+    Socket::IPAddress.new("fb84:8bf7:e905::1", 0).link_local?.should be_false
+
+    Socket::IPAddress.new("fe80::4860:4860:4860:1234", 0).link_local?.should be_true
+  end
+
   it "#==" do
     Socket::IPAddress.new("127.0.0.1", 8080).should eq Socket::IPAddress.new("127.0.0.1", 8080)
     Socket::IPAddress.new("127.0.0.1", 8080).hash.should eq Socket::IPAddress.new("127.0.0.1", 8080).hash

--- a/src/socket/address.cr
+++ b/src/socket/address.cr
@@ -252,6 +252,19 @@ class Socket
       end
     end
 
+    # Returns `true` if this IP is a link-local address.
+    #
+    # IPv4 addresses in `169.254.0.0/16` reserved by [RFC 3927](https://www.rfc-editor.org/rfc/rfc3927) and Link-Local IPv6
+    # Unicast Addresses in `fe80::/10` reserved by [RFC 4291](https://tools.ietf.org/html/rfc4291) are considered link-local.
+    def link_local?
+      case addr = @addr
+      in LibC::InAddr
+        addr.s_addr & 0x000000ffff_u32 == 0x0000fea9_u32 # 169.254.0.0/16
+      in LibC::In6Addr
+        ipv6_addr8(addr).unsafe_as(UInt128) & 0xc0ff_u128 == 0x80fe_u128
+      end
+    end
+
     private def ipv6_addr8(addr : LibC::In6Addr)
       {% if flag?(:darwin) || flag?(:bsd) %}
         addr.__u6_addr.__u6_addr8


### PR DESCRIPTION
This PR adds `Socket::IPAddress#link_local?`like [Ruby's](https://github.com/ruby/ruby/blob/c65d7b4bea170ffe4811534ab33b231f7f57d69f/lib/ipaddr.rb#L280-L293)

(the spec examples are also [from Ruby](https://github.com/ruby/ruby/blob/c65d7b4bea170ffe4811534ab33b231f7f57d69f/test/test_ipaddr.rb#L445))

fix partially: #13198