### PR TITLE
Fix: LibC definition for sys/socket.h (*-linux-gnu targets)

### DIFF
--- a/src/lib_c/i386-linux-gnu/c/sys/socket.cr
+++ b/src/lib_c/i386-linux-gnu/c/sys/socket.cr
@@ -54,10 +54,10 @@ lib LibC
   fun getsockname(fd : Int, addr : Sockaddr*, len : SocklenT*) : Int
   fun getsockopt(fd : Int, level : Int, optname : Int, optval : Void*, optlen : SocklenT*) : Int
   fun listen(fd : Int, n : Int) : Int
-  fun recv(fd : Int, buf : Void*, n : Int, flags : Int) : SSizeT
-  fun recvfrom(fd : Int, buf : Void*, n : Int, flags : Int, addr : Sockaddr*, addr_len : SocklenT*) : SSizeT
-  fun send(fd : Int, buf : Void*, n : Int, flags : Int) : SSizeT
-  fun sendto(fd : Int, buf : Void*, n : Int, flags : Int, addr : Sockaddr*, addr_len : SocklenT) : SSizeT
+  fun recv(fd : Int, buf : Void*, n : SizeT, flags : Int) : SSizeT
+  fun recvfrom(fd : Int, buf : Void*, n : SizeT, flags : Int, addr : Sockaddr*, addr_len : SocklenT*) : SSizeT
+  fun send(fd : Int, buf : Void*, n : SizeT, flags : Int) : SSizeT
+  fun sendto(fd : Int, buf : Void*, n : SizeT, flags : Int, addr : Sockaddr*, addr_len : SocklenT) : SSizeT
   fun setsockopt(fd : Int, level : Int, optname : Int, optval : Void*, optlen : SocklenT) : Int
   fun shutdown(fd : Int, how : Int) : Int
   fun socket(domain : Int, type : Int, protocol : Int) : Int

--- a/src/lib_c/x86_64-linux-gnu/c/sys/socket.cr
+++ b/src/lib_c/x86_64-linux-gnu/c/sys/socket.cr
@@ -54,10 +54,10 @@ lib LibC
   fun getsockname(fd : Int, addr : Sockaddr*, len : SocklenT*) : Int
   fun getsockopt(fd : Int, level : Int, optname : Int, optval : Void*, optlen : SocklenT*) : Int
   fun listen(fd : Int, n : Int) : Int
-  fun recv(fd : Int, buf : Void*, n : Int, flags : Int) : SSizeT
-  fun recvfrom(fd : Int, buf : Void*, n : Int, flags : Int, addr : Sockaddr*, addr_len : SocklenT*) : SSizeT
-  fun send(fd : Int, buf : Void*, n : Int, flags : Int) : SSizeT
-  fun sendto(fd : Int, buf : Void*, n : Int, flags : Int, addr : Sockaddr*, addr_len : SocklenT) : SSizeT
+  fun recv(fd : Int, buf : Void*, n : SizeT, flags : Int) : SSizeT
+  fun recvfrom(fd : Int, buf : Void*, n : SizeT, flags : Int, addr : Sockaddr*, addr_len : SocklenT*) : SSizeT
+  fun send(fd : Int, buf : Void*, n : SizeT, flags : Int) : SSizeT
+  fun sendto(fd : Int, buf : Void*, n : SizeT, flags : Int, addr : Sockaddr*, addr_len : SocklenT) : SSizeT
   fun setsockopt(fd : Int, level : Int, optname : Int, optval : Void*, optlen : SocklenT) : Int
   fun shutdown(fd : Int, how : Int) : Int
   fun socket(domain : Int, type : Int, protocol : Int) : Int


### PR DESCRIPTION
I introduced a buggy LibC definition of `sys/socket.h` in December 2016 (see 56dec2147ea3ed43766b91aa7f7c8659a34959cb) that was only recently noticed (#12982) and identified (https://github.com/crystal-lang/crystal/issues/12982#issuecomment-1487945565).

I'm amazed it went undetected for 6 years.

closes #12982 