### PR TITLE
Fix portable shell command arguments in `Process#prepare_args`

### DIFF
--- a/src/crystal/system/unix/process.cr
+++ b/src/crystal/system/unix/process.cr
@@ -211,16 +211,12 @@ struct Crystal::System::Process
   def self.prepare_args(command : String, args : Enumerable(String)?, shell : Bool) : Array(String)
     if shell
       command = %(#{command} "${@}") unless command.includes?(' ')
-      shell_args = ["/bin/sh", "-c", command, "--"]
+      shell_args = ["/bin/sh", "-c", command, "sh"]
 
       if args
         unless command.includes?(%("${@}"))
           raise ArgumentError.new(%(Can't specify arguments in both command and args without including "${@}" into your command))
         end
-
-        {% if flag?(:freebsd) || flag?(:dragonfly) %}
-          shell_args << ""
-        {% end %}
 
         shell_args.concat(args)
       end


### PR DESCRIPTION
fix: #13919

Not sure if the discussion on #13919 is done, but pushing it as a start just in case there are any issues missed

I haven't noticed anything on linux-gnu and was able to compile the compiler with it. BSDs might need more testing if the smoke test is not enough though