### PR TITLE
Use correct timeout for `Socket#connect` on Windows

### DIFF
--- a/src/crystal/system/win32/event_loop_iocp.cr
+++ b/src/crystal/system/win32/event_loop_iocp.cr
@@ -228,7 +228,7 @@ class Crystal::IOCP::EventLoop < Crystal::EventLoop
   end
 
   def connect(socket : ::Socket, address : ::Socket::Addrinfo | ::Socket::Address, timeout : ::Time::Span?) : IO::Error?
-    socket.overlapped_connect(socket.fd, "ConnectEx") do |overlapped|
+    socket.overlapped_connect(socket.fd, "ConnectEx", timeout) do |overlapped|
       # This is: LibC.ConnectEx(fd, address, address.size, nil, 0, nil, overlapped)
       Crystal::System::Socket.connect_ex.call(socket.fd, address.to_unsafe, address.size, Pointer(Void).null, 0_u32, Pointer(UInt32).null, overlapped.to_unsafe)
     end

--- a/src/crystal/system/win32/socket.cr
+++ b/src/crystal/system/win32/socket.cr
@@ -128,7 +128,7 @@ module Crystal::System::Socket
   end
 
   # :nodoc:
-  def overlapped_connect(socket, method, &)
+  def overlapped_connect(socket, method, timeout, &)
     IOCP::OverlappedOperation.run(socket) do |operation|
       result = yield operation
 
@@ -145,7 +145,7 @@ module Crystal::System::Socket
         return nil
       end
 
-      operation.wait_for_wsa_result(read_timeout) do |error|
+      operation.wait_for_wsa_result(timeout) do |error|
         case error
         when .wsa_io_incomplete?, .wsaeconnrefused?
           return ::Socket::ConnectError.from_os_error(method, error)


### PR DESCRIPTION
It does not appear the use of `read_timeout` here was intended.

This applies to connection-oriented sockets only. Connectionless sockets like `UDPSocket` call `Crystal::System::Socket#system_connect_connectionless` instead which ignores the timeout parameter.