### PR TITLE
Allow block after bracket call syntax

### DIFF
--- a/spec/compiler/parser/parser_spec.cr
+++ b/spec/compiler/parser/parser_spec.cr
@@ -565,6 +565,32 @@ module Crystal
     it_parses "x[{1}]", Call.new("x".call, "[]", TupleLiteral.new([1.int32] of ASTNode))
     it_parses "x[+ 1]", Call.new("x".call, "[]", Call.new(1.int32, "+"))
 
+    it_parses "x[] {}", Call.new("x".call, "[]", block: Block.new)
+    it_parses "x[] do\nend", Call.new("x".call, "[]", block: Block.new)
+
+    it_parses "x[1] { |x| }", Call.new("x".call, "[]", args: [1.int32] of ASTNode, block: Block.new(["x".var]))
+    it_parses "x[1]? { |x| }", Call.new("x".call, "[]?", args: [1.int32] of ASTNode, block: Block.new(["x".var]))
+
+    it_parses "x[a: 1, b: 2] { }", Call.new("x".call, "[]", named_args: [NamedArgument.new("a", 1.int32), NamedArgument.new("b", 2.int32)], block: Block.new)
+    it_parses "x[a: 1, b: 2]? { }", Call.new("x".call, "[]?", named_args: [NamedArgument.new("a", 1.int32), NamedArgument.new("b", 2.int32)], block: Block.new)
+
+    it_parses "foo x[] { } do\nend", Call.new(nil, "foo", args: [Call.new("x".call, "[]", block: Block.new)] of ASTNode, block: Block.new)
+    it_parses "foo x[1]? { } do\nend", Call.new(nil, "foo", args: [Call.new("x".call, "[]?", args: [1.int32] of ASTNode, block: Block.new)] of ASTNode, block: Block.new)
+
+    it_parses "foo x[] do\nend", Call.new(nil, "foo", args: [Call.new("x".call, "[]")] of ASTNode, block: Block.new)
+    it_parses "foo.x[] do\nend", Call.new(Call.new("foo".call, "x"), "[]", block: Block.new)
+
+    it_parses "foo x[1]? do\nend", Call.new(nil, "foo", args: [Call.new("x".call, "[]?", args: [1.int32] of ASTNode)] of ASTNode, block: Block.new)
+    it_parses "foo.x[1]? do\nend", Call.new(Call.new("foo".call, "x"), "[]?", args: [1.int32] of ASTNode, block: Block.new)
+
+    it_parses "Foo[Bar[1] { }, baz[2]? do\n\nend, boo[]] { }",
+      Call.new("Foo".path, "[]",
+        args: [
+          Call.new("Bar".path, "[]", args: [1.int32] of ASTNode, block: Block.new),
+          Call.new("baz".call, "[]?", args: [2.int32] of ASTNode, block: Block.new),
+          Call.new("boo".call, "[]"),
+        ] of ASTNode, block: Block.new)
+
     it_parses "foo(a: 1, &block)", Call.new(nil, "foo", named_args: [NamedArgument.new("a", 1.int32)], block_arg: "block".call)
     it_parses "foo a: 1, &block", Call.new(nil, "foo", named_args: [NamedArgument.new("a", 1.int32)], block_arg: "block".call)
     it_parses "foo a: b(1) do\nend", Call.new(nil, "foo", named_args: [NamedArgument.new("a", Call.new(nil, "b", 1.int32))], block: Block.new)

--- a/src/compiler/crystal/syntax/parser.cr
+++ b/src/compiler/crystal/syntax/parser.cr
@@ -802,7 +802,12 @@ module Crystal
           end_location = token_end_location
           @wants_regex = false
           next_token_skip_space
-          atomic = Call.new(atomic, "[]").at(location)
+
+          if block = parse_block(block: nil, stop_on_do: @stop_on_do)
+            end_location = block.end_location
+          end
+
+          atomic = Call.new(atomic, "[]", block: block).at(location)
           atomic.name_location = name_location
           atomic.end_location = end_location
           atomic.name_size = 0 if atomic.is_a?(Call)
@@ -845,9 +850,11 @@ module Crystal
             skip_space
           end
 
+          block = parse_block(block, stop_on_do: @stop_on_do)
+
           atomic = Call.new(atomic, method_name, (args || [] of ASTNode), block, block_arg, named_args).at(location)
           atomic.name_location = name_location
-          atomic.end_location = end_location
+          atomic.end_location = block.try(&.end_location) || end_location
           atomic.name_size = 0 if atomic.is_a?(Call)
           atomic
         else


### PR DESCRIPTION
Fixes #13975. I've been hitting this issue very much lately, I'm using `self.[]` in many of my projects for "smart constructors" and they sometimes require blocks. There's also a bug in the rough vicinity, `foo[&.bar]` and `foo[1, &.bar]` etc. causing the formatter to crash, maybe I'll try to fix it sometime later.