### PR TITLE
Reserve stack space on non-main threads for crash recovery on Windows

### DIFF
--- a/src/crystal/system/win32/thread.cr
+++ b/src/crystal/system/win32/thread.cr
@@ -12,11 +12,22 @@ module Crystal::System::Thread
     @system_handle = GC.beginthreadex(
       security: Pointer(Void).null,
       stack_size: LibC::UInt.zero,
-      start_address: ->(data : Void*) { data.as(::Thread).start; LibC::UInt.zero },
+      start_address: ->Thread.thread_proc(Void*),
       arglist: self.as(Void*),
       initflag: LibC::UInt.zero,
       thrdaddr: Pointer(LibC::UInt).null,
     )
+  end
+
+  def self.thread_proc(data : Void*) : LibC::UInt
+    # ensure that even in the case of stack overflow there is enough reserved
+    # stack space for recovery (for the main thread this is done in
+    # `Exception::CallStack.setup_crash_handler`)
+    stack_size = Crystal::System::Fiber::RESERVED_STACK_SIZE
+    LibC.SetThreadStackGuarantee(pointerof(stack_size))
+
+    data.as(::Thread).start
+    LibC::UInt.zero
   end
 
   def self.current_handle : Handle

--- a/src/exception/call_stack/stackwalk.cr
+++ b/src/exception/call_stack/stackwalk.cr
@@ -51,7 +51,8 @@ struct Exception::CallStack
     end)
 
     # ensure that even in the case of stack overflow there is enough reserved
-    # stack space for recovery
+    # stack space for recovery (for other threads this is done in
+    # `Crystal::System::Thread.thread_proc`)
     stack_size = Crystal::System::Fiber::RESERVED_STACK_SIZE
     LibC.SetThreadStackGuarantee(pointerof(stack_size))
   end


### PR DESCRIPTION
`LibC.SetThreadStackGuarantee` only works on the current thread. This PR extends it to other threads created explicitly or via `-Dpreview_mt`, so that stack overflows on them will print a stack trace properly:

```crystal
def foo
  x = uninitialized UInt8[512]
  foo
end

Thread.new { foo }.join
```

```
Stack overflow (e.g., infinite or very deep recursion)
[0x7ff79edc1fb7] foo at C:\Users\nicet\crystal\crystal\usr\test.cr:28
[0x7ff79edc1fbc] foo at C:\Users\nicet\crystal\crystal\usr\test.cr:28 (14843 times)
[0x7ff79edc1fa9] -> at C:\Users\nicet\crystal\crystal\usr\test.cr:31
[0x7ff79ee365c3] start at C:\Users\nicet\crystal\crystal\src\crystal\system\thread.cr:116
[0x7ff79ee36957] thread_proc at C:\Users\nicet\crystal\crystal\src\crystal\system\win32\thread.cr:30
[0x7ff79edc1fc9] -> at C:\Users\nicet\crystal\crystal\src\crystal\system\win32\thread.cr:15
[0x7ff79ee75766] GC_wait_marker +454 in C:\Users\nicet\crystal\crystal\test.exe
[0x7ff79ee75a7a] GC_call_with_stack_base +26 in C:\Users\nicet\crystal\crystal\test.exe
[0x7ff79eeacfd6] thread_start<unsigned int (__cdecl*)(void *),1> at minkernel\crts\ucrt\src\appcrt\startup\thread.cpp:97
[0x7fff3525257d] BaseThreadInitThunk +29 in C:\WINDOWS\System32\KERNEL32.DLL
[0x7fff3640aa58] RtlUserThreadStart +40 in C:\WINDOWS\SYSTEM32\ntdll.dll
```