### PR TITLE
Add dark mode to docs

### DIFF
--- a/src/compiler/crystal/tools/doc/html/css/style.css
+++ b/src/compiler/crystal/tools/doc/html/css/style.css
@@ -752,8 +752,8 @@ span.flag.lime {
 
   h1.type-name {
     color: white;
-    background-color: #343434;
-    border: 1px solid #858585;
+    background-color: #202020;
+    border: 1px solid #353535;
   }
 
   .superclass-hierarchy .superclass a,
@@ -832,9 +832,9 @@ span.flag.lime {
   }
 
   .entry-detail .signature {
-    background-color: #343434;
+    background-color: #202020;
     color: white;
-    border: 1px solid #858585;
+    border: 1px solid #353535;
   }
 
   .entry-detail .signature .method-permalink {
@@ -842,7 +842,7 @@ span.flag.lime {
   }
 
   :not(pre)>code {
-    background-color: #343434;
+    background-color: #202020;
   }
 
   span.flag.purple {
@@ -869,7 +869,7 @@ span.flag.lime {
 
   pre {
     color: white;
-    background: #343434;
-    border: 1px solid #858585;
+    background: #202020;
+    border: 1px solid #353535;
   }
 }

--- a/src/compiler/crystal/tools/doc/html/css/style.css
+++ b/src/compiler/crystal/tools/doc/html/css/style.css
@@ -724,3 +724,151 @@ span.flag.lime {
 .main-content h6:hover .anchor .octicon-link {
   visibility: visible
 }
+
+@media (prefers-color-scheme: dark) {
+  :root {
+    color-scheme: dark;
+  }
+
+  html, body {
+    background: #1b1b1b;
+  }
+
+  body {
+    color: white;
+  }
+
+  a {
+    color: #8cb4ff;
+  }
+
+  .main-content a:visited {
+    color: #5f8de3;
+  }
+
+  h1, h2, h3, h4, h5, h6 {
+    color: white;
+  }
+
+  h1.type-name {
+    color: white;
+    background-color: #343434;
+    border: 1px solid #858585;
+  }
+
+  .superclass-hierarchy .superclass a,
+  .superclass-hierarchy .superclass a:visited,
+  .other-type a,
+  .other-type a:visited,
+  .entry-summary .signature {
+    background-color: #343434;
+    color: white;
+    border: 1px solid #858585;
+  }
+
+  .superclass-hierarchy .superclass a:hover,
+  .other-type a:hover,
+  .entry-summary .signature:hover {
+    background: #443d4d;
+    border-color: #b092d4;
+  }
+
+  .kind {
+    color: #b092d4;
+  }
+
+  .n {
+    color: #00ade6;
+  }
+
+  .t {
+    color: #00ade6;
+  }
+
+  .k {
+    color: #ff66ae;
+  }
+
+  .o {
+    color: #ff66ae;
+  }
+
+  .s {
+    color: #7799ff;
+  }
+
+  .i {
+    color: #b38668;
+  }
+
+  .m {
+    color: #b9a5d6;
+  }
+
+  .c {
+    color: #a1a1a1;
+  }
+
+  .methods-inherited a, .methods-inherited a:visited {
+    color: #B290D9;
+  }
+
+  .methods-inherited a:hover {
+    color: #D4B7F4;
+  }
+
+  .methods-inherited .tooltip>span {
+    background: #443d4d;
+  }
+
+  .methods-inherited .tooltip * {
+    color: white;
+  }
+
+  .entry-detail:target .signature {
+    background-color: #443d4d;
+    border: 1px solid #b092d4;
+  }
+
+  .entry-detail .signature {
+    background-color: #343434;
+    color: white;
+    border: 1px solid #858585;
+  }
+
+  .entry-detail .signature .method-permalink {
+    color: #b092d4;
+  }
+
+  :not(pre)>code {
+    background-color: #343434;
+  }
+
+  span.flag.purple {
+    background-color: #443d4d;
+    color: #ECE1F9;
+    border-color: #b092d4;
+  }
+
+  .sidebar input::-webkit-input-placeholder { /* Chrome/Opera/Safari */
+    color: white;
+  }
+  
+  .sidebar input::-moz-placeholder { /* Firefox 19+ */
+    color: white;
+  }
+  
+  .sidebar input:-ms-input-placeholder { /* IE 10+ */
+    color: white;
+  }
+  
+  .sidebar input:-moz-placeholder { /* Firefox 18- */
+    color: white;
+  }
+
+  pre {
+    color: white;
+    background: #343434;
+    border: 1px solid #858585;
+  }
+}

--- a/src/compiler/crystal/tools/doc/html/css/style.css
+++ b/src/compiler/crystal/tools/doc/html/css/style.css
@@ -760,10 +760,11 @@ span.flag.lime {
   .superclass-hierarchy .superclass a:visited,
   .other-type a,
   .other-type a:visited,
-  .entry-summary .signature {
-    background-color: #343434;
+  .entry-summary .signature,
+  .entry-summary a:visited {
+    background-color: #202020;
     color: white;
-    border: 1px solid #858585;
+    border: 1px solid #353535;
   }
 
   .superclass-hierarchy .superclass a:hover,


### PR DESCRIPTION
Hopefully I didn't miss anything :sweat_smile: 

The colors are close to the original ones but lighter enough to pass wcag

Light | Dark
--- | ---
![Screenshot from 2023-05-27 09-37-34](https://github.com/crystal-lang/crystal/assets/18014039/6d80ba2e-e7ce-4a52-916b-5b20ab99fef1) | ![Screenshot from 2023-05-27 09-37-26](https://github.com/crystal-lang/crystal/assets/18014039/3da51c21-bc06-425d-94a0-00ea465ea1a3)
![Screenshot from 2023-05-27 09-45-10](https://github.com/crystal-lang/crystal/assets/18014039/ded5f279-c448-43dc-86f7-fb0a9c861b80) | ![Screenshot from 2023-05-27 09-45-17](https://github.com/crystal-lang/crystal/assets/18014039/7b106ef8-9d2f-427b-ba86-5fdcab44a6f8)
![Screenshot from 2023-05-27 09-46-48](https://github.com/crystal-lang/crystal/assets/18014039/e797f414-5b04-4f48-be61-56c0c600f012) | ![image](https://github.com/crystal-lang/crystal/assets/18014039/971eda9c-1f16-49ba-9bef-440e5af3f581)





