### PR TITLE
Remove `LLVMExtSetCurrentDebugLocation` from `llvm_ext.cc` for LLVM 9+

### DIFF
--- a/src/compiler/crystal/codegen/crystal_llvm_builder.cr
+++ b/src/compiler/crystal/codegen/crystal_llvm_builder.cr
@@ -74,12 +74,12 @@ module Crystal
     end
 
     {% for name in %w(add add_handler alloca and ashr atomicrmw bit_cast build_catch_ret call
-                     catch_pad catch_switch cmpxchg cond current_debug_location exact_sdiv
-                     extract_value fadd fcmp fdiv fence fmul fp2si fp2ui fpext fptrunc fsub
-                     global_string_pointer icmp inbounds_gep int2ptr invoke landing_pad load
-                     lshr mul not or phi ptr2int sdiv select set_current_debug_location sext
-                     shl si2fp srem store store_volatile sub switch trunc udiv ui2fp urem va_arg
-                     xor zext) %}
+                     catch_pad catch_switch clear_current_debug_location cmpxchg cond
+                     current_debug_location exact_sdiv extract_value fadd fcmp fdiv fence fmul
+                     fp2si fp2ui fpext fptrunc fsub global_string_pointer icmp inbounds_gep int2ptr
+                     invoke landing_pad load lshr mul not or phi ptr2int sdiv select
+                     set_current_debug_location sext shl si2fp srem store store_volatile sub switch
+                     trunc udiv ui2fp urem va_arg xor zext) %}
       def {{name.id}}(*args, **kwargs)
         return llvm_nil if @end
 

--- a/src/compiler/crystal/codegen/debug.cr
+++ b/src/compiler/crystal/codegen/debug.cr
@@ -463,7 +463,9 @@ module Crystal
       scope = get_current_debug_scope(location)
 
       if scope
-        builder.set_current_debug_location(location.line_number || 1, location.column_number, scope)
+        debug_loc = di_builder.create_debug_location(location.line_number || 1, location.column_number, scope)
+        # NOTE: `di_builder.context` is only necessary for LLVM 8
+        builder.set_current_debug_location(debug_loc, di_builder.context)
       else
         clear_current_debug_location
       end
@@ -472,7 +474,7 @@ module Crystal
     def clear_current_debug_location
       @current_debug_location = nil
 
-      builder.set_current_debug_location(0, 0, nil)
+      builder.clear_current_debug_location
     end
 
     def emit_fun_debug_metadata(func, fun_name, location, *, debug_types = [] of LibLLVM::MetadataRef, is_optimized = false)

--- a/src/llvm/builder.cr
+++ b/src/llvm/builder.cr
@@ -333,8 +333,25 @@ class LLVM::Builder
     Value.new LibLLVM.build_va_arg(self, list, type, name)
   end
 
+  @[Deprecated("Call `#set_current_debug_location(metadata, context)` or `#clear_current_debug_location` instead")]
   def set_current_debug_location(line, column, scope, inlined_at = nil)
     LibLLVMExt.set_current_debug_location(self, line, column, scope, inlined_at)
+  end
+
+  def set_current_debug_location(metadata, context : LLVM::Context)
+    {% if LibLLVM::IS_LT_90 %}
+      LibLLVM.set_current_debug_location(self, LibLLVM.metadata_as_value(context, metadata))
+    {% else %}
+      LibLLVM.set_current_debug_location2(self, metadata)
+    {% end %}
+  end
+
+  def clear_current_debug_location
+    {% if LibLLVM::IS_LT_90 %}
+      LibLLVMExt.clear_current_debug_location(self)
+    {% else %}
+      LibLLVM.set_current_debug_location2(self, nil)
+    {% end %}
   end
 
   def set_metadata(value, kind, node)

--- a/src/llvm/di_builder.cr
+++ b/src/llvm/di_builder.cr
@@ -14,6 +14,10 @@ struct LLVM::DIBuilder
     LibLLVM.dispose_di_builder(self)
   end
 
+  def context
+    @llvm_module.context
+  end
+
   def create_compile_unit(lang : DwarfSourceLanguage, file, dir, producer, optimized, flags, runtime_version)
     file = create_file(file, dir)
     {% if LibLLVM::IS_LT_110 %}
@@ -151,6 +155,10 @@ struct LLVM::DIBuilder
     LibLLVM.di_builder_get_or_create_subrange(self, lo, count)
   end
 
