### PR TITLE
Optimize `Deque#concat(Indexable)`

### DIFF
--- a/spec/std/deque_spec.cr
+++ b/spec/std/deque_spec.cr
@@ -37,6 +37,22 @@ end
 
 private alias RecursiveDeque = Deque(RecursiveDeque)
 
+# Yields `Deque{}`, `Deque{0}`, `Deque{0, 1}`, `Deque{0, 1, 2}`, ...,
+# `Deque{0, 1, 2, ..., max_size - 1}`. All deques have *max_size* as their
+# capacity; each deque is yielded *max_size* times with a different start
+# position in the internal buffer. Every deque is a fresh instance.
+private def each_queue_repr(max_size, &)
+  (0..max_size).each do |size|
+    max_size.times do |i|
+      x = Deque(Int32).new(max_size, 0)
+      x.rotate!(i)
+      x.pop(max_size - size)
+      x.fill &.itself
+      yield x
+    end
+  end
+end
+
 describe "Deque" do
   describe "implementation" do
     it "works the same as array" do
@@ -241,6 +257,44 @@ describe "Deque" do
       a = Deque{1, 2, 3}
       a.concat((4..1000))
       a.should eq(Deque.new((1..1000).to_a))
+    end
+
+    it "concats indexable" do
+      each_queue_repr(16) do |a|
+        size = a.size
+        b = Array.new(10, &.+(size))
+        a.concat(b).should be(a)
+        a.should eq(Deque.new(size + 10, &.itself))
+      end
+
+      each_queue_repr(16) do |a|
+        size = a.size
+        b = Slice.new(10, &.+(size))
+        a.concat(b).should be(a)
+        a.should eq(Deque.new(size + 10, &.itself))
+      end
+
+      each_queue_repr(16) do |a|
+        size = a.size
+        b = StaticArray(Int32, 10).new(&.+(size))
+        a.concat(b).should be(a)
+        a.should eq(Deque.new(size + 10, &.itself))
+      end
+
+      each_queue_repr(16) do |a|
+        size = a.size
+        b = Deque.new(10, &.+(size))
+        a.concat(b).should be(a)
+        a.should eq(Deque.new(size + 10, &.itself))
+      end
+    end
+
+    it "concats itself" do
+      each_queue_repr(16) do |a|
+        size = a.size
+        a.concat(a).should be(a)
+        a.should eq(Deque.new((0...size).to_a * 2))
+      end
     end
   end
 

--- a/src/deque.cr
+++ b/src/deque.cr
@@ -583,6 +583,13 @@ class Deque(T)
 
   private INITIAL_CAPACITY = 4
 
+  # behaves like `calculate_new_capacity(@capacity + 1)`
+  private def calculate_new_capacity
+    return INITIAL_CAPACITY if @capacity == 0
+
+    @capacity * 2
+  end
+
   private def calculate_new_capacity(new_size)
     new_capacity = @capacity == 0 ? INITIAL_CAPACITY : @capacity
     while new_capacity < new_size

--- a/src/deque.cr
+++ b/src/deque.cr
@@ -20,6 +20,7 @@ class Deque(T)
   @start = 0
   protected setter size
   protected getter buffer
+  protected getter capacity
 
   # Creates a new empty Deque
   def initialize
@@ -150,8 +151,8 @@ class Deque(T)
 
   # Removes all elements from `self`.
   def clear
-    halfs do |r|
-      (@buffer + r.begin).clear(r.end - r.begin)
+    Deque.half_slices(self) do |slice|
+      slice.to_unsafe.clear(slice.size)
     end
     @size = 0
     @start = 0
@@ -339,9 +340,9 @@ class Deque(T)
   #
   # Do not modify the deque while using this variant of `each`!
   def each(& : T ->) : Nil
-    halfs do |r|
-      r.each do |i|
-        yield @buffer[i]
+    Deque.half_slices(self) do |slice|
+      slice.each do |elem|
+        yield elem
       end
     end
   end
@@ -564,20 +565,21 @@ class Deque(T)
     self
   end
 
-  private def halfs(&)
+  # :nodoc:
+  def self.half_slices(deque : Deque, &)
     # For [----] yields nothing
-    # For contiguous [-012] yields 1...4
-    # For separated [234---01] yields 6...8, 0...3
+    # For contiguous [-012] yields @buffer[1...4]
+    # For separated [234---01] yields @buffer[6...8], @buffer[0...3]
 
-    return if empty?
-    a = @start
-    b = @start + size
-    b -= @capacity if b > @capacity
+    return if deque.empty?
+    a = deque.@start
+    b = deque.@start + deque.size
+    b -= deque.capacity if b > deque.capacity
     if a < b
-      yield a...b
+      yield Slice.new(deque.buffer + a, deque.size)
     else
-      yield a...@capacity
-      yield 0...b
+      yield Slice.new(deque.buffer + a, deque.capacity - a)
+      yield Slice.new(deque.buffer, b)
     end
   end
 


### PR DESCRIPTION
Like #13280, but for `Deque`. Depends on #13257.

The main differences are there were no existing overloads more specialized than `Enumerable` arguments here, and there is already only a single buffer growth policy. Benchmarks:

<details>

<summary>Source</summary>

