### PR TITLE
Do not strip the macOS target triple

### DIFF
--- a/spec/std/llvm/llvm_spec.cr
+++ b/spec/std/llvm/llvm_spec.cr
@@ -22,7 +22,7 @@ describe LLVM do
   it ".default_target_triple" do
     triple = LLVM.default_target_triple
     {% if flag?(:darwin) %}
-      triple.should match(/-apple-macosx$/)
+      triple.should match(/-apple-(darwin|macosx)/)
     {% elsif flag?(:android) %}
       triple.should match(/-android$/)
     {% elsif flag?(:linux) %}

--- a/src/llvm.cr
+++ b/src/llvm.cr
@@ -91,12 +91,6 @@ module LLVM
   def self.default_target_triple : String
     chars = LibLLVM.get_default_target_triple
     case triple = string_and_dispose(chars)
-    when .starts_with?("x86_64-apple-macosx"), .starts_with?("x86_64-apple-darwin")
-      # normalize on `macosx` and remove minimum deployment target version
-      "x86_64-apple-macosx"
-    when .starts_with?("aarch64-apple-macosx"), .starts_with?("aarch64-apple-darwin")
-      # normalize on `macosx` and remove minimum deployment target version
-      "aarch64-apple-macosx"
     when .starts_with?("aarch64-unknown-linux-android")
       # remove API version
       "aarch64-unknown-linux-android"


### PR DESCRIPTION
With the release of Xcode 15, a [new linker was introduced](https://developer.apple.com/documentation/xcode-release-notes/xcode-15-release-notes#Linking) and with it came warnings messages as seen in #13846. It appears that the new linker is stricter in which target triples it considers valid. Specifically, it looks like the minimum deployment target is required. E.g., `aarch64-apple-darwin23.3.0` is valid, while `aarch64-apple-darwin` is not. See https://github.com/crystal-lang/crystal/issues/13846#issuecomment-2040146898 for details.

This PR is a follow-up of https://github.com/crystal-lang/distribution-scripts/pull/296. While we have corrected the target triple for macOS `arm64` builds, `x86_64` builds would still emit warnings due to us stripping the minimum deployment target in `LLVM.default_target_triple`.

Fixes #13846
Fixes #14052