### PR TITLE
Fix PCRE2 `Regex` with more than 127 named capture groups

### DIFF
--- a/spec/std/regex/match_data_spec.cr
+++ b/spec/std/regex/match_data_spec.cr
@@ -400,6 +400,12 @@ describe "Regex::MatchData" do
       matchdata(/(Cr)(s)?/, "Crystal").captures.should eq(["Cr", nil])
       matchdata(/(Cr)(?<name1>s)?(tal)?/, "Crystal").captures.should eq(["Cr", nil])
     end
+
+    it "doesn't get named captures when there are more than 255" do
+      regex = Regex.new(Array.new(1000) { |i| "(?<c#{i}>.)" }.join)
+      captures = Array.new(1000) { |i| {"c#{i}", "x"} }.to_h
+      matchdata(regex, "x" * 1000).captures.should eq([] of String)
+    end
   end
 
   describe "#named_captures" do
@@ -415,6 +421,12 @@ describe "Regex::MatchData" do
 
     it "gets a hash of named captures with duplicated name" do
       matchdata(/(?<name>Cr)y(?<name>s)/, "Crystal").named_captures.should eq({"name" => "s"})
+    end
+
+    it "gets more than 127 named captures" do
+      regex = Regex.new(Array.new(1000) { |i| "(?<c#{i}>.)" }.join)
+      captures = Array.new(1000) { |i| {"c#{i}", "x"} }.to_h
+      matchdata(regex, "x" * 1000).named_captures.should eq(captures)
     end
   end
 

--- a/spec/std/regex/match_data_spec.cr
+++ b/spec/std/regex/match_data_spec.cr
@@ -402,9 +402,8 @@ describe "Regex::MatchData" do
     end
 
     it "doesn't get named captures when there are more than 255" do
-      regex = Regex.new(Array.new(1000) { |i| "(?<c#{i}>.)" }.join)
-      captures = Array.new(1000) { |i| {"c#{i}", "x"} }.to_h
-      matchdata(regex, "x" * 1000).captures.should eq([] of String)
+      regex = Regex.new(Array.new(256) { |i| "(?<c#{i}>.)" }.join)
+      matchdata(regex, "x" * 256).captures.should eq([] of String)
     end
   end
 
@@ -424,9 +423,10 @@ describe "Regex::MatchData" do
     end
 
     it "gets more than 127 named captures" do
-      regex = Regex.new(Array.new(1000) { |i| "(?<c#{i}>.)" }.join)
-      captures = Array.new(1000) { |i| {"c#{i}", "x"} }.to_h
-      matchdata(regex, "x" * 1000).named_captures.should eq(captures)
+      regex = Regex.new(Array.new(128) { |i| "(?<c#{i}>.)" }.join)
+      captures = matchdata(regex, "x" * 128).named_captures
+      captures.size.should eq(128)
+      128.times { |i| captures["c#{i}"].should eq("x") }
     end
   end
 

--- a/spec/std/regex_spec.cr
+++ b/spec/std/regex_spec.cr
@@ -398,6 +398,12 @@ describe "Regex" do
     it "duplicate name" do
       /(?<foo>)(?<foo>)/.name_table.should eq({1 => "foo", 2 => "foo"})
     end
+
+    it "more than 255 groups" do
+      regex = Regex.new(Array.new(1000) { |i| "(?<c#{i}>.)" }.join)
+      name_table = Array.new(1000) { |i| {i + 1, "c#{i}"} }.to_h
+      regex.name_table.should eq(name_table)
+    end
   end
 
   it "#capture_count" do


### PR DESCRIPTION
Different things can happen when a `Regex` backed by PCRE2 has too many named capture groups:

* The 256th named capture and onward will overwrite older ones in `Regex#name_table`;
* The 256th named capture and onward will show up in `Regex::MatchData#captures`;
* `Regex::MatchData#named_captures` raises `OverflowError` when there are 128 or more named captures.

Also fixes #13347. Note that the upper limit is 10000 in both [PCRE](http://www.pcre.org/original/doc/html/pcrelimits.html) and [PCRE2](http://www.pcre.org/current/doc/html/pcre2limits.html).