### PR TITLE
Fix `Array(T)#[]=(Int, Int, Array(T))` on shifted arrays

### DIFF
--- a/spec/std/array_spec.cr
+++ b/spec/std/array_spec.cr
@@ -445,6 +445,24 @@ describe "Array" do
       a[3..] = [4, 5, 6]
       a.should eq([1, 2, 3, 4, 5, 6])
     end
+
+    it "reuses the buffer if possible" do
+      a = [1, 2, 3, 4, 5]
+      a.pop
+      a[4, 0] = [6]
+      a.should eq([1, 2, 3, 4, 6])
+      a.@capacity.should eq(5)
+      a.@offset_to_buffer.should eq(0)
+    end
+
+    it "resizes the buffer if capacity is not enough" do
+      a = [1, 2, 3, 4, 5]
+      a.shift
+      a[4, 0] = [6, 7, 8, 9]
+      a.should eq([2, 3, 4, 5, 6, 7, 8, 9])
+      a.@capacity.should eq(10)
+      a.@offset_to_buffer.should eq(1)
+    end
   end
 
   describe "values_at" do


### PR DESCRIPTION
This is like #13256, except for `#[]=` whenever the size of the array increases:

```crystal
class Array(T)
  def inspect(io : IO) : Nil
    io << "["
    @capacity.times do |i|
      io << ", " if i > 0
      if 0 <= i - @offset_to_buffer < @size
        @buffer[i - @offset_to_buffer].inspect(io)
      else
        io << '_'
      end
    end
    io << ']'
  end
end

# element lost after reallocation
# also notice that the buffer unnecessarily shrinks
x = [0, 1, 2, 3, 4] # [0, 1, 2, 3, 4]
x << 5              # [0, 1, 2, 3, 4, 5, _, _, _, _]
x.shift             # [_, 1, 2, 3, 4, 5, _, _, _, _]
x[5, 0] = [6, 7, 8] # [_, 1, 2, 3, 4, 5, 6, 7]

# element lost without reallocation (this is not true, as
# the call to `Pointer#realloc` is unconditional)
x = [0, 1, 2, 3]       # [0, 1, 2, 3]
x << 4                 # [0, 1, 2, 3, 4, _, _, _]
x.shift                # [_, 1, 2, 3, 4, _, _, _]
x[4, 0] = [5, 6, 7, 8] # [_, 1, 2, 3, 4, 5, 6, 7]
```

After this PR:

```crystal
x = [0, 1, 2, 3, 4]
x << 5
x.shift
x[5, 0] = [6, 7, 8] # [_, 1, 2, 3, 4, 5, 6, 7, 8, _]

x = [0, 1, 2, 3]
x << 4
x.shift
x[4, 0] = [5, 6, 7, 8] # [_, 1, 2, 3, 4, 5, 6, 7, 8, _, _, _, _, _, _, _]
```

This indirectly affects the `Range` overload as well, which forwards to this overload.

Also as a result of this fix, _all_ resizing operations on `Array` now grow the buffer consistently using the same policy, unlike previously where some still use `Math.pw2ceil`.