### PR TITLE
Remove `T*` and `T[N]` macro interpolation behavior inside libs

### DIFF
--- a/spec/compiler/parser/to_s_spec.cr
+++ b/spec/compiler/parser/to_s_spec.cr
@@ -147,6 +147,25 @@ describe "ASTNode#to_s" do
   expect_to_s %(lib Foo\n  struct Foo\n    a : Void\n    b : Void\n  end\nend)
   expect_to_s %(lib Foo\n  union Foo\n    a : Int\n    b : Int32\n  end\nend)
   expect_to_s %(lib Foo\n  FOO = 0\nend)
+  expect_to_s <<-CRYSTAL, <<-CRYSTAL
+    lib Foo
+      A = Pointer(Void).new(0)
+      struct B
+        x : Void*
+        y : Int[1]
+      end
+      fun c(Void*) : Char[2]*
+    end
+    CRYSTAL
+    lib Foo
+      A = Pointer(Void).new(0)
+      struct B
+        x : ::Pointer(Void)
+        y : ::StaticArray(Int, 1)
+      end
+      fun c(::Pointer(Void)) : ::Pointer(::StaticArray(Char, 2))
+    end
+    CRYSTAL
   expect_to_s %(lib LibC\n  fun getch = "get.char"\nend)
   expect_to_s %(lib Foo::Bar\nend)
   expect_to_s %(enum Foo\n  A = 0\n  B\nend)

--- a/spec/compiler/semantic/restrictions_augmenter_spec.cr
+++ b/spec/compiler/semantic/restrictions_augmenter_spec.cr
@@ -272,7 +272,7 @@ describe "Semantic: restrictions augmenter" do
   it "augments typedef" do
     before = <<-CRYSTAL
       lib LibFoo
-        type X = Void*
+        type X = Int32
       end
       class Foo
         @x : LibFoo::X
@@ -284,7 +284,7 @@ describe "Semantic: restrictions augmenter" do
 
     after = <<-CRYSTAL
       lib LibFoo
-        type X = Void*
+        type X = Int32
       end
       class Foo
         @x : LibFoo::X

--- a/src/compiler/crystal/syntax/to_s.cr
+++ b/src/compiler/crystal/syntax/to_s.cr
@@ -28,7 +28,6 @@ module Crystal
     def initialize(@str = IO::Memory.new, @macro_expansion_pragmas = nil, @emit_doc = false)
       @indent = 0
       @inside_macro = 0
-      @inside_lib = false
     end
 
     def visit_any(node)
@@ -847,25 +846,6 @@ module Crystal
     def visit(node : Generic)
       name = node.name
 
-      if @inside_lib && (name.is_a?(Path) && name.names.size == 1)
-        case name.names.first
-        when "Pointer"
-          node.type_vars.first.accept self
-          @str << '*'
-          return false
-        when "StaticArray"
-          if node.type_vars.size == 2
-            node.type_vars[0].accept self
-            @str << '['
-            node.type_vars[1].accept self
-            @str << ']'
-            return false
-          end
-        else
-          # Not a special type
-        end
-      end
-
       node.name.accept self
 
       printed_arg = false
@@ -1131,9 +1111,7 @@ module Crystal
       @str << "lib "
       node.name.accept self
       newline
-      @inside_lib = true
       accept_with_indent(node.body)
-      @inside_lib = false
       append_indent
       @str << "end"
       false


### PR DESCRIPTION
Fixes #14213. Reverts 75cd6ce and fbf2eeb.

This disables _all_ such behavior, including inside structs / unions and funs. There is probably no need for `Crystal::ToSVisitor` to do this.