### PR TITLE
```union```, ```intersection``` and ```overlaps?``` for ```Range```s

### DIFF
--- a/src/range.cr
+++ b/src/range.cr
@@ -265,7 +265,6 @@ struct Range(B, E)
     end
 
     larger = (self.end > other.end)
-
     if (larger && self.excludes_end?) || (!larger && other.excludes_end?)
       return (self.begin < other.begin ? self.begin : other.begin)...(self.end > other.end ? self.end : other.end)
     end

--- a/src/range.cr
+++ b/src/range.cr
@@ -252,6 +252,58 @@ struct Range(B, E)
     {% end %}
   end
 
+  # Returns the union of this range, and another.
+  # Returns 0..0 if there is no overlap.
+  #
+  # ```
+  # (1..5).union(5..10) # => 1..10
+  # (1...10).union(1..10) # => 1..10
+  # ```
+  def union(other : Range)
+    if self.end < other.begin || other.end < self.begin
+      return 0..0
+    end
+
+    larger = (self.end > other.end)
+
+    if (larger && self.excludes_end?) || (!larger && other.excludes_end?)
+      return (self.begin < other.begin ? self.begin : other.begin)...(self.end > other.end ? self.end : other.end)
+    end
+
+    (self.begin < other.begin ? self.begin : other.begin)..(self.end > other.end ? self.end : other.end)
+  end
+
+  # Returns the intersection of this range, and another.
+  # Returns 0..0 if there is no overlap.
+  #
+  # ```
+  # (2..10).intersection(0..8) # => 2..8
+  # (1...10).intersection(7..12) # => 7...10
+  # ```
+  def intersection(other : Range)
+    if self.end < other.begin || other.end < self.begin
+      return 0..0
+    end
+
+    larger = (self.end > other.end)
+
+    if (!larger && self.excludes_end?) || (larger && other.excludes_end?)
+      return (self.begin > other.begin ? self.begin : other.begin)...(self.end < other.end ? self.end : other.end)
+    end
+
+    (self.begin > other.begin ? self.begin : other.begin)..(self.end < other.end ? self.end : other.end)
+  end
+
+  # Returns `true` if this range overlaps with another range.
+  # 
+  # ```
+  # (1..10).overlaps?(5..9) # => true
+  # (1...10).overlaps?(10..11) # => false
+  # ```
+  def overlaps?(other : Range) : Bool
+    !(self.end <= other.begin || other.end <= self.begin)
+  end
+
   # Returns `true` if this range excludes the *end* element.
   #
   # ```

--- a/src/range.cr
+++ b/src/range.cr
@@ -256,7 +256,7 @@ struct Range(B, E)
   # Returns 0..0 if there is no overlap.
   #
   # ```
-  # (1..5).union(5..10) # => 1..10
+  # (1..5).union(5..10)   # => 1..10
   # (1...10).union(1..10) # => 1..10
   # ```
   def union(other : Range)
@@ -277,7 +277,7 @@ struct Range(B, E)
   # Returns 0..0 if there is no overlap.
   #
   # ```
-  # (2..10).intersection(0..8) # => 2..8
+  # (2..10).intersection(0..8)   # => 2..8
   # (1...10).intersection(7..12) # => 7...10
   # ```
   def intersection(other : Range)
@@ -286,7 +286,6 @@ struct Range(B, E)
     end
 
     larger = (self.end > other.end)
-
     if (!larger && self.excludes_end?) || (larger && other.excludes_end?)
       return (self.begin > other.begin ? self.begin : other.begin)...(self.end < other.end ? self.end : other.end)
     end
@@ -295,9 +294,9 @@ struct Range(B, E)
   end
 
   # Returns `true` if this range overlaps with another range.
-  # 
+  #
   # ```
-  # (1..10).overlaps?(5..9) # => true
+  # (1..10).overlaps?(5..9)    # => true
   # (1...10).overlaps?(10..11) # => false
   # ```
   def overlaps?(other : Range) : Bool


### PR DESCRIPTION
Based on the request from @jgaskins. Behaviors below:

```
a = 1..5
b = 3..7
a.union(b)        # => 1..7
a.intersection(b) # => 3..5

c = 1..10
d = 1...15
c.union(d)        # => 1...15
c.intersection(d) # => 1..10

e = 1...10
f = 1..15
e.union(f)        # => 1..15
e.intersection(f) # => 1...10

g = 1..5
h = 10..20
g.union(h)        # => 0..0
g.intersection(h) # => 0..0

(1...10).union(1..10)        # => 1..10
(1...10).intersection(1..10) # => 1...10

(1...10).union(10..20) # => 1..20

(1..5).union(5..10) # => 1..10

(1...10).intersection(7..12) # => 7...10
(2..10).intersection(0..8)   # => 2..8

(1...10).overlaps?(10..11)   # => false
(1..10).overlaps?(5..9) # => true
```

Fixes #14487
Fixes #14488

---

P.S., very excited to be making a small contribution to a lovely language. Looking forward to review!