### PR TITLE
Crystal `Not` operators do not need parens

### DIFF
--- a/spec/compiler/parser/to_s_spec.cr
+++ b/spec/compiler/parser/to_s_spec.cr
@@ -150,6 +150,7 @@ describe "ASTNode#to_s" do
   expect_to_s "1e10_f64", "1e10"
   expect_to_s "!a"
   expect_to_s "!(1 < 2)"
+  expect_to_s "!a.b && true"
   expect_to_s "(1 + 2)..3"
   expect_to_s "macro foo\n{{ @type }}\nend"
   expect_to_s "macro foo\n\\{{ @type }}\nend"
@@ -303,20 +304,4 @@ describe "ASTNode#to_s" do
       end
     end
     CRYSTAL
-
-  expect_to_s <<-'CR', <<-'CR'
-  {% verbatim do %}
-    {%
-      if !foo.empty? || 2 == 2
-        raise "oh noes"
-      end
-    %}
-  {% end %}
-  CR
-  {% verbatim do %}
-    {% if !foo.empty? || (2 == 2)
-    raise("oh noes")
-  end %}
-  {% end %}
-  CR
 end

--- a/spec/compiler/parser/to_s_spec.cr
+++ b/spec/compiler/parser/to_s_spec.cr
@@ -303,4 +303,20 @@ describe "ASTNode#to_s" do
       end
     end
     CRYSTAL
+
+  expect_to_s <<-'CR', <<-'CR'
+  {% verbatim do %}
+    {%
+      if !foo.empty? || 2 == 2
+        raise "oh noes"
+      end
+    %}
+  {% end %}
+  CR
+  {% verbatim do %}
+    {% if !foo.empty? || (2 == 2)
+    raise("oh noes")
+  end %}
+  {% end %}
+  CR
 end

--- a/src/compiler/crystal/syntax/to_s.cr
+++ b/src/compiler/crystal/syntax/to_s.cr
@@ -487,7 +487,7 @@ module Crystal
         end
       when Var, NilLiteral, BoolLiteral, CharLiteral, NumberLiteral, StringLiteral,
            StringInterpolation, Path, Generic, InstanceVar, ClassVar, Global,
-           ImplicitObj, TupleLiteral, NamedTupleLiteral, IsA
+           ImplicitObj, TupleLiteral, NamedTupleLiteral, IsA, Not
         false
       when ArrayLiteral
         !!obj.of


### PR DESCRIPTION
Fixes #15286