### PR TITLE
Fix location of global `Path` nodes in certain constructs

### DIFF
--- a/spec/compiler/parser/parser_spec.cr
+++ b/spec/compiler/parser/parser_spec.cr
@@ -2736,5 +2736,17 @@ module Crystal
       node = Parser.parse(source).as(EnumDef).members.first
       node_source(source, node).should eq("protected macro foo; end")
     end
+
+    it "sets correct location of global path in class def" do
+      source = "class ::Foo; end"
+      node = Parser.parse(source).as(ClassDef).name
+      node_source(source, node).should eq("::Foo")
+    end
+
+    it "sets correct location of global path in annotation" do
+      source = "@[::Foo]"
+      node = Parser.parse(source).as(Annotation).path
+      node_source(source, node).should eq("::Foo")
+    end
   end
 end

--- a/src/compiler/crystal/syntax/parser.cr
+++ b/src/compiler/crystal/syntax/parser.cr
@@ -5101,7 +5101,7 @@ module Crystal
         global = true
       end
 
-      path = parse_path(global, @token.location)
+      path = parse_path(global, location)
       skip_space
       path
     end


### PR DESCRIPTION
Some global `Path` nodes had their leading `::` ignored when their locations are computed:

```crystal
macro f(x)
  {{ x.name.column_number }}
end

f(@[::Foo]) # => 7
```

```crystal
enum Foo
  X
end

class ::Foo::Bar
end
# In test.cr:5:9
#
#  5 | class ::Foo::Bar
#              ^----
# Error: can't declare type inside enum Foo
```