### PR TITLE
Fix `ToSVisitor` for expanded string interpolation in backticks

### DIFF
--- a/spec/compiler/parser/to_s_spec.cr
+++ b/spec/compiler/parser/to_s_spec.cr
@@ -178,6 +178,7 @@ describe "ASTNode#to_s" do
   expect_to_s %q(%r{#{1}\/\0}), %q(/#{1}\/\0/)
   expect_to_s %q(`\n\0`), %q(`\n\u0000`)
   expect_to_s %q(`#{1}\n\0`), %q(`#{1}\n\u0000`)
+  expect_to_s Call.new(nil, "`", Call.new("String".path, "interpolation", "x".var, global: true)), %q(`#{::String.interpolation(x)}`)
   expect_to_s "macro foo\n{% verbatim do %}1{% end %}\nend"
   expect_to_s Assign.new("x".var, Expressions.new([1.int32, 2.int32] of ASTNode)), "x = (1\n2\n)"
   expect_to_s "foo.*"

--- a/src/compiler/crystal/syntax/to_s.cr
+++ b/src/compiler/crystal/syntax/to_s.cr
@@ -511,7 +511,13 @@ module Crystal
       when StringInterpolation
         visit_interpolation exp, &.inspect_unquoted.gsub('`', "\\`")
       else
-        raise "Bug: shouldn't happen"
+        # This branch can be reached after the literal expander has expanded
+        # `StringLiteral` nodes to a call to `::String.interpolation` which means
+        # `exp` is a `Call`.
+
+        @str << "\#{"
+        exp.accept(self)
+        @str << "}"
       end
       @str << '`'
       false


### PR DESCRIPTION
The compiler normalizes `StringInterpolation` nodes into a call to `String.interpolation`. 
If such an interpolation is used inside a backticks literal like `` `#{foo}` ``, it normalizes to something like `` grave(::String.interpolation(foo)) ``.[^1]

The `ToSVisitor` does not expect the argument of a backtick method call to be a call.
Hence it errors if such a node would be stringified.
This patch fixes that.

[^1]: I don't think backtick calls can be expressed using normal call syntax so I used the method name `grave` instead for demonstration purposes. Consider it to be a call to the backtick method.