### PR TITLE
Update distribution-scripts

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,7 +8,7 @@ parameters:
   distribution-scripts-version:
     description: "Git ref for version of https://github.com/crystal-lang/distribution-scripts/"
     type: string
-    default: "da59efb2dfd70dcd7272eaecceffb636ef547427"
+    default: "588099d9e9de7ecf5925365796d30f832870e18c"
   previous_crystal_base_url:
     description: "Prefix for URLs to Crystal bootstrap compiler"
     type: string


### PR DESCRIPTION
Updates `distribution-scripts` dependency to https://github.com/crystal-lang/distribution-scripts/commit/588099d9e9de7ecf5925365796d30f832870e18c

This includes the following changes:

* crystal-lang/distribution-scripts#339
* crystal-lang/distribution-scripts#335
* crystal-lang/distribution-scripts#334
* crystal-lang/distribution-scripts#269
* crystal-lang/distribution-scripts#332
* crystal-lang/distribution-scripts#329
* crystal-lang/distribution-scripts#327
* crystal-lang/distribution-scripts#324
* crystal-lang/distribution-scripts#323
* crystal-lang/distribution-scripts#325
