### PR TITLE
Fix: Crystal::RWLock should be a struct

### DIFF
--- a/src/crystal/rw_lock.cr
+++ b/src/crystal/rw_lock.cr
@@ -1,5 +1,5 @@
 # :nodoc:
-class Crystal::RWLock
+struct Crystal::RWLock
   private UNLOCKED = 0
   private LOCKED   = 1
 


### PR DESCRIPTION
The Crystal::RWLock type is used to protect the GC against fiber context switches, to avoid the GC interrupting a thread while it is switching to another fiber, or starting a collection while a thread was preempted by the kernel while it was switching to another fiber.

Problem is: Crystal::RWLock is a class, and as such depends on the GC to be allocated, and... we end up in an infinite loop: GC <-> Crystal::RWLock.

The weirdest part is that it's working, and I have no idea how.