### PR TITLE
[CI] Add tests for LibreSSL 2.7

### DIFF
--- a/.github/workflows/openssl.yml
+++ b/.github/workflows/openssl.yml
@@ -37,8 +37,18 @@ jobs:
       - name: Uninstall openssl and conflicts
         run: apk del openssl-dev openssl-libs-static libxml2-static
       - name: Install ${{ matrix.pkg }}
-        run: apk add "${{ matrix.pkg }}" --repository=${{ matrix.repository }}
-      - name: Print LibSSL version
-        run: bin/crystal eval 'require "openssl"; p! LibSSL::OPENSSL_VERSION, LibSSL::LIBRESSL_VERSION'
+        # `apk add` may exit with a failure status due to some file incompatibilities,
+        # but still install all the necessary parts for our purposes. So we ignore failure.
+        # Reason: ERROR: libressl2.7-libcrypto-2.7.5-r0: trying to overwrite etc/ssl/openssl.cnf owned by libcrypto3-3.3.2-r0.
+        run: apk add "${{ matrix.pkg }}" --repository=${{ matrix.repository }} || true
+      - name: Check LibSSL version
+        run: |
+          bin/crystal eval <<CRYSTAL
+          require "openssl"
+          p! LibSSL::OPENSSL_VERSION, LibSSL::LIBRESSL_VERSION
+          restriction = "${{ matrix.pkg}}".partition("=~")[2]
+          version = "${{ matrix.pkg }}".starts_with?("openssl") ? LibSSL::OPENSSL_VERSION : LibSSL::LIBRESSL_VERSION
+          exit version.starts_with?(restriction) ? 0 : 1
+          CRYSTAL
       - name: Run OpenSSL specs
         run: bin/crystal spec --order=random spec/std/openssl/

--- a/.github/workflows/openssl.yml
+++ b/.github/workflows/openssl.yml
@@ -23,6 +23,8 @@ jobs:
             repository: http://dl-cdn.alpinelinux.org/alpine/v3.17/main
           - pkg: "openssl-dev=~3.3"
             repository: http://dl-cdn.alpinelinux.org/alpine/v3.20/main
+          - pkg: "libressl-dev=~2.7"
+            repository: http://dl-cdn.alpinelinux.org/alpine/v3.9/main
           - pkg: "libressl-dev=~3.4"
             repository: http://dl-cdn.alpinelinux.org/alpine/v3.15/community
           - pkg: "libressl-dev=~3.5"


### PR DESCRIPTION
This is the oldest version of LibreSSL I have been able to dig up. It works in a modern Alpine image, but there's a conflict which leads `apk add` to exit with a failure code. It's still fine to use though. But this means we need to ignore the status code.
To validate we're still using the intended package version, I added a simple check for the version constants in Crystal. So this is even more robust than before.