### PR TITLE
Add methods to Crystal::EventLoop

### DIFF
--- a/src/crystal/scheduler.cr
+++ b/src/crystal/scheduler.cr
@@ -24,6 +24,12 @@ class Crystal::Scheduler
     Thread.current.scheduler.@event_loop
   end
 
+  def self.event_loop?
+    if scheduler = Thread.current?.try(&.scheduler?)
+      scheduler.@event_loop
+    end
+  end
+
   def self.enqueue(fiber : Fiber) : Nil
     Crystal.trace :sched, "enqueue", fiber: fiber do
       thread = Thread.current

--- a/src/crystal/system/event_loop.cr
+++ b/src/crystal/system/event_loop.cr
@@ -17,6 +17,11 @@ abstract class Crystal::EventLoop
     Crystal::Scheduler.event_loop
   end
 
+  @[AlwaysInline]
+  def self.current? : self?
+    Crystal::Scheduler.event_loop?
+  end
+
   # Runs the loop.
   #
   # Returns immediately if events are activable. Set `blocking` to false to

--- a/src/crystal/system/event_loop/file_descriptor.cr
+++ b/src/crystal/system/event_loop/file_descriptor.cr
@@ -19,5 +19,13 @@ abstract class Crystal::EventLoop
 
     # Closes the file descriptor resource.
     abstract def close(file_descriptor : Crystal::System::FileDescriptor) : Nil
+
+    # Removes the file descriptor from the event loop. Can be used to free up
+    # memory resources associated with the file descriptor, as well as removing
+    # the file descriptor from kernel data structures.
+    #
+    # Called by `::IO::FileDescriptor#finalize` before closing the file
+    # descriptor. Errors shall be silently ignored.
+    abstract def delete(file_descriptor : Crystal::System::FileDescriptor) : Nil
   end
 end

--- a/src/crystal/system/event_loop/file_descriptor.cr
+++ b/src/crystal/system/event_loop/file_descriptor.cr
@@ -26,6 +26,6 @@ abstract class Crystal::EventLoop
     #
     # Called by `::IO::FileDescriptor#finalize` before closing the file
     # descriptor. Errors shall be silently ignored.
-    abstract def delete(file_descriptor : Crystal::System::FileDescriptor) : Nil
+    abstract def remove(file_descriptor : Crystal::System::FileDescriptor) : Nil
   end
 end

--- a/src/crystal/system/event_loop/socket.cr
+++ b/src/crystal/system/event_loop/socket.cr
@@ -69,6 +69,6 @@ abstract class Crystal::EventLoop
     #
     # Called by `::Socket#finalize` before closing the socket. Errors shall be
     # silently ignored.
-    abstract def delete(socket : ::Socket) : Nil
+    abstract def remove(socket : ::Socket) : Nil
   end
 end

--- a/src/crystal/system/event_loop/socket.cr
+++ b/src/crystal/system/event_loop/socket.cr
@@ -62,5 +62,13 @@ abstract class Crystal::EventLoop
 
     # Closes the socket.
     abstract def close(socket : ::Socket) : Nil
+
+    # Removes the socket from the event loop. Can be used to free up memory
+    # resources associated with the socket, as well as removing the socket from
+    # kernel data structures.
+    #
+    # Called by `::Socket#finalize` before closing the socket. Errors shall be
+    # silently ignored.
+    abstract def delete(socket : ::Socket) : Nil
   end
 end

--- a/src/crystal/system/file_descriptor.cr
+++ b/src/crystal/system/file_descriptor.cr
@@ -39,6 +39,10 @@ module Crystal::System::FileDescriptor
     event_loop.write(self, slice)
   end
 
+  private def event_loop? : Crystal::EventLoop::FileDescriptor?
+    Crystal::EventLoop.current?
+  end
+
   private def event_loop : Crystal::EventLoop::FileDescriptor
     Crystal::EventLoop.current
   end

--- a/src/crystal/system/socket.cr
+++ b/src/crystal/system/socket.cr
@@ -99,6 +99,10 @@ module Crystal::System::Socket
   # Also used in `Socket#finalize`
   # def socket_close
 
+  private def event_loop? : Crystal::EventLoop::Socket?
+    Crystal::EventLoop.current?
+  end
+
   private def event_loop : Crystal::EventLoop::Socket
     Crystal::EventLoop.current
   end

