### PR TITLE
Support `-static` and `-dynamic` `.lib` suffixes on Windows

### DIFF
--- a/src/compiler/crystal/compiler.cr
+++ b/src/compiler/crystal/compiler.cr
@@ -366,15 +366,28 @@ module Crystal
         @link_flags.try { |flags| link_args << flags }
 
         {% if flag?(:msvc) %}
-          if program.has_flag?("preview_dll") && !program.has_flag?("no_win32_delay_load")
+          extra_suffix = program.has_flag?("preview_dll") ? "-dynamic" : "-static"
+          search_result = Loader.search_libraries(Process.parse_arguments_windows(link_args.join(' ')), extra_suffix: extra_suffix)
+          if not_found = search_result.not_found?
+            error "Cannot locate the .lib files for the following libraries: #{not_found.join(", ")}"
+          end
+
+          link_args = search_result.remaining_args.concat(search_result.library_paths).map { |arg| Process.quote_windows(arg) }
+
+          if !program.has_flag?("no_win32_delay_load")
             # "LINK : warning LNK4199: /DELAYLOAD:foo.dll ignored; no imports found from foo.dll"
             # it is harmless to skip this error because not all import libraries are always used, much
             # less the individual DLLs they refer to
             link_args << "/IGNORE:4199"
 
-            Loader.search_dlls(Process.parse_arguments_windows(link_args.join(' '))).each do |dll|
-              link_args << "/DELAYLOAD:#{dll}"
+            dlls = Set(String).new
+            search_result.library_paths.each do |library_path|
+              Crystal::System::LibraryArchive.imported_dlls(library_path).each do |dll|
+                dlls << dll.downcase
+              end
             end
+            dlls.delete "kernel32.dll"
+            dlls.each { |dll| link_args << "/DELAYLOAD:#{dll}" }
           end
         {% end %}
 

--- a/src/compiler/crystal/compiler.cr
+++ b/src/compiler/crystal/compiler.cr
@@ -366,28 +366,30 @@ module Crystal
         @link_flags.try { |flags| link_args << flags }
 
         {% if flag?(:msvc) %}
-          extra_suffix = program.has_flag?("preview_dll") ? "-dynamic" : "-static"
-          search_result = Loader.search_libraries(Process.parse_arguments_windows(link_args.join(' ').gsub('\n', ' ')), extra_suffix: extra_suffix)
-          if not_found = search_result.not_found?
-            error "Cannot locate the .lib files for the following libraries: #{not_found.join(", ")}"
-          end
-
-          link_args = search_result.remaining_args.concat(search_result.library_paths).map { |arg| Process.quote_windows(arg) }
-
-          if !program.has_flag?("no_win32_delay_load")
-            # "LINK : warning LNK4199: /DELAYLOAD:foo.dll ignored; no imports found from foo.dll"
-            # it is harmless to skip this error because not all import libraries are always used, much
-            # less the individual DLLs they refer to
-            link_args << "/IGNORE:4199"
-
-            dlls = Set(String).new
-            search_result.library_paths.each do |library_path|
-              Crystal::System::LibraryArchive.imported_dlls(library_path).each do |dll|
-                dlls << dll.downcase
-              end
+          unless @cross_compile
+            extra_suffix = program.has_flag?("preview_dll") ? "-dynamic" : "-static"
+            search_result = Loader.search_libraries(Process.parse_arguments_windows(link_args.join(' ').gsub('\n', ' ')), extra_suffix: extra_suffix)
+            if not_found = search_result.not_found?
+              error "Cannot locate the .lib files for the following libraries: #{not_found.join(", ")}"
             end
-            dlls.delete "kernel32.dll"
-            dlls.each { |dll| link_args << "/DELAYLOAD:#{dll}" }
+
+            link_args = search_result.remaining_args.concat(search_result.library_paths).map { |arg| Process.quote_windows(arg) }
+
+            if !program.has_flag?("no_win32_delay_load")
+              # "LINK : warning LNK4199: /DELAYLOAD:foo.dll ignored; no imports found from foo.dll"
+              # it is harmless to skip this error because not all import libraries are always used, much
+              # less the individual DLLs they refer to
+              link_args << "/IGNORE:4199"
+
+              dlls = Set(String).new
+              search_result.library_paths.each do |library_path|
+                Crystal::System::LibraryArchive.imported_dlls(library_path).each do |dll|
+                  dlls << dll.downcase
+                end
+              end
+              dlls.delete "kernel32.dll"
+              dlls.each { |dll| link_args << "/DELAYLOAD:#{dll}" }
+            end
           end
         {% end %}
 

