### PR TITLE
Add Crystal::Repl::Value#runtime_type

### DIFF
--- a/spec/compiler/crystal/tools/repl_spec.cr
+++ b/spec/compiler/crystal/tools/repl_spec.cr
@@ -19,6 +19,16 @@ describe Crystal::Repl do
   end
 
   describe "can return static and runtime type information for" do
+    it "Non Union" do
+      repl = Crystal::Repl.new
+      repl.prelude = "primitives"
+      repl.load_prelude
+
+      repl_value = success_value(repl.parse_and_interpret("1"))
+      repl_value.type.to_s.should eq("Int32")
+      repl_value.runtime_type.to_s.should eq("Int32")
+    end
+
     it "MixedUnionType" do
       repl = Crystal::Repl.new
       repl.prelude = "primitives"

--- a/spec/compiler/crystal/tools/repl_spec.cr
+++ b/spec/compiler/crystal/tools/repl_spec.cr
@@ -17,4 +17,26 @@ describe Crystal::Repl do
     success_value(repl.parse_and_interpret("def foo; 1 + 2; end")).value.should eq(nil)
     success_value(repl.parse_and_interpret("foo")).value.should eq(3)
   end
+
+  describe "can return static and runtime type information for" do
+    it "MixedUnionType" do
+      repl = Crystal::Repl.new
+      repl.prelude = "primitives"
+      repl.load_prelude
+
+      repl_value = success_value(repl.parse_and_interpret("1 || \"a\""))
+      repl_value.type.to_s.should eq("(Int32 | String)")
+      repl_value.runtime_type.to_s.should eq("Int32")
+    end
+
+    it "UnionType" do
+      repl = Crystal::Repl.new
+      repl.prelude = "primitives"
+      repl.load_prelude
+
+      repl_value = success_value(repl.parse_and_interpret("true || 1"))
+      repl_value.type.to_s.should eq("(Bool | Int32)")
+      repl_value.runtime_type.to_s.should eq("Bool")
+    end
+  end
 end

--- a/src/compiler/crystal/interpreter/value.cr
+++ b/src/compiler/crystal/interpreter/value.cr
@@ -67,6 +67,15 @@ struct Crystal::Repl::Value
     end
   end
 
+  def runtime_type : Crystal::Type
+    if type.is_a?(Crystal::UnionType)
+      type_id = @pointer.as(Int32*).value
+      context.type_from_id(type_id)
+    else
+      type
+    end
+  end
+
   # Copies the contents of this value to another pointer.
   def copy_to(pointer : Pointer(UInt8))
     @pointer.copy_to(pointer, context.inner_sizeof_type(@type))


### PR DESCRIPTION
This PR adds `Crystal::Repl::Value#runtime_type` 

This can be used to show type information as part of the repl or others clients: eg `1 :: Int32 <: (String | Int32)` when instructed (I'm not fully sure about the syntax)