### PR TITLE
```separate_unit`` for ```humanize``` and ```humanize_bytes```

### DIFF
--- a/spec/std/humanize_spec.cr
+++ b/spec/std/humanize_spec.cr
@@ -302,10 +302,5 @@ describe Int do
 
     it { assert_prints 1024.humanize_bytes(format: Int::BinaryPrefixFormat::IEC), "1.0kiB" }
     it { assert_prints 1073741824.humanize_bytes(format: Int::BinaryPrefixFormat::IEC), "1.0GiB" }
-
-    # it { assert_prints 0.humanize_bytes(format: Int::BinaryPrefixFormat::JEDEC, separate_unit: true), "0 B" }
-    # it { assert_prints 2048.humanize_bytes(format: Int::BinaryPrefixFormat::JEDEC, separate_unit: true), "2.0 KB" }
-    # it { assert_prints 1073741824.humanize_bytes(format: Int::BinaryPrefixFormat::IEC, separate_unit: true), "1.0 GiB" }
-    # it { assert_prints 1152921504606846976.humanize_bytes(format: Int::BinaryPrefixFormat::JEDEC, separate_unit: true), "1.0 EB" }
   end
 end

--- a/spec/std/humanize_spec.cr
+++ b/spec/std/humanize_spec.cr
@@ -207,6 +207,13 @@ describe Number do
     it { assert_prints 1.0e+34.humanize, "10,000Q" }
     it { assert_prints 1.0e+35.humanize, "100,000Q" }
 
+    it { assert_prints 0.humanize(separate_unit: true), "0.0" }
+    it { assert_prints 12_345.humanize(separate_unit: true), "12.3\u00A0k" }
+    it { assert_prints 0.123_456_78.humanize(5, separate_unit: true), "123.46\u00A0m" }
+    it { assert_prints 1.0e-14.humanize(separate_unit: true), "10.0\u00A0f" }
+    it { assert_prints 1.0e+9.humanize(separate_unit: true), "1.0\u00A0G" }
+    it { assert_prints 1.0e+35.humanize(separate_unit: true), "100,000\u00A0Q" }
+
     it { assert_prints Float32::INFINITY.humanize, "Infinity" }
     it { assert_prints (-Float32::INFINITY).humanize, "-Infinity" }
     it { assert_prints Float32::NAN.humanize, "NaN" }
@@ -261,6 +268,7 @@ describe Number do
       it { assert_prints 1.0e+8.humanize(prefixes: CUSTOM_PREFIXES), "100d" }
       it { assert_prints 1.0e+9.humanize(prefixes: CUSTOM_PREFIXES), "1,000d" }
       it { assert_prints 1.0e+10.humanize(prefixes: CUSTOM_PREFIXES), "10,000d" }
+      it { assert_prints 1.0e+10.humanize(prefixes: CUSTOM_PREFIXES, separate_unit: true), "10,000\u00A0d" }
     end
   end
 end
@@ -281,6 +289,7 @@ describe Int do
     it { assert_prints 1025.humanize_bytes(format: Int::BinaryPrefixFormat::JEDEC), "1.0KB" }
     it { assert_prints 1026.humanize_bytes(format: Int::BinaryPrefixFormat::JEDEC), "1.01KB" }
     it { assert_prints 2048.humanize_bytes(format: Int::BinaryPrefixFormat::JEDEC), "2.0KB" }
+    it { assert_prints 2048.humanize_bytes(format: Int::BinaryPrefixFormat::JEDEC, separate_unit: true), "2.0\u00A0KB" }
 
     it { assert_prints 1536.humanize_bytes(format: Int::BinaryPrefixFormat::JEDEC), "1.5KB" }
     it { assert_prints 524288.humanize_bytes(format: Int::BinaryPrefixFormat::JEDEC), "512KB" }
@@ -289,8 +298,14 @@ describe Int do
     it { assert_prints 1099511627776.humanize_bytes(format: Int::BinaryPrefixFormat::JEDEC), "1.0TB" }
     it { assert_prints 1125899906842624.humanize_bytes(format: Int::BinaryPrefixFormat::JEDEC), "1.0PB" }
     it { assert_prints 1152921504606846976.humanize_bytes(format: Int::BinaryPrefixFormat::JEDEC), "1.0EB" }
+    it { assert_prints 1152921504606846976.humanize_bytes(format: Int::BinaryPrefixFormat::JEDEC, separate_unit: true), "1.0\u00A0EB" }
 
     it { assert_prints 1024.humanize_bytes(format: Int::BinaryPrefixFormat::IEC), "1.0kiB" }
     it { assert_prints 1073741824.humanize_bytes(format: Int::BinaryPrefixFormat::IEC), "1.0GiB" }
+
+    # it { assert_prints 0.humanize_bytes(format: Int::BinaryPrefixFormat::JEDEC, separate_unit: true), "0 B" }
+    # it { assert_prints 2048.humanize_bytes(format: Int::BinaryPrefixFormat::JEDEC, separate_unit: true), "2.0 KB" }
+    # it { assert_prints 1073741824.humanize_bytes(format: Int::BinaryPrefixFormat::IEC, separate_unit: true), "1.0 GiB" }
+    # it { assert_prints 1152921504606846976.humanize_bytes(format: Int::BinaryPrefixFormat::JEDEC, separate_unit: true), "1.0 EB" }
   end
 end

--- a/src/humanize.cr
+++ b/src/humanize.cr
@@ -152,17 +152,17 @@ struct Number
   # delimiter (see `#format`).
   #
   # See `Int#humanize_bytes` to format a file size.
