### PR TITLE
Deprecate `Pointer.new(Int)`

### DIFF
--- a/src/pointer.cr
+++ b/src/pointer.cr
@@ -420,6 +420,7 @@ struct Pointer(T)
   # ptr = Pointer(Int32).new(5678)
   # ptr.address # => 5678
   # ```
+  @[Deprecated("Call `.new(UInt64)` directly instead")]
   def self.new(address : Int)
     new address.to_u64!
   end


### PR DESCRIPTION
Resolves #14669