### PR TITLE
Support YAML deserialization of 128-bit integers

### DIFF
--- a/spec/std/yaml/serialization_spec.cr
+++ b/spec/std/yaml/serialization_spec.cr
@@ -1,4 +1,5 @@
 require "../spec_helper"
+require "../../support/number"
 require "yaml"
 require "big"
 require "big/yaml"
@@ -53,7 +54,7 @@ describe "YAML serialization" do
       end
     end
 
-    {% for int in [Int8, UInt8, Int16, UInt16, Int32, UInt32, Int64, UInt64] %}
+    {% for int in BUILTIN_INTEGER_TYPES %}
       it "does {{ int }}.from_yaml" do
         {{ int }}.from_yaml("0").should(be_a({{ int }})).should eq(0)
         {{ int }}.from_yaml("123").should(be_a({{ int }})).should eq(123)

--- a/src/yaml/from_yaml.cr
+++ b/src/yaml/from_yaml.cr
@@ -57,7 +57,7 @@ def Bool.new(ctx : YAML::ParseContext, node : YAML::Nodes::Node)
   parse_scalar(ctx, node, self)
 end
 
-{% for type in %w(Int8 Int16 Int32 Int64 UInt8 UInt16 UInt32 UInt64) %}
+{% for type in %w(Int8 Int16 Int32 Int64 Int128 UInt8 UInt16 UInt32 UInt64 UInt128) %}
   def {{type.id}}.new(ctx : YAML::ParseContext, node : YAML::Nodes::Node)
     ctx.read_alias(node, {{type.id}}) do |obj|
       return obj


### PR DESCRIPTION
This is now straightforward after #13829.