### PR TITLE
Add AST node methods for macro-related nodes

### DIFF
--- a/spec/compiler/macro/macro_methods_spec.cr
+++ b/spec/compiler/macro/macro_methods_spec.cr
@@ -2546,6 +2546,21 @@ module Crystal
       end
     end
 
+    describe MacroExpression do
+      foo = MacroExpression.new(NilLiteral.new, output: false)
+      bar = MacroExpression.new(1.int32, output: true)
+
+      it "executes exp" do
+        assert_macro %({{x.exp}}), "nil", {x: foo}
+        assert_macro %({{x.exp}}), "1", {x: bar}
+      end
+
+      it "executes output?" do
+        assert_macro %({{x.output?}}), "false", {x: foo}
+        assert_macro %({{x.output?}}), "true", {x: bar}
+      end
+    end
+
     describe "macro if methods" do
       it "executes cond" do
         assert_macro %({{x.cond}}), "true", {x: MacroIf.new(BoolLiteral.new(true), NilLiteral.new)}
@@ -2571,6 +2586,31 @@ module Crystal
 
       it "executes body" do
         assert_macro %({{x.body}}), "puts(bar)", {x: MacroFor.new([Var.new("bar")], Var.new("foo"), Call.new(nil, "puts", [Var.new("bar")] of ASTNode))}
+      end
+    end
+
+    describe MacroLiteral do
+      foo = MacroLiteral.new("foo(1)")
+      bar = MacroLiteral.new("")
+
+      it "executes value" do
+        assert_macro %({{x.value}}), "foo(1)", {x: foo}
+        assert_macro %({{x.value}}), "", {x: bar}
+      end
+    end
+
+    describe MacroVar do
+      foo = MacroVar.new("foo")
+      bar = MacroVar.new("bar", [Var.new("x"), 1.int32] of ASTNode)
+
+      it "executes name" do
+        assert_macro %({{x.name}}), "foo", {x: foo}
+        assert_macro %({{x.name}}), "bar", {x: bar}
+      end
+
+      it "executes exps" do
+        assert_macro %({{x.exps}}), "[] of ::NoReturn", {x: foo}
+        assert_macro %({{x.exps}}), "[x, 1]", {x: bar}
       end
     end
 

--- a/spec/compiler/macro/macro_methods_spec.cr
+++ b/spec/compiler/macro/macro_methods_spec.cr
@@ -2547,17 +2547,13 @@ module Crystal
     end
 
     describe MacroExpression do
-      foo = MacroExpression.new(NilLiteral.new, output: false)
-      bar = MacroExpression.new(1.int32, output: true)
-
       it "executes exp" do
-        assert_macro %({{x.exp}}), "nil", {x: foo}
-        assert_macro %({{x.exp}}), "1", {x: bar}
+        assert_macro %({{x.exp}}), "nil", {x: MacroExpression.new(NilLiteral.new)}
       end
 
       it "executes output?" do
-        assert_macro %({{x.output?}}), "false", {x: foo}
-        assert_macro %({{x.output?}}), "true", {x: bar}
+        assert_macro %({{x.output?}}), "false", {x: MacroExpression.new(NilLiteral.new, output: false)}
+        assert_macro %({{x.output?}}), "true", {x: MacroExpression.new(1.int32, output: true)}
       end
     end
 
@@ -2590,27 +2586,20 @@ module Crystal
     end
 
     describe MacroLiteral do
-      foo = MacroLiteral.new("foo(1)")
-      bar = MacroLiteral.new("")
-
       it "executes value" do
-        assert_macro %({{x.value}}), "foo(1)", {x: foo}
-        assert_macro %({{x.value}}), "", {x: bar}
+        assert_macro %({{x.value}}), "foo(1)", {x: MacroLiteral.new("foo(1)")}
+        assert_macro %({{x.value}}), "", {x: MacroLiteral.new("")}
       end
     end
 
     describe MacroVar do
-      foo = MacroVar.new("foo")
-      bar = MacroVar.new("bar", [Var.new("x"), 1.int32] of ASTNode)
-
       it "executes name" do
-        assert_macro %({{x.name}}), "foo", {x: foo}
-        assert_macro %({{x.name}}), "bar", {x: bar}
+        assert_macro %({{x.name}}), "foo", {x: MacroVar.new("foo")}
       end
 
