### PR TITLE
Remove overflowing `Float#to_u!` interpreter primitive specs

### DIFF
--- a/spec/compiler/interpreter/primitives_spec.cr
+++ b/spec/compiler/interpreter/primitives_spec.cr
@@ -275,7 +275,7 @@ describe Crystal::Repl::Interpreter do
         interpret("23.8_f64.to_{{target_type}}!").should eq(f.to_{{target_type}}!)
       end
 
-      {% unless target_type.starts_with?("u") %}
+      {% unless target_type.starts_with?("u") %} # Do not test undefined behavior that might differ (#13736)
         it "interprets Float32#to_{{target_type}}! (negative)" do
           f = -23.8_f32
           interpret("-23.8_f32.to_{{target_type}}!").should eq(f.to_{{target_type}}!)

--- a/spec/compiler/interpreter/primitives_spec.cr
+++ b/spec/compiler/interpreter/primitives_spec.cr
@@ -270,20 +270,22 @@ describe Crystal::Repl::Interpreter do
         interpret("23.8_f32.to_{{target_type}}!").should eq(f.to_{{target_type}}!)
       end
 
-      it "interprets Float32#to_{{target_type}}! (negative)" do
-        f = -23.8_f32
-        interpret("-23.8_f32.to_{{target_type}}!").should eq(f.to_{{target_type}}!)
-      end
-
       it "interprets Float64#to_{{target_type}}! (positive)" do
         f = 23.8_f64
         interpret("23.8_f64.to_{{target_type}}!").should eq(f.to_{{target_type}}!)
       end
 
-      it "interprets Float64#to_{{target_type}}! (negative)" do
-        f = -23.8_f64
-        interpret("-23.8_f64.to_{{target_type}}!").should eq(f.to_{{target_type}}!)
-      end
+      {% unless target_type.starts_with?("u") %}
+        it "interprets Float32#to_{{target_type}}! (negative)" do
+          f = -23.8_f32
+          interpret("-23.8_f32.to_{{target_type}}!").should eq(f.to_{{target_type}}!)
+        end
+
+        it "interprets Float64#to_{{target_type}}! (negative)" do
+          f = -23.8_f64
+          interpret("-23.8_f64.to_{{target_type}}!").should eq(f.to_{{target_type}}!)
+        end
+      {% end %}
     {% end %}
 
     it "interprets Char#ord" do


### PR DESCRIPTION
Fixes #13736.