### PR TITLE
Update distribution-scripts

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,7 +8,7 @@ parameters:
   distribution-scripts-version:
     description: "Git ref for version of https://github.com/crystal-lang/distribution-scripts/"
     type: string
-    default: "71cd5f39cb3d4ff8f6fee07102022b1d825ddd0f"
+    default: "1ee31a42f0b06776a42fa4635b54dc9ec567e68a"
   previous_crystal_base_url:
     description: "Prefix for URLs to Crystal bootstrap compiler"
     type: string


### PR DESCRIPTION
Updates `distribution-scripts` dependency to https://github.com/crystal-lang/distribution-scripts/commit/1ee31a42f0b06776a42fa4635b54dc9ec567e68a

This includes the following changes:

* crystal-lang/distribution-scripts#350
