### PR TITLE
Use current directory's root for `Dir.glob("/...")` on Windows

### DIFF
--- a/spec/std/dir_spec.cr
+++ b/spec/std/dir_spec.cr
@@ -419,6 +419,7 @@ describe "Dir" do
     it "root pattern" do
       {% if flag?(:windows) %}
         Dir["C:/"].should eq ["C:\\"]
+        Dir["/"].should eq [Path[Dir.current].anchor.not_nil!.to_s]
       {% else %}
         Dir["/"].should eq ["/"]
       {% end %}

--- a/src/dir/glob.cr
+++ b/src/dir/glob.cr
@@ -375,12 +375,7 @@ class Dir
     end
 
     private def self.root
-      # TODO: better implementation for windows?
-      {% if flag?(:windows) %}
-        "C:\\"
-      {% else %}
-        File::SEPARATOR_STRING
-      {% end %}
+      Path[Dir.current].anchor.not_nil!.to_s
     end
 
     private def self.dir?(path, follow_symlinks)


### PR DESCRIPTION
`Dir["/*"]` will list the files immediately under C:\ if the current directory's drive is C:\, or D:\ if the drive is D:\, etc.