### PR TITLE
Abstract Crystal::Scheduler methods

### DIFF
--- a/spec/std/channel_spec.cr
+++ b/spec/std/channel_spec.cr
@@ -2,8 +2,8 @@ require "spec"
 require "./spec_helper"
 
 private def yield_to(fiber)
-  Crystal::Scheduler.enqueue(Fiber.current)
-  Crystal::Scheduler.resume(fiber)
+  Fiber.current.enqueue
+  fiber.resume
 end
 
 private macro parallel(*jobs)

--- a/spec/std/concurrent/select_spec.cr
+++ b/spec/std/concurrent/select_spec.cr
@@ -99,7 +99,7 @@ describe "select" do
         x = b
       end
     ensure
-      Crystal::Scheduler.enqueue(main)
+      main.enqueue
     end
 
     sleep

--- a/src/channel.cr
+++ b/src/channel.cr
@@ -744,7 +744,7 @@ class Channel(T)
 
     def time_expired(fiber : Fiber) : Nil
       if @select_context.try &.try_trigger
-        Crystal::Scheduler.enqueue fiber
+        fiber.enqueue
       end
     end
   end

--- a/src/channel.cr
+++ b/src/channel.cr
@@ -231,7 +231,7 @@ class Channel(T)
       @senders.push pointerof(sender)
       @lock.unlock
 
-      Crystal::Scheduler.reschedule
+      Fiber.suspend
 
       case sender.state
       in .delivered?
@@ -308,7 +308,7 @@ class Channel(T)
       @receivers.push pointerof(receiver)
       @lock.unlock
 
-      Crystal::Scheduler.reschedule
+      Fiber.suspend
 
       case receiver.state
       in .delivered?
@@ -473,7 +473,7 @@ class Channel(T)
     contexts = ops.map &.create_context_and_wait(shared_state)
 
     each_skip_duplicates(ops_locks, &.unlock)
-    Crystal::Scheduler.reschedule
+    Fiber.suspend
 
     contexts.each_with_index do |context, index|
       op = ops[index]

--- a/src/crystal/system/event_loop.cr
+++ b/src/crystal/system/event_loop.cr
@@ -2,6 +2,11 @@ abstract class Crystal::EventLoop
   # Creates an event loop instance
   # def self.create : Crystal::EventLoop
 
+  @[AlwaysInline]
+  def self.current : self
+    Crystal::Scheduler.event_loop
+  end
+
   # Runs the event loop.
   abstract def run_once : Nil
 

--- a/src/crystal/system/unix/event_loop_libevent.cr
+++ b/src/crystal/system/unix/event_loop_libevent.cr
@@ -26,7 +26,7 @@ class Crystal::LibEvent::EventLoop < Crystal::EventLoop
   # Create a new resume event for a fiber.
   def create_resume_event(fiber : Fiber) : Crystal::EventLoop::Event
     event_base.new_event(-1, LibEvent2::EventFlags::None, fiber) do |s, flags, data|
-      Crystal::Scheduler.enqueue data.as(Fiber)
+      data.as(Fiber).enqueue
     end
   end
 
@@ -38,7 +38,7 @@ class Crystal::LibEvent::EventLoop < Crystal::EventLoop
         f.timeout_select_action = nil
         select_action.time_expired(f)
       else
-        Crystal::Scheduler.enqueue f
+        f.enqueue
       end
     end
   end

--- a/src/crystal/system/win32/event_loop_iocp.cr
+++ b/src/crystal/system/win32/event_loop_iocp.cr
@@ -58,7 +58,7 @@ class Crystal::Iocp::EventLoop < Crystal::EventLoop
 
       timed_out = IO::Overlapped.wait_queued_completions(wait_time.total_milliseconds) do |fiber|
         # This block may run multiple times. Every single fiber gets enqueued.
-        Crystal::Scheduler.enqueue fiber
+        fiber.enqueue
       end
 
       # If the wait for completion timed out we've reached the wake time and
@@ -90,7 +90,7 @@ class Crystal::Iocp::EventLoop < Crystal::EventLoop
       fiber.timeout_select_action = nil
       select_action.time_expired(fiber)
     else
-      Crystal::Scheduler.enqueue fiber
+      fiber.enqueue
     end
   end
 

