### PR TITLE
Support non-blocking `File#read` and `#write` on Windows

### DIFF
--- a/spec/std/file_spec.cr
+++ b/spec/std/file_spec.cr
@@ -122,6 +122,22 @@ describe "File" do
         end
       {% end %}
     {% end %}
+
+    it "reads non-blocking file" do
+      File.open(datapath("test_file.txt"), "r", blocking: false) do |f|
+        f.gets_to_end.should eq("Hello World\n" * 20)
+      end
+    end
+
+    it "writes and reads large non-blocking file" do
+      with_tempfile("non-blocking-io.txt") do |path|
+        File.open(path, "w+", blocking: false) do |f|
+          f.puts "Hello World\n" * 40000
+          f.pos = 0
+          f.gets_to_end.should eq("Hello World\n" * 40000)
+        end
+      end
+    end
   end
 
   it "reads entire file" do

--- a/src/crystal/system/win32/event_loop_iocp.cr
+++ b/src/crystal/system/win32/event_loop_iocp.cr
@@ -144,18 +144,15 @@ class Crystal::IOCP::EventLoop < Crystal::EventLoop
   end
 
   def read(file_descriptor : Crystal::System::FileDescriptor, slice : Bytes) : Int32
-    handle = file_descriptor.windows_handle
-    IOCP.overlapped_operation(file_descriptor, handle, "ReadFile", file_descriptor.read_timeout) do |overlapped|
-      ret = LibC.ReadFile(handle, slice, slice.size, out byte_count, overlapped)
+    IOCP.overlapped_operation(file_descriptor, "ReadFile", file_descriptor.read_timeout) do |overlapped|
+      ret = LibC.ReadFile(file_descriptor.windows_handle, slice, slice.size, out byte_count, overlapped)
       {ret, byte_count}
     end.to_i32
   end
 
   def write(file_descriptor : Crystal::System::FileDescriptor, slice : Bytes) : Int32
-    handle = file_descriptor.windows_handle
-
-    IOCP.overlapped_operation(file_descriptor, handle, "WriteFile", file_descriptor.write_timeout, writing: true) do |overlapped|
-      ret = LibC.WriteFile(handle, slice, slice.size, out byte_count, overlapped)
+    IOCP.overlapped_operation(file_descriptor, "WriteFile", file_descriptor.write_timeout, writing: true) do |overlapped|
+      ret = LibC.WriteFile(file_descriptor.windows_handle, slice, slice.size, out byte_count, overlapped)
       {ret, byte_count}
     end.to_i32
   end

--- a/src/crystal/system/win32/iocp.cr
+++ b/src/crystal/system/win32/iocp.cr
@@ -168,8 +168,16 @@ module Crystal::IOCP
     end
   end
 
-  def self.overlapped_operation(target, handle, method, timeout, *, writing = false, &)
+  def self.overlapped_operation(file_descriptor, method, timeout, *, writing = false, &)
+    handle = file_descriptor.windows_handle
+    seekable = LibC.SetFilePointerEx(handle, 0, out original_offset, IO::Seek::Current) != 0
+
     OverlappedOperation.run(handle) do |operation|
+      overlapped = operation.to_unsafe
+      if seekable
+        overlapped.value.union.offset.offset = LibC::DWORD.new(original_offset)
+        overlapped.value.union.offset.offsetHigh = LibC::DWORD.new(original_offset >> 32)
+      end
       result, value = yield operation
 
       if result == 0
@@ -181,15 +189,19 @@ module Crystal::IOCP
         when .error_io_pending?
           # the operation is running asynchronously; do nothing
         when .error_access_denied?
-          raise IO::Error.new "File not open for #{writing ? "writing" : "reading"}", target: target
+          raise IO::Error.new "File not open for #{writing ? "writing" : "reading"}", target: file_descriptor
         else
-          raise IO::Error.from_os_error(method, error, target: target)
+          raise IO::Error.from_os_error(method, error, target: file_descriptor)
         end
       else
+        # operation completed synchronously; seek forward by number of bytes
+        # read or written if handle is seekable, since overlapped I/O doesn't do
+        # it automatically
+        LibC.SetFilePointerEx(handle, value, nil, IO::Seek::Current) if seekable
         return value
       end
 
-      operation.wait_for_result(timeout) do |error|
+      byte_count = operation.wait_for_result(timeout) do |error|
         case error
         when .error_io_incomplete?, .error_operation_aborted?
           raise IO::TimeoutError.new("#{method} timed out")
@@ -200,6 +212,12 @@ module Crystal::IOCP
           return 0_u32
         end
       end
+
+      # operation completed asynchronously; seek to the original file position
+      # plus the number of bytes read or written (other operations might have
+      # moved the file pointer so we don't use `IO::Seek::Current` here)
+      LibC.SetFilePointerEx(handle, original_offset + byte_count, nil, IO::Seek::Set) if seekable
+      byte_count
     end
   end
 


### PR DESCRIPTION
Extracted from #14321.

The specs use opened files in a more or less synchronous manner, merely ensuring passing `blocking: false` to `File.open` do not break. Additional specs that actually exercise concurrency are welcome.