### PR TITLE
Support MSYS2's CLANGARM64 environment on ARM64 Windows

### DIFF
--- a/src/lib_c/aarch64-windows-gnu
+++ b/src/lib_c/aarch64-windows-gnu
@@ -1,0 +1,1 @@
+x86_64-windows-msvc


### PR DESCRIPTION
Resolves part of #6170. Tested using a Windows VM on an Apple M2 host.

The instructions we use in our MinGW-w64 CI workflow will just work by simply replacing `-ucrt-` in the MSYS2 package names with `-clang-aarch64-`. Requires #15155 on both the cross-compilation host and the target.