### PR TITLE
Make `Box` constructor and `object` getter nodoc

### DIFF
--- a/src/box.cr
+++ b/src/box.cr
@@ -5,9 +5,13 @@
 #
 # For an example usage, see `Proc`'s explanation about sending Procs to C.
 class Box(T)
+  # :nodoc:
+  #
   # Returns the original object
   getter object : T
 
+  # :nodoc:
+  #
   # Creates a `Box` with the given object.
   #
   # This method isn't usually used directly. Instead, `Box.box` is used.


### PR DESCRIPTION
The only really useful public API for `Box` are the `.box` and `.unbox` methods. There is no need to create an instance explicitly or deal with an instance in any matter. Instance are confined to the class methods.