### PR TITLE
Fix avoid linking `libpcre` when unused

### DIFF
--- a/src/regex/pcre.cr
+++ b/src/regex/pcre.cr
@@ -6,7 +6,7 @@ module Regex::PCRE
     String.new(LibPCRE.version)
   end
 
-  class_getter version_number : {Int32, Int32} = begin
+  class_getter version_number : {Int32, Int32} do
     version = self.version
     dot = version.index('.') || raise RuntimeError.new("Invalid libpcre2 version")
     space = version.index(' ', dot) || raise RuntimeError.new("Invalid libpcre2 version")

--- a/src/regex/pcre2.cr
+++ b/src/regex/pcre2.cr
@@ -13,7 +13,7 @@ module Regex::PCRE2
     end
   end
 
-  class_getter version_number : {Int32, Int32} = begin
+  class_getter version_number : {Int32, Int32} do
     version = self.version
     dot = version.index('.') || raise RuntimeError.new("Invalid libpcre2 version")
     space = version.index(' ', dot) || raise RuntimeError.new("Invalid libpcre2 version")


### PR DESCRIPTION
As reported by galapagdos on the [Crystal forum](https://forum.crystal-lang.org/t/issue-with-running-crystal-executable-on-another-macos-machine/7080), crystal always links libpcre/libpcre2 even if you don not use regular expressions, and calls the function `pcre2_config_8`.

```sh
crystal build hello_world.cr
ldd hello_world # libpcre2 is linked even if regular expressions are not used
```

This occurs because `begin` is used in `class_getter` in the Regex::PCRE module (src/regex/pcre.cr).

I searched the Crystal code with grep command and could not find any other uses of `begin` in `class_getters`. 
[supplement](https://gist.github.com/kojix2/a23f1af456c6565648b88b89ab2d1168)

```
grep class_getter | grep begin
```

```
src/regex/pcre2.cr:  class_getter version_number : {Int32, Int32} = begin
src/regex/pcre.cr:  class_getter version_number : {Int32, Int32} = begin
```

According to `crystal tool expand`, the macro is expanded as below.

Before:

```cr
module Regex::PCRE2
  @@version_number : ::Tuple(Int32, Int32) = begin
    version = self.version
    dot = if __temp_98 = version.index('.')
            __temp_98
          else
            raise(RuntimeError.new("Invalid libpcre2 version"))
          end
    space = if __temp_105 = version.index(' ', dot)
              __temp_105
            else
              raise(RuntimeError.new("Invalid libpcre2 version"))
            end
    {(version.byte_slice(0, dot)).to_i, (version.byte_slice(dot + 1, (space - dot) - 1)).to_i(false)}
  end

  def self.version_number : ::Tuple(Int32, Int32)
    @@version_number
  end
end
```

After:

```cr
module Regex::PCRE2
  @@version_number : ::Tuple(Int32, Int32) | ::Nil

  def self.version_number : ::Tuple(Int32, Int32)
    if (value = @@version_number).nil?
      @@version_number = (begin
        version = self.version
        dot = (version.index('.')) || (raise(RuntimeError.new("Invalid libpcre2 version")))
        space = (version.index(' ', dot)) || (raise(RuntimeError.new("Invalid libpcre2 version")))
        {(version.byte_slice(0, dot)).to_i, (version.byte_slice(dot + 1, (space - dot) - 1)).to_i(strict: false)}
      end)
    else
      value
    end
  end
end
```

Could you please review if it's ok not to use `begin` here?
Thank you.