### PR TITLE
Fix global `Path` lookup inside macro when def has free variables

### DIFF
--- a/spec/compiler/semantic/macro_spec.cr
+++ b/spec/compiler/semantic/macro_spec.cr
@@ -1109,13 +1109,11 @@ describe "Semantic: macro" do
       module T
       end
 
-      module Foo
-        def self.foo(foo : T) forall T
-          {{ ::T.module? ? 1 : 'a' }}
-        end
+      def foo(x : T) forall T
+        {{ ::T.module? ? 1 : 'a' }}
       end
 
-      Foo.foo("")
+      foo("")
       CRYSTAL
   end
 

--- a/spec/compiler/semantic/macro_spec.cr
+++ b/spec/compiler/semantic/macro_spec.cr
@@ -1104,6 +1104,21 @@ describe "Semantic: macro" do
       CRYSTAL
   end
 
+  it "finds type for global path shared with free var" do
+    assert_type(<<-CRYSTAL) { int32 }
+      module T
+      end
+
+      module Foo
+        def self.foo(foo : T) forall T
+          {{ ::T.module? ? 1 : 'a' }}
+        end
+      end
+
+      Foo.foo("")
+      CRYSTAL
+  end
+
   it "gets named arguments in double splat" do
     assert_type(<<-CRYSTAL) { named_tuple_of({"x": string, "y": bool}) }
       macro foo(**options)

--- a/src/compiler/crystal/macros/interpreter.cr
+++ b/src/compiler/crystal/macros/interpreter.cr
@@ -418,7 +418,7 @@ module Crystal
     end
 
     def resolve?(node : Path)
-      if node.names.size == 1 && (match = @free_vars.try &.[node.names.first]?)
+      if (single_name = node.single_name?) && (match = @free_vars.try &.[single_name]?)
         matched_type = match
       else
         matched_type = @path_lookup.lookup_path(node)

--- a/src/compiler/crystal/macros/types.cr
+++ b/src/compiler/crystal/macros/types.cr
@@ -129,6 +129,8 @@ module Crystal
 
     # Returns the macro type named by a given AST node in the macro language.
     def lookup_macro_type(name : Path)
+      # NOTE: `name.global?` doesn't matter since there are no namespaces for
+      # the AST node types
       if name.names.size == 1
         macro_type = @macro_types[name.names.first]?
       end


### PR DESCRIPTION
The `::` inside `foo` is ignored in the following snippet:

```crystal
module T
end

def foo(x : T) forall T
  {{ ::T.name.stringify }}
end

foo(1)  # => "Int32"
foo("") # => "String"
```

This PR fixes it so that `foo` returns `"T"` regardless of the argument's type. If `module T` isn't defined, then `foo` will always produce a compilation error instead. Note that a simple interpolation like `{{ ::T }}` will produce just `T`, which will still be shadowed by the free variable in the normal language.