### PR TITLE
Fix unnecessarily clearing clean memory in codegen

### DIFF
--- a/src/compiler/crystal/codegen/codegen.cr
+++ b/src/compiler/crystal/codegen/codegen.cr
@@ -2066,6 +2066,7 @@ module Crystal
       struct_type = llvm_struct_type(type)
       if type.passed_by_value?
         type_ptr = alloca struct_type
+        memset type_ptr, int8(0), size_t(struct_type.size)
       else
         if type.is_a?(InstanceVarContainer) && !type.struct? &&
            type.all_instance_vars.each_value.any? &.type.has_inner_pointers?
@@ -2079,7 +2080,6 @@ module Crystal
     end
 
     def pre_initialize_aggregate(type, struct_type, ptr)
-      memset ptr, int8(0), size_t(struct_type.size)
       run_instance_vars_initializers(type, type, ptr)
 
       unless type.struct?
@@ -2149,6 +2149,7 @@ module Crystal
         pointer = call malloc_fun, size
       else
         pointer = call c_malloc_fun, size_t(size)
+        memset pointer, int8(0), size_t(size)
       end
 
       pointer_cast pointer, type.pointer
@@ -2169,9 +2170,9 @@ module Crystal
         pointer = call malloc_fun, size
       else
         pointer = call c_malloc_fun, size_t(size)
+        memset pointer, int8(0), size_t(size)
       end
 
-      memset pointer, int8(0), size_t(size)
       pointer_cast pointer, type.pointer
     end
 

--- a/src/compiler/crystal/codegen/primitives.cr
+++ b/src/compiler/crystal/codegen/primitives.cr
@@ -748,9 +748,11 @@ class Crystal::CodeGenVisitor
     type = node.type
 
     base_type = type.is_a?(VirtualType) ? type.base_type : type
+    struct_type = llvm_struct_type(base_type)
 
     ptr = call_args[target_def.owner.passed_as_self? ? 1 : 0]
-    pre_initialize_aggregate base_type, llvm_struct_type(base_type), ptr
+    memset ptr, int8(0), size_t(struct_type.size)
+    pre_initialize_aggregate base_type, struct_type, ptr
 
     @last = cast_to ptr, type
   end

--- a/src/gc.cr
+++ b/src/gc.cr
@@ -79,11 +79,11 @@ module GC
     malloc(LibC::SizeT.new(size))
   end
 
-  # Allocates *size* bytes of pointer-free memory.
+  # Allocates and clears *size* bytes of pointer-free memory.
   #
   # The client promises that the resulting object will never contain any pointers.
   #
-  # The memory is not cleared. It will be automatically deallocated when unreferenced.
+  # The memory will be automatically deallocated when unreferenced.
   def self.malloc_atomic(size : Int) : Void*
     malloc_atomic(LibC::SizeT.new(size))
   end

--- a/src/gc/boehm.cr
+++ b/src/gc/boehm.cr
@@ -149,7 +149,9 @@ module GC
 
   # :nodoc:
   def self.malloc_atomic(size : LibC::SizeT) : Void*
-    LibGC.malloc_atomic(size)
+    ptr = LibGC.malloc_atomic(size)
+    ptr.clear(size)
+    ptr
   end
 
   # :nodoc:

--- a/src/gc/none.cr
+++ b/src/gc/none.cr
@@ -8,12 +8,14 @@ module GC
 
   # :nodoc:
   def self.malloc(size : LibC::SizeT) : Void*
-    LibC.malloc(size)
+    ptr = LibC.malloc(size)
+    ptr.clear(size)
+    ptr
   end
 
   # :nodoc:
   def self.malloc_atomic(size : LibC::SizeT) : Void*
-    LibC.malloc(size)
+    malloc(size)
   end
 
   # :nodoc:


### PR DESCRIPTION
Closes #14677
Closes #14678
Alternative to / closes #14679

Since #14679 doesn't seem to be received as well as I'd hoped, this is a very condensed version of it, which only does what's necessary to remove the double-clearing of memory.

With this PR, both `__crystal_malloc64` and `__crystal_malloc_atomic64` are expected to return cleared memory.
To make the change as simple as possible, `GC.malloc_atomic` is now also required to return cleared memory.
This could break compatibility with other/older stdlibs.

The performance benefits are the same as shown in #14679.