### PR TITLE
libcrypto: Correct EVP_CIPHER_get_flags argument type

### DIFF
--- a/src/openssl/lib_crypto.cr
+++ b/src/openssl/lib_crypto.cr
@@ -246,14 +246,14 @@ lib LibCrypto
     fun evp_cipher_block_size = EVP_CIPHER_get_block_size(cipher : EVP_CIPHER) : Int32
     fun evp_cipher_key_length = EVP_CIPHER_get_key_length(cipher : EVP_CIPHER) : Int32
     fun evp_cipher_iv_length = EVP_CIPHER_get_iv_length(cipher : EVP_CIPHER) : Int32
-    fun evp_cipher_flags = EVP_CIPHER_get_flags(ctx : EVP_CIPHER_CTX) : CipherFlags
+    fun evp_cipher_flags = EVP_CIPHER_get_flags(cipher : EVP_CIPHER) : CipherFlags
   {% else %}
     fun evp_cipher_name = EVP_CIPHER_name(cipher : EVP_CIPHER) : UInt8*
     fun evp_cipher_nid = EVP_CIPHER_nid(cipher : EVP_CIPHER) : Int32
     fun evp_cipher_block_size = EVP_CIPHER_block_size(cipher : EVP_CIPHER) : Int32
     fun evp_cipher_key_length = EVP_CIPHER_key_length(cipher : EVP_CIPHER) : Int32
     fun evp_cipher_iv_length = EVP_CIPHER_iv_length(cipher : EVP_CIPHER) : Int32
-    fun evp_cipher_flags = EVP_CIPHER_flags(ctx : EVP_CIPHER_CTX) : CipherFlags
+    fun evp_cipher_flags = EVP_CIPHER_flags(cipher : EVP_CIPHER) : CipherFlags
   {% end %}
 
   fun evp_cipher_ctx_new = EVP_CIPHER_CTX_new : EVP_CIPHER_CTX


### PR DESCRIPTION
Per OpenSSL documentation [^1] and the usage of
`LibCrypto#evp_cipher_flags`, `EVP_CIPHER_get_flags` should accept `EVP_CIPHER` rather than `EVP_CIPHER_CTX`.

```
unsigned long EVP_CIPHER_get_flags(const EVP_CIPHER *e);
```

An example of this usage can be seen in `OpenSSL::Cipher#authenticated?` [^2].

This change does not introduce any functional impact but improves clarity by correctly reflecting the expected argument, reducing the need for developers to cross-check other sources.

[^1]: https://docs.openssl.org/1.1.1/man3/EVP_EncryptInit/#synopsis
[^2]: https://github.com/crystal-lang/crystal/blob/2978cd157a7a24a68abcc6d41a12dd7f04afc1f5/src/openssl/cipher.cr#L156C7-L156C21