### PR TITLE
Fix: `Crystal::SpinLock` doesn't need to be allocated on the HEAP

### DIFF
--- a/src/crystal/spin_lock.cr
+++ b/src/crystal/spin_lock.cr
@@ -1,5 +1,5 @@
 # :nodoc:
-class Crystal::SpinLock
+struct Crystal::SpinLock
   private UNLOCKED = 0
   private LOCKED   = 1
 


### PR DESCRIPTION
The object is a mere abstraction over an atomic integer and the object itself are only ever used internally of other objects and not shared, with the exception of Channel where the code explicitly accesses the ivar directly (still no copies).

We can avoid a HEAP allocation everywhere we use them (i.e. in lots of places).

Extracted from #14959