### PR TITLE
Fix regression on `Socket#connect` timeout type restriction

### DIFF
--- a/src/socket.cr
+++ b/src/socket.cr
@@ -110,6 +110,7 @@ class Socket < IO
   # Tries to connect to a remote address. Yields an `IO::TimeoutError` or an
   # `Socket::ConnectError` error if the connection failed.
   def connect(addr, timeout = nil, &)
+    timeout = timeout.seconds unless timeout.is_a?(::Time::Span?)
     result = system_connect(addr, timeout)
     yield result if result.is_a?(Exception)
   end


### PR DESCRIPTION
The `timeout` parameter of `system_connect` has an implict type restriction of `Time::Span?` and we need to convert numeric arguments. This fixes a regression introduced in https://github.com/crystal-lang/crystal/pull/14643.

Resolves #14752
Closes #14753