### PR TITLE
Refactor symbol quoting into `Symbol.quote_for_named_argument`

### DIFF
--- a/src/compiler/crystal/macros/methods.cr
+++ b/src/compiler/crystal/macros/methods.cr
@@ -1048,11 +1048,7 @@ module Crystal
 
     private def to_double_splat(trailing_string = "")
       MacroId.new(entries.join(", ") do |entry|
-        if Symbol.needs_quotes_for_named_argument?(entry.key)
-          "#{entry.key.inspect}: #{entry.value}"
-        else
-          "#{entry.key}: #{entry.value}"
-        end
+        "#{Symbol.quote_for_named_argument(entry.key)}: #{entry.value}"
       end + trailing_string)
     end
   end

--- a/src/compiler/crystal/semantic/call_error.cr
+++ b/src/compiler/crystal/semantic/call_error.cr
@@ -1032,11 +1032,7 @@ class Crystal::Call
         next if arg_type.entries.empty?
         io << ", " unless first
         arg_type.entries.join(io, ", ") do |entry|
-          if Symbol.needs_quotes_for_named_argument?(entry.name)
-            entry.name.inspect(io)
-          else
-            io << entry.name
-          end
+          Symbol.quote_for_named_argument(io, entry.name)
           io << ": " << entry.type
         end
       else
@@ -1049,11 +1045,7 @@ class Crystal::Call
     if named_args = @named_args
       io << ", " unless first
       named_args.join(io, ", ") do |named_arg|
-        if Symbol.needs_quotes_for_named_argument?(named_arg.name)
-          named_arg.name.inspect(io)
-        else
-          io << named_arg.name
-        end
+        Symbol.quote_for_named_argument(io, named_arg.name)
         io << ": " << named_arg.value.type
       end
     end

--- a/src/compiler/crystal/syntax/to_s.cr
+++ b/src/compiler/crystal/syntax/to_s.cr
@@ -885,11 +885,7 @@ module Crystal
     end
 
     def visit_named_arg_name(name)
-      if Symbol.needs_quotes_for_named_argument?(name)
-        name.inspect(@str)
-      else
-        @str << name
-      end
+      Symbol.quote_for_named_argument(@str, name)
     end
 
     def visit(node : Underscore)
@@ -1123,11 +1119,7 @@ module Crystal
       else
         @str << node.name
         @str << " = "
-        if Symbol.needs_quotes_for_named_argument?(node.real_name)
-          node.real_name.inspect(@str)
-        else
-          @str << node.real_name
-        end
+        Symbol.quote_for_named_argument(@str, node.real_name)
       end
       if node.args.size > 0
         @str << '('

--- a/src/compiler/crystal/tools/doc/macro.cr
+++ b/src/compiler/crystal/tools/doc/macro.cr
@@ -111,7 +111,7 @@ class Crystal::Doc::Macro
         if html.none?
           io << name
         else
-          HTML.escape name
+          HTML.escape name, io
         end
       else
         io << "_"

--- a/src/compiler/crystal/tools/doc/macro.cr
+++ b/src/compiler/crystal/tools/doc/macro.cr
@@ -107,14 +107,11 @@ class Crystal::Doc::Macro
   def arg_to_html(arg : Arg, io, html : HTMLOption = :all)
     if arg.external_name != arg.name
       if name = arg.external_name.presence
-        if Symbol.needs_quotes_for_named_argument? name
-          if html.none?
-            name.inspect io
-          else
-            HTML.escape name.inspect, io
-          end
-        else
+        name = Symbol.quote_for_named_argument(name)
+        if html.none?
           io << name
+        else
+          HTML.escape name
         end
       else
         io << "_"

--- a/src/compiler/crystal/tools/doc/method.cr
+++ b/src/compiler/crystal/tools/doc/method.cr
@@ -276,7 +276,7 @@ class Crystal::Doc::Method
         if html.none?
           io << name
         else
-          HTML.escape name
+          HTML.escape name, io
         end
       else
         io << "_"

--- a/src/compiler/crystal/tools/doc/method.cr
+++ b/src/compiler/crystal/tools/doc/method.cr
@@ -272,14 +272,11 @@ class Crystal::Doc::Method
   def arg_to_html(arg : Arg, io, html : HTMLOption = :all)
     if arg.external_name != arg.name
       if name = arg.external_name.presence
-        if Symbol.needs_quotes_for_named_argument? name
-          if html.none?
-            name.inspect io
-          else
-            HTML.escape name.inspect, io
-          end
-        else
+        name = Symbol.quote_for_named_argument(name)
+        if html.none?
           io << name
+        else
+          HTML.escape name
         end
       else
         io << "_"

--- a/src/compiler/crystal/tools/doc/type.cr
+++ b/src/compiler/crystal/tools/doc/type.cr
@@ -517,11 +517,7 @@ class Crystal::Doc::Type
     if (named_args = node.named_args) && !named_args.empty?
       io << ", " unless node.type_vars.empty?
       named_args.join(io, ", ") do |entry|
