### PR TITLE
Add specs for invalid special characters in `Cookie`

### DIFF
--- a/spec/std/http/cookie_spec.cr
+++ b/spec/std/http/cookie_spec.cr
@@ -14,7 +14,7 @@ private def parse_set_cookie(header)
   cookie.not_nil!
 end
 
-# invalid printable ascii characters, non-printable ascii characters and chontrol characters
+# invalid printable ascii characters, non-printable ascii characters and control characters
 private INVALID_COOKIE_VALUES = ("\x00".."\x08").to_a + ("\x0A".."\x1F").to_a + ["\r", "\t", "\n", %(" "), %("), ",", ";", "\\", "\x7f", "\xFF", "🍪"]
 
 module HTTP

--- a/spec/std/http/cookie_spec.cr
+++ b/spec/std/http/cookie_spec.cr
@@ -45,7 +45,7 @@ module HTTP
           HTTP::Cookie.new("x", %(foo\rbar))
         end
 
-        [*("\x00".."\x08"), *("\x0A".."\x1F"), "\t", %(" "), %("), ",", "\\", "\x7f", "\xFF", "🍪"].each do |char|
+        (("\x00".."\x08").to_a + ("\x0A".."\x1F").to_a + ["\t", %(" "), %("), ",", "\\", "\x7f", "\xFF", "🍪"]).each do |char|
           expect_raises IO::Error, "Invalid cookie value" do
             HTTP::Cookie.new("x", char)
           end

--- a/spec/std/http/cookie_spec.cr
+++ b/spec/std/http/cookie_spec.cr
@@ -44,6 +44,12 @@ module HTTP
         expect_raises IO::Error, "Invalid cookie value" do
           HTTP::Cookie.new("x", %(foo\rbar))
         end
+
+        [*("\x00".."\x08"), *("\x0A".."\x1F"), "\t", %(" "), %("), ",", "\\", "\x7f", "\xFF", "🍪"].each do |char|
+          expect_raises IO::Error, "Invalid cookie value" do
+            HTTP::Cookie.new("x", char)
+          end
+        end
       end
 
       describe "with a security prefix" do

--- a/spec/std/http/cookie_spec.cr
+++ b/spec/std/http/cookie_spec.cr
@@ -556,10 +556,10 @@ module HTTP
 
       it "chops value at the first invalid byte" do
         HTTP::Cookies.from_client_headers(
-          HTTP::Headers {"Cookie" => "ginger=snap; cookie=hm🍪delicious; snicker=doodle",}
+          HTTP::Headers{"Cookie" => "ginger=snap; cookie=hm🍪delicious; snicker=doodle"}
         ).to_h.should eq({
-          "ginger" => HTTP::Cookie.new("ginger", "snap"),
-          "cookie" => HTTP::Cookie.new("cookie", "hm"),
+          "ginger"  => HTTP::Cookie.new("ginger", "snap"),
+          "cookie"  => HTTP::Cookie.new("cookie", "hm"),
           "snicker" => HTTP::Cookie.new("snicker", "doodle"),
         })
       end
@@ -577,9 +577,9 @@ module HTTP
 
       it "drops cookies with invalid byte in value" do
         HTTP::Cookies.from_server_headers(
-          HTTP::Headers {"Set-Cookie" => ["ginger=snap", "cookie=hm🍪delicious", "snicker=doodle"],}
+          HTTP::Headers{"Set-Cookie" => ["ginger=snap", "cookie=hm🍪delicious", "snicker=doodle"]}
         ).to_h.should eq({
-          "ginger" => HTTP::Cookie.new("ginger", "snap"),
+          "ginger"  => HTTP::Cookie.new("ginger", "snap"),
           "snicker" => HTTP::Cookie.new("snicker", "doodle"),
         })
       end


### PR DESCRIPTION
These specs describe the status quo of special character handling in `HTTP::Cookie` per #15218.