### PR TITLE
Enable `@[Primitive(:va_arg)]` semantic spec on Windows

### DIFF
--- a/spec/compiler/semantic/primitives_spec.cr
+++ b/spec/compiler/semantic/primitives_spec.cr
@@ -223,7 +223,7 @@ describe "Semantic: primitives" do
       )
   end
 
-  pending_win32 "types va_arg primitive" do
+  it "types va_arg primitive" do
     assert_type(%(
       struct VaList
         @[Primitive(:va_arg)]


### PR DESCRIPTION
Because this semantic spec merely tests the type of a `VaList#next` call (more specifically `Crystal::MainVisitor#visit_va_arg`), it shouldn't matter whether codegen support for `VaList` actually exists, such as on Windows.