### PR TITLE
Fix use global paths in macro bodies

### DIFF
--- a/src/crystal/pointer_linked_list.cr
+++ b/src/crystal/pointer_linked_list.cr
@@ -7,8 +7,8 @@ struct Crystal::PointerLinkedList(T)
 
   module Node
     macro included
-      property previous : Pointer(self) = Pointer(self).null
-      property next : Pointer(self) = Pointer(self).null
+      property previous : ::Pointer(self) = ::Pointer(self).null
+      property next : ::Pointer(self) = ::Pointer(self).null
     end
   end
 

--- a/src/ecr/macros.cr
+++ b/src/ecr/macros.cr
@@ -34,7 +34,7 @@ module ECR
   # ```
   macro def_to_s(filename)
     def to_s(__io__ : IO) : Nil
-      ECR.embed {{filename}}, "__io__"
+      ::ECR.embed {{filename}}, "__io__"
     end
   end
 

--- a/src/intrinsics.cr
+++ b/src/intrinsics.cr
@@ -179,7 +179,7 @@ end
 
 module Intrinsics
   macro debugtrap
-    LibIntrinsics.debugtrap
+    ::LibIntrinsics.debugtrap
   end
 
   def self.pause
@@ -191,15 +191,15 @@ module Intrinsics
   end
 
   macro memcpy(dest, src, len, is_volatile)
-    LibIntrinsics.memcpy({{dest}}, {{src}}, {{len}}, {{is_volatile}})
+    ::LibIntrinsics.memcpy({{dest}}, {{src}}, {{len}}, {{is_volatile}})
   end
 
   macro memmove(dest, src, len, is_volatile)
-    LibIntrinsics.memmove({{dest}}, {{src}}, {{len}}, {{is_volatile}})
+    ::LibIntrinsics.memmove({{dest}}, {{src}}, {{len}}, {{is_volatile}})
   end
 
   macro memset(dest, val, len, is_volatile)
-    LibIntrinsics.memset({{dest}}, {{val}}, {{len}}, {{is_volatile}})
+    ::LibIntrinsics.memset({{dest}}, {{val}}, {{len}}, {{is_volatile}})
   end
 
   def self.read_cycle_counter
@@ -263,43 +263,43 @@ module Intrinsics
   end
 
   macro countleading8(src, zero_is_undef)
-    LibIntrinsics.countleading8({{src}}, {{zero_is_undef}})
+    ::LibIntrinsics.countleading8({{src}}, {{zero_is_undef}})
   end
 
   macro countleading16(src, zero_is_undef)
-    LibIntrinsics.countleading16({{src}}, {{zero_is_undef}})
+    ::LibIntrinsics.countleading16({{src}}, {{zero_is_undef}})
   end
 
   macro countleading32(src, zero_is_undef)
-    LibIntrinsics.countleading32({{src}}, {{zero_is_undef}})
+    ::LibIntrinsics.countleading32({{src}}, {{zero_is_undef}})
   end
 
   macro countleading64(src, zero_is_undef)
-    LibIntrinsics.countleading64({{src}}, {{zero_is_undef}})
+    ::LibIntrinsics.countleading64({{src}}, {{zero_is_undef}})
   end
 
   macro countleading128(src, zero_is_undef)
-    LibIntrinsics.countleading128({{src}}, {{zero_is_undef}})
+    ::LibIntrinsics.countleading128({{src}}, {{zero_is_undef}})
   end
 
   macro counttrailing8(src, zero_is_undef)
-    LibIntrinsics.counttrailing8({{src}}, {{zero_is_undef}})
+    ::LibIntrinsics.counttrailing8({{src}}, {{zero_is_undef}})
   end
 
   macro counttrailing16(src, zero_is_undef)
-    LibIntrinsics.counttrailing16({{src}}, {{zero_is_undef}})
+    ::LibIntrinsics.counttrailing16({{src}}, {{zero_is_undef}})
   end
 
   macro counttrailing32(src, zero_is_undef)
