### PR TITLE
Refactor String header layout reflection

### DIFF
--- a/src/string.cr
+++ b/src/string.cr
@@ -143,9 +143,6 @@ require "c/string"
 # remove the offending byte sequences first.
 class String
   # :nodoc:
-  TYPE_ID = "".crystal_type_id
-
-  # :nodoc:
   #
   # Holds the offset to the first character byte.
   HEADER_SIZE = offsetof(String, @c)
@@ -268,7 +265,7 @@ class String
       str = GC.realloc(str, bytesize.to_u32 + HEADER_SIZE + 1)
     end
 
-    str.as(Pointer(typeof(TYPE_ID))).value = TYPE_ID
+    set_crystal_type_id(str)
     str = str.as(String)
     str.initialize_header(bytesize.to_i, size.to_i)
     str

--- a/src/string.cr
+++ b/src/string.cr
@@ -146,7 +146,9 @@ class String
   TYPE_ID = "".crystal_type_id
 
   # :nodoc:
-  HEADER_SIZE = sizeof({Int32, Int32, Int32})
+  #
+  # Holds the offset to the first character byte.
+  HEADER_SIZE = offsetof(String, @c)
 
   include Comparable(self)
 
@@ -266,9 +268,18 @@ class String
       str = GC.realloc(str, bytesize.to_u32 + HEADER_SIZE + 1)
     end
 
-    str_header = str.as({Int32, Int32, Int32}*)
-    str_header.value = {TYPE_ID, bytesize.to_i, size.to_i}
-    str.as(String)
+    str.as(Pointer(typeof(TYPE_ID))).value = TYPE_ID
+    str = str.as(String)
+    str.initialize_header(bytesize.to_i, size.to_i)
+    str
+  end
+
+  # :nodoc:
+  #
+  # Initializes the header information of a `String` instance.
+  # The actual character content at `@c` is expected to be already filled and is
+  # unaffected by this method.
+  def initialize_header(@bytesize : Int32, @length : Int32 = 0)
   end
 
   # Builds a `String` by creating a `String::Builder` with the given initial capacity, yielding

--- a/src/string/builder.cr
+++ b/src/string/builder.cr
@@ -116,7 +116,7 @@ class String::Builder < IO
       resize_to_capacity(real_bytesize)
     end
 
-    @buffer.as(Pointer(typeof(String::TYPE_ID))).value = String::TYPE_ID
+    String.set_crystal_type_id(@buffer)
     str = @buffer.as(String)
     str.initialize_header((bytesize - 1).to_i)
     str

--- a/src/string/builder.cr
+++ b/src/string/builder.cr
@@ -117,9 +117,10 @@ class String::Builder < IO
       resize_to_capacity(real_bytesize)
     end
 
-    header = @buffer.as({Int32, Int32, Int32}*)
-    header.value = {String::TYPE_ID, @bytesize - 1, 0}
-    @buffer.as(String)
+    @buffer.as(Pointer(typeof(String::TYPE_ID))).value = String::TYPE_ID
+    str = @buffer.as(String)
+    str.initialize_header((bytesize - 1).to_i)
+    str
   end
 
   private def real_bytesize

--- a/src/string/builder.cr
+++ b/src/string/builder.cr
@@ -14,7 +14,6 @@ class String::Builder < IO
     # Make sure to also be able to hold
     # the header size plus the trailing zero byte
     capacity += String::HEADER_SIZE + 1
-    String.check_capacity_in_bounds(capacity)
 
     @buffer = GC.malloc_atomic(capacity.to_u32).as(UInt8*)
     @bytesize = 0


### PR DESCRIPTION
This patch removes the assumption of `String`s memory layout in stdlib when allocating an instance by hand.
The exact memory layout is governed by the compiler (or rather the LLVM backend takes care of the specifics). The assumed layout is probably correct most of the time, but it's not guaranteed.
And it's easy to implement in a way that does not assume anything about the memory layout except that the char array is the last field.
This action decouples the stdlib implementation from compiler internals.

It also paves a way for potential future changes to `String`s layout, for example as suggested in #12020.