### PR TITLE
Support generic types in `crystal tool hierarchy`

### DIFF
--- a/spec/compiler/crystal/tools/hierarchy_spec.cr
+++ b/spec/compiler/crystal/tools/hierarchy_spec.cr
@@ -1,87 +1,90 @@
 require "../../../spec_helper"
 
+private def assert_text_hierarchy(source, filter, expected, *, file = __FILE__, line = __LINE__)
+  program = semantic(source).program
+  output = String.build { |io| Crystal.print_hierarchy(program, io, filter, "text") }
+  output.should eq(expected), file: file, line: line
+end
+
+private def assert_json_hierarchy(source, filter, expected, *, file = __FILE__, line = __LINE__)
+  program = semantic(source).program
+  output = String.build { |io| Crystal.print_hierarchy(program, io, filter, "json") }
+  JSON.parse(output).should eq(JSON.parse(expected)), file: file, line: line
+end
+
 describe Crystal::TextHierarchyPrinter do
   it "works" do
-    program = semantic(<<-CRYSTAL).program
+    assert_text_hierarchy <<-CRYSTAL, "ar$", <<-EOS
       class Foo
       end
 
       class Bar < Foo
       end
       CRYSTAL
-
-    output = String.build { |io| Crystal.print_hierarchy(program, io, "ar$", "text") }
-    output.should eq(<<-EOS)
-    - class Object (4 bytes)
-      |
-      +- class Reference (4 bytes)
-         |
-         +- class Foo (4 bytes)
-            |
-            +- class Bar (4 bytes)\n
-    EOS
+      - class Object (4 bytes)
+        |
+        +- class Reference (4 bytes)
+           |
+           +- class Foo (4 bytes)
+              |
+              +- class Bar (4 bytes)\n
+      EOS
   end
 
   it "shows correct size for Bool member" do
-    program = semantic(<<-CRYSTAL).program
+    assert_text_hierarchy <<-CRYSTAL, "Foo", <<-EOS
       struct Foo
         @x = true
       end
       CRYSTAL
-
-    output = String.build { |io| Crystal.print_hierarchy(program, io, "Foo", "text") }
-    output.should eq(<<-EOS)
-    - class Object (4 bytes)
-      |
-      +- struct Value (0 bytes)
-         |
-         +- struct Struct (0 bytes)
-            |
-            +- struct Foo (1 bytes)
-                   @x : Bool (1 bytes)\n
-    EOS
+      - class Object (4 bytes)
+        |
+        +- struct Value (0 bytes)
+           |
+           +- struct Struct (0 bytes)
+              |
+              +- struct Foo (1 bytes)
+                     @x : Bool (1 bytes)\n
+      EOS
   end
 end
 
 describe Crystal::JSONHierarchyPrinter do
   it "works" do
-    program = semantic(<<-CRYSTAL).program
+    assert_json_hierarchy <<-CRYSTAL, "ar$", <<-JSON
       class Foo
       end
 
       class Bar < Foo
       end
       CRYSTAL
