### PR TITLE
Fix: Add `SA_RESTART` flag to sigaction syscall

### DIFF
--- a/src/crystal/system/unix/signal.cr
+++ b/src/crystal/system/unix/signal.cr
@@ -23,6 +23,11 @@ module Crystal::System::Signal
       unless @@handlers[signal]?
         @@sigset << signal
         action = LibC::Sigaction.new
+
+        # restart some interrupted syscalls (read, write, accept, ...) instead
+        # of returning EINTR:
+        action.sa_flags = LibC::SA_RESTART
+
         action.sa_sigaction = LibC::SigactionHandlerT.new do |value, _, _|
           writer.write_bytes(value) unless writer.closed?
         end

--- a/src/lib_c/aarch64-android/c/signal.cr
+++ b/src/lib_c/aarch64-android/c/signal.cr
@@ -50,6 +50,7 @@ lib LibC
   end
 
   SA_ONSTACK = 0x08000000
+  SA_RESTART = 0x10000000
   SA_SIGINFO = 0x00000004
 
   struct SiginfoT

--- a/src/lib_c/aarch64-darwin/c/signal.cr
+++ b/src/lib_c/aarch64-darwin/c/signal.cr
@@ -45,6 +45,7 @@ lib LibC
   SIG_IGN = SighandlerT.new(Pointer(Void).new(1_u64), Pointer(Void).null)
 
   SA_ONSTACK = 0x0001
+  SA_RESTART = 0x0002
   SA_SIGINFO = 0x0040
 
   struct SiginfoT

--- a/src/lib_c/aarch64-linux-gnu/c/signal.cr
+++ b/src/lib_c/aarch64-linux-gnu/c/signal.cr
@@ -49,6 +49,7 @@ lib LibC
   end
 
   SA_ONSTACK = 0x08000000
+  SA_RESTART = 0x10000000
   SA_SIGINFO = 0x00000004
 
   struct SiginfoT

--- a/src/lib_c/aarch64-linux-musl/c/signal.cr
+++ b/src/lib_c/aarch64-linux-musl/c/signal.cr
@@ -48,6 +48,7 @@ lib LibC
   end
 
   SA_ONSTACK = 0x08000000
+  SA_RESTART = 0x10000000
   SA_SIGINFO = 0x00000004
 
   struct SiginfoT

--- a/src/lib_c/arm-linux-gnueabihf/c/signal.cr
+++ b/src/lib_c/arm-linux-gnueabihf/c/signal.cr
@@ -49,6 +49,7 @@ lib LibC
   end
 
   SA_ONSTACK = 0x08000000
+  SA_RESTART = 0x10000000
   SA_SIGINFO = 0x00000004
 
   struct SiginfoT

--- a/src/lib_c/i386-linux-gnu/c/signal.cr
+++ b/src/lib_c/i386-linux-gnu/c/signal.cr
@@ -49,6 +49,7 @@ lib LibC
   end
 
   SA_ONSTACK = 0x08000000
+  SA_RESTART = 0x10000000
   SA_SIGINFO = 0x00000004
 
   struct SiginfoT

--- a/src/lib_c/i386-linux-musl/c/signal.cr
+++ b/src/lib_c/i386-linux-musl/c/signal.cr
@@ -48,6 +48,7 @@ lib LibC
   end
 
   SA_ONSTACK = 0x08000000
+  SA_RESTART = 0x10000000
   SA_SIGINFO = 0x00000004
 
   struct SiginfoT

--- a/src/lib_c/x86_64-darwin/c/signal.cr
+++ b/src/lib_c/x86_64-darwin/c/signal.cr
@@ -45,6 +45,7 @@ lib LibC
   SIG_IGN = SighandlerT.new(Pointer(Void).new(1_u64), Pointer(Void).null)
 
   SA_ONSTACK = 0x0001
+  SA_RESTART = 0x0002
   SA_SIGINFO = 0x0040
 
   struct SiginfoT

--- a/src/lib_c/x86_64-dragonfly/c/signal.cr
+++ b/src/lib_c/x86_64-dragonfly/c/signal.cr
@@ -51,6 +51,7 @@ lib LibC
   end
 
   SA_ONSTACK = 0x0001
+  SA_RESTART = 0x0002
   SA_SIGINFO = 0x0040
 
   struct Sigval

--- a/src/lib_c/x86_64-freebsd/c/signal.cr
+++ b/src/lib_c/x86_64-freebsd/c/signal.cr
@@ -46,6 +46,7 @@ lib LibC
   end
 
   SA_ONSTACK = 0x0001
+  SA_RESTART = 0x0002
   SA_SIGINFO = 0x0040
 
   struct Sigval

--- a/src/lib_c/x86_64-linux-gnu/c/signal.cr
+++ b/src/lib_c/x86_64-linux-gnu/c/signal.cr
@@ -49,6 +49,7 @@ lib LibC
   end
 
   SA_ONSTACK = 0x08000000
+  SA_RESTART = 0x10000000
   SA_SIGINFO = 0x00000004
 
   struct SiginfoT

--- a/src/lib_c/x86_64-linux-musl/c/signal.cr
+++ b/src/lib_c/x86_64-linux-musl/c/signal.cr
@@ -48,6 +48,7 @@ lib LibC
   end
 
   SA_ONSTACK = 0x08000000
+  SA_RESTART = 0x10000000
   SA_SIGINFO = 0x00000004
 
   struct SiginfoT

--- a/src/lib_c/x86_64-netbsd/c/signal.cr
+++ b/src/lib_c/x86_64-netbsd/c/signal.cr
@@ -47,6 +47,7 @@ lib LibC
   end
 
   SA_ONSTACK = 0x0001
+  SA_RESTART = 0x0002
   SA_SIGINFO = 0x0040
 
   struct SiginfoT

--- a/src/lib_c/x86_64-openbsd/c/signal.cr
+++ b/src/lib_c/x86_64-openbsd/c/signal.cr
@@ -47,6 +47,7 @@ lib LibC
   SIG_IGN = SighandlerT.new(Pointer(Void).new(1_u64), Pointer(Void).null)
 
   SA_ONSTACK = 0x0001
+  SA_RESTART = 0x0002
   SA_SIGINFO = 0x0040
 
   struct SiginfoT

--- a/src/lib_c/x86_64-solaris/c/signal.cr
+++ b/src/lib_c/x86_64-solaris/c/signal.cr
@@ -60,6 +60,7 @@ lib LibC
   end
 
   SA_ONSTACK = 0x00000001
+  SA_RESTART = 0x00000004
   SA_SIGINFO = 0x00000008
 
   struct SiginfoT


### PR DESCRIPTION
We recently changed from signal(2) to sigaction(2) and some IO related syscalls started failing with EINTR.

Reading the different manpages, BSD changed signal(2) to have SA_RESTART semantics, which glibc on Linux followed by not calling the signal syscall but instead calling sigcation with the SA_RESTART flag.

closes #14350 