### PR TITLE
Make `IO::FileDescriptor#tty?` return false for NUL on Windows

### DIFF
--- a/spec/std/io/file_descriptor_spec.cr
+++ b/spec/std/io/file_descriptor_spec.cr
@@ -22,6 +22,21 @@ describe IO::FileDescriptor do
     end
   end
 
+  describe "#tty?" do
+    it "returns false for null device" do
+      File.open(File::NULL) do |f|
+        f.tty?.should be_false
+      end
+    end
+
+    it "returns false for standard streams redirected to null device", tags: %w[slow] do
+      code = %q(print STDIN.tty?, ' ', STDERR.tty?)
+      compile_source(code) do |binpath|
+        `#{shell_command %(#{Process.quote(binpath)} < #{File::NULL} 2> #{File::NULL})}`.should eq("false false")
+      end
+    end
+  end
+
   it "closes on finalize" do
     pipes = [] of IO::FileDescriptor
     assert_finalizes("fd") do

--- a/src/crystal/system/win32/file_descriptor.cr
+++ b/src/crystal/system/win32/file_descriptor.cr
@@ -148,7 +148,7 @@ module Crystal::System::FileDescriptor
   end
 
   private def system_tty?
-    LibC.GetFileType(windows_handle) == LibC::FILE_TYPE_CHAR
+    LibC.GetConsoleMode(windows_handle, out _) != 0
   end
 
   private def system_reopen(other : IO::FileDescriptor)

--- a/src/crystal/system/win32/socket.cr
+++ b/src/crystal/system/win32/socket.cr
@@ -442,7 +442,7 @@ module Crystal::System::Socket
   end
 
   private def system_tty?
-    LibC.GetFileType(LibC::HANDLE.new(fd)) == LibC::FILE_TYPE_CHAR
+    LibC.GetConsoleMode(LibC::HANDLE.new(fd), out _) != 0
   end
 
   private def unbuffered_read(slice : Bytes) : Int32


### PR DESCRIPTION
This makes NUL's behavior on Windows consistent with /dev/null on other systems, see https://forum.crystal-lang.org/t/tty-on-windows/6769 for the relevant discussion.