### PR TITLE
Remove filtering of already mentioned PRs

### DIFF
--- a/scripts/github-changelog.cr
+++ b/scripts/github-changelog.cr
@@ -262,9 +262,6 @@ array = parser.on_key! "data" do
   end
 end
 
-changelog = File.read("CHANGELOG.md")
-array.select! { |pr| pr.merged_at && !changelog.index(pr.permalink) }
-
 sections = array.group_by(&.section)
 
 SECTION_TITLES = {


### PR DESCRIPTION
Currently, the changelog script only prints entries that are not already mentioned in `CHANGELOG.md`, thus representing newly merged PRs that need to be added to the changelog.
With the new changelog format this is no longer practical and instead we're generating the entire changelog section for the current release and replace it for the existing one.