### PR TITLE
Fix compiler artifact name in WindowsCI

### DIFF
--- a/.github/workflows/win.yml
+++ b/.github/workflows/win.yml
@@ -252,7 +252,7 @@ jobs:
       - name: Download Crystal executable
         uses: actions/download-artifact@v4
         with:
-          name: crystal-release
+          name: crystal
           path: build
 
       - name: Restore LLVM
@@ -294,7 +294,7 @@ jobs:
       - name: Download Crystal executable
         uses: actions/download-artifact@v4
         with:
-          name: crystal-release
+          name: crystal
           path: build
 
       - name: Restore LLVM
@@ -330,7 +330,7 @@ jobs:
       - name: Download Crystal executable
         uses: actions/download-artifact@v4
         with:
-          name: crystal-release
+          name: crystal
           path: etc/win-ci/portable
 
       - name: Restore LLVM

--- a/.github/workflows/win_build_portable.yml
+++ b/.github/workflows/win_build_portable.yml
@@ -145,5 +145,5 @@ jobs:
       - name: Upload Crystal binaries
         uses: actions/upload-artifact@v4
         with:
-          name: ${{ inputs.release && 'crystal-release' || 'crystal' }}
+          name: crystal
           path: crystal


### PR DESCRIPTION
Before https://github.com/crystal-lang/crystal/pull/15000 we had two different builds of the compiler in every CI run, a release build and a non-release. Now we only have a release build and there's no need to differentiate by name.
Going back to `crystal` makes the install-crystal action work again.

Resolves https://github.com/crystal-lang/install-crystal/issues/47