### PR TITLE
Add CI workflow for cross-compiling Crystal on MSYS2

### DIFF
--- a/.github/workflows/mingw-w64.yml
+++ b/.github/workflows/mingw-w64.yml
@@ -1,0 +1,91 @@
+name: MinGW-w64 CI
+
+on: [push, pull_request]
+
+permissions: {}
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/master' }}
+
+jobs:
+  x86_64-mingw-w64-cross-compile:
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Download Crystal source
+        uses: actions/checkout@v4
+
+      - name: Install LLVM 18
+        run: |
+          sudo apt remove 'llvm-*' 'libllvm*'
+          wget -qO- https://apt.llvm.org/llvm-snapshot.gpg.key | sudo tee /etc/apt/trusted.gpg.d/apt.llvm.org.asc
+          sudo apt-add-repository -y deb http://apt.llvm.org/noble/ llvm-toolchain-noble-18 main
+          sudo apt install -y llvm-18-dev
+
+      - name: Install Crystal
+        uses: crystal-lang/install-crystal@v1
+        with:
+          crystal: "1.14.0"
+
+      - name: Cross-compile Crystal
+        run: make && make -B target=x86_64-windows-gnu release=1
+
+      - name: Upload crystal.obj
+        uses: actions/upload-artifact@v4
+        with:
+          name: x86_64-mingw-w64-crystal-obj
+          path: .build/crystal.obj
+
+      - name: Upload standard library
+        uses: actions/upload-artifact@v4
+        with:
+          name: x86_64-mingw-w64-crystal-stdlib
+          path: src
+
+  x86_64-mingw-w64-link:
+    runs-on: windows-2022
+    needs: [x86_64-mingw-w64-cross-compile]
+    steps:
+      - name: Setup MSYS2
+        id: msys2
+        uses: msys2/setup-msys2@ddf331adaebd714795f1042345e6ca57bd66cea8 # v2.24.1
+        with:
+          msystem: UCRT64
+          update: true
+          install: >-
+            mingw-w64-ucrt-x86_64-pkgconf
+            mingw-w64-ucrt-x86_64-cc
+            mingw-w64-ucrt-x86_64-gc
+            mingw-w64-ucrt-x86_64-pcre2
+            mingw-w64-ucrt-x86_64-libiconv
+            mingw-w64-ucrt-x86_64-zlib
+            mingw-w64-ucrt-x86_64-llvm
+
+      - name: Download crystal.obj
+        uses: actions/download-artifact@v4
+        with:
+          name: x86_64-mingw-w64-crystal-obj
+
+      - name: Download standard library
+        uses: actions/download-artifact@v4
+        with:
+          name: x86_64-mingw-w64-crystal-stdlib
+          path: share/crystal/src
+
+      - name: Link Crystal executable
+        shell: msys2 {0}
+        run: |
+          mkdir bin
+          cc crystal.obj -o bin/crystal.exe \
+            $(pkg-config bdw-gc libpcre2-8 iconv zlib --libs) \
+            $(llvm-config --libs --system-libs --ldflags) \
+            -lDbgHelp -lole32 -lWS2_32 -Wl,--stack,0x800000
+          ldd bin/crystal.exe | grep -iv /c/windows/system32 | sed 's/.* => //; s/ (.*//' | xargs -t -i cp '{}' bin/
+
+      - name: Upload Crystal
+        uses: actions/upload-artifact@v4
+        with:
+          name: x86_64-mingw-w64-crystal
+          path: |
+            bin/
+            share/


### PR DESCRIPTION
Cross-compiles a MinGW-w64-based Crystal compiler from Ubuntu, then links it on MSYS2's UCRT64 environment. Resolves part of #6170.

The artifact includes the compiler, all dependent DLLs, and the source code only. It is not a complete installation since it is missing e.g. the documentation and the licenses, but it is sufficient for bootstrapping further native compiler builds within MSYS2.

The resulting binary is portable within MSYS2 and can be executed from anywhere inside an MSYS2 shell, although compilation requires `mingw-w64-ucrt-x86_64-cc`, probably `mingw-w64-ucrt-x86_64-pkgconf`, plus the respective development libraries listed in #15077. The DLLs bundled under `bin/` are needed to even start Crystal since they are dynamically linked at load time; they are not strictly needed if Crystal is always run only within MSYS2, but that is the job of an actual `PKGBUILD` file.