### PR TITLE
Crystal::Tracing improvements

### DIFF
--- a/src/crystal/event_loop/epoll.cr
+++ b/src/crystal/event_loop/epoll.cr
@@ -55,7 +55,7 @@ class Crystal::EventLoop::Epoll < Crystal::EventLoop::Polling
   {% end %}
 
   private def system_run(blocking : Bool, & : Fiber ->) : Nil
-    Crystal.trace :evloop, "run", blocking: blocking ? 1 : 0
+    Crystal.trace :evloop, "run", blocking: blocking
 
     # wait for events (indefinitely when blocking)
     buffer = uninitialized LibC::EpollEvent[128]

--- a/src/crystal/event_loop/kqueue.cr
+++ b/src/crystal/event_loop/kqueue.cr
@@ -73,7 +73,7 @@ class Crystal::EventLoop::Kqueue < Crystal::EventLoop::Polling
   private def system_run(blocking : Bool, & : Fiber ->) : Nil
     buffer = uninitialized LibC::Kevent[128]
 
-    Crystal.trace :evloop, "run", blocking: blocking ? 1 : 0
+    Crystal.trace :evloop, "run", blocking: blocking
     timeout = blocking ? nil : Time::Span.zero
     kevents = @kqueue.wait(buffer.to_slice, timeout)
 

--- a/src/crystal/scheduler.cr
+++ b/src/crystal/scheduler.cr
@@ -66,7 +66,7 @@ class Crystal::Scheduler
   end
 
   def self.sleep(time : Time::Span) : Nil
-    Crystal.trace :sched, "sleep", for: time.total_nanoseconds.to_i64!
+    Crystal.trace :sched, "sleep", for: time
     Thread.current.scheduler.sleep(time)
   end
 
@@ -225,7 +225,7 @@ class Crystal::Scheduler
       pending = Atomic(Int32).new(count - 1)
       @@workers = Array(Thread).new(count) do |i|
         if i == 0
-          worker_loop = Fiber.new(name: "Worker Loop") { Thread.current.scheduler.run_loop }
+          worker_loop = Fiber.new(name: "worker-loop") { Thread.current.scheduler.run_loop }
           worker_loop.set_current_thread
           Thread.current.scheduler.enqueue worker_loop
           Thread.current
@@ -272,7 +272,7 @@ class Crystal::Scheduler
 
   # Background loop to cleanup unused fiber stacks.
   def spawn_stack_pool_collector
-    fiber = Fiber.new(name: "Stack pool collector", &->@stack_pool.collect_loop)
+    fiber = Fiber.new(name: "stack-pool-collector", &->@stack_pool.collect_loop)
     {% if flag?(:preview_mt) %} fiber.set_current_thread {% end %}
     enqueue(fiber)
   end

--- a/src/crystal/system/unix/signal.cr
+++ b/src/crystal/system/unix/signal.cr
@@ -82,7 +82,7 @@ module Crystal::System::Signal
   end
 
   private def self.start_loop
-    spawn(name: "Signal Loop") do
+    spawn(name: "signal-loop") do
       loop do
         value = reader.read_bytes(Int32)
       rescue IO::Error

--- a/src/crystal/system/win32/process.cr
+++ b/src/crystal/system/win32/process.cr
@@ -203,7 +203,7 @@ struct Crystal::System::Process
   def self.start_interrupt_loop : Nil
     return unless @@setup_interrupt_handler.test_and_set
 
-    spawn(name: "Interrupt signal loop") do
+    spawn(name: "interrupt-signal-loop") do
       while true
         @@interrupt_count.wait { sleep 50.milliseconds }
 


### PR DESCRIPTION
A couple improvements to `Crystal.trace` because I keep making these changes while working on the execution contexts:

- Avoid spaces in fiber names (easier to columnize with `column -t`)
- Support more types (Bool, Char, Time::Span)