### PR TITLE
Fix version sorting in API docs

### DIFF
--- a/scripts/docs-versions.sh
+++ b/scripts/docs-versions.sh
@@ -3,7 +3,7 @@
 git tag --list | \
 grep -v -E '0\.1?[0-9]\.' | \
 grep '^[0-9]' | \
-tac | \
+sort -rV | \
 awk '
   BEGIN {
     print "{"


### PR DESCRIPTION
![2023-11-18_01-06-43](https://github.com/crystal-lang/crystal/assets/1622080/8fef2e74-7076-4385-93e2-2f90590cd90f)
