### PR TITLE
Fix various typos

### DIFF
--- a/spec/std/http/request_spec.cr
+++ b/spec/std/http/request_spec.cr
@@ -454,7 +454,7 @@ module HTTP
         request.form_params["test"].should eq("foobar")
       end
 
-      it "returns ignors invalid content-type" do
+      it "ignores invalid content-type" do
         request = Request.new("POST", "/form", nil, HTTP::Params.encode({"test" => "foobar"}))
         request.form_params?.should eq(nil)
         request.form_params.size.should eq(0)

--- a/spec/std/io/delimited_spec.cr
+++ b/spec/std/io/delimited_spec.cr
@@ -259,7 +259,7 @@ describe "IO::Delimited" do
         io.gets_to_end.should eq("hello")
       end
 
-      it "handles the case of peek matching first byte, not having enough room, but later not matching (limted slice)" do
+      it "handles the case of peek matching first byte, not having enough room, but later not matching (limited slice)" do
         #                                 not a delimiter
         #                                    ---
         io = MemoryIOWithFixedPeek.new("abcdefgwijkfghhello")

--- a/spec/std/regex_spec.cr
+++ b/spec/std/regex_spec.cr
@@ -433,7 +433,7 @@ describe "Regex" do
       })
     end
 
-    it "alpanumeric" do
+    it "alphanumeric" do
       /(?<f1>)/.name_table.should eq({1 => "f1"})
     end
 

--- a/spec/std/time/span_spec.cr
+++ b/spec/std/time/span_spec.cr
@@ -360,7 +360,7 @@ describe Time::Span do
     1.1.weeks.should eq(7.7.days)
   end
 
-  it "can substract big amount using microseconds" do
+  it "can subtract big amount using microseconds" do
     jan_1_2k = Time.utc(2000, 1, 1)
     past = Time.utc(5, 2, 3, 0, 0, 0)
     delta = (past - jan_1_2k).total_microseconds.to_i64
@@ -368,7 +368,7 @@ describe Time::Span do
     past2.should eq(past)
   end
 
-  it "can substract big amount using milliseconds" do
+  it "can subtract big amount using milliseconds" do
     jan_1_2k = Time.utc(2000, 1, 1)
     past = Time.utc(5, 2, 3, 0, 0, 0)
     delta = (past - jan_1_2k).total_milliseconds.to_i64

--- a/spec/std/yaml/serializable_spec.cr
+++ b/spec/std/yaml/serializable_spec.cr
@@ -1001,7 +1001,7 @@ describe "YAML::Serializable" do
         yaml = YAMLAttrWithPresenceAndIgnoreSerialize.from_yaml(%({"last_name": null}))
         yaml.last_name_present?.should be_true
 
-        # libyaml 0.2.5 removes traling space for empty scalar nodes
+        # libyaml 0.2.5 removes trailing space for empty scalar nodes
         if YAML.libyaml_version >= SemanticVersion.new(0, 2, 5)
           yaml.to_yaml.should eq("---\nlast_name:\n")
         else

--- a/src/channel/select.cr
+++ b/src/channel/select.cr
@@ -142,7 +142,7 @@ class Channel(T)
 
   private def self.each_skip_duplicates(ops_locks, &)
     # Avoid deadlocks from trying to lock the same lock twice.
-    # `ops_lock` is sorted by `lock_object_id`, so identical onces will be in
+    # `ops_lock` is sorted by `lock_object_id`, so identical ones will be in
     # a row and we skip repeats while iterating.
     last_lock_id = nil
     ops_locks.each do |op|

--- a/src/compiler/crystal/types.cr
+++ b/src/compiler/crystal/types.cr
@@ -1389,10 +1389,10 @@ module Crystal
       # Float64 mantissa has 52 bits
       case kind
       when .i8?, .u8?, .i16?, .u16?
-        # Less than 23 bits, so convertable to Float32 and Float64 without precision loss
+        # Less than 23 bits, so convertible to Float32 and Float64 without precision loss
         true
       when .i32?, .u32?
-        # Less than 52 bits, so convertable to Float64 without precision loss
+        # Less than 52 bits, so convertible to Float64 without precision loss
         other_type.kind.f64?
       else
         false

--- a/src/crystal/system/win32/event_loop_iocp.cr
+++ b/src/crystal/system/win32/event_loop_iocp.cr
@@ -76,7 +76,7 @@ class Crystal::IOCP::EventLoop < Crystal::EventLoop
 
       # Wait for completion timed out but it may have been interrupted or we ask
       # for immediate timeout (nonblocking), so we check for the next event
-      # readyness again:
+      # readiness again:
       return false if next_event.wake_at > Time.monotonic
     end
 

--- a/src/docs_pseudo_methods.cr
+++ b/src/docs_pseudo_methods.cr
@@ -227,6 +227,6 @@ end
 struct CRYSTAL_PSEUDO__NoReturn
 end
 
-# Similar in usage to `Nil`. `Void` is prefered for C lib bindings.
+# Similar in usage to `Nil`. `Void` is preferred for C lib bindings.
 struct CRYSTAL_PSEUDO__Void
 end

--- a/src/file.cr
+++ b/src/file.cr
@@ -165,7 +165,7 @@ class File < IO::FileDescriptor
   # *blocking* must be set to `false` on POSIX targets when the file to open
   # isn't a regular file but a character device (e.g. `/dev/tty`) or fifo. These
   # files depend on another process or thread to also be reading or writing, and
-  # system event queues will properly report readyness.
+  # system event queues will properly report readiness.
   #
   # *blocking* may also be set to `nil` in which case the blocking or
   # non-blocking flag will be determined automatically, at the expense of an

--- a/src/gc/none.cr
+++ b/src/gc/none.cr
@@ -154,7 +154,7 @@ module GC
   # will block until it can acquire the lock).
   #
   # In both cases there can't be a deadlock since we won't suspend another
-  # thread until it has successfuly added (or removed) itself to (from) the
+  # thread until it has successfully added (or removed) itself to (from) the
   # linked list and released the lock, and the other thread won't progress until
   # it can add (or remove) itself from the list.
   #


### PR DESCRIPTION
"At least I can fix typos", kojix2 said.
One-liner for finding typos

```sh
fd -E 'lib/*' -e cr \
  | typos --format brief --color always --file-list - \
  | ruby -e 'puts ARGF.readlines.sort_by{|l| l[/`.*?`/].size}'
```