### PR TITLE
Make `Crystal::IOCP::OverlappedOperation` abstract

### DIFF
--- a/src/crystal/system/win32/file_descriptor.cr
+++ b/src/crystal/system/win32/file_descriptor.cr
@@ -234,7 +234,7 @@ module Crystal::System::FileDescriptor
   end
 
   private def lock_file(handle, flags)
-    IOCP::OverlappedOperation.run(handle) do |operation|
+    IOCP::IOOverlappedOperation.run(handle) do |operation|
       result = LibC.LockFileEx(handle, flags, 0, 0xFFFF_FFFF, 0xFFFF_FFFF, operation)
 
       if result == 0
@@ -260,7 +260,7 @@ module Crystal::System::FileDescriptor
   end
 
   private def unlock_file(handle)
-    IOCP::OverlappedOperation.run(handle) do |operation|
+    IOCP::IOOverlappedOperation.run(handle) do |operation|
       result = LibC.UnlockFileEx(handle, 0, 0xFFFF_FFFF, 0xFFFF_FFFF, operation)
 
       if result == 0

--- a/src/crystal/system/win32/iocp.cr
+++ b/src/crystal/system/win32/iocp.cr
@@ -85,6 +85,7 @@ module Crystal::IOCP
     end
 
     abstract def wait_for_result(timeout, & : WinError ->)
+    private abstract def try_cancel : Bool
 
     @overlapped = LibC::OVERLAPPED.new
     @fiber = Fiber.current

--- a/src/crystal/system/win32/iocp.cr
+++ b/src/crystal/system/win32/iocp.cr
@@ -78,65 +78,31 @@ module Crystal::IOCP
     end
   end
 
-  class OverlappedOperation
+  abstract class OverlappedOperation
     enum State
       STARTED
       DONE
     end
 
+    abstract def wait_for_result(timeout, & : WinError ->)
+
     @overlapped = LibC::OVERLAPPED.new
     @fiber = Fiber.current
     @state : State = :started
 
-    def initialize(@handle : LibC::HANDLE)
-    end
-
-    def initialize(handle : LibC::SOCKET)
-      @handle = LibC::HANDLE.new(handle)
-    end
-
-    def self.run(handle, &)
-      operation_storage = uninitialized ReferenceStorage(OverlappedOperation)
-      operation = OverlappedOperation.unsafe_construct(pointerof(operation_storage), handle)
+    def self.run(*args, **opts, &)
+      operation_storage = uninitialized ReferenceStorage(self)
+      operation = unsafe_construct(pointerof(operation_storage), *args, **opts)
       yield operation
     end
 
-    def self.unbox(overlapped : LibC::OVERLAPPED*)
-      start = overlapped.as(Pointer(UInt8)) - offsetof(OverlappedOperation, @overlapped)
-      Box(OverlappedOperation).unbox(start.as(Pointer(Void)))
+    def self.unbox(overlapped : LibC::OVERLAPPED*) : self
+      start = overlapped.as(Pointer(UInt8)) - offsetof(self, @overlapped)
+      Box(self).unbox(start.as(Pointer(Void)))
     end
 
     def to_unsafe
       pointerof(@overlapped)
-    end
-
-    def wait_for_result(timeout, &)
-      wait_for_completion(timeout)
-
-      result = LibC.GetOverlappedResult(@handle, self, out bytes, 0)
-      if result.zero?
-        error = WinError.value
-        yield error
-
-        raise IO::Error.from_os_error("GetOverlappedResult", error)
-      end
-
-      bytes
-    end
-
-    def wait_for_wsa_result(timeout, &)
-      wait_for_completion(timeout)
-
-      flags = 0_u32
-      result = LibC.WSAGetOverlappedResult(LibC::SOCKET.new(@handle.address), self, out bytes, false, pointerof(flags))
-      if result.zero?
-        error = WinError.wsa_value
-        yield error
-
-        raise IO::Error.from_os_error("WSAGetOverlappedResult", error)
-      end
-
-      bytes
     end
 
     protected def schedule(&)
@@ -144,31 +110,12 @@ module Crystal::IOCP
       yield @fiber
     end
 
-    def done!
+    private def done!
       @fiber.cancel_timeout
       @state = :done
     end
 
-    def try_cancel : Bool
-      # Microsoft documentation:
-      # The application must not free or reuse the OVERLAPPED structure
-      # associated with the canceled I/O operations until they have completed
-      # (this does not apply to asynchronous operations that finished
-      # synchronously, as nothing would be queued to the IOCP)
-      ret = LibC.CancelIoEx(@handle, self)
-      if ret.zero?
-        case error = WinError.value
-        when .error_not_found?
-          # Operation has already completed, do nothing
-          return false
-        else
-          raise RuntimeError.from_os_error("CancelIOEx", os_error: error)
-        end
-      end
-      true
-    end
-
-    def wait_for_completion(timeout)
+    private def wait_for_completion(timeout)
       if timeout
         sleep timeout
       else
