### PR TITLE
Support full exponent range in `BigFloat#**(BigInt)`

### DIFF
--- a/spec/std/big/big_float_spec.cr
+++ b/spec/std/big/big_float_spec.cr
@@ -180,7 +180,17 @@ describe "BigFloat" do
   describe "#**" do
     it { ("1.34".to_big_f ** 2).should be_close("1.7956".to_big_f, 1e-12) }
     it { ("-0.05".to_big_f ** 10).should be_close("0.00000000000009765625".to_big_f, 1e-12) }
-    it { (0.1234567890.to_big_f ** 3).should be_close("0.001881676371789154860897069".to_big_f, 1e-12) }
+    it { ("0.1234567890".to_big_f ** 3).should be_close("0.001881676371789154860897069".to_big_f, 1e-12) }
+
+    it { ("1.34".to_big_f ** 2.to_big_i).should be_close("1.7956".to_big_f, 1e-12) }
+    it { ("-0.05".to_big_f ** 10.to_big_i).should be_close("0.00000000000009765625".to_big_f, 1e-12) }
+    it { ("0.1234567890".to_big_f ** 3.to_big_i).should be_close("0.001881676371789154860897069".to_big_f, 1e-12) }
+
+    it { ("10".to_big_f ** (-5).to_big_i).should be_close("0.00001".to_big_f, 1e-12) }
+    it { ("0.1".to_big_f ** (-5).to_big_i).should be_close("100000".to_big_f, 1e-12) }
+    it { ("0".to_big_f ** 1.to_big_i).should eq(0.to_big_f) }
+    it { ("0".to_big_f ** 0.to_big_i).should eq(1.to_big_f) }
+    it { expect_raises(ArgumentError, "Cannot raise 0 to a negative power") { "0".to_big_f ** (-1).to_big_i } }
   end
 
   describe "#abs" do

--- a/src/big/big_float.cr
+++ b/src/big/big_float.cr
@@ -149,6 +149,36 @@ struct BigFloat < Float
   Number.expand_div [BigDecimal], BigDecimal
   Number.expand_div [BigRational], BigRational
 
+  def **(other : BigInt) : BigFloat
+    is_zero = self.zero?
+    if is_zero
+      case other <=> 0
+      when .>(0)
+        return self
+      when .<(0)
+        # there is no BigFloat::Infinity
+        raise ArgumentError.new "Cannot raise 0 to a negative power"
+      end
+    end
+
+    BigFloat.new do |result|
+      LibGMP.mpf_init_set_si(result, 1)
+      next if is_zero # define `0 ** 0 == 1`
+
+      # these are mutated and must be copies of `other` and `self`!
+      exponent = BigInt.new { |mpz| LibGMP.abs(mpz, other) } # `other.abs`
+      k = BigFloat.new { |mpf| LibGMP.mpf_set(mpf, self) }   # `self`
+
+      while exponent > 0
+        LibGMP.mpf_mul(result, result, k) if exponent.to_i!.odd? # `result *= k`
+        LibGMP.fdiv_q_2exp(exponent, exponent, 1)                # `exponent /= 2`
+        LibGMP.mpf_mul(k, k, k) if exponent > 0                  # `k *= k`
+      end
+
+      LibGMP.mpf_ui_div(result, 1, result) if other < 0 # `result = 1 / result`
+    end
+  end
+
   def **(other : Int) : BigFloat
     BigFloat.new { |mpf| LibGMP.mpf_pow_ui(mpf, self, other.to_u64) }
   end

--- a/src/big/big_float.cr
+++ b/src/big/big_float.cr
@@ -152,7 +152,7 @@ struct BigFloat < Float
   def **(other : BigInt) : BigFloat
     is_zero = self.zero?
     if is_zero
-      case other <=> 0
+      case other
       when .>(0)
         return self
       when .<(0)

--- a/src/big/lib_gmp.cr
+++ b/src/big/lib_gmp.cr
@@ -238,6 +238,7 @@ lib LibGMP
   fun mpf_mul = __gmpf_mul(rop : MPF*, op1 : MPF*, op2 : MPF*)
   fun mpf_div = __gmpf_div(rop : MPF*, op1 : MPF*, op2 : MPF*)
   fun mpf_div_ui = __gmpf_div_ui(rop : MPF*, op1 : MPF*, op2 : UI)
+  fun mpf_ui_div = __gmpf_ui_div(rop : MPF*, op1 : UI, op2 : MPF*)
   fun mpf_neg = __gmpf_neg(rop : MPF*, op : MPF*)
   fun mpf_abs = __gmpf_abs(rop : MPF*, op : MPF*)
   fun mpf_sqrt = __gmpf_sqrt(rop : MPF*, op : MPF*)


### PR DESCRIPTION
Supports exponents larger than `UInt64::MAX` and negative exponents. Similar support for primitive integers will be added after #13874.

This is more or less the same implementation as `Int#**(Int)`, except that the temporary variables are mutated in-place to reduce memory allocations.