### PR TITLE
Epoll event loop (linux)

### DIFF
--- a/src/channel.cr
+++ b/src/channel.cr
@@ -743,9 +743,11 @@ class Channel(T)
     end
 
     def time_expired(fiber : Fiber) : Nil
-      if @select_context.try &.try_trigger
-        fiber.enqueue
-      end
+      fiber.enqueue if time_expired?
+    end
+
+    def time_expired? : Bool
+      @select_context.try &.try_trigger || false
     end
   end
 end

--- a/src/crystal/pointer_linked_list.cr
+++ b/src/crystal/pointer_linked_list.cr
@@ -86,4 +86,8 @@ struct Crystal::PointerLinkedList(T)
     each { |node| yield node }
     @head = Pointer(T).null
   end
+
+  def clear : Nil
+    @head = Pointer(T).null
+  end
 end

--- a/src/crystal/system/event_loop.cr
+++ b/src/crystal/system/event_loop.cr
@@ -3,6 +3,8 @@ abstract class Crystal::EventLoop
   def self.create : self
     {% if flag?(:wasi) %}
       Crystal::Wasi::EventLoop.new
+    {% elsif flag?(:linux) || flag?(:solaris) %}
+      Crystal::Epoll::EventLoop.new
     {% elsif flag?(:unix) %}
       Crystal::LibEvent::EventLoop.new
     {% elsif flag?(:win32) %}
@@ -72,6 +74,8 @@ end
 
 {% if flag?(:wasi) %}
   require "./wasi/event_loop"
+{% elsif flag?(:linux) || flag?(:solaris) %}
+  require "./unix/epoll/event_loop"
 {% elsif flag?(:unix) %}
   require "./unix/event_loop_libevent"
 {% elsif flag?(:win32) %}

--- a/src/crystal/system/file.cr
+++ b/src/crystal/system/file.cr
@@ -87,13 +87,6 @@ module Crystal::System::File
   private def self.error_is_file_exists?(errno)
     errno.in?(Errno::EEXIST, WinError::ERROR_FILE_EXISTS)
   end
-
-  # Closes the internal file descriptor without notifying libevent.
-  # This is directly used after the fork of a process to close the
-  # parent's Crystal::System::Signal.@@pipe reference before re initializing
-  # the event loop. In the case of a fork that will exec there is even
-  # no need to initialize the event loop at all.
-  # def file_descriptor_close
 end
 
 {% if flag?(:wasi) %}

--- a/src/crystal/system/file_descriptor.cr
+++ b/src/crystal/system/file_descriptor.cr
@@ -14,6 +14,13 @@ module Crystal::System::FileDescriptor
   # cooked mode otherwise.
   # private def system_raw(enable : Bool, & : ->)
 
+  # Closes the internal file descriptor without notifying libevent.
+  # This is directly used after the fork of a process to close the
+  # parent's Crystal::System::Signal.@@pipe reference before re initializing
+  # the event loop. In the case of a fork that will exec there is even
+  # no need to initialize the event loop at all.
+  # def file_descriptor_close(raise_on_error = true) : Nil
+
   private def system_read(slice : Bytes) : Int32
     event_loop.read(self, slice)
   end

--- a/src/crystal/system/unix/epoll.cr
+++ b/src/crystal/system/unix/epoll.cr
@@ -34,8 +34,6 @@ struct Crystal::System::Epoll
   end
 
   def close : Nil
-    if LibC.close(@epfd) == -1
-      raise RuntimeError.from_errno("close")
-    end
+    LibC.close(@epfd)
   end
 end

--- a/src/crystal/system/unix/epoll/event.cr
+++ b/src/crystal/system/unix/epoll/event.cr
@@ -10,6 +10,7 @@ struct Crystal::Epoll::Event
     IoTimeout
     Sleep
     SelectTimeout
+    Interrupt
   end
 
   getter fiber : Fiber
@@ -24,6 +25,13 @@ struct Crystal::Epoll::Event
   property! linked_event : Epoll::Event*
 
   include PointerLinkedList::Node
+
+  def self.interrupt(fd : Int32) : self*
+    event = Pointer(self).malloc(1)
+    fiber = uninitialized Fiber
+    event.value.initialize(fd, fiber, :interrupt)
+    event
+  end
 
   def initialize(@fd : Int32, @fiber : Fiber, @type : Type)
   end

--- a/src/crystal/system/unix/epoll/event.cr
+++ b/src/crystal/system/unix/epoll/event.cr
@@ -7,7 +7,6 @@ struct Crystal::Epoll::Event
   enum Type
     IoRead
     IoWrite
-    IoTimeout
     Sleep
     SelectTimeout
     System
@@ -17,12 +16,8 @@ struct Crystal::Epoll::Event
   getter type : Type
   getter fd : Int32
 
-  property! timerfd : System::TimerFD
+  property! time : Time::Span?
   getter? timed_out : Bool = false
-
-  # an :io_read and :io_write event may have a linked :io_timeout
-  # an :io_timeout event must be linked to an :io_read or :io_write event
-  property! linked_event : Epoll::Event*
 
   include PointerLinkedList::Node
 
@@ -35,11 +30,8 @@ struct Crystal::Epoll::Event
     event
   end
 
-  def initialize(@fd : Int32, @fiber : Fiber, @type : Type)
-  end
-
-  def initialize(@timerfd : System::TimerFD, @fiber : Fiber, @type : Type)
-    @fd = timerfd.fd
+  def initialize(@fd : Int32, @fiber : Fiber, @type : Type, timeout : Time::Span? = nil)
+    @time = ::Time.monotonic + timeout if timeout
   end
 
   def timed_out! : Bool

--- a/src/crystal/system/unix/epoll/event.cr
+++ b/src/crystal/system/unix/epoll/event.cr
@@ -10,7 +10,7 @@ struct Crystal::Epoll::Event
     IoTimeout
     Sleep
     SelectTimeout
-    Interrupt
+    System
   end
 
   getter fiber : Fiber
@@ -26,10 +26,12 @@ struct Crystal::Epoll::Event
 
   include PointerLinkedList::Node
 
-  def self.interrupt(fd : Int32) : self*
+  # Allocates a system event into the HEAP. A system event doesn't have an
+  # associated fiber.
+  def self.system(fd : Int32) : self*
     event = Pointer(self).malloc(1)
     fiber = uninitialized Fiber
-    event.value.initialize(fd, fiber, :interrupt)
+    event.value.initialize(fd, fiber, :system)
     event
   end
 

--- a/src/crystal/system/unix/epoll/event.cr
+++ b/src/crystal/system/unix/epoll/event.cr
@@ -1,0 +1,38 @@
+{% skip_file unless flag?(:linux) || flag?(:solaris) %}
+
+require "../epoll"
+require "../timerfd"
+
+struct Crystal::Epoll::Event
+  enum Type
+    IoRead
+    IoWrite
+    IoTimeout
+    Sleep
+    SelectTimeout
+  end
+
+  getter fiber : Fiber
+  getter type : Type
+  getter fd : Int32
+
+  property! timerfd : System::TimerFD
+  getter? timed_out : Bool = false
+
+  # an :io_read and :io_write event may have a linked :io_timeout
+  # an :io_timeout event must be linked to an :io_read or :io_write event
+  property! linked_event : Epoll::Event*
+
+  include PointerLinkedList::Node
+
+  def initialize(@fd : Int32, @fiber : Fiber, @type : Type)
+  end
+
+  def initialize(@timerfd : System::TimerFD, @fiber : Fiber, @type : Type)
+    @fd = timerfd.fd
+  end
+
+  def timed_out! : Bool
+    @timed_out = true
+  end
+end

--- a/src/crystal/system/unix/epoll/event_loop.cr
+++ b/src/crystal/system/unix/epoll/event_loop.cr
@@ -47,7 +47,7 @@ class Crystal::Epoll::EventLoop < Crystal::EventLoop
 
       # re-create eventfd to interrupt a run
       @interrupted.clear
-      @eventfd.close
+      LibC.close(@eventfd)
       @eventfd = LibC.eventfd(0, LibC::EFD_CLOEXEC)
       raise RuntimeError.from_errno("eventds") if @eventfd == -1
 

--- a/src/crystal/system/unix/epoll/event_loop.cr
+++ b/src/crystal/system/unix/epoll/event_loop.cr
@@ -102,7 +102,7 @@ class Crystal::Epoll::EventLoop < Crystal::EventLoop
   end
 
   def run(blocking : Bool) : Bool
-    if @events.empty?
+    if @events.empty? && @timers.empty?
       false
     else
       run_internal(blocking)