-    LibIntrinsics.counttrailing32({{src}}, {{zero_is_undef}})
+    ::LibIntrinsics.counttrailing32({{src}}, {{zero_is_undef}})
   end
 
   macro counttrailing64(src, zero_is_undef)
-    LibIntrinsics.counttrailing64({{src}}, {{zero_is_undef}})
+    ::LibIntrinsics.counttrailing64({{src}}, {{zero_is_undef}})
   end
 
   macro counttrailing128(src, zero_is_undef)
-    LibIntrinsics.counttrailing128({{src}}, {{zero_is_undef}})
+    ::LibIntrinsics.counttrailing128({{src}}, {{zero_is_undef}})
   end
 
   def self.fshl8(a, b, count) : UInt8
@@ -343,14 +343,14 @@ module Intrinsics
   end
 
   macro va_start(ap)
-    LibIntrinsics.va_start({{ap}})
+    ::LibIntrinsics.va_start({{ap}})
   end
 
   macro va_end(ap)
-    LibIntrinsics.va_end({{ap}})
+    ::LibIntrinsics.va_end({{ap}})
   end
 end
 
 macro debugger
-  Intrinsics.debugtrap
+  ::Intrinsics.debugtrap
 end

--- a/src/json/serialization.cr
+++ b/src/json/serialization.cr
@@ -164,7 +164,7 @@ module JSON
       private def self.new_from_json_pull_parser(pull : ::JSON::PullParser)
         instance = allocate
         instance.initialize(__pull_for_json_serializable: pull)
-        GC.add_finalizer(instance) if instance.responds_to?(:finalize)
+        ::GC.add_finalizer(instance) if instance.responds_to?(:finalize)
         instance
       end
 
@@ -422,8 +422,8 @@ module JSON
         # Try to find the discriminator while also getting the raw
         # string value of the parsed JSON, so then we can pass it
         # to the final type.
-        json = String.build do |io|
-          JSON.build(io) do |builder|
+        json = ::String.build do |io|
+          ::JSON.build(io) do |builder|
             builder.start_object
             pull.read_object do |key|
               if key == {{field.id.stringify}}

--- a/src/number.cr
+++ b/src/number.cr
@@ -59,7 +59,7 @@ struct Number
   # :nodoc:
   macro expand_div(rhs_types, result_type)
     {% for rhs in rhs_types %}
-      @[AlwaysInline]
+      @[::AlwaysInline]
       def /(other : {{rhs}}) : {{result_type}}
         {{result_type}}.new(self) / {{result_type}}.new(other)
       end
@@ -84,7 +84,7 @@ struct Number
   # [1, 2, 3, 4] of Int64 # : Array(Int64)
   # ```
   macro [](*nums)
-    Array({{@type}}).build({{nums.size}}) do |%buffer|
+    ::Array({{@type}}).build({{nums.size}}) do |%buffer|
       {% for num, i in nums %}
         %buffer[{{i}}] = {{@type}}.new({{num}})
       {% end %}
@@ -113,7 +113,7 @@ struct Number
   # Slice[1_i64, 2_i64, 3_i64, 4_i64] # : Slice(Int64)
   # ```
   macro slice(*nums, read_only = false)
-    %slice = Slice({{@type}}).new({{nums.size}}, read_only: {{read_only}})
+    %slice = ::Slice({{@type}}).new({{nums.size}}, read_only: {{read_only}})
     {% for num, i in nums %}
       %slice.to_unsafe[{{i}}] = {{@type}}.new!({{num}})
     {% end %}
@@ -139,7 +139,7 @@ struct Number
   # StaticArray[1_i64, 2_i64, 3_i64, 4_i64] # : StaticArray(Int64)
   # ```
   macro static_array(*nums)
-    %array = uninitialized StaticArray({{@type}}, {{nums.size}})
+    %array = uninitialized ::StaticArray({{@type}}, {{nums.size}})
     {% for num, i in nums %}
       %array.to_unsafe[{{i}}] = {{@type}}.new!({{num}})
     {% end %}

--- a/src/object.cr
+++ b/src/object.cr
@@ -562,7 +562,7 @@ class Object
 
           def {{method_prefix}}\{{name.var.id}} : \{{name.type}}
             if (value = {{var_prefix}}\{{name.var.id}}).nil?
