### PR TITLE
Inline `ASTNode` bindings dependencies and observers

### DIFF
--- a/src/compiler/crystal/semantic/bindings.cr
+++ b/src/compiler/crystal/semantic/bindings.cr
@@ -328,16 +328,10 @@ module Crystal
       visited = Set(ASTNode).new.compare_by_identity
       owner_trace << node if node.type?.try &.includes_type?(owner)
       visited.add node
-      while true
-        dependencies = node.dependencies.select { |dep| dep.type? && dep.type.includes_type?(owner) && !visited.includes?(dep) }
-        if dependencies.size > 0
-          node = dependencies.first
-          nil_reason = node.nil_reason if node.is_a?(MetaTypeVar)
-          owner_trace << node if node
-          visited.add node
-        else
-          break
-        end
+      while node = node.dependencies.find { |dep| dep.type? && dep.type.includes_type?(owner) && !visited.includes?(dep) }
+        nil_reason = node.nil_reason if node.is_a?(MetaTypeVar)
+        owner_trace << node if node
+        visited.add node
       end
 
       MethodTraceException.new(owner, owner_trace, nil_reason, program.show_error_trace?)

--- a/src/compiler/crystal/semantic/bindings.cr
+++ b/src/compiler/crystal/semantic/bindings.cr
@@ -8,43 +8,11 @@ module Crystal
   # bytes) vs 2 pointers (16 bytes). The other downside is that since this is a
   # struct, we need to be careful with mutation.
   struct SmallNodeList
-    include Indexable(ASTNode)
+    include Enumerable(ASTNode)
 
     @first : ASTNode?
     @second : ASTNode?
     @tail : Array(ASTNode)?
-
-    def size
-      size = 0
-      size += 1 unless @first.nil?
-      size += 1 unless @second.nil?
-      if tail = @tail
-        size += tail.size
-      end
-      size
-    end
-
-    def unsafe_fetch(index : Int)
-      if first = @first
-        if index == 0
-          return first
-        else
-          index -= 1
-        end
-      end
-      if second = @second
-        if index == 0
-          return second
-        else
-          index -= 1
-        end
-      end
-      if tail = @tail
-        tail.unsafe_fetch(index)
-      else
-        raise IndexError.new
-      end
-    end
 
     def each(& : ASTNode ->)
       if first = @first

--- a/src/compiler/crystal/semantic/bindings.cr
+++ b/src/compiler/crystal/semantic/bindings.cr
@@ -15,15 +15,9 @@ module Crystal
     @tail : Array(ASTNode)?
 
     def each(& : ASTNode ->)
-      if first = @first
-        yield first
-        if second = @second
-          yield second
-          if tail = @tail
-            tail.each { |node| yield node }
-          end
-        end
-      end
+      yield @first || return
+      yield @second || return
+      @tail.try(&.each { |node| yield node })
     end
 
     def size

--- a/src/compiler/crystal/semantic/call_error.cr
+++ b/src/compiler/crystal/semantic/call_error.cr
@@ -643,8 +643,7 @@ class Crystal::Call
       if obj.is_a?(InstanceVar)
         scope = self.scope
         ivar = scope.lookup_instance_var(obj.name)
-        deps = ivar.dependencies
-        if deps.size == 1 && deps.first.same?(program.nil_var)
+        if ivar.dependencies.size == 1 && ivar.dependencies.first.same?(program.nil_var)
           similar_name = scope.lookup_similar_instance_var_name(ivar.name)
           if similar_name
             msg << colorize(" (#{ivar.name} was never assigned a value, did you mean #{similar_name}?)").yellow.bold

--- a/src/compiler/crystal/semantic/call_error.cr
+++ b/src/compiler/crystal/semantic/call_error.cr
@@ -643,8 +643,8 @@ class Crystal::Call
       if obj.is_a?(InstanceVar)
         scope = self.scope
         ivar = scope.lookup_instance_var(obj.name)
