### PR TITLE
Enable the interpreter on Windows

### DIFF
--- a/.github/workflows/win.yml
+++ b/.github/workflows/win.yml
@@ -296,6 +296,7 @@ jobs:
         run: |
           Add-Content $env:GITHUB_PATH "$(pwd)\build"
           Add-Content $env:GITHUB_ENV "CRYSTAL_SPEC_COMPILER_BIN=$(pwd)\build\crystal.exe"
+          Add-Content $env:GITHUB_ENV "CRYSTAL_INTERPRETER_LOADER_INFO=1"
 
       - name: Run stdlib specs with interpreter
         run: bin\crystal i spec\std_spec.cr

--- a/.github/workflows/win.yml
+++ b/.github/workflows/win.yml
@@ -265,9 +265,17 @@ jobs:
       - name: Build samples
         run: make -f Makefile.win samples
 
+  x86_64-windows-release:
+    if: github.repository_owner == 'crystal-lang' && (startsWith(github.ref, 'refs/tags/') || startsWith(github.ref, 'refs/heads/ci/'))
+    needs: [x86_64-windows-libs, x86_64-windows-dlls, x86_64-windows-llvm-libs, x86_64-windows-llvm-dlls]
+    uses: ./.github/workflows/win_build_portable.yml
+    with:
+      release: true
+      llvm_version: "18.1.1"
+
   x86_64-windows-test-interpreter:
     runs-on: windows-2022
-    needs: [x86_64-windows]
+    needs: [x86_64-windows-release]
     steps:
       - name: Disable CRLF line ending substitution
         run: |
@@ -279,7 +287,7 @@ jobs:
       - name: Download Crystal executable
         uses: actions/download-artifact@v4
         with:
-          name: crystal
+          name: crystal-release
           path: build
 
       - name: Restore LLVM
@@ -299,14 +307,6 @@ jobs:
 
       - name: Run primitives specs with interpreter
         run: bin\crystal i spec\primitives_spec.cr
-
-  x86_64-windows-release:
-    if: github.repository_owner == 'crystal-lang' && (startsWith(github.ref, 'refs/tags/') || startsWith(github.ref, 'refs/heads/ci/'))
-    needs: [x86_64-windows-libs, x86_64-windows-dlls, x86_64-windows-llvm-libs, x86_64-windows-llvm-dlls]
-    uses: ./.github/workflows/win_build_portable.yml
-    with:
-      release: true
-      llvm_version: "18.1.1"
 
   x86_64-windows-installer:
     if: github.repository_owner == 'crystal-lang' && (startsWith(github.ref, 'refs/tags/') || startsWith(github.ref, 'refs/heads/ci/'))

--- a/.github/workflows/win.yml
+++ b/.github/workflows/win.yml
@@ -7,6 +7,7 @@ concurrency:
   cancel-in-progress: ${{ github.ref != 'refs/heads/master' }}
 
 env:
+  SPEC_SPLIT_DOTS: 160
   CI_LLVM_VERSION: "18.1.1"
 
 jobs:
@@ -265,16 +266,20 @@ jobs:
       - name: Build samples
         run: make -f Makefile.win samples
 
+  x86_64-windows-release:
+    needs: [x86_64-windows-libs, x86_64-windows-dlls, x86_64-windows-llvm-libs, x86_64-windows-llvm-dlls]
+    uses: ./.github/workflows/win_build_portable.yml
+    with:
+      release: true
+      llvm_version: "18.1.1"
+
   x86_64-windows-test-interpreter:
     runs-on: windows-2022
-    needs: [x86_64-windows]
+    needs: [x86_64-windows-release]
     steps:
       - name: Disable CRLF line ending substitution
         run: |
           git config --global core.autocrlf false
-
-      - name: Enable Developer Command Prompt
-        uses: ilammy/msvc-dev-cmd@0b201ec74fa43914dc39ae48a89fd1d8cb592756 # v1.13.0
 
       - name: Download Crystal source
         uses: actions/checkout@v4
@@ -282,7 +287,7 @@ jobs:
       - name: Download Crystal executable
         uses: actions/download-artifact@v4
         with:
-          name: crystal
+          name: crystal-release
           path: build
 
       - name: Restore LLVM
