### PR TITLE
[CI] Update GitHub runner to `macos-14`

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -12,8 +12,8 @@ env:
 
 jobs:
   darwin-test:
-    runs-on: "${{ matrix.runs-on }}"
-    name: "${{ matrix.arch }}"
+    runs-on: ${{ matrix.runs-on }}
+    name: ${{ matrix.arch }}
     strategy:
       matrix:
         include:

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -13,7 +13,7 @@ env:
 jobs:
   darwin-test:
     runs-on: "${{ matrix.runs-on }}"
-    name: "CI ${{ matrix.name }}"
+    name: "CI ${{ matrix.arch }}"
     strategy:
       matrix:
         include:

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -13,7 +13,7 @@ env:
 jobs:
   darwin-test:
     runs-on: "${{ matrix.runs-on }}"
-    name: "CI ${{ matrix.arch }}"
+    name: "${{ matrix.arch }}"
     strategy:
       matrix:
         include:

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -12,7 +12,7 @@ env:
 
 jobs:
   x86_64-darwin-test:
-    runs-on: macos-13
+    runs-on: macos-14
     steps:
       - name: Download Crystal source
         uses: actions/checkout@v4

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -11,7 +11,7 @@ env:
   CI_NIX_SHELL: true
 
 jobs:
-  x86_64-darwin-test:
+  darwin-test:
     runs-on: macos-14
     steps:
       - name: Download Crystal source

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -12,7 +12,15 @@ env:
 
 jobs:
   darwin-test:
-    runs-on: macos-14
+    runs-on: "${{ matrix.runs-on }}"
+    name: "CI ${{ matrix.name }}"
+    strategy:
+      matrix:
+        include:
+        - runs-on: macos-13
+          arch: x86_64-darwin
+        - runs-on: macos-14
+          arch: aarch64-darwin
     steps:
       - name: Download Crystal source
         uses: actions/checkout@v4

--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -51,7 +51,6 @@ jobs:
       matrix:
         target:
           - aarch64-linux-android
-          - aarch64-darwin
           - arm-linux-gnueabihf
           - i386-linux-gnu
           - i386-linux-musl


### PR DESCRIPTION
The `macos-14` runners are running on the M1 architecture.

<del>For some reason, the spec runner breaks down at some point. It's not clear why.</del> (https://github.com/crystal-lang/crystal/issues/14835)