### PR TITLE
Update byte_format.cr example to not use uninitialized

### DIFF
--- a/src/io/byte_format.cr
+++ b/src/io/byte_format.cr
@@ -20,9 +20,9 @@
 # ### Encode to bytes
 #
 # ```
-# raw = uninitialized UInt8[2]
-# IO::ByteFormat::LittleEndian.encode(0x1234_i16, raw.to_slice)
-# raw # => StaticArray[0x34, 0x12]
+# bytes = StaticArray(UInt8, 2).new 0
+# IO::ByteFormat::LittleEndian.encode(0x1234_i16, bytes.to_slice)
+# bytes # => StaticArray[0x34, 0x12]
 # ```
 #
 # ### Encode to IO


### PR DESCRIPTION
Using an unsafe method as the primary example isn't particularly good IMO. Initialising the `StaticArray` with 0s comes with a slight overheard, but I still think it's a better example use-case.