### PR TITLE
Drop default timeout for `Socket#connect` on Windows

### DIFF
--- a/src/crystal/system/win32/socket.cr
+++ b/src/crystal/system/win32/socket.cr
@@ -146,7 +146,7 @@ module Crystal::System::Socket
         return nil
       end
 
-      operation.wait_for_wsa_result(read_timeout || 1.seconds) do |error|
+      operation.wait_for_wsa_result(read_timeout) do |error|
         case error
         when .wsa_io_incomplete?, .wsaeconnrefused?
           return ::Socket::ConnectError.from_os_error(method, error)


### PR DESCRIPTION
IIRC the default timeout of was added when the IOCP event loop did not allow an unlimited timeout. This is possible now, and we can remove the workaround.