### PR TITLE
Add specs for regex literal expansion

### DIFF
--- a/spec/compiler/normalize/regex_spec.cr
+++ b/spec/compiler/normalize/regex_spec.cr
@@ -1,0 +1,31 @@
+require "../../spec_helper"
+
+describe "Normalize: regex literal" do
+  describe "options" do
+    it "empty" do
+      assert_expand %q(/#{"".to_s}/), <<-'CRYSTAL'
+      ::Regex.new("#{"".to_s}", ::Regex::Options.new(0))
+      CRYSTAL
+    end
+    it "i" do
+      assert_expand %q(/#{"".to_s}/i), <<-'CRYSTAL'
+      ::Regex.new("#{"".to_s}", ::Regex::Options.new(1))
+      CRYSTAL
+    end
+    it "x" do
+      assert_expand %q(/#{"".to_s}/x), <<-'CRYSTAL'
+      ::Regex.new("#{"".to_s}", ::Regex::Options.new(8))
+      CRYSTAL
+    end
+    it "im" do
+      assert_expand %q(/#{"".to_s}/im), <<-'CRYSTAL'
+      ::Regex.new("#{"".to_s}", ::Regex::Options.new(7))
+      CRYSTAL
+    end
+    it "imx" do
+      assert_expand %q(/#{"".to_s}/imx), <<-'CRYSTAL'
+      ::Regex.new("#{"".to_s}", ::Regex::Options.new(15))
+      CRYSTAL
+    end
+  end
+end

--- a/src/compiler/crystal/semantic/literal_expander.cr
+++ b/src/compiler/crystal/semantic/literal_expander.cr
@@ -348,7 +348,7 @@ module Crystal
     end
 
     private def regex_options(node)
-      Call.new(Path.global(["Regex", "Options"]).at(node), "new", NumberLiteral.new(node.options.value).at(node)).at(node)
+      Call.new(Path.global(["Regex", "Options"]).at(node), "new", NumberLiteral.new(node.options.value.to_s).at(node)).at(node)
     end
 
     # Convert and to if:

--- a/src/compiler/crystal/semantic/literal_expander.cr
+++ b/src/compiler/crystal/semantic/literal_expander.cr
@@ -343,6 +343,14 @@ module Crystal
       end
     end
 
+    private def regex_new_call(node, value)
+      Call.new(Path.global("Regex").at(node), "new", value, regex_options(node)).at(node)
+    end
+
+    private def regex_options(node)
+      Call.new(Path.global(["Regex", "Options"]).at(node), "new", NumberLiteral.new(node.options.value).at(node)).at(node)
+    end
+
     # Convert and to if:
     #
     # From:
@@ -1017,14 +1025,6 @@ module Crystal
       else
         proc_literal
       end
-    end
-
-    private def regex_new_call(node, value)
-      Call.new(Path.global("Regex").at(node), "new", value, regex_options(node)).at(node)
-    end
-
-    private def regex_options(node)
-      Call.new(Path.global(["Regex", "Options"]).at(node), "new", NumberLiteral.new(node.options.value).at(node)).at(node)
     end
 
     def expand(node)


### PR DESCRIPTION
This is a useful addition in general and particularly prepares for #13252

Edit: Also discovers and fixes a bug (?) introduced in https://github.com/crystal-lang/crystal/pull/13223.

Previous to #13223, the base type of `Regex::Options` was the default `Int32`. That PR changed it to `UInt64` to gain more space.
The parser creates an instance of `Regex::Options` from the modifier flags of a regex literal. When the compiler expands them, the option value is expressed by the base type value of the `Regex::Options` type. The resulting number literal is typed, so the expression for the `MULTILINE` options value would change from `::Regex::Options.new(6)` to `::Regex::Options.new(6_u64)`.
Now this isn't an immediate problem when the base type of `Regex::Options` in the compiler and stdlib align. And even if they don't, autocasting of integer literals should allow the generated code to be compatible with older `Regex::Options` implementations with `Int32` base type.
Still, I think it's better to avoid such unintended side effects and keep the generated code consistent until we explicitly chose to change it for good as discussed in #13252.
The different domain range of `Int32` and `UInt64` is irrelevant for this because the compiler only handles the three modifiers and the biggest integer value needed to represent them is `15` (for `imx`).