### PR TITLE
Do not drop `/LIBPATH` from Windows linker command

### DIFF
--- a/src/compiler/crystal/loader/msvc.cr
+++ b/src/compiler/crystal/loader/msvc.cr
@@ -91,6 +91,7 @@ class Crystal::Loader
     args.each do |arg|
       if lib_path = arg.lchop?("/LIBPATH:")
         extra_search_paths << lib_path
+        remaining << arg if remaining
       elsif !arg.starts_with?('/') && (name = arg.rchop?(".lib"))
         libnames << name
       elsif remaining


### PR DESCRIPTION
This should fix #13528, as the `/LIBPATH`s are still needed by libs to resolve dependencies to other libs.