### PR TITLE
Fix `StaticArray#to_json`

### DIFF
--- a/spec/std/json/serialization_spec.cr
+++ b/spec/std/json/serialization_spec.cr
@@ -587,6 +587,10 @@ describe "JSON serialization" do
       [1, 2, 3].to_json.should eq("[1,2,3]")
     end
 
+    it "does for StaticArray" do
+      StaticArray[1, 2, 3].to_json.should eq("[1,2,3]")
+    end
+
     it "does for Deque" do
       Deque.new([1, 2, 3]).to_json.should eq("[1,2,3]")
     end

--- a/src/json/to_json.cr
+++ b/src/json/to_json.cr
@@ -98,6 +98,14 @@ class Array
   end
 end
 
+struct StaticArray
+  def to_json(json : JSON::Builder) : Nil
+    json.array do
+      each &.to_json(json)
+    end
+  end
+end
+
 class Deque
   def to_json(json : JSON::Builder) : Nil
     json.array do


### PR DESCRIPTION
StaticArray.to_json currently results in a compiler error coming from the crystal stdlib:
```
In /usr/share/crystal/src/json/to_json.cr:10:15

 10 | to_json(json)
              ^---
Error: expected argument #1 to 'StaticArray(Int32, 1)#to_json' to be IO, not JSON::Builder

Overloads are:
 - Object#to_json(io : IO)
 - Object#to_json()
```

Minimal Reproduction Example:
```cr
require "json"

StaticArray[1].to_json
```

This seems to be caused by it using the generic Object.to_json. This PR fixes it by overwriting to_json for StaticArray to be the same as for normal arrays