### PR TITLE
Support `UInt32` and `UInt64` in Log Context

### DIFF
--- a/spec/std/log/log_spec.cr
+++ b/spec/std/log/log_spec.cr
@@ -129,6 +129,12 @@ describe Log do
     Log.context.metadata.should eq(Log::Metadata.build({a: 1, b: 2}))
   end
 
+  it "context supports unsigned values" do
+    Log.context.set a: 1_u32, b: 2_u64
+
+    Log.context.metadata.should eq(Log::Metadata.build({a: 1_u32, b: 2_u64}))
+  end
+
   describe "emitter dsl" do
     it "can be used with message" do
       backend = Log::MemoryBackend.new

--- a/src/log/metadata.cr
+++ b/src/log/metadata.cr
@@ -199,7 +199,7 @@ class Log::Metadata
   end
 
   struct Value
-    Crystal.datum types: {nil: Nil, bool: Bool, i: Int32, i64: Int64, f: Float32, f64: Float64, s: String, time: Time}, hash_key_type: String, immutable: false, target_type: Log::Metadata::Value
+    Crystal.datum types: {nil: Nil, bool: Bool, i: Int32, i64: Int64, u: UInt32, u64: UInt64, f: Float32, f64: Float64, s: String, time: Time}, hash_key_type: String, immutable: false, target_type: Log::Metadata::Value
 
     # Creates `Log::Metadata` from the given *values*.
     # All keys are converted to `String`


### PR DESCRIPTION
This PR adds support for `UInt32` and `UInt64` values in the `Log` context.

I often want to add a request id to every log message in an HTTP request handler. The reasonable solution is something like:
```
Log.context.set request_id: request.object_id
```
But this doesn't work, because `object_id` is a `UInt64` and isn't supported in a log context (see [here](https://play.crystal-lang.org/#/r/gnbs) and [here](https://play.crystal-lang.org/#/r/gnbu)).

For consistency with other supported primitive values, this PR adds support for `UInt32` and `UInt64`. It doesn't add support for all of the other primitive and value types. (I can be persuaded, but the supported set will never realistically be exhaustive.)