### PR TITLE
Add `crystal tool dependencies`

### DIFF
--- a/src/compiler/crystal/command.cr
+++ b/src/compiler/crystal/command.cr
@@ -354,7 +354,7 @@ class Crystal::Command
 
   private def create_compiler(command, no_codegen = false, run = false,
                               hierarchy = false, cursor_command = false,
-                              single_file = false)
+                              single_file = false, dependencies = false)
     compiler = new_compiler
     compiler.progress_tracker = @progress_tracker
     link_flags = [] of String
@@ -410,8 +410,14 @@ class Crystal::Command
         end
       end
 
-      opts.on("-f text|json", "--format text|json", "Output format text (default) or json") do |f|
-        output_format = f
+      if dependencies
+        opts.on("-f tree|flat", "--format tree|flat", "Output format tree (default) or flat") do |f|
+          output_format = f
+        end
+      else
+        opts.on("-f text|json", "--format text|json", "Output format text (default) or json") do |f|
+          output_format = f
+        end
       end
 
       opts.on("--error-trace", "Show full error trace") do
@@ -547,9 +553,16 @@ class Crystal::Command
       end
     end
 
-    output_format ||= "text"
-    unless output_format.in?("text", "json")
-      error "You have input an invalid format, only text and JSON are supported"
+    if dependencies
+      output_format ||= "tree"
+      unless output_format.in?("tree", "flat")
+        error "You have input an invalid format, only tree and flat are supported"
+      end
+    else
+      output_format ||= "text"
+      unless output_format.in?("text", "json")
+        error "You have input an invalid format, only text and JSON are supported"
+      end
     end
 
     error "maximum number of threads cannot be lower than 1" if compiler.n_threads < 1

--- a/src/compiler/crystal/command.cr
+++ b/src/compiler/crystal/command.cr
@@ -43,6 +43,7 @@ class Crystal::Command
         expand                   show macro expansion for given location
         format                   format project, directories and/or files
         hierarchy                show type hierarchy
+        dependencies             show file dependency tree
         implementations          show implementations for given call in location
         types                    show type of main variables
         --help, -h               show this help
@@ -181,6 +182,9 @@ class Crystal::Command
     when "hierarchy".starts_with?(tool)
       options.shift
       hierarchy
+    when "dependencies".starts_with?(tool)
+      options.shift
+      dependencies
     when "implementations".starts_with?(tool)
       options.shift
       implementations

--- a/src/compiler/crystal/compiler.cr
+++ b/src/compiler/crystal/compiler.cr
@@ -144,6 +144,8 @@ module Crystal
     # Whether to link statically
     property? static = false
 
+    property dependency_printer : DependencyPrinter? = nil
+
     # Program that was created for the last compilation.
     property! program : Program
 

--- a/src/compiler/crystal/program.cr
+++ b/src/compiler/crystal/program.cr
@@ -454,6 +454,16 @@ module Crystal
       recorded_requires << RecordedRequire.new(filename, relative_to)
     end
 
+    def run_requires(node : Require, filenames) : Nil
+      filenames.each do |filename|
+        unseen_file = requires.add?(filename)
+
+        if unseen_file
+          yield filename
+        end
+      end
+    end
+
     # Finds *filename* in the configured CRYSTAL_PATH for this program,
     # relative to *relative_to*.
     def find_in_path(filename, relative_to = nil) : Array(String)?

--- a/src/compiler/crystal/program.cr
+++ b/src/compiler/crystal/program.cr
@@ -455,12 +455,18 @@ module Crystal
     end
 
     def run_requires(node : Require, filenames) : Nil
+      dependency_printer = compiler.try(&.dependency_printer)
+
       filenames.each do |filename|
         unseen_file = requires.add?(filename)
+
+        dependency_printer.try(&.enter_file(filename, unseen_file))
 
         if unseen_file
           yield filename
         end
+
+        dependency_printer.try(&.leave_file)
       end
     end
 

--- a/src/compiler/crystal/semantic/semantic_visitor.cr
+++ b/src/compiler/crystal/semantic/semantic_visitor.cr
@@ -69,11 +69,11 @@ abstract class Crystal::SemanticVisitor < Crystal::Visitor
 
     if filenames
       nodes = Array(ASTNode).new(filenames.size)
-      filenames.each do |filename|
-        if @program.requires.add?(filename)
-          nodes << require_file(node, filename)
-        end
+
+      @program.run_requires(node, filenames) do |filename|
+        nodes << require_file(node, filename)
       end
+
       expanded = Expressions.from(nodes)
     else
       expanded = Nop.new

