### PR TITLE
Fix `crystal tool dependencies` format flat

### DIFF
--- a/src/compiler/crystal/tools/dependencies.cr
+++ b/src/compiler/crystal/tools/dependencies.cr
@@ -124,7 +124,7 @@ module Crystal
       end
 
       private def print_indent
-        @io.print "  " * @stack.size unless @stack.empty?
+        @io.print "  " * @stack.size unless @stack.empty? || @format.flat?
       end
     end
 


### PR DESCRIPTION
`tree` and `flat` format are identical except that the former has an indent. This change ensures the indent is only written in the `tree` format.