### PR TITLE
Do not allocate memory in the segmentation fault signal handler

### DIFF
--- a/src/crystal/system/unix/signal.cr
+++ b/src/crystal/system/unix/signal.cr
@@ -135,6 +135,9 @@ module Crystal::System::Signal
   @@segfault_handler = LibC::SigactionHandlerT.new { |sig, info, data|
     # Capture fault signals (SEGV, BUS) and finish the process printing a backtrace first
 
+    # This handler must not allocate memory via the GC! Expanding the heap or
+    # triggering a GC cycle here could geenrate another SEGV
+
     # Determine if the SEGV was inside or 'near' the top of the stack
     # to check for potential stack overflow. 'Near' is a small
     # amount larger than a typical stack frame, 4096 bytes here.

--- a/src/crystal/system/unix/signal.cr
+++ b/src/crystal/system/unix/signal.cr
@@ -136,7 +136,7 @@ module Crystal::System::Signal
     # Capture fault signals (SEGV, BUS) and finish the process printing a backtrace first
 
     # This handler must not allocate memory via the GC! Expanding the heap or
-    # triggering a GC cycle here could geenrate another SEGV
+    # triggering a GC cycle here could generate another SEGV
 
     # Determine if the SEGV was inside or 'near' the top of the stack
     # to check for potential stack overflow. 'Near' is a small

--- a/src/exception/call_stack/libunwind.cr
+++ b/src/exception/call_stack/libunwind.cr
@@ -120,7 +120,7 @@ struct Exception::CallStack
       end
     {% end %}
 
-    if frame = decode_frame(repeated_frame.ip)
+    if frame = unsafe_decode_frame(repeated_frame.ip)
       offset, sname, fname = frame
       Crystal::System.print_error "%s +%lld in %s", sname, offset.to_i64, fname
     else
@@ -147,6 +147,22 @@ struct Exception::CallStack
         file = String.new(info.dli_fname)
       end
       {offset, symbol, file}
+    end
+  end
+
+  protected def self.unsafe_decode_frame(ip)
+    original_ip = ip
+    while LibC.dladdr(ip, out info) != 0
+      offset = original_ip - info.dli_saddr
+      if offset == 0
+        ip -= 1
+        next
+      end
+
+      return if info.dli_sname.null? && info.dli_fname.null?
+      symbol = info.dli_sname || "??".to_unsafe
+      file = info.dli_fname || "??".to_unsafe
+      return {offset, symbol, file}
     end
   end
 end

--- a/src/exception/call_stack/libunwind.cr
+++ b/src/exception/call_stack/libunwind.cr
@@ -150,6 +150,9 @@ struct Exception::CallStack
     end
   end
 
+  # variant of `.decode_frame` that returns the C strings directly instead of
+  # wrapping them in `String.new`, since the SIGSEGV handler cannot allocate
+  # memory via the GC
   protected def self.unsafe_decode_frame(ip)
     original_ip = ip
     while LibC.dladdr(ip, out info) != 0


### PR DESCRIPTION
The `String.new(UInt8*)` call inside `Exception::CallStack.decode_frame` could allocate memory, potentially triggering a GC cycle or expanding the GC heap, which could break the stack trace:

```crystal
x = Pointer(UInt8).null
y = x.value
```

```
Invalid memory access (signal 11) at address 0x0
[0x55dbcfe66a06] *Exception::CallStack::print_backtrace:Nil +118 in /home/quinton/.cache/crystal/crystal-run-test.tmp
[0x55dbcfe55ec6] Program exited because of an invalid memory access
```

This seems to happen on master since #14257, and also to #14047 with Crystal 1.10.1. This PR removes this allocation so that `Crystal::System::Signal.@@segfault_handler` should be allocation-free. (Technically `Fiber.current` could eventually call `Thread.new`, but this should be extremely rare.)