### PR TITLE
`Thread` owns its current fiber (instead of `Crystal::Scheduler`)

### DIFF
--- a/src/crystal/system/thread.cr
+++ b/src/crystal/system/thread.cr
@@ -45,6 +45,9 @@ class Thread
   # Returns the Fiber representing the thread's main stack.
   getter! main_fiber : Fiber
 
+  # Returns the Fiber currently running on the thread.
+  property! current_fiber : Fiber
+
   # :nodoc:
   property next : Thread?
 
@@ -68,7 +71,7 @@ class Thread
   def initialize
     @func = ->(t : Thread) {}
     @system_handle = Crystal::System::Thread.current_handle
-    @main_fiber = Fiber.new(stack_address, self)
+    @current_fiber = @main_fiber = Fiber.new(stack_address, self)
 
     Thread.threads.push(self)
   end
@@ -120,7 +123,7 @@ class Thread
   protected def start
     Thread.threads.push(self)
     Thread.current = self
-    @main_fiber = fiber = Fiber.new(stack_address, self)
+    @current_fiber = @main_fiber = fiber = Fiber.new(stack_address, self)
 
     if name = @name
       self.system_name = name

--- a/src/fiber.cr
+++ b/src/fiber.cr
@@ -173,7 +173,7 @@ class Fiber
 
   # Returns the current fiber.
   def self.current : Fiber
-    Crystal::Scheduler.current_fiber
+    Thread.current.current_fiber
   end
 
   # The fiber's proc is currently running or didn't fully save its context. The
@@ -246,11 +246,11 @@ class Fiber
   # The current fiber will resume after a period of time.
   # The timeout can be cancelled with `cancel_timeout`
   def self.timeout(timeout : Time::Span?, select_action : Channel::TimeoutAction? = nil) : Nil
-    Crystal::Scheduler.current_fiber.timeout(timeout, select_action)
+    Fiber.current.timeout(timeout, select_action)
   end
 
   def self.cancel_timeout : Nil
-    Crystal::Scheduler.current_fiber.cancel_timeout
+    Fiber.current.cancel_timeout
   end
 
   # Yields to the scheduler and allows it to swap execution to other

--- a/src/gc/boehm.cr
+++ b/src/gc/boehm.cr
@@ -374,7 +374,7 @@ module GC
 
       {% if flag?(:preview_mt) %}
         Thread.unsafe_each do |thread|
-          if fiber = thread.@current_fiber
+          if fiber = thread.current_fiber?
             GC.set_stackbottom(thread.gc_thread_handler, fiber.@stack_bottom)
           end
         end

--- a/src/gc/boehm.cr
+++ b/src/gc/boehm.cr
@@ -374,8 +374,7 @@ module GC
 
       {% if flag?(:preview_mt) %}
         Thread.unsafe_each do |thread|
-          if scheduler = thread.@scheduler
-            fiber = scheduler.@current
+          if fiber = thread.@current_fiber
             GC.set_stackbottom(thread.gc_thread_handler, fiber.@stack_bottom)
           end
         end


### PR DESCRIPTION
Moves the reference to the running Fiber from `Crystal::Scheduler` to `Thread`. This way the thread itself knows which fiber is currently running, independently of any scheduling.

This allows the GC collection callback as well as `Fiber.current` to access `Thread#current_fiber` directly, without having to know anything about the schedulers.

This is part 1 of abstracting `Crystal::Scheduler` away.