### PR TITLE
Remove `OverlappedOperation#synchronous`

### DIFF
--- a/src/crystal/system/win32/socket.cr
+++ b/src/crystal/system/win32/socket.cr
@@ -144,7 +144,7 @@ module Crystal::System::Socket
           return ::Socket::Error.from_os_error("ConnectEx", error)
         end
       else
-        operation.synchronous = true
+        operation.done!
         return nil
       end
 
@@ -208,7 +208,7 @@ module Crystal::System::Socket
           return false
         end
       else
-        operation.synchronous = true
+        operation.done!
         return true
       end
 

--- a/src/io/overlapped.cr
+++ b/src/io/overlapped.cr
@@ -140,11 +140,9 @@ module IO::Overlapped
       when .started?
         handle = LibC::HANDLE.new(handle) if handle.is_a?(LibC::SOCKET)
 
-        # Microsoft documentation:
-        # The application must not free or reuse the OVERLAPPED structure
+        # https://learn.microsoft.com/en-us/windows/win32/api/ioapiset/nf-ioapiset-cancelioex
+        # > The application must not free or reuse the OVERLAPPED structure
         # associated with the canceled I/O operations until they have completed
-        # (this does not apply to asynchronous operations that finished
-        # synchronously, as nothing would be queued to the IOCP)
         if LibC.CancelIoEx(handle, pointerof(@overlapped)) != 0
           @state = :cancelled
           @@canceled.push(self) # to increase lifetime


### PR DESCRIPTION
The property `OverlappedOperation#synchronous` indicates when an operation has completed synchronously. That means we don't need to suspend the fiber and wait for completion. The operation is already complete.
But there's actually no need for a separate signal for that. The `state` property already encodes this as state `DONE`. There's nothing else special about "synchronous" completion that would distinguish it from `DONE` state after asynchronous completion.
This change drops the extra ivar and thus simplifies the code a bit.