### PR TITLE
Fix JSON, YAML `use_*_discriminator` for recursive struct types

### DIFF
--- a/spec/std/json/serializable_spec.cr
+++ b/spec/std/json/serializable_spec.cr
@@ -426,6 +426,23 @@ end
 class JSONVariableDiscriminatorEnum8 < JSONVariableDiscriminatorValueType
 end
 
+class JSONStrictDiscriminator
+  include JSON::Serializable
+  include JSON::Serializable::Strict
+
+  property type : String
+
+  use_json_discriminator "type", {foo: JSONStrictDiscriminatorFoo, bar: JSONStrictDiscriminatorBar}
+end
+
+class JSONStrictDiscriminatorFoo < JSONStrictDiscriminator
+end
+
+class JSONStrictDiscriminatorBar < JSONStrictDiscriminator
+  property x : JSONStrictDiscriminator
+  property y : JSONStrictDiscriminator
+end
+
 module JSONNamespace
   struct FooRequest
     include JSON::Serializable
@@ -1070,6 +1087,16 @@ describe "JSON mapping" do
 
       object_enum = JSONVariableDiscriminatorValueType.from_json(%({"type": 18}))
       object_enum.should be_a(JSONVariableDiscriminatorEnum8)
+    end
+
+    it "deserializes with discriminator, strict recursive type" do
+      foo = JSONStrictDiscriminator.from_json(%({"type": "foo"}))
+      foo = foo.should be_a(JSONStrictDiscriminatorFoo)
+
+      bar = JSONStrictDiscriminator.from_json(%({"type": "bar", "x": {"type": "foo"}, "y": {"type": "foo"}}))
+      bar = bar.should be_a(JSONStrictDiscriminatorBar)
+      bar.x.should be_a(JSONStrictDiscriminatorFoo)
+      bar.y.should be_a(JSONStrictDiscriminatorFoo)
     end
   end
 

--- a/spec/std/yaml/serializable_spec.cr
+++ b/spec/std/yaml/serializable_spec.cr
@@ -381,6 +381,23 @@ end
 class YAMLVariableDiscriminatorEnum8 < YAMLVariableDiscriminatorValueType
 end
 
+class YAMLStrictDiscriminator
+  include YAML::Serializable
+  include YAML::Serializable::Strict
+
+  property type : String
+
+  use_yaml_discriminator "type", {foo: YAMLStrictDiscriminatorFoo, bar: YAMLStrictDiscriminatorBar}
+end
+
+class YAMLStrictDiscriminatorFoo < YAMLStrictDiscriminator
+end
+
+class YAMLStrictDiscriminatorBar < YAMLStrictDiscriminator
+  property x : YAMLStrictDiscriminator
+  property y : YAMLStrictDiscriminator
+end
+
 describe "YAML::Serializable" do
   it "works with record" do
     YAMLAttrPoint.new(1, 2).to_yaml.should eq "---\nx: 1\ny: 2\n"
@@ -971,6 +988,16 @@ describe "YAML::Serializable" do
 
       object_enum = YAMLVariableDiscriminatorValueType.from_yaml(%({"type": 18}))
       object_enum.should be_a(YAMLVariableDiscriminatorEnum8)
+    end
+
+    it "deserializes with discriminator, strict recursive type" do
+      foo = YAMLStrictDiscriminator.from_yaml(%({"type": "foo"}))
+      foo = foo.should be_a(YAMLStrictDiscriminatorFoo)
+
+      bar = YAMLStrictDiscriminator.from_yaml(%({"type": "bar", "x": {"type": "foo"}, "y": {"type": "foo"}}))
+      bar = bar.should be_a(YAMLStrictDiscriminatorBar)
+      bar.x.should be_a(YAMLStrictDiscriminatorFoo)
+      bar.y.should be_a(YAMLStrictDiscriminatorFoo)
     end
   end
 

--- a/src/json/serialization.cr
+++ b/src/json/serialization.cr
@@ -200,7 +200,7 @@ module JSON
         {% end %}
 
         {% for name, value in properties %}
-          %var{name} = nil
+          %var{name} = {% if value[:has_default] || value[:nilable] %} nil {% else %} uninitialized {{value[:type]}} {% end %}
           %found{name} = false
         {% end %}
 
@@ -216,26 +216,24 @@ module JSON
           case key
           {% for name, value in properties %}
             when {{value[:key]}}
-              %found{name} = true
               begin
-                %var{name} =
-                  {% if value[:nilable] || value[:has_default] %} pull.read_null_or { {% end %}
+                {% if value[:has_default] || value[:nilable] %} pull.read_null_or do {% else %} begin {% end %}
+                  %var{name} =
+                    {% if value[:root] %}
+                      pull.on_key!({{value[:root]}}) do
+                    {% end %}
 
-                  {% if value[:root] %}
-                    pull.on_key!({{value[:root]}}) do
-                  {% end %}
+                    {% if value[:converter] %}
+                      {{value[:converter]}}.from_json(pull)
+                    {% else %}
+                      ::Union({{value[:type]}}).new(pull)
+                    {% end %}
 
-                  {% if value[:converter] %}
-                    {{value[:converter]}}.from_json(pull)
-                  {% else %}
-                    ::Union({{value[:type]}}).new(pull)
-                  {% end %}
-
-                  {% if value[:root] %}
-                    end
-                  {% end %}
-
-                {% if value[:nilable] || value[:has_default] %} } {% end %}
+                    {% if value[:root] %}
+                      end
+                    {% end %}
+                end
+                %found{name} = true
               rescue exc : ::JSON::ParseException
                 raise ::JSON::SerializableError.new(exc.message, self.class.to_s, {{value[:key]}}, *%key_location, exc)
               end
