### PR TITLE
Add compiler support for AVR architecture (Arduino)

### DIFF
--- a/spec/std/llvm/avr_spec.cr
+++ b/spec/std/llvm/avr_spec.cr
@@ -1,0 +1,198 @@
+require "spec"
+
+{% if flag?(:interpreted) && !flag?(:win32) %}
+  # TODO: figure out how to link against libstdc++ in interpreted code (#14398)
+  pending LLVM::ABI::AVR
+  {% skip_file %}
+{% end %}
+
+require "llvm"
+
+{% if LibLLVM::BUILT_TARGETS.includes?(:avr) %}
+  LLVM.init_avr
+{% end %}
+
+private def abi
+  triple = "avr-unknown-unknown-atmega328p"
+  target = LLVM::Target.from_triple(triple)
+  machine = target.create_target_machine(triple)
+  machine.enable_global_isel = false
+  LLVM::ABI::AVR.new(machine)
+end
+
+private def test(msg, &block : LLVM::ABI, LLVM::Context ->)
+  it msg do
+    abi = abi()
+    ctx = LLVM::Context.new
+    block.call(abi, ctx)
+  end
+end
+
+class LLVM::ABI
+  describe AVR do
+    {% if LibLLVM::BUILT_TARGETS.includes?(:avr) %}
+      describe "align" do
+        test "for integer" do |abi, ctx|
+          abi.align(ctx.int1).should be_a(::Int32)
+          abi.align(ctx.int1).should eq(1)
+          abi.align(ctx.int8).should eq(1)
+          abi.align(ctx.int16).should eq(1)
+          abi.align(ctx.int32).should eq(1)
+          abi.align(ctx.int64).should eq(1)
+        end
+
+        test "for pointer" do |abi, ctx|
+          abi.align(ctx.int8.pointer).should eq(1)
+        end
+
+        test "for float" do |abi, ctx|
+          abi.align(ctx.float).should eq(1)
+        end
+
+        test "for double" do |abi, ctx|
+          abi.align(ctx.double).should eq(1)
+        end
+
+        test "for struct" do |abi, ctx|
+          abi.align(ctx.struct([ctx.int32, ctx.int64])).should eq(1)
+          abi.align(ctx.struct([ctx.int8, ctx.int16])).should eq(1)
+        end
+
+        test "for packed struct" do |abi, ctx|
+          abi.align(ctx.struct([ctx.int32, ctx.int64], packed: true)).should eq(1)
+        end
+
+        test "for array" do |abi, ctx|
+          abi.align(ctx.int16.array(10)).should eq(1)
+        end
+      end
+
+      describe "size" do
+        test "for integer" do |abi, ctx|
+          abi.size(ctx.int1).should be_a(::Int32)
+          abi.size(ctx.int1).should eq(1)
+          abi.size(ctx.int8).should eq(1)
+          abi.size(ctx.int16).should eq(2)
+          abi.size(ctx.int32).should eq(4)
+          abi.size(ctx.int64).should eq(8)
+        end
+
+        test "for pointer" do |abi, ctx|
+          abi.size(ctx.int8.pointer).should eq(2)
+        end
+
+        test "for float" do |abi, ctx|
+          abi.size(ctx.float).should eq(4)
+        end
+
+        test "for double" do |abi, ctx|
+          abi.size(ctx.double).should eq(8)
+        end
+
+        test "for struct" do |abi, ctx|
+          abi.size(ctx.struct([ctx.int32, ctx.int64])).should eq(12)
+          abi.size(ctx.struct([ctx.int16, ctx.int8])).should eq(3)
+          abi.size(ctx.struct([ctx.int32, ctx.int8, ctx.int8])).should eq(6)
+        end
+
+        test "for packed struct" do |abi, ctx|
+          abi.size(ctx.struct([ctx.int32, ctx.int8], packed: true)).should eq(5)
+        end
+
+        test "for array" do |abi, ctx|
+          abi.size(ctx.int16.array(10)).should eq(20)
+        end
+      end
+
+      describe "abi_info" do
+        {% for bits in [1, 8, 16, 32, 64] %}
+          test "int{{bits}}" do |abi, ctx|
+            arg_type = ArgType.direct(ctx.int{{bits}})
+            info = abi.abi_info([ctx.int{{bits}}], ctx.int{{bits}}, true, ctx)
+            info.arg_types.size.should eq(1)
+            info.arg_types[0].should eq(arg_type)
+            info.arg_types[0].kind.should eq(LLVM::ABI::ArgKind::Direct)
+            info.return_type.should eq(arg_type)
+            info.return_type.kind.should eq(LLVM::ABI::ArgKind::Direct)
+          end
+        {% end %}
+
+        test "float" do |abi, ctx|
+          arg_type = ArgType.direct(ctx.float)
+          info = abi.abi_info([ctx.float], ctx.float, true, ctx)
+          info.arg_types.size.should eq(1)
+          info.arg_types[0].should eq(arg_type)
+          info.arg_types[0].kind.should eq(LLVM::ABI::ArgKind::Direct)
+          info.return_type.should eq(arg_type)
+          info.return_type.kind.should eq(LLVM::ABI::ArgKind::Direct)
+        end
+
+        test "double" do |abi, ctx|
+          arg_type = ArgType.direct(ctx.double)
+          info = abi.abi_info([ctx.double], ctx.double, true, ctx)
+          info.arg_types.size.should eq(1)
+          info.arg_types[0].should eq(arg_type)
+          info.arg_types[0].kind.should eq(LLVM::ABI::ArgKind::Direct)
+          info.return_type.should eq(arg_type)
+          info.return_type.kind.should eq(LLVM::ABI::ArgKind::Direct)
+        end
+
+        test "multiple arguments" do |abi, ctx|
+          args = 9.times.map { ctx.int16 }.to_a
+          info = abi.abi_info(args, ctx.int8, false, ctx)
+          info.arg_types.size.should eq(9)
+          info.arg_types.each(&.kind.should eq(LLVM::ABI::ArgKind::Direct))
+        end
+
+        test "multiple arguments above registers" do |abi, ctx|
+          args = 5.times.map { ctx.int32 }.to_a
+          info = abi.abi_info(args, ctx.int8, false, ctx)
+          info.arg_types.size.should eq(5)
+          info.arg_types[0].kind.should eq(LLVM::ABI::ArgKind::Direct)
+          info.arg_types[1].kind.should eq(LLVM::ABI::ArgKind::Direct)
+          info.arg_types[2].kind.should eq(LLVM::ABI::ArgKind::Direct)
+          info.arg_types[3].kind.should eq(LLVM::ABI::ArgKind::Direct)
+          info.arg_types[4].kind.should eq(LLVM::ABI::ArgKind::Indirect)
+        end
+
+        test "struct args within 18 bytes" do |abi, ctx|
+          args = [
+            ctx.int8,                           # rounded to 2 bytes
+            ctx.struct([ctx.int32, ctx.int32]), # 8 bytes
+            ctx.struct([ctx.int32, ctx.int32]), # 8 bytes
+          ]
+          info = abi.abi_info(args, ctx.void, false, ctx)
+          info.arg_types.size.should eq(3)
+          info.arg_types[0].kind.should eq(LLVM::ABI::ArgKind::Direct)
+          info.arg_types[1].kind.should eq(LLVM::ABI::ArgKind::Direct)
+          info.arg_types[2].kind.should eq(LLVM::ABI::ArgKind::Direct)
+        end
+
+        test "struct args over 18 bytes" do |abi, ctx|
+          args = [
+            ctx.int32,                          # 4 bytes
+            ctx.struct([ctx.int32, ctx.int32]), # 8 bytes
+            ctx.struct([ctx.int32, ctx.int32]), # 8 bytes
+          ]
+          info = abi.abi_info(args, ctx.void, false, ctx)
+          info.arg_types.size.should eq(3)
+          info.arg_types[0].kind.should eq(LLVM::ABI::ArgKind::Direct)
+          info.arg_types[1].kind.should eq(LLVM::ABI::ArgKind::Direct)
+          info.arg_types[2].kind.should eq(LLVM::ABI::ArgKind::Indirect)
+        end
+
+        test "returns struct within 8 bytes" do |abi, ctx|
+          rty = ctx.struct([ctx.int32, ctx.int32])
+          info = abi.abi_info([] of Type, rty, true, ctx)
+          info.return_type.kind.should eq(LLVM::ABI::ArgKind::Direct)
+        end
+
+        test "returns struct over 8 bytes" do |abi, ctx|
+          rty = ctx.struct([ctx.int32, ctx.int32, ctx.int8])
+          info = abi.abi_info([] of Type, rty, true, ctx)
+          info.return_type.kind.should eq(LLVM::ABI::ArgKind::Indirect)
+        end
+      end
+    {% end %}
+  end
+end