-        deps = ivar.dependencies?
-        if deps && deps.size == 1 && deps.first.same?(program.nil_var)
+        deps = ivar.dependencies
+        if deps.size == 1 && deps.first.same?(program.nil_var)
           similar_name = scope.lookup_similar_instance_var_name(ivar.name)
           if similar_name
             msg << colorize(" (#{ivar.name} was never assigned a value, did you mean #{similar_name}?)").yellow.bold

--- a/src/compiler/crystal/semantic/cleanup_transformer.cr
+++ b/src/compiler/crystal/semantic/cleanup_transformer.cr
@@ -1090,10 +1090,7 @@ module Crystal
       node = super
 
       unless node.type?
-        if dependencies = node.dependencies?
-          node.unbind_from node.dependencies
-        end
-
+        node.unbind_from node.dependencies
         node.bind_to node.expressions
       end
 

--- a/src/compiler/crystal/semantic/filters.cr
+++ b/src/compiler/crystal/semantic/filters.cr
@@ -1,7 +1,7 @@
 module Crystal
   class TypeFilteredNode < ASTNode
     def initialize(@filter : TypeFilter, @node : ASTNode)
-      dependencies.push @node
+      @dependencies.push @node
       node.add_observer self
       update(@node)
     end

--- a/src/compiler/crystal/semantic/filters.cr
+++ b/src/compiler/crystal/semantic/filters.cr
@@ -1,7 +1,7 @@
 module Crystal
   class TypeFilteredNode < ASTNode
     def initialize(@filter : TypeFilter, @node : ASTNode)
-      @dependencies = [@node] of ASTNode
+      dependencies.push @node
       node.add_observer self
       update(@node)
     end

--- a/src/compiler/crystal/semantic/main_visitor.cr
+++ b/src/compiler/crystal/semantic/main_visitor.cr
@@ -373,7 +373,7 @@ module Crystal
           var.bind_to(@program.nil_var)
           var.nil_if_read = false
 
-          meta_var.bind_to(@program.nil_var) unless meta_var.dependencies.try &.any? &.same?(@program.nil_var)
+          meta_var.bind_to(@program.nil_var) unless meta_var.dependencies.any? &.same?(@program.nil_var)
           node.bind_to(@program.nil_var)
         end
 
@@ -1283,7 +1283,7 @@ module Crystal
         # It can happen that this call is inside an ArrayLiteral or HashLiteral,
         # was expanded but isn't bound to the expansion because the call (together
         # with its expansion) was cloned.
-        if (expanded = node.expanded) && (node.dependencies.size == 0 || !node.type?)
+        if (expanded = node.expanded) && (node.dependencies.empty? || !node.type?)
           node.bind_to(expanded)
         end
 

--- a/src/compiler/crystal/semantic/main_visitor.cr
+++ b/src/compiler/crystal/semantic/main_visitor.cr
@@ -1283,7 +1283,7 @@ module Crystal
         # It can happen that this call is inside an ArrayLiteral or HashLiteral,
         # was expanded but isn't bound to the expansion because the call (together
         # with its expansion) was cloned.
-        if (expanded = node.expanded) && (!node.dependencies? || !node.type?)
+        if (expanded = node.expanded) && (node.dependencies.size == 0 || !node.type?)
           node.bind_to(expanded)
         end
 

--- a/src/compiler/crystal/semantic/type_merge.cr
+++ b/src/compiler/crystal/semantic/type_merge.cr
@@ -25,8 +25,10 @@ module Crystal
         nodes.first.type?
       when 2
         # Merging two types is the most common case, so we optimize it
-        first, second = nodes
-        type_merge(first.type?, second.type?)
+        # We use `#each_cons_pair` to avoid any intermediate allocation
+        nodes.each_cons_pair do |first, second|
+          return type_merge(first.type?, second.type?)
+        end
       else
         combined_union_of compact_types(nodes, &.type?)
       end

--- a/src/compiler/crystal/semantic/type_merge.cr
+++ b/src/compiler/crystal/semantic/type_merge.cr
@@ -17,7 +17,7 @@ module Crystal
       end
     end
 
