### PR TITLE
Fix constants in macro expressions to be referenced from the top level

### DIFF
--- a/spec/primitives/reference_spec.cr
+++ b/spec/primitives/reference_spec.cr
@@ -72,7 +72,7 @@ describe "Primitives: reference" do
     end
 
     # see notes in `Reference.pre_initialize`
-    {% if compare_versions(Crystal::VERSION, "1.2.0") >= 0 %}
+    {% if compare_versions(::Crystal::VERSION, "1.2.0") >= 0 %}
       it "works with virtual type" do
         foo_buffer = GC.malloc(instance_sizeof(Foo))
         foo = Foo.as(Base.class).pre_initialize(foo_buffer).should be_a(Foo)

--- a/spec/std/float_spec.cr
+++ b/spec/std/float_spec.cr
@@ -344,7 +344,7 @@ describe "Float" do
     (-0.0/0.0).finite?.should be_false
   end
 
-  {% if compare_versions(Crystal::VERSION, "0.36.1") > 0 %}
+  {% if compare_versions(::Crystal::VERSION, "0.36.1") > 0 %}
     it "converts infinity" do
       Float32::INFINITY.to_f64.infinite?.should eq 1
       Float32::INFINITY.to_f32.infinite?.should eq 1

--- a/spec/std/number_spec.cr
+++ b/spec/std/number_spec.cr
@@ -69,7 +69,7 @@ describe "Number" do
       (-Float64::INFINITY).round(digits: -3).should eq -Float64::INFINITY
     end
 
-    {% if compare_versions(Crystal::VERSION, "0.36.1") > 0 %}
+    {% if compare_versions(::Crystal::VERSION, "0.36.1") > 0 %}
       it "infinity Float32" do
         Float32::INFINITY.round.should eq Float32::INFINITY
         Float32::INFINITY.round(digits: 0).should eq Float32::INFINITY

--- a/spec/std/object_spec.cr
+++ b/spec/std/object_spec.cr
@@ -116,7 +116,7 @@ private class TestObject
   end
 
   # NOTE: these methods are a syntax error in older versions
-  {% if compare_versions(Crystal::VERSION, "1.12.0-dev") >= 0 %}
+  {% if compare_versions(::Crystal::VERSION, "1.12.0-dev") >= 0 %}
     {% for op in EQ_OPERATORS %}
       def {{ op.id }}(*args, **opts)
         [args, opts]
@@ -225,7 +225,7 @@ describe Object do
       (delegated["foo"] = "bar").should eq({"foo", "bar"})
     end
 
-    {% if compare_versions(Crystal::VERSION, "1.12.0-dev") >= 0 %}
+    {% if compare_versions(::Crystal::VERSION, "1.12.0-dev") >= 0 %}
       {% for op in EQ_OPERATORS %}
         it "forwards \#{{ op.id }} with multiple parameters" do
           test_object = TestObject.new

--- a/spec/std/static_array_spec.cr
+++ b/spec/std/static_array_spec.cr
@@ -288,7 +288,7 @@ describe "StaticArray" do
     # StaticArray#sort_by and #sort_by! don't compile on aarch64-darwin and
     # aarch64-linux-musl due to a codegen error caused by LLVM < 13.0.0.
     # See https://github.com/crystal-lang/crystal/issues/11358 for details.
-    {% unless compare_versions(Crystal::LLVM_VERSION, "13.0.0") < 0 && flag?(:aarch64) && (flag?(:musl) || flag?(:darwin) || flag?(:android)) %}
+    {% unless compare_versions(::Crystal::LLVM_VERSION, "13.0.0") < 0 && flag?(:aarch64) && (flag?(:musl) || flag?(:darwin) || flag?(:android)) %}
       describe "{{ sort }}_by" do
         it "sorts by" do
           a = StaticArray["foo", "a", "hello"]

--- a/src/compiler/crystal/ffi/lib_ffi.cr
+++ b/src/compiler/crystal/ffi/lib_ffi.cr
@@ -1,6 +1,6 @@
 module Crystal
   @[Link("ffi")]
-  {% if compare_versions(Crystal::VERSION, "1.11.0-dev") >= 0 %}
+  {% if compare_versions(::Crystal::VERSION, "1.11.0-dev") >= 0 %}
     @[Link(dll: "libffi.dll")]
   {% end %}
   lib LibFFI

