### PR TITLE
Fix: don't hardcode alpn protocol byte size (OpenSSL)

### DIFF
--- a/src/openssl/ssl/context.cr
+++ b/src/openssl/ssl/context.cr
@@ -178,7 +178,7 @@ abstract class OpenSSL::SSL::Context
       {% if LibSSL.has_method?(:ssl_ctx_set_alpn_select_cb) %}
         alpn_cb = ->(ssl : LibSSL::SSL, o : LibC::Char**, olen : LibC::Char*, i : LibC::Char*, ilen : LibC::Int, data : Void*) {
           proto = Box(Bytes).unbox(data)
-          ret = LibSSL.ssl_select_next_proto(o, olen, proto, 2, i, ilen)
+          ret = LibSSL.ssl_select_next_proto(o, olen, proto, proto.size, i, ilen)
           if ret != LibSSL::OPENSSL_NPN_NEGOTIATED
             LibSSL::SSL_TLSEXT_ERR_NOACK
           else


### PR DESCRIPTION
For some reason OpenSSL used to negotiate the protocol by itself, without invoking the select callback, or maybe didn't respect the total bytesize when processing the alpn string.

That changed in the 3.0.14 and other bugfix releases of OpenSSL, which exposed the bug.

**EDIT**: the best proof is the fixed [OpenSSL 3.0 test suite on CI](https://github.com/crystal-lang/crystal/actions/runs/9745388925/job/26893204981?pr=14769) :heavy_check_mark: 