### PR TITLE
Close some dangling sockets in specs

### DIFF
--- a/spec/std/socket/socket_spec.cr
+++ b/spec/std/socket/socket_spec.cr
@@ -87,7 +87,6 @@ describe Socket, tags: "network" do
 
     expect_raises(IO::TimeoutError) { server.accept }
     expect_raises(IO::TimeoutError) { server.accept? }
-
   ensure
     server.try &.close
   end

--- a/spec/std/socket/socket_spec.cr
+++ b/spec/std/socket/socket_spec.cr
@@ -88,7 +88,8 @@ describe Socket, tags: "network" do
     expect_raises(IO::TimeoutError) { server.accept }
     expect_raises(IO::TimeoutError) { server.accept? }
 
-    server.close
+  ensure
+    server.try &.close
   end
 
   it "sends messages" do

--- a/spec/std/socket/socket_spec.cr
+++ b/spec/std/socket/socket_spec.cr
@@ -87,6 +87,8 @@ describe Socket, tags: "network" do
 
     expect_raises(IO::TimeoutError) { server.accept }
     expect_raises(IO::TimeoutError) { server.accept? }
+
+    server.close
   end
 
   it "sends messages" do

--- a/spec/std/socket/udp_socket_spec.cr
+++ b/spec/std/socket/udp_socket_spec.cr
@@ -28,7 +28,8 @@ describe UDPSocket, tags: "network" do
       socket = UDPSocket.new(family)
       socket.bind(address, 0)
       socket.local_address.address.should eq address
-      socket.close
+  ensure
+      socket.try &.close
     end
 
     it "sends and receives messages" do

--- a/spec/std/socket/udp_socket_spec.cr
+++ b/spec/std/socket/udp_socket_spec.cr
@@ -28,7 +28,7 @@ describe UDPSocket, tags: "network" do
       socket = UDPSocket.new(family)
       socket.bind(address, 0)
       socket.local_address.address.should eq address
-  ensure
+    ensure
       socket.try &.close
     end
 

--- a/spec/std/socket/udp_socket_spec.cr
+++ b/spec/std/socket/udp_socket_spec.cr
@@ -28,6 +28,7 @@ describe UDPSocket, tags: "network" do
       socket = UDPSocket.new(family)
       socket.bind(address, 0)
       socket.local_address.address.should eq address
+      socket.close
     end
 
     it "sends and receives messages" do


### PR DESCRIPTION
These appear to be causing intermittent CI failures, especially on Windows (e.g. https://github.com/crystal-lang/crystal/actions/runs/11031590842/job/30639450164).