### PR TITLE
Add example for `Dir.glob`

### DIFF
--- a/src/dir/glob.cr
+++ b/src/dir/glob.cr
@@ -37,6 +37,10 @@ class Dir
 
   # Returns an array of all files that match against any of *patterns*.
   #
+  # ```
+  # Dir.glob "path/to/folder/*.txt" # Returns all files in the folder that end in ".txt".
+  # Dir.glob "path/to/folder/**/*"  # Returns all files in the target folder and its subfolders.
+  # ```
   # The pattern syntax is similar to shell filename globbing, see `File.match?` for details.
   #
   # NOTE: Path separator in patterns needs to be always `/`. The returned file names use system-specific path separators.

--- a/src/dir/glob.cr
+++ b/src/dir/glob.cr
@@ -38,7 +38,7 @@ class Dir
   # Returns an array of all files that match against any of *patterns*.
   #
   # ```
-  # Dir.glob "path/to/folder/*.txt" # Returns all files in the folder that end in ".txt".
+  # Dir.glob "path/to/folder/*.txt" # Returns all files in the target folder that end in ".txt".
   # Dir.glob "path/to/folder/**/*"  # Returns all files in the target folder and its subfolders.
   # ```
   # The pattern syntax is similar to shell filename globbing, see `File.match?` for details.


### PR DESCRIPTION
I was recently trying to use `Dir.glob` but it wasn't very intuitive without examples. Thankfully, @Blacksmoke16  helped me out.

Currently, the `Enumerable` versions of `Dir.glob` copy the description of the ones that take a `String` or `Path`, which is wrong. Unfortunately, I have no clue how the `Enumerable` version works :rofl: 