### PR TITLE
Allow `Dir.delete` to remove read-only directories on Windows

### DIFF
--- a/spec/std/dir_spec.cr
+++ b/spec/std/dir_spec.cr
@@ -180,6 +180,15 @@ describe "Dir" do
         end
       end
     end
+
+    it "deletes a read-only directory" do
+      with_tempfile("delete-readonly-dir") do |path|
+        Dir.mkdir(path)
+        File.chmod(path, 0o000)
+        Dir.delete(path)
+        Dir.exists?(path).should be_false
+      end
+    end
   end
 
   describe "glob" do


### PR DESCRIPTION
Like #13462, but for directories.

Note that [the read-only toggle on the file properties dialog may not be what you think it is](https://support.microsoft.com/en-us/topic/you-cannot-view-or-change-the-read-only-or-the-system-attributes-of-folders-in-windows-server-2003-in-windows-xp-in-windows-vista-or-in-windows-7-55bd5ec5-d19e-6173-0df1-8f5b49247165); instead `attrib /D` should be used to show whether a directory itself has the read-only flag.