### PR TITLE
Enable full backtrace for exception in process spawn

### DIFF
--- a/src/crystal/system/unix/process.cr
+++ b/src/crystal/system/unix/process.cr
@@ -243,8 +243,9 @@ struct Crystal::System::Process
         writer_pipe.write_bytes(Errno.value.to_i)
       rescue ex
         writer_pipe.write_byte(0)
-        writer_pipe.write_bytes(ex.message.try(&.bytesize) || 0)
-        writer_pipe << ex.message
+        message = ex.inspect_with_backtrace
+        writer_pipe.write_bytes(message.bytesize)
+        writer_pipe << message
         writer_pipe.close
       ensure
         LibC._exit 127


### PR DESCRIPTION
If an exception raises in the code that prepares a forked process for `exec`, the error message of this exception is written through a pipe to the original process, which then raises an exception for the calling code (`Process.run`).
The error only includes a message, no stack trace. So the only stack trace you get is that of the handler which reads the message from the pipe and raises in the original process. 
But that's not very relevant. We want to know the location of the original exception.
This patch changes from sending just the exception message, to printing the entire backtrace (`inspect_with_backtrace`).

```cr
# process-run-exception.cr
Crystal::System::ORIGINAL_STDIN.close

Process.run("true")
```

Without this change:
```console
$  crystal run process-run-exception.cr
Unhandled exception: Error executing process: 'true': Could not reopen file descriptor: Bad file descriptor (RuntimeError)
  from /home/linuxbrew/.linuxbrew/Cellar/crystal/1.12.2/share/crystal/src/crystal/system/unix/process.cr:221:9 in 'spawn'
  from /home/linuxbrew/.linuxbrew/Cellar/crystal/1.12.2/share/crystal/src/process.cr:280:5 in 'initialize'
  from /home/linuxbrew/.linuxbrew/Cellar/crystal/1.12.2/share/crystal/src/process.cr:272:3 in 'new'
  from /home/linuxbrew/.linuxbrew/Cellar/crystal/1.12.2/share/crystal/src/process.cr:178:14 in 'run'
  from .test/process-run-exception.cr:3:1 in '__crystal_main'
  from /home/linuxbrew/.linuxbrew/Cellar/crystal/1.12.2/share/crystal/src/crystal/main.cr:129:5 in 'main_user_code'
  from /home/linuxbrew/.linuxbrew/Cellar/crystal/1.12.2/share/crystal/src/crystal/main.cr:115:7 in 'main'
  from /home/linuxbrew/.linuxbrew/Cellar/crystal/1.12.2/share/crystal/src/crystal/main.cr:141:3 in 'main'
  from /lib/x86_64-linux-gnu/libc.so.6 in '??'
  from /lib/x86_64-linux-gnu/libc.so.6 in '__libc_start_main'
  from /home/johannes/.cache/crystal/crystal-run-process-run-exception.tmp in '_start'
  from ??
```
With this change:
```console
$ bin/crystal run process-run-exception.cr
Unhandled exception: Error executing process: 'true': Could not reopen file descriptor: Bad file descriptor (IO::Error)
  from src/crystal/system/unix/file_descriptor.cr:94:5 in 'system_reopen'
  from src/io/file_descriptor.cr:252:5 in 'reopen'
  from src/crystal/system/unix/process.cr:348:5 in 'reopen_io'
  from src/crystal/system/unix/process.cr:304:5 in 'try_replace'
  from src/crystal/system/unix/process.cr:241:9 in 'spawn'
  from src/process.cr:280:5 in 'initialize'
  from src/process.cr:272:3 in 'new'
  from src/process.cr:178:14 in 'run'
  from .test/process-run-exception.cr:3:1 in '__crystal_main'
  from src/crystal/main.cr:118:5 in 'main_user_code'
  from src/crystal/main.cr:104:7 in 'main'
  from src/crystal/main.cr:130:3 in 'main'
  from /lib/x86_64-linux-gnu/libc.so.6 in '??'
  from /lib/x86_64-linux-gnu/libc.so.6 in '__libc_start_main'
  from /home/johannes/.cache/crystal/crystal-run-process-run-exception.tmp in '_start'
  from ???
 (RuntimeError)
  from src/crystal/system/unix/process.cr:267:9 in 'spawn'
  from src/process.cr:280:5 in 'initialize'
  from src/process.cr:272:3 in 'new'
  from src/process.cr:178:14 in 'run'
  from .test/process-run-exception.cr:3:1 in '__crystal_main'
  from src/crystal/main.cr:118:5 in 'main_user_code'
  from src/crystal/main.cr:104:7 in 'main'
  from src/crystal/main.cr:130:3 in 'main'
  from /lib/x86_64-linux-gnu/libc.so.6 in '??'
  from /lib/x86_64-linux-gnu/libc.so.6 in '__libc_start_main'
  from /home/johannes/.cache/crystal/crystal-run-process-run-exception.tmp in '_start'
  from ???
```