### PR TITLE
Fix `Log::Builder` append `BroadcastBackend` to itself

### DIFF
--- a/spec/std/log/builder_spec.cr
+++ b/spec/std/log/builder_spec.cr
@@ -47,6 +47,44 @@ describe Log::Builder do
     log.level.should eq(s(:info))
   end
 
+  it "creates a log for broadcast backend" do
+    builder = Log::Builder.new
+    a = Log::MemoryBackend.new
+    b = Log::MemoryBackend.new
+
+    broadcast = Log::BroadcastBackend.new
+    broadcast.append(a, :fatal)
+
+    builder.bind("db", :trace, broadcast)
+    builder.bind("db", :info, b)
+
+    log = builder.for("db")
+
+    backend = log.backend.should be_a(Log::BroadcastBackend)
+    backend.@backends.should eq({a => s(:fatal), b => s(:info)})
+    log.source.should eq("db")
+    log.level.should eq(s(:info))
+  end
+
+  it "creates a log for same broadcast backend added multiple times" do
+    builder = Log::Builder.new
+    a = Log::MemoryBackend.new
+
+    broadcast = Log::BroadcastBackend.new
+    broadcast.append(a, :fatal)
+
+    builder.bind("db", :trace, broadcast)
+    builder.bind("db", :info, broadcast)
+
+    log = builder.for("db")
+
+    backend = log.backend.should be_a(Log::BroadcastBackend)
+    backend.should be(broadcast)
+    backend.@backends.should eq({a => s(:fatal)})
+    log.source.should eq("db")
+    log.level.should eq(s(:info))
+  end
+
   it "uses last level for a source x backend" do
     builder = Log::Builder.new
     a = Log::MemoryBackend.new

--- a/src/log/builder.cr
+++ b/src/log/builder.cr
@@ -104,19 +104,16 @@ class Log::Builder
       # if the bind applies for the same backend, the last applied
       # level should be used
       log.initial_level = level
-    when BroadcastBackend
-      current_backend.append(backend, level)
-      # initial_level needs to be recomputed since the append_backend
-      # might be called with the same backend as before but with a
-      # different (higher) level
-      log.initial_level = current_backend.min_level
-      current_backend.level = log.changed_level
     else
-      broadcast = BroadcastBackend.new
-      broadcast.append(current_backend, log.initial_level)
+      broadcast = current_backend.as?(BroadcastBackend)
+      if !broadcast || log.user_provided_broadcast_backend?
+        broadcast = BroadcastBackend.new
+        broadcast.append(current_backend, log.initial_level)
+        log.backend = broadcast
+        log.user_provided_broadcast_backend = false
+      end
       broadcast.append(backend, level)
       broadcast.level = log.changed_level
-      log.backend = broadcast
       log.initial_level = broadcast.min_level
     end
   end

--- a/src/log/builder.cr
+++ b/src/log/builder.cr
@@ -100,6 +100,10 @@ class Log::Builder
     when Nil
       log.backend = backend
       log.initial_level = level
+    when backend
+      # if the bind applies for the same backend, the last applied
+      # level should be used
+      log.initial_level = level
     when BroadcastBackend
       current_backend.append(backend, level)
       # initial_level needs to be recomputed since the append_backend
@@ -108,18 +112,12 @@ class Log::Builder
       log.initial_level = current_backend.min_level
       current_backend.level = log.changed_level
     else
-      if current_backend == backend
-        # if the bind applies for the same backend, the last applied
-        # level should be used
-        log.initial_level = level
-      else
-        broadcast = BroadcastBackend.new
-        broadcast.append(current_backend, log.initial_level)
-        broadcast.append(backend, level)
-        broadcast.level = log.changed_level
-        log.backend = broadcast
-        log.initial_level = broadcast.min_level
-      end
+      broadcast = BroadcastBackend.new
+      broadcast.append(current_backend, log.initial_level)
+      broadcast.append(backend, level)
+      broadcast.level = log.changed_level
+      log.backend = broadcast
+      log.initial_level = broadcast.min_level
     end
   end
 

--- a/src/log/builder.cr
+++ b/src/log/builder.cr
@@ -106,11 +106,14 @@ class Log::Builder
       log.initial_level = level
     else
       broadcast = current_backend.as?(BroadcastBackend)
-      if !broadcast || log.user_provided_broadcast_backend?
+      # If the current backend is not a broadcast backend , we need to
+      # auto-create a broadcast backend for distributing the different log backends.
+      # A broadcast backend explicitly added as a binding, must not be mutated,
+      # so that requires to create a new one as well.
+      if !broadcast || @bindings.any? { |binding| binding.backend.same?(current_backend) }
         broadcast = BroadcastBackend.new
         broadcast.append(current_backend, log.initial_level)
         log.backend = broadcast
-        log.user_provided_broadcast_backend = false
       end
       broadcast.append(backend, level)
       broadcast.level = log.changed_level

--- a/src/log/log.cr
+++ b/src/log/log.cr
@@ -6,6 +6,12 @@ class Log
   property initial_level : Severity
 
   # :nodoc:
+  #
+  # Indicates whether @backend is user-provided or created as a dedicated
+  # backend for this `Log` instance.
+  property? user_provided_broadcast_backend = true
+
+  # :nodoc:
   def initialize(@source : String, @backend : Backend?, level : Severity)
     @initial_level = level
   end

--- a/src/log/log.cr
+++ b/src/log/log.cr
@@ -6,12 +6,6 @@ class Log
   property initial_level : Severity
 
   # :nodoc:
-  #
-  # Indicates whether @backend is user-provided or created as a dedicated
-  # backend for this `Log` instance.
-  property? user_provided_broadcast_backend = true
-
-  # :nodoc:
   def initialize(@source : String, @backend : Backend?, level : Severity)
     @initial_level = level
   end


### PR DESCRIPTION
Resolves #13404

The first commit fixes the immediate bug of adding a broadcast backend to itself.

The second one refactors the builder to avoid mutating a user-provided `BroadcastBackend` entirely
This is implemented via a flag to indicate whether a `Log`'s backend is user-provided or implicitly created for this log instance.