### PR TITLE
Use official Apt respositories for LLVM CI

### DIFF
--- a/.github/workflows/llvm.yml
+++ b/.github/workflows/llvm.yml
@@ -30,7 +30,7 @@ jobs:
 
       - name: Install LLVM ${{ matrix.llvm_version }}
         run: |
-          sudo apt remove llvm-* libllvm*
+          sudo apt remove 'llvm-*' 'libllvm*'
           wget -qO- https://apt.llvm.org/llvm-snapshot.gpg.key | sudo tee /etc/apt/trusted.gpg.d/apt.llvm.org.asc
           sudo apt-add-repository -y deb http://apt.llvm.org/${{ matrix.codename }}/ llvm-toolchain-${{ matrix.codename }}-${{ matrix.llvm_version }} main
           sudo apt install -y llvm-${{ matrix.llvm_version }}-dev lld-${{ matrix.llvm_version }}

--- a/.github/workflows/llvm.yml
+++ b/.github/workflows/llvm.yml
@@ -41,7 +41,7 @@ jobs:
           wget https://apt.llvm.org/llvm.sh
           chmod +x llvm.sh
           sudo ./llvm.sh ${{ matrix.llvm_version }}
-          sudo apt install -y llvm-${{ matrix.llvm_version }}-dev lld
+          sudo apt install -y llvm-${{ matrix.llvm_version }}-dev lld-${{ matrix.llvm_version }}
 
       - name: Install Crystal
         uses: crystal-lang/install-crystal@v1

--- a/.github/workflows/llvm.yml
+++ b/.github/workflows/llvm.yml
@@ -16,13 +16,13 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - {llvm_version: 13, runs-on: ubuntu-22.04., codename: jammy}
-          - {llvm_version: 14, runs-on: ubuntu-22.04., codename: jammy}
-          - {llvm_version: 15, runs-on: ubuntu-22.04., codename: jammy}
-          - {llvm_version: 16, runs-on: ubuntu-22.04., codename: jammy}
-          - {llvm_version: 17, runs-on: ubuntu-24.04., codename: noble}
-          - {llvm_version: 18, runs-on: ubuntu-24.04., codename: noble}
-          - {llvm_version: 19, runs-on: ubuntu-24.04., codename: noble}
+          - {llvm_version: 13, runs-on: ubuntu-22.04, codename: jammy}
+          - {llvm_version: 14, runs-on: ubuntu-22.04, codename: jammy}
+          - {llvm_version: 15, runs-on: ubuntu-22.04, codename: jammy}
+          - {llvm_version: 16, runs-on: ubuntu-22.04, codename: jammy}
+          - {llvm_version: 17, runs-on: ubuntu-24.04, codename: noble}
+          - {llvm_version: 18, runs-on: ubuntu-24.04, codename: noble}
+          - {llvm_version: 19, runs-on: ubuntu-24.04, codename: noble}
     name: "LLVM ${{ matrix.llvm_version }}"
     steps:
       - name: Checkout Crystal source

--- a/.github/workflows/llvm.yml
+++ b/.github/workflows/llvm.yml
@@ -11,51 +11,35 @@ env:
 
 jobs:
   llvm_test:
-    runs-on: ubuntu-22.04
+    runs-on: ${{ matrix.runs-on }}
     strategy:
       fail-fast: false
       matrix:
         include:
