### PR TITLE
Add `Hash#put_if_absent`

### DIFF
--- a/samples/havlak.cr
+++ b/samples/havlak.cr
@@ -51,7 +51,7 @@ class CFG
   property :basic_block_map
 
   def create_node(name)
-    node = (@basic_block_map[name] ||= BasicBlock.new(name))
+    node = @basic_block_map.put_if_absent(name) { BasicBlock.new(name) }
     @start_node ||= node
     node
   end

--- a/spec/std/hash_spec.cr
+++ b/spec/std/hash_spec.cr
@@ -169,7 +169,7 @@ describe "Hash" do
     end
   end
 
-  describe "put" do
+  describe "#put" do
     it "puts in a small hash" do
       a = {} of Int32 => Int32
       a.put(1, 2) { nil }.should eq(nil)
@@ -188,6 +188,33 @@ describe "Hash" do
     it "yields key" do
       a = {} of Int32 => Int32
       a.put(1, 2, &.to_s).should eq("1")
+    end
+  end
+
+  describe "#put_if_absent" do
+    it "puts if key doesn't exist" do
+      v = [] of String
+      h = {} of Int32 => Array(String)
+      h.put_if_absent(1, v).should be(v)
+      h.should eq({1 => v})
+      h[1].should be(v)
+    end
+
+    it "returns existing value if key exists" do
+      v = [] of String
+      h = {1 => v}
+      h.put_if_absent(1, [] of String).should be(v)
+      h.should eq({1 => v})
+      h[1].should be(v)
+    end
+
+    it "accepts a block" do
+      v = [] of String
+      h = {1 => v}
+      h.put_if_absent(1) { [] of String }.should be(v)
+      h.put_if_absent(2) { |key| [key.to_s] }.should eq(["2"])
+      h.should eq({1 => v, 2 => ["2"]})
+      h[1].should be(v)
     end
   end
 

--- a/src/csv.cr
+++ b/src/csv.cr
@@ -181,7 +181,7 @@ class CSV
       headers = @headers = headers.map &.strip
       indices = @indices = {} of String => Int32
       headers.each_with_index do |header, index|
-        indices[header] ||= index
+        indices.put_if_absent(header, index)
       end
     end
     @traversed = false

--- a/src/hash.cr
+++ b/src/hash.cr
@@ -1093,11 +1093,10 @@ class Hash(K, V)
   #
   # ```
   # h = {} of Int32 => Array(String)
-  # a = h.put_if_absent(1) { [] of String } # => []
-  # a << "foo"
-  # h.put_if_absent(1) { [] of String }     # => ["foo"]
+  # h.put_if_absent(1) { |key| [key.to_s] } # => ["1"]
+  # h.put_if_absent(1) { [] of String }     # => ["1"]
   # h.put_if_absent(2) { |key| [key.to_s] } # => ["2"]
-  # h                                       # => {1 => ["foo"], 2 => ["2"]}
+  # h                                       # => {1 => ["1"], 2 => ["2"]}
   # ```
   #
   # `hash.put_if_absent(key) { value }` is a more performant alternative to

--- a/src/ini.cr
+++ b/src/ini.cr
@@ -46,7 +46,7 @@ module INI
         raise ParseException.new("Data after section", lineno, end_idx + 1) unless end_idx == line.size - 1
 
         current_section_name = line[offset + 1...end_idx]
-        current_section = ini[current_section_name] ||= Hash(String, String).new
+        current_section = ini.put_if_absent(current_section_name) { Hash(String, String).new }
       else
         key, eq, value = line.partition('=')
         raise ParseException.new("Expected declaration", lineno, key.size) if eq != "="

--- a/src/mime.cr
+++ b/src/mime.cr
@@ -232,8 +232,7 @@ module MIME
     @@types[extension] = type
     @@types_lower[extension.downcase] = type
 
-    type_extensions = @@extensions[mediatype] ||= Set(String).new
-    type_extensions << extension
+    @@extensions.put_if_absent(mediatype) { Set(String).new } << extension
   end
 
   # Returns all extensions registered for *type*.

--- a/src/spec/cli.cr
+++ b/src/spec/cli.cr
@@ -22,8 +22,7 @@ module Spec
   # :nodoc:
   def self.add_location(file, line)
     locations = @@locations ||= {} of String => Array(Int32)
-    lines = locations[File.expand_path(file)] ||= [] of Int32
-    lines << line
+    locations.put_if_absent(File.expand_path(file)) { [] of Int32 } << line
   end
 
   # :nodoc:

--- a/src/spec/source.cr
+++ b/src/spec/source.cr
@@ -8,8 +8,7 @@ module Spec
   def self.read_line(file, line)
     return nil unless File.file?(file)
 
-    lines = lines_cache[file] ||= File.read_lines(file)
-    lines[line - 1]?
+    lines_cache.put_if_absent(file) { File.read_lines(file) }[line - 1]?
   end
 
   # :nodoc:

--- a/src/spec/source.cr
+++ b/src/spec/source.cr
@@ -8,7 +8,8 @@ module Spec
   def self.read_line(file, line)
     return nil unless File.file?(file)
 
-    lines_cache.put_if_absent(file) { File.read_lines(file) }[line - 1]?
+    lines = lines_cache.put_if_absent(file) { File.read_lines(file) }
+    lines[line - 1]?
   end
 
   # :nodoc:

--- a/src/uri/params.cr
+++ b/src/uri/params.cr
@@ -16,8 +16,7 @@ class URI
     def self.parse(query : String) : self
       parsed = {} of String => Array(String)
       parse(query) do |key, value|
-        ary = parsed[key] ||= [] of String
-        ary.push value
+        parsed.put_if_absent(key) { [] of String } << value
       end
       Params.new(parsed)
     end
@@ -297,9 +296,9 @@ class URI
     # params.fetch_all("item") # => ["pencil", "book", "workbook", "keychain"]
     # ```
     def add(name, value)
-      raw_params[name] ||= [] of String
-      raw_params[name] = [] of String if raw_params[name] == [""]
-      raw_params[name] << value
+      params = raw_params.put_if_absent(name) { [] of String }
+      params.clear if params.size == 1 && params[0] == ""
+      params << value
     end
 
     # Sets all *values* for specified param *name* at once.


### PR DESCRIPTION
Resolves #8660.

This is faster than `hash[key] ||= value` for two reasons:

* If the given key cannot be found, `Hash#insert_new` will not attempt to match the key against any existing keys at all. (This suggests that `find_entry_with_index` followed by `set_entry` or `insert_new` might be faster than `upsert` too, which makes `#upsert` completely unnecessary, but I haven't verified that.)
* A missing key goes directly to `insert_new`, whereas `||=` means any existing value must be upcast to a nilable value and evaluated for truthiness first.

Instead of `#insert_new`, perhaps a copy of `#upsert` that traverses existing keys but doesn't update them could be defined?

Hash-like types such as `ENV.class` and `URI::Params` do not have this. For those types it might be better if a generic implementation is offered via #10886.