### PR TITLE
Always use 0 for offsets of lib / extern union members

### DIFF
--- a/spec/compiler/codegen/debug_spec.cr
+++ b/spec/compiler/codegen/debug_spec.cr
@@ -16,6 +16,33 @@ describe "Code gen: debug" do
       ), debug: Crystal::Debug::All)
   end
 
+  it "codegens lib union (#7335)" do
+    codegen <<-CRYSTAL, debug: Crystal::Debug::All
+      lib Foo
+        union Bar
+          a : Int32
+          b : Int16
+          c : Int8
+        end
+      end
+
+      x = Foo::Bar.new
+      CRYSTAL
+  end
+
+  it "codegens extern union (#7335)" do
+    codegen <<-CRYSTAL, debug: Crystal::Debug::All
+      @[Extern(union: true)]
+      struct Foo
+        @a = uninitialized Int32
+        @b = uninitialized Int16
+        @c = uninitialized Int8
+      end
+
+      x = Foo.new
+      CRYSTAL
+  end
+
   it "inlines instance var access through getter in debug mode" do
     run(%(
       struct Bar

--- a/spec/compiler/codegen/offsetof_spec.cr
+++ b/spec/compiler/codegen/offsetof_spec.cr
@@ -39,4 +39,21 @@ describe "Code gen: offsetof" do
 
     run(code).to_b.should be_true
   end
+
+  it "returns offset of extern union" do
+    run(<<-CRYSTAL).to_b.should be_true
+      @[Extern(union: true)]
+      struct Foo
+        @x = 1.0_f32
+        @y = uninitialized UInt32
+
+        def y
+          @y
+        end
+      end
+
+      f = Foo.new
+      (pointerof(f).as(Void*) + offsetof(Foo, @y).to_i64).as(UInt32*).value == f.y
+      CRYSTAL
+  end
 end

--- a/spec/debug/extern_unions.cr
+++ b/spec/debug/extern_unions.cr
@@ -1,0 +1,17 @@
+@[Extern(union: true)]
+struct Foo
+  @x : Float32
+  @y = uninitialized UInt32
+  @z = uninitialized UInt8[4]
+
+  def initialize(@x)
+  end
+end
+
+raise "wrong endianness" unless IO::ByteFormat::SystemEndian == IO::ByteFormat::LittleEndian
+
+x = Foo.new(1.0_f32)
+# print: x
+# lldb-check: $0 = (x = 1065353216, y = 1, z = "\0\0\x80?")
+# gdb-check: $1 = {x = 1065353216, y = 1, z = "\000\000\200?"}
+debugger

--- a/src/compiler/crystal/codegen/codegen.cr
+++ b/src/compiler/crystal/codegen/codegen.cr
@@ -105,7 +105,7 @@ module Crystal
     end
 
     def offset_of(type, element_index)
-      element_index = element_index.class.zero if type.extern_union?
+      return 0_u64 if type.extern_union?
       llvm_typer.offset_of(llvm_typer.llvm_type(type), element_index)
     end
 

--- a/src/compiler/crystal/codegen/codegen.cr
+++ b/src/compiler/crystal/codegen/codegen.cr
@@ -105,7 +105,7 @@ module Crystal
     end
 
     def offset_of(type, element_index)
-      return 0_u64 if type.extern_union?
+      element_index = element_index.class.zero if type.extern_union?
       llvm_typer.offset_of(llvm_typer.llvm_type(type), element_index)
     end
 

--- a/src/compiler/crystal/codegen/codegen.cr
+++ b/src/compiler/crystal/codegen/codegen.cr
@@ -105,10 +105,13 @@ module Crystal
     end
 
     def offset_of(type, element_index)
+      return 0_u64 if type.extern_union?
       llvm_typer.offset_of(llvm_typer.llvm_type(type), element_index)
     end
 
     def instance_offset_of(type, element_index)
+      # extern unions must be value types, which always use the above
+      # `offset_of` instead
       llvm_typer.offset_of(llvm_typer.llvm_struct_type(type), element_index + 1)
     end
   end

--- a/src/compiler/crystal/codegen/debug.cr
+++ b/src/compiler/crystal/codegen/debug.cr
@@ -158,13 +158,13 @@ module Crystal
 
       size = @program.target_machine.data_layout.size_in_bits(struct_type)
       elements = di_builder.get_or_create_type_array(element_types)
-      debug_type = if type.extern_union?
-                     di_builder.create_union_type(nil, original_type.to_s, nil, 1, size, size, LLVM::DIFlags::Zero, elements)
-                   else
-                     di_builder.create_struct_type(nil, original_type.to_s, nil, 1, size, size, LLVM::DIFlags::Zero, nil, elements)
-                   end
-      unless type.struct?
-        debug_type = di_builder.create_pointer_type(debug_type, 8u64 * llvm_typer.pointer_size, 8u64 * llvm_typer.pointer_size, original_type.to_s)
+      if type.extern_union?
+        debug_type = di_builder.create_union_type(nil, original_type.to_s, nil, 1, size, size, LLVM::DIFlags::Zero, elements)
+      else
+        debug_type = di_builder.create_struct_type(nil, original_type.to_s, nil, 1, size, size, LLVM::DIFlags::Zero, nil, elements)
+        unless type.struct?
+          debug_type = di_builder.create_pointer_type(debug_type, 8u64 * llvm_typer.pointer_size, 8u64 * llvm_typer.pointer_size, original_type.to_s)
+        end
       end
       di_builder.replace_temporary(tmp_debug_type, debug_type)
       debug_type

--- a/src/compiler/crystal/codegen/debug.cr
+++ b/src/compiler/crystal/codegen/debug.cr
@@ -82,7 +82,7 @@ module Crystal
       @debug_files_per_module[@llvm_mod] ||= {} of DebugFilename => LibLLVM::MetadataRef
     end
 
-    def current_debug_file
+    private def current_debug_file
       # These debug files are only used for `DIBuilder#create_union_type`, even
       # though they are unneeded here, just as struct types don't need a file;
       # LLVM 12 or below produces an assertion failure that is now removed

--- a/src/compiler/crystal/codegen/debug.cr
+++ b/src/compiler/crystal/codegen/debug.cr
@@ -148,7 +148,7 @@ module Crystal
       ivars.each_with_index do |(name, ivar), idx|
         next if ivar.type.is_a?(NilType)
         if (ivar_type = ivar.type?) && (ivar_debug_type = get_debug_type(ivar_type))
-          offset = @program.target_machine.data_layout.offset_of_element(struct_type, type.extern_union? ? 0 : idx &+ (type.struct? ? 0 : 1))
+          offset = type.extern_union? ? 0_u64 : @program.target_machine.data_layout.offset_of_element(struct_type, idx &+ (type.struct? ? 0 : 1))
           size = @program.target_machine.data_layout.size_in_bits(llvm_embedded_type(ivar_type))
 
           member = di_builder.create_member_type(nil, name[1..-1], nil, 1, size, size, 8u64 * offset, LLVM::DIFlags::Zero, ivar_debug_type)

--- a/src/compiler/crystal/codegen/debug.cr
+++ b/src/compiler/crystal/codegen/debug.cr
@@ -288,9 +288,6 @@ module Crystal
           offset = @program.target_machine.data_layout.offset_of_element(struct_type, idx &+ (type.struct? ? 0 : 1))
           size = @program.target_machine.data_layout.size_in_bits(llvm_embedded_type(ivar_type))
 
-          # FIXME structs like LibC::PthreadMutexT generate huge offset values
-          next if offset > UInt64::MAX // 8u64
-
           member = di_builder.create_member_type(nil, ivar.name, nil, 1, size, size, 8u64 * offset, LLVM::DIFlags::Zero, ivar_debug_type)
           element_types << member
         end

--- a/src/compiler/crystal/codegen/debug.cr
+++ b/src/compiler/crystal/codegen/debug.cr
@@ -148,7 +148,7 @@ module Crystal
       ivars.each_with_index do |(name, ivar), idx|
         next if ivar.type.is_a?(NilType)
         if (ivar_type = ivar.type?) && (ivar_debug_type = get_debug_type(ivar_type))
-          offset = type.extern_union? ? 0_u64 : @program.target_machine.data_layout.offset_of_element(struct_type, idx &+ (type.struct? ? 0 : 1))
+          offset = @program.target_machine.data_layout.offset_of_element(struct_type, type.extern_union? ? 0 : idx &+ (type.struct? ? 0 : 1))
           size = @program.target_machine.data_layout.size_in_bits(llvm_embedded_type(ivar_type))
 
           member = di_builder.create_member_type(nil, name[1..-1], nil, 1, size, size, 8u64 * offset, LLVM::DIFlags::Zero, ivar_debug_type)

--- a/src/compiler/crystal/codegen/debug.cr
+++ b/src/compiler/crystal/codegen/debug.cr
@@ -159,7 +159,7 @@ module Crystal
       size = @program.target_machine.data_layout.size_in_bits(struct_type)
       elements = di_builder.get_or_create_type_array(element_types)
       if type.extern_union?
-        debug_type = di_builder.create_union_type(nil, original_type.to_s, nil, 1, size, size, LLVM::DIFlags::Zero, elements)
+        debug_type = di_builder.create_union_type(nil, original_type.to_s, current_debug_file, 1, size, size, LLVM::DIFlags::Zero, elements)
       else
         debug_type = di_builder.create_struct_type(nil, original_type.to_s, nil, 1, size, size, LLVM::DIFlags::Zero, nil, elements)
         unless type.struct?

--- a/src/llvm/target_data.cr
+++ b/src/llvm/target_data.cr
@@ -23,6 +23,8 @@ struct LLVM::TargetData
   end
 
   def offset_of_element(struct_type, element)
+    # element_count = LibLLVM.count_struct_element_types(struct_type)
+    # raise "Invalid element idx!" unless element < element_count
     LibLLVM.offset_of_element(self, struct_type, element)
   end
 


### PR DESCRIPTION
Fixes #9744. See https://github.com/crystal-lang/crystal/issues/13205#issuecomment-1503847741. Removes the workaround in #7335.

`pointerof` doesn't have the same issue. Also it seems interpreter specs were broken for a while and fixed here, but I am not 100% sure.

@will @biqqles @zhangkaizhao If possible, please check whether this PR affects #13205, #12589, and https://github.com/crystal-lang/crystal/issues/11934#issuecomment-1079851964 respectively