### PR TITLE
Fix `Log::Metadata#dup` crash with 2+ entries

### DIFF
--- a/spec/std/log/metadata_spec.cr
+++ b/spec/std/log/metadata_spec.cr
@@ -28,6 +28,14 @@ describe Log::Metadata do
     m({a: 1}).extend({} of Symbol => String).should_not be_empty
   end
 
+  describe "#dup" do
+    it "creates a shallow copy" do
+      Log::Metadata.empty.dup.should eq(Log::Metadata.empty)
+      m({a: 1}).dup.should eq(m({a: 1}))
+      m({a: 1, b: 3}).dup.should eq(m({a: 1, b: 3}))
+    end
+  end
+
   it "extend" do
     m({a: 1}).extend({b: 2}).should eq(m({a: 1, b: 2}))
     m({a: 1, b: 3}).extend({b: 2}).should eq(m({a: 1, b: 2}))

--- a/src/log/metadata.cr
+++ b/src/log/metadata.cr
@@ -37,6 +37,10 @@ class Log::Metadata
     data
   end
 
+  def dup : self
+    self
+  end
+
   protected def setup(@parent : Metadata?, entries : NamedTuple | Hash)
     @size = @overridden_size = entries.size
     @max_total_size = @size + (@parent.try(&.max_total_size) || 0)


### PR DESCRIPTION
All reference types have a default `#dup` implementation that allocates new storage with size equal to `instance_sizeof(self)`. `Log::Metadata` uses custom allocation and instances with 2 or more entries are larger than that size, but the default `#dup` only copies the first entry, so anything after that is uninitialized memory and can lead to crashes: (in this case `:unchecked` probably comes from the symbol's internal ID, used in `Mutex`)

```crystal
puts Log::Metadata.new(nil, {a: 1, b: 2}).dup
# a: 1, unchecked: Program hit a breakpoint and no debugger was attached
```

Since `Log::Metadata` is immutable, `#dup` can be a no-op. A true shallow copy would have been:

```crystal
def dup : self
  data_size = instance_sizeof(self) + sizeof(Entry) * {@size - 1, 0}.max
  copy = GC.malloc(data_size).as(self)
  copy.as(Void*).copy_from(self.as(Void*), data_size)
  copy
end
```