### PR TITLE
Fix `Milestone` JSON bindings in `github-changelog` helper

### DIFF
--- a/scripts/github-changelog.cr
+++ b/scripts/github-changelog.cr
@@ -87,7 +87,7 @@ end
 
 record Milestone,
   closed_at : Time?,
-  description : String,
+  description : String?,
   due_on : Time?,
   title : String,
   pull_requests : Array(PullRequest) do


### PR DESCRIPTION
The description can be empty in which case it's `Nil`.