### PR TITLE
Refactor `JSON::Any#size` to use two branches instead of three

### DIFF
--- a/src/json/any.cr
+++ b/src/json/any.cr
@@ -73,9 +73,7 @@ struct JSON::Any
   # Raises if the underlying value is not an `Array` or `Hash`.
   def size : Int
     case object = @raw
-    when Array
-      object.size
-    when Hash
+    when Array, Hash
       object.size
     else
       raise "Expected Array or Hash for #size, not #{object.class}"


### PR DESCRIPTION
I don't see any purpose in having 3 branches; the code becomes more compact with 2 branches. However, there might be some technical reason why there are 3 branches (which I am not aware of). 