### PR TITLE
Fix `File.info(File::NULL)` on Windows

### DIFF
--- a/spec/std/file_spec.cr
+++ b/spec/std/file_spec.cr
@@ -428,8 +428,7 @@ describe "File" do
       info.type.should eq(File::Type::Directory)
     end
 
-    # TODO: support stating nul on windows
-    pending_win32 "gets for a character device" do
+    it "gets for a character device" do
       info = File.info(File::NULL)
       info.type.should eq(File::Type::CharacterDevice)
     end

--- a/src/crystal/system/win32/file.cr
+++ b/src/crystal/system/win32/file.cr
@@ -164,11 +164,7 @@ module Crystal::System::File
     return check_not_found_error("Unable to get file info", path) if handle == LibC::INVALID_HANDLE_VALUE
 
     begin
-      if LibC.GetFileInformationByHandle(handle, out file_info) == 0
-        raise ::File::Error.from_winerror("Unable to get file info", file: path)
-      end
-
-      ::File::Info.new(file_info, LibC::FILE_TYPE_DISK)
+      FileDescriptor.system_info(handle)
     ensure
       LibC.CloseHandle(handle)
     end


### PR DESCRIPTION
This makes the class method return the same thing as `File.open(File::NULL).info` on Windows, since the bulk of the implementation already exists for the latter.

The returned `File::Info` has no fields set other than `@file_type`. This is the same as calling `File#info` on a file descriptor returned by `IO.pipe`.