### PR TITLE
Use `dup3` and `pipe2` to set `O_CLOEXEC` when available

### DIFF
--- a/src/crystal/system/unix/file_descriptor.cr
+++ b/src/crystal/system/unix/file_descriptor.cr
@@ -229,12 +229,11 @@ module Crystal::System::FileDescriptor
     ret = LibC.ttyname_r(fd, path, 256)
     return IO::FileDescriptor.new(fd).tap(&.flush_on_newline=(true)) unless ret == 0
 
-    clone_fd = LibC.open(path, LibC::O_RDWR)
+    clone_fd = LibC.open(path, LibC::O_RDWR | LibC::O_CLOEXEC)
     return IO::FileDescriptor.new(fd).tap(&.flush_on_newline=(true)) if clone_fd == -1
 
     # We don't buffer output for TTY devices to see their output right away
     io = IO::FileDescriptor.new(clone_fd)
-    io.close_on_exec = true
     io.sync = true
     io
   end

--- a/src/lib_c/aarch64-android/c/unistd.cr
+++ b/src/lib_c/aarch64-android/c/unistd.cr
@@ -17,6 +17,7 @@ lib LibC
   fun fchown(__fd : Int, __owner : UidT, __group : GidT) : Int
   fun close(__fd : Int) : Int
   fun dup2(__old_fd : Int, __new_fd : Int) : Int
+  fun dup3(__old_fd : Int, __new_fd : Int, __flags : Int) : Int
   fun _exit(__status : Int) : NoReturn
   fun execvp(__file : Char*, __argv : Char**) : Int
   fun fdatasync(__fd : Int) : Int
@@ -40,6 +41,7 @@ lib LibC
   {% end %}
   fun lseek(__fd : Int, __offset : OffT, __whence : Int) : OffT
   fun pipe(__fds : Int[2]) : Int
+  fun pipe2(__fds : Int[2], __flags : Int) : Int
   fun read(__fd : Int, __buf : Void*, __count : SizeT) : SSizeT
   fun pread(__fd : Int, __buf : Void*, __count : SizeT, __offset : OffT) : SSizeT
   fun rmdir(__path : Char*) : Int

--- a/src/lib_c/aarch64-linux-gnu/c/unistd.cr
+++ b/src/lib_c/aarch64-linux-gnu/c/unistd.cr
@@ -17,6 +17,7 @@ lib LibC
   fun fchown(x0 : Int, x1 : UidT, x2 : GidT) : Int
   fun close(fd : Int) : Int
   fun dup2(fd : Int, fd2 : Int) : Int
+  fun dup3(fd : Int, fd2 : Int, flags : Int) : Int
   fun _exit(status : Int) : NoReturn
   fun execvp(file : Char*, argv : Char**) : Int
   fun fdatasync(fd : Int) : Int
@@ -38,6 +39,7 @@ lib LibC
   fun lockf(fd : Int, cmd : Int, len : OffT) : Int
   fun lseek(fd : Int, offset : OffT, whence : Int) : OffT
   fun pipe(pipedes : StaticArray(Int, 2)) : Int
+  fun pipe2(pipedes : StaticArray(Int, 2), flags : Int) : Int
   fun read(fd : Int, buf : Void*, nbytes : SizeT) : SSizeT
   fun pread(x0 : Int, x1 : Void*, x2 : SizeT, x3 : OffT) : SSizeT
   fun rmdir(path : Char*) : Int

--- a/src/lib_c/aarch64-linux-musl/c/unistd.cr
+++ b/src/lib_c/aarch64-linux-musl/c/unistd.cr
@@ -17,6 +17,7 @@ lib LibC
   fun fchown(x0 : Int, x1 : UidT, x2 : GidT) : Int
   fun close(x0 : Int) : Int
   fun dup2(x0 : Int, x1 : Int) : Int
+  fun dup3(x0 : Int, x1 : Int, x2 : Int) : Int
   fun _exit(x0 : Int) : NoReturn
   fun execvp(x0 : Char*, x1 : Char**) : Int
   fun fdatasync(fd : Int) : Int
@@ -38,6 +39,7 @@ lib LibC
   fun lockf(x0 : Int, x1 : Int, x2 : OffT) : Int
   fun lseek(x0 : Int, x1 : OffT, x2 : Int) : OffT
   fun pipe(x0 : StaticArray(Int, 2)) : Int
