### PR TITLE
Add `Regex::MatchOptions`

### DIFF
--- a/spec/compiler/parser/parser_spec.cr
+++ b/spec/compiler/parser/parser_spec.cr
@@ -1,6 +1,6 @@
 require "../../support/syntax"
 
-private def regex(string, options = Regex::Options::None)
+private def regex(string, options = Regex::CompileOptions::None)
   RegexLiteral.new(StringLiteral.new(string), options)
 end
 
@@ -1197,10 +1197,10 @@ module Crystal
     it_parses "1.!(\n)", Not.new(1.int32)
 
     it_parses "/foo/", regex("foo")
-    it_parses "/foo/i", regex("foo", Regex::Options::IGNORE_CASE)
-    it_parses "/foo/m", regex("foo", Regex::Options::MULTILINE)
-    it_parses "/foo/x", regex("foo", Regex::Options::EXTENDED)
-    it_parses "/foo/imximx", regex("foo", Regex::Options::IGNORE_CASE | Regex::Options::MULTILINE | Regex::Options::EXTENDED)
+    it_parses "/foo/i", regex("foo", Regex::CompileOptions::IGNORE_CASE)
+    it_parses "/foo/m", regex("foo", Regex::CompileOptions::MULTILINE)
+    it_parses "/foo/x", regex("foo", Regex::CompileOptions::EXTENDED)
+    it_parses "/foo/imximx", regex("foo", Regex::CompileOptions::IGNORE_CASE | Regex::CompileOptions::MULTILINE | Regex::CompileOptions::EXTENDED)
     it_parses "/fo\\so/", regex("fo\\so")
     it_parses "/fo\#{1}o/", RegexLiteral.new(StringInterpolation.new(["fo".string, 1.int32, "o".string] of ASTNode))
     it_parses "/(fo\#{\"bar\"}\#{1}o)/", RegexLiteral.new(StringInterpolation.new(["(fo".string, "bar".string, 1.int32, "o)".string] of ASTNode))

--- a/spec/std/regex_spec.cr
+++ b/spec/std/regex_spec.cr
@@ -90,9 +90,16 @@ describe "Regex" do
       end
     end
 
-    it "with options" do
-      /foo/.match(".foo", options: Regex::Options::ANCHORED).should be_nil
-      /foo/.match("foo", options: Regex::Options::ANCHORED).should_not be_nil
+    context "with options" do
+      it "deprecated Regex::Options" do
+        /foo/.match(".foo", options: Regex::Options::ANCHORED).should be_nil
+        /foo/.match("foo", options: Regex::Options::ANCHORED).should_not be_nil
+      end
+
+      it "Regex::Match options" do
+        /foo/.match(".foo", options: Regex::MatchOptions::ANCHORED).should be_nil
+        /foo/.match("foo", options: Regex::MatchOptions::ANCHORED).should_not be_nil
+      end
     end
   end
 
@@ -141,9 +148,16 @@ describe "Regex" do
       /foo/.match_at_byte_index("..foo", -2).should be_nil
     end
 
-    it "with options" do
-      /foo/.match_at_byte_index("..foo", 1, options: Regex::Options::ANCHORED).should be_nil
-      /foo/.match_at_byte_index(".foo", 1, options: Regex::Options::ANCHORED).should_not be_nil
+    context "with options" do
+      it "deprecated Regex::Options" do
+        /foo/.match_at_byte_index("..foo", 1, options: Regex::Options::ANCHORED).should be_nil
+        /foo/.match_at_byte_index(".foo", 1, options: Regex::Options::ANCHORED).should_not be_nil
+      end
+
+      it "Regex::MatchOptions" do
+        /foo/.match_at_byte_index("..foo", 1, options: Regex::MatchOptions::ANCHORED).should be_nil
+        /foo/.match_at_byte_index(".foo", 1, options: Regex::MatchOptions::ANCHORED).should_not be_nil
+      end
     end
   end
 
@@ -211,9 +225,16 @@ describe "Regex" do
       end
     end
 
