### PR TITLE
Add support for `Atomic(Bool)`

### DIFF
--- a/spec/std/atomic_spec.cr
+++ b/spec/std/atomic_spec.cr
@@ -16,6 +16,16 @@ end
 
 describe Atomic do
   describe "#compare_and_set" do
+    it "with bool" do
+      atomic = Atomic.new(true)
+
+      atomic.compare_and_set(false, true).should eq({true, false})
+      atomic.get.should eq(true)
+
+      atomic.compare_and_set(true, false).should eq({true, true})
+      atomic.get.should eq(false)
+    end
+
     it "with integer" do
       atomic = Atomic.new(1)
 
@@ -240,6 +250,12 @@ describe Atomic do
   end
 
   describe "#set" do
+    it "with bool" do
+      atomic = Atomic.new(false)
+      atomic.set(true).should eq(true)
+      atomic.get.should eq(true)
+    end
+
     it "with integer" do
       atomic = Atomic.new(1)
       atomic.set(2).should eq(2)
@@ -272,10 +288,20 @@ describe Atomic do
   it "#lazy_set" do
     atomic = Atomic.new(1)
     atomic.lazy_set(2).should eq(2)
-    atomic.get.should eq(2)
+    atomic.lazy_get.should eq(2)
+
+    bool = Atomic.new(true)
+    bool.lazy_set(false).should eq(false)
+    bool.lazy_get.should eq(false)
   end
 
   describe "#swap" do
+    it "with bool" do
+      atomic = Atomic.new(true)
+      atomic.swap(false).should eq(true)
+      atomic.get.should eq(false)
+    end
+
     it "with integer" do
       atomic = Atomic.new(1)
       atomic.swap(2).should eq(1)

--- a/spec/std/atomic_spec.cr
+++ b/spec/std/atomic_spec.cr
@@ -14,6 +14,12 @@ enum AtomicEnumFlags
   Three
 end
 
+private struct AtomicBooleans
+  @one = Atomic(Bool).new(false)
+  @two = Atomic(Bool).new(false)
+  @three = Atomic(Bool).new(false)
+end
+
 describe Atomic do
   describe "#compare_and_set" do
     it "with bool" do
@@ -346,6 +352,43 @@ describe Atomic do
       atomic = Atomic.new(1)
       atomic.swap(2, :acquire).should eq(1)
       atomic.get.should eq(2)
+    end
+  end
+
+  describe "atomic bool" do
+    it "sizeof" do
+      sizeof(Atomic(Bool)).should eq(1)
+      sizeof(AtomicBooleans).should eq(3)
+    end
+
+    it "gets and sets" do
+      booleans = AtomicBooleans.new
+
+      booleans.@one.get.should eq(false)
+      booleans.@two.get.should eq(false)
+      booleans.@three.get.should eq(false)
+
+      booleans.@two.set(true)
+      booleans.@one.get.should eq(false)
+      booleans.@two.get.should eq(true)
+      booleans.@three.get.should eq(false)
+
+      booleans.@one.set(true)
+      booleans.@three.set(true)
+      booleans.@one.get.should eq(true)
+      booleans.@two.get.should eq(true)
+      booleans.@three.get.should eq(true)
+
+      booleans.@one.set(false)
+      booleans.@three.set(false)
+      booleans.@one.get.should eq(false)
+      booleans.@two.get.should eq(true)
+      booleans.@three.get.should eq(false)
+
+      booleans.@two.set(false)
+      booleans.@one.get.should eq(false)
+      booleans.@two.get.should eq(false)
+      booleans.@three.get.should eq(false)
     end
   end
 end

--- a/src/atomic.cr
+++ b/src/atomic.cr
@@ -465,13 +465,13 @@ end
 # ```
 struct Atomic::Flag
   def initialize
-    @value = 0_u8
+    @value = Atomic(Bool).new(false)
   end
 
   # Atomically tries to set the flag. Only succeeds and returns `true` if the
   # flag wasn't previously set; returns `false` otherwise.
   def test_and_set : Bool
-    ret = Atomic::Ops.atomicrmw(:xchg, pointerof(@value), 1_u8, :sequentially_consistent, false) == 0_u8
+    ret = @value.swap(true, :sequentially_consistent) == false
     {% if flag?(:arm) %}
       Atomic::Ops.fence(:sequentially_consistent, false) if ret
     {% end %}
@@ -483,6 +483,6 @@ struct Atomic::Flag
     {% if flag?(:arm) %}
       Atomic::Ops.fence(:sequentially_consistent, false)
     {% end %}
-    Atomic::Ops.store(pointerof(@value), 0_u8, :sequentially_consistent, true)
+    @value.set(false, :sequentially_consistent)
   end
 end