-              ::raise NilAssertionError.new("\{{@type}}\{{"{{doc_prefix}}".id}}\{{name.var.id}} cannot be nil")
+              ::raise ::NilAssertionError.new("\{{@type}}\{{"{{doc_prefix}}".id}}\{{name.var.id}} cannot be nil")
             else
               value
             end
@@ -574,7 +574,7 @@ class Object
 
           def {{method_prefix}}\{{name.id}}
             if (value = {{var_prefix}}\{{name.id}}).nil?
-              ::raise NilAssertionError.new("\{{@type}}\{{"{{doc_prefix}}".id}}\{{name.id}} cannot be nil")
+              ::raise ::NilAssertionError.new("\{{@type}}\{{"{{doc_prefix}}".id}}\{{name.id}} cannot be nil")
             else
               value
             end
@@ -1293,7 +1293,7 @@ class Object
   # wrapper.capitalize     # => "Hello"
   # ```
   macro delegate(*methods, to object)
-    {% if compare_versions(Crystal::VERSION, "1.12.0-dev") >= 0 %}
+    {% if compare_versions(::Crystal::VERSION, "1.12.0-dev") >= 0 %}
       {% eq_operators = %w(<= >= == != []= ===) %}
       {% for method in methods %}
         {% if method.id.ends_with?('=') && !eq_operators.includes?(method.id.stringify) %}
@@ -1427,18 +1427,18 @@ class Object
   macro def_clone
     # Returns a copy of `self` with all instance variables cloned.
     def clone
-      \{% if @type < Reference && !@type.instance_vars.map(&.type).all? { |t| t == ::Bool || t == ::Char || t == ::Symbol || t == ::String || t < ::Number::Primitive } %}
+      \{% if @type < ::Reference && !@type.instance_vars.map(&.type).all? { |t| t == ::Bool || t == ::Char || t == ::Symbol || t == ::String || t < ::Number::Primitive } %}
         exec_recursive_clone do |hash|
           clone = \{{@type}}.allocate
           hash[object_id] = clone.object_id
           clone.initialize_copy(self)
-          GC.add_finalizer(clone) if clone.responds_to?(:finalize)
+          ::GC.add_finalizer(clone) if clone.responds_to?(:finalize)
           clone
         end
       \{% else %}
         clone = \{{@type}}.allocate
         clone.initialize_copy(self)
-        GC.add_finalizer(clone) if clone.responds_to?(:finalize)
+        ::GC.add_finalizer(clone) if clone.responds_to?(:finalize)
         clone
       \{% end %}
     end

--- a/src/slice.cr
+++ b/src/slice.cr
@@ -34,14 +34,14 @@ struct Slice(T)
   macro [](*args, read_only = false)
     # TODO: there should be a better way to check this, probably
     # asking if @type was instantiated or if T is defined
-    {% if @type.name != "Slice(T)" && T < Number %}
+    {% if @type.name != "Slice(T)" && T < ::Number %}
       {{T}}.slice({{args.splat(", ")}}read_only: {{read_only}})
     {% else %}
-      %ptr = Pointer(typeof({{args.splat}})).malloc({{args.size}})
+      %ptr = ::Pointer(typeof({{args.splat}})).malloc({{args.size}})
       {% for arg, i in args %}
         %ptr[{{i}}] = {{arg}}
       {% end %}
-      Slice.new(%ptr, {{args.size}}, read_only: {{read_only}})
+      ::Slice.new(%ptr, {{args.size}}, read_only: {{read_only}})
     {% end %}
   end
 

--- a/src/spec/dsl.cr
+++ b/src/spec/dsl.cr
@@ -298,8 +298,8 @@ module Spec
       # If the "log" module is required it is configured to emit no entries by default.
       def log_setup
         defined?(::Log) do
-          if Log.responds_to?(:setup)
-            Log.setup_from_env(default_level: :none)
+          if ::Log.responds_to?(:setup)
+            ::Log.setup_from_env(default_level: :none)
           end
         end
       end

