### PR TITLE
Add compiler flags `-Os` and `-Oz` to optimize binary size

### DIFF
--- a/man/crystal.1
+++ b/man/crystal.1
@@ -496,6 +496,10 @@ Low optimization
 Middle optimization
 .It Fl O3
 High optimization
+.It Fl Os
+Middle optimization with focus on file size
+.It Fl Oz
+Middle optimization aggressively focused on file size
 .
 .Sh ENVIRONMENT\ VARIABLES
 .Bl -tag -width "12345678" -compact

--- a/man/crystal.1
+++ b/man/crystal.1
@@ -496,7 +496,7 @@ Low optimization
 Middle optimization
 .It Fl O3
 High optimization
-.It Fl Os
+.It Fl \!Os
 Middle optimization with focus on file size
 .It Fl Oz
 Middle optimization aggressively focused on file size

--- a/src/compiler/crystal/codegen/target.cr
+++ b/src/compiler/crystal/codegen/target.cr
@@ -193,10 +193,10 @@ class Crystal::Codegen::Target
     end
 
     opt_level = case optimization_mode
-                in .o3? then LLVM::CodeGenOptLevel::Aggressive
+                in .o3?             then LLVM::CodeGenOptLevel::Aggressive
                 in .o2?, .os?, .oz? then LLVM::CodeGenOptLevel::Default
-                in .o1? then LLVM::CodeGenOptLevel::Less
-                in .o0? then LLVM::CodeGenOptLevel::None
+                in .o1?             then LLVM::CodeGenOptLevel::Less
+                in .o0?             then LLVM::CodeGenOptLevel::None
                 end
 
     target = LLVM::Target.from_triple(self.to_s)

--- a/src/compiler/crystal/codegen/target.cr
+++ b/src/compiler/crystal/codegen/target.cr
@@ -194,7 +194,7 @@ class Crystal::Codegen::Target
 
     opt_level = case optimization_mode
                 in .o3? then LLVM::CodeGenOptLevel::Aggressive
-                in .o2? then LLVM::CodeGenOptLevel::Default
+                in .o2?, .os?, .oz? then LLVM::CodeGenOptLevel::Default
                 in .o1? then LLVM::CodeGenOptLevel::Less
                 in .o0? then LLVM::CodeGenOptLevel::None
                 end

--- a/src/compiler/crystal/command.cr
+++ b/src/compiler/crystal/command.cr
@@ -664,7 +664,7 @@ class Crystal::Command
     opts.on("--release", "Compile in release mode (-O3 --single-module)") do
       compiler.release!
     end
-    opts.on("-O LEVEL", "Optimization mode: 0 (default), 1, 2, 3") do |level|
+    opts.on("-O LEVEL", "Optimization mode: 0 (default), 1, 2, 3, s, z") do |level|
       if mode = Compiler::OptimizationMode.from_level?(level)
         compiler.optimization_mode = mode
       else

--- a/src/compiler/crystal/command.cr
+++ b/src/compiler/crystal/command.cr
@@ -521,9 +521,12 @@ class Crystal::Command
         opts.on("--release", "Compile in release mode (-O3 --single-module)") do
           compiler.release!
         end
-        opts.on("-O LEVEL", "Optimization mode: 0 (default), 1, 2, 3") do |level|
-          optimization_mode = level.to_i?.try { |v| Compiler::OptimizationMode.from_value?(v) }
-          compiler.optimization_mode = optimization_mode || raise Error.new("Invalid optimization mode: #{level}")
+        opts.on("-O LEVEL", "Optimization mode: 0 (default), 1, 2, 3, s, z") do |level|
+          if mode = Compiler::OptimizationMode.from_level?(level)
+            compiler.optimization_mode = mode
+          else
+            raise Error.new("Unknown optimization mode #{level}")
+          end
         end
       end
 
@@ -662,7 +665,11 @@ class Crystal::Command
       compiler.release!
     end
     opts.on("-O LEVEL", "Optimization mode: 0 (default), 1, 2, 3") do |level|