--- a/src/compiler/crystal/codegen/primitives.cr
+++ b/src/compiler/crystal/codegen/primitives.cr
@@ -1257,7 +1257,7 @@ class Crystal::CodeGenVisitor
     when CharType
       inst.alignment = 4
     else
-      inst.alignment = @program.alignment_byte_width
+      inst.alignment = @program.bits64? ? 8 : 4
     end
   end
 

--- a/src/compiler/crystal/codegen/primitives.cr
+++ b/src/compiler/crystal/codegen/primitives.cr
@@ -1257,7 +1257,7 @@ class Crystal::CodeGenVisitor
     when CharType
       inst.alignment = 4
     else
-      inst.alignment = @program.bits64? ? 8 : 4
+      inst.alignment = @program.alignment_byte_width
     end
   end
 

--- a/src/compiler/crystal/codegen/target.cr
+++ b/src/compiler/crystal/codegen/target.cr
@@ -75,19 +75,6 @@ class Crystal::Codegen::Target
     end
   end
 
-  def alignment_byte_width
-    case @architecture
-    when "aarch64", "x86_64"
-      8
-    when "arm", "i386", "wasm32"
-      4
-    when "avr"
-      1
-    else
-      raise "BUG: unknown Target#alignment_byte_width for #{@architecture} target architecture"
-    end
-  end
-
   def os_name
     case self
     when .macos?

