### PR TITLE
Update XCode 15.3.0 in circleci

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -285,7 +285,7 @@ jobs:
 
   dist_darwin:
     macos:
-      xcode: 13.4.1
+      xcode: 14.3.1
     shell: /bin/bash --login -eo pipefail
     steps:
       - restore_cache:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -285,7 +285,7 @@ jobs:
 
   dist_darwin:
     macos:
-      xcode: 14.3.1
+      xcode: 15.3.0
     shell: /bin/bash --login -eo pipefail
     steps:
       - restore_cache:


### PR DESCRIPTION
The latest [nightly build](https://app.circleci.com/pipelines/github/crystal-lang/crystal/16404/workflows/8814ca28-d8e3-404e-a087-40f5e7033ddd/jobs/86898) fails to even setup the environment. It seems to be doing a lot more work than previous runs, and times out at some point.

The logs mention that XCode is outdated:
```
Warning: Your Xcode (13.4.1) is outdated.
Please update to Xcode 14.2 (or delete it).
```

Updating XCode seems to resolve the CI failure.