### PR TITLE
Update PGP key link

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -6,6 +6,6 @@ the issue tracker. We have a dedicated mailbox where we keep track of them:
 <security@manas.tech>
 
 You can encrypt your message via [Keybase](https://keybase.io/encrypt) (set
-recipient `crystal`) or with our [PGP key](https://crystal-lang.org/crystal-pgp-key.txt)
+recipient `crystal`) or with our [PGP key](https://crystal-lang.org/community/crystal-pgp-key.txt)
 (fingerprint `5995 C83C D754 BE44 8164 1929 0961 7FD3 7CC0 6B54`)
 also available on [Keybase server](https://keybase.io/crystal/pgp_keys.asc).


### PR DESCRIPTION
It seems like the key's location has been changed to `https://crystal-lang.org/community/crystal-pgp-key.txt` instead of `https://crystal-lang.org/crystal-pgp-key.txt`