### PR TITLE
Support `Range#bsearch` when no upper bound

### DIFF
--- a/spec/std/range_spec.cr
+++ b/spec/std/range_spec.cr
@@ -155,6 +155,10 @@ describe "Range" do
       (0_u8...10_u8).bsearch { |x| x >= 10 }.should eq nil
       (0_u32..10_u32).bsearch { |x| x >= 10 }.should eq 10_u32
       (0_u32...10_u32).bsearch { |x| x >= 10 }.should eq nil
+
+      # No upper bound
+      (0..).bsearch { true }.should eq 0
+      (-10...).bsearch { |x| x > 10 }.should eq 11
     end
 
     it "BigInt" do


### PR DESCRIPTION
 (fixes #10030) (ref #11213)

This expands `Range#bsearch` to handle Ranges with a nil upper bound.

The algorithm is:
1. Starting from the lower bound, repeatedly double the value until we find *a* match.
1. We now know that the *first* match exists between the current and previous values of the running upper bound.
1. Proceed with the normal bisecting algorithm, using the current and previous values.

Initially, I limited this to `Number` types so we can use `*` to double the upper bound, but this should be generalizable to other types by using `#succ`. I think we can do that as a separate PR, if desired.

Problems with this implementation:
1. There's a type error because the compiler thinks the yielded value could be Nil, even though we `yield doubled_to.as(B)`. I don't know how to assure the compiler that the yielded value is the same as `B` even when `E` is nil.
1. If the Range does not contain a match, or sometimes if the matching element is followed by non-matching elements, it will loop infinitely. How do we decide when to give up the search?