### PR TITLE
Do not reopen current file in `File#utime` on Windows

### DIFF
--- a/spec/std/file_spec.cr
+++ b/spec/std/file_spec.cr
@@ -1270,7 +1270,7 @@ describe "File" do
   end
 
   describe "utime" do
-    it "sets times with utime" do
+    it "sets times with class method" do
       with_tempfile("utime-set.txt") do |path|
         File.write(path, "")
 
@@ -1284,7 +1284,7 @@ describe "File" do
       end
     end
 
-    it "sets times with futime" do
+    it "sets times with instance method" do
       with_tempfile("utime-set.txt") do |path|
         File.open(path, "w") do |file|
           atime = Time.utc(2000, 1, 2)

--- a/src/crystal/system/unix/file.cr
+++ b/src/crystal/system/unix/file.cr
@@ -183,8 +183,8 @@ module Crystal::System::File
 
   def self.utime(atime : ::Time, mtime : ::Time, filename : String) : Nil
     timevals = uninitialized LibC::Timeval[2]
-    timevals[0] = to_timeval(atime)
-    timevals[1] = to_timeval(mtime)
+    timevals[0] = Crystal::System::Time.to_timeval(atime)
+    timevals[1] = Crystal::System::Time.to_timeval(mtime)
     ret = LibC.utimes(filename, timevals)
     if ret != 0
       raise ::File::Error.from_errno("Error setting time on file", file: filename)
@@ -194,13 +194,13 @@ module Crystal::System::File
   private def system_utime(atime : ::Time, mtime : ::Time, filename : String) : Nil
     ret = {% if LibC.has_method?("futimens") %}
             timespecs = uninitialized LibC::Timespec[2]
-            timespecs[0] = to_timespec(atime)
-            timespecs[1] = to_timespec(mtime)
+            timespecs[0] = Crystal::System::Time.to_timespec(atime)
+            timespecs[1] = Crystal::System::Time.to_timespec(mtime)
             LibC.futimens(fd, timespecs)
           {% elsif LibC.has_method?("futimes") %}
             timevals = uninitialized LibC::Timeval[2]
-            timevals[0] = to_timeval(atime)
-            timevals[1] = to_timeval(mtime)
+            timevals[0] = Crystal::System::Time.to_timeval(atime)
+            timevals[1] = Crystal::System::Time.to_timeval(mtime)
             LibC.futimes(fd, timevals)
           {% else %}
             {% raise "Missing futimens & futimes" %}
@@ -209,20 +209,6 @@ module Crystal::System::File
     if ret != 0
       raise ::File::Error.from_errno("Error setting time on file", file: filename)
     end
-  end
-
-  private def self.to_timespec(time : ::Time)
-    t = uninitialized LibC::Timespec
-    t.tv_sec = typeof(t.tv_sec).new(time.to_unix)
-    t.tv_nsec = typeof(t.tv_nsec).new(time.nanosecond)
-    t
-  end
-
-  private def self.to_timeval(time : ::Time)
-    t = uninitialized LibC::Timeval
-    t.tv_sec = typeof(t.tv_sec).new(time.to_unix)
-    t.tv_usec = typeof(t.tv_usec).new(time.nanosecond // ::Time::NANOSECONDS_PER_MICROSECOND)
-    t
   end
 
   private def system_truncate(size) : Nil

--- a/src/crystal/system/unix/file.cr
+++ b/src/crystal/system/unix/file.cr
@@ -191,7 +191,7 @@ module Crystal::System::File
     end
   end
 
-  def self.futimens(filename : String, fd : Int, atime : ::Time, mtime : ::Time) : Nil
+  private def system_utime(atime : ::Time, mtime : ::Time, filename : String) : Nil
     ret = {% if LibC.has_method?("futimens") %}
             timespecs = uninitialized LibC::Timespec[2]
             timespecs[0] = to_timespec(atime)

--- a/src/crystal/system/unix/time.cr
+++ b/src/crystal/system/unix/time.cr
@@ -40,6 +40,20 @@ module Crystal::System::Time
     {% end %}
   end
 
+  def self.to_timespec(time : ::Time)
+    t = uninitialized LibC::Timespec
+    t.tv_sec = typeof(t.tv_sec).new(time.to_unix)
+    t.tv_nsec = typeof(t.tv_nsec).new(time.nanosecond)
+    t
+  end
+
+  def self.to_timeval(time : ::Time)
+    t = uninitialized LibC::Timeval
+    t.tv_sec = typeof(t.tv_sec).new(time.to_unix)
+    t.tv_usec = typeof(t.tv_usec).new(time.nanosecond // ::Time::NANOSECONDS_PER_MICROSECOND)
+    t
+  end
+
   # Many systems use /usr/share/zoneinfo, Solaris 2 has
   # /usr/share/lib/zoneinfo, IRIX 6 has /usr/lib/locale/TZ.
   ZONE_SOURCES = {

--- a/src/file.cr
+++ b/src/file.cr
@@ -948,7 +948,7 @@ class File < IO::FileDescriptor
 
   # Sets the access and modification times
   def utime(atime : Time, mtime : Time) : Nil
-    Crystal::System::File.futimens(@path, fd, atime, mtime)
+    system_utime(atime, mtime, @path)
   end
 
   # Attempts to set the access and modification times


### PR DESCRIPTION
Opening the file is still needed in the corresponding class method (`File.utime`).