### PR TITLE
Split Windows library build scripts from CI

### DIFF
--- a/.github/workflows/win.yml
+++ b/.github/workflows/win.yml
@@ -38,7 +38,7 @@ jobs:
             libs/mpir.lib
             libs/yaml.lib
             libs/xml2.lib
-          key: win-libs-${{ hashFiles('.github/workflows/win.yml') }}-${{ hashFiles('etc/win-ci/*.ps1') }}-msvc-${{ env.VSCMD_VER }}
+          key: win-libs-${{ hashFiles('.github/workflows/win.yml', 'etc/win-ci/*.ps1') }}-msvc-${{ env.VSCMD_VER }}
       - name: Build libgc
         if: steps.cache-libs.outputs.cache-hit != 'true'
         run: .\etc\win-ci\build-gc.ps1 -BuildTree deps\gc -Version 8.2.2

--- a/.github/workflows/win.yml
+++ b/.github/workflows/win.yml
@@ -39,26 +39,9 @@ jobs:
             libs/yaml.lib
             libs/xml2.lib
           key: win-libs-${{ hashFiles('.github/workflows/win.yml') }}-msvc-${{ env.VSCMD_VER }}
-      - name: Download libgc
-        if: steps.cache-libs.outputs.cache-hit != 'true'
-        uses: actions/checkout@v3
-        with:
-          repository: ivmai/bdwgc
-          ref: v8.2.2
-          path: bdwgc
-      - name: Download libatomic_ops
-        if: steps.cache-libs.outputs.cache-hit != 'true'
-        uses: actions/checkout@v3
-        with:
-          repository: ivmai/libatomic_ops
-          ref: v7.6.14
-          path: bdwgc/libatomic_ops
       - name: Build libgc
         if: steps.cache-libs.outputs.cache-hit != 'true'
-        working-directory: ./bdwgc
-        run: |
-          cmake . -DBUILD_SHARED_LIBS=OFF -Denable_large_config=ON -DCMAKE_POLICY_DEFAULT_CMP0091=NEW -DCMAKE_MSVC_RUNTIME_LIBRARY=MultiThreaded -DCMAKE_FIND_USE_SYSTEM_ENVIRONMENT_PATH=OFF
-          cmake --build . --config Release
+        run: .\etc\win-ci\build-gc.ps1 -Version 8.2.2
       - name: Download libpcre
         if: steps.cache-libs.outputs.cache-hit != 'true'
         run: |
@@ -72,49 +55,12 @@ jobs:
         run: |
           cmake . -DBUILD_SHARED_LIBS=OFF -DPCRE_SUPPORT_UNICODE_PROPERTIES=ON -DPCRE_SUPPORT_JIT=ON -DPCRE_STATIC_RUNTIME=ON -DCMAKE_FIND_USE_SYSTEM_ENVIRONMENT_PATH=OFF
           cmake --build . --config Release
-      - name: Download libpcre2
-        if: steps.cache-libs.outputs.cache-hit != 'true'
-        uses: actions/checkout@v3
-        with:
-          repository: PCRE2Project/pcre2
-          ref: pcre2-10.42
-          path: pcre2
       - name: Build libpcre2
         if: steps.cache-libs.outputs.cache-hit != 'true'
-        working-directory: ./pcre2
-        run: |
-          cmake . -DBUILD_STATIC_LIBS=ON -DBUILD_SHARED_LIBS=OFF -DPCRE2_STATIC_RUNTIME=ON -DPCRE2_BUILD_PCRE2GREP=OFF -DPCRE2_BUILD_TESTS=OFF -DPCRE2_SUPPORT_UNICODE=ON -DPCRE2_SUPPORT_JIT=ON -DCMAKE_FIND_USE_SYSTEM_ENVIRONMENT_PATH=OFF
-          cmake --build . --config Release
-      - name: Download libiconv
-        if: steps.cache-libs.outputs.cache-hit != 'true'
-        uses: actions/checkout@v3
-        with:
-          repository: pffang/libiconv-for-Windows
-          ref: 1353455a6c4e15c9db6865fd9c2bf7203b59c0ec # master@{2022-10-11}
-          path: libiconv
+        run: .\etc\win-ci\build-pcre2.ps1 -Version 10.42
       - name: Build libiconv
         if: steps.cache-libs.outputs.cache-hit != 'true'
-        working-directory: ./libiconv
-        run: |
-          sed -i 's|__declspec (dllimport) ||' libiconv\include\iconv.h
-
-          echo '<Project>
-            <PropertyGroup>
-              <ForceImportAfterCppTargets>$(MsbuildThisFileDirectory)\Override.props</ForceImportAfterCppTargets>
-            </PropertyGroup>
-          </Project>' > 'Directory.Build.props'
-
-          echo '<Project>
-            <ItemDefinitionGroup>
-              <ClCompile>
-                <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
-                <DebugInformationFormat>None</DebugInformationFormat>
-                <WholeProgramOptimization>false</WholeProgramOptimization>
-              </ClCompile>
-            </ItemDefinitionGroup>
-          </Project>' > 'Override.props'
-
-          MSBuild.exe /p:Platform=x64 /p:Configuration=ReleaseStatic libiconv.vcxproj
+        run: .\etc\win-ci\build-iconv.ps1
       - name: Download libffi
         if: steps.cache-libs.outputs.cache-hit != 'true'
         uses: actions/checkout@v3
@@ -232,11 +178,7 @@ jobs:
       - name: Gather libraries
         if: steps.cache-libs.outputs.cache-hit != 'true'
         run: |
-          mkdir libs
           mv pcre/Release/pcre.lib libs/
-          mv pcre2/Release/pcre2-8-static.lib libs/pcre2-8.lib
-          mv libiconv/output/x64/ReleaseStatic/libiconvStatic.lib libs/iconv.lib
-          mv bdwgc/Release/gc.lib libs/
           mv libffi/win32/vs16_x64/x64/Release/libffi.lib libs/ffi.lib
           mv zlib/Release/zlibstatic.lib libs/z.lib
           mv mpir/lib/x64/Release/mpir.lib libs/

--- a/.github/workflows/win.yml
+++ b/.github/workflows/win.yml
@@ -41,7 +41,7 @@ jobs:
           key: win-libs-${{ hashFiles('.github/workflows/win.yml', 'etc/win-ci/*.ps1') }}-msvc-${{ env.VSCMD_VER }}
       - name: Build libgc
         if: steps.cache-libs.outputs.cache-hit != 'true'
-        run: .\etc\win-ci\build-gc.ps1 -BuildTree deps\gc -Version 8.2.2
+        run: .\etc\win-ci\build-gc.ps1 -BuildTree deps\gc -Version 8.2.2 -AtomicOpsVersion 7.8.0
       - name: Build libpcre
         if: steps.cache-libs.outputs.cache-hit != 'true'
         run: .\etc\win-ci\build-pcre.ps1 -BuildTree deps\pcre -Version 8.45

--- a/.github/workflows/win.yml
+++ b/.github/workflows/win.yml
@@ -38,152 +38,34 @@ jobs:
             libs/mpir.lib
             libs/yaml.lib
             libs/xml2.lib
-          key: win-libs-${{ hashFiles('.github/workflows/win.yml') }}-msvc-${{ env.VSCMD_VER }}
+          key: win-libs-${{ hashFiles('.github/workflows/win.yml') }}-${{ hashFiles('etc/win-ci/*.ps1') }}-msvc-${{ env.VSCMD_VER }}
       - name: Build libgc
         if: steps.cache-libs.outputs.cache-hit != 'true'
