### PR TITLE
Fix `SOURCE_DATE_EPOCH` in `Makefile.win`

### DIFF
--- a/Makefile.win
+++ b/Makefile.win
@@ -64,7 +64,7 @@ CRYSTAL_CONFIG_LIBRARY_PATH := $$ORIGIN\lib
 CRYSTAL_CONFIG_BUILD_COMMIT := $(shell git rev-parse --short HEAD)
 CRYSTAL_CONFIG_PATH := $$ORIGIN\src
 CRYSTAL_VERSION ?= $(shell type src\VERSION)
-SOURCE_DATE_EPOCH ?= $(shell type src/SOURCE_DATE_EPOCH || git show -s --format=%ct HEAD)
+SOURCE_DATE_EPOCH ?= $(or $(shell type src\SOURCE_DATE_EPOCH 2>NUL),$(shell git show -s --format=%ct HEAD))
 export_vars = $(eval export CRYSTAL_CONFIG_BUILD_COMMIT CRYSTAL_CONFIG_PATH SOURCE_DATE_EPOCH)
 export_build_vars = $(eval export CRYSTAL_CONFIG_LIBRARY_PATH)
 LLVM_CONFIG ?=


### PR DESCRIPTION
The `SOURCE_DATE_EPOCH` variable in `Makefile.win` has been broken after #14574:

* The `type` built-in never accepts file names with forward slashes, so building the compiler locally always prints `The syntax of the command is incorrect.` to the console.
* With that fixed, if the `src\SOURCE_DATE_EPOCH` file doesn't exist, which is most of the time, then instead `The system cannot find the file specified.` gets printed.
* For some unknown reason, the `%` doesn't get seen by the shell when there is a `||`.

This PR replaces the variable definition with one that works.