### PR TITLE
Simplify implementation of `Serializable#initialize`

### DIFF
--- a/spec/std/json/serializable_spec.cr
+++ b/spec/std/json/serializable_spec.cr
@@ -738,9 +738,10 @@ describe "JSON mapping" do
       json.a.should eq 11
       json.b.should eq "Haha"
 
-      json = JSONAttrWithDefaults.from_json(%({"a":null,"b":null}))
+      json = JSONAttrWithDefaults.from_json(%({"a":null,"b":null,"f":null}))
       json.a.should eq 11
       json.b.should eq "Haha"
+      json.f.should be_nil
     end
 
     it "bool" do

--- a/spec/std/yaml/serializable_spec.cr
+++ b/spec/std/yaml/serializable_spec.cr
@@ -788,9 +788,10 @@ describe "YAML::Serializable" do
       yaml.a.should eq 11
       yaml.b.should eq "Haha"
 
-      yaml = YAMLAttrWithDefaults.from_yaml(%({"a":null,"b":null}))
+      yaml = YAMLAttrWithDefaults.from_yaml(%({"a":null,"b":null,"f":null}))
       yaml.a.should eq 11
       yaml.b.should eq "Haha"
+      yaml.f.should be_nil
 
       yaml = YAMLAttrWithDefaults.from_yaml(%({"b":""}))
       yaml.b.should eq ""

--- a/src/json/pull_parser.cr
+++ b/src/json/pull_parser.cr
@@ -343,11 +343,20 @@ class JSON::PullParser
 
   # Reads a null value and returns it, or executes the given block if the value is not null.
   def read_null_or(&)
+    unless read_null?
+      yield
+    end
+  end
+
+  # Reads the current token if its value is null.
+  #
+  # Returns `true` if the token was read.
+  def read_null? : Bool
     if @kind.null?
       read_next
-      nil
+      true
     else
-      yield
+      false
     end
   end
 

--- a/src/json/serialization.cr
+++ b/src/json/serialization.cr
@@ -202,11 +202,7 @@ module JSON
         # `%var`'s type must be exact to avoid type inference issues with
         # recursively defined serializable types
         {% for name, value in properties %}
-          %var{name} = {% if value[:has_default] || value[:nilable] %}
-                         nil.as(::Union(::Nil, {{value[:type]}}))
-                       {% else %}
-                         uninitialized ::Union({{value[:type]}})
-                       {% end %}
+          %var{name} = uninitialized ::Union({{value[:type]}})
           %found{name} = false
         {% end %}
 
@@ -223,7 +219,7 @@ module JSON
           {% for name, value in properties %}
             when {{value[:key]}}
               begin
-                {% if value[:has_default] || value[:nilable] %} pull.read_null_or do {% else %} begin {% end %}
+                {% if (value[:has_default] && !value[:nilable]) || value[:root] %} pull.read_null_or do {% else %} begin {% end %}
                   %var{name} =
                     {% if value[:root] %} pull.on_key!({{value[:root]}}) do {% else %} begin {% end %}
                       {% if value[:converter] %}
@@ -232,8 +228,8 @@ module JSON
                         ::Union({{value[:type]}}).new(pull)
                       {% end %}
                     end
+                  %found{name} = true
                 end
-                %found{name} = true
               rescue exc : ::JSON::ParseException
                 raise ::JSON::SerializableError.new(exc.message, self.class.to_s, {{value[:key]}}, *%key_location, exc)
               end
@@ -245,25 +241,13 @@ module JSON
         pull.read_next
 
         {% for name, value in properties %}
-          {% unless value[:nilable] || value[:has_default] %}
-            if !%found{name}
-              raise ::JSON::SerializableError.new("Missing JSON attribute: {{value[:key].id}}", self.class.to_s, nil, *%location, nil)
-            end
-          {% end %}
-
-          {% if value[:nilable] %}
-            {% if value[:has_default] != nil %}
-              @{{name}} = %found{name} ? %var{name} : {{value[:default]}}
-            {% else %}
-              @{{name}} = %var{name}
-            {% end %}
-          {% elsif value[:has_default] %}
-            if %found{name} && !%var{name}.nil?
-              @{{name}} = %var{name}
-            end
-          {% else %}
+          if %found{name}
             @{{name}} = %var{name}
-          {% end %}
+          else
+            {% unless value[:has_default] || value[:nilable] %}
+              raise ::JSON::SerializableError.new("Missing JSON attribute: {{value[:key].id}}", self.class.to_s, nil, *%location, nil)
+            {% end %}
+          end
 
           {% if value[:presence] %}
             @{{name}}_present = %found{name}

--- a/src/yaml/schema/core.cr
+++ b/src/yaml/schema/core.cr
@@ -129,9 +129,7 @@ module YAML::Schema::Core
   # If `node` parses to a null value, returns `nil`, otherwise
   # invokes the given block.
   def self.parse_null_or(node : YAML::Nodes::Node, &)
-    if node.is_a?(YAML::Nodes::Scalar) && parse_null?(node)
-      nil
-    else
+    unless parse_null?(node)
       yield
     end
   end
@@ -293,8 +291,13 @@ module YAML::Schema::Core
     end
   end
 
-  private def self.parse_null?(node : Nodes::Scalar)
-    parse_null?(node.value) && node.style.plain?
+  # Returns `true` if *node* parses to a null value.
+  def self.parse_null?(node : Nodes::Node)
+    if node.is_a?(Nodes::Scalar)
+      parse_null?(node.value) && node.style.plain?
+    else
+      false
+    end
   end
 
   private def self.parse_null?(string)

--- a/src/yaml/serialization.cr
+++ b/src/yaml/serialization.cr
@@ -224,15 +224,17 @@ module YAML
             {% for name, value in properties %}
               when {{value[:key]}}
                 begin
-                  {% if value[:has_default] && !value[:nilable] %} YAML::Schema::Core.parse_null_or(value_node) do {% else %} begin {% end %}
-                    %var{name} =
-                      {% if value[:converter] %}
-                        {{value[:converter]}}.from_yaml(ctx, value_node)
-                      {% else %}
-                        ::Union({{value[:type]}}).new(ctx, value_node)
-                      {% end %}
-                    %found{name} = true
-                  end
+                  {% if value[:has_default] && !value[:nilable] %}
+                    next if YAML::Schema::Core.parse_null?(value_node)
+                  {% end %}
+
+                  %var{name} =
+                    {% if value[:converter] %}
+                      {{value[:converter]}}.from_yaml(ctx, value_node)
+                    {% else %}
+                      ::Union({{value[:type]}}).new(ctx, value_node)
+                    {% end %}
+                  %found{name} = true
                 end
             {% end %}
             else


### PR DESCRIPTION
The deserialization logic in `JSON::Serializable` and `YAML::Serializable` is unnecessarily complex. This patch is a refactor for simplicity.

The code for handling whether a value was (not) found and the different conditions (nilable, default) was a major jumble.
The special handling for nilable types is completely unnecessary. If we remove that special case, it all becomes much more straightforward. It also gets rid of duplications. This is the main point of this PR, addressed in the second commit.

The first commit adds specs for #13431 to avoid breaking that in the refactor.

The third commit doesn't change anything structurally, it just simplifies the macro code with a different mechanism. The conditional nesting of `read_null_or`/`parse_null_or` adds unnecessary complexity. We can omit that by just asking the parser for a null value and acting accordingly.