### PR TITLE
Rename `Crystal::NilableType` to `NilableReferenceType`

### DIFF
--- a/spec/compiler/interpreter/is_a_spec.cr
+++ b/spec/compiler/interpreter/is_a_spec.cr
@@ -3,7 +3,7 @@ require "./spec_helper"
 
 describe Crystal::Repl::Interpreter do
   context "is_a?" do
-    it "does is_a? from NilableType to NonGenericClassType (true)" do
+    it "does is_a? from NilableReferenceType to NonGenericClassType (true)" do
       interpret(<<-CRYSTAL).should eq("hello")
         a = "hello" || nil
         if a.is_a?(String)
@@ -14,7 +14,7 @@ describe Crystal::Repl::Interpreter do
         CRYSTAL
     end
 
-    it "does is_a? from NilableType to NonGenericClassType (false)" do
+    it "does is_a? from NilableReferenceType to NonGenericClassType (false)" do
       interpret(<<-CRYSTAL).should eq("bar")
         a = 1 == 1 ? nil : "hello"
         if a.is_a?(String)
@@ -26,7 +26,7 @@ describe Crystal::Repl::Interpreter do
         CRYSTAL
     end
 
-    it "does is_a? from NilableType to GenericClassInstanceType (true)" do
+    it "does is_a? from NilableReferenceType to GenericClassInstanceType (true)" do
       interpret(<<-CRYSTAL).should eq(1)
         class Foo(T)
           def initialize(@x : T)
@@ -46,7 +46,7 @@ describe Crystal::Repl::Interpreter do
         CRYSTAL
     end
 
-    it "does is_a? from NilableType to GenericClassInstanceType (false)" do
+    it "does is_a? from NilableReferenceType to GenericClassInstanceType (false)" do
       interpret(<<-CRYSTAL).should eq(2)
         class Foo(T)
           def initialize(@x : T)

--- a/spec/compiler/interpreter/unions_spec.cr
+++ b/spec/compiler/interpreter/unions_spec.cr
@@ -80,7 +80,7 @@ describe Crystal::Repl::Interpreter do
         CRYSTAL
     end
 
-    it "converts from NilableType to NonGenericClassType" do
+    it "converts from NilableReferenceType to NonGenericClassType" do
       interpret(<<-CRYSTAL).should eq("a")
         a = 1 == 1 ? "a" : nil
         a || "b"

--- a/spec/compiler/semantic/struct_spec.cr
+++ b/spec/compiler/semantic/struct_spec.cr
@@ -65,7 +65,7 @@ describe "Semantic: struct" do
       Foo.new || nil
       ") do
       type = nilable types["Foo"]
-      type.should_not be_a(NilableType)
+      type.should_not be_a(NilableReferenceType)
       type
     end
   end

--- a/src/compiler/crystal/codegen/cast.cr
+++ b/src/compiler/crystal/codegen/cast.cr
@@ -86,7 +86,7 @@ class Crystal::CodeGenVisitor
     end
   end
 
-  def assign_distinct(target_pointer, target_type : NilableType, value_type : Type, value)
+  def assign_distinct(target_pointer, target_type : NilableReferenceType, value_type : Type, value)
     store upcast(value, target_type, value_type), target_pointer
   end
 
@@ -163,7 +163,7 @@ class Crystal::CodeGenVisitor
       union_type.union_types.any? { |ut| value_type.implements?(ut) || ut.implements?(value_type) }
   end
 
-  def assign_distinct(target_pointer, target_type : MixedUnionType, value_type : NilableType, value)
+  def assign_distinct(target_pointer, target_type : MixedUnionType, value_type : NilableReferenceType, value)
     store_in_union target_type, target_pointer, value_type, value
   end
 
@@ -321,11 +321,11 @@ class Crystal::CodeGenVisitor
     cast_to value, to_type
   end
 
-  def downcast_distinct(value, to_type : VirtualType, from_type : NilableType)
+  def downcast_distinct(value, to_type : VirtualType, from_type : NilableReferenceType)
     cast_to value, to_type
   end
 
-  def downcast_distinct(value, to_type : Type, from_type : NilableType)
+  def downcast_distinct(value, to_type : Type, from_type : NilableReferenceType)
     value
   end
 
@@ -362,7 +362,7 @@ class Crystal::CodeGenVisitor
     value
   end
 
-  def downcast_distinct(value, to_type : NilableType, from_type : NilableReferenceUnionType)
+  def downcast_distinct(value, to_type : NilableReferenceType, from_type : NilableReferenceUnionType)
     cast_to value, to_type
   end
 
