### PR TITLE
Fix a typo in compiler source

### DIFF
--- a/src/compiler/crystal/codegen/codegen.cr
+++ b/src/compiler/crystal/codegen/codegen.cr
@@ -255,7 +255,7 @@ module Crystal
 
       # We need to define __crystal_malloc and __crystal_realloc as soon as possible,
       # to avoid some memory being allocated with plain malloc.
-      codgen_well_known_functions @node
+      codegen_well_known_functions @node
 
       initialize_predefined_constants
 
@@ -359,7 +359,7 @@ module Crystal
       end
     end
 
-    def codgen_well_known_functions(node)
+    def codegen_well_known_functions(node)
       visitor = CodegenWellKnownFunctions.new(self)
       node.accept visitor
     end


### PR DESCRIPTION
Hi there.

Here's another typo, but it's a method name, so I've made a new pull request. If the naming is intentional, please ignore it and close the request. 

Note that the expression `codgen` is used only in these two places in the source code.
The method `codgen_well_known_functions` was not used elsewhere.

`grep -r codgen`.

```
CHANGELOG.0.md:* Fixed wrong codgen for tuples/named tuples merge with pass-by-value types
src/compiler/crystal/codegen/codegen.cr:      codgen_well_known_functions @node
src/compiler/crystal/codegen/codegen.cr:    def codgen_well_known_functions(node)
```

So I don't think this change will affect the rest of the code.

Thank you.