### PR TITLE
Improve conversions from `BigInt` to `Int::Primitive`

### DIFF
--- a/spec/std/big/big_int_spec.cr
+++ b/spec/std/big/big_int_spec.cr
@@ -498,98 +498,118 @@ describe "BigInt" do
     a.should eq(b)
   end
 
-  it "can be casted into other Number types" do
-    big = BigInt.new(1234567890)
-    big.to_i.should eq(1234567890)
-    big.to_i8!.should eq(-46)
-    big.to_i16!.should eq(722)
-    big.to_i32.should eq(1234567890)
-    big.to_i64.should eq(1234567890)
-    big.to_u.should eq(1234567890)
-    big.to_u8!.should eq(210)
-    big.to_u16!.should eq(722)
-    big.to_u32.should eq(1234567890)
-
-    expect_raises(OverflowError) { BigInt.new(-1234567890).to_u }
-
-    u64 = big.to_u64
-    u64.should eq(1234567890)
-    u64.should be_a(UInt64)
-  end
-
-  context "conversion to 64-bit" do
-    it "above 64 bits" do
-      big = BigInt.new("9" * 20)
-      expect_raises(OverflowError) { big.to_i64 }
-      expect_raises(OverflowError) { big.to_u64 }
-      big.to_i64!.should eq(7766279631452241919) # 99999999999999999999 - 5*(2**64)
-      big.to_u64!.should eq(7766279631452241919)
-
-      big = BigInt.new("9" * 32)
-      expect_raises(OverflowError) { big.to_i64 }
-      expect_raises(OverflowError) { big.to_u64 }
-      big.to_i64!.should eq(-8814407033341083649)   # 99999999999999999999999999999999 - 5421010862428*(2**64)
-      big.to_u64!.should eq(9632337040368467967u64) # 99999999999999999999999999999999 - 5421010862427*(2**64)
-    end
-
-    it "between 63 and 64 bits" do
-      big = BigInt.new(i = 9999999999999999999u64)
-      expect_raises(OverflowError) { big.to_i64 }
-      big.to_u64.should eq(i)
-      big.to_i64!.should eq(-8446744073709551617) # 9999999999999999999 - 2**64
-      big.to_u64!.should eq(i)
-    end
-
-    it "between 32 and 63 bits" do
-      big = BigInt.new(i = 9999999999999)
-      big.to_i64.should eq(i)
-      big.to_u64.should eq(i)
-      big.to_i64!.should eq(i)
-      big.to_u64!.should eq(i)
-    end
-
-    it "negative under 32 bits" do
-      big = BigInt.new(i = -9999)
-      big.to_i64.should eq(i)
-      expect_raises(OverflowError) { big.to_u64 }
-      big.to_i64!.should eq(i)
-      big.to_u64!.should eq(18446744073709541617u64) # -9999 + 2**64
-    end
-
-    it "negative between 32 and 63 bits" do
-      big = BigInt.new(i = -9999999999999)
-      big.to_i64.should eq(i)
-      expect_raises(OverflowError) { big.to_u64 }
-      big.to_i64!.should eq(i)
-      big.to_u64!.should eq(18446734073709551617u64) # -9999999999999 + 2**64
-    end
-
-    it "negative between 63 and 64 bits" do
-      big = BigInt.new("-9999999999999999999")
-      expect_raises(OverflowError) { big.to_i64 }
-      expect_raises(OverflowError) { big.to_u64 }
-      big.to_i64!.should eq(8446744073709551617) # -9999999999999999999 + 2**64
-      big.to_u64!.should eq(8446744073709551617)
-    end
-
-    it "negative above 64 bits" do
-      big = BigInt.new("-" + "9" * 20)
-      expect_raises(OverflowError) { big.to_i64 }
-      expect_raises(OverflowError) { big.to_u64 }
-      big.to_i64!.should eq(-7766279631452241919)    # -9999999999999999999 + 5*(2**64)
-      big.to_u64!.should eq(10680464442257309697u64) # -9999999999999999999 + 6*(2**64)
-
-      big = BigInt.new("-" + "9" * 32)
-      expect_raises(OverflowError) { big.to_i64 }
-      expect_raises(OverflowError) { big.to_u64 }
-      big.to_i64!.should eq(8814407033341083649) # -99999999999999999999999999999999 + 5421010862428*(2**64)
-      big.to_u64!.should eq(8814407033341083649)
+  describe "#to_i" do
+    it "converts to Int32" do
+      BigInt.new(1234567890).to_i.should(be_a(Int32)).should eq(1234567890)
+      expect_raises(OverflowError) { BigInt.new(2147483648).to_i }
+      expect_raises(OverflowError) { BigInt.new(-2147483649).to_i }
     end
   end
 
