### PR TITLE
Add macro methods for `MacroIf` and `MacroFor` nodes

### DIFF
--- a/spec/compiler/macro/macro_methods_spec.cr
+++ b/spec/compiler/macro/macro_methods_spec.cr
@@ -2517,6 +2517,20 @@ module Crystal
       end
     end
 
+    describe "macro for methods" do
+      it "executes vars" do
+        assert_macro %({{x.vars}}), "[bar]", {x: MacroFor.new([Var.new("bar")], Var.new("foo"), Call.new(nil, "puts", [Var.new("bar")] of ASTNode))}
+      end
+
+      it "executes exp" do
+        assert_macro %({{x.exp}}), "foo", {x: MacroFor.new([Var.new("bar")], Var.new("foo"), Call.new(nil, "puts", [Var.new("bar")] of ASTNode))}
+      end
+
+      it "executes body" do
+        assert_macro %({{x.body}}), "puts(bar)", {x: MacroFor.new([Var.new("bar")], Var.new("foo"), Call.new(nil, "puts", [Var.new("bar")] of ASTNode))}
+      end
+    end
+
     describe "unary expression methods" do
       it "executes exp" do
         assert_macro %({{x.exp}}), "some_call", {x: Not.new("some_call".call)}

--- a/spec/compiler/macro/macro_methods_spec.cr
+++ b/spec/compiler/macro/macro_methods_spec.cr
@@ -2503,6 +2503,20 @@ module Crystal
       end
     end
 
+    describe "macro if methods" do
+      it "executes cond" do
+        assert_macro %({{x.cond}}), "true", {x: MacroIf.new(BoolLiteral.new(true), NilLiteral.new)}
+      end
+
+      it "executes then" do
+        assert_macro %({{x.then}}), "\"test\"", {x: MacroIf.new(BoolLiteral.new(true), StringLiteral.new("test"), StringLiteral.new("foo"))}
+      end
+
+      it "executes else" do
+        assert_macro %({{x.else}}), "\"foo\"", {x: MacroIf.new(BoolLiteral.new(true), StringLiteral.new("test"), StringLiteral.new("foo"))}
+      end
+    end
+
     describe "unary expression methods" do
       it "executes exp" do
         assert_macro %({{x.exp}}), "some_call", {x: Not.new("some_call".call)}

--- a/src/compiler/crystal/macros.cr
+++ b/src/compiler/crystal/macros.cr
@@ -1917,7 +1917,7 @@ module Crystal::Macros
     def exp : ASTNode
     end
 
-    # The body to be executed for each item.
+    # The body of the `for` loop.
     def body : ASTNode
     end
   end

--- a/src/compiler/crystal/macros.cr
+++ b/src/compiler/crystal/macros.cr
@@ -1878,9 +1878,28 @@ module Crystal::Macros
   # class MacroLiteral < ASTNode
   # end
 
-  # if inside a macro
-  # class MacroIf < ASTNode
-  # end
+  # An `if` inside a macro, e.g.
+  #
+  # ```
+  # {% if cond %}
+  #   puts "Then"
+  # {% else %}
+  #   puts "Else"
+  # {% end %}
+  # ```
+  class MacroIf < ASTNode
+    # The condition of the `if` clause
+    def cond : ASTNode
+    end
+
+    # The code to be executed when the condition is truthy
+    def then : ASTNode
+    end
+
+    # The code to be executed when the condition is falsey
+    def else : ASTNode
+    end
+  end
 
   # for inside a macro:
   # class MacroFor < ASTNode

--- a/src/compiler/crystal/macros.cr
+++ b/src/compiler/crystal/macros.cr
@@ -1888,15 +1888,15 @@ module Crystal::Macros
   # {% end %}
   # ```
   class MacroIf < ASTNode
-    # The condition of the `if` clause
+    # The condition of the `if` clause.
     def cond : ASTNode
     end
 
-    # The code to be executed when the condition is truthy
+    # The `then` branch of the `if`.
     def then : ASTNode
     end
 
-    # The code to be executed when the condition is falsey
+    # The `else` branch of the `if`.
     def else : ASTNode
     end
   end
@@ -1909,15 +1909,15 @@ module Crystal::Macros
   # {% end %}
   # ```
   class MacroFor < ASTNode
-    # The variables declared after `for`
+    # The variables declared after `for`.
     def vars : ArrayLiteral(Var)
     end
 
-    # The expression after `in`
+    # The expression after `in`.
     def exp : ASTNode
     end
 
-    # The body to be executed for each item
+    # The body to be executed for each item.
     def body : ASTNode
     end
   end

--- a/src/compiler/crystal/macros.cr
+++ b/src/compiler/crystal/macros.cr
@@ -1901,9 +1901,26 @@ module Crystal::Macros
     end
   end
 
-  # for inside a macro:
-  # class MacroFor < ASTNode
-  # end
+  # A `for` loop inside a macro, e.g.
+  #
+  # ```
+  # {% for x in exp %}
+  #   puts {{x}}
+  # {% end %}
+  # ```
+  class MacroFor < ASTNode
+    # The variables declared after `for`
+    def vars : ArrayLiteral(Var)
+    end
+
+    # The expression after `in`
+    def exp : ASTNode
+    end
+
+    # The body to be executed for each item
+    def body : ASTNode
+    end
+  end
 
   # The `_` expression. May appear in code, such as an assignment target, and in
   # type names.

