### PR TITLE
Fix typo in call_error.cr

### DIFF
--- a/src/compiler/crystal/semantic/call_error.cr
+++ b/src/compiler/crystal/semantic/call_error.cr
@@ -633,7 +633,7 @@ class Crystal::Call
         msg << '\n'
         if similar_name == def_name
           # This check is for the case `a if a = 1`
-          msg << "If you declared '#{def_name}' in a suffix if, declare it in a regular if for this to work. If the variable was declared in a macro it's not visible outside it)"
+          msg << "If you declared '#{def_name}' in a suffix if, declare it in a regular if for this to work. If the variable was declared in a macro it's not visible outside it."
         else
           msg << "Did you mean '#{similar_name}'?"
         end


### PR DESCRIPTION
Hi crystal developers.
I came across this error message today and noticed that the brackets are only on the right side. 

![image](https://github.com/kojix2/crystal/assets/5798442/acb0ee8a-bbd4-46d4-b952-a81de9f41c92)

I changed it to a period.
Feel free to close it if you would prefer another fix.