--- a/src/compiler/crystal/semantic/semantic_visitor.cr
+++ b/src/compiler/crystal/semantic/semantic_visitor.cr
@@ -71,21 +71,7 @@ abstract class Crystal::SemanticVisitor < Crystal::Visitor
       nodes = Array(ASTNode).new(filenames.size)
       filenames.each do |filename|
         if @program.requires.add?(filename)
-          parser = @program.new_parser(File.read(filename))
-          parser.filename = filename
-          parser.wants_doc = @program.wants_doc?
-          begin
-            parsed_nodes = parser.parse
-            parsed_nodes = @program.normalize(parsed_nodes, inside_exp: inside_exp?)
-            # We must type the node immediately, in case a file requires another
-            # *before* one of the files in `filenames`
-            parsed_nodes.accept self
-          rescue ex : CodeError
-            node.raise "while requiring \"#{node.string}\"", ex
-          rescue ex
-            raise Error.new "while requiring \"#{node.string}\"", ex
-          end
-          nodes << FileNode.new(parsed_nodes, filename)
+          nodes << require_file(node, filename)
         end
       end
       expanded = Expressions.from(nodes)
@@ -96,6 +82,25 @@ abstract class Crystal::SemanticVisitor < Crystal::Visitor
     node.expanded = expanded
     node.bind_to(expanded)
     false
+  end
+
+  private def require_file(node : Require, filename : String)
+    parser = @program.new_parser(File.read(filename))
+    parser.filename = filename
+    parser.wants_doc = @program.wants_doc?
+    begin
+      parsed_nodes = parser.parse
+      parsed_nodes = @program.normalize(parsed_nodes, inside_exp: inside_exp?)
+      # We must type the node immediately, in case a file requires another
+      # *before* one of the files in `filenames`
+      parsed_nodes.accept self
+    rescue ex : CodeError
+      node.raise "while requiring \"#{node.string}\"", ex
+    rescue ex
+      raise Error.new "while requiring \"#{node.string}\"", ex
+    end
+
+    FileNode.new(parsed_nodes, filename)
   end
 
   def visit(node : ClassDef)

--- a/src/compiler/crystal/tools/dependencies.cr
+++ b/src/compiler/crystal/tools/dependencies.cr
@@ -5,10 +5,9 @@ require "../syntax/ast"
 class Crystal::Command
   private def dependencies
     config = create_compiler "tool dependencies", no_codegen: true, dependencies: true
-    config.compiler.no_codegen = true
 
     config.compiler.dependency_printer = DependencyPrinter.new(STDOUT, flat: config.output_format == "flat")
-    config.compile
+    config.compiler.top_level_semantic config.sources
   end
 end
 

--- a/src/compiler/crystal/tools/dependencies.cr
+++ b/src/compiler/crystal/tools/dependencies.cr
@@ -13,7 +13,7 @@ class Crystal::Command
         when "tree"
           dependency_printer = DependencyPrinter.new(STDOUT, flat: false)
         else
-          abort "Invalid format: #{format}"
+          error "Invalid format: #{format}"
         end
       end
     end
@@ -34,12 +34,10 @@ module Crystal
     end
 
     def enter_file(filename : String, unseen : Bool)
-      unless unseen
-        @indent += 1
-        return
+      if unseen
+        print_indent
+        print_file(filename)
       end
-      print_indent
-      print_file(filename)
 
       @indent += 1
     end
@@ -50,7 +48,7 @@ module Crystal
 
     private def print_indent
       return if @flat
-      @io.print "  " * @indent.clamp(0..)
+      @io.print "  " * @indent if @indent > 0
     end
 
     private def print_file(filename)

--- a/src/compiler/crystal/tools/dependencies.cr
+++ b/src/compiler/crystal/tools/dependencies.cr
@@ -21,8 +21,7 @@ module Crystal
     def enter_file(filename : String, unseen : Bool)
       print_indent
       print_file(filename)
-      if unseen
-      else
+      unless unseen
         @io.print " (duplicate skipped)"
       end
       @io.puts

--- a/src/compiler/crystal/tools/dependencies.cr
+++ b/src/compiler/crystal/tools/dependencies.cr
@@ -4,24 +4,10 @@ require "../syntax/ast"
 
 class Crystal::Command
   private def dependencies
