### PR TITLE
Drop `MATCH_INVALID_UTF`

### DIFF
--- a/spec/std/regex_spec.cr
+++ b/spec/std/regex_spec.cr
@@ -110,17 +110,9 @@ describe "Regex" do
     end
 
     it "with invalid UTF-8" do
-      {% if Regex::Engine.resolve.name == "Regex::PCRE" %}
-        expect_raises(ArgumentError, "UTF-8 error") do
-          /([\w_\.@#\/\*])+/.match("\xFF\xFE")
-        end
-      {% else %}
-        if Regex::PCRE2.version_number < {10, 36}
-          pending! "Error in libpcre2 < 10.36"
-        else
-          /([\w_\.@#\/\*])+/.match("\xFF\xFE").should be_nil
-        end
-      {% end %}
+      expect_raises(ArgumentError, "UTF-8 error") do
+        /([\w_\.@#\/\*])+/.match("\xFF\xFE")
+      end
     end
   end
 
@@ -154,14 +146,8 @@ describe "Regex" do
     end
 
     it "multibyte index" do
-      if Regex::Engine.version_number < {10, 36}
-        expect_raises(ArgumentError, "bad offset into UTF string") do
-          /foo/.match_at_byte_index("öfoo", 1)
-        end
-      else
-        md = /foo/.match_at_byte_index("öfoo", 1).should_not be_nil
-        md.begin.should eq 1
-        md.byte_begin.should eq 2
+      expect_raises(ArgumentError, "bad offset into UTF string") do
+        /foo/.match_at_byte_index("öfoo", 1)
       end
 
       md = /foo/.match_at_byte_index("öfoo", 2).should_not be_nil
@@ -246,16 +232,8 @@ describe "Regex" do
       end
 
       it "invalid codepoint" do
-        if Regex::Engine.version_number < {10, 36}
-          expect_raises(ArgumentError, "UTF-8 error") do
-            /foo/.matches?("f\x96o")
-          end
-        else
-          /foo/.matches?("f\x96o").should be_false
-          /f\x96o/.matches?("f\x96o").should be_false
-          /f.o/.matches?("f\x96o").should be_false
-          /\bf\b/.matches?("f\x96o").should be_true
-          /\bo\b/.matches?("f\x96o").should be_true
+        expect_raises(ArgumentError, "UTF-8 error") do
+          /foo/.matches?("f\x96o")
         end
       end
     end
@@ -310,12 +288,8 @@ describe "Regex" do
     end
 
     it "multibyte index" do
-      if Regex::Engine.version_number < {10, 36}
-        expect_raises(ArgumentError, "bad offset into UTF string") do
-          /foo/.matches_at_byte_index?("öfoo", 1)
-        end
-      else
-        /foo/.matches_at_byte_index?("öfoo", 1).should be_true
+      expect_raises(ArgumentError, "bad offset into UTF string") do
+        /foo/.matches_at_byte_index?("öfoo", 1)
       end
       /foo/.matches_at_byte_index?("öfoo", 2).should be_true
     end

--- a/spec/std/regex_spec.cr
+++ b/spec/std/regex_spec.cr
@@ -30,7 +30,7 @@ describe "Regex" do
       expect_raises(ArgumentError, /invalid UTF-8 string|UTF-8 error/) do
         Regex.new("\x96")
       end
-      Regex.new("\x96", :NO_UTF8_CHECK).should be_a(Regex)
+      Regex.new("\x96", :NO_UTF_CHECK).should be_a(Regex)
     end
   end
 

--- a/spec/std/regex_spec.cr
+++ b/spec/std/regex_spec.cr
@@ -118,6 +118,11 @@ describe "Regex" do
         Regex.new("([\\w_\\.@#\\/\\*])+", options: Regex::Options::MATCH_INVALID_UTF).match("\xFF\xFE").should be_nil
       end
     end
+
+    it "skip invalid UTF check" do
+      # no exception raised
+      /f.o/.matches?("f\xFFo", options: Regex::MatchOptions::NO_UTF_CHECK)
+    end
   end
 
   describe "#match_at_byte_index" do

--- a/src/regex.cr
+++ b/src/regex.cr
@@ -273,7 +273,7 @@ class Regex
     #
     # NOTE: This option was introduced in PCRE2 10.34 but a bug that can lead to an
     # infinite loop is only fixed in 10.36 (https://github.com/PCRE2Project/pcre2/commit/e0c6029a62db9c2161941ecdf459205382d4d379).
-    MATCH_INVALID_UTF
+    MATCH_INVALID_UTF = 0x1_0000_0000
   end
 
   # Represents compile options passed to `Regex.new`.

--- a/src/regex.cr
+++ b/src/regex.cr
@@ -260,6 +260,20 @@ class Regex
 
     # Do not check the pattern for valid UTF encoding.
     NO_UTF_CHECK = NO_UTF8_CHECK
+
+    # Enable matching against subjects containing invalid UTF bytes.
+    # Invalid bytes never match anything. The entire subject string is
+    # effectively split into segments of valid UTF.
+    #
+    # Read more in the [PCRE2 documentation](https://www.pcre.org/current/doc/html/pcre2unicode.html#matchinvalid).
+    #
+    # When this option is set, `MatchOptions::NO_UTF_CHECK` is ignored at match time.
+    #
+    # Unsupported with PCRE.
+    #
+    # NOTE: This option was introduced in PCRE2 10.34 but a bug that can lead to an
+    # infinite loop is only fixed in 10.36 (https://github.com/PCRE2Project/pcre2/commit/e0c6029a62db9c2161941ecdf459205382d4d379).
+    MATCH_INVALID_UTF
   end
 
   # Represents compile options passed to `Regex.new`.

--- a/src/regex.cr
+++ b/src/regex.cr
@@ -257,6 +257,9 @@ class Regex
     #
     # Unsupported with PCRE.
     ENDANCHORED = 0x8000_0000
+
+    # Do not check the pattern for valid UTF encoding.
+    NO_UTF_CHECK = NO_UTF8_CHECK
   end
 
   # Represents compile options passed to `Regex.new`.

--- a/src/regex.cr
+++ b/src/regex.cr
@@ -296,6 +296,12 @@ class Regex
     #
     # Unsupported with PCRE.
     NO_JIT
+
+    # Do not check subject for valid UTF encoding.
+    #
+    # This option has no effect if the pattern was compiled with
+    # `CompileOptions::MATCH_INVALID_UTF` when using PCRE2 10.34+.
+    NO_UTF_CHECK
   end
 
   # Returns a `Regex::CompileOptions` representing the optional flags applied to this `Regex`.

--- a/src/regex/pcre.cr
+++ b/src/regex/pcre.cr
@@ -74,7 +74,7 @@ module Regex::PCRE
                 when .dollar_endonly? then raise ArgumentError.new("Invalid regex option DOLLAR_ENDONLY for `pcre_exec`")
                 when .firstline?      then raise ArgumentError.new("Invalid regex option FIRSTLINE for `pcre_exec`")
                 when .utf_8?          then raise ArgumentError.new("Invalid regex option UTF_8 for `pcre_exec`")
-                when .no_utf8_check?  then LibPCRE::NO_UTF8_CHECK
+                when .no_utf_check?   then LibPCRE::NO_UTF8_CHECK
                 when .dupnames?       then raise ArgumentError.new("Invalid regex option DUPNAMES for `pcre_exec`")
                 when .ucp?            then raise ArgumentError.new("Invalid regex option UCP for `pcre_exec`")
                 when .endanchored?    then raise ArgumentError.new("Regex::Option::ENDANCHORED is not supported with PCRE")
@@ -96,9 +96,10 @@ module Regex::PCRE
     Regex::MatchOptions.each do |option|
       if options.includes?(option)
         flag |= case option
-                when .anchored?    then LibPCRE::ANCHORED
-                when .endanchored? then raise ArgumentError.new("Regex::Option::ENDANCHORED is not supported with PCRE")
-                when .no_jit?      then raise ArgumentError.new("Regex::Option::NO_JIT is not supported with PCRE")
+                when .anchored?     then LibPCRE::ANCHORED
+                when .endanchored?  then raise ArgumentError.new("Regex::Option::ENDANCHORED is not supported with PCRE")
+                when .no_jit?       then raise ArgumentError.new("Regex::Option::NO_JIT is not supported with PCRE")
+                when .no_utf_check? then LibPCRE::NO_UTF8_CHECK
                 else
                   raise "unreachable"
                 end

--- a/src/regex/pcre.cr
+++ b/src/regex/pcre.cr
@@ -43,7 +43,7 @@ module Regex::PCRE
                 when .dollar_endonly? then LibPCRE::DOLLAR_ENDONLY
                 when .firstline?      then LibPCRE::FIRSTLINE
                 when .utf_8?          then LibPCRE::UTF8
-                when .no_utf8_check?  then LibPCRE::NO_UTF8_CHECK
+                when .no_utf_check?   then LibPCRE::NO_UTF8_CHECK
                 when .dupnames?       then LibPCRE::DUPNAMES
                 when .ucp?            then LibPCRE::UCP
                 when .endanchored?    then raise ArgumentError.new("Regex::Option::ENDANCHORED is not supported with PCRE")

--- a/src/regex/pcre.cr
+++ b/src/regex/pcre.cr
@@ -35,18 +35,19 @@ module Regex::PCRE
     Regex::CompileOptions.each do |option|
       if options.includes?(option)
         flag |= case option
-                when .ignore_case?    then LibPCRE::CASELESS
-                when .multiline?      then LibPCRE::DOTALL | LibPCRE::MULTILINE
-                when .dotall?         then LibPCRE::DOTALL
-                when .extended?       then LibPCRE::EXTENDED
-                when .anchored?       then LibPCRE::ANCHORED
-                when .dollar_endonly? then LibPCRE::DOLLAR_ENDONLY
-                when .firstline?      then LibPCRE::FIRSTLINE
-                when .utf_8?          then LibPCRE::UTF8
-                when .no_utf_check?   then LibPCRE::NO_UTF8_CHECK
-                when .dupnames?       then LibPCRE::DUPNAMES
-                when .ucp?            then LibPCRE::UCP
-                when .endanchored?    then raise ArgumentError.new("Regex::Option::ENDANCHORED is not supported with PCRE")
+                when .ignore_case?       then LibPCRE::CASELESS
+                when .multiline?         then LibPCRE::DOTALL | LibPCRE::MULTILINE
+                when .dotall?            then LibPCRE::DOTALL
+                when .extended?          then LibPCRE::EXTENDED
+                when .anchored?          then LibPCRE::ANCHORED
+                when .dollar_endonly?    then LibPCRE::DOLLAR_ENDONLY
+                when .firstline?         then LibPCRE::FIRSTLINE
+                when .utf_8?             then LibPCRE::UTF8
+                when .no_utf_check?      then LibPCRE::NO_UTF8_CHECK
+                when .dupnames?          then LibPCRE::DUPNAMES
+                when .ucp?               then LibPCRE::UCP
+                when .endanchored?       then raise ArgumentError.new("Regex::Option::ENDANCHORED is not supported with PCRE")
+                when .match_invalid_utf? then raise ArgumentError.new("Regex::Option::MATCH_INVALID_UTF is not supported with PCRE")
                 else
                   raise "unreachable"
                 end

--- a/src/regex/pcre2.cr
+++ b/src/regex/pcre2.cr
@@ -73,7 +73,7 @@ module Regex::PCRE2
                 when .dollar_endonly? then LibPCRE2::DOLLAR_ENDONLY
                 when .firstline?      then LibPCRE2::FIRSTLINE
                 when .utf_8?          then LibPCRE2::UTF
-                when .no_utf8_check?  then LibPCRE2::NO_UTF_CHECK
+                when .no_utf_check?   then LibPCRE2::NO_UTF_CHECK
                 when .dupnames?       then LibPCRE2::DUPNAMES
                 when .ucp?            then LibPCRE2::UCP
                 when .endanchored?    then LibPCRE2::ENDANCHORED

--- a/src/regex/pcre2.cr
+++ b/src/regex/pcre2.cr
@@ -103,7 +103,7 @@ module Regex::PCRE2
                 when .dollar_endonly? then raise ArgumentError.new("Invalid regex option DOLLAR_ENDONLY for `pcre2_match`")
                 when .firstline?      then raise ArgumentError.new("Invalid regex option FIRSTLINE for `pcre2_match`")
                 when .utf_8?          then raise ArgumentError.new("Invalid regex option UTF_8 for `pcre2_match`")
-                when .no_utf8_check?  then LibPCRE2::NO_UTF_CHECK
+                when .no_utf_check?   then LibPCRE2::NO_UTF_CHECK
                 when .dupnames?       then raise ArgumentError.new("Invalid regex option DUPNAMES for `pcre2_match`")
                 when .ucp?            then raise ArgumentError.new("Invalid regex option UCP for `pcre2_match`")
                 when .endanchored?    then LibPCRE2::ENDANCHORED
@@ -124,9 +124,10 @@ module Regex::PCRE2
     Regex::MatchOptions.each do |option|
       if options.includes?(option)
         flag |= case option
-                when .anchored?    then LibPCRE2::ANCHORED
-                when .endanchored? then LibPCRE2::ENDANCHORED
-                when .no_jit?      then LibPCRE2::NO_JIT
+                when .anchored?     then LibPCRE2::ANCHORED
+                when .endanchored?  then LibPCRE2::ENDANCHORED
+                when .no_jit?       then LibPCRE2::NO_JIT
+                when .no_utf_check? then LibPCRE2::NO_UTF_CHECK
                 else
                   raise "unreachable"
                 end

--- a/src/regex/pcre2.cr
+++ b/src/regex/pcre2.cr
@@ -65,18 +65,19 @@ module Regex::PCRE2
     Regex::CompileOptions.each do |option|
       if options.includes?(option)
         flag |= case option
-                when .ignore_case?    then LibPCRE2::CASELESS
-                when .multiline?      then LibPCRE2::DOTALL | LibPCRE2::MULTILINE
-                when .dotall?         then LibPCRE2::DOTALL
-                when .extended?       then LibPCRE2::EXTENDED
-                when .anchored?       then LibPCRE2::ANCHORED
-                when .dollar_endonly? then LibPCRE2::DOLLAR_ENDONLY
-                when .firstline?      then LibPCRE2::FIRSTLINE
-                when .utf_8?          then LibPCRE2::UTF
-                when .no_utf_check?   then LibPCRE2::NO_UTF_CHECK
-                when .dupnames?       then LibPCRE2::DUPNAMES
-                when .ucp?            then LibPCRE2::UCP
-                when .endanchored?    then LibPCRE2::ENDANCHORED
+                when .ignore_case?       then LibPCRE2::CASELESS
+                when .multiline?         then LibPCRE2::DOTALL | LibPCRE2::MULTILINE
+                when .dotall?            then LibPCRE2::DOTALL
+                when .extended?          then LibPCRE2::EXTENDED
+                when .anchored?          then LibPCRE2::ANCHORED
+                when .dollar_endonly?    then LibPCRE2::DOLLAR_ENDONLY
+                when .firstline?         then LibPCRE2::FIRSTLINE
+                when .utf_8?             then LibPCRE2::UTF
+                when .no_utf_check?      then LibPCRE2::NO_UTF_CHECK
+                when .dupnames?          then LibPCRE2::DUPNAMES
+                when .ucp?               then LibPCRE2::UCP
+                when .endanchored?       then LibPCRE2::ENDANCHORED
+                when .match_invalid_utf? then LibPCRE2::MATCH_INVALID_UTF
                 else
                   raise "unreachable"
                 end

--- a/src/regex/pcre2.cr
+++ b/src/regex/pcre2.cr
@@ -23,11 +23,6 @@ module Regex::PCRE2
   # :nodoc:
   def initialize(*, _source @source : String, _options @options)
     options = pcre2_compile_options(options) | LibPCRE2::UTF | LibPCRE2::DUPNAMES | LibPCRE2::UCP
-    # MATCH_INVALID_UTF was introduced in 10.34 but a bug that can lead to an
-    # infinite loop is only fixed in 10.36 (https://github.com/PCRE2Project/pcre2/commit/e0c6029a62db9c2161941ecdf459205382d4d379).
-    if PCRE2.version_number >= {10, 36}
-      options |= LibPCRE2::MATCH_INVALID_UTF
-    end
     @re = PCRE2.compile(source, options) do |error_message|
       raise ArgumentError.new(error_message)
     end


### PR DESCRIPTION
This patch drops the implicit `MATCH_INVALID_UTF` option which was added as part of a bug fix in #13240.

Instead this option is now available in `Regex::CompileOptions` for opt-in.
Similarly, `NO_CHECK_UTF` members are added to `Regex::CompileOptions` and `Regex::MatchOptions`.
`Regex::CompileOptions::NO_CHECK_UTF` is identical to the already existing but undocumented `NO_CHECK_UTF8` member.

Resolves #13312