### PR TITLE
Disable `String#to_f` special number specs on MSYS2 MINGW64 environment

### DIFF
--- a/spec/std/string_spec.cr
+++ b/spec/std/string_spec.cr
@@ -510,13 +510,16 @@ describe "String" do
     "x1.2".to_f64?(strict: false).should be_nil
     "1#{Float64::MAX}".to_f?.should be_nil
     "-1#{Float64::MAX}".to_f?.should be_nil
+    expect_raises(ArgumentError) { "".to_f(whitespace: false) }
+
+    pending! "Old Microsoft C runtime does not handle special floats" if msys2_environment == "MINGW64"
+
     " NaN".to_f?.try(&.nan?).should be_true
     "NaN".to_f?.try(&.nan?).should be_true
     "-NaN".to_f?.try(&.nan?).should be_true
     "nan".to_f?(whitespace: false).try(&.nan?).should be_true
     " nan".to_f?(whitespace: false).should be_nil
     "nan ".to_f?(whitespace: false).should be_nil
-    expect_raises(ArgumentError) { "".to_f(whitespace: false) }
     "nani".to_f?(strict: true).should be_nil
     " INF".to_f?.should eq Float64::INFINITY
     "INF".to_f?.should eq Float64::INFINITY
@@ -554,6 +557,9 @@ describe "String" do
     "x1.2".to_f32?(strict: false).should be_nil
     "1#{Float32::MAX}".to_f32?.should be_nil
     "-1#{Float32::MAX}".to_f32?.should be_nil
+
+    pending! "Old Microsoft C runtime does not handle special floats" if msys2_environment == "MINGW64"
+
     " NaN".to_f32?.try(&.nan?).should be_true
     "NaN".to_f32?.try(&.nan?).should be_true
     "-NaN".to_f32?.try(&.nan?).should be_true
@@ -597,6 +603,9 @@ describe "String" do
     "x1.2".to_f64?(strict: false).should be_nil
     "1#{Float64::MAX}".to_f64?.should be_nil
     "-1#{Float64::MAX}".to_f64?.should be_nil
+
+    pending! "Old Microsoft C runtime does not handle special floats" if msys2_environment == "MINGW64"
+
     " NaN".to_f64?.try(&.nan?).should be_true
     "NaN".to_f64?.try(&.nan?).should be_true
     "-NaN".to_f64?.try(&.nan?).should be_true

--- a/spec/support/win32.cr
+++ b/spec/support/win32.cr
@@ -17,3 +17,24 @@ require "spec"
     describe(describe, file, line, end_line, &block)
   end
 {% end %}
+
+# Heuristic to determine the current MSYS2 environment:
+#
+# - target triple must be `*-windows-gnu`
+# - `uname -s` must return `MINGW64_NT*` or `MSYS_NT*`
+# - the `MSYSTEM` environment variable must be non-empty
+#
+# (ideally we should determine the C runtime used at build time, for now we just
+# assume the build-time and run-time environments are identical)
+def msys2_environment : String?
+  {% if flag?(:win32) && flag?(:gnu) %}
+    uname = IO::Memory.new
+    if Process.run("uname", %w(-s), output: uname).success?
+      uname = uname.to_s
+      if uname.starts_with?("MINGW64_NT") || uname.starts_with?("MSYS_NT")
+        ENV["MSYSTEM"]?.presence
+      end
+    end
+  {% end %}
+rescue IO::Error
+end


### PR DESCRIPTION
Workaround for https://github.com/crystal-lang/crystal/issues/6170#issuecomment-2450242078.