### PR TITLE
Fix: make Crystal::EventLoop#remove(io) a class method

### DIFF
--- a/src/crystal/event_loop.cr
+++ b/src/crystal/event_loop.cr
@@ -1,24 +1,28 @@
 abstract class Crystal::EventLoop
-  # Creates an event loop instance
-  def self.create : self
+  def self.backend_class
     {% if flag?(:wasi) %}
-      Crystal::EventLoop::Wasi.new
+      Crystal::EventLoop::Wasi
     {% elsif flag?(:unix) %}
       # TODO: enable more targets by default (need manual tests or fixes)
       {% if flag?("evloop=libevent") %}
-        Crystal::EventLoop::LibEvent.new
+        Crystal::EventLoop::LibEvent
       {% elsif flag?("evloop=epoll") || flag?(:android) || flag?(:linux) %}
-        Crystal::EventLoop::Epoll.new
+        Crystal::EventLoop::Epoll
       {% elsif flag?("evloop=kqueue") || flag?(:darwin) || flag?(:freebsd) %}
-        Crystal::EventLoop::Kqueue.new
+        Crystal::EventLoop::Kqueue
       {% else %}
-        Crystal::EventLoop::LibEvent.new
+        Crystal::EventLoop::LibEvent
       {% end %}
     {% elsif flag?(:win32) %}
-      Crystal::EventLoop::IOCP.new
+      Crystal::EventLoop::IOCP
     {% else %}
       {% raise "Event loop not supported" %}
     {% end %}
+  end
+
+  # Creates an event loop instance
+  def self.create : self
+    backend_class.new
   end
 
   @[AlwaysInline]

--- a/src/crystal/event_loop/file_descriptor.cr
+++ b/src/crystal/event_loop/file_descriptor.cr
@@ -26,6 +26,7 @@ abstract class Crystal::EventLoop
     #
     # Called by `::IO::FileDescriptor#finalize` before closing the file
     # descriptor. Errors shall be silently ignored.
-    abstract def remove(file_descriptor : Crystal::System::FileDescriptor) : Nil
+    def self.remove(file_descriptor : Crystal::System::FileDescriptor) : Nil
+    end
   end
 end

--- a/src/crystal/event_loop/file_descriptor.cr
+++ b/src/crystal/event_loop/file_descriptor.cr
@@ -19,14 +19,20 @@ abstract class Crystal::EventLoop
 
     # Closes the file descriptor resource.
     abstract def close(file_descriptor : Crystal::System::FileDescriptor) : Nil
+  end
 
-    # Removes the file descriptor from the event loop. Can be used to free up
-    # memory resources associated with the file descriptor, as well as removing
-    # the file descriptor from kernel data structures.
-    #
-    # Called by `::IO::FileDescriptor#finalize` before closing the file
-    # descriptor. Errors shall be silently ignored.
-    def self.remove(file_descriptor : Crystal::System::FileDescriptor) : Nil
-    end
+  # Removes the file descriptor from the event loop. Can be used to free up
+  # memory resources associated with the file descriptor, as well as removing
+  # the file descriptor from kernel data structures.
+  #
+  # Called by `::IO::FileDescriptor#finalize` before closing the file
+  # descriptor. Errors shall be silently ignored.
+  def self.remove(file_descriptor : Crystal::System::FileDescriptor) : Nil
+    backend_class.remove_impl(file_descriptor)
+  end
+
+  # Actual implementation for `.remove`. Must be implemented on a subclass of
+  # `Crystal::EventLoop` when needed.
+  protected def self.remove_impl(file_descriptor : Crystal::System::FileDescriptor) : Nil
   end
 end

--- a/src/crystal/event_loop/iocp.cr
+++ b/src/crystal/event_loop/iocp.cr
@@ -201,9 +201,6 @@ class Crystal::EventLoop::IOCP < Crystal::EventLoop
     LibC.CancelIoEx(file_descriptor.windows_handle, nil) unless file_descriptor.system_blocking?
   end
 
-  def remove(file_descriptor : Crystal::System::FileDescriptor) : Nil
-  end
-
   private def wsa_buffer(bytes)
     wsabuf = LibC::WSABUF.new
     wsabuf.len = bytes.size
@@ -313,8 +310,5 @@ class Crystal::EventLoop::IOCP < Crystal::EventLoop
   end
 
   def close(socket : ::Socket) : Nil
-  end
-
-  def remove(socket : ::Socket) : Nil
   end
 end

--- a/src/crystal/event_loop/libevent.cr
+++ b/src/crystal/event_loop/libevent.cr
@@ -98,9 +98,6 @@ class Crystal::EventLoop::LibEvent < Crystal::EventLoop
     file_descriptor.evented_close
   end
 
