### PR TITLE
Adjust definition of `ExitReason::Aborted`

### DIFF
--- a/src/process/status.cr
+++ b/src/process/status.cr
@@ -14,7 +14,7 @@ enum Process::ExitReason
   #   reserved for normal exits.
   Normal
 
-  # The process terminated abnormally.
+  # The process terminated due to an abort request.
   #
   # * On Unix-like systems, this corresponds to `Signal::ABRT`, `Signal::KILL`,
   #   and `Signal::QUIT`.


### PR DESCRIPTION
Clarify the documentation to distingish aborted process from an abnormal exit which includes other exit reasons as well.
Ref https://github.com/crystal-lang/crystal/issues/15231#issuecomment-2512353630