### PR TITLE
Fix typos in docs for `Set` and `Hash`

### DIFF
--- a/src/hash.cr
+++ b/src/hash.cr
@@ -1055,7 +1055,7 @@ class Hash(K, V)
     self
   end
 
-  # Returns `true` of this Hash is comparing keys by `object_id`.
+  # Returns `true` if this Hash is comparing keys by `object_id`.
   #
   # See `compare_by_identity`.
   getter? compare_by_identity : Bool

--- a/src/set.cr
+++ b/src/set.cr
@@ -73,7 +73,7 @@ struct Set(T)
     self
   end
 
-  # Returns `true` of this Set is comparing objects by `object_id`.
+  # Returns `true` if this Set is comparing objects by `object_id`.
   #
   # See `compare_by_identity`.
   def compare_by_identity? : Bool


### PR DESCRIPTION
Fixed typos in the "compare_by_identity?" comments of Set and Hash.