### PR TITLE
Fix `Process.exec` stream redirection on Windows

### DIFF
--- a/spec/std/process_spec.cr
+++ b/spec/std/process_spec.cr
@@ -479,6 +479,27 @@ pending_interpreted describe: Process do
   {% end %}
 
   describe ".exec" do
+    it "redirects STDIN and STDOUT to files" do
+      with_tempfile("crystal-exec-stdin", "crystal-exec-stdout") do |stdin_path, stdout_path|
+        File.write(stdin_path, "foobar")
+
+        status, _, _ = compile_and_run_source <<-CRYSTAL
+          command = #{stdin_to_stdout_command[0].inspect}
+          args = #{stdin_to_stdout_command[1].to_a} of String
+          stdin_path = #{stdin_path.inspect}
+          stdout_path = #{stdout_path.inspect}
+          File.open(stdin_path) do |input|
+            File.open(stdout_path, "w") do |output|
+              Process.exec(command, args, input: input, output: output)
+            end
+          end
+          CRYSTAL
+
+        status.success?.should be_true
+        File.read(stdout_path).chomp.should eq("foobar")
+      end
+    end
+
     it "gets error from exec" do
       expect_raises(File::NotFoundError, "Error executing process: 'foobarbaz'") do
         Process.exec("foobarbaz")

--- a/spec/std/process_spec.cr
+++ b/spec/std/process_spec.cr
@@ -479,7 +479,7 @@ pending_interpreted describe: Process do
   {% end %}
 
   describe ".exec" do
-    it "redirects STDIN and STDOUT to files" do
+    it "redirects STDIN and STDOUT to files", tags: %w[slow] do
       with_tempfile("crystal-exec-stdin", "crystal-exec-stdout") do |stdin_path, stdout_path|
         File.write(stdin_path, "foobar")
 

--- a/src/lib_c/x86_64-windows-msvc/c/io.cr
+++ b/src/lib_c/x86_64-windows-msvc/c/io.cr
@@ -3,6 +3,7 @@ require "c/stdint"
 lib LibC
   fun _wexecvp(cmdname : WCHAR*, argv : WCHAR**) : IntPtrT
   fun _open_osfhandle(osfhandle : HANDLE, flags : LibC::Int) : LibC::Int
+  fun _dup(fd : Int) : Int
   fun _dup2(fd1 : Int, fd2 : Int) : Int
 
   # unused

--- a/src/lib_c/x86_64-windows-msvc/c/io.cr
+++ b/src/lib_c/x86_64-windows-msvc/c/io.cr
@@ -2,12 +2,12 @@ require "c/stdint"
 
 lib LibC
   fun _wexecvp(cmdname : WCHAR*, argv : WCHAR**) : IntPtrT
+  fun _open_osfhandle(osfhandle : HANDLE, flags : LibC::Int) : LibC::Int
+  fun _dup2(fd1 : Int, fd2 : Int) : Int
 
   # unused
-  fun _open_osfhandle(osfhandle : HANDLE, flags : LibC::Int) : LibC::Int
   fun _get_osfhandle(fd : Int) : IntPtrT
   fun _close(fd : Int) : Int
-  fun _dup2(fd1 : Int, fd2 : Int) : Int
   fun _isatty(fd : Int) : Int
   fun _write(fd : Int, buffer : UInt8*, count : UInt) : Int
   fun _read(fd : Int, buffer : UInt8*, count : UInt) : Int


### PR DESCRIPTION
The following should print the compiler help message to the file `foo.txt`:

```crystal
File.open("foo.txt", "w") do |f|
  Process.exec("crystal", output: f)
end
```

It used to work on Windows in Crystal 1.12, but is now broken since 1.13. This is because `LibC._wexecvp` only inherits file descriptors in the C runtime, not arbitrary Win32 file handles; since we stopped calling `LibC._open_osfhandle`, the C runtime knows nothing about any reopened standard streams in Win32. Thus the above merely prints the help message to the standard output.

This PR creates the missing C file descriptors right before `LibC._wexecvp`. It also fixes a different regression of #14947 where reconfiguring `STDIN.blocking` always fails.

Related: #14422