### PR TITLE
Formatter: Add feature flag for `method_signature_yield`

### DIFF
--- a/spec/compiler/formatter/formatter_spec.cr
+++ b/spec/compiler/formatter/formatter_spec.cr
@@ -1,10 +1,10 @@
 require "spec"
 require "../../../src/compiler/crystal/formatter"
 
-private def assert_format(input, output = input, strict = false, file = __FILE__, line = __LINE__)
+private def assert_format(input, output = input, strict = false, flags = nil, file = __FILE__, line = __LINE__)
   it "formats #{input.inspect}", file, line do
     output = "#{output}\n" unless strict
-    result = Crystal.format(input)
+    result = Crystal.format(input, flags: flags)
     unless result == output
       message = <<-ERROR
         Expected
@@ -553,133 +553,122 @@ describe Crystal::Formatter do
   assert_format "with foo yield bar"
 
   context "adds `&` to yielding methods that don't have a block parameter (#8764)" do
-    assert_format <<-CRYSTAL,
+    assert_format <<-CRYSTAL, <<-CRYSTAL, flags: %w[method_signature_yield]
       def foo
         yield
       end
       CRYSTAL
-      <<-CRYSTAL
       def foo(&)
         yield
       end
       CRYSTAL
 
-    assert_format <<-CRYSTAL,
+    assert_format <<-CRYSTAL, <<-CRYSTAL, flags: %w[method_signature_yield]
       def foo()
         yield
       end
       CRYSTAL
-      <<-CRYSTAL
       def foo(&)
         yield
       end
       CRYSTAL
 
-    assert_format <<-CRYSTAL,
+    assert_format <<-CRYSTAL, <<-CRYSTAL, flags: %w[method_signature_yield]
       def foo(
       )
         yield
       end
       CRYSTAL
-      <<-CRYSTAL
       def foo(&)
         yield
       end
       CRYSTAL
 
     # #13091
-    assert_format <<-CRYSTAL,
+    assert_format <<-CRYSTAL, <<-CRYSTAL, flags: %w[method_signature_yield]
       def foo # bar
         yield
       end
       CRYSTAL
-      <<-CRYSTAL
       def foo(&) # bar
         yield
       end
       CRYSTAL
 
-    assert_format <<-CRYSTAL,
+    assert_format <<-CRYSTAL, <<-CRYSTAL, flags: %w[method_signature_yield]
       def foo(x)
         yield
       end
       CRYSTAL
-      <<-CRYSTAL
       def foo(x, &)
         yield
       end
       CRYSTAL
 
-    assert_format <<-CRYSTAL,
+    assert_format <<-CRYSTAL, <<-CRYSTAL, flags: %w[method_signature_yield]
       def foo(x ,)
         yield
       end
       CRYSTAL
-      <<-CRYSTAL
       def foo(x, &)
         yield
       end
       CRYSTAL
 
-    assert_format <<-CRYSTAL,
+    assert_format <<-CRYSTAL, <<-CRYSTAL, flags: %w[method_signature_yield]
       def foo(x,
       y)
         yield
       end
       CRYSTAL
-      <<-CRYSTAL
       def foo(x,
               y, &)
         yield
       end
       CRYSTAL
 
-    assert_format <<-CRYSTAL,
+    assert_format <<-CRYSTAL, <<-CRYSTAL, flags: %w[method_signature_yield]
       def foo(x,
       y,)
         yield
       end
       CRYSTAL
-      <<-CRYSTAL
       def foo(x,
               y, &)
         yield
       end
       CRYSTAL
 
-    assert_format <<-CRYSTAL,
+    assert_format <<-CRYSTAL, <<-CRYSTAL, flags: %w[method_signature_yield]
       def foo(x
       )
         yield
       end
       CRYSTAL
-      <<-CRYSTAL
       def foo(x,
               &)
         yield
       end
       CRYSTAL
 
