### PR TITLE
Improve man and shell completion for tools

### DIFF
--- a/etc/completion.bash
+++ b/etc/completion.bash
@@ -66,7 +66,7 @@ _crystal()
                 _crystal_compgen_options "${opts}" "${cur}"
             else
                 if [[ "${prev}" == "tool" ]] ; then
-                    local subcommands="context expand flags format hierarchy dependencies implementations unreachable types"
+                    local subcommands="context dependencies expand flags format hierarchy implementations types unreachable"
                     _crystal_compgen_options "${subcommands}" "${cur}"
                 else
                     _crystal_compgen_sources "${cur}"

--- a/etc/completion.bash
+++ b/etc/completion.bash
@@ -66,7 +66,7 @@ _crystal()
                 _crystal_compgen_options "${opts}" "${cur}"
             else
                 if [[ "${prev}" == "tool" ]] ; then
-                    local subcommands="context dependencies flags format hierarchy implementations types"
+                    local subcommands="context expand flags format hierarchy dependencies implementations unreachable types"
                     _crystal_compgen_options "${subcommands}" "${cur}"
                 else
                     _crystal_compgen_sources "${cur}"

--- a/etc/completion.fish
+++ b/etc/completion.fish
@@ -1,5 +1,5 @@
 set -l crystal_commands init build clear_cache docs env eval i interactive play run spec tool help version
-set -l tool_subcommands context expand flags format hierarchy implementations types
+set -l tool_subcommands context expand flags format hierarchy dependencies implementations unreachable types
 
 complete -c crystal -s h -l help -d "Show help" -x
 
@@ -205,6 +205,21 @@ complete -c crystal -n "__fish_seen_subcommand_from implementations" -s s -l sta
 complete -c crystal -n "__fish_seen_subcommand_from implementations" -s p -l progress -d "Enable progress output"
 complete -c crystal -n "__fish_seen_subcommand_from implementations" -s t -l time -d "Enable execution time output"
 complete -c crystal -n "__fish_seen_subcommand_from implementations" -l stdin-filename -d "Source file name to be read from STDIN"
+
+complete -c crystal -n "__fish_seen_subcommand_from tool; and not __fish_seen_subcommand_from $tool_subcommands" -a "unreachable" -d "show methods that are never called" -x
+complete -c crystal -n "__fish_seen_subcommand_from unreachable" -s D -l define -d "Define a compile-time flag"
+complete -c crystal -n "__fish_seen_subcommand_from unreachable" -s f -l format -d "Output format text (default), json, csv, codecov" -a "text json csv codecov" -f
+complete -c crystal -n "__fish_seen_subcommand_from unreachable" -l tallies -d "Print reachable methods and their call counts as well"
+complete -c crystal -n "__fish_seen_subcommand_from unreachable" -l check -d "Exits with error if there is any unreachable code"
+complete -c crystal -n "__fish_seen_subcommand_from unreachable" -l error-trace -d "Show full error trace"
+complete -c crystal -n "__fish_seen_subcommand_from unreachable" -s i -l include -d "Include path"
+complete -c crystal -n "__fish_seen_subcommand_from unreachable" -s e -l exclude -d "Exclude path (default: lib)"
+complete -c crystal -n "__fish_seen_subcommand_from unreachable" -l no-color -d "Disable colored output"
+complete -c crystal -n "__fish_seen_subcommand_from unreachable" -l prelude -d "Use given file as prelude"
+complete -c crystal -n "__fish_seen_subcommand_from unreachable" -s s -l stats -d "Enable statistics output"
+complete -c crystal -n "__fish_seen_subcommand_from unreachable" -s p -l progress -d "Enable progress output"
+complete -c crystal -n "__fish_seen_subcommand_from unreachable" -s t -l time -d "Enable execution time output"
+complete -c crystal -n "__fish_seen_subcommand_from unreachable" -l stdin-filename -d "Source file name to be read from STDIN"
 
 complete -c crystal -n "__fish_seen_subcommand_from tool; and not __fish_seen_subcommand_from $tool_subcommands" -a "types" -d "show type of main variables" -x
 complete -c crystal -n "__fish_seen_subcommand_from types" -s D -l define -d "Define a compile-time flag"

