### PR TITLE
Fix abstract def parameter name in `LibEvent::EventLoop#send_to`

### DIFF
--- a/src/crystal/system/unix/event_loop_libevent.cr
+++ b/src/crystal/system/unix/event_loop_libevent.cr
@@ -104,9 +104,9 @@ class Crystal::LibEvent::EventLoop < Crystal::EventLoop
     {bytes_read, ::Socket::Address.from(sockaddr, addrlen)}
   end
 
-  def send_to(socket : ::Socket, slice : Bytes, addr : ::Socket::Address) : Int32
-    bytes_sent = LibC.sendto(socket.fd, slice.to_unsafe.as(Void*), slice.size, 0, addr, addr.size)
-    raise ::Socket::Error.from_errno("Error sending datagram to #{addr}") if bytes_sent == -1
+  def send_to(socket : ::Socket, slice : Bytes, address : ::Socket::Address) : Int32
+    bytes_sent = LibC.sendto(socket.fd, slice.to_unsafe.as(Void*), slice.size, 0, address, address.size)
+    raise ::Socket::Error.from_errno("Error sending datagram to #{address}") if bytes_sent == -1
     # to_i32 is fine because string/slice sizes are an Int32
     bytes_sent.to_i32
   end

--- a/src/crystal/system/wasi/event_loop.cr
+++ b/src/crystal/system/wasi/event_loop.cr
@@ -52,7 +52,7 @@ class Crystal::Wasi::EventLoop < Crystal::EventLoop
     raise NotImplementedError.new "Crystal::Wasi::EventLoop#receive_from"
   end
 
-  def send_to(socket : ::Socket, slice : Bytes, addr : ::Socket::Address) : Int32
+  def send_to(socket : ::Socket, slice : Bytes, address : ::Socket::Address) : Int32
     raise NotImplementedError.new "Crystal::Wasi::EventLoop#send_to"
   end
 

--- a/src/crystal/system/win32/event_loop_iocp.cr
+++ b/src/crystal/system/win32/event_loop_iocp.cr
@@ -179,10 +179,10 @@ class Crystal::Iocp::EventLoop < Crystal::EventLoop
     bytes.to_i32
   end
 
-  def send_to(socket : ::Socket, bytes : Bytes, addr : ::Socket::Address) : Int32
+  def send_to(socket : ::Socket, bytes : Bytes, address : ::Socket::Address) : Int32
     wsabuf = wsa_buffer(bytes)
     bytes_written = socket.wsa_overlapped_operation(socket.fd, "WSASendTo", socket.write_timeout) do |overlapped|
-      ret = LibC.WSASendTo(socket.fd, pointerof(wsabuf), 1, out bytes_sent, 0, addr, addr.size, overlapped, nil)
+      ret = LibC.WSASendTo(socket.fd, pointerof(wsabuf), 1, out bytes_sent, 0, address, address.size, overlapped, nil)
       {ret, bytes_sent}
     end
     raise ::Socket::Error.from_wsa_error("Error sending datagram to #{addr}") if bytes_written == -1

--- a/src/crystal/system/win32/event_loop_iocp.cr
+++ b/src/crystal/system/win32/event_loop_iocp.cr
@@ -179,13 +179,13 @@ class Crystal::Iocp::EventLoop < Crystal::EventLoop
     bytes.to_i32
   end
 
-  def send_to(socket : ::Socket, bytes : Bytes, address : ::Socket::Address) : Int32
-    wsabuf = wsa_buffer(bytes)
+  def send_to(socket : ::Socket, slice : Bytes, address : ::Socket::Address) : Int32
+    wsabuf = wsa_buffer(slice)
     bytes_written = socket.wsa_overlapped_operation(socket.fd, "WSASendTo", socket.write_timeout) do |overlapped|
       ret = LibC.WSASendTo(socket.fd, pointerof(wsabuf), 1, out bytes_sent, 0, address, address.size, overlapped, nil)
       {ret, bytes_sent}
     end
-    raise ::Socket::Error.from_wsa_error("Error sending datagram to #{addr}") if bytes_written == -1
+    raise ::Socket::Error.from_wsa_error("Error sending datagram to #{address}") if bytes_written == -1
 
     # to_i32 is fine because string/slice sizes are an Int32
     bytes_written.to_i32


### PR DESCRIPTION
Fixup for #14643