### PR TITLE
Optimize `Hash#transform_{keys,values}`

### DIFF
--- a/src/hash.cr
+++ b/src/hash.cr
@@ -1747,7 +1747,7 @@ class Hash(K, V)
   # hash.transform_keys { |key, value| key.to_s * value } # => {"a" => 1, "bb" => 2, "ccc" => 3}
   # ```
   def transform_keys(& : K, V -> K2) : Hash(K2, V) forall K2
-    copy = Hash(K2, V).new(initial_capacity: size <= 4 ? 0 : size)
+    copy = Hash(K2, V).new(initial_capacity: entries_capacity)
     each_with_object(copy) do |(key, value), memo|
       memo[yield(key, value)] = value
     end
@@ -1763,7 +1763,7 @@ class Hash(K, V)
   # hash.transform_values { |value, key| "#{key}#{value}" } # => {:a => "a1", :b => "b2", :c => "c3"}
   # ```
   def transform_values(& : V, K -> V2) : Hash(K, V2) forall V2
-    copy = Hash(K, V2).new(initial_capacity: size <= 4 ? 0 : size)
+    copy = Hash(K, V2).new(initial_capacity: entries_capacity)
     each_with_object(copy) do |(key, value), memo|
       memo[key] = yield(value, key)
     end

--- a/src/hash.cr
+++ b/src/hash.cr
@@ -1747,18 +1747,9 @@ class Hash(K, V)
   # hash.transform_keys { |key, value| key.to_s * value } # => {"a" => 1, "bb" => 2, "ccc" => 3}
   # ```
   def transform_keys(& : K, V -> K2) : Hash(K2, V) forall K2
-    if size <= 4
-      # Building up an empty hash is faster than a pre-allocated one as long as
-      # the size is below 5.
-      each_with_object({} of K2 => V) do |(key, value), memo|
-        memo[yield(key, value)] = value
-      end
-    else
-      hash = Hash(K2, V).new(initial_capacity: size)
-      each do |key, value|
-        hash[yield(key, value)] = value
-      end
-      hash
+    copy = Hash(K2, V).new(initial_capacity: size <= 4 ? 0 : size)
+    each_with_object(copy) do |(key, value), memo|
+      memo[yield(key, value)] = value
     end
   end
 
@@ -1772,18 +1763,9 @@ class Hash(K, V)
   # hash.transform_values { |value, key| "#{key}#{value}" } # => {:a => "a1", :b => "b2", :c => "c3"}
   # ```
   def transform_values(& : V, K -> V2) : Hash(K, V2) forall V2
-    if size <= 4
-      # Building up an empty hash is faster than a pre-allocated one as long as
-      # the size is below 5.
-      each_with_object({} of K => V2) do |(key, value), memo|
-        memo[key] = yield(value, key)
-      end
-    else
-      hash = Hash(K, V2).new(initial_capacity: size)
-      each do |key, value|
-        hash[key] = yield(value, key)
-      end
-      hash
+    copy = Hash(K, V2).new(initial_capacity: size <= 4 ? 0 : size)
+    each_with_object(copy) do |(key, value), memo|
+      memo[key] = yield(value, key)
     end
   end
 


