### PR TITLE
Support case-insensitive matching in `File.match?` and `Dir.glob`

### DIFF
--- a/spec/std/dir_spec.cr
+++ b/spec/std/dir_spec.cr
@@ -487,6 +487,22 @@ describe "Dir" do
       end
     end
 
+    it "respects `CaseInsensitive`" do
+      with_tempfile("glob-case-insensitive") do |path|
+        FileUtils.mkdir_p(path)
+
+        a_txt = File.join(path, "a.txt")
+        b_txt = File.join(path, "B.TXT")
+
+        File.write(a_txt, "")
+        File.write(b_txt, "")
+
+        Dir.glob("#{Path[path].to_posix}/*.txt", match: :case_insensitive).should eq [a_txt, b_txt]
+        Dir.glob("#{Path[path].to_posix}/*.TXT", match: :case_insensitive).should eq [a_txt, b_txt]
+        Dir.glob("#{Path[path].parent.to_posix}/GlOb-cAsE-INSENSITIVE/*", match: :case_insensitive).should eq [a_txt, b_txt]
+      end
+    end
+
     {% if flag?(:win32) %}
       it "respects `NativeHidden` and `OSHidden`" do
         with_tempfile("glob-system-hidden") do |path|

--- a/src/dir/glob.cr
+++ b/src/dir/glob.cr
@@ -134,34 +134,42 @@ class Dir
     record DirectoriesOnly
     record ConstantEntry, path : String, merged : Bool
     record EntryMatch, pattern : String do
-      def matches?(string) : Bool
-        File.match?(pattern, string)
+      def matches?(string, options) : Bool
+        # FIXME: `File.match?` does not support lack of `DotFiles` instead,
+        # remove this option later (note that `.run` currently filters out
+        # dotfiles per path segment, so this flag has no effect here)
+        options |= File::MatchOptions::DotFiles
+        options &= ~File::MatchOptions[NativeHidden, OSHidden]
+        File.match?(pattern, string, options)
       end
     end
     record RecursiveDirectories
     record ConstantDirectory, path : String
     record RootDirectory
     record DirectoryMatch, pattern : String do
-      def matches?(string) : Bool
-        File.match?(pattern, string)
+      def matches?(string, options) : Bool
+        # FIXME: ditto
+        options |= File::MatchOptions::DotFiles
+        options &= ~File::MatchOptions[NativeHidden, OSHidden]
+        File.match?(pattern, string, options)
       end
     end
     alias PatternType = DirectoriesOnly | ConstantEntry | EntryMatch | RecursiveDirectories | ConstantDirectory | RootDirectory | DirectoryMatch
 
-    def self.glob(patterns : Enumerable, *, match, follow_symlinks, &block : String -> _)
+    def self.glob(patterns : Enumerable, *, match options, follow_symlinks, &block : String -> _)
       patterns.each do |pattern|
         if pattern.is_a?(Path)
           pattern = pattern.to_posix.to_s
         end
-        sequences = compile(pattern)
+        sequences = compile(pattern, options)
 
         sequences.each do |sequence|
           if sequence.count(&.is_a?(RecursiveDirectories)) > 1
-            run_tracking(sequence, match: match, follow_symlinks: follow_symlinks) do |match|
+            run_tracking(sequence, options: options, follow_symlinks: follow_symlinks) do |match|
               yield match
             end
           else
-            run(sequence, match: match, follow_symlinks: follow_symlinks) do |match|
+            run(sequence, options: options, follow_symlinks: follow_symlinks) do |match|
               yield match
             end
           end
@@ -169,16 +177,16 @@ class Dir
       end
     end
 
-    private def self.compile(pattern)
+    private def self.compile(pattern, options)
       expanded_patterns = [] of String
       File.expand_brace_pattern(pattern, expanded_patterns)
 
       expanded_patterns.map do |expanded_pattern|
-        single_compile expanded_pattern
+        single_compile expanded_pattern, options
       end
     end
 
-    private def self.single_compile(glob)
+    private def self.single_compile(glob, options)
       list = [] of PatternType
       return list if glob.empty?
 
@@ -188,7 +196,7 @@ class Dir
         list << DirectoriesOnly.new
       else
         file = parts.pop
-        if constant_entry?(file)
+        if constant_entry?(file, options)
           list << ConstantEntry.new file, false
         elsif !file.empty?
           list << EntryMatch.new file
