### PR TITLE
Add the `CTypes` module for common C type aliases

### DIFF
--- a/src/c_types.cr
+++ b/src/c_types.cr
@@ -1,0 +1,150 @@
+# This module exposes the various common platform-dependent arithmetic types
+# from the C language, to be used in lib bindings.
+#
+# For convenience, libs can import types from this module using aliases, so that
+# the types can be used inside the lib without fully qualified paths:
+#
+# ```
+# lib LibFoo
+#   alias Int = CTypes::Int
+#
+#   fun foo(x : Int) : Int     # okay
+#   fun bar(x : CTypes::Char*) # okay
+# end
+# ```
+module CTypes
+  {% unless flag?(:bits32) || flag?(:bits64) %}
+    {% if target = Crystal.constant("TARGET_TRIPLE") %}
+      {% raise "Unsupported target: #{target.id}" %}
+    {% else %}
+      # this is for old compilers that attempt to directly use a newer stdlib
+      # for cross-compilation
+      {% raise "Architecture with unsupported word size" %}
+    {% end %}
+  {% end %}
+
+  # The C `char` type.
+  #
+  # Guaranteed to have at least 8 bits. Equivalent to `UInt8` on all currently
+  # supported targets.
+  alias Char = UInt8
+
+  # The C `signed char` type.
+  #
+  # Guaranteed to have at least 8 bits. Equivalent to `Int8` on all currently
+  # supported targets.
+  alias SChar = Int8
+
+  # The C `unsigned char` type.
+  #
+  # Guaranteed to have at least 8 bits. Equivalent to `UInt8` on all currently
+  # supported targets.
+  alias UChar = UInt8
+
+  # The C `short` type.
+  #
+  # Guaranteed to have at least 16 bits. Equivalent to `Int16` on all currently
+  # supported targets.
+  alias Short = Int16
+
+  # The C `unsigned short` type.
+  #
+  # Guaranteed to have at least 16 bits. Equivalent to `UInt16` on all currently
+  # supported targets.
+  alias UShort = UInt16
+
+  # The C `int` type.
+  #
+  # Guaranteed to have at least 16 bits. Equivalent to `Int32` on all currently
+  # supported targets.
+  alias Int = Int32
+
+  # The C `unsigned int` type.
+  #
+  # Guaranteed to have at least 16 bits. Equivalent to `UInt32` on all currently
+  # supported targets.
+  alias UInt = UInt32
+
+  # The C `long` type.
+  #
+  # Guaranteed to have at least 32 bits. Equivalent to `Int32` on Windows and
+  # on 32-bit targets. Equivalent to `Int64` on 64-bit, non-Windows targets.
+  {% if flag?(:bits32) || flag?(:win32) %}
+    alias Long = Int32
+  {% elsif flag?(:bits64) %}
+    alias Long = Int64
+  {% end %}
+
+  # The C `unsigned long` type.
+  #
+  # Guaranteed to have at least 32 bits. Equivalent to `UInt32` on Windows and
+  # on 32-bit targets. Equivalent to `UInt64` on 64-bit, non-Windows targets.
+  {% if flag?(:bits32) || flag?(:win32) %}
+    alias ULong = UInt32
+  {% elsif flag?(:bits64) %}
+    alias ULong = UInt64
+  {% end %}
+
+  # The C `long long` type.
+  #
+  # Guaranteed to have at least 64 bits. Equivalent to `Int64` on all currently
+  # supported targets.
+  alias LongLong = Int64
+
+  # The C `unsigned long long` type.
+  #
+  # Guaranteed to have at least 64 bits. Equivalent to `UInt64` on all currently
+  # supported targets.
+  alias ULongLong = UInt64
+
+  # The C `float` type.
+  #
+  # Equivalent to `Float32` on all currently supported targets.
+  alias Float = Float32
+
+  # The C `double` type.
+  #
+  # Equivalent to `Float64` on all currently supported targets.
+  alias Double = Float64
+
+  # The C `intptr_t` type.
+  #
+  # Large enough to hold the value of `Pointer#address`. Equivalent to `Int32`
+  # on 32-bit targets, `Int64` on 64-bit targets.
+  {% if flag?(:bits32) %}
+    alias IntPtrT = Int32
+  {% elsif flag?(:bits64) %}
+    alias IntPtrT = Int64
+  {% end %}
+
+  # The C `uintptr_t` type.
+  #
+  # Large enough to hold the value of `Pointer#address`. Equivalent to `UInt32`
+  # on 32-bit targets, `UInt64` on 64-bit targets.
+  {% if flag?(:bits32) %}
+    alias UIntPtrT = UInt32
+  {% elsif flag?(:bits64) %}
+    alias UIntPtrT = UInt64
+  {% end %}
+
+  # The C `size_t` type.
+  #
+  # Guaranteed to have at least 16 bits. Equivalent to `UInt32` on 32-bit
+  # targets, `UInt64` on 64-bit targets.
+  {% if flag?(:bits32) %}
+    alias SizeT = UInt32
+  {% elsif flag?(:bits64) %}
+    alias SizeT = UInt64
+  {% end %}
+
+  # The C `ptrdiff_t` type.
+  #
+  # Large enough to hold the value of `Pointer#-(Pointer)`. Guaranteed to have
+  # at least 17 bits. Equivalent to `Int32` on 32-bit targets, `Int64` on 64-bit
+  # targets.
+  {% if flag?(:bits32) %}
+    alias PtrDiffT = Int32
+  {% elsif flag?(:bits64) %}
+    alias PtrDiffT = Int64
+  {% end %}
+end