--- a/src/crystal/system/win32/event_loop_iocp.cr
+++ b/src/crystal/system/win32/event_loop_iocp.cr
@@ -126,7 +126,7 @@ class Crystal::Iocp::Event
 
   # Frees the event
   def free : Nil
-    Crystal::Scheduler.event_loop.dequeue(self)
+    Crystal::EventLoop.current.dequeue(self)
   end
 
   def delete
@@ -135,6 +135,6 @@ class Crystal::Iocp::Event
 
   def add(timeout : Time::Span?) : Nil
     @wake_at = timeout ? Time.monotonic + timeout : Time.monotonic
-    Crystal::Scheduler.event_loop.enqueue(self)
+    Crystal::EventLoop.current.enqueue(self)
   end
 end

--- a/src/crystal/system/win32/file_descriptor.cr
+++ b/src/crystal/system/win32/file_descriptor.cr
@@ -238,13 +238,13 @@ module Crystal::System::FileDescriptor
     w_pipe_flags |= LibC::FILE_FLAG_OVERLAPPED unless write_blocking
     w_pipe = LibC.CreateNamedPipeA(pipe_name, w_pipe_flags, pipe_mode, 1, PIPE_BUFFER_SIZE, PIPE_BUFFER_SIZE, 0, nil)
     raise IO::Error.from_winerror("CreateNamedPipeA") if w_pipe == LibC::INVALID_HANDLE_VALUE
-    Crystal::Scheduler.event_loop.create_completion_port(w_pipe) unless write_blocking
+    Crystal::EventLoop.current.create_completion_port(w_pipe) unless write_blocking
 
     r_pipe_flags = LibC::FILE_FLAG_NO_BUFFERING
     r_pipe_flags |= LibC::FILE_FLAG_OVERLAPPED unless read_blocking
     r_pipe = LibC.CreateFileW(System.to_wstr(pipe_name), LibC::GENERIC_READ | LibC::FILE_WRITE_ATTRIBUTES, 0, nil, LibC::OPEN_EXISTING, r_pipe_flags, nil)
     raise IO::Error.from_winerror("CreateFileW") if r_pipe == LibC::INVALID_HANDLE_VALUE
-    Crystal::Scheduler.event_loop.create_completion_port(r_pipe) unless read_blocking
+    Crystal::EventLoop.current.create_completion_port(r_pipe) unless read_blocking
 
     r = IO::FileDescriptor.new(r_pipe.address, read_blocking)
     w = IO::FileDescriptor.new(w_pipe.address, write_blocking)

--- a/src/crystal/system/win32/process.cr
+++ b/src/crystal/system/win32/process.cr
@@ -81,7 +81,7 @@ struct Crystal::System::Process
     # stuck forever in that case?
     # (https://learn.microsoft.com/en-us/windows/win32/api/winnt/ns-winnt-jobobject_associate_completion_port)
     @completion_key.fiber = ::Fiber.current
-    Crystal::Scheduler.reschedule
+    Fiber.suspend
 
     # If the IOCP notification is delivered before the process fully exits,
     # wait for it

--- a/src/crystal/system/win32/process.cr
+++ b/src/crystal/system/win32/process.cr
@@ -37,7 +37,7 @@ struct Crystal::System::Process
       LibC::JOBOBJECTINFOCLASS::AssociateCompletionPortInformation,
       LibC::JOBOBJECT_ASSOCIATE_COMPLETION_PORT.new(
         completionKey: @completion_key.as(Void*),
-        completionPort: Crystal::Scheduler.event_loop.iocp,
+        completionPort: Crystal::EventLoop.current.iocp,
       ),
     )
 

--- a/src/crystal/system/win32/process.cr
+++ b/src/crystal/system/win32/process.cr
@@ -81,7 +81,7 @@ struct Crystal::System::Process
     # stuck forever in that case?
     # (https://learn.microsoft.com/en-us/windows/win32/api/winnt/ns-winnt-jobobject_associate_completion_port)
     @completion_key.fiber = ::Fiber.current
-    Fiber.suspend
+    ::Fiber.suspend
 
     # If the IOCP notification is delivered before the process fully exits,
     # wait for it

