### PR TITLE
Move most of spec runner's state into `Spec::CLI`

### DIFF
--- a/spec/compiler/interpreter/spec_helper.cr
+++ b/spec/compiler/interpreter/spec_helper.cr
@@ -24,18 +24,20 @@ end
 # In a nutshell, `interpret_in_separate_process` below calls this same process with an extra option that causes
 # the interpretation of the code from stdin, reading the output from stdout. That string is used as the result of
 # the program being tested.
-def Spec.option_parser
-  option_parser = previous_def
-  option_parser.on("", "--interpret-code PRELUDE", "Execute interpreted code") do |prelude|
-    code = STDIN.gets_to_end
+class Spec::CLI
+  def option_parser
+    option_parser = previous_def
+    option_parser.on("", "--interpret-code PRELUDE", "Execute interpreted code") do |prelude|
+      code = STDIN.gets_to_end
 
-    repl = Crystal::Repl.new
-    repl.prelude = prelude
+      repl = Crystal::Repl.new
+      repl.prelude = prelude
 
-    print repl.run_code(code)
-    exit
+      print repl.run_code(code)
+      exit
+    end
+    option_parser
   end
-  option_parser
 end
 
 def interpret_in_separate_process(code, prelude, file = __FILE__, line = __LINE__)

--- a/spec/std/log/env_config_spec.cr
+++ b/spec/std/log/env_config_spec.cr
@@ -10,7 +10,7 @@ end
 describe "Log.setup_from_env" do
   after_all do
     # Setup logging in specs (again) since these specs perform Log.setup
-    Spec.log_setup
+    Spec.cli.log_setup
   end
 
   describe "backend" do

--- a/src/compiler/crystal/command/spec.cr
+++ b/src/compiler/crystal/command/spec.cr
@@ -24,7 +24,7 @@ class Crystal::Command
         puts opts
         puts
 
-        runtime_options = Spec.option_parser
+        runtime_options = Spec::CLI.new.option_parser
         runtime_options.banner = "Runtime options (passed to spec runner):"
         puts runtime_options
         exit

--- a/src/spec.cr
+++ b/src/spec.cr
@@ -91,45 +91,51 @@ require "./spec/cli"
 # value can be used to rerun the specs in that same order by passing the seed
 # value to `--order`.
 module Spec
-end
+  # :nodoc:
+  class CLI
+    # :nodoc:
+    #
+    # Implement formatter configuration.
+    def configure_formatter(formatter, output_path = nil)
+      case formatter
+      when "junit"
+        junit_formatter = Spec::JUnitFormatter.file(Path.new(output_path.not_nil!))
+        add_formatter(junit_formatter)
+      when "verbose"
+        override_default_formatter(Spec::VerboseFormatter.new)
+      when "tap"
+        override_default_formatter(Spec::TAPFormatter.new)
+      end
+    end
 
-Colorize.on_tty_only!
+    def main(args)
+      Colorize.on_tty_only!
 
-# :nodoc:
-#
-# Implement formatter configuration.
-def Spec.configure_formatter(formatter, output_path = nil)
-  case formatter
-  when "junit"
-    junit_formatter = Spec::JUnitFormatter.file(Path.new(output_path.not_nil!))
-    Spec.add_formatter(junit_formatter)
-  when "verbose"
-    Spec.override_default_formatter(Spec::VerboseFormatter.new)
-  when "tap"
-    Spec.override_default_formatter(Spec::TAPFormatter.new)
+      begin
+        option_parser.parse(args)
+      rescue e : OptionParser::InvalidOption
+        abort("Error: #{e.message}")
+      end
+
+      unless args.empty?
+        STDERR.puts "Error: unknown argument '#{args.first}'"
+        exit 1
+      end
+
+      if ENV["SPEC_VERBOSE"]? == "1"
+        override_default_formatter(Spec::VerboseFormatter.new)
+      end
+
+      add_split_filter ENV["SPEC_SPLIT"]?
+
+      {% unless flag?(:wasm32) %}
+        # TODO(wasm): Enable this once `Process.on_interrupt` is implemented
+        Process.on_interrupt { abort! }
+      {% end %}
+
+      run
+    end
   end
 end
 
