### PR TITLE
Protect fork/exec on targets that don't support atomic CLOEXEC

### DIFF
--- a/src/crystal/system/unix/process.cr
+++ b/src/crystal/system/unix/process.cr
@@ -2,6 +2,7 @@ require "c/signal"
 require "c/stdlib"
 require "c/sys/resource"
 require "c/unistd"
+require "crystal/rw_lock"
 require "file/error"
 
 struct Crystal::System::Process
@@ -127,6 +128,50 @@ struct Crystal::System::Process
     )
   end
 
+  # The RWLock is trying to protect against file descriptors leaking to
+  # sub-processes.
+  #
+  # There is a race condition in the POSIX standard between the creation of a
+  # file descriptor (`accept`, `dup`, `open`, `pipe`, `socket`) and setting the
+  # `FD_CLOEXEC` flag with `fcntl`. During the time window between those two
+  # syscalls, another thread may fork the process and exec another process,
+  # which will leak the file descriptor to that process.
+  #
+  # Most systems have long implemented non standard syscalls that prevent the
+  # race condition, except for Darwin that implements `O_CLOEXEC` but doesn't
+  # implement `SOCK_CLOEXEC` nor `accept4`, `dup3` or `pipe2`.
+  #
+  # NOTE: there may still be some potential leaks (e.g. calling `accept` on a
+  #       blocking socket).
+  {% if LibC.has_constant?(:SOCK_CLOEXEC) && LibC.has_method?(:accept4) && LibC.has_method?(:dup3) && LibC.has_method?(:pipe2) %}
+    # we don't implement .lock_read so compilation will fail if we need to
+    # support another case, instead of silently skipping the rwlock!
+
+    def self.lock_write(&)
+      yield
+    end
+  {% else %}
+    @@rwlock = Crystal::RWLock.new
+
+    def self.lock_read(&)
+      @@rwlock.read_lock
+      begin
+        yield
+      ensure
+        @@rwlock.read_unlock
+      end
+    end
+
+    def self.lock_write(&)
+      @@rwlock.write_lock
+      begin
+        yield
+      ensure
+        @@rwlock.write_unlock
+      end
+    end
+  {% end %}
+
   def self.fork(*, will_exec = false)
     newmask = uninitialized LibC::SigsetT
     oldmask = uninitialized LibC::SigsetT
@@ -135,7 +180,7 @@ struct Crystal::System::Process
     ret = LibC.pthread_sigmask(LibC::SIG_SETMASK, pointerof(newmask), pointerof(oldmask))
     raise RuntimeError.from_errno("Failed to disable signals") unless ret == 0
 
-    case pid = LibC.fork
+    case pid = lock_write { LibC.fork }
     when 0
       # child:
       pid = nil
@@ -274,7 +319,7 @@ struct Crystal::System::Process
     argv = command_args.map &.check_no_null_byte.to_unsafe
     argv << Pointer(UInt8).null
 
-    LibC.execvp(command, argv)
+    lock_write { LibC.execvp(command, argv) }
   end
 
   def self.replace(command_args, env, clear_env, input, output, error, chdir)

--- a/src/crystal/system/unix/socket.cr
+++ b/src/crystal/system/unix/socket.cr
@@ -9,19 +9,18 @@ module Crystal::System::Socket
   alias Handle = Int32
 
   private def create_handle(family, type, protocol, blocking) : Handle
-    socktype = type.value
     {% if LibC.has_constant?(:SOCK_CLOEXEC) %}
-      socktype |= LibC::SOCK_CLOEXEC
+      fd = LibC.socket(family, type.value | LibC::SOCK_CLOEXEC, protocol)
+      raise ::Socket::Error.from_errno("Failed to create socket") if fd == -1
+      fd
+    {% else %}
+      Process.lock_read do
+        fd = LibC.socket(family, type, protocol)
+        raise ::Socket::Error.from_errno("Failed to create socket") if fd == -1
+        Socket.fcntl(fd, LibC::F_SETFD, LibC::FD_CLOEXEC)
+        fd
+      end
     {% end %}
-
-    fd = LibC.socket(family, socktype, protocol)
-    raise ::Socket::Error.from_errno("Failed to create socket") if fd == -1
-
-    {% unless LibC.has_constant?(:SOCK_CLOEXEC) %}
-      Socket.fcntl(fd, LibC::F_SETFD, LibC::FD_CLOEXEC)
-    {% end %}
-
-    fd
   end
 
   private def initialize_handle(fd)
@@ -181,19 +180,19 @@ module Crystal::System::Socket
 
   def self.socketpair(type : ::Socket::Type, protocol : ::Socket::Protocol) : {Handle, Handle}
     fds = uninitialized Handle[2]
-    socktype = type.value
 
     {% if LibC.has_constant?(:SOCK_CLOEXEC) %}
-      socktype |= LibC::SOCK_CLOEXEC
-    {% end %}
-
-    if LibC.socketpair(::Socket::Family::UNIX, socktype, protocol, fds) != 0
-      raise ::Socket::Error.new("socketpair() failed")
-    end
-
-    {% unless LibC.has_constant?(:SOCK_CLOEXEC) %}
-      fcntl(fds[0], LibC::F_SETFD, LibC::FD_CLOEXEC)
-      fcntl(fds[1], LibC::F_SETFD, LibC::FD_CLOEXEC)
+      if LibC.socketpair(::Socket::Family::UNIX, type.value | LibC::SOCK_CLOEXEC, protocol, fds) == -1
+        raise ::Socket::Error.new("socketpair() failed")
+      end
+    {% else %}
+      Process.lock_read do
+        if LibC.socketpair(::Socket::Family::UNIX, type, protocol, fds) == -1
+          raise ::Socket::Error.new("socketpair() failed")
+        end
+        fcntl(fds[0], LibC::F_SETFD, LibC::FD_CLOEXEC)
+        fcntl(fds[1], LibC::F_SETFD, LibC::FD_CLOEXEC)
+      end
     {% end %}
 
     {fds[0], fds[1]}


### PR DESCRIPTION
In addition to the standard `O_CLOEXEC` flag to `open` (POSIX.1-2008), all modern POSIX systems implement non-standard syscalls (`accept4`, `dup3` and `pipe2`) along with the `SOCK_CLOEXEC` flag, that atomically create file descriptors with the  `FD_CLOEXEC` flag.

A notable exception is Darwin that only implements `O_CLOEXEC`.

We thus have to support falling back to `accept`, `dup2` and `pipe` that won't set `FD_CLOEXEC` or `SOCK_CLOEXEC` atomically, which creates a time window during which another thread may fork the process before `FD_CLOEXEC` is set, which will leak the file descriptor to a child process.

This patch introduces a RWLock to prevent fork/exec in such situations.

**Follow up** of #14672, #14673 and #14675.

**Prior art**: Go does exactly that.