### PR TITLE
Use `Int#bit_length` instead of `Math.log2` followed by `#to_i`

### DIFF
--- a/src/hash.cr
+++ b/src/hash.cr
@@ -255,7 +255,7 @@ class Hash(K, V)
         @indices_bytesize = 1
       end
 
-      @indices_size_pow2 = Math.log2(initial_indices_size).to_u8
+      @indices_size_pow2 = initial_indices_size.bit_length.to_u8 - 1
     end
 
     @size = 0

--- a/src/slice/sort.cr
+++ b/src/slice/sort.cr
@@ -1,7 +1,7 @@
 struct Slice(T)
   protected def self.intro_sort!(a, n)
     return if n < 2
-    quick_sort_for_intro_sort!(a, n, Math.log2(n).to_i * 2)
+    quick_sort_for_intro_sort!(a, n, (n.bit_length - 1) * 2)
     insertion_sort!(a, n)
   end
 
@@ -99,7 +99,7 @@ struct Slice(T)
 
   protected def self.intro_sort!(a, n, comp)
     return if n < 2
-    quick_sort_for_intro_sort!(a, n, Math.log2(n).to_i * 2, comp)
+    quick_sort_for_intro_sort!(a, n, (n.bit_length - 1) * 2, comp)
     insertion_sort!(a, n, comp)
   end
 


### PR DESCRIPTION
If `x` is a positive integer, then `Math.log2(x).to_i == x.bit_length - 1`. This identity allows us to remove some unnecessary floating-point computations. Here it is guaranteed that `initial_indices_size >= 16` and `n >= 2` respectively.