### PR TITLE
Fix `find-llvm-config` to ignore `LLVM_CONFIG`'s escape sequences

### DIFF
--- a/src/llvm/ext/find-llvm-config
+++ b/src/llvm/ext/find-llvm-config
@@ -16,7 +16,7 @@ if ! LLVM_CONFIG=$(command -v "$LLVM_CONFIG"); then
 fi
 
 if [ "$LLVM_CONFIG" ]; then
-  printf "$LLVM_CONFIG"
+  printf %s "$LLVM_CONFIG"
 else
   printf "Error: Could not find location of llvm-config. Please specify path in environment variable LLVM_CONFIG.\n" >&2
   printf "Supported LLVM versions: $(cat "$(dirname $0)/llvm-versions.txt" | sed 's/\.0//g')\n" >&2


### PR DESCRIPTION
If the `LLVM_CONFIG` environment variable is already set and points to a valid executable, percent signs and backslashes will be specially interpreted according to `printf`'s rules. This is most likely to happen on MSYS2, since the Windows host might have set `LLVM_CONFIG` to support static LLVM builds:

```sh
$ LLVM_CONFIG='C:\Users\nicet\llvm\18\bin\llvm-config.exe' src/llvm/ext/find-llvm-config
src/llvm/ext/find-llvm-config: line 19: printf: missing unicode digit for \U
C:\Users
icet\llvmin\llvm-config.exe
```

This PR ensures that doesn't happen.