--- a/src/spec/helpers/iterate.cr
+++ b/src/spec/helpers/iterate.cr
@@ -47,7 +47,7 @@ module Spec::Methods
   # See `.it_iterates` for details.
   macro assert_iterates_yielding(expected, method, *, infinite = false, tuple = false)
     %remaining = ({{expected}}).size
-    %ary = [] of typeof(Enumerable.element_type({{ expected }}))
+    %ary = [] of typeof(::Enumerable.element_type({{ expected }}))
     {{ method.id }} do |{% if tuple %}*{% end %}x|
       if %remaining == 0
         if {{ infinite }}
@@ -73,11 +73,11 @@ module Spec::Methods
   #
   # See `.it_iterates` for details.
   macro assert_iterates_iterator(expected, method, *, infinite = false)
-    %ary = [] of typeof(Enumerable.element_type({{ expected }}))
+    %ary = [] of typeof(::Enumerable.element_type({{ expected }}))
     %iter = {{ method.id }}
     ({{ expected }}).size.times do
       %v = %iter.next
-      if %v.is_a?(Iterator::Stop)
+      if %v.is_a?(::Iterator::Stop)
         # Compare the actual value directly. Since there are less
         # then expected values, the expectation will fail and raise.
         %ary.should eq({{ expected }})
@@ -86,7 +86,7 @@ module Spec::Methods
       %ary << %v
     end
     unless {{ infinite }}
-      %iter.next.should be_a(Iterator::Stop)
+      %iter.next.should be_a(::Iterator::Stop)
     end
 
     %ary.should eq({{ expected }})

--- a/src/static_array.cr
+++ b/src/static_array.cr
@@ -50,7 +50,7 @@ struct StaticArray(T, N)
   # * `Number.static_array` is a convenient alternative for designating a
   #   specific numerical item type.
   macro [](*args)
-    %array = uninitialized StaticArray(typeof({{args.splat}}), {{args.size}})
+    %array = uninitialized ::StaticArray(typeof({{args.splat}}), {{args.size}})
     {% for arg, i in args %}
       %array.to_unsafe[{{i}}] = {{arg}}
     {% end %}

--- a/src/syscall/aarch64-linux.cr
+++ b/src/syscall/aarch64-linux.cr
@@ -334,7 +334,7 @@ module Syscall
   end
 
   macro def_syscall(name, return_type, *args)
-    @[AlwaysInline]
+    @[::AlwaysInline]
     def self.{{name.id}}({{args.splat}}) : {{return_type}}
       ret = uninitialized {{return_type}}
 

--- a/src/syscall/arm-linux.cr
+++ b/src/syscall/arm-linux.cr
@@ -409,7 +409,7 @@ module Syscall
   end
 
   macro def_syscall(name, return_type, *args)
-    @[AlwaysInline]
+    @[::AlwaysInline]
     def self.{{name.id}}({{args.splat}}) : {{return_type}}
       ret = uninitialized {{return_type}}
 

--- a/src/syscall/i386-linux.cr
+++ b/src/syscall/i386-linux.cr
@@ -445,7 +445,7 @@ module Syscall
   end
 
   macro def_syscall(name, return_type, *args)
-    @[AlwaysInline]
+    @[::AlwaysInline]
     def self.{{name.id}}({{args.splat}}) : {{return_type}}
       ret = uninitialized {{return_type}}
 

--- a/src/syscall/x86_64-linux.cr
+++ b/src/syscall/x86_64-linux.cr
@@ -368,7 +368,7 @@ module Syscall
   end
 
   macro def_syscall(name, return_type, *args)
-    @[AlwaysInline]
+    @[::AlwaysInline]
     def self.{{name.id}}({{args.splat}}) : {{return_type}}
       ret = uninitialized {{return_type}}
 

--- a/src/uri/params/serializable.cr
+++ b/src/uri/params/serializable.cr
@@ -59,19 +59,19 @@ struct URI::Params
   # ```
   module Serializable
     macro included
