### PR TITLE
Fix static linking when using MinGW-w64

### DIFF
--- a/.github/workflows/mingw-w64.yml
+++ b/.github/workflows/mingw-w64.yml
@@ -80,7 +80,7 @@ jobs:
         shell: msys2 {0}
         run: |
           mkdir bin
-          cc crystal.obj -o bin/crystal.exe -mcrtdll=ucrt -municode \
+          cc crystal.obj -o bin/crystal.exe -municode \
             $(pkg-config bdw-gc libpcre2-8 iconv zlib libffi --libs) \
             $(llvm-config --libs --system-libs --ldflags) \
             -lDbgHelp -lole32 -lWS2_32 -Wl,--stack,0x800000

--- a/.github/workflows/mingw-w64.yml
+++ b/.github/workflows/mingw-w64.yml
@@ -80,7 +80,7 @@ jobs:
         shell: msys2 {0}
         run: |
           mkdir bin
-          cc crystal.obj -o bin/crystal.exe \
+          cc crystal.obj -o bin/crystal.exe -mcrtdll=ucrt -municode \
             $(pkg-config bdw-gc libpcre2-8 iconv zlib libffi --libs) \
             $(llvm-config --libs --system-libs --ldflags) \
             -lDbgHelp -lole32 -lWS2_32 -Wl,--stack,0x800000

--- a/src/compiler/crystal/loader/mingw.cr
+++ b/src/compiler/crystal/loader/mingw.cr
@@ -7,6 +7,8 @@ require "crystal/system/win32/library_archive"
 # The core implementation is derived from the MSVC loader. Main deviations are:
 #
 # - `.parse` follows GNU `ld`'s style, rather than MSVC `link`'s;
+# - `.parse` automatically inserts a C runtime library if `-mcrtdll` isn't
+#   supplied;
 # - `#library_filename` follows the usual naming of the MinGW linker: `.dll.a`
 #   for DLL import libraries, `.a` for other libraries;
 # - `.default_search_paths` relies solely on `.cc_each_library_path`.
@@ -27,6 +29,10 @@ class Crystal::Loader
     libnames = [] of String
     file_paths = [] of String
     extra_search_paths = [] of String
+
+    # note that `msvcrt` is a default runtime chosen at MinGW-w64 build time,
+    # `ucrt` is always UCRT (even in a MINGW64 environment), and
+    # `msvcrt-os` is always MSVCRT (even in a UCRT64 environment)
     crt_dll = "msvcrt"
 
     OptionParser.parse(args.dup) do |parser|

--- a/src/crystal/system/win32/wmain.cr
+++ b/src/crystal/system/win32/wmain.cr
@@ -2,14 +2,12 @@ require "c/stringapiset"
 require "c/winnls"
 require "c/stdlib"
 
-{% begin %}
-  # we have both `main` and `wmain`, so we must choose an unambiguous entry point
+# we have both `main` and `wmain`, so we must choose an unambiguous entry point
+{% if flag?(:msvc) %}
   @[Link({{ flag?(:static) ? "libcmt" : "msvcrt" }})]
-  {% if flag?(:msvc) %}
-    @[Link(ldflags: "/ENTRY:wmainCRTStartup")]
-  {% elsif flag?(:gnu) && !flag?(:interpreted) %}
-    @[Link(ldflags: "-municode")]
-  {% end %}
+  @[Link(ldflags: "/ENTRY:wmainCRTStartup")]
+{% elsif flag?(:gnu) && !flag?(:interpreted) %}
+  @[Link(ldflags: "-municode")]
 {% end %}
 lib LibCrystalMain
 end

--- a/src/empty.cr
+++ b/src/empty.cr
@@ -1,6 +1,6 @@
 require "primitives"
 
-{% if flag?(:win32) %}
+{% if flag?(:msvc) %}
   @[Link({{ flag?(:static) ? "libcmt" : "msvcrt" }})] # For `mainCRTStartup`
 {% end %}
 lib LibCrystalMain

--- a/src/lib_c.cr
+++ b/src/lib_c.cr
@@ -1,6 +1,6 @@
 {% if flag?(:msvc) %}
   @[Link({{ flag?(:static) ? "libucrt" : "ucrt" }})]
-{% elsif flag?(:win32) && flag?(:gnu) && !flag?(:interpreted) %}
+{% elsif flag?(:win32) && flag?(:gnu) %}
   @[Link(ldflags: "-mcrtdll=ucrt")]
 {% end %}
 lib LibC

--- a/src/lib_c.cr
+++ b/src/lib_c.cr
@@ -1,7 +1,5 @@
 {% if flag?(:msvc) %}
   @[Link({{ flag?(:static) ? "libucrt" : "ucrt" }})]
-{% elsif flag?(:win32) && flag?(:gnu) %}
-  @[Link(ldflags: "-mcrtdll=ucrt")]
 {% end %}
 lib LibC
   alias Char = UInt8

--- a/src/lib_c.cr
+++ b/src/lib_c.cr
@@ -1,5 +1,7 @@
-{% if flag?(:win32) %}
+{% if flag?(:msvc) %}
   @[Link({{ flag?(:static) ? "libucrt" : "ucrt" }})]
+{% elsif flag?(:win32) && flag?(:gnu) && !flag?(:interpreted) %}
+  @[Link(ldflags: "-mcrtdll=ucrt")]
 {% end %}
 lib LibC
   alias Char = UInt8


### PR DESCRIPTION
Resolves part of #6170.

* The MinGW-w64 equivalent for MSVC's `libcmt.lib` or `msvcrt.lib` is provided by MinGW-w64's built-in spec files directly (see `cc -dumpspecs`), so we do not link against it.
* There cannot be static libraries for the Win32 APIs in MinGW-w64, because that would be proprietary code; all static libraries on MSYS2 link against the C runtimes dynamically, i.e. they behave like `/MD` in MSVC or `CMAKE_MSVC_RUNTIME_LIBRARY=MultiThreadedDLL` in CMake. We therefore never link against `libucrt`.
* Passing `-lucrt` explicitly may lead to a crash in the startup code when combined with `-static` and `-msvcrt`, depending on the relative link order. In MinGW-w64, [`-lmsvcrt` is already equivalent to `-lucrt` or `-lmsvcrt-os`](https://gcc.gnu.org/onlinedocs/gcc/Cygwin-and-MinGW-Options.html), depending on how it was built; in particular, `/ucrt64/bin/libmsvcrt.a` is a copy of `libucrt.a` in MSYS2, but `/mingw64/bin/libmsvcrt.a` is a copy of `libmsvcrt-os.a`. Thus we drop `-lucrt` entirely and rely on the MinGW-w64's build-time configuration to select the appropriate C runtime.
* `-mcrtdll` can be used to override the C runtime, and it _should_ be possible to cross-build binaries between the MINGW64 and the UCRT64 environments using this flag. The interpreter now imitates this linker behavior.