### PR TITLE
Fix Indexable#first to inherit doco correctly from Enumerable#first

### DIFF
--- a/src/indexable.cr
+++ b/src/indexable.cr
@@ -744,7 +744,7 @@ module Indexable(T)
     true
   end
 
-  # :inherited:
+  # :inherit:
   def first(&)
     size == 0 ? yield : unsafe_fetch(0)
   end


### PR DESCRIPTION
Fixes the `Indexable#first` documentation directive typo from `:inherited:` to `:inherit:` so that the doco will be inherited correctly from `Enumerable#first`.