### PR TITLE
Add `Thread.sleep(Time::Span)`

### DIFF
--- a/src/crystal/system/thread.cr
+++ b/src/crystal/system/thread.cr
@@ -14,6 +14,8 @@ module Crystal::System::Thread
 
   # def self.current_thread=(thread : ::Thread)
 
+  # def self.sleep(time : ::Time::Span) : Nil
+
   # private def system_join : Exception?
 
   # private def system_close
@@ -97,6 +99,12 @@ class Thread
     if exception = @exception
       raise exception
     end
+  end
+
+  # Blocks the current thread for the duration of *time*. Clock precision is
+  # dependent on the operating system and hardware.
+  def self.sleep(time : Time::Span) : Nil
+    Crystal::System::Thread.sleep(time)
   end
 
   # Returns the Thread object associated to the running system thread.

--- a/src/crystal/system/wasi/thread.cr
+++ b/src/crystal/system/wasi/thread.cr
@@ -15,6 +15,18 @@ module Crystal::System::Thread
 
   class_property current_thread : ::Thread { ::Thread.new }
 
+  def self.sleep(time : ::Time::Span) : Nil
+    req = uninitialized LibC::Timespec
+    req.tv_sec = typeof(req.tv_sec).new(time.seconds)
+    req.tv_nsec = typeof(req.tv_nsec).new(time.nanoseconds)
+
+    loop do
+      return if LibC.nanosleep(pointerof(req), out rem) == 0
+      raise RuntimeError.from_errno("nanosleep() failed") unless Errno.value == Errno::EINTR
+      req = rem
+    end
+  end
+
   private def system_join : Exception?
     NotImplementedError.new("Crystal::System::Thread#system_join")
   end

--- a/src/crystal/system/win32/thread.cr
+++ b/src/crystal/system/win32/thread.cr
@@ -51,6 +51,10 @@ module Crystal::System::Thread
     @@current_thread
   end
 
+  def self.sleep(time : ::Time::Span) : Nil
+    LibC.Sleep(time.total_milliseconds.to_i.clamp(1..))
+  end
+
   private def system_join : Exception?
     if LibC.WaitForSingleObject(@system_handle, LibC::INFINITE) != LibC::WAIT_OBJECT_0
       return RuntimeError.from_winerror("WaitForSingleObject")

--- a/src/lib_c/aarch64-android/c/time.cr
+++ b/src/lib_c/aarch64-android/c/time.cr
@@ -28,6 +28,7 @@ lib LibC
   fun gmtime_r(__t : TimeT*, __tm : Tm*) : Tm*
   fun localtime_r(__t : TimeT*, __tm : Tm*) : Tm*
   fun mktime(__tm : Tm*) : TimeT
+  fun nanosleep(__req : Timespec*, __rem : Timespec*) : Int
   fun tzset : Void
   fun timegm(__tm : Tm*) : TimeT
 

--- a/src/lib_c/aarch64-darwin/c/time.cr
+++ b/src/lib_c/aarch64-darwin/c/time.cr
@@ -23,6 +23,7 @@ lib LibC
   fun gmtime_r(x0 : TimeT*, x1 : Tm*) : Tm*
   fun localtime_r(x0 : TimeT*, x1 : Tm*) : Tm*
   fun mktime(x0 : Tm*) : TimeT
+  fun nanosleep(x0 : Timespec*, x1 : Timespec*) : Int
   fun tzset : Void
   fun timegm(x0 : Tm*) : TimeT
 

--- a/src/lib_c/aarch64-linux-gnu/c/time.cr
+++ b/src/lib_c/aarch64-linux-gnu/c/time.cr
@@ -28,6 +28,7 @@ lib LibC
   fun gmtime_r(timer : TimeT*, tp : Tm*) : Tm*
   fun localtime_r(timer : TimeT*, tp : Tm*) : Tm*
   fun mktime(tp : Tm*) : TimeT
+  fun nanosleep(req : Timespec*, rem : Timespec*) : Int
   fun tzset : Void
   fun timegm(tp : Tm*) : TimeT
 

