### PR TITLE
Workaround: do not use `IO::Descriptor` to load debug symbols

### DIFF
--- a/src/crystal/dwarf/abbrev.cr
+++ b/src/crystal/dwarf/abbrev.cr
@@ -237,7 +237,7 @@ module Crystal
         @children
       end
 
-      def self.read(io : IO::FileDescriptor, offset)
+      def self.read(io : SimpleFileDescriptor, offset)
         abbreviations = [] of Abbrev
 
         io.seek(io.tell + offset)

--- a/src/crystal/dwarf/info.cr
+++ b/src/crystal/dwarf/info.cr
@@ -15,7 +15,7 @@ module Crystal
       @offset : Int64
       @ref_offset : Int64
 
-      def initialize(@io : IO::FileDescriptor, @offset)
+      def initialize(@io : SimpleFileDescriptor, @offset)
         @ref_offset = offset
 
         @unit_length = @io.read_bytes(UInt32)

--- a/src/crystal/dwarf/line_numbers.cr
+++ b/src/crystal/dwarf/line_numbers.cr
@@ -172,7 +172,7 @@ module Crystal
 
       @offset : Int64
 
-      def initialize(@io : IO::FileDescriptor, size, @base_address : LibC::SizeT = 0, @strings : Strings? = nil, @line_strings : Strings? = nil)
+      def initialize(@io : SimpleFileDescriptor, size, @base_address : LibC::SizeT = 0, @strings : Strings? = nil, @line_strings : Strings? = nil)
         @offset = @io.tell
         @matrix = Array(Array(Row)).new
         decode_sequences(size)

--- a/src/crystal/dwarf/strings.cr
+++ b/src/crystal/dwarf/strings.cr
@@ -1,7 +1,7 @@
 module Crystal
   module DWARF
     struct Strings
-      def initialize(@io : IO::FileDescriptor, @offset : UInt32 | UInt64, size)
+      def initialize(@io : SimpleFileDescriptor, @offset : UInt32 | UInt64, size)
         # Read a good chunk of bytes to decode strings faster
         # (avoid seeking/reading the IO too many times)
         @buffer = Bytes.new(Math.max(16384, size))

--- a/src/crystal/elf.cr
+++ b/src/crystal/elf.cr
@@ -148,11 +148,11 @@ module Crystal
 
     def self.open(path, &)
       File.open(path, "r") do |file|
-        yield new(file)
+        yield new(SimpleFileDescriptor.new(file.fd))
       end
     end
 
-    def initialize(@io : IO::FileDescriptor)
+    def initialize(@io : SimpleFileDescriptor)
       read_magic
       read_ident
       read_header

--- a/src/crystal/mach_o.cr
+++ b/src/crystal/mach_o.cr
@@ -92,11 +92,11 @@ module Crystal
 
     def self.open(path, &)
       File.open(path, "r") do |file|
-        yield new(file)
+        yield new(SimpleFileDescriptor.new(file.fd))
       end
     end
 
-    def initialize(@io : IO::FileDescriptor)
+    def initialize(@io : SimpleFileDescriptor)
       @magic = read_magic
       @cputype = CpuType.new(@io.read_bytes(Int32, endianness))
       @cpusubtype = @io.read_bytes(Int32, endianness)

--- a/src/crystal/simple_file_descriptor.cr
+++ b/src/crystal/simple_file_descriptor.cr
@@ -9,7 +9,7 @@ module Crystal
     end
 
     def read(slice : Bytes)
-      LibC.read(@fd, slice, slice.size)
+      LibC.read(@fd, slice, slice.size).to_i
     end
 
     def write(slice : Bytes) : Nil
@@ -22,6 +22,7 @@ module Crystal
 
     def pos=(value)
       seek(value)
+      value
     end
 
     def seek(offset, whence : Seek = Seek::Set)

--- a/src/crystal/simple_file_descriptor.cr
+++ b/src/crystal/simple_file_descriptor.cr
@@ -1,0 +1,41 @@
+module Crystal
+  # This "simple" wrapper over a file descriptor calls the C I/O functions
+  # directly, without going through `IO::Buffered` or `IO::Evented`. This is
+  # necessary deep inside the Crystal runtime to break a method call loop where
+  # `IO::Buffered#read` calls itself and leads to type inference problems, see
+  # https://github.com/crystal-lang/crystal/issues/8163#issuecomment-1748962979
+  class SimpleFileDescriptor < IO
+    def initialize(@fd : Int32)
+    end
+
+    def read(slice : Bytes)
+      LibC.read(@fd, slice, slice.size)
+    end
+
+    def write(slice : Bytes) : Nil
+      LibC.write(@fd, slice, slice.size)
+    end
+
+    def pos
+      LibC.lseek(@fd, 0, IO::Seek::Current).to_i64
+    end
+
+    def pos=(value)
+      seek(value)
+    end
+
+    def seek(offset, whence : Seek = Seek::Set)
+      LibC.lseek(@fd, offset, whence)
+    end
+
+    def seek(offset, whence : Seek = Seek::Set, &)
+      original_pos = tell
+      begin
+        seek(offset, whence)
+        yield
+      ensure
+        seek(original_pos)
+      end
+    end
+  end
+end

--- a/src/io/file_descriptor.cr
+++ b/src/io/file_descriptor.cr
@@ -1,4 +1,5 @@
 require "crystal/system/file_descriptor"
+require "crystal/simple_file_descriptor"
 
 # An `IO` over a file descriptor.
 class IO::FileDescriptor < IO


### PR DESCRIPTION
Fixes #8163. Fixes #13720. Fixes #13792. The underlying codegen issue is not fixed here.

Although this might not have the best performance, `Exception::CallStack.load_debug_info` is only called at most once for each process. I have not performed any benchmarks.