### PR TITLE
Fix `IO::FileDescriptor`'s `STDIN` mode spec

### DIFF
--- a/spec/std/io/file_descriptor_spec.cr
+++ b/spec/std/io/file_descriptor_spec.cr
@@ -5,12 +5,20 @@ class IO::FileDescriptor
   include FinalizeCounter
 end
 
+private def shell_command(command)
+  {% if flag?(:win32) %}
+    "cmd.exe /c #{Process.quote(command)}"
+  {% else %}
+    "/bin/sh -c #{Process.quote(command)}"
+  {% end %}
+end
+
 describe IO::FileDescriptor do
-  pending_win32 "reopen STDIN with the right mode" do
+  it "reopen STDIN with the right mode" do
     code = %q(puts "#{STDIN.blocking} #{STDIN.info.type}")
     compile_source(code) do |binpath|
-      `#{Process.quote(binpath)} < #{Process.quote(binpath)}`.chomp.should eq("true File")
-      `echo "" | #{Process.quote(binpath)}`.chomp.should eq("false Pipe")
+      `#{shell_command %(#{Process.quote(binpath)} < #{Process.quote(binpath)})}`.chomp.should eq("true File")
+      `#{shell_command %(echo "" | #{Process.quote(binpath)})}`.chomp.should eq("#{ {{ flag?(:win32) }} } Pipe")
     end
   end
 

--- a/spec/std/io/file_descriptor_spec.cr
+++ b/spec/std/io/file_descriptor_spec.cr
@@ -18,7 +18,7 @@ describe IO::FileDescriptor do
     code = %q(puts "#{STDIN.blocking} #{STDIN.info.type}")
     compile_source(code) do |binpath|
       `#{shell_command %(#{Process.quote(binpath)} < #{Process.quote(binpath)})}`.chomp.should eq("true File")
-      `#{shell_command %(echo "" | #{Process.quote(binpath)})}`.chomp.should eq("#{ {{ flag?(:win32) }} } Pipe")
+      `#{shell_command %(echo "" | #{Process.quote(binpath)})}`.chomp.should eq("#{{{ flag?(:win32) }}} Pipe")
     end
   end
 


### PR DESCRIPTION
Executes the shell command explicitly. There are similar workarounds for `Process` and the macro backtick.

`STDIN` is always blocking on Windows, even after #13362.