### PR TITLE
Add `Colorize::Object#ansi_escape`

### DIFF
--- a/spec/std/colorize_spec.cr
+++ b/spec/std/colorize_spec.cr
@@ -100,16 +100,16 @@ describe "colorize" do
   it "prints colorize ANSI escape codes" do
     Colorize.with.bold.print.should eq("\e[1m")
     Colorize.with.bright.print.should eq("\e[1m")
-    Colorize.with.dim.print.should eq("\e[0;2m")
-    Colorize.with.italic.print.should eq("\e[0;3m")
-    Colorize.with.underline.print.should eq("\e[0;4m")
-    Colorize.with.blink.print.should eq("\e[0;5m")
-    Colorize.with.blink_fast.print.should eq("\e[0;6m")
-    Colorize.with.reverse.print.should eq("\e[0;7m")
-    Colorize.with.hidden.print.should eq("\e[0;8m")
-    Colorize.with.strikethrough.print.should eq("\e[0;9m")
-    Colorize.with.double_underline.print.should eq("\e[0;21m")
-    Colorize.with.overline.print.should eq("\e[0;53m")
+    Colorize.with.dim.print.should eq("\e[2m")
+    Colorize.with.italic.print.should eq("\e[3m")
+    Colorize.with.underline.print.should eq("\e[4m")
+    Colorize.with.blink.print.should eq("\e[5m")
+    Colorize.with.blink_fast.print.should eq("\e[6m")
+    Colorize.with.reverse.print.should eq("\e[7m")
+    Colorize.with.hidden.print.should eq("\e[8m")
+    Colorize.with.strikethrough.print.should eq("\e[9m")
+    Colorize.with.double_underline.print.should eq("\e[21m")
+    Colorize.with.overline.print.should eq("\e[53m")
   end
 
   it "only prints colorize ANSI escape codes" do

--- a/spec/std/colorize_spec.cr
+++ b/spec/std/colorize_spec.cr
@@ -97,6 +97,26 @@ describe "colorize" do
     colorize("hello").overline.to_s.should eq("\e[53mhello\e[0m")
   end
 
+  it "prints colorize ANSI escape codes" do
+    Colorize.with.bold.print.should eq("\e[1m")
+    Colorize.with.bright.print.should eq("\e[1m")
+    Colorize.with.dim.print.should eq("\e[0;2m")
+    Colorize.with.italic.print.should eq("\e[0;3m")
+    Colorize.with.underline.print.should eq("\e[0;4m")
+    Colorize.with.blink.print.should eq("\e[0;5m")
+    Colorize.with.blink_fast.print.should eq("\e[0;6m")
+    Colorize.with.reverse.print.should eq("\e[0;7m")
+    Colorize.with.hidden.print.should eq("\e[0;8m")
+    Colorize.with.strikethrough.print.should eq("\e[0;9m")
+    Colorize.with.double_underline.print.should eq("\e[0;21m")
+    Colorize.with.overline.print.should eq("\e[0;53m")
+  end
+
+  it "only prints colorize ANSI escape codes" do
+    colorize("hello").red.bold.print.should eq("\e[31;1m")
+    colorize("hello").bold.dim.underline.blink.reverse.hidden.print.should eq("\e[1;2;4;5;7;8m")
+  end
+
   it "colorizes mode combination" do
     colorize("hello").bold.dim.underline.blink.reverse.hidden.to_s.should eq("\e[1;2;4;5;7;8mhello\e[0m")
   end

--- a/spec/std/colorize_spec.cr
+++ b/spec/std/colorize_spec.cr
@@ -98,23 +98,23 @@ describe "colorize" do
   end
 
   it "prints colorize ANSI escape codes" do