-        if Symbol.needs_quotes_for_named_argument?(entry.name)
-          entry.name.inspect(io)
-        else
-          io << entry.name
-        end
+        Symbol.quote_for_named_argument(io, entry.name)
         io << ": "
         node_to_html entry.value, io, html: html
       end
@@ -636,11 +632,7 @@ class Crystal::Doc::Type
   def type_to_html(type : Crystal::NamedTupleInstanceType, io, text = nil, html : HTMLOption = :all)
     io << '{'
     type.entries.join(io, ", ") do |entry|
-      if Symbol.needs_quotes_for_named_argument?(entry.name)
-        entry.name.inspect(io)
-      else
-        io << entry.name
-      end
+      Symbol.quote_for_named_argument(io, entry.name)
       io << ": "
       type_to_html entry.type, io, html: html
     end

--- a/src/compiler/crystal/types.cr
+++ b/src/compiler/crystal/types.cr
@@ -2628,11 +2628,7 @@ module Crystal
     def to_s_with_options(io : IO, skip_union_parens : Bool = false, generic_args : Bool = true, codegen : Bool = false) : Nil
       io << "NamedTuple("
       @entries.join(io, ", ") do |entry|
-        if Symbol.needs_quotes_for_named_argument?(entry.name)
-          entry.name.inspect(io)
-        else
-          io << entry.name
-        end
+        Symbol.quote_for_named_argument(io, entry.name)
         io << ": "
         entry_type = entry.type
         entry_type = entry_type.devirtualize unless codegen

--- a/src/named_tuple.cr
+++ b/src/named_tuple.cr
@@ -449,12 +449,7 @@ struct NamedTuple
       {% if i > 0 %}
         io << ", "
       {% end %}
-      key = {{key.stringify}}
-      if Symbol.needs_quotes_for_named_argument?(key)
-        key.inspect(io)
-      else
-        io << key
-      end
+      Symbol.quote_for_named_argument io, {{key.stringify}}
       io << ": "
       self[{{key.symbolize}}].inspect(io)
     {% end %}
@@ -468,12 +463,7 @@ struct NamedTuple
           pp.comma
         {% end %}
         pp.group do
-          key = {{key.stringify}}
-          if Symbol.needs_quotes_for_named_argument?(key)
-            pp.text key.inspect
-          else
-            pp.text key
-          end
+          pp.text Symbol.quote_for_named_argument({{key.stringify}})
           pp.text ": "
           pp.nest do
             pp.breakable ""

--- a/src/symbol.cr
+++ b/src/symbol.cr
@@ -99,6 +99,26 @@ struct Symbol
     end
   end
 
+  # :nodoc:
+  # Appends *string* to *io* and quotes it if necessary.
+  def self.quote_for_named_argument(io : IO, string : String) : Nil
+    if needs_quotes_for_named_argument?(string)
+      string.inspect(io)
+    else
+      io << string
+    end
+  end
+
+  # :nodoc:
+  # Returns *string* and quotes it if necessary.
+  def self.quote_for_named_argument(string : String) : String
+    if needs_quotes_for_named_argument?(string)
+      string.inspect
+    else
+      string
+    end
+  end
+
   def clone
     self
   end

--- a/src/symbol.cr
+++ b/src/symbol.cr
@@ -78,7 +78,6 @@ struct Symbol
   # :nodoc:
   # Determines if a string needs to be quoted to be used for an external
   # parameter name or a named argument's key.
-  @[Deprecated("Use `.quite_for_named_argument` instead")]
   def self.needs_quotes_for_named_argument?(string) : Bool
     case string
     when "", "_"

--- a/src/symbol.cr
+++ b/src/symbol.cr
@@ -78,6 +78,7 @@ struct Symbol
   # :nodoc:
   # Determines if a string needs to be quoted to be used for an external
   # parameter name or a named argument's key.
+  @[Deprecated("Use `.quite_for_named_argument` instead")]
   def self.needs_quotes_for_named_argument?(string) : Bool
     case string
     when "", "_"


### PR DESCRIPTION
Every call to `Symbol.needs_quotes_for_named_argument?` in the compiler and stdlib is used in the same manner to decide whether to use the parameter directly or with inspect. All call sites look like this:

```cr
if Symbol.needs_quotes_for_named_argument?(x)
   x.inspect
else
  x
end
```

This PR extracts that common logic into a helper method `Symbol.quote_for_named_argument`.
Like `.needs_quotes_for_named_argument?`, it's nodoc.

All calls to `Symbol.needs_quotes_for_named_argument?` are replaced by `Symbol.quote_for_named_argument`<del>, and the former is marked as deprecated.
It's a nodoc method, so this would not be absolutely necessary and we could just remove it right away. But it's still nice to keep it available for some time (at least till the next release).</del>