### PR TITLE
Use correct format strings for crash stack traces

### DIFF
--- a/src/exception/call_stack/libunwind.cr
+++ b/src/exception/call_stack/libunwind.cr
@@ -102,35 +102,29 @@ struct Exception::CallStack
   end
 
   private def self.print_frame(repeated_frame)
+    Crystal::System.print_error "[0x%llx] ", repeated_frame.ip.address.to_u64
+    print_frame_location(repeated_frame)
+    Crystal::System.print_error " (%d times)", repeated_frame.count + 1 unless repeated_frame.count == 0
+    Crystal::System.print_error "\n"
+  end
+
+  private def self.print_frame_location(repeated_frame)
     {% if flag?(:debug) %}
       if @@dwarf_loaded &&
          (name = decode_function_name(repeated_frame.ip.address))
         file, line, column = Exception::CallStack.decode_line_number(repeated_frame.ip.address)
         if file && file != "??"
-          if repeated_frame.count == 0
-            Crystal::System.print_error "[0x%lx] %s at %s:%ld:%i\n", repeated_frame.ip, name, file, line, column
-          else
-            Crystal::System.print_error "[0x%lx] %s at %s:%ld:%i (%ld times)\n", repeated_frame.ip, name, file, line, column, repeated_frame.count + 1
-          end
+          Crystal::System.print_error "%s at %s:%d:%d", name, file, line, column
           return
         end
       end
     {% end %}
 
-    frame = decode_frame(repeated_frame.ip)
-    if frame
+    if frame = decode_frame(repeated_frame.ip)
       offset, sname, fname = frame
-      if repeated_frame.count == 0
-        Crystal::System.print_error "[0x%lx] %s +%ld in %s\n", repeated_frame.ip, sname, offset, fname
-      else
-        Crystal::System.print_error "[0x%lx] %s +%ld in %s (%ld times)\n", repeated_frame.ip, sname, offset, fname, repeated_frame.count + 1
-      end
+      Crystal::System.print_error "%s +%lld in %s", sname, offset.to_i64, fname
     else
-      if repeated_frame.count == 0
-        Crystal::System.print_error "[0x%lx] ???\n", repeated_frame.ip
-      else
-        Crystal::System.print_error "[0x%lx] ??? (%ld times)\n", repeated_frame.ip, repeated_frame.count + 1
-      end
+      Crystal::System.print_error "???"
     end
   end
 

--- a/src/exception/call_stack/stackwalk.cr
+++ b/src/exception/call_stack/stackwalk.cr
@@ -150,31 +150,26 @@ struct Exception::CallStack
   end
 
   private def self.print_frame(repeated_frame)
+    Crystal::System.print_error "[0x%llx] ", repeated_frame.ip.address.to_u64
+    print_frame_location(repeated_frame)
+    Crystal::System.print_error " (%d times)", repeated_frame.count + 1 unless repeated_frame.count == 0
+    Crystal::System.print_error "\n"
+  end
+
+  private def self.print_frame_location(repeated_frame)
     if name = decode_function_name(repeated_frame.ip.address)
       file, line, _ = decode_line_number(repeated_frame.ip.address)
       if file != "??" && line != 0
-        if repeated_frame.count == 0
-          Crystal::System.print_error "[0x%llx] %s at %s:%ld\n", repeated_frame.ip, name, file, line
-        else
-          Crystal::System.print_error "[0x%llx] %s at %s:%ld (%ld times)\n", repeated_frame.ip, name, file, line, repeated_frame.count + 1
-        end
+        Crystal::System.print_error "%s at %s:%d", name, file, line
         return
       end
     end
 
     if frame = decode_frame(repeated_frame.ip)
       offset, sname, fname = frame
-      if repeated_frame.count == 0
-        Crystal::System.print_error "[0x%llx] %s +%lld in %s\n", repeated_frame.ip, sname, offset, fname
-      else
-        Crystal::System.print_error "[0x%llx] %s +%lld in %s (%ld times)\n", repeated_frame.ip, sname, offset, fname, repeated_frame.count + 1
-      end
+      Crystal::System.print_error "%s +%lld in %s", sname, offset.to_i64, fname
     else
-      if repeated_frame.count == 0
-        Crystal::System.print_error "[0x%llx] ???\n", repeated_frame.ip
-      else
-        Crystal::System.print_error "[0x%llx] ??? (%ld times)\n", repeated_frame.ip, repeated_frame.count + 1
-      end
+      Crystal::System.print_error "???"
     end
   end
 


### PR DESCRIPTION
When a crash occurs, Crystal is using the incorrect `printf` format strings for `Crystal::System.print_error` when showing the stack trace:

```crystal
def foo(x)
  foo(x - 1)
end

begin
  raise "a"
rescue ex
  # this loads the program's debug info in memory
  # alternatively, setting `$CRYSTAL_LOAD_DEBUG_INFO` to `1` also works
  ex.inspect_with_backtrace
end

foo(1)
```

Run with `--release`:

```
Stack overflow (e.g., infinite or very deep recursion)
[0x55dd6e207f86] print_backtrace at /usr/share/crystal/src/exception/call_stack/libunwind.cr:21474836580:5
[0x55dd6e207f0c] -> at /usr/share/crystal/src/crystal/system/unix/signal.cr:21474836636:5
[0x7f05b4014f90] ?? +139662471548816 in /lib/x86_64-linux-gnu/libc.so.6
[0x55dd6e208745] foo at /home/quinton/crystal/crystal/usr/test.cr:12884901890:3
[0x55dd6e20874a] foo at /home/quinton/crystal/crystal/usr/test.cr:38654705666:9 (140720309009994 times)
[0x55dd6e1e394a] __crystal_main at /home/quinton/crystal/crystal/usr/test.cr:4294967307:1
[0x55dd6e1e834a] main at /usr/share/crystal/src/raise.cr:4294967495:1
[0x7f05b400018a] ?? +139662471463306 in /lib/x86_64-linux-gnu/libc.so.6
[0x7f05b4000245] __libc_start_main +133 in /lib/x86_64-linux-gnu/libc.so.6
[0x55dd6e1e2781] _start +33 in /home/quinton/.cache/crystal/crystal-run-test.tmp
[0x0] ???
```

In particular, the line number and the repeat count are both `Int32`s; when passed into a C variadic function, it is undefined behavior to print them using `%lld`, which requires at least 64 bits. (Only integer types smaller than `LibC::Int` promote in a defined manner.) [It also happens with the empty prelude and non-release mode](https://godbolt.org/z/hrr1rr98z).

This PR switches them to the correct format specifiers while simplifying the implementation, which gives:

```
Stack overflow (e.g., infinite or very deep recursion)
[0x557d1ee80c89] print_backtrace at /home/quinton/crystal/crystal/src/exception/call_stack/libunwind.cr:100:5
[0x557d1ee80c0c] -> at /home/quinton/crystal/crystal/src/crystal/system/unix/signal.cr:156:5
[0x7f107ede7f90] ?? +139708824715152 in /lib/x86_64-linux-gnu/libc.so.6
[0x557d1ee81315] foo at /home/quinton/crystal/crystal/usr/test.cr:2:3
[0x557d1ee8131a] foo at /home/quinton/crystal/crystal/usr/test.cr:2:9 (523778 times)
[0x557d1ee5b695] __crystal_main at /home/quinton/crystal/crystal/usr/test.cr:11:1
[0x557d1ee6040a] main at /home/quinton/crystal/crystal/src/raise.cr:199:1
...
```

First reported in https://github.com/crystal-lang/crystal/issues/13403#issuecomment-1524273440