### PR TITLE
Fix: register GC callbacks inside GC.init

### DIFF
--- a/src/gc/boehm.cr
+++ b/src/gc/boehm.cr
@@ -175,7 +175,7 @@ end
 
 module GC
   {% if flag?(:preview_mt) %}
-    @@lock = Crystal::RWLock.new
+    @@lock = uninitialized Crystal::RWLock
   {% end %}
 
   # :nodoc:
@@ -205,9 +205,32 @@ module GC
     {% end %}
     LibGC.init
 
+    {% if flag?(:preview_mt) %}
+      @@lock = Crystal::RWLock.new
+    {% end %}
+
     LibGC.set_start_callback -> do
       GC.lock_write
     end
+
+    # pushes the stack of pending fibers when the GC wants to collect memory:
+    {% unless flag?(:interpreted) %}
+      GC.before_collect do
+        Fiber.unsafe_each do |fiber|
+          fiber.push_gc_roots unless fiber.running?
+        end
+
+        {% if flag?(:preview_mt) %}
+          Thread.unsafe_each do |thread|
+            if fiber = thread.current_fiber?
+              GC.set_stackbottom(thread.gc_thread_handler, fiber.@stack_bottom)
+            end
+          end
+        {% end %}
+
+        GC.unlock_write
+      end
+    {% end %}
 
     {% if flag?(:tracing) %}
       if ::Crystal::Tracing.enabled?(:gc)
@@ -461,25 +484,6 @@ module GC
       @@prev_push_other_roots.try(&.call)
     end
   end
-
-  # pushes the stack of pending fibers when the GC wants to collect memory:
-  {% unless flag?(:interpreted) %}
-    GC.before_collect do
-      Fiber.unsafe_each do |fiber|
-        fiber.push_gc_roots unless fiber.running?
-      end
-
-      {% if flag?(:preview_mt) %}
-        Thread.unsafe_each do |thread|
-          if fiber = thread.current_fiber?
-            GC.set_stackbottom(thread.gc_thread_handler, fiber.@stack_bottom)
-          end
-        end
-      {% end %}
-
-      GC.unlock_write
-    end
-  {% end %}
 
   # :nodoc:
   def self.stop_world : Nil


### PR DESCRIPTION
Running the std specs with `preview_mt` enabled immediately hangs when using the `master` branch of BDWGC: the process gets stuck waiting on `GC.lock_write`.

What happens is that the GC is trying to collect while Crystal is initializing constants and class variables, it locks the rwlock once, collects, continues to allocate, then tries to lock a second time... but it never unlocked because the `GC.before_collect` callback hasn't been registered, yet.

This patch:

1. Registers the GC callbacks right in the `GC.init` method; this makes sure both callbacks are registered before we start running any Crystal code and the GC needs to start allocating or deallocating.

2. Initializes the rwlock inside the `GC.init` method; this avoids a lazy initializer and makes sure the memory is properly initialized ASAP (before we call any stdlib or user code that will call into the GC).