--- a/src/crystal/system/unix/epoll/event_loop.cr
+++ b/src/crystal/system/unix/epoll/event_loop.cr
@@ -1,0 +1,516 @@
+{% skip_file unless flag?(:linux) || flag?(:solaris) %}
+
+require "./event_queue"
+
+# OPTIMIZE: set `Node` as `epoll_event.data.ptr` instead of setting
+# `epoll_event.data.fd` to skip searches
+
+class Crystal::Epoll::EventLoop < Crystal::EventLoop
+  def initialize
+    # mutex prevents parallel access to the queues
+    @mutex = Thread::Mutex.new
+    @events = EventQueue.new
+
+    # the epoll instance
+    @epoll = System::Epoll.new
+
+    # pipe to interrupt a run
+    @interrupted = Atomic::Flag.new
+    @pipe = uninitialized LibC::Int[2]
+    ret = LibC.pipe2(@pipe, LibC::O_CLOEXEC)
+    raise RuntimeError.from_errno("pipe2") if ret == -1
+
+    # register permanent event
+    epoll_event = uninitialized LibC::EpollEvent
+    epoll_event.events = LibC::EPOLLIN
+    epoll_event.data.fd = @pipe[0]
+    @epoll.add(@pipe[0], pointerof(epoll_event))
+  end
+
+  {% unless flag?(:preview_mt) %}
+    def after_fork : Nil
+      # re-create the epoll instance
+      LibC.close(@epoll.@epfd)
+      @epoll = System::Epoll.new
+
+      # re-create pipe to interrupt a run
+      @pipe.each { |fd| LibC.close(fd) }
+      ret = LibC.pipe2(@pipe, LibC::O_CLOEXEC)
+      raise RuntimeError.from_errno("pipe2") if ret == -1
+
+      # re-register events:
+      epoll_event = uninitialized LibC::EpollEvent
+
+      epoll_event.events = LibC::EPOLLIN
+      epoll_event.data.fd = @pipe[0]
+      @epoll.add(@pipe[0], pointerof(epoll_event))
+
+      @events.each do |node|
+        epoll_event.events = LibC::EPOLLET | LibC::EPOLLEXCLUSIVE
+        epoll_event.events |= LibC::EPOLLIN if node.readers?
+        epoll_event.events |= LibC::EPOLLOUT if node.writers?
+        epoll_event.data.fd = node.fd
+        @epoll.add(node.fd, pointerof(epoll_event))
+      end
+    end
+  {% end %}
+
+  # {% if @top_level.has_constant?(:ExecutionContext) %}
+  #  # prevents parallel runs of the event loop
+  #  @run_mutex = Thread::Mutex.new
+
+  #  # Waits for events and returns a list of runnable fibers.
+  #  # Returns `nil` when there are no events to wait for.
+  #  #
+  #  # May return an empty list on spurious wakeup (we register both read & write
+  #  # IO events, so we may be notified about "ready to write" when we're
+  #  # "waiting for read").
+  #  def run(blocking : Bool) : ExecutionContext::Queue?
+  #    runnables = ExecutionContext::Queue.new
+
+  #    @run_mutex.synchronize do
+  #      return if @events.empty?
+  #      run_internal(blocking) { |fiber| runnables.push(fiber) }
+  #    end
+
+  #    runnables
+  #  end
+  # {% else %}
+  def run(blocking : Bool) : Bool
+    if @events.empty?
+      false
+    else
+      run_internal(blocking) # { |fiber| Crystal::Scheduler.enqueue(fiber) }
+      true
+    end
+  end
+
+  # {% end %}
+
+  private def run_internal(blocking : Bool) : Nil
+    buffer = uninitialized LibC::EpollEvent[32]
+
+    Crystal.trace :evloop, "wait", blocking: blocking ? 1 : 0
+
+    # wait for events (indefinitely when blocking)
+    epoll_events = @epoll.wait(buffer.to_slice, timeout: blocking ? -1 : 0)
+
+    # process each fd
+    @mutex.synchronize do
+      epoll_events.size.times do |i|
+        epoll_event = epoll_events.to_unsafe + i
+
+        # LibC.dprintf 2, "%s\n", epoll_event.value.inspect
+
+        if epoll_event.value.data.fd == @pipe[0]
+          handle_interruption
+          next
+        end
+
+        node = @events[epoll_event.value.data.fd]
+
+        if (epoll_event.value.events & (LibC::EPOLLERR | LibC::EPOLLHUP)) != 0
+          dequeue_all(node) # { |fiber| yield fiber }
+        else
+          process(node, epoll_event) # { |fiber| yield fiber }
+        end
+      end
+    end
+  end
+
+  private def handle_interruption : Nil
+    byte = 0_u8
+    LibC.read(@pipe[0], pointerof(byte), 1)
+    @interrupted.clear
+  end
+
+  private def dequeue_all(node)
+    node.each do |event|
+      case event.value.type
+      in .io_read?, .io_write?
+        cancel event.value.linked_event?
+        # yield event.value.fiber
+        Crystal::Scheduler.enqueue(event.value.fiber)
+      in .sleep?, .io_timeout?, .select_timeout?
+        raise "BUG: a timerfd file descriptor errored or got closed!"
+      end
+    end
+    @epoll.delete(node.fd)
+    @events.delete(node)
+  end
+
+  private def process(node, epoll_event)
+    readable = (epoll_event.value.events & LibC::EPOLLIN) == LibC::EPOLLIN
+    writable = (epoll_event.value.events & LibC::EPOLLOUT) == LibC::EPOLLOUT
+
+    if readable && (event = node.dequeue_reader?)
+      # wakeup one reader:
+      # for :io_read we want to avoid a "thundering herd" issue
+      # for :io_timeout, :select_timeout and :sleep there's only one reader
+      readable = false
+
+      if process_reader?(event)
+        # yield event.value.fiber
+        Crystal::Scheduler.enqueue(event.value.fiber)
+      end
+    end
+
+    if writable && (event = node.dequeue_writer?)
+      # wakeup one writer only (avoid "tundering herd"), cancel timeout (if any)
+      writable = false
+      cancel event.value.linked_event?
+
+      # yield event.value.fiber
+      Crystal::Scheduler.enqueue(event.value.fiber)
+    end
+
+    epoll_sync(node) do
+      @events.delete(node)
+    end
+
+    # validate data integrity
+    raise "BUG: #{node.fd} is ready for reading but no registered reader for #{node.fd}!\n" if readable
+    raise "BUG: #{node.fd} is ready for writing but no registered writer for #{node.fd}!\n" if writable
+  end
+
+  private def process_reader?(event)
+    case event.value.type
+    when .io_read?
+      # wakeup one reader, cancel timeout (if any)
+      cancel event.value.linked_event?
+    when .io_timeout?
+      # cancel linked read/write event
+      io_event = event.value.linked_event
+      io_event.value.timed_out!
+      cancel io_event
+    when .select_timeout?
+      # always dequeue the event but only enqueue the fiber if we win the
+      # atomic CAS
+      return false unless select_action = event.value.fiber.timeout_select_action
+      event.value.fiber.timeout_select_action = nil
+      return false unless select_action.time_expired?
+    when .sleep?
+      # nothing special
+    end
+
+    true
+  end
+
+  def interrupt : Nil
+    # the atomic makes sure we only write 1 byte to the pipe, so we can assume
+    # there's only 1 byte to read when the pipe fd is triggered
+    return unless @interrupted.test_and_set
+
+    byte = 1_u8
+    LibC.write(@pipe[1], pointerof(byte), 1)
+  end
+
+  # fiber
+
+  class FiberEvent
+    include Crystal::EventLoop::Event
+
+    def initialize(@event_loop : Crystal::Epoll::EventLoop, fiber : Fiber, type : Epoll::Event::Type)
+      @event = Epoll::Event.new(fiber.timerfd, fiber, type)
+    end
+
+    # sleeping or select timeout: arm timer & enqueue event
+    def add(timeout : ::Time::Span?) : Nil
+      @event.timerfd.set(::Time.monotonic + timeout)
+      @event_loop.enqueue(pointerof(@event))
+    end
+
+    # select timeout has been cancelled: disarm timer & dequeue event
+    def delete : Nil
+      @event.timerfd.cancel
+      @event_loop.dequeue(pointerof(@event))
+    end
+
+    def free : Nil
+    end
+  end
+
+  def create_resume_event(fiber : Fiber) : FiberEvent
+    FiberEvent.new(self, fiber, :sleep)
+  end
+
+  def create_timeout_event(fiber : Fiber) : FiberEvent
+    FiberEvent.new(self, fiber, :select_timeout)
+  end
+
+  # file descriptor
+
+  def read(file_descriptor : System::FileDescriptor, slice : Bytes) : Int32
+    size = evented_read(file_descriptor.fd, slice, file_descriptor.@read_timeout) do
+      check_open(file_descriptor)
+    end
+
+    if size == -1
+      if Errno.value == Errno::EBADF
+        raise IO::Error.new("File not open for reading", target: file_descriptor)
+      else
+        raise IO::Error.from_errno("read", target: file_descriptor)
+      end
+    else
+      size.to_i32
+    end
+  end
+
+  def write(file_descriptor : System::FileDescriptor, slice : Bytes) : Int32
+    size = evented_write(file_descriptor.fd, slice, file_descriptor.@write_timeout) do
+      check_open(file_descriptor)
+    end
+
+    if size == -1
+      if Errno.value == Errno::EBADF
+        raise IO::Error.new("File not open for writing", target: file_descriptor)
+      else
+        raise IO::Error.from_errno("write", target: file_descriptor)
+      end
+    else
+      size.to_i32
+    end
+  end
+
+  def close(file_descriptor : System::FileDescriptor) : Nil
+    evented_close(file_descriptor.fd)
+  end
+
+  # socket
+
+  def read(socket : ::Socket, slice : Bytes) : Int32
+    size = evented_read(socket.fd, slice, socket.@read_timeout) do
+      check_open(socket)
+    end
+    raise IO::Error.from_errno("read", target: socket) if size == -1
+    size
+  end
+
+  def write(socket : ::Socket, slice : Bytes) : Int32
+    size = evented_write(socket.fd, slice, socket.@write_timeout) do
+      check_open(socket)
+    end
+    raise IO::Error.from_errno("write", target: socket) if size == -1
+    size
+  end
+
+  def accept(socket : ::Socket) : ::Socket::Handle?
+    loop do
+      client_fd = LibC.accept4(socket.fd, nil, nil, LibC::SOCK_CLOEXEC)
+
+      return client_fd unless client_fd == -1
+      return if socket.closed?
+
+      if Errno.value == Errno::EAGAIN
+        wait_readable(socket.fd, socket.@read_timeout) do
+          raise IO::TimeoutError.new("Accept timed out")
+        end
+        return if socket.closed?
+      else
+        raise ::Socket::Error.from_errno("accept")
+      end
+    end
+  end
+
+  def connect(socket : ::Socket, address : ::Socket::Addrinfo | ::Socket::Address, timeout : ::Time::Span?) : IO::Error?
+    loop do
+      ret = LibC.connect(socket.fd, address, address.size)
+      return unless ret == -1
+
+      case Errno.value
+      when Errno::EISCONN
+        return
+      when Errno::EINPROGRESS, Errno::EALREADY
+        wait_writable(socket.fd, timeout) do
+          return IO::TimeoutError.new("Connect timed out")
+        end
+      else
+        return ::Socket::ConnectError.from_errno("connect")
+      end
+    end
+  end
+
+  def send_to(socket : ::Socket, slice : Bytes, address : ::Socket::Address) : Int32
+    bytes_sent = LibC.sendto(socket.fd, slice.to_unsafe.as(Void*), slice.size, 0, address, address.size)
+    raise ::Socket::Error.from_errno("Error sending datagram to #{address}") if bytes_sent == -1
+    bytes_sent.to_i32
+  end
+
+  def receive_from(socket : ::Socket, slice : Bytes) : {Int32, ::Socket::Address}
+    sockaddr = Pointer(LibC::SockaddrStorage).malloc.as(LibC::Sockaddr*)
+
+    # initialize sockaddr with the initialized family of the socket
+    copy = sockaddr.value
+    copy.sa_family = socket.family
+    sockaddr.value = copy
+    addrlen = LibC::SocklenT.new(sizeof(LibC::SockaddrStorage))
+
+    loop do
+      size = LibC.recvfrom(socket.fd, slice, slice.size, 0, sockaddr, pointerof(addrlen))
+      if size == -1
+        if Errno.value == Errno::EAGAIN
+          wait_readable(socket.fd, socket.@read_timeout)
+          check_open(socket)
+        else
+          raise IO::Error.from_errno("recvfrom", target: socket)
+        end
+      else
+        return {size.to_i32, ::Socket::Address.from(sockaddr, addrlen)}
+      end
+    end
+  end
+
+  def close(socket : ::Socket) : Nil
+    evented_close(socket.fd)
+  end
+
+  # evented internals
+
+  private def evented_read(fd : Int32, slice : Bytes, timeout : Time::Span?, &) : Int32
+    loop do
+      ret = LibC.read(fd, slice, slice.size)
+      if ret == -1 && Errno.value == Errno::EAGAIN
+        wait_readable(fd, timeout)
+        yield
+      else
+        return ret.to_i
+      end
+    end
+  end
+
+  private def evented_write(fd : Int32, slice : Bytes, timeout : Time::Span?, &) : Int32
+    loop do
+      ret = LibC.write(fd, slice, slice.size)
+      if ret == -1 && Errno.value == Errno::EAGAIN
+        wait_writable(fd, timeout)
+        yield
+      else
+        return ret.to_i
+      end
+    end
+  end
+
+  private def evented_close(fd : Int32)
+    # {% if @top_level.has_constant?(:ExecutionContext) %}
+    #  runnables = ExecutionContext::Queue.new
+
+    #  @mutex.synchronize do
+    #    return unless node = @events[fd]?
+    #    dequeue_all(node) { |fiber| runnables.push(fiber) }
+    #  end
+
+    #  ExecutionContext.enqueue(runnables) unless runnables.empty?
+    # {% else %}
+    @mutex.synchronize do
+      return unless node = @events[fd]?
+      dequeue_all(node) # { |fiber| Crystal::Scheduler.enqueue(fiber) }
+    end
+    # {% end %}
+  end
+
+  private def wait_readable(fd : Int32, timeout : Time::Span? = nil) : Nil
+    wait(:io_read, fd, timeout) { raise IO::TimeoutError.new("Read timed out") }
+  end
+
+  private def wait_readable(fd : Int32, timeout : Time::Span? = nil, &) : Nil
+    wait(:io_read, fd, timeout) { yield }
+  end
+
+  private def wait_writable(fd : Int32, timeout : Time::Span? = nil) : Nil
+    wait(:io_write, fd, timeout) { raise IO::TimeoutError.new("Write timed out") }
+  end
+
+  private def wait_writable(fd : Int32, timeout : Time::Span? = nil, &) : Nil
+    wait(:io_write, fd, timeout) { yield }
+  end
+
+  private def wait(event_type : Epoll::Event::Type, fd : Int32, timeout : ::Time::Span?, &) : Nil
+    fiber = Fiber.current
+    io_event = Epoll::Event.new(fd, fiber, event_type)
+    io_timeout = uninitialized Epoll::Event
+
+    if timeout
+      timerfd = fiber.timerfd
+      timerfd.set(::Time.monotonic + timeout)
+
+      io_timeout = Epoll::Event.new(timerfd, fiber, :io_timeout)
+      io_timeout.linked_event = pointerof(io_event)
+      io_event.linked_event = pointerof(io_timeout)
+    end
+
+    @mutex.synchronize do
+      unsafe_enqueue pointerof(io_event)
+      unsafe_enqueue pointerof(io_timeout) if timeout
+    end
+
+    Fiber.suspend
+
+    if timeout && io_event.timed_out?
+      yield
+    end
+  end
+
+  private def check_open(io : IO)
+    raise IO::Error.new("Closed stream") if io.closed?
+  end
+
+  # queue internals
+
+  protected def enqueue(event : Epoll::Event*)
+    @mutex.synchronize { unsafe_enqueue(event) }
+  end
+
+  private def unsafe_enqueue(event : Epoll::Event*)
+    Crystal.trace :evloop, "unsafe_enqueue", fd: event.value.fd, type: event.value.type.to_s
+    node = @events.enqueue(event)
+    epoll_sync(node) { raise "unreachable" }
+  end
+
+  # similar to #cancel, except we don't disarm the timer (already done)
+  protected def dequeue(event : Epoll::Event*)
+    @mutex.synchronize do
+      node = @events.dequeue(event)
+      epoll_sync(node) { @events.delete(node) }
+    end
+  end
+
+  # unsafe, yields when there are no more events for fd
+  private def epoll_sync(node)
+    events = 0
+    events |= LibC::EPOLLIN if node.readers?
+    events |= LibC::EPOLLOUT if node.writers?
+
+    # Crystal.trace :evloop, "epoll_sync", fd: node.fd, from: node.events, to: events
+
+    if events == 0
+      Crystal.trace :evloop, "epoll_ctl", op: "del", fd: node.fd
+      @epoll.delete(node.fd)
+      yield
+    else
+      epoll_event = uninitialized LibC::EpollEvent
+      epoll_event.events = events | LibC::EPOLLET | LibC::EPOLLEXCLUSIVE
+      epoll_event.data.fd = node.fd
+
+      if node.events == 0
+        Crystal.trace :evloop, "epoll_ctl", op: "add", fd: node.fd, events: events
+        @epoll.add(node.fd, pointerof(epoll_event))
+      else
+        Crystal.trace :evloop, "epoll_ctl", op: "mod", fd: node.fd, events: events
+        @epoll.modify(node.fd, pointerof(epoll_event))
+      end
+
+      node.events = events
+    end
+  end
+
+  private def cancel(event : Epoll::Event*)
+    event.value.timerfd?.try(&.cancel)
+
+    node = @events.dequeue(event)
+    epoll_sync(node) { @events.delete(node) }
+  end
+
+  @[AlwaysInline]
+  private def cancel(event : Nil)
+  end
+end

