### PR TITLE
Fix indentation of parenthesized `Expressions#to_s`

### DIFF
--- a/spec/compiler/parser/to_s_spec.cr
+++ b/spec/compiler/parser/to_s_spec.cr
@@ -210,6 +210,9 @@ describe "ASTNode#to_s" do
   expect_to_s %(if (1 + 2\n3)\n  4\nend)
   expect_to_s "%x(whoami)", "`whoami`"
   expect_to_s %(begin\n  ()\nend)
+  expect_to_s %(begin\n  (1)\nend)
+  expect_to_s %(begin\n  (@x = x).is_a?(Foo)\nend)
+  expect_to_s %(begin\n  (1)\n  2\nend)
   expect_to_s %(if 1\n  begin\n    2\n  end\nelse\n  begin\n    3\n  end\nend)
   expect_to_s %(foo do\n  begin\n    bar\n  end\nend)
   expect_to_s %q("\e\0\""), %q("\e\u0000\"")
@@ -250,8 +253,10 @@ describe "ASTNode#to_s" do
   expect_to_s "offsetof(Foo, @bar)"
   expect_to_s "def foo(**options, &block)\nend"
   expect_to_s "macro foo\n  123\nend"
-  expect_to_s "if true\n(  1)\nend"
-  expect_to_s "begin\n(  1)\nrescue\nend"
+  expect_to_s "if true\n  (1)\nend"
+  expect_to_s "if true\n  (1)\n  2\nend"
+  expect_to_s "begin\n  (1)\nrescue\nend"
+  expect_to_s "begin\n  (1)\n  2\nrescue\nend"
   expect_to_s %[他.说("你好")]
   expect_to_s %[他.说 = "你好"]
   expect_to_s %[あ.い, う.え.お = 1, 2]

--- a/src/compiler/crystal/syntax/to_s.cr
+++ b/src/compiler/crystal/syntax/to_s.cr
@@ -223,7 +223,7 @@ module Crystal
       else
         node.expressions.each_with_index do |exp, i|
           unless exp.nop?
-            append_indent
+            append_indent unless node.keyword.paren? && i == 0
             exp.accept self
             newline unless node.keyword.paren? && i == node.expressions.size - 1
           end
@@ -1563,7 +1563,7 @@ module Crystal
 
     def accept_with_indent(node : Expressions)
       with_indent do
-        append_indent if node.keyword.begin?
+        append_indent unless node.keyword.none?
         node.accept self
       end
       newline unless node.keyword.none?


### PR DESCRIPTION
Before:

```crystal
if true
(  1)
else
  (  1)
  (  @x = x).is_a?(A)
  2
end
```

After:

```crystal
if true
  (1)
else
  (1)
  (@x = x).is_a?(A)
  2
end
```