-      it "executes exps" do
-        assert_macro %({{x.exps}}), "[] of ::NoReturn", {x: foo}
-        assert_macro %({{x.exps}}), "[x, 1]", {x: bar}
+      it "executes expressions" do
+        assert_macro %({{x.expressions}}), "[] of ::NoReturn", {x: MacroVar.new("foo")}
+        assert_macro %({{x.expressions}}), "[x, 1]", {x: MacroVar.new("bar", [Var.new("x"), 1.int32] of ASTNode)}
       end
     end
 

--- a/src/compiler/crystal/macros.cr
+++ b/src/compiler/crystal/macros.cr
@@ -2380,7 +2380,7 @@ module Crystal::Macros
   # Every variable `node` is equivalent to:
   #
   # ```
-  # {{ "%#{name}".id }}{% if exps = node.exps %}{{ "{#{exps.splat}}".id }}{% end %}
+  # {{ "%#{name}".id }}{% if expressions = node.expressions %}{{ "{#{expressions.splat}}".id }}{% end %}
   # ```
   class MacroVar < ASTNode
     # Returns the name of the fresh variable.
@@ -2388,7 +2388,7 @@ module Crystal::Macros
     end
 
     # Returns the associated indices of the fresh variable.
-    def exps : ArrayLiteral
+    def expressions : ArrayLiteral
     end
   end
 

--- a/src/compiler/crystal/macros.cr
+++ b/src/compiler/crystal/macros.cr
@@ -2303,15 +2303,33 @@ module Crystal::Macros
     end
   end
 
-  # A macro expression,
-  # surrounded by {{ ... }} (output = true)
-  # or by {% ... %} (output = false)
-  # class MacroExpression < ASTNode
-  # end
+  # A macro expression.
+  #
+  # Every expression *node* is equivalent to:
+  #
+  # ```
+  # {% if node.output? %}
+  #   \{{ {{ node.exp }} }}
+  # {% else %}
+  #   \{% {{ node.exp }} %}
+  # {% end %}
+  # ```
+  class MacroExpression < ASTNode
+    # Returns the expression inside this node.
+    def exp : ASTNode
+    end
 
-  # Free text that is part of a macro
-  # class MacroLiteral < ASTNode
-  # end
+    # Returns whether this node interpolates the expression's result.
+    def output? : BoolLiteral
+    end
+  end
+
+  # Free text that is part of a macro.
+  class MacroLiteral < ASTNode
+    # Returns the text of the literal.
+    def value : MacroId
+    end
+  end
 
   # An `if` inside a macro, e.g.
   #
@@ -2355,6 +2373,35 @@ module Crystal::Macros
     # The body of the `for` loop.
     def body : ASTNode
     end
+  end
+
+  # A macro fresh variable.
+  #
+  # Every variable `node` is equivalent to:
+  #
+  # ```
+  # {{ "%#{name}".id }}{% if exps = node.exps %}{{ "{#{exps.splat}}".id }}{% end %}
+  # ```
+  class MacroVar < ASTNode
+    # Returns the name of the fresh variable.
+    def name : MacroId
+    end
+
+    # Returns the associated indices of the fresh variable.
+    def exps : ArrayLiteral
+    end
+  end
+
+  # A verbatim expression.
+  #
+  # Every expression `node` is equivalent to:
+  #
+  # ```
+  # \{% verbatim do %}
+  #   {{ node.exp }}
+  # \{% end %}
+  # ```
+  class MacroVerbatim < UnaryExpression
   end
 
   # The `_` expression. May appear in code, such as an assignment target, and in

--- a/src/compiler/crystal/macros/methods.cr
+++ b/src/compiler/crystal/macros/methods.cr
@@ -1556,7 +1556,7 @@ module Crystal
       case method
       when "name"
         interpret_check_args { MacroId.new(@name) }
-      when "exps"
+      when "expressions"
         interpret_check_args do
           if exps = @exps
             ArrayLiteral.map(exps, &.itself)

--- a/src/compiler/crystal/macros/methods.cr
+++ b/src/compiler/crystal/macros/methods.cr
@@ -1497,6 +1497,19 @@ module Crystal
     end
   end
 
