### PR TITLE
Make ECR handle filename that contains quotation marks

### DIFF
--- a/src/compiler/crystal/syntax/lexer.cr
+++ b/src/compiler/crystal/syntax/lexer.cr
@@ -2372,10 +2372,9 @@ module Crystal
         filename_pos = current_pos
 
         while true
-          case current_char
-          when '"'
+          if '"' == current_char && peek_next_char == ','
             break
-          when '\0'
+          elsif current_char == '\0'
             raise "unexpected end of file in loc pragma"
           else
             next_char_no_column_increment


### PR DESCRIPTION
resolves #12928 

This is just an attempt to solve the problem; I don't personally know if this approach has any issues, so I leave this mostly as a draft.

There might be a need for more of a rework to make the system more robust, this is mostly just intended as a quick fix.