### PR TITLE
Fix `ReadInstanceVar` on typedefs

### DIFF
--- a/spec/compiler/semantic/c_type_spec.cr
+++ b/spec/compiler/semantic/c_type_spec.cr
@@ -2,24 +2,50 @@ require "../../spec_helper"
 
 describe "Semantic: type" do
   it "can call methods of original type" do
-    assert_type("
+    assert_type(<<-CRYSTAL, inject_primitives: true) { uint64 }
       lib Lib
         type X = Void*
         fun foo : X
       end
 
       Lib.foo.address
-    ", inject_primitives: true) { uint64 }
+      CRYSTAL
   end
 
   it "can call methods of parent type" do
-    assert_error("
+    assert_error(<<-CRYSTAL, "undefined method 'baz'")
       lib Lib
         type X = Void*
         fun foo : X
       end
 
       Lib.foo.baz
-    ", "undefined method 'baz'")
+      CRYSTAL
+  end
+
+  it "can access instance variables of original type" do
+    assert_type(<<-CRYSTAL) { int32 }
+      lib Lib
+        struct X
+          x : Int32
+        end
+
+        type Y = X
+        fun foo : Y
+      end
+
+      Lib.foo.@x
+      CRYSTAL
+  end
+
+  it "errors if original type doesn't support instance variables" do
+    assert_error(<<-CRYSTAL, "can't use instance variables inside primitive types (at Int32)")
+      lib Lib
+        type X = Int32
+        fun foo : X
+      end
+
+      Lib.foo.@x
+      CRYSTAL
   end
 end

--- a/src/compiler/crystal/types.cr
+++ b/src/compiler/crystal/types.cr
@@ -2700,7 +2700,7 @@ module Crystal
     end
 
     delegate remove_typedef, pointer?, defs,
-      macros, reference_like?, parents, to: typedef
+      macros, reference_like?, parents, lookup_instance_var, to: typedef
 
     def remove_indirection
       self


### PR DESCRIPTION
Previously the `.@` syntax will always break with an internal `BUG: T is not an InstanceVarContainer`. This PR forwards the lookup to the original type to handle things like extern struct typedefs correctly.