-  def remove(file_descriptor : Crystal::System::FileDescriptor) : Nil
-  end
-
   def read(socket : ::Socket, slice : Bytes) : Int32
     evented_read(socket, "Error reading socket") do
       LibC.recv(socket.fd, slice, slice.size, 0).to_i32
@@ -192,9 +189,6 @@ class Crystal::EventLoop::LibEvent < Crystal::EventLoop
 
   def close(socket : ::Socket) : Nil
     socket.evented_close
-  end
-
-  def remove(socket : ::Socket) : Nil
   end
 
   def evented_read(target, errno_msg : String, &) : Int32

--- a/src/crystal/event_loop/polling.cr
+++ b/src/crystal/event_loop/polling.cr
@@ -164,7 +164,7 @@ abstract class Crystal::EventLoop::Polling < Crystal::EventLoop
     evented_close(file_descriptor)
   end
 
-  def self.remove(file_descriptor : System::FileDescriptor) : Nil
+  protected def self.remove_impl(file_descriptor : System::FileDescriptor) : Nil
     internal_remove(file_descriptor)
   end
 
@@ -267,7 +267,7 @@ abstract class Crystal::EventLoop::Polling < Crystal::EventLoop
     evented_close(socket)
   end
 
-  def self.remove(socket : ::Socket) : Nil
+  protected def self.remove_impl(socket : ::Socket) : Nil
     internal_remove(socket)
   end
 

--- a/src/crystal/event_loop/polling.cr
+++ b/src/crystal/event_loop/polling.cr
@@ -164,7 +164,7 @@ abstract class Crystal::EventLoop::Polling < Crystal::EventLoop
     evented_close(file_descriptor)
   end
 
-  def remove(file_descriptor : System::FileDescriptor) : Nil
+  def self.remove(file_descriptor : System::FileDescriptor) : Nil
     internal_remove(file_descriptor)
   end
 
@@ -267,7 +267,7 @@ abstract class Crystal::EventLoop::Polling < Crystal::EventLoop
     evented_close(socket)
   end
 
-  def remove(socket : ::Socket) : Nil
+  def self.remove(socket : ::Socket) : Nil
     internal_remove(socket)
   end
 
@@ -317,7 +317,7 @@ abstract class Crystal::EventLoop::Polling < Crystal::EventLoop
     end
   end
 
-  private def internal_remove(io)
+  private def self.internal_remove(io)
     return unless (index = io.__evloop_data).valid?
 
     Polling.arena.free(index) do |pd|

--- a/src/crystal/event_loop/socket.cr
+++ b/src/crystal/event_loop/socket.cr
@@ -62,14 +62,20 @@ abstract class Crystal::EventLoop
 
     # Closes the socket.
     abstract def close(socket : ::Socket) : Nil
+  end
 
-    # Removes the socket from the event loop. Can be used to free up memory
-    # resources associated with the socket, as well as removing the socket from
-    # kernel data structures.
-    #
-    # Called by `::Socket#finalize` before closing the socket. Errors shall be
-    # silently ignored.
-    def self.remove(socket : ::Socket) : Nil
-    end
+  # Removes the socket from the event loop. Can be used to free up memory
+  # resources associated with the socket, as well as removing the socket from
+  # kernel data structures.
+  #
+  # Called by `::Socket#finalize` before closing the socket. Errors shall be
+  # silently ignored.
+  def self.remove(socket : ::Socket) : Nil
+    backend_class.remove_impl(socket)
+  end
+
+  # Actual implementation for `.remove`. Must be implemented on a subclass of
+  # `Crystal::EventLoop` when needed.
+  protected def self.remove_impl(socket : ::Socket) : Nil
   end
 end

--- a/src/crystal/event_loop/socket.cr
+++ b/src/crystal/event_loop/socket.cr
@@ -69,6 +69,7 @@ abstract class Crystal::EventLoop
     #
     # Called by `::Socket#finalize` before closing the socket. Errors shall be
     # silently ignored.
-    abstract def remove(socket : ::Socket) : Nil
+    def self.remove(socket : ::Socket) : Nil
+    end
   end
 end

--- a/src/crystal/event_loop/wasi.cr
+++ b/src/crystal/event_loop/wasi.cr
@@ -53,9 +53,6 @@ class Crystal::EventLoop::Wasi < Crystal::EventLoop
     file_descriptor.evented_close
   end
 
