### PR TITLE
Disable specs that break on MinGW-w64

### DIFF
--- a/spec/compiler/codegen/pointer_spec.cr
+++ b/spec/compiler/codegen/pointer_spec.cr
@@ -492,28 +492,33 @@ describe "Code gen: pointer" do
       )).to_b.should be_true
   end
 
-  it "takes pointerof lib external var" do
-    test_c(
-      %(
-        int external_var = 0;
-      ),
-      %(
-        lib LibFoo
-          $external_var : Int32
-        end
+  # FIXME: `$external_var` implies __declspec(dllimport), but we only have an
+  # object file, so MinGW-w64 fails linking (actually MSVC also emits an
+  # LNK4217 linker warning)
+  {% unless flag?(:win32) && flag?(:gnu) %}
+    it "takes pointerof lib external var" do
+      test_c(
+        %(
+          int external_var = 0;
+        ),
+        %(
+          lib LibFoo
+            $external_var : Int32
+          end
 
-        LibFoo.external_var = 1
+          LibFoo.external_var = 1
 
-        ptr = pointerof(LibFoo.external_var)
-        x = ptr.value
+          ptr = pointerof(LibFoo.external_var)
+          x = ptr.value
 
-        ptr.value = 10
-        y = ptr.value
+          ptr.value = 10
+          y = ptr.value
 
-        ptr.value = 100
-        z = LibFoo.external_var
+          ptr.value = 100
+          z = LibFoo.external_var
 
-        x + y + z
-      ), &.to_i.should eq(111))
-  end
+          x + y + z
+        ), &.to_i.should eq(111))
+    end
+  {% end %}
 end

--- a/spec/compiler/codegen/thread_local_spec.cr
+++ b/spec/compiler/codegen/thread_local_spec.cr
@@ -1,4 +1,4 @@
-{% skip_file if flag?(:openbsd) %}
+{% skip_file if flag?(:openbsd) || (flag?(:win32) && flag?(:gnu)) %}
 
 require "../../spec_helper"
 

--- a/spec/std/kernel_spec.cr
+++ b/spec/std/kernel_spec.cr
@@ -8,6 +8,14 @@ describe "PROGRAM_NAME" do
         pending! "Example is broken in Nix shell (#12332)"
       end
 
+      # MSYS2: gcc/ld doesn't support unicode paths
+      # https://github.com/msys2/MINGW-packages/issues/17812
+      {% if flag?(:windows) %}
+        if ENV["MSYSTEM"]?
+          pending! "Example is broken in MSYS2 shell"
+        end
+      {% end %}
+
       File.write(source_file, "File.basename(PROGRAM_NAME).inspect(STDOUT)")
 
       compile_file(source_file, bin_name: "×‽😂") do |executable_file|


### PR DESCRIPTION
These specs do not have straightforward workarounds when run under MSYS2.