### PR TITLE
Fix: Always use `%p` for pointers in `Crystal::System.print_error`

### DIFF
--- a/src/exception/call_stack/libunwind.cr
+++ b/src/exception/call_stack/libunwind.cr
@@ -102,7 +102,7 @@ struct Exception::CallStack
   end
 
   private def self.print_frame(repeated_frame)
-    Crystal::System.print_error "[%p] ", repeated_frame.ip.address
+    Crystal::System.print_error "[%p] ", repeated_frame.ip
     print_frame_location(repeated_frame)
     Crystal::System.print_error " (%d times)", repeated_frame.count + 1 unless repeated_frame.count == 0
     Crystal::System.print_error "\n"

--- a/src/exception/call_stack/stackwalk.cr
+++ b/src/exception/call_stack/stackwalk.cr
@@ -150,7 +150,7 @@ struct Exception::CallStack
   end
 
   private def self.print_frame(repeated_frame)
-    Crystal::System.print_error "[%p] ", repeated_frame.ip.address
+    Crystal::System.print_error "[%p] ", repeated_frame.ip
     print_frame_location(repeated_frame)
     Crystal::System.print_error " (%d times)", repeated_frame.count + 1 unless repeated_frame.count == 0
     Crystal::System.print_error "\n"


### PR DESCRIPTION
Follow-up to #14186, which broke crash stack dumps