### PR TITLE
Fix `String::Buffer` and `IO::Memory` capacity to grow beyond 1GB

### DIFF
--- a/.github/workflows/wasm32.yml
+++ b/.github/workflows/wasm32.yml
@@ -46,6 +46,6 @@ jobs:
 
       - name: Run wasm32_std_spec.wasm
         run: |
-          wasmtime run wasm32_std_spec.wasm -- --verbose
+          wasmtime run wasm32_std_spec.wasm --verbose
         env:
           WASMTIME_BACKTRACE_DETAILS: "1"

--- a/.github/workflows/wasm32.yml
+++ b/.github/workflows/wasm32.yml
@@ -46,6 +46,6 @@ jobs:
 
       - name: Run wasm32_std_spec.wasm
         run: |
-          wasmtime run wasm32_std_spec.wasm --verbose
+          wasmtime run wasm32_std_spec.wasm -- --verbose
         env:
           WASMTIME_BACKTRACE_DETAILS: "1"

--- a/.github/workflows/wasm32.yml
+++ b/.github/workflows/wasm32.yml
@@ -47,5 +47,3 @@ jobs:
       - name: Run wasm32_std_spec.wasm
         run: |
           wasmtime run wasm32_std_spec.wasm
-        env:
-          WASMTIME_BACKTRACE_DETAILS: "1"

--- a/.github/workflows/wasm32.yml
+++ b/.github/workflows/wasm32.yml
@@ -47,3 +47,5 @@ jobs:
       - name: Run wasm32_std_spec.wasm
         run: |
           wasmtime run wasm32_std_spec.wasm
+        env:
+          WASMTIME_BACKTRACE_DETAILS: "1"

--- a/.github/workflows/wasm32.yml
+++ b/.github/workflows/wasm32.yml
@@ -46,6 +46,6 @@ jobs:
 
       - name: Run wasm32_std_spec.wasm
         run: |
-          wasmtime run wasm32_std_spec.wasm --verbose
+          wasmtime run wasm32_std_spec.wasm
         env:
           WASMTIME_BACKTRACE_DETAILS: "1"

--- a/.github/workflows/wasm32.yml
+++ b/.github/workflows/wasm32.yml
@@ -46,6 +46,6 @@ jobs:
 
       - name: Run wasm32_std_spec.wasm
         run: |
-          wasmtime run wasm32_std_spec.wasm
+          wasmtime run wasm32_std_spec.wasm --verbose
         env:
           WASMTIME_BACKTRACE_DETAILS: "1"

--- a/spec/std/io/memory_spec.cr
+++ b/spec/std/io/memory_spec.cr
@@ -505,4 +505,18 @@ describe IO::Memory do
       end
     end
   {% end %}
+
+  it "allocates for > 1 GB", tags: %w[slow] do
+    io = IO::Memory.new
+    mbstring = "a" * 1024 * 1024
+    1024.times { io << mbstring }
+
+    io.bytesize.should eq(1 << 30)
+    io.@capacity.should eq 1 << 30
+
+    io << mbstring
+
+    io.bytesize.should eq (1 << 30) + (1 << 20)
+    io.@capacity.should eq Int32::MAX
+  end
 end

--- a/spec/std/io/memory_spec.cr
+++ b/spec/std/io/memory_spec.cr
@@ -518,5 +518,13 @@ describe IO::Memory do
 
     io.bytesize.should eq (1 << 30) + (1 << 20)
     io.@capacity.should eq Int32::MAX
+
+    1022.times { io << mbstring }
+
+    io.write mbstring.to_slice[0..-4]
+    io << "a"
+    expect_raises(IO::EOFError) do
+      io << "a"
+    end
   end
 end

--- a/spec/std/io/memory_spec.cr
+++ b/spec/std/io/memory_spec.cr
@@ -18,6 +18,17 @@ describe IO::Memory do
     io.gets_to_end.should eq(s)
   end
 
+  it "write raises EOFError" do
+    io = IO::Memory.new
+    initial_capacity = io.@capacity
+    expect_raises(IO::EOFError) do
+      io.write Slice.new(Pointer(UInt8).null, Int32::MAX)
+    end
+    # nothing get's written
+    io.bytesize.should eq 0
+    io.@capacity.should eq initial_capacity
+  end
+
   it "reads byte" do
     io = IO::Memory.new("abc")
     io.read_byte.should eq('a'.ord)

--- a/spec/std/string_builder_spec.cr
+++ b/spec/std/string_builder_spec.cr
@@ -64,6 +64,14 @@ describe String::Builder do
 
       str.bytesize.should eq 1 << 30
       str.capacity.should eq Int32::MAX
