### PR TITLE
Optimize `Hash` for repeated removals and insertions

### DIFF
--- a/src/hash.cr
+++ b/src/hash.cr
@@ -63,18 +63,18 @@ class Hash(K, V)
   #     that involves more memory allocated and worse performance.
   # - @indices:
   #     A buffer of indices into the @entries buffer.
-  #     An index might mean it's empty or deleted. We could use -2 and -1 for
-  #     this but because of an optimization we'll explain later we use 0 and 1,
-  #     and all other values represent indices which are 2 less than their
-  #     actual value (so value 4 means index 2).
+  #     An index might mean it's empty. We could use -1 for this but because
+  #     of an optimization we'll explain later we use 0, and all other values
+  #     represent indices which are 1 less than their actual value (so value
+  #     3 means index 2).
   #     When a key-value pair is inserted we first find the key's hash and
   #     then fit it (by modulo) into the indices buffer size. For example,
   #     assuming we are inserting a new key-value pair with key "hello",
   #     if the indices size is 128, the key is "hello" and its hash is
   #     987 then fitting it into 128 is (987 % 128) gives 91. Lets also
-  #     assume there are already 3 entries in @entries. We go ahead and add
+  #     assume there are already 3 entries in @entries. We go ahead an add
   #     a new entry at index 3, and at position 91 in @indices we store 3
-  #     (well, actually 5 because we store 2 more than the actual index
+  #     (well, actually 4 because we store 1 more than the actual index
   #     because 0 means empty, as explained above).
   #
   # Open addressing means that if, in the example above, we go and try to
@@ -82,7 +82,7 @@ class Hash(K, V)
   # in indices (let's say, 91 again), because it's occupied we will insert
   # it into the next non-empty slot. We try with 92. If it's empty we again
   # go and insert it intro `@entries` and store the index at 92 (continuing
-  # with the previous example we would store the value 5).
+  # with the previous example we would store the value 4).
   #
   # If we keep the size of @indices the same as @entries it means that in the worse
   # case @indices is full and when finding a match we have to traverse it all,
@@ -353,16 +353,6 @@ class Hash(K, V)
   # as Pointer(UInt16).
   private MAX_INDICES_BYTESIZE_2 = 65536
 
-  # Special value returned by `get_index` to indicate an empty index. Can be
-  # replaced with a used index by `#upsert`. Stops linear entry lookup in
-  # `@indices`.
-  private EMPTY_INDEX = -2
-
-  # Special value returned by `get_index` to indicate a deleted index. Can be
-  # replaced with a used index by `#upsert`. Allows linear entry lookup in
-  # `@indices` to continue, so that hash collisions do not break.
-  private DELETED_INDEX = -1
-
   # Inserts or updates a key-value pair.
   # Returns an `Entry` if it was updated, otherwise `nil`.
   private def upsert(key, value) : Entry(K, V)?
@@ -407,8 +397,8 @@ class Hash(K, V)
     while true
       entry_index = get_index(index)
 
-      # If the index entry is unused...
-      if unused_index?(entry_index)
+      # If the index entry is empty...
+      if entry_index == -1
         # If we reached the maximum in `@entries` it's time to resize
         if entries_full?
           resize
@@ -470,25 +460,22 @@ class Hash(K, V)
     while true
       entry_index = get_index(index)
 
-      # If we find an empty index slot, there are no more keys to search
-      if entry_index == EMPTY_INDEX
+      # If we find an empty index slot, there's no such key
+      if entry_index == -1
         return nil
       end
 
-      # Skip over deleted index slots
-      unless entry_index == DELETED_INDEX
-        # We found a non-empty slot, let's see if the key we have matches
-        entry = get_entry(entry_index)
-        if entry_matches?(entry, hash, key)
-          # Mark this index slot as deleted
-          delete_index(index)
-          delete_entry_and_update_counts(entry_index)
-          return entry
-        end
+      # We found a non-empty slot, let's see if the key we have matches
+      entry = get_entry(entry_index)
+      if entry_matches?(entry, hash, key)
+        # Mark this index slot as deleted
+        delete_index(index)
+        delete_entry_and_update_counts(entry_index)
+        return entry
+      else
+        # If it doesn't, check the next index...
+        index = next_index(index)
       end
