### PR TITLE
Restrict some boolean properties to `Bool` in the compiler

### DIFF
--- a/src/compiler/crystal/codegen/codegen.cr
+++ b/src/compiler/crystal/codegen/codegen.cr
@@ -176,8 +176,7 @@ module Crystal
     @c_malloc_fun : LLVMTypedFunction?
     @c_realloc_fun : LLVMTypedFunction?
 
-    def initialize(@program : Program, @node : ASTNode, single_module = false, @debug = Debug::Default)
-      @single_module = !!single_module
+    def initialize(@program : Program, @node : ASTNode, @single_module : Bool = false, @debug = Debug::Default)
       @abi = @program.target_machine.abi
       @llvm_context = LLVM::Context.new
       # LLVM::Context.register(@llvm_context, "main")

--- a/src/compiler/crystal/exception.cr
+++ b/src/compiler/crystal/exception.cr
@@ -7,15 +7,12 @@ module Crystal
   abstract class CodeError < Error
     property? color = false
     property? error_trace = false
+    property? warning = false
 
     @filename : String | VirtualFile | Nil
 
     def to_s(io) : Nil
       to_s_with_source(io, nil)
-    end
-
-    def warning=(warning)
-      @warning = !!warning
     end
 
     abstract def to_s_with_source(io : IO, source)

--- a/src/compiler/crystal/semantic/exception.cr
+++ b/src/compiler/crystal/semantic/exception.cr
@@ -11,19 +11,19 @@ module Crystal
     getter column_number : Int32
     getter size : Int32
 
-    def color=(color)
-      @color = !!color
+    def color=(@color : Bool)
       inner.try &.color=(color)
+      color
     end
 
-    def error_trace=(error_trace)
-      @error_trace = !!error_trace
+    def error_trace=(@error_trace : Bool)
       inner.try &.error_trace=(error_trace)
+      error_trace
     end
 
-    def warning=(warning)
-      super
+    def warning=(@warning : Bool)
       inner.try &.warning=(warning)
+      warning
     end
 
     def self.for_node(node, message, inner = nil)

--- a/src/compiler/crystal/syntax/exception.cr
+++ b/src/compiler/crystal/syntax/exception.cr
@@ -13,10 +13,6 @@ module Crystal
       super(message)
     end
 
-    def color=(color)
-      @color = !!color
-    end
-
     def has_location?
       @filename || @line_number
     end

--- a/src/compiler/crystal/syntax/parser.cr
+++ b/src/compiler/crystal/syntax/parser.cr
@@ -77,9 +77,8 @@ module Crystal
       @assigned_vars = [] of String
     end
 
-    def wants_doc=(wants_doc)
-      @wants_doc = !!wants_doc
-      @doc_enabled = !!wants_doc
+    def wants_doc=(@wants_doc : Bool)
+      @doc_enabled = wants_doc
     end
 
     def parse
@@ -3738,7 +3737,7 @@ module Crystal
       end
 
       @def_nest -= 1
-      @doc_enabled = !!@wants_doc
+      @doc_enabled = @wants_doc
 
       node = Def.new name, params, body, receiver, block_param, return_type, @is_macro_def, @block_arity, is_abstract, splat_index, double_splat: double_splat, free_vars: free_vars
       node.name_location = name_location


### PR DESCRIPTION
Instead of using `!!` inside, the caller has to do this explicitly. (The compiler itself doesn't pass arguments that aren't already `Bool`.)

Note that the following is valid code, but infers `Foo#@foo` to be a `Bool | Nil` rather than `Bool`:

```crystal
class Foo
  # no other declarations of `@foo` here

  def foo=(foo)
    @foo = !!foo
  end
end
```

This happened to `Crystal::CodeError#@warning`.