### PR TITLE
Add `Program#size_t` and `Target#size_bit_width`

### DIFF
--- a/src/compiler/crystal/codegen/call.cr
+++ b/src/compiler/crystal/codegen/call.cr
@@ -239,9 +239,8 @@ class Crystal::CodeGenVisitor
       final_value_casted = cast_to_void_pointer final_value
       gep_call_arg = cast_to_void_pointer gep(llvm_type(call_arg_type), call_arg, 0, 0)
       size = @abi.size(abi_arg_type.type)
-      size = @program.bits64? ? int64(size) : int32(size)
       align = @abi.align(abi_arg_type.type)
-      memcpy(final_value_casted, gep_call_arg, size, align, int1(0))
+      memcpy(final_value_casted, gep_call_arg, size_t(size), align, int1(0))
       call_arg = load cast, final_value
     else
       # Keep same call arg
@@ -256,9 +255,8 @@ class Crystal::CodeGenVisitor
     final_value_casted = cast_to_void_pointer final_value
     call_arg_casted = cast_to_void_pointer call_arg
     size = @abi.size(abi_arg_type.type)
-    size = @program.bits64? ? int64(size) : int32(size)
     align = @abi.align(abi_arg_type.type)
-    memcpy(final_value_casted, call_arg_casted, size, align, int1(0))
+    memcpy(final_value_casted, call_arg_casted, size_t(size), align, int1(0))
     final_value
   end
 
@@ -532,9 +530,8 @@ class Crystal::CodeGenVisitor
             final_value = alloca abi_return.type
             final_value_casted = cast_to_void_pointer final_value
             size = @abi.size(abi_return.type)
-            size = @program.@program.bits64? ? int64(size) : int32(size)
             align = @abi.align(abi_return.type)
-            memcpy(final_value_casted, cast2, size, align, int1(0))
+            memcpy(final_value_casted, cast2, size_t(size), align, int1(0))
             @last = final_value
           end
         in .indirect?

--- a/src/compiler/crystal/codegen/llvm_builder_helper.cr
+++ b/src/compiler/crystal/codegen/llvm_builder_helper.cr
@@ -44,10 +44,8 @@ module Crystal
         value
       when .positive?
         builder.trunc(value, size_t)
-      when .negative?
-        builder.zext(value, size_t)
       else
-        raise "unreachable"
+        builder.zext(value, size_t)
       end
     end
 

--- a/src/compiler/crystal/codegen/llvm_builder_helper.cr
+++ b/src/compiler/crystal/codegen/llvm_builder_helper.cr
@@ -30,6 +30,27 @@ module Crystal
       int32(n)
     end
 
+    def size_t
+      llvm_context.int(@program.size_bit_width)
+    end
+
+    def size_t(n)
+      size_t.const_int(n)
+    end
+
+    def size_t(value : LLVM::Value)
+      case value.type.int_width <=> @program.size_bit_width
+      when .zero?
+        value
+      when .positive?
+        builder.trunc(value, size_t)
+      when .negative?
+        builder.zext(value, size_t)
+      else
+        raise "unreachable"
+      end
+    end
+
     def int(n, type)
       llvm_type(type).const_int(n)
     end

--- a/src/compiler/crystal/codegen/llvm_typer.cr
+++ b/src/compiler/crystal/codegen/llvm_typer.cr
@@ -586,11 +586,7 @@ module Crystal
     end
 
     def size_t
-      if @program.bits64?
-        @llvm_context.int64
-      else
-        @llvm_context.int32
-      end
+      @llvm_context.int(@program.size_bit_width)
     end
 
     @pointer_size : UInt64?

--- a/src/compiler/crystal/codegen/target.cr
+++ b/src/compiler/crystal/codegen/target.cr
@@ -58,6 +58,17 @@ class Crystal::Codegen::Target
     end
   end
 
+  def size_bit_width
+    case @architecture
+    when "aarch64", "x86_64"
+      64
+    when "arm", "i386", "wasm32"
+      32
+    else
+      raise "BUG: unknown Target#size_bit_width for #{@architecture} target architecture"
+    end
+  end
+
   def os_name
     case self
     when .macos?

--- a/src/compiler/crystal/codegen/unions.cr
+++ b/src/compiler/crystal/codegen/unions.cr
@@ -122,11 +122,10 @@ module Crystal
         @llvm_typer.size_of(from_value_type),
         @llvm_typer.size_of(to_value_type),
       }.min
-      size = @program.bits64? ? int64(size) : int32(size)
       memcpy(
         cast_to_void_pointer(union_value(to_llvm_type, union_pointer)),
         cast_to_void_pointer(union_value(from_llvm_type, value)),
-        size,
+        size_t(size),
         align: @llvm_typer.align_of(to_value_type),
         src_align: @llvm_typer.align_of(from_value_type),
         volatile: int1(0),

--- a/src/compiler/crystal/semantic/flags.cr
+++ b/src/compiler/crystal/semantic/flags.cr
@@ -25,6 +25,10 @@ class Crystal::Program
     codegen_target.pointer_bit_width == 64
   end
 
+  def size_bit_width
+    codegen_target.size_bit_width
+  end
+
   private def flags_for_target(target)
     flags = Set(String).new
 


### PR DESCRIPTION
Abstracts the underlying size integers depending on the target's size bit width (64, 32 or even 16-bits for AVR), instead of hardcoding checks for 64 or 32-bits only in different places. Each target can now define its actual `size_t`, and the codegen call the `#size_t` helpers to cast a size to the arch dependent size.

For example [AVR](https://github.com/crystal-lang/crystal/pull/14393) won't need to change the codegen classes, only the target definition.

This is an internal refactor to the compiler, only used when it needs to call external functions (`malloc`, `realloc`) or LLVM intrinsics (e.g. `memset`, `memcpy`). It could eventually be used to have arch-dependent `__crystal_*` functions, though.