### PR TITLE
Use correct string size for `LLVM::Type#inline_asm`

### DIFF
--- a/spec/compiler/codegen/asm_spec.cr
+++ b/spec/compiler/codegen/asm_spec.cr
@@ -3,6 +3,14 @@ require "../../spec_helper"
 describe "Code gen: asm" do
   # TODO: arm asm tests
   {% if flag?(:i386) || flag?(:x86_64) %}
+    it "passes correct string length to LLVM" do
+      run <<-CRYSTAL
+        asm("// 😂😂
+        nop
+        nop")
+        CRYSTAL
+    end
+
     it "codegens without inputs" do
       run(%(
         dst = uninitialized Int32

--- a/src/llvm/type.cr
+++ b/src/llvm/type.cr
@@ -179,9 +179,9 @@ struct LLVM::Type
         LibLLVM.get_inline_asm(
           self,
           asm_string,
-          asm_string.size,
+          asm_string.bytesize,
           constraints,
-          constraints.size,
+          constraints.bytesize,
           (has_side_effects ? 1 : 0),
           (is_align_stack ? 1 : 0),
           LibLLVM::InlineAsmDialect::ATT
@@ -190,9 +190,9 @@ struct LLVM::Type
         LibLLVM.get_inline_asm(
           self,
           asm_string,
-          asm_string.size,
+          asm_string.bytesize,
           constraints,
-          constraints.size,
+          constraints.bytesize,
           (has_side_effects ? 1 : 0),
           (is_align_stack ? 1 : 0),
           LibLLVM::InlineAsmDialect::ATT,


### PR DESCRIPTION
Uses `bytesize` instead of `size` to avoid truncating the template string if it contains non-ASCII characters.