### PR TITLE
Extract `generate_data` to separate Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -139,31 +139,9 @@ llvm_ext: $(LLVM_EXT_OBJ)
 format: ## Format sources
 	./bin/crystal tool format$(if $(check), --check) src spec samples scripts
 
-generate_data: ## Run generator scripts for Unicode, SSL config, ... (usually with `-B`/`--always-make` flag)
-
-generate_data: spec/std/string/graphemes_break_spec.cr
-spec/std/string/graphemes_break_spec.cr: scripts/generate_grapheme_break_specs.cr
-	$(CRYSTAL) run $<
-
-generate_data: src/string/grapheme/properties.cr
-src/string/grapheme/properties.cr: scripts/generate_grapheme_properties.cr
-	$(CRYSTAL) run $<
-
-generate_data: src/openssl/ssl/defaults.cr
-src/openssl/ssl/defaults.cr: scripts/generate_ssl_server_defaults.cr
-	$(CRYSTAL) run $<
-
-generate_data: src/unicode/data.cr
-src/unicode/data.cr: scripts/generate_unicode_data.cr
-	$(CRYSTAL) run $<
-
-generate_data: src/crystal/system/win32/zone_names.cr
-src/crystal/system/win32/zone_names.cr: scripts/generate_windows_zone_names.cr
-	$(CRYSTAL) run $<
-
-generate_data: src/html/entities.cr
-src/html/entities.cr: scripts/generate_html_entities.cr scripts/html_entities.ecr
-	$(CRYSTAL) run $<
+.PHONY: generate_data
+generate_data: ## Run generator scripts for Unicode, SSL config, ...
+	$(MAKE) -B -f scripts/generate_data.mk
 
 .PHONY: install
 install: $(O)/crystal man/crystal.1.gz ## Install the compiler at DESTDIR

--- a/Makefile.win
+++ b/Makefile.win
@@ -141,31 +141,8 @@ llvm_ext: $(LLVM_EXT_OBJ)
 format: ## Format sources
 	.\bin\crystal tool format$(if $(check), --check) src spec samples scripts
 
-generate_data: ## Run generator scripts for Unicode, SSL config, ... (usually with `-B`/`--always-make` flag)
-
-generate_data: spec\std\string\graphemes_break_spec.cr
-spec\std\string\graphemes_break_spec.cr: scripts\generate_grapheme_break_specs.cr
-	$(CRYSTAL) run $<
-
-generate_data: src\string\grapheme\properties.cr
-src\string\grapheme\properties.cr: scripts\generate_grapheme_properties.cr
-	$(CRYSTAL) run $<
-
-generate_data: src\openssl\ssl\defaults.cr
-src\openssl\ssl\defaults.cr: scripts\generate_ssl_server_defaults.cr
-	$(CRYSTAL) run $<
-
-generate_data: src\unicode\data.cr
-src\unicode\data.cr: scripts\generate_unicode_data.cr
-	$(CRYSTAL) run $<
-
-generate_data: src\crystal\system\win32\zone_names.cr
-src\crystal\system\win32\zone_names.cr: scripts\generate_windows_zone_names.cr
-	$(CRYSTAL) run $<
-
-generate_data: src\html\entities.cr
-src\html\entities.cr: scripts\generate_html_entities.cr scripts\html_entities.ecr
-	$(CRYSTAL) run $<
+generate_data: ## Run generator scripts for Unicode, SSL config, ...
+	$(MAKE) -B -f scripts/generate_data.mk
 
 .PHONY: install
 install: $(O)\crystal.exe ## Install the compiler at prefix

--- a/scripts/generate_data.mk
+++ b/scripts/generate_data.mk
@@ -1,0 +1,49 @@
+
+## Run all data generators
+##   $ make -B -f scripts/generate_data.mk
+## Run specific data generator
+##   $ make -B -f scripts/generate_data.mk spec/std/string/graphemes_break_spec.cr
+
+all: ## Run all generators
+.PHONY: all
+
+all: spec/std/string/graphemes_break_spec.cr
+spec/std/string/graphemes_break_spec.cr: scripts/generate_grapheme_break_specs.cr
+	bin/crystal run $<
+
+all: src/string/grapheme/properties.cr
+src/string/grapheme/properties.cr: scripts/generate_grapheme_properties.cr
+	bin/crystal run $<
+
+all: src/openssl/ssl/defaults.cr
+src/openssl/ssl/defaults.cr: scripts/generate_ssl_server_defaults.cr
+	bin/crystal run $<
+
+all: src/unicode/data.cr
+src/unicode/data.cr: scripts/generate_unicode_data.cr
+	bin/crystal run $<
+
+all: src/crystal/system/win32/zone_names.cr
+src/crystal/system/win32/zone_names.cr: scripts/generate_windows_zone_names.cr
+	bin/crystal run $<
+
+all: src/html/entities.cr
+src/html/entities.cr: scripts/generate_html_entities.cr scripts/html_entities.ecr
+	bin/crystal run $<
+
+.PHONY: help
+help: ## Show this help
+	@echo
+	@printf '\033[34mtargets:\033[0m\n'
+	@grep -hE '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) |\
+		sort |\
+		awk 'BEGIN {FS = ":.*?## "}; {printf "  \033[36m%-15s\033[0m %s\n", $$1, $$2}'
+	@echo
+	@printf '\033[34moptional variables:\033[0m\n'
+	@grep -hE '^[a-zA-Z_-]+ \?=.*?## .*$$' $(MAKEFILE_LIST) |\
+		sort |\
+		awk 'BEGIN {FS = " \\?=.*?## "}; {printf "  \033[36m%-15s\033[0m %s\n", $$1, $$2}'
+	@echo
+	@printf '\033[34mrecipes:\033[0m\n'
+	@grep -hE '^##.*$$' $(MAKEFILE_LIST) |\
+		awk 'BEGIN {FS = "## "}; /^## [a-zA-Z_-]/ {printf "  \033[36m%s\033[0m\n", $$2}; /^##  / {printf "  %s\n", $$2}'


### PR DESCRIPTION
The generator recipes are really a separate thing from everything else in the Makefile. These recipes shouldn't implicitly trigger when building anything that depends on `$(SOURCE)`. They're expected to run only explicitly.

An added benefit is removing duplication between `Makefile` and `Makefile.win`. The new extracted makefile should be portable and thus we can use the same recipes on all platforms.

Context: https://github.com/crystal-lang/crystal/issues/14007#issuecomment-1824790834

Closes #14014