### PR TITLE
Deprecate `LLVM::Module#write_bitcode_with_summary_to_file`

### DIFF
--- a/man/crystal.1
+++ b/man/crystal.1
@@ -113,8 +113,6 @@ Generate the output with symbolic debug symbols.
 These are read when debugging the built program with tools like lldb, gdb, valgrind etc. and provide mappings to the original source code for those tools.
 .It Fl -no-debug
 Generate the output without any symbolic debug symbols.
-.It Fl -lto Ar FLAG
-Use ThinLTO --lto=thin.
 .It Fl D Ar FLAG, Fl -define Ar FLAG
 Define a compile-time flag. This is useful to conditionally define types, methods, or commands based on flags available at compile time. The default flags are from the target triple given with --target-triple or the hosts default, if none is given.
 .It Fl -emit Op asm|llvm-bc|llvm-ir|obj

--- a/src/llvm/ext/llvm_ext.cc
+++ b/src/llvm/ext/llvm_ext.cc
@@ -1,8 +1,6 @@
 #include <llvm/IR/DIBuilder.h>
 #include <llvm/IR/IRBuilder.h>
 #include <llvm/IR/DebugLoc.h>
-#include <llvm/Support/raw_ostream.h>
-#include <llvm/Support/FileSystem.h>
 #include <llvm/ExecutionEngine/ExecutionEngine.h>
 #include <llvm/ExecutionEngine/RTDyldMemoryManager.h>
 
@@ -18,8 +16,6 @@ using namespace llvm;
   (LLVM_VERSION_MAJOR < (major) || LLVM_VERSION_MAJOR == (major) && LLVM_VERSION_MINOR <= (minor))
 
 #include <llvm/Target/CodeGenCWrappers.h>
-#include <llvm/Bitcode/BitcodeWriter.h>
-#include <llvm/Analysis/ModuleSummaryAnalysis.h>
 
 #if LLVM_VERSION_GE(16, 0)
 #define makeArrayRef ArrayRef
@@ -83,22 +79,6 @@ LLVMValueRef LLVMExtBuildInvoke2(
   return wrap(unwrap(B)->CreateInvoke((llvm::FunctionType*) unwrap(Ty), unwrap(Fn), unwrap(Then), unwrap(Catch),
                                       makeArrayRef(unwrap(Args), NumArgs),
                                       Bundles, Name));
-}
-
-void LLVMExtWriteBitcodeWithSummaryToFile(LLVMModuleRef mref, const char *File) {
-  // https://github.com/ldc-developers/ldc/pull/1840/files
-  Module *m = unwrap(mref);
-
-  std::error_code EC;
-#if LLVM_VERSION_GE(13, 0)
-  raw_fd_ostream OS(File, EC, sys::fs::OF_None);
-#else
-  raw_fd_ostream OS(File, EC, sys::fs::F_None);
-#endif
-  if (EC) return;
-
-  llvm::ModuleSummaryIndex moduleSummaryIndex = llvm::buildModuleSummaryIndex(*m, nullptr, nullptr);
-  llvm::WriteBitcodeToFile(*m, OS, true, &moduleSummaryIndex, true);
 }
 
 static TargetMachine *unwrap(LLVMTargetMachineRef P) {

--- a/src/llvm/lib_llvm_ext.cr
+++ b/src/llvm/lib_llvm_ext.cr
@@ -32,8 +32,6 @@ lib LibLLVMExt
                                           bundle : LibLLVMExt::OperandBundleDefRef,
                                           name : LibC::Char*) : LibLLVM::ValueRef
 
-  fun write_bitcode_with_summary_to_file = LLVMExtWriteBitcodeWithSummaryToFile(module : LibLLVM::ModuleRef, path : UInt8*) : Void
-
   fun target_machine_enable_global_isel = LLVMExtTargetMachineEnableGlobalIsel(machine : LibLLVM::TargetMachineRef, enable : Bool)
   fun create_mc_jit_compiler_for_module = LLVMExtCreateMCJITCompilerForModule(jit : LibLLVM::ExecutionEngineRef*, m : LibLLVM::ModuleRef, options : LibLLVM::JITCompilerOptions*, options_length : UInt32, enable_global_isel : Bool, error : UInt8**) : Int32
 end

--- a/src/llvm/module.cr
+++ b/src/llvm/module.cr
@@ -53,8 +53,9 @@ class LLVM::Module
     LibLLVM.write_bitcode_to_file self, filename
   end
 
+  @[Deprecated("ThinLTO is no longer supported; use `#write_bitcode_to_file` instead")]
   def write_bitcode_with_summary_to_file(filename : String)
-    LibLLVMExt.write_bitcode_with_summary_to_file self, filename
+    LibLLVM.write_bitcode_to_file self, filename
   end
 
   def write_bitcode_to_memory_buffer


### PR DESCRIPTION
Crystal never calls this method (nor `#write_bitcode_to_file` nor `#write_bitcode_to_fd`, for that matter), and [ThinLTO is already gone](https://github.com/crystal-lang/crystal/pull/11194), so there is no harm in making `#write_bitcode_with_summary_to_file` behave identically to `#write_bitcode_to_file`.