### PR TITLE
String#reverse: note about unicode graphemes

### DIFF
--- a/src/string.cr
+++ b/src/string.cr
@@ -4341,6 +4341,12 @@ class String
   # "Argentina".reverse # => "anitnegrA"
   # "racecar".reverse   # => "racecar"
   # ```
+  #
+  # Works on Unicode graphemes (and not codepoints) so combining characters are preserved.
+  #
+  # ```
+  # puts "Noe\u0308l".reverse # => "lëoN"
+  # ```
   def reverse : String
     return self if bytesize <= 1
 


### PR DESCRIPTION
State that `String#reverse` works on Unicode graphemes (and not codepoints) so combining characters are preserved.