### PR TITLE
Add support for :showdoc: directive for private and protected objects (RFC #0011)

### DIFF
--- a/spec/compiler/crystal/tools/doc/directives_spec.cr
+++ b/spec/compiler/crystal/tools/doc/directives_spec.cr
@@ -1,0 +1,115 @@
+require "../../../spec_helper"
+
+describe Crystal::Doc::Generator do
+  context ":nodoc:" do
+    it "hides documentation from being generated for methods" do
+      program = top_level_semantic(<<-CRYSTAL, wants_doc: true).program
+        class Foo
+          # :nodoc:
+          #
+          # Some docs
+          def foo
+          end
+        end
+        CRYSTAL
+
+      generator = Doc::Generator.new program, [""]
+      generator.type(program.types["Foo"]).lookup_method("foo").should be_nil
+    end
+
+    it "hides documentation from being generated for classes" do
+      program = top_level_semantic(<<-CRYSTAL, wants_doc: true).program
+        # :nodoc:
+        class Foo
+        end
+        CRYSTAL
+
+      generator = Doc::Generator.new program, [""]
+      generator.must_include?(program.types["Foo"]).should be_false
+    end
+  end
+
+  context ":showdoc:" do
+    it "shows documentation for private methods" do
+      program = top_level_semantic(<<-CRYSTAL, wants_doc: true).program
+        class Foo
+          # :showdoc:
+          #
+          # Some docs
+          private def foo
+          end
+        end
+        CRYSTAL
+
+      generator = Doc::Generator.new program, [""]
+      a_def = generator.type(program.types["Foo"]).lookup_method("foo").not_nil!
+      a_def.doc.should eq("Some docs")
+      a_def.visibility.should eq("private")
+    end
+
+    it "does not include documentation for methods within a :nodoc: namespace" do
+      program = top_level_semantic(<<-CRYSTAL, wants_doc: true).program
+        # :nodoc:
+        class Foo
+          # :showdoc:
+          #
+          # Some docs
+          private def foo
+          end
+        end
+        CRYSTAL
+
+      generator = Doc::Generator.new program, [""]
+
+      # If namespace isn't included, don't need to check if the method is included
+      generator.must_include?(program.types["Foo"]).should be_false
+    end
+
+    it "shows all private and protected methods in a :showdoc: namespace" do
+      program = top_level_semantic(<<-CRYSTAL, wants_doc: true).program
+        # :showdoc:
+        class Foo
+          # Some docs for `foo`
+          private def foo
+          end
+
+          # Some docs for `bar`
+          protected def bar
+          end
+
+          # Some docs for `Baz`
+          private class Baz
+          end
+        end
+        CRYSTAL
+
+      generator = Doc::Generator.new program, [""]
+      foo_def = generator.type(program.types["Foo"]).lookup_method("foo").not_nil!
+      foo_def.doc.should eq("Some docs for `foo`")
+      foo_def.visibility.should eq("private")
+
+      bar_def = generator.type(program.types["Foo"]).lookup_method("bar").not_nil!
+      bar_def.doc.should eq("Some docs for `bar`")
+      bar_def.visibility.should eq("protected")
+
+      baz_class = generator.type(program.types["Foo"]).lookup_path("Baz").not_nil!
+      baz_class.doc.should eq("Some docs for `Baz`")
+      baz_class.visibility.should eq("private")
+    end
+
+    it "doesn't show a method marked :nodoc: within a :showdoc: namespace" do
+      program = top_level_semantic(<<-CRYSTAL, wants_doc: true).program
+        # :showdoc:
+        class Foo
+          # :nodoc:
+          # Some docs for `foo`
+          private def foo
+          end
+        end
+        CRYSTAL
+
+      generator = Doc::Generator.new program, [""]
+      generator.type(program.types["Foo"]).lookup_method("foo").should be_nil
+    end
+  end
+end

--- a/src/compiler/crystal/tools/doc/generator.cr
+++ b/src/compiler/crystal/tools/doc/generator.cr
@@ -221,17 +221,7 @@ class Crystal::Doc::Generator
   end
 
   def showdoc?(obj : Crystal::Type)
-    return false if !@program.wants_doc?
-
-    if showdoc?(obj.doc.try &.strip)
-      return true
-    end
-
-    obj.each_namespace do |ns|
-      return true if showdoc?(ns.doc.try &.strip)
-    end
-
-    false
+    showdoc?(obj.doc.try &.strip)
   end
 
   def crystal_builtin?(type)

--- a/src/compiler/crystal/tools/doc/generator.cr
+++ b/src/compiler/crystal/tools/doc/generator.cr
@@ -234,6 +234,16 @@ class Crystal::Doc::Generator
     false
   end
 
+  def showdoc?(obj)
+    return false if !@program.wants_doc?
+
+    if showdoc?(obj.doc.try &.strip)
+      return true
+    end
+
+    false
+  end
+
   def crystal_builtin?(type)
     return false unless project_info.crystal_stdlib?
     # TODO: Enabling this allows links to `NoReturn` to work, but has two `NoReturn`s show up in the sidebar

--- a/src/compiler/crystal/tools/doc/generator.cr
+++ b/src/compiler/crystal/tools/doc/generator.cr
@@ -234,16 +234,6 @@ class Crystal::Doc::Generator
     false
   end
 
-  def showdoc?(obj)
-    return false if !@program.wants_doc?
-
-    if showdoc?(obj.doc.try &.strip)
-      return true
-    end
-
-    false
-  end
-
   def crystal_builtin?(type)
     return false unless project_info.crystal_stdlib?
     # TODO: Enabling this allows links to `NoReturn` to work, but has two `NoReturn`s show up in the sidebar
@@ -325,7 +315,7 @@ class Crystal::Doc::Generator
   end
 
   def doc(obj : Type | Method | Macro | Constant)
-    doc = obj.doc.try &.strip.lchop(":showdoc:")
+    doc = obj.doc.try &.strip.lchop(":showdoc:").strip
 
     return if !doc && !has_doc_annotations?(obj)
 

--- a/src/compiler/crystal/tools/doc/html/_method_detail.html
+++ b/src/compiler/crystal/tools/doc/html/_method_detail.html
@@ -6,7 +6,7 @@
   <% methods.each do |method| %>
     <div class="entry-detail" id="<%= method.html_id %>">
       <div class="signature">
-        <%= method.abstract? ? "abstract " : "" %>
+        <%= method.abstract? ? "abstract " : "" %><%= method.visibility %>
         <%= method.kind %><strong><%= method.name %></strong><%= method.args_to_html %>
 
         <a class="method-permalink" href="<%= method.anchor %>">#</a>

--- a/src/compiler/crystal/tools/doc/html/_method_detail.html
+++ b/src/compiler/crystal/tools/doc/html/_method_detail.html
@@ -6,7 +6,7 @@
   <% methods.each do |method| %>
     <div class="entry-detail" id="<%= method.html_id %>">
       <div class="signature">
-        <%= method.abstract? ? "abstract " : "" %><%= method.visibility %>
+        <%= method.abstract? ? "abstract " : "" %><%= method.visibility.try(&.+(" ")) %>
         <%= method.kind %><strong><%= method.name %></strong><%= method.args_to_html %>
 
         <a class="method-permalink" href="<%= method.anchor %>">#</a>

--- a/src/compiler/crystal/tools/doc/html/type.html
+++ b/src/compiler/crystal/tools/doc/html/type.html
@@ -19,7 +19,9 @@
 <% if type.program? %>
   <%= type.full_name.gsub("::", "::<wbr>") %>
 <% else %>
-  <span class="kind"><%= type.abstract? ? "abstract " : ""%><%= type.kind %></span> <%= type.full_name.gsub("::", "::<wbr>") %>
+  <span class="kind">
+    <%= type.abstract? ? "abstract " : ""%><%= type.visibility %><%= type.kind %>
+  </span> <%= type.full_name.gsub("::", "::<wbr>") %>
 <% end %>
 </h1>
 

--- a/src/compiler/crystal/tools/doc/html/type.html
+++ b/src/compiler/crystal/tools/doc/html/type.html
@@ -20,7 +20,7 @@
   <%= type.full_name.gsub("::", "::<wbr>") %>
 <% else %>
   <span class="kind">
-    <%= type.abstract? ? "abstract " : ""%><%= type.visibility %><%= type.kind %>
+    <%= type.abstract? ? "abstract " : ""%><%= type.visibility.try(&.+(" ")) %><%= type.kind %>
   </span> <%= type.full_name.gsub("::", "::<wbr>") %>
 <% end %>
 </h1>

--- a/src/compiler/crystal/tools/doc/macro.cr
+++ b/src/compiler/crystal/tools/doc/macro.cr
@@ -54,6 +54,10 @@ class Crystal::Doc::Macro
     false
   end
 
+  def visibility
+    @type.visibility
+  end
+
   def kind
     "macro "
   end

--- a/src/compiler/crystal/tools/doc/method.cr
+++ b/src/compiler/crystal/tools/doc/method.cr
@@ -43,7 +43,7 @@ class Crystal::Doc::Method
   # This docs not include the "Description copied from ..." banner
   # in case it's needed.
   def doc
-    doc_info.doc.try &.strip.lchop(":showdoc:")
+    doc_info.doc.try &.strip.lchop(":showdoc:").strip
   end
 
   # Returns the type this method's docs are copied from, but

--- a/src/compiler/crystal/tools/doc/method.cr
+++ b/src/compiler/crystal/tools/doc/method.cr
@@ -139,9 +139,9 @@ class Crystal::Doc::Method
     case @def.visibility
     in .public?
     in .protected?
-      "protected "
+      "protected"
     in .private?
-      "private "
+      "private"
     end
   end
 

--- a/src/compiler/crystal/tools/doc/method.cr
+++ b/src/compiler/crystal/tools/doc/method.cr
@@ -43,7 +43,7 @@ class Crystal::Doc::Method
   # This docs not include the "Description copied from ..." banner
   # in case it's needed.
   def doc
-    doc_info.doc
+    doc_info.doc.try &.strip.lchop(":showdoc:")
   end
 
   # Returns the type this method's docs are copied from, but
@@ -132,6 +132,16 @@ class Crystal::Doc::Method
       "."
     else
       "#"
+    end
+  end
+
+  def visibility
+    case @def.visibility
+    in .public?
+    in .protected?
+      "protected "
+    in .private?
+      "private "
     end
   end
 
@@ -323,6 +333,7 @@ class Crystal::Doc::Method
       builder.field "doc", doc unless doc.nil?
       builder.field "summary", formatted_summary unless formatted_summary.nil?
       builder.field "abstract", abstract?
+      builder.field "visibility", visibility if visibility
       builder.field "args", args unless args.empty?
       builder.field "args_string", args_to_s unless args.empty?
       builder.field "args_html", args_to_html unless args.empty?

--- a/src/compiler/crystal/tools/doc/type.cr
+++ b/src/compiler/crystal/tools/doc/type.cr
@@ -82,7 +82,7 @@ class Crystal::Doc::Type
   end
 
   def visibility
-    @type.private? ? "private " : nil
+    @type.private? ? "private" : nil
   end
 
   def parents_of?(type)

--- a/src/compiler/crystal/tools/doc/type.cr
+++ b/src/compiler/crystal/tools/doc/type.cr
@@ -81,6 +81,10 @@ class Crystal::Doc::Type
     @type.abstract?
   end
 
+  def visibility
+    @type.private? ? "private " : nil
+  end
+
   def parents_of?(type)
     return false unless type
 
@@ -181,7 +185,7 @@ class Crystal::Doc::Type
         defs = [] of Method
         @type.defs.try &.each do |def_name, defs_with_metadata|
           defs_with_metadata.each do |def_with_metadata|
-            next unless def_with_metadata.def.visibility.public?
+            next if !def_with_metadata.def.visibility.public? && !showdoc?(def_with_metadata.def)
             next unless @generator.must_include? def_with_metadata.def
 
             defs << method(def_with_metadata.def, false)
@@ -190,6 +194,10 @@ class Crystal::Doc::Type
         defs.sort_by! { |x| sort_order(x) }
       end
     end
+  end
+
+  private def showdoc?(adef)
+    @generator.showdoc?(adef.doc.try &.strip) || @generator.showdoc?(@type)
   end
 
   private def sort_order(item)
@@ -205,7 +213,7 @@ class Crystal::Doc::Type
       @type.metaclass.defs.try &.each_value do |defs_with_metadata|
         defs_with_metadata.each do |def_with_metadata|
           a_def = def_with_metadata.def
-          next unless a_def.visibility.public?
+          next if !def_with_metadata.def.visibility.public? && !showdoc?(def_with_metadata.def)
 
           body = a_def.body
 
@@ -236,7 +244,9 @@ class Crystal::Doc::Type
       macros = [] of Macro
       @type.metaclass.macros.try &.each_value do |the_macros|
         the_macros.each do |a_macro|
-          if a_macro.visibility.public? && @generator.must_include? a_macro
+          next if !a_macro.visibility.public? && !showdoc?(a_macro)
+
+          if @generator.must_include? a_macro
             macros << self.macro(a_macro)
           end
         end

--- a/src/compiler/crystal/tools/doc/type.cr
+++ b/src/compiler/crystal/tools/doc/type.cr
@@ -197,7 +197,7 @@ class Crystal::Doc::Type
   end
 
   private def showdoc?(adef)
-    @generator.showdoc?(adef.doc.try &.strip) || @generator.showdoc?(@type)
+    @generator.showdoc?(adef.doc.try &.strip)
   end
 
   private def sort_order(item)


### PR DESCRIPTION
First part of splitting up #15294.

Private class:
<img width="1452" alt="image" src="https://github.com/user-attachments/assets/bc1fe2e3-713d-4503-97da-688c8a7ac0c0" />

Private methods:
<img width="1453" alt="image" src="https://github.com/user-attachments/assets/04b71c7b-7aef-4dd2-9b1d-071a63600665" />
<img width="1450" alt="image" src="https://github.com/user-attachments/assets/d8b3938a-8ea3-4654-8862-b7359acf7863" />
