### PR TITLE
Update Windows library versions

### DIFF
--- a/.github/workflows/win.yml
+++ b/.github/workflows/win.yml
@@ -7,7 +7,7 @@ concurrency:
   cancel-in-progress: ${{ github.ref != 'refs/heads/master' }}
 
 env:
-  CI_LLVM_VERSION: "18.1.0"
+  CI_LLVM_VERSION: "18.1.1"
 
 jobs:
   x86_64-windows-libs:
@@ -218,7 +218,7 @@ jobs:
     uses: ./.github/workflows/win_build_portable.yml
     with:
       release: false
-      llvm_version: "18.1.0"
+      llvm_version: "18.1.1"
 
   x86_64-windows-test:
     runs-on: windows-2022
@@ -271,7 +271,7 @@ jobs:
     uses: ./.github/workflows/win_build_portable.yml
     with:
       release: true
-      llvm_version: "18.1.0"
+      llvm_version: "18.1.1"
 
   x86_64-windows-installer:
     if: github.repository_owner == 'crystal-lang' && (startsWith(github.ref, 'refs/tags/') || startsWith(github.ref, 'refs/heads/ci/'))

--- a/.github/workflows/win.yml
+++ b/.github/workflows/win.yml
@@ -7,7 +7,7 @@ concurrency:
   cancel-in-progress: ${{ github.ref != 'refs/heads/master' }}
 
 env:
-  CI_LLVM_VERSION: "18.1.0-rc1"
+  CI_LLVM_VERSION: "18.1.0"
 
 jobs:
   x86_64-windows-libs:
@@ -40,13 +40,13 @@ jobs:
           key: win-libs-${{ hashFiles('.github/workflows/win.yml', 'etc/win-ci/*.ps1') }}-msvc
       - name: Build libgc
         if: steps.cache-libs.outputs.cache-hit != 'true'
-        run: .\etc\win-ci\build-gc.ps1 -BuildTree deps\gc -Version 8.2.2 -AtomicOpsVersion 7.8.0
+        run: .\etc\win-ci\build-gc.ps1 -BuildTree deps\gc -Version 8.2.6 -AtomicOpsVersion 7.8.2
       - name: Build libpcre
         if: steps.cache-libs.outputs.cache-hit != 'true'
         run: .\etc\win-ci\build-pcre.ps1 -BuildTree deps\pcre -Version 8.45
       - name: Build libpcre2
         if: steps.cache-libs.outputs.cache-hit != 'true'
-        run: .\etc\win-ci\build-pcre2.ps1 -BuildTree deps\pcre2 -Version 10.42
+        run: .\etc\win-ci\build-pcre2.ps1 -BuildTree deps\pcre2 -Version 10.43
       - name: Build libiconv
         if: steps.cache-libs.outputs.cache-hit != 'true'
         run: .\etc\win-ci\build-iconv.ps1 -BuildTree deps\iconv
@@ -55,7 +55,7 @@ jobs:
         run: .\etc\win-ci\build-ffi.ps1 -BuildTree deps\ffi -Version 3.3
       - name: Build zlib
         if: steps.cache-libs.outputs.cache-hit != 'true'
-        run: .\etc\win-ci\build-z.ps1 -BuildTree deps\z -Version 1.2.13
+        run: .\etc\win-ci\build-z.ps1 -BuildTree deps\z -Version 1.3.1
       - name: Build mpir
         if: steps.cache-libs.outputs.cache-hit != 'true'
         run: .\etc\win-ci\build-mpir.ps1 -BuildTree deps\mpir
@@ -64,7 +64,7 @@ jobs:
         run: .\etc\win-ci\build-yaml.ps1 -BuildTree deps\yaml -Version 0.2.5
       - name: Build libxml2
         if: steps.cache-libs.outputs.cache-hit != 'true'
