### PR TITLE
Thread: set name

### DIFF
--- a/spec/std/thread_spec.cr
+++ b/spec/std/thread_spec.cr
@@ -49,4 +49,17 @@ describe Thread do
 
     thread.join
   end
+
+  it "names the thread" do
+    Thread.current.name.should be_nil
+    name = nil
+
+    thread = Thread.new(name: "some-name") do
+      name = Thread.current.name
+    end
+    thread.name.should eq("some-name")
+
+    thread.join
+    name.should eq("some-name")
+  end
 end

--- a/src/crystal/scheduler.cr
+++ b/src/crystal/scheduler.cr
@@ -234,7 +234,7 @@ class Crystal::Scheduler
           Thread.current.scheduler.enqueue worker_loop
           Thread.current
         else
-          Thread.new do
+          Thread.new(name: "mt-#{i}") do
             scheduler = Thread.current.scheduler
             pending.sub(1)
             scheduler.run_loop

--- a/src/crystal/system/thread.cr
+++ b/src/crystal/system/thread.cr
@@ -17,6 +17,8 @@ module Crystal::System::Thread
   # private def system_close
 
   # private def stack_address : Void*
+
+  # private def system_name=(String?) : String?
 end
 
 {% if flag?(:wasi) %}
@@ -49,12 +51,14 @@ class Thread
   # :nodoc:
   property previous : Thread?
 
+  getter name : String?
+
   def self.unsafe_each(&)
     threads.unsafe_each { |thread| yield thread }
   end
 
   # Creates and starts a new system thread.
-  def initialize(&@func : ->)
+  def initialize(@name : String? = nil, &@func : ->)
     @system_handle = uninitialized Crystal::System::Thread::Handle
     init_handle
   end
@@ -111,6 +115,7 @@ class Thread
     Thread.threads.push(self)
     Thread.current = self
     @main_fiber = fiber = Fiber.new(stack_address, self)
+    self.system_name = @name
 
     begin
       @func.call

--- a/src/crystal/system/unix/pthread.cr
+++ b/src/crystal/system/unix/pthread.cr
@@ -112,6 +112,22 @@ module Crystal::System::Thread
 
     address
   end
+
+  private def system_name=(name : String?)
+    return unless name
+
+    {% if flag?(:darwin) %}
+      LibC.pthread_setname_np(name)
+    {% elsif flag?(:netbsd) %}
+      LibC.pthread_setname_np(@system_handle, name, nil)
+    {% elsif LibC.has_method?(:pthread_setname_np) %}
+      LibC.pthread_setname_np(@system_handle, name)
+    {% elsif LibC.has_method?(:pthread_set_name_np) %}
+      LibC.pthread_set_name_np(@system_handle, name)
+    {% end %}
+
+    name
+  end
 end
 
 # In musl (alpine) the calls to unwind API segfaults

--- a/src/crystal/system/win32/thread.cr
+++ b/src/crystal/system/win32/thread.cr
@@ -72,4 +72,9 @@ module Crystal::System::Thread
       low_limit
     {% end %}
   end
+
+  private def system_name=(name : String?)
+    LibC.SetThreadDescription(@system_handle, name.to_utf16) if name
+    name
+  end
 end

--- a/src/crystal/system/win32/thread.cr
+++ b/src/crystal/system/win32/thread.cr
@@ -74,7 +74,7 @@ module Crystal::System::Thread
   end
 
   private def system_name=(name : String?)
-    LibC.SetThreadDescription(@system_handle, name.to_utf16) if name
+    LibC.SetThreadDescription(@system_handle, System.to_wstr(name)) if name
     name
   end
 end

--- a/src/lib_c/aarch64-darwin/c/pthread.cr
+++ b/src/lib_c/aarch64-darwin/c/pthread.cr
@@ -25,4 +25,5 @@ lib LibC
   fun pthread_mutex_trylock(x0 : PthreadMutexT*) : Int
   fun pthread_mutex_unlock(x0 : PthreadMutexT*) : Int
   fun pthread_self : PthreadT
+  fun pthread_setname_np(Char*) : Int
 end

--- a/src/lib_c/aarch64-linux-gnu/c/pthread.cr
+++ b/src/lib_c/aarch64-linux-gnu/c/pthread.cr
@@ -36,4 +36,5 @@ lib LibC
   fun pthread_mutex_trylock(mutex : PthreadMutexT*) : Int
   fun pthread_mutex_unlock(mutex : PthreadMutexT*) : Int
   fun pthread_self : PthreadT
+  fun pthread_setname_np(PthreadT, Char*) : Int
 end

--- a/src/lib_c/aarch64-linux-musl/c/pthread.cr
+++ b/src/lib_c/aarch64-linux-musl/c/pthread.cr
@@ -27,4 +27,5 @@ lib LibC
   fun pthread_mutex_trylock(x0 : PthreadMutexT*) : Int
   fun pthread_mutex_unlock(x0 : PthreadMutexT*) : Int
   fun pthread_self : PthreadT
+  fun pthread_setname_np(PthreadT, Char*) : Int
 end

--- a/src/lib_c/arm-linux-gnueabihf/c/pthread.cr
+++ b/src/lib_c/arm-linux-gnueabihf/c/pthread.cr
@@ -36,4 +36,5 @@ lib LibC
   fun pthread_mutex_trylock(mutex : PthreadMutexT*) : Int
   fun pthread_mutex_unlock(mutex : PthreadMutexT*) : Int
   fun pthread_self : PthreadT
+  fun pthread_setname_np(PthreadT, Char*) : Int
 end

--- a/src/lib_c/i386-linux-gnu/c/pthread.cr
+++ b/src/lib_c/i386-linux-gnu/c/pthread.cr
@@ -35,4 +35,5 @@ lib LibC
   fun pthread_mutex_trylock(mutex : PthreadMutexT*) : Int
   fun pthread_mutex_unlock(mutex : PthreadMutexT*) : Int
   fun pthread_self : PthreadT
