### PR TITLE
Add doc gen flags for lib, private, and all

### DIFF
--- a/src/compiler/crystal/command/docs.cr
+++ b/src/compiler/crystal/command/docs.cr
@@ -14,6 +14,7 @@ class Crystal::Command
     sitemap_changefreq = "never"
     project_info = Doc::ProjectInfo.new
     include_all = false
+    include_private = false
     include_lib = false
 
     compiler = new_compiler
@@ -96,6 +97,10 @@ class Crystal::Command
         include_all = true
       end
 
+      opts.on("--include-private", "Include private methdos in docs") do
+        include_private = true
+      end
+
       opts.on("--include-lib", "Include C library bindings in docs") do
         include_lib = true
       end
@@ -152,7 +157,7 @@ class Crystal::Command
     Doc::Generator.new(
       result.program, included_dirs, output_directory, output_format,
       sitemap_base_url, sitemap_priority, sitemap_changefreq,
-      project_info, include_all, include_lib
+      project_info, include_all, include_private, include_lib
     ).run
 
     report_warnings

--- a/src/compiler/crystal/command/docs.cr
+++ b/src/compiler/crystal/command/docs.cr
@@ -13,6 +13,7 @@ class Crystal::Command
     sitemap_priority = "1.0"
     sitemap_changefreq = "never"
     project_info = Doc::ProjectInfo.new
+    include_all = false
 
     compiler = new_compiler
 
@@ -44,6 +45,7 @@ class Crystal::Command
       opts.on("--output=DIR", "-o DIR", "Set the output directory (default: #{output_directory})") do |value|
         output_directory = value
       end
+
       opts.on("--format=FORMAT", "-f FORMAT", "Set the output format [#{VALID_OUTPUT_FORMATS.join(", ")}] (default: #{output_format})") do |value|
         if !VALID_OUTPUT_FORMATS.includes? value
           STDERR.puts "Invalid format '#{value}'"
@@ -87,6 +89,10 @@ class Crystal::Command
 
       opts.on("--prelude ", "Use given file as prelude") do |prelude|
         compiler.prelude = prelude
+      end
+
+      opts.on("--include-all", "Include documentation for entire namespace") do
+        include_all = true
       end
 
       opts.on("-s", "--stats", "Enable statistics output") do
@@ -138,7 +144,11 @@ class Crystal::Command
     compiler.wants_doc = true
     result = compiler.top_level_semantic sources
 
-    Doc::Generator.new(result.program, included_dirs, output_directory, output_format, sitemap_base_url, sitemap_priority, sitemap_changefreq, project_info).run
+    Doc::Generator.new(
+      result.program, included_dirs, output_directory, output_format,
+      sitemap_base_url, sitemap_priority, sitemap_changefreq,
+      project_info, include_all
+    ).run
 
     report_warnings
     exit 1 if warnings_fail_on_exit?

--- a/src/compiler/crystal/command/docs.cr
+++ b/src/compiler/crystal/command/docs.cr
@@ -14,6 +14,7 @@ class Crystal::Command
     sitemap_changefreq = "never"
     project_info = Doc::ProjectInfo.new
     include_all = false
+    include_lib = false
 
     compiler = new_compiler
 
@@ -95,6 +96,10 @@ class Crystal::Command
         include_all = true
       end
 
+      opts.on("--include-lib", "Include C library bindings in docs") do
+        include_lib = true
+      end
+
       opts.on("-s", "--stats", "Enable statistics output") do
         @progress_tracker.stats = true
       end
@@ -147,7 +152,7 @@ class Crystal::Command
     Doc::Generator.new(
       result.program, included_dirs, output_directory, output_format,
       sitemap_base_url, sitemap_priority, sitemap_changefreq,
-      project_info, include_all
+      project_info, include_all, include_lib
     ).run
 
     report_warnings

--- a/src/compiler/crystal/semantic/top_level_visitor.cr
+++ b/src/compiler/crystal/semantic/top_level_visitor.cr
@@ -556,6 +556,8 @@ class Crystal::TopLevelVisitor < Crystal::SemanticVisitor
       scope.types[name] = type
     end
 
+    attach_doc type, node, annotations
+
     node.resolved_type = type
 
     type.private = true if node.visibility.private?
@@ -626,9 +628,7 @@ class Crystal::TopLevelVisitor < Crystal::SemanticVisitor
       type.extern = true
       type.extern_union = node.union?
 