-begin
-  Spec.option_parser.parse(ARGV)
-rescue e : OptionParser::InvalidOption
-  abort("Error: #{e.message}")
-end
-
-unless ARGV.empty?
-  STDERR.puts "Error: unknown argument '#{ARGV.first}'"
-  exit 1
-end
-
-if ENV["SPEC_VERBOSE"]? == "1"
-  Spec.override_default_formatter(Spec::VerboseFormatter.new)
-end
-
-Spec.add_split_filter ENV["SPEC_SPLIT"]?
-
-{% unless flag?(:wasm32) %}
-  # TODO(wasm): Enable this once `Process.on_interrupt` is implemented
-  Process.on_interrupt { Spec.abort! }
-{% end %}
-
-Spec.run
+Spec.cli.main(ARGV)

--- a/src/spec/cli.cr
+++ b/src/spec/cli.cr
@@ -1,139 +1,130 @@
 require "option_parser"
+require "colorize"
 
 # This file is included in the compiler to add usage instructions for the
 # spec runner on `crystal spec --help`.
 
 module Spec
   # :nodoc:
-  class_property pattern : Regex?
-
-  # :nodoc:
-  class_property line : Int32?
-
-  # :nodoc:
-  class_property slowest : Int32?
-
-  # :nodoc:
-  class_property? fail_fast = false
-
-  # :nodoc:
-  class_property? focus = false
-
-  # :nodoc:
-  class_property? dry_run = false
-
-  # :nodoc:
-  class_property? list_tags = false
-
-  # :nodoc:
-  def self.add_location(file, line)
-    locations = @@locations ||= {} of String => Array(Int32)
-    locations.put_if_absent(File.expand_path(file)) { [] of Int32 } << line
-  end
-
-  # :nodoc:
-  def self.add_tag(tag)
-    if anti_tag = tag.lchop?('~')
-      (@@anti_tags ||= Set(String).new) << anti_tag
-    else
-      (@@tags ||= Set(String).new) << tag
-    end
-  end
-
-  # :nodoc:
-  class_getter randomizer_seed : UInt64?
-  class_getter randomizer : Random::PCG32?
-
-  # :nodoc:
-  def self.order=(mode)
-    seed =
-      case mode
-      when "default"
-        nil
-      when "random"
-        Random::Secure.rand(1..99999).to_u64 # 5 digits or less for simplicity
-      when UInt64
-        mode
-      else
-        raise ArgumentError.new("Order must be either 'default', 'random', or a numeric seed value")
-      end
-
-    @@randomizer_seed = seed
-    @@randomizer = seed ? Random::PCG32.new(seed) : nil
-  end
-
-  # :nodoc:
-  class_property option_parser : OptionParser = begin
-    OptionParser.new do |opts|
-      opts.banner = "crystal spec runner"
-      opts.on("-e", "--example STRING", "run examples whose full nested names include STRING") do |pattern|
-        Spec.pattern = Regex.new(Regex.escape(pattern))
-      end
-      opts.on("-l", "--line LINE", "run examples whose line matches LINE") do |line|
-        Spec.line = line.to_i
-      end
-      opts.on("-p", "--profile", "Print the 10 slowest specs") do
-        Spec.slowest = 10
-      end
-      opts.on("--fail-fast", "abort the run on first failure") do
-        Spec.fail_fast = true
-      end
-      opts.on("--location file:line", "run example at line 'line' in file 'file', multiple allowed") do |location|
-        if location =~ /\A(.+?)\:(\d+)\Z/
-          Spec.add_location $1, $2.to_i
-        else
-          STDERR.puts "location #{location} must be file:line"
-          exit 1
-        end
-      end
-      opts.on("--tag TAG", "run examples with the specified TAG, or exclude examples by adding ~ before the TAG.") do |tag|
-        Spec.add_tag tag
-      end
-      opts.on("--list-tags", "lists all the tags used.") do
-        Spec.list_tags = true
-      end
-      opts.on("--order MODE", "run examples in random order by passing MODE as 'random' or to a specific seed by passing MODE as the seed value") do |mode|
-        if mode.in?("default", "random")
-          Spec.order = mode
-        elsif seed = mode.to_u64?
-          Spec.order = seed
-        else
-          abort("order must be either 'default', 'random', or a numeric seed value")
-        end
-      end
-      opts.on("--junit_output OUTPUT_PATH", "generate JUnit XML output within the given OUTPUT_PATH") do |output_path|
-        configure_formatter("junit", output_path)
-      end
-      opts.on("-h", "--help", "show this help") do |pattern|
-        puts opts
-        exit
-      end
-      opts.on("-v", "--verbose", "verbose output") do
-        configure_formatter("verbose")
-      end
-      opts.on("--tap", "Generate TAP output (Test Anything Protocol)") do
-        configure_formatter("tap")
-      end
-      opts.on("--color", "Enabled ANSI colored output") do
-        Colorize.enabled = true
-      end
-      opts.on("--no-color", "Disable ANSI colored output") do
-        Colorize.enabled = false
-      end
-      opts.on("--dry-run", "Pass all tests without execution") do
-        Spec.dry_run = true
-      end
-      opts.unknown_args do |args|
-      end
-    end
-  end
-
-  # :nodoc:
   #
