### PR TITLE
Fix `IO#same_content?` accepting prefix on second stream

### DIFF
--- a/spec/std/io/io_spec.cr
+++ b/spec/std/io/io_spec.cr
@@ -461,6 +461,30 @@ describe IO do
         io2 = IO::Memory.new("hella")
         IO.same_content?(io2, io1).should be_false
       end
+
+      it "refutes prefix match, one way" do
+        io1 = OneByOneIO.new("hello")
+        io2 = IO::Memory.new("hello again")
+        IO.same_content?(io1, io2).should be_false
+      end
+
+      it "refutes prefix match, second way" do
+        io1 = IO::Memory.new("hello")
+        io2 = OneByOneIO.new("hello again")
+        IO.same_content?(io1, io2).should be_false
+      end
+
+      it "refutes prefix match, one way" do
+        io1 = OneByOneIO.new("hello again")
+        io2 = IO::Memory.new("hello")
+        IO.same_content?(io1, io2).should be_false
+      end
+
+      it "refutes prefix match, second way" do
+        io1 = IO::Memory.new("hello again")
+        io2 = OneByOneIO.new("hello")
+        IO.same_content?(io1, io2).should be_false
+      end
     end
   end
 

--- a/src/io.cr
+++ b/src/io.cr
@@ -1219,11 +1219,14 @@ abstract class IO
 
     while true
       read1 = stream1.read(buf1.to_slice)
+      if read1.zero?
+        # First stream is EOF, check if the second has more.
+        return stream2.read_byte.nil?
+      end
       read2 = stream2.read_fully?(buf2.to_slice[0, read1])
       return false unless read2
 
       return false if buf1.to_unsafe.memcmp(buf2.to_unsafe, read1) != 0
-      return true if read1 == 0
     end
   end
 


### PR DESCRIPTION
Resolves #14623