### PR TITLE
Fix `TCPSocket#tcp_keepalive_idle` on Windows

### DIFF
--- a/spec/std/socket/tcp_socket_spec.cr
+++ b/spec/std/socket/tcp_socket_spec.cr
@@ -128,7 +128,7 @@ describe TCPSocket, tags: "network" do
     end
   end
 
-  pending_win32 "settings" do
+  it "settings" do
     port = unused_local_port
 
     TCPServer.open("::", port) do |server|

--- a/src/crystal/system/win32/socket.cr
+++ b/src/crystal/system/win32/socket.cr
@@ -407,11 +407,11 @@ module Crystal::System::Socket
   end
 
   private def system_tcp_keepalive_idle
-    getsockopt LibC::SO_KEEPALIVE, 0, level: ::Socket::Protocol::TCP
+    getsockopt LibC::TCP_KEEPIDLE, 0, level: ::Socket::Protocol::TCP
   end
 
   private def system_tcp_keepalive_idle=(val : Int)
-    setsockopt LibC::SO_KEEPALIVE, val, level: ::Socket::Protocol::TCP
+    setsockopt LibC::TCP_KEEPIDLE, val, level: ::Socket::Protocol::TCP
     val
   end
 


### PR DESCRIPTION
The existing code always raises `WSAENOPROTOOPT` because the wrong level is passed to `getsockopt` or `setsockopt`. It is also incorrect as it is a boolean option that is already exposed via `Socket#keepalive?`.

Note that this option (and `#system_tcp_keepalive_interval`) are only supported on [Windows 10 version 1709 or above](https://learn.microsoft.com/en-us/windows/win32/winsock/ipproto-tcp-socket-options).