### PR TITLE
Fix: No need for explicit memory barriers on ARM

### DIFF
--- a/src/crystal/rw_lock.cr
+++ b/src/crystal/rw_lock.cr
@@ -15,9 +15,6 @@ struct Crystal::RWLock
       @readers.add(1, :acquire)
 
       if @writer.get(:acquire) == UNLOCKED
-        {% if flag?(:arm) %}
-          Atomic.fence(:acquire)
-        {% end %}
         return
       end
 
@@ -26,9 +23,6 @@ struct Crystal::RWLock
   end
 
   def read_unlock : Nil
-    {% if flag?(:arm) %}
-      Atomic.fence(:release)
-    {% end %}
     @readers.sub(1, :release)
   end
 
@@ -40,16 +34,9 @@ struct Crystal::RWLock
     while @readers.get(:acquire) != 0
       Intrinsics.pause
     end
-
-    {% if flag?(:arm) %}
-      Atomic.fence(:acquire)
-    {% end %}
   end
 
   def write_unlock : Nil
-    {% if flag?(:arm) %}
-      Atomic.fence(:release)
-    {% end %}
     @writer.set(UNLOCKED, :release)
   end
 end

--- a/src/crystal/spin_lock.cr
+++ b/src/crystal/spin_lock.cr
@@ -14,17 +14,11 @@ class Crystal::SpinLock
           Intrinsics.pause
         end
       end
-      {% if flag?(:arm) %}
-        Atomic.fence(:acquire)
-      {% end %}
     {% end %}
   end
 
   def unlock
     {% if flag?(:preview_mt) %}
-      {% if flag?(:arm) %}
-        Atomic.fence(:release)
-      {% end %}
       @m.set(UNLOCKED, :release)
     {% end %}
   end

--- a/src/mutex.cr
+++ b/src/mutex.cr
@@ -38,9 +38,6 @@ class Mutex
   @[AlwaysInline]
   def lock : Nil
     if @state.swap(LOCKED, :acquire) == UNLOCKED
-      {% if flag?(:arm) %}
-        Atomic.fence(:acquire)
-      {% end %}
       @mutex_fiber = Fiber.current unless @protection.unchecked?
       return
     end
@@ -67,9 +64,6 @@ class Mutex
 
         if @state.get(:relaxed) == UNLOCKED
           if @state.swap(LOCKED, :acquire) == UNLOCKED
-            {% if flag?(:arm) %}
-              Atomic.fence(:acquire)
-            {% end %}
             @queue_count.sub(1)
 
             @mutex_fiber = Fiber.current unless @protection.unchecked?
@@ -94,9 +88,6 @@ class Mutex
         return false if i == 0
       end
     end
-    {% if flag?(:arm) %}
-      Atomic.fence(:acquire)
-    {% end %}
     true
   end
 


### PR DESCRIPTION
Reading the [LLVM atomics documentation](https://llvm.org/docs/Atomics.html), the notes for code generation state that weak architectures should generate memory barriers, which implies that all memory orders, except for relaxed, should always generate the necessary memory barriers when asked to.

Compiling and disassembling programs for ARMv6 and ARMv7 (you must specify a CPU or CPU feature to target these, otherwise LLVM defaults to ARMv4 or ARMv5), we can indeed notice that memory barriers are properly emitted by the LLVM code generation. For example the assembly contains `dmb ish` for ARMv7 and `mcr 15, 0, r1, cr7, cr10, {5}` for ARMv6.

Compiling for older ARMv4 or ARMv5 the atomics call the `__sync_*` symbols from `libgcc` where memory ordering is a noop (not supported by the micro architecture).

This patch thus removes the explicit memory barriers. They duplicate what LLVM backends are already doing (optimized away in some cases, but there may be edge cases where it's not), and this noticeably simplifies our code.