### PR TITLE
Revert "Fix: Don't link to undocumented types in API docs"

### DIFF
--- a/src/compiler/crystal/tools/doc/html/type.html
+++ b/src/compiler/crystal/tools/doc/html/type.html
@@ -45,10 +45,10 @@
   <code><%= type.formatted_alias_definition %></code>
 <% end %>
 
-<%= OtherTypesTemplate.new("Included Modules", type, included_modules_with_docs) %>
-<%= OtherTypesTemplate.new("Extended Modules", type, extended_modules_with_docs) %>
-<%= OtherTypesTemplate.new("Direct Known Subclasses", type, subclasses_with_docs) %>
-<%= OtherTypesTemplate.new("Direct including types", type, including_types_with_docs) %>
+<%= OtherTypesTemplate.new("Included Modules", type, type.included_modules) %>
+<%= OtherTypesTemplate.new("Extended Modules", type, type.extended_modules) %>
+<%= OtherTypesTemplate.new("Direct Known Subclasses", type, type.subclasses) %>
+<%= OtherTypesTemplate.new("Direct including types", type, type.including_types) %>
 
 <% if locations = type.locations %>
   <h2>
@@ -99,7 +99,7 @@
 <%= MethodSummaryTemplate.new("Instance Method Summary", type.instance_methods) %>
 
 <div class="methods-inherited">
-  <% ancestors_with_docs.each do |ancestor| %>
+  <% type.ancestors.each do |ancestor| %>
     <%= MethodsInheritedTemplate.new(type, ancestor, ancestor.instance_methods, "Instance") %>
     <%= MethodsInheritedTemplate.new(type, ancestor, ancestor.constructors, "Constructor") %>
     <%= MethodsInheritedTemplate.new(type, ancestor, ancestor.class_methods, "Class") %>

--- a/src/compiler/crystal/tools/doc/templates.cr
+++ b/src/compiler/crystal/tools/doc/templates.cr
@@ -30,12 +30,6 @@ module Crystal::Doc
   end
 
   record TypeTemplate, type : Type, types : Array(Type), project_info : ProjectInfo do
-    {% for method in %w[ancestors included_modules extended_modules subclasses including_types] %}
-      def {{method.id}}_with_docs
-        type.{{method.id}}.select!(&.in?(types))
-      end
-    {% end %}
-
     ECR.def_to_s "#{__DIR__}/html/type.html"
   end
 


### PR DESCRIPTION
Reverts crystal-lang/crystal#14878

The patch is broken. It removes even links to documented types.