### PR TITLE
Make `BigDecimal`'s comparisons exact

### DIFF
--- a/spec/std/big/big_decimal_spec.cr
+++ b/spec/std/big/big_decimal_spec.cr
@@ -388,6 +388,20 @@ describe BigDecimal do
 
     BigRational.new(1, 2).should eq(BigDecimal.new("0.5"))
     BigRational.new(1, 4).should eq(BigDecimal.new("0.25"))
+
+    (1.to_big_d / 3).should be < BigRational.new(1, 3)
+    (-(1.to_big_d / 3)).should be > BigRational.new(-1, 3)
+    (-1.to_big_d / 3).should be < BigRational.new(-1, 3)
+
+    BigRational.new(1, 3).should be > 1.to_big_d / 3
+    BigRational.new(-1, 3).should be < -(1.to_big_d / 3)
+    BigRational.new(-1, 3).should be > -1.to_big_d / 3
+
+    (1.to_big_d / 3 + BigDecimal.new(1, BigDecimal::DEFAULT_PRECISION)).should be > BigRational.new(1, 3)
+    (-(1.to_big_d / 3) - BigDecimal.new(1, BigDecimal::DEFAULT_PRECISION)).should be < BigRational.new(-1, 3)
+
+    BigRational.new(1, 3).should be < (1.to_big_d / 3 + BigDecimal.new(1, BigDecimal::DEFAULT_PRECISION))
+    BigRational.new(-1, 3).should be > (-(1.to_big_d / 3) - BigDecimal.new(1, BigDecimal::DEFAULT_PRECISION))
   end
 
   it "keeps precision" do

--- a/spec/std/big/big_decimal_spec.cr
+++ b/spec/std/big/big_decimal_spec.cr
@@ -377,8 +377,23 @@ describe BigDecimal do
     (BigDecimal.new("7.5") > 6.6).should be_true
     (6.6 < BigDecimal.new("7.5")).should be_true
 
-    BigDecimal.new("6.6").should eq(6.6)
-    6.6.should eq(BigDecimal.new("6.6"))
+    "1.0000000000000002".to_big_d.should be < 1.0.next_float
+    (1.0.to_big_d + 0.5.to_big_d ** 52).should eq(1.0.next_float)
+    "1.0000000000000003".to_big_d.should be > 1.0.next_float
+
+    1.0.next_float.should be > "1.0000000000000002".to_big_d
+    1.0.next_float.should eq(1.0.to_big_d + 0.5.to_big_d ** 52)
+    1.0.next_float.should be < "1.0000000000000003".to_big_d
+
+    0.to_big_d.should be < Float64::INFINITY
+    (Float64::MAX.to_big_d ** 7).should be < Float64::INFINITY
+    0.to_big_d.should be > -Float64::INFINITY
+    (Float64::MIN.to_big_d ** 7).should be > -Float64::INFINITY
+
+    Float64::INFINITY.should be > 0.to_big_d
+    Float64::INFINITY.should be > (Float64::MAX.to_big_d ** 7)
+    (-Float64::INFINITY).should be < 0.to_big_d
+    (-Float64::INFINITY).should be < (Float64::MIN.to_big_d ** 7)
 
     (BigDecimal.new("6.5") > 7).should be_false
     (BigDecimal.new("7.5") > 6).should be_true
@@ -402,6 +417,20 @@ describe BigDecimal do
 
     BigRational.new(1, 3).should be < (1.to_big_d / 3 + BigDecimal.new(1, BigDecimal::DEFAULT_PRECISION))
     BigRational.new(-1, 3).should be > (-(1.to_big_d / 3) - BigDecimal.new(1, BigDecimal::DEFAULT_PRECISION))
+  end
+
+  describe "#<=>" do
+    it "compares against NaNs" do
+      (1.to_big_d <=> Float64::NAN).should be_nil
+      (1.to_big_d <=> Float32::NAN).should be_nil
+      (Float64::NAN <=> 1.to_big_d).should be_nil
+      (Float32::NAN <=> 1.to_big_d).should be_nil
+
+      typeof(1.to_big_d <=> Float64::NAN).should eq(Int32?)
+      typeof(1.to_big_d <=> Float32::NAN).should eq(Int32?)
+      typeof(Float64::NAN <=> 1.to_big_d).should eq(Int32?)
+      typeof(Float32::NAN <=> 1.to_big_d).should eq(Int32?)
+    end
   end
 
   it "keeps precision" do

