### PR TITLE
Fix invalid returns in class getter's lazy evaluation blocks

### DIFF
--- a/spec/std/socket/spec_helper.cr
+++ b/spec/std/socket/spec_helper.cr
@@ -2,8 +2,6 @@ require "spec"
 require "socket"
 
 module SocketSpecHelper
-  @@supports_ipv6 : Bool?
-
   class_getter?(supports_ipv6 : Bool) { detect_supports_ipv6? }
 
   private def self.detect_supports_ipv6? : Bool

--- a/spec/std/socket/spec_helper.cr
+++ b/spec/std/socket/spec_helper.cr
@@ -2,7 +2,11 @@ require "spec"
 require "socket"
 
 module SocketSpecHelper
-  class_getter?(supports_ipv6 : Bool) do
+  @@supports_ipv6 : Bool?
+
+  class_getter?(supports_ipv6 : Bool) { detect_supports_ipv6? }
+
+  private def self.detect_supports_ipv6? : Bool
     TCPServer.open("::1", 0) { return true }
     false
   rescue Socket::Error

--- a/spec/support/time.cr
+++ b/spec/support/time.cr
@@ -72,7 +72,9 @@ end
     # Enable the `SeTimeZonePrivilege` privilege before changing the system time
     # zone. This is necessary because the privilege is by default granted but
     # disabled for any new process. This only needs to be done once per run.
-    class_getter? time_zone_privilege_enabled : Bool do
+    class_getter?(time_zone_privilege_enabled : Bool) { detect_time_zone_privilege_enabled? }
+
+    private def self.detect_time_zone_privilege_enabled? : Bool
       if LibC.LookupPrivilegeValueW(nil, SeTimeZonePrivilege, out time_zone_luid) == 0
         raise RuntimeError.from_winerror("LookupPrivilegeValueW")
       end


### PR DESCRIPTION
Using `return` in a class getter will immediately return from the generated method, never setting the class variable to the returned value, which is kept `nil` so the initializer code is called repeatedly instead of being called _once_ then cached.

Extracted from #15340 