-  it "can cast UInt64::MAX to UInt64 (#2264)" do
-    BigInt.new(UInt64::MAX).to_u64.should eq(UInt64::MAX)
+  describe "#to_i!" do
+    it "converts to Int32" do
+      BigInt.new(1234567890).to_i!.should(be_a(Int32)).should eq(1234567890)
+      BigInt.new(2147483648).to_i!.should eq(Int32::MIN)
+      BigInt.new(-2147483649).to_i!.should eq(Int32::MAX)
+    end
   end
+
+  describe "#to_u" do
+    it "converts to UInt32" do
+      BigInt.new(1234567890).to_u.should(be_a(UInt32)).should eq(1234567890_u32)
+      expect_raises(OverflowError) { BigInt.new(4294967296).to_u }
+      expect_raises(OverflowError) { BigInt.new(-1).to_u }
+    end
+  end
+
+  describe "#to_u!" do
+    it "converts to UInt32" do
+      BigInt.new(1234567890).to_u!.should(be_a(UInt32)).should eq(1234567890_u32)
+      BigInt.new(4294967296).to_u!.should eq(0_u32)
+      BigInt.new(-1).to_u!.should eq(UInt32::MAX)
+    end
+  end
+
+  {% for n in [8, 16, 32, 64, 128] %}
+    describe "#to_u{{n}}" do
+      it "converts to UInt{{n}}" do
+        (0..{{n - 1}}).each do |i|
+          (1.to_big_i << i).to_u{{n}}.should eq(UInt{{n}}.new(1) << i)
+        end
+
+        UInt{{n}}::MIN.to_big_i.to_u{{n}}.should eq(UInt{{n}}::MIN)
+        UInt{{n}}::MAX.to_big_i.to_u{{n}}.should eq(UInt{{n}}::MAX)
+      end
+
+      it "raises OverflowError" do
+        expect_raises(OverflowError) { (1.to_big_i << {{n}}).to_u{{n}} }
+        expect_raises(OverflowError) { (-1.to_big_i).to_u{{n}} }
+        expect_raises(OverflowError) { (-1.to_big_i << {{n}}).to_u{{n}} }
+      end
+    end
+
+    describe "#to_i{{n}}" do
+      it "converts to Int{{n}}" do
+        (0..{{n - 2}}).each do |i|
+          (1.to_big_i << i).to_i{{n}}.should eq(Int{{n}}.new(1) << i)
+          (-1.to_big_i << i).to_i{{n}}.should eq(Int{{n}}.new(-1) << i)
+        end
+
+        Int{{n}}.zero.to_big_i.to_i{{n}}.should eq(Int{{n}}.zero)
+        Int{{n}}::MAX.to_big_i.to_i{{n}}.should eq(Int{{n}}::MAX)
+        Int{{n}}::MIN.to_big_i.to_i{{n}}.should eq(Int{{n}}::MIN)
+      end
+
+      it "raises OverflowError" do
+        expect_raises(OverflowError) { (Int{{n}}::MAX.to_big_i + 1).to_i{{n}} }
+        expect_raises(OverflowError) { (Int{{n}}::MIN.to_big_i - 1).to_i{{n}} }
+        expect_raises(OverflowError) { (1.to_big_i << {{n}}).to_i{{n}} }
+        expect_raises(OverflowError) { (-1.to_big_i << {{n}}).to_i{{n}} }
+      end
+    end
+
+    describe "#to_u{{n}}!" do
+      it "converts to UInt{{n}}" do
+        (0..{{n - 1}}).each do |i|
+          (1.to_big_i << i).to_u{{n}}!.should eq(UInt{{n}}.new(1) << i)
+        end
+
+        UInt{{n}}::MAX.to_big_i.to_u{{n}}!.should eq(UInt{{n}}::MAX)
+      end
+
+      it "converts modulo (2 ** {{n}})" do
+        (1.to_big_i << {{n}}).to_u{{n}}!.should eq(UInt{{n}}.new(0))
+        (-1.to_big_i).to_u{{n}}!.should eq(UInt{{n}}::MAX)
+        (-1.to_big_i << {{n}}).to_u{{n}}!.should eq(UInt{{n}}.new(0))
+        (123.to_big_i - (1.to_big_i << {{n}})).to_u{{n}}!.should eq(UInt{{n}}.new(123))
+        (123.to_big_i + (1.to_big_i << {{n}})).to_u{{n}}!.should eq(UInt{{n}}.new(123))
+        (123.to_big_i - (1.to_big_i << {{n + 2}})).to_u{{n}}!.should eq(UInt{{n}}.new(123))
+        (123.to_big_i + (1.to_big_i << {{n + 2}})).to_u{{n}}!.should eq(UInt{{n}}.new(123))
+      end
+    end
+
+    describe "#to_i{{n}}!" do
+      it "converts to Int{{n}}" do
+        (0..126).each do |i|
+          (1.to_big_i << i).to_i{{n}}!.should eq(Int{{n}}.new(1) << i)
+          (-1.to_big_i << i).to_i{{n}}!.should eq(Int{{n}}.new(-1) << i)
+        end
+
+        Int{{n}}::MAX.to_big_i.to_i{{n}}!.should eq(Int{{n}}::MAX)
+        Int{{n}}::MIN.to_big_i.to_i{{n}}!.should eq(Int{{n}}::MIN)
+      end
+
+      it "converts modulo (2 ** {{n}})" do
+        (1.to_big_i << {{n - 1}}).to_i{{n}}!.should eq(Int{{n}}::MIN)
+        (1.to_big_i << {{n}}).to_i{{n}}!.should eq(Int{{n}}.new(0))
+        (-1.to_big_i << {{n}}).to_i{{n}}!.should eq(Int{{n}}.new(0))
+        (123.to_big_i - (1.to_big_i << {{n}})).to_i{{n}}!.should eq(Int{{n}}.new(123))
+        (123.to_big_i + (1.to_big_i << {{n}})).to_i{{n}}!.should eq(Int{{n}}.new(123))
+        (123.to_big_i - (1.to_big_i << {{n + 2}})).to_i{{n}}!.should eq(Int{{n}}.new(123))
+        (123.to_big_i + (1.to_big_i << {{n + 2}})).to_i{{n}}!.should eq(Int{{n}}.new(123))
+      end
+    end
+  {% end %}
 
   it "does String#to_big_i" do
     "123456789123456789".to_big_i.should eq(BigInt.new("123456789123456789"))

