### PR TITLE
Add `CharLiteral#ord`

### DIFF
--- a/spec/compiler/macro/macro_methods_spec.cr
+++ b/spec/compiler/macro/macro_methods_spec.cr
@@ -367,6 +367,13 @@ module Crystal
       end
     end
 
+    describe "char methods" do
+      it "executes ord" do
+        assert_macro %({{'a'.ord}}), %(97)
+        assert_macro %({{'龍'.ord}}), %(40845)
+      end
+    end
+
     describe "string methods" do
       it "executes string == string" do
         assert_macro %({{"foo" == "foo"}}), %(true)

--- a/src/compiler/crystal/macros.cr
+++ b/src/compiler/crystal/macros.cr
@@ -562,6 +562,10 @@ module Crystal::Macros
     # Returns a `MacroId` for this character's contents.
     def id : MacroId
     end
+
+    # Similar to `Char#ord`.
+    def ord : NumberLiteral
+    end
   end
 
   # A string literal.

--- a/src/compiler/crystal/macros/methods.cr
+++ b/src/compiler/crystal/macros/methods.cr
@@ -602,6 +602,19 @@ module Crystal
     def to_macro_id
       @value.to_s
     end
+
+    def interpret(method : String, args : Array(ASTNode), named_args : Hash(String, ASTNode)?, block : Crystal::Block?, interpreter : Crystal::MacroInterpreter, name_loc : Location?)
+      case method
+      when "ord"
+        interpret_check_args { NumberLiteral.new(ord) }
+      else
+        super
+      end
+    end
+
+    def ord
+      @value.ord
+    end
   end
 
   class StringLiteral


### PR DESCRIPTION
This is extremely useful for doing byte-based operations on characters in compile-time contexts.

Fixes #9830.