-    it "with options" do
-      /foo/.matches?(".foo", options: Regex::Options::ANCHORED).should be_false
-      /foo/.matches?("foo", options: Regex::Options::ANCHORED).should be_true
+    context "with options" do
+      it "deprecated Regex::Options" do
+        /foo/.matches?(".foo", options: Regex::Options::ANCHORED).should be_false
+        /foo/.matches?("foo", options: Regex::Options::ANCHORED).should be_true
+      end
+
+      it "Regex::MatchOptions" do
+        /foo/.matches?(".foo", options: Regex::MatchOptions::ANCHORED).should be_false
+        /foo/.matches?("foo", options: Regex::MatchOptions::ANCHORED).should be_true
+      end
     end
 
     it "doesn't crash with a large single line string" do
@@ -257,9 +278,16 @@ describe "Regex" do
       /foo/.matches_at_byte_index?("..foo", -2).should be_false
     end
 
-    it "with options" do
-      /foo/.matches_at_byte_index?("..foo", 1, options: Regex::Options::ANCHORED).should be_false
-      /foo/.matches_at_byte_index?(".foo", 1, options: Regex::Options::ANCHORED).should be_true
+    context "with options" do
+      it "deprecated Regex::Options" do
+        /foo/.matches_at_byte_index?("..foo", 1, options: Regex::Options::ANCHORED).should be_false
+        /foo/.matches_at_byte_index?(".foo", 1, options: Regex::Options::ANCHORED).should be_true
+      end
+
+      it "Regex::MatchOptions" do
+        /foo/.matches_at_byte_index?("..foo", 1, options: Regex::MatchOptions::ANCHORED).should be_false
+        /foo/.matches_at_byte_index?(".foo", 1, options: Regex::MatchOptions::ANCHORED).should be_true
+      end
     end
   end
 

--- a/spec/std/regex_spec.cr
+++ b/spec/std/regex_spec.cr
@@ -12,15 +12,15 @@ describe "Regex" do
 
     describe "options" do
       it "regular" do
-        Regex.new("", Regex::Options::ANCHORED).options.anchored?.should be_true
+        Regex.new("", Regex::CompileOptions::ANCHORED).options.anchored?.should be_true
       end
 
       it "unnamed option" do
         {% if Regex::Engine.resolve.name == "Regex::PCRE" %}
-          Regex.new("^/foo$", Regex::Options.new(0x00000020)).matches?("/foo\n").should be_false
+          Regex.new("^/foo$", Regex::CompileOptions.new(0x00000020)).matches?("/foo\n").should be_false
         {% else %}
           expect_raises ArgumentError, "Unknown Regex::Option value: 64" do
-            Regex.new("", Regex::Options.new(0x00000040))
+            Regex.new("", Regex::CompileOptions.new(0x00000040))
           end
         {% end %}
       end
@@ -200,8 +200,8 @@ describe "Regex" do
       end
 
       it "anchored" do
-        Regex.new("foo", Regex::Options::ANCHORED).matches?("foo").should be_true
-        Regex.new("foo", Regex::Options::ANCHORED).matches?(".foo").should be_false
+        Regex.new("foo", Regex::CompileOptions::ANCHORED).matches?("foo").should be_true
+        Regex.new("foo", Regex::CompileOptions::ANCHORED).matches?(".foo").should be_false
       end
     end
 
@@ -391,18 +391,18 @@ describe "Regex" do
   end
 
   it "#==" do
-    regex = Regex.new("foo", Regex::Options::IGNORE_CASE)
-    (regex == Regex.new("foo", Regex::Options::IGNORE_CASE)).should be_true
+    regex = Regex.new("foo", Regex::CompileOptions::IGNORE_CASE)
+    (regex == Regex.new("foo", Regex::CompileOptions::IGNORE_CASE)).should be_true
     (regex == Regex.new("foo")).should be_false
-    (regex == Regex.new("bar", Regex::Options::IGNORE_CASE)).should be_false
+    (regex == Regex.new("bar", Regex::CompileOptions::IGNORE_CASE)).should be_false
     (regex == Regex.new("bar")).should be_false
   end
 
   it "#hash" do
-    hash = Regex.new("foo", Regex::Options::IGNORE_CASE).hash
-    hash.should eq(Regex.new("foo", Regex::Options::IGNORE_CASE).hash)
+    hash = Regex.new("foo", Regex::CompileOptions::IGNORE_CASE).hash
+    hash.should eq(Regex.new("foo", Regex::CompileOptions::IGNORE_CASE).hash)
     hash.should_not eq(Regex.new("foo").hash)
