### PR TITLE
Added `Path` as possible argument type to UNIXSocket and UNIXServer

### DIFF
--- a/spec/std/socket/address_spec.cr
+++ b/spec/std/socket/address_spec.cr
@@ -456,6 +456,10 @@ end
       Socket::UNIXAddress.new("some_path").hash.should_not eq Socket::UNIXAddress.new("other_path").hash
     end
 
+    it "accepts `Path` input" do
+      Socket::UNIXAddress.new(Path.new("some_path")).should eq Socket::UNIXAddress.new("some_path")
+    end
+
     describe ".parse" do
       it "parses relative" do
         address = Socket::UNIXAddress.parse "unix://foo.sock"

--- a/spec/std/socket/unix_server_spec.cr
+++ b/spec/std/socket/unix_server_spec.cr
@@ -33,6 +33,18 @@ describe UNIXServer do
       end
     end
 
+    it "creates the socket file from `Path`" do
+      with_tempfile("unix_server.sock") do |path|
+        path = Path.new(path)
+        UNIXServer.open(path) do
+          File.exists?(path).should be_true
+          File.info(path).type.socket?.should be_true
+        end
+
+        File.exists?(path).should be_false
+      end
+    end
+
     it "deletes socket file on close" do
       with_tempfile("unix_server-close.sock") do |path|
         server = UNIXServer.new(path)

--- a/spec/std/socket/unix_socket_spec.cr
+++ b/spec/std/socket/unix_socket_spec.cr
@@ -43,6 +43,29 @@ describe UNIXSocket do
     end
   end
 
+  it "initializes with `Path` paths" do
+    with_tempfile("unix_socket.sock") do |path|
+      path_path = Path.new(path)
+      UNIXServer.open(path_path) do |server|
+        server.local_address.family.should eq(Socket::Family::UNIX)
+        server.local_address.path.should eq(path)
+
+        UNIXSocket.open(path_path) do |client|
+          client.local_address.family.should eq(Socket::Family::UNIX)
+          client.local_address.path.should eq(path)
+
+          server.accept do |sock|
+            sock.local_address.family.should eq(Socket::Family::UNIX)
+            sock.local_address.path.should eq(path)
+
+            sock.remote_address.family.should eq(Socket::Family::UNIX)
+            sock.remote_address.path.should eq(path)
+          end
+        end
+      end
+    end
+  end
+
   it "sync flag after accept" do
     with_tempfile("unix_socket-accept.sock") do |path|
       UNIXServer.open(path) do |server|

--- a/src/socket/address.cr
+++ b/src/socket/address.cr
@@ -765,7 +765,8 @@ class Socket
                       sizeof(typeof(LibC::SockaddrUn.new.sun_path)) - 1
                     {% end %}
 
-    def initialize(@path : String)
+    def initialize(path : Path | String)
+      @path = path.to_s
       if @path.bytesize > MAX_PATH_SIZE
         raise ArgumentError.new("Path size exceeds the maximum size of #{MAX_PATH_SIZE} bytes")
       end

--- a/src/socket/unix_server.cr
+++ b/src/socket/unix_server.cr
@@ -37,7 +37,9 @@ class UNIXServer < UNIXSocket
   # ```
   #
   # [Only the stream type is supported on Windows](https://devblogs.microsoft.com/commandline/af_unix-comes-to-windows/#unsupportedunavailable).
-  def initialize(@path : String, type : Type = Type::STREAM, backlog : Int = 128)
+  def initialize(path : Path | String, type : Type = Type::STREAM, backlog : Int = 128)
+    path = path.to_s
+    @path = path
     super(Family::UNIX, type)
 
     system_bind(UNIXAddress.new(path), path) do |error|
@@ -53,15 +55,17 @@ class UNIXServer < UNIXSocket
   end
 
   # Creates a UNIXServer from an already configured raw file descriptor
-  def initialize(*, fd : Handle, type : Type = Type::STREAM, @path : String? = nil)
-    super(fd: fd, type: type, path: @path)
+  def initialize(*, fd : Handle, type : Type = Type::STREAM, path : Path | String? = nil)
+    path = path.to_s
+    @path = path
+    super(fd: fd, type: type, path: path)
   end
 
   # Creates a new UNIX server and yields it to the block. Eventually closes the
   # server socket when the block returns.
   #
   # Returns the value of the block.
-  def self.open(path, type : Type = Type::STREAM, backlog = 128, &)
+  def self.open(path : Path | String, type : Type = Type::STREAM, backlog = 128, &)
     server = new(path, type, backlog)
     begin
       yield server

--- a/src/socket/unix_server.cr
+++ b/src/socket/unix_server.cr
@@ -38,8 +38,7 @@ class UNIXServer < UNIXSocket
   #
   # [Only the stream type is supported on Windows](https://devblogs.microsoft.com/commandline/af_unix-comes-to-windows/#unsupportedunavailable).
   def initialize(path : Path | String, type : Type = Type::STREAM, backlog : Int = 128)
-    path = path.to_s
-    @path = path
+    @path = path = path.to_s
     super(Family::UNIX, type)
 
     system_bind(UNIXAddress.new(path), path) do |error|
@@ -56,8 +55,7 @@ class UNIXServer < UNIXSocket
 
   # Creates a UNIXServer from an already configured raw file descriptor
   def initialize(*, fd : Handle, type : Type = Type::STREAM, path : Path | String? = nil)
-    path = path.to_s
-    @path = path
+    @path = path = path.to_s
     super(fd: fd, type: type, path: path)
   end
 

--- a/src/socket/unix_server.cr
+++ b/src/socket/unix_server.cr
@@ -38,11 +38,10 @@ class UNIXServer < UNIXSocket
   #
   # [Only the stream type is supported on Windows](https://devblogs.microsoft.com/commandline/af_unix-comes-to-windows/#unsupportedunavailable).
   def initialize(path : Path | String, type : Type = Type::STREAM, backlog : Int = 128)
