### PR TITLE
Add `src/SOURCE_DATE_EPOCH` to release tree

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -46,7 +46,8 @@ SPEC_FLAGS := $(if $(verbose),-v )$(if $(junit_output),--junit_output $(junit_ou
 CRYSTAL_CONFIG_LIBRARY_PATH := '$$ORIGIN/../lib/crystal'
 CRYSTAL_CONFIG_BUILD_COMMIT ?= $(shell git rev-parse --short HEAD 2> /dev/null)
 CRYSTAL_CONFIG_PATH := '$$ORIGIN/../share/crystal/src'
-SOURCE_DATE_EPOCH ?= $(shell (git show -s --format=%ct HEAD || stat -c "%Y" Makefile || stat -f "%m" Makefile) 2> /dev/null)
+CRYSTAL_VERSION ?= $(shell cat src/VERSION)
+SOURCE_DATE_EPOCH ?= $(shell (cat src/SOURCE_DATE_EPOCH || (git show -s --format=%ct HEAD || stat -c "%Y" Makefile || stat -f "%m" Makefile)) 2> /dev/null)
 ifeq ($(shell command -v ld.lld >/dev/null && uname -s),Linux)
   EXPORT_CC ?= CC="$(CC) -fuse-ld=lld"
 endif
@@ -63,7 +64,6 @@ LLVM_VERSION := $(if $(LLVM_CONFIG),$(shell $(LLVM_CONFIG) --version 2> /dev/nul
 LLVM_EXT_DIR = src/llvm/ext
 LLVM_EXT_OBJ = $(LLVM_EXT_DIR)/llvm_ext.o
 CXXFLAGS += $(if $(debug),-g -O0)
-CRYSTAL_VERSION ?= $(shell cat src/VERSION)
 
 DESTDIR ?=
 PREFIX ?= /usr/local

--- a/Makefile.win
+++ b/Makefile.win
@@ -63,7 +63,8 @@ SPEC_FLAGS := $(if $(verbose),-v )$(if $(junit_output),--junit_output $(junit_ou
 CRYSTAL_CONFIG_LIBRARY_PATH := $$ORIGIN\lib
 CRYSTAL_CONFIG_BUILD_COMMIT := $(shell git rev-parse --short HEAD)
 CRYSTAL_CONFIG_PATH := $$ORIGIN\src
-SOURCE_DATE_EPOCH := $(shell git show -s --format=%ct HEAD)
+CRYSTAL_VERSION ?= $(shell type src\VERSION)
+SOURCE_DATE_EPOCH ?= $(shell type src/SOURCE_DATE_EPOCH || git show -s --format=%ct HEAD)
 export_vars = $(eval export CRYSTAL_CONFIG_BUILD_COMMIT CRYSTAL_CONFIG_PATH SOURCE_DATE_EPOCH)
 export_build_vars = $(eval export CRYSTAL_CONFIG_LIBRARY_PATH)
 LLVM_CONFIG ?=
@@ -71,7 +72,6 @@ LLVM_VERSION := $(if $(LLVM_CONFIG),$(shell $(LLVM_CONFIG) --version))
 LLVM_EXT_DIR = src\llvm\ext
 LLVM_EXT_OBJ = $(LLVM_EXT_DIR)\llvm_ext.obj
 CXXFLAGS += $(if $(static),$(if $(debug),/MTd /Od ,/MT ),$(if $(debug),/MDd /Od ,/MD ))
-CRYSTAL_VERSION ?= $(shell type src\VERSION)
 
 prefix ?= $(or $(ProgramW6432),$(ProgramFiles))\crystal
 BINDIR ?= $(prefix)

--- a/scripts/release-update.sh
+++ b/scripts/release-update.sh
@@ -16,6 +16,9 @@ minor_branch="${CRYSTAL_VERSION%.*}"
 next_minor="$((${minor_branch#*.} + 1))"
 echo "${CRYSTAL_VERSION%%.*}.${next_minor}.0-dev" > src/VERSION
 
+# Remove SOURCE_DATE_EPOCH (only used in source tree of a release)
+rm -f src/SOURCE_DATE_EPOCH
+
 # Edit PREVIOUS_CRYSTAL_BASE_URL in .circleci/config.yml
 sed -i -E "s|[0-9.]+/crystal-[0-9.]+-[0-9]|$CRYSTAL_VERSION/crystal-$CRYSTAL_VERSION-1|g" .circleci/config.yml
 

--- a/scripts/update-changelog.sh
+++ b/scripts/update-changelog.sh
@@ -44,6 +44,11 @@ git switch $branch 2>/dev/null || git switch -c $branch;
 echo "${VERSION}" > src/VERSION
 git add src/VERSION
 
+# Write release date into src/SOURCE_DATE_EPOCH
+release_date=$(head -n1 $current_changelog | grep -o -P '(?<=\()[^)]+')
+echo "$(date --utc --date="${release_date}" +%s)" > src/SOURCE_DATE_EPOCH
+git add src/SOURCE_DATE_EPOCH
+
 if grep --silent -E "^## \[$VERSION\]" CHANGELOG.md; then
   echo "Replacing section in CHANGELOG"
 


### PR DESCRIPTION
The Crystal compiler version info (`crystal --version`) includes a date representing the chronological aspect of the comiler version.
It's supposed to represent the date of the source code. But this information is not available in a bare snapshot of the source tree. The `Makefile` tries to read the date of the last commit from `git`, which requires `git` and the repository.

This patch adds a file `src/SOURCE_DATE_EPOCH` which sits alongside `src/VERSION` to have both data available next to each other.
It gets automatically populated in the release process and is removed afterwards. So it should only be available in the source tree of tagged release commits.

A practical use case for this is https://github.com/NixOS/nixpkgs/issues/306765 as well as any other package build that doesn't use the git repository.