### PR TITLE
Use per-thread libxml2 global state on all platforms

### DIFF
--- a/src/xml.cr
+++ b/src/xml.cr
@@ -107,12 +107,7 @@ module XML
   end
 
   protected def self.with_indent_tree_output(indent : Bool, &)
-    ptr = {% if flag?(:win32) %}
-            LibXML.__xmlIndentTreeOutput
-          {% else %}
-            pointerof(LibXML.xmlIndentTreeOutput)
-          {% end %}
-
+    ptr = LibXML.__xmlIndentTreeOutput
     old, ptr.value = ptr.value, indent ? 1 : 0
     begin
       yield
@@ -122,12 +117,7 @@ module XML
   end
 
   protected def self.with_tree_indent_string(string : String, &)
-    ptr = {% if flag?(:win32) %}
-            LibXML.__xmlTreeIndentString
-          {% else %}
-            pointerof(LibXML.xmlTreeIndentString)
-          {% end %}
-
+    ptr = LibXML.__xmlTreeIndentString
     old, ptr.value = ptr.value, string.to_unsafe
     begin
       yield

--- a/src/xml/libxml2.cr
+++ b/src/xml/libxml2.cr
@@ -13,14 +13,8 @@ lib LibXML
 
   fun xmlInitParser
 
-  # TODO: check if other platforms also support per-thread globals
-  {% if flag?(:win32) %}
-    fun __xmlIndentTreeOutput : Int*
-    fun __xmlTreeIndentString : UInt8**
-  {% else %}
-    $xmlIndentTreeOutput : Int
-    $xmlTreeIndentString : UInt8*
-  {% end %}
+  fun __xmlIndentTreeOutput : Int*
+  fun __xmlTreeIndentString : UInt8**
 
   alias Dtd = Void*
   alias Dict = Void*


### PR DESCRIPTION
Follow-up to #13486.

libxml2's build files enable threads by default, so I'd be surprised if any platform still disables them (embedded systems don't count yet).