### PR TITLE
Skip eacces spec for superuser

### DIFF
--- a/spec/std/file_spec.cr
+++ b/spec/std/file_spec.cr
@@ -867,7 +867,15 @@ describe "File" do
   pending_win32 "raises when reading a file with no permission" do
     with_tempfile("file.txt") do |path|
       File.touch(path)
-      File.chmod(path, 0)
+      File.chmod(path, File::Permissions::None)
+      {% if flag?(:unix) %}
+        # TODO: Find a better way to execute this spec when running as privileged
+        # user. Compiling a program and running a separate process would be a
+        # lot of overhead.
+        if LibC.getuid == 0
+          pending! "Spec cannot run as superuser"
+        end
+      {% end %}
       expect_raises(File::AccessDeniedError) { File.read(path) }
     end
   end


### PR DESCRIPTION
With this patch, `file_spec` succeeds when run as superuser (ref #13217).

The intent is identical to #13226 but this expectation runs in the main spec process, so doing the same privilege drop is not an option. It would be possible to run the spec in a separate process, but that's very inefficient. It's easier to just skip it when running as superuser. This makes the spec work and we can try to find a better solution later.