-  def remove(file_descriptor : Crystal::System::FileDescriptor) : Nil
-  end
-
   def read(socket : ::Socket, slice : Bytes) : Int32
     evented_read(socket, "Error reading socket") do
       LibC.recv(socket.fd, slice, slice.size, 0).to_i32
@@ -86,9 +83,6 @@ class Crystal::EventLoop::Wasi < Crystal::EventLoop
 
   def close(socket : ::Socket) : Nil
     socket.evented_close
-  end
-
-  def remove(socket : ::Socket) : Nil
   end
 
   def evented_read(target, errno_msg : String, &) : Int32

--- a/src/crystal/system/unix/process.cr
+++ b/src/crystal/system/unix/process.cr
@@ -352,7 +352,7 @@ struct Crystal::System::Process
 
   private def self.reopen_io(src_io : IO::FileDescriptor, dst_io : IO::FileDescriptor)
     if src_io.closed?
-      Crystal::EventLoop.current.remove(dst_io)
+      typeof(Crystal::EventLoop.current).remove(dst_io)
       dst_io.file_descriptor_close
     else
       src_io = to_real_fd(src_io)

--- a/src/crystal/system/unix/process.cr
+++ b/src/crystal/system/unix/process.cr
@@ -352,7 +352,7 @@ struct Crystal::System::Process
 
   private def self.reopen_io(src_io : IO::FileDescriptor, dst_io : IO::FileDescriptor)
     if src_io.closed?
-      typeof(Crystal::EventLoop.current).remove(dst_io)
+      Crystal::EventLoop.remove(dst_io)
       dst_io.file_descriptor_close
     else
       src_io = to_real_fd(src_io)

--- a/src/crystal/system/unix/signal.cr
+++ b/src/crystal/system/unix/signal.cr
@@ -111,7 +111,7 @@ module Crystal::System::Signal
   # descriptors of the parent process and send it received signals.
   def self.after_fork
     @@pipe.each do |pipe_io|
-      typeof(Crystal::EventLoop.current).remove(pipe_io)
+      Crystal::EventLoop.remove(pipe_io)
       pipe_io.file_descriptor_close { }
     end
   ensure

--- a/src/crystal/system/unix/signal.cr
+++ b/src/crystal/system/unix/signal.cr
@@ -111,7 +111,7 @@ module Crystal::System::Signal
   # descriptors of the parent process and send it received signals.
   def self.after_fork
     @@pipe.each do |pipe_io|
-      Crystal::EventLoop.current.remove(pipe_io)
+      typeof(Crystal::EventLoop.current).remove(pipe_io)
       pipe_io.file_descriptor_close { }
     end
   ensure

--- a/src/io/file_descriptor.cr
+++ b/src/io/file_descriptor.cr
@@ -255,7 +255,7 @@ class IO::FileDescriptor < IO
   def finalize
     return if closed? || !close_on_finalize?
 
-    event_loop?.try(&.remove(self))
+    typeof(Crystal::EventLoop.current).remove(self)
     file_descriptor_close { } # ignore error
   end
 

--- a/src/io/file_descriptor.cr
+++ b/src/io/file_descriptor.cr
@@ -255,7 +255,7 @@ class IO::FileDescriptor < IO
   def finalize
     return if closed? || !close_on_finalize?
 
-    typeof(Crystal::EventLoop.current).remove(self)
+    Crystal::EventLoop.remove(self)
     file_descriptor_close { } # ignore error
   end
 

--- a/src/socket.cr
+++ b/src/socket.cr
@@ -430,7 +430,7 @@ class Socket < IO
   def finalize
     return if closed?
 
-    typeof(Crystal::EventLoop.current).remove(self)
+    Crystal::EventLoop.remove(self)
     socket_close { } # ignore error
   end
 

--- a/src/socket.cr
+++ b/src/socket.cr
@@ -430,7 +430,7 @@ class Socket < IO
   def finalize
     return if closed?
 
-    event_loop?.try(&.remove(self))
+    typeof(Crystal::EventLoop.current).remove(self)
     socket_close { } # ignore error
   end
 


### PR DESCRIPTION
The method is called from `IO::FileDescriptor` and `Socket` finalizers, which means they can be run from any thread during GC collections, yet calling an instance method means accessing the current event loop, which may have not been instantiated yet for the thread.

Only the polling event loops (epoll, kqueue) need this method, and they don't need an instance method to clean up the fd in the global arena. The other event loops don't need it.

This patch thus changes the instance method into a class method so there isn't any attempt to allocate in a GC finalizer.

Bonus: being a NOOP for other event loops, the call will be optimized away, while it previously always had to resolve the event loop instance; the polling event loops will also be able to directly cleanup.