### PR TITLE
Never use string interpolation in `Crystal::System.print_error`

### DIFF
--- a/src/crystal/scheduler.cr
+++ b/src/crystal/scheduler.cr
@@ -135,8 +135,8 @@ class Crystal::Scheduler
   end
 
   private def fatal_resume_error(fiber, message)
-    Crystal::System.print_error "\nFATAL: #{message}: #{fiber}\n"
-    caller.each { |line| Crystal::System.print_error "  from #{line}\n" }
+    Crystal::System.print_error "\nFATAL: %s: %s\n", message, fiber.to_s
+    caller.each { |line| Crystal::System.print_error "  from %s\n", line }
     exit 1
   end
 
@@ -259,7 +259,7 @@ class Crystal::Scheduler
       if env_workers && !env_workers.empty?
         workers = env_workers.to_i?
         if !workers || workers < 1
-          Crystal::System.print_error "FATAL: Invalid value for CRYSTAL_WORKERS: #{env_workers}\n"
+          Crystal::System.print_error "FATAL: Invalid value for CRYSTAL_WORKERS: %s\n", env_workers
           exit 1
         end
 

--- a/src/exception/call_stack/interpreter.cr
+++ b/src/exception/call_stack/interpreter.cr
@@ -27,7 +27,7 @@ struct Exception::CallStack
 
   def self.print_backtrace : Nil
     unwind.each do |frame|
-      Crystal::System.print_error frame.unsafe_as(String)
+      Crystal::System.print_error "%s\n", frame.unsafe_as(String)
     end
   end
 end

--- a/src/raise.cr
+++ b/src/raise.cr
@@ -45,7 +45,7 @@ private def traverse_eh_table(leb, start, ip, actions, &)
 
   lp_start_encoding = leb.read_uint8 # @LPStart encoding
   if lp_start_encoding != 0xff_u8
-    Crystal::System.print_error "Unexpected encoding for LPStart: #{lp_start_encoding}\n"
+    Crystal::System.print_error "Unexpected encoding for LPStart: 0x%x\n", lp_start_encoding
     LibC.exit 1
   end
 
@@ -55,7 +55,7 @@ private def traverse_eh_table(leb, start, ip, actions, &)
 
   cs_encoding = leb.read_uint8 # CS Encoding (1: uleb128, 3: uint32)
   if cs_encoding != 1 && cs_encoding != 3
-    Crystal::System.print_error "Unexpected CS encoding: #{cs_encoding}\n"
+    Crystal::System.print_error "Unexpected CS encoding: 0x%x\n", cs_encoding
     LibC.exit 1
   end
 
@@ -218,7 +218,7 @@ end
 
 {% if flag?(:wasm32) %}
   def raise(exception : Exception) : NoReturn
-    Crystal::System.print_error "EXITING: Attempting to raise:\n#{exception.inspect_with_backtrace}"
+    Crystal::System.print_error "EXITING: Attempting to raise:\n%s\n", exception.inspect_with_backtrace
     LibIntrinsics.debugtrap
     LibC.exit(1)
   end


### PR DESCRIPTION
This prevents very bad things like the following from happening:

```
$ CRYSTAL_WORKERS=%d crystal run -Dpreview_mt file.cr
FATAL: invalid value for CRYSTAL_WORKERS: 44429088
$ CRYSTAL_WORKERS=%n crystal run -Dpreview_mt file.cr
Program received and didn't handle signal ABRT (6)
```
