### PR TITLE
Extract system implementation of `UNIXSocket.pair` as `Crystal::System::Socket.socketpair`

### DIFF
--- a/src/crystal/system/socket.cr
+++ b/src/crystal/system/socket.cr
@@ -79,6 +79,8 @@ module Crystal::System::Socket
 
   # def self.fcntl(fd, cmd, arg = 0)
 
+  # def self.socketpair(type, protocol) : {Handle, Handle}
+
   private def system_read(slice : Bytes) : Int32
     event_loop.read(self, slice)
   end

--- a/src/crystal/system/socket.cr
+++ b/src/crystal/system/socket.cr
@@ -79,7 +79,7 @@ module Crystal::System::Socket
 
   # def self.fcntl(fd, cmd, arg = 0)
 
-  # def self.socketpair(type : ::Socket::Type, protocol ::Socket::Protocol) : {Handle, Handle}
+  # def self.socketpair(type : ::Socket::Type, protocol : ::Socket::Protocol) : {Handle, Handle}
 
   private def system_read(slice : Bytes) : Int32
     event_loop.read(self, slice)

--- a/src/crystal/system/socket.cr
+++ b/src/crystal/system/socket.cr
@@ -79,7 +79,7 @@ module Crystal::System::Socket
 
   # def self.fcntl(fd, cmd, arg = 0)
 
-  # def self.socketpair(type, protocol) : {Handle, Handle}
+  # def self.socketpair(type : ::Socket::Type, protocol ::Socket::Protocol) : {Handle, Handle}
 
   private def system_read(slice : Bytes) : Int32
     event_loop.read(self, slice)

--- a/src/crystal/system/unix/socket.cr
+++ b/src/crystal/system/unix/socket.cr
@@ -179,7 +179,7 @@ module Crystal::System::Socket
     r
   end
 
-  def self.socketpair(type, protocol) : {Handle, Handle}
+  def self.socketpair(type : ::Socket::Type, protocol ::Socket::Protocol) : {Handle, Handle}
     fds = uninitialized Handle[2]
     socktype = type.value
 

--- a/src/crystal/system/unix/socket.cr
+++ b/src/crystal/system/unix/socket.cr
@@ -179,7 +179,7 @@ module Crystal::System::Socket
     r
   end
 
-  def self.socketpair(type : ::Socket::Type, protocol ::Socket::Protocol) : {Handle, Handle}
+  def self.socketpair(type : ::Socket::Type, protocol : ::Socket::Protocol) : {Handle, Handle}
     fds = uninitialized Handle[2]
     socktype = type.value
 

--- a/src/crystal/system/wasi/socket.cr
+++ b/src/crystal/system/wasi/socket.cr
@@ -135,7 +135,7 @@ module Crystal::System::Socket
     r
   end
 
-  def self.socketpair(type, protocol) : {Handle, Handle}
+  def self.socketpair(type : ::Socket::Type, protocol ::Socket::Protocol) : {Handle, Handle}
     raise NotImplementedError.new("Crystal::System::Socket.socketpair")
   end
 

--- a/src/crystal/system/wasi/socket.cr
+++ b/src/crystal/system/wasi/socket.cr
@@ -135,7 +135,7 @@ module Crystal::System::Socket
     r
   end
 
-  def self.socketpair(type : ::Socket::Type, protocol ::Socket::Protocol) : {Handle, Handle}
+  def self.socketpair(type : ::Socket::Type, protocol : ::Socket::Protocol) : {Handle, Handle}
     raise NotImplementedError.new("Crystal::System::Socket.socketpair")
   end
 

--- a/src/crystal/system/wasi/socket.cr
+++ b/src/crystal/system/wasi/socket.cr
@@ -135,6 +135,10 @@ module Crystal::System::Socket
     r
   end
 
+  def self.socketpair(type, protocol) : {Handle, Handle}
+    raise NotImplementedError.new("Crystal::System::Socket.socketpair")
+  end
+
   private def system_tty?
     LibC.isatty(fd) == 1
   end

