### PR TITLE
Move timeout properties to `Socket` and `IO::FileDescriptor`

### DIFF
--- a/src/io/evented.cr
+++ b/src/io/evented.cr
@@ -6,46 +6,11 @@ module IO::Evented
   @read_timed_out = false
   @write_timed_out = false
 
-  @read_timeout : Time::Span?
-  @write_timeout : Time::Span?
-
   @readers = Crystal::ThreadLocalValue(Deque(Fiber)).new
   @writers = Crystal::ThreadLocalValue(Deque(Fiber)).new
 
   @read_event = Crystal::ThreadLocalValue(Crystal::EventLoop::Event).new
   @write_event = Crystal::ThreadLocalValue(Crystal::EventLoop::Event).new
-
-  # Returns the time to wait when reading before raising an `IO::TimeoutError`.
-  def read_timeout : Time::Span?
-    @read_timeout
-  end
-
-  # Sets the time to wait when reading before raising an `IO::TimeoutError`.
-  def read_timeout=(timeout : Time::Span?) : ::Time::Span?
-    @read_timeout = timeout
-  end
-
-  # Sets the number of seconds to wait when reading before raising an `IO::TimeoutError`.
-  def read_timeout=(read_timeout : Number) : Number
-    self.read_timeout = read_timeout.seconds
-    read_timeout
-  end
-
-  # Returns the time to wait when writing before raising an `IO::TimeoutError`.
-  def write_timeout : Time::Span?
-    @write_timeout
-  end
-
-  # Sets the time to wait when writing before raising an `IO::TimeoutError`.
-  def write_timeout=(timeout : Time::Span?) : ::Time::Span?
-    @write_timeout = timeout
-  end
-
-  # Sets the number of seconds to wait when writing before raising an `IO::TimeoutError`.
-  def write_timeout=(write_timeout : Number) : Number
-    self.write_timeout = write_timeout.seconds
-    write_timeout
-  end
 
   def evented_read(slice : Bytes, errno_msg : String, &) : Int32
     loop do

--- a/src/io/file_descriptor.cr
+++ b/src/io/file_descriptor.cr
@@ -18,6 +18,41 @@ class IO::FileDescriptor < IO
   # will then fail.
   property? close_on_finalize : Bool
 
+  @read_timeout : Time::Span?
+  @write_timeout : Time::Span?
+
+  # Returns the time to wait when reading before raising an `IO::TimeoutError`.
+  def read_timeout : Time::Span?
+    @read_timeout
+  end
+
+  # Sets the time to wait when reading before raising an `IO::TimeoutError`.
+  def read_timeout=(timeout : Time::Span?) : ::Time::Span?
+    @read_timeout = timeout
+  end
+
+  # Sets the number of seconds to wait when reading before raising an `IO::TimeoutError`.
+  def read_timeout=(read_timeout : Number) : Number
+    self.read_timeout = read_timeout.seconds
+    read_timeout
+  end
+
+  # Returns the time to wait when writing before raising an `IO::TimeoutError`.
+  def write_timeout : Time::Span?
+    @write_timeout
+  end
+
+  # Sets the time to wait when writing before raising an `IO::TimeoutError`.
+  def write_timeout=(timeout : Time::Span?) : ::Time::Span?
+    @write_timeout = timeout
+  end
+
+  # Sets the number of seconds to wait when writing before raising an `IO::TimeoutError`.
+  def write_timeout=(write_timeout : Number) : Number
+    self.write_timeout = write_timeout.seconds
+    write_timeout
+  end
+
   def initialize(fd, blocking = nil, *, @close_on_finalize = true)
     @volatile_fd = Atomic.new(fd)
     @closed = system_closed?

--- a/src/io/file_descriptor.cr
+++ b/src/io/file_descriptor.cr
@@ -18,18 +18,8 @@ class IO::FileDescriptor < IO
   # will then fail.
   property? close_on_finalize : Bool
 
-  @read_timeout : Time::Span?
-  @write_timeout : Time::Span?
-
-  # Returns the time to wait when reading before raising an `IO::TimeoutError`.
-  def read_timeout : Time::Span?
-    @read_timeout
-  end
-
-  # Sets the time to wait when reading before raising an `IO::TimeoutError`.
-  def read_timeout=(timeout : Time::Span?) : ::Time::Span?
-    @read_timeout = timeout
-  end
+  # The time to wait when reading before raising an `IO::TimeoutError`.
+  property read_timeout : Time::Span?
 
   # Sets the number of seconds to wait when reading before raising an `IO::TimeoutError`.
   def read_timeout=(read_timeout : Number) : Number
@@ -37,15 +27,8 @@ class IO::FileDescriptor < IO
     read_timeout
   end
 
-  # Returns the time to wait when writing before raising an `IO::TimeoutError`.
-  def write_timeout : Time::Span?
-    @write_timeout
-  end
-
   # Sets the time to wait when writing before raising an `IO::TimeoutError`.
-  def write_timeout=(timeout : Time::Span?) : ::Time::Span?
-    @write_timeout = timeout
-  end
+  property write_timeout : Time::Span?
 
   # Sets the number of seconds to wait when writing before raising an `IO::TimeoutError`.
   def write_timeout=(write_timeout : Number) : Number

--- a/src/io/overlapped.cr
+++ b/src/io/overlapped.cr
@@ -8,41 +8,6 @@ module IO::Overlapped
     property fiber : Fiber?
   end
 