-    assert_format <<-CRYSTAL,
+    assert_format <<-CRYSTAL, <<-CRYSTAL, flags: %w[method_signature_yield]
       def foo(x,
       )
         yield
       end
       CRYSTAL
-      <<-CRYSTAL
       def foo(x,
               &)
         yield
       end
       CRYSTAL
 
-    assert_format <<-CRYSTAL,
+    assert_format <<-CRYSTAL, <<-CRYSTAL, flags: %w[method_signature_yield]
       def foo(
       x)
         yield
       end
       CRYSTAL
-      <<-CRYSTAL
       def foo(
         x, &
       )
@@ -687,13 +676,12 @@ describe Crystal::Formatter do
       end
       CRYSTAL
 
-    assert_format <<-CRYSTAL,
+    assert_format <<-CRYSTAL, <<-CRYSTAL, flags: %w[method_signature_yield]
       def foo(
       x, y)
         yield
       end
       CRYSTAL
-      <<-CRYSTAL
       def foo(
         x, y, &
       )
@@ -701,14 +689,13 @@ describe Crystal::Formatter do
       end
       CRYSTAL
 
-    assert_format <<-CRYSTAL,
+    assert_format <<-CRYSTAL, <<-CRYSTAL, flags: %w[method_signature_yield]
       def foo(
       x,
       y)
         yield
       end
       CRYSTAL
