### PR TITLE
Fix: use `SOCK_CLOEXEC` with `FD_CLOEXEC` fallback

### DIFF
--- a/spec/std/socket/socket_spec.cr
+++ b/spec/std/socket/socket_spec.cr
@@ -57,6 +57,9 @@ describe Socket, tags: "network" do
         client.family.should eq(Socket::Family::INET)
         client.type.should eq(Socket::Type::STREAM)
         client.protocol.should eq(Socket::Protocol::TCP)
+        {% unless flag?(:win32) %}
+          client.close_on_exec?.should be_true
+        {% end %}
       ensure
         client.close
       end

--- a/spec/std/socket/tcp_server_spec.cr
+++ b/spec/std/socket/tcp_server_spec.cr
@@ -140,10 +140,8 @@ describe TCPServer, tags: "network" do
   describe "accept" do
     {% unless flag?(:win32) %}
       it "sets close on exec flag" do
-        port = unused_local_port
-
-        TCPServer.open("::", port) do |server|
-          TCPSocket.open("::", port) do |client|
+        TCPServer.open("localhost", 0) do |server|
+          TCPSocket.open("localhost", server.local_address.port) do |client|
             server.accept? do |sock|
               sock.close_on_exec?.should be_true
             end

--- a/spec/std/socket/tcp_server_spec.cr
+++ b/spec/std/socket/tcp_server_spec.cr
@@ -136,4 +136,20 @@ describe TCPServer, tags: "network" do
       end
     end
   {% end %}
+
+  describe "accept" do
+    {% unless flag?(:win32) %}
+      it "sets close on exec flag" do
+        port = unused_local_port
+
+        TCPServer.open("::", port) do |server|
+          TCPSocket.open("::", port) do |client|
+            server.accept? do |sock|
+              sock.close_on_exec?.should be_true
+            end
+          end
+        end
+      end
+    {% end %}
+  end
 end

--- a/spec/std/socket/unix_server_spec.cr
+++ b/spec/std/socket/unix_server_spec.cr
@@ -147,6 +147,20 @@ describe UNIXServer do
         ret.should be_nil
       end
     end
+
+    {% unless flag?(:win32) %}
+      it "sets close on exec flag" do
+        with_tempfile("unix_socket-accept.sock") do |path|
+          UNIXServer.open(path) do |server|
+            UNIXSocket.open(path) do |client|
+              server.accept? do |sock|
+                sock.close_on_exec?.should be_true
+              end
+            end
+          end
+        end
+      end
+    {% end %}
   end
 
   # Datagram socket type is not supported on Windows yet:

--- a/spec/std/socket/unix_socket_spec.cr
+++ b/spec/std/socket/unix_socket_spec.cr
@@ -103,7 +103,7 @@ describe UNIXSocket do
         sizes.should contain(left.recv_buffer_size)
 
         left.close_on_exec?.should be_true
-        left.close_on_exec?.should be_true
+        right.close_on_exec?.should be_true
       end
     end
   {% end %}

--- a/spec/std/socket/unix_socket_spec.cr
+++ b/spec/std/socket/unix_socket_spec.cr
@@ -101,6 +101,9 @@ describe UNIXSocket do
 
         (left.recv_buffer_size = size).should eq(size)
         sizes.should contain(left.recv_buffer_size)
+
+        left.close_on_exec?.should be_true
+        left.close_on_exec?.should be_true
       end
     end
   {% end %}

--- a/src/crystal/system/unix/event_loop_libevent.cr
+++ b/src/crystal/system/unix/event_loop_libevent.cr
@@ -155,7 +155,13 @@ class Crystal::LibEvent::EventLoop < Crystal::EventLoop
 
   def accept(socket : ::Socket) : ::Socket::Handle?
     loop do
