### PR TITLE
Add `Crystal::System::Time.ticks`

### DIFF
--- a/src/crystal/system/time.cr
+++ b/src/crystal/system/time.cr
@@ -3,6 +3,8 @@ module Crystal::System::Time
   # since `0001-01-01 00:00:00`.
   # def self.compute_utc_seconds_and_nanoseconds : {Int64, Int32}
 
+  # Returns the current time from the monotonic clock in `{seconds,
+  # nanoseconds}`.
   # def self.monotonic : {Int64, Int32}
 
   # Returns a list of paths where time zone data should be looked up.

--- a/src/crystal/system/time.cr
+++ b/src/crystal/system/time.cr
@@ -7,6 +7,10 @@ module Crystal::System::Time
   # nanoseconds}`.
   # def self.monotonic : {Int64, Int32}
 
+  # Returns the current time from the monotonic clock in nanoseconds.
+  # Doesn't raise nor allocates GC HEAP memory.
+  # def self.ticks : UInt64
+
   # Returns a list of paths where time zone data should be looked up.
   # def self.zone_sources : Enumerable(String)
 

--- a/src/crystal/system/unix/time.cr
+++ b/src/crystal/system/unix/time.cr
@@ -46,6 +46,16 @@ module Crystal::System::Time
     {% end %}
   end
 
+  def self.ticks : UInt64
+    {% if flag?(:darwin) %}
+      info = mach_timebase_info
+      LibC.mach_absolute_time &* info.numer // info.denom
+    {% else %}
+      LibC.clock_gettime(LibC::CLOCK_MONOTONIC, out tp)
+      tp.tv_sec.to_u64! &* NANOSECONDS_PER_SECOND &+ tp.tv_nsec.to_u64!
+    {% end %}
+  end
+
   def self.to_timespec(time : ::Time)
     t = uninitialized LibC::Timespec
     t.tv_sec = typeof(t.tv_sec).new(time.to_unix)

--- a/src/crystal/system/win32/time.cr
+++ b/src/crystal/system/win32/time.cr
@@ -53,13 +53,9 @@ module Crystal::System::Time
     ((filetime.dwHighDateTime.to_u64 << 32) | filetime.dwLowDateTime.to_u64).to_f64 / FILETIME_TICKS_PER_SECOND.to_f64
   end
 
-  @@performance_frequency : Int64?
-
-  private def self.performance_frequency
-    @@performance_frequency ||= begin
-      LibC.QueryPerformanceFrequency(out frequency)
-      frequency
-    end
+  private class_getter performance_frequency : Int64 do
+    LibC.QueryPerformanceFrequency(out frequency)
+    frequency
   end
 
   def self.monotonic : {Int64, Int32}

--- a/src/crystal/system/win32/time.cr
+++ b/src/crystal/system/win32/time.cr
@@ -66,7 +66,11 @@ module Crystal::System::Time
     LibC.QueryPerformanceCounter(out ticks)
     frequency = performance_frequency
     {ticks // frequency, (ticks.remainder(frequency) * NANOSECONDS_PER_SECOND / frequency).to_i32}
+  end
 
+  def self.ticks : UInt64
+    LibC.QueryPerformanceCounter(out ticks)
+    ticks.to_u64! &* (NANOSECONDS_PER_SECOND // performance_frequency)
   end
 
   def self.load_localtime : ::Time::Location?

--- a/src/crystal/system/win32/time.cr
+++ b/src/crystal/system/win32/time.cr
@@ -53,21 +53,20 @@ module Crystal::System::Time
     ((filetime.dwHighDateTime.to_u64 << 32) | filetime.dwLowDateTime.to_u64).to_f64 / FILETIME_TICKS_PER_SECOND.to_f64
   end
 
-  @@performance_frequency : Int64 = begin
-    ret = LibC.QueryPerformanceFrequency(out frequency)
-    if ret == 0
-      raise RuntimeError.from_winerror("QueryPerformanceFrequency")
-    end
+  @@performance_frequency : Int64?
 
-    frequency
+  private def self.performance_frequency
+    @@performance_frequency ||= begin
+      LibC.QueryPerformanceFrequency(out frequency)
+      frequency
+    end
   end
 
   def self.monotonic : {Int64, Int32}
-    if LibC.QueryPerformanceCounter(out ticks) == 0
-      raise RuntimeError.from_winerror("QueryPerformanceCounter")
-    end
+    LibC.QueryPerformanceCounter(out ticks)
+    frequency = performance_frequency
+    {ticks // frequency, (ticks.remainder(frequency) * NANOSECONDS_PER_SECOND / frequency).to_i32}
 
-    {ticks // @@performance_frequency, (ticks.remainder(@@performance_frequency) * NANOSECONDS_PER_SECOND / @@performance_frequency).to_i32}
   end
 
   def self.load_localtime : ::Time::Location?


### PR DESCRIPTION
The first two commits are straightforward. They mostly do a bit of cleanup. Details are in the commit descriptions.

I'm not sure about the third one: it's meant for #14618 where I want the monotonic time as a basic integer, yet can't have it allocate memory (GC may not be initialized) and raising would be an issue (`.monotonic` may raise on ).