### PR TITLE
Use `LibGMP::SI` and `UI` for size checks, not `Long` and `ULong`

### DIFF
--- a/spec/std/big/big_int_spec.cr
+++ b/spec/std/big/big_int_spec.cr
@@ -193,7 +193,7 @@ describe "BigInt" do
 
   it "raises if factorial of 2^64" do
     expect_raises ArgumentError do
-      (LibGMP::ULong::MAX.to_big_i + 1).factorial
+      (LibGMP::UI::MAX.to_big_i + 1).factorial
     end
   end
 

--- a/src/big/big_float.cr
+++ b/src/big/big_float.cr
@@ -43,9 +43,9 @@ struct BigFloat < Float
   def initialize(num : Int)
     Int.primitive_si_ui_check(num) do |si, ui, big_i|
       {
-        LibGMP.mpf_init_set_si(out @mpf, {{ si }}),
-        LibGMP.mpf_init_set_ui(out @mpf, {{ ui }}),
-        begin
+        si: LibGMP.mpf_init_set_si(out @mpf, {{ si }}),
+        ui: LibGMP.mpf_init_set_ui(out @mpf, {{ ui }}),
+        big_i: begin
           LibGMP.mpf_init(out @mpf)
           LibGMP.mpf_set_z(self, {{ big_i }})
         end,
@@ -103,9 +103,9 @@ struct BigFloat < Float
   def <=>(other : Int)
     Int.primitive_si_ui_check(other) do |si, ui, big_i|
       {
-        LibGMP.mpf_cmp_si(self, {{ si }}),
-        LibGMP.mpf_cmp_ui(self, {{ ui }}),
-        self <=> {{ big_i }},
+        si: LibGMP.mpf_cmp_si(self, {{ si }}),
+        ui: LibGMP.mpf_cmp_ui(self, {{ ui }}),
+        big_i: self <=> {{ big_i }},
       }
     end
   end

--- a/src/big/big_float.cr
+++ b/src/big/big_float.cr
@@ -43,8 +43,8 @@ struct BigFloat < Float
   def initialize(num : Int)
     Int.primitive_si_ui_check(num) do |si, ui, big_i|
       {
-        si: LibGMP.mpf_init_set_si(out @mpf, {{ si }}),
-        ui: LibGMP.mpf_init_set_ui(out @mpf, {{ ui }}),
+        si:    LibGMP.mpf_init_set_si(out @mpf, {{ si }}),
+        ui:    LibGMP.mpf_init_set_ui(out @mpf, {{ ui }}),
         big_i: begin
           LibGMP.mpf_init(out @mpf)
           LibGMP.mpf_set_z(self, {{ big_i }})
@@ -103,8 +103,8 @@ struct BigFloat < Float
   def <=>(other : Int)
     Int.primitive_si_ui_check(other) do |si, ui, big_i|
       {
-        si: LibGMP.mpf_cmp_si(self, {{ si }}),
-        ui: LibGMP.mpf_cmp_ui(self, {{ ui }}),
+        si:    LibGMP.mpf_cmp_si(self, {{ si }}),
+        ui:    LibGMP.mpf_cmp_ui(self, {{ ui }}),
         big_i: self <=> {{ big_i }},
       }
     end

--- a/src/big/big_float.cr
+++ b/src/big/big_float.cr
@@ -40,29 +40,16 @@ struct BigFloat < Float
     LibGMP.mpf_set(self, num)
   end
 
-  def initialize(num : Int8 | Int16 | Int32)
-    LibGMP.mpf_init_set_si(out @mpf, num)
-  end
-
-  def initialize(num : UInt8 | UInt16 | UInt32)
-    LibGMP.mpf_init_set_ui(out @mpf, num)
-  end
-
-  def initialize(num : Int64)
-    if LibGMP::Long == Int64
-      LibGMP.mpf_init_set_si(out @mpf, num)
-    else
-      LibGMP.mpf_init(out @mpf)
-      LibGMP.mpf_set_z(self, num.to_big_i)
-    end
-  end
-
-  def initialize(num : UInt64)
-    if LibGMP::ULong == UInt64
-      LibGMP.mpf_init_set_ui(out @mpf, num)
-    else
-      LibGMP.mpf_init(out @mpf)
-      LibGMP.mpf_set_z(self, num.to_big_i)
+  def initialize(num : Int)
+    Int.primitive_si_ui_check(num) do |si, ui, big_i|
+      {
+        LibGMP.mpf_init_set_si(out @mpf, {{ si }}),
+        LibGMP.mpf_init_set_ui(out @mpf, {{ ui }}),
+        begin
+          LibGMP.mpf_init(out @mpf)
+          LibGMP.mpf_set_z(self, {{ big_i }})
+        end,
+      }
     end
   end
 
@@ -113,14 +100,18 @@ struct BigFloat < Float
     LibGMP.mpf_cmp_d(self, other) unless other.nan?
   end
 
-  def <=>(other : Number)
-    if other.is_a?(Int8 | Int16 | Int32) || (LibGMP::Long == Int64 && other.is_a?(Int64))
-      LibGMP.mpf_cmp_si(self, other)
-    elsif other.is_a?(UInt8 | UInt16 | UInt32) || (LibGMP::ULong == UInt64 && other.is_a?(UInt64))
-      LibGMP.mpf_cmp_ui(self, other)
-    else
-      LibGMP.mpf_cmp(self, other.to_big_f)
+  def <=>(other : Int)
+    Int.primitive_si_ui_check(other) do |si, ui, big_i|
+      {
+        LibGMP.mpf_cmp_si(self, {{ si }}),
+        LibGMP.mpf_cmp_ui(self, {{ ui }}),
+        self <=> {{ big_i }},
+      }
     end
+  end
+
+  def <=>(other : Number)
+    LibGMP.mpf_cmp(self, other.to_big_f)
   end
 
   def - : BigFloat

--- a/src/big/big_int.cr
+++ b/src/big/big_int.cr
@@ -166,9 +166,9 @@ struct BigInt < Int
   def +(other : Int) : BigInt
     Int.primitive_ui_check(other) do |ui, neg_ui, big_i|
       {
-        BigInt.new { |mpz| LibGMP.add_ui(mpz, self, {{ ui }}) },
-        BigInt.new { |mpz| LibGMP.sub_ui(mpz, self, {{ neg_ui }}) },
-        self + {{ big_i }},
+        ui: BigInt.new { |mpz| LibGMP.add_ui(mpz, self, {{ ui }}) },
+        neg_ui: BigInt.new { |mpz| LibGMP.sub_ui(mpz, self, {{ neg_ui }}) },
+        big_i: self + {{ big_i }},
       }
     end
   end
@@ -184,9 +184,9 @@ struct BigInt < Int
   def -(other : Int) : BigInt
     Int.primitive_ui_check(other) do |ui, neg_ui, big_i|
       {
-        BigInt.new { |mpz| LibGMP.sub_ui(mpz, self, {{ ui }}) },
-        BigInt.new { |mpz| LibGMP.add_ui(mpz, self, {{ neg_ui }}) },
-        self - {{ big_i }},
+        ui: BigInt.new { |mpz| LibGMP.sub_ui(mpz, self, {{ ui }}) },
+        neg_ui: BigInt.new { |mpz| LibGMP.add_ui(mpz, self, {{ neg_ui }}) },
+        big_i: self - {{ big_i }},
       }
     end
   end
@@ -253,9 +253,9 @@ struct BigInt < Int
   def unsafe_floored_div(other : Int) : BigInt
     Int.primitive_ui_check(other) do |ui, neg_ui, big_i|
       {
-        BigInt.new { |mpz| LibGMP.fdiv_q_ui(mpz, self, {{ ui }}) },
-        BigInt.new { |mpz| LibGMP.fdiv_q_ui(mpz, -self, {{ neg_ui }}) },
-        unsafe_floored_div({{ big_i }}),
+        ui: BigInt.new { |mpz| LibGMP.fdiv_q_ui(mpz, self, {{ ui }}) },
+        neg_ui: BigInt.new { |mpz| LibGMP.fdiv_q_ui(mpz, -self, {{ neg_ui }}) },
+        big_i: unsafe_floored_div({{ big_i }}),
       }
     end
   end
@@ -267,9 +267,9 @@ struct BigInt < Int
   def unsafe_truncated_div(other : Int) : BigInt
     Int.primitive_ui_check(other) do |ui, neg_ui, big_i|
       {
-        BigInt.new { |mpz| LibGMP.tdiv_q_ui(mpz, self, {{ ui }}) },
-        BigInt.new { |mpz| LibGMP.tdiv_q_ui(mpz, self, {{ neg_ui }}); LibGMP.neg(mpz, mpz) },
-        unsafe_truncated_div({{ big_i }}),
+        ui: BigInt.new { |mpz| LibGMP.tdiv_q_ui(mpz, self, {{ ui }}) },
+        neg_ui: BigInt.new { |mpz| LibGMP.tdiv_q_ui(mpz, self, {{ neg_ui }}); LibGMP.neg(mpz, mpz) },
+        big_i: unsafe_truncated_div({{ big_i }}),
       }
     end
   end
@@ -299,9 +299,9 @@ struct BigInt < Int
   def unsafe_floored_mod(other : Int) : BigInt
     Int.primitive_ui_check(other) do |ui, neg_ui, big_i|
       {
-        BigInt.new { |mpz| LibGMP.fdiv_r_ui(mpz, self, {{ ui }}) },
-        BigInt.new { |mpz| LibGMP.fdiv_r_ui(mpz, self, {{ neg_ui }}); LibGMP.neg(mpz, mpz) },
-        unsafe_floored_mod({{ big_i }}),
+        ui: BigInt.new { |mpz| LibGMP.fdiv_r_ui(mpz, self, {{ ui }}) },
+        neg_ui: BigInt.new { |mpz| LibGMP.fdiv_r_ui(mpz, self, {{ neg_ui }}); LibGMP.neg(mpz, mpz) },
+        big_i: unsafe_floored_mod({{ big_i }}),
       }
     end
   end
@@ -313,9 +313,9 @@ struct BigInt < Int
   def unsafe_truncated_mod(other : Int) : BigInt
     Int.primitive_ui_check(other) do |ui, neg_ui, big_i|
       {
-        BigInt.new { |mpz| LibGMP.tdiv_r_ui(mpz, self, {{ ui }}) },
-        BigInt.new { |mpz| LibGMP.tdiv_r_ui(mpz, self, {{ neg_ui }}) },
-        unsafe_truncated_mod({{ big_i }}),
+        ui: BigInt.new { |mpz| LibGMP.tdiv_r_ui(mpz, self, {{ ui }}) },
+        neg_ui: BigInt.new { |mpz| LibGMP.tdiv_r_ui(mpz, self, {{ neg_ui }}) },
+        big_i: unsafe_truncated_mod({{ big_i }}),
       }
     end
   end
@@ -330,9 +330,9 @@ struct BigInt < Int
     the_q = BigInt.new
     the_r = Int.primitive_ui_check(number) do |ui, neg_ui, big_i|
       {
-        BigInt.new { |r| LibGMP.fdiv_qr_ui(the_q, r, self, {{ ui }}) },
-        BigInt.new { |r| LibGMP.fdiv_qr_ui(the_q, r, -self, {{ neg_ui }}); LibGMP.neg(r, r) },
-        BigInt.new { |r| LibGMP.fdiv_qr(the_q, r, self, {{ big_i }}) },
+        ui: BigInt.new { |r| LibGMP.fdiv_qr_ui(the_q, r, self, {{ ui }}) },
+        neg_ui: BigInt.new { |r| LibGMP.fdiv_qr_ui(the_q, r, -self, {{ neg_ui }}); LibGMP.neg(r, r) },
+        big_i: BigInt.new { |r| LibGMP.fdiv_qr(the_q, r, self, {{ big_i }}) },
       }
     end
     {the_q, the_r}
@@ -348,9 +348,9 @@ struct BigInt < Int
     the_q = BigInt.new
     the_r = Int.primitive_ui_check(number) do |ui, neg_ui, big_i|
       {
-        BigInt.new { |r| LibGMP.tdiv_qr_ui(the_q, r, self, {{ ui }}) },
-        BigInt.new { |r| LibGMP.tdiv_qr_ui(the_q, r, self, {{ neg_ui }}); LibGMP.neg(the_q, the_q) },
-        BigInt.new { |r| LibGMP.tdiv_qr(the_q, r, self, {{ big_i }}) },
+        ui: BigInt.new { |r| LibGMP.tdiv_qr_ui(the_q, r, self, {{ ui }}) },
+        neg_ui: BigInt.new { |r| LibGMP.tdiv_qr_ui(the_q, r, self, {{ neg_ui }}); LibGMP.neg(the_q, the_q) },
+        big_i: BigInt.new { |r| LibGMP.tdiv_qr(the_q, r, self, {{ big_i }}) },
       }
     end
     {the_q, the_r}
@@ -363,9 +363,9 @@ struct BigInt < Int
   def divisible_by?(number : Int) : Bool
     Int.primitive_ui_check(number) do |ui, neg_ui, big_i|
       {
-        LibGMP.divisible_ui_p(self, {{ ui }}) != 0,
-        LibGMP.divisible_ui_p(self, {{ neg_ui }}) != 0,
-        divisible_by?({{ big_i }}),
+        ui: LibGMP.divisible_ui_p(self, {{ ui }}) != 0,
+        neg_ui: LibGMP.divisible_ui_p(self, {{ neg_ui }}) != 0,
+        big_i: divisible_by?({{ big_i }}),
       }
     end
   end
@@ -431,15 +431,15 @@ struct BigInt < Int
   def gcd(other : Int) : Int
     Int.primitive_ui_check(other) do |ui, neg_ui, big_i|
       {
-        begin
+        ui: begin
           result = LibGMP.gcd_ui(nil, self, {{ ui }})
           result == 0 ? self : result
         end,
-        begin
+        neg_ui: begin
           result = LibGMP.gcd_ui(nil, self, {{ neg_ui }})
           result == 0 ? self : result
         end,
-        gcd({{ big_i }}),
+        big_i: gcd({{ big_i }}),
       }
     end
   end
@@ -453,9 +453,9 @@ struct BigInt < Int
   def lcm(other : Int) : BigInt
     Int.primitive_ui_check(other) do |ui, neg_ui, big_i|
       {
-        BigInt.new { |mpz| LibGMP.lcm_ui(mpz, self, {{ ui }}) },
-        BigInt.new { |mpz| LibGMP.lcm_ui(mpz, self, {{ neg_ui }}) },
-        lcm({{ big_i }}),
+        ui: BigInt.new { |mpz| LibGMP.lcm_ui(mpz, self, {{ ui }}) },
+        neg_ui: BigInt.new { |mpz| LibGMP.lcm_ui(mpz, self, {{ neg_ui }}) },
+        big_i: lcm({{ big_i }}),
       }
     end
   end
@@ -808,9 +808,9 @@ struct Int
   def -(other : BigInt) : BigInt
     Int.primitive_ui_check(self) do |ui, neg_ui, big_i|
       {
-        BigInt.new { |mpz| LibGMP.neg(mpz, other); LibGMP.add_ui(mpz, mpz, {{ ui }}) },
-        BigInt.new { |mpz| LibGMP.neg(mpz, other); LibGMP.sub_ui(mpz, mpz, {{ neg_ui }}) },
-        {{ big_i }} - other,
+        ui: BigInt.new { |mpz| LibGMP.neg(mpz, other); LibGMP.add_ui(mpz, mpz, {{ ui }}) },
+        neg_ui: BigInt.new { |mpz| LibGMP.neg(mpz, other); LibGMP.sub_ui(mpz, mpz, {{ neg_ui }}) },
+        big_i: {{ big_i }} - other,
       }
     end
   end

--- a/src/big/big_int.cr
+++ b/src/big/big_int.cr
@@ -48,29 +48,33 @@ struct BigInt < Int
 
   # Creates a `BigInt` from the given *num*.
   def self.new(num : Int::Primitive)
-    if LibGMP::SI::MIN <= num <= LibGMP::UI::MAX
-      if num <= LibGMP::SI::MAX
-        LibGMP.init_set_si(out mpz1, LibGMP::SI.new!(num))
-        new(mpz1)
-      else
-        LibGMP.init_set_ui(out mpz2, LibGMP::UI.new!(num))
-        new(mpz2)
-      end
-    else
-      negative = num < 0
-      num = num.abs_unsigned
-      capacity = (num.bit_length - 1) // (sizeof(LibGMP::MpLimb) * 8) + 1
+    Int.primitive_si_ui_check(num) do |si, ui, _|
+      {
+        begin
+          LibGMP.init_set_si(out mpz1, {{ si }})
+          new(mpz1)
+        end,
+        begin
+          LibGMP.init_set_ui(out mpz2, {{ ui }})
+          new(mpz2)
+        end,
+        begin
+          negative = num < 0
+          num = num.abs_unsigned
+          capacity = (num.bit_length - 1) // (sizeof(LibGMP::MpLimb) * 8) + 1
 
-      # This assumes GMP wasn't built with its experimental nails support:
-      # https://gmplib.org/manual/Low_002dlevel-Functions
-      unsafe_build(capacity) do |limbs|
-        appender = limbs.to_unsafe.appender
-        limbs.size.times do
-          appender << LibGMP::MpLimb.new!(num)
-          num = num.unsafe_shr(sizeof(LibGMP::MpLimb) * 8)
-        end
-        {capacity, negative}
-      end
+          # This assumes GMP wasn't built with its experimental nails support:
+          # https://gmplib.org/manual/Low_002dlevel-Functions
+          unsafe_build(capacity) do |limbs|
+            appender = limbs.to_unsafe.appender
+            limbs.size.times do
+              appender << LibGMP::MpLimb.new!(num)
+              num = num.unsafe_shr(sizeof(LibGMP::MpLimb) * 8)
+            end
+            {capacity, negative}
+          end
+        end,
+      }
     end
   end
 
@@ -141,19 +145,13 @@ struct BigInt < Int
     LibGMP.cmp(mpz, other)
   end
 
-  def <=>(other : Int::Signed)
-    if LibC::Long::MIN <= other <= LibC::Long::MAX
-      LibGMP.cmp_si(mpz, other)
-    else
-      self <=> BigInt.new(other)
-    end
-  end
-
-  def <=>(other : Int::Unsigned)
-    if other <= LibC::ULong::MAX
-      LibGMP.cmp_ui(mpz, other)
-    else
-      self <=> BigInt.new(other)
+  def <=>(other : Int)
+    Int.primitive_si_ui_check(other) do |si, ui, big_i|
+      {
+        LibGMP.cmp_si(self, {{ si }}),
+        LibGMP.cmp_ui(self, {{ ui }}),
+        self <=> {{ big_i }},
+      }
     end
   end
 
@@ -166,12 +164,12 @@ struct BigInt < Int
   end
 
   def +(other : Int) : BigInt
-    if other < 0
-      self - other.abs
-    elsif other <= LibGMP::ULong::MAX
-      BigInt.new { |mpz| LibGMP.add_ui(mpz, self, other) }
-    else
-      self + other.to_big_i
+    Int.primitive_ui_check(other) do |ui, neg_ui, big_i|
+      {
+        BigInt.new { |mpz| LibGMP.add_ui(mpz, self, {{ ui }}) },
+        BigInt.new { |mpz| LibGMP.sub_ui(mpz, self, {{ neg_ui }}) },
+        self + {{ big_i }},
+      }
     end
   end
 
@@ -184,12 +182,12 @@ struct BigInt < Int
   end
 
   def -(other : Int) : BigInt
-    if other < 0
-      self + other.abs
-    elsif other <= LibGMP::ULong::MAX
-      BigInt.new { |mpz| LibGMP.sub_ui(mpz, self, other) }
-    else
-      self - other.to_big_i
+    Int.primitive_ui_check(other) do |ui, neg_ui, big_i|
+      {
+        BigInt.new { |mpz| LibGMP.sub_ui(mpz, self, {{ ui }}) },
+        BigInt.new { |mpz| LibGMP.add_ui(mpz, self, {{ neg_ui }}) },
+        self - {{ big_i }},
+      }
     end
   end
 
@@ -208,26 +206,24 @@ struct BigInt < Int
   def factorial : BigInt
     if self < 0
       raise ArgumentError.new("Factorial not defined for negative values")
-    elsif self > LibGMP::ULong::MAX
-      raise ArgumentError.new("Factorial not supported for numbers bigger than 2^64")
+    elsif self > LibGMP::UI::MAX
+      raise ArgumentError.new("Factorial not supported for numbers bigger than #{LibGMP::UI::MAX}")
     end
-    BigInt.new { |mpz| LibGMP.fac_ui(mpz, self) }
+    BigInt.new { |mpz| LibGMP.fac_ui(mpz, LibGMP::UI.new!(self)) }
   end
 
   def *(other : BigInt) : BigInt
     BigInt.new { |mpz| LibGMP.mul(mpz, self, other) }
   end
 
-  def *(other : LibGMP::IntPrimitiveSigned) : BigInt
-    BigInt.new { |mpz| LibGMP.mul_si(mpz, self, other) }
-  end
-
-  def *(other : LibGMP::IntPrimitiveUnsigned) : BigInt
-    BigInt.new { |mpz| LibGMP.mul_ui(mpz, self, other) }
-  end
-
   def *(other : Int) : BigInt
-    self * other.to_big_i
+    Int.primitive_si_ui_check(other) do |si, ui, big_i|
+      {
+        BigInt.new { |mpz| LibGMP.mul_si(mpz, self, {{ si }}) },
+        BigInt.new { |mpz| LibGMP.mul_ui(mpz, self, {{ ui }}) },
+        self * {{ big_i }},
+      }
+    end
   end
 
   def &*(other) : BigInt
@@ -238,19 +234,10 @@ struct BigInt < Int
   Number.expand_div [BigDecimal], BigDecimal
   Number.expand_div [BigRational], BigRational
 
-  def //(other : Int::Unsigned) : BigInt
-    check_division_by_zero other
-    unsafe_floored_div(other)
-  end
-
   def //(other : Int) : BigInt
     check_division_by_zero other
 
-    if other < 0
-      (-self).unsafe_floored_div(-other)
-    else
-      unsafe_floored_div(other)
-    end
+    unsafe_floored_div(other)
   end
 
   def tdiv(other : Int) : BigInt
@@ -264,12 +251,12 @@ struct BigInt < Int
   end
 
   def unsafe_floored_div(other : Int) : BigInt
-    if LibGMP::ULong == UInt32 && (other < Int32::MIN || other > UInt32::MAX)
-      unsafe_floored_div(other.to_big_i)
-    elsif other < 0
-      -BigInt.new { |mpz| LibGMP.fdiv_q_ui(mpz, self, other.abs) }
-    else
-      BigInt.new { |mpz| LibGMP.fdiv_q_ui(mpz, self, other) }
+    Int.primitive_ui_check(other) do |ui, neg_ui, big_i|
+      {
+        BigInt.new { |mpz| LibGMP.fdiv_q_ui(mpz, self, {{ ui }}) },
+        BigInt.new { |mpz| LibGMP.fdiv_q_ui(mpz, -self, {{ neg_ui }}) },
+        unsafe_floored_div({{ big_i }}),
+      }
     end
   end
 
@@ -278,23 +265,19 @@ struct BigInt < Int
   end
 
   def unsafe_truncated_div(other : Int) : BigInt
-    if LibGMP::ULong == UInt32 && (other < Int32::MIN || other > UInt32::MAX)
-      unsafe_truncated_div(other.to_big_i)
-    elsif other < 0
-      -BigInt.new { |mpz| LibGMP.tdiv_q_ui(mpz, self, other.abs) }
-    else
-      BigInt.new { |mpz| LibGMP.tdiv_q_ui(mpz, self, other) }
+    Int.primitive_ui_check(other) do |ui, neg_ui, big_i|
+      {
+        BigInt.new { |mpz| LibGMP.tdiv_q_ui(mpz, self, {{ ui }}) },
+        BigInt.new { |mpz| LibGMP.tdiv_q_ui(mpz, self, {{ neg_ui }}); LibGMP.neg(mpz, mpz) },
+        unsafe_truncated_div({{ big_i }}),
+      }
     end
   end
 
   def %(other : Int) : BigInt
     check_division_by_zero other
 
-    if other < 0
-      -(-self).unsafe_floored_mod(other.abs)
-    else
-      unsafe_floored_mod(other)
-    end
+    unsafe_floored_mod(other)
   end
 
   def remainder(other : Int) : BigInt
@@ -303,33 +286,10 @@ struct BigInt < Int
     unsafe_truncated_mod(other)
   end
 
-  def divmod(number : BigInt) : {BigInt, BigInt}
+  def divmod(number : Int) : {BigInt, BigInt}
     check_division_by_zero number
 
     unsafe_floored_divmod(number)
-  end
-
-  def divmod(number : LibGMP::ULong)
-    check_division_by_zero number
-    unsafe_floored_divmod(number)
-  end
-
-  def divmod(number : Int::Signed) : {BigInt, BigInt}
-    check_division_by_zero number
-    if number > 0 && number <= LibC::Long::MAX
-      unsafe_floored_divmod(LibGMP::ULong.new(number))
-    else
-      divmod(number.to_big_i)
-    end
-  end
-
-  def divmod(number : Int::Unsigned)
-    check_division_by_zero number
-    if number <= LibC::ULong::MAX
-      unsafe_floored_divmod(LibGMP::ULong.new(number))
-    else
-      divmod(number.to_big_i)
-    end
   end
 
   def unsafe_floored_mod(other : BigInt) : BigInt
@@ -337,12 +297,12 @@ struct BigInt < Int
   end
 
   def unsafe_floored_mod(other : Int) : BigInt
-    if (other < LibGMP::Long::MIN || other > LibGMP::ULong::MAX)
-      unsafe_floored_mod(other.to_big_i)
-    elsif other < 0
-      -BigInt.new { |mpz| LibGMP.fdiv_r_ui(mpz, self, other.abs) }
-    else
-      BigInt.new { |mpz| LibGMP.fdiv_r_ui(mpz, self, other) }
+    Int.primitive_ui_check(other) do |ui, neg_ui, big_i|
+      {
+        BigInt.new { |mpz| LibGMP.fdiv_r_ui(mpz, self, {{ ui }}) },
+        BigInt.new { |mpz| LibGMP.fdiv_r_ui(mpz, self, {{ neg_ui }}); LibGMP.neg(mpz, mpz) },
+        unsafe_floored_mod({{ big_i }}),
+      }
     end
   end
 
@@ -350,12 +310,14 @@ struct BigInt < Int
     BigInt.new { |mpz| LibGMP.tdiv_r(mpz, self, other) }
   end
 
-  def unsafe_truncated_mod(other : LibGMP::IntPrimitive) : BigInt
-    BigInt.new { |mpz| LibGMP.tdiv_r_ui(mpz, self, other.abs) }
-  end
-
   def unsafe_truncated_mod(other : Int) : BigInt
-    BigInt.new { |mpz| LibGMP.tdiv_r_ui(mpz, self, other.abs.to_big_i) }
+    Int.primitive_ui_check(other) do |ui, neg_ui, big_i|
+      {
+        BigInt.new { |mpz| LibGMP.tdiv_r_ui(mpz, self, {{ ui }}) },
+        BigInt.new { |mpz| LibGMP.tdiv_r_ui(mpz, self, {{ neg_ui }}) },
+        unsafe_truncated_mod({{ big_i }}),
+      }
+    end
   end
 
   def unsafe_floored_divmod(number : BigInt) : {BigInt, BigInt}
@@ -364,9 +326,15 @@ struct BigInt < Int
     {the_q, the_r}
   end
 
-  def unsafe_floored_divmod(number : LibGMP::ULong) : {BigInt, BigInt}
+  def unsafe_floored_divmod(number : Int) : {BigInt, BigInt}
     the_q = BigInt.new
-    the_r = BigInt.new { |r| LibGMP.fdiv_qr_ui(the_q, r, self, number) }
+    the_r = Int.primitive_ui_check(number) do |ui, neg_ui, big_i|
+      {
+        BigInt.new { |r| LibGMP.fdiv_qr_ui(the_q, r, self, {{ ui }}) },
+        BigInt.new { |r| LibGMP.fdiv_qr_ui(the_q, r, -self, {{ neg_ui }}); LibGMP.neg(r, r) },
+        BigInt.new { |r| LibGMP.fdiv_qr(the_q, r, self, {{ big_i }}) },
+      }
+    end
     {the_q, the_r}
   end
 
@@ -376,9 +344,15 @@ struct BigInt < Int
     {the_q, the_r}
   end
 
-  def unsafe_truncated_divmod(number : LibGMP::ULong)
+  def unsafe_truncated_divmod(number : Int)
     the_q = BigInt.new
-    the_r = BigInt.new { |r| LibGMP.tdiv_qr_ui(the_q, r, self, number) }
+    the_r = Int.primitive_ui_check(number) do |ui, neg_ui, big_i|
+      {
+        BigInt.new { |r| LibGMP.tdiv_qr_ui(the_q, r, self, {{ ui }}) },
+        BigInt.new { |r| LibGMP.tdiv_qr_ui(the_q, r, self, {{ neg_ui }}); LibGMP.neg(the_q, the_q) },
+        BigInt.new { |r| LibGMP.tdiv_qr(the_q, r, self, {{ big_i }}) },
+      }
+    end
     {the_q, the_r}
   end
 
@@ -386,17 +360,13 @@ struct BigInt < Int
     LibGMP.divisible_p(self, number) != 0
   end
 
-  def divisible_by?(number : LibGMP::ULong) : Bool
-    LibGMP.divisible_ui_p(self, number) != 0
-  end
-
   def divisible_by?(number : Int) : Bool
-    if 0 <= number <= LibGMP::ULong::MAX
-      LibGMP.divisible_ui_p(self, number) != 0
-    elsif LibGMP::Long::MIN < number < 0
-      LibGMP.divisible_ui_p(self, number.abs) != 0
-    else
-      divisible_by?(number.to_big_i)
+    Int.primitive_ui_check(number) do |ui, neg_ui, big_i|
+      {
+        LibGMP.divisible_ui_p(self, {{ ui }}) != 0,
+        LibGMP.divisible_ui_p(self, {{ neg_ui }}) != 0,
+        divisible_by?({{ big_i }}),
+      }
     end
   end
 
@@ -459,8 +429,19 @@ struct BigInt < Int
 
   # :ditto:
   def gcd(other : Int) : Int
-    result = LibGMP.gcd_ui(nil, self, other.abs.to_u64)
-    result == 0 ? self : result
+    Int.primitive_ui_check(other) do |ui, neg_ui, big_i|
+      {
+        begin
+          result = LibGMP.gcd_ui(nil, self, {{ ui }})
+          result == 0 ? self : result
+        end,
+        begin
+          result = LibGMP.gcd_ui(nil, self, {{ neg_ui }})
+          result == 0 ? self : result
+        end,
+        gcd({{ big_i }}),
+      }
+    end
   end
 
   # Returns the least common multiple of `self` and *other*.
@@ -470,7 +451,13 @@ struct BigInt < Int
 
   # :ditto:
   def lcm(other : Int) : BigInt
-    BigInt.new { |mpz| LibGMP.lcm_ui(mpz, self, other.abs.to_u64) }
+    Int.primitive_ui_check(other) do |ui, neg_ui, big_i|
+      {
+        BigInt.new { |mpz| LibGMP.lcm_ui(mpz, self, {{ ui }}) },
+        BigInt.new { |mpz| LibGMP.lcm_ui(mpz, self, {{ neg_ui }}) },
+        lcm({{ big_i }}),
+      }
+    end
   end
 
   def bit_length : Int32
@@ -819,15 +806,12 @@ struct Int
   end
 
   def -(other : BigInt) : BigInt
-    if self < 0
-      -(abs + other)
-    else
-      # The line below segfault on linux 32 bits for a (yet) unknown reason:
-      #
-      #     BigInt.new { |mpz| LibGMP.ui_sub(mpz, self.to_u64, other) }
-      #
-      # So for now we do it a bit slower.
-      to_big_i - other
+    Int.primitive_ui_check(self) do |ui, neg_ui, big_i|
+      {
+        BigInt.new { |mpz| LibGMP.neg(mpz, other); LibGMP.add_ui(mpz, mpz, {{ ui }}) },
+        BigInt.new { |mpz| LibGMP.neg(mpz, other); LibGMP.sub_ui(mpz, mpz, {{ neg_ui }}) },
+        {{ big_i }} - other,
+      }
     end
   end
 
@@ -982,7 +966,7 @@ struct Crystal::Hasher
 
   def int(value : BigInt)
     # it should calculate `remainder(HASH_MODULUS)`
-    if LibGMP::ULong == UInt64
+    if LibGMP::UI == UInt64
       v = LibGMP.tdiv_ui(value, HASH_MODULUS).to_i64
       value < 0 ? -v : v
     elsif value >= HASH_MODULUS_INT_P || value <= HASH_MODULUS_INT_N

--- a/src/big/big_int.cr
+++ b/src/big/big_int.cr
@@ -50,15 +50,15 @@ struct BigInt < Int
   def self.new(num : Int::Primitive)
     Int.primitive_si_ui_check(num) do |si, ui, _|
       {
-        begin
+        si: begin
           LibGMP.init_set_si(out mpz1, {{ si }})
           new(mpz1)
         end,
-        begin
+        ui: begin
           LibGMP.init_set_ui(out mpz2, {{ ui }})
           new(mpz2)
         end,
-        begin
+        big_i: begin
           negative = num < 0
           num = num.abs_unsigned
           capacity = (num.bit_length - 1) // (sizeof(LibGMP::MpLimb) * 8) + 1
@@ -148,9 +148,9 @@ struct BigInt < Int
   def <=>(other : Int)
     Int.primitive_si_ui_check(other) do |si, ui, big_i|
       {
-        LibGMP.cmp_si(self, {{ si }}),
-        LibGMP.cmp_ui(self, {{ ui }}),
-        self <=> {{ big_i }},
+        si: LibGMP.cmp_si(self, {{ si }}),
+        ui: LibGMP.cmp_ui(self, {{ ui }}),
+        big_i: self <=> {{ big_i }},
       }
     end
   end
@@ -219,9 +219,9 @@ struct BigInt < Int
   def *(other : Int) : BigInt
     Int.primitive_si_ui_check(other) do |si, ui, big_i|
       {
-        BigInt.new { |mpz| LibGMP.mul_si(mpz, self, {{ si }}) },
-        BigInt.new { |mpz| LibGMP.mul_ui(mpz, self, {{ ui }}) },
-        self * {{ big_i }},
+        si: BigInt.new { |mpz| LibGMP.mul_si(mpz, self, {{ si }}) },
+        ui: BigInt.new { |mpz| LibGMP.mul_ui(mpz, self, {{ ui }}) },
+        big_i: self * {{ big_i }},
       }
     end
   end

--- a/src/big/big_int.cr
+++ b/src/big/big_int.cr
@@ -148,8 +148,8 @@ struct BigInt < Int
   def <=>(other : Int)
     Int.primitive_si_ui_check(other) do |si, ui, big_i|
       {
-        si: LibGMP.cmp_si(self, {{ si }}),
-        ui: LibGMP.cmp_ui(self, {{ ui }}),
+        si:    LibGMP.cmp_si(self, {{ si }}),
+        ui:    LibGMP.cmp_ui(self, {{ ui }}),
         big_i: self <=> {{ big_i }},
       }
     end
@@ -166,9 +166,9 @@ struct BigInt < Int
   def +(other : Int) : BigInt
     Int.primitive_ui_check(other) do |ui, neg_ui, big_i|
       {
-        ui: BigInt.new { |mpz| LibGMP.add_ui(mpz, self, {{ ui }}) },
+        ui:     BigInt.new { |mpz| LibGMP.add_ui(mpz, self, {{ ui }}) },
         neg_ui: BigInt.new { |mpz| LibGMP.sub_ui(mpz, self, {{ neg_ui }}) },
-        big_i: self + {{ big_i }},
+        big_i:  self + {{ big_i }},
       }
     end
   end
@@ -184,9 +184,9 @@ struct BigInt < Int
   def -(other : Int) : BigInt
     Int.primitive_ui_check(other) do |ui, neg_ui, big_i|
       {
-        ui: BigInt.new { |mpz| LibGMP.sub_ui(mpz, self, {{ ui }}) },
+        ui:     BigInt.new { |mpz| LibGMP.sub_ui(mpz, self, {{ ui }}) },
         neg_ui: BigInt.new { |mpz| LibGMP.add_ui(mpz, self, {{ neg_ui }}) },
-        big_i: self - {{ big_i }},
+        big_i:  self - {{ big_i }},
       }
     end
   end
@@ -219,8 +219,8 @@ struct BigInt < Int
   def *(other : Int) : BigInt
     Int.primitive_si_ui_check(other) do |si, ui, big_i|
       {
-        si: BigInt.new { |mpz| LibGMP.mul_si(mpz, self, {{ si }}) },
-        ui: BigInt.new { |mpz| LibGMP.mul_ui(mpz, self, {{ ui }}) },
+        si:    BigInt.new { |mpz| LibGMP.mul_si(mpz, self, {{ si }}) },
+        ui:    BigInt.new { |mpz| LibGMP.mul_ui(mpz, self, {{ ui }}) },
         big_i: self * {{ big_i }},
       }
     end
@@ -253,9 +253,9 @@ struct BigInt < Int
   def unsafe_floored_div(other : Int) : BigInt
     Int.primitive_ui_check(other) do |ui, neg_ui, big_i|
       {
-        ui: BigInt.new { |mpz| LibGMP.fdiv_q_ui(mpz, self, {{ ui }}) },
+        ui:     BigInt.new { |mpz| LibGMP.fdiv_q_ui(mpz, self, {{ ui }}) },
         neg_ui: BigInt.new { |mpz| LibGMP.fdiv_q_ui(mpz, -self, {{ neg_ui }}) },
-        big_i: unsafe_floored_div({{ big_i }}),
+        big_i:  unsafe_floored_div({{ big_i }}),
       }
     end
   end
@@ -267,9 +267,9 @@ struct BigInt < Int
   def unsafe_truncated_div(other : Int) : BigInt
     Int.primitive_ui_check(other) do |ui, neg_ui, big_i|
       {
-        ui: BigInt.new { |mpz| LibGMP.tdiv_q_ui(mpz, self, {{ ui }}) },
+        ui:     BigInt.new { |mpz| LibGMP.tdiv_q_ui(mpz, self, {{ ui }}) },
         neg_ui: BigInt.new { |mpz| LibGMP.tdiv_q_ui(mpz, self, {{ neg_ui }}); LibGMP.neg(mpz, mpz) },
-        big_i: unsafe_truncated_div({{ big_i }}),
+        big_i:  unsafe_truncated_div({{ big_i }}),
       }
     end
   end
@@ -299,9 +299,9 @@ struct BigInt < Int
   def unsafe_floored_mod(other : Int) : BigInt
     Int.primitive_ui_check(other) do |ui, neg_ui, big_i|
       {
-        ui: BigInt.new { |mpz| LibGMP.fdiv_r_ui(mpz, self, {{ ui }}) },
+        ui:     BigInt.new { |mpz| LibGMP.fdiv_r_ui(mpz, self, {{ ui }}) },
         neg_ui: BigInt.new { |mpz| LibGMP.fdiv_r_ui(mpz, self, {{ neg_ui }}); LibGMP.neg(mpz, mpz) },
-        big_i: unsafe_floored_mod({{ big_i }}),
+        big_i:  unsafe_floored_mod({{ big_i }}),
       }
     end
   end
@@ -313,9 +313,9 @@ struct BigInt < Int
   def unsafe_truncated_mod(other : Int) : BigInt
     Int.primitive_ui_check(other) do |ui, neg_ui, big_i|
       {
-        ui: BigInt.new { |mpz| LibGMP.tdiv_r_ui(mpz, self, {{ ui }}) },
+        ui:     BigInt.new { |mpz| LibGMP.tdiv_r_ui(mpz, self, {{ ui }}) },
         neg_ui: BigInt.new { |mpz| LibGMP.tdiv_r_ui(mpz, self, {{ neg_ui }}) },
-        big_i: unsafe_truncated_mod({{ big_i }}),
+        big_i:  unsafe_truncated_mod({{ big_i }}),
       }
     end
   end
@@ -330,9 +330,9 @@ struct BigInt < Int
     the_q = BigInt.new
     the_r = Int.primitive_ui_check(number) do |ui, neg_ui, big_i|
       {
-        ui: BigInt.new { |r| LibGMP.fdiv_qr_ui(the_q, r, self, {{ ui }}) },
+        ui:     BigInt.new { |r| LibGMP.fdiv_qr_ui(the_q, r, self, {{ ui }}) },
         neg_ui: BigInt.new { |r| LibGMP.fdiv_qr_ui(the_q, r, -self, {{ neg_ui }}); LibGMP.neg(r, r) },
-        big_i: BigInt.new { |r| LibGMP.fdiv_qr(the_q, r, self, {{ big_i }}) },
+        big_i:  BigInt.new { |r| LibGMP.fdiv_qr(the_q, r, self, {{ big_i }}) },
       }
     end
     {the_q, the_r}
@@ -348,9 +348,9 @@ struct BigInt < Int
     the_q = BigInt.new
     the_r = Int.primitive_ui_check(number) do |ui, neg_ui, big_i|
       {
-        ui: BigInt.new { |r| LibGMP.tdiv_qr_ui(the_q, r, self, {{ ui }}) },
+        ui:     BigInt.new { |r| LibGMP.tdiv_qr_ui(the_q, r, self, {{ ui }}) },
         neg_ui: BigInt.new { |r| LibGMP.tdiv_qr_ui(the_q, r, self, {{ neg_ui }}); LibGMP.neg(the_q, the_q) },
-        big_i: BigInt.new { |r| LibGMP.tdiv_qr(the_q, r, self, {{ big_i }}) },
+        big_i:  BigInt.new { |r| LibGMP.tdiv_qr(the_q, r, self, {{ big_i }}) },
       }
     end
     {the_q, the_r}
@@ -363,9 +363,9 @@ struct BigInt < Int
   def divisible_by?(number : Int) : Bool
     Int.primitive_ui_check(number) do |ui, neg_ui, big_i|
       {
-        ui: LibGMP.divisible_ui_p(self, {{ ui }}) != 0,
+        ui:     LibGMP.divisible_ui_p(self, {{ ui }}) != 0,
         neg_ui: LibGMP.divisible_ui_p(self, {{ neg_ui }}) != 0,
-        big_i: divisible_by?({{ big_i }}),
+        big_i:  divisible_by?({{ big_i }}),
       }
     end
   end
@@ -453,9 +453,9 @@ struct BigInt < Int
   def lcm(other : Int) : BigInt
     Int.primitive_ui_check(other) do |ui, neg_ui, big_i|
       {
-        ui: BigInt.new { |mpz| LibGMP.lcm_ui(mpz, self, {{ ui }}) },
+        ui:     BigInt.new { |mpz| LibGMP.lcm_ui(mpz, self, {{ ui }}) },
         neg_ui: BigInt.new { |mpz| LibGMP.lcm_ui(mpz, self, {{ neg_ui }}) },
-        big_i: lcm({{ big_i }}),
+        big_i:  lcm({{ big_i }}),
       }
     end
   end
@@ -808,9 +808,9 @@ struct Int
   def -(other : BigInt) : BigInt
     Int.primitive_ui_check(self) do |ui, neg_ui, big_i|
       {
-        ui: BigInt.new { |mpz| LibGMP.neg(mpz, other); LibGMP.add_ui(mpz, mpz, {{ ui }}) },
+        ui:     BigInt.new { |mpz| LibGMP.neg(mpz, other); LibGMP.add_ui(mpz, mpz, {{ ui }}) },
         neg_ui: BigInt.new { |mpz| LibGMP.neg(mpz, other); LibGMP.sub_ui(mpz, mpz, {{ neg_ui }}) },
-        big_i: {{ big_i }} - other,
+        big_i:  {{ big_i }} - other,
       }
     end
   end

--- a/src/big/big_rational.cr
+++ b/src/big/big_rational.cr
@@ -105,8 +105,8 @@ struct BigRational < Number
   def <=>(other : Int)
     Int.primitive_si_ui_check(other) do |si, ui, big_i|
       {
-        si: LibGMP.mpq_cmp_si(self, {{ si }}, 1),
-        ui: LibGMP.mpq_cmp_ui(self, {{ ui }}, 1),
+        si:    LibGMP.mpq_cmp_si(self, {{ si }}, 1),
+        ui:    LibGMP.mpq_cmp_ui(self, {{ ui }}, 1),
         big_i: self <=> {{ big_i }},
       }
     end

--- a/src/big/big_rational.cr
+++ b/src/big/big_rational.cr
@@ -105,9 +105,9 @@ struct BigRational < Number
   def <=>(other : Int)
     Int.primitive_si_ui_check(other) do |si, ui, big_i|
       {
-        LibGMP.mpq_cmp_si(self, {{ si }}, 1),
-        LibGMP.mpq_cmp_ui(self, {{ ui }}, 1),
-        self <=> {{ big_i }},
+        si: LibGMP.mpq_cmp_si(self, {{ si }}, 1),
+        ui: LibGMP.mpq_cmp_ui(self, {{ ui }}, 1),
+        big_i: self <=> {{ big_i }},
       }
     end
   end

--- a/src/big/big_rational.cr
+++ b/src/big/big_rational.cr
@@ -102,15 +102,13 @@ struct BigRational < Number
     self <=> other.to_big_r
   end
 
-  def <=>(other : Int::Primitive)
-    if LibGMP::SI::MIN <= other <= LibGMP::UI::MAX
-      if other <= LibGMP::SI::MAX
-        LibGMP.mpq_cmp_si(self, LibGMP::SI.new!(other), 1)
-      else
-        LibGMP.mpq_cmp_ui(self, LibGMP::UI.new!(other), 1)
-      end
-    else
-      self <=> other.to_big_i
+  def <=>(other : Int)
+    Int.primitive_si_ui_check(other) do |si, ui, big_i|
+      {
+        LibGMP.mpq_cmp_si(self, {{ si }}, 1),
+        LibGMP.mpq_cmp_ui(self, {{ ui }}, 1),
+        self <=> {{ big_i }},
+      }
     end
   end
 

--- a/src/big/lib_gmp.cr
+++ b/src/big/lib_gmp.cr
@@ -23,10 +23,6 @@ lib LibGMP
   alias Double = LibC::Double
   alias BitcntT = UI
 
-  alias IntPrimitiveSigned = Int8 | Int16 | Int32 | LibC::Long
-  alias IntPrimitiveUnsigned = UInt8 | UInt16 | UInt32 | LibC::ULong
-  alias IntPrimitive = IntPrimitiveSigned | IntPrimitiveUnsigned
-
   {% if flag?(:win32) && flag?(:bits64) %}
     alias MpExp = LibC::Long
     alias MpSize = LibC::LongLong

--- a/src/big/number.cr
+++ b/src/big/number.cr
@@ -8,17 +8,18 @@ struct BigFloat
     self.class.new(self / other)
   end
 
-  def /(other : UInt8 | UInt16 | UInt32 | UInt64) : BigFloat
+  def /(other : Int::Primitive) : BigFloat
     # Division by 0 in BigFloat is not allowed, there is no BigFloat::Infinity
     raise DivisionByZeroError.new if other == 0
-    if other.is_a?(UInt8 | UInt16 | UInt32) || (LibGMP::ULong == UInt64 && other.is_a?(UInt64))
-      BigFloat.new { |mpf| LibGMP.mpf_div_ui(mpf, self, other) }
-    else
-      BigFloat.new { |mpf| LibGMP.mpf_div(mpf, self, other.to_big_f) }
+    Int.primitive_ui_check(other) do |ui, neg_ui, _|
+      {
+        BigFloat.new { |mpf| LibGMP.mpf_div_ui(mpf, self, {{ ui }}) },
+        BigFloat.new { |mpf| LibGMP.mpf_div_ui(mpf, self, {{ neg_ui }}); LibGMP.mpf_neg(mpf, mpf) },
+        BigFloat.new { |mpf| LibGMP.mpf_div(mpf, self, BigFloat.new(other)) },
+      }
     end
   end
 
-  Number.expand_div [Int8, Int16, Int32, Int64, Int128, UInt128], BigFloat
   Number.expand_div [Float32, Float64], BigFloat
 end
 
@@ -30,6 +31,61 @@ end
 struct BigRational
   Number.expand_div [Int8, UInt8, Int16, UInt16, Int32, UInt32, Int64, UInt64, Int128, UInt128], BigRational
   Number.expand_div [Float32, Float64], BigRational
+end
+
+struct Int
+  # :nodoc:
+  # Yields 3 expressions: `Call`s nodes that convert *var* into a `LibGMP::SI`,
+  # a `LibGMP::UI`, and a `BigInt` respectively. These expressions are not
+  # evaluated unless they are interpolated in *block*.
+  #
+  # *block* should return a 3-tuple: the first element is returned by the macro
+  # if *var* fits into a `LibGMP::SI`, the second returned if *var* fits into a
+  # `LibGMP::UI`, and the third otherwise.
+  macro primitive_si_ui_check(var, &block)
+    {%
+      exps = yield(
+        "::LibGMP::SI.new!(#{var.id})".id,
+        "::LibGMP::UI.new!(#{var.id})".id,
+        "::BigInt.new(#{var.id})".id,
+      )
+    %}
+    if ::LibGMP::SI::MIN <= {{ var }} <= ::LibGMP::UI::MAX
+      if {{ var }} <= ::LibGMP::SI::MAX
+        {{ exps[0] }}
+      else
+        {{ exps[1] }}
+      end
+    else
+      {{ exps[2] }}
+    end
+  end
+
+  # :nodoc:
+  # Yields 3 expressions: `Call`s nodes that convert *var* into a `LibGMP::UI`,
+  # the negative of *var* into a `LibGMP::UI`, and *var* into a `BigInt`,
+  # respectively. These expressions are not evaluated unless they are
+  # interpolated in *block*.
+  #
+  # *block* should return a 3-tuple: the first element is returned by the macro
+  # if *var* fits into a `LibGMP::UI`, the second returned if the negative of
+  # *var* fits into a `LibGMP::UI`, and the third otherwise.
+  macro primitive_ui_check(var, &block)
+    {%
+      exps = yield(
+        "::LibGMP::UI.new!(#{var.id})".id,
+        "::LibGMP::UI.new!((#{var.id}).abs_unsigned)".id,
+        "::BigInt.new(#{var.id})".id,
+      )
+    %}
+    if ::LibGMP::UI::MIN <= {{ var }} <= ::LibGMP::UI::MAX
+      {{ exps[0] }}
+    elsif {{ var }}.responds_to?(:abs_unsigned) && {{ var }}.abs_unsigned <= ::LibGMP::UI::MAX
+      {{ exps[1] }}
+    else
+      {{ exps[2] }}
+    end
+  end
 end
 
 struct Int8

--- a/src/big/number.cr
+++ b/src/big/number.cr
@@ -13,9 +13,9 @@ struct BigFloat
     raise DivisionByZeroError.new if other == 0
     Int.primitive_ui_check(other) do |ui, neg_ui, _|
       {
-        ui: BigFloat.new { |mpf| LibGMP.mpf_div_ui(mpf, self, {{ ui }}) },
+        ui:     BigFloat.new { |mpf| LibGMP.mpf_div_ui(mpf, self, {{ ui }}) },
         neg_ui: BigFloat.new { |mpf| LibGMP.mpf_div_ui(mpf, self, {{ neg_ui }}); LibGMP.mpf_neg(mpf, mpf) },
-        big_i: BigFloat.new { |mpf| LibGMP.mpf_div(mpf, self, BigFloat.new(other)) },
+        big_i:  BigFloat.new { |mpf| LibGMP.mpf_div(mpf, self, BigFloat.new(other)) },
       }
     end
   end

--- a/src/big/number.cr
+++ b/src/big/number.cr
@@ -39,9 +39,9 @@ struct Int
   # a `LibGMP::UI`, and a `BigInt` respectively. These expressions are not
   # evaluated unless they are interpolated in *block*.
   #
-  # *block* should return a 3-tuple: the first element is returned by the macro
-  # if *var* fits into a `LibGMP::SI`, the second returned if *var* fits into a
-  # `LibGMP::UI`, and the third otherwise.
+  # *block* should return a named tuple: the value for `:si` is returned by the
+  # macro if *var* fits into a `LibGMP::SI`, the value for `:ui` returned if
+  # *var* fits into a `LibGMP::UI`, and the value for `:big_i` otherwise.
   macro primitive_si_ui_check(var, &block)
     {%
       exps = yield(
@@ -52,12 +52,12 @@ struct Int
     %}
     if ::LibGMP::SI::MIN <= {{ var }} <= ::LibGMP::UI::MAX
       if {{ var }} <= ::LibGMP::SI::MAX
-        {{ exps[0] }}
+        {{ exps[:si] }}
       else
-        {{ exps[1] }}
+        {{ exps[:ui] }}
       end
     else
-      {{ exps[2] }}
+      {{ exps[:big_i] }}
     end
   end
 


### PR DESCRIPTION
Following #13303, this PR uses `LibGMP::SI` and `LibGMP::UI` for proper integer size checks in most of the `Big*` number types' methods. This means 64-bit integer arguments that don't fit into 32 bits will now be able to use many MPIR functions on Windows directly, without being converted to `BigInt`s first.

Some methods that take `Int::Primitive` arguments are promoted to accept `Int`, relying on overload ordering so that `BigInt` overloads take precedence. The opposite direction is not done, as that would technically be a breaking change.

Several parts are left out for future work:

* `BigFloat#to_i64` and `#to_u64` still rely on `LibGMP::Long` and `ULong`.
* `BigFloat#**(Int)` expects the argument to fit into an `UInt64`.
* `Int.primitive_ui_check(num)` will always convert `num` to a `BigInt` if it is negative and not primitive. This is only a problem if `Int` is inherited outside the standard library.