### PR TITLE
Add compiler command `crystal clear_cache`

### DIFF
--- a/spec/compiler/crystal/commands/clear_cache_spec.cr
+++ b/spec/compiler/crystal/commands/clear_cache_spec.cr
@@ -1,0 +1,16 @@
+require "../../../spec_helper"
+
+describe Crystal::Command do
+  describe "clear_cache" do
+    it "clears any cached compiler files" do
+      file_path = File.join(CacheDir.instance.dir, "test_cache_file")
+      Dir.mkdir_p(File.dirname(file_path))
+      File.touch(file_path)
+      File.exists?(file_path).should be_true
+
+      Crystal::Command.run(["clear_cache"])
+
+      File.exists?(file_path).should be_false
+    end
+  end
+end

--- a/spec/compiler/crystal/commands/clear_cache_spec.cr
+++ b/spec/compiler/crystal/commands/clear_cache_spec.cr
@@ -1,7 +1,27 @@
 require "../../../spec_helper"
 
+class Crystal::CacheDir
+  class_setter instance
+
+  def initialize(@dir)
+    Dir.mkdir_p(dir)
+  end
+end
+
 describe Crystal::Command do
   describe "clear_cache" do
+    around_each do |example|
+      old_cache_dir = CacheDir.instance
+      temp_dir_name = File.tempname
+      begin
+        CacheDir.instance = CacheDir.new(temp_dir_name)
+        example.run
+      ensure
+        FileUtils.rm_rf(temp_dir_name)
+        CacheDir.instance = old_cache_dir
+      end
+    end
+
     it "clears any cached compiler files" do
       file_path = File.tempname(dir: CacheDir.instance.dir)
       Dir.mkdir_p(File.dirname(file_path))

--- a/spec/compiler/crystal/commands/clear_cache_spec.cr
+++ b/spec/compiler/crystal/commands/clear_cache_spec.cr
@@ -3,7 +3,7 @@ require "../../../spec_helper"
 describe Crystal::Command do
   describe "clear_cache" do
     it "clears any cached compiler files" do
-      file_path = File.join(CacheDir.instance.dir, "test_cache_file")
+      file_path = File.tempname(dir: CacheDir.instance.dir)
       Dir.mkdir_p(File.dirname(file_path))
       File.touch(file_path)
       File.exists?(file_path).should be_true
@@ -11,6 +11,7 @@ describe Crystal::Command do
       Crystal::Command.run(["clear_cache"])
 
       File.exists?(file_path).should be_false
+      File.exists?(CacheDir.instance.dir).should be_false
     end
   end
 end

--- a/src/compiler/crystal/command.cr
+++ b/src/compiler/crystal/command.cr
@@ -19,6 +19,7 @@ class Crystal::Command
     Command:
         init                     generate a new project
         build                    build an executable
+        clear_cache              clear the compiler cache
         docs                     generate documentation
         env                      print Crystal environment information
         eval                     eval code from args or standard input
@@ -112,6 +113,9 @@ class Crystal::Command
     when "tool".starts_with?(command)
       options.shift
       tool
+    when command == "clear_cache"
+      options.shift
+      clear_cache
     when "help".starts_with?(command), "--help" == command, "-h" == command
       puts USAGE
       exit

--- a/src/compiler/crystal/command/clear_cache.cr
+++ b/src/compiler/crystal/command/clear_cache.cr
@@ -20,7 +20,6 @@ class Crystal::Command
       opts.on("-v", "--verbose", "Display detailed information") do
         verbose = true
       end
-
     end
     puts "Clearing compiler cache at #{CacheDir.instance.dir.inspect}" if verbose
     FileUtils.rm_rf(CacheDir.instance.dir)

--- a/src/compiler/crystal/command/clear_cache.cr
+++ b/src/compiler/crystal/command/clear_cache.cr
@@ -1,0 +1,22 @@
+# Implementation of the `crystal clear_cache` command
+
+class Crystal::Command
+  private def clear_cache
+    OptionParser.parse(@options) do |opts|
+      opts.banner = <<-'BANNER'
+        Usage: crystal clear_cache
+
+        Clears the compiler cache
+
+        Options:
+        BANNER
+
+      opts.on("-h", "--help", "Show this message") do
+        puts opts
+        exit
+      end
+    end
+    puts "clearing compiler cache at \"#{CacheDir.instance.dir}\""
+    FileUtils.rm_rf(CacheDir.instance.dir)
+  end
+end

--- a/src/compiler/crystal/command/clear_cache.cr
+++ b/src/compiler/crystal/command/clear_cache.cr
@@ -22,7 +22,7 @@ class Crystal::Command
       end
 
     end
-    puts "clearing compiler cache at \"#{CacheDir.instance.dir}\"" if verbose
+    puts "Clearing compiler cache at #{CacheDir.instance.dir.inspect}" if verbose
     FileUtils.rm_rf(CacheDir.instance.dir)
   end
 end

--- a/src/compiler/crystal/command/clear_cache.cr
+++ b/src/compiler/crystal/command/clear_cache.cr
@@ -2,6 +2,7 @@
 
 class Crystal::Command
   private def clear_cache
+    verbose = false
     OptionParser.parse(@options) do |opts|
       opts.banner = <<-'BANNER'
         Usage: crystal clear_cache
@@ -15,8 +16,13 @@ class Crystal::Command
         puts opts
         exit
       end
+
+      opts.on("-v", "--verbose", "Display detailed information") do
+        verbose = true
+      end
+
     end
-    puts "clearing compiler cache at \"#{CacheDir.instance.dir}\""
+    puts "clearing compiler cache at \"#{CacheDir.instance.dir}\"" if verbose
     FileUtils.rm_rf(CacheDir.instance.dir)
   end
 end


### PR DESCRIPTION
Seemed simple enough to implement so I took a crack at it. Working perhaps isn't the best, but I think is moderately clear enough. Didn't add any tests because I don't know enough about the compiler to know how to easily generate cache files.

Fixes #4730