### PR TITLE
Fix: use `uninitialized LibC::SigsetT`

### DIFF
--- a/src/crystal/system/unix/pthread.cr
+++ b/src/crystal/system/unix/pthread.cr
@@ -208,7 +208,7 @@ module Crystal::System::Thread
       Thread.current_thread.@suspended.set(true)
 
       # block all signals but SIG_RESUME
-      mask = LibC::SigsetT.new
+      mask = uninitialized LibC::SigsetT
       LibC.sigfillset(pointerof(mask))
       LibC.sigdelset(pointerof(mask), SIG_RESUME)
 


### PR DESCRIPTION
`LibC::SigsetT` is a `struct` on some platforms and an alias to `UInt32` on others. `.new` is only valid for the struct variant. `uninitialized` should work in either case.

This code is only used with `-Dgc_none`, so a reproduction needs to include that flag and build for a target where `LibC::SigsetT = alias UInt32`, such as `aarch64-apple-darwin`.

```console
$ bin/crystal build .test/hello-world.cr -Dgc_none --cross-compile --target=aarch64-apple-darwin24.1.0
Showing last frame. Use --error-trace for full trace.

In src/crystal/system/unix/pthread.cr:211:28

 211 | mask = LibC::SigsetT.new
                            ^--
Error: wrong number of arguments for 'UInt32.new' (given 0, expected 1..7)

Overloads are:
 - UInt32.new(value : String, base : Int = 10, whitespace : Bool = true, underscore : Bool = false, prefix : Bool = false, strict : Bool = true, leading_zero_is_octal : Bool = false)
 - UInt32.new(value)
```