### PR TITLE
Generalize allowed values for compiler CLI `--format` option

### DIFF
--- a/src/compiler/crystal/command.cr
+++ b/src/compiler/crystal/command.cr
@@ -344,8 +344,7 @@ class Crystal::Command
     specified_output : Bool,
     hierarchy_exp : String?,
     cursor_location : String?,
-    output_format : String?,
-    dependency_output_format : DependencyPrinter::Format,
+    output_format : String,
     combine_rpath : Bool,
     includes : Array(String),
     excludes : Array(String),
@@ -378,7 +377,6 @@ class Crystal::Command
     hierarchy_exp = nil
     cursor_location = nil
     output_format = nil
-    dependency_output_format = nil
     excludes = [] of String
     includes = [] of String
     verbose = false
@@ -427,11 +425,6 @@ class Crystal::Command
       end
 
       if dependencies
-        opts.on("-f tree|flat|dot|mermaid", "--format tree|flat|dot|mermaid", "Output format tree (default), flat, dot, or mermaid") do |f|
-          dependency_output_format = DependencyPrinter::Format.parse?(f)
-          error "Invalid format: #{f}. Options are: tree, flat, dot, or mermaid" unless dependency_output_format
-        end
-
         opts.on("-i <path>", "--include <path>", "Include path") do |f|
           includes << f
         end
@@ -443,10 +436,10 @@ class Crystal::Command
         opts.on("--verbose", "Show skipped and filtered paths") do
           verbose = true
         end
-      else
-        opts.on("-f #{allowed_formats.join("|")}", "--format #{allowed_formats.join("|")}", "Output format: #{allowed_formats[0]} (default), #{allowed_formats[1..].join(", ")}") do |f|
-          output_format = f
-        end
+      end
+
+      opts.on("-f #{allowed_formats.join("|")}", "--format #{allowed_formats.join("|")}", "Output format: #{allowed_formats[0]} (default), #{allowed_formats[1..].join(", ")}") do |f|
+        output_format = f
       end
 
       if unreachable_command
@@ -598,9 +591,7 @@ class Crystal::Command
       end
     end
 
-    dependency_output_format ||= DependencyPrinter::Format::Tree
-
-    output_format ||= "text"
+    output_format ||= allowed_formats[0]
     unless output_format.in?(allowed_formats)
       error "You have input an invalid format: #{output_format}. Supported formats: #{allowed_formats.join(", ")}"
     end
@@ -617,8 +608,8 @@ class Crystal::Command
 
     combine_rpath = run && !no_codegen
     @config = CompilerConfig.new compiler, sources, output_filename, emit_base_filename,
-      arguments, specified_output, hierarchy_exp, cursor_location, output_format,
-      dependency_output_format.not_nil!, combine_rpath, includes, excludes, verbose, check
+      arguments, specified_output, hierarchy_exp, cursor_location, output_format.not_nil!,
+      combine_rpath, includes, excludes, verbose, check
   end
 
   private def gather_sources(filenames)

--- a/src/compiler/crystal/command.cr
+++ b/src/compiler/crystal/command.cr
@@ -247,8 +247,8 @@ class Crystal::Command
     end
   end
 
-  private def compile_no_codegen(command, wants_doc = false, hierarchy = false, no_cleanup = false, cursor_command = false, top_level = false, path_filter = false, unreachable_command = false)
-    config = create_compiler command, no_codegen: true, hierarchy: hierarchy, cursor_command: cursor_command, path_filter: path_filter, unreachable_command: unreachable_command
+  private def compile_no_codegen(command, wants_doc = false, hierarchy = false, no_cleanup = false, cursor_command = false, top_level = false, path_filter = false, unreachable_command = false, allowed_formats = ["text", "json"])
+    config = create_compiler command, no_codegen: true, hierarchy: hierarchy, cursor_command: cursor_command, path_filter: path_filter, unreachable_command: unreachable_command, allowed_formats: allowed_formats
     config.compiler.no_codegen = true
     config.compiler.no_cleanup = no_cleanup
     config.compiler.wants_doc = wants_doc
@@ -364,7 +364,8 @@ class Crystal::Command
   private def create_compiler(command, no_codegen = false, run = false,
                               hierarchy = false, cursor_command = false,
                               single_file = false, dependencies = false,
-                              path_filter = false, unreachable_command = false)
+                              path_filter = false, unreachable_command = false,
+                              allowed_formats = ["text", "json"])
     compiler = new_compiler
     compiler.progress_tracker = @progress_tracker
     link_flags = [] of String
@@ -443,7 +444,7 @@ class Crystal::Command
           verbose = true
         end
       else
-        opts.on("-f text|json", "--format text|json", "Output format text (default) or json") do |f|
+        opts.on("-f #{allowed_formats.join("|")}", "--format #{allowed_formats.join("|")}", "Output format: #{allowed_formats[0]} (default), #{allowed_formats[1..].join(", ")}") do |f|
           output_format = f
         end
       end
@@ -600,8 +601,8 @@ class Crystal::Command
     dependency_output_format ||= DependencyPrinter::Format::Tree
 
     output_format ||= "text"
-    unless output_format.in?("text", "json")
-      error "You have input an invalid format, only text and JSON are supported"
+    unless output_format.in?(allowed_formats)
+      error "You have input an invalid format: #{output_format}. Supported formats: #{allowed_formats.join(", ")}"
     end
 
     error "maximum number of threads cannot be lower than 1" if compiler.n_threads < 1

--- a/src/compiler/crystal/tools/dependencies.cr
+++ b/src/compiler/crystal/tools/dependencies.cr
@@ -4,9 +4,9 @@ require "../syntax/ast"
 
 class Crystal::Command
   private def dependencies
-    config = create_compiler "tool dependencies", no_codegen: true, dependencies: true
+    config = create_compiler "tool dependencies", no_codegen: true, dependencies: true, allowed_formats: DependencyPrinter::Format.names.map!(&.downcase)
 
-    dependency_printer = DependencyPrinter.create(STDOUT, format: config.dependency_output_format, verbose: config.verbose)
+    dependency_printer = DependencyPrinter.create(STDOUT, format: DependencyPrinter::Format.parse(config.output_format), verbose: config.verbose)
 
     dependency_printer.includes.concat config.includes.map { |path| ::Path[path].expand.to_s }
     dependency_printer.excludes.concat config.excludes.map { |path| ::Path[path].expand.to_s }
@@ -21,8 +21,8 @@ end
 module Crystal
   abstract class DependencyPrinter
     enum Format
-      Flat
       Tree
+      Flat
       Dot
       Mermaid
     end


### PR DESCRIPTION
Refactors handling of the `--format` option to be universal. Commands can pass in their specific format options.
This already reduces some duplicate code that was introduced for the specific formats of `crystal tool dependencies`.

It'll be useful for further output format enhancements (such as `crystal tool unreachable` in #13926).