### PR TITLE
Remove calls to `LibC._setmode`

### DIFF
--- a/src/crystal/system/win32/file.cr
+++ b/src/crystal/system/win32/file.cr
@@ -50,9 +50,6 @@ module Crystal::System::File
       return {-1, Errno.value}
     end
 
-    # Only binary mode is supported
-    LibC._setmode fd, LibC::O_BINARY
-
     {fd, Errno::NONE}
   end
 

--- a/src/crystal/system/win32/file_descriptor.cr
+++ b/src/crystal/system/win32/file_descriptor.cr
@@ -222,7 +222,6 @@ module Crystal::System::FileDescriptor
     console_handle = false
     handle = windows_handle(fd)
     if handle != LibC::INVALID_HANDLE_VALUE
-      LibC._setmode fd, LibC::O_BINARY
       # TODO: use `out old_mode` after implementing interpreter out closured var
       old_mode = uninitialized LibC::DWORD
       if LibC.GetConsoleMode(handle, pointerof(old_mode)) != 0

--- a/src/lib_c/x86_64-windows-msvc/c/io.cr
+++ b/src/lib_c/x86_64-windows-msvc/c/io.cr
@@ -8,7 +8,6 @@ lib LibC
   fun _get_osfhandle(fd : Int) : IntPtrT
   fun _dup2(fd1 : Int, fd2 : Int) : Int
   fun _open_osfhandle(osfhandle : HANDLE, flags : LibC::Int) : LibC::Int
-  fun _setmode(fd : LibC::Int, mode : LibC::Int) : LibC::Int
 
   # unused
   fun _write(fd : Int, buffer : UInt8*, count : UInt) : Int
@@ -21,4 +20,5 @@ lib LibC
   fun _chsize_s(fd : Int, size : Int64) : ErrnoT
   fun _pipe(pfds : Int*, psize : UInt, textmode : Int) : Int
   fun _commit(fd : Int) : Int
+  fun _setmode(fd : LibC::Int, mode : LibC::Int) : LibC::Int
 end


### PR DESCRIPTION
Reverts #13397.

Binary / text mode is only a concept in C, not Win32; since we have switched from `_read` / `_write` to `ReadFile` / `WriteFile` even for blocking operations, it should be safe to drop the use of `_setmode` entirely.