### PR TITLE
Fix: EventLoop::Polling::FiberEvent [fixup #14996]

### DIFF
--- a/src/crystal/event_loop/polling.cr
+++ b/src/crystal/event_loop/polling.cr
@@ -123,11 +123,11 @@ abstract class Crystal::EventLoop::Polling < Crystal::EventLoop
   # fiber interface, see Crystal::EventLoop
 
   def create_resume_event(fiber : Fiber) : FiberEvent
-    FiberEvent.new(self, fiber, :sleep)
+    FiberEvent.new(:sleep, fiber)
   end
 
   def create_timeout_event(fiber : Fiber) : FiberEvent
-    FiberEvent.new(self, fiber, :select_timeout)
+    FiberEvent.new(:select_timeout, fiber)
   end
 
   # file descriptor interface, see Crystal::EventLoop::FileDescriptor

--- a/src/crystal/event_loop/polling/fiber_event.cr
+++ b/src/crystal/event_loop/polling/fiber_event.cr
@@ -1,7 +1,7 @@
 class Crystal::EventLoop::Polling::FiberEvent
   include Crystal::EventLoop::Event
 
-  def initialize(@event_loop : EventLoop, fiber : Fiber, type : Event::Type)
+  def initialize(type : Event::Type, fiber : Fiber)
     @event = Event.new(type, fiber)
   end
 
@@ -10,15 +10,15 @@ class Crystal::EventLoop::Polling::FiberEvent
     seconds, nanoseconds = System::Time.monotonic
     now = Time::Span.new(seconds: seconds, nanoseconds: nanoseconds)
     @event.wake_at = now + timeout
-    @event_loop.add_timer(pointerof(@event))
+    EventLoop.current.add_timer(pointerof(@event))
   end
 
   # select timeout has been cancelled
   def delete : Nil
     return unless @event.wake_at?
 
-    @event.wake_at = nil
-    @event_loop.delete_timer(pointerof(@event))
+    EventLoop.current.delete_timer(pointerof(@event))
+    clear
   end
 
   # fiber died


### PR DESCRIPTION
Reduces discrepancies with the refactored `IOCP::FiberEvent` and fixes a couple issues:

1. No need to tie the event to a specific event loop;
2. Clear wake_at _after_ dequeueing the timer (MT bug).