### PR TITLE
Cleanup for `IOCP::OverlappedOperation`

### DIFF
--- a/src/crystal/system/win32/event_loop_iocp.cr
+++ b/src/crystal/system/win32/event_loop_iocp.cr
@@ -233,7 +233,7 @@ class Crystal::IOCP::EventLoop < Crystal::EventLoop
   def connect(socket : ::Socket, address : ::Socket::Addrinfo | ::Socket::Address, timeout : ::Time::Span?) : IO::Error?
     socket.overlapped_connect(socket.fd, "ConnectEx") do |overlapped|
       # This is: LibC.ConnectEx(fd, address, address.size, nil, 0, nil, overlapped)
-      Crystal::System::Socket.connect_ex.call(socket.fd, address.to_unsafe, address.size, Pointer(Void).null, 0_u32, Pointer(UInt32).null, overlapped)
+      Crystal::System::Socket.connect_ex.call(socket.fd, address.to_unsafe, address.size, Pointer(Void).null, 0_u32, Pointer(UInt32).null, overlapped.to_unsafe)
     end
   end
 
@@ -256,7 +256,7 @@ class Crystal::IOCP::EventLoop < Crystal::EventLoop
         received_bytes = uninitialized UInt32
         Crystal::System::Socket.accept_ex.call(socket.fd, client_handle,
           output_buffer.to_unsafe.as(Void*), buffer_size.to_u32!,
-          address_size.to_u32!, address_size.to_u32!, pointerof(received_bytes), overlapped)
+          address_size.to_u32!, address_size.to_u32!, pointerof(received_bytes), overlapped.to_unsafe)
       end
 
       if success

--- a/src/crystal/system/win32/iocp.cr
+++ b/src/crystal/system/win32/iocp.cr
@@ -70,7 +70,7 @@ module Crystal::IOCP
     end
 
     @overlapped = LibC::OVERLAPPED.new
-    @fiber : Fiber? = nil
+    @fiber = Fiber.current
     @state : State = :initialized
     property next : OverlappedOperation?
     property previous : OverlappedOperation?
@@ -92,7 +92,6 @@ module Crystal::IOCP
 
     def start
       raise Exception.new("Invalid state #{@state}") unless @state.initialized?
-      @fiber = Fiber.current
       @state = State::STARTED
       self
     end
@@ -131,7 +130,7 @@ module Crystal::IOCP
     protected def schedule(&)
       case @state
       when .started?
-        yield @fiber.not_nil!
+        yield @fiber
         done!
       when .cancelled?
         @@canceled.delete(self)

--- a/src/crystal/system/win32/socket.cr
+++ b/src/crystal/system/win32/socket.cr
@@ -130,7 +130,7 @@ module Crystal::System::Socket
   # :nodoc:
   def overlapped_connect(socket, method, &)
     IOCP::OverlappedOperation.run(socket) do |operation|
-      result = yield operation.start
+      result = yield operation
 
       if result == 0
         case error = WinError.wsa_value
@@ -196,7 +196,7 @@ module Crystal::System::Socket
 
   def overlapped_accept(socket, method, &)
     IOCP::OverlappedOperation.run(socket) do |operation|
-      result = yield operation.start
+      result = yield operation
 
       if result == 0
         case error = WinError.wsa_value


### PR DESCRIPTION
This is a light refactor of `IOCP::OverlappedOperation` to simplify the implementation.

* Add `OverlappedOperation#to_unsafe` as standard format for passing to C functions
* Add `OverlappedOperation.unbox` for the reverse
* Drop unnecessary `OverlappedOperation#start` to simplify the logic