### PR TITLE
Refactor `EventLoop` interface for sleeps & select timeouts

### DIFF
--- a/src/channel/select/timeout_action.cr
+++ b/src/channel/select/timeout_action.cr
@@ -58,9 +58,11 @@ class Channel(T)
     end
 
     def time_expired(fiber : Fiber) : Nil
-      if @select_context.try &.try_trigger
-        fiber.enqueue
-      end
+      fiber.enqueue if time_expired?
+    end
+
+    def time_expired? : Bool
+      @select_context.try &.try_trigger || false
     end
   end
 end

--- a/src/crystal/system/event_loop.cr
+++ b/src/crystal/system/event_loop.cr
@@ -51,7 +51,7 @@ abstract class Crystal::EventLoop
     abstract def free : Nil
 
     # Adds a new timeout to this event.
-    abstract def add(timeout : Time::Span?) : Nil
+    abstract def add(timeout : Time::Span) : Nil
   end
 end
 

--- a/src/crystal/system/unix/event_libevent.cr
+++ b/src/crystal/system/unix/event_libevent.cr
@@ -19,16 +19,16 @@ module Crystal::LibEvent
       @freed = false
     end
 
-    def add(timeout : Time::Span?) : Nil
-      if timeout
-        timeval = LibC::Timeval.new(
-          tv_sec: LibC::TimeT.new(timeout.total_seconds),
-          tv_usec: timeout.nanoseconds // 1_000
-        )
-        LibEvent2.event_add(@event, pointerof(timeval))
-      else
-        LibEvent2.event_add(@event, nil)
-      end
+    def add(timeout : Time::Span) : Nil
+      timeval = LibC::Timeval.new(
+        tv_sec: LibC::TimeT.new(timeout.total_seconds),
+        tv_usec: timeout.nanoseconds // 1_000
+      )
+      LibEvent2.event_add(@event, pointerof(timeval))
+    end
+
+    def add(timeout : Nil) : Nil
+      LibEvent2.event_add(@event, nil)
     end
 
     def free : Nil

--- a/src/crystal/system/wasi/event_loop.cr
+++ b/src/crystal/system/wasi/event_loop.cr
@@ -126,7 +126,7 @@ end
 struct Crystal::Wasi::Event
   include Crystal::EventLoop::Event
 
-  def add(timeout : Time::Span?) : Nil
+  def add(timeout : Time::Span) : Nil
   end
 
   def free : Nil

--- a/src/crystal/system/wasi/event_loop.cr
+++ b/src/crystal/system/wasi/event_loop.cr
@@ -129,6 +129,9 @@ struct Crystal::Wasi::Event
   def add(timeout : Time::Span) : Nil
   end
 
+  def add(timeout : Nil) : Nil
+  end
+
   def free : Nil
   end
 

--- a/src/crystal/system/win32/event_loop_iocp.cr
+++ b/src/crystal/system/win32/event_loop_iocp.cr
@@ -292,8 +292,8 @@ class Crystal::IOCP::Event
     free
   end
 
-  def add(timeout : Time::Span?) : Nil
-    @wake_at = timeout ? Time.monotonic + timeout : Time.monotonic
+  def add(timeout : Time::Span) : Nil
+    @wake_at = Time.monotonic + timeout
     Crystal::EventLoop.current.enqueue(self)
   end
 end

--- a/src/fiber.cr
+++ b/src/fiber.cr
@@ -234,20 +234,21 @@ class Fiber
   end
 
   # :nodoc:
-  def timeout(timeout : Time::Span?, select_action : Channel::TimeoutAction? = nil) : Nil
+  def timeout(timeout : Time::Span, select_action : Channel::TimeoutAction) : Nil
     @timeout_select_action = select_action
     timeout_event.add(timeout)
   end
 
   # :nodoc:
   def cancel_timeout : Nil
+    return unless @timeout_select_action
     @timeout_select_action = nil
     @timeout_event.try &.delete
   end
 
   # The current fiber will resume after a period of time.
   # The timeout can be cancelled with `cancel_timeout`
-  def self.timeout(timeout : Time::Span?, select_action : Channel::TimeoutAction? = nil) : Nil
+  def self.timeout(timeout : Time::Span, select_action : Channel::TimeoutAction) : Nil
     Fiber.current.timeout(timeout, select_action)
   end
 


### PR DESCRIPTION
A couple refactors related to select timeout and the signature of Crystal::EventLoop::Event#add that only needs to handle a nilable for libevent (because it caches events); other loop don't need that.

Extracted from #14959 