### PR TITLE
Deprecate `::sleep(Number)`

### DIFF
--- a/samples/channel_select.cr
+++ b/samples/channel_select.cr
@@ -2,7 +2,7 @@ def generator(n : T) forall T
   channel = Channel(T).new
   spawn do
     loop do
-      sleep n
+      sleep n.seconds
       channel.send n
     end
   end

--- a/samples/conway.cr
+++ b/samples/conway.cr
@@ -78,7 +78,7 @@ struct ConwayMap
   end
 end
 
-PAUSE_MILLIS  =  20
+PAUSE         = 20.milliseconds
 DEFAULT_COUNT = 300
 INITIAL_MAP   = [
   "                        1           ",
@@ -99,6 +99,6 @@ spawn { gets; exit }
 1.upto(DEFAULT_COUNT) do |i|
   puts map
   puts "n = #{i}\tPress ENTER to exit"
-  sleep PAUSE_MILLIS * 0.001
+  sleep PAUSE
   map.next
 end

--- a/samples/tcp_client.cr
+++ b/samples/tcp_client.cr
@@ -6,5 +6,5 @@ socket = TCPSocket.new "127.0.0.1", 9000
 10.times do |i|
   socket.puts i
   puts "Server response: #{socket.gets}"
-  sleep 0.5
+  sleep 0.5.seconds
 end

--- a/spec/std/benchmark_spec.cr
+++ b/spec/std/benchmark_spec.cr
@@ -13,8 +13,8 @@ describe Benchmark::IPS::Job do
     # test several things to avoid running a benchmark over and over again in
     # the specs
     j = Benchmark::IPS::Job.new(0.001, 0.001, interactive: false)
-    a = j.report("a") { sleep 0.001 }
-    b = j.report("b") { sleep 0.002 }
+    a = j.report("a") { sleep 1.milliseconds }
+    b = j.report("b") { sleep 2.milliseconds }
 
     j.execute
 

--- a/spec/std/channel_spec.cr
+++ b/spec/std/channel_spec.cr
@@ -110,7 +110,7 @@ describe Channel do
 
       it "raises if channel is closed while waiting" do
         ch = Channel(String).new
-        spawn_and_wait(->{ sleep 0.2; ch.close }) do
+        spawn_and_wait(->{ sleep 0.2.seconds; ch.close }) do
           expect_raises Channel::ClosedError do
             Channel.select(ch.receive_select_action)
           end
@@ -129,7 +129,7 @@ describe Channel do
           end
         }
 
-        spawn_and_wait(->{ sleep 0.2; ch.close }) do
+        spawn_and_wait(->{ sleep 0.2.seconds; ch.close }) do
           r = parallel p.call, p.call, p.call, p.call
           r.should eq({1, 1, 1, 1})
         end
@@ -178,7 +178,7 @@ describe Channel do
 
       it "returns nil channel is closed while waiting" do
         ch = Channel(String).new
-        spawn_and_wait(->{ sleep 0.2; ch.close }) do
+        spawn_and_wait(->{ sleep 0.2.seconds; ch.close }) do
           i, m = Channel.select(ch.receive_select_action?)
           m.should be_nil
         end
@@ -191,7 +191,7 @@ describe Channel do
           Channel.select(ch.receive_select_action?)
         }
 
-        spawn_and_wait(->{ sleep 0.2; ch.close }) do
+        spawn_and_wait(->{ sleep 0.2.seconds; ch.close }) do
           r = parallel p.call, p.call, p.call, p.call
           r.should eq({ {0, nil}, {0, nil}, {0, nil}, {0, nil} })
         end
@@ -273,7 +273,7 @@ describe Channel do
 
       it "raises if channel is closed while waiting" do
         ch = Channel(String).new
-        spawn_and_wait(->{ sleep 0.2; ch.close }) do
+        spawn_and_wait(->{ sleep 0.2.seconds; ch.close }) do
           expect_raises Channel::ClosedError do
             Channel.select(ch.send_select_action("foo"))
           end
@@ -292,7 +292,7 @@ describe Channel do
           end
         }
 
-        spawn_and_wait(->{ sleep 0.2; ch.close }) do
+        spawn_and_wait(->{ sleep 0.2.seconds; ch.close }) do
           r = parallel p.call, p.call, p.call, p.call
           r.should eq({1, 1, 1, 1})
         end

--- a/spec/std/http/client/client_spec.cr
+++ b/spec/std/http/client/client_spec.cr
@@ -6,7 +6,7 @@ require "http/server"
 require "http/log"
 require "log/spec"
 
