### PR TITLE
Drop `Crystal::System::Socket#system_send`

### DIFF
--- a/src/crystal/system/socket.cr
+++ b/src/crystal/system/socket.cr
@@ -15,8 +15,6 @@ module Crystal::System::Socket
 
   # private def system_accept
 
-  # private def system_send(bytes : Bytes) : Int32
-
   # private def system_send_to(bytes : Bytes, addr : ::Socket::Address)
 
   # private def system_receive(bytes)

--- a/src/crystal/system/unix/socket.cr
+++ b/src/crystal/system/unix/socket.cr
@@ -79,12 +79,6 @@ module Crystal::System::Socket
     end
   end
 
-  private def system_send(bytes : Bytes) : Int32
-    evented_send(bytes, "Error sending datagram") do |slice|
-      LibC.send(fd, slice.to_unsafe.as(Void*), slice.size, 0)
-    end
-  end
-
   private def system_send_to(bytes : Bytes, addr : ::Socket::Address)
     bytes_sent = LibC.sendto(fd, bytes.to_unsafe.as(Void*), bytes.size, 0, addr, addr.size)
     raise ::Socket::Error.from_errno("Error sending datagram to #{addr}") if bytes_sent == -1

--- a/src/crystal/system/wasi/socket.cr
+++ b/src/crystal/system/wasi/socket.cr
@@ -33,12 +33,6 @@ module Crystal::System::Socket
     (raise NotImplementedError.new "Crystal::System::Socket#system_accept").as(Int32)
   end
 
-  private def system_send(bytes : Bytes) : Int32
-    evented_send(bytes, "Error sending datagram") do |slice|
-      LibC.send(fd, slice.to_unsafe.as(Void*), slice.size, 0)
-    end
-  end
-
   private def system_send_to(bytes : Bytes, addr : ::Socket::Address)
     raise NotImplementedError.new "Crystal::System::Socket#system_send_to"
   end

--- a/src/crystal/system/win32/socket.cr
+++ b/src/crystal/system/win32/socket.cr
@@ -259,17 +259,6 @@ module Crystal::System::Socket
     wsabuf
   end
 
-  private def system_send(message : Bytes) : Int32
-    wsabuf = wsa_buffer(message)
-
-    bytes = overlapped_write(fd, "WSASend") do |overlapped|
-      ret = LibC.WSASend(fd, pointerof(wsabuf), 1, out bytes_sent, 0, overlapped, nil)
-      {ret, bytes_sent}
-    end
-
-    bytes.to_i32
-  end
-
   private def system_send_to(bytes : Bytes, addr : ::Socket::Address)
     wsabuf = wsa_buffer(bytes)
     bytes_written = overlapped_write(fd, "WSASendTo") do |overlapped|

--- a/src/socket.cr
+++ b/src/socket.cr
@@ -226,7 +226,7 @@ class Socket < IO
   # sock.send(Bytes[0])
   # ```
   def send(message) : Int32
-    system_send(message.to_slice)
+    system_write(message.to_slice)
   end
 
   # Sends a message to the specified remote address.


### PR DESCRIPTION
The intention of this method is equivalent to`#system_write` and the implementations are also identical.
There's no need for this duplication.

This does not affect the public API method `Socket#send` though. It's not identical to `Socket#write` because the latter is buffered and it ensures the entire data is sent.

Ref: https://github.com/crystal-lang/rfcs/pull/7#discussion_r1616381024