### PR TITLE
Fix codegen error when discarding `is_a?` or `responds_to?`'s result

### DIFF
--- a/spec/compiler/codegen/is_a_spec.cr
+++ b/spec/compiler/codegen/is_a_spec.cr
@@ -45,6 +45,16 @@ describe "Codegen: is_a?" do
     run("1.is_a?(Object)").to_b.should be_true
   end
 
+  it "doesn't error if result is discarded (#14113)" do
+    run(<<-CRYSTAL).to_i.should eq(1)
+      class Foo
+      end
+
+      (Foo.new || "").is_a?(Foo)
+      1
+      CRYSTAL
+  end
+
   it "evaluate method on filtered type" do
     run("a = 1; a = 'a'; if a.is_a?(Char); a.ord; else; 0; end").to_i.chr.should eq('a')
   end

--- a/spec/compiler/codegen/responds_to_spec.cr
+++ b/spec/compiler/codegen/responds_to_spec.cr
@@ -51,6 +51,18 @@ describe "Codegen: responds_to?" do
       )).to_b.should be_false
   end
 
+  it "doesn't error if result is discarded (#14113)" do
+    run(<<-CRYSTAL).to_i.should eq(1)
+      class Foo
+        def foo
+        end
+      end
+
+      (Foo.new || "").responds_to?(:foo)
+      1
+      CRYSTAL
+  end
+
   it "works with virtual type" do
     run(%(
       class Foo

--- a/src/compiler/crystal/codegen/codegen.cr
+++ b/src/compiler/crystal/codegen/codegen.cr
@@ -1471,12 +1471,15 @@ module Crystal
 
     def codegen_type_filter(node, &)
       accept node.obj
-      obj_type = node.obj.type
 
-      type_id = type_id @last, obj_type
-      filtered_type = yield(obj_type).not_nil!
+      if @needs_value
+        obj_type = node.obj.type
 
-      @last = match_type_id obj_type, filtered_type, type_id
+        type_id = type_id @last, obj_type
+        filtered_type = yield(obj_type).not_nil!
+
+        @last = match_type_id obj_type, filtered_type, type_id
+      end
 
       false
     end


### PR DESCRIPTION
Fixes #14113.