### PR TITLE
Add `URI::Params#merge`, `#merge!` and `URI#update_query_params`

### DIFF
--- a/spec/std/uri/params_spec.cr
+++ b/spec/std/uri/params_spec.cr
@@ -305,6 +305,28 @@ class URI
 
         params.to_s.should eq("foo=bar&foo=baz&foo=buzz&foo=extra&qux=zoo")
       end
+
+      describe "does not modify the other params" do
+        it "with replace: true" do
+          params = Params.parse("foo=bar")
+          other_params = Params.parse("foo=buzz&foo=extra")
+
+          params.merge!(other_params, replace: true)
+          params.add("foo", "another")
+
+          other_params.to_s.should eq("foo=buzz&foo=extra")
+        end
+
+        it "with replace: false" do
+          params = Params.parse("foo=bar")
+          other_params = Params.parse("foo=buzz&foo=extra")
+
+          params.merge!(other_params, replace: false)
+          params.add("foo", "another")
+
+          other_params.to_s.should eq("foo=buzz&foo=extra")
+        end
+      end
     end
 
     describe "#merge" do

--- a/spec/std/uri/params_spec.cr
+++ b/spec/std/uri/params_spec.cr
@@ -296,6 +296,42 @@ class URI
       end
     end
 
+    describe "#merge!" do
+      it "modifies the reciever" do
+        params = Params.parse("foo=bar&foo=baz&qux=zoo")
+        other_params = Params.parse("foo=buzz&foo=extra")
+
+        params.merge!(other_params, replace: false)
+
+        params.to_s.should eq("foo=bar&foo=baz&foo=buzz&foo=extra&qux=zoo")
+      end
+    end
+
+    describe "#merge" do
+      it "replaces all values with the same key by default" do
+        params = Params.parse("foo=bar&foo=baz&qux=zoo")
+        other_params = Params.parse("foo=buzz&foo=extra")
+
+        params.merge(other_params).to_s.should eq("foo=buzz&foo=extra&qux=zoo")
+      end
+
+      it "appends values with the same key with replace: false" do
+        params = Params.parse("foo=bar&foo=baz&qux=zoo")
+        other_params = Params.parse("foo=buzz&foo=extra")
+
+        params.merge(other_params, replace: false).to_s.should eq("foo=bar&foo=baz&foo=buzz&foo=extra&qux=zoo")
+      end
+
+      it "does not modify the reciever" do
+        params = Params.parse("foo=bar&foo=baz&qux=zoo")
+        other_params = Params.parse("foo=buzz&foo=extra")
+
+        params.merge(other_params)
+
+        params.to_s.should eq("foo=bar&foo=baz&qux=zoo")
+      end
+    end
+
     describe "#empty?" do
       it "test empty?" do
         Params.parse("foo=bar&foo=baz&baz=qux").empty?.should be_false

--- a/spec/std/uri_spec.cr
+++ b/spec/std/uri_spec.cr
@@ -349,22 +349,6 @@ describe "URI" do
       uri = URI.parse("?id=30&limit=5#time=1305298413")
       uri.query_params.should eq(expected_params)
     end
-
-    describe "when invoked with a block" do
-      it "returns the modified URI::Params" do
-        expected_params = URI::Params{"id" => "30"}
-
-        uri = URI.parse("http://foo.com?id=30&limit=5#time=1305298413")
-        uri.query_params { |params| params.delete("limit") }.should eq(expected_params)
-      end
-
-      it "commits changes to the URI::Object" do
-        uri = URI.parse("http://foo.com?id=30&limit=5#time=1305298413")
-        uri.query_params { |params| params.delete("limit") }
-
-        uri.to_s.should eq("http://foo.com?id=30#time=1305298413")
-      end
-    end
   end
 
   describe "#query_params=" do
@@ -382,6 +366,22 @@ describe "URI" do
       uri.query_params = params
       uri.query_params.should eq params
       uri.query.should eq "foo=bar&foo=baz"
