### PR TITLE
Fix memory leak in `OpenSSL::SSL::Socket#peer_certificate`

### DIFF
--- a/src/openssl/ssl/socket.cr
+++ b/src/openssl/ssl/socket.cr
@@ -275,11 +275,12 @@ abstract class OpenSSL::SSL::Socket < IO
   # is returned does not indicate information about the verification state.
   def peer_certificate : OpenSSL::X509::Certificate?
     raw_cert = LibSSL.ssl_get_peer_certificate(@ssl)
-
     if raw_cert
-      cert = OpenSSL::X509::Certificate.new(raw_cert)
-      LibCrypto.x509_free(raw_cert)
-      cert
+      begin
+        OpenSSL::X509::Certificate.new(raw_cert)
+      ensure
+        LibCrypto.x509_free(raw_cert)
+      end
     end
   end
 end

--- a/src/openssl/ssl/socket.cr
+++ b/src/openssl/ssl/socket.cr
@@ -274,7 +274,12 @@ abstract class OpenSSL::SSL::Socket < IO
   # an anonymous cipher is used, no certificates are sent. That a certificate
   # is returned does not indicate information about the verification state.
   def peer_certificate : OpenSSL::X509::Certificate?
-    cert = LibSSL.ssl_get_peer_certificate(@ssl)
-    OpenSSL::X509::Certificate.new cert if cert
+    raw_cert = LibSSL.ssl_get_peer_certificate(@ssl)
+
+    if raw_cert
+      cert = OpenSSL::X509::Certificate.new(raw_cert)
+      LibCrypto.x509_free(raw_cert)
+      cert
+    end
   end
 end


### PR DESCRIPTION
While opening lots of HTTPS connections (from [Heii On-Call](https://heiioncall.com/) outbound prober processes for website monitoring / alerting), I discovered a substantial memory leak. This memory leak causes our processes to hit their memory limits and restart several times per day. I traced the leak down to a call to `OpenSSL::SSL::Socket#peer_certificate`, which we recently started using to inspect SSL certificate expiry dates, so we can warn our users about soon-to-expire certificates.

As per https://www.openssl.org/docs/man3.1/man3/SSL_get1_peer_certificate.html :

> The reference count of the X509 object returned by SSL_get1_peer_certificate() is incremented by one, so that it will not be destroyed when the session containing the peer certificate is freed. The X509 object must be explicitly freed using X509_free().

The attached fix ensures that the raw `LibCrypto::X509` certificate is freed with `LibCrypto.x509_free` after it is `LibCrypto.x509_dup`'d into a new `OpenSSL::X509::Certificate` instance within the `OpenSSL::X509::Certificate` constructor.

Running with this change monkeypatched does fix our memory leak. 😄 