-      client_fd = LibC.accept(socket.fd, nil, nil)
+      client_fd =
+        {% if LibC.has_method?(:accept4) && LibC.has_constant?(:SOCK_CLOEXEC) %}
+          LibC.accept4(socket.fd, nil, nil, LibC::SOCK_CLOEXEC)
+        {% else %}
+          LibC.accept(socket.fd, nil, nil)
+        {% end %}
+
       if client_fd == -1
         if socket.closed?
           return
@@ -168,6 +174,9 @@ class Crystal::LibEvent::EventLoop < Crystal::EventLoop
           raise ::Socket::Error.from_errno("accept")
         end
       else
+        {% unless LibC.has_constant?(:SOCK_CLOEXEC) %}
+          Crystal::System::Socket.fcntl(client_fd, LibC::F_SETFD, LibC::FD_CLOEXEC)
+        {% end %}
         return client_fd
       end
     end

--- a/src/crystal/system/unix/event_loop_libevent.cr
+++ b/src/crystal/system/unix/event_loop_libevent.cr
@@ -156,7 +156,7 @@ class Crystal::LibEvent::EventLoop < Crystal::EventLoop
   def accept(socket : ::Socket) : ::Socket::Handle?
     loop do
       client_fd =
-        {% if LibC.has_method?(:accept4) && LibC.has_constant?(:SOCK_CLOEXEC) %}
+        {% if LibC.has_method?(:accept4) %}
           LibC.accept4(socket.fd, nil, nil, LibC::SOCK_CLOEXEC)
         {% else %}
           LibC.accept(socket.fd, nil, nil)
@@ -174,7 +174,7 @@ class Crystal::LibEvent::EventLoop < Crystal::EventLoop
           raise ::Socket::Error.from_errno("accept")
         end
       else
-        {% unless LibC.has_constant?(:SOCK_CLOEXEC) %}
+        {% unless LibC.has_method?(:accept4) %}
           Crystal::System::Socket.fcntl(client_fd, LibC::F_SETFD, LibC::FD_CLOEXEC)
         {% end %}
         return client_fd

--- a/src/crystal/system/unix/socket.cr
+++ b/src/crystal/system/unix/socket.cr
@@ -18,7 +18,7 @@ module Crystal::System::Socket
     raise ::Socket::Error.from_errno("Failed to create socket") if fd == -1
 
     {% unless LibC.has_constant?(:SOCK_CLOEXEC) %}
-      ::Crystal::System::Socket.fcntl(fd, LibC::F_SETFD, LibC::FD_CLOEXEC)
+      Socket.fcntl(fd, LibC::F_SETFD, LibC::FD_CLOEXEC)
     {% end %}
 
     fd

--- a/src/crystal/system/unix/socket.cr
+++ b/src/crystal/system/unix/socket.cr
@@ -9,21 +9,22 @@ module Crystal::System::Socket
   alias Handle = Int32
 
   private def create_handle(family, type, protocol, blocking) : Handle
+    socktype = type.value
     {% if LibC.has_constant?(:SOCK_CLOEXEC) %}
-      # Forces opened sockets to be closed on `exec(2)`.
-      type = type.to_i | LibC::SOCK_CLOEXEC
+      socktype |= LibC::SOCK_CLOEXEC
     {% end %}
-    fd = LibC.socket(family, type, protocol)
+
+    fd = LibC.socket(family, socktype, protocol)
     raise ::Socket::Error.from_errno("Failed to create socket") if fd == -1
+
+    {% unless LibC.has_constant?(:SOCK_CLOEXEC) %}
+      ::Crystal::System::Socket.fcntl(fd, LibC::F_SETFD, LibC::FD_CLOEXEC)
+    {% end %}
+
     fd
   end
 
   private def initialize_handle(fd)
-    {% unless LibC.has_constant?(:SOCK_CLOEXEC) %}
-      # Forces opened sockets to be closed on `exec(2)`. Only for platforms that don't
-      # support `SOCK_CLOEXEC` (e.g., Darwin).
-      LibC.fcntl(fd, LibC::F_SETFD, LibC::FD_CLOEXEC)
-    {% end %}
   end
 
   # Tries to bind the socket to a local address.

