### PR TITLE
Add `Spec::Formatter#should_print_summary?`

### DIFF
--- a/src/spec/context.cr
+++ b/src/spec/context.cr
@@ -178,10 +178,12 @@ module Spec
 
     def finish(elapsed_time, aborted = false)
       Spec.cli.formatters.each(&.finish(elapsed_time, aborted))
-      Spec.cli.formatters.each(&.print_results(elapsed_time, aborted))
+      if Spec.cli.formatters.any?(&.should_print_summary?)
+        print_summary(elapsed_time, aborted)
+      end
     end
 
-    def print_results(elapsed_time, aborted = false)
+    def print_summary(elapsed_time, aborted = false)
       pendings = results_for(:pending)
       unless pendings.empty?
         puts

--- a/src/spec/formatter.cr
+++ b/src/spec/formatter.cr
@@ -19,7 +19,8 @@ module Spec
     def finish(elapsed_time, aborted)
     end
 
-    def print_results(elapsed_time : Time::Span, aborted : Bool)
+    def should_print_summary?
+      false
     end
   end
 
@@ -54,8 +55,8 @@ module Spec
       @io.puts
     end
 
-    def print_results(elapsed_time : Time::Span, aborted : Bool)
-      Spec.cli.root_context.print_results(elapsed_time, aborted)
+    def should_print_summary?
+      true
     end
   end
 
@@ -110,8 +111,8 @@ module Spec
       @io.puts Spec.color(@last_description, result.kind)
     end
 
-    def print_results(elapsed_time : Time::Span, aborted : Bool)
-      Spec.cli.root_context.print_results(elapsed_time, aborted)
+    def should_print_summary?
+      true
     end
   end
 


### PR DESCRIPTION
Extracted from #14259

Note that at most one active formatter can ever print a summary due to how the `Spec` CLI works: `Spec::JUnitFormatter` can be added but doesn't print a summary, the other options replace the first formatter. See also #10045.