### PR TITLE
Remove `__declspec(dllimport)` from Windows libiconv build

### DIFF
--- a/.github/workflows/win.yml
+++ b/.github/workflows/win.yml
@@ -96,6 +96,8 @@ jobs:
         if: steps.cache-libs.outputs.cache-hit != 'true'
         working-directory: ./libiconv
         run: |
+          sed -i 's|__declspec (dllimport) ||' libiconv\include\iconv.h
+
           echo '<Project>
             <PropertyGroup>
               <ForceImportAfterCppTargets>$(MsbuildThisFileDirectory)\Override.props</ForceImportAfterCppTargets>


### PR DESCRIPTION
The libiconv static library we build for our Windows packages apparently tries to import `libiconv_version` from the libiconv DLL, so almost every program built on Windows behaves like a DLL that depends on libiconv, producing messages similar to the following during compilation:

```
Creating library C:\Users\runneradmin\AppData\Local\crystal\cache\D-a-crystal-crystal-src-ecr-process.cr\macro_run.lib and object C:\Users\runneradmin\AppData\Local\crystal\cache\D-a-crystal-crystal-src-ecr-process.cr\macro_run.exp
Creating library D:\a\crystal\crystal\.build\crystal-next.lib and object D:\a\crystal\crystal\.build\crystal-next.exp
```

This PR fixes it by removing [this hardcoded `__declspec(dllimport)`](https://github.com/pffang/libiconv-for-Windows/blob/1353455a6c4e15c9db6865fd9c2bf7203b59c0ec/libiconv/include/iconv.h#L32) added when that third-party repository upgraded libiconv from 1.16 to 1.17, introduced via #12745. (This `__declspec` is never a good idea in the first place because MSVC would warn about conflicting keywords when building a libiconv DLL.)