### PR TITLE
Add docs to enum member helper methods

### DIFF
--- a/spec/compiler/semantic/enum_spec.cr
+++ b/spec/compiler/semantic/enum_spec.cr
@@ -623,7 +623,7 @@ describe "Semantic: enum" do
     CRYSTAL
 
     a_defs = result.program.types["Foo"].lookup_defs("bar?")
-    a_defs.first.doc.should_not be_nil
+    a_defs.first.doc.should eq("Returns `true` if this enum value equals `Bar`")
   end
 
   it "marks helper methods with `:nodoc:` if the member is `:nodoc:`" do
@@ -635,6 +635,6 @@ describe "Semantic: enum" do
     CRYSTAL
 
     a_defs = result.program.types["Foo"].lookup_defs("bar?")
-    a_defs.first.doc.try &.starts_with?(":nodoc:").should be_true
+    a_defs.first.doc.should eq(":nodoc:")
   end
 end

--- a/spec/compiler/semantic/enum_spec.cr
+++ b/spec/compiler/semantic/enum_spec.cr
@@ -613,4 +613,28 @@ describe "Semantic: enum" do
     a_def = result.program.types["Foo"].lookup_defs("foo").first
     a_def.previous.should be_nil
   end
+
+  it "adds docs to helper methods" do
+    result = top_level_semantic <<-CRYSTAL, wants_doc: true
+    enum Foo
+      # These are the docs for `Bar`
+      Bar = 1
+    end
+    CRYSTAL
+
+    a_defs = result.program.types["Foo"].lookup_defs("bar?")
+    a_defs.first.doc.should_not be_nil
+  end
+
+  it "marks helper methods with `:nodoc:` if the member is `:nodoc:`" do
+    result = top_level_semantic <<-CRYSTAL, wants_doc: true
+    enum Foo
+      # :nodoc:
+      Bar = 1
+    end
+    CRYSTAL
+
+    a_defs = result.program.types["Foo"].lookup_defs("bar?")
+    a_defs.first.doc.try &.starts_with?(":nodoc:").should be_true
+  end
 end

--- a/src/compiler/crystal/semantic/top_level_visitor.cr
+++ b/src/compiler/crystal/semantic/top_level_visitor.cr
@@ -824,10 +824,13 @@ class Crystal::TopLevelVisitor < Crystal::SemanticVisitor
     method_name = is_flags ? "includes?" : "=="
     body = Call.new(Var.new("self").at(member), method_name, Path.new(member.name).at(member)).at(member)
     a_def = Def.new("#{member.name.underscore}?", body: body).at(member)
-    a_def.doc = <<-DOC
-    #{":nodoc:" if member.doc.try &.starts_with?(":nodoc:")}
-    Returns `true` if this enum value #{is_flags ? "contains" : "equals"} `#{member.name}`
-    DOC
+
+    a_def.doc = if member.doc.try &.starts_with?(":nodoc:")
+                  ":nodoc:"
+                else
+                  "Returns `true` if this enum value #{is_flags ? "contains" : "equals"} `#{member.name}`"
+                end
+
     enum_type.add_def a_def
   end
 

--- a/src/compiler/crystal/semantic/top_level_visitor.cr
+++ b/src/compiler/crystal/semantic/top_level_visitor.cr
@@ -824,6 +824,10 @@ class Crystal::TopLevelVisitor < Crystal::SemanticVisitor
     method_name = is_flags ? "includes?" : "=="
     body = Call.new(Var.new("self").at(member), method_name, Path.new(member.name).at(member)).at(member)
     a_def = Def.new("#{member.name.underscore}?", body: body).at(member)
+    a_def.doc = <<-DOC
+    #{":nodoc:" if member.doc.try &.starts_with?(":nodoc:")}
+    Returns `true` if this enum value #{is_flags ? "contains" : "equals"} `#{member.name}`
+    DOC
     enum_type.add_def a_def
   end
 


### PR DESCRIPTION
Mark these methods as nodoc if the member is nodoc.

Closes #11333 