### PR TITLE
Support Unix sockets on Windows

### DIFF
--- a/spec/std/socket/address_spec.cr
+++ b/spec/std/socket/address_spec.cr
@@ -19,7 +19,7 @@ describe Socket::Address do
       address.should eq Socket::IPAddress.new("192.168.0.1", 8081)
     end
 
-    pending_win32 "parses UNIX" do
+    it "parses UNIX" do
       address = Socket::Address.parse "unix://socket.sock"
       address.should eq Socket::UNIXAddress.new("socket.sock")
     end

--- a/spec/std/socket/unix_server_spec.cr
+++ b/spec/std/socket/unix_server_spec.cr
@@ -1,4 +1,3 @@
-{% skip_file if flag?(:win32) %}
 require "../spec_helper"
 require "socket"
 require "../../support/fibers"
@@ -21,6 +20,7 @@ describe UNIXServer do
       with_tempfile("unix_server.sock") do |path|
         UNIXServer.open(path) do
           File.exists?(path).should be_true
+          File.info(path).type.socket?.should be_true
         end
 
         File.exists?(path).should be_false

--- a/spec/std/socket/unix_server_spec.cr
+++ b/spec/std/socket/unix_server_spec.cr
@@ -149,17 +149,22 @@ describe UNIXServer do
     end
   end
 
-  describe "datagrams" do
-    it "can send and receive datagrams" do
-      with_tempfile("unix_dgram_server.sock") do |path|
-        UNIXServer.open(path, Socket::Type::DGRAM) do |s|
-          UNIXSocket.open(path, Socket::Type::DGRAM) do |c|
-            c.send("foobar")
-            msg, _addr = s.receive(512)
-            msg.should eq "foobar"
+  # Datagram socket type is not supported on Windows yet:
+  # https://devblogs.microsoft.com/commandline/af_unix-comes-to-windows/#unsupportedunavailable
+  # https://github.com/microsoft/WSL/issues/5272
+  {% unless flag?(:win32) %}
+    describe "datagrams" do
+      it "can send and receive datagrams" do
+        with_tempfile("unix_dgram_server.sock") do |path|
+          UNIXServer.open(path, Socket::Type::DGRAM) do |s|
+            UNIXSocket.open(path, Socket::Type::DGRAM) do |c|
+              c.send("foobar")
+              msg, _addr = s.receive(512)
+              msg.should eq "foobar"
+            end
           end
         end
       end
     end
-  end
+  {% end %}
 end

--- a/spec/std/socket/unix_socket_spec.cr
+++ b/spec/std/socket/unix_socket_spec.cr
@@ -1,4 +1,3 @@
-{% skip_file if flag?(:win32) %}
 require "spec"
 require "socket"
 require "../../support/tempfile"

--- a/src/crystal/system/win32/file.cr
+++ b/src/crystal/system/win32/file.cr
@@ -126,28 +126,29 @@ module Crystal::System::File
   def self.info?(path : String, follow_symlinks : Bool) : ::File::Info?
     winpath = System.to_wstr(path)
 
-    unless follow_symlinks
-      # First try using GetFileAttributes to check if it's a reparse point
-      file_attributes = uninitialized LibC::WIN32_FILE_ATTRIBUTE_DATA
-      ret = LibC.GetFileAttributesExW(
-        winpath,
-        LibC::GET_FILEEX_INFO_LEVELS::GetFileExInfoStandard,
-        pointerof(file_attributes)
-      )
-      return check_not_found_error("Unable to get file info", path) if ret == 0
+    # First try using GetFileAttributes to check if it's a reparse point
+    file_attributes = uninitialized LibC::WIN32_FILE_ATTRIBUTE_DATA
+    ret = LibC.GetFileAttributesExW(
+      winpath,
+      LibC::GET_FILEEX_INFO_LEVELS::GetFileExInfoStandard,
+      pointerof(file_attributes)
+    )
+    return check_not_found_error("Unable to get file info", path) if ret == 0
 
-      if file_attributes.dwFileAttributes.bits_set? LibC::FILE_ATTRIBUTE_REPARSE_POINT
-        # Could be a symlink, retrieve its reparse tag with FindFirstFile
-        handle = LibC.FindFirstFileW(winpath, out find_data)
-        return check_not_found_error("Unable to get file info", path) if handle == LibC::INVALID_HANDLE_VALUE
+    if file_attributes.dwFileAttributes.bits_set? LibC::FILE_ATTRIBUTE_REPARSE_POINT
+      # Could be a symlink, retrieve its reparse tag with FindFirstFile
+      handle = LibC.FindFirstFileW(winpath, out find_data)
+      return check_not_found_error("Unable to get file info", path) if handle == LibC::INVALID_HANDLE_VALUE
 
-        if LibC.FindClose(handle) == 0
-          raise RuntimeError.from_winerror("FindClose")
-        end
+      if LibC.FindClose(handle) == 0
+        raise RuntimeError.from_winerror("FindClose")
+      end
 
-        if find_data.dwReserved0 == LibC::IO_REPARSE_TAG_SYMLINK
-          return ::File::Info.new(find_data)
-        end
+      case find_data.dwReserved0
+      when LibC::IO_REPARSE_TAG_SYMLINK
+        return ::File::Info.new(find_data) unless follow_symlinks
+      when LibC::IO_REPARSE_TAG_AF_UNIX
+        return ::File::Info.new(find_data)
       end
     end
 
@@ -373,7 +374,8 @@ module Crystal::System::File
             end
             return {name, is_relative}
           else