@@ -200,7 +208,7 @@ class Dir
         when dir == "**"
           list << RecursiveDirectories.new
         when dir.empty?
-        when constant_entry?(dir)
+        when constant_entry?(dir, options)
           case last = list[-1]
           when ConstantDirectory
             list[-1] = ConstantDirectory.new File.join(dir, last.path)
@@ -214,6 +222,14 @@ class Dir
         end
       end
 
+      # FIXME: if `options.case_insensitive?` is true, then there will be
+      # neither `ConstantDirectory` nor `ConstantEntry` subpatterns, so Windows
+      # absolute paths will start with a `DirectoryMatch` for the anchor, which
+      # is then treated like a relative path; this is wrong, so anchors should
+      # be recognized here and `RootDirectory` should support them
+      #
+      # but then what if we really want `./C:` on filesystems that support that
+      # name?
       if glob.starts_with?('/')
         list << RootDirectory.new
       end
@@ -221,7 +237,9 @@ class Dir
       list
     end
 
-    private def self.constant_entry?(file)
+    private def self.constant_entry?(file, options)
+      return false if options.case_insensitive?
+
       file.each_char do |char|
         return false if char.in?('*', '?')
       end
@@ -229,17 +247,17 @@ class Dir
       true
     end
 
-    private def self.run_tracking(sequence, match, follow_symlinks, &block : String -> _)
+    private def self.run_tracking(sequence, options, follow_symlinks, &block : String -> _)
       result_tracker = Set(String).new
 
-      run(sequence, match, follow_symlinks) do |result|
+      run(sequence, options, follow_symlinks) do |result|
         if result_tracker.add?(result)
           yield result
         end
       end
     end
 
-    private def self.run(sequence, match, follow_symlinks, &block : String -> _)
+    private def self.run(sequence, options, follow_symlinks, &block : String -> _)
       return if sequence.empty?
 
       path_stack = [] of Tuple(Int32, String?, Crystal::System::Dir::Entry?)
@@ -271,14 +289,14 @@ class Dir
         in EntryMatch
           next if sequence[pos + 1]?.is_a?(RecursiveDirectories)
           each_child(path) do |entry|
-            next unless matches_file?(entry, match)
-            yield join(path, entry.name) if cmd.matches?(entry.name)
+            next unless matches_file?(entry, options)
+            yield join(path, entry.name) if cmd.matches?(entry.name, options)
           end
         in DirectoryMatch
           next_cmd = sequence[next_pos]?
 
           each_child(path) do |entry|
-            if cmd.matches?(entry.name)
+            if cmd.matches?(entry.name, options)
               is_dir = entry.dir?
               fullpath = join(path, entry.name)
               if is_dir.nil?
@@ -331,7 +349,7 @@ class Dir
 
             if entry = read_entry(dir)
               next if entry.name.in?(".", "..")
-              next unless matches_file?(entry, match)
+              next unless matches_file?(entry, options)
 
               if dir_path.bytesize == 0
                 fullpath = entry.name
@@ -345,7 +363,7 @@ class Dir
                   yield fullpath if next_cmd.path == entry.name
                 end
               when EntryMatch
-                yield fullpath if next_cmd.matches?(entry.name)
+                yield fullpath if next_cmd.matches?(entry.name, options)
               end
 
               is_dir = entry.dir?

--- a/src/file.cr
+++ b/src/file.cr
@@ -85,7 +85,7 @@ class File < IO::FileDescriptor
            "/dev/null"
          {% end %}
 
-  # Options used to control the behavior of `Dir.glob`.
+  # Options used to control the behavior of `File.match?` and `Dir.glob`.
   @[Flags]
   enum MatchOptions
     # Includes files whose name begins with a period (`.`).
@@ -99,6 +99,8 @@ class File < IO::FileDescriptor
     # system attributes, `OSHidden` must also be used.
     #
     # On other systems, this has no effect.
+    #
+    # Cannot be used in `File.match?`.
     NativeHidden
 
     # Includes files which are considered hidden by operating system
@@ -111,13 +113,28 @@ class File < IO::FileDescriptor
     # `NativeHidden`.
     #
     # On other systems, this has no effect.
+    #
+    # Cannot be used in `File.match?`.
     OSHidden
