### PR TITLE
Don't pass socket file descriptors to subprocesses on Unix (`SOCK_CLOEXEC`)

### DIFF
--- a/spec/std/socket/socket_spec.cr
+++ b/spec/std/socket/socket_spec.cr
@@ -159,4 +159,9 @@ describe Socket, tags: "network" do
       end
     end
   end
+
+  it "closes on exec by default" do
+    socket = Socket.new(Socket::Family::INET, Socket::Type::STREAM, Socket::Protocol::TCP)
+    socket.close_on_exec?.should be_true
+  end
 end

--- a/spec/std/socket/socket_spec.cr
+++ b/spec/std/socket/socket_spec.cr
@@ -160,8 +160,10 @@ describe Socket, tags: "network" do
     end
   end
 
-  it "closes on exec by default" do
-    socket = Socket.new(Socket::Family::INET, Socket::Type::STREAM, Socket::Protocol::TCP)
-    socket.close_on_exec?.should be_true
-  end
+  {% unless flag?(:win32) %}
+    it "closes on exec by default" do
+      socket = Socket.new(Socket::Family::INET, Socket::Type::STREAM, Socket::Protocol::TCP)
+      socket.close_on_exec?.should be_true
+    end
+  {% end %}
 end

--- a/src/crystal/system/unix/socket.cr
+++ b/src/crystal/system/unix/socket.cr
@@ -9,6 +9,10 @@ module Crystal::System::Socket
   alias Handle = Int32
 
   private def create_handle(family, type, protocol, blocking) : Handle
+    {% if LibC.has_constant?(:SOCK_CLOEXEC) %}
+      # Forces opened sockets to be closed on `exec(2)`.
+      type = type.to_i | LibC::SOCK_CLOEXEC
+    {% end %}
     fd = LibC.socket(family, type, protocol)
     raise ::Socket::Error.from_errno("Failed to create socket") if fd == -1
     fd


### PR DESCRIPTION
The comment 8 lines down suggests that this has been lost at some point.

Fixes #14630