### PR TITLE
Document builtin constants

### DIFF
--- a/src/compiler/crystal/program.cr
+++ b/src/compiler/crystal/program.cr
@@ -278,33 +278,73 @@ module Crystal
         define_crystal_string_constant "BUILD_COMMIT", build_commit
       else
         define_crystal_nil_constant "BUILD_COMMIT"
-      end
+      end.doc = <<-MD
+        The build commit identifier of the Crystal compiler.
+        MD
 
-      define_crystal_string_constant "BUILD_DATE", Crystal::Config.date
-      define_crystal_string_constant "CACHE_DIR", CacheDir.instance.dir
-      define_crystal_string_constant "DEFAULT_PATH", Crystal::Config.path
-      define_crystal_string_constant "DESCRIPTION", Crystal::Config.description
-      define_crystal_string_constant "PATH", Crystal::CrystalPath.default_path
-      define_crystal_string_constant "LIBRARY_PATH", Crystal::CrystalLibraryPath.default_path
-      define_crystal_string_constant "LIBRARY_RPATH", Crystal::CrystalLibraryPath.default_rpath
-      define_crystal_string_constant "VERSION", Crystal::Config.version
-      define_crystal_string_constant "LLVM_VERSION", Crystal::Config.llvm_version
-      define_crystal_string_constant "HOST_TRIPLE", Crystal::Config.host_target.to_s
-      define_crystal_string_constant "TARGET_TRIPLE", Crystal::Config.host_target.to_s
+      define_crystal_string_constant "BUILD_DATE", Crystal::Config.date, <<-MD
+        The build date of the Crystal compiler.
+        MD
+      define_crystal_string_constant "CACHE_DIR", CacheDir.instance.dir, <<-MD
+        The cache directory configured for the Crystal compiler.
+
+        The value is defined by the environment variable `CRYSTAL_CACHE_DIR` and
+        defaults to the user's configured cache directory.
+        MD
+      define_crystal_string_constant "DEFAULT_PATH", Crystal::Config.path, <<-MD
+        The default Crystal path configured in the compiler. This value is baked
+        into the compiler and usually points to the accompanying version of the
+        standard library.
+        MD
+      define_crystal_string_constant "DESCRIPTION", Crystal::Config.description, <<-MD
+        Full version information of the Crystal compiler. Equivalent to `crystal --version`.
+        MD
+      define_crystal_string_constant "PATH", Crystal::CrystalPath.default_path, <<-MD
+        Colon-separated paths where the compiler searches for required source files.
+
+        The value is defined by the environment variable `CRYSTAL_PATH`
+        and defaults to `DEFAULT_PATH`.
+        MD
+      define_crystal_string_constant "LIBRARY_PATH", Crystal::CrystalLibraryPath.default_path, <<-MD
+        Colon-separated paths where the compiler searches for (binary) libraries.
+
+        The value is defined by the environment variables `CRYSTAL_LIBRARY_PATH`.
+        MD
+      define_crystal_string_constant "LIBRARY_RPATH", Crystal::CrystalLibraryPath.default_rpath, <<-MD
+        Colon-separated paths where the loader searches for dynamic libraries at runtime.
+
+        The value is defined by the environment variables `CRYSTAL_LIBRARY_RPATH`.
+        MD
+      define_crystal_string_constant "VERSION", Crystal::Config.version, <<-MD
+        The version of the Crystal compiler.
+        MD
+      define_crystal_string_constant "LLVM_VERSION", Crystal::Config.llvm_version, <<-MD
+        The version of LLVM used by the Crystal compiler.
+        MD
+      define_crystal_string_constant "HOST_TRIPLE", Crystal::Config.host_target.to_s, <<-MD
+        The LLVM target triple of the host system (the machine that the compiler runs on).
+        MD
+      define_crystal_string_constant "TARGET_TRIPLE", Crystal::Config.host_target.to_s, <<-MD
+        The LLVM target triple of the target system (the machine that the compiler builds for).
+        MD
     end
 
-    private def define_crystal_string_constant(name, value)
-      define_crystal_constant name, StringLiteral.new(value).tap(&.set_type(string))
+    private def define_crystal_string_constant(name, value, doc = nil)
+      define_crystal_constant name, StringLiteral.new(value).tap(&.set_type(string)), doc
     end
 
-    private def define_crystal_nil_constant(name)
-      define_crystal_constant name, NilLiteral.new.tap(&.set_type(self.nil))
+    private def define_crystal_nil_constant(name, doc = nil)
+      define_crystal_constant name, NilLiteral.new.tap(&.set_type(self.nil)), doc
     end
 
-    private def define_crystal_constant(name, value)
+    private def define_crystal_constant(name, value, doc = nil) : Const
       crystal.types[name] = const = Const.new self, crystal, name, value
       const.no_init_flag = true
+      if doc
+        const.doc = doc
+      end
       predefined_constants << const
+      const
     end
 
     property(target_machine : LLVM::TargetMachine) { codegen_target.to_target_machine }


### PR DESCRIPTION
This is the easiest implementation attaching the documentation directly in the compiler where the constants are defined.
Further enhancements to allow hooking into constant documentation from stdlib would be possible. Use cases are limited, so I'm not sure if there would be much value in it. This is definitely a helpful improvement.

Resolves #14085