### PR TITLE
Change `Regex::MatchData#to_s` to return matched substring

### DIFF
--- a/spec/std/regex/match_data_spec.cr
+++ b/spec/std/regex/match_data_spec.cr
@@ -22,9 +22,9 @@ describe "Regex::MatchData" do
   end
 
   it "#to_s" do
-    matchdata(/f(o)(x)/, "the fox").to_s.should eq(%(Regex::MatchData("fox" 1:"o" 2:"x")))
-    matchdata(/f(?<lettero>o)(?<letterx>x)/, "the fox").to_s.should eq(%(Regex::MatchData("fox" lettero:"o" letterx:"x")))
-    matchdata(/fox/, "the fox").to_s.should eq(%(Regex::MatchData("fox")))
+    matchdata(/f(o)(x)/, "the fox").to_s.should eq("fox")
+    matchdata(/f(?<lettero>o)(?<letterx>x)/, "the fox").to_s.should eq("fox")
+    matchdata(/fox/, "the fox").to_s.should eq("fox")
   end
 
   it "#pretty_print" do

--- a/src/regex/match_data.cr
+++ b/src/regex/match_data.cr
@@ -336,10 +336,6 @@ class Regex
     end
 
     def inspect(io : IO) : Nil
-      to_s(io)
-    end
-
-    def to_s(io : IO) : Nil
       name_table = @regex.name_table
 
       io << "Regex::MatchData("
@@ -348,6 +344,16 @@ class Regex
         self[i]?.inspect(io)
       end
       io << ')'
+    end
+
+    # Prints the matched substring to *io*.
+    #
+    # ```
+    # "Crystal".match!(/yst/).to_s         # => "yst"
+    # "Crystal".match!(/(y)(s)(?=t)/).to_s # => "ys"
+    # ```
+    def to_s(io : IO) : Nil
+      io << self[0]
     end
 
     def pretty_print(pp) : Nil

--- a/src/regex/match_data.cr
+++ b/src/regex/match_data.cr
@@ -346,14 +346,19 @@ class Regex
       io << ')'
     end
 
-    # Prints the matched substring to *io*.
+    # Returns the matched substring.
     #
     # ```
     # "Crystal".match!(/yst/).to_s         # => "yst"
     # "Crystal".match!(/(y)(s)(?=t)/).to_s # => "ys"
     # ```
+    def to_s : String
+      self[0]
+    end
+
+    # Prints the matched substring to *io*.
     def to_s(io : IO) : Nil
-      io << self[0]
+      io << to_s
     end
 
     def pretty_print(pp) : Nil


### PR DESCRIPTION
Related issue: https://github.com/crystal-lang/crystal/issues/13118

Currently, `MatchData#to_s` is the same as `MatchData#inspect`, which means that it returns an object representation of the MatchData: `Regex::MatchData("ys" 1:"y" 2:"s")`

This is not only inconsistent with [Ruby, which returns the matched substring](https://ruby-doc.org/core-2.4.1/MatchData.html#method-i-to_s), and most other languages, like [rust's regexp crate](https://docs.rs/regex/latest/regex/struct.Match.html#method.as_str), but also not really useful for anything besides debugging (which is exactly where you should use inspect over to_s).

Much more useful would be for it to return the matched substring. Currently, the only way to do so is via match[0], but that's unintuitive and confusing

Thus, this PR changes `#to_s` to do just that. This is a breaking change, but I doubt many codebases actually use or rely on the old to_s. `#inspect` still has the old behaviour.

Resolves part of https://github.com/crystal-lang/crystal/issues/13118