### PR TITLE
Refactor code for `Deque` buffer resizing

### DIFF
--- a/src/deque.cr
+++ b/src/deque.cr
@@ -606,14 +606,13 @@ class Deque(T)
   end
 
   private def resize_to_capacity(capacity)
+    old_capacity, @capacity = @capacity, capacity
+
     unless @buffer
-      @capacity = capacity
       @buffer = Pointer(T).malloc(@capacity)
       return
     end
 
-    old_capacity = @capacity
-    @capacity = capacity
     @buffer = @buffer.realloc(@capacity)
 
     finish = @start + @size

--- a/src/deque.cr
+++ b/src/deque.cr
@@ -590,9 +590,11 @@ class Deque(T)
     @capacity * 2
   end
 
+  # behaves like `resize_if_cant_insert(1)`
   private def resize_if_cant_insert
     new_capacity = calculate_new_capacity
-    if new_capacity > @capacity
+    # `>=` instead of `>` to ensure there is room for one element
+    if new_capacity >= @capacity
       resize_to_capacity(new_capacity)
     end
   end

--- a/src/deque.cr
+++ b/src/deque.cr
@@ -583,6 +583,13 @@ class Deque(T)
 
   private INITIAL_CAPACITY = 4
 
+  # behaves like `calculate_new_capacity(@capacity + 1)`
+  private def calculate_new_capacity
+    return INITIAL_CAPACITY if @capacity == 0
+
+    @capacity * 2
+  end
+
   private def calculate_new_capacity(new_size)
     new_capacity = @capacity == 0 ? INITIAL_CAPACITY : @capacity
     while new_capacity < new_size

--- a/src/deque.cr
+++ b/src/deque.cr
@@ -592,10 +592,8 @@ class Deque(T)
 
   # behaves like `resize_if_cant_insert(1)`
   private def resize_if_cant_insert
-    new_capacity = calculate_new_capacity
-    # `>=` instead of `>` to ensure there is room for one element
-    if new_capacity >= @capacity
-      resize_to_capacity(new_capacity)
+    if @size >= @capacity
+      resize_to_capacity(calculate_new_capacity)
     end
   end
 

--- a/src/deque.cr
+++ b/src/deque.cr
@@ -590,14 +590,6 @@ class Deque(T)
     @capacity * 2
   end
 
-  private def calculate_new_capacity(new_size)
-    new_capacity = @capacity == 0 ? INITIAL_CAPACITY : @capacity
-    while new_capacity < new_size
-      new_capacity *= 2
-    end
-    new_capacity
-  end
-
   private def resize_if_cant_insert
     new_capacity = calculate_new_capacity
     if new_capacity > @capacity

--- a/src/deque.cr
+++ b/src/deque.cr
@@ -598,7 +598,14 @@ class Deque(T)
     new_capacity
   end
 
-  private def resize_if_cant_insert(insert_size = 1)
+  private def resize_if_cant_insert
+    new_capacity = calculate_new_capacity
+    if new_capacity > @capacity
+      resize_to_capacity(new_capacity)
+    end
+  end
+
+  private def resize_if_cant_insert(insert_size)
     new_capacity = calculate_new_capacity(@size + insert_size)
     if new_capacity > @capacity
       resize_to_capacity(new_capacity)

--- a/src/deque.cr
+++ b/src/deque.cr
@@ -605,13 +605,6 @@ class Deque(T)
     end
   end
 
-  private def resize_if_cant_insert(insert_size)
-    new_capacity = calculate_new_capacity(@size + insert_size)
-    if new_capacity > @capacity
-      resize_to_capacity(new_capacity)
-    end
-  end
-
   private def resize_to_capacity(capacity)
     old_capacity, @capacity = @capacity, capacity
 


### PR DESCRIPTION
This refactor aligns the code for `Deque` buffer growth to that of `Array` after #13256 (that piece of code came after this refactor). The resizing policy is unchanged.