### PR TITLE
Add getters for option in InvalidOption and MissingOption classes

### DIFF
--- a/src/option_parser.cr
+++ b/src/option_parser.cr
@@ -85,12 +85,16 @@ class OptionParser
   end
 
   class InvalidOption < Exception
+    getter option
+
     def initialize(option)
       super("Invalid option: #{option}")
     end
   end
 
   class MissingOption < Exception
+    getter option
+
     def initialize(option)
       super("Missing option: #{option}")
     end


### PR DESCRIPTION
Hi all
When an error occurs in OptionParser, I would like to be able to catch which option caused the error. 
Could it be changed this way?