### PR TITLE
Support absolute paths in `CRYSTAL_INTERPRETER_LOADER_INFO`

### DIFF
--- a/src/compiler/crystal/interpreter/context.cr
+++ b/src/compiler/crystal/interpreter/context.cr
@@ -405,13 +405,6 @@ class Crystal::Repl::Context
     args.delete("-lgc")
 
     Crystal::Loader.parse(args).tap do |loader|
-      if ENV["CRYSTAL_INTERPRETER_LOADER_INFO"]?.presence
-        STDERR.puts "Crystal::Loader loaded libraries:"
-        loader.loaded_libraries.each do |path|
-          STDERR.puts "      #{path}"
-        end
-      end
-
       # FIXME: Part 2: This is a workaround for initial integration of the interpreter:
       # We append a handle to the current executable (i.e. the compiler program)
       # to the loader's handle list. This gives the loader access to all the symbols in the compiler program,
@@ -421,7 +414,10 @@ class Crystal::Repl::Context
       loader.load_current_program_handle
 
       if ENV["CRYSTAL_INTERPRETER_LOADER_INFO"]?.presence
-        STDERR.puts "      current program handle"
+        STDERR.puts "Crystal::Loader loaded libraries:"
+        loader.loaded_libraries.each do |path|
+          STDERR.puts "      #{path}"
+        end
       end
     end
   }

--- a/src/compiler/crystal/loader/msvc.cr
+++ b/src/compiler/crystal/loader/msvc.cr
@@ -139,7 +139,7 @@ class Crystal::Loader
       return false unless handle
 
       @handles << handle
-      @loaded_libraries << dll
+      @loaded_libraries << (module_filename(handle) || dll)
     end
 
     true
@@ -157,6 +157,7 @@ class Crystal::Loader
   def load_current_program_handle
     if LibC.GetModuleHandleExW(0, nil, out hmodule) != 0
       @handles << hmodule
+      @loaded_libraries << (Process.executable_path || "current program handle")
     end
   end
 
@@ -165,6 +166,19 @@ class Crystal::Loader
       LibC.FreeLibrary(handle)
     end
     @handles.clear
+  end
+
+  private def module_filename(handle)
+    Crystal::System.retry_wstr_buffer do |buffer, small_buf|
+      len = LibC.GetModuleFileNameW(handle, buffer, buffer.size)
+      if 0 < len < buffer.size
+        break String.from_utf16(buffer[0, len])
+      elsif small_buf && len == buffer.size
+        next 32767 # big enough. 32767 is the maximum total path length of UNC path.
+      else
+        break nil
+      end
+    end
   end
 
   # Returns a list of directories used as the default search paths.

--- a/src/compiler/crystal/loader/unix.cr
+++ b/src/compiler/crystal/loader/unix.cr
@@ -120,6 +120,7 @@ class Crystal::Loader
   def load_current_program_handle
     if program_handle = LibC.dlopen(nil, LibC::RTLD_LAZY | LibC::RTLD_GLOBAL)
       @handles << program_handle
+      @loaded_libraries << (Process.executable_path || "current program handle")
     end
   end
 


### PR DESCRIPTION
This PR retrieves the actual paths for the DLLs loaded using an unqualified name (mainly system DLLs), as well as the current process handles. Using `Crystal::Loader` directly on Windows will now give something like this:

```
Crystal::Loader loaded libraries:
      C:\Users\nicet\AppData\Local\crystal\cache\gc.dll
      C:\Users\nicet\AppData\Local\crystal\cache\pcre2-8.dll
      C:\Users\nicet\AppData\Local\crystal\cache\libiconv.dll
      C:\WINDOWS\System32\KERNEL32.DLL
      C:\Users\nicet\AppData\Local\crystal\cache\crystal-run-test.exe.tmp.exe
```

Running the interpreter will give:

```
Crystal::Loader loaded libraries:
      C:\crystal\pcre2-8.dll
      C:\crystal\gc.dll
      C:\crystal\libiconv.dll
      C:\WINDOWS\System32\ADVAPI32.dll
      C:\WINDOWS\System32\SHELL32.dll
      C:\WINDOWS\System32\ole32.dll
      C:\WINDOWS\System32\WS2_32.dll
      C:\WINDOWS\System32\KERNEL32.DLL
      C:\WINDOWS\System32\ucrtbase.dll
      C:\Program Files\Microsoft Visual Studio\2022\Community\Common7\IDE\api-ms-win-crt-convert-l1-1-0.dll
      C:\Program Files\Microsoft Visual Studio\2022\Community\Common7\IDE\api-ms-win-crt-environment-l1-1-0.dll
      C:\Program Files\Microsoft Visual Studio\2022\Community\Common7\IDE\api-ms-win-crt-filesystem-l1-1-0.dll
      C:\Program Files\Microsoft Visual Studio\2022\Community\Common7\IDE\api-ms-win-crt-heap-l1-1-0.dll
      C:\Program Files\Microsoft Visual Studio\2022\Community\Common7\IDE\api-ms-win-crt-locale-l1-1-0.dll
      C:\Program Files\Microsoft Visual Studio\2022\Community\Common7\IDE\api-ms-win-crt-math-l1-1-0.dll
      C:\Program Files\Microsoft Visual Studio\2022\Community\Common7\IDE\api-ms-win-crt-multibyte-l1-1-0.dll
      C:\WINDOWS\System32\ucrtbase.dll
      C:\Program Files\Microsoft Visual Studio\2022\Community\Common7\IDE\api-ms-win-crt-runtime-l1-1-0.dll
      C:\Program Files\Microsoft Visual Studio\2022\Community\Common7\IDE\api-ms-win-crt-stdio-l1-1-0.dll
      C:\Program Files\Microsoft Visual Studio\2022\Community\Common7\IDE\api-ms-win-crt-string-l1-1-0.dll
      C:\Program Files\Microsoft Visual Studio\2022\Community\Common7\IDE\api-ms-win-crt-time-l1-1-0.dll
      C:\Program Files\Microsoft Visual Studio\2022\Community\Common7\IDE\api-ms-win-crt-utility-l1-1-0.dll
      C:\Users\nicet\crystal\crystal\.build\crystal.exe
```