### PR TITLE
Add fiber safety to `__crystal_once` & `class_[getter|property]?(&)` macros

### DIFF
--- a/spec/std/socket/spec_helper.cr
+++ b/spec/std/socket/spec_helper.cr
@@ -2,7 +2,11 @@ require "spec"
 require "socket"
 
 module SocketSpecHelper
-  class_getter?(supports_ipv6 : Bool) do
+  @@supports_ipv6 : Bool?
+
+  class_getter?(supports_ipv6 : Bool) { detect_supports_ipv6? }
+
+  private def self.detect_supports_ipv6? : Bool
     TCPServer.open("::1", 0) { return true }
     false
   rescue Socket::Error

--- a/spec/support/time.cr
+++ b/spec/support/time.cr
@@ -72,7 +72,9 @@ end
     # Enable the `SeTimeZonePrivilege` privilege before changing the system time
     # zone. This is necessary because the privilege is by default granted but
     # disabled for any new process. This only needs to be done once per run.
-    class_getter? time_zone_privilege_enabled : Bool do
+    class_getter?(time_zone_privilege_enabled : Bool) { detect_time_zone_privilege_enabled? }
+
+    private def self.detect_time_zone_privilege_enabled? : Bool
       if LibC.LookupPrivilegeValueW(nil, SeTimeZonePrivilege, out time_zone_luid) == 0
         raise RuntimeError.from_winerror("LookupPrivilegeValueW")
       end

--- a/src/crystal/once.cr
+++ b/src/crystal/once.cr
@@ -57,6 +57,8 @@
 
   # :nodoc:
   fun __crystal_once_init : Nil
+    Thread.init
+    Fiber.init
     Crystal.once_mutex = Mutex.new(:reentrant)
   end
 
@@ -105,6 +107,8 @@
 
   # :nodoc:
   fun __crystal_once_init : Void*
+    Thread.init
+    Fiber.init
     Crystal::OnceState.new.as(Void*)
   end
 

--- a/src/crystal/once.cr
+++ b/src/crystal/once.cr
@@ -21,8 +21,8 @@
     # :nodoc:
     enum OnceState : Int8
       Processing    = -1
-      Uninitialized = 0
-      Initialized   = 1
+      Uninitialized =  0
+      Initialized   =  1
     end
 
     @@once_mutex = uninitialized Mutex

--- a/src/crystal/system/thread.cr
+++ b/src/crystal/system/thread.cr
@@ -2,6 +2,8 @@
 module Crystal::System::Thread
   # alias Handle
 
+  # def self.init : Nil
+
   # def self.new_handle(thread_obj : ::Thread) : Handle
 
   # def self.current_handle : Handle
@@ -48,7 +50,16 @@ class Thread
   include Crystal::System::Thread
 
   # all thread objects, so the GC can see them (it doesn't scan thread locals)
-  protected class_getter(threads) { Thread::LinkedList(Thread).new }
+  @@threads = uninitialized Thread::LinkedList(Thread)
+
+  protected def self.threads : Thread::LinkedList(Thread)
+    @@threads
+  end
+
+  def self.init : Nil
+    @@threads = Thread::LinkedList(Thread).new
+    Crystal::System::Thread.init
+  end
 
   @system_handle : Crystal::System::Thread::Handle
   @exception : Exception?

--- a/src/crystal/system/unix/pthread.cr
+++ b/src/crystal/system/unix/pthread.cr
@@ -26,6 +26,16 @@ module Crystal::System::Thread
     raise RuntimeError.from_os_error("pthread_create", Errno.new(ret)) unless ret == 0
   end
 
+  def self.init : Nil
+    {% if flag?(:musl) %}
+      @@main_handle = current_handle
+    {% elsif flag?(:openbsd) || flag?(:android) %}
+      ret = LibC.pthread_key_create(out current_key, nil)
+      raise RuntimeError.from_os_error("pthread_key_create", Errno.new(ret)) unless ret == 0
+      @@current_key = current_key
+    {% end %}
+  end
+
   def self.thread_proc(data : Void*) : Void*
     th = data.as(::Thread)
 
