### PR TITLE
Remove `XML::Error.errors`

### DIFF
--- a/spec/std/xml/reader_spec.cr
+++ b/spec/std/xml/reader_spec.cr
@@ -577,15 +577,5 @@ module XML
 
       reader.errors.map(&.to_s).should eq ["Opening and ending tag mismatch: people line 1 and foo"]
     end
-
-    it "adds errors to `XML::Error.errors` (deprecated)" do
-      XML::Error.errors # clear class error list
-
-      reader = XML::Reader.new(%(<people></foo>))
-      reader.read
-      reader.expand?
-
-      XML::Error.errors.try(&.map(&.to_s)).should eq ["Opening and ending tag mismatch: people line 1 and foo"]
-    end
   end
 end

--- a/src/xml/error.cr
+++ b/src/xml/error.cr
@@ -11,22 +11,9 @@ class XML::Error < Exception
     super(message)
   end
 
-  @@errors = [] of self
-
-  # :nodoc:
-  protected def self.add_errors(errors)
-    @@errors.concat(errors)
-  end
-
   @[Deprecated("This class accessor is deprecated. XML errors are accessible directly in the respective context via `XML::Reader#errors` and `XML::Node#errors`.")]
   def self.errors : Array(XML::Error)?
-    if @@errors.empty?
-      nil
-    else
-      errors = @@errors.dup
-      @@errors.clear
-      errors
-    end
+    {% raise "`XML::Error.errors` is deprecated and its implementation was removed because it leaks memory when it's not used.\nSee https://github.com/crystal-lang/crystal/issues/14934 for details." %}
   end
 
   def self.collect(errors, &)

--- a/src/xml/error.cr
+++ b/src/xml/error.cr
@@ -13,7 +13,7 @@ class XML::Error < Exception
 
   @[Deprecated("This class accessor is deprecated. XML errors are accessible directly in the respective context via `XML::Reader#errors` and `XML::Node#errors`.")]
   def self.errors : Array(XML::Error)?
-    {% raise "`XML::Error.errors` is deprecated and its implementation was removed because it leaks memory when it's not used.\nSee https://github.com/crystal-lang/crystal/issues/14934 for details." %}
+    {% raise "`XML::Error.errors` was removed because it leaks memory when it's not used. XML errors are accessible directly in the respective context via `XML::Reader#errors` and `XML::Node#errors`.\nSee https://github.com/crystal-lang/crystal/issues/14934 for details. " %}
   end
 
   def self.collect(errors, &)

--- a/src/xml/reader.cr
+++ b/src/xml/reader.cr
@@ -198,9 +198,7 @@ class XML::Reader
   end
 
   private def collect_errors(&)
-    Error.collect(@errors) { yield }.tap do
-      Error.add_errors(@errors)
-    end
+    Error.collect(@errors) { yield }
   end
 
   private def check_no_null_byte(attribute)


### PR DESCRIPTION
Resolves #14934

`XML::Error.errors` collects all error messages from libxml2. Using it is deprecated, but without any calls to it, the error array is never cleared. So we're dropping it because it cannot be fixed. The new error mechanism based on `XML::Reader#errors` is better in every regard.

Closes #14966