### PR TITLE
Extract `#system_read` and `#system_write` for `FileDescriptor` and `Socket`

### DIFF
--- a/src/crystal/system/file_descriptor.cr
+++ b/src/crystal/system/file_descriptor.cr
@@ -13,6 +13,10 @@ module Crystal::System::FileDescriptor
   # For the duration of the block, enables raw mode if *enable* is true, enables
   # cooked mode otherwise.
   # private def system_raw(enable : Bool, & : ->)
+
+  # private def system_read(slice : Bool) : Int32
+
+  # private def system_write(slice : Bool) : Int32
 end
 
 {% if flag?(:wasi) %}

--- a/src/crystal/system/socket.cr
+++ b/src/crystal/system/socket.cr
@@ -71,9 +71,9 @@ module Crystal::System::Socket
 
   # def self.fcntl(fd, cmd, arg = 0)
 
-  # private def unbuffered_read(slice : Bytes) : Int32
+  # private def system_read(slice : Bytes) : Int32
 
-  # private def unbuffered_write(slice : Bytes) : Nil
+  # private def system_write(slice : Bytes) : Int32
 
   # private def system_close
 

--- a/src/crystal/system/unix/file_descriptor.cr
+++ b/src/crystal/system/unix/file_descriptor.cr
@@ -17,7 +17,7 @@ module Crystal::System::FileDescriptor
   STDOUT_HANDLE = 1
   STDERR_HANDLE = 2
 
-  private def unbuffered_read(slice : Bytes) : Int32
+  private def system_read(slice : Bytes) : Int32
     evented_read(slice, "Error reading file") do
       LibC.read(fd, slice, slice.size).tap do |return_code|
         if return_code == -1 && Errno.value == Errno::EBADF
@@ -27,7 +27,7 @@ module Crystal::System::FileDescriptor
     end
   end
 
-  private def unbuffered_write(slice : Bytes) : Nil
+  private def system_write(slice : Bytes) : Int32
     evented_write(slice, "Error writing file") do |slice|
       LibC.write(fd, slice, slice.size).tap do |return_code|
         if return_code == -1 && Errno.value == Errno::EBADF

--- a/src/crystal/system/unix/socket.cr
+++ b/src/crystal/system/unix/socket.cr
@@ -250,13 +250,13 @@ module Crystal::System::Socket
     LibC.isatty(fd) == 1
   end
 
-  private def unbuffered_read(slice : Bytes) : Int32
+  private def system_read(slice : Bytes) : Int32
     evented_read(slice, "Error reading socket") do
       LibC.recv(fd, slice, slice.size, 0).to_i32
     end
   end
 
-  private def unbuffered_write(slice : Bytes) : Nil
+  private def system_write(slice : Bytes) : Int32
     evented_write(slice, "Error writing to socket") do |slice|
       LibC.send(fd, slice, slice.size, 0)
     end

--- a/src/crystal/system/wasi/socket.cr
+++ b/src/crystal/system/wasi/socket.cr
@@ -161,13 +161,13 @@ module Crystal::System::Socket
     LibC.isatty(fd) == 1
   end
 
-  private def unbuffered_read(slice : Bytes) : Int32
+  private def system_read(slice : Bytes) : Int32
     evented_read(slice, "Error reading socket") do
       LibC.recv(fd, slice, slice.size, 0).to_i32
     end
   end
 
-  private def unbuffered_write(slice : Bytes) : Nil
+  private def system_write(slice : Bytes) : Int32
     evented_write(slice, "Error writing to socket") do |slice|
       LibC.send(fd, slice, slice.size, 0)
     end

--- a/src/crystal/system/win32/socket.cr
+++ b/src/crystal/system/win32/socket.cr
@@ -445,7 +445,7 @@ module Crystal::System::Socket
     LibC.GetConsoleMode(LibC::HANDLE.new(fd), out _) != 0
   end
 
-  private def unbuffered_read(slice : Bytes) : Int32
+  private def system_read(slice : Bytes) : Int32
     wsabuf = wsa_buffer(slice)
 
     bytes_read = overlapped_read(fd, "WSARecv", connreset_is_error: false) do |overlapped|
@@ -457,7 +457,7 @@ module Crystal::System::Socket
     bytes_read.to_i32
   end
 
-  private def unbuffered_write(slice : Bytes) : Nil
+  private def system_write(slice : Bytes) : Int32
     wsabuf = wsa_buffer(slice)
 
     bytes = overlapped_write(fd, "WSASend") do |overlapped|

--- a/src/io/file_descriptor.cr
+++ b/src/io/file_descriptor.cr
@@ -263,6 +263,16 @@ class IO::FileDescriptor < IO
     pp.text inspect
   end
 
+  private def unbuffered_read(slice : Bytes) : Int32
+    system_read(slice)
+  end
+
+  private def unbuffered_write(slice : Bytes) : Nil
+    until slice.empty?
+      slice += system_write(slice)
+    end
+  end
+
   private def unbuffered_rewind : Nil
     self.pos = 0
   end

--- a/src/socket.cr
+++ b/src/socket.cr
@@ -424,6 +424,16 @@ class Socket < IO
     system_tty?
   end
 
+  private def unbuffered_read(slice : Bytes) : Int32
+    system_read(slice)
+  end
+
+  private def unbuffered_write(slice : Bytes) : Nil
+    until slice.empty?
+      slice += system_write(slice)
+    end
+  end
+
   private def unbuffered_rewind : Nil
     raise Socket::Error.new("Can't rewind")
   end


### PR DESCRIPTION
Currently, individual system implementations of `System::FileDescriptor` and `System::Socket` implement `IO#unbuffered_read` and `IO#unbuffered_write` directly. This patch pulls the implementation up to be shared between all platforms, and instead delegates to `#system_read` and `#system_write`.

`#unbuffered_write` is now responsible for ensuring that the entire content of the slice is written, calling `system_write` multiple times if necessary. (Looks like this wasn't implemented correctly in `Socket` on Windows before)

This is a simplification step in preparation for a bigger refactoring which will delegate `#system_read` and `#system_write` to the event loop (https://github.com/crystal-lang/rfcs/pull/7).