### PR TITLE
Fix block parameter unpacking inside macros

### DIFF
--- a/spec/compiler/codegen/macro_spec.cr
+++ b/spec/compiler/codegen/macro_spec.cr
@@ -1880,7 +1880,7 @@ describe "Code gen: macro" do
       )).to_b.should eq(true)
   end
 
-  it "does block unpacking inside macro expression (##13707)" do
+  it "does block unpacking inside macro expression (#13707)" do
     run(%(
       {% begin %}
         {%

--- a/spec/compiler/semantic/macro_spec.cr
+++ b/spec/compiler/semantic/macro_spec.cr
@@ -1657,6 +1657,16 @@ describe "Semantic: macro" do
     method.location.not_nil!.expanded_location.not_nil!.line_number.should eq(9)
   end
 
+  it "unpacks block parameters inside macros (#13742)" do
+    assert_no_errors <<-CRYSTAL
+      macro foo
+        {% [{1, 2}, {3, 4}].each { |(k, v)| k } %}
+      end
+
+      foo
+      CRYSTAL
+  end
+
   it "executes OpAssign (#9356)" do
     assert_type(<<-CRYSTAL) { int32 }
       {% begin %}

--- a/spec/compiler/semantic/macro_spec.cr
+++ b/spec/compiler/semantic/macro_spec.cr
@@ -1665,6 +1665,15 @@ describe "Semantic: macro" do
 
       foo
       CRYSTAL
+
+    assert_no_errors <<-CRYSTAL
+      macro foo
+        {% [{1, 2}, {3, 4}].each { |(k, v)| k } %}
+      end
+
+      foo
+      foo
+      CRYSTAL
   end
 
   it "executes OpAssign (#9356)" do

--- a/spec/spec_helper.cr
+++ b/spec/spec_helper.cr
@@ -10,6 +10,8 @@ require "./support/tempfile"
 require "./support/win32"
 
 class Crystal::Program
+  setter temp_var_counter
+
   def union_of(type1, type2, type3)
     union_of([type1, type2, type3] of Type).not_nil!
   end
@@ -82,7 +84,23 @@ def assert_normalize(from, to, flags = nil, *, file = __FILE__, line = __LINE__)
   program.flags.concat(flags.split) if flags
   from_nodes = Parser.parse(from)
   to_nodes = program.normalize(from_nodes)
-  to_nodes.to_s.strip.should eq(to.strip), file: file, line: line
+  to_nodes_str = to_nodes.to_s.strip
+  to_nodes_str.should eq(to.strip), file: file, line: line
+
+  # first idempotency check: the result should be fully normalized
+  to_nodes_str2 = program.normalize(to_nodes).to_s.strip
+  unless to_nodes_str2 == to_nodes_str
+    fail "Idempotency failed:\nBefore: #{to_nodes_str.inspect}\nAfter:  #{to_nodes_str2.inspect}", file: file, line: line
+  end
+
+  # second idempotency check: if the normalizer mutates the original node,
+  # further normalizations should not produce a different result
+  program.temp_var_counter = 0
+  to_nodes_str2 = program.normalize(from_nodes).to_s.strip
+  unless to_nodes_str2 == to_nodes_str
+    fail "Idempotency failed:\nBefore: #{to_nodes_str.inspect}\nAfter:  #{to_nodes_str2.inspect}", file: file, line: line
+  end
+
   to_nodes
 end
 

--- a/src/compiler/crystal/macros/interpreter.cr
+++ b/src/compiler/crystal/macros/interpreter.cr
@@ -358,8 +358,11 @@ module Crystal
         args = node.args.map { |arg| accept arg }
         named_args = node.named_args.try &.to_h { |arg| {arg.name, accept arg.value} }
 
+        # normalize needed for param unpacking
+        block = node.block.try { |b| @program.normalize(b) }
+
         begin
-          @last = receiver.interpret(node.name, args, named_args, node.block, self, node.name_location)
+          @last = receiver.interpret(node.name, args, named_args, block, self, node.name_location)
         rescue ex : MacroRaiseException
           # Re-raise to avoid the logic in the other rescue blocks and to retain the original location
           raise ex

--- a/src/compiler/crystal/semantic/normalizer.cr
+++ b/src/compiler/crystal/semantic/normalizer.cr
@@ -451,7 +451,10 @@ module Crystal
       return node unless unpacks
 
       # as `node` is mutated in-place, ensure it can only be mutated once
-      node.unpacks = nil
+      # we consider a block to be mutated if any unpack already has a
+      # corresponding block parameter with a name (as the fictitious packed
+      # parameters have empty names)
+      return node if unpacks.any? { |index, _| !node.args[index].name.empty? }
 
       extra_expressions = [] of ASTNode
       next_unpacks = [] of {String, Expressions}

--- a/src/compiler/crystal/semantic/normalizer.cr
+++ b/src/compiler/crystal/semantic/normalizer.cr
@@ -450,6 +450,9 @@ module Crystal
       unpacks = node.unpacks
       return node unless unpacks
 
+      # as `node` is mutated in-place, ensure it can only be mutated once
+      node.unpacks = nil
+
       extra_expressions = [] of ASTNode
       next_unpacks = [] of {String, Expressions}
 

--- a/src/compiler/crystal/syntax/transformer.cr
+++ b/src/compiler/crystal/syntax/transformer.cr
@@ -559,7 +559,6 @@ module Crystal
     end
 
     def transform(node : MacroExpression)
-      node.exp = node.exp.transform(self)
       node
     end
 
@@ -572,15 +571,10 @@ module Crystal
     end
 
     def transform(node : MacroIf)
-      node.cond = node.cond.transform(self)
-      node.then = node.then.transform(self)
-      node.else = node.else.transform(self)
       node
     end
 
     def transform(node : MacroFor)
-      node.exp = node.exp.transform(self)
-      node.body = node.body.transform(self)
       node
     end
 


### PR DESCRIPTION
Fixes #13742 (regression on master).

This effectively reverts #13709; it seems the compiler doesn't need normalizations on all those kinds of macro nodes every time.