### PR TITLE
Disable `Tuple#to_static_array` spec on AArch64

### DIFF
--- a/spec/std/tuple_spec.cr
+++ b/spec/std/tuple_spec.cr
@@ -342,18 +342,23 @@ describe "Tuple" do
     ary.size.should eq(0)
   end
 
-  it "#to_static_array" do
-    ary = {1, 'a', true}.to_static_array
-    ary.should be_a(StaticArray(Int32 | Char | Bool, 3))
-    ary.should eq(StaticArray[1, 'a', true])
-    ary.size.should eq(3)
+  # Tuple#to_static_array don't compile on aarch64-darwin and
+  # aarch64-linux-musl due to a codegen error caused by LLVM < 13.0.0.
+  # See https://github.com/crystal-lang/crystal/issues/11358 for details.
+  {% unless compare_versions(Crystal::LLVM_VERSION, "13.0.0") < 0 && flag?(:aarch64) && (flag?(:musl) || flag?(:darwin) || flag?(:android)) %}
+    it "#to_static_array" do
+      ary = {1, 'a', true}.to_static_array
+      ary.should be_a(StaticArray(Int32 | Char | Bool, 3))
+      ary.should eq(StaticArray[1, 'a', true])
+      ary.size.should eq(3)
 
-    ary = Tuple.new.to_static_array
-    ary.should be_a(StaticArray(NoReturn, 0))
-    ary.size.should eq(0)
+      ary = Tuple.new.to_static_array
+      ary.should be_a(StaticArray(NoReturn, 0))
+      ary.size.should eq(0)
 
-    ary = Tuple(String | Int32).new(1).to_static_array
-    ary.should be_a(StaticArray(String | Int32, 1))
-    ary.should eq StaticArray[1.as(String | Int32)]
-  end
+      ary = Tuple(String | Int32).new(1).to_static_array
+      ary.should be_a(StaticArray(String | Int32, 1))
+      ary.should eq StaticArray[1.as(String | Int32)]
+    end
+  {% end %}
 end


### PR DESCRIPTION
Fixes #14835