--- a/src/big/big_int.cr
+++ b/src/big/big_int.cr
@@ -61,6 +61,8 @@ struct BigInt < Int
       num = num.abs_unsigned
       capacity = (num.bit_length - 1) // (sizeof(LibGMP::MpLimb) * 8) + 1
 
+      # This assumes GMP wasn't built with its experimental nails support:
+      # https://gmplib.org/manual/Low_002dlevel-Functions
       unsafe_build(capacity) do |limbs|
         appender = limbs.to_unsafe.appender
         limbs.size.times do
@@ -83,6 +85,16 @@ struct BigInt < Int
     size, negative = yield Slice.new(limbs, capacity)
     LibGMP.limbs_finish(pointerof(mpz), size * (negative ? -1 : 1))
     new(mpz)
+  end
+
+  # Returns a read-only `Slice` of the limbs that make up this integer, which
+  # is effectively `abs.digits(2 ** N)` where `N` is the number of bits in
+  # `LibGMP::MpLimb`, except that an empty `Slice` is returned for zero.
+  #
+  # This assumes GMP wasn't built with its experimental nails support:
+  # https://gmplib.org/manual/Low_002dlevel-Functions
+  private def limbs
+    Slice.new(LibGMP.limbs_read(self), LibGMP.size(self), read_only: true)
   end
 
   # :ditto:
@@ -621,91 +633,113 @@ struct BigInt < Int
     to_i32
   end
 
