### PR TITLE
Default to INET6 for TCPServer, TCPSocket and UDPSocket

### DIFF
--- a/spec/std/socket/tcp_server_spec.cr
+++ b/spec/std/socket/tcp_server_spec.cr
@@ -37,6 +37,12 @@ describe TCPServer, tags: "network" do
         end
       end
 
+      it "can bind to ::1" do
+        server = TCPServer.new
+        server.bind("::1", 0)
+        server.local_address.address.should eq "::1"
+      end
+
       it "raises when port is negative" do
         error = expect_raises(Socket::Addrinfo::Error) do
           TCPServer.new(address, -12)

--- a/src/socket/tcp_server.cr
+++ b/src/socket/tcp_server.cr
@@ -28,7 +28,7 @@ class TCPServer < TCPSocket
   include Socket::Server
 
   # Creates a new `TCPServer`, waiting to be bound.
-  def self.new(family : Family = Family::INET)
+  def self.new(family : Family = Family::INET6)
     super(family)
   end
 
@@ -53,7 +53,7 @@ class TCPServer < TCPSocket
   end
 
   # Creates a TCPServer from an already configured raw file descriptor
-  def initialize(*, fd : Handle, family : Family = Family::INET)
+  def initialize(*, fd : Handle, family : Family = Family::INET6)
     super(fd: fd, family: family)
   end
 

--- a/src/socket/tcp_socket.cr
+++ b/src/socket/tcp_socket.cr
@@ -15,7 +15,7 @@ require "./ip_socket"
 # ```
 class TCPSocket < IPSocket
   # Creates a new `TCPSocket`, waiting to be connected.
-  def self.new(family : Family = Family::INET, blocking = false)
+  def self.new(family : Family = Family::INET6, blocking = false)
     super(family, Type::STREAM, Protocol::TCP, blocking)
   end
 
@@ -45,7 +45,7 @@ class TCPSocket < IPSocket
   end
 
   # Creates a TCPSocket from an already configured raw file descriptor
-  def initialize(*, fd : Handle, family : Family = Family::INET, blocking = false)
+  def initialize(*, fd : Handle, family : Family = Family::INET6, blocking = false)
     super fd, family, Type::STREAM, Protocol::TCP, blocking
   end
 

--- a/src/socket/udp_socket.cr
+++ b/src/socket/udp_socket.cr
@@ -13,7 +13,7 @@ require "./ip_socket"
 # incoming messages and sends outgoing messages on request.
 #
 # This implementation supports both IPv4 and IPv6 addresses. For IPv4 addresses you must use
-# `Socket::Family::INET` family (default) or `Socket::Family::INET6` for IPv6 # addresses.
+# `Socket::Family::INET` family or `Socket::Family::INET6` (default) for IPv6 addresses.
 #
 # NOTE: To use `UDPSocket`, you must explicitly import it with `require "socket"`
 #
@@ -53,7 +53,7 @@ require "./ip_socket"
 # end
 # ```
 class UDPSocket < IPSocket
-  def initialize(family : Family = Family::INET)
+  def initialize(family : Family = Family::INET6)
     super(family, Type::DGRAM, Protocol::UDP)
   end
 


### PR DESCRIPTION
Any reason why `Family` in `TCPServer`, `TCPSocket` and `UDPSocket` defaults to `INET` and not `INET6`? 

Noticed that

```crystal
s = TCPServer.new
s.bind("::1", 0)
```
resulted in
```
Hostname lookup for ::1 failed: Address family for hostname not supported (Socket::Addrinfo::Error)
```