### PR TITLE
Update `DeallocationStack` for Windows context switch

### DIFF
--- a/src/fiber/context/x86_64-microsoft.cr
+++ b/src/fiber/context/x86_64-microsoft.cr
@@ -4,19 +4,20 @@ class Fiber
   # :nodoc:
   def makecontext(stack_ptr, fiber_main) : Nil
     # A great explanation on stack contexts for win32:
-    # https://cfsamson.gitbook.io/green-threads-explained-in-200-lines-of-rust/supporting-windows
+    # https://web.archive.org/web/20220527113808/https://cfsamson.gitbook.io/green-threads-explained-in-200-lines-of-rust/supporting-windows
 
-    # 8 registers + 2 qwords for NT_TIB + 1 parameter + 10 128bit XMM registers
-    @context.stack_top = (stack_ptr - (11 + 10*2)).as(Void*)
+    # 8 registers + 3 qwords for NT_TIB + 1 parameter + 10 128bit XMM registers
+    @context.stack_top = (stack_ptr - (12 + 10*2)).as(Void*)
     @context.resumable = 1
 
     stack_ptr[0] = fiber_main.pointer # %rbx: Initial `resume` will `ret` to this address
     stack_ptr[-1] = self.as(Void*)    # %rcx: puts `self` as first argument for `fiber_main`
 
-    # The following two values are stored in the Thread Information Block (NT_TIB)
+    # The following three values are stored in the Thread Information Block (NT_TIB)
     # and are used by Windows to track the current stack limits
-    stack_ptr[-2] = @stack        # %gs:0x10: Stack Limit
-    stack_ptr[-3] = @stack_bottom # %gs:0x08: Stack Base
+    stack_ptr[-2] = @stack        # %gs:0x1478: Win32 DeallocationStack
+    stack_ptr[-3] = @stack        # %gs:0x10: Stack Limit
+    stack_ptr[-4] = @stack_bottom # %gs:0x08: Stack Base
   end
 
   # :nodoc:
@@ -27,6 +28,7 @@ class Fiber
       #                %rcx           , %rdx
       asm("
           pushq %rcx
+          pushq %gs:0x1478  // Thread Information Block: Win32 DeallocationStack
           pushq %gs:0x10    // Thread Information Block: Stack Limit
           pushq %gs:0x08    // Thread Information Block: Stack Base
           pushq %rdi        // push 1st argument (because of initial resume)
@@ -73,6 +75,7 @@ class Fiber
           popq %rdi         // pop 1st argument (for initial resume)
           popq %gs:0x08
           popq %gs:0x10
+          popq %gs:0x1478
           popq %rcx
           ")
     {% else %}
@@ -80,6 +83,7 @@ class Fiber
       # instructions that breaks the context switching.
       asm("
           pushq %rcx
+          pushq %gs:0x1478  // Thread Information Block: Win32 DeallocationStack
           pushq %gs:0x10    // Thread Information Block: Stack Limit
           pushq %gs:0x08    // Thread Information Block: Stack Base
           pushq %rdi        // push 1st argument (because of initial resume)
@@ -126,6 +130,7 @@ class Fiber
           popq %rdi         // pop 1st argument (for initial resume)
           popq %gs:0x08
           popq %gs:0x10
+          popq %gs:0x1478
           popq %rcx
           " :: "r"(current_context), "r"(new_context))
     {% end %}


### PR DESCRIPTION
Calling `LibC.GetCurrentThreadStackLimits` outside the main fiber of a thread will continue to return the original stack top of that thread:

```crystal
LibC.GetCurrentThreadStackLimits(out low_limit, out high_limit)
low_limit  # => 86767566848
high_limit # => 86775955456

spawn do
  LibC.GetCurrentThreadStackLimits(out low_limit2, out high_limit2)
  low_limit2  # => 86767566848
  high_limit2 # => 1863570554880
end

sleep 1.second
```

This doesn't affect the Crystal runtime because the function is only called once to initialize the main thread, nor the GC because [it probes the stack top using `VirtualQuery`](https://github.com/ivmai/bdwgc/blob/39394464633d64131690b56fca7379924d9a5abe/win32_threads.c#L656-L672). It may nonetheless affect other external libraries because the bad stack will most certainly contain unmapped memory.

The correct way is to also update the [Win32-specific, non-NT `DeallocationStack` field](https://en.wikipedia.org/w/index.php?title=Win32_Thread_Information_Block&oldid=1194048970#Stack_information_stored_in_the_TIB), since this is the actual stack top that gets returned (see also [Wine's implementation](https://gitlab.winehq.org/wine/wine/-/blob/a4e77b33f6897d930261634c1b3ba5e4edc209f3/dlls/kernelbase/thread.c#L131-135)).