### PR TITLE
Add Crystal::System::Thread.current_thread? + Thread#scheduler?

### DIFF
--- a/src/crystal/system/thread.cr
+++ b/src/crystal/system/thread.cr
@@ -10,6 +10,8 @@ module Crystal::System::Thread
 
   # def self.current_thread : ::Thread
 
+  # def self.current_thread? : ::Thread?
+
   # def self.current_thread=(thread : ::Thread)
 
   # private def system_join : Exception?
@@ -102,6 +104,11 @@ class Thread
     Crystal::System::Thread.current_thread
   end
 
+  # :nodoc:
+  def self.current? : Thread?
+    Crystal::System::Thread.current_thread?
+  end
+
   # Associates the Thread object to the running system thread.
   protected def self.current=(current : Thread) : Thread
     Crystal::System::Thread.current_thread = current
@@ -121,6 +128,11 @@ class Thread
 
   # :nodoc:
   getter scheduler : Crystal::Scheduler { Crystal::Scheduler.new(self) }
+
+  # :nodoc:
+  def scheduler? : ::Crystal::Scheduler?
+    @scheduler
+  end
 
   protected def start
     Thread.threads.push(self)

--- a/src/crystal/system/unix/pthread.cr
+++ b/src/crystal/system/unix/pthread.cr
@@ -55,6 +55,12 @@ module Crystal::System::Thread
       end
     end
 
+    def self.current_thread? : ::Thread?
+      if ptr = LibC.pthread_getspecific(@@current_key)
+        ptr.as(::Thread)
+      end
+    end
+
     def self.current_thread=(thread : ::Thread)
       ret = LibC.pthread_setspecific(@@current_key, thread.as(Void*))
       raise RuntimeError.from_os_error("pthread_setspecific", Errno.new(ret)) unless ret == 0
@@ -63,6 +69,10 @@ module Crystal::System::Thread
   {% else %}
     @[ThreadLocal]
     class_property current_thread : ::Thread { ::Thread.new }
+
+    def self.current_thread? : ::Thread?
+      @@current_thread
+    end
   {% end %}
 
   private def system_join : Exception?

--- a/src/crystal/system/win32/thread.cr
+++ b/src/crystal/system/win32/thread.cr
@@ -47,6 +47,10 @@ module Crystal::System::Thread
   @[ThreadLocal]
   class_property current_thread : ::Thread { ::Thread.new }
 
+  def self.current_thread? : ::Thread?
+    @@current_thread
+  end
+
   private def system_join : Exception?
     if LibC.WaitForSingleObject(@system_handle, LibC::INFINITE) != LibC::WAIT_OBJECT_0
       return RuntimeError.from_winerror("WaitForSingleObject")


### PR DESCRIPTION
The internal runtime may need to access the current thread and scheduler before they're actually defined *and* without lazily defining them (e.g. tracing).

Extracted from #14659 