--- a/src/crystal/system/win32/socket.cr
+++ b/src/crystal/system/win32/socket.cr
@@ -79,7 +79,7 @@ module Crystal::System::Socket
       raise ::Socket::Error.from_wsa_error("WSASocketW")
     end
 
-    Crystal::Scheduler.event_loop.create_completion_port LibC::HANDLE.new(socket)
+    Crystal::EventLoop.current.create_completion_port LibC::HANDLE.new(socket)
 
     socket
   end

--- a/src/fiber.cr
+++ b/src/fiber.cr
@@ -168,7 +168,7 @@ class Fiber
     {% unless flag?(:interpreted) %}
       Crystal::Scheduler.stack_pool.release(@stack)
     {% end %}
-    Crystal::Scheduler.reschedule
+    Fiber.suspend
   end
 
   # Returns the current fiber.
@@ -283,6 +283,19 @@ class Fiber
   # ```
   def self.yield : Nil
     Crystal::Scheduler.yield
+  end
+
+  # Yields to the scheduler and tells it to swap execution to another waiting
+  # fibers. Unlike `Fiber.yield` the current fiber won't be automatically
+  # reenqueued and won't be resumed until it has been explicitely reenqueued.
+  #
+  # This is equivalent to `sleep` without a time.
+  #
+  # This method is particularly useful to stop the execution of the current
+  # fiber until something happens, for example an IO event, a message is ready
+  # in a channel, and so on.
+  def self.suspend : Nil
+    Crystal::Scheduler.reschedule
   end
 
   def to_s(io : IO) : Nil

--- a/src/fiber.cr
+++ b/src/fiber.cr
@@ -223,12 +223,12 @@ class Fiber
 
   # :nodoc:
   def resume_event : Crystal::EventLoop::Event
-    @resume_event ||= Crystal::Scheduler.event_loop.create_resume_event(self)
+    @resume_event ||= Crystal::EventLoop.current.create_resume_event(self)
   end
 
   # :nodoc:
   def timeout_event : Crystal::EventLoop::Event
-    @timeout_event ||= Crystal::Scheduler.event_loop.create_timeout_event(self)
+    @timeout_event ||= Crystal::EventLoop.current.create_timeout_event(self)
   end
 
   # :nodoc:

--- a/src/io/evented.cr
+++ b/src/io/evented.cr
@@ -90,7 +90,7 @@ module IO::Evented
     readers = @readers.get { Deque(Fiber).new }
     readers << Fiber.current
     add_read_event(timeout)
-    Crystal::Scheduler.reschedule
+    Fiber.suspend
 
     if @read_timed_out
       @read_timed_out = false
@@ -115,7 +115,7 @@ module IO::Evented
     writers = @writers.get { Deque(Fiber).new }
     writers << Fiber.current
     add_write_event(timeout)
-    Crystal::Scheduler.reschedule
+    Fiber.suspend
 
     if @write_timed_out
       @write_timed_out = false

--- a/src/io/evented.cr
+++ b/src/io/evented.cr
@@ -137,8 +137,14 @@ module IO::Evented
   def evented_close : Nil
     @read_event.consume_each &.free
     @write_event.consume_each &.free
-    @readers.consume_each &.enqueue
-    @writers.consume_each &.enqueue
+
+    @readers.consume_each do |readers|
+      Crystal::Scheduler.enqueue readers
+    end
+
+    @writers.consume_each do |writers|
+      Crystal::Scheduler.enqueue writers
+    end
   end
 
   private def resume_pending_readers

--- a/src/io/evented.cr
+++ b/src/io/evented.cr
@@ -67,7 +67,7 @@ module IO::Evented
     @read_timed_out = timed_out
 
     if reader = @readers.get?.try &.shift?
-      Crystal::Scheduler.enqueue reader
+      reader.enqueue
     end
   end
 
@@ -76,7 +76,7 @@ module IO::Evented
     @write_timed_out = timed_out
 
     if writer = @writers.get?.try &.shift?
-      Crystal::Scheduler.enqueue writer
+      writer.enqueue
     end
   end
 
@@ -136,16 +136,9 @@ module IO::Evented
 
   def evented_close : Nil
     @read_event.consume_each &.free
-
     @write_event.consume_each &.free
