### PR TITLE
Implement `#sort_by` inside macros using `Enumerable#sort_by`

### DIFF
--- a/spec/compiler/macro/macro_methods_spec.cr
+++ b/spec/compiler/macro/macro_methods_spec.cr
@@ -928,6 +928,16 @@ module Crystal
         assert_macro %({{["c".id, "b", "a".id].sort}}), %([a, "b", c])
       end
 
+      it "executes sort_by" do
+        assert_macro %({{["abc", "a", "ab"].sort_by { |x| x.size }}}), %(["a", "ab", "abc"])
+      end
+
+      it "calls block exactly once for each element in #sort_by" do
+        assert_macro <<-CRYSTAL, %(5)
+          {{ (i = 0; ["abc", "a", "ab", "abcde", "abcd"].sort_by { i += 1 }; i) }}
+          CRYSTAL
+      end
+
       it "executes uniq" do
         assert_macro %({{[1, 1, 1, 2, 3, 1, 2, 3, 4].uniq}}), %([1, 2, 3, 4])
       end
@@ -1018,10 +1028,6 @@ module Crystal
     describe HashLiteral do
       it "executes size" do
         assert_macro %({{{:a => 1, :b => 3}.size}}), "2"
-      end
-
-      it "executes sort_by" do
-        assert_macro %({{["abc", "a", "ab"].sort_by { |x| x.size }}}), %(["a", "ab", "abc"])
       end
 
       it "executes empty?" do

--- a/src/compiler/crystal/macros/methods.cr
+++ b/src/compiler/crystal/macros/methods.cr
@@ -554,8 +554,7 @@ module Crystal
     end
 
     def interpret_compare(other : NumberLiteral)
-      # it should not be possible to obtain a NaN number literal
-      (to_number <=> other.to_number).not_nil!
+      to_number <=> other.to_number
     end
 
     def bool_bin_op(method, args, named_args, block, &)
@@ -3243,7 +3242,7 @@ end
 private record InterpretCompareWrapper, node : Crystal::ASTNode do
   include Comparable(self)
 
-  def <=>(other : self) : Int
+  def <=>(other : self)
     node.interpret_compare(other.node)
   end
 end


### PR DESCRIPTION
Ensures that the block in `ArrayLiteral#sort_by` and `TupleLiteral#sort_by` is called exactly once for each element, by not using `Enumerable#sort` under the hood.

Extracted from #14894