### PR TITLE
Refactor Object getter/property macros to remove duplications

### DIFF
--- a/src/crystal/properties.cr
+++ b/src/crystal/properties.cr
@@ -1,0 +1,90 @@
+# Macro helpers to implement the getter and property macros on `Object`.
+
+module Crystal
+  {% for prefixes in { {"", "", "@", "#"}, {"class_", "self.", "@@", "."} } %}
+    {%
+      macro_prefix = prefixes[0].id
+      method_prefix = prefixes[1].id
+      var_prefix = prefixes[2].id
+      doc_prefix = prefixes[3]
+    %}
+
+    # :nodoc:
+    macro def_{{macro_prefix}}var(name, nilable)
+      \{% if name.is_a?(TypeDeclaration) %}
+        \{% if nilable %}
+          {{var_prefix}}\{{name.var.id}} : \{{name.type}}? \{% if name.value %} = \{{name.value}} \{% end %}
+        \{% else %}
+          {{var_prefix}}\{{name}}
+        \{% end %}
+      \{% elsif name.is_a?(Assign) %}
+        {{var_prefix}}\{{name}}
+      \{% end %}
+    end
+
+    {% for suffix in {"", "?"} %}
+      # :nodoc:
+      macro def_{{macro_prefix}}getter{{suffix.id}}(name, &block)
+        \{% if name.is_a?(TypeDeclaration) %}
+          \{% var_name = name.var.id %}
+          \{% type = name.type %}
+        \{% elsif name.is_a?(Assign) %}
+          \{% var_name = name.target %}
+          \{% type = nil %}
+        \{% else %}
+          \{% var_name = name.id %}
+          \{% type = nil %}
+        \{% end %}
+
+        def {{method_prefix}}\{{var_name}}{{suffix.id}} \{% if type %} : \{{type}} \{% end %}
+          \{% if block %}
+            if (\%value = {{var_prefix}}\{{var_name}}).nil?
+              {{var_prefix}}\{{var_name}} = \{{yield}}
+            else
+              \%value
+            end
+          \{% else %}
+            {{var_prefix}}\{{var_name}}
+          \{% end %}
+        end
+      end
+    {% end %}
+
+    # :nodoc:
+    macro def_{{macro_prefix}}getter!(klass, name)
+      \{% if name.is_a?(TypeDeclaration) %}
+        \{% var_name = name.var.id %}
+        \{% type = name.type %}
+      \{% else %}
+        \{% var_name = name.id %}
+        \{% type = nil %}
+      \{% end %}
+
+      def {{method_prefix}}\{{var_name}}? \{% if type %} : \{{type}}? \{% end %}
+        {{var_prefix}}\{{var_name}}
+      end
+
+      def {{method_prefix}}\{{var_name}} \{% if type %} : \{{type}} \{% end %}
+        if (%value = {{var_prefix}}\{{var_name}}).nil?
+          ::raise ::NilAssertionError.new(\{{"#{klass.id}#{{{doc_prefix}}.id}#{var_name} cannot be nil"}})
+        else
+          %value
+        end
+      end
+    end
+
+    # :nodoc:
+    macro def_{{macro_prefix}}setter(name)
+      \{% if name.is_a?(TypeDeclaration) %}
+        def {{method_prefix}}\{{name.var.id}}=({{var_prefix}}\{{name.var.id}} : \{{name.type}})
+        end
+      \{% elsif name.is_a?(Assign) %}
+        def {{method_prefix}}\{{name.target.id}}=({{var_prefix}}\{{name.target.id}})
+        end
+      \{% else %}
+        def {{method_prefix}}\{{name.id}}=({{var_prefix}}\{{name.id}})
+        end
+      \{% end %}
+    end
+  {% end %}
+end

--- a/src/object.cr
+++ b/src/object.cr
@@ -1,3 +1,5 @@
+require "crystal/properties"
+
 # `Object` is the base type of all Crystal objects.
 class Object
   # Returns `true` if this object is equal to *other*.
@@ -324,12 +326,11 @@ class Object
     pointerof(x).as(T*).value
   end
 
