### PR TITLE
No default cipher list for openssl client sockets

### DIFF
--- a/src/openssl/ssl/context.cr
+++ b/src/openssl/ssl/context.cr
@@ -40,8 +40,6 @@ abstract class OpenSSL::SSL::Context
     # context = OpenSSL::SSL::Context::Client.new
     # context.add_options(OpenSSL::SSL::Options::NO_SSL_V2 | OpenSSL::SSL::Options::NO_SSL_V3)
     # ```
-    #
-    # It uses `CIPHERS_OLD` compatibility level by default.
     def initialize(method : LibSSL::SSLMethod = Context.default_method)
       super(method)
 

--- a/src/openssl/ssl/context.cr
+++ b/src/openssl/ssl/context.cr
@@ -49,8 +49,6 @@ abstract class OpenSSL::SSL::Context
       {% if LibSSL.has_method?(:x509_verify_param_lookup) %}
         self.default_verify_param = "ssl_server"
       {% end %}
-
-      self.ciphers = CIPHERS_OLD
     end
 
     # Returns a new TLS client context with only the given method set.


### PR DESCRIPTION
It should be up to the OS to set the default ciphers, eg. if a cipher
suddenly is deemed insecure or there's a reason to have another cipher
order, such as ChaCha over any AES cipher because of lack of hardware
support.

Currently Crystal will expose up-to-date OS to security considerations
because of hard coded cipher lists, that might not be so up to date,
unless the application is recompiled with a modern Crystal version.