-  def to_i8 : Int8
-    to_i32.to_i8
-  end
-
-  def to_i16 : Int16
-    to_i32.to_i16
-  end
-
-  def to_i32 : Int32
-    LibGMP.get_si(self).to_i32
-  end
-
-  def to_i64 : Int64
-    if LibGMP::Long::MIN <= self <= LibGMP::Long::MAX
-      LibGMP.get_si(self).to_i64
-    else
-      to_s.to_i64 { raise OverflowError.new }
-    end
-  end
-
-  def to_i!
+  def to_i! : Int32
     to_i32!
-  end
-
-  def to_i8! : Int8
-    LibGMP.get_si(self).to_i8!
-  end
-
-  def to_i16! : Int16
-    LibGMP.get_si(self).to_i16!
-  end
-
-  def to_i32! : Int32
-    LibGMP.get_si(self).to_i32!
-  end
-
-  def to_i64! : Int64
-    (self % BITS64).to_u64.to_i64!
   end
 
   def to_u : UInt32
     to_u32
   end
 
-  def to_u8 : UInt8
-    to_u32.to_u8
-  end
-
-  def to_u16 : UInt16
-    to_u32.to_u16
-  end
-
-  def to_u32 : UInt32
-    to_u64.to_u32
-  end
-
-  def to_u64 : UInt64
-    if LibGMP::ULong::MIN <= self <= LibGMP::ULong::MAX
-      LibGMP.get_ui(self).to_u64
-    else
-      to_s.to_u64 { raise OverflowError.new }
-    end
-  end
-
-  def to_u!
+  def to_u! : UInt32
     to_u32!
   end
 
-  def to_u8! : UInt8
-    LibGMP.get_ui(self).to_u8!
+  {% for n in [8, 16, 32, 64, 128] %}
+    def to_i{{n}} : Int{{n}}
+      \{% if Int{{n}} == LibGMP::Long %}
+        LibGMP.fits_slong_p(self) != 0 ? LibGMP.get_si(self) : raise OverflowError.new
+      \{% elsif Int{{n}}::MAX.is_a?(NumberLiteral) && Int{{n}}::MAX < LibGMP::Long::MAX %}
+        LibGMP::Long.new(self).to_i{{n}}
+      \{% else %}
+        to_primitive_i(Int{{n}})
+      \{% end %}
+    end
+
+    def to_u{{n}} : UInt{{n}}
+      \{% if Int{{n}} == LibGMP::Long %}
+        LibGMP.fits_ulong_p(self) != 0 ? LibGMP.get_ui(self) : raise OverflowError.new
+      \{% elsif Int{{n}}::MAX.is_a?(NumberLiteral) && Int{{n}}::MAX < LibGMP::Long::MAX %}
+        LibGMP::ULong.new(self).to_u{{n}}
+      \{% else %}
+        to_primitive_u(UInt{{n}})
+      \{% end %}
+    end
+
+    def to_i{{n}}! : Int{{n}}
+      to_u{{n}}!.to_i{{n}}!
+    end
+
+    def to_u{{n}}! : UInt{{n}}
+      \{% if Int{{n}} == LibGMP::Long %}
+        LibGMP.get_ui(self) &* sign
+      \{% elsif Int{{n}}::MAX.is_a?(NumberLiteral) && Int{{n}}::MAX < LibGMP::Long::MAX %}
+        LibGMP::ULong.new!(self).to_u{{n}}!
+      \{% else %}
+        to_primitive_u!(UInt{{n}})
+      \{% end %}
+    end
+  {% end %}
+
+  private def to_primitive_i(type : T.class) : T forall T
+    self >= 0 ? to_primitive_i_positive(T) : to_primitive_i_negative(T)
   end
 
-  def to_u16! : UInt16
-    LibGMP.get_ui(self).to_u16!
+  private def to_primitive_u(type : T.class) : T forall T
+    self >= 0 ? to_primitive_i_positive(T) : raise OverflowError.new
   end
 
-  def to_u32! : UInt32
-    LibGMP.get_ui(self).to_u32!
+  private def to_primitive_u!(type : T.class) : T forall T
+    limbs = self.limbs
+    max_bits = sizeof(T) * 8
+    bits_per_limb = sizeof(LibGMP::MpLimb) * 8
+
+    x = T.zero
+    limbs.each_with_index do |limb, i|
+      break if i * bits_per_limb >= max_bits
+      x |= T.new!(limb) << (i * bits_per_limb)
+    end
+    x &* sign
   end
 
