### PR TITLE
Do not hardcode `ReferenceStorage` as a built-in type

### DIFF
--- a/spec/compiler/semantic/reference_storage_spec.cr
+++ b/spec/compiler/semantic/reference_storage_spec.cr
@@ -3,6 +3,10 @@ require "../../spec_helper"
 describe "Semantic: ReferenceStorage" do
   it "errors if T is a struct type" do
     assert_error <<-CRYSTAL, "Can't instantiate ReferenceStorage(T) with T = Foo (T must be a reference type)"
+      @[Primitive(:reference_storage_type)]
+      struct ReferenceStorage(T) < Value
+      end
+
       struct Foo
         @x = 1
       end
@@ -13,12 +17,20 @@ describe "Semantic: ReferenceStorage" do
 
   it "errors if T is a value type" do
     assert_error <<-CRYSTAL, "Can't instantiate ReferenceStorage(T) with T = Int32 (T must be a reference type)"
+      @[Primitive(:reference_storage_type)]
+      struct ReferenceStorage(T) < Value
+      end
+
       ReferenceStorage(Int32)
       CRYSTAL
   end
 
   it "errors if T is a union type" do
     assert_error <<-CRYSTAL, "Can't instantiate ReferenceStorage(T) with T = (Bar | Foo) (T must be a reference type)"
+      @[Primitive(:reference_storage_type)]
+      struct ReferenceStorage(T) < Value
+      end
+
       class Foo
       end
 
@@ -31,10 +43,30 @@ describe "Semantic: ReferenceStorage" do
 
   it "errors if T is a nilable type" do
     assert_error <<-CRYSTAL, "Can't instantiate ReferenceStorage(T) with T = (Foo | Nil) (T must be a reference type)"
+      @[Primitive(:reference_storage_type)]
+      struct ReferenceStorage(T) < Value
+      end
+
       class Foo
       end
 
       ReferenceStorage(Foo?)
+      CRYSTAL
+  end
+
+  it "allows a different name" do
+    assert_type(<<-CRYSTAL) { types["Foo"].metaclass }
+      @[Primitive(:reference_storage_type)]
+      struct MyRef(U) < Value
+        def u
+          U
+        end
+      end
+
+      class Foo
+      end
+
+      MyRef(Foo).new.u
       CRYSTAL
   end
 end

--- a/src/compiler/crystal/program.cr
+++ b/src/compiler/crystal/program.cr
@@ -197,10 +197,6 @@ module Crystal
       types["Struct"] = struct_t = @struct_t = NonGenericClassType.new self, self, "Struct", value
       abstract_value_type(struct_t)
 
-      types["ReferenceStorage"] = @reference_storage = reference_storage = GenericReferenceStorageType.new self, self, "ReferenceStorage", value, ["T"]
-      reference_storage.declare_instance_var("@type_id", int32)
-      reference_storage.can_be_stored = false
-
       types["Enumerable"] = @enumerable = GenericModuleType.new self, self, "Enumerable", ["T"]
       types["Indexable"] = @indexable = GenericModuleType.new self, self, "Indexable", ["T"]
 