+
+    # Includes files whose name differs from the match pattern in letter case
+    # only. The comparison is done using `Char#downcase`, not by the underlying
+    # filesystem's case mappings.
+    CaseInsensitive
+
+    # Returns a suitable platform-specific default set of options for
+    # `File.match?`.
+    #
+    # Currently this is `DotFiles` on all platforms.
+    def self.match_default : self
+      DotFiles
+    end
 
     # Returns a suitable platform-specific default set of options for
     # `Dir.glob` and `Dir.[]`.
     #
-    # Currently this is always `NativeHidden | OSHidden`.
-    def self.glob_default
+    # Currently this is `NativeHidden | OSHidden` on all platforms.
+    def self.glob_default : self
       NativeHidden | OSHidden
     end
   end
@@ -477,8 +494,22 @@ class File < IO::FileDescriptor
   # recognized, according to the path's kind. If *path* is a `String`, only `/`
   # is considered a directory separator.
   #
+  # The *options* argument controls the match behavior in the following ways:
+  #
+  # * Path segments beginning with a period (`.`) are matched if and only if
+  #   *options* includes `MatchOptions::DotFiles`.
+  # * If `MatchOptions::CaseInsensitive` is present, all characters are matched
+  #   in a case-insesnsitive manner, and character sets are disallowed.
+  # * Both `MatchOptions::NativeHidden` and `MatchOptions::OSHidden` raise
+  #   `ArgumentError`; this method never accesses the filesystem.
+  #
   # NOTE: Only `/` in *pattern* matches directory separators in *path*.
-  def self.match?(pattern : String, path : Path | String) : Bool
+  def self.match?(pattern : String, path : Path | String, options : MatchOptions = MatchOptions.match_default) : Bool
+    # TODO: support the absence of DotFiles
+    raise ArgumentError.new "Match flags must include DotFiles" unless options.dot_files?
+
+    raise ArgumentError.new "Invalid match flags: #{options}" if options.native_hidden? || options.os_hidden?
+
     expanded_patterns = [] of String
     File.expand_brace_pattern(pattern, expanded_patterns)
 
@@ -489,13 +520,12 @@ class File < IO::FileDescriptor
       separators = Path.separators(Path::Kind::POSIX)
     end
 
-    expanded_patterns.each do |expanded_pattern|
-      return true if match_single_pattern(expanded_pattern, path, separators)
+    expanded_patterns.any? do |expanded_pattern|
+      match_single_pattern(expanded_pattern, path, separators, options)
     end
-    false
   end
 
-  private def self.match_single_pattern(pattern : String, path : String, separators)
+  private def self.match_single_pattern(pattern : String, path : String, separators, options : MatchOptions)
     # linear-time algorithm adapted from https://research.swtch.com/glob
     preader = Char::Reader.new(pattern)
     sreader = Char::Reader.new(path)
@@ -541,6 +571,10 @@ class File < IO::FileDescriptor
         when {'[', false}
           pnext = preader.has_next?
 
+          if options.case_insensitive?
+            raise BadPatternError.new "Cannot use character sets in case-insensitive match"
+          end
+
           character_matched = false
           character_set_open = true
           escaped = false
@@ -577,7 +611,6 @@ class File < IO::FileDescriptor
                 when '\\'
                   range_end = preader.next_char
                 else
-                  # Nothing
                   # TODO: check if this branch is fine
                 end
                 range = (pchar..range_end)
@@ -587,7 +620,6 @@ class File < IO::FileDescriptor
               end
             end
             pnext = preader.has_next?
-            false
           end
           raise BadPatternError.new "Invalid character set: unterminated character set" if character_set_open
 
@@ -599,7 +631,12 @@ class File < IO::FileDescriptor
         else
           escaped = false
 
-          if snext && sreader.current_char == pchar
+          if options.case_insensitive?
+            pchar = pchar.downcase
+            char = char.downcase
+          end
+
+          if snext && char == pchar
             preader.next_char
             sreader.next_char
             next


### PR DESCRIPTION
Resolves #13510.

**`Dir.glob` does not currently work.** See `src/dir/glob.cr:225:7` for the problem.

As a first implementation, case-insensitive comparisons are done using the blockless `Char#downcase`, and no case options are accepted. (I had a different branch that wrapped `Char::Reader` behind a case-insensitive decorator, but it was more troubling than it was worth.)