### PR TITLE
Optimize runtime for non single-module(01,02) compilation

### DIFF
--- a/src/char.cr
+++ b/src/char.cr
@@ -63,6 +63,7 @@ struct Char
   # 'b' - 'a' # => 1
   # 'c' - 'a' # => 2
   # ```
+  @[AlwaysInline]
   def -(other : Char) : Int32
     ord - other.ord
   end
@@ -93,6 +94,7 @@ struct Char
   # 'a' + 1 # => 'b'
   # 'a' + 2 # => 'c'
   # ```
+  @[AlwaysInline]
   def +(other : Int) : Char
     (ord + other).chr
   end
@@ -103,6 +105,7 @@ struct Char
   # 'c' - 1 # => 'b'
   # 'c' - 2 # => 'a'
   # ```
+  @[AlwaysInline]
   def -(other : Int) : Char
     (ord - other).chr
   end
@@ -118,6 +121,7 @@ struct Char
   # 'z' <=> 'z' # => 0
   # 'c' <=> 'a' # => 2
   # ```
+  @[AlwaysInline]
   def <=>(other : Char)
     self - other
   end
@@ -151,6 +155,7 @@ struct Char
 
   # Returns `true` if this char is an ASCII character
   # (codepoint is in (0..127))
+  @[AlwaysInline]
   def ascii? : Bool
     ord < 128
   end

--- a/src/comparable.cr
+++ b/src/comparable.cr
@@ -21,6 +21,7 @@
 module Comparable(T)
   # Compares this object to *other* based on the receiver’s `<=>` method,
   # returning `true` if it returns a negative number.
+  @[AlwaysInline]
   def <(other : T) : Bool
     cmp = self <=> other
     cmp ? cmp < 0 : false
@@ -28,6 +29,7 @@ module Comparable(T)
 
   # Compares this object to *other* based on the receiver’s `<=>` method,
   # returning `true` if it returns a value equal or less then `0`.
+  @[AlwaysInline]
   def <=(other : T)
     cmp = self <=> other
     cmp ? cmp <= 0 : false
@@ -52,6 +54,7 @@ module Comparable(T)
 
   # Compares this object to *other* based on the receiver’s `<=>` method,
   # returning `true` if it returns a value greater then `0`.
+  @[AlwaysInline]
   def >(other : T) : Bool
     cmp = self <=> other
     cmp ? cmp > 0 : false
@@ -59,6 +62,7 @@ module Comparable(T)
 
   # Compares this object to *other* based on the receiver’s `<=>` method,
   # returning `true` if it returns a value equal or greater than `0`.
+  @[AlwaysInline]
   def >=(other : T)
     cmp = self <=> other
     cmp ? cmp >= 0 : false

--- a/src/enum.cr
+++ b/src/enum.cr
@@ -328,10 +328,12 @@ struct Enum
   # Color::Blue <=> Color::Red  # => 1
   # Color::Blue <=> Color::Blue # => 0
   # ```
+  @[AlwaysInline]
   def <=>(other : self)
     value <=> other.value
   end
 
+  @[AlwaysInline]
   def ==(other)
     false
   end
@@ -358,6 +360,7 @@ struct Enum
   # Color::Red == Color::Red  # => true
   # Color::Red == Color::Blue # => false
   # ```
+  @[AlwaysInline]
   def ==(other : self)
     value == other.value
   end

--- a/src/enumerable.cr
+++ b/src/enumerable.cr
@@ -50,7 +50,7 @@ module Enumerable(T)
   # ["ant", "bear", "cat"].all? { |word| word.size >= 4 } # => false
   # ```
   def all?(& : T ->) : Bool
-    each { |e| return false unless yield e }
+    each { |e| return false unless yield(e) }
     true
   end
 
@@ -85,7 +85,7 @@ module Enumerable(T)
   # ["ant", "bear", "cat"].any? { |word| word.size > 4 }  # => false
   # ```
   def any?(& : T ->) : Bool
-    each { |e| return true if yield e }
+    each { |e| return true if yield(e) }
     false
   end
 
@@ -507,7 +507,7 @@ module Enumerable(T)
     i = offset
     each do |elem|
       yield elem, i
-      i += 1
+      i &+= 1
     end
   end
 

--- a/src/float.cr
+++ b/src/float.cr
@@ -140,16 +140,19 @@ struct Float32
   # Float32.new "20"                        # => 20.0
   # Float32.new "  20  ", whitespace: false # raises ArgumentError: Invalid Float32: "  20  "
   # ```
+  @[AlwaysInline]
   def self.new(value : String, whitespace : Bool = true, strict : Bool = true) : self
     value.to_f32 whitespace: whitespace, strict: strict
   end
 
   # Returns a `Float32` by invoking `to_f32` on *value*.
+  @[AlwaysInline]
   def self.new(value)
     value.to_f32
   end
 
   # Returns a `Float32` by invoking `to_f32!` on *value*.
+  @[AlwaysInline]
   def self.new!(value) : self
     value.to_f32!
   end

--- a/src/hash.cr
+++ b/src/hash.cr
@@ -2146,6 +2146,7 @@ class Hash(K, V)
       new(0_u32, key, value)
     end
 
+    @[AlwaysInline]
     def deleted? : Bool
       @hash == 0_u32
     end

--- a/src/indexable.cr
+++ b/src/indexable.cr
@@ -571,8 +571,7 @@ module Indexable(T)
   # ```
   def each_index(& : Int32 ->) : Nil
     i = 0
-    s = size
-    while Intrinsics.likely(i < s)
+    while Intrinsics.likely(i < size)
       yield i
       i &+= 1
     end

--- a/src/int.cr
+++ b/src/int.cr
@@ -140,6 +140,7 @@ struct Int
     unsafe_div other
   end
 
+  @[AlwaysInline]
   private def check_div_argument(other)
     if other == 0
       raise DivisionByZeroError.new
@@ -207,10 +208,16 @@ struct Int
   #
   # -8000 >> 1 # => -4000
   # ```
+  @[AlwaysInline]
   def >>(count : Int)
-    if count < 0
-      self << count.abs
-    elsif count < sizeof(self) * 8
+    if Intrinsics.unlikely(count < 0)
+      count = count.abs
+      if Intrinsics.likely(count < sizeof(self) * 8)
+        self.unsafe_shl(count)
+      else
+        self.class.zero
+      end
+    elsif Intrinsics.likely(count < sizeof(self) * 8)
       self.unsafe_shr(count)
     else
       self.class.zero
