### PR TITLE
Compiler: parallel codegen with MT

### DIFF
--- a/src/llvm/lib_llvm/bit_reader.cr
+++ b/src/llvm/lib_llvm/bit_reader.cr
@@ -1,0 +1,5 @@
+require "./types"
+
+lib LibLLVM
+  fun parse_bitcode_in_context2 = LLVMParseBitcodeInContext2(c : ContextRef, mb : MemoryBufferRef, m : ModuleRef*) : Int
+end

--- a/src/llvm/module.cr
+++ b/src/llvm/module.cr
@@ -6,6 +6,12 @@ class LLVM::Module
 
   getter context : Context
 
+  def self.parse(memory_buffer : MemoryBuffer, context : Context) : self
+    LibLLVM.parse_bitcode_in_context2(context, memory_buffer, out module_ref)
+    raise "BUG: failed to parse LLVM bitcode from memory buffer" unless module_ref
+    new(module_ref, context)
+  end
+
   def initialize(@unwrap : LibLLVM::ModuleRef, @context : Context)
     @owned = false
   end


### PR DESCRIPTION
This implements parallel codegen of object files when MT is enabled in the compiler, which brings some performance improvements.

For example to compile Crystal itself on my laptop with empty caches: the codegen takes ~20s with `fork` and only ~14s with MT (~35s without this patch). With a filled cache `fork` takes ~9s and only ~4s with MT (~5s without this patch) :rocket: 

The biggest issue is LLVM having thread safety issues. The most prominent is that LLVMContext can't be shared, while the C library creates a global context, and from my tests LLVMTargetMachine can't be shared across threads either. There are no issues with the LLVM optimization pass with LLVM 16 at least; it might be different in LLVM 12 and before that use a different API (and reuses LLVM objects).

I applied the patch on top of Crystal 1.11.1 and I could build _and_ rebuild the compiler in non-release mode, `-O1`, `-O2`, `-O3` or `--single-module`. Sadly, a compiler built with `--single-module -O1` or `--release` will segfault during codegen :sob: