### PR TITLE
Add `Socket::Address.from` without `addrlen`

### DIFF
--- a/spec/std/socket/address_spec.cr
+++ b/spec/std/socket/address_spec.cr
@@ -51,6 +51,7 @@ describe Socket::IPAddress do
     addr2.port.should eq(addr1.port)
     typeof(addr2.address).should eq(String)
     addr2.address.should eq(addr1.address)
+    addr2.should eq(Socket::IPAddress.from(addr1_c))
   end
 
   it "transforms an IPv6 address into a C struct and back" do
@@ -64,6 +65,7 @@ describe Socket::IPAddress do
     addr2.port.should eq(addr1.port)
     typeof(addr2.address).should eq(String)
     addr2.address.should eq(addr1.address)
+    addr2.should eq(Socket::IPAddress.from(addr1_c))
   end
 
   it "won't resolve domains" do
@@ -431,6 +433,7 @@ end
       addr2.family.should eq(addr1.family)
       addr2.path.should eq(addr1.path)
       addr2.to_s.should eq(path)
+      addr2 = Socket::UNIXAddress.from(addr1.to_unsafe)
     end
 
     it "raises when path is too long" do

--- a/src/socket/address.cr
+++ b/src/socket/address.cr
@@ -21,6 +21,26 @@ class Socket
       end
     end
 
+    # :ditto:
+    def self.from(sockaddr : LibC::Sockaddr*) : Address
+      case family = Family.new(sockaddr.value.sa_family)
+      when Family::INET6
+        sockaddr = sockaddr.as(LibC::SockaddrIn6*)
+
+        IPAddress.new(sockaddr, sizeof(typeof(sockaddr)))
+      when Family::INET
+        sockaddr = sockaddr.as(LibC::SockaddrIn*)
+
+        IPAddress.new(sockaddr, sizeof(typeof(sockaddr)))
+      when Family::UNIX
+        sockaddr = sockaddr.as(LibC::SockaddrUn*)
+
+        UNIXAddress.new(sockaddr, sizeof(typeof(sockaddr)))
+      else
+        raise "Unsupported family type: #{family} (#{family.value})"
+      end
+    end
+
     # Parses a `Socket::Address` from an URI.
     #
     # Supported formats:
@@ -108,6 +128,22 @@ class Socket
         new(sockaddr.as(LibC::SockaddrIn6*), addrlen.to_i)
       when Family::INET
         new(sockaddr.as(LibC::SockaddrIn*), addrlen.to_i)
+      else
+        raise "Unsupported family type: #{family} (#{family.value})"
+      end
+    end
+
+    # :ditto:
+    def self.from(sockaddr : LibC::Sockaddr*) : IPAddress
+      case family = Family.new(sockaddr.value.sa_family)
+      when Family::INET6
+        sockaddr = sockaddr.as(LibC::SockaddrIn6*)
+
+        new(sockaddr, sizeof(typeof(sockaddr)))
+      when Family::INET
+        sockaddr = sockaddr.as(LibC::SockaddrIn*)
+
+        new(sockaddr, sizeof(typeof(sockaddr)))
       else
         raise "Unsupported family type: #{family} (#{family.value})"
       end
@@ -747,6 +783,17 @@ class Socket
         raise NotImplementedError.new "Socket::UNIXAddress.from"
       {% else %}
         new(sockaddr.as(LibC::SockaddrUn*), addrlen.to_i)
+      {% end %}
+    end
+
+    # :ditto:
+    def self.from(sockaddr : LibC::Sockaddr*) : UNIXAddress
+      {% if flag?(:wasm32) %}
+        raise NotImplementedError.new "Socket::UNIXAddress.from"
+      {% else %}
+        sockaddr = sockaddr.as(LibC::SockaddrUn*)
+
+        new(sockaddr, sizeof(typeof(sockaddr)))
       {% end %}
     end
 


### PR DESCRIPTION
I'm not sure why this was implemented this way. The `addlen` parameter is not necessary when creating an address from a `LibC::Sockaddr` pointer, as it can be obtained directly within the method.