### PR TITLE
OpenBSD: fix integration and broken specs

### DIFF
--- a/bin/crystal
+++ b/bin/crystal
@@ -196,7 +196,7 @@ esac
 if [ -x "$CRYSTAL_DIR/${CRYSTAL_BIN}" ]; then
   __warning_msg "Using compiled compiler at ${CRYSTAL_DIR#"$PWD/"}/${CRYSTAL_BIN}"
   exec "$CRYSTAL_DIR/${CRYSTAL_BIN}" "$@"
-elif !($PARENT_CRYSTAL_EXISTS); then
+elif (! $PARENT_CRYSTAL_EXISTS); then
   __error_msg 'You need to have a crystal executable in your path! or set CRYSTAL env variable'
   exit 1
 else

--- a/spec/compiler/loader/unix_spec.cr
+++ b/spec/compiler/loader/unix_spec.cr
@@ -40,7 +40,11 @@ describe Crystal::Loader do
       exc = expect_raises(Crystal::Loader::LoadError, /no such file|not found|cannot open/i) do
         Crystal::Loader.parse(["-l", "foo/bar.o"], search_paths: [] of String)
       end
-      exc.message.should contain File.join(Dir.current, "foo", "bar.o")
+      {% if flag?(:openbsd) %}
+        exc.message.should contain "foo/bar.o"
+      {% else %}
+        exc.message.should contain File.join(Dir.current, "foo", "bar.o")
+      {% end %}
     end
   end
 

--- a/spec/std/exception/call_stack_spec.cr
+++ b/spec/std/exception/call_stack_spec.cr
@@ -55,14 +55,19 @@ describe "Backtrace" do
     error.to_s.should contain("IndexError")
   end
 
-  it "prints crash backtrace to stderr", tags: %w[slow] do
-    sample = datapath("crash_backtrace_sample")
+  {% if flag?(:openbsd) %}
+    # FIXME: the segfault handler doesn't work on OpenBSD
+    pending "prints crash backtrace to stderr"
+  {% else %}
+    it "prints crash backtrace to stderr", tags: %w[slow] do
+      sample = datapath("crash_backtrace_sample")
 
-    _, output, error = compile_and_run_file(sample)
+      _, output, error = compile_and_run_file(sample)
 
-    output.to_s.should be_empty
-    error.to_s.should contain("Invalid memory access")
-  end
+      output.to_s.should be_empty
+      error.to_s.should contain("Invalid memory access")
+    end
+  {% end %}
 
   # Do not test this on platforms that cannot remove the current working
   # directory of the process:

--- a/spec/std/io/io_spec.cr
+++ b/spec/std/io/io_spec.cr
@@ -425,9 +425,9 @@ describe IO do
       str.read_fully?(slice).should be_nil
     end
 
-    # pipe(2) returns bidirectional file descriptors on FreeBSD and Solaris,
+    # pipe(2) returns bidirectional file descriptors on some platforms,
     # gate this test behind the platform flag.
-    {% unless flag?(:freebsd) || flag?(:solaris) %}
+    {% unless flag?(:freebsd) || flag?(:solaris) || flag?(:openbsd) %}
       it "raises if trying to read to an IO not opened for reading" do
         IO.pipe do |r, w|
           expect_raises(IO::Error, "File not open for reading") do
@@ -574,9 +574,9 @@ describe IO do
       io.read_byte.should be_nil
     end
 
-    # pipe(2) returns bidirectional file descriptors on FreeBSD and Solaris,
+    # pipe(2) returns bidirectional file descriptors on some platforms,
     # gate this test behind the platform flag.
-    {% unless flag?(:freebsd) || flag?(:solaris) %}
+    {% unless flag?(:freebsd) || flag?(:solaris) || flag?(:openbsd) %}
       it "raises if trying to write to an IO not opened for writing" do
         IO.pipe do |r, w|
           # unless sync is used the flush on close triggers the exception again

