### PR TITLE
Add annotations to output of `crystal tool unreachable`

### DIFF
--- a/src/compiler/crystal/tools/unreachable.cr
+++ b/src/compiler/crystal/tools/unreachable.cr
@@ -42,6 +42,10 @@ module Crystal
         io << a_def.location << "\t"
         io << a_def.short_reference << "\t"
         io << a_def.length << " lines"
+        if annotations = a_def.all_annotations
+          io << "\t"
+          annotations.join(io, " ")
+        end
         io.puts
       end
     end
@@ -54,6 +58,9 @@ module Crystal
             builder.field "location", a_def.location.to_s
             if lines = a_def.length
               builder.field "lines", lines
+            end
+            if annotations = a_def.all_annotations
+              builder.field "annotations", annotations.map(&.to_s)
             end
           end
         end


### PR DESCRIPTION
Annotations can be helpful for analyzing unreachable defs. For example, a def with annotation `Deprecated` could be considered as less relevant.
This information is easily available, so it's a simple to change to make it available in the output.

Example output:
```txt
foobar.cr:1:1     top-level foo   3 lines
foobar.cr:7:1     top-level foo   3 lines @[Deprecated("You should use bar")] @[Experimental]
foobar.cr:11:1    top-level bar   3 lines @[Deprecated("You should use foo\nreally!")]
```