### PR TITLE
Implement `codecov` format for `unreachable` tool

### DIFF
--- a/src/compiler/crystal/tools/unreachable.cr
+++ b/src/compiler/crystal/tools/unreachable.cr
@@ -6,7 +6,7 @@ require "csv"
 module Crystal
   class Command
     private def unreachable
-      config, result = compile_no_codegen "tool unreachable", path_filter: true, unreachable_command: true, allowed_formats: %w[text json csv]
+      config, result = compile_no_codegen "tool unreachable", path_filter: true, unreachable_command: true, allowed_formats: %w[text json csv codecov]
 
       unreachable = UnreachableVisitor.new
 
@@ -42,6 +42,8 @@ module Crystal
         to_json(STDOUT)
       when "csv"
         to_csv(STDOUT)
+      when "codecov"
+        to_codecov(STDOUT)
       else
         to_text(STDOUT)
       end
@@ -107,6 +109,31 @@ module Crystal
             row << location.column_number
             row << a_def.length
             row << a_def.all_annotations.try(&.join(" "))
+          end
+        end
+      end
+    end
+
+    # https://docs.codecov.com/docs/codecov-custom-coverage-format
+    def to_codecov(io)
+      hits = Hash(String, Hash(Int32, Int32)).new { |hash, key| hash[key] = Hash(Int32, Int32).new(0) }
+
+      each do |a_def, location, count|
+        hits[location.filename][location.line_number] = count
+      end
+
+      JSON.build io do |builder|
+        builder.object do
+          builder.string "coverage"
+          builder.object do
+            hits.each do |filename, line_coverage|
+              builder.string filename
+              builder.object do
+                line_coverage.each do |line, count|
+                  builder.field line, count
+                end
+              end
+            end
           end
         end
       end


### PR DESCRIPTION
Resolves #15058

I ended up only marking the method definition line as missed. Primarily because it's not clear how many lines of the method are actually executable. This'll still get the job done, but without bloating the report with mostly useless information without actually running the method itself to know what lines would and would not be executed.

Open to ideas on how to best add test coverage to this. But for now here's an example from one of the Athena components:

```sh
$ ccrystal tool unreachable coverage/bin/image_size.cr --format=codecov | oq .
Using compiled compiler at /home/george/dev/git/crystal/.build/crystal
{
  "coverage": {
    "src/components/image_size/spec/athena-image_size_spec.cr": {
      "49": 0,
      "108": 0,
      "142": 0
    },
    "src/components/image_size/src/extractors/extractor.cr": {
      "2": 0
    },
    "src/components/image_size/src/image.cr": {
      "68": 0
    }
  }
}
```

And with `--tallies`:
```json
{
  "coverage": {
    "src/components/image_size/spec/athena-image_size_spec.cr": {
      "5": 1,
      "27": 1,
      "39": 1,
      "49": 0,
      "67": 1,
      "88": 1,
      "108": 0,
      "120": 1,
      "130": 1,
      "142": 0,
      "160": 1,
      "180": 2
    },
    "src/components/image_size/src/extractors/abstract_ico.cr": {
      "4": 2
    },
    "src/components/image_size/src/extractors/abstract_png.cr": {
      "7": 2,
      "37": 2
    },
    "src/components/image_size/src/extractors/abstract_tiff.cr": {
      "25": 2
    },
    "src/components/image_size/src/extractors/bmp.cr": {
      "6": 2,
      "32": 1
    },
    "src/components/image_size/src/extractors/cur.cr": {
      "4": 1,
      "8": 1
    },
    "src/components/image_size/src/extractors/extractor.cr": {
      "2": 0,
      "4": 2
    },
    "src/components/image_size/src/extractors/gif.cr": {
      "5": 2,
      "19": 1
    },
    "src/components/image_size/src/extractors/ico.cr": {
      "4": 1,
      "8": 1
    },
    "src/components/image_size/src/extractors/ii_tiff.cr": {
      "4": 1,
      "8": 9
    },
    "src/components/image_size/src/extractors/jpeg.cr": {
      "40": 2,
      "83": 1,
      "87": 1,
      "118": 3
    },
    "src/components/image_size/src/extractors/mm_tiff.cr": {
      "4": 1,
      "8": 9
    },
    "src/components/image_size/src/extractors/mng.cr": {
      "4": 2,
      "15": 1
    },
    "src/components/image_size/src/extractors/psd.cr": {
      "4": 2,
      "15": 1
    },
    "src/components/image_size/src/extractors/svg.cr": {
      "6": 2,
      "32": 1,
      "38": 2
    },
    "src/components/image_size/src/extractors/swf.cr": {
      "4": 2,
      "17": 1,
      "21": 5
    },
    "src/components/image_size/src/extractors/webp.cr": {
      "13": 2,
      "42": 1
    },
    "src/components/image_size/src/image.cr": {
      "28": 21,
      "37": 3,
      "43": 1,
      "49": 4,
      "59": 2,
      "68": 0
    }
  }
}
```

Only thing I'm not sure about is if the file needs to be absolute or relative. I created https://github.com/codecov/feedback/discussions/530 to get some clarity on that.