### PR TITLE
Disallow weird assignments

### DIFF
--- a/spec/compiler/parser/parser_spec.cr
+++ b/spec/compiler/parser/parser_spec.cr
@@ -276,6 +276,9 @@ module Crystal
     assert_syntax_error "a.b() += 1"
     assert_syntax_error "a.[]() += 1"
 
+    assert_syntax_error "a.[] 0 = 1"
+    assert_syntax_error "a.[] 0 += 1"
+
     it_parses "def foo\n1\nend", Def.new("foo", body: 1.int32)
     it_parses "def downto(n)\n1\nend", Def.new("downto", ["n".arg], 1.int32)
     it_parses "def foo ; 1 ; end", Def.new("foo", body: 1.int32)

--- a/spec/compiler/parser/parser_spec.cr
+++ b/spec/compiler/parser/parser_spec.cr
@@ -2245,6 +2245,17 @@ module Crystal
     assert_syntax_error "foo &.[0]? = 1"
     assert_syntax_error "foo &.[0]? += 1"
 
+    assert_syntax_error "foo &.[]?=(1)"
+    assert_syntax_error "foo &.[]? = 1"
+    assert_syntax_error "foo &.[]? 0 =(1)"
+    assert_syntax_error "foo &.[]? 0 = 1"
+    assert_syntax_error "foo &.[]?(0)=(1)"
+    assert_syntax_error "foo &.[]?(0) = 1"
+    assert_syntax_error "foo &.[] 0 =(1)"
+    assert_syntax_error "foo &.[] 0 = 1"
+    assert_syntax_error "foo &.[](0)=(1)"
+    assert_syntax_error "foo &.[](0) = 1"
+
     describe "end locations" do
       assert_end_location "nil"
       assert_end_location "false"

--- a/spec/compiler/parser/parser_spec.cr
+++ b/spec/compiler/parser/parser_spec.cr
@@ -278,6 +278,7 @@ module Crystal
 
     assert_syntax_error "a.[] 0 = 1"
     assert_syntax_error "a.[] 0 += 1"
+    assert_syntax_error "a b: 0 = 1"
 
     it_parses "def foo\n1\nend", Def.new("foo", body: 1.int32)
     it_parses "def downto(n)\n1\nend", Def.new("downto", ["n".arg], 1.int32)

--- a/spec/compiler/parser/parser_spec.cr
+++ b/spec/compiler/parser/parser_spec.cr
@@ -2256,6 +2256,11 @@ module Crystal
     assert_syntax_error "foo &.[](0)=(1)"
     assert_syntax_error "foo &.[](0) = 1"
 
+    assert_syntax_error "foo &.bar.[] 0 =(1)"
+    assert_syntax_error "foo &.bar.[] 0 = 1"
+    assert_syntax_error "foo &.bar.[](0)=(1)"
+    assert_syntax_error "foo &.bar.[](0) = 1"
+
     describe "end locations" do
       assert_end_location "nil"
       assert_end_location "false"

--- a/spec/compiler/parser/parser_spec.cr
+++ b/spec/compiler/parser/parser_spec.cr
@@ -2821,5 +2821,29 @@ module Crystal
       node = Parser.parse(source).as(Annotation).path
       node_source(source, node).should eq("::Foo")
     end
+
+    it "sets correct location of call dot" do
+      parser = Parser.new("a.b")
+      node = parser.parse.as(Call)
+      dot_location = node.dot_location.not_nil!
+      dot_location.line_number.should eq(1)
+      dot_location.column_number.should eq(2)
+    end
+
+    it "sets correct location of call dot in assignment" do
+      parser = Parser.new("a.b = c")
+      node = parser.parse.as(Call)
+      dot_location = node.dot_location.not_nil!
+      dot_location.line_number.should eq(1)
+      dot_location.column_number.should eq(2)
+    end
+
+    it "sets correct location of call dot in operator assignment" do
+      parser = Parser.new("a.b += c")
+      node = parser.parse.as(OpAssign).target.as(Call)
+      dot_location = node.dot_location.not_nil!
+      dot_location.line_number.should eq(1)
+      dot_location.column_number.should eq(2)
+    end
   end
 end

