### PR TITLE
Formatter: Add more whitespace around `ProcLiteral`s

### DIFF
--- a/spec/compiler/formatter/formatter_spec.cr
+++ b/spec/compiler/formatter/formatter_spec.cr
@@ -1629,6 +1629,14 @@ describe Crystal::Formatter do
   assert_format "->( x : Int32 , y )   { x }", "->(x : Int32, y) { x }"
   assert_format "->{}"
 
+  # #13232
+  assert_format "->{}", "-> { }", flags: %w[proc_literal_whitespace]
+  assert_format "->(){}", "-> { }", flags: %w[proc_literal_whitespace]
+  assert_format "->{1}", "-> { 1 }", flags: %w[proc_literal_whitespace]
+  assert_format "->(x : Int32) {}", "->(x : Int32) { }", flags: %w[proc_literal_whitespace]
+  assert_format "-> : Int32 {}", "-> : Int32 { }", flags: %w[proc_literal_whitespace]
+  assert_format "->do\nend", "-> do\nend", flags: %w[proc_literal_whitespace]
+
   assert_format "-> : Int32 {}"
   assert_format "-> : Int32 | String { 1 }"
   assert_format "-> : Array(Int32) {}"

--- a/src/compiler/crystal/tools/formatter.cr
+++ b/src/compiler/crystal/tools/formatter.cr
@@ -4256,7 +4256,7 @@ module Crystal
         skip_space_or_newline
       end
 
-      write " " unless a_def.args.empty? && !return_type
+      write " " if a_def.args.present? || return_type || flag?("proc_literal_whitespace")
 
       is_do = false
       if @token.keyword?(:do)
@@ -4264,6 +4264,7 @@ module Crystal
         is_do = true
       else
         write_token :OP_LCURLY
+        write " " if a_def.body.is_a?(Nop) && flag?("proc_literal_whitespace")
       end
       skip_space
 


### PR DESCRIPTION
Resolves #13232.

The feature flag for #13002 is `proc_literal_whitespace`.