### PR TITLE
Refactor `LLVM.default_target_triple` to avoid regex

### DIFF
--- a/spec/std/llvm/llvm_spec.cr
+++ b/spec/std/llvm/llvm_spec.cr
@@ -28,7 +28,7 @@ describe LLVM do
       triple.should match(/-dragonfly/)
     {% elsif flag?(:netbsd) %}
       triple.should match(/-netbsd/)
-    {% elsif flag?(:was) %}
+    {% elsif flag?(:wasi) %}
       triple.should match(/-wasi/)
     {% else %}
       pending! "Unknown operating system"

--- a/spec/std/llvm/llvm_spec.cr
+++ b/spec/std/llvm/llvm_spec.cr
@@ -17,7 +17,7 @@ describe LLVM do
     {% if flag?(:darwin) %}
       triple.should match(/-apple-macosx$/)
     {% elsif flag?(:linux) %}
-      triple.should match(/-linux-/)
+      triple.should match(/-linux/)
     {% elsif flag?(:windows) %}
       triple.should match(/-windows-/)
     {% elsif flag?(:freebsd) %}

--- a/spec/std/llvm/llvm_spec.cr
+++ b/spec/std/llvm/llvm_spec.cr
@@ -11,4 +11,27 @@ describe LLVM do
       LLVM.normalize_triple("x86_64-linux-gnu").should eq("x86_64-unknown-linux-gnu")
     end
   end
+
+  it ".default_target_triple" do
+    triple = LLVM.default_target_triple
+    {% if flag?(:darwin) %}
+      triple.should match(/-apple-macosx$/)
+    {% elsif flag?(:linux) %}
+      triple.should match(/-linux-/)
+    {% elsif flag?(:windows) %}
+      triple.should match(/-windows-/)
+    {% elsif flag?(:freebsd) %}
+      triple.should match(/-freebsd/)
+    {% elsif flag?(:openbsd) %}
+      triple.should match(/-openbsd/)
+    {% elsif flag?(:dragonfly) %}
+      triple.should match(/-dragonfly/)
+    {% elsif flag?(:netbsd) %}
+      triple.should match(/-netbsd/)
+    {% elsif flag?(:was) %}
+      triple.should match(/-wasi/)
+    {% else %}
+      pending! "Unknown operating system"
+    {% end %}
+  end
 end

--- a/spec/std/llvm/llvm_spec.cr
+++ b/spec/std/llvm/llvm_spec.cr
@@ -16,6 +16,8 @@ describe LLVM do
     triple = LLVM.default_target_triple
     {% if flag?(:darwin) %}
       triple.should match(/-apple-macosx$/)
+    {% elsif flag?(:android) %}
+      triple.should match(/-android$/)
     {% elsif flag?(:linux) %}
       triple.should match(/-linux/)
     {% elsif flag?(:windows) %}

--- a/src/llvm.cr
+++ b/src/llvm.cr
@@ -88,14 +88,14 @@ module LLVM
 
   def self.default_target_triple : String
     chars = LibLLVM.get_default_target_triple
-    triple = string_and_dispose(chars)
-    if triple =~ /x86_64-apple-macosx|x86_64-apple-darwin/
+    case triple = string_and_dispose(chars)
+    when .starts_with?("x86_64-apple-macosx"), .starts_with?("x86_64-apple-darwin")
       # normalize on `macosx` and remove minimum deployment target version
       "x86_64-apple-macosx"
-    elsif triple =~ /aarch64-apple-macosx|aarch64-apple-darwin/
+    when .starts_with?("aarch64-apple-macosx"), .starts_with?("aarch64-apple-darwin")
       # normalize on `macosx` and remove minimum deployment target version
       "aarch64-apple-macosx"
-    elsif triple =~ /aarch64-unknown-linux-android/
+    when .starts_with?("aarch64-unknown-linux-android")
       # remove API version
       "aarch64-unknown-linux-android"
     else


### PR DESCRIPTION
There's no need to use regex for matching plain strings in `LLVM.default_target_triple`.
I replaced it with `String#starts_with?`. The functional equivalent would've been `#includes?` but as far as I am aware, the target triple always starts with the arch so this there should never be anything before these search strings.