### PR TITLE
Fix `Proc#call` that takes and returns large extern structs by value

### DIFF
--- a/spec/std/llvm/aarch64_spec.cr
+++ b/spec/std/llvm/aarch64_spec.cr
@@ -133,7 +133,7 @@ class LLVM::ABI
           info.return_type.should eq(ArgType.direct(str, cast: ctx.int64.array(2)))
         end
 
-        test "does with structs between 64 and 128 bits" do |abi, ctx|
+        test "does with structs larger than 128 bits" do |abi, ctx|
           str = ctx.struct([ctx.int64, ctx.int64, ctx.int8])
           arg_types = [str]
           return_type = str
@@ -141,7 +141,7 @@ class LLVM::ABI
           info = abi.abi_info(arg_types, return_type, true, ctx)
           info.arg_types.size.should eq(1)
 
-          info.arg_types[0].should eq(ArgType.indirect(str, nil))
+          info.arg_types[0].should eq(ArgType.indirect(str, Attribute::ByVal))
           info.return_type.should eq(ArgType.indirect(str, Attribute::StructRet))
         end
 

--- a/spec/std/llvm/aarch64_spec.cr
+++ b/spec/std/llvm/aarch64_spec.cr
@@ -141,7 +141,7 @@ class LLVM::ABI
           info = abi.abi_info(arg_types, return_type, true, ctx)
           info.arg_types.size.should eq(1)
 
-          info.arg_types[0].should eq(ArgType.indirect(str, Attribute::ByVal))
+          info.arg_types[0].should eq(ArgType.indirect(str, nil))
           info.return_type.should eq(ArgType.indirect(str, Attribute::StructRet))
         end
 

--- a/spec/std/llvm/x86_64_abi_spec.cr
+++ b/spec/std/llvm/x86_64_abi_spec.cr
@@ -5,17 +5,17 @@ require "llvm"
   LLVM.init_x86
 {% end %}
 
-private def abi
-  triple = LLVM.default_target_triple.gsub(/^(.+?)-/, "x86_64-")
+private def abi(win64 = false)
+  triple = win64 ? "x86_64-windows-msvc" : LLVM.default_target_triple.gsub(/^(.+?)-/, "x86_64-")
   target = LLVM::Target.from_triple(triple)
   machine = target.create_target_machine(triple)
   machine.enable_global_isel = false
-  LLVM::ABI::X86_64.new(machine)
+  win64 ? LLVM::ABI::X86_Win64.new(machine) : LLVM::ABI::X86_64.new(machine)
 end
 
-private def test(msg, &block : LLVM::ABI, LLVM::Context ->)
-  it msg do
-    abi = abi()
+private def test(msg, *, win64 = false, file = __FILE__, line = __LINE__, &block : LLVM::ABI, LLVM::Context ->)
+  it msg, file: file, line: line do
+    abi = abi(win64)
     ctx = LLVM::Context.new
     block.call(abi, ctx)
   end
@@ -133,7 +133,37 @@ class LLVM::ABI
           info.return_type.should eq(ArgType.direct(str, cast: ctx.struct([ctx.int64, ctx.int64])))
         end
 
-        test "does with structs between 64 and 128 bits" do |abi, ctx|
+        test "does with structs larger than 128 bits" do |abi, ctx|
+          str = ctx.struct([ctx.int64, ctx.int64, ctx.int8])
+          arg_types = [str]
+          return_type = str
+
+          info = abi.abi_info(arg_types, return_type, true, ctx)
+          info.arg_types.size.should eq(1)
+
+          info.arg_types[0].should eq(ArgType.indirect(str, Attribute::ByVal))
+          info.return_type.should eq(ArgType.indirect(str, Attribute::StructRet))
+        end
+      end
+    {% end %}
+  end
+
+  describe X86_Win64 do
+    {% if LibLLVM::BUILT_TARGETS.includes?(:x86) %}
+      describe "abi_info" do
+        test "does with structs between 64 and 128 bits", win64: true do |abi, ctx|
+          str = ctx.struct([ctx.int64, ctx.int16])
+          arg_types = [str]
+          return_type = str
+
+          info = abi.abi_info(arg_types, return_type, true, ctx)
+          info.arg_types.size.should eq(1)
+
+          info.arg_types[0].should eq(ArgType.indirect(str, Attribute::ByVal))
+          info.return_type.should eq(ArgType.indirect(str, Attribute::StructRet))
+        end
+
+        test "does with structs larger than 128 bits", win64: true do |abi, ctx|
           str = ctx.struct([ctx.int64, ctx.int64, ctx.int8])
           arg_types = [str]
           return_type = str

