### PR TITLE
Remove incorrect uses of `describe`

### DIFF
--- a/spec/std/benchmark_spec.cr
+++ b/spec/std/benchmark_spec.cr
@@ -34,58 +34,8 @@ private def create_entry
   Benchmark::IPS::Entry.new("label", ->{ 1 + 1 })
 end
 
-describe Benchmark::IPS::Entry, "#set_cycles" do
-  it "sets the number of cycles needed to make 100ms" do
-    e = create_entry
-    e.set_cycles(2.seconds, 100)
-    e.cycles.should eq(5)
-
-    e.set_cycles(100.milliseconds, 1)
-    e.cycles.should eq(1)
-  end
-
-  it "sets the cycles to 1 no matter what" do
-    e = create_entry
-    e.set_cycles(2.seconds, 1)
-    e.cycles.should eq(1)
-  end
-end
-
-describe Benchmark::IPS::Entry, "#calculate_stats" do
-  it "correctly calculates basic stats" do
-    e = create_entry
-    e.calculate_stats([2, 4, 4, 4, 5, 5, 7, 9])
-
-    e.size.should eq(8)
-    e.mean.should eq(5.0)
-    e.variance.should eq(4.0)
-    e.stddev.should eq(2.0)
-  end
-end
-
 private def h_mean(mean)
   create_entry.tap { |e| e.mean = mean }.human_mean
-end
-
-describe Benchmark::IPS::Entry, "#human_mean" do
-  it { h_mean(0.01234567890123).should eq(" 12.35m") }
-  it { h_mean(0.12345678901234).should eq("123.46m") }
-
-  it { h_mean(1.23456789012345).should eq("  1.23 ") }
-  it { h_mean(12.3456789012345).should eq(" 12.35 ") }
-  it { h_mean(123.456789012345).should eq("123.46 ") }
-
-  it { h_mean(1234.56789012345).should eq("  1.23k") }
-  it { h_mean(12345.6789012345).should eq(" 12.35k") }
-  it { h_mean(123456.789012345).should eq("123.46k") }
-
-  it { h_mean(1234567.89012345).should eq("  1.23M") }
-  it { h_mean(12345678.9012345).should eq(" 12.35M") }
-  it { h_mean(123456789.012345).should eq("123.46M") }
-
-  it { h_mean(1234567890.12345).should eq("  1.23G") }
-  it { h_mean(12345678901.2345).should eq(" 12.35G") }
-  it { h_mean(123456789012.345).should eq("123.46G") }
 end
 
 private def h_ips(seconds)
@@ -93,22 +43,74 @@ private def h_ips(seconds)
   create_entry.tap { |e| e.mean = mean }.human_iteration_time
 end
 
-describe Benchmark::IPS::Entry, "#human_iteration_time" do
-  it { h_ips(1234.567_890_123).should eq("1,234.57s ") }
-  it { h_ips(123.456_789_012_3).should eq("123.46s ") }
-  it { h_ips(12.345_678_901_23).should eq(" 12.35s ") }
-  it { h_ips(1.234_567_890_123).should eq("  1.23s ") }
+describe Benchmark::IPS::Entry do
+  describe "#set_cycles" do
+    it "sets the number of cycles needed to make 100ms" do
+      e = create_entry
+      e.set_cycles(2.seconds, 100)
+      e.cycles.should eq(5)
 
-  it { h_ips(0.123_456_789_012).should eq("123.46ms") }
-  it { h_ips(0.012_345_678_901).should eq(" 12.35ms") }
-  it { h_ips(0.001_234_567_890).should eq("  1.23ms") }
+      e.set_cycles(100.milliseconds, 1)
+      e.cycles.should eq(1)
+    end
 
