### PR TITLE
Fix: handle pointers in NilableCast codegen

### DIFF
--- a/src/compiler/crystal/semantic/bindings.cr
+++ b/src/compiler/crystal/semantic/bindings.cr
@@ -474,14 +474,14 @@ module Crystal
 
       @upcast = false
 
-      if obj_type
+      if obj_type && !(obj_type.pointer? || to_type.pointer?)
         filtered_type = obj_type.filter_by(to_type)
 
         # If the filtered type didn't change it means that an
         # upcast is being made, for example:
         #
-        #   1 as Int32 | Float64
-        #   Bar.new as Foo # where Bar < Foo
+        #   1.as?(Int32 | Float64)
+        #   Bar.new.as?(Foo) # where Bar < Foo
         if obj_type == filtered_type && !to_type.is_a?(GenericClassType) &&
            to_type.can_be_stored?
           filtered_type = to_type.virtual_type


### PR DESCRIPTION
Nilable casts (`.as?`) don't handle pointers, and the behavior of `.as?` was different from `.as` where the later would cast a reference to a pointer (for example) while the former would return nil.

- [x] LLVM codegen of NilableCast
  - [ ] bitcast validation errors on LLVM <= 14 (see CI);
- [ ] interpreter has the exact same issue (may be fixed separately);

closes #14491