### PR TITLE
Fix `Number#humanize` printing of `(-)Infinity` and `NaN`

### DIFF
--- a/spec/std/humanize_spec.cr
+++ b/spec/std/humanize_spec.cr
@@ -207,6 +207,14 @@ describe Number do
     it { assert_prints 1.0e+34.humanize, "10,000Q" }
     it { assert_prints 1.0e+35.humanize, "100,000Q" }
 
+    it { assert_prints Float32::INFINITY.humanize, "Infinity" }
+    it { assert_prints (-Float32::INFINITY).humanize, "-Infinity" }
+    it { assert_prints Float32::NAN.humanize, "NaN" }
+
+    it { assert_prints Float64::INFINITY.humanize, "Infinity" }
+    it { assert_prints (-Float64::INFINITY).humanize, "-Infinity" }
+    it { assert_prints Float64::NAN.humanize, "NaN" }
+
     it { assert_prints 1_234.567_890_123.humanize(precision: 2, significant: false), "1.23k" }
     it { assert_prints 123.456_789_012_3.humanize(precision: 2, significant: false), "123.46" }
     it { assert_prints 12.345_678_901_23.humanize(precision: 2, significant: false), "12.35" }

--- a/src/humanize.cr
+++ b/src/humanize.cr
@@ -216,7 +216,7 @@ struct Number
   #
   # See `Int#humanize_bytes` to format a file size.
   def humanize(io : IO, precision = 3, separator = '.', delimiter = ',', *, base = 10 ** 3, significant = true, &prefixes : (Int32, Float64) -> {Int32, _} | {Int32, _, Bool}) : Nil
-    if zero?
+    if zero? || (responds_to?(:infinite?) && self.infinite?) || (responds_to?(:nan?) && self.nan?)
       digits = 0
     else
       log = Math.log10(abs)


### PR DESCRIPTION
Fixes issue #14955 `Number#humanize` handling of `Infinity` and `NaN` by skipping the problematic `log.floor.to_i` line that was previously raising an `OverflowError`. The actual handling of printing `(-)Infinity` or `NaN` is then done by the call to `Number#format`.

Fixes #14955 