-  it { h_ips(0.000_123_456_789).should eq("123.46µs") }
-  it { h_ips(0.000_012_345_678).should eq(" 12.35µs") }
-  it { h_ips(0.000_001_234_567).should eq("  1.23µs") }
+    it "sets the cycles to 1 no matter what" do
+      e = create_entry
+      e.set_cycles(2.seconds, 1)
+      e.cycles.should eq(1)
+    end
+  end
 
-  it { h_ips(0.000_000_123_456).should eq("123.46ns") }
-  it { h_ips(0.000_000_012_345).should eq(" 12.34ns") }
-  it { h_ips(0.000_000_001_234).should eq("  1.23ns") }
-  it { h_ips(0.000_000_000_123).should eq("  0.12ns") }
+  describe "#calculate_stats" do
+    it "correctly calculates basic stats" do
+      e = create_entry
+      e.calculate_stats([2, 4, 4, 4, 5, 5, 7, 9])
+
+      e.size.should eq(8)
+      e.mean.should eq(5.0)
+      e.variance.should eq(4.0)
+      e.stddev.should eq(2.0)
+    end
+  end
+
+  describe "#human_mean" do
+    it { h_mean(0.01234567890123).should eq(" 12.35m") }
+    it { h_mean(0.12345678901234).should eq("123.46m") }
+
+    it { h_mean(1.23456789012345).should eq("  1.23 ") }
+    it { h_mean(12.3456789012345).should eq(" 12.35 ") }
+    it { h_mean(123.456789012345).should eq("123.46 ") }
+
+    it { h_mean(1234.56789012345).should eq("  1.23k") }
+    it { h_mean(12345.6789012345).should eq(" 12.35k") }
+    it { h_mean(123456.789012345).should eq("123.46k") }
+
+    it { h_mean(1234567.89012345).should eq("  1.23M") }
+    it { h_mean(12345678.9012345).should eq(" 12.35M") }
+    it { h_mean(123456789.012345).should eq("123.46M") }
+
+    it { h_mean(1234567890.12345).should eq("  1.23G") }
+    it { h_mean(12345678901.2345).should eq(" 12.35G") }
+    it { h_mean(123456789012.345).should eq("123.46G") }
+  end
+
+  describe "#human_iteration_time" do
+    it { h_ips(1234.567_890_123).should eq("1,234.57s ") }
+    it { h_ips(123.456_789_012_3).should eq("123.46s ") }
+    it { h_ips(12.345_678_901_23).should eq(" 12.35s ") }
+    it { h_ips(1.234_567_890_123).should eq("  1.23s ") }
+
+    it { h_ips(0.123_456_789_012).should eq("123.46ms") }
+    it { h_ips(0.012_345_678_901).should eq(" 12.35ms") }
+    it { h_ips(0.001_234_567_890).should eq("  1.23ms") }
+
+    it { h_ips(0.000_123_456_789).should eq("123.46µs") }
+    it { h_ips(0.000_012_345_678).should eq(" 12.35µs") }
+    it { h_ips(0.000_001_234_567).should eq("  1.23µs") }
+
+    it { h_ips(0.000_000_123_456).should eq("123.46ns") }
+    it { h_ips(0.000_000_012_345).should eq(" 12.34ns") }
+    it { h_ips(0.000_000_001_234).should eq("  1.23ns") }
+    it { h_ips(0.000_000_000_123).should eq("  0.12ns") }
+  end
 end

--- a/spec/std/string_scanner_spec.cr
+++ b/spec/std/string_scanner_spec.cr
@@ -1,356 +1,358 @@
 require "spec"
 require "string_scanner"
 
