### PR TITLE
Distribute LLVM DLLs on Windows CI

### DIFF
--- a/.github/workflows/win.yml
+++ b/.github/workflows/win.yml
@@ -164,21 +164,21 @@ jobs:
         if: steps.cache-openssl-dlls.outputs.cache-hit != 'true'
         run: .\etc\win-ci\build-openssl.ps1 -BuildTree deps\openssl -Version 3.1.0 -Dynamic
 
-  x86_64-windows-llvm:
+  x86_64-windows-llvm-libs:
     runs-on: windows-2022
     steps:
       - name: Enable Developer Command Prompt
         uses: ilammy/msvc-dev-cmd@cec98b9d092141f74527d0afa6feb2af698cfe89 # v1.12.1
 
       - name: Cache LLVM
-        id: cache-llvm
+        id: cache-llvm-libs
         uses: actions/cache@v3
         with:
           path: llvm
           key: llvm-libs-${{ env.CI_LLVM_VERSION }}-msvc
 
       - name: Download LLVM
-        if: steps.cache-llvm.outputs.cache-hit != 'true'
+        if: steps.cache-llvm-libs.outputs.cache-hit != 'true'
         run: |
           iwr https://github.com/llvm/llvm-project/releases/download/llvmorg-${{ env.CI_LLVM_VERSION }}/llvm-${{ env.CI_LLVM_VERSION }}.src.tar.xz -OutFile llvm.tar.xz
           (Get-FileHash -Algorithm SHA256 .\llvm.tar.xz).hash -eq "D820E63BC3A6F4F833EC69A1EF49A2E81992E90BC23989F98946914B061AB6C7"
@@ -187,7 +187,7 @@ jobs:
           mv llvm-* llvm-src
 
       - name: Download LLVM's CMake files
-        if: steps.cache-llvm.outputs.cache-hit != 'true'
+        if: steps.cache-llvm-libs.outputs.cache-hit != 'true'
         run: |
           iwr https://github.com/llvm/llvm-project/releases/download/llvmorg-${{ env.CI_LLVM_VERSION }}/cmake-${{ env.CI_LLVM_VERSION }}.src.tar.xz -OutFile cmake.tar.xz
           (Get-FileHash -Algorithm SHA256 .\cmake.tar.xz).hash -eq "B6D83C91F12757030D8361DEDC5DD84357B3EDB8DA406B5D0850DF8B6F7798B1"
@@ -196,7 +196,7 @@ jobs:
           mv cmake-* cmake
 
       - name: Build LLVM
-        if: steps.cache-llvm.outputs.cache-hit != 'true'
+        if: steps.cache-llvm-libs.outputs.cache-hit != 'true'
         run: |
           mkdir llvm-build
           cd llvm-build
@@ -204,8 +204,34 @@ jobs:
           cmake --build . --config Release
           cmake "-DCMAKE_INSTALL_PREFIX=$(pwd)\..\llvm" -P cmake_install.cmake
 
+  x86_64-windows-llvm-dlls:
+    runs-on: windows-2022
+    steps:
+      - name: Disable CRLF line ending substitution
+        run: |
+          git config --global core.autocrlf false
+
+      - name: Enable Developer Command Prompt
+        uses: ilammy/msvc-dev-cmd@cec98b9d092141f74527d0afa6feb2af698cfe89 # v1.12.1
+
+      - name: Download Crystal source
+        uses: actions/checkout@v4
+
+      - name: Cache LLVM
+        id: cache-llvm-dlls
+        uses: actions/cache@v3
+        with:
+          path: |
+            libs/llvm_VERSION
+            libs/llvm-dynamic.lib
+            dlls/LLVM-C.dll
+          key: llvm-dlls-${{ env.CI_LLVM_VERSION }}-${{ hashFiles('etc/win-ci/build-llvm.ps1') }}-msvc
+      - name: Build LLVM
+        if: steps.cache-llvm-dlls.outputs.cache-hit != 'true'
+        run: .\etc\win-ci\build-llvm.ps1 -BuildTree deps\llvm -Version ${{ env.CI_LLVM_VERSION }} -TargetsToBuild X86,AArch64 -Dynamic
+
   x86_64-windows:
-    needs: [x86_64-windows-libs, x86_64-windows-dlls, x86_64-windows-llvm]
+    needs: [x86_64-windows-libs, x86_64-windows-dlls, x86_64-windows-llvm-libs, x86_64-windows-llvm-dlls]
     uses: ./.github/workflows/win_build_portable.yml
     with:
       release: false
@@ -258,7 +284,7 @@ jobs:
 
   x86_64-windows-release:
     if: github.repository_owner == 'crystal-lang' && (startsWith(github.ref, 'refs/tags/') || startsWith(github.ref, 'refs/heads/ci/'))
