### PR TITLE
Optimize hash lookup in `Enumerable#group_by`

### DIFF
--- a/src/enumerable.cr
+++ b/src/enumerable.cr
@@ -636,11 +636,7 @@ module Enumerable(T)
     h = Hash(U, Array(T)).new
     each do |e|
       v = yield e
-      if h.has_key?(v)
-        h[v].push(e)
-      else
-        h[v] = [e]
-      end
+      h.put_if_absent(v, Array(T).new) << e
     end
     h
   end

--- a/src/enumerable.cr
+++ b/src/enumerable.cr
@@ -636,7 +636,7 @@ module Enumerable(T)
     h = Hash(U, Array(T)).new
     each do |e|
       v = yield e
-      h.put_if_absent(v, Array(T).new) << e
+      h.put_if_absent(v) { Array(T).new } << e
     end
     h
   end


### PR DESCRIPTION
Using `Hash#put_if_absent` reduces the number of hash lookups from 2 to 1.