### PR TITLE
[CI] Extract interpreter workflow and split `std_spec` execution

### DIFF
--- a/.github/workflows/interpreter.yml
+++ b/.github/workflows/interpreter.yml
@@ -19,18 +19,46 @@ jobs:
       - uses: actions/checkout@v3
 
       - name: Test interpreter_spec
-        run: make deps && bin/crystal build -o interpreter_spec spec/compiler/interpreter_spec.cr && ./interpreter_spec
+        run: make deps && bin/crystal build -o interpreter_spec spec/compiler/interpreter_spec.cr && ./interpreter_spec --junit_output .junit/interpreter_spec.xml
 
-  test-interpreter-std_spec:
+  build-interpreter:
     runs-on: ubuntu-22.04
     container:
       image: crystallang/crystal:1.7.3-build
-    name: "Test interpreter std_spec"
+    name: Build interpreter
     steps:
       - uses: actions/checkout@v3
 
       - name: Build compiler
         run: make interpreter=1 release=1
 
+      - name: Upload compiler artifact
+        uses: actions/upload-artifact@v3
+        with:
+          name: crystal-interpreter
+          path: |
+            .build/crystal
+
+  test-interpreter-std_spec:
+    needs: build-interpreter
+    runs-on: ubuntu-22.04
+    container:
+      image: crystallang/crystal:1.7.3-build
+    strategy:
+      matrix:
+        part: [0, 1, 2, 3]
+    name: "Test std_spec with interpreter (${{ matrix.part }})"
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Download compiler artifact
+        uses: actions/download-artifact@v3
+        with:
+          name: crystal-interpreter
+          path: .build/
+
+      - name: Mark downloaded compiler as executable
+        run: chmod +x .build/crystal
+
       - name: Run std_spec with interpreter
-        run: bin/crystal i spec/interpreter_std_spec.cr -- --junit_output .junit/interpreter-std_spec.xml
+        run: SPEC_SPLIT="${{ matrix.part }}%4" bin/crystal i spec/interpreter_std_spec.cr -- --junit_output .junit/interpreter-std_spec.${{ matrix.part }}.xml

--- a/.github/workflows/interpreter.yml
+++ b/.github/workflows/interpreter.yml
@@ -1,0 +1,36 @@
+name: Interpreter Test
+
+on: [push, pull_request]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  SPEC_SPLIT_DOTS: 160
+
+jobs:
+  test-interpreter_spec:
+    runs-on: ubuntu-22.04
+    container:
+      image: crystallang/crystal:1.7.3-build
+    name: "Test Interpreter"
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Test interpreter_spec
+        run: make deps && bin/crystal build -o interpreter_spec spec/compiler/interpreter_spec.cr && ./interpreter_spec
+
+  test-interpreter-std_spec:
+    runs-on: ubuntu-22.04
+    container:
+      image: crystallang/crystal:1.7.3-build
+    name: "Test interpreter std_spec"
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Build compiler
+        run: make interpreter=1 release=1
+
+      - name: Run std_spec with interpreter
+        run: bin/crystal i spec/interpreter_std_spec.cr -- --junit_output .junit/interpreter-std_spec.xml

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -116,34 +116,6 @@ jobs:
       - name: Test
         run: bin/ci with_build_env 'CRYSTAL_WORKERS=4 make std_spec threads=1 FLAGS="-D preview_mt"'
 
-  test_interpreter:
-    env:
-      ARCH: ${{ matrix.arch }}
-      ARCH_CMD: linux64
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        arch:
-          - x86_64
-    steps:
-      - name: Download Crystal source
-        uses: actions/checkout@v3
-
-      - name: Prepare System
-        run: bin/ci prepare_system
-
-      - name: Prepare Build
-        run: bin/ci prepare_build
-
-      - name: Test interpreter
-        run: bin/ci with_build_env 'make deps && bin/crystal build -o interpreter_spec spec/compiler/interpreter_spec.cr && ./interpreter_spec'
-
-      - name: Build interpreter
-        run: bin/ci with_build_env 'make interpreter=1 release=1'
-
-      - name: Test std specs with interpreter
-        run: bin/ci with_build_env 'bin/crystal i spec/interpreter_std_spec.cr'
-
   check_format:
     env:
       ARCH: x86_64


### PR DESCRIPTION
`test_interpreter` is failing almost constantly in CI due to running out of memory.

Execution of `interpreter-std_spec` uses almost 10G memory, but the GHA runners only have around 8G available.
```
        Command being timed: "bin/crystal i spec/interpreter_std_spec.cr -- --junit_output .junit/interpreter-std_spec.xml"
        User time (seconds): 369.31
        System time (seconds): 4.90
        Percent of CPU this job got: 277%
        Elapsed (wall clock) time (h:mm:ss or m:ss): 2:15.03
        Average shared text size (kbytes): 0
        Average unshared data size (kbytes): 0
        Average stack size (kbytes): 0
        Average total size (kbytes): 0
        Maximum resident set size (kbytes): 9926492
        Average resident set size (kbytes): 0
        Major (requiring I/O) page faults: 0
        Minor (reclaiming a frame) page faults: 686100
        Voluntary context switches: 21253
        Involuntary context switches: 6934
        Swaps: 0
        File system inputs: 0
        File system outputs: 6128
        Socket messages sent: 0
        Socket messages received: 0
        Signals delivered: 0
        Page size (bytes): 4096
        Exit status: 0
```
Splitting the entire spec suite into separate pieces reduces the total amount of memory. We already have the mechanism with `SPEC_SPLIT` available. It was previously used for CI on x86.

We should probably try to reduce the interpreters memory usage, but this is a quick workaround to get CI green again.