### PR TITLE
Add `Process::Status#exit_code?`

### DIFF
--- a/spec/std/process/status_spec.cr
+++ b/spec/std/process/status_spec.cr
@@ -36,6 +36,16 @@ describe Process::Status do
     end
   end
 
+  it "#exit_code?" do
+    Process::Status.new(exit_status(0)).exit_code?.should eq 0
+    Process::Status.new(exit_status(1)).exit_code?.should eq 1
+    Process::Status.new(exit_status(127)).exit_code?.should eq 127
+    Process::Status.new(exit_status(128)).exit_code?.should eq 128
+    Process::Status.new(exit_status(255)).exit_code?.should eq 255
+
+    status_for(:interrupted).exit_code?.should eq({% if flag?(:unix) %}nil{% else %}LibC::STATUS_CONTROL_C_EXIT.to_i32!{% end %})
+  end
+
   it "#success?" do
     Process::Status.new(exit_status(0)).success?.should be_true
     Process::Status.new(exit_status(1)).success?.should be_false

--- a/src/process/status.cr
+++ b/src/process/status.cr
@@ -215,8 +215,21 @@ class Process::Status
   # Process.new("sleep", ["10"]).tap(&.terminate).wait.exit_code # RuntimeError: Abnormal exit has no exit code
   # ```
   def exit_code : Int32
+    exit_code? || raise RuntimeError.new("Abnormal exit has no exit code")
+  end
+
+  # Returns the exit code of the process if it exited normally.
+  #
+  # Returns `nil` if the status describes an abnormal exit.
+  #
+  # ```
+  # Process.run("true").exit_code?                                # => 1
+  # Process.run("exit 123", shell: true).exit_code?               # => 123
+  # Process.new("sleep", ["10"]).tap(&.terminate).wait.exit_code? # => nil
+  # ```
+  def exit_code? : Int32?
     {% if flag?(:unix) %}
-      raise RuntimeError.new("Abnormal exit has no exit code") unless normal_exit?
+      return unless normal_exit?
 
       # define __WEXITSTATUS(status) (((status) & 0xff00) >> 8)
       (@exit_status & 0xff00) >> 8


### PR DESCRIPTION
Adds a new method `#exit_code?` which returns `nil` if no value is available as proposed in #15228.

This provides an alternative to `#exit_code` which raises in this case since #15241.