### PR TITLE
Remove double `.cr.cr` extension in `require` path lookup

### DIFF
--- a/spec/compiler/crystal_path/crystal_path_spec.cr
+++ b/spec/compiler/crystal_path/crystal_path_spec.cr
@@ -111,8 +111,8 @@ describe Crystal::CrystalPath do
     it "foo.cr" do
       assert_iterates_yielding [
         "x/foo.cr",
-        "x/foo.cr/foo.cr.cr",
-        "x/foo.cr/src/foo.cr.cr",
+        "x/foo.cr/foo.cr",
+        "x/foo.cr/src/foo.cr",
       ], path.each_file_expansion("foo.cr", "x")
     end
 
@@ -130,11 +130,11 @@ describe Crystal::CrystalPath do
     it "foo.cr/bar.cr" do
       assert_iterates_yielding [
         "x/foo.cr/bar.cr",
-        "x/foo.cr/src/bar.cr.cr",
-        "x/foo.cr/src/foo.cr/bar.cr.cr",
-        "x/foo.cr/bar.cr/bar.cr.cr",
-        "x/foo.cr/src/bar.cr/bar.cr.cr",
-        "x/foo.cr/src/foo.cr/bar.cr/bar.cr.cr",
+        "x/foo.cr/src/bar.cr",
+        "x/foo.cr/src/foo.cr/bar.cr",
+        "x/foo.cr/bar.cr/bar.cr",
+        "x/foo.cr/src/bar.cr/bar.cr",
+        "x/foo.cr/src/foo.cr/bar.cr/bar.cr",
       ], path.each_file_expansion("foo.cr/bar.cr", "x")
     end
 
@@ -156,7 +156,7 @@ describe Crystal::CrystalPath do
     it "./foo.cr" do
       assert_iterates_yielding [
         "x/./foo.cr",
-        "x/./foo.cr/foo.cr.cr",
+        "x/./foo.cr/foo.cr",
       ], path.each_file_expansion("./foo.cr", "x")
     end
 

--- a/spec/compiler/crystal_path/crystal_path_spec.cr
+++ b/spec/compiler/crystal_path/crystal_path_spec.cr
@@ -116,6 +116,28 @@ describe Crystal::CrystalPath do
       ], path.each_file_expansion("foo.cr", "x")
     end
 
+    it "foo.cr/bar" do
+      assert_iterates_yielding [
+        "x/foo.cr/bar.cr",
+        "x/foo.cr/src/bar.cr",
+        "x/foo.cr/src/foo.cr/bar.cr",
+        "x/foo.cr/bar/bar.cr",
+        "x/foo.cr/src/bar/bar.cr",
+        "x/foo.cr/src/foo.cr/bar/bar.cr",
+      ], path.each_file_expansion("foo.cr/bar", "x")
+    end
+
+    it "foo.cr/bar.cr" do
+      assert_iterates_yielding [
+        "x/foo.cr/bar.cr",
+        "x/foo.cr/src/bar.cr.cr",
+        "x/foo.cr/src/foo.cr/bar.cr.cr",
+        "x/foo.cr/bar.cr/bar.cr.cr",
+        "x/foo.cr/src/bar.cr/bar.cr.cr",
+        "x/foo.cr/src/foo.cr/bar.cr/bar.cr.cr",
+      ], path.each_file_expansion("foo.cr/bar.cr", "x")
+    end
+
     it "foo" do
       assert_iterates_yielding [
         "x/foo.cr",

--- a/src/compiler/crystal/crystal_path.cr
+++ b/src/compiler/crystal/crystal_path.cr
@@ -155,18 +155,16 @@ module Crystal
 
         # If it's "foo/bar/baz", check if "foo/src/foo/bar/baz/baz.cr" exists (shard, namespaced, nested)
         yield "#{shard_src}/#{shard_name}/#{shard_path}/#{shard_path_stem}.cr"
+      else
+        basename = File.basename(relative_filename, ".cr")
 
-        return nil
-      end
+        # If it's "foo", check if "foo/foo.cr" exists (for the std, nested)
+        yield "#{relative_filename}/#{basename}.cr"
 
-      basename = File.basename(relative_filename, ".cr")
-
-      # If it's "foo", check if "foo/foo.cr" exists (for the std, nested)
-      yield "#{relative_filename}/#{basename}.cr"
-
-      unless filename_is_relative
-        # If it's "foo", check if "foo/src/foo.cr" exists (for a shard)
-        yield "#{relative_filename}/src/#{basename}.cr"
+        unless filename_is_relative
+          # If it's "foo", check if "foo/src/foo.cr" exists (for a shard)
+          yield "#{relative_filename}/src/#{basename}.cr"
+        end
       end
     end
 

--- a/src/compiler/crystal/crystal_path.cr
+++ b/src/compiler/crystal/crystal_path.cr
@@ -138,27 +138,28 @@ module Crystal
 
       if !filename_is_relative && shard_path
         shard_src = "#{relative_to}/#{shard_name}/src"
+        shard_path_stem = shard_path.rchop(".cr")
 
         # If it's "foo/bar/baz", check if "foo/src/bar/baz.cr" exists (for a shard, non-namespaced structure)
-        yield "#{shard_src}/#{shard_path}.cr"
+        yield "#{shard_src}/#{shard_path_stem}.cr"
 
         # Then check if "foo/src/foo/bar/baz.cr" exists (for a shard, namespaced structure)
-        yield "#{shard_src}/#{shard_name}/#{shard_path}.cr"
+        yield "#{shard_src}/#{shard_name}/#{shard_path_stem}.cr"
 
         # If it's "foo/bar/baz", check if "foo/bar/baz/baz.cr" exists (std, nested)
-        basename = File.basename(relative_filename)
+        basename = File.basename(relative_filename, ".cr")
         yield "#{relative_filename}/#{basename}.cr"
 
         # If it's "foo/bar/baz", check if "foo/src/foo/bar/baz/baz.cr" exists (shard, non-namespaced, nested)
-        yield "#{shard_src}/#{shard_path}/#{shard_path}.cr"
+        yield "#{shard_src}/#{shard_path}/#{shard_path_stem}.cr"
 
         # If it's "foo/bar/baz", check if "foo/src/foo/bar/baz/baz.cr" exists (shard, namespaced, nested)
-        yield "#{shard_src}/#{shard_name}/#{shard_path}/#{shard_path}.cr"
+        yield "#{shard_src}/#{shard_name}/#{shard_path}/#{shard_path_stem}.cr"
 
         return nil
       end
 
-      basename = File.basename(relative_filename)
+      basename = File.basename(relative_filename, ".cr")
 
       # If it's "foo", check if "foo/foo.cr" exists (for the std, nested)
       yield "#{relative_filename}/#{basename}.cr"


### PR DESCRIPTION
If a require path ends in `.cr`, some lookup paths would end up with a double extension `.cr.cr`. This is pretty unlikely to be ever intended. An example use case is a shard name that ends in `.cr` (see #8665, this patch is the first stage for fixing this issue).

This patch removes the double extensions to make lookup paths more reasonable. The main change is happening in ed8a8b26a9827bb4eacefe47ffc6e5a74fd545c8. The spec changes in this commit clearly show the effects.

It would be possible to maintain backwards compatibility by keeping the old paths around. I don't think this is really necessary because the filenames are so weird and I don't expect that to be used.

So I'd rather prefer it as a simple replacement. If we notice any issues, we can add the removed paths back in.

This addresses part of #13210