-  {% for prefixes in { {"", "", "@", "#"}, {"class_", "self.", "@@", "."} } %}
+  {% for prefixes in { {"", "", "@"}, {"class_", "self.", "@@"} } %}
     {%
       macro_prefix = prefixes[0].id
       method_prefix = prefixes[1].id
       var_prefix = prefixes[2].id
-      doc_prefix = prefixes[3].id
     %}
 
     # Defines getter methods for each of the given arguments.
@@ -446,140 +447,10 @@ class Object
     # end
     # ```
     macro {{macro_prefix}}getter(*names, &block)
-      \{% if block %}
-        \{% if names.size != 1 %}
-          \{{ raise "Only one argument can be passed to `getter` with a block" }}
-        \{% end %}
-
-        \{% name = names[0] %}
-
-        \{% if name.is_a?(TypeDeclaration) %}
-          {{var_prefix}}\{{name.var.id}} : \{{name.type}}?
-
-          def {{method_prefix}}\{{name.var.id}} : \{{name.type}}
-            if (%value = {{var_prefix}}\{{name.var.id}}).nil?
-              {{var_prefix}}\{{name.var.id}} = \{{yield}}
-            else
-              %value
-            end
-          end
-        \{% else %}
-          def {{method_prefix}}\{{name.id}}
-            if (%value = {{var_prefix}}\{{name.id}}).nil?
-              {{var_prefix}}\{{name.id}} = \{{yield}}
-            else
-              %value
-            end
-          end
-        \{% end %}
-      \{% else %}
-        \{% for name in names %}
-          \{% if name.is_a?(TypeDeclaration) %}
-            {{var_prefix}}\{{name}}
-
-            def {{method_prefix}}\{{name.var.id}} : \{{name.type}}
-              {{var_prefix}}\{{name.var.id}}
-            end
-          \{% elsif name.is_a?(Assign) %}
-            {{var_prefix}}\{{name}}
-
-            def {{method_prefix}}\{{name.target.id}}
-              {{var_prefix}}\{{name.target.id}}
-            end
-          \{% else %}
-            def {{method_prefix}}\{{name.id}}
-              {{var_prefix}}\{{name.id}}
-            end
-          \{% end %}
-        \{% end %}
-      \{% end %}
-    end
-
-    # Defines raise-on-nil and nilable getter methods for each of the given arguments.
-    #
-    # Writing:
-    #
-    # ```
-    # class Person
-    #   {{macro_prefix}}getter! name
-    # end
-    # ```
-    #
-    # Is the same as writing:
-    #
-    # ```
-    # class Person
-    #   def {{method_prefix}}name?
-    #     {{var_prefix}}name
-    #   end
-    #
-    #   def {{method_prefix}}name
-    #     {{var_prefix}}name.not_nil!
-    #   end
-    # end
-    # ```
-    #
-    # The arguments can be string literals, symbol literals or plain names:
-    #
-    # ```
-    # class Person
-    #   {{macro_prefix}}getter! :name, "age"
-    # end
-    # ```
-    #
-    # If a type declaration is given, a variable with that name
-    # is declared with that type, as nilable.
-    #
-    # ```
-    # class Person
-    #   {{macro_prefix}}getter! name : String
-    # end
-    # ```
-    #
-    # is the same as writing:
-    #
-    # ```
-    # class Person
-    #   {{var_prefix}}name : String?
-    #
-    #   def {{method_prefix}}name?
-    #     {{var_prefix}}name
-    #   end
-    #
-    #   def {{method_prefix}}name
-    #     {{var_prefix}}name.not_nil!
-    #   end
-    # end
-    # ```
-    macro {{macro_prefix}}getter!(*names)
-      \{% for name in names %}
-        \{% if name.is_a?(TypeDeclaration) %}
-          {{var_prefix}}\{{name}}?
-
-          def {{method_prefix}}\{{name.var.id}}? : \{{name.type}}?
-            {{var_prefix}}\{{name.var.id}}
-          end
-
-          def {{method_prefix}}\{{name.var.id}} : \{{name.type}}
-            if (%value = {{var_prefix}}\{{name.var.id}}).nil?
-              ::raise ::NilAssertionError.new("\{{@type}}\{{"{{doc_prefix}}".id}}\{{name.var.id}} cannot be nil")
-            else
-              %value
-            end
-          end
-        \{% else %}
-          def {{method_prefix}}\{{name.id}}?
-            {{var_prefix}}\{{name.id}}
-          end
-
-          def {{method_prefix}}\{{name.id}}
-            if (%value = {{var_prefix}}\{{name.id}}).nil?
-              ::raise ::NilAssertionError.new("\{{@type}}\{{"{{doc_prefix}}".id}}\{{name.id}} cannot be nil")
-            else
-              %value
-            end
-          end
-        \{% end %}
+      \{% raise "Only one argument can be passed to `{{macro_prefix}}getter` with a block" if block && names.size > 1 %}
+      \{% for name, index in names %}
+        ::Crystal.def_{{macro_prefix}}var(\{{name}}, \{{!!block}})
+        ::Crystal.def_{{macro_prefix}}getter(\{{name}}) \{% if block %} { \{{yield}} } \{% end %}
       \{% end %}
     end
 
