### PR TITLE
Use empty prelude for compiler tools specs

### DIFF
--- a/spec/compiler/crystal/tools/context_spec.cr
+++ b/spec/compiler/crystal/tools/context_spec.cr
@@ -3,6 +3,7 @@ require "../../../spec_helper"
 private def processed_context_visitor(code, cursor_location)
   compiler = Compiler.new
   compiler.no_codegen = true
+  compiler.prelude = "empty"
   result = compiler.compile(Compiler::Source.new(".", code), "fake-no-build")
 
   visitor = ContextVisitor.new(cursor_location)

--- a/spec/compiler/crystal/tools/context_spec.cr
+++ b/spec/compiler/crystal/tools/context_spec.cr
@@ -118,15 +118,20 @@ describe "context" do
   it "includes last call" do
     assert_context_includes %(
       class Foo
-        property lorem
+        def lorem
+          @lorem
+        end
 
         def initialize(@lorem : Int64)
         end
       end
 
+      def foo(f)
+      end
+
       f = Foo.new(1i64)
 
-      puts f.lo‸rem
+      foo f.lo‸rem
       1
     ), "f.lorem", ["Int64"]
   end
@@ -141,9 +146,13 @@ describe "context" do
 
   it "does includes regex special variables" do
     assert_context_keys %(
+      def match
+        $~ = "match"
+      end
+
       def foo
-        s = "string"
-        s =~ /s/
+        s = "foo"
+        match
         ‸
         0
       end
@@ -185,11 +194,7 @@ describe "context" do
 
   it "can handle union types" do
     assert_context_includes %(
-    a = if rand() > 0
-      1i64
-    else
-      "foo"
-    end
+    a = 1_i64.as(Int64 | String)
     ‸
     0
     ), "a", ["(Int64 | String)"]
@@ -197,11 +202,7 @@ describe "context" do
 
   it "can display text output" do
     run_context_tool(%(
-    a = if rand() > 0
-      1i64
-    else
-      "foo"
-    end
+    a = 1_i64.as(Int64 | String)
     ‸
     0
     )) do |result|
@@ -218,11 +219,7 @@ describe "context" do
 
   it "can display json output" do
     run_context_tool(%(
-    a = if rand() > 0
-      1i64
-    else
-      "foo"
-    end
+    a = 1_i64.as(Int64 | String)
     ‸
     0
     )) do |result|

--- a/spec/compiler/crystal/tools/expand_spec.cr
+++ b/spec/compiler/crystal/tools/expand_spec.cr
@@ -5,6 +5,7 @@ private def processed_expand_visitor(code, cursor_location)
   compiler.no_codegen = true
   compiler.no_cleanup = true
   compiler.wants_doc = true
+  compiler.prelude = "empty"
   result = compiler.compile(Compiler::Source.new(".", code), "fake-no-build")
 
   visitor = ExpandVisitor.new(cursor_location)

--- a/spec/compiler/crystal/tools/implementations_spec.cr
+++ b/spec/compiler/crystal/tools/implementations_spec.cr
@@ -52,7 +52,7 @@ describe "implementations" do
         1
       end
 
-      puts f‸oo
+      f‸oo
     )
   end
 
@@ -117,7 +117,6 @@ describe "implementations" do
       end
 
       while f‸oo
-        puts 2
       end
     )
   end
@@ -129,7 +128,6 @@ describe "implementations" do
       end
 
       if f‸oo
-        puts 2
       end
     )
   end
@@ -140,7 +138,7 @@ describe "implementations" do
         1
       end
 
-      puts 2 if f‸oo
+      2 if f‸oo
     )
   end
 
@@ -151,7 +149,6 @@ describe "implementations" do
       end
 
       begin
-        puts 2
       rescue
         f‸oo
       end

--- a/spec/compiler/crystal/tools/implementations_spec.cr
+++ b/spec/compiler/crystal/tools/implementations_spec.cr
@@ -3,6 +3,7 @@ require "../../../spec_helper"
 private def processed_implementation_visitor(code, cursor_location)
   compiler = Compiler.new
   compiler.no_codegen = true
+  compiler.prelude = "empty"
   result = compiler.compile(Compiler::Source.new(".", code), "fake-no-build")
 
   visitor = ImplementationsVisitor.new(cursor_location)


### PR DESCRIPTION
The spec suites for several compiler tools instantiate a `Compiler` instance to process example source code. These examples usually do not require the standard library (or they can be easily adjusted to do so). Requiring the default prelude from stdlib is quite costly and these costs add up when running many samples.

This patch applies some tiny refactors to specs that rely on features from the stdlib prelude. These seem to be not particularly relevant for the test scenario because we're testing compiler features, not stdlib implementations.

* `property` macro - simply replaced by an explicit `def`
* calls to `puts`: Sometimes the intention is to call _a_ method and `puts`. This can be easily replaced by a call to a dummy def. In some cases there might be some intent to introduce side effects, but I don't see how that' significant. I opted to dropp some calls, but this could use careful review.
* calls to `::rand` with the intention to create a union type. This can be easily replaced by an explicit cast to the union type, which makes the spec more succinct.
* One example in `context_spec` tests assignments to special variable `$~` from a regex match. I replaced that with a custom def that assigns the special variable.

I think overall this is a valuable improvement making the examples self-contained and more expressive.

These changes allow using the compiler with the `empty` prelude which results in significantly less compilation effort.

With this patch, the spec runtime for these tests reduces from 3:06 minutes to 13.81 seconds (over 90% reduction! 🎉🚀)
```console
$ git switch master # 5915e3b32f973cdcabbd1b679f60b59621266628
$ bin/crystal spec spec/compiler/crystal/tools/{context,expand,implementations}_spec.cr
.............................................................................................................

Finished in 3:06 minutes
109 examples, 0 failures, 0 errors, 0 pending

$ git switch spec/perf-tools-empty-prelude
$ bin/crystal spec spec/compiler/crystal/tools/{context,expand,implementations}_spec.cr
.............................................................................................................

Finished in 13.81 seconds
109 examples, 0 failures, 0 errors, 0 pending
```

Other tool specs do not instantiate the `Compiler`. They use the `Parser` and various visitors directly, and so does the `semantic` spec helper. The stdlib prelude is only injected in `Compiler#parse`, so they are not affected.

There might be other places in the compiler spec suite which could use a smaller prelude, though.