### PR TITLE
Optimize `String#index(Char)` and `#rindex(Char)` for invalid UTF-8

### DIFF
--- a/src/string.cr
+++ b/src/string.cr
@@ -3450,7 +3450,11 @@ class String
   def rindex(search : Char, offset = size - 1)
     # If it's ASCII we can delegate to slice
     if single_byte_optimizable?
-      return search.ascii? ? to_slice.rindex(search.ord.to_u8, offset) : nil
+      # With `single_byte_optimizable?` there are only ASCII characters and invalid UTF-8 byte
+      # sequences and we can immediately reject any non-ASCII codepoint.
+      return unless search.ascii?
+      
+      return to_slice.fast_rindex(search.ord.to_u8, offset)
     end
 
     offset += size if offset < 0

--- a/src/string.cr
+++ b/src/string.cr
@@ -3335,7 +3335,11 @@ class String
   def index(search : Char, offset = 0) : Int32?
     # If it's ASCII we can delegate to slice
     if single_byte_optimizable?
-      return search.ascii? ? to_slice.fast_index(search.ord.to_u8, offset) : nil
+      # With `single_byte_optimizable?` there are only ASCII characters and invalid UTF-8 byte
+      # sequences and we can immediately reject any non-ASCII codepoint.
+      return unless search.ascii?
+      
+      return to_slice.fast_index(search.ord.to_u8, offset)
     end
 
     offset += size if offset < 0

--- a/src/string.cr
+++ b/src/string.cr
@@ -3338,7 +3338,7 @@ class String
       # With `single_byte_optimizable?` there are only ASCII characters and invalid UTF-8 byte
       # sequences and we can immediately reject any non-ASCII codepoint.
       return unless search.ascii?
-      
+
       return to_slice.fast_index(search.ord.to_u8, offset)
     end
 
@@ -3453,7 +3453,7 @@ class String
       # With `single_byte_optimizable?` there are only ASCII characters and invalid UTF-8 byte
       # sequences and we can immediately reject any non-ASCII codepoint.
       return unless search.ascii?
-      
+
       return to_slice.rindex(search.ord.to_u8, offset)
     end
 

--- a/src/string.cr
+++ b/src/string.cr
@@ -3454,7 +3454,7 @@ class String
       # sequences and we can immediately reject any non-ASCII codepoint.
       return unless search.ascii?
       
-      return to_slice.fast_rindex(search.ord.to_u8, offset)
+      return to_slice.rindex(search.ord.to_u8, offset)
     end
 
     offset += size if offset < 0

--- a/src/string.cr
+++ b/src/string.cr
@@ -3334,8 +3334,8 @@ class String
   # ```
   def index(search : Char, offset = 0) : Int32?
     # If it's ASCII we can delegate to slice
-    if search.ascii? && single_byte_optimizable?
-      return to_slice.fast_index(search.ord.to_u8, offset)
+    if single_byte_optimizable?
+      return search.ascii? ? to_slice.fast_index(search.ord.to_u8, offset) : nil
     end
 
     offset += size if offset < 0
@@ -3445,8 +3445,8 @@ class String
   # ```
   def rindex(search : Char, offset = size - 1)
     # If it's ASCII we can delegate to slice
-    if search.ascii? && single_byte_optimizable?
-      return to_slice.rindex(search.ord.to_u8, offset)
+    if single_byte_optimizable?
+      return search.ascii? ? to_slice.rindex(search.ord.to_u8, offset) : nil
     end
 
     offset += size if offset < 0


### PR DESCRIPTION
If `str.single_byte_optimizable?` is true, then `str` contains only ASCII characters and invalid UTF-8 byte sequences, therefore we can immediately reject any non-ASCII codepoint.