--- a/spec/std/socket/addrinfo_spec.cr
+++ b/spec/std/socket/addrinfo_spec.cr
@@ -24,8 +24,8 @@ describe Socket::Addrinfo, tags: "network" do
     end
 
     it "raises helpful message on getaddrinfo failure" do
-      expect_raises(Socket::Addrinfo::Error, "Hostname lookup for badhostname failed: ") do
-        Socket::Addrinfo.resolve("badhostname", 80, type: Socket::Type::DGRAM)
+      expect_raises(Socket::Addrinfo::Error, "Hostname lookup for badhostname.unknown failed: ") do
+        Socket::Addrinfo.resolve("badhostname.unknown", 80, type: Socket::Type::DGRAM)
       end
     end
 

--- a/spec/std/socket/tcp_server_spec.cr
+++ b/spec/std/socket/tcp_server_spec.cr
@@ -43,7 +43,7 @@ describe TCPServer, tags: "network" do
         end
         error.os_error.should eq({% if flag?(:win32) %}
           WinError::WSATYPE_NOT_FOUND
-        {% elsif flag?(:linux) && !flag?(:android) %}
+        {% elsif (flag?(:linux) && !flag?(:android)) || flag?(:openbsd) %}
           Errno.new(LibC::EAI_SERVICE)
         {% else %}
           Errno.new(LibC::EAI_NONAME)
@@ -96,7 +96,7 @@ describe TCPServer, tags: "network" do
         # FIXME: Resolve special handling for win32. The error code handling should be identical.
         {% if flag?(:win32) %}
           [WinError::WSAHOST_NOT_FOUND, WinError::WSATRY_AGAIN].should contain err.os_error
-        {% elsif flag?(:android) || flag?(:netbsd) %}
+        {% elsif flag?(:android) || flag?(:netbsd) || flag?(:openbsd) %}
           err.os_error.should eq(Errno.new(LibC::EAI_NODATA))
         {% else %}
           [Errno.new(LibC::EAI_NONAME), Errno.new(LibC::EAI_AGAIN)].should contain err.os_error
@@ -110,7 +110,7 @@ describe TCPServer, tags: "network" do
         # FIXME: Resolve special handling for win32. The error code handling should be identical.
         {% if flag?(:win32) %}
           [WinError::WSAHOST_NOT_FOUND, WinError::WSATRY_AGAIN].should contain err.os_error
-        {% elsif flag?(:android) || flag?(:netbsd) %}
+        {% elsif flag?(:android) || flag?(:netbsd) || flag?(:openbsd) %}
           err.os_error.should eq(Errno.new(LibC::EAI_NODATA))
         {% else %}
           [Errno.new(LibC::EAI_NONAME), Errno.new(LibC::EAI_AGAIN)].should contain err.os_error

--- a/spec/std/socket/tcp_socket_spec.cr
+++ b/spec/std/socket/tcp_socket_spec.cr
@@ -47,7 +47,7 @@ describe TCPSocket, tags: "network" do
         end
         error.os_error.should eq({% if flag?(:win32) %}
           WinError::WSATYPE_NOT_FOUND
-        {% elsif flag?(:linux) && !flag?(:android) %}
+        {% elsif (flag?(:linux) && !flag?(:android)) || flag?(:openbsd) %}
           Errno.new(LibC::EAI_SERVICE)
         {% else %}
           Errno.new(LibC::EAI_NONAME)
@@ -79,7 +79,7 @@ describe TCPSocket, tags: "network" do
         # FIXME: Resolve special handling for win32. The error code handling should be identical.
         {% if flag?(:win32) %}
           [WinError::WSAHOST_NOT_FOUND, WinError::WSATRY_AGAIN].should contain err.os_error
-        {% elsif flag?(:android) || flag?(:netbsd) %}
+        {% elsif flag?(:android) || flag?(:netbsd) || flag?(:openbsd) %}
           err.os_error.should eq(Errno.new(LibC::EAI_NODATA))
         {% else %}
           [Errno.new(LibC::EAI_NONAME), Errno.new(LibC::EAI_AGAIN)].should contain err.os_error
@@ -93,7 +93,7 @@ describe TCPSocket, tags: "network" do
         # FIXME: Resolve special handling for win32. The error code handling should be identical.
         {% if flag?(:win32) %}
           [WinError::WSAHOST_NOT_FOUND, WinError::WSATRY_AGAIN].should contain err.os_error
-        {% elsif flag?(:android) || flag?(:netbsd) %}
+        {% elsif flag?(:android) || flag?(:netbsd) || flag?(:openbsd) %}
           err.os_error.should eq(Errno.new(LibC::EAI_NODATA))
         {% else %}
           [Errno.new(LibC::EAI_NONAME), Errno.new(LibC::EAI_AGAIN)].should contain err.os_error

--- a/spec/std/socket/udp_socket_spec.cr
+++ b/spec/std/socket/udp_socket_spec.cr
@@ -88,6 +88,9 @@ describe UDPSocket, tags: "network" do
     elsif {{ flag?(:netbsd) }} && family == Socket::Family::INET6
       # FIXME: fails with "setsockopt: EADDRNOTAVAIL"
       pending "joins and transmits to multicast groups"
+    elsif {{ flag?(:openbsd) }}
+      # FIXME: fails with "setsockopt: EINVAL (ipv4) or EADDRNOTAVAIL (ipv6)"
+      pending "joins and transmits to multicast groups"
     else
       it "joins and transmits to multicast groups" do
         udp = UDPSocket.new(family)

--- a/src/compiler/crystal/compiler.cr
+++ b/src/compiler/crystal/compiler.cr
@@ -501,6 +501,12 @@ module Crystal
         link_flags = @link_flags || ""
         link_flags += " -rdynamic"
 
+        if program.has_flag?("freebsd") || program.has_flag?("openbsd")
+          # pkgs are installed to usr/local/lib but it's not in LIBRARY_PATH by
+          # default; we declare it to ease linking on these platforms:
+          link_flags += " -L/usr/local/lib"
+        end
+
         if program.has_flag?("openbsd")
           # OpenBSD requires Indirect Branch Tracking by default, but we're not
           # compatible (yet), so we disable it for now:

--- a/src/compiler/crystal/compiler.cr
+++ b/src/compiler/crystal/compiler.cr
@@ -500,6 +500,13 @@ module Crystal
       else
         link_flags = @link_flags || ""
         link_flags += " -rdynamic"
+
+        if program.has_flag?("openbsd")
+          # OpenBSD requires Indirect Branch Tracking by default, but we're not
+          # compatible (yet), so we disable it for now:
+          link_flags += " -Wl,-znobtcfi"
+        end
+
         {DEFAULT_LINKER, %(#{DEFAULT_LINKER} "${@}" -o #{Process.quote_posix(output_filename)} #{link_flags} #{program.lib_flags(@cross_compile)}), object_names}
       end
     end

--- a/src/lib_c/x86_64-openbsd/c/netdb.cr
+++ b/src/lib_c/x86_64-openbsd/c/netdb.cr
@@ -13,6 +13,7 @@ lib LibC
   EAI_FAIL       =  -4
   EAI_FAMILY     =  -6
   EAI_MEMORY     = -10
+  EAI_NODATA     =  -5
   EAI_NONAME     =  -2
   EAI_SERVICE    =  -8
   EAI_SOCKTYPE   =  -7


### PR DESCRIPTION
Follow up of #15115 but for OpenBSD.

Fixes compatibility with OpenBSD 7.4 that enforced indirect branch tracking by default but we're not compatible yet (see #13665), so we must disable it.

With this patch I can run the std specs, except for the SSL specs because of openssl/libressl mess, as well as the compiler specs, except for the interpreter specs that regularly crash with SIGABRT (may help to debug issues in the interpreter).

Note: the segfault handler is broken on OpenBSD and processes eventually crash with SIGILL after receiving SIGSEGV.