+  fun pipe2(x0 : StaticArray(Int, 2), x1 : Int) : Int
   fun read(x0 : Int, x1 : Void*, x2 : SizeT) : SSizeT
   fun pread(x0 : Int, x1 : Void*, x2 : SizeT, x3 : OffT) : SSizeT
   fun rmdir(x0 : Char*) : Int

--- a/src/lib_c/arm-linux-gnueabihf/c/unistd.cr
+++ b/src/lib_c/arm-linux-gnueabihf/c/unistd.cr
@@ -17,6 +17,7 @@ lib LibC
   fun fchown(fd : Int, owner : UidT, group : GidT) : Int
   fun close(fd : Int) : Int
   fun dup2(fd : Int, fd2 : Int) : Int
+  fun dup3(fd : Int, fd2 : Int, flags : Int) : Int
   fun _exit(status : Int) : NoReturn
   fun execvp(file : Char*, argv : Char**) : Int
   fun fdatasync(fd : Int) : Int
@@ -38,6 +39,7 @@ lib LibC
   fun lockf(fd : Int, cmd : Int, len : OffT) : Int
   fun lseek(fd : Int, offset : OffT, whence : Int) : OffT
   fun pipe(pipedes : StaticArray(Int, 2)) : Int
+  fun pipe2(pipedes : StaticArray(Int, 2), flags : Int) : Int
   fun read(fd : Int, buf : Void*, nbytes : SizeT) : SSizeT
   fun pread(x0 : Int, x1 : Void*, x2 : SizeT, x3 : OffT) : SSizeT
   fun rmdir(path : Char*) : Int

--- a/src/lib_c/i386-linux-gnu/c/unistd.cr
+++ b/src/lib_c/i386-linux-gnu/c/unistd.cr
@@ -17,6 +17,7 @@ lib LibC
   fun fchown(fd : Int, owner : UidT, group : GidT) : Int
   fun close(fd : Int) : Int
   fun dup2(fd : Int, fd2 : Int) : Int
+  fun dup3(fd : Int, fd2 : Int, flags : Int) : Int
   fun _exit(status : Int) : NoReturn
   fun execvp(file : Char*, argv : Char**) : Int
   fun fdatasync(fd : Int) : Int
@@ -38,6 +39,7 @@ lib LibC
   fun lockf = lockf64(fd : Int, cmd : Int, len : OffT) : Int
   fun lseek = lseek64(fd : Int, offset : OffT, whence : Int) : OffT
   fun pipe(pipedes : StaticArray(Int, 2)) : Int
+  fun pipe2(pipedes : StaticArray(Int, 2), flags : Int) : Int
   fun read(fd : Int, buf : Void*, nbytes : SizeT) : SSizeT
   fun pread = pread64(x0 : Int, x1 : Void*, x2 : SizeT, x3 : OffT) : SSizeT
   fun rmdir(path : Char*) : Int

--- a/src/lib_c/i386-linux-musl/c/unistd.cr
+++ b/src/lib_c/i386-linux-musl/c/unistd.cr
@@ -17,6 +17,7 @@ lib LibC
   fun fchown(x0 : Int, x1 : UidT, x2 : GidT) : Int
   fun close(x0 : Int) : Int
   fun dup2(x0 : Int, x1 : Int) : Int
+  fun dup3(x0 : Int, x1 : Int, x2 : Int) : Int
   fun _exit(x0 : Int) : NoReturn
   fun execvp(x0 : Char*, x1 : Char**) : Int
   fun fdatasync(x0 : Int) : Int
@@ -38,6 +39,7 @@ lib LibC
   fun lockf(x0 : Int, x1 : Int, x2 : OffT) : Int
   fun lseek(x0 : Int, x1 : OffT, x2 : Int) : OffT
   fun pipe(x0 : StaticArray(Int, 2)) : Int
+  fun pipe2(x0 : StaticArray(Int, 2), flags : Int) : Int
   fun read(x0 : Int, x1 : Void*, x2 : SizeT) : SSizeT
   fun pread(x0 : Int, x1 : Void*, x2 : SizeT, x3 : OffT) : SSizeT
   fun rmdir(x0 : Char*) : Int

--- a/src/lib_c/x86_64-dragonfly/c/unistd.cr
+++ b/src/lib_c/x86_64-dragonfly/c/unistd.cr
@@ -16,6 +16,7 @@ lib LibC
   fun fchown(x0 : Int, x1 : UidT, x2 : GidT) : Int
   fun close(x0 : Int) : Int
   fun dup2(x0 : Int, x1 : Int) : Int
