### PR TITLE
Add location information to more MacroIf related nodes

### DIFF
--- a/spec/compiler/parser/parser_spec.cr
+++ b/spec/compiler/parser/parser_spec.cr
@@ -2709,6 +2709,9 @@ module Crystal
         CR
 
         node = parser.parse.should be_a MacroIf
+        location = node.location.should_not be_nil
+        location.line_number.should eq 1
+        location.column_number.should eq 3
 
         then_node = node.then.should be_a Expressions
         then_node_location = then_node.location.should_not be_nil

--- a/src/compiler/crystal/syntax/parser.cr
+++ b/src/compiler/crystal/syntax/parser.cr
@@ -3386,9 +3386,9 @@ module Crystal
 
         return MacroFor.new(vars, exp, body).at_end(token_end_location)
       when Keyword::IF
-        return parse_macro_if(start_location, macro_state)
+        return parse_macro_if(start_location, macro_state).at(location)
       when Keyword::UNLESS
-        return parse_macro_if(start_location, macro_state, is_unless: true)
+        return parse_macro_if(start_location, macro_state, is_unless: true).at(location)
       when Keyword::BEGIN
         next_token_skip_space
         check :OP_PERCENT_RCURLY
@@ -3494,7 +3494,7 @@ module Crystal
       end
 
       a_then, a_else = a_else, a_then if is_unless
-      MacroIf.new(cond, a_then, a_else).at(location).at_end(token_end_location)
+      MacroIf.new(cond, a_then, a_else).at_end(token_end_location)
     end
 
     def parse_expression_inside_macro

--- a/src/compiler/crystal/syntax/parser.cr
+++ b/src/compiler/crystal/syntax/parser.cr
@@ -3213,7 +3213,7 @@ module Crystal
         when .macro_literal?
           pieces << MacroLiteral.new(@token.value.to_s).at(@token.location).at_end(token_end_location)
         when .macro_expression_start?
-          pieces << MacroExpression.new(parse_macro_expression)
+          pieces << MacroExpression.new(parse_macro_expression).at(@token.location).at_end(token_end_location)
           check_macro_expression_end
           skip_whitespace = check_macro_skip_whitespace
         when .macro_control_start?
@@ -3341,6 +3341,7 @@ module Crystal
     end
 
     def parse_macro_control(start_location, macro_state = Token::MacroState.default)
+      location = @token.location
       next_token_skip_space_or_newline
 
       case @token.value
@@ -3400,7 +3401,7 @@ module Crystal
         next_token_skip_space
         check :OP_PERCENT_RCURLY
 
-        return MacroIf.new(BoolLiteral.new(true), body).at_end(token_end_location)
+        return MacroIf.new(BoolLiteral.new(true), body).at(location).at_end(token_end_location)
       when Keyword::ELSE, Keyword::ELSIF, Keyword::END
         return nil
       when Keyword::VERBATIM
@@ -3428,7 +3429,7 @@ module Crystal
       exps = parse_expressions
       @in_macro_expression = false
 
-      MacroExpression.new(exps, output: false).at_end(token_end_location)
+      MacroExpression.new(exps, output: false).at(location).at_end(token_end_location)
     end
 
     def parse_macro_if(start_location, macro_state, check_end = true, is_unless = false)
@@ -3493,7 +3494,7 @@ module Crystal
       end
 
       a_then, a_else = a_else, a_then if is_unless
-      MacroIf.new(cond, a_then, a_else).at_end(token_end_location)
+      MacroIf.new(cond, a_then, a_else).at(location).at_end(token_end_location)
     end
 
     def parse_expression_inside_macro


### PR DESCRIPTION
This PR adds some more location information to nodes related to `MacroIf`.

The most significant addition is when you have a `MacroIf` node like:

```cr
{% if 1 == 2 %}
  {{2 * 2}}
{% end %}
```
The `then` block of it is parsed as an `Expressions` that consists of `[MaccroLiteral, MacroExpression, MacroLiteral]`. I added location information to the nested `MacroExpression` so it knows it's on line 2 instead of line 1, which is what you'd get if you did `node.then.location` since that's the location of the first `MacroLiteral`. This is essentially my workaround for https://github.com/crystal-lang/crystal/issues/14884#issuecomment-2423904262.

This PR also handles `Begin` and `MacroIf` nodes when nested in another node.
