### PR TITLE
Fix Valgrind memory leak warning by freeing alternate signal stack

### DIFF
--- a/src/crystal/at_exit_handlers.cr
+++ b/src/crystal/at_exit_handlers.cr
@@ -1,9 +1,14 @@
 # :nodoc:
 module Crystal::AtExitHandlers
   private class_getter(handlers) { [] of Int32, ::Exception? -> }
+  private class_getter(internal_handlers) { [] of Int32, ::Exception? -> }
 
   def self.add(handler)
     handlers << handler
+  end
+
+  def self.__crystal_add(handler)
+    internal_handlers << handler
   end
 
   def self.run(status, exception = nil)
@@ -14,6 +19,18 @@ module Crystal::AtExitHandlers
           handler.call status, exception
         rescue handler_ex
           Crystal::System.print_error "Error running at_exit handler: %s\n", handler_ex.message || ""
+          status = 1 if status.zero?
+        end
+      end
+    end
+
+    if internal_handlers = @@internal_handlers
+      # Run the registered internal handlers in reverse order
+      while handler = internal_handlers.pop?
+        begin
+          handler.call status, exception
+        rescue handler_ex
+          Crystal::System.print_error "Error running internal at_exit handler: %s\n", handler_ex.message || ""
           status = 1 if status.zero?
         end
       end

--- a/src/crystal/system/unix/signal.cr
+++ b/src/crystal/system/unix/signal.cr
@@ -227,6 +227,10 @@ module Crystal::System::Signal
     altstack.ss_flags = 0
     LibC.sigaltstack(pointerof(altstack), nil)
 
+    at_exit {
+      LibC.free(altstack.ss_sp)
+    }
+
     action = LibC::Sigaction.new
     action.sa_flags = LibC::SA_ONSTACK | LibC::SA_SIGINFO
     action.sa_sigaction = @@segfault_handler

--- a/src/crystal/system/unix/signal.cr
+++ b/src/crystal/system/unix/signal.cr
@@ -227,7 +227,7 @@ module Crystal::System::Signal
     altstack.ss_flags = 0
     LibC.sigaltstack(pointerof(altstack), nil)
 
-    at_exit {
+    Crystal::AtExitHandlers.__crystal_add ->(s : Int32, e : ::Exception?) {
       reset_signal_stack(pointerof(altstack))
     }
 


### PR DESCRIPTION
Hello,

This is a proof-of-concept pull request.

Recently, it was reported on the forum that when running Crystal programs with Valgrind, the alternate signal stack allocated by LibC.malloc is not freed before the program ends. Instead, the operating system frees it after the program finishes.

https://forum.crystal-lang.org/t/valgrind-memory-leak-in-helloworld-app-crystal-lang/7583

> [emrum](https://forum.crystal-lang.org/u/emrum/summary)
>
> ==387674== HEAP SUMMARY:
> ==387674== in use at exit: 8,192 bytes in 1 blocks
> ==387674== total heap usage: 15 allocs, 14 frees, 12,336 bytes allocated

> [HertzDevil](https://forum.crystal-lang.org/u/HertzDevil)
>
> For the record, the 8192 bytes leaked here are the alternate stack for the signal handler, which is allocated using LibC.malloc directly

To fix this, I added an at_exit signal handler that switches back to the default stack and then frees the alternate stack. This stops Valgrind from showing a "memory leak" warning.

This pull request also adds a new system-level at_exit handler in AtExitHandlers. I created this because it is not good practice to use the regular at_exit for system tasks. The new handler can be used to free memory allocated by LibC.malloc and handle other system cleanup.

Thank you for reviewing this.