--- a/spec/std/big/big_decimal_spec.cr
+++ b/spec/std/big/big_decimal_spec.cr
@@ -417,6 +417,12 @@ describe BigDecimal do
 
     BigRational.new(1, 3).should be < (1.to_big_d / 3 + BigDecimal.new(1, BigDecimal::DEFAULT_PRECISION))
     BigRational.new(-1, 3).should be > (-(1.to_big_d / 3) - BigDecimal.new(1, BigDecimal::DEFAULT_PRECISION))
+
+    (0.5.to_big_d ** 10000).should eq(0.5.to_big_f ** 10000)
+    "5.0123727492064520093e-3011".to_big_d.should be > 0.5.to_big_f ** 10000
+
+    (0.5.to_big_f ** 10000).should eq(0.5.to_big_d ** 10000)
+    (0.5.to_big_f ** 10000).should be < "5.0123727492064520093e-3011".to_big_d
   end
 
   describe "#<=>" do

--- a/src/big/big_decimal.cr
+++ b/src/big/big_decimal.cr
@@ -345,7 +345,11 @@ struct BigDecimal < Number
     self <=> other.to_big_r
   end
 
-  def <=>(other : Int | Float)
+  def <=>(other : BigFloat) : Int32
+    self <=> other.to_big_r
+  end
+
+  def <=>(other : Int)
     self <=> BigDecimal.new(other)
   end
 
@@ -823,7 +827,7 @@ end
 
 struct BigFloat
   def <=>(other : BigDecimal)
-    to_big_d <=> other
+    -(other <=> self)
   end
 end
 

--- a/src/big/big_decimal.cr
+++ b/src/big/big_decimal.cr
@@ -756,7 +756,7 @@ struct BigDecimal < Number
   end
 
   private def power_ten_to(x : Int) : Int
-    x == 1 ? TEN_I : TEN_I ** x
+    TEN_I ** x
   end
 
   # Factors out any extra powers of ten in the internal representation.

--- a/src/big/big_decimal.cr
+++ b/src/big/big_decimal.cr
@@ -335,6 +335,16 @@ struct BigDecimal < Number
     end
   end
 
+  def <=>(other : Float::Primitive) : Int32?
+    return nil if other.nan?
+
+    if sign = other.infinite?
+      return -sign
+    end
+
+    self <=> other.to_big_r
+  end
+
   def <=>(other : Int | Float)
     self <=> BigDecimal.new(other)
   end
@@ -794,7 +804,8 @@ struct Float
   include Comparable(BigDecimal)
 
   def <=>(other : BigDecimal)
-    to_big_d <=> other
+    cmp = other <=> self
+    -cmp if cmp
   end
 
   # Converts `self` to `BigDecimal`.
@@ -807,6 +818,12 @@ struct Float
   # ```
   def to_big_d : BigDecimal
     BigDecimal.new(self)
+  end
+end
+
+struct BigFloat
+  def <=>(other : BigDecimal)
+    to_big_d <=> other
   end
 end
 

--- a/src/big/big_int.cr
+++ b/src/big/big_int.cr
@@ -433,8 +433,11 @@ struct BigInt < Int
   def **(other : Int) : BigInt
     if other < 0
       raise ArgumentError.new("Negative exponent isn't supported")
+    elsif other == 1
+      self
+    else
+      BigInt.new { |mpz| LibGMP.pow_ui(mpz, self, other) }
     end
-    BigInt.new { |mpz| LibGMP.pow_ui(mpz, self, other) }
   end
 
   # Returns the greatest common divisor of `self` and *other*.

--- a/src/big/big_rational.cr
+++ b/src/big/big_rational.cr
@@ -78,11 +78,16 @@ struct BigRational < Number
   end
 
   def numerator : BigInt
-    BigInt.new { |mpz| LibGMP.mpq_get_num(mpz, self) }
+    # Returns `LibGMP.mpq_numref(self)`, whose C macro expansion effectively
+    # produces a raw member access. This is only as safe as copying `BigInt`s by
+    # value, as both involve copying `LibGMP::MPZ` around which has reference
+    # semantics, and `BigInt`s cannot be safely mutated in-place this way; see
+    # #9825 for details. Ditto for `#denominator`.
+    BigInt.new(@mpq._mp_num)
   end
 
   def denominator : BigInt
-    BigInt.new { |mpz| LibGMP.mpq_get_den(mpz, self) }
+    BigInt.new(@mpq._mp_den)
   end
 
   def <=>(other : BigRational)


### PR DESCRIPTION
Conversions from `BigRational | Float` to `BigDecimal` are inexact, but conversions from `BigDecimal | Float` to `BigRational` are exact, so the latter ones are used to implement `#<=>`.

Comparisons between `BigDecimal` and `Float::Primitive` now respect infinities and NaNs.