### PR TITLE
Relax return type of `String#byte_index` to match `offset`

### DIFF
--- a/spec/std/string_spec.cr
+++ b/spec/std/string_spec.cr
@@ -1303,7 +1303,7 @@ describe "String" do
     end
   end
 
-  describe "byte_index" do
+  describe "#byte_index" do
     it { "foo".byte_index('o'.ord).should eq(1) }
     it { "foo bar booz".byte_index('o'.ord, 3).should eq(9) }
     it { "foo".byte_index('a'.ord).should be_nil }
@@ -1337,6 +1337,11 @@ describe "String" do
       "foo foo".byte_index("oo", 2).should eq(5)
       "こんにちは世界".byte_index("ちは").should eq(9)
     end
+
+    # Check offset type
+    it { "foo".byte_index('o'.ord, 0_i64).should be_a(Int64) }
+    it { "foo".byte_index('o', 0_i64).should be_a(Int64) }
+    it { "foo".byte_index("o", 0_i64).should be_a(Int64) }
   end
 
   describe "includes?" do

--- a/src/string.cr
+++ b/src/string.cr
@@ -3695,7 +3695,7 @@ class String
   # "Dizzy Miss Lizzy".byte_index('z'.ord, -4)  # => 13
   # "Dizzy Miss Lizzy".byte_index('z'.ord, -17) # => nil
   # ```
-  def byte_index(byte : Int, offset = 0) : Int32?
+  def byte_index(byte : Int, offset = 0)
     offset += bytesize if offset < 0
     return if offset < 0
 
@@ -3722,7 +3722,7 @@ class String
   # "Dizzy Miss Lizzy".byte_index('z', -4)  # => 13
   # "Dizzy Miss Lizzy".byte_index('z', -17) # => nil
   # ```
-  def byte_index(char : Char, offset = 0) : Int32?
+  def byte_index(char : Char, offset = 0)
     return byte_index(char.ord, offset) if char.ascii?
 
     offset += bytesize if offset < 0
@@ -3763,7 +3763,7 @@ class String
   # "Dizzy Miss Lizzy".byte_index("izzy", -4) # => 12
   # "Dizzy Miss Lizzy".byte_index("izzy", -3) # => nil
   # ```
-  def byte_index(search : String, offset = 0) : Int32?
+  def byte_index(search : String, offset = 0)
     offset += bytesize if offset < 0
     return if offset < 0
 


### PR DESCRIPTION
Like #10972, but for `String#byte_index`.