### PR TITLE
Darwin: Only set FD_CLOEXEC when creating a socket FD

### DIFF
--- a/src/crystal/system/unix/socket.cr
+++ b/src/crystal/system/unix/socket.cr
@@ -15,15 +15,15 @@ module Crystal::System::Socket
     {% end %}
     fd = LibC.socket(family, type, protocol)
     raise ::Socket::Error.from_errno("Failed to create socket") if fd == -1
+    {% unless LibC.has_constant?(:SOCK_CLOEXEC) %}
+      # Forces opened sockets to be closed on `exec(2)`. Only for platforms that don't
+      # support `SOCK_CLOEXEC` (e.g., Darwin).
+      fcntl(fd, LibC::F_SETFD, LibC::FD_CLOEXEC)
+    {% end %}
     fd
   end
 
   private def initialize_handle(fd)
-    {% unless LibC.has_constant?(:SOCK_CLOEXEC) %}
-      # Forces opened sockets to be closed on `exec(2)`. Only for platforms that don't
-      # support `SOCK_CLOEXEC` (e.g., Darwin).
-      LibC.fcntl(fd, LibC::F_SETFD, LibC::FD_CLOEXEC)
-    {% end %}
   end
 
   private def system_connect(addr, timeout = nil)

--- a/src/crystal/system/unix/socket.cr
+++ b/src/crystal/system/unix/socket.cr
@@ -18,7 +18,8 @@ module Crystal::System::Socket
     {% unless LibC.has_constant?(:SOCK_CLOEXEC) %}
       # Forces opened sockets to be closed on `exec(2)`. Only for platforms that don't
       # support `SOCK_CLOEXEC` (e.g., Darwin).
-      fcntl(LibC::F_SETFD, LibC::FD_CLOEXEC)
+      r = LibC.fcntl(fd, LibC::F_SETFD, LibC::FD_CLOEXEC)
+      raise ::Socket::Error.from_errno("fcntl() failed") if r == -1
     {% end %}
     fd
   end

--- a/src/crystal/system/unix/socket.cr
+++ b/src/crystal/system/unix/socket.cr
@@ -18,7 +18,7 @@ module Crystal::System::Socket
     {% unless LibC.has_constant?(:SOCK_CLOEXEC) %}
       # Forces opened sockets to be closed on `exec(2)`. Only for platforms that don't
       # support `SOCK_CLOEXEC` (e.g., Darwin).
-      fcntl(fd, LibC::F_SETFD, LibC::FD_CLOEXEC)
+      fcntl(LibC::F_SETFD, LibC::FD_CLOEXEC)
     {% end %}
     fd
   end

--- a/src/crystal/system/unix/socket.cr
+++ b/src/crystal/system/unix/socket.cr
@@ -18,8 +18,8 @@ module Crystal::System::Socket
     {% unless LibC.has_constant?(:SOCK_CLOEXEC) %}
       # Forces opened sockets to be closed on `exec(2)`. Only for platforms that don't
       # support `SOCK_CLOEXEC` (e.g., Darwin).
-      r = LibC.fcntl(fd, LibC::F_SETFD, LibC::FD_CLOEXEC)
-      raise ::Socket::Error.from_errno("fcntl() failed") if r == -1
+      ret = LibC.fcntl(fd, LibC::F_SETFD, LibC::FD_CLOEXEC)
+      raise ::Socket::Error.from_errno("fcntl() failed") if ret == -1
     {% end %}
     fd
   end


### PR DESCRIPTION
Not when an existing FD is passed to Socket.new