@@ -228,22 +235,30 @@ struct Int
   # 8000 << 32 # => 0
   # 8000 << -1 # => 4000
   # ```
+  @[AlwaysInline]
   def <<(count : Int)
-    if count < 0
-      self >> count.abs
-    elsif count < sizeof(self) * 8
+    if Intrinsics.unlikely(count < 0)
+      count = count.abs
+      if Intrinsics.likely(count < sizeof(self) * 8)
+        self.unsafe_shr(count)
+      else
+        self.class.zero
+      end
+    elsif Intrinsics.likely(count < sizeof(self) * 8)
       self.unsafe_shl(count)
     else
       self.class.zero
     end
   end
 
+  @[AlwaysInline]
   def <=>(other : Int) : Int32
     # Override Number#<=> because when comparing
     # Int vs Int there's no way we can return `nil`
     self > other ? 1 : (self < other ? -1 : 0)
   end
 
+  @[AlwaysInline]
   def abs : self
     self >= 0 ? self : -self
   end
@@ -346,6 +361,7 @@ struct Int
     to_f ** exponent
   end
 
+  @[AlwaysInline]
   def ===(char : Char)
     self === char.ord
   end
@@ -359,6 +375,7 @@ struct Int
   # 11.bit(3) # => 1
   # 11.bit(4) # => 0
   # ```
+  @[AlwaysInline]
   def bit(bit)
     self >> bit & 1
   end
@@ -415,6 +432,7 @@ struct Int
   # 0b1101.bits_set?(0b0111) # => false
   # 0b1101.bits_set?(0b1100) # => true
   # ```
+  @[AlwaysInline]
   def bits_set?(mask) : Bool
     (self & mask) == mask
   end
@@ -532,17 +550,19 @@ struct Int
     hasher.int(self)
   end
 
+  @[AlwaysInline]
   def succ : self
     self + 1
   end
 
+  @[AlwaysInline]
   def pred : self
     self - 1
   end
 
   def times(&block : self ->) : Nil
     i = self ^ self
-    while i < self
+    while Intrinsics.likely(i < self)
       yield i
       i &+= 1
     end
@@ -557,8 +577,8 @@ struct Int
     x = self
     while true
       yield x
-      return if x == to
-      x += 1
+      return if Intrinsics.unlikely(x == to)
+      x &+= 1
     end
   end
 
@@ -572,8 +592,8 @@ struct Int
     x = self
     while true
       yield x
-      return if x == to
-      x -= 1
+      return if Intrinsics.unlikely(x == to)
+      x &-= 1
     end
   end
 
@@ -972,6 +992,7 @@ struct Int8
   # 128_u8.neg_signed     # => -128_i8
   # Int16::MIN.neg_signed # raises OverflowError
   # ```
+  @[AlwaysInline]
   def neg_signed : self
     -self
   end
@@ -987,6 +1008,7 @@ struct Int8
   # 0b01001011_u8.bit_reverse          # => 0b11010010
   # 0b1100100001100111_u16.bit_reverse # => 0b1110011000010011
   # ```
+  @[AlwaysInline]
   def bit_reverse : self
     Intrinsics.bitreverse8(self).to_i8!
   end
@@ -999,15 +1021,18 @@ struct Int8
   # ```
   # 0x12_i8.byte_swap # => 0x12
   # ```
+  @[AlwaysInline]
   def byte_swap : self
     self
   end
 
   # Returns the number of leading `0`-bits.
+  @[AlwaysInline]
   def leading_zeros_count
     Intrinsics.countleading8(self, false)
   end
 
+  @[AlwaysInline]
   def trailing_zeros_count
     Intrinsics.counttrailing8(self, false)
   end
@@ -1021,6 +1046,7 @@ struct Int8
   # 0b01001101_u8.rotate_left(11) # => 0b01101010
   # 0b01001101_u8.rotate_left(-1) # => 0b10100110
   # ```
+  @[AlwaysInline]
   def rotate_left(n : Int) : self
     Intrinsics.fshl8(self, self, n.to_i8!).to_i8!
   end
@@ -1034,6 +1060,7 @@ struct Int8
   # 0b01001101_u8.rotate_right(11) # => 0b10101001
   # 0b01001101_u8.rotate_right(-1) # => 0b10011010
   # ```
+  @[AlwaysInline]
   def rotate_right(n : Int) : self
     Intrinsics.fshr8(self, self, n.to_i8!).to_i8!
   end
@@ -1072,6 +1099,7 @@ struct Int16
   Number.expand_div [Float32], Float32
   Number.expand_div [Float64], Float64
 
+  @[AlwaysInline]
   def - : Int16
     0_i16 - self
   end
@@ -1158,6 +1186,7 @@ struct Int16
   # 128_u8.neg_signed     # => -128_i8
   # Int16::MIN.neg_signed # raises OverflowError
   # ```
+  @[AlwaysInline]
   def neg_signed : self
     -self
   end
@@ -1173,6 +1202,7 @@ struct Int16
   # 0b01001011_u8.bit_reverse          # => 0b11010010
   # 0b1100100001100111_u16.bit_reverse # => 0b1110011000010011
   # ```
+  @[AlwaysInline]
   def bit_reverse : self
     Intrinsics.bitreverse16(self).to_i16!
   end
@@ -1185,15 +1215,18 @@ struct Int16
   # ```
   # 0x1234_i16.byte_swap # => 0x3412
   # ```
+  @[AlwaysInline]
   def byte_swap : self
     Intrinsics.bswap16(self).to_i16!
   end
 
   # Returns the number of leading `0`-bits.
+  @[AlwaysInline]
   def leading_zeros_count
     Intrinsics.countleading16(self, false)
   end
 
+  @[AlwaysInline]
   def trailing_zeros_count
     Intrinsics.counttrailing16(self, false)
   end
@@ -1207,6 +1240,7 @@ struct Int16
   # 0b01001101_u8.rotate_left(11) # => 0b01101010
   # 0b01001101_u8.rotate_left(-1) # => 0b10100110
   # ```
