### PR TITLE
Make `fcntl` defined on all platforms

### DIFF
--- a/src/crystal/system/wasi/file_descriptor.cr
+++ b/src/crystal/system/wasi/file_descriptor.cr
@@ -11,6 +11,12 @@ module Crystal::System::FileDescriptor
     raise NotImplementedError.new "Crystal::System::FileDescriptor.pipe"
   end
 
+  def self.fcntl(fd, cmd, arg = 0)
+    r = LibC.fcntl(fd, cmd, arg)
+    raise IO::Error.from_errno("fcntl() failed") if r == -1
+    r
+  end
+
   private def system_blocking_init(value)
   end
 

--- a/src/crystal/system/win32/file_descriptor.cr
+++ b/src/crystal/system/win32/file_descriptor.cr
@@ -79,6 +79,10 @@ module Crystal::System::FileDescriptor
     false
   end
 
+  def self.fcntl(fd, cmd, arg = 0)
+    raise NotImplementedError.new "Crystal::System::FileDescriptor.fcntl"
+  end
+
   private def windows_handle
     FileDescriptor.windows_handle!(fd)
   end

--- a/src/crystal/system/win32/socket.cr
+++ b/src/crystal/system/win32/socket.cr
@@ -437,9 +437,7 @@ module Crystal::System::Socket
   end
 
   def self.fcntl(fd, cmd, arg = 0)
-    ret = LibC.fcntl fd, cmd, arg
-    raise Socket::Error.from_errno("fcntl() failed") if ret == -1
-    ret
+    raise NotImplementedError.new "Crystal::System::Socket.fcntl"
   end
 
   private def system_tty?

--- a/src/io/file_descriptor.cr
+++ b/src/io/file_descriptor.cr
@@ -56,15 +56,13 @@ class IO::FileDescriptor < IO
     self.system_close_on_exec = value
   end
 
-  {% unless flag?(:win32) %}
-    def self.fcntl(fd, cmd, arg = 0)
-      Crystal::System::FileDescriptor.fcntl(fd, cmd, arg)
-    end
+  def self.fcntl(fd, cmd, arg = 0)
+    Crystal::System::FileDescriptor.fcntl(fd, cmd, arg)
+  end
 
-    def fcntl(cmd, arg = 0)
-      Crystal::System::FileDescriptor.fcntl(fd, cmd, arg)
-    end
-  {% end %}
+  def fcntl(cmd, arg = 0)
+    Crystal::System::FileDescriptor.fcntl(fd, cmd, arg)
+  end
 
   # Returns a `File::Info` object for this file descriptor, or raises
   # `IO::Error` in case of an error.


### PR DESCRIPTION
* Allows `IO::FileDescriptor.fcntl` on WebAssembly, since the binding for it appears to have been used for `Socket.fcntl` already.
* Raises `NotImplementedError` on Windows, preventing a compilation error and a link error.