@@ -673,160 +544,14 @@ class Object
     # end
     # ```
     #
-    # If a block is given to the macro, a getter is generated
-    # with a variable that is lazily initialized with
-    # the block's contents, for examples see `#{{macro_prefix}}getter`.
+    # If a block is given to the macro, a getter is generated with a variable
+    # that is lazily initialized with the block's contents, for examples see
+    # `#{{macro_prefix}}getter`.
     macro {{macro_prefix}}getter?(*names, &block)
-      \{% if block %}
-        \{% if names.size != 1 %}
-          \{{ raise "Only one argument can be passed to `getter?` with a block" }}
-        \{% end %}
-
-        \{% name = names[0] %}
-
-        \{% if name.is_a?(TypeDeclaration) %}
-          {{var_prefix}}\{{name.var.id}} : \{{name.type}}?
-
-          def {{method_prefix}}\{{name.var.id}}? : \{{name.type}}
-            if (%value = {{var_prefix}}\{{name.var.id}}).nil?
-              {{var_prefix}}\{{name.var.id}} = \{{yield}}
-            else
-              %value
-            end
-          end
-        \{% else %}
-          def {{method_prefix}}\{{name.id}}?
-            if (%value = {{var_prefix}}\{{name.id}}).nil?
-              {{var_prefix}}\{{name.id}} = \{{yield}}
-            else
-              %value
-            end
-          end
-        \{% end %}
-      \{% else %}
-        \{% for name in names %}
-          \{% if name.is_a?(TypeDeclaration) %}
-            {{var_prefix}}\{{name}}
-
-            def {{method_prefix}}\{{name.var.id}}? : \{{name.type}}
-              {{var_prefix}}\{{name.var.id}}
-            end
-          \{% elsif name.is_a?(Assign) %}
-            {{var_prefix}}\{{name}}
-
-            def {{method_prefix}}\{{name.target.id}}?
-              {{var_prefix}}\{{name.target.id}}
-            end
-          \{% else %}
-            def {{method_prefix}}\{{name.id}}?
-              {{var_prefix}}\{{name.id}}
-            end
-          \{% end %}
-        \{% end %}
-      \{% end %}
-    end
-
-    # Defines setter methods for each of the given arguments.
-    #
-    # Writing:
-    #
-    # ```
-    # class Person
-    #   {{macro_prefix}}setter name
-    # end
-    # ```
-    #
-    # Is the same as writing:
-    #
-    # ```
-    # class Person
-    #   def {{method_prefix}}name=({{var_prefix}}name)
-    #   end
-    # end
-    # ```
-    #
-    # The arguments can be string literals, symbol literals or plain names:
-    #
-    # ```
-    # class Person
-    #   {{macro_prefix}}setter :name, "age"
-    # end
-    # ```
-    #
-    # If a type declaration is given, a variable with that name
-    # is declared with that type.
-    #
-    # ```
-    # class Person
-    #   {{macro_prefix}}setter name : String
-    # end
-    # ```
-    #
-    # is the same as writing:
-    #
-    # ```
-    # class Person
-    #   {{var_prefix}}name : String
-    #
-    #   def {{method_prefix}}name=({{var_prefix}}name : String)
-    #   end
-    # end
-    # ```
-    #
-    # The type declaration can also include an initial value:
-    #
-    # ```
-    # class Person
-    #   {{macro_prefix}}setter name : String = "John Doe"
-    # end
-    # ```
-    #
-    # Is the same as writing:
-    #
-    # ```
-    # class Person
-    #   {{var_prefix}}name : String = "John Doe"
-    #
-    #   def {{method_prefix}}name=({{var_prefix}}name : String)
-    #   end
-    # end
-    # ```
-    #
-    # An assignment can be passed too, but in this case the type of the
-    # variable must be easily inferable from the initial value:
-    #
-    # ```
-    # class Person
-    #   {{macro_prefix}}setter name = "John Doe"
-    # end
-    # ```
-    #
-    # Is the same as writing:
-    #
-    # ```
-    # class Person
-    #   {{var_prefix}}name = "John Doe"
-    #
-    #   def {{method_prefix}}name=({{var_prefix}}name)
-    #   end
-    # end
-    # ```
-    macro {{macro_prefix}}setter(*names)
-      \{% for name in names %}
-        \{% if name.is_a?(TypeDeclaration) %}
-          {{var_prefix}}\{{name}}
-
-          def {{method_prefix}}\{{name.var.id}}=({{var_prefix}}\{{name.var.id}} : \{{name.type}})
-          end
-        \{% elsif name.is_a?(Assign) %}
-          {{var_prefix}}\{{name}}
-
-          def {{method_prefix}}\{{name.target.id}}=({{var_prefix}}\{{name.target.id}})
-          end
-        \{% else %}
-          def {{method_prefix}}\{{name.id}}=({{var_prefix}}\{{name.id}})
-          end
-        \{% end %}
+      \{% raise "Only one argument can be passed to `{{macro_prefix}}getter?` with a block" if block && names.size > 1 %}
+      \{% for name, index in names %}
+        ::Crystal.def_{{macro_prefix}}var(\{{name}}, \{{!!block}})
+        ::Crystal.def_{{macro_prefix}}getter?(\{{name}}) \{% if block %} { \{{yield}} } \{% end %}
       \{% end %}
     end
 
