### PR TITLE
[CI] Refactor `crystal_bootstrap_version`

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -19,20 +19,24 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        crystal_bootstrap_version: [1.2.2, 1.3.2, 1.4.1, 1.5.1, 1.6.2]
-        flags: ["USE_PCRE1=true"]
+        crystal_bootstrap_version: [1.7.3, 1.8.2, 1.9.2]
+        flags: [""]
         include:
           # libffi is only available starting from the 1.2.2 build images
           - crystal_bootstrap_version: 1.0.0
             flags: "FLAGS=-Dwithout_ffi USE_PCRE1=true"
           - crystal_bootstrap_version: 1.1.1
             flags: "FLAGS=-Dwithout_ffi USE_PCRE1=true"
-          - crystal_bootstrap_version: 1.7.3
-            flags: ""
-          - crystal_bootstrap_version: 1.8.2
-            flags: ""
-          - crystal_bootstrap_version: 1.9.2
-            flags: ""
+          - crystal_bootstrap_version: 1.2.2
+            flags: "USE_PCRE1=true"
+          - crystal_bootstrap_version: 1.3.2
+            flags: "USE_PCRE1=true"
+          - crystal_bootstrap_version: 1.4.1
+            flags: "USE_PCRE1=true"
+          - crystal_bootstrap_version: 1.5.1
+            flags: "USE_PCRE1=true"
+          - crystal_bootstrap_version: 1.6.2
+            flags: "USE_PCRE1=true"
     steps:
       - name: Download Crystal source
         uses: actions/checkout@v4


### PR DESCRIPTION
This changes the configuration format so that the most recent versions are the regular format and older ones are special cases with the extra `USE_PCRE1=true` configuration.

There's also an initiative to drop CI for older versions alltogether (#12937) but this change does not do any of that sort. It just changes the configuration format, the result stays identical.