### PR TITLE
Replace calls to `StaticArray(UInt8, 1)#unsafe_as(UInt8)`

### DIFF
--- a/src/crystal/system/unix/getrandom.cr
+++ b/src/crystal/system/unix/getrandom.cr
@@ -64,7 +64,7 @@ module Crystal::System::Random
     if @@getrandom_available
       buf = uninitialized UInt8[1]
       getrandom(buf.to_slice)
-      buf.unsafe_as(UInt8)
+      buf[0]
     elsif urandom = @@urandom
       urandom.read_byte.not_nil!
     else

--- a/src/crystal/system/unix/getrandom.cr
+++ b/src/crystal/system/unix/getrandom.cr
@@ -62,9 +62,9 @@ module Crystal::System::Random
     init unless @@initialized
 
     if @@getrandom_available
-      buf = uninitialized UInt8[1]
-      getrandom(buf.to_slice)
-      buf[0]
+      buf = uninitialized UInt8
+      getrandom(pointerof(buf).to_slice(1))
+      buf
     elsif urandom = @@urandom
       urandom.read_byte.not_nil!
     else

--- a/src/crystal/system/wasi/random.cr
+++ b/src/crystal/system/wasi/random.cr
@@ -9,6 +9,6 @@ module Crystal::System::Random
   def self.next_u : UInt8
     buf = uninitialized UInt8[1]
     random_bytes(buf.to_slice)
-    buf.unsafe_as(UInt8)
+    buf[0]
   end
 end

--- a/src/crystal/system/wasi/random.cr
+++ b/src/crystal/system/wasi/random.cr
@@ -7,8 +7,8 @@ module Crystal::System::Random
   end
 
   def self.next_u : UInt8
-    buf = uninitialized UInt8[1]
-    random_bytes(buf.to_slice)
-    buf[0]
+    buf = uninitialized UInt8
+    random_bytes(pointerof(buf).to_slice(1))
+    buf
   end
 end

--- a/src/crystal/system/win32/random.cr
+++ b/src/crystal/system/win32/random.cr
@@ -10,6 +10,6 @@ module Crystal::System::Random
   def self.next_u : UInt8
     buf = uninitialized UInt8[1]
     random_bytes(buf.to_slice)
-    buf.unsafe_as(UInt8)
+    buf[0]
   end
 end

--- a/src/crystal/system/win32/random.cr
+++ b/src/crystal/system/win32/random.cr
@@ -8,8 +8,8 @@ module Crystal::System::Random
   end
 
   def self.next_u : UInt8
-    buf = uninitialized UInt8[1]
-    random_bytes(buf.to_slice)
-    buf[0]
+    buf = uninitialized UInt8
+    random_bytes(pointerof(buf).to_slice(1))
+    buf
   end
 end


### PR DESCRIPTION
It's unnecessary to use `unsafe_as` to retrieve the value of a single-item `StaticArray`.
However, the entire `StaticArray` is unnecessary because we just need a slice pointing to the location of the value.
The resulting machinecode should be identical in all three variants.