### PR TITLE
Fix OpenSSL error handling for EOF (support for OpenSSL 3.2)

### DIFF
--- a/src/openssl.cr
+++ b/src/openssl.cr
@@ -90,7 +90,8 @@ module OpenSSL
           @code, message = fetch_error_details
           if @code == 0
             errno = {% if flag?(:win32?) %} WinError.wsa_value {% else %} Errno.value {% end %}
-            if {% if flag?(:win32) %} errno.error_success? {% else %} errno.none? {% end %}
+            success = {% if flag?(:win32) %} errno.error_success? {% else %} errno.none? {% end %}
+            if success
               message = "Unexpected EOF"
               @underlying_eof = true
             else

--- a/src/openssl.cr
+++ b/src/openssl.cr
@@ -89,15 +89,13 @@ module OpenSSL
         when .syscall?
           @code, message = fetch_error_details
           if @code == 0
-            case return_code
-            when 0
+            errno = Errno.value
+            if errno.none?
               message = "Unexpected EOF"
               @underlying_eof = true
-            when -1
-              cause = RuntimeError.from_errno(func || "OpenSSL")
-              message = "I/O error"
             else
-              message = "Unknown error"
+              cause = RuntimeError.from_os_error(func || "OpenSSL", os_error: errno)
+              message = "I/O error"
             end
           end
         when .ssl?

--- a/src/openssl.cr
+++ b/src/openssl.cr
@@ -89,8 +89,8 @@ module OpenSSL
         when .syscall?
           @code, message = fetch_error_details
           if @code == 0
-            errno = Errno.value
-            if errno.none?
+            errno = {% if flag?(:win32?) %} WinError.wsa_value {% else %} Errno.value {% end %}
+            if {% if flag?(:win32) %} errno.error_success? {% else %} errno.none? {% end %}
               message = "Unexpected EOF"
               @underlying_eof = true
             else

--- a/src/openssl.cr
+++ b/src/openssl.cr
@@ -89,7 +89,7 @@ module OpenSSL
         when .syscall?
           @code, message = fetch_error_details
           if @code == 0
-            errno = {% if flag?(:win32?) %} WinError.wsa_value {% else %} Errno.value {% end %}
+            errno = {% if flag?(:win32) %} WinError.wsa_value {% else %} Errno.value {% end %}
             success = {% if flag?(:win32) %} errno.error_success? {% else %} errno.none? {% end %}
             if success
               message = "Unexpected EOF"


### PR DESCRIPTION
This is following the reasoning from https://github.com/crystal-lang/crystal/issues/14168#issuecomment-1877224928

I'm not entirely sure this is exactly correct API usage. The documentation is not very extensive. But judging from the resulting behaviour, and backed by available documentation it seems to be more correct than the current implementation.