-    Colorize.with.bold.print.should eq("\e[1m")
-    Colorize.with.bright.print.should eq("\e[1m")
-    Colorize.with.dim.print.should eq("\e[2m")
-    Colorize.with.italic.print.should eq("\e[3m")
-    Colorize.with.underline.print.should eq("\e[4m")
-    Colorize.with.blink.print.should eq("\e[5m")
-    Colorize.with.blink_fast.print.should eq("\e[6m")
-    Colorize.with.reverse.print.should eq("\e[7m")
-    Colorize.with.hidden.print.should eq("\e[8m")
-    Colorize.with.strikethrough.print.should eq("\e[9m")
-    Colorize.with.double_underline.print.should eq("\e[21m")
-    Colorize.with.overline.print.should eq("\e[53m")
+    Colorize.with.bold.ansi_escape.should eq("\e[1m")
+    Colorize.with.bright.ansi_escape.should eq("\e[1m")
+    Colorize.with.dim.ansi_escape.should eq("\e[2m")
+    Colorize.with.italic.ansi_escape.should eq("\e[3m")
+    Colorize.with.underline.ansi_escape.should eq("\e[4m")
+    Colorize.with.blink.ansi_escape.should eq("\e[5m")
+    Colorize.with.blink_fast.ansi_escape.should eq("\e[6m")
+    Colorize.with.reverse.ansi_escape.should eq("\e[7m")
+    Colorize.with.hidden.ansi_escape.should eq("\e[8m")
+    Colorize.with.strikethrough.ansi_escape.should eq("\e[9m")
+    Colorize.with.double_underline.ansi_escape.should eq("\e[21m")
+    Colorize.with.overline.ansi_escape.should eq("\e[53m")
   end
 
   it "only prints colorize ANSI escape codes" do
-    colorize("hello").red.bold.print.should eq("\e[31;1m")
-    colorize("hello").bold.dim.underline.blink.reverse.hidden.print.should eq("\e[1;2;4;5;7;8m")
+    colorize("hello").red.bold.ansi_escape.should eq("\e[31;1m")
+    colorize("hello").bold.dim.underline.blink.reverse.hidden.ansi_escape.should eq("\e[1;2;4;5;7;8m")
   end
 
   it "colorizes mode combination" do

--- a/src/colorize.cr
+++ b/src/colorize.cr
@@ -497,7 +497,7 @@ struct Colorize::Object(T)
   protected def self.print(io : IO, color : {fore: Color, back: Color, mode: Mode}) : Nil
     last_color = @@last_color
     append_start(io, color)
-    @@last_color = color
+    @@last_color = last_color
   end
 
   protected def self.surround(io, color, &)

--- a/src/colorize.cr
+++ b/src/colorize.cr
@@ -460,6 +460,26 @@ struct Colorize::Object(T)
     end
   end
 
+  # Prints the ANSI escape codes for an object. Note that this has no effect on a `Colorize::Object` with content,
+  # only the escape codes.
+  #
+  # ```
+  # require "colorize"
+  #
+  # Colorize.with.red.print        # => "\e[31m"
+  # "hello world".green.bold.print # => "\e[32;1m"
+  # ```
+  def print : String
+    String.build do |io|
+      print io
+    end
+  end
+
+  # Same as `print` but writes to a given *io*.
+  def print(io : IO) : Nil
+    self.class.print(io, to_named_tuple)
+  end
+
   private def to_named_tuple
     {
       fore: @fore,
@@ -473,6 +493,12 @@ struct Colorize::Object(T)
     back: ColorANSI::Default.as(Color),
     mode: Mode::None,
   }
+
+  protected def self.print(io : IO, color : {fore: Color, back: Color, mode: Mode}) : Nil
+    last_color = @@last_color
+    append_start(io, color)
+    @@last_color = color
+  end
 
   protected def self.surround(io, color, &)
     last_color = @@last_color

--- a/src/colorize.cr
+++ b/src/colorize.cr
@@ -466,18 +466,18 @@ struct Colorize::Object(T)
   # ```
   # require "colorize"
   #
-  # Colorize.with.red.print        # => "\e[31m"
-  # "hello world".green.bold.print # => "\e[32;1m"
+  # Colorize.with.red.ansi_escape        # => "\e[31m"
+  # "hello world".green.bold.ansi_escape # => "\e[32;1m"
   # ```
-  def print : String
+  def ansi_escape : String
     String.build do |io|
-      print io
+      ansi_escape io
     end
   end
 
-  # Same as `print` but writes to a given *io*.
-  def print(io : IO) : Nil
-    self.class.print(io, to_named_tuple)
+  # Same as `ansi_escape` but writes to a given *io*.
+  def ansi_escape(io : IO) : Nil
+    self.class.ansi_escape(io, to_named_tuple)
   end
 
   private def to_named_tuple
@@ -494,7 +494,7 @@ struct Colorize::Object(T)
     mode: Mode::None,
   }
 
-  protected def self.print(io : IO, color : {fore: Color, back: Color, mode: Mode}) : Nil
+  protected def self.ansi_escape(io : IO, color : {fore: Color, back: Color, mode: Mode}) : Nil
     last_color = @@last_color
     append_start(io, color)
     @@last_color = last_color


### PR DESCRIPTION
Closes #15079. ~~I am cautious of the spec test for `.bright.print` as it returned different results when testing.~~ (resolved now)