-        run: .\etc\win-ci\build-gc.ps1 -Version 8.2.2
-      - name: Download libpcre
-        if: steps.cache-libs.outputs.cache-hit != 'true'
-        run: |
-          iwr https://cs.stanford.edu/pub/exim/pcre/pcre-8.45.zip -OutFile pcre.zip
-          (Get-FileHash -Algorithm SHA256 .\pcre.zip).hash -eq "5b709aa45ea3b8bb73052947200ad187f651a2049158fb5bbfed329e4322a977"
-          7z x pcre.zip
-          mv pcre-* pcre
+        run: .\etc\win-ci\build-gc.ps1 -BuildTree deps\gc -Version 8.2.2
       - name: Build libpcre
         if: steps.cache-libs.outputs.cache-hit != 'true'
-        working-directory: ./pcre
-        run: |
-          cmake . -DBUILD_SHARED_LIBS=OFF -DPCRE_SUPPORT_UNICODE_PROPERTIES=ON -DPCRE_SUPPORT_JIT=ON -DPCRE_STATIC_RUNTIME=ON -DCMAKE_FIND_USE_SYSTEM_ENVIRONMENT_PATH=OFF
-          cmake --build . --config Release
+        run: .\etc\win-ci\build-pcre.ps1 -BuildTree deps\pcre -Version 8.45
       - name: Build libpcre2
         if: steps.cache-libs.outputs.cache-hit != 'true'
-        run: .\etc\win-ci\build-pcre2.ps1 -Version 10.42
+        run: .\etc\win-ci\build-pcre2.ps1 -BuildTree deps\pcre2 -Version 10.42
       - name: Build libiconv
         if: steps.cache-libs.outputs.cache-hit != 'true'
-        run: .\etc\win-ci\build-iconv.ps1
-      - name: Download libffi
-        if: steps.cache-libs.outputs.cache-hit != 'true'
-        uses: actions/checkout@v3
-        with:
-          repository: winlibs/libffi
-          ref: libffi-3.3
-          path: libffi
+        run: .\etc\win-ci\build-iconv.ps1 -BuildTree deps\iconv
       - name: Build libffi
         if: steps.cache-libs.outputs.cache-hit != 'true'
-        working-directory: ./libffi
-        run: |
-          echo '<Project>
-            <PropertyGroup>
-              <ForceImportAfterCppTargets>$(MsbuildThisFileDirectory)\Override.props</ForceImportAfterCppTargets>
-            </PropertyGroup>
-          </Project>' > 'Directory.Build.props'
-
-          echo '<Project>
-            <ItemDefinitionGroup Label="Configuration">
-              <ClCompile>
-                <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
-                <DebugInformationFormat>None</DebugInformationFormat>
-                <WholeProgramOptimization>false</WholeProgramOptimization>
-              </ClCompile>
-              <Link>
-                <GenerateDebugInformation>false</GenerateDebugInformation>
-              </Link>
-            </ItemDefinitionGroup>
-          </Project>' > 'Override.props'
-
-          MSBuild.exe /p:PlatformToolset=v143 /p:Platform=x64 /p:Configuration=Release win32\vs16_x64\libffi-msvc.sln -target:libffi:Rebuild
-      - name: Download zlib
-        if: steps.cache-libs.outputs.cache-hit != 'true'
-        run: |
-          iwr https://github.com/madler/zlib/archive/v1.2.13.zip -OutFile zlib.zip
-          (Get-FileHash -Algorithm SHA256 .\zlib.zip).hash -eq "C2856951BBF30E30861ACE3765595D86BA13F2CF01279D901F6C62258C57F4FF"
-          7z x zlib.zip
-          mv zlib-* zlib
+        run: .\etc\win-ci\build-ffi.ps1 -BuildTree deps\ffi -Version 3.3
       - name: Build zlib
         if: steps.cache-libs.outputs.cache-hit != 'true'
-        working-directory: ./zlib
-        run: |
-          cmake . -DCMAKE_POLICY_DEFAULT_CMP0091=NEW -DCMAKE_MSVC_RUNTIME_LIBRARY=MultiThreaded -DCMAKE_FIND_USE_SYSTEM_ENVIRONMENT_PATH=OFF
-          cmake --build . --config Release
-      - name: Download mpir
-        if: steps.cache-libs.outputs.cache-hit != 'true'
-        uses: actions/checkout@v3
-        with:
-          repository: BrianGladman/mpir
-          ref: 28d01062f62de1218d511c4574da4006f92be3bd  # master@{2022-10-12}
-          path: mpir
+        run: .\etc\win-ci\build-z.ps1 -BuildTree deps\z -Version 1.2.13
       - name: Build mpir
         if: steps.cache-libs.outputs.cache-hit != 'true'
