### PR TITLE
Fix interpreter specs on Windows

### DIFF
--- a/spec/compiler/interpreter/lib_spec.cr
+++ b/spec/compiler/interpreter/lib_spec.cr
@@ -2,6 +2,22 @@
 require "./spec_helper"
 require "../loader/spec_helper"
 
+private def ldflags
+  {% if flag?(:win32) %}
+    "/LIBPATH:#{SPEC_CRYSTAL_LOADER_LIB_PATH} sum.lib"
+  {% else %}
+    "-L#{SPEC_CRYSTAL_LOADER_LIB_PATH} -lsum"
+  {% end %}
+end
+
+private def ldflags_with_backtick
+  {% if flag?(:win32) %}
+    "/LIBPATH:#{SPEC_CRYSTAL_LOADER_LIB_PATH} `powershell.exe -C Write-Host -NoNewline sum.lib`"
+  {% else %}
+    "-L#{SPEC_CRYSTAL_LOADER_LIB_PATH} -l`echo sum`"
+  {% end %}
+end
+
 describe Crystal::Repl::Interpreter do
   context "variadic calls" do
     before_all do
@@ -11,7 +27,7 @@ describe Crystal::Repl::Interpreter do
 
     it "promotes float" do
       interpret(<<-CRYSTAL).should eq 3.5
-        @[Link(ldflags: "-L#{SPEC_CRYSTAL_LOADER_LIB_PATH} -lsum")]
+        @[Link(ldflags: #{ldflags.inspect})]
         lib LibSum
           fun sum_float(count : Int32, ...) : Float32
         end
@@ -22,7 +38,7 @@ describe Crystal::Repl::Interpreter do
 
     it "promotes int" do
       interpret(<<-CRYSTAL).should eq 5
-        @[Link(ldflags: "-L#{SPEC_CRYSTAL_LOADER_LIB_PATH} -lsum")]
+        @[Link(ldflags: #{ldflags.inspect})]
         lib LibSum
           fun sum_int(count : Int32, ...) : Int32
         end
@@ -33,7 +49,7 @@ describe Crystal::Repl::Interpreter do
 
     it "promotes enum" do
       interpret(<<-CRYSTAL).should eq 5
-        @[Link(ldflags: "-L#{SPEC_CRYSTAL_LOADER_LIB_PATH} -lsum")]
+        @[Link(ldflags: #{ldflags.inspect})]
         lib LibSum
           fun sum_int(count : Int32, ...) : Int32
         end
@@ -63,7 +79,7 @@ describe Crystal::Repl::Interpreter do
 
     it "expands ldflags" do
       interpret(<<-CRYSTAL).should eq 4
-        @[Link(ldflags: "-L#{SPEC_CRYSTAL_LOADER_LIB_PATH} -l`echo sum`")]
+        @[Link(ldflags: #{ldflags_with_backtick.inspect})]
         lib LibSum
           fun simple_sum_int(a : Int32, b : Int32) : Int32
         end

--- a/spec/compiler/interpreter/spec_helper.cr
+++ b/spec/compiler/interpreter/spec_helper.cr
@@ -5,6 +5,7 @@ require "compiler/crystal/interpreter/*"
 def interpret(code, *, prelude = "primitives", file = __FILE__, line = __LINE__)
   if prelude == "primitives"
     context, value = interpret_with_context(code)
+    context.loader?.try &.close_all
     value.value
   else
     interpret_in_separate_process(code, prelude, file: file, line: line)

--- a/src/compiler/crystal/interpreter/context.cr
+++ b/src/compiler/crystal/interpreter/context.cr
@@ -46,6 +46,9 @@ class Crystal::Repl::Context
 
   def initialize(@program : Program)
     @program.flags << "interpreted"
+    {% if flag?(:win32) %}
+      @program.flags << "preview_dll"
+    {% end %}
 
     @gc_references = [] of Void*
 
@@ -391,6 +394,8 @@ class Crystal::Repl::Context
   def type_from_id(id : Int32) : Type
     @id_to_type[id]
   end
+
+  getter? loader : Loader?
 
   getter(loader : Loader) {
     lib_flags = program.lib_flags


### PR DESCRIPTION
This PR resolves the spec failures in `make -fMakefile.win interpreter_spec`. Probably depends on #14143 and #14144.

* Always adds the `preview_dll` flag when running the interpreter on Windows. This is fine, because eventually that flag's behavior will become the default, and what is now static linking by default will eventually require `--static`.
* Uses MSVC linker flags in the interpreter `@[Link]` specs.
* Ensures that interpreter specs running in the current process close all opened libraries in the `Crystal::Loader` instance after each run. This is necessary since any open handle to a DLL prevents Windows from deleting it, affecting spec cleanup. `Crystal::Loader` itself's specs do this already.

As a consequence, `make -fMakefile.win crystal interpreter=1` followed by `bin\crystal i` should now be enough to start a REPL session, although it seems there are still major issues getting interpreted stdlib specs to work.