-        run: .\etc\win-ci\build-xml2.ps1 -BuildTree deps\xml2 -Version 2.11.3
+        run: .\etc\win-ci\build-xml2.ps1 -BuildTree deps\xml2 -Version 2.12.5
 
       - name: Cache OpenSSL
         id: cache-openssl
@@ -121,13 +121,13 @@ jobs:
           key: win-dlls-${{ hashFiles('.github/workflows/win.yml', 'etc/win-ci/*.ps1') }}-msvc
       - name: Build libgc
         if: steps.cache-dlls.outputs.cache-hit != 'true'
-        run: .\etc\win-ci\build-gc.ps1 -BuildTree deps\gc -Version 8.2.4 -AtomicOpsVersion 7.8.0 -Dynamic
+        run: .\etc\win-ci\build-gc.ps1 -BuildTree deps\gc -Version 8.2.6 -AtomicOpsVersion 7.8.2 -Dynamic
       - name: Build libpcre
         if: steps.cache-dlls.outputs.cache-hit != 'true'
         run: .\etc\win-ci\build-pcre.ps1 -BuildTree deps\pcre -Version 8.45 -Dynamic
       - name: Build libpcre2
         if: steps.cache-dlls.outputs.cache-hit != 'true'
-        run: .\etc\win-ci\build-pcre2.ps1 -BuildTree deps\pcre2 -Version 10.42 -Dynamic
+        run: .\etc\win-ci\build-pcre2.ps1 -BuildTree deps\pcre2 -Version 10.43 -Dynamic
       - name: Build libiconv
         if: steps.cache-dlls.outputs.cache-hit != 'true'
         run: .\etc\win-ci\build-iconv.ps1 -BuildTree deps\iconv -Dynamic
@@ -136,7 +136,7 @@ jobs:
         run: .\etc\win-ci\build-ffi.ps1 -BuildTree deps\ffi -Version 3.3 -Dynamic
       - name: Build zlib
         if: steps.cache-dlls.outputs.cache-hit != 'true'
-        run: .\etc\win-ci\build-z.ps1 -BuildTree deps\z -Version 1.2.13 -Dynamic
+        run: .\etc\win-ci\build-z.ps1 -BuildTree deps\z -Version 1.3.1 -Dynamic
       - name: Build mpir
         if: steps.cache-dlls.outputs.cache-hit != 'true'
         run: .\etc\win-ci\build-mpir.ps1 -BuildTree deps\mpir -Dynamic
@@ -145,7 +145,7 @@ jobs:
         run: .\etc\win-ci\build-yaml.ps1 -BuildTree deps\yaml -Version 0.2.5 -Dynamic
       - name: Build libxml2
         if: steps.cache-dlls.outputs.cache-hit != 'true'
-        run: .\etc\win-ci\build-xml2.ps1 -BuildTree deps\xml2 -Version 2.11.3 -Dynamic
+        run: .\etc\win-ci\build-xml2.ps1 -BuildTree deps\xml2 -Version 2.12.5 -Dynamic
 
       - name: Cache OpenSSL
         id: cache-openssl-dlls
@@ -218,7 +218,7 @@ jobs:
     uses: ./.github/workflows/win_build_portable.yml
     with:
       release: false
-      llvm_version: "18.1.0-rc1"
+      llvm_version: "18.1.0"
 
   x86_64-windows-test:
     runs-on: windows-2022
@@ -271,7 +271,7 @@ jobs:
     uses: ./.github/workflows/win_build_portable.yml
     with:
       release: true
-      llvm_version: "18.1.0-rc1"
+      llvm_version: "18.1.0"
 
   x86_64-windows-installer:
     if: github.repository_owner == 'crystal-lang' && (startsWith(github.ref, 'refs/tags/') || startsWith(github.ref, 'refs/heads/ci/'))


### PR DESCRIPTION
Updates Boehm GC, PCRE2, zlib, libxml2, and LLVM to their most recent versions.

OpenSSL is skipped, since it appears to be unsupported (#14168).