### PR TITLE
Fix `SyntaxHighlighter::HTML` to escape identifier values

### DIFF
--- a/spec/std/crystal/syntax_highlighter/html_spec.cr
+++ b/spec/std/crystal/syntax_highlighter/html_spec.cr
@@ -73,7 +73,7 @@ describe Crystal::SyntaxHighlighter::HTML do
       == < <= > >= != =~ !~
       & | ^ ~ ** >> << %
     ).each do |op|
-      it_highlights %(def #{op}), %(<span class="k">def</span> <span class="m">#{op}</span>)
+      it_highlights %(def #{op}), %(<span class="k">def</span> <span class="m">#{HTML.escape(op)}</span>)
     end
 
     it_highlights %(def //), %(<span class="k">def</span> <span class="m">/</span><span class="m">/</span>)

--- a/src/crystal/syntax_highlighter/html.cr
+++ b/src/crystal/syntax_highlighter/html.cr
@@ -52,7 +52,7 @@ class Crystal::SyntaxHighlighter::HTML < Crystal::SyntaxHighlighter
     when .string?
       span "s" { ::HTML.escape(value, @io) }
     when .ident?
-      span "m", &.print value
+      span "m" { ::HTML.escape(value, @io) }
     when .keyword?, .self?
       span "k", &.print value
     when .primitive_literal?


### PR DESCRIPTION
Identifiers can include special characters (namely `<` and `>`) and thus must be escaped for use in HTML.

This caused CI failures with updated docker build images (https://github.com/crystal-lang/distribution-scripts/pull/231/files) on Ubuntu 22.04 with libxml2 2.9.13. 
https://app.circleci.com/pipelines/github/crystal-lang/crystal/11529/workflows/7fbbce79-346a-4cc3-967a-012367f78779/jobs/75252
