### PR TITLE
Remove `LLVMExtCreateMCJITCompilerForModule` from `llvm_ext.cc`

### DIFF
--- a/src/compiler/crystal/codegen/target.cr
+++ b/src/compiler/crystal/codegen/target.cr
@@ -195,7 +195,7 @@ class Crystal::Codegen::Target
 
     target = LLVM::Target.from_triple(self.to_s)
     machine = target.create_target_machine(self.to_s, cpu: cpu, features: features, opt_level: opt_level, code_model: code_model).not_nil!
-    # We need to disable global isel until https://reviews.llvm.org/D80898 is released,
+    # FIXME: We need to disable global isel until https://reviews.llvm.org/D80898 is released,
     # or we fixed generating values for 0 sized types.
     # When removing this, also remove it from the ABI specs and jit compiler.
     # See https://github.com/crystal-lang/crystal/issues/9297#issuecomment-636512270

--- a/src/llvm/ext/llvm_ext.cc
+++ b/src/llvm/ext/llvm_ext.cc
@@ -2,6 +2,7 @@
 #include <llvm/IR/IRBuilder.h>
 #include <llvm/IR/DebugLoc.h>
 #include <llvm/Target/TargetMachine.h>
+#include <llvm-c/TargetMachine.h>
 
 using namespace llvm;
 
@@ -13,8 +14,6 @@ using namespace llvm;
 
 #define LLVM_VERSION_LE(major, minor) \
   (LLVM_VERSION_MAJOR < (major) || LLVM_VERSION_MAJOR == (major) && LLVM_VERSION_MINOR <= (minor))
-
-#include <llvm/Target/CodeGenCWrappers.h>
 
 #if LLVM_VERSION_GE(16, 0)
 #define makeArrayRef ArrayRef

--- a/src/llvm/ext/llvm_ext.cc
+++ b/src/llvm/ext/llvm_ext.cc
@@ -1,8 +1,7 @@
 #include <llvm/IR/DIBuilder.h>
 #include <llvm/IR/IRBuilder.h>
 #include <llvm/IR/DebugLoc.h>
-#include <llvm/ExecutionEngine/ExecutionEngine.h>
-#include <llvm/ExecutionEngine/RTDyldMemoryManager.h>
+#include <llvm/Target/TargetMachine.h>
 
 using namespace llvm;
 
@@ -87,77 +86,6 @@ static TargetMachine *unwrap(LLVMTargetMachineRef P) {
 
 void LLVMExtTargetMachineEnableGlobalIsel(LLVMTargetMachineRef T, LLVMBool Enable) {
   unwrap(T)->setGlobalISel(Enable);
-}
-
-// Copy paste of https://github.com/llvm/llvm-project/blob/dace8224f38a31636a02fe9c2af742222831f70c/llvm/lib/ExecutionEngine/ExecutionEngineBindings.cpp#L160-L214
-// but with a parameter to set global isel state
-LLVMBool LLVMExtCreateMCJITCompilerForModule(
-    LLVMExecutionEngineRef *OutJIT, LLVMModuleRef M,
-    LLVMMCJITCompilerOptions *PassedOptions, size_t SizeOfPassedOptions,
-    LLVMBool EnableGlobalISel,
-    char **OutError) {
-  LLVMMCJITCompilerOptions options;
-  // If the user passed a larger sized options struct, then they were compiled
-  // against a newer LLVM. Tell them that something is wrong.
-  if (SizeOfPassedOptions > sizeof(options)) {
-    *OutError = strdup(
-      "Refusing to use options struct that is larger than my own; assuming "
-      "LLVM library mismatch.");
-    return 1;
-  }
-
-
-  // Defend against the user having an old version of the API by ensuring that
-  // any fields they didn't see are cleared. We must defend against fields being
-  // set to the bitwise equivalent of zero, and assume that this means "do the
-  // default" as if that option hadn't been available.
-  LLVMInitializeMCJITCompilerOptions(&options, sizeof(options));
-  memcpy(&options, PassedOptions, SizeOfPassedOptions);
-
-
-  TargetOptions targetOptions;
-  targetOptions.EnableFastISel = options.EnableFastISel;
-  targetOptions.EnableGlobalISel = EnableGlobalISel;
-  std::unique_ptr<Module> Mod(unwrap(M));
-
-  if (Mod)
-    // Set function attribute "frame-pointer" based on
-    // NoFramePointerElim.
-    for (auto &F : *Mod) {
-      auto Attrs = F.getAttributes();
-      StringRef Value = options.NoFramePointerElim ? "all" : "none";
-      #if LLVM_VERSION_GE(14, 0)
-        Attrs = Attrs.addFnAttribute(F.getContext(), "frame-pointer", Value);
-      #else
-        Attrs = Attrs.addAttribute(F.getContext(), AttributeList::FunctionIndex,
-                                   "frame-pointer", Value);
-      #endif
-      F.setAttributes(Attrs);
-    }
-
-
-  std::string Error;
-  EngineBuilder builder(std::move(Mod));
-  builder.setEngineKind(EngineKind::JIT)
-         .setErrorStr(&Error)
-         .setOptLevel((CodeGenOpt::Level)options.OptLevel)
-         .setTargetOptions(targetOptions);
-  bool JIT;
-  if (auto CM = unwrap(options.CodeModel, JIT))
-    builder.setCodeModel(*CM);
-  if (options.MCJMM)
-    builder.setMCJITMemoryManager(
-      std::unique_ptr<RTDyldMemoryManager>(unwrap(options.MCJMM)));
-
-  TargetMachine* tm = builder.selectTarget();
-  tm->setGlobalISel(EnableGlobalISel);
-
-  if (ExecutionEngine *JIT = builder.create(tm)) {
-    *OutJIT = wrap(JIT);
-    return 0;
-  }
-  *OutError = strdup(Error.c_str());
-  return 1;
 }
 
 } // extern "C"

