### PR TITLE
RFC 2: ExecutionContext

### DIFF
--- a/spec/std/spec_helper.cr
+++ b/spec/std/spec_helper.cr
@@ -43,7 +43,7 @@ def spawn_and_check(before : Proc(_), file = __FILE__, line = __LINE__, &block :
 
     # This is a workaround to ensure the "before" fiber
     # is unscheduled. Otherwise it might stay alive running the event loop
-    spawn(same_thread: true) do
+    spawn(same_thread: !{{flag?(:execution_context)}}) do
       while x.get != 2
         Fiber.yield
       end

--- a/spec/std/thread_spec.cr
+++ b/spec/std/thread_spec.cr
@@ -46,7 +46,11 @@ pending_interpreted describe: Thread do
 
   it "names the thread" do
     {% if flag?(:execution_context) %}
-      Thread.current.name.should eq("DEFAULT")
+      {% if flag?(:mt) %}
+        Thread.current.name.should match(/^DEFAULT-\d+$/)
+      {% else %}
+        Thread.current.name.should eq("DEFAULT")
+      {% end %}
     {% else %}
       Thread.current.name.should be_nil
     {% end %}

--- a/spec/support/mt_abort_timeout.cr
+++ b/spec/support/mt_abort_timeout.cr
@@ -5,7 +5,7 @@ private SPEC_TIMEOUT = 15.seconds
 Spec.around_each do |example|
   done = Channel(Exception?).new
 
-  spawn(same_thread: true) do
+  spawn(same_thread: !{{flag?(:execution_context)}}) do
     begin
       example.run
     rescue e

--- a/src/crystal/system/thread.cr
+++ b/src/crystal/system/thread.cr
@@ -179,6 +179,18 @@ class Thread
     Crystal::System::Thread.sleep(time)
   end
 
+  # Delays execution for a brief moment.
+  @[NoInline]
+  def self.delay(backoff : Int32) : Int32
+    if backoff < 7
+      backoff.times { Intrinsics.pause }
+      backoff &+ 1
+    else
+      Thread.yield
+      0
+    end
+  end
+
   # Returns the Thread object associated to the running system thread.
   def self.current : Thread
     Crystal::System::Thread.current_thread

--- a/src/crystal/tracing.cr
+++ b/src/crystal/tracing.cr
@@ -59,7 +59,7 @@ module Crystal
 
           n = value.size.clamp(..remaining)
           value.to_unsafe.copy_to(@buf.to_unsafe + pos, n)
-          @size = pos + n
+          @size = pos &+ n
         end
 
         def write(value : String) : Nil
@@ -71,7 +71,7 @@ module Crystal
           i = 0
           value.each_byte do |byte|
             chars[i] = byte
-            i += 1
+            i &+= 1
           end
           write chars.to_slice[0, i]
         end
@@ -106,7 +106,7 @@ module Crystal
         end
 
         def write(value : Time::Span) : Nil
-          write(value.seconds * Time::NANOSECONDS_PER_SECOND + value.nanoseconds)
+          write(value.seconds &* Time::NANOSECONDS_PER_SECOND &+ value.nanoseconds)
         end
 
         def write(value : Bool) : Nil
@@ -204,7 +204,7 @@ module Crystal
       private def self.each_token(slice, delim = ',', &)
         while e = slice.index(delim.ord)
           yield slice[0, e]
-          slice = slice[(e + 1)..]
+          slice = slice[(e &+ 1)..]
         end
         yield slice[0..] unless slice.size == 0
       end
@@ -268,7 +268,7 @@ module Crystal
         begin
           yield
         ensure
-          duration = System::Time.ticks - time
+          duration = System::Time.ticks &- time
           Tracing.log(section.to_id, operation, time, **metadata, duration: duration)
         end
       else

--- a/src/fiber/execution_context.cr
+++ b/src/fiber/execution_context.cr
@@ -20,7 +20,11 @@ module Fiber::ExecutionContext
 
   # :nodoc:
   def self.init_default_context : Nil
-    @@default = SingleThreaded.default
+    {% if flag?(:mt) %}
+      @@default = MultiThreaded.default(default_workers_count)
+    {% else %}
+      @@default = SingleThreaded.default
+    {% end %}
     @@monitor = Monitor.new
   end
 

--- a/src/fiber/execution_context/multi_threaded.cr
+++ b/src/fiber/execution_context/multi_threaded.cr
@@ -1,0 +1,277 @@
+require "./global_queue"
+require "./multi_threaded/scheduler"
+
+module Fiber::ExecutionContext
+  # MT scheduler.
+  #
+  # Owns multiple threads and starts a scheduler in each one. The number of
+  # threads is dynamic. Setting the minimum and maximum to the same value will
+  # start a fixed number of threads.
+  #
+  # Fully concurrent, fully parallel: fibers running in this context can be
+  # resumed by any thread in the context; fibers can run concurrently and in
+  # parallel to each other, in addition to running in parallel to every other
+  # fibers running in other contexts.
+  class MultiThreaded
+    include ExecutionContext
+
+    getter name : String
+
+    @mutex : Thread::Mutex
+    @condition : Thread::ConditionVariable
+    protected getter global_queue : GlobalQueue
+
+    getter stack_pool : Fiber::StackPool = Fiber::StackPool.new
+    getter event_loop : Crystal::EventLoop = Crystal::EventLoop.create
+    @event_loop_lock = Atomic(Bool).new(false)
+
+    @parked = Atomic(Int32).new(0)
+    @spinning = Atomic(Int32).new(0)
+
+    # :nodoc:
+    protected def self.default(size : Int32) : self
+      new("DEFAULT", 1..size, hijack: true)
+    end
+
+    # Starts a context with a maximum number of threads. Threads aren't started
+    # right away, but will be started as needed to increase parallelism up to
+    # the configured maximum.
+    def self.new(name : String, size : Int32) : self
+      new(name, 0..size, hijack: false)
+    end
+
+    # Starts a context with a maximum number of threads. Threads aren't started
+    # right away, but will be started as needed to increase parallelism up to
+    # the configured maximum.
+    def self.new(name : String, size : Range(Nil, Int32)) : self
+      new(name, 0..size.end, hijack: false)
+    end
+
+    # Starts a context with a minimum and a maximum number of threads. The
+    # minimum number of threads will be started right away, then threads will be
+    # started as needed to increase parallelism up to the configured maximum.
+    def self.new(name : String, size : Range(Int32, Int32)) : self
+      new(name, size, hijack: false)
+    end
+
+    protected def initialize(@name : String, @size : Range(Int32, Int32), hijack : Bool)
+      raise ArgumentError.new("#{self.class.name} needs at least one thread") if @size.end < 1
+
+      @mutex = Thread::Mutex.new
+      @condition = Thread::ConditionVariable.new
+
+      @global_queue = GlobalQueue.new(@mutex)
+      @schedulers = Array(Scheduler).new(@size.end)
+      @threads = Array(Thread).new(@size.end)
+
+      @rng = Random::PCG32.new
+
+      start_schedulers(hijack)
+      start_initial_threads(hijack)
+
+      ExecutionContext.execution_contexts.push(self)
+    end
+
+    # The number of threads that have been started.
+    def size : Int32
+      @threads.size
+    end
+
+    # The maximum number of threads that can be started.
+    def capacity : Int32
+      @size.end
+    end
+
+    def stack_pool? : Fiber::StackPool?
+      @stack_pool
+    end
+
+    private def start_schedulers(hijack)
+      @size.end.times do |index|
+        @schedulers << Scheduler.new(self, "#{@name}-#{index}")
+      end
+    end
+
+    private def start_initial_threads(hijack)
+      @size.begin.times do |index|
+        scheduler = @schedulers[index]
+
+        if hijack && index == 0
+          @threads << hijack_current_thread(scheduler, index)
+        else
+          @threads << start_thread(scheduler, index)
+        end
+      end
+    end
+
+    # Attaches *scheduler* to the current `Thread`, usually the process' main
+    # thread. Starts a `Fiber` to run the scheduler loop.
+    private def hijack_current_thread(scheduler, index) : Thread
+      thread = Thread.current
+      thread.internal_name = scheduler.name
+      thread.execution_context = self
+      thread.scheduler = scheduler
+
+      scheduler.thread = thread
+      scheduler.main_fiber = Fiber.new("#{scheduler.name}:loop", self) do
+        scheduler.run_loop
+      end
+
+      thread
+    end
+
+    # Starts a new `Thread` and attaches *scheduler*. Runs the scheduler loop
+    # directly in the thread's main `Fiber`.
+    private def start_thread(scheduler, index) : Thread
+      Thread.new(name: scheduler.name) do |thread|
+        thread.execution_context = self
+        thread.scheduler = scheduler
+
+        scheduler.thread = thread
+        scheduler.main_fiber = thread.main_fiber
+        scheduler.main_fiber.name = "#{scheduler.name}:loop"
+        scheduler.run_loop
+      end
+    end
+
+    def spawn(*, name : String? = nil, same_thread : Bool, &block : ->) : Fiber
+      raise ArgumentError.new("#{self.class.name}#spawn doesn't support same_thread:true") if same_thread
+      self.spawn(name: name, &block)
+    end
+
+    def enqueue(fiber : Fiber) : Nil
+      if ExecutionContext.current == self
+        # local enqueue: push to local queue of current scheduler
+        ExecutionContext::Scheduler.current.enqueue(fiber)
+      else
+        # cross context: push to global queue
+        Crystal.trace :sched, "enqueue", fiber: fiber, to_context: self
+        @global_queue.push(fiber)
+        wake_scheduler
+      end
+    end
+
+    # Picks a scheduler at random then iterates all schedulers to try to steal
+    # fibers from.
+    protected def steal(& : Scheduler ->) : Nil
+      return if size == 1
+
+      i = @rng.next_int
+      n = @schedulers.size
+
+      n.times do |j|
+        if scheduler = @schedulers[(i &+ j) % n]?
+          yield scheduler
+        end
+      end
+    end
+
+    protected def park_thread(&) : Fiber?
+      @mutex.synchronize do
+        # avoid races by checking queues again
+        if fiber = yield
+          return fiber
+        end
+
+        Crystal.trace :sched, "park"
+        @parked.add(1, :acquire_release)
+
+        @condition.wait(@mutex)
+
+        # we don't decrement @parked because #wake_scheduler did
+        Crystal.trace :sched, "wakeup"
+      end
+
+      nil
+    end
+
+    # This method always runs in parallel!
+    #
+    # This can be called from any thread in the context but can also be called
+    # from external execution contexts, in which case the context may have its
+    # last thread about to park itself, and we must prevent the last thread from
+    # parking when there is a parallel cross context enqueue!
+    #
+    # OPTIMIZE: instead of blindly spending time (blocking progress on the
+    # current thread) to unpark a thread / start a new thread we could move the
+    # responsibility to an external observer to increase parallelism in a MT
+    # context when it detects pending work.
+    protected def wake_scheduler : Nil
+      # another thread is spinning: nothing to do (it shall notice the enqueue)
+      if @spinning.get(:relaxed) > 0
+        return
+      end
+
+      # interrupt a thread waiting on the event loop
+      if @event_loop_lock.get(:relaxed)
+        @event_loop.interrupt
+        return
+      end
+
+      # we can check @parked without locking the mutex because we can't push to
+      # the global queue _and_ park the thread at the same time, so either the
+      # thread is already parked (and we must awake it) or it noticed (or will
+      # notice) the fiber in the global queue;
+      #
+      # we still rely on an atomic to make sure the actual value is visible by
+      # the current thread
+      if @parked.get(:acquire) > 0
+        @mutex.synchronize do
+          # avoid race conditions
+          return if @parked.get(:relaxed) == 0
+          return if @spinning.get(:relaxed) > 0
+
+          # increase the number of spinning threads _now_ to avoid multiple
+          # threads from trying to wakeup multiple threads at the same time
+          #
+          # we must also decrement the number of parked threads because another
+          # thread could lock the mutex and increment @spinning again before the
+          # signaled thread is resumed
+          spinning = @spinning.add(1, :acquire_release)
+          parked = @parked.sub(1, :acquire_release)
+
+          @condition.signal
+        end
+        return
+      end
+
+      # check if we can start another thread; no need for atomics, the values
+      # shall be rather stable over time and we check them again inside the
+      # mutex
+      return if @threads.size == @size.end
+
+      @mutex.synchronize do
+        index = @threads.size
+        return if index == @size.end # check again
+
+        @threads << start_thread(@schedulers[index], index)
+      end
+    end
+
+    # Only one thread is allowed to run the event loop. Yields then returns true
+    # if the lock was acquired, otherwise returns false immediately.
+    protected def lock_evloop?(&) : Bool
+      if @event_loop_lock.swap(true, :acquire) == false
+        begin
+          yield
+        ensure
+          @event_loop_lock.set(false, :release)
+        end
+        true
+      else
+        false
+      end
+    end
+
+    @[AlwaysInline]
+    def inspect(io : IO) : Nil
+      to_s(io)
+    end
+
+    def to_s(io : IO) : Nil
+      io << "#<" << self.class.name << ":0x"
+      object_id.to_s(io, 16)
+      io << ' ' << name << '>'
+    end
+  end
+end

--- a/src/fiber/execution_context/multi_threaded/scheduler.cr
+++ b/src/fiber/execution_context/multi_threaded/scheduler.cr
@@ -1,0 +1,265 @@
+require "crystal/pointer_linked_list"
+require "../scheduler"
+require "../runnables"
+
+module Fiber::ExecutionContext
+  class MultiThreaded
+    # MT fiber scheduler.
+    #
+    # Owns a single thread inside a MT execution context.
+    class Scheduler
+      include ExecutionContext::Scheduler
+
+      getter name : String
+
+      # :nodoc:
+      property execution_context : MultiThreaded
+      protected property! thread : Thread
+      protected property! main_fiber : Fiber
+
+      @global_queue : GlobalQueue
+      @runnables : Runnables(256)
+      @event_loop : Crystal::EventLoop
+
+      @tick : Int32 = 0
+      @spinning = false
+      @waiting = false
+      @parked = false
+
+      protected def initialize(@execution_context, @name)
+        @global_queue = @execution_context.global_queue
+        @runnables = Runnables(256).new(@global_queue)
+        @event_loop = @execution_context.event_loop
+      end
+
+      # :nodoc:
+      def spawn(*, name : String? = nil, same_thread : Bool, &block : ->) : Fiber
+        raise RuntimeError.new("#{self.class.name}#spawn doesn't support same_thread:true") if same_thread
+        self.spawn(name: name, &block)
+      end
+
+      # Unlike `ExecutionContext::MultiThreaded#enqueue` this method is only
+      # safe to call on `ExecutionContext.current` which should always be the
+      # case, since cross context enqueues must call
+      # `ExecutionContext::MultiThreaded#enqueue` through `Fiber#enqueue`.
+      protected def enqueue(fiber : Fiber) : Nil
+        Crystal.trace :sched, "enqueue", fiber: fiber
+        @runnables.push(fiber)
+        @execution_context.wake_scheduler unless @execution_context.capacity == 1
+      end
+
+      protected def reschedule : Nil
+        Crystal.trace :sched, "reschedule"
+        if fiber = quick_dequeue?
+          resume fiber unless fiber == thread.current_fiber
+        else
+          # nothing to do: switch back to the main loop to spin/wait/park
+          resume main_fiber
+        end
+      end
+
+      protected def resume(fiber : Fiber) : Nil
+        Crystal.trace :sched, "resume", fiber: fiber
+
+        # in a multithreaded environment the fiber may be dequeued before its
+        # running context has been saved on the stack (thread A tries to resume
+        # fiber but thread B didn't saved its context yet); we must wait until
+        # the context switch assembly saved all registers on the stack and set
+        # the fiber as resumable.
+        attempts = 0
+
+        until fiber.resumable?
+          if fiber.dead?
+            raise "BUG: tried to resume dead fiber #{fiber} (#{inspect})"
+          end
+
+          # OPTIMIZE: if the thread saving the fiber context has been preempted,
+          # this will block the current thread from progressing... shall we
+          # abort and reenqueue the fiber after MAX attempts?
+          attempts = Thread.delay(attempts)
+        end
+
+        swapcontext(fiber)
+      end
+
+      private def quick_dequeue? : Fiber?
+        # every once in a while: dequeue from global queue to avoid two fibers
+        # constantly respawing each other to completely occupy the local queue
+        if (@tick &+= 1) % 61 == 0
+          if fiber = @global_queue.pop?
+            return fiber
+          end
+        end
+
+        # dequeue from local queue
+        if fiber = @runnables.shift?
+          return fiber
+        end
+      end
+
+      protected def run_loop : Nil
+        Crystal.trace :sched, "started"
+
+        loop do
+          if fiber = find_next_runnable
+            spin_stop if @spinning
+            resume fiber
+          else
+            # the event loop enqueued a fiber (or was interrupted) or the
+            # scheduler was unparked: go for the next iteration
+          end
+        rescue exception
+          Crystal.print_error_buffered("BUG: %s#run_loop [%s] crashed",
+            self.class.name, @name, exception: exception)
+        end
+      end
+
+      private def find_next_runnable : Fiber?
+        find_next_runnable do |fiber|
+          return fiber if fiber
+        end
+      end
+
+      private def find_next_runnable(&) : Nil
+        list = Fiber::List.new
+
+        # nothing to do: start spinning
+        spinning do
+          yield @global_queue.grab?(@runnables, divisor: @execution_context.size)
+
+          if @execution_context.lock_evloop? { @event_loop.run(pointerof(list), blocking: false) }
+            unless list.empty?
+              # must stop spinning before calling enqueue_many that may call
+              # wake_scheduler which returns immediately if a thread is
+              # spinning... but we're spinning, so that would always fail to
+              # wake sleeping schedulers despite having runnable fibers
+              spin_stop
+              yield enqueue_many(pointerof(list))
+            end
+          end
+
+          yield try_steal?
+        end
+
+        # wait on the event loop for events and timers to activate
+        evloop_ran = @execution_context.lock_evloop? do
+          @waiting = true
+
+          # there is a time window between stop spinning and start waiting
+          # during which another context may have enqueued a fiber, check again
+          # before blocking on the event loop to avoid missing a runnable fiber,
+          # which may block for a long time:
+          yield @global_queue.grab?(@runnables, divisor: @execution_context.size)
+
+          # block on the event loop until an event is ready or the loop is
+          # interrupted
+          @event_loop.run(pointerof(list), blocking: true)
+        ensure
+          @waiting = false
+        end
+
+        if evloop_ran
+          yield enqueue_many(pointerof(list))
+
+          # the event loop was interrupted: restart the loop
+          return
+        end
+
+        # no runnable fiber and another thread is already running the event
+        # loop: park the thread until another scheduler or another context
+        # enqueues a fiber
+        @execution_context.park_thread do
+          # by the time we acquire the lock, another thread may have enqueued
+          # fiber(s) and already tried to wakeup a thread (race) so we must
+          # check again; we don't check the scheduler's local queue (it's empty)
+
+          yield @global_queue.unsafe_grab?(@runnables, divisor: @execution_context.size)
+          yield try_steal?
+
+          @parked = true
+          nil
+        end
+        @parked = false
+
+        # immediately mark the scheduler as spinning (we just unparked); we
+        # don't increment the number of spinning threads since
+        # `MultiThreaded#wake_scheduler` already did
+        @spinning = true
+      end
+
+      private def enqueue_many(list : Fiber::List*) : Fiber?
+        if fiber = list.value.pop?
+          Crystal.trace :sched, "enqueue", size: list.value.size, fiber: fiber
+          unless list.value.empty?
+            @runnables.bulk_push(list)
+            @execution_context.wake_scheduler unless @execution_context.capacity == 1
+          end
+          fiber
+        end
+      end
+
+      # This method always runs in parallel!
+      private def try_steal? : Fiber?
+        @execution_context.steal do |other|
+          if other == self
+            # no need to steal from ourselves
+            next
+          end
+
+          if fiber = @runnables.steal_from(other.@runnables)
+            Crystal.trace :sched, "stole", from: other, size: @runnables.size, fiber: fiber
+            return fiber
+          end
+        end
+      end
+
+      # OPTIMIZE: skip spinning if there are enough threads spinning already
+      private def spinning(&)
+        spin_start
+
+        4.times do |attempt|
+          Thread.yield unless attempt == 0
+          yield
+        end
+
+        spin_stop
+      end
+
+      private def spin_start : Nil
+        return if @spinning
+
+        @spinning = true
+        @execution_context.@spinning.add(1, :acquire_release)
+      end
+
+      private def spin_stop : Nil
+        return unless @spinning
+
+        @execution_context.@spinning.sub(1, :acquire_release)
+        @spinning = false
+      end
+
+      def inspect(io : IO) : Nil
+        to_s(io)
+      end
+
+      def to_s(io : IO) : Nil
+        io << "#<" << self.class.name << ":0x"
+        object_id.to_s(io, 16)
+        io << ' ' << @name << '>'
+      end
+
+      def status : String
+        if @spinning
+          "spinning"
+        elsif @waiting
+          "event-loop"
+        elsif @parked
+          "parked"
+        else
+          "running"
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Here finally comes the first draft pull request for [RFC 2](https://github.com/crystal-lang/rfcs/pull/2) extracted from the [execution_context](https://github.com/ysbaddaden/execution_context) shard.

**Status**

All three execution contexts have been implemented:

- `ExecutionContext::SingleThreaded` to create a concurrent only context (the fibers run on a single thread but will run in parallel to other fibers in other contexts); this is the default context (unless you specify `-Dmt`).

- `ExecutionContext::MultiThreaded` to create a concurrent+parallel context with work stealing (fibers in the context may be resumed by any thread); this is the default context is you specify `-Dmt`.

- `ExecutionContext::Isolated` to run a single fiber in a dedicated thread (no concurrency, no parallelism), while still being able to communicate with other fibers in other contexts normally (Channel, Mutex, ...), doing IO operations, or spawning fibers (transparently to another context).

Both the single and multi threaded contexts share the same queues and overall logic, but with different optimizations. The isolated context doesn't need any queues and relies on a special loop. It's the only context that can shutdown for the time being (we may implement cooperation shutdown or shrinking/growing the MT context).

Alongside the execution contexts, a monitoring thread is running, for the moment limited to collecting fiber stacks regularly, but shall evolve (in subsequent pull requests) to handle much more situations by monitoring the execution contexts. For example the shard has a proof-of-concept for a cooperative yield for fibers that have been running for too time (may be checked at cancellation points or manually in CPU heavy loops). See the TODO in `monitor.cr` for more exciting ideas.

**Stability**

Ovber the development of the shard, the schedulers have proved hard to fix of race conditions, though all known races have been squashed, and the schedulers have proved to be quite stable (and fast).

So far both the ST and MT contexts can run the crystal std specs... save for:

- MT: some sporadic segfaults :sob: maybe because of the same-thread fiber assumption being broken, or maybe an issue with threads starting up or shutdown down in parallel to GC collections.
- ST: a GC bug where the GC will sometimes enter an infinite loop trying to allocate a large object (see https://github.com/ivmai/bdwgc/issues/691), the issue can't be reproduced with GC 8.3 (unreleased).

**Usage**

The feature is opt-in for the time being.

You must compile your application with both the `-Dexecution_context` to use the ExecutionContext schedulers, and `-Dpreview_mt` compile time flags.

**Notes**

A number of individual commits peripheral to the current feature have already been extracted into individual pull requests. The ones that haven't are because they may still change as this PR continues to evolve or may be dropped (e.g. Thread::WaitGroup).