### PR TITLE
Fix `Log` to emit with `exception` even if block outputs `nil`

### DIFF
--- a/spec/std/log/log_spec.cr
+++ b/spec/std/log/log_spec.cr
@@ -264,13 +264,28 @@ describe Log do
       entry.exception.should be_nil
     end
 
-    it "does not emit anything when a nil is emitted" do
+    it "does not emit when block returns nil" do
       backend = Log::MemoryBackend.new
       log = Log.new("a", backend, :notice)
 
       log.notice { nil }
 
       backend.entries.should be_empty
+    end
+
+    it "does emit when block returns nil but exception is provided" do
+      backend = Log::MemoryBackend.new
+      log = Log.new("a", backend, :notice)
+      ex = Exception.new "the attached exception"
+
+      log.notice(exception: ex) { nil }
+
+      entry = backend.entries.first
+      entry.source.should eq("a")
+      entry.severity.should eq(s(:notice))
+      entry.message.should eq("")
+      entry.data.should eq(Log::Metadata.empty)
+      entry.exception.should eq(ex)
     end
   end
 end

--- a/src/log/log.cr
+++ b/src/log/log.cr
@@ -65,13 +65,16 @@ class Log
       dsl = Emitter.new(@source, severity, exception)
       result = yield dsl
 
-      case result
-      when Entry
-        backend.dispatch result
-      when Nil
-        # emit nothing
-      else
-        backend.dispatch dsl.emit(result.to_s)
+      unless result.nil? && exception.nil?
+        entry =
+           case result
+           when Entry
+             result
+           else
+             dsl.emit(result.to_s)
+           end
+
+        backend.dispatch entry
       end
     end
   {% end %}


### PR DESCRIPTION
Fixes #15221 `Log` regression where exceptions are not logged when the given block returns `nil`: exceptions are now logged as expected whether the block returns `nil`.

```crystal
# now logs the exception even though the given block returns nil
Log.error(exception: e) { }

# continues to skip logging when both exception is nil and block returns nil
Log.error { }               
```