### PR TITLE
Improve docs for `String#rindex!`

### DIFF
--- a/src/string.cr
+++ b/src/string.cr
@@ -3586,9 +3586,17 @@ class String
     match_result.try &.begin
   end
 
-  # :ditto:
-  #
+  # Returns the index of the _last_ appearance of *search* in the string,
+  # If *offset* is present, it defines the position to _end_ the search
+  # (characters beyond this point are ignored).
   # Raises `Enumerable::NotFoundError` if *search* does not occur in `self`.
+  #
+  # ```
+  # "Hello, World".rindex!('o')    # => 8
+  # "Hello, World".rindex!('Z')    # => Enumerable::NotFoundError
+  # "Hello, World".rindex!("o", 5) # => 4
+  # "Hello, World".rindex!("W", 2) # => Enumerable::NotFoundError
+  # ```
   def rindex!(search : Regex, offset = size, *, options : Regex::MatchOptions = Regex::MatchOptions::None) : Int32
     rindex(search, offset, options: options) || raise Enumerable::NotFoundError.new
   end

--- a/src/string.cr
+++ b/src/string.cr
@@ -3471,10 +3471,8 @@ class String
   # (characters beyond this point are ignored).
   #
   # ```
-  # "Hello, World".rindex('o')    # => 8
-  # "Hello, World".rindex('Z')    # => nil
-  # "Hello, World".rindex("o", 5) # => 4
-  # "Hello, World".rindex("W", 2) # => nil
+  # "Hello, World".rindex('o') # => 8
+  # "Hello, World".rindex('Z') # => nil
   # ```
   def rindex(search : Char, offset = size - 1)
     # If it's ASCII we can delegate to slice
@@ -3519,7 +3517,14 @@ class String
     end
   end
 
-  # :ditto:
+  # Returns the index of the _last_ appearance of *search* in the string,
+  # If *offset* is present, it defines the position to _end_ the search
+  # (characters beyond this point are ignored).
+  #
+  # ```
+  # "Hello, World".rindex("orld")    # => 8
+  # "Hello, World".rindex("snorlax") # => nil
+  # ```
   def rindex(search : String, offset = size - search.size) : Int32?
     offset += size if offset < 0
     return if offset < 0
@@ -3572,7 +3577,14 @@ class String
     end
   end
 
-  # :ditto:
+  # Returns the index of the _last_ appearance of *search* in the string,
+  # If *offset* is present, it defines the position to _end_ the search
+  # (characters beyond this point are ignored).
+  #
+  # ```
+  # "Hello, World".rindex(/world/i) # => 7
+  # "Hello, World".rindex(/world/)  # => nil
+  # ```
   def rindex(search : Regex, offset = size, *, options : Regex::MatchOptions = Regex::MatchOptions::None) : Int32?
     offset += size if offset < 0
     return nil unless 0 <= offset <= size
@@ -3592,23 +3604,37 @@ class String
   # Raises `Enumerable::NotFoundError` if *search* does not occur in `self`.
   #
   # ```
-  # "Hello, World".rindex!('o')    # => 8
-  # "Hello, World".rindex!('Z')    # => Enumerable::NotFoundError
-  # "Hello, World".rindex!("o", 5) # => 4
-  # "Hello, World".rindex!("W", 2) # => Enumerable::NotFoundError
+  # "Hello, World".rindex('o') # => 8
+  # "Hello, World".rindex('Z') # => Enumerable::NotFoundError
   # ```
-  def rindex!(search : Regex, offset = size, *, options : Regex::MatchOptions = Regex::MatchOptions::None) : Int32
-    rindex(search, offset, options: options) || raise Enumerable::NotFoundError.new
+  def rindex!(search : Char, offset = size - 1) : Int32
+    rindex(search, offset) || raise Enumerable::NotFoundError.new
   end
 
-  # :ditto:
+  # Returns the index of the _last_ appearance of *search* in the string,
+  # If *offset* is present, it defines the position to _end_ the search
+  # (characters beyond this point are ignored).
+  # Raises `Enumerable::NotFoundError` if *search* does not occur in `self`.
+  #
+  # ```
+  # "Hello, World".rindex("orld")    # => 8
+  # "Hello, World".rindex("snorlax") # => nil
+  # ```
   def rindex!(search : String, offset = size - search.size) : Int32
     rindex(search, offset) || raise Enumerable::NotFoundError.new
   end
 
-  # :ditto:
-  def rindex!(search : Char, offset = size - 1) : Int32
-    rindex(search, offset) || raise Enumerable::NotFoundError.new
+  # Returns the index of the _last_ appearance of *search* in the string,
+  # If *offset* is present, it defines the position to _end_ the search
+  # (characters beyond this point are ignored).
+  # Raises `Enumerable::NotFoundError` if *search* does not occur in `self`.
+  #
+  # ```
+  # "Hello, World".rindex(/world/i) # => 7
+  # "Hello, World".rindex(/world/)  # => nil
+  # ```
+  def rindex!(search : Regex, offset = size, *, options : Regex::MatchOptions = Regex::MatchOptions::None) : Int32
+    rindex(search, offset, options: options) || raise Enumerable::NotFoundError.new
   end
 
   # Searches separator or pattern (`Regex`) in the string, and returns

