### PR TITLE
Revert "Fix OpenSSL error handling for EOF (support for OpenSSL 3.2) (#14169)"

### DIFF
--- a/spec/std/openssl/ssl/socket_spec.cr
+++ b/spec/std/openssl/ssl/socket_spec.cr
@@ -160,26 +160,20 @@ describe OpenSSL::SSL::Socket do
     server_context, client_context = ssl_context_pair
     server_context.disable_session_resume_tickets # avoid Broken pipe
 
-    server_finished_reading = Channel(String | Exception).new
+    server_finished_reading = Channel(String).new
     spawn do
       OpenSSL::SSL::Server.open(tcp_server, server_context, sync_close: true) do |server|
         server_socket = server.accept
         received = server_socket.gets_to_end # interprets underlying socket close as a graceful EOF
         server_finished_reading.send(received)
       end
-    rescue exc
-      server_finished_reading.send exc
     end
-
     socket = TCPSocket.new(tcp_server.local_address.address, tcp_server.local_address.port)
     socket_ssl = OpenSSL::SSL::Socket::Client.new(socket, client_context, hostname: "example.com", sync_close: true)
     socket_ssl.print "hello"
     socket_ssl.flush # needed today see #5375
     socket.close     # close underlying socket without gracefully shutting down SSL at all
     server_received = server_finished_reading.receive
-    if server_received.is_a?(Exception)
-      raise server_received
-    end
     server_received.should eq("hello")
   end
 end


### PR DESCRIPTION
Reverts (most of) #14169.
I wasn't too confident about this patch and it appears it might negatively effect previously working versions of OpenSSL. So it's better to revert it and look for a proper solution to support OpenSSL 3.2.0.

See https://github.com/crystal-lang/crystal/issues/14200#issuecomment-1887112353