### PR TITLE
Move `File.readable?`, `.writable?`, `.executable?` to `File::Info`

### DIFF
--- a/src/file.cr
+++ b/src/file.cr
@@ -288,6 +288,7 @@ class File < IO::FileDescriptor
   # File.write("foo", "foo")
   # File.readable?("foo") # => true
   # ```
+  @[Deprecated("Use `File::Info.readable?` instead")]
   def self.readable?(path : Path | String) : Bool
     Crystal::System::File.readable?(path.to_s)
   end
@@ -298,6 +299,7 @@ class File < IO::FileDescriptor
   # File.write("foo", "foo")
   # File.writable?("foo") # => true
   # ```
+  @[Deprecated("Use `File::Info.writable?` instead")]
   def self.writable?(path : Path | String) : Bool
     Crystal::System::File.writable?(path.to_s)
   end
@@ -308,6 +310,7 @@ class File < IO::FileDescriptor
   # File.write("foo", "foo")
   # File.executable?("foo") # => false
   # ```
+  @[Deprecated("Use `File::Info.executable?` instead")]
   def self.executable?(path : Path | String) : Bool
     Crystal::System::File.executable?(path.to_s)
   end

--- a/src/file/info.cr
+++ b/src/file/info.cr
@@ -142,5 +142,35 @@ class File
     def symlink?
       type.symlink?
     end
+
+    # Returns `true` if *path* is readable by the real user id of this process else returns `false`.
+    #
+    # ```
+    # File.write("foo", "foo")
+    # File::Info.readable?("foo") # => true
+    # ```
+    def self.readable?(path : Path | String) : Bool
+      Crystal::System::File.readable?(path.to_s)
+    end
+
+    # Returns `true` if *path* is writable by the real user id of this process else returns `false`.
+    #
+    # ```
+    # File.write("foo", "foo")
+    # File::Info.writable?("foo") # => true
+    # ```
+    def self.writable?(path : Path | String) : Bool
+      Crystal::System::File.writable?(path.to_s)
+    end
+
+    # Returns `true` if *path* is executable by the real user id of this process else returns `false`.
+    #
+    # ```
+    # File.write("foo", "foo")
+    # File::Info.executable?("foo") # => false
+    # ```
+    def self.executable?(path : Path | String) : Bool
+      Crystal::System::File.executable?(path.to_s)
+    end
   end
 end


### PR DESCRIPTION
Resolves part of #14245