### PR TITLE
Support `instance_sizeof(T)` in the interpreter

### DIFF
--- a/spec/compiler/interpreter/sizeof_spec.cr
+++ b/spec/compiler/interpreter/sizeof_spec.cr
@@ -7,4 +7,16 @@ describe Crystal::Repl::Interpreter do
       interpret("sizeof(typeof(1))").should eq(4)
     end
   end
+
+  context "instance_sizeof" do
+    it "interprets instance_sizeof typeof" do
+      interpret(<<-CRYSTAL).should eq(16)
+        class Foo
+          @x = 0_i64
+        end
+
+        instance_sizeof(typeof(Foo.new))
+        CRYSTAL
+    end
+  end
 end

--- a/src/compiler/crystal/interpreter/compiler.cr
+++ b/src/compiler/crystal/interpreter/compiler.cr
@@ -1422,6 +1422,14 @@ class Crystal::Repl::Compiler < Crystal::Visitor
     false
   end
 
+  def visit(node : InstanceSizeOf)
+    return false unless @wants_value
+
+    put_i32 inner_instance_sizeof_type(node.exp), node: node
+
+    false
+  end
+
   def visit(node : TypeNode)
     return false unless @wants_value
 
@@ -3361,25 +3369,8 @@ class Crystal::Repl::Compiler < Crystal::Visitor
     @instructions.instructions.size
   end
 
-  private def aligned_sizeof_type(node : ASTNode) : Int32
-    @context.aligned_sizeof_type(node)
-  end
-
-  private def aligned_sizeof_type(type : Type?) : Int32
-    @context.aligned_sizeof_type(type)
-  end
-
-  private def inner_sizeof_type(node : ASTNode) : Int32
-    @context.inner_sizeof_type(node)
-  end
-
-  private def inner_sizeof_type(type : Type?) : Int32
-    @context.inner_sizeof_type(type)
-  end
-
-  private def aligned_instance_sizeof_type(type : Type) : Int32
-    @context.aligned_instance_sizeof_type(type)
-  end
+  private delegate inner_sizeof_type, aligned_sizeof_type,
+    inner_instance_sizeof_type, aligned_instance_sizeof_type, to: @context
 
   private def ivar_offset(type : Type, name : String) : Int32
     if type.extern_union?

--- a/src/compiler/crystal/interpreter/context.cr
+++ b/src/compiler/crystal/interpreter/context.cr
@@ -316,7 +316,19 @@ class Crystal::Repl::Context
   end
 
   def aligned_instance_sizeof_type(type : Type) : Int32
-    align(@program.instance_size_of(type.sizeof_type).to_i32)
+    align(inner_instance_sizeof_type(type))
+  end
+
+  def inner_instance_sizeof_type(node : ASTNode) : Int32
+    inner_instance_sizeof_type(node.type?)
+  end
+
+  def inner_instance_sizeof_type(type : Type) : Int32
+    @program.instance_size_of(type.sizeof_type).to_i32
+  end
+
+  def inner_instance_sizeof_type(type : Nil) : Int32
+    0
   end
 
   def offset_of(type : Type, index : Int32) : Int32


### PR DESCRIPTION
That is, when the semantic phase cannot resolve such an expression to a compile-time constant.