### PR TITLE
Fix client-side `TCPSocket#remote_address` on Windows

### DIFF
--- a/spec/std/http/server/server_spec.cr
+++ b/spec/std/http/server/server_spec.cr
@@ -472,7 +472,7 @@ describe HTTP::Server do
     end
   end
 
-  pending_win32 describe: "#remote_address / #local_address" do
+  describe "#remote_address / #local_address" do
     it "for http server" do
       remote_address = nil
       local_address = nil

--- a/spec/std/socket/tcp_socket_spec.cr
+++ b/spec/std/socket/tcp_socket_spec.cr
@@ -21,7 +21,7 @@ describe TCPSocket, tags: "network" do
             sock.local_address.port.should eq(port)
             sock.local_address.address.should eq(address)
 
-              client.remote_address.port.should eq(port)
+            client.remote_address.port.should eq(port)
             sock.remote_address.address.should eq address
           end
         end

--- a/spec/std/socket/tcp_socket_spec.cr
+++ b/spec/std/socket/tcp_socket_spec.cr
@@ -21,10 +21,7 @@ describe TCPSocket, tags: "network" do
             sock.local_address.port.should eq(port)
             sock.local_address.address.should eq(address)
 
-            # FIXME: This should work on win32
-            {% unless flag?(:win32) %}
               client.remote_address.port.should eq(port)
-            {% end %}
             sock.remote_address.address.should eq address
           end
         end

--- a/src/crystal/system/win32/socket.cr
+++ b/src/crystal/system/win32/socket.cr
@@ -124,6 +124,18 @@ module Crystal::System::Socket
           return yield ::Socket::Error.from_os_error("ConnectEx", wsa_error)
         end
       end
+
+      # from https://learn.microsoft.com/en-us/windows/win32/winsock/sol-socket-socket-options:
+      #
+      # > This option is used with the ConnectEx, WSAConnectByList, and
+      # > WSAConnectByName functions. This option updates the properties of the
+      # > socket after the connection is established. This option should be set
+      # > if the getpeername, getsockname, getsockopt, setsockopt, or shutdown
+      # > functions are to be used on the connected socket.
+      optname = LibC::SO_UPDATE_CONNECT_CONTEXT
+      if LibC.setsockopt(fd, LibC::SOL_SOCKET, optname, nil, 0) == LibC::SOCKET_ERROR
+        return yield ::Socket::Error.from_wsa_error("setsockopt #{optname}")
+      end
     end
 
     if error

--- a/src/crystal/system/win32/socket.cr
+++ b/src/crystal/system/win32/socket.cr
@@ -124,22 +124,22 @@ module Crystal::System::Socket
           return yield ::Socket::Error.from_os_error("ConnectEx", wsa_error)
         end
       end
-
-      # from https://learn.microsoft.com/en-us/windows/win32/winsock/sol-socket-socket-options:
-      #
-      # > This option is used with the ConnectEx, WSAConnectByList, and
-      # > WSAConnectByName functions. This option updates the properties of the
-      # > socket after the connection is established. This option should be set
-      # > if the getpeername, getsockname, getsockopt, setsockopt, or shutdown
-      # > functions are to be used on the connected socket.
-      optname = LibC::SO_UPDATE_CONNECT_CONTEXT
-      if LibC.setsockopt(fd, LibC::SOL_SOCKET, optname, nil, 0) == LibC::SOCKET_ERROR
-        return yield ::Socket::Error.from_wsa_error("setsockopt #{optname}")
-      end
     end
 
     if error
-      yield error
+      return yield error
+    end
+
+    # from https://learn.microsoft.com/en-us/windows/win32/winsock/sol-socket-socket-options:
+    #
+    # > This option is used with the ConnectEx, WSAConnectByList, and
+    # > WSAConnectByName functions. This option updates the properties of the
+    # > socket after the connection is established. This option should be set
+    # > if the getpeername, getsockname, getsockopt, setsockopt, or shutdown
+    # > functions are to be used on the connected socket.
+    optname = LibC::SO_UPDATE_CONNECT_CONTEXT
+    if LibC.setsockopt(fd, LibC::SOL_SOCKET, optname, nil, 0) == LibC::SOCKET_ERROR
+      return yield ::Socket::Error.from_wsa_error("setsockopt #{optname}")
     end
   end
 

--- a/src/lib_c/x86_64-windows-msvc/c/mswsock.cr
+++ b/src/lib_c/x86_64-windows-msvc/c/mswsock.cr
@@ -2,7 +2,8 @@ require "./guiddef"
 
 @[Link("mswsock")]
 lib LibC
-  SO_UPDATE_ACCEPT_CONTEXT = 0x700B
+  SO_UPDATE_ACCEPT_CONTEXT  = 0x700B
+  SO_UPDATE_CONNECT_CONTEXT = 0x7010
 
   alias AcceptEx = Proc(SOCKET, SOCKET, Void*, DWORD, DWORD, DWORD, DWORD*, OVERLAPPED*, BOOL)
   WSAID_ACCEPTEX = GUID.new(0xb5367df1, 0xcbac, 0x11cf, UInt8.static_array(0x95, 0xca, 0x00, 0x80, 0x5f, 0x48, 0xa1, 0x92))


### PR DESCRIPTION
This is done by setting the `SO_UPDATE_CONNECT_CONTEXT` option upon successful connection, just as `SO_UPDATE_ACCEPT_CONTEXT` is required upon successful listening.