### PR TITLE
Remove calls to `Pointer.new(Int)`

### DIFF
--- a/src/crystal/system/win32/thread_mutex.cr
+++ b/src/crystal/system/win32/thread_mutex.cr
@@ -37,7 +37,7 @@ class Thread
     def unlock : Nil
       # `owningThread` is declared as `LibC::HANDLE` for historical reasons, so
       # the following comparison is correct
-      unless @cs.owningThread == LibC::HANDLE.new(LibC.GetCurrentThreadId)
+      unless @cs.owningThread == LibC::HANDLE.new(LibC.GetCurrentThreadId.to_u64!)
         raise RuntimeError.new "Attempt to unlock a mutex locked by another thread"
       end
       LibC.LeaveCriticalSection(self)

--- a/src/crystal/tracing.cr
+++ b/src/crystal/tracing.cr
@@ -141,7 +141,7 @@ module Crystal
         {% if flag?(:win32) %}
           handle = LibC.CreateFileW(filename, LibC::FILE_GENERIC_WRITE, LibC::DEFAULT_SHARE_MODE, nil, LibC::CREATE_ALWAYS, LibC::FILE_ATTRIBUTE_NORMAL, LibC::HANDLE.null)
           # not using LibC::INVALID_HANDLE_VALUE because it doesn't exist (yet)
-          return handle.address unless handle == LibC::HANDLE.new(-1)
+          return handle.address unless handle == LibC::HANDLE.new(-1.to_u64!)
 
           error = uninitialized UInt16[256]
           len = LibC.FormatMessageW(LibC::FORMAT_MESSAGE_FROM_SYSTEM, nil, WinError.value, 0, error, error.size, nil)

--- a/src/lib_c/aarch64-android/c/sys/mman.cr
+++ b/src/lib_c/aarch64-android/c/sys/mman.cr
@@ -10,7 +10,7 @@ lib LibC
   MAP_SHARED            = 0x01
   MAP_ANON              = LibC::MAP_ANONYMOUS
   MAP_ANONYMOUS         = 0x20
-  MAP_FAILED            = Pointer(Void).new(-1)
+  MAP_FAILED            = Pointer(Void).new(-1.to_u64!)
   POSIX_MADV_DONTNEED   =  4
   POSIX_MADV_NORMAL     =  0
   POSIX_MADV_RANDOM     =  1

--- a/src/lib_c/aarch64-darwin/c/dlfcn.cr
+++ b/src/lib_c/aarch64-darwin/c/dlfcn.cr
@@ -4,7 +4,7 @@ lib LibC
   RTLD_GLOBAL  = 0x8
   RTLD_LOCAL   = 0x4
   RTLD_DEFAULT = Pointer(Void).new(-2)
-  RTLD_NEXT    = Pointer(Void).new(-1)
+  RTLD_NEXT    = Pointer(Void).new(-1.to_u64!)
 
   struct DlInfo
     dli_fname : Char*

--- a/src/lib_c/aarch64-darwin/c/sys/mman.cr
+++ b/src/lib_c/aarch64-darwin/c/sys/mman.cr
@@ -9,7 +9,7 @@ lib LibC
   MAP_PRIVATE           = 0x0002
   MAP_SHARED            = 0x0001
   MAP_ANON              = 0x1000
-  MAP_FAILED            = Pointer(Void).new(-1)
+  MAP_FAILED            = Pointer(Void).new(-1.to_u64!)
   POSIX_MADV_DONTNEED   = 4
   POSIX_MADV_NORMAL     = 0
   POSIX_MADV_RANDOM     = 1

--- a/src/lib_c/aarch64-linux-gnu/c/sys/mman.cr
+++ b/src/lib_c/aarch64-linux-gnu/c/sys/mman.cr
@@ -10,7 +10,7 @@ lib LibC
   MAP_SHARED            = 0x01
   MAP_ANON              = LibC::MAP_ANONYMOUS
   MAP_ANONYMOUS         = 0x20
