### PR TITLE
Optimize `Indexable#each_slice(&)`

### DIFF
--- a/spec/std/array_spec.cr
+++ b/spec/std/array_spec.cr
@@ -1959,6 +1959,11 @@ describe "Array" do
 
   it_iterates "#each_index", [0, 1, 2], [1, 2, 3].each_index
 
+  it_iterates "#each_slice", [[0, 1], [2, 3], [4, 5], [6]], [0, 1, 2, 3, 4, 5, 6].each_slice(2)
+  it_iterates "#each_slice", [[0, 1, 2], [3, 4, 5], [6, 7, 8]], [0, 1, 2, 3, 4, 5, 6, 7, 8].each_slice(3)
+  it_iterates "#each_slice", [(0..15).to_a, (16..31).to_a, (32..47).to_a], Array.new(48, &.itself).each_slice(16)
+  it_iterates "#each_slice", [(0..18).to_a, (19..37).to_a, (38..47).to_a], Array.new(48, &.itself).each_slice(19)
+
   describe "transpose" do
     it "transposes elements" do
       [['a', 'b'], ['c', 'd'], ['e', 'f']].transpose.should eq([['a', 'c', 'e'], ['b', 'd', 'f']])

--- a/spec/std/indexable_spec.cr
+++ b/spec/std/indexable_spec.cr
@@ -201,6 +201,18 @@ describe Indexable do
     is.should eq([0, 1, 2])
   end
 
+  it "does each_slice" do
+    indexable = SafeIndexable.new(7)
+    is = [] of Array(Int32)
+    indexable.each_slice(2) { |i| is << i }.should be_nil
+    is.should eq([[0, 1], [2, 3], [4, 5], [6]])
+
+    indexable = SafeIndexable.new(9)
+    is = [] of Array(Int32)
+    indexable.each_slice(3) { |i| is << i }.should be_nil
+    is.should eq([[0, 1, 2], [3, 4, 5], [6, 7, 8]])
+  end
+
   it "iterates through a subset of its elements (#3386)" do
     indexable = SafeIndexable.new(5)
     elems = [] of Int32

--- a/spec/std/slice_spec.cr
+++ b/spec/std/slice_spec.cr
@@ -447,6 +447,10 @@ describe "Slice" do
   it_iterates "#each", [1, 2, 3], Slice[1, 2, 3].each
   it_iterates "#reverse_each", [3, 2, 1], Slice[1, 2, 3].reverse_each
   it_iterates "#each_index", [0, 1, 2], Slice[1, 2, 3].each_index
+  it_iterates "#each_slice", [[0, 1], [2, 3], [4, 5], [6]], Slice[0, 1, 2, 3, 4, 5, 6].each_slice(2)
+  it_iterates "#each_slice", [[0, 1, 2], [3, 4, 5], [6, 7, 8]], Slice[0, 1, 2, 3, 4, 5, 6, 7, 8].each_slice(3)
+  it_iterates "#each_slice", [(0..15).to_a, (16..31).to_a, (32..47).to_a], Slice.new(48, &.itself).each_slice(16)
+  it_iterates "#each_slice", [(0..18).to_a, (19..37).to_a, (38..47).to_a], Slice.new(48, &.itself).each_slice(19)
 
   it "does to_a" do
     slice = Slice.new(3) { |i| i }

--- a/spec/std/static_array_spec.cr
+++ b/spec/std/static_array_spec.cr
@@ -321,4 +321,8 @@ describe "StaticArray" do
   it_iterates "#each", [1, 2, 3], StaticArray[1, 2, 3].each
   it_iterates "#reverse_each", [3, 2, 1], StaticArray[1, 2, 3].reverse_each
   it_iterates "#each_index", [0, 1, 2], StaticArray[1, 2, 3].each_index
+  it_iterates "#each_slice", [[0, 1], [2, 3], [4, 5], [6]], StaticArray[0, 1, 2, 3, 4, 5, 6].each_slice(2)
+  it_iterates "#each_slice", [[0, 1, 2], [3, 4, 5], [6, 7, 8]], StaticArray[0, 1, 2, 3, 4, 5, 6, 7, 8].each_slice(3)
+  it_iterates "#each_slice", [(0..15).to_a, (16..31).to_a, (32..47).to_a], StaticArray(Int32, 48).new(&.itself).each_slice(16)
+  it_iterates "#each_slice", [(0..18).to_a, (19..37).to_a, (38..47).to_a], StaticArray(Int32, 48).new(&.itself).each_slice(19)
 end

