### PR TITLE
Update example code for `::spawn` with `WaitGroup`

### DIFF
--- a/src/concurrent.cr
+++ b/src/concurrent.cr
@@ -40,6 +40,7 @@ end
 # # Write "1" every 1 second and "2" every 2 seconds for 6 seconds.
 #
 # require "wait_group"
+#
 # wg = WaitGroup.new 2
 #
 # spawn do


### PR DESCRIPTION
Currently, [the example in the docs](https://crystal-lang.org/api/1.14.0/toplevel.html#spawn(*,name:String|Nil=nil,same_thread=false,&block)-class-method) for `::spawn` still uses the old way of handling fibers that return `nil`, namely:
```cr
# Write "1" every 1 second and "2" every 2 seconds for 6 seconds.

ch = Channel(Nil).new

spawn do
  6.times do
    sleep 1.second
    puts 1
  end
  ch.send(nil)
end

spawn do
  3.times do
    sleep 2.seconds
    puts 2
  end
  ch.send(nil)
end

2.times { ch.receive }
```

This PR aims to modernise the example using `WaitGroup`.