-
-    output = String.build { |io| Crystal.print_hierarchy(program, io, "ar$", "json") }
-    JSON.parse(output).should eq(JSON.parse(<<-EOS))
-    {
-      "name": "Object",
-      "kind": "class",
-      "size_in_bytes": 4,
-      "sub_types": [
-        {
-          "name": "Reference",
-          "kind": "class",
-          "size_in_bytes": 4,
-          "sub_types": [
-            {
-              "name": "Foo",
-              "kind": "class",
-              "size_in_bytes": 4,
-              "sub_types": [
-                {
-                  "name": "Bar",
-                  "kind": "class",
-                  "size_in_bytes": 4,
-                  "sub_types": []
-                }
-              ]
-            }
-          ]
-        }
-      ]
-    }
-    EOS
+      {
+        "name": "Object",
+        "kind": "class",
+        "size_in_bytes": 4,
+        "sub_types": [
+          {
+            "name": "Reference",
+            "kind": "class",
+            "size_in_bytes": 4,
+            "sub_types": [
+              {
+                "name": "Foo",
+                "kind": "class",
+                "size_in_bytes": 4,
+                "sub_types": [
+                  {
+                    "name": "Bar",
+                    "kind": "class",
+                    "size_in_bytes": 4,
+                    "sub_types": []
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      }
+      JSON
   end
 end

--- a/src/compiler/crystal/tools/print_hierarchy.cr
+++ b/src/compiler/crystal/tools/print_hierarchy.cr
@@ -103,11 +103,104 @@ module Crystal
     end
 
     def type_size(type)
-      @llvm_typer.size_of(@llvm_typer.llvm_struct_type(type))
+      return nil unless constant_type_size?(type)
+
+      if type.is_a?(GenericClassType)
+        # obtain a "generic instance" where all arguments are simply the unbound
+        # parameters themselves; if we are here, `LLVMTyper` should never be
+        # requesting the size of a `TypeParameter`
+        type_vars = type.type_vars.map { |type_var| type.type_parameter(type_var).as(TypeVar) }
+        type = type.instantiate(type_vars)
+      end
+
+      llvm_type =
+        case type
+        when PointerInstanceType, ProcInstanceType
+          @llvm_typer.llvm_type(type, wants_size: true)
+        when InstanceVarContainer
+          @llvm_typer.llvm_struct_type(type, wants_size: true)
+        else
+          @llvm_typer.llvm_type(type, wants_size: true)
+        end
+
+      @llvm_typer.size_of(llvm_type)
     end
 
     def ivar_size(ivar)
-      @llvm_typer.size_of(@llvm_typer.llvm_embedded_type(ivar.type))
+      return nil unless constant_ivar_size?(ivar.type)
+      llvm_type = @llvm_typer.llvm_embedded_type(ivar.type, wants_size: true)
+      @llvm_typer.size_of(llvm_type)
+    end
+
+    # Returns `true` if `type`'s size (`sizeof` for values, `instance_sizeof`
+    # for references) is a constant, in particular if it doesn't depend on
+    # `type`'s generic type parameters. `type` is never a generic instance.
+    def constant_type_size?(type)
+      case type
+      when GenericUnionType, StaticArrayType, TupleType, NamedTupleType
+        false
+      when PointerType, ProcType
+        true
+      when GenericClassType
+        type.all_instance_vars.each do |_, ivar|
+          return false unless ivar_type = ivar.type?
+          return false unless constant_ivar_size?(ivar_type)
+        end
+        true
+      else
+        true
+      end
+    end
+
+    # Returns `true` if `sizeof(type)` is a constant, in particular if it
+    # doesn't depend on `type`'s generic type parameters. Unlike
+    # `#constant_type_size?`, here `type` can be a generic instance, but not an
+    # uninstantiated generic.
+    def constant_ivar_size?(type)
+      return true unless type.unbound? || type.is_a?(GenericType)
+
+      case type
+      when GenericType
+        type_vars = type.type_vars.map { |type_var| type.type_parameter(type_var).as(TypeVar) }
+        constant_ivar_size?(type.instantiate(type_vars))
+      when TypeParameter
+        false
+      when MixedUnionType
+        type.union_types.all? { |t| constant_ivar_size?(t) }
+      when StaticArrayInstanceType
+        return false unless constant_ivar_size?(type.element_type)
+        case size_var = type.size
+        when NumberLiteral
+          true
+        when Var
+          return false unless size_var_type = size_var.type?
+          return false unless constant_ivar_size?(size_var_type)
+        else
+          false
+        end
+      when TupleInstanceType
+        type.tuple_types.all? { |t| constant_ivar_size?(t) }
+      when NamedTupleInstanceType
+        type.entries.all? { |entry| constant_ivar_size?(entry.type) }
+      when GenericModuleInstanceType
+        # TODO: verify
+        type.generic_type.each_instantiated_type do |instance|
+          instance.as(GenericModuleInstanceType).raw_including_types.try &.each do |including_type|
+            return false unless constant_ivar_size?(including_type)
+          end
+        end
+        true
+      when InstanceVarContainer
+        if type.struct?
+          type.all_instance_vars.each do |_, ivar|
+            return false unless ivar_type = ivar.type?
+            return false unless constant_ivar_size?(ivar_type)
+          end
+        end
+        true
+      else
+        true
+      end
     end
   end
 
@@ -149,10 +242,9 @@ module Crystal
       @io << "+" unless @indents.empty?
       @io << "- " << (type.struct? ? "struct" : "class") << " " << type
 
-      if (type.is_a?(NonGenericClassType) || type.is_a?(GenericClassInstanceType)) &&
-         !type.is_a?(PointerInstanceType) && !type.is_a?(ProcInstanceType)
+      if type_size = type_size(type)
         with_color.light_gray.surround(@io) do
-          @io << " (" << type_size(type) << " bytes)"
+          @io << " (" << type_size << " bytes)"
         end
       end
       @io << '\n'
@@ -173,35 +265,22 @@ module Crystal
       # Nothing to do
     end
 
-    def print_instance_vars(type : GenericClassType, has_subtypes)
-      instance_vars = type.instance_vars
-      return if instance_vars.empty?
-
-      max_name_size = instance_vars.keys.max_of &.size
-
-      instance_vars.each do |name, var|
-        print_indent
-        @io << (@indents.last ? "|" : " ") << (has_subtypes ? "  .   " : "      ")
-
-        with_color.light_gray.surround(@io) do
-          name.ljust(@io, max_name_size)
-          @io << " : " << var
-        end
-        @io << '\n'
-      end
-    end
-
     def print_instance_vars(type, has_subtypes)
       instance_vars = type.instance_vars
       return if instance_vars.empty?
 
       instance_vars = instance_vars.values
-      typed_instance_vars = instance_vars.select &.type?
+      instance_var_types = {} of MetaTypeVar => {Type, UInt64?}
+      instance_vars.each do |ivar|
+        if type = ivar.type?
+          instance_var_types[ivar] = {type, ivar_size(ivar)}
+        end
+      end
 
       max_name_size = instance_vars.max_of &.name.size
 
-      max_type_size = typed_instance_vars.max_of?(&.type.to_s.size) || 0
-      max_bytes_size = typed_instance_vars.max_of? { |var| ivar_size(var).to_s.size } || 0
+      max_type_size = instance_var_types.max_of? { |_, (type, _)| type.to_s.size } || 0
+      max_bytes_size = instance_var_types.max_of? { |_, (_, size)| size.try(&.to_s.size) || 0 } || 0
 
       instance_vars.each do |ivar|
         print_indent
@@ -210,12 +289,17 @@ module Crystal
         with_color.light_gray.surround(@io) do
           ivar.name.ljust(@io, max_name_size)
           @io << " : "
-          if ivar_type = ivar.type?
-            ivar_type.to_s.ljust(@io, max_type_size)
-            with_color.light_gray.surround(@io) do
-              @io << " ("
-              ivar_size(ivar).to_s.rjust(@io, max_bytes_size)
-              @io << " bytes)"
+          if entry = instance_var_types[ivar]?
+            ivar_type, size = entry
+            if size
+              ivar_type.to_s.ljust(@io, max_type_size)
+              with_color.light_gray.surround(@io) do
+                @io << " ("
+                size.to_s.rjust(@io, max_bytes_size)
+                @io << " bytes)"
+              end
+            else
+              @io << ivar_type
             end
           else
             @io << "MISSING".colorize.red.bright
@@ -284,8 +368,7 @@ module Crystal
       @json.field "name", type.to_s
       @json.field "kind", type.struct? ? "struct" : "class"
 
-      if (type.is_a?(NonGenericClassType) || type.is_a?(GenericClassInstanceType)) &&
-         !type.is_a?(PointerInstanceType) && !type.is_a?(ProcInstanceType)
+      if type_size = type_size(type)
         @json.field "size_in_bytes", type_size(type)
       end
     end
@@ -302,22 +385,6 @@ module Crystal
       # Nothing to do
     end
 
-    def print_instance_vars(type : GenericClassType, has_subtypes)
-      instance_vars = type.instance_vars
-      return if instance_vars.empty?
-
-      @json.field "instance_vars" do
-        @json.array do
-          instance_vars.each do |name, var|
-            @json.object do
-              @json.field "name", name.to_s
-              @json.field "type", var.to_s
-            end
-          end
-        end
-      end
-    end
-
     def print_instance_vars(type, has_subtypes)
       instance_vars = type.instance_vars
       return if instance_vars.empty?
@@ -330,7 +397,9 @@ module Crystal
               @json.object do
                 @json.field "name", instance_var.name.to_s
                 @json.field "type", ivar_type.to_s
-                @json.field "size_in_bytes", ivar_size(instance_var)
+                if ivar_size = ivar_size(instance_var)
+                  @json.field "size_in_bytes", ivar_size
+                end
               end
             end
           end


### PR DESCRIPTION
Right now, the hierarchy tool does not support generic types, in that it simply prints those types' instance variables themselves again instead of their types and sizes:

```
$ bin/crystal tool hierarchy src/prelude.cr -e "^(Array|Slice)$"
- class Object (4 bytes)
  |
  +- class Reference (4 bytes)
  |  |
  |  +- class Array(T)
  |         @size             : @size
  |         @capacity         : @capacity
  |         @offset_to_buffer : @offset_to_buffer
  |         @buffer           : @buffer
  |
  +- struct Value (0 bytes)
     |
     +- struct Struct (0 bytes)
        |
        +- struct Slice(T)
               @size      : @size
               @read_only : @read_only
               @pointer   : @pointer
```

This PR adds support for those members by ensuring that the byte sizes are queried only when they are independent of any unbound type parameters, most notably instances of `Pointer` and `Proc`:

```
class Array(T) (24 bytes)
    @size             : Int32      (4 bytes)
    @capacity         : Int32      (4 bytes)
    @offset_to_buffer : Int32      (4 bytes)
    @buffer           : Pointer(T) (8 bytes)

struct Slice(T) (16 bytes)
    @size      : Int32      (4 bytes)
    @read_only : Bool       (1 bytes)
    @pointer   : Pointer(T) (8 bytes)
```

In this case, all of `Array` and `Slice`'s members have constant sizes, so their total sizes are also shown.

When used as an instance variable, `Array` has a fixed size regardless of its members, because `Array` is a reference:

```
class Indexable::CombinationIterator(A, T) (64 bytes)
    @size    : Int32            (4 bytes)
    @n       : Int32            (4 bytes)
    @copy    : Array(T)         (8 bytes)
    @pool    : Array(T)         (8 bytes)
    @indices : Array(Int32)     (8 bytes)
    @stop    : Bool             (1 bytes)
    @i       : Int32            (4 bytes)
    @first   : Bool             (1 bytes)
    @reuse   : (Array(T) | Nil) (8 bytes)
```

For structs, an example of a constant-size generic type being used generically is `Set`:

```
struct Set(T) (8 bytes)
    @hash : Hash(T, Nil) (8 bytes)

struct Iterator::UniqIterator(I, T, U)
    @iterator : I
    @func     : Proc(T, U) (16 bytes)
    @set      : Set(U)     ( 8 bytes)
```

Here `Iterator::UniqIterator` does not have a constant size because `@iterator`'s size can change depending on `I`.