### PR TITLE
Ensure `Enumerable#to_a` and `Enumerable#tally` properly retain return type of `T`

### DIFF
--- a/spec/std/enumerable_spec.cr
+++ b/spec/std/enumerable_spec.cr
@@ -1,6 +1,27 @@
 require "spec"
 require "spec/helpers/iterate"
 
+module SomeInterface; end
+
+private record One do
+  include SomeInterface
+end
+
+private record Two do
+  include SomeInterface
+end
+
+private struct InterfaceEnumerable(T)
+  include Enumerable(T)
+
+  @values = [One.new, Two.new]
+
+  def each(&)
+    yield @values[0]
+    yield @values[1]
+  end
+end
+
 private class SpecEnumerable
   include Enumerable(Int32)
 
@@ -132,12 +153,16 @@ describe "Enumerable" do
   end
 
   describe "to_a" do
-    context "with a block" do
+    it "with a block" do
       SpecEnumerable.new.to_a { |e| e*2 }.should eq [2, 4, 6]
     end
 
-    context "without a block" do
+    it "without a block" do
       SpecEnumerable.new.to_a.should eq [1, 2, 3]
+    end
+
+    it "without a block of an interface type" do
+      InterfaceEnumerable(SomeInterface).new.to_a.should eq [One.new, Two.new]
     end
   end
 

--- a/spec/std/enumerable_spec.cr
+++ b/spec/std/enumerable_spec.cr
@@ -11,14 +11,12 @@ private record Two do
   include SomeInterface
 end
 
-private struct InterfaceEnumerable(T)
-  include Enumerable(T)
-
-  @values = [One.new, Two.new]
+private struct InterfaceEnumerable
+  include Enumerable(SomeInterface)
 
   def each(&)
-    yield @values[0]
-    yield @values[1]
+    yield One.new
+    yield Two.new
   end
 end
 
@@ -162,7 +160,7 @@ describe "Enumerable" do
     end
 
     it "without a block of an interface type" do
-      InterfaceEnumerable(SomeInterface).new.to_a.should eq [One.new, Two.new]
+      InterfaceEnumerable.new.to_a.should eq [One.new, Two.new]
     end
   end
 

--- a/spec/std/enumerable_spec.cr
+++ b/spec/std/enumerable_spec.cr
@@ -1479,6 +1479,10 @@ describe "Enumerable" do
           {'c' => 1, 'r' => 2, 'y' => 2, 's' => 1, 't' => 1, 'a' => 1, 'l' => 1, 'u' => 1, 'b' => 1}
         )
       end
+
+      it "tallies an interface type" do
+        InterfaceEnumerable.new.tally.should eq({One.new => 1, Two.new => 1})
+      end
     end
   end
 

--- a/spec/std/indexable_spec.cr
+++ b/spec/std/indexable_spec.cr
@@ -1,27 +1,27 @@
 require "spec"
 require "spec/helpers/iterate"
 
-module SomeInterface; end
+module OtherInterface; end
 
-private record One do
-  include SomeInterface
+private record Three do
+  include OtherInterface
 end
 
-private record Two do
-  include SomeInterface
+private record Four do
+  include OtherInterface
 end
 
 private struct InterfaceIndexable
-  include Indexable(SomeInterface)
+  include Indexable(OtherInterface)
 
   def size
     2
   end
 
-  def unsafe_fetch(index : Int) : SomeInterface
+  def unsafe_fetch(index : Int) : OtherInterface
     case index
-    when 0 then One.new
-    when 1 then Two.new
+    when 0 then Three.new
+    when 1 then Four.new
     else
       raise ""
     end
@@ -848,7 +848,7 @@ describe Indexable do
 
   describe "#to_a" do
     it "without a block of an interface type" do
-      InterfaceIndexable.new.to_a.should eq [One.new, Two.new]
+      InterfaceIndexable.new.to_a.should eq [Three.new, Four.new]
     end
   end
 end

--- a/spec/std/indexable_spec.cr
+++ b/spec/std/indexable_spec.cr
@@ -1,6 +1,35 @@
 require "spec"
 require "spec/helpers/iterate"
 
