### PR TITLE
Skip building `llvm_ext.cc` on LLVM 18 or above

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -59,7 +59,7 @@ EXPORTS_BUILD := \
 	CRYSTAL_CONFIG_LIBRARY_PATH=$(CRYSTAL_CONFIG_LIBRARY_PATH)
 SHELL = sh
 LLVM_CONFIG := $(shell src/llvm/ext/find-llvm-config)
-LLVM_VERSION := $(if $(LLVM_CONFIG), $(shell $(LLVM_CONFIG) --version 2> /dev/null))
+LLVM_VERSION := $(if $(LLVM_CONFIG),$(shell $(LLVM_CONFIG) --version 2> /dev/null))
 LLVM_EXT_DIR = src/llvm/ext
 LLVM_EXT_OBJ = $(LLVM_EXT_DIR)/llvm_ext.o
 DEPS = $(LLVM_EXT_OBJ)
@@ -78,6 +78,12 @@ ifeq ($(or $(TERM),$(TERM),dumb),dumb)
   colorize = $(shell printf >&2 "$1")
 else
   colorize = $(shell printf >&2 "\033[33m$1\033[0m\n")
+endif
+
+ifneq ($(LLVM_VERSION),)
+  ifeq ($(shell test $(firstword $(subst ., ,$(LLVM_VERSION))) -ge 18; echo $$?),0)
+    DEPS =
+  endif
 endif
 
 check_llvm_config = $(eval \
@@ -208,7 +214,7 @@ $(O)/primitives_spec: $(O)/crystal $(DEPS) $(SOURCES) $(SPEC_SOURCES)
 	@mkdir -p $(O)
 	$(EXPORT_CC) ./bin/crystal build $(FLAGS) $(SPEC_WARNINGS_OFF) -o $@ spec/primitives_spec.cr
 
-$(O)/interpreter_spec: deps $(SOURCES) $(SPEC_SOURCES)
+$(O)/interpreter_spec: $(DEPS) $(SOURCES) $(SPEC_SOURCES)
 	$(eval interpreter=1)
 	@mkdir -p $(O)
 	$(EXPORT_CC) ./bin/crystal build $(FLAGS) $(SPEC_WARNINGS_OFF) -o $@ spec/compiler/interpreter_spec.cr

--- a/Makefile
+++ b/Makefile
@@ -62,7 +62,6 @@ LLVM_CONFIG := $(shell src/llvm/ext/find-llvm-config)
 LLVM_VERSION := $(if $(LLVM_CONFIG),$(shell $(LLVM_CONFIG) --version 2> /dev/null))
 LLVM_EXT_DIR = src/llvm/ext
 LLVM_EXT_OBJ = $(LLVM_EXT_DIR)/llvm_ext.o
-DEPS = $(LLVM_EXT_OBJ)
 CXXFLAGS += $(if $(debug),-g -O0)
 CRYSTAL_VERSION ?= $(shell cat src/VERSION)
 
@@ -80,6 +79,7 @@ else
   colorize = $(shell printf >&2 "\033[33m$1\033[0m\n")
 endif
 
+DEPS = $(LLVM_EXT_OBJ)
 ifneq ($(LLVM_VERSION),)
   ifeq ($(shell test $(firstword $(subst ., ,$(LLVM_VERSION))) -ge 18; echo $$?),0)
     DEPS =

--- a/Makefile.win
+++ b/Makefile.win
@@ -82,6 +82,12 @@ DATADIR ?= $(prefix)
 
 colorize = $1
 
+ifneq ($(LLVM_VERSION),)
+  ifeq ($(shell if $(firstword $(subst ., ,$(LLVM_VERSION))) GEQ 18 echo 0),0)
+    DEPS =
+  endif
+endif
+
 check_llvm_config = $(eval \
 	check_llvm_config := $(if $(LLVM_VERSION),\
 		$(info $(call colorize,Using $(LLVM_CONFIG) [version=$(LLVM_VERSION)])),\
@@ -198,7 +204,7 @@ $(O)\primitives_spec.exe: $(O)\crystal.exe $(DEPS) $(SOURCES) $(SPEC_SOURCES)
 	@$(call MKDIR,"$(O)")
 	.\bin\crystal build $(FLAGS) $(SPEC_WARNINGS_OFF) -o "$@" spec\primitives_spec.cr
 
-$(O)\interpreter_spec: deps $(SOURCES) $(SPEC_SOURCES)
+$(O)\interpreter_spec: $(DEPS) $(SOURCES) $(SPEC_SOURCES)
 	$(eval interpreter=1)
 	@$(call MKDIR, "$(O)")
 	.\bin\crystal build $(FLAGS) $(SPEC_WARNINGS_OFF) -o $@ spec\compiler\interpreter_spec.cr

--- a/Makefile.win
+++ b/Makefile.win
@@ -70,7 +70,6 @@ LLVM_CONFIG ?=
 LLVM_VERSION := $(if $(LLVM_CONFIG),$(shell $(LLVM_CONFIG) --version))
 LLVM_EXT_DIR = src\llvm\ext
 LLVM_EXT_OBJ = $(LLVM_EXT_DIR)\llvm_ext.obj
-DEPS = $(LLVM_EXT_OBJ)
 CXXFLAGS += $(if $(static),$(if $(debug),/MTd /Od ,/MT ),$(if $(debug),/MDd /Od ,/MD ))
 CRYSTAL_VERSION ?= $(shell type src\VERSION)
 
@@ -82,6 +81,7 @@ DATADIR ?= $(prefix)
 
 colorize = $1
 
+DEPS = $(LLVM_EXT_OBJ)
 ifneq ($(LLVM_VERSION),)
   ifeq ($(shell if $(firstword $(subst ., ,$(LLVM_VERSION))) GEQ 18 echo 0),0)
     DEPS =


### PR DESCRIPTION
It is still possible to build the empty object file by doing `make llvm_ext` explicitly, but that doesn't matter as `LibLLVMExt`'s `@[Link]` annotation should never be used to populate the linker arguments anyway.