### PR TITLE
Update distribution-scripts

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,7 @@ parameters:
   distribution-scripts-version:
     description: "Git ref for version of https://github.com/crystal-lang/distribution-scripts/"
     type: string
-    default: "c6e09318a20369d7448f368d050a8a8821f31d85"
+    default: "e15cbd3b6b3e1bac1b16905f1b1a15ba6ae4e554"
   previous_crystal_base_url:
     description: "Prefix for URLs to Crystal bootstrap compiler"
     type: string

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,7 @@ parameters:
   distribution-scripts-version:
     description: "Git ref for version of https://github.com/crystal-lang/distribution-scripts/"
     type: string
-    default: "4b3af3fb9ebeb2c74850bc7025a17a38ab82c5f4"
+    default: "c6e09318a20369d7448f368d050a8a8821f31d85"
   previous_crystal_base_url:
     description: "Prefix for URLs to Crystal bootstrap compiler"
     type: string


### PR DESCRIPTION
Updates `distribution-scripts` dependency to https://github.com/crystal-lang/distribution-scripts/commit/c6e09318a20369d7448f368d050a8a8821f31d85

This includes the following changes:

* crystal-lang/distribution-scripts#254
* crystal-lang/distribution-scripts#251
* crystal-lang/distribution-scripts#249
* crystal-lang/distribution-scripts#248
* crystal-lang/distribution-scripts#247
* crystal-lang/distribution-scripts#246