-
-      # Nope, move on to the next slot
-      index = next_index(index)
     end
   end
 
@@ -531,23 +518,20 @@ class Hash(K, V)
     while true
       entry_index = get_index(index)
 
-      # If we find an empty index slot, there are no more keys to search
-      if entry_index == EMPTY_INDEX
+      # If we find an empty index slot, there's no such key
+      if entry_index == -1
         return nil
       end
 
-      # Skip over deleted index slots
-      unless entry_index == DELETED_INDEX
-        # We found a non-empty slot, let's see if the key we have matches
-        entry = get_entry(entry_index)
-        if entry_matches?(entry, hash, key)
-          # It does!
-          return entry, entry_index
-        end
+      # We found a non-empty slot, let's see if the key we have matches
+      entry = get_entry(entry_index)
+      if entry_matches?(entry, hash, key)
+        # It does!
+        return entry, entry_index
+      else
+        # Nope, move on to the next slot
+        index = next_index(index)
       end
-
-      # Nope, move on to the next slot
-      index = next_index(index)
     end
   end
 
@@ -637,10 +621,10 @@ class Hash(K, V)
       end
 
       if has_indices
-        # Then we try to find an empty or deleted index slot
+        # Then we try to find an empty index slot
         # (we should find one now that we have more space)
         index = fit_in_indices(entry_hash)
-        until unused_index?(get_index(index))
+        until get_index(index) == -1
           index = next_index(index)
         end
         set_index(index, new_entry_index)
@@ -757,7 +741,7 @@ class Hash(K, V)
   end
 
   # Gets from `@indices` at the given `index`.
-  # Returns `EMPTY_INDEX`, `DELETED_INDEX`, or an index in `@entries`.
+  # Returns the index in `@entries` or `-1` if the slot is empty.
   private def get_index(index : Int32) : Int32
     # Check what we have: UInt8, Int16 or UInt32 buckets
     value = case @indices_bytesize
@@ -769,16 +753,15 @@ class Hash(K, V)
               @indices.as(UInt32*)[index].to_i32!
             end
 
-    # Because we increment the value by two when we store the value
-    # here we have to subtract two
-    value &- 2
+    # Because we increment the value by one when we store the value
+    # here we have to subtract one
+    value - 1
   end
 
   # Sets `@indices` at `index` with the given value.
   private def set_index(index, value) : Nil
-    # We actually store 2 more than the value so that `EMPTY_INDEX` and
-    # `DELETED_INDEX` could fit.
-    value &+= 2
+    # We actually store 1 more than the value because 0 means empty.
+    value += 1
 
     # We also have to see what we have: UInt8, UInt16 or UInt32 buckets.
     case @indices_bytesize
@@ -791,19 +774,19 @@ class Hash(K, V)
     end
   end
 
-  # Marks `@indices` at `index` as deleted. Might also adjust subsequent index
-  # slots to ensure `DELETED_INDEX` never appears before the natural position of
+  # Marks `@indices` at `index` as empty. Might also adjust subsequent index
+  # slots to ensure empty indices never appear before the natural position of
   # any used index, in case of previous hash collisions.
   private def delete_index(index) : Nil
     # https://en.wikipedia.org/w/index.php?title=Open_addressing&oldid=1188919190#Example_pseudocode
     i = index
-    set_index(i, DELETED_INDEX)
+    set_index(i, -1)
 
     j = i
     while true
       j = next_index(j)
       entry_index = get_index(j)
-      break if unused_index?(entry_index)
+      break if entry_index == -1
 
       entry = get_entry(entry_index)
       k = fit_in_indices(entry.hash)
@@ -815,16 +798,9 @@ class Hash(K, V)
       end
 
       set_index(i, entry_index)
-      set_index(j, DELETED_INDEX)
+      set_index(j, -1)
       i = j
     end
