### PR TITLE
Backport bugfixes to `release/1.8` for release 1.8.2

### DIFF
--- a/spec/compiler/codegen/offsetof_spec.cr
+++ b/spec/compiler/codegen/offsetof_spec.cr
@@ -56,4 +56,12 @@ describe "Code gen: offsetof" do
       (pointerof(f).as(Void*) + offsetof(Foo, @y).to_i64).as(UInt32*).value == f.y
       CRYSTAL
   end
+
+  it "returns offset of `StaticArray#@buffer`" do
+    run(<<-CRYSTAL).to_b.should be_true
+      x = uninitialized Int32[4]
+      pointerof(x.@buffer).value = 12345
+      (pointerof(x).as(Void*) + offsetof(Int32[4], @buffer).to_i64).as(Int32*).value == x.@buffer
+      CRYSTAL
+  end
 end

--- a/spec/compiler/interpreter/pointers_spec.cr
+++ b/spec/compiler/interpreter/pointers_spec.cr
@@ -121,6 +121,32 @@ describe Crystal::Repl::Interpreter do
       CRYSTAL
     end
 
+    it "pointerof read `StaticArray#@buffer` (1)" do
+      interpret(<<-CRYSTAL).should eq(2)
+        struct StaticArray(T, N)
+          def to_unsafe
+            pointerof(@buffer)
+          end
+
+          def x
+            @buffer
+          end
+        end
+
+        foo = uninitialized Int32[4]
+        foo.to_unsafe.value = 2
+        foo.x
+        CRYSTAL
+    end
+
+    it "pointerof read `StaticArray#@buffer` (2)" do
+      interpret(<<-CRYSTAL).should eq(2)
+        foo = uninitialized Int32[4]
+        pointerof(foo.@buffer).value = 2
+        foo.@buffer
+        CRYSTAL
+    end
+
     it "interprets pointer set and get (union type)" do
       interpret(<<-CRYSTAL).should eq(10)
         ptr = Pointer(Int32 | Bool).malloc(1_u64)

--- a/spec/std/iterator_spec.cr
+++ b/spec/std/iterator_spec.cr
@@ -165,6 +165,11 @@ describe Iterator do
       iter.next.should be_a(Iterator::Stop)
     end
 
+    # NOTE: This spec would only fail in release mode.
+    it "does not experience tuple upcase bug of #13411" do
+      [{true}].each.chain([{1}].each).first(3).to_a.should eq [{true}, {1}]
+    end
+
     describe "chain indeterminate number of iterators" do
       it "chains all together" do
         iters = [[0], [1], [2, 3], [4, 5, 6]].each.map &.each

--- a/spec/std/log/metadata_spec.cr
+++ b/spec/std/log/metadata_spec.cr
@@ -28,6 +28,14 @@ describe Log::Metadata do
     m({a: 1}).extend({} of Symbol => String).should_not be_empty
   end
 
+  describe "#dup" do
+    it "creates a shallow copy" do
+      Log::Metadata.empty.dup.should eq(Log::Metadata.empty)
+      m({a: 1}).dup.should eq(m({a: 1}))
+      m({a: 1, b: 3}).dup.should eq(m({a: 1, b: 3}))
+    end
+  end
+
   it "extend" do
     m({a: 1}).extend({b: 2}).should eq(m({a: 1, b: 2}))
     m({a: 1, b: 3}).extend({b: 2}).should eq(m({a: 1, b: 2}))

--- a/spec/std/string_spec.cr
+++ b/spec/std/string_spec.cr
@@ -2266,7 +2266,7 @@ describe "String" do
     end
   end
 
-  describe "scan" do
+  describe "#scan" do
     it "does without block" do
       a = "cruel world"
       a.scan(/\w+/).map(&.[0]).should eq(["cruel", "world"])
