### PR TITLE
Optimize `Doc::Method#compute_doc_info` to avoid duplicate regex

### DIFF
--- a/src/compiler/crystal/tools/doc/method.cr
+++ b/src/compiler/crystal/tools/doc/method.cr
@@ -57,8 +57,9 @@ class Crystal::Doc::Method
   private def compute_doc_info : DocInfo?
     def_doc = @def.doc
     if def_doc
+      ancestor_doc_info = nil
       # TODO: warn about `:inherit:` not finding an ancestor
-      inherit_def_doc = def_doc.gsub(/^[ \t]*:inherit:[ \t]*$/m) { ancestor_doc_info.try(&.doc) || break }
+      inherit_def_doc = def_doc.gsub(/^[ \t]*:inherit:[ \t]*$/m) { (ancestor_doc_info ||= self.ancestor_doc_info).try(&.doc) || break }
 
       if inherit_def_doc && !inherit_def_doc.same?(def_doc)
         return DocInfo.new(inherit_def_doc, nil)

--- a/src/compiler/crystal/tools/doc/method.cr
+++ b/src/compiler/crystal/tools/doc/method.cr
@@ -57,15 +57,11 @@ class Crystal::Doc::Method
   private def compute_doc_info : DocInfo?
     def_doc = @def.doc
     if def_doc
-      has_inherit = def_doc =~ /^\s*:inherit:\s*$/m
-      if has_inherit
-        ancestor_info = self.ancestor_doc_info
-        if ancestor_info
-          def_doc = def_doc.gsub(/^[ \t]*:inherit:[ \t]*$/m, ancestor_info.doc.not_nil!)
-          return DocInfo.new(def_doc, nil)
-        end
+      # TODO: warn about `:inherit:` not finding an ancestor
+      inherit_def_doc = def_doc.gsub(/^[ \t]*:inherit:[ \t]*$/m) { ancestor_doc_info.try(&.doc) || break }
 
-        # TODO: warn about `:inherit:` not finding an ancestor
+      if inherit_def_doc && !inherit_def_doc.same?(def_doc)
+        return DocInfo.new(inherit_def_doc, nil)
       end
 
       if @def.name.starts_with?(PSEUDO_METHOD_PREFIX)

--- a/src/compiler/crystal/tools/doc/method.cr
+++ b/src/compiler/crystal/tools/doc/method.cr
@@ -59,8 +59,13 @@ class Crystal::Doc::Method
     if def_doc
       ancestor_doc_info = nil
       # TODO: warn about `:inherit:` not finding an ancestor
-      inherit_def_doc = def_doc.gsub(/^[ \t]*:inherit:[ \t]*$/m) { (ancestor_doc_info ||= self.ancestor_doc_info).try(&.doc) || break }
+      inherit_def_doc = def_doc.gsub(/^[ \t]*:inherit:[ \t]*$/m) do
+        ancestor_doc_info ||= self.ancestor_doc_info
+        ancester_doc_info.try(&.doc) || break
+      end
 
+      # inherit_def_doc is nil when breaking from the gsub block which means
+      # no ancestor doc info was found
       if inherit_def_doc && !inherit_def_doc.same?(def_doc)
         return DocInfo.new(inherit_def_doc, nil)
       end

--- a/src/compiler/crystal/tools/doc/method.cr
+++ b/src/compiler/crystal/tools/doc/method.cr
@@ -61,7 +61,7 @@ class Crystal::Doc::Method
       # TODO: warn about `:inherit:` not finding an ancestor
       inherit_def_doc = def_doc.gsub(/^[ \t]*:inherit:[ \t]*$/m) do
         ancestor_doc_info ||= self.ancestor_doc_info
-        ancester_doc_info.try(&.doc) || break
+        ancestor_doc_info.try(&.doc) || break
       end
 
       # inherit_def_doc is nil when breaking from the gsub block which means


### PR DESCRIPTION
The algorithm executed basically the same regex twice: once to see whether it matches and then to replace all occurrences.
This patch reduces it to a single regex match by avoiding the initial check.
