### PR TITLE
Add some missing `LLVM::Context` bindings

### DIFF
--- a/src/llvm/context.cr
+++ b/src/llvm/context.cr
@@ -74,18 +74,20 @@ class LLVM::Context
   def ppc_fp128 : Type
     Type.new LibLLVM.ppc_fp128_type_in_context(self)
   end
+
+  def pointer(address_space = 0) : Type
     {% if LibLLVM::IS_LT_150 %}
       {% raise "Opaque pointers are only supported on LLVM 15.0 or above" %}
     {% else %}
-      Type.new LibLLVM.pointer_type_in_context(self, 0)
+      Type.new LibLLVM.pointer_type_in_context(self, address_space)
     {% end %}
   end
 
-  def void_pointer : Type
+  def void_pointer(address_space = 0) : Type
     {% if LibLLVM::IS_LT_150 %}
-      int8.pointer
+      int8.pointer(address_space)
     {% else %}
-      pointer
+      pointer(address_space)
     {% end %}
   end
 

--- a/src/llvm/context.cr
+++ b/src/llvm/context.cr
@@ -51,6 +51,10 @@ class LLVM::Context
     Type.new LibLLVM.int_type_in_context(self, bits)
   end
 
+  def half : Type
+    Type.new LibLLVM.half_type_in_context(self)
+  end
+
   def float : Type
     Type.new LibLLVM.float_type_in_context(self)
   end
@@ -59,7 +63,17 @@ class LLVM::Context
     Type.new LibLLVM.double_type_in_context(self)
   end
 
-  def pointer : Type
+  def x86_fp80 : Type
+    Type.new LibLLVM.x86_fp80_type_in_context(self)
+  end
+
+  def fp128 : Type
+    Type.new LibLLVM.fp128_type_in_context(self)
+  end
+
+  def ppc_fp128 : Type
+    Type.new LibLLVM.ppc_fp128_type_in_context(self)
+  end
     {% if LibLLVM::IS_LT_150 %}
       {% raise "Opaque pointers are only supported on LLVM 15.0 or above" %}
     {% else %}

--- a/src/llvm/lib_llvm/core.cr
+++ b/src/llvm/lib_llvm/core.cr
@@ -58,8 +58,12 @@ lib LibLLVM
   fun int_type_in_context = LLVMIntTypeInContext(c : ContextRef, num_bits : UInt) : TypeRef
   fun get_int_type_width = LLVMGetIntTypeWidth(integer_ty : TypeRef) : UInt
 
+  fun half_type_in_context = LLVMHalfTypeInContext(c : ContextRef) : TypeRef
   fun float_type_in_context = LLVMFloatTypeInContext(c : ContextRef) : TypeRef
   fun double_type_in_context = LLVMDoubleTypeInContext(c : ContextRef) : TypeRef
+  fun x86_fp80_type_in_context = LLVMX86FP80TypeInContext(c : ContextRef) : TypeRef
+  fun fp128_type_in_context = LLVMFP128TypeInContext(c : ContextRef) : TypeRef
+  fun ppc_fp128_type_in_context = LLVMPPCFP128TypeInContext(c : ContextRef) : TypeRef
 
   fun function_type = LLVMFunctionType(return_type : TypeRef, param_types : TypeRef*, param_count : UInt, is_var_arg : Bool) : TypeRef
   fun is_function_var_arg = LLVMIsFunctionVarArg(function_ty : TypeRef) : Bool

--- a/src/llvm/type.cr
+++ b/src/llvm/type.cr
@@ -50,11 +50,11 @@ struct LLVM::Type
     Value.new LibLLVM.get_undef(self)
   end
 
-  def pointer : LLVM::Type
+  def pointer(address_space = 0) : LLVM::Type
     {% if LibLLVM::IS_LT_150 %}
-      Type.new LibLLVM.pointer_type(self, 0)
+      Type.new LibLLVM.pointer_type(self, address_space)
     {% else %}
-      Type.new LibLLVM.pointer_type_in_context(LibLLVM.get_type_context(self), 0)
+      Type.new LibLLVM.pointer_type_in_context(LibLLVM.get_type_context(self), address_space)
     {% end %}
   end
 


### PR DESCRIPTION
I noticed a couple missing bindings in `LLVM::Context` while playing with a pure Crystal [data layout parser + generic ABI](https://gist.github.com/ysbaddaden/cf58d33e316067a9e4ad886976cbdc98) to implement `alignof`, `sizeof` and `offsetof`. Namely

- create f16, f80 and f128 floating point types
- specify the address space for pointers (might be useful to implement PROGMEM for the AVR target?)

So here they are.