@@ -296,21 +301,12 @@ jobs:
         run: |
           Add-Content $env:GITHUB_PATH "$(pwd)\build"
           Add-Content $env:GITHUB_ENV "CRYSTAL_SPEC_COMPILER_BIN=$(pwd)\build\crystal.exe"
-          Add-Content $env:GITHUB_ENV "CRYSTAL_INTERPRETER_LOADER_INFO=1"
 
       - name: Run stdlib specs with interpreter
         run: bin\crystal i spec\std_spec.cr
 
       - name: Run primitives specs with interpreter
         run: bin\crystal i spec\primitives_spec.cr
-
-  x86_64-windows-release:
-    if: github.repository_owner == 'crystal-lang' && (startsWith(github.ref, 'refs/tags/') || startsWith(github.ref, 'refs/heads/ci/'))
-    needs: [x86_64-windows-libs, x86_64-windows-dlls, x86_64-windows-llvm-libs, x86_64-windows-llvm-dlls]
-    uses: ./.github/workflows/win_build_portable.yml
-    with:
-      release: true
-      llvm_version: "18.1.1"
 
   x86_64-windows-installer:
     if: github.repository_owner == 'crystal-lang' && (startsWith(github.ref, 'refs/tags/') || startsWith(github.ref, 'refs/heads/ci/'))

--- a/.github/workflows/win.yml
+++ b/.github/workflows/win.yml
@@ -273,6 +273,9 @@ jobs:
         run: |
           git config --global core.autocrlf false
 
+      - name: Enable Developer Command Prompt
+        uses: ilammy/msvc-dev-cmd@0b201ec74fa43914dc39ae48a89fd1d8cb592756 # v1.13.0
+
       - name: Download Crystal source
         uses: actions/checkout@v4
 

--- a/.github/workflows/win.yml
+++ b/.github/workflows/win.yml
@@ -265,6 +265,41 @@ jobs:
       - name: Build samples
         run: make -f Makefile.win samples
 
+  x86_64-windows-test-interpreter:
+    runs-on: windows-2022
+    needs: [x86_64-windows]
+    steps:
+      - name: Disable CRLF line ending substitution
+        run: |
+          git config --global core.autocrlf false
+
+      - name: Download Crystal source
+        uses: actions/checkout@v4
+
+      - name: Download Crystal executable
+        uses: actions/download-artifact@v4
+        with:
+          name: crystal
+          path: build
+
+      - name: Restore LLVM
+        uses: actions/cache/restore@v4
+        with:
+          path: llvm
+          key: llvm-libs-${{ env.CI_LLVM_VERSION }}-msvc
+          fail-on-cache-miss: true
+
+      - name: Set up environment
+        run: |
+          Add-Content $env:GITHUB_PATH "$(pwd)\build"
+          Add-Content $env:GITHUB_ENV "CRYSTAL_SPEC_COMPILER_BIN=$(pwd)\build\crystal.exe"
+
+      - name: Run stdlib specs with interpreter
+        run: bin\crystal i spec\std_spec.cr
+
+      - name: Run primitives specs with interpreter
+        run: bin\crystal i spec\primitives_spec.cr
+
   x86_64-windows-release:
     if: github.repository_owner == 'crystal-lang' && (startsWith(github.ref, 'refs/tags/') || startsWith(github.ref, 'refs/heads/ci/'))
     needs: [x86_64-windows-libs, x86_64-windows-dlls, x86_64-windows-llvm-libs, x86_64-windows-llvm-dlls]

--- a/.github/workflows/win.yml
+++ b/.github/workflows/win.yml
@@ -265,17 +265,9 @@ jobs:
       - name: Build samples
         run: make -f Makefile.win samples
 
-  x86_64-windows-release:
-    if: github.repository_owner == 'crystal-lang' && (startsWith(github.ref, 'refs/tags/') || startsWith(github.ref, 'refs/heads/ci/'))
-    needs: [x86_64-windows-libs, x86_64-windows-dlls, x86_64-windows-llvm-libs, x86_64-windows-llvm-dlls]
-    uses: ./.github/workflows/win_build_portable.yml
-    with:
-      release: true
-      llvm_version: "18.1.1"
-
   x86_64-windows-test-interpreter:
     runs-on: windows-2022
