### PR TITLE
Add `LLVM.version`

### DIFF
--- a/spec/std/llvm/llvm_spec.cr
+++ b/spec/std/llvm/llvm_spec.cr
@@ -2,6 +2,10 @@ require "spec"
 require "llvm"
 
 describe LLVM do
+  it ".version" do
+    LLVM.version.should eq LibLLVM::VERSION
+  end
+
   describe ".normalize_triple" do
     it "works" do
       LLVM.normalize_triple("x86_64-apple-macos").should eq("x86_64-apple-macos")

--- a/src/compiler/crystal/config.cr
+++ b/src/compiler/crystal/config.cr
@@ -10,15 +10,6 @@ module Crystal
       {{ read_file("#{__DIR__}/../../VERSION").chomp }}
     end
 
-    def self.llvm_version
-      {% if LibLLVM.has_method?(:get_version) %}
-        LibLLVM.get_version(out major, out minor, out patch)
-        "#{major}.#{minor}.#{patch}"
-      {% else %}
-        LibLLVM::VERSION
-      {% end %}
-    end
-
     def self.description
       String.build do |io|
         io << "Crystal " << version
@@ -27,7 +18,7 @@ module Crystal
 
         io << "\n\nThe compiler was not built in release mode." unless release_mode?
 
-        io << "\n\nLLVM: " << llvm_version
+        io << "\n\nLLVM: " << LLVM.version
         io << "\nDefault target: " << host_target
         io << "\n"
       end

--- a/src/compiler/crystal/program.cr
+++ b/src/compiler/crystal/program.cr
@@ -316,7 +316,7 @@ module Crystal
       define_crystal_string_constant "VERSION", Crystal::Config.version, <<-MD
         The version of the Crystal compiler.
         MD
-      define_crystal_string_constant "LLVM_VERSION", Crystal::Config.llvm_version, <<-MD
+      define_crystal_string_constant "LLVM_VERSION", LLVM.version, <<-MD
         The version of LLVM used by the Crystal compiler.
         MD
       define_crystal_string_constant "HOST_TRIPLE", Crystal::Config.host_target.to_s, <<-MD

--- a/src/llvm.cr
+++ b/src/llvm.cr
@@ -4,6 +4,22 @@ require "c/string"
 module LLVM
   @@initialized = false
 
+  # Returns the runtime version of LLVM.
+  #
+  # Starting with LLVM 16, this method returns the version as reported by
+  # `LLVMGetVersion` at runtime. Older versions of LLVM do not expose this
+  # information, so the value falls back to `LibLLVM::VERSION` which is
+  # determined at compile time and might slightly be out of sync to the
+  # dynamic library loaded at runtime.
+  def self.version
+    {% if LibLLVM.has_method?(:get_version) %}
+      LibLLVM.get_version(out major, out minor, out patch)
+      "#{major}.#{minor}.#{patch}"
+    {% else %}
+      LibLLVM::VERSION
+    {% end %}
+  end
+
   def self.init_x86 : Nil
     return if @@initialized_x86
     @@initialized_x86 = true


### PR DESCRIPTION
Adds a new public method `LLVM.version` which returns the runtime version of libllvm (via `LLVMGetVersion` if available)
<del>And we use that method in the compiller for `crystal --version` and the `Crystal::LLVM_VERSION` constant.</del>