@@ -53,13 +63,7 @@ module Crystal::System::Thread
   # Android appears to support TLS to some degree, but executables fail with
   # an underaligned TLS segment, see https://github.com/crystal-lang/crystal/issues/13951
   {% if flag?(:openbsd) || flag?(:android) %}
-    @@current_key : LibC::PthreadKeyT
-
-    @@current_key = begin
-      ret = LibC.pthread_key_create(out current_key, nil)
-      raise RuntimeError.from_os_error("pthread_key_create", Errno.new(ret)) unless ret == 0
-      current_key
-    end
+    @@current_key = uninitialized LibC::PthreadKeyT
 
     def self.current_thread : ::Thread
       if ptr = LibC.pthread_getspecific(@@current_key)
@@ -84,10 +88,17 @@ module Crystal::System::Thread
     end
   {% else %}
     @[ThreadLocal]
-    class_property current_thread : ::Thread { ::Thread.new }
+    @@current_thread : ::Thread?
+
+    def self.current_thread : ::Thread
+      @@current_thread ||= ::Thread.new
+    end
 
     def self.current_thread? : ::Thread?
       @@current_thread
+    end
+
+    def self.current_thread=(@@current_thread : ::Thread)
     end
   {% end %}
 
@@ -169,7 +180,7 @@ module Crystal::System::Thread
   end
 
   {% if flag?(:musl) %}
-    @@main_handle : Handle = current_handle
+    @@main_handle = uninitialized Handle
 
     def self.current_is_main?
       current_handle == @@main_handle

--- a/src/crystal/system/wasi/thread.cr
+++ b/src/crystal/system/wasi/thread.cr
@@ -1,6 +1,9 @@
 module Crystal::System::Thread
   alias Handle = Nil
 
+  def self.init : Nil
+  end
+
   def self.new_handle(thread_obj : ::Thread) : Handle
     raise NotImplementedError.new("Crystal::System::Thread.new_handle")
   end
@@ -13,7 +16,16 @@ module Crystal::System::Thread
     raise NotImplementedError.new("Crystal::System::Thread.yield_current")
   end
 
-  class_property current_thread : ::Thread { ::Thread.new }
+  def self.current_thread : ::Thread
+    @@current_thread ||= ::Thread.new
+  end
+
+  def self.current_thread? : ::Thread?
+    @@current_thread
+  end
+
+  def self.current_thread=(@@current_thread : ::Thread)
+  end
 
   def self.sleep(time : ::Time::Span) : Nil
     req = uninitialized LibC::Timespec

--- a/src/fiber.cr
+++ b/src/fiber.cr
@@ -44,8 +44,16 @@ end
 # notifications that IO is ready or a timeout reached. When a fiber can be woken,
 # the event loop enqueues it in the scheduler
 class Fiber
+  @@fibers = uninitialized Thread::LinkedList(Fiber)
+
+  protected def self.fibers : Thread::LinkedList(Fiber)
+    @@fibers
+  end
+
   # :nodoc:
-  protected class_getter(fibers) { Thread::LinkedList(Fiber).new }
+  def self.init : Nil
+    @@fibers = Thread::LinkedList(Fiber).new
+  end
 
   @context : Context
   @stack : Void*

--- a/src/object.cr
+++ b/src/object.cr
@@ -432,7 +432,11 @@ class Object
     # end
     # ```
     #
+    # {% if macro_prefix == "class_" %}
+    # Is similar to writing (thread and fiber safety omitted):
+    # {% else %}
     # Is the same as writing:
+    # {% end %}
     #
     # ```
     # class Person
@@ -448,29 +452,71 @@ class Object
     macro {{macro_prefix}}getter(*names, &block)
       \{% if block %}
         \{% if names.size != 1 %}
-          \{{ raise "Only one argument can be passed to `getter` with a block" }}
+          \{{ raise "Only one argument can be passed to `#{macro_prefix}getter` with a block" }}
         \{% end %}
 
         \{% name = names[0] %}
 
         \{% if name.is_a?(TypeDeclaration) %}
