### PR TITLE
Added LibC::SSizeT for Win32

### DIFF
--- a/src/lib_c/x86_64-windows-msvc/c/stddef.cr
+++ b/src/lib_c/x86_64-windows-msvc/c/stddef.cr
@@ -1,3 +1,4 @@
 lib LibC
   alias SizeT = UInt64
+  alias SSizeT = Int64
 end


### PR DESCRIPTION
Win32 was missing LibC::SSizeT and this change adds it in to add parity with the Linux/Unix LibC.