### PR TITLE
Adds initial support for external commands

### DIFF
--- a/spec/compiler/crystal/commands/external_command_spec.cr
+++ b/spec/compiler/crystal/commands/external_command_spec.cr
@@ -1,7 +1,7 @@
 require "../../../spec_helper"
 
 describe Crystal::Command do
-  it "exec external commands" do
+  it "exec external commands", tags: %w[slow] do
     with_temp_executable "crystal-external" do |path|
       with_tempfile "crystal-external.cr" do |source_file|
         File.write source_file, <<-CRYSTAL

--- a/spec/primitives/external_command_spec.cr
+++ b/spec/primitives/external_command_spec.cr
@@ -1,3 +1,5 @@
+{% skip_file if flag?(:interpreted) %}
+
 require "../spec_helper"
 
 describe Crystal::Command do

--- a/spec/primitives/external_command_spec.cr
+++ b/spec/primitives/external_command_spec.cr
@@ -1,4 +1,4 @@
-require "../../../spec_helper"
+require "../spec_helper"
 
 describe Crystal::Command do
   it "exec external commands", tags: %w[slow] do

--- a/spec/primitives/external_command_spec.cr
+++ b/spec/primitives/external_command_spec.cr
@@ -18,7 +18,7 @@ describe Crystal::Command do
       process = Process.new(ENV["CRYSTAL_SPEC_COMPILER_BIN"]? || "bin/crystal",
         ["external", "foo", "bar"],
         output: :pipe,
-        env: {"PATH" => File.dirname(path)}
+        env: {"PATH" => {ENV["PATH"], File.dirname(path)}.join(Process::PATH_DELIMITER)}
       )
       output = process.output.gets_to_end
       status = process.wait

--- a/src/compiler/crystal/command.cr
+++ b/src/compiler/crystal/command.cr
@@ -130,6 +130,8 @@ class Crystal::Command
     else
       if command.ends_with?(".cr")
         error "file '#{command}' does not exist"
+      elsif external_command = Process.find_executable("crystal-#{command}")
+        Process.exec(external_command, options, env: {"CRYSTAL" => Process.executable_path})
       else
         error "unknown command: #{command}"
       end

--- a/src/compiler/crystal/command.cr
+++ b/src/compiler/crystal/command.cr
@@ -131,6 +131,7 @@ class Crystal::Command
       if command.ends_with?(".cr")
         error "file '#{command}' does not exist"
       elsif external_command = Process.find_executable("crystal-#{command}")
+        options.shift
         Process.exec(external_command, options, env: {"CRYSTAL" => Process.executable_path})
       else
         error "unknown command: #{command}"


### PR DESCRIPTION
Add support for external commands. Inspired by git and cabal.

When running `crystal ext foo bar` if `ext` is not a built-in command, it will look up for `crystal-ext` executable in the `PATH` and run that program. The current compiler location is passed as the `CRYSTAL` env variable, this can be used to run the compiler from the external commands or access additional information present in `crystal env`.

```crystal
# crystal-ext.cr
pp! ENV["CRYSTAL"]?
pp! PROGRAM_NAME
pp! ARGV
```

```
% crystal build crystal-ext.cr
% PATH=".:$PATH" ./bin/crystal ext foo bar 
ENV["CRYSTAL"]? # => "/Users/bcardiff/Projects/crystal/master/.build/crystal"
PROGRAM_NAME # => "./crystal-ext"
ARGV # => ["foo", "bar"]
```

This will help to shrink the compiler, but also open the game for external commands.

---

* ~~What kind of spec should be added on the CI for this change? A manual one? Because calling `Crystal::Command.run` as the rest of the compiler specs will end up calling `exec`.~~

* I'm not sure how/if git and cabal list external commands in the help. I would like to offer some discoverability with some description if possible, but that could be deferred for a later PR probably once we are certain we want this.

