### PR TITLE
Windows: drop internal environment variables from `ENV`

### DIFF
--- a/spec/std/env_spec.cr
+++ b/spec/std/env_spec.cr
@@ -173,4 +173,14 @@ describe "ENV" do
   ensure
     ENV.delete("FOO")
   end
+
+  {% if flag?(:win32) %}
+    it "skips internal environment variables" do
+      key = "=#{Path[Dir.current].drive}"
+      ENV.has_key?(key).should be_false
+      ENV[key]?.should be_nil
+      expect_raises(ArgumentError) { ENV[key] = "foo" }
+      expect_raises(ArgumentError) { ENV[key] = nil }
+    end
+  {% end %}
 end

--- a/src/crystal/system/win32/env.cr
+++ b/src/crystal/system/win32/env.cr
@@ -26,7 +26,7 @@ module Crystal::System::Env
 
   # Gets an environment variable.
   def self.get(key : String) : String?
-    check_valid_key(key) { return nil }
+    return nil unless valid_key?(key)
     key = System.to_wstr(key, "key")
 
     System.retry_wstr_buffer do |buffer, small_buf|
@@ -55,7 +55,7 @@ module Crystal::System::Env
 
   # Returns `true` if environment variable is set.
   def self.has_key?(key : String) : Bool
-    check_valid_key(key) { return false }
+    return false unless valid_key?(key)
     key = System.to_wstr(key, "key")
 
     buffer = uninitialized UInt16[1]
@@ -94,11 +94,11 @@ module Crystal::System::Env
     end.to_utf16.to_unsafe
   end
 
-  private def self.check_valid_key(key : String, &)
-    yield if key.empty? || key.includes?('=')
+  private def self.valid_key?(key : String)
+    !(key.empty? || key.includes?('='))
   end
 
   private def self.check_valid_key(key : String)
-    check_valid_key(key) { raise ArgumentError.new("Invalid env key #{key.inspect}") }
+    raise ArgumentError.new("Invalid env key #{key.inspect}") unless valid_key?(key)
   end
 end

--- a/src/crystal/system/win32/env.cr
+++ b/src/crystal/system/win32/env.cr
@@ -5,6 +5,7 @@ require "c/processenv"
 module Crystal::System::Env
   # Sets an environment variable or unsets it if *value* is `nil`.
   def self.set(key : String, value : String) : Nil
+    check_valid_key(key)
     key = System.to_wstr(key, "key")
     value = System.to_wstr(value, "value")
 
@@ -15,6 +16,7 @@ module Crystal::System::Env
 
   # Unsets an environment variable.
   def self.set(key : String, value : Nil) : Nil
+    check_valid_key(key)
     key = System.to_wstr(key, "key")
 
     if LibC.SetEnvironmentVariableW(key, nil) == 0
@@ -24,6 +26,7 @@ module Crystal::System::Env
 
   # Gets an environment variable.
   def self.get(key : String) : String?
+    check_valid_key(key) { return nil }
     key = System.to_wstr(key, "key")
 
     System.retry_wstr_buffer do |buffer, small_buf|
@@ -52,6 +55,7 @@ module Crystal::System::Env
 
   # Returns `true` if environment variable is set.
   def self.has_key?(key : String) : Bool
+    check_valid_key(key) { return false }
     key = System.to_wstr(key, "key")
 
     buffer = uninitialized UInt16[1]
@@ -66,10 +70,10 @@ module Crystal::System::Env
     begin
       while !pointer.value.zero?
         string, pointer = String.from_utf16(pointer)
+        # Skip internal environment variables that are reserved by `cmd.exe`
+        # (`%=ExitCode%`, `%=ExitCodeAscii%`, `%=::%`, `%=C:%` ...)
+        next if string.starts_with?('=')
         key, _, value = string.partition('=')
-        # The actual env variables are preceded by these weird lines in the output:
-        # "=::=::\", "=C:=c:\foo\bar", "=ExitCode=00000000" -- skip them.
-        next if key.empty?
         yield key, value
       end
     ensure
@@ -83,12 +87,18 @@ module Crystal::System::Env
     # `System.to_wstr` here
     String.build do |io|
       env.each do |(key, value)|
-        if key.includes?('=') || key.empty?
-          raise ArgumentError.new("Invalid env key #{key.inspect}")
-        end
+        check_valid_key(key)
         io << key.check_no_null_byte("key") << '=' << value.check_no_null_byte("value") << '\0'
       end
       io << '\0'
     end.to_utf16.to_unsafe
+  end
+
+  private def self.check_valid_key(key : String, &)
+    yield if key.empty? || key.includes?('=')
+  end
+
+  private def self.check_valid_key(key : String)
+    check_valid_key(key) { raise ArgumentError.new("Invalid env key #{key.inspect}") }
   end
 end


### PR DESCRIPTION
`ENV.each` excludes environment variable names that include an `=`, for example the internal environment variables reserved by `cmd.exe` like `%=C:%` and `%=ExitCode%`, but the remaining methods can still access them. This PR disallows that.