-      if location = node.location
-        type.add_location(location)
-      end
+      attach_doc type, node, annotations
 
       current_type.types[node.name] = type
     end
@@ -641,13 +641,20 @@ class Crystal::TopLevelVisitor < Crystal::SemanticVisitor
   end
 
   def visit(node : TypeDef)
+    annotations = read_annotations
+
     type = current_type.types[node.name]?
     if type
       node.raise "#{node.name} is already defined"
     else
       typed_def_type = lookup_type(node.type_spec)
       typed_def_type = check_allowed_in_lib node.type_spec, typed_def_type
-      current_type.types[node.name] = TypeDefType.new @program, current_type, node.name, typed_def_type
+      type = TypeDefType.new @program, current_type, node.name, typed_def_type
+
+      attach_doc type, node, annotations
+
+      current_type.types[node.name] = type
+
       false
     end
   end

--- a/src/compiler/crystal/semantic/type_declaration_visitor.cr
+++ b/src/compiler/crystal/semantic/type_declaration_visitor.cr
@@ -193,8 +193,8 @@ class Crystal::TypeDeclarationVisitor < Crystal::SemanticVisitor
 
   def declare_c_struct_or_union_field(type, field_name, var, location)
     type.instance_vars[var.name] = var
-    type.add_def Def.new("#{field_name}=", [Arg.new("value")], Primitive.new("struct_or_union_set").at(location))
-    type.add_def Def.new(field_name, body: InstanceVar.new(var.name))
+    type.add_def Def.new("#{field_name}=", [Arg.new("value")], Primitive.new("struct_or_union_set").at(location)).at(location)
+    type.add_def Def.new(field_name, body: InstanceVar.new(var.name)).at(location)
   end
 
   def declare_instance_var(node, var)

--- a/src/compiler/crystal/syntax/ast.cr
+++ b/src/compiler/crystal/syntax/ast.cr
@@ -575,6 +575,7 @@ module Crystal
     include SpecialVar
 
     property name : String
+    property doc : String?
 
     def initialize(@name : String)
     end

--- a/src/compiler/crystal/syntax/ast.cr
+++ b/src/compiler/crystal/syntax/ast.cr
@@ -1979,6 +1979,7 @@ module Crystal
 
   class TypeDef < ASTNode
     property name : String
+    property doc : String?
     property type_spec : ASTNode
     property name_location : Location?
 
@@ -2002,6 +2003,7 @@ module Crystal
   class CStructOrUnionDef < ASTNode
     property name : String
     property body : ASTNode
+    property doc : String?
     property? union : Bool
 
     def initialize(@name, body = nil, @union = false)

--- a/src/compiler/crystal/syntax/parser.cr
+++ b/src/compiler/crystal/syntax/parser.cr
@@ -5947,6 +5947,8 @@ module Crystal
     end
 
     def parse_type_def
+      doc = @token.doc
+
       next_token_skip_space_or_newline
       name = check_const
       name_location = @token.location
@@ -5959,11 +5961,15 @@ module Crystal
 
       typedef = TypeDef.new name, type
       typedef.name_location = name_location
+      typedef.doc = doc
+
       typedef
     end
 
     def parse_c_struct_or_union(union : Bool)
+      doc = @token.doc
       location = @token.location
+
       next_token_skip_space_or_newline
       name = check_const
       next_token_skip_statement_end
@@ -5972,7 +5978,10 @@ module Crystal
       end_location = token_end_location
       next_token_skip_space
 
-      CStructOrUnionDef.new(name, Expressions.from(body), union: union).at(location).at_end(end_location)
+      cstruct = CStructOrUnionDef.new(name, Expressions.from(body), union: union)
+      cstruct.doc = doc
+
+      cstruct.at(location).at_end(end_location)
     end
 
     def parse_c_struct_or_union_body

--- a/src/compiler/crystal/syntax/parser.cr
+++ b/src/compiler/crystal/syntax/parser.cr
@@ -6023,6 +6023,7 @@ module Crystal
     end
 
     def parse_c_struct_or_union_fields(exps)
+      doc = @token.doc
       vars = [Var.new(@token.value.to_s).at(@token.location).at_end(token_end_location)]
 
       next_token_skip_space_or_newline
@@ -6041,6 +6042,7 @@ module Crystal
       skip_statement_end
 
       vars.each do |var|
