### PR TITLE
Add a testcase line number to the output of JUnitFormatter

### DIFF
--- a/spec/std/spec/junit_formatter_spec.cr
+++ b/spec/std/spec/junit_formatter_spec.cr
@@ -18,8 +18,8 @@ describe "JUnit Formatter" do
     expected = <<-XML
                  <?xml version="1.0"?>
                  <testsuite tests="2" skipped="0" errors="0" failures="0" time="0.0" hostname="#{System.hostname}">
-                   <testcase file="spec/some_spec.cr" classname="spec.some_spec" name="should do something"/>
-                   <testcase file="spec/some_spec.cr" classname="spec.some_spec" name="should do something else"/>
+                   <testcase file="spec/some_spec.cr" classname="spec.some_spec" name="should do something" line="33"/>
+                   <testcase file="spec/some_spec.cr" classname="spec.some_spec" name="should do something else" line="50"/>
                  </testsuite>
                  XML
 
@@ -34,7 +34,7 @@ describe "JUnit Formatter" do
     expected = <<-XML
                  <?xml version="1.0"?>
                  <testsuite tests="1" skipped="1" errors="0" failures="0" time="0.0" hostname="#{System.hostname}">
-                   <testcase file="spec/some_spec.cr" classname="spec.some_spec" name="should do something">
+                   <testcase file="spec/some_spec.cr" classname="spec.some_spec" name="should do something" line="33">
                      <skipped/>
                    </testcase>
                  </testsuite>
@@ -51,7 +51,7 @@ describe "JUnit Formatter" do
     expected = <<-XML
                  <?xml version="1.0"?>
                  <testsuite tests="1" skipped="0" errors="0" failures="1" time="0.0" hostname="#{System.hostname}">
-                   <testcase file="spec/some_spec.cr" classname="spec.some_spec" name="should do something">
+                   <testcase file="spec/some_spec.cr" classname="spec.some_spec" name="should do something" line="33">
                      <failure/>
                    </testcase>
                  </testsuite>
@@ -68,7 +68,7 @@ describe "JUnit Formatter" do
     expected = <<-XML
                  <?xml version="1.0"?>
                  <testsuite tests="1" skipped="0" errors="1" failures="0" time="0.0" hostname="#{System.hostname}">
-                   <testcase file="spec/some_spec.cr" classname="spec.some_spec" name="should do something">
+                   <testcase file="spec/some_spec.cr" classname="spec.some_spec" name="should do something" line="33">
                      <error message="foo" type="MyException"></error>
                    </testcase>
                  </testsuite>
@@ -88,14 +88,14 @@ describe "JUnit Formatter" do
     expected = <<-XML
                  <?xml version="1.0"?>
                  <testsuite tests="4" skipped="1" errors="1" failures="1" time="0.0" hostname="#{System.hostname}">
-                   <testcase file="spec/some_spec.cr" classname="spec.some_spec" name="should do something1" time="2.0"/>
-                   <testcase file="spec/some_spec.cr" classname="spec.some_spec" name="should do something2" time="0.5">
+                   <testcase file="spec/some_spec.cr" classname="spec.some_spec" name="should do something1" line="33" time="2.0"/>
+                   <testcase file="spec/some_spec.cr" classname="spec.some_spec" name="should do something2" line="50" time="0.5">
                      <failure/>
                    </testcase>
-                   <testcase file="spec/some_spec.cr" classname="spec.some_spec" name="should do something3">
+                   <testcase file="spec/some_spec.cr" classname="spec.some_spec" name="should do something3" line="65">
                      <error/>
                    </testcase>
-                   <testcase file="spec/some_spec.cr" classname="spec.some_spec" name="should do something4">
+                   <testcase file="spec/some_spec.cr" classname="spec.some_spec" name="should do something4" line="80">
                      <skipped/>
                    </testcase>
                  </testsuite>

--- a/src/spec/junit_formatter.cr
+++ b/src/spec/junit_formatter.cr
@@ -67,6 +67,8 @@ module Spec
       HTML.escape(classname(result), io)
       io << %(" name=")
       HTML.escape(escape_xml_attr(result.description), io)
+      io << %(" line=")
+      HTML.escape(result.line.to_s, io)
 
       if elapsed = result.elapsed
         io << %(" time=")

--- a/src/spec/junit_formatter.cr
+++ b/src/spec/junit_formatter.cr
@@ -68,7 +68,7 @@ module Spec
       io << %(" name=")
       HTML.escape(escape_xml_attr(result.description), io)
       io << %(" line=")
-      HTML.escape(result.line.to_s, io)
+      io << result.line
 
       if elapsed = result.elapsed
         io << %(" time=")


### PR DESCRIPTION
This pull request adds a line number to every testcase in the JUnitFormatter output. Closes #13467. 

Example:
```xml
<?xml version="1.0"?>
<testsuite tests="1" skipped="0" errors="0" failures="1" time="2.003540435" timestamp="2023-05-13T19:25:33Z" hostname="my-hostname">
  <testcase file="/path/to/project/directory/mlcsim/spec/mlcsim/transcoder_spec.cr" classname="spec.mlcsim.transcoder_spec" 
    name="MLCSim::Transcoder when transcoding encodes a value into cells" time="2.3956e-5" line="5"/>
</testsuite>
```