### PR TITLE
Fix size of type_id in `Object.set_crystal_type_id`

### DIFF
--- a/spec/std/object_spec.cr
+++ b/spec/std/object_spec.cr
@@ -122,6 +122,10 @@ private class TestObject
   def self.test_annotation_count
     {{ @type.instance_vars.select(&.annotation(TestObject::TestAnnotation)).size }}
   end
+
+  def self.do_set_crystal_type_id(ptr)
+    set_crystal_type_id(ptr)
+  end
 end
 
 private class DelegatedTestObject
@@ -558,5 +562,12 @@ describe Object do
       x.not_nil!.foo.should eq(2)
       x.foo.should eq(3)
     end
+  end
+
+  it ".set_crystal_type_id" do
+    ary = StaticArray[Int32::MAX, Int32::MAX]
+    TestObject.do_set_crystal_type_id(pointerof(ary))
+    ary[0].should eq TestObject.crystal_instance_type_id
+    ary[1].should eq Int32::MAX
   end
 end

--- a/src/object.cr
+++ b/src/object.cr
@@ -1430,7 +1430,7 @@ class Object
   end
 
   protected def self.set_crystal_type_id(ptr)
-    ptr.as(LibC::SizeT*).value = LibC::SizeT.new(crystal_instance_type_id)
+    ptr.as(Pointer(typeof(crystal_instance_type_id))).value = crystal_instance_type_id
     ptr
   end
 end


### PR DESCRIPTION
The type of `crystal_type_id` is `Int32`, not `LibC::SizeT`. On 64-bit systems this wrong size would write a 64-bit integer into a space that's only suppose to be 32-bit wide.

This bug has limited practical effect. Due to byte ordering the memory representation of 32-bit and small 64-bit values are (usually) identical. The type id is never wider than 32-bits so this works correctly. The only negative side effect would be overriding the first 4 bytes of the object data that follows the type id.
This method is only called from `WeakRef.allocate` on an empty object where this is irrelevant.

It's sill a bug and needs to be fixed. For the fix I opted to infer the type based on the type of `crystal_instance_type_id` (which is a compiler primitive). The size does not need to be hard-coded into stdlib.