@@ -414,7 +414,7 @@ class Crystal::CodeGenVisitor
     end
   end
 
-  def downcast_distinct(value, to_type : NilableType, from_type : MixedUnionType)
+  def downcast_distinct(value, to_type : NilableReferenceType, from_type : MixedUnionType)
     _, value_ptr = union_type_and_value_pointer(value, from_type)
     load(llvm_type(to_type), cast_to_pointer(value_ptr, to_type))
   end
@@ -541,11 +541,11 @@ class Crystal::CodeGenVisitor
     cast_to value, to_type
   end
 
-  def upcast_distinct(value, to_type : NilableType, from_type : NilType?)
+  def upcast_distinct(value, to_type : NilableReferenceType, from_type : NilType?)
     llvm_type(to_type).null
   end
 
-  def upcast_distinct(value, to_type : NilableType, from_type : Type)
+  def upcast_distinct(value, to_type : NilableReferenceType, from_type : Type)
     value
   end
 

--- a/src/compiler/crystal/codegen/cond.cr
+++ b/src/compiler/crystal/codegen/cond.cr
@@ -17,7 +17,7 @@ class Crystal::CodeGenVisitor
     codegen_cond type.typedef
   end
 
-  private def codegen_cond_impl(type : NilableType | NilableReferenceUnionType | PointerInstanceType)
+  private def codegen_cond_impl(type : NilableReferenceType | NilableReferenceUnionType | PointerInstanceType)
     not_null_pointer? @last
   end
 

--- a/src/compiler/crystal/codegen/debug.cr
+++ b/src/compiler/crystal/codegen/debug.cr
@@ -242,7 +242,7 @@ module Crystal
       debug_type
     end
 
-    def create_debug_type(type : NilableType, original_type : Type)
+    def create_debug_type(type : NilableReferenceType, original_type : Type)
       get_debug_type(type.not_nil_type, original_type)
     end
 

--- a/src/compiler/crystal/codegen/llvm_typer.cr
+++ b/src/compiler/crystal/codegen/llvm_typer.cr
@@ -217,7 +217,7 @@ module Crystal
       end
     end
 
-    private def create_llvm_type(type : NilableType, wants_size)
+    private def create_llvm_type(type : NilableReferenceType, wants_size)
       llvm_type(type.not_nil_type, wants_size)
     end
 

--- a/src/compiler/crystal/codegen/type_id.cr
+++ b/src/compiler/crystal/codegen/type_id.cr
@@ -9,7 +9,7 @@ class Crystal::CodeGenVisitor
     type_id_impl(type.remove_indirection)
   end
 
-  private def type_id_impl(value, type : NilableType)
+  private def type_id_impl(value, type : NilableReferenceType)
     builder.select null_pointer?(value), type_id(@program.nil), type_id(type.not_nil_type)
   end
 

--- a/src/compiler/crystal/interpreter/cast.cr
+++ b/src/compiler/crystal/interpreter/cast.cr
@@ -23,7 +23,7 @@ class Crystal::Repl::Compiler
     upcast_distinct node, from.typedef, to
   end
 
-  private def upcast_distinct(node : ASTNode, from : NilableType, to : MixedUnionType)
+  private def upcast_distinct(node : ASTNode, from : NilableReferenceType, to : MixedUnionType)
     put_nilable_type_in_union(aligned_sizeof_type(to), node: nil)
   end
 
@@ -161,18 +161,18 @@ class Crystal::Repl::Compiler
     # Nothing to do: both are represented as pointers which already carry the type ID
   end
 
-  private def upcast_distinct(node : ASTNode, from : NilableType | NilableReferenceUnionType, to : NilType)
+  private def upcast_distinct(node : ASTNode, from : NilableReferenceType | NilableReferenceUnionType, to : NilType)
     # TODO: not tested
     # TODO: this is actually a downcast so it's not right, but this is also present
     # in the main compiler so something should be fixed there first
     pop aligned_sizeof_type(from), node: nil
   end
 
-  private def upcast_distinct(node : ASTNode, from : NilType, to : NilableType)
+  private def upcast_distinct(node : ASTNode, from : NilType, to : NilableReferenceType)
     put_i64 0_i64, node: nil
   end
 
-  private def upcast_distinct(node : ASTNode, from : Type, to : NilableType)
+  private def upcast_distinct(node : ASTNode, from : Type, to : NilableReferenceType)
     # Nothing: both are represented as pointers
   end
 
@@ -407,19 +407,19 @@ class Crystal::Repl::Compiler
     end
   end
 
