### PR TITLE
[Backport release/1.15] Update shards 0.19.1

### DIFF
--- a/.github/workflows/win_build_portable.yml
+++ b/.github/workflows/win_build_portable.yml
@@ -127,7 +127,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: crystal-lang/shards
-          ref: v0.19.0
+          ref: v0.19.1
           path: shards
 
       - name: Build shards release


### PR DESCRIPTION
Automated backport of #15366 to `release/1.15`, triggered by a label.