### PR TITLE
Fix invalid UTF-8 handling in `Char::Reader#previous_char`

### DIFF
--- a/spec/std/char/reader_spec.cr
+++ b/spec/std/char/reader_spec.cr
@@ -10,7 +10,8 @@ end
 
 private def assert_reads_at_end(bytes, *, file = __FILE__, line = __LINE__)
   str = String.new bytes
-  reader = Char::Reader.new(at_end: str)
+  reader = Char::Reader.new(str, pos: bytes.size)
+  reader.previous_char
   reader.current_char.should eq(str[0]), file: file, line: line
   reader.current_char_width.should eq(bytes.size), file: file, line: line
   reader.pos.should eq(0), file: file, line: line
@@ -18,7 +19,9 @@ private def assert_reads_at_end(bytes, *, file = __FILE__, line = __LINE__)
 end
 
 private def assert_invalid_byte_sequence_at_end(bytes, *, file = __FILE__, line = __LINE__)
-  reader = Char::Reader.new(at_end: String.new bytes)
+  str = String.new bytes
+  reader = Char::Reader.new(str, pos: bytes.size)
+  reader.previous_char
   reader.current_char.should eq(Char::REPLACEMENT), file: file, line: line
   reader.current_char_width.should eq(1), file: file, line: line
   reader.pos.should eq(bytes.size - 1), file: file, line: line
@@ -211,7 +214,7 @@ describe "Char::Reader" do
     assert_invalid_byte_sequence Bytes[0xf4, 0x8f, 0xa0]
   end
 
-  describe "#previous_char / at_end" do
+  describe "#previous_char" do
     it "reads on valid UTF-8" do
       assert_reads_at_end Bytes[0x00]
       assert_reads_at_end Bytes[0x7f]

--- a/spec/std/char/reader_spec.cr
+++ b/spec/std/char/reader_spec.cr
@@ -1,11 +1,28 @@
 require "spec"
 require "char/reader"
 
-private def assert_invalid_byte_sequence(bytes)
+private def assert_invalid_byte_sequence(bytes, *, file = __FILE__, line = __LINE__)
   reader = Char::Reader.new(String.new bytes)
-  reader.current_char.should eq(Char::REPLACEMENT)
-  reader.current_char_width.should eq(1)
-  reader.error.should eq(bytes[0])
+  reader.current_char.should eq(Char::REPLACEMENT), file: file, line: line
+  reader.current_char_width.should eq(1), file: file, line: line
+  reader.error.should eq(bytes[0]), file: file, line: line
+end
+
+private def assert_reads_at_end(bytes, *, file = __FILE__, line = __LINE__)
+  str = String.new bytes
+  reader = Char::Reader.new(at_end: str)
+  reader.current_char.should eq(str[0]), file: file, line: line
+  reader.current_char_width.should eq(bytes.size), file: file, line: line
+  reader.pos.should eq(0), file: file, line: line
+  reader.error.should be_nil, file: file, line: line
+end
+
+private def assert_invalid_byte_sequence_at_end(bytes, *, file = __FILE__, line = __LINE__)
+  reader = Char::Reader.new(at_end: String.new bytes)
+  reader.current_char.should eq(Char::REPLACEMENT), file: file, line: line
+  reader.current_char_width.should eq(1), file: file, line: line
+  reader.pos.should eq(bytes.size - 1), file: file, line: line
+  reader.error.should eq(bytes[-1]), file: file, line: line
 end
 
 describe "Char::Reader" do
@@ -192,5 +209,113 @@ describe "Char::Reader" do
 
   it "errors if fourth_byte is out of bounds" do
     assert_invalid_byte_sequence Bytes[0xf4, 0x8f, 0xa0]