-    hash.should_not eq(Regex.new("bar", Regex::Options::IGNORE_CASE).hash)
+    hash.should_not eq(Regex.new("bar", Regex::CompileOptions::IGNORE_CASE).hash)
     hash.should_not eq(Regex.new("bar").hash)
   end
 

--- a/src/compiler/crystal/semantic/literal_expander.cr
+++ b/src/compiler/crystal/semantic/literal_expander.cr
@@ -1,7 +1,7 @@
 module Crystal
   class LiteralExpander
     def initialize(@program : Program)
-      @regexes = [] of {String, Regex::Options}
+      @regexes = [] of {String, Regex::CompileOptions}
     end
 
     # Converts an array literal to creating an Array and storing the values:

--- a/src/compiler/crystal/syntax/ast.cr
+++ b/src/compiler/crystal/syntax/ast.cr
@@ -518,9 +518,9 @@ module Crystal
 
   class RegexLiteral < ASTNode
     property value : ASTNode
-    property options : Regex::Options
+    property options : Regex::CompileOptions
 
-    def initialize(@value, @options = Regex::Options::None)
+    def initialize(@value, @options = Regex::CompileOptions::None)
     end
 
     def accept_children(visitor)

--- a/src/compiler/crystal/syntax/parser.cr
+++ b/src/compiler/crystal/syntax/parser.cr
@@ -2134,7 +2134,7 @@ module Crystal
     end
 
     def consume_delimiter(pieces, delimiter_state, has_interpolation)
-      options = Regex::Options::None
+      options = Regex::CompileOptions::None
       token_end_location = nil
       while true
         case @token.type
@@ -2194,17 +2194,17 @@ module Crystal
     end
 
     def consume_regex_options
-      options = Regex::Options::None
+      options = Regex::CompileOptions::None
       while true
         case current_char
         when 'i'
-          options |= Regex::Options::IGNORE_CASE
+          options |= Regex::CompileOptions::IGNORE_CASE
           next_char
         when 'm'
-          options |= Regex::Options::MULTILINE
+          options |= Regex::CompileOptions::MULTILINE
           next_char
         when 'x'
-          options |= Regex::Options::EXTENDED
+          options |= Regex::CompileOptions::EXTENDED
           next_char
         else
           if 'a' <= current_char.downcase <= 'z'

--- a/src/compiler/crystal/syntax/to_s.cr
+++ b/src/compiler/crystal/syntax/to_s.cr
@@ -994,9 +994,9 @@ module Crystal
         end
         @str << '/'
       end
-      @str << 'i' if node.options.includes? Regex::Options::IGNORE_CASE
-      @str << 'm' if node.options.includes? Regex::Options::MULTILINE
-      @str << 'x' if node.options.includes? Regex::Options::EXTENDED
+      @str << 'i' if node.options.ignore_case?
+      @str << 'm' if node.options.multiline?
+      @str << 'x' if node.options.extended?
       false
     end
 

--- a/src/regex.cr
+++ b/src/regex.cr
@@ -207,6 +207,10 @@ class Regex
     '=', '!', '<', '>', '|', ':', '-',
   }
 
+  # Represents compile options passed to `Regex.new`.
+  #
+  # This type is intended to be renamed to `CompileOptions`. Please use that
+  # name.
   @[Flags]
   enum Options : UInt64
     # Case insensitive match.
@@ -231,7 +235,7 @@ class Regex
     # Ignore white space and `#` comments.
     EXTENDED = 0x0000_0008
 
-    # Force pattern anchoring.
+    # Force pattern anchoring at the start of the subject.
     ANCHORED = 0x0000_0010
 
     DOLLAR_ENDONLY = 0x0000_0020
@@ -246,14 +250,40 @@ class Regex
     # :nodoc:
     UCP = 0x2000_0000
 
+    # Force pattern anchoring at the end of the subject.
+    #
+    # Unsupported with PCRE.
     ENDANCHORED = 0x8000_0000
+
+    # Disable JIT engine.
+    #
+    # Unsupported with PCRE.
     NO_JIT
   end
 
