### PR TITLE
Handle trailing comma with multiple parameters on the same line

### DIFF
--- a/spec/compiler/formatter/formatter_spec.cr
+++ b/spec/compiler/formatter/formatter_spec.cr
@@ -919,6 +919,13 @@ describe Crystal::Formatter do
     CRYSTAL
 
   assert_format <<-CRYSTAL
+    def foo(
+      a, b,
+    )
+    end
+    CRYSTAL
+
+  assert_format <<-CRYSTAL
     macro foo(
       a,
       *b,

--- a/src/compiler/crystal/tools/formatter.cr
+++ b/src/compiler/crystal/tools/formatter.cr
@@ -1651,7 +1651,7 @@ module Crystal
       yield
 
       # Write "," before skipping spaces to prevent inserting comment between argument and comma.
-      write "," if has_more || (wrote_newline && @token.type.op_comma?) || (write_trailing_comma && flag?("def_trailing_comma"))
+      write "," if has_more || (wrote_newline && @token.type.op_comma?) || (write_trailing_comma && flag?("def_trailing_comma")) || (write_trailing_comma && @token.type.op_comma?)
 
       just_wrote_newline = skip_space
       if @token.type.newline?


### PR DESCRIPTION
This is going directly into `release/1.14` given with https://github.com/crystal-lang/crystal/pull/14718 being merged, `master` now enforces it so there is nothing to change anymore.

Fix here was basically allowing it to write the comma if the new formatter rules says there should be one, and there is already a comma present. This makes it BC since it won't add one without either the flag, or a comma already being present.