### PR TITLE
Strip `.1` minor version from `find-llvm-config` 

### DIFF
--- a/src/llvm/ext/find-llvm-config
+++ b/src/llvm/ext/find-llvm-config
@@ -26,6 +26,6 @@ if [ "$LLVM_CONFIG" ]; then
   esac
 else
   printf "Error: Could not find location of llvm-config. Please specify path in environment variable LLVM_CONFIG.\n" >&2
-  printf "Supported LLVM versions: $(cat "$(dirname $0)/llvm-versions.txt" | sed 's/\.0//g')\n" >&2
+  printf "Supported LLVM versions: $(cat "$(dirname $0)/llvm-versions.txt" | sed 's/\.[01]//g')\n" >&2
   exit 1
 fi


### PR DESCRIPTION
In its help message, the find message only strips `.0` minor from the version string. Recent LLVM versions use the `.1` minor version to indicate a stable release, so we have `18.1` and `19.1` in the file.

Error output before and after this patch:

```diff
 Error: Could not find location of llvm-config. Please specify path in environment variable LLVM_CONFIG.
-Supported LLVM versions: 19.1 18.1 17 16 15 14 13 12 11.1 11 10 9 8
+Supported LLVM versions: 19 18 17 16 15 14 13 12 11 11 10 9 8
```