-  MAP_FAILED            = Pointer(Void).new(-1)
+  MAP_FAILED            = Pointer(Void).new(-1.to_u64!)
   POSIX_MADV_DONTNEED   =  4
   POSIX_MADV_NORMAL     =  0
   POSIX_MADV_RANDOM     =  1

--- a/src/lib_c/aarch64-linux-musl/c/dlfcn.cr
+++ b/src/lib_c/aarch64-linux-musl/c/dlfcn.cr
@@ -4,7 +4,7 @@ lib LibC
   RTLD_GLOBAL  = 256
   RTLD_LOCAL   =   0
   RTLD_DEFAULT = Pointer(Void).new(0)
-  RTLD_NEXT    = Pointer(Void).new(-1)
+  RTLD_NEXT    = Pointer(Void).new(-1.to_u64!)
 
   struct DlInfo
     dli_fname : Char*

--- a/src/lib_c/aarch64-linux-musl/c/sys/mman.cr
+++ b/src/lib_c/aarch64-linux-musl/c/sys/mman.cr
@@ -10,7 +10,7 @@ lib LibC
   MAP_SHARED            = 0x01
   MAP_ANON              = 0x20
   MAP_ANONYMOUS         = LibC::MAP_ANON
-  MAP_FAILED            = Pointer(Void).new(-1)
+  MAP_FAILED            = Pointer(Void).new(-1.to_u64!)
   POSIX_MADV_DONTNEED   =  0
   POSIX_MADV_NORMAL     =  0
   POSIX_MADV_RANDOM     =  1

--- a/src/lib_c/arm-linux-gnueabihf/c/sys/mman.cr
+++ b/src/lib_c/arm-linux-gnueabihf/c/sys/mman.cr
@@ -10,7 +10,7 @@ lib LibC
   MAP_SHARED            = 0x01
   MAP_ANON              = LibC::MAP_ANONYMOUS
   MAP_ANONYMOUS         = 0x20
-  MAP_FAILED            = Pointer(Void).new(-1)
+  MAP_FAILED            = Pointer(Void).new(-1.to_u64!)
   POSIX_MADV_DONTNEED   =  4
   POSIX_MADV_NORMAL     =  0
   POSIX_MADV_RANDOM     =  1

--- a/src/lib_c/i386-linux-gnu/c/sys/mman.cr
+++ b/src/lib_c/i386-linux-gnu/c/sys/mman.cr
@@ -10,7 +10,7 @@ lib LibC
   MAP_SHARED            = 0x01
   MAP_ANON              = LibC::MAP_ANONYMOUS
   MAP_ANONYMOUS         = 0x20
-  MAP_FAILED            = Pointer(Void).new(-1)
+  MAP_FAILED            = Pointer(Void).new(-1.to_u64!)
   POSIX_MADV_DONTNEED   =  4
   POSIX_MADV_NORMAL     =  0
   POSIX_MADV_RANDOM     =  1

--- a/src/lib_c/i386-linux-musl/c/dlfcn.cr
+++ b/src/lib_c/i386-linux-musl/c/dlfcn.cr
@@ -4,7 +4,7 @@ lib LibC
   RTLD_GLOBAL  = 256
   RTLD_LOCAL   =   0
   RTLD_DEFAULT = Pointer(Void).new(0)
-  RTLD_NEXT    = Pointer(Void).new(-1)
+  RTLD_NEXT    = Pointer(Void).new(-1.to_u64!)
 
   struct DlInfo
     dli_fname : Char*

--- a/src/lib_c/i386-linux-musl/c/sys/mman.cr
+++ b/src/lib_c/i386-linux-musl/c/sys/mman.cr
@@ -10,7 +10,7 @@ lib LibC
   MAP_SHARED            = 0x01
   MAP_ANON              = 0x20
   MAP_ANONYMOUS         = LibC::MAP_ANON
-  MAP_FAILED            = Pointer(Void).new(-1)
+  MAP_FAILED            = Pointer(Void).new(-1.to_u64!)
   POSIX_MADV_DONTNEED   =  0
   POSIX_MADV_NORMAL     =  0
   POSIX_MADV_RANDOM     =  1

