### PR TITLE
Correctly ignore nested deprecation warnings

### DIFF
--- a/spec/compiler/semantic/warnings_spec.cr
+++ b/spec/compiler/semantic/warnings_spec.cr
@@ -267,6 +267,19 @@ describe "Semantic: warnings" do
       end
     end
 
+    it "ignores nested calls to deprecated methods" do
+      x = assert_warning <<-CRYSTAL,
+        @[Deprecated]
+        def foo; bar; end
+
+        @[Deprecated]
+        def bar; end
+
+        foo
+        CRYSTAL
+        "warning in line 7\nWarning: Deprecated top-level foo."
+    end
+
     it "errors if invalid argument type" do
       assert_error <<-CRYSTAL,
         @[Deprecated(42)]

--- a/src/compiler/crystal/semantic/cleanup_transformer.cr
+++ b/src/compiler/crystal/semantic/cleanup_transformer.cr
@@ -464,7 +464,9 @@ module Crystal
         return expanded.transform self
       end
 
-      @program.check_call_to_deprecated_method(node)
+      unless @current_def.try(&.annotation(@program.deprecated_annotation))
+        @program.check_call_to_deprecated_method(node)
+      end
 
       # Need to transform these manually because node.block doesn't
       # need to be transformed if it has a fun_literal


### PR DESCRIPTION
Resolves  #13507

This is a very basic implementation to ignore warnigs when calling a deprecated method directly within the body of another deprecated method.
It covers the most common use case.

A more sophisticated approach would take other deprecation scopes into account as well (for example, ignore any deprecation warnings from within a deprecated type). But that requires more complex changes and we're getting already most of the way with this basic implementation.