### PR TITLE
Only enable IOCP notifications in `Process#wait`, not `.new`

### DIFF
--- a/spec/std/process_spec.cr
+++ b/spec/std/process_spec.cr
@@ -101,6 +101,11 @@ describe Process do
         end
       end
     end
+
+    it "doesn't break if process is collected before completion" do
+      200.times { Process.new(*exit_code_command(0)) }
+      10.times { GC.collect }
+    end
   end
 
   describe "#wait" do

--- a/src/crystal/system/win32/process.cr
+++ b/src/crystal/system/win32/process.cr
@@ -63,6 +63,7 @@ struct Crystal::System::Process
 
   def wait
     # enable IOCP notifications
+    @completion_key.fiber = ::Fiber.current
     config_job_object(
       LibC::JOBOBJECTINFOCLASS::AssociateCompletionPortInformation,
       LibC::JOBOBJECT_ASSOCIATE_COMPLETION_PORT.new(
@@ -80,7 +81,6 @@ struct Crystal::System::Process
     # TODO: message delivery is "not guaranteed"; does it ever happen? Are we
     # stuck forever in that case?
     # (https://learn.microsoft.com/en-us/windows/win32/api/winnt/ns-winnt-jobobject_associate_completion_port)
-    @completion_key.fiber = ::Fiber.current
     ::Fiber.suspend
 
     # If the IOCP notification is delivered before the process fully exits,


### PR DESCRIPTION
On Windows, `Process`es could be garbage-collected before their completion events are received, meaning `Crystal::IOCP.wait_queued_completions` could receive invalid objects: (note that `Process` doesn't require explicit uses of `LibC.PostQueuedCompletionStatus` or `Crystal::IOCP::OverlappedOperation`)

```crystal
200.times do
  Process.new("hostname.exe")
end

10.times { GC.collect }

`hostname`
```

```
Invalid memory access (C0000005) at address 0x2e07fca2f68
[0x7ff73d503cc0] run at C:\crystal\src\crystal\system\win32\iocp.cr:48
[0x7ff73d5011a4] reschedule at C:\crystal\src\crystal\scheduler.cr:160
[0x7ff73d5015b7] sleep at C:\crystal\src\crystal\scheduler.cr:168
[0x7ff73d50154e] sleep at C:\crystal\src\crystal\scheduler.cr:65
[0x7ff73d47120d] sleep at C:\crystal\src\concurrent.cr:23
[0x7ff73d471306] -> at C:\crystal\src\crystal\system\win32\process.cr:208
[0x7ff73d4fba28] run at C:\crystal\src\fiber.cr:143
[0x7ff73d4715d9] -> at C:\crystal\src\fiber.cr:95
```

This PR ensures those events are not enabled until `Process#wait` is called. Previous lost events do not matter as we first use `LibC.GetExitCodeProcess` to determine if the process has already exited.