### PR TITLE
Fix misaligned store in `Bool` to union upcasts

### DIFF
--- a/src/compiler/crystal/codegen/unions.cr
+++ b/src/compiler/crystal/codegen/unions.cr
@@ -85,7 +85,7 @@ module Crystal
       store type_id(value, @program.bool), union_type_id(struct_type, union_pointer)
 
       # To store a boolean in a union
-      # we sign-extend it to the size in bits of the union
+      # we zero-extend it to the size in bits of the union
       union_size = @llvm_typer.size_of(union_value_type)
       int_type = llvm_context.int((union_size * 8).to_i32)
 

--- a/src/compiler/crystal/codegen/unions.cr
+++ b/src/compiler/crystal/codegen/unions.cr
@@ -81,16 +81,19 @@ module Crystal
 
     def store_bool_in_union(target_type, union_pointer, value)
       struct_type = llvm_type(target_type)
+      union_value_type = struct_type.struct_element_types[1]
       store type_id(value, @program.bool), union_type_id(struct_type, union_pointer)
 
       # To store a boolean in a union
       # we sign-extend it to the size in bits of the union
-      union_size = @llvm_typer.size_of(struct_type.struct_element_types[1])
+      union_size = @llvm_typer.size_of(union_value_type)
       int_type = llvm_context.int((union_size * 8).to_i32)
 
       bool_as_extended_int = builder.zext(value, int_type)
       casted_value_ptr = pointer_cast(union_value(struct_type, union_pointer), int_type.pointer)
-      store bool_as_extended_int, casted_value_ptr
+      inst = store bool_as_extended_int, casted_value_ptr
+      set_alignment(inst, @llvm_typer.align_of(union_value_type))
+      inst
     end
 
     def store_nil_in_union(target_type, union_pointer)


### PR DESCRIPTION
Fixes #14898.

The code path for `Nil` looks similar, but it is perfectly fine: it directly stores `[8 x i64] zeroinitializer` to the data field, whose default alignment naturally matches.