### PR TITLE
Add `CRYSTAL_CONFIG_CC` compiler config

### DIFF
--- a/src/compiler/crystal/compiler.cr
+++ b/src/compiler/crystal/compiler.cr
@@ -27,8 +27,8 @@ module Crystal
   # A Compiler parses source code, type checks it and
   # optionally generates an executable.
   class Compiler
-    private DEFAULT_LINKER = ENV["CC"]? || "cc"
-    private MSVC_LINKER    = ENV["CC"]? || "cl.exe"
+    private DEFAULT_LINKER = ENV["CC"]? || {{ env("CRYSTAL_CONFIG_CC") || "cc" }}
+    private MSVC_LINKER    = ENV["CC"]? || {{ env("CRYSTAL_CONFIG_CC") || "cl.exe" }}
 
     # A source to the compiler: its filename and source code.
     record Source,


### PR DESCRIPTION
This environment variable allows to bake into the compiler a default path for `CC` pointing to a specific linker.
Currently, the fixed default default is `cc` (`cl.exe` on Windows). Changing this when compiling the compiler allows taking into account a linker designed for a specific build environment. An example for this would be homebrew, where the compiler should use the linker installed in homebrew because it knows where to find libraries installed via homebrew.

An alternative would be patching the source when necessary, but that's more fragile. An environment variable is more reliable. It serves as a reference that this value can be configured.

Originally suggested in https://forum.crystal-lang.org/t/crystal-installation-using-linuxbrew-is-not-working/6559/10?u=straight-shoota