### PR TITLE
Add note about locale-dependent system error messages

### DIFF
--- a/src/errno.cr
+++ b/src/errno.cr
@@ -38,7 +38,10 @@ enum Errno
     {% end %}
   {% end %}
 
-  # Convert an Errno to an error message
+  # Returns the system error message associated with this errno.
+  #
+  # NOTE: The result may depend on the current system locale. Specs and
+  # comparisons should use `#value` instead of this method.
   def message : String
     unsafe_message { |slice| String.new(slice) }
   end

--- a/src/winerror.cr
+++ b/src/winerror.cr
@@ -60,6 +60,9 @@ enum WinError : UInt32
   # using the current default `LANGID`.
   #
   # On non-win32 platforms the result is always an empty string.
+  #
+  # NOTE: The result may depend on the current system locale. Specs and
+  # comparisons should use `#value` instead of this method.
   def message : String
     {% if flag?(:win32) %}
       unsafe_message { |slice| String.from_utf16(slice).strip }


### PR DESCRIPTION
Resolves part of #11952.

`WasiError#message` is implemented entirely in Crystal and locale-independent.