-    dependency_printer = nil
-    option_parser = parse_with_crystal_opts do |opts|
-      opts.on("-f FORMAT", "--format FORMAT", "Format the output. Available options: flat, tree (default)") do |format|
-        case format
-        when "flat"
-          dependency_printer = DependencyPrinter.new(STDOUT, flat: true)
-        when "tree"
-          dependency_printer = DependencyPrinter.new(STDOUT, flat: false)
-        else
-          error "Invalid format: #{format}"
-        end
-      end
-    end
-
-    config = create_compiler "tool dependencies", no_codegen: true
+    config = create_compiler "tool dependencies", no_codegen: true, dependencies: true
     config.compiler.no_codegen = true
 
-    config.compiler.dependency_printer = dependency_printer || DependencyPrinter.new(STDOUT)
+    config.compiler.dependency_printer = DependencyPrinter.new(STDOUT, flat: config.output_format == "flat")
     config.compile
   end
 end

--- a/src/compiler/crystal/tools/dependencies.cr
+++ b/src/compiler/crystal/tools/dependencies.cr
@@ -13,7 +13,7 @@ end
 
 module Crystal
   class DependencyPrinter
-    @indent = 0
+    @depth = 0
 
     def initialize(@io : IO, @flat : Bool = false)
     end
@@ -24,16 +24,16 @@ module Crystal
         print_file(filename)
       end
 
-      @indent += 1
+      @depth += 1
     end
 
     def leave_file
-      @indent -= 1
+      @depth -= 1
     end
 
     private def print_indent
       return if @flat
-      @io.print "  " * @indent if @indent > 0
+      @io.print "  " * @depth if @depth > 0
     end
 
     private def print_file(filename)

--- a/src/compiler/crystal/tools/dependencies.cr
+++ b/src/compiler/crystal/tools/dependencies.cr
@@ -1,0 +1,60 @@
+require "set"
+require "colorize"
+require "../syntax/ast"
+
+class Crystal::Command
+  private def dependencies
+    dependency_printer = nil
+    option_parser = parse_with_crystal_opts do |opts|
+      opts.on("-f FORMAT", "--format FORMAT", "Format the output. Available options: flat, tree (default)") do |format|
+        case format
+        when "flat"
+          dependency_printer = DependencyPrinter.new(STDOUT, flat: true)
+        when "tree"
+          dependency_printer = DependencyPrinter.new(STDOUT, flat: false)
+        else
+          abort "Invalid format: #{format}"
+        end
+      end
+    end
+
+    config = create_compiler "tool dependencies", no_codegen: true
+    config.compiler.no_codegen = true
+
+    config.compiler.dependency_printer = dependency_printer || DependencyPrinter.new(STDOUT)
+    config.compile
+  end
+end
+
+module Crystal
+  class DependencyPrinter
+    @indent = 0
+
+    def initialize(@io : IO, @flat : Bool = false)
+    end
+
+    def enter_file(filename : String, unseen : Bool)
+      unless unseen
+        @indent += 1
+        return
+      end
+      print_indent
+      print_file(filename)
+
+      @indent += 1
+    end
+
+    def leave_file
+      @indent -= 1
+    end
+
+    private def print_indent
+      return if @flat
+      @io.print "  " * @indent.clamp(0..)
+    end
+
+    private def print_file(filename)
+      @io.puts ::Path[filename].relative_to?(Dir.current) || filename
+    end
+  end
+end

--- a/src/compiler/crystal/tools/dependencies.cr
+++ b/src/compiler/crystal/tools/dependencies.cr
@@ -19,10 +19,13 @@ module Crystal
     end
 
     def enter_file(filename : String, unseen : Bool)
+      print_indent
+      print_file(filename)
       if unseen
-        print_indent
-        print_file(filename)
+      else
+        @io.print " (duplicate skipped)"
       end
+      @io.puts
 
       @depth += 1
     end
@@ -37,7 +40,7 @@ module Crystal
     end
 
     private def print_file(filename)
-      @io.puts ::Path[filename].relative_to?(Dir.current) || filename
+      @io.print ::Path[filename].relative_to?(Dir.current) || filename
     end
   end
 end


### PR DESCRIPTION
This tool prints all source files read by the compiler in their require order.

It's a basic implementation with two format options, `tree` and `flat`. They are identical except that `flat` has no indent.
Files are printed exactly in the order they are required. Duplicates (i.e. when a file had already been required before) are not shown.

<details>
<summary>Example output for an empty file</summary>

