### PR TITLE
Use `CMAKE_MSVC_RUNTIME_LIBRARY` flag in win.yml

### DIFF
--- a/.github/workflows/win.yml
+++ b/.github/workflows/win.yml
@@ -1,4 +1,4 @@
-  name: Windows CI
+name: Windows CI
 
 on: [push, pull_request]
 

--- a/.github/workflows/win.yml
+++ b/.github/workflows/win.yml
@@ -1,4 +1,4 @@
-name: Windows CI
+  name: Windows CI
 
 on: [push, pull_request]
 
@@ -200,7 +200,7 @@ jobs:
         run: |
           mkdir llvm-build
           cd llvm-build
-          cmake ..\llvm-src -Thost=x64 -DLLVM_TARGETS_TO_BUILD="X86;AArch64" -DLLVM_USE_CRT_RELEASE=MT -DBUILD_SHARED_LIBS=OFF -DCMAKE_FIND_USE_SYSTEM_ENVIRONMENT_PATH=OFF -DLLVM_INCLUDE_BENCHMARKS=OFF -DLLVM_INCLUDE_TESTS=OFF -DLLVM_ENABLE_ZSTD=OFF
+          cmake ..\llvm-src -Thost=x64 -DLLVM_TARGETS_TO_BUILD="X86;AArch64" -DCMAKE_MSVC_RUNTIME_LIBRARY=MultiThreaded -DBUILD_SHARED_LIBS=OFF -DCMAKE_FIND_USE_SYSTEM_ENVIRONMENT_PATH=OFF -DLLVM_INCLUDE_BENCHMARKS=OFF -DLLVM_INCLUDE_TESTS=OFF -DLLVM_ENABLE_ZSTD=OFF
           cmake --build . --config Release
           cmake "-DCMAKE_INSTALL_PREFIX=$(pwd)\..\llvm" -P cmake_install.cmake
 


### PR DESCRIPTION
The minimum CMake version required to build LLVM is bumped, and as a result `LLVM_USE_CRT_*` is now deprecated.