### PR TITLE
Fix `Range#size` return type to `Int32`

### DIFF
--- a/src/range.cr
+++ b/src/range.cr
@@ -482,7 +482,7 @@ struct Range(B, E)
   # (3..8).size  # => 6
   # (3...8).size # => 5
   # ```
-  def size
+  def size : Int32
     b = self.begin
     e = self.end
 
@@ -490,7 +490,7 @@ struct Range(B, E)
     if b.is_a?(Int) && e.is_a?(Int)
       e -= 1 if @exclusive
       n = e - b + 1
-      n < 0 ? 0 : n
+      n < 0 ? 0 : n.to_i32
     else
       if b.nil? || e.nil?
         raise ArgumentError.new("Can't calculate size of an open range")

--- a/src/range.cr
+++ b/src/range.cr
@@ -482,6 +482,9 @@ struct Range(B, E)
   # (3..8).size  # => 6
   # (3...8).size # => 5
   # ```
+  #
+  # Raises `OverflowError` if the difference is bigger than `Int32`.
+  # Raises `ArgumentError` if either `begin` or `end` are `nil`.
   def size : Int32
     b = self.begin
     e = self.end


### PR DESCRIPTION
Resolves #14587

The `super` implementation `Enumerable#size` has the same type restriction already.

See also https://github.com/crystal-lang/crystal/issues/13648#issuecomment-1636514078