### PR TITLE
Disable `Process.pgid` spec on Windows

### DIFF
--- a/spec/std/process_spec.cr
+++ b/spec/std/process_spec.cr
@@ -392,14 +392,16 @@ describe Process do
     process.terminated?.should be_true
   end
 
-  pending_win32 ".pgid" do
-    process = Process.new(*standing_command)
-    Process.pgid(process.pid).should be_a(Int64)
-    process.terminate
-    Process.pgid.should eq(Process.pgid(Process.pid))
-  ensure
-    process.try(&.wait)
-  end
+  {% unless flag?(:win32) %}
+    it ".pgid" do
+      process = Process.new(*standing_command)
+      Process.pgid(process.pid).should be_a(Int64)
+      process.terminate
+      Process.pgid.should eq(Process.pgid(Process.pid))
+    ensure
+      process.try(&.wait)
+    end
+  {% end %}
 
   {% unless flag?(:preview_mt) || flag?(:win32) %}
     describe ".fork" do


### PR DESCRIPTION
`Process.pgid` is not implemented on Windows and there is a pending spec for it. There are some Windows analogs to POSIX process group IDs:

* [Console process groups](https://learn.microsoft.com/en-us/windows/console/console-process-groups) control how processes receive Ctrl+C and Ctrl+Break interrupts. The process group ID is same as the process ID when `CREATE_NEW_PROCESS_GROUP` is given to `CreateProcess`, but it doesn't look like Win32 exposes a way to retrieve the ID itself for an arbitrary child process or whether this option was given to a process.
* [Job objects](https://learn.microsoft.com/en-us/windows/win32/procthread/job-objects) can also be viewed as process groups. They are named Win32 objects so they technically have a string ID rather than a numeric one, but those names are for internal use only.
* Whatever Cygwin does.

It is unlikely there will ever be a suitable analog on Windows. This PR permanently disables this pending spec on Windows.