### PR TITLE
Mark `__crystal_personality` as nodoc [fixup #15070]

### DIFF
--- a/src/raise.cr
+++ b/src/raise.cr
@@ -207,12 +207,14 @@ end
       alias DISPATCHER_CONTEXT = Void
     end
 
+    # :nodoc:
     lib LibUnwind
       alias PersonalityFn = Int32, Action, UInt64, Exception*, Void* -> ReasonCode
 
       fun _GCC_specific_handler(ms_exc : LibC::EXCEPTION_RECORD64*, this_frame : Void*, ms_orig_context : LibC::CONTEXT*, ms_disp : LibC::DISPATCHER_CONTEXT*, gcc_per : PersonalityFn) : LibC::EXCEPTION_DISPOSITION
     end
 
+    # :nodoc:
     fun __crystal_personality(ms_exc : LibC::EXCEPTION_RECORD64*, this_frame : Void*, ms_orig_context : LibC::CONTEXT*, ms_disp : LibC::DISPATCHER_CONTEXT*) : LibC::EXCEPTION_DISPOSITION
       LibUnwind._GCC_specific_handler(ms_exc, this_frame, ms_orig_context, ms_disp, ->__crystal_personality_imp)
     end
@@ -294,6 +296,7 @@ fun __crystal_raise_overflow : NoReturn
 end
 
 {% if flag?(:interpreted) %}
+  # :nodoc:
   def __crystal_raise_cast_failed(obj, type_name : String, location : String)
     raise TypeCastError.new("Cast from #{obj.class} to #{type_name} failed, at #{location}")
   end

--- a/src/raise.cr
+++ b/src/raise.cr
@@ -182,6 +182,7 @@ end
   end
 {% else %}
   {% mingw = flag?(:win32) && flag?(:gnu) %}
+  # :nodoc:
   fun {{ mingw ? "__crystal_personality_imp".id : "__crystal_personality".id }}(
     version : Int32, actions : LibUnwind::Action, exception_class : UInt64, exception_object : LibUnwind::Exception*, context : Void*,
   ) : LibUnwind::ReasonCode


### PR DESCRIPTION
I noticed that this internal function is not `:nodoc:` since #15070:  
[API Link](https://crystal-lang.org/api/master/toplevel.html#__crystal_personality%28version%3AInt32%2Cactions%3ALibUnwind%3A%3AAction%2Cexception_class%3AUInt64%2Cexception_object%3APointer%28LibUnwind%3A%3AException%29%2Ccontext%3APointer%28Void%29%29-class-method)
