### PR TITLE
Fix timeout events getting lost on Windows

### DIFF
--- a/src/crystal/system/event_loop.cr
+++ b/src/crystal/system/event_loop.cr
@@ -11,7 +11,7 @@ abstract class Crystal::EventLoop
   # Creates a timeout_event.
   abstract def create_timeout_event(fiber : Fiber) : Event
 
-  abstract struct Event
+  module Event
     # Frees the event.
     abstract def free : Nil
 

--- a/src/crystal/system/unix/event_libevent.cr
+++ b/src/crystal/system/unix/event_libevent.cr
@@ -5,7 +5,9 @@ require "./lib_event2"
 {% end %}
 
 # :nodoc:
-struct Crystal::LibEvent::Event < Crystal::EventLoop::Event
+struct Crystal::LibEvent::Event
+  include Crystal::EventLoop::Event
+
   VERSION = String.new(LibEvent2.event_get_version)
 
   def self.callback(&block : Int32, LibEvent2::EventFlags, Void* ->)

--- a/src/crystal/system/wasi/event_loop.cr
+++ b/src/crystal/system/wasi/event_loop.cr
@@ -33,7 +33,9 @@ class Crystal::Wasi::EventLoop < Crystal::EventLoop
   end
 end
 
-struct Crystal::Wasi::Event < Crystal::EventLoop::Event
+struct Crystal::Wasi::Event
+  include Crystal::EventLoop::Event
+
   def add(timeout : Time::Span?) : Nil
   end
 

--- a/src/crystal/system/win32/event_loop_iocp.cr
+++ b/src/crystal/system/win32/event_loop_iocp.cr
@@ -69,13 +69,13 @@ class Crystal::Iocp::EventLoop < Crystal::EventLoop
   end
 
   def enqueue(event : Crystal::Iocp::Event)
-    unless @queue.any? &.id.==(event.id)
+    unless @queue.includes?(event)
       @queue << event
     end
   end
 
   def dequeue(event : Crystal::Iocp::Event)
-    @queue.reject_did_remove? &.id.==(event.id)
+    @queue.delete(event)
   end
 
   # Create a new resume event for a fiber.
@@ -88,16 +88,14 @@ class Crystal::Iocp::EventLoop < Crystal::EventLoop
   end
 end
 
-struct Crystal::Iocp::Event < Crystal::EventLoop::Event
-  getter id : UInt64
+class Crystal::Iocp::Event
+  include Crystal::EventLoop::Event
+
   getter fiber
   getter wake_at
   getter? timeout
 
-  @@id = Atomic(UInt64).new(0)
-
   def initialize(@fiber : Fiber, @wake_at = Time.monotonic, *, @timeout = false)
-    @id = @@id.add(1)
   end
 
   # Frees the event

--- a/src/deque.cr
+++ b/src/deque.cr
@@ -299,6 +299,14 @@ class Deque(T)
     self
   end
 
+  # :nodoc:
+  # needed by `Crystal::Iocp::EventLoop#dequeue`; acts like `#reject!`, returns
+  # like `#delete`
+  def reject_did_remove?(&) : Bool
+    match = internal_delete { |e| yield e }
+    !match.nil?
+  end
+
   # Modifies `self`, deleting the elements in the collection for which
   # `pattern === element`.
   #

--- a/src/deque.cr
+++ b/src/deque.cr
@@ -299,14 +299,6 @@ class Deque(T)
     self
   end
 
-  # :nodoc:
-  # needed by `Crystal::Iocp::EventLoop#dequeue`; acts like `#reject!`, returns
-  # like `#delete`
-  def reject_did_remove?(&) : Bool
-    match = internal_delete { |e| yield e }
-    !match.nil?
-  end
-
   # Modifies `self`, deleting the elements in the collection for which
   # `pattern === element`.
   #


### PR DESCRIPTION
Fixes #13519 in a relatively non-intrusive manner. (The more intrusive alternative is to turn `Crystal::EventLoop::Event` into a module and `Crystal::Iocp::Event` into a class.)