+  def create_debug_location(line, column, scope, inlined_at = nil)
+    LibLLVM.di_builder_create_debug_location(context, line, column, scope, inlined_at)
+  end
+
   def end
     LibLLVM.di_builder_finalize(self)
   end
@@ -191,7 +199,7 @@ struct LLVM::DIBuilder
   end
 
   private def extract_metadata_array(metadata : LibLLVM::MetadataRef)
-    metadata_as_value = LibLLVM.metadata_as_value(@llvm_module.context, metadata)
+    metadata_as_value = LibLLVM.metadata_as_value(context, metadata)
     operand_count = LibLLVM.get_md_node_num_operands(metadata_as_value).to_i
     operands = Pointer(LibLLVM::ValueRef).malloc(operand_count)
     LibLLVM.get_md_node_operands(metadata_as_value, operands)

--- a/src/llvm/lib_llvm/core.cr
+++ b/src/llvm/lib_llvm/core.cr
@@ -183,8 +183,11 @@ lib LibLLVM
   fun get_insert_block = LLVMGetInsertBlock(builder : BuilderRef) : BasicBlockRef
   fun dispose_builder = LLVMDisposeBuilder(builder : BuilderRef)
 
-  {% unless LibLLVM::IS_LT_90 %}
+  {% if LibLLVM::IS_LT_90 %}
+    fun set_current_debug_location = LLVMSetCurrentDebugLocation(builder : BuilderRef, l : ValueRef)
+  {% else %}
     fun get_current_debug_location2 = LLVMGetCurrentDebugLocation2(builder : BuilderRef) : MetadataRef
+    fun set_current_debug_location2 = LLVMSetCurrentDebugLocation2(builder : BuilderRef, loc : MetadataRef)
   {% end %}
   fun get_current_debug_location = LLVMGetCurrentDebugLocation(builder : BuilderRef) : ValueRef
 

--- a/src/llvm/lib_llvm/debug_info.cr
+++ b/src/llvm/lib_llvm/debug_info.cr
@@ -45,6 +45,10 @@ lib LibLLVM
     builder : DIBuilderRef, scope : MetadataRef, file_scope : MetadataRef, discriminator : UInt
   ) : MetadataRef
 
+  fun di_builder_create_debug_location = LLVMDIBuilderCreateDebugLocation(
+    ctx : ContextRef, line : UInt, column : UInt, scope : MetadataRef, inlined_at : MetadataRef
+  ) : MetadataRef
+
   fun di_builder_get_or_create_type_array = LLVMDIBuilderGetOrCreateTypeArray(builder : DIBuilderRef, types : MetadataRef*, length : SizeT) : MetadataRef
 
   fun di_builder_create_subroutine_type = LLVMDIBuilderCreateSubroutineType(

--- a/src/llvm/lib_llvm_ext.cr
+++ b/src/llvm/lib_llvm_ext.cr
@@ -13,9 +13,8 @@ lib LibLLVMExt
 
   {% if LibLLVM::IS_LT_90 %}
     fun di_builder_create_enumerator = LLVMExtDIBuilderCreateEnumerator(builder : LibLLVM::DIBuilderRef, name : Char*, value : Int64) : LibLLVM::MetadataRef
+    fun clear_current_debug_location = LLVMExtClearCurrentDebugLocation(b : LibLLVM::BuilderRef)
   {% end %}
-
-  fun set_current_debug_location = LLVMExtSetCurrentDebugLocation(LibLLVM::BuilderRef, Int, Int, LibLLVM::MetadataRef, LibLLVM::MetadataRef)
 
   fun build_operand_bundle_def = LLVMExtBuildOperandBundleDef(name : LibC::Char*,
                                                               input : LibLLVM::ValueRef*,


### PR DESCRIPTION
Resolves part of #13946. Closes #13487.

`LLVM::Builder#set_current_debug_location(line, column, scope, inlined_at = nil)` is now deprecated. The corresponding metadata should be created using `LLVM::DIBuilder#create_debug_location`.

A compiler built with LLVM 8 still needs the existing `LLVMExtSetCurrentDebugLocation` when clearing the current debug location, since doing `debug_loc = di_builder.create_debug_location(0, 0, nil)` or calling `LibLLVM.set_current_debug_location(self, nil)` will break the generated IR.