### PR TITLE
Make `Enum` an abstract struct

### DIFF
--- a/src/enum.cr
+++ b/src/enum.cr
@@ -100,7 +100,7 @@
 #
 # Color::Red.value # : UInt8
 # ```
-struct Enum
+abstract struct Enum
   include Comparable(self)
 
   # Returns *value*.


### PR DESCRIPTION
The `Enum` is not intended to be instantiated and the compiler won't even let us. This type just serves as a common ancestor for all `enum` types.

That fits exactly the defintion of `abstract` types, but for some reason this keyword is missing on `Enum`. Instead all protections against instantiations are implemented explicitly in the compiler (and they go even further than for normal abstract types). 
Adding the `abstract` modifier to the type def is still a useful addition, at least for documentation purposes.
This shouldn't change any behaviour as it's already impossible to instantiate `Enum`.
