### PR TITLE
Fix: cleanup T on Thread::LinkedList(T)#delete

### DIFF
--- a/src/crystal/system/thread_linked_list.cr
+++ b/src/crystal/system/thread_linked_list.cr
@@ -47,16 +47,21 @@ class Thread
     # `#unsafe_each` until the method has returned.
     def delete(node : T) : Nil
       @mutex.synchronize do
-        if previous = node.previous
-          previous.next = node.next
+        previous = node.previous
+        _next = node.next
+
+        if previous
+          node.previous = nil
+          previous.next = _next
         else
-          @head = node.next
+          @head = _next
         end
 
-        if _next = node.next
-          _next.previous = node.previous
+        if _next
+          node.next = nil
+          _next.previous = previous
         else
-          @tail = node.previous
+          @tail = previous
         end
       end
     end


### PR DESCRIPTION
We internally use `Thread::LinkedList(T)` to keep a list of all threads & fibers, so the GC won't collect them and know all the stacks to scan during a GC collection. I noticed that `#delete` doesn't cleanup the `@previous` and `@next` links of the T objects.

When we remove the thread or fiber from the list, it means they have terminated and the objects should get collected at some point, so I guess cleanup isn't very important. On the other hand, there isn't much harm to cleanup a couple pointers (quite the opposite).

In fact, while investigating a memory leak with `PerfTools::MemProf.pretty_log_object_graph(io, Fiber)` I noticed a number of `Fiber` objects kept references to the same set of other fibers, while with proper cleanup, the graph of objects remained clean & stable, maybe because the `Fiber` objects disappear much more quickly.