### PR TITLE
Update distribution-scripts

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,7 +8,7 @@ parameters:
   distribution-scripts-version:
     description: "Git ref for version of https://github.com/crystal-lang/distribution-scripts/"
     type: string
-    default: "7a013f14ed64e7e569b5e453eab02af63cf62b61"
+    default: "fe82a34ad7855ddb432a26ef7e48c46e7b440e49"
   previous_crystal_base_url:
     description: "Prefix for URLs to Crystal bootstrap compiler"
     type: string


### PR DESCRIPTION
Updates `distribution-scripts` dependency to https://github.com/crystal-lang/distribution-scripts/commit/fe82a34ad7855ddb432a26ef7e48c46e7b440e49

This includes the following changes:

* crystal-lang/distribution-scripts#312
* crystal-lang/distribution-scripts#315
* crystal-lang/distribution-scripts#314
* crystal-lang/distribution-scripts#284
* crystal-lang/distribution-scripts#283
* crystal-lang/distribution-scripts#282
* crystal-lang/distribution-scripts#313
