### PR TITLE
Update distribution-scripts

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,7 +8,7 @@ parameters:
   distribution-scripts-version:
     description: "Git ref for version of https://github.com/crystal-lang/distribution-scripts/"
     type: string
-    default: "a9e0c6c12987b8b01b17e71c38f489e45937e1bf"
+    default: "23f1c53342fddef61600890ee5db1743968894af"
   previous_crystal_base_url:
     description: "Prefix for URLs to Crystal bootstrap compiler"
     type: string

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,7 +8,7 @@ parameters:
   distribution-scripts-version:
     description: "Git ref for version of https://github.com/crystal-lang/distribution-scripts/"
     type: string
-    default: "23f1c53342fddef61600890ee5db1743968894af"
+    default: "7a013f14ed64e7e569b5e453eab02af63cf62b61"
   previous_crystal_base_url:
     description: "Prefix for URLs to Crystal bootstrap compiler"
     type: string


### PR DESCRIPTION
Updates `distribution-scripts` dependency to https://github.com/crystal-lang/distribution-scripts/commit/23f1c53342fddef61600890ee5db1743968894af

This includes the following changes:

* crystal-lang/distribution-scripts#311
* crystal-lang/distribution-scripts#310
* crystal-lang/distribution-scripts#309
* crystal-lang/distribution-scripts#307
* crystal-lang/distribution-scripts#306
* crystal-lang/distribution-scripts#305
