### PR TITLE
Add `WaitGroup` to `docs_main.cr`

### DIFF
--- a/src/docs_main.cr
+++ b/src/docs_main.cr
@@ -58,4 +58,5 @@ require "./syscall"
 {% unless flag?(:win32) %}
   require "./system/*"
 {% end %}
+require "./wait_group"
 require "./docs_pseudo_methods"


### PR DESCRIPTION
`WaitGroup` is missing from the API docs because it wasn't added to `docs_main.cr`.

This was the first new file with a public API added in a long time. I checked the git logs of the past years to see if we forgot anything else (I'd expect we would've noticed by now, but you might never know what's missing if you can't see it 🤷).

Follow-up to #14167