--- a/src/lib_c/x86_64-darwin/c/dlfcn.cr
+++ b/src/lib_c/x86_64-darwin/c/dlfcn.cr
@@ -4,7 +4,7 @@ lib LibC
   RTLD_GLOBAL  = 0x8
   RTLD_LOCAL   = 0x4
   RTLD_DEFAULT = Pointer(Void).new(-2)
-  RTLD_NEXT    = Pointer(Void).new(-1)
+  RTLD_NEXT    = Pointer(Void).new(-1.to_u64!)
 
   struct DlInfo
     dli_fname : Char*

--- a/src/lib_c/x86_64-darwin/c/sys/mman.cr
+++ b/src/lib_c/x86_64-darwin/c/sys/mman.cr
@@ -10,7 +10,7 @@ lib LibC
   MAP_SHARED            = 0x0001
   MAP_ANON              = 0x1000
   MAP_ANONYMOUS         = LibC::MAP_ANON
-  MAP_FAILED            = Pointer(Void).new(-1)
+  MAP_FAILED            = Pointer(Void).new(-1.to_u64!)
   POSIX_MADV_DONTNEED   = 4
   POSIX_MADV_NORMAL     = 0
   POSIX_MADV_RANDOM     = 1

--- a/src/lib_c/x86_64-dragonfly/c/dlfcn.cr
+++ b/src/lib_c/x86_64-dragonfly/c/dlfcn.cr
@@ -4,7 +4,7 @@ lib LibC
   RTLD_GLOBAL  = 0x100
   RTLD_LOCAL   =     0
   RTLD_DEFAULT = Pointer(Void).new(-2)
-  RTLD_NEXT    = Pointer(Void).new(-1)
+  RTLD_NEXT    = Pointer(Void).new(-1.to_u64!)
 
   struct DlInfo
     dli_fname : Char*

--- a/src/lib_c/x86_64-dragonfly/c/sys/mman.cr
+++ b/src/lib_c/x86_64-dragonfly/c/sys/mman.cr
@@ -10,7 +10,7 @@ lib LibC
   MAP_SHARED            = 0x0001
   MAP_ANON              = 0x1000
   MAP_ANONYMOUS         = LibC::MAP_ANON
-  MAP_FAILED            = Pointer(Void).new(-1)
+  MAP_FAILED            = Pointer(Void).new(-1.to_u64!)
   POSIX_MADV_NORMAL     = LibC::MADV_NORMAL
   POSIX_MADV_RANDOM     = LibC::MADV_RANDOM
   POSIX_MADV_SEQUENTIAL = LibC::MADV_SEQUENTIAL

--- a/src/lib_c/x86_64-freebsd/c/dlfcn.cr
+++ b/src/lib_c/x86_64-freebsd/c/dlfcn.cr
@@ -4,7 +4,7 @@ lib LibC
   RTLD_GLOBAL  = 0x100
   RTLD_LOCAL   =     0
   RTLD_DEFAULT = Pointer(Void).new(-2)
-  RTLD_NEXT    = Pointer(Void).new(-1)
+  RTLD_NEXT    = Pointer(Void).new(-1.to_u64!)
 
   struct DlInfo
     dli_fname : Char*

--- a/src/lib_c/x86_64-freebsd/c/sys/mman.cr
+++ b/src/lib_c/x86_64-freebsd/c/sys/mman.cr
@@ -10,7 +10,7 @@ lib LibC
   MAP_SHARED            = 0x0001
   MAP_ANON              = 0x1000
   MAP_ANONYMOUS         = LibC::MAP_ANON
-  MAP_FAILED            = Pointer(Void).new(-1)
+  MAP_FAILED            = Pointer(Void).new(-1.to_u64!)
   POSIX_MADV_DONTNEED   = 4
   POSIX_MADV_NORMAL     = 0
   POSIX_MADV_RANDOM     = 1

--- a/src/lib_c/x86_64-linux-gnu/c/sys/mman.cr
+++ b/src/lib_c/x86_64-linux-gnu/c/sys/mman.cr
@@ -10,7 +10,7 @@ lib LibC
   MAP_SHARED            = 0x01
   MAP_ANON              = LibC::MAP_ANONYMOUS
   MAP_ANONYMOUS         = 0x20
