### PR TITLE
Fix regression with `NamedTuple.new` when using key with a hyphen

### DIFF
--- a/spec/std/named_tuple_spec.cr
+++ b/spec/std/named_tuple_spec.cr
@@ -20,6 +20,10 @@ describe "NamedTuple" do
     t.class.should_not eq(NamedTuple(foo: Int32, bar: String))
   end
 
+  it "does NamedTuple.new, with hyphen in key" do
+    NamedTuple("a-b": String).new("a-b": "foo").should eq({"a-b": "foo"})
+  end
+
   it "does NamedTuple.from" do
     t = NamedTuple(foo: Int32, bar: Int32).from({:foo => 1, :bar => 2})
     t.should eq({foo: 1, bar: 2})

--- a/src/named_tuple.cr
+++ b/src/named_tuple.cr
@@ -70,7 +70,7 @@ struct NamedTuple
       {% begin %}
         {
           {% for key in T %}
-            {{ key.stringify }}: options[{{ key.symbolize }}].as(typeof(element_type({{ key }}))),
+            {{ key.stringify }}: options[{{ key.symbolize }}].as(typeof(element_type({{ key.symbolize }}))),
           {% end %}
         }
       {% end %}


### PR DESCRIPTION
Fixes #14784

Likely a regression from https://github.com/crystal-lang/crystal/pull/12011 as it was working pre 1.5.0.