### PR TITLE
Mark the return type of methods such as `Slice#copy_to` as `Nil`

### DIFF
--- a/src/slice.cr
+++ b/src/slice.cr
@@ -488,14 +488,14 @@ struct Slice(T)
     super(range) { |i| yield i }
   end
 
-  def copy_from(source : Pointer(T), count)
+  def copy_from(source : Pointer(T), count) : Nil
     check_writable
     check_size(count)
 
     @pointer.copy_from(source, count)
   end
 
-  def copy_to(target : Pointer(T), count)
+  def copy_to(target : Pointer(T), count) : Nil
     check_size(count)
 
     @pointer.copy_to(target, count)
@@ -513,7 +513,7 @@ struct Slice(T)
   # dst             # => Slice['a', 'a', 'a', 'b', 'b']
   # dst.copy_to src # raises IndexError
   # ```
-  def copy_to(target : self)
+  def copy_to(target : self) : Nil
     target.check_writable
     raise IndexError.new if target.size < size
 
@@ -524,18 +524,18 @@ struct Slice(T)
   #
   # Raises `IndexError` if the destination slice cannot fit the data being transferred.
   @[AlwaysInline]
-  def copy_from(source : self)
+  def copy_from(source : self) : Nil
     source.copy_to(self)
   end
 
-  def move_from(source : Pointer(T), count)
+  def move_from(source : Pointer(T), count) : Nil
     check_writable
     check_size(count)
 
     @pointer.move_from(source, count)
   end
 
-  def move_to(target : Pointer(T), count)
+  def move_to(target : Pointer(T), count) : Nil
     @pointer.move_to(target, count)
   end
 
@@ -554,7 +554,7 @@ struct Slice(T)
   # ```
   #
   # See also: `Pointer#move_to`.
-  def move_to(target : self)
+  def move_to(target : self) : Nil
     target.check_writable
     raise IndexError.new if target.size < size
 
@@ -566,7 +566,7 @@ struct Slice(T)
   #
   # Raises `IndexError` if the destination slice cannot fit the data being transferred.
   @[AlwaysInline]
-  def move_from(source : self)
+  def move_from(source : self) : Nil
     source.move_to(self)
   end
 


### PR DESCRIPTION
Prevent inadvertent access to unsafe pointers.

Closes #13773