### PR TITLE
Implement `IO#tty?` in Win32

### DIFF
--- a/src/crystal/system/win32/file_descriptor.cr
+++ b/src/crystal/system/win32/file_descriptor.cr
@@ -148,7 +148,7 @@ module Crystal::System::FileDescriptor
   end
 
   private def system_tty?
-    LibC._isatty(fd) != 0
+    LibC.GetFileType(windows_handle) == LibC::FILE_TYPE_CHAR
   end
 
   private def system_reopen(other : IO::FileDescriptor)

--- a/src/crystal/system/win32/socket.cr
+++ b/src/crystal/system/win32/socket.cr
@@ -442,7 +442,7 @@ module Crystal::System::Socket
   end
 
   private def system_tty?
-    false
+    LibC.GetFileType(LibC::HANDLE.new(fd)) == LibC::FILE_TYPE_CHAR
   end
 
   private def unbuffered_read(slice : Bytes) : Int32


### PR DESCRIPTION
Originally `Socket#tty?` was made to return false because `LibC._isatty` requires a C file descriptor and we didn't want to transfer handle ownership from Win32 to the CRT. This is no longer true.