### PR TITLE
Optimize the constructors of `Time::Span`

### DIFF
--- a/spec/std/time/span_spec.cr
+++ b/spec/std/time/span_spec.cr
@@ -34,6 +34,23 @@ describe Time::Span do
     t1.to_s.should eq("1.01:00:00")
   end
 
+  it "initializes with type restrictions" do
+    t = Time::Span.new seconds: 1_u8, nanoseconds: 1_u8
+    t.should eq(Time::Span.new seconds: 1, nanoseconds: 1)
+
+    t = Time::Span.new seconds: 127_i8, nanoseconds: 1_000_000_000
+    t.should eq(Time::Span.new seconds: 128)
+
+    t = Time::Span.new seconds: -128_i8, nanoseconds: -1_000_000_000
+    t.should eq(Time::Span.new seconds: -129)
+
+    t = Time::Span.new seconds: 255_u8, nanoseconds: 1_000_000_000
+    t.should eq(Time::Span.new seconds: 256)
+
+    t = Time::Span.new seconds: 0_u8, nanoseconds: -1_000_000_000
+    t.should eq(Time::Span.new seconds: -1)
+  end
+
   it "initializes with big seconds value" do
     t = Time::Span.new hours: 0, minutes: 0, seconds: 1231231231231
     t.total_seconds.should eq(1231231231231)

--- a/src/time/span.cr
+++ b/src/time/span.cr
@@ -65,22 +65,19 @@ struct Time::Span
   # ```
   def initialize(*, seconds : Int, nanoseconds : Int)
     # Normalize nanoseconds in the range 0...1_000_000_000
-    seconds += nanoseconds.tdiv(NANOSECONDS_PER_SECOND)
-    nanoseconds = nanoseconds.remainder(NANOSECONDS_PER_SECOND)
+    @seconds = seconds.to_i64 + nanoseconds.tdiv(NANOSECONDS_PER_SECOND)
+    @nanoseconds = nanoseconds.remainder(NANOSECONDS_PER_SECOND).to_i32
 
     # Make sure that if seconds is positive, nanoseconds is
     # positive too. Likewise, if seconds is negative, make
     # sure that nanoseconds is negative too.
-    if seconds > 0 && nanoseconds < 0
-      seconds -= 1
-      nanoseconds += NANOSECONDS_PER_SECOND
-    elsif seconds < 0 && nanoseconds > 0
-      seconds += 1
-      nanoseconds -= NANOSECONDS_PER_SECOND
+    if @seconds > 0 && @nanoseconds < 0
+      @seconds -= 1
+      @nanoseconds += NANOSECONDS_PER_SECOND
+    elsif @seconds < 0 && @nanoseconds > 0
+      @seconds += 1
+      @nanoseconds -= NANOSECONDS_PER_SECOND
     end
-
-    @seconds = seconds.to_i64
-    @nanoseconds = nanoseconds.to_i32
   end
 
   # Creates a new `Time::Span` from the *nanoseconds* given
@@ -93,10 +90,7 @@ struct Time::Span
   # Time::Span.new(nanoseconds: 5_500_000_000) # => 00:00:05.500000000
   # ```
   def self.new(*, nanoseconds : Int)
-    new(
-      seconds: nanoseconds.to_i64.tdiv(NANOSECONDS_PER_SECOND),
-      nanoseconds: nanoseconds.to_i64.remainder(NANOSECONDS_PER_SECOND),
-    )
+    new(seconds: 0, nanoseconds: nanoseconds)
   end
 
   # Creates a new `Time::Span` from the *days*, *hours*, *minutes*, *seconds* and *nanoseconds* given
@@ -111,7 +105,7 @@ struct Time::Span
   def self.new(*, days : Int = 0, hours : Int = 0, minutes : Int = 0, seconds : Int = 0, nanoseconds : Int = 0)
     new(
       seconds: compute_seconds(days, hours, minutes, seconds),
-      nanoseconds: nanoseconds.to_i64,
+      nanoseconds: nanoseconds,
     )
   end
 

--- a/src/time/span.cr
+++ b/src/time/span.cr
@@ -65,7 +65,7 @@ struct Time::Span
   # ```
   def initialize(*, seconds : Int, nanoseconds : Int)
     # Normalize nanoseconds in the range 0...1_000_000_000
-    @seconds = seconds.to_i64 + nanoseconds.tdiv(NANOSECONDS_PER_SECOND)
+    @seconds = seconds.to_i64 + nanoseconds.tdiv(NANOSECONDS_PER_SECOND).to_i64
     @nanoseconds = nanoseconds.remainder(NANOSECONDS_PER_SECOND).to_i32
 
     # Make sure that if seconds is positive, nanoseconds is


### PR DESCRIPTION
1. Avoid arithmetic overflow exception.
2. Remove unnecessary type conversions.
3. Remove unnecessary normalization.

Closes #13797