### PR TITLE
Update distribution-scripts

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,7 +8,7 @@ parameters:
   distribution-scripts-version:
     description: "Git ref for version of https://github.com/crystal-lang/distribution-scripts/"
     type: string
-    default: "96e431e170979125018bd4fd90111a3147477eec"
+    default: "da59efb2dfd70dcd7272eaecceffb636ef547427"
   previous_crystal_base_url:
     description: "Prefix for URLs to Crystal bootstrap compiler"
     type: string


### PR DESCRIPTION
Updates `distribution-scripts` dependency to https://github.com/crystal-lang/distribution-scripts/commit/da59efb2dfd70dcd7272eaecceffb636ef547427

This includes the following changes:

* crystal-lang/distribution-scripts#326