-  def humanize(io : IO, precision = 3, separator = '.', delimiter = ',', *, base = 10 ** 3, significant = true, prefixes : Indexable = SI_PREFIXES) : Nil
-    humanize(io, precision, separator, delimiter, base: base, significant: significant) do |magnitude, _|
+  def humanize(io : IO, precision = 3, separator = '.', delimiter = ',', *, base = 10 ** 3, significant = true, separate_unit = false, prefixes : Indexable = SI_PREFIXES) : Nil
+    humanize(io, precision, separator, delimiter, base: base, significant: significant, separate_unit: separate_unit) do |magnitude, _|
       magnitude = Number.prefix_index(magnitude, prefixes: prefixes)
       {magnitude, Number.si_prefix(magnitude, prefixes)}
     end
   end
 
   # :ditto:
-  def humanize(precision = 3, separator = '.', delimiter = ',', *, base = 10 ** 3, significant = true, prefixes = SI_PREFIXES) : String
+  def humanize(precision = 3, separator = '.', delimiter = ',', *, base = 10 ** 3, significant = true, separate_unit = false, prefixes = SI_PREFIXES) : String
     String.build do |io|
-      humanize(io, precision, separator, delimiter, base: base, significant: significant, prefixes: prefixes)
+      humanize(io, precision, separator, delimiter, base: base, significant: significant, separate_unit: separate_unit, prefixes: prefixes)
     end
   end
 
@@ -215,7 +215,7 @@ struct Number
   # ```
   #
   # See `Int#humanize_bytes` to format a file size.
-  def humanize(io : IO, precision = 3, separator = '.', delimiter = ',', *, base = 10 ** 3, significant = true, &prefixes : (Int32, Float64) -> {Int32, _} | {Int32, _, Bool}) : Nil
+  def humanize(io : IO, precision = 3, separator = '.', delimiter = ',', *, base = 10 ** 3, significant = true, separate_unit = false, &prefixes : (Int32, Float64) -> {Int32, _} | {Int32, _, Bool}) : Nil
     if zero? || (responds_to?(:infinite?) && self.infinite?) || (responds_to?(:nan?) && self.nan?)
       digits = 0
     else
@@ -259,29 +259,30 @@ struct Number
 
     number.format(io, separator, delimiter, decimal_places: decimal_places, only_significant: significant)
 
