### PR TITLE
Fix: Atomics and Locks (ARM, AArch64, X86)

### DIFF
--- a/src/atomic.cr
+++ b/src/atomic.cr
@@ -70,7 +70,7 @@ struct Atomic(T)
   end
 
   def compare_and_set(cmp : T, new : T, success_ordering : Ordering, failure_ordering : Ordering) : {T, Bool}
-    {% if compare_versions(Crystal::LLVM_VERSION, "1.13.0") >= 0 %}
+    {% if compare_versions(Crystal::LLVM_VERSION, "13.0.0") >= 0 %}
       # LLVM since 13.0.0 accepts any combination of success & failure ordering
       case success_ordering
         {% for s_ordering in Ordering.constants %}

--- a/src/atomic.cr
+++ b/src/atomic.cr
@@ -69,6 +69,22 @@ struct Atomic(T)
     Ops.cmpxchg(pointerof(@value), cmp.as(T), new.as(T), :sequentially_consistent, :sequentially_consistent)
   end
 
+  # Compares this atomic's value with *cmp* using explicit memory orderings:
+  #
+  # * if they are equal, sets the value to *new*, and returns `{old_value, true}`
+  # * if they are not equal the value remains the same, and returns `{old_value, false}`
+  #
+  # Reference types are compared by `#same?`, not `#==`.
+  #
+  # ```
+  # atomic = Atomic.new(0_u32)
+  #
+  # value = atomic.get(:acquire)
+  # loop do
+  #   value, success = atomic.compare_and_set(value, value &+ 1, :acquire_release, :acquire)
+  #   break if success
+  # end
+  # ```
   def compare_and_set(cmp : T, new : T, success_ordering : Ordering, failure_ordering : Ordering) : {T, Bool}
     case {success_ordering, failure_ordering}
     when {.relaxed?, .relaxed?}

--- a/src/atomic.cr
+++ b/src/atomic.cr
@@ -127,7 +127,7 @@ struct Atomic(T)
         in .sequentially_consistent?
           raise "BUG: failure ordering shall be no stronger than success ordering"
         end
-      in .acquire_release?
+      in .sequentially_consistent?
         case failure_ordering
         in .relaxed?
           Ops.cmpxchg(pointerof(@value), cmp.as(T), new.as(T), :sequentially_consistent, :monotonic)

--- a/src/atomic.cr
+++ b/src/atomic.cr
@@ -289,7 +289,7 @@ struct Atomic(T)
     in .sequentially_consistent?
       Ops.store(pointerof(@value), value.as(T), :sequentially_consistent, true)
     in .acquire?, .acquire_release?
-      raise "BUG: Atomic store cannot have acquire semantic"
+      raise ArgumentError.new("Atomic store cannot have acquire semantic")
     end
     value
   end
@@ -316,7 +316,7 @@ struct Atomic(T)
     in .sequentially_consistent?
       Ops.load(pointerof(@value), :sequentially_consistent, true)
     in .release?, .acquire_release?
-      raise "BUG: Atomic load cannot have release semantic"
+      raise ArgumentError.new("Atomic load cannot have release semantic")
     end
   end
 

--- a/src/atomic.cr
+++ b/src/atomic.cr
@@ -110,9 +110,9 @@ struct Atomic(T)
         Ops.cmpxchg(pointerof(@value), cmp.as(T), new.as(T), :sequentially_consistent, :sequentially_consistent)
       else
         if failure_ordering.release? || failure_ordering.acquire_release?
-          raise ArgumentError.new("BUG: failure ordering cannot include release semantics")
+          raise ArgumentError.new("Failure ordering cannot include release semantics")
         end
-        raise ArgumentError.new("BUG: failure ordering shall be no stronger than success ordering")
+        raise ArgumentError.new("Failure ordering shall be no stronger than success ordering")
       end
     {% end %}
   end

