### PR TITLE
Always call `LibXML.xmlInitParser` when requiring XML libraries

### DIFF
--- a/src/xml/libxml2.cr
+++ b/src/xml/libxml2.cr
@@ -11,9 +11,10 @@ require "./save_options"
 lib LibXML
   alias Int = LibC::Int
 
+  fun xmlInitParser
+
   # TODO: check if other platforms also support per-thread globals
   {% if flag?(:win32) %}
-    fun xmlInitParser
     fun __xmlIndentTreeOutput : Int*
     fun __xmlTreeIndentString : UInt8**
   {% else %}
@@ -324,9 +325,7 @@ lib LibXML
   fun xmlValidateNameValue(value : UInt8*) : Int
 end
 
-{% if flag?(:win32) %}
-  LibXML.xmlInitParser
-{% end %}
+LibXML.xmlInitParser
 
 LibXML.xmlGcMemSetup(
   ->GC.free,


### PR DESCRIPTION
This may fix #10365. I need more confirmation from macOS users.

libxml2 used to have a lot of different initialization functions, and will usually call one of them itself when a client calls any XML function. My guess is those initializations by libxml2 weren't enough in older versions (this is probably why all of them except `xmlInitParser` are deprecated nowadays).