### PR TITLE
Allow constants to start with non-ascii uppercase and titlecase

### DIFF
--- a/spec/compiler/lexer/lexer_spec.cr
+++ b/spec/compiler/lexer/lexer_spec.cr
@@ -276,6 +276,8 @@ describe "Lexer" do
   it_lexes "&+@foo", :OP_AMP_PLUS
   it_lexes "&-@foo", :OP_AMP_MINUS
   it_lexes_const "Foo"
+  it_lexes_const "ÁrvíztűrőTükörfúrógép"
+  it_lexes_const "ǅǈǋǲᾈᾉᾊ"
   it_lexes_instance_var "@foo"
   it_lexes_class_var "@@foo"
   it_lexes_globals ["$foo", "$FOO", "$_foo", "$foo123"]

--- a/src/compiler/crystal/syntax/lexer.cr
+++ b/src/compiler/crystal/syntax/lexer.cr
@@ -1048,7 +1048,7 @@ module Crystal
 
         scan_ident(start)
       else
-        if current_char.ascii_uppercase?
+        if current_char.uppercase? || current_char.titlecase?
           while ident_part?(next_char)
             # Nothing to do
           end


### PR DESCRIPTION
Modified parser to allow constants to start with non-ascii uppercase and titlecase.

Fixes #12791

On further inspection, I noticed there was an unmerged PR for this: (closes #12792) , however this one adds support for both non-ascii uppercase and titlecase.  Also the testing here is somewhat simpler, as I am just checking that a CONST type was generated by the lexer.