### PR TITLE
Use `IO::DEFAULT_BUFFER_SIZE` in `Digest#update`

### DIFF
--- a/src/digest/digest.cr
+++ b/src/digest/digest.cr
@@ -219,7 +219,7 @@ abstract class Digest
 
   # Reads the io's data and updates the digest with it.
   def update(io : IO) : self
-    buffer = uninitialized UInt8[4096]
+    buffer = uninitialized UInt8[IO::DEFAULT_BUFFER_SIZE]
     while (read_bytes = io.read(buffer.to_slice)) > 0
       self << buffer.to_slice[0, read_bytes]
     end


### PR DESCRIPTION
Is about 20% faster when the `io` doesn't have read buffering enabled.