### PR TITLE
MT: few fixes and improvements

### DIFF
--- a/spec/std/http/server/server_spec.cr
+++ b/spec/std/http/server/server_spec.cr
@@ -45,12 +45,9 @@ describe HTTP::Server do
     server = HTTP::Server.new { }
     server.bind_unused_port
 
-    spawn do
+    run_server(server) do
       server.close
-      sleep 0.001
     end
-
-    server.listen
   end
 
   it "closes the server" do

--- a/spec/std/http/spec_helper.cr
+++ b/spec/std/http/spec_helper.cr
@@ -46,6 +46,11 @@ def run_server(server, &)
     wait_for { server.listening? }
     wait_until_blocked f
 
+    {% if flag?(:preview_mt) %}
+      # avoids fiber synchronization issues in specs, like closing the server
+      # before we properly listen, ...
+      sleep 0.001
+    {% end %}
     yield server_done
   ensure
     server.close unless server.closed?

--- a/src/concurrent.cr
+++ b/src/concurrent.cr
@@ -59,10 +59,8 @@ end
 # ```
 def spawn(*, name : String? = nil, same_thread = false, &block)
   fiber = Fiber.new(name, &block)
-  if same_thread
-    fiber.@current_thread.set(Thread.current)
-  end
-  Crystal::Scheduler.enqueue fiber
+  {% if flag?(:preview_mt) %} fiber.set_current_thread if same_thread {% end %}
+  fiber.enqueue
   fiber
 end
 

--- a/src/crystal/scheduler.cr
+++ b/src/crystal/scheduler.cr
@@ -59,7 +59,10 @@ class Crystal::Scheduler
   end
 
   def self.yield : Nil
-    Thread.current.scheduler.yield
+    # TODO: Fiber switching and libevent for wasm32
+    {% unless flag?(:wasm32) %}
+      Thread.current.scheduler.sleep(0.seconds)
+    {% end %}
   end
 
   def self.yield(fiber : Fiber) : Nil
@@ -172,13 +175,6 @@ class Crystal::Scheduler
   protected def sleep(time : Time::Span) : Nil
     @current.resume_event.add(time)
     reschedule
-  end
-
-  protected def yield : Nil
-    # TODO: Fiber switching and libevent for wasm32
-    {% unless flag?(:wasm32) %}
-      sleep(0.seconds)
-    {% end %}
   end
 
   protected def yield(fiber : Fiber) : Nil

--- a/src/crystal/scheduler.cr
+++ b/src/crystal/scheduler.cr
@@ -78,7 +78,7 @@ class Crystal::Scheduler
     Thread.current.scheduler.yield(fiber)
   end
 
-  private def validate_running_thread(fiber : Fiber) : Nil
+  private def self.validate_running_thread(fiber : Fiber) : Nil
     {% if flag?(:preview_mt) %}
       if th = fiber.get_current_thread
         unless th == Thread.current

--- a/src/crystal/scheduler.cr
+++ b/src/crystal/scheduler.cr
@@ -158,9 +158,7 @@ class Crystal::Scheduler
   protected def reschedule : Nil
     loop do
       if runnable = @lock.sync { @runnables.shift? }
-        unless runnable == @current
-          runnable.resume
-        end
+        resume(runnable) unless runnable == @current
         break
       else
         @event_loop.run_once
@@ -198,10 +196,11 @@ class Crystal::Scheduler
       fiber_channel = self.fiber_channel
       loop do
         @lock.lock
+
         if runnable = @runnables.shift?
           @runnables << Fiber.current
           @lock.unlock
-          runnable.resume
+          resume(runnable)
         else
           @sleeping = true
           @lock.unlock
@@ -211,7 +210,7 @@ class Crystal::Scheduler
           @sleeping = false
           @runnables << Fiber.current
           @lock.unlock
-          fiber.resume
+          resume(fiber)
         end
       end
     end

--- a/src/crystal/scheduler.cr
+++ b/src/crystal/scheduler.cr
@@ -191,7 +191,7 @@ class Crystal::Scheduler
 
     protected def find_target_thread
       if workers = @@workers
-        @rr_target += 1
+        @rr_target &+= 1
         workers[@rr_target % workers.size]
       else
         Thread.current

--- a/src/crystal/system/thread.cr
+++ b/src/crystal/system/thread.cr
@@ -105,7 +105,7 @@ class Thread
   end
 
   # :nodoc:
-  getter scheduler : Crystal::Scheduler { Crystal::Scheduler.new(main_fiber) }
+  getter scheduler : Crystal::Scheduler { Crystal::Scheduler.new(self) }
 
   protected def start
     Thread.threads.push(self)

--- a/src/fiber.cr
+++ b/src/fiber.cr
@@ -62,7 +62,7 @@ class Fiber
   property name : String?
 
   @alive = true
-  @current_thread = Atomic(Thread?).new(nil)
+  {% if flag?(:preview_mt) %} @current_thread = Atomic(Thread?).new(nil) {% end %}
 
   # :nodoc:
   property next : Fiber?
