### PR TITLE
Handle NaNs when comparing `BigFloat` against `Float`

### DIFF
--- a/spec/std/big/big_float_spec.cr
+++ b/spec/std/big/big_float_spec.cr
@@ -87,6 +87,22 @@ describe "BigFloat" do
     end
   end
 
+  describe "#<=>" do
+    it "compares against NaNs" do
+      (1.to_big_f <=> Float64::NAN).should be_nil
+      (1.to_big_f <=> Float32::NAN).should be_nil
+      (Float64::NAN <=> 1.to_big_f).should be_nil
+      (Float32::NAN <=> 1.to_big_f).should be_nil
+
+      typeof(1.to_big_f <=> Float64::NAN).should eq(Int32?)
+      typeof(1.to_big_f <=> Float32::NAN).should eq(Int32?)
+      typeof(Float64::NAN <=> 1.to_big_f).should eq(Int32?)
+      typeof(Float32::NAN <=> 1.to_big_f).should eq(Int32?)
+
+      typeof(1.to_big_f <=> 1.to_big_f).should eq(Int32)
+    end
+  end
+
   describe "unary #-" do
     it do
       bf = "0.12345".to_big_f

--- a/src/big/big_float.cr
+++ b/src/big/big_float.cr
@@ -103,8 +103,8 @@ struct BigFloat < Float
     LibGMP.mpf_cmp_z(self, other)
   end
 
-  def <=>(other : Float32 | Float64)
-    LibGMP.mpf_cmp_d(self, other.to_f64)
+  def <=>(other : Float::Primitive)
+    LibGMP.mpf_cmp_d(self, other) unless other.nan?
   end
 
   def <=>(other : Number)
@@ -387,10 +387,6 @@ end
 struct Number
   include Comparable(BigFloat)
 
-  def <=>(other : BigFloat)
-    -(other <=> self)
-  end
-
   def +(other : BigFloat)
     other + self
   end
@@ -409,6 +405,19 @@ struct Number
 
   def to_big_f : BigFloat
     BigFloat.new(self)
+  end
+end
+
+struct Int
+  def <=>(other : BigFloat)
+    -(other <=> self)
+  end
+end
+
+struct Float
+  def <=>(other : BigFloat)
+    cmp = other <=> self
+    -cmp if cmp
   end
 end
 


### PR DESCRIPTION
Like #13293, but for `BigFloat` against `Float64::NAN` or `Float32::NAN`.