### PR TITLE
Improve exception hierarchy

### DIFF
--- a/src/exception.cr
+++ b/src/exception.cr
@@ -69,6 +69,15 @@ class Exception
   end
 end
 
+# Raised when there is an error in the program logic.
+# This kind of error should lead directly to a fix in the code.
+class LogicError < Exception
+end
+
+# Raised when an error occurs while performing mathematical operations.
+class ArithmeticError < LogicError
+end
+
 # Raised when the given index is invalid.
 #
 # ```
@@ -86,7 +95,7 @@ end
 # ```
 # [1, 2, 3].first(-4) # raises ArgumentError (attempt to take negative size)
 # ```
-class ArgumentError < Exception
+class ArgumentError < LogicError
   def initialize(message = "Argument error")
     super(message)
   end
@@ -97,7 +106,7 @@ end
 # ```
 # [1, "hi"][1].as(Int32) # raises TypeCastError (cast to Int32 failed)
 # ```
-class TypeCastError < Exception
+class TypeCastError < LogicError
   def initialize(message = "Type Cast error")
     super(message)
   end
@@ -123,7 +132,7 @@ end
 # ```
 # 1 // 0 # raises DivisionByZeroError (Division by 0)
 # ```
-class DivisionByZeroError < Exception
+class DivisionByZeroError < ArithmeticError
   def initialize(message = "Division by 0")
     super(message)
   end
@@ -137,7 +146,7 @@ end
 # Int32::MIN - 1      # raises OverflowError (Arithmetic overflow)
 # Float64::MAX.to_f32 # raises OverflowError (Arithmetic overflow)
 # ```
-class OverflowError < Exception
+class OverflowError < ArithmeticError
   def initialize(message = "Arithmetic overflow")
     super(message)
   end
@@ -147,7 +156,7 @@ end
 #
 # This can be used either to stub out method bodies, or when the method is not
 # implemented on the current platform.
-class NotImplementedError < Exception
+class NotImplementedError < LogicError
   def initialize(item)
     super("Not Implemented: #{item}")
   end
@@ -158,7 +167,7 @@ end
 # ```
 # "hello".index('x').not_nil! # raises NilAssertionError ("hello" does not contain 'x')
 # ```
-class NilAssertionError < Exception
+class NilAssertionError < LogicError
   def initialize(message = "Nil assertion failed")
     super(message)
   end

--- a/src/time.cr
+++ b/src/time.cr
@@ -212,7 +212,11 @@ require "crystal/system/time"
 # elapsed_time # => 20.milliseconds (approximately)
 # ```
 struct Time
-  class FloatingTimeConversionError < Exception
+  # Raised when an error occurs while performing a `Time` based operation.
+  class Error < Exception
+  end
+
+  class FloatingTimeConversionError < Time::Error
   end
 
   include Comparable(Time)

--- a/src/time/location.cr
+++ b/src/time/location.cr
@@ -51,7 +51,7 @@ class Time::Location
   # the time zone database.
   #
   # See `Time::Location.load` for details.
-  class InvalidLocationNameError < Exception
+  class InvalidLocationNameError < Time::Error
     getter name, source
 
     def initialize(@name : String, @source : String? = nil)
@@ -63,7 +63,7 @@ class Time::Location
 
   # `InvalidTimezoneOffsetError` is raised if `Time::Location::Zone.new`
   # receives an invalid time zone offset.
-  class InvalidTimezoneOffsetError < Exception
+  class InvalidTimezoneOffsetError < Time::Error
     def initialize(offset : Int)
       super "Invalid time zone offset: #{offset}"
     end

--- a/src/time/location/loader.cr
+++ b/src/time/location/loader.cr
@@ -5,7 +5,7 @@ class Time::Location
   # time zone data.
   #
   # Details on the exact cause can be found in the error message.
-  class InvalidTZDataError < Exception
+  class InvalidTZDataError < Time::Error
     def self.initialize(message : String? = "Malformed time zone information", cause : Exception? = nil)
       super(message, cause)
     end


### PR DESCRIPTION
Implements what was proposed in https://github.com/crystal-lang/crystal/issues/11639#issuecomment-2090480502. Also not actually sure why I thought `OverflowError` inherited `RuntimeError`, so I handled that too.