### PR TITLE
Update distribution-scripts

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,7 +8,7 @@ parameters:
   distribution-scripts-version:
     description: "Git ref for version of https://github.com/crystal-lang/distribution-scripts/"
     type: string
-    default: "535aedb8b09d77caaa1583700f371cd04343b7e8"
+    default: "46c295d14e4dc3f6b7d9598c0b4dd89e93232def"
   previous_crystal_base_url:
     description: "Prefix for URLs to Crystal bootstrap compiler"
     type: string


### PR DESCRIPTION
Updates `distribution-scripts` dependency to https://github.com/crystal-lang/distribution-scripts/commit/46c295d14e4dc3f6b7d9598c0b4dd89e93232def

This includes the following changes:

* crystal-lang/distribution-scripts#296
* crystal-lang/distribution-scripts#297
* crystal-lang/distribution-scripts#294
* crystal-lang/distribution-scripts#291
* crystal-lang/distribution-scripts#274
* crystal-lang/distribution-scripts#286
* crystal-lang/distribution-scripts#281
* crystal-lang/distribution-scripts#270
* crystal-lang/distribution-scripts#263
* crystal-lang/distribution-scripts#273
