### PR TITLE
Skip OpenSSL spec on aarch64-linux-gnu

### DIFF
--- a/spec/std/openssl/ssl/server_spec.cr
+++ b/spec/std/openssl/ssl/server_spec.cr
@@ -4,7 +4,8 @@ require "../../spec_helper"
 require "../../../support/ssl"
 
 # TODO: Windows networking in the interpreter requires #12495
-{% if flag?(:interpreted) && flag?(:win32) %}
+# TODO: libssl 1.1.1 on aarch64 with gnu libc seems to be broken (#15005)
+{% if (flag?(:interpreted) && flag?(:win32)) || (flag?(:aarch64) && flag?(:gnu) && LibSSL::OPENSSL_VERSION != "0.0.0" && compare_versions(LibSSL::OPENSSL_VERSION, "1.1.1") <= 0) %}
   pending OpenSSL::SSL::Server
   {% skip_file %}
 {% end %}

--- a/spec/std/openssl/ssl/socket_spec.cr
+++ b/spec/std/openssl/ssl/socket_spec.cr
@@ -5,7 +5,8 @@ require "../../socket/spec_helper"
 require "../../../support/ssl"
 
 # TODO: Windows networking in the interpreter requires #12495
-{% if flag?(:interpreted) && flag?(:win32) %}
+# TODO: libssl 1.1.1 on aarch64 with gnu libc seems to be broken (#15005)
+{% if (flag?(:interpreted) && flag?(:win32)) || (flag?(:aarch64) && flag?(:gnu) && LibSSL::OPENSSL_VERSION != "0.0.0" && compare_versions(LibSSL::OPENSSL_VERSION, "1.1.1") <= 0) %}
   pending OpenSSL::SSL::Socket
   {% skip_file %}
 {% end %}


### PR DESCRIPTION
This is a workaround for #15005 to avoid crashing the spec process from OpenSSL specs.