### PR TITLE
Update distribution-scripts

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,7 +8,7 @@ parameters:
   distribution-scripts-version:
     description: "Git ref for version of https://github.com/crystal-lang/distribution-scripts/"
     type: string
-    default: "e15cbd3b6b3e1bac1b16905f1b1a15ba6ae4e554"
+    default: "535aedb8b09d77caaa1583700f371cd04343b7e8"
   previous_crystal_base_url:
     description: "Prefix for URLs to Crystal bootstrap compiler"
     type: string


### PR DESCRIPTION
Updates `distribution-scripts` dependency to https://github.com/crystal-lang/distribution-scripts/commit/535aedb8b09d77caaa1583700f371cd04343b7e8

This includes the following changes:

* crystal-lang/distribution-scripts#278
* crystal-lang/distribution-scripts#279
* crystal-lang/distribution-scripts#271
* crystal-lang/distribution-scripts#261