### PR TITLE
Allow mixing of integers and pointers in `Crystal::System.print_error`

### DIFF
--- a/spec/std/crystal/system_spec.cr
+++ b/spec/std/crystal/system_spec.cr
@@ -42,5 +42,9 @@ describe "Crystal::System" do
       print_error_to_s("%lu,%lu,%llu,%llu", *values).should eq(values.join(','))
       print_error_to_s("%lx,%lx,%llx,%llx", *values).should eq(values.join(',', &.to_s(16)))
     end
+
+    it "can mix pointers and ints" do
+      print_error_to_s("%d,%p,%s", Pointer(UInt8).new(123), 0x456, "abc".to_unsafe.address).should eq("123,0x456,abc")
+    end
   end
 end

--- a/src/crystal/system/unix/signal.cr
+++ b/src/crystal/system/unix/signal.cr
@@ -149,7 +149,7 @@ module Crystal::System::Signal
     if is_stack_overflow
       Crystal::System.print_error "Stack overflow (e.g., infinite or very deep recursion)\n"
     else
-      Crystal::System.print_error "Invalid memory access (signal %d) at address 0x%lx\n", sig, addr
+      Crystal::System.print_error "Invalid memory access (signal %d) at address %p\n", sig, addr
     end
 
     Exception::CallStack.print_backtrace

--- a/src/exception/call_stack/libunwind.cr
+++ b/src/exception/call_stack/libunwind.cr
@@ -102,7 +102,7 @@ struct Exception::CallStack
   end
 
   private def self.print_frame(repeated_frame)
-    Crystal::System.print_error "[0x%llx] ", repeated_frame.ip.address.to_u64
+    Crystal::System.print_error "[%p] ", repeated_frame.ip
     print_frame_location(repeated_frame)
     Crystal::System.print_error " (%d times)", repeated_frame.count + 1 unless repeated_frame.count == 0
     Crystal::System.print_error "\n"

--- a/src/exception/call_stack/stackwalk.cr
+++ b/src/exception/call_stack/stackwalk.cr
@@ -37,7 +37,7 @@ struct Exception::CallStack
       case exception_info.value.exceptionRecord.value.exceptionCode
       when LibC::EXCEPTION_ACCESS_VIOLATION
         addr = exception_info.value.exceptionRecord.value.exceptionInformation[1]
-        Crystal::System.print_error "Invalid memory access (C0000005) at address 0x%llx\n", addr
+        Crystal::System.print_error "Invalid memory access (C0000005) at address %p\n", Pointer(Void).new(addr)
         print_backtrace(exception_info)
         LibC._exit(1)
       when LibC::EXCEPTION_STACK_OVERFLOW
@@ -150,7 +150,7 @@ struct Exception::CallStack
   end
 
   private def self.print_frame(repeated_frame)
-    Crystal::System.print_error "[0x%llx] ", repeated_frame.ip.address.to_u64
+    Crystal::System.print_error "[%p] ", repeated_frame.ip
     print_frame_location(repeated_frame)
     Crystal::System.print_error " (%d times)", repeated_frame.count + 1 unless repeated_frame.count == 0
     Crystal::System.print_error "\n"


### PR DESCRIPTION
When an external library calls `Crystal::System.print_error` with an argument, we do not have control over the argument type; in the case of Boehm GC, that argument is always an unsigned integer, even though the actual format specifier might be `%s` or `%p`. This PR makes those argument types interchangeable. (An integer or pointer is interpreted as the address to a null-terminated string for `%s`, never the address of a Crystal `String`.)

Also uses `%p` consistently in our own calls to `.print_error`.
