### PR TITLE
Optimize non-atomic memory allocation

### DIFF
--- a/src/compiler/crystal/codegen/codegen.cr
+++ b/src/compiler/crystal/codegen/codegen.cr
@@ -2146,11 +2146,23 @@ module Crystal
     end
 
     def calloc(type)
-      generic_malloc(type) { crystal_calloc_fun }
+      if crystal_calloc_fun
+        generic_malloc(type) { crystal_calloc_fun }
+      else
+        ptr = malloc(type)
+        memset ptr, int8(0), size_t(type.size)
+        ptr
+      end
     end
 
     def calloc_atomic(type)
-      generic_malloc(type) { crystal_calloc_atomic_fun }
+      if crystal_calloc_atomic_fun
+        generic_malloc(type) { crystal_calloc_atomic_fun }
+      else
+        ptr = malloc_atomic(type)
+        memset ptr, int8(0), size_t(type.size)
+        ptr
+      end
     end
 
     def generic_malloc(type, &)
@@ -2174,11 +2186,25 @@ module Crystal
     end
 
     def array_calloc(type, count)
-      generic_array_malloc(type, count) { crystal_calloc_fun }
+      if crystal_calloc_fun
+        generic_array_malloc(type, count) { crystal_calloc_fun }
+      else
+        size = builder.mul type.size, count
+        ptr = array_malloc(type, count)
+        memset ptr, int8(0), size_t(size)
+        ptr
+      end
     end
 
     def array_calloc_atomic(type, count)
-      generic_array_malloc(type, count) { crystal_calloc_atomic_fun }
+      if crystal_calloc_atomic_fun
+        generic_array_malloc(type, count) { crystal_calloc_atomic_fun }
+      else
+        size = builder.mul type.size, count
+        ptr = array_malloc_atomic(type, count)
+        memset ptr, int8(0), size_t(size)
+        ptr
+      end
     end
 
     def generic_array_malloc(type, count, &)

--- a/src/compiler/crystal/codegen/codegen.cr
+++ b/src/compiler/crystal/codegen/codegen.cr
@@ -9,6 +9,8 @@ module Crystal
   MAIN_NAME           = "__crystal_main"
   RAISE_NAME          = "__crystal_raise"
   RAISE_OVERFLOW_NAME = "__crystal_raise_overflow"
+  CALLOC_NAME         = "__crystal_calloc64"
+  CALLOC_ATOMIC_NAME  = "__crystal_calloc_atomic64"
   MALLOC_NAME         = "__crystal_malloc64"
   MALLOC_ATOMIC_NAME  = "__crystal_malloc_atomic64"
   REALLOC_NAME        = "__crystal_realloc64"
@@ -187,6 +189,8 @@ module Crystal
 
     @malloc_fun : LLVMTypedFunction?
     @malloc_atomic_fun : LLVMTypedFunction?
+    @calloc_fun : LLVMTypedFunction?
+    @calloc_atomic_fun : LLVMTypedFunction?
     @realloc_fun : LLVMTypedFunction?
     @raise_overflow_fun : LLVMTypedFunction?
     @c_malloc_fun : LLVMTypedFunction?
@@ -364,9 +368,8 @@ module Crystal
 
       def visit(node : FunDef)
         case node.name
-        when MALLOC_NAME, MALLOC_ATOMIC_NAME, REALLOC_NAME, RAISE_NAME,
-             @codegen.personality_name, GET_EXCEPTION_NAME, RAISE_OVERFLOW_NAME,
-             ONCE_INIT, ONCE
+        when MALLOC_NAME, MALLOC_ATOMIC_NAME, CALLOC_NAME, CALLOC_ATOMIC_NAME, REALLOC_NAME, RAISE_NAME,
+             @codegen.personality_name, GET_EXCEPTION_NAME, RAISE_OVERFLOW_NAME, ONCE_INIT, ONCE
           @codegen.accept node
         end
 
@@ -2066,12 +2069,13 @@ module Crystal
       struct_type = llvm_struct_type(type)
       if type.passed_by_value?
         type_ptr = alloca struct_type
+        memset type_ptr, int8(0), size_t(struct_type.size)
       else
         if type.is_a?(InstanceVarContainer) && !type.struct? &&
            type.all_instance_vars.each_value.any? &.type.has_inner_pointers?
-          type_ptr = malloc struct_type
+          type_ptr = calloc struct_type
         else
-          type_ptr = malloc_atomic struct_type
+          type_ptr = calloc_atomic struct_type
         end
       end
 
@@ -2079,7 +2083,6 @@ module Crystal
     end
 
     def pre_initialize_aggregate(type, struct_type, ptr)
-      memset ptr, int8(0), size_t(struct_type.size)
       run_instance_vars_initializers(type, type, ptr)
 
       unless type.struct?
@@ -2142,6 +2145,14 @@ module Crystal
       generic_malloc(type) { crystal_malloc_atomic_fun }
     end
 
