### PR TITLE
Workaround regular timeouts in `HTTP::Server` specs with MT

### DIFF
--- a/spec/std/http/server/server_spec.cr
+++ b/spec/std/http/server/server_spec.cr
@@ -45,12 +45,9 @@ describe HTTP::Server do
     server = HTTP::Server.new { }
     server.bind_unused_port
 
-    spawn do
+    run_server(server) do
       server.close
-      sleep 0.001
     end
-
-    server.listen
   end
 
   it "closes the server" do

--- a/spec/std/http/spec_helper.cr
+++ b/spec/std/http/spec_helper.cr
@@ -46,6 +46,11 @@ def run_server(server, &)
     wait_for { server.listening? }
     wait_until_blocked f
 
+    {% if flag?(:preview_mt) %}
+      # avoids fiber synchronization issues in specs, like closing the server
+      # before we properly listen, ...
+      sleep 0.001
+    {% end %}
     yield server_done
   ensure
     server.close unless server.closed?


### PR DESCRIPTION
The core of the issue is a synchronization issue between fibers that test edge cases in HTTP::Server, for example what's happening after closing the fiber (from another fiber) while we have no guarantee that the server is actually listening.

I couldn't find a proper way to fix the issue. The only solution that fixed the reproducibility was adding a one millisecond sleep after starting the server.

closes #13211