### PR TITLE
DragonFlyBSD: std specs fixes + pending

### DIFF
--- a/spec/std/io/io_spec.cr
+++ b/spec/std/io/io_spec.cr
@@ -427,7 +427,7 @@ describe IO do
 
     # pipe(2) returns bidirectional file descriptors on some platforms,
     # gate this test behind the platform flag.
-    {% unless flag?(:freebsd) || flag?(:solaris) || flag?(:openbsd) %}
+    {% unless flag?(:freebsd) || flag?(:solaris) || flag?(:openbsd) || flag?(:dragonfly) %}
       it "raises if trying to read to an IO not opened for reading" do
         IO.pipe do |r, w|
           expect_raises(IO::Error, "File not open for reading") do
@@ -576,7 +576,7 @@ describe IO do
 
     # pipe(2) returns bidirectional file descriptors on some platforms,
     # gate this test behind the platform flag.
-    {% unless flag?(:freebsd) || flag?(:solaris) || flag?(:openbsd) %}
+    {% unless flag?(:freebsd) || flag?(:solaris) || flag?(:openbsd) || flag?(:dragonfly) %}
       it "raises if trying to write to an IO not opened for writing" do
         IO.pipe do |r, w|
           # unless sync is used the flush on close triggers the exception again
@@ -736,9 +736,13 @@ describe IO do
         it "says invalid byte sequence" do
           io = SimpleIOMemory.new(Slice.new(1, 255_u8))
           io.set_encoding("EUC-JP")
-          expect_raises ArgumentError, {% if flag?(:musl) || flag?(:freebsd) || flag?(:netbsd) %}"Incomplete multibyte sequence"{% else %}"Invalid multibyte sequence"{% end %} do
-            io.read_char
-          end
+          message =
+            {% if flag?(:musl) || flag?(:freebsd) || flag?(:netbsd) || flag?(:dragonfly) %}
+              "Incomplete multibyte sequence"
+            {% else %}
+              "Invalid multibyte sequence"
+            {% end %}
+          expect_raises(ArgumentError, message) { io.read_char }
         end
 
         it "skips invalid byte sequences" do

--- a/spec/std/signal_spec.cr
+++ b/spec/std/signal_spec.cr
@@ -18,7 +18,19 @@ pending_interpreted describe: "Signal" do
     Signal::ABRT.should be_a(Signal)
   end
 
-  {% unless flag?(:win32) %}
+  {% if flag?(:dragonfly) %}
+    # FIXME: can't use SIGUSR1/SIGUSR2 because Boehm uses them + no
+    # SIRTMIN/SIGRTMAX support => figure which signals we could use
+    pending "runs a signal handler"
+    pending "ignores a signal"
+    pending "allows chaining of signals"
+    pending "CHLD.reset sets default Crystal child handler"
+    pending "CHLD.ignore sets default Crystal child handler"
+    pending "CHLD.trap is called after default Crystal child handler"
+    pending "CHLD.reset removes previously set trap"
+  {% end %}
+
+  {% unless flag?(:win32) || flag?(:dragonfly) %}
     # can't use SIGUSR1/SIGUSR2 on FreeBSD because Boehm uses them to suspend/resume threads
     signal1 = {% if flag?(:freebsd) %} Signal.new(LibC::SIGRTMAX - 1) {% else %} Signal::USR1 {% end %}
     signal2 = {% if flag?(:freebsd) %} Signal.new(LibC::SIGRTMAX - 2) {% else %} Signal::USR2 {% end %}

--- a/spec/std/socket/tcp_socket_spec.cr
+++ b/spec/std/socket/tcp_socket_spec.cr
@@ -33,13 +33,18 @@ describe TCPSocket, tags: "network" do
         end
       end
 
-      it "raises when connection is refused" do
-        port = unused_local_port
+      {% if flag?(:dragonfly) %}
+        # FIXME: this spec regularly hangs in a vagrant/libvirt VM
+        pending "raises when connection is refused"
+      {% else %}
+        it "raises when connection is refused" do
+          port = unused_local_port
 