-describe StringScanner, "#scan" do
-  it "returns the string matched and advances the offset" do
-    s = StringScanner.new("this is a string")
-    s.scan(/\w+/).should eq("this")
-    s.scan(' ').should eq(" ")
-    s.scan("is ").should eq("is ")
-    s.scan(/\w+\s/).should eq("a ")
-    s.scan(/\w+/).should eq("string")
+describe StringScanner do
+  describe "#scan" do
+    it "returns the string matched and advances the offset" do
+      s = StringScanner.new("this is a string")
+      s.scan(/\w+/).should eq("this")
+      s.scan(' ').should eq(" ")
+      s.scan("is ").should eq("is ")
+      s.scan(/\w+\s/).should eq("a ")
+      s.scan(/\w+/).should eq("string")
+    end
+
+    it "returns nil if it can't match from the offset" do
+      s = StringScanner.new("test string")
+      s.scan(/\w+/).should_not be_nil # => "test"
+      s.scan(/\w+/).should be_nil
+      s.scan('s').should be_nil
+      s.scan("string").should be_nil
+      s.scan(/\s\w+/).should_not be_nil # => " string"
+      s.scan(/.*/).should_not be_nil    # => ""
+    end
   end
 
-  it "returns nil if it can't match from the offset" do
-    s = StringScanner.new("test string")
-    s.scan(/\w+/).should_not be_nil # => "test"
-    s.scan(/\w+/).should be_nil
-    s.scan('s').should be_nil
-    s.scan("string").should be_nil
-    s.scan(/\s\w+/).should_not be_nil # => " string"
-    s.scan(/.*/).should_not be_nil    # => ""
-  end
-end
+  describe "#scan_until" do
+    it "returns the string matched and advances the offset" do
+      s = StringScanner.new("test string")
+      s.scan_until(/t /).should eq("test ")
+      s.offset.should eq(5)
+      s.scan_until("tr").should eq("str")
+      s.offset.should eq(8)
+      s.scan_until('n').should eq("in")
+      s.offset.should eq(10)
+    end
 
-describe StringScanner, "#scan_until" do
-  it "returns the string matched and advances the offset" do
-    s = StringScanner.new("test string")
-    s.scan_until(/t /).should eq("test ")
-    s.offset.should eq(5)
-    s.scan_until("tr").should eq("str")
-    s.offset.should eq(8)
-    s.scan_until('n').should eq("in")
-    s.offset.should eq(10)
+    it "returns nil if it can't match from the offset" do
+      s = StringScanner.new("test string")
+      s.offset = 8
+      s.scan_until(/tr/).should be_nil
+      s.scan_until('r').should be_nil
+      s.scan_until("tr").should be_nil
+    end
   end
 
-  it "returns nil if it can't match from the offset" do
-    s = StringScanner.new("test string")
-    s.offset = 8
-    s.scan_until(/tr/).should be_nil
-    s.scan_until('r').should be_nil
-    s.scan_until("tr").should be_nil
-  end
-end
+  describe "#skip" do
+    it "advances the offset but does not returns the string matched" do
+      s = StringScanner.new("this is a string")
 
-describe StringScanner, "#skip" do
-  it "advances the offset but does not returns the string matched" do
-    s = StringScanner.new("this is a string")
+      s.skip(/\w+\s/).should eq(5)
+      s.offset.should eq(5)
+      s[0]?.should_not be_nil
 
-    s.skip(/\w+\s/).should eq(5)
-    s.offset.should eq(5)
-    s[0]?.should_not be_nil
+      s.skip(/\d+/).should eq(nil)
+      s.offset.should eq(5)
 
-    s.skip(/\d+/).should eq(nil)
-    s.offset.should eq(5)
+      s.skip('i').should eq(1)
+      s.offset.should eq(6)
 
-    s.skip('i').should eq(1)
-    s.offset.should eq(6)
+      s.skip("s ").should eq(2)
+      s.offset.should eq(8)
 
-    s.skip("s ").should eq(2)
-    s.offset.should eq(8)
+      s.skip(/\w+\s/).should eq(2)
+      s.offset.should eq(10)
 
