### PR TITLE
EventLoop: yield fibers internally [fixup #14996]

### DIFF
--- a/spec/std/crystal/evented/poll_descriptor_spec.cr
+++ b/spec/std/crystal/evented/poll_descriptor_spec.cr
@@ -5,7 +5,7 @@ require "spec"
 class Crystal::Evented::FakeLoop < Crystal::Evented::EventLoop
   getter operations = [] of {Symbol, Int32, Crystal::Evented::Arena::Index | Bool}
 
-  private def system_run(blocking : Bool) : Nil
+  private def system_run(blocking : Bool, & : Fiber ->) : Nil
   end
 
   private def interrupt : Nil


### PR DESCRIPTION
Refactors the internals of the epoll/kqueue event loop to `yield` the fiber(s) to be resumed instead of blindly calling `Crystal::Scheduler.enqueue`, so the `#run` method becomes the one place responsible to enqueue the fibers.

The current behavior doesn't change, the `#run` method still enqueues the fiber immediately, but it can now be changed in a single place.

For example the [execution context shard](https://github.com/ysbaddaden/execution_context) monkey-patches an alternative `#run` method that collects and returns fibers to avoid parallel enqueues from an evloop run to interrupt the evloop run (:sob:).

Note that the `#close` method still directly enqueues waiting fibers one by one, for now.