### PR TITLE
Add file context to IO errors in event loop

### DIFF
--- a/spec/std/file_spec.cr
+++ b/spec/std/file_spec.cr
@@ -929,7 +929,7 @@ describe "File" do
             pending! "Spec cannot run as superuser"
           end
         {% end %}
-        expect_raises(File::AccessDeniedError) { File.read(path) }
+        expect_raises(File::AccessDeniedError, path) { File.read(path) }
       end
     end
   {% end %}
@@ -946,7 +946,7 @@ describe "File" do
           pending! "Spec cannot run as superuser"
         end
       {% end %}
-      expect_raises(File::AccessDeniedError) { File.write(path, "foo") }
+      expect_raises(File::AccessDeniedError, path) { File.write(path, "foo") }
     end
   end
 

--- a/src/file/error.cr
+++ b/src/file/error.cr
@@ -24,6 +24,14 @@ class File::Error < IO::Error
     "#{message}: '#{file.inspect_unquoted}'"
   end
 
+  protected def self.build_message(message, *, file : File) : String
+    build_message(message, file: file.path)
+  end
+
+  protected def self.build_message(message, *, file) : String
+    build_message(message, file: file.to_s)
+  end
+
   protected def self.build_message(message, *, file : String, other : String) : String
     "#{message}: '#{file.inspect_unquoted}' -> '#{other.inspect_unquoted}'"
   end
@@ -38,6 +46,14 @@ class File::Error < IO::Error
       end
     end
   {% end %}
+
+  def self.new(message, *, file : File, other : String? = nil)
+    new(message, file: file.path, other: other)
+  end
+
+  def self.new(message, *, file, other : String? = nil)
+    new(message, file: file.to_s, other: other)
+  end
 
   def initialize(message, *, file : String | Path, @other : String? = nil)
     @file = file.to_s

--- a/src/io/evented.cr
+++ b/src/io/evented.cr
@@ -58,7 +58,7 @@ module IO::Evented
       if Errno.value == Errno::EAGAIN
         wait_readable
       else
-        raise IO::Error.from_errno(errno_msg)
+        raise File::Error.from_errno(errno_msg, file: self)
       end
     end
   ensure
@@ -79,7 +79,7 @@ module IO::Evented
           if Errno.value == Errno::EAGAIN
             wait_writable
           else
-            raise IO::Error.from_errno(errno_msg)
+            raise File::Error.from_errno(errno_msg, file: self)
           end
         end
       end

--- a/src/io/overlapped.cr
+++ b/src/io/overlapped.cr
@@ -52,12 +52,12 @@ module IO::Overlapped
       if timeout && error.wait_timeout?
         return true
       else
-        raise IO::Error.from_os_error("GetQueuedCompletionStatusEx", error)
+        raise File::Error.from_os_error("GetQueuedCompletionStatusEx", error)
       end
     end
 
     if removed == 0
-      raise IO::Error.new("GetQueuedCompletionStatusEx returned 0")
+      raise File::Error.new("GetQueuedCompletionStatusEx returned 0")
     end
 
     removed.times do |i|
@@ -112,7 +112,7 @@ module IO::Overlapped
         error = WinError.value
         yield error
 
-        raise IO::Error.from_os_error("GetOverlappedResult", error)
+        raise File::Error.from_os_error("GetOverlappedResult", error)
       end
 
       bytes
@@ -126,7 +126,7 @@ module IO::Overlapped
         error = WinError.wsa_value
         yield error
 
-        raise IO::Error.from_os_error("WSAGetOverlappedResult", error)
+        raise File::Error.from_os_error("WSAGetOverlappedResult", error)
       end
 
       bytes
@@ -190,9 +190,9 @@ module IO::Overlapped
         when .error_io_pending?
           # the operation is running asynchronously; do nothing
         when .error_access_denied?
-          raise IO::Error.new "File not open for #{writing ? "writing" : "reading"}"
+          raise File::Error.new "File not open for #{writing ? "writing" : "reading"}", file: self
         else
-          raise IO::Error.from_os_error(method, error)
+          raise File::Error.from_os_error(method, error, file: self)
         end
       else
         operation.synchronous = true
@@ -224,7 +224,7 @@ module IO::Overlapped
         when .wsa_io_pending?
           # the operation is running asynchronously; do nothing
         else
-          raise IO::Error.from_os_error(method, error)
+          raise File::Error.from_os_error(method, error, file: self)
         end
       else
         operation.synchronous = true


### PR DESCRIPTION
Errors on read/write operations in `evented.cr` and `overlapped.cr` did not convey any contextual information about the IO. It would just say that the operation failed, but not on what file. Other file-related errors already use `File::Error` with an associated `file` property.
This patch changes error in evented IO operations to `File::Error` with context information.

In contrast to file-only methods these are also used for `FileDescriptor` and `Socket` IO which do not have a file name. In these cases there's not much identifiable information.
An alternative solution could be to raise `File::Error` only for `File` instances, and `IO::Error` otherwise. This could be resolved with a private `raise` method that instantiates the appropriate class. We can still do that, but I started with the current patch which seemed to be the smaller change.

Note that the displayed file information is explicitly `File#path`, not `File#to_s` which is practically unusable.