### PR TITLE
Fix `String#gsub` with empty match at multibyte char

### DIFF
--- a/spec/std/string_spec.cr
+++ b/spec/std/string_spec.cr
@@ -1915,6 +1915,11 @@ describe "String" do
       "a  b".gsub(/\B/, "-").should eq "a - b"
       "┬  7".gsub(/\B/, "-").should eq "-┬- - 7"
     end
+
+    it "empty string" do
+      "ab".gsub("", "-").should eq "-a-b-"
+      "┬7".gsub("", "-").should eq "-┬-7-"
+    end
   end
 
   it "scans using $~" do

--- a/spec/std/string_spec.cr
+++ b/spec/std/string_spec.cr
@@ -1734,7 +1734,7 @@ describe "String" do
     end
   end
 
-  describe "gsub" do
+  describe "#gsub" do
     it "gsubs char with char" do
       "foobar".gsub('o', 'e').should eq("feebar")
     end
@@ -1909,6 +1909,11 @@ describe "String" do
 
     it "ignores if backreferences: false" do
       "foo".gsub(/o/, "x\\0x", backreferences: false).should eq("fx\\0xx\\0x")
+    end
+
+    it "empty match" do
+      "a  b".gsub(/\B/, "-").should eq "a - b"
+      "┬  7".gsub(/\B/, "-").should eq "-┬- - 7"
     end
   end
 

--- a/src/string.cr
+++ b/src/string.cr
@@ -2864,7 +2864,8 @@ class String
         yield str, match, buffer
 
         if str.bytesize == 0
-          byte_offset = index + 1
+          # The pattern matched an empty result. We must advance one character to avoid stagnation.
+          byte_offset = index + Char::Reader.new(self, pos: byte_offset).current_char_width
           last_byte_offset = index
         else
           byte_offset = index + str.bytesize

--- a/src/string.cr
+++ b/src/string.cr
@@ -2807,7 +2807,8 @@ class String
         buffer << yield string
 
         if string.bytesize == 0
-          byte_offset = index + 1
+          # The pattern matched an empty result. We must advance one character to avoid stagnation.
+          byte_offset = index + Char::Reader.new(self, pos: byte_offset).current_char_width
           last_byte_offset = index
         else
           byte_offset = index + string.bytesize


### PR DESCRIPTION
Fixes #13341