### PR TITLE
Implement most of `Crystal::System.print_error` in native Crystal

### DIFF
--- a/spec/std/crystal/system_spec.cr
+++ b/spec/std/crystal/system_spec.cr
@@ -1,0 +1,46 @@
+require "spec"
+
+private def print_error_to_s(format, *args)
+  io = IO::Memory.new
+  Crystal::System.print_error(format, *args) do |bytes|
+    io.write_string(bytes)
+  end
+  io.to_s
+end
+
+describe "Crystal::System" do
+  describe ".print_error" do
+    it "works" do
+      print_error_to_s("abcde").should eq("abcde")
+    end
+
+    it "supports %d" do
+      print_error_to_s("%d,%d,%d,%d,%d", 0, 1234, Int32::MAX, Int32::MIN, UInt64::MAX).should eq("0,1234,2147483647,-2147483648,-1")
+    end
+
+    it "supports %u" do
+      print_error_to_s("%u,%u,%u,%u,%u", 0, 1234, UInt32::MAX, Int32::MIN, UInt64::MAX).should eq("0,1234,4294967295,2147483648,4294967295")
+    end
+
+    it "supports %x" do
+      print_error_to_s("%x,%x,%x,%x,%x", 0, 0x1234, UInt32::MAX, Int32::MIN, UInt64::MAX).should eq("0,1234,ffffffff,80000000,ffffffff")
+    end
+
+    it "supports %p" do
+      print_error_to_s("%p,%p,%p", Pointer(Void).new(0x0), Pointer(Void).new(0x1234), Pointer(Void).new(UInt64::MAX)).should eq("0x0,0x1234,0xffffffffffffffff")
+    end
+
+    it "supports %s" do
+      print_error_to_s("%s,%s", "abc\0def", "ghi".to_unsafe).should eq("abc\0def,ghi")
+    end
+
+    it "supports %l width" do
+      values = {LibC::Long::MIN, LibC::Long::MAX, LibC::LongLong::MIN, LibC::LongLong::MAX}
+      print_error_to_s("%ld,%ld,%lld,%lld", *values).should eq(values.join(','))
+
+      values = {LibC::ULong::MIN, LibC::ULong::MAX, LibC::ULongLong::MIN, LibC::ULongLong::MAX}
+      print_error_to_s("%lu,%lu,%llu,%llu", *values).should eq(values.join(','))
+      print_error_to_s("%lx,%lx,%llx,%llx", *values).should eq(values.join(',', &.to_s(16)))
+    end
+  end
+end

--- a/spec/std/crystal/system_spec.cr
+++ b/spec/std/crystal/system_spec.cr
@@ -31,7 +31,7 @@ describe "Crystal::System" do
     end
 
     it "supports %s" do
-      print_error_to_s("%s,%s", "abc\0def", "ghi".to_unsafe).should eq("abc\0def,ghi")
+      print_error_to_s("%s,%s,%s", "abc\0def", "ghi".to_unsafe, Pointer(UInt8).null).should eq("abc\0def,ghi,(null)")
     end
 
     it "supports %l width" do

--- a/src/crystal/system/print_error.cr
+++ b/src/crystal/system/print_error.cr
@@ -4,7 +4,7 @@ module Crystal::System
   # IO to work (fibers, scheduler, event_loop).
   def self.print_error(message, *args)
     print_error(message, *args) do |bytes|
-      {% if flag?(:unix) %}
+      {% if flag?(:unix) || flag?(:wasm32) %}
         LibC.write 2, bytes, bytes.size
       {% elsif flag?(:win32) %}
         LibC._write 2, bytes, bytes.size

--- a/src/crystal/system/print_error.cr
+++ b/src/crystal/system/print_error.cr
@@ -56,7 +56,7 @@ module Crystal::System
 
       case fmt_ptr.value
       when 's'
-        read_arg(Union(String, Pointer(UInt8))) do |arg|
+        read_arg(::Union(String, Pointer(UInt8))) do |arg|
           yield to_string_slice(arg)
         end
       when 'd'

--- a/src/crystal/system/print_error.cr
+++ b/src/crystal/system/print_error.cr
@@ -12,16 +12,18 @@ module Crystal::System
     end
   end
 
