### PR TITLE
Revert "Refactor win32 `File::Descriptor#unbuffered_read`, `#unbuffered_write`"

### DIFF
--- a/src/crystal/system/win32/file_descriptor.cr
+++ b/src/crystal/system/win32/file_descriptor.cr
@@ -18,7 +18,17 @@ module Crystal::System::FileDescriptor
     if ConsoleUtils.console?(handle)
       ConsoleUtils.read(handle, slice)
     elsif system_blocking?
-      unbuffered_read_blocking(handle, slice)
+      if LibC.ReadFile(handle, slice, slice.size, out bytes_read, nil) == 0
+        case error = WinError.value
+        when .error_access_denied?
+          raise IO::Error.new "File not open for reading", target: self
+        when .error_broken_pipe?
+          return 0_i32
+        else
+          raise IO::Error.from_os_error("Error reading file", error, target: self)
+        end
+      end
+      bytes_read.to_i32
     else
       overlapped_operation(handle, "ReadFile", read_timeout) do |overlapped|
         ret = LibC.ReadFile(handle, slice, slice.size, out byte_count, overlapped)
@@ -27,25 +37,20 @@ module Crystal::System::FileDescriptor
     end
   end
 
-  private def unbuffered_read_blocking(handle, slice)
-    ret = LibC.ReadFile(handle, slice, slice.size, out bytes_read, nil)
-    return bytes_read.to_i32 unless ret.zero?
-
-    case error = WinError.value
-    when .error_access_denied?
-      raise IO::Error.new "File not open for reading", target: self
-    when .error_broken_pipe?
-      return 0_i32
-    else
-      raise IO::Error.from_os_error("Error reading file", error, target: self)
-    end
-  end
-
   private def unbuffered_write(slice : Bytes) : Nil
     handle = windows_handle
     until slice.empty?
       if system_blocking?
-        bytes_written = unbuffered_write_blocking(handle, slice)
+        if LibC.WriteFile(handle, slice, slice.size, out bytes_written, nil) == 0
+          case error = WinError.value
+          when .error_access_denied?
+            raise IO::Error.new "File not open for writing", target: self
+          when .error_broken_pipe?
+            return 0_u32
+          else
+            raise IO::Error.from_os_error("Error writing file", error, target: self)
+          end
+        end
       else
         bytes_written = overlapped_operation(handle, "WriteFile", write_timeout, writing: true) do |overlapped|
           ret = LibC.WriteFile(handle, slice, slice.size, out byte_count, overlapped)
@@ -54,20 +59,6 @@ module Crystal::System::FileDescriptor
       end
 
       slice += bytes_written
-    end
-  end
-
-  private def unbuffered_write_blocking(handle, slice)
-    ret = LibC.WriteFile(handle, slice, slice.size, out bytes_written, nil)
-    return bytes_written unless ret.zero?
-
-    case error = WinError.value
-    when .error_access_denied?
-      raise IO::Error.new "File not open for writing", target: self
-    when .error_broken_pipe?
-      return 0_u32
-    else
-      raise IO::Error.from_os_error("Error writing file", error, target: self)
     end
   end
 


### PR DESCRIPTION
Reverts crystal-lang/crystal#14388 due to unintentionally changing semantics.

https://github.com/crystal-lang/crystal/pull/14388#discussion_r1539538702