### PR TITLE
Fix instantiated method signatures in error traces

### DIFF
--- a/src/compiler/crystal/semantic/call.cr
+++ b/src/compiler/crystal/semantic/call.cr
@@ -1119,46 +1119,9 @@ class Crystal::Call
       ::raise ex
     else
       msg = String.build do |io|
-        io << "instantiating '" << full_name(obj.try(&.type)) << '('
-
-        first = true
-        args.each do |arg|
-          case {arg_type = arg.type, arg}
-          when {TupleInstanceType, Splat}
-            next if arg_type.tuple_types.empty?
-            io << ", " unless first
-            arg_type.tuple_types.join(io, ", ")
-          when {NamedTupleInstanceType, DoubleSplat}
-            next if arg_type.entries.empty?
-            io << ", " unless first
-            arg_type.entries.join(io, ", ") do |entry|
-              if Symbol.needs_quotes_for_named_argument?(entry.name)
-                entry.name.inspect(io)
-              else
-                io << entry.name
-              end
-              io << ": " << entry.type
-            end
-          else
-            io << ", " unless first
-            io << arg.type
-          end
-          first = false
-        end
-
-        if named_args = @named_args
-          io << ", " unless first
-          named_args.join(io, ", ") do |named_arg|
-            if Symbol.needs_quotes_for_named_argument?(named_arg.name)
-              named_arg.name.inspect(io)
-            else
-              io << named_arg.name
-            end
-            io << ": " << named_arg.value.type
-          end
-        end
-
-        io << ")'"
+        io << "instantiating '"
+        signature(io)
+        io << "'"
       end
       raise msg, ex
     end

--- a/src/compiler/crystal/semantic/call.cr
+++ b/src/compiler/crystal/semantic/call.cr
@@ -1128,7 +1128,6 @@ class Crystal::Call
             next if arg_type.tuple_types.empty?
             io << ", " unless first
             arg_type.tuple_types.join(io, ", ")
-            first = false
           when {NamedTupleInstanceType, DoubleSplat}
             next if arg_type.entries.empty?
             io << ", " unless first
@@ -1140,12 +1139,11 @@ class Crystal::Call
               end
               io << ": " << entry.type
             end
-            first = false
           else
             io << ", " unless first
             io << arg.type
-            first = false
           end
+          first = false
         end
 
         if named_args = @named_args

--- a/src/compiler/crystal/semantic/call_error.cr
+++ b/src/compiler/crystal/semantic/call_error.cr
@@ -1018,6 +1018,49 @@ class Crystal::Call
     end
   end
 
+  def signature(io : IO) : Nil
+    io << full_name(obj.try(&.type)) << '('
+
+    first = true
+    args.each do |arg|
+      case {arg_type = arg.type, arg}
+      when {TupleInstanceType, Splat}
+        next if arg_type.tuple_types.empty?
+        io << ", " unless first
+        arg_type.tuple_types.join(io, ", ")
+      when {NamedTupleInstanceType, DoubleSplat}
+        next if arg_type.entries.empty?
+        io << ", " unless first
+        arg_type.entries.join(io, ", ") do |entry|
+          if Symbol.needs_quotes_for_named_argument?(entry.name)
+            entry.name.inspect(io)
+          else
+            io << entry.name
+          end
+          io << ": " << entry.type
+        end
+      else
+        io << ", " unless first
+        io << arg.type
+      end
+      first = false
+    end
+
+    if named_args = @named_args
+      io << ", " unless first
+      named_args.join(io, ", ") do |named_arg|
+        if Symbol.needs_quotes_for_named_argument?(named_arg.name)
+          named_arg.name.inspect(io)
+        else
+          io << named_arg.name
+        end
+        io << ": " << named_arg.value.type
+      end
+    end
+
+    io << ')'
+  end
+
   private def colorize(obj)
     program.colorize(obj)
   end

--- a/src/compiler/crystal/semantic/call_error.cr
+++ b/src/compiler/crystal/semantic/call_error.cr
@@ -1005,7 +1005,7 @@ class Crystal::Call
 
   def self.full_name(owner, method_name = name)
     case owner
-    when Program
+    when Program, Nil
       method_name
     when owner.program.class_type
       # Class's instance_type is Object, not Class, so we cannot treat it like


### PR DESCRIPTION
Fixes part of #13566 by including named arguments in the instantiated method signatures that show up in error traces. This PR only touches the traces, not the final error message itself.

Also expands single and double splat arguments. Also uses `Call#full_name` to prefer `T.method` over `T.class#method` for class methods.