-private def test_server(host, port, read_time = 0, content_type = "text/plain", write_response = true, &)
+private def test_server(host, port, read_time = 0.seconds, content_type = "text/plain", write_response = true, &)
   server = TCPServer.new(host, port)
   begin
     spawn do
@@ -312,12 +312,12 @@ module HTTP
     end
 
     it "doesn't read the body if request was HEAD" do
-      resp_get = test_server("localhost", 0, 0) do |server|
+      resp_get = test_server("localhost", 0, 0.seconds) do |server|
         client = Client.new("localhost", server.local_address.port)
         break client.get("/")
       end
 
-      test_server("localhost", 0, 0) do |server|
+      test_server("localhost", 0, 0.seconds) do |server|
         client = Client.new("localhost", server.local_address.port)
         resp_head = client.head("/")
         resp_head.headers.should eq(resp_get.headers)
@@ -338,7 +338,7 @@ module HTTP
     end
 
     it "tests read_timeout" do
-      test_server("localhost", 0, 0) do |server|
+      test_server("localhost", 0, 0.seconds) do |server|
         client = Client.new("localhost", server.local_address.port)
         client.read_timeout = 1.second
         client.get("/")
@@ -348,7 +348,7 @@ module HTTP
       # it doesn't make sense to try to write because the client will already
       # timeout on read. Writing a response could lead on an exception in
       # the server if the socket is closed.
-      test_server("localhost", 0, 0.5, write_response: false) do |server|
+      test_server("localhost", 0, 0.5.seconds, write_response: false) do |server|
         client = Client.new("localhost", server.local_address.port)
         expect_raises(IO::TimeoutError, {% if flag?(:win32) %} "WSARecv timed out" {% else %} "Read timed out" {% end %}) do
           client.read_timeout = 0.001
@@ -362,7 +362,7 @@ module HTTP
       # it doesn't make sense to try to write because the client will already
       # timeout on read. Writing a response could lead on an exception in
       # the server if the socket is closed.
-      test_server("localhost", 0, 0, write_response: false) do |server|
+      test_server("localhost", 0, 0.seconds, write_response: false) do |server|
         client = Client.new("localhost", server.local_address.port)
         expect_raises(IO::TimeoutError, {% if flag?(:win32) %} "WSASend timed out" {% else %} "Write timed out" {% end %}) do
           client.write_timeout = 0.001
@@ -372,7 +372,7 @@ module HTTP
     end
 
     it "tests connect_timeout" do
-      test_server("localhost", 0, 0) do |server|
+      test_server("localhost", 0, 0.seconds) do |server|
         client = Client.new("localhost", server.local_address.port)
         client.connect_timeout = 0.5
         client.get("/")

--- a/spec/std/http/server/server_spec.cr
+++ b/spec/std/http/server/server_spec.cr
@@ -65,14 +65,14 @@ describe HTTP::Server do
     while !server.listening?
       Fiber.yield
     end
-    sleep 0.1
+    sleep 0.1.seconds
 
     schedule_timeout ch
 
     TCPSocket.open(address.address, address.port) { }
 
     # wait before closing the server
-    sleep 0.1
+    sleep 0.1.seconds
     server.close
 
     ch.receive.should eq SpecChannelStatus::End

--- a/spec/std/http/spec_helper.cr
+++ b/spec/std/http/spec_helper.cr
@@ -49,7 +49,7 @@ def run_server(server, &)
     {% if flag?(:preview_mt) %}
       # avoids fiber synchronization issues in specs, like closing the server
       # before we properly listen, ...
-      sleep 0.001
+      sleep 1.millisecond
     {% end %}
     yield server_done
   ensure

--- a/spec/std/openssl/ssl/server_spec.cr
+++ b/spec/std/openssl/ssl/server_spec.cr
@@ -130,7 +130,7 @@ describe OpenSSL::SSL::Server do
 
     OpenSSL::SSL::Server.open tcp_server, server_context do |server|
       spawn do
-        sleep 1
+        sleep 1.second
         OpenSSL::SSL::Socket::Client.open(TCPSocket.new(tcp_server.local_address.address, tcp_server.local_address.port), client_context, hostname: "example.com") do |socket|
         end
       end

--- a/spec/std/signal_spec.cr
+++ b/spec/std/signal_spec.cr
@@ -27,7 +27,7 @@ pending_interpreted describe: "Signal" do
       Process.signal Signal::USR1, Process.pid
       10.times do |i|
         break if ran
