### PR TITLE
Fix codegen spec for `ProcPointer` of virtual type

### DIFF
--- a/spec/compiler/codegen/proc_spec.cr
+++ b/spec/compiler/codegen/proc_spec.cr
@@ -966,7 +966,6 @@ describe "Code gen: proc" do
       )).to_i.should eq(1)
   end
 
-  # FIXME: JIT compilation of this spec is broken, forcing normal compilation (#10961)
   it "doesn't crash when taking a proc pointer to a virtual type (#9823)" do
     run(%(
       abstract struct Parent
@@ -990,7 +989,7 @@ describe "Code gen: proc" do
       end
 
       Child1.new.as(Parent).get
-    ), flags: [] of String)
+    ), Proc(Int32, Int32, Int32))
   end
 
   it "doesn't crash when taking a proc pointer that multidispatches on the top-level (#3822)" do


### PR DESCRIPTION
The spec in #10964 is breaking the JIT because it is trying to return a `Proc`, which comprises 2 `Void*`s and therefore isn't supported by `LLVM::GenericValue`. The same would have happened if the spec were written like this:

```crystal
run(<<-CRYSTAL)
  x = uninitialized ->
  x
  CRYSTAL
```

Turning it into a typed spec (#14090) gets rid of this implicit value.