### PR TITLE
Add `EventLoop::Socket` module

### DIFF
--- a/src/crystal/system/event_loop.cr
+++ b/src/crystal/system/event_loop.cr
@@ -45,6 +45,15 @@ abstract class Crystal::EventLoop
   end
 end
 
+abstract class Crystal::EventLoop
+  # The socket module is empty by default and filled with abstract defs when
+  # crystal/system/socket.cr is required.
+  module Socket
+  end
+
+  include Socket
+end
+
 {% if flag?(:wasi) %}
   require "./wasi/event_loop"
 {% elsif flag?(:unix) %}

--- a/src/crystal/system/event_loop/socket.cr
+++ b/src/crystal/system/event_loop/socket.cr
@@ -10,16 +10,32 @@ abstract class Crystal::EventLoop
     # when available. Otherwise returns immediately.
     #
     # Returns the number of bytes read (up to `slice.size`).
-    # Returns 0 when the socket is closed and not data available.
+    # Returns 0 when the socket is closed and no data available.
     abstract def read(socket : ::Socket, slice : Bytes) : Int32
 
     # Writes at least one byte from *slice* to the socket.
     #
     # Blocks the current fiber if the socket is not ready for writing,
-    # continuing when it is. Otherwise returns immediately.
+    # continuing when ready. Otherwise returns immediately.
     #
     # Returns the number of bytes written (up to `slice.size`).
     abstract def write(socket : ::Socket, slice : Bytes) : Int32
+
+    # Accepts an incoming TCP connection on the socket.
+    #
+    # Blocks the current fiber if no connection is watiting, continuing when one
+    # becomes available. Otherwise returns immediately.
+    #
+    # Returns a handle to the socket for the new connection.
+    abstract def accept(socket : ::Socket) : ::Socket::Handle?
+
+    # Opens a connection on *socket* to the target *address*.
+    #
+    # Blocks the current fiber and continues when the connection is established.
+    #
+    # Returns `IO::Error` in case of en error. The caller is responsible for
+    # raising it as an exception if necessary.
+    abstract def connect(socket : ::Socket, address : ::Socket::Addrinfo | ::Socket::Address, timeout : ::Time::Span?) : IO::Error?
 
     # Closes the socket.
     abstract def close(socket : ::Socket) : Nil

--- a/src/crystal/system/event_loop/socket.cr
+++ b/src/crystal/system/event_loop/socket.cr
@@ -27,7 +27,7 @@ abstract class Crystal::EventLoop
 
     # Accepts an incoming TCP connection on the socket.
     #
-    # Blocks the current fiber if no connection is watiting, continuing when one
+    # Blocks the current fiber if no connection is waiting, continuing when one
     # becomes available. Otherwise returns immediately.
     #
     # Returns a handle to the socket for the new connection.
@@ -37,7 +37,7 @@ abstract class Crystal::EventLoop
     #
     # Blocks the current fiber and continues when the connection is established.
     #
-    # Returns `IO::Error` in case of en error. The caller is responsible for
+    # Returns `IO::Error` in case of an error. The caller is responsible for
     # raising it as an exception if necessary.
     abstract def connect(socket : ::Socket, address : ::Socket::Addrinfo | ::Socket::Address, timeout : ::Time::Span?) : IO::Error?
 
@@ -53,7 +53,7 @@ abstract class Crystal::EventLoop
     # Receives at least one byte from the socket into *slice*, capturing the
     # source address.
     #
-    # Blocks the current fiber if if no data is available for reading, continuing
+    # Blocks the current fiber if no data is available for reading, continuing
     # when available. Otherwise returns immediately.
     #
     # Returns a tuple containing the number of bytes received (up to `slice.size`)

