### PR TITLE
Fix interpreter internal overflow for `UInt128#to_f32` and `#to_f32!`

### DIFF
--- a/spec/primitives/int_spec.cr
+++ b/spec/primitives/int_spec.cr
@@ -137,4 +137,11 @@ describe "Primitives: Int" do
       expect_raises(OverflowError) { Float32::MAX.to_u128.succ.to_f32 } # Float32::MAX == 2 ** 128 - 2 ** 104
     end
   end
+
+  describe "#to_f!" do
+    it "doesn't raise on overflow for UInt128#to_f32" do
+      UInt128::MAX.to_f32!.should eq(Float32::INFINITY)
+      Float32::MAX.to_u128.succ.to_f32!.should eq(Float32::MAX)
+    end
+  end
 end

--- a/src/compiler/crystal/interpreter/instructions.cr
+++ b/src/compiler/crystal/interpreter/instructions.cr
@@ -278,6 +278,7 @@ require "./repl"
       u128_to_f32: {
         pop_values: [value : UInt128],
         push:       true,
+        overflow:   true,
         code:       value.to_f32,
       },
       u128_to_f64: {

--- a/src/compiler/crystal/interpreter/instructions.cr
+++ b/src/compiler/crystal/interpreter/instructions.cr
@@ -286,6 +286,11 @@ require "./repl"
         push:       true,
         code:       value.to_f64,
       },
+      u128_to_f32_bang: {
+        pop_values: [value : UInt128],
+        push:       true,
+        code:       value.to_f32!,
+      },
       f32_to_f64: {
         pop_values: [value : Float32],
         push:       true,

--- a/src/compiler/crystal/interpreter/primitives.cr
+++ b/src/compiler/crystal/interpreter/primitives.cr
@@ -815,7 +815,7 @@ class Crystal::Repl::Compiler
     in {.u128?, .u32?}  then checked ? u128_to_u32(node: node) : pop(8, node: node)
     in {.u128?, .u64?}  then checked ? u128_to_u64(node: node) : pop(8, node: node)
     in {.u128?, .u128?} then nop
-    in {.u128?, .f32?}  then u128_to_f32(node: node)
+    in {.u128?, .f32?}  then checked ? u128_to_f32(node: node) : u128_to_f32_bang(node: node)
     in {.u128?, .f64?}  then u128_to_f64(node: node)
     in {.f32?, .i8?}    then f32_to_f64(node: node); checked ? f64_to_i8(node: node) : f64_to_i64_bang(node: node)
     in {.f32?, .i16?}   then f32_to_f64(node: node); checked ? f64_to_i16(node: node) : f64_to_i64_bang(node: node)


### PR DESCRIPTION
Makes code like `UInt128::MAX.to_f32` raise `OverflowError` in the interpreted code, not in the interpreter itself. Also makes `UInt128::MAX.to_f32!` not raise any `OverflowError`.

This was discovered by running `spec/primitives/int_spec.cr` with the interpreter.