### PR TITLE
Respect `--static` on Windows

### DIFF
--- a/.github/workflows/win_build_portable.yml
+++ b/.github/workflows/win_build_portable.yml
@@ -114,7 +114,9 @@ jobs:
       - name: Build Crystal
         run: |
           bin/crystal.bat env
-          make -f Makefile.win -B ${{ inputs.release && 'release=1' || '' }}
+          # TODO: 1.11.2 still needs `-Dpreview_dll`, remove this flag once the base compiler is updated
+          make -f Makefile.win -B FLAGS=-Dpreview_dll ${{ inputs.release && 'release=1' || '' }}
+          cp dlls/* .build/
 
       - name: Download shards release
         uses: actions/checkout@v4

--- a/.github/workflows/win_build_portable.yml
+++ b/.github/workflows/win_build_portable.yml
@@ -114,9 +114,13 @@ jobs:
       - name: Build Crystal
         run: |
           bin/crystal.bat env
-          # TODO: 1.11.2 still needs `-Dpreview_dll`, remove this flag once the base compiler is updated
+          # TODO: the 1.11.2 compiler only understands `-Dpreview_dll`; remove this once the
+          # base compiler is updated
           make -f Makefile.win -B FLAGS=-Dpreview_dll ${{ inputs.release && 'release=1' || '' }}
-          cp dlls/* .build/
+          # TODO: 1.11.2 comes with LLVM 17's DLL and copies it to the output directory, but a
+          # dynamically linked compiler requires LLVM 18, so we must overwrite it; remove this
+          # line once the base compiler is updated
+          cp dlls/LLVM-C.dll .build/
 
       - name: Download shards release
         uses: actions/checkout@v4

--- a/Makefile.win
+++ b/Makefile.win
@@ -71,7 +71,7 @@ LLVM_VERSION := $(if $(LLVM_CONFIG),$(shell $(LLVM_CONFIG) --version))
 LLVM_EXT_DIR = src\llvm\ext
 LLVM_EXT_OBJ = $(LLVM_EXT_DIR)\llvm_ext.obj
 DEPS = $(LLVM_EXT_OBJ)
-CXXFLAGS += $(if $(debug),/MTd /Od,/MT)
+CXXFLAGS += $(if $(static),$(if $(debug),/MTd /Od ,/MT ),$(if $(debug),/MDd /Od ,/MD ))
 CRYSTAL_VERSION ?= $(shell type src\VERSION)
 
 prefix ?= $(or $(ProgramW6432),$(ProgramFiles))\crystal

--- a/src/compiler/crystal/codegen/codegen.cr
+++ b/src/compiler/crystal/codegen/codegen.cr
@@ -1517,7 +1517,7 @@ module Crystal
       unless var
         var = llvm_mod.globals.add(llvm_c_return_type(type), name)
         var.linkage = LLVM::Linkage::External
-        if @program.has_flag?("win32") && @program.has_flag?("preview_dll")
+        if @program.has_flag?("win32") && !@program.has_flag?("static")
           var.dll_storage_class = LLVM::DLLStorageClass::DLLImport
         end
         var.thread_local = thread_local

--- a/src/compiler/crystal/compiler.cr
+++ b/src/compiler/crystal/compiler.cr
@@ -333,7 +333,7 @@ module Crystal
         {% end %}
 
         {% if flag?(:windows) %}
-          copy_dlls(program, output_filename) if program.has_flag?("preview_dll")
+          copy_dlls(program, output_filename) unless static?
         {% end %}
       end
 
@@ -442,7 +442,7 @@ module Crystal
 
         {% if flag?(:msvc) %}
           unless @cross_compile
-            extra_suffix = program.has_flag?("preview_dll") ? "-dynamic" : "-static"
+            extra_suffix = static? ? "-static" : "-dynamic"
             search_result = Loader.search_libraries(Process.parse_arguments_windows(link_args.join(' ').gsub('\n', ' ')), extra_suffix: extra_suffix)
             if not_found = search_result.not_found?
               error "Cannot locate the .lib files for the following libraries: #{not_found.join(", ")}"

--- a/src/compiler/crystal/interpreter/context.cr
+++ b/src/compiler/crystal/interpreter/context.cr
@@ -46,9 +46,6 @@ class Crystal::Repl::Context
 
   def initialize(@program : Program)
     @program.flags << "interpreted"
-    {% if flag?(:win32) %}
-      @program.flags << "preview_dll"
-    {% end %}
 
     @gc_references = [] of Void*
 

--- a/src/crystal/system/win32/wmain.cr
+++ b/src/crystal/system/win32/wmain.cr
@@ -4,7 +4,7 @@ require "c/stdlib"
 
 {% begin %}
   # we have both `main` and `wmain`, so we must choose an unambiguous entry point
-  @[Link({{ flag?(:preview_dll) ? "msvcrt" : "libcmt" }}, ldflags: "/ENTRY:wmainCRTStartup")]
+  @[Link({{ flag?(:static) ? "libcmt" : "msvcrt" }}, ldflags: "/ENTRY:wmainCRTStartup")]
 {% end %}
 lib LibCrystalMain
 end

--- a/src/empty.cr
+++ b/src/empty.cr
@@ -1,7 +1,7 @@
 require "primitives"
 
 {% if flag?(:win32) %}
-  @[Link({{ flag?(:preview_dll) ? "msvcrt" : "libcmt" }})] # For `mainCRTStartup`
+  @[Link({{ flag?(:static) ? "libcmt" : "msvcrt" }})] # For `mainCRTStartup`
 {% end %}
 lib LibCrystalMain
   @[Raises]

--- a/src/lib_c.cr
+++ b/src/lib_c.cr
@@ -1,5 +1,5 @@
 {% if flag?(:win32) %}
-  @[Link({{ flag?(:preview_dll) ? "ucrt" : "libucrt" }})]
+  @[Link({{ flag?(:static) ? "libucrt" : "ucrt" }})]
 {% end %}
 lib LibC
   alias Char = UInt8

--- a/src/llvm/lib_llvm.cr
+++ b/src/llvm/lib_llvm.cr
@@ -1,5 +1,5 @@
 {% begin %}
-  {% if flag?(:win32) && flag?(:preview_dll) %}
+  {% if flag?(:win32) && !flag?(:static) %}
     {% config = nil %}
     {% for dir in Crystal::LIBRARY_PATH.split(';') %}
       {% config ||= read_file?("#{dir.id}/llvm_VERSION") %}

--- a/src/raise.cr
+++ b/src/raise.cr
@@ -95,7 +95,7 @@ end
   require "exception/lib_unwind"
 
   {% begin %}
-    @[Link({{ flag?(:preview_dll) ? "vcruntime" : "libvcruntime" }})]
+    @[Link({{ flag?(:static) ? "libvcruntime" : "vcruntime" }})]
   {% end %}
   lib LibC
     fun _CxxThrowException(ex : Void*, throw_info : Void*) : NoReturn


### PR DESCRIPTION
Makes `--static` opt in to static linking on Windows. Also makes the Windows binaries dynamically linked.

Dynamic linking is now the default, and the `-Dpreview_dll` flag has no effect after this PR. Building a dynamically linked compiler from 1.11.x still needs this flag though, because the base compiler doesn't incorporate this PR yet.

Note that linking against `vcruntime` means that the [VC++ Redistributable](https://aka.ms/vs/17/release/vc_redist.x64.exe) is now required to run the compiler. The GUI installer must later be able to detect its installation (e.g. via the registry key `HKLM\SOFTWARE\Microsoft\VisualStudio\14.0\VC\Runtimes\X64\Installed`).