### PR TITLE
Fix enable docs for builtin constants

### DIFF
--- a/src/compiler/crystal/program.cr
+++ b/src/compiler/crystal/program.cr
@@ -279,7 +279,7 @@ module Crystal
       else
         build_commit_const = define_crystal_nil_constant "BUILD_COMMIT"
       end
-      build_commit_const.doc = <<-MD if wants_doc?
+      build_commit_const.doc = <<-MD
         The build commit identifier of the Crystal compiler.
         MD
 
@@ -341,9 +341,8 @@ module Crystal
     private def define_crystal_constant(name, value, doc = nil) : Const
       crystal.types[name] = const = Const.new self, crystal, name, value
       const.no_init_flag = true
-      if doc && wants_doc?
-        const.doc = doc
-      end
+      const.doc = doc
+
       predefined_constants << const
       const
     end


### PR DESCRIPTION
The builtins are created inside the initializer. At this point `wants_doc?` is always `false` becase the doc generator only set it to `true` after the initializer.

I don't think there's any noticable impact from having a dozend doc strings assigned in every program AST, even without `wants_doc`. Skipping docs is an optimization that pays out when parsing huge program ASTs. But for these few doc strings, there shouldn't be any issue.
The doc strings are literals, so they don't even occupy any memory (not that it would hurt much if it did).

Follow-up to  #14276