### PR TITLE
Error when trying to build aarch64 with LLVM 12 and below

### DIFF
--- a/src/compiler/crystal/compiler.cr
+++ b/src/compiler/crystal/compiler.cr
@@ -312,6 +312,13 @@ module Crystal
     end
 
     private def codegen(program, node : ASTNode, sources, output_filename)
+      {% if LibLLVM::IS_LT_130 %}
+        if @codegen_target.architecture == "aarch64"
+          stderr.puts "Error: Target #{@codegen_target} is unavailable with LLVM 12 or lower."
+          exit 1
+        end
+      {% end %}
+
       llvm_modules = @progress_tracker.stage("Codegen (crystal)") do
         program.codegen node, debug: debug, frame_pointers: frame_pointers,
           single_module: @single_module || @cross_compile || !@emit_targets.none?


### PR DESCRIPTION
Resolves  #11358

Code generation for aarch64 is broken with LLVM 12 and below. This patch makes the compiler refuse to generate this code.