### PR TITLE
OpenSSL: don't set default ECDH curve

### DIFF
--- a/src/openssl/ssl/context.cr
+++ b/src/openssl/ssl/context.cr
@@ -130,8 +130,6 @@ abstract class OpenSSL::SSL::Context
       {% if LibSSL.has_method?(:x509_verify_param_lookup) %}
         self.default_verify_param = "ssl_client"
       {% end %}
-
-      set_tmp_ecdh_key(curve: LibCrypto::NID_X9_62_prime256v1)
     end
 
     # Returns a new TLS server context with only the given method set.


### PR DESCRIPTION
Disables the ECDH curve configuration that was limiting the curve selection to insecure curves.

Before (sslscan, openssl 1.1.1f, ubuntu 20.04):

```
  Server Key Exchange Group(s):
TLSv1.3  128 bits  secp256r1 (NIST P-256)
TLSv1.2  128 bits  secp256r1 (NIST P-256)
```

After (sslscan, openssl 1.1.1f, ubuntu 20.04):

```
  Server Key Exchange Group(s):
TLSv1.3  128 bits  secp256r1 (NIST P-256)
TLSv1.3  192 bits  secp384r1 (NIST P-384)
TLSv1.3  260 bits  secp521r1 (NIST P-521)
TLSv1.3  128 bits  x25519
TLSv1.3  224 bits  x448
TLSv1.2  128 bits  secp256r1 (NIST P-256)
TLSv1.2  192 bits  secp384r1 (NIST P-384)
TLSv1.2  260 bits  secp521r1 (NIST P-521)
TLSv1.2  128 bits  x25519
TLSv1.2  224 bits  x448
```

Also, ciphers now use Curve 25519 by default instead of Curve P-256

follow up to #14655
closes #9060