-  # Returns a `Regex::Options` representing the optional flags applied to this `Regex`.
+  alias CompileOptions = Options
+
+  # Represents options passed to regex match methods such as `Regex#match`.
+  @[Flags]
+  enum MatchOptions
+    # Force pattern anchoring at the start of the subject.
+    ANCHORED
+
+    # Force pattern anchoring at the end of the subject.
+    #
+    # Unsupported with PCRE.
+    ENDANCHORED
+
+    # Disable JIT engine.
+    #
+    # Unsupported with PCRE.
+    NO_JIT
+  end
+
+  # Returns a `Regex::CompileOptions` representing the optional flags applied to this `Regex`.
   #
   # ```
-  # /ab+c/ix.options      # => Regex::Options::IGNORE_CASE | Regex::Options::EXTENDED
+  # /ab+c/ix.options      # => Regex::CompileOptions::IGNORE_CASE | Regex::CompileOptions::EXTENDED
   # /ab+c/ix.options.to_s # => "IGNORE_CASE | EXTENDED"
   # ```
   getter options : Options
@@ -268,9 +298,9 @@ class Regex
   # Creates a new `Regex` out of the given source `String`.
   #
   # ```
-  # Regex.new("^a-z+:\\s+\\w+")                   # => /^a-z+:\s+\w+/
-  # Regex.new("cat", Regex::Options::IGNORE_CASE) # => /cat/i
-  # options = Regex::Options::IGNORE_CASE | Regex::Options::EXTENDED
+  # Regex.new("^a-z+:\\s+\\w+")                          # => /^a-z+:\s+\w+/
+  # Regex.new("cat", Regex::CompileOptions::IGNORE_CASE) # => /cat/i
+  # options = Regex::CompileOptions::IGNORE_CASE | Regex::CompileOptions::EXTENDED
   # Regex.new("dog", options) # => /dog/ix
   # ```
   def self.new(source : String, options : Options = Options::None)
@@ -475,12 +505,28 @@ class Regex
   # /(.)(.)/.match("abc", 1).try &.[2]   # => "c"
   # /(.)(.)/.match("クリスタル", 3).try &.[2] # => "ル"
   # ```
-  def match(str, pos = 0, options = Regex::Options::None) : MatchData?
+  def match(str, pos = 0, options : Regex::MatchOptions = Regex::MatchOptions::None) : MatchData?
     if byte_index = str.char_index_to_byte_index(pos)
       $~ = match_at_byte_index(str, byte_index, options)
     else
       $~ = nil
     end
+  end
+
+  # :ditto:
+  @[Deprecated("Use the overload with `Regex::MatchOptions` instead.")]
+  def match(str, pos = 0, *, options) : MatchData?
+    if byte_index = str.char_index_to_byte_index(pos)
+      $~ = match_at_byte_index(str, byte_index, options)
+    else
+      $~ = nil
+    end
+  end
+
+  # :ditto:
+  @[Deprecated("Use the overload with `Regex::MatchOptions` instead.")]
+  def match(str, pos, _options) : MatchData?
+    match(str, pos, options: _options)
   end
 
   # Match at byte index. Matches a regular expression against `String`
@@ -493,12 +539,28 @@ class Regex
   # /(.)(.)/.match_at_byte_index("abc", 1).try &.[2]   # => "c"
   # /(.)(.)/.match_at_byte_index("クリスタル", 3).try &.[2] # => "ス"
   # ```
-  def match_at_byte_index(str, byte_index = 0, options = Regex::Options::None) : MatchData?
+  def match_at_byte_index(str, byte_index = 0, options : Regex::MatchOptions = Regex::MatchOptions::None) : MatchData?
     if byte_index > str.bytesize
       $~ = nil
     else
       $~ = match_impl(str, byte_index, options)
     end
+  end
+
+  # :ditto:
+  @[Deprecated("Use the overload with `Regex::MatchOptions` instead.")]
+  def match_at_byte_index(str, byte_index = 0, *, options) : MatchData?
+    if byte_index > str.bytesize
+      $~ = nil
+    else
+      $~ = match_impl(str, byte_index, options)
+    end
+  end
+
+  # :ditto:
+  @[Deprecated("Use the overload with `Regex::MatchOptions` instead.")]
+  def match_at_byte_index(str, byte_index, _options) : MatchData?
+    match_at_byte_index(str, byte_index, options: _options)
   end
 
   # Match at character index. It behaves like `#match`, however it returns `Bool` value.
