### PR TITLE
Fix `JSON::Serializable` on certain recursively defined types

### DIFF
--- a/spec/std/json/serializable_spec.cr
+++ b/spec/std/json/serializable_spec.cr
@@ -465,6 +465,18 @@ module JSONNamespace
   end
 end
 
+class JSONSomething
+  include JSON::Serializable
+
+  property value : JSONAttrValue(Set(SomethingElse)?)?
+end
+
+class JSONSomethingElse
+  include JSON::Serializable
+
+  property value : JSONAttrValue(Set(SomethingElse)?)?
+end
+
 describe "JSON mapping" do
   it "works with record" do
     JSONAttrPoint.new(1, 2).to_json.should eq "{\"x\":1,\"y\":2}"
@@ -1106,5 +1118,10 @@ describe "JSON mapping" do
       request.foo.id.should eq "id:foo"
       request.bar.id.should eq "id:bar"
     end
+  end
+
+  it "fixes #13337" do
+    JSONSomething.from_json(%({"value":{}})).value.should_not be_nil
+    JSONSomethingElse.from_json(%({"value":{}})).value.should_not be_nil
   end
 end

--- a/spec/std/json/serializable_spec.cr
+++ b/spec/std/json/serializable_spec.cr
@@ -468,13 +468,13 @@ end
 class JSONSomething
   include JSON::Serializable
 
-  property value : JSONAttrValue(Set(SomethingElse)?)?
+  property value : JSONAttrValue(Set(JSONSomethingElse)?)?
 end
 
 class JSONSomethingElse
   include JSON::Serializable
 
-  property value : JSONAttrValue(Set(SomethingElse)?)?
+  property value : JSONAttrValue(Set(JSONSomethingElse)?)?
 end
 
 describe "JSON mapping" do

--- a/spec/std/yaml/serializable_spec.cr
+++ b/spec/std/yaml/serializable_spec.cr
@@ -398,6 +398,18 @@ class YAMLStrictDiscriminatorBar < YAMLStrictDiscriminator
   property y : YAMLStrictDiscriminator
 end
 
+class YAMLSomething
+  include YAML::Serializable
+
+  property value : YAMLAttrValue(Set(YAMLSomethingElse)?)?
+end
+
+class YAMLSomethingElse
+  include YAML::Serializable
+
+  property value : YAMLAttrValue(Set(YAMLSomethingElse)?)?
+end
+
 describe "YAML::Serializable" do
   it "works with record" do
     YAMLAttrPoint.new(1, 2).to_yaml.should eq "---\nx: 1\ny: 2\n"
@@ -1007,5 +1019,10 @@ describe "YAML::Serializable" do
       request.foo.id.should eq "id:foo"
       request.bar.id.should eq "id:bar"
     end
+  end
+
+  it "fixes #13337" do
+    YAMLSomething.from_yaml(%({"value":{}})).value.should_not be_nil
+    YAMLSomethingElse.from_yaml(%({"value":{}})).value.should_not be_nil
   end
 end

--- a/src/json/serialization.cr
+++ b/src/json/serialization.cr
@@ -186,7 +186,6 @@ module JSON
           {% unless ann && (ann[:ignore] || ann[:ignore_deserialize]) %}
             {%
               properties[ivar.id] = {
-                type:        ivar.type,
                 key:         ((ann && ann[:key]) || ivar).id.stringify,
                 has_default: ivar.has_default_value?,
                 default:     ivar.default_value,
@@ -200,7 +199,11 @@ module JSON
         {% end %}
 
         {% for name, value in properties %}
-          %var{name} = {% if value[:has_default] || value[:nilable] %} nil {% else %} uninitialized ::Union({{value[:type]}}) {% end %}
+          %var{name} = {% if value[:has_default] || value[:nilable] %}
+                         nil.as(typeof(nil, @{{name}}))
+                       {% else %}
+                         uninitialized typeof(@{{name}})
+                       {% end %}
           %found{name} = false
         {% end %}
 
@@ -223,7 +226,7 @@ module JSON
                       {% if value[:converter] %}
                         {{value[:converter]}}.from_json(pull)
                       {% else %}
-                        ::Union({{value[:type]}}).new(pull)
+                        typeof(@{{name}}).new(pull)
                       {% end %}
                     end
                 end

--- a/src/json/serialization.cr
+++ b/src/json/serialization.cr
@@ -198,9 +198,11 @@ module JSON
           {% end %}
         {% end %}
 
+        # `%var`'s type must be exact to avoid type inference issues with
+        # recursively defined serializable types
         {% for name, value in properties %}
           %var{name} = {% if value[:has_default] || value[:nilable] %}
-                         nil.as(typeof(nil, @{{name}}))
+                         nil.as(::Nil | typeof(@{{name}}))
                        {% else %}
                          uninitialized typeof(@{{name}})
                        {% end %}
@@ -291,7 +293,6 @@ module JSON
           {% unless ann && (ann[:ignore] || ann[:ignore_serialize] == true) %}
             {%
               properties[ivar.id] = {
-                type:             ivar.type,
                 key:              ((ann && ann[:key]) || ivar).id.stringify,
                 root:             ann && ann[:root],
                 converter:        ann && ann[:converter],

--- a/src/yaml/serialization.cr
+++ b/src/yaml/serialization.cr
@@ -203,9 +203,11 @@ module YAML
           {% end %}
         {% end %}
 
+        # `%var`'s type must be exact to avoid type inference issues with
+        # recursively defined serializable types
         {% for name, value in properties %}
           %var{name} = {% if value[:has_default] || value[:nilable] %}
-                         nil.as(typeof(nil, @{{name}}))
+                         nil.as(::Nil, typeof(@{{name}}))
                        {% else %}
                          uninitialized typeof(@{{name}})
                        {% end %}
@@ -300,7 +302,6 @@ module YAML
           {% unless ann && (ann[:ignore] || ann[:ignore_serialize]) %}
             {%
               properties[ivar.id] = {
-                type:      ivar.type,
                 key:       ((ann && ann[:key]) || ivar).id.stringify,
                 converter: ann && ann[:converter],
                 emit_null: (ann && (ann[:emit_null] != nil) ? ann[:emit_null] : emit_nulls),

--- a/src/yaml/serialization.cr
+++ b/src/yaml/serialization.cr
@@ -207,7 +207,7 @@ module YAML
         # recursively defined serializable types
         {% for name, value in properties %}
           %var{name} = {% if value[:has_default] || value[:nilable] %}
-                         nil.as(::Nil, typeof(@{{name}}))
+                         nil.as(::Nil | typeof(@{{name}}))
                        {% else %}
                          uninitialized typeof(@{{name}})
                        {% end %}


### PR DESCRIPTION
Fixes #13337. Does not affect https://github.com/crystal-lang/crystal/pull/13238#issuecomment-1512096511.

I couldn't reproduce the same error with YAML