### PR TITLE
Add `::exit!` to skip running `at_exit` handlers

### DIFF
--- a/spec/std/kernel_spec.cr
+++ b/spec/std/kernel_spec.cr
@@ -72,9 +72,9 @@ describe ".exit!" do
   it "does not run at_exit handlers", tags: %w[slow] do
     status, _, _ = compile_and_run_source <<-CRYSTAL
     at_exit do |status|
-      status + 2
+      exit! 5
     end
-    exit 3
+    exit! 3
     CRYSTAL
     status.exit_code.should eq 3
   end

--- a/spec/std/kernel_spec.cr
+++ b/spec/std/kernel_spec.cr
@@ -34,7 +34,7 @@ describe "ARGV" do
   end
 end
 
-describe "exit" do
+describe ".exit" do
   it "exits normally with status 0", tags: %w[slow] do
     status, _, _ = compile_and_run_source "exit"
     status.success?.should be_true
@@ -44,6 +44,39 @@ describe "exit" do
     status, _, _ = compile_and_run_source "exit 42"
     status.success?.should be_false
     status.exit_code.should eq(42)
+  end
+
+  it "runs at_exit handlers", tags: %w[slow] do
+    status, _, _ = compile_and_run_source <<-CRYSTAL
+    at_exit do |status|
+      exit 5
+    end
+    exit 3
+    CRYSTAL
+    status.exit_code.should eq 5
+  end
+end
+
+describe ".exit!" do
+  it "exits normally with status 0", tags: %w[slow] do
+    status, _, _ = compile_and_run_source "exit!"
+    status.success?.should be_true
+  end
+
+  it "exits with given error code", tags: %w[slow] do
+    status, _, _ = compile_and_run_source "exit! 42"
+    status.success?.should be_false
+    status.exit_code.should eq(42)
+  end
+
+  it "does not run at_exit handlers", tags: %w[slow] do
+    status, _, _ = compile_and_run_source <<-CRYSTAL
+    at_exit do |status|
+      status + 2
+    end
+    exit 3
+    CRYSTAL
+    status.exit_code.should eq 3
   end
 end
 

--- a/src/kernel.cr
+++ b/src/kernel.cr
@@ -522,6 +522,14 @@ end
 # Registered `at_exit` procs are executed.
 def exit(status = 0) : NoReturn
   status = Crystal::AtExitHandlers.run status
+  exit!(status)
+end
+
+# Terminates execution immediately, returning the given status code
+# to the invoking environment.
+#
+# Registered `at_exit` procs are not executed.
+def exit!(status = 0) : NoReturn
   Crystal.ignore_stdio_errors { STDOUT.flush }
   Crystal.ignore_stdio_errors { STDERR.flush }
   Process.exit(status)


### PR DESCRIPTION
Resolves part of #8687, adding `::exit!` to exit directly without running `at_exit` handlers.