### PR TITLE
EventLoop: store Timers in min Pairing Heap [fixup #14996]

### DIFF
--- a/spec/std/crystal/evented/timers_spec.cr
+++ b/spec/std/crystal/evented/timers_spec.cr
@@ -10,6 +10,9 @@ describe Crystal::Evented::Timers do
     event = Crystal::Evented::Event.new(:sleep, Fiber.current, timeout: 7.seconds)
     timers.add(pointerof(event))
     timers.empty?.should be_false
+
+    timers.delete(pointerof(event))
+    timers.empty?.should be_true
   end
 
   it "#next_ready?" do
@@ -18,9 +21,18 @@ describe Crystal::Evented::Timers do
     timers.next_ready?.should be_nil
 
     # with events
-    event = Crystal::Evented::Event.new(:sleep, Fiber.current, timeout: 5.seconds)
-    timers.add(pointerof(event))
-    timers.next_ready?.should eq(event.wake_at?)
+    event1s = Crystal::Evented::Event.new(:sleep, Fiber.current, timeout: 1.second)
+    event3m = Crystal::Evented::Event.new(:sleep, Fiber.current, timeout: 3.minutes)
+    event5m = Crystal::Evented::Event.new(:sleep, Fiber.current, timeout: 5.minutes)
+
+    timers.add(pointerof(event5m))
+    timers.next_ready?.should eq(event5m.wake_at?)
+
+    timers.add(pointerof(event1s))
+    timers.next_ready?.should eq(event1s.wake_at?)
+
+    timers.add(pointerof(event3m))
+    timers.next_ready?.should eq(event1s.wake_at?)
   end
 
   it "#dequeue_ready" do
@@ -66,18 +78,6 @@ describe Crystal::Evented::Timers do
 
     event0.wake_at = -1.minute
     timers.add(pointerof(event0)).should be_true # added new head (next ready)
-
-    # TODO: forcefully dequeue the next ready event, then check the order
-
-    # events = [] of Crystal::Evented::Event*
-    # timers.each { |event| events << event }
-    # events.should eq([
-    #   pointerof(event0),
-    #   pointerof(event1),
-    #   pointerof(event3),
-    #   pointerof(event2),
-    # ])
-    timers.empty?.should be_false
   end
 
   it "#delete" do

--- a/spec/std/crystal/evented/timers_spec.cr
+++ b/spec/std/crystal/evented/timers_spec.cr
@@ -67,14 +67,16 @@ describe Crystal::Evented::Timers do
     event0.wake_at = -1.minute
     timers.add(pointerof(event0)).should be_true # added new head (next ready)
 
-    events = [] of Crystal::Evented::Event*
-    timers.each { |event| events << event }
-    events.should eq([
-      pointerof(event0),
-      pointerof(event1),
-      pointerof(event3),
-      pointerof(event2),
-    ])
+    # TODO: forcefully dequeue the next ready event, then check the order
+
+    # events = [] of Crystal::Evented::Event*
+    # timers.each { |event| events << event }
+    # events.should eq([
+    #   pointerof(event0),
+    #   pointerof(event1),
+    #   pointerof(event3),
+    #   pointerof(event2),
+    # ])
     timers.empty?.should be_false
   end
 

--- a/spec/std/crystal/pairing_heap_spec.cr
+++ b/spec/std/crystal/pairing_heap_spec.cr
@@ -1,0 +1,137 @@
+require "spec"
+require "../../../src/crystal/pointer_pairing_heap"
+
+private struct Node
+  getter key : Int32
+
+  include Crystal::PointerPairingHeap::Node
+
+  def initialize(@key : Int32)
+  end
+
+  def heap_compare(other : Pointer(self)) : Bool
+    key < other.value.key
+  end
+end
+
+describe Crystal::PointerPairingHeap do
+  it "#add" do
+    heap = Crystal::PointerPairingHeap(Node).new
+    node1 = Node.new(1)
+    node2 = Node.new(2)
+    node2b = Node.new(2)
+    node3 = Node.new(3)
+
+    # can add distinct nodes
+    heap.add(pointerof(node3))
+    heap.add(pointerof(node1))
+    heap.add(pointerof(node2))
+
+    # can add duplicate key (different nodes)
+    heap.add(pointerof(node2b))
+
+    # can't add same node twice
+    expect_raises(ArgumentError) { heap.add(pointerof(node1)) }
+
+    # can re-add removed nodes
+    heap.delete(pointerof(node3))
+    heap.add(pointerof(node3))
+
+    heap.shift?.should eq(pointerof(node1))
+    heap.add(pointerof(node1))
+  end
+
+  it "#shift?" do
+    heap = Crystal::PointerPairingHeap(Node).new
+    nodes = StaticArray(Node, 10).new { |i| Node.new(i) }
+
+    # insert in random order
+    (0..9).to_a.shuffle.each do |i|
+      heap.add nodes.to_unsafe + i
+    end
+
+    # removes in ascending order
+    10.times do |i|
+      heap.shift?.should eq(nodes.to_unsafe + i)
+    end
+  end
+
+  it "#delete" do
+    heap = Crystal::PointerPairingHeap(Node).new
+    nodes = StaticArray(Node, 10).new { |i| Node.new(i) }
+
+    # noop: empty
+    heap.delete(nodes.to_unsafe + 0).should eq({false, false})
+
+    # insert in random order
+    (0..9).to_a.shuffle.each do |i|
+      heap.add nodes.to_unsafe + i
+    end
+
+    # noop: unknown node
+    node11 = Node.new(11)
+    heap.delete(pointerof(node11)).should eq({false, false})
+
+    # remove some values
+    heap.delete(nodes.to_unsafe + 3).should eq({true, false})
+    heap.delete(nodes.to_unsafe + 7).should eq({true, false})
+    heap.delete(nodes.to_unsafe + 1).should eq({true, false})
+
+    # remove tail
+    heap.delete(nodes.to_unsafe + 9).should eq({true, false})
+
+    # remove head
+    heap.delete(nodes.to_unsafe + 0).should eq({true, true})
+
+    # repeatedly delete min
+    [2, 4, 5, 6, 8].each do |i|
+      heap.shift?.should eq(nodes.to_unsafe + i)
+    end
+    heap.shift?.should be_nil
+  end
+
+  it "adds 1000 nodes then shifts them in order" do
+    heap = Crystal::PointerPairingHeap(Node).new
+
+    nodes = StaticArray(Node, 1000).new { |i| Node.new(i) }
+    (0..999).to_a.shuffle.each { |i| heap.add(nodes.to_unsafe + i) }
+
+    i = 0
+    while node = heap.shift?
+      node.value.key.should eq(i)
+      i += 1
+    end
+    i.should eq(1000)
+
+    heap.shift?.should be_nil
+  end
+
+  it "randomly adds while we shift nodes" do
+    heap = Crystal::PointerPairingHeap(Node).new
+
+    nodes = uninitialized StaticArray(Node, 1000)
+    (0..999).to_a.shuffle.each_with_index { |i, j| nodes[j] = Node.new(i) }
+
+    i = 0
+    removed = 0
+
+    # regularly calls delete-min while we insert
+    loop do
+      if rand(0..5) == 0
+        removed += 1 if heap.shift?
+      else
+        heap.add(nodes.to_unsafe + i)
+        break if (i += 1) == 1000
+      end
+    end
+
+    # exhaust the heap
+    while heap.shift?
+      removed += 1
+    end
+
+    # we must have added and removed all nodes _once_
+    i.should eq(1000)
+    removed.should eq(1000)
+  end
+end

--- a/src/crystal/pointer_pairing_heap.cr
+++ b/src/crystal/pointer_pairing_heap.cr
@@ -1,0 +1,161 @@
+# :nodoc:
+#
+# Tree of `T` structs referenced as pointers.
+# `T` must include `Crystal::PointerPairingHeap::Node`.
+class Crystal::PointerPairingHeap(T)
+  module Node
+    macro included
+      property? heap_previous : Pointer(self)?
+      property? heap_next : Pointer(self)?
+      property? heap_child : Pointer(self)?
+    end
+
+    # Compare self with other. For example:
+    #
+    # Use `<` to create a min heap.
+    # Use `>` to create a max heap.
+    abstract def heap_compare(other : Pointer(self)) : Bool
+  end
+
+  @head : T* | Nil
+
+  private def head=(head)
+    @head = head
+    head.value.heap_previous = nil if head
+    head
+  end
+
+  def empty?
+    @head.nil?
+  end
+
+  def first? : T* | Nil
+    @head
+  end
+
+  def shift? : T* | Nil
+    if node = @head
+      self.head = merge_pairs(node.value.heap_child?)
+      node.value.heap_child = nil
+      node
+    end
+  end
+
+  def add(node : T*) : Bool
+    if node.value.heap_previous? || node.value.heap_next? || node.value.heap_child?
+      raise ArgumentError.new("The node is already in a Pairing Heap tree")
+    end
+    self.head = meld(@head, node)
+    node == @head
+  end
+
+  def delete(node : T*) : {Bool, Bool}
+    if node == @head
+      self.head = merge_pairs(node.value.heap_child?)
+      node.value.heap_child = nil
+      return {true, true}
+    end
+
+    if remove?(node)
+      subtree = merge_pairs(node.value.heap_child?)
+      self.head = meld(@head, subtree)
+      unlink(node)
+      return {true, false}
+    end
+
+    {false, false}
+  end
+
+  private def remove?(node)
+    if previous_node = node.value.heap_previous?
+      next_sibling = node.value.heap_next?
+
+      if previous_node.value.heap_next? == node
+        previous_node.value.heap_next = next_sibling
+      else
+        previous_node.value.heap_child = next_sibling
+      end
+
+      if next_sibling
+        next_sibling.value.heap_previous = previous_node
+      end
+
+      true
+    else
+      false
+    end
+  end
+
+  def clear : Nil
+    if node = @head
+      clear_recursive(node)
+      @head = nil
+    end
+  end
+
+  private def clear_recursive(node)
+    child = node.value.heap_child?
+    while child
+      clear_recursive(child)
+      child = child.value.heap_next?
+    end
+    unlink(node)
+  end
+
+  private def meld(a : T*, b : T*) : T*
+    if a.value.heap_compare(b)
+      add_child(a, b)
+    else
+      add_child(b, a)
+    end
+  end
+
+  private def meld(a : T*, b : Nil) : T*
+    a
+  end
+
+  private def meld(a : Nil, b : T*) : T*
+    b
+  end
+
+  private def meld(a : Nil, b : Nil) : Nil
+  end
+
+  private def add_child(parent : T*, node : T*) : T*
+    first_child = parent.value.heap_child?
+    parent.value.heap_child = node
+
+    first_child.value.heap_previous = node if first_child
+    node.value.heap_previous = parent
+    node.value.heap_next = first_child
+
+    parent
+  end
+
+  # Twopass merge of the children of *node* into pairs of two.
+  private def merge_pairs(a : T*) : T* | Nil
+    a.value.heap_previous = nil
+
+    if b = a.value.heap_next?
+      a.value.heap_next = nil
+      b.value.heap_previous = nil
+    else
+      return a
+    end
+
+    rest = merge_pairs(b.value.heap_next?)
+    b.value.heap_next = nil
+
+    pair = meld(a, b)
+    meld(pair, rest)
+  end
+
+  private def merge_pairs(node : Nil) : Nil
+  end
+
+  private def unlink(node) : Nil
+    node.value.heap_previous = nil
+    node.value.heap_next = nil
+    node.value.heap_child = nil
+  end
+end

--- a/src/crystal/system/unix/evented/event.cr
+++ b/src/crystal/system/unix/evented/event.cr
@@ -1,4 +1,5 @@
 require "crystal/pointer_linked_list"
+require "crystal/pointer_pairing_heap"
 
 # Information about the event that a `Fiber` is waiting on.
 #
@@ -35,6 +36,9 @@ struct Crystal::Evented::Event
   # The event can be added to `Waiters` lists.
   include PointerLinkedList::Node
 
+  # The event can be added to the `Timers` list.
+  include PointerPairingHeap::Node
+
   def initialize(@type : Type, @fiber, @index = nil, timeout : Time::Span? = nil)
     if timeout
       seconds, nanoseconds = System::Time.monotonic
@@ -54,5 +58,9 @@ struct Crystal::Evented::Event
   #
   # NOTE: musn't be changed after registering the event into `Timers`!
   def wake_at=(@wake_at)
+  end
+
+  def heap_compare(other : Pointer(self)) : Bool
+    wake_at < other.value.wake_at
   end
 end

--- a/src/crystal/system/unix/evented/timers.cr
+++ b/src/crystal/system/unix/evented/timers.cr
@@ -38,12 +38,21 @@ struct Crystal::Evented::Timers
   # Add a new timer into the list. Returns true if it is the next ready timer.
   def add(event : Evented::Event*) : Bool
     @heap.add(event)
+    @heap.first? == event
   end
 
   # Remove a timer from the list. Returns a tuple(dequeued, was_next_ready) of
   # booleans. The first bool tells whether the event was dequeued, in which case
   # the second one tells if it was the next ready event.
   def delete(event : Evented::Event*) : {Bool, Bool}
-    @heap.delete(event)
+    if @heap.first? == event
+      @heap.shift?
+      {true, true}
+    elsif event.value.heap_previous?
+      @heap.delete(event)
+      {true, false}
+    else
+      {false, false}
+    end
   end
 end

--- a/src/crystal/system/unix/evented/timers.cr
+++ b/src/crystal/system/unix/evented/timers.cr
@@ -1,86 +1,49 @@
+require "crystal/pointer_pairing_heap"
+
 # List of `Event` ordered by `Event#wake_at` ascending. Optimized for fast
 # dequeue and determining when is the next timer event.
 #
-# Thread unsafe: parallel accesses much be protected.
+# Thread unsafe: parallel accesses much be protected!
 #
-# NOTE: this is a struct because it only wraps a const pointer to a deque
+# NOTE: this is a struct because it only wraps a const pointer to an object
 # allocated in the heap.
-#
-# OPTIMIZE: consider a skiplist for faster lookups (add/delete).
-#
-# OPTIMIZE: we could avoid memmove on add/delete by allocating a buffer, putting
-# entries at whatever available index in the buffer, and linking entries in
-# order (using indices so we can realloc the buffer); we'd have to keep a list
-# of free indexes, too. It could be a good combo of unbounded linked list while
-# retaining some memory locality. It should even be compatible with a skiplist
-# (e.g. make entries a fixed height tower instead of prev/next node).
 struct Crystal::Evented::Timers
   def initialize
-    @list = Deque(Evented::Event*).new
+    @heap = PointerPairingHeap(Evented::Event).new
   end
 
   def empty? : Bool
-    @list.empty?
+    @heap.empty?
   end
 
-  # Returns the time at which the next timer is supposed to run.
+  # Returns the time of the next ready timer (if any).
   def next_ready? : Time::Span?
-    @list.first?.try(&.value.wake_at)
+    @heap.first?.try(&.value.wake_at)
   end
 
   # Dequeues and yields each ready timer (their `#wake_at` is lower than
   # `System::Time.monotonic`) from the oldest to the most recent (i.e. time
   # ascending).
   def dequeue_ready(& : Evented::Event* -> Nil) : Nil
-    return if @list.empty?
-
     seconds, nanoseconds = System::Time.monotonic
     now = Time::Span.new(seconds: seconds, nanoseconds: nanoseconds)
-    n = 0
 
-    @list.each do |event|
+    while event = @heap.first?
       break if event.value.wake_at > now
+      @heap.shift?
       yield event
-      n += 1
     end
-
-    # OPTIMIZE: consume the n entries at once
-    n.times { @list.shift }
   end
 
   # Add a new timer into the list. Returns true if it is the next ready timer.
   def add(event : Evented::Event*) : Bool
-    if @list.empty?
-      @list << event
-      true
-    elsif index = lookup(event.value.wake_at)
-      @list.insert(index, event)
-      index == 0
-    else
-      @list.push(event)
-      false
-    end
-  end
-
-  private def lookup(wake_at)
-    @list.each_with_index do |event, index|
-      return index if event.value.wake_at >= wake_at
-    end
+    @heap.add(event)
   end
 
   # Remove a timer from the list. Returns a tuple(dequeued, was_next_ready) of
   # booleans. The first bool tells whether the event was dequeued, in which case
   # the second one tells if it was the next ready event.
   def delete(event : Evented::Event*) : {Bool, Bool}
-    if index = @list.index(event)
-      @list.delete_at(index)
-      {true, index.zero?}
-    else
-      {false, false}
-    end
-  end
-
-  def each(&) : Nil
-    @list.each { |event| yield event }
+    @heap.delete(event)
   end
 end


### PR DESCRIPTION
Related to [RFC #0012](https://github.com/crystal-lang/rfcs/pull/12).

Replaces the `Deque` used in #14996 for a min [Pairing Heap] which is a kind of [Mergeable Heap] and is one of the best performing heap in practical tests when arbitrary deletions are required (think cancelling a timeout), otherwise a D-ary Heap (e.g. 4-heap) will usually perform better. See the [A Nearly-Tight Analysis of Multipass Pairing Heaps](https://epubs.siam.org/doi/epdf/10.1137/1.9781611973068.52) paper or the Wikipedia page for more details.

The implementation itself is based on the [Pairing Heaps: Experiments and Analysis](https://dl.acm.org/doi/pdf/10.1145/214748.214759) paper, and merely implements a recursive twopass algorithm (the auxiliary twopass might perform even better). The `Crystal::PointerPairingList(T)` type is generic and relies on intrusive nodes (the links are into `T`) to avoid extra allocations for the nodes (same as `Crystal::PointerLinkedList(T)`). It also requires a `T#heap_compare` method, so we can use the same type for a min or max heap, or to build a more complex comparison.

Note: I also tried a 4-heap, and while it performs very well and only needs a flat array, the arbitrary deletion (e.g. cancelling timeout) needs a linear scan and its performance quickly plummets, even at low occupancy, and becomes painfully slow at higher occupancy (tens of microseconds on _each_ delete, while the pairing heap does it in tens of nanoseconds).

Follow up to #14996 

~~Builds on top of #15205, you should open the [last commit](586496ee994fb55bd22ebd5fdde3dd568b050e19) for just the pairing heap.~~

[Mergeable Heap]: https://en.wikipedia.org/wiki/Mergeable_heap
[Pairing Heap]: https://en.wikipedia.org/wiki/Pairing_heap
[D-ary Heap]: https://en.wikipedia.org/wiki/D-ary_heap