-            raise ::File::Error.new("Not a symlink", file: path)
+            # not a symlink (e.g. IO_REPARSE_TAG_AF_UNIX)
+            return nil
           end
         end
 

--- a/src/crystal/system/win32/file_info.cr
+++ b/src/crystal/system/win32/file_info.cr
@@ -53,9 +53,15 @@ module Crystal::System::FileInfo
       ::File::Type::CharacterDevice
     when LibC::FILE_TYPE_DISK
       # See: https://msdn.microsoft.com/en-us/library/windows/desktop/aa365511(v=vs.85).aspx
-      if @file_attributes.dwFileAttributes.bits_set?(LibC::FILE_ATTRIBUTE_REPARSE_POINT) &&
-         @reparse_tag == LibC::IO_REPARSE_TAG_SYMLINK
-        ::File::Type::Symlink
+      if @file_attributes.dwFileAttributes.bits_set?(LibC::FILE_ATTRIBUTE_REPARSE_POINT)
+        case @reparse_tag
+        when LibC::IO_REPARSE_TAG_SYMLINK
+          ::File::Type::Symlink
+        when LibC::IO_REPARSE_TAG_AF_UNIX
+          ::File::Type::Socket
+        else
+          ::File::Type::Unknown
+        end
       elsif @file_attributes.dwFileAttributes.bits_set? LibC::FILE_ATTRIBUTE_DIRECTORY
         ::File::Type::Directory
       else

--- a/src/crystal/system/win32/socket.cr
+++ b/src/crystal/system/win32/socket.cr
@@ -85,9 +85,11 @@ module Crystal::System::Socket
   end
 
   private def initialize_handle(handle)
-    system_getsockopt(handle, LibC::SO_REUSEADDR, 0) do |value|
-      if value == 0
-        system_setsockopt(handle, LibC::SO_EXCLUSIVEADDRUSE, 1)
+    unless @family.unix?
+      system_getsockopt(handle, LibC::SO_REUSEADDR, 0) do |value|
+        if value == 0
+          system_setsockopt(handle, LibC::SO_EXCLUSIVEADDRUSE, 1)
+        end
       end
     end
   end
@@ -173,7 +175,7 @@ module Crystal::System::Socket
 
   private def system_bind(addr, addrstr, &)
     unless LibC.bind(fd, addr, addr.size) == 0
-      yield ::Socket::BindError.from_errno("Could not bind to '#{addrstr}'")
+      yield ::Socket::BindError.from_wsa_error("Could not bind to '#{addrstr}'")
     end
   end
 

--- a/src/socket/unix_server.cr
+++ b/src/socket/unix_server.cr
@@ -2,7 +2,8 @@ require "./unix_socket"
 
 # A local interprocess communication server socket.
 #
-# Only available on UNIX and UNIX-like operating systems.
+# Available on UNIX-like operating systems, and Windows 10 Build 17063 or above.
+# Not all features are supported on Windows.
 #
 # NOTE: To use `UNIXServer`, you must explicitly import it with `require "socket"`
 #
@@ -30,9 +31,12 @@ class UNIXServer < UNIXSocket
   #
   # The server is of stream type by default, but this can be changed for
   # another type. For example datagram messages:
+  #
   # ```
   # UNIXServer.new("/tmp/dgram.sock", Socket::Type::DGRAM)
   # ```
+  #
+  # [Only the stream type is supported on Windows](https://devblogs.microsoft.com/commandline/af_unix-comes-to-windows/#unsupportedunavailable).
   def initialize(@path : String, type : Type = Type::STREAM, backlog : Int = 128)
     super(Family::UNIX, type)
 

--- a/src/socket/unix_socket.cr
+++ b/src/socket/unix_socket.cr
@@ -1,6 +1,7 @@
 # A local interprocess communication clientsocket.
 #
-# Only available on UNIX and UNIX-like operating systems.
+# Available on UNIX-like operating systems, and Windows 10 Build 17063 or above.
+# Not all features are supported on Windows.
 #
 # NOTE: To use `UNIXSocket`, you must explicitly import it with `require "socket"`
 #
@@ -50,6 +51,8 @@ class UNIXSocket < Socket
 
   # Returns a pair of unnamed UNIX sockets.
   #
+  # [Not supported on Windows](https://devblogs.microsoft.com/commandline/af_unix-comes-to-windows/#unsupportedunavailable).
+  #
   # ```
   # require "socket"
   #
@@ -65,7 +68,7 @@ class UNIXSocket < Socket
   # left.gets # => "message"
   # ```
   def self.pair(type : Type = Type::STREAM) : {UNIXSocket, UNIXSocket}
-    {% if flag?(:wasm32) %}
+    {% if flag?(:wasm32) || flag?(:win32) %}
       raise NotImplementedError.new "UNIXSocket.pair"
     {% else %}
       fds = uninitialized Int32[2]
@@ -87,6 +90,8 @@ class UNIXSocket < Socket
   # block. Eventually closes both sockets when the block returns.
   #
   # Returns the value of the block.
+  #
+  # [Not supported on Windows](https://devblogs.microsoft.com/commandline/af_unix-comes-to-windows/#unsupportedunavailable).
   def self.pair(type : Type = Type::STREAM, &)
     left, right = pair(type)
     begin


### PR DESCRIPTION
Resolves #13197.

This is only a best effort to expose what is already supported by Winsock 2.0. [Windows 10 Build 17093 or above will supposedly support communication between Unix sockets across Windows/WSL](https://devblogs.microsoft.com/commandline/windowswsl-interop-with-af_unix/), which is not tested here.