### PR TITLE
Remove most `LLVM::DIBuilder` functions from `llvm_ext.cc`

### DIFF
--- a/src/compiler/crystal/codegen/crystal_llvm_builder.cr
+++ b/src/compiler/crystal/codegen/crystal_llvm_builder.cr
@@ -61,6 +61,14 @@ module Crystal
       @builder.build_operand_bundle_def(name, values)
     end
 
+    def current_debug_location_metadata
+      {% if LibLLVM::IS_LT_90 %}
+        LibLLVM.value_as_metadata LibLLVM.get_current_debug_location(@builder)
+      {% else %}
+        LibLLVM.get_current_debug_location2(@builder)
+      {% end %}
+    end
+
     def to_unsafe
       @builder.to_unsafe
     end

--- a/src/compiler/crystal/codegen/debug.cr
+++ b/src/compiler/crystal/codegen/debug.cr
@@ -2,12 +2,18 @@ require "./codegen"
 
 module Crystal
   class CodeGenVisitor
-    CRYSTAL_LANG_DEBUG_IDENTIFIER = 0x28_u32
-    #
-    # We have to use it because LLDB has builtin type system support for C++/clang that we can use for now for free.
-    # Later on we can implement LLDB Crystal type system so we can get official Language ID
-    #
-    CPP_LANG_DEBUG_IDENTIFIER = 0x0004_u32
+    # workaround for `LLVM::Builder` not being GC'ed (#13250)
+    private class DIBuilder
+      def initialize(mod : LLVM::Module)
+        @builder = LLVM::DIBuilder.new(mod)
+      end
+
+      def finalize
+        @builder.dispose
+      end
+
+      forward_missing_to @builder
+    end
 
     record FunMetadata, filename : String, metadata : LibLLVM::MetadataRef
 
@@ -20,13 +26,14 @@ module Crystal
     @debug_types_per_module = {} of LLVM::Module => Hash(Type, LibLLVM::MetadataRef?)
 
     def di_builder(llvm_module = @llvm_mod || @main_mod)
-      di_builders = @di_builders ||= {} of LLVM::Module => LLVM::DIBuilder
-      di_builders[llvm_module] ||= LLVM::DIBuilder.new(llvm_module).tap do |di_builder|
+      di_builders = @di_builders ||= {} of LLVM::Module => DIBuilder
+      di_builders[llvm_module] ||= DIBuilder.new(llvm_module).tap do |di_builder|
         file, dir = file_and_dir(llvm_module.name == "" ? "main" : llvm_module.name)
         # @debug.variables? is set to true if parameter --debug is set in command line.
         # This flag affects only debug variables generation. It sets Optimized parameter to false.
         is_optimised = !@debug.variables?
-        di_builder.create_compile_unit(CPP_LANG_DEBUG_IDENTIFIER, file, dir, "Crystal", is_optimised, "", 0_u32)
+        # TODO: switch to Crystal's language code for LLVM 16+ (#13174)
+        di_builder.create_compile_unit(LLVM::DwarfSourceLanguage::C_plus_plus, file, dir, "Crystal", is_optimised, "", 0_u32)
       end
     end
 
@@ -66,8 +73,7 @@ module Crystal
         int = di_builder.create_basic_type("int", 32, 32, LLVM::DwarfTypeEncoding::Signed)
         debug_types << int
       end
-      debug_types_array = di_builder.get_or_create_type_array(debug_types)
-      di_builder.create_subroutine_type(nil, debug_types_array)
+      di_builder.create_subroutine_type(nil, debug_types)
     end
 
     def debug_type_cache
@@ -141,7 +147,6 @@ module Crystal
                 end
         di_builder.create_enumerator(name, value)
       end
-      elements = di_builder.get_or_create_array(elements)
       di_builder.create_enumeration_type(nil, original_type.to_s, nil, 1, 32, 32, elements, get_debug_type(type.base_type))
     end
 
@@ -165,11 +170,10 @@ module Crystal
       end
 
       size = @program.target_machine.data_layout.size_in_bits(struct_type)
-      elements = di_builder.get_or_create_type_array(element_types)
       if type.extern_union?
-        debug_type = di_builder.create_union_type(nil, original_type.to_s, current_debug_file, 1, size, size, LLVM::DIFlags::Zero, elements)
+        debug_type = di_builder.create_union_type(nil, original_type.to_s, current_debug_file, 1, size, size, LLVM::DIFlags::Zero, element_types)
       else
-        debug_type = di_builder.create_struct_type(nil, original_type.to_s, nil, 1, size, size, LLVM::DIFlags::Zero, nil, elements)
+        debug_type = di_builder.create_struct_type(nil, original_type.to_s, nil, 1, size, size, LLVM::DIFlags::Zero, nil, element_types)
         unless type.struct?
           debug_type = di_builder.create_pointer_type(debug_type, 8u64 * llvm_typer.pointer_size, 8u64 * llvm_typer.pointer_size, original_type.to_s)
         end
@@ -206,12 +210,12 @@ module Crystal
 
       size = @program.target_machine.data_layout.size_in_bits(struct_type.struct_element_types[is_struct ? 0 : 1])
       offset = @program.target_machine.data_layout.offset_of_element(struct_type, 1) * 8u64
-      debug_type = di_builder.create_union_type(nil, nil, current_debug_file, 1, size, size, LLVM::DIFlags::Zero, di_builder.get_or_create_type_array(element_types))
+      debug_type = di_builder.create_union_type(nil, "", current_debug_file, 1, size, size, LLVM::DIFlags::Zero, element_types)
       unless is_struct
         element_types.clear
         element_types << di_builder.create_member_type(nil, "type_id", nil, 1, 32, 32, 0, LLVM::DIFlags::Zero, get_debug_type(@program.uint32))
         element_types << di_builder.create_member_type(nil, "union", nil, 1, size, size, offset, LLVM::DIFlags::Zero, debug_type)
-        debug_type = di_builder.create_struct_type(nil, original_type.to_s, nil, 1, struct_type_size, struct_type_size, LLVM::DIFlags::Zero, nil, di_builder.get_or_create_type_array(element_types))
+        debug_type = di_builder.create_struct_type(nil, original_type.to_s, nil, 1, struct_type_size, struct_type_size, LLVM::DIFlags::Zero, nil, element_types)
       end
       di_builder.replace_temporary(tmp_debug_type, debug_type)
       debug_type
@@ -234,7 +238,7 @@ module Crystal
       end
 
       size = @program.target_machine.data_layout.size_in_bits(struct_type)