--- a/src/compiler/crystal/codegen/primitives.cr
+++ b/src/compiler/crystal/codegen/primitives.cr
@@ -1305,6 +1305,10 @@ class Crystal::CodeGenVisitor
     failure_node.raise "cannot include release semantics" if failure_ordering.release? || failure_ordering.acquire_release?
 
     {% if LibLLVM::IS_LT_130 %}
+      # Atomic(T) macros enforce this rule to provide a consistent public API
+      # regardless of which LLVM version crystal was compiled with. The compiler,
+      # however, only needs to make sure that the codegen is correct for the LLVM
+      # version
       failure_node.raise "shall be no stronger than success ordering" if failure_ordering > success_ordering
     {% end %}
   end

--- a/src/compiler/crystal/codegen/primitives.cr
+++ b/src/compiler/crystal/codegen/primitives.cr
@@ -1307,31 +1307,8 @@ class Crystal::CodeGenVisitor
       success_node.raise "cannot be unordered" if success_ordering.unordered?
       failure_node.raise "cannot be unordered" if failure_ordering.unordered?
 
-      case success_ordering
-      when .monotonic?
-        unless failure_ordering.monotonic?
-          failure_node.raise "shall be no stronger than success ordering"
-        end
-      when .acquire?, .release?
-        case failure_ordering
-        when .release?
-          failure_node.raise "cannot include release semantics"
-        when .acquire_release?, .sequentially_consistent?
-          failure_node.raise "shall be no stronger than success ordering"
-        end
-      when .acquire_release?
-        case failure_ordering
-        when .release?, .acquire_release?
-          failure_node.raise "cannot include release semantics"
-        when .sequentially_consistent?
-          failure_node.raise "shall be no stronger than success ordering"
-        end
-      when .sequentially_consistent?
-        case failure_ordering
-        when .release?, .acquire_release?
-          failure_node.raise "cannot include release semantics"
-        end
-      end
+      failure_node.raise "shall be no stronger than success ordering" if failure_ordering > success_ordering
+      failure_node.raise "cannot include release semantics" if failure_ordering.release? || failure_ordering.acquire_release?
     end
   {% end %}
 

--- a/src/crystal/rw_lock.cr
+++ b/src/crystal/rw_lock.cr
@@ -1,37 +1,55 @@
 # :nodoc:
 class Crystal::RWLock
-  @writer = Atomic(Int32).new(0)
+  private UNLOCKED = 0
+  private LOCKED   = 1
+
+  @writer = Atomic(Int32).new(UNLOCKED)
   @readers = Atomic(Int32).new(0)
 
-  def read_lock
+  def read_lock : Nil
     loop do
-      while @writer.get != 0
+      while @writer.get(:relaxed) != UNLOCKED
         Intrinsics.pause
       end
 
-      @readers.add(1)
+      @readers.add(1, :acquire)
 
-      break if @writer.get == 0
+      if @writer.get(:acquire) == UNLOCKED
+        {% if flag?(:arm) %}
+          Atomic.fence(:acquire)
+        {% end %}
+        return
+      end
 
-      @readers.sub(1)
+      @readers.sub(1, :release)
     end
   end
 
-  def read_unlock
-    @readers.sub(1)
+  def read_unlock : Nil
+    {% if flag?(:arm) %}
+      Atomic.fence(:release)
+    {% end %}
+    @readers.sub(1, :release)
   end
 
-  def write_lock
-    while @writer.swap(1) != 0
+  def write_lock : Nil
+    while @writer.swap(LOCKED, :acquire) != UNLOCKED
       Intrinsics.pause
     end
 
-    while @readers.get != 0
+    while @readers.get(:acquire) != 0
       Intrinsics.pause
     end
+
+    {% if flag?(:arm) %}
+      Atomic.fence(:acquire)
+    {% end %}
   end
 
-  def write_unlock
-    @writer.lazy_set(0)
+  def write_unlock : Nil
+    {% if flag?(:arm) %}
+      Atomic.fence(:release)
+    {% end %}
+    @writer.set(UNLOCKED, :release)
   end
 end