-    needs: [x86_64-windows-release]
+    needs: [x86_64-windows]
     steps:
       - name: Disable CRLF line ending substitution
         run: |
@@ -287,7 +279,7 @@ jobs:
       - name: Download Crystal executable
         uses: actions/download-artifact@v4
         with:
-          name: crystal-release
+          name: crystal
           path: build
 
       - name: Restore LLVM
@@ -307,6 +299,14 @@ jobs:
 
       - name: Run primitives specs with interpreter
         run: bin\crystal i spec\primitives_spec.cr
+
+  x86_64-windows-release:
+    if: github.repository_owner == 'crystal-lang' && (startsWith(github.ref, 'refs/tags/') || startsWith(github.ref, 'refs/heads/ci/'))
+    needs: [x86_64-windows-libs, x86_64-windows-dlls, x86_64-windows-llvm-libs, x86_64-windows-llvm-dlls]
+    uses: ./.github/workflows/win_build_portable.yml
+    with:
+      release: true
+      llvm_version: "18.1.1"
 
   x86_64-windows-installer:
     if: github.repository_owner == 'crystal-lang' && (startsWith(github.ref, 'refs/tags/') || startsWith(github.ref, 'refs/heads/ci/'))

--- a/.github/workflows/win_build_portable.yml
+++ b/.github/workflows/win_build_portable.yml
@@ -114,7 +114,7 @@ jobs:
       - name: Build Crystal
         run: |
           bin/crystal.bat env
-          make -f Makefile.win -B ${{ inputs.release && 'release=1' || '' }}
+          make -f Makefile.win -B ${{ inputs.release && 'release=1' || '' }} interpreter=1
 
       - name: Download shards release
         uses: actions/checkout@v4

--- a/spec/std/http/client/client_spec.cr
+++ b/spec/std/http/client/client_spec.cr
@@ -6,6 +6,12 @@ require "http/server"
 require "http/log"
 require "log/spec"
 
+# TODO: Windows networking in the interpreter requires #12495
+{% if flag?(:interpreted) && flag?(:win32) %}
+  pending HTTP::Client
+  {% skip_file %}
+{% end %}
+
 private def test_server(host, port, read_time = 0, content_type = "text/plain", write_response = true, &)
   server = TCPServer.new(host, port)
   begin

--- a/spec/std/http/server/server_spec.cr
+++ b/spec/std/http/server/server_spec.cr
@@ -4,6 +4,12 @@ require "http/client"
 require "../../../support/ssl"
 require "../../../support/channel"
 
+# TODO: Windows networking in the interpreter requires #12495
+{% if flag?(:interpreted) && flag?(:win32) %}
+  pending HTTP::Server
+  {% skip_file %}
+{% end %}
+
 # TODO: replace with `HTTP::Client.get` once it supports connecting to Unix socket (#2735)
 private def unix_request(path)
   UNIXSocket.open(path) do |io|

--- a/spec/std/http/web_socket_spec.cr
+++ b/spec/std/http/web_socket_spec.cr
@@ -7,6 +7,12 @@ require "../../support/fibers"
 require "../../support/ssl"
 require "../socket/spec_helper.cr"
 
+# TODO: Windows networking in the interpreter requires #12495
+{% if flag?(:interpreted) && flag?(:win32) %}
+  pending HTTP::WebSocket
+  {% skip_file %}
+{% end %}
+
 private def assert_text_packet(packet, size, final = false)
   assert_packet packet, HTTP::WebSocket::Protocol::Opcode::TEXT, size, final: final
 end

--- a/spec/std/io/io_spec.cr
+++ b/spec/std/io/io_spec.cr
@@ -816,23 +816,26 @@ describe IO do
           io.gets_to_end.should eq("\r\nFoo\nBar")
         end
 
-        it "gets ascii from socket (#9056)" do
-          server = TCPServer.new "localhost", 0
-          sock = TCPSocket.new "localhost", server.local_address.port
-          begin
-            sock.set_encoding("ascii")
-            spawn do
-              client = server.accept
-              message = client.gets
-              client << "#{message}\n"
+        # TODO: Windows networking in the interpreter requires #12495
+        {% unless flag?(:interpreted) || flag?(:win32) %}
+          it "gets ascii from socket (#9056)" do
+            server = TCPServer.new "localhost", 0
+            sock = TCPSocket.new "localhost", server.local_address.port
+            begin
+              sock.set_encoding("ascii")
+              spawn do
+                client = server.accept
+                message = client.gets
+                client << "#{message}\n"
+              end
+              sock << "K\n"
+              sock.gets.should eq("K")
+            ensure
+              server.close
+              sock.close
             end
