### PR TITLE
Add specefic format logic for BigRational

### DIFF
--- a/src/humanize.cr
+++ b/src/humanize.cr
@@ -50,6 +50,9 @@ struct Number
     elsif number.is_a?(Int)
       integer = number.abs.to_s
       decimals = ""
+    elsif number.is_a?(BigRational)
+      io << number.numerator.format + "/" + number.denominator.format
+      return
     else
       # TODO: optimize for BigDecimal
       string = number.abs.to_s


### PR DESCRIPTION
resolves #14062

This is a small change, but it fixes the issue and is perhaps not the most efficient solution; the main goal was to not affect the current code base too much.
In the issues, there are 2 approaches mentioned; I went ahead with this one since if a user wants the result as a float, they can still do that by converting the BigRational to a float. 

But I want to present this PR more as a proposal for a solution than as a final solution (thereby, no tests are written/updated). If there is consensus to take the other approach, is that also an option.