--- a/src/array.cr
+++ b/src/array.cr
@@ -1111,6 +1111,11 @@ class Array(T)
     @size = size.to_i
   end
 
+  # :inherit:
+  def each_slice(count : Int, &)
+    to_unsafe_slice.each_slice(count) { |elems| yield elems }
+  end
+
   # Optimized version of `Enumerable#map`.
   def map(& : T -> U) : Array(U) forall U
     Array(U).new(size) { |i| yield @buffer[i] }

--- a/src/indexable.cr
+++ b/src/indexable.cr
@@ -630,6 +630,19 @@ module Indexable(T)
     self
   end
 
+  # :inherit:
+  def each_slice(count : Int, &) : Nil
+    i = 0
+    while i + count <= size
+      yield Array.new(count) { |j| unsafe_fetch(i + j) }
+      i += count
+    end
+    if i < size
+      yield Array.new(size - i) { |j| unsafe_fetch(i + j) }
+    end
+    nil
+  end
+
   # Optimized version of `Enumerable#join` that performs better when
   # all of the elements in this indexable are strings: the total string
   # bytesize to return can be computed before creating the final string,

--- a/src/slice.cr
+++ b/src/slice.cr
@@ -392,6 +392,25 @@ struct Slice(T)
   private SMALL_SLICE_SIZE = 16 # same as Array::SMALL_ARRAY_SIZE
 
   # :inherit:
+  def each_slice(count : Int, &) : Nil
+    if count >= SMALL_SLICE_SIZE
+      ptr = @pointer
+      ptr_last = ptr + count * ((size - 1) // count)
+      ptr_end = ptr + size
+      while ptr <= ptr_last
+        n = {count, ptr_end - ptr}.min
+        yield Array(T).build(n) do |buf|
+          ptr.copy_to(buf, n)
+          n
+        end
+        ptr += count
+      end
+    else
+      super { |elems| yield elems }
+    end
+  end
+
+  # :inherit:
   #
   # Raises if this slice is read-only.
   def map!(& : T -> _) : self

--- a/src/static_array.cr
+++ b/src/static_array.cr
@@ -158,6 +158,11 @@ struct StaticArray(T, N)
     self
   end
 
+  # :inherit:
+  def each_slice(count : Int, &)
+    to_slice.each_slice(count) { |elems| yield elems }
+  end
+
   # Returns a new static array where elements are mapped by the given block.
   #
   # ```


### PR DESCRIPTION
If the elements of an `Enumerable` are already stored contiguously in memory and each iteration returns a fresh `Array` (i.e. `reuse` is `false` or unset), it is faster to construct that returned array's contents with a single slice copy than inserting repeatedly. Benchmarks:

```crystal
require "benchmark"

module Indexable(T)
  def each_slice2(count : Int, &)
    # this PR's implementation
  end
end

struct Slice(T)
  def each_slice3(count : Int, &)
    # this PR's implementation
  end
end

require "benchmark"

N = ENV["N"]?.try(&.split(',').map(&.to_i)) || [10000]
M = ENV["M"]?.try(&.split(',').map(&.to_i)) || [16]

x = [] of Void*

M.each do |m|
  N.each do |n|
    arr = Slice.new(n) { |i| Pointer(Void).new(i) }
    puts "n = #{n}, m = #{m}"
    Benchmark.ips(n) do |b|
      b.report("Enumerable (m = #{m})") do
        arr.each_slice(m) { |v| x = v }
      end

      b.report("Indexable (m = #{m})") do
        arr.each_slice2(m) { |v| x = v }
      end

      b.report("Slice (m = #{m})") do
        arr.each_slice3(m) { |v| x = v }
      end
    end
  end
end
```

Results: ([raw output](https://gist.github.com/HertzDevil/8eb318e84d4914f7b5a02e7f3207e174))

![each_slice](https://github.com/user-attachments/assets/b24a237b-a505-4aa4-bf7d-ff5407aaee18)

These results were taken on an x86-64 machine, where the `Slice` implementation starts to outmatch the `Indexable` one when `m` is around 5 to 8. On AArch64 this number is slightly higher, so for simplicity the heuristic uses `SMALL_SLICE_SIZE = 16`.