### PR TITLE
Split `LLVM::Builder` overloads that don't take an operand bundle

### DIFF
--- a/src/llvm/builder.cr
+++ b/src/llvm/builder.cr
@@ -89,12 +89,24 @@ class LLVM::Builder
     Value.new LibLLVMExt.build_call2(self, func.function_type, func, (args.to_unsafe.as(LibLLVM::ValueRef*)), args.size, bundle, name)
   end
 
-  def call(type : LLVM::Type, func : LLVM::Function, args : Array(LLVM::Value), name : String = "", bundle : LLVM::OperandBundleDef = LLVM::OperandBundleDef.null)
+  def call(type : LLVM::Type, func : LLVM::Function, args : Array(LLVM::Value), name : String = "")
+    # check_type("call", type)
+    # check_func(func)
+    # check_values(args)
+
+    Value.new LibLLVM.build_call2(self, type, func, (args.to_unsafe.as(LibLLVM::ValueRef*)), args.size, name)
+  end
+
+  def call(type : LLVM::Type, func : LLVM::Function, args : Array(LLVM::Value), name : String, bundle : LLVM::OperandBundleDef)
     # check_type("call", type)
     # check_func(func)
     # check_values(args)
 
     Value.new LibLLVMExt.build_call2(self, type, func, (args.to_unsafe.as(LibLLVM::ValueRef*)), args.size, bundle, name)
+  end
+
+  def call(type : LLVM::Type, func : LLVM::Function, args : Array(LLVM::Value), bundle : LLVM::OperandBundleDef)
+    call(type, func, args, "", bundle)
   end
 
   def alloca(type, name = "")
@@ -281,7 +293,14 @@ class LLVM::Builder
     Value.new LibLLVMExt.build_invoke2 self, fn.function_type, fn, (args.to_unsafe.as(LibLLVM::ValueRef*)), args.size, a_then, a_catch, bundle, name
   end
 
-  def invoke(type : LLVM::Type, fn : LLVM::Function, args : Array(LLVM::Value), a_then, a_catch, bundle : LLVM::OperandBundleDef = LLVM::OperandBundleDef.null, name = "")
+  def invoke(type : LLVM::Type, fn : LLVM::Function, args : Array(LLVM::Value), a_then, a_catch, *, name = "")
+    # check_type("invoke", type)
+    # check_func(fn)
+
+    Value.new LibLLVM.build_invoke2 self, type, fn, (args.to_unsafe.as(LibLLVM::ValueRef*)), args.size, a_then, a_catch, name
+  end
+
+  def invoke(type : LLVM::Type, fn : LLVM::Function, args : Array(LLVM::Value), a_then, a_catch, bundle : LLVM::OperandBundleDef, name = "")
     # check_type("invoke", type)
     # check_func(fn)
 


### PR DESCRIPTION
Fixes #13563.

The treatments for `#call` and `#invoke` are slightly different, because the former defines `name` as a positional parameter before `bundle`, and the latter defines them in opposite order.