### PR TITLE
Fix using `System.retry_with_buffer` with stack buffer

### DIFF
--- a/src/crystal/system/unix/group.cr
+++ b/src/crystal/system/unix/group.cr
@@ -14,7 +14,7 @@ module Crystal::System::Group
     grp = uninitialized LibC::Group
     grp_pointer = pointerof(grp)
     System.retry_with_buffer("getgrnam_r", GETGR_R_SIZE_MAX) do |buf|
-      LibC.getgrnam_r(groupname, grp_pointer, buf, buf.size, pointerof(grp_pointer)).tap do |ret|
+      LibC.getgrnam_r(groupname, grp_pointer, buf, buf.size, pointerof(grp_pointer)).tap do
         # It's not necessary to check success with `ret == 0` because `grp_pointer` will be NULL on failure
         return from_struct(grp) if grp_pointer
       end
@@ -28,7 +28,7 @@ module Crystal::System::Group
     grp = uninitialized LibC::Group
     grp_pointer = pointerof(grp)
     System.retry_with_buffer("getgrgid_r", GETGR_R_SIZE_MAX) do |buf|
-      LibC.getgrgid_r(groupid, grp_pointer, buf, buf.size, pointerof(grp_pointer)).tap do |ret|
+      LibC.getgrgid_r(groupid, grp_pointer, buf, buf.size, pointerof(grp_pointer)).tap do
         # It's not necessary to check success with `ret == 0` because `grp_pointer` will be NULL on failure
         return from_struct(grp) if grp_pointer
       end

--- a/src/crystal/system/unix/group.cr
+++ b/src/crystal/system/unix/group.cr
@@ -14,10 +14,11 @@ module Crystal::System::Group
     grp = uninitialized LibC::Group
     grp_pointer = pointerof(grp)
     System.retry_with_buffer("getgrnam_r", GETGR_R_SIZE_MAX) do |buf|
-      LibC.getgrnam_r(groupname, grp_pointer, buf, buf.size, pointerof(grp_pointer))
+      LibC.getgrnam_r(groupname, grp_pointer, buf, buf.size, pointerof(grp_pointer)).tap do |ret|
+        # It's not necessary to check success with `ret == 0` because `grp_pointer` will be NULL on failure
+        return from_struct(grp) if grp_pointer
+      end
     end
-
-    from_struct(grp) if grp_pointer
   end
 
   private def from_id?(groupid : String)
@@ -27,8 +28,10 @@ module Crystal::System::Group
     grp = uninitialized LibC::Group
     grp_pointer = pointerof(grp)
     System.retry_with_buffer("getgrgid_r", GETGR_R_SIZE_MAX) do |buf|
-      LibC.getgrgid_r(groupid, grp_pointer, buf, buf.size, pointerof(grp_pointer))
+      LibC.getgrgid_r(groupid, grp_pointer, buf, buf.size, pointerof(grp_pointer)).tap do |ret|
+        # It's not necessary to check success with `ret == 0` because `grp_pointer` will be NULL on failure
+        return from_struct(grp) if grp_pointer
+      end
     end
-    from_struct(grp) if grp_pointer
   end
 end

--- a/src/crystal/system/unix/path.cr
+++ b/src/crystal/system/unix/path.cr
@@ -11,14 +11,13 @@ module Crystal::System::Path
       pwd_pointer = pointerof(pwd)
       ret = nil
       System.retry_with_buffer("getpwuid_r", User::GETPW_R_SIZE_MAX) do |buf|
-        ret = LibC.getpwuid_r(id, pwd_pointer, buf, buf.size, pointerof(pwd_pointer))
+        ret = LibC.getpwuid_r(id, pwd_pointer, buf, buf.size, pointerof(pwd_pointer)).tap do |ret|
+          # It's not necessary to check success with `ret == 0` because `pwd_pointer` will be NULL on failure
+          return String.new(pwd.pw_dir) if pwd_pointer
+        end
       end
 
-      if pwd_pointer
-        String.new(pwd.pw_dir)
-      else
-        raise RuntimeError.from_os_error("getpwuid_r", Errno.new(ret.not_nil!))
-      end
+      raise RuntimeError.from_os_error("getpwuid_r", Errno.new(ret.not_nil!))
     end
   end
 end