+    end
+  end
+
+  describe "#update_query_params" do
+    it "returns the modified URI::Params" do
+      expected_params = URI::Params{"id" => "30"}
+
+      uri = URI.parse("http://foo.com?id=30&limit=5#time=1305298413")
+      uri.update_query_params { |params| params.delete("limit") }.should eq(expected_params)
+    end
+
+    it "commits changes to the URI::Object" do
+      uri = URI.parse("http://foo.com?id=30&limit=5#time=1305298413")
+      uri.update_query_params { |params| params.delete("limit") }
+
+      uri.to_s.should eq("http://foo.com?id=30#time=1305298413")
     end
   end
 

--- a/spec/std/uri_spec.cr
+++ b/spec/std/uri_spec.cr
@@ -374,7 +374,8 @@ describe "URI" do
       expected_params = URI::Params{"id" => "30"}
 
       uri = URI.parse("http://foo.com?id=30&limit=5#time=1305298413")
-      uri.update_query_params { |params| params.delete("limit") }.should eq(uri)
+      uri.update_query_params { |params| params.delete("limit") }.should be(uri)
+      uri.query_params.should eq(expected_params)
     end
 
     it "commits changes to the URI::Object" do

--- a/spec/std/uri_spec.cr
+++ b/spec/std/uri_spec.cr
@@ -370,11 +370,11 @@ describe "URI" do
   end
 
   describe "#update_query_params" do
-    it "returns the modified URI::Params" do
+    it "returns self" do
       expected_params = URI::Params{"id" => "30"}
 
       uri = URI.parse("http://foo.com?id=30&limit=5#time=1305298413")
-      uri.update_query_params { |params| params.delete("limit") }.should eq(expected_params)
+      uri.update_query_params { |params| params.delete("limit") }.should eq(uri)
     end
 
     it "commits changes to the URI::Object" do

--- a/spec/std/uri_spec.cr
+++ b/spec/std/uri_spec.cr
@@ -349,6 +349,22 @@ describe "URI" do
       uri = URI.parse("?id=30&limit=5#time=1305298413")
       uri.query_params.should eq(expected_params)
     end
+
+    describe "when invoked with a block" do
+      it "returns the modified URI::Params" do
+        expected_params = URI::Params{"id" => "30"}
+
+        uri = URI.parse("http://foo.com?id=30&limit=5#time=1305298413")
+        uri.query_params { |params| params.delete("limit") }.should eq(expected_params)
+      end
+
+      it "commits changes to the URI::Object" do
+        uri = URI.parse("http://foo.com?id=30&limit=5#time=1305298413")
+        uri.query_params { |params| params.delete("limit") }
+
+        uri.to_s.should eq("http://foo.com?id=30#time=1305298413")
+      end
+    end
   end
 
   describe "#query_params=" do

--- a/src/uri.cr
+++ b/src/uri.cr
@@ -286,7 +286,7 @@ class URI
     self.query = params.to_s
   end
 
-  # Yields a `URI::Params` of the URI#query and commits any modifications.
+  # Yields the value of `#query_params` commits any modifications of the `URI::Params` instance to self.
   # Returns the modified `URI::Params`
   #
   # ```

--- a/src/uri.cr
+++ b/src/uri.cr
@@ -273,6 +273,26 @@ class URI
     URI::Params.parse(@query || "")
   end
 
+  # Yields a `URI::Params` of the URI#query and commits any modifications.
+  # Returns the modified `URI::Params` 
+  # 
+  # ```
+  # require "uri"
+  # uri = URI.parse("http://foo.com?id=30&limit=5#time=1305298413")
+  # uri.query_params { |params| params.delete_all("limit") } # => URI::Params{"id" => ["30"]}
+  #
+  # puts uri.to_s # => "http://foo.com?id=30#time=1305298413"
+  # ```
+  def query_params(&) : URI::Params
+    params = query_params
+
+    yield params
+
+    self.query_params = params
+
+    query_params
+  end
+
   # Sets `query` to stringified *params*.
   #
   # ```

