### PR TITLE
Fix infinite recursion of expanded nodes in `UnreachableVisitor`

### DIFF
--- a/src/compiler/crystal/tools/unreachable.cr
+++ b/src/compiler/crystal/tools/unreachable.cr
@@ -70,7 +70,7 @@ module Crystal
   class UnreachableVisitor < Visitor
     @used_def_locations = Set(Location).new
     @defs : Set(Def) = Set(Def).new.compare_by_identity
-    @visited_defs : Set(Def) = Set(Def).new.compare_by_identity
+    @visited : Set(ASTNode) = Set(ASTNode).new.compare_by_identity
 
     property includes = [] of String
     property excludes = [] of String
@@ -102,6 +102,8 @@ module Crystal
     end
 
     def visit(node : ExpandableNode)
+      return false unless @visited.add?(node)
+
       if expanded = node.expanded
         expanded.accept self
       end
@@ -121,7 +123,7 @@ module Crystal
           @used_def_locations << location if interested_in(location)
         end
 
-        if @visited_defs.add?(a_def)
+        if @visited.add?(a_def)
           a_def.body.accept(self)
         end
       end


### PR DESCRIPTION
We're already remembering which def bodies have been visited in order to prevent revisits. Apparently, `ExpandableNode` can be reached multiple times as well.
This patch generalizes the register to contain any `ASTNode` and uses it for `ExpandableNode` as well.

This bug appeard for `crystal tool unreachable spec/compiler_spec.cr`. With this patch it works fine.
I could not find a reduced example for a spec.