### PR TITLE
Remove `SetShouldExit` in Powershell wrapper

### DIFF
--- a/bin/crystal.ps1
+++ b/bin/crystal.ps1
@@ -238,8 +238,6 @@ function Exec-Process {
     $hnd = $Process.Handle
     Wait-Process -Id $Process.Id
 
-    # and return it properly too: https://stackoverflow.com/a/50202663
-    $host.SetShouldExit($Process.ExitCode)
     Exit $Process.ExitCode
 }
 


### PR DESCRIPTION
The `SetShouldExit` command leads to unexpected behaviour as it terminates the entire console session.

Before this patch:
```console
> .\bin\crystal eval 'exit 23'

[process exited with code 23 (0x00000017)]
You can now close this terminal with Ctrl+D, or press Enter to restart.
```
Session closed.

With a success exit code, there is not even an exit message and instead the entire terminal would close.

After this patch:
```console
> .\bin\crystal.ps1 eval 'exit 23'
```
Session continues.