--- a/src/crystal/compiler_rt.cr
+++ b/src/crystal/compiler_rt.cr
@@ -86,7 +86,7 @@ require "./compiler_rt/divmod128.cr"
   {% end %}
 
   # https://github.com/llvm/llvm-project/commit/d6216e2cd1a5e07f8509215ee5422ff5ee358da8
-  {% if compare_versions(Crystal::LLVM_VERSION, "14.0.0") >= 0 %}
+  {% if compare_versions(::Crystal::LLVM_VERSION, "14.0.0") >= 0 %}
     # the following overflow comparisons must be identical to the ones in
     # `Crystal::CodeGenVisitor#codegen_out_of_range`
 

--- a/src/crystal/lib_iconv.cr
+++ b/src/crystal/lib_iconv.cr
@@ -5,7 +5,7 @@ require "c/stddef"
 {% end %}
 
 @[Link("iconv")]
-{% if compare_versions(Crystal::VERSION, "1.11.0-dev") >= 0 %}
+{% if compare_versions(::Crystal::VERSION, "1.11.0-dev") >= 0 %}
   @[Link(dll: "libiconv.dll")]
 {% end %}
 lib LibIconv

--- a/src/fiber/context/aarch64.cr
+++ b/src/fiber/context/aarch64.cr
@@ -38,7 +38,7 @@ class Fiber
     # Eventually reset LR to zero to avoid the ARM unwinder to mistake the
     # context switch as a regular call.
 
