### PR TITLE
Add `Log` overloads for logging exceptions without giving a block

### DIFF
--- a/spec/std/log/log_spec.cr
+++ b/spec/std/log/log_spec.cr
@@ -106,6 +106,26 @@ describe Log do
     backend.entries.all? { |e| e.exception == ex }.should be_true
   end
 
+  it "can log exceptions without specifying a block" do
+    backend = Log::MemoryBackend.new
+    log = Log.new("a", backend, :warn)
+    ex = Exception.new
+
+    log.trace(exception: ex)
+    log.debug(exception: ex)
+    log.info(exception: ex)
+    log.notice(exception: ex)
+    log.warn(exception: ex)
+    log.error(exception: ex)
+    log.fatal(exception: ex)
+
+    backend.entries.map { |e| {e.source, e.severity, e.message, e.data, e.exception} }.should eq([
+      {"a", s(:warn), "", Log::Metadata.empty, ex},
+      {"a", s(:error), "", Log::Metadata.empty, ex},
+      {"a", s(:fatal), "", Log::Metadata.empty, ex},
+    ])
+  end
+
   it "contains the current context" do
     Log.context.set a: 1
 

--- a/src/log/log.cr
+++ b/src/log/log.cr
@@ -41,6 +41,15 @@ class Log
   {% for method in %w(trace debug info notice warn error fatal) %}
     {% severity = method.id.camelcase %}
 
+    # Logs the given *exception* if the logger's current severity is lower than
+    # or equal to `Severity::{{severity}}`.
+    def {{method.id}}(*, exception : Exception) : Nil
+      severity = Severity::{{severity}}
+      if level <= severity && (backend = @backend)
+        backend.dispatch Emitter.new(@source, severity, exception).emit("")
+      end
+    end
+
     # Logs a message if the logger's current severity is lower than or equal to
     # `Severity::{{ severity }}`.
     #

--- a/src/log/main.cr
+++ b/src/log/main.cr
@@ -37,6 +37,11 @@ class Log
 
   {% for method in %i(trace debug info notice warn error fatal) %}
     # See `Log#{{method.id}}`.
+    def self.{{method.id}}(*, exception : Exception) : Nil
+      Top.{{method.id}}(exception: exception)
+    end
+
+    # See `Log#{{method.id}}`.
     def self.{{method.id}}(*, exception : Exception? = nil)
       Top.{{method.id}}(exception: exception) do |dsl|
         yield dsl


### PR DESCRIPTION
Per the discussion on #15221 and #15253, this change provides non-yielding overloads to the `Log.{{severity}}` methods for logging exceptions without giving an associated message producing block:

```crystal
# previously a block was required to log a bare exception without a 
# message, like so:
Log.error(exception: ex) { "" }

# this change provides non-yielding overloads to log bare exceptions 
# without requiring an empty block, which is a little easier for this 
# use case:
Log.error(exception: ex)
```