+    io << '\u00A0' if unit && separate_unit
     io << unit
   end
 
   # :ditto:
-  def humanize(precision = 3, separator = '.', delimiter = ',', *, base = 10 ** 3, significant = true, &) : String
+  def humanize(precision = 3, separator = '.', delimiter = ',', *, base = 10 ** 3, significant = true, separate_unit = false, &) : String
     String.build do |io|
-      humanize(io, precision, separator, delimiter, base: base, significant: significant) do |magnitude, number|
+      humanize(io, precision, separator, delimiter, base: base, significant: significant, separate_unit: separate_unit) do |magnitude, number|
         yield magnitude, number
       end
     end
   end
 
   # :ditto:
-  def humanize(io : IO, precision = 3, separator = '.', delimiter = ',', *, base = 10 ** 3, significant = true, prefixes : Proc) : Nil
-    humanize(io, precision, separator, delimiter, base: base, significant: significant) do |magnitude, number|
+  def humanize(io : IO, precision = 3, separator = '.', delimiter = ',', *, base = 10 ** 3, significant = true, separate_unit = false, prefixes : Proc) : Nil
+    humanize(io, precision, separator, delimiter, base: base, significant: significant, separate_unit: separate_unit) do |magnitude, number|
       prefixes.call(magnitude, number)
     end
   end
 
   # :ditto:
-  def humanize(precision = 3, separator = '.', delimiter = ',', *, base = 10 ** 3, significant = true, prefixes : Proc) : String
+  def humanize(precision = 3, separator = '.', delimiter = ',', *, base = 10 ** 3, significant = true, separate_unit = false, prefixes : Proc) : String
     String.build do |io|
-      humanize(io, precision, separator, delimiter, base: base, significant: significant, prefixes: prefixes)
+      humanize(io, precision, separator, delimiter, base: base, significant: significant, separate_unit: separate_unit, prefixes: prefixes)
     end
   end
 end
@@ -321,18 +322,19 @@ struct Int
   # ```
   #
   # See `Number#humanize` for more details on the behaviour and arguments.
-  def humanize_bytes(io : IO, precision : Int = 3, separator = '.', *, significant : Bool = true, format : BinaryPrefixFormat = :IEC) : Nil
+  def humanize_bytes(io : IO, precision : Int = 3, separator = '.', *, significant : Bool = true, separate_unit : Bool = false, format : BinaryPrefixFormat = :IEC) : Nil
     humanize(io, precision, separator, nil, base: 1024, significant: significant) do |magnitude|
       magnitude = Number.prefix_index(magnitude)
+      spacing = separate_unit ? '\u00A0' : ""
 
       prefix = Number.si_prefix(magnitude)
       if prefix.nil?
         unit = "B"
       else
         if format.iec?
-          unit = "#{prefix}iB"
+          unit = "#{spacing}#{prefix}iB"
         else
-          unit = "#{prefix.upcase}B"
+          unit = "#{spacing}#{prefix.upcase}B"
         end
       end
       {magnitude, unit, magnitude > 0}
@@ -340,9 +342,9 @@ struct Int
   end
 
   # :ditto:
-  def humanize_bytes(precision : Int = 3, separator = '.', *, significant : Bool = true, format : BinaryPrefixFormat = :IEC) : String
+  def humanize_bytes(precision : Int = 3, separator = '.', *, significant : Bool = true, separate_unit : Bool = false, format : BinaryPrefixFormat = :IEC) : String
     String.build do |io|
-      humanize_bytes(io, precision, separator, significant: significant, format: format)
+      humanize_bytes(io, precision, separator, significant: significant, separate_unit: separate_unit, format: format)
     end
   end
 end


### PR DESCRIPTION
Adds a ```separate_unit``` parameter to the ```humanize``` and ```humanize_bytes``` methods. If selected adds a non-breaking space (```'\u00A0'```) between the value and the unit.

Also includes relevant specs.

Fixes #14349