@@ -959,143 +684,11 @@ class Object
     # end
     # ```
     macro {{macro_prefix}}property(*names, &block)
-      \{% if block %}
-        \{% if names.size != 1 %}
-          \{{ raise "Only one argument can be passed to `property` with a block" }}
-        \{% end %}
-
-        \{% name = names[0] %}
-
-        \{% if name.is_a?(TypeDeclaration) %}
-          {{var_prefix}}\{{name.var.id}} : \{{name.type}}?
-
-          def {{method_prefix}}\{{name.var.id}} : \{{name.type}}
-            if (%value = {{var_prefix}}\{{name.var.id}}).nil?
-              {{var_prefix}}\{{name.var.id}} = \{{yield}}
-            else
-              %value
-            end
-          end
-
-          def {{method_prefix}}\{{name.var.id}}=({{var_prefix}}\{{name.var.id}} : \{{name.type}})
-          end
-        \{% else %}
-          def {{method_prefix}}\{{name.id}}
-            if (%value = {{var_prefix}}\{{name.id}}).nil?
-              {{var_prefix}}\{{name.id}} = \{{yield}}
-            else
-              %value
-            end
-          end
-
-          def {{method_prefix}}\{{name.id}}=({{var_prefix}}\{{name.id}})
-          end
-        \{% end %}
-      \{% else %}
-        \{% for name in names %}
-          \{% if name.is_a?(TypeDeclaration) %}
-            {{var_prefix}}\{{name}}
-
-            def {{method_prefix}}\{{name.var.id}} : \{{name.type}}
-              {{var_prefix}}\{{name.var.id}}
-            end
-
-            def {{method_prefix}}\{{name.var.id}}=({{var_prefix}}\{{name.var.id}} : \{{name.type}})
-            end
-          \{% elsif name.is_a?(Assign) %}
-            {{var_prefix}}\{{name}}
-
-            def {{method_prefix}}\{{name.target.id}}
-              {{var_prefix}}\{{name.target.id}}
-            end
-
-            def {{method_prefix}}\{{name.target.id}}=({{var_prefix}}\{{name.target.id}})
-            end
-          \{% else %}
-            def {{method_prefix}}\{{name.id}}
-              {{var_prefix}}\{{name.id}}
-            end
-
-            def {{method_prefix}}\{{name.id}}=({{var_prefix}}\{{name.id}})
-            end
-          \{% end %}
-        \{% end %}
-      \{% end %}
-    end
-
-    # Defines raise-on-nil property methods for each of the given arguments.
-    #
-    # Writing:
-    #
-    # ```
-    # class Person
-    #   {{macro_prefix}}property! name
-    # end
-    # ```
-    #
-    # Is the same as writing:
-    #
-    # ```
-    # class Person
-    #   def {{method_prefix}}name=({{var_prefix}}name)
-    #   end
-    #
-    #   def {{method_prefix}}name?
-    #     {{var_prefix}}name
-    #   end
-    #
-    #   def {{method_prefix}}name
-    #     {{var_prefix}}name.not_nil!
-    #   end
-    # end
-    # ```
-    #
-    # The arguments can be string literals, symbol literals or plain names:
-    #
-    # ```
-    # class Person
-    #   {{macro_prefix}}property! :name, "age"
-    # end
-    # ```
-    #
-    # If a type declaration is given, a variable with that name
-    # is declared with that type, as nilable.
-    #
-    # ```
-    # class Person
-    #   {{macro_prefix}}property! name : String
-    # end
-    # ```
-    #
-    # Is the same as writing:
-    #
-    # ```
-    # class Person
-    #   {{var_prefix}}name : String?
-    #
-    #   def {{method_prefix}}name=({{var_prefix}}name)
-    #   end
-    #
-    #   def {{method_prefix}}name?
-    #     {{var_prefix}}name
-    #   end
-    #
-    #   def {{method_prefix}}name
-    #     {{var_prefix}}name.not_nil!
-    #   end
-    # end
-    # ```
-    macro {{macro_prefix}}property!(*names)
-      {{macro_prefix}}getter! \{{names.splat}}
-
-      \{% for name in names %}
-        \{% if name.is_a?(TypeDeclaration) %}
-          def {{method_prefix}}\{{name.var.id}}=({{var_prefix}}\{{name.var.id}} : \{{name.type}})
-          end
-        \{% else %}
-          def {{method_prefix}}\{{name.id}}=({{var_prefix}}\{{name.id}})
-          end
-        \{% end %}
+      \{% raise "Only one argument can be passed to `{{macro_prefix}}property` with a block" if block && names.size > 1 %}
+      \{% for name, index in names %}
+        ::Crystal.def_{{macro_prefix}}var(\{{name}}, \{{!!block}})
+        ::Crystal.def_{{macro_prefix}}getter(\{{name}}) \{% if block %} { \{{yield}} } \{% end %}
+        ::Crystal.def_{{macro_prefix}}setter(\{{name}})
       \{% end %}
     end
 
