### PR TITLE
Use `Set(T)` instead of `Hash(T, Bool)`

### DIFF
--- a/src/iterator.cr
+++ b/src/iterator.cr
@@ -1283,18 +1283,14 @@ module Iterator(T)
     include IteratorWrapper
 
     def initialize(@iterator : I, @func : T -> U)
-      @hash = {} of U => Bool
+      @set = Set(U).new
     end
 
     def next
       while true
         value = wrapped_next
         transformed = @func.call value
-
-        unless @hash[transformed]?
-          @hash[transformed] = true
-          return value
-        end
+        return value if @set.add?(transformed)
       end
     end
   end

--- a/src/reference.cr
+++ b/src/reference.cr
@@ -139,7 +139,8 @@ class Reference
 
   # :nodoc:
   module ExecRecursive
-    alias Registry = Hash({UInt64, Symbol}, Bool)
+    # NOTE: can't use `Set` here because of prelude require order
+    alias Registry = Hash({UInt64, Symbol}, Nil)
 
     {% if flag?(:preview_mt) %}
       @@exec_recursive = Crystal::ThreadLocalValue(Registry).new
@@ -159,14 +160,12 @@ class Reference
   private def exec_recursive(method, &)
     hash = ExecRecursive.hash
     key = {object_id, method}
-    if hash[key]?
-      false
-    else
-      hash[key] = true
+    hash.put(key, nil) do
       yield
       hash.delete(key)
-      true
+      return true
     end
+    false
   end
 
   # :nodoc:


### PR DESCRIPTION
All these hashes do not care about the difference between a `false` key and a non-existent key, so a `Set` is more appropriate.

This also removes a few double lookups.