### PR TITLE
Use `Fiber#enqueue`

### DIFF
--- a/spec/std/channel_spec.cr
+++ b/spec/std/channel_spec.cr
@@ -2,8 +2,8 @@ require "spec"
 require "./spec_helper"
 
 private def yield_to(fiber)
-  Crystal::Scheduler.enqueue(Fiber.current)
-  Crystal::Scheduler.resume(fiber)
+  Fiber.current.enqueue
+  fiber.resume
 end
 
 private macro parallel(*jobs)

--- a/spec/std/concurrent/select_spec.cr
+++ b/spec/std/concurrent/select_spec.cr
@@ -99,7 +99,7 @@ describe "select" do
         x = b
       end
     ensure
-      Crystal::Scheduler.enqueue(main)
+      main.enqueue
     end
 
     sleep

--- a/src/channel.cr
+++ b/src/channel.cr
@@ -744,7 +744,7 @@ class Channel(T)
 
     def time_expired(fiber : Fiber) : Nil
       if @select_context.try &.try_trigger
-        Crystal::Scheduler.enqueue fiber
+        fiber.enqueue
       end
     end
   end

--- a/src/crystal/system/unix/event_loop_libevent.cr
+++ b/src/crystal/system/unix/event_loop_libevent.cr
@@ -26,7 +26,7 @@ class Crystal::LibEvent::EventLoop < Crystal::EventLoop
   # Create a new resume event for a fiber.
   def create_resume_event(fiber : Fiber) : Crystal::EventLoop::Event
     event_base.new_event(-1, LibEvent2::EventFlags::None, fiber) do |s, flags, data|
-      Crystal::Scheduler.enqueue data.as(Fiber)
+      data.as(Fiber).enqueue
     end
   end
 
@@ -38,7 +38,7 @@ class Crystal::LibEvent::EventLoop < Crystal::EventLoop
         f.timeout_select_action = nil
         select_action.time_expired(f)
       else
-        Crystal::Scheduler.enqueue f
+        f.enqueue
       end
     end
   end

--- a/src/crystal/system/win32/event_loop_iocp.cr
+++ b/src/crystal/system/win32/event_loop_iocp.cr
@@ -58,7 +58,7 @@ class Crystal::Iocp::EventLoop < Crystal::EventLoop
 
       timed_out = IO::Overlapped.wait_queued_completions(wait_time.total_milliseconds) do |fiber|
         # This block may run multiple times. Every single fiber gets enqueued.
-        Crystal::Scheduler.enqueue fiber
+        fiber.enqueue
       end
 
       # If the wait for completion timed out we've reached the wake time and
@@ -90,7 +90,7 @@ class Crystal::Iocp::EventLoop < Crystal::EventLoop
       fiber.timeout_select_action = nil
       select_action.time_expired(fiber)
     else
-      Crystal::Scheduler.enqueue fiber
+      fiber.enqueue
     end
   end
 

--- a/src/io/evented.cr
+++ b/src/io/evented.cr
@@ -67,7 +67,7 @@ module IO::Evented
     @read_timed_out = timed_out
 
     if reader = @readers.get?.try &.shift?
-      Crystal::Scheduler.enqueue reader
+      reader.enqueue
     end
   end
 
@@ -76,7 +76,7 @@ module IO::Evented
     @write_timed_out = timed_out
 
     if writer = @writers.get?.try &.shift?
-      Crystal::Scheduler.enqueue writer
+      writer.enqueue
     end
   end
 


### PR DESCRIPTION
Replaces calls to `Crystal::Scheduler.enqueue(fiber)` to `fiber.enqueue`.

Related to the other PRs that abstract Crystal::Scheduler away.