### PR TITLE
Set IO to be sync for `File` by default

### DIFF
--- a/src/crystal/system/unix/file_descriptor.cr
+++ b/src/crystal/system/unix/file_descriptor.cr
@@ -36,6 +36,7 @@ module Crystal::System::FileDescriptor
 
   private def system_blocking_init(value)
     self.system_blocking = false unless value
+    self.sync = value
   end
 
   private def system_close_on_exec?

--- a/src/crystal/system/wasi/file_descriptor.cr
+++ b/src/crystal/system/wasi/file_descriptor.cr
@@ -18,6 +18,7 @@ module Crystal::System::FileDescriptor
   end
 
   private def system_blocking_init(value)
+    self.sync = value
   end
 
   private def system_reopen(other : IO::FileDescriptor)

--- a/src/crystal/system/win32/file_descriptor.cr
+++ b/src/crystal/system/win32/file_descriptor.cr
@@ -101,6 +101,7 @@ module Crystal::System::FileDescriptor
 
   private def system_blocking_init(value)
     @system_blocking = value
+    self.sync = value
     Crystal::EventLoop.current.create_completion_port(windows_handle) unless value
   end
 


### PR DESCRIPTION
Since [userspace buffers prevent Crystal from closing files automatically on program exit](https://github.com/crystal-lang/crystal/issues/13995#issuecomment-2504326622), maybe we should avoid using them for file I/O by default. Folks can enable userspace buffering explicitly if they need its benefits.

Fixes #13995