### PR TITLE
Windows: Do not close process handle in `Process#close`

### DIFF
--- a/spec/std/process_spec.cr
+++ b/spec/std/process_spec.cr
@@ -333,9 +333,7 @@ describe Process do
       {% end %}
     end
 
-    # TODO: this spec gives "WaitForSingleObject: The handle is invalid."
-    # is this because standard streams on windows aren't async?
-    pending_win32 "can link processes together" do
+    it "can link processes together" do
       buffer = IO::Memory.new
       Process.run(*stdin_to_stdout_command) do |cat|
         Process.run(*stdin_to_stdout_command, input: cat.output, output: buffer) do

--- a/src/process.cr
+++ b/src/process.cr
@@ -328,6 +328,7 @@ class Process
     Process::Status.new(@process_info.wait)
   ensure
     close
+    @process_info.release
   end
 
   # Whether the process is still registered in the system.
@@ -346,7 +347,6 @@ class Process
     close_io @input
     close_io @output
     close_io @error
-    @process_info.release
   end
 
   # Asks this process to terminate.


### PR DESCRIPTION
Fixes #13425.

`Crystal::System::Process#release` is already a no-op on Unix-like systems.