### PR TITLE
Support DLL delay-loading on Windows

### DIFF
--- a/src/compiler/crystal/loader.cr
+++ b/src/compiler/crystal/loader.cr
@@ -10,8 +10,6 @@ require "option_parser"
 # finding symbols inside them.
 #
 # See system-specific implementations in ./loader for details.
-#
-# A Windows implementation is not yet available.
 class Crystal::Loader
   class LoadError < Exception
     property args : Array(String)?

--- a/src/compiler/crystal/loader/msvc.cr
+++ b/src/compiler/crystal/loader/msvc.cr
@@ -44,7 +44,7 @@ class Crystal::Loader
         next unless File.file?(library_path)
 
         Crystal::System::LibraryArchive.imported_dlls(library_path).each do |dll|
-          dlls << dll unless dll.downcase == "kernel32.dll"
+          dlls << dll unless dll.compare("kernel32.dll", case_insensitive: true).zero?
         end
         break
       end

--- a/src/compiler/crystal/loader/msvc.cr
+++ b/src/compiler/crystal/loader/msvc.cr
@@ -20,8 +20,41 @@ class Crystal::Loader
 
   # Parses linker arguments in the style of `link.exe`.
   def self.parse(args : Array(String), *, search_paths : Array(String) = default_search_paths) : self
-    libnames = [] of String
+    search_paths, libnames = parse_args(args, search_paths)
     file_paths = [] of String
+
+    begin
+      self.new(search_paths, libnames, file_paths)
+    rescue exc : LoadError
+      exc.args = args
+      exc.search_paths = search_paths
+      raise exc
+    end
+  end
+
+  # Returns the list of DLLs imported from the libraries specified in the given
+  # linker arguments. Used by the compiler for delay-loaded DLL support.
+  def self.search_dlls(args : Array(String), *, search_paths : Array(String) = default_search_paths) : Set(String)
+    search_paths, libnames = parse_args(args, search_paths)
+    dlls = Set(String).new
+
+    libnames.each do |libname|
+      search_paths.each do |directory|
+        library_path = File.join(directory, library_filename(libname))
+        next unless File.file?(library_path)
+
+        Crystal::System::LibraryArchive.imported_dlls(library_path).each do |dll|
+          dlls << dll unless dll.downcase == "kernel32.dll"
+        end
+        break
+      end
+    end
+
+    dlls
+  end
+
+  private def self.parse_args(args, search_paths)
+    libnames = [] of String
 
     # NOTE: `/LIBPATH`s are prepended before the default paths:
     # (https://docs.microsoft.com/en-us/cpp/build/reference/libpath-additional-libpath)
@@ -39,14 +72,7 @@ class Crystal::Loader
     end
 
     search_paths = extra_search_paths + search_paths
-
-    begin
-      self.new(search_paths, libnames, file_paths)
-    rescue exc : LoadError
-      exc.args = args
-      exc.search_paths = search_paths
-      raise exc
-    end
+    {search_paths, libnames}
   end
 
   def self.library_filename(libname : String) : String

--- a/src/crystal/main.cr
+++ b/src/crystal/main.cr
@@ -129,6 +129,7 @@ end
 
 {% if flag?(:win32) %}
   require "./system/win32/wmain"
+  require "./system/win32/delay_load"
 {% end %}
 
 {% if flag?(:wasi) %}

