### PR TITLE
[Fix]: Doc for Set#proper_superset_of? is incorrect

### DIFF
--- a/src/set.cr
+++ b/src/set.cr
@@ -472,7 +472,7 @@ struct Set(T)
 
   # Returns `true` if the set is a superset of the *other* set.
   #
-  # The *other* must have the same or fewer elements than this set, and all of
+  # The *other* must have fewer elements than this set, and all of
   # elements in the *other* set must be present in this set.
   #
   # ```


### PR DESCRIPTION
The doc for the method should say it needs to be fewer which can be seen by the example.