--- a/src/compiler/crystal/codegen/target.cr
+++ b/src/compiler/crystal/codegen/target.cr
@@ -75,6 +75,19 @@ class Crystal::Codegen::Target
     end
   end
 
+  def alignment_byte_width
+    case @architecture
+    when "aarch64", "x86_64"
+      8
+    when "arm", "i386", "wasm32"
+      4
+    when "avr"
+      1
+    else
+      raise "BUG: unknown Target#alignment_byte_width for #{@architecture} target architecture"
+    end
+  end
+
   def os_name
     case self
     when .macos?

--- a/src/compiler/crystal/codegen/target.cr
+++ b/src/compiler/crystal/codegen/target.cr
@@ -99,6 +99,7 @@ class Crystal::Codegen::Target
   def executable_extension
     case
     when windows? then ".exe"
+    when avr?     then ".elf"
     else               ""
     end
   end
@@ -209,6 +210,11 @@ class Crystal::Codegen::Target
       end
     when "avr"
       LLVM.init_avr
+
+      if cpu.blank?
+        # the ABI call convention, codegen and the linker need to known the CPU model
+        raise Target::Error.new("AVR targets must declare a CPU model, for example --mcpu=atmega328p")
+      end
     when "wasm32"
       LLVM.init_webassembly
     else

--- a/src/compiler/crystal/codegen/target.cr
+++ b/src/compiler/crystal/codegen/target.cr
@@ -51,10 +51,14 @@ class Crystal::Codegen::Target
 
   def pointer_bit_width
     case @architecture
-    when "x86_64", "aarch64"
+    when "aarch64", "x86_64"
       64
-    else
+    when "arm", "i386", "wasm32"
       32
+    when "avr"
+      16
+    else
+      raise "BUG: unknown Target#pointer_bit_width for #{@architecture} target architecture"
     end
   end
 
@@ -64,6 +68,8 @@ class Crystal::Codegen::Target
       64
     when "arm", "i386", "wasm32"
       32
+    when "avr"
+      16
     else
       raise "BUG: unknown Target#size_bit_width for #{@architecture} target architecture"
     end
@@ -181,6 +187,10 @@ class Crystal::Codegen::Target
     environment_parts.any? &.in?("gnueabihf", "musleabihf")
   end
 
+  def avr?
+    @architecture == "avr"
+  end
+
   def to_target_machine(cpu = "", features = "", optimization_mode = Compiler::OptimizationMode::O0,
                         code_model = LLVM::CodeModel::Default) : LLVM::TargetMachine
     case @architecture
@@ -197,6 +207,8 @@ class Crystal::Codegen::Target
       if cpu.empty? && !features.includes?("fp") && armhf?
         features += "+vfp2"
       end
+    when "avr"
+      LLVM.init_avr
     when "wasm32"
       LLVM.init_webassembly
     else