+        var.doc = doc
         exps << TypeDeclaration.new(var, type).at(var).at_end(type)
       end
     end

--- a/src/compiler/crystal/tools/doc/generator.cr
+++ b/src/compiler/crystal/tools/doc/generator.cr
@@ -21,14 +21,14 @@ class Crystal::Doc::Generator
   FLAGS = FLAG_COLORS.keys
 
   def self.new(program : Program, included_dirs : Array(String))
-    new(program, included_dirs, ".", "html", nil, "1.0", "never", ProjectInfo.new("test", "0.0.0-test"))
+    new(program, included_dirs, ".", "html", nil, "1.0", "never", ProjectInfo.new("test", "0.0.0-test"), false)
   end
 
-  def initialize(@program : Program, @included_dirs : Array(String),
-                 @output_dir : String, @output_format : String,
-                 @sitemap_base_url : String?,
-                 @sitemap_priority : String, @sitemap_changefreq : String,
-                 @project_info : ProjectInfo)
+  def initialize(
+    @program : Program, @included_dirs : Array(String), @output_dir : String, @output_format : String,
+    @sitemap_base_url : String?, @sitemap_priority : String, @sitemap_changefreq : String,
+    @project_info : ProjectInfo, @include_all : Bool
+  )
     @base_dir = Dir.current.chomp
     @types = {} of Crystal::Type => Doc::Type
   end
@@ -185,7 +185,7 @@ class Crystal::Doc::Generator
   def must_include?(location : Crystal::Location)
     case filename = location.filename
     when String
-      @included_dirs.any? { |included_dir| filename.starts_with? included_dir }
+      @include_all || @included_dirs.any? { |included_dir| filename.starts_with? included_dir }
     when VirtualFile
       must_include? filename.expanded_location
     else

--- a/src/compiler/crystal/tools/doc/html/_method_detail.html
+++ b/src/compiler/crystal/tools/doc/html/_method_detail.html
@@ -6,7 +6,7 @@
   <% methods.each do |method| %>
     <div class="entry-detail" id="<%= method.html_id %>">
       <div class="signature">
-        <%= method.abstract? ? "abstract " : "" %>
+        <%= method.abstract? ? "abstract " : "" %><%= method.visibility %>
         <%= method.kind %><strong><%= method.name %></strong><%= method.args_to_html %>
 
         <a class="method-permalink" href="<%= method.anchor %>">#</a>

--- a/src/compiler/crystal/tools/doc/html/type.html
+++ b/src/compiler/crystal/tools/doc/html/type.html
@@ -45,6 +45,14 @@
   <code><%= type.formatted_alias_definition %></code>
 <% end %>
 
+<% if type.type_def? %>
+  <h2>
+    <%= Crystal::Doc.anchor_link("type-definition") %>
+    Type Definition
+  </h2>
+  <code><%= type.formatted_type_definition %></code>
+<% end %>
+
 <%= OtherTypesTemplate.new("Included Modules", type, type.included_modules) %>
 <%= OtherTypesTemplate.new("Extended Modules", type, type.extended_modules) %>
 <%= OtherTypesTemplate.new("Direct Known Subclasses", type, type.subclasses) %>
@@ -93,24 +101,29 @@
   </dl>
 <% end %>
 
-<%= MethodSummaryTemplate.new("Constructors", type.constructors) %>
-<%= MethodSummaryTemplate.new(type.program? ? "Method Summary" : "Class Method Summary", type.class_methods) %>
-<%= MethodSummaryTemplate.new("Macro Summary", type.macros) %>
-<%= MethodSummaryTemplate.new("Instance Method Summary", type.instance_methods) %>
+<% if type.lib? %>
+  <%= MethodSummaryTemplate.new("Function Summary", type.class_methods) %>
+  <%= MethodDetailTemplate.new("Function Detail", type.class_methods) %>
+<% else %>
+  <%= MethodSummaryTemplate.new("Constructors", type.constructors) %>
+  <%= MethodSummaryTemplate.new(type.program? ? "Method Summary" : "Class Method Summary", type.class_methods) %>
+  <%= MethodSummaryTemplate.new("Macro Summary", type.macros) %>
+  <%= MethodSummaryTemplate.new("Instance Method Summary", type.instance_methods) %>
 