-  MAP_FAILED            = Pointer(Void).new(-1)
+  MAP_FAILED            = Pointer(Void).new(-1.to_u64!)
   POSIX_MADV_DONTNEED   =  4
   POSIX_MADV_NORMAL     =  0
   POSIX_MADV_RANDOM     =  1

--- a/src/lib_c/x86_64-linux-musl/c/dlfcn.cr
+++ b/src/lib_c/x86_64-linux-musl/c/dlfcn.cr
@@ -4,7 +4,7 @@ lib LibC
   RTLD_GLOBAL  = 256
   RTLD_LOCAL   =   0
   RTLD_DEFAULT = Pointer(Void).new(0)
-  RTLD_NEXT    = Pointer(Void).new(-1)
+  RTLD_NEXT    = Pointer(Void).new(-1.to_u64!)
 
   struct DlInfo
     dli_fname : Char*

--- a/src/lib_c/x86_64-linux-musl/c/sys/mman.cr
+++ b/src/lib_c/x86_64-linux-musl/c/sys/mman.cr
@@ -10,7 +10,7 @@ lib LibC
   MAP_SHARED            = 0x01
   MAP_ANON              = 0x20
   MAP_ANONYMOUS         = LibC::MAP_ANON
-  MAP_FAILED            = Pointer(Void).new(-1)
+  MAP_FAILED            = Pointer(Void).new(-1.to_u64!)
   POSIX_MADV_DONTNEED   =  0
   POSIX_MADV_NORMAL     =  0
   POSIX_MADV_RANDOM     =  1

--- a/src/lib_c/x86_64-netbsd/c/dlfcn.cr
+++ b/src/lib_c/x86_64-netbsd/c/dlfcn.cr
@@ -3,7 +3,7 @@ lib LibC
   RTLD_NOW     =     2
   RTLD_GLOBAL  = 0x100
   RTLD_LOCAL   = 0x200
-  RTLD_NEXT    = Pointer(Void).new(-1)
+  RTLD_NEXT    = Pointer(Void).new(-1.to_u64!)
   RTLD_DEFAULT = Pointer(Void).new(-2)
 
   struct DlInfo

--- a/src/lib_c/x86_64-netbsd/c/sys/mman.cr
+++ b/src/lib_c/x86_64-netbsd/c/sys/mman.cr
@@ -10,7 +10,7 @@ lib LibC
   MAP_FIXED             = 0x0010
   MAP_ANON              = 0x1000
   MAP_ANONYMOUS         = LibC::MAP_ANON
-  MAP_FAILED            = Pointer(Void).new(-1)
+  MAP_FAILED            = Pointer(Void).new(-1.to_u64!)
   MAP_STACK             = 0x2000
   POSIX_MADV_NORMAL     =      0
   POSIX_MADV_RANDOM     =      1

--- a/src/lib_c/x86_64-openbsd/c/dlfcn.cr
+++ b/src/lib_c/x86_64-openbsd/c/dlfcn.cr
@@ -4,7 +4,7 @@ lib LibC
   RTLD_GLOBAL  = 0x100
   RTLD_LOCAL   = 0x000
   RTLD_DEFAULT = Pointer(Void).new(-2)
-  RTLD_NEXT    = Pointer(Void).new(-1)
+  RTLD_NEXT    = Pointer(Void).new(-1.to_u64!)
 
   struct DlInfo
     dli_fname : Char*

--- a/src/lib_c/x86_64-openbsd/c/sys/mman.cr
+++ b/src/lib_c/x86_64-openbsd/c/sys/mman.cr
@@ -10,7 +10,7 @@ lib LibC
   MAP_SHARED            = 0x0001
   MAP_ANON              = 0x1000
   MAP_ANONYMOUS         = LibC::MAP_ANON
-  MAP_FAILED            = Pointer(Void).new(-1)
+  MAP_FAILED            = Pointer(Void).new(-1.to_u64!)
   MAP_STACK             = 0x4000
   POSIX_MADV_DONTNEED   =      4
   POSIX_MADV_NORMAL     =      0