--- a/src/crystal/system/unix/epoll/event_loop.cr
+++ b/src/crystal/system/unix/epoll/event_loop.cr
@@ -15,7 +15,7 @@ class Crystal::Epoll::EventLoop < Crystal::EventLoop
     # notification to interrupt a run
     @interrupted = Atomic::Flag.new
     @eventfd = System::EventFD.new
-    @eventfd_event = Epoll::Event.interrupt(@eventfd.fd)
+    @eventfd_event = Epoll::Event.system(@eventfd.fd)
     @eventfd_node = EventQueue::Node.new(@eventfd.fd)
     @eventfd_node.add(@eventfd_event)
 
@@ -47,7 +47,7 @@ class Crystal::Epoll::EventLoop < Crystal::EventLoop
       @interrupted.clear
       @eventfd.close
       @eventfd = System::EventFD.new
-      @eventfd_event = Epoll::Event.interrupt(@eventfd.fd)
+      @eventfd_event = Epoll::Event.system(@eventfd.fd)
       @eventfd_node.clear
       @eventfd_node.add(@eventfd_event)
 
@@ -142,8 +142,8 @@ class Crystal::Epoll::EventLoop < Crystal::EventLoop
         Crystal::Scheduler.enqueue(event.value.fiber)
       in .sleep?, .io_timeout?, .select_timeout?
         raise "BUG: a timerfd file descriptor errored or got closed!"
-      in .interrupt?
-        raise "BUG: an eventfd file descriptor errored or got closed!"
+      in .system?
+        raise "BUG: a system file descriptor errored or got closed!"
       end
     end
     @events.delete(node)

--- a/src/crystal/system/unix/epoll/event_loop.cr
+++ b/src/crystal/system/unix/epoll/event_loop.cr
@@ -48,7 +48,7 @@ class Crystal::Epoll::EventLoop < Crystal::EventLoop
       @eventfd.close
       @eventfd = System::EventFD.new
       @eventfd_event = Epoll::Event.system(@eventfd.fd)
-      @eventfd_node.clear
+      @eventfd_node = EventQueue::Node.new(@eventfd.fd)
       @eventfd_node.add(@eventfd_event)
 
       # re-register events:

