### PR TITLE
Add location information to implicit flag enum members

### DIFF
--- a/spec/compiler/semantic/doc_spec.cr
+++ b/spec/compiler/semantic/doc_spec.cr
@@ -353,6 +353,24 @@ describe "Semantic: doc" do
     a.locations.not_nil!.size.should eq(1)
   end
 
+  it "stores location for implicit flag enum members" do
+    result = semantic %(
+      @[Flags]
+      enum Foo
+        A = 1
+        B = 2
+      end
+    ), wants_doc: true
+    program = result.program
+    foo = program.types["Foo"]
+
+    a_loc = foo.types["All"].locations.should_not be_nil
+    a_loc.should_not be_empty
+
+    b_loc = foo.types["None"].locations.should_not be_nil
+    b_loc.should_not be_empty
+  end
+
   it "stores doc for constant" do
     result = semantic %(
       # Hello

--- a/src/compiler/crystal/semantic/top_level_visitor.cr
+++ b/src/compiler/crystal/semantic/top_level_visitor.cr
@@ -655,16 +655,27 @@ class Crystal::TopLevelVisitor < Crystal::SemanticVisitor
 
       if enum_type.flags?
         unless enum_type.types.has_key?("None")
-          enum_type.add_constant("None", 0)
+          none_member = enum_type.add_constant("None", 0)
+
+          if node_location = node.location
+            none_member.add_location node_location
+          end
+
           define_enum_none_question_method(enum_type, node)
         end
 
         unless enum_type.types.has_key?("All")
           all_value = enum_type.base_type.kind.cast(0).as(Int::Primitive)
+
           enum_type.types.each_value do |member|
             all_value |= interpret_enum_value(member.as(Const).value, enum_type.base_type)
           end
-          enum_type.add_constant("All", all_value)
+
+          all_member = enum_type.add_constant("All", all_value)
+
+          if node_location = node.location
+            all_member.add_location node_location
+          end
         end
       end
 


### PR DESCRIPTION
Fixes #14117

`All` and `None` now properly show up in the docs. However I do not like how they're ordered so thoughts on having a follow up PR to fix the order in the doc context. E.g. `None` first, user defined members, then `All` last?

I also noticed there is no `#all?` method to go along with `#none?`. I can put together a PR for that, but also came across https://github.com/crystal-lang/crystal/pull/10497 which provides an alternative way of handling it. Or even make this PR obsolete.