### PR TITLE
Show PCRE/PCRE2 configuration on CI

### DIFF
--- a/.github/workflows/regex-engine.yml
+++ b/.github/workflows/regex-engine.yml
@@ -16,6 +16,8 @@ jobs:
         uses: actions/checkout@v3
       - name: Assert using PCRE
         run: bin/crystal eval 'abort unless Regex::Engine == Regex::PCRE'
+      - name: Show PCRE config
+        run: bin/crystal scripts/print_regex_config.cr
       - name: Run Regex specs
         run: bin/crystal spec --order=random spec/std/regex*
   pcre2:
@@ -31,5 +33,7 @@ jobs:
         run: bin/crystal eval 'abort unless Regex::Engine == Regex::PCRE2'
       - name: Assert select PCRE
         run: bin/crystal eval -Duse_pcre 'abort unless Regex::Engine == Regex::PCRE'
+      - name: Show PCRE2 config
+        run: bin/crystal scripts/print_regex_config.cr
       - name: Run Regex specs
         run: bin/crystal spec --order=random spec/std/regex*

--- a/bin/ci
+++ b/bin/ci
@@ -98,6 +98,7 @@ prepare_system() {
 }
 
 build() {
+  with_build_env 'bin/crystal scripts/print_regex_config.cr'
   with_build_env 'make std_spec clean threads=1 junit_output=.junit/std_spec.xml'
 
   case $ARCH in

--- a/scripts/print_regex_config.cr
+++ b/scripts/print_regex_config.cr
@@ -1,0 +1,135 @@
+#! /usr/bin/env crystal
+
+{% if Regex::Engine.resolve.name == "Regex::PCRE2" %}
+  enum LibPCRE2::BSR : UInt32
+    UNICODE = 1
+    ANYCRLF = 2
+  end
+
+  @[Flags]
+  enum LibPCRE2::COMPILED_WIDTHS : UInt32
+    U8
+    U16
+    U32
+    Unused
+  end
+
+  enum LibPCRE2::NEWLINE : UInt32
+    CR      = 1
+    LF      = 2
+    CRLF    = 3
+    ANY     = 4
+    ANYCRLF = 5
+    NUL     = 6
+  end
+
+  def config(kind : UInt32.class, what)
+    where = uninitialized UInt32
+    LibPCRE2.config(what, pointerof(where))
+    where
+  end
+
+  def config(kind : Bool.class, what)
+    config(UInt32, what) != 0
+  end
+
+  def config(kind : String.class, what)
+    where = Bytes.new(LibPCRE2.config(what, nil) - 1)
+    LibPCRE2.config(what, where)
+    String.new(where).inspect
+  end
+
+  def config(kind : Enum.class, what)
+    kind.new(config(UInt32, what))
+  end
+
+  puts <<-EOS
+  Using PCRE2 #{config(String, LibPCRE2::CONFIG_VERSION)}
+  * PCRE2_CONFIG_BSR:               #{config(LibPCRE2::BSR, LibPCRE2::CONFIG_BSR)}
+  * PCRE2_CONFIG_COMPILED_WIDTHS:   #{config(LibPCRE2::COMPILED_WIDTHS, LibPCRE2::CONFIG_COMPILED_WIDTHS)}
+  * PCRE2_CONFIG_DEPTHLIMIT:        #{config(UInt32, LibPCRE2::CONFIG_DEPTHLIMIT)}
+  * PCRE2_CONFIG_HEAPLIMIT:         #{config(UInt32, LibPCRE2::CONFIG_HEAPLIMIT)}
+  * PCRE2_CONFIG_JIT:               #{config(Bool, LibPCRE2::CONFIG_JIT)}
+  * PCRE2_CONFIG_JITTARGET:         #{config(String, LibPCRE2::CONFIG_JITTARGET)}
+  * PCRE2_CONFIG_LINKSIZE:          #{config(UInt32, LibPCRE2::CONFIG_LINKSIZE)}
+  * PCRE2_CONFIG_MATCHLIMIT:        #{config(UInt32, LibPCRE2::CONFIG_MATCHLIMIT)}
+  * PCRE2_CONFIG_NEVER_BACKSLASH_C: #{config(Bool, LibPCRE2::CONFIG_NEVER_BACKSLASH_C)}
+  * PCRE2_CONFIG_NEWLINE:           #{config(LibPCRE2::NEWLINE, LibPCRE2::CONFIG_NEWLINE)}
+  * PCRE2_CONFIG_PARENSLIMIT:       #{config(UInt32, LibPCRE2::CONFIG_PARENSLIMIT)}
+  * PCRE2_CONFIG_UNICODE:           #{config(Bool, LibPCRE2::CONFIG_UNICODE)}
+  * PCRE2_CONFIG_UNICODE_VERSION:   #{config(String, LibPCRE2::CONFIG_UNICODE_VERSION)}
+  EOS
+{% else %}
+  enum LibPCRE::BSR : LibC::Int
+    UNICODE = 0
+    ANYCRLF = 1
+  end
+
+  enum LibPCRE::NEWLINE : LibC::Int
+    CR      = 0x000d
+    LF      = 0x000a
+    CRLF    = 0x0d0a
+    ANYCRLF =     -2
+    ANY     =     -1
+  end
+
+  lib LibPCRE
+    CONFIG_UTF8                   =  0
+    CONFIG_NEWLINE                =  1
+    CONFIG_LINK_SIZE              =  2
+    CONFIG_POSIX_MALLOC_THRESHOLD =  3
+    CONFIG_MATCH_LIMIT            =  4
+    CONFIG_STACKRECURSE           =  5
+    CONFIG_UNICODE_PROPERTIES     =  6
+    CONFIG_MATCH_LIMIT_RECURSION  =  7
+    CONFIG_BSR                    =  8
+    CONFIG_UTF16                  = 10
+    CONFIG_JITTARGET              = 11
+    CONFIG_UTF32                  = 12
+    CONFIG_PARENS_LIMIT           = 13
+  end
+
+  def config(kind : LibC::Int.class, what)
+    where = uninitialized LibC::Int
+    LibPCRE.config(what, pointerof(where))
+    where
+  end
+
+  def config(kind : LibC::ULong.class, what)
+    where = uninitialized LibC::ULong
+    LibPCRE.config(what, pointerof(where))
+    where
+  end
+
+  def config(kind : Bool.class, what)
+    config(LibC::Int, what) != 0
+  end
+
+  def config(kind : String.class, what)
+    where = uninitialized LibC::Char*
+    LibPCRE.config(what, pointerof(where))
+    (where ? String.new(where) : nil).inspect
+  end
+
+  def config(kind : Enum.class, what)
+    kind.new(config(LibC::Int, what))
+  end
+
+  puts <<-EOS
+  Using PCRE #{String.new(LibPCRE.version).inspect}
+  * PCRE_CONFIG_BSR:                    #{config(LibPCRE::BSR, LibPCRE::CONFIG_BSR)}
+  * PCRE_CONFIG_JIT:                    #{config(Bool, LibPCRE::CONFIG_JIT)}
+  * PCRE_CONFIG_JITTARGET:              #{config(String, LibPCRE::CONFIG_JITTARGET)}
+  * PCRE_CONFIG_LINK_SIZE:              #{config(LibC::Int, LibPCRE::CONFIG_LINK_SIZE)}
+  * PCRE_CONFIG_PARENS_LIMIT:           #{config(LibC::ULong, LibPCRE::CONFIG_PARENS_LIMIT)}
+  * PCRE_CONFIG_MATCH_LIMIT:            #{config(LibC::ULong, LibPCRE::CONFIG_MATCH_LIMIT)}
+  * PCRE_CONFIG_MATCH_LIMIT_RECURSION:  #{config(LibC::ULong, LibPCRE::CONFIG_MATCH_LIMIT_RECURSION)}
+  * PCRE_CONFIG_NEWLINE:                #{config(LibPCRE::NEWLINE, LibPCRE::CONFIG_NEWLINE)}
+  * PCRE_CONFIG_POSIX_MALLOC_THRESHOLD: #{config(LibC::Int, LibPCRE::CONFIG_POSIX_MALLOC_THRESHOLD)}
+  * PCRE_CONFIG_STACKRECURSE:           #{config(Bool, LibPCRE::CONFIG_STACKRECURSE)}
+  * PCRE_CONFIG_UTF16:                  #{config(Bool, LibPCRE::CONFIG_UTF16)}
+  * PCRE_CONFIG_UTF32:                  #{config(Bool, LibPCRE::CONFIG_UTF32)}
+  * PCRE_CONFIG_UTF8:                   #{config(Bool, LibPCRE::CONFIG_UTF8)}
+  * PCRE_CONFIG_UNICODE_PROPERTIES:     #{config(Bool, LibPCRE::CONFIG_UNICODE_PROPERTIES)}
+  EOS
+{% end %}

--- a/spec/std/regex_spec.cr
+++ b/spec/std/regex_spec.cr
@@ -276,7 +276,8 @@ describe "Regex" do
       str = File.read(datapath("large_single_line_string.txt"))
 
       {% if Regex::Engine.resolve.name == "Regex::PCRE" %}
-        LibPCRE.config LibPCRE::CONFIG_JIT, out jit_enabled
+        jit_enabled = uninitialized LibC::Int
+        LibPCRE.config LibPCRE::CONFIG_JIT, pointerof(jit_enabled)
         pending! "PCRE JIT mode not available." unless 1 == jit_enabled
 
         # This match may raise on JIT stack limit or not. If it raises, the error message should be the expected one.

--- a/src/regex/lib_pcre.cr
+++ b/src/regex/lib_pcre.cr
@@ -84,7 +84,7 @@ lib LibPCRE
   type Pcre = Void*
   type PcreExtra = Void*
   fun compile = pcre_compile(pattern : UInt8*, options : Int, errptr : UInt8**, erroffset : Int*, tableptr : Void*) : Pcre
-  fun config = pcre_config(what : Int, where : Int*) : Int
+  fun config = pcre_config(what : Int, where : Void*) : Int
   fun exec = pcre_exec(code : Pcre, extra : PcreExtra, subject : UInt8*, length : Int, offset : Int, options : Int, ovector : Int*, ovecsize : Int) : Int
   fun study = pcre_study(code : Pcre, options : Int, errptr : UInt8**) : PcreExtra
   fun free_study = pcre_free_study(extra : PcreExtra) : Void


### PR DESCRIPTION
This PR adds a script that shows the compile-time configuration settings, including ones not used in the standard library, of PCRE or PCRE2. Currently only some Linux jobs call this script, because that's where PCRE2-related failures most likely happen at this moment. It gives:

**x86_64-gnu-test (1.7.3)**

```
Using PCRE2 "10.34 2019-11-21"
* PCRE2_CONFIG_BSR:               UNICODE
* PCRE2_CONFIG_COMPILED_WIDTHS:   U8 | U16 | U32
* PCRE2_CONFIG_DEPTHLIMIT:        10000000
* PCRE2_CONFIG_HEAPLIMIT:         20000000
* PCRE2_CONFIG_JIT:               true
* PCRE2_CONFIG_JITTARGET:         "x86 64bit (little endian + unaligned)"
* PCRE2_CONFIG_LINKSIZE:          2
* PCRE2_CONFIG_MATCHLIMIT:        10000000
* PCRE2_CONFIG_NEVER_BACKSLASH_C: false
* PCRE2_CONFIG_NEWLINE:           LF
* PCRE2_CONFIG_PARENSLIMIT:       250
* PCRE2_CONFIG_UNICODE:           true
* PCRE2_CONFIG_UNICODE_VERSION:   "12.1.0"
```

**PCRE (from Alpine apk)**

```
Using PCRE "8.45 2021-06-15"
* PCRE_CONFIG_BSR:                    UNICODE
* PCRE_CONFIG_JIT:                    true
* PCRE_CONFIG_JITTARGET:              "x86 64bit (little endian + unaligned)"
* PCRE_CONFIG_LINK_SIZE:              2
* PCRE_CONFIG_PARENS_LIMIT:           250
* PCRE_CONFIG_MATCH_LIMIT:            10000000
* PCRE_CONFIG_MATCH_LIMIT_RECURSION:  8192
* PCRE_CONFIG_NEWLINE:                LF
* PCRE_CONFIG_POSIX_MALLOC_THRESHOLD: 10
* PCRE_CONFIG_STACKRECURSE:           true
* PCRE_CONFIG_UTF16:                  false
* PCRE_CONFIG_UTF32:                  false
* PCRE_CONFIG_UTF8:                   true
* PCRE_CONFIG_UNICODE_PROPERTIES:     true
```

**PCRE2 (from Alpine apk)**

```
Using PCRE2 "10.40 2022-04-14"
* PCRE2_CONFIG_BSR:               UNICODE
* PCRE2_CONFIG_COMPILED_WIDTHS:   U8 | U16 | U32
* PCRE2_CONFIG_DEPTHLIMIT:        8192
* PCRE2_CONFIG_HEAPLIMIT:         20000000
* PCRE2_CONFIG_JIT:               true
* PCRE2_CONFIG_JITTARGET:         "x86 64bit (little endian + unaligned)"
* PCRE2_CONFIG_LINKSIZE:          2
* PCRE2_CONFIG_MATCHLIMIT:        10000000
* PCRE2_CONFIG_NEVER_BACKSLASH_C: false
* PCRE2_CONFIG_NEWLINE:           LF
* PCRE2_CONFIG_PARENSLIMIT:       250
* PCRE2_CONFIG_UNICODE:           true
* PCRE2_CONFIG_UNICODE_VERSION:   "14.0.0"
```

Unfortunately this doesn't seem particularly relevant to #13306.