### PR TITLE
Refactor implementation of `Iterator::ChainIterator`

### DIFF
--- a/spec/std/iterator_spec.cr
+++ b/spec/std/iterator_spec.cr
@@ -165,6 +165,12 @@ describe Iterator do
       iter.next.should be_a(Iterator::Stop)
     end
 
+    it "does not experience tuple upcase bug of #13411" do
+      ary = [] of Bool | Int32
+      [{true}].each.chain([{1}].each).each { |v| ary < v }
+      ary.should eq [true, 1]
+    end
+
     describe "chain indeterminate number of iterators" do
       it "chains all together" do
         iters = [[0], [1], [2, 3], [4, 5, 6]].each.map &.each

--- a/spec/std/iterator_spec.cr
+++ b/spec/std/iterator_spec.cr
@@ -165,10 +165,9 @@ describe Iterator do
       iter.next.should be_a(Iterator::Stop)
     end
 
+    # NOTE: This spec would only fail in release mode.
     it "does not experience tuple upcase bug of #13411" do
-      ary = [] of Tuple(Bool | Int32)
-      [{true}].each.chain([{1}].each).each { |v| ary << v }
-      ary.should eq [{true}, {1}]
+      [{true}].each.chain([{1}].each).first(3).to_a.should eq [{true}, {1}]
     end
 
     describe "chain indeterminate number of iterators" do

--- a/spec/std/iterator_spec.cr
+++ b/spec/std/iterator_spec.cr
@@ -166,9 +166,9 @@ describe Iterator do
     end
 
     it "does not experience tuple upcase bug of #13411" do
-      ary = [] of Bool | Int32
-      [{true}].each.chain([{1}].each).each { |v| ary < v }
-      ary.should eq [true, 1]
+      ary = [] of Tuple(Bool | Int32)
+      [{true}].each.chain([{1}].each).each { |v| ary << v }
+      ary.should eq [{true}, {1}]
     end
 
     describe "chain indeterminate number of iterators" do

--- a/src/iterator.cr
+++ b/src/iterator.cr
@@ -277,16 +277,15 @@ module Iterator(T)
     end
 
     def next
-      if @iterator1_consumed
-        @iterator2.next
-      else
+      unless @iterator1_consumed
         value = @iterator1.next
         if value.is_a?(Stop)
           @iterator1_consumed = true
-          value = @iterator2.next
+        else
+          return value
         end
-        value
       end
+      @iterator2.next
     end
   end
 


### PR DESCRIPTION
Primarily this implementation avoids the symptom of #13411 observed in this method. So it's a bug fix, but it doesn't address the root issue.

It's a good refactor regardless. It simplifies the implementation a little bit.