### PR TITLE
Improve performance of `JSON::Builder#string` with direct stringification

### DIFF
--- a/src/json/builder.cr
+++ b/src/json/builder.cr
@@ -137,7 +137,7 @@ class JSON::Builder
     end
   end
 
-  class Escape < IO
+  private class Escape < IO
     def initialize(@io : IO)
     end
 

--- a/src/json/builder.cr
+++ b/src/json/builder.cr
@@ -25,6 +25,7 @@ class JSON::Builder
   def initialize(@io : IO)
     @state = [StartState.new] of State
     @current_indent = 0
+    @escape = Escape.new(io)
   end
 
   # Starts a document.
@@ -101,13 +102,32 @@ class JSON::Builder
   #
   # This method can also be used to write the name of an object field.
   def string(value) : Nil
-    string = value.to_s
+    string do |io|
+      value.to_s(io)
+    end
+  end
 
+  def string(& : IO ->) : Nil
     scalar(string: true) do
       io << '"'
+      yield @escape
+      io << '"'
+    end
+  end
 
-      cursor = start = string.to_unsafe
-      fin = cursor + string.bytesize
+  class Escape < IO
+    def initialize(@io : IO)
+    end
+
+    delegate :flush, :tty?, :pos, :pos=, :seek, to: @io
+
+    def read(slice : Bytes)
+      raise ""
+    end
+
+    def write(slice : Bytes) : Nil
+      cursor = start = slice.to_unsafe
+      fin = cursor + slice.bytesize
 
       while cursor < fin
         case byte = cursor.value
@@ -118,11 +138,11 @@ class JSON::Builder
         when '\n' then escape = "\\n"
         when '\r' then escape = "\\r"
         when '\t' then escape = "\\t"
-        when .<(0x20), 0x7F # Char#ascii_control?
-          io.write_string Slice.new(start, cursor - start)
-          io << "\\u00"
-          io << '0' if byte < 0x10
-          byte.to_s(io, 16)
+        when .<(0x20), 0x7f # Char#ascii_control?
+          @io.write_string Slice.new(start, cursor - start)
+          @io << "\\u00"
+          @io << '0' if byte < 0x10
+          byte.to_s(@io, 16)
           cursor += 1
           start = cursor
           next
@@ -131,15 +151,13 @@ class JSON::Builder
           next
         end
 
-        io.write_string Slice.new(start, cursor - start)
-        io << escape
+        @io.write_string Slice.new(start, cursor - start)
+        @io << escape
         cursor += 1
         start = cursor
       end
 
-      io.write_string Slice.new(start, cursor - start)
-
-      io << '"'
+      @io.write_string Slice.new(start, cursor - start)
     end
   end
 

--- a/src/json/builder.cr
+++ b/src/json/builder.cr
@@ -102,7 +102,7 @@ class JSON::Builder
   #
   # ```
   # JSON.build do |builder|
-  #   builder.string(foo)
+  #   builder.string("foo")
   # end # => %("foo")
   # JSON.build do |builder|
   #   builder.string([1, 2])

--- a/src/json/builder.cr
+++ b/src/json/builder.cr
@@ -111,20 +111,13 @@ class JSON::Builder
 
       while cursor < fin
         case byte = cursor.value
-        when '\\'
-          escape = "\\\\"
-        when '"'
-          escape = "\\\""
-        when '\b'
-          escape = "\\b"
-        when '\f'
-          escape = "\\f"
-        when '\n'
-          escape = "\\n"
-        when '\r'
-          escape = "\\r"
-        when '\t'
-          escape = "\\t"
+        when '\\' then escape = "\\\\"
+        when '"'  then escape = "\\\""
+        when '\b' then escape = "\\b"
+        when '\f' then escape = "\\f"
+        when '\n' then escape = "\\n"
+        when '\r' then escape = "\\r"
+        when '\t' then escape = "\\t"
         when .<(0x20), 0x7F # Char#ascii_control?
           io.write_string Slice.new(start, cursor - start)
           io << "\\u00"

