### PR TITLE
Add overloads for `URI::Params.encode` with `IO` parameter

### DIFF
--- a/spec/std/uri/params_spec.cr
+++ b/spec/std/uri/params_spec.cr
@@ -79,7 +79,7 @@ class URI
 
       it "builds from hash with IO" do
         io = IO::Memory.new
-        Params.encode({"foo" => "bar", "baz" => ["quux", "quuz"]}, io)
+        Params.encode(io, {"foo" => "bar", "baz" => ["quux", "quuz"]})
         io.to_s.should eq("foo=bar&baz=quux&baz=quuz")
       end
 
@@ -90,7 +90,7 @@ class URI
 
       it "builds from named tuple with IO" do
         io = IO::Memory.new
-        encoded = Params.encode({foo: "bar", baz: ["quux", "quuz"]}, io)
+        encoded = Params.encode(io, {foo: "bar", baz: ["quux", "quuz"]})
         io.to_s.should eq("foo=bar&baz=quux&baz=quuz")
       end
     end

--- a/spec/std/uri/params_spec.cr
+++ b/spec/std/uri/params_spec.cr
@@ -61,6 +61,14 @@ class URI
 
         encoded.should eq("foo%20bar=hello%20world")
       end
+
+      it "builds with IO" do
+        io = IO::Memory.new
+        Params.build(io) do |form|
+          form.add("custom", "key")
+        end
+        io.to_s.should eq("custom=key")
+      end
     end
 
     describe ".encode" do
@@ -69,9 +77,21 @@ class URI
         encoded.should eq("foo=bar&baz=quux&baz=quuz")
       end
 
+      it "builds from hash with IO" do
+        io = IO::Memory.new
+        Params.encode({"foo" => "bar", "baz" => ["quux", "quuz"]}, io)
+        io.to_s.should eq("foo=bar&baz=quux&baz=quuz")
+      end
+
       it "builds from named tuple" do
         encoded = Params.encode({foo: "bar", baz: ["quux", "quuz"]})
         encoded.should eq("foo=bar&baz=quux&baz=quuz")
+      end
+
+      it "builds from named tuple with IO" do
+        io = IO::Memory.new
+        encoded = Params.encode({foo: "bar", baz: ["quux", "quuz"]}, io)
+        io.to_s.should eq("foo=bar&baz=quux&baz=quuz")
       end
     end
 

--- a/src/uri/params.cr
+++ b/src/uri/params.cr
@@ -100,10 +100,10 @@ class URI
     # require "uri/params"
     #
     # io = IO::Memory.new
-    # URI::Params.encode({"foo" => "bar", "baz" => ["quux", "quuz"]}, io)
+    # URI::Params.encode(io, {"foo" => "bar", "baz" => ["quux", "quuz"]})
     # io.to_s # => "foo=bar&baz=quux&baz=quuz"
     # ```
-    def self.encode(hash : Hash(String, String | Array(String)), io : IO) : Nil
+    def self.encode(io : IO, hash : Hash(String, String | Array(String))) : Nil
       build(io) do |builder|
         hash.each do |key, value|
           builder.add key, value
@@ -132,10 +132,10 @@ class URI
     # require "uri/params"
     #
     # io = IO::Memory.new
-    # URI::Params.encode({foo: "bar", baz: ["quux", "quuz"]}, io)
+    # URI::Params.encode(io, {foo: "bar", baz: ["quux", "quuz"]})
     # io.to_s # => "foo=bar&baz=quux&baz=quuz"
     # ```
-    def self.encode(named_tuple : NamedTuple, io : IO) : Nil
+    def self.encode(io : IO, named_tuple : NamedTuple) : Nil
       build(io) do |builder|
         named_tuple.each do |key, value|
           builder.add key.to_s, value

--- a/src/uri/params.cr
+++ b/src/uri/params.cr
@@ -94,6 +94,23 @@ class URI
       end
     end
 
+    # Appends the given key value pairs as a url-encoded URI form/query to the given `io`.
+    #
+    # ```
+    # require "uri/params"
+    #
+    # io = IO::Memory.new
+    # URI::Params.encode({"foo" => "bar", "baz" => ["quux", "quuz"]}, io)
+    # io.to_s # => "foo=bar&baz=quux&baz=quuz"
+    # ```
+    def self.encode(hash : Hash(String, String | Array(String)), io : IO) : Nil
+      build(io) do |builder|
+        hash.each do |key, value|
+          builder.add key, value
+        end
+      end
+    end
+
     # Returns the given key value pairs as a url-encoded URI form/query.
     #
     # ```
@@ -101,8 +118,25 @@ class URI
     #
     # URI::Params.encode({foo: "bar", baz: ["quux", "quuz"]}) # => "foo=bar&baz=quux&baz=quuz"
     # ```
-    def self.encode(named_tuple : NamedTuple)
+    def self.encode(named_tuple : NamedTuple) : String
       build do |builder|
+        named_tuple.each do |key, value|
+          builder.add key.to_s, value
+        end
+      end
+    end
+
+    # Appends the given key value pairs as a url-encoded URI form/query to the given `io`.
+    #
+    # ```
+    # require "uri/params"
+    #
+    # io = IO::Memory.new
+    # URI::Params.encode({foo: "bar", baz: ["quux", "quuz"]}, io)
+    # io.to_s # => "foo=bar&baz=quux&baz=quuz"
+    # ```
+    def self.encode(named_tuple : NamedTuple, io : IO) : Nil
+      build(io) do |builder|
         named_tuple.each do |key, value|
           builder.add key.to_s, value
         end
@@ -141,6 +175,11 @@ class URI
       String.build do |io|
         yield Builder.new(io, space_to_plus: space_to_plus)
       end
+    end
+
+    # :ditto:
+    def self.build(io : IO, *, space_to_plus : Bool = true, & : Builder ->) : Nil
+      yield Builder.new(io, space_to_plus: space_to_plus)
     end
 
     protected getter raw_params


### PR DESCRIPTION
Fixes #13788

This adds in a new method overload for `URI::Params.encode` that allows you to pass in your own `IO` object.