-      compiler.optimization_mode = Compiler::OptimizationMode.from_value?(level.to_i) || raise Error.new("Unknown optimization mode #{level}")
+      if mode = Compiler::OptimizationMode.from_level?(level)
+        compiler.optimization_mode = mode
+      else
+        raise Error.new("Unknown optimization mode #{level}")
+      end
     end
     opts.on("--single-module", "Generate a single LLVM module") do
       compiler.single_module = true

--- a/src/compiler/crystal/command.cr
+++ b/src/compiler/crystal/command.cr
@@ -525,7 +525,7 @@ class Crystal::Command
           if mode = Compiler::OptimizationMode.from_level?(level)
             compiler.optimization_mode = mode
           else
-            raise Error.new("Unknown optimization mode #{level}")
+            raise Error.new("Invalid optimization mode: O#{level}")
           end
         end
       end
@@ -668,7 +668,7 @@ class Crystal::Command
       if mode = Compiler::OptimizationMode.from_level?(level)
         compiler.optimization_mode = mode
       else
-        raise Error.new("Unknown optimization mode #{level}")
+        raise Error.new("Invalid optimization mode: O#{level}")
       end
     end
     opts.on("--single-module", "Generate a single LLVM module") do

--- a/src/compiler/crystal/compiler.cr
+++ b/src/compiler/crystal/compiler.cr
@@ -733,7 +733,7 @@ module Crystal
           in .os?
             builder.opt_level = 2
             builder.use_inliner_with_threshold = 50
-          in .os?
+          in .oz?
             builder.opt_level = 2
             builder.use_inliner_with_threshold = 5
           end

--- a/src/compiler/crystal/compiler.cr
+++ b/src/compiler/crystal/compiler.cr
@@ -104,10 +104,10 @@ module Crystal
 
       # optimize for size, enables most O2 optimizations but aims for smaller
       # code size
-      Os = 4
+      Os
 
       # optimize aggressively for size rather than speed
-      Oz = 5
+      Oz
 
       def suffix
         ".#{to_s.downcase}"

--- a/src/compiler/crystal/compiler.cr
+++ b/src/compiler/crystal/compiler.cr
@@ -747,14 +747,8 @@ module Crystal
       protected def optimize(llvm_mod)
         LLVM::PassBuilderOptions.new do |options|
           case @optimization_mode
-          in .o3?
-            passes = "default<O3>"
-          in .o2?
-            passes = "default<O2>"
-          in .o1?
-            passes = "default<O1>"
-          in .o0?
-            passes = "default<O0>"
+          in .o0?, .o1?, .o2?, .o3?
+            passes = "default<#{@optimization_mode}>"
           in .os?
             {% if LibLLVM::IS_LT_170 %}
               passes = "default<O2>"

--- a/src/compiler/crystal/compiler.cr
+++ b/src/compiler/crystal/compiler.cr
@@ -718,6 +718,8 @@ module Crystal
           registry.initialize_all
 
           builder = LLVM::PassManagerBuilder.new
+          builder.size_level = 0
+
           case optimization_mode
           in .o3?
             builder.opt_level = 3
@@ -732,13 +734,13 @@ module Crystal
             # default behaviour, no optimizations
           in .os?
             builder.opt_level = 2
+            builder.size_level = 1
             builder.use_inliner_with_threshold = 50
           in .oz?
             builder.opt_level = 2
+            builder.size_level = 2
             builder.use_inliner_with_threshold = 5
           end
-
-          builder.size_level = 0
 
           builder
         end

--- a/src/llvm/ext/llvm_ext.cc
+++ b/src/llvm/ext/llvm_ext.cc
@@ -90,26 +90,3 @@ void LLVMExtSetTargetMachineGlobalISel(LLVMTargetMachineRef T, LLVMBool Enable) 
 #endif
 
 } // extern "C"
-
-#if LLVM_VERSION_GE(13, 0) && !LLVM_VERSION_GE(17, 0)
-#include <llvm-c/Transforms/PassBuilder.h>
-#include "llvm/Passes/PassBuilder.h"
-
-namespace llvm {
-  class LLVMPassBuilderOptions {
-  public:
-    bool DebugLogging;
-    bool VerifyEach;
-    PipelineTuningOptions PTO;
-  };
-}
-
-DEFINE_SIMPLE_CONVERSION_FUNCTIONS(LLVMPassBuilderOptions, LLVMPassBuilderOptionsRef)
-
-extern "C" {
-  void LLVMPassBuilderOptionsSetInlinerThreshold(LLVMPassBuilderOptionsRef Options, int Threshold) {
-    unwrap(Options)->PTO.InlinerThreshold = Threshold;
-  }
-}
-#endif
-