--- a/src/compiler/crystal/compiler.cr
+++ b/src/compiler/crystal/compiler.cr
@@ -367,7 +367,7 @@ module Crystal
 
         {% if flag?(:msvc) %}
           extra_suffix = program.has_flag?("preview_dll") ? "-dynamic" : "-static"
-          search_result = Loader.search_libraries(Process.parse_arguments_windows(link_args.join(' ')), extra_suffix: extra_suffix)
+          search_result = Loader.search_libraries(Process.parse_arguments_windows(link_args.join(' ').gsub('\n', ' ')), extra_suffix: extra_suffix)
           if not_found = search_result.not_found?
             error "Cannot locate the .lib files for the following libraries: #{not_found.join(", ")}"
           end

--- a/src/compiler/crystal/loader/msvc.cr
+++ b/src/compiler/crystal/loader/msvc.cr
@@ -50,10 +50,7 @@ class Crystal::Loader
     search_paths, libnames = parse_args(args, search_paths, remaining: result.remaining_args)
 
     libnames.each do |libname|
-      if ::Path[libname].absolute?
-        library_path = library_filename(libname)
-        found_path = File.file?(library_path) ? library_path : nil
-      else
+      if ::Path::SEPARATORS.any? { |separator| libname.includes?(separator) }
         found_path = search_paths.each do |directory|
           if extra_suffix
             library_path = File.join(directory, library_filename(libname + extra_suffix))
@@ -62,6 +59,9 @@ class Crystal::Loader
           library_path = File.join(directory, library_filename(libname))
           break library_path if File.file?(library_path)
         end
+      else
+        library_path = library_filename(libname)
+        found_path = File.file?(library_path) ? library_path : nil
       end
 
       if found_path

--- a/src/compiler/crystal/loader/msvc.cr
+++ b/src/compiler/crystal/loader/msvc.cr
@@ -32,28 +32,44 @@ class Crystal::Loader
     end
   end
 
-  # Returns the list of DLLs imported from the libraries specified in the given
-  # linker arguments. Used by the compiler for delay-loaded DLL support.
-  def self.search_dlls(args : Array(String), *, search_paths : Array(String) = default_search_paths) : Set(String)
-    search_paths, libnames = parse_args(args, search_paths)
-    dlls = Set(String).new
+  struct SearchLibResult
+    getter library_paths = [] of String
+    getter remaining_args = [] of String
+    getter(not_found) { [] of String }
+
+    def not_found?
+      @not_found
+    end
+  end
+
+  # Extracts the command-line arguments from *args* that add libraries and
+  # expands them to their absolute paths. Returns a `SearchLibResult` with those
+  # expanded paths, plus unused arguments and libraries that were not found.
+  def self.search_libraries(args : Array(String), *, search_paths : Array(String) = default_search_paths, extra_suffix : String? = nil) : SearchLibResult
+    result = SearchLibResult.new
+    search_paths, libnames = parse_args(args, search_paths, remaining: result.remaining_args)
 
     libnames.each do |libname|
-      search_paths.each do |directory|
-        library_path = File.join(directory, library_filename(libname))
-        next unless File.file?(library_path)
-
-        Crystal::System::LibraryArchive.imported_dlls(library_path).each do |dll|
-          dlls << dll unless dll.compare("kernel32.dll", case_insensitive: true).zero?
+      found_path = search_paths.each do |directory|
+        if extra_suffix
+          library_path = File.join(directory, library_filename(libname + extra_suffix))
+          break library_path if File.file?(library_path)
         end
-        break
+        library_path = File.join(directory, library_filename(libname))
+        break library_path if File.file?(library_path)
+      end
+
+      if found_path
+        result.library_paths << found_path
+      else
+        result.not_found << libname
       end
     end
 
-    dlls
+    result
   end
 
-  private def self.parse_args(args, search_paths)
+  def self.parse_args(args, search_paths, *, remaining = nil)
     libnames = [] of String
 
     # NOTE: `/LIBPATH`s are prepended before the default paths:
@@ -68,10 +84,14 @@ class Crystal::Loader
         extra_search_paths << lib_path
       elsif !arg.starts_with?('/') && (name = arg.rchop?(".lib"))
         libnames << name
+      elsif remaining
+        remaining << arg
       end
     end
 
     search_paths = extra_search_paths + search_paths
+    search_paths.uniq! &.downcase
+    libnames.uniq! &.downcase
     {search_paths, libnames}
   end
 

--- a/src/compiler/crystal/loader/msvc.cr
+++ b/src/compiler/crystal/loader/msvc.cr
@@ -50,13 +50,18 @@ class Crystal::Loader
     search_paths, libnames = parse_args(args, search_paths, remaining: result.remaining_args)
 
     libnames.each do |libname|
