### PR TITLE
Fix `Regex#inspect` with non-literal-compatible options

### DIFF
--- a/spec/std/regex_spec.cr
+++ b/spec/std/regex_spec.cr
@@ -449,15 +449,29 @@ describe "Regex" do
   end
 
   describe "#inspect" do
-    it "with options" do
-      /foo/.inspect.should eq("/foo/")
-      /foo/im.inspect.should eq("/foo/im")
-      /foo/imx.inspect.should eq("/foo/imx")
+    context "with literal-compatible options" do
+      it "prints flags" do
+        /foo/.inspect.should eq("/foo/")
+        /foo/im.inspect.should eq("/foo/im")
+        /foo/imx.inspect.should eq("/foo/imx")
+      end
+
+      it "escapes" do
+        %r(/).inspect.should eq("/\\//")
+        %r(\/).inspect.should eq("/\\//")
+      end
     end
 
-    it "escapes" do
-      %r(/).inspect.should eq("/\\//")
-      %r(\/).inspect.should eq("/\\//")
+    context "with non-literal-compatible options" do
+      it "prints flags" do
+        Regex.new("foo", :anchored).inspect.should eq %(Regex.new("foo", Regex::Options::ANCHORED))
+        Regex.new("foo", :no_utf_check).inspect.should eq %(Regex.new("foo", Regex::Options::NO_UTF8_CHECK))
+        Regex.new("foo", Regex::CompileOptions[IGNORE_CASE, ANCHORED]).inspect.should eq %(Regex.new("foo", Regex::Options[IGNORE_CASE, ANCHORED]))
+      end
+
+      it "escapes" do
+        Regex.new(%("), :anchored).inspect.should eq %(Regex.new("\\"", Regex::Options::ANCHORED))
+      end
     end
   end
 

--- a/src/regex.cr
+++ b/src/regex.cr
@@ -592,9 +592,13 @@ class Regex
 
   # Prints to *io* an unambiguous string representation of this regular expression object.
   #
-  # Uses `#inspect_literal` if the literal representation with basic option flags
-  # is sufficient (i.e. no other options than `IGNORE_CASE`, `MULTILINE`, or `EXTENDED`).
-  # Otherwise the result is equivalent to `#inspect_extensive`.
+  # Uses the regex literal syntax with basic option flags if sufficient (i.e. no
+  # other options than `IGNORE_CASE`, `MULTILINE`, or `EXTENDED` are set).
+  # Otherwise the syntax presents a `Regex.new` call.
+  # ```
+  # /ab+c/ix.inspect                     # => "/ab+c/ix"
+  # Regex.new("ab+c", :anchored).inspect # => Regex.new("ab+c", Regex::Options::ANCHORED)
+  # ```
   def inspect(io : IO) : Nil
     if (options & ~CompileOptions[IGNORE_CASE, MULTILINE, EXTENDED]).none?
       inspect_literal(io)
@@ -615,7 +619,7 @@ class Regex
   # /ab+c/ix.inspect_literal                     # => "/ab+c/ix"
   # Regex.new("ab+c", :anchored).inspect_literal # => "/ab+c/"
   # ```
-  def inspect_literal(io : IO) : Nil
+  private def inspect_literal(io : IO) : Nil
     io << '/'
     Regex.append_source(source, io)
     io << '/'
@@ -632,7 +636,7 @@ class Regex
   # /ab+c/ix.inspect_literal                     # => Regex.new("ab+c", Regex::Options[IGNORE_CASE, EXTENDED])
   # Regex.new("ab+c", :anchored).inspect_literal # => Regex.new("ab+c", Regex::Options::ANCHORED)
   # ```
-  def inspect_extensive(io : IO) : Nil
+  private def inspect_extensive(io : IO) : Nil
     io << "Regex.new("
     source.inspect(io)
     io << ", "


### PR DESCRIPTION
With this patch `Regex#inspect` only uses the literal syntax when all option flags can be represented. If options includes additional flags, it uses a more extensive representation based on the constructor form.

I'm not sure if the helper methods `#inspect_literal` and `#inspect_extensive` should really be exposed. I can't see any specific use case for calling them directly instead of `#inspect`. We could make them `private` and move all documentation to `#inspect`.

Resolves #14530