### PR TITLE
Make `ReferenceStorage(T)` non-atomic if `T` is non-atomic

### DIFF
--- a/spec/primitives/pointer_spec.cr
+++ b/spec/primitives/pointer_spec.cr
@@ -1,0 +1,24 @@
+require "spec"
+require "../support/finalize"
+
+private class Inner
+  include FinalizeCounter
+
+  def initialize(@key : String)
+  end
+end
+
+private class Outer
+  @inner = Inner.new("reference-storage")
+end
+
+describe "Primitives: pointer" do
+  describe ".malloc" do
+    it "is non-atomic for ReferenceStorage(T) if T is non-atomic (#14692)" do
+      FinalizeState.reset
+      outer = Outer.unsafe_construct(Pointer(ReferenceStorage(Outer)).malloc(1))
+      GC.collect
+      FinalizeState.count("reference-storage").should eq(0)
+    end
+  end
+end

--- a/spec/primitives/pointer_spec.cr
+++ b/spec/primitives/pointer_spec.cr
@@ -1,5 +1,6 @@
 require "spec"
 require "../support/finalize"
+require "../support/interpreted"
 
 private class Inner
   include FinalizeCounter
@@ -14,7 +15,7 @@ end
 
 describe "Primitives: pointer" do
   describe ".malloc" do
-    it "is non-atomic for ReferenceStorage(T) if T is non-atomic (#14692)" do
+    pending_interpreted "is non-atomic for ReferenceStorage(T) if T is non-atomic (#14692)" do
       FinalizeState.reset
       outer = Outer.unsafe_construct(Pointer(ReferenceStorage(Outer)).malloc(1))
       GC.collect

--- a/src/compiler/crystal/codegen/types.cr
+++ b/src/compiler/crystal/codegen/types.cr
@@ -69,6 +69,8 @@ module Crystal
         self.tuple_types.any? &.has_inner_pointers?
       when NamedTupleInstanceType
         self.entries.any? &.type.has_inner_pointers?
+      when ReferenceStorageType
+        self.reference_type.has_inner_pointers?
       when PrimitiveType
         false
       when EnumType


### PR DESCRIPTION
Fixes #14692.