```
src/prelude.cr
  src/crystal/once.cr
  src/lib_c.cr
  src/macros.cr
  src/object.cr
  src/comparable.cr
  src/exception.cr
    src/exception/call_stack.cr
      src/exception/call_stack/libunwind.cr
        src/lib_c/x86_64-linux-gnu/c/dlfcn.cr
        src/lib_c/x86_64-linux-gnu/c/stdio.cr
          src/lib_c/x86_64-linux-gnu/c/sys/types.cr
            src/lib_c/x86_64-linux-gnu/c/stddef.cr
            src/lib_c/x86_64-linux-gnu/c/stdint.cr
        src/lib_c/x86_64-linux-gnu/c/string.cr
        src/exception/lib_unwind.cr
        src/exception/call_stack/dwarf.cr
          src/crystal/dwarf.cr
            src/crystal/dwarf/abbrev.cr
            src/crystal/dwarf/info.cr
            src/crystal/dwarf/line_numbers.cr
            src/crystal/dwarf/strings.cr
          src/exception/call_stack/elf.cr
            src/crystal/elf.cr
            src/lib_c/x86_64-linux-gnu/c/link.cr
              src/lib_c/x86_64-linux-gnu/c/elf.cr
    src/system_error.cr
  src/iterable.cr
  src/iterator.cr
    src/enumerable.cr
  src/steppable.cr
  src/indexable.cr
    src/indexable/mutable.cr
  src/string.cr
    src/lib_c/x86_64-linux-gnu/c/stdlib.cr
      src/lib_c/x86_64-linux-gnu/c/sys/wait.cr
        src/lib_c/x86_64-linux-gnu/c/signal.cr
          src/lib_c/x86_64-linux-gnu/c/time.cr
    src/crystal/small_deque.cr
    src/crystal/iconv.cr
      src/lib_c/x86_64-linux-gnu/c/iconv.cr
    src/string/builder.cr
      src/io.cr
        src/lib_c/x86_64-linux-gnu/c/errno.cr
        src/lib_c/x86_64-linux-gnu/c/unistd.cr
        src/io/argf.cr
        src/io/buffered.cr
        src/io/byte_format.cr
        src/io/console.cr
        src/io/delimited.cr
        src/io/encoding.cr
        src/io/encoding_stubs.cr
        src/io/error.cr
        src/io/evented.cr
          src/crystal/thread_local_value.cr
        src/io/file_descriptor.cr
          src/crystal/system/file_descriptor.cr
            src/crystal/system/unix/file_descriptor.cr
              src/lib_c/x86_64-linux-gnu/c/fcntl.cr
                src/lib_c/x86_64-linux-gnu/c/sys/stat.cr
              src/termios.cr
                src/lib_c/x86_64-linux-gnu/c/termios.cr
        src/io/hexdump.cr
        src/io/memory.cr
        src/io/multi_writer.cr
        src/io/overlapped.cr
        src/io/sized.cr
        src/io/stapled.cr
    src/string/formatter.cr
    src/string/grapheme.cr
      src/string/grapheme/grapheme.cr
        src/string/grapheme/properties.cr
    src/string/utf16.cr
  src/number.cr
  src/primitives.cr
  src/annotations.cr
  src/array.cr
  src/atomic.cr
    src/llvm/enums/atomic.cr
  src/base64.cr
  src/bool.cr
  src/box.cr
  src/char.cr
  src/char/reader.cr
  src/class.cr
  src/concurrent.cr
    src/fiber.cr
      src/crystal/system/thread_linked_list.cr
        src/crystal/system/thread_mutex.cr
          src/crystal/system/unix/pthread_mutex.cr
            src/lib_c/x86_64-linux-gnu/c/pthread.cr
      src/fiber/context.cr
        src/fiber/context/aarch64.cr
        src/fiber/context/arm.cr
        src/fiber/context/i386.cr
        src/fiber/context/interpreted.cr
        src/fiber/context/wasm32.cr
        src/fiber/context/x86_64-microsoft.cr
        src/fiber/context/x86_64-sysv.cr
      src/fiber/stack_pool.cr
        src/crystal/system/fiber.cr
          src/crystal/system/unix/fiber.cr
            src/lib_c/x86_64-linux-gnu/c/sys/mman.cr
    src/channel.cr
      src/crystal/spin_lock.cr
      src/crystal/pointer_linked_list.cr
    src/crystal/scheduler.cr
      src/crystal/system/event_loop.cr
        src/crystal/system/unix/event_loop_libevent.cr
          src/crystal/system/unix/event_libevent.cr
            src/crystal/system/unix/lib_event2.cr
              src/lib_c/x86_64-linux-gnu/c/netdb.cr
                src/lib_c/x86_64-linux-gnu/c/netinet/in.cr
                  src/lib_c/x86_64-linux-gnu/c/sys/socket.cr
      src/crystal/system/print_error.cr
      src/crystal/fiber_channel.cr
      src/crystal/system/thread.cr
        src/crystal/system/thread_condition_variable.cr
          src/crystal/system/unix/pthread_condition_variable.cr
        src/crystal/system/unix/pthread.cr
          src/lib_c/x86_64-linux-gnu/c/sched.cr
  src/crystal/compiler_rt.cr
    src/crystal/compiler_rt/fixint.cr
    src/crystal/compiler_rt/float.cr
    src/crystal/compiler_rt/mul.cr
    src/crystal/compiler_rt/divmod128.cr
  src/crystal/main.cr
    src/process/executable_path.cr
  src/deque.cr
  src/dir.cr
    src/crystal/system/dir.cr
      src/crystal/system/unix/dir.cr
        src/lib_c/x86_64-linux-gnu/c/dirent.cr
    src/dir/glob.cr
  src/enum.cr
  src/env.cr
    src/crystal/system/env.cr
      src/crystal/system/unix/env.cr
  src/errno.cr
  src/winerror.cr
  src/wasi_error.cr
  src/file.cr
    src/file/error.cr
    src/crystal/system/file.cr
      src/crystal/system/unix/file.cr
        src/lib_c/x86_64-linux-gnu/c/sys/file.cr
    src/file/info.cr
      src/crystal/system/file_info.cr
        src/crystal/system/unix/file_info.cr
    src/file/preader.cr
    src/file/tempfile.cr
  src/float.cr
    src/float/printer.cr
      src/float/printer/cached_powers.cr
      src/float/printer/diy_fp.cr
        src/float/printer/ieee.cr
      src/float/printer/dragonbox.cr
        src/float/printer/dragonbox_cache.cr
      src/float/printer/grisu3.cr
  src/gc.cr
    src/gc/boehm.cr
  src/hash.cr
    src/crystal/hasher.cr
  src/int.cr
  src/intrinsics.cr
  src/kernel.cr
    src/crystal/at_exit_handlers.cr
  src/math/math.cr
    src/math/libm.cr
  src/mutex.cr
  src/named_tuple.cr
  src/nil.cr
  src/humanize.cr
  src/path.cr
    src/crystal/system/path.cr
      src/crystal/system/unix/path.cr
        src/crystal/system/unix/user.cr
          src/lib_c/x86_64-linux-gnu/c/pwd.cr
          src/crystal/system/unix.cr
  src/pointer.cr
  src/pretty_print.cr
  src/proc.cr
  src/process.cr
    src/crystal/system/process.cr
      src/crystal/system/unix/process.cr
        src/lib_c/x86_64-linux-gnu/c/sys/resource.cr
    src/process/shell.cr
    src/process/status.cr
  src/raise.cr
  src/random.cr
    src/random/pcg32.cr
      src/random/secure.cr
        src/crystal/system/random.cr
          src/crystal/system/unix/getrandom.cr
            src/crystal/system/unix/syscall.cr
              src/syscall.cr
                src/syscall/aarch64-linux.cr
                src/syscall/arm-linux.cr
                src/syscall/i386-linux.cr
                src/syscall/x86_64-linux.cr
  src/range.cr
    src/range/bsearch.cr
  src/reference.cr
  src/regex.cr
    src/regex/engine.cr
      src/regex/pcre2.cr
        src/regex/lib_pcre2.cr
    src/regex/match_data.cr
  src/set.cr
  src/signal.cr
    src/crystal/system/signal.cr
      src/crystal/system/unix/signal.cr
  src/slice.cr
    src/slice/sort.cr
  src/static_array.cr
  src/struct.cr
  src/symbol.cr
  src/system.cr
    src/crystal/system.cr
      src/crystal/system/unix/hostname.cr
      src/crystal/system/unix/sysconf_cpucount.cr
  src/time.cr
    src/crystal/system/time.cr
      src/crystal/system/unix/time.cr
        src/lib_c/x86_64-linux-gnu/c/sys/time.cr
    src/time/format.cr
      src/time/format/formatter.cr
        src/time/format/pattern.cr
      src/time/format/parser.cr
      src/time/format/custom/http_date.cr
        src/time/format/custom/rfc_2822.cr
      src/time/format/custom/iso_8601.cr
      src/time/format/custom/rfc_3339.cr
      src/time/format/custom/yaml_date.cr
    src/time/location.cr
      src/time/location/loader.cr
    src/time/span.cr
  src/tuple.cr
  src/unicode/unicode.cr
    src/unicode/data.cr
  src/union.cr
  src/va_list.cr
    src/lib_c/x86_64-linux-gnu/c/stdarg.cr
  src/value.cr
```

</details>

Resolves #11481