### PR TITLE
Fix code example in `Process::Status#exit_code` docs

### DIFF
--- a/src/process/status.cr
+++ b/src/process/status.cr
@@ -245,7 +245,7 @@ class Process::Status
   # Raises `RuntimeError` if the status describes an abnormal exit.
   #
   # ```
-  # Process.run("true").exit_code                                # => 1
+  # Process.run("true").exit_code                                # => 0
   # Process.run("exit 123", shell: true).exit_code               # => 123
   # Process.new("sleep", ["10"]).tap(&.terminate).wait.exit_code # RuntimeError: Abnormal exit has no exit code
   # ```
@@ -258,7 +258,7 @@ class Process::Status
   # Returns `nil` if the status describes an abnormal exit.
   #
   # ```
-  # Process.run("true").exit_code?                                # => 1
+  # Process.run("true").exit_code?                                # => 0
   # Process.run("exit 123", shell: true).exit_code?               # => 123
   # Process.new("sleep", ["10"]).tap(&.terminate).wait.exit_code? # => nil
   # ```


### PR DESCRIPTION
OR?

```crystal
Process.run("false").exit_code # => 1
```