### PR TITLE
Fix time span overflow on `Int#milliseconds` and `Int#microseconds`

### DIFF
--- a/spec/std/time/span_spec.cr
+++ b/spec/std/time/span_spec.cr
@@ -367,4 +367,12 @@ describe Time::Span do
     past2 = jan_1_2k + delta.microseconds
     past2.should eq(past)
   end
+
+  it "can substract big amount using milliseconds" do
+    jan_1_2k = Time.utc(2000, 1, 1)
+    past = Time.utc(5, 2, 3, 0, 0, 0)
+    delta = (past - jan_1_2k).total_milliseconds.to_i64
+    past2 = jan_1_2k + delta.milliseconds
+    past2.should eq(past)
+  end
 end

--- a/spec/std/time/span_spec.cr
+++ b/spec/std/time/span_spec.cr
@@ -359,4 +359,12 @@ describe Time::Span do
     2.weeks.should eq(14.days)
     1.1.weeks.should eq(7.7.days)
   end
+
+  it "can substract big amount using microseconds" do
+    jan_1_2k = Time.utc(2000, 1, 1)
+    past = Time.utc(5, 2, 3, 0, 0, 0)
+    delta = (past - jan_1_2k).total_microseconds.to_i64
+    past2 = jan_1_2k + delta.microseconds
+    past2.should eq(past)
+  end
 end

--- a/src/time/span.cr
+++ b/src/time/span.cr
@@ -479,7 +479,8 @@ struct Int
 
   # Returns a `Time::Span` of `self` microseconds.
   def microseconds : Time::Span
-    Time::Span.new(nanoseconds: (self.to_i64 * Time::NANOSECONDS_PER_MICROSECOND))
+    sec, m = self.to_i64.divmod(1_000_000)
+    Time::Span.new(seconds: sec, nanoseconds: m * 1_000)
   end
 
   # :ditto:

--- a/src/time/span.cr
+++ b/src/time/span.cr
@@ -469,7 +469,8 @@ struct Int
 
   # Returns a `Time::Span` of `self` milliseconds.
   def milliseconds : Time::Span
-    Time::Span.new(nanoseconds: (self.to_i64 * Time::NANOSECONDS_PER_MILLISECOND))
+    sec, m = self.to_i64.divmod(1_000)
+    Time::Span.new(seconds: sec, nanoseconds: m * 1_000_000)
   end
 
   # :ditto:


### PR DESCRIPTION
Extracted from https://github.com/will/crystal-pg/pull/277

cc: @snadon