### PR TITLE
Fix error handling for `LibC.clock_gettime(CLOCK_MONOTONIC)` calls

### DIFF
--- a/src/crystal/system/unix/pthread_condition_variable.cr
+++ b/src/crystal/system/unix/pthread_condition_variable.cr
@@ -42,8 +42,7 @@ class Thread
 
           LibC.pthread_cond_timedwait_relative_np(self, mutex, pointerof(ts))
         {% else %}
-          clock_gettime_ret = LibC.clock_gettime(LibC::CLOCK_MONOTONIC, out ts)
-          raise RuntimeError.from_errno("clock_gettime(CLOCK_MONOTONIC)") unless clock_gettime_ret == 0
+          LibC.clock_gettime(LibC::CLOCK_MONOTONIC, out ts)
           ts.tv_sec += time.to_i
           ts.tv_nsec += time.nanoseconds
 

--- a/src/crystal/system/unix/pthread_condition_variable.cr
+++ b/src/crystal/system/unix/pthread_condition_variable.cr
@@ -42,7 +42,8 @@ class Thread
 
           LibC.pthread_cond_timedwait_relative_np(self, mutex, pointerof(ts))
         {% else %}
-          LibC.clock_gettime(LibC::CLOCK_MONOTONIC, out ts)
+          clock_gettime_ret = LibC.clock_gettime(LibC::CLOCK_MONOTONIC, out ts)
+          raise RuntimeError.from_errno("clock_gettime(CLOCK_MONOTONIC)") unless clock_gettime_ret == 0
           ts.tv_sec += time.to_i
           ts.tv_nsec += time.nanoseconds
 

--- a/src/crystal/system/unix/time.cr
+++ b/src/crystal/system/unix/time.cr
@@ -50,8 +50,7 @@ module Crystal::System::Time
       info = mach_timebase_info
       LibC.mach_absolute_time &* info.numer // info.denom
     {% else %}
-      ret = LibC.clock_gettime(LibC::CLOCK_MONOTONIC, out tp)
-      raise RuntimeError.from_errno("clock_gettime(CLOCK_MONOTONIC)") unless ret == 0
+      LibC.clock_gettime(LibC::CLOCK_MONOTONIC, out tp)
       tp.tv_sec.to_u64! &* NANOSECONDS_PER_SECOND &+ tp.tv_nsec.to_u64!
     {% end %}
   end

--- a/src/crystal/system/unix/time.cr
+++ b/src/crystal/system/unix/time.cr
@@ -39,9 +39,8 @@ module Crystal::System::Time
       nanoseconds = total_nanoseconds.remainder(NANOSECONDS_PER_SECOND)
       {seconds.to_i64, nanoseconds.to_i32}
     {% else %}
-      if LibC.clock_gettime(LibC::CLOCK_MONOTONIC, out tp) == 1
-        raise RuntimeError.from_errno("clock_gettime(CLOCK_MONOTONIC)")
-      end
+      ret = LibC.clock_gettime(LibC::CLOCK_MONOTONIC, out tp)
+      raise RuntimeError.from_errno("clock_gettime(CLOCK_MONOTONIC)") unless ret == 0
       {tp.tv_sec.to_i64, tp.tv_nsec.to_i32}
     {% end %}
   end
@@ -51,7 +50,8 @@ module Crystal::System::Time
       info = mach_timebase_info
       LibC.mach_absolute_time &* info.numer // info.denom
     {% else %}
-      LibC.clock_gettime(LibC::CLOCK_MONOTONIC, out tp)
+      ret = LibC.clock_gettime(LibC::CLOCK_MONOTONIC, out tp)
+      raise RuntimeError.from_errno("clock_gettime(CLOCK_MONOTONIC)") unless ret == 0
       tp.tv_sec.to_u64! &* NANOSECONDS_PER_SECOND &+ tp.tv_nsec.to_u64!
     {% end %}
   end


### PR DESCRIPTION
POSIX `clock_gettime` returns 0 on success and -1 on error. See https://man7.org/linux/man-pages/man3/clock_gettime.3.html#RETURN_VALUE

The code for `Crystal::System::Time.compute_utc_seconds_and_nanoseconds` correctly does a `raise RuntimeError.from_errno(...) unless ret == 0`. However, the code for `Crystal::System::Time.monotonic` **incorrectly** does a `raise ... if ret == 1` (checking for **positive** one return value, not a negative one!). So any errors will not be detected, and the uninitialized timespec struct will be used by the caller.

This PR fixes this to make the `monotonic` return value checking logic be the same.

(My context is that in 1.14.0 I am still occasionally seeing an unreproducible segfault in CI related to `Time.monotonic` https://forum.crystal-lang.org/t/how-to-diagnose-occasional-segfault-in-time-monotonic-within-timecop-travel/6099 and came across this as I was looking more closely at the code.)