### PR TITLE
Allow OpenSSL clients to choose cipher

### DIFF
--- a/spec/std/openssl/ssl/context_spec.cr
+++ b/spec/std/openssl/ssl/context_spec.cr
@@ -32,7 +32,6 @@ describe OpenSSL::SSL::Context do
     (context.options & OpenSSL::SSL::Options::NO_SESSION_RESUMPTION_ON_RENEGOTIATION).should eq(OpenSSL::SSL::Options::NO_SESSION_RESUMPTION_ON_RENEGOTIATION)
     (context.options & OpenSSL::SSL::Options::SINGLE_ECDH_USE).should eq(OpenSSL::SSL::Options::SINGLE_ECDH_USE)
     (context.options & OpenSSL::SSL::Options::SINGLE_DH_USE).should eq(OpenSSL::SSL::Options::SINGLE_DH_USE)
-    (context.options & OpenSSL::SSL::Options::CIPHER_SERVER_PREFERENCE).should eq(OpenSSL::SSL::Options::CIPHER_SERVER_PREFERENCE)
     {% if compare_versions(LibSSL::OPENSSL_VERSION, "1.1.0") >= 0 %}
       (context.options & OpenSSL::SSL::Options::NO_RENEGOTIATION).should eq(OpenSSL::SSL::Options::NO_RENEGOTIATION)
     {% end %}

--- a/src/openssl/ssl/context.cr
+++ b/src/openssl/ssl/context.cr
@@ -133,7 +133,6 @@ abstract class OpenSSL::SSL::Context
     def initialize(method : LibSSL::SSLMethod = Context.default_method)
       super(method)
 
-      add_options(OpenSSL::SSL::Options::CIPHER_SERVER_PREFERENCE)
       {% if LibSSL.has_method?(:x509_verify_param_lookup) %}
         self.default_verify_param = "ssl_client"
       {% end %}


### PR DESCRIPTION
As all intermediate ciphers are secure.
Recommended behavior according to
https://wiki.mozilla.org/Security/Server_Side_TLS