### PR TITLE
Build samples on Windows CI

### DIFF
--- a/.github/workflows/win.yml
+++ b/.github/workflows/win.yml
@@ -375,4 +375,5 @@ jobs:
         run: make -f Makefile.win primitives_spec
 
       - name: Build samples
-        run: make -f Makefile.win samples
+        working-directory: ./samples
+        run: make -f Makefile.win

--- a/.github/workflows/win.yml
+++ b/.github/workflows/win.yml
@@ -373,3 +373,6 @@ jobs:
 
       - name: Run primitives specs
         run: make -f Makefile.win primitives_spec
+
+      - name: Build samples
+        run: make -f Makefile.win samples

--- a/.github/workflows/win.yml
+++ b/.github/workflows/win.yml
@@ -375,5 +375,4 @@ jobs:
         run: make -f Makefile.win primitives_spec
 
       - name: Build samples
-        working-directory: ./samples
-        run: make -f Makefile.win
+        run: make -f Makefile.win samples

--- a/samples/Makefile.win
+++ b/samples/Makefile.win
@@ -1,7 +1,7 @@
 MKDIR = if not exist $1 mkdir $1
 RMDIR = if exist $1 rd /S /Q $1
 
-CRYSTAL := ../bin/crystal# Crystal compiler to use
+CRYSTAL := ..\bin\crystal.bat# Crystal compiler to use
 O := .build# Output directory
 
 BUILDABLE_SOURCES := $(wildcard *.cr llvm/*.cr compiler/*.cr)

--- a/samples/Makefile.win
+++ b/samples/Makefile.win
@@ -1,3 +1,10 @@
+all:
+
+MAKEFLAGS += --no-builtin-rules
+.SUFFIXES:
+
+SHELL := cmd.exe
+
 MKDIR = if not exist $1 mkdir $1
 RMDIR = if exist $1 rd /S /Q $1
 


### PR DESCRIPTION
The last remaining failing sample, `sdl/raytracer.cr`, now works on Windows as it doesn't rely on `Signal::INT.trap` anymore. This PR adds `make samples` as a kind of smoke test for Windows.