### PR TITLE
Fix `LibM.hypotf` and `ldexpf` link errors on Windows

### DIFF
--- a/src/math/libm.cr
+++ b/src/math/libm.cr
@@ -180,11 +180,17 @@ lib LibM
   fun frexp_f64 = frexp(value : Float64, exp : Int32*) : Float64
   fun gamma_f32 = lgammaf(value : Float32) : Float32
   fun gamma_f64 = lgamma(value : Float64) : Float64
-  fun hypot_f32 = hypotf(value1 : Float32, value2 : Float32) : Float32
+  {% if flag?(:win32) %}
+    fun hypot_f32 = _hypotf(value1 : Float32, value2 : Float32) : Float32
+  {% else %}
+    fun hypot_f32 = hypotf(value1 : Float32, value2 : Float32) : Float32
+  {% end %}
   fun hypot_f64 = hypot(value1 : Float64, value2 : Float64) : Float64
   fun ilogb_f32 = ilogbf(value : Float32) : Int32
   fun ilogb_f64 = ilogb(value : Float64) : Int32
-  fun ldexp_f32 = ldexpf(value1 : Float32, value2 : Int32) : Float32
+  {% unless flag?(:win32) %}
+    fun ldexp_f32 = ldexpf(value1 : Float32, value2 : Int32) : Float32
+  {% end %}
   fun ldexp_f64 = ldexp(value1 : Float64, value2 : Int32) : Float64
   fun log1p_f32 = log1pf(value : Float32) : Float32
   fun log1p_f64 = log1p(value : Float64) : Float64

--- a/src/math/math.cr
+++ b/src/math/math.cr
@@ -609,7 +609,12 @@ module Math
 
   # Multiplies the given floating-point *value* by 2 raised to the power *exp*.
   def ldexp(value : Float32, exp : Int32) : Float32
-    LibM.ldexp_f32(value, exp)
+    {% if flag?(:win32) %}
+      # ucrt does not export `ldexpf` and instead defines it like this
+      LibM.ldexp_f64(value, exp).to_f32!
+    {% else %}
+      LibM.ldexp_f32(value, exp)
+    {% end %}
   end
 
   # :ditto:
@@ -657,7 +662,7 @@ module Math
   # Decomposes the given floating-point *value* into a normalized fraction and an integral power of two.
   def frexp(value : Float32) : {Float32, Int32}
     {% if flag?(:win32) %}
-      # libucrt does not export `frexpf` and instead defines it like this
+      # ucrt does not export `frexpf` and instead defines it like this
       frac = LibM.frexp_f64(value, out exp)
       {frac.to_f32, exp}
     {% else %}


### PR DESCRIPTION
`hypotf` is not exported by `ucrtbase.dll`, but `_hypotf` is, so that symbol is used instead; the two functions are identical. `ldexpf` is not exported, so it is implemented on top of `ldexp` on Windows, similar to `frexpf`.

This is necessary to fix linker errors when the C runtime DLL is used.