-        expect_raises(Socket::ConnectError, "Error connecting to '#{address}:#{port}'") do
-          TCPSocket.new(address, port)
+          expect_raises(Socket::ConnectError, "Error connecting to '#{address}:#{port}'") do
+            TCPSocket.new(address, port)
+          end
         end
-      end
+      {% end %}
 
       it "raises when port is negative" do
         error = expect_raises(Socket::Addrinfo::Error) do
@@ -54,11 +59,16 @@ describe TCPSocket, tags: "network" do
         {% end %})
       end
 
-      it "raises when port is zero" do
-        expect_raises(Socket::ConnectError) do
-          TCPSocket.new(address, 0)
+      {% if flag?(:dragonfly) %}
+        # FIXME: this spec regularly hangs in a vagrant/libvirt VM
+        pending "raises when port is zero"
+      {% else %}
+        it "raises when port is zero" do
+          expect_raises(Socket::ConnectError) do
+            TCPSocket.new(address, 0)
+          end
         end
-      end
+      {% end %}
     end
 
     describe "address resolution" do
@@ -112,105 +122,114 @@ describe TCPSocket, tags: "network" do
     end
   end
 
-  it "sync from server" do
-    port = unused_local_port
+  {% if flag?(:dragonfly) %}
+    # FIXME: these specs regularly hang in a vagrant/libvirt VM
+    pending "sync from server"
+    pending "settings"
+    pending "fails when connection is refused"
+    pending "sends and receives messages"
+    pending "sends and receives messages (fibers & channels)"
+  {% else %}
+    it "sync from server" do
+      port = unused_local_port
 
-    TCPServer.open("::", port) do |server|
-      TCPSocket.open("localhost", port) do |client|
-        sock = server.accept
-        sock.sync?.should eq(server.sync?)
-      end
+      TCPServer.open("::", port) do |server|
+        TCPSocket.open("localhost", port) do |client|
+          sock = server.accept
+          sock.sync?.should eq(server.sync?)
+        end
 
-      # test sync flag propagation after accept
-      server.sync = !server.sync?
+        # test sync flag propagation after accept
+        server.sync = !server.sync?
 
-      TCPSocket.open("localhost", port) do |client|
-        sock = server.accept
-        sock.sync?.should eq(server.sync?)
-      end
-    end
-  end
-
-  it "settings" do
-    port = unused_local_port
-
-    TCPServer.open("::", port) do |server|
-      TCPSocket.open("localhost", port) do |client|
-        # test protocol specific socket options
-        (client.tcp_nodelay = true).should be_true
-        client.tcp_nodelay?.should be_true
-        (client.tcp_nodelay = false).should be_false
-        client.tcp_nodelay?.should be_false
-
-        {% unless flag?(:openbsd) || flag?(:netbsd) %}
-          (client.tcp_keepalive_idle = 42).should eq 42
-          client.tcp_keepalive_idle.should eq 42
-          (client.tcp_keepalive_interval = 42).should eq 42
-          client.tcp_keepalive_interval.should eq 42
-          (client.tcp_keepalive_count = 42).should eq 42
-          client.tcp_keepalive_count.should eq 42
-        {% end %}
+        TCPSocket.open("localhost", port) do |client|
+          sock = server.accept
+          sock.sync?.should eq(server.sync?)
+        end
       end
     end
-  end
 
-  it "fails when connection is refused" do
-    port = TCPServer.open("localhost", 0) do |server|
-      server.local_address.port
+    it "settings" do
+      port = unused_local_port
+
+      TCPServer.open("::", port) do |server|
+        TCPSocket.open("localhost", port) do |client|
+          # test protocol specific socket options
+          (client.tcp_nodelay = true).should be_true
+          client.tcp_nodelay?.should be_true
+          (client.tcp_nodelay = false).should be_false
+          client.tcp_nodelay?.should be_false
+
+          {% unless flag?(:openbsd) || flag?(:netbsd) %}
+            (client.tcp_keepalive_idle = 42).should eq 42
+            client.tcp_keepalive_idle.should eq 42
+            (client.tcp_keepalive_interval = 42).should eq 42
+            client.tcp_keepalive_interval.should eq 42
+            (client.tcp_keepalive_count = 42).should eq 42
+            client.tcp_keepalive_count.should eq 42
+          {% end %}
+        end
+      end
     end
 