-        working-directory: ./mpir
-        run: |
-          $VsVersion = "vs$((& "${env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\vswhere.exe" -property displayName) -replace '.*\b\d\d(\d\d)\b.*', '$1')"
-
-          echo '<Project>
-            <PropertyGroup>
-              <ForceImportAfterCppTargets>$(MsbuildThisFileDirectory)\Override.props</ForceImportAfterCppTargets>
-            </PropertyGroup>
-          </Project>' > 'msvc\Directory.Build.props'
-
-          echo '<Project>
-            <ItemDefinitionGroup Label="Configuration">
-              <ClCompile>
-                <DebugInformationFormat>None</DebugInformationFormat>
-                <WholeProgramOptimization>false</WholeProgramOptimization>
-              </ClCompile>
-            </ItemDefinitionGroup>
-          </Project>' > 'msvc\Override.props'
-
-          MSBuild.exe /p:Platform=x64 /p:Configuration=Release /p:DefineConstants=MSC_BUILD_DLL ".\msvc\$VsVersion\lib_mpir_gc\lib_mpir_gc.vcxproj"
-      - name: Download libyaml
-        if: steps.cache-libs.outputs.cache-hit != 'true'
-        run: |
-          iwr https://github.com/yaml/libyaml/archive/0.2.5.zip -OutFile libyaml.zip
-          (Get-FileHash -Algorithm SHA256 .\libyaml.zip).hash -eq "14605BAA6DFC0C4D3AB943A46A627413C0388736E453B67FE4E90C9683C8CBC8"
-          7z x libyaml.zip
-          mv libyaml-* libyaml
+        run: .\etc\win-ci\build-mpir.ps1 -BuildTree deps\mpir
       - name: Build libyaml
         if: steps.cache-libs.outputs.cache-hit != 'true'
-        working-directory: ./libyaml
-        run: |
-          cmake . -DCMAKE_POLICY_DEFAULT_CMP0091=NEW -DCMAKE_MSVC_RUNTIME_LIBRARY=MultiThreaded -DCMAKE_FIND_USE_SYSTEM_ENVIRONMENT_PATH=OFF
-          cmake --build . --config Release
-      - name: Download libxml2
-        if: steps.cache-libs.outputs.cache-hit != 'true'
-        uses: actions/checkout@v3
-        with:
-          repository: GNOME/libxml2
-          ref: f507d167f1755b7eaea09fb1a44d29aab828b6d1  # v2.10.3
-          path: libxml2
+        run: .\etc\win-ci\build-yaml.ps1 -BuildTree deps\yaml -Version 0.2.5
       - name: Build libxml2
         if: steps.cache-libs.outputs.cache-hit != 'true'
-        working-directory: ./libxml2
-        run: |
-          cmake . -DBUILD_SHARED_LIBS=OFF -DLIBXML2_WITH_PROGRAMS=OFF -DLIBXML2_WITH_HTTP=OFF -DLIBXML2_WITH_FTP=OFF -DLIBXML2_WITH_TESTS=OFF -DCMAKE_POLICY_DEFAULT_CMP0091=NEW -DCMAKE_MSVC_RUNTIME_LIBRARY=MultiThreaded -DCMAKE_FIND_USE_SYSTEM_ENVIRONMENT_PATH=OFF -DLIBXML2_WITH_ICONV=OFF -DLIBXML2_WITH_LZMA=OFF -DLIBXML2_WITH_PYTHON=OFF -DLIBXML2_WITH_ZLIB=OFF
-
-          echo '<Project>
-            <PropertyGroup>
-              <ForceImportAfterCppTargets>$(MsbuildThisFileDirectory)\Override.props</ForceImportAfterCppTargets>
-            </PropertyGroup>
-          </Project>' > 'Directory.Build.props'
-
-          echo '<Project>
-            <ItemDefinitionGroup>
-              <ClCompile>
-                <PreprocessorDefinitions>LIBXML_STATIC;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-              </ClCompile>
-            </ItemDefinitionGroup>
-          </Project>' > 'Override.props'
-
-          cmake --build . --config Release
-      - name: Gather libraries
-        if: steps.cache-libs.outputs.cache-hit != 'true'
-        run: |
-          mv pcre/Release/pcre.lib libs/
-          mv libffi/win32/vs16_x64/x64/Release/libffi.lib libs/ffi.lib
-          mv zlib/Release/zlibstatic.lib libs/z.lib
-          mv mpir/lib/x64/Release/mpir.lib libs/
-          mv libyaml/Release/yaml.lib libs/
-          mv libxml2/Release/libxml2s.lib libs/xml2.lib
+        run: .\etc\win-ci\build-xml2.ps1 -BuildTree deps\xml2 -Version 2.11.3
 
       - name: Cache OpenSSL
         id: cache-openssl
@@ -193,32 +75,13 @@ jobs:
             libs/crypto.lib
             libs/ssl.lib
             libs/openssl_VERSION
-          key: win-openssl-libs-3.0.7-msvc-${{ env.VSCMD_VER }}
+          key: win-openssl-libs-3.0.7-${{ hashFiles('etc/win-ci/build-openssl.ps1') }}-msvc-${{ env.VSCMD_VER }}
       - name: Set up NASM
         if: steps.cache-openssl.outputs.cache-hit != 'true'
         uses: ilammy/setup-nasm@321e6ed62a1fc77024a3bd853deb33645e8b22c4 # v1.4.0
-      - name: Download OpenSSL
-        if: steps.cache-openssl.outputs.cache-hit != 'true'
-        run: |
-          iwr https://www.openssl.org/source/openssl-3.0.7.tar.gz -OutFile openssl.tar.gz
-          (Get-FileHash -Algorithm SHA256 .\openssl.tar.gz).hash -eq "83049d042a260e696f62406ac5c08bf706fd84383f945cf21bd61e9ed95c396e"
-          7z x openssl.tar.gz
-          7z x openssl.tar
-          mv openssl-* openssl
       - name: Build OpenSSL
         if: steps.cache-openssl.outputs.cache-hit != 'true'
-        working-directory: ./openssl
-        run: |
-          sed -i 's|/Zi /Fd.*\.pdb||' Configurations/10-main.conf
-          sed -i 's|/debug|/debug:none|' Configurations/10-main.conf
-          perl Configure VC-WIN64A /MT -static no-tests --with-zlib-lib=..\zlib\Release --with-zlib-include=..\zlib
-          nmake
-      - name: Gather OpenSSL
-        if: steps.cache-openssl.outputs.cache-hit != 'true'
-        run: |
-          cp openssl/libcrypto.lib libs/crypto.lib
-          cp openssl/libssl.lib libs/ssl.lib
-          [IO.File]::WriteAllLines("libs/openssl_VERSION", "3.0.7")
+        run: .\etc\win-ci\build-openssl.ps1 -BuildTree deps\openssl -Version 3.1.0
 
       - name: Cache LLVM
         id: cache-llvm

--- a/.github/workflows/win.yml
+++ b/.github/workflows/win.yml
@@ -75,7 +75,7 @@ jobs:
             libs/crypto.lib
             libs/ssl.lib
             libs/openssl_VERSION
-          key: win-openssl-libs-3.0.7-${{ hashFiles('etc/win-ci/build-openssl.ps1') }}-msvc-${{ env.VSCMD_VER }}
+          key: win-openssl-libs-3.1.0-${{ hashFiles('etc/win-ci/build-openssl.ps1') }}-msvc-${{ env.VSCMD_VER }}
       - name: Set up NASM
         if: steps.cache-openssl.outputs.cache-hit != 'true'
         uses: ilammy/setup-nasm@321e6ed62a1fc77024a3bd853deb33645e8b22c4 # v1.4.0

--- a/etc/win-ci/build-ffi.ps1
+++ b/etc/win-ci/build-ffi.ps1
@@ -7,7 +7,7 @@ param(
 . "$(Split-Path -Parent $MyInvocation.MyCommand.Path)\setup.ps1"
 
 [void](New-Item -Name (Split-Path -Parent $BuildTree) -ItemType Directory -Force)
-Setup-Git -Path $BuildTree -Url https://github.com/winlibs/libffi.git -Branch libffi-$Version
+Setup-Git -Path $BuildTree -Url https://github.com/winlibs/libffi.git -Ref libffi-$Version
 
 Run-InDirectory $BuildTree {
     if ($Dynamic) {

--- a/etc/win-ci/build-gc.ps1
+++ b/etc/win-ci/build-gc.ps1
@@ -7,8 +7,8 @@ param(
 . "$(Split-Path -Parent $MyInvocation.MyCommand.Path)\setup.ps1"
 
 [void](New-Item -Name (Split-Path -Parent $BuildTree) -ItemType Directory -Force)
-Setup-Git -Path $BuildTree -Url https://github.com/ivmai/bdwgc.git -Branch v$Version
-Setup-Git -Path $BuildTree\libatomic_ops -Url https://github.com/ivmai/libatomic_ops.git -Branch v7.8.0
+Setup-Git -Path $BuildTree -Url https://github.com/ivmai/bdwgc.git -Ref v$Version
+Setup-Git -Path $BuildTree\libatomic_ops -Url https://github.com/ivmai/libatomic_ops.git -Ref v7.8.0
 
 Run-InDirectory $BuildTree {
     $args = "-Dbuild_cord=OFF -Denable_large_config=ON -DCMAKE_POLICY_DEFAULT_CMP0091=NEW -DCMAKE_FIND_USE_SYSTEM_ENVIRONMENT_PATH=OFF"

--- a/etc/win-ci/build-gc.ps1
+++ b/etc/win-ci/build-gc.ps1
@@ -1,0 +1,32 @@
+param(
+    [Parameter(Mandatory)] [string] $Version,
+    [switch] $Dynamic
+)
+
+. "$(Split-Path -Parent $MyInvocation.MyCommand.Path)\setup.ps1"
+
+Setup-Git -Path deps\gc -Url https://github.com/ivmai/bdwgc.git -Branch v$Version
+Setup-Git -Path deps\gc\libatomic_ops -Url https://github.com/ivmai/libatomic_ops.git -Branch v7.8.0
+
+Run-InDirectory deps\gc {
+    $args = "-Dbuild_cord=OFF -Denable_large_config=ON -DCMAKE_POLICY_DEFAULT_CMP0091=NEW -DCMAKE_FIND_USE_SYSTEM_ENVIRONMENT_PATH=OFF"
+    if ($Dynamic) {
+        $args = "-DBUILD_SHARED_LIBS=ON $args"
+    } else {
+        $args = "-DBUILD_SHARED_LIBS=OFF -DCMAKE_MSVC_RUNTIME_LIBRARY=MultiThreaded $args"
+    }
+    & $cmake . $args.split(' ')
+    & $cmake --build . --config Release
+    if (-not $?) {
+        Write-Host "Error: Failed to build libgc" -ForegroundColor Red
+        Exit 1
+    }
+}
+
+if ($Dynamic) {
+    mv -Force deps\gc\Release\gc.lib libs\gc-dynamic.lib
+    mv -Force deps\gc\Release\gc.dll dlls\
+} else {
+    mv -Force deps\gc\Release\gc.lib libs\
+}
+

--- a/etc/win-ci/build-gc.ps1
+++ b/etc/win-ci/build-gc.ps1
@@ -1,6 +1,7 @@
 param(
     [Parameter(Mandatory)] [string] $BuildTree,
     [Parameter(Mandatory)] [string] $Version,
+    [Parameter(Mandatory)] [string] $AtomicOpsVersion,
     [switch] $Dynamic
 )
 
@@ -8,7 +9,7 @@ param(
 
 [void](New-Item -Name (Split-Path -Parent $BuildTree) -ItemType Directory -Force)
 Setup-Git -Path $BuildTree -Url https://github.com/ivmai/bdwgc.git -Ref v$Version
-Setup-Git -Path $BuildTree\libatomic_ops -Url https://github.com/ivmai/libatomic_ops.git -Ref v7.8.0
+Setup-Git -Path $BuildTree\libatomic_ops -Url https://github.com/ivmai/libatomic_ops.git -Ref v$AtomicOpsVersion
 
 Run-InDirectory $BuildTree {
     $args = "-Dbuild_cord=OFF -Denable_large_config=ON -DCMAKE_POLICY_DEFAULT_CMP0091=NEW -DCMAKE_FIND_USE_SYSTEM_ENVIRONMENT_PATH=OFF"

--- a/etc/win-ci/build-iconv.ps1
+++ b/etc/win-ci/build-iconv.ps1
@@ -30,9 +30,9 @@ Run-InDirectory $BuildTree {
                 <GenerateDebugInformation>false</GenerateDebugInformation>
             </Link>
         </ItemDefinitionGroup>
-        <ItemDefinitionGroup Condition=`"'`$(Configuration)'=='ReleaseStatic'`">
+        <ItemDefinitionGroup Condition=`"'`$(Configuration)'=='Release'`">
             <ClCompile>
-                <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
+                <RuntimeLibrary>MultiThreadedDLL</RuntimeLibrary>
             </ClCompile>
         </ItemDefinitionGroup>
     </Project>" > 'Override.props'

--- a/etc/win-ci/build-iconv.ps1
+++ b/etc/win-ci/build-iconv.ps1
@@ -6,7 +6,7 @@ param(
 . "$(Split-Path -Parent $MyInvocation.MyCommand.Path)\setup.ps1"
 
 [void](New-Item -Name (Split-Path -Parent $BuildTree) -ItemType Directory -Force)
-Setup-Git -Path $BuildTree -Url https://github.com/pffang/libiconv-for-Windows.git -Commit 1353455a6c4e15c9db6865fd9c2bf7203b59c0ec # master@{2022-10-11}
+Setup-Git -Path $BuildTree -Url https://github.com/pffang/libiconv-for-Windows.git -Ref 1353455a6c4e15c9db6865fd9c2bf7203b59c0ec # master@{2022-10-11}
 
 Run-InDirectory $BuildTree {
     Replace-Text libiconv\include\iconv.h '__declspec (dllimport) ' ''

--- a/etc/win-ci/build-iconv.ps1
+++ b/etc/win-ci/build-iconv.ps1
@@ -1,0 +1,51 @@
+param(
+    [switch] $Dynamic
+)
+
+. "$(Split-Path -Parent $MyInvocation.MyCommand.Path)\setup.ps1"
+
+Setup-Git -Path deps\iconv -Url https://github.com/pffang/libiconv-for-Windows.git -Commit 1353455a6c4e15c9db6865fd9c2bf7203b59c0ec # master@{2022-10-11}
+
+Run-InDirectory deps\iconv {
+    Replace-Text .\libiconv\include\iconv.h '__declspec (dllimport) ' ''
+
+    echo "<Project>
+        <PropertyGroup>
+            <ForceImportAfterCppTargets>`$(MsbuildThisFileDirectory)\Override.props</ForceImportAfterCppTargets>
+        </PropertyGroup>
+    </Project>" > 'Directory.Build.props'
+
+    echo "<Project>
+        <ItemDefinitionGroup>
+            <ClCompile>
+                <DebugInformationFormat>None</DebugInformationFormat>
+                <WholeProgramOptimization>false</WholeProgramOptimization>
+            </ClCompile>
+            <Link>
+                <GenerateDebugInformation>false</GenerateDebugInformation>
+            </Link>
+        </ItemDefinitionGroup>
+        <ItemDefinitionGroup Condition=`"'`$(Configuration)'=='ReleaseStatic'`">
+            <ClCompile>
+                <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
+            </ClCompile>
+        </ItemDefinitionGroup>
+    </Project>" > 'Override.props'
+
+    if ($Dynamic) {
+        MSBuild.exe /p:Platform=x64 /p:Configuration=Release libiconv.vcxproj
+    } else {
+        MSBuild.exe /p:Platform=x64 /p:Configuration=ReleaseStatic libiconv.vcxproj
+    }
+    if (-not $?) {
+        Write-Host "Error: Failed to build libiconv" -ForegroundColor Red
+        Exit 1
+    }
+}
+
+if ($Dynamic) {
+    mv -Force deps\iconv\output\x64\Release\libiconv.lib libs\iconv-dynamic.lib
+    mv -Force deps\iconv\output\x64\Release\libiconv.dll dlls\
+} else {
+    mv -Force deps\iconv\output\x64\ReleaseStatic\libiconvStatic.lib libs\iconv.lib
+}

--- a/etc/win-ci/build-mpir.ps1
+++ b/etc/win-ci/build-mpir.ps1
@@ -6,7 +6,7 @@ param(
 . "$(Split-Path -Parent $MyInvocation.MyCommand.Path)\setup.ps1"
 
 [void](New-Item -Name (Split-Path -Parent $BuildTree) -ItemType Directory -Force)
-Setup-Git -Path $BuildTree -Url https://github.com/BrianGladman/mpir.git -Commit dc82b0475dea84d5338356e49176c40be03a5bdf # master@{2023-02-10}
+Setup-Git -Path $BuildTree -Url https://github.com/BrianGladman/mpir.git -Ref dc82b0475dea84d5338356e49176c40be03a5bdf # master@{2023-02-10}
 
 Run-InDirectory $BuildTree {
     $vsVersion = "vs$((& "${env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\vswhere.exe" -property displayName) -replace '.*\b\d\d(\d\d)\b.*', '$1')"

--- a/etc/win-ci/build-mpir.ps1
+++ b/etc/win-ci/build-mpir.ps1
@@ -1,0 +1,48 @@
+param(
+    [Parameter(Mandatory)] [string] $BuildTree,
+    [switch] $Dynamic
+)
+
+. "$(Split-Path -Parent $MyInvocation.MyCommand.Path)\setup.ps1"
+
+[void](New-Item -Name (Split-Path -Parent $BuildTree) -ItemType Directory -Force)
+Setup-Git -Path $BuildTree -Url https://github.com/BrianGladman/mpir.git -Commit dc82b0475dea84d5338356e49176c40be03a5bdf # master@{2023-02-10}
+
+Run-InDirectory $BuildTree {
+    $vsVersion = "vs$((& "${env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\vswhere.exe" -property displayName) -replace '.*\b\d\d(\d\d)\b.*', '$1')"
+
+    echo '<Project>
+        <PropertyGroup>
+            <ForceImportAfterCppTargets>$(MsbuildThisFileDirectory)\Override.props</ForceImportAfterCppTargets>
+        </PropertyGroup>
+    </Project>' > 'msvc\Directory.Build.props'
+
+    echo '<Project>
+        <ItemDefinitionGroup>
+            <ClCompile>
+                <DebugInformationFormat>None</DebugInformationFormat>
+                <WholeProgramOptimization>false</WholeProgramOptimization>
+            </ClCompile>
+            <Link>
+                <GenerateDebugInformation>false</GenerateDebugInformation>
+            </Link>
+        </ItemDefinitionGroup>
+    </Project>' > 'msvc\Override.props'
+
+    if ($Dynamic) {
+        MSBuild.exe /p:Platform=x64 /p:Configuration=Release "msvc\$vsVersion\dll_mpir_gc\dll_mpir_gc.vcxproj"
+    } else {
+        MSBuild.exe /p:Platform=x64 /p:Configuration=Release "msvc\$vsVersion\lib_mpir_gc\lib_mpir_gc.vcxproj"
+    }
+    if (-not $?) {
+        Write-Host "Error: Failed to build MPIR" -ForegroundColor Red
+        Exit 1
+    }
+}
+
+if ($Dynamic) {
+    mv -Force $BuildTree\dll\x64\Release\mpir.lib libs\mpir-dynamic.lib
+    mv -Force $BuildTree\dll\x64\Release\mpir.dll dlls\
+} else {
+    mv -Force $BuildTree\lib\x64\Release\mpir.lib libs\
+}

--- a/etc/win-ci/build-openssl.ps1
+++ b/etc/win-ci/build-openssl.ps1
@@ -32,7 +32,7 @@ if ($Dynamic) {
     mv -Force $BuildTree\libcrypto-$major-x64.dll dlls\
     mv -Force $BuildTree\libssl-$major-x64.dll dlls\
 } else {
-    mv -Force $BuildTree\libcrypto.lib libs\
-    mv -Force $BuildTree\libssl.lib libs\
+    mv -Force $BuildTree\libcrypto.lib libs\crypto.lib
+    mv -Force $BuildTree\libssl.lib libs\ssl.lib
 }
 [IO.File]::WriteAllLines("libs\openssl_VERSION", $Version)

--- a/etc/win-ci/build-openssl.ps1
+++ b/etc/win-ci/build-openssl.ps1
@@ -7,7 +7,7 @@ param(
 . "$(Split-Path -Parent $MyInvocation.MyCommand.Path)\setup.ps1"
 
 [void](New-Item -Name (Split-Path -Parent $BuildTree) -ItemType Directory -Force)
-Setup-Git -Path $BuildTree -Url https://github.com/openssl/openssl -Branch openssl-$Version
+Setup-Git -Path $BuildTree -Url https://github.com/openssl/openssl -Ref openssl-$Version
 
 Run-InDirectory $BuildTree {
     Replace-Text Configurations\10-main.conf '/Zi /Fdossl_static.pdb' ''

--- a/etc/win-ci/build-openssl.ps1
+++ b/etc/win-ci/build-openssl.ps1
@@ -1,0 +1,38 @@
+param(
+    [Parameter(Mandatory)] [string] $BuildTree,
+    [Parameter(Mandatory)] [string] $Version,
+    [switch] $Dynamic
+)
+
+. "$(Split-Path -Parent $MyInvocation.MyCommand.Path)\setup.ps1"
+
+[void](New-Item -Name (Split-Path -Parent $BuildTree) -ItemType Directory -Force)
+Setup-Git -Path $BuildTree -Url https://github.com/openssl/openssl -Branch openssl-$Version
+
+Run-InDirectory $BuildTree {
+    Replace-Text Configurations\10-main.conf '/Zi /Fdossl_static.pdb' ''
+    Replace-Text Configurations\10-main.conf '"/nologo /debug"' '"/nologo /debug:none"'
+
+    if ($Dynamic) {
+        perl Configure VC-WIN64A no-tests
+    } else {
+        perl Configure VC-WIN64A /MT -static no-tests
+    }
+    nmake
+    if (-not $?) {
+        Write-Host "Error: Failed to build OpenSSL" -ForegroundColor Red
+        Exit 1
+    }
+}
+
+if ($Dynamic) {
+    $major = $Version -replace '\..*', ''
+    mv -Force $BuildTree\libcrypto.lib libs\crypto-dynamic.lib
+    mv -Force $BuildTree\libssl.lib libs\ssl-dynamic.lib
+    mv -Force $BuildTree\libcrypto-$major-x64.dll dlls\
+    mv -Force $BuildTree\libssl-$major-x64.dll dlls\
+} else {
+    mv -Force $BuildTree\libcrypto.lib libs\
+    mv -Force $BuildTree\libssl.lib libs\
+}
+[IO.File]::WriteAllLines("libs\openssl_VERSION", $Version)

--- a/etc/win-ci/build-pcre.ps1
+++ b/etc/win-ci/build-pcre.ps1
@@ -4,11 +4,25 @@ param(
     [switch] $Dynamic
 )
 
+function Find-7Zip {
+    $Path = Get-Command "7z" -CommandType Application -TotalCount 1 -ErrorAction SilentlyContinue
+    if ($Path) { return $Path.Path }
+
+    $Path = "$env:ProgramFiles\7-Zip\7z.exe"
+    if (Test-Path -Path $Path -PathType Leaf) { return $Path }
+
+    $Path = "${env:ProgramFiles(x86)}\7-Zip\7z.exe"
+    if (Test-Path -Path $Path -PathType Leaf) { return $Path }
+
+    Write-Host "Error: Cannot locate 7-Zip executable" -ForegroundColor Red
+    Exit 1
+}
+
 . "$(Split-Path -Parent $MyInvocation.MyCommand.Path)\setup.ps1"
 
 [void](New-Item -Name (Split-Path -Parent $BuildTree) -ItemType Directory -Force)
 Invoke-WebRequest https://cs.stanford.edu/pub/exim/pcre/pcre-$Version.zip -OutFile pcre.zip
-& $7z x pcre.zip
+& (Find-7Zip) x pcre.zip
 mv pcre-* $BuildTree
 rm pcre.zip
 

--- a/etc/win-ci/build-pcre.ps1
+++ b/etc/win-ci/build-pcre.ps1
@@ -1,0 +1,35 @@
+param(
+    [Parameter(Mandatory)] [string] $BuildTree,
+    [Parameter(Mandatory)] [string] $Version,
+    [switch] $Dynamic
+)
+
+. "$(Split-Path -Parent $MyInvocation.MyCommand.Path)\setup.ps1"
+
+[void](New-Item -Name (Split-Path -Parent $BuildTree) -ItemType Directory -Force)
+Invoke-WebRequest https://cs.stanford.edu/pub/exim/pcre/pcre-$Version.zip -OutFile pcre.zip
+& $7z x pcre.zip
+mv pcre-* $BuildTree
+rm pcre.zip
+
+Run-InDirectory $BuildTree {
+    $args = "-DPCRE_BUILD_PCREGREP=OFF -DPCRE_BUILD_TESTS=OFF -DPCRE_BUILD_PCRECPP=OFF -DPCRE_SUPPORT_JIT=ON -DPCRE_SUPPORT_UNICODE_PROPERTIES=ON -DCMAKE_FIND_USE_SYSTEM_ENVIRONMENT_PATH=OFF"
+    if ($Dynamic) {
+        $args = "-DBUILD_SHARED_LIBS=ON $args"
+    } else {
+        $args = "-DBUILD_SHARED_LIBS=OFF -DPCRE_STATIC_RUNTIME=ON $args"
+    }
+    & $cmake . $args.split(' ')
+    & $cmake --build . --config Release
+    if (-not $?) {
+        Write-Host "Error: Failed to build PCRE" -ForegroundColor Red
+        Exit 1
+    }
+}
+
+if ($Dynamic) {
+    mv -Force $BuildTree\Release\pcre.lib libs\pcre-dynamic.lib
+    mv -Force $BuildTree\Release\pcre.dll dlls\
+} else {
+    mv -Force $BuildTree\Release\pcre.lib libs\
+}

--- a/etc/win-ci/build-pcre2.ps1
+++ b/etc/win-ci/build-pcre2.ps1
@@ -7,7 +7,7 @@ param(
 . "$(Split-Path -Parent $MyInvocation.MyCommand.Path)\setup.ps1"
 
 [void](New-Item -Name (Split-Path -Parent $BuildTree) -ItemType Directory -Force)
-Setup-Git -Path $BuildTree -Url https://github.com/PCRE2Project/pcre2.git -Branch pcre2-$Version
+Setup-Git -Path $BuildTree -Url https://github.com/PCRE2Project/pcre2.git -Ref pcre2-$Version
 
 Run-InDirectory $BuildTree {
     $args = "-DPCRE2_BUILD_PCRE2GREP=OFF -DPCRE2_BUILD_TESTS=OFF -DPCRE2_SUPPORT_UNICODE=ON -DPCRE2_SUPPORT_JIT=ON -DCMAKE_FIND_USE_SYSTEM_ENVIRONMENT_PATH=OFF"

--- a/etc/win-ci/build-pcre2.ps1
+++ b/etc/win-ci/build-pcre2.ps1
@@ -1,0 +1,30 @@
+param(
+    [Parameter(Mandatory)] [string] $Version,
+    [switch] $Dynamic
+)
+
+. "$(Split-Path -Parent $MyInvocation.MyCommand.Path)\setup.ps1"
+
+Setup-Git -Path deps\pcre2 -Url https://github.com/PCRE2Project/pcre2.git -Branch pcre2-$Version
+
+Run-InDirectory deps\pcre2 {
+    $args = "-DPCRE2_BUILD_PCRE2GREP=OFF -DPCRE2_BUILD_TESTS=OFF -DPCRE2_SUPPORT_UNICODE=ON -DPCRE2_SUPPORT_JIT=ON -DCMAKE_FIND_USE_SYSTEM_ENVIRONMENT_PATH=OFF"
+    if ($Dynamic) {
+        $args = "-DBUILD_STATIC_LIBS=OFF -DBUILD_SHARED_LIBS=ON $args"
+    } else {
+        $args = "-DBUILD_STATIC_LIBS=ON -DBUILD_SHARED_LIBS=OFF -DPCRE2_STATIC_RUNTIME=ON $args"
+    }
+    & $cmake . $args.split(' ')
+    & $cmake --build . --config Release
+    if (-not $?) {
+        Write-Host "Error: Failed to build libpcre2" -ForegroundColor Red
+        Exit 1
+    }
+}
+
+if ($Dynamic) {
+    mv -Force deps\pcre2\Release\pcre2-8.lib libs\pcre2-8-dynamic.lib
+    mv -Force deps\pcre2\Release\pcre2-8.dll dlls\
+} else {
+    mv -Force deps\pcre2\Release\pcre2-8-static.lib libs\pcre2-8.lib
+}

--- a/etc/win-ci/build-xml2.ps1
+++ b/etc/win-ci/build-xml2.ps1
@@ -7,7 +7,7 @@ param(
 . "$(Split-Path -Parent $MyInvocation.MyCommand.Path)\setup.ps1"
 
 [void](New-Item -Name (Split-Path -Parent $BuildTree) -ItemType Directory -Force)
-Setup-Git -Path $BuildTree -Url https://gitlab.gnome.org/GNOME/libxml2.git -Branch v$Version
+Setup-Git -Path $BuildTree -Url https://gitlab.gnome.org/GNOME/libxml2.git -Ref v$Version
 
 Run-InDirectory $BuildTree {
     $args = "-DLIBXML2_WITH_TESTS=OFF -DLIBXML2_WITH_PROGRAMS=OFF -DLIBXML2_WITH_HTTP=OFF -DLIBXML2_WITH_FTP=OFF -DLIBXML2_WITH_ICONV=OFF -DLIBXML2_WITH_LZMA=OFF -DLIBXML2_WITH_PYTHON=OFF -DLIBXML2_WITH_ZLIB=OFF -DCMAKE_FIND_USE_SYSTEM_ENVIRONMENT_PATH=OFF"

--- a/etc/win-ci/build-xml2.ps1
+++ b/etc/win-ci/build-xml2.ps1
@@ -7,11 +7,10 @@ param(
 . "$(Split-Path -Parent $MyInvocation.MyCommand.Path)\setup.ps1"
 
 [void](New-Item -Name (Split-Path -Parent $BuildTree) -ItemType Directory -Force)
-Setup-Git -Path $BuildTree -Url https://github.com/ivmai/bdwgc.git -Branch v$Version
-Setup-Git -Path $BuildTree\libatomic_ops -Url https://github.com/ivmai/libatomic_ops.git -Branch v7.8.0
+Setup-Git -Path $BuildTree -Url https://gitlab.gnome.org/GNOME/libxml2.git -Branch v$Version
 
 Run-InDirectory $BuildTree {
-    $args = "-Dbuild_cord=OFF -Denable_large_config=ON -DCMAKE_POLICY_DEFAULT_CMP0091=NEW -DCMAKE_FIND_USE_SYSTEM_ENVIRONMENT_PATH=OFF"
+    $args = "-DLIBXML2_WITH_TESTS=OFF -DLIBXML2_WITH_PROGRAMS=OFF -DLIBXML2_WITH_HTTP=OFF -DLIBXML2_WITH_FTP=OFF -DLIBXML2_WITH_ICONV=OFF -DLIBXML2_WITH_LZMA=OFF -DLIBXML2_WITH_PYTHON=OFF -DLIBXML2_WITH_ZLIB=OFF -DCMAKE_FIND_USE_SYSTEM_ENVIRONMENT_PATH=OFF"
     if ($Dynamic) {
         $args = "-DBUILD_SHARED_LIBS=ON $args"
     } else {
@@ -20,15 +19,14 @@ Run-InDirectory $BuildTree {
     & $cmake . $args.split(' ')
     & $cmake --build . --config Release
     if (-not $?) {
-        Write-Host "Error: Failed to build libgc" -ForegroundColor Red
+        Write-Host "Error: Failed to build libxml2" -ForegroundColor Red
         Exit 1
     }
 }
 
 if ($Dynamic) {
-    mv -Force $BuildTree\Release\gc.lib libs\gc-dynamic.lib
-    mv -Force $BuildTree\Release\gc.dll dlls\
+    mv -Force $BuildTree\Release\libxml2.lib libs\xml2-dynamic.lib
+    mv -Force $BuildTree\Release\libxml2.dll dlls\
 } else {
-    mv -Force $BuildTree\Release\gc.lib libs\
+    mv -Force $BuildTree\Release\libxml2s.lib libs\xml2.lib
 }
-

--- a/etc/win-ci/build-yaml.ps1
+++ b/etc/win-ci/build-yaml.ps1
@@ -7,11 +7,10 @@ param(
 . "$(Split-Path -Parent $MyInvocation.MyCommand.Path)\setup.ps1"
 
 [void](New-Item -Name (Split-Path -Parent $BuildTree) -ItemType Directory -Force)
-Setup-Git -Path $BuildTree -Url https://github.com/ivmai/bdwgc.git -Branch v$Version
-Setup-Git -Path $BuildTree\libatomic_ops -Url https://github.com/ivmai/libatomic_ops.git -Branch v7.8.0
+Setup-Git -Path $BuildTree -Url https://github.com/yaml/libyaml.git -Branch $Version
 
 Run-InDirectory $BuildTree {
-    $args = "-Dbuild_cord=OFF -Denable_large_config=ON -DCMAKE_POLICY_DEFAULT_CMP0091=NEW -DCMAKE_FIND_USE_SYSTEM_ENVIRONMENT_PATH=OFF"
+    $args = "-DBUILD_TESTING=OFF -DCMAKE_POLICY_DEFAULT_CMP0091=NEW -DCMAKE_FIND_USE_SYSTEM_ENVIRONMENT_PATH=OFF"
     if ($Dynamic) {
         $args = "-DBUILD_SHARED_LIBS=ON $args"
     } else {
@@ -20,15 +19,14 @@ Run-InDirectory $BuildTree {
     & $cmake . $args.split(' ')
     & $cmake --build . --config Release
     if (-not $?) {
-        Write-Host "Error: Failed to build libgc" -ForegroundColor Red
+        Write-Host "Error: Failed to build libyaml" -ForegroundColor Red
         Exit 1
     }
 }
 
 if ($Dynamic) {
-    mv -Force $BuildTree\Release\gc.lib libs\gc-dynamic.lib
-    mv -Force $BuildTree\Release\gc.dll dlls\
+    mv -Force $BuildTree\Release\yaml.lib libs\yaml-dynamic.lib
+    mv -Force $BuildTree\Release\yaml.dll dlls\
 } else {
-    mv -Force $BuildTree\Release\gc.lib libs\
+    mv -Force $BuildTree\Release\yaml.lib libs\
 }
-

--- a/etc/win-ci/build-yaml.ps1
+++ b/etc/win-ci/build-yaml.ps1
@@ -7,7 +7,7 @@ param(
 . "$(Split-Path -Parent $MyInvocation.MyCommand.Path)\setup.ps1"
 
 [void](New-Item -Name (Split-Path -Parent $BuildTree) -ItemType Directory -Force)
-Setup-Git -Path $BuildTree -Url https://github.com/yaml/libyaml.git -Branch $Version
+Setup-Git -Path $BuildTree -Url https://github.com/yaml/libyaml.git -Ref $Version
 
 Run-InDirectory $BuildTree {
     $args = "-DBUILD_TESTING=OFF -DCMAKE_POLICY_DEFAULT_CMP0091=NEW -DCMAKE_FIND_USE_SYSTEM_ENVIRONMENT_PATH=OFF"

--- a/etc/win-ci/build-z.ps1
+++ b/etc/win-ci/build-z.ps1
@@ -7,28 +7,26 @@ param(
 . "$(Split-Path -Parent $MyInvocation.MyCommand.Path)\setup.ps1"
 
 [void](New-Item -Name (Split-Path -Parent $BuildTree) -ItemType Directory -Force)
-Setup-Git -Path $BuildTree -Url https://github.com/ivmai/bdwgc.git -Branch v$Version
-Setup-Git -Path $BuildTree\libatomic_ops -Url https://github.com/ivmai/libatomic_ops.git -Branch v7.8.0
+Setup-Git -Path $BuildTree -Url https://github.com/madler/zlib.git -Branch v$Version
 
 Run-InDirectory $BuildTree {
-    $args = "-Dbuild_cord=OFF -Denable_large_config=ON -DCMAKE_POLICY_DEFAULT_CMP0091=NEW -DCMAKE_FIND_USE_SYSTEM_ENVIRONMENT_PATH=OFF"
+    $args = "-DCMAKE_POLICY_DEFAULT_CMP0091=NEW -DCMAKE_FIND_USE_SYSTEM_ENVIRONMENT_PATH=OFF"
     if ($Dynamic) {
         $args = "-DBUILD_SHARED_LIBS=ON $args"
     } else {
         $args = "-DBUILD_SHARED_LIBS=OFF -DCMAKE_MSVC_RUNTIME_LIBRARY=MultiThreaded $args"
     }
     & $cmake . $args.split(' ')
-    & $cmake --build . --config Release
+    & $cmake --build . --target $(if ($Dynamic) { 'zlib' } else { 'zlibstatic' }) --config Release
     if (-not $?) {
-        Write-Host "Error: Failed to build libgc" -ForegroundColor Red
+        Write-Host "Error: Failed to build zlib" -ForegroundColor Red
         Exit 1
     }
 }
 
 if ($Dynamic) {
-    mv -Force $BuildTree\Release\gc.lib libs\gc-dynamic.lib
-    mv -Force $BuildTree\Release\gc.dll dlls\
+    mv -Force $BuildTree\Release\zlib.lib libs\z-dynamic.lib
+    mv -Force $BuildTree\Release\zlib1.dll dlls\
 } else {
-    mv -Force $BuildTree\Release\gc.lib libs\
+    mv -Force $BuildTree\Release\zlibstatic.lib libs\z.lib
 }
-

--- a/etc/win-ci/build-z.ps1
+++ b/etc/win-ci/build-z.ps1
@@ -7,7 +7,7 @@ param(
 . "$(Split-Path -Parent $MyInvocation.MyCommand.Path)\setup.ps1"
 
 [void](New-Item -Name (Split-Path -Parent $BuildTree) -ItemType Directory -Force)
-Setup-Git -Path $BuildTree -Url https://github.com/madler/zlib.git -Branch v$Version
+Setup-Git -Path $BuildTree -Url https://github.com/madler/zlib.git -Ref v$Version
 
 Run-InDirectory $BuildTree {
     $args = "-DCMAKE_POLICY_DEFAULT_CMP0091=NEW -DCMAKE_FIND_USE_SYSTEM_ENVIRONMENT_PATH=OFF"

--- a/etc/win-ci/setup.ps1
+++ b/etc/win-ci/setup.ps1
@@ -39,16 +39,11 @@ function Setup-Git {
     param(
         [Parameter(Mandatory)] [string] $Path,
         [Parameter(Mandatory)] [string] $Url,
-        [string] $Branch = $null,
-        [string] $Commit = $null
+        [string] $Ref = $null
     )
 
     if (-not (Test-Path $Path)) {
         $args = "clone", "--config", "core.autocrlf=false", $Url, $Path
-        if ($Branch) {
-            $args += "-b"
-            $args += $Branch
-        }
         Write-Host "$git $args" -ForegroundColor Cyan
         & $git $args
         if (-not $?) {
@@ -57,10 +52,10 @@ function Setup-Git {
         }
     }
 
-    if ($Commit) {
+    if ($Ref) {
         Run-InDirectory $Path {
-            Write-Host "$git checkout $Commit" -ForegroundColor Cyan
-            & $git checkout $Commit
+            Write-Host "$git checkout $Ref" -ForegroundColor Cyan
+            & $git checkout $Ref
         }
     }
 }

--- a/etc/win-ci/setup.ps1
+++ b/etc/win-ci/setup.ps1
@@ -24,20 +24,6 @@ function Find-Git {
     Exit 1
 }
 
-function Find-7Zip {
-    $Path = Get-Command "7z" -CommandType Application -TotalCount 1 -ErrorAction SilentlyContinue
-    if ($Path) { return $Path.Path }
-
-    $Path = "$env:ProgramFiles\7-Zip\7z.exe"
-    if (Test-Path -Path $Path -PathType Leaf) { return $Path }
-
-    $Path = "${env:ProgramFiles(x86)}\7-Zip\7z.exe"
-    if (Test-Path -Path $Path -PathType Leaf) { return $Path }
-
-    Write-Host "Error: Cannot locate 7-Zip executable" -ForegroundColor Red
-    Exit 1
-}
-
 function Find-CMake {
     $Path = Get-Command "cmake" -CommandType Application -TotalCount 1 -ErrorAction SilentlyContinue
     if ($Path) { return $Path.Path }
@@ -91,7 +77,6 @@ function Replace-Text {
 }
 
 $git = Find-Git
-$7z = Find-7Zip
 $cmake = Find-CMake
 
 [void](New-Item -Name libs -ItemType Directory -Force)

--- a/etc/win-ci/setup.ps1
+++ b/etc/win-ci/setup.ps1
@@ -6,7 +6,7 @@ function Run-InDirectory {
 
     [void](New-Item -Name $Path -ItemType Directory -Force)
     Push-Location $Path
-    [Environment]::CurrentDirectory = $Path
+    [Environment]::CurrentDirectory = (Get-Location -PSProvider FileSystem).ProviderPath
     try { & $ScriptBlock } finally {
         Pop-Location
         [Environment]::CurrentDirectory = (Get-Location -PSProvider FileSystem).ProviderPath
@@ -31,7 +31,7 @@ function Find-7Zip {
     $Path = "$env:ProgramFiles\7-Zip\7z.exe"
     if (Test-Path -Path $Path -PathType Leaf) { return $Path }
 
-    $Path = "$env:ProgramFiles(x86)\7-Zip\7z.exe"
+    $Path = "${env:ProgramFiles(x86)}\7-Zip\7z.exe"
     if (Test-Path -Path $Path -PathType Leaf) { return $Path }
 
     Write-Host "Error: Cannot locate 7-Zip executable" -ForegroundColor Red
@@ -96,4 +96,3 @@ $cmake = Find-CMake
 
 [void](New-Item -Name libs -ItemType Directory -Force)
 [void](New-Item -Name dlls -ItemType Directory -Force)
-[void](New-Item -Name deps -ItemType Directory -Force)

--- a/etc/win-ci/setup.ps1
+++ b/etc/win-ci/setup.ps1
@@ -1,0 +1,99 @@
+function Run-InDirectory {
+    param(
+        [Parameter(Mandatory)] [string] $Path,
+        [Parameter(Mandatory)] [scriptblock] $ScriptBlock
+    )
+
+    [void](New-Item -Name $Path -ItemType Directory -Force)
+    Push-Location $Path
+    [Environment]::CurrentDirectory = $Path
+    try { & $ScriptBlock } finally {
+        Pop-Location
+        [Environment]::CurrentDirectory = (Get-Location -PSProvider FileSystem).ProviderPath
+    }
+}
+
+function Find-Git {
+    $Path = Get-Command "git" -CommandType Application -TotalCount 1 -ErrorAction SilentlyContinue
+    if ($Path) { return $Path.Path }
+
+    $Path = "$env:ProgramFiles\Git\cmd\git.exe"
+    if (Test-Path -Path $Path -PathType Leaf) { return $Path }
+
+    Write-Host "Error: Cannot locate Git executable" -ForegroundColor Red
+    Exit 1
+}
+
+function Find-7Zip {
+    $Path = Get-Command "7z" -CommandType Application -TotalCount 1 -ErrorAction SilentlyContinue
+    if ($Path) { return $Path.Path }
+
+    $Path = "$env:ProgramFiles\7-Zip\7z.exe"
+    if (Test-Path -Path $Path -PathType Leaf) { return $Path }
+
+    $Path = "$env:ProgramFiles(x86)\7-Zip\7z.exe"
+    if (Test-Path -Path $Path -PathType Leaf) { return $Path }
+
+    Write-Host "Error: Cannot locate 7-Zip executable" -ForegroundColor Red
+    Exit 1
+}
+
+function Find-CMake {
+    $Path = Get-Command "cmake" -CommandType Application -TotalCount 1 -ErrorAction SilentlyContinue
+    if ($Path) { return $Path.Path }
+
+    $Path = "$env:ProgramFiles\CMake\bin\cmake.exe"
+    if (Test-Path -Path $Path -PathType Leaf) { return $Path }
+
+    Write-Host "Error: Cannot locate CMake executable" -ForegroundColor Red
+    Exit 1
+}
+
+function Setup-Git {
+    param(
+        [Parameter(Mandatory)] [string] $Path,
+        [Parameter(Mandatory)] [string] $Url,
+        [string] $Branch = $null,
+        [string] $Commit = $null
+    )
+
+    if (-not (Test-Path $Path)) {
+        $args = "clone", "--config", "core.autocrlf=false", $Url, $Path
+        if ($Branch) {
+            $args += "-b"
+            $args += $Branch
+        }
+        Write-Host "$git $args" -ForegroundColor Cyan
+        & $git $args
+        if (-not $?) {
+            Write-Host "Error: Failed to clone Git repository" -ForegroundColor Red
+            Exit 1
+        }
+    }
+
+    if ($Commit) {
+        Run-InDirectory $Path {
+            Write-Host "$git checkout $Commit" -ForegroundColor Cyan
+            & $git checkout $Commit
+        }
+    }
+}
+
+function Replace-Text {
+    param(
+        [Parameter(Mandatory)] [string] $Path,
+        [Parameter(Mandatory)] [string] $Pattern,
+        [Parameter(Mandatory)] [AllowEmptyString()] [string] $Replacement
+    )
+
+    $content = [System.IO.File]::ReadAllText($Path).Replace($Pattern, $Replacement)
+    [System.IO.File]::WriteAllText($Path, $content)
+}
+
+$git = Find-Git
+$7z = Find-7Zip
+$cmake = Find-CMake
+
+[void](New-Item -Name libs -ItemType Directory -Force)
+[void](New-Item -Name dlls -ItemType Directory -Force)
+[void](New-Item -Name deps -ItemType Directory -Force)


### PR DESCRIPTION
This PR extracts the build scripts for the various third-party libraries in the Windows CI jobs into individual PowerShell scripts.

These scripts can be run from any directory. They all require CMake and Git; `setup.ps1` will try to detect them from several common locations, even if they aren't present in `%PATH%`. Additionally, building PCRE requires 7-Zip, and building OpenSSL requires NASM and Strawberry Perl.

All those scripts support static and dynamic builds; the latter adds `-dynamic` to the names of all import libraries, in accordance with #13473. To build the libraries as DLLs, start from the MSVC developer prompt: (Strawberry Perl adds a lot of things to `%PATH%`, so it is a good idea to use the portable installation and keep `%PATH%` intact outside building OpenSSL)

```
> powershell
PS> .\etc\win-ci\build-gc.ps1 -BuildTree deps\gc -Version 8.2.2 -AtomicOpsVersion 7.8.0 -Dynamic
PS> .\etc\win-ci\build-pcre.ps1 -BuildTree deps\pcre -Version 8.45 -Dynamic
PS> .\etc\win-ci\build-pcre2.ps1 -BuildTree deps\pcre2 -Version 10.42 -Dynamic
PS> .\etc\win-ci\build-iconv.ps1 -BuildTree deps\iconv -Dynamic
PS> .\etc\win-ci\build-ffi.ps1 -BuildTree deps\ffi -Version 3.3 -Dynamic
PS> .\etc\win-ci\build-z.ps1 -BuildTree deps\z -Version 1.2.13 -Dynamic
PS> .\etc\win-ci\build-mpir.ps1 -BuildTree deps\mpir -Dynamic
PS> .\etc\win-ci\build-yaml.ps1 -BuildTree deps\yaml -Version 0.2.5 -Dynamic
PS> .\etc\win-ci\build-xml2.ps1 -BuildTree deps\xml2 -Version 2.11.3 -Dynamic
PS> exit
> ...\strawberry-perl\portableshell.bat /SETENV
> powershell
PS> .\etc\win-ci\build-openssl.ps1 -BuildTree deps\openssl -Version 3.1.0 -Dynamic
```

This will place all the import libraries inside `.\libs` and all the DLLs inside `.\dlls`. To build static libraries simply remove the `-Dynamic`; static and dynamic builds should use separate build trees to avoid surprising behavior.

This PR also upgrades libxml2 from 2.10.3 to 2.11.3, and OpenSSL from 3.0.7 to 3.1.0.

Eventually the scripts will be moved to a completely different place where all the libraries (and possibly [the installer too](https://github.com/crystal-lang/crystal/issues/13426)) will be published as a single artifact.