--- a/src/llvm/ext/llvm_ext.cc
+++ b/src/llvm/ext/llvm_ext.cc
@@ -90,3 +90,26 @@ void LLVMExtSetTargetMachineGlobalISel(LLVMTargetMachineRef T, LLVMBool Enable) 
 #endif
 
 } // extern "C"
+
+#if LLVM_VERSION_GE(13, 0) && !LLVM_VERSION_GE(17, 0)
+#include <llvm-c/Transforms/PassBuilder.h>
+#include "llvm/Passes/PassBuilder.h"
+
+namespace llvm {
+  class LLVMPassBuilderOptions {
+  public:
+    bool DebugLogging;
+    bool VerifyEach;
+    PipelineTuningOptions PTO;
+  };
+}
+
+DEFINE_SIMPLE_CONVERSION_FUNCTIONS(LLVMPassBuilderOptions, LLVMPassBuilderOptionsRef)
+
+extern "C" {
+  void LLVMPassBuilderOptionsSetInlinerThreshold(LLVMPassBuilderOptionsRef Options, int Threshold) {
+    unwrap(Options)->PTO.InlinerThreshold = Threshold;
+  }
+}
+#endif
+

--- a/src/llvm/function_pass_manager.cr
+++ b/src/llvm/function_pass_manager.cr
@@ -1,5 +1,6 @@
-{% skip_file unless LibLLVM::IS_LT_170 %}
-
+{% unless LibLLVM::IS_LT_170 %}
+  @[Deprecated("The legacy pass manager was removed in LLVM 17. Use `LLVM::PassBuilderOptions` instead")]
+{% end %}
 class LLVM::FunctionPassManager
   def initialize(@unwrap : LibLLVM::PassManagerRef)
   end
@@ -33,6 +34,9 @@ class LLVM::FunctionPassManager
     LibLLVM.dispose_pass_manager(@unwrap)
   end
 
+  {% unless LibLLVM::IS_LT_170 %}
+    @[Deprecated("The legacy pass manager was removed in LLVM 17. Use `LLVM::PassBuilderOptions` instead")]
+  {% end %}
   struct Runner
     @fpm : FunctionPassManager
 

--- a/src/llvm/function_pass_manager.cr
+++ b/src/llvm/function_pass_manager.cr
@@ -1,6 +1,5 @@
-{% unless LibLLVM::IS_LT_130 %}
-  @[Deprecated("The legacy pass manager was removed in LLVM 17. Use `LLVM::PassBuilderOptions` instead")]
-{% end %}
+{% skip_file unless LibLLVM::IS_LT_170 %}
+
 class LLVM::FunctionPassManager
   def initialize(@unwrap : LibLLVM::PassManagerRef)
   end
@@ -34,9 +33,6 @@ class LLVM::FunctionPassManager
     LibLLVM.dispose_pass_manager(@unwrap)
   end
 
-  {% unless LibLLVM::IS_LT_130 %}
-    @[Deprecated("The legacy pass manager was removed in LLVM 17. Use `LLVM::PassBuilderOptions` instead")]
-  {% end %}
   struct Runner
     @fpm : FunctionPassManager
 

--- a/src/llvm/lib_llvm/initialization.cr
+++ b/src/llvm/lib_llvm/initialization.cr
@@ -6,11 +6,13 @@ lib LibLLVM
   fun initialize_core = LLVMInitializeCore(r : PassRegistryRef)
   fun initialize_transform_utils = LLVMInitializeTransformUtils(r : PassRegistryRef)
   fun initialize_scalar_opts = LLVMInitializeScalarOpts(r : PassRegistryRef)