-    def type_merge(nodes : Array(ASTNode)) : Type?
+    def type_merge(nodes : Enumerable(ASTNode)) : Type?
       case nodes.size
       when 0
         nil
@@ -161,7 +161,7 @@ module Crystal
   end
 
   class Type
-    def self.merge(nodes : Array(ASTNode)) : Type?
+    def self.merge(nodes : Enumerable(ASTNode)) : Type?
       nodes.find(&.type?).try &.type.program.type_merge(nodes)
     end
 


### PR DESCRIPTION
Every `ASTNode` contains two arrays used for type inference and checking: dependencies and observers. By default, these are created lazily, but most active (ie. effectively typed) `ASTNode`s end up creating them. Furthermore, on average both these lists contain less than 2 elements each.

This PR replaces the both `Array(ASTNode)?` references in `ASTNode` by inlined structs that can hold two elements and a tail array for the cases where more links are needed. This reduces number of allocations, bytes allocated, number of instructions executed and running time.

Some numbers from compiling the Crystal compiler itself without running codegen (since type binding occurs in the semantic phase anyway).

* Running time (measured with hyperfine running with `GC_DONT_GC=1`): ~6% reduction
  Before:
  ```
  Benchmark 1: ./self-semantic-only.sh
    Time (mean ± σ):      3.398 s ±  0.152 s    [User: 2.264 s, System: 0.470 s]
    Range (min … max):    3.029 s …  3.575 s    10 runs
  ```

  After:
  ```
  Benchmark 1: ./self-semantic-only.sh
    Time (mean ± σ):      3.180 s ±  0.095 s    [User: 2.153 s, System: 0.445 s]
    Range (min … max):    3.046 s …  3.345 s    10 runs
  ```

* Memory (as reported by the compiler itself, with GC): ~9.6% reduction
  Before:
  ```
  Parse:                             00:00:00.000038590 (   1.05MB)
  Semantic (top level):              00:00:00.483357706 ( 174.13MB)
  Semantic (new):                    00:00:00.002156811 ( 174.13MB)
  Semantic (type declarations):      00:00:00.038313066 ( 174.13MB)
  Semantic (abstract def check):     00:00:00.014283169 ( 190.13MB)
  Semantic (restrictions augmenter): 00:00:00.010672651 ( 206.13MB)
  Semantic (ivars initializers):     00:00:04.660611385 (1250.07MB)
  Semantic (cvars initializers):     00:00:00.008343907 (1250.07MB)
  Semantic (main):                   00:00:00.780627942 (1346.07MB)
  Semantic (cleanup):                00:00:00.000961914 (1346.07MB)
  Semantic (recursive struct check): 00:00:00.001121766 (1346.07MB)
  ```

  After:
  ```
  Parse:                             00:00:00.000044417 (   1.05MB)
  Semantic (top level):              00:00:00.546445955 ( 190.03MB)
  Semantic (new):                    00:00:00.002488975 ( 190.03MB)
  Semantic (type declarations):      00:00:00.040234541 ( 206.03MB)
  Semantic (abstract def check):     00:00:00.015473723 ( 222.03MB)
  Semantic (restrictions augmenter): 00:00:00.010828366 ( 222.03MB)
  Semantic (ivars initializers):     00:00:03.324639987 (1135.96MB)
  Semantic (cvars initializers):     00:00:00.007359853 (1135.96MB)
  Semantic (main):                   00:00:01.806822202 (1217.96MB)
  Semantic (cleanup):                00:00:00.000626975 (1217.96MB)
  Semantic (recursive struct check): 00:00:00.001435494 (1217.96MB)
  ```

* Callgrind stats:
  - Instruction refs: 17,477,865,704 -> 16,712,610,033 (~4.4% reduction)
  - Estimated cycles: 26,835,733,874 -> 26,154,926,143 (~2.5% reduction)
  - `GC_malloc_kind` call count: 35,161,616 -> 25,684,997 (~27% reduction)