### PR TITLE
Fix `Colorize.enabled?`'s documentation

### DIFF
--- a/src/colorize.cr
+++ b/src/colorize.cr
@@ -129,8 +129,7 @@ module Colorize
   # "hello".colorize.red.to_s # => "hello"
   # ```
   #
-  # NOTE: This is by default disabled on non-TTY devices because they likely don't support ANSI escape codes.
-  # This will also be disabled if the environment variable `TERM` is "dumb" or `NO_COLOR` contains any value.
+  # NOTE: This is by default disabled if the environment variable `NO_COLOR` contains any value.
   class_property? enabled : Bool { !ENV.has_key?("NO_COLOR") }
 
   # Makes `Colorize.enabled` `true` if and only if both of `STDOUT.tty?`


### PR DESCRIPTION
The default behavior was not there when #11664 was extracted from #7690.