### PR TITLE
Respect alignments above `alignof(Void*)` inside union values

### DIFF
--- a/spec/compiler/codegen/cast_spec.cr
+++ b/spec/compiler/codegen/cast_spec.cr
@@ -77,6 +77,33 @@ describe "Code gen: cast" do
       )).to_b.should be_true
   end
 
+  it "upcasts from union to union with different alignment" do
+    run(<<-CRYSTAL).to_i.should eq(1)
+      require "prelude"
+
+      a = 1 || 2_i64
+      a.as(Int32 | Int64 | Int128)
+      CRYSTAL
+  end
+
+  it "downcasts from union to union with different alignment" do
+    run(<<-CRYSTAL).to_i.should eq(1)
+      require "prelude"
+
+      a = 1 || 2_i64 || 3_i128
+      a.as(Int32 | Int64)
+      CRYSTAL
+  end
+
+  it "sidecasts from union to union with different alignment" do
+    run(<<-CRYSTAL).to_i.should eq(1)
+      require "prelude"
+
+      a = 1 || 2_i64
+      a.as(Int32 | Int128)
+      CRYSTAL
+  end
+
   it "casts from virtual to single type" do
     run(%(
       require "prelude"

--- a/spec/compiler/codegen/sizeof_spec.cr
+++ b/spec/compiler/codegen/sizeof_spec.cr
@@ -279,6 +279,16 @@ describe "Code gen: sizeof" do
         alignof(Foo)
         CRYSTAL
     end
+
+    it "gets alignof union" do
+      run("alignof(Int32 | Int8)").to_i.should eq(8)
+      run("alignof(Int32 | Int64)").to_i.should eq(8)
+    end
+
+    it "alignof mixed union is not less than alignof its variant types" do
+      # NOTE: `alignof(Int128) == 16` is not guaranteed
+      run("alignof(Int32 | Int128) >= alignof(Int128)").to_b.should be_true
+    end
   end
 
   describe "instance_alignof" do

--- a/src/compiler/crystal/codegen/codegen.cr
+++ b/src/compiler/crystal/codegen/codegen.cr
@@ -2253,11 +2253,11 @@ module Crystal
       res
     end
 
-    def memcpy(dest, src, len, align, volatile)
+    def memcpy(dest, src, len, align, volatile, *, src_align = align)
       res = call c_memcpy_fun, [dest, src, len, volatile]
 
       LibLLVM.set_instr_param_alignment(res, 1, align)
-      LibLLVM.set_instr_param_alignment(res, 2, align)
+      LibLLVM.set_instr_param_alignment(res, 2, src_align)
 
       res
     end

--- a/src/compiler/crystal/codegen/unions.cr
+++ b/src/compiler/crystal/codegen/unions.cr
@@ -143,12 +143,9 @@ module Crystal
     end
 
     def downcast_distinct_union_types(value, to_type : MixedUnionType, from_type : MixedUnionType)
-      to_llvm_type = llvm_type(to_type)
-      from_llvm_type = llvm_type(from_type)
-
       # If from_type and to_type have the same alignment, we don't need a
       # separate value; just cast the larger value pointer to the smaller one
-      if @llvm_typer.align_of(to_llvm_type) == @llvm_typer.align_of(from_llvm_type)
+      if align_of(to_type) == align_of(from_type)
         cast_to_pointer value, to_type
       else
         # This is the same as upcasting and we need that separate, newly aligned

--- a/src/compiler/crystal/codegen/unions.cr
+++ b/src/compiler/crystal/codegen/unions.cr
@@ -118,7 +118,7 @@ module Crystal
       union_value_type = from_llvm_type.struct_element_types[1]
       target_value_ptr = union_value(to_llvm_type, union_pointer)
       union_value = load(union_value_type, union_value(from_llvm_type, value))
-      store union_value, pointer_cast(target_value_ptr, union_value_type)
+      store union_value, pointer_cast(target_value_ptr, union_value_type.pointer)
     end
 
     def assign_distinct_union_types(to_pointer, to_type, from_type, from_pointer)


### PR DESCRIPTION
Fixes the codegen issue in https://github.com/crystal-lang/crystal/pull/14277#issuecomment-1917060388.

If `alignof(Int128) == 16` (due to #13609 this is not true for x86-64 targets before LLVM 18), An `Int32 | Int128` will now place its type ID and data at offsets 0 and 16 respectively, including on AArch64, where `alignof(Int128) == 16` has always been the case. This also means that if, say, a 64-byte-aligned value becomes available in Crystal (e.g. for AVX-512), then a union of that value with anything else requires at least 128 bytes of storage, with 60 bytes of padding after the type ID.

**This is an ABI breaking change**. It might be worth mentioning this even though Crystal makes no guarantees about ABI stability and most users won't be affected.

This doesn't cover the interpreter yet.