### PR TITLE
Fix error message when parsing unknown JSON enum value

### DIFF
--- a/spec/std/json/serialization_spec.cr
+++ b/spec/std/json/serialization_spec.cr
@@ -302,6 +302,9 @@ describe "JSON serialization" do
         expect_raises(JSON::ParseException, %(Unknown enum JSONSpecEnum value: "three")) do
           JSONSpecEnum.from_json(%("three"))
         end
+        expect_raises(JSON::ParseException, %(Unknown enum JSONSpecEnum value: "three")) do
+          NamedTuple(foo: JSONSpecEnum).from_json(%({"foo": "three", "other": 1}))
+        end
         expect_raises(JSON::ParseException, %(Expected String but was Int)) do
           JSONSpecEnum.from_json(%(1))
         end

--- a/src/json/from_json.cr
+++ b/src/json/from_json.cr
@@ -318,11 +318,13 @@ def Enum.new(pull : JSON::PullParser)
   {% if @type.annotation(Flags) %}
     value = {{ @type }}::None
     pull.read_array do
-      value |= parse?(pull.read_string) || pull.raise "Unknown enum #{self} value: #{pull.string_value.inspect}"
+      string = pull.read_string
+      value |= parse?(string) || pull.raise "Unknown enum #{self} value: #{string.inspect}"
     end
     value
   {% else %}
-    parse?(pull.read_string) || pull.raise "Unknown enum #{self} value: #{pull.string_value.inspect}"
+    string = pull.read_string
+    parse?(string) || pull.raise "Unknown enum #{self} value: #{string.inspect}"
   {% end %}
 end
 


### PR DESCRIPTION
`#string_value` can be the value of the next token, which results in a confusing error message.

```crystal
require "json"

enum Test
  Valid
  Other
end

struct Foo
  include JSON::Serializable
  @foo : Test
end

text = %({"foo": "value", "things": "Stuff"})

Foo.from_json(text)
```

On `1.9.2` this will raise an unhelpful error:

```
$ crystal run test.cr
Unhandled exception: Unknown enum Test value: "things" at line 1, column 26
  parsing Foo#foo at line 1, column 2 (JSON::SerializableError)
  from /usr/share/crystal/src/json/serialization.cr:182:7 in 'initialize:__pull_for_json_serializable'
```

Note that if it's not part of a larger JSON object, the message will be correct:

```crystal
Test.from_json(%("value") # => Unhandled exception: Unknown enum Test value: "value"
```