### PR TITLE
Avoid unwinding the stack on hot path in method call lookups

### DIFF
--- a/src/compiler/crystal/semantic/call.cr
+++ b/src/compiler/crystal/semantic/call.cr
@@ -13,6 +13,11 @@ class Crystal::Call
   property? uses_with_scope = false
 
   class RetryLookupWithLiterals < ::Exception
+    @@dummy_call_stack = Exception::CallStack.new
+
+    def initialize
+      self.callstack = @@dummy_call_stack
+    end
   end
 
   def program


### PR DESCRIPTION
The method lookup code uses an exception to retry lookups using auto-casting. This is effectively using an exception for execution control, which is not what they are intended for (in Crystal). On `raise`, Crystal will try to unwind the call stack and save it to be able to report the original place where the exception was thrown, and this is a very expensive operation. To avoid that, initialize the callstack of the special `RetryLookupWithLiterals` exception class always with the same fixed value.

This cuts the compilation times for the compiler itself in about 1 second (both using a development and a release optimized compiler). More importantly, since the affected code path happens during semantic analysis, it also cuts that time but approximately 1 second, which should benefit development tools such as crystalline.

Some numbers from non-rigorous measurement, using a release build of the compiler building the compiler itself:

- Full build (ie. `GC_DONT_GC=1 make -B`): from 15.0s (baseline) to 13.9s (with this patch)
- Semantic analysis only (ie. `GC_DONT_GC=1 make -B FLAGS="--no-codegen"`): from 7.3s (baseline) to 6s (with this patch)

Btw, I think a better solution would be to refactor the code so that we don't use exceptions for flow control. But that's *a lot* more work.