### PR TITLE
HTTP Server should allow custom concurrency models

### DIFF
--- a/src/http/server.cr
+++ b/src/http/server.cr
@@ -445,6 +445,12 @@ class HTTP::Server
     listen
   end
 
+  # Overwrite this method to implement an alternative concurrency handler
+  # one example could be the use of a fiber pool
+  protected def dispatch(io)
+    spawn handle_client(io)
+  end
+
   # Starts the server. Blocks until the server is closed.
   def listen : Nil
     raise "Can't re-start closed server" if closed?
@@ -465,9 +471,7 @@ class HTTP::Server
           end
 
           if io
-            # a non nillable version of the closured io
-            _io = io
-            spawn handle_client(_io)
+            dispatch(io)
           else
             break
           end


### PR DESCRIPTION
Splitting out this function makes it simple to implement a custom HTTP::Server using a Fiber pool i.e.

```crystal
require "fiberpool"

class MyServer < HTTP::Server
  @my_pool : FiberPool = FiberPool.new(200)

  protected def dispatch(io)
    @my_pool.run { handle_client(io) }
  end
end
```

for example