### PR TITLE
Fixup libressl version range for `lib_crypto` [fixup #14900]

### DIFF
--- a/src/openssl/lib_crypto.cr
+++ b/src/openssl/lib_crypto.cr
@@ -1,7 +1,7 @@
 # Supported library versions:
 #
 # * openssl (1.1.0–3.3+)
-# * libressl (2.0–3.8+)
+# * libressl (2.0–4.0+)
 #
 # See https://crystal-lang.org/reference/man/required_libraries.html#tls
 {% begin %}


### PR DESCRIPTION
Fixup for https://github.com/crystal-lang/crystal/pull/14900 The version info was updated to 4.0 for `lib_ssl` but not `lib_crypto`.