### PR TITLE
Add missing return type of `LibC.VirtualQuery`

### DIFF
--- a/src/crystal/system/win32/thread.cr
+++ b/src/crystal/system/win32/thread.cr
@@ -76,7 +76,9 @@ module Crystal::System::Thread
     {% else %}
       tib = LibC.NtCurrentTeb
       high_limit = tib.value.stackBase
-      LibC.VirtualQuery(tib.value.stackLimit, out mbi, sizeof(LibC::MEMORY_BASIC_INFORMATION))
+      if LibC.VirtualQuery(tib.value.stackLimit, out mbi, sizeof(LibC::MEMORY_BASIC_INFORMATION)) == 0
+        raise RuntimeError.from_winerror("VirtualQuery")
+      end
       low_limit = mbi.allocationBase
       low_limit
     {% end %}

--- a/src/lib_c/x86_64-windows-msvc/c/memoryapi.cr
+++ b/src/lib_c/x86_64-windows-msvc/c/memoryapi.cr
@@ -11,5 +11,5 @@ lib LibC
 
   fun VirtualFree(lpAddress : Void*, dwSize : SizeT, dwFreeType : DWORD) : BOOL
   fun VirtualProtect(lpAddress : Void*, dwSize : SizeT, flNewProtect : DWORD, lpfOldProtect : DWORD*) : BOOL
-  fun VirtualQuery(lpAddress : Void*, lpBuffer : MEMORY_BASIC_INFORMATION*, dwLength : SizeT)
+  fun VirtualQuery(lpAddress : Void*, lpBuffer : MEMORY_BASIC_INFORMATION*, dwLength : SizeT) : SizeT
 end


### PR DESCRIPTION
This function is only used when `-Dwin7` is specified and its return value was unused.