### PR TITLE
Do not reopen current file in `File#chmod` on Windows

### DIFF
--- a/spec/std/file_spec.cr
+++ b/spec/std/file_spec.cr
@@ -351,7 +351,7 @@ describe "File" do
   end
 
   describe "chmod" do
-    it "changes file permissions" do
+    it "changes file permissions with class method" do
       path = datapath("chmod.txt")
       begin
         File.write(path, "")
@@ -362,7 +362,7 @@ describe "File" do
       end
     end
 
-    it "changes file permissions with fchmod" do
+    it "changes file permissions with instance method" do
       path = datapath("chmod.txt")
       begin
         File.open(path, "w") do |file|

--- a/src/crystal/system/unix/file.cr
+++ b/src/crystal/system/unix/file.cr
@@ -119,7 +119,7 @@ module Crystal::System::File
     end
   end
 
-  def self.fchmod(path, fd, mode)
+  private def system_chmod(path, mode)
     if LibC.fchmod(fd, mode) == -1
       raise ::File::Error.from_errno("Error changing permissions", file: path)
     end

--- a/src/crystal/system/win32/file.cr
+++ b/src/crystal/system/win32/file.cr
@@ -233,9 +233,26 @@ module Crystal::System::File
     end
   end
 
-  def self.fchmod(path : String, fd : Int, mode : Int32 | ::File::Permissions) : Nil
-    # TODO: use fd instead of path
-    chmod path, mode
+  private def system_chmod(path : String, mode : Int32 | ::File::Permissions) : Nil
+    mode = ::File::Permissions.new(mode) unless mode.is_a? ::File::Permissions
+    handle = windows_handle
+
+    basic_info = uninitialized LibC::FILE_BASIC_INFO
+    if LibC.GetFileInformationByHandleEx(handle, LibC::FILE_INFO_BY_HANDLE_CLASS::FileBasicInfo, pointerof(basic_info), sizeof(typeof(basic_info))) == 0
+      raise ::File::Error.from_winerror("Error changing permissions", file: path)
+    end
+
+    # Only the owner writable bit is used, since windows only supports
+    # the read only attribute.
+    if mode.owner_write?
+      basic_info.fileAttributes &= ~LibC::FILE_ATTRIBUTE_READONLY
+    else
+      basic_info.fileAttributes |= LibC::FILE_ATTRIBUTE_READONLY
+    end
+
+    if LibC.SetFileInformationByHandle(handle, LibC::FILE_INFO_BY_HANDLE_CLASS::FileBasicInfo, pointerof(basic_info), sizeof(typeof(basic_info))) == 0
+      raise ::File::Error.from_winerror("Error changing permissions", file: path)
+    end
   end
 
   def self.delete(path : String, *, raise_on_missing : Bool) : Bool

--- a/src/file.cr
+++ b/src/file.cr
@@ -943,7 +943,7 @@ class File < IO::FileDescriptor
   # file.info.permissions.value # => 0o700
   # ```
   def chmod(permissions : Int | Permissions) : Nil
-    Crystal::System::File.fchmod(@path, fd, permissions)
+    system_chmod(@path, permissions)
   end
 
   # Sets the access and modification times

--- a/src/lib_c/x86_64-windows-msvc/c/fileapi.cr
+++ b/src/lib_c/x86_64-windows-msvc/c/fileapi.cr
@@ -111,4 +111,5 @@ lib LibC
   ) : BOOL
   fun SetFileTime(hFile : HANDLE, lpCreationTime : FILETIME*,
                   lpLastAccessTime : FILETIME*, lpLastWriteTime : FILETIME*) : BOOL
+  fun SetFileInformationByHandle(hFile : HANDLE, fileInformationClass : FILE_INFO_BY_HANDLE_CLASS, lpFileInformation : Void*, dwBufferSize : DWORD) : BOOL
 end

--- a/src/lib_c/x86_64-windows-msvc/c/minwinbase.cr
+++ b/src/lib_c/x86_64-windows-msvc/c/minwinbase.cr
@@ -45,6 +45,10 @@ lib LibC
     GetFileExMaxInfoLevel
   end
 
+  enum FILE_INFO_BY_HANDLE_CLASS
+    FileBasicInfo = 0
+  end
+
   LOCKFILE_FAIL_IMMEDIATELY = DWORD.new(0x00000001)
   LOCKFILE_EXCLUSIVE_LOCK   = DWORD.new(0x00000002)
 

--- a/src/lib_c/x86_64-windows-msvc/c/winbase.cr
+++ b/src/lib_c/x86_64-windows-msvc/c/winbase.cr
@@ -57,4 +57,14 @@ lib LibC
   fun MoveFileExW(lpExistingFileName : LPWSTR, lpNewFileName : LPWSTR, dwFlags : DWORD) : BOOL
 
   fun GetBinaryTypeW(lpApplicationName : LPWSTR, lpBinaryType : DWORD*) : BOOL
+
+  struct FILE_BASIC_INFO
+    creationTime : LARGE_INTEGER
+    lastAccessTime : LARGE_INTEGER
+    lastWriteTime : LARGE_INTEGER
+    changeTime : LARGE_INTEGER
+    fileAttributes : DWORD
+  end
+
+  fun GetFileInformationByHandleEx(hFile : HANDLE, fileInformationClass : FILE_INFO_BY_HANDLE_CLASS, lpFileInformation : Void*, dwBufferSize : DWORD) : BOOL
 end


### PR DESCRIPTION
Similar to #13625, but for `File#chmod` instead.