### PR TITLE
Replace `type` declarations for void pointers with `alias` in `libxml2`

### DIFF
--- a/src/xml/libxml2.cr
+++ b/src/xml/libxml2.cr
@@ -22,8 +22,8 @@ lib LibXML
     $xmlTreeIndentString : UInt8*
   {% end %}
 
-  type Dtd = Void*
-  type Dict = Void*
+  alias Dtd = Void*
+  alias Dict = Void*
 
   struct NS
     next : NS*
@@ -89,9 +89,9 @@ lib LibXML
     node_tab : Node**
   end
 
-  type InputBuffer = Void*
-  type XMLTextReader = Void*
-  type XMLTextReaderLocator = Void*
+  alias InputBuffer = Void*
+  alias XMLTextReader = Void*
+  alias XMLTextReaderLocator = Void*
 
   enum ParserSeverity
     VALIDITY_WARNING = 1
@@ -159,7 +159,7 @@ lib LibXML
   alias OutputWriteCallback = (Void*, UInt8*, Int) -> Int
   alias OutputCloseCallback = (Void*) -> Int
 
-  type SaveCtxPtr = Void*
+  alias SaveCtxPtr = Void*
 
   fun xmlSaveToIO(iowrite : OutputWriteCallback, ioclose : OutputCloseCallback, ioctx : Void*, encoding : UInt8*, options : XML::SaveOptions) : SaveCtxPtr
   fun xmlSaveTree(ctx : SaveCtxPtr, node : Node*) : LibC::Long
@@ -176,7 +176,7 @@ lib LibXML
     error : Int
   end
 
-  type TextWriter = Void*
+  alias TextWriter = Void*
 
   fun xmlNewTextWriter(out : OutputBuffer*) : TextWriter
   fun xmlTextWriterStartDocument(TextWriter, version : UInt8*, encoding : UInt8*, standalone : UInt8*) : Int


### PR DESCRIPTION
This is a workaround for https://github.com/crystal-lang/crystal/issues/8544 when used with older compiler versions without the fix from https://github.com/crystal-lang/crystal/pull/11636 (released in 1.3).

Extracted from #14401