### PR TITLE
Add `Fiber.suspend`

### DIFF
--- a/src/channel.cr
+++ b/src/channel.cr
@@ -231,7 +231,7 @@ class Channel(T)
       @senders.push pointerof(sender)
       @lock.unlock
 
-      Crystal::Scheduler.reschedule
+      Fiber.suspend
 
       case sender.state
       in .delivered?
@@ -308,7 +308,7 @@ class Channel(T)
       @receivers.push pointerof(receiver)
       @lock.unlock
 
-      Crystal::Scheduler.reschedule
+      Fiber.suspend
 
       case receiver.state
       in .delivered?
@@ -473,7 +473,7 @@ class Channel(T)
     contexts = ops.map &.create_context_and_wait(shared_state)
 
     each_skip_duplicates(ops_locks, &.unlock)
-    Crystal::Scheduler.reschedule
+    Fiber.suspend
 
     contexts.each_with_index do |context, index|
       op = ops[index]

--- a/src/crystal/system/win32/process.cr
+++ b/src/crystal/system/win32/process.cr
@@ -81,7 +81,7 @@ struct Crystal::System::Process
     # stuck forever in that case?
     # (https://learn.microsoft.com/en-us/windows/win32/api/winnt/ns-winnt-jobobject_associate_completion_port)
     @completion_key.fiber = ::Fiber.current
-    Crystal::Scheduler.reschedule
+    Fiber.suspend
 
     # If the IOCP notification is delivered before the process fully exits,
     # wait for it

--- a/src/crystal/system/win32/process.cr
+++ b/src/crystal/system/win32/process.cr
@@ -81,7 +81,7 @@ struct Crystal::System::Process
     # stuck forever in that case?
     # (https://learn.microsoft.com/en-us/windows/win32/api/winnt/ns-winnt-jobobject_associate_completion_port)
     @completion_key.fiber = ::Fiber.current
-    Fiber.suspend
+    ::Fiber.suspend
 
     # If the IOCP notification is delivered before the process fully exits,
     # wait for it

--- a/src/fiber.cr
+++ b/src/fiber.cr
@@ -168,7 +168,7 @@ class Fiber
     {% unless flag?(:interpreted) %}
       Crystal::Scheduler.stack_pool.release(@stack)
     {% end %}
-    Crystal::Scheduler.reschedule
+    Fiber.suspend
   end
 
   # Returns the current fiber.
@@ -283,6 +283,19 @@ class Fiber
   # ```
   def self.yield : Nil
     Crystal::Scheduler.yield
+  end
+
+  # Yields to the scheduler and tells it to swap execution to another waiting
+  # fibers. Unlike `Fiber.yield` the current fiber won't be automatically
+  # reenqueued and won't be resumed until it has been explicitely reenqueued.
+  #
+  # This is equivalent to `sleep` without a time.
+  #
+  # This method is particularly useful to stop the execution of the current
+  # fiber until something happens, for example an IO event, a message is ready
+  # in a channel, and so on.
+  def self.suspend : Nil
+    Crystal::Scheduler.reschedule
   end
 
   def to_s(io : IO) : Nil

--- a/src/fiber.cr
+++ b/src/fiber.cr
@@ -285,15 +285,16 @@ class Fiber
     Crystal::Scheduler.yield
   end
 
-  # Yields to the scheduler and tells it to swap execution to another waiting
-  # fibers. Unlike `Fiber.yield` the current fiber won't be automatically
-  # reenqueued and won't be resumed until it has been explicitely reenqueued.
+  # Suspends execution of the current fiber indefinitely.
+  #
+  # Unlike `Fiber.yield` the current fiber is not automatically
+  # reenqueued and can only be resumed whith an explicit call to `#enqueue`.
   #
   # This is equivalent to `sleep` without a time.
   #
-  # This method is particularly useful to stop the execution of the current
-  # fiber until something happens, for example an IO event, a message is ready
-  # in a channel, and so on.
+  # This method is meant to be used in concurrency primitives. It's particularly 
+  # useful if the fiber needs to wait  for something to happen (for example an IO
+  # event, a message is ready in a channel, etc.) which triggers a re-enqueue.
   def self.suspend : Nil
     Crystal::Scheduler.reschedule
   end

--- a/src/fiber.cr
+++ b/src/fiber.cr
@@ -292,7 +292,7 @@ class Fiber
   #
   # This is equivalent to `sleep` without a time.
   #
-  # This method is meant to be used in concurrency primitives. It's particularly 
+  # This method is meant to be used in concurrency primitives. It's particularly
   # useful if the fiber needs to wait  for something to happen (for example an IO
   # event, a message is ready in a channel, etc.) which triggers a re-enqueue.
   def self.suspend : Nil

--- a/src/io/evented.cr
+++ b/src/io/evented.cr
@@ -90,7 +90,7 @@ module IO::Evented
     readers = @readers.get { Deque(Fiber).new }
     readers << Fiber.current
     add_read_event(timeout)
-    Crystal::Scheduler.reschedule
+    Fiber.suspend
 
     if @read_timed_out
       @read_timed_out = false
@@ -115,7 +115,7 @@ module IO::Evented
     writers = @writers.get { Deque(Fiber).new }
     writers << Fiber.current
     add_write_event(timeout)
-    Crystal::Scheduler.reschedule
+    Fiber.suspend
 
     if @write_timed_out
       @write_timed_out = false

--- a/src/io/overlapped.cr
+++ b/src/io/overlapped.cr
@@ -162,7 +162,7 @@ module IO::Overlapped
     end
     Crystal::Scheduler.event_loop.enqueue(timeout_event)
 
-    Crystal::Scheduler.reschedule
+    Fiber.suspend
 
     Crystal::Scheduler.event_loop.dequeue(timeout_event)
   end

--- a/src/mutex.cr
+++ b/src/mutex.cr
@@ -79,7 +79,8 @@ class Mutex
 
         @queue.push Fiber.current
       end
-      Crystal::Scheduler.reschedule
+
+      Fiber.suspend
     end
 
     @mutex_fiber = Fiber.current unless @protection.unchecked?

--- a/src/wait_group.cr
+++ b/src/wait_group.cr
@@ -106,7 +106,7 @@ class WaitGroup
       @waiting.push(pointerof(waiting))
     end
 
-    Crystal::Scheduler.reschedule
+    Fiber.suspend
 
     return if done?
     raise RuntimeError.new("Positive WaitGroup counter (early wake up?)")


### PR DESCRIPTION
Replaces the private `Crystal::Scheduler.reschedule` method that suspends the execution of the current fiber (that must be manually re-enqueued to be resumed) with a public method:  `Fiber.suspend`.

> [!NOTE]
> It could be `Fiber.reschedule`. I'm not sure which term is more explicit and closer to the intent?

Related to the other PRs that abstract Crystal::Scheduler away.