### PR TITLE
Use our own `libffi` repository on Windows CI

### DIFF
--- a/.github/workflows/win.yml
+++ b/.github/workflows/win.yml
@@ -53,7 +53,7 @@ jobs:
         run: .\etc\win-ci\build-iconv.ps1 -BuildTree deps\iconv
       - name: Build libffi
         if: steps.cache-libs.outputs.cache-hit != 'true'
-        run: .\etc\win-ci\build-ffi.ps1 -BuildTree deps\ffi -Version 3.3
+        run: .\etc\win-ci\build-ffi.ps1 -BuildTree deps\ffi -Version 3.4.6
       - name: Build zlib
         if: steps.cache-libs.outputs.cache-hit != 'true'
         run: .\etc\win-ci\build-z.ps1 -BuildTree deps\z -Version 1.3.1
@@ -134,7 +134,7 @@ jobs:
         run: .\etc\win-ci\build-iconv.ps1 -BuildTree deps\iconv -Dynamic
       - name: Build libffi
         if: steps.cache-dlls.outputs.cache-hit != 'true'
-        run: .\etc\win-ci\build-ffi.ps1 -BuildTree deps\ffi -Version 3.3 -Dynamic
+        run: .\etc\win-ci\build-ffi.ps1 -BuildTree deps\ffi -Version 3.4.6 -Dynamic
       - name: Build zlib
         if: steps.cache-dlls.outputs.cache-hit != 'true'
         run: .\etc\win-ci\build-z.ps1 -BuildTree deps\z -Version 1.3.1 -Dynamic

--- a/etc/win-ci/build-ffi.ps1
+++ b/etc/win-ci/build-ffi.ps1
@@ -7,7 +7,7 @@ param(
 . "$(Split-Path -Parent $MyInvocation.MyCommand.Path)\setup.ps1"
 
 [void](New-Item -Name (Split-Path -Parent $BuildTree) -ItemType Directory -Force)
-Setup-Git -Path $BuildTree -Url https://github.com/HertzDevil/libffi.git -Ref v$Version
+Setup-Git -Path $BuildTree -Url https://github.com/crystal-lang/libffi.git -Ref v$Version
 
 Run-InDirectory $BuildTree {
     $args = "-DCMAKE_FIND_USE_SYSTEM_ENVIRONMENT_PATH=OFF"


### PR DESCRIPTION
Resolves part of #14802.

It was only a matter of time, but I decided to fork the libffi upstream and write [my own `CMakeLists.txt`](https://github.com/HertzDevil/libffi/blob/441390ce33ae2d9bf2916184fe6b7207b306dd3e/CMakeLists.txt). It only handles x64 MSVC, but we could easily extend it to support ARM64 in the near future. Note that the Windows CI already uses libffi since there are interpreter tests and stdlib tests running with the interpreter.

If we are confident that it works then we should later transfer ownership of the fork to crystal-lang (I will continue to maintain it).