### PR TITLE
Decode URI component for search functionality in docs

### DIFF
--- a/src/compiler/crystal/tools/doc/html/js/doc.js
+++ b/src/compiler/crystal/tools/doc/html/js/doc.js
@@ -99,7 +99,7 @@ document.addEventListener('DOMContentLoaded', function() {
     // TODO: Add OpenSearch description
     var searchQuery = location.hash.substring(3);
     history.pushState({searchQuery: searchQuery}, "Search for " + searchQuery, location.href.replace(/#q=.*/, ""));
-    searchInput.value = searchQuery;
+    searchInput.value = decodeURIComponent(searchQuery);
     document.addEventListener('CrystalDocs:loaded', performSearch);
   }
 


### PR DESCRIPTION
Before:
<img width="720" alt="image" src="https://github.com/crystal-lang/crystal/assets/32797552/31c9fa5c-ee56-4c3a-9e0b-cfcab65267d9">

After:
<img width="834" alt="image" src="https://github.com/crystal-lang/crystal/assets/32797552/ede72452-5323-4705-92eb-07a9d9656f0a">