-          - llvm_version: "13.0.0"
-            llvm_filename: "clang+llvm-13.0.0-x86_64-linux-gnu-ubuntu-20.04.tar.xz"
-          - llvm_version: "14.0.0"
-            llvm_filename: "clang+llvm-14.0.0-x86_64-linux-gnu-ubuntu-18.04.tar.xz"
-          - llvm_version: "15.0.6"
-            llvm_filename: "clang+llvm-15.0.6-x86_64-linux-gnu-ubuntu-18.04.tar.xz"
-          - llvm_version: "16.0.3"
-            llvm_filename: "clang+llvm-16.0.3-x86_64-linux-gnu-ubuntu-22.04.tar.xz"
-          - llvm_version: "17.0.6"
-            llvm_filename: "clang+llvm-17.0.6-x86_64-linux-gnu-ubuntu-22.04.tar.xz"
-          - llvm_version: "18.1.4"
-            llvm_filename: "clang+llvm-18.1.4-x86_64-linux-gnu-ubuntu-18.04.tar.xz"
-          - llvm_version: "19.1.0"
-            llvm_filename: "LLVM-19.1.0-Linux-X64.tar.xz"
+          - llvm_version: 13
+            runs-on: ubuntu-22.04
+          - llvm_version: 14
+            runs-on: ubuntu-22.04
+          - llvm_version: 15
+            runs-on: ubuntu-22.04
+          - llvm_version: 16
+            runs-on: ubuntu-22.04
+          - llvm_version: 17
+            runs-on: ubuntu-24.04
+          - llvm_version: 18
+            runs-on: ubuntu-24.04
+          - llvm_version: 19
+            runs-on: ubuntu-24.04
     name: "LLVM ${{ matrix.llvm_version }}"
     steps:
       - name: Checkout Crystal source
         uses: actions/checkout@v4
 
-      - name: Cache LLVM
-        id: cache-llvm
-        uses: actions/cache@v4
-        with:
-          path: ./llvm
-          key: llvm-${{ matrix.llvm_version }}
-        if: "${{ !env.ACT }}"
-
       - name: Install LLVM ${{ matrix.llvm_version }}
         run: |
-          mkdir -p llvm
-          curl -L "https://github.com/llvm/llvm-project/releases/download/llvmorg-${{ matrix.llvm_version }}/${{ matrix.llvm_filename }}" > llvm.tar.xz
-          tar x --xz -C llvm --strip-components=1 -f llvm.tar.xz
-        if: steps.cache-llvm.outputs.cache-hit != 'true'
-
-      - name: Set up LLVM
-        run: |
-          sudo apt-get install -y libtinfo5
-          echo "PATH=$(pwd)/llvm/bin:$PATH" >> $GITHUB_ENV
-          echo "LLVM_CONFIG=$(pwd)/llvm/bin/llvm-config" >> $GITHUB_ENV
-          echo "LD_LIBRARY_PATH=$(pwd)/llvm/lib:$LD_LIBRARY_PATH" >> $GITHUB_ENV
+          wget https://apt.llvm.org/llvm.sh
+          chmod +x llvm.sh
+          sudo ./llvm.sh ${{ matrix.llvm_version }}
 
       - name: Install Crystal
         uses: crystal-lang/install-crystal@v1

--- a/.github/workflows/llvm.yml
+++ b/.github/workflows/llvm.yml
@@ -16,20 +16,13 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - llvm_version: 13
-            runs-on: ubuntu-22.04
-          - llvm_version: 14
-            runs-on: ubuntu-22.04
-          - llvm_version: 15
-            runs-on: ubuntu-22.04
-          - llvm_version: 16
-            runs-on: ubuntu-22.04
-          - llvm_version: 17
-            runs-on: ubuntu-24.04
-          - llvm_version: 18
-            runs-on: ubuntu-24.04
-          - llvm_version: 19
-            runs-on: ubuntu-24.04
+          - {llvm_version: 13, runs-on: ubuntu-22.04., codename: jammy}
+          - {llvm_version: 14, runs-on: ubuntu-22.04., codename: jammy}
+          - {llvm_version: 15, runs-on: ubuntu-22.04., codename: jammy}
+          - {llvm_version: 16, runs-on: ubuntu-22.04., codename: jammy}
+          - {llvm_version: 17, runs-on: ubuntu-24.04., codename: noble}
+          - {llvm_version: 18, runs-on: ubuntu-24.04., codename: noble}
+          - {llvm_version: 19, runs-on: ubuntu-24.04., codename: noble}
     name: "LLVM ${{ matrix.llvm_version }}"
     steps:
       - name: Checkout Crystal source
@@ -38,9 +31,8 @@ jobs:
       - name: Install LLVM ${{ matrix.llvm_version }}
         run: |
           sudo apt remove llvm-* libllvm*
