### PR TITLE
Fix incorrect overflow in `UInt64.from_yaml`

### DIFF
--- a/spec/std/yaml/serializable_spec.cr
+++ b/spec/std/yaml/serializable_spec.cr
@@ -746,21 +746,21 @@ describe "YAML::Serializable" do
   end
 
   it "checks that values fit into integer types" do
-    expect_raises(YAML::ParseException, /Expected Int16/) do
+    expect_raises(YAML::ParseException, /Can't read Int16/) do
       YAMLAttrWithSmallIntegers.from_yaml(%({"foo": 21000000, "bar": 7}))
     end
 
-    expect_raises(YAML::ParseException, /Expected Int8/) do
+    expect_raises(YAML::ParseException, /Can't read Int8/) do
       YAMLAttrWithSmallIntegers.from_yaml(%({"foo": 21, "bar": 7000}))
     end
   end
 
   it "checks that non-integer values for integer fields report the expected type" do
-    expect_raises(YAML::ParseException, /Expected Int16, not "a"/) do
+    expect_raises(YAML::ParseException, /Can't read Int16/) do
       YAMLAttrWithSmallIntegers.from_yaml(%({"foo": "a", "bar": 7}))
     end
 
-    expect_raises(YAML::ParseException, /Expected Int8, not "a"/) do
+    expect_raises(YAML::ParseException, /Can't read Int8/) do
       YAMLAttrWithSmallIntegers.from_yaml(%({"foo": 21, "bar": "a"}))
     end
   end

--- a/spec/std/yaml/serialization_spec.cr
+++ b/spec/std/yaml/serialization_spec.cr
@@ -53,14 +53,32 @@ describe "YAML serialization" do
       end
     end
 
-    it "does Int32#from_yaml" do
-      Int32.from_yaml("123").should eq(123)
+    {% for int in [Int8, UInt8, Int16, UInt16, Int32, UInt32, Int64, UInt64] %}
+      it "does {{ int }}.from_yaml" do
+        {{ int }}.from_yaml("0").should(be_a({{ int }})).should eq(0)
+        {{ int }}.from_yaml("123").should(be_a({{ int }})).should eq(123)
+        {{ int }}.from_yaml({{ int }}::MIN.to_s).should(be_a({{ int }})).should eq({{ int }}::MIN)
+        {{ int }}.from_yaml({{ int }}::MAX.to_s).should(be_a({{ int }})).should eq({{ int }}::MAX)
+      end
+
+      it "raises if {{ int }}.from_yaml overflows" do
+        expect_raises(YAML::ParseException, "Can't read {{ int }}") do
+          {{ int }}.from_yaml(({{ int }}::MIN.to_big_i - 1).to_s)
+        end
+        expect_raises(YAML::ParseException, "Can't read {{ int }}") do
+          {{ int }}.from_yaml(({{ int }}::MAX.to_big_i + 1).to_s)
+        end
+      end
+    {% end %}
+
+    it "does Int.from_yaml with prefixes" do
       Int32.from_yaml("0xabc").should eq(0xabc)
       Int32.from_yaml("0b10110").should eq(0b10110)
+      Int32.from_yaml("0777").should eq(0o777)
     end
 
-    it "does Int64#from_yaml" do
-      Int64.from_yaml("123456789123456789").should eq(123456789123456789)
+    it "does Int.from_yaml with underscores" do
+      Int32.from_yaml("1_2_34").should eq(1_2_34)
     end
 
     it "does String#from_yaml" do


### PR DESCRIPTION
`UInt64.from_yaml` raises `YAML::ParseException` if the value is larger than `Int64::MAX`. This is because [the method relies on `YAML::Schema::Core.parse_scalar` which, being primarily intended for `YAML::Any`'s use, supports only `Int64`](https://github.com/crystal-lang/crystal/pull/5007#pullrequestreview-66271858). This PR fixes that by skipping `parse_scalar` altogether.

Note that `OverflowError` is never raised, since string-to-integer conversions raise `ArgumentError` instead, and there are no more integer-to-integer conversions.