### PR TITLE
Make `BigRational.new(BigFloat)` exact

### DIFF
--- a/spec/std/big/big_rational_spec.cr
+++ b/spec/std/big/big_rational_spec.cr
@@ -1,6 +1,17 @@
 require "spec"
 require "big"
 
+private def with_precision(precision, &)
+  old_precision = BigFloat.default_precision
+  BigFloat.default_precision = precision
+
+  begin
+    yield
+  ensure
+    BigFloat.default_precision = old_precision
+  end
+end
+
 private def br(n, d)
   BigRational.new(n, d)
 end
@@ -33,6 +44,14 @@ describe BigRational do
 
     expect_raises(DivisionByZeroError) do
       BigRational.new(2, 0)
+    end
+  end
+
+  it "initializes from BigFloat with high precision" do
+    (0..12).each do |i|
+      bf = BigFloat.new(2.0, precision: 64) ** 64 + BigFloat.new(2.0, precision: 64) ** i
+      br = BigRational.new(bf)
+      br.should eq(bf)
     end
   end
 

--- a/spec/std/big/big_rational_spec.cr
+++ b/spec/std/big/big_rational_spec.cr
@@ -1,17 +1,6 @@
 require "spec"
 require "big"
 
-private def with_precision(precision, &)
-  old_precision = BigFloat.default_precision
-  BigFloat.default_precision = precision
-
-  begin
-    yield
-  ensure
-    BigFloat.default_precision = old_precision
-  end
-end
-
 private def br(n, d)
   BigRational.new(n, d)
 end

--- a/src/big/lib_gmp.cr
+++ b/src/big/lib_gmp.cr
@@ -196,6 +196,7 @@ lib LibGMP
   # # Precision
   fun mpf_set_default_prec = __gmpf_set_default_prec(prec : BitcntT)
   fun mpf_get_default_prec = __gmpf_get_default_prec : BitcntT
+  fun mpf_get_prec = __gmpf_get_prec(op : MPF*) : BitcntT
 
   # # Conversion
   fun mpf_get_str = __gmpf_get_str(str : UInt8*, expptr : MpExp*, base : Int, n_digits : LibC::SizeT, op : MPF*) : UInt8*


### PR DESCRIPTION
`BigRational.new(Float::Primitive)` is exact, and so is `BigFloat.new(BigRational)`, which GMP provides. `BigRational.new(BigFloat)` isn't, because it shares the same overload as primitive floats, and assumes only 52 bits of precision are available in the mantissa:

```crystal
# the default precision is already 64 bits almost everywhere
BigFloat.default_precision = 64

x = 2.to_big_f ** 64
x          # => 1.8446744073709551616e+19
x.to_big_r # => 18446744073709551616

x = 2.to_big_f ** 64 + 1.to_big_f
x          # => 1.8446744073709551617e+19
x.to_big_r # => 18446744073709551616

x = 2.to_big_f ** 64 + 2048.to_big_f
x          # => 1.8446744073709553664e+19
x.to_big_r # => 18446744073709551616

x = 2.to_big_f ** 64 + 4095.to_big_f
x          # => 1.8446744073709555711e+19
x.to_big_r # => 18446744073709551616

x = 2.to_big_f ** 64 + 4096.to_big_f
x          # => 1.8446744073709555712e+19
x.to_big_r # => 18446744073709555712
```

This PR ensures no bits are lost after using `Math.frexp` to decompose the argument.