### PR TITLE
Add `LLVM::Builder#finalize`

### DIFF
--- a/src/llvm/builder.cr
+++ b/src/llvm/builder.cr
@@ -389,7 +389,7 @@ class LLVM::Builder
 
   def finalize
     return if @disposed
-    
+
     dispose
   end
 

--- a/src/llvm/builder.cr
+++ b/src/llvm/builder.cr
@@ -388,8 +388,6 @@ class LLVM::Builder
   end
 
   def finalize
-    return if @disposed
-
     dispose
   end
 

--- a/src/llvm/builder.cr
+++ b/src/llvm/builder.cr
@@ -387,6 +387,12 @@ class LLVM::Builder
     LibLLVM.dispose_builder(@unwrap)
   end
 
+  def finalize
+    return if @disposed
+    
+    dispose
+  end
+
   # The next lines are for ease debugging when a types/values
   # are incorrectly used across contexts.
 


### PR DESCRIPTION
Resolves #14861 using the second proposed solution: adding a `finalize` method to the `LLVM::Builder` class