### PR TITLE
Add `Crystal::EventLoop.current`

### DIFF
--- a/src/crystal/system/event_loop.cr
+++ b/src/crystal/system/event_loop.cr
@@ -2,6 +2,11 @@ abstract class Crystal::EventLoop
   # Creates an event loop instance
   # def self.create : Crystal::EventLoop
 
+  @[AlwaysInline]
+  def self.current : self
+    Crystal::Scheduler.event_loop
+  end
+
   # Runs the event loop.
   abstract def run_once : Nil
 

--- a/src/crystal/system/win32/event_loop_iocp.cr
+++ b/src/crystal/system/win32/event_loop_iocp.cr
@@ -126,7 +126,7 @@ class Crystal::Iocp::Event
 
   # Frees the event
   def free : Nil
-    Crystal::Scheduler.event_loop.dequeue(self)
+    Crystal::EventLoop.current.dequeue(self)
   end
 
   def delete
@@ -135,6 +135,6 @@ class Crystal::Iocp::Event
 
   def add(timeout : Time::Span?) : Nil
     @wake_at = timeout ? Time.monotonic + timeout : Time.monotonic
-    Crystal::Scheduler.event_loop.enqueue(self)
+    Crystal::EventLoop.current.enqueue(self)
   end
 end

--- a/src/crystal/system/win32/file_descriptor.cr
+++ b/src/crystal/system/win32/file_descriptor.cr
@@ -238,13 +238,13 @@ module Crystal::System::FileDescriptor
     w_pipe_flags |= LibC::FILE_FLAG_OVERLAPPED unless write_blocking
     w_pipe = LibC.CreateNamedPipeA(pipe_name, w_pipe_flags, pipe_mode, 1, PIPE_BUFFER_SIZE, PIPE_BUFFER_SIZE, 0, nil)
     raise IO::Error.from_winerror("CreateNamedPipeA") if w_pipe == LibC::INVALID_HANDLE_VALUE
-    Crystal::Scheduler.event_loop.create_completion_port(w_pipe) unless write_blocking
+    Crystal::EventLoop.current.create_completion_port(w_pipe) unless write_blocking
 
     r_pipe_flags = LibC::FILE_FLAG_NO_BUFFERING
     r_pipe_flags |= LibC::FILE_FLAG_OVERLAPPED unless read_blocking
     r_pipe = LibC.CreateFileW(System.to_wstr(pipe_name), LibC::GENERIC_READ | LibC::FILE_WRITE_ATTRIBUTES, 0, nil, LibC::OPEN_EXISTING, r_pipe_flags, nil)
     raise IO::Error.from_winerror("CreateFileW") if r_pipe == LibC::INVALID_HANDLE_VALUE
-    Crystal::Scheduler.event_loop.create_completion_port(r_pipe) unless read_blocking
+    Crystal::EventLoop.current.create_completion_port(r_pipe) unless read_blocking
 
     r = IO::FileDescriptor.new(r_pipe.address, read_blocking)
     w = IO::FileDescriptor.new(w_pipe.address, write_blocking)

--- a/src/crystal/system/win32/process.cr
+++ b/src/crystal/system/win32/process.cr
@@ -37,7 +37,7 @@ struct Crystal::System::Process
       LibC::JOBOBJECTINFOCLASS::AssociateCompletionPortInformation,
       LibC::JOBOBJECT_ASSOCIATE_COMPLETION_PORT.new(
         completionKey: @completion_key.as(Void*),
-        completionPort: Crystal::Scheduler.event_loop.iocp,
+        completionPort: Crystal::EventLoop.current.iocp,
       ),
     )
 

--- a/src/crystal/system/win32/socket.cr
+++ b/src/crystal/system/win32/socket.cr
@@ -79,7 +79,7 @@ module Crystal::System::Socket
       raise ::Socket::Error.from_wsa_error("WSASocketW")
     end
 
-    Crystal::Scheduler.event_loop.create_completion_port LibC::HANDLE.new(socket)
+    Crystal::EventLoop.current.create_completion_port LibC::HANDLE.new(socket)
 
     socket
   end

--- a/src/fiber.cr
+++ b/src/fiber.cr
@@ -223,12 +223,12 @@ class Fiber
 
   # :nodoc:
   def resume_event : Crystal::EventLoop::Event
-    @resume_event ||= Crystal::Scheduler.event_loop.create_resume_event(self)
+    @resume_event ||= Crystal::EventLoop.current.create_resume_event(self)
   end
 
   # :nodoc:
   def timeout_event : Crystal::EventLoop::Event
-    @timeout_event ||= Crystal::Scheduler.event_loop.create_timeout_event(self)
+    @timeout_event ||= Crystal::EventLoop.current.create_timeout_event(self)
   end
 
   # :nodoc:

--- a/src/io/evented.cr
+++ b/src/io/evented.cr
@@ -101,7 +101,7 @@ module IO::Evented
   end
 
   private def add_read_event(timeout = @read_timeout) : Nil
-    event = @read_event.get { Crystal::Scheduler.event_loop.create_fd_read_event(self) }
+    event = @read_event.get { Crystal::EventLoop.current.create_fd_read_event(self) }
     event.add timeout
   end
 
@@ -126,7 +126,7 @@ module IO::Evented
   end
 
   private def add_write_event(timeout = @write_timeout) : Nil
-    event = @write_event.get { Crystal::Scheduler.event_loop.create_fd_write_event(self) }
+    event = @write_event.get { Crystal::EventLoop.current.create_fd_write_event(self) }
     event.add timeout
   end
 

--- a/src/io/overlapped.cr
+++ b/src/io/overlapped.cr
@@ -16,7 +16,7 @@ module IO::Overlapped
     else
       timeout = timeout.to_u64
     end
-    result = LibC.GetQueuedCompletionStatusEx(Crystal::Scheduler.event_loop.iocp, overlapped_entries, overlapped_entries.size, out removed, timeout, false)
+    result = LibC.GetQueuedCompletionStatusEx(Crystal::EventLoop.current.iocp, overlapped_entries, overlapped_entries.size, out removed, timeout, false)
     if result == 0
       error = WinError.value
       if timeout && error.wait_timeout?
@@ -160,11 +160,14 @@ module IO::Overlapped
     else
       timeout_event = Crystal::Iocp::Event.new(Fiber.current, Time::Span::MAX)
     end
-    Crystal::Scheduler.event_loop.enqueue(timeout_event)
+    # memoize event loop to make sure that we still target the same instance
+    # after wakeup (guaranteed by current MT model but let's be future proof)
+    event_loop = Crystal::EventLoop.current
+    event_loop.enqueue(timeout_event)
 
     Crystal::Scheduler.reschedule
 
-    Crystal::Scheduler.event_loop.dequeue(timeout_event)
+    event_loop.dequeue(timeout_event)
   end
 
   def overlapped_operation(handle, method, timeout, *, writing = false, &)

--- a/src/kernel.cr
+++ b/src/kernel.cr
@@ -562,7 +562,7 @@ end
         ->Crystal::System::SignalChildHandler.after_fork,
 
         # reinit event loop:
-        ->{ Crystal::Scheduler.event_loop.after_fork },
+        ->{ Crystal::EventLoop.current.after_fork },
 
         # more clean ups (may depend on event loop):
         ->Random::DEFAULT.new_seed,


### PR DESCRIPTION
Abstracts where the current event loop instance is stored, instead of assuming `Crystal::Scheduler.event_loop`.

Related to the other PRs that abstract Crystal::Scheduler away.