+  @[AlwaysInline]
   def rotate_left(n : Int) : self
     Intrinsics.fshl16(self, self, n.to_i16!).to_i16!
   end
@@ -1220,6 +1254,7 @@ struct Int16
   # 0b01001101_u8.rotate_right(11) # => 0b10101001
   # 0b01001101_u8.rotate_right(-1) # => 0b10011010
   # ```
+  @[AlwaysInline]
   def rotate_right(n : Int) : self
     Intrinsics.fshr16(self, self, n.to_i16!).to_i16!
   end
@@ -1258,6 +1293,7 @@ struct Int32
   Number.expand_div [Float32], Float32
   Number.expand_div [Float64], Float64
 
+  @[AlwaysInline]
   def - : Int32
     0 - self
   end
@@ -1344,6 +1380,7 @@ struct Int32
   # 128_u8.neg_signed     # => -128_i8
   # Int16::MIN.neg_signed # raises OverflowError
   # ```
+  @[AlwaysInline]
   def neg_signed : self
     -self
   end
@@ -1359,6 +1396,7 @@ struct Int32
   # 0b01001011_u8.bit_reverse          # => 0b11010010
   # 0b1100100001100111_u16.bit_reverse # => 0b1110011000010011
   # ```
+  @[AlwaysInline]
   def bit_reverse : self
     Intrinsics.bitreverse32(self).to_i32!
   end
@@ -1371,15 +1409,18 @@ struct Int32
   # ```
   # 0x12345678_i32.byte_swap # => 0x78563412
   # ```
+  @[AlwaysInline]
   def byte_swap : self
     Intrinsics.bswap32(self).to_i32!
   end
 
   # Returns the number of leading `0`-bits.
+  @[AlwaysInline]
   def leading_zeros_count
     Intrinsics.countleading32(self, false)
   end
 
+  @[AlwaysInline]
   def trailing_zeros_count
     Intrinsics.counttrailing32(self, false)
   end
@@ -1393,6 +1434,7 @@ struct Int32
   # 0b01001101_u8.rotate_left(11) # => 0b01101010
   # 0b01001101_u8.rotate_left(-1) # => 0b10100110
   # ```
+  @[AlwaysInline]
   def rotate_left(n : Int) : self
     Intrinsics.fshl32(self, self, n.to_i32!).to_i32!
   end
@@ -1406,6 +1448,7 @@ struct Int32
   # 0b01001101_u8.rotate_right(11) # => 0b10101001
   # 0b01001101_u8.rotate_right(-1) # => 0b10011010
   # ```
+  @[AlwaysInline]
   def rotate_right(n : Int) : self
     Intrinsics.fshr32(self, self, n.to_i32!).to_i32!
   end
@@ -1444,6 +1487,7 @@ struct Int64
   Number.expand_div [Float32], Float32
   Number.expand_div [Float64], Float64
 
+  @[AlwaysInline]
   def - : Int64
     0_i64 - self
   end
@@ -1530,6 +1574,7 @@ struct Int64
   # 128_u8.neg_signed     # => -128_i8
   # Int16::MIN.neg_signed # raises OverflowError
   # ```
+  @[AlwaysInline]
   def neg_signed : self
     -self
   end
@@ -1545,6 +1590,7 @@ struct Int64
   # 0b01001011_u8.bit_reverse          # => 0b11010010
   # 0b1100100001100111_u16.bit_reverse # => 0b1110011000010011
   # ```
+  @[AlwaysInline]
   def bit_reverse : self
     Intrinsics.bitreverse64(self).to_i64!
   end
@@ -1558,15 +1604,18 @@ struct Int64
   # 0x12345678_i64.byte_swap         # => 0x7856341200000000
   # 0x123456789ABCDEF0_i64.byte_swap # => -0xf21436587a9cbee
   # ```
+  @[AlwaysInline]
   def byte_swap : self
     Intrinsics.bswap64(self).to_i64!
   end
 
   # Returns the number of leading `0`-bits.
+  @[AlwaysInline]
   def leading_zeros_count
     Intrinsics.countleading64(self, false)
   end
 
+  @[AlwaysInline]
   def trailing_zeros_count
     Intrinsics.counttrailing64(self, false)
   end
@@ -1580,6 +1629,7 @@ struct Int64
   # 0b01001101_u8.rotate_left(11) # => 0b01101010
   # 0b01001101_u8.rotate_left(-1) # => 0b10100110
   # ```
+  @[AlwaysInline]
   def rotate_left(n : Int) : self
     Intrinsics.fshl64(self, self, n.to_i64!).to_i64!
   end
@@ -1593,6 +1643,7 @@ struct Int64
   # 0b01001101_u8.rotate_right(11) # => 0b10101001
   # 0b01001101_u8.rotate_right(-1) # => 0b10011010
   # ```
+  @[AlwaysInline]
   def rotate_right(n : Int) : self
     Intrinsics.fshr64(self, self, n.to_i64!).to_i64!
   end
@@ -1719,6 +1770,7 @@ struct Int128
   # 128_u8.neg_signed     # => -128_i8
   # Int16::MIN.neg_signed # raises OverflowError
   # ```
+  @[AlwaysInline]
   def neg_signed : self
     -self
   end
@@ -1734,6 +1786,7 @@ struct Int128
   # 0b01001011_u8.bit_reverse          # => 0b11010010
   # 0b1100100001100111_u16.bit_reverse # => 0b1110011000010011
   # ```
+  @[AlwaysInline]
   def bit_reverse : self
     Intrinsics.bitreverse128(self).to_i128!
   end
@@ -1746,15 +1799,18 @@ struct Int128
   # ```
   # 0x123456789_i128.byte_swap # ＝> -0x7698badcff0000000000000000000000
   # ```
+  @[AlwaysInline]
   def byte_swap : self
     Intrinsics.bswap128(self).to_i128!
   end
 
   # Returns the number of leading `0`-bits.
+  @[AlwaysInline]
   def leading_zeros_count
     Intrinsics.countleading128(self, false)
   end
 
+  @[AlwaysInline]
   def trailing_zeros_count
     Intrinsics.counttrailing128(self, false)
   end
@@ -1768,6 +1824,7 @@ struct Int128
   # 0b01001101_u8.rotate_left(11) # => 0b01101010
   # 0b01001101_u8.rotate_left(-1) # => 0b10100110
   # ```