@@ -1205,67 +798,236 @@ class Object
     # with a variable that is lazily initialized with
     # the block's contents, for examples see `#{{macro_prefix}}property`.
     macro {{macro_prefix}}property?(*names, &block)
-      \{% if block %}
-        \{% if names.size != 1 %}
-          \{{ raise "Only one argument can be passed to `property?` with a block" }}
-        \{% end %}
+      \{% raise "Only one argument can be passed to `{{macro_prefix}}property?` with a block" if block && names.size > 1 %}
+      \{% for name, index in names %}
+        ::Crystal.def_{{macro_prefix}}var(\{{name}}, \{{!!block}})
+        ::Crystal.def_{{macro_prefix}}getter?(\{{name}}) \{% if block %} { \{{yield}} } \{% end %}
+        ::Crystal.def_{{macro_prefix}}setter(\{{name}})
+      \{% end %}
+    end
 
-        \{% name = names[0] %}
+    # Defines raise-on-nil and nilable getter methods for each of the given arguments.
+    #
+    # Writing:
+    #
+    # ```
+    # class Person
+    #   {{macro_prefix}}getter! name
+    # end
+    # ```
+    #
+    # Is the same as writing:
+    #
+    # ```
+    # class Person
+    #   def {{method_prefix}}name?
+    #     {{var_prefix}}name
+    #   end
+    #
+    #   def {{method_prefix}}name
+    #     {{var_prefix}}name.not_nil!
+    #   end
+    # end
+    # ```
+    #
+    # The arguments can be string literals, symbol literals or plain names:
+    #
+    # ```
+    # class Person
+    #   {{macro_prefix}}getter! :name, "age"
+    # end
+    # ```
+    #
+    # If a type declaration is given, a variable with that name
+    # is declared with that type, as nilable.
+    #
+    # ```
+    # class Person
+    #   {{macro_prefix}}getter! name : String
+    # end
+    # ```
+    #
+    # is the same as writing:
+    #
+    # ```
+    # class Person
+    #   {{var_prefix}}name : String?
+    #
+    #   def {{method_prefix}}name?
+    #     {{var_prefix}}name
+    #   end
+    #
+    #   def {{method_prefix}}name
+    #     {{var_prefix}}name.not_nil!
+    #   end
+    # end
+    # ```
+    macro {{macro_prefix}}getter!(*names)
+      \{% for name in names %}
+        ::Crystal.def_{{macro_prefix}}var(\{{name}}, true)
+        ::Crystal.def_{{macro_prefix}}getter!(\{{@type}}, \{{name}})
+      \{% end %}
+    end
 
