### PR TITLE
Fix read console input on windows with codepage support

### DIFF
--- a/src/lib_c/x86_64-windows-msvc/c/consoleapi.cr
+++ b/src/lib_c/x86_64-windows-msvc/c/consoleapi.cr
@@ -14,6 +14,14 @@ lib LibC
   fun GetConsoleCP : DWORD
   fun GetConsoleOutputCP : DWORD
 
+  fun ReadConsoleW(
+    hConsoleInput : HANDLE,
+    lpBuffer : Void*,
+    nNumberOfCharsToRead : DWORD,
+    lpNumberOfCharsRead : DWORD*,
+    pInputControl : Void*
+  ) : BOOL
+
   CTRL_C_EVENT     = 0
   CTRL_BREAK_EVENT = 1
 

--- a/src/string/utf16.cr
+++ b/src/string/utf16.cr
@@ -128,8 +128,10 @@ class String
     {string, pointer + 1}
   end
 
+  # :nodoc:
+  #
   # Yields each decoded char in the given slice.
-  private def self.each_utf16_char(slice : Slice(UInt16), &)
+  def self.each_utf16_char(slice : Slice(UInt16), &)
     i = 0
     while i < slice.size
       byte = slice[i].to_i
@@ -153,8 +155,10 @@ class String
     end
   end
 
+  # :nodoc:
+  #
   # Yields each decoded char in the given pointer, stopping at the first null byte.
-  private def self.each_utf16_char(pointer : Pointer(UInt16), &) : Pointer(UInt16)
+  def self.each_utf16_char(pointer : Pointer(UInt16), &) : Pointer(UInt16)
     loop do
       byte = pointer.value.to_i
       break if byte == 0


### PR DESCRIPTION
Console input on windows is typically not encoded in UTF-8. The best cause of action seems to be using the `ReadConsole` function which is made particularly for the use case of reading from the console. It's only used if the file descriptor is a console.
This is similar to what Golang does (https://github.com/crystal-lang/crystal/issues/13731#issuecomment-1668989153).

I don't know an easy way to test this because we would need to pass process input through a console.

Resolves #13731
