### PR TITLE
Fix `Socket#close` error handling on Windows

### DIFF
--- a/src/crystal/system/win32/socket.cr
+++ b/src/crystal/system/win32/socket.cr
@@ -486,11 +486,11 @@ module Crystal::System::Socket
     ret = LibC.closesocket(handle)
 
     if ret != 0
-      case Errno.value
-      when Errno::EINTR, Errno::EINPROGRESS
+      case err = WinError.wsa_value
+      when WinError::WSAEINTR, WinError::WSAEINPROGRESS
         # ignore
       else
-        return ::Socket::Error.from_wsa_error("Error closing socket")
+        raise ::Socket::Error.from_os_error("Error closing socket", err)
       end
     end
   end


### PR DESCRIPTION
* Check for `WinError.wsa_value` instead of `Errno.value`, since Windows does not set the latter.
* Actually raise the exception instead of returning it, the same as `src/crystal/system/unix/socket.cr`.