### PR TITLE
Parser: Don't skip the token immediately after `lib` name

### DIFF
--- a/spec/compiler/parser/parser_spec.cr
+++ b/spec/compiler/parser/parser_spec.cr
@@ -2129,6 +2129,8 @@ module Crystal
 
     it_parses "macro foo; bar class: 1; end", Macro.new("foo", body: MacroLiteral.new(" bar class: 1; "))
 
+    assert_syntax_error "lib Foo%end", %(unexpected token: "%")
+
     describe "end locations" do
       assert_end_location "nil"
       assert_end_location "false"

--- a/spec/support/syntax.cr
+++ b/spec/support/syntax.cr
@@ -133,8 +133,8 @@ class Crystal::ASTNode
   end
 end
 
-def assert_syntax_error(str, message = nil, line = nil, column = nil, metafile = __FILE__, metaline = __LINE__, metaendline = __END_LINE__)
-  it "says syntax error on #{str.inspect}", metafile, metaline, metaendline do
+def assert_syntax_error(str, message = nil, line = nil, column = nil, metafile = __FILE__, metaline = __LINE__, metaendline = __END_LINE__, *, focus : Bool = false)
+  it "says syntax error on #{str.inspect}", metafile, metaline, metaendline, focus: focus do
     begin
       parse str
       fail "Expected SyntaxException to be raised", metafile, metaline

--- a/spec/support/syntax.cr
+++ b/spec/support/syntax.cr
@@ -133,8 +133,8 @@ class Crystal::ASTNode
   end
 end
 
-def assert_syntax_error(str, message = nil, line = nil, column = nil, metafile = __FILE__, metaline = __LINE__, metaendline = __END_LINE__, *, focus : Bool = false)
-  it "says syntax error on #{str.inspect}", metafile, metaline, metaendline, focus: focus do
+def assert_syntax_error(str, message = nil, line = nil, column = nil, metafile = __FILE__, metaline = __LINE__, metaendline = __END_LINE__)
+  it "says syntax error on #{str.inspect}", metafile, metaline, metaendline do
     begin
       parse str
       fail "Expected SyntaxException to be raised", metafile, metaline

--- a/src/compiler/crystal/syntax/parser.cr
+++ b/src/compiler/crystal/syntax/parser.cr
@@ -5589,7 +5589,7 @@ module Crystal
 
       name_location = @token.location
       name = parse_path
-      next_token_skip_statement_end
+      skip_statement_end
 
       body = push_visibility { parse_lib_body_expressions }
 


### PR DESCRIPTION
For example, `lib Foo%end` should raise a syntax error because of the `%`

Found this bug while working on #13375