### PR TITLE
Add spec for `Compress::Gzip::Writer` with `extra`

### DIFF
--- a/spec/std/compress/gzip/gzip_spec.cr
+++ b/spec/std/compress/gzip/gzip_spec.cr
@@ -71,4 +71,27 @@ describe Compress::Gzip do
       end
     end
   end
+
+  it "writes and reads file with extra fields" do
+    io = IO::Memory.new
+    Compress::Gzip::Writer.open(io) do |gzip|
+      header = gzip.header
+      header.modification_time = Time.utc(2012, 9, 4, 22, 6, 5)
+      header.os = 3_u8
+      header.extra = Bytes[1, 2, 3, 4, 5]
+      header.name = "test.txt"
+      header.comment = "happy birthday"
+      gzip << "One\nTwo"
+    end
+    io.rewind
+    Compress::Gzip::Reader.open(io) do |gzip|
+      header = gzip.header.not_nil!
+      header.modification_time.to_utc.should eq(Time.utc(2012, 9, 4, 22, 6, 5))
+      header.os.should eq(3_u8)
+      header.extra.should eq(Bytes[1, 2, 3, 4, 5])
+      header.name.should eq("test.txt")
+      header.comment.should eq("happy birthday")
+      gzip.gets_to_end.should eq("One\nTwo")
+    end
+  end
 end


### PR DESCRIPTION
This adds a spec to ensure that writing an `extra` header field works.

Follow-up to #14550

Note the generated gzip data is *not* binary identical to the `test.gz` fixture, so we cannot directly compare the written gzip data.
Instead, the spec reads the data and verifies it has the same content as `test.gz`.
I believe the difference is because `Compress::Gzip::Writer` does not include a CRC for the header data (ref [C implementation](https://gist.github.com/kojix2/bd9523fdd3c1e7f8be4ce2c91fd17435#file-test_gzip_generator-c-L39)).

```
Compress::Gzip::Writer:
00000000  1f 8b 08 1c 4d 7b 46 50  00 03 05 00 01 02 03 04  ....M{FP........
00000010  05 74 65 73 74 2e 74 78  74 00 68 61 70 70 79 20  .test.txt.happy
00000020  62 69 72 74 68 64 61 79  00 f3 cf 4b e5 0a 29 cf  birthday...K..).
00000030  07 00 09 b9 78 f5 07 00  00 00                    ....x.....

test.gz:
00000000  1f 8b 08 1f 4d 7b 46 50  02 03 05 00 01 02 03 04  ....M{FP........
00000010  05 74 65 73 74 2e 74 78  74 00 68 61 70 70 79 20  .test.txt.happy
00000020  62 69 72 74 68 64 61 79  00 a1 2d f3 cf 4b e5 0a  birthday..-..K..
00000030  29 cf 07 00 09 b9 78 f5  07 00 00 00              ).....x.....
```