@@ -183,13 +130,71 @@ module Crystal::IOCP
         end
       end
     end
+
+    private def try_cancel : Bool
+      # Microsoft documentation:
+      # The application must not free or reuse the OVERLAPPED structure
+      # associated with the canceled I/O operations until they have completed
+      # (this does not apply to asynchronous operations that finished
+      # synchronously, as nothing would be queued to the IOCP)
+      ret = LibC.CancelIoEx(@handle, self)
+      if ret.zero?
+        case error = WinError.value
+        when .error_not_found?
+          # Operation has already completed, do nothing
+          return false
+        else
+          raise RuntimeError.from_os_error("CancelIoEx", os_error: error)
+        end
+      end
+      true
+    end
+  end
+
+  class IOOverlappedOperation < OverlappedOperation
+    def initialize(@handle : LibC::HANDLE)
+    end
+
+    def wait_for_result(timeout, & : WinError ->)
+      wait_for_completion(timeout)
+
+      result = LibC.GetOverlappedResult(@handle, self, out bytes, 0)
+      if result.zero?
+        error = WinError.value
+        yield error
+
+        raise IO::Error.from_os_error("GetOverlappedResult", error)
+      end
+
+      bytes
+    end
+  end
+
+  class WSAOverlappedOperation < OverlappedOperation
+    def initialize(@handle : LibC::SOCKET)
+    end
+
+    def wait_for_result(timeout, & : WinError ->)
+      wait_for_completion(timeout)
+
+      flags = 0_u32
+      result = LibC.WSAGetOverlappedResult(@handle, self, out bytes, false, pointerof(flags))
+      if result.zero?
+        error = WinError.wsa_value
+        yield error
+
+        raise IO::Error.from_os_error("WSAGetOverlappedResult", error)
+      end
+
+      bytes
+    end
   end
 
   def self.overlapped_operation(file_descriptor, method, timeout, *, offset = nil, writing = false, &)
     handle = file_descriptor.windows_handle
     seekable = LibC.SetFilePointerEx(handle, 0, out original_offset, IO::Seek::Current) != 0
 
-    OverlappedOperation.run(handle) do |operation|
+    IOOverlappedOperation.run(handle) do |operation|
       overlapped = operation.to_unsafe
       if seekable
         start_offset = offset || original_offset
@@ -243,7 +248,7 @@ module Crystal::IOCP
   end
 
   def self.wsa_overlapped_operation(target, socket, method, timeout, connreset_is_error = true, &)
-    OverlappedOperation.run(socket) do |operation|
+    WSAOverlappedOperation.run(socket) do |operation|
       result, value = yield operation
 
       if result == LibC::SOCKET_ERROR
@@ -257,7 +262,7 @@ module Crystal::IOCP
         return value
       end
 
-      operation.wait_for_wsa_result(timeout) do |error|
+      operation.wait_for_result(timeout) do |error|
         case error
         when .wsa_io_incomplete?, .error_operation_aborted?
           raise IO::TimeoutError.new("#{method} timed out")

--- a/src/crystal/system/win32/socket.cr
+++ b/src/crystal/system/win32/socket.cr
@@ -129,7 +129,7 @@ module Crystal::System::Socket
 
   # :nodoc:
   def overlapped_connect(socket, method, timeout, &)
-    IOCP::OverlappedOperation.run(socket) do |operation|
+    IOCP::WSAOverlappedOperation.run(socket) do |operation|
       result = yield operation
 
       if result == 0
@@ -145,7 +145,7 @@ module Crystal::System::Socket
         return nil
       end
 
-      operation.wait_for_wsa_result(timeout) do |error|
+      operation.wait_for_result(timeout) do |error|
         case error
         when .wsa_io_incomplete?, .wsaeconnrefused?
           return ::Socket::ConnectError.from_os_error(method, error)
@@ -192,7 +192,7 @@ module Crystal::System::Socket
   end
 
   def overlapped_accept(socket, method, &)
-    IOCP::OverlappedOperation.run(socket) do |operation|
+    IOCP::WSAOverlappedOperation.run(socket) do |operation|
       result = yield operation
 
       if result == 0
@@ -206,7 +206,7 @@ module Crystal::System::Socket
         return true
       end
 
-      operation.wait_for_wsa_result(read_timeout) do |error|
+      operation.wait_for_result(read_timeout) do |error|
         case error
         when .wsa_io_incomplete?, .wsaenotsock?
           return false


### PR DESCRIPTION
This allows different overlapped operations to provide their own closure data, instead of putting everything in one big class, such as in https://github.com/crystal-lang/crystal/pull/14979#discussion_r1746549086.