### PR TITLE
Refactor win32 `System::FileDescriptor#unbuffered_{read,write}`

### DIFF
--- a/src/crystal/system/win32/file_descriptor.cr
+++ b/src/crystal/system/win32/file_descriptor.cr
@@ -52,7 +52,7 @@ module Crystal::System::FileDescriptor
     handle = windows_handle
     until slice.empty?
       if system_blocking?
-        bytes_written = blocking_write(handle, slice)
+        bytes_written = write_blocking(handle, slice)
       else
         bytes_written = overlapped_operation(handle, "WriteFile", write_timeout, writing: true) do |overlapped|
           ret = LibC.WriteFile(handle, slice, slice.size, out byte_count, overlapped)
@@ -64,7 +64,7 @@ module Crystal::System::FileDescriptor
     end
   end
 
-  private def blocking_write(handle, slice)
+  private def write_blocking(handle, slice)
     ret = LibC.WriteFile(handle, slice, slice.size, out bytes_written, nil)
     if ret.zero?
       case error = WinError.value

--- a/src/crystal/system/win32/file_descriptor.cr
+++ b/src/crystal/system/win32/file_descriptor.cr
@@ -24,23 +24,28 @@ module Crystal::System::FileDescriptor
     if ConsoleUtils.console?(handle)
       ConsoleUtils.read(handle, slice)
     elsif system_blocking?
-      if LibC.ReadFile(handle, slice, slice.size, out bytes_read, nil) == 0
-        case error = WinError.value
-        when .error_access_denied?
-          raise IO::Error.new "File not open for reading", target: self
-        when .error_broken_pipe?
-          return 0_i32
-        else
-          raise IO::Error.from_os_error("Error reading file", error, target: self)
-        end
-      end
-      bytes_read.to_i32
+      read_blocking(handle, slice)
     else
       overlapped_operation(handle, "ReadFile", read_timeout) do |overlapped|
         ret = LibC.ReadFile(handle, slice, slice.size, out byte_count, overlapped)
         {ret, byte_count}
       end.to_i32
     end
+  end
+
+  private def read_blocking(handle, slice)
+    ret = LibC.ReadFile(handle, slice, slice.size, out bytes_read, nil)
+    if ret.zero?
+      case error = WinError.value
+      when .error_access_denied?
+        raise IO::Error.new "File not open for reading", target: self
+      when .error_broken_pipe?
+        return 0_i32
+      else
+        raise IO::Error.from_os_error("Error reading file", error, target: self)
+      end
+    end
+    bytes_read.to_i32
   end
 
   private def unbuffered_write(slice : Bytes) : Nil

--- a/src/crystal/system/win32/file_descriptor.cr
+++ b/src/crystal/system/win32/file_descriptor.cr
@@ -52,16 +52,7 @@ module Crystal::System::FileDescriptor
     handle = windows_handle
     until slice.empty?
       if system_blocking?
-        if LibC.WriteFile(handle, slice, slice.size, out bytes_written, nil) == 0
-          case error = WinError.value
-          when .error_access_denied?
-            raise IO::Error.new "File not open for writing", target: self
-          when .error_broken_pipe?
-            return 0_u32
-          else
-            raise IO::Error.from_os_error("Error writing file", error, target: self)
-          end
-        end
+        bytes_written = blocking_write(handle, slice)
       else
         bytes_written = overlapped_operation(handle, "WriteFile", write_timeout, writing: true) do |overlapped|
           ret = LibC.WriteFile(handle, slice, slice.size, out byte_count, overlapped)
@@ -71,6 +62,21 @@ module Crystal::System::FileDescriptor
 
       slice += bytes_written
     end
+  end
+
+  private def blocking_write(handle, slice)
+    ret = LibC.WriteFile(handle, slice, slice.size, out bytes_written, nil)
+    if ret.zero?
+      case error = WinError.value
+      when .error_access_denied?
+        raise IO::Error.new "File not open for writing", target: self
+      when .error_broken_pipe?
+        return 0_u32
+      else
+        raise IO::Error.from_os_error("Error writing file", error, target: self)
+      end
+    end
+    bytes_written
   end
 
   private def system_blocking?


### PR DESCRIPTION
Extracts blocking read and write implementations into separate methods, `#read_blocking` and `#write_blocking` to harmonize the level of abstraction in `#unbuffered_read`/`#unbuffered_write`.

I'm not touching the buffered branch because it's going to be a single call after the event loop refactor.