--- a/src/compiler/crystal/macros/methods.cr
+++ b/src/compiler/crystal/macros/methods.cr
@@ -1465,6 +1465,21 @@ module Crystal
     end
   end
 
+  class MacroIf
+    def interpret(method : String, args : Array(ASTNode), named_args : Hash(String, ASTNode)?, block : Crystal::Block?, interpreter : Crystal::MacroInterpreter, name_loc : Location?)
+      case method
+      when "cond"
+        interpret_check_args { @cond }
+      when "then"
+        interpret_check_args { @then }
+      when "else"
+        interpret_check_args { @else }
+      else
+        super
+      end
+    end
+  end
+
   class UnaryExpression
     def interpret(method : String, args : Array(ASTNode), named_args : Hash(String, ASTNode)?, block : Crystal::Block?, interpreter : Crystal::MacroInterpreter, name_loc : Location?)
       case method

--- a/src/compiler/crystal/macros/methods.cr
+++ b/src/compiler/crystal/macros/methods.cr
@@ -1480,6 +1480,21 @@ module Crystal
     end
   end
 
+  class MacroFor
+    def interpret(method : String, args : Array(ASTNode), named_args : Hash(String, ASTNode)?, block : Crystal::Block?, interpreter : Crystal::MacroInterpreter, name_loc : Location?)
+      case method
+      when "vars"
+        interpret_check_args { ArrayLiteral.map(@vars, &.itself) }
+      when "exp"
+        interpret_check_args { @exp }
+      when "body"
+        interpret_check_args { @body }
+      else
+        super
+      end
+    end
+  end
+
   class UnaryExpression
     def interpret(method : String, args : Array(ASTNode), named_args : Hash(String, ASTNode)?, block : Crystal::Block?, interpreter : Crystal::MacroInterpreter, name_loc : Location?)
       case method

--- a/src/compiler/crystal/macros/types.cr
+++ b/src/compiler/crystal/macros/types.cr
@@ -88,6 +88,7 @@ module Crystal
       @macro_types["Cast"] = NonGenericMacroType.new self, "Cast", ast_node
       @macro_types["NilableCast"] = NonGenericMacroType.new self, "NilableCast", ast_node
       @macro_types["MacroId"] = NonGenericMacroType.new self, "MacroId", ast_node
+      @macro_types["MacroFor"] = NonGenericMacroType.new self, "MacroFor", ast_node
       @macro_types["MacroIf"] = NonGenericMacroType.new self, "MacroIf", ast_node
       @macro_types["TypeNode"] = NonGenericMacroType.new self, "TypeNode", ast_node
 
@@ -115,7 +116,6 @@ module Crystal
       @macro_types["Include"] = NonGenericMacroType.new self, "Include", ast_node
       @macro_types["TypeDef"] = NonGenericMacroType.new self, "TypeDef", ast_node
       @macro_types["MacroExpression"] = NonGenericMacroType.new self, "MacroExpression", ast_node
-      @macro_types["MacroFor"] = NonGenericMacroType.new self, "MacroFor", ast_node
       @macro_types["MacroLiteral"] = NonGenericMacroType.new self, "MacroLiteral", ast_node
       @macro_types["MacroVar"] = NonGenericMacroType.new self, "MacroVar", ast_node
       @macro_types["MacroVerbatim"] = NonGenericMacroType.new self, "MacroVerbatim", unary_expression

--- a/src/compiler/crystal/macros/types.cr
+++ b/src/compiler/crystal/macros/types.cr
@@ -88,6 +88,7 @@ module Crystal
       @macro_types["Cast"] = NonGenericMacroType.new self, "Cast", ast_node
       @macro_types["NilableCast"] = NonGenericMacroType.new self, "NilableCast", ast_node
       @macro_types["MacroId"] = NonGenericMacroType.new self, "MacroId", ast_node
+      @macro_types["MacroIf"] = NonGenericMacroType.new self, "MacroIf", ast_node
       @macro_types["TypeNode"] = NonGenericMacroType.new self, "TypeNode", ast_node
 
       # bottom type
@@ -115,7 +116,6 @@ module Crystal
       @macro_types["TypeDef"] = NonGenericMacroType.new self, "TypeDef", ast_node
       @macro_types["MacroExpression"] = NonGenericMacroType.new self, "MacroExpression", ast_node
       @macro_types["MacroFor"] = NonGenericMacroType.new self, "MacroFor", ast_node
-      @macro_types["MacroIf"] = NonGenericMacroType.new self, "MacroIf", ast_node
       @macro_types["MacroLiteral"] = NonGenericMacroType.new self, "MacroLiteral", ast_node
       @macro_types["MacroVar"] = NonGenericMacroType.new self, "MacroVar", ast_node
       @macro_types["MacroVerbatim"] = NonGenericMacroType.new self, "MacroVerbatim", unary_expression


### PR DESCRIPTION
This fixes a small part of [#3274](https://github.com/crystal-lang/crystal/issues/3274#issuecomment-860092436) (cc @HertzDevil). I implemented these methods because I need them for a DSL macro that alters every node of a given block. It should leave macro `if`s and `for`s as they are while still altering their bodies, so I needed a way to reconstruct those nodes from their parts.

This is my very first PR for Crystal, please let me know if anything is not as it's supposed to be!