### PR TITLE
Explicit `Crystal.once_init` method

### DIFF
--- a/src/compiler/crystal/codegen/once.cr
+++ b/src/compiler/crystal/codegen/once.cr
@@ -5,20 +5,16 @@ class Crystal::CodeGenVisitor
 
   def once_init
     if once_init_fun = typed_fun?(@main_mod, ONCE_INIT)
+      # legacy (kept for backward compatibility): the compiler must save the
+      # state returned by __crystal_once_init
       once_init_fun = check_main_fun ONCE_INIT, once_init_fun
 
-      if once_init_fun.type.return_type.void?
-        call once_init_fun
-      else
-        # legacy (kept for backward compatibility): the compiler must save the
-        # state returned by __crystal_once_init
-        once_state_global = @main_mod.globals.add(once_init_fun.type.return_type, ONCE_STATE)
-        once_state_global.linkage = LLVM::Linkage::Internal if @single_module
-        once_state_global.initializer = once_init_fun.type.return_type.null
+      once_state_global = @main_mod.globals.add(once_init_fun.type.return_type, ONCE_STATE)
+      once_state_global.linkage = LLVM::Linkage::Internal if @single_module
+      once_state_global.initializer = once_init_fun.type.return_type.null
 
-        state = call once_init_fun
-        store state, once_state_global
-      end
+      state = call once_init_fun
+      store state, once_state_global
     end
   end
 

--- a/src/crystal/main.cr
+++ b/src/crystal/main.cr
@@ -53,9 +53,10 @@ module Crystal
   # :nodoc:
   def self.init_runtime : Nil
     # `__crystal_once` directly or indirectly depends on `Fiber` and `Thread`
-    # so we explicitly initialize their class vars
+    # so we explicitly initialize their class vars, then init crystal/once
     Thread.init
     Fiber.init
+    Crystal.once_init
   end
 
   # :nodoc:


### PR DESCRIPTION
Adds `Crystal.once_init` that allows to remove the `Crystal.once_mutex=` setter.

It also removes the need for the `__crystal_once_init` fun that won't be defined anymore —it's only kept for the legacy implementation. This is one less compiler dependency on runtime.

Follow up to #15369