### PR TITLE
Remove relative path to vendored shards `markd` and `reply`

### DIFF
--- a/src/compiler/crystal/interpreter/repl_reader.cr
+++ b/src/compiler/crystal/interpreter/repl_reader.cr
@@ -1,4 +1,4 @@
-require "../../../../lib/reply/src/reply"
+require "reply"
 
 class Crystal::ReplReader < Reply::Reader
   KEYWORDS = %w(

--- a/src/compiler/crystal/tools/doc/generator.cr
+++ b/src/compiler/crystal/tools/doc/generator.cr
@@ -1,4 +1,4 @@
-require "../../../../../lib/markd/src/markd"
+require "markd"
 require "crystal/syntax_highlighter/html"
 
 class Crystal::Doc::Generator

--- a/src/compiler/crystal/tools/playground/server.cr
+++ b/src/compiler/crystal/tools/playground/server.cr
@@ -2,7 +2,7 @@ require "http/server"
 require "log"
 require "ecr/macros"
 require "compiler/crystal/tools/formatter"
-require "../../../../../lib/markd/src/markd"
+require "markd"
 
 module Crystal::Playground
   Log = ::Log.for("crystal.playground")


### PR DESCRIPTION
Following discussion in #13784, this PR (re)removes the relative paths to the vendored shards, allowing the Crystal compiler itself to be used as a library a lot easier.

This change does mean that in order to use the compiler within Crystal, it's necessary to add equivalent `markd` and `reply` shards to the project, as it won't be using the ones provided by the compiler itself.