### PR TITLE
Add `ECR::Lexer::SyntaxException` with location info

### DIFF
--- a/src/ecr/lexer.cr
+++ b/src/ecr/lexer.cr
@@ -132,11 +132,7 @@ class ECR::Lexer
 
           if is_end
             setup_control_token(start_pos, is_escape, suppress_leading, true)
-
-            if current_char != '>'
-              raise "Expecting '>' after '-%'"
-            end
-
+            raise "Expecting '>' after '-%'" if current_char != '>'
             next_char
             break
           end

--- a/src/ecr/lexer.cr
+++ b/src/ecr/lexer.cr
@@ -108,20 +108,11 @@ class ECR::Lexer
       case current_char
       when '\0'
         if is_output
-          raise SyntaxException.new(
-            "Unexpected end of file inside <%= ...",
-            @line_number, @column_number
-          )
+          raise "Unexpected end of file inside <%= ..."
         elsif is_escape
-          raise SyntaxException.new(
-            "Unexpected end of file inside <%% ...",
-            @line_number, @column_number
-          )
+          raise "Unexpected end of file inside <%% ..."
         else
-          raise SyntaxException.new(
-            "Unexpected end of file inside <% ...",
-            @line_number, @column_number
-          )
+          raise "Unexpected end of file inside <% ..."
         end
       when '\n'
         @line_number += 1
@@ -143,10 +134,7 @@ class ECR::Lexer
             setup_control_token(start_pos, is_escape, suppress_leading, true)
 
             if current_char != '>'
-              raise SyntaxException.new(
-                "Expecting '>' after '-%'",
-                @line_number, @column_number
-              )
+              raise "Expecting '>' after '-%'"
             end
 
             next_char
@@ -222,5 +210,9 @@ class ECR::Lexer
 
   private def string_range(start_pos, end_pos)
     @reader.string.byte_slice(start_pos, end_pos - start_pos)
+  end
+
+  private def raise(message : String)
+    raise SyntaxException.new(message, @line_number, @column_number)
   end
 end


### PR DESCRIPTION
Closes #15220. Don't know if I should add a rescue to `ECR.process_string` that re-raises as a ECR::SyntaxException, for now though I think this works. Didn't end up going with `Crystal::SyntaxException` as that required pulling in the entire ast / parser / compiler files which seemed silly for a simple exception.