-  # Blank implementation to reduce the interface of spec's option parser for
-  # inclusion in the compiler. This avoids depending on more of `Spec`
-  # module.
-  # The real implementation in `../spec.cr` overrides this for actual use.
-  def self.configure_formatter(formatter, output_path = nil)
+  # Configuration for a spec runner. More global state is defined in `./dsl.cr`.
+  class CLI
+    getter pattern : Regex?
+    getter line : Int32?
+    getter slowest : Int32?
+    getter? fail_fast = false
+    property? focus = false
+    getter? dry_run = false
+    getter? list_tags = false
+
+    def add_location(file, line)
+      locations = @locations ||= {} of String => Array(Int32)
+      locations.put_if_absent(File.expand_path(file)) { [] of Int32 } << line
+    end
+
+    def add_tag(tag)
+      if anti_tag = tag.lchop?('~')
+        (@anti_tags ||= Set(String).new) << anti_tag
+      else
+        (@tags ||= Set(String).new) << tag
+      end
+    end
+
+    getter randomizer_seed : UInt64?
+    getter randomizer : Random::PCG32?
+
+    def order=(mode)
+      seed =
+        case mode
+        when "default"
+          nil
+        when "random"
+          Random::Secure.rand(1..99999).to_u64 # 5 digits or less for simplicity
+        when UInt64
+          mode
+        else
+          raise ArgumentError.new("Order must be either 'default', 'random', or a numeric seed value")
+        end
+
+      @randomizer_seed = seed
+      @randomizer = seed ? Random::PCG32.new(seed) : nil
+    end
+
+    def option_parser : OptionParser
+      @option_parser ||= OptionParser.new do |opts|
+        opts.banner = "crystal spec runner"
+        opts.on("-e", "--example STRING", "run examples whose full nested names include STRING") do |pattern|
+          @pattern = Regex.new(Regex.escape(pattern))
+        end
+        opts.on("-l", "--line LINE", "run examples whose line matches LINE") do |line|
+          @line = line.to_i
+        end
+        opts.on("-p", "--profile", "Print the 10 slowest specs") do
+          @slowest = 10
+        end
+        opts.on("--fail-fast", "abort the run on first failure") do
+          @fail_fast = true
+        end
+        opts.on("--location file:line", "run example at line 'line' in file 'file', multiple allowed") do |location|
+          if location =~ /\A(.+?)\:(\d+)\Z/
+            add_location $1, $2.to_i
+          else
+            STDERR.puts "location #{location} must be file:line"
+            exit 1
+          end
+        end
+        opts.on("--tag TAG", "run examples with the specified TAG, or exclude examples by adding ~ before the TAG.") do |tag|
+          add_tag tag
+        end
+        opts.on("--list-tags", "lists all the tags used.") do
+          @list_tags = true
+        end
+        opts.on("--order MODE", "run examples in random order by passing MODE as 'random' or to a specific seed by passing MODE as the seed value") do |mode|
+          if mode.in?("default", "random")
+            self.order = mode
+          elsif seed = mode.to_u64?
+            self.order = seed
+          else
+            abort("order must be either 'default', 'random', or a numeric seed value")
+          end
+        end
+        opts.on("--junit_output OUTPUT_PATH", "generate JUnit XML output within the given OUTPUT_PATH") do |output_path|
+          configure_formatter("junit", output_path)
+        end
+        opts.on("-h", "--help", "show this help") do |pattern|
+          puts opts
+          exit
+        end
+        opts.on("-v", "--verbose", "verbose output") do
+          configure_formatter("verbose")
+        end
+        opts.on("--tap", "Generate TAP output (Test Anything Protocol)") do
+          configure_formatter("tap")
+        end
+        opts.on("--color", "Enabled ANSI colored output") do
+          Colorize.enabled = true
+        end
+        opts.on("--no-color", "Disable ANSI colored output") do
+          Colorize.enabled = false
+        end
+        opts.on("--dry-run", "Pass all tests without execution") do
+          @dry_run = true
+        end
+        opts.unknown_args do |args|
+        end
+      end
+    end
+
+    # Blank implementation to reduce the interface of spec's option parser for
+    # inclusion in the compiler. This avoids depending on more of `Spec`
+    # module.
+    # The real implementation in `../spec.cr` overrides this for actual use.
+    def configure_formatter(formatter, output_path = nil)
+    end
+  end
+
+  @[Deprecated("This is an internal API.")]
+  def self.randomizer : Random::PCG32?
+    @@cli.randomizer
   end
 end