--- a/src/atomic.cr
+++ b/src/atomic.cr
@@ -292,7 +292,7 @@ struct Atomic(T)
       address = atomicrmw(:xchg, pointerof(@value).as(LibC::SizeT*), LibC::SizeT.new(value.as(Void*).address), ordering)
       Pointer(T).new(address).as(T)
     {% elsif T == Bool %}
-      atomicrmw(:xchg, as_pointer, cast_to(value), ordering) == 1_u8
+      cast_from atomicrmw(:xchg, as_pointer, cast_to(value), ordering)
     {% else %}
       atomicrmw(:xchg, pointerof(@value), value, ordering)
     {% end %}
@@ -414,8 +414,8 @@ struct Atomic(T)
   private def as_pointer
     {% if T == Bool %}
       # assumes that a bool sizeof/alignof is 1 byte (and that a struct wrapping
-      # a single boolean ivar is has a sizeof/alignof of at least 1 byte, too)
-      # so we can safely cast the int1 representation of a bool as an int8.
+      # a single boolean ivar has a sizeof/alignof of at least 1 byte, too) so
+      # we can safely cast the int1 representation of a bool as an int8.
       pointerof(@value).as(Int8*)
     {% else %}
       pointerof(@value)
@@ -434,7 +434,7 @@ struct Atomic(T)
   @[AlwaysInline]
   private def cast_from(value : Tuple)
     {% if T == Bool %}
-      {value[0] == 1_i8, value[1]}
+      {value[0].unsafe_as(Bool), value[1]}
     {% else %}
       value
     {% end %}
@@ -443,7 +443,7 @@ struct Atomic(T)
   @[AlwaysInline]
   private def cast_from(value)
     {% if T == Bool %}
-      value == 1_i8
+      value.unsafe_as(Bool)
     {% else %}
       value
     {% end %}

--- a/src/atomic.cr
+++ b/src/atomic.cr
@@ -43,8 +43,8 @@ struct Atomic(T)
 
   # Creates an Atomic with the given initial value.
   def initialize(@value : T)
-    {% if !T.union? && (T == Char || T < Int::Primitive || T < Enum) %}
-      # Support integer types, enum types, or char (because it's represented as an integer)
+    {% if !T.union? && (T == Bool || T == Char || T < Int::Primitive || T < Enum) %}
+      # Support integer types, enum types, bool or char (because it's represented as an integer)
     {% elsif T < Pointer %}
       # Support pointer types
     {% elsif T.union_types.all? { |t| t == Nil || t < Reference } && T != Nil %}
@@ -71,7 +71,7 @@ struct Atomic(T)
   # atomic.get                   # => 3
   # ```
   def compare_and_set(cmp : T, new : T) : {T, Bool}
-    Ops.cmpxchg(pointerof(@value), cmp.as(T), new.as(T), :sequentially_consistent, :sequentially_consistent)
+    cast_from Ops.cmpxchg(as_pointer, cast_to(cmp), cast_to(new), :sequentially_consistent, :sequentially_consistent)
   end
 
   # Compares this atomic's value with *cmp* using explicit memory orderings:
@@ -93,25 +93,25 @@ struct Atomic(T)
   def compare_and_set(cmp : T, new : T, success_ordering : Ordering, failure_ordering : Ordering) : {T, Bool}
     case {success_ordering, failure_ordering}
     when {.relaxed?, .relaxed?}
-      Ops.cmpxchg(pointerof(@value), cmp.as(T), new.as(T), :monotonic, :monotonic)
+      cast_from Ops.cmpxchg(as_pointer, cast_to(cmp), cast_to(new), :monotonic, :monotonic)
     when {.acquire?, .relaxed?}
-      Ops.cmpxchg(pointerof(@value), cmp.as(T), new.as(T), :acquire, :monotonic)
+      cast_from Ops.cmpxchg(as_pointer, cast_to(cmp), cast_to(new), :acquire, :monotonic)
     when {.acquire?, .acquire?}
-      Ops.cmpxchg(pointerof(@value), cmp.as(T), new.as(T), :acquire, :acquire)
+      cast_from Ops.cmpxchg(as_pointer, cast_to(cmp), cast_to(new), :acquire, :acquire)
     when {.release?, .relaxed?}
-      Ops.cmpxchg(pointerof(@value), cmp.as(T), new.as(T), :release, :monotonic)
+      cast_from Ops.cmpxchg(as_pointer, cast_to(cmp), cast_to(new), :release, :monotonic)
     when {.release?, .acquire?}
-      Ops.cmpxchg(pointerof(@value), cmp.as(T), new.as(T), :release, :acquire)
+      cast_from Ops.cmpxchg(as_pointer, cast_to(cmp), cast_to(new), :release, :acquire)
     when {.acquire_release?, .relaxed?}
