### PR TITLE
MT: math overflow after spawning Int32::MAX + 1 fibers

### DIFF
--- a/src/crystal/scheduler.cr
+++ b/src/crystal/scheduler.cr
@@ -191,7 +191,7 @@ class Crystal::Scheduler
 
     protected def find_target_thread
       if workers = @@workers
-        @rr_target += 1
+        @rr_target &+= 1
         workers[@rr_target % workers.size]
       else
         Thread.current


### PR DESCRIPTION
This only happens after a lot of fibers has started, and can take over 24 days if spawning a fiber every millisecond, but it can eventually happen.