### PR TITLE
Always use unstable sort for simple types

### DIFF
--- a/src/slice.cr
+++ b/src/slice.cr
@@ -981,13 +981,23 @@ struct Slice(T)
   # the result could also be `[b, a]`.
   #
   # If stability is expendable, `#unstable_sort!` provides a performance
-  # advantage over stable sort.
+  # advantage over stable sort. As an optimization, if `T` is any primitive
+  # integer type, `Char`, any enum type, any `Pointer` instance, `Symbol`, or
+  # `Time::Span`, then an unstable sort is automatically used.
   #
   # Raises `ArgumentError` if the comparison between any two elements returns `nil`.
   def sort! : self
-    Slice.merge_sort!(self)
+    # If two values `x, y : T` have the same binary representation whenever they
+    # compare equal, i.e. `x <=> y == 0` implies
+    # `pointerof(x).memcmp(pointerof(y), 1) == 0`, then swapping the two values
+    # is a no-op and therefore a stable sort isn't required
+    {% if T.union_types.size == 1 && (T <= Int::Primitive || T <= Char || T <= Enum || T <= Pointer || T <= Symbol || T <= Time::Span) %}
+      unstable_sort!
+    {% else %}
+      Slice.merge_sort!(self)
 
-    self
+      self
+    {% end %}
   end
 
   # Sorts all elements in `self` based on the return value of the comparison


### PR DESCRIPTION
When calling `#sort!` without a block, if two elements have the same binary representations whenever they compare equal using `#<=>`, then they are indistinguishable from each other and swapping is a no-op. This allows the use of unstable sorting which runs slightly faster and requires no temporary allocations, as opposed to stable sorting which allocates memory linear in the collection size.

Following this criterion, the only reference type that supports unstable sorting is:

```crystal
class Foo
  include Comparable(self)

  def <=>(other : self) : Int32
    object_id <=> other.object_id
  end
end
```

Primitive floats do not support it, as the signed zeros compare equal but have opposite sign bits. For simplicity, unions also aren't touched; either they don't have a meaningful, non-null `#<=>` defined across the variant types, or they break the criterion (e.g. `1_i32` and `1_i8` have different type IDs).

`#sort` always delegates to `#sort!`. This does not affect `#sort_by!` since the projected element type alone doesn't guarantee the original elements themselves can be swapped in the same way.