### PR TITLE
Add `File::BadExecutableError`

### DIFF
--- a/spec/std/process_spec.cr
+++ b/spec/std/process_spec.cr
@@ -68,9 +68,18 @@ describe Process do
       end
     end
 
-    pending_win32 "raises if command is not executable" do
+    it "raises if command is not executable" do
       with_tempfile("crystal-spec-run") do |path|
         File.touch path
+        expect_raises({% if flag?(:win32) %} File::BadExecutableError {% else %} File::AccessDeniedError {% end %}, "Error executing process: '#{path.inspect_unquoted}'") do
+          Process.new(path)
+        end
+      end
+    end
+
+    it "raises if command is not executable" do
+      with_tempfile("crystal-spec-run") do |path|
+        Dir.mkdir path
         expect_raises(File::AccessDeniedError, "Error executing process: '#{path.inspect_unquoted}'") do
           Process.new(path)
         end

--- a/src/crystal/system/unix/process.cr
+++ b/src/crystal/system/unix/process.cr
@@ -257,7 +257,7 @@ struct Crystal::System::Process
 
   private def self.raise_exception_from_errno(command, errno = Errno.value)
     case errno
-    when Errno::EACCES, Errno::ENOENT
+    when Errno::EACCES, Errno::ENOENT, Errno::ENOEXEC
       raise ::File::Error.from_os_error("Error executing process", errno, file: command)
     else
       raise IO::Error.from_os_error("Error executing process: '#{command}'", errno)

--- a/src/crystal/system/win32/process.cr
+++ b/src/crystal/system/win32/process.cr
@@ -212,7 +212,7 @@ struct Crystal::System::Process
        ) == 0
       error = WinError.value
       case error.to_errno
-      when Errno::EACCES, Errno::ENOENT
+      when Errno::EACCES, Errno::ENOENT, Errno::ENOEXEC
         raise ::File::Error.from_os_error("Error executing process", error, file: command_args)
       else
         raise IO::Error.from_os_error("Error executing process: '#{command_args}'", error)

--- a/src/file/error.cr
+++ b/src/file/error.cr
@@ -11,8 +11,10 @@ class File::Error < IO::Error
       File::NotFoundError.new(message, **opts)
     when Errno::EEXIST, WinError::ERROR_ALREADY_EXISTS
       File::AlreadyExistsError.new(message, **opts)
-    when Errno::EACCES, WinError::ERROR_PRIVILEGE_NOT_HELD
+    when Errno::EACCES, WinError::ERROR_ACCESS_DENIED, WinError::ERROR_PRIVILEGE_NOT_HELD
       File::AccessDeniedError.new(message, **opts)
+    when Errno::ENOEXEC, WinError::ERROR_BAD_EXE_FORMAT
+      File::BadExecutableError.new(message, **opts)
     else
       super message, os_error, **opts
     end
@@ -25,6 +27,17 @@ class File::Error < IO::Error
   protected def self.build_message(message, *, file : String, other : String) : String
     "#{message}: '#{file.inspect_unquoted}' -> '#{other.inspect_unquoted}'"
   end
+
+  {% if flag?(:win32) %}
+    protected def self.os_error_message(os_error : WinError, *, file : String) : String?
+      case os_error
+      when WinError::ERROR_BAD_EXE_FORMAT
+        os_error.formatted_message(file)
+      else
+        super
+      end
+    end
+  {% end %}
 
   def initialize(message, *, file : String | Path, @other : String? = nil)
     @file = file.to_s
@@ -39,4 +52,7 @@ class File::AlreadyExistsError < File::Error
 end
 
 class File::AccessDeniedError < File::Error
+end
+
+class File::BadExecutableError < File::Error
 end

--- a/src/system_error.cr
+++ b/src/system_error.cr
@@ -36,7 +36,7 @@
 #   Returns the respective error message for *os_error*.
 #   By default it returns the result of `Errno#message` or `WinError#message`.
 #   This method can be overridden for customization of the error message based
-#   on *or_error*  and *opts*.
+#   on *os_error* and *opts*.
 module SystemError
   macro included
     extend ::SystemError::ClassMethods


### PR DESCRIPTION
This PR maps `Errno::ENOEXEC` and `WinError::ERROR_BAD_EXE_FORMAT` to a new exception class, `File::BadExecutableError`, that is raised if `Process.new` receives a file that has execute permissions but isn't really an executable file. `WinError::ERROR_BAD_EXE_FORMAT` passes the file argument to `LibC.FormatMessageW`. Fixes #12985. (The new exception class isn't technically necessary, I just think this is a good chance to capture this error in a platform-independent way.)

Note that this doesn't happen naturally on POSIX systems, where `Process.new` is backed by `LibC.execvp`; if `execvp` failed because of `ENOEXEC`, execution of the same file is attempted again via `sh` as though it is a shell script. Therefore, trying to execute a Windows executable on a non-WSL Linux produces:

```crystal
begin
  p Process.run("/home/quinton/crystal/crystal/crystal.exe", output: :inherit, error: :inherit)
rescue ex
  p ex
end
```

```
/home/quinton/crystal/crystal/crystal.exe: 1: MZ����@▒��: not found
/home/quinton/crystal/crystal/crystal.exe: 2: Syntax error: word unexpected (expecting ")")
Process::Status[2]
```

However, [musl is known not to fall back to `sh`](https://www.openwall.com/lists/musl/2018/03/09/1), in which case `File::BadExecutableError` could still be caught. If we want to use `LibC.execv` instead then we must replicate the `$PATH` lookup ourselves when the file name does not include a slash character.

This PR also maps `WinError::ERROR_ACCESS_DENIED` to `File::AccessDeniedError`. This happens when `Process.new` receives a directory on Windows.