### PR TITLE
Add `EventLoop::FileDescriptor` module

### DIFF
--- a/src/crystal/system/event_loop.cr
+++ b/src/crystal/system/event_loop.cr
@@ -45,6 +45,14 @@ abstract class Crystal::EventLoop
   end
 end
 
+require "./event_loop/file_descriptor"
+
+abstract class Crystal::EventLoop
+  # The FileDescriptor interface is always needed, so we include it right in
+  # the main interface.
+  include FileDescriptor
+end
+
 {% if flag?(:wasi) %}
   require "./wasi/event_loop"
 {% elsif flag?(:unix) %}

--- a/src/crystal/system/event_loop/file_descriptor.cr
+++ b/src/crystal/system/event_loop/file_descriptor.cr
@@ -12,7 +12,7 @@ abstract class Crystal::EventLoop
     # Writes at least one byte from *slice* to the file descriptor.
     #
     # Blocks the current fiber if the file descriptor isn't ready for writing,
-    # continuing when it is. Otherwise returns immediately.
+    # continuing when ready. Otherwise returns immediately.
     #
     # Returns the number of bytes written (up to `slice.size`).
     abstract def write(file_descriptor : Crystal::System::FileDescriptor, slice : Bytes) : Int32

--- a/src/crystal/system/event_loop/file_descriptor.cr
+++ b/src/crystal/system/event_loop/file_descriptor.cr
@@ -1,13 +1,20 @@
 abstract class Crystal::EventLoop
   module FileDescriptor
-    # Reads at least one byte from the file descriptor into *slice* and continues
-    # fiber when the read is complete.
-    # Returns the number of bytes read.
+    # Reads at least one byte from the file descriptor into *slice*.
+    #
+    # Blocks the current fiber if no data is available for reading, continuing
+    # when available. Otherwise returns immediately.
+    #
+    # Returns the number of bytes read (up to `slice.size`).
+    # Returns 0 when EOF is reached.
     abstract def read(file_descriptor : Crystal::System::FileDescriptor, slice : Bytes) : Int32
 
-    # Writes at least one byte from *slice* to the file descriptor and continues
-    # fiber when the write is complete.
-    # Returns the number of bytes written.
+    # Writes at least one byte from *slice* to the file descriptor.
+    #
+    # Blocks the current fiber if the file descriptor isn't ready for writing,
+    # continuing when it is. Otherwise returns immediately.
+    #
+    # Returns the number of bytes written (up to `slice.size`).
     abstract def write(file_descriptor : Crystal::System::FileDescriptor, slice : Bytes) : Int32
 
     # Closes the file descriptor resource.

--- a/src/crystal/system/event_loop/file_descriptor.cr
+++ b/src/crystal/system/event_loop/file_descriptor.cr
@@ -1,0 +1,16 @@
+abstract class Crystal::EventLoop
+  module FileDescriptor
+    # Reads at least one byte from the file descriptor into *slice* and continues
+    # fiber when the read is complete.
+    # Returns the number of bytes read.
+    abstract def read(file_descriptor : Crystal::System::FileDescriptor, slice : Bytes) : Int32
+
+    # Writes at least one byte from *slice* to the file descriptor and continues
+    # fiber when the write is complete.
+    # Returns the number of bytes written.
+    abstract def write(file_descriptor : Crystal::System::FileDescriptor, slice : Bytes) : Int32
+
+    # Closes the file descriptor resource.
+    abstract def close(file_descriptor : Crystal::System::FileDescriptor) : Nil
+  end
+end

--- a/src/crystal/system/file_descriptor.cr
+++ b/src/crystal/system/file_descriptor.cr
@@ -14,9 +14,17 @@ module Crystal::System::FileDescriptor
   # cooked mode otherwise.
   # private def system_raw(enable : Bool, & : ->)
 
-  # private def system_read(slice : Bool) : Int32
+  private def system_read(slice : Bytes) : Int32
+    event_loop.read(self, slice)
+  end
 
-  # private def system_write(slice : Bool) : Int32
+  private def system_write(slice : Bytes) : Int32
+    event_loop.write(self, slice)
+  end
+
+  private def event_loop : Crystal::EventLoop::FileDescriptor
+    Crystal::EventLoop.current
+  end
 end
 
 {% if flag?(:wasi) %}

--- a/src/crystal/system/unix/event_loop_libevent.cr
+++ b/src/crystal/system/unix/event_loop_libevent.cr
@@ -75,4 +75,28 @@ class Crystal::LibEvent::EventLoop < Crystal::EventLoop
       end
     end
   end
+
+  def read(file_descriptor : Crystal::System::FileDescriptor, slice : Bytes) : Int32
+    file_descriptor.evented_read("Error reading file_descriptor") do
+      LibC.read(file_descriptor.fd, slice, slice.size).tap do |return_code|
+        if return_code == -1 && Errno.value == Errno::EBADF
+          raise IO::Error.new "File not open for reading", target: file_descriptor
+        end
+      end
+    end
+  end
+
+  def write(file_descriptor : Crystal::System::FileDescriptor, slice : Bytes) : Int32
+    file_descriptor.evented_write("Error writing file_descriptor") do
+      LibC.write(file_descriptor.fd, slice, slice.size).tap do |return_code|
+        if return_code == -1 && Errno.value == Errno::EBADF
+          raise IO::Error.new "File not open for writing", target: file_descriptor
+        end
+      end
+    end
+  end
+
+  def close(file_descriptor : Crystal::System::FileDescriptor) : Nil
+    file_descriptor.evented_close
+  end
 end

--- a/src/crystal/system/wasi/event_loop.cr
+++ b/src/crystal/system/wasi/event_loop.cr
@@ -35,6 +35,30 @@ class Crystal::Wasi::EventLoop < Crystal::EventLoop
   def create_fd_read_event(io : IO::Evented, edge_triggered : Bool = false) : Crystal::EventLoop::Event
     raise NotImplementedError.new("Crystal::Wasi::EventLoop.create_fd_read_event")
   end
+
+  def read(file_descriptor : Crystal::System::FileDescriptor, slice : Bytes) : Int32
+    file_descriptor.evented_read("Error reading file_descriptor") do
+      LibC.read(file_descriptor.fd, slice, slice.size).tap do |return_code|
+        if return_code == -1 && Errno.value == Errno::EBADF
+          raise IO::Error.new "File not open for reading", target: file_descriptor
+        end
+      end
+    end
+  end
+
+  def write(file_descriptor : Crystal::System::FileDescriptor, slice : Bytes) : Int32
+    file_descriptor.evented_write("Error writing file_descriptor") do
+      LibC.write(file_descriptor.fd, slice, slice.size).tap do |return_code|
+        if return_code == -1 && Errno.value == Errno::EBADF
+          raise IO::Error.new "File not open for writing", target: file_descriptor
+        end
+      end
+    end
+  end
+
+  def close(file_descriptor : Crystal::System::FileDescriptor) : Nil
+    file_descriptor.evented_close
+  end
 end
 
 struct Crystal::Wasi::Event


### PR DESCRIPTION
Extracts the system interface for `FileDescriptor` operations on the event loop to a `EventLoop` module.

This implements part of https://github.com/crystal-lang/rfcs/pull/7

Related: #14643 does the same for `Socket`