--- a/spec/compiler/parser/parser_spec.cr
+++ b/spec/compiler/parser/parser_spec.cr
@@ -2236,6 +2236,13 @@ module Crystal
 
     assert_syntax_error "lib Foo%end", %(unexpected token: "%")
 
+    assert_syntax_error "foo[0]? = 1"
+    assert_syntax_error "foo[0]? += 1"
+    assert_syntax_error "foo.[0]? = 1"
+    assert_syntax_error "foo.[0]? += 1"
+    assert_syntax_error "foo &.[0]? = 1"
+    assert_syntax_error "foo &.[0]? += 1"
+
     describe "end locations" do
       assert_end_location "nil"
       assert_end_location "false"

--- a/spec/compiler/parser/parser_spec.cr
+++ b/spec/compiler/parser/parser_spec.cr
@@ -2236,6 +2236,8 @@ module Crystal
 
     assert_syntax_error "lib Foo%end", %(unexpected token: "%")
 
+    assert_syntax_error "foo.[]? = 1"
+    assert_syntax_error "foo.[]? += 1"
     assert_syntax_error "foo[0]? = 1"
     assert_syntax_error "foo[0]? += 1"
     assert_syntax_error "foo.[0]? = 1"

--- a/spec/support/syntax.cr
+++ b/spec/support/syntax.cr
@@ -133,8 +133,8 @@ class Crystal::ASTNode
   end
 end
 
-def assert_syntax_error(str, message = nil, line = nil, column = nil, metafile = __FILE__, metaline = __LINE__, metaendline = __END_LINE__)
-  it "says syntax error on #{str.inspect}", metafile, metaline, metaendline do
+def assert_syntax_error(str, message = nil, line = nil, column = nil, metafile = __FILE__, metaline = __LINE__, metaendline = __END_LINE__, *, focus : Bool = false)
+  it "says syntax error on #{str.inspect}", metafile, metaline, metaendline, focus: focus do
     begin
       parse str
       fail "Expected SyntaxException to be raised", metafile, metaline

--- a/src/compiler/crystal/syntax/ast.cr
+++ b/src/compiler/crystal/syntax/ast.cr
@@ -647,13 +647,13 @@ module Crystal
     property block : Block?
     property block_arg : ASTNode?
     property named_args : Array(NamedArgument)?
-    property dot_location : Location?
     property name_location : Location?
     @name_size = -1
     property doc : String?
     property visibility = Visibility::Public
     property? global : Bool
     property? expansion = false
+    property? args_in_brackets = false
     property? has_parentheses = false
 
     def initialize(@obj, @name, @args = [] of ASTNode, @block = nil, @block_arg = nil, @named_args = nil, @global : Bool = false)

--- a/src/compiler/crystal/syntax/ast.cr
+++ b/src/compiler/crystal/syntax/ast.cr
@@ -647,6 +647,7 @@ module Crystal
     property block : Block?
     property block_arg : ASTNode?
     property named_args : Array(NamedArgument)?
+    property dot_location : Location?
     property name_location : Location?
     @name_size = -1
     property doc : String?

--- a/src/compiler/crystal/syntax/parser.cr
+++ b/src/compiler/crystal/syntax/parser.cr
@@ -678,6 +678,8 @@ module Crystal
             break
           end
         when .op_period?
+          dot_location = @token.location
+
           check_void_value atomic, location
 
           @wants_regex = false
@@ -761,6 +763,7 @@ module Crystal
               end
 
               atomic = Call.new(atomic, "#{name}=", arg).at(location).at_end(end_location)
+              atomic.dot_location = dot_location
               atomic.name_location = name_location
               next
             when .assignment_operator?
@@ -769,6 +772,7 @@ module Crystal
               next_token_skip_space_or_newline
               value = parse_op_assign
               call = Call.new(atomic, name).at(location)