--- a/src/lib_c.cr
+++ b/src/lib_c.cr
@@ -1,29 +1,22 @@
+require "c_types"
+
 {% if flag?(:win32) %}
   @[Link({{ flag?(:static) ? "libucrt" : "ucrt" }})]
 {% end %}
 lib LibC
-  alias Char = UInt8
-  alias UChar = Char
-  alias SChar = Int8
-  alias Short = Int16
-  alias UShort = UInt16
-  alias Int = Int32
-  alias UInt = UInt32
-
-  {% if flag?(:bits32) || flag?(:win32) %}
-    alias Long = Int32
-    alias ULong = UInt32
-  {% elsif flag?(:bits64) %}
-    alias Long = Int64
-    alias ULong = UInt64
-  {% else %}
-    {% raise "Architecture with unsupported word size" %}
-  {% end %}
-
-  alias LongLong = Int64
-  alias ULongLong = UInt64
-  alias Float = Float32
-  alias Double = Float64
+  alias Char = CTypes::Char
+  alias UChar = CTypes::UChar
+  alias SChar = CTypes::SChar
+  alias Short = CTypes::Short
+  alias UShort = CTypes::UShort
+  alias Int = CTypes::Int
+  alias UInt = CTypes::UInt
+  alias Long = CTypes::Long
+  alias ULong = CTypes::ULong
+  alias LongLong = CTypes::LongLong
+  alias ULongLong = CTypes::ULongLong
+  alias Float = CTypes::Float
+  alias Double = CTypes::Double
 
   {% if flag?(:android) %}
     {% default_api_version = 31 %}

--- a/src/lib_c/aarch64-android/c/stddef.cr
+++ b/src/lib_c/aarch64-android/c/stddef.cr
@@ -1,3 +1,5 @@
+require "c_types"
+
 lib LibC
-  alias SizeT = ULong
+  alias SizeT = CTypes::SizeT
 end

--- a/src/lib_c/aarch64-darwin/c/stddef.cr
+++ b/src/lib_c/aarch64-darwin/c/stddef.cr
@@ -1,3 +1,5 @@
+require "c_types"
+
 lib LibC
-  alias SizeT = ULong
+  alias SizeT = CTypes::SizeT
 end

--- a/src/lib_c/aarch64-linux-gnu/c/stddef.cr
+++ b/src/lib_c/aarch64-linux-gnu/c/stddef.cr
@@ -1,3 +1,5 @@
+require "c_types"
+
 lib LibC
-  alias SizeT = ULong
+  alias SizeT = CTypes::SizeT
 end

--- a/src/lib_c/aarch64-linux-musl/c/stddef.cr
+++ b/src/lib_c/aarch64-linux-musl/c/stddef.cr
@@ -1,3 +1,5 @@
+require "c_types"
+
 lib LibC
-  alias SizeT = ULong
+  alias SizeT = CTypes::SizeT
 end

--- a/src/lib_c/arm-linux-gnueabihf/c/stddef.cr
+++ b/src/lib_c/arm-linux-gnueabihf/c/stddef.cr
@@ -1,3 +1,5 @@
+require "c_types"
+
 lib LibC
-  alias SizeT = UInt
+  alias SizeT = CTypes::SizeT
 end

