### PR TITLE
Redefine `Process::Status#normal_exit?` on Windows

### DIFF
--- a/spec/std/process/status_spec.cr
+++ b/spec/std/process/status_spec.cr
@@ -27,12 +27,8 @@ describe Process::Status do
     Process::Status.new(exit_status(128)).exit_code.should eq 128
     Process::Status.new(exit_status(255)).exit_code.should eq 255
 
-    if {{ flag?(:unix) }}
-      expect_raises(RuntimeError, "Abnormal exit has no exit code") do
-        status_for(:interrupted).exit_code
-      end
-    else
-      status_for(:interrupted).exit_code.should eq({% if flag?(:unix) %}0{% else %}LibC::STATUS_CONTROL_C_EXIT.to_i32!{% end %})
+    expect_raises(RuntimeError, "Abnormal exit has no exit code") do
+      status_for(:interrupted).exit_code
     end
   end
 
@@ -43,7 +39,7 @@ describe Process::Status do
     Process::Status.new(exit_status(128)).exit_code?.should eq 128
     Process::Status.new(exit_status(255)).exit_code?.should eq 255
 
-    status_for(:interrupted).exit_code?.should eq({% if flag?(:unix) %}nil{% else %}LibC::STATUS_CONTROL_C_EXIT.to_i32!{% end %})
+    status_for(:interrupted).exit_code?.should be_nil
   end
 
   it "#success?" do
@@ -63,7 +59,7 @@ describe Process::Status do
     Process::Status.new(exit_status(128)).normal_exit?.should be_true
     Process::Status.new(exit_status(255)).normal_exit?.should be_true
 
-    status_for(:interrupted).normal_exit?.should eq {{ flag?(:win32) }}
+    status_for(:interrupted).normal_exit?.should be_false
   end
 
   it "#signal_exit?" do

--- a/src/process/status.cr
+++ b/src/process/status.cr
@@ -135,7 +135,8 @@ class Process::Status
         @exit_status & 0xC0000000_u32 == 0 ? ExitReason::Normal : ExitReason::Unknown
       end
     {% elsif flag?(:unix) && !flag?(:wasm32) %}
-      if normal_exit?
+      # define __WIFEXITED(status) (__WTERMSIG(status) == 0)
+      if signal_code == 0
         ExitReason::Normal
       elsif signal_exit?
         case Signal.from_value?(signal_code)
@@ -181,13 +182,12 @@ class Process::Status
   end
 
   # Returns `true` if the process terminated normally.
+  #
+  # Equivalent to `ExitReason#Normal`
+  #
+  # * `#exit_reason` provides more insights into other exit reasons.
   def normal_exit? : Bool
-    {% if flag?(:unix) %}
-      # define __WIFEXITED(status) (__WTERMSIG(status) == 0)
-      signal_code == 0
-    {% else %}
-      true
-    {% end %}
+    exit_reason.normal?
   end
 
   # If `signal_exit?` is `true`, returns the *Signal* the process

--- a/src/process/status.cr
+++ b/src/process/status.cr
@@ -183,7 +183,7 @@ class Process::Status
 
   # Returns `true` if the process terminated normally.
   #
-  # Equivalent to `ExitReason#Normal`
+  # Equivalent to `ExitReason::Normal`
   #
   # * `#exit_reason` provides more insights into other exit reasons.
   def normal_exit? : Bool

--- a/src/process/status.cr
+++ b/src/process/status.cr
@@ -228,9 +228,9 @@ class Process::Status
   # Process.new("sleep", ["10"]).tap(&.terminate).wait.exit_code? # => nil
   # ```
   def exit_code? : Int32?
-    {% if flag?(:unix) %}
-      return unless normal_exit?
+    return unless normal_exit?
 
+    {% if flag?(:unix) %}
       # define __WEXITSTATUS(status) (((status) & 0xff00) >> 8)
       (@exit_status & 0xff00) >> 8
     {% else %}


### PR DESCRIPTION
Aligns the definition of `Process::Status#normal_exit?` with `Process::ExitReason::Normal` as discusssed in #15231.