--- a/src/crystal/system/event_loop/socket.cr
+++ b/src/crystal/system/event_loop/socket.cr
@@ -1,0 +1,8 @@
+# This file is only required when sockets are used (`require "./event_loop/socket"` in `src/crystal/system/socket.cr`)
+#
+# It fills `Crystal::EventLoop::Socket` with abstract defs.
+
+abstract class Crystal::EventLoop
+  module Socket
+  end
+end

--- a/src/crystal/system/event_loop/socket.cr
+++ b/src/crystal/system/event_loop/socket.cr
@@ -4,5 +4,24 @@
 
 abstract class Crystal::EventLoop
   module Socket
+    # Reads at least one byte from the socket into *slice*.
+    #
+    # Blocks the current fiber if no data is available for reading, continuing
+    # when available. Otherwise returns immediately.
+    #
+    # Returns the number of bytes read (up to `slice.size`).
+    # Returns 0 when the socket is closed and not data available.
+    abstract def read(socket : ::Socket, slice : Bytes) : Int32
+
+    # Writes at least one byte from *slice* to the socket.
+    #
+    # Blocks the current fiber if the socket is not ready for writing,
+    # continuing when it is. Otherwise returns immediately.
+    #
+    # Returns the number of bytes written (up to `slice.size`).
+    abstract def write(socket : ::Socket, slice : Bytes) : Int32
+
+    # Closes the socket.
+    abstract def close(socket : ::Socket) : Nil
   end
 end

--- a/src/crystal/system/event_loop/socket.cr
+++ b/src/crystal/system/event_loop/socket.cr
@@ -11,6 +11,8 @@ abstract class Crystal::EventLoop
     #
     # Returns the number of bytes read (up to `slice.size`).
     # Returns 0 when the socket is closed and no data available.
+    #
+    # Use `#send_to` for sending a message to a specific target address.
     abstract def read(socket : ::Socket, slice : Bytes) : Int32
 
     # Writes at least one byte from *slice* to the socket.
@@ -19,6 +21,8 @@ abstract class Crystal::EventLoop
     # continuing when ready. Otherwise returns immediately.
     #
     # Returns the number of bytes written (up to `slice.size`).
+    #
+    # Use `#receive_from` for capturing the source address of a message.
     abstract def write(socket : ::Socket, slice : Bytes) : Int32
 
     # Accepts an incoming TCP connection on the socket.
@@ -36,6 +40,25 @@ abstract class Crystal::EventLoop
     # Returns `IO::Error` in case of en error. The caller is responsible for
     # raising it as an exception if necessary.
     abstract def connect(socket : ::Socket, address : ::Socket::Addrinfo | ::Socket::Address, timeout : ::Time::Span?) : IO::Error?
+
+    # Sends at least one byte from *slice* to the socket with a target address
+    # *address*.
+    #
+    # Blocks the current fiber if the socket is not ready for writing,
+    # continuing when ready. Otherwise returns immediately.
+    #
+    # Returns the number of bytes sent (up to `slice.size`).
+    abstract def send_to(socket : ::Socket, slice : Bytes, address : ::Socket::Address) : Int32
+
+    # Receives at least one byte from the socket into *slice*, capturing the
+    # source address.
+    #
+    # Blocks the current fiber if if no data is available for reading, continuing
+    # when available. Otherwise returns immediately.
+    #
+    # Returns a tuple containing the number of bytes received (up to `slice.size`)
+    # and the source address.
+    abstract def receive_from(socket : ::Socket, slice : Bytes) : Tuple(Int32, ::Socket::Address)
 
     # Closes the socket.
     abstract def close(socket : ::Socket) : Nil

--- a/src/crystal/system/socket.cr
+++ b/src/crystal/system/socket.cr
@@ -21,9 +21,13 @@ module Crystal::System::Socket
     event_loop.accept(self)
   end
 
-  # private def system_send_to(bytes : Bytes, addr : ::Socket::Address)
+  private def system_send_to(bytes : Bytes, addr : ::Socket::Address)
+    event_loop.send_to(self, bytes, addr)
+  end
 
