### PR TITLE
Fix query runtime version of LLVM

### DIFF
--- a/src/compiler/crystal/config.cr
+++ b/src/compiler/crystal/config.cr
@@ -11,7 +11,12 @@ module Crystal
     end
 
     def self.llvm_version
-      LibLLVM::VERSION
+      {% if LibLLVM.has_method?(:get_version) %}
+        LibLLVM.get_version(out major, out minor, out patch)
+        "#{major}.#{minor}.#{patch}"
+      {% else %}
+        LibLLVM::VERSION
+      {% end %}
     end
 
     def self.description

--- a/src/llvm/lib_llvm/core.cr
+++ b/src/llvm/lib_llvm/core.cr
@@ -17,6 +17,10 @@ lib LibLLVM
 
   fun dispose_message = LLVMDisposeMessage(message : Char*)
 
+  {% unless LibLLVM::IS_LT_160 %}
+    fun get_version = LLVMGetVersion(major : UInt*, minor : UInt*, patch : UInt*) : Void
+  {% end %}
+
   fun create_context = LLVMContextCreate : ContextRef
   fun dispose_context = LLVMContextDispose(c : ContextRef)
 


### PR DESCRIPTION
Use the runtime version of libllvm (via `LLVMGetVersion`, if available) for `crystal --version` and `Crystal::LLVM_VERSION` constant. The version of a dynamically loaded library might differ from `LibLLVM::VERSION` which is the version at build time.

Resolves #15353