### PR TITLE
Fix skip spec execution on error exit

### DIFF
--- a/src/spec/dsl.cr
+++ b/src/spec/dsl.cr
@@ -205,18 +205,23 @@ module Spec
   def self.run
     @@start_time = Time.monotonic
 
-    at_exit do
-      log_setup
-      maybe_randomize
-      run_filters
-      root_context.run
-    rescue ex
-      STDERR.print "Unhandled exception: "
-      ex.inspect_with_backtrace(STDERR)
-      STDERR.flush
-      @@aborted = true
-    ensure
-      finish_run
+    at_exit do |status|
+      # Do not run specs if the process is exiting on an error
+      next unless status == 0
+
+      begin
+        log_setup
+        maybe_randomize
+        run_filters
+        root_context.run
+      rescue ex
+        STDERR.print "Unhandled exception: "
+        ex.inspect_with_backtrace(STDERR)
+        STDERR.flush
+        @@aborted = true
+      ensure
+        finish_run
+      end
     end
   end
 


### PR DESCRIPTION
Spec execution is triggered by an `at_exit` handler. This handler should not execute when the process is exiting due to a previous error.

Ref: https://github.com/crystal-lang/crystal/issues/13763#issuecomment-1812549723