### PR TITLE
Avoid identifier naming collision in `getter`, `setter`, and `property` macros

### DIFF
--- a/src/object.cr
+++ b/src/object.cr
@@ -457,18 +457,18 @@ class Object
           {{var_prefix}}\{{name.var.id}} : \{{name.type}}?
 
           def {{method_prefix}}\{{name.var.id}} : \{{name.type}}
-            if (value = {{var_prefix}}\{{name.var.id}}).nil?
+            if (%value = {{var_prefix}}\{{name.var.id}}).nil?
               {{var_prefix}}\{{name.var.id}} = \{{yield}}
             else
-              value
+              %value
             end
           end
         \{% else %}
           def {{method_prefix}}\{{name.id}}
-            if (value = {{var_prefix}}\{{name.id}}).nil?
+            if (%value = {{var_prefix}}\{{name.id}}).nil?
               {{var_prefix}}\{{name.id}} = \{{yield}}
             else
-              value
+              %value
             end
           end
         \{% end %}
@@ -561,10 +561,10 @@ class Object
           end
 
           def {{method_prefix}}\{{name.var.id}} : \{{name.type}}
-            if (value = {{var_prefix}}\{{name.var.id}}).nil?
+            if (%value = {{var_prefix}}\{{name.var.id}}).nil?
               ::raise ::NilAssertionError.new("\{{@type}}\{{"{{doc_prefix}}".id}}\{{name.var.id}} cannot be nil")
             else
-              value
+              %value
             end
           end
         \{% else %}
@@ -573,10 +573,10 @@ class Object
           end
 
           def {{method_prefix}}\{{name.id}}
-            if (value = {{var_prefix}}\{{name.id}}).nil?
+            if (%value = {{var_prefix}}\{{name.id}}).nil?
               ::raise ::NilAssertionError.new("\{{@type}}\{{"{{doc_prefix}}".id}}\{{name.id}} cannot be nil")
             else
-              value
+              %value
             end
           end
         \{% end %}
@@ -688,18 +688,18 @@ class Object
           {{var_prefix}}\{{name.var.id}} : \{{name.type}}?
 
           def {{method_prefix}}\{{name.var.id}}? : \{{name.type}}
-            if (value = {{var_prefix}}\{{name.var.id}}).nil?
+            if (%value = {{var_prefix}}\{{name.var.id}}).nil?
               {{var_prefix}}\{{name.var.id}} = \{{yield}}
             else
-              value
+              %value
             end
           end
         \{% else %}
           def {{method_prefix}}\{{name.id}}?
-            if (value = {{var_prefix}}\{{name.id}}).nil?
+            if (%value = {{var_prefix}}\{{name.id}}).nil?
               {{var_prefix}}\{{name.id}} = \{{yield}}
             else
-              value
+              %value
             end
           end
         \{% end %}
@@ -970,10 +970,10 @@ class Object
           {{var_prefix}}\{{name.var.id}} : \{{name.type}}?
 
           def {{method_prefix}}\{{name.var.id}} : \{{name.type}}
-            if (value = {{var_prefix}}\{{name.var.id}}).nil?
+            if (%value = {{var_prefix}}\{{name.var.id}}).nil?
               {{var_prefix}}\{{name.var.id}} = \{{yield}}
             else
-              value
+              %value
             end
           end
 
@@ -981,10 +981,10 @@ class Object
           end
         \{% else %}
           def {{method_prefix}}\{{name.id}}
-            if (value = {{var_prefix}}\{{name.id}}).nil?
+            if (%value = {{var_prefix}}\{{name.id}}).nil?
               {{var_prefix}}\{{name.id}} = \{{yield}}
             else
-              value
+              %value
             end
           end
 
@@ -1216,10 +1216,10 @@ class Object
           {{var_prefix}}\{{name.var.id}} : \{{name.type}}?
 
           def {{method_prefix}}\{{name.var.id}}? : \{{name.type}}
-            if (value = {{var_prefix}}\{{name.var.id}}).nil?
+            if (%value = {{var_prefix}}\{{name.var.id}}).nil?
               {{var_prefix}}\{{name.var.id}} = \{{yield}}
             else
-              value
+              %value
             end
           end
 
@@ -1227,10 +1227,10 @@ class Object
           end
         \{% else %}
           def {{method_prefix}}\{{name.id}}?
-            if (value = {{var_prefix}}\{{name.id}}).nil?
+            if (%value = {{var_prefix}}\{{name.id}}).nil?
               {{var_prefix}}\{{name.id}} = \{{yield}}
             else
-              value
+              %value
             end
           end
 


### PR DESCRIPTION
## TL;DR

Currently, you can't refer to an identifier called `value` inside a `getter`, `setter`, and `property` blocks due to that identifier colliding with one defined inside the macro. This commit uses a safe variable name to avoid that collision.

## Details

Given the following code:

```crystal
struct Foo
  getter value = "bar"
  getter baz : String do
    value.upcase
  end
end

Foo.new.baz
```

I get this error:

```
In foo.cr:8:9

 8 | Foo.new.baz
             ^--
Error: instantiating 'Foo#baz()'


In foo.cr:4:11

 4 | value.upcase
           ^-----
Error: undefined method 'upcase' for Nil

Nil trace:

  foo.cr:4

        value.upcase


  macro getter (in expanded macro: macro_4331394032:117):10

                if (value = @baz).nil?


  macro getter (in expanded macro: macro_4331394032:117):10

                if (value = @baz).nil?


  macro getter (in expanded macro: macro_4331394032:117):7

              @baz : String?
```

This didn't make sense because my `value` method is guaranteed to return a `String` at compile time. One thing I noticed was that changing the `getter baz` block to `self.value.upcase` worked, which pointed to a naming collision.

I did find local variables named `value` in those macros, and this PR updates them with the `%` sigil. With this PR, that example code runs as expected.