### PR TITLE
Add nodoc filter to doc type methods

### DIFF
--- a/spec/compiler/crystal/tools/doc/type_spec.cr
+++ b/spec/compiler/crystal/tools/doc/type_spec.cr
@@ -311,4 +311,41 @@ describe Doc::Type do
       type.included_modules.map(&.full_name).should eq ["Baz", "Mod1::Baz"]
     end
   end
+
+  describe "#included_modules" do
+    it "only include types with docs" do
+      program = semantic(<<-CRYSTAL, wants_doc: true).program
+        # :nodoc:
+        module Mod3
+          module Baz
+          end
+        end
+
+        module Mod2
+          # :nodoc:
+          module Baz
+          end
+        end
+
+        module Mod1
+          module Baz
+          end
+        end
+
+        module Baz
+        end
+
+        class Foo
+          extend Baz
+          extend Mod1::Baz
+          extend Mod2::Baz
+          extend Mod3::Baz
+        end
+        CRYSTAL
+
+      generator = Doc::Generator.new program, [""]
+      type = generator.type(program.types["Foo"])
+      type.extended_modules.map(&.full_name).should eq ["Baz", "Mod1::Baz"]
+    end
+  end
 end

--- a/spec/compiler/crystal/tools/doc/type_spec.cr
+++ b/spec/compiler/crystal/tools/doc/type_spec.cr
@@ -212,4 +212,36 @@ describe Doc::Type do
       type.macros.map(&.name).should eq ["+", "~", "foo"]
     end
   end
+
+  describe "#subclasses" do
+    it "only include types with docs" do
+      program = semantic(<<-CRYSTAL, wants_doc: true).program
+        class Foo
+        end
+
+        class Bar < Foo
+        end
+
+        # :nodoc:
+        class Baz < Foo
+        end
+
+        module Mod1
+          class Bar < ::Foo
+          end
+        end
+
+        # :nodoc:
+        module Mod2
+          class Baz < ::Foo
+          end
+        end
+        CRYSTAL
+
+      generator = Doc::Generator.new program, [""]
+      type = generator.type(program.types["Foo"])
+      type.subclasses.map(&.full_name).should eq ["Bar", "Mod1::Bar"]
+    end
+  end
+
 end

--- a/spec/compiler/crystal/tools/doc/type_spec.cr
+++ b/spec/compiler/crystal/tools/doc/type_spec.cr
@@ -244,4 +244,34 @@ describe Doc::Type do
     end
   end
 
+  describe "#ancestors" do
+    it "only include types with docs" do
+      program = semantic(<<-CRYSTAL, wants_doc: true).program
+        # :nodoc:
+        module Mod3
+          class Baz
+          end
+        end
+
+        class Mod2::Baz < Mod3::Baz
+        end
+
+        module Mod1
+          # :nodoc:
+          class Baz < Mod2::Baz
+          end
+        end
+
+        class Baz < Mod1::Baz
+        end
+
+        class Foo < Baz
+        end
+        CRYSTAL
+
+      generator = Doc::Generator.new program, [""]
+      type = generator.type(program.types["Foo"])
+      type.ancestors.map(&.full_name).should eq ["Baz", "Mod2::Baz"]
+    end
+  end
 end

--- a/spec/compiler/crystal/tools/doc/type_spec.cr
+++ b/spec/compiler/crystal/tools/doc/type_spec.cr
@@ -274,4 +274,41 @@ describe Doc::Type do
       type.ancestors.map(&.full_name).should eq ["Baz", "Mod2::Baz"]
     end
   end
+
+  describe "#included_modules" do
+    it "only include types with docs" do
+      program = semantic(<<-CRYSTAL, wants_doc: true).program
+        # :nodoc:
+        module Mod3
+          module Baz
+          end
+        end
+
+        module Mod2
+          # :nodoc:
+          module Baz
+          end
+        end
+
+        module Mod1
+          module Baz
+          end
+        end
+
+        module Baz
+        end
+
+        class Foo
+          include Baz
+          include Mod1::Baz
+          include Mod2::Baz
+          include Mod3::Baz
+        end
+        CRYSTAL
+
+      generator = Doc::Generator.new program, [""]
+      type = generator.type(program.types["Foo"])
+      type.included_modules.map(&.full_name).should eq ["Baz", "Mod1::Baz"]
+    end
+  end
 end

--- a/src/compiler/crystal/tools/doc/type.cr
+++ b/src/compiler/crystal/tools/doc/type.cr
@@ -248,6 +248,7 @@ class Crystal::Doc::Type
       included_modules = [] of Type
       @type.parents.try &.each do |parent|
         if parent.module?
+          next unless @generator.must_include? parent
           included_modules << @generator.type(parent)
         end
       end

--- a/src/compiler/crystal/tools/doc/type.cr
+++ b/src/compiler/crystal/tools/doc/type.cr
@@ -106,6 +106,7 @@ class Crystal::Doc::Type
 
     unless ast_node?
       @type.ancestors.each do |ancestor|
+        next unless @generator.must_include? ancestor
         doc_type = @generator.type(ancestor)
         ancestors << doc_type
         break if ancestor == @generator.program.object || doc_type.ast_node?

--- a/src/compiler/crystal/tools/doc/type.cr
+++ b/src/compiler/crystal/tools/doc/type.cr
@@ -263,6 +263,7 @@ class Crystal::Doc::Type
       extended_modules = [] of Type
       @type.metaclass.parents.try &.each do |parent|
         if parent.module?
+          next unless @generator.must_include? parent
           extended_modules << @generator.type(parent)
         end
       end


### PR DESCRIPTION
The doc generator is creating links to non-documented type. I tried to fix this in #14878, but it turned that it removed links to documented non-top-level types.

Instead, filters will now be applied in `Doc::Type#ancestors`, `Doc::Type#included_modules` and `Doc::Type#extended_modules` instead  as it was already done in `Doc::Type#subclasses`.

Some specs to verify correct(?) behavior has been added.


## Example of File.html.

### Before:
![file_html_before](https://github.com/user-attachments/assets/a6580b42-a891-4d99-b6d6-4b5a3f1ac163)

### After:
![file_html_after](https://github.com/user-attachments/assets/1ede4b58-81a5-45b2-9020-2bf713b6990b)

Fixes #9816, #12018