-      debug_type = di_builder.create_union_type(nil, original_type.to_s, current_debug_file, 1, size, size, LLVM::DIFlags::Zero, di_builder.get_or_create_type_array(element_types))
+      debug_type = di_builder.create_union_type(nil, original_type.to_s, current_debug_file, 1, size, size, LLVM::DIFlags::Zero, element_types)
       di_builder.replace_temporary(tmp_debug_type, debug_type)
       debug_type
     end
@@ -274,7 +278,7 @@ module Crystal
       end
 
       size = @program.target_machine.data_layout.size_in_bits(struct_type)
-      debug_type = di_builder.create_struct_type(nil, original_type.to_s, nil, 1, size, size, LLVM::DIFlags::Zero, nil, di_builder.get_or_create_type_array(element_types))
+      debug_type = di_builder.create_struct_type(nil, original_type.to_s, nil, 1, size, size, LLVM::DIFlags::Zero, nil, element_types)
       unless type.struct?
         debug_type = di_builder.create_pointer_type(debug_type, 8u64 * llvm_typer.pointer_size, 8u64 * llvm_typer.pointer_size, original_type.to_s)
       end
@@ -302,7 +306,7 @@ module Crystal
       end
 
       size = @program.target_machine.data_layout.size_in_bits(struct_type)
-      debug_type = di_builder.create_struct_type(nil, original_type.to_s, nil, 1, size, size, LLVM::DIFlags::Zero, nil, di_builder.get_or_create_type_array(element_types))
+      debug_type = di_builder.create_struct_type(nil, original_type.to_s, nil, 1, size, size, LLVM::DIFlags::Zero, nil, element_types)
       unless type.struct?
         debug_type = di_builder.create_pointer_type(debug_type, 8u64 * llvm_typer.pointer_size, 8u64 * llvm_typer.pointer_size, original_type.to_s)
       end
@@ -370,7 +374,7 @@ module Crystal
       old_debug_location = @current_debug_location
       set_current_debug_location location
       if builder.current_debug_location != llvm_nil && (ptr = alloca)
-        di_builder.insert_declare_at_end(ptr, var, expr, builder.current_debug_location, block)
+        di_builder.insert_declare_at_end(ptr, var, expr, builder.current_debug_location_metadata, block)
         set_current_debug_location old_debug_location
         true
       else

--- a/src/llvm/di_builder.cr
+++ b/src/llvm/di_builder.cr
@@ -1,122 +1,200 @@
 require "./lib_llvm"
 
 struct LLVM::DIBuilder
-  def initialize(@llvm_module : Module)
-    @unwrap = LibLLVMExt.create_di_builder(llvm_module)
+  private DW_TAG_structure_type = 19
+
+  private def initialize(@unwrap : LibLLVM::DIBuilderRef, @llvm_module : Module)
   end
 
-  def create_compile_unit(lang, file, dir, producer, optimized, flags, runtime_version)
-    LibLLVMExt.di_builder_create_compile_unit(self, lang, file, dir, producer, optimized ? 1 : 0, flags, runtime_version)
+  def self.new(mod : LLVM::Module)
+    new(LibLLVM.create_di_builder(mod), mod)
+  end
+
+  def dispose
+    LibLLVM.dispose_di_builder(self)
+  end
+
+  def create_compile_unit(lang : DwarfSourceLanguage, file, dir, producer, optimized, flags, runtime_version)
+    file = create_file(file, dir)
+    {% if LibLLVM::IS_LT_110 %}
+      LibLLVM.di_builder_create_compile_unit(self,
+        lang, file, producer, producer.bytesize, optimized ? 1 : 0, flags, flags.bytesize, runtime_version,
+        split_name: nil, split_name_len: 0, kind: LibLLVM::DWARFEmissionKind::Full, dwo_id: 0,
+        split_debug_inlining: 1, debug_info_for_profiling: 0,
+      )
+    {% else %}
+      LibLLVM.di_builder_create_compile_unit(self,
+        lang, file, producer, producer.bytesize, optimized ? 1 : 0, flags, flags.bytesize, runtime_version,
+        split_name: nil, split_name_len: 0, kind: LibLLVM::DWARFEmissionKind::Full, dwo_id: 0,
+        split_debug_inlining: 1, debug_info_for_profiling: 0, sys_root: nil, sys_root_len: 0, sdk: nil, sdk_len: 0,
+      )
+    {% end %}
+  end
+
+  @[Deprecated("Pass an `LLVM::DwarfSourceLanguage` for `lang` instead")]
+  def create_compile_unit(lang cpp_lang_code, file, dir, producer, optimized, flags, runtime_version)
+    # map the c++ values from `llvm::dwarf::SourceLanguage` to the c values from `LLVMDWARFSourceLanguage`
+    c_lang_code =
+      case cpp_lang_code
+      when 0x8001; DwarfSourceLanguage::Mips_Assembler
+      when 0x8e57; DwarfSourceLanguage::GOOGLE_RenderScript
+      when 0xb000; DwarfSourceLanguage::BORLAND_Delphi
+      else         DwarfSourceLanguage.new(lang - 1)
+      end
+
+    create_compile_unit(c_lang_code, file, dir, producer, optimized, flags, runtime_version)
   end
 
   def create_basic_type(name, size_in_bits, align_in_bits, encoding)
-    LibLLVMExt.di_builder_create_basic_type(self, name, size_in_bits, align_in_bits, encoding.value)
+    LibLLVM.di_builder_create_basic_type(self, name, name.bytesize, size_in_bits, encoding.value, DIFlags::Zero)
   end
 
   def get_or_create_type_array(types : Array(LibLLVM::MetadataRef))
-    LibLLVMExt.di_builder_get_or_create_type_array(self, types, types.size)
+    LibLLVM.di_builder_get_or_create_type_array(self, types, types.size)
   end
 
   def create_subroutine_type(file, parameter_types)
-    LibLLVMExt.di_builder_create_subroutine_type(self, file, parameter_types)
+    LibLLVM.di_builder_create_subroutine_type(self, file, parameter_types, parameter_types.size, DIFlags::Zero)
   end
 
   def create_file(file, dir)
-    LibLLVMExt.di_builder_create_file(self, file, dir)
+    LibLLVM.di_builder_create_file(self, file, file.bytesize, dir, dir.bytesize)
   end
 
   def create_lexical_block(scope, file_scope, line, column)
