### PR TITLE
Drop unused methods in `IO::Evented`

### DIFF
--- a/src/io/evented.cr
+++ b/src/io/evented.cr
@@ -49,15 +49,6 @@ module IO::Evented
     end
   end
 
-  def evented_send(errno_msg : String, &) : Int32
-    bytes_written = yield
-    raise Socket::Error.from_errno(errno_msg) if bytes_written == -1
-    # `to_i32` is acceptable because `Slice#size` is an Int32
-    bytes_written.to_i32
-  ensure
-    resume_pending_writers
-  end
-
   # :nodoc:
   def resume_read(timed_out = false) : Nil
     @read_timed_out = timed_out
@@ -124,10 +115,6 @@ module IO::Evented
   private def add_write_event(timeout = @write_timeout) : Nil
     event = @write_event.get { Crystal::EventLoop.current.create_fd_write_event(self) }
     event.add timeout
-  end
-
-  def evented_reopen : Nil
-    evented_close
   end
 
   def evented_close : Nil


### PR DESCRIPTION
After both #14639 and #14643 are merged, these methods are not used anymore.