### PR TITLE
Use `IO.copy` in `IO#gets_to_end`

### DIFF
--- a/src/io.cr
+++ b/src/io.cr
@@ -563,10 +563,7 @@ abstract class IO
           decoder.write(str)
         end
       else
-        buffer = uninitialized UInt8[DEFAULT_BUFFER_SIZE]
-        while (read_bytes = read(buffer.to_slice)) > 0
-          str.write buffer.to_slice[0, read_bytes]
-        end
+        IO.copy(self, str)
       end
     end
   end


### PR DESCRIPTION
The implementation is almost identical. `IO.copy` also keeps track of the size which is irrelevant for `#gets_to_end`. But I'm sure optimizations will get rid of it.
The similar `#getb_to_end` alrady uses `IO.copy`.