### PR TITLE
Make `Makefile` work on MSYS2

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -180,6 +180,13 @@ install: $(O)/$(CRYSTAL_BIN) man/crystal.1.gz ## Install the compiler at DESTDIR
 	$(INSTALL) -d -m 0755 "$(DESTDIR)$(PREFIX)/share/fish/vendor_completions.d/"
 	$(INSTALL) -m 644 etc/completion.fish "$(DESTDIR)$(PREFIX)/share/fish/vendor_completions.d/crystal.fish"
 
+ifeq ($(WINDOWS),1)
+.PHONY: install_dlls
+install_dlls: $(O)/$(CRYSTAL_BIN) ## Install the compiler's dependent DLLs at DESTDIR (Windows only)
+	$(INSTALL) -d -m 0755 "$(BINDIR)/"
+	@ldd $(O)/$(CRYSTAL_BIN) | grep -iv ' => /c/windows/system32' | sed 's/.* => //; s/ (.*//' | xargs -t -i $(INSTALL) -m 0755 '{}' "$(BINDIR)/"
+endif
+
 .PHONY: uninstall
 uninstall: ## Uninstall the compiler from DESTDIR
 	rm -f "$(BINDIR)/$(CRYSTAL_BIN)"

--- a/Makefile
+++ b/Makefile
@@ -48,7 +48,8 @@ CRYSTAL_CONFIG_BUILD_COMMIT ?= $(shell git rev-parse --short HEAD 2> /dev/null)
 CRYSTAL_CONFIG_PATH := '$$ORIGIN/../share/crystal/src'
 CRYSTAL_VERSION ?= $(shell cat src/VERSION)
 SOURCE_DATE_EPOCH ?= $(shell (cat src/SOURCE_DATE_EPOCH || (git show -s --format=%ct HEAD || stat -c "%Y" Makefile || stat -f "%m" Makefile)) 2> /dev/null)
-ifeq ($(shell command -v ld.lld >/dev/null && uname -s),Linux)
+check_lld := command -v ld.lld >/dev/null && case "$$(uname -s)" in MINGW32*|MINGW64*|Linux) echo 1;; esac
+ifeq ($(shell $(check_lld)),1)
   EXPORT_CC ?= CC="$(CC) -fuse-ld=lld"
 endif
 EXPORTS := \

--- a/bin/crystal
+++ b/bin/crystal
@@ -184,9 +184,18 @@ fi
 # with symlinks resolved as well (see https://github.com/crystal-lang/crystal/issues/12969).
 cd "$(realpath "$(pwd)")"
 
-if [ -x "$CRYSTAL_DIR/crystal" ]; then
-  __warning_msg "Using compiled compiler at ${CRYSTAL_DIR#"$PWD/"}/crystal"
-  exec "$CRYSTAL_DIR/crystal" "$@"
+case "$(uname -s)" in
+  CYGWIN*|MSYS_NT*|MINGW32_NT*|MINGW64_NT*)
+    CRYSTAL_BIN="crystal.exe"
+    ;;
+  *)
+    CRYSTAL_BIN="crystal"
+    ;;
+esac
+
+if [ -x "$CRYSTAL_DIR/${CRYSTAL_BIN}" ]; then
+  __warning_msg "Using compiled compiler at ${CRYSTAL_DIR#"$PWD/"}/${CRYSTAL_BIN}"
+  exec "$CRYSTAL_DIR/${CRYSTAL_BIN}" "$@"
 elif !($PARENT_CRYSTAL_EXISTS); then
   __error_msg 'You need to have a crystal executable in your path! or set CRYSTAL env variable'
   exit 1