-    needs: [x86_64-windows-libs, x86_64-windows-dlls, x86_64-windows-llvm]
+    needs: [x86_64-windows-libs, x86_64-windows-dlls, x86_64-windows-llvm-libs, x86_64-windows-llvm-dlls]
     uses: ./.github/workflows/win_build_portable.yml
     with:
       release: true

--- a/.github/workflows/win_build_portable.yml
+++ b/.github/workflows/win_build_portable.yml
@@ -93,6 +93,15 @@ jobs:
           path: llvm
           key: llvm-libs-${{ inputs.llvm_version }}-msvc
           fail-on-cache-miss: true
+      - name: Restore LLVM DLLs
+        uses: actions/cache/restore@v3
+        with:
+          path: |
+            libs/llvm_VERSION
+            libs/llvm-dynamic.lib
+            dlls/LLVM-C.dll
+          key: llvm-dlls-${{ inputs.llvm_version }}-${{ hashFiles('etc/win-ci/build-llvm.ps1') }}-msvc
+          fail-on-cache-miss: true
 
       - name: Set up environment
         run: |

--- a/etc/win-ci/build-llvm.ps1
+++ b/etc/win-ci/build-llvm.ps1
@@ -1,0 +1,42 @@
+param(
+    [Parameter(Mandatory)] [string] $BuildTree,
+    [Parameter(Mandatory)] [string] $Version,
+    [Parameter(Mandatory)] [string[]] $TargetsToBuild,
+    [switch] $Dynamic
+)
+
+if (-not $Dynamic) {
+    Write-Host "Error: Building LLVM as a static library is not supported yet" -ForegroundColor Red
+    Exit 1
+}
+
+. "$(Split-Path -Parent $MyInvocation.MyCommand.Path)\setup.ps1"
+
+[void](New-Item -Name (Split-Path -Parent $BuildTree) -ItemType Directory -Force)
+Setup-Git -Path $BuildTree -Url https://github.com/llvm/llvm-project.git -Ref llvmorg-$Version
+
+Run-InDirectory $BuildTree\build {
+    $args = "-Thost=x64 -DLLVM_TARGETS_TO_BUILD=""$($TargetsToBuild -join ';')"" -DCMAKE_FIND_USE_SYSTEM_ENVIRONMENT_PATH=OFF -DLLVM_INCLUDE_BENCHMARKS=OFF -DLLVM_INCLUDE_DOCS=OFF -DLLVM_INCLUDE_TESTS=OFF -DLLVM_ENABLE_ZSTD=OFF"
+    if ($Dynamic) {
+        $args = "-DCMAKE_MSVC_RUNTIME_LIBRARY=MultiThreadedDLL $args"
+    } else {
+        $args = "-DCMAKE_MSVC_RUNTIME_LIBRARY=MultiThreaded -DLLVM_BUILD_LLVM_C_DYLIB=OFF $args"
+    }
+    & $cmake ..\llvm $args.split(' ')
+    & $cmake --build . --config Release --target llvm-config --target LLVM-C
+    if (-not $?) {
+        Write-Host "Error: Failed to build LLVM" -ForegroundColor Red
+        Exit 1
+    }
+}
+
+if ($Dynamic) {
+    mv -Force $BuildTree\build\Release\lib\LLVM-C.lib libs\llvm-dynamic.lib
+    mv -Force $BuildTree\build\Release\bin\LLVM-C.dll dlls\
+} else {
+    # TODO (probably never)
+}
+
+Add-Content libs\llvm_VERSION $(& "$BuildTree\build\Release\bin\llvm-config.exe" --version)
+Add-Content libs\llvm_VERSION $(& "$BuildTree\build\Release\bin\llvm-config.exe" --targets-built)
+Add-Content libs\llvm_VERSION $(& "$BuildTree\build\Release\bin\llvm-config.exe" --system-libs)


### PR DESCRIPTION
This adds the `etc/win-ci/build-llvm.ps1` script that builds the LLVM C interface DLL, its import library, plus the `llvm_VERSION` file mentioned in #14101, in the same way other dynamic libraries are built on Windows CI.

LLVM as a static library is unaffected. It is very unlikely `build-llvm.ps1` would support that in the future.

In theory, once LLVM 18 comes out, this should allow Crystal to rebuild itself as a dynamically linked executable without `llvm_ext.obj` nor `llvm-config.exe`. This is still not enough to use LLVM's Windows installers, but then the only missing part becomes [synthesizing `llvm_VERSION` from an existing `LLVM-C.DLL`](https://github.com/crystal-lang/crystal/pull/14112).