### PR TITLE
Fix `IO::Delimited` reading into limited slice with peek

### DIFF
--- a/spec/std/io/delimited_spec.cr
+++ b/spec/std/io/delimited_spec.cr
@@ -259,6 +259,22 @@ describe "IO::Delimited" do
         io.gets_to_end.should eq("hello")
       end
 
+      it "handles the case of peek matching first byte, not having enough room, but later not matching (limted slice)" do
+        #                                 not a delimiter
+        #                                    ---
+        io = MemoryIOWithFixedPeek.new("abcdefgwijkfghhello")
+        #                               -------    ---
+        #                                peek    delimiter
+        io.peek_size = 7
+        delimited = IO::Delimited.new(io, read_delimiter: "fgh")
+
+        delimited.peek.should eq("abcde".to_slice)
+        delimited.read_string(6).should eq "abcdef"
+        delimited.read_string(5).should eq("gwijk")
+        delimited.gets_to_end.should eq("")
+        io.gets_to_end.should eq("hello")
+      end
+
       it "handles the case of peek matching first byte, not having enough room, later only partially matching" do
         #                                  delimiter
         #                                    ------------

--- a/src/io/delimited.cr
+++ b/src/io/delimited.cr
@@ -111,11 +111,13 @@ class IO::Delimited < IO
         next_index = @active_delimiter_buffer.index(first_byte, 1)
 
         # We read up to that new match, if any, or the entire buffer
-        read_bytes = next_index || @active_delimiter_buffer.size
+        read_bytes = Math.min(next_index || @active_delimiter_buffer.size, slice.size)
 
         slice.copy_from(@active_delimiter_buffer[0, read_bytes])
         slice += read_bytes
         @active_delimiter_buffer += read_bytes
+
+        return read_bytes if slice.empty?
         return read_bytes + read_internal(slice)
       end
     end


### PR DESCRIPTION
When copying into a slice we cannot assume it has unlimited capacity. In this case we need to restrict `next_index || @active_delimiter_buffer.size` to `slice.size` in order to avoid writing more than would fit.

I checked related code in this method but did not find a similar isssue elsewhere.

Resolves #14751