### PR TITLE
Update specs for `Int::Primitive.from_json`

### DIFF
--- a/spec/std/json/serialization_spec.cr
+++ b/spec/std/json/serialization_spec.cr
@@ -1,4 +1,5 @@
 require "../spec_helper"
+require "../../support/number"
 require "spec/helpers/iterate"
 require "json"
 require "big"
@@ -36,22 +37,34 @@ describe "JSON serialization" do
       Path.from_json(%("foo/bar")).should eq(Path.new("foo/bar"))
     end
 
-    it "does UInt64.from_json" do
-      UInt64.from_json(UInt64::MAX.to_s).should eq(UInt64::MAX)
-    end
-
-    it "does UInt128.from_json" do
-      UInt128.from_json(UInt128::MAX.to_s).should eq(UInt128::MAX)
-    end
-
-    it "does Int128.from_json" do
-      Int128.from_json(Int128::MAX.to_s).should eq(Int128::MAX)
-    end
-
-    it "raises ParserException for overflow UInt64.from_json" do
-      expect_raises(JSON::ParseException, "Can't read UInt64 at line 0, column 0") do
-        UInt64.from_json("1#{UInt64::MAX}")
+    {% for int in BUILTIN_INTEGER_TYPES %}
+      it "does {{ int }}.from_json" do
+        {{ int }}.from_json("0").should(be_a({{ int }})).should eq(0)
+        {{ int }}.from_json("123").should(be_a({{ int }})).should eq(123)
+        {{ int }}.from_json({{ int }}::MIN.to_s).should(be_a({{ int }})).should eq({{ int }}::MIN)
+        {{ int }}.from_json({{ int }}::MAX.to_s).should(be_a({{ int }})).should eq({{ int }}::MAX)
       end
+
+      # NOTE: "Invalid" shows up only for `Int64`
+      it "raises if {{ int }}.from_json overflows" do
+        expect_raises(JSON::ParseException, /(Can't read|Invalid) {{ int }}/) do
+          {{ int }}.from_json(({{ int }}::MIN.to_big_i - 1).to_s)
+        end
+        expect_raises(JSON::ParseException, /(Can't read|Invalid) {{ int }}/) do
+          {{ int }}.from_json(({{ int }}::MAX.to_big_i + 1).to_s)
+        end
+      end
+    {% end %}
+
+    it "errors on non-base-10 ints" do
+      expect_raises(JSON::ParseException) { Int32.from_json "0b1" }
+      expect_raises(JSON::ParseException) { Int32.from_json "0o1" }
+      expect_raises(JSON::ParseException) { Int32.from_json "0x1" }
+      expect_raises(JSON::ParseException) { Int32.from_json "01" }
+    end
+
+    it "errors on underscores inside ints" do
+      expect_raises(JSON::ParseException) { Int32.from_json "1_2" }
     end
 
     it "does Array(Nil)#from_json" do


### PR DESCRIPTION
Makes those specs more or less identical to their YAML counterparts after #13834.