+    def calloc(type)
+      generic_malloc(type) { crystal_calloc_fun }
+    end
+
+    def calloc_atomic(type)
+      generic_malloc(type) { crystal_calloc_atomic_fun }
+    end
+
     def generic_malloc(type, &)
       size = type.size
 
@@ -2162,6 +2173,14 @@ module Crystal
       generic_array_malloc(type, count) { crystal_malloc_atomic_fun }
     end
 
+    def array_calloc(type, count)
+      generic_array_malloc(type, count) { crystal_calloc_fun }
+    end
+
+    def array_calloc_atomic(type, count)
+      generic_array_malloc(type, count) { crystal_calloc_atomic_fun }
+    end
+
     def generic_array_malloc(type, count, &)
       size = builder.mul type.size, count
 
@@ -2171,7 +2190,6 @@ module Crystal
         pointer = call c_malloc_fun, size_t(size)
       end
 
-      memset pointer, int8(0), size_t(size)
       pointer_cast pointer, type.pointer
     end
 
@@ -2188,6 +2206,24 @@ module Crystal
       @malloc_atomic_fun ||= typed_fun?(@main_mod, MALLOC_ATOMIC_NAME)
       if malloc_fun = @malloc_atomic_fun
         check_main_fun MALLOC_ATOMIC_NAME, malloc_fun
+      else
+        nil
+      end
+    end
+
+    def crystal_calloc_fun
+      @calloc_fun ||= typed_fun?(@main_mod, CALLOC_NAME)
+      if malloc_fun = @calloc_fun
+        check_main_fun CALLOC_NAME, malloc_fun
+      else
+        nil
+      end
+    end
+
+    def crystal_calloc_atomic_fun
+      @calloc_atomic_fun ||= typed_fun?(@main_mod, CALLOC_ATOMIC_NAME)
+      if malloc_fun = @calloc_atomic_fun
+        check_main_fun CALLOC_ATOMIC_NAME, malloc_fun
       else
         nil
       end

--- a/src/compiler/crystal/codegen/primitives.cr
+++ b/src/compiler/crystal/codegen/primitives.cr
@@ -748,9 +748,11 @@ class Crystal::CodeGenVisitor
     type = node.type
 
     base_type = type.is_a?(VirtualType) ? type.base_type : type
+    struct_type = llvm_struct_type(base_type)
 
     ptr = call_args[target_def.owner.passed_as_self? ? 1 : 0]
-    pre_initialize_aggregate base_type, llvm_struct_type(base_type), ptr
+    memset ptr, int8(0), size_t(struct_type.size)
+    pre_initialize_aggregate base_type, struct_type, ptr
 
     @last = cast_to ptr, type
   end
@@ -765,9 +767,9 @@ class Crystal::CodeGenVisitor
     end
 
     if type.element_type.has_inner_pointers?
-      last = array_malloc(llvm_type, call_args[1])
+      last = array_calloc(llvm_type, call_args[1])
     else
-      last = array_malloc_atomic(llvm_type, call_args[1])
+      last = array_calloc_atomic(llvm_type, call_args[1])
     end
 
     if @debug.line_numbers?

--- a/src/gc.cr
+++ b/src/gc.cr
@@ -36,6 +36,28 @@ fun __crystal_malloc_atomic64(size : UInt64) : Void*
 end
 
 # :nodoc:
+fun __crystal_calloc64(size : UInt64) : Void*
+  {% if flag?(:bits32) %}
+    if size > UInt32::MAX
+      raise ArgumentError.new("Given size is bigger than UInt32::MAX")
+    end
+  {% end %}
+
+  GC.calloc(LibC::SizeT.new(size))
+end
+
+# :nodoc:
+fun __crystal_calloc_atomic64(size : UInt64) : Void*
+  {% if flag?(:bits32) %}
+    if size > UInt32::MAX
+      raise ArgumentError.new("Given size is bigger than UInt32::MAX")
+    end
+  {% end %}
+
+  GC.calloc_atomic(LibC::SizeT.new(size))
+end
+
+# :nodoc:
 fun __crystal_realloc64(ptr : Void*, size : UInt64) : Void*
   {% if flag?(:bits32) %}
     if size > UInt32::MAX
@@ -70,7 +92,8 @@ module GC
     expl_freed_bytes_since_gc : UInt64,
     obtained_from_os_bytes : UInt64
 
-  # Allocates and clears *size* bytes of memory.
+  # Allocates *size* bytes of memory.
+  # The returned memory may or may not be cleared.
   #
   # The resulting object may contain pointers and they will be tracked by the GC.
   #
@@ -80,12 +103,31 @@ module GC
   end
 
   # Allocates *size* bytes of pointer-free memory.
+  # The returned memory may or may not be cleared.
   #
   # The client promises that the resulting object will never contain any pointers.
   #
   # The memory is not cleared. It will be automatically deallocated when unreferenced.
   def self.malloc_atomic(size : Int) : Void*
     malloc_atomic(LibC::SizeT.new(size))
