### PR TITLE
Use Win32 heap functions with `-Dgc_none`

### DIFF
--- a/src/lib_c/x86_64-windows-msvc/c/heapapi.cr
+++ b/src/lib_c/x86_64-windows-msvc/c/heapapi.cr
@@ -1,6 +1,8 @@
 require "c/winnt"
 
 lib LibC
+  HEAP_ZERO_MEMORY = 0x00000008
+
   fun GetProcessHeap : HANDLE
   fun HeapAlloc(hHeap : HANDLE, dwFlags : DWORD, dwBytes : SizeT) : Void*
   fun HeapReAlloc(hHeap : HANDLE, dwFlags : DWORD, lpMem : Void*, dwBytes : SizeT) : Void*


### PR DESCRIPTION
These functions can (re)allocate and zero memory in a single call, including `HeapReAlloc` when the new memory size is larger than the original.