-        \{% if name.is_a?(TypeDeclaration) %}
-          {{var_prefix}}\{{name.var.id}} : \{{name.type}}?
+    # Defines raise-on-nil property methods for each of the given arguments.
+    #
+    # Writing:
+    #
+    # ```
+    # class Person
+    #   {{macro_prefix}}property! name
+    # end
+    # ```
+    #
+    # Is the same as writing:
+    #
+    # ```
+    # class Person
+    #   def {{method_prefix}}name=({{var_prefix}}name)
+    #   end
+    #
+    #   def {{method_prefix}}name?
+    #     {{var_prefix}}name
+    #   end
+    #
+    #   def {{method_prefix}}name
+    #     {{var_prefix}}name.not_nil!
+    #   end
+    # end
+    # ```
+    #
+    # The arguments can be string literals, symbol literals or plain names:
+    #
+    # ```
+    # class Person
+    #   {{macro_prefix}}property! :name, "age"
+    # end
+    # ```
+    #
+    # If a type declaration is given, a variable with that name
+    # is declared with that type, as nilable.
+    #
+    # ```
+    # class Person
+    #   {{macro_prefix}}property! name : String
+    # end
+    # ```
+    #
+    # Is the same as writing:
+    #
+    # ```
+    # class Person
+    #   {{var_prefix}}name : String?
+    #
+    #   def {{method_prefix}}name=({{var_prefix}}name)
+    #   end
+    #
+    #   def {{method_prefix}}name?
+    #     {{var_prefix}}name
+    #   end
+    #
+    #   def {{method_prefix}}name
+    #     {{var_prefix}}name.not_nil!
+    #   end
+    # end
+    # ```
+    macro {{macro_prefix}}property!(*names)
+      \{% for name in names %}
+        ::Crystal.def_var(\{{name}}, true)
+        ::Crystal.def_getter!(\{{@type}}, \{{name}})
+        ::Crystal.def_setter(\{{name}})
+      \{% end %}
+    end
 
