### PR TITLE
Make utilities posix compatible

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -144,7 +144,7 @@ samples: ## Build example programs
 docs: ## Generate standard library documentation
 	$(call check_llvm_config)
 	./bin/crystal docs src/docs_main.cr $(DOCS_OPTIONS) --project-name=Crystal --project-version=$(CRYSTAL_VERSION) --source-refname=$(CRYSTAL_CONFIG_BUILD_COMMIT)
-	cp -av doc/ docs/
+	cp -R -P -p doc/ docs/
 
 .PHONY: crystal
 crystal: $(O)/$(CRYSTAL_BIN) ## Build the compiler
@@ -167,7 +167,7 @@ install: $(O)/$(CRYSTAL_BIN) man/crystal.1.gz ## Install the compiler at DESTDIR
 	$(INSTALL) -m 0755 "$(O)/$(CRYSTAL_BIN)" "$(BINDIR)/$(CRYSTAL_BIN)"
 
 	$(INSTALL) -d -m 0755 $(DATADIR)
-	cp -av src "$(DATADIR)/src"
+	cp -R -P -p src "$(DATADIR)/src"
 	rm -rf "$(DATADIR)/$(LLVM_EXT_OBJ)" # Don't install llvm_ext.o
 
 	$(INSTALL) -d -m 0755 "$(MANDIR)/man1/"
@@ -205,8 +205,8 @@ uninstall: ## Uninstall the compiler from DESTDIR
 install_docs: docs ## Install docs at DESTDIR
 	$(INSTALL) -d -m 0755 $(DATADIR)
 
-	cp -av docs "$(DATADIR)/docs"
-	cp -av samples "$(DATADIR)/examples"
+	cp -R -P -p docs "$(DATADIR)/docs"
+	cp -R -P -p samples "$(DATADIR)/examples"
 
 .PHONY: uninstall_docs
 uninstall_docs: ## Uninstall docs from DESTDIR

--- a/Makefile
+++ b/Makefile
@@ -168,7 +168,7 @@ install: $(O)/$(CRYSTAL_BIN) man/crystal.1.gz ## Install the compiler at DESTDIR
 	$(INSTALL) -m 0755 "$(O)/$(CRYSTAL_BIN)" "$(BINDIR)/$(CRYSTAL_BIN)"
 
 	$(INSTALL) -d -m 0755 $(DATADIR)
-	cp -R $(if $(deref_symlinks),-L --preserve=all,-P -p) src "$(DATADIR)/src"
+	cp -R -p $(if $(deref_symlinks),-L,-P) src "$(DATADIR)/src"
 	rm -rf "$(DATADIR)/$(LLVM_EXT_OBJ)" # Don't install llvm_ext.o
 
 	$(INSTALL) -d -m 0755 "$(MANDIR)/man1/"

--- a/bin/crystal
+++ b/bin/crystal
@@ -32,10 +32,8 @@ resolve_symlinks() {
     _resolve_symlinks "$1"
 }
 
-_resolve_symlinks() {
+_resolve_symlinks() (
     _assert_no_path_cycles "$@" || return
-
-    local dir_context path
 
     if path=$(readlink -- "$1"); then
         dir_context=$(dirname -- "$1")
@@ -43,7 +41,7 @@ _resolve_symlinks() {
     else
         printf '%s\n' "$1"
     fi
-}
+)
 
 _prepend_dir_context_if_necessary() {
     if [ "$1" = . ]; then
@@ -60,9 +58,7 @@ _prepend_path_if_relative() {
     esac
 }
 
-_assert_no_path_cycles() {
-    local target path
-
+_assert_no_path_cycles() (
     target=$1
     shift
 
@@ -71,7 +67,7 @@ _assert_no_path_cycles() {
             return 1
         fi
     done
-}
+)
 
 canonicalize_path() {
     if [ -d "$1" ]; then
@@ -85,35 +81,32 @@ _canonicalize_dir_path() {
     { cd "$1" 2>/dev/null && pwd -P; }
 }
 
-_canonicalize_file_path() {
-    local dir file
+_canonicalize_file_path() (
     dir=$(dirname -- "$1")
     file=$(basename -- "$1")
     { cd "$dir" 2>/dev/null >/dev/null && printf '%s/%s\n' "$(pwd -P)" "$file"; }
-}
+)
 
 ##############################################################################
 
 # Based on http://stackoverflow.com/q/370047/641451
-remove_path_item() {
-  local path item
-
+remove_path_item() (
   path="$1"
 
   printf "%s" "$path" | awk -v item="$2" -v RS=: -v ORS=: '$0 != item' | sed 's/:$//'
-}
+)
 
 ##############################################################################
 
-__has_colors() {
-  local num_colors=$(tput colors 2>/dev/null)
+__has_colors() (
+  num_colors=$(tput colors 2>/dev/null)
 
   if [ -n "$num_colors" ] && [ "$num_colors" -gt 2 ]; then
     return 0
   else
     return 1
   fi
-}
+)
 __error_msg() {
   if __has_colors; then
     # bold red coloring
@@ -148,7 +141,7 @@ export CRYSTAL_HAS_WRAPPER=true
 PARENT_CRYSTAL="$CRYSTAL"
 
 # check if the parent crystal command is a path that refers to this script
-if [ -z "${PARENT_CRYSTAL##*/*}" -a "$(realpath "$PARENT_CRYSTAL")" = "$SCRIPT_PATH" ]; then
+if [ -z "${PARENT_CRYSTAL##*/*}" ] && [ "$(realpath "$PARENT_CRYSTAL")" = "$SCRIPT_PATH" ]; then
   # ignore it and use `crystal` as parent compiler command
   PARENT_CRYSTAL="crystal"
 fi
@@ -174,8 +167,8 @@ PARENT_CRYSTAL_EXISTS=$(test !$?)
 if ($PARENT_CRYSTAL_EXISTS); then
   if [ -z "$CRYSTAL_CONFIG_LIBRARY_PATH" ] || [ -z "$CRYSTAL_LIBRARY_PATH" ]; then
     CRYSTAL_INSTALLED_LIBRARY_PATH="$($PARENT_CRYSTAL env CRYSTAL_LIBRARY_PATH 2> /dev/null || echo "")"
-    export CRYSTAL_LIBRARY_PATH=${CRYSTAL_LIBRARY_PATH:-$CRYSTAL_INSTALLED_LIBRARY_PATH}
-    export CRYSTAL_CONFIG_LIBRARY_PATH=${CRYSTAL_CONFIG_LIBRARY_PATH:-$CRYSTAL_INSTALLED_LIBRARY_PATH}
+    export CRYSTAL_LIBRARY_PATH="${CRYSTAL_LIBRARY_PATH:-$CRYSTAL_INSTALLED_LIBRARY_PATH}"
+    export CRYSTAL_CONFIG_LIBRARY_PATH="${CRYSTAL_CONFIG_LIBRARY_PATH:-$CRYSTAL_INSTALLED_LIBRARY_PATH}"
   fi
 fi
 


### PR DESCRIPTION
Replace `cp -av` with `cp -R -P -p` because neither `-a` nor `-v` are POSIX compliant (Makefile)

Replace `local` keyword in shell functions with subshell style `( )` functions.  (bin/crystal)

Fixed other Shellcheck warnings. (bin/crystal)

Fixes #14846