### PR TITLE
Drop the static LLVM libraries on Windows CI

### DIFF
--- a/.github/workflows/win.yml
+++ b/.github/workflows/win.yml
@@ -238,14 +238,15 @@ jobs:
       - name: Restore LLVM
         uses: actions/cache/restore@v4
         with:
-          path: llvm
-          key: llvm-libs-${{ env.CI_LLVM_VERSION }}-msvc
+          path: llvm-config.exe
+          key: llvm-dlls-${{ inputs.llvm_version }}-${{ hashFiles('etc/win-ci/build-llvm.ps1') }}-msvc
           fail-on-cache-miss: true
 
       - name: Set up environment
         run: |
           Add-Content $env:GITHUB_PATH "$(pwd)\build"
           Add-Content $env:GITHUB_ENV "CRYSTAL_SPEC_COMPILER_BIN=$(pwd)\build\crystal.exe"
+          Add-Content $env:GITHUB_ENV "LLVM_CONFIG=$(pwd)\llvm-config.exe"
 
       - name: Run stdlib specs
         run: make -f Makefile.win std_spec
@@ -279,8 +280,8 @@ jobs:
       - name: Restore LLVM
         uses: actions/cache/restore@v4
         with:
-          path: llvm
-          key: llvm-libs-${{ env.CI_LLVM_VERSION }}-msvc
+          path: llvm-config.exe
+          key: llvm-dlls-${{ inputs.llvm_version }}-${{ hashFiles('etc/win-ci/build-llvm.ps1') }}-msvc
           fail-on-cache-miss: true
 
       - name: Set up environment
@@ -315,13 +316,14 @@ jobs:
       - name: Restore LLVM
         uses: actions/cache/restore@v4
         with:
-          path: llvm
-          key: llvm-libs-${{ env.CI_LLVM_VERSION }}-msvc
+          path: llvm-config.exe
+          key: llvm-dlls-${{ inputs.llvm_version }}-${{ hashFiles('etc/win-ci/build-llvm.ps1') }}-msvc
           fail-on-cache-miss: true
 
       - name: Set up environment
         run: |
           Add-Content $env:GITHUB_PATH "$(pwd)\etc\win-ci\portable"
+          Add-Content $env:GITHUB_ENV "LLVM_CONFIG=$(pwd)\llvm-config.exe"
 
       - name: Build docs
         run: make -f Makefile.win install_docs prefix=etc\win-ci\portable

--- a/.github/workflows/win.yml
+++ b/.github/workflows/win.yml
@@ -196,14 +196,17 @@ jobs:
         id: cache-llvm-dlls
         uses: actions/cache@v4
         with:
-          path: |
+          path: | # llvm-config is needed on CI only and not distributed
             libs/llvm_VERSION
             libs/llvm-dynamic.lib
             dlls/LLVM-C.dll
+            llvm-config.exe
           key: llvm-dlls-${{ env.CI_LLVM_VERSION }}-${{ hashFiles('etc/win-ci/build-llvm.ps1') }}-msvc
       - name: Build LLVM
         if: steps.cache-llvm-dlls.outputs.cache-hit != 'true'
-        run: .\etc\win-ci\build-llvm.ps1 -BuildTree deps\llvm -Version ${{ env.CI_LLVM_VERSION }} -TargetsToBuild X86,AArch64 -Dynamic
+        run: |
+          .\etc\win-ci\build-llvm.ps1 -BuildTree deps\llvm -Version ${{ env.CI_LLVM_VERSION }} -TargetsToBuild X86,AArch64 -Dynamic
+          cp deps\llvm\build\Release\bin\llvm-config.exe .
 
   x86_64-windows-release:
     needs: [x86_64-windows-libs, x86_64-windows-dlls, x86_64-windows-llvm-dlls]

--- a/.github/workflows/win.yml
+++ b/.github/workflows/win.yml
@@ -239,7 +239,7 @@ jobs:
         uses: actions/cache/restore@v4
         with:
           path: llvm-config.exe
-          key: llvm-dlls-${{ inputs.llvm_version }}-${{ hashFiles('etc/win-ci/build-llvm.ps1') }}-msvc
+          key: llvm-dlls-${{ env.CI_LLVM_VERSION }}-${{ hashFiles('etc/win-ci/build-llvm.ps1') }}-msvc
           fail-on-cache-miss: true
 
       - name: Set up environment
@@ -281,7 +281,7 @@ jobs:
         uses: actions/cache/restore@v4
         with:
           path: llvm-config.exe
-          key: llvm-dlls-${{ inputs.llvm_version }}-${{ hashFiles('etc/win-ci/build-llvm.ps1') }}-msvc
+          key: llvm-dlls-${{ env.CI_LLVM_VERSION }}-${{ hashFiles('etc/win-ci/build-llvm.ps1') }}-msvc
           fail-on-cache-miss: true
 
       - name: Set up environment
@@ -317,7 +317,7 @@ jobs:
         uses: actions/cache/restore@v4
         with:
           path: llvm-config.exe
-          key: llvm-dlls-${{ inputs.llvm_version }}-${{ hashFiles('etc/win-ci/build-llvm.ps1') }}-msvc
+          key: llvm-dlls-${{ env.CI_LLVM_VERSION }}-${{ hashFiles('etc/win-ci/build-llvm.ps1') }}-msvc
           fail-on-cache-miss: true
 
       - name: Set up environment

--- a/.github/workflows/win.yml
+++ b/.github/workflows/win.yml
@@ -179,29 +179,6 @@ jobs:
         if: steps.cache-openssl-dlls.outputs.cache-hit != 'true'
         run: .\etc\win-ci\build-openssl.ps1 -BuildTree deps\openssl -Version 3.1.0 -Dynamic
 