-  private def downcast_distinct(node : ASTNode, from : MixedUnionType, to : PrimitiveType | EnumType | NonGenericClassType | GenericClassInstanceType | GenericClassInstanceMetaclassType | NilableType | NilableProcType | NilableReferenceUnionType | ReferenceUnionType | MetaclassType | VirtualType | VirtualMetaclassType)
+  private def downcast_distinct(node : ASTNode, from : MixedUnionType, to : PrimitiveType | EnumType | NonGenericClassType | GenericClassInstanceType | GenericClassInstanceMetaclassType | NilableReferenceType | NilableProcType | NilableReferenceUnionType | ReferenceUnionType | MetaclassType | VirtualType | VirtualMetaclassType)
     remove_from_union(aligned_sizeof_type(from), aligned_sizeof_type(to), node: nil)
   end
 
-  private def downcast_distinct(node : ASTNode, from : NilableType, to : NonGenericClassType | GenericClassInstanceType)
+  private def downcast_distinct(node : ASTNode, from : NilableReferenceType, to : NonGenericClassType | GenericClassInstanceType)
     # Nothing to do
   end
 
-  private def downcast_distinct(node : ASTNode, from : NilableType, to : NilType)
+  private def downcast_distinct(node : ASTNode, from : NilableReferenceType, to : NilType)
     pop sizeof(Pointer(Void)), node: nil
   end
 
-  private def downcast_distinct(node : ASTNode, from : NilableReferenceUnionType, to : VirtualType | NonGenericClassType | GenericClassInstanceType | NilableType)
+  private def downcast_distinct(node : ASTNode, from : NilableReferenceUnionType, to : VirtualType | NonGenericClassType | GenericClassInstanceType | NilableReferenceType)
     # Nothing to do
   end
 

--- a/src/compiler/crystal/interpreter/compiler.cr
+++ b/src/compiler/crystal/interpreter/compiler.cr
@@ -1766,7 +1766,7 @@ class Crystal::Repl::Compiler < Crystal::Visitor
       reference_is_a(type_id(filtered_type), node: node)
     when MixedUnionType
       union_is_a(aligned_sizeof_type(type), type_id(filtered_type), node: node)
-    when NilableType
+    when NilableReferenceType
       if filtered_type.nil_type?
         pointer_is_null(node: node)
       else

--- a/src/compiler/crystal/interpreter/to_bool.cr
+++ b/src/compiler/crystal/interpreter/to_bool.cr
@@ -21,7 +21,7 @@ class Crystal::Repl::Compiler
     pointer_is_not_null node: nil
   end
 
-  private def value_to_bool(node : ASTNode, type : NilableType)
+  private def value_to_bool(node : ASTNode, type : NilableReferenceType)
     pointer_is_not_null node: nil
   end
 

--- a/src/compiler/crystal/program.cr
+++ b/src/compiler/crystal/program.cr
@@ -429,7 +429,7 @@ module Crystal
         if types.size == 2
           other_type = types[1]
           if other_type.reference_like? && !other_type.virtual?
-            return NilableType.new(self, other_type)
+            return NilableReferenceType.new(self, other_type)
           else
             untyped_type = other_type.remove_typedef
             if untyped_type.proc?

--- a/src/compiler/crystal/semantic/lib.cr
+++ b/src/compiler/crystal/semantic/lib.cr
@@ -279,7 +279,7 @@ class Crystal::Type
       self.tuple_types.all? &.allowed_in_lib?
     when NamedTupleInstanceType
       self.entries.all? &.type.allowed_in_lib?
-    when NilableType
+    when NilableReferenceType
       self.not_nil_type.allowed_in_lib?
     when NilableProcType
       self.proc_type.allowed_in_lib?

--- a/src/compiler/crystal/types.cr
+++ b/src/compiler/crystal/types.cr
@@ -92,7 +92,7 @@ module Crystal
     # In this case this type can be represented with a single pointer.
     def reference_like?
       case self
-      when NilType, NilableType, NilableReferenceUnionType, ReferenceUnionType
+      when NilType, NilableReferenceType, NilableReferenceUnionType, ReferenceUnionType
         true
       when NonGenericClassType
         !self.struct?
@@ -3267,7 +3267,7 @@ module Crystal
   # A union type that has two types: Nil and another Reference type.
   # Can be represented as a maybe-null pointer where the type id
   # of the type that is not nil is known at compile time.
-  class NilableType < UnionType
+  class NilableReferenceType < UnionType
     def initialize(program, not_nil_type)
       super(program, [program.nil, not_nil_type] of Type)
     end


### PR DESCRIPTION
The name `NilableType` suggests that other types like `NilableReferenceUnionType` and `NilableProcType` inherit from it, but this is not the case.