### PR TITLE
Make `String#sub` raise `IndexError` if index is equal to size

### DIFF
--- a/spec/std/string_spec.cr
+++ b/spec/std/string_spec.cr
@@ -1694,6 +1694,18 @@ describe "String" do
       "あいうえお".sub(2, "けくこ").should eq("あいけくこえお")
     end
 
+    it "raises if index is out of bounds" do
+      expect_raises(IndexError) { "hello".sub(5, 'x') }
+      expect_raises(IndexError) { "hello".sub(6, "") }
+      expect_raises(IndexError) { "hello".sub(-6, 'x') }
+      expect_raises(IndexError) { "hello".sub(-7, "") }
+
+      expect_raises(IndexError) { "あいうえお".sub(5, 'x') }
+      expect_raises(IndexError) { "あいうえお".sub(6, "") }
+      expect_raises(IndexError) { "あいうえお".sub(-6, 'x') }
+      expect_raises(IndexError) { "あいうえお".sub(-7, "") }
+    end
+
     it "subs range with char" do
       "hello".sub(1..2, 'a').should eq("halo")
     end

--- a/src/string.cr
+++ b/src/string.cr
@@ -2536,7 +2536,7 @@ class String
     index += size if index < 0
 
     byte_index = char_index_to_byte_index(index)
-    raise IndexError.new unless byte_index
+    raise IndexError.new unless byte_index && byte_index < bytesize
 
     width = char_bytesize_at(byte_index)
     replacement_width = replacement.bytesize


### PR DESCRIPTION
Previously this would raise `Negative count (ArgumentError)` instead, unlike any other out-of-bound index.