### PR TITLE
Support Android API levels 24 - 27

### DIFF
--- a/lib/reply/src/term_size.cr
+++ b/lib/reply/src/term_size.cr
@@ -145,6 +145,10 @@ end
       {% end %}
     {% end %}
 
-    fun ioctl(fd : Int, request : ULong, ...) : Int
+    {% if flag?(:android) %}
+      fun ioctl(__fd : Int, __request : Int, ...) : Int
+    {% else %}
+      fun ioctl(fd : Int, request : ULong, ...) : Int
+    {% end %}
   end
 {% end %}

--- a/src/crystal/iconv.cr
+++ b/src/crystal/iconv.cr
@@ -1,4 +1,4 @@
-{% if flag?(:use_libiconv) || flag?(:win32) %}
+{% if flag?(:use_libiconv) || flag?(:win32) || (flag?(:android) && LibC::ANDROID_API < 28) %}
   require "./lib_iconv"
   private USE_LIBICONV = true
 {% else %}

--- a/src/crystal/system/unix/file_descriptor.cr
+++ b/src/crystal/system/unix/file_descriptor.cr
@@ -1,6 +1,9 @@
 require "c/fcntl"
 require "io/evented"
 require "termios"
+{% if flag?(:android) && LibC::ANDROID_API < 28 %}
+  require "c/sys/ioctl"
+{% end %}
 
 # :nodoc:
 module Crystal::System::FileDescriptor
@@ -198,7 +201,7 @@ module Crystal::System::FileDescriptor
     system_console_mode do |mode|
       flags = LibC::ECHO | LibC::ECHOE | LibC::ECHOK | LibC::ECHONL
       mode.c_lflag = enable ? (mode.c_lflag | flags) : (mode.c_lflag & ~flags)
-      if LibC.tcsetattr(fd, LibC::TCSANOW, pointerof(mode)) != 0
+      if FileDescriptor.tcsetattr(fd, LibC::TCSANOW, pointerof(mode)) != 0
         raise IO::Error.from_errno("tcsetattr")
       end
       yield
@@ -208,13 +211,13 @@ module Crystal::System::FileDescriptor
   private def system_raw(enable : Bool, & : ->)
     system_console_mode do |mode|
       if enable
-        LibC.cfmakeraw(pointerof(mode))
+        FileDescriptor.cfmakeraw(pointerof(mode))
       else
         mode.c_iflag |= LibC::BRKINT | LibC::ISTRIP | LibC::ICRNL | LibC::IXON
         mode.c_oflag |= LibC::OPOST
         mode.c_lflag |= LibC::ECHO | LibC::ECHOE | LibC::ECHOK | LibC::ECHONL | LibC::ICANON | LibC::ISIG | LibC::IEXTEN
       end
-      if LibC.tcsetattr(fd, LibC::TCSANOW, pointerof(mode)) != 0
+      if FileDescriptor.tcsetattr(fd, LibC::TCSANOW, pointerof(mode)) != 0
         raise IO::Error.from_errno("tcsetattr")
       end
       yield
@@ -223,13 +226,60 @@ module Crystal::System::FileDescriptor
 
   @[AlwaysInline]
   private def system_console_mode(&)
-    if LibC.tcgetattr(fd, out mode) != 0
-      raise IO::Error.from_errno("tcgetattr")
+    before = FileDescriptor.tcgetattr(fd)
+    begin
+      yield before
+    ensure
+      FileDescriptor.tcsetattr(fd, LibC::TCSANOW, pointerof(before))
     end
+  end
 
-    before = mode
-    ret = yield mode
-    LibC.tcsetattr(fd, LibC::TCSANOW, pointerof(before))
-    ret
+  @[AlwaysInline]
+  def self.tcgetattr(fd)
+    termios = uninitialized LibC::Termios
+    ret = {% if flag?(:android) && !LibC.has_method?(:tcgetattr) %}
+            LibC.ioctl(fd, LibC::TCGETS, pointerof(termios))
+          {% else %}
+            LibC.tcgetattr(fd, pointerof(termios))
+          {% end %}
+    raise IO::Error.from_errno("tcgetattr") if ret != 0
+    termios
+  end
+
+  @[AlwaysInline]
+  def self.tcsetattr(fd, optional_actions, termios_p)
+    {% if flag?(:android) && !LibC.has_method?(:tcsetattr) %}
+      optional_actions = optional_actions.value if optional_actions.is_a?(Termios::LineControl)
+      cmd = case optional_actions
+            when LibC::TCSANOW
+              LibC::TCSETS
+            when LibC::TCSADRAIN
+              LibC::TCSETSW
+            when LibC::TCSAFLUSH
+              LibC::TCSETSF
+            else
+              Errno.value = Errno::EINVAL
+              return LibC::Int.new(-1)
+            end
+
+      LibC.ioctl(fd, cmd, termios_p)
+    {% else %}
+      LibC.tcsetattr(fd, optional_actions, termios_p)
+    {% end %}
+  end
+
+  @[AlwaysInline]
+  def self.cfmakeraw(termios_p)
+    {% if flag?(:android) && !LibC.has_method?(:cfmakeraw) %}
+      s.value.c_iflag &= ~(LibC::IGNBRK | LibC::BRKINT | LibC::PARMRK | LibC::ISTRIP | LibC::INLCR | LibC::IGNCR | LibC::ICRNL | LibC::IXON)
+      s.value.c_oflag &= ~LibC::OPOST
+      s.value.c_lflag &= ~(LibC::ECHO | LibC::ECHONL | LibC::ICANON | LibC::ISIG | LibC::IEXTEN)
+      s.value.c_cflag &= ~(LibC::CSIZE | LibC::PARENB)
+      s.value.c_cflag |= LibC::CS8
+      s.value.c_cc[LibC::VMIN] = 1
+      s.value.c_cc[LibC::VTIME] = 0
+    {% else %}
+      LibC.cfmakeraw(termios_p)
+    {% end %}
   end
 end

