### PR TITLE
Update `shell.nix` to use LLVM 18 from `nixpkgs-unstable`

### DIFF
--- a/shell.nix
+++ b/shell.nix
@@ -19,16 +19,13 @@
 # $ nix-shell --pure --arg musl true
 #
 
-{llvm ? 11, musl ? false, system ? builtins.currentSystem}:
+{llvm ? 18, musl ? false, system ? builtins.currentSystem}:
 
 let
   nixpkgs = import (builtins.fetchTarball {
-    name = "nixpkgs-23.05";
-    url = "https://github.com/NixOS/nixpkgs/archive/23.05.tar.gz";
-    sha256 = "10wn0l08j9lgqcw8177nh2ljrnxdrpri7bp0g7nvrsn9rkawvlbf";
-  }) {
-    inherit system;
-  };
+    name = "nixpkgs-unstable";
+    url = "https://github.com/NixOS/nixpkgs/archive/master.tar.gz";
+  }) { inherit system; };
 
   pkgs = if musl then nixpkgs.pkgsMusl else nixpkgs;
   llvmPackages = pkgs."llvmPackages_${toString llvm}";


### PR DESCRIPTION
The update to `nixpkgs-23.11` (#14269) showed some build errors due to missing symbols from `libllvm_ext.o`. 
`nixpkgs-unstable` already has LLVM 18 available, so we can switch to that and completely ditch llvm_ext.

There are some spec failures in CI related to iconv.
Somebody should investigate that on a macOS machine.

`nixpgs-24.05` is expected to be released in a couple of weeks, at which point we could switch back to a stable channel.

Resolves #14269
Depends on #14590