### PR TITLE
Update distribution-scripts

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,7 +8,7 @@ parameters:
   distribution-scripts-version:
     description: "Git ref for version of https://github.com/crystal-lang/distribution-scripts/"
     type: string
-    default: "46c295d14e4dc3f6b7d9598c0b4dd89e93232def"
+    default: "8c3a9f6bf64499f1e3d1838d2ae9b967d5e7f796"
   previous_crystal_base_url:
     description: "Prefix for URLs to Crystal bootstrap compiler"
     type: string


### PR DESCRIPTION
Updates `distribution-scripts` dependency to https://github.com/crystal-lang/distribution-scripts/commit/8c3a9f6bf64499f1e3d1838d2ae9b967d5e7f796

This includes the following changes:

* crystal-lang/distribution-scripts#303
* crystal-lang/distribution-scripts#301
* crystal-lang/distribution-scripts#302
* crystal-lang/distribution-scripts#300
* crystal-lang/distribution-scripts#298
