### PR TITLE
Implement Socket `reuse_port` (=`reuse_address`) on Windows

### DIFF
--- a/spec/std/http/server/server_spec.cr
+++ b/spec/std/http/server/server_spec.cr
@@ -81,7 +81,7 @@ describe HTTP::Server do
     ch.receive.end?.should be_true
   end
 
-  pending_win32 "reuses the TCP port (SO_REUSEPORT)" do
+  it "reuses the TCP port (SO_REUSEPORT)" do
     s1 = HTTP::Server.new { |ctx| }
     address = s1.bind_unused_port(reuse_port: true)
 

--- a/spec/std/socket/tcp_server_spec.cr
+++ b/spec/std/socket/tcp_server_spec.cr
@@ -1,7 +1,6 @@
 {% skip_file if flag?(:wasm32) %}
 
 require "./spec_helper"
-require "../../support/win32"
 
 describe TCPServer, tags: "network" do
   describe ".new" do
@@ -52,7 +51,7 @@ describe TCPServer, tags: "network" do
       end
 
       describe "reuse_port" do
-        pending_win32 "raises when port is in use" do
+        it "raises when port is in use" do
           TCPServer.open(address, 0) do |server|
             expect_raises(Socket::BindError, "Could not bind to '#{address}:#{server.local_address.port}': ") do
               TCPServer.open(address, server.local_address.port) { }
@@ -60,7 +59,7 @@ describe TCPServer, tags: "network" do
           end
         end
 
-        pending_win32 "raises when not binding with reuse_port" do
+        it "raises when not binding with reuse_port" do
           TCPServer.open(address, 0, reuse_port: true) do |server|
             expect_raises(Socket::BindError) do
               TCPServer.open(address, server.local_address.port) { }
@@ -68,7 +67,7 @@ describe TCPServer, tags: "network" do
           end
         end
 
-        pending_win32 "raises when port is not ready to be reused" do
+        it "raises when port is not ready to be reused" do
           TCPServer.open(address, 0) do |server|
             expect_raises(Socket::BindError) do
               TCPServer.open(address, server.local_address.port, reuse_port: true) { }
@@ -76,7 +75,7 @@ describe TCPServer, tags: "network" do
           end
         end
 
-        pending_win32 "binds to used port with reuse_port = true" do
+        it "binds to used port with reuse_port = true" do
           TCPServer.open(address, 0, reuse_port: true) do |server|
             TCPServer.open(address, server.local_address.port, reuse_port: true) { }
           end

--- a/src/crystal/system/win32/socket.cr
+++ b/src/crystal/system/win32/socket.cr
@@ -268,21 +268,6 @@ module Crystal::System::Socket
     val
   end
 
-  # SO_REUSEADDR, as used in posix, is always assumed on windows
-  # the SO_REUSEADDR flag on windows is the equivalent of SO_REUSEPORT on linux
-  # https://learn.microsoft.com/en-us/windows/win32/winsock/using-so-reuseaddr-and-so-exclusiveaddruse#application-strategies
-  macro finished
-    # the address component of a binding can always be reused on windows
-    def reuse_address? : Bool
-      true
-    end
-
-    # there is no effect on windows
-    def reuse_address=(val : Bool)
-      val
-    end
-  end
-
   private def system_linger
     v = LibC::Linger.new
     ret = getsockopt LibC::SO_LINGER, v

--- a/src/crystal/system/win32/socket.cr
+++ b/src/crystal/system/win32/socket.cr
@@ -258,7 +258,7 @@ module Crystal::System::Socket
   end
 
   private def system_reuse_port=(val : Bool)
-    reuse_address = val
+    self.reuse_address = val
   end
 
   private def system_linger

--- a/src/crystal/system/win32/socket.cr
+++ b/src/crystal/system/win32/socket.cr
@@ -254,11 +254,11 @@ module Crystal::System::Socket
   end
 
   private def system_reuse_port?
-    false
+    reuse_address?
   end
 
   private def system_reuse_port=(val : Bool)
-    raise NotImplementedError.new("Socket#reuse_port=")
+    reuse_address = val
   end
 
   private def system_linger

--- a/src/crystal/system/win32/socket.cr
+++ b/src/crystal/system/win32/socket.cr
@@ -268,8 +268,9 @@ module Crystal::System::Socket
     val
   end
 
-  # and SO_REUSEADDR is always assumed on windows
-  # confusingly, the SO_REUSEADDR flag on windows is the equivalent of SO_REUSEPORT on linux
+  # SO_REUSEADDR, as used in posix, is always assumed on windows
+  # the SO_REUSEADDR flag on windows is the equivalent of SO_REUSEPORT on linux
+  # https://learn.microsoft.com/en-us/windows/win32/winsock/using-so-reuseaddr-and-so-exclusiveaddruse#application-strategies
   macro finished
     # the address component of a binding can always be reused on windows
     def reuse_address? : Bool

--- a/src/socket.cr
+++ b/src/socket.cr
@@ -339,13 +339,28 @@ class Socket < IO
       val
     end
 
-    def reuse_address? : Bool
-      getsockopt_bool LibC::SO_REUSEADDR
-    end
+    # SO_REUSEADDR, as used in posix, is always assumed on windows
+    # the SO_REUSEADDR flag on windows is the equivalent of SO_REUSEPORT on linux
+    # https://learn.microsoft.com/en-us/windows/win32/winsock/using-so-reuseaddr-and-so-exclusiveaddruse#application-strategies
+    {% if flag?(:win32) %}
+      # the address component of a binding can always be reused on windows
+      def reuse_address? : Bool
+        true
+      end
 
-    def reuse_address=(val : Bool)
-      setsockopt_bool LibC::SO_REUSEADDR, val
-    end
+      # there is no effect on windows
+      def reuse_address=(val : Bool)
+        val
+      end
+    {% else %}
+      def reuse_address? : Bool
+        getsockopt_bool LibC::SO_REUSEADDR
+      end
+
+      def reuse_address=(val : Bool)
+        setsockopt_bool LibC::SO_REUSEADDR, val
+      end
+    {% end %}
 
     def reuse_port? : Bool
       system_reuse_port?


### PR DESCRIPTION
I think this is a better solution than having runtime errors on windows and having to write code like this for multi-platform support

```crystal
    # example of what needs to be written before this commit is merged
    @socket = UDPSocket.new @address.family
    @socket.reuse_address = true
    {% unless flag?(:win32) %}
      @socket.reuse_port = true
    {% end %}
```

noting that windows SO_REUSEADDR == linux SO_REUSEPORT
and on windows, reuse of the address component of a binding is always allowed

I've also changed the socket defaults to use `SO_EXCLUSIVEADDRUSE`
as per [the docs](https://learn.microsoft.com/en-us/windows/win32/winsock/using-so-reuseaddr-and-so-exclusiveaddruse#application-strategies):

<img width="593" alt="image" src="https://user-images.githubusercontent.com/368013/232349893-93bee3bb-ca73-48e9-86f3-ac6f8c2d5eb9.png">

<img width="601" alt="image" src="https://user-images.githubusercontent.com/368013/232349969-5ea85976-c022-4b18-b232-7d0ab4c828f8.png">