--- a/src/uri.cr
+++ b/src/uri.cr
@@ -292,7 +292,7 @@ class URI
   # ```
   # require "uri"
   # uri = URI.parse("http://foo.com?id=30&limit=5#time=1305298413")
-  # uri.query_params { |params| params.delete_all("limit") } # => URI::Params{"id" => ["30"]}
+  # uri.update_query_params { |params| params.delete_all("limit") } # => URI::Params{"id" => ["30"]}
   #
   # puts uri.to_s # => "http://foo.com?id=30#time=1305298413"
   # ```

--- a/src/uri.cr
+++ b/src/uri.cr
@@ -273,26 +273,6 @@ class URI
     URI::Params.parse(@query || "")
   end
 
-  # Yields a `URI::Params` of the URI#query and commits any modifications.
-  # Returns the modified `URI::Params`
-  #
-  # ```
-  # require "uri"
-  # uri = URI.parse("http://foo.com?id=30&limit=5#time=1305298413")
-  # uri.query_params { |params| params.delete_all("limit") } # => URI::Params{"id" => ["30"]}
-  #
-  # puts uri.to_s # => "http://foo.com?id=30#time=1305298413"
-  # ```
-  def query_params(&) : URI::Params
-    params = query_params
-
-    yield params
-
-    self.query_params = params
-
-    query_params
-  end
-
   # Sets `query` to stringified *params*.
   #
   # ```
@@ -304,6 +284,26 @@ class URI
   # ```
   def query_params=(params : URI::Params)
     self.query = params.to_s
+  end
+
+  # Yields a `URI::Params` of the URI#query and commits any modifications.
+  # Returns the modified `URI::Params`
+  #
+  # ```
+  # require "uri"
+  # uri = URI.parse("http://foo.com?id=30&limit=5#time=1305298413")
+  # uri.query_params { |params| params.delete_all("limit") } # => URI::Params{"id" => ["30"]}
+  #
+  # puts uri.to_s # => "http://foo.com?id=30#time=1305298413"
+  # ```
+  def update_query_params(&) : URI::Params
+    params = query_params
+
+    yield params
+
+    self.query_params = params
+
+    query_params
   end
 
   # Returns the authority component of this URI.

--- a/src/uri.cr
+++ b/src/uri.cr
@@ -296,14 +296,14 @@ class URI
   #
   # puts uri.to_s # => "http://foo.com?id=30#time=1305298413"
   # ```
-  def update_query_params(& : URI::Params -> _) : URI::Params
+  def update_query_params(& : URI::Params -> _) : URI
     params = query_params
 
     yield params
 
     self.query_params = params
 
-    query_params
+    self
   end
 
   # Returns the authority component of this URI.

--- a/src/uri.cr
+++ b/src/uri.cr
@@ -296,7 +296,7 @@ class URI
   #
   # puts uri.to_s # => "http://foo.com?id=30#time=1305298413"
   # ```
-  def update_query_params(&) : URI::Params
+  def update_query_params(& : URI::Params -> _) : URI::Params
     params = query_params
 
     yield params

--- a/src/uri.cr
+++ b/src/uri.cr
@@ -274,8 +274,8 @@ class URI
   end
 
   # Yields a `URI::Params` of the URI#query and commits any modifications.
-  # Returns the modified `URI::Params` 
-  # 
+  # Returns the modified `URI::Params`
+  #
   # ```
   # require "uri"
   # uri = URI.parse("http://foo.com?id=30&limit=5#time=1305298413")

--- a/src/uri/params.cr
+++ b/src/uri/params.cr
@@ -393,7 +393,7 @@ class URI
     # params = URI::Params.parse("foo=bar&foo=baz&qux=zoo")
     # other_params = URI::Params.parse("foo=buzz&foo=extra")
     # params.merge(other_params).to_s # => "foo=buzz&foo=extra&qux=zoo"
