### PR TITLE
Disallow assignments to calls with parentheses

### DIFF
--- a/spec/compiler/parser/parser_spec.cr
+++ b/spec/compiler/parser/parser_spec.cr
@@ -267,6 +267,15 @@ module Crystal
     assert_syntax_error "a.b(), c.d = 1"
     assert_syntax_error "a.b, c.d() = 1"
 
+    assert_syntax_error "a() = 1"
+    assert_syntax_error "a {} = 1"
+    assert_syntax_error "a.b() = 1"
+    assert_syntax_error "a.[]() = 1"
+    assert_syntax_error "a() += 1"
+    assert_syntax_error "a {} += 1"
+    assert_syntax_error "a.b() += 1"
+    assert_syntax_error "a.[]() += 1"
+
     it_parses "def foo\n1\nend", Def.new("foo", body: 1.int32)
     it_parses "def downto(n)\n1\nend", Def.new("downto", ["n".arg], 1.int32)
     it_parses "def foo ; 1 ; end", Def.new("foo", body: 1.int32)

--- a/src/compiler/crystal/syntax/parser.cr
+++ b/src/compiler/crystal/syntax/parser.cr
@@ -376,6 +376,8 @@ module Crystal
           break
         when .op_eq?
           slash_is_regex!
+          break unless can_be_assigned?(atomic)
+
           if atomic.is_a?(Call) && atomic.name == "[]"
             next_token_skip_space_or_newline
 
@@ -385,8 +387,6 @@ module Crystal
             atomic.args << arg
             atomic.end_location = arg.end_location
           else
-            break unless can_be_assigned?(atomic)
-
             if atomic.is_a?(Path) && (inside_def? || inside_fun? || @is_constant_assignment)
               raise "dynamic constant assignment. Constants can only be declared at the top level or inside other types."
             end
@@ -6185,7 +6185,7 @@ module Crystal
       when Var, InstanceVar, ClassVar, Path, Global, Underscore
         true
       when Call
-        (node.obj.nil? && node.args.size == 0 && node.block.nil?) || node.name == "[]"
+        !node.has_parentheses? && ((node.obj.nil? && node.args.empty? && node.block.nil?) || node.name == "[]")
       else
         false
       end


### PR DESCRIPTION
Resolves part of https://github.com/crystal-lang/crystal/issues/14482#issuecomment-2051404293. The other part about named arguments is unaffected.

```crystal
foo = 1
foo() = 2     # Error: unexpected token: "="
foo.[]() = 3  # Error: unexpected token: "="
foo() += 4    # Error: unexpected token: "+="
foo.[]() += 5 # Error: unexpected token: "+="
```

By the way, `foo = 1; foo() += 2` used to raise an internal `NilAssertionError` in the normalizer.