### PR TITLE
Fix formatter on call without parentheses followed by doc comment

### DIFF
--- a/spec/compiler/formatter/formatter_spec.cr
+++ b/spec/compiler/formatter/formatter_spec.cr
@@ -2893,6 +2893,14 @@ describe Crystal::Formatter do
     end
   end
 
+  # #14256
+  assert_format <<-CRYSTAL
+    foo bar # comment
+
+    # doc
+    def baz; end
+    CRYSTAL
+
   # CVE-2021-42574
   describe "Unicode bi-directional control characters" do
     ['\u202A', '\u202B', '\u202C', '\u202D', '\u202E', '\u2066', '\u2067', '\u2068', '\u2069'].each do |char|

--- a/src/compiler/crystal/tools/formatter.cr
+++ b/src/compiler/crystal/tools/formatter.cr
@@ -2981,8 +2981,6 @@ module Crystal
     end
 
     def finish_args(has_parentheses, has_newlines, ends_with_newline, found_comment, column)
-      skip_space
-
       if has_parentheses
         if @token.type.op_comma?
           next_token


### PR DESCRIPTION
This `skip_space` would consume trailing comments, newlines and comments after newlines which on calls without parentheses. It would be fine to keep it when there are parentheses (because then we expect `OP_RPAREN`), but it seems to be entirely unnecessary.

Reslolves #14286