-<div class="methods-inherited">
-  <% type.ancestors.each do |ancestor| %>
-    <%= MethodsInheritedTemplate.new(type, ancestor, ancestor.instance_methods, "Instance") %>
-    <%= MethodsInheritedTemplate.new(type, ancestor, ancestor.constructors, "Constructor") %>
-    <%= MethodsInheritedTemplate.new(type, ancestor, ancestor.class_methods, "Class") %>
-    <%= MacrosInheritedTemplate.new(type, ancestor, ancestor.macros) %>
-  <% end %>
-</div>
+  <div class="methods-inherited">
+    <% type.ancestors.each do |ancestor| %>
+      <%= MethodsInheritedTemplate.new(type, ancestor, ancestor.instance_methods, "Instance") %>
+      <%= MethodsInheritedTemplate.new(type, ancestor, ancestor.constructors, "Constructor") %>
+      <%= MethodsInheritedTemplate.new(type, ancestor, ancestor.class_methods, "Class") %>
+      <%= MacrosInheritedTemplate.new(type, ancestor, ancestor.macros) %>
+    <% end %>
+  </div>
 
-<%= MethodDetailTemplate.new("Constructor Detail", type.constructors) %>
-<%= MethodDetailTemplate.new(type.program? ? "Method Detail" : "Class Method Detail", type.class_methods) %>
-<%= MethodDetailTemplate.new("Macro Detail", type.macros) %>
-<%= MethodDetailTemplate.new("Instance Method Detail", type.instance_methods) %>
+  <%= MethodDetailTemplate.new("Constructor Detail", type.constructors) %>
+  <%= MethodDetailTemplate.new(type.program? ? "Method Detail" : "Class Method Detail", type.class_methods) %>
+  <%= MethodDetailTemplate.new("Macro Detail", type.macros) %>
+  <%= MethodDetailTemplate.new("Instance Method Detail", type.instance_methods) %>
+<% end %>
 </div>
 
 </body>

--- a/src/compiler/crystal/tools/doc/html/type.html
+++ b/src/compiler/crystal/tools/doc/html/type.html
@@ -19,7 +19,9 @@
 <% if type.program? %>
   <%= type.full_name.gsub("::", "::<wbr>") %>
 <% else %>
-  <span class="kind"><%= type.abstract? ? "abstract " : ""%><%= type.kind %></span> <%= type.full_name.gsub("::", "::<wbr>") %>
+  <span class="kind">
+    <%= type.abstract? ? "abstract " : ""%><%= type.visibility %><%= type.kind %>
+  </span> <%= type.full_name.gsub("::", "::<wbr>") %>
 <% end %>
 </h1>
 

--- a/src/compiler/crystal/tools/doc/macro.cr
+++ b/src/compiler/crystal/tools/doc/macro.cr
@@ -54,6 +54,10 @@ class Crystal::Doc::Macro
     false
   end
 
+  def visibility
+    @type.visibility
+  end
+
   def kind
     "macro "
   end

--- a/src/compiler/crystal/tools/doc/method.cr
+++ b/src/compiler/crystal/tools/doc/method.cr
@@ -158,6 +158,17 @@ class Crystal::Doc::Method
     @def.abstract?
   end
 
+  def visibility
+    case @def.visibility
+    in .public?
+      ""
+    in .protected?
+      "protected "
+    in .private?
+      "private "
+    end
+  end
+
   def return_type
     return_type = @def.return_type
 

--- a/src/compiler/crystal/tools/doc/method.cr
+++ b/src/compiler/crystal/tools/doc/method.cr
@@ -126,6 +126,8 @@ class Crystal::Doc::Method
 
   def prefix
     case
+    when @type.lib?
+      "."
     when @type.program?
       ""
     when @class_method
@@ -174,6 +176,8 @@ class Crystal::Doc::Method
 
   def kind
     case
+    when @type.lib?
+      "fun "
     when @type.program?
       "def "
     when @class_method

--- a/src/compiler/crystal/tools/doc/method.cr
+++ b/src/compiler/crystal/tools/doc/method.cr
@@ -201,7 +201,9 @@ class Crystal::Doc::Method
   def id
     String.build do |io|
       io << to_s.delete(' ')
-      if @class_method
+      if @type.lib?
+        io << "-function"
+      elsif @class_method
         io << "-class-method"
       else
         io << "-instance-method"
@@ -342,7 +344,7 @@ class Crystal::Doc::Method
       builder.field "args_string", args_to_s unless args.empty?
       builder.field "args_html", args_to_html unless args.empty?
       builder.field "location", location unless location.nil?
