### PR TITLE
Fix out-of-bounds access in `Int128::MIN.to_s(base: 2)`

### DIFF
--- a/spec/std/int_spec.cr
+++ b/spec/std/int_spec.cr
@@ -376,6 +376,7 @@ describe "Int" do
       it_converts_to_s 62, "10", base: 62
       it_converts_to_s 97, "1z", base: 62
       it_converts_to_s 3843, "ZZ", base: 62
+      it_converts_to_s Int128::MIN, "-1#{"0" * 127}", base: 2
 
       it "raises on base 1" do
         expect_raises(ArgumentError, "Invalid base 1") { 123.to_s(1) }

--- a/src/int.cr
+++ b/src/int.cr
@@ -749,7 +749,7 @@ struct Int
     # representation, plus one byte for the negative sign (possibly used by the
     # string-returning overload).
     chars = uninitialized UInt8[129]
-    ptr_end = chars.to_unsafe + 128
+    ptr_end = chars.to_unsafe + 129
     ptr = ptr_end
     num = self
 


### PR DESCRIPTION
`ptr` is decremented before being written to, so it should initially be at the end of `chars`.