### PR TITLE
Fix `LLVM.default_target_triple` to normalize aarch64 darwin target

### DIFF
--- a/src/llvm.cr
+++ b/src/llvm.cr
@@ -90,7 +90,11 @@ module LLVM
     chars = LibLLVM.get_default_target_triple
     triple = string_and_dispose(chars)
     if triple =~ /x86_64-apple-macosx|x86_64-apple-darwin/
+      # normalize on `macosx` and remove minimum deployment target version
       "x86_64-apple-macosx"
+    elsif triple =~ /aarch64-apple-macosx|aarch64-apple-darwin/
+      # normalize on `macosx` and remove minimum deployment target version
+      "aarch64-apple-macosx"
     elsif triple =~ /aarch64-unknown-linux-android/
       # remove API version
       "aarch64-unknown-linux-android"


### PR DESCRIPTION
Resolves #13594