--- a/src/lib_c/aarch64-android/c/sys/socket.cr
+++ b/src/lib_c/aarch64-android/c/sys/socket.cr
@@ -48,6 +48,7 @@ lib LibC
   end
 
   fun accept(__fd : Int, __addr : Sockaddr*, __addr_length : SocklenT*) : Int
+  fun accept4(__fd : Int, __addr : Sockaddr*, __addr_length : SocklenT*, __flags : Int) : Int
   fun bind(__fd : Int, __addr : Sockaddr*, __addr_length : SocklenT) : Int
   fun connect(__fd : Int, __addr : Sockaddr*, __addr_length : SocklenT) : Int
   fun getpeername(__fd : Int, __addr : Sockaddr*, __addr_length : SocklenT*) : Int

--- a/src/lib_c/aarch64-linux-gnu/c/sys/socket.cr
+++ b/src/lib_c/aarch64-linux-gnu/c/sys/socket.cr
@@ -48,6 +48,7 @@ lib LibC
   end
 
   fun accept(fd : Int, addr : Sockaddr*, addr_len : SocklenT*) : Int
+  fun accept4(fd : Int, addr : Sockaddr*, addr_len : SocklenT*, flags : Int) : Int
   fun bind(fd : Int, addr : Sockaddr*, len : SocklenT) : Int
   fun connect(fd : Int, addr : Sockaddr*, len : SocklenT) : Int
   fun getpeername(fd : Int, addr : Sockaddr*, len : SocklenT*) : Int

--- a/src/lib_c/aarch64-linux-musl/c/sys/socket.cr
+++ b/src/lib_c/aarch64-linux-musl/c/sys/socket.cr
@@ -48,6 +48,7 @@ lib LibC
   end
 
   fun accept(x0 : Int, x1 : Sockaddr*, x2 : SocklenT*) : Int
+  fun accept4(x0 : Int, x1 : Sockaddr*, x2 : SocklenT*, x3 : Int) : Int
   fun bind(x0 : Int, x1 : Sockaddr*, x2 : SocklenT) : Int
   fun connect(x0 : Int, x1 : Sockaddr*, x2 : SocklenT) : Int
   fun getpeername(x0 : Int, x1 : Sockaddr*, x2 : SocklenT*) : Int

--- a/src/lib_c/arm-linux-gnueabihf/c/sys/socket.cr
+++ b/src/lib_c/arm-linux-gnueabihf/c/sys/socket.cr
@@ -48,6 +48,7 @@ lib LibC
   end
 
   fun accept(fd : Int, addr : Sockaddr*, addr_len : SocklenT*) : Int
+  fun accept4(fd : Int, addr : Sockaddr*, addr_len : SocklenT*, flags : Int) : Int
   fun bind(fd : Int, addr : Sockaddr*, len : SocklenT) : Int
   fun connect(fd : Int, addr : Sockaddr*, len : SocklenT) : Int
   fun getpeername(fd : Int, addr : Sockaddr*, len : SocklenT*) : Int

--- a/src/lib_c/i386-linux-gnu/c/sys/socket.cr
+++ b/src/lib_c/i386-linux-gnu/c/sys/socket.cr
@@ -48,6 +48,7 @@ lib LibC
   end
 
   fun accept(fd : Int, addr : Sockaddr*, addr_len : SocklenT*) : Int
+  fun accept4(fd : Int, addr : Sockaddr*, addr_len : SocklenT*, flags : Int) : Int
   fun bind(fd : Int, addr : Sockaddr*, len : SocklenT) : Int
   fun connect(fd : Int, addr : Sockaddr*, len : SocklenT) : Int
   fun getpeername(fd : Int, addr : Sockaddr*, len : SocklenT*) : Int