-  def to_u64! : UInt64
-    (self % BITS64).to_u64
+  private def to_primitive_i_positive(type : T.class) : T forall T
+    limbs = self.limbs
+    bits_per_limb = sizeof(LibGMP::MpLimb) * 8
+
+    highest_limb_index = (sizeof(T) * 8 - 1) // bits_per_limb
+    raise OverflowError.new if limbs.size > highest_limb_index + 1
+    if highest_limb = limbs[highest_limb_index]?
+      mask = LibGMP::MpLimb.new!(T::MAX >> (bits_per_limb * highest_limb_index))
+      raise OverflowError.new if highest_limb > mask
+    end
+
+    x = T.zero
+    preshift_limit = T::MAX >> bits_per_limb
+    limbs.reverse_each do |limb|
+      x <<= bits_per_limb
+      x |= limb
+    end
+    x
   end
 
-  private BITS64 = BigInt.new(1) << 64
+  private def to_primitive_i_negative(type : T.class) : T forall T
+    limbs = self.limbs
+    bits_per_limb = sizeof(LibGMP::MpLimb) * 8
+
+    x = T.zero.abs_unsigned
+    limit = T::MIN.abs_unsigned
+    preshift_limit = limit >> bits_per_limb
+    limbs.reverse_each do |limb|
+      raise OverflowError.new if x > preshift_limit
+      x <<= bits_per_limb
+
+      # precondition: T must be larger than LibGMP::MpLimb, otherwise overflows
+      # like `0_i8 | 256` would happen and `x += limb` should be called instead
+      x |= limb
+      raise OverflowError.new if x > limit
+    end
+    x.neg_signed
+  end
 
   def to_f : Float64
     to_f64

--- a/src/big/big_int.cr
+++ b/src/big/big_int.cr
@@ -657,9 +657,9 @@ struct BigInt < Int
     end
 
     def to_u{{n}} : UInt{{n}}
-      \{% if Int{{n}} == LibGMP::Long %}
+      \{% if UInt{{n}} == LibGMP::ULong %}
         LibGMP.fits_ulong_p(self) != 0 ? LibGMP.get_ui(self) : raise OverflowError.new
-      \{% elsif Int{{n}}::MAX.is_a?(NumberLiteral) && Int{{n}}::MAX < LibGMP::Long::MAX %}
+      \{% elsif UInt{{n}}::MAX.is_a?(NumberLiteral) && UInt{{n}}::MAX < LibGMP::ULong::MAX %}
         LibGMP::ULong.new(self).to_u{{n}}
       \{% else %}
         to_primitive_u(UInt{{n}})
@@ -671,9 +671,9 @@ struct BigInt < Int
     end
 
     def to_u{{n}}! : UInt{{n}}
-      \{% if Int{{n}} == LibGMP::Long %}
+      \{% if UInt{{n}} == LibGMP::ULong %}
         LibGMP.get_ui(self) &* sign
-      \{% elsif Int{{n}}::MAX.is_a?(NumberLiteral) && Int{{n}}::MAX < LibGMP::Long::MAX %}
+      \{% elsif UInt{{n}}::MAX.is_a?(NumberLiteral) && UInt{{n}}::MAX < LibGMP::ULong::MAX %}
         LibGMP::ULong.new!(self).to_u{{n}}!
       \{% else %}
         to_primitive_u!(UInt{{n}})

--- a/src/big/big_int.cr
+++ b/src/big/big_int.cr
@@ -647,20 +647,20 @@ struct BigInt < Int
 
   {% for n in [8, 16, 32, 64, 128] %}
     def to_i{{n}} : Int{{n}}