+
+      1023.times { str << mbstring }
+
+      str.write mbstring.to_slice[0..(-4 - String::HEADER_SIZE)]
+      str << "a"
+      expect_raises(IO::EOFError) do
+        str << "a"
+      end
     end
   end
 end

--- a/spec/std/string_builder_spec.cr
+++ b/spec/std/string_builder_spec.cr
@@ -52,42 +52,31 @@ describe String::Builder do
     builder.capacity.should eq initial_capacity
   end
 
-  it "allocates for > 1 GB", tags: %w[slow], focus: true do
-    Crystal::System.print_error "start test\n"
+  it "allocates for > 1 GB", tags: %w[slow] do
     String::Builder.build do |str|
-      Crystal::System.print_error "start block\n"
       mbstring = "a" * 1024 * 1024
-      Crystal::System.print_error "allocated mbstring\n"
       1023.times { str << mbstring }
-      Crystal::System.print_error "wrote 999 MB\n"
 
       str.bytesize.should eq (1 << 30) - (1 << 20)
       str.capacity.should eq 1 << 30
-      Crystal::System.print_error "tested bytesize and capacity\n"
 
       str << mbstring
 
-      Crystal::System.print_error "wrote another MB\n"
-
       str.bytesize.should eq 1 << 30
       str.capacity.should eq Int32::MAX
-      Crystal::System.print_error "tested bytesize and capacity\n"
 
       1023.times { str << mbstring }
-      Crystal::System.print_error "wrote 999 MB\n"
 
       # FIXME: https://github.com/crystal-lang/crystal/actions/runs/6895836942/job/18764260201?pr=13989
       {% unless flag?(:wasm32) %}
         str.write mbstring.to_slice[0..(-4 - String::HEADER_SIZE)]
-        Crystal::System.print_error "wrote almost 1 MB\n"
+        str.write mbstring.to_slice[0..(-4 - String::HEADER_SIZE)]
         str << "a"
-        Crystal::System.print_error "wrote last byte\n"
         expect_raises(IO::EOFError) do
           str << "a"
         end
       {% end %}
       Crystal::System.print_error "end block\n"
     end
-    Crystal::System.print_error "end test\n"
   end
 end

--- a/spec/std/string_builder_spec.cr
+++ b/spec/std/string_builder_spec.cr
@@ -40,4 +40,15 @@ describe String::Builder do
       str.chomp!(44).to_s.should eq("a,b,c")
     end
   end
+
+  it "raises EOFError" do
+    builder = String::Builder.new
+    initial_capacity = builder.capacity
+    expect_raises(IO::EOFError) do
+      builder.write Slice.new(Pointer(UInt8).null, Int32::MAX)
+    end
+    # nothing get's written
+    builder.bytesize.should eq 0
+    builder.capacity.should eq initial_capacity
+  end
 end

--- a/spec/std/string_builder_spec.cr
+++ b/spec/std/string_builder_spec.cr
@@ -76,13 +76,16 @@ describe String::Builder do
       1023.times { str << mbstring }
       Crystal::System.print_error "wrote 999 MB\n"
 
-      str.write mbstring.to_slice[0..(-4 - String::HEADER_SIZE)]
-      Crystal::System.print_error "wrote almost 1 MB\n"
-      str << "a"
-      Crystal::System.print_error "wrote last byte\n"
-      expect_raises(IO::EOFError) do
+      # FIXME: https://github.com/crystal-lang/crystal/actions/runs/6895836942/job/18764260201?pr=13989
+      {% unless flag?(:wasm32) %}
+        str.write mbstring.to_slice[0..(-4 - String::HEADER_SIZE)]
+        Crystal::System.print_error "wrote almost 1 MB\n"
         str << "a"
-      end
+        Crystal::System.print_error "wrote last byte\n"
+        expect_raises(IO::EOFError) do
+          str << "a"
+        end
+      {% end %}
       Crystal::System.print_error "end block\n"
     end
     Crystal::System.print_error "end test\n"

--- a/spec/std/string_builder_spec.cr
+++ b/spec/std/string_builder_spec.cr
@@ -52,26 +52,39 @@ describe String::Builder do
     builder.capacity.should eq initial_capacity
   end
 
-  it "allocates for > 1 GB", tags: %w[slow] do
+  it "allocates for > 1 GB", tags: %w[slow], focus: true do
+    Crystal::System.print_error "start test\n"
     String::Builder.build do |str|
+      Crystal::System.print_error "start block\n"
       mbstring = "a" * 1024 * 1024
+      Crystal::System.print_error "allocated mbstring\n"
       1023.times { str << mbstring }
