### PR TITLE
Update Int128/UInt128 documentation to use literals

### DIFF
--- a/src/int.cr
+++ b/src/int.cr
@@ -1299,9 +1299,8 @@ struct Int64
 end
 
 struct Int128
-  # TODO: eventually update to literals once UInt128 bit support is finished
-  MIN = new(1) << 127
-  MAX = ~MIN
+  MIN = -170141183460469231731687303715884105728_i128
+  MAX =  170141183460469231731687303715884105727_i128
 
   # Returns an `Int128` by invoking `to_i128` on *value*.
   # See `String#to_i` for more details.
@@ -1329,8 +1328,7 @@ struct Int128
   Number.expand_div [Float64], Float64
 
   def -
-    # TODO: use 0_i128 - self
-    Int128.new(0) - self
+    0_i128 - self
   end
 
   # :nodoc:
@@ -1867,9 +1865,8 @@ struct UInt64
 end
 
 struct UInt128
-  # TODO: eventually update to literals once UInt128 bit support is finished
-  MIN = new 0
-  MAX = ~MIN
+  MIN =                                       0_u128
+  MAX = 340282366920938463463374607431768211455_u128
 
   # Returns an `UInt128` by invoking `to_u128` on *value*.
   # See `String#to_i` for more details.
@@ -1897,8 +1894,7 @@ struct UInt128
   Number.expand_div [Float64], Float64
 
   def &-
-    # TODO: use 0_u128 &- self
-    UInt128.new(0) &- self
+    0_u128 &- self
   end
 
   def abs


### PR DESCRIPTION
#13671 

Use literals for 128 bit integers (signed + unsigned) as per TODO comments.