### PR TITLE
Refactor expectations with `SpecChannelStatus` to be explicit

### DIFF
--- a/spec/std/http/server/server_spec.cr
+++ b/spec/std/http/server/server_spec.cr
@@ -75,7 +75,7 @@ describe HTTP::Server do
     sleep 0.1
     server.close
 
-    ch.receive.end?.should be_true
+    ch.receive.should eq SpecChannelStatus::End
   end
 
   it "reuses the TCP port (SO_REUSEPORT)" do

--- a/spec/std/io/io_spec.cr
+++ b/spec/std/io/io_spec.cr
@@ -973,11 +973,11 @@ describe IO do
 
         schedule_timeout ch
 
-        ch.receive.begin?.should be_true
+        ch.receive.should eq SpecChannelStatus::Begin
         wait_until_blocked f
 
         read.close
-        ch.receive.end?.should be_true
+        ch.receive.should eq SpecChannelStatus::End
       end
     end
 
@@ -996,11 +996,11 @@ describe IO do
 
         schedule_timeout ch
 
-        ch.receive.begin?.should be_true
+        ch.receive.should eq SpecChannelStatus::Begin
         wait_until_blocked f
 
         write.close
-        ch.receive.end?.should be_true
+        ch.receive.should eq SpecChannelStatus::End
       end
     end
   end

--- a/spec/std/socket/unix_server_spec.cr
+++ b/spec/std/socket/unix_server_spec.cr
@@ -95,13 +95,13 @@ describe UNIXServer do
           ch.send(:end)
         end
 
-        ch.receive.begin?.should be_true
+        ch.receive.should eq SpecChannelStatus::Begin
 
         # wait for the server to call accept
         wait_until_blocked f
 
         server.close
-        ch.receive.end?.should be_true
+        ch.receive.should eq SpecChannelStatus::End
 
         exception.should be_a(IO::Error)
         exception.try(&.message).should eq("Closed stream")
@@ -136,13 +136,13 @@ describe UNIXServer do
           ch.send :end
         end
 
-        ch.receive.begin?.should be_true
+        ch.receive.should eq SpecChannelStatus::Begin
 
         # wait for the server to call accept
         wait_until_blocked f
 
         server.close
-        ch.receive.end?.should be_true
+        ch.receive.should eq SpecChannelStatus::End
 
         ret.should be_nil
       end


### PR DESCRIPTION
Comparing against the expected value offers better information when the spec fails because it shows the actual value, instead of true/fals for a predicate method.