### PR TITLE
Windows: open standard streams in binary mode

### DIFF
--- a/spec/std/io/file_descriptor_spec.cr
+++ b/spec/std/io/file_descriptor_spec.cr
@@ -37,6 +37,34 @@ describe IO::FileDescriptor do
     end
   end
 
+  it "opens STDIN in binary mode" do
+    code = %q(print STDIN.gets_to_end.includes?('\r'))
+    compile_source(code) do |binpath|
+      io_in = IO::Memory.new("foo\r\n")
+      io_out = IO::Memory.new
+      Process.run(binpath, input: io_in, output: io_out)
+      io_out.to_s.should eq("true")
+    end
+  end
+
+  it "opens STDOUT in binary mode" do
+    code = %q(puts "foo")
+    compile_source(code) do |binpath|
+      io = IO::Memory.new
+      Process.run(binpath, output: io)
+      io.to_s.should eq("foo\n")
+    end
+  end
+
+  it "opens STDERR in binary mode" do
+    code = %q(STDERR.puts "foo")
+    compile_source(code) do |binpath|
+      io = IO::Memory.new
+      Process.run(binpath, error: io)
+      io.to_s.should eq("foo\n")
+    end
+  end
+
   it "does not close if close_on_finalize is false" do
     pipes = [] of IO::FileDescriptor
     assert_finalizes("fd") do

--- a/src/crystal/system/win32/file_descriptor.cr
+++ b/src/crystal/system/win32/file_descriptor.cr
@@ -171,6 +171,7 @@ module Crystal::System::FileDescriptor
     console_handle = false
     handle = windows_handle(fd)
     if handle != LibC::INVALID_HANDLE_VALUE
+      LibC._setmode fd, LibC::O_BINARY
       # TODO: use `out old_mode` after implementing interpreter out closured var
       old_mode = uninitialized LibC::DWORD
       if LibC.GetConsoleMode(handle, pointerof(old_mode)) != 0


### PR DESCRIPTION
Fixes #13304.

This only affects `Process`es that are programs built by Crystal, including those from macro `run`s; `Process.run`ning a C application that prints `\r\n` without doing the same `LibC._setmode` call will still result in `\r\r\n`.