--- a/src/crystal/system/win32/delay_load.cr
+++ b/src/crystal/system/win32/delay_load.cr
@@ -1,0 +1,205 @@
+require "c/delayimp"
+
+private ERROR_SEVERITY_ERROR = 0xC0000000_u32
+private FACILITY_VISUALCPP   =           0x6d
+
+private macro vcpp_exception(err)
+  {{ ERROR_SEVERITY_ERROR | (FACILITY_VISUALCPP << 16) | err }}
+end
+
+lib LibC
+  $image_base = __ImageBase : IMAGE_DOS_HEADER
+end
+
+private macro p_from_rva(rva)
+  pointerof(LibC.image_base).as(UInt8*) + {{ rva }}
+end
+
+module Crystal::System::DelayLoad
+  @[Extern]
+  record InternalImgDelayDescr,
+    grAttrs : LibC::DWORD,
+    szName : LibC::LPSTR,
+    phmod : LibC::HMODULE*,
+    pIAT : LibC::IMAGE_THUNK_DATA*,
+    pINT : LibC::IMAGE_THUNK_DATA*,
+    pBoundIAT : LibC::IMAGE_THUNK_DATA*,
+    pUnloadIAT : LibC::IMAGE_THUNK_DATA*,
+    dwTimeStamp : LibC::DWORD
+
+  @[AlwaysInline]
+  def self.pinh_from_image_base(hmod : LibC::HMODULE)
+    (hmod.as(UInt8*) + hmod.as(LibC::IMAGE_DOS_HEADER*).value.e_lfanew).as(LibC::IMAGE_NT_HEADERS*)
+  end
+
+  @[AlwaysInline]
+  def self.interlocked_exchange(atomic : LibC::HMODULE*, value : LibC::HMODULE)
+    Atomic::Ops.atomicrmw(:xchg, atomic, value, :sequentially_consistent, false)
+  end
+end
+
+# This is a port of the default delay-load helper function in the `DelayHlp.cpp`
+# file that comes with Microsoft Visual C++, except that all user-defined hooks
+# are omitted. It is called every time the program attempts to load a symbol
+# from a DLL. For more details see:
+# https://learn.microsoft.com/en-us/cpp/build/reference/understanding-the-helper-function
+#
+# It is available even when the `preview_dll` flag is absent, so that system
+# DLLs such as `advapi32.dll` and shards can be delay-loaded in the usual mixed
+# static/dynamic builds by passing the appropriate linker flags explicitly.
+#
+# The delay load helper cannot call functions from the library being loaded, as
+# that leads to an infinite recursion. In particular, if `preview_dll` is in
+# effect, `Crystal::System.print_error` will not work, because the C runtime
+# library DLLs are also delay-loaded and `LibC.snprintf` is unavailable. If you
+# want print debugging inside this function, try the following:
+#
+# ```
+# lib LibC
+#   STD_OUTPUT_HANDLE = -11
+#
+#   fun GetStdHandle(nStdHandle : DWORD) : HANDLE
+#   fun FormatMessageA(dwFlags : DWORD, lpSource : Void*, dwMessageId : DWORD, dwLanguageId : DWORD, lpBuffer : LPSTR, nSize : DWORD, arguments : Void*) : DWORD
+# end
+#
+# buf = uninitialized LibC::CHAR[512]
+# args = StaticArray[dli.szDll, dli.dlp.union.szProcName]
+# len = LibC.FormatMessageA(LibC::FORMAT_MESSAGE_FROM_STRING | LibC::FORMAT_MESSAGE_ARGUMENT_ARRAY, "Loading `%2` from `%1`\n", 0, 0, buf, buf.size, args)
+# LibC.WriteFile(LibC.GetStdHandle(LibC::STD_OUTPUT_HANDLE), buf, len, out _, nil)
+# ```
+#
+# `kernel32.dll` is the only DLL guaranteed to be available. It cannot be
+# delay-loaded and the Crystal compiler excludes it from the linker arguments.
+#
+# This function does _not_ work with the empty prelude yet!
+fun __delayLoadHelper2(pidd : LibC::ImgDelayDescr*, ppfnIATEntry : LibC::FARPROC*) : LibC::FARPROC
+  # TODO: support protected delay load? (/GUARD:CF)
+  # DloadAcquireSectionWriteAccess
+
+  # Set up some data we use for the hook procs but also useful for our own use
+  idd = Crystal::System::DelayLoad::InternalImgDelayDescr.new(
+    grAttrs: pidd.value.grAttrs,
+    szName: p_from_rva(pidd.value.rvaDLLName).as(LibC::LPSTR),
+    phmod: p_from_rva(pidd.value.rvaHmod).as(LibC::HMODULE*),
+    pIAT: p_from_rva(pidd.value.rvaIAT).as(LibC::IMAGE_THUNK_DATA*),
+    pINT: p_from_rva(pidd.value.rvaINT).as(LibC::IMAGE_THUNK_DATA*),
+    pBoundIAT: p_from_rva(pidd.value.rvaBoundIAT).as(LibC::IMAGE_THUNK_DATA*),
+    pUnloadIAT: p_from_rva(pidd.value.rvaUnloadIAT).as(LibC::IMAGE_THUNK_DATA*),
+    dwTimeStamp: pidd.value.dwTimeStamp,
+  )
+
+  dli = LibC::DelayLoadInfo.new(
+    cb: sizeof(LibC::DelayLoadInfo),
+    pidd: pidd,
+    ppfn: ppfnIATEntry,
+    szDll: idd.szName,
+    dlp: LibC::DelayLoadProc.new,
+    hmodCur: LibC::HMODULE.null,
+    pfnCur: LibC::FARPROC.null,
+    dwLastError: LibC::DWORD.zero,
+  )
+
+  if 0 == idd.grAttrs & LibC::DLAttrRva
+    rgpdli = pointerof(dli)
+
+    # DloadReleaseSectionWriteAccess
+
+    LibC.RaiseException(
+      vcpp_exception(87_u32), # WinError::ERROR_INVALID_PARAMETER
+      0,
+      1,
+      Pointer(LibC::ULONG_PTR).new(pointerof(rgpdli).address),
+    )
+  end
+
+  hmod = idd.phmod.value
+
+  # Calculate the index for the IAT entry in the import address table
+  # N.B. The INT entries are ordered the same as the IAT entries so
+  # the calculation can be done on the IAT side.
+  iIAT = ppfnIATEntry.as(LibC::IMAGE_THUNK_DATA*) - idd.pIAT
+  iINT = iIAT
+
+  pitd = idd.pINT + iINT
+
+  dli.dlp.fImportByName = pitd.value.u1.ordinal & LibC::IMAGE_ORDINAL_FLAG == 0
+
+  if dli.dlp.fImportByName
+    import_by_name = p_from_rva(LibC::RVA.new!(pitd.value.u1.addressOfData))
+    dli.dlp.union.szProcName = import_by_name + offsetof(LibC::IMAGE_IMPORT_BY_NAME, @name)
+  else
+    dli.dlp.union.dwOrdinal = LibC::DWORD.new!(pitd.value.u1.ordinal & 0xFFFF)
+  end
+
+  # Check to see if we need to try to load the library.
+  if !hmod
+    # note: ANSI variant used here
+    unless hmod = LibC.LoadLibraryExA(dli.szDll, nil, 0)
+      dli.dwLastError = LibC.GetLastError
+
+      rgpdli = pointerof(dli)
+
+      # DloadReleaseSectionWriteAccess
+      LibC.RaiseException(
+        vcpp_exception(126_u32), # WinError::ERROR_MOD_NOT_FOUND
+        0,
+        1,
+        Pointer(LibC::ULONG_PTR).new(pointerof(rgpdli).address),
+      )
+
+      # If we get to here, we blindly assume that the handler of the exception
+      # has magically fixed everything up and left the function pointer in
+      # dli.pfnCur.
+      return dli.pfnCur
+    end
+
+    # Store the library handle.  If it is already there, we infer
+    # that another thread got there first, and we need to do a
+    # FreeLibrary() to reduce the refcount
+    hmodT = Crystal::System::DelayLoad.interlocked_exchange(idd.phmod, hmod)
+    LibC.FreeLibrary(hmod) if hmodT == hmod
+  end
+
+  # Go for the procedure now.
+  dli.hmodCur = hmod
+  if pidd.value.rvaBoundIAT != 0 && pidd.value.dwTimeStamp != 0
+    # bound imports exist...check the timestamp from the target image
+    pinh = Crystal::System::DelayLoad.pinh_from_image_base(hmod)
+
+    if pinh.value.signature == LibC::IMAGE_NT_SIGNATURE &&
+       pinh.value.fileHeader.timeDateStamp == idd.dwTimeStamp &&
+       hmod.address == pinh.value.optionalHeader.imageBase
+      # Everything is good to go, if we have a decent address
+      # in the bound IAT!
+      if pfnRet = LibC::FARPROC.new(idd.pBoundIAT[iIAT].u1.function)
+        ppfnIATEntry.value = pfnRet
+        # DloadReleaseSectionWriteAccess
+        return pfnRet
+      end
+    end
+  end
+
+  unless pfnRet = LibC.GetProcAddress(hmod, dli.dlp.union.szProcName)
+    dli.dwLastError = LibC.GetLastError
+
+    rgpdli = pointerof(dli)
+
+    # DloadReleaseSectionWriteAccess
+    LibC.RaiseException(
+      vcpp_exception(127_u32), # WinError::ERROR_PROC_NOT_FOUND
+      0,
+      1,
+      Pointer(LibC::ULONG_PTR).new(pointerof(rgpdli).address),
+    )
+    # DloadAcquireSectionWriteAccess
+
+    # If we get to here, we blindly assume that the handler of the exception
+    # has magically fixed everything up and left the function pointer in
+    # dli.pfnCur.
+    pfnRet = dli.pfnCur
+  end
+
+  ppfnIATEntry.value = pfnRet
+  # DloadReleaseSectionWriteAccess
+  pfnRet
+end

