### PR TITLE
Fix `TopLevelVisitor` adding existing `ClassDef` type to current scope

### DIFF
--- a/spec/compiler/semantic/alias_spec.cr
+++ b/spec/compiler/semantic/alias_spec.cr
@@ -178,6 +178,22 @@ describe "Semantic: alias" do
         Bar.bar
         )) { int32 }
     end
+
+    it "reopens #{type} through alias within itself" do
+      assert_type <<-CRYSTAL { int32 }
+        #{type} Foo
+          alias Bar = Foo
+
+          #{type} Bar
+            def self.bar
+              1
+            end
+          end
+        end
+
+        Foo.bar
+        CRYSTAL
+    end
   end
 
   %w(class struct).each do |type|

--- a/src/compiler/crystal/semantic/top_level_visitor.cr
+++ b/src/compiler/crystal/semantic/top_level_visitor.cr
@@ -193,9 +193,9 @@ class Crystal::TopLevelVisitor < Crystal::SemanticVisitor
       if superclass.is_a?(GenericClassInstanceType)
         superclass.generic_type.add_subclass(type)
       end
+      scope.types[name] = type
     end
 
-    scope.types[name] = type
     node.resolved_type = type
 
     process_annotations(annotations) do |annotation_type, ann|


### PR DESCRIPTION
When a type is reopened, the compiler adds it as nested type to the current scope (i.e. where it's reopened). That's wrong because the reopened type is already scoped to the location of the original location and this could lead to cycles.

For example, the following program would crash the compiler with an infinite recursion:
```cr
class Foo
  alias Bar = Foo

  class Bar
  end
end
```

This fix makes sure to only add newly defined types to the current scope, not reopened ones. All other visitor methods which defined types already do this, only `ClassDef` was unconditionally adding to the current scope.