-        sleep 0.1
+        sleep 0.1.seconds
       end
       ran.should be_true
     ensure
@@ -52,7 +52,7 @@ pending_interpreted describe: "Signal" do
       end
 
       Process.signal Signal::USR1, Process.pid
-      sleep 0.1
+      sleep 0.1.seconds
       ran_first.should be_true
       ran_second.should be_true
     ensure

--- a/spec/support/channel.cr
+++ b/spec/support/channel.cr
@@ -10,9 +10,9 @@ def schedule_timeout(c : Channel(SpecChannelStatus))
       # TODO: it's not clear why some interpreter specs
       # take more than 1 second in some cases.
       # See #12429.
-      sleep 5
+      sleep 5.seconds
     {% else %}
-      sleep 1
+      sleep 1.second
     {% end %}
     c.send(SpecChannelStatus::Timeout)
   end

--- a/spec/support/retry.cr
+++ b/spec/support/retry.cr
@@ -7,7 +7,7 @@ def retry(n = 5, &)
     if i == 0
       Fiber.yield
     else
-      sleep 0.01 * (2**i)
+      sleep 10.milliseconds * (2**i)
     end
   else
     return

--- a/src/benchmark.cr
+++ b/src/benchmark.cr
@@ -11,8 +11,8 @@ require "./benchmark/**"
 # require "benchmark"
 #
 # Benchmark.ips do |x|
-#   x.report("short sleep") { sleep 0.01 }
-#   x.report("shorter sleep") { sleep 0.001 }
+#   x.report("short sleep") { sleep 10.milliseconds }
+#   x.report("shorter sleep") { sleep 1.millisecond }
 # end
 # ```
 #
@@ -31,7 +31,7 @@ require "./benchmark/**"
 # require "benchmark"
 #
 # Benchmark.ips(warmup: 4, calculation: 10) do |x|
-#   x.report("sleep") { sleep 0.01 }
+#   x.report("sleep") { sleep 10.milliseconds }
 # end
 # ```
 #

--- a/src/concurrent.cr
+++ b/src/concurrent.cr
@@ -7,6 +7,7 @@ require "crystal/tracing"
 #
 # While this fiber is waiting this time, other ready-to-execute
 # fibers might start their execution.
+@[Deprecated("Use `::sleep(Time::Span)` instead")]
 def sleep(seconds : Number) : Nil
   if seconds < 0
     raise ArgumentError.new "Sleep seconds must be positive"
@@ -42,7 +43,7 @@ end
 #
 # spawn do
 #   6.times do
-#     sleep 1
+#     sleep 1.second
 #     puts 1
 #   end
 #   ch.send(nil)
@@ -50,7 +51,7 @@ end
 #
 # spawn do
 #   3.times do
-#     sleep 2
+#     sleep 2.seconds
 #     puts 2
 #   end
 #   ch.send(nil)

--- a/src/crystal/system/unix/file_descriptor.cr
+++ b/src/crystal/system/unix/file_descriptor.cr
@@ -158,7 +158,7 @@ module Crystal::System::FileDescriptor
 
     if retry
       until flock(op)
-        sleep 0.1
+        sleep 0.1.seconds
       end
     else
       flock(op) || raise IO::Error.from_errno("Error applying file lock: file is already locked", target: self)

--- a/src/crystal/system/win32/file_descriptor.cr
+++ b/src/crystal/system/win32/file_descriptor.cr
@@ -217,7 +217,7 @@ module Crystal::System::FileDescriptor
     handle = windows_handle
     if retry
       until lock_file(handle, flags)
-        sleep 0.1
+        sleep 0.1.seconds
       end
     else
       lock_file(handle, flags) || raise IO::Error.from_winerror("Error applying file lock: file is already locked")

--- a/src/signal.cr
+++ b/src/signal.cr
@@ -8,17 +8,17 @@ require "crystal/system/signal"
 #
 # ```
 # puts "Ctrl+C still has the OS default action (stops the program)"
-# sleep 3
+# sleep 3.seconds
 #
 # Signal::INT.trap do
 #   puts "Gotcha!"
 # end
 # puts "Ctrl+C will be caught from now on"
-# sleep 3
+# sleep 3.seconds
 #
 # Signal::INT.reset
 # puts "Ctrl+C is back to the OS default action"
-# sleep 3
+# sleep 3.seconds
 # ```
 #
 # WARNING: An uncaught exception in a signal handler is a fatal error.


### PR DESCRIPTION
This is in line with other places in the standard library that favor `Time::Span` over number types, such as #14368 and #14805.