--- a/src/lib_c/i386-linux-musl/c/sys/socket.cr
+++ b/src/lib_c/i386-linux-musl/c/sys/socket.cr
@@ -48,6 +48,7 @@ lib LibC
   end
 
   fun accept(x0 : Int, x1 : Sockaddr*, x2 : SocklenT*) : Int
+  fun accept4(x0 : Int, x1 : Sockaddr*, x2 : SocklenT*, x3 : Int) : Int
   fun bind(x0 : Int, x1 : Sockaddr*, x2 : SocklenT) : Int
   fun connect(x0 : Int, x1 : Sockaddr*, x2 : SocklenT) : Int
   fun getpeername(x0 : Int, x1 : Sockaddr*, x2 : SocklenT*) : Int

--- a/src/lib_c/x86_64-dragonfly/c/sys/socket.cr
+++ b/src/lib_c/x86_64-dragonfly/c/sys/socket.cr
@@ -51,6 +51,7 @@ lib LibC
   end
 
   fun accept(x0 : Int, x1 : Sockaddr*, x2 : SocklenT*) : Int
+  fun accept4(x0 : Int, x1 : Sockaddr*, x2 : SocklenT*, x3 : Int) : Int
   fun bind(x0 : Int, x1 : Sockaddr*, x2 : SocklenT) : Int
   fun connect(x0 : Int, x1 : Sockaddr*, x2 : SocklenT) : Int
   fun getpeername(x0 : Int, x1 : Sockaddr*, x2 : SocklenT*) : Int

--- a/src/lib_c/x86_64-freebsd/c/sys/socket.cr
+++ b/src/lib_c/x86_64-freebsd/c/sys/socket.cr
@@ -51,6 +51,7 @@ lib LibC
   end
 
   fun accept(x0 : Int, x1 : Sockaddr*, x2 : SocklenT*) : Int
+  fun accept4(x0 : Int, x1 : Sockaddr*, x2 : SocklenT*, x3 : Int) : Int
   fun bind(x0 : Int, x1 : Sockaddr*, x2 : SocklenT) : Int
   fun connect(x0 : Int, x1 : Sockaddr*, x2 : SocklenT) : Int
   fun getpeername(x0 : Int, x1 : Sockaddr*, x2 : SocklenT*) : Int

--- a/src/lib_c/x86_64-linux-gnu/c/sys/socket.cr
+++ b/src/lib_c/x86_64-linux-gnu/c/sys/socket.cr
@@ -48,6 +48,7 @@ lib LibC
   end
 
   fun accept(fd : Int, addr : Sockaddr*, addr_len : SocklenT*) : Int
+  fun accept4(fd : Int, addr : Sockaddr*, addr_len : SocklenT*, flags : Int) : Int
   fun bind(fd : Int, addr : Sockaddr*, len : SocklenT) : Int
   fun connect(fd : Int, addr : Sockaddr*, len : SocklenT) : Int
   fun getpeername(fd : Int, addr : Sockaddr*, len : SocklenT*) : Int

--- a/src/lib_c/x86_64-linux-musl/c/sys/socket.cr
+++ b/src/lib_c/x86_64-linux-musl/c/sys/socket.cr
@@ -48,6 +48,7 @@ lib LibC
   end
 
   fun accept(x0 : Int, x1 : Sockaddr*, x2 : SocklenT*) : Int
+  fun accept4(x0 : Int, x1 : Sockaddr*, x2 : SocklenT*, x3 : Int) : Int
   fun bind(x0 : Int, x1 : Sockaddr*, x2 : SocklenT) : Int
   fun connect(x0 : Int, x1 : Sockaddr*, x2 : SocklenT) : Int
   fun getpeername(x0 : Int, x1 : Sockaddr*, x2 : SocklenT*) : Int

--- a/src/lib_c/x86_64-netbsd/c/sys/socket.cr
+++ b/src/lib_c/x86_64-netbsd/c/sys/socket.cr
@@ -51,6 +51,7 @@ lib LibC
   end
 
   fun accept(x0 : Int, x1 : Sockaddr*, x2 : SocklenT*) : Int
