### PR TITLE
Make `File.readable?` and `.writable?` follow symlinks on Windows

### DIFF
--- a/spec/std/file_spec.cr
+++ b/spec/std/file_spec.cr
@@ -200,9 +200,24 @@ describe "File" do
     it "gives false when a component of the path is a file" do
       File.exists?(datapath("dir", "test_file.txt", "")).should be_false
     end
+
+    it "follows symlinks" do
+      with_tempfile("good_symlink.txt", "bad_symlink.txt") do |good_path, bad_path|
+        File.symlink(File.expand_path(datapath("test_file.txt")), good_path)
+        File.symlink(File.expand_path(datapath("non_existing_file.txt")), bad_path)
+
+        File.exists?(good_path).should be_true
+        File.exists?(bad_path).should be_false
+      end
+    end
   end
 
   describe "executable?" do
+    it "gives true" do
+      crystal = Process.executable_path || pending! "Unable to locate compiler executable"
+      File.executable?(crystal).should be_true
+    end
+
     it "gives false" do
       File.executable?(datapath("test_file.txt")).should be_false
     end
@@ -213,6 +228,17 @@ describe "File" do
 
     it "gives false when a component of the path is a file" do
       File.executable?(datapath("dir", "test_file.txt", "")).should be_false
+    end
+
+    it "follows symlinks" do
+      with_tempfile("good_symlink_x.txt", "bad_symlink_x.txt") do |good_path, bad_path|
+        crystal = Process.executable_path || pending! "Unable to locate compiler executable"
+        File.symlink(File.expand_path(crystal), good_path)
+        File.symlink(File.expand_path(datapath("non_existing_file.txt")), bad_path)
+
+        File.executable?(good_path).should be_true
+        File.executable?(bad_path).should be_false
+      end
     end
   end
 
@@ -248,7 +274,28 @@ describe "File" do
           File.readable?(path).should be_false
         end
       end
+
+      it "follows symlinks" do
+        with_tempfile("good_symlink_r.txt", "bad_symlink_r.txt", "unreadable.txt") do |good_path, bad_path, unreadable|
+          File.write(unreadable, "")
+          File.chmod(unreadable, 0o222)
+          pending_if_superuser!
+
+          File.symlink(File.expand_path(datapath("test_file.txt")), good_path)
+          File.symlink(File.expand_path(unreadable), bad_path)
+
+          File.readable?(good_path).should be_true
+          File.readable?(bad_path).should be_false
+        end
+      end
     {% end %}
+
+    it "gives false when the symbolic link destination doesn't exist" do
+      with_tempfile("missing_symlink_r.txt") do |missing_path|
+        File.symlink(File.expand_path(datapath("non_existing_file.txt")), missing_path)
+        File.readable?(missing_path).should be_false
+      end
+    end
   end
 
   describe "writable?" do
@@ -270,6 +317,27 @@ describe "File" do
         File.chmod(path, 0o444)
         pending_if_superuser!
         File.writable?(path).should be_false
+      end
+    end
+
+    it "follows symlinks" do
+      with_tempfile("good_symlink_w.txt", "bad_symlink_w.txt", "readonly.txt") do |good_path, bad_path, readonly|
+        File.write(readonly, "")
+        File.chmod(readonly, 0o444)
+        pending_if_superuser!
+
+        File.symlink(File.expand_path(datapath("test_file.txt")), good_path)
+        File.symlink(File.expand_path(readonly), bad_path)
+
+        File.writable?(good_path).should be_true
+        File.writable?(bad_path).should be_false
+      end
+    end
+
+    it "gives false when the symbolic link destination doesn't exist" do
+      with_tempfile("missing_symlink_w.txt") do |missing_path|
+        File.symlink(File.expand_path(datapath("non_existing_file.txt")), missing_path)
+        File.writable?(missing_path).should be_false
       end
     end
   end


### PR DESCRIPTION
This matches the behavior on Unix-like systems. The ability to opt out could be reintroduced as part of #13291.

Note that `File.readable?` can never return false for an existing file on Windows since the method doesn't respect ACLs, but it does return false for a non-existing file. Hence, this method is now entirely equivalent to `File.exists?`.
