### PR TITLE
Refactor specs for `HTML.unescape`

### DIFF
--- a/spec/std/html_spec.cr
+++ b/spec/std/html_spec.cr
@@ -101,7 +101,7 @@ describe "HTML" do
     end
 
     it "invalid utf-8" do
-      expect_raises(ArgumentError, "UTF-8 error: illegal byte") do
+      expect_raises(ArgumentError, "UTF-8 error") do
         HTML.unescape("test \xff\xfe").should eq "test \xff\xfe"
       end
     end

--- a/spec/std/html_spec.cr
+++ b/spec/std/html_spec.cr
@@ -4,124 +4,106 @@ require "html"
 describe "HTML" do
   describe ".escape" do
     it "does not change a safe string" do
-      str = HTML.escape("safe_string")
-
-      str.should eq("safe_string")
+      HTML.escape("safe_string").should eq("safe_string")
     end
 
     it "escapes dangerous characters from a string" do
-      str = HTML.escape("< & > ' \"")
-
-      str.should eq("&lt; &amp; &gt; &#39; &quot;")
+      HTML.escape("< & > ' \"").should eq("&lt; &amp; &gt; &#39; &quot;")
     end
   end
 
   describe ".unescape" do
-    it "does not change a safe string" do
-      str = HTML.unescape("safe_string")
-
-      str.should eq("safe_string")
+    it "identity" do
+      HTML.unescape("safe_string").should be("safe_string")
     end
 
-    it "unescapes html special characters" do
-      str = HTML.unescape("&lt; &amp; &gt;")
+    it "empty entity" do
+      HTML.unescape("foo&;bar").should eq "foo&;bar"
+    end
 
-      str.should eq("< & >")
+    context "numeric entities" do
+      it "decimal" do
+        HTML.unescape("3 &#43; 2 &#00061 5").should eq("3 + 2 = 5")
+      end
+
+      it "hex" do
+        HTML.unescape("&#x000033; &#x2B; 2 &#x0003D &#x000035").should eq("3 + 2 = 5")
+      end
+
+      it "early termination" do
+        HTML.unescape("&# &#x &#128;43 &#169f &#xa9").should eq "&# &#x €43 ©f ©"
+      end
+
+      it "ISO-8859-1 replacement" do
+        HTML.unescape("&#x87;").should eq "‡"
+      end
+
+      it "does not unescape Char::MAX_CODEPOINT" do
+        # U+10FFFF and U+10FFFE are noncharacter and are not replaced
+        HTML.unescape("limit &#x10FFFF;").should eq("limit &#x10FFFF;")
+        HTML.unescape("limit &#x10FFFE;").should eq("limit &#x10FFFE;")
+        HTML.unescape("limit &#x10FFFD;").should eq("limit \u{10FFFD}")
+      end
+
+      it "does not unescape characters above Char::MAX_CODEPOINT" do
+        HTML.unescape("limit &#x110000;").should eq("limit \uFFFD")
+        HTML.unescape("limit &#1114112;").should eq("limit \uFFFD")
+      end
+
+      it "space characters" do
+        HTML.unescape("&#x0020;&#32;&#x0009;&#x000A;&#x000C;&#x0080;&#x009F;").should eq("  \t\n\f\u20AC\u0178")
+      end
+
+      it "does not escape non-space unicode control characters" do
+        HTML.unescape("&#x0001;-&#x001F; &#x000D; &#x007F;&#x000;").should eq("&#x0001;-&#x001F; &#x000D; &#x007F;\uFFFD")
+      end
+
+      it "does not escape noncharacter codepoints" do
+        # noncharacters http://www.unicode.org/faq/private_use.html
+        string = "&#xFDD0;-&#xFDEF; &#xFFFE; &#FFFF; &#x1FFFE; &#x1FFFF; &#x2FFFE; &#x10FFFF;"
+        HTML.unescape(string).should eq(string)
+      end
+
+      it "does not escape unicode surrogate characters" do
+        HTML.unescape("&#xD800;-&#xDFFF;").should eq("\uFFFD-\uFFFD")
+      end
+    end
+
+    context "named entities" do
+      it "simple named entities" do
+        HTML.unescape("&lt; &amp; &gt;").should eq("< & >")
+        HTML.unescape("nbsp&nbsp;space ").should eq("nbsp\u{0000A0}space ")
+      end
+
+      it "without trailing semicolon" do
+        HTML.unescape("&amphello").should eq("&hello")
+      end
+
+      it "end of string" do
+        HTML.unescape("&amp; &amp").should eq("& &")
+      end
+
+      it "multi codepoint" do
+        HTML.unescape(" &NotSquareSuperset; ").should eq(" ⊐̸ ")
+      end
+
+      it "invalid entities" do
+        HTML.unescape("&&lt;&amp&gt;&quot&abcdefghijklmn &ThisIsNotAnEntity;").should eq("&<&>\"&abcdefghijklmn &ThisIsNotAnEntity;")
+      end
+
+      it "entity with numerical characters" do
+        HTML.unescape("&frac34;").should eq("\u00BE")
+      end
     end
 
     it "unescapes javascript example from a string" do
