### PR TITLE
Use `Crystal::PointerLinkedList` instead of `Deque` in `Mutex`

### DIFF
--- a/src/fiber/pointer_linked_list_node.cr
+++ b/src/fiber/pointer_linked_list_node.cr
@@ -1,6 +1,8 @@
+require "crystal/pointer_linked_list"
+
 class Fiber
   # :nodoc:
-  struct Waiting
+  struct PointerLinkedListNode
     include Crystal::PointerLinkedList::Node
 
     def initialize(@fiber : Fiber)

--- a/src/fiber/waiting.cr
+++ b/src/fiber/waiting.cr
@@ -1,0 +1,13 @@
+class Fiber
+  # :nodoc:
+  struct Waiting
+    include Crystal::PointerLinkedList::Node
+
+    def initialize(@fiber : Fiber)
+    end
+
+    def enqueue : Nil
+      @fiber.enqueue
+    end
+  end
+end

--- a/src/mutex.cr
+++ b/src/mutex.cr
@@ -25,7 +25,7 @@ class Mutex
   @lock_count = 0
   @queue = Crystal::PointerLinkedList(Fiber::Waiting).new
   @queue_count = Atomic(Int32).new(0)
-  @spin = Crystal::SpinLock.new
+  @lock = Crystal::SpinLock.new
 
   enum Protection
     Checked
@@ -62,7 +62,7 @@ class Mutex
 
       waiting = Fiber::Waiting.new(Fiber.current)
 
-      @spin.sync do
+      @lock.sync do
         @queue_count.add(1)
 
         if @state.get(:relaxed) == UNLOCKED
@@ -120,7 +120,7 @@ class Mutex
     end
 
     waiting = nil
-    @spin.sync do
+    @lock.sync do
       if @queue_count.get == 0
         return
       end

--- a/src/mutex.cr
+++ b/src/mutex.cr
@@ -1,4 +1,4 @@
-require "fiber/waiting"
+require "fiber/pointer_linked_list_node"
 require "crystal/spin_lock"
 
 # A fiber-safe mutex.
@@ -23,7 +23,7 @@ class Mutex
   @state = Atomic(Int32).new(UNLOCKED)
   @mutex_fiber : Fiber?
   @lock_count = 0
-  @queue = Crystal::PointerLinkedList(Fiber::Waiting).new
+  @queue = Crystal::PointerLinkedList(Fiber::PointerLinkedListNode).new
   @queue_count = Atomic(Int32).new(0)
   @lock = Crystal::SpinLock.new
 
@@ -60,7 +60,7 @@ class Mutex
     loop do
       break if try_lock
 
-      waiting = Fiber::Waiting.new(Fiber.current)
+      waiting = Fiber::PointerLinkedListNode.new(Fiber.current)
 
       @lock.sync do
         @queue_count.add(1)

--- a/src/wait_group.cr
+++ b/src/wait_group.cr
@@ -1,7 +1,6 @@
 require "fiber"
-require "fiber/waiting"
+require "fiber/pointer_linked_list_node"
 require "crystal/spin_lock"
-require "crystal/pointer_linked_list"
 
 # Suspend execution until a collection of fibers are finished.
 #
@@ -49,7 +48,7 @@ class WaitGroup
   end
 
   def initialize(n : Int32 = 0)
-    @waiting = Crystal::PointerLinkedList(Fiber::Waiting).new
+    @waiting = Crystal::PointerLinkedList(Fiber::PointerLinkedListNode).new
     @lock = Crystal::SpinLock.new
     @counter = Atomic(Int32).new(n)
   end
@@ -118,7 +117,7 @@ class WaitGroup
   def wait : Nil
     return if done?
 
-    waiting = Fiber::Waiting.new(Fiber.current)
+    waiting = Fiber::PointerLinkedListNode.new(Fiber.current)
 
     @lock.sync do
       # must check again to avoid a race condition where #done may have


### PR DESCRIPTION
Follows `WaitGroup` that uses a linked list instead of a deque to store the waiting fibers.

The flat array doesn't have much impact on performance: we only reach the head or the tail once to dequeue/dequeue one fiber at a time. This however spares a number of GC allocations since the Deque has to be allocated plus its buffer that will have to be reallocated sometimes (and will only ever grow, never shrink).

Extracts the undocumented `Fiber::Waiting` struct from `WaitGroup` that acts as the node in the linked list.

Renames `@lock` to `@spin` since the former was a bit confusing, for example with `@lock_count` that counts the number of reentrancy.