### PR TITLE
Improve `__crystal_once` performance

### DIFF
--- a/src/crystal/once.cr
+++ b/src/crystal/once.cr
@@ -81,7 +81,7 @@ fun __crystal_once_exec(flag : Bool*, initializer : Void*) : Void
     Proc(Nil).new(initializer, Pointer(Void).null).call
     Atomic::Ops.store(flag, :initialized, :release, false)
   ensure
-    {% if flag?(:preview_mt) %}
+    {% if flag?(:preview_mt) || flag?(:win32) %}
       state.unlock
     {% end %}
   end


### PR DESCRIPTION
## Description

This PR significantly improves `__crystal_once` performance.

I originally wrote this code for a custom crystal stdlib focused on microchips without `malloc`.  

While the previous implementation used an array to keep track of all variables currently being initialized, this one (ab)uses the given `flag` boolean pointer as an enum with three values to represent the "being initialized" state.

Also, the previous implementation always used a mutex when accessing any const variable using `-Dpreview_mt`.
This implementation instead has a fast path for the (very likely) scenario that the variable was already initialized which doesn't need a mutex.

## Let's talk numbers

Benchmark code and results on my machine can be found here:  
https://gitlab.com/-/snippets/4772439