### PR TITLE
Make `IO::Buffered#buffer_size=` idempotent

### DIFF
--- a/spec/std/io/buffered_spec.cr
+++ b/spec/std/io/buffered_spec.cr
@@ -72,6 +72,15 @@ describe "IO::Buffered" do
     end
   end
 
+  it "can set buffer_size to the same value after first use" do
+    io = BufferedWrapper.new(IO::Memory.new("hello\r\nworld\n"))
+    io.buffer_size = 16_384
+    io.gets
+
+    io.buffer_size = 16_384
+    io.buffer_size.should eq(16_384)
+  end
+
   it "does gets" do
     io = BufferedWrapper.new(IO::Memory.new("hello\r\nworld\n"))
     io.gets.should eq("hello")

--- a/src/io/buffered.cr
+++ b/src/io/buffered.cr
@@ -49,7 +49,7 @@ module IO::Buffered
   # Set the buffer size of both the read and write buffer
   # Cannot be changed after any of the buffers have been allocated
   def buffer_size=(value)
-    if @in_buffer || @out_buffer
+    if (@in_buffer || @out_buffer) && (buffer_size != value)
       raise ArgumentError.new("Cannot change buffer_size after buffers have been allocated")
     end
     @buffer_size = value


### PR DESCRIPTION
The purpose of raising an exception here is to prevent the caller from doing something unsafe. _Changing_ the value is unsafe, but setting `buffer_size` to the same value is a safe operation.

Fixes #11270