### PR TITLE
Fix: Display `Bool`'s size as 1 byte in `crystal tool hierarchy`, not 0

### DIFF
--- a/spec/compiler/crystal/tools/hierarchy_spec.cr
+++ b/spec/compiler/crystal/tools/hierarchy_spec.cr
@@ -21,6 +21,26 @@ describe Crystal::TextHierarchyPrinter do
             +- class Bar (4 bytes)\n
     EOS
   end
+
+  it "shows correct size for Bool member" do
+    program = semantic(<<-CRYSTAL).program
+      struct Foo
+        @x = true
+      end
+      CRYSTAL
+
+    output = String.build { |io| Crystal.print_hierarchy(program, io, "Foo", "text") }
+    output.should eq(<<-EOS)
+    - class Object (4 bytes)
+      |
+      +- struct Value (0 bytes)
+        |
+        +- struct Struct (0 bytes)
+            |
+            +- struct Foo (1 bytes)
+                  @x : Bool (1 bytes)\n
+    EOS
+  end
 end
 
 describe Crystal::JSONHierarchyPrinter do

--- a/spec/compiler/crystal/tools/hierarchy_spec.cr
+++ b/spec/compiler/crystal/tools/hierarchy_spec.cr
@@ -38,7 +38,7 @@ describe Crystal::TextHierarchyPrinter do
         +- struct Struct (0 bytes)
             |
             +- struct Foo (1 bytes)
-                  @x : Bool (1 bytes)\n
+                   @x : Bool (1 bytes)\n
     EOS
   end
 end

--- a/spec/compiler/crystal/tools/hierarchy_spec.cr
+++ b/spec/compiler/crystal/tools/hierarchy_spec.cr
@@ -34,8 +34,8 @@ describe Crystal::TextHierarchyPrinter do
     - class Object (4 bytes)
       |
       +- struct Value (0 bytes)
-        |
-        +- struct Struct (0 bytes)
+         |
+         +- struct Struct (0 bytes)
             |
             +- struct Foo (1 bytes)
                    @x : Bool (1 bytes)\n

--- a/src/compiler/crystal/codegen/codegen.cr
+++ b/src/compiler/crystal/codegen/codegen.cr
@@ -92,9 +92,6 @@ module Crystal
         # `Pointer(Void).malloc` must work like `Pointer(UInt8).malloc`,
         # that is, consider Void like the size of a byte.
         1
-      elsif type.is_a?(BoolType)
-        # LLVM reports 0 for bool (i1) but it must be 1 because it does occupy memory
-        1
       else
         llvm_typer.size_of(llvm_typer.llvm_type(type))
       end

--- a/src/compiler/crystal/codegen/llvm_typer.cr
+++ b/src/compiler/crystal/codegen/llvm_typer.cr
@@ -247,7 +247,7 @@ module Crystal
 
     private def create_llvm_type(type : NonGenericModuleType | GenericClassType, wants_size)
       # This can only be reached if the module or generic class don't have implementors
-      @llvm_context.void
+      @llvm_context.int1
     end
 
     private def create_llvm_type(type : Type, wants_size)

--- a/src/compiler/crystal/codegen/llvm_typer.cr
+++ b/src/compiler/crystal/codegen/llvm_typer.cr
@@ -247,7 +247,7 @@ module Crystal
 
     private def create_llvm_type(type : NonGenericModuleType | GenericClassType, wants_size)
       # This can only be reached if the module or generic class don't have implementors
-      @llvm_context.int1
+      @llvm_context.void
     end
 
     private def create_llvm_type(type : Type, wants_size)

--- a/src/compiler/crystal/interpreter/compiler.cr
+++ b/src/compiler/crystal/interpreter/compiler.cr
@@ -2010,7 +2010,8 @@ class Crystal::Repl::Compiler < Crystal::Visitor
     args = node.args
     obj_type = obj.try(&.type) || target_def.owner
 
-    if obj_type == @context.program
+    # TODO: should this use `Type#passed_as_self?` instead?
+    if obj_type == @context.program || obj_type.is_a?(FileModule)
       # Nothing
     elsif obj_type.passed_by_value?
       args_bytesize += sizeof(Pointer(UInt8))

--- a/src/compiler/crystal/interpreter/local_vars.cr
+++ b/src/compiler/crystal/interpreter/local_vars.cr
@@ -80,7 +80,8 @@ class Crystal::Repl::LocalVars
 
   def declare(name : String, type : Type) : Int32?
     is_self = name == "self"
-    return if is_self && type.is_a?(Program)
+    # TODO: should this use `Type#passed_as_self?` instead?
+    return if is_self && (type.is_a?(Program) || type.is_a?(FileModule))
 
     key = Key.new(name, @block_level)
 

--- a/src/llvm/target_data.cr
+++ b/src/llvm/target_data.cr
@@ -7,7 +7,8 @@ struct LLVM::TargetData
   end
 
   def size_in_bytes(type)
-    size_in_bits(type) // 8
+    size_in_bits = size_in_bits(type)
+    size_in_bits // 8 &+ (size_in_bits & 0x7 != 0 ? 1 : 0)
   end
 
   def abi_size(type)


### PR DESCRIPTION
This is a more general fix than #8273 that works for any LLVM integer type whose bit width is not a multiple of 8 (although Crystal only uses `i1`).