### PR TITLE
Drop `Char::Reader#@end`

### DIFF
--- a/spec/std/char/reader_spec.cr
+++ b/spec/std/char/reader_spec.cr
@@ -102,6 +102,7 @@ describe "Char::Reader" do
     reader.pos.should eq(0)
     reader.current_char.ord.should eq(0)
     reader.has_previous?.should be_false
+    reader.has_next?.should be_false
   end
 
   it "gets previous char (ascii)" do
@@ -109,8 +110,10 @@ describe "Char::Reader" do
     reader.pos.should eq(4)
     reader.current_char.should eq('o')
     reader.has_previous?.should be_true
+    reader.has_next?.should be_true
 
     reader.previous_char.should eq('l')
+    reader.has_next?.should be_true
     reader.previous_char.should eq('l')
     reader.previous_char.should eq('e')
     reader.previous_char.should eq('h')
@@ -126,8 +129,10 @@ describe "Char::Reader" do
     reader.pos.should eq(9)
     reader.current_char.should eq('語')
     reader.has_previous?.should be_true
+    reader.has_next?.should be_true
 
     reader.previous_char.should eq('本')
+    reader.has_next?.should be_true
     reader.previous_char.should eq('日')
     reader.previous_char.should eq('á')
     reader.previous_char.should eq('h')

--- a/src/char/reader.cr
+++ b/src/char/reader.cr
@@ -59,7 +59,6 @@ struct Char
       @pos = pos.to_i
       @current_char = '\0'
       @current_char_width = 0
-      @end = false
       decode_current_char
     end
 
@@ -69,7 +68,6 @@ struct Char
       @pos = @string.bytesize
       @current_char = '\0'
       @current_char_width = 0
-      @end = false
       decode_previous_char
     end
 
@@ -83,7 +81,7 @@ struct Char
     # reader.peek_next_char # => '\0'
     # ```
     def has_next? : Bool
-      !@end
+      @pos < @string.bytesize
     end
 
     # Reads the next character in the string,
@@ -177,7 +175,7 @@ struct Char
     # C
     # ```
     def each(&) : Nil
-      while @pos < @string.bytesize
+      while has_next?
         yield current_char
 
         @pos += @current_char_width
@@ -251,26 +249,22 @@ struct Char
     private def decode_current_char
       decode_char_at(@pos) do |code_point, width, error|
         @current_char_width = width
-        @end = @pos == @string.bytesize
         @error = error
         @current_char = code_point.unsafe_chr
       end
     end
 
     private def decode_previous_char
-      if @pos == 0
-        @end = @pos == @string.bytesize
-      else
-        while @pos > 0
-          @pos -= 1
-          break if (byte_at(@pos) & 0xC0) != 0x80
-        end
-        decode_char_at(@pos) do |code_point, width, error|
-          @current_char_width = width
-          @end = @pos == @string.bytesize
-          @error = error
-          @current_char = code_point.unsafe_chr
-        end
+      return if @pos == 0
+
+      while @pos > 0
+        @pos -= 1
+        break if (byte_at(@pos) & 0xC0) != 0x80
+      end
+      decode_char_at(@pos) do |code_point, width, error|
+        @current_char_width = width
+        @error = error
+        @current_char = code_point.unsafe_chr
       end
     end
 


### PR DESCRIPTION
This is a follow-up to #13817 which removed one of the two places that read the value of `Char::Reader#@end`. It was replaced by a comparison `@pos < @string.bytesize`. This expression is always quivalent to `@end`, so it's entirely redundant. 
This patch removes the remaining use in `#has_next?` and removes the instance variable entirely.
Additionaly, the implementation of `#each` switches back to use `#has_next?` as it was before #13817.

See also #13816 for some prior discussion.