### PR TITLE
Hide `Hash::Entry` from public API docs

### DIFF
--- a/src/hash.cr
+++ b/src/hash.cr
@@ -2149,6 +2149,7 @@ class Hash(K, V)
     hash
   end
 
+  # :nodoc:
   struct Entry(K, V)
     getter key, value, hash
 


### PR DESCRIPTION
Follow up to https://github.com/crystal-lang/crystal/pull/14862#discussion_r1702172687. 

There isn't really a way to obtain a `Hash::Entry` via the public `Hash` API. It's obviously an implementation detail so should just hide it.