### PR TITLE
Fix requires for `time/time_spec.cr` and `time/format_spec.cr`

### DIFF
--- a/spec/std/time/format_spec.cr
+++ b/spec/std/time/format_spec.cr
@@ -1,4 +1,5 @@
 require "../spec_helper"
+require "../../support/time"
 require "spec/helpers/string"
 
 def parse_time(format, string)

--- a/spec/std/time/time_spec.cr
+++ b/spec/std/time/time_spec.cr
@@ -1,4 +1,5 @@
 require "../spec_helper"
+require "../../support/time"
 require "spec/helpers/iterate"
 
 CALENDAR_WEEK_TEST_DATA = [


### PR DESCRIPTION
There used to be a `spec/std/time/spec_helper.cr` file, but it was merged into `spec/support/time.cr`. This PR adds the missing requires so that these two spec files can be run alone.