### PR TITLE
Changed code template to get version number from shard.yml

### DIFF
--- a/src/compiler/crystal/tools/init/template/example.cr.ecr
+++ b/src/compiler/crystal/tools/init/template/example.cr.ecr
@@ -1,6 +1,6 @@
 # TODO: Write documentation for `<%= module_name %>`
 module <%= module_name %>
-  VERSION = "0.1.0"
+  VERSION = {{ `shards version`.chomp.stringify }}
 
   # TODO: Put your code here
 end


### PR DESCRIPTION
Currently, after running `crystal init lib something`, the generated source code file defines a separate `VERSION = 0.1.0` constant, even though the authoritative source of the version number is supposed to be `shard.yml`, which might lead to mismatches.

Using
```cr
VERSION = {{ `shards version`.chomp.stringify }}
```
we can guarantee that the constant matches the number defined in `shard.yml` at all times.