### PR TITLE
Fix crash stack trace decoding on macOS

### DIFF
--- a/src/exception/call_stack/libunwind.cr
+++ b/src/exception/call_stack/libunwind.cr
@@ -110,12 +110,14 @@ struct Exception::CallStack
 
   private def self.print_frame_location(repeated_frame)
     {% if flag?(:debug) %}
-      if @@dwarf_loaded &&
-         (name = decode_function_name(repeated_frame.ip.address))
-        file, line, column = Exception::CallStack.decode_line_number(repeated_frame.ip.address)
-        if file && file != "??"
-          Crystal::System.print_error "%s at %s:%d:%d", name, file, line, column
-          return
+      if @@dwarf_loaded
+        pc = CallStack.decode_address(repeated_frame.ip)
+        if name = decode_function_name(pc)
+          file, line, column = Exception::CallStack.decode_line_number(pc)
+          if file && file != "??"
+            Crystal::System.print_error "%s at %s:%d:%d", name, file, line, column
+            return
+          end
         end
       end
     {% end %}


### PR DESCRIPTION
Adds a `Exception::CallStack.decode_address` call to account for ASLR on macOS systems, which `caller` / `Exception::CallStack.unwind` already uses. Example: (run with `CRYSTAL_LOAD_DEBUG_INFO=1` or call `caller` beforehand, since Unix-like systems do not currently load debug info upon crashes)

```crystal
def foo
  x = Pointer(UInt8).null
  y = x.value
end

foo
```

Before:

```
[0x10043b4f4] *Exception::CallStack::print_backtrace:Nil +104 in /Users/quinton/.cache/crystal/crystal-run-small.tmp
[0x1004270f0] ~procProc(Int32, Pointer(LibC::SiginfoT), Pointer(Void), Nil)@src/crystal/system/unix/signal.cr:135 +320 in /Users/quinton/.cache/crystal/crystal-run-small.tmp
[0x18cb49a24] _sigtramp +56 in /usr/lib/system/libsystem_platform.dylib
[0x1004274ac] *foo:UInt8 +20 in /Users/quinton/.cache/crystal/crystal-run-small.tmp
[0x10041a868] __crystal_main +984 in /Users/quinton/.cache/crystal/crystal-run-small.tmp
[0x1004cbae8] *Crystal::main_user_code<Int32, Pointer(Pointer(UInt8))>:Nil +12 in /Users/quinton/.cache/crystal/crystal-run-small.tmp
[0x1004cba50] *Crystal::main<Int32, Pointer(Pointer(UInt8))>:Int32 +60 in /Users/quinton/.cache/crystal/crystal-run-small.tmp
[0x1004238c4] main +12 in /Users/quinton/.cache/crystal/crystal-run-small.tmp
```

After:

```
[0x1021f74f0] print_backtrace at /Users/quinton/crystal/crystal/src/exception/call_stack/libunwind.cr:100:5
[0x1021e30ec] -> at /Users/quinton/crystal/crystal/src/crystal/system/unix/signal.cr:162:5
[0x18cb49a24] _sigtramp +56 in /usr/lib/system/libsystem_platform.dylib
[0x1021e34a8] foo at /Users/quinton/crystal/crystal/usr/small.cr:36:3
[0x1021d6864] __crystal_main at /Users/quinton/crystal/crystal/usr/small.cr:40:1
[0x102287ae8] main_user_code at /Users/quinton/crystal/crystal/src/crystal/main.cr:129:5
[0x102287a50] main at /Users/quinton/crystal/crystal/src/crystal/main.cr:115:7
[0x1021df8c0] main at /Users/quinton/crystal/crystal/src/crystal/main.cr:141:3
```