### PR TITLE
Fix code example for `Process.on_terminate`

### DIFF
--- a/src/process.cr
+++ b/src/process.cr
@@ -89,7 +89,7 @@ class Process
   #   end
   # end
   #
-  # wait_channel.receive
+  # wait_channel.receive?
   # puts "bye"
   # ```
   def self.on_terminate(&handler : ::Process::ExitReason ->) : Nil


### PR DESCRIPTION
Small tweak to the example. Currently, it results in an exception:
```
terminating gracefully
Unhandled exception: Channel is closed (Channel::ClosedError)
...
```

Instead of

```
terminating gracefully
bye
```