### PR TITLE
Add location to result from macro method interpretation

### DIFF
--- a/spec/compiler/macro/macro_methods_spec.cr
+++ b/spec/compiler/macro/macro_methods_spec.cr
@@ -762,6 +762,10 @@ module Crystal
         assert_macro %({{[1, 2, 3].map { |e| e == 2 }}}), "[false, true, false]"
       end
 
+      it "executes map assigns location" do
+        assert_macro %({{[1].map { |e| e }.filename }}), %("")
+      end
+
       it "executes reduce with no initial value" do
         assert_macro %({{[1, 2, 3].reduce { |acc, val| acc * val }}}), "6"
       end

--- a/src/compiler/crystal/macros/interpreter.cr
+++ b/src/compiler/crystal/macros/interpreter.cr
@@ -367,7 +367,7 @@ module Crystal
         block = node.block.try { |b| @program.normalize(b) }
 
         begin
-          @last = receiver.interpret(node.name, args, named_args, block, self, node.name_location)
+          result = receiver.interpret(node.name, args, named_args, block, self, node.name_location)
         rescue ex : MacroRaiseException
           # Re-raise to avoid the logic in the other rescue blocks and to retain the original location
           raise ex
@@ -376,6 +376,8 @@ module Crystal
         rescue ex
           node.raise ex.message
         end
+        result.location ||= node.name_location
+        @last = result
       else
         # no receiver: special calls
         # may raise `Crystal::TopLevelMacroRaiseException`

--- a/src/compiler/crystal/macros/interpreter.cr
+++ b/src/compiler/crystal/macros/interpreter.cr
@@ -367,7 +367,7 @@ module Crystal
         block = node.block.try { |b| @program.normalize(b) }
 
         begin
-          result = receiver.interpret(node.name, args, named_args, block, self, node.name_location)
+          @last = receiver.interpret(node.name, args, named_args, block, self, node.name_location)
         rescue ex : MacroRaiseException
           # Re-raise to avoid the logic in the other rescue blocks and to retain the original location
           raise ex
@@ -376,8 +376,7 @@ module Crystal
         rescue ex
           node.raise ex.message
         end
-        result.location ||= node.name_location
-        @last = result
+        @last.location ||= node.name_location
       else
         # no receiver: special calls
         # may raise `Crystal::TopLevelMacroRaiseException`

--- a/src/compiler/crystal/macros/methods.cr
+++ b/src/compiler/crystal/macros/methods.cr
@@ -393,7 +393,7 @@ module Crystal
     def interpret(method : String, args : Array(ASTNode), named_args : Hash(String, ASTNode)?, block : Crystal::Block?, interpreter : Crystal::MacroInterpreter, name_loc : Location?)
       case method
       when "id"
-        interpret_check_args { MacroId.new(to_macro_id) }
+        interpret_check_args { MacroId.new(to_macro_id).at(location) }
       when "stringify"
         interpret_check_args { stringify }
       when "symbolize"


### PR DESCRIPTION
When calling a macro method, the result is typically a newly created AST node. So in most cases, the location of the AST node should be the location of the call. There are some exceptions though. Some methods don't create new nodes, they are just getters for pre-existing ones (for example: `Def#body` returns the AST node of the body). 
So if the returned node already has a location, we should not override it. Pre-existing nodes are typically created from parsing source code and thus should be expected to have a location.
I did not verify this for all cases, so this change has some potential for injecting a false location into an existing node becuase we're mutating the stored instance without cloning it. But I don't think there's a high risk for this, nor would this have a major effect. An incorrect location is worse than no location, but not much. And the fix for both is identical: make sure the correct location is used when the node is created.

This fixes the immediate bug in #15202, not the deeper issue with AST nodes missing location info being passed to LLVM.