### PR TITLE
Fix: can't resume a running fiber

### DIFF
--- a/src/crystal/scheduler.cr
+++ b/src/crystal/scheduler.cr
@@ -27,7 +27,8 @@ class Crystal::Scheduler
     scheduler = thread.scheduler
 
     {% if flag?(:preview_mt) %}
-      th = fiber.@current_thread.lazy_get || scheduler.find_target_thread
+      th = fiber.get_current_thread
+      fiber.set_current_thread(scheduler.find_target_thread) unless th
 
       if th == thread
         scheduler.enqueue(fiber)

--- a/src/crystal/scheduler.cr
+++ b/src/crystal/scheduler.cr
@@ -28,7 +28,7 @@ class Crystal::Scheduler
 
     {% if flag?(:preview_mt) %}
       th = fiber.get_current_thread
-      th = fiber.set_current_thread(scheduler.find_target_thread) unless th
+      th ||= fiber.set_current_thread(scheduler.find_target_thread)
 
       if th == thread
         scheduler.enqueue(fiber)

--- a/src/crystal/scheduler.cr
+++ b/src/crystal/scheduler.cr
@@ -28,7 +28,7 @@ class Crystal::Scheduler
 
     {% if flag?(:preview_mt) %}
       th = fiber.get_current_thread
-      fiber.set_current_thread(scheduler.find_target_thread) unless th
+      th = fiber.set_current_thread(scheduler.find_target_thread) unless th
 
       if th == thread
         scheduler.enqueue(fiber)


### PR DESCRIPTION
The changes in #14098 require that the fiber be associated to a thread once, instead of doing it on every swapcontext, yet enqueueing the fiber didn't do it while associating the fiber to a thread, which led to further enqueues to associate the fiber to any other thread, in which case a thread B was trying to resume a fiber that was still running on thread A (it didn't swap context, yet).

closes #14124