### PR TITLE
Skip indirections in `Crystal::Scheduler`

### DIFF
--- a/src/crystal/scheduler.cr
+++ b/src/crystal/scheduler.cr
@@ -59,7 +59,10 @@ class Crystal::Scheduler
   end
 
   def self.yield : Nil
-    Thread.current.scheduler.yield
+    # TODO: Fiber switching and libevent for wasm32
+    {% unless flag?(:wasm32) %}
+      Thread.current.scheduler.sleep(0.seconds)
+    {% end %}
   end
 
   def self.yield(fiber : Fiber) : Nil
@@ -172,13 +175,6 @@ class Crystal::Scheduler
   protected def sleep(time : Time::Span) : Nil
     @current.resume_event.add(time)
     reschedule
-  end
-
-  protected def yield : Nil
-    # TODO: Fiber switching and libevent for wasm32
-    {% unless flag?(:wasm32) %}
-      sleep(0.seconds)
-    {% end %}
   end
 
   protected def yield(fiber : Fiber) : Nil

--- a/src/crystal/scheduler.cr
+++ b/src/crystal/scheduler.cr
@@ -158,9 +158,7 @@ class Crystal::Scheduler
   protected def reschedule : Nil
     loop do
       if runnable = @lock.sync { @runnables.shift? }
-        unless runnable == @current
-          runnable.resume
-        end
+        resume(runnable) unless runnable == @current
         break
       else
         @event_loop.run_once
@@ -198,10 +196,11 @@ class Crystal::Scheduler
       fiber_channel = self.fiber_channel
       loop do
         @lock.lock
+
         if runnable = @runnables.shift?
           @runnables << Fiber.current
           @lock.unlock
-          runnable.resume
+          resume(runnable)
         else
           @sleeping = true
           @lock.unlock
@@ -211,7 +210,7 @@ class Crystal::Scheduler
           @sleeping = false
           @runnables << Fiber.current
           @lock.unlock
-          fiber.resume
+          resume(fiber)
         end
       end
     end


### PR DESCRIPTION
They avoid a bunch of Scheduler (class <-> instance) <-> Fiber indirections or calling `Thread.current.scheduler` repeatedly. They might be optimized away by LLVM but it's still nicer to have something more direct when reading.

See the individual commits for more details.