### PR TITLE
Corrects Windows lib lookup in case-sensitive OSes

### DIFF
--- a/src/lib_c/x86_64-windows-msvc/c/libloaderapi.cr
+++ b/src/lib_c/x86_64-windows-msvc/c/libloaderapi.cr
@@ -1,6 +1,6 @@
 require "c/winnt"
 
-@[Link("Kernel32")]
+@[Link("kernel32")]
 lib LibC
   alias FARPROC = Void*
 

--- a/src/lib_c/x86_64-windows-msvc/c/winsock2.cr
+++ b/src/lib_c/x86_64-windows-msvc/c/winsock2.cr
@@ -3,7 +3,7 @@ require "./basetsd"
 require "./guiddef"
 require "./winbase"
 
-@[Link("WS2_32")]
+@[Link("ws2_32")]
 lib LibC
   alias SOCKET = UINT_PTR
 


### PR DESCRIPTION
Downcase name of Windows import libraries to avoid duplicates references (Eg. kernel32 and Kernel32) but to correctly find the libraries on case-sensitive filesystems, like when cross-compiling from Linux.

While on Windows `Kernel32` and `kernel32` result in the correct library found for linking, it does not work the same way when cross-compiling.

This also applies to Winsock2 (ws2_32) usage.

The change normalizes on the usage of downcased names for these libraries (which will have no impact when compiling natively on Windows).

Prior to this change:

```console
$ crystal build --cross-compile --target x86_64-windows-gnu 1.cr
cc 1.obj -o 1  -Wl,--stack,0x800000 -L/usr/local/bin/../lib/crystal -lgc -lpthread \
  -ldl -municode -lntdll -liconv -ladvapi32 -lshell32 \
  -lole32 -lWS2_32 -lkernel32 -lKernel32
```

After:

```console
$ crystal build --cross-compile --target x86_64-windows-gnu 1.cr
cc 1.obj -o 1  -Wl,--stack,0x800000 -L/usr/local/bin/../lib/crystal -lgc -lpthread \
  -ldl -municode -lntdll -liconv -ladvapi32 -lshell32 \
  -lole32 -lws2_32 -lkernel32
```