### PR TITLE
Fix `bin\crystal.ps1` inside a PowerShell session

### DIFF
--- a/bin/crystal.bat
+++ b/bin/crystal.bat
@@ -1,2 +1,2 @@
 @echo off
-powershell.exe -NoProfile -ExecutionPolicy Bypass -Command "%~dp0crystal.ps1" --%% %*
+powershell.exe -NoProfile -ExecutionPolicy Bypass -File "%~dp0crystal.ps1" %*

--- a/bin/crystal.ps1
+++ b/bin/crystal.ps1
@@ -207,8 +207,6 @@ function Exec-Process {
     $hnd = $Process.Handle
     Wait-Process -Id $Process.Id
 
-    # and return it properly too: https://stackoverflow.com/a/50202663
-    $host.SetShouldExit($Process.ExitCode)
     Exit $Process.ExitCode
 }
 


### PR DESCRIPTION
The change in #13048 made any use of the script inside a PowerShell session exit that session altogether. This PR uses a different workaround that still propagates the exit code correctly.

This causes things to be quoted slightly differently compared to #11524:

```cmd
>bin\crystal eval "puts 1 + 2, \"1 + 2\", \"'\\\"\""
```