+  @[AlwaysInline]
   def rotate_left(n : Int) : self
     Intrinsics.fshl128(self, self, n.to_i128!).to_i128!
   end
@@ -1781,6 +1838,7 @@ struct Int128
   # 0b01001101_u8.rotate_right(11) # => 0b10101001
   # 0b01001101_u8.rotate_right(-1) # => 0b10011010
   # ```
+  @[AlwaysInline]
   def rotate_right(n : Int) : self
     Intrinsics.fshr128(self, self, n.to_i128!).to_i128!
   end
@@ -1819,6 +1877,7 @@ struct UInt8
   Number.expand_div [Float32], Float32
   Number.expand_div [Float64], Float64
 
+  @[AlwaysInline]
   def &- : UInt8
     0_u8 &- self
   end
@@ -1909,6 +1968,7 @@ struct UInt8
   # 128_u8.neg_signed     # => -128_i8
   # Int16::MIN.neg_signed # raises OverflowError
   # ```
+  @[AlwaysInline]
   def neg_signed : Int8
     0_i8 - self
   end
@@ -1924,6 +1984,7 @@ struct UInt8
   # 0b01001011_u8.bit_reverse          # => 0b11010010
   # 0b1100100001100111_u16.bit_reverse # => 0b1110011000010011
   # ```
+  @[AlwaysInline]
   def bit_reverse : self
     Intrinsics.bitreverse8(self)
   end
@@ -1936,15 +1997,18 @@ struct UInt8
   # ```
   # 0x12_u8.byte_swap # => 0x12
   # ```
+  @[AlwaysInline]
   def byte_swap : self
     self
   end
 
   # Returns the number of leading `0`-bits.
+  @[AlwaysInline]
   def leading_zeros_count
     Intrinsics.countleading8(self, false)
   end
 
+  @[AlwaysInline]
   def trailing_zeros_count
     Intrinsics.counttrailing8(self, false)
   end
@@ -1958,6 +2022,7 @@ struct UInt8
   # 0b01001101_u8.rotate_left(11) # => 0b01101010
   # 0b01001101_u8.rotate_left(-1) # => 0b10100110
   # ```
+  @[AlwaysInline]
   def rotate_left(n : Int) : self
     Intrinsics.fshl8(self, self, n.to_u8!)
   end
@@ -1971,6 +2036,7 @@ struct UInt8
   # 0b01001101_u8.rotate_right(11) # => 0b10101001
   # 0b01001101_u8.rotate_right(-1) # => 0b10011010
   # ```
+  @[AlwaysInline]
   def rotate_right(n : Int) : self
     Intrinsics.fshr8(self, self, n.to_u8!)
   end
@@ -2009,6 +2075,7 @@ struct UInt16
   Number.expand_div [Float32], Float32
   Number.expand_div [Float64], Float64
 
+  @[AlwaysInline]
   def &- : UInt16
     0_u16 &- self
   end
@@ -2099,6 +2166,7 @@ struct UInt16
   # 128_u8.neg_signed     # => -128_i8
   # Int16::MIN.neg_signed # raises OverflowError
   # ```
+  @[AlwaysInline]
   def neg_signed : Int16
     0_i16 - self
   end
@@ -2114,6 +2182,7 @@ struct UInt16
   # 0b01001011_u8.bit_reverse          # => 0b11010010
   # 0b1100100001100111_u16.bit_reverse # => 0b1110011000010011
   # ```
+  @[AlwaysInline]
   def bit_reverse : self
     Intrinsics.bitreverse16(self)
   end
@@ -2126,15 +2195,18 @@ struct UInt16
   # ```
   # 0x1234_u16.byte_swap # => 0x3412
   # ```
+  @[AlwaysInline]
   def byte_swap : self
     Intrinsics.bswap16(self)
   end
 
   # Returns the number of leading `0`-bits.
+  @[AlwaysInline]
   def leading_zeros_count
     Intrinsics.countleading16(self, false)
   end
 
+  @[AlwaysInline]
   def trailing_zeros_count
     Intrinsics.counttrailing16(self, false)
   end
@@ -2148,6 +2220,7 @@ struct UInt16
   # 0b01001101_u8.rotate_left(11) # => 0b01101010
   # 0b01001101_u8.rotate_left(-1) # => 0b10100110
   # ```
+  @[AlwaysInline]
   def rotate_left(n : Int) : self
     Intrinsics.fshl16(self, self, n.to_u16!)
   end
@@ -2161,6 +2234,7 @@ struct UInt16
   # 0b01001101_u8.rotate_right(11) # => 0b10101001
   # 0b01001101_u8.rotate_right(-1) # => 0b10011010
   # ```
+  @[AlwaysInline]
   def rotate_right(n : Int) : self
     Intrinsics.fshr16(self, self, n.to_u16!)
   end
@@ -2199,6 +2273,7 @@ struct UInt32
   Number.expand_div [Float32], Float32
   Number.expand_div [Float64], Float64
 
+  @[AlwaysInline]
   def &- : UInt32
     0_u32 &- self
   end
@@ -2289,6 +2364,7 @@ struct UInt32
   # 128_u8.neg_signed     # => -128_i8
   # Int16::MIN.neg_signed # raises OverflowError
   # ```
+  @[AlwaysInline]
   def neg_signed : Int32
     0_i32 - self
   end
@@ -2304,6 +2380,7 @@ struct UInt32
   # 0b01001011_u8.bit_reverse          # => 0b11010010
   # 0b1100100001100111_u16.bit_reverse # => 0b1110011000010011
   # ```
+  @[AlwaysInline]
   def bit_reverse : self
     Intrinsics.bitreverse32(self)
   end
@@ -2316,15 +2393,18 @@ struct UInt32
   # ```
   # 0x12345678_u32.byte_swap # => 0x78563412
   # ```
+  @[AlwaysInline]
   def byte_swap : self
     Intrinsics.bswap32(self)
   end
 
   # Returns the number of leading `0`-bits.
+  @[AlwaysInline]
   def leading_zeros_count
     Intrinsics.countleading32(self, false)
   end
 
+  @[AlwaysInline]
   def trailing_zeros_count
     Intrinsics.counttrailing32(self, false)
   end
