### PR TITLE
Refactor use `IO#read_byte` instead of `#read_char` in `HTTP::ChunkedContent`

### DIFF
--- a/src/http/content.cr
+++ b/src/http/content.cr
@@ -192,11 +192,11 @@ module HTTP
     end
 
     private def read_crlf
-      char = @io.read_char
-      if char == '\r'
-        char = @io.read_char
+      char = @io.read_byte
+      if char === '\r'
+        char = @io.read_byte
       end
-      if char != '\n'
+      unless char === '\n'
         raise IO::Error.new("Invalid HTTP chunked content: expected CRLF")
       end
     end


### PR DESCRIPTION
The HTTP protocol is based on ASCII characters, so there's no need to employ UTF-8 decoding.