+              call.dot_location = dot_location
               call.name_location = name_location
               atomic = OpAssign.new(call, method, value).at(location)
               atomic.name_location = op_name_location
@@ -790,6 +794,7 @@ module Crystal
             block = parse_block(block, stop_on_do: @stop_on_do)
             atomic = Call.new atomic, name, (args || [] of ASTNode), block, block_arg, named_args
             atomic.has_parentheses = has_parentheses
+            atomic.dot_location = dot_location
             atomic.name_location = name_location
             atomic.end_location = block.try(&.end_location) || call_args.try(&.end_location) || end_location
             atomic.at(location)

--- a/src/compiler/crystal/syntax/parser.cr
+++ b/src/compiler/crystal/syntax/parser.cr
@@ -1652,6 +1652,8 @@ module Crystal
         call = call.as(Call)
 
         if @token.type.op_eq?
+          unexpected_token unless can_be_assigned?(call)
+
           next_token_skip_space
           if @token.type.op_lparen?
             next_token_skip_space

--- a/src/compiler/crystal/syntax/parser.cr
+++ b/src/compiler/crystal/syntax/parser.cr
@@ -6191,7 +6191,7 @@ module Crystal
         true
       when Call
         return false if node.has_parentheses?
-        return true if node.obj.nil? && node.args.empty? && node.block.nil?
+        return true if node.obj.nil? && node.args.empty? && node.named_args.nil? && node.block.nil?
         node.name == "[]" && node.dot_location.nil?
       else
         false

--- a/src/compiler/crystal/syntax/parser.cr
+++ b/src/compiler/crystal/syntax/parser.cr
@@ -1631,7 +1631,7 @@ module Crystal
       elsif @token.type.op_lsquare?
         call = parse_atomic_method_suffix obj, location
 
-        if @token.type.op_eq? && call.is_a?(Call) && call.name == "[]"
+        if @token.type.op_eq? && call.is_a?(Call) && can_be_assigned?(call)
           next_token_skip_space
           exp = parse_op_assign
           call.name = "#{call.name}="
@@ -1671,7 +1671,7 @@ module Crystal
         else
           call = parse_atomic_method_suffix call, location
 
-          if @token.type.op_eq? && call.is_a?(Call) && call.name == "[]"
+          if @token.type.op_eq? && call.is_a?(Call) && can_be_assigned?(call)
             next_token_skip_space
             exp = parse_op_assign
             call.name = "#{call.name}="

--- a/src/compiler/crystal/syntax/parser.cr
+++ b/src/compiler/crystal/syntax/parser.cr
@@ -6190,7 +6190,9 @@ module Crystal
       when Var, InstanceVar, ClassVar, Path, Global, Underscore
         true
       when Call
-        !node.has_parentheses? && ((node.obj.nil? && node.args.empty? && node.block.nil?) || node.name == "[]")
+        return false if node.has_parentheses?
+        return true if node.obj.nil? && node.args.empty? && node.block.nil?
+        node.name == "[]" && node.dot_location.nil?
       else
         false
       end

--- a/src/compiler/crystal/syntax/parser.cr
+++ b/src/compiler/crystal/syntax/parser.cr
@@ -1623,7 +1623,7 @@ module Crystal
       elsif @token.type.op_lsquare?
         call = parse_atomic_method_suffix obj, location
 
-        if @token.type.op_eq? && call.is_a?(Call)
+        if @token.type.op_eq? && call.is_a?(Call) && call.name == "[]"
           next_token_skip_space
           exp = parse_op_assign
           call.name = "#{call.name}="


### PR DESCRIPTION
Closes #12830

Added `Call#dot_location` so that the AST for `a[0]` can be differentiated from `a.[] 0`. This makes it easier to disallow `a.[] 0 = 1`

Added a check for whether `Call#named_args` is `nil` so that `a b: 0 = 1` is disallowed and not treated like an assignment to `a` (where `b: 0` was ignored)