### PR TITLE
[CI] Pin package repos for OpenSSL packages

### DIFF
--- a/.github/workflows/openssl.yml
+++ b/.github/workflows/openssl.yml
@@ -14,12 +14,12 @@ jobs:
     steps:
       - name: Download Crystal source
         uses: actions/checkout@v4
-      - name: Uninstall openssl 1.1
-        run: apk del openssl-dev
+      - name: Uninstall openssl
+        run: apk del openssl-dev python3 libxml2-static
       - name: Upgrade alpine-keys
         run: apk upgrade alpine-keys
       - name: Install openssl 3.0
-        run: apk add "openssl-dev=~3.0" --repository=http://dl-cdn.alpinelinux.org/alpine/v3.19/community
+        run: apk add "openssl-dev=~3.0" --repository=http://dl-cdn.alpinelinux.org/alpine/v3.17/main
       - name: Check LibSSL version
         run: bin/crystal eval 'require "openssl"; p! LibSSL::OPENSSL_VERSION, LibSSL::LIBRESSL_VERSION'
       - name: Run OpenSSL specs

--- a/.github/workflows/openssl.yml
+++ b/.github/workflows/openssl.yml
@@ -34,7 +34,7 @@ jobs:
       - name: Uninstall openssl
         run: apk del openssl-dev
       - name: Install openssl 1.1.1
-        run: apk add "openssl1.1-compat-dev=~1.1.1"
+        run: apk add "openssl1.1-compat-dev=~1.1.1" --repository=http://dl-cdn.alpinelinux.org/alpine/v3.18/community
       - name: Check LibSSL version
         run: bin/crystal eval 'require "openssl"; p! LibSSL::OPENSSL_VERSION, LibSSL::LIBRESSL_VERSION'
       - name: Run OpenSSL specs

--- a/.github/workflows/openssl.yml
+++ b/.github/workflows/openssl.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Upgrade alpine-keys
         run: apk upgrade alpine-keys
       - name: Install openssl 3.0
-        run: apk add "openssl-dev=~3.0"
+        run: apk add "openssl-dev=~3.0" --repository=http://dl-cdn.alpinelinux.org/alpine/v3.19/community
       - name: Check LibSSL version
         run: bin/crystal eval 'require "openssl"; p! LibSSL::OPENSSL_VERSION, LibSSL::LIBRESSL_VERSION'
       - name: Run OpenSSL specs

--- a/.github/workflows/openssl.yml
+++ b/.github/workflows/openssl.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Download Crystal source
         uses: actions/checkout@v4
       - name: Uninstall openssl
-        run: apk del openssl-dev python3 libxml2-static
+        run: apk del openssl-dev libxml2-static
       - name: Upgrade alpine-keys
         run: apk upgrade alpine-keys
       - name: Install openssl 3.0


### PR DESCRIPTION
This is a necessary preparatory step to update the docker image to Crystal 1.13.1 (#14810). The image is based on Alpine 3.20 which has neither OpenSSL 3.0 nor 1.1.1 in its repository. Thus the current configuration fails after an upgrade: https://github.com/crystal-lang/crystal/actions/runs/9922862005?pr=14810
