### PR TITLE
Add support for dash separator to `Enum.parse`

### DIFF
--- a/spec/std/enum_spec.cr
+++ b/spec/std/enum_spec.cr
@@ -288,6 +288,8 @@ describe Enum do
 
     SpecEnum2.parse("FORTY_FOUR").should eq(SpecEnum2::FORTY_FOUR)
     SpecEnum2.parse("forty_four").should eq(SpecEnum2::FORTY_FOUR)
+    SpecEnum2.parse("FORTY-FOUR").should eq(SpecEnum2::FORTY_FOUR)
+    SpecEnum2.parse("forty-four").should eq(SpecEnum2::FORTY_FOUR)
     SpecEnum2.parse("FortyFour").should eq(SpecEnum2::FORTY_FOUR)
     SpecEnum2.parse("FORTYFOUR").should eq(SpecEnum2::FORTY_FOUR)
     SpecEnum2.parse("fortyfour").should eq(SpecEnum2::FORTY_FOUR)
@@ -301,9 +303,10 @@ describe Enum do
     SpecEnumWithCaseSensitiveMembers.parse("Foo").should eq SpecEnumWithCaseSensitiveMembers::FOO
   end
 
-  it "parses?" do
+  it ".parse?" do
     SpecEnum.parse?("Two").should eq(SpecEnum::Two)
     SpecEnum.parse?("Four").should be_nil
+    SpecEnum.parse?("Fo-ur").should be_nil
   end
 
   it "clones" do

--- a/spec/std/json/serialization_spec.cr
+++ b/spec/std/json/serialization_spec.cr
@@ -293,9 +293,8 @@ describe "JSON serialization" do
         JSONSpecEnum.from_json(%("One")).should eq(JSONSpecEnum::One)
         JSONSpecEnum.from_json(%("two")).should eq(JSONSpecEnum::Two)
         JSONSpecEnum.from_json(%("ONE_HUNDRED")).should eq(JSONSpecEnum::OneHundred)
-        expect_raises(JSON::ParseException, %(Unknown enum JSONSpecEnum value: "ONE-HUNDRED")) do
-          JSONSpecEnum.from_json(%("ONE-HUNDRED"))
-        end
+        JSONSpecEnum.from_json(%("ONE-HUNDRED")).should eq(JSONSpecEnum::OneHundred)
+
         expect_raises(JSON::ParseException, %(Unknown enum JSONSpecEnum value: " one ")) do
           JSONSpecEnum.from_json(%(" one "))
         end

--- a/spec/std/yaml/serialization_spec.cr
+++ b/spec/std/yaml/serialization_spec.cr
@@ -232,9 +232,8 @@ describe "YAML serialization" do
         YAMLSpecEnum.from_yaml(%("One")).should eq(YAMLSpecEnum::One)
         YAMLSpecEnum.from_yaml(%("two")).should eq(YAMLSpecEnum::Two)
         YAMLSpecEnum.from_yaml(%("ONE_HUNDRED")).should eq(YAMLSpecEnum::OneHundred)
-        expect_raises(YAML::ParseException, %(Unknown enum YAMLSpecEnum value: "ONE-HUNDRED")) do
-          YAMLSpecEnum.from_yaml(%("ONE-HUNDRED"))
-        end
+        YAMLSpecEnum.from_yaml(%("ONE-HUNDRED")).should eq(YAMLSpecEnum::OneHundred)
+
         expect_raises(YAML::ParseException, %(Unknown enum YAMLSpecEnum value: " one ")) do
           YAMLSpecEnum.from_yaml(%(" one "))
         end

--- a/src/enum.cr
+++ b/src/enum.cr
@@ -477,9 +477,10 @@ struct Enum
   # Returns the enum member that has the given name, or
   # raises `ArgumentError` if no such member exists. The comparison is made by using
   # `String#camelcase` and `String#downcase` between *string* and
-  # the enum members names, so a member named "FortyTwo" or "FORTY_TWO"
+  # the enum members names. Dashes (`-`) in *string* have the same meaning as an underscore (`_`).
+  # A member named "FortyTwo" or "FORTY_TWO"
   # is found with any of these strings: "forty_two", "FortyTwo", "FORTY_TWO",
-  # "FORTYTWO", "fortytwo".
+  # "Forty-Two", "FORTYTWO", "fortytwo".
   #
   # ```
   # Color.parse("Red")    # => Color::Red
@@ -493,9 +494,10 @@ struct Enum
   # Returns the enum member that has the given name, or
   # `nil` if no such member exists. The comparison is made by using
   # `String#camelcase` and `String#downcase` between *string* and
-  # the enum members names, so a member named "FortyTwo" or "FORTY_TWO"
+  # the enum members names. Dashes (`-`) in *string* have the same meaning as an underscore (`_`).
+  # A member named "FortyTwo", or "FORTY_TWO"
   # is found with any of these strings: "forty_two", "FortyTwo", "FORTY_TWO",
-  # "FORTYTWO", "fortytwo".
+  # "Forty-Two", "FORTYTWO", "fortytwo".
   #
   # ```
   # Color.parse?("Red")    # => Color::Red
@@ -506,7 +508,7 @@ struct Enum
   # If multiple members match the same normalized string, the first one is returned.
   def self.parse?(string : String) : self?
     {% begin %}
-      case string.camelcase.downcase
+      case string.gsub('-', '_').camelcase.downcase
       # Temporarily map all constants to their normalized value in order to
       # avoid duplicates in the `case` conditions.
       # `FOO` and `Foo` members would both generate `when "foo"` which creates a compile time error.


### PR DESCRIPTION
Resolves #13206