### PR TITLE
Add mobile support to docs

### DIFF
--- a/src/compiler/crystal/tools/doc/html/_head.html
+++ b/src/compiler/crystal/tools/doc/html/_head.html
@@ -1,5 +1,6 @@
 <meta charset="utf-8" />
 <meta http-equiv="X-UA-Compatible" content="IE=edge">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
 <meta name="generator" content="Crystal Docs <%= Crystal::VERSION %>">
 <meta name="crystal_docs.project_version" content="<%= project_info.version %>">
 <meta name="crystal_docs.project_name" content="<%= project_info.name %>">

--- a/src/compiler/crystal/tools/doc/html/css/style.css
+++ b/src/compiler/crystal/tools/doc/html/css/style.css
@@ -724,3 +724,71 @@ span.flag.lime {
 .main-content h6:hover .anchor .octicon-link {
   visibility: visible
 }
+
+img {
+  max-width: 100%;
+}
+
+#sidebar-btn {
+  height: 32px;
+  width: 32px;
+}
+
+#sidebar-btn-label {
+  height: 2em;
+  width: 2em;
+}
+
+#sidebar-btn, #sidebar-btn-label {
+  display: none;
+  margin: .7rem;
+  appearance: none;
+  color: black;
+  cursor: pointer;
+}
+
+@media only screen and (max-width: 635px) {
+  .sidebar, .main-content {
+    /* svg size + vertical margin - .search-box padding-top */
+    padding-top: calc(2em + 2 * 0.7rem - 13px);
+  }
+
+  #sidebar-btn, #sidebar-btn-label {
+    display: block;
+    position: absolute;
+    z-index: 50;
+    transition-duration: 200ms;
+    left: 0;
+  }
+  
+  #sidebar-btn:not(:checked) ~ #sidebar-btn-label > .close,
+  #sidebar-btn:checked ~ #sidebar-btn-label > .open,
+  #sidebar-btn:checked ~ .main-content {
+    display: none;
+  }
+
+  #sidebar-btn:checked {
+    left: calc(100% - 32px - (2 * 0.7rem));
+  }
+
+  #sidebar-btn:checked ~ #sidebar-btn-label {
+    color: white;
+    /* 100% - svg size - horizontal margin */
+    left: calc(100% - 2em - (2 * 0.7rem));
+  }
+
+  #sidebar-btn~.sidebar {
+    width: 0%;
+  }
+
+  #sidebar-btn:checked~.sidebar {
+    visibility: visible;
+    width: 100%;
+  }
+
+  .sidebar {
+    transition-duration: 200ms;
+    max-width: 100vw;
+    visibility: hidden;
+  }
+}

--- a/src/compiler/crystal/tools/doc/html/css/style.css
+++ b/src/compiler/crystal/tools/doc/html/css/style.css
@@ -940,4 +940,8 @@ img {
     background: #202020;
     border: 1px solid #353535;
   }
+
+  #sidebar-btn, #sidebar-btn-label {
+    color: white; 
+  }
 }

--- a/src/compiler/crystal/tools/doc/html/js/doc.js
+++ b/src/compiler/crystal/tools/doc/html/js/doc.js
@@ -29,7 +29,7 @@ document.addEventListener('DOMContentLoaded', function() {
     var openTypes = typesList.querySelectorAll('.current');
     if (openTypes.length > 0) {
       var lastOpenType = openTypes[openTypes.length - 1];
-      lastOpenType.scrollIntoView();
+      lastOpenType.scrollIntoView(!(window.matchMedia('only screen and (max-width: 635px)')).matches);
     }
   }
 

--- a/src/compiler/crystal/tools/doc/html/main.html
+++ b/src/compiler/crystal/tools/doc/html/main.html
@@ -11,6 +11,7 @@
 <body>
 
 <%= Crystal::Doc::SVG_DEFS %>
+<%= Crystal::Doc::SIDEBAR_BUTTON %>
 <%= SidebarTemplate.new(project_info, types, nil) %>
 
 <div class="main-content">

--- a/src/compiler/crystal/tools/doc/html/type.html
+++ b/src/compiler/crystal/tools/doc/html/type.html
@@ -11,6 +11,7 @@
 <body>
 
 <%= Crystal::Doc::SVG_DEFS %>
+<%= Crystal::Doc::SIDEBAR_BUTTON %>
 <%= SidebarTemplate.new(project_info, types, type) %>
 
 <div class="main-content">

--- a/src/compiler/crystal/tools/doc/templates.cr
+++ b/src/compiler/crystal/tools/doc/templates.cr
@@ -9,6 +9,14 @@ module Crystal::Doc
   </svg>
   SVG
 
+  SIDEBAR_BUTTON = <<-HTML
+  <input type="checkbox" id="sidebar-btn">
+  <label for="sidebar-btn" id="sidebar-btn-label">
+    <svg class="open" xmlns="http://www.w3.org/2000/svg" height="2em" width="2em" viewBox="0 0 512 512"><title>Open Sidebar</title><path fill="currentColor" d="M80 96v64h352V96H80zm0 112v64h352v-64H80zm0 112v64h352v-64H80z"></path></svg>
+    <svg class="close" xmlns="http://www.w3.org/2000/svg" width="2em" height="2em" viewBox="0 0 512 512"><title>Close Sidebar</title><path fill="currentColor" d="m118.6 73.4-45.2 45.2L210.7 256 73.4 393.4l45.2 45.2L256 301.3l137.4 137.3 45.2-45.2L301.3 256l137.3-137.4-45.2-45.2L256 210.7Z"></path></svg>
+  </label>
+  HTML
+
   def self.anchor_link(anchor : String)
     anchor = anchor.downcase.gsub(' ', '-')
 


### PR DESCRIPTION
This PR adds mobile support to docs

There hasn't been any prior discussion/communication about this, so it may require a lot of changes. The key parts are:

- No JS
- Doesn't change many parts of the dom
- I drew the icons for licensing reasons - if you have better ones in mind, let me know
- `lastOpenType.scrollIntoView` is no longer on top, because `DOMContentLoaded` is emitted before CSS is done (causing the open type to not be in view)

[output.webm](https://github.com/crystal-lang/crystal/assets/18014039/d95cece8-3508-4255-81c3-04aa173ccc47)

[Screencast from 2023-05-29 14-14-41.webm](https://github.com/crystal-lang/crystal/assets/18014039/c20d2365-e819-41f5-af20-c282b6795b48)

fix: #13489
~~TODO: change open svg color to white on dark mode when #13512 gets merged~~