### PR TITLE
Add `Thread#internal_name=`

### DIFF
--- a/src/crystal/system/thread.cr
+++ b/src/crystal/system/thread.cr
@@ -182,6 +182,11 @@ class Thread
     self.system_name = name
   end
 
+  # Changes the Thread#name property but doesn't update the system name. Useful
+  # on the main thread where we'd change the process name (e.g. top, ps, ...).
+  def internal_name=(@name : String)
+  end
+
   # Holds the GC thread handler
   property gc_thread_handler : Void* = Pointer(Void).null
 


### PR DESCRIPTION
Allows to change the `Thread#name` property without affecting the system name used by the OS, which affect ps, top, gdb, ...

We usually want to change the system name, except for the main thread. For example is we name the thread "DEFAULT" then ps will report our process as "DEFAULT" instead of "myapp" (oops).