### PR TITLE
Prefer `strerror_r` over `strerror` for thread-safe errno

### DIFF
--- a/src/lib_c/aarch64-android/c/string.cr
+++ b/src/lib_c/aarch64-android/c/string.cr
@@ -5,5 +5,6 @@ lib LibC
   fun memcmp(__lhs : Void*, __rhs : Void*, __n : SizeT) : Int
   fun strcmp(__lhs : Char*, __rhs : Char*) : Int
   fun strerror(__errno_value : Int) : Char*
+  fun strerror_r(Int, Char*, SizeT) : Int
   fun strlen(__s : Char*) : SizeT
 end

--- a/src/lib_c/aarch64-darwin/c/string.cr
+++ b/src/lib_c/aarch64-darwin/c/string.cr
@@ -5,5 +5,6 @@ lib LibC
   fun memcmp(x0 : Void*, x1 : Void*, x2 : SizeT) : Int
   fun strcmp(x0 : Char*, x1 : Char*) : Int
   fun strerror(x0 : Int) : Char*
+  fun strerror_r(Int, Char*, SizeT) : Int
   fun strlen(x0 : Char*) : SizeT
 end

--- a/src/lib_c/aarch64-linux-gnu/c/string.cr
+++ b/src/lib_c/aarch64-linux-gnu/c/string.cr
@@ -5,5 +5,6 @@ lib LibC
   fun memcmp(s1 : Void*, s2 : Void*, n : SizeT) : Int
   fun strcmp(s1 : Char*, s2 : Char*) : Int
   fun strerror(errnum : Int) : Char*
+  fun strerror_r = __xpg_strerror_r(Int, Char*, SizeT) : Int
   fun strlen(s : Char*) : SizeT
 end

--- a/src/lib_c/aarch64-linux-musl/c/string.cr
+++ b/src/lib_c/aarch64-linux-musl/c/string.cr
@@ -5,5 +5,6 @@ lib LibC
   fun memcmp(x0 : Void*, x1 : Void*, x2 : SizeT) : Int
   fun strcmp(x0 : Char*, x1 : Char*) : Int
   fun strerror(x0 : Int) : Char*
+  fun strerror_r(Int, Char*, SizeT) : Int
   fun strlen(x0 : Char*) : SizeT
 end

--- a/src/lib_c/arm-linux-gnueabihf/c/string.cr
+++ b/src/lib_c/arm-linux-gnueabihf/c/string.cr
@@ -5,5 +5,6 @@ lib LibC
   fun memcmp(s1 : Void*, s2 : Void*, n : SizeT) : Int
   fun strcmp(s1 : Char*, s2 : Char*) : Int
   fun strerror(errnum : Int) : Char*
+  fun strerror_r = __xpg_strerror_r(Int, Char*, SizeT) : Int
   fun strlen(s : Char*) : SizeT
 end

--- a/src/lib_c/i386-linux-gnu/c/string.cr
+++ b/src/lib_c/i386-linux-gnu/c/string.cr
@@ -5,5 +5,6 @@ lib LibC
   fun memcmp(s1 : Void*, s2 : Void*, n : SizeT) : Int
   fun strcmp(s1 : Char*, s2 : Char*) : Int
   fun strerror(errnum : Int) : Char*
+  fun strerror_r = __xpg_strerror_r(Int, Char*, SizeT) : Int
   fun strlen(s : Char*) : SizeT
 end

--- a/src/lib_c/i386-linux-musl/c/string.cr
+++ b/src/lib_c/i386-linux-musl/c/string.cr
@@ -5,5 +5,6 @@ lib LibC
   fun memcmp(x0 : Void*, x1 : Void*, x2 : SizeT) : Int
   fun strcmp(x0 : Char*, x1 : Char*) : Int
   fun strerror(x0 : Int) : Char*
+  fun strerror_r(Int, Char*, SizeT) : Int
   fun strlen(x0 : Char*) : SizeT
 end

--- a/src/lib_c/wasm32-wasi/c/string.cr
+++ b/src/lib_c/wasm32-wasi/c/string.cr
@@ -5,5 +5,6 @@ lib LibC
   fun memcmp(x0 : Void*, x1 : Void*, x2 : SizeT) : Int
   fun strcmp(x0 : Char*, x1 : Char*) : Int
   fun strerror(x0 : Int) : Char*
+  fun strerror_r(Int, Char*, SizeT) : Int
   fun strlen(x0 : Char*) : ULong
 end

