### PR TITLE
Use MSYS2's upstream LLVM version on MinGW-w64 CI

### DIFF
--- a/.github/workflows/mingw-w64.yml
+++ b/.github/workflows/mingw-w64.yml
@@ -18,12 +18,13 @@ jobs:
       - name: Download Crystal source
         uses: actions/checkout@v4
 
-      - name: Install LLVM 19
+      - name: Install LLVM
         run: |
+          _llvm_major=$(wget -qO- https://raw.githubusercontent.com/msys2/MINGW-packages/refs/heads/master/mingw-w64-llvm/PKGBUILD | grep '_version=' | sed -E 's/_version=([0-9]+).*/\1/')
           sudo apt remove 'llvm-*' 'libllvm*'
           wget -qO- https://apt.llvm.org/llvm-snapshot.gpg.key | sudo tee /etc/apt/trusted.gpg.d/apt.llvm.org.asc
-          sudo apt-add-repository -y deb http://apt.llvm.org/noble/ llvm-toolchain-noble-19 main
-          sudo apt install -y llvm-19-dev
+          sudo apt-add-repository -y deb http://apt.llvm.org/noble/ llvm-toolchain-noble-${_llvm_major} main
+          sudo apt install -y llvm-${_llvm_major}-dev
 
       - name: Install Crystal
         uses: crystal-lang/install-crystal@v1

--- a/.github/workflows/mingw-w64.yml
+++ b/.github/workflows/mingw-w64.yml
@@ -18,12 +18,12 @@ jobs:
       - name: Download Crystal source
         uses: actions/checkout@v4
 
-      - name: Install LLVM 18
+      - name: Install LLVM 19
         run: |
           sudo apt remove 'llvm-*' 'libllvm*'
           wget -qO- https://apt.llvm.org/llvm-snapshot.gpg.key | sudo tee /etc/apt/trusted.gpg.d/apt.llvm.org.asc
-          sudo apt-add-repository -y deb http://apt.llvm.org/noble/ llvm-toolchain-noble-18 main
-          sudo apt install -y llvm-18-dev
+          sudo apt-add-repository -y deb http://apt.llvm.org/noble/ llvm-toolchain-noble-19 main
+          sudo apt install -y llvm-19-dev
 
       - name: Install Crystal
         uses: crystal-lang/install-crystal@v1


### PR DESCRIPTION
MSYS2's Pacman has upgraded LLVM to 19.1.3-1 and dropped 18, breaking our CI, so we pick a newer LLVM version on the cross-compiling host to match the target for now (i.e. until #15091)