### PR TITLE
Fix create new `target_machine` for every program

### DIFF
--- a/src/compiler/crystal/compiler.cr
+++ b/src/compiler/crystal/compiler.cr
@@ -254,7 +254,7 @@ module Crystal
       program.compiler = self
       program.filename = sources.first.filename
       program.codegen_target = codegen_target
-      program.target_machine = target_machine
+      program.target_machine = create_target_machine
       program.flags << "release" if release?
       program.flags << "debug" unless debug.none?
       program.flags << "static" if static?
@@ -662,6 +662,10 @@ module Crystal
     end
 
     getter(target_machine : LLVM::TargetMachine) do
+      create_target_machine
+    end
+
+    def create_target_machine
       @codegen_target.to_target_machine(@mcpu || "", @mattr || "", @optimization_mode, @mcmodel)
     rescue ex : ArgumentError
       stderr.print colorize("Error: ").red.bold


### PR DESCRIPTION
`Compiler#new_program` instantiates a new `Program` instance which is used for compiling a macro `run` program. Some properties (such as codegen target) can be shared between multiple compilations. But the `TargetMachine` instance must not be shared because this would leak potentially incompatible data layouts between programs.
This patch creates a new instance of `TargetMachine` for every program.

See https://github.com/crystal-lang/crystal/issues/14496#issuecomment-2161174346 and previous comments for details.

Resolves (probably) #14496