-      Ops.cmpxchg(pointerof(@value), cmp.as(T), new.as(T), :acquire_release, :monotonic)
+      cast_from Ops.cmpxchg(as_pointer, cast_to(cmp), cast_to(new), :acquire_release, :monotonic)
     when {.acquire_release?, .acquire?}
-      Ops.cmpxchg(pointerof(@value), cmp.as(T), new.as(T), :acquire_release, :acquire)
+      cast_from Ops.cmpxchg(as_pointer, cast_to(cmp), cast_to(new), :acquire_release, :acquire)
     when {.sequentially_consistent?, .relaxed?}
-      Ops.cmpxchg(pointerof(@value), cmp.as(T), new.as(T), :sequentially_consistent, :monotonic)
+      cast_from Ops.cmpxchg(as_pointer, cast_to(cmp), cast_to(new), :sequentially_consistent, :monotonic)
     when {.sequentially_consistent?, .acquire?}
-      Ops.cmpxchg(pointerof(@value), cmp.as(T), new.as(T), :sequentially_consistent, :acquire)
+      cast_from Ops.cmpxchg(as_pointer, cast_to(cmp), cast_to(new), :sequentially_consistent, :acquire)
     when {.sequentially_consistent?, .sequentially_consistent?}
-      Ops.cmpxchg(pointerof(@value), cmp.as(T), new.as(T), :sequentially_consistent, :sequentially_consistent)
+      cast_from Ops.cmpxchg(as_pointer, cast_to(cmp), cast_to(new), :sequentially_consistent, :sequentially_consistent)
     else
       if failure_ordering.release? || failure_ordering.acquire_release?
         raise ArgumentError.new("Failure ordering cannot include release semantics")
@@ -132,6 +132,7 @@ struct Atomic(T)
   def add(value : T, ordering : Ordering = :sequentially_consistent) : T
     check_pointer_type
     check_reference_type
+    check_bool_type
     atomicrmw(:add, pointerof(@value), value, ordering)
   end
 
@@ -147,6 +148,7 @@ struct Atomic(T)
   def sub(value : T, ordering : Ordering = :sequentially_consistent) : T
     check_pointer_type
     check_reference_type
+    check_bool_type
     atomicrmw(:sub, pointerof(@value), value, ordering)
   end
 
@@ -162,6 +164,7 @@ struct Atomic(T)
   def and(value : T, ordering : Ordering = :sequentially_consistent) : T
     check_pointer_type
     check_reference_type
+    check_bool_type
     atomicrmw(:and, pointerof(@value), value, ordering)
   end
 
@@ -177,6 +180,7 @@ struct Atomic(T)
   def nand(value : T, ordering : Ordering = :sequentially_consistent) : T
     check_pointer_type
     check_reference_type
+    check_bool_type
     atomicrmw(:nand, pointerof(@value), value, ordering)
   end
 
@@ -192,6 +196,7 @@ struct Atomic(T)
   def or(value : T, ordering : Ordering = :sequentially_consistent) : T
     check_pointer_type
     check_reference_type
+    check_bool_type
     atomicrmw(:or, pointerof(@value), value, ordering)
   end
 
@@ -207,6 +212,7 @@ struct Atomic(T)
   def xor(value : T, ordering : Ordering = :sequentially_consistent) : T
     check_pointer_type
     check_reference_type
+    check_bool_type
     atomicrmw(:xor, pointerof(@value), value, ordering)
   end
 
@@ -225,6 +231,7 @@ struct Atomic(T)
   # ```
   def max(value : T, ordering : Ordering = :sequentially_consistent)
     check_reference_type
+    check_bool_type
     {% if T < Enum %}
       if @value.value.is_a?(Int::Signed)
         atomicrmw(:max, pointerof(@value), value, ordering)
@@ -255,6 +262,7 @@ struct Atomic(T)
   # ```
   def min(value : T, ordering : Ordering = :sequentially_consistent)
     check_reference_type
+    check_bool_type
     {% if T < Enum %}
       if @value.value.is_a?(Int::Signed)
         atomicrmw(:min, pointerof(@value), value, ordering)
@@ -283,6 +291,8 @@ struct Atomic(T)
     {% elsif T.union_types.all? { |t| t == Nil || t < Reference } && T != Nil %}
       address = atomicrmw(:xchg, pointerof(@value).as(LibC::SizeT*), LibC::SizeT.new(value.as(Void*).address), ordering)
       Pointer(T).new(address).as(T)
+    {% elsif T == Bool %}
+      atomicrmw(:xchg, as_pointer, cast_to(value), ordering) == 1_u8
     {% else %}
       atomicrmw(:xchg, pointerof(@value), value, ordering)
     {% end %}
@@ -298,11 +308,11 @@ struct Atomic(T)
   def set(value : T, ordering : Ordering = :sequentially_consistent) : T
     case ordering
     in .relaxed?
