### PR TITLE
Fix stringification of abnormal `Process::Status` on Windows [fixup #15255]

### DIFF
--- a/spec/std/process/status_spec.cr
+++ b/spec/std/process/status_spec.cr
@@ -228,9 +228,7 @@ describe Process::Status do
 
     it "on abnormal exit" do
       {% if flag?(:win32) %}
-        expect_raises(NotImplementedError, "Not Implemented: Process::Status#exit_signal") do
-          status_for(:interrupted).to_s
-        end
+        assert_prints status_for(:interrupted).to_s, "3221225786"
       {% elsif flag?(:wasi) %}
         assert_prints status_for(:interrupted).to_s, "INT"
       {% else %}
@@ -258,9 +256,7 @@ describe Process::Status do
 
     it "on abnormal exit" do
       {% if flag?(:win32) %}
-        expect_raises(NotImplementedError, "Not Implemented: Process::Status#exit_signal") do
-          status_for(:interrupted).inspect
-        end
+        assert_prints status_for(:interrupted).inspect, "Process::Status[3221225786]"
       {% elsif flag?(:wasi) %}
         assert_prints status_for(:interrupted).inspect, "Process::Status[Signal::INT]"
       {% else %}

--- a/spec/std/process/status_spec.cr
+++ b/spec/std/process/status_spec.cr
@@ -229,8 +229,6 @@ describe Process::Status do
     it "on abnormal exit" do
       {% if flag?(:win32) %}
         assert_prints status_for(:interrupted).to_s, "3221225786"
-      {% elsif flag?(:wasi) %}
-        assert_prints status_for(:interrupted).to_s, "INT"
       {% else %}
         assert_prints status_for(:interrupted).to_s, "INT"
       {% end %}
@@ -257,8 +255,6 @@ describe Process::Status do
     it "on abnormal exit" do
       {% if flag?(:win32) %}
         assert_prints status_for(:interrupted).inspect, "Process::Status[3221225786]"
-      {% elsif flag?(:wasi) %}
-        assert_prints status_for(:interrupted).inspect, "Process::Status[Signal::INT]"
       {% else %}
         assert_prints status_for(:interrupted).inspect, "Process::Status[Signal::INT]"
       {% end %}

--- a/spec/std/process/status_spec.cr
+++ b/spec/std/process/status_spec.cr
@@ -226,6 +226,18 @@ describe Process::Status do
       assert_prints Process::Status.new(exit_status(255)).to_s, "255"
     end
 
+    it "on abnormal exit" do
+      {% if flag?(:win32) %}
+        expect_raises(NotImplementedError, "Not Implemented: Process::Status#exit_signal") do
+          status_for(:interrupted).to_s
+        end
+      {% elsif flag?(:wasi) %}
+        assert_prints status_for(:interrupted).to_s, "INT"
+      {% else %}
+        assert_prints status_for(:interrupted).to_s, "INT"
+      {% end %}
+    end
+
     {% if flag?(:unix) && !flag?(:wasi) %}
       it "with exit signal" do
         assert_prints Process::Status.new(Signal::HUP.value).to_s, "HUP"
@@ -242,6 +254,18 @@ describe Process::Status do
       assert_prints Process::Status.new(exit_status(127)).inspect, "Process::Status[127]"
       assert_prints Process::Status.new(exit_status(128)).inspect, "Process::Status[128]"
       assert_prints Process::Status.new(exit_status(255)).inspect, "Process::Status[255]"
+    end
+
+    it "on abnormal exit" do
+      {% if flag?(:win32) %}
+        expect_raises(NotImplementedError, "Not Implemented: Process::Status#exit_signal") do
+          status_for(:interrupted).inspect
+        end
+      {% elsif flag?(:wasi) %}
+        assert_prints status_for(:interrupted).inspect, "Process::Status[Signal::INT]"
+      {% else %}
+        assert_prints status_for(:interrupted).inspect, "Process::Status[Signal::INT]"
+      {% end %}
     end
 
     {% if flag?(:unix) && !flag?(:wasi) %}

--- a/src/process/status.cr
+++ b/src/process/status.cr
@@ -257,11 +257,15 @@ class Process::Status
   # `Process::Status[Signal::HUP]`.
   def inspect(io : IO) : Nil
     io << "Process::Status["
-    if normal_exit?
-      exit_code.inspect(io)
-    else
-      exit_signal.inspect(io)
-    end
+    {% if flag?(:win32) %}
+      @exit_status.to_s(io)
+    {% else %}
+      if normal_exit?
+        exit_code.inspect(io)
+      else
+        exit_signal.inspect(io)
+      end
+    {% end %}
     io << "]"
   end
 
@@ -270,11 +274,15 @@ class Process::Status
   # A normal exit status prints the numerical value (`0`, `1` etc).
   # A signal exit status prints the name of the `Signal` member (`HUP`, `INT`, etc.).
   def to_s(io : IO) : Nil
-    if normal_exit?
-      io << exit_code
-    else
-      io << exit_signal
-    end
+    {% if flag?(:win32) %}
+      @exit_status.to_s(io)
+    {% else %}
+      if normal_exit?
+        io << exit_code
+      else
+        io << exit_signal
+      end
+    {% end %}
   end
 
   # Returns a textual representation of the process status.
@@ -282,10 +290,14 @@ class Process::Status
   # A normal exit status prints the numerical value (`0`, `1` etc).
   # A signal exit status prints the name of the `Signal` member (`HUP`, `INT`, etc.).
   def to_s : String
-    if normal_exit?
-      exit_code.to_s
-    else
-      exit_signal.to_s
-    end
+    {% if flag?(:win32) %}
+      @exit_status.to_s
+    {% else %}
+      if normal_exit?
+        exit_code.to_s
+      else
+        exit_signal.to_s
+      end
+    {% end %}
   end
 end


### PR DESCRIPTION
The change in #15255 broke `Process::Status#to_s` and `#inspect` on Windows due to the redefinition of `#normal_exit?`. Unfortunately we were missing specs for this, so it did go unnoticed.

This patch adds specs and restablishes the previous behaviour with the small improvement of treating the `exit_status` value as `UInt32` instead of `Int32`, which results in positive numbers.

```cr
# Crystal 1.14.0
Process::Status.new(LibC::STATUS_CONTROL_C_EXIT)).inspect # => "Process::Status[-1073741510]"

# master
Process::Status.new(LibC::STATUS_CONTROL_C_EXIT)).inspect # NotImplementedError: Process::Status#exit_signal

# this patch
Process::Status.new(LibC::STATUS_CONTROL_C_EXIT)).inspect # => "Process::Status[3221225786]"
```

There's still room for improvement, for example map the values to names and/or use base 16 numerals as is custom for error statuses on Windows), but I'll leave that for a follow-up.