-    s.skip(/\w+\s/).should eq(2)
-    s.offset.should eq(10)
-
-    s.skip(/\w+/).should eq(6)
-    s.offset.should eq(16)
-  end
-end
-
-describe StringScanner, "#skip_until" do
-  it "advances the offset but does not returns the string matched" do
-    s = StringScanner.new("this is a string")
-
-    s.skip_until(/not/).should eq(nil)
-    s.offset.should eq(0)
-    s[0]?.should be_nil
-
-    s.skip_until(/\sis\s/).should eq(8)
-    s.offset.should eq(8)
-    s[0]?.should_not be_nil
-
-    s.skip_until("st").should eq(4)
-    s.offset.should eq(12)
-    s[0]?.should_not be_nil
-
-    s.skip_until("ng").should eq(4)
-    s.offset.should eq(16)
-    s[0]?.should_not be_nil
-  end
-end
-
-describe StringScanner, "#eos" do
-  it "it is true when the offset is at the end" do
-    s = StringScanner.new("this is a string")
-    s.eos?.should eq(false)
-    s.skip(/(\w+\s?){4}/)
-    s.eos?.should eq(true)
-  end
-end
-
-describe StringScanner, "#check" do
-  it "returns the string matched but does not advances the offset" do
-    s = StringScanner.new("this is a string")
-    s.offset = 5
-
-    s.check(/\w+\s/).should eq("is ")
-    s.offset.should eq(5)
-    s.check(/\w+\s/).should eq("is ")
-    s.offset.should eq(5)
-    s.check('i').should eq("i")
-    s.offset.should eq(5)
-    s.check("is ").should eq("is ")
-    s.offset.should eq(5)
+      s.skip(/\w+/).should eq(6)
+      s.offset.should eq(16)
+    end
   end
 
-  it "returns nil if it can't match from the offset" do
-    s = StringScanner.new("test string")
-    s.check(/\d+/).should be_nil
-    s.check('0').should be_nil
-    s.check("01").should be_nil
-  end
-end
+  describe "#skip_until" do
+    it "advances the offset but does not returns the string matched" do
+      s = StringScanner.new("this is a string")
 
-describe StringScanner, "#check_until" do
-  it "returns the string matched and advances the offset" do
-    s = StringScanner.new("test string")
-    s.check_until(/tr/).should eq("test str")
-    s.offset.should eq(0)
-    s.check_until('r').should eq("test str")
-    s.offset.should eq(0)
-    s.check_until("tr").should eq("test str")
-    s.offset.should eq(0)
-    s.check_until(/g/).should eq("test string")
-    s.offset.should eq(0)
-    s.check_until('g').should eq("test string")
-    s.offset.should eq(0)
-    s.check_until("ng").should eq("test string")
-    s.offset.should eq(0)
+      s.skip_until(/not/).should eq(nil)
+      s.offset.should eq(0)
+      s[0]?.should be_nil
+
+      s.skip_until(/\sis\s/).should eq(8)
+      s.offset.should eq(8)
+      s[0]?.should_not be_nil
+
+      s.skip_until("st").should eq(4)
+      s.offset.should eq(12)
+      s[0]?.should_not be_nil
+
+      s.skip_until("ng").should eq(4)
+      s.offset.should eq(16)
+      s[0]?.should_not be_nil
+    end
   end
 
