### PR TITLE
Revert "Remove relative path to vendored shard `markd` (#13040)"

### DIFF
--- a/src/compiler/crystal/interpreter/repl_reader.cr
+++ b/src/compiler/crystal/interpreter/repl_reader.cr
@@ -1,4 +1,4 @@
-require "reply"
+require "../../../../lib/reply/src/reply"
 
 class Crystal::ReplReader < Reply::Reader
   KEYWORDS = %w(

--- a/src/compiler/crystal/tools/doc/generator.cr
+++ b/src/compiler/crystal/tools/doc/generator.cr
@@ -1,4 +1,4 @@
-require "markd"
+require "../../../../../lib/markd/src/markd"
 require "crystal/syntax_highlighter/html"
 
 class Crystal::Doc::Generator


### PR DESCRIPTION
This reverts #13040 and applies the opposite transformation towards explicitly relative path for `reply` (ref https://github.com/crystal-lang/crystal/issues/12976#issuecomment-1396837703).
We never changed the require in https://github.com/crystal-lang/crystal/blob/45c529691cd2dc037de2a6c957dbbf7dedc86177/src/compiler/crystal/tools/playground/server.cr#L5, so this establishes uniformity. And it's probably a bit less fragile in case `CRYSTAL_PATH` gets messed up without `lib`.