### PR TITLE
Fix: Remove double URL escape in `HTTP::Server::Response.redirect`

### DIFF
--- a/spec/std/http/server/response_spec.cr
+++ b/spec/std/http/server/response_spec.cr
@@ -374,7 +374,7 @@ describe HTTP::Server::Response do
       io = IO::Memory.new
       response = Response.new(io)
       u = URI.new "https", host: "example.com", path: "auth",
-                           query: URI::Params.new({ "redirect_uri" => ["http://example.com/callback"] })
+        query: URI::Params.new({"redirect_uri" => ["http://example.com/callback"]})
       response.redirect(u)
       io.to_s.should eq("HTTP/1.1 302 Found\r\nLocation: https://example.com/auth?redirect_uri=http%3A%2F%2Fexample.com%2Fcallback\r\nContent-Length: 0\r\n\r\n")
     end

--- a/spec/std/http/server/response_spec.cr
+++ b/spec/std/http/server/response_spec.cr
@@ -370,6 +370,15 @@ describe HTTP::Server::Response do
       io.to_s.should eq("HTTP/1.1 302 Found\r\nLocation: https://example.com/path%0Afoo%20bar\r\nContent-Length: 0\r\n\r\n")
     end
 
+    it "doesn't encode URIs twice" do
+      io = IO::Memory.new
+      response = Response.new(io)
+      u = URI.new "https", host: "example.com", path: "auth",
+                           query: URI::Params.new({ "redirect_uri" => ["http://example.com/callback"] })
+      response.redirect(u)
+      io.to_s.should eq("HTTP/1.1 302 Found\r\nLocation: https://example.com/auth?redirect_uri=http%3A%2F%2Fexample.com%2Fcallback\r\nContent-Length: 0\r\n\r\n")
+    end
+
     it "permanent redirect" do
       io = IO::Memory.new
       response = Response.new(io)

--- a/src/http/server/response.cr
+++ b/src/http/server/response.cr
@@ -187,9 +187,15 @@ class HTTP::Server
       check_headers
 
       self.status = status
-      headers["Location"] = String.build do |io|
-        URI.encode(location.to_s, io) { |byte| URI.reserved?(byte) || URI.unreserved?(byte) }
-      end
+      headers["Location"] = if location.is_a? URI
+                              location.to_s
+                            else
+                              String.build do |io|
+                                URI.encode(location.to_s, io) do |byte|
+                                  URI.reserved?(byte) || URI.unreserved?(byte)
+                                end
+                              end
+                            end
       close
     end
 


### PR DESCRIPTION
fixes #13320

I tried to use the Oauth2::Client from Crystal it suggests to redirect the browser (https://github.com/crystal-lang/crystal/blob/master/src/oauth2/client.cr#L26-L28) after getting the authorization uri. The returned type is an URI already and thus encoded. In my case I was using it to connect to a keycloak, and I wondered, why keycloak doesn't accept the redirect_uri, then I noticed it was encoded twice.

This PR avoids encoding twice.