+  fun dup3(x0 : Int, x1 : Int, x2 : Int) : Int
   fun _exit(x0 : Int) : NoReturn
   fun execvp(x0 : Char*, x1 : Char**) : Int
   @[ReturnsTwice]
@@ -36,6 +37,7 @@ lib LibC
   fun lockf(x0 : Int, x1 : Int, x2 : OffT) : Int
   fun lseek(x0 : Int, x1 : OffT, x2 : Int) : OffT
   fun pipe(x0 : Int*) : Int
+  fun pipe2(x0 : Int*, x1 : Int) : Int
   fun read(x0 : Int, x1 : Void*, x2 : SizeT) : SSizeT
   fun pread(x0 : Int, x1 : Void*, x2 : SizeT, x3 : OffT) : SSizeT
   fun rmdir(x0 : Char*) : Int

--- a/src/lib_c/x86_64-freebsd/c/unistd.cr
+++ b/src/lib_c/x86_64-freebsd/c/unistd.cr
@@ -16,6 +16,7 @@ lib LibC
   fun fchown(x0 : Int, x1 : UidT, x2 : GidT) : Int
   fun close(x0 : Int) : Int
   fun dup2(x0 : Int, x1 : Int) : Int
+  fun dup3(x0 : Int, x1 : Int, x2 : Int) : Int
   fun _exit(x0 : Int) : NoReturn
   fun execvp(x0 : Char*, x1 : Char**) : Int
   fun fdatasync(fd : Int) : Int
@@ -37,6 +38,7 @@ lib LibC
   fun lockf(x0 : Int, x1 : Int, x2 : OffT) : Int
   fun lseek(x0 : Int, x1 : OffT, x2 : Int) : OffT
   fun pipe(x0 : Int*) : Int
+  fun pipe2(x0 : Int*, x1 : Int) : Int
   fun read(x0 : Int, x1 : Void*, x2 : SizeT) : SSizeT
   fun pread(x0 : Int, x1 : Void*, x2 : SizeT, x3 : OffT) : SSizeT
   fun rmdir(x0 : Char*) : Int

--- a/src/lib_c/x86_64-linux-gnu/c/unistd.cr
+++ b/src/lib_c/x86_64-linux-gnu/c/unistd.cr
@@ -17,6 +17,7 @@ lib LibC
   fun fchown(fd : Int, owner : UidT, group : GidT) : Int
   fun close(fd : Int) : Int
   fun dup2(fd : Int, fd2 : Int) : Int
+  fun dup3(fd : Int, fd2 : Int, flags : Int) : Int
   fun _exit(status : Int) : NoReturn
   fun execvp(file : Char*, argv : Char**) : Int
   fun fdatasync(fd : Int) : Int
@@ -38,6 +39,7 @@ lib LibC
   fun lockf(fd : Int, cmd : Int, len : OffT) : Int
   fun lseek(fd : Int, offset : OffT, whence : Int) : OffT
   fun pipe(pipedes : StaticArray(Int, 2)) : Int
+  fun pipe2(pipedes : StaticArray(Int, 2), flags : Int) : Int
   fun read(fd : Int, buf : Void*, nbytes : SizeT) : SSizeT
   fun pread(x0 : Int, x1 : Void*, x2 : SizeT, x3 : OffT) : SSizeT
   fun rmdir(path : Char*) : Int

--- a/src/lib_c/x86_64-linux-musl/c/unistd.cr
+++ b/src/lib_c/x86_64-linux-musl/c/unistd.cr
@@ -17,6 +17,7 @@ lib LibC
   fun fchown(x0 : Int, x1 : UidT, x2 : GidT) : Int
   fun close(x0 : Int) : Int
   fun dup2(x0 : Int, x1 : Int) : Int
+  fun dup3(x0 : Int, x1 : Int, x2 : Int) : Int
   fun _exit(x0 : Int) : NoReturn
   fun execvp(x0 : Char*, x1 : Char**) : Int
   fun fdatasync(x0 : Int) : Int
@@ -38,6 +39,7 @@ lib LibC
   fun lockf(x0 : Int, x1 : Int, x2 : OffT) : Int
   fun lseek(x0 : Int, x1 : OffT, x2 : Int) : OffT
   fun pipe(x0 : StaticArray(Int, 2)) : Int