--- a/src/llvm/jit_compiler.cr
+++ b/src/llvm/jit_compiler.cr
@@ -5,9 +5,17 @@ class LLVM::JITCompiler
     mod.take_ownership { raise "Can't create two JIT compilers for the same module" }
 
     # if LibLLVM.create_jit_compiler_for_module(out @unwrap, mod, 3, out error) != 0
-    if LibLLVMExt.create_mc_jit_compiler_for_module(out @unwrap, mod, nil, 0, false, out error) != 0
+    if LibLLVM.create_mc_jit_compiler_for_module(out @unwrap, mod, nil, 0, out error) != 0
       raise LLVM.string_and_dispose(error)
     end
+
+    # We need to disable global isel until https://reviews.llvm.org/D80898 is released,
+    # or we fixed generating values for 0 sized types.
+    # When removing this, also remove it from the ABI specs and Crystal::Codegen::Target.
+    # See https://github.com/crystal-lang/crystal/issues/9297#issuecomment-636512270
+    # for background info
+    target_machine = LibLLVM.get_execution_engine_target_machine(@unwrap)
+    LibLLVMExt.target_machine_enable_global_isel(target_machine, false)
 
     @finalized = false
   end

--- a/src/llvm/jit_compiler.cr
+++ b/src/llvm/jit_compiler.cr
@@ -9,7 +9,7 @@ class LLVM::JITCompiler
       raise LLVM.string_and_dispose(error)
     end
 
-    # We need to disable global isel until https://reviews.llvm.org/D80898 is released,
+    # FIXME: We need to disable global isel until https://reviews.llvm.org/D80898 is released,
     # or we fixed generating values for 0 sized types.
     # When removing this, also remove it from the ABI specs and Crystal::Codegen::Target.
     # See https://github.com/crystal-lang/crystal/issues/9297#issuecomment-636512270

--- a/src/llvm/lib_llvm/execution_engine.cr
+++ b/src/llvm/lib_llvm/execution_engine.cr
@@ -28,5 +28,6 @@ lib LibLLVM
   fun create_mc_jit_compiler_for_module = LLVMCreateMCJITCompilerForModule(out_jit : ExecutionEngineRef*, m : ModuleRef, options : MCJITCompilerOptions*, size_of_options : SizeT, out_error : Char**) : Bool
   fun dispose_execution_engine = LLVMDisposeExecutionEngine(ee : ExecutionEngineRef)
   fun run_function = LLVMRunFunction(ee : ExecutionEngineRef, f : ValueRef, num_args : UInt, args : GenericValueRef*) : GenericValueRef
+  fun get_execution_engine_target_machine = LLVMGetExecutionEngineTargetMachine(ee : ExecutionEngineRef) : TargetMachineRef
   fun get_pointer_to_global = LLVMGetPointerToGlobal(ee : ExecutionEngineRef, global : ValueRef) : Void*
 end

--- a/src/llvm/lib_llvm_ext.cr
+++ b/src/llvm/lib_llvm_ext.cr
@@ -33,5 +33,4 @@ lib LibLLVMExt
                                           name : LibC::Char*) : LibLLVM::ValueRef
 
   fun target_machine_enable_global_isel = LLVMExtTargetMachineEnableGlobalIsel(machine : LibLLVM::TargetMachineRef, enable : Bool)
-  fun create_mc_jit_compiler_for_module = LLVMExtCreateMCJITCompilerForModule(jit : LibLLVM::ExecutionEngineRef*, m : LibLLVM::ModuleRef, options : LibLLVM::MCJITCompilerOptions*, options_length : UInt32, enable_global_isel : Bool, error : UInt8**) : Int32
 end


### PR DESCRIPTION
Resolves part of #13946.

There is no need to disable GlobalISel immediately upon JIT compiler creation, because the target machine can be retrieved afterwards via the LLVM C API, and with it we could use the much shorter `LLVMExtTargetMachineEnableGlobalIsel` instead (which will be available in LLVM 18 too). `LLVMExtCreateMCJITCompilerForModule` doesn't do anything extra other than updating the target machine's option (twice).