--- a/src/lib_c/aarch64-linux-musl/c/time.cr
+++ b/src/lib_c/aarch64-linux-musl/c/time.cr
@@ -28,6 +28,7 @@ lib LibC
   fun gmtime_r(x0 : TimeT*, x1 : Tm*) : Tm*
   fun localtime_r(x0 : TimeT*, x1 : Tm*) : Tm*
   fun mktime(x0 : Tm*) : TimeT
+  fun nanosleep(x0 : Timespec*, x1 : Timespec*) : Int
   fun tzset : Void
   fun timegm(x0 : Tm*) : TimeT
 

--- a/src/lib_c/arm-linux-gnueabihf/c/time.cr
+++ b/src/lib_c/arm-linux-gnueabihf/c/time.cr
@@ -28,6 +28,7 @@ lib LibC
   fun gmtime_r(timer : TimeT*, tp : Tm*) : Tm*
   fun localtime_r(timer : TimeT*, tp : Tm*) : Tm*
   fun mktime(tp : Tm*) : TimeT
+  fun nanosleep(req : Timespec*, rem : Timespec*) : Int
   fun tzset : Void
   fun timegm(tp : Tm*) : TimeT
 

--- a/src/lib_c/i386-linux-gnu/c/time.cr
+++ b/src/lib_c/i386-linux-gnu/c/time.cr
@@ -28,6 +28,7 @@ lib LibC
   fun gmtime_r(timer : TimeT*, tp : Tm*) : Tm*
   fun localtime_r(timer : TimeT*, tp : Tm*) : Tm*
   fun mktime(tp : Tm*) : TimeT
+  fun nanosleep(req : Timespec*, rem : Timespec*) : Int
   fun tzset : Void
   fun timegm(tp : Tm*) : TimeT
 

--- a/src/lib_c/i386-linux-musl/c/time.cr
+++ b/src/lib_c/i386-linux-musl/c/time.cr
@@ -28,6 +28,7 @@ lib LibC
   fun gmtime_r(x0 : TimeT*, x1 : Tm*) : Tm*
   fun localtime_r(x0 : TimeT*, x1 : Tm*) : Tm*
   fun mktime(x0 : Tm*) : TimeT
+  fun nanosleep(x0 : Timespec*, x1 : Timespec*) : Int
   fun tzset : Void
   fun timegm(x0 : Tm*) : TimeT
 

--- a/src/lib_c/wasm32-wasi/c/time.cr
+++ b/src/lib_c/wasm32-wasi/c/time.cr
@@ -28,6 +28,7 @@ lib LibC
   fun gmtime_r(x0 : TimeT*, x1 : Tm*) : Tm*
   fun localtime_r(x0 : TimeT*, x1 : Tm*) : Tm*
   fun mktime(x0 : Tm*) : TimeT
+  fun nanosleep(x0 : Timespec*, x1 : Timespec*) : Int
   fun timegm(x0 : Tm*) : TimeT
   fun futimes(fd : Int, times : Timeval[2]) : Int
 end

--- a/src/lib_c/x86_64-darwin/c/time.cr
+++ b/src/lib_c/x86_64-darwin/c/time.cr
@@ -23,6 +23,7 @@ lib LibC
   fun gmtime_r(x0 : TimeT*, x1 : Tm*) : Tm*
   fun localtime_r(x0 : TimeT*, x1 : Tm*) : Tm*
   fun mktime(x0 : Tm*) : TimeT
+  fun nanosleep(x0 : Timespec*, x1 : Timespec*) : Int
   fun tzset : Void
   fun timegm(x0 : Tm*) : TimeT
 

--- a/src/lib_c/x86_64-dragonfly/c/time.cr
+++ b/src/lib_c/x86_64-dragonfly/c/time.cr
@@ -28,6 +28,7 @@ lib LibC
   fun gmtime_r(x0 : TimeT*, x1 : Tm*) : Tm*
   fun localtime_r(x0 : TimeT*, x1 : Tm*) : Tm*
   fun mktime(x0 : Tm*) : TimeT
+  fun nanosleep(x0 : Timespec*, x1 : Timespec*) : Int
   fun tzset : Void
   fun timegm(x0 : Tm*) : TimeT
 

