### PR TITLE
Refactor cancellation of `IOCP::OverlappedOperation`

### DIFF
--- a/src/crystal/system/win32/iocp.cr
+++ b/src/crystal/system/win32/iocp.cr
@@ -132,7 +132,7 @@ module Crystal::IOCP
       @state = :done
     end
 
-    def cancel! : Bool
+    def try_cancel : Bool
       # Microsoft documentation:
       # The application must not free or reuse the OVERLAPPED structure
       # associated with the canceled I/O operations until they have completed
@@ -159,7 +159,7 @@ module Crystal::IOCP
       end
 
       unless @state.done?
-        if cancel!
+        if try_cancel
           Fiber.suspend
         end
       end

--- a/src/crystal/system/win32/iocp.cr
+++ b/src/crystal/system/win32/iocp.cr
@@ -79,7 +79,8 @@ module Crystal::IOCP
     end
 
     def self.run(handle, &)
-      operation = OverlappedOperation.new(handle)
+      operation_storage = uninitialized ReferenceStorage(OverlappedOperation)
+      operation = OverlappedOperation.unsafe_construct(pointerof(operation_storage), handle)
       yield operation
     end
 

--- a/src/crystal/system/win32/iocp.cr
+++ b/src/crystal/system/win32/iocp.cr
@@ -206,7 +206,7 @@ module Crystal::IOCP
 
       operation.wait_for_result(timeout) do |error|
         case error
-        when .error_io_incomplete?
+        when .error_io_incomplete?, .error_operation_aborted?
           raise IO::TimeoutError.new("#{method} timed out")
         when .error_handle_eof?
           return 0_u32
@@ -236,7 +236,7 @@ module Crystal::IOCP
 
       operation.wait_for_wsa_result(timeout) do |error|
         case error
-        when .wsa_io_incomplete?
+        when .wsa_io_incomplete?, .error_operation_aborted?
           raise IO::TimeoutError.new("#{method} timed out")
         when .wsaeconnreset?
           return 0_u32 unless connreset_is_error

--- a/src/crystal/system/win32/iocp.cr
+++ b/src/crystal/system/win32/iocp.cr
@@ -160,6 +160,8 @@ module Crystal::IOCP
 
       unless @state.done?
         if try_cancel
+          # Wait for cancellation to complete. We must not free the operation
+          # until it's completed.
           Fiber.suspend
         end
       end

--- a/src/crystal/system/win32/iocp.cr
+++ b/src/crystal/system/win32/iocp.cr
@@ -122,13 +122,8 @@ module Crystal::IOCP
     end
 
     protected def schedule(&)
-      case @state
-      when .started?
-        done!
-        yield @fiber
-      else
-        raise Exception.new("Invalid state #{@state}")
-      end
+      done!
+      yield @fiber
     end
 
     def done!

--- a/src/crystal/system/win32/iocp.cr
+++ b/src/crystal/system/win32/iocp.cr
@@ -118,10 +118,7 @@ module Crystal::IOCP
 
     def wait_for_wsa_result(timeout, &)
       wait_for_completion(timeout)
-      wsa_result { |error| yield error }
-    end
 
-    def wsa_result(&)
       raise Exception.new("Invalid state #{@state}") unless @state.done? || @state.started?
       flags = 0_u32
       result = LibC.WSAGetOverlappedResult(LibC::SOCKET.new(@handle.address), self, out bytes, false, pointerof(flags))

--- a/src/crystal/system/win32/socket.cr
+++ b/src/crystal/system/win32/socket.cr
@@ -216,6 +216,8 @@ module Crystal::System::Socket
         case error
         when .wsa_io_incomplete?, .wsaenotsock?
           return false
+        when .error_operation_aborted?
+          raise IO::TimeoutError.new("#{method} timed out")
         end
       end
 

--- a/src/crystal/system/win32/socket.cr
+++ b/src/crystal/system/win32/socket.cr
@@ -208,11 +208,7 @@ module Crystal::System::Socket
         return true
       end
 
-      unless operation.wait_for_completion(read_timeout)
-        raise IO::TimeoutError.new("#{method} timed out")
-      end
-
-      operation.wsa_result do |error|
+      operation.wait_for_wsa_result(read_timeout) do |error|
         case error
         when .wsa_io_incomplete?, .wsaenotsock?
           return false

--- a/src/crystal/system/win32/socket.cr
+++ b/src/crystal/system/win32/socket.cr
@@ -142,7 +142,6 @@ module Crystal::System::Socket
           return ::Socket::Error.from_os_error("ConnectEx", error)
         end
       else
-        operation.done!
         return nil
       end
 
@@ -204,7 +203,6 @@ module Crystal::System::Socket
           return false
         end
       else
-        operation.done!
         return true
       end
 


### PR DESCRIPTION
When an overlapped operation gets cancelled, we still need to wait for completion of the operation (with status `ERROR_OPERATION_ABORTED`) before it can be freed.
Previously we stored a reference to cancelled operations in a linked list and removed them when complete. This allows continuing executing the fiber directly after the cancellation is triggered, but it's also quite a bit of overhead.
Also it makes it impossible to allocate operations on the stack.

Cancellation is triggered when an operation times out.

The change in this patch is that after a timeout the fiber is suspended again, expecting completion via the event loop. Then the operation can be freed.

* Removes the `CANCELLED` state. It's no longer necessary, we only need to distinguish whether a fiber was woken up due to timeout or completion. A follow-up will further simplify the state handling.
* Replace special timeout event and fiber scheduling logic with generic `sleep` and `suspend`
* Drops `@@cancelled` linked list.
* Drops the workaround from https://github.com/crystal-lang/crystal/pull/14724#issuecomment-2187401075

