### PR TITLE
Make equality between `Complex` and other numbers exact

### DIFF
--- a/spec/std/complex_spec.cr
+++ b/spec/std/complex_spec.cr
@@ -53,7 +53,9 @@ describe "Complex" do
       (a == b).should be_true
       (a == c).should be_false
 
-      (a == BigDecimal.new(53, 1)).should be_false
+      {% unless flag?(:wasm32) %}
+        (a == BigDecimal.new(53, 1)).should be_false
+      {% end %}
     end
 
     it "number == complex" do
@@ -63,7 +65,9 @@ describe "Complex" do
       (a == b).should be_true
       (a == c).should be_false
 
-      (BigDecimal.new(72, 1) == c).should be_false
+      {% unless flag?(:wasm32) %}
+        (BigDecimal.new(72, 1) == c).should be_false
+      {% end %}
     end
   end
 

--- a/spec/std/complex_spec.cr
+++ b/spec/std/complex_spec.cr
@@ -1,6 +1,7 @@
 require "spec"
 require "complex"
 require "../support/number"
+require "big"
 
 # exact equality, including component signs
 private def assert_complex_eq(z1 : Complex, z2 : Complex, *, file = __FILE__, line = __LINE__)
@@ -49,6 +50,8 @@ describe "Complex" do
       c = 4.2
       (a == b).should be_true
       (a == c).should be_false
+
+      (a == BigDecimal.new(53, 1)).should be_false
     end
 
     it "number == complex" do
@@ -57,6 +60,8 @@ describe "Complex" do
       c = Complex.new(7.2, 0)
       (a == b).should be_true
       (a == c).should be_false
+
+      (BigDecimal.new(72, 1) == c).should be_false
     end
   end
 

--- a/spec/std/complex_spec.cr
+++ b/spec/std/complex_spec.cr
@@ -1,7 +1,9 @@
 require "spec"
 require "complex"
 require "../support/number"
-require "big"
+{% unless flag?(:wasm32) %}
+  require "big"
+{% end %}
 
 # exact equality, including component signs
 private def assert_complex_eq(z1 : Complex, z2 : Complex, *, file = __FILE__, line = __LINE__)

--- a/src/complex.cr
+++ b/src/complex.cr
@@ -37,7 +37,7 @@ struct Complex
 
   # :ditto:
   def ==(other : Number)
-    self == other.to_c
+    @real == other && @imag.zero?
   end
 
   # :ditto:
@@ -307,7 +307,7 @@ struct Number
   end
 
   def ==(other : Complex)
-    to_c == other
+    other == self
   end
 
   def cis : Complex


### PR DESCRIPTION
`#to_c` effectively calls `#to_f64`, which may lead to precision loss. This PR replaces that with a direct comparison with the real component, relying on the exactness of that `#==`.

In practice, this only affects comparisons between `Complex` and the `Big*` types, since integer-float comparisons are still subject to #14303:

```crystal
# not affected by this PR
(2.0 ** 64).to_c == UInt64::MAX # => true
```