### PR TITLE
Allow skipping compiler tool specs that require Git

### DIFF
--- a/spec/compiler/crystal/tools/doc/project_info_spec.cr
+++ b/spec/compiler/crystal/tools/doc/project_info_spec.cr
@@ -5,6 +5,8 @@ private alias ProjectInfo = Crystal::Doc::ProjectInfo
 
 private def run_git(command)
   Process.run(%(git -c user.email="" -c user.name="spec" #{command}), shell: true)
+rescue IO::Error
+  pending! "Git is not available"
 end
 
 private def assert_with_defaults(initial, expected, *, file = __FILE__, line = __LINE__)

--- a/spec/compiler/crystal/tools/init_spec.cr
+++ b/spec/compiler/crystal/tools/init_spec.cr
@@ -41,9 +41,17 @@ private def run_init_project(skeleton_type, name, author, email, github_name, di
   ).run
 end
 
+private def git_available?
+  Process.run(Crystal::Git.executable).success?
+rescue IO::Error
+  false
+end
+
 module Crystal
   describe Init::InitProject do
     it "correctly uses git config" do
+      pending! "Git is not available" unless git_available?
+
       within_temporary_directory do
         File.write(".gitconfig", <<-INI)
         [user]
@@ -212,9 +220,11 @@ module Crystal
           )
         end
 
-        with_file "example/.git/config" { }
+        if git_available?
+          with_file "example/.git/config" { }
 
-        with_file "other-example-directory/.git/config" { }
+          with_file "other-example-directory/.git/config" { }
+        end
       end
     end
   end


### PR DESCRIPTION
Under rare circumstances like a minimal MSYS2 setup (e.g. the CI in #15124), Git might not be available at all when running the compiler specs, but this is not a hard failure for `crystal init` and `crystal docs`. This PR marks the relevant specs as pending if Git cannot be found.