### PR TITLE
Improve `Process::Status#to_s` for abnormal exits on Windows

### DIFF
--- a/spec/std/process/status_spec.cr
+++ b/spec/std/process/status_spec.cr
@@ -241,7 +241,7 @@ describe Process::Status do
 
     it "on abnormal exit" do
       {% if flag?(:win32) %}
-        assert_prints status_for(:interrupted).to_s, "3221225786"
+        assert_prints status_for(:interrupted).to_s, "STATUS_CONTROL_C_EXIT"
       {% else %}
         assert_prints status_for(:interrupted).to_s, "INT"
       {% end %}
@@ -269,7 +269,7 @@ describe Process::Status do
 
     it "on abnormal exit" do
       {% if flag?(:win32) %}
-        assert_prints status_for(:interrupted).inspect, "Process::Status[3221225786]"
+        assert_prints status_for(:interrupted).inspect, "Process::Status[LibC::STATUS_CONTROL_C_EXIT]"
       {% else %}
         assert_prints status_for(:interrupted).inspect, "Process::Status[Signal::INT]"
       {% end %}


### PR DESCRIPTION
Abnormal exit statuses on Windows are indicated by specific status values which correlate to `LibC` constants.
This patch changes `Status#to_s` (and `#inspect`) to return the name of the constant if available. This improves usability because it's easier to interpret the status.

Follow-up on #15267