--- a/src/compiler/crystal/codegen/call.cr
+++ b/src/compiler/crystal/codegen/call.cr
@@ -597,12 +597,19 @@ class Crystal::CodeGenVisitor
       abi_info = abi_info(target_def)
     end
 
+    sret = abi_info && sret?(abi_info)
     arg_offset = is_closure ? 2 : 1
+    arg_offset += 1 if sret
+
     arg_types = fun_type.try(&.arg_types) || target_def.try &.args.map &.type
     arg_types.try &.each_with_index do |arg_type, i|
       if abi_info && (abi_arg_type = abi_info.arg_types[i]?) && (attr = abi_arg_type.attr)
         @last.add_instruction_attribute(i + arg_offset, attr, llvm_context, abi_arg_type.type)
       end
+    end
+
+    if abi_info && sret
+      @last.add_instruction_attribute(1, LLVM::Attribute::StructRet, llvm_context, abi_info.return_type.type)
     end
   end
 

--- a/src/compiler/crystal/codegen/fun.cr
+++ b/src/compiler/crystal/codegen/fun.cr
@@ -535,11 +535,14 @@ class Crystal::CodeGenVisitor
         value = pointer2
       end
     else
+      abi_info = target_def.abi_info? ? abi_info(target_def) : nil
+      sret = abi_info && sret?(abi_info)
+
       # If it's an extern struct on a def that must be codegened with C ABI
       # compatibility, and it's not passed byval, we must cast the value
       if target_def.c_calling_convention? && arg.type.extern? && !context.fun.attributes(index + 1).by_val?
         # ... unless it's passed indirectly (ie. as a pointer to memory allocated by the caller)
-        if target_def.abi_info? && abi_info(target_def).arg_types[index].kind.indirect?
+        if abi_info.try &.arg_types[index - (sret ? 1 : 0)].kind.indirect?
           value = declare_debug_for_function_argument(arg.name, var_type, index + 1, value, location) unless target_def.naked?
           context.vars[arg.name] = LLVMVar.new(value, var_type)
         else

--- a/src/llvm/abi/aarch64.cr
+++ b/src/llvm/abi/aarch64.cr
@@ -134,7 +134,7 @@ class LLVM::ABI::AArch64 < LLVM::ABI
                end
         ArgType.direct(aty, cast)
       else
-        ArgType.indirect(aty, LLVM::Attribute::ByVal)
+        ArgType.indirect(aty, nil)
       end
     end
   end

--- a/src/llvm/abi/aarch64.cr
+++ b/src/llvm/abi/aarch64.cr
@@ -134,7 +134,7 @@ class LLVM::ABI::AArch64 < LLVM::ABI
                end
         ArgType.direct(aty, cast)
       else
-        ArgType.indirect(aty, nil)
+        ArgType.indirect(aty, LLVM::Attribute::ByVal)
       end
     end
   end

--- a/src/llvm/abi/x86_win64.cr
+++ b/src/llvm/abi/x86_win64.cr
@@ -12,7 +12,7 @@ class LLVM::ABI::X86_Win64 < LLVM::ABI::X86
         when 2 then ArgType.direct(t, context.int16)
         when 4 then ArgType.direct(t, context.int32)
         when 8 then ArgType.direct(t, context.int64)
-        else        ArgType.indirect(t, nil)
+        else        ArgType.indirect(t, LLVM::Attribute::ByVal)
         end
       else
         non_struct(t, context)


### PR DESCRIPTION
Fixes #14322 by adding the missing `byval` and `sret` LLVM call site attributes. This affects not just the AArch64 ABI, but the Windows x64 ABI too.