### PR TITLE
Compiler: refactor codegen

### DIFF
--- a/src/compiler/crystal/compiler.cr
+++ b/src/compiler/crystal/compiler.cr
@@ -509,13 +509,7 @@ module Crystal
       if n_threads == 1
         sequential_codegen(units, reused)
       else
-        {% if flag?(:preview_mt) %}
-          raise "Cannot fork compiler in multithread mode."
-        {% elsif LibC.has_method?("fork") %}
-          fork_codegen(units, n_threads, reused)
-        {% else %}
-          raise "Cannot fork compiler. `Crystal::System::Process.fork` is not implemented on this system."
-        {% end %}
+        parallel_codegen(units, n_threads, reused)
       end
     end
 
@@ -530,6 +524,16 @@ module Crystal
           reused << unit.name if unit.reused_previous_compilation?
         end
       end
+    end
+
+    private def parallel_codegen(units, n_threads, reused)
+      {% if flag?(:preview_mt) %}
+        raise "Cannot fork compiler in multithread mode."
+      {% elsif LibC.has_method?("fork") %}
+        fork_codegen(units, n_threads, reused)
+      {% else %}
+        raise "Cannot fork compiler. `Crystal::System::Process.fork` is not implemented on this system."
+      {% end %}
     end
 
     private def fork_codegen(units, n_threads, reused)


### PR DESCRIPTION
Refactors `Crystal::Compiler`:

1. extracts `#sequential_codegen`, `#parallel_codegen` and `#fork_codegen` methods;
2. merges `#codegen_many_units` into `#codegen` directly;
3. stops collecting reused units: `#fork_codegen` now updates `CompilationUnit#reused_compilation_unit?` state as reported by the forked processes, and `#print_codegen_stats` now counts & filters the reused units.

Prerequisite for #14748 that will introduce `#mt_codegen`.