-      <<-CRYSTAL
       def foo(
         x,
         y, &
@@ -717,14 +704,13 @@ describe Crystal::Formatter do
       end
       CRYSTAL
 
-    assert_format <<-CRYSTAL,
+    assert_format <<-CRYSTAL, <<-CRYSTAL, flags: %w[method_signature_yield]
       def foo(
       x,
       )
         yield
       end
       CRYSTAL
-      <<-CRYSTAL
       def foo(
         x,
         &
@@ -733,7 +719,155 @@ describe Crystal::Formatter do
       end
       CRYSTAL
 
-    assert_format "macro f\n  yield\n  {{ yield }}\nend"
+    assert_format "macro f\n  yield\n  {{ yield }}\nend", flags: %w[method_signature_yield]
+  end
+
+  context "does not add `&` without flag `method_signature_yield`" do
+    assert_format <<-CRYSTAL
+      def foo
+        yield
+      end
+      CRYSTAL
+
+    assert_format <<-CRYSTAL, <<-CRYSTAL
+      def foo()
+        yield
+      end
+      CRYSTAL
+      def foo
+        yield
+      end
+      CRYSTAL
+
+    assert_format <<-CRYSTAL, <<-CRYSTAL
+      def foo(
+      )
+        yield
+      end
+      CRYSTAL
+      def foo
+        yield
+      end
+      CRYSTAL
+
+    # #13091
+    assert_format <<-CRYSTAL
+      def foo # bar
+        yield
+      end
+      CRYSTAL
+
+    assert_format <<-CRYSTAL
+      def foo(x)
+        yield
+      end
+      CRYSTAL
+
+    assert_format <<-CRYSTAL, <<-CRYSTAL
+      def foo(x ,)
+        yield
+      end
+      CRYSTAL
+      def foo(x)
+        yield
+      end
+      CRYSTAL
+
+    assert_format <<-CRYSTAL
+      def foo(x,
+              y)
+        yield
+      end
+      CRYSTAL
+
+    assert_format <<-CRYSTAL, <<-CRYSTAL
+      def foo(x,
+      y,)
+        yield
+      end
+      CRYSTAL
+      def foo(x,
+              y)
+        yield
+      end
+      CRYSTAL
+
+    assert_format <<-CRYSTAL, <<-CRYSTAL
+      def foo(x
+      )
+        yield
+      end
+      CRYSTAL
+      def foo(x)
+        yield
+      end
+      CRYSTAL
+
+    assert_format <<-CRYSTAL, <<-CRYSTAL
+      def foo(x,
+      )
+        yield
+      end
+      CRYSTAL
+      def foo(x)
+        yield
+      end
+      CRYSTAL
+
+    assert_format <<-CRYSTAL, <<-CRYSTAL
+      def foo(
+      x)
+        yield
+      end
+      CRYSTAL
+      def foo(
+        x
+      )
+        yield
+      end
+      CRYSTAL
+
+    assert_format <<-CRYSTAL, <<-CRYSTAL
+      def foo(
+      x, y)
+        yield
+      end
+      CRYSTAL
+      def foo(
+        x, y
+      )
+        yield
+      end
+      CRYSTAL
+
+    assert_format <<-CRYSTAL, <<-CRYSTAL
+      def foo(
+      x,
+      y)
+        yield
+      end
+      CRYSTAL
+      def foo(
+        x,
+        y
+      )
+        yield
+      end
+      CRYSTAL
+
+    assert_format <<-CRYSTAL, <<-CRYSTAL
+      def foo(
+      x,
+      )
+        yield
+      end
+      CRYSTAL
+      def foo(
+        x
+      )
+        yield
+      end
+      CRYSTAL
   end
 
   assert_format "1   +   2", "1 + 2"

--- a/spec/compiler/formatter/formatter_spec.cr
+++ b/spec/compiler/formatter/formatter_spec.cr
@@ -719,6 +719,16 @@ describe Crystal::Formatter do
       end
       CRYSTAL
 
+    assert_format <<-CRYSTAL, <<-CRYSTAL, flags: %w[method_signature_yield]
+      def foo(a, **b)
+        yield
+      end
+      CRYSTAL
+      def foo(a, **b, &)
+        yield
+      end
+      CRYSTAL
+
     assert_format "macro f\n  yield\n  {{ yield }}\nend", flags: %w[method_signature_yield]
   end
 
@@ -865,6 +875,12 @@ describe Crystal::Formatter do
       def foo(
         x
       )
+        yield
+      end
+      CRYSTAL
+
+    assert_format <<-CRYSTAL
+      def foo(a, **b)
         yield
       end
       CRYSTAL

--- a/src/compiler/crystal/tools/formatter.cr
+++ b/src/compiler/crystal/tools/formatter.cr
@@ -1521,7 +1521,7 @@ module Crystal
     end
 
     def format_def_args(node : Def | Macro)
-      yields = node.is_a?(Def) && !node.block_arity.nil?
+      yields = node.is_a?(Def) && !node.block_arity.nil? && flag?("method_signature_yield")
       format_def_args node.args, node.block_arg, node.splat_index, false, node.double_splat, yields
     end
 
@@ -1559,7 +1559,7 @@ module Crystal
       end
 
       args.each_with_index do |arg, i|
-        has_more = !last?(i, args) || double_splat || block_arg || (yields && flag?("method_signature_yield")) || variadic
+        has_more = !last?(i, args) || double_splat || block_arg || yields || variadic
         wrote_newline = format_def_arg(wrote_newline, has_more) do
           if i == splat_index
             write_token :OP_STAR

--- a/src/compiler/crystal/tools/formatter.cr
+++ b/src/compiler/crystal/tools/formatter.cr
@@ -1595,7 +1595,7 @@ module Crystal
         end
       elsif yields
         wrote_newline = format_def_arg(wrote_newline, false) do
-          write "&" if flag?("method_signature_yield")
+          write "&"
           skip_space_or_newline
         end
       end


### PR DESCRIPTION
Adds support for feature flags in the formatter. So far, this is only exposed in the internal API and not the CLI.
This allows us to merge formatter changes into master without enabling them in the compiler tool yet, for the purpose of bundling multiple changes into a single release as discussed in #13002.

The only feature flag so far is `method_signature_yield` which guards the behaviour introduced in #12951 that adds a `&` to yielding methods' signatures.
As a result, this behaviour is now *disabled* in `crystal tool format` per https://github.com/crystal-lang/crystal/issues/13002#issuecomment-1476117344
Specs ensure proper formatter behaviour with and without the flag.