-    # params.merge(other_params, replace: true).to_s # => "foo=bar&foo=baz&foo=buzz&foo=extra&qux=zoo"
+    # params.merge(other_params, replace: false).to_s # => "foo=bar&foo=baz&foo=buzz&foo=extra&qux=zoo"
     # ```
     def merge(params : URI::Params, *, replace : Bool = true) : URI::Params
       dup.merge!(params, replace: replace)

--- a/src/uri/params.cr
+++ b/src/uri/params.cr
@@ -362,14 +362,13 @@ class URI
       raw_params.delete(name)
     end
 
-
     # Similar to `#merge` but the receiver is modified.
     #
     # ```
     # params = URI::Params.parse("foo=bar&foo=baz&qux=zoo")
     # other_params = URI::Params.parse("foo=buzz&foo=extra")
     # params.merge!(other_params).to_s # => "foo=buzz&foo=extra&qux=zoo"
-    # params.fetch_all("foo") # => ["buzz", "extra"]
+    # params.fetch_all("foo")          # => ["buzz", "extra"]
     # ```
     def merge!(params : URI::Params, *, replace : Bool = true) : URI::Params
       params.reduce({} of String => Bool?) do |memo, (key, value)|
@@ -392,7 +391,7 @@ class URI
     # ```
     # params = URI::Params.parse("foo=bar&foo=baz&qux=zoo")
     # other_params = URI::Params.parse("foo=buzz&foo=extra")
-    # params.merge(other_params).to_s # => "foo=buzz&foo=extra&qux=zoo"
+    # params.merge(other_params).to_s                 # => "foo=buzz&foo=extra&qux=zoo"
     # params.merge(other_params, replace: false).to_s # => "foo=bar&foo=baz&foo=buzz&foo=extra&qux=zoo"
     # ```
     def merge(params : URI::Params, *, replace : Bool = true) : URI::Params

--- a/src/uri/params.cr
+++ b/src/uri/params.cr
@@ -362,6 +362,43 @@ class URI
       raw_params.delete(name)
     end
 
+
+    # Similar to `#merge` but the receiver is modified.
+    #
+    # ```
+    # params = URI::Params.parse("foo=bar&foo=baz&qux=zoo")
+    # other_params = URI::Params.parse("foo=buzz&foo=extra")
+    # params.merge!(other_params).to_s # => "foo=buzz&foo=extra&qux=zoo"
+    # params.fetch_all("foo") # => ["buzz", "extra"]
+    # ```
+    def merge!(params : URI::Params, *, replace : Bool = true) : URI::Params
+      params.reduce({} of String => Bool?) do |memo, (key, value)|
+        if replace && !memo[key]?
+          self[key] = value
+        else
+          add(key, value)
+        end
+
+        memo[key] = true
+        memo
+      end
+
+      self
+    end
+
+    # Merges a URI::Params with these params. Returns a new URI::Params.
+    # If *replace* is set to `true`, then values with the same key will be overridden.
+    #
+    # ```
+    # params = URI::Params.parse("foo=bar&foo=baz&qux=zoo")
+    # other_params = URI::Params.parse("foo=buzz&foo=extra")
+    # params.merge(other_params).to_s # => "foo=buzz&foo=extra&qux=zoo"
+    # params.merge(other_params, replace: true).to_s # => "foo=bar&foo=baz&foo=buzz&foo=extra&qux=zoo"
+    # ```
+    def merge(params : URI::Params, *, replace : Bool = true) : URI::Params
+      dup.merge!(params, replace: replace)
+    end
+
     # Serializes to string representation as http url-encoded form.
     #
     # ```

--- a/src/uri/params.cr
+++ b/src/uri/params.cr
@@ -374,7 +374,7 @@ class URI
     # See `#merge` for a non-mutating alternative
     def merge!(params : URI::Params, *, replace : Bool = true) : URI::Params
       if replace
