### PR TITLE
[CI] Use personal access token for backport workflow [fixup #15372]

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -22,10 +22,12 @@ jobs:
       - uses: actions/checkout@v4
         with:
           ref: ${{ github.event.pull_request.head.sha }}
+          token: ${{ secrets.BACKPORT_ACTION_GITHUB_PAT }}
 
       - name: Create backport PR
         uses: korthout/backport-action@be567af183754f6a5d831ae90f648954763f17f5 # v3.1.0
         with:
+          github_token: ${{ secrets.BACKPORT_ACTION_GITHUB_PAT }}
           # Config README: https://github.com/korthout/backport-action#backport-action
           copy_labels_pattern: '^(breaking-change|security|topic:.*|kind:.*|platform:.*)$'
           copy_milestone: true


### PR DESCRIPTION
This is a fixup for #15372.
The backport workflow by default doesn't have authorization to update workflow files in the repository (see https://github.com/korthout/backport-action/issues/368). But workflow file updates are common in backported PRs.
As a workaround, we can use a personal access token with approriate permissions.