### PR TITLE
Add `Token::Kind#unary_operator?`

### DIFF
--- a/src/compiler/crystal/syntax/parser.cr
+++ b/src/compiler/crystal/syntax/parser.cr
@@ -627,7 +627,7 @@ module Crystal
     def parse_prefix
       name_location = @token.location
       case token_type = @token.type
-      when .op_bang?, .op_plus?, .op_minus?, .op_tilde?, .op_amp_plus?, .op_amp_minus?
+      when .unary_operator?
         location = @token.location
         next_token_skip_space_or_newline
         check_void_expression_keyword

--- a/src/compiler/crystal/syntax/to_s.cr
+++ b/src/compiler/crystal/syntax/to_s.cr
@@ -332,6 +332,7 @@ module Crystal
       visit_call node
     end
 
+    # Related: `Token::Kind#unary_operator?`
     UNARY_OPERATORS = {"+", "-", "~", "&+", "&-"}
 
     def visit_call(node, ignore_obj = false)

--- a/src/compiler/crystal/syntax/token.cr
+++ b/src/compiler/crystal/syntax/token.cr
@@ -249,6 +249,13 @@ module Crystal
         end
       end
 
+      # Returns true if the operator can be used in prefix notation.
+      #
+      # Related: `ToSVisitor::UNARY_OPERATORS`
+      def unary_operator?
+        self.in?(OP_BANG, OP_PLUS, OP_MINUS, OP_TILDE, OP_AMP_PLUS, OP_AMP_MINUS)
+      end
+
       def magic?
         magic_dir? || magic_end_line? || magic_file? || magic_line?
       end

--- a/src/compiler/crystal/tools/formatter.cr
+++ b/src/compiler/crystal/tools/formatter.cr
@@ -2541,13 +2541,14 @@ module Crystal
       write_token :OP_COLON_COLON if node.global?
 
       if obj
-        {Token::Kind::OP_BANG, Token::Kind::OP_PLUS, Token::Kind::OP_MINUS, Token::Kind::OP_TILDE, Token::Kind::OP_AMP_PLUS, Token::Kind::OP_AMP_MINUS}.each do |op|
-          if node.name == op.to_s && @token.type == op && node.args.empty?
-            write op
-            next_token_skip_space_or_newline
-            accept obj
-            return false
-          end
+        # This handles unary operators written in prefix notation.
+        # The relevant distinction is that the call has a receiver and the
+        # current token is not that object but a unary operator.
+        if @token.type.unary_operator? && node.name == @token.type.to_s && node.args.empty?
+          write @token.type
+          next_token_skip_space_or_newline
+          accept obj
+          return false
         end
 
         accept obj


### PR DESCRIPTION
This is a tiny refactor to merge two duplicate definitions of unary operators into a predicate method of `Token::Kind`.
Also simplifies the handling of unary operators in prefix notation in the formatter.

There's another similar definition in `ToSVisitor::UNARY_OPERATORS` but it's based on method name, not token type. This is practically not very relevant, but it's not trivial to integrate into one. So I think it's fine to keep this duplication, but I've added cross-references between the two.