@@ -2338,6 +2418,7 @@ struct UInt32
   # 0b01001101_u8.rotate_left(11) # => 0b01101010
   # 0b01001101_u8.rotate_left(-1) # => 0b10100110
   # ```
+  @[AlwaysInline]
   def rotate_left(n : Int) : self
     Intrinsics.fshl32(self, self, n.to_u32!)
   end
@@ -2351,6 +2432,7 @@ struct UInt32
   # 0b01001101_u8.rotate_right(11) # => 0b10101001
   # 0b01001101_u8.rotate_right(-1) # => 0b10011010
   # ```
+  @[AlwaysInline]
   def rotate_right(n : Int) : self
     Intrinsics.fshr32(self, self, n.to_u32!)
   end
@@ -2389,6 +2471,7 @@ struct UInt64
   Number.expand_div [Float32], Float32
   Number.expand_div [Float64], Float64
 
+  @[AlwaysInline]
   def &- : UInt64
     0_u64 &- self
   end
@@ -2403,6 +2486,7 @@ struct UInt64
   # 2_u16.to_signed # => 2_i16
   # 3_i64.to_signed # => 3_i64
   # ```
+  @[AlwaysInline]
   def to_signed : Int64
     to_i64
   end
@@ -2479,6 +2563,7 @@ struct UInt64
   # 128_u8.neg_signed     # => -128_i8
   # Int16::MIN.neg_signed # raises OverflowError
   # ```
+  @[AlwaysInline]
   def neg_signed : Int64
     0_i64 - self
   end
@@ -2494,6 +2579,7 @@ struct UInt64
   # 0b01001011_u8.bit_reverse          # => 0b11010010
   # 0b1100100001100111_u16.bit_reverse # => 0b1110011000010011
   # ```
+  @[AlwaysInline]
   def bit_reverse : self
     Intrinsics.bitreverse64(self)
   end
@@ -2506,15 +2592,18 @@ struct UInt64
   # ```
   # 0x123456789ABCDEF0_u64.byte_swap # => 0xF0DEBC9A78563412
   # ```
+  @[AlwaysInline]
   def byte_swap : self
     Intrinsics.bswap64(self)
   end
 
   # Returns the number of leading `0`-bits.
+  @[AlwaysInline]
   def leading_zeros_count
     Intrinsics.countleading64(self, false)
   end
 
+  @[AlwaysInline]
   def trailing_zeros_count
     Intrinsics.counttrailing64(self, false)
   end
@@ -2528,6 +2617,7 @@ struct UInt64
   # 0b01001101_u8.rotate_left(11) # => 0b01101010
   # 0b01001101_u8.rotate_left(-1) # => 0b10100110
   # ```
+  @[AlwaysInline]
   def rotate_left(n : Int) : self
     Intrinsics.fshl64(self, self, n.to_u64!)
   end
@@ -2541,6 +2631,7 @@ struct UInt64
   # 0b01001101_u8.rotate_right(11) # => 0b10101001
   # 0b01001101_u8.rotate_right(-1) # => 0b10011010
   # ```
+  @[AlwaysInline]
   def rotate_right(n : Int) : self
     Intrinsics.fshr64(self, self, n.to_u64!)
   end
@@ -2580,6 +2671,7 @@ struct UInt128
   Number.expand_div [Float32], Float32
   Number.expand_div [Float64], Float64
 
+  @[AlwaysInline]
   def &-
     # TODO: use 0_u128 &- self
     UInt128.new(0) &- self
@@ -2671,6 +2763,7 @@ struct UInt128
   # 128_u8.neg_signed     # => -128_i8
   # Int16::MIN.neg_signed # raises OverflowError
   # ```
+  @[AlwaysInline]
   def neg_signed : Int128
     Int128.new(0) - self
   end
@@ -2686,6 +2779,7 @@ struct UInt128
   # 0b01001011_u8.bit_reverse          # => 0b11010010
   # 0b1100100001100111_u16.bit_reverse # => 0b1110011000010011
   # ```
+  @[AlwaysInline]
   def bit_reverse : self
     Intrinsics.bitreverse128(self)
   end
@@ -2698,15 +2792,18 @@ struct UInt128
   # ```
   # 0x123456789ABCDEF013579BDF2468ACE0_u128.byte_swap # ＝> 0xE0AC6824DF9B5713F0DEBC9A78563412
   # ```
+  @[AlwaysInline]
   def byte_swap : self
     Intrinsics.bswap128(self)
   end
 
   # Returns the number of leading `0`-bits.
+  @[AlwaysInline]
   def leading_zeros_count
     Intrinsics.countleading128(self, false)
   end
 
+  @[AlwaysInline]
   def trailing_zeros_count
     Intrinsics.counttrailing128(self, false)
   end
@@ -2720,6 +2817,7 @@ struct UInt128
   # 0b01001101_u8.rotate_left(11) # => 0b01101010
   # 0b01001101_u8.rotate_left(-1) # => 0b10100110
   # ```
+  @[AlwaysInline]
   def rotate_left(n : Int) : self
     Intrinsics.fshl128(self, self, n.to_u128!)
   end
@@ -2733,6 +2831,7 @@ struct UInt128
   # 0b01001101_u8.rotate_right(11) # => 0b10101001
   # 0b01001101_u8.rotate_right(-1) # => 0b10011010
   # ```
+  @[AlwaysInline]
   def rotate_right(n : Int) : self
     Intrinsics.fshr128(self, self, n.to_u128!)
   end

--- a/src/intrinsics.cr
+++ b/src/intrinsics.cr
@@ -163,6 +163,8 @@ lib LibIntrinsics
     {% if flag?(:interpreted) %} @[Primitive(:interpreter_intrinsics_pause)] {% end %}
     fun arm_hint = "llvm.aarch64.hint"(hint : Int32)
   {% end %}
+
+  fun expect_i1 = "llvm.expect.i1"(val : Bool, exp : Bool) : Bool
 end
 
 module Intrinsics
@@ -190,62 +192,77 @@ module Intrinsics
     LibIntrinsics.memset({{dest}}, {{val}}, {{len}}, {{is_volatile}})
   end
 
+  @[AlwaysInline]
   def self.read_cycle_counter
     LibIntrinsics.read_cycle_counter
   end
 
+  @[AlwaysInline]
   def self.bitreverse8(id) : UInt8
     LibIntrinsics.bitreverse8(id)
   end
 