+      Crystal::System.print_error "wrote 999 MB\n"
 
       str.bytesize.should eq (1 << 30) - (1 << 20)
       str.capacity.should eq 1 << 30
+      Crystal::System.print_error "tested bytesize and capacity\n"
 
       str << mbstring
 
+      Crystal::System.print_error "wrote another MB\n"
+
       str.bytesize.should eq 1 << 30
       str.capacity.should eq Int32::MAX
+      Crystal::System.print_error "tested bytesize and capacity\n"
 
       1023.times { str << mbstring }
+      Crystal::System.print_error "wrote 999 MB\n"
 
       str.write mbstring.to_slice[0..(-4 - String::HEADER_SIZE)]
+      Crystal::System.print_error "wrote almost 1 MB\n"
       str << "a"
+      Crystal::System.print_error "wrote last byte\n"
       expect_raises(IO::EOFError) do
         str << "a"
       end
+      Crystal::System.print_error "end block\n"
     end
+    Crystal::System.print_error "end test\n"
   end
 end

--- a/spec/std/string_builder_spec.cr
+++ b/spec/std/string_builder_spec.cr
@@ -52,7 +52,7 @@ describe String::Builder do
     builder.capacity.should eq initial_capacity
   end
 
-  # FIXME(wasm32): https://github.com/crystal-lang/crystal/pull/13989#issuecomment-1817481289
+  # FIXME(wasm32): https://github.com/crystal-lang/crystal/issues/14057
   {% if flag?(:wasm32) %}
     pending "allocation for > 1 GB"
   {% else %}

--- a/spec/std/string_builder_spec.cr
+++ b/spec/std/string_builder_spec.cr
@@ -70,13 +70,11 @@ describe String::Builder do
       # FIXME: https://github.com/crystal-lang/crystal/actions/runs/6895836942/job/18764260201?pr=13989
       {% unless flag?(:wasm32) %}
         str.write mbstring.to_slice[0..(-4 - String::HEADER_SIZE)]
-        str.write mbstring.to_slice[0..(-4 - String::HEADER_SIZE)]
         str << "a"
         expect_raises(IO::EOFError) do
           str << "a"
         end
       {% end %}
-      Crystal::System.print_error "end block\n"
     end
   end
 end

--- a/spec/std/string_builder_spec.cr
+++ b/spec/std/string_builder_spec.cr
@@ -51,4 +51,19 @@ describe String::Builder do
     builder.bytesize.should eq 0
     builder.capacity.should eq initial_capacity
   end
+
+  it "allocates for > 1 GB", tags: %w[slow] do
+    String::Builder.build do |str|
+      mbstring = "a" * 1024 * 1024
+      1023.times { str << mbstring }
+
+      str.bytesize.should eq (1 << 30) - (1 << 20)
+      str.capacity.should eq 1 << 30
+
+      str << mbstring
+
+      str.bytesize.should eq 1 << 30
+      str.capacity.should eq Int32::MAX
+    end
+  end
 end

--- a/src/io/memory.cr
+++ b/src/io/memory.cr
@@ -451,6 +451,8 @@ class IO::Memory < IO
   end
 
   private def increase_capacity_by(count)
+    raise IO::EOFError.new if count >= Int32::MAX - bytesize
+
     new_bytesize = @pos + count
     return if new_bytesize <= @capacity
 

--- a/src/io/memory.cr
+++ b/src/io/memory.cr
@@ -90,11 +90,7 @@ class IO::Memory < IO
 
     return if count == 0
 
-    new_bytesize = @pos + count
-    if new_bytesize > @capacity
-      check_resizeable
-      resize_to_capacity(Math.pw2ceil(new_bytesize))
-    end
+    increase_capacity_by(count)
 
     slice.copy_to(@buffer + @pos, count)
 
@@ -112,11 +108,7 @@ class IO::Memory < IO
     check_writeable
     check_open
 
-    new_bytesize = @pos + 1
-    if new_bytesize > @capacity
-      check_resizeable
-      resize_to_capacity(Math.pw2ceil(new_bytesize))
-    end
+    increase_capacity_by(1)
 
     (@buffer + @pos).value = byte
 
@@ -456,6 +448,20 @@ class IO::Memory < IO
     unless @resizeable
       raise IO::Error.new "Non-resizeable stream"
     end
+  end
+
+  private def increase_capacity_by(count)
+    new_bytesize = @pos + count
+    return if new_bytesize <= @capacity
+
+    check_resizeable
+
+    new_capacity = calculate_new_capacity(new_bytesize)
+    resize_to_capacity(new_capacity)
+  end
+
+  private def calculate_new_capacity(new_bytesize : Int32)
+    Math.pw2ceil(new_bytesize)
   end
 
   private def resize_to_capacity(capacity)

