### PR TITLE
Support `-dynamic.lib` in Windows interpreter

### DIFF
--- a/spec/compiler/loader/msvc_spec.cr
+++ b/spec/compiler/loader/msvc_spec.cr
@@ -125,4 +125,30 @@ describe Crystal::Loader do
       end
     end
   end
+
+  describe "lib suffix" do
+    before_all do
+      FileUtils.mkdir_p(SPEC_CRYSTAL_LOADER_LIB_PATH)
+    end
+
+    after_all do
+      FileUtils.rm_rf(SPEC_CRYSTAL_LOADER_LIB_PATH)
+    end
+
+    it "respects -dynamic" do
+      build_c_dynlib(compiler_datapath("loader", "foo.c"), lib_name: "foo-dynamic")
+      loader = Crystal::Loader.new([SPEC_CRYSTAL_LOADER_LIB_PATH] of String)
+      loader.load_library?("foo").should be_true
+    ensure
+      loader.close_all if loader
+    end
+
+    it "ignores -static" do
+      build_c_dynlib(compiler_datapath("loader", "foo.c"), lib_name: "bar-static")
+      loader = Crystal::Loader.new([SPEC_CRYSTAL_LOADER_LIB_PATH] of String)
+      loader.load_library?("bar").should be_false
+    ensure
+      loader.close_all if loader
+    end
+  end
 end

--- a/spec/compiler/loader/spec_helper.cr
+++ b/spec/compiler/loader/spec_helper.cr
@@ -2,8 +2,8 @@ require "spec"
 
 SPEC_CRYSTAL_LOADER_LIB_PATH = File.join(SPEC_TEMPFILE_PATH, "loader")
 
-def build_c_dynlib(c_filename, target_dir = SPEC_CRYSTAL_LOADER_LIB_PATH)
-  o_filename = File.join(target_dir, Crystal::Loader.library_filename(File.basename(c_filename, ".c")))
+def build_c_dynlib(c_filename, *, lib_name = nil, target_dir = SPEC_CRYSTAL_LOADER_LIB_PATH)
+  o_filename = File.join(target_dir, Crystal::Loader.library_filename(lib_name || File.basename(c_filename, ".c")))
 
   {% if flag?(:msvc) %}
     o_basename = o_filename.rchop(".lib")


### PR DESCRIPTION
Like #13473, but for the interpreter; if there is a `@[Link("foo")]` annotation, then the interpreter will first look for `foo-dynamic.lib` before `foo.lib`. DLL lookup is unchanged, and `-static.lib` files are ignored. Fixes #13891.