### PR TITLE
Fix return type restriction for `ENV.fetch`

### DIFF
--- a/spec/std/env_spec.cr
+++ b/spec/std/env_spec.cr
@@ -137,6 +137,10 @@ describe "ENV" do
         ENV.fetch("2")
       end
     end
+
+    it "fetches arbitrary default value" do
+      ENV.fetch("nonexistent", true).should be_true
+    end
   end
 
   it "handles unicode" do

--- a/src/env.cr
+++ b/src/env.cr
@@ -60,7 +60,7 @@ module ENV
 
   # Retrieves a value corresponding to the given *key*. Return the second argument's value
   # if the *key* does not exist.
-  def self.fetch(key, default) : String?
+  def self.fetch(key, default : T) : String | T forall T
     fetch(key) { default }
   end
 


### PR DESCRIPTION
This return type restriction was too restrictive. `Env.fetch("x", y)` can return the type of `y` whatever it is. This is now identical to the return type restriction of the yielding overload.