### PR TITLE
Cache `Exception::CallStack.empty` to avoid repeat `Array` allocation

### DIFF
--- a/src/exception/call_stack.cr
+++ b/src/exception/call_stack.cr
@@ -34,9 +34,7 @@ struct Exception::CallStack
   def initialize(@callstack : Array(Void*) = CallStack.unwind)
   end
 
-  def self.empty
-    new([] of Void*)
-  end
+  class_getter empty = new([] of Void*)
 
   def printable_backtrace : Array(String)
     @backtrace ||= decode_backtrace


### PR DESCRIPTION
Follow-up on #15017, addresses https://github.com/crystal-lang/crystal/pull/15017#issuecomment-2365167690