### PR TITLE
Avoid double file buffering

### DIFF
--- a/src/crystal/system/unix/getrandom.cr
+++ b/src/crystal/system/unix/getrandom.cr
@@ -33,7 +33,7 @@ module Crystal::System::Random
       return unless urandom.info.type.character_device?
 
       urandom.close_on_exec = true
-      urandom.sync = true # don't buffer bytes
+      urandom.read_buffering = false # don't buffer bytes
       @@urandom = urandom
     end
   end

--- a/src/digest/digest.cr
+++ b/src/digest/digest.cr
@@ -213,6 +213,7 @@ abstract class Digest
   # Reads the file's content and updates the digest with it.
   def file(file_name : Path | String) : self
     File.open(file_name) do |io|
+      # `#update` works with big buffers so there's no need for additional read buffering in the file
       io.read_buffering = false
       self << io
     end

--- a/src/digest/digest.cr
+++ b/src/digest/digest.cr
@@ -213,6 +213,7 @@ abstract class Digest
   # Reads the file's content and updates the digest with it.
   def file(file_name : Path | String) : self
     File.open(file_name) do |io|
+      io.read_buffering = false
       self << io
     end
   end

--- a/src/file.cr
+++ b/src/file.cr
@@ -795,6 +795,7 @@ class File < IO::FileDescriptor
   # See `self.new` for what *mode* can be.
   def self.write(filename : Path | String, content, perm = DEFAULT_CREATE_PERMISSIONS, encoding = nil, invalid = nil, mode = "w")
     open(filename, mode, perm, encoding: encoding, invalid: invalid) do |file|
+      file.sync = true
       case content
       when Bytes
         file.write(content)

--- a/src/file.cr
+++ b/src/file.cr
@@ -795,9 +795,9 @@ class File < IO::FileDescriptor
   # See `self.new` for what *mode* can be.
   def self.write(filename : Path | String, content, perm = DEFAULT_CREATE_PERMISSIONS, encoding = nil, invalid = nil, mode = "w")
     open(filename, mode, perm, encoding: encoding, invalid: invalid) do |file|
-      file.sync = true
       case content
-      when Bytes
+      when Bytes, String
+        file.sync = true
         file.write(content)
       when IO
         IO.copy(content, file)

--- a/src/file.cr
+++ b/src/file.cr
@@ -800,6 +800,7 @@ class File < IO::FileDescriptor
         file.sync = true
         file.write(content)
       when IO
+        file.sync = true
         IO.copy(content, file)
       else
         file.print(content)

--- a/src/file.cr
+++ b/src/file.cr
@@ -796,7 +796,7 @@ class File < IO::FileDescriptor
   def self.write(filename : Path | String, content, perm = DEFAULT_CREATE_PERMISSIONS, encoding = nil, invalid = nil, mode = "w")
     open(filename, mode, perm, encoding: encoding, invalid: invalid) do |file|
       case content
-      when Bytes, String
+      when Bytes
         file.sync = true
         file.write(content)
       when IO


### PR DESCRIPTION
Avoid allocating file buffers when not needed.