--- a/src/io/console.cr
+++ b/src/io/console.cr
@@ -92,7 +92,7 @@ class IO::FileDescriptor < IO
   @[Deprecated]
   macro noecho_from_tc_mode!
     mode.c_lflag &= ~(Termios::LocalMode.flags(ECHO, ECHOE, ECHOK, ECHONL).value)
-    LibC.tcsetattr(fd, Termios::LineControl::TCSANOW, pointerof(mode))
+    Crystal::System::FileDescriptor.tcsetattr(fd, Termios::LineControl::TCSANOW, pointerof(mode))
   end
 
   @[Deprecated]
@@ -109,12 +109,12 @@ class IO::FileDescriptor < IO
                      Termios::LocalMode::ICANON |
                      Termios::LocalMode::ISIG |
                      Termios::LocalMode::IEXTEN).value
-    LibC.tcsetattr(fd, Termios::LineControl::TCSANOW, pointerof(mode))
+    Crystal::System::FileDescriptor.tcsetattr(fd, Termios::LineControl::TCSANOW, pointerof(mode))
   end
 
   @[Deprecated]
   macro raw_from_tc_mode!
-    LibC.cfmakeraw(pointerof(mode))
-    LibC.tcsetattr(fd, Termios::LineControl::TCSANOW, pointerof(mode))
+    Crystal::System::FileDescriptor.cfmakeraw(pointerof(mode))
+    Crystal::System::FileDescriptor.tcsetattr(fd, Termios::LineControl::TCSANOW, pointerof(mode))
   end
 end

--- a/src/lib_c.cr
+++ b/src/lib_c.cr
@@ -27,7 +27,7 @@ lib LibC
 
   {% if flag?(:android) %}
     {% default_api_version = 31 %}
-    {% min_supported_version = 28 %}
+    {% min_supported_version = 24 %}
     {% api_version_var = env("ANDROID_PLATFORM") || env("ANDROID_NATIVE_API_LEVEL") %}
     {% api_version = api_version_var ? api_version_var.gsub(/^android-/, "").to_i : default_api_version %}
     {% raise "TODO: Support Android API level below #{min_supported_version}" unless api_version >= min_supported_version %}

--- a/src/lib_c/aarch64-android/c/iconv.cr
+++ b/src/lib_c/aarch64-android/c/iconv.cr
@@ -1,9 +1,9 @@
 require "./stddef"
 
 lib LibC
-  type IconvT = Void*
-
   {% if ANDROID_API >= 28 %}
+    type IconvT = Void*
+
     fun iconv(__converter : IconvT, __src_buf : Char**, __src_bytes_left : SizeT*, __dst_buf : Char**, __dst_bytes_left : SizeT*) : SizeT
     fun iconv_close(__converter : IconvT) : Int
     fun iconv_open(__src_encoding : Char*, __dst_encoding : Char*) : IconvT

--- a/src/lib_c/aarch64-android/c/sys/ioctl.cr
+++ b/src/lib_c/aarch64-android/c/sys/ioctl.cr
@@ -1,0 +1,8 @@
+lib LibC
+  TCGETS  = 0x5401
+  TCSETS  = 0x5402
+  TCSETSW = 0x5403
+  TCSETSF = 0x5404
+
+  fun ioctl(__fd : Int, __request : Int, ...) : Int
+end

--- a/src/lib_c/aarch64-android/c/termios.cr
+++ b/src/lib_c/aarch64-android/c/termios.cr
@@ -168,8 +168,6 @@ lib LibC
     c_cc : StaticArray(CcT, 19) # cc_t[NCCS]
   end
 
-  # TODO: defined inline for `21 <= ANDROID_API < 28` in terms of `ioctl`, but
-  # `lib/reply/src/term_size.cr` contains an incompatible definition of it
   {% if ANDROID_API >= 28 %}
     fun tcgetattr(__fd : Int, __t : Termios*) : Int
     fun tcsetattr(__fd : Int, __optional_actions : Int, __t : Termios*) : Int


### PR DESCRIPTION
Fixes #13883.

@I3oris The `ioctl` definition in the REPLy shard has been modified because it is incompatible with Bionic C's definition, needed by this PR. Feel free to incorporate this into upstream.