### PR TITLE
Fix `Pointer#+(offset: Int64)` doc parameter name typo

### DIFF
--- a/src/primitives.cr
+++ b/src/primitives.cr
@@ -282,7 +282,7 @@ struct Pointer(T)
   end
 
   # Returns a new pointer whose address is this pointer's address
-  # incremented by `other * sizeof(T)`.
+  # incremented by `offset * sizeof(T)`.
   #
   # ```
   # ptr = Pointer(Int32).new(1234)


### PR DESCRIPTION
The `Pointer#+(offset: Int64)` comments refer to the wrong input parameter name `other`, fixed to correctly refer to `offset` instead.