@@ -2302,6 +2302,10 @@ describe "String" do
       r = %r([\s,]*(~@|[\[\]{}()'`~^@]|"(?:\\.|[^\\"])*"|;.*|[^\s\[\]{}('"`,;)]*))
       "hello".scan(r).map(&.[0]).should eq(["hello", ""])
       "hello world".scan(/\w+|(?= )/).map(&.[0]).should eq(["hello", "", "world"])
+    end
+
+    it "works when match is empty, multibyte char" do
+      "\u{80}\u{800}\u{10000}".scan(/()/).map(&.begin).should eq([0, 1, 2, 3])
     end
 
     it "works with strings with block" do

--- a/spec/std/yaml/serializable_spec.cr
+++ b/spec/std/yaml/serializable_spec.cr
@@ -410,6 +410,25 @@ class YAMLSomethingElse
   property value : YAMLAttrValue(Set(YAMLSomethingElse)?)?
 end
 
+module YAMLDiscriminatorBug
+  abstract class Base
+    include YAML::Serializable
+
+    use_yaml_discriminator("type", {"a" => A, "b" => B, "c" => C})
+  end
+
+  class A < Base
+  end
+
+  class B < Base
+    property source : Base
+    property value : Int32 = 1
+  end
+
+  class C < B
+  end
+end
+
 describe "YAML::Serializable" do
   it "works with record" do
     YAMLAttrPoint.new(1, 2).to_yaml.should eq "---\nx: 1\ny: 2\n"
@@ -1010,6 +1029,14 @@ describe "YAML::Serializable" do
       bar = bar.should be_a(YAMLStrictDiscriminatorBar)
       bar.x.should be_a(YAMLStrictDiscriminatorFoo)
       bar.y.should be_a(YAMLStrictDiscriminatorFoo)
+    end
+
+    it "deserializes with discriminator, another recursive type, fixes: #13429" do
+      c = YAMLDiscriminatorBug::Base.from_yaml %q({"type": "c", "source": {"type": "a"}, "value": 2})
+      c.as(YAMLDiscriminatorBug::C).value.should eq 2
+
+      c = YAMLDiscriminatorBug::Base.from_yaml %q({"type": "c", "source": {"type": "a"}})
+      c.as(YAMLDiscriminatorBug::C).value.should eq 1
     end
   end
 

--- a/src/compiler/crystal/codegen/codegen.cr
+++ b/src/compiler/crystal/codegen/codegen.cr
@@ -105,13 +105,13 @@ module Crystal
     end
 
     def offset_of(type, element_index)
-      return 0_u64 if type.extern_union?
+      return 0_u64 if type.extern_union? || type.is_a?(StaticArrayInstanceType)
       llvm_typer.offset_of(llvm_typer.llvm_type(type), element_index)
     end
 
     def instance_offset_of(type, element_index)
-      # extern unions must be value types, which always use the above
-      # `offset_of` instead
+      # extern unions and static arrays must be value types, which always use
+      # the above `offset_of` instead
       llvm_typer.offset_of(llvm_typer.llvm_struct_type(type), element_index + 1)
     end
   end

--- a/src/iterator.cr
+++ b/src/iterator.cr
@@ -277,16 +277,15 @@ module Iterator(T)
     end
 
     def next
-      if @iterator1_consumed
-        @iterator2.next
-      else
+      unless @iterator1_consumed
         value = @iterator1.next
         if value.is_a?(Stop)
           @iterator1_consumed = true
-          value = @iterator2.next
+        else
+          return value
         end
-        value
       end
+      @iterator2.next
     end
   end
 

--- a/src/json/serialization.cr
+++ b/src/json/serialization.cr
@@ -190,6 +190,7 @@ module JSON
                 has_default: ivar.has_default_value?,
                 default:     ivar.default_value,
                 nilable:     ivar.type.nilable?,
+                type:        ivar.type,
                 root:        ann && ann[:root],
                 converter:   ann && ann[:converter],
                 presence:    ann && ann[:presence],
@@ -202,9 +203,9 @@ module JSON
         # recursively defined serializable types
         {% for name, value in properties %}
           %var{name} = {% if value[:has_default] || value[:nilable] %}
-                         nil.as(::Nil | typeof(@{{name}}))
+                         nil.as(::Union(::Nil, {{value[:type]}}))
                        {% else %}
-                         uninitialized typeof(@{{name}})
+                         uninitialized ::Union({{value[:type]}})
                        {% end %}
           %found{name} = false
         {% end %}
@@ -228,7 +229,7 @@ module JSON
                       {% if value[:converter] %}
                         {{value[:converter]}}.from_json(pull)
                       {% else %}
-                        typeof(@{{name}}).new(pull)
+                        ::Union({{value[:type]}}).new(pull)
                       {% end %}
                     end
                 end

--- a/src/log/metadata.cr
+++ b/src/log/metadata.cr
@@ -37,6 +37,10 @@ class Log::Metadata
     data
   end
 
+  def dup : self
+    self
+  end
+
   protected def setup(@parent : Metadata?, entries : NamedTuple | Hash)
     @size = @overridden_size = entries.size
     @max_total_size = @size + (@parent.try(&.max_total_size) || 0)

--- a/src/string.cr
+++ b/src/string.cr
@@ -2872,7 +2872,7 @@ class String
           last_byte_offset = byte_offset
         end
 
-        match = pattern.match_at_byte_index(self, byte_offset)
+        match = pattern.match_at_byte_index(self, byte_offset, Regex::MatchOptions::NO_UTF_CHECK)
       end
 
       if last_byte_offset < bytesize
@@ -4100,7 +4100,8 @@ class String
     count = 0
     match_offset = slice_offset = 0
 
-    while match = separator.match_at_byte_index(self, match_offset)
+    options = Regex::MatchOptions::None
+    while match = separator.match_at_byte_index(self, match_offset, options)
       index = match.byte_begin(0)
       match_bytesize = match.byte_end(0) - index
       next_offset = index + match_bytesize
@@ -4124,6 +4125,7 @@ class String
 
       break if limit && count + 1 == limit
       break if match_offset >= bytesize
+      options |= :no_utf_check
     end
 
     yield byte_slice(slice_offset) unless remove_empty && slice_offset == bytesize
@@ -4583,13 +4585,15 @@ class String
   def scan(pattern : Regex, &) : self
     byte_offset = 0
 
-    while match = pattern.match_at_byte_index(self, byte_offset)
+    options = Regex::MatchOptions::None
+    while match = pattern.match_at_byte_index(self, byte_offset, options)
       index = match.byte_begin(0)
       $~ = match
       yield match
       match_bytesize = match.byte_end(0) - index
       match_bytesize += char_bytesize_at(byte_offset) if match_bytesize == 0
       byte_offset = index + match_bytesize
+      options |= :no_utf_check
     end
 
     self

--- a/src/string.cr
+++ b/src/string.cr
@@ -1715,8 +1715,8 @@ class String
     if single_byte_optimizable?
       unsafe_byte_slice_string(1, bytesize - 1)
     else
-      reader = Char::Reader.new(self)
-      unsafe_byte_slice_string(reader.current_char_width, bytesize - reader.current_char_width)
+      first_char_bytesize = char_bytesize_at(0)
+      unsafe_byte_slice_string(first_char_bytesize, bytesize - first_char_bytesize)
     end
   end
 
@@ -2524,8 +2524,7 @@ class String
     byte_index = char_index_to_byte_index(index)
     raise IndexError.new unless byte_index
 
-    reader = Char::Reader.new(self, pos: byte_index)
-    width = reader.current_char_width
+    width = char_bytesize_at(byte_index)
     replacement_width = replacement.bytesize
     new_bytesize = bytesize - width + replacement_width
 
@@ -2808,7 +2807,7 @@ class String
 
         if string.bytesize == 0
           # The pattern matched an empty result. We must advance one character to avoid stagnation.
-          byte_offset = index + Char::Reader.new(self, pos: byte_offset).current_char_width
+          byte_offset = index + char_bytesize_at(byte_offset)
           last_byte_offset = index
         else
           byte_offset = index + string.bytesize
@@ -2866,7 +2865,7 @@ class String
 
         if str.bytesize == 0
           # The pattern matched an empty result. We must advance one character to avoid stagnation.
-          byte_offset = index + Char::Reader.new(self, pos: byte_offset).current_char_width
+          byte_offset = index + char_bytesize_at(byte_offset)
           last_byte_offset = index
         else
           byte_offset = index + str.bytesize
@@ -4589,7 +4588,7 @@ class String
       $~ = match
       yield match
       match_bytesize = match.byte_end(0) - index
-      match_bytesize += 1 if match_bytesize == 0
+      match_bytesize += char_bytesize_at(byte_offset) if match_bytesize == 0
       byte_offset = index + match_bytesize
     end
 

--- a/src/yaml/serialization.cr
+++ b/src/yaml/serialization.cr
@@ -196,6 +196,7 @@ module YAML
                 has_default: ivar.has_default_value?,
                 default:     ivar.default_value,
                 nilable:     ivar.type.nilable?,
+                type:        ivar.type,
                 converter:   ann && ann[:converter],
                 presence:    ann && ann[:presence],
               }
@@ -207,9 +208,9 @@ module YAML
         # recursively defined serializable types
         {% for name, value in properties %}
           %var{name} = {% if value[:has_default] || value[:nilable] %}
-                         nil.as(::Nil | typeof(@{{name}}))
+                         nil.as(::Union(::Nil, {{value[:type]}}))
                        {% else %}
-                         uninitialized typeof(@{{name}})
+                         uninitialized ::Union({{value[:type]}})
                        {% end %}
           %found{name} = false
         {% end %}
@@ -232,7 +233,7 @@ module YAML
                       {% if value[:converter] %}
                         {{value[:converter]}}.from_yaml(ctx, value_node)
                       {% else %}
-                        typeof(@{{name}}).new(ctx, value_node)
+                        ::Union({{value[:type]}}).new(ctx, value_node)
                       {% end %}
                   end
 


### PR DESCRIPTION
This branch backports the following bugfixes to the release branch https://github.com/crystal-lang/crystal/tree/release/1.8:


* #13430
* https://github.com/crystal-lang/crystal/pull/13319
* https://github.com/crystal-lang/crystal/pull/13387
* https://github.com/crystal-lang/crystal/pull/13369
* https://github.com/crystal-lang/crystal/pull/13412
* https://github.com/crystal-lang/crystal/pull/13406

I have moved all of them to the [1.8.2 milestone](https://github.com/crystal-lang/crystal/milestone/71).