### PR TITLE
Add `Crystal::System.panic`

### DIFF
--- a/src/crystal/system/panic.cr
+++ b/src/crystal/system/panic.cr
@@ -1,0 +1,39 @@
+module Crystal::System
+  # Prints a system error message on the standard error then exits with an error
+  # status.
+  #
+  # You should always prefer raising an exception, built with
+  # `RuntimeError.from_os_error` for example, but there are a few cases where we
+  # can't allocate any memory (e.g. stop the world) and still need to fail when
+  # reaching a system error.
+  #
+  # On Linux *error* defaults to the current `Errno`. On Windows it defaults to
+  # the current `WinError`. On Wasm32 the actual `WasiError` must be passed.
+  {% if flag?(:unix) %}
+    def self.panic(syscall_name : String, error : Errno = Errno.value) : NoReturn
+      buffer = LibC.strerror(error.value)
+      message = Bytes.new(buffer, LibC.strlen(buffer))
+      System.print_error("%s failed with ", syscall_name)
+      System.print_error(message)
+      System.print_error(" (%s)\n", error.to_s)
+      exit 1
+    end
+  {% elsif flag?(:win32) %}
+    def self.panic(syscall_name : String, error : WinError = WinError.value) : NoReturn
+      buffer = uninitialized UInt16[256]
+      size = LibC.FormatMessageW(LibC::FORMAT_MESSAGE_FROM_SYSTEM, nil, error.value, 0, buffer, buffer.size, nil)
+      message = buffer.to_slice[0, size]
+      System.print_error("%s failed with ", syscall_name)
+      System.print_error(message)
+      System.print_error(" (%s)\n", error.to_s)
+      exit 1
+    end
+  {% elsif flag?(:wasm32) %}
+    def self.panic(syscall_name : String, error : WasiError) : NoReturn
+      System.print_error("%s failed with %s (%s)", syscall_name, error.message, error.to_s)
+      exit 1
+    end
+  {% else %}
+    {% raise "Unsupported target" %}
+  {% end %}
+end

--- a/src/crystal/system/panic.cr
+++ b/src/crystal/system/panic.cr
@@ -6,34 +6,11 @@ module Crystal::System
   # `RuntimeError.from_os_error` for example, but there are a few cases where we
   # can't allocate any memory (e.g. stop the world) and still need to fail when
   # reaching a system error.
-  #
-  # On Linux *error* defaults to the current `Errno`. On Windows it defaults to
-  # the current `WinError`. On Wasm32 the actual `WasiError` must be passed.
-  {% if flag?(:unix) %}
-    def self.panic(syscall_name : String, error : Errno = Errno.value) : NoReturn
-      buffer = LibC.strerror(error.value)
-      message = Bytes.new(buffer, LibC.strlen(buffer))
-      System.print_error("%s failed with ", syscall_name)
-      System.print_error(message)
-      System.print_error(" (%s)\n", error.to_s)
-      exit 1
-    end
-  {% elsif flag?(:win32) %}
-    def self.panic(syscall_name : String, error : WinError = WinError.value) : NoReturn
-      buffer = uninitialized UInt16[256]
-      size = LibC.FormatMessageW(LibC::FORMAT_MESSAGE_FROM_SYSTEM, nil, error.value, 0, buffer, buffer.size, nil)
-      message = buffer.to_slice[0, size]
-      System.print_error("%s failed with ", syscall_name)
-      System.print_error(message)
-      System.print_error(" (%s)\n", error.to_s)
-      exit 1
-    end
-  {% elsif flag?(:wasm32) %}
-    def self.panic(syscall_name : String, error : WasiError) : NoReturn
-      System.print_error("%s failed with %s (%s)", syscall_name, error.message, error.to_s)
-      exit 1
-    end
-  {% else %}
-    {% raise "Unsupported target" %}
-  {% end %}
+  def self.panic(syscall_name : String, error : Errno | WinError | WasiError) : NoReturn
+    System.print_error("%s failed with ", syscall_name)
+    error.unsafe_message { |slice| System.print_error(slice) }
+    System.print_error(" (%s)\n", error.to_s)
+
+    LibC._exit(1)
+  end
 end

--- a/src/crystal/tracing.cr
+++ b/src/crystal/tracing.cr
@@ -1,3 +1,5 @@
+require "./system/panic"
+
 module Crystal
   # :nodoc:
   module Tracing

--- a/src/errno.cr
+++ b/src/errno.cr
@@ -40,10 +40,16 @@ enum Errno
 
   # Convert an Errno to an error message
   def message : String
-    String.new(LibC.strerror(value))
+    unsafe_message { |slice| String.new(slice) }
   end
 
-  # Returns the value of libc's errno.
+  # :nodoc:
+  def unsafe_message(&)
+    pointer = LibC.strerror(value)
+    yield Bytes.new(pointer, LibC.strlen(pointer))
+  end
+
+  # returns the value of libc's errno.
   def self.value : self
     {% if flag?(:netbsd) || flag?(:openbsd) || flag?(:android) %}
       Errno.new LibC.__errno.value

--- a/src/wasi_error.cr
+++ b/src/wasi_error.cr
@@ -83,6 +83,11 @@ enum WasiError : UInt16
     end
   end
 
+  # :nodoc:
+  def unsafe_message(&)
+    yield message.to_slice
+  end
+
   # Transforms this `WasiError` value to the equivalent `Errno` value.
   #
   # This is only defined for some values. If no transformation is defined for

--- a/src/winerror.cr
+++ b/src/winerror.cr
@@ -61,17 +61,17 @@ enum WinError : UInt32
   #
   # On non-win32 platforms the result is always an empty string.
   def message : String
-    formatted_message
+    unsafe_message { |slice| String.from_utf16(slice).strip }
   end
 
   # :nodoc:
-  def formatted_message : String
+  def unsafe_message(&)
     {% if flag?(:win32) %}
       buffer = uninitialized UInt16[256]
       size = LibC.FormatMessageW(LibC::FORMAT_MESSAGE_FROM_SYSTEM, nil, value, 0, buffer, buffer.size, nil)
-      String.from_utf16(buffer.to_slice[0, size]).strip
+      yield buffer.to_slice[0, size]
     {% else %}
-      ""
+      yield "".to_slice
     {% end %}
   end
 

--- a/src/winerror.cr
+++ b/src/winerror.cr
@@ -61,7 +61,11 @@ enum WinError : UInt32
   #
   # On non-win32 platforms the result is always an empty string.
   def message : String
-    unsafe_message { |slice| String.from_utf16(slice).strip }
+    {% if flag?(:win32) %}
+      unsafe_message { |slice| String.from_utf16(slice).strip }
+    {% else %}
+      ""
+    {% end %}
   end
 
   # :nodoc:


### PR DESCRIPTION
Prints a system error message on the standard error then exits with an error status. Raising an exception should always be preferred but there are a few cases where we can't allocate any memory (e.g. stop the world) and still need to fail when reaching a system error.

Extracted from #14729