### PR TITLE
Compiler: missing normalization of macro expressions (and others)

### DIFF
--- a/spec/compiler/codegen/macro_spec.cr
+++ b/spec/compiler/codegen/macro_spec.cr
@@ -1879,4 +1879,20 @@ describe "Code gen: macro" do
       Foo.new.bar
       )).to_b.should eq(true)
   end
+
+  it "does block unpacking inside macro expression (##13707)" do
+    run(%(
+      {% begin %}
+        {%
+          data = [{1, 2}, {3, 4}]
+          value = 0
+          data.each do |(k, v)|
+            value += k
+            value += v
+          end
+        %}
+        {{ value }}
+      {% end %}
+      )).to_i.should eq(10)
+  end
 end

--- a/src/compiler/crystal/syntax/transformer.cr
+++ b/src/compiler/crystal/syntax/transformer.cr
@@ -559,6 +559,7 @@ module Crystal
     end
 
     def transform(node : MacroExpression)
+      node.exp = node.exp.transform(self)
       node
     end
 
@@ -571,10 +572,15 @@ module Crystal
     end
 
     def transform(node : MacroIf)
+      node.cond = node.cond.transform(self)
+      node.then = node.then.transform(self)
+      node.else = node.else.transform(self)
       node
     end
 
     def transform(node : MacroFor)
+      node.exp = node.exp.transform(self)
+      node.body = node.body.transform(self)
       node
     end
 


### PR DESCRIPTION
Fixes #13707