### PR TITLE
Refactor `UnreachablePresenter`

### DIFF
--- a/spec/compiler/crystal/tools/unreachable_spec.cr
+++ b/spec/compiler/crystal/tools/unreachable_spec.cr
@@ -11,9 +11,7 @@ def processed_unreachable_visitor(code)
   visitor.excludes << Path[Dir.current].to_posix.to_s
   visitor.includes << "."
 
-  process_result = visitor.process(result)
-
-  {visitor, process_result}
+  visitor.process(result)
 end
 
 private def assert_unreachable(code, file = __FILE__, line = __LINE__)
@@ -27,9 +25,9 @@ private def assert_unreachable(code, file = __FILE__, line = __LINE__)
 
   code = code.gsub('༓', "")
 
-  visitor, result = processed_unreachable_visitor(code)
+  defs = processed_unreachable_visitor(code)
 
-  result_location = result.defs.try &.compact_map(&.location).sort_by! do |loc|
+  result_location = defs.try &.compact_map(&.location).sort_by! do |loc|
     {loc.filename.as(String), loc.line_number, loc.column_number}
   end.map(&.to_s)
 

--- a/src/compiler/crystal/tools/unreachable.cr
+++ b/src/compiler/crystal/tools/unreachable.cr
@@ -6,7 +6,6 @@ module Crystal
   class Command
     private def unreachable
       config, result = compile_no_codegen "tool unreachable", path_filter: true, unreachable_command: true
-      format = config.output_format
 
       unreachable = UnreachableVisitor.new
 
@@ -25,12 +24,7 @@ module Crystal
         }
       end
 
-      case format
-      when "json"
-        defs.to_json(STDOUT)
-      else
-        defs.to_text(STDOUT)
-      end
+      defs.to_s(STDOUT, format: config.output_format)
 
       if config.check
         exit 1 unless defs.defs.empty?
@@ -40,6 +34,15 @@ module Crystal
 
   record UnreachableResult, defs : Array(Def) do
     include JSON::Serializable
+
+    def to_s(io, *, format)
+      case format
+      when "json"
+        to_json(STDOUT)
+      else
+        to_text(STDOUT)
+      end
+    end
 
     def to_text(io)
       defs.each do |a_def|


### PR DESCRIPTION
This is a tiny code cleanup for the `crystal tool unreachable` command. It clearly separates the data returned from the compiler visitor and its representation.