### PR TITLE
Fix: Hash `@indices` can grow larger than Int32::MAX bytes

### DIFF
--- a/spec/manual/hash_large_spec.cr
+++ b/spec/manual/hash_large_spec.cr
@@ -1,0 +1,8 @@
+require "spec"
+
+it "creates Hash at maximum capacity" do
+  # we don't try to go as high as Int32::MAX because it would allocate 18GB of
+  # memory in total. This already tests for Int32 overflows while 'only' needing
+  # 4.5GB of memory.
+  Hash(Int32, Int32).new(initial_capacity: (Int32::MAX // 4) + 1)
+end

--- a/spec/std/hash_spec.cr
+++ b/spec/std/hash_spec.cr
@@ -1393,10 +1393,6 @@ describe "Hash" do
     hash.@indices_size_pow2.should eq(12)
   end
 
-  it "creates with max capacity", tags: %w[slow] do
-    Hash(Int32, Int32).new(initial_capacity: Int32::MAX)
-  end
-
   describe "#rehash" do
     it "rehashes" do
       a = [1]

--- a/spec/std/hash_spec.cr
+++ b/spec/std/hash_spec.cr
@@ -1393,7 +1393,7 @@ describe "Hash" do
     hash.@indices_size_pow2.should eq(12)
   end
 
-  it "creates with max capacity", slow: true do
+  it "creates with max capacity", tags: %w[slow] do
     Hash(Int32, Int32).new(initial_capacity: Int32::MAX)
   end
 

--- a/spec/std/hash_spec.cr
+++ b/spec/std/hash_spec.cr
@@ -1393,6 +1393,10 @@ describe "Hash" do
     hash.@indices_size_pow2.should eq(12)
   end
 
+  it "creates with max capacity", slow: true do
+    Hash(Int32, Int32).new(initial_capacity: Int32::MAX)
+  end
+
   describe "#rehash" do
     it "rehashes" do
       a = [1]

--- a/src/hash.cr
+++ b/src/hash.cr
@@ -236,12 +236,14 @@ class Hash(K, V)
       # Translate initial capacity to the nearest power of 2, but keep it a minimum of 8.
       if initial_capacity < 8
         initial_entries_size = 8
+      elsif initial_capacity > 2**30
+        initial_entries_size = Int32::MAX
       else
         initial_entries_size = Math.pw2ceil(initial_capacity)
       end
 
       # Because we always keep indice_size >= entries_size * 2
-      initial_indices_size = initial_entries_size * 2
+      initial_indices_size = initial_entries_size.to_u64 * 2
 
       @entries = malloc_entries(initial_entries_size)
 

--- a/src/hash.cr
+++ b/src/hash.cr
@@ -830,7 +830,7 @@ class Hash(K, V)
 
   # The actual number of bytes needed to allocate `@indices`.
   private def indices_malloc_size(size)
-    size * @indices_bytesize
+    size.to_u64 * @indices_bytesize
   end
 
   # Reallocates `size` number of indices for `@indices`.


### PR DESCRIPTION
fixes #15341

See https://github.com/crystal-lang/crystal/issues/15341#issuecomment-2589582505 for details.