### PR TITLE
Log: delete source from builder cache when finalize

### DIFF
--- a/src/log/builder.cr
+++ b/src/log/builder.cr
@@ -157,4 +157,10 @@ class Log::Builder
     end
     false
   end
+
+  # NOTE: workaround for https://github.com/crystal-lang/crystal/pull/14473
+  protected def cleanup_collected_log(log : Log) : Nil
+    ref = @logs.fetch(log.source) { return }
+    @logs.delete(log.source) if ref.value.nil? || ref.value == self
+  end
 end

--- a/src/log/builder.cr
+++ b/src/log/builder.cr
@@ -161,6 +161,6 @@ class Log::Builder
   # NOTE: workaround for https://github.com/crystal-lang/crystal/pull/14473
   protected def cleanup_collected_log(log : Log) : Nil
     ref = @logs.fetch(log.source) { return }
-    @logs.delete(log.source) if ref.value.nil? || ref.value == self
+    @logs.delete(log.source) if ref.value.nil? || ref.value == log
   end
 end

--- a/src/log/log.cr
+++ b/src/log/log.cr
@@ -10,6 +10,10 @@ class Log
     @initial_level = level
   end
 
+  def finalize : Nil
+    Log.builder.@logs.delete(@source)
+  end
+
   # :nodoc:
   def changed_level : Severity?
     @level

--- a/src/log/log.cr
+++ b/src/log/log.cr
@@ -11,7 +11,8 @@ class Log
   end
 
   def finalize : Nil
-    Log.builder.@logs.delete(@source)
+    # NOTE: workaround for https://github.com/crystal-lang/crystal/pull/14473
+    Log.builder.cleanup_collected_log(self)
   end
 
   # :nodoc:


### PR DESCRIPTION
The cache of logs in Log::Builder is using a WeakRef for the Log object to not prevent the GC from collecting them, that would leak memory, but it keeps the hash entry, which also leaks, keeping strings (potentially dynamically allocated) along with entries in the hash (infinitely growing hash).

This patch adds a finalizer to Log, as suggested by @beta, to remove the log entry from the builder cache when a Log object is collected.

The runtime improvement for the sample from #14473 is dramatic. It looks almost flat with a mere 5s versus 67s for the current master at 100 000 iterations.

![log_leak](https://github.com/crystal-lang/crystal/assets/47380/789bfa38-a55f-45b0-a18f-066814623a7c)

**Note**: this is a **workaround** to fix the leak, that can be monkey-patched in applications that need it, not a proper solution to the problem.