### PR TITLE
Fix `Process.run` with closed IO

### DIFF
--- a/spec/std/process_spec.cr
+++ b/spec/std/process_spec.cr
@@ -181,6 +181,14 @@ pending_interpreted describe: Process do
       $?.exit_code.should eq(0)
     end
 
+    it "forwards closed io" do
+      closed_io = IO::Memory.new
+      closed_io.close
+      Process.run(*stdin_to_stdout_command, input: closed_io)
+      Process.run(*stdin_to_stdout_command, output: closed_io)
+      Process.run(*stdin_to_stdout_command, error: closed_io)
+    end
+
     it "sets working directory with string" do
       parent = File.dirname(Dir.current)
       command = {% if flag?(:win32) %}

--- a/src/crystal/system/unix/process.cr
+++ b/src/crystal/system/unix/process.cr
@@ -292,6 +292,11 @@ struct Crystal::System::Process
   end
 
   private def self.reopen_io(src_io : IO::FileDescriptor, dst_io : IO::FileDescriptor)
+    if src_io.closed?
+      dst_io.close
+      return
+    end
+
     src_io = to_real_fd(src_io)
 
     dst_io.reopen(src_io)

--- a/src/process.cr
+++ b/src/process.cr
@@ -294,6 +294,14 @@ class Process
     when IO::FileDescriptor
       stdio
     when IO
+      if stdio.closed?
+        if dst_io == STDIN
+          return File.open(File::NULL, "r").tap(&.close)
+        else
+          return File.open(File::NULL, "w").tap(&.close)
+        end
+      end
+
       if dst_io == STDIN
         fork_io, process_io = IO.pipe(read_blocking: true)
 


### PR DESCRIPTION
IOs passed to `Process.run` experience some indirection which blew up if an IO is closed.
This patch ensures that closed IOs are handled correctly.

* A closed IO that is not a `IO::FileDescriptor` is replaced with a closed file descriptor
* A closed file descriptor won't be reopened in the new process

Resolves part of https://github.com/crystal-lang/crystal/issues/14569