### PR TITLE
Change spec runner to exit with failure for `focus: true`

### DIFF
--- a/src/spec/dsl.cr
+++ b/src/spec/dsl.cr
@@ -251,7 +251,7 @@ module Spec
   def self.finish_run
     elapsed_time = Time.monotonic - @@start_time.not_nil!
     root_context.finish(elapsed_time, @@aborted)
-    exit 1 if !root_context.succeeded || @@aborted
+    exit 1 if !root_context.succeeded || @@aborted || (focus? && ENV["SPEC_FOCUS_NO_FAIL"]? != "1")
   end
 
   # :nodoc:


### PR DESCRIPTION
This changes the behaviour of the spec runner: In focus mode, the exit code of successful runs will be overriden to `1` to prevent CI from silently running on a subset of tests due to an accidentally commited `focus: true`.

`focus: true` is typically used in interactive mode where the print output is most important for the user to understand if the spec run was successful. The failure status code should not have any effect in this use case.

The old behiavour can be regained by setting the environment variable `SPEC_FOCUS_NO_FAIL=1`. Then the exit code will be success (`0`) if all focused specs succeed.

Resolves #10989