### PR TITLE
Add `Exception::CallStack.empty`

### DIFF
--- a/src/compiler/crystal/semantic/call.cr
+++ b/src/compiler/crystal/semantic/call.cr
@@ -13,10 +13,8 @@ class Crystal::Call
   property? uses_with_scope = false
 
   class RetryLookupWithLiterals < ::Exception
-    @@dummy_call_stack = Exception::CallStack.new
-
     def initialize
-      self.callstack = @@dummy_call_stack
+      self.callstack = Exception::CallStack.empty
     end
   end
 

--- a/src/exception/call_stack.cr
+++ b/src/exception/call_stack.cr
@@ -31,8 +31,11 @@ struct Exception::CallStack
   @callstack : Array(Void*)
   @backtrace : Array(String)?
 
-  def initialize
-    @callstack = CallStack.unwind
+  def initialize(@callstack : Array(Void*) = CallStack.unwind)
+  end
+
+  def self.empty
+    new([] of Void*)
   end
 
   def printable_backtrace : Array(String)


### PR DESCRIPTION
This is a follow-up on https://github.com/crystal-lang/crystal/pull/15002 which explicitly assigns a dummy callstack to `RetryLookupWithLiterals` for performance reasons.
`CallStack.empty` is intended to make this use case a bit more ergonomical. It doesn't require allocating a dummy instance with fake data. Instead, it's an explicitly empty callstack. This makes this mechanism easier to re-use in other places (ref https://github.com/crystal-lang/crystal/issues/11658#issuecomment-2352649774).