### PR TITLE
Fix GC `sig_suspend`, `sig_resume` for `gc_none`

### DIFF
--- a/src/crystal/system/unix/pthread.cr
+++ b/src/crystal/system/unix/pthread.cr
@@ -269,16 +269,16 @@ module Crystal::System::Thread
     {% end %}
 
   def self.sig_suspend : ::Signal
-    if GC.responds_to?(:sig_suspend)
-      GC.sig_suspend
+    if (gc = GC).responds_to?(:sig_suspend)
+      gc.sig_suspend
     else
       ::Signal.new(SIG_SUSPEND)
     end
   end
 
   def self.sig_resume : ::Signal
-    if GC.responds_to?(:sig_resume)
-      GC.sig_resume
+    if (gc = GC).responds_to?(:sig_resume)
+      gc.sig_resume
     else
       ::Signal.new(SIG_RESUME)
     end


### PR DESCRIPTION
The gc_none interface doesn't define the `sig_suspend` nor `sig_resume` class methods. The program should still compile but commit 57017f6 improperly checks for the method existence, and the methods are always required and compilation fails.

The following is enough to reproduce:

```console
$ bin/crystal spec -Dgc_none spec/std/process_spec.cr
In src/crystal/system/unix/pthread.cr:273:10

 273 | GC.sig_suspend
          ^----------
Error: undefined method 'sig_suspend' for GC:Module
```

Closes https://github.com/ysbaddaden/gc/issues/32