-  it "returns nil if it can't match from the offset" do
-    s = StringScanner.new("test string")
-    s.offset = 8
-    s.check_until(/tr/).should be_nil
-    s.check_until('r').should be_nil
-    s.check_until("tr").should be_nil
-  end
-end
-
-describe StringScanner, "#rest" do
-  it "returns the remainder of the string from the offset" do
-    s = StringScanner.new("this is a string")
-    s.rest.should eq("this is a string")
-
-    s.scan(/this is a /)
-    s.rest.should eq("string")
-
-    s.scan(/string/)
-    s.rest.should eq("")
-  end
-end
-
-describe StringScanner, "#[]" do
-  it "allows access to subgroups of the last match" do
-    s = StringScanner.new("Fri Dec 12 1975 14:39")
-    regex = /(?<wday>\w+) (?<month>\w+) (?<day>\d+)/
-    s.scan(regex).should eq("Fri Dec 12")
-    s[0].should eq("Fri Dec 12")
-    s[1].should eq("Fri")
-    s[2].should eq("Dec")
-    s[3].should eq("12")
-    s["wday"].should eq("Fri")
-    s["month"].should eq("Dec")
-    s["day"].should eq("12")
-
-    s.scan(' ').should eq(" ")
-    s[0].should eq(" ")
-    s.scan("1975").should eq("1975")
-    s[0].should eq("1975")
+  describe "#eos" do
+    it "it is true when the offset is at the end" do
+      s = StringScanner.new("this is a string")
+      s.eos?.should eq(false)
+      s.skip(/(\w+\s?){4}/)
+      s.eos?.should eq(true)
+    end
   end
 
-  it "raises when there is no last match" do
-    s = StringScanner.new("Fri Dec 12 1975 14:39")
+  describe "#check" do
+    it "returns the string matched but does not advances the offset" do
+      s = StringScanner.new("this is a string")
+      s.offset = 5
 
-    s.scan(/this is not there/)
-    expect_raises(Exception, "Nil assertion failed") { s[0] }
+      s.check(/\w+\s/).should eq("is ")
+      s.offset.should eq(5)
+      s.check(/\w+\s/).should eq("is ")
+      s.offset.should eq(5)
+      s.check('i').should eq("i")
+      s.offset.should eq(5)
+      s.check("is ").should eq("is ")
+      s.offset.should eq(5)
+    end
 
-    s.scan('t')
-    expect_raises(Exception, "Nil assertion failed") { s[0] }
-
-    s.scan("this is not there")
-    expect_raises(Exception, "Nil assertion failed") { s[0] }
+    it "returns nil if it can't match from the offset" do
+      s = StringScanner.new("test string")
+      s.check(/\d+/).should be_nil
+      s.check('0').should be_nil
+      s.check("01").should be_nil
+    end
   end
 
-  it "raises when there is no subgroup" do
-    s = StringScanner.new("Fri Dec 12 1975 14:39")
-    regex = /(?<wday>\w+) (?<month>\w+) (?<day>\d+)/
+  describe "#check_until" do
+    it "returns the string matched and advances the offset" do
+      s = StringScanner.new("test string")
+      s.check_until(/tr/).should eq("test str")
+      s.offset.should eq(0)
+      s.check_until('r').should eq("test str")
+      s.offset.should eq(0)
+      s.check_until("tr").should eq("test str")
+      s.offset.should eq(0)
+      s.check_until(/g/).should eq("test string")
+      s.offset.should eq(0)
+      s.check_until('g').should eq("test string")
+      s.offset.should eq(0)
+      s.check_until("ng").should eq("test string")
+      s.offset.should eq(0)
+    end
 
-    s.scan(regex)
-
-    s[0].should_not be_nil
-    expect_raises(IndexError) { s[5] }
-    expect_raises(KeyError, "Capture group 'something' does not exist") { s["something"] }
-
-    s.scan(' ')
-
-    s[0].should_not be_nil
-    expect_raises(IndexError) { s[1] }
-    expect_raises(KeyError, "Capture group 'something' does not exist") { s["something"] }
-
-    s.scan("1975")
-
-    s[0].should_not be_nil
-    expect_raises(IndexError) { s[1] }
-    expect_raises(KeyError, "Capture group 'something' does not exist") { s["something"] }
-  end
-end
-
-describe StringScanner, "#[]?" do
-  it "allows access to subgroups of the last match" do
-    s = StringScanner.new("Fri Dec 12 1975 14:39")
-    result = s.scan(/(?<wday>\w+) (?<month>\w+) (?<day>\d+)/)
-
-    result.should eq("Fri Dec 12")
-    s[0]?.should eq("Fri Dec 12")
-    s[1]?.should eq("Fri")
-    s[2]?.should eq("Dec")
-    s[3]?.should eq("12")
-    s["wday"]?.should eq("Fri")
-    s["month"]?.should eq("Dec")
-    s["day"]?.should eq("12")
-
-    s.scan(' ').should eq(" ")
-    s[0]?.should eq(" ")
-    s.scan("1975").should eq("1975")
-    s[0]?.should eq("1975")
+    it "returns nil if it can't match from the offset" do
+      s = StringScanner.new("test string")
+      s.offset = 8
+      s.check_until(/tr/).should be_nil
+      s.check_until('r').should be_nil
+      s.check_until("tr").should be_nil
+    end
   end
 