-          def {{method_prefix}}\{{name.var.id}}? : \{{name.type}}
-            if (%value = {{var_prefix}}\{{name.var.id}}).nil?
-              {{var_prefix}}\{{name.var.id}} = \{{yield}}
-            else
-              %value
-            end
-          end
-
-          def {{method_prefix}}\{{name.var.id}}=({{var_prefix}}\{{name.var.id}} : \{{name.type}})
-          end
-        \{% else %}
-          def {{method_prefix}}\{{name.id}}?
-            if (%value = {{var_prefix}}\{{name.id}}).nil?
-              {{var_prefix}}\{{name.id}} = \{{yield}}
-            else
-              %value
-            end
-          end
-
-          def {{method_prefix}}\{{name.id}}=({{var_prefix}}\{{name.id}})
-          end
-        \{% end %}
-      \{% else %}
-        \{% for name in names %}
-          \{% if name.is_a?(TypeDeclaration) %}
-            {{var_prefix}}\{{name}}
-
-            def {{method_prefix}}\{{name.var.id}}? : \{{name.type}}
-              {{var_prefix}}\{{name.var.id}}
-            end
-
-            def {{method_prefix}}\{{name.var.id}}=({{var_prefix}}\{{name.var.id}} : \{{name.type}})
-            end
-          \{% elsif name.is_a?(Assign) %}
-            {{var_prefix}}\{{name}}
-
-            def {{method_prefix}}\{{name.target.id}}?
-              {{var_prefix}}\{{name.target.id}}
-            end
-
-            def {{method_prefix}}\{{name.target.id}}=({{var_prefix}}\{{name.target.id}})
-            end
-          \{% else %}
-            def {{method_prefix}}\{{name.id}}?
-              {{var_prefix}}\{{name.id}}
-            end
-
-            def {{method_prefix}}\{{name.id}}=({{var_prefix}}\{{name.id}})
-            end
-          \{% end %}
-        \{% end %}
+    # Defines setter methods for each of the given arguments.
+    #
+    # Writing:
+    #
+    # ```
+    # class Person
+    #   {{macro_prefix}}setter name
+    # end
+    # ```
+    #
+    # Is the same as writing:
+    #
+    # ```
+    # class Person
+    #   def {{method_prefix}}name=({{var_prefix}}name)
+    #   end
+    # end
+    # ```
+    #
+    # The arguments can be string literals, symbol literals or plain names:
+    #
+    # ```
+    # class Person
+    #   {{macro_prefix}}setter :name, "age"
+    # end
+    # ```
+    #
+    # If a type declaration is given, a variable with that name
+    # is declared with that type.
+    #
+    # ```
+    # class Person
+    #   {{macro_prefix}}setter name : String
+    # end
+    # ```
+    #
+    # is the same as writing:
+    #
+    # ```
+    # class Person
+    #   {{var_prefix}}name : String
+    #
+    #   def {{method_prefix}}name=({{var_prefix}}name : String)
+    #   end
+    # end
+    # ```
+    #
+    # The type declaration can also include an initial value:
+    #
+    # ```
+    # class Person
+    #   {{macro_prefix}}setter name : String = "John Doe"
+    # end
+    # ```
+    #
+    # Is the same as writing:
+    #
+    # ```
+    # class Person
+    #   {{var_prefix}}name : String = "John Doe"
+    #
+    #   def {{method_prefix}}name=({{var_prefix}}name : String)
+    #   end
+    # end
+    # ```
+    #
+    # An assignment can be passed too, but in this case the type of the
+    # variable must be easily inferable from the initial value:
+    #
+    # ```
+    # class Person
+    #   {{macro_prefix}}setter name = "John Doe"
+    # end
+    # ```
+    #
+    # Is the same as writing:
+    #
+    # ```
+    # class Person
+    #   {{var_prefix}}name = "John Doe"
+    #
+    #   def {{method_prefix}}name=({{var_prefix}}name)
+    #   end
+    # end
+    # ```
+    macro {{macro_prefix}}setter(*names)
+      \{% for name in names %}
+        ::Crystal.def_{{macro_prefix}}var(\{{name}}, false)
+        ::Crystal.def_{{macro_prefix}}setter(\{{name}})
       \{% end %}
     end
   {% end %}

--- a/src/object.cr
+++ b/src/object.cr
@@ -933,9 +933,9 @@ class Object
     # ```
     macro {{macro_prefix}}property!(*names)
       \{% for name in names %}
-        ::Crystal.def_var(\{{name}}, true)
-        ::Crystal.def_getter!(\{{@type}}, \{{name}})
-        ::Crystal.def_setter(\{{name}})
+        ::Crystal.def_{{macro_prefix}}var(\{{name}}, true)
+        ::Crystal.def_{{macro_prefix}}getter!(\{{@type}}, \{{name}})
+        ::Crystal.def_{{macro_prefix}}setter(\{{name}})
       \{% end %}
     end
 