--- a/src/crystal/system/win32/delay_load.cr
+++ b/src/crystal/system/win32/delay_load.cr
@@ -4,7 +4,7 @@ private ERROR_SEVERITY_ERROR = 0xC0000000_u32
 private FACILITY_VISUALCPP   =           0x6d
 
 private macro vcpp_exception(err)
-  {{ ERROR_SEVERITY_ERROR | (FACILITY_VISUALCPP << 16) | err }}
+  {{ ERROR_SEVERITY_ERROR | (FACILITY_VISUALCPP << 16) | WinError.constant(err.id) }}
 end
 
 lib LibC
@@ -105,10 +105,10 @@ fun __delayLoadHelper2(pidd : LibC::ImgDelayDescr*, ppfnIATEntry : LibC::FARPROC
     # DloadReleaseSectionWriteAccess
 
     LibC.RaiseException(
-      vcpp_exception(87_u32), # WinError::ERROR_INVALID_PARAMETER
+      vcpp_exception(ERROR_INVALID_PARAMETER),
       0,
       1,
-      Pointer(LibC::ULONG_PTR).new(pointerof(rgpdli).address),
+      pointerof(rgpdli).as(LibC::ULONG_PTR*),
     )
   end
 
@@ -141,10 +141,10 @@ fun __delayLoadHelper2(pidd : LibC::ImgDelayDescr*, ppfnIATEntry : LibC::FARPROC
 
       # DloadReleaseSectionWriteAccess
       LibC.RaiseException(
-        vcpp_exception(126_u32), # WinError::ERROR_MOD_NOT_FOUND
+        vcpp_exception(ERROR_MOD_NOT_FOUND),
         0,
         1,
-        Pointer(LibC::ULONG_PTR).new(pointerof(rgpdli).address),
+        pointerof(rgpdli).as(LibC::ULONG_PTR*),
       )
 
       # If we get to here, we blindly assume that the handler of the exception
@@ -186,10 +186,10 @@ fun __delayLoadHelper2(pidd : LibC::ImgDelayDescr*, ppfnIATEntry : LibC::FARPROC
 
     # DloadReleaseSectionWriteAccess
     LibC.RaiseException(
-      vcpp_exception(127_u32), # WinError::ERROR_PROC_NOT_FOUND
+      vcpp_exception(ERROR_PROC_NOT_FOUND),
       0,
       1,
-      Pointer(LibC::ULONG_PTR).new(pointerof(rgpdli).address),
+      pointerof(rgpdli).as(LibC::ULONG_PTR*),
     )
     # DloadAcquireSectionWriteAccess
 

--- a/src/lib_c/x86_64-windows-msvc/c/delayimp.cr
+++ b/src/lib_c/x86_64-windows-msvc/c/delayimp.cr
@@ -1,0 +1,40 @@
+require "c/libloaderapi"
+require "c/winnt"
+
+lib LibC
+  alias RVA = DWORD
+
+  struct ImgDelayDescr
+    grAttrs : DWORD     # attributes
+    rvaDLLName : RVA    # RVA to dll name
+    rvaHmod : RVA       # RVA of module handle
+    rvaIAT : RVA        # RVA of the IAT
+    rvaINT : RVA        # RVA of the INT
+    rvaBoundIAT : RVA   # RVA of the optional bound IAT
+    rvaUnloadIAT : RVA  # RVA of optional copy of original IAT
+    dwTimeStamp : DWORD # 0 if not bound, O.W. date/time stamp of DLL bound to (Old BIND)
+  end
+
+  DLAttrRva = 0x1
+
+  union DelayLoadProc_union
+    szProcName : LPSTR
+    dwOrdinal : DWORD
+  end
+
+  struct DelayLoadProc
+    fImportByName : BOOL
+    union : DelayLoadProc_union
+  end
+
+  struct DelayLoadInfo
+    cb : DWORD            # size of structure
+    pidd : ImgDelayDescr* # raw form of data (everything is there)
+    ppfn : FARPROC*       # points to address of function to load
+    szDll : LPSTR         # name of dll
+    dlp : DelayLoadProc   # name or ordinal of procedure
+    hmodCur : HMODULE     # the hInstance of the library we have loaded
+    pfnCur : FARPROC      # the actual function that will be called
+    dwLastError : DWORD   # error received (if an error notification)
+  end
+end

--- a/src/lib_c/x86_64-windows-msvc/c/errhandlingapi.cr
+++ b/src/lib_c/x86_64-windows-msvc/c/errhandlingapi.cr
@@ -11,5 +11,6 @@ lib LibC
 
   fun GetLastError : DWORD
   fun SetLastError(dwErrCode : DWORD)
+  fun RaiseException(dwExceptionCode : DWORD, dwExceptionFlags : DWORD, nNumberOfArguments : DWORD, lpArguments : ULONG_PTR*)
   fun AddVectoredExceptionHandler(first : DWORD, handler : PVECTORED_EXCEPTION_HANDLER) : Void*
 end

--- a/src/lib_c/x86_64-windows-msvc/c/libloaderapi.cr
+++ b/src/lib_c/x86_64-windows-msvc/c/libloaderapi.cr
@@ -4,6 +4,7 @@ require "c/winnt"
 lib LibC
   alias FARPROC = Void*
 
+  fun LoadLibraryExA(lpLibFileName : LPSTR, hFile : HANDLE, dwFlags : DWORD) : HMODULE
   fun LoadLibraryExW(lpLibFileName : LPWSTR, hFile : HANDLE, dwFlags : DWORD) : HMODULE
   fun FreeLibrary(hLibModule : HMODULE) : BOOL
 

--- a/src/lib_c/x86_64-windows-msvc/c/winnt.cr
+++ b/src/lib_c/x86_64-windows-msvc/c/winnt.cr
@@ -198,4 +198,104 @@ lib LibC
     protect : DWORD
     type : DWORD
   end
+
+  IMAGE_NT_SIGNATURE = 0x00004550 # PE00
+
+  struct IMAGE_DOS_HEADER
+    e_magic : WORD
+    e_cblp : WORD
+    e_cp : WORD
+    e_crlc : WORD
+    e_cparhdr : WORD
+    e_minalloc : WORD
+    e_maxalloc : WORD
+    e_ss : WORD
+    e_sp : WORD
+    e_csum : WORD
+    e_ip : WORD
+    e_cs : WORD
+    e_lfarlc : WORD
+    e_ovno : WORD
+    e_res : WORD[4]
+    e_oemid : WORD
+    e_oeminfo : WORD
+    e_res2 : WORD[10]
+    e_lfanew : LONG
+  end
+
+  struct IMAGE_FILE_HEADER
+    machine : WORD
+    numberOfSections : WORD
+    timeDateStamp : DWORD
+    pointerToSymbolTable : DWORD
+    numberOfSymbols : DWORD
+    sizeOfOptionalHeader : WORD
+    characteristics : WORD
+  end
+
+  struct IMAGE_DATA_DIRECTORY
+    virtualAddress : DWORD
+    size : DWORD
+  end
+
+  struct IMAGE_OPTIONAL_HEADER64
+    magic : WORD
+    majorLinkerVersion : BYTE
+    minorLinkerVersion : BYTE
+    sizeOfCode : DWORD
+    sizeOfInitializedData : DWORD
+    sizeOfUninitializedData : DWORD
+    addressOfEntryPoint : DWORD
+    baseOfCode : DWORD
+    imageBase : ULongLong
+    sectionAlignment : DWORD
+    fileAlignment : DWORD
+    majorOperatingSystemVersion : WORD
+    minorOperatingSystemVersion : WORD
+    majorImageVersion : WORD
+    minorImageVersion : WORD
+    majorSubsystemVersion : WORD
+    minorSubsystemVersion : WORD
+    win32VersionValue : DWORD
+    sizeOfImage : DWORD
+    sizeOfHeaders : DWORD
+    checkSum : DWORD
+    subsystem : WORD
+    dllCharacteristics : WORD
+    sizeOfStackReserve : ULongLong
+    sizeOfStackCommit : ULongLong
+    sizeOfHeapReserve : ULongLong
+    sizeOfHeapCommit : ULongLong
+    loaderFlags : DWORD
+    numberOfRvaAndSizes : DWORD
+    dataDirectory : IMAGE_DATA_DIRECTORY[16] # IMAGE_NUMBEROF_DIRECTORY_ENTRIES
+  end
+
+  struct IMAGE_NT_HEADERS64
+    signature : DWORD
+    fileHeader : IMAGE_FILE_HEADER
+    optionalHeader : IMAGE_OPTIONAL_HEADER64
+  end
+
+  struct IMAGE_IMPORT_BY_NAME
+    hint : WORD
+    name : CHAR[1]
+  end
+
+  union IMAGE_THUNK_DATA64_u1
+    forwarderString : ULongLong
+    function : ULongLong
+    ordinal : ULongLong
+    addressOfData : ULongLong
+  end
+
+  struct IMAGE_THUNK_DATA64
+    u1 : IMAGE_THUNK_DATA64_u1
+  end
+
+  IMAGE_ORDINAL_FLAG64 = 0x8000000000000000_u64
+
+  alias IMAGE_NT_HEADERS = IMAGE_NT_HEADERS64
+  alias IMAGE_THUNK_DATA = IMAGE_THUNK_DATA64
+  IMAGE_ORDINAL_FLAG = IMAGE_ORDINAL_FLAG64
 end

--- a/src/raise.cr
+++ b/src/raise.cr
@@ -94,6 +94,9 @@ end
 {% elsif flag?(:win32) %}
   require "exception/lib_unwind"
 
+  {% begin %}
+    @[Link({{ flag?(:preview_dll) ? "vcruntime" : "libvcruntime" }})]
+  {% end %}
   lib LibC
     fun _CxxThrowException(ex : Void*, throw_info : Void*) : NoReturn
   end


### PR DESCRIPTION
This PR adds [support for the `/DELAYLOAD` MSVC linker flag](https://learn.microsoft.com/en-us/cpp/build/reference/linker-support-for-delay-loaded-dlls), and additionally makes almost all DLLs delay-loaded when `-Dpreview_dll` is used to build a load-time dynamically linked executable.

When a program is linked against a DLL import library, by default the startup code automatically calls `LoadLibrary` and `GetProcAddress` behind the scenes to perform the actual linking, and terminates with `STATUS_DLL_NOT_FOUND = 0xC0000135` if a DLL cannot be found. This happens before the entry point gets called, so Crystal's runtime cannot intercept the error at all, and the parent process receives no information other than the exit code. With delayed loading, the DLLs and symbols are only loaded the first time they are used, and `__delayLoadHelper2` becomes the linker function, which must be defined separately.

One way to obtain this linker function is to link against `delayimp.lib` from Visual C++ for a sensible default implementation with support for several user-defined hooks, and the other is to port the reference implementation to Crystal. This PR does the latter, which gives us complete control over the link process, in particular the DLL search order and error reporting. At the moment `fun __delayLoadHelper2` is a verbatim port of the file [`Microsoft Visual Studio\2022\Community\VC\Tools\MSVC\14.35.32215\include\delayhlp.cpp`](https://github.com/icestudent/vc-19-changes/blob/master/delayhlp.cpp), except all the hooks are omitted. In the future we could enhance this function to deliver a better experience when dealing with DLLs on Windows.

When `-Dpreview_dll` is specified, if both the host and the target use MSVC, the compiler will now look up all the import libraries passed to the linker, and append a `/DELAYLOAD` linker flag for every imported DLL, reusing the logic from `Crystal::Loader`. No loader is actually created, and the compiler itself never loads any dynamic libraries this way. For example, running `dumpbin /dependents` on an empty source code compiled with `-Dpreview_dll` gives:

```
File Type: EXECUTABLE IMAGE

  Image has the following dependencies:

    KERNEL32.dll

  Image has the following delay load dependencies:

    pcre2-8.dll
    gc.dll
    libiconv.dll
    ADVAPI32.dll
    VCRUNTIME140.dll
    SHELL32.dll
    ole32.dll
    dbghelp.dll
    api-ms-win-crt-runtime-l1-1-0.dll
    api-ms-win-crt-heap-l1-1-0.dll
    api-ms-win-crt-string-l1-1-0.dll
    api-ms-win-crt-stdio-l1-1-0.dll
    api-ms-win-crt-math-l1-1-0.dll
    api-ms-win-crt-filesystem-l1-1-0.dll
    api-ms-win-crt-locale-l1-1-0.dll
```

The commented out `FormatMessageA` stub in `delay_load.cr` gives:

```
Loading `_initterm_e` from `api-ms-win-crt-runtime-l1-1-0.dll`
Loading `_set_app_type` from `api-ms-win-crt-runtime-l1-1-0.dll`
Loading `_set_fmode` from `api-ms-win-crt-stdio-l1-1-0.dll`
Loading `__p__commode` from `api-ms-win-crt-stdio-l1-1-0.dll`
Loading `_crt_atexit` from `api-ms-win-crt-runtime-l1-1-0.dll`
Loading `_configure_wide_argv` from `api-ms-win-crt-runtime-l1-1-0.dll`
Loading `_configthreadlocale` from `api-ms-win-crt-locale-l1-1-0.dll`
Loading `_initialize_wide_environment` from `api-ms-win-crt-runtime-l1-1-0.dll`
Loading `_initterm` from `api-ms-win-crt-runtime-l1-1-0.dll`
Loading `_set_new_mode` from `api-ms-win-crt-heap-l1-1-0.dll`
Loading `_get_initial_wide_environment` from `api-ms-win-crt-runtime-l1-1-0.dll`
Loading `__p___wargv` from `api-ms-win-crt-runtime-l1-1-0.dll`
Loading `__p___argc` from `api-ms-win-crt-runtime-l1-1-0.dll`
Loading `malloc` from `api-ms-win-crt-heap-l1-1-0.dll`
Loading `GC_init` from `gc.dll`
Loading `GC_set_start_callback` from `gc.dll`
Loading `GC_set_warn_proc` from `gc.dll`
Loading `GC_malloc` from `gc.dll`
Loading `memset` from `VCRUNTIME140.dll`
Loading `GC_malloc_atomic` from `gc.dll`
Loading `GC_register_finalizer_ignore_self` from `gc.dll`
Loading `GC_get_push_other_roots` from `gc.dll`
Loading `GC_set_push_other_roots` from `gc.dll`
Loading `SystemFunction036` from `ADVAPI32.dll`
Loading `_get_osfhandle` from `api-ms-win-crt-stdio-l1-1-0.dll`
Loading `_setmode` from `api-ms-win-crt-stdio-l1-1-0.dll`
Loading `GC_realloc` from `gc.dll`
Loading `GC_get_my_stackbottom` from `gc.dll`
Loading `pcre2_config_8` from `pcre2-8.dll`
Loading `memchr` from `VCRUNTIME140.dll`
Loading `memcpy` from `VCRUNTIME140.dll`
Loading `free` from `api-ms-win-crt-heap-l1-1-0.dll`
Loading `exit` from `api-ms-win-crt-runtime-l1-1-0.dll`
```

This behavior can be disabled if `-Dno_win32_delay_load` is also provided; the linker function remains available, so individual DLLs can still be delay-loaded if the respective `/DELAYLOAD` flag is provided explicitly.

A side effect of this change is that a missing DLL is no longer an error as long as the executable doesn't call any function from that DLL, but the most useful benefit is not having to link the entire `user32.dll` upfront whenever OpenSSL is used (they use `MessageBoxW` for certain errors).