### PR TITLE
Add Crystal::Repl#parse_and_interpret

### DIFF
--- a/spec/compiler/crystal/tools/repl_spec.cr
+++ b/spec/compiler/crystal/tools/repl_spec.cr
@@ -1,0 +1,19 @@
+require "../../../spec_helper"
+
+private def success_value(result) : Crystal::Repl::Value
+  success_result = result.should be_a(Crystal::Repl::EvalSuccess)
+  success_result.warnings.infos.should be_empty
+  success_result.value
+end
+
+describe Crystal::Repl do
+  it "can parse and evaluate snippets" do
+    repl = Crystal::Repl.new
+    repl.prelude = "primitives"
+    repl.load_prelude
+
+    success_value(repl.parse_and_interpret("1 + 2")).value.should eq(3)
+    success_value(repl.parse_and_interpret("def foo; 1 + 2; end")).value.should eq(nil)
+    success_value(repl.parse_and_interpret("foo")).value.should eq(3)
+  end
+end

--- a/spec/compiler/crystal/tools/repl_spec.cr
+++ b/spec/compiler/crystal/tools/repl_spec.cr
@@ -1,3 +1,5 @@
+{% skip_file if flag?(:without_interpreter) %}
+
 require "../../../spec_helper"
 
 private def success_value(result : Crystal::Repl::EvalResult) : Crystal::Repl::Value

--- a/spec/compiler/crystal/tools/repl_spec.cr
+++ b/spec/compiler/crystal/tools/repl_spec.cr
@@ -1,9 +1,8 @@
 require "../../../spec_helper"
 
-private def success_value(result) : Crystal::Repl::Value
-  success_result = result.should be_a(Crystal::Repl::EvalSuccess)
-  success_result.warnings.infos.should be_empty
-  success_result.value
+private def success_value(result : Crystal::Repl::EvalResult) : Crystal::Repl::Value
+  result.warnings.infos.should be_empty
+  result.value.should_not be_nil
 end
 
 describe Crystal::Repl do

--- a/src/compiler/crystal/interpreter/repl.cr
+++ b/src/compiler/crystal/interpreter/repl.cr
@@ -22,15 +22,13 @@ class Crystal::Repl
       when "exit"
         break
       when .presence
-        parser = new_parser(expression)
-        parser.warnings.report(STDOUT)
+        result = parse_and_interpret(expression)
+        result.warnings.report(STDOUT)
 
-        node = parser.parse
-        next unless node
+        next unless result.is_a?(EvalSuccess)
 
-        value = interpret(node)
         print " => "
-        puts SyntaxHighlighter::Colorize.highlight!(value.to_s)
+        puts SyntaxHighlighter::Colorize.highlight!(result.value.to_s)
       end
     rescue ex : EscapingException
       print "Unhandled exception: "
@@ -42,6 +40,19 @@ class Crystal::Repl
     rescue ex : Exception
       ex.inspect_with_backtrace(STDOUT)
     end
+  end
+
+  record EvalSuccess, value : Value, warnings : WarningCollection
+  record EvalParserError, warnings : WarningCollection
+
+  def parse_and_interpret(expression : String) : EvalSuccess | EvalParserError
+    parser = new_parser(expression)
+
+    node = parser.parse
+    return EvalParserError.new(warnings: parser.warnings) unless node
+
+    value = interpret(node)
+    return EvalSuccess.new(value: value, warnings: parser.warnings)
   end
 
   def run_file(filename, argv)
@@ -68,7 +79,7 @@ class Crystal::Repl
     interpret(exps)
   end
 
-  private def load_prelude
+  def load_prelude
     node = parse_prelude
 
     interpret_and_exit_on_error(node)

--- a/src/compiler/crystal/interpreter/repl.cr
+++ b/src/compiler/crystal/interpreter/repl.cr
@@ -25,7 +25,7 @@ class Crystal::Repl
         result = parse_and_interpret(expression)
         result.warnings.report(STDOUT)
 
-        next unless result.is_a?(EvalSuccess)
+        next unless result.value
 
         print " => "
         puts SyntaxHighlighter::Colorize.highlight!(result.value.to_s)
@@ -42,17 +42,16 @@ class Crystal::Repl
     end
   end
 
-  record EvalSuccess, value : Value, warnings : WarningCollection
-  record EvalParserError, warnings : WarningCollection
+  record EvalResult, value : Value?, warnings : WarningCollection
 
-  def parse_and_interpret(expression : String) : EvalSuccess | EvalParserError
+  def parse_and_interpret(expression : String) : EvalResult
     parser = new_parser(expression)
 
     node = parser.parse
-    return EvalParserError.new(warnings: parser.warnings) unless node
+    return EvalResult.new(value: nil, warnings: parser.warnings) unless node
 
     value = interpret(node)
-    return EvalSuccess.new(value: value, warnings: parser.warnings)
+    return EvalResult.new(value: value, warnings: parser.warnings)
   end
 
   def run_file(filename, argv)


### PR DESCRIPTION
This PR adds a `Crystal::Repl#parse_and_interpret` method that is convenient to use the repl interpreter as library.

The current interpreter api seems lower level . The repl is, as expected, tight to getting the input from stdin.

The added spec shows how the repl can be instantiated and consumed as a library.