### PR TITLE
Fix docs for `Char#ascii_number?` stating wrong minium base

### DIFF
--- a/src/char.cr
+++ b/src/char.cr
@@ -157,7 +157,7 @@ struct Char
 
   # Returns `true` if this char is an ASCII number in specified base.
   #
-  # Base can be from 0 to 36 with digits from '0' to '9' and 'a' to 'z' or 'A' to 'Z'.
+  # Base can be from 2 to 36 with digits from '0' to '9' and 'a' to 'z' or 'A' to 'Z'.
   #
   # ```
   # '4'.ascii_number?     # => true


### PR DESCRIPTION
Giving a base lower than 2 will raise a compile error.