-  # private def system_receive(bytes)
+  private def system_receive_from(bytes : Bytes) : Tuple(Int32, ::Socket::Address)
+    event_loop.receive_from(self, bytes)
+  end
 
   # private def system_close_read
 

--- a/src/crystal/system/socket.cr
+++ b/src/crystal/system/socket.cr
@@ -7,7 +7,9 @@ module Crystal::System::Socket
   # Initializes a file descriptor / socket handle for use with Crystal Socket
   # private def initialize_handle(fd)
 
-  # private def system_connect(addr, timeout = nil)
+  private def system_connect(addr, timeout = nil)
+    event_loop.connect(self, addr, timeout)
+  end
 
   # Tries to bind the socket to a local address.
   # Yields an `Socket::BindError` if the binding failed.
@@ -15,7 +17,9 @@ module Crystal::System::Socket
 
   # private def system_listen(backlog)
 
-  # private def system_accept
+  private def system_accept
+    event_loop.accept(self)
+  end
 
   # private def system_send_to(bytes : Bytes, addr : ::Socket::Address)
 

--- a/src/crystal/system/socket.cr
+++ b/src/crystal/system/socket.cr
@@ -71,11 +71,19 @@ module Crystal::System::Socket
 
   # def self.fcntl(fd, cmd, arg = 0)
 
-  # private def system_read(slice : Bytes) : Int32
+  private def system_read(slice : Bytes) : Int32
+    event_loop.read(self, slice)
+  end
 
-  # private def system_write(slice : Bytes) : Int32
+  private def system_write(slice : Bytes) : Int32
+    event_loop.write(self, slice)
+  end
 
   # private def system_close
+
+  private def event_loop : Crystal::EventLoop::Socket
+    Crystal::EventLoop.current
+  end
 
   # IPSocket:
 

--- a/src/crystal/system/socket.cr
+++ b/src/crystal/system/socket.cr
@@ -1,3 +1,5 @@
+require "./event_loop/socket"
+
 module Crystal::System::Socket
   # Creates a file descriptor / socket handle
   # private def create_handle(family, type, protocol, blocking) : Handle

--- a/src/crystal/system/unix/event_loop_libevent.cr
+++ b/src/crystal/system/unix/event_loop_libevent.cr
@@ -75,4 +75,20 @@ class Crystal::LibEvent::EventLoop < Crystal::EventLoop
       end
     end
   end
+
+  def read(socket : ::Socket, slice : Bytes) : Int32
+    socket.evented_read("Error reading socket") do
+      LibC.recv(socket.fd, slice, slice.size, 0).to_i32
+    end
+  end
+
+  def write(socket : ::Socket, slice : Bytes) : Int32
+    socket.evented_write("Error writing to socket") do
+      LibC.send(socket.fd, slice, slice.size, 0).to_i32
+    end
+  end
+
+  def close(socket : ::Socket) : Nil
+    socket.evented_close
+  end
 end

--- a/src/crystal/system/unix/socket.cr
+++ b/src/crystal/system/unix/socket.cr
@@ -248,23 +248,11 @@ module Crystal::System::Socket
     LibC.isatty(fd) == 1
   end
 
-  private def system_read(slice : Bytes) : Int32
-    evented_read("Error reading socket") do
-      LibC.recv(fd, slice, slice.size, 0).to_i32
-    end
-  end
-
-  private def system_write(slice : Bytes) : Int32
-    evented_write("Error writing to socket") do
-      LibC.send(fd, slice, slice.size, 0)
-    end
-  end
-
   private def system_close
     # Perform libevent cleanup before LibC.close.
     # Using a file descriptor after it has been closed is never defined and can
     # always lead to undefined results. This is not specific to libevent.
-    evented_close
+    event_loop.close(self)
 
     # Clear the @volatile_fd before actually closing it in order to
     # reduce the chance of reading an outdated fd value