-  x86_64-windows-llvm-libs:
-    runs-on: windows-2022
-    steps:
-      - name: Enable Developer Command Prompt
-        uses: ilammy/msvc-dev-cmd@0b201ec74fa43914dc39ae48a89fd1d8cb592756 # v1.13.0
-
-      - name: Cache LLVM
-        id: cache-llvm-libs
-        uses: actions/cache@v4
-        with:
-          path: llvm
-          key: llvm-libs-${{ env.CI_LLVM_VERSION }}-msvc
-
-      - name: Build LLVM
-        if: steps.cache-llvm-libs.outputs.cache-hit != 'true'
-        run: |
-          git clone --config core.autocrlf=false -b llvmorg-${{ env.CI_LLVM_VERSION }} --depth 1 https://github.com/llvm/llvm-project.git
-          mkdir llvm-build
-          cd llvm-build
-          cmake ..\llvm-project\llvm -Thost=x64 -DLLVM_TARGETS_TO_BUILD="X86;AArch64" -DCMAKE_MSVC_RUNTIME_LIBRARY=MultiThreaded -DBUILD_SHARED_LIBS=OFF -DCMAKE_FIND_USE_SYSTEM_ENVIRONMENT_PATH=OFF -DLLVM_INCLUDE_BENCHMARKS=OFF -DLLVM_INCLUDE_TESTS=OFF -DLLVM_ENABLE_ZSTD=OFF
-          cmake --build . --config Release
-          cmake "-DCMAKE_INSTALL_PREFIX=$(pwd)\..\llvm" -P cmake_install.cmake
-
   x86_64-windows-llvm-dlls:
     runs-on: windows-2022
     steps:
@@ -229,7 +206,7 @@ jobs:
         run: .\etc\win-ci\build-llvm.ps1 -BuildTree deps\llvm -Version ${{ env.CI_LLVM_VERSION }} -TargetsToBuild X86,AArch64 -Dynamic
 
   x86_64-windows-release:
-    needs: [x86_64-windows-libs, x86_64-windows-dlls, x86_64-windows-llvm-libs, x86_64-windows-llvm-dlls]
+    needs: [x86_64-windows-libs, x86_64-windows-dlls, x86_64-windows-llvm-dlls]
     uses: ./.github/workflows/win_build_portable.yml
     with:
       release: true
@@ -266,7 +243,6 @@ jobs:
         run: |
           Add-Content $env:GITHUB_PATH "$(pwd)\build"
           Add-Content $env:GITHUB_ENV "CRYSTAL_SPEC_COMPILER_BIN=$(pwd)\build\crystal.exe"
-          Add-Content $env:GITHUB_ENV "LLVM_CONFIG=$(pwd)\llvm\bin\llvm-config.exe"
 
       - name: Run stdlib specs
         run: make -f Makefile.win std_spec
@@ -343,7 +319,6 @@ jobs:
       - name: Set up environment
         run: |
           Add-Content $env:GITHUB_PATH "$(pwd)\etc\win-ci\portable"
-          Add-Content $env:GITHUB_ENV "LLVM_CONFIG=$(pwd)\llvm\bin\llvm-config.exe"
 
       - name: Build docs
         run: make -f Makefile.win install_docs prefix=etc\win-ci\portable

--- a/.github/workflows/win_build_portable.yml
+++ b/.github/workflows/win_build_portable.yml
@@ -107,7 +107,6 @@ jobs:
       - name: Set up environment
         run: |
           echo "CRYSTAL_LIBRARY_PATH=$(pwd)\libs" >> ${env:GITHUB_ENV}
-          echo "LLVM_CONFIG=$(pwd)\llvm\bin\llvm-config.exe" >> ${env:GITHUB_ENV}
           # NOTE: the name of the libiconv DLL has changed, so we manually copy
           # the new one to the existing Crystal installation; remove after
           # updating the base compiler to 1.14

--- a/.github/workflows/win_build_portable.yml
+++ b/.github/workflows/win_build_portable.yml
@@ -101,12 +101,14 @@ jobs:
             libs/llvm_VERSION
             libs/llvm-dynamic.lib
             dlls/LLVM-C.dll
+            llvm-config.exe
           key: llvm-dlls-${{ inputs.llvm_version }}-${{ hashFiles('etc/win-ci/build-llvm.ps1') }}-msvc
           fail-on-cache-miss: true
 
       - name: Set up environment
         run: |
           echo "CRYSTAL_LIBRARY_PATH=$(pwd)\libs" >> ${env:GITHUB_ENV}
+          echo "LLVM_CONFIG=$(pwd)\llvm-config.exe" >> ${env:GITHUB_ENV}
           # NOTE: the name of the libiconv DLL has changed, so we manually copy
           # the new one to the existing Crystal installation; remove after
           # updating the base compiler to 1.14

--- a/.github/workflows/win_build_portable.yml
+++ b/.github/workflows/win_build_portable.yml
@@ -88,12 +88,6 @@ jobs:
             dlls/libssl-3-x64.dll
           key: win-openssl-dlls-3.1.0-${{ hashFiles('etc/win-ci/build-openssl.ps1') }}-msvc
           fail-on-cache-miss: true
-      - name: Restore LLVM
-        uses: actions/cache/restore@v4
-        with:
-          path: llvm
-          key: llvm-libs-${{ inputs.llvm_version }}-msvc
-          fail-on-cache-miss: true
       - name: Restore LLVM DLLs
         uses: actions/cache/restore@v4
         with:


### PR DESCRIPTION
These are no longer needed, because `LLVM-C.dll` is completely sufficient, and because nothing gets copied to the release packages.