### PR TITLE
Fix: don't run thread specs with the interpreter

### DIFF
--- a/spec/interpreter_std_spec.cr
+++ b/spec/interpreter_std_spec.cr
@@ -235,9 +235,9 @@ require "./std/system_error_spec.cr"
 require "./std/system/group_spec.cr"
 # require "./std/system_spec.cr" (failed to run)
 require "./std/system/user_spec.cr"
-require "./std/thread/condition_variable_spec.cr"
-require "./std/thread/mutex_spec.cr"
-# require "./std/thread_spec.cr" (failed to run)
+# require "./std/thread/condition_variable_spec.cr" (interpreter must support threads)
+# require "./std/thread/mutex_spec.cr" (interpreter must support threads)
+# require "./std/thread_spec.cr" (interpreter must support threads)
 require "./std/time/custom_formats_spec.cr"
 require "./std/time/format_spec.cr"
 require "./std/time/location_spec.cr"


### PR DESCRIPTION
Starting threads very likely requires support from the interpreter to create the thread (so it knows about it) to run the interpreted code in.

This fixes the "can't resume running fiber" exceptions that started appearing in the [WaitGroup pull request](https://github.com/crystal-lang/crystal/pull/14167), because they were always run after the thread related specs.

What's happening is that either the interpreter or the interpreted code becomes confused, and the scheduler is trying to resume a fiber that's already running in another thread (it might even be a thread's main fiber).

Running the specs in random order (instead of sequentially) would likely trigger the issue.