### PR TITLE
Clarify single-byte docs for `String#byte_slice`

### DIFF
--- a/src/string.cr
+++ b/src/string.cr
@@ -1173,7 +1173,7 @@ class String
   # only remaining bytes are returned.
   #
   # This method should be avoided,
-  # unless the string is proven to be ASCII-only (for example `#ascii_only?`),
+  # unless the string is known to only contain single-byte characters (for example `#ascii_only?`),
   # or the byte positions are known to be at character boundaries.
   # Otherwise, multi-byte characters may be split, leading to an invalid UTF-8 encoding.
   #
@@ -1206,7 +1206,7 @@ class String
   # If the end index is bigger than `#bytesize`, only remaining bytes are returned.
   #
   # This method should be avoided,
-  # unless the string is proven to be ASCII-only (for example `#ascii_only?`),
+  # unless the string is known to only contain single-byte characters (for example `#ascii_only?`),
   # or the byte positions are known to be at character boundaries.
   # Otherwise, multi-byte characters may be split, leading to an invalid UTF-8 encoding.
   #
@@ -1272,7 +1272,7 @@ class String
   # from the end of the string.
   #
   # This method should be avoided,
-  # unless the string is proven to be ASCII-only (for example `#ascii_only?`),
+  # unless the string is known to only contain single-byte characters (for example `#ascii_only?`),
   # or the byte positions are known to be at character boundaries.
   # Otherwise, multi-byte characters may be split, leading to an invalid UTF-8 encoding.
   #
@@ -1299,7 +1299,7 @@ class String
   # from the end of the string.
   #
   # This method should be avoided,
-  # unless the string is proven to be ASCII-only (for example `#ascii_only?`),
+  # unless the string is known to only contain single-byte characters (for example `#ascii_only?`),
   # or the byte positions are known to be at character boundaries.
   # Otherwise, multi-byte characters may be split, leading to an invalid UTF-8 encoding.
   #


### PR DESCRIPTION
This is a documentation-only change.

`String#byte_slice` can lead to unexpected behavior when slicing multibyte characters. The docs mention this, but equate "single-byte" with "ASCII", the latter of which is a subset.

For example, `ñ` is not ASCII but is a single-byte character.

```crystal
str = "so\xF1ar"

str.byte_slice(3) == str[3..]
# => true
```

This updates the docs, effectively replacing "ASCII" with "single-byte".