### PR TITLE
Add incremental optimization levels

### DIFF
--- a/src/compiler/crystal/codegen/target.cr
+++ b/src/compiler/crystal/codegen/target.cr
@@ -164,7 +164,7 @@ class Crystal::Codegen::Target
     environment_parts.any? &.in?("gnueabihf", "musleabihf")
   end
 
-  def to_target_machine(cpu = "", features = "", release = false,
+  def to_target_machine(cpu = "", features = "", optimization_mode = Compiler::OptimizationMode::O0,
                         code_model = LLVM::CodeModel::Default) : LLVM::TargetMachine
     case @architecture
     when "i386", "x86_64"
@@ -186,7 +186,12 @@ class Crystal::Codegen::Target
       raise Target::Error.new("Unsupported architecture for target triple: #{self}")
     end
 
-    opt_level = release ? LLVM::CodeGenOptLevel::Aggressive : LLVM::CodeGenOptLevel::None
+    opt_level = case optimization_mode
+                in .o3? then LLVM::CodeGenOptLevel::Aggressive
+                in .o2? then LLVM::CodeGenOptLevel::Default
+                in .o1? then LLVM::CodeGenOptLevel::Less
+                in .o0? then LLVM::CodeGenOptLevel::None
+                end
 
     target = LLVM::Target.from_triple(self.to_s)
     machine = target.create_target_machine(self.to_s, cpu: cpu, features: features, opt_level: opt_level, code_model: code_model).not_nil!

--- a/src/compiler/crystal/command.cr
+++ b/src/compiler/crystal/command.cr
@@ -505,8 +505,11 @@ class Crystal::Command
       end
 
       unless no_codegen
-        opts.on("--release", "Compile in release mode") do
-          compiler.release = true
+        opts.on("--release", "Compile in release mode (-O3 --single-module)") do
+          compiler.release!
+        end
+        opts.on("-O LEVEL", "Optimization mode: 0 (default), 1, 2, 3") do |level|
+          compiler.optimization_mode = Compiler::OptimizationMode.from_value?(level.to_i) || raise Error.new("Unknown optimization mode #{level}")
         end
       end
 
@@ -641,8 +644,11 @@ class Crystal::Command
       @error_trace = true
       compiler.show_error_trace = true
     end
-    opts.on("--release", "Compile in release mode") do
-      compiler.release = true
+    opts.on("--release", "Compile in release mode (-O3 --single-module)") do
+      compiler.release!
+    end
+    opts.on("-O LEVEL", "Optimization mode: 0 (default), 1, 2, 3") do |level|
+      compiler.optimization_mode = Compiler::OptimizationMode.from_value?(level.to_i) || raise Error.new("Unknown optimization mode #{level}")
     end
     opts.on("-s", "--stats", "Enable statistics output") do
       compiler.progress_tracker.stats = true

--- a/src/compiler/crystal/compiler.cr
+++ b/src/compiler/crystal/compiler.cr
@@ -83,17 +83,17 @@ module Crystal
     # Optimization mode
     enum OptimizationMode
       # [default] no optimization, fastest compilation, slowest runtime
-      O0
+      O0 = 0
 
       # low, compilation slower than O0, runtime faster than O0
-      O1
+      O1 = 1
 
       # middle, compilation slower than O1, runtime faster than O1
-      O2
+      O2 = 2
 
       # high, slowest compilation, fastest runtime
       # enables with --release flag
-      O3
+      O3 = 3
 
       def suffix
         ".#{to_s.downcase}"

--- a/src/compiler/crystal/compiler.cr
+++ b/src/compiler/crystal/compiler.cr
@@ -80,14 +80,35 @@ module Crystal
     # the source file to compile.
     property prelude = "prelude"
 
-    # If `true`, runs LLVM optimizations.
-    property? release = false
+    # Optimization mode
+    enum OptimizationMode
+      # [default] no optimization, fastest compilation, slowest runtime
+      O0
+
+      # low, compilation slower than O0, runtime faster than O0
+      O1
+
+      # middle, compilation slower than O1, runtime faster than O1
+      O2
+
+      # high, slowest compilation, fastest runtime
+      # enables with --release flag
+      O3
+
+      def suffix
+        ".#{to_s.downcase}"
+      end
+    end
+
+    # Sets the Optimization mode.
+    property optimization_mode = OptimizationMode::O0
 
     # Sets the code model. Check LLVM docs to learn about this.
     property mcmodel = LLVM::CodeModel::Default
 
     # If `true`, generates a single LLVM module. By default
     # one LLVM module is created for each type in a program.
+    # --release automatically enable this option
     property? single_module = false
 
     # A `ProgressTracker` object which tracks compilation progress.
@@ -202,6 +223,16 @@ module Crystal
       Result.new program, node
     end
 
+    # Set maximum level of optimization.
+    def release!
+      @optimization_mode = OptimizationMode::O3
+      @single_module = true
+    end
+
+    def release?
+      @optimization_mode.o3? && @single_module
+    end
+
     private def new_program(sources)
       @program = program = Program.new
       program.compiler = self
@@ -254,8 +285,8 @@ module Crystal
 
     private def bc_flags_changed?(output_dir)
       bc_flags_changed = true
-      current_bc_flags = "#{@codegen_target}|#{@mcpu}|#{@mattr}|#{@release}|#{@link_flags}|#{@mcmodel}"
-      bc_flags_filename = "#{output_dir}/bc_flags"
+      current_bc_flags = "#{@codegen_target}|#{@mcpu}|#{@mattr}|#{@link_flags}|#{@mcmodel}"
+      bc_flags_filename = "#{output_dir}/bc_flags#{optimization_mode.suffix}"
       if File.file?(bc_flags_filename)
         previous_bc_flags = File.read(bc_flags_filename).strip
         bc_flags_changed = previous_bc_flags != current_bc_flags
@@ -266,7 +297,7 @@ module Crystal
 
     private def codegen(program, node : ASTNode, sources, output_filename)
       llvm_modules = @progress_tracker.stage("Codegen (crystal)") do
-        program.codegen node, debug: debug, single_module: @single_module || @release || @cross_compile || !@emit_targets.none?
+        program.codegen node, debug: debug, single_module: @single_module || @cross_compile || !@emit_targets.none?
       end
 
       output_dir = CacheDir.instance.directory_for(sources)
@@ -319,7 +350,7 @@ module Crystal
       llvm_mod = unit.llvm_mod
 
       @progress_tracker.stage("Codegen (bc+obj)") do
-        optimize llvm_mod if @release
+        optimize llvm_mod unless @optimization_mode.o0?
 
         unit.emit(@emit_targets, emit_base_filename || output_filename)
 
@@ -581,7 +612,7 @@ module Crystal
     end
 
     getter(target_machine : LLVM::TargetMachine) do
-      @codegen_target.to_target_machine(@mcpu || "", @mattr || "", @release, @mcmodel)
+      @codegen_target.to_target_machine(@mcpu || "", @mattr || "", @optimization_mode, @mcmodel)
     rescue ex : ArgumentError
       stderr.print colorize("Error: ").red.bold
       stderr.print "llc: "
@@ -615,16 +646,35 @@ module Crystal
           registry.initialize_all
 
           builder = LLVM::PassManagerBuilder.new
-          builder.opt_level = 3
+          case optimization_mode
+          in .o3?
+            builder.opt_level = 3
+            builder.use_inliner_with_threshold = 275
+          in .o2?
+            builder.opt_level = 2
+            builder.use_inliner_with_threshold = 275
+          in .o1?
+            builder.opt_level = 1
+            builder.use_inliner_with_threshold = 150
+          in .o0?
+            # default behaviour, no optimizations
+          end
+
           builder.size_level = 0
-          builder.use_inliner_with_threshold = 275
+
           builder
         end
       end
     {% else %}
       protected def optimize(llvm_mod)
         LLVM::PassBuilderOptions.new do |options|
-          LLVM.run_passes(llvm_mod, "default<O3>", target_machine, options)
+          mode = case @optimization_mode
+                 in .o3? then "default<O3>"
+                 in .o2? then "default<O2>"
+                 in .o1? then "default<O1>"
+                 in .o0? then "default<O0>"
+                 end
+          LLVM.run_passes(llvm_mod, mode, target_machine, options)
         end
       end
     {% end %}
@@ -713,6 +763,7 @@ module Crystal
           @name = "#{@name[0..16]}-#{::Crystal::Digest::MD5.hexdigest(@name)}"
         end
 
+        @name = "#{@name}#{@compiler.optimization_mode.suffix}"
         @object_extension = compiler.codegen_target.object_extension
       end
 
@@ -730,8 +781,8 @@ module Crystal
         # in the cache directory.
         #
         # On a next compilation of the same project, and if the compile
-        # flags didn't change (a combination of the target triple, mcpu,
-        # release and link flags, amongst others), we check if the new
+        # flags didn't change (a combination of the target triple, mcpu
+        # and link flags, amongst others), we check if the new
         # `.bc` file is exactly the same as the old one. In that case
         # the `.o` file will also be the same, so we simply reuse the
         # old one. Generating an `.o` file is what takes most time.
@@ -775,7 +826,7 @@ module Crystal
         end
 
         if must_compile
-          compiler.optimize llvm_mod if compiler.release?
+          compiler.optimize llvm_mod unless compiler.optimization_mode.o0?
           compiler.target_machine.emit_obj_to_file llvm_mod, temporary_object_name
           File.rename(temporary_object_name, object_name)
         else

--- a/src/compiler/crystal/macros/macros.cr
+++ b/src/compiler/crystal/macros/macros.cr
@@ -145,7 +145,7 @@ class Crystal::Program
 
       # Although release takes longer, once the bc is cached in .crystal
       # the subsequent times will make program execution faster.
-      host_compiler.release = true
+      host_compiler.release!
 
       # Don't cleanup old directories after compiling: it might happen
       # that in doing so we remove the directory associated with the current


### PR DESCRIPTION
This is just draft, for discussion. Here i add two new levels of optimization (--level2 and --level1) to existing ones `--release` and `default`.
Reason: I have quite big project which is compiled very slow, and also have big start time (it read data from db, and do some heavy calculations on it). So if i compile it without optimization it starts very slow, if i compile it with --release, compilation take too long. So debugging such project is real pain. By adding new incremental optimization level, i can solve this problem.

Of course this level2, and level1 optimization not even close in terms of performance to `--release` option, because it optimize every module (which is class in crystal), unlike `--release` which optimize united module (using hard inlining). But it fast enough to debug my project.

This is results for my project:
`--release`: initial compile: 61s, incremental compile(change 1 file): 61s, start time: 2s
`--level2`: initial compile: 12.6s, incremental compile(change 1 file): 5.3s, start time: 7s
`--level1`: initial compile: 12s, incremental compile(change 1 file): 5.2s, start time: 7.5s
`default`: initial compile: 7,4s, incremental compile(change 1 file): 5.3s, start time: 23.5s

Build crystal compiler (run time here is recompile crystal by new binary with clean cache and level0, to reduce llvm interference): 
`--release`: initial compile: 7m38,818s, incremental compile(change 1 file): 7m34,734s, run time: 0m36,086s
`--level2`: initial compile: 1m5,084s, incremental compile(change 1 file): 0m22,129s, run time: 0m42,691s
`--level1`: initial compile: 1m1,384s, incremental compile(change 1 file): 0m22,106s, run time: 0m42,980s
`default`: initial compile: 0m27,484s, incremental compile(change 1 file): 0m22,071s, run time: 0m55,572s