+  @[AlwaysInline]
   def self.bitreverse16(id) : UInt16
     LibIntrinsics.bitreverse16(id)
   end
 
+  @[AlwaysInline]
   def self.bitreverse32(id) : UInt32
     LibIntrinsics.bitreverse32(id)
   end
 
+  @[AlwaysInline]
   def self.bitreverse64(id) : UInt64
     LibIntrinsics.bitreverse64(id)
   end
 
+  @[AlwaysInline]
   def self.bitreverse128(id) : UInt128
     LibIntrinsics.bitreverse128(id)
   end
 
+  @[AlwaysInline]
   def self.bswap16(id) : UInt16
     LibIntrinsics.bswap16(id)
   end
 
+  @[AlwaysInline]
   def self.bswap32(id) : UInt32
     LibIntrinsics.bswap32(id)
   end
 
+  @[AlwaysInline]
   def self.bswap64(id) : UInt64
     LibIntrinsics.bswap64(id)
   end
 
+  @[AlwaysInline]
   def self.bswap128(id) : UInt128
     LibIntrinsics.bswap128(id)
   end
 
+  @[AlwaysInline]
   def self.popcount8(src) : Int8
     LibIntrinsics.popcount8(src)
   end
 
+  @[AlwaysInline]
   def self.popcount16(src) : Int16
     LibIntrinsics.popcount16(src)
   end
 
+  @[AlwaysInline]
   def self.popcount32(src) : Int32
     LibIntrinsics.popcount32(src)
   end
 
+  @[AlwaysInline]
   def self.popcount64(src) : Int64
     LibIntrinsics.popcount64(src)
   end
 
+  @[AlwaysInline]
   def self.popcount128(src)
     LibIntrinsics.popcount128(src)
   end
@@ -290,42 +307,52 @@ module Intrinsics
     LibIntrinsics.counttrailing128({{src}}, {{zero_is_undef}})
   end
 
+  @[AlwaysInline]
   def self.fshl8(a, b, count) : UInt8
     LibIntrinsics.fshl8(a, b, count)
   end
 
+  @[AlwaysInline]
   def self.fshl16(a, b, count) : UInt16
     LibIntrinsics.fshl16(a, b, count)
   end
 
+  @[AlwaysInline]
   def self.fshl32(a, b, count) : UInt32
     LibIntrinsics.fshl32(a, b, count)
   end
 
+  @[AlwaysInline]
   def self.fshl64(a, b, count) : UInt64
     LibIntrinsics.fshl64(a, b, count)
   end
 
+  @[AlwaysInline]
   def self.fshl128(a, b, count) : UInt128
     LibIntrinsics.fshl128(a, b, count)
   end
 
+  @[AlwaysInline]
   def self.fshr8(a, b, count) : UInt8
     LibIntrinsics.fshr8(a, b, count)
   end
 
+  @[AlwaysInline]
   def self.fshr16(a, b, count) : UInt16
     LibIntrinsics.fshr16(a, b, count)
   end
 
+  @[AlwaysInline]
   def self.fshr32(a, b, count) : UInt32
     LibIntrinsics.fshr32(a, b, count)
   end
 
+  @[AlwaysInline]
   def self.fshr64(a, b, count) : UInt64
     LibIntrinsics.fshr64(a, b, count)
   end
 
+  @[AlwaysInline]
   def self.fshr128(a, b, count) : UInt128
     LibIntrinsics.fshr128(a, b, count)
   end
@@ -336,6 +363,14 @@ module Intrinsics
 
   macro va_end(ap)
     LibIntrinsics.va_end({{ap}})
+  end
+
+  macro likely(val)
+    LibIntrinsics.expect_i1((({{val}})), true)
+  end
+
+  macro unlikely(val)
+    LibIntrinsics.expect_i1((({{val}})), false)
   end
 end
 

--- a/src/json/lexer.cr
+++ b/src/json/lexer.cr
@@ -309,6 +309,7 @@ abstract class JSON::Lexer
     number_end
   end
 
+  @[AlwaysInline]
   private def next_char
     @column_number += 1
     next_char_no_column_increment

--- a/src/object.cr
+++ b/src/object.cr
@@ -10,6 +10,7 @@ class Object
   # By default this method is implemented as `!(self == other)`
   # so there's no need to override this unless there's a more efficient
   # way to do it.
+  @[AlwaysInline]
   def !=(other)
     !(self == other)
   end
@@ -46,6 +47,7 @@ class Object
   #
   # Object simply implements `===` by invoking `==`, but subclasses
   # (notably `Regex`) can override it to provide meaningful case-equality semantics.
+  @[AlwaysInline]
   def ===(other)
     self == other
   end
@@ -201,11 +203,13 @@ class Object
   # 10.in?(0, 1, 10)   # => true
   # 10.in?(:foo, :bar) # => false
   # ```
+  @[AlwaysInline]
   def in?(collection : Object) : Bool
     collection.includes?(self)
   end
 
   # :ditto:
+  @[AlwaysInline]
   def in?(*values : Object) : Bool
     in?(values)
   end
@@ -319,6 +323,7 @@ class Object
   # `as`, you can't specify some types in the type grammar using a short notation, so
   # specifying a static array must always be done as `StaticArray(T, N)`, a tuple
   # as `Tuple(...)` and so on, never as `UInt8[4]` or `{Int32, Int32}`.
+  @[AlwaysInline]
   def unsafe_as(type : T.class) forall T
     x = self
     pointerof(x).as(T*).value
@@ -1429,6 +1434,7 @@ class Object
     end
   end
 
+  @[AlwaysInline]
   protected def self.set_crystal_type_id(ptr)
     ptr.as(Pointer(typeof(crystal_instance_type_id))).value = crystal_instance_type_id
     ptr

--- a/src/pointer.cr
+++ b/src/pointer.cr
@@ -40,15 +40,18 @@ struct Pointer(T)
       @start = @pointer
     end
 
+    @[AlwaysInline]
     def <<(value : T)
       @pointer.value = value
       @pointer += 1
     end
 
+    @[AlwaysInline]
     def size : Int64
       @pointer - @start
     end
 
+    @[AlwaysInline]
     def pointer
       @pointer
     end
@@ -65,6 +68,7 @@ struct Pointer(T)
   # b = Pointer(Int32).new(0)
   # b.null? # => true
   # ```
