### PR TITLE
Fix limit memory usage of `XML::Error.errors`

### DIFF
--- a/spec/std/xml/reader_spec.cr
+++ b/spec/std/xml/reader_spec.cr
@@ -587,18 +587,16 @@ module XML
         "Opening and ending tag mismatch: people line 1 and foo",
       ]
 
-      4.times do
-        XML::Reader.new(%(<people></foo>)).tap(&.read).expand?
+      %w[foo bar baz qux quux corge grault].each do |tag|
+        XML::Reader.new(%(<#{tag}></a>)).tap(&.read).expand?
       end
-      XML::Reader.new(%(<)).tap(&.read).expand?
-      XML::Reader.new(%(<people></foo>)).tap(&.read).expand?
 
       XML::Error.errors.try(&.map(&.to_s)).should eq [
-        "Opening and ending tag mismatch: people line 1 and foo",
-        "Opening and ending tag mismatch: people line 1 and foo",
-        "Opening and ending tag mismatch: people line 1 and foo",
-        "StartTag: invalid element name",
-        "Opening and ending tag mismatch: people line 1 and foo",
+        "Opening and ending tag mismatch: baz line 1 and a",
+        "Opening and ending tag mismatch: qux line 1 and a",
+        "Opening and ending tag mismatch: quux line 1 and a",
+        "Opening and ending tag mismatch: corge line 1 and a",
+        "Opening and ending tag mismatch: grault line 1 and a",
       ]
     end
   end

--- a/spec/std/xml/reader_spec.cr
+++ b/spec/std/xml/reader_spec.cr
@@ -590,14 +590,14 @@ module XML
       4.times do
         XML::Reader.new(%(<people></foo>)).tap(&.read).expand?
       end
-      XML::Reader.new(%(<bar)).tap(&.read).expand?
+      XML::Reader.new(%(<)).tap(&.read).expand?
       XML::Reader.new(%(<people></foo>)).tap(&.read).expand?
 
       XML::Error.errors.try(&.map(&.to_s)).should eq [
         "Opening and ending tag mismatch: people line 1 and foo",
         "Opening and ending tag mismatch: people line 1 and foo",
         "Opening and ending tag mismatch: people line 1 and foo",
-        "Couldn't find end of Start Tag bar",
+        "StartTag: invalid element name",
         "Opening and ending tag mismatch: people line 1 and foo",
       ]
     end

--- a/spec/std/xml/reader_spec.cr
+++ b/spec/std/xml/reader_spec.cr
@@ -581,11 +581,25 @@ module XML
     it "adds errors to `XML::Error.errors` (deprecated)" do
       XML::Error.errors # clear class error list
 
-      reader = XML::Reader.new(%(<people></foo>))
-      reader.read
-      reader.expand?
 
-      XML::Error.errors.try(&.map(&.to_s)).should eq ["Opening and ending tag mismatch: people line 1 and foo"]
+      XML::Reader.new(%(<people></foo>)).tap(&.read).expand?
+      XML::Error.errors.try(&.map(&.to_s)).should eq [
+        "Opening and ending tag mismatch: people line 1 and foo",
+      ]
+
+      4.times do
+        XML::Reader.new(%(<people></foo>)).tap(&.read).expand?
+      end
+      XML::Reader.new(%(<bar)).tap(&.read).expand?
+      XML::Reader.new(%(<people></foo>)).tap(&.read).expand?
+
+      XML::Error.errors.try(&.map(&.to_s)).should eq [
+        "Opening and ending tag mismatch: people line 1 and foo",
+        "Opening and ending tag mismatch: people line 1 and foo",
+        "Opening and ending tag mismatch: people line 1 and foo",
+        "Couldn't find end of Start Tag bar",
+        "Opening and ending tag mismatch: people line 1 and foo",
+      ]
     end
   end
 end

--- a/spec/std/xml/reader_spec.cr
+++ b/spec/std/xml/reader_spec.cr
@@ -581,7 +581,6 @@ module XML
     it "adds errors to `XML::Error.errors` (deprecated)" do
       XML::Error.errors # clear class error list
 
-
       XML::Reader.new(%(<people></foo>)).tap(&.read).expand?
       XML::Error.errors.try(&.map(&.to_s)).should eq [
         "Opening and ending tag mismatch: people line 1 and foo",

--- a/src/xml/error.cr
+++ b/src/xml/error.cr
@@ -11,8 +11,17 @@ class XML::Error < Exception
     super(message)
   end
 
+  @@max_error_capacity = 5
+
   @[Deprecated("This class property is deprecated. XML errors are accessible directly in the respective context via `XML::Reader#errors` and `XML::Node#errors`.")]
-  class_property max_error_capacity = 5
+  def self.max_error_capacity=(@@max_error_capacity)
+  end
+
+  @[Deprecated("This class property is deprecated. XML errors are accessible directly in the respective context via `XML::Reader#errors` and `XML::Node#errors`.")]
+  def self.max_error_capacity
+    @@max_error_capacity
+  end
+
   @@errors = Deque(self).new(max_error_capacity)
 
   # :nodoc:


### PR DESCRIPTION
This patch limits the size of `XML::Error.errors` to contain only the last 10 error messages.
A new class property `XML::Error.max_error_capacity` allows configuration of the error capacity. This property is already marked as deprecated because it'll vanish together with `XML::Error.errors`.

Resolves #14934
Closes https://github.com/crystal-lang/crystal/pull/14936