### PR TITLE
Expose inherited macros in generated API docs

### DIFF
--- a/src/compiler/crystal/tools/doc/html/_macros_inherited.html
+++ b/src/compiler/crystal/tools/doc/html/_macros_inherited.html
@@ -1,0 +1,11 @@
+<% macro_groups = macros.group_by { |m| m.name } %>
+<% unless macro_groups.empty? %>
+  <h3>Macros inherited from <%= ancestor.kind %> <code><%= ancestor.link_from(type) %></code></h3>
+  <% i = 0 %>
+  <% macro_groups.each do |k, v| %>
+    <a href="<%= type.path_to(ancestor) %><%= v[0].anchor %>" class="tooltip">
+      <span><%= v.map { |m| m.name + m.args_to_html(:highlight) } .join("<br/>") %></span>
+    <%= k %></a><%= ", " if i != macro_groups.size - 1 %>
+    <% i += 1 %>
+  <% end %>
+<% end %>

--- a/src/compiler/crystal/tools/doc/html/type.html
+++ b/src/compiler/crystal/tools/doc/html/type.html
@@ -103,6 +103,7 @@
     <%= MethodsInheritedTemplate.new(type, ancestor, ancestor.instance_methods, "Instance") %>
     <%= MethodsInheritedTemplate.new(type, ancestor, ancestor.constructors, "Constructor") %>
     <%= MethodsInheritedTemplate.new(type, ancestor, ancestor.class_methods, "Class") %>
+    <%= MacrosInheritedTemplate.new(type, ancestor, ancestor.macros) %>
   <% end %>
 </div>
 

--- a/src/compiler/crystal/tools/doc/templates.cr
+++ b/src/compiler/crystal/tools/doc/templates.cr
@@ -49,6 +49,10 @@ module Crystal::Doc
     ECR.def_to_s "#{__DIR__}/html/_methods_inherited.html"
   end
 
+  record MacrosInheritedTemplate, type : Type, ancestor : Type, macros : Array(Macro) do
+    ECR.def_to_s "#{__DIR__}/html/_macros_inherited.html"
+  end
+
   record OtherTypesTemplate, title : String, type : Type, other_types : Array(Type) do
     ECR.def_to_s "#{__DIR__}/html/_other_types.html"
   end


### PR DESCRIPTION
![image](https://github.com/crystal-lang/crystal/assets/12136995/3fc394dd-277e-4f66-874c-99c8b099aec0)

![image](https://github.com/crystal-lang/crystal/assets/12136995/8531b13b-c7bf-4fb3-ad87-c1311b729ea4)

Unsure how I feel about the `Object` macros, it's technically correct, but not really something that makes sense to actually call like that.

```cr
Int.setter foo : Int32
```
Is valid code but produces invalid code so results in a compiler error. Could make sense to make those macros private, but then would need like a `:showdoc:` directive to allow them to be rendered.

Resolves #13809 