-  fun initialize_obj_c_arc_opts = LLVMInitializeObjCARCOpts(r : PassRegistryRef)
+  {% if LibLLVM::IS_LT_160 %}
+    fun initialize_obj_c_arc_opts = LLVMInitializeObjCARCOpts(r : PassRegistryRef)
+    fun initialize_instrumentation = LLVMInitializeInstrumentation(r : PassRegistryRef)
+  {% end %}
   fun initialize_vectorization = LLVMInitializeVectorization(r : PassRegistryRef)
   fun initialize_inst_combine = LLVMInitializeInstCombine(r : PassRegistryRef)
   fun initialize_ipo = LLVMInitializeIPO(r : PassRegistryRef)
-  fun initialize_instrumentation = LLVMInitializeInstrumentation(r : PassRegistryRef)
   fun initialize_analysis = LLVMInitializeAnalysis(r : PassRegistryRef)
   fun initialize_ipa = LLVMInitializeIPA(r : PassRegistryRef)
   fun initialize_code_gen = LLVMInitializeCodeGen(r : PassRegistryRef)

--- a/src/llvm/lib_llvm/initialization.cr
+++ b/src/llvm/lib_llvm/initialization.cr
@@ -6,13 +6,11 @@ lib LibLLVM
   fun initialize_core = LLVMInitializeCore(r : PassRegistryRef)
   fun initialize_transform_utils = LLVMInitializeTransformUtils(r : PassRegistryRef)
   fun initialize_scalar_opts = LLVMInitializeScalarOpts(r : PassRegistryRef)
-  {% if LibLLVM::IS_LT_160 %}
-    fun initialize_obj_c_arc_opts = LLVMInitializeObjCARCOpts(r : PassRegistryRef)
-    fun initialize_instrumentation = LLVMInitializeInstrumentation(r : PassRegistryRef)
-  {% end %}
+  {% if LibLLVM::IS_LT_160 %} fun initialize_obj_c_arc_opts = LLVMInitializeObjCARCOpts(r : PassRegistryRef) {% end %}
   fun initialize_vectorization = LLVMInitializeVectorization(r : PassRegistryRef)
   fun initialize_inst_combine = LLVMInitializeInstCombine(r : PassRegistryRef)
   fun initialize_ipo = LLVMInitializeIPO(r : PassRegistryRef)
+  {% if LibLLVM::IS_LT_160 %} fun initialize_instrumentation = LLVMInitializeInstrumentation(r : PassRegistryRef) {% end %}
   fun initialize_analysis = LLVMInitializeAnalysis(r : PassRegistryRef)
   fun initialize_ipa = LLVMInitializeIPA(r : PassRegistryRef)
   fun initialize_code_gen = LLVMInitializeCodeGen(r : PassRegistryRef)

--- a/src/llvm/lib_llvm/transforms/pass_builder.cr
+++ b/src/llvm/lib_llvm/transforms/pass_builder.cr
@@ -10,7 +10,9 @@ lib LibLLVM
 
   fun create_pass_builder_options = LLVMCreatePassBuilderOptions : PassBuilderOptionsRef
   fun dispose_pass_builder_options = LLVMDisposePassBuilderOptions(options : PassBuilderOptionsRef)
-  fun pass_builder_options_set_inliner_threshold = LLVMPassBuilderOptionsSetInlinerThreshold(PassBuilderOptionsRef, Int)
+  {% unless LibLLVM::IS_LT_170 %}
+    fun pass_builder_options_set_inliner_threshold = LLVMPassBuilderOptionsSetInlinerThreshold(PassBuilderOptionsRef, Int)
+  {% end %}
   fun pass_builder_options_set_loop_unrolling = LLVMPassBuilderOptionsSetLoopUnrolling(PassBuilderOptionsRef, Bool)
   fun pass_builder_options_set_loop_vectorization = LLVMPassBuilderOptionsSetLoopVectorization(PassBuilderOptionsRef, Bool)
   fun pass_builder_options_set_slp_vectorization = LLVMPassBuilderOptionsSetSLPVectorization(PassBuilderOptionsRef, Bool)