-  it "returns nil when there is no last match" do
-    s = StringScanner.new("Fri Dec 12 1975 14:39")
-    s.scan(/this is not there/)
+  describe "#rest" do
+    it "returns the remainder of the string from the offset" do
+      s = StringScanner.new("this is a string")
+      s.rest.should eq("this is a string")
 
-    s[0]?.should be_nil
+      s.scan(/this is a /)
+      s.rest.should eq("string")
 
-    s.scan('t')
-    s[0]?.should be_nil
-
-    s.scan("this is not there")
-    s[0]?.should be_nil
+      s.scan(/string/)
+      s.rest.should eq("")
+    end
   end
 
-  it "raises when there is no subgroup" do
-    s = StringScanner.new("Fri Dec 12 1975 14:39")
+  describe "#[]" do
+    it "allows access to subgroups of the last match" do
+      s = StringScanner.new("Fri Dec 12 1975 14:39")
+      regex = /(?<wday>\w+) (?<month>\w+) (?<day>\d+)/
+      s.scan(regex).should eq("Fri Dec 12")
+      s[0].should eq("Fri Dec 12")
+      s[1].should eq("Fri")
+      s[2].should eq("Dec")
+      s[3].should eq("12")
+      s["wday"].should eq("Fri")
+      s["month"].should eq("Dec")
+      s["day"].should eq("12")
 
-    s.scan(/(?<wday>\w+) (?<month>\w+) (?<day>\d+)/)
+      s.scan(' ').should eq(" ")
+      s[0].should eq(" ")
+      s.scan("1975").should eq("1975")
+      s[0].should eq("1975")
+    end
 
-    s[0]?.should_not be_nil
-    s[5]?.should be_nil
-    s["something"]?.should be_nil
+    it "raises when there is no last match" do
+      s = StringScanner.new("Fri Dec 12 1975 14:39")
 
-    s.scan(' ')
+      s.scan(/this is not there/)
+      expect_raises(Exception, "Nil assertion failed") { s[0] }
 
-    s[0]?.should_not be_nil
-    s[1]?.should be_nil
-    s["something"]?.should be_nil
+      s.scan('t')
+      expect_raises(Exception, "Nil assertion failed") { s[0] }
 
-    s.scan("1975")
+      s.scan("this is not there")
+      expect_raises(Exception, "Nil assertion failed") { s[0] }
+    end
 
-    s[0]?.should_not be_nil
-    s[1]?.should be_nil
-    s["something"]?.should be_nil
-  end
-end
+    it "raises when there is no subgroup" do
+      s = StringScanner.new("Fri Dec 12 1975 14:39")
+      regex = /(?<wday>\w+) (?<month>\w+) (?<day>\d+)/
 
-describe StringScanner, "#string" do
-  it { StringScanner.new("foo").string.should eq("foo") }
-end
+      s.scan(regex)
 
-describe StringScanner, "#offset" do
-  it "returns the current position" do
-    s = StringScanner.new("this is a string")
-    s.offset.should eq(0)
-    s.scan(/\w+/)
-    s.offset.should eq(4)
-  end
-end
+      s[0].should_not be_nil
+      expect_raises(IndexError) { s[5] }
+      expect_raises(KeyError, "Capture group 'something' does not exist") { s["something"] }
 