@@ -248,7 +246,7 @@ module JSON
 
         {% for name, value in properties %}
           {% unless value[:nilable] || value[:has_default] %}
-            if %var{name}.nil? && !%found{name} && !::Union({{value[:type]}}).nilable?
+            if !%found{name}
               raise ::JSON::SerializableError.new("Missing JSON attribute: {{value[:key].id}}", self.class.to_s, nil, *%location, nil)
             end
           {% end %}
@@ -264,7 +262,7 @@ module JSON
               @{{name}} = %var{name}
             end
           {% else %}
-            @{{name}} = (%var{name}).as({{value[:type]}})
+            @{{name}} = %var{name}
           {% end %}
 
           {% if value[:presence] %}

--- a/src/json/serialization.cr
+++ b/src/json/serialization.cr
@@ -219,19 +219,13 @@ module JSON
               begin
                 {% if value[:has_default] || value[:nilable] %} pull.read_null_or do {% else %} begin {% end %}
                   %var{name} =
-                    {% if value[:root] %}
-                      pull.on_key!({{value[:root]}}) do
-                    {% end %}
-
-                    {% if value[:converter] %}
-                      {{value[:converter]}}.from_json(pull)
-                    {% else %}
-                      ::Union({{value[:type]}}).new(pull)
-                    {% end %}
-
-                    {% if value[:root] %}
-                      end
-                    {% end %}
+                    {% if value[:root] %} pull.on_key!({{value[:root]}}) do {% else %} begin {% end %}
+                      {% if value[:converter] %}
+                        {{value[:converter]}}.from_json(pull)
+                      {% else %}
+                        ::Union({{value[:type]}}).new(pull)
+                      {% end %}
+                    end
                 end
                 %found{name} = true
               rescue exc : ::JSON::ParseException

--- a/src/json/serialization.cr
+++ b/src/json/serialization.cr
@@ -200,7 +200,7 @@ module JSON
         {% end %}
 
         {% for name, value in properties %}
-          %var{name} = {% if value[:has_default] || value[:nilable] %} nil {% else %} uninitialized {{value[:type]}} {% end %}
+          %var{name} = {% if value[:has_default] || value[:nilable] %} nil {% else %} uninitialized ::Union({{value[:type]}}) {% end %}
           %found{name} = false
         {% end %}
 

--- a/src/yaml/serialization.cr
+++ b/src/yaml/serialization.cr
@@ -205,7 +205,7 @@ module YAML
         {% end %}
 
         {% for name, value in properties %}
-          %var{name} = nil
+          %var{name} = {% if value[:has_default] || value[:nilable] %} nil {% else %} uninitialized {{value[:type]}} {% end %}
           %found{name} = false
         {% end %}
 
@@ -221,20 +221,19 @@ module YAML
             case key
             {% for name, value in properties %}
               when {{value[:key]}}
-                %found{name} = true
                 begin
-                  %var{name} =
-                    {% if value[:nilable] || value[:has_default] %} YAML::Schema::Core.parse_null_or(value_node) { {% end %}
+                  {% if value[:has_default] && !value[:nilable] %} YAML::Schema::Core.parse_null_or(value_node) do {% else %} begin {% end %}
+                    %var{name} =
+                      {% if value[:converter] %}
+                        {{value[:converter]}}.from_yaml(ctx, value_node)
+                      {% elsif value[:type].is_a?(Path) || value[:type].is_a?(Generic) %}
+                        {{value[:type]}}.new(ctx, value_node)
+                      {% else %}
+                        ::Union({{value[:type]}}).new(ctx, value_node)
+                      {% end %}
+                  end
 
-                    {% if value[:converter] %}
-                      {{value[:converter]}}.from_yaml(ctx, value_node)
-                    {% elsif value[:type].is_a?(Path) || value[:type].is_a?(Generic) %}
-                      {{value[:type]}}.new(ctx, value_node)
-                    {% else %}
-                      ::Union({{value[:type]}}).new(ctx, value_node)
-                    {% end %}
-
-                  {% if value[:nilable] || value[:has_default] %} } {% end %}
+                  %found{name} = true
                 end
             {% end %}
             else
@@ -253,7 +252,7 @@ module YAML
 
         {% for name, value in properties %}
           {% unless value[:nilable] || value[:has_default] %}
-            if %var{name}.nil? && !%found{name} && !::Union({{value[:type]}}).nilable?
+            if !%found{name}
               node.raise "Missing YAML attribute: {{value[:key].id}}"
             end
           {% end %}
@@ -269,7 +268,7 @@ module YAML
               @{{name}} = %var{name}
             end
           {% else %}
-            @{{name}} = (%var{name}).as({{value[:type]}})
+            @{{name}} = %var{name}
           {% end %}
 
           {% if value[:presence] %}

--- a/src/yaml/serialization.cr
+++ b/src/yaml/serialization.cr
@@ -205,7 +205,7 @@ module YAML
         {% end %}
 
         {% for name, value in properties %}
-          %var{name} = {% if value[:has_default] || value[:nilable] %} nil {% else %} uninitialized {{value[:type]}} {% end %}
+          %var{name} = {% if value[:has_default] || value[:nilable] %} nil {% else %} uninitialized ::Union({{value[:type]}}) {% end %}
           %found{name} = false
         {% end %}
 


### PR DESCRIPTION
Fixes #13214. This makes sure the temporary variables are not nilable for properties that aren't nilable and have no default values, since otherwise it seems the deserialization method recursively calls itself and breaks type inference.

This was discovered for JSON but applies to YAML as well.