### PR TITLE
Fix `Enum#includes?` to require all bits set

### DIFF
--- a/spec/std/enum_spec.cr
+++ b/spec/std/enum_spec.cr
@@ -144,6 +144,12 @@ describe Enum do
   it "does includes?" do
     (SpecEnumFlags::One | SpecEnumFlags::Two).includes?(SpecEnumFlags::One).should be_true
     (SpecEnumFlags::One | SpecEnumFlags::Two).includes?(SpecEnumFlags::Three).should be_false
+    SpecEnumFlags::One.includes?(SpecEnumFlags::None).should be_true
+    SpecEnumFlags::None.includes?(SpecEnumFlags::None).should be_true
+    SpecEnumFlags::None.includes?(SpecEnumFlags::One).should be_false
+    SpecEnumFlags::One.includes?(SpecEnumFlags::One | SpecEnumFlags::Two).should be_false
+    (SpecEnumFlags::One | SpecEnumFlags::Two).includes?(SpecEnumFlags::One | SpecEnumFlags::Two).should be_true
+    (SpecEnumFlags::One | SpecEnumFlags::Two | SpecEnumFlags::Three).includes?(SpecEnumFlags::One | SpecEnumFlags::Two).should be_true
   end
 
   describe "each" do

--- a/src/enum.cr
+++ b/src/enum.cr
@@ -337,20 +337,9 @@ struct Enum
   end
 
   # Returns `true` if this enum member's value includes *other*. This
-  # performs a logical "and" between this enum member's value and *other*'s,
-  # so instead of writing:
+  # performs a logical "and" between this enum member's value and *other*'s.
   #
-  # ```
-  # (member & value) != 0
-  # ```
-  #
-  # you can write:
-  #
-  # ```
-  # member.includes?(value)
-  # ```
-  #
-  # The above is mostly useful with flag enums.
+  # This is mostly useful for flag enums.
   #
   # For example:
   #
@@ -360,7 +349,7 @@ struct Enum
   # mode.includes?(IOMode::Async) # => false
   # ```
   def includes?(other : self) : Bool
-    (value & other.value) != 0
+    value.bits_set?(other.value)
   end
 
   # Returns `true` if this enum member and *other* have the same underlying value.
@@ -390,7 +379,7 @@ struct Enum
     {% if @type.annotation(Flags) %}
       return if value == 0
       {% for member in @type.constants %}
-        {% if member.stringify != "All" %}
+        {% if member.stringify != "All" && member.stringify != "None" %}
           if includes?(self.class.new({{@type.constant(member)}}))
             yield self.class.new({{@type.constant(member)}}), {{@type.constant(member)}}
           end


### PR DESCRIPTION
The implementation of `Enum#includes?` is too lax and returns true if any common bit is set (https://github.com/crystal-lang/crystal/issues/13160#issuecomment-1457988313). This patch checks that all bits are set.

@HertzDevil Suggested this might need to be merged together with #13160, but I would see it as fix that makes sense on its own. We can pool them together, but I don't think it's strictly necessary...?

The behaviour of `None` may need some explanation. The current implementation always returns `false` when the parameter is `None` (even for `None.includes?(None)`). Some code may depend on this quirk, including the implementation of `Enum.each` (hence this needed to be fixed as well).
I wouldn't expect much code to be affected and it's probably best to apply this change regardless. It is a bug and fixing it may have a small chance of breaking someone's code.