--- a/src/crystal/spin_lock.cr
+++ b/src/crystal/spin_lock.cr
@@ -1,28 +1,31 @@
 # :nodoc:
 class Crystal::SpinLock
+  private UNLOCKED = 0
+  private LOCKED   = 1
+
   {% if flag?(:preview_mt) %}
-    @m = Atomic(Int32).new(0)
+    @m = Atomic(Int32).new(UNLOCKED)
   {% end %}
 
   def lock
     {% if flag?(:preview_mt) %}
-      while @m.swap(1) == 1
-        while @m.get == 1
+      while @m.swap(LOCKED, :acquire) == LOCKED
+        while @m.get(:relaxed) == LOCKED
           Intrinsics.pause
         end
       end
-      {% if flag?(:aarch64) %}
-        Atomic::Ops.fence :sequentially_consistent, false 
-      {% end %}      
+      {% if flag?(:arm) %}
+        Atomic.fence(:acquire)
+      {% end %}
     {% end %}
   end
 
   def unlock
     {% if flag?(:preview_mt) %}
-      {% if flag?(:aarch64) %}
-        Atomic::Ops.fence :sequentially_consistent, false 
+      {% if flag?(:arm) %}
+        Atomic.fence(:release)
       {% end %}
-      @m.lazy_set(0)
+      @m.set(UNLOCKED, :release)
     {% end %}
   end
 

--- a/src/mutex.cr
+++ b/src/mutex.cr
@@ -16,7 +16,10 @@ require "crystal/spin_lock"
 # mutex from the same fiber will deadlock. Any fiber can unlock the mutex, even
 # if it wasn't previously locked.
 class Mutex
-  @state = Atomic(Int32).new(0)
+  private UNLOCKED = 0
+  private LOCKED   = 1
+
+  @state = Atomic(Int32).new(UNLOCKED)
   @mutex_fiber : Fiber?
   @lock_count = 0
   @queue = Deque(Fiber).new
@@ -34,7 +37,10 @@ class Mutex
 
   @[AlwaysInline]
   def lock : Nil
-    if @state.swap(1) == 0
+    if @state.swap(LOCKED, :acquire) == UNLOCKED
+      {% if flag?(:arm) %}
+        Atomic.fence(:acquire)
+      {% end %}
       @mutex_fiber = Fiber.current unless @protection.unchecked?
       return
     end
@@ -49,20 +55,24 @@ class Mutex
     end
 
     lock_slow
-    nil
   end
 
   @[NoInline]
-  private def lock_slow
+  private def lock_slow : Nil
     loop do
       break if try_lock
 
       @lock.sync do
         @queue_count.add(1)
-        if @state.get == 0
-          if @state.swap(1) == 0
-            @queue_count.add(-1)
-            @mutex_fiber = Fiber.current
+
+        if @state.get(:relaxed) == UNLOCKED
+          if @state.swap(LOCKED, :acquire) == UNLOCKED
+            {% if flag?(:arm) %}
+              Atomic.fence(:acquire)
+            {% end %}
+            @queue_count.sub(1)
+
+            @mutex_fiber = Fiber.current unless @protection.unchecked?
             return
           end
         end
@@ -72,20 +82,21 @@ class Mutex
       Crystal::Scheduler.reschedule
     end
 
-    @mutex_fiber = Fiber.current
-    nil
+    @mutex_fiber = Fiber.current unless @protection.unchecked?
   end
 
   private def try_lock
     i = 1000
-    while @state.swap(1) != 0
-      while @state.get != 0
+    while @state.swap(LOCKED, :acquire) != UNLOCKED
+      while @state.get(:relaxed) != UNLOCKED
         Intrinsics.pause
         i &-= 1
         return false if i == 0
       end
     end
-
+    {% if flag?(:arm) %}
+      Atomic.fence(:acquire)
+    {% end %}
     true
   end
 