--- a/src/spec/context.cr
+++ b/src/spec/context.cr
@@ -126,13 +126,15 @@ module Spec
     exception : Exception?
 
   # :nodoc:
-  def self.root_context
-    RootContext.instance
-  end
+  class CLI
+    def root_context
+      RootContext.instance
+    end
 
-  # :nodoc:
-  def self.current_context : Context
-    RootContext.current_context
+    # :nodoc:
+    def current_context : Context
+      RootContext.current_context
+    end
   end
 
   # :nodoc:
@@ -167,7 +169,7 @@ module Spec
     end
 
     def report_formatters(result)
-      Spec.formatters.each(&.report(result))
+      Spec.cli.formatters.each(&.report(result))
     end
 
     def succeeded
@@ -175,8 +177,8 @@ module Spec
     end
 
     def finish(elapsed_time, aborted = false)
-      Spec.formatters.each(&.finish(elapsed_time, aborted))
-      Spec.formatters.each(&.print_results(elapsed_time, aborted))
+      Spec.cli.formatters.each(&.finish(elapsed_time, aborted))
+      Spec.cli.formatters.each(&.print_results(elapsed_time, aborted))
     end
 
     def print_results(elapsed_time, aborted = false)
@@ -223,13 +225,13 @@ module Spec
         end
       end
 
-      if Spec.slowest
+      if Spec.cli.slowest
         puts
         results = results_for(:success) + results_for(:fail)
-        top_n = results.sort_by { |res| -res.elapsed.not_nil!.to_f }[0..Spec.slowest.not_nil!]
+        top_n = results.sort_by { |res| -res.elapsed.not_nil!.to_f }[0..Spec.cli.slowest.not_nil!]
         top_n_time = top_n.sum &.elapsed.not_nil!.total_seconds
         percent = (top_n_time * 100) / elapsed_time.total_seconds
-        puts "Top #{Spec.slowest} slowest examples (#{top_n_time.humanize} seconds, #{percent.round(2)}% of total time):"
+        puts "Top #{Spec.cli.slowest} slowest examples (#{top_n_time.humanize} seconds, #{percent.round(2)}% of total time):"
         top_n.each do |res|
           puts "  #{res.description}"
           res_elapsed = res.elapsed.not_nil!.total_seconds.humanize
@@ -252,7 +254,7 @@ module Spec
       puts "Aborted!".colorize.red if aborted
       puts "Finished in #{Spec.to_human(elapsed_time)}"
       puts Spec.color("#{total} examples, #{failures.size} failures, #{errors.size} errors, #{pendings.size} pending", final_status)
-      puts Spec.color("Only running `focus: true`", :focus) if Spec.focus?
+      puts Spec.color("Only running `focus: true`", :focus) if Spec.cli.focus?
 
       unless failures_and_errors.empty?
         puts
@@ -268,13 +270,13 @@ module Spec
     end
 
     def print_order_message
-      if randomizer_seed = Spec.randomizer_seed
+      if randomizer_seed = Spec.cli.randomizer_seed
         puts Spec.color("Randomized with seed: #{randomizer_seed}", :order)
       end
     end
 
     def describe(description, file, line, end_line, focus, tags, &block)
-      Spec.focus = true if focus
+      Spec.cli.focus = true if focus
 
       context = Spec::ExampleGroup.new(@@current_context, description, file, line, end_line, focus, tags)
       @@current_context.children << context
@@ -298,7 +300,7 @@ module Spec
 
     private def add_example(description, file, line, end_line, focus, tags, block)
       check_nesting_spec(file, line) do
-        Spec.focus = true if focus
+        Spec.cli.focus = true if focus
         @@current_context.children <<
           Example.new(@@current_context, description, file, line, end_line, focus, tags, block)
       end
@@ -334,12 +336,12 @@ module Spec
 
     # :nodoc:
     def run
-      Spec.formatters.each(&.push(self))
+      Spec.cli.formatters.each(&.push(self))
 
       ran = run_around_all_hooks(ExampleGroup::Procsy.new(self) { internal_run })
       ran || internal_run
 
