### PR TITLE
Do not attempt downcasing first when case-folding a `Char`

### DIFF
--- a/spec/std/char_spec.cr
+++ b/spec/std/char_spec.cr
@@ -19,6 +19,7 @@ describe "Char" do
     end
     it { 'Ń'.downcase(Unicode::CaseOptions::Fold).should eq('ń') }
     it { 'ꭰ'.downcase(Unicode::CaseOptions::Fold).should eq('Ꭰ') }
+    it { 'Ꭰ'.downcase(Unicode::CaseOptions::Fold).should eq('Ꭰ') }
   end
 
   it "#succ" do

--- a/spec/std/char_spec.cr
+++ b/spec/std/char_spec.cr
@@ -18,6 +18,7 @@ describe "Char" do
       actual.should eq(['s', 's'])
     end
     it { 'Ń'.downcase(Unicode::CaseOptions::Fold).should eq('ń') }
+    it { 'ꭰ'.downcase(Unicode::CaseOptions::Fold).should eq('Ꭰ') }
   end
 
   it "#succ" do

--- a/spec/std/string_spec.cr
+++ b/spec/std/string_spec.cr
@@ -635,32 +635,20 @@ describe "String" do
   end
 
   describe "#downcase" do
-    it { "HELLO!".downcase.should eq("hello!") }
-    it { "HELLO MAN!".downcase.should eq("hello man!") }
-    it { "ÁÉÍÓÚĀ".downcase.should eq("áéíóúā") }
-    it { "AEIİOU".downcase(Unicode::CaseOptions::Turkic).should eq("aeıiou") }
-    it { "ÁEÍOÚ".downcase(Unicode::CaseOptions::ASCII).should eq("ÁeÍoÚ") }
-    it { "İ".downcase.should eq("i̇") }
-    it { "Baﬄe".downcase(Unicode::CaseOptions::Fold).should eq("baffle") }
-    it { "ﬀ".downcase(Unicode::CaseOptions::Fold).should eq("ff") }
-    it { "tschüß".downcase(Unicode::CaseOptions::Fold).should eq("tschüss") }
-    it { "ΣίσυφοςﬁÆ".downcase(Unicode::CaseOptions::Fold).should eq("σίσυφοσfiæ") }
+    it { assert_prints "HELLO!".downcase, "hello!" }
+    it { assert_prints "HELLO MAN!".downcase, "hello man!" }
+    it { assert_prints "ÁÉÍÓÚĀ".downcase, "áéíóúā" }
+    it { assert_prints "AEIİOU".downcase(Unicode::CaseOptions::Turkic), "aeıiou" }
+    it { assert_prints "ÁEÍOÚ".downcase(Unicode::CaseOptions::ASCII), "ÁeÍoÚ" }
+    it { assert_prints "İ".downcase, "i̇" }
+    it { assert_prints "Baﬄe".downcase(Unicode::CaseOptions::Fold), "baffle" }
+    it { assert_prints "ﬀ".downcase(Unicode::CaseOptions::Fold), "ff" }
+    it { assert_prints "tschüß".downcase(Unicode::CaseOptions::Fold), "tschüss" }
+    it { assert_prints "ΣίσυφοςﬁÆ".downcase(Unicode::CaseOptions::Fold), "σίσυφοσfiæ" }
+    it { assert_prints "ꭰ".downcase(Unicode::CaseOptions::Fold), "Ꭰ" }
 
     it "does not touch invalid code units in an otherwise ascii string" do
       "\xB5!\xE0\xC1\xB5?".downcase.should eq("\xB5!\xE0\xC1\xB5?")
