### PR TITLE
Drop privileges in chroot spec

### DIFF
--- a/spec/std/process_spec.cr
+++ b/spec/std/process_spec.cr
@@ -428,6 +428,12 @@ describe Process do
     {% if flag?(:unix) && !flag?(:android) %}
       it "raises when unprivileged" do
         status, output, _ = compile_and_run_source <<-'CRYSTAL'
+          # Try to drop privileges. Ignoring any errors because dropping is only
+          # necessary for a privileged user and it doesn't matter when it fails
+          # for an unprivileged one.
+          # This particular UID is often attributed to the `nobody` user.
+          LibC.setuid(65534)
+
           begin
             Process.chroot(".")
             puts "FAIL"

--- a/src/lib_c/aarch64-android/c/unistd.cr
+++ b/src/lib_c/aarch64-android/c/unistd.cr
@@ -30,6 +30,7 @@ lib LibC
   fun getpid : PidT
   fun getppid : PidT
   fun getuid : UidT
+  fun setuid(uid : UidT) : Int
   fun isatty(__fd : Int) : Int
   fun ttyname_r(__fd : Int, __buf : Char*, __buf_size : SizeT) : Int
   fun lchown(__path : Char*, __owner : UidT, __group : GidT) : Int

--- a/src/lib_c/aarch64-darwin/c/unistd.cr
+++ b/src/lib_c/aarch64-darwin/c/unistd.cr
@@ -30,6 +30,7 @@ lib LibC
   fun getpid : PidT
   fun getppid : PidT
   fun getuid : UidT
+  fun setuid(uid : UidT) : Int
   fun isatty(x0 : Int) : Int
   fun ttyname_r(fd : Int, buf : Char*, buffersize : SizeT) : Int
   fun lchown(x0 : Char*, x1 : UidT, x2 : GidT) : Int

--- a/src/lib_c/aarch64-linux-gnu/c/unistd.cr
+++ b/src/lib_c/aarch64-linux-gnu/c/unistd.cr
@@ -30,6 +30,7 @@ lib LibC
   fun getpid : PidT
   fun getppid : PidT
   fun getuid : UidT
+  fun setuid(uid : UidT) : Int
   fun isatty(fd : Int) : Int
   fun ttyname_r(fd : Int, buf : Char*, buffersize : SizeT) : Int
   fun lchown(file : Char*, owner : UidT, group : GidT) : Int

--- a/src/lib_c/aarch64-linux-musl/c/unistd.cr
+++ b/src/lib_c/aarch64-linux-musl/c/unistd.cr
@@ -30,6 +30,7 @@ lib LibC
   fun getpid : PidT
   fun getppid : PidT
   fun getuid : UidT
+  fun setuid(uid : UidT) : Int
   fun isatty(x0 : Int) : Int
   fun ttyname_r(fd : Int, buf : Char*, buffersize : SizeT) : Int
   fun lchown(x0 : Char*, x1 : UidT, x2 : GidT) : Int

--- a/src/lib_c/arm-linux-gnueabihf/c/unistd.cr
+++ b/src/lib_c/arm-linux-gnueabihf/c/unistd.cr
@@ -30,6 +30,7 @@ lib LibC
   fun getpid : PidT
   fun getppid : PidT
   fun getuid : UidT
+  fun setuid(uid : UidT) : Int
   fun isatty(fd : Int) : Int
   fun ttyname_r(fd : Int, buf : Char*, buffersize : SizeT) : Int
   fun lchown(file : Char*, owner : UidT, group : GidT) : Int

--- a/src/lib_c/i386-linux-gnu/c/unistd.cr
+++ b/src/lib_c/i386-linux-gnu/c/unistd.cr
@@ -30,6 +30,7 @@ lib LibC
   fun getpid : PidT
   fun getppid : PidT
   fun getuid : UidT
+  fun setuid(uid : UidT) : Int
   fun isatty(fd : Int) : Int
   fun ttyname_r(fd : Int, buf : Char*, buffersize : SizeT) : Int
   fun lchown(file : Char*, owner : UidT, group : GidT) : Int

--- a/src/lib_c/i386-linux-musl/c/unistd.cr
+++ b/src/lib_c/i386-linux-musl/c/unistd.cr
@@ -30,6 +30,7 @@ lib LibC
   fun getpid : PidT
   fun getppid : PidT
   fun getuid : UidT