-
-    @readers.consume_each do |readers|
-      Crystal::Scheduler.enqueue readers
-    end
-
-    @writers.consume_each do |writers|
-      Crystal::Scheduler.enqueue writers
-    end
+    @readers.consume_each &.enqueue
+    @writers.consume_each &.enqueue
   end
 
   private def resume_pending_readers

--- a/src/io/evented.cr
+++ b/src/io/evented.cr
@@ -101,7 +101,7 @@ module IO::Evented
   end
 
   private def add_read_event(timeout = @read_timeout) : Nil
-    event = @read_event.get { Crystal::Scheduler.event_loop.create_fd_read_event(self) }
+    event = @read_event.get { Crystal::EventLoop.current.create_fd_read_event(self) }
     event.add timeout
   end
 
@@ -126,7 +126,7 @@ module IO::Evented
   end
 
   private def add_write_event(timeout = @write_timeout) : Nil
-    event = @write_event.get { Crystal::Scheduler.event_loop.create_fd_write_event(self) }
+    event = @write_event.get { Crystal::EventLoop.current.create_fd_write_event(self) }
     event.add timeout
   end
 

--- a/src/io/overlapped.cr
+++ b/src/io/overlapped.cr
@@ -16,7 +16,7 @@ module IO::Overlapped
     else
       timeout = timeout.to_u64
     end
-    result = LibC.GetQueuedCompletionStatusEx(Crystal::Scheduler.event_loop.iocp, overlapped_entries, overlapped_entries.size, out removed, timeout, false)
+    result = LibC.GetQueuedCompletionStatusEx(Crystal::EventLoop.current.iocp, overlapped_entries, overlapped_entries.size, out removed, timeout, false)
     if result == 0
       error = WinError.value
       if timeout && error.wait_timeout?
@@ -160,11 +160,12 @@ module IO::Overlapped
     else
       timeout_event = Crystal::Iocp::Event.new(Fiber.current, Time::Span::MAX)
     end
-    Crystal::Scheduler.event_loop.enqueue(timeout_event)
+    event_loop = Crystal::EventLoop.current
+    event_loop.enqueue(timeout_event)
 
     Crystal::Scheduler.reschedule
 
-    Crystal::Scheduler.event_loop.dequeue(timeout_event)
+    event_loop.dequeue(timeout_event)
   end
 
   def overlapped_operation(handle, method, timeout, *, writing = false, &)

--- a/src/io/overlapped.cr
+++ b/src/io/overlapped.cr
@@ -163,7 +163,7 @@ module IO::Overlapped
     event_loop = Crystal::EventLoop.current
     event_loop.enqueue(timeout_event)
 
-    Crystal::Scheduler.reschedule
+    Fiber.suspend
 
     event_loop.dequeue(timeout_event)
   end

--- a/src/kernel.cr
+++ b/src/kernel.cr
@@ -562,7 +562,7 @@ end
         ->Crystal::System::SignalChildHandler.after_fork,
 
         # reinit event loop:
-        ->{ Crystal::Scheduler.event_loop.after_fork },
+        ->{ Crystal::EventLoop.current.after_fork },
 
         # more clean ups (may depend on event loop):
         ->Random::DEFAULT.new_seed,

--- a/src/mutex.cr
+++ b/src/mutex.cr
@@ -79,7 +79,8 @@ class Mutex
 
         @queue.push Fiber.current
       end
-      Crystal::Scheduler.reschedule
+
+      Fiber.suspend
     end
 
     @mutex_fiber = Fiber.current unless @protection.unchecked?

--- a/src/wait_group.cr
+++ b/src/wait_group.cr
@@ -106,7 +106,7 @@ class WaitGroup
       @waiting.push(pointerof(waiting))
     end
 
-    Crystal::Scheduler.reschedule
+    Fiber.suspend
 
     return if done?
     raise RuntimeError.new("Positive WaitGroup counter (early wake up?)")


### PR DESCRIPTION
Changes are internal (private), except for `Fiber.suspend` that introduces a new public method.

- Add `Crystal::EventLoop.current` instead of `Crystal::Scheduler.event_loop`
- Use `Fiber#enqueue` instead of `Crystal::Scheduler.enqueue`
- Add `Fiber.suspend` instead of `Crystal::Scheduler.reschedule`
  - alternative: it could be `Fiber.reschedule`

This is part 2 of abstracting `Crystal::Scheduler` away.