-          wget https://apt.llvm.org/llvm.sh
-          chmod +x llvm.sh
-          sudo ./llvm.sh ${{ matrix.llvm_version }}
+          wget -qO- https://apt.llvm.org/llvm-snapshot.gpg.key | sudo tee /etc/apt/trusted.gpg.d/apt.llvm.org.asc
+          sudo apt-add-repository -y deb http://apt.llvm.org/${{ matrix.codename }}/ llvm-toolchain-${{ matrix.codename }}-${{ matrix.llvm_version }} main
           sudo apt install -y llvm-${{ matrix.llvm_version }}-dev lld-${{ matrix.llvm_version }}
 
       - name: Install Crystal

--- a/.github/workflows/llvm.yml
+++ b/.github/workflows/llvm.yml
@@ -47,4 +47,4 @@ jobs:
         run: make compiler_spec junit_output=.junit/compiler_spec.xml
 
       - name: Integration test
-        run: make crystal std_spec threads=1 junit_output=.junit/std_spec.xml
+        run: EXPORT_CC='CC="cc -fuse-ld=lld-${{ matrix.llvm_version }}"' make crystal std_spec threads=1 junit_output=.junit/std_spec.xml

--- a/.github/workflows/llvm.yml
+++ b/.github/workflows/llvm.yml
@@ -44,7 +44,7 @@ jobs:
         run: make -B deps
 
       - name: Test compiler_spec
-        run: make compiler_spec junit_output=.junit/compiler_spec.xml
+        run: EXPORT_CC='CC="cc -fuse-ld=lld"' make compiler_spec junit_output=.junit/compiler_spec.xml
 
       - name: Integration test
-        run: EXPORT_CC='CC="cc -fuse-ld=lld-${{ matrix.llvm_version }}"' make crystal std_spec threads=1 junit_output=.junit/std_spec.xml
+        run: EXPORT_CC='CC="cc -fuse-ld=lld"' make crystal std_spec threads=1 junit_output=.junit/std_spec.xml

--- a/.github/workflows/llvm.yml
+++ b/.github/workflows/llvm.yml
@@ -37,9 +37,11 @@ jobs:
 
       - name: Install LLVM ${{ matrix.llvm_version }}
         run: |
+          sudo apt remove llvm-* libllvm*
           wget https://apt.llvm.org/llvm.sh
           chmod +x llvm.sh
           sudo ./llvm.sh ${{ matrix.llvm_version }}
+          sudo apt install -y llvm-${{ matrix.llvm_version }}-dev lld
 
       - name: Install Crystal
         uses: crystal-lang/install-crystal@v1

--- a/.github/workflows/llvm.yml
+++ b/.github/workflows/llvm.yml
@@ -33,7 +33,7 @@ jobs:
           sudo apt remove 'llvm-*' 'libllvm*'
           wget -qO- https://apt.llvm.org/llvm-snapshot.gpg.key | sudo tee /etc/apt/trusted.gpg.d/apt.llvm.org.asc
           sudo apt-add-repository -y deb http://apt.llvm.org/${{ matrix.codename }}/ llvm-toolchain-${{ matrix.codename }}-${{ matrix.llvm_version }} main
-          sudo apt install -y llvm-${{ matrix.llvm_version }}-dev lld-${{ matrix.llvm_version }}
+          sudo apt install -y llvm-${{ matrix.llvm_version }}-dev lld
 
       - name: Install Crystal
         uses: crystal-lang/install-crystal@v1
@@ -44,7 +44,7 @@ jobs:
         run: make -B deps
 
       - name: Test compiler_spec
-        run: EXPORT_CC='CC="cc -fuse-ld=lld"' make compiler_spec junit_output=.junit/compiler_spec.xml
+        run: make compiler_spec junit_output=.junit/compiler_spec.xml
 
       - name: Integration test
-        run: EXPORT_CC='CC="cc -fuse-ld=lld"' make crystal std_spec threads=1 junit_output=.junit/std_spec.xml
+        run: make crystal std_spec threads=1 junit_output=.junit/std_spec.xml


### PR DESCRIPTION
Closes #14573. See also #15052.

The minimum LLVM versions provided for each Ubuntu LTS version are:

* Bionic (18.04): 5
* Focal (20.04): 9
* Jammy (22.04): 13
* Noble (24.04): 17