### PR TITLE
Fix `FileUtils.ln_sf` to override special file types

### DIFF
--- a/spec/std/file_utils_spec.cr
+++ b/spec/std/file_utils_spec.cr
@@ -733,6 +733,23 @@ describe "FileUtils" do
       end
     {% end %}
 
+    it "overwrites a destination dir in dir" do
+      with_tempfile("ln_sf_src", "ln_sf_dst_dir_exists") do |path1, path2|
+        test_with_string_and_path(path1, path2) do |arg1, arg2|
+          FileUtils.touch([path1])
+          dir_dest = File.join(path2, File.basename(path1))
+          Dir.mkdir_p(dir_dest)
+          File.symlink?(path1).should be_false
+          File.symlink?(path2).should be_false
+
+          FileUtils.ln_sf(arg1, arg2)
+          File.symlink?(path1).should be_false
+          File.symlink?(dir_dest).should be_true
+          FileUtils.rm_rf([path1, path2])
+        end
+      end
+    end
+
     it "overwrites a destination file inside a dir" do
       with_tempfile("ln_sf_dst_dir", "ln_sf_dst") do |dir, path2|
         dir += File::SEPARATOR

--- a/spec/std/file_utils_spec.cr
+++ b/spec/std/file_utils_spec.cr
@@ -715,6 +715,24 @@ describe "FileUtils" do
       end
     end
 
+    {% if flag?(:unix) %}
+      it "overwrites a destination named pipe" do
+        with_tempfile("ln_sf_src", "ln_sf_dst_pipe_exists") do |path1, path2|
+          test_with_string_and_path(path1, path2) do |arg1, arg2|
+            FileUtils.touch([path1])
+            `mkfifo #{path2}`
+            File.symlink?(path1).should be_false
+            File.symlink?(path2).should be_false
+
+            FileUtils.ln_sf(arg1, arg2)
+            File.symlink?(path1).should be_false
+            File.symlink?(path2).should be_true
+            FileUtils.rm_rf([path1, path2])
+          end
+        end
+      end
+    {% end %}
+
     it "overwrites a destination file inside a dir" do
       with_tempfile("ln_sf_dst_dir", "ln_sf_dst") do |dir, path2|
         dir += File::SEPARATOR

--- a/src/file_utils.cr
+++ b/src/file_utils.cr
@@ -223,7 +223,7 @@ module FileUtils
       dest_path = File.join(dest_path, File.basename(src_path))
     end
 
-    File.delete?(dest_path)
+    rm_rf(dest_path) if File.exists?(dest_path)
     File.symlink(src_path, dest_path)
   end
 

--- a/src/file_utils.cr
+++ b/src/file_utils.cr
@@ -223,7 +223,7 @@ module FileUtils
       dest_path = File.join(dest_path, File.basename(src_path))
     end
 
-    File.delete(dest_path) if File.file?(dest_path)
+    File.delete?(dest_path)
     File.symlink(src_path, dest_path)
   end
 


### PR DESCRIPTION
The current implementation using `File.file?` checks only if the destination is an ordinary file. But any kind of file should be deleted, regardless of its type. So `File.exists?` would be better suited here.

Also, we need to use `rm_rf` instead of `File.delete` because `dest_path` can be a directory.