--- a/etc/completion.fish
+++ b/etc/completion.fish
@@ -1,5 +1,5 @@
 set -l crystal_commands init build clear_cache docs env eval i interactive play run spec tool help version
-set -l tool_subcommands context expand flags format hierarchy dependencies implementations unreachable types
+set -l tool_subcommands context dependencies expand flags format hierarchy implementations types unreachable
 
 complete -c crystal -s h -l help -d "Show help" -x
 

--- a/etc/completion.zsh
+++ b/etc/completion.zsh
@@ -168,14 +168,14 @@ _crystal-tool() {
 
       commands=(
         "context:show context for given location"
+        "dependencies:show tree of required source files"
         "expand:show macro expansion for given location"
         "flags:print all macro 'flag?' values"
         "format:format project, directories and/or files"
         "hierarchy:show type hierarchy"
-        "dependencies:show tree of required source files"
         "implementations:show implementations for given call in location"
-        "unreachable:show methods that are never called"
         "types:show type of main variables"
+        "unreachable:show methods that are never called"
       )
 
       _describe -t commands 'Crystal tool command' commands

--- a/etc/completion.zsh
+++ b/etc/completion.zsh
@@ -41,7 +41,8 @@ local -a exec_args; exec_args=(
   '(\*)'{-D+,--define=}'[define a compile-time flag]:' \
   '(--error-trace)--error-trace[show full error trace]' \
   '(-s --stats)'{-s,--stats}'[enable statistics output]' \
-  '(-t --time)'{-t,--time}'[enable execution time output]'
+  '(-t --time)'{-t,--time}'[enable execution time output]' \
+  '(-p --progress)'{-p,--progress}'[enable progress output]'
 )
 
 local -a format_args; format_args=(
@@ -61,9 +62,13 @@ local -a cursor_args; cursor_args=(
   '(-c --cursor)'{-c,--cursor}'[cursor location with LOC as path/to/file.cr:line:column]:LOC'
 )
 
-local -a include_exclude_args; cursor_args=(
+local -a include_exclude_args; include_exclude_args=(
   '(-i --include)'{-i,--include}'[Include path in output]' \
   '(-i --exclude)'{-i,--exclude}'[Exclude path in output]'
+)
+
+local -a stdin_filename_args; stdin_filename_args=(
+  '(--stdin-filename)--stdin-filename[source file name to be read from STDIN]'
 )
 
 local -a programfile; programfile='*:Crystal File:_files -g "*.cr(.)"'
@@ -163,12 +168,13 @@ _crystal-tool() {
 
       commands=(
         "context:show context for given location"
-        "dependencies:show tree of required source files"
         "expand:show macro expansion for given location"
         "flags:print all macro 'flag?' values"
         "format:format project, directories and/or files"
         "hierarchy:show type hierarchy"
+        "dependencies:show tree of required source files"
         "implementations:show implementations for given call in location"
+        "unreachable:show methods that are never called"
         "types:show type of main variables"
       )
 
@@ -187,6 +193,7 @@ _crystal-tool() {
             $exec_args \
             $format_args \
             $prelude_args \
+            $stdin_filename_args \
             $cursor_args
         ;;
 
@@ -198,6 +205,7 @@ _crystal-tool() {
             $exec_args \
             '(-f --format)'{-f,--format}'[output format 'tree' (default), 'flat', 'dot', or 'mermaid']:' \
             $prelude_args \
+            $stdin_filename_args \
             $include_exclude_args
         ;;
 
@@ -209,12 +217,14 @@ _crystal-tool() {
             $exec_args \
             $format_args \
             $prelude_args \
+            $stdin_filename_args \
             $cursor_args
         ;;
 
         (flags)
           _arguments \
             $programfile \
+            $no_color_args \
             $help_args
         ;;
 
@@ -223,8 +233,9 @@ _crystal-tool() {
             $programfile \
             $help_args \
             $no_color_args \
-            $format_args \
+            $include_exclude_args \
             '(--check)--check[checks that formatting code produces no changes]' \
+            '(--show-backtrace)--show-backtrace[show backtrace on a bug (used only for debugging)]'
         ;;
 
         (hierarchy)
@@ -235,6 +246,7 @@ _crystal-tool() {
             $exec_args \
             $format_args \
             $prelude_args \
+            $stdin_filename_args \
             '(-e)-e[filter types by NAME regex]:'
         ;;
 
@@ -246,7 +258,22 @@ _crystal-tool() {
             $exec_args \
             $format_args \
             $prelude_args \
-            $cursor_args
+            $cursor_args \
+            $stdin_filename_args
+        ;;
+
+        (unreachable)
+          _arguments \
+            $programfile \
+            $help_args \
+            $no_color_args \
+            $exec_args \
+            $include_exclude_args \
+            '(-f --format)'{-f,--format}'[output format: text (default), json, csv, codecov]:' \
+            $prelude_args \
+            '(--check)--check[exits with error if there is any unreachable code]' \
+            '(--tallies)--tallies[print reachable methods and their call counts as well]' \
+            $stdin_filename_args
         ;;
 
         (types)
@@ -256,7 +283,8 @@ _crystal-tool() {
             $no_color_args \
             $exec_args \
             $format_args \
-            $prelude_args
+            $prelude_args \
+            $stdin_filename_args
         ;;
       esac
     ;;

--- a/man/crystal.1
+++ b/man/crystal.1
@@ -369,7 +369,7 @@ Disable colored output.
 .Op --
 .Op arguments
 .Pp
-Run a tool. The available tools are: context, expand, flags, format, hierarchy, dependencies, implementations, unreachable, and types.
+Run a tool. The available tools are: context, dependencies, expand, flags, format, hierarchy, implementations, types, and unreachable.
 .Pp
 Tools:
 .Bl -tag -offset indent

--- a/man/crystal.1
+++ b/man/crystal.1
@@ -369,7 +369,7 @@ Disable colored output.
 .Op --
 .Op arguments
 .Pp
-Run a tool. The available tools are: context, dependencies, flags, format, hierarchy, implementations, and types.
+Run a tool. The available tools are: context, expand, flags, format, hierarchy, dependencies, implementations, unreachable, and types.
 .Pp
 Tools:
 .Bl -tag -offset indent
@@ -442,7 +442,7 @@ Options:
 .It Fl D Ar FLAG, Fl -define= Ar FLAG
 Define a compile-time flag. This is useful to conditionally define types, methods, or commands based on flags available at compile time. The default flags are from the target triple given with --target-triple or the hosts default, if none is given.
 .It Fl f Ar FORMAT, Fl -format= Ar FORMAT
-Output format 'text' (default), 'json', or 'csv'.
+Output format 'text' (default), 'json', 'codecov', or 'csv'.
 .It Fl -tallies
 Print reachable methods and their call counts as well.
 .It Fl -check

--- a/src/compiler/crystal/command.cr
+++ b/src/compiler/crystal/command.cr
@@ -40,14 +40,14 @@ class Crystal::Command
 
     Tool:
         context                  show context for given location
+        dependencies             show file dependency tree
         expand                   show macro expansion for given location
         flags                    print all macro `flag?` values
         format                   format project, directories and/or files
         hierarchy                show type hierarchy
-        dependencies             show file dependency tree
         implementations          show implementations for given call in location
-        unreachable              show methods that are never called
         types                    show type of main variables
+        unreachable              show methods that are never called
         --help, -h               show this help
     USAGE
 


### PR DESCRIPTION
Partial follow up to #15059 to update man docs with new format. Also noticed I'm unable to tab complete `unreachable` on bash, so fixed that and ensured all tools and options are present in each shell completion file.

As a side node, it's a real PITA to update these. Would be :100: if there was a way to generate these via some configuration or something :shrug:.