### PR TITLE
Enable runners from `runs-on.com` for Aarch64 CI

### DIFF
--- a/.github/workflows/aarch64.yml
+++ b/.github/workflows/aarch64.yml
@@ -8,7 +8,7 @@ concurrency:
 
 jobs:
   aarch64-musl-build:
-    runs-on: [linux, ARM64]
+    runs-on: [runs-on, runner=2cpu-linux-arm64, "run-id=${{ github.run_id }}"]
     if: github.repository == 'crystal-lang/crystal'
     steps:
       - name: Download Crystal source
@@ -26,7 +26,7 @@ jobs:
             src/llvm/ext/llvm_ext.o
   aarch64-musl-test-stdlib:
     needs: aarch64-musl-build
-    runs-on: [linux, ARM64]
+    runs-on: [runs-on, runner=4cpu-linux-arm64, "family=m7g", ram=16, "run-id=${{ github.run_id }}"]
     if: github.repository == 'crystal-lang/crystal'
     steps:
       - name: Download Crystal source
@@ -43,7 +43,7 @@ jobs:
           args: make std_spec
   aarch64-musl-test-compiler:
     needs: aarch64-musl-build
-    runs-on: [linux, ARM64]
+    runs-on: [runs-on, runner=4cpu-linux-arm64, "family=m7g", ram=16, "run-id=${{ github.run_id }}"]
     if: github.repository == 'crystal-lang/crystal'
     steps:
       - name: Download Crystal source
@@ -59,7 +59,7 @@ jobs:
         with:
           args: make primitives_spec compiler_spec FLAGS=-Dwithout_ffi
   aarch64-gnu-build:
-    runs-on: [linux, ARM64]
+    runs-on: [runs-on, runner=2cpu-linux-arm64, "run-id=${{ github.run_id }}"]
     if: github.repository == 'crystal-lang/crystal'
     steps:
       - name: Download Crystal source
@@ -77,7 +77,7 @@ jobs:
             src/llvm/ext/llvm_ext.o
   aarch64-gnu-test-stdlib:
     needs: aarch64-gnu-build
-    runs-on: [linux, ARM64]
+    runs-on: [runs-on, runner=4cpu-linux-arm64, "family=m7g", ram=16, "run-id=${{ github.run_id }}"]
     if: github.repository == 'crystal-lang/crystal'
     steps:
       - name: Download Crystal source
@@ -94,7 +94,7 @@ jobs:
           args: make std_spec
   aarch64-gnu-test-compiler:
     needs: aarch64-gnu-build
-    runs-on: [linux, ARM64]
+    runs-on: [runs-on, runner=4cpu-linux-arm64, "family=m7g", ram=16, "run-id=${{ github.run_id }}"]
     if: github.repository == 'crystal-lang/crystal'
     steps:
       - name: Download Crystal source

--- a/.github/workflows/aarch64.yml
+++ b/.github/workflows/aarch64.yml
@@ -14,7 +14,7 @@ jobs:
       - name: Download Crystal source
         uses: actions/checkout@v4
       - name: Build Crystal
-        uses: docker://jhass/crystal:1.0.0-alpine-build
+        uses: docker://crystallang/crystal:1.13.2-alpine-84codes-build
         with:
           args: make crystal
       - name: Upload Crystal executable
@@ -38,9 +38,9 @@ jobs:
       - name: Mark downloaded compiler as executable
         run: chmod +x .build/crystal
       - name: Run stdlib specs
-        uses: docker://jhass/crystal:1.0.0-alpine-build
+        uses: docker://crystallang/crystal:1.13.2-alpine-84codes-build
         with:
-          args: make std_spec FLAGS=-Duse_pcre
+          args: make std_spec
   aarch64-musl-test-compiler:
     needs: aarch64-musl-build
     runs-on: [linux, ARM64]
@@ -55,7 +55,7 @@ jobs:
       - name: Mark downloaded compiler as executable
         run: chmod +x .build/crystal
       - name: Run compiler specs
-        uses: docker://jhass/crystal:1.0.0-alpine-build
+        uses: docker://crystallang/crystal:1.13.2-alpine-84codes-build
         with:
           args: make primitives_spec compiler_spec FLAGS=-Dwithout_ffi
   aarch64-gnu-build:
@@ -65,7 +65,7 @@ jobs:
       - name: Download Crystal source
         uses: actions/checkout@v4
       - name: Build Crystal
-        uses: docker://jhass/crystal:1.0.0-build
+        uses: docker://crystallang/crystal:1.13.2-ubuntu-84codes-build
         with:
           args: make crystal
       - name: Upload Crystal executable
@@ -89,7 +89,7 @@ jobs:
       - name: Mark downloaded compiler as executable
         run: chmod +x .build/crystal
       - name: Run stdlib specs
-        uses: docker://jhass/crystal:1.0.0-build
+        uses: docker://crystallang/crystal:1.13.2-ubuntu-84codes-build
         with:
           args: make std_spec
   aarch64-gnu-test-compiler:
@@ -106,6 +106,6 @@ jobs:
       - name: Mark downloaded compiler as executable
         run: chmod +x .build/crystal
       - name: Run compiler specs
-        uses: docker://jhass/crystal:1.0.0-build
+        uses: docker://crystallang/crystal:1.13.2-ubuntu-84codes-build
         with:
           args: make primitives_spec compiler_spec


### PR DESCRIPTION
Our previous sponsoring for a CI server from Works On Arm has run out, so we need a replacement to run CI on aarch64 (see https://forum.crystal-lang.org/t/sponsored-servers-for-ci-on-aarch64-running-out/7099).
We might be getting some new sponsoring from Works On Arm, but that hasn't materialized yet. And we would like to get CI workflows running again.

https://runs-on.com is a service that provisions machines on AWS on demand to run workflow jobs.
It triggers when a job is tagged as `runs-on` and you can configure what kind of machine you like this to run on. The machine specification could likely use some fine tuning (we can use other instance types, and theoretically 8GB should be sufficient). But that'll be a follow-up. For now we know that this works.
We expect this to be more price-efficient setup than renting a fixed server or a CI runner service.

This patch also includes an update to the latest base image. The old arm base images were using Crystal 1.0 and some outdated libraries which caused problems on the new runners (#15005). The build images are based on the docker images from [84codes/crystal](https://hub.docker.com/r/84codes/crystal).

Thanks to @crohr for providing runs-on.com and helping with some issues we faced while setting this up.
