### PR TITLE
Add `Crypto::Bcrypt::Password#==`

### DIFF
--- a/spec/std/crypto/bcrypt/password_spec.cr
+++ b/spec/std/crypto/bcrypt/password_spec.cr
@@ -78,4 +78,13 @@ describe "Crypto::Bcrypt::Password" do
       (password2y.verify "secret").should be_true
     end
   end
+
+  describe "#==" do
+    it "is equal if the string representations are equal" do
+      canonical = Crypto::Bcrypt::Password.create("secret", 4)
+      challenge = Crypto::Bcrypt::Password.new(canonical.to_s)
+
+      canonical.should eq challenge
+    end
+  end
 end

--- a/src/crypto/bcrypt/password.cr
+++ b/src/crypto/bcrypt/password.cr
@@ -83,4 +83,6 @@ class Crypto::Bcrypt::Password
   def inspect(io : IO) : Nil
     to_s(io)
   end
+
+  def_equals_and_hash
 end


### PR DESCRIPTION
Use case: my `User` records (via `DB::Serializable`) aren't considered `==` because their `password` properties are not considered `==` despite all properties being equal. This leads to confusing spec failures when doing `actual_user.should eq expected_user`.

Since `Crypto::Bcrypt::Password` doesn't appear to accrue state, as an alternative to adding `==` it seems like it could instead be a `struct` vs a `class`? This would do the same thing. Both of these ideas pass in `spec/std/crypto/bcrypt/password_spec.cr`. I went with the `def_equals` because it's the monkeypatch I use in apps that require passwords (you can't monkeypatch a `class` to a `struct`), but I'm also happy to convert it to a `struct`.