### PR TITLE
Add `Regex.literal`

### DIFF
--- a/spec/std/regex_spec.cr
+++ b/spec/std/regex_spec.cr
@@ -34,6 +34,14 @@ describe "Regex" do
     end
   end
 
+  it ".literal" do
+    Regex.literal("foo").should eq /foo/
+    Regex.literal("foo", i: true).should eq /foo/i
+    Regex.literal("foo", i: true, m: true).should eq /foo/im
+    Regex.literal("foo", i: true, m: true, x: true).should eq /foo/imx
+    Regex.literal("foo", x: true).should eq /foo/x
+  end
+
   it "#options" do
     /cat/.options.ignore_case?.should be_false
     /cat/i.options.ignore_case?.should be_true

--- a/src/regex.cr
+++ b/src/regex.cr
@@ -335,6 +335,15 @@ class Regex
     new(_source: source, _options: options)
   end
 
+  # Creates a new `Regex` instance from a literal consisting of a *pattern* and the named parameter modifiers.
+  def self.literal(pattern : String, *, i : Bool = false, m : Bool = false, x : Bool = false) : self
+    options = CompileOptions::None
+    options |= :ignore_case if i
+    options |= :multiline if m
+    options |= :extended if x
+    new(pattern, options: options)
+  end
+
   # Determines Regex's source validity. If it is, `nil` is returned.
   # If it's not, a `String` containing the error message is returned.
   #


### PR DESCRIPTION
Implements `Regex.literal` as an interface for the compiler to build a `Regex` from a literal.
Proposed in https://github.com/crystal-lang/crystal/issues/13252#issuecomment-1491963281

This is just the first part of that issue, the stdlib API. A follow-up will then add compiler integration.