### PR TITLE
Add support for negative start index in `Slice#[start, count]`

### DIFF
--- a/spec/std/slice_spec.cr
+++ b/spec/std/slice_spec.cr
@@ -104,25 +104,34 @@ describe "Slice" do
 
   it "does []? with start and count" do
     slice = Slice.new(4) { |i| i + 1 }
+
     slice1 = slice[1, 2]?
     slice1.should_not be_nil
     slice1 = slice1.not_nil!
     slice1.size.should eq(2)
+    slice1.to_unsafe.should eq(slice.to_unsafe + 1)
     slice1[0].should eq(2)
     slice1[1].should eq(3)
 
-    slice[-1, 1]?.should be_nil
+    slice2 = slice[-1, 1]?
+    slice2.should_not be_nil
+    slice2 = slice2.not_nil!
+    slice2.size.should eq(1)
+    slice2.to_unsafe.should eq(slice.to_unsafe + 3)
+
     slice[3, 2]?.should be_nil
     slice[0, 5]?.should be_nil
-    slice[3, -1]?.should be_nil
+    expect_raises(ArgumentError, "Negative count: -1") { slice[3, -1]? }
   end
 
   it "does []? with range" do
     slice = Slice.new(4) { |i| i + 1 }
+
     slice1 = slice[1..2]?
     slice1.should_not be_nil
     slice1 = slice1.not_nil!
     slice1.size.should eq(2)
+    slice1.to_unsafe.should eq(slice.to_unsafe + 1)
     slice1[0].should eq(2)
     slice1[1].should eq(3)
 
@@ -134,15 +143,20 @@ describe "Slice" do
 
   it "does [] with start and count" do
     slice = Slice.new(4) { |i| i + 1 }
+
     slice1 = slice[1, 2]
     slice1.size.should eq(2)
+    slice1.to_unsafe.should eq(slice.to_unsafe + 1)
     slice1[0].should eq(2)
     slice1[1].should eq(3)
 
-    expect_raises(IndexError) { slice[-1, 1] }
+    slice2 = slice[-1, 1]
+    slice2.size.should eq(1)
+    slice2.to_unsafe.should eq(slice.to_unsafe + 3)
+
     expect_raises(IndexError) { slice[3, 2] }
     expect_raises(IndexError) { slice[0, 5] }
-    expect_raises(IndexError) { slice[3, -1] }
+    expect_raises(ArgumentError, "Negative count: -1") { slice[3, -1] }
   end
 
   it "does empty?" do
@@ -659,6 +673,7 @@ describe "Slice" do
     subslice = slice[2..4]
     subslice.read_only?.should be_false
     subslice.size.should eq(3)
+    subslice.to_unsafe.should eq(slice.to_unsafe + 2)
     subslice.should eq(Slice.new(3) { |i| i + 3 })
   end
 

--- a/src/slice.cr
+++ b/src/slice.cr
@@ -222,8 +222,12 @@ struct Slice(T)
   end
 
   # Returns a new slice that starts at *start* elements from this slice's start,
-  # and of *count* size.
+  # and of exactly *count* size.
   #
+  # Negative *start* is added to `#size`, thus it's treated as index counting
+  # from the end of the array, `-1` designating the last element.
+  #
+  # Raises `ArgumentError` if *count* is negative.
   # Returns `nil` if the new slice falls outside this slice.
   #
   # ```
@@ -232,6 +236,8 @@ struct Slice(T)
   #
   # slice[1, 3]?  # => Slice[11, 12, 13]
   # slice[1, 33]? # => nil
+  # slice[-3, 2]?  # => Slice[12, 13]
+  # slice[-3, 10]?  # => nil
   # ```
   def []?(start : Int, count : Int) : Slice(T)?
     # we skip the calculated count because the subslice must contain exactly
@@ -243,8 +249,12 @@ struct Slice(T)
   end
 
   # Returns a new slice that starts at *start* elements from this slice's start,
-  # and of *count* size.
+  # and of exactly *count* size.
   #
+  # Negative *start* is added to `#size`, thus it's treated as index counting
+  # from the end of the array, `-1` designating the last element.
+  #
+  # Raises `ArgumentError` if *count* is negative.
   # Raises `IndexError` if the new slice falls outside this slice.
   #
   # ```
@@ -253,6 +263,8 @@ struct Slice(T)
   #
   # slice[1, 3]  # => Slice[11, 12, 13]
   # slice[1, 33] # raises IndexError
+  # slice[-3, 2] # => Slice[12, 13]
+  # slice[-3, 10] # raises IndexError
   # ```
   def [](start : Int, count : Int) : Slice(T)
     self[start, count]? || raise IndexError.new

--- a/src/slice.cr
+++ b/src/slice.cr
@@ -234,10 +234,10 @@ struct Slice(T)
   # slice = Slice.new(5) { |i| i + 10 }
   # slice # => Slice[10, 11, 12, 13, 14]
   #
-  # slice[1, 3]?  # => Slice[11, 12, 13]
-  # slice[1, 33]? # => nil
+  # slice[1, 3]?   # => Slice[11, 12, 13]
+  # slice[1, 33]?  # => nil
   # slice[-3, 2]?  # => Slice[12, 13]
-  # slice[-3, 10]?  # => nil
+  # slice[-3, 10]? # => nil
   # ```
   def []?(start : Int, count : Int) : Slice(T)?
     # we skip the calculated count because the subslice must contain exactly
@@ -261,9 +261,9 @@ struct Slice(T)
   # slice = Slice.new(5) { |i| i + 10 }
   # slice # => Slice[10, 11, 12, 13, 14]
   #
-  # slice[1, 3]  # => Slice[11, 12, 13]
-  # slice[1, 33] # raises IndexError
-  # slice[-3, 2] # => Slice[12, 13]
+  # slice[1, 3]   # => Slice[11, 12, 13]
+  # slice[1, 33]  # raises IndexError
+  # slice[-3, 2]  # => Slice[12, 13]
   # slice[-3, 10] # raises IndexError
   # ```
   def [](start : Int, count : Int) : Slice(T)

--- a/src/slice.cr
+++ b/src/slice.cr
@@ -234,8 +234,10 @@ struct Slice(T)
   # slice[1, 33]? # => nil
   # ```
   def []?(start : Int, count : Int) : Slice(T)?
-    return unless 0 <= start <= @size
-    return unless 0 <= count <= @size - start
+    # we skip the calculated count because the subslice must contain exactly
+    # *count* elements
+    start, _ = Indexable.normalize_start_and_count(start, count, size) { return }
+    return unless count <= @size - start
 
     Slice.new(@pointer + start, count, read_only: @read_only)
   end


### PR DESCRIPTION
Allows `slice[-3, 3]` to return the last 3 elements of the slice, for example, similar to how Array#[-start, count] behaves, with the difference that Slice returns exactly *count* elements, while Array returns up to *count* elements.

Introduces a couple changes:

- negative start now returns from the end of the slice instead of returning nil/raising IndexError
- negative count now raises ArgumentError instead of returning nil/raising IndexError

I believe the current behavior is buggy (unexpected result, underspecified documentation), but this can be considered a breaking change.

refs #14775 