--- a/src/crystal/system/unix/epoll/event_queue.cr
+++ b/src/crystal/system/unix/epoll/event_queue.cr
@@ -1,0 +1,103 @@
+{% skip_file unless flag?(:linux) || flag?(:solaris) %}
+
+require "./event"
+
+# NOTE: this is a struct because it only wraps a const pointer to a hash
+# allocated in the heap —no need to allocate an object and dereference 2
+# pointers when we can only dereference 1.
+struct Crystal::Epoll::EventQueue
+  class Node
+    property fd : Int32
+    property events : Int32 = 0
+
+    getter readers = PointerLinkedList(Event).new
+    getter writers = PointerLinkedList(Event).new
+
+    def initialize(@fd : Int32)
+      @events = 0
+    end
+
+    def readers? : Bool
+      !@readers.empty?
+    end
+
+    def writers? : Bool
+      !@writers.empty?
+    end
+
+    def add(event : Event*) : Nil
+      case event.value.type
+      when .io_write?
+        @writers.push(event)
+      else
+        @readers.push(event)
+      end
+    end
+
+    def each(&block : Event* ->) : Nil
+      @readers.each(&block)
+      @writers.each(&block)
+    end
+
+    def dequeue_reader? : Event* | Nil
+      @readers.shift?
+    end
+
+    def dequeue_writer? : Event* | Nil
+      @writers.shift?
+    end
+
+    def delete(event)
+      case event.value.type
+      when .io_write?
+        @writers.delete(event)
+      else
+        @readers.delete(event)
+      end
+    end
+
+    def clear : Nil
+      @readers.clear
+      @writers.clear
+      @events = 0
+    end
+  end
+
+  def initialize
+    # OPTIMIZE: there may be a more efficient data structure than open
+    # addressing hash (?)
+    @list = {} of Int32 => Node
+  end
+
+  def [](fd : Int32) : Node
+    @list.fetch(fd) { raise "BUG: unregistered file descriptor: #{fd}" }
+  end
+
+  def []?(fd : Int32) : Node?
+    @list[fd]?
+  end
+
+  def enqueue(event : Event*) : Node
+    node = @list[event.value.fd] ||= Node.new(event.value.fd)
+    node.add(event)
+    node
+  end
+
+  def dequeue(event : Event*) : Node
+    node = self[event.value.fd]
+    node.delete(event)
+    node
+  end
+
+  def delete(node : Node) : Nil
+    @list.delete(node.fd)
+  end
+
+  def empty? : Bool
+    @list.empty?
+  end
+
+  def each(& : Node ->) : Nil
+    @list.each_value { |node| yield node }
+  end
+end

--- a/src/crystal/system/unix/epoll/timers.cr
+++ b/src/crystal/system/unix/epoll/timers.cr
@@ -4,6 +4,10 @@ struct Crystal::Epoll::Timers
     @list = Deque(Epoll::Event*).new
   end
 
+  def empty? : Bool
+    @list.empty?
+  end
+
   def next_ready? : Time::Span?
     @list.first?.try(&.value.time)
   end

--- a/src/crystal/system/unix/epoll/timers.cr
+++ b/src/crystal/system/unix/epoll/timers.cr
@@ -1,0 +1,45 @@
+# NOTE: this is a struct because it's a mere pointer to a Deque
+struct Crystal::Epoll::Timers
+  def initialize
+    @list = Deque(Epoll::Event*).new
+  end
+
+  def next_ready? : Time::Span?
+    @list.first?.try(&.value.time)
+  end
+
+  def dequeue_ready(&) : Nil
+    return if @list.empty?
+
+    now = Time.monotonic
+    n = 0
+
+    @list.each do |event|
+      break if event.value.time > now
+      yield event
+      n += 1
+    end
+
+    n.times { @list.shift }
+  end
+
+  def add(event : Epoll::Event*) : Nil
+    if @list.empty?
+      @list << event
+    elsif index = lookup(event.value.time)
+      @list.insert(index, event)
+    else
+      @list.push(event)
+    end
+  end
+
+  def delete(event : Epoll::Event*) : Nil
+    @list.delete(event)
+  end
+
+  private def lookup(time)
+    @list.each_with_index do |event, index|
+      return index if event.value.time >= time
+    end
+  end
+end

--- a/src/crystal/system/unix/eventfd.cr
+++ b/src/crystal/system/unix/eventfd.cr
@@ -1,0 +1,31 @@
+require "c/sys/eventfd"
+
+struct Crystal::System::EventFD
+  # NOTE: no need to concern ourselves with endianness: we interpret the bytes
+  # in the system order and eventfd can only be used locally (no cross system
+  # issues).
+
+  getter fd : Int32
+
+  def initialize(value = 0)
+    @fd = LibC.eventfd(value, LibC::EFD_CLOEXEC)
+    raise RuntimeError.from_errno("eventfd") if @fd == -1
+  end
+
+  def read : UInt64
+    buf = uninitialized UInt8[8]
+    bytes_read = LibC.read(@fd, buf.to_unsafe, buf.size)
+    raise RuntimeError.from_errno("eventfd_read") unless bytes_read == 8
+    buf.unsafe_as(UInt64)
+  end
+
+  def write(value : UInt64) : Nil
+    buf = value.unsafe_as(StaticArray(UInt8, 8))
+    bytes_written = LibC.write(@fd, buf.to_unsafe, buf.size)
+    raise RuntimeError.from_errno("eventfd_write") if bytes_written == 8
+  end
+
+  def close : Nil
+    LibC.close(@fd)
+  end
+end

--- a/src/crystal/system/unix/file_descriptor.cr
+++ b/src/crystal/system/unix/file_descriptor.cr
@@ -120,12 +120,13 @@ module Crystal::System::FileDescriptor
     file_descriptor_close
   end
 
-  def file_descriptor_close : Nil
+  def file_descriptor_close(raise_on_error = true) : Nil
     # Clear the @volatile_fd before actually closing it in order to
     # reduce the chance of reading an outdated fd value
     _fd = @volatile_fd.swap(-1)
+    return if _fd == -1
 
-    if LibC.close(_fd) != 0
+    if LibC.close(_fd) != 0 && raise_on_error
       case Errno.value
       when Errno::EINTR, Errno::EINPROGRESS
         # ignore

--- a/src/crystal/system/unix/file_descriptor.cr
+++ b/src/crystal/system/unix/file_descriptor.cr
@@ -1,5 +1,7 @@
 require "c/fcntl"
-require "io/evented"
+{% unless flag?(:linux) || flag?(:solaris) %}
+  require "io/evented"
+{% end %}
 require "termios"
 {% if flag?(:android) && LibC::ANDROID_API < 28 %}
   require "c/sys/ioctl"
@@ -7,7 +9,9 @@ require "termios"
 
 # :nodoc:
 module Crystal::System::FileDescriptor
-  include IO::Evented
+  {% unless flag?(:linux) || flag?(:solaris) %}
+    include IO::Evented
+  {% end %}
 
   # Platform-specific type to represent a file descriptor handle to the operating
   # system.

--- a/src/crystal/system/unix/process.cr
+++ b/src/crystal/system/unix/process.cr
@@ -187,6 +187,9 @@ struct Crystal::System::Process
       if will_exec
         # reset signal handlers, then sigmask (inherited on exec):
         Crystal::System::Signal.after_fork_before_exec
+        if Crystal::EventLoop.current.responds_to?(:after_fork_before_exec)
+          Crystal::EventLoop.current.after_fork_before_exec
+        end
         LibC.sigemptyset(pointerof(newmask))
         LibC.pthread_sigmask(LibC::SIG_SETMASK, pointerof(newmask), nil)
       else

--- a/src/crystal/system/unix/process.cr
+++ b/src/crystal/system/unix/process.cr
@@ -187,9 +187,13 @@ struct Crystal::System::Process
       if will_exec
         # reset signal handlers, then sigmask (inherited on exec):
         Crystal::System::Signal.after_fork_before_exec
-        if Crystal::EventLoop.current.responds_to?(:after_fork_before_exec)
-          Crystal::EventLoop.current.after_fork_before_exec
+
+        # some event loop need to fix their mutexes (to close some fd)
+        current_event_loop = Crystal::EventLoop.current
+        if current_event_loop.responds_to?(:after_fork_before_exec)
+          current_event_loop.after_fork_before_exec
         end
+
         LibC.sigemptyset(pointerof(newmask))
         LibC.pthread_sigmask(LibC::SIG_SETMASK, pointerof(newmask), nil)
       else

--- a/src/crystal/system/unix/socket.cr
+++ b/src/crystal/system/unix/socket.cr
@@ -1,10 +1,14 @@
 require "c/netdb"
 require "c/netinet/tcp"
 require "c/sys/socket"
-require "io/evented"
+{% unless flag?(:linux) || flag?(:solaris) %}
+  require "io/evented"
+{% end %}
 
 module Crystal::System::Socket
-  include IO::Evented
+  {% unless flag?(:linux) || flag?(:solaris) %}
+    include IO::Evented
+  {% end %}
 
   alias Handle = Int32
 

--- a/src/crystal/system/unix/timerfd.cr
+++ b/src/crystal/system/unix/timerfd.cr
@@ -1,0 +1,35 @@
+{% skip_file unless flag?(:linux) || flag?(:solaris) %}
+
+require "c/sys/timerfd"
+
+struct Crystal::System::TimerFD
+  getter fd : Int32
+
+  # Create a `timerfd` instance set to the monotonic clock.
+  def initialize
+    @fd = LibC.timerfd_create(LibC::CLOCK_MONOTONIC, LibC::TFD_CLOEXEC)
+    raise RuntimeError.from_errno("timerfd_settime") if @fd == -1
+  end
+
+  # Arm (start) the timer to run at *time* (absolute time).
+  def set(time : ::Time::Span) : Nil
+    itimerspec = uninitialized LibC::Itimerspec
+    itimerspec.it_interval.tv_sec = 0
+    itimerspec.it_interval.tv_nsec = 0
+    itimerspec.it_value.tv_sec = typeof(itimerspec.it_value.tv_sec).new!(time.@seconds)
+    itimerspec.it_value.tv_nsec = typeof(itimerspec.it_value.tv_nsec).new!(time.@nanoseconds)
+    ret = LibC.timerfd_settime(@fd, LibC::TFD_TIMER_ABSTIME, pointerof(itimerspec), nil)
+    raise RuntimeError.from_errno("timerfd_settime") if ret == -1
+  end
+
+  # Disarm (stop) the timer.
+  def cancel : Nil
+    itimerspec = LibC::Itimerspec.new
+    ret = LibC.timerfd_settime(@fd, LibC::TFD_TIMER_ABSTIME, pointerof(itimerspec), nil)
+    raise RuntimeError.from_errno("timerfd_settime") if ret == -1
+  end
+
+  def close
+    LibC.close(@fd)
+  end
+end