--- a/src/compiler/crystal/compiler.cr
+++ b/src/compiler/crystal/compiler.cr
@@ -463,10 +463,13 @@ module Crystal
       elsif program.has_flag? "wasm32"
         link_flags = @link_flags || ""
         {"wasm-ld", %(wasm-ld "${@}" -o #{Process.quote_posix(output_filename)} #{link_flags} -lc #{program.lib_flags}), object_names}
+      elsif program.has_flag? "avr"
+        link_flags = @link_flags || ""
+        link_flags += " --target=avr-unknown-unknown -mmcu=#{@mcpu} -Wl,--gc-sections"
+        {DEFAULT_LINKER, %(#{DEFAULT_LINKER} "${@}" -o #{Process.quote_posix(output_filename)} #{link_flags} #{program.lib_flags}), object_names}
       else
         link_flags = @link_flags || ""
         link_flags += " -rdynamic"
-
         {DEFAULT_LINKER, %(#{DEFAULT_LINKER} "${@}" -o #{Process.quote_posix(output_filename)} #{link_flags} #{program.lib_flags}), object_names}
       end
     end

--- a/src/compiler/crystal/semantic/flags.cr
+++ b/src/compiler/crystal/semantic/flags.cr
@@ -29,6 +29,10 @@ class Crystal::Program
     codegen_target.size_bit_width
   end
 
+  def alignment_byte_width
+    codegen_target.alignment_byte_width
+  end
+
   private def flags_for_target(target)
     flags = Set(String).new
 

--- a/src/compiler/crystal/semantic/flags.cr
+++ b/src/compiler/crystal/semantic/flags.cr
@@ -56,6 +56,10 @@ class Crystal::Program
 
     flags.add "bsd" if target.bsd?
 
+    if target.avr? && (cpu = target_machine.cpu.presence)
+      flags.add cpu
+    end
+
     flags
   end
 end

--- a/src/compiler/crystal/semantic/flags.cr
+++ b/src/compiler/crystal/semantic/flags.cr
@@ -29,10 +29,6 @@ class Crystal::Program
     codegen_target.size_bit_width
   end
 
-  def alignment_byte_width
-    codegen_target.alignment_byte_width
-  end
-
   private def flags_for_target(target)
     flags = Set(String).new
 

--- a/src/intrinsics.cr
+++ b/src/intrinsics.cr
@@ -4,45 +4,57 @@ lib LibIntrinsics
   {% if flag?(:interpreted) %} @[Primitive(:interpreter_intrinsics_debugtrap)] {% end %}
   fun debugtrap = "llvm.debugtrap"
 
-  {% if flag?(:bits64) %}
+  {% if flag?(:avr) %}
     {% if compare_versions(Crystal::LLVM_VERSION, "15.0.0") < 0 %}
-      {% if flag?(:interpreted) %} @[Primitive(:interpreter_intrinsics_memcpy)] {% end %}
-      fun memcpy = "llvm.memcpy.p0i8.p0i8.i64"(dest : Void*, src : Void*, len : UInt64, is_volatile : Bool)
-
-      {% if flag?(:interpreted) %} @[Primitive(:interpreter_intrinsics_memmove)] {% end %}
-      fun memmove = "llvm.memmove.p0i8.p0i8.i64"(dest : Void*, src : Void*, len : UInt64, is_volatile : Bool)
-
-      {% if flag?(:interpreted) %} @[Primitive(:interpreter_intrinsics_memset)] {% end %}
-      fun memset = "llvm.memset.p0i8.i64"(dest : Void*, val : UInt8, len : UInt64, is_volatile : Bool)
+      fun memcpy = "llvm.memcpy.p0i8.p0i8.i16"(dest : Void*, src : Void*, len : UInt16, is_volatile : Bool)
+      fun memmove = "llvm.memmove.p0i8.p0i8.i16"(dest : Void*, src : Void*, len : UInt16, is_volatile : Bool)
+      fun memset = "llvm.memset.p0i8.i16"(dest : Void*, val : UInt8, len : UInt16, is_volatile : Bool)
     {% else %}
-      {% if flag?(:interpreted) %} @[Primitive(:interpreter_intrinsics_memcpy)] {% end %}
-      fun memcpy = "llvm.memcpy.p0.p0.i64"(dest : Void*, src : Void*, len : UInt64, is_volatile : Bool)
-
-      {% if flag?(:interpreted) %} @[Primitive(:interpreter_intrinsics_memmove)] {% end %}
-      fun memmove = "llvm.memmove.p0.p0.i64"(dest : Void*, src : Void*, len : UInt64, is_volatile : Bool)
-
-      {% if flag?(:interpreted) %} @[Primitive(:interpreter_intrinsics_memset)] {% end %}
-      fun memset = "llvm.memset.p0.i64"(dest : Void*, val : UInt8, len : UInt64, is_volatile : Bool)
+      fun memcpy = "llvm.memcpy.p0.p0.i16"(dest : Void*, src : Void*, len : UInt16, is_volatile : Bool)
+      fun memmove = "llvm.memmove.p0.p0.i16"(dest : Void*, src : Void*, len : UInt16, is_volatile : Bool)
+      fun memset = "llvm.memset.p0.i16"(dest : Void*, val : UInt8, len : UInt16, is_volatile : Bool)
     {% end %}
   {% else %}
-    {% if compare_versions(Crystal::LLVM_VERSION, "15.0.0") < 0 %}
-      {% if flag?(:interpreted) %} @[Primitive(:interpreter_intrinsics_memcpy)] {% end %}
-      fun memcpy = "llvm.memcpy.p0i8.p0i8.i32"(dest : Void*, src : Void*, len : UInt32, is_volatile : Bool)
+    {% if flag?(:bits64) %}
+      {% if compare_versions(Crystal::LLVM_VERSION, "15.0.0") < 0 %}
+        {% if flag?(:interpreted) %} @[Primitive(:interpreter_intrinsics_memcpy)] {% end %}
+        fun memcpy = "llvm.memcpy.p0i8.p0i8.i64"(dest : Void*, src : Void*, len : UInt64, is_volatile : Bool)
 
-      {% if flag?(:interpreted) %} @[Primitive(:interpreter_intrinsics_memmove)] {% end %}
-      fun memmove = "llvm.memmove.p0i8.p0i8.i32"(dest : Void*, src : Void*, len : UInt32, is_volatile : Bool)
+        {% if flag?(:interpreted) %} @[Primitive(:interpreter_intrinsics_memmove)] {% end %}
+        fun memmove = "llvm.memmove.p0i8.p0i8.i64"(dest : Void*, src : Void*, len : UInt64, is_volatile : Bool)
 
-      {% if flag?(:interpreted) %} @[Primitive(:interpreter_intrinsics_memset)] {% end %}
-      fun memset = "llvm.memset.p0i8.i32"(dest : Void*, val : UInt8, len : UInt32, is_volatile : Bool)
+        {% if flag?(:interpreted) %} @[Primitive(:interpreter_intrinsics_memset)] {% end %}
+        fun memset = "llvm.memset.p0i8.i64"(dest : Void*, val : UInt8, len : UInt64, is_volatile : Bool)
+      {% else %}
+        {% if flag?(:interpreted) %} @[Primitive(:interpreter_intrinsics_memcpy)] {% end %}
+        fun memcpy = "llvm.memcpy.p0.p0.i64"(dest : Void*, src : Void*, len : UInt64, is_volatile : Bool)
+
+        {% if flag?(:interpreted) %} @[Primitive(:interpreter_intrinsics_memmove)] {% end %}
+        fun memmove = "llvm.memmove.p0.p0.i64"(dest : Void*, src : Void*, len : UInt64, is_volatile : Bool)
+
+        {% if flag?(:interpreted) %} @[Primitive(:interpreter_intrinsics_memset)] {% end %}
+        fun memset = "llvm.memset.p0.i64"(dest : Void*, val : UInt8, len : UInt64, is_volatile : Bool)
+      {% end %}
     {% else %}
-      {% if flag?(:interpreted) %} @[Primitive(:interpreter_intrinsics_memcpy)] {% end %}
-      fun memcpy = "llvm.memcpy.p0.p0.i32"(dest : Void*, src : Void*, len : UInt32, is_volatile : Bool)
+      {% if compare_versions(Crystal::LLVM_VERSION, "15.0.0") < 0 %}
+        {% if flag?(:interpreted) %} @[Primitive(:interpreter_intrinsics_memcpy)] {% end %}
+        fun memcpy = "llvm.memcpy.p0i8.p0i8.i32"(dest : Void*, src : Void*, len : UInt32, is_volatile : Bool)
 
-      {% if flag?(:interpreted) %} @[Primitive(:interpreter_intrinsics_memmove)] {% end %}
-      fun memmove = "llvm.memmove.p0.p0.i32"(dest : Void*, src : Void*, len : UInt32, is_volatile : Bool)
+        {% if flag?(:interpreted) %} @[Primitive(:interpreter_intrinsics_memmove)] {% end %}
+        fun memmove = "llvm.memmove.p0i8.p0i8.i32"(dest : Void*, src : Void*, len : UInt32, is_volatile : Bool)
 
-      {% if flag?(:interpreted) %} @[Primitive(:interpreter_intrinsics_memset)] {% end %}
-      fun memset = "llvm.memset.p0.i32"(dest : Void*, val : UInt8, len : UInt32, is_volatile : Bool)
+        {% if flag?(:interpreted) %} @[Primitive(:interpreter_intrinsics_memset)] {% end %}
+        fun memset = "llvm.memset.p0i8.i32"(dest : Void*, val : UInt8, len : UInt32, is_volatile : Bool)
+      {% else %}
+        {% if flag?(:interpreted) %} @[Primitive(:interpreter_intrinsics_memcpy)] {% end %}
+        fun memcpy = "llvm.memcpy.p0.p0.i32"(dest : Void*, src : Void*, len : UInt32, is_volatile : Bool)
+
+        {% if flag?(:interpreted) %} @[Primitive(:interpreter_intrinsics_memmove)] {% end %}
+        fun memmove = "llvm.memmove.p0.p0.i32"(dest : Void*, src : Void*, len : UInt32, is_volatile : Bool)
+
+        {% if flag?(:interpreted) %} @[Primitive(:interpreter_intrinsics_memset)] {% end %}
+        fun memset = "llvm.memset.p0.i32"(dest : Void*, val : UInt8, len : UInt32, is_volatile : Bool)
+      {% end %}
     {% end %}
   {% end %}
 

--- a/src/llvm.cr
+++ b/src/llvm.cr
@@ -52,6 +52,22 @@ module LLVM
     {% end %}
   end
 
+  def self.init_avr : Nil
+    return if @@initialized_avr
+    @@initialized_avr = true
+
+    {% if LibLLVM::BUILT_TARGETS.includes?(:avr) %}
+      LibLLVM.initialize_avr_target_info
+      LibLLVM.initialize_avr_target
+      LibLLVM.initialize_avr_target_mc
+      LibLLVM.initialize_avr_asm_printer
+      LibLLVM.initialize_avr_asm_parser
+      LibLLVM.link_in_mc_jit
+    {% else %}
+      raise "ERROR: LLVM was built without AVR target"
+    {% end %}
+  end
+
   def self.init_webassembly : Nil
     return if @@initialized_webassembly
     @@initialized_webassembly = true

--- a/src/llvm/abi/avr.cr
+++ b/src/llvm/abi/avr.cr
@@ -16,7 +16,7 @@ class LLVM::ABI::AVR < LLVM::ABI
     super target_machine
 
     # "Reduced Tiny" core devices only have 16 General Purpose Registers
-    if mcpu && AVRTINY.includes?(mcpu)
+    if mcpu.in?(AVRTINY)
       @rsize = 4 # values above 4 bytes are returned by memory
       @rmin = 20 # 6 registers for call arguments (R25..R20)
     else

--- a/src/llvm/abi/avr.cr
+++ b/src/llvm/abi/avr.cr
@@ -1,7 +1,7 @@
 require "../abi"
 
 class LLVM::ABI::AVR < LLVM::ABI
-  AVRTINY = {
+  AVRTINY = StaticArray[
     "attiny4",
     "attiny5",
     "attiny9",
@@ -10,7 +10,7 @@ class LLVM::ABI::AVR < LLVM::ABI
     "attiny104",
     "attiny20",
     "attiny40",
-  }
+  ]
 
   def initialize(target_machine : TargetMachine, mcpu : String? = nil)
     super target_machine

--- a/src/llvm/abi/avr.cr
+++ b/src/llvm/abi/avr.cr
@@ -1,0 +1,82 @@
+require "../abi"
+
+class LLVM::ABI::AVR < LLVM::ABI
+  AVRTINY = {
+    "attiny4",
+    "attiny5",
+    "attiny9",
+    "attiny10",
+    "attiny102",
+    "attiny104",
+    "attiny20",
+    "attiny40",
+  }
+
+  def initialize(target_machine : TargetMachine, mcpu : String? = nil)
+    super target_machine
+
+    # "Reduced Tiny" core devices only have 16 General Purpose Registers
+    if mcpu && AVRTINY.includes?(mcpu)
+      @rsize = 4 # values above 4 bytes are returned by memory
+      @rmin = 20 # 6 registers for call arguments (R25..R20)
+    else
+      @rsize = 8 # values above 8 bytes are returned by memory
+      @rmin = 8  # 18 registers for call arguments (R25..R8)
+    end
+  end
+
+  def align(type : Type) : Int32
+    target_data.abi_alignment(type).to_i32
+  end
+
+  def size(type : Type) : Int32
+    target_data.abi_size(type).to_i32
+  end
+
+  # Follows AVR GCC, while Clang (and Rust) are incompatible, despite LLVM
+  # itself being compliant.
+  #
+  # - <https://gcc.gnu.org/wiki/avr-gcc>
+  # - <https://bugs.llvm.org/show_bug.cgi?id=46140>
+  def abi_info(atys : Array(Type), rty : Type, ret_def : Bool, context : Context) : LLVM::ABI::FunctionType
+    ret_ty = compute_return_type(rty, ret_def, context)
+    arg_tys = compute_arg_types(atys, context)
+    FunctionType.new(arg_tys, ret_ty)
+  end
+
+  # Pass in registers unless the returned type is a struct larger than 8 bytes
+  # (4 bytes on reduced tiny cores).
+  #
+  # Rust & Clang always return a struct _indirectly_.
+  private def compute_return_type(rty, ret_def, context)
+    if !ret_def
+      ArgType.direct(context.void)
+    elsif size(rty) > @rsize
+      ArgType.indirect(rty, LLVM::Attribute::StructRet)
+    else
+      # let the LLVM AVR backend handle the pw2ceil padding of structs
+      ArgType.direct(rty)
+    end
+  end
+
+  # Fill the R25 -> R8 registers (R20 on reduced tiny cores), rounding odd byte
+  # sizes to the next even number, then pass by memory (indirect), so {i8, i32}
+  # are passed as R24 then R20..R23 (LSB -> MSB) for example.
+  #
+  # Rust & Clang always pass structs _indirectly_.
+  private def compute_arg_types(atys, context)
+    rn = 26
+    atys.map do |aty|
+      bytes = size(aty)
+      bytes += 1 if bytes.odd?
+      rn -= bytes
+
+      if bytes == 0 || rn < @rmin
+        ArgType.indirect(aty, LLVM::Attribute::StructRet)
+      else
+        # let the LLVM AVR backend handle the odd to next even number padding
+        ArgType.direct(aty)
+      end
+    end
+  end
+end

--- a/src/llvm/lib_llvm/target.cr
+++ b/src/llvm/lib_llvm/target.cr
@@ -13,6 +13,11 @@ lib LibLLVM
   fun initialize_arm_target_mc = LLVMInitializeARMTargetMC
   fun initialize_arm_asm_printer = LLVMInitializeARMAsmPrinter
   fun initialize_arm_asm_parser = LLVMInitializeARMAsmParser
+  fun initialize_avr_target_info = LLVMInitializeAVRTargetInfo
+  fun initialize_avr_target = LLVMInitializeAVRTarget
+  fun initialize_avr_target_mc = LLVMInitializeAVRTargetMC
+  fun initialize_avr_asm_printer = LLVMInitializeAVRAsmPrinter
+  fun initialize_avr_asm_parser = LLVMInitializeAVRAsmParser
   fun initialize_webassembly_target_info = LLVMInitializeWebAssemblyTargetInfo
   fun initialize_webassembly_target = LLVMInitializeWebAssemblyTarget
   fun initialize_webassembly_target_mc = LLVMInitializeWebAssemblyTargetMC
@@ -31,4 +36,5 @@ lib LibLLVM
   fun abi_size_of_type = LLVMABISizeOfType(td : TargetDataRef, ty : TypeRef) : ULongLong
   fun abi_alignment_of_type = LLVMABIAlignmentOfType(td : TargetDataRef, ty : TypeRef) : UInt
   fun offset_of_element = LLVMOffsetOfElement(td : TargetDataRef, struct_ty : TypeRef, element : UInt) : ULongLong
+  fun copy_string_rep_of_target_data = LLVMCopyStringRepOfTargetData(td : TargetDataRef) : Char*
 end

--- a/src/llvm/lib_llvm/target_machine.cr
+++ b/src/llvm/lib_llvm/target_machine.cr
@@ -15,6 +15,7 @@ lib LibLLVM
   fun dispose_target_machine = LLVMDisposeTargetMachine(t : TargetMachineRef)
   fun get_target_machine_target = LLVMGetTargetMachineTarget(t : TargetMachineRef) : TargetRef
   fun get_target_machine_triple = LLVMGetTargetMachineTriple(t : TargetMachineRef) : Char*
+  fun get_target_machine_cpu = LLVMGetTargetMachineCPU(t : TargetMachineRef) : Char*
   fun create_target_data_layout = LLVMCreateTargetDataLayout(t : TargetMachineRef) : TargetDataRef
   {% unless LibLLVM::IS_LT_180 %}
     fun set_target_machine_global_isel = LLVMSetTargetMachineGlobalISel(t : TargetMachineRef, enable : Bool)

--- a/src/llvm/target_data.cr
+++ b/src/llvm/target_data.cr
@@ -30,6 +30,6 @@ struct LLVM::TargetData
   end
 
   def to_data_layout_string
-    String.new(LibLLVM.copy_string_rep_of_target_data(self))
+    LLVM.string_and_dispose(LibLLVM.copy_string_rep_of_target_data(self))
   end
 end

--- a/src/llvm/target_machine.cr
+++ b/src/llvm/target_machine.cr
@@ -19,6 +19,11 @@ class LLVM::TargetMachine
     LLVM.string_and_dispose(triple_c)
   end
 
+  def cpu : String
+    cpu_c = LibLLVM.get_target_machine_cpu(self)
+    LLVM.string_and_dispose(cpu_c)
+  end
+
   def emit_obj_to_file(llvm_mod, filename)
     emit_to_file llvm_mod, filename, LLVM::CodeGenFileType::ObjectFile
   end
@@ -53,6 +58,8 @@ class LLVM::TargetMachine
       ABI::AArch64.new(self)
     when /arm/
       ABI::ARM.new(self)
+    when /avr/
+      ABI::AVR.new(self, cpu)
     when /wasm32/
       ABI::Wasm32.new(self)
     else


### PR DESCRIPTION
Experimental support for the AVR (Atmel) CPU architectures as found on popular Arduino boards (e.g. Uno).

- Supports the `avr-unknown-unknown` target triple;
- Enables the AVR target in LLVM;
- Implements the ABI as per [GCC AVR](https://gcc.gnu.org/wiki/avr-gcc) (barely tested), with support for both regular and "reduced tiny" cores (less registers);
- ~~Starts hacking support for 16-bit `size_t`~~ extracted as #14442;
- Requires CPU model to be specified with `--mcpu` (impacts the ABI, codegen & linker);
- Exports the specified CPU model as a compiler flag;
- Links the executable program (courtesy of @RX14);
- No support for stdlib (must compile with `--prelude=empty`), for obvious reasons. Alternative stdlib shall happen in external shards.

Initial cross compilations seem to generate a proper file, identical or close to clang and less optimized for size than AVR GCC.

**Follow ups:**

- Add support for `-Os` (optsize) and `-Oz` (minsize) with `LLVMPassBuilderOptionsSetInlinerThreshold`. The thresholds in LLVM are 50 and 5 respectively (I guess clang uses these) while Rust uses 75 and 25. We could also disable some specific optimizations (e.g. loop unrolling). That would help reduce the program size which can be _very_ restricted on AVR (e.g. 32KB). See #14463.

- The compiler hardcodes pointer sizes to 64-bit (`Pointer#address`, `#object_id` and pointer manipulation). It would be interesting to have per-target support for `size_t` and `uintptr_t` actual sizes, instead of casting and assuming LLVM will optimize.

**Basic instructions:**

Install the GCC AVR toolchain and avr-libc. On Debian/Ubuntu:

```sh
$ apt install gcc-avr avr-libc
```

Cross compile a crystal binary, specifying the actual CPU (e.g. Arduino Uno uses an atmega328p) and the empty prelude, link it as a `.elf` file and generate a `.hex` file:

```sh
$ CC=avr-gcc crystal build \
  --target=avr-unknown-unknown --mcpu=atmega328p \
  --prelude=empty --no-debug --single-module -O2 blink.cr
$ avr-objcopy -O ihex blink.elf blink.hex
```

When #14463 is merged we may use -Os and -Oz to further reduce the executable file size. The `--gc-sections` linker option is mostly useful when linking external libraries.

Now you should be able to upload the hex file to your AVR board, using avrdude for example.