-describe StringScanner, "#offset=" do
-  it "sets the current position" do
-    s = StringScanner.new("this is a string")
-    s.offset = 5
-    s.scan(/\w+/).should eq("is")
-  end
+      s.scan(' ')
 
-  it "raises on negative positions" do
-    s = StringScanner.new("this is a string")
-    expect_raises(IndexError) { s.offset = -2 }
-  end
-end
+      s[0].should_not be_nil
+      expect_raises(IndexError) { s[1] }
+      expect_raises(KeyError, "Capture group 'something' does not exist") { s["something"] }
 
-describe StringScanner, "#inspect" do
-  it "has information on the scanner" do
-    s = StringScanner.new("this is a string")
-    s.inspect.should eq(%(#<StringScanner 0/16 "this " >))
-    s.scan(/\w+\s/)
-    s.inspect.should eq(%(#<StringScanner 5/16 "s is " >))
-    s.scan(/\w+\s/)
-    s.inspect.should eq(%(#<StringScanner 8/16 "s a s" >))
-    s.scan(/\w+\s\w+/)
-    s.inspect.should eq(%(#<StringScanner 16/16 "tring" >))
+      s.scan("1975")
+
+      s[0].should_not be_nil
+      expect_raises(IndexError) { s[1] }
+      expect_raises(KeyError, "Capture group 'something' does not exist") { s["something"] }
+    end
   end
 
-  it "works with small strings" do
-    s = StringScanner.new("hi")
-    s.inspect.should eq(%(#<StringScanner 0/2 "hi" >))
-    s.scan(/\w\w/)
-    s.inspect.should eq(%(#<StringScanner 2/2 "hi" >))
+  describe "#[]?" do
+    it "allows access to subgroups of the last match" do
+      s = StringScanner.new("Fri Dec 12 1975 14:39")
+      result = s.scan(/(?<wday>\w+) (?<month>\w+) (?<day>\d+)/)
+
+      result.should eq("Fri Dec 12")
+      s[0]?.should eq("Fri Dec 12")
+      s[1]?.should eq("Fri")
+      s[2]?.should eq("Dec")
+      s[3]?.should eq("12")
+      s["wday"]?.should eq("Fri")
+      s["month"]?.should eq("Dec")
+      s["day"]?.should eq("12")
+
+      s.scan(' ').should eq(" ")
+      s[0]?.should eq(" ")
+      s.scan("1975").should eq("1975")
+      s[0]?.should eq("1975")
+    end
+
+    it "returns nil when there is no last match" do
+      s = StringScanner.new("Fri Dec 12 1975 14:39")
+      s.scan(/this is not there/)
+
+      s[0]?.should be_nil
+
+      s.scan('t')
+      s[0]?.should be_nil
+
+      s.scan("this is not there")
+      s[0]?.should be_nil
+    end
+
+    it "raises when there is no subgroup" do
+      s = StringScanner.new("Fri Dec 12 1975 14:39")
+
+      s.scan(/(?<wday>\w+) (?<month>\w+) (?<day>\d+)/)
+
+      s[0]?.should_not be_nil
+      s[5]?.should be_nil
+      s["something"]?.should be_nil
+
+      s.scan(' ')
+
+      s[0]?.should_not be_nil
+      s[1]?.should be_nil
+      s["something"]?.should be_nil
+
+      s.scan("1975")
+
+      s[0]?.should_not be_nil
+      s[1]?.should be_nil
+      s["something"]?.should be_nil
+    end
   end
-end
 
-describe StringScanner, "#peek" do
-  it "shows the next len characters without advancing the offset" do
-    s = StringScanner.new("this is a string")
-    s.offset.should eq(0)
-    s.peek(4).should eq("this")
-    s.offset.should eq(0)
-    s.peek(7).should eq("this is")
-    s.offset.should eq(0)
+  describe "#string" do
+    it { StringScanner.new("foo").string.should eq("foo") }
   end
-end
 
-describe StringScanner, "#reset" do
-  it "resets the scan offset to the beginning and clears the last match" do
-    s = StringScanner.new("this is a string")
-    s.scan_until(/str/)
-    s[0]?.should_not be_nil
-    s.offset.should_not eq(0)
-
-    s.reset
-    s[0]?.should be_nil
-    s.offset.should eq(0)
+  describe "#offset" do
+    it "returns the current position" do
+      s = StringScanner.new("this is a string")
+      s.offset.should eq(0)
+      s.scan(/\w+/)
+      s.offset.should eq(4)
+    end
   end
-end
 
-describe StringScanner, "#terminate" do
-  it "moves the scan offset to the end of the string and clears the last match" do
-    s = StringScanner.new("this is a string")
-    s.scan_until(/str/)
-    s[0]?.should_not be_nil
-    s.eos?.should eq(false)
+  describe "#offset=" do
+    it "sets the current position" do
+      s = StringScanner.new("this is a string")
+      s.offset = 5
+      s.scan(/\w+/).should eq("is")
+    end
 
-    s.terminate
-    s[0]?.should be_nil
-    s.eos?.should eq(true)
+    it "raises on negative positions" do
+      s = StringScanner.new("this is a string")
+      expect_raises(IndexError) { s.offset = -2 }
+    end
+  end
+
+  describe "#inspect" do
+    it "has information on the scanner" do
+      s = StringScanner.new("this is a string")
+      s.inspect.should eq(%(#<StringScanner 0/16 "this " >))
+      s.scan(/\w+\s/)
+      s.inspect.should eq(%(#<StringScanner 5/16 "s is " >))
+      s.scan(/\w+\s/)
+      s.inspect.should eq(%(#<StringScanner 8/16 "s a s" >))
+      s.scan(/\w+\s\w+/)
+      s.inspect.should eq(%(#<StringScanner 16/16 "tring" >))
+    end
+
+    it "works with small strings" do
+      s = StringScanner.new("hi")
+      s.inspect.should eq(%(#<StringScanner 0/2 "hi" >))
+      s.scan(/\w\w/)
+      s.inspect.should eq(%(#<StringScanner 2/2 "hi" >))
+    end
+  end
+
+  describe "#peek" do
+    it "shows the next len characters without advancing the offset" do
+      s = StringScanner.new("this is a string")
+      s.offset.should eq(0)
+      s.peek(4).should eq("this")
+      s.offset.should eq(0)
+      s.peek(7).should eq("this is")
+      s.offset.should eq(0)
+    end
+  end
+
+  describe "#reset" do
+    it "resets the scan offset to the beginning and clears the last match" do
+      s = StringScanner.new("this is a string")
+      s.scan_until(/str/)
+      s[0]?.should_not be_nil
+      s.offset.should_not eq(0)
+
+      s.reset
+      s[0]?.should be_nil
+      s.offset.should eq(0)
+    end
+  end
+
+  describe "#terminate" do
+    it "moves the scan offset to the end of the string and clears the last match" do
+      s = StringScanner.new("this is a string")
+      s.scan_until(/str/)
+      s[0]?.should_not be_nil
+      s.eos?.should eq(false)
+
+      s.terminate
+      s[0]?.should be_nil
+      s.eos?.should eq(true)
+    end
   end
 end


### PR DESCRIPTION
A small number of specs pass both the class name and the method name as separate arguments to `describe`:

```crystal
class Foo
  def bar
  end
end

describe Foo, "#bar" do
end
```

But `describe` doesn't work like that and the method name is treated as a file name instead. This PR turns those specs back to the conventional form:

```crystal
describe Foo do
  describe "#bar" do
  end
end
```