### PR TITLE
Refactor `Enumerable#map` to delegate to `#map_with_index`

### DIFF
--- a/src/enumerable.cr
+++ b/src/enumerable.cr
@@ -1033,9 +1033,9 @@ module Enumerable(T)
   # [1, 2, 3].map { |i| i * 10 } # => [10, 20, 30]
   # ```
   def map(& : T -> U) : Array(U) forall U
-    ary = [] of U
-    each { |e| ary << yield e }
-    ary
+    map_with_index do |e|
+      yield e
+    end
   end
 
   # Like `map`, but the block gets passed both the element and its index.


### PR DESCRIPTION
`#map` and `map_with_index` are identical except that the latter also yields an index counter. 

But this counter is entirely optional and can be omitted from the block. It's possible to call `#map_with_index` with exactly the same signature as `#map`.

```cr
["foo", "bar"].map_with_index do |e|
  e.upcase
end # => ["FOO", "BAR"]

["foo", "bar"].map do |e|
  e.upcase
end # => ["FOO", "BAR"]
```

The implementation of both methods is also pretty much identical, in `Enumerable` as well as in any including type.
Of course, `map_with_index` has a counter and yields its value. But LLVM optimization happily removes it when unused.

So I think it makes sense to implement `Enumerable#map` by delegating to `#map_with_index`. This embodies the close connection between these two methods.
As a result, including types only need to override `#map_with_index` with a custom implementation and `#map` will follow suit. 
Including types *may* still override `#map` with a custom implementation, of course.