-        @raw_params.merge!(params.raw_params) { |_, _, second| second.dup }
+        @raw_params.merge!(params.raw_params) { |_, first, second| second.dup }
       else
         @raw_params.merge!(params.raw_params) do |_, first, second|
           first + second

--- a/src/uri/params.cr
+++ b/src/uri/params.cr
@@ -362,7 +362,7 @@ class URI
       raw_params.delete(name)
     end
 
-    # Similar to `#merge` but the receiver is modified.
+    # Merges *params* into self.
     #
     # ```
     # params = URI::Params.parse("foo=bar&foo=baz&qux=zoo")
@@ -370,9 +370,11 @@ class URI
     # params.merge!(other_params).to_s # => "foo=buzz&foo=extra&qux=zoo"
     # params.fetch_all("foo")          # => ["buzz", "extra"]
     # ```
+    #
+    # See `#merge` for a non-mutating alternative
     def merge!(params : URI::Params, *, replace : Bool = true) : URI::Params
       if replace
-        @raw_params.merge!(params.raw_params)
+        @raw_params.merge!(params.raw_params) { |_, _, second| second.dup }
       else
         @raw_params.merge!(params.raw_params) do |_, first, second|
           first + second
@@ -382,8 +384,9 @@ class URI
       self
     end
 
-    # Merges a URI::Params with these params. Returns a new URI::Params.
-    # If *replace* is set to `true`, then values with the same key will be overridden.
+    # Merges *params* and self into a new instance.
+    # If *replace* is `false` values with the same key are concatenated.
+    # Otherwise the value in *params* overrides the one in self.
     #
     # ```
     # params = URI::Params.parse("foo=bar&foo=baz&qux=zoo")
@@ -391,6 +394,8 @@ class URI
     # params.merge(other_params).to_s                 # => "foo=buzz&foo=extra&qux=zoo"
     # params.merge(other_params, replace: false).to_s # => "foo=bar&foo=baz&foo=buzz&foo=extra&qux=zoo"
     # ```
+    #
+    # See `#merge!` for a mutating alternative
     def merge(params : URI::Params, *, replace : Bool = true) : URI::Params
       dup.merge!(params, replace: replace)
     end

--- a/src/uri/params.cr
+++ b/src/uri/params.cr
@@ -371,15 +371,12 @@ class URI
     # params.fetch_all("foo")          # => ["buzz", "extra"]
     # ```
     def merge!(params : URI::Params, *, replace : Bool = true) : URI::Params
-      params.reduce({} of String => Bool?) do |memo, (key, value)|
-        if replace && !memo[key]?
-          self[key] = value
-        else
-          add(key, value)
+      if replace
+        @raw_params.merge!(params.raw_params)
+      else
+        @raw_params.merge!(params.raw_params) do |_, first, second|
+          first + second
         end
-
-        memo[key] = true
-        memo
       end
 
       self

--- a/src/uri/params.cr
+++ b/src/uri/params.cr
@@ -374,7 +374,7 @@ class URI
     # See `#merge` for a non-mutating alternative
     def merge!(params : URI::Params, *, replace : Bool = true) : URI::Params
       if replace
-        @raw_params.merge!(params.raw_params) { |_, first, second| second.dup }
+        @raw_params.merge!(params.raw_params) { |_, _first, second| second.dup }
       else
         @raw_params.merge!(params.raw_params) do |_, first, second|
           first + second


### PR DESCRIPTION
This PR adds 3 new methods in the URI namespace.

2 utility methods on `URI::Params` for merging other `URI::Params`, destructively and non-destructively.
* `merge(other : URI::Params, *, replace : Bool) : URI::Params`
*  `merge!(other : URI::Params, *, replace : Bool) : URI::Params`

It also adds a method on `URI` to mutate query_params on the URI object in place.
* `update_query_params(&) : URI::Params`

Happy to speak more to it, modify, or close if needed.

closes #13399 