### PR TITLE
Add flags missing from termios

### DIFF
--- a/src/lib_c/aarch64-linux-gnu/c/termios.cr
+++ b/src/lib_c/aarch64-linux-gnu/c/termios.cr
@@ -7,6 +7,13 @@ lib LibC
   VINTR     =        0
   VKILL     =        3
   VMIN      =        6
+  VSWTC     =        7
+  VREPRINT  =       12
+  VDISCARD  =       13
+  VWERASE   =       14
+  VLNEXT    =       15
+  VEOL2     =       16
+  VTIME     =        5
   VQUIT     =        1
   VSTART    =        8
   VSTOP     =        9

--- a/src/lib_c/aarch64-linux-musl/c/termios.cr
+++ b/src/lib_c/aarch64-linux-musl/c/termios.cr
@@ -7,6 +7,13 @@ lib LibC
   VINTR     =        0
   VKILL     =        3
   VMIN      =        6
+  VSWTC     =        7
+  VREPRINT  =       12
+  VDISCARD  =       13
+  VWERASE   =       14
+  VLNEXT    =       15
+  VEOL2     =       16
+  VTIME     =        5
   VQUIT     =        1
   VSTART    =        8
   VSTOP     =        9

--- a/src/lib_c/arm-linux-gnueabihf/c/termios.cr
+++ b/src/lib_c/arm-linux-gnueabihf/c/termios.cr
@@ -7,6 +7,13 @@ lib LibC
   VINTR     =        0
   VKILL     =        3
   VMIN      =        6
+  VSWTC     =        7
+  VREPRINT  =       12
+  VDISCARD  =       13
+  VWERASE   =       14
+  VLNEXT    =       15
+  VEOL2     =       16
+  VTIME     =        5
   VQUIT     =        1
   VSTART    =        8
   VSTOP     =        9

--- a/src/lib_c/i386-linux-gnu/c/termios.cr
+++ b/src/lib_c/i386-linux-gnu/c/termios.cr
@@ -7,6 +7,13 @@ lib LibC
   VINTR     =        0
   VKILL     =        3
   VMIN      =        6
+  VSWTC     =        7
+  VREPRINT  =       12
+  VDISCARD  =       13
+  VWERASE   =       14
+  VLNEXT    =       15
+  VEOL2     =       16
+  VTIME     =        5
   VQUIT     =        1
   VSTART    =        8
   VSTOP     =        9

--- a/src/lib_c/i386-linux-musl/c/termios.cr
+++ b/src/lib_c/i386-linux-musl/c/termios.cr
@@ -7,6 +7,13 @@ lib LibC
   VINTR     =        0
   VKILL     =        3
   VMIN      =        6
+  VSWTC     =        7
+  VREPRINT  =       12
+  VDISCARD  =       13
+  VWERASE   =       14
+  VLNEXT    =       15
+  VEOL2     =       16
+  VTIME     =        5
   VQUIT     =        1
   VSTART    =        8
   VSTOP     =        9

--- a/src/lib_c/x86_64-linux-gnu/c/termios.cr
+++ b/src/lib_c/x86_64-linux-gnu/c/termios.cr
@@ -7,6 +7,13 @@ lib LibC
   VINTR     =        0
   VKILL     =        3
   VMIN      =        6
+  VSWTC     =        7
+  VREPRINT  =       12
+  VDISCARD  =       13
+  VWERASE   =       14
+  VLNEXT    =       15
+  VEOL2     =       16
+  VTIME     =        5
   VQUIT     =        1
   VSTART    =        8
   VSTOP     =        9

--- a/src/lib_c/x86_64-linux-musl/c/termios.cr
+++ b/src/lib_c/x86_64-linux-musl/c/termios.cr
@@ -7,6 +7,13 @@ lib LibC
   VINTR     =        0
   VKILL     =        3
   VMIN      =        6
+  VSWTC     =        7
+  VREPRINT  =       12
+  VDISCARD  =       13
+  VWERASE   =       14
+  VLNEXT    =       15
+  VEOL2     =       16
+  VTIME     =        5
   VQUIT     =        1
   VSTART    =        8
   VSTOP     =        9


### PR DESCRIPTION
Adding flags from c_cc characters section. Refer to https://sites.uclouvain.be/SystInfo/usr/include/bits/termios.h.html