### PR TITLE
Fix race condition in `pthread_create` handle initialization

### DIFF
--- a/spec/std/thread/condition_variable_spec.cr
+++ b/spec/std/thread/condition_variable_spec.cr
@@ -1,11 +1,3 @@
-{% if flag?(:musl) %}
-  # FIXME: These thread specs occasionally fail on musl/alpine based ci, so
-  # they're disabled for now to reduce noise.
-  # See https://github.com/crystal-lang/crystal/issues/8738
-  pending Thread::ConditionVariable
-  {% skip_file %}
-{% end %}
-
 require "../spec_helper"
 
 # interpreter doesn't support threads yet (#14287)

--- a/spec/std/thread/mutex_spec.cr
+++ b/spec/std/thread/mutex_spec.cr
@@ -1,11 +1,3 @@
-{% if flag?(:musl) %}
-  # FIXME: These thread specs occasionally fail on musl/alpine based ci, so
-  # they're disabled for now to reduce noise.
-  # See https://github.com/crystal-lang/crystal/issues/8738
-  pending Thread::Mutex
-  {% skip_file %}
-{% end %}
-
 require "../spec_helper"
 
 # interpreter doesn't support threads yet (#14287)

--- a/spec/std/thread_spec.cr
+++ b/spec/std/thread_spec.cr
@@ -1,13 +1,5 @@
 require "./spec_helper"
 
-{% if flag?(:musl) %}
-  # FIXME: These thread specs occasionally fail on musl/alpine based ci, so
-  # they're disabled for now to reduce noise.
-  # See https://github.com/crystal-lang/crystal/issues/8738
-  pending Thread
-  {% skip_file %}
-{% end %}
-
 # interpreter doesn't support threads yet (#14287)
 pending_interpreted describe: Thread do
   it "allows passing an argumentless fun to execute" do


### PR DESCRIPTION
Fixes #8738. You could run `bin/crystal build spec/std/thread_spec.cr spec/std/thread/* && while ./thread_spec; do :; done` to assure yourself that it doesn't crash anymore.