--- a/src/crystal/system/wasi/event_loop.cr
+++ b/src/crystal/system/wasi/event_loop.cr
@@ -35,6 +35,22 @@ class Crystal::Wasi::EventLoop < Crystal::EventLoop
   def create_fd_read_event(io : IO::Evented, edge_triggered : Bool = false) : Crystal::EventLoop::Event
     raise NotImplementedError.new("Crystal::Wasi::EventLoop.create_fd_read_event")
   end
+
+  def read(socket : ::Socket, slice : Bytes) : Int32
+    socket.evented_read("Error reading socket") do
+      LibC.recv(socket.fd, slice, slice.size, 0).to_i32
+    end
+  end
+
+  def write(socket : ::Socket, slice : Bytes) : Int32
+    socket.evented_write("Error writing to socket") do
+      LibC.send(socket.fd, slice, slice.size, 0)
+    end
+  end
+
+  def close(socket : ::Socket) : Nil
+    socket.evented_close
+  end
 end
 
 struct Crystal::Wasi::Event

--- a/src/crystal/system/wasi/event_loop.cr
+++ b/src/crystal/system/wasi/event_loop.cr
@@ -48,6 +48,14 @@ class Crystal::Wasi::EventLoop < Crystal::EventLoop
     end
   end
 
+  def connect(socket : ::Socket, address : ::Socket::Addrinfo | ::Socket::Address, timeout : ::Time::Span | ::Nil) : IO::Error?
+    raise NotImplementedError.new "Crystal::Wasi::EventLoop#connect"
+  end
+
+  def accept(socket : ::Socket) : ::Socket::Handle?
+    raise NotImplementedError.new "Crystal::Wasi::EventLoop#accept"
+  end
+
   def close(socket : ::Socket) : Nil
     socket.evented_close
   end

--- a/src/crystal/system/wasi/event_loop.cr
+++ b/src/crystal/system/wasi/event_loop.cr
@@ -48,6 +48,14 @@ class Crystal::Wasi::EventLoop < Crystal::EventLoop
     end
   end
 
+  def receive_from(socket : ::Socket, slice : Bytes) : Tuple(Int32, ::Socket::Address)
+    raise NotImplementedError.new "Crystal::Wasi::EventLoop#receive_from"
+  end
+
+  def send_to(socket : ::Socket, slice : Bytes, addr : ::Socket::Address) : Int32
+    raise NotImplementedError.new "Crystal::Wasi::EventLoop#send_to"
+  end
+
   def connect(socket : ::Socket, address : ::Socket::Addrinfo | ::Socket::Address, timeout : ::Time::Span | ::Nil) : IO::Error?
     raise NotImplementedError.new "Crystal::Wasi::EventLoop#connect"
   end

--- a/src/crystal/system/wasi/socket.cr
+++ b/src/crystal/system/wasi/socket.cr
@@ -25,14 +25,6 @@ module Crystal::System::Socket
     raise NotImplementedError.new "Crystal::System::Socket#system_listen"
   end
 
-  private def system_send_to(bytes : Bytes, addr : ::Socket::Address)
-    raise NotImplementedError.new "Crystal::System::Socket#system_send_to"
-  end
-
-  private def system_receive(bytes)
-    raise NotImplementedError.new "Crystal::System::Socket#system_receive"
-  end
-
   private def system_close_read
     if LibC.shutdown(fd, LibC::SHUT_RD) != 0
       raise ::Socket::Error.from_errno("shutdown read")

--- a/src/crystal/system/wasi/socket.cr
+++ b/src/crystal/system/wasi/socket.cr
@@ -15,10 +15,6 @@ module Crystal::System::Socket
   private def initialize_handle(fd)
   end
 
-  private def system_connect(addr, timeout = nil)
-    raise NotImplementedError.new "Crystal::System::Socket#system_connect"
-  end
-
   # Tries to bind the socket to a local address.
   # Yields an `Socket::BindError` if the binding failed.
   private def system_bind(addr, addrstr, &)
