### PR TITLE
Fix check for file type

### DIFF
--- a/spec/compiler/crystal_path/crystal_path_spec.cr
+++ b/spec/compiler/crystal_path/crystal_path_spec.cr
@@ -68,6 +68,9 @@ describe Crystal::CrystalPath do
   assert_finds "../test_folder", relative_to: "test_files/test_folder/file_three.cr", results: [
     "test_files/test_folder/test_folder.cr",
   ]
+  assert_finds "foo.cr", results: [
+    "foo.cr/foo.cr",
+  ]
 
   # For `require "foo"`:
   # 1. foo.cr (to find something in the standard library)

--- a/src/compiler/crystal/crystal_path.cr
+++ b/src/compiler/crystal/crystal_path.cr
@@ -120,7 +120,7 @@ module Crystal
 
       each_file_expansion(filename, relative_to) do |path|
         absolute_path = File.expand_path(path, dir: @current_dir)
-        return absolute_path if File.exists?(absolute_path)
+        return absolute_path if File.file?(absolute_path)
       end
 
       nil


### PR DESCRIPTION
A resolved require path does not just need to exist, it also needs to be a file. Otherwise there will be confusion when there's a folder with the same name of a potential path.

Resolves #8665