### PR TITLE
fix Log AsyncDispatcher where setup changes

### DIFF
--- a/src/log/dispatch.cr
+++ b/src/log/dispatch.cr
@@ -53,6 +53,7 @@ class Log
 
     def dispatch(entry : Entry, backend : Backend) : Nil
       @channel.send({entry, backend})
+    rescue Channel::ClosedError
     end
 
     private def write_logs


### PR DESCRIPTION
I am seeing errors like this running specs:

```
Unhandled exception in spawn: Channel is closed (Channel::ClosedError)
  from /usr/share/crystal/src/channel.cr:228:8 in 'send'
  from /usr/share/crystal/src/log/dispatch.cr:55:7 in 'dispatch'
  from /usr/share/crystal/src/log/backend.cr:24:5 in 'dispatch'
  from /usr/share/crystal/src/log/log.cr:36:3 in 'lurk'
  from lib/inotify/src/inotify/watcher.cr:35:7 in '->'
  from /usr/share/crystal/src/fiber.cr:146:11 in 'run'
  from /usr/share/crystal/src/fiber.cr:98:34 in '->'
  from ???
```
I assume its related to log levels changing, and commenting out the `Log.debug` line fixes the issue or commenting out the log setup lines below also resolve the issue.

```crystal
::Log.setup("*", :trace)

Spec.before_suite do
  ::Log.setup("*", :trace)
end
```

I don't think using Log should raise errors and think it's preferable that it fails to log the output