### PR TITLE
Refactor narrow OpenSSL requires for digest implementations

### DIFF
--- a/src/digest/md5.cr
+++ b/src/digest/md5.cr
@@ -1,5 +1,5 @@
 require "./digest"
-require "openssl"
+require "openssl/digest"
 
 # Implements the MD5 digest algorithm.
 #

--- a/src/digest/sha1.cr
+++ b/src/digest/sha1.cr
@@ -1,5 +1,5 @@
 require "./digest"
-require "openssl"
+require "openssl/digest"
 
 # Implements the SHA1 digest algorithm.
 #

--- a/src/digest/sha256.cr
+++ b/src/digest/sha256.cr
@@ -1,5 +1,5 @@
 require "./digest"
-require "openssl"
+require "openssl/digest"
 
 # Implements the SHA256 digest algorithm.
 #

--- a/src/digest/sha512.cr
+++ b/src/digest/sha512.cr
@@ -1,5 +1,5 @@
 require "./digest"
-require "openssl"
+require "openssl/digest"
 
 # Implements the SHA512 digest algorithm.
 #


### PR DESCRIPTION
As mentioned in https://github.com/crystal-lang/crystal/pull/13693#issuecomment-1724327728, the digest implementations need only require `openssl/digest`, not the entire `openssl` library.