-      \{% if Int{{n}} == LibGMP::Long %}
-        LibGMP.fits_slong_p(self) != 0 ? LibGMP.get_si(self) : raise OverflowError.new
-      \{% elsif Int{{n}}::MAX.is_a?(NumberLiteral) && Int{{n}}::MAX < LibGMP::Long::MAX %}
-        LibGMP::Long.new(self).to_i{{n}}
+      \{% if Int{{n}} == LibGMP::SI %}
+        LibGMP.{{ flag?(:win32) ? "fits_si_p".id : "fits_slong_p".id }}(self) != 0 ? LibGMP.get_si(self) : raise OverflowError.new
+      \{% elsif Int{{n}}::MAX.is_a?(NumberLiteral) && Int{{n}}::MAX < LibGMP::SI::MAX %}
+        LibGMP::SI.new(self).to_i{{n}}
       \{% else %}
         to_primitive_i(Int{{n}})
       \{% end %}
     end
 
     def to_u{{n}} : UInt{{n}}
-      \{% if UInt{{n}} == LibGMP::ULong %}
-        LibGMP.fits_ulong_p(self) != 0 ? LibGMP.get_ui(self) : raise OverflowError.new
-      \{% elsif UInt{{n}}::MAX.is_a?(NumberLiteral) && UInt{{n}}::MAX < LibGMP::ULong::MAX %}
-        LibGMP::ULong.new(self).to_u{{n}}
+      \{% if UInt{{n}} == LibGMP::UI %}
+        LibGMP.{{ flag?(:win32) ? "fits_ui_p".id : "fits_ulong_p".id }}(self) != 0 ? LibGMP.get_ui(self) : raise OverflowError.new
+      \{% elsif UInt{{n}}::MAX.is_a?(NumberLiteral) && UInt{{n}}::MAX < LibGMP::UI::MAX %}
+        LibGMP::UI.new(self).to_u{{n}}
       \{% else %}
         to_primitive_u(UInt{{n}})
       \{% end %}
@@ -671,10 +671,10 @@ struct BigInt < Int
     end
 
     def to_u{{n}}! : UInt{{n}}
-      \{% if UInt{{n}} == LibGMP::ULong %}
+      \{% if UInt{{n}} == LibGMP::UI %}
         LibGMP.get_ui(self) &* sign
-      \{% elsif UInt{{n}}::MAX.is_a?(NumberLiteral) && UInt{{n}}::MAX < LibGMP::ULong::MAX %}
-        LibGMP::ULong.new!(self).to_u{{n}}!
+      \{% elsif UInt{{n}}::MAX.is_a?(NumberLiteral) && UInt{{n}}::MAX < LibGMP::UI::MAX %}
+        LibGMP::UI.new!(self).to_u{{n}}!
       \{% else %}
         to_primitive_u!(UInt{{n}})
       \{% end %}

--- a/src/big/lib_gmp.cr
+++ b/src/big/lib_gmp.cr
@@ -149,6 +149,10 @@ lib LibGMP
 
   fun fits_ulong_p = __gmpz_fits_ulong_p(op : MPZ*) : Int
   fun fits_slong_p = __gmpz_fits_slong_p(op : MPZ*) : Int
+  {% if flag?(:win32) %}
+    fun fits_ui_p = __gmpz_fits_ui_p(op : MPZ*) : Int
+    fun fits_si_p = __gmpz_fits_si_p(op : MPZ*) : Int
+  {% end %}
 
   # # Special Functions
 

--- a/src/big/lib_gmp.cr
+++ b/src/big/lib_gmp.cr
@@ -68,6 +68,7 @@ lib LibGMP
   fun get_si = __gmpz_get_si(op : MPZ*) : SI
   fun get_ui = __gmpz_get_ui(op : MPZ*) : UI
   fun get_d = __gmpz_get_d(op : MPZ*) : Double
+  fun get_d_2exp = __gmpz_get_d_2exp(exp : Long*, op : MPZ*) : Double
 
   # # Arithmetic
 
@@ -136,9 +137,6 @@ lib LibGMP
   fun cmp_ui = __gmpz_cmp_ui(op1 : MPZ*, op2 : UI) : Int
   fun cmp_d = __gmpz_cmp_d(op1 : MPZ*, op2 : Double) : Int
 
-  # # Conversion
-  fun get_d_2exp = __gmpz_get_d_2exp(exp : Long*, op : MPZ*) : Double
-
   # # Number Theoretic Functions
 
   fun gcd = __gmpz_gcd(rop : MPZ*, op1 : MPZ*, op2 : MPZ*)