-  # Minimal drop-in replacement for a C `printf` function. Currently the only
-  # supported format specifiers are `%(l|ll)?[dpsux]`; more should be added only
-  # when we need them or an external library passes its own format string here.
-  # Since `print_error` may be called under low memory conditions or even with
-  # a corrupted heap, this implementation should be as low-level as possible,
-  # avoiding memory allocations wherever possible.
+  # Minimal drop-in replacement for a C `printf` function. Yields successive
+  # `Bytes` to the block, which should do the actual printing.
   #
-  # Yields successive `Bytes` to the block, which should do the actual printing.
+  # *format* only supports the `%(l|ll)?[dpsux]` format specifiers; more should
+  # be added only when we need them or an external library passes its own format
+  # string to here. *format* must also be null-terminated.
   #
-  # Note that C's `printf` is incompatible with Crystal's `sprintf`, because the
+  # Since this method may be called under low memory conditions or even with a
+  # corrupted heap, its implementation should be as low-level as possible,
+  # avoiding memory allocations.
+  #
+  # NOTE: C's `printf` is incompatible with Crystal's `sprintf`, because the
   # latter does not support argument width specifiers nor `%p`.
   def self.print_error(format, *args, &)
     ptr, format_len = to_unsafe_string(format)

--- a/src/crystal/system/print_error.cr
+++ b/src/crystal/system/print_error.cr
@@ -56,7 +56,7 @@ module Crystal::System
 
       case fmt_ptr.value
       when 's'
-        read_arg(::Union(String, Pointer(UInt8))) do |arg|
+        read_arg(String | Pointer(UInt8)) do |arg|
           yield to_string_slice(arg)
         end
       when 'd'

--- a/src/crystal/system/print_error.cr
+++ b/src/crystal/system/print_error.cr
@@ -1,15 +1,148 @@
 module Crystal::System
-  # Prints directly to stderr without going through an IO.
+  # Prints directly to stderr without going through an `IO::FileDescriptor`.
   # This is useful for error messages from components that are required for
   # IO to work (fibers, scheduler, event_loop).
   def self.print_error(message, *args)
