### PR TITLE
Do not use nilable `Pointer`s

### DIFF
--- a/src/compiler/crystal/interpreter/interpreter.cr
+++ b/src/compiler/crystal/interpreter/interpreter.cr
@@ -1082,7 +1082,7 @@ class Crystal::Repl::Interpreter
     argv.size + 1
   end
 
-  @argv_unsafe : Pointer(Pointer(UInt8))?
+  @argv_unsafe = Pointer(Pointer(UInt8)).null
 
   private def argv_unsafe
     @argv_unsafe ||= begin

--- a/src/io/buffered.cr
+++ b/src/io/buffered.cr
@@ -6,6 +6,8 @@
 # Additionally, several methods, like `#gets`, are implemented in a more
 # efficient way.
 module IO::Buffered
+  @in_buffer = Pointer(UInt8).null
+  @out_buffer = Pointer(UInt8).null
   @in_buffer_rem = Bytes.empty
   @out_count = 0
   @sync = false

--- a/src/openssl/ssl/context.cr
+++ b/src/openssl/ssl/context.cr
@@ -452,7 +452,7 @@ abstract class OpenSSL::SSL::Context
     LibSSL.ssl_ctx_set_verify(@handle, mode, nil)
   end
 
-  @alpn_protocol : Pointer(Void)?
+  @alpn_protocol = Pointer(Void).null
 
   # Specifies an ALPN protocol to negotiate with the remote endpoint. This is
   # required to negotiate HTTP/2 with browsers, since browser vendors decided

--- a/src/proc.cr
+++ b/src/proc.cr
@@ -69,7 +69,7 @@
 # ```
 # module Ticker
 #   # The callback for the user doesn't have a Void*
-#   @@box : Pointer(Void)?
+#   @@box = Pointer(Void).null
 #
 #   def self.on_tick(&callback : Int32 ->)
 #     # Since Proc is a {Void*, Void*}, we can't turn that into a Void*, so we

--- a/src/string/formatter.cr
+++ b/src/string/formatter.cr
@@ -15,8 +15,8 @@ struct String::Formatter(A)
     Named
   end
 
-  @format_buf : Pointer(UInt8)?
-  @temp_buf : Pointer(UInt8)?
+  @format_buf = Pointer(UInt8).null
+  @temp_buf = Pointer(UInt8).null
   @arg_mode : Mode = :none
 
   def initialize(string, @args : A, @io : IO)


### PR DESCRIPTION
These uses do not distinguish between a null pointer and `nil`, and dropping the `Nil` reduces the space used (every `IO::Buffered` now occupies 16 less bytes on 64-bit systems).

The same effect could also be achieved by supporting nilable pointers at the ABI level, similar to how `Proc?` has the same binary representation as `Proc`. That approach is not without its own problems:

```crystal
proc = Proc(Nil).new(Pointer(Void).null, Pointer(Void).null)
proc                  # => #<Proc(Nil):0x0>
!!proc                # => true
proc.as(Proc(Nil)?)   # => nil
!!proc.as(Proc(Nil)?) # => false
```