### PR TITLE
Fix libiconv build on Windows

### DIFF
--- a/etc/win-ci/cygwin-build-iconv.sh
+++ b/etc/win-ci/cygwin-build-iconv.sh
@@ -23,8 +23,12 @@ else
   export CXXFLAGS="-MT"
   enable_shared=no
   enable_static=yes
+  # GNU libiconv appears to define `BUILDING_DLL` unconditionally, so the static
+  # library contains `/EXPORT` directives that make any executable also export
+  # the iconv symbols, which we don't want
+  find . '(' -name '*.h' -or -name '*.h.build.in' ')' -print0 | xargs -0 -i sed -i 's/__declspec(dllexport)//' '{}'
 fi
-export CPPFLAGS="-D_WIN32_WINNT=_WIN32_WINNT_WIN7 -I$(pwd)/iconv/include"
+export CPPFLAGS="-O2 -D_WIN32_WINNT=_WIN32_WINNT_WIN7 -I$(pwd)/iconv/include"
 export LDFLAGS="-L$(pwd)/iconv/lib"
 
 ./configure --host=x86_64-w64-mingw32 --prefix="$(pwd)/iconv" --enable-shared="${enable_shared}" --enable-static="${enable_static}"


### PR DESCRIPTION
* Do not export symbols from the executable when linking against the static library.
* Build in release mode.