### PR TITLE
Enable bindings for functions in LibreSSL

### DIFF
--- a/src/openssl/lib_crypto.cr
+++ b/src/openssl/lib_crypto.cr
@@ -103,7 +103,7 @@ lib LibCrypto
   alias BioMethodDestroy = Bio* -> Int
   alias BioMethodCallbackCtrl = (Bio*, Int, Void*) -> Long
 
-  {% if compare_versions(LibCrypto::OPENSSL_VERSION, "1.1.0") >= 0 %}
+  {% if compare_versions(LibCrypto::OPENSSL_VERSION, "1.1.0") >= 0 || compare_versions(LibCrypto::LIBRESSL_VERSION, "2.7.0") >= 0 %}
     type BioMethod = Void
   {% else %}
     struct BioMethod
@@ -123,7 +123,7 @@ lib LibCrypto
   fun BIO_new(BioMethod*) : Bio*
   fun BIO_free(Bio*) : Int
 
-  {% if compare_versions(LibCrypto::OPENSSL_VERSION, "1.1.0") >= 0 %}
+  {% if compare_versions(LibCrypto::OPENSSL_VERSION, "1.1.0") >= 0 || compare_versions(LibCrypto::LIBRESSL_VERSION, "2.7.0") >= 0 %}
     fun BIO_set_data(Bio*, Void*)
     fun BIO_get_data(Bio*) : Void*
     fun BIO_set_init(Bio*, Int)
@@ -139,6 +139,7 @@ lib LibCrypto
     fun BIO_meth_set_destroy(BioMethod*, BioMethodDestroy)
     fun BIO_meth_set_callback_ctrl(BioMethod*, BioMethodCallbackCtrl)
   {% end %}
+  # LibreSSL does not define these symbols
   {% if compare_versions(LibCrypto::OPENSSL_VERSION, "1.1.1") >= 0 %}
     fun BIO_meth_set_read_ex(BioMethod*, BioMethodRead)
     fun BIO_meth_set_write_ex(BioMethod*, BioMethodWrite)
@@ -223,7 +224,7 @@ lib LibCrypto
 
   fun evp_digestfinal_ex = EVP_DigestFinal_ex(ctx : EVP_MD_CTX, md : UInt8*, size : UInt32*) : Int32
 
-  {% if compare_versions(OPENSSL_VERSION, "1.1.0") >= 0 %}
+  {% if compare_versions(OPENSSL_VERSION, "1.1.0") >= 0 || compare_versions(LibCrypto::LIBRESSL_VERSION, "2.7.0") >= 0 %}
     fun evp_md_ctx_new = EVP_MD_CTX_new : EVP_MD_CTX
     fun evp_md_ctx_free = EVP_MD_CTX_free(ctx : EVP_MD_CTX)
   {% else %}
@@ -300,7 +301,7 @@ lib LibCrypto
   fun md5 = MD5(data : UInt8*, length : LibC::SizeT, md : UInt8*) : UInt8*
 
   fun pkcs5_pbkdf2_hmac_sha1 = PKCS5_PBKDF2_HMAC_SHA1(pass : LibC::Char*, passlen : LibC::Int, salt : UInt8*, saltlen : LibC::Int, iter : LibC::Int, keylen : LibC::Int, out : UInt8*) : LibC::Int
-  {% if compare_versions(OPENSSL_VERSION, "1.0.0") >= 0 %}
+  {% if compare_versions(OPENSSL_VERSION, "1.0.0") >= 0 || LIBRESSL_VERSION != "0.0.0" %}
     fun pkcs5_pbkdf2_hmac = PKCS5_PBKDF2_HMAC(pass : LibC::Char*, passlen : LibC::Int, salt : UInt8*, saltlen : LibC::Int, iter : LibC::Int, digest : EVP_MD, keylen : LibC::Int, out : UInt8*) : LibC::Int
   {% end %}
 
@@ -374,12 +375,12 @@ lib LibCrypto
 
   fun x509_store_add_cert = X509_STORE_add_cert(ctx : X509_STORE, x : X509) : Int
 
-  {% unless compare_versions(OPENSSL_VERSION, "1.1.0") >= 0 %}
+  {% unless compare_versions(OPENSSL_VERSION, "1.1.0") >= 0 || compare_versions(LibCrypto::LIBRESSL_VERSION, "3.0.0") >= 0 %}
     fun err_load_crypto_strings = ERR_load_crypto_strings
     fun openssl_add_all_algorithms = OPENSSL_add_all_algorithms_noconf
   {% end %}
 
-  {% if compare_versions(OPENSSL_VERSION, "1.0.2") >= 0 %}
+  {% if compare_versions(OPENSSL_VERSION, "1.0.2") >= 0 || LIBRESSL_VERSION != "0.0.0" %}
     type X509VerifyParam = Void*
 
     @[Flags]

--- a/src/openssl/lib_ssl.cr
+++ b/src/openssl/lib_ssl.cr
@@ -139,7 +139,7 @@ lib LibSSL
     NETSCAPE_DEMO_CIPHER_CHANGE_BUG = 0x40000000
     CRYPTOPRO_TLSEXT_BUG            = 0x80000000
 
