### PR TITLE
Refactor base64 encoding

### DIFF
--- a/spec/std/base64_spec.cr
+++ b/spec/std/base64_spec.cr
@@ -83,7 +83,7 @@ describe "Base64" do
       7,
       8190,          # 1 segment below the buffer size
       8191,          # 2 bytes below the buffer size
-      8192,          # 1 byte belowbuffer size
+      8192,          # 1 byte below buffer size
       8193,          # encoding buffer size
       8194,          # 1 byte over the buffer size
       8195,          # 2 bytes over the buffer size

--- a/src/base64.cr
+++ b/src/base64.cr
@@ -313,7 +313,7 @@ module Base64
 
   # Internal method of encode_base64_buffer.
   #
-  # On most archivectures supported by crystal, unaligned memory access is very cheap.
+  # On most architectures supported by Crystal, unaligned memory access is very cheap.
   # This section thus tries to improve performance by unrolling the loop and by replacing
   # three aligned UInt8 accesses by one unaligned UInt32 access (discarding the last byte).
   # The caller has to make sure that there's at least one readable byte behind the last given pair,
@@ -356,9 +356,9 @@ module Base64
     return if pairs <= 0
 
     if pairs > 1
-      encode_base64_buffer__full_pairs_excess(input, output, pairs - 1, charset)
-      input += 3 &* (pairs - 1)
-      output += 4 &* (pairs - 1)
+      encode_base64_buffer__full_pairs_excess(input, output, pairs &- 1, charset)
+      input += 3 &* (pairs &- 1)
+      output += 4 &* (pairs &- 1)
     end
 
     charset = charset.as(UInt8*)


### PR DESCRIPTION
This PR rewrites the entire base64-encoding logic.
While doing so, it adds methods used to encode (normal, urlsafe and strict) base64 from one `IO` into another.
Also, `urlsafe_encode(data, io)` now received an optional `padding = true` parameter to reach feature parity between all ways to encode base64 (buffer to buffer, buffer to IO, IO to IO).

Encoding from buffer to buffer only saw small performance improvements, but everything related to `IO`s saw very significant performance improvements.

The specs from #14604 have been copied over to this PR, although more should probably be added.

<details>
<summary>Benchmark Code</summary>

For this benchmark, I copied the `base64.cr` file from this repo into `base64blob.cr` and renamed the module inside to `Base64Blob`. This way, both variants can be used in parallel.

### Direct Comparison

```cr
require "benchmark"
require "base64"

require "./base64blob"

asma = "a" * 10
amed = "a" * 1000
abig = "a" * 1_000_000
dev_zero = File.new("/dev/zero", "w+")

macro bench(name, input, *output)
  puts "\nBenchmark: #{ {{name}} }"
  Benchmark.ips do |x|
    x.report("old") { Base64.encode({{input}}, {{output.splat}}) }
    x.report("new") { Base64Blob.encode({{input}}, {{output.splat}}) }
  end
end

bench("10 byte string to string", asma)
bench("1000 byte string to string", amed)
bench("1_000_0000 byte string to string", abig)

bench("10 byte string to IO", asma, dev_zero)
bench("1000 byte string to IO", amed, dev_zero)
bench("1_000_0000 byte string to IO", abig, dev_zero)

# For comparison with #14604
#bench("10 byte IO to IO", IO::Sized.new(dev_zero, 10), dev_zero)
#bench("1000 bytes IO to IO", IO::Sized.new(dev_zero, 1000), dev_zero)
#bench("1_000_000 bytes IO to IO", IO::Sized.new(dev_zero, 1_000_000), dev_zero)
```

### Throughput:
```cr
require "benchmark"
require "./base64blob.cr"

input = File.new("/dev/zero", "r")
output = File.new("/dev/zero", "w")
input_size = 2**30 # 1GiB

Benchmark.ips do |x|
  x.report("throughput (1GiB)") { Base64Blob.strict_encode(IO::Sized.new(input, input_size), output) }
end
```

</details>

<details>
<summary>My Benchmark Results (Fedora 40, Ryzen 3600)</summary>

### Direct comparisons

```yaml
Benchmark: 10 byte string to string
old  34.96M ( 28.61ns) (± 0.34%)  32.0B/op   1.11× slower
new  38.97M ( 25.66ns) (± 0.33%)  32.0B/op        fastest

Benchmark: 1000 byte string to string
old   1.14M (874.90ns) (± 1.20%)  2.0kB/op   1.38× slower
new   1.58M (632.77ns) (± 0.48%)  2.0kB/op        fastest

Benchmark: 1_000_0000 byte string to string
old   1.43k (697.02µs) (± 0.59%)  1.3MB/op   1.52× slower
new   2.19k (457.18µs) (± 1.19%)  1.3MB/op        fastest

Benchmark: 10 byte string to IO
old   2.92M (342.82ns) (± 1.04%)  0.0B/op   1.14× slower
new   3.32M (301.40ns) (± 0.51%)  0.0B/op        fastest

Benchmark: 1000 byte string to IO
old 215.74k (  4.64µs) (± 0.73%)  0.0B/op   6.21× slower
new   1.34M (746.07ns) (± 0.64%)  0.0B/op        fastest

Benchmark: 1_000_0000 byte string to IO
old 229.40  (  4.36ms) (± 0.98%)  0.0B/op   9.29× slower
new   2.13k (469.31µs) (± 0.97%)  0.0B/op        fastest

Benchmark: 10 byte IO to IO
old   2.30M (435.64ns) (± 0.23%)  96.0B/op   8.59× slower
new  19.72M ( 50.70ns) (± 0.99%)  96.0B/op        fastest

Benchmark: 1000 bytes IO to IO
old 211.53k (  4.73µs) (± 1.49%)  96.0B/op   8.10× slower
new   1.71M (583.84ns) (± 0.49%)  96.0B/op        fastest

Benchmark: 1_000_000 bytes IO to IO
old 231.63  (  4.32ms) (± 0.59%)  93.0B/op   8.17× slower
new   1.89k (528.53µs) (± 0.57%)  96.0B/op        fastest
```

> **NOTE: The Buffer-to-IO encoding methods call `#flush` on the output IO, which explains why encoding 10 bytes to IO takes `> 300ns`. Without the explicit flush, this number goes down to `18.63ns`**

> **NOTE: The IO-to-IO encoding methods were compared against #14604**

### Throughput

Reading from and writing to `/dev/zero`, the code needed `490.62ms` per `1 GiB` (-> 2.04GiB / 2.19GB per second) in strict mode and `565.33ms` using the default `#encode` (-> 1.77GiB / 1.90GB per second)

</details>

Closes https://github.com/crystal-lang/crystal/pull/14604