### PR TITLE
Support `LLVMSetTargetMachineGlobalISel` from LLVM 18

### DIFF
--- a/src/llvm/ext/llvm_ext.cc
+++ b/src/llvm/ext/llvm_ext.cc
@@ -59,7 +59,7 @@ static TargetMachine *unwrap(LLVMTargetMachineRef P) {
   return reinterpret_cast<TargetMachine *>(P);
 }
 
-void LLVMExtTargetMachineEnableGlobalIsel(LLVMTargetMachineRef T, LLVMBool Enable) {
+void LLVMExtSetTargetMachineGlobalISel(LLVMTargetMachineRef T, LLVMBool Enable) {
   unwrap(T)->setGlobalISel(Enable);
 }
 

--- a/src/llvm/ext/llvm_ext.cc
+++ b/src/llvm/ext/llvm_ext.cc
@@ -55,6 +55,7 @@ LLVMValueRef LLVMExtBuildInvoke2(
                                       Bundles, Name));
 }
 
+#if !LLVM_VERSION_GE(18, 0)
 static TargetMachine *unwrap(LLVMTargetMachineRef P) {
   return reinterpret_cast<TargetMachine *>(P);
 }
@@ -62,5 +63,6 @@ static TargetMachine *unwrap(LLVMTargetMachineRef P) {
 void LLVMExtSetTargetMachineGlobalISel(LLVMTargetMachineRef T, LLVMBool Enable) {
   unwrap(T)->setGlobalISel(Enable);
 }
+#endif
 
 } // extern "C"

--- a/src/llvm/jit_compiler.cr
+++ b/src/llvm/jit_compiler.cr
@@ -15,7 +15,11 @@ class LLVM::JITCompiler
     # See https://github.com/crystal-lang/crystal/issues/9297#issuecomment-636512270
     # for background info
     target_machine = LibLLVM.get_execution_engine_target_machine(@unwrap)
-    LibLLVMExt.target_machine_enable_global_isel(target_machine, false)
+    {% if LibLLVM::IS_LT_180 %}
+      LibLLVMExt.target_machine_enable_global_isel(target_machine, false)
+    {% else %}
+      LibLLVM.set_target_machine_global_isel(target_machine, 0)
+    {% end %}
 
     @finalized = false
   end

--- a/src/llvm/jit_compiler.cr
+++ b/src/llvm/jit_compiler.cr
@@ -15,11 +15,7 @@ class LLVM::JITCompiler
     # See https://github.com/crystal-lang/crystal/issues/9297#issuecomment-636512270
     # for background info
     target_machine = LibLLVM.get_execution_engine_target_machine(@unwrap)
-    {% if LibLLVM::IS_LT_180 %}
-      LibLLVMExt.target_machine_enable_global_isel(target_machine, false)
-    {% else %}
-      LibLLVM.set_target_machine_global_isel(target_machine, 0)
-    {% end %}
+    {{ LibLLVM::IS_LT_180 ? LibLLVMExt : LibLLVM }}.set_target_machine_global_isel(target_machine, 0)
 
     @finalized = false
   end

--- a/src/llvm/lib_llvm.cr
+++ b/src/llvm/lib_llvm.cr
@@ -19,6 +19,7 @@ end
 
 {% begin %}
   lib LibLLVM
+    IS_180 = {{LibLLVM::VERSION.starts_with?("18.0")}}
     IS_170 = {{LibLLVM::VERSION.starts_with?("17.0")}}
     IS_160 = {{LibLLVM::VERSION.starts_with?("16.0")}}
     IS_150 = {{LibLLVM::VERSION.starts_with?("15.0")}}
@@ -40,6 +41,7 @@ end
     IS_LT_150 = {{compare_versions(LibLLVM::VERSION, "15.0.0") < 0}}
     IS_LT_160 = {{compare_versions(LibLLVM::VERSION, "16.0.0") < 0}}
     IS_LT_170 = {{compare_versions(LibLLVM::VERSION, "17.0.0") < 0}}
+    IS_LT_180 = {{compare_versions(LibLLVM::VERSION, "18.0.0") < 0}}
   end
 {% end %}
 

--- a/src/llvm/lib_llvm/target_machine.cr
+++ b/src/llvm/lib_llvm/target_machine.cr
@@ -16,6 +16,9 @@ lib LibLLVM
   fun get_target_machine_target = LLVMGetTargetMachineTarget(t : TargetMachineRef) : TargetRef
   fun get_target_machine_triple = LLVMGetTargetMachineTriple(t : TargetMachineRef) : Char*
   fun create_target_data_layout = LLVMCreateTargetDataLayout(t : TargetMachineRef) : TargetDataRef
+  {% unless LibLLVM::IS_LT_180 %}
+    fun set_target_machine_global_isel = LLVMSetTargetMachineGlobalISel(t : TargetMachineRef, enable : Bool)
+  {% end %}
   fun target_machine_emit_to_file = LLVMTargetMachineEmitToFile(t : TargetMachineRef, m : ModuleRef, filename : Char*, codegen : LLVM::CodeGenFileType, error_message : Char**) : Bool
 
   fun get_default_target_triple = LLVMGetDefaultTargetTriple : Char*

--- a/src/llvm/lib_llvm_ext.cr
+++ b/src/llvm/lib_llvm_ext.cr
@@ -31,5 +31,5 @@ lib LibLLVMExt
                                           bundle : LibLLVMExt::OperandBundleDefRef,
                                           name : LibC::Char*) : LibLLVM::ValueRef
 
-  fun target_machine_enable_global_isel = LLVMExtTargetMachineEnableGlobalIsel(machine : LibLLVM::TargetMachineRef, enable : Bool)
+  fun set_target_machine_global_isel = LLVMExtSetTargetMachineGlobalISel(t : LibLLVM::TargetMachineRef, enable : LibLLVM::Bool)
 end

--- a/src/llvm/target_machine.cr
+++ b/src/llvm/target_machine.cr
@@ -28,7 +28,11 @@ class LLVM::TargetMachine
   end
 
   def enable_global_isel=(enable : Bool)
-    LibLLVMExt.target_machine_enable_global_isel(self, enable)
+    {% if LibLLVM::IS_LT_180 %}
+      LibLLVMExt.target_machine_enable_global_isel(self, enable)
+    {% else %}
+      LibLLVM.set_target_machine_global_isel(self, enable ? 1 : 0)
+    {% end %}
   end
 
   private def emit_to_file(llvm_mod, filename, type)

--- a/src/llvm/target_machine.cr
+++ b/src/llvm/target_machine.cr
@@ -28,11 +28,8 @@ class LLVM::TargetMachine
   end
 
   def enable_global_isel=(enable : Bool)
-    {% if LibLLVM::IS_LT_180 %}
-      LibLLVMExt.target_machine_enable_global_isel(self, enable)
-    {% else %}
-      LibLLVM.set_target_machine_global_isel(self, enable ? 1 : 0)
-    {% end %}
+    {{ LibLLVM::IS_LT_180 ? LibLLVMExt : LibLLVM }}.set_target_machine_global_isel(self, enable ? 1 : 0)
+    enable
   end
 
   private def emit_to_file(llvm_mod, filename, type)


### PR DESCRIPTION
Resolves part of #13946.