-    {% if compare_versions(OPENSSL_VERSION, "1.1.0") >= 0 %}
+    {% if compare_versions(OPENSSL_VERSION, "1.1.0") >= 0 || compare_versions(LibCrypto::LIBRESSL_VERSION, "2.3.0") >= 0 %}
       MICROSOFT_SESS_ID_BUG            = 0x00000000
       NETSCAPE_CHALLENGE_BUG           = 0x00000000
       NETSCAPE_REUSE_CIPHER_CHANGE_BUG = 0x00000000
@@ -237,6 +237,7 @@ lib LibSSL
     fun ssl_get_peer_certificate = SSL_get_peer_certificate(handle : SSL) : LibCrypto::X509
   {% end %}
 
+  # In LibreSSL these functions are implemented as macros
   {% if compare_versions(OPENSSL_VERSION, "1.1.0") >= 0 %}
     fun ssl_ctx_get_options = SSL_CTX_get_options(ctx : SSLContext) : ULong
     fun ssl_ctx_set_options = SSL_CTX_set_options(ctx : SSLContext, larg : ULong) : ULong
@@ -251,12 +252,13 @@ lib LibSSL
   fun ssl_ctx_set_cert_verify_callback = SSL_CTX_set_cert_verify_callback(ctx : SSLContext, callback : CertVerifyCallback, arg : Void*)
 
   # control TLS 1.3 session ticket generation
+  # LibreSSL does not seem to implement these functions
   {% if compare_versions(OPENSSL_VERSION, "1.1.1") >= 0 %}
     fun ssl_ctx_set_num_tickets = SSL_CTX_set_num_tickets(ctx : SSLContext, larg : LibC::SizeT) : Int
     fun ssl_set_num_tickets = SSL_set_num_tickets(ctx : SSL, larg : LibC::SizeT) : Int
   {% end %}
 
-  {% if compare_versions(OPENSSL_VERSION, "1.1.0") >= 0 %}
+  {% if compare_versions(OPENSSL_VERSION, "1.1.0") >= 0 || compare_versions(LibCrypto::LIBRESSL_VERSION, "2.3.0") >= 0  %}
     fun tls_method = TLS_method : SSLMethod
   {% else %}
     fun ssl_library_init = SSL_library_init
@@ -264,7 +266,7 @@ lib LibSSL
     fun sslv23_method = SSLv23_method : SSLMethod
   {% end %}
 
-  {% if compare_versions(OPENSSL_VERSION, "1.0.2") >= 0 || compare_versions(LIBRESSL_VERSION, "2.5.0") >= 0 %}
+  {% if compare_versions(OPENSSL_VERSION, "1.0.2") >= 0 || compare_versions(LIBRESSL_VERSION, "2.1.0") >= 0 %}
     alias ALPNCallback = (SSL, Char**, Char*, Char*, Int, Void*) -> Int
 
     fun ssl_get0_alpn_selected = SSL_get0_alpn_selected(handle : SSL, data : Char**, len : LibC::UInt*) : Void
@@ -272,7 +274,7 @@ lib LibSSL
     fun ssl_ctx_set_alpn_protos = SSL_CTX_set_alpn_protos(ctx : SSLContext, protos : Char*, protos_len : Int) : Int
   {% end %}
 
-  {% if compare_versions(OPENSSL_VERSION, "1.0.2") >= 0 %}
+  {% if compare_versions(OPENSSL_VERSION, "1.0.2") >= 0 || compare_versions(LIBRESSL_VERSION, "2.7.0") >= 0 %}
     alias X509VerifyParam = LibCrypto::X509VerifyParam
 
     fun dtls_method = DTLS_method : SSLMethod
@@ -282,7 +284,7 @@ lib LibSSL
     fun ssl_ctx_set1_param = SSL_CTX_set1_param(ctx : SSLContext, param : X509VerifyParam) : Int
   {% end %}
 
-  {% if compare_versions(OPENSSL_VERSION, "1.1.0") >= 0 %}
+  {% if compare_versions(OPENSSL_VERSION, "1.1.0") >= 0 || compare_versions(LIBRESSL_VERSION, "3.6.0") >= 0 %}
     fun ssl_ctx_set_security_level = SSL_CTX_set_security_level(ctx : SSLContext, level : Int) : Void
     fun ssl_ctx_get_security_level = SSL_CTX_get_security_level(ctx : SSLContext) : Int
   {% end %}
@@ -293,7 +295,7 @@ lib LibSSL
   {% end %}
 end
 
-{% unless compare_versions(LibSSL::OPENSSL_VERSION, "1.1.0") >= 0 %}
+{% if LibSSL.has_method?(:ssl_library_init) %}
   LibSSL.ssl_library_init
   LibSSL.ssl_load_error_strings
   LibCrypto.openssl_add_all_algorithms


### PR DESCRIPTION
A lot of symbols that are available in LibreSSL are missing in the bindings when macro branches only checked for OpenSSL versions. I added the respective LibreSSL versions.