### PR TITLE
Change `libevent` event loop to wait forever when blocking

### DIFF
--- a/src/crystal/event_loop/libevent.cr
+++ b/src/crystal/event_loop/libevent.cr
@@ -15,7 +15,9 @@ class Crystal::EventLoop::LibEvent < Crystal::EventLoop
   {% end %}
 
   def run(blocking : Bool) : Bool
-    event_base.loop(once: true, nonblock: !blocking)
+    flags = LibEvent2::EventLoopFlags::Once
+    flags |= blocking ? LibEvent2::EventLoopFlags::NoExitOnEmpty : LibEvent2::EventLoopFlags::NonBlock
+    event_base.loop(flags)
   end
 
   def interrupt : Nil

--- a/src/crystal/event_loop/libevent/event.cr
+++ b/src/crystal/event_loop/libevent/event.cr
@@ -61,10 +61,7 @@ class Crystal::EventLoop::LibEvent < Crystal::EventLoop
 
       # NOTE: may return `true` even if no event has been triggered (e.g.
       #       nonblocking), but `false` means that nothing was processed.
-      def loop(once : Bool, nonblock : Bool) : Bool
-        flags = LibEvent2::EventLoopFlags::None
-        flags |= LibEvent2::EventLoopFlags::Once if once
-        flags |= LibEvent2::EventLoopFlags::NonBlock if nonblock
+      def loop(flags : LibEvent2::EventLoopFlags) : Bool
         LibEvent2.event_base_loop(@base, flags) == 0
       end
 

--- a/src/crystal/event_loop/libevent/lib_event2.cr
+++ b/src/crystal/event_loop/libevent/lib_event2.cr
@@ -31,8 +31,9 @@ lib LibEvent2
 
   @[Flags]
   enum EventLoopFlags
-    Once     = 0x01
-    NonBlock = 0x02
+    Once          = 0x01
+    NonBlock      = 0x02
+    NoExitOnEmpty = 0x04
   end
 
   @[Flags]


### PR DESCRIPTION
~~Same as #14949 but with a twist:~~ the libevent evloop no longer returns when it's empty (no queued events), so the behavior doesn't rely on the existence of the stack-pool-collector fiber repeatedly sleeping.

The Polling evloop already waits forever (when blocking) and IOCP will also with #15238.

**edit**: extracted drop fiber channel commit.