### PR TITLE
[CI] Upgrade `resource_class` for `test_preview_mt`

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -116,6 +116,7 @@ jobs:
   test_preview_mt:
     machine:
       image: ubuntu-2004:202201-02
+    resource_class: large
     environment:
       <<: *env
       TRAVIS_OS_NAME: linux


### PR DESCRIPTION
The `test_preview_mt` seems to be running out of memory lately. Most other heavy jobs are already using `resource_class: large` with 8GB instead of 4GB (https://circleci.com/docs/configuration-reference/#resourceclass).

Failing run: https://app.circleci.com/pipelines/github/crystal-lang/crystal/14146/workflows/ec55264e-c860-495a-851b-b7994e3075b5/jobs/81442?utm_campaign=vcs-integration-link&utm_medium=referral&utm_source=github-checks-link&utm_content=summary