### PR TITLE
Add type restriction `host : String` in `TCPSocket` and `Addrinfo`

### DIFF
--- a/src/socket/addrinfo.cr
+++ b/src/socket/addrinfo.cr
@@ -30,7 +30,7 @@ class Socket
     #
     # addrinfos = Socket::Addrinfo.resolve("example.org", "http", type: Socket::Type::STREAM, protocol: Socket::Protocol::TCP)
     # ```
-    def self.resolve(domain, service, family : Family? = nil, type : Type = nil, protocol : Protocol = Protocol::IP, timeout = nil) : Array(Addrinfo)
+    def self.resolve(domain : String, service, family : Family? = nil, type : Type = nil, protocol : Protocol = Protocol::IP, timeout = nil) : Array(Addrinfo)
       addrinfos = [] of Addrinfo
 
       getaddrinfo(domain, service, family, type, protocol, timeout) do |addrinfo|
@@ -56,7 +56,7 @@ class Socket
     #
     # The iteration will be stopped once the block returns something that isn't
     # an `Exception` (e.g. a `Socket` or `nil`).
-    def self.resolve(domain, service, family : Family? = nil, type : Type = nil, protocol : Protocol = Protocol::IP, timeout = nil, &)
+    def self.resolve(domain : String, service, family : Family? = nil, type : Type = nil, protocol : Protocol = Protocol::IP, timeout = nil, &)
       getaddrinfo(domain, service, family, type, protocol, timeout) do |addrinfo|
         loop do
           value = yield addrinfo.not_nil!
@@ -196,13 +196,13 @@ class Socket
     #
     # addrinfos = Socket::Addrinfo.tcp("example.org", 80)
     # ```
-    def self.tcp(domain, service, family = Family::UNSPEC, timeout = nil) : Array(Addrinfo)
+    def self.tcp(domain : String, service, family = Family::UNSPEC, timeout = nil) : Array(Addrinfo)
       resolve(domain, service, family, Type::STREAM, Protocol::TCP)
     end
 
     # Resolves a domain for the TCP protocol with STREAM type, and yields each
     # possible `Addrinfo`. See `#resolve` for details.
-    def self.tcp(domain, service, family = Family::UNSPEC, timeout = nil, &)
+    def self.tcp(domain : String, service, family = Family::UNSPEC, timeout = nil, &)
       resolve(domain, service, family, Type::STREAM, Protocol::TCP) { |addrinfo| yield addrinfo }
     end
 
@@ -215,13 +215,13 @@ class Socket
     #
     # addrinfos = Socket::Addrinfo.udp("example.org", 53)
     # ```
-    def self.udp(domain, service, family = Family::UNSPEC, timeout = nil) : Array(Addrinfo)
+    def self.udp(domain : String, service, family = Family::UNSPEC, timeout = nil) : Array(Addrinfo)
       resolve(domain, service, family, Type::DGRAM, Protocol::UDP)
     end
 
     # Resolves a domain for the UDP protocol with DGRAM type, and yields each
     # possible `Addrinfo`. See `#resolve` for details.
-    def self.udp(domain, service, family = Family::UNSPEC, timeout = nil, &)
+    def self.udp(domain : String, service, family = Family::UNSPEC, timeout = nil, &)
       resolve(domain, service, family, Type::DGRAM, Protocol::UDP) { |addrinfo| yield addrinfo }
     end
 

--- a/src/socket/tcp_socket.cr
+++ b/src/socket/tcp_socket.cr
@@ -26,7 +26,7 @@ class TCPSocket < IPSocket
   # must be in seconds (integers or floats).
   #
   # Note that `dns_timeout` is currently ignored.
-  def initialize(host, port, dns_timeout = nil, connect_timeout = nil, blocking = false)
+  def initialize(host : String, port, dns_timeout = nil, connect_timeout = nil, blocking = false)
     Addrinfo.tcp(host, port, timeout: dns_timeout) do |addrinfo|
       super(addrinfo.family, addrinfo.type, addrinfo.protocol, blocking)
       connect(addrinfo, timeout: connect_timeout) do |error|
@@ -53,7 +53,7 @@ class TCPSocket < IPSocket
   # eventually closes the socket when the block returns.
   #
   # Returns the value of the block.
-  def self.open(host, port, &)
+  def self.open(host : String, port, &)
     sock = new(host, port)
     begin
       yield sock


### PR DESCRIPTION
The type of the `host` and `domain` parameter in several methods of `TCPSocket` and `Addrinfo` is effectively `String`. This patch adds the respective type restriction.

Other parameters could use similar restrictions, but might need more research. `port`/`service` seems to accept `Int | String`, for example.

Resolves #14699