### PR TITLE
`XML::Reader`: Disallow attributes containing null bytes

### DIFF
--- a/spec/std/xml/reader_spec.cr
+++ b/spec/std/xml/reader_spec.cr
@@ -359,6 +359,11 @@ module XML
         reader.value.should eq("2")
         reader.read.should be_false
       end
+
+      it "raises if attribute contains null byte" do
+        reader = Reader.new("<root/>")
+        expect_raises(Exception) { reader.move_to_attribute("\0") }
+      end
     end
 
     describe "#[]" do
@@ -378,6 +383,11 @@ module XML
         reader.read # </root>
         reader["id"].should eq("1")
       end
+
+      it "raises if attribute contains null byte" do
+        reader = Reader.new("<root/>")
+        expect_raises(Exception) { reader["\0"] }
+      end
     end
 
     describe "#[]?" do
@@ -396,6 +406,11 @@ module XML
         reader["id"]?.should be_nil
         reader.read # </root>
         reader["id"]?.should eq("1")
+      end
+
+      it "raises if attribute contains null byte" do
+        reader = Reader.new("<root/>")
+        expect_raises(Exception) { reader["\0"]? }
       end
     end
 

--- a/src/xml/reader.cr
+++ b/src/xml/reader.cr
@@ -119,6 +119,7 @@ class XML::Reader
 
   # Moves to the `XML::Reader::Type::ATTRIBUTE` with the specified name.
   def move_to_attribute(name : String) : Bool
+    check_no_null_byte(name)
     LibXML.xmlTextReaderMoveToAttribute(@reader, name) == 1
   end
 
@@ -131,6 +132,7 @@ class XML::Reader
   # Gets the attribute content for the *attribute* given by name.
   # Returns `nil` if attribute is not found.
   def []?(attribute : String) : String?
+    check_no_null_byte(attribute)
     value = LibXML.xmlTextReaderGetAttribute(@reader, attribute)
     String.new(value) if value
   end
@@ -198,6 +200,12 @@ class XML::Reader
   private def collect_errors(&)
     Error.collect(@errors) { yield }.tap do
       Error.add_errors(@errors)
+    end
+  end
+
+  private def check_no_null_byte(attribute)
+    if attribute.byte_index(0)
+      raise XML::Error.new("Invalid attribute name: #{attribute.inspect} (contains null character)", 0)
     end
   end
 end


### PR DESCRIPTION
These are the only remaining libxml2 functions which accept an arbitrary C string argument but aren't guarded by null checks yet.