### PR TITLE
Avoid realloc callstack array when unwinding

### DIFF
--- a/src/exception/call_stack/libunwind.cr
+++ b/src/exception/call_stack/libunwind.cr
@@ -38,7 +38,7 @@ struct Exception::CallStack
 
   {% if flag?(:interpreted) %} @[Primitive(:interpreter_call_stack_unwind)] {% end %}
   protected def self.unwind : Array(Void*)
-    callstack = [] of Void*
+    callstack = Array(Void*).new(16)
     backtrace_fn = ->(context : LibUnwind::Context, data : Void*) do
       bt = data.as(typeof(callstack))
 

--- a/src/exception/call_stack/libunwind.cr
+++ b/src/exception/call_stack/libunwind.cr
@@ -38,7 +38,7 @@ struct Exception::CallStack
 
   {% if flag?(:interpreted) %} @[Primitive(:interpreter_call_stack_unwind)] {% end %}
   protected def self.unwind : Array(Void*)
-    callstack = Array(Void*).new(16)
+    callstack = Array(Void*).new(32)
     backtrace_fn = ->(context : LibUnwind::Context, data : Void*) do
       bt = data.as(typeof(callstack))
 


### PR DESCRIPTION
Most often the callstack is larger than 3, don't know if 16 is resonable value, but at least it avoid realloc the array in many apps.