### PR TITLE
Update `LibCrypto` bindings for LibreSSL 3.5+

### DIFF
--- a/.github/workflows/openssl.yml
+++ b/.github/workflows/openssl.yml
@@ -71,3 +71,18 @@ jobs:
         run: bin/crystal eval 'require "openssl"; p! LibSSL::OPENSSL_VERSION, LibSSL::LIBRESSL_VERSION'
       - name: Run OpenSSL specs
         run: bin/crystal spec --order=random spec/std/openssl/
+  libressl38:
+    runs-on: ubuntu-latest
+    name: "LibreSSL 3.5"
+    container: crystallang/crystal:1.13.1-alpine
+    steps:
+      - name: Download Crystal source
+        uses: actions/checkout@v2
+      - name: Uninstall openssl
+        run: apk del openssl-dev openssl-libs-static
+      - name: Install libressl 3.8
+        run: apk add "libressl-dev=~3.8" --repository=http://dl-cdn.alpinelinux.org/alpine/v3.20/community
+      - name: Check LibSSL version
+        run: bin/crystal eval 'require "openssl"; p! LibSSL::OPENSSL_VERSION, LibSSL::LIBRESSL_VERSION'
+      - name: Run OpenSSL specs
+        run: bin/crystal spec --order=random spec/std/openssl/

--- a/.github/workflows/openssl.yml
+++ b/.github/workflows/openssl.yml
@@ -56,3 +56,18 @@ jobs:
         run: bin/crystal eval 'require "openssl"; p! LibSSL::OPENSSL_VERSION, LibSSL::LIBRESSL_VERSION'
       - name: Run OpenSSL specs
         run: bin/crystal spec --order=random spec/std/openssl/
+  libressl35:
+    runs-on: ubuntu-latest
+    name: "LibreSSL 3.5"
+    container: crystallang/crystal:1.13.1-alpine
+    steps:
+      - name: Download Crystal source
+        uses: actions/checkout@v2
+      - name: Uninstall openssl
+        run: apk del openssl-dev openssl-libs-static
+      - name: Install libressl 3.5
+        run: apk add "libressl-dev=~3.5" --repository=http://dl-cdn.alpinelinux.org/alpine/v3.16/community
+      - name: Check LibSSL version
+        run: bin/crystal eval 'require "openssl"; p! LibSSL::OPENSSL_VERSION, LibSSL::LIBRESSL_VERSION'
+      - name: Run OpenSSL specs
+        run: bin/crystal spec --order=random spec/std/openssl/

--- a/src/openssl/lib_crypto.cr
+++ b/src/openssl/lib_crypto.cr
@@ -57,7 +57,10 @@ lib LibCrypto
 
   struct Bio
     method : Void*
-    callback : (Void*, Int, Char*, Int, Long, Long) -> Long
+    callback : BIO_callback_fn
+    {% if compare_versions(LIBRESSL_VERSION, "3.5.0") >= 0 %}
+      callback_ex : BIO_callback_fn_ex
+    {% end %}
     cb_arg : Char*
     init : Int
     shutdown : Int
@@ -71,6 +74,9 @@ lib LibCrypto
     num_read : ULong
     num_write : ULong
   end
+
+  alias BIO_callback_fn = (Bio*, Int, Char*, Int, Long, Long) -> Long
+  alias BIO_callback_fn_ex = (Bio*, Int, Char, SizeT, Int, Long, Int, SizeT*) -> Long
 
   PKCS5_SALT_LEN     =  8
   EVP_MAX_KEY_LENGTH = 32


### PR DESCRIPTION
The layout of the `BIO` struct has changed in LibreSSL 3.5.0. This change reflects that.

However, we probably could remove these explicit struct definition as mentioned in https://github.com/crystal-lang/crystal/issues/12647#issuecomment-1793547051. Its layout is internal to the library and the Crystal bindings only interact with pointers to a bio struct. That'll be a follow-up.

Resolves #12647