### PR TITLE
Do not use `pointerof(Path)` in the standard library

### DIFF
--- a/src/crystal/system/win32/path.cr
+++ b/src/crystal/system/win32/path.cr
@@ -6,12 +6,16 @@ module Crystal::System::Path
   def self.home : String
     if home_path = ENV["USERPROFILE"]?.presence
       home_path
-    elsif LibC.SHGetKnownFolderPath(pointerof(LibC::FOLDERID_Profile), 0, nil, out path_ptr) == 0
-      home_path, _ = String.from_utf16(path_ptr)
-      LibC.CoTaskMemFree(path_ptr)
-      home_path
     else
-      raise RuntimeError.from_winerror("SHGetKnownFolderPath")
+      # TODO: interpreter doesn't implement pointerof(Path)` yet
+      folderid = LibC::FOLDERID_Profile
+      if LibC.SHGetKnownFolderPath(pointerof(folderid), 0, nil, out path_ptr) == 0
+        home_path, _ = String.from_utf16(path_ptr)
+        LibC.CoTaskMemFree(path_ptr)
+        home_path
+      else
+        raise RuntimeError.from_winerror("SHGetKnownFolderPath")
+      end
     end
   end
 end


### PR DESCRIPTION
This addresses a todo (?) in the interpreter which currently [blocks the interpreter on Windows](https://github.com/crystal-lang/crystal/issues/12396).

All other instances in the repository are in non-interpreted compiler specs.