-  end
-
-  # Returns whether the given *index* is unused, i.e. it is empty or deleted.
-  private def unused_index?(index : Int32) : Bool
-    # all valid indices are non-negative, so this is more or less equivalent to
-    # `index.in?(EMPTY_INDEX, DELETED_INDEX)`
-    index < 0
   end
 
   # Returns the capacity of `@indices`.


### PR DESCRIPTION
Hash deletions do not clear `@indices`, so subsequent insertions with the same key cannot use those slots, and effectively behave like hash collisions. This PR adds an extra sentinel value for deleted index slots; they can be later filled in and, unlike the empty sentinel, do not halt index scans. See https://forum.crystal-lang.org/t/hash-delete-followed-by-insert-performance-issues/6784 for a discussion. Credit goes to @homonoidian for discovering this.

<details>
<summary>Benchmark:</summary>

```crystal
require "benchmark"

Benchmark.ips do |b|
  (2..10).each do |i|
    capacity = 1 << i
    b.report("capacity = #{capacity}, empty") do
      h = Hash(Int32, Int32).new(initial_capacity: capacity)
      10000.times do
        h.delete(100)
        h[100] = 123
      end
    end
  end
end

puts

Benchmark.ips do |b|
  (2..10).each do |i|
    capacity = 1 << i
    b.report("capacity = #{capacity}, filled") do
      h = Hash(Int32, Int32).new(initial_capacity: capacity)
      (capacity // 4).times { |i| h[i] = i }
      10000.times do
        h.delete(100)
        h[100] = 123
      end
    end
  end
end
```

Before:

```
   capacity = 4, empty  14.96k ( 66.83µs) (± 0.53%)    176B/op         fastest
   capacity = 8, empty  14.96k ( 66.83µs) (± 0.69%)    176B/op    1.00× slower
  capacity = 16, empty  13.82k ( 72.38µs) (± 0.94%)    272B/op    1.08× slower
  capacity = 32, empty   1.91k (522.44µs) (± 3.49%)    592B/op    7.82× slower
  capacity = 64, empty   1.07k (938.40µs) (± 0.57%)  0.99kB/op   14.04× slower
 capacity = 128, empty 582.25  (  1.72ms) (± 0.50%)  2.32kB/op   25.70× slower
 capacity = 256, empty 322.94  (  3.10ms) (± 0.50%)  4.38kB/op   46.34× slower
 capacity = 512, empty 169.62  (  5.90ms) (± 0.94%)   8.1kB/op   88.22× slower
capacity = 1024, empty  88.60  ( 11.29ms) (± 1.19%)  16.1kB/op  168.89× slower

   capacity = 4, filled   7.97k (125.51µs) (± 0.63%)    176B/op        fastest
   capacity = 8, filled   6.94k (144.02µs) (± 0.82%)    177B/op   1.15× slower
  capacity = 16, filled   4.55k (219.98µs) (± 1.70%)    272B/op   1.75× slower
  capacity = 32, filled   2.23k (448.43µs) (± 1.06%)    592B/op   3.57× slower
  capacity = 64, filled   1.18k (849.64µs) (± 0.64%)  0.99kB/op   6.77× slower
 capacity = 128, filled 660.20  (  1.51ms) (± 0.65%)  2.32kB/op  12.07× slower
 capacity = 256, filled 365.25  (  2.74ms) (± 0.59%)  4.39kB/op  21.81× slower
 capacity = 512, filled 198.40  (  5.04ms) (± 4.68%)   8.1kB/op  40.16× slower
capacity = 1024, filled 102.61  (  9.75ms) (± 2.87%)  16.1kB/op  77.65× slower
```

After:

