### PR TITLE
Drop flag `openbsd6.2`

### DIFF
--- a/src/crystal/system/unix/fiber.cr
+++ b/src/crystal/system/unix/fiber.cr
@@ -3,7 +3,7 @@ require "c/sys/mman"
 module Crystal::System::Fiber
   def self.allocate_stack(stack_size) : Void*
     flags = LibC::MAP_PRIVATE | LibC::MAP_ANON
-    {% if flag?(:openbsd) && !flag?(:"openbsd6.2") %}
+    {% if flag?(:openbsd) %}
       flags |= LibC::MAP_STACK
     {% end %}
 


### PR DESCRIPTION
OpenBSD 6.2 has been out of support since 2018.
I don't think this flag is useful anymore.
It was introduced in c9f449c6fc9c5d1afdaf920e301377ab0312036b to keep support with older versions.