### PR TITLE
Fix shard crystal version in `crystal init`

### DIFF
--- a/spec/compiler/crystal/tools/init_spec.cr
+++ b/spec/compiler/crystal/tools/init_spec.cr
@@ -165,7 +165,7 @@ module Crystal
           parsed["version"].should eq("0.1.0")
           parsed["authors"].should eq(["John Smith <john@smith.com>"])
           parsed["license"].should eq("MIT")
-          parsed["crystal"].should eq(Crystal::Config.version)
+          parsed["crystal"].should eq(">= #{Crystal::Config.version}")
           parsed["targets"]?.should be_nil
         end
 

--- a/src/compiler/crystal/tools/init/template/shard.yml.ecr
+++ b/src/compiler/crystal/tools/init/template/shard.yml.ecr
@@ -10,6 +10,6 @@ targets:
     main: src/<%= config.name %>.cr
 
 <%- end -%>
-crystal: <%= Crystal::Config.version %>
+crystal: '>= <%= Crystal::Config.version %>'
 
 license: MIT


### PR DESCRIPTION
The `crystal: x.y.z` format is described as legacy and discouraged in the shards docs, so update it to use the version constraint.
