### PR TITLE
Fix `Process.exists?` throwing errors on EPERM

### DIFF
--- a/src/crystal/system/unix/process.cr
+++ b/src/crystal/system/unix/process.cr
@@ -79,8 +79,14 @@ struct Crystal::System::Process
     if ret == 0
       true
     else
-      return false if Errno.value == Errno::ESRCH
-      raise RuntimeError.from_errno("kill")
+      case Errno.value
+      when Errno::EPERM
+        true
+      when Errno::ESRCH
+        false
+      else
+        raise RuntimeError.from_errno("kill")
+      end
     end
   end
 


### PR DESCRIPTION
`kill(3p)` says that EPERM is returned if the process "does not have permission to send the signal to any receiving process". If that happens, then it's effectively confirmation that the process exists and thus shouldn't result in throwing an error.