### PR TITLE
[CI] Update LLVM 18 for `wasm32-test`

### DIFF
--- a/.github/workflows/wasm32.yml
+++ b/.github/workflows/wasm32.yml
@@ -22,14 +22,14 @@ jobs:
         with:
           wasmtime-version: "2.0.0"
 
-      - name: Install LLVM 13
+      - name: Install LLVM
         run: |
           apt-get update
           apt-get install -y curl lsb-release wget software-properties-common gnupg
           curl -O https://apt.llvm.org/llvm.sh
           chmod +x llvm.sh
-          ./llvm.sh 13
-          ln -s $(which wasm-ld-13) /usr/bin/wasm-ld
+          ./llvm.sh 18
+          ln -s $(which wasm-ld-18) /usr/bin/wasm-ld
 
       - name: Download wasm32 libs
         run: |


### PR DESCRIPTION
LLVM 13 binaries are no longer available which breaks the CI workflow. Updating to LLVM 18 should have no negative consequences.