### PR TITLE
Allow `--single-module` and `--threads` for `eval` and `spec`

### DIFF
--- a/src/compiler/crystal/command.cr
+++ b/src/compiler/crystal/command.cr
@@ -540,6 +540,12 @@ class Crystal::Command
       end
 
       unless no_codegen
+        opts.on("--single-module", "Generate a single LLVM module") do
+          compiler.single_module = true
+        end
+        opts.on("--threads NUM", "Maximum number of threads to use") do |n_threads|
+          compiler.n_threads = n_threads.to_i? || raise Error.new("Invalid thread count: #{n_threads}")
+        end
         unless run
           opts.on("--target TRIPLE", "Target triple") do |triple|
             compiler.codegen_target = Codegen::Target.new(triple)

--- a/src/compiler/crystal/command.cr
+++ b/src/compiler/crystal/command.cr
@@ -540,12 +540,6 @@ class Crystal::Command
       end
 
       unless no_codegen
-        opts.on("--single-module", "Generate a single LLVM module") do
-          compiler.single_module = true
-        end
-        opts.on("--threads NUM", "Maximum number of threads to use") do |n_threads|
-          compiler.n_threads = n_threads.to_i? || raise Error.new("Invalid thread count: #{n_threads}")
-        end
         unless run
           opts.on("--target TRIPLE", "Target triple") do |triple|
             compiler.codegen_target = Codegen::Target.new(triple)
@@ -663,6 +657,12 @@ class Crystal::Command
     end
     opts.on("-O LEVEL", "Optimization mode: 0 (default), 1, 2, 3") do |level|
       compiler.optimization_mode = Compiler::OptimizationMode.from_value?(level.to_i) || raise Error.new("Unknown optimization mode #{level}")
+    end
+    opts.on("--single-module", "Generate a single LLVM module") do
+      compiler.single_module = true
+    end
+    opts.on("--threads NUM", "Maximum number of threads to use") do |n_threads|
+      compiler.n_threads = n_threads.to_i? || raise Error.new("Invalid thread count: #{n_threads}")
     end
     opts.on("-s", "--stats", "Enable statistics output") do
       compiler.progress_tracker.stats = true


### PR DESCRIPTION
`--single-module` makes sense because both `--release` and `-O` are already available for `crystal eval` and `crystal spec`.

`--threads=1` is useful when dealing with huge spec suites on platforms with limited memory.