-      builder.field "def", self.def
+      builder.field @type.lib? ? "fun" : "def", self.def
     end
   end
 

--- a/src/compiler/crystal/tools/doc/type.cr
+++ b/src/compiler/crystal/tools/doc/type.cr
@@ -72,6 +72,10 @@ class Crystal::Doc::Type
     @type.abstract?
   end
 
+  def visibility
+    @type.private? ? "private " : ""
+  end
+
   def parents_of?(type)
     return false unless type
 
@@ -193,7 +197,7 @@ class Crystal::Doc::Type
         defs = [] of Method
         @type.defs.try &.each do |def_name, defs_with_metadata|
           defs_with_metadata.each do |def_with_metadata|
-            next unless def_with_metadata.def.visibility.public?
+            next unless def_with_metadata.def.visibility.public? || @generator.include_private
             next unless @generator.must_include? def_with_metadata.def
 
             defs << method(def_with_metadata.def, false)

--- a/src/compiler/crystal/tools/doc/type.cr
+++ b/src/compiler/crystal/tools/doc/type.cr
@@ -13,6 +13,8 @@ class Crystal::Doc::Type
     case @type
     when Const
       "const"
+    when .extern_union?
+      "union"
     when .struct?
       "struct"
     when .class?, .metaclass?

--- a/src/compiler/crystal/tools/doc/type.cr
+++ b/src/compiler/crystal/tools/doc/type.cr
@@ -191,7 +191,7 @@ class Crystal::Doc::Type
   def instance_methods
     @instance_methods ||= begin
       case @type
-      when Program
+      when Program, LibType
         [] of Method
       else
         defs = [] of Method

--- a/src/compiler/crystal/tools/doc/type.cr
+++ b/src/compiler/crystal/tools/doc/type.cr
@@ -28,7 +28,9 @@ class Crystal::Doc::Type
     when AnnotationType
       "annotation"
     when LibType
-      "module"
+      "lib"
+    when TypeDefType
+      "type"
     else
       raise "Unhandled type in `kind`: #{@type}"
     end
@@ -144,6 +146,18 @@ class Crystal::Doc::Type
     @type.is_a?(Const)
   end
 
+  def type_def?
+    @type.is_a?(TypeDefType)
+  end
+
+  def lib?
+    @type.is_a?(LibType)
+  end
+
+  def fun_def?
+    @type.is_a?(FunDef)
+  end
+
   def alias_definition
     alias_def = @type.as?(AliasType).try(&.aliased_type)
     alias_def
@@ -151,6 +165,15 @@ class Crystal::Doc::Type
 
   def formatted_alias_definition
     type_to_html alias_definition.as(Crystal::Type)
+  end
+
+  def type_definition
+    type_def = @type.as?(TypeDefType).try(&.typedef)
+    type_def
+  end
+
+  def formatted_type_definition
+    type_to_html type_definition.as(Crystal::Type)
   end
 
   @types : Array(Type)?


### PR DESCRIPTION
- Resolves #6721
- Resolves #7904 
- Resolves #14711

Three new flags are added to the documentation generator:
- `--include-all` will include everything in the namespace (stdlib, shards, project files)
  - this is useful for locally viewing all of the methods/objects available without needing to reference several different documentation pages
  - this is also useful for tooling, as running this command will provide the entire namespace/modules/types/methods/etc

![image](https://github.com/user-attachments/assets/15b547c4-dfe6-43c0-9200-dff81bd304fd)

- `--include-private` will include all private methods
  - this is mostly intended for tooling, to allow knowing the private/protected methods of objects when doing autocomplete and the like

![image](https://github.com/user-attachments/assets/e446526f-9ce6-4469-b6cc-1244744d90c4)

- `--include-lib` will generate documentation for lib/fun/cstruct/union/typedef/etc
  - this is useful for autocomplete with tooling
  - this is also useful for libraries meant to bind a C library, to know what methods are available without reading the documentation
  
![image](https://github.com/user-attachments/assets/66e918af-0f1d-467e-9fc7-031973aecf20)
![image](https://github.com/user-attachments/assets/a1a22a48-fb77-4839-9aa4-32afbc1bade6)
![image](https://github.com/user-attachments/assets/0b89c09a-722a-4162-817a-a4ef24297b04)
![image](https://github.com/user-attachments/assets/941bcc66-6a61-4bd9-8bb8-4c4ce83569bb)
