### PR TITLE
Unify `EventLoop.create`

### DIFF
--- a/src/crystal/system/event_loop.cr
+++ b/src/crystal/system/event_loop.cr
@@ -1,6 +1,16 @@
 abstract class Crystal::EventLoop
   # Creates an event loop instance
-  # def self.create : Crystal::EventLoop
+  def self.create
+    {% if flag?(:wasi) %}
+      Crystal::Wasi::EventLoop.new
+    {% elsif flag?(:unix) %}
+      Crystal::LibEvent::EventLoop.new
+    {% elsif flag?(:win32) %}
+      Crystal::Iocp::EventLoop.new
+    {% else %}
+      {% raise "Event loop not supported" %}
+    {% end %}
+  end
 
   @[AlwaysInline]
   def self.current : self

--- a/src/crystal/system/event_loop.cr
+++ b/src/crystal/system/event_loop.cr
@@ -6,7 +6,7 @@ abstract class Crystal::EventLoop
     {% elsif flag?(:unix) %}
       Crystal::LibEvent::EventLoop.new
     {% elsif flag?(:win32) %}
-      Crystal::Iocp::EventLoop.new
+      Crystal::IOCP::EventLoop.new
     {% else %}
       {% raise "Event loop not supported" %}
     {% end %}

--- a/src/crystal/system/event_loop.cr
+++ b/src/crystal/system/event_loop.cr
@@ -1,6 +1,6 @@
 abstract class Crystal::EventLoop
   # Creates an event loop instance
-  def self.create
+  def self.create : Crystal::EventLoop
     {% if flag?(:wasi) %}
       Crystal::Wasi::EventLoop.new
     {% elsif flag?(:unix) %}

--- a/src/crystal/system/event_loop.cr
+++ b/src/crystal/system/event_loop.cr
@@ -1,6 +1,6 @@
 abstract class Crystal::EventLoop
   # Creates an event loop instance
-  def self.create : Crystal::EventLoop
+  def self.create : self
     {% if flag?(:wasi) %}
       Crystal::Wasi::EventLoop.new
     {% elsif flag?(:unix) %}

--- a/src/crystal/system/unix/event_loop_libevent.cr
+++ b/src/crystal/system/unix/event_loop_libevent.cr
@@ -1,13 +1,6 @@
 require "./event_libevent"
 
 # :nodoc:
-abstract class Crystal::EventLoop
-  def self.create
-    Crystal::LibEvent::EventLoop.new
-  end
-end
-
-# :nodoc:
 class Crystal::LibEvent::EventLoop < Crystal::EventLoop
   private getter(event_base) { Crystal::LibEvent::Event::Base.new }
 

--- a/src/crystal/system/wasi/event_loop.cr
+++ b/src/crystal/system/wasi/event_loop.cr
@@ -1,11 +1,4 @@
 # :nodoc:
-abstract class Crystal::EventLoop
-  def self.create
-    Crystal::Wasi::EventLoop.new
-  end
-end
-
-# :nodoc:
 class Crystal::Wasi::EventLoop < Crystal::EventLoop
   # Runs the event loop.
   def run(blocking : Bool) : Bool

--- a/src/crystal/system/win32/event_loop_iocp.cr
+++ b/src/crystal/system/win32/event_loop_iocp.cr
@@ -2,13 +2,6 @@ require "c/ioapiset"
 require "crystal/system/print_error"
 
 # :nodoc:
-abstract class Crystal::EventLoop
-  def self.create
-    Crystal::Iocp::EventLoop.new
-  end
-end
-
-# :nodoc:
 class Crystal::Iocp::EventLoop < Crystal::EventLoop
   # This is a list of resume and timeout events managed outside of IOCP.
   @queue = Deque(Crystal::Iocp::Event).new


### PR DESCRIPTION
Unifies all platform-specific implementations of `EventLoop.create` into a single method. This makes it more comprehensible which event loop implementation is used on which target.
This will be handy when we introduce new event loop implementations and select them at runtime.