### PR TITLE
Fix `bin/crystal` when no global `crystal` command is installed

### DIFF
--- a/bin/crystal
+++ b/bin/crystal
@@ -153,8 +153,11 @@ if [ -z "${PARENT_CRYSTAL##*/*}" -a "$(realpath "$PARENT_CRYSTAL")" = "$SCRIPT_P
   PARENT_CRYSTAL="crystal"
 fi
 
+PARENT_CRYSTAL_COMMAND=$(realpath "$(command -v "$PARENT_CRYSTAL" 2> /dev/null)" 2> /dev/null)
+PARENT_CRYSTAL_EXISTS=$(test !$?)
+
 # check if the parent crystal command refers to this script
-if [ "$(realpath "$(command -v "$PARENT_CRYSTAL")")" = "$SCRIPT_PATH" ]; then
+if [ "$PARENT_CRYSTAL_COMMAND" = "$SCRIPT_PATH" ]; then
   # remove the path to this script from PATH
   NEW_PATH="$(remove_path_item "$(remove_path_item "$PATH" "$SCRIPT_ROOT")" "bin")"
   # if the PATH did not change it will lead to an infinite recursion => display error
@@ -162,23 +165,28 @@ if [ "$(realpath "$(command -v "$PARENT_CRYSTAL")")" = "$SCRIPT_PATH" ]; then
     __error_msg 'Could not remove the script bin/crystal from the PATH. Remove it by hand or set the CRYSTAL env variable'
     exit 1
   fi
-  # re-execute this script with the cleaned up PATH
-  export PATH="$NEW_PATH"
-  exec "$SCRIPT_PATH" "$@"
+  PARENT_CRYSTAL_COMMAND=$(realpath "$(PATH=$NEW_PATH command -v "$PARENT_CRYSTAL" 2> /dev/null)" 2> /dev/null)
+  PARENT_CRYSTAL_EXISTS=$(test !$?)
+  if [ "$PARENT_CRYSTAL_COMMAND" = "$SCRIPT_PATH" ]; then
+    __error_msg 'Could not remove the script bin/crystal from the PATH. Remove it by hand or set the CRYSTAL env variable'
+    exit 1
+  fi
 fi
 
-if [ -z "$CRYSTAL_CONFIG_LIBRARY_PATH" ] || [ -z "$CRYSTAL_LIBRARY_PATH" ]; then
-  CRYSTAL_INSTALLED_LIBRARY_PATH="$($PARENT_CRYSTAL env CRYSTAL_LIBRARY_PATH || echo "")"
-  export CRYSTAL_LIBRARY_PATH=${CRYSTAL_LIBRARY_PATH:-$CRYSTAL_INSTALLED_LIBRARY_PATH}
-  export CRYSTAL_CONFIG_LIBRARY_PATH=${CRYSTAL_CONFIG_LIBRARY_PATH:-$CRYSTAL_INSTALLED_LIBRARY_PATH}
+if ($PARENT_CRYSTAL_EXISTS); then
+  if [ -z "$CRYSTAL_CONFIG_LIBRARY_PATH" ] || [ -z "$CRYSTAL_LIBRARY_PATH" ]; then
+    CRYSTAL_INSTALLED_LIBRARY_PATH="$($PARENT_CRYSTAL_COMMAND env CRYSTAL_LIBRARY_PATH 2> /dev/null || echo "")"
+    export CRYSTAL_LIBRARY_PATH=${CRYSTAL_LIBRARY_PATH:-$CRYSTAL_INSTALLED_LIBRARY_PATH}
+    export CRYSTAL_CONFIG_LIBRARY_PATH=${CRYSTAL_CONFIG_LIBRARY_PATH:-$CRYSTAL_INSTALLED_LIBRARY_PATH}
+  fi
 fi
 
 if [ -x "$CRYSTAL_DIR/crystal" ]; then
   __warning_msg "Using compiled compiler at ${CRYSTAL_DIR#"$PWD/"}/crystal"
   exec "$CRYSTAL_DIR/crystal" "$@"
-elif ! command -v "$PARENT_CRYSTAL" > /dev/null; then
+elif !($PARENT_CRYSTAL_EXISTS); then
   __error_msg 'You need to have a crystal executable in your path! or set CRYSTAL env variable'
   exit 1
 else
-  exec "$PARENT_CRYSTAL" "$@"
+  exec "$PARENT_CRYSTAL_COMMAND" "$@"
 fi


### PR DESCRIPTION
#11712 and #13032 changed how `bin/crystal` reacts to when the command `crystal` resolves to itself.
This broke some previously working use cases including in https://github.com/crystal-lang/test-ecosystem (https://github.com/crystal-lang/crystal/pull/11712#issuecomment-1497531460).

This patch corrects the semantics to keep existing workflows enabled.
It works with test-ecosystem: https://github.com/crystal-lang/test-ecosystem/actions/runs/4619250181

Previously, if the wrapper script notices that `crystal` points to itself, it would remove its parent directory from `PATH` and execute itself again with the changed path.
Th removal from `PATH` not only affects the lookup path for the compiler executable, but also everything run inside the compiler (for example in macros or in the case of `crystal spec` and `crystal run` anything in the program being executed). So it's not a good idea for `bin/crystal` to modify `PATH`.

With this patch, the script resolves the `PARENT_CRYSTAL_COMMAND` and calls that. If it points to itself, it tries again with a modified path like before, but that path is only used for the `command` lookup. It does no longer re-execute itself with a different path.