### PR TITLE
Add `.gitattributes` to repository

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,28 @@
+## Sources
+
+*.cr text eol=lf
+
+## Sourced-in dependencies
+
+lib/** linguist-vendored
+
+## Generated files
+
+# produced by scripts/generate_windows_zone_names.cr
+src/crystal/system/win32/zone_names.cr linguist-generated
+# produced by scripts/generate_ssl_server_defaults.cr
+src/openssl/ssl/defaults.cr linguist-generated
+# produced by scripts/generate_grapheme_properties.cr
+src/string/grapheme/properties.cr linguist-generated
+# produced by scripts/generate_unicode_data.cr
+src/unicode/data.cr linguist-generated
+# produced by spec/generate_interpreter_spec.sh
+spec/interpreter_std_spec.cr linguist-generated
+# produced by scripts/generate_grapheme_break_specs.cr
+spec/std/string/grapheme_break_spec.cr linguist-generated
+# produced by spec/generate_wasm32_spec.sh
+spec/wasm32_std_spec.cr linguist-generated
+
+## Syntax highlighting
+
+Makefile.win linguist-language=makefile


### PR DESCRIPTION
This minimal `.gitattributes` does a few things:

* Marks all Crystal source files as using LF for line endings. This prevents automatic end-of-line conversions on those files on checkouts even if `core.autocrlf` is not set. (CRLFs are normalized into LFs on checkins.)
* Excludes `markd` and `reply`, compiler dependencies that we explicitly source in, from the repository stats.
* Excludes several automatically generated files from diff views by default.
* Allows GitHub to recognize `Makefile.win` as a Makefile and apply syntax highlighting.

In the future we should add `*.cr text eol=lf` to `crystal init` as well, as suggested in https://github.com/crystal-lang/crystal/issues/5831#issuecomment-373738241 and https://github.com/crystal-lang/crystal/issues/13304#issuecomment-1503362416.