### PR TITLE
Add `HTTP::Cookie#expire`

### DIFF
--- a/spec/std/http/cookie_spec.cr
+++ b/spec/std/http/cookie_spec.cr
@@ -74,8 +74,8 @@ module HTTP
       cookie = HTTP::Cookie.new("hello", "world")
       cookie.destroy
 
-      assert cookie.value.empty?
-      assert cookie.expired?
+      cookie.value.empty?.should be_true
+      cookie.expired?.should be_true
     end
 
     describe "#name=" do

--- a/spec/std/http/cookie_spec.cr
+++ b/spec/std/http/cookie_spec.cr
@@ -76,6 +76,7 @@ module HTTP
 
       cookie.value.empty?.should be_true
       cookie.expired?.should be_true
+      cookie.max_age.should eq(Time::Span.zero)
     end
 
     describe "#name=" do

--- a/spec/std/http/cookie_spec.cr
+++ b/spec/std/http/cookie_spec.cr
@@ -70,6 +70,14 @@ module HTTP
       end
     end
 
+    it "#destroy" do
+      cookie = HTTP::Cookie.new("hello", "world")
+      cookie.destroy
+
+      assert cookie.value.empty?
+      assert cookie.expired?
+    end
+
     describe "#name=" do
       it "raises on invalid name" do
         cookie = HTTP::Cookie.new("x", "")

--- a/spec/std/http/cookie_spec.cr
+++ b/spec/std/http/cookie_spec.cr
@@ -70,9 +70,9 @@ module HTTP
       end
     end
 
-    it "#destroy" do
+    it "#expire" do
       cookie = HTTP::Cookie.new("hello", "world")
-      cookie.destroy
+      cookie.expire
 
       cookie.value.empty?.should be_true
       cookie.expired?.should be_true

--- a/src/http/cookie.cr
+++ b/src/http/cookie.cr
@@ -198,7 +198,8 @@ module HTTP
     # Browsers delete cookies that have expired.
     def destroy
       self.value = ""
-      self.expires = 5.minutes.ago
+      self.expires = Time::UNIx_EPOCH
+      self.max_age = Time::Span.zero
     end
 
     # :nodoc:

--- a/src/http/cookie.cr
+++ b/src/http/cookie.cr
@@ -192,6 +192,15 @@ module HTTP
       end
     end
 
+    # tell the browser to delete the cookie.
+    # Set its value to an empty string
+    # and set its expiration time to the past
+    # Browsers delete cookies that have expired.
+    def destroy
+      self.value = ""
+      self.expires = 5.minutes.ago
+    end
+
     # :nodoc:
     module Parser
       module Regex

--- a/src/http/cookie.cr
+++ b/src/http/cookie.cr
@@ -198,7 +198,7 @@ module HTTP
     # Browsers delete cookies that have expired.
     def destroy
       self.value = ""
-      self.expires = Time::UNIx_EPOCH
+      self.expires = Time::UNIX_EPOCH
       self.max_age = Time::Span.zero
     end
 

--- a/src/http/cookie.cr
+++ b/src/http/cookie.cr
@@ -192,10 +192,8 @@ module HTTP
       end
     end
 
-    # tell the browser to delete the cookie.
-    # Set its value to an empty string
-    # and set its expiration time to the past
-    # Browsers delete cookies that have expired.
+    # Destroys the cookie.
+    # This is done by causing the cookie to expire. Also clears its value.
     def destroy
       self.value = ""
       self.expires = Time::UNIX_EPOCH

--- a/src/http/cookie.cr
+++ b/src/http/cookie.cr
@@ -192,9 +192,19 @@ module HTTP
       end
     end
 
-    # Destroys the cookie.
-    # This is done by causing the cookie to expire. Also clears its value.
-    def destroy
+    # Expires the cookie.
+    #
+    # Causes the cookie to be destroyed. Sets the value to the empty string and
+    # expires its lifetime.
+    #
+    # ```
+    # cookie = HTTP::Cookie.new("hello", "world")
+    # cookie.expire
+    #
+    # cookie.value    # => ""
+    # cookie.expired? # => true
+    # ```
+    def expire
       self.value = ""
       self.expires = Time::UNIX_EPOCH
       self.max_age = Time::Span.zero


### PR DESCRIPTION
# Reasoning

I tried to use `cookies.delete("...")` today and it didn't cause the cookie to expire from the browser. It sent it again on the next request.

This method sets the cookie value to an empty string and seets the expiry date to 5 minutes ago. Browsers automatically delete expired cookies.

My aim is to provide a convenience to anyone who happens to need to use `HTTP::Cookie`