-      def self.from_www_form(params : String)
-        new_from_www_form URI::Params.parse params
+      def self.from_www_form(params : ::String)
+        new_from_www_form ::URI::Params.parse params
       end
 
       # :nodoc:
       #
       # This is needed so that nested types can pass the name thru internally.
       # Has to be public so the generated code can call it, but should be considered an implementation detail.
-      def self.from_www_form(params : ::URI::Params, name : String)
+      def self.from_www_form(params : ::URI::Params, name : ::String)
         new_from_www_form(params, name)
       end
 
-      protected def self.new_from_www_form(params : ::URI::Params, name : String? = nil)
+      protected def self.new_from_www_form(params : ::URI::Params, name : ::String? = nil)
         instance = allocate
         instance.initialize(__uri_params: params, name: name)
         GC.add_finalizer(instance) if instance.responds_to?(:finalize)
@@ -79,12 +79,12 @@ struct URI::Params
       end
 
       macro inherited
-        def self.from_www_form(params : String)
-          new_from_www_form URI::Params.parse params
+        def self.from_www_form(params : ::String)
+          new_from_www_form ::URI::Params.parse params
         end
 
         # :nodoc:
-        def self.from_www_form(params : ::URI::Params, name : String)
+        def self.from_www_form(params : ::URI::Params, name : ::String)
           new_from_www_form(params, name)
         end
       end

--- a/src/yaml/serialization.cr
+++ b/src/yaml/serialization.cr
@@ -156,11 +156,11 @@ module YAML
       # Define a `new` directly in the included type,
       # so it overloads well with other possible initializes
 
-      def self.new(ctx : YAML::ParseContext, node : YAML::Nodes::Node)
+      def self.new(ctx : ::YAML::ParseContext, node : ::YAML::Nodes::Node)
         new_from_yaml_node(ctx, node)
       end
 
-      private def self.new_from_yaml_node(ctx : YAML::ParseContext, node : YAML::Nodes::Node)
+      private def self.new_from_yaml_node(ctx : ::YAML::ParseContext, node : ::YAML::Nodes::Node)
         ctx.read_alias(node, self) do |obj|
           return obj
         end
@@ -170,7 +170,7 @@ module YAML
         ctx.record_anchor(node, instance)
 
         instance.initialize(__context_for_yaml_serializable: ctx, __node_for_yaml_serializable: node)
-        GC.add_finalizer(instance) if instance.responds_to?(:finalize)
+        ::GC.add_finalizer(instance) if instance.responds_to?(:finalize)
         instance
       end
 
@@ -178,7 +178,7 @@ module YAML
       # so it can compete with other possible initializes
 
       macro inherited
-        def self.new(ctx : YAML::ParseContext, node : YAML::Nodes::Node)
+        def self.new(ctx : ::YAML::ParseContext, node : ::YAML::Nodes::Node)
           new_from_yaml_node(ctx, node)
         end
       end
@@ -409,17 +409,17 @@ module YAML
         {% mapping.raise "Mapping argument must be a HashLiteral or a NamedTupleLiteral, not #{mapping.class_name.id}" %}
       {% end %}
 
-      def self.new(ctx : YAML::ParseContext, node : YAML::Nodes::Node)
+      def self.new(ctx : ::YAML::ParseContext, node : ::YAML::Nodes::Node)
         ctx.read_alias(node, \{{@type}}) do |obj|
           return obj
         end
 
-        unless node.is_a?(YAML::Nodes::Mapping)
+        unless node.is_a?(::YAML::Nodes::Mapping)
           node.raise "Expected YAML mapping, not #{node.class}"
         end
 
         node.each do |key, value|
-          next unless key.is_a?(YAML::Nodes::Scalar) && value.is_a?(YAML::Nodes::Scalar)
+          next unless key.is_a?(::YAML::Nodes::Scalar) && value.is_a?(::YAML::Nodes::Scalar)
           next unless key.value == {{field.id.stringify}}
 
           discriminator_value = value.value


### PR DESCRIPTION
Fixes the issue reported in #14860, but for *all* paths (not just `Crystal`) and only in locations where namespaces could clash.
That affects `macro` bodies which can be expanded in uncontrolled scopes.

This is a fixup for #14282 (released in 1.12.0).

Resolves #14860