### PR TITLE
Add `Process::Status#abnormal_exit?`

### DIFF
--- a/spec/std/process/status_spec.cr
+++ b/spec/std/process/status_spec.cr
@@ -62,6 +62,16 @@ describe Process::Status do
     status_for(:interrupted).normal_exit?.should be_false
   end
 
+  it "#abnormal_exit?" do
+    Process::Status.new(exit_status(0)).abnormal_exit?.should be_false
+    Process::Status.new(exit_status(1)).abnormal_exit?.should be_false
+    Process::Status.new(exit_status(127)).abnormal_exit?.should be_false
+    Process::Status.new(exit_status(128)).abnormal_exit?.should be_false
+    Process::Status.new(exit_status(255)).abnormal_exit?.should be_false
+
+    status_for(:interrupted).abnormal_exit?.should be_true
+  end
+
   it "#signal_exit?" do
     Process::Status.new(exit_status(0)).signal_exit?.should be_false
     Process::Status.new(exit_status(1)).signal_exit?.should be_false

--- a/src/process/status.cr
+++ b/src/process/status.cr
@@ -91,6 +91,13 @@ enum Process::ExitReason
   # * On Unix-like systems, this corresponds to `Signal::TERM`.
   # * On Windows, this corresponds to the `CTRL_LOGOFF_EVENT` and `CTRL_SHUTDOWN_EVENT` messages.
   SessionEnded
+
+  # Returns `true` if the process exited abnormally.
+  #
+  # This includes all values except `Normal`.
+  def abnormal?
+    !normal?
+  end
 end
 
 # The status of a terminated process. Returned by `Process#wait`.

--- a/src/process/status.cr
+++ b/src/process/status.cr
@@ -197,6 +197,15 @@ class Process::Status
     exit_reason.normal?
   end
 
+  # Returns `true` if the process terminated abnormally.
+  #
+  # Equivalent to `ExitReason#abnormal?`
+  #
+  # * `#exit_reason` provides more insights into the specific exit reason.
+  def abnormal_exit? : Bool
+    exit_reason.abnormal?
+  end
+
   # If `signal_exit?` is `true`, returns the *Signal* the process
   # received and didn't handle. Will raise if `signal_exit?` is `false`.
   #

--- a/src/process/status.cr
+++ b/src/process/status.cr
@@ -193,6 +193,7 @@ class Process::Status
   # Equivalent to `ExitReason::Normal`
   #
   # * `#exit_reason` provides more insights into other exit reasons.
+  # * `#abnormal_exit?` returns the inverse.
   def normal_exit? : Bool
     exit_reason.normal?
   end
@@ -202,6 +203,7 @@ class Process::Status
   # Equivalent to `ExitReason#abnormal?`
   #
   # * `#exit_reason` provides more insights into the specific exit reason.
+  # * `#normal_exit?` returns the inverse.
   def abnormal_exit? : Bool
     exit_reason.abnormal?
   end


### PR DESCRIPTION
This adds convenience methods for the inverse of `ExitReason#normal`?  and `Status#normal_exit?` as discusseed #15231.