### PR DESCRIPTION
Preallocating the correct-size hash is faster for hash sizes > 4, but the empty hash is faster for sizes <= 4. It would be a lot closer, but [`Hash#upsert` allocates an initial capacity of 4](https://github.com/crystal-lang/crystal/blob/562fb7bf7a580fa915c5ac7330c362ac4d19a564/src/hash.cr#L362) when the hash is empty but [`Hash#initialize` sets the floor for `initial_capacity` at 8 elements](https://github.com/crystal-lang/crystal/blob/562fb7bf7a580fa915c5ac7330c362ac4d19a564/src/hash.cr#L237-L238).

This PR gives the best of both worlds by using the current approach when the source hash has <= 4 keys in it, or a fully preallocated hash for > 4.

<details><summary>Benchmark code</summary>

```crystal
require "benchmark"

{
  1,
  4,
  5,
  10,
  100,
  1_000,
}.each do |size|
  hash = Array
    .new(size) { |i| {i.to_s, i.to_s} }
    .to_h

  unless hash.transform_keys(&.itself) == hash.transform_keys_optimized(&.itself)
    raise "Oops! #{hash.transform_keys_optimized(&.itself).pretty_inspect}"
  end

  puts
  puts
  puts "### #{size}"
  puts "Keys"
  Benchmark.ips do |x|
    x.report "baseline" { hash.transform_keys(&.itself) }
    x.report "optimized" { hash.transform_keys_optimized(&.itself) }
  end
  puts
  puts "Values"
  Benchmark.ips do |x|
    x.report "baseline" { hash.transform_values(&.itself) }
    x.report "optimized" { hash.transform_values_optimized(&.itself) }
  end
end

class Hash(K, V)
  def transform_keys_optimized(& : K, V -> K2) : Hash(K2, V) forall K2
    hash = Hash(K2, V).new(initial_capacity: size)
    each do |key, value|
      hash[yield(key, value)] = value
    end
    hash
  end

  def transform_values_optimized(& : V, K -> V2) : Hash(K, V2) forall V2
    hash = Hash(K, V2).new(initial_capacity: size)
    each do |key, value|
      hash[key] = yield(value, key)
    end
    hash
  end
end
```

</details>

```
### 1
Keys
 baseline  28.39M ( 35.23ns) (± 1.34%)  176B/op        fastest
optimized  20.34M ( 49.18ns) (± 1.41%)  272B/op   1.40× slower

Values
 baseline  29.40M ( 34.01ns) (± 1.61%)  176B/op        fastest
optimized  20.30M ( 49.27ns) (± 1.96%)  272B/op   1.45× slower


### 4
Keys
 baseline  17.18M ( 58.19ns) (± 2.63%)  176B/op        fastest
optimized  13.56M ( 73.76ns) (± 1.19%)  272B/op   1.27× slower

Values
 baseline  17.19M ( 58.17ns) (± 2.61%)  176B/op        fastest
optimized  13.56M ( 73.74ns) (± 1.16%)  272B/op   1.27× slower


### 5
Keys
 baseline  10.14M ( 98.62ns) (± 1.09%)  384B/op   1.23× slower
optimized  12.45M ( 80.34ns) (± 1.00%)  272B/op        fastest

Values
 baseline  10.07M ( 99.34ns) (± 4.05%)  384B/op   1.23× slower
optimized  12.40M ( 80.66ns) (± 3.20%)  272B/op        fastest


### 10
Keys
 baseline   5.04M (198.33ns) (± 4.11%)  832B/op   1.28× slower
optimized   6.46M (154.82ns) (± 0.96%)  512B/op        fastest

Values
 baseline   5.08M (196.95ns) (± 2.39%)  832B/op   1.27× slower
optimized   6.43M (155.58ns) (± 3.46%)  512B/op        fastest


### 100
Keys
 baseline 560.97k (  1.78µs) (± 1.02%)  7.09kB/op   1.35× slower
optimized 757.56k (  1.32µs) (± 1.02%)  3.34kB/op        fastest

Values
 baseline 562.41k (  1.78µs) (± 1.02%)  7.09kB/op   1.34× slower
optimized 754.39k (  1.33µs) (± 2.92%)  3.34kB/op        fastest


### 1000
Keys
 baseline  49.88k ( 20.05µs) (± 1.27%)  56.4kB/op   1.47× slower
optimized  73.53k ( 13.60µs) (± 1.89%)  28.1kB/op        fastest

Values
 baseline  49.67k ( 20.13µs) (± 1.23%)  56.4kB/op   1.47× slower
optimized  73.05k ( 13.69µs) (± 3.42%)  28.1kB/op        fastest
```