--- a/src/crystal/system/unix/event_loop_libevent.cr
+++ b/src/crystal/system/unix/event_loop_libevent.cr
@@ -96,7 +96,7 @@ class Crystal::LibEvent::EventLoop < Crystal::EventLoop
     file_descriptor.evented_close
   end
 
-  def delete(file_descriptor : Crystal::System::FileDescriptor) : Nil
+  def remove(file_descriptor : Crystal::System::FileDescriptor) : Nil
   end
 
   def read(socket : ::Socket, slice : Bytes) : Int32
@@ -192,7 +192,7 @@ class Crystal::LibEvent::EventLoop < Crystal::EventLoop
     socket.evented_close
   end
 
-  def delete(socket : ::Socket) : Nil
+  def remove(socket : ::Socket) : Nil
   end
 
   def evented_read(target, errno_msg : String, &) : Int32

--- a/src/crystal/system/unix/event_loop_libevent.cr
+++ b/src/crystal/system/unix/event_loop_libevent.cr
@@ -96,6 +96,9 @@ class Crystal::LibEvent::EventLoop < Crystal::EventLoop
     file_descriptor.evented_close
   end
 
+  def delete(file_descriptor : Crystal::System::FileDescriptor) : Nil
+  end
+
   def read(socket : ::Socket, slice : Bytes) : Int32
     evented_read(socket, "Error reading socket") do
       LibC.recv(socket.fd, slice, slice.size, 0).to_i32
@@ -187,6 +190,9 @@ class Crystal::LibEvent::EventLoop < Crystal::EventLoop
 
   def close(socket : ::Socket) : Nil
     socket.evented_close
+  end
+
+  def delete(socket : ::Socket) : Nil
   end
 
   def evented_read(target, errno_msg : String, &) : Int32

--- a/src/crystal/system/unix/event_loop_libevent.cr
+++ b/src/crystal/system/unix/event_loop_libevent.cr
@@ -4,6 +4,9 @@ require "./event_libevent"
 class Crystal::LibEvent::EventLoop < Crystal::EventLoop
   private getter(event_base) { Crystal::LibEvent::Event::Base.new }
 
+  def after_fork_before_exec : Nil
+  end
+
   {% unless flag?(:preview_mt) %}
     # Reinitializes the event loop after a fork.
     def after_fork : Nil

--- a/src/crystal/system/unix/process.cr
+++ b/src/crystal/system/unix/process.cr
@@ -185,6 +185,9 @@ struct Crystal::System::Process
       # child:
       pid = nil
       if will_exec
+        # notify event loop
+        Crystal::EventLoop.current.after_fork_before_exec
+
         # reset signal handlers, then sigmask (inherited on exec):
         Crystal::System::Signal.after_fork_before_exec
         LibC.sigemptyset(pointerof(newmask))

--- a/src/crystal/system/wasi/event_loop.cr
+++ b/src/crystal/system/wasi/event_loop.cr
@@ -53,7 +53,7 @@ class Crystal::Wasi::EventLoop < Crystal::EventLoop
     file_descriptor.evented_close
   end
 
-  def delete(file_descriptor : Crystal::System::FileDescriptor) : Nil
+  def remove(file_descriptor : Crystal::System::FileDescriptor) : Nil
   end
 
   def read(socket : ::Socket, slice : Bytes) : Int32
@@ -88,7 +88,7 @@ class Crystal::Wasi::EventLoop < Crystal::EventLoop
     socket.evented_close
   end
 
-  def delete(socket : ::Socket) : Nil
+  def remove(socket : ::Socket) : Nil
   end
 
   def evented_read(target, errno_msg : String, &) : Int32

--- a/src/crystal/system/wasi/event_loop.cr
+++ b/src/crystal/system/wasi/event_loop.cr
@@ -53,6 +53,9 @@ class Crystal::Wasi::EventLoop < Crystal::EventLoop
     file_descriptor.evented_close
   end
 
+  def delete(file_descriptor : Crystal::System::FileDescriptor) : Nil
+  end
+
   def read(socket : ::Socket, slice : Bytes) : Int32
     evented_read(socket, "Error reading socket") do
       LibC.recv(socket.fd, slice, slice.size, 0).to_i32
