### PR TITLE
Automatically detect MSVC tools on Windows interpreter

### DIFF
--- a/src/compiler/crystal/codegen/link.cr
+++ b/src/compiler/crystal/codegen/link.cr
@@ -1,3 +1,8 @@
+{% if flag?(:msvc) %}
+  require "crystal/system/win32/visual_studio"
+  require "crystal/system/win32/windows_sdk"
+{% end %}
+
 module Crystal
   struct LinkAnnotation
     getter lib : String?
@@ -270,6 +275,43 @@ module Crystal
 
         yield dll_path || dll, !dll_path.nil?
       end
+    end
+
+    # Detects the current MSVC linker and the relevant linker flags that
+    # recreate the MSVC developer prompt's standard library paths. If both MSVC
+    # and the Windows SDK are available, the linker will be an absolute path and
+    # the linker flags will contain the `/LIBPATH`s for the system libraries.
+    #
+    # Has no effect if the host compiler is not using MSVC.
+    def msvc_compiler_and_flags : {String, Array(String)}
+      linker = Compiler::MSVC_LINKER
+      link_args = [] of String
+
+      {% if flag?(:msvc) %}
+        if msvc_path = Crystal::System::VisualStudio.find_latest_msvc_path
+          if win_sdk_libpath = Crystal::System::WindowsSDK.find_win10_sdk_libpath
+            host_bits = {{ flag?(:aarch64) ? "ARM64" : flag?(:bits64) ? "x64" : "x86" }}
+            target_bits = has_flag?("aarch64") ? "arm64" : has_flag?("bits64") ? "x64" : "x86"
+
+            # MSVC build tools and Windows SDK found; recreate `LIB` environment variable
+            # that is normally expected on the MSVC developer command prompt
+            link_args << "/LIBPATH:#{msvc_path.join("atlmfc", "lib", target_bits)}"
+            link_args << "/LIBPATH:#{msvc_path.join("lib", target_bits)}"
+            link_args << "/LIBPATH:#{win_sdk_libpath.join("ucrt", target_bits)}"
+            link_args << "/LIBPATH:#{win_sdk_libpath.join("um", target_bits)}"
+
+            # use exact path for compiler instead of relying on `PATH`, unless
+            # explicitly overridden by `%CC%`
+            # (letter case shouldn't matter in most cases but being exact doesn't hurt here)
+            unless ENV.has_key?("CC")
+              target_bits = target_bits.sub("arm", "ARM")
+              linker = msvc_path.join("bin", "Host#{host_bits}", target_bits, "cl.exe").to_s
+            end
+          end
+        end
+      {% end %}
+
+      {linker, link_args}
     end
 
     PKG_CONFIG_PATH = Process.find_executable("pkg-config")

--- a/src/compiler/crystal/interpreter/context.cr
+++ b/src/compiler/crystal/interpreter/context.cr
@@ -406,6 +406,13 @@ class Crystal::Repl::Context
     # (MSVC doesn't seem to have this issue)
     args.delete("-lgc")
 
+    # recreate the MSVC developer prompt environment, similar to how compiled
+    # code does it in `Compiler#linker_command`
+    if program.has_flag?("msvc")
+      _, link_args = program.msvc_compiler_and_flags
+      args.concat(link_args)
+    end
+
     Crystal::Loader.parse(args, dll_search_paths: dll_search_paths).tap do |loader|
       # FIXME: Part 2: This is a workaround for initial integration of the interpreter:
       # We append a handle to the current executable (i.e. the compiler program)


### PR DESCRIPTION
Recreates the MSVC developer prompt environment so that the interpreter can be used outside such a prompt, similar to normal compilation.