### PR TITLE
Fix format for `asm` with comments

### DIFF
--- a/spec/compiler/formatter/formatter_spec.cr
+++ b/spec/compiler/formatter/formatter_spec.cr
@@ -1708,6 +1708,7 @@ describe Crystal::Formatter do
       # bar
     )
     CRYSTAL
+
   assert_format <<-CRYSTAL, <<-CRYSTAL
     asm(
       # the assembly template string, following the

--- a/spec/compiler/formatter/formatter_spec.cr
+++ b/spec/compiler/formatter/formatter_spec.cr
@@ -1708,6 +1708,29 @@ describe Crystal::Formatter do
       # bar
     )
     CRYSTAL
+  assert_format <<-CRYSTAL, <<-CRYSTAL
+    asm(
+      # the assembly template string, following the
+      # syntax for LLVM's integrated assembler
+      "nop" :               # output operands
+    "=r"(foo), "=r"(bar) : # input operands
+    "r"(1), "r"(baz) :     # names of clobbered registers
+    "eax", "memory" :      # optional flags, corresponding to the LLVM IR
+      # sideeffect / alignstack / inteldialect / unwind attributes
+    "volatile", "alignstack", "intel", "unwind"
+    )
+    CRYSTAL
+    asm(
+      # the assembly template string, following the
+      # syntax for LLVM's integrated assembler
+      "nop" :                # output operands
+      "=r"(foo), "=r"(bar) : # input operands
+      "r"(1), "r"(baz) :     # names of clobbered registers
+      "eax", "memory" :      # optional flags, corresponding to the LLVM IR
+      # sideeffect / alignstack / inteldialect / unwind attributes
+      "volatile", "alignstack", "intel", "unwind"
+    )
+    CRYSTAL
 
   assert_format "1 # foo\n1234 # bar", "1    # foo\n1234 # bar"
   assert_format "1234 # foo\n1 # bar", "1234 # foo\n1    # bar"

--- a/spec/compiler/formatter/formatter_spec.cr
+++ b/spec/compiler/formatter/formatter_spec.cr
@@ -1695,6 +1695,20 @@ describe Crystal::Formatter do
   assert_format %(asm("a" : "b"(c) : "d"(e)\n        : "f",\n          "g"))
   assert_format %(asm("a" ::: "a"\n        : "volatile",\n          "intel"))
 
+  assert_format <<-CRYSTAL, <<-CRYSTAL
+    asm(
+    # foo
+    "nop"
+    # bar
+    )
+    CRYSTAL
+    asm(
+      # foo
+      "nop"
+      # bar
+    )
+    CRYSTAL
+
   assert_format "1 # foo\n1234 # bar", "1    # foo\n1234 # bar"
   assert_format "1234 # foo\n1 # bar", "1234 # foo\n1    # bar"
   assert_format "1#foo", "1 # foo"

--- a/src/compiler/crystal/tools/formatter.cr
+++ b/src/compiler/crystal/tools/formatter.cr
@@ -4370,6 +4370,7 @@ module Crystal
       skip_space
 
       if @token.type.newline?
+        @indent += 2
         consume_newlines
         has_newlines = true
       end
@@ -4378,7 +4379,7 @@ module Crystal
       string = StringLiteral.new(node.text)
 
       if has_newlines
-        write_indent(@indent + 2, string)
+        write_indent(@indent, string)
       else
         indent(@column, string)
       end
@@ -4386,11 +4387,12 @@ module Crystal
       skip_space
 
       if @token.type.newline?
+        consume_newlines
         if node.outputs || node.inputs
-          consume_newlines
           column += 4
           write_indent(column)
         end
+        @wrote_newline = true
       end
 
       skip_space_or_newline
@@ -4457,7 +4459,9 @@ module Crystal
       skip_space_or_newline
 
       if has_newlines
-        write_line
+        @indent -= 2
+
+        write_line unless @wrote_newline
         write_indent
       end
 

--- a/src/compiler/crystal/tools/formatter.cr
+++ b/src/compiler/crystal/tools/formatter.cr
@@ -4392,7 +4392,6 @@ module Crystal
           column += 4
           write_indent(column)
         end
-        @wrote_newline = true
       end
 
       skip_space_or_newline

--- a/src/compiler/crystal/tools/formatter.cr
+++ b/src/compiler/crystal/tools/formatter.cr
@@ -4420,7 +4420,8 @@ module Crystal
           write_token :OP_COLON
           part_index += 1
         end
-        skip_space_or_newline
+        skip_space
+        consume_newlines
 
         case part_index
         when 1
@@ -4483,7 +4484,12 @@ module Crystal
     end
 
     def visit_asm_parts(parts, colon_column, &) : Nil
-      write " "
+      if @wrote_newline
+        write_indent
+      else
+        write " "
+      end
+
       column = @column
 
       parts.each_with_index do |part, i|


### PR DESCRIPTION
Fixes a formatter bug that appeared in https://github.com/crystal-lang/crystal-book/pull/746