### PR TITLE
Add backports to changelog generator

### DIFF
--- a/scripts/github-changelog.cr
+++ b/scripts/github-changelog.cr
@@ -271,6 +271,10 @@ record PullRequest,
     md = title.match(/\[fixup #(.\d+)/) || return
     md[1]?.try(&.to_i)
   end
+
+  def clean_title
+    title.sub(/^\[?(?:#{type}|#{sub_topic})(?::|\]:?) /i, "")
+  end
 end
 
 def query_milestone(api_token, repository, number)
@@ -342,7 +346,7 @@ struct ChangelogEntry
     if pr.deprecated?
       io << "**[deprecation]** "
     end
-    io << pr.title.sub(/^\[?(?:#{pr.type}|#{pr.sub_topic})(?::|\]:?) /i, "")
+    io << pr.clean_title
 
     io << " ("
     pull_requests.join(io, ", ") do |pr|

--- a/scripts/github-changelog.cr
+++ b/scripts/github-changelog.cr
@@ -379,10 +379,20 @@ class ChangelogEntry
 
   def collect_authors
     authors = [] of String
-    pull_requests.each do |pr|
+
+    if backported_from = self.backported_from
+      if author = backported_from.author
+        authors << author
+      end
+    end
+
+    pull_requests.each_with_index do |pr, i|
+      next if backported_from && i.zero?
+
       author = pr.author || next
       authors << author unless authors.includes?(author)
     end
+
     authors
   end
 

--- a/scripts/github-changelog.cr
+++ b/scripts/github-changelog.cr
@@ -388,6 +388,7 @@ class ChangelogEntry
 
   def print_ref_labels(io)
     pull_requests.each { |pr| print_ref_label(io, pr) }
+    backported_from.try { |pr| print_ref_label(io, pr) }
   end
 
   def print_ref_label(io, pr)


### PR DESCRIPTION
Adds support for the automated backport workflow added in #15372.

See the changelog for 1.15.1 as an example: #15401.