### PR TITLE
Add CSV output format to `crystal tool unreachable`

### DIFF
--- a/src/compiler/crystal/tools/unreachable.cr
+++ b/src/compiler/crystal/tools/unreachable.cr
@@ -6,7 +6,7 @@ require "csv"
 module Crystal
   class Command
     private def unreachable
-      config, result = compile_no_codegen "tool unreachable", path_filter: true, unreachable_command: true, allowed_formats: ["text", "json", "csv"]
+      config, result = compile_no_codegen "tool unreachable", path_filter: true, unreachable_command: true, allowed_formats: %w[text json csv]
 
       unreachable = UnreachableVisitor.new
 
@@ -25,7 +25,7 @@ module Crystal
         }
       end
 
-      UnreachablePresenter.new(defs, format: config.output_format || "text").to_s(STDOUT)
+      UnreachablePresenter.new(defs, format: config.output_format).to_s(STDOUT)
 
       if config.check
         exit 1 unless defs.empty?

--- a/src/compiler/crystal/tools/unreachable.cr
+++ b/src/compiler/crystal/tools/unreachable.cr
@@ -1,11 +1,12 @@
 require "../syntax/ast"
 require "../compiler"
 require "json"
+require "csv"
 
 module Crystal
   class Command
     private def unreachable
-      config, result = compile_no_codegen "tool unreachable", path_filter: true, unreachable_command: true
+      config, result = compile_no_codegen "tool unreachable", path_filter: true, unreachable_command: true, allowed_formats: ["text", "json", "csv"]
 
       unreachable = UnreachableVisitor.new
 
@@ -24,7 +25,7 @@ module Crystal
         }
       end
 
-      UnreachablePresenter.new(defs, format: config.output_format).to_s(STDOUT)
+      UnreachablePresenter.new(defs, format: config.output_format || "text").to_s(STDOUT)
 
       if config.check
         exit 1 unless defs.empty?
@@ -39,6 +40,8 @@ module Crystal
       case format
       when "json"
         to_json(STDOUT)
+      when "csv"
+        to_csv(STDOUT)
       else
         to_text(STDOUT)
       end
@@ -79,6 +82,22 @@ module Crystal
             if annotations = a_def.all_annotations
               builder.field "annotations", annotations.map(&.to_s)
             end
+          end
+        end
+      end
+    end
+
+    def to_csv(io)
+      CSV.build(io) do |builder|
+        builder.row %w[name file line column length annotations]
+        each do |a_def, location|
+          builder.row do |row|
+            row << a_def.short_reference
+            row << location.filename
+            row << location.line_number
+            row << location.column_number
+            row << a_def.length
+            row << a_def.all_annotations.try(&.join(" "))
           end
         end
       end


### PR DESCRIPTION
The CSV format makes it easy to use the output for data analysis.

Example output:

```csv
name,file,line,column,length,annotations
top-level foo,.test/foobar.cr,1,1,3,
top-level foo,.test/foobar.cr,7,1,3,"@[Deprecated(""You should use `bar`"")] @[Experimental]"
top-level bar,.test/foobar.cr,13,1,3,"@[Deprecated(""You should use `foo`\nreally!"")]"
Foo#foo,.test/foobar.cr,24,3,2,
Foo.foo,.test/foobar.cr,30,3,2,
top-level foo_yield,.test/foobar.cr,40,1,3,
top-level foo_proc,.test/foobar.cr,50,1,3,
"FooG(G, H)#foo",.test/foobar.cr,69,3,2,
```