+  end
+
+  # Allocates and clears *size* bytes of memory.
+  #
+  # The resulting object may contain pointers and they will be tracked by the GC.
+  #
+  # The memory will be automatically deallocated when unreferenced.
+  def self.calloc(size : Int) : Void*
+    calloc(LibC::SizeT.new(size))
+  end
+
+  # Allocates and clears *size* bytes of pointer-free memory.
+  #
+  # The client promises that the resulting object will never contain any pointers.
+  #
+  # The memory is not cleared. It will be automatically deallocated when unreferenced.
+  def self.calloc_atomic(size : Int) : Void*
+    calloc_atomic(LibC::SizeT.new(size))
   end
 
   # Changes the allocated memory size of *pointer* to *size*.

--- a/src/gc/boehm.cr
+++ b/src/gc/boehm.cr
@@ -153,6 +153,18 @@ module GC
   end
 
   # :nodoc:
+  def self.calloc(size : LibC::SizeT) : Void*
+    LibGC.malloc(size)
+  end
+
+  # :nodoc:
+  def self.calloc_atomic(size : LibC::SizeT) : Void*
+    ptr = LibGC.malloc_atomic(size)
+    ptr.clear(size)
+    ptr
+  end
+
+  # :nodoc:
   def self.realloc(ptr : Void*, size : LibC::SizeT) : Void*
     LibGC.realloc(ptr, size)
   end

--- a/src/gc/none.cr
+++ b/src/gc/none.cr
@@ -17,6 +17,19 @@ module GC
   end
 
   # :nodoc:
+  def self.calloc(size : LibC::SizeT) : Void*
+    # Using `LibC.calloc` would be more efficient, but that is currently not defined.
+    ptr = LibC.malloc(size)
+    ptr.clear(size)
+    ptr
+  end
+
+  # :nodoc:
+  def self.calloc_atomic(size : LibC::SizeT) : Void*
+    calloc(size)
+  end
+
+  # :nodoc:
   def self.realloc(pointer : Void*, size : LibC::SizeT) : Void*
     LibC.realloc(pointer, size)
   end

--- a/src/primitives.cr
+++ b/src/primitives.cr
@@ -205,15 +205,15 @@ struct Pointer(T)
   # ptr[9] # => 0
   # ```
   #
-  # The implementation uses `GC.malloc` if the compiler is aware that the
+  # The implementation uses `GC.calloc` if the compiler is aware that the
   # allocated type contains inner address pointers. Otherwise it uses
-  # `GC.malloc_atomic`. Primitive types are expected to not contain pointers,
+  # `GC.calloc_atomic`. Primitive types are expected to not contain pointers,
   # except `Void`. `Proc` and `Pointer` are expected to contain pointers.
   # For unions, structs and collection types (tuples, static array)
   # it depends on the contained types. All other types, including classes are
   # expected to contain inner address pointers.
   #
-  # To override this implicit behaviour, `GC.malloc` and `GC.malloc_atomic`
+  # To override this implicit behaviour, `GC.calloc` and `GC.calloc_atomic`
   # can be used directly instead.
   @[Primitive(:pointer_malloc)]
   def self.malloc(size : UInt64)


### PR DESCRIPTION
Closes #14677
Closes #14678

This PR adds two new well-known functions used in the compiler:
- `__crystal_calloc64`
- `__crystal_calloc_atomic64`

These functions are analogues to `__crystal_malloc64` and `__crystal_malloc_atomic64`, but they guarantee that any memory allocated using them is cleared.
This can be used as an optimization as crystal mustn't clear this memory as required with memory allocated using the `malloc` versions.

If the `__crystal_calloc*` functions cannot be found, the old behaviour is used.

Additionally, two new `GC` methods `calloc` and `calloc_atomic` have been added with the same behaviour.

The description of the  `GC` method `malloc` (which clears memory in bdwgc and doesn't clear memory with no GC) has been updated to reflech that it does *not* always clear any memory. Unless the underlying GC is changed, this is not a breaking change.

---

In the case of bdwgc, only non-atomic memory allocations got faster.

Code:
```cr
require "benchmark"

Benchmark.ips(calculation: 60) do |x|
  x.report("malloc") { Pointer(String).malloc(1) }
end

Benchmark.ips(calculation: 60) do |x|
  x.report("malloc") { Pointer(String).malloc(2 ** 10) }
end

Benchmark.ips(calculation: 60) do |x|
  x.report("malloc") { Pointer(String).malloc(2 ** 24) }
end
```

Results:
|Bytesize | Before | After |
|-|-|-|
| 8B | 8.02ns | 7.35ns |
| 8KiB | 824.02ns | 746.20ns |
| 128MiB | 23.44ms | 11.84ms |

As can be seen from these results, large memory allocations profit a lot while small memory allocations only see a small improvement.
Also, it may be interesting to see how often LLVM can remove the memset completely.

More advanced benchmarks must still be done.