+module SomeInterface; end
+
+private record One do
+  include SomeInterface
+end
+
+private record Two do
+  include SomeInterface
+end
+
+private struct InterfaceIndexable(T, S)
+  include Indexable(T)
+
+  @values = [One.new, Two.new]
+
+  def size : Int32
+    S
+  end
+
+  def unsafe_fetch(index : Int) : T
+    case index
+    when 0 then @values[0]
+    when 1 then @values[1]
+    else
+      raise ""
+    end
+  end
+end
+
 private class SafeIndexable
   include Indexable(Int32)
 
@@ -816,6 +845,12 @@ describe Indexable do
     describe "n > size (#14088)" do
       it_iterates "#each_repeated_combination", [[1, 1, 1], [1, 1, 2], [1, 2, 2], [2, 2, 2]], SafeIndexable.new(2, 1).each_repeated_combination(3)
       it_iterates "#each_repeated_combination", [[1, 1, 1, 1], [1, 1, 1, 2], [1, 1, 2, 2], [1, 2, 2, 2], [2, 2, 2, 2]], SafeIndexable.new(2, 1).each_repeated_combination(4)
+    end
+  end
+
+  describe "#to_a" do
+    it "without a block of an interface type" do
+      InterfaceIndexable(SomeInterface, 2).new.to_a.should eq [One.new, Two.new]
     end
   end
 end

--- a/spec/std/indexable_spec.cr
+++ b/spec/std/indexable_spec.cr
@@ -11,19 +11,17 @@ private record Two do
   include SomeInterface
 end
 
-private struct InterfaceIndexable(T, S)
-  include Indexable(T)
+private struct InterfaceIndexable
+  include Indexable(SomeInterface)
 
-  @values = [One.new, Two.new]
-
-  def size : Int32
-    S
+  def size
+    2
   end
 
-  def unsafe_fetch(index : Int) : T
+  def unsafe_fetch(index : Int) : SomeInterface
     case index
-    when 0 then @values[0]
-    when 1 then @values[1]
+    when 0 then One.new
+    when 1 then Two.new
     else
       raise ""
     end
@@ -850,7 +848,7 @@ describe Indexable do
 
   describe "#to_a" do
     it "without a block of an interface type" do
-      InterfaceIndexable(SomeInterface, 2).new.to_a.should eq [One.new, Two.new]
+      InterfaceIndexable.new.to_a.should eq [One.new, Two.new]
     end
   end
 end

--- a/src/enumerable.cr
+++ b/src/enumerable.cr
@@ -1994,7 +1994,9 @@ module Enumerable(T)
   # (1..5).to_a # => [1, 2, 3, 4, 5]
   # ```
   def to_a : Array(T)
-    to_a(&.itself)
+    ary = [] of T
+    each { |e| ary << e }
+    ary
   end
 
   # Returns an `Array` with the results of running *block* against each element of the collection.

--- a/src/enumerable.cr
+++ b/src/enumerable.cr
@@ -1970,7 +1970,7 @@ module Enumerable(T)
   # ["a", "b", "c", "b"].tally # => {"a"=>1, "b"=>2, "c"=>1}
   # ```
   def tally : Hash(T, Int32)
-    tally_by(&.itself)
+    tally_by(Hash(T, Int32).new, &.itself)
   end
 
   # Tallies the collection. Accepts a *hash* to count occurrences.

--- a/src/indexable.cr
+++ b/src/indexable.cr
@@ -693,6 +693,17 @@ module Indexable(T)
     end
   end
 
+  # Returns an `Array` with all the elements in the collection.
+  #
+  # ```
+  # {1, 2, 3}.to_a # => [1, 2, 3]
+  # ```
+  def to_a : Array(T)
+    ary = Array(T).new(size)
+    each { |e| ary << e }
+    ary
+  end
+
   # Returns an `Array` with the results of running *block* against each element of the collection.
   #
   # ```


### PR DESCRIPTION
Fixes #14440