### PR TITLE
Include `Crystal::System::User` instead of extending it

### DIFF
--- a/src/crystal/system/unix/user.cr
+++ b/src/crystal/system/unix/user.cr
@@ -4,14 +4,41 @@ require "../unix"
 module Crystal::System::User
   GETPW_R_SIZE_MAX = 1024 * 16
 
-  private def from_struct(pwd)
+  def initialize(@username : String, @id : String, @group_id : String, @name : String, @home_directory : String, @shell : String)
+  end
+
+  def system_username
+    @username
+  end
+
+  def system_id
+    @id
+  end
+
+  def system_group_id
+    @group_id
+  end
+
+  def system_name
+    @name
+  end
+
+  def system_home_directory
+    @home_directory
+  end
+
+  def system_shell
+    @shell
+  end
+
+  private def self.from_struct(pwd)
     username = String.new(pwd.pw_name)
     # `pw_gecos` is not part of POSIX and bionic for example always leaves it null
     user = pwd.pw_gecos ? String.new(pwd.pw_gecos).partition(',')[0] : username
-    new(username, pwd.pw_uid.to_s, pwd.pw_gid.to_s, user, String.new(pwd.pw_dir), String.new(pwd.pw_shell))
+    ::System::User.new(username, pwd.pw_uid.to_s, pwd.pw_gid.to_s, user, String.new(pwd.pw_dir), String.new(pwd.pw_shell))
   end
 
-  private def from_username?(username : String)
+  def self.from_username?(username : String)
     username.check_no_null_byte
 
     pwd = uninitialized LibC::Passwd
@@ -24,7 +51,7 @@ module Crystal::System::User
     end
   end
 
-  private def from_id?(id : String)
+  def self.from_id?(id : String)
     id = id.to_u32?
     return unless id
 

--- a/src/crystal/system/user.cr
+++ b/src/crystal/system/user.cr
@@ -1,3 +1,21 @@
+module Crystal::System::User
+  # def system_username : String
+
+  # def system_id : String
+
+  # def system_group_id : String
+
+  # def system_name : String
+
+  # def system_home_directory : String
+
+  # def system_shell : String
+
+  # def self.from_username?(username : String) : ::System::User?
+
+  # def self.from_id?(id : String) : ::System::User?
+end
+
 {% if flag?(:wasi) %}
   require "./wasi/user"
 {% elsif flag?(:unix) %}

--- a/src/crystal/system/wasi/user.cr
+++ b/src/crystal/system/wasi/user.cr
@@ -1,9 +1,33 @@
 module Crystal::System::User
-  private def from_username?(username : String)
-    raise NotImplementedError.new("Crystal::System::User#from_username?")
+  def system_username
+    raise NotImplementedError.new("Crystal::System::User#system_username")
   end
 
-  private def from_id?(id : String)
-    raise NotImplementedError.new("Crystal::System::User#from_id?")
+  def system_id
+    raise NotImplementedError.new("Crystal::System::User#system_id")
+  end
+
+  def system_group_id
+    raise NotImplementedError.new("Crystal::System::User#system_group_id")
+  end
+
+  def system_name
+    raise NotImplementedError.new("Crystal::System::User#system_name")
+  end
+
+  def system_home_directory
+    raise NotImplementedError.new("Crystal::System::User#system_home_directory")
+  end
+
+  def system_shell
+    raise NotImplementedError.new("Crystal::System::User#system_shell")
+  end
+
+  def self.from_username?(username : String)
+    raise NotImplementedError.new("Crystal::System::User.from_username?")
+  end
+
+  def self.from_id?(id : String)
+    raise NotImplementedError.new("Crystal::System::User.from_id?")
   end
 end

--- a/src/system/user.cr
+++ b/src/system/user.cr
@@ -17,33 +17,42 @@ class System::User
   class NotFoundError < Exception
   end
 
-  extend Crystal::System::User
+  include Crystal::System::User
 
   # The user's username.
-  getter username : String
+  def username : String
+    system_username
+  end
 
   # The user's identifier.
-  getter id : String
+  def id : String
+    system_id
+  end
 
   # The user's primary group identifier.
-  getter group_id : String
+  def group_id : String
+    system_group_id
+  end
 
   # The user's real or full name.
   #
   # May not be present on all platforms. Returns the same value as `#username`
   # if neither a real nor full name is available.
-  getter name : String
+  def name : String
+    system_name
+  end
 
   # The user's home directory.
-  getter home_directory : String
+  def home_directory : String
+    system_home_directory
+  end
 
   # The user's login shell.
-  getter shell : String
-
-  def_equals_and_hash @id
-
-  private def initialize(@username, @id, @group_id, @name, @home_directory, @shell)
+  def shell : String
+    system_shell
   end
+
+  def_equals_and_hash id
 
   # Returns the user associated with the given username.
   #
@@ -56,7 +65,7 @@ class System::User
   #
   # Returns `nil` if no such user exists.
   def self.find_by?(*, name : String) : System::User?
-    from_username?(name)
+    Crystal::System::User.from_username?(name)
   end
 
   # Returns the user associated with the given ID.
@@ -70,7 +79,7 @@ class System::User
   #
   # Returns `nil` if no such user exists.
   def self.find_by?(*, id : String) : System::User?
-    from_id?(id)
+    Crystal::System::User.from_id?(id)
   end
 
   def to_s(io)


### PR DESCRIPTION
This refactor decouples `System::User`'s instance variables from the platform-specific implementation, since not all of these will be needed on Windows.