+  end
+
+  describe "#previous_char / at_end" do
+    it "reads on valid UTF-8" do
+      assert_reads_at_end Bytes[0x00]
+      assert_reads_at_end Bytes[0x7f]
+
+      assert_reads_at_end Bytes[0xc2, 0x80]
+      assert_reads_at_end Bytes[0xc2, 0xbf]
+      assert_reads_at_end Bytes[0xdf, 0x80]
+      assert_reads_at_end Bytes[0xdf, 0xbf]
+
+      assert_reads_at_end Bytes[0xe1, 0x80, 0x80]
+      assert_reads_at_end Bytes[0xe1, 0x80, 0xbf]
+      assert_reads_at_end Bytes[0xe1, 0x9f, 0x80]
+      assert_reads_at_end Bytes[0xe1, 0x9f, 0xbf]
+      assert_reads_at_end Bytes[0xed, 0x80, 0x80]
+      assert_reads_at_end Bytes[0xed, 0x80, 0xbf]
+      assert_reads_at_end Bytes[0xed, 0x9f, 0x80]
+      assert_reads_at_end Bytes[0xed, 0x9f, 0xbf]
+      assert_reads_at_end Bytes[0xef, 0x80, 0x80]
+      assert_reads_at_end Bytes[0xef, 0x80, 0xbf]
+      assert_reads_at_end Bytes[0xef, 0x9f, 0x80]
+      assert_reads_at_end Bytes[0xef, 0x9f, 0xbf]
+
+      assert_reads_at_end Bytes[0xe0, 0xa0, 0x80]
+      assert_reads_at_end Bytes[0xe0, 0xa0, 0xbf]
+      assert_reads_at_end Bytes[0xe0, 0xbf, 0x80]
+      assert_reads_at_end Bytes[0xe0, 0xbf, 0xbf]
+      assert_reads_at_end Bytes[0xe1, 0xa0, 0x80]
+      assert_reads_at_end Bytes[0xe1, 0xa0, 0xbf]
+      assert_reads_at_end Bytes[0xe1, 0xbf, 0x80]
+      assert_reads_at_end Bytes[0xe1, 0xbf, 0xbf]
+      assert_reads_at_end Bytes[0xef, 0xa0, 0x80]
+      assert_reads_at_end Bytes[0xef, 0xa0, 0xbf]
+      assert_reads_at_end Bytes[0xef, 0xbf, 0x80]
+      assert_reads_at_end Bytes[0xef, 0xbf, 0xbf]
+
+      assert_reads_at_end Bytes[0xf1, 0x80, 0x80, 0x80]
+      assert_reads_at_end Bytes[0xf1, 0x8f, 0x80, 0x80]
+      assert_reads_at_end Bytes[0xf4, 0x80, 0x80, 0x80]
+      assert_reads_at_end Bytes[0xf4, 0x8f, 0x80, 0x80]
+
+      assert_reads_at_end Bytes[0xf0, 0x90, 0x80, 0x80]
+      assert_reads_at_end Bytes[0xf0, 0xbf, 0x80, 0x80]
+      assert_reads_at_end Bytes[0xf3, 0x90, 0x80, 0x80]
+      assert_reads_at_end Bytes[0xf3, 0xbf, 0x80, 0x80]
+    end
+
+    it "errors on invalid UTF-8" do
+      assert_invalid_byte_sequence_at_end Bytes[0x80]
+      assert_invalid_byte_sequence_at_end Bytes[0xbf]
+      assert_invalid_byte_sequence_at_end Bytes[0xc0]
+      assert_invalid_byte_sequence_at_end Bytes[0xff]
+
+      assert_invalid_byte_sequence_at_end Bytes[0x00, 0x80]
+      assert_invalid_byte_sequence_at_end Bytes[0x7f, 0x80]
+      assert_invalid_byte_sequence_at_end Bytes[0x80, 0x80]
+      assert_invalid_byte_sequence_at_end Bytes[0x9f, 0x80]
+      assert_invalid_byte_sequence_at_end Bytes[0xa0, 0x80]
+      assert_invalid_byte_sequence_at_end Bytes[0xbf, 0x80]
+      assert_invalid_byte_sequence_at_end Bytes[0xc0, 0x80]
+      assert_invalid_byte_sequence_at_end Bytes[0xc1, 0x80]
+      assert_invalid_byte_sequence_at_end Bytes[0xe0, 0x80]
+      assert_invalid_byte_sequence_at_end Bytes[0xff, 0x80]
+
+      assert_invalid_byte_sequence_at_end Bytes[0x00, 0x80, 0x80]
+      assert_invalid_byte_sequence_at_end Bytes[0x7f, 0x80, 0x80]
+      assert_invalid_byte_sequence_at_end Bytes[0x80, 0x80, 0x80]
+      assert_invalid_byte_sequence_at_end Bytes[0x8f, 0x80, 0x80]
+      assert_invalid_byte_sequence_at_end Bytes[0x90, 0x80, 0x80]
+      assert_invalid_byte_sequence_at_end Bytes[0xbf, 0x80, 0x80]
+      assert_invalid_byte_sequence_at_end Bytes[0xc0, 0x80, 0x80]
+      assert_invalid_byte_sequence_at_end Bytes[0xc1, 0x80, 0x80]
+      assert_invalid_byte_sequence_at_end Bytes[0xc2, 0x80, 0x80]
+      assert_invalid_byte_sequence_at_end Bytes[0xdf, 0x80, 0x80]
+      assert_invalid_byte_sequence_at_end Bytes[0xe0, 0x80, 0x80]
+      assert_invalid_byte_sequence_at_end Bytes[0xe0, 0x9f, 0xbf]
+      assert_invalid_byte_sequence_at_end Bytes[0xf0, 0x80, 0x80]
+      assert_invalid_byte_sequence_at_end Bytes[0xff, 0x80, 0x80]
+
+      assert_invalid_byte_sequence_at_end Bytes[0x00, 0xa0, 0x80]
+      assert_invalid_byte_sequence_at_end Bytes[0x7f, 0xa0, 0x80]
+      assert_invalid_byte_sequence_at_end Bytes[0x80, 0xa0, 0x80]
+      assert_invalid_byte_sequence_at_end Bytes[0x8f, 0xa0, 0x80]
+      assert_invalid_byte_sequence_at_end Bytes[0x90, 0xa0, 0x80]
+      assert_invalid_byte_sequence_at_end Bytes[0xbf, 0xa0, 0x80]
+      assert_invalid_byte_sequence_at_end Bytes[0xc0, 0xa0, 0x80]
+      assert_invalid_byte_sequence_at_end Bytes[0xc1, 0xa0, 0x80]
+      assert_invalid_byte_sequence_at_end Bytes[0xc2, 0xa0, 0x80]
+      assert_invalid_byte_sequence_at_end Bytes[0xdf, 0xa0, 0x80]
+      assert_invalid_byte_sequence_at_end Bytes[0xed, 0xa0, 0x80]
+      assert_invalid_byte_sequence_at_end Bytes[0xed, 0xbf, 0xbf]
+      assert_invalid_byte_sequence_at_end Bytes[0xf0, 0xa0, 0x80]
+      assert_invalid_byte_sequence_at_end Bytes[0xff, 0xa0, 0x80]
+
+      assert_invalid_byte_sequence_at_end Bytes[0x00, 0x80, 0x80, 0x80]
+      assert_invalid_byte_sequence_at_end Bytes[0xef, 0x80, 0x80, 0x80]
+      assert_invalid_byte_sequence_at_end Bytes[0xf0, 0x80, 0x80, 0x80]
+      assert_invalid_byte_sequence_at_end Bytes[0xf5, 0x80, 0x80, 0x80]
+      assert_invalid_byte_sequence_at_end Bytes[0xff, 0x80, 0x80, 0x80]
+
+      assert_invalid_byte_sequence_at_end Bytes[0x00, 0x90, 0x80, 0x80]
+      assert_invalid_byte_sequence_at_end Bytes[0xef, 0x90, 0x80, 0x80]
+      assert_invalid_byte_sequence_at_end Bytes[0xf4, 0x90, 0x80, 0x80]
+      assert_invalid_byte_sequence_at_end Bytes[0xf5, 0x90, 0x80, 0x80]
+      assert_invalid_byte_sequence_at_end Bytes[0xff, 0x90, 0x80, 0x80]
+    end
   end
 end


### PR DESCRIPTION
Fixes #14010.

This relies on an explicit reverse DFA for the UTF-8 encoding, instead of actually "trying" 1 - 4 bytes for a valid byte sequence.