### PR TITLE
Update distribution-scripts

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,7 @@ parameters:
   distribution-scripts-version:
     description: "Git ref for version of https://github.com/crystal-lang/distribution-scripts/"
     type: string
-    default: "dd0ef752b995c04b5e3bf80e474881ba107e4476"
+    default: "5ced0bc13de682688110387adc313fe02f96bab7"
   previous_crystal_base_url:
     description: "Prefix for URLs to Crystal bootstrap compiler"
     type: string


### PR DESCRIPTION
Updates `distribution-scripts` dependency to https://github.com/crystal-lang/distribution-scripts/commit/5ced0bc13de682688110387adc313fe02f96bab7

This includes the following changes:

* crystal-lang/distribution-scripts#235
* crystal-lang/distribution-scripts#232
* crystal-lang/distribution-scripts#231
* crystal-lang/distribution-scripts#230
* crystal-lang/distribution-scripts#227
* crystal-lang/distribution-scripts#225