### PR TITLE
Undocument `IO::Evented`

### DIFF
--- a/src/io/evented.cr
+++ b/src/io/evented.cr
@@ -2,6 +2,7 @@
 
 require "crystal/thread_local_value"
 
+# :nodoc:
 module IO::Evented
   @read_timed_out = false
   @write_timed_out = false


### PR DESCRIPTION
`IO::Evented` is an OS-specific implementation detail of the event loop that leaked out to the documentation. It should've never been part of the public API.

Ref https://github.com/crystal-lang/crystal/issues/14747#issuecomment-2188530095