### PR TITLE
Fix macro `Crystal::LIBRARY_PATH.split` when cross-compiling

### DIFF
--- a/src/crystal/system/win32/process.cr
+++ b/src/crystal/system/win32/process.cr
@@ -7,6 +7,12 @@ require "process/shell"
 require "crystal/atomic_semaphore"
 
 struct Crystal::System::Process
+  {% if host_flag?(:windows) %}
+    HOST_PATH_DELIMITER = ';'
+  {% else %}
+    HOST_PATH_DELIMITER = ':'
+  {% end %}
+
   getter pid : LibC::DWORD
   @thread_id : LibC::DWORD
   @process_handle : LibC::HANDLE

--- a/src/llvm/lib_llvm.cr
+++ b/src/llvm/lib_llvm.cr
@@ -1,7 +1,7 @@
 {% begin %}
   {% if flag?(:win32) && !flag?(:static) %}
     {% config = nil %}
-    {% for dir in Crystal::LIBRARY_PATH.split(';') %}
+    {% for dir in Crystal::LIBRARY_PATH.split(Process::HOST_PATH_DELIMITER) %}
       {% config ||= read_file?("#{dir.id}/llvm_VERSION") %}
     {% end %}
 

--- a/src/llvm/lib_llvm.cr
+++ b/src/llvm/lib_llvm.cr
@@ -1,7 +1,7 @@
 {% begin %}
   {% if flag?(:win32) && !flag?(:static) %}
     {% config = nil %}
-    {% for dir in Crystal::LIBRARY_PATH.split(Process::HOST_PATH_DELIMITER) %}
+    {% for dir in Crystal::LIBRARY_PATH.split(Crystal::System::Process::HOST_PATH_DELIMITER) %}
       {% config ||= read_file?("#{dir.id}/llvm_VERSION") %}
     {% end %}
 

--- a/src/openssl/lib_crypto.cr
+++ b/src/openssl/lib_crypto.cr
@@ -3,7 +3,7 @@
     {% if flag?(:win32) %}
       {% from_libressl = false %}
       {% ssl_version = nil %}
-      {% for dir in Crystal::LIBRARY_PATH.split(Process::HOST_PATH_DELIMITER) %}
+      {% for dir in Crystal::LIBRARY_PATH.split(Crystal::System::Process::HOST_PATH_DELIMITER) %}
         {% unless ssl_version %}
           {% config_path = "#{dir.id}\\openssl_VERSION" %}
           {% if config_version = read_file?(config_path) %}

--- a/src/openssl/lib_crypto.cr
+++ b/src/openssl/lib_crypto.cr
@@ -3,7 +3,7 @@
     {% if flag?(:win32) %}
       {% from_libressl = false %}
       {% ssl_version = nil %}
-      {% for dir in Crystal::LIBRARY_PATH.split(';') %}
+      {% for dir in Crystal::LIBRARY_PATH.split(Process::HOST_PATH_DELIMITER) %}
         {% unless ssl_version %}
           {% config_path = "#{dir.id}\\openssl_VERSION" %}
           {% if config_version = read_file?(config_path) %}

--- a/src/openssl/lib_ssl.cr
+++ b/src/openssl/lib_ssl.cr
@@ -9,7 +9,7 @@ require "./lib_crypto"
     {% if flag?(:win32) %}
       {% from_libressl = false %}
       {% ssl_version = nil %}
-      {% for dir in Crystal::LIBRARY_PATH.split(Process::HOST_PATH_DELIMITER) %}
+      {% for dir in Crystal::LIBRARY_PATH.split(Crystal::System::Process::HOST_PATH_DELIMITER) %}
         {% unless ssl_version %}
           {% config_path = "#{dir.id}\\openssl_VERSION" %}
           {% if config_version = read_file?(config_path) %}

--- a/src/openssl/lib_ssl.cr
+++ b/src/openssl/lib_ssl.cr
@@ -9,7 +9,7 @@ require "./lib_crypto"
     {% if flag?(:win32) %}
       {% from_libressl = false %}
       {% ssl_version = nil %}
-      {% for dir in Crystal::LIBRARY_PATH.split(';') %}
+      {% for dir in Crystal::LIBRARY_PATH.split(Process::HOST_PATH_DELIMITER) %}
         {% unless ssl_version %}
           {% config_path = "#{dir.id}\\openssl_VERSION" %}
           {% if config_version = read_file?(config_path) %}

--- a/src/process/executable_path.cr
+++ b/src/process/executable_path.cr
@@ -9,14 +9,6 @@ class Process
     PATH_DELIMITER = ':'
   {% end %}
 
-  {% if host_flag?(:windows) %}
-    # :nodoc:
-    HOST_PATH_DELIMITER = ';'
-  {% else %}
-    # :nodoc:
-    HOST_PATH_DELIMITER = ':'
-  {% end %}
-
   # :nodoc:
   INITIAL_PATH = ENV["PATH"]?
 

--- a/src/process/executable_path.cr
+++ b/src/process/executable_path.cr
@@ -9,6 +9,14 @@ class Process
     PATH_DELIMITER = ':'
   {% end %}
 
+  {% if host_flag?(:windows) %}
+    # :nodoc:
+    HOST_PATH_DELIMITER = ';'
+  {% else %}
+    # :nodoc:
+    HOST_PATH_DELIMITER = ':'
+  {% end %}
+
   # :nodoc:
   INITIAL_PATH = ENV["PATH"]?
 


### PR DESCRIPTION
`Crystal::LIBRARY_PATH` always uses the host platform's path delimiter, but `Process::PATH_DELIMITER` is defined in terms of the target platform, which can break cross-compilation from a non-Windows system to Windows when `CRYSTAL_LIBRARY_PATH` has multiple items. This PR adds the correct delimiter as a constant.

By the way, this is actually the first usage of `host_flag?` in the repository.