### PR TITLE
Set UTF-8 charset on directory listing in `HTTP::StaticFileHandler`

### DIFF
--- a/src/http/server/handlers/static_file_handler.cr
+++ b/src/http/server/handlers/static_file_handler.cr
@@ -86,7 +86,7 @@ class HTTP::StaticFileHandler
     context.response.headers["Accept-Ranges"] = "bytes"
 
     if @directory_listing && is_dir
-      context.response.content_type = "text/html"
+      context.response.content_type = "text/html;charset=UTF-8;"
       directory_listing(context.response, request_path, file_path)
     elsif is_file
       last_modified = file_info.modification_time

--- a/src/http/server/handlers/static_file_handler.cr
+++ b/src/http/server/handlers/static_file_handler.cr
@@ -86,7 +86,7 @@ class HTTP::StaticFileHandler
     context.response.headers["Accept-Ranges"] = "bytes"
 
     if @directory_listing && is_dir
-      context.response.content_type = "text/html;charset=UTF-8;"
+      context.response.content_type = "text/html; charset=utf-8"
       directory_listing(context.response, request_path, file_path)
     elsif is_file
       last_modified = file_info.modification_time


### PR DESCRIPTION
Within the directory listing handler, the absence of an explicit charset in the content type has led to issues, particularly with directories containing non-ASCII symbols, resulting in broken displays.



<img src="https://github.com/crystal-lang/crystal/assets/860357/b4bbdf18-9593-4b48-a3b3-b2db48dd15c2" width="440" height="240">



Adding charset charset=UTF-8 to the Content-type header fixes this issue.


<img src="https://github.com/crystal-lang/crystal/assets/860357/0a73f0c3-de4b-464c-baaa-bd15ff8c2913" width="440" height="240">


Alternative solution is to add <meta charset="UTF-8"> to https://github.com/crystal-lang/crystal/blob/master/src/http/server/handlers/static_file_handler.html