-      Spec.formatters.each(&.pop)
+      Spec.cli.formatters.each(&.pop)
     end
 
     protected def report(status : Status, description, file, line, elapsed = nil, ex = nil)

--- a/src/spec/dsl.cr
+++ b/src/spec/dsl.cr
@@ -3,6 +3,10 @@ require "option_parser"
 
 module Spec
   # :nodoc:
+  # The default spec runner.
+  class_getter cli = CLI.new
+
+  # :nodoc:
   enum InfoKind
     Comment
     Focus
@@ -61,14 +65,6 @@ module Spec
   class NestingSpecError < SpecError
   end
 
-  @@aborted = false
-
-  # :nodoc:
-  def self.abort!
-    @@aborted = true
-    finish_run
-  end
-
   # :nodoc:
   def self.to_human(span : Time::Span)
     total_milliseconds = span.total_milliseconds
@@ -92,17 +88,6 @@ module Spec
 
   record SplitFilter, remainder : Int32, quotient : Int32
 
-  @@split_filter : SplitFilter? = nil
-
-  def self.add_split_filter(filter)
-    if filter
-      r, _, m = filter.partition('%')
-      @@split_filter = SplitFilter.new(remainder: r.to_i, quotient: m.to_i)
-    else
-      @@split_filter = nil
-    end
-  end
-
   # Instructs the spec runner to execute the given block
   # before each spec in the spec suite.
   #
@@ -118,7 +103,7 @@ module Spec
   #
   # will print, just before each spec, 1 and then 2.
   def self.before_each(&block)
-    root_context.before_each(&block)
+    @@cli.root_context.before_each(&block)
   end
 
   # Instructs the spec runner to execute the given block
@@ -136,7 +121,7 @@ module Spec
   #
   # will print, just after each spec, 2 and then 1.
   def self.after_each(&block)
-    root_context.after_each(&block)
+    @@cli.root_context.after_each(&block)
   end
 
   # Instructs the spec runner to execute the given block
@@ -154,7 +139,7 @@ module Spec
   #
   # will print, just before the spec suite starts, 1 and then 2.
   def self.before_suite(&block)
-    root_context.before_all(&block)
+    @@cli.root_context.before_all(&block)
   end
 
   # Instructs the spec runner to execute the given block
@@ -172,7 +157,7 @@ module Spec
   #
   # will print, just after the spec suite ends, 2 and then 1.
   def self.after_suite(&block)
-    root_context.after_all(&block)
+    @@cli.root_context.after_all(&block)
   end
 
   # Instructs the spec runner to execute the given block when each spec in the
@@ -196,129 +181,157 @@ module Spec
   # it { }
   # ```
   def self.around_each(&block : Example::Procsy ->)
-    root_context.around_each(&block)
+    @@cli.root_context.around_each(&block)
   end
 
-  @@start_time : Time::Span? = nil
-
   # :nodoc:
-  def self.run
-    @@start_time = Time.monotonic
+  class CLI
+    @aborted = false
 
-    at_exit do |status|
-      # Do not run specs if the process is exiting on an error
-      next unless status == 0
+    def abort!
+      @aborted = true
+      finish_run
+    end
 
-      begin
-        if Spec.list_tags?
-          execute_list_tags
-        else
-          execute_examples
-        end
-      rescue ex
-        STDERR.print "Unhandled exception: "
-        ex.inspect_with_backtrace(STDERR)
-        STDERR.flush
-        @@aborted = true
-      ensure
-        finish_run unless Spec.list_tags?
+    @split_filter : SplitFilter? = nil
+
+    def add_split_filter(filter)
+      if filter
+        r, _, m = filter.partition('%')
+        @split_filter = SplitFilter.new(remainder: r.to_i, quotient: m.to_i)
+      else
+        @split_filter = nil
       end
     end
-  end
 
-  # :nodoc:
-  def self.execute_examples
-    log_setup
-    maybe_randomize
-    run_filters
-    root_context.run
-  end
+    @start_time : Time::Span? = nil
 
-  # :nodoc:
-  def self.execute_list_tags
-    run_filters
-    tag_counts = collect_tags(root_context)
-    print_list_tags(tag_counts)
-  end
+    def run
+      @start_time = Time.monotonic
 
-  private def self.collect_tags(context) : Hash(String, Int32)
-    tag_counts = Hash(String, Int32).new(0)
-    collect_tags(tag_counts, context, Set(String).new)
-    tag_counts
-  end
+      at_exit do |status|
+        # Do not run specs if the process is exiting on an error
+        next unless status == 0
 
