### PR TITLE
Fix `Crystal::Loader.default_search_paths` spec for macOS

### DIFF
--- a/spec/compiler/loader/unix_spec.cr
+++ b/spec/compiler/loader/unix_spec.cr
@@ -53,7 +53,7 @@ describe Crystal::Loader do
       with_env "LD_LIBRARY_PATH": "ld1::ld2", "DYLD_LIBRARY_PATH": nil do
         search_paths = Crystal::Loader.default_search_paths
         {% if flag?(:darwin) %}
-          search_paths.should eq ["/usr/lib", "/usr/local/lib"]
+          search_paths[-2..].should eq ["/usr/lib", "/usr/local/lib"]
         {% else %}
           search_paths[0, 2].should eq ["ld1", "ld2"]
           {% if flag?(:android) %}


### PR DESCRIPTION
This is a genuine failure introduced by #15127 because the whole `search_paths` has an extra element referring to the Nix store.