--- a/src/lib_c/x86_64-freebsd/c/time.cr
+++ b/src/lib_c/x86_64-freebsd/c/time.cr
@@ -28,6 +28,7 @@ lib LibC
   fun gmtime_r(x0 : TimeT*, x1 : Tm*) : Tm*
   fun localtime_r(x0 : TimeT*, x1 : Tm*) : Tm*
   fun mktime(x0 : Tm*) : TimeT
+  fun nanosleep(x0 : Timespec*, x1 : Timespec*) : Int
   fun tzset : Void
   fun timegm(x0 : Tm*) : TimeT
 

--- a/src/lib_c/x86_64-linux-gnu/c/time.cr
+++ b/src/lib_c/x86_64-linux-gnu/c/time.cr
@@ -28,6 +28,7 @@ lib LibC
   fun gmtime_r(timer : TimeT*, tp : Tm*) : Tm*
   fun localtime_r(timer : TimeT*, tp : Tm*) : Tm*
   fun mktime(tp : Tm*) : TimeT
+  fun nanosleep(req : Timespec*, rem : Timespec*) : Int
   fun tzset : Void
   fun timegm(tp : Tm*) : TimeT
 

--- a/src/lib_c/x86_64-linux-musl/c/time.cr
+++ b/src/lib_c/x86_64-linux-musl/c/time.cr
@@ -28,6 +28,7 @@ lib LibC
   fun gmtime_r(x0 : TimeT*, x1 : Tm*) : Tm*
   fun localtime_r(x0 : TimeT*, x1 : Tm*) : Tm*
   fun mktime(x0 : Tm*) : TimeT
+  fun nanosleep(x0 : Timespec*, x1 : Timespec*) : Int
   fun tzset : Void
   fun timegm(x0 : Tm*) : TimeT
 

--- a/src/lib_c/x86_64-netbsd/c/time.cr
+++ b/src/lib_c/x86_64-netbsd/c/time.cr
@@ -28,6 +28,7 @@ lib LibC
   fun gmtime_r = __gmtime_r50(x0 : TimeT*, x1 : Tm*) : Tm*
   fun localtime_r = __localtime_r50(x0 : TimeT*, x1 : Tm*) : Tm*
   fun mktime = __mktime50(x0 : Tm*) : TimeT
+  fun nanosleep = __nanosleep50(x0 : Timespec*, x1 : Timespec*) : Int
   fun tzset : Void
   fun timegm = __timegm50(x0 : Tm*) : TimeT
 

--- a/src/lib_c/x86_64-openbsd/c/time.cr
+++ b/src/lib_c/x86_64-openbsd/c/time.cr
@@ -28,6 +28,7 @@ lib LibC
   fun gmtime_r(x0 : TimeT*, x1 : Tm*) : Tm*
   fun localtime_r(x0 : TimeT*, x1 : Tm*) : Tm*
   fun mktime(x0 : Tm*) : TimeT
+  fun nanosleep(x0 : Timespec*, x1 : Timespec*) : Int
   fun tzset : Void
   fun timegm(x0 : Tm*) : TimeT
 

--- a/src/lib_c/x86_64-solaris/c/time.cr
+++ b/src/lib_c/x86_64-solaris/c/time.cr
@@ -26,6 +26,7 @@ lib LibC
   fun gmtime_r(x0 : TimeT*, x1 : Tm*) : Tm*
   fun localtime_r(x0 : TimeT*, x1 : Tm*) : Tm*
   fun mktime(x0 : Tm*) : TimeT
+  fun nanosleep(x0 : Timespec*, x1 : Timespec*) : Int
   fun tzset : Void
   fun timegm(x0 : Tm*) : TimeT
 


### PR DESCRIPTION
Suspends the execution of the current thread for a given duration.

This is meant as a system helper only. My use cases are starting a bare thread (without a scheduler or event loop) to execute some operations at regular intervals.

An example is an experiment for [RFC 2](https://github.com/crystal-lang/rfcs/pull/2) of a monitoring thread to collect stacks, to check how long a fiber has been running, and more.

Another example is an in-progress feature for [perf-tools](https://github.com/crystal-lang/perf-tools) that regularly prints runtime information, without impacting or being impacted by the schedulers.