@@ -136,7 +136,7 @@ class Fiber
       {% end %}
     thread.gc_thread_handler, @stack_bottom = GC.current_thread_stack_bottom
     @name = "main"
-    @current_thread.set(thread)
+    {% if flag?(:preview_mt) %} @current_thread.set(thread) {% end %}
     Fiber.fibers.push(self)
   end
 
@@ -305,4 +305,16 @@ class Fiber
     # Push the used section of the stack
     GC.push_stack @context.stack_top, @stack_bottom
   end
+
+  {% if flag?(:preview_mt) %}
+    # :nodoc:
+    def set_current_thread(thread = Thread.current) : Thread
+      @current_thread.set(thread)
+    end
+
+    # :nodoc:
+    def get_current_thread : Thread?
+      @current_thread.lazy_get
+    end
+  {% end %}
 end

--- a/src/fiber/stack_pool.cr
+++ b/src/fiber/stack_pool.cr
@@ -7,14 +7,13 @@ class Fiber
 
     def initialize
       @deque = Deque(Void*).new
-      @mutex = Thread::Mutex.new
     end
 
     # Removes and frees at most *count* stacks from the top of the pool,
     # returning memory to the operating system.
     def collect(count = lazy_size // 2) : Nil
       count.times do
-        if stack = @mutex.synchronize { @deque.shift? }
+        if stack = @deque.shift?
           Crystal::System::Fiber.free_stack(stack, STACK_SIZE)
         else
           return
@@ -22,21 +21,28 @@ class Fiber
       end
     end
 
+    def collect_loop(every = 5.seconds) : Nil
+      loop do
+        sleep every
+        collect
+      end
+    end
+
     # Removes a stack from the bottom of the pool, or allocates a new one.
     def checkout : {Void*, Void*}
-      stack = @mutex.synchronize { @deque.pop? } || Crystal::System::Fiber.allocate_stack(STACK_SIZE)
+      stack = @deque.pop? || Crystal::System::Fiber.allocate_stack(STACK_SIZE)
       {stack, stack + STACK_SIZE}
     end
 
     # Appends a stack to the bottom of the pool.
     def release(stack) : Nil
-      @mutex.synchronize { @deque.push(stack) }
+      @deque.push(stack)
     end
 
     # Returns the approximated size of the pool. It may be equal or slightly
     # bigger or smaller than the actual size.
     def lazy_size : Int32
-      @mutex.synchronize { @deque.size }
+      @deque.size
     end
   end
 end

--- a/src/kernel.cr
+++ b/src/kernel.cr
@@ -563,14 +563,6 @@ end
 {% end %}
 
 {% unless flag?(:interpreted) || flag?(:wasm32) %}
-  # Background loop to cleanup unused fiber stacks.
-  spawn(name: "Fiber Clean Loop") do
-    loop do
-      sleep 5
-      Fiber.stack_pool.collect
-    end
-  end
-
   {% if flag?(:win32) %}
     Crystal::System::Process.start_interrupt_loop
   {% else %}
@@ -586,7 +578,5 @@ end
   Exception::CallStack.load_debug_info if ENV["CRYSTAL_LOAD_DEBUG_INFO"]? == "1"
   Exception::CallStack.setup_crash_handler
 
-  {% if flag?(:preview_mt) %}
-    Crystal::Scheduler.init_workers
-  {% end %}
+  Crystal::Scheduler.init
 {% end %}


### PR DESCRIPTION
First a couple fixes: an issue in the MT scheduler (math overflow when spawning Int32::MAX + 1 fibers), and a workaround to avoid #13211.

The scheduler always replaces the current thread for a fiber (which is inefficient) and it's breaking "a fiber will only ever live on the same thread". I refactored how fibers are associated to a thread, and enforced `#resume(fiber)` and `#yield(fiber)` to verify that the fiber we're trying to resume has indeed been associated with the current scheduler. The two methods are barely used (only `#resume` in specs), so there shouldn't be no impact.

Note: we may want to deprecate `Fiber#resume` and `Crystal::Scheduler#yield(fiber)` that try to immediately resume the fiber in the current thread, in favor to `Fiber#enqueue` that will properly dispatch. Again, `#resume` is only used in the stdlib specs, and `#yield(fiber)` isn't used at all.

I simplified a couple indirections, for example `Fiber.yield` that went through 5 inner calls when it could be simplified to only 2, or the scheduler calling `Fiber#resume` when it could call `#resume(fiber)` directly.

I also tried to improve on the design, for example have one Fiber::StackPool per scheduler so we can (safely) recycle stacks, move `#set_current_thread` from the scheduler to Fiber, instead of a couple systems (Fiber::StackPool that only creates stacks, and Scheduler#free_stacks that will do some clean on `#reschedule`).

Sadly, all these changes don't seem to improve the _performance_ of MT :disappointed: 

See all the individual commits and their description for more details.