-    expect_raises(Socket::ConnectError, "Error connecting to 'localhost:#{port}'") do
-      TCPSocket.new("localhost", port)
+    it "fails when connection is refused" do
+      port = TCPServer.open("localhost", 0) do |server|
+        server.local_address.port
+      end
+
+      expect_raises(Socket::ConnectError, "Error connecting to 'localhost:#{port}'") do
+        TCPSocket.new("localhost", port)
+      end
     end
-  end
 
-  it "sends and receives messages" do
-    port = unused_local_port
+    it "sends and receives messages" do
+      port = unused_local_port
 
-    TCPServer.open("::", port) do |server|
+      TCPServer.open("::", port) do |server|
+        TCPSocket.open("localhost", port) do |client|
+          sock = server.accept
+
+          client << "ping"
+          sock.gets(4).should eq("ping")
+          sock << "pong"
+          client.gets(4).should eq("pong")
+        end
+      end
+    end
+
+    it "sends and receives messages (fibers & channels)" do
+      port = unused_local_port
+
+      channel = Channel(Exception?).new
+      spawn do
+        TCPServer.open("::", port) do |server|
+          channel.send nil
+          sock = server.accept
+          sock.read_timeout = 3.second
+          sock.write_timeout = 3.second
+
+          sock.gets(4).should eq("ping")
+          sock << "pong"
+          channel.send nil
+        end
+      rescue exc
+        channel.send exc
+      end
+
+      if exc = channel.receive
+        raise exc
+      end
+
       TCPSocket.open("localhost", port) do |client|
-        sock = server.accept
-
+        client.read_timeout = 3.second
+        client.write_timeout = 3.second
         client << "ping"
-        sock.gets(4).should eq("ping")
-        sock << "pong"
         client.gets(4).should eq("pong")
       end
-    end
-  end
 
-  it "sends and receives messages" do
-    port = unused_local_port
-
-    channel = Channel(Exception?).new
-    spawn do
-      TCPServer.open("::", port) do |server|
-        channel.send nil
-        sock = server.accept
-        sock.read_timeout = 3.second
-        sock.write_timeout = 3.second
-
-        sock.gets(4).should eq("ping")
-        sock << "pong"
-        channel.send nil
+      if exc = channel.receive
+        raise exc
       end
-    rescue exc
-      channel.send exc
     end
-
-    if exc = channel.receive
-      raise exc
-    end
-
-    TCPSocket.open("localhost", port) do |client|
-      client.read_timeout = 3.second
-      client.write_timeout = 3.second
-      client << "ping"
-      client.gets(4).should eq("pong")
-    end
-
-    if exc = channel.receive
-      raise exc
-    end
-  end
+  {% end %}
 end

--- a/spec/std/socket/udp_socket_spec.cr
+++ b/spec/std/socket/udp_socket_spec.cr
@@ -78,6 +78,10 @@ describe UDPSocket, tags: "network" do
       # Darwin also has a bug that prevents selecting the "default" interface.
       # https://lists.apple.com/archives/darwin-kernel/2014/Mar/msg00012.html
       pending "joins and transmits to multicast groups"
+    elsif {{ flag?(:dragonfly) }} && family == Socket::Family::INET6
+      # TODO: figure out why updating `multicast_loopback` produces a
+      # `setsockopt 9: Can't assign requested address
+      pending "joins and transmits to multicast groups"
     elsif {{ flag?(:solaris) }} && family == Socket::Family::INET
       # TODO: figure out why updating `multicast_loopback` produces a
       # `setsockopt 18: Invalid argument` error


### PR DESCRIPTION
With these changes I can run all the std and compiler specs in DragonFlyBSD 6.4 VM (vagrant/libvirt).

I disabled some TCP specs that usually hang for me. Starting the servers usually work, but trying to _connect_ (especially expecting errors) are left hanging. It might be a network or even a DNS issue inside the VM (or vagrant or libvirt configuration). I didn't investigate deeply.