### PR TITLE
`IO#gets` should have same result regardless of #peek availability

### DIFF
--- a/spec/std/io/io_spec.cr
+++ b/spec/std/io/io_spec.cr
@@ -183,6 +183,40 @@ describe IO do
       io.gets(chomp: false).should be_nil
     end
 
+    it "does gets with empty string (no peek)" do
+      io = SimpleIOMemory.new("")
+      io.gets(chomp: true).should be_nil
+    end
+
+    it "does gets with empty string (with peek)" do
+      io = IO::Memory.new("")
+      io.gets(chomp: true).should be_nil
+    end
+
+    it "does gets with \\n (no peek)" do
+      io = SimpleIOMemory.new("\n")
+      io.gets(chomp: true).should eq("")
+      io.gets(chomp: true).should be_nil
+    end
+
+    it "does gets with \\n (with peek)" do
+      io = IO::Memory.new("\n")
+      io.gets(chomp: true).should eq("")
+      io.gets(chomp: true).should be_nil
+    end
+
+    it "does gets with \\r\\n (no peek)" do
+      io = SimpleIOMemory.new("\r\n")
+      io.gets(chomp: true).should eq("")
+      io.gets(chomp: true).should be_nil
+    end
+
+    it "does gets with \\r\\n (with peek)" do
+      io = IO::Memory.new("\r\n")
+      io.gets(chomp: true).should eq("")
+      io.gets(chomp: true).should be_nil
+    end
+
     it "does gets with big line" do
       big_line = "a" * 20_000
       io = SimpleIOMemory.new("#{big_line}\nworld\n")

--- a/src/io.cr
+++ b/src/io.cr
@@ -753,7 +753,7 @@ abstract class IO
   private def gets_slow(delimiter : Char, limit, chomp)
     buffer = String::Builder.new
     bytes_read = gets_slow(delimiter, limit, chomp, buffer)
-    bytes_read ? buffer.to_s : nil
+    buffer.to_s if bytes_read
   end
 
   private def gets_slow(delimiter : Char, limit, chomp, buffer : String::Builder) : Bool

--- a/src/io.cr
+++ b/src/io.cr
@@ -752,11 +752,12 @@ abstract class IO
 
   private def gets_slow(delimiter : Char, limit, chomp)
     buffer = String::Builder.new
-    gets_slow(delimiter, limit, chomp, buffer)
-    buffer.empty? ? nil : buffer.to_s
+    bytes_read = gets_slow(delimiter, limit, chomp, buffer)
+    bytes_read.zero? ? nil : buffer.to_s
   end
 
-  private def gets_slow(delimiter : Char, limit, chomp, buffer : String::Builder) : Nil
+  private def gets_slow(delimiter : Char, limit, chomp, buffer : String::Builder) : Int32
+    bytes_read = 0
     chomp_rn = delimiter == '\n' && chomp
 
     while true
@@ -766,6 +767,7 @@ abstract class IO
       end
 
       char, char_bytesize = info
+      bytes_read += char_bytesize
 
       # Consider the case of \r\n when the delimiter is \n and chomp = true
       if chomp_rn && char == '\r'
@@ -776,6 +778,7 @@ abstract class IO
         end
 
         char2, char_bytesize2 = info2
+        bytes_read += char_bytesize2
         if char2 == '\n'
           break
         end
@@ -801,6 +804,8 @@ abstract class IO
       break if char_bytesize >= limit
       limit -= char_bytesize
     end
+
+    bytes_read
   end
 
   # Reads until *delimiter* is found or the end of the `IO` is reached.

--- a/src/io.cr
+++ b/src/io.cr
@@ -753,11 +753,11 @@ abstract class IO
   private def gets_slow(delimiter : Char, limit, chomp)
     buffer = String::Builder.new
     bytes_read = gets_slow(delimiter, limit, chomp, buffer)
-    bytes_read.zero? ? nil : buffer.to_s
+    bytes_read ? buffer.to_s : nil
   end
 
-  private def gets_slow(delimiter : Char, limit, chomp, buffer : String::Builder) : Int32
-    bytes_read = 0
+  private def gets_slow(delimiter : Char, limit, chomp, buffer : String::Builder) : Bool
+    bytes_read = false
     chomp_rn = delimiter == '\n' && chomp
 
     while true
@@ -767,7 +767,7 @@ abstract class IO
       end
 
       char, char_bytesize = info
-      bytes_read += char_bytesize
+      bytes_read = true
 
       # Consider the case of \r\n when the delimiter is \n and chomp = true
       if chomp_rn && char == '\r'
@@ -778,7 +778,6 @@ abstract class IO
         end
 
         char2, char_bytesize2 = info2
-        bytes_read += char_bytesize2
         if char2 == '\n'
           break
         end


### PR DESCRIPTION
At [Heii On-Call](https://heiioncall.com/) we ran into a problem with Crystal 1.10.0. We found that when parsing HTTP responses, `HTTP.parse_headers_and_body` was behaving differently depending on whether the `IO` had `#peek` or not. We run a lot of `HEAD` requests for monitoring customer APIs/websites, so the IO contents often looks something like: "Header: Value\r\n\r\n" where there's an empty line at the end, not followed by any body contents. That was working fine until Crystal 1.10.0 😮 

It turns out that`HTTP.parse_headers_and_body` totally breaks if `io.gets(chomp: true)` returns a `nil` before it returns an empty `""`, see https://github.com/crystal-lang/crystal/blob/1.10.0/src/http/common.cr#L121 . (There is no case in `parse_headers_and_body` for handling the `nil` from `read_header_line`.)

We then found that `IO#gets` was actually behaving differently depending on whether the `IO` had a `#peek` or not! ❗ 

We expect that an IO wrapping an empty string `""` should have `#gets` returning `nil`, while an IO wrapping a newline `"\n"` or a CRLF newline `"\r\n"` should have `#gets` returning an empty string `""`. 

In 1.10.0, an IO **without** `#peek` that wraps just a newline will incorrectly have `gets(chomp: true)` returning `nil`, when it should return `""`. This PR fixes that behavior, and adds tests.