-          {{var_prefix}}\{{name.var.id}} : \{{name.type}}?
+          {% if macro_prefix == "class_" %}
+            {{var_prefix}}\{{name.var.id}} : \{{name.type}}?
 
-          def {{method_prefix}}\{{name.var.id}} : \{{name.type}}
-            if (%value = {{var_prefix}}\{{name.var.id}}).nil?
-              {{var_prefix}}\{{name.var.id}} = \{{yield}}
-            else
-              %value
+            {% if compare_versions(Crystal::VERSION, "1.16.0-dev") >= 0 %}
+              {{var_prefix}}__\{{name.var.id}}_once_flag : ::Crystal::OnceState = :uninitialized
+            {% else %}
+              {{var_prefix}}__\{{name.var.id}}_once_flag : Bool = false
+            {% end %}
+
+            def {{method_prefix}}\{{name.var.id}} : \{{name.type}}
+              if %value = {{var_prefix}}\{{name.var.id}}
+                return %value
+              end
+              ::Crystal.once(pointerof({{var_prefix}}__\{{name.var.id}}_once_flag)) do
+                if {{var_prefix}}\{{name.var.id}}.nil?
+                  {{var_prefix}}\{{name.var.id}} = \{{yield}}
+                end
+              end
+              {{var_prefix}}\{{name.var.id}}.not_nil!
             end
-          end
+          {% else %}
+            {{var_prefix}}\{{name.var.id}} : \{{name.type}}?
+
+            def {{method_prefix}}\{{name.var.id}} : \{{name.type}}
+              if (%value = {{var_prefix}}\{{name.var.id}}).nil?
+                {{var_prefix}}\{{name.var.id}} = \{{yield}}
+              else
+                %value
+              end
+            end
+          {% end %}
         \{% else %}
-          def {{method_prefix}}\{{name.id}}
-            if (%value = {{var_prefix}}\{{name.id}}).nil?
-              {{var_prefix}}\{{name.id}} = \{{yield}}
-            else
-              %value
+          {% if macro_prefix == "class_" %}
+            {% if compare_versions(Crystal::VERSION, "1.16.0-dev") >= 0 %}
+              {{var_prefix}}__\{{name.id}}_once_flag : ::Crystal::OnceState = :uninitialized
+            {% else %}
+              {{var_prefix}}__\{{name.id}}_once_flag : Bool = false
+            {% end %}
+
+            def {{method_prefix}}\{{name.id}}
+              if %value = {{var_prefix}}\{{name.id}}
+                return %value
+              end
+              ::Crystal.once(pointerof({{var_prefix}}__\{{name.id}}_once_flag)) do
+                if {{var_prefix}}\{{name.id}}.nil?
+                  {{var_prefix}}\{{name.id}} = \{{yield}}
+                end
+              end
+              {{var_prefix}}\{{name.id}}.not_nil!
             end
-          end
+          {% else %}
+            def {{method_prefix}}\{{name.id}}
+              if (%value = {{var_prefix}}\{{name.id}}).nil?
+                {{var_prefix}}\{{name.id}} = \{{yield}}
+              else
+                %value
+              end
+            end
+          {% end %}
         \{% end %}
       \{% else %}
         \{% for name in names %}
@@ -679,29 +725,71 @@ class Object
     macro {{macro_prefix}}getter?(*names, &block)
       \{% if block %}
         \{% if names.size != 1 %}
-          \{{ raise "Only one argument can be passed to `getter?` with a block" }}
+          \{{ raise "Only one argument can be passed to `#{macro_prefix}getter?` with a block" }}
         \{% end %}
 
         \{% name = names[0] %}
 
         \{% if name.is_a?(TypeDeclaration) %}
-          {{var_prefix}}\{{name.var.id}} : \{{name.type}}?
+          {% if macro_prefix == "class_" %}
+            {{var_prefix}}\{{name.var.id}} : \{{name.type}}?
 
