### PR TITLE
Add support for `Etc/UTC` time zone identifier without tzdb

### DIFF
--- a/spec/std/time/location_spec.cr
+++ b/spec/std/time/location_spec.cr
@@ -69,7 +69,7 @@ class Time::Location
           Location.load("").should eq Location::UTC
 
           # Etc/UTC could be pointing to anything
-          Location.load("Etc/UTC").should_not eq Location::UTC
+          Location.load("Etc/UTC").should eq Location::UTC
         end
       end
 

--- a/spec/std/time/location_spec.cr
+++ b/spec/std/time/location_spec.cr
@@ -67,8 +67,6 @@ class Time::Location
         with_zoneinfo do
           Location.load("UTC").should eq Location::UTC
           Location.load("").should eq Location::UTC
-
-          # Etc/UTC could be pointing to anything
           Location.load("Etc/UTC").should eq Location::UTC
         end
       end

--- a/src/time/location.cr
+++ b/src/time/location.cr
@@ -278,11 +278,11 @@ class Time::Location
   def self.load(name : String) : Location
     case name
     when "", "UTC", "Etc/UTC"
-          # `UTC` is a special identifier, empty string represents a fallback mechanism.
-          # `Etc/UTC` is technically a tzdb identifier which could potentially point to anything.
-          # But we map it to `Location::UTC` directly for convenience which allows it to work
-          # without a copy of the database.
-          UTC 
+      # `UTC` is a special identifier, empty string represents a fallback mechanism.
+      # `Etc/UTC` is technically a tzdb identifier which could potentially point to anything.
+      # But we map it to `Location::UTC` directly for convenience which allows it to work
+      # without a copy of the database.
+      UTC
     when "Local"
       local
     when .includes?(".."), .starts_with?('/'), .starts_with?('\\')

--- a/src/time/location.cr
+++ b/src/time/location.cr
@@ -236,7 +236,7 @@ class Time::Location
   #
   # *name* is understood to be a location name in the IANA Time
   # Zone database, such as `"America/New_York"`. As special cases,
-  # `"UTC"` and empty string (`""`) return `Location::UTC`, and
+  # `"UTC"` `"Etc/UTC"` and empty string (`""`) return `Location::UTC`, and
   # `"Local"` returns `Location.local`.
   #
   # The implementation uses a list of system-specific paths to look for a time
@@ -339,7 +339,7 @@ class Time::Location
   # The environment variable `ENV["TZ"]` is consulted for finding the time zone
   # to use.
   #
-  # * `"UTC"` and empty string (`""`) return `Location::UTC`
+  # * `"UTC"`, `"Etc/UTC"` and empty string (`""`) return `Location::UTC`
   # * Any other value (such as `"Europe/Berlin"`) is tried to be resolved using
   #   `Location.load`.
   # * If `ENV["TZ"]` is not set, the system's local time zone data will be used

--- a/src/time/location.cr
+++ b/src/time/location.cr
@@ -277,7 +277,7 @@ class Time::Location
   # `Location`, unless the time zone database has been updated in between.
   def self.load(name : String) : Location
     case name
-    when "", "UTC"
+    when "", "UTC","Etc/UTC"
       UTC
     when "Local"
       local

--- a/src/time/location.cr
+++ b/src/time/location.cr
@@ -278,7 +278,11 @@ class Time::Location
   def self.load(name : String) : Location
     case name
     when "", "UTC", "Etc/UTC"
-      UTC
+          # `UTC` is a special identifier, empty string represents a fallback mechanism.
+          # `Etc/UTC` is technically a tzdb identifier which could potentially point to anything.
+          # But we map it to `Location::UTC` directly for convenience which allows it to work
+          # without a copy of the database.
+          UTC 
     when "Local"
       local
     when .includes?(".."), .starts_with?('/'), .starts_with?('\\')

--- a/src/time/location.cr
+++ b/src/time/location.cr
@@ -236,7 +236,7 @@ class Time::Location
   #
   # *name* is understood to be a location name in the IANA Time
   # Zone database, such as `"America/New_York"`. As special cases,
-  # `"UTC"` `"Etc/UTC"` and empty string (`""`) return `Location::UTC`, and
+  # `"UTC"`, `"Etc/UTC"` and empty string (`""`) return `Location::UTC`, and
   # `"Local"` returns `Location.local`.
   #
   # The implementation uses a list of system-specific paths to look for a time

--- a/src/time/location.cr
+++ b/src/time/location.cr
@@ -348,7 +348,7 @@ class Time::Location
   #   `Location::UTC` is returned.
   def self.load_local : Location
     case tz = ENV["TZ"]?
-    when "", "UTC"
+    when "", "UTC", "Etc/UTC"
       return UTC
     when Nil
       if localtime = Crystal::System::Time.load_localtime

--- a/src/time/location.cr
+++ b/src/time/location.cr
@@ -277,7 +277,7 @@ class Time::Location
   # `Location`, unless the time zone database has been updated in between.
   def self.load(name : String) : Location
     case name
-    when "", "UTC","Etc/UTC"
+    when "", "UTC", "Etc/UTC"
       UTC
     when "Local"
       local


### PR DESCRIPTION
refers to this https://github.com/crystal-lang/crystal/issues/14074,

Also I took the liberty of adding a few common things to .gitignore,
I can seperate that into a distinguish PR if you want