--- a/src/json/builder.cr
+++ b/src/json/builder.cr
@@ -97,8 +97,17 @@ class JSON::Builder
     end
   end
 
-  # Writes a string. The given *value* is first converted to a `String`
-  # by invoking `to_s` on it.
+  # Writes a string with the content of `value`.
+  # The payload is stringified via `to_s(IO)` and escaped for JSON representation.
+  #
+  # ```
+  # JSON.build do |builder|
+  #   builder.string(foo)
+  # end # => %("foo")
+  # JSON.build do |builder|
+  #   builder.string([1, 2])
+  # end # => %("[1, 2]")
+  # ```
   #
   # This method can also be used to write the name of an object field.
   def string(value) : Nil
@@ -107,6 +116,19 @@ class JSON::Builder
     end
   end
 
+  # Writes a string with the contents written to the yielded `IO`.
+  # The payload gets escaped for JSON representation.
+  #
+  # ```
+  # JSON.build do |builder|
+  #   builder.string do |io|
+  #     io << "foo"
+  #     io << [1, 2]
+  #   end # => %("foo[1, 2]")
+  # end
+  # ```
+  #
+  # This method can also be used to write the name of an object field.
   def string(& : IO ->) : Nil
     scalar(string: true) do
       io << '"'

--- a/src/json/to_json.cr
+++ b/src/json/to_json.cr
@@ -165,7 +165,9 @@ end
 
 struct Time::Format
   def to_json(value : Time, json : JSON::Builder) : Nil
-    format(value).to_json(json)
+    json.string do |io|
+      format(value, io)
+    end
   end
 end
 
@@ -274,7 +276,9 @@ struct Time
   #
   # See `#from_json` for reference.
   def to_json(json : JSON::Builder) : Nil
-    json.string(Time::Format::RFC_3339.format(self, fraction_digits: 0))
+    json.string do |io|
+      Time::Format::RFC_3339.format(self, io, fraction_digits: 0)
+    end
   end
 end
 

--- a/src/uri/json.cr
+++ b/src/uri/json.cr
@@ -23,6 +23,6 @@ class URI
   # URI.parse("http://example.com").to_json # => %("http://example.com")
   # ```
   def to_json(builder : JSON::Builder)
-    builder.string to_s
+    builder.string self
   end
 end

--- a/src/uuid/json.cr
+++ b/src/uuid/json.cr
@@ -33,7 +33,7 @@ struct UUID
   # uuid.to_json # => "\"87b3042b-9b9a-41b7-8b15-a93d3f17025e\""
   # ```
   def to_json(json : JSON::Builder) : Nil
-    json.string(to_s)
+    json.string(self)
   end
 
   # :nodoc:


### PR DESCRIPTION
Refactor `JSON::Builder#string` to stringify values directly into a custom `Escape` IO that escapes while directly passing through to the builder's `IO`. This is much more efficient than the current approach which stringifies into a normal string first and then escapes that.

As expected, performance improves over master with #13915 even more. There's no intermediary heap allocation anymore.

```
this patch  3.55M (281.84ns) (± 6.79%)  0.0B/op        fastest
    master  3.14M (318.93ns) (±12.05%)  176B/op   1.13× slower
    1.10.1  2.42M (413.18ns) (±13.22%)  176B/op   1.47× slower
```

This is only using a rather small URI stringification (176B as the difference in heap allocations tells). The effect would be much intensified for bigger payloads.

<details>
<summary>Benchmark source</summary>

```cr
require "benchmark"
require "json"
require "uri"
require "uri/json"

io = File.open("out.json", "w")
json = JSON::Builder.new(io)
json.start_document
json.start_array
uri = URI.parse "http://foo.com/posts?id=30&limit=5#time=1305298413"

Benchmark.ips do |x|
  x.report "this patch" do
    json.string(uri)
  end

  x.report "master" do
    json.string(uri.to_s)
  end

  x.report "1.10.1" do
    json.string_char_reader(uri)
  end
end

File.delete("out.json")
```

</details>

Resolves #13921