### PR TITLE
Remove two outdated LLVM fun bindings

### DIFF
--- a/src/llvm.cr
+++ b/src/llvm.cr
@@ -14,7 +14,6 @@ module LLVM
       LibLLVM.initialize_x86_target_mc
       LibLLVM.initialize_x86_asm_printer
       LibLLVM.initialize_x86_asm_parser
-      # LibLLVM.link_in_jit
       LibLLVM.link_in_mc_jit
     {% else %}
       raise "ERROR: LLVM was built without X86 target"
@@ -31,7 +30,6 @@ module LLVM
       LibLLVM.initialize_aarch64_target_mc
       LibLLVM.initialize_aarch64_asm_printer
       LibLLVM.initialize_aarch64_asm_parser
-      # LibLLVM.link_in_jit
       LibLLVM.link_in_mc_jit
     {% else %}
       raise "ERROR: LLVM was built without AArch64 target"
@@ -48,7 +46,6 @@ module LLVM
       LibLLVM.initialize_arm_target_mc
       LibLLVM.initialize_arm_asm_printer
       LibLLVM.initialize_arm_asm_parser
-      # LibLLVM.link_in_jit
       LibLLVM.link_in_mc_jit
     {% else %}
       raise "ERROR: LLVM was built without ARM target"
@@ -65,7 +62,6 @@ module LLVM
       LibLLVM.initialize_webassembly_target_mc
       LibLLVM.initialize_webassembly_asm_printer
       LibLLVM.initialize_webassembly_asm_parser
-      # LibLLVM.link_in_jit
       LibLLVM.link_in_mc_jit
     {% else %}
       raise "ERROR: LLVM was built without WebAssembly target"

--- a/src/llvm/lib_llvm.cr
+++ b/src/llvm/lib_llvm.cr
@@ -222,7 +222,6 @@ lib LibLLVM
   fun initialize_webassembly_target = LLVMInitializeWebAssemblyTarget
   fun initialize_webassembly_target_info = LLVMInitializeWebAssemblyTargetInfo
   fun initialize_webassembly_target_mc = LLVMInitializeWebAssemblyTargetMC
-  fun initialize_native_target = LLVMInitializeNativeTarget
   fun is_constant = LLVMIsConstant(val : ValueRef) : Int32
   fun is_function_var_arg = LLVMIsFunctionVarArg(ty : TypeRef) : Int32
   fun module_create_with_name_in_context = LLVMModuleCreateWithNameInContext(module_id : UInt8*, context : ContextRef) : ModuleRef
@@ -266,7 +265,6 @@ lib LibLLVM
   fun type_of = LLVMTypeOf(val : ValueRef) : TypeRef
   fun write_bitcode_to_file = LLVMWriteBitcodeToFile(module : ModuleRef, path : UInt8*) : Int32
   fun verify_module = LLVMVerifyModule(module : ModuleRef, action : LLVM::VerifierFailureAction, outmessage : UInt8**) : Int32
-  fun link_in_jit = LLVMLinkInJIT
   fun link_in_mc_jit = LLVMLinkInMCJIT
   fun start_multithreaded = LLVMStartMultithreaded : Int32
   fun stop_multithreaded = LLVMStopMultithreaded


### PR DESCRIPTION
`LLVMLinkInJIT`, which was superseded by `LLVMLinkInMCJIT`, has not been available since LLVM 3.6.

`LLVMInitializeNativeTarget` is a static line function in the original C header. Dynamic libraries do not export it, and there is never a need for that function either considering the way we use `llvm-config --targets-built` to initialize the targets supported.