### PR TITLE
`Reference#exec_recursive[_clone]` aren't fiber aware

### DIFF
--- a/src/fiber.cr
+++ b/src/fiber.cr
@@ -339,7 +339,7 @@ class Fiber
   # :nodoc:
   #
   # Protects `Reference#inspect` and `Reference#pretty_print` against recursion.
-  def exec_recursive(object_id : UInt64, method : Symbol, &) : Bool
+  def exec_recursive(object_id : UInt64, method : Symbol, &)
     # NOTE: can't use `Set` because of prelude require order
     hash = (@exec_recursive ||= Hash({UInt64, Symbol}, Nil).new)
     key = {object_id, method}
@@ -355,14 +355,14 @@ class Fiber
   #
   # Protects `Reference#clone` implementations against recursion. See
   # `Reference#exec_recursive_clone` for more details.
-  def exec_recursive_clone(object_id : UInt64, &) : Bool
+  def exec_recursive_clone(object_id : UInt64, &)
     # NOTE: can't use `Set` because of prelude require order
-    hash = (@exec_recursive_clone ||= Hash(UInt64, Nil).new)
-    hash.put(object_id, nil) do
-      yield
+    hash = (@exec_recursive_clone ||= Hash(UInt64, UInt64).new)
+    clone_object_id = hash[object_id]?
+    unless clone_object_id
+      clone_object_id = yield(hash).object_id
       hash.delete(object_id)
-      return true
     end
-    false
+    Pointer(Void).new(clone_object_id)
   end
 end

--- a/src/reference.cr
+++ b/src/reference.cr
@@ -199,6 +199,7 @@ class Reference
   # end
   # ```
   private def exec_recursive_clone(&)
-    Fiber.current.exec_recursive_clone(object_id) { yield }
+    pointer = Fiber.current.exec_recursive_clone(object_id) { |hash| yield hash }
+    pointer.as(self)
   end
 end


### PR DESCRIPTION
Recursion of the `#inspect` and `#pretty_print` methods is handled by a global hash, which is a per-thread global, but if any of these methods yield —which will happen because they're writing to an IO— another fiber running on the same thread will falsely detect a recursion if it inspects the same object.

This patch moves `Reference#exec_recursive` methods as instances of `Fiber`, using a per-fiber hash instead of per-thread/process hash.

The example from #15088 now correctly prints:

```
0: [YieldInspect]
1: [YieldInspect]
```