--- a/src/crystal/system/win32/file_descriptor.cr
+++ b/src/crystal/system/win32/file_descriptor.cr
@@ -176,8 +176,8 @@ module Crystal::System::FileDescriptor
     file_descriptor_close
   end
 
-  def file_descriptor_close
-    if LibC.CloseHandle(windows_handle) == 0
+  def file_descriptor_close(raise_on_error = true) : Nil
+    if LibC.CloseHandle(windows_handle) == 0 && raise_on_error
       raise IO::Error.from_winerror("Error closing file", target: self)
     end
   end

--- a/src/crystal/tracing.cr
+++ b/src/crystal/tracing.cr
@@ -7,6 +7,7 @@ module Crystal
     enum Section
       GC
       Sched
+      Evloop
 
       def self.from_id(slice) : self
         {% begin %}
@@ -81,6 +82,9 @@ module Crystal
 
         def write(uint : Int::Unsigned) : Nil
           System.to_int_slice(uint, 10, false, 2) { |bytes| write(bytes) }
+        end
+
+        def write(x : Nil) : Nil
         end
 
         def to_slice : Bytes

--- a/src/fiber.cr
+++ b/src/fiber.cr
@@ -1,6 +1,10 @@
 require "crystal/system/thread_linked_list"
 require "./fiber/context"
 
+{% if flag?(:linux) || flag?(:solaris) %}
+  require "crystal/system/unix/timerfd"
+{% end %}
+
 # :nodoc:
 @[NoInline]
 fun _fiber_get_stack_top : Void*
@@ -162,6 +166,7 @@ class Fiber
     Fiber.inactive(self)
 
     # Delete the resume event if it was used by `yield` or `sleep`
+    {% if flag?(:linux) || flag?(:solaris) %} @timerfd.try &.close {% end %}
     @resume_event.try &.free
     @timeout_event.try &.free
     @timeout_select_action = nil
@@ -222,6 +227,16 @@ class Fiber
   def enqueue : Nil
     Crystal::Scheduler.enqueue(self)
   end
+
+  {% if flag?(:linux) || flag?(:solaris) %}
+    # :nodoc:
+    def timerfd : Crystal::System::TimerFD
+      # we keep a single timerfd per fiber and use it for all event types (:sleep,
+      # :io_timeout and :fiber_timeout) because there can only be one event at any
+      # point in time; it avoids creating/closing timers continuously.
+      @timerfd ||= Crystal::System::TimerFD.new
+    end
+  {% end %}
 
   # :nodoc:
   def resume_event : Crystal::EventLoop::Event

--- a/src/fiber.cr
+++ b/src/fiber.cr
@@ -241,6 +241,7 @@ class Fiber
 
   # :nodoc:
   def cancel_timeout : Nil
+    return unless @timeout_select_action
     @timeout_select_action = nil
     @timeout_event.try &.delete
   end

--- a/src/io/evented.cr
+++ b/src/io/evented.cr
@@ -1,4 +1,6 @@
-{% skip_file if flag?(:win32) %}
+{% skip_file if flag?(:win32) || flag?(:linux) || flag?(:solaris) %}
+# Windows: we use IOCP
+# Linux/Solaris: we use epoll
 
 require "crystal/thread_local_value"
 

--- a/src/io/file_descriptor.cr
+++ b/src/io/file_descriptor.cr
@@ -236,7 +236,7 @@ class IO::FileDescriptor < IO
   def finalize
     return if closed? || !close_on_finalize?
 
-    close rescue nil
+    file_descriptor_close(raise_on_error: false)
   end
 
   def closed? : Bool

--- a/src/lib_c/aarch64-android/c/sys/epoll.cr
+++ b/src/lib_c/aarch64-android/c/sys/epoll.cr
@@ -20,7 +20,6 @@ lib LibC
     u64 : UInt64
   end
 
-  @[Packed]
   struct EpollEvent
     events : UInt32
     data : EpollDataT

--- a/src/lib_c/aarch64-android/c/sys/epoll.cr
+++ b/src/lib_c/aarch64-android/c/sys/epoll.cr
@@ -1,0 +1,32 @@
+lib LibC
+  EPOLLIN  = 0x001_u32
+  EPOLLOUT = 0x004_u32
+  EPOLLERR = 0x008_u32
+  EPOLLHUP = 0x010_u32
+
+  EPOLLEXCLUSIVE = 1_u32 << 28
+  EPOLLET        = 1_u32 << 31
+
+  EPOLL_CTL_ADD = 1
+  EPOLL_CTL_DEL = 2
+  EPOLL_CTL_MOD = 3
+
+  EPOLL_CLOEXEC = 0o2000000
+
+  union EpollDataT
+    ptr : Void*
+    fd : Int
+    u32 : UInt32
+    u64 : UInt64
+  end
+
+  @[Packed]
+  struct EpollEvent
+    events : UInt32
+    data : EpollDataT
+  end
+
+  fun epoll_create1(Int) : Int
+  fun epoll_ctl(Int, Int, Int, EpollEvent*) : Int
+  fun epoll_wait(Int, EpollEvent*, Int, Int) : Int
+end

--- a/src/lib_c/aarch64-android/c/sys/eventfd.cr
+++ b/src/lib_c/aarch64-android/c/sys/eventfd.cr
@@ -1,0 +1,9 @@
+lib LibC
+  EFD_CLOEXEC = 0o2000000
+
+  alias EventfdT = UInt64
+
+  fun eventfd(count : UInt, flags : Int) : Int
+  fun eventfd_read(fd : Int, value : EventfdT*) : Int
+  fun eventfd_write(fd : Int, value : EventfdT) : Int
+end

--- a/src/lib_c/aarch64-android/c/sys/eventfd.cr
+++ b/src/lib_c/aarch64-android/c/sys/eventfd.cr
@@ -1,9 +1,5 @@
 lib LibC
   EFD_CLOEXEC = 0o2000000
 
-  alias EventfdT = UInt64
-
   fun eventfd(count : UInt, flags : Int) : Int
-  fun eventfd_read(fd : Int, value : EventfdT*) : Int
-  fun eventfd_write(fd : Int, value : EventfdT) : Int
 end

--- a/src/lib_c/aarch64-android/c/sys/timerfd.cr
+++ b/src/lib_c/aarch64-android/c/sys/timerfd.cr
@@ -1,0 +1,10 @@
+require "../time"
+
+lib LibC
+  TFD_NONBLOCK      = 0o0004000
+  TFD_CLOEXEC       = 0o2000000
+  TFD_TIMER_ABSTIME = 1 << 0
+
+  fun timerfd_create(ClockidT, Int) : Int
+  fun timerfd_settime(Int, Int, Itimerspec*, Itimerspec*) : Int
+end

--- a/src/lib_c/aarch64-android/c/time.cr
+++ b/src/lib_c/aarch64-android/c/time.cr
@@ -23,6 +23,11 @@ lib LibC
     tv_nsec : Long
   end
 
+  struct Itimerspec
+    it_interval : Timespec
+    it_value : Timespec
+  end
+
   fun clock_gettime(__clock : ClockidT, __ts : Timespec*) : Int
   fun clock_settime(__clock : ClockidT, __ts : Timespec*) : Int
   fun gmtime_r(__t : TimeT*, __tm : Tm*) : Tm*

--- a/src/lib_c/aarch64-linux-gnu/c/sys/epoll.cr
+++ b/src/lib_c/aarch64-linux-gnu/c/sys/epoll.cr
@@ -20,7 +20,6 @@ lib LibC
     u64 : UInt64
   end
 
-  @[Packed]
   struct EpollEvent
     events : UInt32
     data : EpollDataT

--- a/src/lib_c/aarch64-linux-gnu/c/sys/epoll.cr
+++ b/src/lib_c/aarch64-linux-gnu/c/sys/epoll.cr
@@ -1,0 +1,32 @@
+lib LibC
+  EPOLLIN  = 0x001_u32
+  EPOLLOUT = 0x004_u32
+  EPOLLERR = 0x008_u32
+  EPOLLHUP = 0x010_u32
+
+  EPOLLEXCLUSIVE = 1_u32 << 28
+  EPOLLET        = 1_u32 << 31
+
+  EPOLL_CTL_ADD = 1
+  EPOLL_CTL_DEL = 2
+  EPOLL_CTL_MOD = 3
+
+  EPOLL_CLOEXEC = 0o2000000
+
+  union EpollDataT
+    ptr : Void*
+    fd : Int
+    u32 : UInt32
+    u64 : UInt64
+  end
+
+  @[Packed]
+  struct EpollEvent
+    events : UInt32
+    data : EpollDataT
+  end
+
+  fun epoll_create1(Int) : Int
+  fun epoll_ctl(Int, Int, Int, EpollEvent*) : Int
+  fun epoll_wait(Int, EpollEvent*, Int, Int) : Int
+end

--- a/src/lib_c/aarch64-linux-gnu/c/sys/eventfd.cr
+++ b/src/lib_c/aarch64-linux-gnu/c/sys/eventfd.cr
@@ -1,0 +1,9 @@
+lib LibC
+  EFD_CLOEXEC = 0o2000000
+
+  alias EventfdT = UInt64
+
+  fun eventfd(count : UInt, flags : Int) : Int
+  fun eventfd_read(fd : Int, value : EventfdT*) : Int
+  fun eventfd_write(fd : Int, value : EventfdT) : Int
+end

--- a/src/lib_c/aarch64-linux-gnu/c/sys/eventfd.cr
+++ b/src/lib_c/aarch64-linux-gnu/c/sys/eventfd.cr
@@ -1,9 +1,5 @@
 lib LibC
   EFD_CLOEXEC = 0o2000000
 
-  alias EventfdT = UInt64
-
   fun eventfd(count : UInt, flags : Int) : Int
-  fun eventfd_read(fd : Int, value : EventfdT*) : Int
-  fun eventfd_write(fd : Int, value : EventfdT) : Int
 end