-    LibLLVMExt.di_builder_create_lexical_block(self, scope, file_scope, line, column)
+    LibLLVM.di_builder_create_lexical_block(self, scope, file_scope, line, column)
   end
 
   def create_lexical_block_file(scope, file_scope, discriminator = 0)
-    LibLLVMExt.di_builder_create_lexical_block_file(self, scope, file_scope, discriminator)
+    LibLLVM.di_builder_create_lexical_block_file(self, scope, file_scope, discriminator)
   end
 
   def create_function(scope, name, linkage_name, file, line, composite_type, is_local_to_unit, is_definition,
                       scope_line, flags, is_optimized, func)
-    LibLLVMExt.di_builder_create_function(self, scope, name, linkage_name, file, line, composite_type,
-      is_local_to_unit, is_definition, scope_line, flags, is_optimized, func)
+    sub = LibLLVM.di_builder_create_function(self, scope, name, name.bytesize,
+      linkage_name, linkage_name.bytesize, file, line, composite_type, is_local_to_unit ? 1 : 0,
+      is_definition ? 1 : 0, scope_line, flags, is_optimized ? 1 : 0)
+    LibLLVM.set_subprogram(func, sub)
+    sub
   end
 
   def create_auto_variable(scope, name, file, line, type, align_in_bits, flags = DIFlags::Zero)
-    LibLLVMExt.di_builder_create_auto_variable(self, scope, name, file, line, type, 1, flags, align_in_bits)
+    LibLLVM.di_builder_create_auto_variable(self, scope, name, name.bytesize, file, line, type, 1, flags, align_in_bits)
   end
 
   def create_parameter_variable(scope, name, argno, file, line, type, flags = DIFlags::Zero)
-    LibLLVMExt.di_builder_create_parameter_variable(self, scope, name, argno, file, line, type, 1, flags)
+    LibLLVM.di_builder_create_parameter_variable(self, scope, name, name.bytesize, argno, file, line, type, 1, flags)
   end
 
   def create_expression(addr, length)
-    LibLLVMExt.di_builder_create_expression(self, addr, length)
+    LibLLVM.di_builder_create_expression(self, addr, length)
   end
 
-  def insert_declare_at_end(storage, var_info, expr, dl, block)
-    LibLLVMExt.di_builder_insert_declare_at_end(self, storage, var_info, expr, dl, block)
+  def insert_declare_at_end(storage, var_info, expr, dl : LibLLVM::MetadataRef, block)
+    LibLLVM.di_builder_insert_declare_at_end(self, storage, var_info, expr, dl, block)
   end
 
   def get_or_create_array(elements : Array(LibLLVM::MetadataRef))
-    LibLLVMExt.di_builder_get_or_create_array(self, elements, elements.size)
+    LibLLVM.di_builder_get_or_create_array(self, elements, elements.size)
   end
 
   def create_enumerator(name, value)
-    LibLLVMExt.di_builder_create_enumerator(self, name, value)
+    {% if LibLLVM::IS_LT_90 %}
+      LibLLVMExt.di_builder_create_enumerator(self, name, value)
+    {% else %}
+      LibLLVM.di_builder_create_enumerator(self, name, name.bytesize, value, 0)
+    {% end %}
   end
 
   def create_enumeration_type(scope, name, file, line_number, size_in_bits, align_in_bits, elements, underlying_type)
-    LibLLVMExt.di_builder_create_enumeration_type(self, scope, name, file, line_number, size_in_bits,
-      align_in_bits, elements, underlying_type)
+    LibLLVM.di_builder_create_enumeration_type(self, scope, name, name.bytesize, file, line_number,
+      size_in_bits, align_in_bits, elements, elements.size, underlying_type)
   end
 
   def create_struct_type(scope, name, file, line, size_in_bits, align_in_bits, flags, derived_from, element_types)
-    LibLLVMExt.di_builder_create_struct_type(self, scope, name, file, line, size_in_bits, align_in_bits,
-      flags, derived_from, element_types)
+    LibLLVM.di_builder_create_struct_type(self, scope, name, name.bytesize, file, line,
+      size_in_bits, align_in_bits, flags, derived_from, element_types, element_types.size, 0, nil, nil, 0)
   end
 
   def create_union_type(scope, name, file, line, size_in_bits, align_in_bits, flags, element_types)
-    LibLLVMExt.di_builder_create_union_type(self, scope, name, file, line, size_in_bits, align_in_bits,
-      flags, element_types)
+    LibLLVM.di_builder_create_union_type(self, scope, name, name.bytesize, file, line,
+      size_in_bits, align_in_bits, flags, element_types, element_types.size, 0, nil, 0)
   end
 
   def create_array_type(size_in_bits, align_in_bits, type, subs)
-    elements = self.get_or_create_array(subs)
-    LibLLVMExt.di_builder_create_array_type(self, size_in_bits, align_in_bits, type, elements)
+    LibLLVM.di_builder_create_array_type(self, size_in_bits, align_in_bits, type, subs, subs.size)
   end
 
   def create_member_type(scope, name, file, line, size_in_bits, align_in_bits, offset_in_bits, flags, ty)
