### PR TITLE
Add message about non-release mode to `crystal --version`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -39,9 +39,9 @@ override FLAGS += -D strict_multi_assign -D preview_overload_order $(if $(releas
 SPEC_WARNINGS_OFF := --exclude-warnings spec/std --exclude-warnings spec/compiler --exclude-warnings spec/primitives
 SPEC_FLAGS := $(if $(verbose),-v )$(if $(junit_output),--junit_output $(junit_output) )$(if $(order),--order=$(order) )
 CRYSTAL_CONFIG_LIBRARY_PATH := '$$ORIGIN/../lib/crystal'
-CRYSTAL_CONFIG_BUILD_COMMIT := $(shell git rev-parse --short HEAD 2> /dev/null)
+CRYSTAL_CONFIG_BUILD_COMMIT ?= $(shell git rev-parse --short HEAD 2> /dev/null)
 CRYSTAL_CONFIG_PATH := '$$ORIGIN/../share/crystal/src'
-SOURCE_DATE_EPOCH := $(shell (git show -s --format=%ct HEAD || stat -c "%Y" Makefile || stat -f "%m" Makefile) 2> /dev/null)
+SOURCE_DATE_EPOCH ?= $(shell (git show -s --format=%ct HEAD || stat -c "%Y" Makefile || stat -f "%m" Makefile) 2> /dev/null)
 ifeq ($(shell command -v ld.lld >/dev/null && uname -s),Linux)
   EXPORT_CC ?= CC="$(CC) -fuse-ld=lld"
 endif

--- a/src/compiler/crystal/config.cr
+++ b/src/compiler/crystal/config.cr
@@ -17,13 +17,13 @@ module Crystal
     def self.description
       formatted_sha = "[#{build_commit}] " if build_commit
       formatted_date = "(#{date})" unless date.empty?
-      release_msg = "\nRelease mode: false" unless release_mode
 
       <<-DOC
         Crystal #{version} #{formatted_sha}#{formatted_date}
 
         LLVM: #{llvm_version}
-        Default target: #{self.host_target}#{release_msg}
+        Default target: #{self.host_target}
+        Release mode: #{self.release_mode}
         DOC
     end
 
@@ -44,11 +44,7 @@ module Crystal
     end
 
     def self.release_mode
-      {% if flag?(:release) %}
-        true
-      {% else %}
-        false
-      {% end %}
+      {{ flag?(:release) }}
     end
 
     @@host_target : Crystal::Codegen::Target?

--- a/src/compiler/crystal/config.cr
+++ b/src/compiler/crystal/config.cr
@@ -15,15 +15,17 @@ module Crystal
     end
 
     def self.description
-      formatted_sha = "[#{build_commit}] " if build_commit
-      formatted_date = "(#{date})" unless date.empty?
+      details = [version]
+      details << "[#{build_commit}]" if build_commit
+      details << "(#{date})" unless date.empty?
+
+      development_msg = "\n\nThe compiler was not built in release mode." unless release_mode?
 
       <<-DOC
-        Crystal #{version} #{formatted_sha}#{formatted_date}
+        Crystal #{details.join(" ")}
 
         LLVM: #{llvm_version}
-        Default target: #{self.host_target}
-        Release mode: #{self.release_mode}
+        Default target: #{self.host_target}#{development_msg}
         DOC
     end
 
@@ -43,7 +45,7 @@ module Crystal
       end
     end
 
-    def self.release_mode
+    def self.release_mode?
       {{ flag?(:release) }}
     end
 

--- a/src/compiler/crystal/config.cr
+++ b/src/compiler/crystal/config.cr
@@ -20,10 +20,10 @@ module Crystal
         io << " [" << build_commit << "]" if build_commit
         io << " (" << date << ")" unless date.empty?
 
+        io << "\n\nThe compiler was not built in release mode." unless release_mode?
+
         io << "\n\nLLVM: " << llvm_version
         io << "\nDefault target: " << host_target
-
-        io << "\n\nThe compiler was not built in release mode." unless release_mode?
         io << "\n"
       end
     end

--- a/src/compiler/crystal/config.cr
+++ b/src/compiler/crystal/config.cr
@@ -15,18 +15,17 @@ module Crystal
     end
 
     def self.description
-      details = [version]
-      details << "[#{build_commit}]" if build_commit
-      details << "(#{date})" unless date.empty?
+      String.build do |io|
+        io << "Crystal " << version
+        io << " [" << build_commit << "]" if build_commit
+        io << " (" << date << ")" unless date.empty?
 
-      development_msg = "\n\nThe compiler was not built in release mode." unless release_mode?
+        io << "\n\nLLVM: " << llvm_version
+        io << "\nDefault target: " << host_target
 
-      <<-DOC
-        Crystal #{details.join(" ")}
-
-        LLVM: #{llvm_version}
-        Default target: #{self.host_target}#{development_msg}
-        DOC
+        io << "\n\nThe compiler was not built in release mode." unless release_mode?
+        io << "\n"
+      end
     end
 
     def self.build_commit

--- a/src/compiler/crystal/config.cr
+++ b/src/compiler/crystal/config.cr
@@ -16,11 +16,14 @@ module Crystal
 
     def self.description
       formatted_sha = "[#{build_commit}] " if build_commit
+      formatted_date = "(#{date})" unless date.empty?
+      release_msg = "\nRelease mode: false" unless release_mode
+
       <<-DOC
-        Crystal #{version} #{formatted_sha}(#{date})
+        Crystal #{version} #{formatted_sha}#{formatted_date}
 
         LLVM: #{llvm_version}
-        Default target: #{self.host_target}
+        Default target: #{self.host_target}#{release_msg}
         DOC
     end
 
@@ -38,6 +41,14 @@ module Crystal
       else
         ""
       end
+    end
+
+    def self.release_mode
+      {% if flag?(:release) %}
+        true
+      {% else %}
+        false
+      {% end %}
     end
 
     @@host_target : Crystal::Codegen::Target?


### PR DESCRIPTION
* Allow passing in git sha and date to Makefile
* Remove empty parens when date is ""
* Add message when compiler was not compiled in release mode

When building in a nix derivation, there is no git directory, so you have to pass in the sha manually. Also, all the file modification times are set to epcoh, and I think it'd be nicer to just have the builds not have a date rather than the obviously wrong 1970-01-01.

I don't think we need to always have release mode information, but it would be useful I think to have a way to see when you're working with a non-release compiler.