### PR TITLE
Fix `tool implementations` to handle gracefully a def with missing location

### DIFF
--- a/spec/compiler/crystal/tools/implementations_spec.cr
+++ b/spec/compiler/crystal/tools/implementations_spec.cr
@@ -478,4 +478,18 @@ describe "implementations" do
     F‸oo
     )
   end
+
+  it "find implementation on def with no location" do
+    _, result = processed_implementation_visitor <<-CRYSTAL, Location.new(".", 5, 5)
+      enum Foo
+        FOO
+      end
+
+      Foo.new(42)
+      CRYSTAL
+
+    result.implementations.not_nil!.map do |e|
+      Location.new(e.filename, e.line, e.column).to_s
+    end.should eq ["<unknown>:0:0"]
+  end
 end

--- a/src/compiler/crystal/tools/implementations.cr
+++ b/src/compiler/crystal/tools/implementations.cr
@@ -53,7 +53,9 @@ module Crystal
         @line = macro_location.line_number + loc.line_number
         @column = loc.column_number
       else
-        raise "not implemented"
+        @line = loc.line_number
+        @column = loc.column_number
+        @filename = "<unknown>"
       end
     end
 
@@ -111,7 +113,7 @@ module Crystal
 
       if target_defs = node.target_defs
         target_defs.each do |target_def|
-          @locations << target_def.location.not_nil!
+          @locations << (target_def.location || Location.new(nil, 0, 0))
         end
       end
       false


### PR DESCRIPTION
Without this change, `crystal tool implementations` would crash when a target def has no location.

The example uses an enum type's `.new` method which is defined by the compiler without a location.

This patch fixes the nil error. The result may still not be terribly useful, but it's better than crashing the program.