### PR TITLE
Optimize `Array#concat(Indexable)`

### DIFF
--- a/spec/std/array_spec.cr
+++ b/spec/std/array_spec.cr
@@ -541,6 +541,20 @@ describe "Array" do
       a.@capacity.should eq(6)
     end
 
+    it "concats indexable" do
+      a = [1, 2, 3]
+      a.concat(Slice.new(97) { |i| i + 4 })
+      a.should eq((1..100).to_a)
+
+      a = [1, 2, 3]
+      a.concat(StaticArray(Int32, 97).new { |i| i + 4 })
+      a.should eq((1..100).to_a)
+
+      a = [1, 2, 3]
+      a.concat(Deque.new(97) { |i| i + 4 })
+      a.should eq((1..100).to_a)
+    end
+
     it "concats a union of arrays" do
       a = [1, '2']
       a.concat([3] || ['4'])

--- a/src/array.cr
+++ b/src/array.cr
@@ -746,16 +746,35 @@ class Array(T)
   # ary.concat(["c", "d"])
   # ary # => ["a", "b", "c", "d"]
   # ```
-  def concat(other : Array) : self
+  def concat(other : Indexable) : self
     other_size = other.size
 
     resize_if_cant_insert(other_size)
 
-    (@buffer + @size).copy_from(other.to_unsafe, other_size)
+    concat_indexable(other)
 
     @size += other_size
 
     self
+  end
+
+  private def concat_indexable(other : Array | Slice | StaticArray)
+    (@buffer + @size).copy_from(other.to_unsafe, other.size)
+  end
+
+  private def concat_indexable(other : Deque)
+    ptr = @buffer + @size
+    Deque.half_slices(other) do |slice|
+      ptr.copy_from(slice.to_unsafe, slice.size)
+      ptr += slice.size
+    end
+  end
+
+  private def concat_indexable(other)
+    appender = (@buffer + @size).appender
+    other.each do |elem|
+      appender << elem
+    end
   end
 
   # :ditto:

--- a/src/deque.cr
+++ b/src/deque.cr
@@ -576,10 +576,11 @@ class Deque(T)
     b = deque.@start + deque.size
     b -= deque.capacity if b > deque.capacity
     if a < b
-      yield Slice.new(deque.buffer + a, deque.size)
+      # TODO: this `typeof` is a workaround for 1.0.0; remove it eventually
+      yield Slice(typeof(deque.buffer.value)).new(deque.buffer + a, deque.size)
     else
-      yield Slice.new(deque.buffer + a, deque.capacity - a)
-      yield Slice.new(deque.buffer, b)
+      yield Slice(typeof(deque.buffer.value)).new(deque.buffer + a, deque.capacity - a)
+      yield Slice(typeof(deque.buffer.value)).new(deque.buffer, b)
     end
   end
 

--- a/src/deque.cr
+++ b/src/deque.cr
@@ -20,6 +20,7 @@ class Deque(T)
   @start = 0
   protected setter size
   protected getter buffer
+  protected getter capacity
 
   # Creates a new empty Deque
   def initialize
@@ -150,8 +151,8 @@ class Deque(T)
 
   # Removes all elements from `self`.
   def clear
-    halfs do |r|
-      (@buffer + r.begin).clear(r.end - r.begin)
+    Deque.half_slices(self) do |slice|
+      slice.to_unsafe.clear(slice.size)
     end
     @size = 0
     @start = 0
@@ -339,9 +340,9 @@ class Deque(T)
   #
   # Do not modify the deque while using this variant of `each`!
   def each(& : T ->) : Nil
-    halfs do |r|
-      r.each do |i|
-        yield @buffer[i]
+    Deque.half_slices(self) do |slice|
+      slice.each do |elem|
+        yield elem
       end
     end
   end
@@ -564,20 +565,21 @@ class Deque(T)
     self
   end
 
-  private def halfs(&)
+  # :nodoc:
+  def self.half_slices(deque : Deque, &)
     # For [----] yields nothing
-    # For contiguous [-012] yields 1...4
-    # For separated [234---01] yields 6...8, 0...3
+    # For contiguous [-012] yields @buffer[1...4]
+    # For separated [234---01] yields @buffer[6...8], @buffer[0...3]
 
-    return if empty?
-    a = @start
-    b = @start + size
-    b -= @capacity if b > @capacity
+    return if deque.empty?
+    a = deque.@start
+    b = deque.@start + deque.size
+    b -= deque.capacity if b > deque.capacity
     if a < b
-      yield a...b
+      yield Slice.new(deque.buffer + a, deque.size)
     else
-      yield a...@capacity
-      yield 0...b
+      yield Slice.new(deque.buffer + a, deque.capacity - a)
+      yield Slice.new(deque.buffer, b)
     end
   end
 