@@ -27,10 +23,6 @@ module Crystal::System::Socket
 
   private def system_listen(backlog, &)
     raise NotImplementedError.new "Crystal::System::Socket#system_listen"
-  end
-
-  private def system_accept
-    (raise NotImplementedError.new "Crystal::System::Socket#system_accept").as(Int32)
   end
 
   private def system_send_to(bytes : Bytes, addr : ::Socket::Address)

--- a/src/crystal/system/wasi/socket.cr
+++ b/src/crystal/system/wasi/socket.cr
@@ -155,23 +155,11 @@ module Crystal::System::Socket
     LibC.isatty(fd) == 1
   end
 
-  private def system_read(slice : Bytes) : Int32
-    evented_read("Error reading socket") do
-      LibC.recv(fd, slice, slice.size, 0).to_i32
-    end
-  end
-
-  private def system_write(slice : Bytes) : Int32
-    evented_write("Error writing to socket") do
-      LibC.send(fd, slice, slice.size, 0)
-    end
-  end
-
   private def system_close
     # Perform libevent cleanup before LibC.close.
     # Using a file descriptor after it has been closed is never defined and can
     # always lead to undefined results. This is not specific to libevent.
-    evented_close
+    event_loop.close(self)
 
     # Clear the @volatile_fd before actually closing it in order to
     # reduce the chance of reading an outdated fd value

--- a/src/crystal/system/win32/socket.cr
+++ b/src/crystal/system/win32/socket.cr
@@ -227,13 +227,6 @@ module Crystal::System::Socket
     end
   end
 
-  private def wsa_buffer(bytes)
-    wsabuf = LibC::WSABUF.new
-    wsabuf.len = bytes.size
-    wsabuf.buf = bytes.to_unsafe
-    wsabuf
-  end
-
   private def system_close_read
     if LibC.shutdown(fd, LibC::SH_RECEIVE) != 0
       raise ::Socket::Error.from_wsa_error("shutdown read")
@@ -376,18 +369,6 @@ module Crystal::System::Socket
 
   private def system_tty?
     LibC.GetConsoleMode(LibC::HANDLE.new(fd), out _) != 0
-  end
-
-  private def overlapped_write(socket, method, &)
-    wsa_overlapped_operation(socket, method, write_timeout) do |operation|
-      yield operation
-    end
-  end
-
-  private def overlapped_read(socket, method, *, connreset_is_error = true, &)
-    wsa_overlapped_operation(socket, method, read_timeout, connreset_is_error) do |operation|
-      yield operation
-    end
   end
 
   def system_close

--- a/src/crystal/system/win32/socket.cr
+++ b/src/crystal/system/win32/socket.cr
@@ -434,29 +434,6 @@ module Crystal::System::Socket
     LibC.GetConsoleMode(LibC::HANDLE.new(fd), out _) != 0
   end
 
-  private def system_read(slice : Bytes) : Int32
-    wsabuf = wsa_buffer(slice)
-
-    bytes_read = overlapped_read(fd, "WSARecv", connreset_is_error: false) do |overlapped|
-      flags = 0_u32
-      ret = LibC.WSARecv(fd, pointerof(wsabuf), 1, out bytes_received, pointerof(flags), overlapped, nil)
-      {ret, bytes_received}
-    end
-
-    bytes_read.to_i32
-  end
-
-  private def system_write(slice : Bytes) : Int32
-    wsabuf = wsa_buffer(slice)
-
-    bytes = overlapped_write(fd, "WSASend") do |overlapped|
-      ret = LibC.WSASend(fd, pointerof(wsabuf), 1, out bytes_sent, 0, overlapped, nil)
-      {ret, bytes_sent}
-    end
-
-    bytes.to_i32
-  end
-
   private def overlapped_write(socket, method, &)
     wsa_overlapped_operation(socket, method, write_timeout) do |operation|
       yield operation

