### PR TITLE
Update distribution-scripts

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,7 +8,7 @@ parameters:
   distribution-scripts-version:
     description: "Git ref for version of https://github.com/crystal-lang/distribution-scripts/"
     type: string
-    default: "588099d9e9de7ecf5925365796d30f832870e18c"
+    default: "2f56eecf233f52229b93eab4acd2bca51f0f8edf"
   previous_crystal_base_url:
     description: "Prefix for URLs to Crystal bootstrap compiler"
     type: string


### PR DESCRIPTION
Updates `distribution-scripts` dependency to https://github.com/crystal-lang/distribution-scripts/commit/2f56eecf233f52229b93eab4acd2bca51f0f8edf

This includes the following changes:

* crystal-lang/distribution-scripts#338