### PR DESCRIPTION
When concatenating an `Indexable` to an `Array`, we already know the argument's number of elements in advance and this number won't change (formally this needs the wording from #13061), so we never need more than one reallocation of the array's buffer. Additionally, for containers that store their elements in a contiguous buffer (or two in the case of `Deque`), we can leverage `Intrinsics.memcpy` whenever the element types are the same. Benchmarks:

<details>

<summary>Source</summary>

```crystal
require "benchmark"

class Array(T)
  def concat2(other : Indexable)
    # this PR's implementation
  end
end

{% begin %}
  M = {{ env("M").to_i }}
  N = {{ env("N").to_i }}
{% end %}
puts "M=#{M}, N=#{N}"

x = [] of Int64
y_slice = Slice(Int64).empty
y_static_array = uninitialized Int64[N]
y_deque = Deque(Int64).new

puts "Slice:"
Benchmark.ips do |b|
  b.report("ctrl") do
    x = Array(Int64).new(M, &.to_i64)
    y_slice = Slice(Int64).new(N, &.to_i64)
  end

  b.report("old") do
    x = Array(Int64).new(M, &.to_i64)
    y_slice = Slice(Int64).new(N, &.to_i64)
    x.concat(y_slice)
  end

  b.report("new") do
    x = Array(Int64).new(M, &.to_i64)
    y_slice = Slice(Int64).new(N, &.to_i64)
    x.concat2(y_slice)
  end
end

puts "StaticArray:"
Benchmark.ips do |b|
  b.report("old") do
    x = Array(Int64).new(M, &.to_i64)
    x.concat(y_static_array)
  end

  b.report("new") do
    x = Array(Int64).new(M, &.to_i64)
    x.concat2(y_static_array)
  end
end

puts "Deque:"
Benchmark.ips do |b|
  b.report("ctrl") do
    x = Array(Int64).new(M, &.to_i64)
    y_deque = Deque(Int64).new(N, &.to_i64)
  end

  b.report("old") do
    x = Array(Int64).new(M, &.to_i64)
    y_deque = Deque(Int64).new(N, &.to_i64)
    x.concat(y_deque)
  end

  b.report("new") do
    x = Array(Int64).new(M, &.to_i64)
    y_deque = Deque(Int64).new(N, &.to_i64)
    x.concat2(y_deque)
  end
end
```

</details>

```
M=1000, N=100
Slice:
ctrl 948.57k (  1.05µs) (± 0.92%)  8.86kB/op        fastest
 old 642.38k (  1.56µs) (± 0.80%)  20.1kB/op   1.48× slower
 new 668.03k (  1.50µs) (± 0.74%)  20.1kB/op   1.42× slower
StaticArray:
old 709.49k (  1.41µs) (± 0.31%)  19.1kB/op   1.05× slower
new 742.15k (  1.35µs) (± 0.78%)  19.1kB/op        fastest
Deque:
ctrl 917.24k (  1.09µs) (± 0.71%)  8.89kB/op        fastest
 old 627.34k (  1.59µs) (± 0.55%)  20.2kB/op   1.46× slower
 new 654.55k (  1.53µs) (± 0.72%)  20.2kB/op   1.40× slower

M=1000, N=1000
Slice:
ctrl 491.24k (  2.04µs) (± 0.93%)  15.7kB/op        fastest
 old 214.47k (  4.66µs) (± 0.64%)  63.6kB/op   2.29× slower
 new 283.87k (  3.52µs) (± 0.90%)  36.7kB/op   1.73× slower
StaticArray:
old 278.31k (  3.59µs) (± 0.68%)  55.8kB/op   1.37× slower
new 382.17k (  2.62µs) (± 1.30%)  28.8kB/op        fastest
Deque:
ctrl 495.76k (  2.02µs) (± 1.05%)  15.7kB/op        fastest
 old 222.66k (  4.49µs) (± 0.88%)  63.6kB/op   2.23× slower
 new 303.31k (  3.30µs) (± 0.90%)  36.7kB/op   1.63× slower

M=100, N=1000
Slice:
ctrl 968.83k (  1.03µs) (± 0.78%)  8.86kB/op        fastest
 old 400.14k (  2.50µs) (± 0.71%)  27.7kB/op   2.42× slower
 new 472.52k (  2.12µs) (± 0.59%)  20.7kB/op   2.05× slower
StaticArray:
old 614.25k (  1.63µs) (± 0.59%)  19.8kB/op   1.27× slower
new 778.45k (  1.28µs) (± 0.43%)  12.9kB/op        fastest
Deque:
ctrl 833.65k (  1.20µs) (± 0.55%)  8.89kB/op        fastest
 old 373.26k (  2.68µs) (± 0.62%)  27.7kB/op   2.23× slower
 new 436.66k (  2.29µs) (± 0.40%)  20.7kB/op   1.91× slower
```

The above results are collected on top of #13275; without that PR, when `N ≪ M`, i.e. a small `Indexable` is being concatenated to a large `Array`, the `Array`'s buffer size would grow to the next power of 2, which is often less inefficient than the new growth policy. In contrast, the existing `#concat(Enumerable)` inserts elements one by one, so it already uses the new growth policy.

The old `Array#concat(Array)` overload is absorbed into the new implementation for `Indexable` arguments.