### PR TITLE
Remove the prelude from some compiler specs

### DIFF
--- a/spec/compiler/codegen/block_spec.cr
+++ b/spec/compiler/codegen/block_spec.cr
@@ -505,8 +505,6 @@ describe "Code gen: block" do
 
   it "can break without value from yielder that returns nilable (1)" do
     run(%(
-      require "prelude"
-
       def foo
         yield
         ""
@@ -522,8 +520,6 @@ describe "Code gen: block" do
 
   it "can break without value from yielder that returns nilable (2)" do
     run(%(
-      require "prelude"
-
       def foo
         yield
         ""
@@ -539,8 +535,6 @@ describe "Code gen: block" do
 
   it "break with value from yielder that returns a nilable" do
     run(%(
-      require "prelude"
-
       def foo
         yield
         ""
@@ -1046,8 +1040,6 @@ describe "Code gen: block" do
 
   it "codegens method invocation on a object of a captured block with a type that was never instantiated" do
     codegen(%(
-      require "prelude"
-
       class Bar
         def initialize(@bar : NoReturn)
         end
@@ -1076,8 +1068,6 @@ describe "Code gen: block" do
 
   it "codegens method invocation on a object of a captured block with a type that was never instantiated (2)" do
     codegen(%(
-      require "prelude"
-
       class Bar
         def initialize(@bar : NoReturn)
         end

--- a/spec/compiler/codegen/class_spec.cr
+++ b/spec/compiler/codegen/class_spec.cr
@@ -857,8 +857,6 @@ describe "Code gen: class" do
 
   it "codegens singleton (#718)" do
     run(%(
-      require "prelude"
-
       class Singleton
         @@instance = new
 

--- a/spec/compiler/codegen/class_var_spec.cr
+++ b/spec/compiler/codegen/class_var_spec.cr
@@ -106,8 +106,6 @@ describe "Codegen: class var" do
 
   it "uses var in class var initializer" do
     run(%(
-      require "prelude"
-
       class Foo
         @@var : Int32
         @@var = begin
@@ -130,8 +128,6 @@ describe "Codegen: class var" do
 
   it "reads simple class var before another complex one" do
     run(%(
-      require "prelude"
-
       class Foo
         @@var2 : Int32
         @@var2 = @@var &+ 1
@@ -149,8 +145,6 @@ describe "Codegen: class var" do
 
   it "initializes class var of union with single type" do
     run(%(
-      require "prelude"
-
       class Foo
         @@var : Int32 | String
         @@var = 42
@@ -241,8 +235,6 @@ describe "Codegen: class var" do
 
   it "doesn't use nilable type for initializer" do
     run(%(
-      require "prelude"
-
       class Foo
         @@foo : Int32?
         @@foo = 42
@@ -261,8 +253,6 @@ describe "Codegen: class var" do
 
   it "codegens class var with begin and vars" do
     run(%(
-      require "prelude"
-
       class Foo
         @@foo : Int32
         @@foo = begin
@@ -282,8 +272,6 @@ describe "Codegen: class var" do
 
   it "codegens class var with type declaration begin and vars" do
     run(%(
-      require "prelude"
-
       class Foo
         @@foo : Int32 = begin
           a = 1
@@ -352,8 +340,6 @@ describe "Codegen: class var" do
 
   it "gets pointerof class var complex constant" do
     run(%(
-      require "prelude"
-
       z = Foo.foo
 
       class Foo

--- a/spec/compiler/codegen/is_a_spec.cr
+++ b/spec/compiler/codegen/is_a_spec.cr
@@ -594,8 +594,6 @@ describe "Codegen: is_a?" do
 
   it "resets truthy state after visiting nodes (bug)" do
     run(%(
-      require "prelude"
-
       a = 123
       if !1.is_a?(Int32)
         a = 456
@@ -782,8 +780,6 @@ describe "Codegen: is_a?" do
 
   it "codegens untyped var (#4009)" do
     codegen(%(
-      require "prelude"
-
       i = 1
       1 || i.is_a?(Int32) ? "" : i
       ))

--- a/spec/compiler/codegen/macro_spec.cr
+++ b/spec/compiler/codegen/macro_spec.cr
@@ -554,13 +554,12 @@ describe "Code gen: macro" do
 
   it "can iterate union types" do
     run(%(
-      require "prelude"
       class Foo
         def initialize
           @x = 1; @x = 1.1
         end
         def foo
-          {{ @type.instance_vars.first.type.union_types.map(&.name).sort }}.join('-')
+          {{ @type.instance_vars.first.type.union_types.map(&.name).sort.join("-") }}
         end
       end
       Foo.new.foo
@@ -613,10 +612,9 @@ describe "Code gen: macro" do
 
   it "can access type variables of a generic type" do
     run(%(
-      require "prelude"
       class Foo(T, K)
         def self.foo : String
-          {{ @type.type_vars.map(&.stringify) }}.join('-')
+          {{ @type.type_vars.map(&.stringify).join("-") }}
         end
       end
       Foo.foo
@@ -697,8 +695,6 @@ describe "Code gen: macro" do
 
   it "executes subclasses" do
     run(%(
-      require "prelude"
-
       class Foo
       end
 
@@ -711,15 +707,12 @@ describe "Code gen: macro" do
       class Qux < Baz
       end
 
-      names = {{ Foo.subclasses.map &.name }}
-      names.join('-')
+      {{ Foo.subclasses.map(&.name).join("-") }}
       )).to_string.should eq("Bar-Baz")
   end
 
   it "executes all_subclasses" do
     run(%(
-      require "prelude"
-
       class Foo
       end
 
@@ -729,8 +722,7 @@ describe "Code gen: macro" do
       class Baz < Bar
       end
 
-      names = {{ Foo.all_subclasses.map &.name }}
-      names.join('-')
+      {{ Foo.all_subclasses.map(&.name).join("-") }}
       )).to_string.should eq("Bar-Baz")
   end
 
@@ -813,8 +805,6 @@ describe "Code gen: macro" do
 
   it "copies base macro def to sub-subtype even after it was copied to a subtype (#448)" do
     run(%(
-      require "prelude"
-
       class Object
         def class_name : String
           {{@type.name.stringify}}

--- a/spec/compiler/codegen/pointer_spec.cr
+++ b/spec/compiler/codegen/pointer_spec.cr
@@ -325,8 +325,6 @@ describe "Code gen: pointer" do
 
   it "does pointerof class variable with class" do
     run(%(
-      require "prelude"
-
       class Bar
         def initialize(@x : Int32)
         end
@@ -406,8 +404,6 @@ describe "Code gen: pointer" do
 
   it "uses correct llvm module for typedef metaclass (#2877)" do
     run(%(
-      require "prelude"
-
       lib LibFoo
         type Foo = Void*
         type Bar = Void*
@@ -456,8 +452,6 @@ describe "Code gen: pointer" do
 
   it "generates correct code for Pointer.malloc(0) (#2905)" do
     run(%(
-      require "prelude"
-
       class Foo
         def initialize(@value : Int32)
         end

--- a/spec/compiler/codegen/return_spec.cr
+++ b/spec/compiler/codegen/return_spec.cr
@@ -22,11 +22,11 @@ describe "Code gen: return" do
   end
 
   it "return from function with nilable type" do
-    run(%(require "prelude"; def foo; return Reference.new if 1 == 1; end; foo.nil?)).to_b.should be_false
+    run(%(def foo; return Reference.new if 1 == 1; end; foo.nil?)).to_b.should be_false
   end
 
   it "return from function with nilable type 2" do
-    run(%(require "prelude"; def foo; return Reference.new if 1 == 1; end; foo.nil?)).to_b.should be_false
+    run(%(def foo; return Reference.new if 1 == 1; end; foo.nil?)).to_b.should be_false
   end
 
   it "returns empty from function" do

--- a/spec/compiler/codegen/super_spec.cr
+++ b/spec/compiler/codegen/super_spec.cr
@@ -417,8 +417,6 @@ describe "Codegen: super" do
 
   it "calls super from virtual metaclass type (#2841)" do
     run(%(
-      require "prelude"
-
       abstract class Foo
         def self.bar(x : Bool)
           x

--- a/spec/compiler/codegen/var_spec.cr
+++ b/spec/compiler/codegen/var_spec.cr
@@ -113,8 +113,6 @@ describe "Code gen: var" do
 
   it "codegens assignment that can never be reached" do
     codegen(%(
-      require "prelude"
-
       if 1 == 1 && (x = nil)
         z = x
       end

--- a/spec/compiler/codegen/virtual_spec.cr
+++ b/spec/compiler/codegen/virtual_spec.cr
@@ -293,8 +293,6 @@ describe "Code gen: virtual type" do
 
   it "doesn't lookup in Value+ when virtual type is Object+" do
     run(%(
-      require "prelude"
-
       class Object
         def foo
           !nil?

--- a/spec/compiler/semantic/instance_var_spec.cr
+++ b/spec/compiler/semantic/instance_var_spec.cr
@@ -741,8 +741,6 @@ describe "Semantic: instance var" do
 
   it "infers type from tuple literal" do
     assert_type(%(
-      require "prelude"
-
       class Foo
         def initialize
           @x = {1, "foo"}
@@ -759,8 +757,6 @@ describe "Semantic: instance var" do
 
   it "infers type from named tuple literal" do
     assert_type(%(
-      require "prelude"
-
       class Foo
         def initialize
           @x = {x: 1, y: "foo"}

--- a/spec/compiler/semantic/proc_spec.cr
+++ b/spec/compiler/semantic/proc_spec.cr
@@ -249,8 +249,6 @@ describe "Semantic: proc" do
 
   it "types proc literal hard type inference (1)" do
     assert_type(%(
-      require "prelude"
-
       class Foo
         def initialize(@x : Int32)
         end
@@ -543,8 +541,6 @@ describe "Semantic: proc" do
 
   it "types proc literal with a type that was never instantiated" do
     assert_type(%(
-      require "prelude"
-
       class Foo
         def initialize(@x : Int32)
         end
@@ -560,8 +556,6 @@ describe "Semantic: proc" do
 
   it "types proc pointer with a type that was never instantiated" do
     assert_type(%(
-      require "prelude"
-
       class Foo
         def initialize(@x : Int32)
         end


### PR DESCRIPTION
Those `require "prelude"`s can be eliminated with no or very little effort (`Array#join` is moved into an adjacent macro expression). Most of these are codegen specs.