--- a/src/lib_c/x86_64-solaris/c/dlfcn.cr
+++ b/src/lib_c/x86_64-solaris/c/dlfcn.cr
@@ -4,7 +4,7 @@ lib LibC
   RTLD_GLOBAL  = 0x00100
   RTLD_LOCAL   = 0x00000
   RTLD_DEFAULT = Pointer(Void).new(-2)
-  RTLD_NEXT    = Pointer(Void).new(-1)
+  RTLD_NEXT    = Pointer(Void).new(-1.to_u64!)
 
   struct DlInfo
     dli_fname : Char*

--- a/src/lib_c/x86_64-solaris/c/sys/mman.cr
+++ b/src/lib_c/x86_64-solaris/c/sys/mman.cr
@@ -12,7 +12,7 @@ lib LibC
   MAP_ANON      = 0x100
   MAP_ANONYMOUS = LibC::MAP_ANON
 
-  MAP_FAILED = Pointer(Void).new(-1)
+  MAP_FAILED = Pointer(Void).new(-1.to_u64!)
 
   POSIX_MADV_DONTNEED   = 4
   POSIX_MADV_NORMAL     = 0

--- a/src/lib_c/x86_64-windows-msvc/c/handleapi.cr
+++ b/src/lib_c/x86_64-windows-msvc/c/handleapi.cr
@@ -1,7 +1,7 @@
 require "c/winnt"
 
 lib LibC
-  INVALID_HANDLE_VALUE = HANDLE.new(-1)
+  INVALID_HANDLE_VALUE = HANDLE.new(-1.to_u64!)
 
   fun CloseHandle(hObject : HANDLE) : BOOL
 

--- a/src/lib_c/x86_64-windows-msvc/c/winreg.cr
+++ b/src/lib_c/x86_64-windows-msvc/c/winreg.cr
@@ -18,13 +18,13 @@ lib LibC
     QWORD_LITTLE_ENDIAN        = QWORD
   end
 
-  HKEY_CLASSES_ROOT     = Pointer(Void).new(0x80000000).as(HKEY)
-  HKEY_CURRENT_USER     = Pointer(Void).new(0x80000001).as(HKEY)
-  HKEY_LOCAL_MACHINE    = Pointer(Void).new(0x80000002).as(HKEY)
-  HKEY_USERS            = Pointer(Void).new(0x80000003).as(HKEY)
-  HKEY_PERFORMANCE_DATA = Pointer(Void).new(0x80000004).as(HKEY)
-  HKEY_CURRENT_CONFIG   = Pointer(Void).new(0x80000005).as(HKEY)
-  HKEY_DYN_DATA         = Pointer(Void).new(0x8000006).as(HKEY)
+  HKEY_CLASSES_ROOT     = Pointer(Void).new(0x80000000_u64).as(HKEY)
+  HKEY_CURRENT_USER     = Pointer(Void).new(0x80000001_u64).as(HKEY)
+  HKEY_LOCAL_MACHINE    = Pointer(Void).new(0x80000002_u64).as(HKEY)
+  HKEY_USERS            = Pointer(Void).new(0x80000003_u64).as(HKEY)
+  HKEY_PERFORMANCE_DATA = Pointer(Void).new(0x80000004_u64).as(HKEY)
+  HKEY_CURRENT_CONFIG   = Pointer(Void).new(0x80000005_u64).as(HKEY)
+  HKEY_DYN_DATA         = Pointer(Void).new(0x8000006_u64).as(HKEY)
 
   fun RegOpenKeyExW(hKey : HKEY, lpSubKey : LPWSTR, ulOptions : DWORD, samDesired : REGSAM, phkResult : HKEY*) : LSTATUS
   fun RegCloseKey(hKey : HKEY) : LSTATUS


### PR DESCRIPTION
This is a preparatory step to dropping the overload `Pointer.new(Int)` (#14669). It replaces all calls to this overloads with explicit casts to `UInt64` at the call site, which ends up resolving to the main overload `Pointer.new(UInt64)`.