### PR TITLE
Use per-thread libxml2 global state on Windows

### DIFF
--- a/src/xml.cr
+++ b/src/xml.cr
@@ -105,6 +105,36 @@ module XML
 
     Node.new(doc, errors)
   end
+
+  protected def self.with_indent_tree_output(indent : Bool, &)
+    ptr = {% if flag?(:win32) %}
+            LibXML.__xmlIndentTreeOutput
+          {% else %}
+            pointerof(LibXML.xmlIndentTreeOutput)
+          {% end %}
+
+    old, ptr.value = ptr.value, indent ? 1 : 0
+    begin
+      yield
+    ensure
+      ptr.value = old
+    end
+  end
+
+  protected def self.with_tree_indent_string(string : String, &)
+    ptr = {% if flag?(:win32) %}
+            LibXML.__xmlTreeIndentString
+          {% else %}
+            pointerof(LibXML.xmlTreeIndentString)
+          {% end %}
+
+    old, ptr.value = ptr.value, string.to_unsafe
+    begin
+      yield
+    ensure
+      ptr.value = old
+    end
+  end
 end
 
 require "./xml/*"

--- a/src/xml/libxml2.cr
+++ b/src/xml/libxml2.cr
@@ -8,8 +8,15 @@ require "./save_options"
 lib LibXML
   alias Int = LibC::Int
 
-  $xmlIndentTreeOutput : Int
-  $xmlTreeIndentString : UInt8*
+  # TODO: check if other platforms also support per-thread globals
+  {% if flag?(:win32) %}
+    fun xmlInitParser
+    fun __xmlIndentTreeOutput : Int*
+    fun __xmlTreeIndentString : UInt8**
+  {% else %}
+    $xmlIndentTreeOutput : Int
+    $xmlTreeIndentString : UInt8*
+  {% end %}
 
   type Dtd = Void*
   type Dict = Void*
@@ -313,6 +320,10 @@ lib LibXML
 
   fun xmlValidateNameValue(value : UInt8*) : Int
 end
+
+{% if flag?(:win32) %}
+  LibXML.xmlInitParser
+{% end %}
 
 LibXML.xmlGcMemSetup(
   ->GC.free,


### PR DESCRIPTION
On Windows we build libxml2 with thread support, so the two global variables we declare in `LibXML` are [C macros rather than exports](https://gitlab.gnome.org/GNOME/libxml2/-/blob/981093abd1c5d2fd2045511b384bb42a63caeeea/include/libxml/globals.h#L389-405). When using libxml2 as a DLL, we must recreate those macros instead of binding to `xmlIndentTreeOutput` and `xmlTreeIndentString` directly.

Those functions have been around in libxml2 for a long time, so this PR is probably applicable to more platforms than just Windows.