### PR TITLE
Remove unnecessary calls to `#unsafe_as(UInt64)` etc.

### DIFF
--- a/src/compiler/crystal/interpreter/compiler.cr
+++ b/src/compiler/crystal/interpreter/compiler.cr
@@ -3350,7 +3350,7 @@ class Crystal::Repl::Compiler < Crystal::Visitor
   end
 
   private def append(value : Int8)
-    append value.unsafe_as(UInt8)
+    append value.to_u8!
   end
 
   private def append(value : Symbol)

--- a/src/compiler/crystal/interpreter/instructions.cr
+++ b/src/compiler/crystal/interpreter/instructions.cr
@@ -1472,7 +1472,7 @@ require "./repl"
       symbol_to_s: {
         pop_values: [index : Int32],
         push:       true,
-        code:       @context.index_to_symbol(index).object_id.unsafe_as(UInt64),
+        code:       @context.index_to_symbol(index).object_id.to_u64!,
       },
       # >>> Symbol (1)
 

--- a/src/crystal/hasher.cr
+++ b/src/crystal/hasher.cr
@@ -118,6 +118,8 @@ struct Crystal::Hasher
   end
 
   def self.reduce_num(value : Int)
+    # The result of `remainder(HASH_MODULUS)` is in the range `0...HASH_MODULUS`,
+    # and thus guaranteed to fit into `UInt64`
     value.remainder(HASH_MODULUS).to_u64!
   end
 

--- a/src/crystal/hasher.cr
+++ b/src/crystal/hasher.cr
@@ -77,7 +77,7 @@ struct Crystal::Hasher
 
   HASH_NAN       =      0_u64
   HASH_INF_PLUS  = 314159_u64
-  HASH_INF_MINUS = (-314159_i64).unsafe_as(UInt64)
+  HASH_INF_MINUS = (-314159_i64).to_u64!
 
   @@seed = uninitialized UInt64[2]
   Crystal::System::Random.random_bytes(@@seed.to_slice.to_unsafe_bytes)
@@ -106,7 +106,7 @@ struct Crystal::Hasher
   end
 
   def self.reduce_num(value : Int8 | Int16 | Int32)
-    value.to_i64.unsafe_as(UInt64)
+    value.to_u64!
   end
 
   def self.reduce_num(value : UInt8 | UInt16 | UInt32)
@@ -118,7 +118,7 @@ struct Crystal::Hasher
   end
 
   def self.reduce_num(value : Int)
-    value.remainder(HASH_MODULUS).to_i64.unsafe_as(UInt64)
+    value.remainder(HASH_MODULUS).to_u64!
   end
 
   # This function is for reference implementation, and it is used for `BigFloat`.
@@ -157,7 +157,7 @@ struct Crystal::Hasher
     exp = exp >= 0 ? exp % HASH_BITS : HASH_BITS - 1 - ((-1 - exp) % HASH_BITS)
     x = ((x << exp) & HASH_MODULUS) | x >> (HASH_BITS - exp)
 
-    (x * (value < 0 ? -1 : 1)).to_i64.unsafe_as(UInt64)
+    (x * (value < 0 ? -1 : 1)).to_u64!
   end
 
   def self.reduce_num(value : Float32)

--- a/src/crystal/hasher.cr
+++ b/src/crystal/hasher.cr
@@ -118,7 +118,7 @@ struct Crystal::Hasher
   end
 
   def self.reduce_num(value : Int)
-    # The result of `remainder(HASH_MODULUS)` is in the range `0...HASH_MODULUS`,
+    # The result of `remainder(HASH_MODULUS)` is a 64-bit integer,
     # and thus guaranteed to fit into `UInt64`
     value.remainder(HASH_MODULUS).to_u64!
   end


### PR DESCRIPTION
This rewrites some use cases of `unsafe_as` casting between integer types. These conversions are not unsafe and don't need `unsafe_as`. They can be expressed with appropriate `to_uX!` calls.

The different overloads of `Hasher#reduce_num` could probably be merged to one or two defs. I'll leave that to a follow-up.