### PR TITLE
termios: add missing `VTIME` macros on Darwin

### DIFF
--- a/src/lib_c/aarch64-darwin/c/termios.cr
+++ b/src/lib_c/aarch64-darwin/c/termios.cr
@@ -11,6 +11,7 @@ lib LibC
   VSTART    =         12
   VSTOP     =         13
   VSUSP     =         10
+  VTIME     =         17
   BRKINT    = 0x00000002
   ICRNL     = 0x00000100
   IGNBRK    = 0x00000001

--- a/src/lib_c/x86_64-darwin/c/termios.cr
+++ b/src/lib_c/x86_64-darwin/c/termios.cr
@@ -11,6 +11,7 @@ lib LibC
   VSTART    =         12
   VSTOP     =         13
   VSUSP     =         10
+  VTIME     =         17
   BRKINT    = 0x00000002
   ICRNL     = 0x00000100
   IGNBRK    = 0x00000001


### PR DESCRIPTION
The `VMIN` macros are already defined, but the `VTIME` macros are not. The `VTIME` macro allow you to specify the `read` timeout before `read` can return. It complements `VMIN`.

Edit: Just got informed that the `LibC` provided by Crystal is for internal purposes and only exposes whatever is needed for the standard library. Closing. 🙂 