-  private def self.collect_tags(tag_counts, context : Context, tags)
-    if context.responds_to?(:tags) && (context_tags = context.tags)
-      tags += context_tags
+        begin
+          if list_tags?
+            execute_list_tags
+          else
+            execute_examples
+          end
+        rescue ex
+          STDERR.print "Unhandled exception: "
+          ex.inspect_with_backtrace(STDERR)
+          STDERR.flush
+          @aborted = true
+        ensure
+          finish_run unless list_tags?
+        end
+      end
     end
-    context.children.each do |child|
-      collect_tags(tag_counts, child, tags)
+
+    def execute_examples
+      log_setup
+      maybe_randomize
+      run_filters
+      root_context.run
     end
-  end
 
-  private def self.collect_tags(tag_counts, example : Example, tags)
-    if example_tags = example.tags
-      tags += example_tags
+    def execute_list_tags
+      run_filters
+      tag_counts = collect_tags(root_context)
+      print_list_tags(tag_counts)
     end
-    if tags.empty?
-      tag_counts.update("untagged") { |count| count + 1 }
-    else
-      tags.tally(tag_counts)
+
+    private def collect_tags(context) : Hash(String, Int32)
+      tag_counts = Hash(String, Int32).new(0)
+      collect_tags(tag_counts, context, Set(String).new)
+      tag_counts
     end
-  end
 
-  private def self.print_list_tags(tag_counts : Hash(String, Int32)) : Nil
-    return if tag_counts.empty?
-    longest_name_size = tag_counts.keys.max_of(&.size)
-    tag_counts.to_a.sort_by! { |k, v| {-v, k} }.each do |tag_name, count|
-      puts "#{tag_name.rjust(longest_name_size)}: #{count}"
+    private def collect_tags(tag_counts, context : Context, tags)
+      if context.responds_to?(:tags) && (context_tags = context.tags)
+        tags += context_tags
+      end
+      context.children.each do |child|
+        collect_tags(tag_counts, child, tags)
+      end
     end
-  end
 
-  # :nodoc:
-  #
-  # Workaround for #8914
-  private macro defined?(t)
-    {% if t.resolve? %}
-      {{ yield }}
-    {% end %}
-  end
+    private def collect_tags(tag_counts, example : Example, tags)
+      if example_tags = example.tags
+        tags += example_tags
+      end
+      if tags.empty?
+        tag_counts.update("untagged") { |count| count + 1 }
+      else
+        tags.tally(tag_counts)
+      end
+    end
 
-  # :nodoc:
-  def self.log_setup
-  end
+    private def print_list_tags(tag_counts : Hash(String, Int32)) : Nil
+      return if tag_counts.empty?
+      longest_name_size = tag_counts.keys.max_of(&.size)
+      tag_counts.to_a.sort_by! { |k, v| {-v, k} }.each do |tag_name, count|
+        puts "#{tag_name.rjust(longest_name_size)}: #{count}"
+      end
+    end
 
-  # :nodoc:
-  macro finished
     # :nodoc:
     #
-    # Initialized the log module for the specs.
-    # If the "log" module is required it is configured to emit no entries by default.
-    def self.log_setup
-      defined?(::Log) do
-        if Log.responds_to?(:setup)
-          Log.setup_from_env(default_level: :none)
+    # Workaround for #8914
+    private macro defined?(t)
+      {% if t.resolve? %}
+        {{ yield }}
+      {% end %}
+    end
+
+    # :nodoc:
+    def log_setup
+    end
+
+    # :nodoc:
+    macro finished
+      # :nodoc:
+      #
+      # Initialized the log module for the specs.
+      # If the "log" module is required it is configured to emit no entries by default.
+      def log_setup
+        defined?(::Log) do
+          if Log.responds_to?(:setup)
+            Log.setup_from_env(default_level: :none)
+          end
         end
       end
     end
-  end
 
-  def self.finish_run
-    elapsed_time = Time.monotonic - @@start_time.not_nil!
-    root_context.finish(elapsed_time, @@aborted)
-    exit 1 if !root_context.succeeded || @@aborted || (focus? && ENV["SPEC_FOCUS_NO_FAIL"]? != "1")
-  end
+    def finish_run
+      elapsed_time = Time.monotonic - @start_time.not_nil!
+      root_context.finish(elapsed_time, @aborted)
+      exit 1 if !root_context.succeeded || @aborted || (focus? && ENV["SPEC_FOCUS_NO_FAIL"]? != "1")
+    end
 
