### PR TITLE
Add `IO::FileDescriptor::Handle`

### DIFF
--- a/src/crystal/system/unix/file_descriptor.cr
+++ b/src/crystal/system/unix/file_descriptor.cr
@@ -9,7 +9,9 @@ require "termios"
 module Crystal::System::FileDescriptor
   include IO::Evented
 
-  @volatile_fd : Atomic(Int32)
+  # Platform-specific type to represent a file descriptor handle to the operating
+  # system.
+  alias Handle = Int32
 
   private def unbuffered_read(slice : Bytes)
     evented_read(slice, "Error reading file") do

--- a/src/crystal/system/win32/file_descriptor.cr
+++ b/src/crystal/system/win32/file_descriptor.cr
@@ -7,7 +7,10 @@ require "io/overlapped"
 module Crystal::System::FileDescriptor
   include IO::Overlapped
 
-  @volatile_fd : Atomic(LibC::Int)
+  # Platform-specific type to represent a file descriptor handle to the operating
+  # system.
+  alias Handle = ::LibC::Int
+
   @system_blocking = true
 
   private def unbuffered_read(slice : Bytes)

--- a/src/io/file_descriptor.cr
+++ b/src/io/file_descriptor.cr
@@ -5,9 +5,10 @@ class IO::FileDescriptor < IO
   include Crystal::System::FileDescriptor
   include IO::Buffered
 
-  # The raw file-descriptor. It is defined to be an `Int`, but its size is
-  # platform-specific.
-  def fd : Int
+  @volatile_fd : Atomic(Handle)
+
+  # Returns the raw file-descriptor handle. Its type is platform-specific.
+  def fd : Handle
     @volatile_fd.get
   end
 


### PR DESCRIPTION
Adds a generic type representing a platform-specific file descriptor handle, analog to `Socket::Handle`.

Resolves part of #14389