### PR TITLE
Optimize `IO#read_string(0)`

### DIFF
--- a/src/io.cr
+++ b/src/io.cr
@@ -433,6 +433,8 @@ abstract class IO
   # io.read_string(6) # raises IO::EOFError
   # ```
   def read_string(bytesize : Int) : String
+    return "" if bytesize == 0
+
     String.new(bytesize) do |ptr|
       if decoder = decoder()
         read = decoder.read_utf8(self, Slice.new(ptr, bytesize))


### PR DESCRIPTION
When fetching an empty string from a remote server, we can avoid a heap allocation by returning an empty string as an optimized special case.

I also checked and `IO#read_fully(slice : Slice)` does not need this optimization. It already short-circuits if there is nothing to read.