### PR TITLE
Disable `mkfifo` spec for interpreter

### DIFF
--- a/spec/std/file_utils_spec.cr
+++ b/spec/std/file_utils_spec.cr
@@ -715,6 +715,7 @@ describe "FileUtils" do
       end
     end
 
+    # FIXME: `Process.run` and backtick don't work in the interpreter (#12241)
     {% if flag?(:unix) && !flag?(:interpreted) %}
       it "overwrites a destination named pipe" do
         with_tempfile("ln_sf_src", "ln_sf_dst_pipe_exists") do |path1, path2|


### PR DESCRIPTION
I am rather certain that our interpreter CI is stuck because this spec from #13896 calls `mkfifo` via a backtick, which is basically `Process.run` and doesn't work yet (#12241).