### PR TITLE
Makefile: Add `all` target as default before including `Makfile.local`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,5 @@
+all:
+
 -include Makefile.local # for optional local options e.g. threads
 
 # Recipes for this Makefile

--- a/Makefile.win
+++ b/Makefile.win
@@ -1,3 +1,5 @@
+all:
+
 -include Makefile.win.local # for optional local options e.g. threads
 
 # Recipes for this Makefile


### PR DESCRIPTION
This change ensures that `all` is defined before all other targets and thus is he default, instead of a random target defined in `Makefile.local`.