+  @[AlwaysInline]
   def null? : Bool
     address == 0
   end
@@ -79,6 +83,7 @@ struct Pointer(T)
   # ptr2 = ptr + 1
   # ptr2.address # => 1238
   # ```
+  @[AlwaysInline]
   def +(other : Int)
     self + other.to_i64
   end
@@ -93,6 +98,7 @@ struct Pointer(T)
   # ptr2 = ptr - 1
   # ptr2.address # => 1230
   # ```
+  @[AlwaysInline]
   def -(other : Int)
     # TODO: If throwing on overflow for integer conversion is implemented,
     # then (here and in `Pointer#-`) for a `UInt64` argument the call to
@@ -102,6 +108,7 @@ struct Pointer(T)
 
   # Returns `-1`, `0` or `1` depending on whether this pointer's address is less, equal or greater than *other*'s address,
   # respectively.
+  @[AlwaysInline]
   def <=>(other : self)
     address <=> other.address
   end
@@ -115,6 +122,7 @@ struct Pointer(T)
   # ptr[2] # => 12
   # ptr[3] # => 13
   # ```
+  @[AlwaysInline]
   def [](offset)
     (self + offset).value
   end
@@ -128,6 +136,7 @@ struct Pointer(T)
   # ptr2 = ptr + 1
   # ptr2.value # => 42
   # ```
+  @[AlwaysInline]
   def []=(offset, value : T)
     (self + offset).value = value
   end
@@ -285,6 +294,7 @@ struct Pointer(T)
   # ptr2.memcmp(ptr1, 4) # => 10
   # ptr1.memcmp(ptr1, 4) # => 0
   # ```
+  @[AlwaysInline]
   def memcmp(other : Pointer(T), count : Int) : Int32
     LibC.memcmp(self.as(Void*), (other.as(Void*)), (count * sizeof(T)))
   end
@@ -299,6 +309,7 @@ struct Pointer(T)
   # ptr[2] # => 4
   # ptr[3] # => 3
   # ```
+  @[AlwaysInline]
   def swap(i, j)
     self[i], self[j] = self[j], self[i]
   end
@@ -408,6 +419,7 @@ struct Pointer(T)
   # ptr = Pointer(Int32).null
   # ptr.address # => 0
   # ```
+  @[AlwaysInline]
   def self.null
     new 0_u64
   end
@@ -486,6 +498,7 @@ struct Pointer(T)
   end
 
   # Returns a `Pointer::Appender` for this pointer.
+  @[AlwaysInline]
   def appender : Pointer::Appender
     Pointer::Appender.new(self)
   end
@@ -497,6 +510,7 @@ struct Pointer(T)
   # slice = ptr.to_slice(4)                # => Slice[10, 11, 12, 13]
   # slice.class                            # => Slice(Int32)
   # ```
+  @[AlwaysInline]
   def to_slice(size) : Slice(T)
     Slice.new(self, size)
   end
@@ -508,6 +522,7 @@ struct Pointer(T)
   # ptr.clear(3)
   # ptr.to_slice(6) # => Slice[0, 0, 0, 13, 14, 15]
   # ```
+  @[AlwaysInline]
   def clear(count = 1)
     Intrinsics.memset(self.as(Void*), 0_u8, bytesize(count), false)
   end
@@ -516,6 +531,7 @@ struct Pointer(T)
     self
   end
 
+  @[AlwaysInline]
   private def bytesize(count)
     {% if flag?(:bits64) %}
       count.to_u64 * sizeof(T)

--- a/src/range.cr
+++ b/src/range.cr
@@ -86,6 +86,7 @@ struct Range(B, E)
   # Range.new(1, 10)                  # => 1..10
   # Range.new(1, 10, exclusive: true) # => 1...10
   # ```
+  @[AlwaysInline]
   def initialize(@begin : B, @end : E, @exclusive : Bool = false)
   end
 
@@ -124,7 +125,7 @@ struct Range(B, E)
       end
     {% else %}
       end_value = @end
-      while end_value.nil? || current < end_value
+      while Intrinsics.likely(end_value.nil? || current < end_value)
         {{ "yield current".id }}
         current = current.succ
       end
@@ -171,7 +172,7 @@ struct Range(B, E)
         {{ "yield current".id }}
       end
     {% else %}
-      while begin_value.nil? || begin_value < current
+      while Intrinsics.likely(begin_value.nil? || begin_value < current)
         current = current.pred
         {{ "yield current".id }}
       end
@@ -223,7 +224,7 @@ struct Range(B, E)
       end
     {% else %}
       end_value = @end
-      while end_value.nil? || current < end_value
+      while Intrinsics.likely(end_value.nil? || current < end_value)
         yield current
         by.times do
           current = current.succ
@@ -260,6 +261,7 @@ struct Range(B, E)
   # (1..10).excludes_end?  # => false
   # (1...10).excludes_end? # => true
   # ```
+  @[AlwaysInline]
   def excludes_end? : Bool
     @exclusive
   end
@@ -274,6 +276,7 @@ struct Range(B, E)
   # (1...10).includes?(9)  # => true
   # (1...10).includes?(10) # => false
   # ```
+  @[AlwaysInline]
   def includes?(value) : Bool
     begin_value = @begin
     end_value = @end
@@ -286,6 +289,7 @@ struct Range(B, E)
   end
 
   # Same as `includes?`.
+  @[AlwaysInline]
   def covers?(value)
     includes?(value)
   end
@@ -307,6 +311,7 @@ struct Range(B, E)
   # ```
   #
   # See also: `Object#===`.
+  @[AlwaysInline]
   def ===(value)
     includes?(value)
   end

--- a/src/reference.cr
+++ b/src/reference.cr
@@ -61,22 +61,26 @@ class Reference
   end
 
   # Returns `true` if this reference is the same as *other*. Invokes `same?`.
+  @[AlwaysInline]
   def ==(other : self)
     same?(other)
   end
 
   # Returns `false` (other can only be a `Value` here).
+  @[AlwaysInline]
   def ==(other)
     false
   end
 
   # Returns `true` if this reference is the same as *other*. This is only
   # `true` if this reference's `object_id` is the same as *other*'s.
