### PR TITLE
[CI] Add workflow for backporting PRs to release branches

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -1,0 +1,33 @@
+# WARNING:
+# When extending this action, be aware that $GITHUB_TOKEN allows write access to
+# the GitHub repository. This means that it should not evaluate user input in a
+# way that allows code injection.
+
+name: Backport
+
+on:
+  pull_request_target:
+    types: [closed, labeled]
+
+permissions:
+  contents: write # so it can comment
+  pull-requests: write # so it can create pull requests
+
+jobs:
+  backport:
+    name: Backport Pull Request
+    if: github.repository_owner == 'crystal-lang' && github.event.pull_request.merged == true && (github.event_name != 'labeled' || startsWith('backport', github.event.label.name))
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+
+      - name: Create backport PR
+        uses: korthout/backport-action@be567af183754f6a5d831ae90f648954763f17f5 # v3.1.0
+        with:
+          # Config README: https://github.com/korthout/backport-action#backport-action
+          copy_labels_pattern: '^(breaking-change|security|topic:.*|kind:.*|platform:.*)$'
+          copy_milestone: true
+          pull_description: |-
+            Automated backport of #${pull_number} to `${target_branch}`, triggered by a label.


### PR DESCRIPTION
Use https://github.com/korthout/backport-action to backport PRs to release branches.
The workflow is triggered when a PR is merged and has a label `backport $branch` or when such a label is added to a merged PR.