-    {% if compare_versions(Crystal::LLVM_VERSION, "9.0.0") >= 0 %}
+    {% if compare_versions(::Crystal::LLVM_VERSION, "9.0.0") >= 0 %}
       asm("
       stp     d15, d14, [sp, #-22*8]!
       stp     d13, d12, [sp, #2*8]

--- a/src/fiber/context/arm.cr
+++ b/src/fiber/context/arm.cr
@@ -30,7 +30,7 @@ class Fiber
 
     {% if flag?(:armhf) %}
       #                r0             , r1
-      {% if compare_versions(Crystal::LLVM_VERSION, "9.0.0") >= 0 %}
+      {% if compare_versions(::Crystal::LLVM_VERSION, "9.0.0") >= 0 %}
         asm("
           // declare the presence of a conservative FPU to the ASM compiler
           .fpu vfp
@@ -78,7 +78,7 @@ class Fiber
           " :: "r"(current_context), "r"(new_context))
       {% end %}
     {% elsif flag?(:arm) %}
-      {% if compare_versions(Crystal::LLVM_VERSION, "9.0.0") >= 0 %}
+      {% if compare_versions(::Crystal::LLVM_VERSION, "9.0.0") >= 0 %}
         asm("
           stmdb  sp!, {r0, r4-r11, lr}  // push 1st argument + callee-saved registers
           str    sp, [r0, #0]           // current_context.stack_top = sp

--- a/src/fiber/context/i386.cr
+++ b/src/fiber/context/i386.cr
@@ -18,7 +18,7 @@ class Fiber
   @[NoInline]
   @[Naked]
   def self.swapcontext(current_context, new_context) : Nil
-    {% if compare_versions(Crystal::LLVM_VERSION, "9.0.0") >= 0 %}
+    {% if compare_versions(::Crystal::LLVM_VERSION, "9.0.0") >= 0 %}
       #                %ecx           , %eax
       asm("
       movl 8(%esp), %eax

--- a/src/fiber/context/x86_64-microsoft.cr
+++ b/src/fiber/context/x86_64-microsoft.cr
@@ -23,7 +23,7 @@ class Fiber
   @[NoInline]
   @[Naked]
   def self.swapcontext(current_context, new_context) : Nil
-    {% if compare_versions(Crystal::LLVM_VERSION, "9.0.0") >= 0 %}
+    {% if compare_versions(::Crystal::LLVM_VERSION, "9.0.0") >= 0 %}
       #                %rcx           , %rdx
       asm("
           pushq %rcx

--- a/src/fiber/context/x86_64-sysv.cr
+++ b/src/fiber/context/x86_64-sysv.cr
@@ -16,7 +16,7 @@ class Fiber
   @[NoInline]
   @[Naked]
   def self.swapcontext(current_context, new_context) : Nil
-    {% if compare_versions(Crystal::LLVM_VERSION, "9.0.0") >= 0 %}
+    {% if compare_versions(::Crystal::LLVM_VERSION, "9.0.0") >= 0 %}
       #                %rdi           , %rsi
       asm("
       pushq %rdi        // push 1st argument (because of initial resume)

--- a/src/gc/boehm.cr
+++ b/src/gc/boehm.cr
@@ -32,7 +32,7 @@ require "crystal/tracing"
   @[Link("gc", pkg_config: "bdw-gc")]
 {% end %}
 
-{% if compare_versions(Crystal::VERSION, "1.11.0-dev") >= 0 %}
+{% if compare_versions(::Crystal::VERSION, "1.11.0-dev") >= 0 %}
   @[Link(dll: "gc.dll")]
 {% end %}
 lib LibGC

--- a/src/indexable/mutable.cr
+++ b/src/indexable/mutable.cr
@@ -222,7 +222,7 @@ module Indexable::Mutable(T)
   # a.map! { |x| x * x }
   # a # => [1, 4, 9]
   # ```
-  {% if compare_versions(Crystal::VERSION, "1.1.1") >= 0 %}
+  {% if compare_versions(::Crystal::VERSION, "1.1.1") >= 0 %}
   def map!(& : T -> _) : self # TODO: add as constant
   {% else %}
   def map!(&) # it doesn't compile with the type annotation in the 1.0.0 compiler

--- a/src/intrinsics.cr
+++ b/src/intrinsics.cr
@@ -5,7 +5,7 @@ lib LibIntrinsics
   fun debugtrap = "llvm.debugtrap"
 
   {% if flag?(:avr) %}
-    {% if compare_versions(Crystal::LLVM_VERSION, "15.0.0") < 0 %}
+    {% if compare_versions(::Crystal::LLVM_VERSION, "15.0.0") < 0 %}
       fun memcpy = "llvm.memcpy.p0i8.p0i8.i16"(dest : Void*, src : Void*, len : UInt16, is_volatile : Bool)
       fun memmove = "llvm.memmove.p0i8.p0i8.i16"(dest : Void*, src : Void*, len : UInt16, is_volatile : Bool)
       fun memset = "llvm.memset.p0i8.i16"(dest : Void*, val : UInt8, len : UInt16, is_volatile : Bool)
@@ -16,7 +16,7 @@ lib LibIntrinsics
     {% end %}
   {% else %}
     {% if flag?(:bits64) %}
-      {% if compare_versions(Crystal::LLVM_VERSION, "15.0.0") < 0 %}
+      {% if compare_versions(::Crystal::LLVM_VERSION, "15.0.0") < 0 %}
         {% if flag?(:interpreted) %} @[Primitive(:interpreter_intrinsics_memcpy)] {% end %}
         fun memcpy = "llvm.memcpy.p0i8.p0i8.i64"(dest : Void*, src : Void*, len : UInt64, is_volatile : Bool)
 
@@ -36,7 +36,7 @@ lib LibIntrinsics
         fun memset = "llvm.memset.p0.i64"(dest : Void*, val : UInt8, len : UInt64, is_volatile : Bool)
       {% end %}
     {% else %}
-      {% if compare_versions(Crystal::LLVM_VERSION, "15.0.0") < 0 %}
+      {% if compare_versions(::Crystal::LLVM_VERSION, "15.0.0") < 0 %}
         {% if flag?(:interpreted) %} @[Primitive(:interpreter_intrinsics_memcpy)] {% end %}
         fun memcpy = "llvm.memcpy.p0i8.p0i8.i32"(dest : Void*, src : Void*, len : UInt32, is_volatile : Bool)
 

--- a/src/lib_z/lib_z.cr
+++ b/src/lib_z/lib_z.cr
@@ -1,5 +1,5 @@
 @[Link("z")]
-{% if compare_versions(Crystal::VERSION, "1.11.0-dev") >= 0 %}
+{% if compare_versions(::Crystal::VERSION, "1.11.0-dev") >= 0 %}
   @[Link(dll: "zlib1.dll")]
 {% end %}
 lib LibZ

--- a/src/llvm/lib_llvm.cr
+++ b/src/llvm/lib_llvm.cr
@@ -15,7 +15,7 @@
     {% llvm_ldflags = lines[2] %}
 
     @[Link("llvm")]
-    {% if compare_versions(Crystal::VERSION, "1.11.0-dev") >= 0 %}
+    {% if compare_versions(::Crystal::VERSION, "1.11.0-dev") >= 0 %}
       @[Link(dll: "LLVM-C.dll")]
     {% end %}
     lib LibLLVM

--- a/src/math/libm.cr
+++ b/src/math/libm.cr
@@ -96,7 +96,7 @@ lib LibM
 
     @[Primitive(:interpreter_libm_powi_f64)]
     fun powi_f64 = "llvm.powi.f64"(value : Float64, power : Int32) : Float64
-  {% elsif compare_versions(Crystal::LLVM_VERSION, "13.0.0") < 0 %}
+  {% elsif compare_versions(::Crystal::LLVM_VERSION, "13.0.0") < 0 %}
     fun powi_f32 = "llvm.powi.f32"(value : Float32, power : Int32) : Float32
     fun powi_f64 = "llvm.powi.f64"(value : Float64, power : Int32) : Float64
   {% else %}

--- a/src/object.cr
+++ b/src/object.cr
@@ -1293,7 +1293,7 @@ class Object
   # wrapper.capitalize     # => "Hello"
   # ```
   macro delegate(*methods, to object)
-    {% if compare_versions(Crystal::VERSION, "1.12.0-dev") >= 0 %}
+    {% if compare_versions(::Crystal::VERSION, "1.12.0-dev") >= 0 %}
       {% eq_operators = %w(<= >= == != []= ===) %}
       {% for method in methods %}
         {% if method.id.ends_with?('=') && !eq_operators.includes?(method.id.stringify) %}

--- a/src/openssl/lib_crypto.cr
+++ b/src/openssl/lib_crypto.cr
@@ -36,7 +36,7 @@
 {% else %}
   @[Link(ldflags: "`command -v pkg-config > /dev/null && pkg-config --libs --silence-errors libcrypto || printf %s '-lcrypto'`")]
 {% end %}
-{% if compare_versions(Crystal::VERSION, "1.11.0-dev") >= 0 %}
+{% if compare_versions(::Crystal::VERSION, "1.11.0-dev") >= 0 %}
   # TODO: if someone brings their own OpenSSL 1.x.y on Windows, will this have a different name?
   @[Link(dll: "libcrypto-3-x64.dll")]
 {% end %}

--- a/src/openssl/lib_ssl.cr
+++ b/src/openssl/lib_ssl.cr
@@ -43,7 +43,7 @@ require "./lib_crypto"
 {% else %}
   @[Link(ldflags: "`command -v pkg-config > /dev/null && pkg-config --libs --silence-errors libssl || printf %s '-lssl -lcrypto'`")]
 {% end %}
-{% if compare_versions(Crystal::VERSION, "1.11.0-dev") >= 0 %}
+{% if compare_versions(::Crystal::VERSION, "1.11.0-dev") >= 0 %}
   # TODO: if someone brings their own OpenSSL 1.x.y on Windows, will this have a different name?
   @[Link(dll: "libssl-3-x64.dll")]
   @[Link(dll: "libcrypto-3-x64.dll")]

--- a/src/primitives.cr
+++ b/src/primitives.cr
@@ -91,7 +91,7 @@ class Reference
   # See also: `Reference.unsafe_construct`.
   @[Experimental("This API is still under development. Join the discussion about custom reference allocation at [#13481](https://github.com/crystal-lang/crystal/issues/13481).")]
   @[Primitive(:pre_initialize)]
-  {% if compare_versions(Crystal::VERSION, "1.2.0") >= 0 %}
+  {% if compare_versions(::Crystal::VERSION, "1.2.0") >= 0 %}
     def self.pre_initialize(address : Pointer)
       # This ensures `.pre_initialize` is instantiated for every subclass,
       # otherwise all calls will refer to the sole instantiation in

--- a/src/regex/lib_pcre.cr
+++ b/src/regex/lib_pcre.cr
@@ -1,5 +1,5 @@
 @[Link("pcre", pkg_config: "libpcre")]
-{% if compare_versions(Crystal::VERSION, "1.11.0-dev") >= 0 %}
+{% if compare_versions(::Crystal::VERSION, "1.11.0-dev") >= 0 %}
   @[Link(dll: "pcre.dll")]
 {% end %}
 lib LibPCRE

--- a/src/regex/lib_pcre2.cr
+++ b/src/regex/lib_pcre2.cr
@@ -1,5 +1,5 @@
 @[Link("pcre2-8", pkg_config: "libpcre2-8")]
-{% if compare_versions(Crystal::VERSION, "1.11.0-dev") >= 0 %}
+{% if compare_versions(::Crystal::VERSION, "1.11.0-dev") >= 0 %}
   @[Link(dll: "pcre2-8.dll")]
 {% end %}
 lib LibPCRE2

--- a/src/socket/addrinfo.cr
+++ b/src/socket/addrinfo.cr
@@ -66,7 +66,7 @@ class Socket
               if value.is_a?(Socket::ConnectError)
                 raise Socket::ConnectError.from_os_error("Error connecting to '#{domain}:#{service}'", value.os_error)
               else
-                {% if flag?(:win32) && compare_versions(Crystal::LLVM_VERSION, "13.0.0") < 0 %}
+                {% if flag?(:win32) && compare_versions(::Crystal::LLVM_VERSION, "13.0.0") < 0 %}
                   # FIXME: Workaround for https://github.com/crystal-lang/crystal/issues/11047
                   array = StaticArray(UInt8, 0).new(0)
                 {% end %}

--- a/src/tuple.cr
+++ b/src/tuple.cr
@@ -545,7 +545,7 @@ struct Tuple
   # {1, 2, 3, 4, 5}.to_a # => [1, 2, 3, 4, 5]
   # ```
   def to_a : Array(Union(*T))
-    {% if compare_versions(Crystal::VERSION, "1.1.0") < 0 %}
+    {% if compare_versions(::Crystal::VERSION, "1.1.0") < 0 %}
       to_a(&.itself.as(Union(*T)))
     {% else %}
       to_a(&.itself)

--- a/src/unicode/unicode.cr
+++ b/src/unicode/unicode.cr
@@ -147,7 +147,7 @@ module Unicode
 
   # TODO: remove the workaround for 1.0.0 eventually (needed until #10713)
   private macro dfa_state(*transitions)
-    {% if compare_versions(Crystal::VERSION, "1.1.0") >= 0 %}
+    {% if compare_versions(::Crystal::VERSION, "1.1.0") >= 0 %}
       {% x = 0_u64 %}
       {% for tr, i in transitions %}
         {% x |= (1_u64 << (i * 6)) * tr * 6 %}

--- a/src/xml/libxml2.cr
+++ b/src/xml/libxml2.cr
@@ -5,7 +5,7 @@ require "./html_parser_options"
 require "./save_options"
 
 @[Link("xml2", pkg_config: "libxml-2.0")]
-{% if compare_versions(Crystal::VERSION, "1.11.0-dev") >= 0 %}
+{% if compare_versions(::Crystal::VERSION, "1.11.0-dev") >= 0 %}
   @[Link(dll: "libxml2.dll")]
 {% end %}
 lib LibXML

--- a/src/yaml/lib_yaml.cr
+++ b/src/yaml/lib_yaml.cr
@@ -1,7 +1,7 @@
 require "./enums"
 
 @[Link("yaml", pkg_config: "yaml-0.1")]
-{% if compare_versions(Crystal::VERSION, "1.11.0-dev") >= 0 %}
+{% if compare_versions(::Crystal::VERSION, "1.11.0-dev") >= 0 %}
   @[Link(dll: "yaml.dll")]
 {% end %}
 lib LibYAML


### PR DESCRIPTION
Referencing `Crystal` in a macro conflicts with user-defined `Crystal`.

```crystal
module Jewel
  class Crystal
    delegate to_s, to: self.class
  end
end

puts Jewel::Crystal.new
```

```console
$ crystal --version
Crystal 1.13.1 [405f313e0] (2024-07-12)

$ crystal jewel.cr
In crystal/src/object.cr:1296:28

 1296 | {% if compare_versions(Crystal::VERSION, "1.12.0-dev") >= 0 %}
                               ^---------------
Error: undefined constant Crystal::VERSION
```

It works correctly with earlier versions of Crystal or this PR.

```console
$ crystal jewel.cr
Jewel::Crystal
```

This fix was created mechanically by
```zsh
sed -i -e 's/compare_versions(Crystal/compare_versions(::Crystal/g' **/*.cr(^/)
```

Best regards,