+  @[AlwaysInline]
   def same?(other : Reference) : Bool
     object_id == other.object_id
   end
 
   # Returns `false`: a reference is never `nil`.
+  @[AlwaysInline]
   def same?(other : Nil)
     false
   end

--- a/src/slice.cr
+++ b/src/slice.cr
@@ -151,6 +151,7 @@ struct Slice(T)
   # slice = Slice(UInt8).empty
   # slice.size # => 0
   # ```
+  @[AlwaysInline]
   def self.empty : self
     new(Pointer(T).null, 0)
   end
@@ -252,6 +253,7 @@ struct Slice(T)
   # slice[1, 3]  # => Slice[11, 12, 13]
   # slice[1, 33] # raises IndexError
   # ```
+  @[AlwaysInline]
   def [](start : Int, count : Int) : Slice(T)
     self[start, count]? || raise IndexError.new
   end
@@ -271,6 +273,7 @@ struct Slice(T)
   # slice[1..3]?  # => Slice[11, 12, 13]
   # slice[1..33]? # => nil
   # ```
+  @[AlwaysInline]
   def []?(range : Range)
     start, count = Indexable.range_to_index_and_count(range, size) || raise IndexError.new
     self[start, count]?
@@ -302,6 +305,7 @@ struct Slice(T)
   # slice[1..3]  # => Slice[11, 12, 13]
   # slice[1..33] # raises IndexError
   # ```
+  @[AlwaysInline]
   def [](range : Range) : Slice(T)
     start, count = Indexable.range_to_index_and_count(range, size) || raise IndexError.new
     self[start, count]
@@ -328,6 +332,7 @@ struct Slice(T)
   # :inherit:
   #
   # Raises if this slice is read-only.
+  @[AlwaysInline]
   def swap(index0 : Int, index1 : Int) : self
     check_writable
     super

--- a/src/static_array.cr
+++ b/src/static_array.cr
@@ -135,6 +135,7 @@ struct StaticArray(T, N)
   # array = StaticArray(Int32, 3).new { |i| i + 1 }
   # array.size # => 3
   # ```
+  @[AlwaysInline]
   def size : Int32
     N
   end
@@ -376,6 +377,7 @@ struct StaticArray(T, N)
   # ary = StaticArray(Int32, 3).new(42)
   # ary.to_unsafe[0] # => 42
   # ```
+  @[AlwaysInline]
   def to_unsafe : Pointer(T)
     pointerof(@buffer)
   end

--- a/src/string.cr
+++ b/src/string.cr
@@ -3071,6 +3071,7 @@ class String
   #
   # "abcdef".compare("ABCDEF", case_insensitive: true) == 0 # => true
   # ```
+  @[AlwaysInline]
   def ==(other : self) : Bool
     return true if same?(other)
     return false unless bytesize == other.bytesize
@@ -5264,8 +5265,9 @@ class String
   # "hello".size # => 5
   # "你好".size    # => 2
   # ```
+  @[AlwaysInline]
   def size : Int32
-    if @length > 0 || @bytesize == 0
+    if Intrinsics.likely(@length > 0 || @bytesize == 0)
       return @length
     end
 
@@ -5325,6 +5327,7 @@ class String
     result ? result.to_s : self
   end
 
+  @[AlwaysInline]
   protected def char_bytesize_at(byte_index)
     String.char_bytesize_at(to_unsafe + byte_index)
   end
@@ -5433,6 +5436,7 @@ class String
   #
   # May contain invalid UTF-8 byte sequences; `#scrub` may be used to first
   # obtain a `String` that is guaranteed to be valid UTF-8.
+  @[AlwaysInline]
   def to_slice : Bytes
     Slice.new(to_unsafe, bytesize, read_only: true)
   end
@@ -5441,6 +5445,7 @@ class String
   #
   # May contain invalid UTF-8 byte sequences; `#scrub` may be used to first
   # obtain a `String` that is guaranteed to be valid UTF-8.
+  @[AlwaysInline]
   def to_unsafe : UInt8*
     pointerof(@c)
   end

--- a/src/tuple.cr
+++ b/src/tuple.cr
@@ -171,6 +171,7 @@ struct Tuple
     {% end %}
   end
 
+  @[AlwaysInline]
   def unsafe_fetch(index : Int)
     self[index]
   end
@@ -191,6 +192,7 @@ struct Tuple
   # i = 3
   # tuple[i] # raises IndexError
   # ```
+  @[AlwaysInline]
   def [](index : Int)
     at(index)
   end
@@ -212,6 +214,7 @@ struct Tuple
   # i = 2
   # Foo[i] # raises IndexError
   # ```
+  @[AlwaysInline]
   def self.[](index : Int)
     self[index]? || raise IndexError.new
   end
@@ -234,6 +237,7 @@ struct Tuple
   # i = 3
   # tuple[i]? # => nil
   # ```
+  @[AlwaysInline]
   def []?(index : Int)
     at(index) { nil }
   end


### PR DESCRIPTION
All this changes questionable and I don't know even if it pass specs. Also optimization results was for my set of benchmarks, and I don't know if it would work for something else.

Changes:
--
1) behavior of `AlwaysInline`, now AlwaysInline behave like it sounds, purely inline code on crystal level. Before it just marks it in llvm (so inline works only in current llvm module, no cross module inlining). Not sure if backtrace btw works. So now all methods marked by AlwaysInline, like headers in C++. Also mark by this AlwaysInline many small but critical methods, which have most slowdown in per module compilation. This marks was only done for methods, which I only found was to be slow, in my tests. But I am sure there also many methods which I missed.
2) Also add `likely` intrinsic which should help in non single-module optimizations.

Results:
--
In this PR `-O2` became is a decent level of compilation, which runtime is 0.9-2 times slower than release (in 1 test even faster), but compile time is 3-4 times faster, incremental compile time: 5-10 times faster.
`--release` just little faster after all this optimizations, because single-module and O3 doing similar thing with inlining. 
On the recompile compiler this optimizations have no visible effect.

Example of optimization from some benchmarks:
--
brainfuck       
Master: `-O2: initial: 2.40s, incremental: 1.33s, run time: 19.71s`                                                       
This branch: `-O2: initial: 2.25s, incremental: 1.32s, run time: 4.90s`
brainfuck runtime 4 times faster in this branch. and almost equal release result: 4.26s (which compile time is 6.74s)
