### PR TITLE
`YAML::Serializable#use_yaml_discriminator` to use `NumberLiteral#to_number`

### DIFF
--- a/src/yaml/serialization.cr
+++ b/src/yaml/serialization.cr
@@ -417,8 +417,7 @@ module YAML
             {% if key.is_a?(NumberLiteral) %}
               # An enum value is always a typed NumberLiteral and stringifies with type
               # suffix unless it's Int32.
-              # TODO: Replace this workaround with NumberLiteral#to_number after the next release
-              {% key = key.id.split("_")[0] %}
+              {% key = key.to_number %}
             {% end %}
             when {{key.id.stringify}}
               return {{value.id}}.new(ctx, node)


### PR DESCRIPTION
resolves #13557