### PR TITLE
Fix: signal handler musn't depend on the event loop

### DIFF
--- a/src/crystal/system/unix/signal.cr
+++ b/src/crystal/system/unix/signal.cr
@@ -84,9 +84,7 @@ module Crystal::System::Signal
   private def self.start_loop
     spawn(name: "signal-loop") do
       loop do
-        buf = uninitialized StaticArray(UInt8, 4)
-        reader.read_fully(buf.to_slice)
-        value = buf.unsafe_as(Int32)
+        value = reader.read_bytes(Int32)
       rescue IO::Error
         next
       else


### PR DESCRIPTION
Only a limited set of POSIX functions are signal safe, and the system functions that the event loop implementations can rely on isn't in the list (e.g. epoll, kevent, malloc, ...).

Now, the writer side of the pipe is blocking, so we should never reach a nonblocking case that would trigger an event loop wait, but going to the event loop may still be doing far too much or dangerous things: an event loop might not be available (e.g. bare thread) and it might be lazily allocated (signal unsafe).