### PR TITLE
Fix overflow in `File#read_at` for large offsets on Windows

### DIFF
--- a/src/crystal/system/win32/file_descriptor.cr
+++ b/src/crystal/system/win32/file_descriptor.cr
@@ -259,8 +259,8 @@ module Crystal::System::FileDescriptor
     handle = windows_handle(fd)
 
     overlapped = LibC::OVERLAPPED.new
-    overlapped.union.offset.offset = LibC::DWORD.new(offset)
-    overlapped.union.offset.offsetHigh = LibC::DWORD.new(offset >> 32)
+    overlapped.union.offset.offset = LibC::DWORD.new!(offset)
+    overlapped.union.offset.offsetHigh = LibC::DWORD.new!(offset >> 32)
     if LibC.ReadFile(handle, buffer, buffer.size, out bytes_read, pointerof(overlapped)) == 0
       error = WinError.value
       return 0_i64 if error == WinError::ERROR_HANDLE_EOF


### PR DESCRIPTION
Allows `File#read_at` to work for offsets at 2 GiB or larger.