+  fun pipe2(x0 : StaticArray(Int, 2), flags : Int) : Int
   fun read(x0 : Int, x1 : Void*, x2 : SizeT) : SSizeT
   fun pread(x0 : Int, x1 : Void*, x2 : SizeT, x3 : OffT) : SSizeT
   fun rmdir(x0 : Char*) : Int

--- a/src/lib_c/x86_64-netbsd/c/unistd.cr
+++ b/src/lib_c/x86_64-netbsd/c/unistd.cr
@@ -16,6 +16,7 @@ lib LibC
   fun fchown = __posix_fchown(x0 : Int, x1 : UidT, x2 : GidT) : Int
   fun close(x0 : Int) : Int
   fun dup2(x0 : Int, x1 : Int) : Int
+  fun dup3(x0 : Int, x1 : Int, x2 : Int) : Int
   fun _exit(x0 : Int) : NoReturn
   fun execvp(x0 : Char*, x1 : Char**) : Int
   fun fdatasync(x0 : Int) : Int
@@ -37,6 +38,7 @@ lib LibC
   fun lockf(x0 : Int, x1 : Int, x2 : OffT) : Int
   fun lseek(x0 : Int, x1 : OffT, x2 : Int) : OffT
   fun pipe(x0 : Int*) : Int
+  fun pipe2(x0 : Int*, x1 : Int) : Int
   fun read(x0 : Int, x1 : Void*, x2 : SizeT) : SSizeT
   fun pread(x0 : Int, x1 : Void*, x2 : SizeT, x3 : OffT) : SSizeT
   fun rmdir(x0 : Char*) : Int

--- a/src/lib_c/x86_64-openbsd/c/unistd.cr
+++ b/src/lib_c/x86_64-openbsd/c/unistd.cr
@@ -16,6 +16,7 @@ lib LibC
   fun fchown(x0 : Int, x1 : UidT, x2 : GidT) : Int
   fun close(x0 : Int) : Int
   fun dup2(x0 : Int, x1 : Int) : Int
+  fun dup3(x0 : Int, x1 : Int, x2 : Int) : Int
   fun _exit(x0 : Int) : NoReturn
   fun execvp(x0 : Char*, x1 : Char**) : Int
   fun fdatasync(x0 : Int) : Int
@@ -37,6 +38,7 @@ lib LibC
   fun lockf(x0 : Int, x1 : Int, x2 : OffT) : Int
   fun lseek(x0 : Int, x1 : OffT, x2 : Int) : OffT
   fun pipe(x0 : Int*) : Int
+  fun pipe2(x0 : Int*, x1 : Int) : Int
   fun read(x0 : Int, x1 : Void*, x2 : SizeT) : SSizeT
   fun pread(x0 : Int, x1 : Void*, x2 : SizeT, x3 : OffT) : SSizeT
   fun rmdir(x0 : Char*) : Int

--- a/src/lib_c/x86_64-solaris/c/unistd.cr
+++ b/src/lib_c/x86_64-solaris/c/unistd.cr
@@ -18,6 +18,7 @@ lib LibC
   fun fchown(x0 : Int, x1 : UidT, x2 : GidT) : Int
   fun close(x0 : Int) : Int
   fun dup2(x0 : Int, x1 : Int) : Int
+  fun dup3(x0 : Int, x1 : Int, x2 : Int) : Int
   fun _exit(x0 : Int) : NoReturn
   fun execvp(x0 : Char*, x1 : Char**) : Int
   fun fdatasync(fd : Int) : Int
@@ -40,6 +41,7 @@ lib LibC
   fun lockf(x0 : Int, x1 : Int, x2 : OffT) : Int
   fun lseek(x0 : Int, x1 : OffT, x2 : Int) : OffT
   fun pipe(x0 : Int*) : Int
+  fun pipe2(x0 : Int*, flags : Int) : Int
   fun read(x0 : Int, x1 : Void*, x2 : SizeT) : SSizeT
   fun pread(x0 : Int, x1 : Void*, x2 : SizeT, x3 : OffT) : SSizeT
   fun rmdir(x0 : Char*) : Int


### PR DESCRIPTION
We already support for `dup3` when available to set `FD_CLOEXEC` safely... but we were missing LibC bindings, so it wasn't used in practice.

The patch applies the same logic to `IO#reopen`: we prefer `pipe2` over the regular `pipe` to set `FD_CLOEXEC` safely.

Both syscalls aren't standard, but they're widely available (Linux, BSD, but Darwin). The LibC bindings have been added to targets that support them.

Companion to #14672