### PR TITLE
Fix doc for return type of `Crystal::Macros::Case#else`

### DIFF
--- a/src/compiler/crystal/macros.cr
+++ b/src/compiler/crystal/macros.cr
@@ -1525,7 +1525,7 @@ module Crystal::Macros
     end
 
     # Returns the `else` of this `case`.
-    def else : ArrayLiteral(When)
+    def else : ASTNode
     end
 
     # Returns whether this `case` is exhaustive (`case ... in`).


### PR DESCRIPTION
The else body is a regular Crystal expression, possibly `Nop`, never an array of `when` clauses.

This is purely a documentation change, the implementation remains the same.