### PR TITLE
Fix typos in src

### DIFF
--- a/src/compiler/crystal/syntax/parser.cr
+++ b/src/compiler/crystal/syntax/parser.cr
@@ -4584,7 +4584,7 @@ module Crystal
       when Splat
         push_block_vars(node.exp)
       else
-        raise "BUG: unxpected block var: #{node} (#{node.class})"
+        raise "BUG: unexpected block var: #{node} (#{node.class})"
       end
     end
 

--- a/src/enum.cr
+++ b/src/enum.cr
@@ -167,11 +167,11 @@ struct Enum
 
   # Returns an unambiguous `String` representation of this enum member.
   # In the case of a single member value, this is the fully qualified name of
-  # the member (equvalent to `#to_s` with the enum name as prefix).
+  # the member (equivalent to `#to_s` with the enum name as prefix).
   # In the case of multiple members (for a flags enum), it's a call to `Enum.[]`
   # for recreating the same value.
   #
-  # If the value can't be represented fully by named members, the remainig value
+  # If the value can't be represented fully by named members, the remaining value
   # is appended.
   #
   # ```

--- a/src/file.cr
+++ b/src/file.cr
@@ -207,7 +207,7 @@ class File < IO::FileDescriptor
 
   # Returns whether the file given by *path* exists.
   #
-  # Symbolic links are dereferenced, posibly recursively. Returns `false` if a
+  # Symbolic links are dereferenced, possibly recursively. Returns `false` if a
   # symbolic link refers to a non-existent file.
   #
   # ```

--- a/src/html.cr
+++ b/src/html.cr
@@ -235,7 +235,7 @@ module HTML
     # The entity name cannot be longer than the longest name in the lookup tables.
     entity_name = Slice.new(start_ptr, Math.min(ptr - start_ptr, MAX_ENTITY_NAME_SIZE))
 
-    # If we cann't find an entity on the first try, we need to search each prefix
+    # If we can't find an entity on the first try, we need to search each prefix
     # of it, starting from the largest.
     while entity_name.size >= 2
       case

--- a/src/http/headers.cr
+++ b/src/http/headers.cr
@@ -315,7 +315,7 @@ struct HTTP::Headers
 
   # Serializes headers according to the HTTP protocol.
   #
-  # Prints a list of HTTP header fields in the format desribed in [RFC 7230 §3.2](https://www.rfc-editor.org/rfc/rfc7230#section-3.2),
+  # Prints a list of HTTP header fields in the format described in [RFC 7230 §3.2](https://www.rfc-editor.org/rfc/rfc7230#section-3.2),
   # with each field terminated by a CRLF sequence (`"\r\n"`).
   #
   # The serialization does *not* include a double CRLF sequence at the end.

--- a/src/io/delimited.cr
+++ b/src/io/delimited.cr
@@ -192,7 +192,7 @@ class IO::Delimited < IO
     slice.copy_from(peek[0, index])
     slice += index
 
-    # Copy the rest of the peek buffer into delimted buffer
+    # Copy the rest of the peek buffer into delimited buffer
     @delimiter_buffer.copy_from(rest)
     @active_delimiter_buffer = @delimiter_buffer[0, rest.size]
 


### PR DESCRIPTION
Hi crystal developers!
I found some typos in `src` dirctory using [typos-cli](https://github.com/crate-ci/typos).
Thank you as always.