### PR TITLE
Add `CRYSTAL_CONFIG_LIBRARY_RPATH` compiler config

### DIFF
--- a/src/compiler/crystal/codegen/link.cr
+++ b/src/compiler/crystal/codegen/link.cr
@@ -112,7 +112,7 @@ module Crystal
     def self.default_rpath : String
       # do not call `CrystalPath.expand_paths`, as `$ORIGIN` inside this env
       # variable is always expanded at run time
-      ENV.fetch("CRYSTAL_LIBRARY_RPATH", "")
+      ENV.fetch("CRYSTAL_LIBRARY_RPATH", {{ env("CRYSTAL_CONFIG_LIBRARY_RPATH") || "" }})
     end
 
     # Adds the compiler itself's RPATH to the environment for the duration of


### PR DESCRIPTION
It's already possible to configure the default value for `CRYSTAL_LIBRARY_PATH`. This PR adds the same for `CRYSTAL_LIBRARY_RPATH`. I had already assumed this would work by trying to use it in the homebrew formula. https://forum.crystal-lang.org/t/crystal-installation-using-linuxbrew-is-not-working/6559/6?u=straight-shoota
But it doesn't. So time change that!