### PR TITLE
Refactor use of `Process::Status#exit_code` to `#exit_code?`

### DIFF
--- a/src/compiler/crystal/command.cr
+++ b/src/compiler/crystal/command.cr
@@ -301,8 +301,8 @@ class Crystal::Command
       puts "Execute: #{elapsed_time}"
     end
 
-    if status.exit_reason.normal? && !error_on_exit
-      exit status.exit_code
+    if (exit_code = status.exit_code?) && !error_on_exit
+      exit exit_code
     end
 
     if message = exit_message(status)

--- a/src/compiler/crystal/compiler.cr
+++ b/src/compiler/crystal/compiler.cr
@@ -876,16 +876,17 @@ module Crystal
 
       status = $?
       unless status.success?
-        if status.normal_exit?
-          case status.exit_code
-          when 126
-            linker_not_found File::AccessDeniedError, linker_name
-          when 127
-            linker_not_found File::NotFoundError, linker_name
-          end
+        exit_code = status.exit_code?
+        case exit_code
+        when 126
+          linker_not_found File::AccessDeniedError, linker_name
+        when 127
+          linker_not_found File::NotFoundError, linker_name
+        when nil
+          # abnormal exit
+          exit_code = 1
         end
-        code = status.normal_exit? ? status.exit_code : 1
-        error "execution of command failed with exit status #{status}: #{command}", exit_code: code
+        error "execution of command failed with exit status #{status}: #{command}", exit_code: exit_code
       end
     end
 

--- a/src/compiler/crystal/macros/methods.cr
+++ b/src/compiler/crystal/macros/methods.cr
@@ -325,7 +325,7 @@ module Crystal
         command = "#{Process.quote(original_filename)} #{Process.quote(run_args)}"
 
         message = IO::Memory.new
-        message << "Error executing run (exit code: #{result.status.exit_code}): #{command}\n"
+        message << "Error executing run (exit code: #{result.status}): #{command}\n"
 
         if result.stdout.empty? && result.stderr.empty?
           message << "\nGot no output."

--- a/src/process/status.cr
+++ b/src/process/status.cr
@@ -240,7 +240,7 @@ class Process::Status
 
   # Returns `true` if the process exited normally with an exit code of `0`.
   def success? : Bool
-    normal_exit? && exit_code == 0
+    exit_code? == 0
   end
 
   private def signal_code


### PR DESCRIPTION
Use the new non-raising variant `#exit_code?` (introduced in #15247) where possible over `#exit_code` which raises since https://github.com/crystal-lang/crystal/pull/15241. The code can also be simplified in some cases, removing unnecessary calls to `Status#normal_exit?`.