### PR TITLE
Fix docs dark mode dropdown background on blink

### DIFF
--- a/src/compiler/crystal/tools/doc/html/css/style.css
+++ b/src/compiler/crystal/tools/doc/html/css/style.css
@@ -1,3 +1,7 @@
+:root {
+  color-scheme: light dark;
+}
+
 html, body {
   background: #FFFFFF;
   position: relative;
@@ -794,10 +798,6 @@ img {
 }
 
 @media (prefers-color-scheme: dark) {
-  :root {
-    color-scheme: dark;
-  }
-
   html, body {
     background: #1b1b1b;
   }
@@ -822,6 +822,10 @@ img {
     color: white;
     background-color: #202020;
     border: 1px solid #353535;
+  }
+
+  .project-versions-nav > option {
+    background-color: #222;
   }
 
   .superclass-hierarchy .superclass a,


### PR DESCRIPTION
fix: #13839

the `color-scheme` moving to the top is not really relevant to the bug fix but it's clearer, I can revert it if needed

![image](https://github.com/crystal-lang/crystal/assets/18014039/d2ff0edb-9209-491a-8a91-95f14ef4194d)
