### PR TITLE
Use wrapping arithmetic for `Int::Primitive#unsafe_chr`

### DIFF
--- a/spec/primitives/int_spec.cr
+++ b/spec/primitives/int_spec.cr
@@ -131,6 +131,13 @@ describe "Primitives: Int" do
     end
   end
 
+  describe "#unsafe_chr" do
+    it "doesn't raise on overflow" do
+      (0x41_i64 - 0x100000000_i64).unsafe_chr.should eq('A')
+      0xFFFF_FFFF_0010_FFFF_u64.unsafe_chr.should eq('\u{10FFFF}')
+    end
+  end
+
   describe "#to_f" do
     it "raises on overflow for UInt128#to_f32" do
       expect_raises(OverflowError) { UInt128::MAX.to_f32 }

--- a/src/primitives.cr
+++ b/src/primitives.cr
@@ -406,7 +406,8 @@ end
     struct {{int.id}}
       # Returns a `Char` that has the unicode codepoint of `self`,
       # without checking if this integer is in the range valid for
-      # chars (`0..0xd7ff` and `0xe000..0x10ffff`).
+      # chars (`0..0xd7ff` and `0xe000..0x10ffff`). In case of overflow
+      # a wrapping is performed.
       #
       # You should never use this method unless `chr` turns out to
       # be a bottleneck.
@@ -414,7 +415,7 @@ end
       # ```
       # 97.unsafe_chr # => 'a'
       # ```
-      @[::Primitive(:convert)]
+      @[::Primitive(:unchecked_convert)]
       def unsafe_chr : Char
       end
 


### PR DESCRIPTION
Resolves #14017.