--- a/src/crystal/system/unix/path.cr
+++ b/src/crystal/system/unix/path.cr
@@ -11,7 +11,7 @@ module Crystal::System::Path
       pwd_pointer = pointerof(pwd)
       ret = nil
       System.retry_with_buffer("getpwuid_r", User::GETPW_R_SIZE_MAX) do |buf|
-        ret = LibC.getpwuid_r(id, pwd_pointer, buf, buf.size, pointerof(pwd_pointer)).tap do |ret|
+        ret = LibC.getpwuid_r(id, pwd_pointer, buf, buf.size, pointerof(pwd_pointer)).tap do
           # It's not necessary to check success with `ret == 0` because `pwd_pointer` will be NULL on failure
           return String.new(pwd.pw_dir) if pwd_pointer
         end

--- a/src/crystal/system/unix/user.cr
+++ b/src/crystal/system/unix/user.cr
@@ -17,10 +17,11 @@ module Crystal::System::User
     pwd = uninitialized LibC::Passwd
     pwd_pointer = pointerof(pwd)
     System.retry_with_buffer("getpwnam_r", GETPW_R_SIZE_MAX) do |buf|
-      LibC.getpwnam_r(username, pwd_pointer, buf, buf.size, pointerof(pwd_pointer))
+      LibC.getpwnam_r(username, pwd_pointer, buf, buf.size, pointerof(pwd_pointer)).tap do |ret|
+        # It's not necessary to check success with `ret == 0` because `pwd_pointer` will be NULL on failure
+        return from_struct(pwd) if pwd_pointer
+      end
     end
-
-    from_struct(pwd) if pwd_pointer
   end
 
   private def from_id?(id : String)
@@ -30,9 +31,10 @@ module Crystal::System::User
     pwd = uninitialized LibC::Passwd
     pwd_pointer = pointerof(pwd)
     System.retry_with_buffer("getpwuid_r", GETPW_R_SIZE_MAX) do |buf|
-      LibC.getpwuid_r(id, pwd_pointer, buf, buf.size, pointerof(pwd_pointer))
+      LibC.getpwuid_r(id, pwd_pointer, buf, buf.size, pointerof(pwd_pointer)).tap do |ret|
+        # It's not necessary to check success with `ret == 0` because `pwd_pointer` will be NULL on failure
+        return from_struct(pwd) if pwd_pointer
+      end
     end
-
-    from_struct(pwd) if pwd_pointer
   end
 end

--- a/src/crystal/system/unix/user.cr
+++ b/src/crystal/system/unix/user.cr
@@ -17,7 +17,7 @@ module Crystal::System::User
     pwd = uninitialized LibC::Passwd
     pwd_pointer = pointerof(pwd)
     System.retry_with_buffer("getpwnam_r", GETPW_R_SIZE_MAX) do |buf|
-      LibC.getpwnam_r(username, pwd_pointer, buf, buf.size, pointerof(pwd_pointer)).tap do |ret|
+      LibC.getpwnam_r(username, pwd_pointer, buf, buf.size, pointerof(pwd_pointer)).tap do
         # It's not necessary to check success with `ret == 0` because `pwd_pointer` will be NULL on failure
         return from_struct(pwd) if pwd_pointer
       end
@@ -31,7 +31,7 @@ module Crystal::System::User
     pwd = uninitialized LibC::Passwd
     pwd_pointer = pointerof(pwd)
     System.retry_with_buffer("getpwuid_r", GETPW_R_SIZE_MAX) do |buf|
-      LibC.getpwuid_r(id, pwd_pointer, buf, buf.size, pointerof(pwd_pointer)).tap do |ret|
+      LibC.getpwuid_r(id, pwd_pointer, buf, buf.size, pointerof(pwd_pointer)).tap do
         # It's not necessary to check success with `ret == 0` because `pwd_pointer` will be NULL on failure
         return from_struct(pwd) if pwd_pointer
       end


### PR DESCRIPTION
`retry_with_buffer` uses a stack allocated buffer for the happy case of small allocations. But this means the buffer is only valid *inside* the block. Outside of it, the stack memory may be corrupted because it can get overwritten by other data.

All call sites of `retry_with_buffer` were not paying attention to this. In all cases the buffer is used as scratch space to put dynamically sized properties of a struct. This data is later used to construct a `String` instance. This needs to happen within the block of `retry_with_buffer` to ensure the buffer is valid.

This error hasn't been noticed until I tried a little refactor in #14614. I suppose the code usually still works fine because there are no further calls which could override the stack data.
It only failed in the interpreter, which I guess does something differently. May this need further investigation?