### PR TITLE
Windows: Read effective file permissions using DACLs

### DIFF
--- a/src/crystal/system/win32/dir.cr
+++ b/src/crystal/system/win32/dir.cr
@@ -68,7 +68,7 @@ module Crystal::System::Dir
     if dir.file_handle == LibC::INVALID_HANDLE_VALUE
       handle = LibC.CreateFileW(
         System.to_wstr(path),
-        LibC::ACCESS_MASK::FILE_READ_ATTRIBUTES,
+        LibC::ACCESS_MASK::FILE_READ_ATTRIBUTES | LibC::ACCESS_MASK::READ_CONTROL,
         LibC::FILE_SHARE_READ | LibC::FILE_SHARE_WRITE | LibC::FILE_SHARE_DELETE,
         nil,
         LibC::OPEN_EXISTING,

--- a/src/crystal/system/win32/dir.cr
+++ b/src/crystal/system/win32/dir.cr
@@ -68,7 +68,7 @@ module Crystal::System::Dir
     if dir.file_handle == LibC::INVALID_HANDLE_VALUE
       handle = LibC.CreateFileW(
         System.to_wstr(path),
-        LibC::FILE_READ_ATTRIBUTES,
+        LibC::ACCESS_MASK::FILE_READ_ATTRIBUTES,
         LibC::FILE_SHARE_READ | LibC::FILE_SHARE_WRITE | LibC::FILE_SHARE_DELETE,
         nil,
         LibC::OPEN_EXISTING,

--- a/src/crystal/system/win32/file.cr
+++ b/src/crystal/system/win32/file.cr
@@ -58,15 +58,15 @@ module Crystal::System::File
 
   private def self.posix_to_open_opts(flags : Int32, perm : ::File::Permissions)
     access = if flags.bits_set? LibC::O_WRONLY
-               LibC::GENERIC_WRITE
+               LibC::ACCESS_MASK::GENERIC_WRITE
              elsif flags.bits_set? LibC::O_RDWR
-               LibC::GENERIC_READ | LibC::GENERIC_WRITE
+               LibC::ACCESS_MASK::GENERIC_READ | LibC::ACCESS_MASK::GENERIC_WRITE
              else
-               LibC::GENERIC_READ
+               LibC::ACCESS_MASK::GENERIC_READ
              end
 
     if flags.bits_set? LibC::O_APPEND
-      access |= LibC::FILE_APPEND_DATA
+      access |= LibC::ACCESS_MASK::FILE_APPEND_DATA
     end
 
     if flags.bits_set? LibC::O_TRUNC
@@ -92,7 +92,7 @@ module Crystal::System::File
 
     if flags.bits_set? LibC::O_TEMPORARY
       attributes |= LibC::FILE_FLAG_DELETE_ON_CLOSE | LibC::FILE_ATTRIBUTE_TEMPORARY
-      access |= LibC::DELETE
+      access |= LibC::ACCESS_MASK::DELETE
     end
 
     if flags.bits_set? LibC::O_SHORT_LIVED
@@ -153,7 +153,7 @@ module Crystal::System::File
 
     handle = LibC.CreateFileW(
       System.to_wstr(path),
-      LibC::FILE_READ_ATTRIBUTES,
+      LibC::ACCESS_MASK::FILE_READ_ATTRIBUTES,
       LibC::FILE_SHARE_READ | LibC::FILE_SHARE_WRITE | LibC::FILE_SHARE_DELETE,
       nil,
       LibC::OPEN_EXISTING,
@@ -321,7 +321,7 @@ module Crystal::System::File
   private def self.symlink_info?(path)
     handle = LibC.CreateFileW(
       System.to_wstr(path),
-      LibC::FILE_READ_ATTRIBUTES,
+      LibC::ACCESS_MASK::FILE_READ_ATTRIBUTES,
       LibC::DEFAULT_SHARE_MODE,
       nil,
       LibC::OPEN_EXISTING,
@@ -393,7 +393,7 @@ module Crystal::System::File
     mtime = Crystal::System::Time.to_filetime(modification_time)
     handle = LibC.CreateFileW(
       System.to_wstr(path),
-      LibC::FILE_WRITE_ATTRIBUTES,
+      LibC::ACCESS_MASK::FILE_WRITE_ATTRIBUTES,
       LibC::FILE_SHARE_READ | LibC::FILE_SHARE_WRITE | LibC::FILE_SHARE_DELETE,
       nil,
       LibC::OPEN_EXISTING,

--- a/src/crystal/system/win32/file_descriptor.cr
+++ b/src/crystal/system/win32/file_descriptor.cr
@@ -180,7 +180,7 @@ module Crystal::System::FileDescriptor
 
     r_pipe_flags = LibC::FILE_FLAG_NO_BUFFERING
     r_pipe_flags |= LibC::FILE_FLAG_OVERLAPPED unless read_blocking
-    r_pipe = LibC.CreateFileW(System.to_wstr(pipe_name), LibC::GENERIC_READ | LibC::FILE_WRITE_ATTRIBUTES, 0, nil, LibC::OPEN_EXISTING, r_pipe_flags, nil)
+    r_pipe = LibC.CreateFileW(System.to_wstr(pipe_name), LibC::ACCESS_MASK::GENERIC_READ | LibC::ACCESS_MASK::FILE_WRITE_ATTRIBUTES, 0, nil, LibC::OPEN_EXISTING, r_pipe_flags, nil)
     raise IO::Error.from_winerror("CreateFileW") if r_pipe == LibC::INVALID_HANDLE_VALUE
     Crystal::Scheduler.event_loop.create_completion_port(r_pipe) unless read_blocking
 

--- a/src/crystal/system/win32/windows_registry.cr
+++ b/src/crystal/system/win32/windows_registry.cr
@@ -7,7 +7,7 @@ module Crystal::System::WindowsRegistry
   #
   # Users need to ensure the opened key will be closed after usage (see `#close`).
   # *sam* specifies desired access rights to the key to be opened.
-  def self.open?(handle : LibC::HKEY, name : Slice(UInt16), sam = LibC::REGSAM::READ)
+  def self.open?(handle : LibC::HKEY, name : Slice(UInt16), sam = LibC::REGSAM::KEY_READ)
     status = LibC.RegOpenKeyExW(handle, name, 0, sam, out sub_handle)
     status = WinError.new(status)
 
@@ -22,7 +22,7 @@ module Crystal::System::WindowsRegistry
     end
   end
 
-  def self.open?(handle : LibC::HKEY, name : Slice(UInt16), sam = LibC::REGSAM::READ, &)
+  def self.open?(handle : LibC::HKEY, name : Slice(UInt16), sam = LibC::REGSAM::KEY_READ, &)
     key_handle = open?(handle, name, sam)
 
     return unless key_handle

--- a/src/lib_c/x86_64-windows-msvc/c/accctrl.cr
+++ b/src/lib_c/x86_64-windows-msvc/c/accctrl.cr
@@ -69,6 +69,5 @@ lib LibC
     trusteeForm : TRUSTEE_FORM
     trusteeType : TRUSTEE_TYPE
     union : TRUSTEE_W_union
-    ptstrName : LPWSTR
   end
 end

--- a/src/lib_c/x86_64-windows-msvc/c/accctrl.cr
+++ b/src/lib_c/x86_64-windows-msvc/c/accctrl.cr
@@ -1,0 +1,74 @@
+lib LibC
+  enum SE_OBJECT_TYPE
+    UNKNOWN_OBJECT_TYPE
+    FILE_OBJECT
+    SERVICE
+    PRINTER
+    REGISTRY_KEY
+    LMSHARE
+    KERNEL_OBJECT
+    WINDOW_OBJECT
+    DS_OBJECT
+    DS_OBJECT_ALL
+    PROVIDER_DEFINED_OBJECT
+    WMIGUID_OBJECT
+    REGISTRY_WOW64_32KEY
+    REGISTRY_WOW64_64KEY
+  end
+
+  enum MULTIPLE_TRUSTEE_OPERATION
+    NO_MULTIPLE_TRUSTEE
+    TRUSTEE_IS_IMPERSONATE
+  end
+
+  enum TRUSTEE_FORM
+    SID
+    NAME
+    BAD_FORM
+    OBJECTS_AND_SID
+    OBJECTS_AND_NAME
+  end
+
+  enum TRUSTEE_TYPE
+    UNKNOWN
+    USER
+    GROUP
+    DOMAIN
+    ALIAS
+    WELL_KNOWN_GROUP
+    DELETED
+    INVALID
+    COMPUTER
+  end
+
+  struct OBJECTS_AND_SID
+    objectsPresent : DWORD
+    objectTypeGuid : GUID
+    inheritedObjectTypeGuid : GUID
+    pSid : SID*
+  end
+
+  struct OBJECTS_AND_NAME_W
+    objectsPresent : DWORD
+    objectType : SE_OBJECT_TYPE
+    objectTypeName : LPWSTR
+    inheritedObjectTypeName : LPWSTR
+    ptstrName : LPWSTR
+  end
+
+  union TRUSTEE_W_union
+    ptstrName : LPWSTR
+    pSid : SID*
+    pObjectsAndSid : OBJECTS_AND_SID*
+    pObjectsAndName : OBJECTS_AND_NAME_W*
+  end
+
+  struct TRUSTEE_W
+    pMultipleTrustee : TRUSTEE_W*
+    multipleTrusteeOperation : MULTIPLE_TRUSTEE_OPERATION
+    trusteeForm : TRUSTEE_FORM
+    trusteeType : TRUSTEE_TYPE
+    union : TRUSTEE_W_union
+    ptstrName : LPWSTR
+  end
+end

--- a/src/lib_c/x86_64-windows-msvc/c/aclapi.cr
+++ b/src/lib_c/x86_64-windows-msvc/c/aclapi.cr
@@ -1,0 +1,7 @@
+@[Link("advapi32")]
+lib LibC
+  fun GetSecurityInfo(handle : HANDLE, objectType : SE_OBJECT_TYPE, securityInfo : DWORD, ppsidOwner : SID**,
+                      ppsidGroup : SID**, ppDacl : ACL**, ppSacl : ACL**, ppSecurityDescriptor : SECURITY_DESCRIPTOR**) : DWORD
+  fun BuildTrusteeWithSidW(pTrustee : TRUSTEE_W*, pSid : SID*)
+  fun GetEffectiveRightsFromAclW(pacl : ACL*, pTrustee : TRUSTEE_W*, pAccessRights : ACCESS_MASK*) : DWORD
+end

--- a/src/lib_c/x86_64-windows-msvc/c/fileapi.cr
+++ b/src/lib_c/x86_64-windows-msvc/c/fileapi.cr
@@ -65,9 +65,6 @@ lib LibC
 
   DEFAULT_SHARE_MODE = FILE_SHARE_READ | FILE_SHARE_WRITE | FILE_SHARE_DELETE
 
-  GENERIC_READ  = 0x80000000
-  GENERIC_WRITE = 0x40000000
-
   fun CreateFileW(lpFileName : LPWSTR, dwDesiredAccess : DWORD, dwShareMode : DWORD,
                   lpSecurityAttributes : SECURITY_ATTRIBUTES*, dwCreationDisposition : DWORD,
                   dwFlagsAndAttributes : DWORD, hTemplateFile : HANDLE) : HANDLE

--- a/src/lib_c/x86_64-windows-msvc/c/processthreadsapi.cr
+++ b/src/lib_c/x86_64-windows-msvc/c/processthreadsapi.cr
@@ -54,5 +54,7 @@ lib LibC
                       lpKernelTime : FILETIME*, lpUserTime : FILETIME*) : BOOL
   fun SwitchToThread : BOOL
 
+  GetCurrentProcessToken = HANDLE.new(-4) # C static inline function
+
   PROCESS_QUERY_INFORMATION = 0x0400
 end

--- a/src/lib_c/x86_64-windows-msvc/c/securitybaseapi.cr
+++ b/src/lib_c/x86_64-windows-msvc/c/securitybaseapi.cr
@@ -1,0 +1,4 @@
+@[Link("advapi32")]
+lib LibC
+  fun CreateWellKnownSid(wellKnownSidType : WELL_KNOWN_SID_TYPE, domainSid : SID*, pSid : SID*, cbSid : DWORD*) : BOOL
+end

--- a/src/lib_c/x86_64-windows-msvc/c/securitybaseapi.cr
+++ b/src/lib_c/x86_64-windows-msvc/c/securitybaseapi.cr
@@ -1,4 +1,8 @@
+require "c/winnt"
+
 @[Link("advapi32")]
 lib LibC
   fun CreateWellKnownSid(wellKnownSidType : WELL_KNOWN_SID_TYPE, domainSid : SID*, pSid : SID*, cbSid : DWORD*) : BOOL
+
+  fun GetTokenInformation(tokenHandle : HANDLE, tokenInformationClass : TOKEN_INFORMATION_CLASS, tokenInformation : Void*, tokenInformationLength : DWORD, returnLength : DWORD*) : BOOL
 end

--- a/src/lib_c/x86_64-windows-msvc/c/winbase.cr
+++ b/src/lib_c/x86_64-windows-msvc/c/winbase.cr
@@ -4,6 +4,8 @@ require "c/int_safe"
 require "c/minwinbase"
 
 lib LibC
+  fun LocalFree(hMem : Void*) : Void*
+
   FORMAT_MESSAGE_ALLOCATE_BUFFER = 0x00000100_u32
   FORMAT_MESSAGE_IGNORE_INSERTS  = 0x00000200_u32
   FORMAT_MESSAGE_FROM_STRING     = 0x00000400_u32

--- a/src/lib_c/x86_64-windows-msvc/c/winnt.cr
+++ b/src/lib_c/x86_64-windows-msvc/c/winnt.cr
@@ -110,6 +110,37 @@ lib LibC
     KEY_WRITE = 0x20006
   end
 
+  struct SID_IDENTIFIER_AUTHORITY
+    value : BYTE[6]
+  end
+
+  struct SID
+    revision : BYTE
+    subAuthorityCount : BYTE
+    identifierAuthority : SID_IDENTIFIER_AUTHORITY
+    subAuthority : DWORD[1]
+  end
+
+  SECURITY_MAX_SID_SIZE = 68
+
+  enum WELL_KNOWN_SID_TYPE
+    WinWorldSid = 1
+  end
+
+  alias SECURITY_DESCRIPTOR = Void # body unused
+
+  OWNER_SECURITY_INFORMATION = 0x00000001_u32
+  GROUP_SECURITY_INFORMATION = 0x00000002_u32
+  DACL_SECURITY_INFORMATION  = 0x00000004_u32
+
+  struct ACL
+    aclRevision : BYTE
+    sbz1 : BYTE
+    aclSize : WORD
+    aceCount : WORD
+    sbz2 : WORD
+  end
+
   struct CONTEXT
     p1Home : DWORD64
     p2Home : DWORD64

--- a/src/lib_c/x86_64-windows-msvc/c/winnt.cr
+++ b/src/lib_c/x86_64-windows-msvc/c/winnt.cr
@@ -19,12 +19,6 @@ lib LibC
   FILE_ATTRIBUTE_READONLY      =   0x1
   FILE_ATTRIBUTE_REPARSE_POINT = 0x400
 
-  FILE_APPEND_DATA = 0x00000004
-
-  DELETE                = 0x00010000
-  FILE_READ_ATTRIBUTES  =       0x80
-  FILE_WRITE_ATTRIBUTES =     0x0100
-
   MAXIMUM_REPARSE_DATA_BUFFER_SIZE = 0x4000
 
   IO_REPARSE_TAG_SYMLINK = 0xA000000C_u32
@@ -34,58 +28,86 @@ lib LibC
   PAGE_READWRITE =  0x04
   PAGE_GUARD     = 0x100
 
-  PROCESS_QUERY_LIMITED_INFORMATION =     0x1000
-  SYNCHRONIZE                       = 0x00100000
+  PROCESS_QUERY_LIMITED_INFORMATION = 0x1000
 
   DUPLICATE_CLOSE_SOURCE = 0x00000001
   DUPLICATE_SAME_ACCESS  = 0x00000002
 
-  enum REGSAM
+  @[Flags]
+  enum ACCESS_MASK : DWORD
+    GENERIC_READ  = 0x80000000
+    GENERIC_WRITE = 0x40000000
+
+    DELETE       = 0x00010000
+    READ_CONTROL = 0x00020000
+    WRITE_DAC    = 0x00040000
+    WRITE_OWNER  = 0x00080000
+    SYNCHRONIZE  = 0x00100000
+
+    FILE_READ_DATA            = 0x0001 # file & pipe
+    FILE_LIST_DIRECTORY       = 0x0001 # directory
+    FILE_WRITE_DATA           = 0x0002 # file & pipe
+    FILE_ADD_FILE             = 0x0002 # directory
+    FILE_APPEND_DATA          = 0x0004 # file
+    FILE_ADD_SUBDIRECTORY     = 0x0004 # directory
+    FILE_CREATE_PIPE_INSTANCE = 0x0004 # named pipe
+    FILE_READ_EA              = 0x0008 # file & directory
+    FILE_WRITE_EA             = 0x0010 # file & directory
+    FILE_EXECUTE              = 0x0020 # file
+    FILE_TRAVERSE             = 0x0020 # directory
+    FILE_DELETE_CHILD         = 0x0040 # directory
+    FILE_READ_ATTRIBUTES      = 0x0080 # all
+    FILE_WRITE_ATTRIBUTES     = 0x0100 # all
+
+    FILE_GENERIC_READ    = 0x120089 # STANDARD_RIGHTS_READ | FILE_READ_DATA | FILE_READ_ATTRIBUTES | FILE_READ_EA | SYNCHRONIZE
+    FILE_GENERIC_WRITE   = 0x120116 # STANDARD_RIGHTS_WRITE | FILE_WRITE_DATA | FILE_WRITE_ATTRIBUTES | FILE_WRITE_EA | FILE_APPEND_DATA | SYNCHRONIZE
+    FILE_GENERIC_EXECUTE = 0x1200A0 # STANDARD_RIGHTS_EXECUTE | FILE_READ_ATTRIBUTES | FILE_EXECUTE | SYNCHRONIZE
+
     # Required to query the values of a registry key.
-    QUERY_VALUE = 0x0001
+    KEY_QUERY_VALUE = 0x0001
 
     # Required to create, delete, or set a registry value.
-    SET_VALUE = 0x0002
+    KEY_SET_VALUE = 0x0002
 
     # Required to create a subkey of a registry key.
-    CREATE_SUB_KEY = 0x0004
+    KEY_CREATE_SUB_KEY = 0x0004
 
     # Required to enumerate the subkeys of a registry key.
-    ENUMERATE_SUB_KEYS = 0x0008
+    KEY_ENUMERATE_SUB_KEYS = 0x0008
 
     # Required to request change notifications for a registry key or for subkeys of a registry key.
-    NOTIFY = 0x0010
+    KEY_NOTIFY = 0x0010
 
     # Reserved for system use.
-    CREATE_LINK = 0x0020
+    KEY_CREATE_LINK = 0x0020
 
     # Indicates that an application on 64-bit Windows should operate on the 32-bit registry view. This flag is ignored by 32-bit Windows.
     # This flag must be combined using the OR operator with the other flags in this table that either query or access registry values.
     # Windows 2000: This flag is not supported.
-    WOW64_32KEY = 0x0200
+    KEY_WOW64_32KEY = 0x0200
 
     # Indicates that an application on 64-bit Windows should operate on the 64-bit registry view. This flag is ignored by 32-bit Windows.
     # This flag must be combined using the OR operator with the other flags in this table that either query or access registry values.
     # Windows 2000: This flag is not supported.
-    WOW64_64KEY = 0x0100
+    KEY_WOW64_64KEY = 0x0100
 
-    WOW64_RES = 0x0300
+    KEY_WOW64_RES = 0x0300
 
     # Combines the `STANDARD_RIGHTS_READ`, `QUERY_VALUE`, `ENUMERATE_SUB_KEYS`, and `NOTIFY` values.
     # (STANDARD_RIGHTS_READ | QUERY_VALUE | ENUMERATE_SUB_KEYS | NOTIFY) & ~SYNCHRONIZE
-    READ = 0x20019
+    KEY_READ = 0x20019
 
     # Combines the `STANDARD_RIGHTS_REQUIRED`, `QUERY_VALUE`, `SET_VALUE`, `CREATE_SUB_KEY`, `ENUMERATE_SUB_KEYS`, `NOTIFY`, and `CREATE_LINK` access rights.
     # (STANDARD_RIGHTS_ALL | KEY_QUERY_VALUE | KEY_SET_VALUE | KEY_CREATE_SUB_KEY | KEY_ENUMERATE_SUB_KEYS | KEY_NOTIFY | KEY_CREATE_LINK) & ~SYNCHRONIZE
-    ALL_ACCESS = 0xf003f
+    KEY_ALL_ACCESS = 0xf003f
 
     # Equivalent to `READ`.
     # KEY_READ & ~SYNCHRONIZE
-    EXECUTE = 0x20019
+    KEY_EXECUTE = 0x20019
 
     # Combines the STANDARD_RIGHTS_WRITE, `KEY_SET_VALUE`, and `KEY_CREATE_SUB_KEY` access rights.
     # (STANDARD_RIGHTS_WRITE | KEY_SET_VALUE | KEY_CREATE_SUB_KEY) & ~SYNCHRONIZE
-    WRITE = 0x20006
+    KEY_WRITE = 0x20006
   end
 
   struct CONTEXT

--- a/src/lib_c/x86_64-windows-msvc/c/winnt.cr
+++ b/src/lib_c/x86_64-windows-msvc/c/winnt.cr
@@ -141,6 +141,14 @@ lib LibC
     sbz2 : WORD
   end
 
+  struct TOKEN_OWNER
+    owner : SID*
+  end
+
+  enum TOKEN_INFORMATION_CLASS
+    TokenOwner = 4
+  end
+
   struct CONTEXT
     p1Home : DWORD64
     p2Home : DWORD64

--- a/src/lib_c/x86_64-windows-msvc/c/winreg.cr
+++ b/src/lib_c/x86_64-windows-msvc/c/winreg.cr
@@ -1,5 +1,6 @@
 lib LibC
   alias LSTATUS = DWORD
+  alias REGSAM = ACCESS_MASK
 
   enum RegistryRoutineFlags
     NONE                       = 0


### PR DESCRIPTION
This is a proof of concept for the reading part of #13233. It directly accesses the DACL (discretionary access control list) of a file handle to retrieve the effective rights for different principals:

* the owner for `File.info`;
* the POSIX compatibility owner group for `File.info`; (this notion of owner group is no longer meaningful for most Windows applications, so this will probably change to something else)
* the "Everyone" group (`S-1-1-0`) for `File.info`;
* the user associated with the current process for `File.readable?` and `.writable?`.

Then it determines that a file has read / write / execute permission if and only if _all_ the individual rights covered by `FILE_GENERIC_READ` / `FILE_GENERIC_WRITE` / `FILE_GENERIC_EXECUTE` are granted. They correspond to the following items on the advanced security settings dialog for a file:

* `FILE_GENERIC_READ`
  * List folder / read data
  * Read attributes
  * Read extended attributes
  * Read permissions
  * Synchronize (not shown)
* `FILE_GENERIC_WRITE`
  * Create files / write data
  * Create folders / append data
  * Write attributes
  * Write extended attributes
  * Read permissions
  * Synchronize (not shown)
* `FILE_GENERIC_EXECUTE`
  * Traverse folder / execute file
  * Read attributes
  * Read permissions
  * Synchronize (not shown)

In particular, "Traverse folder" has the same meaning as POSIX's execute permission on directories.

This PR alone breaks several specs because `File.chmod` and the `perm` parameter of `File.new` do not manipulate any file handles' DACLs yet.