### PR TITLE
Docs: Reference `Process.executable_path` at `PROGRAM_NAME`

### DIFF
--- a/src/kernel.cr
+++ b/src/kernel.cr
@@ -42,6 +42,12 @@ STDOUT = IO::FileDescriptor.from_stdio(1)
 STDERR = IO::FileDescriptor.from_stdio(2)
 
 # The name, the program was called with.
+#
+# The result is may be a relative or absolute path (including symbolic links),
+# just the command name or the empty string.
+#
+# See `Process.executable_path` for a more convenient alternative that always
+# returns the absolute real path to the executable file (if it exists).
 PROGRAM_NAME = String.new(ARGV_UNSAFE.value)
 
 # An array of arguments passed to the program.

--- a/src/kernel.cr
+++ b/src/kernel.cr
@@ -43,7 +43,7 @@ STDERR = IO::FileDescriptor.from_stdio(2)
 
 # The name, the program was called with.
 #
-# The result is may be a relative or absolute path (including symbolic links),
+# The result may be a relative or absolute path (including symbolic links),
 # just the command name or the empty string.
 #
 # See `Process.executable_path` for a more convenient alternative that always


### PR DESCRIPTION
Readers of the `PROGRAM_NAME` docs are currently not informed about the similar and usually more convenient `Process.executable_path`. This patch adds a reference.
The back reference already exists.

Ref: https://forum.crystal-lang.org/t/how-to-get-the-current-running-binary-root-realpath-from-crystal-source-code/5625