### PR TITLE
Harmonize close on exec for `Socket` & `FileDescriptor` on Windows

### DIFF
--- a/src/crystal/system/win32/socket.cr
+++ b/src/crystal/system/win32/socket.cr
@@ -432,8 +432,7 @@ module Crystal::System::Socket
   end
 
   private def system_close_on_exec=(arg : Bool)
-    raise NotImplementedError.new
-    "Crystal::System::Socket#system_close_on_exec=" if arg
+    raise NotImplementedError.new "Crystal::System::Socket#system_close_on_exec=" if arg
   end
 
   def self.fcntl(fd, cmd, arg = 0)


### PR DESCRIPTION
Fixes the `system_close_on_exec` property like methods on `Crystal:::System::Socket` for the windows platform. They tried to access `LibC::F_GETFD` and `LibC::F_SETFD` that don't exist. 

The behavior is unsupported on Windows, and it's now harmonized with how `Crystal::System::FileDescriptor` handles it (i.e. returning `false` and raising when trying to enable it).