-    LibLLVMExt.di_builder_create_member_type(self, scope, name, file, line, size_in_bits, align_in_bits,
+    LibLLVM.di_builder_create_member_type(self, scope, name, name.bytesize, file, line, size_in_bits, align_in_bits,
       offset_in_bits, flags, ty)
   end
 
   def create_pointer_type(pointee, size_in_bits, align_in_bits, name)
-    LibLLVMExt.di_builder_create_pointer_type(self, pointee, size_in_bits, align_in_bits, name)
+    LibLLVM.di_builder_create_pointer_type(self, pointee, size_in_bits, align_in_bits, 0, name, name.bytesize)
   end
 
   def create_replaceable_composite_type(scope, name, file, line)
-    LibLLVMExt.di_builder_create_replaceable_composite_type(self, scope, name, file, line)
+    LibLLVM.di_builder_create_replaceable_composite_type(self, DW_TAG_structure_type, name, name.bytesize,
+      scope, file, line, 0, 0, 0, DIFlags::FwdDecl, nil, 0)
   end
 
   def replace_temporary(from, to)
-    LibLLVMExt.di_builder_replace_temporary(self, from, to)
+    LibLLVM.metadata_replace_all_uses_with(from, to)
   end
 
   def create_unspecified_type(name : String)
-    LibLLVMExt.di_builder_create_unspecified_type(self, name, name.size)
+    LibLLVM.di_builder_create_unspecified_type(self, name, name.bytesize)
   end
 
   def get_or_create_array_subrange(lo, count)
-    LibLLVMExt.di_builder_get_or_create_array_subrange(self, lo, count)
-  end
-
-  def create_reference_type(debug_type)
-    LibLLVM.di_builder_create_reference_type(self, 16, debug_type) # 16 is the code for DW_TAG_reference_type
+    LibLLVM.di_builder_get_or_create_subrange(self, lo, count)
   end
 
   def end
-    LibLLVMExt.di_builder_finalize(self)
+    LibLLVM.di_builder_finalize(self)
   end
 
   def to_unsafe
     @unwrap
+  end
+
+  @[Deprecated("Use a `LibLLVM::MetadataRef` for `dl` instead")]
+  def insert_declare_at_end(storage, var_info, expr, dl : LibLLVM::ValueRef | LLVM::Value, block)
+    dl = dl.to_unsafe unless dl.is_a?(LibLLVM::ValueRef)
+    insert_declare_at_end(storage, var_info, expr, LibLLVM.value_as_metadata(dl), block)
+  end
+
+  @[Deprecated("Pass an array for `parameter_types` directly")]
+  def create_subroutine_type(file, parameter_types : LibLLVM::MetadataRef)
+    create_subroutine_type(file, extract_metadata_array(parameter_types))
+  end
+
+  @[Deprecated("Pass an array for `elements` directly")]
+  def create_enumeration_type(scope, name, file, line_number, size_in_bits, align_in_bits, elements : LibLLVM::MetadataRef, underlying_type)
+    create_enumeration_type(scope, name, file, line_number, size_in_bits, align_in_bits, extract_metadata_array(elements), underlying_type)
+  end
+
+  @[Deprecated("Pass an array for `element_types` directly")]
+  def create_struct_type(scope, name, file, line, size_in_bits, align_in_bits, flags, derived_from, element_types : LibLLVM::MetadataRef)
+    create_struct_type(scope, name, file, line, size_in_bits, align_in_bits, flags, derived_from, extract_metadata_array(element_types))
+  end
+
+  @[Deprecated("Pass an array for `element_types` directly")]
+  def create_union_type(scope, name, file, line, size_in_bits, align_in_bits, flags, element_types : LibLLVM::MetadataRef)
+    create_union_type(scope, name, file, line, size_in_bits, align_in_bits, flags, extract_metadata_array(element_types))
+  end
+
+  @[Deprecated("Pass an array for `subs` directly")]
+  def create_array_type(size_in_bits, align_in_bits, type, subs : LibLLVM::MetadataRef)
+    create_array_type(size_in_bits, align_in_bits, type, extract_metadata_array(subs))
+  end
+
+  private def extract_metadata_array(metadata : LibLLVM::MetadataRef)
+    metadata_as_value = LibLLVM.metadata_as_value(@llvm_module.context, metadata)
+    operand_count = LibLLVM.get_md_node_num_operands(metadata_as_value).to_i
+    operands = Pointer(LibLLVM::ValueRef).malloc(operand_count)
+    LibLLVM.get_md_node_operands(metadata_as_value, operands)
+    Slice.new(operand_count) { |i| LibLLVM.value_as_metadata(operands[i]) }
   end
 end

--- a/src/llvm/enums.cr
+++ b/src/llvm/enums.cr
@@ -322,14 +322,87 @@ module LLVM
     HiUser         = 0xff
   end
 
+  enum DwarfSourceLanguage
+    C89
+    C
+    Ada83
+    C_plus_plus
+    Cobol74
+    Cobol85
+    Fortran77
+    Fortran90
+    Pascal83
+    Modula2
+
+    # New in DWARF v3:
+
+    Java
+    C99
+    Ada95
+    Fortran95
+    PLI
+    ObjC
+    ObjC_plus_plus
+    UPC
+    D
+
+    # New in DWARF v4:
+
+    Python
+
+    # New in DWARF v5:
+
+    OpenCL
+    Go
+    Modula3
+    Haskell
+    C_plus_plus_03
+    C_plus_plus_11
+    OCaml
+    Rust
+    C11
+    Swift
+    Julia
+    Dylan
+    C_plus_plus_14
+    Fortran03
+    Fortran08
+    RenderScript
+    BLISS
+
+    {% unless LibLLVM::IS_LT_160 %}
+      Kotlin
+      Zig
+      Crystal
+      C_plus_plus_17
+      C_plus_plus_20
+      C17
+      Fortran18
+      Ada2005
+      Ada2012
+    {% end %}
+
+    # Vendor extensions:
+
+    Mips_Assembler
+    GOOGLE_RenderScript
+    BORLAND_Delphi
+  end
+
   enum DIFlags : UInt32
-    Zero                = 0
-    Private             = 1
-    Protected           = 2
-    Public              = 3
-    FwdDecl             = 1 << 2
-    AppleBlock          = 1 << 3
-    BlockByrefStruct    = 1 << 4
+    Zero       = 0
+    Private    = 1
+    Protected  = 2
+    Public     = 3
+    FwdDecl    = 1 << 2
+    AppleBlock = 1 << 3
+
+    {% if LibLLVM::IS_LT_100 %}
+      BlockByrefStruct = 1 << 4
+    {% else %}
+      ReservedBit4 = 1 << 4
+    {% end %}
+
     Virtual             = 1 << 5
     Artificial          = 1 << 6
     Explicit            = 1 << 7
@@ -347,14 +420,24 @@ module LLVM
     IntroducedVirtual   = 1 << 18
     BitField            = 1 << 19
     NoReturn            = 1 << 20
-    MainSubprogram      = 1 << 21
+
+    {% if LibLLVM::IS_LT_90 %}
+      MainSubprogram = 1 << 21
+    {% end %}
+
     PassByValue         = 1 << 22
     TypePassByReference = 1 << 23
     EnumClass           = 1 << 24
     Thunk               = 1 << 25
-    NonTrivial          = 1 << 26
-    BigEndian           = 1 << 27
-    LittleEndian        = 1 << 28
+
+    {% if LibLLVM::IS_LT_90 %}
+      Trivial = 1 << 26
+    {% else %}
+      NonTrivial = 1 << 26
+    {% end %}
+
+    BigEndian    = 1 << 27
+    LittleEndian = 1 << 28
   end
 
   struct Value

--- a/src/llvm/ext/llvm_ext.cc
+++ b/src/llvm/ext/llvm_ext.cc
@@ -1,10 +1,6 @@
 #include <llvm/IR/DIBuilder.h>
 #include <llvm/IR/IRBuilder.h>
-#include <llvm/IR/Module.h>
-#include <llvm/Support/CBindingWrapping.h>
 #include <llvm/IR/DebugLoc.h>
-#include <llvm/IR/LLVMContext.h>
-#include <llvm/IR/Metadata.h>
 #include <llvm/Support/raw_ostream.h>
 #include <llvm/Support/FileSystem.h>
 #include <llvm/ExecutionEngine/ExecutionEngine.h>
@@ -25,217 +21,20 @@ using namespace llvm;
 #include <llvm/Bitcode/BitcodeWriter.h>
 #include <llvm/Analysis/ModuleSummaryAnalysis.h>
 
-typedef DIBuilder *DIBuilderRef;
-#define DIArray DINodeArray
 template <typename T> T *unwrapDIptr(LLVMMetadataRef v) {
   return (T *)(v ? unwrap<MDNode>(v) : NULL);
 }
 
-#define DIDescriptor DIScope
-#define unwrapDI unwrapDIptr
-
 extern "C" {
 
-LLVMDIBuilderRef LLVMExtNewDIBuilder(LLVMModuleRef mref) {
-  Module *m = unwrap(mref);
-  return wrap(new DIBuilder(*m));
-}
-
-LLVMMetadataRef LLVMExtDIBuilderCreateFile(
-    DIBuilderRef Dref, const char *File, const char *Dir) {
-  return wrap(Dref->createFile(File, Dir));
-}
-
-LLVMMetadataRef LLVMExtDIBuilderCreateCompileUnit(
-    DIBuilderRef Dref, unsigned Lang, const char *File, const char *Dir,
-    const char *Producer, int Optimized, const char *Flags,
-    unsigned RuntimeVersion) {
-  DIFile *F = Dref->createFile(File, Dir);
-  return wrap(Dref->createCompileUnit(Lang, F, Producer, Optimized,
-                                      Flags, RuntimeVersion));
-}
-
-LLVMMetadataRef LLVMExtDIBuilderCreateFunction(
-    DIBuilderRef Dref, LLVMMetadataRef Scope, const char *Name,
-    const char *LinkageName, LLVMMetadataRef File, unsigned Line,
-    LLVMMetadataRef CompositeType, bool IsLocalToUnit, bool IsDefinition,
-    unsigned ScopeLine,
-    DINode::DIFlags Flags,
-    bool IsOptimized,
-    LLVMValueRef Func) {
-  DISubprogram *Sub = Dref->createFunction(
-      unwrapDI<DIScope>(Scope), StringRef(Name), StringRef(LinkageName), unwrapDI<DIFile>(File), Line,
-      unwrapDI<DISubroutineType>(CompositeType),
-      ScopeLine, Flags, DISubprogram::toSPFlags(IsLocalToUnit, IsDefinition, IsOptimized));
-  unwrap<Function>(Func)->setSubprogram(Sub);
-  return wrap(Sub);
-}
-
-LLVMMetadataRef LLVMExtDIBuilderCreateLexicalBlock(
-    DIBuilderRef Dref, LLVMMetadataRef Scope, LLVMMetadataRef File,
-    unsigned Line, unsigned Column) {
-  return wrap(Dref->createLexicalBlock(unwrapDI<DIDescriptor>(Scope),
-                                       unwrapDI<DIFile>(File), Line, Column));
-}
-
-LLVMMetadataRef LLVMExtDIBuilderCreateBasicType(
-    DIBuilderRef Dref, const char *Name, uint64_t SizeInBits,
-    uint64_t AlignInBits, unsigned Encoding) {
-  return wrap(Dref->createBasicType(Name, SizeInBits, Encoding));
-}
-
-LLVMMetadataRef LLVMExtDIBuilderGetOrCreateTypeArray(
-    DIBuilderRef Dref, LLVMMetadataRef *Data, unsigned Length) {
-  Metadata **DataValue = unwrap(Data);
-  return wrap(
-      Dref->getOrCreateTypeArray(ArrayRef<Metadata *>(DataValue, Length))
-          .get());
-}
-
-LLVMMetadataRef LLVMExtDIBuilderGetOrCreateArray(
-    DIBuilderRef Dref, LLVMMetadataRef *Data, unsigned Length) {
-  Metadata **DataValue = unwrap(Data);
-  return wrap(
-      Dref->getOrCreateArray(ArrayRef<Metadata *>(DataValue, Length)).get());
-}
-
-LLVMMetadataRef LLVMExtDIBuilderCreateSubroutineType(
-    DIBuilderRef Dref, LLVMMetadataRef File, LLVMMetadataRef ParameterTypes) {
-  DISubroutineType *CT = Dref->createSubroutineType(DITypeRefArray(unwrap<MDTuple>(ParameterTypes)));
-  return wrap(CT);
-}
-
-LLVMMetadataRef LLVMExtDIBuilderCreateAutoVariable(
-    DIBuilderRef Dref, LLVMMetadataRef Scope, const char *Name,
-    LLVMMetadataRef File, unsigned Line, LLVMMetadataRef Ty,
-    int AlwaysPreserve,
-    DINode::DIFlags Flags,
-    uint32_t AlignInBits) {
-  DILocalVariable *V = Dref->createAutoVariable(
-      unwrapDI<DIDescriptor>(Scope), Name, unwrapDI<DIFile>(File), Line,
-      unwrapDI<DIType>(Ty), AlwaysPreserve, Flags, AlignInBits);
-  return wrap(V);
-}
-
-LLVMMetadataRef LLVMExtDIBuilderCreateParameterVariable(
-    DIBuilderRef Dref, LLVMMetadataRef Scope, const char *Name,
-    unsigned ArgNo, LLVMMetadataRef File, unsigned Line,
-    LLVMMetadataRef Ty, int AlwaysPreserve,
-    DINode::DIFlags Flags
-    ) {
-  DILocalVariable *V = Dref->createParameterVariable
-    (unwrapDI<DIDescriptor>(Scope), Name, ArgNo, unwrapDI<DIFile>(File), Line,
-     unwrapDI<DIType>(Ty), AlwaysPreserve, Flags);
-  return wrap(V);
-}
-
-LLVMValueRef LLVMExtDIBuilderInsertDeclareAtEnd(
-    DIBuilderRef Dref, LLVMValueRef Storage, LLVMMetadataRef VarInfo,
-    LLVMMetadataRef Expr, LLVMValueRef DL, LLVMBasicBlockRef Block) {
-  Instruction *Instr =
-    Dref->insertDeclare(unwrap(Storage), unwrap<DILocalVariable>(VarInfo),
-                        unwrapDI<DIExpression>(Expr),
-                        DebugLoc(cast<MDNode>(unwrap<MetadataAsValue>(DL)->getMetadata())),
-                        unwrap(Block));
-  return wrap(Instr);
-}
-
-LLVMMetadataRef LLVMExtDIBuilderCreateExpression(
-    DIBuilderRef Dref, uint64_t *Addr, size_t Length) {
-  return wrap(Dref->createExpression(ArrayRef<uint64_t>(Addr, Length)));
-}
-
-LLVMMetadataRef LLVMExtDIBuilderCreateEnumerationType(
-    DIBuilderRef Dref, LLVMMetadataRef Scope, const char *Name,
-    LLVMMetadataRef File, unsigned LineNumber, uint64_t SizeInBits,
-    uint64_t AlignInBits, LLVMMetadataRef Elements,
-    LLVMMetadataRef UnderlyingType) {
-  DICompositeType *enumType = Dref->createEnumerationType(
-      unwrapDI<DIDescriptor>(Scope), Name, unwrapDI<DIFile>(File), LineNumber,
-      SizeInBits, AlignInBits, DINodeArray(unwrapDI<MDTuple>(Elements)),
-      unwrapDI<DIType>(UnderlyingType));
-  return wrap(enumType);
-}
-
+#if LLVM_VERSION_GE(9, 0)
+#else
 LLVMMetadataRef LLVMExtDIBuilderCreateEnumerator(
-    DIBuilderRef Dref, const char *Name, int64_t Value) {
-  DIEnumerator *e = Dref->createEnumerator(Name, Value);
+    LLVMDIBuilderRef Dref, const char *Name, int64_t Value) {
+  DIEnumerator *e = unwrap(Dref)->createEnumerator(Name, Value);
   return wrap(e);
 }
-
-LLVMMetadataRef LLVMExtDIBuilderCreateStructType(
-    DIBuilderRef Dref, LLVMMetadataRef Scope, const char *Name,
-    LLVMMetadataRef File, unsigned Line, uint64_t SizeInBits,
-    uint64_t AlignInBits,
-    DINode::DIFlags Flags,
-    LLVMMetadataRef DerivedFrom, LLVMMetadataRef Elements) {
-  DICompositeType *CT = Dref->createStructType(
-      unwrapDI<DIDescriptor>(Scope), Name, unwrapDI<DIFile>(File), Line,
-      SizeInBits, AlignInBits, Flags, unwrapDI<DIType>(DerivedFrom),
-      DINodeArray(unwrapDI<MDTuple>(Elements)));
-  return wrap(CT);
-}
-
-LLVMMetadataRef LLVMExtDIBuilderCreateUnionType(
-    DIBuilderRef Dref, LLVMMetadataRef Scope, const char *Name,
-    LLVMMetadataRef File, unsigned Line, uint64_t SizeInBits,
-    uint64_t AlignInBits,
-    DINode::DIFlags Flags,
-    LLVMMetadataRef Elements) {
-  DICompositeType *CT = Dref->createUnionType(
-      unwrapDI<DIDescriptor>(Scope), Name, unwrapDI<DIFile>(File), Line,
-      SizeInBits, AlignInBits, Flags,
-      DINodeArray(unwrapDI<MDTuple>(Elements)));
-  return wrap(CT);
-}
-
-LLVMMetadataRef LLVMExtDIBuilderCreateArrayType(
-    DIBuilderRef Dref, uint64_t Size, uint64_t AlignInBits,
-    LLVMMetadataRef Type, LLVMMetadataRef Subs) {
-      return wrap(Dref->createArrayType(Size, AlignInBits, unwrapDI<DIType>(Type), DINodeArray(unwrapDI<MDTuple>(Subs))));
-}
-
-
-LLVMMetadataRef LLVMExtDIBuilderCreateReplaceableCompositeType(
-  DIBuilderRef Dref, LLVMMetadataRef Scope, const char *Name,
-  LLVMMetadataRef File, unsigned Line) {
-  DICompositeType *CT = Dref->createReplaceableCompositeType(llvm::dwarf::DW_TAG_structure_type,
-                                                             Name,
-                                                             unwrapDI<DIScope>(Scope),
-                                                             unwrapDI<DIFile>(File),
-                                                             Line);
-  return wrap(CT);
-}
-
-void LLVMExtDIBuilderReplaceTemporary(
-  DIBuilderRef Dref, LLVMMetadataRef From, LLVMMetadataRef To) {
-  auto *Node = unwrap<MDNode>(From);
-  auto *Type = unwrap<DIType>(To);
-
-  llvm::TempMDNode fwd_decl(Node);
-  Dref->replaceTemporary(std::move(fwd_decl), Type);
-}
-
-LLVMMetadataRef LLVMExtDIBuilderCreateMemberType(
-    DIBuilderRef Dref, LLVMMetadataRef Scope, const char *Name, LLVMMetadataRef File,
-    unsigned Line, uint64_t SizeInBits, uint64_t AlignInBits, uint64_t OffsetInBits,
-    DINode::DIFlags Flags,
-    LLVMMetadataRef Ty) {
-  DIDerivedType *DT = Dref->createMemberType(
-      unwrapDI<DIDescriptor>(Scope), Name, unwrapDI<DIFile>(File), Line,
-      SizeInBits, AlignInBits, OffsetInBits, Flags, unwrapDI<DIType>(Ty));
-  return wrap(DT);
-}
-
-LLVMMetadataRef LLVMExtDIBuilderCreatePointerType(
-    DIBuilderRef Dref, LLVMMetadataRef PointeeType,
-    uint64_t SizeInBits, uint64_t AlignInBits, const char *Name) {
-  DIDerivedType *T = Dref->createPointerType(unwrapDI<DIType>(PointeeType),
-                                             SizeInBits, AlignInBits,
-                                             None,
-                                             Name);
-  return wrap(T);
-}
+#endif
 
 void LLVMExtSetCurrentDebugLocation(
   LLVMBuilderRef Bref, unsigned Line, unsigned Col, LLVMMetadataRef Scope,
@@ -246,8 +45,8 @@ void LLVMExtSetCurrentDebugLocation(
   else
     unwrap(Bref)->SetCurrentDebugLocation(
       DILocation::get(unwrap<MDNode>(Scope)->getContext(), Line, Col,
-                      unwrapDI<DILocalScope>(Scope),
-                      unwrapDI<DILocation>(InlinedAt)));
+                      unwrapDIptr<DILocalScope>(Scope),
+                      unwrapDIptr<DILocation>(InlinedAt)));
 #else
   unwrap(Bref)->SetCurrentDebugLocation(
       DebugLoc::get(Line, Col, Scope ? unwrap<MDNode>(Scope) : nullptr,
@@ -375,9 +174,4 @@ LLVMBool LLVMExtCreateMCJITCompilerForModule(
   return 1;
 }
 
-LLVMMetadataRef LLVMExtDIBuilderGetOrCreateArraySubrange(
-  DIBuilderRef Dref, uint64_t Lo,
-  uint64_t Count) {
-    return wrap(Dref->getOrCreateSubrange(Lo, Count));
-  }
-}
+} // extern "C"

--- a/src/llvm/lib_llvm_ext.cr
+++ b/src/llvm/lib_llvm_ext.cr
@@ -8,112 +8,12 @@ lib LibLLVMExt
   alias Char = LibC::Char
   alias Int = LibC::Int
   alias UInt = LibC::UInt
-  alias SizeT = LibC::SizeT
 
-  type DIBuilder = Void*
   type OperandBundleDefRef = Void*
 
-  fun create_di_builder = LLVMExtNewDIBuilder(LibLLVM::ModuleRef) : DIBuilder
-  fun di_builder_finalize = LLVMDIBuilderFinalize(DIBuilder)
-
-  fun di_builder_create_function = LLVMExtDIBuilderCreateFunction(
-    builder : DIBuilder, scope : LibLLVM::MetadataRef, name : Char*,
-    linkage_name : Char*, file : LibLLVM::MetadataRef, line : UInt,
-    composite_type : LibLLVM::MetadataRef, is_local_to_unit : Bool, is_definition : Bool,
-    scope_line : UInt, flags : LLVM::DIFlags, is_optimized : Bool, func : LibLLVM::ValueRef
-  ) : LibLLVM::MetadataRef
-
-  fun di_builder_create_file = LLVMExtDIBuilderCreateFile(builder : DIBuilder, file : Char*, dir : Char*) : LibLLVM::MetadataRef
-  fun di_builder_create_compile_unit = LLVMExtDIBuilderCreateCompileUnit(builder : DIBuilder,
-                                                                         lang : UInt, file : Char*,
-                                                                         dir : Char*,
-                                                                         producer : Char*,
-                                                                         optimized : Int, flags : Char*,
-                                                                         runtime_version : UInt) : LibLLVM::MetadataRef
-  fun di_builder_create_lexical_block = LLVMExtDIBuilderCreateLexicalBlock(builder : DIBuilder,
-                                                                           scope : LibLLVM::MetadataRef,
-                                                                           file : LibLLVM::MetadataRef,
-                                                                           line : Int,
-                                                                           column : Int) : LibLLVM::MetadataRef
-
-  fun di_builder_create_basic_type = LLVMExtDIBuilderCreateBasicType(builder : DIBuilder,
-                                                                     name : Char*,
-                                                                     size_in_bits : UInt64,
-                                                                     align_in_bits : UInt64,
-                                                                     encoding : UInt) : LibLLVM::MetadataRef
-
-  fun di_builder_create_auto_variable = LLVMExtDIBuilderCreateAutoVariable(builder : DIBuilder,
-                                                                           scope : LibLLVM::MetadataRef,
-                                                                           name : Char*,
-                                                                           file : LibLLVM::MetadataRef, line : UInt,
-                                                                           type : LibLLVM::MetadataRef,
-                                                                           always_preserve : Int,
-                                                                           flags : LLVM::DIFlags,
-                                                                           align_in_bits : UInt32) : LibLLVM::MetadataRef
-
-  fun di_builder_create_parameter_variable = LLVMExtDIBuilderCreateParameterVariable(builder : DIBuilder,
-                                                                                     scope : LibLLVM::MetadataRef,
-                                                                                     name : Char*, arg_no : UInt,
-                                                                                     file : LibLLVM::MetadataRef, line : UInt, type : LibLLVM::MetadataRef,
-                                                                                     always_preserve : Int, flags : LLVM::DIFlags) : LibLLVM::MetadataRef
-
-  fun di_builder_insert_declare_at_end = LLVMExtDIBuilderInsertDeclareAtEnd(builder : DIBuilder,
-                                                                            storage : LibLLVM::ValueRef,
-                                                                            var_info : LibLLVM::MetadataRef,
-                                                                            expr : LibLLVM::MetadataRef,
-                                                                            dl : LibLLVM::ValueRef,
-                                                                            block : LibLLVM::BasicBlockRef) : LibLLVM::ValueRef
-
-  fun di_builder_create_expression = LLVMExtDIBuilderCreateExpression(builder : DIBuilder,
-                                                                      addr : UInt64*, length : SizeT) : LibLLVM::MetadataRef
-
-  fun di_builder_get_or_create_array = LLVMExtDIBuilderGetOrCreateArray(builder : DIBuilder, data : LibLLVM::MetadataRef*, length : SizeT) : LibLLVM::MetadataRef
-  fun di_builder_create_enumerator = LLVMExtDIBuilderCreateEnumerator(builder : DIBuilder, name : Char*, value : Int64) : LibLLVM::MetadataRef
-  fun di_builder_create_enumeration_type = LLVMExtDIBuilderCreateEnumerationType(builder : DIBuilder,
-                                                                                 scope : LibLLVM::MetadataRef, name : Char*, file : LibLLVM::MetadataRef, line_number : UInt,
-                                                                                 size_in_bits : UInt64, align_in_bits : UInt64, elements : LibLLVM::MetadataRef, underlying_type : LibLLVM::MetadataRef) : LibLLVM::MetadataRef
-
-  fun di_builder_get_or_create_type_array = LLVMExtDIBuilderGetOrCreateTypeArray(builder : DIBuilder, data : LibLLVM::MetadataRef*, length : SizeT) : LibLLVM::MetadataRef
-  fun di_builder_create_subroutine_type = LLVMExtDIBuilderCreateSubroutineType(builder : DIBuilder, file : LibLLVM::MetadataRef, parameter_types : LibLLVM::MetadataRef) : LibLLVM::MetadataRef
-
-  fun di_builder_create_struct_type = LLVMExtDIBuilderCreateStructType(builder : DIBuilder,
-                                                                       scope : LibLLVM::MetadataRef, name : Char*, file : LibLLVM::MetadataRef, line : UInt, size_in_bits : UInt64,
-                                                                       align_in_bits : UInt64, flags : LLVM::DIFlags, derived_from : LibLLVM::MetadataRef, element_types : LibLLVM::MetadataRef) : LibLLVM::MetadataRef
-
-  fun di_builder_create_union_type = LLVMExtDIBuilderCreateUnionType(builder : DIBuilder,
-                                                                     scope : LibLLVM::MetadataRef, name : Char*, file : LibLLVM::MetadataRef, line : UInt, size_in_bits : UInt64,
-                                                                     align_in_bits : UInt64, flags : LLVM::DIFlags, element_types : LibLLVM::MetadataRef) : LibLLVM::MetadataRef
-
-  fun di_builder_create_array_type = LLVMExtDIBuilderCreateArrayType(builder : DIBuilder, size : UInt64,
-                                                                     alignInBits : UInt64, ty : LibLLVM::MetadataRef,
-                                                                     subscripts : LibLLVM::MetadataRef) : LibLLVM::MetadataRef
-
-  fun di_builder_create_member_type = LLVMExtDIBuilderCreateMemberType(builder : DIBuilder,
-                                                                       scope : LibLLVM::MetadataRef, name : Char*, file : LibLLVM::MetadataRef, line : UInt, size_in_bits : UInt64,
-                                                                       align_in_bits : UInt64, offset_in_bits : UInt64, flags : LLVM::DIFlags, ty : LibLLVM::MetadataRef) : LibLLVM::MetadataRef
-
-  fun di_builder_create_pointer_type = LLVMExtDIBuilderCreatePointerType(builder : DIBuilder,
-                                                                         pointee_type : LibLLVM::MetadataRef,
-                                                                         size_in_bits : UInt64,
-                                                                         align_in_bits : UInt64,
-                                                                         name : Char*) : LibLLVM::MetadataRef
-
-  fun di_builder_create_replaceable_composite_type = LLVMExtDIBuilderCreateReplaceableCompositeType(builder : DIBuilder,
-                                                                                                    scope : LibLLVM::MetadataRef,
-                                                                                                    name : Char*,
-                                                                                                    file : LibLLVM::MetadataRef,
-                                                                                                    line : UInt) : LibLLVM::MetadataRef
-
-  fun di_builder_create_unspecified_type = LLVMDIBuilderCreateUnspecifiedType(builder : LibLLVMExt::DIBuilder,
-                                                                              name : Void*,
-                                                                              size : LibC::SizeT) : LibLLVM::MetadataRef
-
-  fun di_builder_create_lexical_block_file = LLVMDIBuilderCreateLexicalBlockFile(builder : LibLLVMExt::DIBuilder,
-                                                                                 scope : LibLLVM::MetadataRef,
-                                                                                 file_scope : LibLLVM::MetadataRef,
-                                                                                 discriminator : UInt32) : LibLLVM::MetadataRef
-
-  fun di_builder_replace_temporary = LLVMExtDIBuilderReplaceTemporary(builder : DIBuilder, from : LibLLVM::MetadataRef, to : LibLLVM::MetadataRef)
+  {% if LibLLVM::IS_LT_90 %}
+    fun di_builder_create_enumerator = LLVMExtDIBuilderCreateEnumerator(builder : LibLLVM::DIBuilderRef, name : Char*, value : Int64) : LibLLVM::MetadataRef
+  {% end %}
 
   fun set_current_debug_location = LLVMExtSetCurrentDebugLocation(LibLLVM::BuilderRef, Int, Int, LibLLVM::MetadataRef, LibLLVM::MetadataRef)
 
@@ -133,8 +33,6 @@ lib LibLLVMExt
                                           name : LibC::Char*) : LibLLVM::ValueRef
 
   fun write_bitcode_with_summary_to_file = LLVMExtWriteBitcodeWithSummaryToFile(module : LibLLVM::ModuleRef, path : UInt8*) : Void
-
-  fun di_builder_get_or_create_array_subrange = LLVMExtDIBuilderGetOrCreateArraySubrange(builder : DIBuilder, lo : UInt64, count : UInt64) : LibLLVM::MetadataRef
 
   fun target_machine_enable_global_isel = LLVMExtTargetMachineEnableGlobalIsel(machine : LibLLVM::TargetMachineRef, enable : Bool)
   fun create_mc_jit_compiler_for_module = LLVMExtCreateMCJITCompilerForModule(jit : LibLLVM::ExecutionEngineRef*, m : LibLLVM::ModuleRef, options : LibLLVM::JITCompilerOptions*, options_length : UInt32, enable_global_isel : Bool, error : UInt8**) : Int32


### PR DESCRIPTION
This removes all functions in `llvm_ext.cc` that are required by `LLVM::DIBuilder` by using their official counterparts, except for `LLVMExtDIBuilderCreateEnumerator`, which did not exist in LLVM 8.0. For the remaining functions see #13177.

There are some breaking changes to align our LLVM API to the official one for debug info generation:

* `LLVM::Builder#create_compile_unit` now uses language codes as they are defined in the C header, not the C++ ones.
* `LLVM::Builder#insert_declare_at_end` now takes the debug location as a `LibLLVM::MetadataRef` instead of an `LLVM::Value`. There is currently no Crystal wrapper for `LibLLVM::MetadataRef`. (`LLVM::Metadata` is an empty struct used only as a namespace for the _unused_ `LLVM::Metadata::Type` enum.)
* The `LLVM::Builder#create_*_type` family now takes `Array`s or `Slice`s of metadata elements, without having to call `#get_or_create_array` or `#get_or_create_type_array` first, because LLVM does it for us. Conversely, Crystal itself no longer calls those array conversion functions, but it does unpack the metadata returned by them to maintain API compatibility; this is of course more expensive, so those overloads are deprecated.
* The members of the `LLVM::DwarfSourceLanguage` and `LLVM::DIFlags` enums now change depending on the LLVM version. In practice this isn't a huge problem because the LLVM version must be selected at build time.

There is also a workaround for #13250. It is internal to Crystal and not part of the breaking changes.

`LLVM::DIBuilder#create_reference_type` is completely removed, since it is unused by Crystal and the corresponding `LibLLVMExt` implementation + binding never existed.