### PR TITLE
Fix: init schedulers before we spawn fibers

### DIFF
--- a/src/kernel.cr
+++ b/src/kernel.cr
@@ -563,12 +563,6 @@ end
 {% end %}
 
 {% unless flag?(:interpreted) || flag?(:wasm32) %}
-  {% if flag?(:win32) %}
-    Crystal::System::Process.start_interrupt_loop
-  {% else %}
-    Crystal::System::Signal.setup_default_handlers
-  {% end %}
-
   # load debug info on start up of the program is executed with CRYSTAL_LOAD_DEBUG_INFO=1
   # this will make debug info available on print_frame that is used by Crystal's segfault handler
   #
@@ -579,4 +573,10 @@ end
   Exception::CallStack.setup_crash_handler
 
   Crystal::Scheduler.init
+
+  {% if flag?(:win32) %}
+    Crystal::System::Process.start_interrupt_loop
+  {% else %}
+    Crystal::System::Signal.setup_default_handlers
+  {% end %}
 {% end %}


### PR DESCRIPTION
The signal and interrupt handlers spawn fibers, and should thus be setup after we properly start the fiber schedulers.

This is working today because we lazily start schedulers for a thread, and we happen to not have recursive dependencies, but https://github.com/crystal-lang/rfcs/pull/2 is a whole different story :sweat_smile: 