--- a/src/lib_c/i386-linux-gnu/c/stddef.cr
+++ b/src/lib_c/i386-linux-gnu/c/stddef.cr
@@ -1,3 +1,5 @@
+require "c_types"
+
 lib LibC
-  alias SizeT = UInt
+  alias SizeT = CTypes::SizeT
 end

--- a/src/lib_c/i386-linux-musl/c/stddef.cr
+++ b/src/lib_c/i386-linux-musl/c/stddef.cr
@@ -1,3 +1,5 @@
+require "c_types"
+
 lib LibC
-  alias SizeT = UInt
+  alias SizeT = CTypes::SizeT
 end

--- a/src/lib_c/wasm32-wasi/c/stddef.cr
+++ b/src/lib_c/wasm32-wasi/c/stddef.cr
@@ -1,3 +1,5 @@
+require "c_types"
+
 lib LibC
-  alias SizeT = ULong
+  alias SizeT = CTypes::SizeT
 end

--- a/src/lib_c/x86_64-darwin/c/stddef.cr
+++ b/src/lib_c/x86_64-darwin/c/stddef.cr
@@ -1,3 +1,5 @@
+require "c_types"
+
 lib LibC
-  alias SizeT = ULong
+  alias SizeT = CTypes::SizeT
 end

--- a/src/lib_c/x86_64-dragonfly/c/stddef.cr
+++ b/src/lib_c/x86_64-dragonfly/c/stddef.cr
@@ -1,3 +1,5 @@
+require "c_types"
+
 lib LibC
-  alias SizeT = ULong
+  alias SizeT = CTypes::SizeT
 end

--- a/src/lib_c/x86_64-freebsd/c/stddef.cr
+++ b/src/lib_c/x86_64-freebsd/c/stddef.cr
@@ -1,3 +1,5 @@
+require "c_types"
+
 lib LibC
-  alias SizeT = ULong
+  alias SizeT = CTypes::SizeT
 end

--- a/src/lib_c/x86_64-linux-gnu/c/stddef.cr
+++ b/src/lib_c/x86_64-linux-gnu/c/stddef.cr
@@ -1,3 +1,5 @@
+require "c_types"
+
 lib LibC
-  alias SizeT = ULong
+  alias SizeT = CTypes::SizeT
 end

--- a/src/lib_c/x86_64-linux-musl/c/stddef.cr
+++ b/src/lib_c/x86_64-linux-musl/c/stddef.cr
@@ -1,3 +1,5 @@
+require "c_types"
+
 lib LibC
-  alias SizeT = ULong
+  alias SizeT = CTypes::SizeT
 end

--- a/src/lib_c/x86_64-netbsd/c/stddef.cr
+++ b/src/lib_c/x86_64-netbsd/c/stddef.cr
@@ -1,3 +1,5 @@
+require "c_types"
+
 lib LibC
-  alias SizeT = ULong
+  alias SizeT = CTypes::SizeT
 end

--- a/src/lib_c/x86_64-openbsd/c/stddef.cr
+++ b/src/lib_c/x86_64-openbsd/c/stddef.cr
@@ -1,3 +1,5 @@
+require "c_types"
+
 lib LibC
-  alias SizeT = ULong
+  alias SizeT = CTypes::SizeT
 end

--- a/src/lib_c/x86_64-solaris/c/stddef.cr
+++ b/src/lib_c/x86_64-solaris/c/stddef.cr
@@ -1,3 +1,5 @@
+require "c_types"
+
 lib LibC
-  alias SizeT = ULong
+  alias SizeT = CTypes::SizeT
 end

--- a/src/lib_c/x86_64-windows-msvc/c/stddef.cr
+++ b/src/lib_c/x86_64-windows-msvc/c/stddef.cr
@@ -1,3 +1,5 @@
+require "c_types"
+
 lib LibC
-  alias SizeT = UInt64
+  alias SizeT = CTypes::SizeT
 end

--- a/src/lib_c/x86_64-windows-msvc/c/stdint.cr
+++ b/src/lib_c/x86_64-windows-msvc/c/stdint.cr
@@ -1,4 +1,6 @@
+require "c_types"
+
 lib LibC
-  alias IntPtrT = Int64
-  alias UIntPtrT = UInt64
+  alias IntPtrT = CTypes::IntPtrT
+  alias UIntPtrT = CTypes::UIntPtrT
 end


### PR DESCRIPTION
See https://github.com/crystal-lang/crystal/issues/13504#issuecomment-1752989906.