--- a/src/lib_c/x86_64-darwin/c/string.cr
+++ b/src/lib_c/x86_64-darwin/c/string.cr
@@ -5,5 +5,6 @@ lib LibC
   fun memcmp(x0 : Void*, x1 : Void*, x2 : SizeT) : Int
   fun strcmp(x0 : Char*, x1 : Char*) : Int
   fun strerror(x0 : Int) : Char*
+  fun strerror_r(Int, Char*, SizeT) : Int
   fun strlen(x0 : Char*) : SizeT
 end

--- a/src/lib_c/x86_64-dragonfly/c/string.cr
+++ b/src/lib_c/x86_64-dragonfly/c/string.cr
@@ -5,5 +5,6 @@ lib LibC
   fun memcmp(x0 : Void*, x1 : Void*, x2 : SizeT) : Int
   fun strcmp(x0 : Char*, x1 : Char*) : Int
   fun strerror(x0 : Int) : Char*
+  fun strerror_r(Int, Char*, SizeT) : Int
   fun strlen(x0 : Char*) : SizeT
 end

--- a/src/lib_c/x86_64-freebsd/c/string.cr
+++ b/src/lib_c/x86_64-freebsd/c/string.cr
@@ -5,5 +5,6 @@ lib LibC
   fun memcmp(x0 : Void*, x1 : Void*, x2 : SizeT) : Int
   fun strcmp(x0 : Char*, x1 : Char*) : Int
   fun strerror(x0 : Int) : Char*
+  fun strerror_r(Int, Char*, SizeT) : Int
   fun strlen(x0 : Char*) : SizeT
 end

--- a/src/lib_c/x86_64-linux-gnu/c/string.cr
+++ b/src/lib_c/x86_64-linux-gnu/c/string.cr
@@ -5,5 +5,6 @@ lib LibC
   fun memcmp(s1 : Void*, s2 : Void*, n : SizeT) : Int
   fun strcmp(s1 : Char*, s2 : Char*) : Int
   fun strerror(errnum : Int) : Char*
+  fun strerror_r = __xpg_strerror_r(Int, Char*, SizeT) : Int
   fun strlen(s : Char*) : SizeT
 end

--- a/src/lib_c/x86_64-linux-musl/c/string.cr
+++ b/src/lib_c/x86_64-linux-musl/c/string.cr
@@ -5,5 +5,6 @@ lib LibC
   fun memcmp(x0 : Void*, x1 : Void*, x2 : SizeT) : Int
   fun strcmp(x0 : Char*, x1 : Char*) : Int
   fun strerror(x0 : Int) : Char*
+  fun strerror_r(Int, Char*, SizeT) : Int
   fun strlen(x0 : Char*) : SizeT
 end

--- a/src/lib_c/x86_64-netbsd/c/string.cr
+++ b/src/lib_c/x86_64-netbsd/c/string.cr
@@ -5,5 +5,6 @@ lib LibC
   fun memcmp(x0 : Void*, x1 : Void*, x2 : SizeT) : Int
   fun strcmp(x0 : Char*, x1 : Char*) : Int
   fun strerror(x0 : Int) : Char*
+  fun strerror_r(Int, Char*, SizeT) : Int
   fun strlen(x0 : Char*) : ULong
 end

--- a/src/lib_c/x86_64-openbsd/c/string.cr
+++ b/src/lib_c/x86_64-openbsd/c/string.cr
@@ -5,5 +5,6 @@ lib LibC
   fun memcmp(x0 : Void*, x1 : Void*, x2 : SizeT) : Int
   fun strcmp(x0 : Char*, x1 : Char*) : Int
   fun strerror(x0 : Int) : Char*
+  fun strerror_r(Int, Char*, SizeT) : Int
   fun strlen(x0 : Char*) : ULong
 end

--- a/src/lib_c/x86_64-solaris/c/string.cr
+++ b/src/lib_c/x86_64-solaris/c/string.cr
@@ -5,5 +5,6 @@ lib LibC
   fun memcmp(x0 : Void*, x1 : Void*, x2 : SizeT) : Int
   fun strcmp(x0 : Char*, x1 : Char*) : Int
   fun strerror(x0 : Int) : Char*
+  fun strerror_r(Int, Char*, SizeT) : Int
   fun strlen(x0 : Char*) : SizeT
 end


### PR DESCRIPTION
Prefer the thread safe `strerror_r` over the thread unsafe `strerror` for reporting Errno message.

Follow up to #14733 