### PR TITLE
Add `Enumerable/Iterator#filter_map`

### DIFF
--- a/spec/std/enumerable_spec.cr
+++ b/spec/std/enumerable_spec.cr
@@ -113,6 +113,10 @@ describe "Enumerable" do
     it { Set{1, nil, 2, nil, 3}.compact_map { |x| x.try &.+(1) }.should eq([2, 3, 4]) }
   end
 
+  describe "filter map" do
+    it { (1..10).filter_map { |i| i * 2 if i.even? }.should eq([4, 8, 12, 16, 20]) }
+  end
+
   describe "size without block" do
     it "returns the number of elements in the Enumerable" do
       SpecEnumerable.new.size.should eq 3

--- a/spec/std/iterator_spec.cr
+++ b/spec/std/iterator_spec.cr
@@ -162,6 +162,16 @@ describe Iterator do
     end
   end
 
+  describe "filter_map" do
+    it "applies the function and removes falsy values" do
+      assert_iterates_iterator [4, 8], (1..5).each.filter_map { |i| i * 2 if i.even? }
+    end
+
+    it "sums after filter_map to_a" do
+      (1..5).each.filter_map { |i| i * 2 if i.even? }.to_a.sum.should eq(12)
+    end
+  end
+
   describe "chain" do
     it "chains" do
       iter = (1..2).each.chain(('a'..'b').each)

--- a/src/enumerable.cr
+++ b/src/enumerable.cr
@@ -257,6 +257,22 @@ module Enumerable(T)
     ary
   end
 
+  # Returns an `Array` containing the truthy results (everything except `false` or `nil`)
+  # of running the block against each element of the collection.
+  #
+  # ```
+  # (1..10).filter_map { |i| i * 2 if i.even? } # => [4, 8, 12, 16, 20]
+  # ```
+  def filter_map(& : T -> _)
+    ary = [] of typeof((yield Enumerable.element_type(self)).not_nil!)
+    each do |e|
+      if v = yield e
+        ary << v
+      end
+    end
+    ary
+  end
+
   # Returns the number of elements in the collection for which
   # the passed block is truthy.
   #


### PR DESCRIPTION
Adds convenience method introduced in Ruby 2.7.

Refs:
- https://www.rubydoc.info/stdlib/core/Enumerable:filter_map
- https://forum.crystal-lang.org/t/ruby-2-7-new-enumerable-methods/800