### PR TITLE
Add `Time.unix_ns` and `#to_unix_ns`

### DIFF
--- a/spec/std/time/time_spec.cr
+++ b/spec/std/time/time_spec.cr
@@ -212,12 +212,30 @@ describe Time do
     time.utc?.should be_true
   end
 
-  it ".to_unix_ns" do
-    nanoseconds = 1439404155001457425
-    time = Time.unix_ns(nanoseconds)
-    time.should eq(Time.utc(2015, 8, 12, 18, 29, 15, nanosecond: 1457425))
-    time.to_unix_ns.should eq(nanoseconds)
-    time.utc?.should be_true
+  describe ".unix_ns" do
+    it "supports Int64 values" do
+      nanoseconds = 1439404155001457425i64
+      time = Time.unix_ns(nanoseconds)
+      time.should eq(Time.utc(2015, 8, 12, 18, 29, 15, nanosecond: 1457425))
+      time.to_unix_ns.should eq(nanoseconds)
+      time.utc?.should be_true
+    end
+
+    it "supports maximum valid time" do
+      nanoseconds = Int128.new("253402300799999999999")
+      time = Time.unix_ns(nanoseconds)
+      time.should eq(Time.utc(9999, 12, 31, 23, 59, 59, nanosecond: 999999999))
+      time.to_unix_ns.should eq(nanoseconds)
+      time.utc?.should be_true
+    end
+
+    it "supports minimum valid time" do
+      nanoseconds = Int128.new("-62135596800000000000")
+      time = Time.unix_ns(nanoseconds)
+      time.should eq(Time.utc(1, 1, 1, 0, 0, 0, nanosecond: 0))
+      time.to_unix_ns.should eq(nanoseconds)
+      time.utc?.should be_true
+    end
   end
 
   describe ".local without arguments" do

--- a/spec/std/time/time_spec.cr
+++ b/spec/std/time/time_spec.cr
@@ -212,6 +212,14 @@ describe Time do
     time.utc?.should be_true
   end
 
+  it ".to_unix_ns" do
+    nanoseconds = 1439404155001457425
+    time = Time.unix_ns(nanoseconds)
+    time.should eq(Time.utc(2015, 8, 12, 18, 29, 15, nanosecond: 1457425))
+    time.to_unix_ns.should eq(nanoseconds)
+    time.utc?.should be_true
+  end
+
   describe ".local without arguments" do
     it "current time is similar in different locations" do
       (Time.local - Time.utc).should be_close(0.seconds, 1.second)

--- a/src/time.cr
+++ b/src/time.cr
@@ -535,6 +535,22 @@ struct Time
     utc(seconds: seconds, nanoseconds: nanoseconds.to_i)
   end
 
+  # Creates a new `Time` instance that corresponds to the number of
+  # *nanoseconds* elapsed since the Unix epoch (`1970-01-01 00:00:00.000000000 UTC`).
+  #
+  # The time zone is always UTC.
+  #
+  # ```
+  # time = Time.unix_ns(981173106789479273) # => 2001-02-03 04:05:06.789479273 UTC
+  # time.nanosecond                         # => 789479273
+  # ```
+  def self.unix_ns(nanoseconds : Int) : Time
+    nanoseconds = nanoseconds.to_i64
+    seconds = UNIX_EPOCH.total_seconds + (nanoseconds // 1_000_000_000)
+    nanoseconds = nanoseconds % 1_000_000_000
+    utc(seconds: seconds, nanoseconds: nanoseconds.to_i)
+  end
+
   # Creates a new `Time` instance with the same local date-time representation
   # (wall clock) in a different *location*.
   #
@@ -1252,6 +1268,17 @@ struct Time
   # ```
   def to_unix_ms : Int64
     to_unix * 1_000 + (nanosecond // NANOSECONDS_PER_MILLISECOND)
+  end
+
+  # Returns the number of nanoseconds since the Unix epoch
+  # (`1970-01-01 00:00:00.000000000 UTC`).
+  #
+  # ```
+  # time = Time.utc(2016, 1, 12, 3, 4, 5, nanosecond: 678_910_123)
+  # time.to_unix_ns # => 1452567845678910123
+  # ```
+  def to_unix_ns : Int64
+    (to_unix * NANOSECONDS_PER_SECOND) + nanosecond
   end
 
   # Returns the number of seconds since the Unix epoch

--- a/src/time.cr
+++ b/src/time.cr
@@ -1276,8 +1276,8 @@ struct Time
   # time = Time.utc(2016, 1, 12, 3, 4, 5, nanosecond: 678_910_123)
   # time.to_unix_ns # => 1452567845678910123
   # ```
-  def to_unix_ns : Int64
-    (to_unix * NANOSECONDS_PER_SECOND) + nanosecond
+  def to_unix_ns : Int128
+    (to_unix.to_i128 * NANOSECONDS_PER_SECOND) + nanosecond
   end
 
   # Returns the number of seconds since the Unix epoch

--- a/src/time.cr
+++ b/src/time.cr
@@ -545,7 +545,6 @@ struct Time
   # time.nanosecond                         # => 789479273
   # ```
   def self.unix_ns(nanoseconds : Int) : Time
-    nanoseconds = nanoseconds.to_i64
     seconds = UNIX_EPOCH.total_seconds + (nanoseconds // 1_000_000_000)
     nanoseconds = nanoseconds % 1_000_000_000
     utc(seconds: seconds, nanoseconds: nanoseconds.to_i)


### PR DESCRIPTION
I am currently working on an application that requires nanosecond time precision (telemetry data). I receive the number of nanoseconds since the unix epoch. There are already convenience methods when the value is milliseconds (`unix_ms` and `to_unix_ms`) however as far as I can tell there is nothing for nanoseconds despite `Time` supporting the precision. 

In my application I have patched in these methods to `Time`. These methods might be too niche for being included in the standard library though.