### PR TITLE
Add workaround for `Value#not_nil!` copying the receiver

### DIFF
--- a/spec/std/object_spec.cr
+++ b/spec/std/object_spec.cr
@@ -162,6 +162,14 @@ private class DefEquals
   def_equals @x
 end
 
+private struct TestMutableStruct
+  getter x = 0
+
+  def foo
+    @x += 1
+  end
+end
+
 describe Object do
   describe "delegate" do
     it "delegates" do
@@ -542,6 +550,12 @@ describe Object do
       expect_raises(NilAssertionError, "custom message") do
         nil.not_nil!("custom message")
       end
+    end
+
+    it "does not copy its receiver when it is a value (#13263)" do
+      x = TestMutableStruct.new
+      x.not_nil!.foo.should eq(1)
+      x.not_nil!.foo.should eq(2)
     end
   end
 end

--- a/src/object.cr
+++ b/src/object.cr
@@ -220,7 +220,17 @@ class Object
   # for example using [`if var`](https://crystal-lang.org/reference/syntax_and_semantics/if_var.html).
   # `not_nil!` is only meant as a last resort when there's no other way to explain this to the compiler.
   # Either way, consider instead raising a concrete exception with a descriptive message.
-  def not_nil!(message = nil)
+  def not_nil!
+    self
+  end
+
+  # :ditto:
+  #
+  # *message* has no effect. It is only used by `Nil#not_nil!(message = nil)`.
+  def not_nil!(message)
+    # FIXME: the above param-less overload cannot be expressed as an optional
+    # parameter here, because that would copy the receiver if it is a struct;
+    # see https://github.com/crystal-lang/crystal/issues/13263#issuecomment-1492885817
     self
   end
 


### PR DESCRIPTION
This quick patch fixes #13263. The codegen issue will be created separately if I could identify it.