### PR TITLE
Add macro methods for `Include` and `Extend`

### DIFF
--- a/spec/compiler/macro/macro_methods_spec.cr
+++ b/spec/compiler/macro/macro_methods_spec.cr
@@ -2562,6 +2562,26 @@ module Crystal
       end
     end
 
+    describe Include do
+      foo = Include.new("Foo".path)
+      bar = Include.new(Generic.new("Bar".path, ["Int32".path] of ASTNode))
+
+      it "executes name" do
+        assert_macro %({{x.name}}), "Foo", {x: foo}
+        assert_macro %({{x.name}}), "Bar(Int32)", {x: bar}
+      end
+    end
+
+    describe Extend do
+      foo = Extend.new("Foo".path)
+      bar = Extend.new(Generic.new("Bar".path, ["Int32".path] of ASTNode))
+
+      it "executes name" do
+        assert_macro %({{x.name}}), "Foo", {x: foo}
+        assert_macro %({{x.name}}), "Bar(Int32)", {x: bar}
+      end
+    end
+
     describe "visibility modifier methods" do
       node = VisibilityModifier.new(Visibility::Protected, Def.new("some_def"))
 

--- a/src/compiler/crystal/macros.cr
+++ b/src/compiler/crystal/macros.cr
@@ -1797,11 +1797,19 @@ module Crystal::Macros
     end
   end
 
-  # class Include < ASTNode
-  # end
+  # An `include` statement.
+  class Include < ASTNode
+    # Returns the name of the type being included.
+    def name : ASTNode
+    end
+  end
 
-  # class Extend < ASTNode
-  # end
+  # An `extend` statement.
+  class Extend < ASTNode
+    # Returns the name of the type being extended.
+    def name : ASTNode
+    end
+  end
 
   # class LibDef < ASTNode
   # end

--- a/src/compiler/crystal/macros.cr
+++ b/src/compiler/crystal/macros.cr
@@ -1798,6 +1798,12 @@ module Crystal::Macros
   end
 
   # An `include` statement.
+  #
+  # Every statement `node` is equivalent to:
+  #
+  # ```
+  # include {{ node.name }}
+  # ```
   class Include < ASTNode
     # Returns the name of the type being included.
     def name : ASTNode
@@ -1805,6 +1811,12 @@ module Crystal::Macros
   end
 
   # An `extend` statement.
+  #
+  # Every statement `node` is equivalent to:
+  #
+  # ```
+  # extend {{ node.name }}
+  # ```
   class Extend < ASTNode
     # Returns the name of the type being extended.
     def name : ASTNode

--- a/src/compiler/crystal/macros/methods.cr
+++ b/src/compiler/crystal/macros/methods.cr
@@ -1519,6 +1519,28 @@ module Crystal
     end
   end
 
+  class Include
+    def interpret(method : String, args : Array(ASTNode), named_args : Hash(String, ASTNode)?, block : Crystal::Block?, interpreter : Crystal::MacroInterpreter, name_loc : Location?)
+      case method
+      when "name"
+        interpret_check_args { @name }
+      else
+        super
+      end
+    end
+  end
+
+  class Extend
+    def interpret(method : String, args : Array(ASTNode), named_args : Hash(String, ASTNode)?, block : Crystal::Block?, interpreter : Crystal::MacroInterpreter, name_loc : Location?)
+      case method
+      when "name"
+        interpret_check_args { @name }
+      else
+        super
+      end
+    end
+  end
+
   class OffsetOf
     def interpret(method : String, args : Array(ASTNode), named_args : Hash(String, ASTNode)?, block : Crystal::Block?, interpreter : Crystal::MacroInterpreter, name_loc : Location?)
       case method


### PR DESCRIPTION
Resolves part of #3274.

Note that #14063 is not required for these nodes to be accessible in the macro language, because grammatically `include` and `extend` can be directly passed to macros:

```crystal
module Foo
  macro foo(x)
    {% p! x, x.name, x.class_name %} # okay
  end

  foo include Foo
  foo extend Foo
end
```