### PR TITLE
Respect `NO_COLOR` in the compiler

### DIFF
--- a/src/compiler/crystal/command.cr
+++ b/src/compiler/crystal/command.cr
@@ -58,7 +58,7 @@ class Crystal::Command
   @compiler : Compiler?
 
   def initialize(@options : Array(String))
-    @color = ENV["TERM"]? != "dumb"
+    @color = ENV["TERM"]? != "dumb" && !ENV.has_key?("NO_COLOR")
     @error_trace = false
     @progress_tracker = ProgressTracker.new
   end
@@ -743,7 +743,7 @@ class Crystal::Command
 
   private def error(msg, exit_code = 1)
     # This is for the case where the main command is wrong
-    @color = false if ARGV.includes?("--no-color") || ENV["TERM"]? == "dumb"
+    @color = false if ARGV.includes?("--no-color") || ENV["TERM"]? == "dumb" || ENV.has_key?("NO_COLOR")
     Crystal.error msg, @color, exit_code: exit_code
   end
 


### PR DESCRIPTION
This is _not_ `Colorize.on_tty_only!`, because in theory `@compiler`'s output and error streams may not be `STDOUT` and `STDERR`. (In practice that will work until #13925 is resolved.)