### PR TITLE
Refactor `Socket#system_receive` to return `Address`

### DIFF
--- a/src/crystal/system/unix/socket.cr
+++ b/src/crystal/system/unix/socket.cr
@@ -105,7 +105,7 @@ module Crystal::System::Socket
       LibC.recvfrom(fd, slice, slice.size, 0, sockaddr, pointerof(addrlen))
     end
 
-    {bytes_read, sockaddr, addrlen}
+    {bytes_read, ::Socket::Address.from(sockaddr, addrlen)}
   end
 
   private def system_close_read

--- a/src/crystal/system/win32/socket.cr
+++ b/src/crystal/system/win32/socket.cr
@@ -299,7 +299,7 @@ module Crystal::System::Socket
       {ret, bytes_received}
     end
 
-    {bytes_read.to_i32, sockaddr, addrlen}
+    {bytes_read.to_i32, ::Socket::Address.from(sockaddr, addrlen)}
   end
 
   private def system_close_read

--- a/src/socket.cr
+++ b/src/socket.cr
@@ -255,11 +255,10 @@ class Socket < IO
   def receive(max_message_size = 512) : {String, Address}
     address = nil
     message = String.new(max_message_size) do |buffer|
-      bytes_read, sockaddr, addrlen = system_receive(Slice.new(buffer, max_message_size))
-      address = Address.from(sockaddr, addrlen)
+      bytes_read, address = system_receive(Slice.new(buffer, max_message_size))
       {bytes_read, 0}
     end
-    {message, address.not_nil!}
+    {message, address.as(Address)}
   end
 
   # Receives a binary message from the previously bound address.
@@ -274,8 +273,7 @@ class Socket < IO
   # bytes_read, client_addr = server.receive(message)
   # ```
   def receive(message : Bytes) : {Int32, Address}
-    bytes_read, sockaddr, addrlen = system_receive(message)
-    {bytes_read, Address.from(sockaddr, addrlen)}
+    system_receive(message)
   end
 
   # Calls `shutdown(2)` with `SHUT_RD`

--- a/src/socket/udp_socket.cr
+++ b/src/socket/udp_socket.cr
@@ -70,11 +70,10 @@ class UDPSocket < IPSocket
   def receive(max_message_size = 512) : {String, IPAddress}
     address = nil
     message = String.new(max_message_size) do |buffer|
-      bytes_read, sockaddr, addrlen = system_receive(Slice.new(buffer, max_message_size))
-      address = IPAddress.from(sockaddr, addrlen)
+      bytes_read, address = system_receive(Slice.new(buffer, max_message_size))
       {bytes_read, 0}
     end
-    {message, address.not_nil!}
+    {message, address.as(IPAddress)}
   end
 
   # Receives a binary message from the previously bound address.
@@ -89,8 +88,8 @@ class UDPSocket < IPSocket
   # bytes_read, client_addr = server.receive(message)
   # ```
   def receive(message : Bytes) : {Int32, IPAddress}
-    bytes_read, sockaddr, addrlen = system_receive(message)
-    {bytes_read, IPAddress.from(sockaddr, addrlen)}
+    bytes_read, address = system_receive(message)
+    {bytes_read, address.as(IPAddress)}
   end
 
   # Reports whether transmitted multicast packets should be copied and sent


### PR DESCRIPTION
The internal method `Socket#system_receive` returns the remote address in a platform-specific way, consisting of a `LibC::Sockaddr` pointer and the length of the address.
I'm not sure what's the motivation behind that and I don't see a good reason. Returning a `Socket::Address` value directly leads to a cleaner API with native Crystal types only.

This cleans up the interface and make it free of platform specifics in preparation of a bigger refactoring of the event loop (#10766).