### PR TITLE
Add `Thread::LinkedList#each` to safely iterate lists

### DIFF
--- a/src/crystal/system/thread.cr
+++ b/src/crystal/system/thread.cr
@@ -74,6 +74,10 @@ class Thread
     @@threads.try(&.unsafe_each { |thread| yield thread })
   end
 
+  def self.each(&)
+    threads.each { |thread| yield thread }
+  end
+
   def self.lock : Nil
     threads.@mutex.lock
   end

--- a/src/crystal/system/thread_linked_list.cr
+++ b/src/crystal/system/thread_linked_list.cr
@@ -24,6 +24,13 @@ class Thread
       end
     end
 
+    # Safely iterates the list.
+    def each(&) : Nil
+      @mutex.synchronize do
+        unsafe_each { |node| yield node }
+      end
+    end
+
     # Appends a node to the tail of the list. The operation is thread-safe.
     #
     # There are no guarantees that a node being pushed will be iterated by

--- a/src/fiber.cr
+++ b/src/fiber.cr
@@ -78,6 +78,11 @@ class Fiber
     @@fibers.try(&.unsafe_each { |fiber| yield fiber })
   end
 
+  # :nodoc:
+  def self.each(&)
+    fibers.each { |fiber| yield fiber }
+  end
+
   # Creates a new `Fiber` instance.
   #
   # When the fiber is executed, it runs *proc* in its context.


### PR DESCRIPTION
Sometimes we'd like to be able to safely iterate the lists. Also adds `Thread.each(&)` and `Fiber.each(&)` as convenience accessors.

This will be used in RFC 2 to safely iterate execution contexts for example.