### PR TITLE
[CI] Add check for shards binary in `test_dist_linux_on_docker`

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -477,6 +477,7 @@ jobs:
       - run: bin/ci prepare_system
       - run: echo 'export CURRENT_TAG="$CIRCLE_TAG"' >> $BASH_ENV
       - run: bin/ci prepare_build
+      - run: bin/ci with_build_env 'shards --version'
       - run:
           command: bin/ci build
           no_output_timeout: 30m


### PR DESCRIPTION
This is to detect issues like https://github.com/crystal-lang/distribution-scripts/issues/330 directly in the build process.