-    {% if flag?(:unix) %}
-      LibC.dprintf 2, message, *args
-    {% elsif flag?(:win32) %}
-      buffer = StaticArray(UInt8, 512).new(0_u8)
-      len = LibC.snprintf(buffer, buffer.size, message, *args)
-      LibC._write 2, buffer, len
-    {% end %}
+    print_error(message, *args) do |bytes|
+      {% if flag?(:unix) %}
+        LibC.write 2, bytes, bytes.size
+      {% elsif flag?(:win32) %}
+        LibC._write 2, bytes, bytes.size
+      {% end %}
+    end
+  end
+
+  # Minimal drop-in replacement for a C `printf` function. Currently the only
+  # supported format specifiers are `%(l|ll)?[dpsux]`; more should be added only
+  # when we need them or an external library passes its own format string here.
+  # Since `print_error` may be called under low memory conditions or even with
+  # a corrupted heap, this implementation should be as low-level as possible,
+  # avoiding memory allocations wherever possible.
+  #
+  # Yields successive `Bytes` to the block, which should do the actual printing.
+  #
+  # Note that C's `printf` is incompatible with Crystal's `sprintf`, because the
+  # latter does not support argument width specifiers nor `%p`.
+  def self.print_error(format, *args, &)
+    ptr, format_len = to_unsafe_string(format)
+    finish = ptr + format_len
+    arg_index = 0
+
+    while ptr < finish
+      next_percent = ptr
+      while next_percent < finish && !(next_percent.value === '%')
+        next_percent += 1
+      end
+      yield Slice.new(ptr, next_percent - ptr)
+
+      fmt_ptr = next_percent + 1
+      width = 0
+      if fmt_ptr.value === 'l'
+        width = 1
+        fmt_ptr += 1
+        if fmt_ptr.value === 'l'
+          width = 2
+          fmt_ptr += 1
+        end
+      end
+
+      break unless fmt_ptr < finish
+
+      case fmt_ptr.value
+      when 's'
+        if (arg = args[arg_index].as?(String | UInt8*)).nil?
+          yield "(???)".to_slice
+        else
+          yield Slice.new(*to_unsafe_string(arg))
+        end
+        arg_index += 1
+      when 'd'
+        if (arg = args[arg_index].as?(Int::Primitive)).nil?
+          yield "(???)".to_slice
+        else
+          to_unsafe_int(arg, 10, true, width) { |bytes| yield bytes }
+        end
+        arg_index += 1
+      when 'u'
+        if (arg = args[arg_index].as?(Int::Primitive)).nil?
+          yield "(???)".to_slice
+        else
+          to_unsafe_int(arg, 10, false, width) { |bytes| yield bytes }
+        end
+        arg_index += 1
+      when 'x'
+        if (arg = args[arg_index].as?(Int::Primitive)).nil?
+          yield "(???)".to_slice
+        else
+          to_unsafe_int(arg, 16, false, width) { |bytes| yield bytes }
+        end
+        arg_index += 1
+      when 'p'
+        if (arg = args[arg_index].as?(Void*)).nil?
+          yield "(???)".to_slice
+        else
+          # NOTE: MSVC uses `%X` rather than `0x%x`, we follow the latter on all platforms
+          yield "0x".to_slice
+          to_unsafe_int(arg.address, 16, false, 2) { |bytes| yield bytes }
+        end
+        arg_index += 1
+      else
+        yield Slice.new(next_percent, fmt_ptr + 1 - next_percent)
+      end
+
+      ptr = fmt_ptr + 1
+    end
+  end
+
+  private def self.to_unsafe_string(str)
+    if str.is_a?(UInt8*)
+      {str, LibC.strlen(str)}
+    else
+      str = str.to_s
+      {str.to_unsafe, str.bytesize}
+    end
+  end
+
+  # simplified version of `Int#internal_to_s`
+  private def self.to_unsafe_int(num, base, signed, width, &)
+    if num == 0
+      yield "0".to_slice
+      return
+    end
+
+    # Given sizeof(num) <= 64 bits, we need at most 20 bytes for `%d` or `%u`
+    # note that `chars` does not have to be null-terminated, since we are
+    # only yielding a `Bytes`
+    chars = uninitialized UInt8[20]
+    ptr_end = chars.to_unsafe + 20
+    ptr = ptr_end
+
+    num = case {signed, width}
+          when {true, 2}  then LibC::LongLong.new!(num)
+          when {true, 1}  then LibC::Long.new!(num)
+          when {true, 0}  then LibC::Int.new!(num)
+          when {false, 2} then LibC::ULongLong.new!(num)
+          when {false, 1} then LibC::ULong.new!(num)
+          else                 LibC::UInt.new!(num)
+          end
+
+    neg = num < 0
+
+    # do not assume Crystal constant initialization succeeds, hence not `DIGITS`
+    digits = "0123456789abcdef".to_unsafe
+
+    while num != 0
+      ptr -= 1
+      ptr.value = digits[num.remainder(base).abs]
+      num = num.tdiv(base)
+    end
+
+    if neg
+      ptr -= 1
+      ptr.value = '-'.ord.to_u8
+    end
+
+    yield Slice.new(ptr, ptr_end - ptr)
   end
 
   def self.print_exception(message, ex)

--- a/src/crystal/system/print_error.cr
+++ b/src/crystal/system/print_error.cr
@@ -13,7 +13,7 @@ module Crystal::System
   end
 
   # Minimal drop-in replacement for a C `printf` function. Yields successive
-  # `Bytes` to the block, which should do the actual printing.
+  # non-empty `Bytes` to the block, which should do the actual printing.
   #
   # *format* only supports the `%(l|ll)?[dpsux]` format specifiers; more should
   # be added only when we need them or an external library passes its own format
@@ -37,7 +37,9 @@ module Crystal::System
       while next_percent < finish && !(next_percent.value === '%')
         next_percent += 1
       end
-      yield Slice.new(ptr, next_percent - ptr)
+      unless next_percent == ptr
+        yield Slice.new(ptr, next_percent - ptr)
+      end
 
       fmt_ptr = next_percent + 1
       width = 0


### PR DESCRIPTION
This PR handles the formatting aspects of `Crystal::System.print_error` to the extent needed by all existing calls to it (see https://github.com/crystal-lang/crystal/issues/12396#issuecomment-1852160277), so that it depends on `LibC.write` or `._write` directly, instead of `.dprintf` or `.snprintf`.

On Windows, the last remaining use of `LibC.snprintf` would be `sprintf "%g"` after this PR.