### PR TITLE
Rename `Crystal::Iocp` to `Crystal::IOCP`

### DIFF
--- a/src/crystal/system/win32/event_loop_iocp.cr
+++ b/src/crystal/system/win32/event_loop_iocp.cr
@@ -4,14 +4,14 @@ require "crystal/system/print_error"
 # :nodoc:
 abstract class Crystal::EventLoop
   def self.create
-    Crystal::Iocp::EventLoop.new
+    Crystal::IOCP::EventLoop.new
   end
 end
 
 # :nodoc:
-class Crystal::Iocp::EventLoop < Crystal::EventLoop
+class Crystal::IOCP::EventLoop < Crystal::EventLoop
   # This is a list of resume and timeout events managed outside of IOCP.
-  @queue = Deque(Crystal::Iocp::Event).new
+  @queue = Deque(Crystal::IOCP::Event).new
 
   @lock = Crystal::SpinLock.new
   @interrupted = Atomic(Bool).new(false)
@@ -130,23 +130,23 @@ class Crystal::Iocp::EventLoop < Crystal::EventLoop
     LibC.QueueUserAPC(->(ptr : LibC::ULONG_PTR) {}, thread, LibC::ULONG_PTR.new(0))
   end
 
-  def enqueue(event : Crystal::Iocp::Event)
+  def enqueue(event : Crystal::IOCP::Event)
     unless @queue.includes?(event)
       @queue << event
     end
   end
 
-  def dequeue(event : Crystal::Iocp::Event)
+  def dequeue(event : Crystal::IOCP::Event)
     @queue.delete(event)
   end
 
   # Create a new resume event for a fiber.
   def create_resume_event(fiber : Fiber) : Crystal::EventLoop::Event
-    Crystal::Iocp::Event.new(fiber)
+    Crystal::IOCP::Event.new(fiber)
   end
 
   def create_timeout_event(fiber) : Crystal::EventLoop::Event
-    Crystal::Iocp::Event.new(fiber, timeout: true)
+    Crystal::IOCP::Event.new(fiber, timeout: true)
   end
 
   private def wsa_buffer(bytes)
@@ -261,7 +261,7 @@ class Crystal::Iocp::EventLoop < Crystal::EventLoop
   end
 end
 
-class Crystal::Iocp::Event
+class Crystal::IOCP::Event
   include Crystal::EventLoop::Event
 
   getter fiber

--- a/src/io/overlapped.cr
+++ b/src/io/overlapped.cr
@@ -157,10 +157,10 @@ module IO::Overlapped
   # Returns `false` if the operation timed out.
   def schedule_overlapped(timeout : Time::Span?, line = __LINE__) : Bool
     if timeout
-      timeout_event = Crystal::Iocp::Event.new(Fiber.current)
+      timeout_event = Crystal::IOCP::Event.new(Fiber.current)
       timeout_event.add(timeout)
     else
-      timeout_event = Crystal::Iocp::Event.new(Fiber.current, Time::Span::MAX)
+      timeout_event = Crystal::IOCP::Event.new(Fiber.current, Time::Span::MAX)
     end
     # memoize event loop to make sure that we still target the same instance
     # after wakeup (guaranteed by current MT model but let's be future proof)


### PR DESCRIPTION
This is a simple internal rename. `IOCP` is an acronym and we usually spell them in all caps (`URI`, `HTTP`, `CSV`, `XML`, `ECR`, `UUID`, ...). This change applies this established style.