-  # :nodoc:
-  def self.maybe_randomize
-    if randomizer = @@randomizer
-      root_context.randomize(randomizer)
+    # :nodoc:
+    def maybe_randomize
+      if randomizer = @randomizer
+        root_context.randomize(randomizer)
+      end
+    end
+
+    # :nodoc:
+    def run_filters
+      root_context.run_filters(@pattern, @line, @locations, @split_filter, @focus, @tags, @anti_tags)
     end
   end
 
-  # :nodoc:
-  def self.run_filters
-    root_context.run_filters(@@pattern, @@line, @@locations, @@split_filter, @@focus, @@tags, @@anti_tags)
+  @[Deprecated("This is an internal API.")]
+  def self.finish_run
+    @@cli.finish_run
+  end
+
+  @[Deprecated("This is an internal API.")]
+  def self.add_split_filter(filter)
+    @@cli.add_split_filter(filter)
   end
 end
 

--- a/src/spec/example.cr
+++ b/src/spec/example.cr
@@ -18,10 +18,10 @@ module Spec
 
     # :nodoc:
     def run
-      Spec.root_context.check_nesting_spec(file, line) do
-        Spec.formatters.each(&.before_example(description))
+      Spec.cli.root_context.check_nesting_spec(file, line) do
+        Spec.cli.formatters.each(&.before_example(description))
 
-        if Spec.dry_run?
+        if Spec.cli.dry_run?
           @parent.report(:success, description, file, line)
           return
         end
@@ -51,12 +51,12 @@ module Spec
       @parent.report(:success, description, file, line, Time.monotonic - start)
     rescue ex : Spec::AssertionFailed
       @parent.report(:fail, description, file, line, Time.monotonic - start, ex)
-      Spec.abort! if Spec.fail_fast?
+      Spec.cli.abort! if Spec.cli.fail_fast?
     rescue ex : Spec::ExamplePending
       @parent.report(:pending, description, file, line, Time.monotonic - start)
     rescue ex
       @parent.report(:error, description, file, line, Time.monotonic - start, ex)
-      Spec.abort! if Spec.fail_fast?
+      Spec.cli.abort! if Spec.cli.fail_fast?
     ensure
       @parent.run_after_each_hooks
     end

--- a/src/spec/formatter.cr
+++ b/src/spec/formatter.cr
@@ -55,7 +55,7 @@ module Spec
     end
 
     def print_results(elapsed_time : Time::Span, aborted : Bool)
-      Spec.root_context.print_results(elapsed_time, aborted)
+      Spec.cli.root_context.print_results(elapsed_time, aborted)
     end
   end
 
@@ -111,22 +111,34 @@ module Spec
     end
 
     def print_results(elapsed_time : Time::Span, aborted : Bool)
-      Spec.root_context.print_results(elapsed_time, aborted)
+      Spec.cli.root_context.print_results(elapsed_time, aborted)
     end
   end
 
-  @@formatters = [Spec::DotFormatter.new] of Spec::Formatter
-
   # :nodoc:
-  def self.formatters
-    @@formatters
+  class CLI
+    @formatters = [Spec::DotFormatter.new] of Spec::Formatter
+
+    def formatters
+      @formatters
+    end
+
+    def override_default_formatter(formatter)
+      @formatters[0] = formatter
+    end
+
+    def add_formatter(formatter)
+      @formatters << formatter
+    end
   end
 
+  @[Deprecated("This is an internal API.")]
   def self.override_default_formatter(formatter)
-    @@formatters[0] = formatter
+    @@cli.override_default_formatter(formatter)
   end
 
+  @[Deprecated("This is an internal API.")]
   def self.add_formatter(formatter)
-    @@formatters << formatter
+    @@cli.add_formatter(formatter)
   end
 end

--- a/src/spec/methods.cr
+++ b/src/spec/methods.cr
@@ -17,7 +17,7 @@ module Spec::Methods
   #
   # If `focus` is `true`, only this `describe`, and others marked with `focus: true`, will run.
   def describe(description = nil, file = __FILE__, line = __LINE__, end_line = __END_LINE__, focus : Bool = false, tags : String | Enumerable(String) | Nil = nil, &block)
-    Spec.root_context.describe(description.to_s, file, line, end_line, focus, tags, &block)
+    Spec.cli.root_context.describe(description.to_s, file, line, end_line, focus, tags, &block)
   end
 
   # Defines an example group that establishes a specific context,
