### PR TITLE
Fix System V ABI for packed structs with misaligned fields

### DIFF
--- a/spec/std/llvm/x86_64_abi_spec.cr
+++ b/spec/std/llvm/x86_64_abi_spec.cr
@@ -144,6 +144,30 @@ class LLVM::ABI
           info.arg_types[0].should eq(ArgType.indirect(str, Attribute::ByVal))
           info.return_type.should eq(ArgType.indirect(str, Attribute::StructRet))
         end
+
+        test "does with packed struct containing unaligned fields (#9873)" do |abi, ctx|
+          str = ctx.struct([ctx.int8, ctx.int16], packed: true)
+          arg_types = [str]
+          return_type = str
+
+          info = abi.abi_info(arg_types, return_type, true, ctx)
+          info.arg_types.size.should eq(1)
+
+          info.arg_types[0].should eq(ArgType.indirect(str, Attribute::ByVal))
+          info.return_type.should eq(ArgType.indirect(str, Attribute::StructRet))
+        end
+
+        test "does with packed struct not containing unaligned fields" do |abi, ctx|
+          str = ctx.struct([ctx.int16, ctx.int8], packed: true)
+          arg_types = [str]
+          return_type = str
+
+          info = abi.abi_info(arg_types, return_type, true, ctx)
+          info.arg_types.size.should eq(1)
+
+          info.arg_types[0].should eq(ArgType.direct(str, cast: ctx.struct([ctx.int64])))
+          info.return_type.should eq(ArgType.direct(str, cast: ctx.struct([ctx.int64])))
+        end
       end
     {% end %}
   end


### PR DESCRIPTION
Fixes #9873. Section 3.2.3 of the [System V ABI reference](https://gitlab.com/x86-psABIs/x86-64-ABI) says: (emphasis own)

> The classification of aggregate (structures and arrays) and union types works as follows:
>
> 1. If the size of an object is larger than eight eightbytes, or __it contains unaligned fields__, it has class MEMORY.

The same behavior is verified with [C on Clang](https://godbolt.org/z/o1d4EvPbK). Actually calling `Proc`s that take or return those misaligned structs will most likely require #14323 as well, as `byval` and `sret` are now mandatory.

On an unrelated note: while the reference says "eight eightbytes", an earlier revision said "four" instead, which is what Crystal currently uses for classification. This probably won't matter unless Crystal supports 512-bit vectors natively.