--- a/src/llvm/lib_llvm/transforms/pass_builder.cr
+++ b/src/llvm/lib_llvm/transforms/pass_builder.cr
@@ -10,4 +10,8 @@ lib LibLLVM
 
   fun create_pass_builder_options = LLVMCreatePassBuilderOptions : PassBuilderOptionsRef
   fun dispose_pass_builder_options = LLVMDisposePassBuilderOptions(options : PassBuilderOptionsRef)
+  fun pass_builder_options_set_inliner_threshold = LLVMPassBuilderOptionsSetInlinerThreshold(PassBuilderOptionsRef, Int)
+  fun pass_builder_options_set_loop_unrolling = LLVMPassBuilderOptionsSetLoopUnrolling(PassBuilderOptionsRef, Bool)
+  fun pass_builder_options_set_loop_vectorization = LLVMPassBuilderOptionsSetLoopVectorization(PassBuilderOptionsRef, Bool)
+  fun pass_builder_options_set_slp_vectorization = LLVMPassBuilderOptionsSetSLPVectorization(PassBuilderOptionsRef, Bool)
 end

--- a/src/llvm/module.cr
+++ b/src/llvm/module.cr
@@ -84,11 +84,12 @@ class LLVM::Module
     self
   end
 
-  {% if LibLLVM::IS_LT_170 %}
-    def new_function_pass_manager
-      FunctionPassManager.new LibLLVM.create_function_pass_manager_for_module(self)
-    end
+  {% unless LibLLVM::IS_LT_170 %}
+    @[Deprecated("The legacy pass manager was removed in LLVM 17. Use `LLVM::PassBuilderOptions` instead")]
   {% end %}
+  def new_function_pass_manager
+    FunctionPassManager.new LibLLVM.create_function_pass_manager_for_module(self)
+  end
 
   def ==(other : self)
     @unwrap == other.@unwrap

--- a/src/llvm/module.cr
+++ b/src/llvm/module.cr
@@ -84,12 +84,11 @@ class LLVM::Module
     self
   end
 
-  {% unless LibLLVM::IS_LT_130 %}
-    @[Deprecated("The legacy pass manager was removed in LLVM 17. Use `LLVM::PassBuilderOptions` instead")]
+  {% if LibLLVM.has_method?(:create_function_pass_manager_for_module) %}
+    def new_function_pass_manager
+      FunctionPassManager.new LibLLVM.create_function_pass_manager_for_module(self)
+    end
   {% end %}
-  def new_function_pass_manager
-    FunctionPassManager.new LibLLVM.create_function_pass_manager_for_module(self)
-  end
 
   def ==(other : self)
     @unwrap == other.@unwrap

--- a/src/llvm/module.cr
+++ b/src/llvm/module.cr
@@ -84,7 +84,7 @@ class LLVM::Module
     self
   end
 
-  {% if LibLLVM.has_method?(:create_function_pass_manager_for_module) %}
+  {% if LibLLVM::IS_LT_170 %}
     def new_function_pass_manager
       FunctionPassManager.new LibLLVM.create_function_pass_manager_for_module(self)
     end

--- a/src/llvm/module_pass_manager.cr
+++ b/src/llvm/module_pass_manager.cr
@@ -1,6 +1,5 @@
-{% unless LibLLVM::IS_LT_130 %}
-  @[Deprecated("The legacy pass manager was removed in LLVM 17. Use `LLVM::PassBuilderOptions` instead")]
-{% end %}
+{% skip_file unless LibLLVM::IS_LT_170 %}
+
 class LLVM::ModulePassManager
   def initialize
     @unwrap = LibLLVM.pass_manager_create

--- a/src/llvm/module_pass_manager.cr
+++ b/src/llvm/module_pass_manager.cr
@@ -1,5 +1,6 @@
-{% skip_file unless LibLLVM::IS_LT_170 %}
-
+{% unless LibLLVM::IS_LT_170 %}
+  @[Deprecated("The legacy pass manager was removed in LLVM 17. Use `LLVM::PassBuilderOptions` instead")]
+{% end %}
 class LLVM::ModulePassManager
   def initialize
     @unwrap = LibLLVM.pass_manager_create

--- a/src/llvm/pass_builder_options.cr
+++ b/src/llvm/pass_builder_options.cr
@@ -25,4 +25,20 @@ class LLVM::PassBuilderOptions
 
     LibLLVM.dispose_pass_builder_options(self)
   end