@@ -107,10 +118,7 @@ class Mutex
       @mutex_fiber = nil
     end
 
-    {% if flag?(:aarch64) %}
-      Atomic::Ops.fence :sequentially_consistent, false
-    {% end %}
-    @state.lazy_set(0)
+    @state.set(UNLOCKED, :release)
 
     if @queue_count.get == 0
       return
@@ -127,8 +135,6 @@ class Mutex
       end
     end
     fiber.enqueue if fiber
-
-    nil
   end
 
   def synchronize(&)


### PR DESCRIPTION
This patch should fix the use of atomics in locks once and for all (until we add new architectures, that each will need to be investigated). All usages should now be correct as per the textbook, instead of relying on hacks without much impact.

## Explanation

CPU architectures with a weak memory model (such as ARM) can reorder the CPU instructions at runtime (unlike X86), not following the exact order of the assembly. We must respect the memory model guarantees to ensure that we have proper barrier or specific memory ordering at specific places when they are required (e.g. locks).

A lock must ensure that anything after the lock was acquired aren't executed before the lock is acquired, and the other way around: anything before we release the lock must be executed before we actually release it. Each architecture has different quirks:

- **AArch64**: atomics guarantee the ordering but we must use explicit atomics everywhere (at least load/store with acquire/release ordering) ([source](https://elixir.bootlin.com/linux/v4.4/source/arch/arm/include/asm/spinlock.h#L26));
- **ARM v6/v7**: atomics don't guarantee any ordering (only the atomicity of the operation), there must add explicit memory barriers around locks (**help wanted**: can someone test on ARMv6 or v7 hardware? :bow:) ([source](https://elixir.bootlin.com/linux/v4.4/source/arch/arm/include/asm/spinlock.h#L48));
- **X86**: it seems we can go away with a non atomic store, yet using acquire/release ordering isn't any slower than a non atomic store.

## Explicit orderings

X86 is the main reason I added specific orderings. I couldn't notice differences in AArch64 between seq-cst and acq/rel, but on X86 it had a great impact, being no slower than the lazy store while using correct atomics.

Note: I'm following the algorithms used by the Linux v4.4 kernel overall.

## Performance impact

I ran the "mutex" example from #14272 by @jgaskins ten times at different MT levels (ranging from 1 to 128 threads) and charted the average value. See [run.cr](https://gist.github.com/ysbaddaden/74c27148dc0ecfb7e6f2145caa65a2f2).

![mutex-x86](https://github.com/crystal-lang/crystal/assets/47380/77398cc4-bf5e-470d-8e38-d4c558bd23b5)

On X86 (intel haswell i7-4712HQ, 4 cores, 8 threads) we see that the current patch isn't any slower than the current master (incorrect but appears to work), whereas just using load + store with the default sequentially consistent ordering has a huge impact.

![mutex-aarch64](https://github.com/crystal-lang/crystal/assets/47380/88a43c95-2861-4721-a06b-588caded3e2f)

On AArch64 (Neoverse N1 server, 160 cores) we can see that this patch is slower than master with the traditional LL/SC atomics (inherited from ARMv6), but that the difference becomes unnoticeable when the new LSE atomics are enabled (`--mattr=+lse`) which significantly outperform LL/SC on this hardware.

**Future evolution**: we might want to enable LSE atomics by default for AArch64 when available: can detect `lse` feature with [LLVM 15](https://github.com/llvm/llvm-project/commit/ff33b6f90ac2ff60f5084e1c49ae583e122a7323) and [this snippet](https://github.com/crystal-lang/crystal/pull/2824#issuecomment-1936543327) by @HertzDevil and maybe a flag to disable when needed.

**Help Wanted**: I'd be very interested to see results of LL/SC vs LSE atomics for other AArch64 CPUs: Apple, Raspberry Pi, AWS, ... :bow: 

Related issues:
- #13010 
- #14272