@@ -511,7 +573,7 @@ class Regex
   # # `$~` is not set even if last match succeeds.
   # $~ # raises Exception
   # ```
-  def matches?(str, pos = 0, options = Regex::Options::None) : Bool
+  def matches?(str, pos = 0, options : Regex::MatchOptions = Regex::MatchOptions::None) : Bool
     if byte_index = str.char_index_to_byte_index(pos)
       matches_at_byte_index?(str, byte_index, options)
     else
@@ -519,12 +581,42 @@ class Regex
     end
   end
 
+  # :ditto:
+  @[Deprecated("Use the overload with `Regex::MatchOptions` instead.")]
+  def matches?(str, pos = 0, *, options) : Bool
+    if byte_index = str.char_index_to_byte_index(pos)
+      matches_at_byte_index?(str, byte_index, options)
+    else
+      false
+    end
+  end
+
+  # :ditto:
+  @[Deprecated("Use the overload with `Regex::MatchOptions` instead.")]
+  def matches?(str, pos, _options) : Bool
+    matches?(str, pos, options: _options)
+  end
+
   # Match at byte index. It behaves like `#match_at_byte_index`, however it returns `Bool` value.
   # It neither returns `MatchData` nor assigns it to the `$~` variable.
-  def matches_at_byte_index?(str, byte_index = 0, options = Regex::Options::None) : Bool
+  def matches_at_byte_index?(str, byte_index = 0, options : Regex::MatchOptions = Regex::MatchOptions::None) : Bool
     return false if byte_index > str.bytesize
 
     matches_impl(str, byte_index, options)
+  end
+
+  # :ditto:
+  @[Deprecated("Use the overload with `Regex::MatchOptions` instead.")]
+  def matches_at_byte_index?(str, byte_index = 0, *, options) : Bool
+    return false if byte_index > str.bytesize
+
+    matches_impl(str, byte_index, options)
+  end
+
+  # :ditto:
+  @[Deprecated("Use the overload with `Regex::MatchOptions` instead.")]
+  def matches_at_byte_index?(str, byte_index, _options) : Bool
+    matches_at_byte_index?(str, byte_index, options: _options)
   end
 
   # Returns a `Hash` where the values are the names of capture groups and the

--- a/src/regex.cr
+++ b/src/regex.cr
@@ -500,7 +500,7 @@ class Regex
   # /(.)(.)/.match("abc", 1).try &.[2]   # => "c"
   # /(.)(.)/.match("クリスタル", 3).try &.[2] # => "ル"
   # ```
-  def match(str, pos = 0, options : Regex::MatchOptions = Regex::MatchOptions::None) : MatchData?
+  def match(str : String, pos : Int32 = 0, options : Regex::MatchOptions = :none) : MatchData?
     if byte_index = str.char_index_to_byte_index(pos)
       $~ = match_at_byte_index(str, byte_index, options)
     else
@@ -534,7 +534,7 @@ class Regex
   # /(.)(.)/.match_at_byte_index("abc", 1).try &.[2]   # => "c"
   # /(.)(.)/.match_at_byte_index("クリスタル", 3).try &.[2] # => "ス"
   # ```
-  def match_at_byte_index(str, byte_index = 0, options : Regex::MatchOptions = Regex::MatchOptions::None) : MatchData?
+  def match_at_byte_index(str : String, byte_index : Int32 = 0, options : Regex::MatchOptions = :none) : MatchData?
     if byte_index > str.bytesize
       $~ = nil
     else
@@ -568,7 +568,7 @@ class Regex
   # # `$~` is not set even if last match succeeds.
   # $~ # raises Exception
   # ```
-  def matches?(str, pos = 0, options : Regex::MatchOptions = Regex::MatchOptions::None) : Bool
+  def matches?(str : String, pos : Int32 = 0, options : Regex::MatchOptions = :none) : Bool
     if byte_index = str.char_index_to_byte_index(pos)
       matches_at_byte_index?(str, byte_index, options)
     else
@@ -594,7 +594,7 @@ class Regex
 
   # Match at byte index. It behaves like `#match_at_byte_index`, however it returns `Bool` value.
   # It neither returns `MatchData` nor assigns it to the `$~` variable.
