### PR TITLE
Fix leap second handling for timezone information files

### DIFF
--- a/src/time/location/loader.cr
+++ b/src/time/location/loader.cr
@@ -110,7 +110,7 @@ class Time::Location
 
     abbreviations = read_buffer(io, abbrev_length)
 
-    leap_second_time_pairs = Bytes.new(num_leap_seconds)
+    leap_second_time_pairs = Bytes.new(num_leap_seconds * 8)
     io.read_fully(leap_second_time_pairs)
 
     isstddata = Bytes.new(num_std_wall)


### PR DESCRIPTION
[A leap second record in a TZif file occupies 8 bytes, not 1 byte.](https://datatracker.ietf.org/doc/html/rfc8536#section-3.2) On my machine the system zoneinfo files do not contain leap seconds, but they can be seen in action by downloading the official tzdata manually, then running something like `zic -d out -L leapseconds africa`. Set `$ZONEINFO` to point to that `out` directory, and the number of leap second records should be non-zero.

Not fixing this bug means the standard/wall clock indicators and the [version 2+ data blocks](https://github.com/crystal-lang/crystal/issues/11907) would be entirely corrupted. Note that each leap second record occupies 12 bytes instead when 64-bit times are present.