### PR TITLE
Fix `UNIXSocket#receive`

### DIFF
--- a/src/socket/unix_socket.cr
+++ b/src/socket/unix_socket.cr
@@ -97,8 +97,8 @@ class UNIXSocket < Socket
     UNIXAddress.new(path.to_s)
   end
 
-  def receive
-    bytes_read, sockaddr, addrlen = recvfrom
-    {bytes_read, UNIXAddress.from(sockaddr, addrlen)}
+  def receive(max_message_size = 512) : {String, UNIXAddress}
+    message, address = super(max_message_size)
+    {message, address.as(UNIXAddress)}
   end
 end


### PR DESCRIPTION
`UNIXSocket#receive` has been broken since at least #14384 and wouldn't even compile. We were missing specs for this entirely.