--- a/src/string.cr
+++ b/src/string.cr
@@ -3471,8 +3471,10 @@ class String
   # (characters beyond this point are ignored).
   #
   # ```
-  # "Hello, World".rindex('o') # => 8
-  # "Hello, World".rindex('Z') # => nil
+  # "Hello, World".rindex('o')    # => 8
+  # "Hello, World".rindex('Z')    # => nil
+  # "Hello, World".rindex('o', 5) # => 4
+  # "Hello, World".rindex('W', 2) # => nil
   # ```
   def rindex(search : Char, offset = size - 1)
     # If it's ASCII we can delegate to slice
@@ -3524,6 +3526,8 @@ class String
   # ```
   # "Hello, World".rindex("orld")    # => 8
   # "Hello, World".rindex("snorlax") # => nil
+  # "Hello, World".rindex("o", 5)    # => 4
+  # "Hello, World".rindex("W", 2)    # => nil
   # ```
   def rindex(search : String, offset = size - search.size) : Int32?
     offset += size if offset < 0
@@ -3584,6 +3588,8 @@ class String
   # ```
   # "Hello, World".rindex(/world/i) # => 7
   # "Hello, World".rindex(/world/)  # => nil
+  # "Hello, World".rindex(/o/, 5)   # => 4
+  # "Hello, World".rindex(/W/, 2)   # => nil
   # ```
   def rindex(search : Regex, offset = size, *, options : Regex::MatchOptions = Regex::MatchOptions::None) : Int32?
     offset += size if offset < 0
@@ -3604,8 +3610,10 @@ class String
   # Raises `Enumerable::NotFoundError` if *search* does not occur in `self`.
   #
   # ```
-  # "Hello, World".rindex('o') # => 8
-  # "Hello, World".rindex('Z') # => Enumerable::NotFoundError
+  # "Hello, World".rindex!('o')    # => 8
+  # "Hello, World".rindex!('Z')    # raises Enumerable::NotFoundError
+  # "Hello, World".rindex!('o', 5) # => 4
+  # "Hello, World".rindex!('W', 2) # raises Enumerable::NotFoundError
   # ```
   def rindex!(search : Char, offset = size - 1) : Int32
     rindex(search, offset) || raise Enumerable::NotFoundError.new
@@ -3617,8 +3625,10 @@ class String
   # Raises `Enumerable::NotFoundError` if *search* does not occur in `self`.
   #
   # ```
-  # "Hello, World".rindex("orld")    # => 8
-  # "Hello, World".rindex("snorlax") # => Enumerable::NotFoundError
+  # "Hello, World".rindex!("orld")    # => 8
+  # "Hello, World".rindex!("snorlax") # raises Enumerable::NotFoundError
+  # "Hello, World".rindex!("o", 5)    # => 4
+  # "Hello, World".rindex!("W", 2)    # raises Enumerable::NotFoundError
   # ```
   def rindex!(search : String, offset = size - search.size) : Int32
     rindex(search, offset) || raise Enumerable::NotFoundError.new
@@ -3630,8 +3640,10 @@ class String
   # Raises `Enumerable::NotFoundError` if *search* does not occur in `self`.
   #
   # ```
-  # "Hello, World".rindex(/world/i) # => 7
-  # "Hello, World".rindex(/world/)  # => Enumerable::NotFoundError
+  # "Hello, World".rindex!(/world/i) # => 7
+  # "Hello, World".rindex!(/world/)  # raises Enumerable::NotFoundError
+  # "Hello, World".rindex!(/o/, 5)   # => 4
+  # "Hello, World".rindex!(/W/, 2)   # raises Enumerable::NotFoundError
   # ```
   def rindex!(search : Regex, offset = size, *, options : Regex::MatchOptions = Regex::MatchOptions::None) : Int32
     rindex(search, offset, options: options) || raise Enumerable::NotFoundError.new

--- a/src/string.cr
+++ b/src/string.cr
@@ -3618,7 +3618,7 @@ class String
   #
   # ```
   # "Hello, World".rindex("orld")    # => 8
-  # "Hello, World".rindex("snorlax") # => nil
+  # "Hello, World".rindex("snorlax") # => Enumerable::NotFoundError
   # ```
   def rindex!(search : String, offset = size - search.size) : Int32
     rindex(search, offset) || raise Enumerable::NotFoundError.new
@@ -3631,7 +3631,7 @@ class String
   #
   # ```
   # "Hello, World".rindex(/world/i) # => 7
-  # "Hello, World".rindex(/world/)  # => nil
+  # "Hello, World".rindex(/world/)  # => Enumerable::NotFoundError
   # ```
   def rindex!(search : Regex, offset = size, *, options : Regex::MatchOptions = Regex::MatchOptions::None) : Int32
     rindex(search, offset, options: options) || raise Enumerable::NotFoundError.new


### PR DESCRIPTION
`rindex!` is currently copying the `rindex` example, which explicitly states that it returns `nil`. 
![image](https://github.com/user-attachments/assets/04c5429c-af52-40be-a8c0-6b902fbea419)