+  fun setuid(uid : UidT) : Int
   fun isatty(x0 : Int) : Int
   fun ttyname_r(fd : Int, buf : Char*, buffersize : SizeT) : Int
   fun lchown(x0 : Char*, x1 : UidT, x2 : GidT) : Int

--- a/src/lib_c/x86_64-darwin/c/unistd.cr
+++ b/src/lib_c/x86_64-darwin/c/unistd.cr
@@ -30,6 +30,7 @@ lib LibC
   fun getpid : PidT
   fun getppid : PidT
   fun getuid : UidT
+  fun setuid(uid : UidT) : Int
   fun isatty(x0 : Int) : Int
   fun ttyname_r(fd : Int, buf : Char*, buffersize : SizeT) : Int
   fun lchown(x0 : Char*, x1 : UidT, x2 : GidT) : Int

--- a/src/lib_c/x86_64-dragonfly/c/unistd.cr
+++ b/src/lib_c/x86_64-dragonfly/c/unistd.cr
@@ -28,6 +28,7 @@ lib LibC
   fun getpid : PidT
   fun getppid : PidT
   fun getuid : UidT
+  fun setuid(uid : UidT) : Int
   fun isatty(x0 : Int) : Int
   fun ttyname_r(fd : Int, buf : Char*, buffersize : SizeT) : Int
   fun lchown(x0 : Char*, x1 : UidT, x2 : GidT) : Int

--- a/src/lib_c/x86_64-freebsd/c/unistd.cr
+++ b/src/lib_c/x86_64-freebsd/c/unistd.cr
@@ -29,6 +29,7 @@ lib LibC
   fun getpid : PidT
   fun getppid : PidT
   fun getuid : UidT
+  fun setuid(uid : UidT) : Int
   fun isatty(x0 : Int) : Int
   fun ttyname_r(fd : Int, buf : Char*, buffersize : SizeT) : Int
   fun lchown(x0 : Char*, x1 : UidT, x2 : GidT) : Int

--- a/src/lib_c/x86_64-linux-gnu/c/unistd.cr
+++ b/src/lib_c/x86_64-linux-gnu/c/unistd.cr
@@ -30,6 +30,7 @@ lib LibC
   fun getpid : PidT
   fun getppid : PidT
   fun getuid : UidT
+  fun setuid(uid : UidT) : Int
   fun isatty(fd : Int) : Int
   fun ttyname_r(fd : Int, buf : Char*, buffersize : SizeT) : Int
   fun lchown(file : Char*, owner : UidT, group : GidT) : Int

--- a/src/lib_c/x86_64-linux-musl/c/unistd.cr
+++ b/src/lib_c/x86_64-linux-musl/c/unistd.cr
@@ -30,6 +30,7 @@ lib LibC
   fun getpid : PidT
   fun getppid : PidT
   fun getuid : UidT
+  fun setuid(uid : UidT) : Int
   fun isatty(x0 : Int) : Int
   fun ttyname_r(fd : Int, buf : Char*, buffersize : SizeT) : Int
   fun lchown(x0 : Char*, x1 : UidT, x2 : GidT) : Int

--- a/src/lib_c/x86_64-netbsd/c/unistd.cr
+++ b/src/lib_c/x86_64-netbsd/c/unistd.cr
@@ -29,6 +29,7 @@ lib LibC
   fun getpid : PidT
   fun getppid : PidT
   fun getuid : UidT
+  fun setuid(uid : UidT) : Int
   fun isatty(x0 : Int) : Int
   fun ttyname_r(fd : Int, buf : Char*, buffersize : SizeT) : Int
   fun lchown = __posix_lchown(x0 : Char*, x1 : UidT, x2 : GidT) : Int

--- a/src/lib_c/x86_64-openbsd/c/unistd.cr
+++ b/src/lib_c/x86_64-openbsd/c/unistd.cr
@@ -29,6 +29,7 @@ lib LibC
   fun getpid : PidT
   fun getppid : PidT
   fun getuid : UidT
+  fun setuid(uid : UidT) : Int
   fun isatty(x0 : Int) : Int
   fun ttyname_r(fd : Int, buf : Char*, buffersize : SizeT) : Int
   fun lchown(x0 : Char*, x1 : UidT, x2 : GidT) : Int


### PR DESCRIPTION
With this patch, `process_spec` succeeds when run as superuser (ref https://github.com/crystal-lang/crystal/issues/13217#issuecomment-1481924359).