### PR TITLE
Add alternative letter casings for `Enum` names

### DIFF
--- a/spec/std/enum_spec.cr
+++ b/spec/std/enum_spec.cr
@@ -107,6 +107,30 @@ describe Enum do
     end
   end
 
+  describe "#downcase_name" do
+    it "for simple enum" do
+      assert_prints SpecEnum::One.downcase_name, "one"
+      assert_prints SpecEnum::Two.downcase_name, "two"
+      assert_prints SpecEnum2::FortyTwo.downcase_name, "fortytwo"
+    end
+  end
+
+  describe "#snakecase_name" do
+    it "for simple enum" do
+      assert_prints SpecEnum::One.snakecase_name, "one"
+      assert_prints SpecEnum2::FortyTwo.snakecase_name, "forty_two"
+      assert_prints SpecEnum2::FORTY_FOUR.snakecase_name, "forty_four"
+    end
+  end
+
+  describe "#kebabcase_name" do
+    it "for simple enum" do
+      assert_prints SpecEnum::One.kebabcase_name, "one"
+      assert_prints SpecEnum2::FortyTwo.kebabcase_name, "forty-two"
+      assert_prints SpecEnum2::FORTY_FOUR.kebabcase_name, "forty-four"
+    end
+  end
+
   it "creates an enum instance from an auto-casted symbol (#8573)" do
     enum_value = SpecEnum.new(:two)
     enum_value.should eq SpecEnum::Two

--- a/src/enum.cr
+++ b/src/enum.cr
@@ -165,6 +165,51 @@ struct Enum
     {% end %}
   end
 
+  def downcase_name(io : IO) : Nil
+    io << downcase_name
+  end
+
+  def downcase_name : String
+    {% begin %}
+      case self
+      {% for member in @type.constants %}
+        in .{{ member.id.underscore }}?
+          "{{ member.id.downcase }}"
+      {% end %}
+      end
+    {% end %}
+  end
+
+  def snakecase_name(io : IO) : Nil
+    io << snakecase_name
+  end
+
+  def snakecase_name : String
+    {% begin %}
+      case self
+      {% for member in @type.constants %}
+        in .{{ member.id.underscore }}?
+          "{{ member.id.underscore }}"
+      {% end %}
+      end
+    {% end %}
+  end
+
+  def kebabcase_name(io : IO) : Nil
+    io << kebabcase_name
+  end
+
+  def kebabcase_name : String
+    {% begin %}
+      case self
+      {% for member in @type.constants %}
+        in .{{ member.id.underscore }}?
+          "{{ member.id.underscore.tr("_", "-") }}"
+      {% end %}
+      end
+    {% end %}
+  end
+
   # Returns an unambiguous `String` representation of this enum member.
   # In the case of a single member value, this is the fully qualified name of
   # the member (equivalent to `#to_s` with the enum name as prefix).


### PR DESCRIPTION
I need these in enums all the time. A lot of times, enum values are serialized in other systems (databases, third-party services, etc) differently, so I usually implement these methods myself in my apps. I wasn't sure how many other people were experiencing this, but then I saw [this thread on the forum](https://forum.crystal-lang.org/t/how-to-downcase-an-enum-member-name/6313), so I'm clearly not alone in this.

In hindsight, `snakecase_name` should probably be `underscore_name` to match `String#underscore`. We don't seem to have any precedent for `kebabcase` in the stdlib, but it's pretty common to serialize low-cardinality multi-word string values this way.

This isn't complete yet, there are still a couple things that should be done, but I wanted to get something started since I'd already written the code for the forum post.

- [ ] Update `Enum#to_json` to use `snakecase_name` (or `underscore_name`, whatever we call it) rather than [its current bespoke implementation](https://github.com/crystal-lang/crystal/blob/f5844b0fc1ad9eec10cb823f732b9e6e72ee7422/src/json/to_json.cr#L218-L228)
  - This implementation is also more efficient than the current one since it avoids a heap allocation
- [ ] Use `member_name` because I'd forgotten about [this](https://github.com/crystal-lang/crystal/blob/f5844b0fc1ad9eec10cb823f732b9e6e72ee7422/src/enum.cr#L229-L230)
- [ ] Add `Flags` support