### PR TITLE
Make DLL delay-load opt-in

### DIFF
--- a/src/compiler/crystal/compiler.cr
+++ b/src/compiler/crystal/compiler.cr
@@ -383,7 +383,7 @@ module Crystal
 
             link_args = search_result.remaining_args.concat(search_result.library_paths).map { |arg| Process.quote_windows(arg) }
 
-            if !program.has_flag?("no_win32_delay_load")
+            if program.has_flag?("preview_win32_delay_load")
               # "LINK : warning LNK4199: /DELAYLOAD:foo.dll ignored; no imports found from foo.dll"
               # it is harmless to skip this error because not all import libraries are always used, much
               # less the individual DLLs they refer to


### PR DESCRIPTION
This is a temporary workaround for #13644 for Crystal 1.9 until we could figure out whether the linker error can be fixed.