### PR TITLE
Fix: don't allocate on Fiber.unsafe_each and Thread.unsafe_each

### DIFF
--- a/src/crystal/system/thread.cr
+++ b/src/crystal/system/thread.cr
@@ -57,7 +57,7 @@ class Thread
   getter name : String?
 
   def self.unsafe_each(&)
-    threads.unsafe_each { |thread| yield thread }
+    @@threads.try(&.unsafe_each { |thread| yield thread })
   end
 
   # Creates and starts a new system thread.

--- a/src/fiber.cr
+++ b/src/fiber.cr
@@ -73,7 +73,7 @@ class Fiber
 
   # :nodoc:
   def self.unsafe_each(&)
-    fibers.unsafe_each { |fiber| yield fiber }
+    @@fibers.try(&.unsafe_each { |fiber| yield fiber })
   end
 
   # Creates a new `Fiber` instance.


### PR DESCRIPTION
These methods are called during GC collections, which may happen before the Thread::LinkedList objects are created, leading to an infinite loop of malloc -> collect -> malloc -> collect -> ...

Kudos to @BlobCodes for identifying the issue!

fixes #14633