### PR TITLE
Avoid `@[ThreadLocal]` on Android

### DIFF
--- a/src/crystal/system/unix/pthread.cr
+++ b/src/crystal/system/unix/pthread.cr
@@ -31,9 +31,12 @@ module Crystal::System::Thread
     raise RuntimeError.from_errno("sched_yield") unless ret == 0
   end
 
-  {% if flag?(:openbsd) %}
-    # no thread local storage (TLS) for OpenBSD,
-    # we use pthread's specific storage (TSS) instead:
+  # no thread local storage (TLS) for OpenBSD,
+  # we use pthread's specific storage (TSS) instead
+  #
+  # Android appears to support TLS to some degree, but executables fail with
+  # an underaligned TLS segment, see https://github.com/crystal-lang/crystal/issues/13951
+  {% if flag?(:openbsd) || flag?(:android) %}
     @@current_key : LibC::PthreadKeyT
 
     @@current_key = begin

--- a/src/lib_c/aarch64-android/c/pthread.cr
+++ b/src/lib_c/aarch64-android/c/pthread.cr
@@ -23,7 +23,9 @@ lib LibC
   fun pthread_detach(__pthread : PthreadT) : Int
   fun pthread_getattr_np(__pthread : PthreadT, __attr : PthreadAttrT*) : Int
   fun pthread_equal(__lhs : PthreadT, __rhs : PthreadT) : Int
+  fun pthread_getspecific(__key : PthreadKeyT) : Void*
   fun pthread_join(__pthread : PthreadT, __return_value_ptr : Void**) : Int
+  fun pthread_key_create(__key_ptr : PthreadKeyT*, __key_destructor : Void* ->) : Int
 
   fun pthread_mutexattr_destroy(__attr : PthreadMutexattrT*) : Int
   fun pthread_mutexattr_init(__attr : PthreadMutexattrT*) : Int
@@ -36,4 +38,6 @@ lib LibC
   fun pthread_mutex_unlock(__mutex : PthreadMutexT*) : Int
 
   fun pthread_self : PthreadT
+
+  fun pthread_setspecific(__key : PthreadKeyT, __value : Void*) : Int
 end

--- a/src/lib_c/aarch64-android/c/sys/types.cr
+++ b/src/lib_c/aarch64-android/c/sys/types.cr
@@ -30,6 +30,7 @@ lib LibC
   end
 
   alias PthreadCondattrT = Long
+  alias PthreadKeyT = Int
 
   struct PthreadMutexT
     __private : Int32[10]


### PR DESCRIPTION
Closes #13951.