### PR TITLE
Fix log format in update-distribution-scripts.sh

### DIFF
--- a/scripts/update-distribution-scripts.sh
+++ b/scripts/update-distribution-scripts.sh
@@ -42,7 +42,7 @@ sed -i -E "/distribution-scripts-version:/{n;n;n;s/default: \".*\"/default: \"$r
 git add .circleci/config.yml
 
 message="Updates \`distribution-scripts\` dependency to https://github.com/crystal-lang/distribution-scripts/commit/$reference"
-log=$($GIT_DS log $old_reference..$reference --format="%s" | sed "s/.*(/crystal-lang\/distribution-scripts/;s/^/* /;")
+log=$($GIT_DS log $old_reference..$reference --format="%s" | sed "s/.*(/crystal-lang\/distribution-scripts/;s/^/* /;s/)$//")
 message=$(printf "%s\n\nThis includes the following changes:\n\n%s" "$message" "$log")
 
 git commit -m "Update distribution-scripts" -m "$message"


### PR DESCRIPTION
Removes a residual `)` at the end of each log entry.