### PR TITLE
Allow word breaks between module names in docs

### DIFF
--- a/src/compiler/crystal/tools/doc/html/type.html
+++ b/src/compiler/crystal/tools/doc/html/type.html
@@ -17,9 +17,9 @@
 <div class="main-content">
 <h1 class="type-name">
 <% if type.program? %>
-  <%= type.full_name %>
+  <%= type.full_name.gsub(/::/, "::<wbr>") %>
 <% else %>
-  <span class="kind"><%= type.abstract? ? "abstract " : ""%><%= type.kind %></span> <%= type.full_name %>
+  <span class="kind"><%= type.abstract? ? "abstract " : ""%><%= type.kind %></span> <%= type.full_name.gsub(/::/, "::<wbr>") %>
 <% end %>
 </h1>
 

--- a/src/compiler/crystal/tools/doc/html/type.html
+++ b/src/compiler/crystal/tools/doc/html/type.html
@@ -17,9 +17,9 @@
 <div class="main-content">
 <h1 class="type-name">
 <% if type.program? %>
-  <%= type.full_name.gsub(/::/, "::<wbr>") %>
+  <%= type.full_name.gsub("::", "::<wbr>") %>
 <% else %>
-  <span class="kind"><%= type.abstract? ? "abstract " : ""%><%= type.kind %></span> <%= type.full_name.gsub(/::/, "::<wbr>") %>
+  <span class="kind"><%= type.abstract? ? "abstract " : ""%><%= type.kind %></span> <%= type.full_name.gsub("::", "::<wbr>") %>
 <% end %>
 </h1>
 


### PR DESCRIPTION
Allow word breaks between module names in docs for easier mobile viewing

Before:
![image](https://github.com/crystal-lang/crystal/assets/32797552/d2f63081-b1e0-43b9-a867-e71f8e6c3740)

After:
![image](https://github.com/crystal-lang/crystal/assets/32797552/8741d534-6b42-4889-aa96-ce07ba191ac8)
