### PR TITLE
Update distribution-scripts

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -296,7 +296,7 @@ jobs:
           command: |
             brew unlink python@2 || true
 
-            brew install ruby@3 libffi pkgconfig libtool
+            brew install ruby@3 libffi pkgconfig libtool automake
 
             sudo mkdir -p /opt/crystal
             sudo chown $(whoami) /opt/crystal/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,7 +8,7 @@ parameters:
   distribution-scripts-version:
     description: "Git ref for version of https://github.com/crystal-lang/distribution-scripts/"
     type: string
-    default: "fe82a34ad7855ddb432a26ef7e48c46e7b440e49"
+    default: "96e431e170979125018bd4fd90111a3147477eec"
   previous_crystal_base_url:
     description: "Prefix for URLs to Crystal bootstrap compiler"
     type: string


### PR DESCRIPTION
Updates `distribution-scripts` dependency to https://github.com/crystal-lang/distribution-scripts/commit/96e431e170979125018bd4fd90111a3147477eec

This includes the following changes:

* crystal-lang/distribution-scripts#320
* crystal-lang/distribution-scripts#319

Requires #14777
