### PR TITLE
Improve `System::User` specs on Windows

### DIFF
--- a/spec/std/system/user_spec.cr
+++ b/spec/std/system/user_spec.cr
@@ -2,9 +2,9 @@ require "spec"
 require "system/user"
 
 {% if flag?(:win32) %}
-  {% name, id = `whoami /USER /FO TABLE /NH`.stringify.chomp.split(" ") %}
-  USER_NAME = {{ name }}
-  USER_ID   = {{ id }}
+  {% parts = `whoami /USER /FO TABLE /NH`.stringify.chomp.split(" ") %}
+  USER_NAME = {{ parts[0..-2].join(" ") }}
+  USER_ID   = {{ parts[-1] }}
 {% else %}
   USER_NAME = {{ `id -un`.stringify.chomp }}
   USER_ID   = {{ `id -u`.stringify.chomp }}
@@ -17,8 +17,7 @@ def normalized_username(username)
   # on Windows, domain names are case-insensitive, so we unify the letter case
   # from sources like `whoami`, `hostname`, or Win32 APIs
   {% if flag?(:win32) %}
-    domain, _, user = username.partition('\\')
-    "#{domain.upcase}\\#{user}"
+    username.upcase
   {% else %}
     username
   {% end %}


### PR DESCRIPTION
* Ensures `USER_NAME` and `USER_ID` are correct if the current username contains whitespace characters.
* Normalizes the username portion of the user ID in assertions as well, since it seems some versions of Windows would break the specs without it. We already do this to the domain portion.