--- a/src/lib_c/aarch64-linux-gnu/c/sys/timerfd.cr
+++ b/src/lib_c/aarch64-linux-gnu/c/sys/timerfd.cr
@@ -1,0 +1,10 @@
+require "../time"
+
+lib LibC
+  TFD_NONBLOCK      = 0o0004000
+  TFD_CLOEXEC       = 0o2000000
+  TFD_TIMER_ABSTIME = 1 << 0
+
+  fun timerfd_create(ClockidT, Int) : Int
+  fun timerfd_settime(Int, Int, Itimerspec*, Itimerspec*) : Int
+end

--- a/src/lib_c/aarch64-linux-gnu/c/time.cr
+++ b/src/lib_c/aarch64-linux-gnu/c/time.cr
@@ -23,6 +23,11 @@ lib LibC
     tv_nsec : Long
   end
 
+  struct Itimerspec
+    it_interval : Timespec
+    it_value : Timespec
+  end
+
   fun clock_gettime(clock_id : ClockidT, tp : Timespec*) : Int
   fun clock_settime(clock_id : ClockidT, tp : Timespec*) : Int
   fun gmtime_r(timer : TimeT*, tp : Tm*) : Tm*

--- a/src/lib_c/aarch64-linux-musl/c/sys/epoll.cr
+++ b/src/lib_c/aarch64-linux-musl/c/sys/epoll.cr
@@ -20,7 +20,6 @@ lib LibC
     u64 : UInt64
   end
 
-  @[Packed]
   struct EpollEvent
     events : UInt32
     data : EpollDataT

--- a/src/lib_c/aarch64-linux-musl/c/sys/epoll.cr
+++ b/src/lib_c/aarch64-linux-musl/c/sys/epoll.cr
@@ -1,0 +1,32 @@
+lib LibC
+  EPOLLIN  = 0x001_u32
+  EPOLLOUT = 0x004_u32
+  EPOLLERR = 0x008_u32
+  EPOLLHUP = 0x010_u32
+
+  EPOLLEXCLUSIVE = 1_u32 << 28
+  EPOLLET        = 1_u32 << 31
+
+  EPOLL_CTL_ADD = 1
+  EPOLL_CTL_DEL = 2
+  EPOLL_CTL_MOD = 3
+
+  EPOLL_CLOEXEC = 0o2000000
+
+  union EpollDataT
+    ptr : Void*
+    fd : Int
+    u32 : UInt32
+    u64 : UInt64
+  end
+
+  @[Packed]
+  struct EpollEvent
+    events : UInt32
+    data : EpollDataT
+  end
+
+  fun epoll_create1(Int) : Int
+  fun epoll_ctl(Int, Int, Int, EpollEvent*) : Int
+  fun epoll_wait(Int, EpollEvent*, Int, Int) : Int
+end

--- a/src/lib_c/aarch64-linux-musl/c/sys/eventfd.cr
+++ b/src/lib_c/aarch64-linux-musl/c/sys/eventfd.cr
@@ -1,0 +1,9 @@
+lib LibC
+  EFD_CLOEXEC = 0o2000000
+
+  alias EventfdT = UInt64
+
+  fun eventfd(count : UInt, flags : Int) : Int
+  fun eventfd_read(fd : Int, value : EventfdT*) : Int
+  fun eventfd_write(fd : Int, value : EventfdT) : Int
+end

--- a/src/lib_c/aarch64-linux-musl/c/sys/eventfd.cr
+++ b/src/lib_c/aarch64-linux-musl/c/sys/eventfd.cr
@@ -1,9 +1,5 @@
 lib LibC
   EFD_CLOEXEC = 0o2000000
 
-  alias EventfdT = UInt64
-
   fun eventfd(count : UInt, flags : Int) : Int
-  fun eventfd_read(fd : Int, value : EventfdT*) : Int
-  fun eventfd_write(fd : Int, value : EventfdT) : Int
 end

--- a/src/lib_c/aarch64-linux-musl/c/sys/timerfd.cr
+++ b/src/lib_c/aarch64-linux-musl/c/sys/timerfd.cr
@@ -1,0 +1,10 @@
+require "../time"
+
+lib LibC
+  TFD_NONBLOCK      = 0o0004000
+  TFD_CLOEXEC       = 0o2000000
+  TFD_TIMER_ABSTIME = 1 << 0
+
+  fun timerfd_create(ClockidT, Int) : Int
+  fun timerfd_settime(Int, Int, Itimerspec*, Itimerspec*) : Int
+end

--- a/src/lib_c/aarch64-linux-musl/c/time.cr
+++ b/src/lib_c/aarch64-linux-musl/c/time.cr
@@ -23,6 +23,11 @@ lib LibC
     tv_nsec : Long
   end
 
+  struct Itimerspec
+    it_interval : Timespec
+    it_value : Timespec
+  end
+
   fun clock_gettime(x0 : ClockidT, x1 : Timespec*) : Int
   fun clock_settime(x0 : ClockidT, x1 : Timespec*) : Int
   fun gmtime_r(x0 : TimeT*, x1 : Tm*) : Tm*

--- a/src/lib_c/arm-linux-gnueabihf/c/sys/epoll.cr
+++ b/src/lib_c/arm-linux-gnueabihf/c/sys/epoll.cr
@@ -20,7 +20,6 @@ lib LibC
     u64 : UInt64
   end
 
-  @[Packed]
   struct EpollEvent
     events : UInt32
     data : EpollDataT

--- a/src/lib_c/arm-linux-gnueabihf/c/sys/epoll.cr
+++ b/src/lib_c/arm-linux-gnueabihf/c/sys/epoll.cr
@@ -1,0 +1,32 @@
+lib LibC
+  EPOLLIN  = 0x001_u32
+  EPOLLOUT = 0x004_u32
+  EPOLLERR = 0x008_u32
+  EPOLLHUP = 0x010_u32
+
+  EPOLLEXCLUSIVE = 1_u32 << 28
+  EPOLLET        = 1_u32 << 31
+
+  EPOLL_CTL_ADD = 1
+  EPOLL_CTL_DEL = 2
+  EPOLL_CTL_MOD = 3
+
+  EPOLL_CLOEXEC = 0o2000000
+
+  union EpollDataT
+    ptr : Void*
+    fd : Int
+    u32 : UInt32
+    u64 : UInt64
+  end
+
+  @[Packed]
+  struct EpollEvent
+    events : UInt32
+    data : EpollDataT
+  end
+
+  fun epoll_create1(Int) : Int
+  fun epoll_ctl(Int, Int, Int, EpollEvent*) : Int
+  fun epoll_wait(Int, EpollEvent*, Int, Int) : Int
+end

--- a/src/lib_c/arm-linux-gnueabihf/c/sys/eventfd.cr
+++ b/src/lib_c/arm-linux-gnueabihf/c/sys/eventfd.cr
@@ -1,0 +1,9 @@
+lib LibC
+  EFD_CLOEXEC = 0o2000000
+
+  alias EventfdT = UInt64
+
+  fun eventfd(count : UInt, flags : Int) : Int
+  fun eventfd_read(fd : Int, value : EventfdT*) : Int
+  fun eventfd_write(fd : Int, value : EventfdT) : Int
+end

--- a/src/lib_c/arm-linux-gnueabihf/c/sys/eventfd.cr
+++ b/src/lib_c/arm-linux-gnueabihf/c/sys/eventfd.cr
@@ -1,9 +1,5 @@
 lib LibC
   EFD_CLOEXEC = 0o2000000
 
-  alias EventfdT = UInt64
-
   fun eventfd(count : UInt, flags : Int) : Int
-  fun eventfd_read(fd : Int, value : EventfdT*) : Int
-  fun eventfd_write(fd : Int, value : EventfdT) : Int
 end

--- a/src/lib_c/arm-linux-gnueabihf/c/sys/timerfd.cr
+++ b/src/lib_c/arm-linux-gnueabihf/c/sys/timerfd.cr
@@ -1,0 +1,10 @@
+require "../time"
+
+lib LibC
+  TFD_NONBLOCK      = 0o0004000
+  TFD_CLOEXEC       = 0o2000000
+  TFD_TIMER_ABSTIME = 1 << 0
+
+  fun timerfd_create(ClockidT, Int) : Int
+  fun timerfd_settime(Int, Int, Itimerspec*, Itimerspec*) : Int
+end

--- a/src/lib_c/arm-linux-gnueabihf/c/time.cr
+++ b/src/lib_c/arm-linux-gnueabihf/c/time.cr
@@ -23,6 +23,11 @@ lib LibC
     tv_nsec : Long
   end
 
+  struct Itimerspec
+    it_interval : Timespec
+    it_value : Timespec
+  end
+
   fun clock_gettime(clock_id : ClockidT, tp : Timespec*) : Int
   fun clock_settime(clock_id : ClockidT, tp : Timespec*) : Int
   fun gmtime_r(timer : TimeT*, tp : Tm*) : Tm*

--- a/src/lib_c/i386-linux-gnu/c/sys/epoll.cr
+++ b/src/lib_c/i386-linux-gnu/c/sys/epoll.cr
@@ -20,7 +20,6 @@ lib LibC
     u64 : UInt64
   end
 
-  @[Packed]
   struct EpollEvent
     events : UInt32
     data : EpollDataT

--- a/src/lib_c/i386-linux-gnu/c/sys/epoll.cr
+++ b/src/lib_c/i386-linux-gnu/c/sys/epoll.cr
@@ -1,0 +1,32 @@
+lib LibC
+  EPOLLIN  = 0x001_u32
+  EPOLLOUT = 0x004_u32
+  EPOLLERR = 0x008_u32
+  EPOLLHUP = 0x010_u32
+
+  EPOLLEXCLUSIVE = 1_u32 << 28
+  EPOLLET        = 1_u32 << 31
+
+  EPOLL_CTL_ADD = 1
+  EPOLL_CTL_DEL = 2
+  EPOLL_CTL_MOD = 3
+
+  EPOLL_CLOEXEC = 0o2000000
+
+  union EpollDataT
+    ptr : Void*
+    fd : Int
+    u32 : UInt32
+    u64 : UInt64
+  end
+
+  @[Packed]
+  struct EpollEvent
+    events : UInt32
+    data : EpollDataT
+  end
+
+  fun epoll_create1(Int) : Int
+  fun epoll_ctl(Int, Int, Int, EpollEvent*) : Int
+  fun epoll_wait(Int, EpollEvent*, Int, Int) : Int
+end

