### PR TITLE
Fix `crystal docs` check `File.exists?` for `shard.yml`

### DIFF
--- a/src/compiler/crystal/tools/doc/project_info.cr
+++ b/src/compiler/crystal/tools/doc/project_info.cr
@@ -160,7 +160,7 @@ module Crystal::Doc
     end
 
     def self.read_shard_properties
-      return {nil, nil} unless File.readable?("shard.yml")
+      return {nil, nil} unless File.exists?("shard.yml")
 
       name = nil
       version = nil


### PR DESCRIPTION
`File.readable?` ignores `shard.yml` if it exists but is not readable for the process.

I think `File.exists?` is better suited here. If the file exists, it should be expected to be readable. If it is not, that's likely an errror which the user would like to know about.