### PR TITLE
Add `Float32::MIN_SUBNORMAL` and `Float64::MIN_SUBNORMAL`

### DIFF
--- a/spec/std/float_printer_spec.cr
+++ b/spec/std/float_printer_spec.cr
@@ -63,8 +63,8 @@ describe "Float32#to_s" do
     it_converts_to_s 0xFFC0_0000_u32.unsafe_as(Float32), "NaN"
     it_converts_to_s Float32::MIN_POSITIVE, "1.1754944e-38"
     it_converts_to_s Float32::MAX, "3.4028235e+38"
-    it_converts_to_s hexfloat("0x1.ffffffp-127_f32"), "1.1754942e-38" # largest denormal
-    it_converts_to_s 1.0e-45_f32                                      # smallest denormal
+    it_converts_to_s Float32::MIN_POSITIVE.prev_float, "1.1754942e-38" # largest subnormal
+    it_converts_to_s Float32::MIN_SUBNORMAL, "1.0e-45"
   end
 
   context "Ryu f2s_test.cc BoundaryRoundEven" do
@@ -347,8 +347,8 @@ describe "Float64#to_s" do
     it_converts_to_s 0xFFF8_0000_0000_0000_u64.unsafe_as(Float64), "NaN"
     it_converts_to_s Float64::MIN_POSITIVE, "2.2250738585072014e-308"
     it_converts_to_s Float64::MAX, "1.7976931348623157e+308"
-    it_converts_to_s hexfloat("0x1.fffffffffffffp-1023"), "2.225073858507201e-308" # largest denormal
-    it_converts_to_s 5.0e-324                                                      # smallest denormal
+    it_converts_to_s Float64::MIN_POSITIVE.prev_float, "2.225073858507201e-308" # largest subnormal
+    it_converts_to_s Float64::MIN_SUBNORMAL, "5.0e-324"
   end
 
   context "Ryu d2s_test.cc LotsOfTrailingZeros" do

--- a/spec/std/float_spec.cr
+++ b/spec/std/float_spec.cr
@@ -225,7 +225,7 @@ describe "Float" do
 
   describe "#next_float" do
     it "does for f64" do
-      0.0.next_float.should eq(5.0e-324) # smallest denormal (not MIN_POSITIVE)
+      0.0.next_float.should eq(Float64::MIN_SUBNORMAL)
       1.0.next_float.should eq(1.0000000000000002)
       (-1.0).next_float.should eq(-0.9999999999999999)
       Float64::MAX.next_float.should eq(Float64::INFINITY)
@@ -235,7 +235,7 @@ describe "Float" do
     end
 
     it "does for f32" do
-      0.0_f32.next_float.should eq(1.0e-45_f32) # smallest denormal (not MIN_POSITIVE)
+      0.0_f32.next_float.should eq(Float32::MIN_SUBNORMAL)
       1.0_f32.next_float.should eq(1.0000001_f32)
       (-1.0_f32).next_float.should eq(-0.99999994_f32)
       Float32::MAX.next_float.should eq(Float32::INFINITY)
@@ -247,7 +247,7 @@ describe "Float" do
 
   describe "#prev_float" do
     it "does for f64" do
-      0.0.prev_float.should eq(-5.0e-324) # smallest denormal (not MIN_POSITIVE)
+      0.0.prev_float.should eq(-Float64::MIN_SUBNORMAL)
       1.0.prev_float.should eq(0.9999999999999999)
       (-1.0).prev_float.should eq(-1.0000000000000002)
       Float64::MIN.prev_float.should eq(-Float64::INFINITY)
@@ -257,7 +257,7 @@ describe "Float" do
     end
 
     it "does for f32" do
-      0.0_f32.prev_float.should eq(-1.0e-45_f32) # smallest denormal (not MIN_POSITIVE)
+      0.0_f32.prev_float.should eq(-Float32::MIN_SUBNORMAL)
       1.0_f32.prev_float.should eq(0.99999994_f32)
       (-1.0_f32).prev_float.should eq(-1.0000001_f32)
       Float32::MIN.prev_float.should eq(-Float32::INFINITY)

--- a/src/float.cr
+++ b/src/float.cr
@@ -129,8 +129,10 @@ struct Float32
   MIN_10_EXP = -37
   # The maximum possible power of 10 exponent (such that 10**MAX_10_EXP is representable)
   MAX_10_EXP = 38
-  # Smallest representable positive value
+  # Smallest normal positive value, whose previous representable value is subnormal
   MIN_POSITIVE = 1.17549435e-38_f32
+  # Smallest representable positive value, whose previous representable value is zero
+  MIN_SUBNORMAL = 1.0e-45_f32
 
   # Returns a `Float32` by invoking `String#to_f32` on *value*.
   #
@@ -249,8 +251,10 @@ struct Float64
   MIN_10_EXP = -307
   # The maximum possible power of 10 exponent (such that 10**MAX_10_EXP is representable)
   MAX_10_EXP = 308
-  # Smallest representable positive value
+  # Smallest normal positive value, whose previous representable value is subnormal
   MIN_POSITIVE = 2.2250738585072014e-308_f64
+  # Smallest representable positive value, whose previous representable value is zero
+  MIN_SUBNORMAL = 5.0e-324_f64
 
   # Returns a `Float64` by invoking `String#to_f64` on *value*.
   #


### PR DESCRIPTION
Resolves #11135.

Following IEEE 754-2008, they are called "subnormal" rather than "denormal"; all denormal binary32 or binary64 floats are subnormal numbers, but this is not the case for IEEE decimal floats.