### PR TITLE
Codegen: on demand distribution to forked processes

### DIFF
--- a/src/compiler/crystal/compiler.cr
+++ b/src/compiler/crystal/compiler.cr
@@ -567,24 +567,25 @@ module Crystal
 
         workers.each do |pid, input, output|
           spawn do
+            overqueued = 0
+
             overqueue.times do
               if (index = indexes.add(1)) < units.size
                 input.puts index
+                overqueued += 1
               end
             end
 
             while (index = indexes.add(1)) < units.size
               input.puts index
 
-              if response = output.gets(chomp: true)
-                channel.send response
-              end
+              response = output.gets(chomp: true).not_nil!
+              channel.send response
             end
 
-            overqueue.times do
-              if response = output.gets(chomp: true)
-                channel.send response
-              end
+            overqueued.times do
+              response = output.gets(chomp: true).not_nil!
+              channel.send response
             end
 
             input << '\n'

--- a/src/compiler/crystal/compiler.cr
+++ b/src/compiler/crystal/compiler.cr
@@ -546,7 +546,7 @@ module Crystal
         return all_reused
       end
 
-      {% if !Crystal::System::Process.class.has_method?("fork") %}
+      {% if !LibC.has_method?("fork") %}
         raise "Cannot fork compiler. `Crystal::System::Process.fork` is not implemented on this system."
       {% elsif flag?(:preview_mt) %}
         raise "Cannot fork compiler in multithread mode"


### PR DESCRIPTION
This patch optimizes the `Codegen (bc+obj)` pass of the compiler by taking better advantage of multiple CPU cores.

Instead of pre-slicing the list of compilation units then having each forked process handle its personal list, with some finishing before the others, this patch adds bidirectional pipes to push the compilation units as the forked processes make progress, so that each forked process will continue to compile for as long as there is something to compile.

The forker processes are overqueued with one compilation unit to avoid latencies (they compile the next unit while the main process pushes the next).

This only improves performance when there are multiple compilation units. It won't have any effect when `--single-module` (implied by `--release`) is set, and will have little impact when a module is extra large (e.g. crystal specs) unless maybe when there are multiple of them and they were set to the same forked process.

Example: while compiling Crystal the `Codegen (bc+obj)` pass goes from ~18s to ~11s on an empty cache, and ~5s to ~3s on a full cache recompilation.

Related to #14227 but using forks+pipes instead of threads+channel.