@@ -147,8 +145,15 @@ lib LibGMP
   fun lcm_ui = __gmpz_lcm_ui(rop : MPZ*, op1 : MPZ*, op2 : UI)
   fun remove = __gmpz_remove(rop : MPZ*, op : MPZ*, f : MPZ*) : BitcntT
 
-  # Special Functions
+  # # Miscellaneous Functions
 
+  fun fits_ulong_p = __gmpz_fits_ulong_p(op : MPZ*) : Int
+  fun fits_slong_p = __gmpz_fits_slong_p(op : MPZ*) : Int
+
+  # # Special Functions
+
+  fun size = __gmpz_size(op : MPZ*) : SizeT
+  fun limbs_read = __gmpz_limbs_read(x : MPZ*) : MpLimb*
   fun limbs_write = __gmpz_limbs_write(x : MPZ*, n : MpSize) : MpLimb*
   fun limbs_finish = __gmpz_limbs_finish(x : MPZ*, s : MpSize)
 

--- a/src/int.cr
+++ b/src/int.cr
@@ -895,6 +895,11 @@ struct Int8
     self < 0 ? 0_u8 &- self : to_u8!
   end
 
+  # :nodoc:
+  def neg_signed : self
+    -self
+  end
+
   def popcount : Int8
     Intrinsics.popcount8(self)
   end
@@ -998,6 +1003,11 @@ struct Int16
   # :nodoc:
   def abs_unsigned : UInt16
     self < 0 ? 0_u16 &- self : to_u16!
+  end
+
+  # :nodoc:
+  def neg_signed : self
+    -self
   end
 
   def popcount : Int16
@@ -1105,6 +1115,11 @@ struct Int32
     self < 0 ? 0_u32 &- self : to_u32!
   end
 
+  # :nodoc:
+  def neg_signed : self
+    -self
+  end
+
   def popcount : Int32
     Intrinsics.popcount32(self)
   end
@@ -1208,6 +1223,11 @@ struct Int64
   # :nodoc:
   def abs_unsigned : UInt64
     self < 0 ? 0_u64 &- self : to_u64!
+  end
+
+  # :nodoc:
+  def neg_signed : self
+    -self
   end
 
   def popcount : Int64
@@ -1316,6 +1336,11 @@ struct Int128
   # :nodoc:
   def abs_unsigned : UInt128
     self < 0 ? UInt128.new(0) &- self : to_u128!
+  end
+
+  # :nodoc:
+  def neg_signed : self
+    -self
   end
 
   def popcount
@@ -1427,6 +1452,11 @@ struct UInt8
     self
   end
 
+  # :nodoc:
+  def neg_signed : Int8
+    0_i8 - self
+  end
+
   def popcount : Int8
     Intrinsics.popcount8(self)
   end
@@ -1534,6 +1564,11 @@ struct UInt16
   # :nodoc:
   def abs_unsigned : self
     self
+  end
+
+  # :nodoc:
+  def neg_signed : Int16
+    0_i16 - self
   end
 
   def popcount : Int16
@@ -1645,6 +1680,11 @@ struct UInt32
     self
   end
 
+  # :nodoc:
+  def neg_signed : Int32
+    0_i32 - self
+  end
+
   def popcount : Int32
     Intrinsics.popcount32(self)
   end
@@ -1752,6 +1792,11 @@ struct UInt64
   # :nodoc:
   def abs_unsigned : self
     self
+  end
+
+  # :nodoc:
+  def neg_signed : Int64
+    0_i64 - self
   end
 
   def popcount : Int64
@@ -1863,6 +1908,11 @@ struct UInt128
   # :nodoc:
   def abs_unsigned : self
     self
+  end
+
+  # :nodoc:
+  def neg_signed : Int128
+    Int128.new(0) - self
   end
 
   def popcount


### PR DESCRIPTION
Resolves #11978. Resolves #12771. Fixes #13561.

`BigInt` now accesses its limbs directly for target types larger than `LibC::Long`, so there are no longer calls to `BigInt#to_s` or `#%` in these conversions. (This is especially important on Windows where `Long` is only 32 bits.) The new conversion to large negative signed integers requires `Int::Primitive#neg_signed` from #13439; this method, like `#abs_unsigned`, is currently not exposed.