### PR TITLE
Fix free variable matching of bound numeric values

### DIFF
--- a/spec/compiler/semantic/restrictions_spec.cr
+++ b/spec/compiler/semantic/restrictions_spec.cr
@@ -1221,6 +1221,19 @@ describe "Restrictions" do
       CR
   end
 
+  it "matches number in bound free variable (#13605)" do
+    assert_type(<<-CR) { generic_class "Foo", 1.int32 }
+      class Foo(T)
+      end
+
+      def foo(x : Foo(T), y : Foo(T)) forall T
+        y
+      end
+
+      foo(Foo(1).new, Foo(1).new)
+      CR
+  end
+
   it "sets number as unbound generic type var (#13110)" do
     assert_type(<<-CR) { generic_class "Foo", 1.int32 }
       class Foo(T)

--- a/src/compiler/crystal/semantic/call.cr
+++ b/src/compiler/crystal/semantic/call.cr
@@ -1040,7 +1040,7 @@ class Crystal::Call
                             when Self
                               match.context.instantiated_type
                             when Crystal::Path
-                              match.context.defining_type.lookup_type_var(output, match.context.free_vars)
+                              match.context.defining_type.lookup_type_var(output, match.context.bound_free_vars)
                             else
                               output
                             end
@@ -1091,12 +1091,12 @@ class Crystal::Call
 
   private def lookup_node_type(context, node)
     bubbling_exception do
-      context.defining_type.lookup_type(node, self_type: context.instantiated_type.instance_type, free_vars: context.free_vars, allow_typeof: false)
+      context.defining_type.lookup_type(node, self_type: context.instantiated_type.instance_type, free_vars: context.bound_free_vars, allow_typeof: false)
     end
   end
 
   private def lookup_node_type?(context, node)
-    context.defining_type.lookup_type?(node, self_type: context.instantiated_type.instance_type, free_vars: context.free_vars, allow_typeof: false)
+    context.defining_type.lookup_type?(node, self_type: context.instantiated_type.instance_type, free_vars: context.bound_free_vars, allow_typeof: false)
   end
 
   def bubbling_exception(&)

--- a/src/compiler/crystal/semantic/call_error.cr
+++ b/src/compiler/crystal/semantic/call_error.cr
@@ -532,7 +532,7 @@ class Crystal::Call
     unless expected_type
       restriction = def_arg.restriction
       if restriction
-        expected_type = match_context.instantiated_type.lookup_type?(restriction, free_vars: match_context.free_vars)
+        expected_type = match_context.instantiated_type.lookup_type?(restriction, free_vars: match_context.bound_free_vars)
       end
     end
     expected_type ||= def_arg.restriction.not_nil!

--- a/src/compiler/crystal/semantic/main_visitor.cr
+++ b/src/compiler/crystal/semantic/main_visitor.cr
@@ -3076,7 +3076,7 @@ module Crystal
     # # Helpers
 
     def free_vars
-      match_context.try &.free_vars
+      match_context.try &.bound_free_vars
     end
 
     def check_closured(var, mark_as_mutably_closured : Bool = false)

--- a/src/compiler/crystal/semantic/match.cr
+++ b/src/compiler/crystal/semantic/match.cr
@@ -44,9 +44,9 @@ module Crystal
     property defining_type : Type
 
     # Any instance variables associated with the method instantiation
-    getter free_vars : Hash(String, TypeVar)?
+    getter bound_free_vars : Hash(String, TypeVar)?
 
-    # Def free variables, unbound (`def (X, Y) ...`)
+    # Def free variables (`def ... forall X, Y`)
     property def_free_vars : Array(String)?
 
     # The type that represents `self` (overriding `instantiated_type`), used to
@@ -54,21 +54,21 @@ module Crystal
     # subtype
     property self_restriction_type : Type?
 
-    def initialize(@instantiated_type, @defining_type, @free_vars = nil, @def_free_vars = nil, @self_restriction_type = nil)
+    def initialize(@instantiated_type, @defining_type, @bound_free_vars = nil, @def_free_vars = nil, @self_restriction_type = nil)
     end
 
