### PR TITLE
Disable implicit execution of batch files

### DIFF
--- a/spec/std/process_spec.cr
+++ b/spec/std/process_spec.cr
@@ -232,6 +232,19 @@ pending_interpreted describe: Process do
       output.should eq "`echo hi`\n"
     end
 
+    describe "does not execute batch files" do
+      %w[.bat .Bat .BAT .cmd .cmD .CmD].each do |ext|
+        it ext do
+          with_tempfile "process_run.#{ext}" do |path|
+            File.write(path, "echo '#{ext}'")
+            expect_raises {{ flag?(:win32) ? File::BadExecutableError : File::AccessDeniedError }}, "Error executing process" do
+              Process.run(path)
+            end
+          end
+        end
+      end
+    end
+
     describe "environ" do
       it "clears the environment" do
         value = Process.run(*print_env_command, clear_env: true) do |proc|

--- a/spec/std/process_spec.cr
+++ b/spec/std/process_spec.cr
@@ -235,8 +235,8 @@ pending_interpreted describe: Process do
     describe "does not execute batch files" do
       %w[.bat .Bat .BAT .cmd .cmD .CmD].each do |ext|
         it ext do
-          with_tempfile "process_run.#{ext}" do |path|
-            File.write(path, "echo '#{ext}'")
+          with_tempfile "process_run#{ext}" do |path|
+            File.write(path, "echo '#{ext}'\n")
             expect_raises {{ flag?(:win32) ? File::BadExecutableError : File::AccessDeniedError }}, "Error executing process" do
               Process.run(path)
             end

--- a/src/crystal/system/win32/process.cr
+++ b/src/crystal/system/win32/process.cr
@@ -316,7 +316,7 @@ struct Crystal::System::Process
       # > Because of this, it’s possible to inject commands if someone can control the part of command arguments of the batch file.
       # https://flatt.tech/research/posts/batbadbut-you-cant-securely-execute-commands-on-windows/
       if command.byte_slice?(-4, 4).try(&.downcase).in?(".bat", ".cmd")
-        raise ::File::Error.from_winerror("Error executing process", winerror: WinError::ERROR_BAD_EXE_FORMAT, file: command)
+        raise ::File::Error.from_os_error("Error executing process", WinError::ERROR_BAD_EXE_FORMAT, file: command)
       end
 
       command_args = [command]

--- a/src/crystal/system/win32/process.cr
+++ b/src/crystal/system/win32/process.cr
@@ -309,6 +309,16 @@ struct Crystal::System::Process
       end
       command
     else
+      # Disable implicit execution of batch files (https://github.com/crystal-lang/crystal/issues/14536)
+      #
+      # > `CreateProcessW()` implicitly spawns `cmd.exe` when executing batch files (`.bat`, `.cmd`, etc.), even if the application didn’t specify them in the command line.
+      # > The problem is that the `cmd.exe` has complicated parsing rules for the command arguments, and programming language runtimes fail to escape the command arguments properly.
+      # > Because of this, it’s possible to inject commands if someone can control the part of command arguments of the batch file.
+      # https://flatt.tech/research/posts/batbadbut-you-cant-securely-execute-commands-on-windows/
+      if command.byte_slice?(-4, 4).try(&.downcase).in?(".bat", ".cmd")
+        raise ::File::Error.from_winerror("Error executing process", winerror: WinError::ERROR_BAD_EXE_FORMAT, file: command)
+      end
+
       command_args = [command]
       command_args.concat(args) if args
       command_args


### PR DESCRIPTION
This patch disables the implicit execution of batch files (i.e. path name extension `.bat` or `.cmd`, case-insensitive) in `Process.run` on Windows with `shell: false` (default). There are no effects on other operating systems.
The disabled behaviour is an irrational and potentially dangerous feature of `CreateProcessW` which is not intended for `Process.run`.

If you want to run a batch file on Windows, you need to launch it through a shell, either implicitly with `shell: true` or explicitly by running `cmd.exe` with the batch file as argument.
The semantics are different on POSIX platforms where you can directly execute a shell script if it has a shebang. The mechanism on Windows works differently, as `CreateProcessW` implicitly injects `cmd.exe /c` which changes the semantics of run arguments.

A similar approach has been taken by node.js: https://github.com/nodejs/node/commit/64b67779f72ea9e4a0f444284576df9e591d79a0

Resolves #14536