### PR TITLE
Deprecate LLVM's legacy pass manager

### DIFF
--- a/src/llvm/function_pass_manager.cr
+++ b/src/llvm/function_pass_manager.cr
@@ -1,3 +1,6 @@
+{% unless LibLLVM::IS_LT_130 %}
+  @[Deprecated("The legacy pass manager was removed in LLVM 17. Use `LLVM::PassBuilderOptions` instead")]
+{% end %}
 class LLVM::FunctionPassManager
   def initialize(@unwrap : LibLLVM::PassManagerRef)
   end
@@ -31,6 +34,9 @@ class LLVM::FunctionPassManager
     LibLLVM.dispose_pass_manager(@unwrap)
   end
 
+  {% unless LibLLVM::IS_LT_130 %}
+    @[Deprecated("The legacy pass manager was removed in LLVM 17. Use `LLVM::PassBuilderOptions` instead")]
+  {% end %}
   struct Runner
     @fpm : FunctionPassManager
 

--- a/src/llvm/module.cr
+++ b/src/llvm/module.cr
@@ -84,6 +84,9 @@ class LLVM::Module
     self
   end
 
+  {% unless LibLLVM::IS_LT_130 %}
+    @[Deprecated("The legacy pass manager was removed in LLVM 17. Use `LLVM::PassBuilderOptions` instead")]
+  {% end %}
   def new_function_pass_manager
     FunctionPassManager.new LibLLVM.create_function_pass_manager_for_module(self)
   end

--- a/src/llvm/module_pass_manager.cr
+++ b/src/llvm/module_pass_manager.cr
@@ -1,3 +1,6 @@
+{% unless LibLLVM::IS_LT_130 %}
+  @[Deprecated("The legacy pass manager was removed in LLVM 17. Use `LLVM::PassBuilderOptions` instead")]
+{% end %}
 class LLVM::ModulePassManager
   def initialize
     @unwrap = LibLLVM.pass_manager_create

--- a/src/llvm/pass_manager_builder.cr
+++ b/src/llvm/pass_manager_builder.cr
@@ -1,3 +1,6 @@
+{% unless LibLLVM::IS_LT_130 %}
+  @[Deprecated("The legacy pass manager was removed in LLVM 17. Use `LLVM::PassBuilderOptions` instead")]
+{% end %}
 class LLVM::PassManagerBuilder
   def initialize
     @unwrap = LibLLVM.pass_manager_builder_create

--- a/src/llvm/pass_registry.cr
+++ b/src/llvm/pass_registry.cr
@@ -1,3 +1,6 @@
+{% unless LibLLVM::IS_LT_130 %}
+  @[Deprecated("The legacy pass manager was removed in LLVM 17. Use `LLVM::PassBuilderOptions` instead")]
+{% end %}
 struct LLVM::PassRegistry
   def self.instance : self
     new LibLLVM.get_global_pass_registry


### PR DESCRIPTION
Crystal has migrated to the new pass manager for LLVM 13 or above, and the legacy pass manager is now [removed](https://github.com/llvm/llvm-project/commit/f7ca01333214f934c580c162afdee933e7430b6c) [in](https://github.com/llvm/llvm-project/commit/0aac9a2875bad4f065367e4a6553fad78605f895) [LLVM 17](https://github.com/llvm/llvm-project/commit/62ef97e0631ff41ad53436477cecc7d3eb244d1b). This PR adds deprecation notices when the legacy types are used in LLVM 13 to 16. (It is acceptable to use them in LLVM 8 to 12, which our bindings still support.)