### PR TITLE
Fix copy-paste-typo in spec describe

### DIFF
--- a/spec/compiler/crystal/tools/doc/type_spec.cr
+++ b/spec/compiler/crystal/tools/doc/type_spec.cr
@@ -312,7 +312,7 @@ describe Doc::Type do
     end
   end
 
-  describe "#included_modules" do
+  describe "#extended_modules" do
     it "only include types with docs" do
       program = semantic(<<-CRYSTAL, wants_doc: true).program
         # :nodoc:


### PR DESCRIPTION
When looking into #15053 i found a copy-paste-typo in a spec describe.