-      found_path = search_paths.each do |directory|
-        if extra_suffix
-          library_path = File.join(directory, library_filename(libname + extra_suffix))
+      if Path[libname].absolute?
+        library_path = library_filename(libname)
+        found_path = File.file?(library_path) ? library_path : nil
+      else
+        found_path = search_paths.each do |directory|
+          if extra_suffix
+            library_path = File.join(directory, library_filename(libname + extra_suffix))
+            break library_path if File.file?(library_path)
+          end
+          library_path = File.join(directory, library_filename(libname))
           break library_path if File.file?(library_path)
         end
-        library_path = File.join(directory, library_filename(libname))
-        break library_path if File.file?(library_path)
       end
 
       if found_path

--- a/src/compiler/crystal/loader/msvc.cr
+++ b/src/compiler/crystal/loader/msvc.cr
@@ -50,7 +50,7 @@ class Crystal::Loader
     search_paths, libnames = parse_args(args, search_paths, remaining: result.remaining_args)
 
     libnames.each do |libname|
-      if Path[libname].absolute?
+      if ::Path[libname].absolute?
         library_path = library_filename(libname)
         found_path = File.file?(library_path) ? library_path : nil
       else

--- a/src/crystal/system/win32/delay_load.cr
+++ b/src/crystal/system/win32/delay_load.cr
@@ -122,11 +122,12 @@ fun __delayLoadHelper2(pidd : LibC::ImgDelayDescr*, ppfnIATEntry : LibC::FARPROC
 
   pitd = idd.pINT + iINT
 
-  dli.dlp.fImportByName = pitd.value.u1.ordinal & LibC::IMAGE_ORDINAL_FLAG == 0
+  import_by_name = (pitd.value.u1.ordinal & LibC::IMAGE_ORDINAL_FLAG) == 0
+  dli.dlp.fImportByName = import_by_name ? 1 : 0
 
-  if dli.dlp.fImportByName
-    import_by_name = p_from_rva(LibC::RVA.new!(pitd.value.u1.addressOfData))
-    dli.dlp.union.szProcName = import_by_name + offsetof(LibC::IMAGE_IMPORT_BY_NAME, @name)
+  if import_by_name
+    image_import_by_name = p_from_rva(LibC::RVA.new!(pitd.value.u1.addressOfData))
+    dli.dlp.union.szProcName = image_import_by_name + offsetof(LibC::IMAGE_IMPORT_BY_NAME, @name)
   else
     dli.dlp.union.dwOrdinal = LibC::DWORD.new!(pitd.value.u1.ordinal & 0xFFFF)
   end

--- a/src/crystal/system/win32/library_archive.cr
+++ b/src/crystal/system/win32/library_archive.cr
@@ -70,8 +70,11 @@ module Crystal::System::LibraryArchive
       sig2 = io.read_bytes(UInt16, IO::ByteFormat::LittleEndian)
       return unless sig2 == 0xFFFF
 
-      # version(2) + machine(2) + time(4) + size(4) + ordinal/hint(2) + flags(2)
-      io.skip(16)
+      version = io.read_bytes(UInt16, IO::ByteFormat::LittleEndian)
+      return unless version == 0 # 1 and 2 are used by object files (ANON_OBJECT_HEADER)
+
+      # machine(2) + time(4) + size(4) + ordinal/hint(2) + flags(2)
+      io.skip(14)
 
       # TODO: is there a way to do this without constructing a temporary string,
       # but with the optimizations present in `IO#gets`?


### PR DESCRIPTION
As described in https://github.com/crystal-lang/crystal/issues/11575#issuecomment-1538685602, this PR makes the Crystal compiler look for `foo-static.lib` before `foo.lib` in each library search directory on Windows, and `foo-dynamic.lib` before `foo.lib` if `-Dpreview_dll` is specified. Only `foo` is affected; any path separator (`/` or `\`) will disable the extra suffix behavior.

This will allow us to finally distribute static and DLL import libraries side-by-side in `CRYSTAL_LIBRARY_PATH`. The next step would be having CI collect the import libraries into `$ORIGIN/lib/*-dynamic.lib`, and the DLLs themselves into `$ORIGIN/*.dll`. The DLLs do not have their own directory since Crystal itself might look them up in the same directory as the executable.

This PR also enables delay-loading for all DLLs, even when `-Dpreview_dll` is not used. This is not a problem for static libraries because they simply do not import DLLs (this is already the case when the Crystal interpreter loads those .lib files).