### PR TITLE
Place `--emit` files back in current directory when running source

### DIFF
--- a/src/compiler/crystal/command.cr
+++ b/src/compiler/crystal/command.cr
@@ -331,6 +331,7 @@ class Crystal::Command
     compiler : Compiler,
     sources : Array(Compiler::Source),
     output_filename : String,
+    emit_base_filename : String?,
     arguments : Array(String),
     specified_output : Bool,
     hierarchy_exp : String?,
@@ -338,7 +339,7 @@ class Crystal::Command
     output_format : String?,
     combine_rpath : Bool do
     def compile(output_filename = self.output_filename)
-      compiler.emit_base_filename = output_filename.rchop(File.extname(output_filename))
+      compiler.emit_base_filename = emit_base_filename || output_filename.rchop(File.extname(output_filename))
       compiler.compile sources, output_filename, combine_rpath: combine_rpath
     end
 
@@ -553,8 +554,12 @@ class Crystal::Command
       error "can't use `#{output_filename}` as output filename because it's a directory"
     end
 
+    if run
+      emit_base_filename = ::Path[sources.first.filename].stem
+    end
+
     combine_rpath = run && !no_codegen
-    @config = CompilerConfig.new compiler, sources, output_filename, arguments, specified_output, hierarchy_exp, cursor_location, output_format, combine_rpath
+    @config = CompilerConfig.new compiler, sources, output_filename, emit_base_filename, arguments, specified_output, hierarchy_exp, cursor_location, output_format, combine_rpath
   end
 
   private def gather_sources(filenames)


### PR DESCRIPTION
#13370 caused `run --emit=...` to place those files in the same directory as the temporary executable, e.g. `~/.cache/crystal/crystal-run-test.ll`. This restores the previous behavior where they are placed in the current directory.