+
+  def set_inliner_threshold(threshold : Int)
+    LibLLVM.pass_builder_options_set_inliner_threshold(self, threshold)
+  end
+
+  def set_loop_unrolling(enabled : Bool)
+    LibLLVM.pass_builder_options_set_loop_unrolling(self, enabled ? 1 : 0)
+  end
+
+  def set_loop_vectorization(enabled : Bool)
+    LibLLVM.pass_builder_options_set_loop_vectorization(self, enabled ? 1 : 0)
+  end
+
+  def set_slp_vectorization(enabled : Bool)
+    LibLLVM.pass_builder_options_set_slp_vectorization(self, enabled ? 1 : 0)
+  end
 end

--- a/src/llvm/pass_builder_options.cr
+++ b/src/llvm/pass_builder_options.cr
@@ -26,9 +26,11 @@ class LLVM::PassBuilderOptions
     LibLLVM.dispose_pass_builder_options(self)
   end
 
-  def set_inliner_threshold(threshold : Int)
-    LibLLVM.pass_builder_options_set_inliner_threshold(self, threshold)
-  end
+  {% if LibLLVM.has_method?(:pass_builder_options_set_inliner_threshold) %}
+    def set_inliner_threshold(threshold : Int)
+      LibLLVM.pass_builder_options_set_inliner_threshold(self, threshold)
+    end
+  {% end %}
 
   def set_loop_unrolling(enabled : Bool)
     LibLLVM.pass_builder_options_set_loop_unrolling(self, enabled)

--- a/src/llvm/pass_builder_options.cr
+++ b/src/llvm/pass_builder_options.cr
@@ -26,7 +26,7 @@ class LLVM::PassBuilderOptions
     LibLLVM.dispose_pass_builder_options(self)
   end
 
-  {% if LibLLVM.has_method?(:pass_builder_options_set_inliner_threshold) %}
+  {% unless LibLLVM::IS_LT_170 %}
     def set_inliner_threshold(threshold : Int)
       LibLLVM.pass_builder_options_set_inliner_threshold(self, threshold)
     end

--- a/src/llvm/pass_builder_options.cr
+++ b/src/llvm/pass_builder_options.cr
@@ -31,14 +31,14 @@ class LLVM::PassBuilderOptions
   end
 
   def set_loop_unrolling(enabled : Bool)
-    LibLLVM.pass_builder_options_set_loop_unrolling(self, enabled ? 1 : 0)
+    LibLLVM.pass_builder_options_set_loop_unrolling(self, enabled)
   end
 
   def set_loop_vectorization(enabled : Bool)
-    LibLLVM.pass_builder_options_set_loop_vectorization(self, enabled ? 1 : 0)
+    LibLLVM.pass_builder_options_set_loop_vectorization(self, enabled)
   end
 
   def set_slp_vectorization(enabled : Bool)
-    LibLLVM.pass_builder_options_set_slp_vectorization(self, enabled ? 1 : 0)
+    LibLLVM.pass_builder_options_set_slp_vectorization(self, enabled)
   end
 end

--- a/src/llvm/pass_manager_builder.cr
+++ b/src/llvm/pass_manager_builder.cr
@@ -1,6 +1,5 @@
-{% unless LibLLVM::IS_LT_130 %}
-  @[Deprecated("The legacy pass manager was removed in LLVM 17. Use `LLVM::PassBuilderOptions` instead")]
-{% end %}
+{% skip_file unless LibLLVM::IS_LT_170 %}
+
 class LLVM::PassManagerBuilder
   def initialize
     @unwrap = LibLLVM.pass_manager_builder_create

--- a/src/llvm/pass_manager_builder.cr
+++ b/src/llvm/pass_manager_builder.cr
@@ -1,5 +1,6 @@
-{% skip_file unless LibLLVM::IS_LT_170 %}
-
+{% unless LibLLVM::IS_LT_170 %}
+  @[Deprecated("The legacy pass manager was removed in LLVM 17. Use `LLVM::PassBuilderOptions` instead")]
+{% end %}
 class LLVM::PassManagerBuilder
   def initialize
     @unwrap = LibLLVM.pass_manager_builder_create

