### PR TITLE
Add `String#matches_full?`

### DIFF
--- a/spec/std/string_spec.cr
+++ b/spec/std/string_spec.cr
@@ -2343,6 +2343,22 @@ describe "String" do
     "foo".matches?(/bar/).should eq(false)
   end
 
+  it "#matches_full?" do
+    "foo".matches_full?(/foo/).should be_true
+    "fooo".matches_full?(/foo/).should be_false
+    "ofoo".matches_full?(/foo/).should be_false
+    "pattern".matches_full?(/(\A)?pattern(\z)?/).should be_true
+    "_pattern_".matches_full?(/(\A)?pattern(\z)?/).should be_false
+  end
+
+  it "#match_full?" do
+    "foo".match_full(/foo/).not_nil![0].should eq "foo"
+    "fooo".match_full(/foo/).should be_nil
+    "ofoo".match_full(/foo/).should be_nil
+    "pattern".match_full(/(\A)?pattern(\z)?/).not_nil![0].should eq "pattern"
+    "_pattern_".match_full(/(\A)?pattern(\z)?/).should be_nil
+  end
+
   it "has size (same as size)" do
     "テスト".size.should eq(3)
   end

--- a/spec/std/string_spec.cr
+++ b/spec/std/string_spec.cr
@@ -2344,7 +2344,7 @@ describe "String" do
   end
 
   it "#matches_full?" do
-    pending! if Regex::Engine == Regex::PCRE
+    pending! if {{ Regex::Engine.resolve.name == "Regex::PCRE" }}
     "foo".matches_full?(/foo/).should be_true
     "fooo".matches_full?(/foo/).should be_false
     "ofoo".matches_full?(/foo/).should be_false
@@ -2353,7 +2353,7 @@ describe "String" do
   end
 
   it "#match_full" do
-    pending! if Regex::Engine == Regex::PCRE
+    pending! if {{ Regex::Engine.resolve.name == "Regex::PCRE" }}
     "foo".match_full(/foo/).not_nil![0].should eq "foo"
     "fooo".match_full(/foo/).should be_nil
     "ofoo".match_full(/foo/).should be_nil
@@ -2362,7 +2362,7 @@ describe "String" do
   end
 
   it "#match_full!" do
-    pending! if Regex::Engine == Regex::PCRE
+    pending! if {{ Regex::Engine.resolve.name == "Regex::PCRE" }}
     "foo".match_full!(/foo/).not_nil![0].should eq "foo"
     expect_raises(Regex::Error) { "fooo".match_full!(/foo/) }
     expect_raises(Regex::Error) { "ofoo".match_full!(/foo/) }

--- a/spec/std/string_spec.cr
+++ b/spec/std/string_spec.cr
@@ -2344,6 +2344,7 @@ describe "String" do
   end
 
   it "#matches_full?" do
+    pending! if Regex::Engine == Regex::PCRE
     "foo".matches_full?(/foo/).should be_true
     "fooo".matches_full?(/foo/).should be_false
     "ofoo".matches_full?(/foo/).should be_false
@@ -2352,6 +2353,7 @@ describe "String" do
   end
 
   it "#match_full" do
+    pending! if Regex::Engine == Regex::PCRE
     "foo".match_full(/foo/).not_nil![0].should eq "foo"
     "fooo".match_full(/foo/).should be_nil
     "ofoo".match_full(/foo/).should be_nil
@@ -2360,6 +2362,7 @@ describe "String" do
   end
 
   it "#match_full!" do
+    pending! if Regex::Engine == Regex::PCRE
     "foo".match_full!(/foo/).not_nil![0].should eq "foo"
     expect_raises(Regex::Error) { "fooo".match_full!(/foo/) }
     expect_raises(Regex::Error) { "ofoo".match_full!(/foo/) }

--- a/spec/std/string_spec.cr
+++ b/spec/std/string_spec.cr
@@ -2351,7 +2351,7 @@ describe "String" do
     "_pattern_".matches_full?(/(\A)?pattern(\z)?/).should be_false
   end
 
-  it "#match_full?" do
+  it "#match_full" do
     "foo".match_full(/foo/).not_nil![0].should eq "foo"
     "fooo".match_full(/foo/).should be_nil
     "ofoo".match_full(/foo/).should be_nil

--- a/spec/std/string_spec.cr
+++ b/spec/std/string_spec.cr
@@ -2359,6 +2359,14 @@ describe "String" do
     "_pattern_".match_full(/(\A)?pattern(\z)?/).should be_nil
   end
 
+  it "#match_full!" do
+    "foo".match_full!(/foo/).not_nil![0].should eq "foo"
+    expect_raises(Regex::Error) { "fooo".match_full!(/foo/) }
+    expect_raises(Regex::Error) { "ofoo".match_full!(/foo/) }
+    "pattern".match_full!(/(\A)?pattern(\z)?/).not_nil![0].should eq "pattern"
+    expect_raises(Regex::Error) { "_pattern_".match_full!(/(\A)?pattern(\z)?/) }
+  end
+
   it "has size (same as size)" do
     "テスト".size.should eq(3)
   end