+  fun pthread_setname_np(PthreadT, Char*) : Int
 end

--- a/src/lib_c/i386-linux-musl/c/pthread.cr
+++ b/src/lib_c/i386-linux-musl/c/pthread.cr
@@ -27,4 +27,5 @@ lib LibC
   fun pthread_mutex_trylock(x0 : PthreadMutexT*) : Int
   fun pthread_mutex_unlock(x0 : PthreadMutexT*) : Int
   fun pthread_self : PthreadT
+  fun pthread_setname_np(PthreadT, Char*) : Int
 end

--- a/src/lib_c/x86_64-darwin/c/pthread.cr
+++ b/src/lib_c/x86_64-darwin/c/pthread.cr
@@ -25,4 +25,5 @@ lib LibC
   fun pthread_mutex_trylock(x0 : PthreadMutexT*) : Int
   fun pthread_mutex_unlock(x0 : PthreadMutexT*) : Int
   fun pthread_self : PthreadT
+  fun pthread_setname_np(Char*) : Int
 end

--- a/src/lib_c/x86_64-dragonfly/c/pthread.cr
+++ b/src/lib_c/x86_64-dragonfly/c/pthread.cr
@@ -29,4 +29,5 @@ lib LibC
   fun pthread_mutex_trylock(x0 : PthreadMutexT*) : Int
   fun pthread_mutex_unlock(x0 : PthreadMutexT*) : Int
   fun pthread_self : PthreadT
+  fun pthread_setname_np(PthreadT, Char*) : Int
 end

--- a/src/lib_c/x86_64-freebsd/c/pthread.cr
+++ b/src/lib_c/x86_64-freebsd/c/pthread.cr
@@ -29,4 +29,5 @@ lib LibC
   fun pthread_mutex_trylock(x0 : PthreadMutexT*) : Int
   fun pthread_mutex_unlock(x0 : PthreadMutexT*) : Int
   fun pthread_self : PthreadT
+  fun pthread_set_name_np(PthreadT, Char*)
 end

--- a/src/lib_c/x86_64-linux-gnu/c/pthread.cr
+++ b/src/lib_c/x86_64-linux-gnu/c/pthread.cr
@@ -35,4 +35,5 @@ lib LibC
   fun pthread_mutex_trylock(mutex : PthreadMutexT*) : Int
   fun pthread_mutex_unlock(mutex : PthreadMutexT*) : Int
   fun pthread_self : PthreadT
+  fun pthread_setname_np(PthreadT, Char*) : Int
 end

--- a/src/lib_c/x86_64-linux-musl/c/pthread.cr
+++ b/src/lib_c/x86_64-linux-musl/c/pthread.cr
@@ -27,4 +27,5 @@ lib LibC
   fun pthread_mutex_trylock(x0 : PthreadMutexT*) : Int
   fun pthread_mutex_unlock(x0 : PthreadMutexT*) : Int
   fun pthread_self : PthreadT
+  fun pthread_setname_np(PthreadT, Char*) : Int
 end

--- a/src/lib_c/x86_64-netbsd/c/pthread.cr
+++ b/src/lib_c/x86_64-netbsd/c/pthread.cr
@@ -35,5 +35,6 @@ lib LibC
   fun pthread_mutex_trylock(x0 : PthreadMutexT*) : Int
   fun pthread_mutex_unlock(x0 : PthreadMutexT*) : Int
   fun pthread_self : PthreadT
+  fun pthread_setname_np(PthreadT, Char*, Void*) : Int
   fun pthread_setspecific(PthreadKeyT, Void*) : Int
 end

--- a/src/lib_c/x86_64-openbsd/c/pthread.cr
+++ b/src/lib_c/x86_64-openbsd/c/pthread.cr
@@ -30,6 +30,7 @@ lib LibC
   fun pthread_mutex_trylock(x0 : PthreadMutexT*) : Int
   fun pthread_mutex_unlock(x0 : PthreadMutexT*) : Int
   fun pthread_self : PthreadT
+  fun pthread_set_name_np(PthreadT, Char*)
   fun pthread_setspecific(PthreadKeyT, Void*) : Int
   fun pthread_stackseg_np(PthreadT, StackT*) : Int
 end

--- a/src/lib_c/x86_64-windows-msvc/c/processthreadsapi.cr
+++ b/src/lib_c/x86_64-windows-msvc/c/processthreadsapi.cr
@@ -50,6 +50,7 @@ lib LibC
                      bInheritHandles : BOOL, dwCreationFlags : DWORD,
                      lpEnvironment : Void*, lpCurrentDirectory : LPWSTR,
                      lpStartupInfo : STARTUPINFOW*, lpProcessInformation : PROCESS_INFORMATION*) : BOOL
+  fun SetThreadDescription(hThread : HANDLE, lpThreadDescription : LPWSTR) : BOOL
   fun SetThreadStackGuarantee(stackSizeInBytes : DWORD*) : BOOL
   fun GetProcessTimes(hProcess : HANDLE, lpCreationTime : FILETIME*, lpExitTime : FILETIME*,
                       lpKernelTime : FILETIME*, lpUserTime : FILETIME*) : BOOL


### PR DESCRIPTION
This allows to identify the thread by name, including in system applications, such as `top -H` or `gdb` sessions. For example with MT:4 we can see the main crystal thread (not renamed), the 7 GC threads, and the 3 MT threads.

![Capture d’écran de 2024-01-26 18-25-08@2x](https://github.com/crystal-lang/crystal/assets/47380/f9c59a10-efaa-4776-bbf5-88b2caf31b9c)
