### PR TITLE
Fix generate docs for builtins `HOST_TRIPLE` and `TARGET_TRIPLE`

### DIFF
--- a/src/compiler/crystal/tools/doc/generator.cr
+++ b/src/compiler/crystal/tools/doc/generator.cr
@@ -227,7 +227,7 @@ class Crystal::Doc::Generator
 
     {"BUILD_COMMIT", "BUILD_DATE", "CACHE_DIR", "DEFAULT_PATH",
      "DESCRIPTION", "PATH", "VERSION", "LLVM_VERSION",
-     "LIBRARY_PATH", "LIBRARY_RPATH"}.each do |name|
+     "LIBRARY_PATH", "LIBRARY_RPATH", "HOST_TRIPLE", "TARGET_TRIPLE"}.each do |name|
       return true if type == crystal_type.types[name]?
     end
 


### PR DESCRIPTION
When we originally added these constants in #13823 we overlooked that we also need to make the doc generator aware they are builtins which should be included in the doc output.
This is of course a bit brittle setup and we should try to find a better solution, but for now this patch fixes that these two constants show up in the API docs.