--- a/src/lib_c/i386-linux-gnu/c/sys/eventfd.cr
+++ b/src/lib_c/i386-linux-gnu/c/sys/eventfd.cr
@@ -1,0 +1,9 @@
+lib LibC
+  EFD_CLOEXEC = 0o2000000
+
+  alias EventfdT = UInt64
+
+  fun eventfd(count : UInt, flags : Int) : Int
+  fun eventfd_read(fd : Int, value : EventfdT*) : Int
+  fun eventfd_write(fd : Int, value : EventfdT) : Int
+end

--- a/src/lib_c/i386-linux-gnu/c/sys/eventfd.cr
+++ b/src/lib_c/i386-linux-gnu/c/sys/eventfd.cr
@@ -1,9 +1,5 @@
 lib LibC
   EFD_CLOEXEC = 0o2000000
 
-  alias EventfdT = UInt64
-
   fun eventfd(count : UInt, flags : Int) : Int
-  fun eventfd_read(fd : Int, value : EventfdT*) : Int
-  fun eventfd_write(fd : Int, value : EventfdT) : Int
 end

--- a/src/lib_c/i386-linux-gnu/c/sys/timerfd.cr
+++ b/src/lib_c/i386-linux-gnu/c/sys/timerfd.cr
@@ -1,0 +1,10 @@
+require "../time"
+
+lib LibC
+  TFD_NONBLOCK      = 0o0004000
+  TFD_CLOEXEC       = 0o2000000
+  TFD_TIMER_ABSTIME = 1 << 0
+
+  fun timerfd_create(ClockidT, Int) : Int
+  fun timerfd_settime(Int, Int, Itimerspec*, Itimerspec*) : Int
+end

--- a/src/lib_c/i386-linux-gnu/c/time.cr
+++ b/src/lib_c/i386-linux-gnu/c/time.cr
@@ -23,6 +23,11 @@ lib LibC
     tv_nsec : Long
   end
 
+  struct Itimerspec
+    it_interval : Timespec
+    it_value : Timespec
+  end
+
   fun clock_gettime(clock_id : ClockidT, tp : Timespec*) : Int
   fun clock_settime(clock_id : ClockidT, tp : Timespec*) : Int
   fun gmtime_r(timer : TimeT*, tp : Tm*) : Tm*

--- a/src/lib_c/i386-linux-musl/c/sys/epoll.cr
+++ b/src/lib_c/i386-linux-musl/c/sys/epoll.cr
@@ -20,7 +20,6 @@ lib LibC
     u64 : UInt64
   end
 
-  @[Packed]
   struct EpollEvent
     events : UInt32
     data : EpollDataT

--- a/src/lib_c/i386-linux-musl/c/sys/epoll.cr
+++ b/src/lib_c/i386-linux-musl/c/sys/epoll.cr
@@ -1,0 +1,32 @@
+lib LibC
+  EPOLLIN  = 0x001_u32
+  EPOLLOUT = 0x004_u32
+  EPOLLERR = 0x008_u32
+  EPOLLHUP = 0x010_u32
+
+  EPOLLEXCLUSIVE = 1_u32 << 28
+  EPOLLET        = 1_u32 << 31
+
+  EPOLL_CTL_ADD = 1
+  EPOLL_CTL_DEL = 2
+  EPOLL_CTL_MOD = 3
+
+  EPOLL_CLOEXEC = 0o2000000
+
+  union EpollDataT
+    ptr : Void*
+    fd : Int
+    u32 : UInt32
+    u64 : UInt64
+  end
+
+  @[Packed]
+  struct EpollEvent
+    events : UInt32
+    data : EpollDataT
+  end
+
+  fun epoll_create1(Int) : Int
+  fun epoll_ctl(Int, Int, Int, EpollEvent*) : Int
+  fun epoll_wait(Int, EpollEvent*, Int, Int) : Int
+end

--- a/src/lib_c/i386-linux-musl/c/sys/eventfd.cr
+++ b/src/lib_c/i386-linux-musl/c/sys/eventfd.cr
@@ -1,0 +1,9 @@
+lib LibC
+  EFD_CLOEXEC = 0o2000000
+
+  alias EventfdT = UInt64
+
+  fun eventfd(count : UInt, flags : Int) : Int
+  fun eventfd_read(fd : Int, value : EventfdT*) : Int
+  fun eventfd_write(fd : Int, value : EventfdT) : Int
+end

--- a/src/lib_c/i386-linux-musl/c/sys/eventfd.cr
+++ b/src/lib_c/i386-linux-musl/c/sys/eventfd.cr
@@ -1,9 +1,5 @@
 lib LibC
   EFD_CLOEXEC = 0o2000000
 
-  alias EventfdT = UInt64
-
   fun eventfd(count : UInt, flags : Int) : Int
-  fun eventfd_read(fd : Int, value : EventfdT*) : Int
-  fun eventfd_write(fd : Int, value : EventfdT) : Int
 end

--- a/src/lib_c/i386-linux-musl/c/sys/timerfd.cr
+++ b/src/lib_c/i386-linux-musl/c/sys/timerfd.cr
@@ -1,0 +1,10 @@
+require "../time"
+
+lib LibC
+  TFD_NONBLOCK      = 0o0004000
+  TFD_CLOEXEC       = 0o2000000
+  TFD_TIMER_ABSTIME = 1 << 0
+
+  fun timerfd_create(ClockidT, Int) : Int
+  fun timerfd_settime(Int, Int, Itimerspec*, Itimerspec*) : Int
+end

--- a/src/lib_c/i386-linux-musl/c/time.cr
+++ b/src/lib_c/i386-linux-musl/c/time.cr
@@ -23,6 +23,11 @@ lib LibC
     tv_nsec : Long
   end
 
+  struct Itimerspec
+    it_interval : Timespec
+    it_value : Timespec
+  end
+
   fun clock_gettime(x0 : ClockidT, x1 : Timespec*) : Int
   fun clock_settime(x0 : ClockidT, x1 : Timespec*) : Int
   fun gmtime_r(x0 : TimeT*, x1 : Tm*) : Tm*

--- a/src/lib_c/x86_64-linux-gnu/c/sys/epoll.cr
+++ b/src/lib_c/x86_64-linux-gnu/c/sys/epoll.cr
@@ -1,0 +1,32 @@
+lib LibC
+  EPOLLIN  = 0x001_u32
+  EPOLLOUT = 0x004_u32
+  EPOLLERR = 0x008_u32
+  EPOLLHUP = 0x010_u32
+
+  EPOLLEXCLUSIVE = 1_u32 << 28
+  EPOLLET        = 1_u32 << 31
+
+  EPOLL_CTL_ADD = 1
+  EPOLL_CTL_DEL = 2
+  EPOLL_CTL_MOD = 3
+
+  EPOLL_CLOEXEC = 0o2000000
+
+  union EpollDataT
+    ptr : Void*
+    fd : Int
+    u32 : UInt32
+    u64 : UInt64
+  end
+
+  @[Packed]
+  struct EpollEvent
+    events : UInt32
+    data : EpollDataT
+  end
+
+  fun epoll_create1(Int) : Int
+  fun epoll_ctl(Int, Int, Int, EpollEvent*) : Int
+  fun epoll_wait(Int, EpollEvent*, Int, Int) : Int
+end

--- a/src/lib_c/x86_64-linux-gnu/c/sys/eventfd.cr
+++ b/src/lib_c/x86_64-linux-gnu/c/sys/eventfd.cr
@@ -1,0 +1,9 @@
+lib LibC
+  EFD_CLOEXEC = 0o2000000
+
+  alias EventfdT = UInt64
+
+  fun eventfd(count : UInt, flags : Int) : Int
+  fun eventfd_read(fd : Int, value : EventfdT*) : Int
+  fun eventfd_write(fd : Int, value : EventfdT) : Int
+end

--- a/src/lib_c/x86_64-linux-gnu/c/sys/eventfd.cr
+++ b/src/lib_c/x86_64-linux-gnu/c/sys/eventfd.cr
@@ -1,9 +1,5 @@
 lib LibC
   EFD_CLOEXEC = 0o2000000
 
-  alias EventfdT = UInt64
-
   fun eventfd(count : UInt, flags : Int) : Int
-  fun eventfd_read(fd : Int, value : EventfdT*) : Int
-  fun eventfd_write(fd : Int, value : EventfdT) : Int
 end

--- a/src/lib_c/x86_64-linux-gnu/c/sys/timerfd.cr
+++ b/src/lib_c/x86_64-linux-gnu/c/sys/timerfd.cr
@@ -1,0 +1,10 @@
+require "../time"
+
+lib LibC
+  TFD_NONBLOCK      = 0o0004000
+  TFD_CLOEXEC       = 0o2000000
+  TFD_TIMER_ABSTIME = 1 << 0
+
+  fun timerfd_create(ClockidT, Int) : Int
+  fun timerfd_settime(Int, Int, Itimerspec*, Itimerspec*) : Int
+end

--- a/src/lib_c/x86_64-linux-gnu/c/time.cr
+++ b/src/lib_c/x86_64-linux-gnu/c/time.cr
@@ -23,6 +23,11 @@ lib LibC
     tv_nsec : Long
   end
 
+  struct Itimerspec
+    it_interval : Timespec
+    it_value : Timespec
+  end
+
   fun clock_gettime(clock_id : ClockidT, tp : Timespec*) : Int
   fun clock_settime(clock_id : ClockidT, tp : Timespec*) : Int
   fun gmtime_r(timer : TimeT*, tp : Tm*) : Tm*

