### PR TITLE
Change `IO::Buffered#peek`'s return type to `Bytes`

### DIFF
--- a/src/io/buffered.cr
+++ b/src/io/buffered.cr
@@ -98,7 +98,7 @@ module IO::Buffered
   # peek data if the current buffer is empty:
   # otherwise no read is performed and whatever
   # is in the buffer is returned.
-  def peek : Bytes?
+  def peek : Bytes
     check_open
 
     if @in_buffer_rem.empty?


### PR DESCRIPTION
Fixes #8163. Fixes #13720. Fixes #13792. It is marked as a regression because #11242 introduced new code paths on master that call `IO::Buffered#peek`.

Here `Bytes.empty` and `IO::Buffered#@in_buffer_rem` are both `Byte`s, so indeed the def can never return nil.

The underlying compiler bug is not affected. For an explanation of the bug see #13862.