-            sock << "K\n"
-            sock.gets.should eq("K")
-          ensure
-            server.close
-            sock.close
           end
-        end
+        {% end %}
       end
 
       describe "encode" do

--- a/spec/std/oauth2/client_spec.cr
+++ b/spec/std/oauth2/client_spec.cr
@@ -3,6 +3,12 @@ require "oauth2"
 require "http/server"
 require "../http/spec_helper"
 
+# TODO: Windows networking in the interpreter requires #12495
+{% if flag?(:interpreted) && flag?(:win32) %}
+  pending OAuth2::Client
+  {% skip_file %}
+{% end %}
+
 describe OAuth2::Client do
   describe "authorization uri" do
     it "gets with default endpoint" do

--- a/spec/std/openssl/ssl/server_spec.cr
+++ b/spec/std/openssl/ssl/server_spec.cr
@@ -3,6 +3,12 @@ require "socket"
 require "../../spec_helper"
 require "../../../support/ssl"
 
+# TODO: Windows networking in the interpreter requires #12495
+{% if flag?(:interpreted) && flag?(:win32) %}
+  pending OpenSSL::SSL::Server
+  {% skip_file %}
+{% end %}
+
 describe OpenSSL::SSL::Server do
   it "sync_close" do
     TCPServer.open(0) do |tcp_server|

--- a/spec/std/openssl/ssl/socket_spec.cr
+++ b/spec/std/openssl/ssl/socket_spec.cr
@@ -4,6 +4,12 @@ require "../../spec_helper"
 require "../../socket/spec_helper"
 require "../../../support/ssl"
 
+# TODO: Windows networking in the interpreter requires #12495
+{% if flag?(:interpreted) && flag?(:win32) %}
+  pending OpenSSL::SSL::Socket
+  {% skip_file %}
+{% end %}
+
 describe OpenSSL::SSL::Socket do
   describe OpenSSL::SSL::Socket::Server do
     it "auto accept client by default" do

--- a/spec/std/process_spec.cr
+++ b/spec/std/process_spec.cr
@@ -55,7 +55,12 @@ private def newline
 end
 
 # interpreted code doesn't receive SIGCHLD for `#wait` to work (#12241)
-pending_interpreted describe: Process do
+{% if flag?(:interpreted) && !flag?(:win32) %}
+  pending Process
+  {% skip_file %}
+{% end %}
+
+describe Process do
   describe ".new" do
     it "raises if command doesn't exist" do
       expect_raises(File::NotFoundError, "Error executing process: 'foobarbaz'") do

--- a/spec/std/socket/socket_spec.cr
+++ b/spec/std/socket/socket_spec.cr
@@ -2,6 +2,12 @@ require "./spec_helper"
 require "../../support/tempfile"
 require "../../support/win32"
 
+# TODO: Windows networking in the interpreter requires #12495
+{% if flag?(:interpreted) && flag?(:win32) %}
+  pending Socket
+  {% skip_file %}
+{% end %}
+
 describe Socket, tags: "network" do
   describe ".unix" do
     it "creates a unix socket" do

--- a/spec/std/socket/tcp_socket_spec.cr
+++ b/spec/std/socket/tcp_socket_spec.cr
@@ -3,6 +3,12 @@
 require "./spec_helper"
 require "../../support/win32"
 
+# TODO: Windows networking in the interpreter requires #12495
+{% if flag?(:interpreted) && flag?(:win32) %}
+  pending TCPSocket
+  {% skip_file %}
+{% end %}
+
 describe TCPSocket, tags: "network" do
   describe "#connect" do
     each_ip_family do |family, address|

--- a/spec/std/socket/unix_server_spec.cr
+++ b/spec/std/socket/unix_server_spec.cr
@@ -4,6 +4,12 @@ require "../../support/fibers"
 require "../../support/channel"
 require "../../support/tempfile"
 
