### PR TITLE
Fix ECR escape sequences containing `-`

### DIFF
--- a/spec/std/data/test_template7.ecr
+++ b/spec/std/data/test_template7.ecr
@@ -1,0 +1,5 @@
+<%% if @name %>
+Greetings, <%%= @name %>!
+  <%-% else -%>
+Greetings!
+<%-% end -%>

--- a/spec/std/ecr/ecr_lexer_spec.cr
+++ b/spec/std/ecr/ecr_lexer_spec.cr
@@ -210,6 +210,87 @@ describe "ECR::Lexer" do
     token.type.should eq(t :eof)
   end
 
+  it "lexes with <%-% %> (#14734)" do
+    lexer = ECR::Lexer.new("hello <%-% foo %> bar")
+
+    token = lexer.next_token
+    token.type.should eq(t :string)
+    token.value.should eq("hello ")
+    token.column_number.should eq(1)
+    token.line_number.should eq(1)
+
+    token = lexer.next_token
+    token.type.should eq(t :string)
+    token.value.should eq("<%- foo %>")
+    token.line_number.should eq(1)
+    token.column_number.should eq(11)
+    token.suppress_leading?.should be_false
+    token.suppress_trailing?.should be_false
+
+    token = lexer.next_token
+    token.type.should eq(t :string)
+    token.value.should eq(" bar")
+    token.line_number.should eq(1)
+    token.column_number.should eq(18)
+
+    token = lexer.next_token
+    token.type.should eq(t :eof)
+  end
+
+  it "lexes with <%-%= %> (#14734)" do
+    lexer = ECR::Lexer.new("hello <%-%= foo %> bar")
+
+    token = lexer.next_token
+    token.type.should eq(t :string)
+    token.value.should eq("hello ")
+    token.column_number.should eq(1)
+    token.line_number.should eq(1)
+
+    token = lexer.next_token
+    token.type.should eq(t :string)
+    token.value.should eq("<%-= foo %>")
+    token.line_number.should eq(1)
+    token.column_number.should eq(11)
+    token.suppress_leading?.should be_false
+    token.suppress_trailing?.should be_false
+
+    token = lexer.next_token
+    token.type.should eq(t :string)
+    token.value.should eq(" bar")
+    token.line_number.should eq(1)
+    token.column_number.should eq(19)
+
+    token = lexer.next_token
+    token.type.should eq(t :eof)
+  end
+
+  it "lexes with <%% -%> (#14734)" do
+    lexer = ECR::Lexer.new("hello <%% foo -%> bar")
+
+    token = lexer.next_token
+    token.type.should eq(t :string)
+    token.value.should eq("hello ")
+    token.column_number.should eq(1)
+    token.line_number.should eq(1)
+
+    token = lexer.next_token
+    token.type.should eq(t :string)
+    token.value.should eq("<% foo -%>")
+    token.line_number.should eq(1)
+    token.column_number.should eq(10)
+    token.suppress_leading?.should be_false
+    token.suppress_trailing?.should be_false
+
+    token = lexer.next_token
+    token.type.should eq(t :string)
+    token.value.should eq(" bar")
+    token.line_number.should eq(1)
+    token.column_number.should eq(18)
+
+    token = lexer.next_token
+    token.type.should eq(t :eof)
+  end
+
   it "lexes with <% %> and correct location info" do
     lexer = ECR::Lexer.new("hi\nthere <% foo\nbar %> baz")
 

--- a/spec/std/ecr/ecr_spec.cr
+++ b/spec/std/ecr/ecr_spec.cr
@@ -65,6 +65,18 @@ describe "ECR" do
     io.to_s.should eq("string with -%")
   end
 
+  it "does with <%% %>" do
+    io = IO::Memory.new
+    ECR.embed "#{__DIR__}/../data/test_template7.ecr", io
+    io.to_s.should eq(<<-ECR)
+      <% if @name %>
+      Greetings, <%= @name %>!
+        <%- else -%>
+      Greetings!
+      <%- end -%>
+      ECR
+  end
+
   it ".render" do
     ECR.render("#{__DIR__}/../data/test_template2.ecr").should eq("123")
   end

--- a/src/ecr.cr
+++ b/src/ecr.cr
@@ -14,7 +14,8 @@
 #
 # A comment can be created the same as normal code: `<% # hello %>` or by the special
 # tag: `<%# hello %>`. An ECR tag can be inserted directly (i.e. the tag itself may be
-# escaped) by using a second `%` like so: `<%% a = b %>` or `<%%= foo %>`.
+# escaped) by using a second `%` like so: `<%% a = b %>` or `<%%= foo %>`. Dashes may
+# also be present in those escaped tags and have no effect on the surrounding text.
 #
 # NOTE: To use `ECR`, you must explicitly import it with `require "ecr"`
 #

--- a/src/ecr/lexer.cr
+++ b/src/ecr/lexer.cr
@@ -44,12 +44,8 @@ class ECR::Lexer
         next_char
         next_char
 
-        if current_char == '-'
-          @token.suppress_leading = true
-          next_char
-        else
-          @token.suppress_leading = false
-        end
+        suppress_leading = current_char == '-'
+        next_char if suppress_leading
 
         case current_char
         when '='
@@ -64,7 +60,7 @@ class ECR::Lexer
           copy_location_info_to_token
         end
 
-        return consume_control(is_output, is_escape)
+        return consume_control(is_output, is_escape, suppress_leading)
       end
     else
       # consume string
@@ -97,7 +93,7 @@ class ECR::Lexer
     @token
   end
 
-  private def consume_control(is_output, is_escape)
+  private def consume_control(is_output, is_escape, suppress_leading)
     start_pos = current_pos
     while true
       case current_char
@@ -126,8 +122,7 @@ class ECR::Lexer
           @column_number = column_number
 
           if is_end
-            @token.suppress_trailing = true
-            setup_control_token(start_pos, is_escape)
+            setup_control_token(start_pos, is_escape, suppress_leading, true)
             raise "Expecting '>' after '-%'" if current_char != '>'
             next_char
             break
@@ -135,8 +130,7 @@ class ECR::Lexer
         end
       when '%'
         if peek_next_char == '>'
-          @token.suppress_trailing = false
-          setup_control_token(start_pos, is_escape)
+          setup_control_token(start_pos, is_escape, suppress_leading, false)
           break
         end
       else
@@ -155,12 +149,18 @@ class ECR::Lexer
     @token
   end
 
-  private def setup_control_token(start_pos, is_escape)
-    @token.value = if is_escape
-                     "<%#{string_range(start_pos, current_pos + 2)}"
-                   else
-                     string_range(start_pos)
-                   end
+  private def setup_control_token(start_pos, is_escape, suppress_leading, suppress_trailing)
+    @token.suppress_leading = !is_escape && suppress_leading
+    @token.suppress_trailing = !is_escape && suppress_trailing
+    @token.value =
+      if is_escape
+        head = suppress_leading ? "<%-" : "<%"
+        tail = string_range(start_pos, current_pos + (suppress_trailing ? 3 : 2))
+        head + tail
+      else
+        string_range(start_pos)
+      end
+
     next_char
     next_char
   end


### PR DESCRIPTION
Fixes #14734.

Also makes it documented behavior that the escaped tags never strip leading indentation or trailing newlines, so the following:

```ecr
foo
  <%-%# comment -%>
bar
```

renders:

```
foo
  <%-# comment -%>
bar
```

instead of:

```
foo
<%-# comment -%>bar
```

so that if an ECR template itself is rendered by another ECR template, the indentation is preserved.