--- a/src/io/memory.cr
+++ b/src/io/memory.cr
@@ -463,6 +463,12 @@ class IO::Memory < IO
   end
 
   private def calculate_new_capacity(new_bytesize : Int32)
+    # If the new bytesize is bigger than 1 << 30, the next power of two would
+    # be 1 << 31, which is out of range for Int32.
+    # So we limit the capacity to Int32::MAX in order to be able to use the
+    # range (1 << 30) < new_bytesize < Int32::MAX
+    return Int32::MAX if new_bytesize > 1 << 30
+
     Math.pw2ceil(new_bytesize)
   end
 

--- a/src/string/builder.cr
+++ b/src/string/builder.cr
@@ -130,6 +130,12 @@ class String::Builder < IO
   end
 
   private def calculate_new_capacity(new_bytesize)
+    # If the new bytesize is bigger than 1 << 30, the next power of two would
+    # be 1 << 31, which is out of range for Int32.
+    # So we limit the capacity to Int32::MAX in order to be able to use the
+    # range (1 << 30) < new_bytesize < Int32::MAX
+    return Int32::MAX if new_bytesize > 1 << 30
+
     Math.pw2ceil(new_bytesize)
   end
 

--- a/src/string/builder.cr
+++ b/src/string/builder.cr
@@ -41,21 +41,14 @@ class String::Builder < IO
     return if slice.empty?
 
     count = slice.size
-    new_bytesize = real_bytesize + count
-    if new_bytesize > @capacity
-      resize_to_capacity(Math.pw2ceil(new_bytesize))
-    end
 
+    increase_capacity_by count
     slice.copy_to(@buffer + real_bytesize, count)
     @bytesize += count
   end
 
   def write_byte(byte : UInt8) : Nil
-    new_bytesize = real_bytesize + 1
-    if new_bytesize > @capacity
-      resize_to_capacity(Math.pw2ceil(new_bytesize))
-    end
-
+    increase_capacity_by 1
     @buffer[real_bytesize] = byte
 
     @bytesize += 1
@@ -124,6 +117,18 @@ class String::Builder < IO
 
   private def real_bytesize
     @bytesize + String::HEADER_SIZE
+  end
+
+  private def increase_capacity_by(count)
+    new_bytesize = real_bytesize + count
+    return if new_bytesize <= @capacity
+
+    new_capacity = calculate_new_capacity(new_bytesize)
+    resize_to_capacity(new_capacity)
+  end
+
+  private def calculate_new_capacity(new_bytesize)
+    Math.pw2ceil(new_bytesize)
   end
 
   private def resize_to_capacity(capacity)

--- a/src/string/builder.cr
+++ b/src/string/builder.cr
@@ -120,6 +120,8 @@ class String::Builder < IO
   end
 
   private def increase_capacity_by(count)
+    raise IO::EOFError.new if count >= Int32::MAX - real_bytesize
+
     new_bytesize = real_bytesize + count
     return if new_bytesize <= @capacity
 

--- a/src/string/builder.cr
+++ b/src/string/builder.cr
@@ -101,17 +101,18 @@ class String::Builder < IO
     raise "Can only invoke 'to_s' once on String::Builder" if @finished
     @finished = true
 
-    write_byte 0_u8
+    real_bytesize = real_bytesize()
+    @buffer[real_bytesize] = 0_u8
+    real_bytesize += 1
 
     # Try to reclaim some memory if capacity is bigger than what we need
-    real_bytesize = real_bytesize()
     if @capacity > real_bytesize
       resize_to_capacity(real_bytesize)
     end
 
     String.set_crystal_type_id(@buffer)
     str = @buffer.as(String)
-    str.initialize_header((bytesize - 1).to_i)
+    str.initialize_header(bytesize)
     str
   end
 


### PR DESCRIPTION
The byte buffer for `IO::Memory` and `String::Buffer` grows exponentially by the next power of two bigger then the currently requested size. So for example, if space is requested for 78 bytes, it allocates for a capacity of 128 bytes (`1 << 7`).

The maximum size of a buffer is `Int32::MAX`, which is just one below a power of tw (`(1 << 31) - 1`). So if space is requested for more than `1 << 30` bytes, the next power of two would be `1 << 31` which is out of range and raises `ArithmeticError`.
This means, the sizes between `(1 << 30) + 1` and `(2 << 31) - 1` would all be valid but cannot be reached by the dynamically growing buffer. If the actually required bytesize does not exeed `(2 << 31) - 1`, it should be possible to allocate that much.

This patch clamps the maximum cacpacity to `Int32::MAX`. That enables sizes in that range and there will only be an error if that is definitely not enough space.

Resolves #13987