-    def get_free_var(name)
-      @free_vars.try &.[name]?
+    def bound_free_var?(name)
+      @bound_free_vars.try &.[name]?
     end
 
-    def set_free_var(name, type)
-      free_vars = @free_vars ||= {} of String => TypeVar
+    def bind_free_var(name, type)
+      bound_free_vars = @bound_free_vars ||= {} of String => TypeVar
       type = type.remove_literal if type.is_a?(Type)
-      free_vars[name] = type
+      bound_free_vars[name] = type
     end
 
-    def has_def_free_var?(name)
-      return false if get_free_var(name)
+    def has_unbound_free_var?(name)
+      return false if bound_free_var?(name)
       return true if @def_free_vars.try &.includes?(name)
 
       defining_type.metaclass? && defining_type.type_var?(name)
@@ -98,7 +98,7 @@ module Crystal
     end
 
     def clone
-      MatchContext.new(@instantiated_type, @defining_type, @free_vars.dup, @def_free_vars.dup, @self_restriction_type)
+      MatchContext.new(@instantiated_type, @defining_type, @bound_free_vars.dup, @def_free_vars.dup, @self_restriction_type)
     end
   end
 

--- a/src/compiler/crystal/semantic/method_lookup.cr
+++ b/src/compiler/crystal/semantic/method_lookup.cr
@@ -122,7 +122,7 @@ module Crystal
           context.defining_type = macro_owner if macro_owner
           context.self_restriction_type = item.def.self_restriction_type
           context.def_free_vars = item.def.free_vars
-          context.free_vars.try &.clear
+          context.bound_free_vars.try &.clear
 
           match = signature.match(item, context)
 
@@ -146,7 +146,7 @@ module Crystal
             context.defining_type = path_lookup if macro_owner
             context.self_restriction_type = nil
             context.def_free_vars = nil
-            context.free_vars.try &.clear
+            context.bound_free_vars.try &.clear
           end
         end
 
@@ -369,7 +369,7 @@ module Crystal
 
       # We reuse a match context without free vars, but we create
       # new ones when there are free vars.
-      context = context.clone if context.free_vars
+      context = context.clone if context.bound_free_vars
 
       Match.new(a_def, (matched_arg_types || arg_types), context, matched_named_arg_types)
     end
@@ -481,7 +481,7 @@ module Crystal
                 end
 
                 new_subtype_matches ||= [] of Match
-                new_subtype_matches.push Match.new(cloned_def, full_subtype_match.arg_types, MatchContext.new(subtype_lookup, full_subtype_match.context.defining_type, full_subtype_match.context.free_vars), full_subtype_match.named_arg_types)
+                new_subtype_matches.push Match.new(cloned_def, full_subtype_match.arg_types, MatchContext.new(subtype_lookup, full_subtype_match.context.defining_type, full_subtype_match.context.bound_free_vars), full_subtype_match.named_arg_types)
               end
 
               # Reset the `self` restriction override

--- a/src/compiler/crystal/semantic/restrictions.cr
+++ b/src/compiler/crystal/semantic/restrictions.cr
@@ -1263,14 +1263,14 @@ module Crystal
           end
         when Path
           if first_name = other_type_var.single_name?
-            if context.has_def_free_var?(first_name)
-              # If the free variable is already set to another
-              # number, there's no match
-              existing = context.get_free_var(first_name)
-              if existing && existing != type_var
-                return nil
-              end
+            # If the free variable is already set to another
+            # number, there's no match
+            if existing = context.get_free_var(first_name)
+              return existing == type_var ? existing : nil
+            end
 
+            # If the free variable is not yet bound, there is a match
+            if context.has_def_free_var?(first_name)
               context.set_free_var(first_name, type_var)
               return type_var
             end


### PR DESCRIPTION
Fixes #13605.

Also renames a few things in `Crystal::MatchContext` for clarity.