### PR TITLE
Add MSVC invalid parameter handler

### DIFF
--- a/src/exception/call_stack/stackwalk.cr
+++ b/src/exception/call_stack/stackwalk.cr
@@ -55,6 +55,16 @@ struct Exception::CallStack
     # `Crystal::System::Thread.thread_proc`)
     stack_size = Crystal::System::Fiber::RESERVED_STACK_SIZE
     LibC.SetThreadStackGuarantee(pointerof(stack_size))
+
+    # this catches invalid argument checks inside the C runtime library
+    LibC._set_invalid_parameter_handler(->(expression, _function, _file, _line, _pReserved) do
+      message = expression ? String.from_utf16(expression)[0] : "(no message)"
+      Crystal::System.print_error "CRT invalid parameter handler invoked: %s\n", message
+      caller.each do |frame|
+        Crystal::System.print_error "  from %s\n", frame
+      end
+      LibC._exit(1)
+    end)
   end
 
   {% if flag?(:interpreted) %} @[Primitive(:interpreter_call_stack_unwind)] {% end %}

--- a/src/lib_c/x86_64-windows-msvc/c/stdint.cr
+++ b/src/lib_c/x86_64-windows-msvc/c/stdint.cr
@@ -1,3 +1,4 @@
 lib LibC
   alias IntPtrT = Int64
+  alias UIntPtrT = UInt64
 end

--- a/src/lib_c/x86_64-windows-msvc/c/stdlib.cr
+++ b/src/lib_c/x86_64-windows-msvc/c/stdlib.cr
@@ -16,4 +16,7 @@ lib LibC
   fun realloc(ptr : Void*, size : SizeT) : Void*
   fun strtof(nptr : Char*, endptr : Char**) : Float
   fun strtod(nptr : Char*, endptr : Char**) : Double
+
+  alias InvalidParameterHandler = WCHAR*, WCHAR*, WCHAR*, UInt, UIntPtrT ->
+  fun _set_invalid_parameter_handler(pNew : InvalidParameterHandler) : InvalidParameterHandler
 end


### PR DESCRIPTION
On Windows, if you call one of the C runtime functions that triggers an invalid argument error, by default the process will exit immediately with the code 0xC0000409 (see #13235 for an example where this happens). This PR adds a handler for such errors:

```crystal
LibC._close(-1)
```

```
CRT invalid parameter handler invoked: (no message)
  from minkernel\crts\ucrt\src\appcrt\misc\invalid_parameter.cpp:114 in '_invalid_parameter_internal'
  from minkernel\crts\ucrt\src\appcrt\lowio\close.cpp:71 in '_close_internal'
  from minkernel\crts\ucrt\src\appcrt\lowio\close.cpp:76 in '_close'
  from usr\test.cr:1 in '__crystal_main'
  from src\crystal\main.cr:129 in 'main_user_code'
  from src\crystal\main.cr:115 in 'main'
  from src\crystal\main.cr:141 in 'main'
  from src\crystal\system\win32\wmain.cr:37 in 'wmain'
  from D:\a\_work\1\s\src\vctools\crt\vcstartup\src\startup\exe_common.inl:288 in '__scrt_common_main_seh'
  from C:\WINDOWS\System32\KERNEL32.DLL +75133 in 'BaseThreadInitThunk'
  from C:\WINDOWS\SYSTEM32\ntdll.dll +371288 in 'RtlUserThreadStart'
```

The error message is unavailable unless the debug version of the C runtime is used: (#14312)

```crystal
# src/lib_c.cr
@[Link("libucrtd")]
lib LibC
  # ...
end
```

```
CRT invalid parameter handler invoked: (fh >= 0 && (unsigned)fh < (unsigned)_nhandle)
  from minkernel\crts\ucrt\src\appcrt\misc\invalid_parameter.cpp:110 in '_invalid_parameter_internal'
  from minkernel\crts\ucrt\src\appcrt\lowio\close.cpp:55 in '_close_internal'
  from minkernel\crts\ucrt\src\appcrt\lowio\close.cpp:76 in '_close'
  from usr\test.cr:1 in '__crystal_main'
...
```