### PR TITLE
Support synchronous socket operations on Windows

### DIFF
--- a/src/crystal/system/win32/event_loop_iocp.cr
+++ b/src/crystal/system/win32/event_loop_iocp.cr
@@ -22,6 +22,15 @@ class Crystal::Iocp::EventLoop < Crystal::EventLoop
     if iocp.null?
       raise IO::Error.from_winerror("CreateIoCompletionPort")
     end
+    if parent
+      # all overlapped operations may finish synchronously, in which case we do
+      # not reschedule the running fiber; the following call tells Win32 not to
+      # queue an I/O completion packet to the associated IOCP as well, as this
+      # would be done by default
+      if LibC.SetFileCompletionNotificationModes(handle, LibC::FILE_SKIP_COMPLETION_PORT_ON_SUCCESS) == 0
+        raise IO::Error.from_winerror("SetFileCompletionNotificationModes")
+      end
+    end
     iocp
   end
 

--- a/src/io/overlapped.cr
+++ b/src/io/overlapped.cr
@@ -152,9 +152,9 @@ module IO::Overlapped
         # Microsoft documentation:
         # The application must not free or reuse the OVERLAPPED structure
         # associated with the canceled I/O operations until they have completed
-        # (this applies even to asynchronous operations that completed
-        # synchronously)
-        if synchronous? || LibC.CancelIoEx(handle, pointerof(@overlapped)) != 0
+        # (this does not apply to asynchronous operations that finished
+        # synchronously, as nothing would be queued to the IOCP)
+        if !synchronous? && LibC.CancelIoEx(handle, pointerof(@overlapped)) != 0
           @state = :cancelled
           @@canceled.push(self) # to increase lifetime
         end

--- a/src/lib_c/x86_64-windows-msvc/c/winbase.cr
+++ b/src/lib_c/x86_64-windows-msvc/c/winbase.cr
@@ -25,6 +25,10 @@ lib LibC
   fun CreateNamedPipeA(lpName : LPSTR, dwOpenMode : DWORD, dwPipeMode : DWORD, nMaxInstances : DWORD,
                        nOutBufferSize : DWORD, nInBufferSize : DWORD, nDefaultTimeOut : DWORD, lpSecurityAttributes : SECURITY_ATTRIBUTES*) : HANDLE
 
+  FILE_SKIP_COMPLETION_PORT_ON_SUCCESS = 1_u8
+
+  fun SetFileCompletionNotificationModes(fileHandle : HANDLE, flags : UChar) : BOOL
+
   fun GetEnvironmentVariableW(lpName : LPWSTR, lpBuffer : LPWSTR, nSize : DWORD) : DWORD
   fun GetEnvironmentStringsW : LPWCH
   fun FreeEnvironmentStringsW(lpszEnvironmentBlock : LPWCH) : BOOL


### PR DESCRIPTION
Inspired by #13362, this PR adds handling for `AcceptEx`, `ConnectEx`, `WSARecv`, `WSARecvFrom`, `WSASend`, and `WSASendTo` when they complete synchronously, despite using overlapped I/O. In these cases they will not queue anything to the shared I/O completion port at all.

This scenario probably happens when both connected ends are on the same host machine, but unfortunately, once again this is not enough to get the playground working on Windows.