### PR TITLE
Fix error message for calling `record` macro with kwargs

### DIFF
--- a/src/macros.cr
+++ b/src/macros.cr
@@ -61,13 +61,13 @@
 # p.copy_with x: 3   # => #<Point(@x=3, @y=2)>
 # p                  # => #<Point(@x=0, @y=2)>
 # ```
-macro record(__name, *properties, **kwargs)
+macro record(__name name, *properties, **kwargs)
   {% raise <<-TXT unless kwargs.empty?
-macro `record` does not accept named arguments
-    Did you mean:
+    macro `record` does not accept named arguments
+      Did you mean:
 
-    record #{name}, #{(properties + kwargs.map { |name, value| "#{name} : #{value}" }).join(", ").id}
-TXT
+      record #{name}, #{(properties + kwargs.map { |name, value| "#{name} : #{value}" }).join(", ").id}
+    TXT
   %}
 
   struct {{name.id}}

--- a/src/macros.cr
+++ b/src/macros.cr
@@ -62,14 +62,10 @@
 # p                  # => #<Point(@x=0, @y=2)>
 # ```
 macro record(name, *properties, **kwargs)
-  {% raise "#{name} does not accept named arguments
-    You probably wrote:
+  {% raise "macro `record` does not accept named arguments
+    Did you mean:
 
-      record #{name}, name: String
-
-    instead of:
-
-      record #{name}, name : String
+    record #{name}, #{(properties + kwargs.map{|name, value| "#{name} : #{value}"}).join(", ").id}
     " unless kwargs.empty? %}
 
   struct {{name.id}}

--- a/src/macros.cr
+++ b/src/macros.cr
@@ -61,7 +61,17 @@
 # p.copy_with x: 3   # => #<Point(@x=3, @y=2)>
 # p                  # => #<Point(@x=0, @y=2)>
 # ```
-macro record(name, *properties)
+macro record(name, *properties, **kwargs)
+  {% raise "#{name} does not accept named arguments
+    You probably wrote:
+
+      record #{name}, name: String
+
+    instead of:
+
+      record #{name}, name : String
+    " unless kwargs.empty? %}
+
   struct {{name.id}}
     {% for property in properties %}
       {% if property.is_a?(Assign) %}

--- a/src/macros.cr
+++ b/src/macros.cr
@@ -65,7 +65,7 @@ macro record(name, *properties, **kwargs)
   {% raise "macro `record` does not accept named arguments
     Did you mean:
 
-    record #{name}, #{(properties + kwargs.map{|name, value| "#{name} : #{value}"}).join(", ").id}
+    record #{name}, #{(properties + kwargs.map { |name, value| "#{name} : #{value}" }).join(", ").id}
     " unless kwargs.empty? %}
 
   struct {{name.id}}

--- a/src/macros.cr
+++ b/src/macros.cr
@@ -61,7 +61,7 @@
 # p.copy_with x: 3   # => #<Point(@x=3, @y=2)>
 # p                  # => #<Point(@x=0, @y=2)>
 # ```
-macro record(name, *properties, **kwargs)
+macro record(__name, *properties, **kwargs)
   {% raise "macro `record` does not accept named arguments
     Did you mean:
 

--- a/src/macros.cr
+++ b/src/macros.cr
@@ -62,11 +62,13 @@
 # p                  # => #<Point(@x=0, @y=2)>
 # ```
 macro record(__name, *properties, **kwargs)
-  {% raise "macro `record` does not accept named arguments
+  {% raise <<-TXT unless kwargs.empty?
+macro `record` does not accept named arguments
     Did you mean:
 
     record #{name}, #{(properties + kwargs.map { |name, value| "#{name} : #{value}" }).join(", ").id}
-    " unless kwargs.empty? %}
+TXT
+  %}
 
   struct {{name.id}}
     {% for property in properties %}


### PR DESCRIPTION
Thanks to straight-shoota, hertdevil, blacksmoke, and devonte's thoughts and ideas we now get this error message when a named arg is provided to `record`

```
Error: Cat does not accept named arguments

    You probably wrote:

      record Cat, name: String

    instead of:

      record Cat, name : String
 ```

The error is a bit long but I believe it is better than just telling the user that record does not accept named arguments. The space costs are more than made up for by the clarity of the message.