### PR TITLE
Add `Process::Status#system_exit_status`

### DIFF
--- a/spec/std/process/status_spec.cr
+++ b/spec/std/process/status_spec.cr
@@ -44,10 +44,10 @@ describe Process::Status do
 
   it "#system_exit_status" do
     Process::Status.new(exit_status(0)).exit_status.should eq 0_u32
-    Process::Status.new(exit_status(1)).exit_status.should eq({{ flag?(:unix) ? 0x0100_u32 : 1_u32}})
-    Process::Status.new(exit_status(127)).exit_status.should eq({{ flag?(:unix) ? 0x7f00_u32 : 127_u32}})
-    Process::Status.new(exit_status(128)).exit_status.should eq({{ flag?(:unix) ? 0x8000_u32 : 128_u32}})
-    Process::Status.new(exit_status(255)).exit_status.should eq({{ flag?(:unix) ? 0xFF00_u32 : 255_u32}})
+    Process::Status.new(exit_status(1)).exit_status.should eq({{ flag?(:unix) ? 0x0100_u32 : 1_u32 }})
+    Process::Status.new(exit_status(127)).exit_status.should eq({{ flag?(:unix) ? 0x7f00_u32 : 127_u32 }})
+    Process::Status.new(exit_status(128)).exit_status.should eq({{ flag?(:unix) ? 0x8000_u32 : 128_u32 }})
+    Process::Status.new(exit_status(255)).exit_status.should eq({{ flag?(:unix) ? 0xFF00_u32 : 255_u32 }})
 
     status_for(:interrupted).exit_status.should eq({% if flag?(:unix) %}Signal::INT.value{% else %}LibC::STATUS_CONTROL_C_EXIT{% end %})
   end

--- a/spec/std/process/status_spec.cr
+++ b/spec/std/process/status_spec.cr
@@ -43,13 +43,13 @@ describe Process::Status do
   end
 
   it "#system_exit_status" do
-    Process::Status.new(exit_status(0)).exit_status.should eq 0_u32
-    Process::Status.new(exit_status(1)).exit_status.should eq({{ flag?(:unix) ? 0x0100_u32 : 1_u32 }})
-    Process::Status.new(exit_status(127)).exit_status.should eq({{ flag?(:unix) ? 0x7f00_u32 : 127_u32 }})
-    Process::Status.new(exit_status(128)).exit_status.should eq({{ flag?(:unix) ? 0x8000_u32 : 128_u32 }})
-    Process::Status.new(exit_status(255)).exit_status.should eq({{ flag?(:unix) ? 0xFF00_u32 : 255_u32 }})
+    Process::Status.new(exit_status(0)).system_exit_status.should eq 0_u32
+    Process::Status.new(exit_status(1)).system_exit_status.should eq({{ flag?(:unix) ? 0x0100_u32 : 1_u32 }})
+    Process::Status.new(exit_status(127)).system_exit_status.should eq({{ flag?(:unix) ? 0x7f00_u32 : 127_u32 }})
+    Process::Status.new(exit_status(128)).system_exit_status.should eq({{ flag?(:unix) ? 0x8000_u32 : 128_u32 }})
+    Process::Status.new(exit_status(255)).system_exit_status.should eq({{ flag?(:unix) ? 0xFF00_u32 : 255_u32 }})
 
-    status_for(:interrupted).exit_status.should eq({% if flag?(:unix) %}Signal::INT.value{% else %}LibC::STATUS_CONTROL_C_EXIT{% end %})
+    status_for(:interrupted).system_exit_status.should eq({% if flag?(:unix) %}Signal::INT.value{% else %}LibC::STATUS_CONTROL_C_EXIT{% end %})
   end
 
   it "#success?" do

--- a/spec/std/process/status_spec.cr
+++ b/spec/std/process/status_spec.cr
@@ -42,6 +42,16 @@ describe Process::Status do
     status_for(:interrupted).exit_code?.should be_nil
   end
 
+  it "#system_exit_status" do
+    Process::Status.new(exit_status(0)).exit_status.should eq 0_u32
+    Process::Status.new(exit_status(1)).exit_status.should eq({{ flag?(:unix) ? 0x0100_u32 : 1_u32}})
+    Process::Status.new(exit_status(127)).exit_status.should eq({{ flag?(:unix) ? 0x7f00_u32 : 127_u32}})
+    Process::Status.new(exit_status(128)).exit_status.should eq({{ flag?(:unix) ? 0x8000_u32 : 128_u32}})
+    Process::Status.new(exit_status(255)).exit_status.should eq({{ flag?(:unix) ? 0xFF00_u32 : 255_u32}})
+
+    status_for(:interrupted).exit_status.should eq({% if flag?(:unix) %}Signal::INT.value{% else %}LibC::STATUS_CONTROL_C_EXIT{% end %})
+  end
+
   it "#success?" do
     Process::Status.new(exit_status(0)).success?.should be_true
     Process::Status.new(exit_status(1)).success?.should be_false

--- a/src/process/status.cr
+++ b/src/process/status.cr
@@ -108,6 +108,13 @@ class Process::Status
     @exit_status.to_i32!
   end
 
+  # Returns the exit status as indicated by the operating system.
+  #
+  # It can encode exit codes and termination signals and is platform-specific.
+  def system_exit_status : UInt32
+    @exit_status.to_u32!
+  end
+
   {% if flag?(:win32) %}
     # :nodoc:
     def initialize(@exit_status : UInt32)


### PR DESCRIPTION
Provides a consistent, portable API to retrieve the platform-specific exit status, as discussed in https://github.com/crystal-lang/crystal/issues/8381#issuecomment-2537367972 f.