-  def matches_at_byte_index?(str, byte_index = 0, options : Regex::MatchOptions = Regex::MatchOptions::None) : Bool
+  def matches_at_byte_index?(str : String, byte_index : Int32 = 0, options : Regex::MatchOptions = :none) : Bool
     return false if byte_index > str.bytesize
 
     matches_impl(str, byte_index, options)

--- a/src/regex.cr
+++ b/src/regex.cr
@@ -256,6 +256,9 @@ class Regex
     ENDANCHORED = 0x8000_0000
   end
 
+  # Represents compile options passed to `Regex.new`.
+  #
+  # This alias is supposed to replace `Options`.
   alias CompileOptions = Options
 
   # Represents options passed to regex match methods such as `Regex#match`.

--- a/src/regex.cr
+++ b/src/regex.cr
@@ -254,11 +254,6 @@ class Regex
     #
     # Unsupported with PCRE.
     ENDANCHORED = 0x8000_0000
-
-    # Disable JIT engine.
-    #
-    # Unsupported with PCRE.
-    NO_JIT
   end
 
   alias CompileOptions = Options

--- a/src/regex/pcre.cr
+++ b/src/regex/pcre.cr
@@ -21,7 +21,7 @@ module Regex::PCRE
 
   private def pcre_compile_options(options)
     flag = 0
-    Regex::Options.each do |option|
+    Regex::CompileOptions.each do |option|
       if options.includes?(option)
         flag |= case option
                 when .ignore_case?    then LibPCRE::CASELESS

--- a/src/regex/pcre.cr
+++ b/src/regex/pcre.cr
@@ -81,6 +81,27 @@ module Regex::PCRE
     flag
   end
 
+  private def pcre_match_options(options : Regex::MatchOptions)
+    flag = 0
+    Regex::MatchOptions.each do |option|
+      if options.includes?(option)
+        flag |= case option
+                when .anchored?    then LibPCRE::ANCHORED
+                when .endanchored? then raise ArgumentError.new("Regex::Option::ENDANCHORED is not supported with PCRE")
+                when .no_jit?      then raise ArgumentError.new("Regex::Option::NO_JIT is not supported with PCRE")
+                else
+                  raise "unreachable"
+                end
+        options &= ~option
+      end
+    end
+
+    # Unnamed values are explicitly used PCRE options, just pass them through:
+    flag |= options.value
+
+    flag
+  end
+
   def finalize
     LibPCRE.free_study @extra
     {% unless flag?(:interpreted) %}

--- a/src/regex/pcre.cr
+++ b/src/regex/pcre.cr
@@ -36,7 +36,6 @@ module Regex::PCRE
                 when .dupnames?       then LibPCRE::DUPNAMES
                 when .ucp?            then LibPCRE::UCP
                 when .endanchored?    then raise ArgumentError.new("Regex::Option::ENDANCHORED is not supported with PCRE")
-                when .no_jit?         then raise ArgumentError.new("Invalid regex option NO_JIT for `pcre_compile`")
                 else
                   raise "unreachable"
                 end
@@ -67,7 +66,6 @@ module Regex::PCRE
                 when .dupnames?       then raise ArgumentError.new("Invalid regex option DUPNAMES for `pcre_exec`")
                 when .ucp?            then raise ArgumentError.new("Invalid regex option UCP for `pcre_exec`")
                 when .endanchored?    then raise ArgumentError.new("Regex::Option::ENDANCHORED is not supported with PCRE")
-                when .no_jit?         then raise ArgumentError.new("Regex::Option::NO_JIT is not supported with PCRE")
                 else
                   raise "unreachable"
                 end

--- a/src/regex/pcre2.cr
+++ b/src/regex/pcre2.cr
@@ -101,6 +101,26 @@ module Regex::PCRE2
     flag
   end
 
+  private def pcre2_match_options(options : Regex::MatchOptions)
+    flag = 0
+    Regex::MatchOptions.each do |option|
+      if options.includes?(option)
+        flag |= case option
+                when .anchored?    then LibPCRE2::ANCHORED
+                when .endanchored? then LibPCRE2::ENDANCHORED
+                when .no_jit?      then LibPCRE2::NO_JIT
+                else
+                  raise "unreachable"
+                end
+        options &= ~option
+      end
+    end
+    unless options.none?
+      raise ArgumentError.new("Unknown Regex::MatchOption value: #{options}")
+    end
+    flag
+  end
+
   def finalize
     {% unless flag?(:interpreted) %}
       LibPCRE2.code_free @re

