### PR TITLE
Fix missing param count in compilation error message

### DIFF
--- a/spec/compiler/semantic/macro_spec.cr
+++ b/spec/compiler/semantic/macro_spec.cr
@@ -271,6 +271,24 @@ describe "Semantic: macro" do
       CRYSTAL
   end
 
+  it "errors if find macros but missing argument" do
+    assert_error(<<-CRYSTAL, "wrong number of arguments for macro 'foo' (given 0, expected 1)")
+      macro foo(x)
+        1
+      end
+
+      foo
+      CRYSTAL
+
+    assert_error(<<-CRYSTAL, "wrong number of arguments for macro 'foo' (given 0, expected 1)")
+      private macro foo(x)
+        1
+      end
+
+      foo
+      CRYSTAL
+  end
+
   describe "raise" do
     describe "inside macro" do
       describe "without node" do

--- a/src/compiler/crystal/semantic/call_error.cr
+++ b/src/compiler/crystal/semantic/call_error.cr
@@ -902,7 +902,6 @@ class Crystal::Call
 
     macros = in_macro_target &.lookup_macros(def_name)
     return unless macros.is_a?(Array(Macro))
-    macros = macros.reject &.visibility.private?
 
     if msg = single_def_error_message(macros, named_args)
       raise msg


### PR DESCRIPTION
A private macro definition with one parameter which is called with no parameter resulted in a compiler error message where the "expected" count was missing. From the original issue:

```crystal
private macro foo(x)
end

foo # Error: wrong number of arguments for macro 'foo' (given 0, expected )
```

The error was caused by a statement that rejected private macros, which resulted in `all_arguments_sizes` being empty.

The removed code was added in cabb0219a6ecda8777d16bf2ffe511381f74c8d7. The affected specs are green, so I assume there's no regression without that statement.

Fixes https://github.com/crystal-lang/crystal/issues/13872