### PR TITLE
Fix `Atomic#max` and `#min` for signed enums

### DIFF
--- a/spec/std/atomic_spec.cr
+++ b/spec/std/atomic_spec.cr
@@ -4,6 +4,7 @@ enum AtomicEnum
   One
   Two
   Three
+  Minus = -1
 end
 
 @[Flags]
@@ -126,6 +127,16 @@ describe Atomic do
     atomic.get.should eq(UInt32::MAX)
   end
 
+  it "#max with signed enum" do
+    atomic = Atomic.new(AtomicEnum::Two)
+    atomic.max(AtomicEnum::One).should eq(AtomicEnum::Two)
+    atomic.get.should eq(AtomicEnum::Two)
+    atomic.max(AtomicEnum::Three).should eq(AtomicEnum::Two)
+    atomic.get.should eq(AtomicEnum::Three)
+    atomic.max(AtomicEnum::Minus).should eq(AtomicEnum::Three)
+    atomic.get.should eq(AtomicEnum::Three)
+  end
+
   it "#min with signed" do
     atomic = Atomic.new(5)
     atomic.min(10).should eq(5)
@@ -140,6 +151,16 @@ describe Atomic do
     atomic.get.should eq(10_u32)
     atomic.min(15_u32).should eq(10_u32)
     atomic.get.should eq(10_u32)
+  end
+
+  it "#min with signed enum" do
+    atomic = Atomic.new(AtomicEnum::Two)
+    atomic.min(AtomicEnum::Three).should eq(AtomicEnum::Two)
+    atomic.get.should eq(AtomicEnum::Two)
+    atomic.min(AtomicEnum::One).should eq(AtomicEnum::Two)
+    atomic.get.should eq(AtomicEnum::One)
+    atomic.min(AtomicEnum::Minus).should eq(AtomicEnum::One)
+    atomic.get.should eq(AtomicEnum::Minus)
   end
 
   it "#set" do

--- a/src/atomic.cr
+++ b/src/atomic.cr
@@ -125,7 +125,13 @@ struct Atomic(T)
   # atomic.get     # => 10
   # ```
   def max(value : T)
-    {% if T < Int::Signed %}
+    {% if T < Enum %}
+      if @value.value.is_a?(Int::Signed)
+        Ops.atomicrmw(:max, pointerof(@value), value, :sequentially_consistent, false)
+      else
+        Ops.atomicrmw(:umax, pointerof(@value), value, :sequentially_consistent, false)
+      end
+    {% elsif T < Int::Signed %}
       Ops.atomicrmw(:max, pointerof(@value), value, :sequentially_consistent, false)
     {% else %}
       Ops.atomicrmw(:umax, pointerof(@value), value, :sequentially_consistent, false)
@@ -144,7 +150,13 @@ struct Atomic(T)
   # atomic.get    # => 3
   # ```
   def min(value : T)
-    {% if T < Int::Signed %}
+    {% if T < Enum %}
+      if @value.value.is_a?(Int::Signed)
+        Ops.atomicrmw(:min, pointerof(@value), value, :sequentially_consistent, false)
+      else
+        Ops.atomicrmw(:umin, pointerof(@value), value, :sequentially_consistent, false)
+      end
+    {% elsif T < Int::Signed %}
       Ops.atomicrmw(:min, pointerof(@value), value, :sequentially_consistent, false)
     {% else %}
       Ops.atomicrmw(:umin, pointerof(@value), value, :sequentially_consistent, false)


### PR DESCRIPTION
Since enum types are not subtypes of their base types, the check `T < Int::Signed` in `Atomic(T)#max` and `#min` will always return false for enum types, which makes signed enums always use the unsigned interpretation. This PR adds the necessary runtime type checks. (The `TypeNode#base_type` suggested in #9803 could turn this runtime check into a compile-time one.)