--- a/src/lib_c/x86_64-linux-musl/c/sys/epoll.cr
+++ b/src/lib_c/x86_64-linux-musl/c/sys/epoll.cr
@@ -1,0 +1,32 @@
+lib LibC
+  EPOLLIN  = 0x001_u32
+  EPOLLOUT = 0x004_u32
+  EPOLLERR = 0x008_u32
+  EPOLLHUP = 0x010_u32
+
+  EPOLLEXCLUSIVE = 1_u32 << 28
+  EPOLLET        = 1_u32 << 31
+
+  EPOLL_CTL_ADD = 1
+  EPOLL_CTL_DEL = 2
+  EPOLL_CTL_MOD = 3
+
+  EPOLL_CLOEXEC = 0o2000000
+
+  union EpollDataT
+    ptr : Void*
+    fd : Int
+    u32 : UInt32
+    u64 : UInt64
+  end
+
+  @[Packed]
+  struct EpollEvent
+    events : UInt32
+    data : EpollDataT
+  end
+
+  fun epoll_create1(Int) : Int
+  fun epoll_ctl(Int, Int, Int, EpollEvent*) : Int
+  fun epoll_wait(Int, EpollEvent*, Int, Int) : Int
+end

--- a/src/lib_c/x86_64-linux-musl/c/sys/eventfd.cr
+++ b/src/lib_c/x86_64-linux-musl/c/sys/eventfd.cr
@@ -1,0 +1,9 @@
+lib LibC
+  EFD_CLOEXEC = 0o2000000
+
+  alias EventfdT = UInt64
+
+  fun eventfd(count : UInt, flags : Int) : Int
+  fun eventfd_read(fd : Int, value : EventfdT*) : Int
+  fun eventfd_write(fd : Int, value : EventfdT) : Int
+end

--- a/src/lib_c/x86_64-linux-musl/c/sys/eventfd.cr
+++ b/src/lib_c/x86_64-linux-musl/c/sys/eventfd.cr
@@ -1,9 +1,5 @@
 lib LibC
   EFD_CLOEXEC = 0o2000000
 
-  alias EventfdT = UInt64
-
   fun eventfd(count : UInt, flags : Int) : Int
-  fun eventfd_read(fd : Int, value : EventfdT*) : Int
-  fun eventfd_write(fd : Int, value : EventfdT) : Int
 end

--- a/src/lib_c/x86_64-linux-musl/c/sys/timerfd.cr
+++ b/src/lib_c/x86_64-linux-musl/c/sys/timerfd.cr
@@ -1,0 +1,10 @@
+require "../time"
+
+lib LibC
+  TFD_NONBLOCK      = 0o0004000
+  TFD_CLOEXEC       = 0o2000000
+  TFD_TIMER_ABSTIME = 1 << 0
+
+  fun timerfd_create(ClockidT, Int) : Int
+  fun timerfd_settime(Int, Int, Itimerspec*, Itimerspec*) : Int
+end

--- a/src/lib_c/x86_64-linux-musl/c/time.cr
+++ b/src/lib_c/x86_64-linux-musl/c/time.cr
@@ -23,6 +23,11 @@ lib LibC
     tv_nsec : Long
   end
 
+  struct Itimerspec
+    it_interval : Timespec
+    it_value : Timespec
+  end
+
   fun clock_gettime(x0 : ClockidT, x1 : Timespec*) : Int
   fun clock_settime(x0 : ClockidT, x1 : Timespec*) : Int
   fun gmtime_r(x0 : TimeT*, x1 : Tm*) : Tm*

--- a/src/lib_c/x86_64-solaris/c/sys/epoll.cr
+++ b/src/lib_c/x86_64-solaris/c/sys/epoll.cr
@@ -1,0 +1,32 @@
+lib LibC
+  EPOLLIN  = 0x001_u32
+  EPOLLOUT = 0x004_u32
+  EPOLLERR = 0x008_u32
+  EPOLLHUP = 0x010_u32
+
+  EPOLLEXCLUSIVE = 1_u32 << 28
+  EPOLLET        = 1_u32 << 31
+
+  EPOLL_CTL_ADD = 1
+  EPOLL_CTL_DEL = 2
+  EPOLL_CTL_MOD = 3
+
+  EPOLL_CLOEXEC = 0o2000000
+
+  union EpollDataT
+    ptr : Void*
+    fd : Int
+    u32 : UInt32
+    u64 : UInt64
+  end
+
+  @[Packed]
+  struct EpollEvent
+    events : UInt32
+    data : EpollDataT
+  end
+
+  fun epoll_create1(Int) : Int
+  fun epoll_ctl(Int, Int, Int, EpollEvent*) : Int
+  fun epoll_wait(Int, EpollEvent*, Int, Int) : Int
+end

--- a/src/lib_c/x86_64-solaris/c/sys/eventfd.cr
+++ b/src/lib_c/x86_64-solaris/c/sys/eventfd.cr
@@ -1,0 +1,9 @@
+lib LibC
+  EFD_CLOEXEC = 0o2000000
+
+  alias EventfdT = UInt64
+
+  fun eventfd(count : UInt, flags : Int) : Int
+  fun eventfd_read(fd : Int, value : EventfdT*) : Int
+  fun eventfd_write(fd : Int, value : EventfdT) : Int
+end

--- a/src/lib_c/x86_64-solaris/c/sys/eventfd.cr
+++ b/src/lib_c/x86_64-solaris/c/sys/eventfd.cr
@@ -1,9 +1,5 @@
 lib LibC
   EFD_CLOEXEC = 0o2000000
 
-  alias EventfdT = UInt64
-
   fun eventfd(count : UInt, flags : Int) : Int
-  fun eventfd_read(fd : Int, value : EventfdT*) : Int
-  fun eventfd_write(fd : Int, value : EventfdT) : Int
 end

--- a/src/lib_c/x86_64-solaris/c/sys/timerfd.cr
+++ b/src/lib_c/x86_64-solaris/c/sys/timerfd.cr
@@ -1,0 +1,10 @@
+require "../time"
+
+lib LibC
+  TFD_NONBLOCK      = 0o0004000
+  TFD_CLOEXEC       = 0o2000000
+  TFD_TIMER_ABSTIME = 1 << 0
+
+  fun timerfd_create(ClockidT, Int) : Int
+  fun timerfd_settime(Int, Int, Itimerspec*, Itimerspec*) : Int
+end

--- a/src/lib_c/x86_64-solaris/c/time.cr
+++ b/src/lib_c/x86_64-solaris/c/time.cr
@@ -21,6 +21,11 @@ lib LibC
     tv_nsec : Long
   end
 
+  struct Itimerspec
+    it_interval : Timespec
+    it_value : Timespec
+  end
+
   fun clock_gettime(x0 : ClockidT, x1 : Timespec*) : Int
   fun clock_settime(x0 : ClockidT, x1 : Timespec*) : Int
   fun gmtime_r(x0 : TimeT*, x1 : Tm*) : Tm*


### PR DESCRIPTION
Implements a custom event loop on top of `epoll` for Linux (and Solaris?), following [RFC #7](https://github.com/crystal-lang/rfcs/pull/7). It's not particularly optimized yet (e.g. it still allocates), but seems to be working.

The EventQueue and Timers types aren't the best solutions (performance wise) but they work and abstract their own logic (keep a list of events per fd / keep a sorted list of timers). We should be able to improve (e.g. linked lists -> ordered linked lists -> skiplists, ...)

**ISSUES**

- [x] ~~`#after_fork` must close & nullify every `Fiber#timerfd` & update pending events to use the new fd~~ (not needed with one timerfd per eventloop, see below);
- [x] ~~must reset mutex after fork before exec (preview mt);~~
- [x] ~~must "close" fd in all eventloops (preview mt);~~
- [x] ~~LibC bindings for `aarch-linux-musl` are wrong;~~
- [x] ~~investigate segfault runs on CI;~~
- [x] ~~support `:preview_mt` (broken CI);~~
- [x] ~~can't modify a registered fd with EPOLLEXCLUSIVE set~~ (disabled for now);
- [x] `BUG: a timerfd file descriptor errored or got closed!` [on CI](https://github.com/crystal-lang/crystal/actions/runs/9996237662/job/27630213287);
- [x] `epoll_ctl(EPOLL_CTL_MOD): No such file or directory (RuntimeError)` [on CI](https://github.com/crystal-lang/crystal/actions/runs/9998761642/job/27638371030?pr=14814);
- [ ] `Unhandled exception: pthread_mutex_unlock: Operation not permitted (RuntimeError)` [on CI](https://github.com/crystal-lang/crystal/actions/runs/9998761647/job/27638373500?pr=14814) and [again](https://github.com/ysbaddaden/crystal/actions/runs/10042763961/job/27753944638)
- [x] ~~infinite loop in interpreter on CI (primitives spec);~~

**OPTIMIZE**

- [x] `epoll_event.data` should point to Node instead of fd, so we could skip searches;
- [x] use `eventfd` instead of `pipe2` to interrupt the loop;
- [x] one `timerfd` per eventloop should be enough (wait until next timer => we can't enqueue another timer on that thread anymore => for MT a parallel enqueue will interrupt `epoll_wait`); we still need a `timerfd` because `epoll_wait` only has millisecond precision; we also need a list of timers to know the next timer, and which timers are ready.

**TODO**

- [ ] don't raise BUG exceptions, print BUG warnings to STDERR;
- [ ] more testing: please help to break it :hammer: 
- [ ] extract fix for #14807 (distinct PR);
- [ ] extract fix for double event dequeue in `Fiber#cancel_timeout` (distinct PR);
- [x] cleanup Crystal::Epoll::EventLoop (commented code, debug traces);
- [ ] use `:ev_epoll` flag instead of forcing it for Linux (not yet: I want CI test runs);