### PR TITLE
Use link refs for PR links in changelog

### DIFF
--- a/scripts/github-changelog.cr
+++ b/scripts/github-changelog.cr
@@ -143,11 +143,21 @@ record PullRequest,
       io << "**[deprecation]** "
     end
     io << title.sub(/^\[?(?:#{type}|#{sub_topic})(?::|\]:?) /i, "") << " ("
-    io << "[#" << number << "](" << permalink << ")"
+    link_ref(io)
     if author = self.author
       io << ", thanks @" << author
     end
     io << ")"
+  end
+
+  def link_ref(io)
+    io << "[#" << number << "]"
+  end
+
+  def print_ref_label(io)
+    link_ref(io)
+    io << ": " << permalink
+    io.puts
   end
 
   def <=>(other : self)
@@ -334,6 +344,9 @@ SECTION_TITLES.each do |id, title|
     topic_prs.each do |pr|
       puts "- #{pr}"
     end
+    puts
+
+    topic_prs.each(&.print_ref_label(STDOUT))
     puts
   end
 end


### PR DESCRIPTION
This makes the individual entries easier to read with just the PR number and the URL is detached at the end of the current section.

Example diff that this change produces in `CHANGELOG.md`:

```diff
-- Allow multiple parameters and blocks for operators ending in `=` ([#14159](https://github.com/crystal-lang/crystal/pull/14159), thanks @HertzDevil)
+- Allow multiple parameters and blocks for operators ending in `=` ([#14159], thanks @HertzDevil)
+
+[#14159]: https://github.com/crystal-lang/crystal/pull/14159
```