--- a/src/string.cr
+++ b/src/string.cr
@@ -4687,6 +4687,34 @@ class String
     regex.matches? self, pos, options: options
   end
 
+  # Returns `true` if the regular expression *regex* matches this string entirely.
+  # It also updates `$~` with the result.
+  #
+  # ```
+  # "foo".match_full(/foo/)   # => Regex::MatchData("foo")
+  # $~                        # => Regex::MatchData("foo")
+  # "fooo".match_full(/foo/)  # => nil
+  # $~                        # raises Exception
+  # ```
+  def match_full(regex : Regex) : Regex::MatchData?
+    match = /(?:#{regex})\z/.match_at_byte_index(self, 0, Regex::Options::ANCHORED)
+    $~ = match
+    match
+  end
+
+  # Returns `true` if the regular expression *regex* matches this string entirely.
+  #
+  # ```
+  # "foo".matches_full?(/foo/)  # => true
+  # "fooo".matches_full?(/foo/) # => false
+  #
+  # # `$~` is not set even if last match succeeds.
+  # $~ # raises Exception
+  # ```
+  def matches_full?(regex : Regex) : Bool
+    starts_with?(/(?:#{regex})\z/)
+  end
+
   # Searches the string for instances of *pattern*,
   # yielding a `Regex::MatchData` for each match.
   def scan(pattern : Regex, *, options : Regex::MatchOptions = Regex::MatchOptions::None, &) : self

--- a/src/string.cr
+++ b/src/string.cr
@@ -4701,6 +4701,21 @@ class String
     match(regex, options: Regex::MatchOptions::ANCHORED | Regex::MatchOptions::ENDANCHORED)
   end
 
+  # Matches the regular expression *regex* against the entire string and returns
+  # the resulting `MatchData`.
+  # It also updates `$~` with the result.
+  # Raises `Regex::Error` if there are no matches.
+  #
+  # ```
+  # "foo".match_full!(/foo/)  # => Regex::MatchData("foo")
+  # $~                        # => Regex::MatchData("foo")
+  # "fooo".match_full!(/foo/) # Regex::Error
+  # $~                        # raises Exception
+  # ```
+  def match_full!(regex : Regex) : Regex::MatchData?
+    match!(regex, options: Regex::MatchOptions::ANCHORED | Regex::MatchOptions::ENDANCHORED)
+  end
+
   # Returns `true` if the regular expression *regex* matches this string entirely.
   #
   # ```

--- a/src/string.cr
+++ b/src/string.cr
@@ -4692,15 +4692,13 @@ class String
   # It also updates `$~` with the result.
   #
   # ```
-  # "foo".match_full(/foo/)   # => Regex::MatchData("foo")
-  # $~                        # => Regex::MatchData("foo")
-  # "fooo".match_full(/foo/)  # => nil
-  # $~                        # raises Exception
+  # "foo".match_full(/foo/)  # => Regex::MatchData("foo")
+  # $~                       # => Regex::MatchData("foo")
+  # "fooo".match_full(/foo/) # => nil
+  # $~                       # raises Exception
   # ```
   def match_full(regex : Regex) : Regex::MatchData?
-    match = /(?:#{regex})\z/.match_at_byte_index(self, 0, Regex::Options::ANCHORED)
-    $~ = match
-    match
+    match(regex, options: Regex::MatchOptions::ANCHORED | Regex::MatchOptions::ENDANCHORED)
   end
 
   # Returns `true` if the regular expression *regex* matches this string entirely.
@@ -4713,7 +4711,7 @@ class String
   # $~ # raises Exception
   # ```
   def matches_full?(regex : Regex) : Bool
-    starts_with?(/(?:#{regex})\z/)
+    matches?(regex, options: Regex::MatchOptions::ANCHORED | Regex::MatchOptions::ENDANCHORED)
   end
 
   # Searches the string for instances of *pattern*,

--- a/src/string.cr
+++ b/src/string.cr
@@ -4687,7 +4687,8 @@ class String
     regex.matches? self, pos, options: options
   end
 
-  # Returns `true` if the regular expression *regex* matches this string entirely.
+  # Matches the regular expression *regex* against the entire string and returns
+  # the resulting `MatchData`.
   # It also updates `$~` with the result.
   #
   # ```


### PR DESCRIPTION
This is a reissue of #9312 with a new implementation based on the new potential from PCRE2, `Regex::MatchData::ENDANCHORED`.
Also adds `#match_full!` as an equivalent to `#match!` which was introduced in the mean time.

Closes #9312
Closes #9309