### PR TITLE
Don't spawn subprocess if codegen spec uses flags but not the prelude

### DIFF
--- a/spec/compiler/codegen/macro_spec.cr
+++ b/spec/compiler/codegen/macro_spec.cr
@@ -1885,4 +1885,9 @@ describe "Code gen: macro" do
       {% end %}
       )).to_i.should eq(10)
   end
+
+  it "accepts compile-time flags" do
+    run("{{ flag?(:foo) ? 1 : 0 }}", flags: %w(foo)).to_i.should eq(1)
+    run("{{ flag?(:foo) ? 1 : 0 }}", Int32, flags: %w(foo)).should eq(1)
+  end
 end

--- a/spec/spec_helper.cr
+++ b/spec/spec_helper.cr
@@ -294,7 +294,7 @@ def run(code, filename = nil, inject_primitives = true, debug = Crystal::Debug::
   # in the current executable!), so instead we compile
   # the program and run it, printing the last
   # expression and using that to compare the result.
-  if code.includes?(%(require "prelude")) || flags
+  if code.includes?(%(require "prelude"))
     ast = Parser.parse(code).as(Expressions)
     last = ast.expressions.last
     assign = Assign.new(Var.new("__tempvar"), last)
@@ -315,7 +315,9 @@ def run(code, filename = nil, inject_primitives = true, debug = Crystal::Debug::
       return SpecRunOutput.new(output)
     end
   else
-    new_program.run(code, filename: filename, debug: debug)
+    program = new_program
+    program.flags.concat(flags) if flags
+    program.run(code, filename: filename, debug: debug)
   end
 end
 
@@ -324,10 +326,12 @@ def run(code, return_type : T.class, filename : String? = nil, inject_primitives
     code = %(require "primitives"\n#{code})
   end
 
-  if code.includes?(%(require "prelude")) || flags
+  if code.includes?(%(require "prelude"))
     fail "TODO: support the prelude in typed codegen specs", file: file
   else
-    new_program.run(code, return_type: T, filename: filename, debug: debug)
+    program = new_program
+    program.flags.concat(flags) if flags
+    program.run(code, return_type: T, filename: filename, debug: debug)
   end
 end
 


### PR DESCRIPTION
The `run` spec helper always spawns a subprocess if any compile-time flags are specified. In practice, the only specs using the `flags` parameter are the ones for `-Dstrict_multi_assign` and the obsolete ones for `-Dpreview_overload` in #7206, which all separately require the prelude anyway. (There is one outlier that is addressed in #14903.) This PR allows specs specifying `flags` but not requiring the prelude to use LLVM's JIT.