### PR TITLE
Do not remove the whitespace in `foo ()` when formatting

### DIFF
--- a/spec/compiler/formatter/formatter_spec.cr
+++ b/spec/compiler/formatter/formatter_spec.cr
@@ -1837,6 +1837,8 @@ describe Crystal::Formatter do
   assert_format "foo (1; 2)"
   assert_format "foo ((1) ? 2 : 3)", "foo((1) ? 2 : 3)"
   assert_format "foo((1..3))"
+  assert_format "foo ()"
+  assert_format "foo ( )", "foo ()"
   assert_format "def foo(\n\n#foo\nx,\n\n#bar\nz\n)\nend", "def foo(\n  # foo\n  x,\n\n  # bar\n  z\n)\nend"
   assert_format "def foo(\nx, #foo\nz #bar\n)\nend", "def foo(\n  x, # foo\n  z  # bar\n)\nend"
   assert_format "a = 1;;; b = 2", "a = 1; b = 2"

--- a/src/compiler/crystal/tools/formatter.cr
+++ b/src/compiler/crystal/tools/formatter.cr
@@ -2774,8 +2774,13 @@ module Crystal
          !node.named_args && !node.block_arg && !node.block &&
          (expressions = node.args[0].as?(Expressions)) &&
          expressions.keyword.paren? && expressions.expressions.size == 1
-        skip_space
-        node.args[0] = expressions.expressions[0]
+        # ...except do not transform `foo ()` into `foo()`, as the former is
+        # actually semantically equivalent to `foo(nil)`
+        arg = expressions.expressions[0]
+        unless arg.is_a?(Nop)
+          skip_space
+          node.args[0] = arg
+        end
       end
 
       if @token.type.op_lparen?


### PR DESCRIPTION
Fixes #14418.