### PR TITLE
Make `bin/crystal` work on MSYS2

### DIFF
--- a/bin/crystal
+++ b/bin/crystal
@@ -137,7 +137,7 @@ SCRIPT_ROOT="$(dirname "$SCRIPT_PATH")"
 CRYSTAL_ROOT="$(dirname "$SCRIPT_ROOT")"
 CRYSTAL_DIR="$CRYSTAL_ROOT/.build"
 
-export CRYSTAL_PATH="${CRYSTAL_PATH:-lib:$CRYSTAL_ROOT/src}"
+export CRYSTAL_PATH="${CRYSTAL_PATH:-./lib:$CRYSTAL_ROOT/src}"
 if [ -n "${CRYSTAL_PATH##*"$CRYSTAL_ROOT"/src*}" ]; then
   __warning_msg "CRYSTAL_PATH env variable does not contain $CRYSTAL_ROOT/src"
 fi


### PR DESCRIPTION
Normally, [MSYS2 automatically translates path lists](https://www.msys2.org/docs/filesystem-paths/) between Windows and Unix formats in the environment variables, as long as the variable looks like a Unix path list. You could try this even with an MSVC-built compiler:

```sh
$ /c/crystal/crystal.exe env CRYSTAL_PATH
lib;C:\crystal\src
$ CRYSTAL_PATH='/c/crystal/src' /c/crystal/crystal.exe env CRYSTAL_PATH
C:/crystal/src
$ CRYSTAL_PATH='/c/crystal/src:/d/e:/foo/bar' /c/crystal/crystal.exe env CRYSTAL_PATH
C:\crystal\src;D:\e;C:\msys64\foo\bar
```

`bin/crystal` defaults `CRYSTAL_PATH` to `lib:.../src` if it is not already set in the current environment. The problem is that `lib:.../src` doesn't look like a Unix path list [according to MSYS2](https://github.com/msys2/msys2-runtime/blob/2bfb7739dadf6a27f9b4c006adfd69944f3df2f1/winsup/cygwin/msys2_path_conv.cc#L339), so no conversion is done:

```sh
$ CRYSTAL_PATH='lib:/c/Users/nicet/crystal/crystal/src' /c/crystal/crystal.exe env CRYSTAL_PATH
lib:/c/Users/nicet/crystal/crystal/src
```

Turning the `lib` into `./lib` seems to trick MSYS2 into performing the conversion:

```sh
$ CRYSTAL_PATH='./lib:/c/Users/nicet/crystal/crystal/src' /c/crystal/crystal.exe env CRYSTAL_PATH
.\lib;C:\Users\nicet\crystal\crystal\src
```

Cygwin does not appear to do this automatically and one probably has to use `cygpath -p` directly.