### PR TITLE
Increase memory for stdlib CI runners from runs-on to 16GB

### DIFF
--- a/.github/workflows/aarch64.yml
+++ b/.github/workflows/aarch64.yml
@@ -26,7 +26,7 @@ jobs:
             src/llvm/ext/llvm_ext.o
   aarch64-musl-test-stdlib:
     needs: aarch64-musl-build
-    runs-on: [runs-on, runner=2cpu-linux-arm64, "family=m7g", ram=8, "run-id=${{ github.run_id }}"]
+    runs-on: [runs-on, runner=4cpu-linux-arm64, "family=m7g", ram=16, "run-id=${{ github.run_id }}"]
     if: github.repository == 'crystal-lang/crystal'
     steps:
       - name: Download Crystal source
@@ -77,7 +77,7 @@ jobs:
             src/llvm/ext/llvm_ext.o
   aarch64-gnu-test-stdlib:
     needs: aarch64-gnu-build
-    runs-on: [runs-on, runner=2cpu-linux-arm64, "family=m7g", ram=8, "run-id=${{ github.run_id }}"]
+    runs-on: [runs-on, runner=4cpu-linux-arm64, "family=m7g", ram=16, "run-id=${{ github.run_id }}"]
     if: github.repository == 'crystal-lang/crystal'
     steps:
       - name: Download Crystal source


### PR DESCRIPTION
#15030 reduced the runner instances for all CI jobs to machines with 8GB. This looked fine at first, but the `test-stdlib` jobs have been unstable since merging. This patch increases runners to bigger instances with more memory to bring stability.