```crystal
require "benchmark"

class Deque(T)
  def concat2(other : Indexable)
    # this PR's implementation
  end
end

{% begin %}
  M = {{ env("M").to_i }}
  N = {{ env("N").to_i }}
{% end %}
puts "M=#{M}, N=#{N}"

x = Deque(Int64).new

puts "Array:"
y_array = Array(Int64).new
Benchmark.ips do |b|
  b.report("ctrl") { x = Deque(Int64).new(M, &.to_i64); y_array = Array(Int64).new(N, &.to_i64) }
  b.report("old")  { x = Deque(Int64).new(M, &.to_i64); y_array = Array(Int64).new(N, &.to_i64); x.concat(y_array) }
  b.report("new")  { x = Deque(Int64).new(M, &.to_i64); y_array = Array(Int64).new(N, &.to_i64); x.concat2(y_array) }
end

puts "Slice:"
y_slice = Slice(Int64).empty
Benchmark.ips do |b|
  b.report("ctrl") { x = Deque(Int64).new(M, &.to_i64); y_slice = Slice(Int64).new(N, &.to_i64) }
  b.report("old")  { x = Deque(Int64).new(M, &.to_i64); y_slice = Slice(Int64).new(N, &.to_i64); x.concat(y_slice) }
  b.report("new")  { x = Deque(Int64).new(M, &.to_i64); y_slice = Slice(Int64).new(N, &.to_i64); x.concat2(y_slice) }
end

puts "StaticArray:"
y_static_array = uninitialized Int64[N]
Benchmark.ips do |b|
  b.report("old")  { x = Deque(Int64).new(M, &.to_i64); x.concat(y_static_array) }
  b.report("new")  { x = Deque(Int64).new(M, &.to_i64); x.concat2(y_static_array) }
end

puts "Deque:"
y_deque = Deque(Int64).new
Benchmark.ips do |b|
  b.report("ctrl") { x = Deque(Int64).new(M, &.to_i64); y_deque = Deque(Int64).new(N, &.to_i64) }
  b.report("old")  { x = Deque(Int64).new(M, &.to_i64); y_deque = Deque(Int64).new(N, &.to_i64); x.concat(y_deque) }
  b.report("new")  { x = Deque(Int64).new(M, &.to_i64); y_deque = Deque(Int64).new(N, &.to_i64); x.concat2(y_deque) }
end
```

</details>

```
M=1000, N=100
Array:
ctrl 820.27k (  1.22µs) (± 0.95%)  8.89kB/op        fastest
 old 448.18k (  2.23µs) (± 0.72%)  24.5kB/op   1.83× slower
 new 489.15k (  2.04µs) (± 0.92%)  24.5kB/op   1.68× slower
Slice:
ctrl 837.32k (  1.19µs) (± 0.85%)  8.86kB/op        fastest
 old 446.36k (  2.24µs) (± 0.97%)  24.5kB/op   1.88× slower
 new 499.05k (  2.00µs) (± 1.02%)  24.5kB/op   1.68× slower
StaticArray:
old 474.77k (  2.11µs) (± 0.69%)  23.5kB/op   1.13× slower
new 534.29k (  1.87µs) (± 0.96%)  23.5kB/op        fastest
Deque:
ctrl 808.45k (  1.24µs) (± 0.73%)  8.89kB/op        fastest
 old 440.56k (  2.27µs) (± 0.95%)  24.5kB/op   1.84× slower
 new 490.72k (  2.04µs) (± 0.70%)  24.5kB/op   1.65× slower

M=1000, N=1000
Array:
ctrl 493.17k (  2.03µs) (± 1.11%)  15.7kB/op        fastest
 old 192.04k (  5.21µs) (± 0.56%)  31.3kB/op   2.57× slower
 new 345.75k (  2.89µs) (± 2.76%)  31.3kB/op   1.43× slower
Slice:
ctrl 495.68k (  2.02µs) (± 1.07%)  15.7kB/op        fastest
 old 194.21k (  5.15µs) (± 0.53%)  31.3kB/op   2.55× slower
 new 334.78k (  2.99µs) (± 0.75%)  31.3kB/op   1.48× slower
StaticArray:
old 232.06k (  4.31µs) (± 0.49%)  23.5kB/op   1.91× slower
new 444.11k (  2.25µs) (± 0.63%)  23.5kB/op        fastest
Deque:
ctrl 455.51k (  2.20µs) (± 0.84%)  15.7kB/op        fastest
 old 188.27k (  5.31µs) (± 0.68%)  31.3kB/op   2.42× slower
 new 321.27k (  3.11µs) (± 0.56%)  31.3kB/op   1.42× slower

M=100, N=1000
Array:
ctrl 939.99k (  1.06µs) (± 0.90%)  8.89kB/op        fastest
 old 219.48k (  4.56µs) (± 0.72%)  32.8kB/op   4.28× slower
 new 452.07k (  2.21µs) (± 0.70%)  21.4kB/op   2.08× slower
Slice:
ctrl 956.11k (  1.05µs) (± 0.88%)  8.86kB/op        fastest
 old 219.85k (  4.55µs) (± 0.56%)  32.8kB/op   4.35× slower
 new 459.57k (  2.18µs) (± 0.61%)  21.4kB/op   2.08× slower
StaticArray:
old 273.96k (  3.65µs) (± 0.50%)  25.0kB/op   2.51× slower
new 686.58k (  1.46µs) (± 0.66%)  13.6kB/op        fastest
Deque:
ctrl 820.61k (  1.22µs) (± 0.79%)  8.89kB/op        fastest
 old 212.27k (  4.71µs) (± 0.99%)  32.8kB/op   3.87× slower
 new 426.32k (  2.35µs) (± 1.14%)  21.4kB/op   1.92× slower
```