--- a/src/llvm/pass_registry.cr
+++ b/src/llvm/pass_registry.cr
@@ -9,19 +9,19 @@ struct LLVM::PassRegistry
   end
 
   {% begin %}
-    Inits = [
-      "initialize_core",
-      "initialize_transform_utils",
-      "initialize_scalar_opts",
-      {% unless LibLLVM::IS_LT_160 %} "initialize_obj_c_arc_opts", {% end %}
-      "initialize_vectorization",
-      "initialize_inst_combine",
-      "initialize_ipo",
-      {% unless LibLLVM::IS_LT_160 %} "initialize_instrumentation", {% end %}
-      "initialize_analysis",
-      "initialize_ipa",
-      "initialize_code_gen",
-      "initialize_target",
+    Inits = %w[
+      initialize_core
+      initialize_transform_utils
+      initialize_scalar_opts
+      {% if LibLLVM::IS_LT_160 %} initialize_obj_c_arc_opts {% end %}
+      initialize_vectorization
+      initialize_inst_combine
+      initialize_ipo
+      {% if LibLLVM::IS_LT_160 %} initialize_instrumentation {% end %}
+      initialize_analysis
+      initialize_ipa
+      initialize_code_gen
+      initialize_target
     ]
   {% end %}
 

--- a/src/llvm/pass_registry.cr
+++ b/src/llvm/pass_registry.cr
@@ -1,5 +1,6 @@
-{% skip_file unless LibLLVM::IS_LT_170 %}
-
+{% unless LibLLVM::IS_LT_170 %}
+  @[Deprecated("The legacy pass manager was removed in LLVM 17. Use `LLVM::PassBuilderOptions` instead")]
+{% end %}
 struct LLVM::PassRegistry
   def self.instance : self
     new LibLLVM.get_global_pass_registry

--- a/src/llvm/pass_registry.cr
+++ b/src/llvm/pass_registry.cr
@@ -8,34 +8,32 @@ struct LLVM::PassRegistry
   def initialize(@unwrap : LibLLVM::PassRegistryRef)
   end
 
-  Inits = %w(
-    initialize_core
-    initialize_transform_utils
-    initialize_scalar_opts
-    initialize_obj_c_arc_opts
-    initialize_vectorization
-    initialize_inst_combine
-    initialize_ipo
-    initialize_instrumentation
-    initialize_analysis
-    initialize_ipa
-    initialize_code_gen
-    initialize_target
-  )
+  {% begin %}
+    Inits = [
+      "initialize_core",
+      "initialize_transform_utils",
+      "initialize_scalar_opts",
+      {% unless LibLLVM::IS_LT_160 %} "initialize_obj_c_arc_opts", {% end %}
+      "initialize_vectorization",
+      "initialize_inst_combine",
+      "initialize_ipo",
+      {% unless LibLLVM::IS_LT_160 %} "initialize_instrumentation", {% end %}
+      "initialize_analysis",
+      "initialize_ipa",
+      "initialize_code_gen",
+      "initialize_target",
+    ]
+  {% end %}
 
   {% for name in Inits %}
-    {% if LibLLVM.has_method?(name) %}
-      def {{name.id}}
-        LibLLVM.{{name.id}} self
-      end
-    {% end %}
+    def {{name.id}}
+      LibLLVM.{{name.id}} self
+    end
   {% end %}
 
   def initialize_all
     {% for name in Inits %}
-      {% if LibLLVM.has_method?(name) %}
-        {{name.id}}
-      {% end %}
+      {{name.id}}
     {% end %}
   end
 


### PR DESCRIPTION
Follows LLVM defaults. Tajkes advantage that LLVMRunPasses now handles Os and Oz directly, and manually applies the LLVM defaults for LLVM 13 to 16 (new pas manager). The Oz configuration with the legacy manager (LLVM < 13) don't disable the vectorizations; I'm not sure how to do it or if it's worth implementing.

Maybe we'd like to adjust the inliner thresholds to account for Crystal. For example Rust uses 75 and 25. Clang also keeps the SLP vectorization enabled. I didn't check the impact (yet).

Of course this is related to #14393 