### PR TITLE
Refactor `IOCP::OverlappedOperation` internalize `handle` and `wait_for_completion`

### DIFF
--- a/src/crystal/system/win32/iocp.cr
+++ b/src/crystal/system/win32/iocp.cr
@@ -118,7 +118,10 @@ module Crystal::IOCP
 
     def wait_for_wsa_result(timeout, &)
       wait_for_completion(timeout)
+      wsa_result { |error| yield error }
+    end
 
+    def wsa_result(&)
       raise Exception.new("Invalid state #{@state}") unless @state.done? || @state.started?
       flags = 0_u32
       result = LibC.WSAGetOverlappedResult(LibC::SOCKET.new(@handle.address), self, out bytes, false, pointerof(flags))
@@ -161,7 +164,7 @@ module Crystal::IOCP
       @state = :done
     end
 
-    private def wait_for_completion(timeout)
+    def wait_for_completion(timeout)
       if timeout
         timeout_event = Crystal::IOCP::Event.new(Fiber.current)
         timeout_event.add(timeout)

--- a/src/crystal/system/win32/socket.cr
+++ b/src/crystal/system/win32/socket.cr
@@ -208,7 +208,11 @@ module Crystal::System::Socket
         return true
       end
 
-      operation.wait_for_wsa_result(read_timeout) do |error|
+      unless operation.wait_for_completion(read_timeout)
+        raise IO::TimeoutError.new("#{method} timed out")
+      end
+
+      operation.wsa_result do |error|
         case error
         when .wsa_io_incomplete?, .wsaenotsock?
           return false

--- a/src/crystal/system/win32/socket.cr
+++ b/src/crystal/system/win32/socket.cr
@@ -148,7 +148,7 @@ module Crystal::System::Socket
 
       IOCP.schedule_overlapped(read_timeout || 1.seconds)
 
-      operation.wsa_result(socket) do |error|
+      operation.wsa_result do |error|
         case error
         when .wsa_io_incomplete?, .wsaeconnrefused?
           return ::Socket::ConnectError.from_os_error(method, error)
@@ -214,7 +214,7 @@ module Crystal::System::Socket
         raise IO::TimeoutError.new("#{method} timed out")
       end
 
-      operation.wsa_result(socket) do |error|
+      operation.wsa_result do |error|
         case error
         when .wsa_io_incomplete?, .wsaenotsock?
           return false

--- a/src/crystal/system/win32/socket.cr
+++ b/src/crystal/system/win32/socket.cr
@@ -146,9 +146,7 @@ module Crystal::System::Socket
         return nil
       end
 
-      IOCP.schedule_overlapped(read_timeout || 1.seconds)
-
-      operation.wsa_result do |error|
+      operation.wait_for_wsa_result(read_timeout || 1.seconds) do |error|
         case error
         when .wsa_io_incomplete?, .wsaeconnrefused?
           return ::Socket::ConnectError.from_os_error(method, error)
@@ -210,11 +208,7 @@ module Crystal::System::Socket
         return true
       end
 
-      unless IOCP.schedule_overlapped(read_timeout)
-        raise IO::TimeoutError.new("#{method} timed out")
-      end
-
-      operation.wsa_result do |error|
+      operation.wait_for_wsa_result(read_timeout) do |error|
         case error
         when .wsa_io_incomplete?, .wsaenotsock?
           return false


### PR DESCRIPTION
Moves the `schedule_overlapped` overlapped method into `OverlappedOperation` and call it directly from the result methods, reducing the external API.
`@handle` becomes a property of `OverlappedOperation` which will be necessary for a follow-up refactor anyway.
