### PR TITLE
Update distribution-scripts

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,7 +8,7 @@ parameters:
   distribution-scripts-version:
     description: "Git ref for version of https://github.com/crystal-lang/distribution-scripts/"
     type: string
-    default: "8c3a9f6bf64499f1e3d1838d2ae9b967d5e7f796"
+    default: "a9e0c6c12987b8b01b17e71c38f489e45937e1bf"
   previous_crystal_base_url:
     description: "Prefix for URLs to Crystal bootstrap compiler"
     type: string


### PR DESCRIPTION
Updates `distribution-scripts` dependency to https://github.com/crystal-lang/distribution-scripts/commit/a9e0c6c12987b8b01b17e71c38f489e45937e1bf

This includes the following changes:

* crystal-lang/distribution-scripts#304