@@ -83,6 +86,9 @@ class Crystal::Wasi::EventLoop < Crystal::EventLoop
 
   def close(socket : ::Socket) : Nil
     socket.evented_close
+  end
+
+  def delete(socket : ::Socket) : Nil
   end
 
   def evented_read(target, errno_msg : String, &) : Int32

--- a/src/crystal/system/win32/event_loop_iocp.cr
+++ b/src/crystal/system/win32/event_loop_iocp.cr
@@ -161,6 +161,9 @@ class Crystal::IOCP::EventLoop < Crystal::EventLoop
     LibC.CancelIoEx(file_descriptor.windows_handle, nil) unless file_descriptor.system_blocking?
   end
 
+  def delete(file_descriptor : Crystal::System::FileDescriptor) : Nil
+  end
+
   private def wsa_buffer(bytes)
     wsabuf = LibC::WSABUF.new
     wsabuf.len = bytes.size
@@ -270,6 +273,9 @@ class Crystal::IOCP::EventLoop < Crystal::EventLoop
   end
 
   def close(socket : ::Socket) : Nil
+  end
+
+  def delete(socket : ::Socket) : Nil
   end
 end
 

--- a/src/crystal/system/win32/event_loop_iocp.cr
+++ b/src/crystal/system/win32/event_loop_iocp.cr
@@ -161,7 +161,7 @@ class Crystal::IOCP::EventLoop < Crystal::EventLoop
     LibC.CancelIoEx(file_descriptor.windows_handle, nil) unless file_descriptor.system_blocking?
   end
 
-  def delete(file_descriptor : Crystal::System::FileDescriptor) : Nil
+  def remove(file_descriptor : Crystal::System::FileDescriptor) : Nil
   end
 
   private def wsa_buffer(bytes)
@@ -275,7 +275,7 @@ class Crystal::IOCP::EventLoop < Crystal::EventLoop
   def close(socket : ::Socket) : Nil
   end
 
-  def delete(socket : ::Socket) : Nil
+  def remove(socket : ::Socket) : Nil
   end
 end
 

--- a/src/io/file_descriptor.cr
+++ b/src/io/file_descriptor.cr
@@ -255,7 +255,7 @@ class IO::FileDescriptor < IO
   def finalize
     return if closed? || !close_on_finalize?
 
-    event_loop.remove(self)
+    event_loop?.try(&.remove(self))
     file_descriptor_close { } # ignore error
   end
 

--- a/src/io/file_descriptor.cr
+++ b/src/io/file_descriptor.cr
@@ -255,7 +255,7 @@ class IO::FileDescriptor < IO
   def finalize
     return if closed? || !close_on_finalize?
 
-    event_loop.delete(self)
+    event_loop.remove(self)
     file_descriptor_close { } # ignore error
   end
 

--- a/src/io/file_descriptor.cr
+++ b/src/io/file_descriptor.cr
@@ -255,6 +255,7 @@ class IO::FileDescriptor < IO
   def finalize
     return if closed? || !close_on_finalize?
 
+    event_loop.delete(self)
     file_descriptor_close { } # ignore error
   end
 

--- a/src/socket.cr
+++ b/src/socket.cr
@@ -430,7 +430,7 @@ class Socket < IO
   def finalize
     return if closed?
 
-    event_loop.delete(self)
+    event_loop.remove(self)
     socket_close { } # ignore error
   end
 

--- a/src/socket.cr
+++ b/src/socket.cr
@@ -430,7 +430,7 @@ class Socket < IO
   def finalize
     return if closed?
 
-    event_loop.remove(self)
+    event_loop?.try(&.remove(self))
     socket_close { } # ignore error
   end
 

--- a/src/socket.cr
+++ b/src/socket.cr
@@ -430,6 +430,7 @@ class Socket < IO
   def finalize
     return if closed?
 
+    event_loop.delete(self)
     socket_close { } # ignore error
   end
 


### PR DESCRIPTION
Add `#after_fork_before_exec` to allow an evloop to do some cleanup before exec (UNIX only).
Add `#remove(io)` to allow an evloop to free resources when the IO is closed in a GC finalizer.

Extracted from #14959 