--- a/src/crystal/system/win32/socket.cr
+++ b/src/crystal/system/win32/socket.cr
@@ -363,6 +363,10 @@ module Crystal::System::Socket
     raise NotImplementedError.new "Crystal::System::Socket.fcntl"
   end
 
+  def self.socketpair(type, protocol) : {Handle, Handle}
+    raise NotImplementedError.new("Crystal::System::Socket.socketpair")
+  end
+
   private def system_tty?
     LibC.GetConsoleMode(LibC::HANDLE.new(fd), out _) != 0
   end

--- a/src/crystal/system/win32/socket.cr
+++ b/src/crystal/system/win32/socket.cr
@@ -363,7 +363,7 @@ module Crystal::System::Socket
     raise NotImplementedError.new "Crystal::System::Socket.fcntl"
   end
 
-  def self.socketpair(type : ::Socket::Type, protocol ::Socket::Protocol) : {Handle, Handle}
+  def self.socketpair(type : ::Socket::Type, protocol : ::Socket::Protocol) : {Handle, Handle}
     raise NotImplementedError.new("Crystal::System::Socket.socketpair")
   end
 

--- a/src/crystal/system/win32/socket.cr
+++ b/src/crystal/system/win32/socket.cr
@@ -363,7 +363,7 @@ module Crystal::System::Socket
     raise NotImplementedError.new "Crystal::System::Socket.fcntl"
   end
 
-  def self.socketpair(type, protocol) : {Handle, Handle}
+  def self.socketpair(type : ::Socket::Type, protocol ::Socket::Protocol) : {Handle, Handle}
     raise NotImplementedError.new("Crystal::System::Socket.socketpair")
   end
 

--- a/src/socket/unix_socket.cr
+++ b/src/socket/unix_socket.cr
@@ -68,8 +68,9 @@ class UNIXSocket < Socket
   # left.gets # => "message"
   # ```
   def self.pair(type : Type = Type::STREAM) : {UNIXSocket, UNIXSocket}
-    fds = Crystal::System::Socket.socketpair(type, Protocol::IP)
-    {UNIXSocket.new(fd: fds[0], type: type), UNIXSocket.new(fd: fds[1], type: type)}
+    Crystal::System::Socket
+      .socketpair(type, Protocol::IP)
+      .map { |fd| UNIXSocket.new(fd: fd, type: type) }
   end
 
   # Creates a pair of unnamed UNIX sockets (see `pair`) and yields them to the

--- a/src/socket/unix_socket.cr
+++ b/src/socket/unix_socket.cr
@@ -68,7 +68,7 @@ class UNIXSocket < Socket
   # left.gets # => "message"
   # ```
   def self.pair(type : Type = Type::STREAM) : {UNIXSocket, UNIXSocket}
-    fds = Crystal::System::Socket.socketpair(type, protocol: 0)
+    fds = Crystal::System::Socket.socketpair(type, protocol: Protocol::IP)
     {UNIXSocket.new(fd: fds[0], type: type), UNIXSocket.new(fd: fds[1], type: type)}
   end
 

--- a/src/socket/unix_socket.cr
+++ b/src/socket/unix_socket.cr
@@ -68,7 +68,7 @@ class UNIXSocket < Socket
   # left.gets # => "message"
   # ```
   def self.pair(type : Type = Type::STREAM) : {UNIXSocket, UNIXSocket}
-    fds = Crystal::System::Socket.socketpair(type, protocol: Protocol::IP)
+    fds = Crystal::System::Socket.socketpair(type, Protocol::IP)
     {UNIXSocket.new(fd: fds[0], type: type), UNIXSocket.new(fd: fds[1], type: type)}
   end
 


### PR DESCRIPTION
The implementation screamed to be extracted into Crystal::System::Socket.

Follow up to #14672.