### PR TITLE
Clarify behavior of strings with invalid UTF-8 byte sequences

### DIFF
--- a/src/string.cr
+++ b/src/string.cr
@@ -98,12 +98,12 @@ require "c/string"
 #
 # ### Non UTF-8 valid strings
 #
-# String might end up being conformed of bytes which are an invalid
+# A string might end up being composed of bytes which form an invalid
 # byte sequence according to UTF-8. This can happen if the string is created
 # via one of the constructors that accept bytes, or when getting a string
-# from `String.build` or `IO::Memory`. No exception will be raised, but
-# invalid byte sequences, when asked as chars, will use the unicode replacement
-# char (value 0xFFFD). For example:
+# from `String.build` or `IO::Memory`. No exception will be raised, but every
+# byte that doesn't start a valid UTF-8 byte sequence is interpreted as though
+# it encodes the Unicode replacement character (U+FFFD) by itself. For example:
 #
 # ```
 # # here 255 is not a valid byte value in the UTF-8 encoding
@@ -134,6 +134,13 @@ require "c/string"
 # and having a program raise an exception or stop because of this
 # is not good. It's better if programs are more resilient, but
 # show a replacement character when there's an error in incoming data.
+#
+# Note that this interpretation only applies to methods inside Crystal; calling
+# `#to_slice` or `#to_unsafe`, e.g. when passing a string to a C library, will
+# expose the invalid UTF-8 byte sequences. In particular, `Regex`'s underlying
+# engine may reject strings that are not valid UTF-8, or it may invoke undefined
+# behavior on invalid strings. If this is undesired, `#scrub` could be used to
+# remove the offending byte sequences first.
 class String
   # :nodoc:
   TYPE_ID = "".crystal_type_id
@@ -5254,11 +5261,17 @@ class String
   # Returns the underlying bytes of this String.
   #
   # The returned slice is read-only.
+  #
+  # May contain invalid UTF-8 byte sequences; `#scrub` may be used to first
+  # obtain a `String` that is guaranteed to be valid UTF-8.
   def to_slice : Bytes
     Slice.new(to_unsafe, bytesize, read_only: true)
   end
 
   # Returns a pointer to the underlying bytes of this String.
+  #
+  # May contain invalid UTF-8 byte sequences; `#scrub` may be used to first
+  # obtain a `String` that is guaranteed to be valid UTF-8.
   def to_unsafe : UInt8*
     pointerof(@c)
   end


### PR DESCRIPTION
Includes a blanket statement that `Regex` might not like `String`s with invalid UTF-8 byte sequences (not just PCRE and PCRE2, but also any future replacement if the day ever comes), and encourages people to use `#scrub` if applicable.