### PR TITLE
Do not remove trailing comma from multi-line macro/def parameters

### DIFF
--- a/spec/compiler/formatter/formatter_spec.cr
+++ b/spec/compiler/formatter/formatter_spec.cr
@@ -929,6 +929,14 @@ describe Crystal::Formatter do
       end
       CRYSTAL
 
+    assert_format <<-CRYSTAL, flags: %w[def_trailing_comma]
+      fun foo(
+        a : Int32,
+        ...
+      )
+      end
+      CRYSTAL
+
     assert_format <<-CRYSTAL, <<-CRYSTAL, flags: %w[def_trailing_comma]
       def foo(
         a,

--- a/spec/compiler/formatter/formatter_spec.cr
+++ b/spec/compiler/formatter/formatter_spec.cr
@@ -32,7 +32,7 @@ private def assert_format(input, output = input, strict = false, flags = nil, fi
     end
 
     # Check idempotency
-    result2 = Crystal.format(result)
+    result2 = Crystal.format(result, flags: flags)
     unless result == result2
       fail "Idempotency failed:\nBefore: #{result.inspect}\nAfter:  #{result2.inspect}", file: file, line: line
     end
@@ -882,6 +882,163 @@ describe Crystal::Formatter do
     assert_format <<-CRYSTAL
       def foo(a, **b)
         yield
+      end
+      CRYSTAL
+  end
+
+  context "adds trailing comma to def multi-line normal, splat, and double splat parameters" do
+    assert_format <<-CRYSTAL, <<-CRYSTAL, flags: %w[def_trailing_comma]
+      macro foo(
+        a,
+        b
+      )
+      end
+      CRYSTAL
+      macro foo(
+        a,
+        b,
+      )
+      end
+      CRYSTAL
+
+    assert_format <<-CRYSTAL, <<-CRYSTAL, flags: %w[def_trailing_comma]
+      macro foo(
+        a,
+        *b
+      )
+      end
+      CRYSTAL
+      macro foo(
+        a,
+        *b,
+      )
+      end
+      CRYSTAL
+
+    assert_format <<-CRYSTAL, <<-CRYSTAL, flags: %w[def_trailing_comma]
+      def foo(
+        a,
+        b
+      )
+      end
+      CRYSTAL
+      def foo(
+        a,
+        b,
+      )
+      end
+      CRYSTAL
+
+    assert_format <<-CRYSTAL, <<-CRYSTAL, flags: %w[def_trailing_comma]
+      def foo(
+        a,
+        @[Ann] b
+      )
+      end
+      CRYSTAL
+      def foo(
+        a,
+        @[Ann] b,
+      )
+      end
+      CRYSTAL
+
+    assert_format <<-CRYSTAL, <<-CRYSTAL, flags: %w[def_trailing_comma]
+      def foo(
+        a,
+        @[Ann]
+        b
+      )
+      end
+      CRYSTAL
+      def foo(
+        a,
+        @[Ann]
+        b,
+      )
+      end
+      CRYSTAL
+
+    assert_format <<-CRYSTAL, <<-CRYSTAL, flags: %w[def_trailing_comma]
+      def foo(
+        a, b
+      )
+      end
+      CRYSTAL
+      def foo(
+        a, b,
+      )
+      end
+      CRYSTAL
+
+    assert_format <<-CRYSTAL, <<-CRYSTAL, flags: %w[def_trailing_comma]
+      def foo(
+        a, b,
+        c, d
+      )
+      end
+      CRYSTAL
+      def foo(
+        a, b,
+        c, d,
+      )
+      end
+      CRYSTAL
+
+    assert_format <<-CRYSTAL, <<-CRYSTAL, flags: %w[def_trailing_comma]
+      def foo(
+        a, # Foo
+        b # Bar
+      )
+      end
+      CRYSTAL
+      def foo(
+        a, # Foo
+        b, # Bar
+      )
+      end
+      CRYSTAL
+
+    assert_format <<-CRYSTAL, <<-CRYSTAL, flags: %w[def_trailing_comma]
+      def foo(
+        a,
+        *b
+      )
+      end
+      CRYSTAL
+      def foo(
+        a,
+        *b,
+      )
+      end
+      CRYSTAL
+
+    assert_format <<-CRYSTAL, <<-CRYSTAL, flags: %w[def_trailing_comma]
+      def foo(
+        a,
+        **b
+      )
+      end
+      CRYSTAL
+      def foo(
+        a,
+        **b,
+      )
+      end
+      CRYSTAL
+
+    assert_format <<-CRYSTAL, flags: %w[def_trailing_comma]
+      def foo(
+        a,
+        &block
+      )
+      end
+      CRYSTAL
+
+    assert_format <<-CRYSTAL, flags: %w[def_trailing_comma]
+      def foo(
+        a,
+      )
       end
       CRYSTAL
   end

--- a/spec/compiler/formatter/formatter_spec.cr
+++ b/spec/compiler/formatter/formatter_spec.cr
@@ -916,6 +916,20 @@ describe Crystal::Formatter do
       CRYSTAL
 
     assert_format <<-CRYSTAL, <<-CRYSTAL, flags: %w[def_trailing_comma]
+      fun foo(
+        a : Int32,
+        b : Int32
+      )
+      end
+      CRYSTAL
+      fun foo(
+        a : Int32,
+        b : Int32,
+      )
+      end
+      CRYSTAL
+
+    assert_format <<-CRYSTAL, <<-CRYSTAL, flags: %w[def_trailing_comma]
       def foo(
         a,
         b
@@ -925,6 +939,48 @@ describe Crystal::Formatter do
       def foo(
         a,
         b,
+      )
+      end
+      CRYSTAL
+
+    assert_format <<-CRYSTAL, <<-CRYSTAL, flags: %w[def_trailing_comma]
+      def foo(
+        a : Int32,
+        b : Int32
+      )
+      end
+      CRYSTAL
+      def foo(
+        a : Int32,
+        b : Int32,
+      )
+      end
+      CRYSTAL
+
+    assert_format <<-CRYSTAL, <<-CRYSTAL, flags: %w[def_trailing_comma]
+      def foo(
+        a : Int32,
+        b : Int32 = 1
+      )
+      end
+      CRYSTAL
+      def foo(
+        a : Int32,
+        b : Int32 = 1,
+      )
+      end
+      CRYSTAL
+
+    assert_format <<-CRYSTAL, <<-CRYSTAL, flags: %w[def_trailing_comma]
+      def foo(
+        a,
+        b c
+      )
+      end
+      CRYSTAL
+      def foo(
+        a,
+        b c,
       )
       end
       CRYSTAL

--- a/src/compiler/crystal/tools/formatter.cr
+++ b/src/compiler/crystal/tools/formatter.cr
@@ -1562,7 +1562,7 @@ module Crystal
 
       args.each_with_index do |arg, i|
         has_more = !last?(i, args) || double_splat || block_arg || yields || variadic
-        wrote_newline = format_def_arg(wrote_newline, has_more) do
+        wrote_newline = format_def_arg(wrote_newline, has_more, true) do
           if i == splat_index
             write_token :OP_STAR
             skip_space_or_newline
@@ -1577,7 +1577,7 @@ module Crystal
       end
 
       if double_splat
-        wrote_newline = format_def_arg(wrote_newline, block_arg || yields) do
+        wrote_newline = format_def_arg(wrote_newline, block_arg || yields, true) do
           write_token :OP_STAR_STAR
           skip_space_or_newline
 
@@ -1645,13 +1645,13 @@ module Crystal
       end
     end
 
-    def format_def_arg(wrote_newline, has_more, &)
+    def format_def_arg(wrote_newline, has_more, write_trailing_comma = false, &)
       write_indent if wrote_newline
 
       yield
 
       # Write "," before skipping spaces to prevent inserting comment between argument and comma.
-      write "," if has_more
+      write "," if has_more || (write_trailing_comma && flag?("def_trailing_comma"))
 
       just_wrote_newline = skip_space
       if @token.type.newline?


### PR DESCRIPTION
This behavior is behind the `def_trailing_comma` flag as per #13002. Once we go to remove the flag, will need to go and update all the existing formatter specs that it's not currently enabled for. At that point can probably just remove the specs I added as pretty sure they're handled via other assertions.

Fixes #13169