### PR TITLE
[CI] Add `no_output_timeout` for `dist_darwin` setup environment

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -285,7 +285,7 @@ jobs:
 
   dist_darwin:
     macos:
-      xcode: 13.4.1
+      xcode: 15.3.0
     shell: /bin/bash --login -eo pipefail
     steps:
       - restore_cache:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -293,6 +293,7 @@ jobs:
             - brew-cache-v1
       - run:
           name: Setup environment
+          no_output_timeout: 40m
           command: |
             brew unlink python@2 || true
 


### PR DESCRIPTION
The `dist_darwin` jobs keeps running out of the context deadline while preparing the environment.

Example: https://app.circleci.com/pipelines/github/crystal-lang/crystal/16855/workflows/4dd8d733-7ac7-4e8a-be51-f411af642980/jobs/87938

This patch increases the deadline from 10 minutes to 40 minutes, which should be plenty.