### PR TITLE
Make `cmd.exe` drop `%PROCESSOR_ARCHITECTURE%` in `Process` specs

### DIFF
--- a/spec/std/process_spec.cr
+++ b/spec/std/process_spec.cr
@@ -32,7 +32,7 @@ end
 private def print_env_command
   {% if flag?(:win32) %}
     # cmd adds these by itself, clear them out before printing.
-    shell_command("set COMSPEC=& set PATHEXT=& set PROMPT=& set")
+    shell_command("set COMSPEC=& set PATHEXT=& set PROMPT=& set PROCESSOR_ARCHITECTURE=& set")
   {% else %}
     {"env", [] of String}
   {% end %}


### PR DESCRIPTION
On ARM64 this appears to be set to `ARM64` automatically by `cmd.exe`, even when an empty environment block is passed to `LibC.CreateProcessW`.