### PR TITLE
Makefile: Add `interpreter_spec`

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -136,7 +136,7 @@ jobs:
         run: bin/ci prepare_build
 
       - name: Test interpreter
-        run: bin/ci with_build_env 'make deps && bin/crystal build -o interpreter_spec spec/compiler/interpreter_spec.cr && ./interpreter_spec'
+        run: bin/ci with_build_env 'make interpreter_spec'
 
       - name: Build interpreter
         run: bin/ci with_build_env 'make interpreter=1 release=1'

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -37,4 +37,4 @@ jobs:
         run: bin/ci build
 
       - name: Test interpreter
-        run: bin/ci with_build_env 'bin/crystal spec --order=random spec/compiler/interpreter_spec.cr'
+        run: bin/ci with_build_env 'make interpreter_spec'

--- a/Makefile
+++ b/Makefile
@@ -102,6 +102,10 @@ compiler_spec: $(O)/compiler_spec ## Run compiler specs
 primitives_spec: $(O)/primitives_spec ## Run primitives specs
 	$(O)/primitives_spec $(SPEC_FLAGS)
 
+.PHONY: interpreter_spec
+interpreter_spec: $(O)/interpreter_spec ## Run interpreter specs
+	$(O)/interpreter_spec $(SPEC_FLAGS)
+
 .PHONY: smoke_test
 smoke_test: ## Build specs as a smoke test
 smoke_test: $(O)/std_spec $(O)/compiler_spec $(O)/crystal
@@ -193,6 +197,11 @@ $(O)/compiler_spec: $(DEPS) $(SOURCES) $(SPEC_SOURCES)
 $(O)/primitives_spec: $(O)/crystal $(DEPS) $(SOURCES) $(SPEC_SOURCES)
 	@mkdir -p $(O)
 	$(EXPORT_CC) ./bin/crystal build $(FLAGS) $(SPEC_WARNINGS_OFF) -o $@ spec/primitives_spec.cr
+
+$(O)/interpreter_spec: $(SOURCES) $(SPEC_SOURCES)
+	$(eval interpreter=1)
+	@mkdir -p $(O)
+	$(EXPORT_CC) ./bin/crystal build $(FLAGS) $(SPEC_WARNINGS_OFF) -o $@ spec/compiler/interpreter_spec.cr
 
 $(O)/crystal: $(DEPS) $(SOURCES)
 	$(call check_llvm_config)

--- a/Makefile
+++ b/Makefile
@@ -198,7 +198,7 @@ $(O)/primitives_spec: $(O)/crystal $(DEPS) $(SOURCES) $(SPEC_SOURCES)
 	@mkdir -p $(O)
 	$(EXPORT_CC) ./bin/crystal build $(FLAGS) $(SPEC_WARNINGS_OFF) -o $@ spec/primitives_spec.cr
 
-$(O)/interpreter_spec: $(SOURCES) $(SPEC_SOURCES)
+$(O)/interpreter_spec: deps $(SOURCES) $(SPEC_SOURCES)
 	$(eval interpreter=1)
 	@mkdir -p $(O)
 	$(EXPORT_CC) ./bin/crystal build $(FLAGS) $(SPEC_WARNINGS_OFF) -o $@ spec/compiler/interpreter_spec.cr

--- a/Makefile.win
+++ b/Makefile.win
@@ -104,6 +104,10 @@ compiler_spec: $(O)\compiler_spec.exe ## Run compiler specs
 primitives_spec: $(O)\primitives_spec.exe ## Run primitives specs
 	$(O)\primitives_spec $(SPEC_FLAGS)
 
+.PHONY: interpreter_spec
+interpreter_spec: $(O)\interpreter_spec ## Run interpreter specs
+	$(O)\interpreter_spec $(SPEC_FLAGS)
+
 .PHONY: smoke_test
 smoke_test: ## Build specs as a smoke test
 smoke_test: $(O)\std_spec.exe $(O)\compiler_spec.exe $(O)\crystal.exe
@@ -184,6 +188,11 @@ $(O)\compiler_spec.exe: $(DEPS) $(SOURCES) $(SPEC_SOURCES)
 $(O)\primitives_spec.exe: $(O)\crystal.exe $(DEPS) $(SOURCES) $(SPEC_SOURCES)
 	@$(call MKDIR,"$(O)")
 	.\bin\crystal build $(FLAGS) $(SPEC_WARNINGS_OFF) -o "$@" spec\primitives_spec.cr
+
+$(O)/interpreter_spec: $(SOURCES) $(SPEC_SOURCES)
+	$(eval interpreter=1)
+	@$(call MKDIR, "$(O)")
+	.\bin\crystal build $(FLAGS) $(SPEC_WARNINGS_OFF) -o $@ spec\compiler\interpreter_spec.cr
 
 $(O)\crystal.exe: $(DEPS) $(SOURCES) $(O)\crystal.res
 	$(call check_llvm_config)

--- a/Makefile.win
+++ b/Makefile.win
@@ -189,7 +189,7 @@ $(O)\primitives_spec.exe: $(O)\crystal.exe $(DEPS) $(SOURCES) $(SPEC_SOURCES)
 	@$(call MKDIR,"$(O)")
 	.\bin\crystal build $(FLAGS) $(SPEC_WARNINGS_OFF) -o "$@" spec\primitives_spec.cr
 
-$(O)/interpreter_spec: $(SOURCES) $(SPEC_SOURCES)
+$(O)\interpreter_spec: $(SOURCES) $(SPEC_SOURCES)
 	$(eval interpreter=1)
 	@$(call MKDIR, "$(O)")
 	.\bin\crystal build $(FLAGS) $(SPEC_WARNINGS_OFF) -o $@ spec\compiler\interpreter_spec.cr

--- a/Makefile.win
+++ b/Makefile.win
@@ -189,7 +189,7 @@ $(O)\primitives_spec.exe: $(O)\crystal.exe $(DEPS) $(SOURCES) $(SPEC_SOURCES)
 	@$(call MKDIR,"$(O)")
 	.\bin\crystal build $(FLAGS) $(SPEC_WARNINGS_OFF) -o "$@" spec\primitives_spec.cr
 
-$(O)\interpreter_spec: $(SOURCES) $(SPEC_SOURCES)
+$(O)\interpreter_spec: deps $(SOURCES) $(SPEC_SOURCES)
 	$(eval interpreter=1)
 	@$(call MKDIR, "$(O)")
 	.\bin\crystal build $(FLAGS) $(SPEC_WARNINGS_OFF) -o $@ spec\compiler\interpreter_spec.cr


### PR DESCRIPTION
Standardizes the execution of `interpreter_spec` in a Makefile recipe similar to the the other spec suites.