@@ -46,7 +46,7 @@ module Spec::Methods
   #
   # If `focus` is `true`, only this test, and others marked with `focus: true`, will run.
   def it(description = "assert", file = __FILE__, line = __LINE__, end_line = __END_LINE__, focus : Bool = false, tags : String | Enumerable(String) | Nil = nil, &block)
-    Spec.root_context.it(description.to_s, file, line, end_line, focus, tags, &block)
+    Spec.cli.root_context.it(description.to_s, file, line, end_line, focus, tags, &block)
   end
 
   # Defines a pending test case.
@@ -72,7 +72,7 @@ module Spec::Methods
   #
   # If `focus` is `true`, only this test, and others marked with `focus: true`, will run.
   def pending(description = "assert", file = __FILE__, line = __LINE__, end_line = __END_LINE__, focus : Bool = false, tags : String | Enumerable(String) | Nil = nil)
-    Spec.root_context.pending(description.to_s, file, line, end_line, focus, tags)
+    Spec.cli.root_context.pending(description.to_s, file, line, end_line, focus, tags)
   end
 
   # Fails an example.
@@ -124,10 +124,10 @@ module Spec::Methods
   # end
   # ```
   def before_each(&block)
-    if Spec.current_context.is_a?(RootContext)
+    if Spec.cli.current_context.is_a?(RootContext)
       raise "Can't call `before_each` outside of a describe/context"
     end
-    Spec.current_context.before_each(&block)
+    Spec.cli.current_context.before_each(&block)
   end
 
   # Executes the given block after each spec in the current context runs.
@@ -154,10 +154,10 @@ module Spec::Methods
   # end
   # ```
   def after_each(&block)
-    if Spec.current_context.is_a?(RootContext)
+    if Spec.cli.current_context.is_a?(RootContext)
       raise "Can't call `after_each` outside of a describe/context"
     end
-    Spec.current_context.after_each(&block)
+    Spec.cli.current_context.after_each(&block)
   end
 
   # Executes the given block before the first spec in the current context runs.
@@ -184,10 +184,10 @@ module Spec::Methods
   # end
   # ```
   def before_all(&block)
-    if Spec.current_context.is_a?(RootContext)
+    if Spec.cli.current_context.is_a?(RootContext)
       raise "Can't call `before_all` outside of a describe/context"
     end
-    Spec.current_context.before_all(&block)
+    Spec.cli.current_context.before_all(&block)
   end
 
   # Executes the given block after the last spec in the current context runs.
@@ -214,10 +214,10 @@ module Spec::Methods
   # end
   # ```
   def after_all(&block)
-    if Spec.current_context.is_a?(RootContext)
+    if Spec.cli.current_context.is_a?(RootContext)
       raise "Can't call `after_all` outside of a describe/context"
     end
-    Spec.current_context.after_all(&block)
+    Spec.cli.current_context.after_all(&block)
   end
 
   # Executes the given block when each spec in the current context runs.
@@ -252,10 +252,10 @@ module Spec::Methods
   # end
   # ```
   def around_each(&block : Example::Procsy ->)
-    if Spec.current_context.is_a?(RootContext)
+    if Spec.cli.current_context.is_a?(RootContext)
       raise "Can't call `around_each` outside of a describe/context"
     end
-    Spec.current_context.around_each(&block)
+    Spec.cli.current_context.around_each(&block)
   end
 
   # Executes the given block when the current context runs.
@@ -297,10 +297,10 @@ module Spec::Methods
   # end
   # ```
   def around_all(&block : ExampleGroup::Procsy ->)
-    if Spec.current_context.is_a?(RootContext)
+    if Spec.cli.current_context.is_a?(RootContext)
       raise "Can't call `around_all` outside of a describe/context"
     end
-    Spec.current_context.around_all(&block)
+    Spec.cli.current_context.around_all(&block)
   end
 end
 


### PR DESCRIPTION
This PR combines most of `Spec`'s global state into a new `Spec::CLI` class, with the end goal of making the spec runner itself more reusable and testable. The new singleton state is `Spec.cli`; eventually, only `Spec`'s public class methods should delegate to this singleton, and methods within the runner shouldn't refer to it. The remaining class variables are:

* `Spec::RootContext.@@instance`
* `Spec::RootContext.@@current_context`
* `Spec::RootContext.@@spec_nesting`
* `Spec::Example.@@example_counter`
* `Spec.@@lines_cache`

Class methods of `Spec` that should have been `nodoc` are marked as deprecated.