### PR TITLE
Windows: Use local configuration for LLVM when linking dynamically

### DIFF
--- a/src/llvm/lib_llvm.cr
+++ b/src/llvm/lib_llvm.cr
@@ -13,24 +13,28 @@
     {% llvm_version = lines[0] %}
     {% llvm_targets = lines[1] %}
     {% llvm_ldflags = lines[2] %}
-    {% extra_lib = "llvm" %}
+
+    @[Link("llvm")]
+    lib LibLLVM
+    end
   {% else %}
     {% llvm_config = env("LLVM_CONFIG") || `#{__DIR__}/ext/find-llvm-config`.stringify %}
     {% llvm_version = `#{llvm_config.id} --version`.stringify %}
     {% llvm_targets = env("LLVM_TARGETS") || `#{llvm_config.id} --targets-built`.stringify %}
     {% llvm_ldflags = "`#{llvm_config.id} --libs --system-libs --ldflags#{" --link-static".id if flag?(:static)}#{" 2> /dev/null".id unless flag?(:win32)}`" %}
-    {% extra_lib = flag?(:win32) ? nil : "stdc++" %}
+
+    {% unless flag?(:win32) %}
+      @[Link("stdc++")]
+      lib LibLLVM
+      end
+    {% end %}
   {% end %}
 
-  {% if extra_lib %}
-    @[Link({{ extra_lib }})]
-  {% end %}
   @[Link(ldflags: {{ llvm_ldflags }})]
   lib LibLLVM
     VERSION = {{ llvm_version.strip.gsub(/git/, "") }}
     BUILT_TARGETS = {{ llvm_targets.strip.downcase.split(' ').map(&.id.symbolize) }}
   end
-  {% debug %}
 {% end %}
 
 {% begin %}

--- a/src/llvm/lib_llvm.cr
+++ b/src/llvm/lib_llvm.cr
@@ -1,19 +1,34 @@
 {% begin %}
-lib LibLLVM
-  LLVM_CONFIG = {{ env("LLVM_CONFIG") || `#{__DIR__}/ext/find-llvm-config`.stringify }}
-end
-{% end %}
+  {% if flag?(:win32) && flag?(:preview_dll) %}
+    {% config = nil %}
+    {% for dir in Crystal::LIBRARY_PATH.split(';') %}
+      {% config ||= read_file?("#{dir.id}/llvm_VERSION") %}
+    {% end %}
 
-{% begin %}
-  {% unless flag?(:win32) %}
-    @[Link("stdc++")]
+    {% unless config %}
+      {% raise "Cannot determine LLVM configuration; ensure the file `llvm_VERSION` exists under `CRYSTAL_LIBRARY_PATH`" %}
+    {% end %}
+
+    {% lines = config.lines.map(&.chomp) %}
+    {% llvm_version = lines[0] %}
+    {% llvm_targets = lines[1] %}
+    {% llvm_ldflags = lines[2] %}
+    {% extra_lib = "llvm" %}
+  {% else %}
+    {% llvm_config = env("LLVM_CONFIG") || `#{__DIR__}/ext/find-llvm-config`.stringify %}
+    {% llvm_version = `#{llvm_config.id} --version`.stringify %}
+    {% llvm_targets = env("LLVM_TARGETS") || `#{llvm_config.id} --targets-built`.stringify %}
+    {% llvm_ldflags = `#{llvm_config.id} --libs --system-libs --ldflags#{" --link-static".id if flag?(:static)}#{" 2> /dev/null".id unless flag?(:win32)}`.stringify %}
+    {% extra_lib = flag?(:win32) ? nil : "stdc++" %}
   {% end %}
-  @[Link(ldflags: {{"`#{LibLLVM::LLVM_CONFIG} --libs --system-libs --ldflags#{" --link-static".id if flag?(:static)}#{" 2> /dev/null".id unless flag?(:win32)}`"}})]
+
+  {% if extra_lib %}
+    @[Link({{ extra_lib }})]
+  {% end %}
+  @[Link(ldflags: {{ llvm_ldflags.strip }})]
   lib LibLLVM
-    VERSION = {{`#{LibLLVM::LLVM_CONFIG} --version`.chomp.stringify.gsub(/git/, "")}}
-    BUILT_TARGETS = {{ (
-                         env("LLVM_TARGETS") || `#{LibLLVM::LLVM_CONFIG} --targets-built`
-                       ).strip.downcase.split(' ').map(&.id.symbolize) }}
+    VERSION = {{ llvm_version.strip.gsub(/git/, "") }}
+    BUILT_TARGETS = {{ llvm_targets.strip.downcase.split(' ').map(&.id.symbolize) }}
   end
 {% end %}
 

--- a/src/llvm/lib_llvm.cr
+++ b/src/llvm/lib_llvm.cr
@@ -18,18 +18,19 @@
     {% llvm_config = env("LLVM_CONFIG") || `#{__DIR__}/ext/find-llvm-config`.stringify %}
     {% llvm_version = `#{llvm_config.id} --version`.stringify %}
     {% llvm_targets = env("LLVM_TARGETS") || `#{llvm_config.id} --targets-built`.stringify %}
-    {% llvm_ldflags = `#{llvm_config.id} --libs --system-libs --ldflags#{" --link-static".id if flag?(:static)}#{" 2> /dev/null".id unless flag?(:win32)}`.stringify %}
+    {% llvm_ldflags = "`#{llvm_config.id} --libs --system-libs --ldflags#{" --link-static".id if flag?(:static)}#{" 2> /dev/null".id unless flag?(:win32)}`" %}
     {% extra_lib = flag?(:win32) ? nil : "stdc++" %}
   {% end %}
 
   {% if extra_lib %}
     @[Link({{ extra_lib }})]
   {% end %}
-  @[Link(ldflags: {{ llvm_ldflags.strip }})]
+  @[Link(ldflags: {{ llvm_ldflags }})]
   lib LibLLVM
     VERSION = {{ llvm_version.strip.gsub(/git/, "") }}
     BUILT_TARGETS = {{ llvm_targets.strip.downcase.split(' ').map(&.id.symbolize) }}
   end
+  {% debug %}
 {% end %}
 
 {% begin %}


### PR DESCRIPTION
Similar to how `openssl_VERSION` is already used on Windows, `LLVM` will now locate the first file called `llvm_VERSION` from `CRYSTAL_LIBRARY_PATH`, reading its contents to configure LLVM, rather than running `%LLVM_CONFIG%`. This file should consist of 3 lines:

* the output of `llvm-config --version`, using the same `llvm-config.exe` that built `LLVM-C.dll`
* the output of `llvm-config --targets-built`
* the output of `llvm-config --system-libs` (we assume `--libs --ldflags` do nothing more than locating `LLVM-C.lib` in the original LLVM installation)

On my LLVM 18-dev build, the file looks like this:

```
18.0.0git
X86
psapi.lib shell32.lib ole32.lib uuid.lib advapi32.lib
```

Then to make dynamic linking work, copy `lib/LLVM-C.lib` from LLVM to the Crystal installation's `lib/llvm-dynamic.lib`, as well as `bin/LLVM-C.dll` to the Crystal compiler's directory. This means we will be able to distribute LLVM as a dynamic-only library on Windows, without having to also distribute `llvm-config.exe` at all, since the above configuration is essentially synchronized to the DLL provided by Crystal.

This PR does not touch our Windows CI, that will be the next step.