-          def {{method_prefix}}\{{name.var.id}}? : \{{name.type}}
-            if (%value = {{var_prefix}}\{{name.var.id}}).nil?
-              {{var_prefix}}\{{name.var.id}} = \{{yield}}
-            else
-              %value
+            {% if compare_versions(Crystal::VERSION, "1.16.0-dev") >= 0 %}
+              {{var_prefix}}__\{{name.var.id}}_once_flag : ::Crystal::OnceState = :uninitialized
+            {% else %}
+              {{var_prefix}}__\{{name.var.id}}_once_flag : Bool = false
+            {% end %}
+
+            def {{method_prefix}}\{{name.var.id}}? : \{{name.type}}
+              if %value = {{var_prefix}}\{{name.var.id}}
+                return %value
+              end
+              ::Crystal.once(pointerof({{var_prefix}}__\{{name.var.id}}_once_flag)) do
+                if {{var_prefix}}\{{name.var.id}}.nil?
+                  {{var_prefix}}\{{name.var.id}} = \{{yield}}
+                end
+              end
+              {{var_prefix}}\{{name.var.id}}.not_nil!
             end
-          end
+          {% else %}
+            {{var_prefix}}\{{name.var.id}} : \{{name.type}}?
+
+            def {{method_prefix}}\{{name.var.id}}? : \{{name.type}}
+              if (%value = {{var_prefix}}\{{name.var.id}}).nil?
+                {{var_prefix}}\{{name.var.id}} = \{{yield}}
+              else
+                %value
+              end
+            end
+          {% end %}
         \{% else %}
-          def {{method_prefix}}\{{name.id}}?
-            if (%value = {{var_prefix}}\{{name.id}}).nil?
-              {{var_prefix}}\{{name.id}} = \{{yield}}
-            else
-              %value
+          {% if macro_prefix == "class_" %}
+            {% if compare_versions(Crystal::VERSION, "1.16.0-dev") >= 0 %}
+              {{var_prefix}}__\{{name.id}}_once_flag : ::Crystal::OnceState = :uninitialized
+            {% else %}
+              {{var_prefix}}__\{{name.id}}_once_flag : Bool = false
+            {% end %}
+
+            def {{method_prefix}}\{{name.id}}?
+              if %value = {{var_prefix}}\{{name.id}}
+                return %value
+              end
+              ::Crystal.once(pointerof({{var_prefix}}__\{{name.id}}_once_flag)) do
+                if {{var_prefix}}\{{name.id}}.nil?
+                  {{var_prefix}}\{{name.id}} = \{{yield}}
+                end
+              end
+              {{var_prefix}}\{{name.id}}.not_nil!
             end
-          end
+          {% else %}
+            def {{method_prefix}}\{{name.id}}?
+              if (%value = {{var_prefix}}\{{name.id}}).nil?
+                {{var_prefix}}\{{name.id}} = \{{yield}}
+              else
+                %value
+              end
+            end
+          {% end %}
         \{% end %}
       \{% else %}
         \{% for name in names %}
@@ -942,7 +1030,11 @@ class Object
     # end
     # ```
     #
+    # {% if macro_prefix == "class_" %}
+    # Is similar to writing (thread and fiber safety omitted):
+    # {% else %}
     # Is the same as writing:
+    # {% end %}
     #
     # ```
     # class Person
@@ -961,32 +1053,74 @@ class Object
     macro {{macro_prefix}}property(*names, &block)
       \{% if block %}
         \{% if names.size != 1 %}
-          \{{ raise "Only one argument can be passed to `property` with a block" }}
+          \{{ raise "Only one argument can be passed to `#{macro_prefix}property` with a block" }}
         \{% end %}
 
         \{% name = names[0] %}
 
         \{% if name.is_a?(TypeDeclaration) %}
-          {{var_prefix}}\{{name.var.id}} : \{{name.type}}?
+          {% if macro_prefix == "class_" %}
+            {{var_prefix}}\{{name.var.id}} : \{{name.type}}?
 
