### PR TITLE
Add `Log#emit` for dynamic log level for events

### DIFF
--- a/spec/std/log/log_spec.cr
+++ b/spec/std/log/log_spec.cr
@@ -69,6 +69,21 @@ describe Log do
     ])
   end
 
+  it "can emit logs at a given severity" do
+    backend = Log::MemoryBackend.new
+    log = Log.new("a", backend, :warn)
+
+    Log::Severity.values.each do |severity|
+      log.emit(severity) { "#{severity} message" } unless severity.none?
+    end
+
+    backend.entries.map { |e| {e.severity, e.message} }.should eq([
+      {s(:warn), "Warn message"},
+      {s(:error), "Error message"},
+      {s(:fatal), "Fatal message"},
+    ])
+  end
+
   it "level can be changed" do
     backend = Log::MemoryBackend.new
     log = Log.new("a", backend, :warn)


### PR DESCRIPTION
Fixes #15083 

The diff for this PR should read better if you ignore whitespace because the method body was extracted from the macro.