### PR TITLE
MT: reduce interleaved backtraces in spawn unhandled exceptions

### DIFF
--- a/src/fiber.cr
+++ b/src/fiber.cr
@@ -140,12 +140,20 @@ class Fiber
     GC.unlock_read
     @proc.call
   rescue ex
+    io = {% if flag?(:preview_mt) %}
+           IO::Memory.new(4096) # PIPE_BUF
+         {% else %}
+           STDERR
+         {% end %}
     if name = @name
-      STDERR.print "Unhandled exception in spawn(name: #{name}): "
+      io << "Unhandled exception in spawn(name: " <<  name << "): "
     else
-      STDERR.print "Unhandled exception in spawn: "
+      io << "Unhandled exception in spawn: "
     end
-    ex.inspect_with_backtrace(STDERR)
+    ex.inspect_with_backtrace(io)
+    {% if flag?(:preview_mt) %}
+      STDERR.write(io.to_slice)
+    {% end %}
     STDERR.flush
   ensure
     # Remove the current fiber from the linked list

--- a/src/fiber.cr
+++ b/src/fiber.cr
@@ -146,7 +146,7 @@ class Fiber
            STDERR
          {% end %}
     if name = @name
-      io << "Unhandled exception in spawn(name: " <<  name << "): "
+      io << "Unhandled exception in spawn(name: " << name << "): "
     else
       io << "Unhandled exception in spawn: "
     end


### PR DESCRIPTION
Instead of doing many individual writes to STDERR that may happen concurrently with other threads, we buffer the message in memory so we can write _once_.

I tried with 10 000 fibers and 16 threads and I couldn't get any interleaved message. That doesn't mean it can't happen, especially with other concurrent writes to STDERR —which an alternative solution to use a mutex wouldn't prevent it either.

Note: I chose to use a HEAP allocated buffer rather than a stack allocated one because the latter wouldn't be resizeable, and there is no guarantee that the backtrace would fit within 4KB (`PIPE_BUF` on Linux).

closes #8299