-          def {{method_prefix}}\{{name.var.id}} : \{{name.type}}
-            if (%value = {{var_prefix}}\{{name.var.id}}).nil?
-              {{var_prefix}}\{{name.var.id}} = \{{yield}}
-            else
-              %value
+            {% if compare_versions(Crystal::VERSION, "1.16.0-dev") >= 0 %}
+              {{var_prefix}}__\{{name.var.id}}_once_flag : ::Crystal::OnceState = :uninitialized
+            {% else %}
+              {{var_prefix}}__\{{name.var.id}}_once_flag : Bool = false
+            {% end %}
+
+            def {{method_prefix}}\{{name.var.id}} : \{{name.type}}
+              if %value = {{var_prefix}}\{{name.var.id}}
+                return %value
+              end
+              ::Crystal.once(pointerof({{var_prefix}}__\{{name.var.id}}_once_flag)) do
+                if {{var_prefix}}\{{name.var.id}}.nil?
+                  {{var_prefix}}\{{name.var.id}} = \{{yield}}
+                end
+              end
+              {{var_prefix}}\{{name.var.id}}.not_nil!
             end
-          end
+          {% else %}
+            {{var_prefix}}\{{name.var.id}} : \{{name.type}}?
+
+            def {{method_prefix}}\{{name.var.id}} : \{{name.type}}
+              if (%value = {{var_prefix}}\{{name.var.id}}).nil?
+                {{var_prefix}}\{{name.var.id}} = \{{yield}}
+              else
+                %value
+              end
+            end
+          {% end %}
 
           def {{method_prefix}}\{{name.var.id}}=({{var_prefix}}\{{name.var.id}} : \{{name.type}})
           end
         \{% else %}
-          def {{method_prefix}}\{{name.id}}
-            if (%value = {{var_prefix}}\{{name.id}}).nil?
-              {{var_prefix}}\{{name.id}} = \{{yield}}
-            else
-              %value
+          {% if macro_prefix == "class_" %}
+            {% if compare_versions(Crystal::VERSION, "1.16.0-dev") >= 0 %}
+              {{var_prefix}}__\{{name.id}}_once_flag : ::Crystal::OnceState = :uninitialized
+            {% else %}
+              {{var_prefix}}__\{{name.id}}_once_flag : Bool = false
+            {% end %}
+
+            def {{method_prefix}}\{{name.id}}
+              if %value = {{var_prefix}}\{{name.id}}
+                return %value
+              end
+              ::Crystal.once(pointerof({{var_prefix}}__\{{name.id}}_once_flag)) do
+                if {{var_prefix}}\{{name.id}}.nil?
+                  {{var_prefix}}\{{name.id}} = \{{yield}}
+                end
+              end
+              {{var_prefix}}\{{name.id}}.not_nil!
             end
-          end
+          {% else %}
+            def {{method_prefix}}\{{name.id}}
+              if (%value = {{var_prefix}}\{{name.id}}).nil?
+                {{var_prefix}}\{{name.id}} = \{{yield}}
+              else
+                %value
+              end
+            end
+          {% end %}
 
           def {{method_prefix}}\{{name.id}}=({{var_prefix}}\{{name.id}})
           end
@@ -1207,32 +1341,74 @@ class Object
     macro {{macro_prefix}}property?(*names, &block)
       \{% if block %}
         \{% if names.size != 1 %}
-          \{{ raise "Only one argument can be passed to `property?` with a block" }}
+          \{{ raise "Only one argument can be passed to `#{macro_prefix}property?` with a block" }}
         \{% end %}
 
         \{% name = names[0] %}
 
         \{% if name.is_a?(TypeDeclaration) %}
-          {{var_prefix}}\{{name.var.id}} : \{{name.type}}?
+          {% if macro_prefix == "class_" %}
+            {{var_prefix}}\{{name.var.id}} : \{{name.type}}?
 
