### PR TITLE
Strip whitespace before determining summary line

### DIFF
--- a/spec/compiler/crystal/tools/doc/generator_spec.cr
+++ b/spec/compiler/crystal/tools/doc/generator_spec.cr
@@ -163,6 +163,17 @@ describe Doc::Generator do
       doc_method = Doc::Method.new generator, doc_type, a_def, false
       doc_method.formatted_summary.should eq %(<p>Some Method</p>)
     end
+
+    it "should exclude whitespace before the summary line" do
+      program = Program.new
+      generator = Doc::Generator.new program, ["."]
+      doc_type = Doc::Type.new generator, program
+
+      a_def = Def.new "foo"
+      a_def.doc = " \n\nSome Method\n\nMore Data"
+      doc_method = Doc::Method.new generator, doc_type, a_def, false
+      doc_method.formatted_summary.should eq %(<p>Some Method</p>)
+    end
   end
 
   describe "#formatted_doc" do

--- a/src/compiler/crystal/tools/doc/generator.cr
+++ b/src/compiler/crystal/tools/doc/generator.cr
@@ -290,7 +290,7 @@ class Crystal::Doc::Generator
   end
 
   def summary(context, string)
-    line = fetch_doc_lines(string).lines.first? || ""
+    line = fetch_doc_lines(string.strip).lines.first? || ""
 
     dot_index = line =~ /\.($|\s)/
     if dot_index


### PR DESCRIPTION
* Ensures empty `#` lines are skipped in favor of the actual content