### PR TITLE
Codegen: stats and progress issues

### DIFF
--- a/src/compiler/crystal/compiler.cr
+++ b/src/compiler/crystal/compiler.cr
@@ -518,7 +518,7 @@ module Crystal
         end
         if @progress_tracker.stats?
           units.each do |unit|
-            all_reused << unit.name  && unit.reused_previous_compilation?
+            all_reused << unit.name && unit.reused_previous_compilation?
           end
         end
         return all_reused


### PR DESCRIPTION
The `--stats` and `--progress` params had a couple issues:

- codegen progress isn't updated when `--threads=1` (always the case on Windows);
- only stats need to collect reused modules (progress doesn't).

**Idea for a follow-up**: the report fiber of forked codegen could set `unit.reused_previous_compilation` instead of collecting reused module names, then we wouldn't need to collect the module names into a reused array (we can trust `units` to be updated) and the `#print_codegen_stats` method would count & filter has needed.