### PR TITLE
Use `boehmgc` package from nixpkgs in `shell.nix`

### DIFF
--- a/shell.nix
+++ b/shell.nix
@@ -108,23 +108,8 @@ let
     };
   }."llvm_${toString llvm}");
 
-  boehmgc = pkgs.stdenv.mkDerivation rec {
-    pname = "boehm-gc";
-    version = "8.2.4";
-
-    src = builtins.fetchTarball {
-      url = "https://github.com/ivmai/bdwgc/releases/download/v${version}/gc-${version}.tar.gz";
-      sha256 = "0primpxl7hykfbmszf7ppbv7k1nj41f1r5m56n96q92mmzqlwybm";
-    };
-
-    configureFlags = [
-      "--disable-debug"
-      "--disable-dependency-tracking"
-      "--disable-shared"
-      "--enable-large-config"
-    ];
-
-    enableParallelBuilding = true;
+  boehmgc = pkgs.boehmgc.override {
+    enableLargeConfig = true;
   };
 
   stdLibDeps = with pkgs; [


### PR DESCRIPTION
This is largely a simplification. I don't think we need to build our own derivation of the GC when there's already a generic one in nixpkgs. With overrides we get almost the same configuration as our custom build.
The custom build was previously necessary because we required unreleased patches.
That's gone now and we should be fine with any recent upstream version.

Most significant changes as far as I can see are some compile flags are gone:

* `--disable-debug`: Not sure if there's any particular reason for this.
* `--disable-dependency-tracking`: There seems to be a reason to use this for building unified binaries on macOS. https://github.com/ivmai/bdwgc/blob/b1fe06200d716cd63d3ec321654fb4d03d610240/docs/platforms/README.darwin#L9
  I don't think this is necessary for a development environment, so it's probably fine to drop it.
* `--disabled-shared` should not be necessary. We *could* set `enableStatic` instead but I don't think that's necessary for a development environment.