### PR TITLE
Allow `File.delete` to remove read-only files on Windows

### DIFF
--- a/spec/std/file_spec.cr
+++ b/spec/std/file_spec.cr
@@ -220,7 +220,7 @@ describe "File" do
       other = datapath("test_file.ini")
 
       with_tempfile("test_file_symlink.txt") do |symlink|
-        File.symlink(File.real_path(file), symlink)
+        File.symlink(File.realpath(file), symlink)
 
         File.same?(file, symlink).should be_false
         File.same?(file, symlink, follow_symlinks: true).should be_true
@@ -514,7 +514,7 @@ describe "File" do
     end
   end
 
-  describe "delete" do
+  describe ".delete" do
     it "deletes a file" do
       with_tempfile("delete-file.txt") do |filename|
         File.open(filename, "w") { }
@@ -530,6 +530,20 @@ describe "File" do
         File.exists?(file.path).should be_true
         file.delete
         File.exists?(file.path).should be_false
+      end
+    end
+
+    it "deletes a read-only file" do
+      with_tempfile("delete-file-dir") do |path|
+        Dir.mkdir(path)
+        File.chmod(path, 0o755)
+
+        filename = File.join(path, "foo")
+        File.open(filename, "w") { }
+        File.exists?(filename).should be_true
+        File.chmod(filename, 0o000)
+        File.delete(filename)
+        File.exists?(filename).should be_false
       end
     end
 

--- a/spec/support/tempfile.cr
+++ b/spec/support/tempfile.cr
@@ -31,7 +31,7 @@ def with_tempfile(*paths, file = __FILE__, &)
   ensure
     if SPEC_TEMPFILE_CLEANUP
       paths.each do |path|
-        rm_rf(path) if File.exists?(path)
+        FileUtils.rm_rf(path) if File.exists?(path)
       end
     end
   end
@@ -74,24 +74,6 @@ end
 
 if SPEC_TEMPFILE_CLEANUP
   at_exit do
-    rm_rf(SPEC_TEMPFILE_PATH) if Dir.exists?(SPEC_TEMPFILE_PATH)
-  end
-end
-
-private def rm_rf(path : String) : Nil
-  if Dir.exists?(path) && !File.symlink?(path)
-    Dir.each_child(path) do |entry|
-      src = File.join(path, entry)
-      rm_rf(src)
-    end
-    Dir.delete(path)
-  else
-    begin
-      File.delete(path)
-    rescue File::AccessDeniedError
-      # To be able to delete read-only files (e.g. ones under .git/) on Windows.
-      File.chmod(path, 0o666)
-      File.delete(path)
-    end
+    FileUtils.rm_rf(SPEC_TEMPFILE_PATH) if Dir.exists?(SPEC_TEMPFILE_PATH)
   end
 end


### PR DESCRIPTION
Closes #9903.

Note that file deletion on POSIX only requires write and execute permissions on the parent directory, and the file itself's owner and permissions do not matter, so nothing special needs to be done for Unix-like systems. This PR can be seen as aligning Windows' behavior to POSIX.

The [similar helper method in Shards](https://github.com/crystal-lang/shards/blob/d75b004dd3d024027b519fff06cfeecadfd691cd/src/helpers.cr#L2-L20) can also be removed after this.