### PR TITLE
Print error if unable to delay-load DLL on Windows

### DIFF
--- a/src/crystal/system/win32/delay_load.cr
+++ b/src/crystal/system/win32/delay_load.cr
@@ -122,11 +122,12 @@ fun __delayLoadHelper2(pidd : LibC::ImgDelayDescr*, ppfnIATEntry : LibC::FARPROC
 
   pitd = idd.pINT + iINT
 
-  dli.dlp.fImportByName = pitd.value.u1.ordinal & LibC::IMAGE_ORDINAL_FLAG == 0
+  import_by_name = (pitd.value.u1.ordinal & LibC::IMAGE_ORDINAL_FLAG) == 0
+  dli.dlp.fImportByName = import_by_name ? 1 : 0
 
-  if dli.dlp.fImportByName
-    import_by_name = p_from_rva(LibC::RVA.new!(pitd.value.u1.addressOfData))
-    dli.dlp.union.szProcName = import_by_name + offsetof(LibC::IMAGE_IMPORT_BY_NAME, @name)
+  if import_by_name
+    image_import_by_name = p_from_rva(LibC::RVA.new!(pitd.value.u1.addressOfData))
+    dli.dlp.union.szProcName = image_import_by_name + offsetof(LibC::IMAGE_IMPORT_BY_NAME, @name)
   else
     dli.dlp.union.dwOrdinal = LibC::DWORD.new!(pitd.value.u1.ordinal & 0xFFFF)
   end

--- a/src/lib_c/x86_64-windows-msvc/c/errhandlingapi.cr
+++ b/src/lib_c/x86_64-windows-msvc/c/errhandlingapi.cr
@@ -11,6 +11,5 @@ lib LibC
 
   fun GetLastError : DWORD
   fun SetLastError(dwErrCode : DWORD)
-  fun RaiseException(dwExceptionCode : DWORD, dwExceptionFlags : DWORD, nNumberOfArguments : DWORD, lpArguments : ULONG_PTR*)
   fun AddVectoredExceptionHandler(first : DWORD, handler : PVECTORED_EXCEPTION_HANDLER) : Void*
 end

--- a/src/lib_c/x86_64-windows-msvc/c/processenv.cr
+++ b/src/lib_c/x86_64-windows-msvc/c/processenv.cr
@@ -2,6 +2,8 @@ require "c/winnt"
 
 @[Link("kernel32")]
 lib LibC
+  fun GetStdHandle(nStdHandle : DWORD) : HANDLE
+
   fun GetCurrentDirectoryW(nBufferLength : DWORD, lpBuffer : LPWSTR) : DWORD
   fun SetCurrentDirectoryW(lpPathname : LPWSTR) : BOOL
 

--- a/src/lib_c/x86_64-windows-msvc/c/processthreadsapi.cr
+++ b/src/lib_c/x86_64-windows-msvc/c/processthreadsapi.cr
@@ -43,6 +43,7 @@ lib LibC
   fun GetCurrentProcessId : DWORD
   fun OpenProcess(dwDesiredAccess : DWORD, bInheritHandle : BOOL, dwProcessId : DWORD) : HANDLE
   fun GetExitCodeProcess(hProcess : HANDLE, lpExitCode : DWORD*) : BOOL
+  fun ExitProcess(uExitCode : UInt) : NoReturn
   fun TerminateProcess(hProcess : HANDLE, uExitCode : UInt) : BOOL
   fun CreateProcessW(lpApplicationName : LPWSTR, lpCommandLine : LPWSTR,
                      lpProcessAttributes : SECURITY_ATTRIBUTES*, lpThreadAttributes : SECURITY_ATTRIBUTES*,

--- a/src/lib_c/x86_64-windows-msvc/c/winbase.cr
+++ b/src/lib_c/x86_64-windows-msvc/c/winbase.cr
@@ -12,6 +12,10 @@ lib LibC
   FORMAT_MESSAGE_ARGUMENT_ARRAY  = 0x00002000_u32
   FORMAT_MESSAGE_MAX_WIDTH_MASK  = 0x000000FF_u32
 
+  STD_ERROR_HANDLE = DWORD.new!(-12)
+
+  fun FormatMessageA(dwFlags : DWORD, lpSource : Void*, dwMessageId : DWORD, dwLanguageId : DWORD,
+                     lpBuffer : LPSTR, nSize : DWORD, arguments : Void*) : DWORD
   fun FormatMessageW(dwFlags : DWORD, lpSource : Void*, dwMessageId : DWORD, dwLanguageId : DWORD,
                      lpBuffer : LPWSTR, nSize : DWORD, arguments : Void*) : DWORD
 


### PR DESCRIPTION
This replaces the Windows exceptions from the reference implementations entirely, and instead causes the process to exit immediately with exit code 1. This also means that failure to resolve a lib fun at run time is irrecoverable; code that anticipates failure or performs custom error handling must still use `LibC.LoadLibrary` / `LibC.GetProcAddress` or `Crystal::Loader` directly.