### PR TITLE
Do not add trailing `+` in `TypeNode#id` for virtual types

### DIFF
--- a/spec/compiler/macro/macro_methods_spec.cr
+++ b/spec/compiler/macro/macro_methods_spec.cr
@@ -1694,6 +1694,16 @@ module Crystal
         end
       end
 
+      describe "#id" do
+        it "does not include trailing + for virtual type" do
+          assert_macro("{{klass.id}}", "Foo") do |program|
+            foo = NonGenericClassType.new(program, program, "Foo", program.reference)
+            bar = NonGenericClassType.new(program, program, "Bar", foo)
+            {klass: TypeNode.new(foo.virtual_type)}
+          end
+        end
+      end
+
       describe "#warning" do
         it "emits a warning at a specific node" do
           assert_warning <<-CRYSTAL, "Oh noes"

--- a/src/compiler/crystal/semantic/ast.cr
+++ b/src/compiler/crystal/semantic/ast.cr
@@ -87,7 +87,7 @@ module Crystal
     end
 
     def to_macro_id
-      @type.to_s
+      @type.not_nil!.devirtualize.to_s
     end
 
     def clone_without_location


### PR DESCRIPTION
Fixes https://forum.crystal-lang.org/t/how-to-make-union-types-macro-work-also-on-base-classes/5875.