### PR TITLE
[CI] Trigger windows release jobs on tag

### DIFF
--- a/.github/workflows/win.yml
+++ b/.github/workflows/win.yml
@@ -252,14 +252,14 @@ jobs:
         run: make -f Makefile.win samples
 
   x86_64-windows-release:
-    if: github.repository_owner == 'crystal-lang' && (startsWith(github.ref, 'refs/heads/release/') || startsWith(github.ref, 'refs/heads/ci/'))
+    if: github.repository_owner == 'crystal-lang' && (startsWith(github.ref, 'refs/tags/') || startsWith(github.ref, 'refs/heads/ci/'))
     needs: [x86_64-windows-libs, x86_64-windows-dlls, x86_64-windows-llvm]
     uses: ./.github/workflows/win_build_portable.yml
     with:
       release: true
 
   x86_64-windows-installer:
-    if: github.repository_owner == 'crystal-lang' && (startsWith(github.ref, 'refs/heads/release/') || startsWith(github.ref, 'refs/heads/ci/'))
+    if: github.repository_owner == 'crystal-lang' && (startsWith(github.ref, 'refs/tags/') || startsWith(github.ref, 'refs/heads/ci/'))
     runs-on: windows-2022
     needs: [x86_64-windows-release]
     steps:


### PR DESCRIPTION
I don't think there's much reason to trigger these release builds on a push to a `release/` branch. There can be intermediary commits on a release branch (just like on master) that should not trigger a release build.
But we should have release builds on tags. 

The ability to trigger a maintenance release on a `ci/*` branch makes sense.