### PR TITLE
Fix `Array#flatten` to discard `Iterator::Stop`

### DIFF
--- a/spec/std/array_spec.cr
+++ b/spec/std/array_spec.cr
@@ -2116,7 +2116,9 @@ describe "Array" do
     t = [4, 5, 6, [7, 8]]
     u = [9, [10, 11].each]
     a = [s, t, u, 12, 13]
-    a.flatten.to_a.should eq([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13])
+    result = a.flatten.to_a
+    result.should eq([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13])
+    result.should be_a(Array(Int32))
   end
 
   it "#skip" do

--- a/src/array.cr
+++ b/src/array.cr
@@ -2224,12 +2224,9 @@ class Array(T)
 
     def self.element_type(ary)
       case ary
-      when Array
-        element_type(ary.first)
-      when Iterator
-        elem = element_type(ary.next)
-        raise "" if elem.is_a?(Iterator::Stop)
-        elem
+      when Array, Iterator
+        ary.each { |elem| return element_type(elem) }
+        ::raise ""
       else
         ary
       end

--- a/src/array.cr
+++ b/src/array.cr
@@ -2227,7 +2227,9 @@ class Array(T)
       when Array
         element_type(ary.first)
       when Iterator
-        element_type(ary.next)
+        elem = element_type(ary.next)
+        raise "" if elem.is_a?(Iterator::Stop)
+        elem
       else
         ary
       end


### PR DESCRIPTION
When calling `Array#flatten` with an iterator as part of the flattened collections, the resulting array would have `Iterator::Stop` as part of the element type.

`Iterator::Stop` is just an indicator for the end of an iterator and not part of its elements. So it must be filtered out when typing the flattened array. `FlattenHelper` failed to do that.
This patch refactors the implementation to be more like `Enumerable.element_type` which has a similar purpose just without flattening.