### PR TITLE
Remove the entire compiler code base from `external_command_spec`

### DIFF
--- a/spec/primitives/external_command_spec.cr
+++ b/spec/primitives/external_command_spec.cr
@@ -1,8 +1,8 @@
 {% skip_file if flag?(:interpreted) %}
 
-require "../spec_helper"
+require "../support/tempfile"
 
-describe Crystal::Command do
+describe "Crystal::Command" do
   it "exec external commands", tags: %w[slow] do
     with_temp_executable "crystal-external" do |path|
       with_tempfile "crystal-external.cr" do |source_file|


### PR DESCRIPTION
The spec file only needs `support/tempfile`, not the entire `spec_helper`, which also include the entire compiler code base.