### PR TITLE
Add MinGW-w64 CI workflow for stdlib and compiler specs

### DIFF
--- a/.github/workflows/mingw-w64.yml
+++ b/.github/workflows/mingw-w64.yml
@@ -8,6 +8,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: ${{ github.ref != 'refs/heads/master' }}
 
+env:
+  SPEC_SPLIT_DOTS: 160
+
 jobs:
   x86_64-mingw-w64-cross-compile:
     runs-on: ubuntu-24.04
@@ -89,3 +92,63 @@ jobs:
           path: |
             bin/
             share/
+
+  x86_64-mingw-w64-test:
+    runs-on: windows-2022
+    needs: [x86_64-mingw-w64-link]
+    steps:
+      - name: Setup MSYS2
+        id: msys2
+        uses: msys2/setup-msys2@ddf331adaebd714795f1042345e6ca57bd66cea8 # v2.24.1
+        with:
+          msystem: UCRT64
+          update: true
+          install: >-
+            git
+            make
+            mingw-w64-ucrt-x86_64-pkgconf
+            mingw-w64-ucrt-x86_64-cc
+            mingw-w64-ucrt-x86_64-gc
+            mingw-w64-ucrt-x86_64-pcre2
+            mingw-w64-ucrt-x86_64-libiconv
+            mingw-w64-ucrt-x86_64-zlib
+            mingw-w64-ucrt-x86_64-llvm
+            mingw-w64-ucrt-x86_64-gmp
+            mingw-w64-ucrt-x86_64-libxml2
+            mingw-w64-ucrt-x86_64-libyaml
+            mingw-w64-ucrt-x86_64-openssl
+            mingw-w64-ucrt-x86_64-libffi
+
+      - name: Disable CRLF line ending substitution
+        run: |
+          git config --global core.autocrlf false
+
+      - name: Download Crystal source
+        uses: actions/checkout@v4
+
+      - name: Download Crystal executable
+        uses: actions/download-artifact@v4
+        with:
+          name: x86_64-mingw-w64-crystal
+          path: crystal
+
+      - name: Run stdlib specs
+        shell: msys2 {0}
+        run: |
+          export PATH="$(pwd)/crystal/bin:$PATH"
+          export CRYSTAL_SPEC_COMPILER_BIN="$(pwd)/crystal/bin/crystal.exe"
+          make std_spec
+
+      - name: Run compiler specs
+        shell: msys2 {0}
+        run: |
+          export PATH="$(pwd)/crystal/bin:$PATH"
+          export CRYSTAL_SPEC_COMPILER_BIN="$(pwd)/crystal/bin/crystal.exe"
+          make compiler_spec FLAGS=-Dwithout_ffi
+
+      - name: Run primitives specs
+        shell: msys2 {0}
+        run: |
+          export PATH="$(pwd)/crystal/bin:$PATH"
+          export CRYSTAL_SPEC_COMPILER_BIN="$(pwd)/crystal/bin/crystal.exe"
+          make -o .build/crystal.exe primitives_spec # we know the compiler is fresh; do not rebuild it here

--- a/src/compiler/crystal/compiler.cr
+++ b/src/compiler/crystal/compiler.cr
@@ -479,7 +479,7 @@ module Crystal
         link_flags += " -Wl,--stack,0x800000"
         lib_flags = program.lib_flags(@cross_compile)
         lib_flags = expand_lib_flags(lib_flags) if expand
-        cmd = %(#{DEFAULT_LINKER} #{Process.quote_windows(object_names)} -o #{Process.quote_windows(output_filename)} #{link_flags} #{lib_flags})
+        cmd = %(#{DEFAULT_LINKER} #{Process.quote_windows(object_names)} -o #{Process.quote_windows(output_filename)} #{link_flags} #{lib_flags}).gsub('\n', ' ')
 
         if cmd.size > 32000
           # The command line would be too big, pass the args through a file instead.


### PR DESCRIPTION
Resolves part of #6170.

The use of the build artifact is temporary; once Crystal is available from MSYS2's Pacman, we should be able to use that directly for the test job. (The build job needs to stay because we need that artifact to bootstrap the Pacman build first.)

The MSYS Git is only needed for `spec/compiler/crystal/tools/init_spec.cr` and `spec/compiler/crystal/tools/doc/project_info_spec.cr`. Apparently some of the specs in those files fail if Git cannot be located at all.

As a final touch, this PR also ensures build commands have their embedded newlines replaced with whitespace, just like for MSVC, otherwise tools like `ld.exe` might consider `\n-lLLVM-18\n` on the command line a single argument and fail.