### PR TITLE
Fix relative file paths in spec output

### DIFF
--- a/src/spec/context.cr
+++ b/src/spec/context.cr
@@ -191,6 +191,8 @@ module Spec
       failures = results_for(:fail)
       errors = results_for(:error)
 
+      cwd = Dir.current
+
       failures_and_errors = failures + errors
       unless failures_and_errors.empty?
         puts
@@ -216,7 +218,7 @@ module Spec
 
             if ex.is_a?(SpecError)
               puts
-              puts Spec.color("     # #{Spec.relative_file(ex.file)}:#{ex.line}", :comment)
+              puts Spec.color("     # #{Path[ex.file].relative_to(cwd)}:#{ex.line}", :comment)
             end
           end
         end
@@ -232,7 +234,7 @@ module Spec
         top_n.each do |res|
           puts "  #{res.description}"
           res_elapsed = res.elapsed.not_nil!.total_seconds.humanize
-          puts "    #{res_elapsed.colorize.bold} seconds #{Spec.relative_file(res.file)}:#{res.line}"
+          puts "    #{res_elapsed.colorize.bold} seconds #{Path[res.file].relative_to(cwd)}:#{res.line}"
         end
       end
 
@@ -258,7 +260,7 @@ module Spec
         puts "Failed examples:"
         puts
         failures_and_errors.each do |fail|
-          print Spec.color("crystal spec #{Spec.relative_file(fail.file)}:#{fail.line}", :error)
+          print Spec.color("crystal spec #{Path[fail.file].relative_to(cwd)}:#{fail.line}", :error)
           puts Spec.color(" # #{fail.description}", :comment)
         end
       end

--- a/src/spec/source.cr
+++ b/src/spec/source.cr
@@ -11,14 +11,4 @@ module Spec
     lines = lines_cache.put_if_absent(file) { File.read_lines(file) }
     lines[line - 1]?
   end
-
-  # :nodoc:
-  def self.relative_file(file)
-    cwd = Dir.current
-    if basename = file.lchop? cwd
-      basename.lchop '/'
-    else
-      file
-    end
-  end
 end


### PR DESCRIPTION
Relativized paths in the spec output (for example for `Failed examples`) are wrong on Windows. They incorrectly include a leading directory separator, making them relative to the drive root:

```
Failed examples:

crystal spec \spec\fail_spec.cr:3 # assert
```

The implementation does not account for other directory separators than `\`.
This fix replaces it with `Path#relative_to` which handles this correctly.