### PR TITLE
Add `Set#rehash`

### DIFF
--- a/spec/std/set_spec.cr
+++ b/spec/std/set_spec.cr
@@ -421,4 +421,18 @@ describe "Set" do
       set.clone.compare_by_identity?.should be_true
     end
   end
+
+  describe "#rehash" do
+    it "rehashes" do
+      a = [1]
+      s = Set{a}
+      (10..100).each do |i|
+        s << [i]
+      end
+      a << 2
+      s.should_not contain(a)
+      s.rehash
+      s.should contain(a)
+    end
+  end
 end

--- a/src/hash.cr
+++ b/src/hash.cr
@@ -1976,11 +1976,11 @@ class Hash(K, V)
     self
   end
 
-  # Rebuilds the hash table based on the current value of each key.
+  # Rebuilds the hash table based on the current keys.
   #
-  # When using mutable data types as keys, changing the value of a key after
-  # it was inserted into the `Hash` may lead to undefined behaviour.
-  # This method re-indexes the hash using the current key values.
+  # When using mutable data types as keys, modifying a key after it was inserted
+  # into the `Hash` may lead to undefined behaviour. This method re-indexes the
+  # hash using the current keys.
   def rehash : Nil
     do_compaction(rehash: true)
   end

--- a/src/set.cr
+++ b/src/set.cr
@@ -479,6 +479,15 @@ struct Set(T)
   def same?(other : Set) : Bool
     @hash.same?(other.@hash)
   end
+
+  # Rebuilds the set based on the current elements.
+  #
+  # When using mutable data types as elements, modifying an elements after it
+  # was inserted into the `Set` may lead to undefined behaviour. This method
+  # re-indexes the set using the current elements.
+  def rehash : Nil
+    @hash.rehash
+  end
 end
 
 module Enumerable


### PR DESCRIPTION
This method is necessary for `Set`s containing mutable elements to work correctly. Previously this must be done by accessing the underlying `Hash` directly, i.e. `set.@hash.rehash`.