### PR TITLE
Redefine `Process::Status#signal_exit?`

### DIFF
--- a/spec/std/process/status_spec.cr
+++ b/spec/std/process/status_spec.cr
@@ -138,7 +138,7 @@ describe Process::Status do
       Process::Status.new(0x00).signal_exit?.should be_false
       Process::Status.new(0x01).signal_exit?.should be_true
       Process::Status.new(0x7e).signal_exit?.should be_true
-      Process::Status.new(0x7f).signal_exit?.should be_false
+      Process::Status.new(0x7f).signal_exit?.should be_true
     end
   {% end %}
 

--- a/src/process/status.cr
+++ b/src/process/status.cr
@@ -180,12 +180,14 @@ class Process::Status
   end
 
   # Returns `true` if the process was terminated by a signal.
+  #
+  # NOTE: In contrast to `WIFSIGNALED` in glibc, the status code `0x7E` (`SIGSTOP`)
+  # is considered a signal.
+  #
+  # * `#abnormal_exit?` is a more portable alternative.
+  # * `#exit_signal?` provides more information about the signal.
   def signal_exit? : Bool
-    {% if flag?(:unix) %}
-      0x01 <= (@exit_status & 0x7F) <= 0x7E
-    {% else %}
-      false
-    {% end %}
+    !!exit_signal?
   end
 
   # Returns `true` if the process terminated normally.


### PR DESCRIPTION
Aligns `Status#signal_exit?` with `#exit_signal?` from #15284.
This includes the change that `Signal::STOP` (`0x7e`) is considered a signal by `#signal_exit?`, in concordance with `#exit_signal?`. See discussion in https://github.com/crystal-lang/crystal/issues/15231#issuecomment-2501712968