### PR TITLE
Remove unnecessary file check for CLI arguments

### DIFF
--- a/src/compiler/crystal/command.cr
+++ b/src/compiler/crystal/command.cr
@@ -582,9 +582,6 @@ class Crystal::Command
 
   private def gather_sources(filenames)
     filenames.map do |filename|
-      unless File.file?(filename)
-        error "file '#{filename}' does not exist"
-      end
       filename = File.expand_path(filename)
       Compiler::Source.new(filename, File.read(filename))
     end


### PR DESCRIPTION
Resolves #13849

This patch momentarily degrades the error UX because read errors do not mention which file they appear on. That should improve with https://github.com/crystal-lang/crystal/pull/13852 though, so I'm not taking any extra measures here.