### PR TITLE
Allow to specify git fork of distribution-scripts in CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,6 +1,10 @@
 version: 2.1
 
 parameters:
+  distribution-scripts-repo:
+    description: "Git url https://github.com/crystal-lang/distribution-scripts/"
+    type: string
+    default: "https://github.com/crystal-lang/distribution-scripts.git"
   distribution-scripts-version:
     description: "Git ref for version of https://github.com/crystal-lang/distribution-scripts/"
     type: string
@@ -142,7 +146,7 @@ jobs:
     steps:
       # checkout specific distribution-scripts version to perform releases and nightly
       - run: |
-          git clone https://github.com/crystal-lang/distribution-scripts.git ~/distribution-scripts
+          git clone << pipeline.parameters.distribution-scripts-repo >> ~/distribution-scripts
           cd ~/distribution-scripts
           git checkout << pipeline.parameters.distribution-scripts-version >>
       # persist relevant information for build process


### PR DESCRIPTION
In order to test custom changes of future PRs,
need to specify the fork repo and version.

After it merged could be triggered from bash or other pipelines:

```shell
export CIRCLECI_API_KEY=<generate from circleci>
export CRYSTAL_BRANCH="release/1.10" ; Or master
export FORK_OWNER=miry
export FORK_BRANCH=<branch>

$ curl --request POST \
     --url "https://circleci.com/api/v2/project/github/${FORK_OWNER}/crystal/pipeline" \
     --header "Circle-Token: ${CIRCLECI_API_KEY}" \
     --header "content-type: application/json" \
     --data '{"branch":"'$CRYSTAL_BRANCH'","parameters":{"distribution-scripts-repo":"https://github.com/'$FORK_OWNER'/distribution-scripts.git","distribution-scripts-version":"'$FORK_BRANCH'"}}'
```

### References

* https://circleci.com/blog/triggering-pipelines-from-pipelines/
* https://circleci.com/docs/triggers-overview/
* https://circleci.com/docs/api-developers-guide/#getting-started-with-the-api
* https://circleci.com/docs/pipeline-variables/#conditional-workflows