-          def {{method_prefix}}\{{name.var.id}}? : \{{name.type}}
-            if (%value = {{var_prefix}}\{{name.var.id}}).nil?
-              {{var_prefix}}\{{name.var.id}} = \{{yield}}
-            else
-              %value
+            {% if compare_versions(Crystal::VERSION, "1.16.0-dev") >= 0 %}
+              {{var_prefix}}__\{{name.var.id}}_once_flag : ::Crystal::OnceState = :uninitialized
+            {% else %}
+              {{var_prefix}}__\{{name.var.id}}_once_flag : Bool = false
+            {% end %}
+
+            def {{method_prefix}}\{{name.var.id}}? : \{{name.type}}
+              if %value = {{var_prefix}}\{{name.var.id}}
+                return %value
+              end
+              ::Crystal.once(pointerof({{var_prefix}}__\{{name.var.id}}_once_flag)) do
+                if {{var_prefix}}\{{name.var.id}}.nil?
+                  {{var_prefix}}\{{name.var.id}} = \{{yield}}
+                end
+              end
+              {{var_prefix}}\{{name.var.id}}.not_nil!
             end
-          end
+          {% else %}
+            {{var_prefix}}\{{name.var.id}} : \{{name.type}}?
+
+            def {{method_prefix}}\{{name.var.id}}? : \{{name.type}}
+              if (%value = {{var_prefix}}\{{name.var.id}}).nil?
+                {{var_prefix}}\{{name.var.id}} = \{{yield}}
+              else
+                %value
+              end
+            end
+          {% end %}
 
           def {{method_prefix}}\{{name.var.id}}=({{var_prefix}}\{{name.var.id}} : \{{name.type}})
           end
         \{% else %}
-          def {{method_prefix}}\{{name.id}}?
-            if (%value = {{var_prefix}}\{{name.id}}).nil?
-              {{var_prefix}}\{{name.id}} = \{{yield}}
-            else
-              %value
+          {% if macro_prefix == "class_" %}
+            {% if compare_versions(Crystal::VERSION, "1.16.0-dev") >= 0 %}
+              {{var_prefix}}__\{{name.id}}_once_flag : ::Crystal::OnceState = :uninitialized
+            {% else %}
+              {{var_prefix}}__\{{name.id}}_once_flag : Bool = false
+            {% end %}
+
+            def {{method_prefix}}\{{name.id}}?
+              if %value = {{var_prefix}}\{{name.id}}
+                return %value
+              end
+              ::Crystal.once(pointerof({{var_prefix}}__\{{name.id}}_once_flag)) do
+                if {{var_prefix}}\{{name.id}}.nil?
+                  {{var_prefix}}\{{name.id}} = \{{yield}}
+                end
+              end
+              {{var_prefix}}\{{name.id}}.not_nil!
             end
-          end
+          {% else %}
+            def {{method_prefix}}\{{name.id}}?
+              if (%value = {{var_prefix}}\{{name.id}}).nil?
+                {{var_prefix}}\{{name.id}} = \{{yield}}
+              else
+                %value
+              end
+            end
+          {% end %}
 
           def {{method_prefix}}\{{name.id}}=({{var_prefix}}\{{name.id}})
           end


### PR DESCRIPTION
Fixes a couple issues:

1. `__crystal_once` isn't fiber safe (concurrency issues); the initializer can be invoked multiple times from multiple fibers (despite using `Mutex`).

   This issue is fixed by always using the `Mutex` not only when MT is enabled.

2. `class_getter`, `class_getter?`, `class_property` and `class_property?` are neither thread nor fiber safe (parallelism & concurrency issues).

   This issue is fixed by reusing `Crystal.once`.

**NOTE**: calls to the aforementioned macros had to be dropped in Fiber and Thread because Mutex depends on them and we need the later to implement said macros (chicken/egg => infinite recursion => stack overflows).

~~This is a **breaking change** because the block is now captured, and we can't `return` from it anymore. This is outlined by the commit that fixes `SocketSpecHelper.supports_ipv6?` that didn't work as expected anyway (the `@@supports_ipv6` class var was never set to `true`).~~ The block is no longer captured. We might want to introduce a compile time flag to enable the new behavior as it could help with some LLVM inlining behavior (inline the check).

builds on top of #15333
closes #14905 