### PR TITLE
Refactor some uses of the blockless `String#split`

### DIFF
--- a/src/crystal/system/unix/env.cr
+++ b/src/crystal/system/unix/env.cr
@@ -42,9 +42,11 @@ module Crystal::System::Env
     while environ_ptr
       environ_value = environ_ptr.value
       if environ_value
-        key_value = String.new(environ_value).split('=', 2)
-        key = key_value[0]
-        value = key_value[1]? || ""
+        # this does `String.new(environ_value).partition('=')` without an intermediary string
+        key_value = Slice.new(environ_value, LibC.strlen(environ_value))
+        split_index = key_value.index!(0x3d_u8) # '='
+        key = String.new(key_value[0, split_index])
+        value = String.new(key_value[split_index + 1..])
         yield key, value
         environ_ptr += 1
       else

--- a/src/http/formdata.cr
+++ b/src/http/formdata.cr
@@ -138,13 +138,15 @@ module HTTP::FormData
     size = nil
     name = nil
 
-    parts = content_disposition.split(';')
-    type = parts[0]
-    raise Error.new("Invalid Content-Disposition: not form-data") unless type == "form-data"
-    (1...parts.size).each do |i|
-      part = parts[i]
+    first = true
+    content_disposition.split(';') do |part|
+      if first
+        first = false
+        raise Error.new("Invalid Content-Disposition: not form-data") unless part == "form-data"
+        next
+      end
 
-      key, value = part.split('=', 2)
+      key, _, value = part.partition('=')
       key = key.strip
       value = value.strip
       if value[0] == '"'

--- a/src/http/formdata.cr
+++ b/src/http/formdata.cr
@@ -138,15 +138,11 @@ module HTTP::FormData
     size = nil
     name = nil
 
-    first = true
-    content_disposition.split(';') do |part|
-      if first
-        first = false
-        raise Error.new("Invalid Content-Disposition: not form-data") unless part == "form-data"
-        next
-      end
-
-      key, _, value = part.partition('=')
+    parts = content_disposition.split(';')
+    type = parts.shift?
+    raise Error.new("Invalid Content-Disposition: not form-data") unless type == "form-data"
+    parts.each do |part|
+      key, value = part.split('=', 2)
       key = key.strip
       value = value.strip
       if value[0] == '"'

--- a/src/http/formdata.cr
+++ b/src/http/formdata.cr
@@ -142,7 +142,7 @@ module HTTP::FormData
     type = parts.shift?
     raise Error.new("Invalid Content-Disposition: not form-data") unless type == "form-data"
     parts.each do |part|
-      key, value = part.split('=', 2)
+      key, _, value = part.partition('=')
       key = key.strip
       value = value.strip
       if value[0] == '"'

--- a/src/openssl/x509/name.cr
+++ b/src/openssl/x509/name.cr
@@ -14,8 +14,8 @@ module OpenSSL::X509
     # ```
     def self.parse(string : String) : Name
       new.tap do |name|
-        string.split('/').each do |entry|
-          oid, value = entry.split('=')
+        string.split('/') do |entry|
+          oid, _, value = entry.partition('=')
           name.add_entry(oid, value)
         end
       end

--- a/src/process/executable_path.cr
+++ b/src/process/executable_path.cr
@@ -95,7 +95,7 @@ class Process
     end
 
     if path && !has_separator
-      path.split(PATH_DELIMITER).each do |path_entry|
+      path.split(PATH_DELIMITER) do |path_entry|
         yield Path.new(path_entry, name)
       end
     end

--- a/src/semantic_version.cr
+++ b/src/semantic_version.cr
@@ -178,7 +178,7 @@ struct SemanticVersion
     # ```
     def self.parse(str : String) : self
       identifiers = [] of String | Int32
-      str.split('.').each do |val|
+      str.split('.') do |val|
         if number = val.to_i32?
           identifiers << number
         else

--- a/src/spec/context.cr
+++ b/src/spec/context.cr
@@ -210,7 +210,7 @@ module Spec
             puts
 
             message = ex.is_a?(SpecError) ? ex.to_s : ex.inspect_with_backtrace
-            message.split('\n').each do |line|
+            message.split('\n') do |line|
               print "       "
               puts Spec.color(line, :error)
             end

--- a/src/spec/dsl.cr
+++ b/src/spec/dsl.cr
@@ -96,8 +96,8 @@ module Spec
 
   def self.add_split_filter(filter)
     if filter
-      r, m = filter.split('%').map &.to_i
-      @@split_filter = SplitFilter.new(remainder: r, quotient: m)
+      r, _, m = filter.partition('%')
+      @@split_filter = SplitFilter.new(remainder: r.to_i, quotient: m.to_i)
     else
       @@split_filter = nil
     end


### PR DESCRIPTION
The ones followed by `Array#each` can use the block overload directly. Some others can be replaced by `String#partition`.