--- a/src/io/evented.cr
+++ b/src/io/evented.cr
@@ -49,6 +49,15 @@ module IO::Evented
     end
   end
 
+  def evented_send(errno_msg : String, &) : Int32
+    bytes_written = yield
+    raise Socket::Error.from_errno(errno_msg) if bytes_written == -1
+    # `to_i32` is acceptable because `Slice#size` is an Int32
+    bytes_written.to_i32
+  ensure
+    resume_pending_writers
+  end
+
   # :nodoc:
   def resume_read(timed_out = false) : Nil
     @read_timed_out = timed_out
@@ -115,6 +124,10 @@ module IO::Evented
   private def add_write_event(timeout = @write_timeout) : Nil
     event = @write_event.get { Crystal::EventLoop.current.create_fd_write_event(self) }
     event.add timeout
+  end
+
+  def evented_reopen : Nil
+    evented_close
   end
 
   def evented_close : Nil

--- a/src/io/evented.cr
+++ b/src/io/evented.cr
@@ -49,15 +49,6 @@ module IO::Evented
     end
   end
 
-  def evented_send(errno_msg : String, &) : Int32
-    bytes_written = yield
-    raise Socket::Error.from_errno(errno_msg) if bytes_written == -1
-    # `to_i32` is acceptable because `Slice#size` is an Int32
-    bytes_written.to_i32
-  ensure
-    resume_pending_writers
-  end
-
   # :nodoc:
   def resume_read(timed_out = false) : Nil
     @read_timed_out = timed_out
@@ -124,10 +115,6 @@ module IO::Evented
   private def add_write_event(timeout = @write_timeout) : Nil
     event = @write_event.get { Crystal::EventLoop.current.create_fd_write_event(self) }
     event.add timeout
-  end
-
-  def evented_reopen : Nil
-    evented_close
   end
 
   def evented_close : Nil

--- a/src/socket.cr
+++ b/src/socket.cr
@@ -256,7 +256,7 @@ class Socket < IO
   def receive(max_message_size = 512) : {String, Address}
     address = nil
     message = String.new(max_message_size) do |buffer|
-      bytes_read, address = system_receive(Slice.new(buffer, max_message_size))
+      bytes_read, address = system_receive_from(Slice.new(buffer, max_message_size))
       {bytes_read, 0}
     end
     {message, address.as(Address)}
@@ -274,7 +274,7 @@ class Socket < IO
   # bytes_read, client_addr = server.receive(message)
   # ```
   def receive(message : Bytes) : {Int32, Address}
-    system_receive(message)
+    system_receive_from(message)
   end
 
   # Calls `shutdown(2)` with `SHUT_RD`

--- a/src/socket/udp_socket.cr
+++ b/src/socket/udp_socket.cr
@@ -70,7 +70,7 @@ class UDPSocket < IPSocket
   def receive(max_message_size = 512) : {String, IPAddress}
     address = nil
     message = String.new(max_message_size) do |buffer|
-      bytes_read, address = system_receive(Slice.new(buffer, max_message_size))
+      bytes_read, address = system_receive_from(Slice.new(buffer, max_message_size))
       {bytes_read, 0}
     end
     {message, address.as(IPAddress)}
@@ -88,7 +88,7 @@ class UDPSocket < IPSocket
   # bytes_read, client_addr = server.receive(message)
   # ```
   def receive(message : Bytes) : {Int32, IPAddress}
-    bytes_read, address = system_receive(message)
+    bytes_read, address = system_receive_from(message)
     {bytes_read, address.as(IPAddress)}
   end
 


### PR DESCRIPTION
Extracts the system interface for `Socket` operations on the event loop to a `EventLoop` module.

This implements part of https://github.com/crystal-lang/rfcs/pull/7

Related: #14639 does the same for `FileDescriptor`