### PR TITLE
Suppress compiler output in `compile_file` spec helper

### DIFF
--- a/spec/std/spec_helper.cr
+++ b/spec/std/spec_helper.cr
@@ -78,11 +78,18 @@ end
 def compile_file(source_file, *, bin_name = "executable_file", flags = %w(), file = __FILE__, &)
   with_temp_executable(bin_name, file: file) do |executable_file|
     compiler = ENV["CRYSTAL_SPEC_COMPILER_BIN"]? || "bin/crystal"
-    Process.run(compiler, ["build"] + flags + ["-o", executable_file, source_file], env: {
+    args = ["build"] + flags + ["-o", executable_file, source_file]
+    output = IO::Memory.new
+    status = Process.run(compiler, args, env: {
       "CRYSTAL_PATH"         => Crystal::PATH,
       "CRYSTAL_LIBRARY_PATH" => Crystal::LIBRARY_PATH,
       "CRYSTAL_CACHE_DIR"    => Crystal::CACHE_DIR,
-    }, error: Process::Redirect::Inherit)
+    }, output: output, error: output)
+
+    unless status.success?
+      fail "Compiler command `#{compiler} #{args.join(" ")}` failed with status #{status}.#{"\n" if output}#{output}"
+    end
+
     File.exists?(executable_file).should be_true
 
     yield executable_file


### PR DESCRIPTION
This patch removes the `Using compiled compiler at .build/crystal` messages spattered in the spec output because stderr was inherited. Now the stderr and stdout of the compiler process are captured and only printed in case of a failure.
