### PR TITLE
Fix tool init error message when target exists but not a dir

### DIFF
--- a/src/compiler/crystal/tools/init.cr
+++ b/src/compiler/crystal/tools/init.cr
@@ -238,8 +238,8 @@ module Crystal
       end
 
       def run
-        if File.file?(config.expanded_dir)
-          raise Error.new "#{config.dir.inspect} is a file"
+        if (info = File.info?(config.expanded_dir)) && !info.directory?
+          raise Error.new "#{config.dir.inspect} is a #{info.type.to_s.downcase}"
         end
 
         views = self.views


### PR DESCRIPTION
The current implementation using `File.file?` checks only if the lib directory is an ordinary file. But only directory is allowed. Other file types (special device, named pipe) are as invalid as an ordinary file.

This patch changes the check to succeed only if the path does not exists or is a directory.