### PR TITLE
OpenSSL: don't change default cipher suites

### DIFF
--- a/src/openssl/ssl/context.cr
+++ b/src/openssl/ssl/context.cr
@@ -40,8 +40,6 @@ abstract class OpenSSL::SSL::Context
     # context = OpenSSL::SSL::Context::Client.new
     # context.add_options(OpenSSL::SSL::Options::NO_SSL_V2 | OpenSSL::SSL::Options::NO_SSL_V3)
     # ```
-    #
-    # It uses `CIPHERS_OLD` compatibility level by default.
     def initialize(method : LibSSL::SSLMethod = Context.default_method)
       super(method)
 
@@ -49,8 +47,6 @@ abstract class OpenSSL::SSL::Context
       {% if LibSSL.has_method?(:x509_verify_param_lookup) %}
         self.default_verify_param = "ssl_server"
       {% end %}
-
-      self.ciphers = CIPHERS_OLD
     end
 
     # Returns a new TLS client context with only the given method set.
@@ -128,8 +124,6 @@ abstract class OpenSSL::SSL::Context
     # context = OpenSSL::SSL::Context::Server.new
     # context.add_options(OpenSSL::SSL::Options::NO_SSL_V2 | OpenSSL::SSL::Options::NO_SSL_V3)
     # ```
-    #
-    # It uses `CIPHERS_INTERMEDIATE` compatibility level by default.
     def initialize(method : LibSSL::SSLMethod = Context.default_method)
       super(method)
 
@@ -138,8 +132,6 @@ abstract class OpenSSL::SSL::Context
       {% end %}
 
       set_tmp_ecdh_key(curve: LibCrypto::NID_X9_62_prime256v1)
-
-      self.ciphers = CIPHERS_INTERMEDIATE
     end
 
     # Returns a new TLS server context with only the given method set.


### PR DESCRIPTION
See the below pull request & issue for details (and experimental research). Basically: enforcing a hardcoded string is a bad practice, as the constant will only change with future releases crystal (delaying a security fix to upgrading your application to the latest crystal release or latest master branch) + it will override an otherwise securely configured system (oops).

Note: in practice it won't change much, because the list of ciphers wasn't changed for TLS v1.2 and below starting from OpenSSL 1.1+ (see #14657).

closes #13686
closes #13727

**NOTE**: we might want to reconsider https://github.com/crystal-lang/crystal/pull/13695 —or not: let the system configuration dictate the behavior.