-  @read_timeout : Time::Span?
-  @write_timeout : Time::Span?
-
-  # Returns the time to wait when reading before raising an `IO::TimeoutError`.
-  def read_timeout : Time::Span?
-    @read_timeout
-  end
-
-  # Sets the time to wait when reading before raising an `IO::TimeoutError`.
-  def read_timeout=(timeout : Time::Span?) : ::Time::Span?
-    @read_timeout = timeout
-  end
-
-  # Sets the number of seconds to wait when reading before raising an `IO::TimeoutError`.
-  def read_timeout=(read_timeout : Number) : Number
-    self.read_timeout = read_timeout.seconds
-    read_timeout
-  end
-
-  # Returns the time to wait when writing before raising an `IO::TimeoutError`.
-  def write_timeout : Time::Span?
-    @write_timeout
-  end
-
-  # Sets the time to wait when writing before raising an `IO::TimeoutError`.
-  def write_timeout=(timeout : Time::Span?) : ::Time::Span?
-    @write_timeout = timeout
-  end
-
-  # Sets the number of seconds to wait when writing before raising an `IO::TimeoutError`.
-  def write_timeout=(write_timeout : Number) : Number
-    self.write_timeout = write_timeout.seconds
-    write_timeout
-  end
-
   def self.wait_queued_completions(timeout, &)
     overlapped_entries = uninitialized LibC::OVERLAPPED_ENTRY[1]
 

--- a/src/socket.cr
+++ b/src/socket.cr
@@ -23,18 +23,8 @@ class Socket < IO
   getter type : Type
   getter protocol : Protocol
 
-  @read_timeout : Time::Span?
-  @write_timeout : Time::Span?
-
-  # Returns the time to wait when reading before raising an `IO::TimeoutError`.
-  def read_timeout : Time::Span?
-    @read_timeout
-  end
-
-  # Sets the time to wait when reading before raising an `IO::TimeoutError`.
-  def read_timeout=(timeout : Time::Span?) : ::Time::Span?
-    @read_timeout = timeout
-  end
+  # The time to wait when reading before raising an `IO::TimeoutError`.
+  property read_timeout : Time::Span?
 
   # Sets the number of seconds to wait when reading before raising an `IO::TimeoutError`.
   def read_timeout=(read_timeout : Number) : Number
@@ -42,15 +32,8 @@ class Socket < IO
     read_timeout
   end
 
-  # Returns the time to wait when writing before raising an `IO::TimeoutError`.
-  def write_timeout : Time::Span?
-    @write_timeout
-  end
-
   # Sets the time to wait when writing before raising an `IO::TimeoutError`.
-  def write_timeout=(timeout : Time::Span?) : ::Time::Span?
-    @write_timeout = timeout
-  end
+  property write_timeout : Time::Span?
 
   # Sets the number of seconds to wait when writing before raising an `IO::TimeoutError`.
   def write_timeout=(write_timeout : Number) : Number

--- a/src/socket.cr
+++ b/src/socket.cr
@@ -23,6 +23,41 @@ class Socket < IO
   getter type : Type
   getter protocol : Protocol
 
+  @read_timeout : Time::Span?
+  @write_timeout : Time::Span?
+
+  # Returns the time to wait when reading before raising an `IO::TimeoutError`.
+  def read_timeout : Time::Span?
+    @read_timeout
+  end
+
+  # Sets the time to wait when reading before raising an `IO::TimeoutError`.
+  def read_timeout=(timeout : Time::Span?) : ::Time::Span?
+    @read_timeout = timeout
+  end
+
+  # Sets the number of seconds to wait when reading before raising an `IO::TimeoutError`.
+  def read_timeout=(read_timeout : Number) : Number
+    self.read_timeout = read_timeout.seconds
+    read_timeout
+  end
+
+  # Returns the time to wait when writing before raising an `IO::TimeoutError`.
+  def write_timeout : Time::Span?
+    @write_timeout
+  end
+
+  # Sets the time to wait when writing before raising an `IO::TimeoutError`.
+  def write_timeout=(timeout : Time::Span?) : ::Time::Span?
+    @write_timeout = timeout
+  end
+
+  # Sets the number of seconds to wait when writing before raising an `IO::TimeoutError`.
+  def write_timeout=(write_timeout : Number) : Number
+    self.write_timeout = write_timeout.seconds
+    write_timeout
+  end
+
   # Creates a TCP socket. Consider using `TCPSocket` or `TCPServer` unless you
   # need full control over the socket.
   def self.tcp(family : Family, blocking = false) : self


### PR DESCRIPTION
Both `Socket` and `IO::FileDescriptor` have public `read_timeout` and `write_timeout` properties. For some reasons these ended up being defined in `IO::Evented` (which is a shared module between the two, but only on Unix systems), and `IO::Overlapped` (same job, but on Windows). That puts a general public API in places that are implementation-specific. The definitions are exactly identical, but they should never be duplicated in platform specific modules. They need to be defined in the public API space.

This patch moves the definitions to `Socket` and `IO::FileDescriptor` directly. This ends up still duplicated, but that's okay. Both types don't have any common ancestors except generic `IO`. It's just coincidental that the internal implementation is shared.

The code can also be simplified a by defining getters and setters with the `property` macro. That reduces the code a lot and leaves only the odd `Number` overloads (which might be good for deprecation? cf. #14368) preventing it from becoming a two-liner.