### PR TITLE
Add Regex options support inspection

### DIFF
--- a/spec/std/regex_spec.cr
+++ b/spec/std/regex_spec.cr
@@ -541,7 +541,7 @@ describe "Regex" do
   end
 
   it ".supports_match_options?" do
-    Regex.supports_compile_options?(:anchored).should be_true
-    Regex.supports_compile_options?(:endanchored).should eq Regex::Engine.version_number >= {10, 0}
+    Regex.supports_match_options?(:anchored).should be_true
+    Regex.supports_match_options?(:endanchored).should eq Regex::Engine.version_number >= {10, 0}
   end
 end

--- a/spec/std/regex_spec.cr
+++ b/spec/std/regex_spec.cr
@@ -534,4 +534,14 @@ describe "Regex" do
       end
     )
   end
+
+  it ".supports_compile_options?" do
+    Regex.supports_compile_options?(:anchored).should be_true
+    Regex.supports_compile_options?(:endanchored).should eq Regex::Engine.version_number >= {10, 0}
+  end
+
+  it ".supports_match_options?" do
+    Regex.supports_compile_options?(:anchored).should be_true
+    Regex.supports_compile_options?(:endanchored).should eq Regex::Engine.version_number >= {10, 0}
+  end
 end

--- a/src/regex.cr
+++ b/src/regex.cr
@@ -285,6 +285,14 @@ class Regex
   # This alias is supposed to replace `Options`.
   alias CompileOptions = Options
 
+  # Returns `true` if the regex engine supports all *options* flags when compiling a pattern.
+  def self.supports_compile_options?(options : CompileOptions) : Bool
+    options.each do |flag|
+      return false unless Engine.supports_compile_flag?(flag)
+    end
+    true
+  end
+
   # Represents options passed to regex match methods such as `Regex#match`.
   @[Flags]
   enum MatchOptions
@@ -306,6 +314,14 @@ class Regex
     # This option has no effect if the pattern was compiled with
     # `CompileOptions::MATCH_INVALID_UTF` when using PCRE2 10.34+.
     NO_UTF_CHECK
+  end
+
+  # Returns `true` if the regex engine supports all *options* flags when matching a pattern.
+  def self.supports_match_options?(options : MatchOptions) : Bool
+    options.each do |flag|
+      return false unless Engine.supports_match_flag?(flag)
+    end
+    true
   end
 
   # Returns a `Regex::CompileOptions` representing the optional flags applied to this `Regex`.

--- a/src/regex/pcre.cr
+++ b/src/regex/pcre.cr
@@ -61,6 +61,10 @@ module Regex::PCRE
     flag
   end
 
+  def self.supports_compile_flag?(options)
+    !options.endanchored? && !options.match_invalid_utf?
+  end
+
   private def pcre_match_options(options)
     flag = 0
     Regex::Options.each do |option|
@@ -111,6 +115,10 @@ module Regex::PCRE
     flag |= options.value
 
     flag
+  end
+
+  def self.supports_match_flag?(options)
+    !options.endanchored? && !options.no_jit?
   end
 
   def finalize

--- a/src/regex/pcre2.cr
+++ b/src/regex/pcre2.cr
@@ -90,6 +90,10 @@ module Regex::PCRE2
     flag
   end
 
+  def self.supports_compile_flag?(options)
+    true
+  end
+
   private def pcre2_match_options(options)
     flag = 0
     Regex::Options.each do |option|
@@ -138,6 +142,10 @@ module Regex::PCRE2
       raise ArgumentError.new("Unknown Regex::MatchOption value: #{options}")
     end
     flag
+  end
+
+  def self.supports_match_flag?(options)
+    true
   end
 
   protected def self.error_impl(source)


### PR DESCRIPTION
Add methods `Regex.supports_compile_options?` and `Regex.supports_match_options?` to check whether the regex engine supports specific options.
This is a more robust and convenient alternative to checking the engine version explicitly before using options with partial support.