### PR TITLE
infra(make): Add `generate_data` target for running generator scripts

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,6 +18,8 @@ all:
 ##   $ make std_spec
 ## Run compiler tests
 ##   $ make compiler_spec
+## Run generators (Unicode, SSL config, ...)
+##   $ make -B generate_data
 
 CRYSTAL ?= crystal ## which previous crystal compiler use
 LLVM_CONFIG ?=     ## llvm-config command path to use
@@ -136,6 +138,28 @@ llvm_ext: $(LLVM_EXT_OBJ)
 .PHONY: format
 format: ## Format sources
 	./bin/crystal tool format$(if $(check), --check) src spec samples scripts
+
+generate_data: ## Run generator scripts for Unicode, SSL config, ... (usually with `-B`/`--always-make` flag)
+
+generate_data: spec/std/string/graphemes_break_spec.cr
+spec/std/string/graphemes_break_spec.cr: scripts/generate_grapheme_break_specs.cr
+	$(CRYSTAL) run $<
+
+generate_data: src/string/grapheme/properties.cr
+src/string/grapheme/properties.cr: scripts/generate_grapheme_properties.cr
+	$(CRYSTAL) run $<
+
+generate_data: src/openssl/ssl/defaults.cr
+src/openssl/ssl/defaults.cr: scripts/generate_ssl_server_defaults.cr
+	$(CRYSTAL) run $<
+
+generate_data: src/unicode/data.cr
+src/unicode/data.cr: scripts/generate_unicode_data.cr
+	$(CRYSTAL) run $<
+
+generate_data: src/crystal/system/win32/zone_names.cr
+src/crystal/system/win32/zone_names.cr: scripts/generate_windows_zone_names.cr
+	$(CRYSTAL) run $<
 
 .PHONY: install
 install: $(O)/crystal man/crystal.1.gz ## Install the compiler at DESTDIR

--- a/Makefile.win
+++ b/Makefile.win
@@ -143,24 +143,24 @@ format: ## Format sources
 
 generate_data: ## Run generator scripts for Unicode, SSL config, ... (usually with `-B`/`--always-make` flag)
 
-generate_data: spec/std/string/graphemes_break_spec.cr
-spec/std/string/graphemes_break_spec.cr: scripts/generate_grapheme_break_specs.cr
+generate_data: spec\std\string\graphemes_break_spec.cr
+spec\std\string\graphemes_break_spec.cr: scripts\generate_grapheme_break_specs.cr
 	$(CRYSTAL) run $<
 
-generate_data: src/string/grapheme/properties.cr
-src/string/grapheme/properties.cr: scripts/generate_grapheme_properties.cr
+generate_data: src\string\grapheme\properties.cr
+src\string\grapheme\properties.cr: scripts\generate_grapheme_properties.cr
 	$(CRYSTAL) run $<
 
-generate_data: src/openssl/ssl/defaults.cr
-src/openssl/ssl/defaults.cr: scripts/generate_ssl_server_defaults.cr
+generate_data: src\openssl\ssl\defaults.cr
+src\openssl\ssl\defaults.cr: scripts\generate_ssl_server_defaults.cr
 	$(CRYSTAL) run $<
 
-generate_data: src/unicode/data.cr
-src/unicode/data.cr: scripts/generate_unicode_data.cr
+generate_data: src\unicode\data.cr
+src\unicode\data.cr: scripts\generate_unicode_data.cr
 	$(CRYSTAL) run $<
 
-generate_data: src/crystal/system/win32/zone_names.cr
-src/crystal/system/win32/zone_names.cr: scripts/generate_windows_zone_names.cr
+generate_data: src\crystal\system\win32\zone_names.cr
+src\crystal\system\win32\zone_names.cr: scripts\generate_windows_zone_names.cr
 	$(CRYSTAL) run $<
 
 .PHONY: install

--- a/Makefile.win
+++ b/Makefile.win
@@ -18,6 +18,8 @@ all:
 ##   $ make -f Makefile.win std_spec
 ## Run compiler tests
 ##   $ make -f Makefile.win compiler_spec
+## Run generators (Unicode, SSL config, ...)
+##   $ make -B generate_data
 
 CRYSTAL ?= crystal ## which previous crystal compiler use
 LLVM_CONFIG ?=     ## llvm-config command path to use
@@ -138,6 +140,28 @@ llvm_ext: $(LLVM_EXT_OBJ)
 .PHONY: format
 format: ## Format sources
 	.\bin\crystal tool format$(if $(check), --check) src spec samples scripts
+
+generate_data: ## Run generator scripts for Unicode, SSL config, ... (usually with `-B`/`--always-make` flag)
+
+generate_data: spec/std/string/graphemes_break_spec.cr
+spec/std/string/graphemes_break_spec.cr: scripts/generate_grapheme_break_specs.cr
+	$(CRYSTAL) run $<
+
+generate_data: src/string/grapheme/properties.cr
+src/string/grapheme/properties.cr: scripts/generate_grapheme_properties.cr
+	$(CRYSTAL) run $<
+
+generate_data: src/openssl/ssl/defaults.cr
+src/openssl/ssl/defaults.cr: scripts/generate_ssl_server_defaults.cr
+	$(CRYSTAL) run $<
+
+generate_data: src/unicode/data.cr
+src/unicode/data.cr: scripts/generate_unicode_data.cr
+	$(CRYSTAL) run $<
+
+generate_data: src/crystal/system/win32/zone_names.cr
+src/crystal/system/win32/zone_names.cr: scripts/generate_windows_zone_names.cr
+	$(CRYSTAL) run $<
 
 .PHONY: install
 install: $(O)\crystal.exe ## Install the compiler at prefix


### PR DESCRIPTION
This target makes it easy to run all generator scripts at once. I want to add this as a check to the release process.