-      Ops.store(pointerof(@value), value.as(T), :monotonic, true)
+      Ops.store(as_pointer, cast_to(value), :monotonic, true)
     in .release?
-      Ops.store(pointerof(@value), value.as(T), :release, true)
+      Ops.store(as_pointer, cast_to(value), :release, true)
     in .sequentially_consistent?
-      Ops.store(pointerof(@value), value.as(T), :sequentially_consistent, true)
+      Ops.store(as_pointer, cast_to(value), :sequentially_consistent, true)
     in .acquire?, .acquire_release?
       raise ArgumentError.new("Atomic store cannot have acquire semantic")
     end
@@ -325,11 +335,11 @@ struct Atomic(T)
   def get(ordering : Ordering = :sequentially_consistent) : T
     case ordering
     in .relaxed?
-      Ops.load(pointerof(@value), :monotonic, true)
+      cast_from Ops.load(as_pointer, :monotonic, true)
     in .acquire?
-      Ops.load(pointerof(@value), :acquire, true)
+      cast_from Ops.load(as_pointer, :acquire, true)
     in .sequentially_consistent?
-      Ops.load(pointerof(@value), :sequentially_consistent, true)
+      cast_from Ops.load(as_pointer, :sequentially_consistent, true)
     in .release?, .acquire_release?
       raise ArgumentError.new("Atomic load cannot have release semantic")
     end
@@ -340,6 +350,12 @@ struct Atomic(T)
   # NOTE: use with caution, this may break atomic guarantees.
   def lazy_get
     @value
+  end
+
+  private macro check_bool_type
+    {% if T == Bool %}
+      {% raise "Cannot call `#{@type}##{@def.name}` for `#{T}` type" %}
+    {% end %}
   end
 
   private macro check_pointer_type
@@ -392,6 +408,45 @@ struct Atomic(T)
     @[Primitive(:store_atomic)]
     def self.store(ptr : T*, value : T, ordering : LLVM::AtomicOrdering, volatile : Bool) : Nil forall T
     end
+  end
+
+  @[AlwaysInline]
+  private def as_pointer
+    {% if T == Bool %}
+      # assumes that a bool sizeof/alignof is 1 byte (and that a struct wrapping
+      # a single boolean ivar is has a sizeof/alignof of at least 1 byte, too)
+      # so we can safely cast the int1 representation of a bool as an int8.
+      pointerof(@value).as(Int8*)
+    {% else %}
+      pointerof(@value)
+    {% end %}
+  end
+
+@[AlwaysInline]
+  private def cast_to(value)
+    {% if T == Bool %}
+      value ? 1_i8 : 0_i8
+    {% else %}
+      value.as(T)
+    {% end %}
+  end
+
+  @[AlwaysInline]
+  private def cast_from(value : Tuple)
+    {% if T == Bool %}
+      {value[0] == 1_i8, value[1]}
+    {% else %}
+      value
+    {% end %}
+  end
+
+  @[AlwaysInline]
+  private def cast_from(value)
+    {% if T == Bool %}
+      value == 1_i8
+    {% else %}
+      value
+    {% end %}
   end
 end
 

--- a/src/atomic.cr
+++ b/src/atomic.cr
@@ -422,7 +422,7 @@ struct Atomic(T)
     {% end %}
   end
 
-@[AlwaysInline]
+  @[AlwaysInline]
   private def cast_to(value)
     {% if T == Bool %}
       value ? 1_i8 : 0_i8


### PR DESCRIPTION
Tries to enable Atomic(Bool) that should be possible since Bool is represented as an int1 during codegen.

The issue is that atomic ops need at least 1 byte, thus operate on an int8 (or more). A simple solution would be to make `@value` an Int8 when T is Bool, but while doing so the compiler becomes incapable to infer the type of `@value` anymore (see #7975) + we can't set `@value : {{ T == Bool ? Int8 : T }}` at the class level because `T` is unknown at this point.

This patch thus relies on a hack I'm not sure if it's clever or lucky or plain stupid (it's probably a mix of each):

We may represent Bool as an int1 _but_ it looks like the generated assembly acts on a byte (int8). In fact sizeof(Bool) == alignof(Bool) == 1. We also wrap `@value` in a struct which means that sizeof/alignof will also be 1 byte anyway, so it seems safe to cast `@value : Bool` as an int8 pointer `pointerof(@value).as(Int8*)`: there's enough padding to operate on the whole byte (not just the one bit).

Again: it works, but that sounds fragile, ~~if not plain bad...~~.

TODO:
- [x] spec that uses a Foo type with multiple Atomic(Bool) + intertwined Atomic(Int8) and Atomic(Int16) and verify they don't corrupt each other.