-    path = path.to_s
-    @path = path
+    @path = path.to_s
     super(Family::UNIX, type)
 
-    system_bind(UNIXAddress.new(path), path) do |error|
+    system_bind(UNIXAddress.new(@path), @path) do |error|
       close(delete: false)
       raise error
     end
@@ -56,9 +55,8 @@ class UNIXServer < UNIXSocket
 
   # Creates a UNIXServer from an already configured raw file descriptor
   def initialize(*, fd : Handle, type : Type = Type::STREAM, path : Path | String? = nil)
-    path = path.to_s
-    @path = path
-    super(fd: fd, type: type, path: path)
+    @path = path.to_s
+    super(fd: fd, type: type, path: @path)
   end
 
   # Creates a new UNIX server and yields it to the block. Eventually closes the

--- a/src/socket/unix_server.cr
+++ b/src/socket/unix_server.cr
@@ -38,10 +38,11 @@ class UNIXServer < UNIXSocket
   #
   # [Only the stream type is supported on Windows](https://devblogs.microsoft.com/commandline/af_unix-comes-to-windows/#unsupportedunavailable).
   def initialize(path : Path | String, type : Type = Type::STREAM, backlog : Int = 128)
-    @path = path.to_s
+    path = path.to_s
+    @path = path
     super(Family::UNIX, type)
 
-    system_bind(UNIXAddress.new(@path), @path) do |error|
+    system_bind(UNIXAddress.new(path), path) do |error|
       close(delete: false)
       raise error
     end
@@ -55,8 +56,9 @@ class UNIXServer < UNIXSocket
 
   # Creates a UNIXServer from an already configured raw file descriptor
   def initialize(*, fd : Handle, type : Type = Type::STREAM, path : Path | String? = nil)
-    @path = path.to_s
-    super(fd: fd, type: type, path: @path)
+    path = path.to_s
+    @path = path
+    super(fd: fd, type: type, path: path)
   end
 
   # Creates a new UNIX server and yields it to the block. Eventually closes the

--- a/src/socket/unix_socket.cr
+++ b/src/socket/unix_socket.cr
@@ -19,8 +19,7 @@ class UNIXSocket < Socket
 
   # Connects a named UNIX socket, bound to a filesystem pathname.
   def initialize(path : Path | String, type : Type = Type::STREAM)
-    path = path.to_s
-    @path = path
+    @path = path = path.to_s
     super(Family::UNIX, type, Protocol::IP)
 
     connect(UNIXAddress.new(path)) do |error|

--- a/src/socket/unix_socket.cr
+++ b/src/socket/unix_socket.cr
@@ -19,10 +19,11 @@ class UNIXSocket < Socket
 
   # Connects a named UNIX socket, bound to a filesystem pathname.
   def initialize(path : Path | String, type : Type = Type::STREAM)
-    @path = path.to_s
+    path = path.to_s
+    @path = path
     super(Family::UNIX, type, Protocol::IP)
 
-    connect(UNIXAddress.new(@path)) do |error|
+    connect(UNIXAddress.new(path)) do |error|
       close
       raise error
     end

--- a/src/socket/unix_socket.cr
+++ b/src/socket/unix_socket.cr
@@ -18,7 +18,9 @@ class UNIXSocket < Socket
   getter path : String?
 
   # Connects a named UNIX socket, bound to a filesystem pathname.
-  def initialize(@path : String, type : Type = Type::STREAM)
+  def initialize(path : Path | String, type : Type = Type::STREAM)
+    path = path.to_s
+    @path = path
     super(Family::UNIX, type, Protocol::IP)
 
     connect(UNIXAddress.new(path)) do |error|
@@ -40,7 +42,7 @@ class UNIXSocket < Socket
   # eventually closes the socket when the block returns.
   #
   # Returns the value of the block.
-  def self.open(path, type : Type = Type::STREAM, &)
+  def self.open(path : Path | String, type : Type = Type::STREAM, &)
     sock = new(path, type)
     begin
       yield sock

--- a/src/socket/unix_socket.cr
+++ b/src/socket/unix_socket.cr
@@ -19,11 +19,10 @@ class UNIXSocket < Socket
 
   # Connects a named UNIX socket, bound to a filesystem pathname.
   def initialize(path : Path | String, type : Type = Type::STREAM)
-    path = path.to_s
-    @path = path
+    @path = path.to_s
     super(Family::UNIX, type, Protocol::IP)
 
-    connect(UNIXAddress.new(path)) do |error|
+    connect(UNIXAddress.new(@path)) do |error|
       close
       raise error
     end
@@ -34,7 +33,8 @@ class UNIXSocket < Socket
   end
 
   # Creates a UNIXSocket from an already configured raw file descriptor
-  def initialize(*, fd : Handle, type : Type = Type::STREAM, @path : String? = nil)
+  def initialize(*, fd : Handle, type : Type = Type::STREAM, path : Path | String? = nil)
+    @path = path.to_s
     super fd, Family::UNIX, type, Protocol::IP
   end
 


### PR DESCRIPTION
As outlined in #15259, `UNIXSocket`, `UNIXServer` and `UNIXAddress` should accept `Path | String`, like `File` does.

I based the implementation off [that in File](https://github.com/crystal-lang/crystal/blob/dacd97bccc80b41c7d6c448cfad19d37184766e9/src/file.cr#L173).

I couldn't run the specs due to some obscure error though, but for FWIW that fails for me on 1.15-dev and 1.14.0 without these changes as well :shrug:
![image](https://github.com/user-attachments/assets/da5e47d8-b54a-41bd-8aa2-d8ef10003405)