+  fun accept4(x0 : Int, x1 : Sockaddr*, x2 : SocklenT*, x3 : Int) : Int
   fun bind(x0 : Int, x1 : Sockaddr*, x2 : SocklenT) : Int
   fun connect(x0 : Int, x1 : Sockaddr*, x2 : SocklenT) : Int
   fun getpeername(x0 : Int, x1 : Sockaddr*, x2 : SocklenT*) : Int

--- a/src/lib_c/x86_64-openbsd/c/sys/socket.cr
+++ b/src/lib_c/x86_64-openbsd/c/sys/socket.cr
@@ -51,6 +51,7 @@ lib LibC
   end
 
   fun accept(x0 : Int, x1 : Sockaddr*, x2 : SocklenT*) : Int
+  fun accept4(x0 : Int, x1 : Sockaddr*, x2 : SocklenT*, x3 : Int) : Int
   fun bind(x0 : Int, x1 : Sockaddr*, x2 : SocklenT) : Int
   fun connect(x0 : Int, x1 : Sockaddr*, x2 : SocklenT) : Int
   fun getpeername(x0 : Int, x1 : Sockaddr*, x2 : SocklenT*) : Int

--- a/src/lib_c/x86_64-solaris/c/sys/socket.cr
+++ b/src/lib_c/x86_64-solaris/c/sys/socket.cr
@@ -50,6 +50,7 @@ lib LibC
   end
 
   fun accept(x0 : Int, x1 : Sockaddr*, x2 : SocklenT*) : Int
+  fun accept4(x0 : Int, x1 : Sockaddr*, x2 : SocklenT*, x3 : Int) : Int
   fun bind(x0 : Int, x1 : Sockaddr*, x2 : SocklenT) : Int
   fun connect(x0 : Int, x1 : Sockaddr*, x2 : SocklenT) : Int
   fun getpeername(x0 : Int, x1 : Sockaddr*, x2 : SocklenT*) : Int

--- a/src/socket/unix_socket.cr
+++ b/src/socket/unix_socket.cr
@@ -75,12 +75,17 @@ class UNIXSocket < Socket
 
       socktype = type.value
       {% if LibC.has_constant?(:SOCK_CLOEXEC) %}
-      socktype |= LibC::SOCK_CLOEXEC
+        socktype |= LibC::SOCK_CLOEXEC
       {% end %}
 
       if LibC.socketpair(Family::UNIX, socktype, 0, fds) != 0
-        raise Socket::Error.new("socketpair:")
+        raise Socket::Error.new("socketpair() failed")
       end
+
+      {% unless LibC.has_constant?(:SOCK_CLOEXEC) %}
+        Crystal::System::Socket.fcntl(fds[0], LibC::F_SETFD, LibC::FD_CLOEXEC)
+        Crystal::System::Socket.fcntl(fds[1], LibC::F_SETFD, LibC::FD_CLOEXEC)
+      {% end %}
 
       {UNIXSocket.new(fd: fds[0], type: type), UNIXSocket.new(fd: fds[1], type: type)}
     {% end %}


### PR DESCRIPTION
Harmonizes the implementations between Darwin and other POSIX platforms for the "close on exec" behavior.

When `SOCK_CLOEXEC` is available, we always use it in the `socket`, `socketpair` and `accept4` syscalls. When `SOCK_CLOEXEC` isn't available, we don't delay to `Socket#initialize_handle` anymore to set `FD_CLOEXEC` for Darwin only, but immediately call `fcntl` to set it after the above syscalls.

The `accept4` syscall is non-standard but widely available: Linux, all supported BSD, except for Darwin (obviously).

The patch also fixes an issue where TCP and UNIX client sockets didn't have `FD_CLOEXEC` on POSIX platforms... except for Darwin.

closes #14650