### PR TITLE
Fix `Array#replace` on shifted arrays

### DIFF
--- a/spec/std/array_spec.cr
+++ b/spec/std/array_spec.cr
@@ -960,11 +960,51 @@ describe "Array" do
     end
   end
 
-  it "does replace" do
-    a = [1, 2, 3]
-    b = [1]
-    b.replace a
-    b.should eq(a)
+  describe "#replace" do
+    it "replaces all elements" do
+      a = [1, 2, 3]
+      b = [4, 5, 6]
+      a.replace(b).should be(a)
+      a.should eq(b)
+    end
+
+    it "reuses the buffer if possible" do
+      a = [1, 2, 3, 4, 5]
+      a.shift
+      b = [6, 7, 8, 9, 10]
+      a.replace(b).should be(a)
+      a.should eq(b)
+      a.@capacity.should eq(5)
+      a.@offset_to_buffer.should eq(0)
+
+      a = [1, 2, 3, 4, 5]
+      a.shift(2)
+      b = [6, 7, 8, 9]
+      a.replace(b).should be(a)
+      a.should eq(b)
+      a.@capacity.should eq(5)
+      a.@offset_to_buffer.should eq(1)
+    end
+
+    it "resizes the buffer if capacity is not enough" do
+      a = [1, 2, 3, 4, 5]
+      b = [6, 7, 8, 9, 10, 11]
+      a.replace(b).should be(a)
+      a.should eq(b)
+      a.@capacity.should eq(10)
+      a.@offset_to_buffer.should eq(0)
+    end
+
+    it "clears unused elements if new size is smaller" do
+      a = [1, 2, 3, 4, 5]
+      b = [6, 7, 8]
+      a.replace(b).should be(a)
+      a.should eq(b)
+      a.@capacity.should eq(5)
+      a.@offset_to_buffer.should eq(0)
+      a.unsafe_fetch(3).should eq(0)
+      a.unsafe_fetch(4).should eq(0)
+    end
   end
 
   it "does reverse with an odd number of elements" do

--- a/src/array.cr
+++ b/src/array.cr
@@ -2059,7 +2059,18 @@ class Array(T)
     @capacity - @offset_to_buffer
   end
 
-  private def calculate_new_capacity(new_size = @capacity + 1)
+  # behaves like `calculate_new_capacity(@capacity + 1)`
+  private def calculate_new_capacity
+    return INITIAL_CAPACITY if @capacity == 0
+
+    if @capacity < CAPACITY_THRESHOLD
+      @capacity * 2
+    else
+      @capacity + (@capacity + 3 * CAPACITY_THRESHOLD) // 4
+    end
+  end
+
+  private def calculate_new_capacity(new_size)
     new_capacity = @capacity == 0 ? INITIAL_CAPACITY : @capacity
     while new_capacity < new_size
       if new_capacity < CAPACITY_THRESHOLD

--- a/src/array.cr
+++ b/src/array.cr
@@ -1392,9 +1392,17 @@ class Array(T)
   # a2 # => [1, 2, 3]
   # ```
   def replace(other : Array) : self
-    @size = other.size
-    resize_to_capacity(Math.pw2ceil(@size)) if @size > @capacity
+    if other.size > @capacity
+      reset_buffer_to_root_buffer
+      resize_to_capacity(calculate_new_capacity(other.size))
+    elsif other.size > remaining_capacity
+      shift_buffer_by(remaining_capacity - other.size)
+    elsif other.size < @size
+      (@buffer + other.size).clear(@size - other.size)
+    end
+
     @buffer.copy_from(other.to_unsafe, other.size)
+    @size = other.size
     self
   end
 
@@ -2051,14 +2059,16 @@ class Array(T)
     @capacity - @offset_to_buffer
   end
 
-  private def calculate_new_capacity
-    return INITIAL_CAPACITY if @capacity == 0
-
-    if @capacity < CAPACITY_THRESHOLD
-      @capacity * 2
-    else
-      @capacity + (@capacity + 3 * CAPACITY_THRESHOLD) // 4
+  private def calculate_new_capacity(new_size = @capacity + 1)
+    new_capacity = @capacity == 0 ? INITIAL_CAPACITY : @capacity
+    while new_capacity < new_size
+      if new_capacity < CAPACITY_THRESHOLD
+        new_capacity *= 2
+      else
+        new_capacity += (new_capacity + 3 * CAPACITY_THRESHOLD) // 4
+      end
     end
+    new_capacity
   end
 
   private def increase_capacity


### PR DESCRIPTION
`Array#replace` is broken because it never accounts for the space available between an `Array`'s root and real buffers, if `#shift` has been called on that `Array`. Here are two examples:

```crystal
class Array(T)
  def dump
    String.build do |io|
      io << "["
      @capacity.times do |i|
        io << ", " if i > 0
        if 0 <= i - @offset_to_buffer < @size
          @buffer[i - @offset_to_buffer].inspect(io)
        else
          io << '_'
        end
      end
      io << ']'
    end
  end
end

x = [0, 1, 2, 3, 4]
x.shift
x.dump # => [_, 1, 2, 3, 4]

# element lost after reallocation
x.replace([0, 1, 2, 3, 4, 5, 6, 7])
x.dump # => [_, 0, 1, 2, 3, 4, 5, 6]
10000.times { x << 1 } # segfault

# element lost without reallocation
x = [0, 1, 2, 3, 4]
x.shift
x.replace([5, 6, 7, 8, 9])
x.dump # => [_, 5, 6, 7, 8]
10000.times { x << 1 } # segfault
```

Both `#replace` calls write into memory outside the array buffer. This PR ensures the above doesn't happen:

```crystal
x = [0, 1, 2, 3, 4]
x.shift
x.replace([0, 1, 2, 3, 4, 5, 6, 7])
x.dump # => [0, 1, 2, 3, 4, 5, 6, 7, _, _]
10000.times { x << 1 } # okay

# element lost without reallocation
x = [0, 1, 2, 3, 4]
x.shift
x.replace([5, 6, 7, 8, 9])
x.dump # => [5, 6, 7, 8, 9]
10000.times { x << 1 } # okay
```

Additionally, it clears the unused region if the new array is smaller. This is important for arrays of reference types because previously the trailing elements would still be reachable after such a call to `#replace` and therefore cannot be garbage-collected.