### PR TITLE
Add UUID v7

### DIFF
--- a/spec/std/uuid_spec.cr
+++ b/spec/std/uuid_spec.cr
@@ -269,4 +269,21 @@ describe "UUID" do
       UUID.v5_x500(data).v5?.should eq(true)
     end
   end
+
+  describe "v7" do
+    it "generates a v7 UUID" do
+      uuid = UUID.v7
+      uuid.v7?.should eq true
+      uuid.variant.rfc9562?.should eq true
+    end
+
+    it "generates UUIDs that are sortable with 1ms precision" do
+      uuids = Array.new(10) do
+        sleep 1.millisecond
+        UUID.v7
+      end
+
+      uuids.should eq uuids.sort
+    end
+  end
 end


### PR DESCRIPTION
Part of #14288. This PR doesn't implement all of the requested UUID versions, but v7 is gaining in popularity for its ability to sort UUID values chronologically and RFC 9562 was [published last month](https://datatracker.ietf.org/doc/rfc9562/history/).

It's notable that RFC 4122 has been obsoleted via RFC 9562, so I [included an alias](https://github.com/jgaskins/crystal/blob/8a8e202348e506ed0779eb067b2187cbcfeb1a16/src/uuid.cr#L27) for the new RFC in the `Variant` enum.

Spec: https://www.rfc-editor.org/rfc/rfc9562#name-uuid-version-7