```
   capacity = 4, empty  15.26k ( 65.52µs) (± 0.39%)    176B/op        fastest
   capacity = 8, empty  15.24k ( 65.60µs) (± 0.57%)    176B/op   1.00× slower
  capacity = 16, empty  14.19k ( 70.48µs) (± 1.32%)    272B/op   1.08× slower
  capacity = 32, empty  10.70k ( 93.47µs) (± 0.79%)    592B/op   1.43× slower
  capacity = 64, empty  10.69k ( 93.54µs) (± 3.13%)  0.99kB/op   1.43× slower
 capacity = 128, empty  10.77k ( 92.86µs) (± 1.04%)  2.32kB/op   1.42× slower
 capacity = 256, empty  11.43k ( 87.45µs) (± 1.32%)  4.39kB/op   1.33× slower
 capacity = 512, empty  11.51k ( 86.85µs) (± 0.67%)   8.1kB/op   1.33× slower
capacity = 1024, empty  11.50k ( 86.95µs) (± 0.60%)  16.1kB/op   1.33× slower

   capacity = 4, filled   8.02k (124.74µs) (± 0.72%)    176B/op   1.18× slower
   capacity = 8, filled   7.04k (141.99µs) (± 0.66%)    177B/op   1.34× slower
  capacity = 16, filled   4.57k (218.80µs) (± 0.54%)    272B/op   2.07× slower
  capacity = 32, filled   9.12k (109.67µs) (± 1.14%)    592B/op   1.04× slower
  capacity = 64, filled   9.45k (105.78µs) (± 0.80%)  0.99kB/op        fastest
 capacity = 128, filled   7.51k (133.13µs) (± 0.95%)  2.32kB/op   1.26× slower
 capacity = 256, filled   7.58k (131.92µs) (± 0.77%)  4.39kB/op   1.25× slower
 capacity = 512, filled   7.61k (131.43µs) (± 0.66%)   8.1kB/op   1.24× slower
capacity = 1024, filled   8.86k (112.91µs) (± 0.68%)  16.1kB/op   1.07× slower
```

</details>

This scenario now runs in O(1) instead of O(n) time. Note however that deletion is now the opposite, running in O(n) time to the number of hash collisions, instead of O(1). That means it is possible to craft other scenarios where running time grows from linear to quadratic:

<details>
<summary>Benchmark:</summary>

```crystal
require "benchmark"

record BadKey, x : Int32 do
  def hash
    1
  end
end

# all keys have hash collisions; the first key in the collision chain is
# deleted at every step, so `#index_for_entry_index` returns immediately,
# but `#delete_index` shifts the entire chain of indices
Benchmark.ips do |b|
  (6..10).each do |n|
    b.report("N = #{1 << n}") do
      h = Hash(BadKey, Void*).new(initial_capacity: 4096)
      keys = Array.new(1 << n) { |i| BadKey.new(i) }
      keys.each { |k| h[k] = Pointer(Void).null }

      keys.cycle(1000) do |k|
        h.delete(k)
        h[k] = Pointer(Void).null
      end
    end
  end
end
```

Before:

```
  N = 64   4.29  (233.37ms) (± 0.37%)  80.6kB/op        fastest
 N = 128   2.13  (469.17ms) (± 0.18%)  81.1kB/op   2.01× slower
 N = 256   1.05  (952.04ms) (± 0.08%)  81.3kB/op   4.08× slower
 N = 512 511.41m (  1.96s ) (± 0.04%)  82.0kB/op   8.38× slower
N = 1024 239.93m (  4.17s ) (± 0.17%)  84.1kB/op  17.86× slower
```

After:

```
  N = 64  89.49  ( 11.18ms) (± 0.50%)  80.4kB/op         fastest
 N = 128  22.58  ( 44.30ms) (± 0.75%)  80.8kB/op    3.96× slower
 N = 256   5.66  (176.81ms) (± 0.54%)  81.3kB/op   15.82× slower
 N = 512   1.38  (722.15ms) (± 2.30%)  82.0kB/op   64.62× slower
N = 1024 341.43m (  2.93s ) (± 0.43%)  84.1kB/op  262.09× slower
```

</details>

Note that checking `Hash::Entry#deleted?` doesn't suffice because that also returns true for elements in `@entries` which were previously unused. Also this PR doesn't change how `@entries` is used, and `#do_compaction` will still be called every now and then whenever `@entries` reaches its capacity (similar to alternating `#push` and `#shift` calls on an `Array`).