--- a/src/compiler/crystal/compiler.cr
+++ b/src/compiler/crystal/compiler.cr
@@ -476,6 +476,7 @@ module Crystal
         {DEFAULT_LINKER, %(#{DEFAULT_LINKER} "${@}" -o #{Process.quote_posix(output_filename)} #{link_flags} #{program.lib_flags(@cross_compile)}), object_names}
       elsif program.has_flag?("win32") && program.has_flag?("gnu")
         link_flags = @link_flags || ""
+        link_flags += " -Wl,--stack,0x800000"
         lib_flags = program.lib_flags(@cross_compile)
         lib_flags = expand_lib_flags(lib_flags) if expand
         cmd = %(#{DEFAULT_LINKER} #{Process.quote_windows(object_names)} -o #{Process.quote_windows(output_filename)} #{link_flags} #{lib_flags})

--- a/src/llvm/ext/find-llvm-config
+++ b/src/llvm/ext/find-llvm-config
@@ -16,7 +16,14 @@ if ! LLVM_CONFIG=$(command -v "$LLVM_CONFIG"); then
 fi
 
 if [ "$LLVM_CONFIG" ]; then
-  printf %s "$LLVM_CONFIG"
+  case "$(uname -s)" in
+    MINGW32_NT*|MINGW64_NT*)
+      printf "%s" "$(cygpath -w "$LLVM_CONFIG")"
+      ;;
+    *)
+      printf "%s" "$LLVM_CONFIG"
+      ;;
+  esac
 else
   printf "Error: Could not find location of llvm-config. Please specify path in environment variable LLVM_CONFIG.\n" >&2
   printf "Supported LLVM versions: $(cat "$(dirname $0)/llvm-versions.txt" | sed 's/\.0//g')\n" >&2

--- a/src/llvm/lib_llvm.cr
+++ b/src/llvm/lib_llvm.cr
@@ -1,5 +1,5 @@
 {% begin %}
-  {% if flag?(:win32) && !flag?(:static) %}
+  {% if flag?(:msvc) && !flag?(:static) %}
     {% config = nil %}
     {% for dir in Crystal::LIBRARY_PATH.split(Crystal::System::Process::HOST_PATH_DELIMITER) %}
       {% config ||= read_file?("#{dir.id}/llvm_VERSION") %}
@@ -21,7 +21,7 @@
     lib LibLLVM
     end
   {% else %}
-    {% llvm_config = env("LLVM_CONFIG") || `#{__DIR__}/ext/find-llvm-config`.stringify %}
+    {% llvm_config = env("LLVM_CONFIG") || `sh #{__DIR__}/ext/find-llvm-config`.stringify %}
     {% llvm_version = `#{llvm_config.id} --version`.stringify %}
     {% llvm_targets = env("LLVM_TARGETS") || `#{llvm_config.id} --targets-built`.stringify %}
     {% llvm_ldflags = "`#{llvm_config.id} --libs --system-libs --ldflags#{" --link-static".id if flag?(:static)}#{" 2> /dev/null".id unless flag?(:win32)}`" %}


### PR DESCRIPTION
Resolves part of #6170.

* Uses `llvm-config` instead of `llvm_VERSION` for the `x86_64-windows-gnu` target. Also invokes the `find-llvm-config` script using `sh` explicitly and ensures the script returns a Windows path. (This pretty much means a MinGW-w64-based compiler will require the entire MSYS2 environment to work.)
* Increases the stack size from the default 2 MiB to 8 MiB, consistent with builds using the MSVC toolchain.
* `Makefile` and the `bin/crystal` script now recognize `.build/crystal.exe` as the local compiler under MSYS2.
* If `.build/crystal.exe` already exists and we are on Windows, `Makefile` now builds a temporary executable first, just like in `Makefile.win`.
* Ensures `Makefile` doesn't interpret backslashes in `llvm-config.exe`'s path as escape sequences.
* Adds a separate `install_dlls` target for installing the compiler's dependent DLLs to the given prefix's `bin` directory. This is only needed if the installation is to be distributed outside MSYS2.
* Detects the presence of `lld` which can be installed using the `mingw-w64-ucrt-x86_64-lld` package.

With this patch, cross-compiling from MSVC-based Crystal will no longer work until #15091 is merged. Instead it can be done from Linux, including WSL, assuming the host and target LLVM versions are identical (right now MSYS2 has 18.1.8):

```sh
# on Linux
make clean crystal && make -B target=x86_64-windows-gnu

# on MSYS2's UCRT64 environment
pacman -Sy \
  mingw-w64-ucrt-x86_64-gcc mingw-w64-ucrt-x86_64-pkgconf \
  mingw-w64-ucrt-x86_64-gc mingw-w64-ucrt-x86_64-pcre2 mingw-w64-ucrt-x86_64-libiconv \
  mingw-w64-ucrt-x86_64-zlib mingw-w64-ucrt-x86_64-llvm
cc .build/crystal.obj -o .build/crystal.exe \
  $(pkg-config bdw-gc libpcre2-8 iconv zlib --libs) \
  $(llvm-config --libs --system-libs --ldflags) \
  -lDbgHelp -lole32 -lWS2_32 -Wl,--stack,0x800000
```