-    end
-
-    describe "with IO" do
-      it { String.build { |io| "HELLO!".downcase io }.should eq "hello!" }
-      it { String.build { |io| "HELLO MAN!".downcase io }.should eq "hello man!" }
-      it { String.build { |io| "ÁÉÍÓÚĀ".downcase io }.should eq "áéíóúā" }
-      it { String.build { |io| "AEIİOU".downcase io, Unicode::CaseOptions::Turkic }.should eq "aeıiou" }
-      it { String.build { |io| "ÁEÍOÚ".downcase io, Unicode::CaseOptions::ASCII }.should eq "ÁeÍoÚ" }
-      it { String.build { |io| "İ".downcase io }.should eq "i̇" }
-      it { String.build { |io| "Baﬄe".downcase io, Unicode::CaseOptions::Fold }.should eq "baffle" }
-      it { String.build { |io| "ﬀ".downcase io, Unicode::CaseOptions::Fold }.should eq "ff" }
-      it { String.build { |io| "tschüß".downcase io, Unicode::CaseOptions::Fold }.should eq "tschüss" }
-      it { String.build { |io| "ΣίσυφοςﬁÆ".downcase io, Unicode::CaseOptions::Fold }.should eq "σίσυφοσfiæ" }
     end
   end
 

--- a/spec/std/string_spec.cr
+++ b/spec/std/string_spec.cr
@@ -646,6 +646,7 @@ describe "String" do
     it { assert_prints "tschüß".downcase(Unicode::CaseOptions::Fold), "tschüss" }
     it { assert_prints "ΣίσυφοςﬁÆ".downcase(Unicode::CaseOptions::Fold), "σίσυφοσfiæ" }
     it { assert_prints "ꭰ".downcase(Unicode::CaseOptions::Fold), "Ꭰ" }
+    it { assert_prints "Ꭰ".downcase(Unicode::CaseOptions::Fold), "Ꭰ" }
 
     it "does not touch invalid code units in an otherwise ascii string" do
       "\xB5!\xE0\xC1\xB5?".downcase.should eq("\xB5!\xE0\xC1\xB5?")

--- a/src/char.cr
+++ b/src/char.cr
@@ -400,8 +400,26 @@ struct Char
   # 'x'.downcase # => 'x'
   # '.'.downcase # => '.'
   # ```
+  #
+  # If `options.fold?` is true, then returns the case-folded equivalent instead.
+  # Note that this will return `self` if a multiple-character case folding
+  # exists, even if a separate single-character transformation is also defined
+  # in Unicode.
+  #
+  # ```
+  # 'Z'.downcase(Unicode::CaseOptions::Fold) # => 'z'
+  # 'x'.downcase(Unicode::CaseOptions::Fold) # => 'x'
+  # 'ς'.downcase(Unicode::CaseOptions::Fold) # => 'σ'
+  # 'ꭰ'.downcase(Unicode::CaseOptions::Fold) # => 'Ꭰ'
+  # 'ẞ'.downcase(Unicode::CaseOptions::Fold) # => 'ẞ' # not U+00DF 'ß'
+  # 'ᾈ'.downcase(Unicode::CaseOptions::Fold) # => "ᾈ" # not U+1F80 'ᾀ'
+  # ```
   def downcase(options : Unicode::CaseOptions = :none) : Char
-    Unicode.downcase(self, options)
+    if options.fold?
+      Unicode.foldcase(self, options)
+    else
+      Unicode.downcase(self, options)
+    end
   end
 
   # Yields each char for the downcase equivalent of this char.
@@ -409,8 +427,19 @@ struct Char
   # This method takes into account the possibility that an downcase
   # version of a char might result in multiple chars, like for
   # 'İ', which results in 'i' and a dot mark.
+  #
+  # ```
+  # 'Z'.downcase { |v| puts v }                             # prints 'z'
+  # 'ς'.downcase(Unicode::CaseOptions::Fold) { |v| puts v } # prints 'σ'
+  # 'ẞ'.downcase(Unicode::CaseOptions::Fold) { |v| puts v } # prints 's', 's'
+  # 'ᾈ'.downcase(Unicode::CaseOptions::Fold) { |v| puts v } # prints 'ἀ', 'ι'
+  # ```
   def downcase(options : Unicode::CaseOptions = :none, &)
-    Unicode.downcase(self, options) { |char| yield char }
+    if options.fold?
+      Unicode.foldcase(self, options) { |char| yield char }
+    else
+      Unicode.downcase(self, options) { |char| yield char }
+    end
   end
 
   # Returns the upcase equivalent of this char.


### PR DESCRIPTION
Fixes the case-folding bug mentioned in #13534.