--- a/src/object.cr
+++ b/src/object.cr
@@ -450,7 +450,7 @@ class Object
       \{% raise "Only one argument can be passed to `{{macro_prefix}}getter` with a block" if block && names.size > 1 %}
       \{% for name, index in names %}
         ::Crystal.def_{{macro_prefix}}var(\{{name}}, \{{!!block}})
-        ::Crystal.def_{{macro_prefix}}getter(\{{name}}) \{% if block %} { \{{yield}} } \{% end %}
+        ::Crystal.def_{{macro_prefix}}getter(\{{name}}) \{{ block }}
       \{% end %}
     end
 
@@ -551,7 +551,7 @@ class Object
       \{% raise "Only one argument can be passed to `{{macro_prefix}}getter?` with a block" if block && names.size > 1 %}
       \{% for name, index in names %}
         ::Crystal.def_{{macro_prefix}}var(\{{name}}, \{{!!block}})
-        ::Crystal.def_{{macro_prefix}}getter?(\{{name}}) \{% if block %} { \{{yield}} } \{% end %}
+        ::Crystal.def_{{macro_prefix}}getter?(\{{name}}) \{{block}}
       \{% end %}
     end
 
@@ -687,7 +687,7 @@ class Object
       \{% raise "Only one argument can be passed to `{{macro_prefix}}property` with a block" if block && names.size > 1 %}
       \{% for name, index in names %}
         ::Crystal.def_{{macro_prefix}}var(\{{name}}, \{{!!block}})
-        ::Crystal.def_{{macro_prefix}}getter(\{{name}}) \{% if block %} { \{{yield}} } \{% end %}
+        ::Crystal.def_{{macro_prefix}}getter(\{{name}}) \{{block}}
         ::Crystal.def_{{macro_prefix}}setter(\{{name}})
       \{% end %}
     end
@@ -801,7 +801,7 @@ class Object
       \{% raise "Only one argument can be passed to `{{macro_prefix}}property?` with a block" if block && names.size > 1 %}
       \{% for name, index in names %}
         ::Crystal.def_{{macro_prefix}}var(\{{name}}, \{{!!block}})
-        ::Crystal.def_{{macro_prefix}}getter?(\{{name}}) \{% if block %} { \{{yield}} } \{% end %}
+        ::Crystal.def_{{macro_prefix}}getter?(\{{name}}) \{{block}}
         ::Crystal.def_{{macro_prefix}}setter(\{{name}})
       \{% end %}
     end


### PR DESCRIPTION
Extracts def macros to avoid most of the duplication between getter, getter?, property and property? as well as getter! and property! (be they for ivars or class vars).

The def macros are defined in the `Crystal` namespace to avoid polluting the `Object` type with internal, undocumented, macros.

It's still a bit of macro mess, but at least each implementation is no longer duplicated.

The downside is that macros generating calls to other macros is slowing the semantic passes and uses more memory. For example compiling crystal itself:

Before:
```
Semantic (top level):              00:00:00.366039601 ( 190.06MB)
Semantic (new):                    00:00:00.002077768 ( 190.06MB)
Semantic (type declarations):      00:00:00.033126181 ( 198.06MB)
Semantic (abstract def check):     00:00:00.015921465 ( 222.06MB)
Semantic (restrictions augmenter): 00:00:00.010128594 ( 222.06MB)
Semantic (ivars initializers):     00:00:02.880108440 (1152.00MB)
Semantic (cvars initializers):     00:00:00.007371344 (1160.00MB)
```

After:
```
Semantic (top level):              00:00:00.416716450 ( 222.14MB)
Semantic (new):                    00:00:00.002005603 ( 222.14MB)
Semantic (type declarations):      00:00:00.031955767 ( 230.14MB)
Semantic (abstract def check):     00:00:00.013552446 ( 254.14MB)
Semantic (restrictions augmenter): 00:00:00.009634944 ( 254.14MB)
Semantic (ivars initializers):     00:00:03.001631343 (1144.07MB)
Semantic (cvars initializers):     00:00:00.006819680 (1144.07MB)
```