### PR TITLE
Use separate names for constant and class variable internals

### DIFF
--- a/spec/compiler/codegen/class_var_spec.cr
+++ b/spec/compiler/codegen/class_var_spec.cr
@@ -564,6 +564,19 @@ describe "Codegen: class var" do
     mod.to_s.should_not contain("x:init")
   end
 
+  it "doesn't error if class var shares name with const (#7865)" do
+    run(<<-CRYSTAL).to_string.should eq("asdfgh")
+      require "prelude"
+
+      class Pattern
+        @@A = "asdf"
+        A = "\#{@@A}gh"
+      end
+
+      Pattern::A
+      CRYSTAL
+  end
+
   it "catch infinite loop in class var initializer" do
     run(%(
       require "prelude"

--- a/spec/llvm-ir/const-read-debug-loc.cr
+++ b/spec/llvm-ir/const-read-debug-loc.cr
@@ -10,7 +10,7 @@ def a_foo
 end
 
 THE_FOO.foo
-# CHECK:      call %Foo** @"~THE_FOO:read"()
+# CHECK:      call %Foo** @"~THE_FOO:const_read"()
 # CHECK-SAME: !dbg [[LOC:![0-9]+]]
 # CHECK:      [[LOC]] = !DILocation
 # CHECK-SAME: line: 12

--- a/src/compiler/crystal/codegen/const.cr
+++ b/src/compiler/crystal/codegen/const.cr
@@ -222,7 +222,7 @@ class Crystal::CodeGenVisitor
       return global
     end
 
-    read_function_name = "~#{const.llvm_name}:read"
+    read_function_name = "~#{const.llvm_name}:const_read"
     func = typed_fun?(@main_mod, read_function_name) || create_read_const_function(read_function_name, const)
     func = check_main_fun read_function_name, func
     call func

--- a/src/compiler/crystal/codegen/types.cr
+++ b/src/compiler/crystal/codegen/types.cr
@@ -185,7 +185,7 @@ module Crystal
     property? no_init_flag = false
 
     def initialized_llvm_name
-      "#{llvm_name}:init"
+      "#{llvm_name}:const_init"
     end
 
     # Returns `true` if this constant's value is a simple literal, like


### PR DESCRIPTION
Fixes #7865. Does not affect #14093.