### PR TITLE
Fix `min_by?` in IOCP event loop `#run_once`

### DIFF
--- a/src/crystal/system/win32/event_loop_iocp.cr
+++ b/src/crystal/system/win32/event_loop_iocp.cr
@@ -42,7 +42,7 @@ class Crystal::Iocp::EventLoop < Crystal::EventLoop
     # timeout for waiting on the completion port.
     # OPTIMIZE: Implement @queue as a priority queue in order to avoid this
     # explicit search for the lowest value and dequeue more efficient.
-    next_event = @queue.min_by(&.wake_at)
+    next_event = @queue.min_by?(&.wake_at)
 
     unless next_event
       Crystal::System.print_error "Warning: No runnables in scheduler. Exiting program.\n"


### PR DESCRIPTION
`min_by` raises if the queue is empty but we want to handle this case explicitly in the following condition.

This is practically not very relevant as the queue should never be empty in normal operation. But it might be useful when working on the event loop itself.