--- a/src/regex/pcre2.cr
+++ b/src/regex/pcre2.cr
@@ -43,7 +43,7 @@ module Regex::PCRE2
 
   private def pcre2_compile_options(options)
     flag = 0
-    Regex::Options.each do |option|
+    Regex::CompileOptions.each do |option|
       if options.includes?(option)
         flag |= case option
                 when .ignore_case?    then LibPCRE2::CASELESS

--- a/src/regex/pcre2.cr
+++ b/src/regex/pcre2.cr
@@ -58,7 +58,6 @@ module Regex::PCRE2
                 when .dupnames?       then LibPCRE2::DUPNAMES
                 when .ucp?            then LibPCRE2::UCP
                 when .endanchored?    then LibPCRE2::ENDANCHORED
-                when .no_jit?         then raise ArgumentError.new("Invalid regex option NO_JIT for `pcre2_compile`")
                 else
                   raise "unreachable"
                 end
@@ -88,7 +87,6 @@ module Regex::PCRE2
                 when .dupnames?       then raise ArgumentError.new("Invalid regex option DUPNAMES for `pcre2_match`")
                 when .ucp?            then raise ArgumentError.new("Invalid regex option UCP for `pcre2_match`")
                 when .endanchored?    then LibPCRE2::ENDANCHORED
-                when .no_jit?         then LibPCRE2::NO_JIT
                 else
                   raise "unreachable"
                 end

--- a/src/string.cr
+++ b/src/string.cr
@@ -5012,7 +5012,7 @@ class String
   # "hh22".starts_with?(/[a-z]{2}/) # => true
   # ```
   def starts_with?(re : Regex) : Bool
-    !!($~ = re.match_at_byte_index(self, 0, Regex::Options::ANCHORED))
+    !!($~ = re.match_at_byte_index(self, 0, Regex::MatchOptions::ANCHORED))
   end
 
   # Returns `true` if this string ends with the given *str*.

--- a/src/string_scanner.cr
+++ b/src/string_scanner.cr
@@ -92,7 +92,7 @@ class StringScanner
   # s.scan(/.*/)    # => ""
   # ```
   def scan(pattern) : String?
-    match(pattern, advance: true, options: Regex::Options::ANCHORED)
+    match(pattern, advance: true, options: Regex::MatchOptions::ANCHORED)
   end
 
   # Scans the string _until_ the *pattern* is matched. Returns the substring up
@@ -108,10 +108,10 @@ class StringScanner
   # s.scan_until(/g/)  # => "ing"
   # ```
   def scan_until(pattern) : String?
-    match(pattern, advance: true, options: Regex::Options::None)
+    match(pattern, advance: true, options: Regex::MatchOptions::None)
   end
 
-  private def match(pattern, advance = true, options = Regex::Options::ANCHORED)
+  private def match(pattern, advance = true, options = Regex::MatchOptions::ANCHORED)
     match = pattern.match_at_byte_index(@str, @byte_offset, options)
     @last_match = match
     if match
@@ -167,7 +167,7 @@ class StringScanner
   # s.check(/\w+/) # => "is"
   # ```
   def check(pattern) : String?
-    match(pattern, advance: false, options: Regex::Options::ANCHORED)
+    match(pattern, advance: false, options: Regex::MatchOptions::ANCHORED)
   end
 
   # Returns the value that `#scan_until` would return, without advancing the
@@ -181,7 +181,7 @@ class StringScanner
   # s.check_until(/g/)  # => "test string"
   # ```
   def check_until(pattern) : String?
-    match(pattern, advance: false, options: Regex::Options::None)
+    match(pattern, advance: false, options: Regex::MatchOptions::None)
   end
 
   # Returns the *n*-th subgroup in the most recent match.


### PR DESCRIPTION
Adds a dedicated type for options passed to regex match methods.
The overload accepting `Regex::Options` is deprecated.

`Regex::Options` should be renamed to `Regex::CompileOptions` for clarity, but that would be a breaking change if someone opened the type to add custom methods. So `CompileOptions` is only added as an alias.

Goes on top of  #13223