-      str = HTML.unescape("&lt;script&gt;alert&#40;&#39;You are being hacked&#39;&#41;&lt;/script&gt;")
-
-      str.should eq("<script>alert('You are being hacked')</script>")
+      HTML.unescape("&lt;script&gt;alert&#40;&#39;You are being hacked&#39;&#41;&lt;/script&gt;").should eq("<script>alert('You are being hacked')</script>")
     end
 
-    it "unescapes decimal encoded chars" do
-      str = HTML.unescape("&lt;&#104;&#101llo world&gt;")
-
-      str.should eq("<hello world>")
-    end
-
-    it "unescapes with invalid entities" do
-      str = HTML.unescape("&&lt;&amp&gt;&quot&abcdefghijklmn &ThisIsNotAnEntity;")
-
-      str.should eq("&<&>\"&abcdefghijklmn &ThisIsNotAnEntity;")
-    end
-
-    it "unescapes hex encoded chars" do
-      str = HTML.unescape("3 &#x0002B; 2 &#x0003D 5")
-
-      str.should eq("3 + 2 = 5")
-    end
-
-    it "unescapes decimal encoded chars" do
-      str = HTML.unescape("3 &#00043; 2 &#00061 5")
-
-      str.should eq("3 + 2 = 5")
-    end
-
-    it "unescapes &nbsp;" do
-      str = HTML.unescape("nbsp&nbsp;space ")
-
-      str.should eq("nbsp\u{0000A0}space ")
-    end
-
-    it "does not unescape Char::MAX_CODEPOINT" do
-      # Char::MAX_CODEPOINT is actually a noncharacter and is not replaced
-      str = HTML.unescape("limit &#x10FFFF;")
-      str.should eq("limit &#x10FFFF;")
-
-      str = HTML.unescape("limit &#1114111;")
-      str.should eq("limit &#1114111;")
-    end
-
-    it "does not unescape characters above Char::MAX_CODEPOINT" do
-      str = HTML.unescape("limit &#x110000;")
-      str.should eq("limit \uFFFD")
-
-      str = HTML.unescape("limit &#1114112;")
-      str.should eq("limit \uFFFD")
-    end
-
-    it "unescapes &NotSquareSuperset;" do
-      str = HTML.unescape(" &NotSquareSuperset; ")
-
-      str.should eq(" ⊐̸ ")
-    end
-
-    it "unescapes entities without trailing semicolon" do
-      str = HTML.unescape("&amphello")
-      str.should eq("&hello")
-    end
-
-    it "unescapes named character reference with numerical characters" do
-      str = HTML.unescape("&frac34;")
-      str.should eq("\u00BE")
-    end
-
-    it "does not escape unicode control characters except space characters" do
-      string = "&#x0001;-&#x001F; &#x000D; &#x007F;"
-      HTML.unescape(string).should eq(string)
-
-      string = HTML.unescape("&#x0080;-&#x009F;")
-      string.should eq("\u20AC-\u0178")
-
-      HTML.unescape("&#x000;").should eq("\uFFFD")
-    end
-
-    it "escapes space characters" do
-      string = HTML.unescape("&#x0020;&#32;&#x0009;&#x000A;&#x000C;")
-      string.should eq("  \t\n\f")
-    end
-
-    it "does not escape noncharacter codepoints" do
-      # noncharacters http://www.unicode.org/faq/private_use.html
-      string = "&#xFDD0;-&#xFDEF; &#xFFFE; &#FFFF; &#x1FFFE; &#x1FFFF; &#x2FFFE; &#x10FFFF;"
-      HTML.unescape(string).should eq(string)
-    end
-
-    it "does not escape unicode surrogate characters" do
-      string = "&#xD800;-&#xDFFF;"
-      HTML.unescape(string).should eq("\uFFFD-\uFFFD")
+    it "invalid utf-8" do
+      expect_raises(ArgumentError, "UTF-8 error: illegal byte") do
+        HTML.unescape("test \xff\xfe").should eq "test \xff\xfe"
+      end
     end
   end
 end


### PR DESCRIPTION
The specs for `HTML.unescape` are improved by proper structuring and readjusting for conciseness.
Also adding some missing edge cases.