### PR TITLE
Expose LLVM instruction builder for `neg` and `fneg`

### DIFF
--- a/src/llvm/builder.cr
+++ b/src/llvm/builder.cr
@@ -239,11 +239,13 @@ class LLVM::Builder
     end
   {% end %}
 
-  def not(value, name = "")
-    # check_value(value)
+  {% for name in %w(not neg fneg) %}
+    def {{name.id}}(value, name = "")
+      # check_value(value)
 
-    Value.new LibLLVM.build_not(self, value, name)
-  end
+      Value.new LibLLVM.build_{{name.id}}(self, value, name)
+    end
+  {% end %}
 
   def unreachable
     Value.new LibLLVM.build_unreachable(self)

--- a/src/llvm/lib_llvm/core.cr
+++ b/src/llvm/lib_llvm/core.cr
@@ -239,6 +239,8 @@ lib LibLLVM
   fun build_or = LLVMBuildOr(BuilderRef, lhs : ValueRef, rhs : ValueRef, name : Char*) : ValueRef
   fun build_xor = LLVMBuildXor(BuilderRef, lhs : ValueRef, rhs : ValueRef, name : Char*) : ValueRef
   fun build_not = LLVMBuildNot(BuilderRef, value : ValueRef, name : Char*) : ValueRef
+  fun build_neg = LLVMBuildNeg(BuilderRef, value : ValueRef, name : Char*) : ValueRef
+  fun build_fneg = LLVMBuildFNeg(BuilderRef, value : ValueRef, name : Char*) : ValueRef
 
   fun build_malloc = LLVMBuildMalloc(BuilderRef, ty : TypeRef, name : Char*) : ValueRef
   fun build_array_malloc = LLVMBuildArrayMalloc(BuilderRef, ty : TypeRef, val : ValueRef, name : Char*) : ValueRef


### PR DESCRIPTION
# Purpose
Exposes the LLVM-C API to build `neg` and `fneg` instructions

# Reason
While the `neg` instruction is just a "super instruction" to `0 - self`, `fneg` as an instruction maintains NaN-ness inside of the floating point representation which may not be kept by performing `0 - self`.

# Notes
- If requested, an issue can be opened under the general goal of exposing more/updating the LLVM-C API to its modern counterparts (e.g. `LLVMArrayType` vs `LLVMArrayType2`)
- Bindings were tested as part of another [project](https://github.com/JarnaChao09/EECE5183-Compiler/blob/master/src/compiler/ast/unary.cr#L132-L145)