### PR TITLE
Use `Fiber::StackPool` in the interpreter

### DIFF
--- a/src/crystal/system/unix/fiber.cr
+++ b/src/crystal/system/unix/fiber.cr
@@ -1,7 +1,7 @@
 require "c/sys/mman"
 
 module Crystal::System::Fiber
-  def self.allocate_stack(stack_size) : Void*
+  def self.allocate_stack(stack_size, protect) : Void*
     flags = LibC::MAP_PRIVATE | LibC::MAP_ANON
     {% if flag?(:openbsd) %}
       flags |= LibC::MAP_STACK
@@ -14,7 +14,10 @@ module Crystal::System::Fiber
       LibC.madvise(pointer, stack_size, LibC::MADV_NOHUGEPAGE)
     {% end %}
 
-    LibC.mprotect(pointer, 4096, LibC::PROT_NONE)
+    if protect
+      LibC.mprotect(pointer, 4096, LibC::PROT_NONE)
+    end
+
     pointer
   end
 

--- a/src/crystal/system/wasi/fiber.cr
+++ b/src/crystal/system/wasi/fiber.cr
@@ -1,5 +1,5 @@
 module Crystal::System::Fiber
-  def self.allocate_stack(stack_size) : Void*
+  def self.allocate_stack(stack_size, protect) : Void*
     LibC.malloc(stack_size)
   end
 


### PR DESCRIPTION
For some reason, when the GC allocates an 8 MB fiber stack in the interpreter, it might expand the heap only to find that the new pages are already [black-listed](https://github.com/ivmai/bdwgc/blob/master/docs/gcdescr.md#black-listing), so it repeats until the system gives a good heap address. A single allocation could sometimes commit [over 4 GB of memory](https://github.com/crystal-lang/crystal/issues/12396#issuecomment-2014951431) this way.

This PR bypasses the GC entirely and allocates those fiber stacks using `mmap` or `VirtualAlloc` directly, the same as non-interpreted code. It doesn't change how stack pools are used, every `Crystal::Repl::Interpreter` still maintains its own pool. Apart from making specs like `channel_spec.cr` actually finish on Windows, it looks like the interpreted stdlib specs also run slightly faster on Linux.

The REPL interpreter object still uses the old allocation via `Crystal::Repl::Interpreter.new`'s default argument for `@stack`.