+# TODO: Windows networking in the interpreter requires #12495
+{% if flag?(:interpreted) && flag?(:win32) %}
+  pending UNIXServer
+  {% skip_file %}
+{% end %}
+
 describe UNIXServer do
   describe ".new" do
     it "raises when path is too long" do

--- a/spec/std/socket/unix_socket_spec.cr
+++ b/spec/std/socket/unix_socket_spec.cr
@@ -2,6 +2,12 @@ require "spec"
 require "socket"
 require "../../support/tempfile"
 
+# TODO: Windows networking in the interpreter requires #12495
+{% if flag?(:interpreted) && flag?(:win32) %}
+  pending UNIXSocket
+  {% skip_file %}
+{% end %}
+
 describe UNIXSocket do
   it "raises when path is too long" do
     with_tempfile("unix_socket-too_long-#{("a" * 2048)}.sock") do |path|

--- a/spec/std/uuid_spec.cr
+++ b/spec/std/uuid_spec.cr
@@ -1,6 +1,7 @@
 require "spec"
 require "uuid"
 require "spec/helpers/string"
+require "../support/wasm32"
 
 describe "UUID" do
   describe "#==" do

--- a/src/crystal/system/win32/iocp.cr
+++ b/src/crystal/system/win32/iocp.cr
@@ -96,14 +96,9 @@ module Crystal::IOCP
     end
 
     def self.run(handle, &)
-      # TODO: implement `pre_initialize` in the interpreter
-      {% if flag?(:interpreted) %}
-        yield OverlappedOperation.new(handle)
-      {% else %}
-        operation_storage = uninitialized ReferenceStorage(OverlappedOperation)
-        operation = OverlappedOperation.unsafe_construct(pointerof(operation_storage), handle)
-        yield operation
-      {% end %}
+      operation_storage = uninitialized ReferenceStorage(OverlappedOperation)
+      operation = OverlappedOperation.unsafe_construct(pointerof(operation_storage), handle)
+      yield operation
     end
 
     def self.unbox(overlapped : LibC::OVERLAPPED*)

--- a/src/crystal/system/win32/iocp.cr
+++ b/src/crystal/system/win32/iocp.cr
@@ -79,9 +79,14 @@ module Crystal::IOCP
     end
 
     def self.run(handle, &)
-      operation_storage = uninitialized ReferenceStorage(OverlappedOperation)
-      operation = OverlappedOperation.unsafe_construct(pointerof(operation_storage), handle)
-      yield operation
+      # TODO: implement `pre_initialize` in the interpreter
+      {% if flag?(:interpreted) %}
+        yield OverlappedOperation.new(handle)
+      {% else %}
+        operation_storage = uninitialized ReferenceStorage(OverlappedOperation)
+        operation = OverlappedOperation.unsafe_construct(pointerof(operation_storage), handle)
+        yield operation
+      {% end %}
     end
 
     def self.unbox(overlapped : LibC::OVERLAPPED*)

--- a/src/kernel.cr
+++ b/src/kernel.cr
@@ -616,3 +616,16 @@ end
     Crystal::System::Signal.setup_default_handlers
   {% end %}
 {% end %}
+
+# This is a temporary workaround to ensure there is always something in the IOCP
+# event loop being awaited, since both the interrupt loop and the fiber stack
+# pool collector are disabled in interpreted code. Without this, asynchronous
+# code that bypasses `Crystal::IOCP::OverlappedOperation` does not currently
+# work, see https://github.com/crystal-lang/crystal/pull/14949#issuecomment-2328314463
+{% if flag?(:interpreted) && flag?(:win32) %}
+  spawn(name: "Interpreter idle loop") do
+    while true
+      sleep 1.day
+    end
+  end
+{% end %}


### PR DESCRIPTION
Closes #12396.

A good chunk of networking specs are disabled because they call `Crystal::System::Socket.accept_ex.call`, which is not yet supported in the interpreter; this is now tracked in #12495. There is also a workaround for the event loop issue mentioned in https://github.com/crystal-lang/crystal/pull/14949#issuecomment-2328314463, ~~and another for the lack of `Reference.pre_initialize` support (this won't be necessary after #14968)~~.

On the other hand, `Process` indeed works, so interpreter support on Windows is not strictly inferior to Unix-like systems.