### PR TITLE
Change short_reference for top-level methods to `::foo`

### DIFF
--- a/spec/compiler/semantic/def_spec.cr
+++ b/spec/compiler/semantic/def_spec.cr
@@ -284,7 +284,7 @@ describe "Semantic: def" do
 
       foo
       ),
-      "method top-level foo must return Int32 but it is returning Char"
+      "method ::foo must return Int32 but it is returning Char"
   end
 
   it "errors if return type doesn't match on instance method" do

--- a/spec/compiler/semantic/warnings_spec.cr
+++ b/spec/compiler/semantic/warnings_spec.cr
@@ -40,7 +40,7 @@ describe "Semantic: warnings" do
 
         foo
         CRYSTAL
-        "warning in line 5\nWarning: Deprecated top-level foo. Do not use me"
+        "warning in line 5\nWarning: Deprecated ::foo. Do not use me"
     end
 
     it "deprecation reason is optional" do
@@ -51,7 +51,7 @@ describe "Semantic: warnings" do
 
         foo
         CRYSTAL
-        "warning in line 5\nWarning: Deprecated top-level foo."
+        "warning in line 5\nWarning: Deprecated ::foo."
     end
 
     it "detects deprecated instance methods" do
@@ -127,7 +127,7 @@ describe "Semantic: warnings" do
 
         foo(a: 2)
         CRYSTAL
-        "warning in line 5\nWarning: Deprecated top-level foo:a."
+        "warning in line 5\nWarning: Deprecated ::foo:a."
     end
 
     it "detects deprecated initialize" do
@@ -277,7 +277,7 @@ describe "Semantic: warnings" do
 
         foo
         CRYSTAL
-        "warning in line 7\nWarning: Deprecated top-level foo."
+        "warning in line 7\nWarning: Deprecated ::foo."
     end
 
     it "errors if invalid argument type" do
@@ -316,7 +316,7 @@ describe "Semantic: warnings" do
         end
 
         foo
-      ), "warning in line 6\nWarning: Deprecated top-level foo. Do not use me"
+      ), "warning in line 6\nWarning: Deprecated ::foo. Do not use me"
     end
 
     it "deprecation reason is optional" do
@@ -326,7 +326,7 @@ describe "Semantic: warnings" do
         end
 
         foo
-      ), "warning in line 6\nWarning: Deprecated top-level foo."
+      ), "warning in line 6\nWarning: Deprecated ::foo."
     end
 
     it "detects deprecated class macros" do
@@ -372,7 +372,7 @@ describe "Semantic: warnings" do
         end
 
         foo(a: 2)
-      ), "warning in line 6\nWarning: Deprecated top-level foo."
+      ), "warning in line 6\nWarning: Deprecated ::foo."
     end
 
     it "informs warnings once per call site location (a)" do

--- a/src/compiler/crystal/semantic/warnings.cr
+++ b/src/compiler/crystal/semantic/warnings.cr
@@ -76,7 +76,7 @@ module Crystal
     def short_reference
       case owner
       when Program
-        "top-level #{name}"
+        "::#{name}"
       when MetaclassType
         "#{owner.instance_type.to_s(generic_args: false)}.#{name}"
       else
@@ -122,7 +122,7 @@ module Crystal
     def short_reference
       case owner
       when Program
-        "top-level #{name}"
+        "::#{name}"
       when .metaclass?
         "#{owner.instance_type}.#{name}"
       else


### PR DESCRIPTION
Closes part of: #13957 