@@ -497,7 +493,7 @@ module Crystal
 
     {% for name in %w(object no_return value number reference void nil bool char int int8 int16 int32 int64 int128
                      uint8 uint16 uint32 uint64 uint128 float float32 float64 string symbol pointer enumerable indexable
-                     array static_array reference_storage exception tuple named_tuple proc union enum range regex crystal
+                     array static_array exception tuple named_tuple proc union enum range regex crystal
                      packed_annotation thread_local_annotation no_inline_annotation
                      always_inline_annotation naked_annotation returns_twice_annotation
                      raises_annotation primitive_annotation call_convention_annotation

--- a/src/compiler/crystal/semantic/semantic_visitor.cr
+++ b/src/compiler/crystal/semantic/semantic_visitor.cr
@@ -522,6 +522,16 @@ abstract class Crystal::SemanticVisitor < Crystal::Visitor
     when @program.experimental_annotation
       # ditto DeprecatedAnnotation
       ExperimentalAnnotation.from(ann)
+    when @program.primitive_annotation
+      # there isn't a PrimitiveAnnotation type yet, so we validate right here
+      if ann.args.size != 1
+        ann.raise "expected Primitive annotation to have one argument"
+      end
+
+      arg = ann.args.first
+      unless arg.is_a?(SymbolLiteral)
+        arg.raise "expected Primitive argument to be a symbol literal"
+      end
     end
   end
 

--- a/src/compiler/crystal/semantic/top_level_visitor.cr
+++ b/src/compiler/crystal/semantic/top_level_visitor.cr
@@ -41,12 +41,28 @@ class Crystal::TopLevelVisitor < Crystal::SemanticVisitor
 
   @last_doc : String?
 
+  # special types recognized for `@[Primitive]`
+  private enum PrimitiveType
+    ReferenceStorageType
+  end
+
   def visit(node : ClassDef)
     check_outside_exp node, "declare class"
 
     scope, name, type = lookup_type_def(node)
 
     annotations = read_annotations
+
+    special_type = nil
+    process_annotations(annotations) do |annotation_type, ann|
+      case annotation_type
+      when @program.primitive_annotation
+        arg = ann.args.first.as(SymbolLiteral)
+        unless special_type = PrimitiveType.parse?(arg.value)
+          arg.raise "BUG: Unknown primitive type #{arg.value.inspect}"
+        end
+      end
+    end
 
     created_new_type = false
 
@@ -70,14 +86,30 @@ class Crystal::TopLevelVisitor < Crystal::SemanticVisitor
       end
     else
       created_new_type = true
-      if type_vars = node.type_vars
-        type = GenericClassType.new @program, scope, name, nil, type_vars, false
-        type.splat_index = node.splat_index
-      else
-        type = NonGenericClassType.new @program, scope, name, nil, false
+      case special_type
+      in Nil
+        if type_vars = node.type_vars
+          type = GenericClassType.new @program, scope, name, nil, type_vars, false
+          type.splat_index = node.splat_index
+        else
+          type = NonGenericClassType.new @program, scope, name, nil, false
+        end
+        type.abstract = node.abstract?
+        type.struct = node.struct?
+      in .reference_storage_type?
+        unless type_vars = node.type_vars
+          node.raise "BUG: Expected reference_storage_type to be a generic struct"
+        end
+        unless type_vars.size == 1
+          node.raise "BUG: Expected reference_storage_type to have a single generic type parameter"
+        end
+        if node.splat_index
+          node.raise "BUG: Expected reference_storage_type to have no splat parameter"
+        end
+        type = GenericReferenceStorageType.new @program, scope, name, @program.value, type_vars
+        type.declare_instance_var("@type_id", @program.int32)
+        type.can_be_stored = false
       end
-      type.abstract = node.abstract?
-      type.struct = node.struct?
     end
 
     type.private = true if node.visibility.private?
@@ -132,6 +164,10 @@ class Crystal::TopLevelVisitor < Crystal::SemanticVisitor
 
       if superclass.struct? && !superclass.abstract?
         node.raise "can't extend non-abstract struct #{superclass}"
+      end
+
+      if type.is_a?(GenericReferenceStorageType) && superclass != @program.value
+        node.raise "BUG: Expected reference_storage_type to inherit from Value"
       end
     end
 
@@ -375,7 +411,7 @@ class Crystal::TopLevelVisitor < Crystal::SemanticVisitor
 
     process_def_annotations(node, annotations) do |annotation_type, ann|
       if annotation_type == @program.primitive_annotation
-        process_primitive_annotation(node, ann)
+        process_def_primitive_annotation(node, ann)
       end
 
       node.add_annotation(annotation_type, ann)
@@ -460,17 +496,8 @@ class Crystal::TopLevelVisitor < Crystal::SemanticVisitor
     false
   end
 
-  private def process_primitive_annotation(node, ann)
-    if ann.args.size != 1
-      ann.raise "expected Primitive annotation to have one argument"
-    end
-
-    arg = ann.args.first
-    unless arg.is_a?(SymbolLiteral)
-      arg.raise "expected Primitive argument to be a symbol literal"
-    end
-
-    value = arg.value
+  private def process_def_primitive_annotation(node, ann)
+    value = ann.args.first.as(SymbolLiteral).value
 
     primitive = Primitive.new(value)
     primitive.location = node.location
@@ -924,7 +951,7 @@ class Crystal::TopLevelVisitor < Crystal::SemanticVisitor
       if annotation_type == @program.call_convention_annotation
         call_convention = parse_call_convention(ann, call_convention)
       elsif annotation_type == @program.primitive_annotation
-        process_primitive_annotation(external, ann)
+        process_def_primitive_annotation(external, ann)
       else
         ann.raise "funs can only be annotated with: NoInline, AlwaysInline, Naked, ReturnsTwice, Raises, CallConvention"
       end

--- a/src/reference_storage.cr
+++ b/src/reference_storage.cr
@@ -13,7 +13,8 @@
 # WARNING: `ReferenceStorage` is unsuitable when instances of `T` require more
 # than `instance_sizeof(T)` bytes, such as `String` and `Log::Metadata`.
 @[Experimental("This type's API is still under development. Join the discussion about custom reference allocation at [#13481](https://github.com/crystal-lang/crystal/issues/13481).")]
-struct ReferenceStorage(T)
+@[Primitive(:reference_storage_type)]
+struct ReferenceStorage(T) < Value
   private def initialize
   end
 


### PR DESCRIPTION
Fixes #14194. Checked with `make clean crystal && git checkout 1.9.0 && bin/crystal spec spec/std/int_spec.cr`. (Even earlier versions would still fail due to an LLVM intrinsic name mismatch regarding opaque pointers, unrelated to this feature.)