+  class MacroExpression
+    def interpret(method : String, args : Array(ASTNode), named_args : Hash(String, ASTNode)?, block : Crystal::Block?, interpreter : Crystal::MacroInterpreter, name_loc : Location?)
+      case method
+      when "exp"
+        interpret_check_args { @exp }
+      when "output?"
+        interpret_check_args { BoolLiteral.new(@output) }
+      else
+        super
+      end
+    end
+  end
+
   class MacroIf
     def interpret(method : String, args : Array(ASTNode), named_args : Hash(String, ASTNode)?, block : Crystal::Block?, interpreter : Crystal::MacroInterpreter, name_loc : Location?)
       case method
@@ -1521,6 +1534,36 @@ module Crystal
         interpret_check_args { @exp }
       when "body"
         interpret_check_args { @body }
+      else
+        super
+      end
+    end
+  end
+
+  class MacroLiteral
+    def interpret(method : String, args : Array(ASTNode), named_args : Hash(String, ASTNode)?, block : Crystal::Block?, interpreter : Crystal::MacroInterpreter, name_loc : Location?)
+      case method
+      when "value"
+        interpret_check_args { MacroId.new(@value) }
+      else
+        super
+      end
+    end
+  end
+
+  class MacroVar
+    def interpret(method : String, args : Array(ASTNode), named_args : Hash(String, ASTNode)?, block : Crystal::Block?, interpreter : Crystal::MacroInterpreter, name_loc : Location?)
+      case method
+      when "name"
+        interpret_check_args { MacroId.new(@name) }
+      when "exps"
+        interpret_check_args do
+          if exps = @exps
+            ArrayLiteral.map(exps, &.itself)
+          else
+            empty_no_return_array
+          end
+        end
       else
         super
       end

--- a/src/compiler/crystal/macros/types.cr
+++ b/src/compiler/crystal/macros/types.cr
@@ -90,9 +90,14 @@ module Crystal
       @macro_types["Cast"] = NonGenericMacroType.new self, "Cast", ast_node
       @macro_types["NilableCast"] = NonGenericMacroType.new self, "NilableCast", ast_node
       @macro_types["MacroId"] = NonGenericMacroType.new self, "MacroId", ast_node
+      @macro_types["TypeNode"] = NonGenericMacroType.new self, "TypeNode", ast_node
+
+      @macro_types["MacroExpression"] = NonGenericMacroType.new self, "MacroExpression", ast_node
       @macro_types["MacroFor"] = NonGenericMacroType.new self, "MacroFor", ast_node
       @macro_types["MacroIf"] = NonGenericMacroType.new self, "MacroIf", ast_node
-      @macro_types["TypeNode"] = NonGenericMacroType.new self, "TypeNode", ast_node
+      @macro_types["MacroLiteral"] = NonGenericMacroType.new self, "MacroLiteral", ast_node
+      @macro_types["MacroVar"] = NonGenericMacroType.new self, "MacroVar", ast_node
+      @macro_types["MacroVerbatim"] = NonGenericMacroType.new self, "MacroVerbatim", unary_expression
 
       # bottom type
       @macro_types["NoReturn"] = @macro_no_return = NoReturnMacroType.new self
@@ -117,10 +122,6 @@ module Crystal
       @macro_types["ExternalVar"] = NonGenericMacroType.new self, "ExternalVar", ast_node
       @macro_types["Include"] = NonGenericMacroType.new self, "Include", ast_node
       @macro_types["TypeDef"] = NonGenericMacroType.new self, "TypeDef", ast_node
-      @macro_types["MacroExpression"] = NonGenericMacroType.new self, "MacroExpression", ast_node
-      @macro_types["MacroLiteral"] = NonGenericMacroType.new self, "MacroLiteral", ast_node
-      @macro_types["MacroVar"] = NonGenericMacroType.new self, "MacroVar", ast_node
-      @macro_types["MacroVerbatim"] = NonGenericMacroType.new self, "MacroVerbatim", unary_expression
     end
 
     # Returns the macro type for a given AST node. This association is done


### PR DESCRIPTION
Resolves part of #3274.

`MacroVerbatim` has no new methods, since `UnaryExpression` covers everything already.