### PR TITLE
Hierarchy tool: Fix byte sizes for `Proc`s inside extern structs

### DIFF
--- a/spec/compiler/crystal/tools/hierarchy_spec.cr
+++ b/spec/compiler/crystal/tools/hierarchy_spec.cr
@@ -41,6 +41,36 @@ describe Crystal::TextHierarchyPrinter do
                    @x : Bool (1 bytes)\n
     EOS
   end
+
+  it "shows correct size for Proc inside extern struct" do
+    program = semantic(<<-CRYSTAL).program
+      @[Extern]
+      struct Foo
+        @x = uninitialized ->
+      end
+
+      lib Bar
+        struct Foo
+          x : Int32 -> Int32
+        end
+      end
+      CRYSTAL
+
+    output = String.build { |io| Crystal.print_hierarchy(program, io, "Foo", "text") }
+    output.should eq(<<-EOS)
+    - class Object (4 bytes)
+      |
+      +- struct Value (0 bytes)
+         |
+         +- struct Struct (0 bytes)
+            |
+            +- struct Bar::Foo (8 bytes)
+            |      @x : Proc(Int32, Int32) (8 bytes)
+            |
+            +- struct Foo (8 bytes)
+                   @x : Proc(Nil) (8 bytes)\n
+    EOS
+  end
 end
 
 describe Crystal::JSONHierarchyPrinter do


### PR DESCRIPTION
Extern structs store `Proc`s without the closure pointer, so they should use `llvm_embedded_c_type` rather than `llvm_embedded_type` for the correct byte sizes.

The total sizes of the extern structs themselves are already correct and unaffected by this PR.