### PR TITLE
Remove TODO in `Crystal::Loader` on Windows

### DIFF
--- a/src/compiler/crystal/loader/msvc.cr
+++ b/src/compiler/crystal/loader/msvc.cr
@@ -185,7 +185,6 @@ class Crystal::Loader
   end
 
   private def open_library(path : String)
-    # TODO: respect `@[Link(dll:)]`'s search order
     LibC.LoadLibraryExW(System.to_wstr(path), nil, 0)
   end
 


### PR DESCRIPTION
This has been addressed by #14146 from outside the loader, and there is essentially only one TODO left for #11575.