### PR TITLE
RFC 2 : Delay Fiber stack association

### DIFF
--- a/spec/std/fiber/execution_context/global_queue_spec.cr
+++ b/spec/std/fiber/execution_context/global_queue_spec.cr
@@ -1,0 +1,225 @@
+require "./spec_helper"
+
+describe Fiber::ExecutionContext::GlobalQueue do
+  it "#initialize" do
+    q = Fiber::ExecutionContext::GlobalQueue.new(Thread::Mutex.new)
+    q.empty?.should be_true
+  end
+
+  it "#unsafe_push and #unsafe_pop" do
+    f1 = Fiber.new(name: "f1") { }
+    f2 = Fiber.new(name: "f2") { }
+    f3 = Fiber.new(name: "f3") { }
+
+    q = Fiber::ExecutionContext::GlobalQueue.new(Thread::Mutex.new)
+    q.unsafe_push(f1)
+    q.size.should eq(1)
+
+    q.unsafe_push(f2)
+    q.unsafe_push(f3)
+    q.size.should eq(3)
+
+    q.unsafe_pop?.should be(f3)
+    q.size.should eq(2)
+
+    q.unsafe_pop?.should be(f2)
+    q.unsafe_pop?.should be(f1)
+    q.unsafe_pop?.should be_nil
+    q.size.should eq(0)
+    q.empty?.should be_true
+  end
+
+  describe "#unsafe_grab?" do
+    it "can't grab from empty queue" do
+      q = Fiber::ExecutionContext::GlobalQueue.new(Thread::Mutex.new)
+      runnables = Fiber::ExecutionContext::Runnables(6).new(q)
+      q.unsafe_grab?(runnables, 4).should be_nil
+    end
+
+    it "grabs fibers" do
+      q = Fiber::ExecutionContext::GlobalQueue.new(Thread::Mutex.new)
+      fibers = 10.times.map { |i| Fiber.new(name: "f#{i}") { } }.to_a
+      fibers.each { |f| q.unsafe_push(f) }
+
+      runnables = Fiber::ExecutionContext::Runnables(6).new(q)
+      fiber = q.unsafe_grab?(runnables, 4)
+
+      # returned the last enqueued fiber
+      fiber.should be(fibers[9])
+
+      # enqueued the next 2 fibers
+      runnables.size.should eq(2)
+      runnables.shift?.should be(fibers[8])
+      runnables.shift?.should be(fibers[7])
+
+      # the remaining fibers are still there:
+      6.downto(0).each do |i|
+        q.unsafe_pop?.should be(fibers[i])
+      end
+    end
+
+    it "can't grab more than available" do
+      f = Fiber.new { }
+      q = Fiber::ExecutionContext::GlobalQueue.new(Thread::Mutex.new)
+      q.unsafe_push(f)
+
+      # dequeues the unique fiber
+      runnables = Fiber::ExecutionContext::Runnables(6).new(q)
+      fiber = q.unsafe_grab?(runnables, 4)
+      fiber.should be(f)
+
+      # had nothing left to dequeue
+      runnables.size.should eq(0)
+    end
+
+    it "clamps divisor to 1" do
+      f = Fiber.new { }
+      q = Fiber::ExecutionContext::GlobalQueue.new(Thread::Mutex.new)
+      q.unsafe_push(f)
+
+      # dequeues the unique fiber
+      runnables = Fiber::ExecutionContext::Runnables(6).new(q)
+      fiber = q.unsafe_grab?(runnables, 0)
+      fiber.should be(f)
+
+      # had nothing left to dequeue
+      runnables.size.should eq(0)
+    end
+  end
+
+  # interpreter doesn't support threads yet (#14287)
+  pending_interpreted describe: "thread safety" do
+    it "one by one" do
+      fibers = StaticArray(Fiber::ExecutionContext::FiberCounter, 763).new do |i|
+        Fiber::ExecutionContext::FiberCounter.new(Fiber.new(name: "f#{i}") { })
+      end
+
+      n = 7
+      increments = 15
+      queue = Fiber::ExecutionContext::GlobalQueue.new(Thread::Mutex.new)
+      ready = Thread::WaitGroup.new(n)
+      shutdown = Thread::WaitGroup.new(n)
+
+      n.times do |i|
+        Thread.new(name: "ONE-#{i}") do |thread|
+          slept = 0
+          ready.done
+
+          loop do
+            if fiber = queue.pop?
+              fc = fibers.find { |x| x.@fiber == fiber }.not_nil!
+              queue.push(fiber) if fc.increment < increments
+              slept = 0
+            elsif slept < 100
+              slept += 1
+              Thread.sleep(1.nanosecond) # don't burn CPU
+            else
+              break
+            end
+          end
+        rescue exception
+          Crystal::System.print_error "\nthread: #{thread.name}: exception: #{exception}"
+        ensure
+          shutdown.done
+        end
+      end
+      ready.wait
+
+      fibers.each_with_index do |fc, i|
+        queue.push(fc.@fiber)
+        Thread.sleep(10.nanoseconds) if i % 10 == 9
+      end
+
+      shutdown.wait
+
+      # must have dequeued each fiber exactly X times
+      fibers.each { |fc| fc.counter.should eq(increments) }
+    end
+
+    it "bulk operations" do
+      n = 7
+      increments = 15
+
+      fibers = StaticArray(Fiber::ExecutionContext::FiberCounter, 765).new do |i| # 765 can be divided by 3 and 5
+        Fiber::ExecutionContext::FiberCounter.new(Fiber.new(name: "f#{i}") { })
+      end
+
+      queue = Fiber::ExecutionContext::GlobalQueue.new(Thread::Mutex.new)
+      ready = Thread::WaitGroup.new(n)
+      shutdown = Thread::WaitGroup.new(n)
+
+      n.times do |i|
+        Thread.new(name: "BULK-#{i}") do |thread|
+          slept = 0
+
+          r = Fiber::ExecutionContext::Runnables(3).new(queue)
+
+          batch = Fiber::List.new
+          size = 0
+
+          reenqueue = -> {
+            if size > 0
+              queue.bulk_push(pointerof(batch))
+              names = [] of String?
+              batch.each { |f| names << f.name }
+              batch.clear
+              size = 0
+            end
+          }
+
+          execute = ->(fiber : Fiber) {
+            fc = fibers.find { |x| x.@fiber == fiber }.not_nil!
+
+            if fc.increment < increments
+              batch.push(fc.@fiber)
+              size += 1
+            end
+          }
+
+          ready.done
+
+          loop do
+            if fiber = r.shift?
+              execute.call(fiber)
+              slept = 0
+              next
+            end
+
+            if fiber = queue.grab?(r, 1)
+              reenqueue.call
+              execute.call(fiber)
+              slept = 0
+              next
+            end
+
+            if slept >= 100
+              break
+            end
+
+            reenqueue.call
+            slept += 1
+            Thread.sleep(1.nanosecond) # don't burn CPU
+          end
+        rescue exception
+          Crystal::System.print_error "\nthread #{thread.name} raised: #{exception}"
+        ensure
+          shutdown.done
+        end
+      end
+      ready.wait
+
+      # enqueue in batches of 5
+      0.step(to: fibers.size - 1, by: 5) do |i|
+        list = Fiber::List.new
+        5.times { |j| list.push(fibers[i + j].@fiber) }
+        queue.bulk_push(pointerof(list))
+        Thread.sleep(10.nanoseconds) if i % 4 == 3
+      end
+
+      shutdown.wait
+
+      # must have dequeued each fiber exactly X times (no less, no more)
+      fibers.each { |fc| fc.counter.should eq(increments) }
+    end
+  end
+end

--- a/spec/std/fiber/execution_context/global_queue_spec.cr
+++ b/spec/std/fiber/execution_context/global_queue_spec.cr
@@ -7,9 +7,9 @@ describe Fiber::ExecutionContext::GlobalQueue do
   end
 
   it "#unsafe_push and #unsafe_pop" do
-    f1 = Fiber.new(name: "f1") { }
-    f2 = Fiber.new(name: "f2") { }
-    f3 = Fiber.new(name: "f3") { }
+    f1 = new_fake_fiber("f1")
+    f2 = new_fake_fiber("f2")
+    f3 = new_fake_fiber("f3")
 
     q = Fiber::ExecutionContext::GlobalQueue.new(Thread::Mutex.new)
     q.unsafe_push(f1)
@@ -38,7 +38,7 @@ describe Fiber::ExecutionContext::GlobalQueue do
 
     it "grabs fibers" do
       q = Fiber::ExecutionContext::GlobalQueue.new(Thread::Mutex.new)
-      fibers = 10.times.map { |i| Fiber.new(name: "f#{i}") { } }.to_a
+      fibers = 10.times.map { |i| new_fake_fiber("f#{i}") }.to_a
       fibers.each { |f| q.unsafe_push(f) }
 
       runnables = Fiber::ExecutionContext::Runnables(6).new(q)
@@ -59,7 +59,7 @@ describe Fiber::ExecutionContext::GlobalQueue do
     end
 
     it "can't grab more than available" do
-      f = Fiber.new { }
+      f = new_fake_fiber
       q = Fiber::ExecutionContext::GlobalQueue.new(Thread::Mutex.new)
       q.unsafe_push(f)
 
@@ -73,7 +73,7 @@ describe Fiber::ExecutionContext::GlobalQueue do
     end
 
     it "clamps divisor to 1" do
-      f = Fiber.new { }
+      f = new_fake_fiber
       q = Fiber::ExecutionContext::GlobalQueue.new(Thread::Mutex.new)
       q.unsafe_push(f)
 
@@ -91,7 +91,7 @@ describe Fiber::ExecutionContext::GlobalQueue do
   pending_interpreted describe: "thread safety" do
     it "one by one" do
       fibers = StaticArray(Fiber::ExecutionContext::FiberCounter, 763).new do |i|
-        Fiber::ExecutionContext::FiberCounter.new(Fiber.new(name: "f#{i}") { })
+        Fiber::ExecutionContext::FiberCounter.new(new_fake_fiber("f#{i}"))
       end
 
       n = 7
@@ -141,7 +141,7 @@ describe Fiber::ExecutionContext::GlobalQueue do
       increments = 15
 
       fibers = StaticArray(Fiber::ExecutionContext::FiberCounter, 765).new do |i| # 765 can be divided by 3 and 5
-        Fiber::ExecutionContext::FiberCounter.new(Fiber.new(name: "f#{i}") { })
+        Fiber::ExecutionContext::FiberCounter.new(new_fake_fiber("f#{i}"))
       end
 
       queue = Fiber::ExecutionContext::GlobalQueue.new(Thread::Mutex.new)

--- a/spec/std/fiber/execution_context/runnables_spec.cr
+++ b/spec/std/fiber/execution_context/runnables_spec.cr
@@ -9,7 +9,7 @@ describe Fiber::ExecutionContext::Runnables do
 
   describe "#push" do
     it "enqueues the fiber in local queue" do
-      fibers = 4.times.map { |i| Fiber.new(name: "f#{i}") { } }.to_a
+      fibers = 4.times.map { |i| new_fake_fiber("f#{i}") }.to_a
 
       # local enqueue
       g = Fiber::ExecutionContext::GlobalQueue.new(Thread::Mutex.new)
@@ -25,7 +25,7 @@ describe Fiber::ExecutionContext::Runnables do
     end
 
     it "moves half the local queue to the global queue on overflow" do
-      fibers = 5.times.map { |i| Fiber.new(name: "f#{i}") { } }.to_a
+      fibers = 5.times.map { |i| new_fake_fiber("f#{i}") }.to_a
 
       # local enqueue + overflow
       g = Fiber::ExecutionContext::GlobalQueue.new(Thread::Mutex.new)
@@ -48,12 +48,12 @@ describe Fiber::ExecutionContext::Runnables do
 
       4.times do
         # local
-        4.times { r.push(Fiber.new { }) }
+        4.times { r.push(new_fake_fiber) }
         2.times { r.shift? }
-        2.times { r.push(Fiber.new { }) }
+        2.times { r.push(new_fake_fiber) }
 
         # overflow (2+1 fibers are sent to global queue + 1 local)
-        2.times { r.push(Fiber.new { }) }
+        2.times { r.push(new_fake_fiber) }
 
         # clear
         3.times { r.shift? }
@@ -73,7 +73,7 @@ describe Fiber::ExecutionContext::Runnables do
   describe "#bulk_push" do
     it "fills the local queue" do
       l = Fiber::List.new
-      fibers = 4.times.map { |i| Fiber.new(name: "f#{i}") { } }.to_a
+      fibers = 4.times.map { |i| new_fake_fiber("f#{i}") }.to_a
       fibers.each { |f| l.push(f) }
 
       # local enqueue
@@ -87,7 +87,7 @@ describe Fiber::ExecutionContext::Runnables do
 
     it "pushes the overflow to the global queue" do
       l = Fiber::List.new
-      fibers = 7.times.map { |i| Fiber.new(name: "f#{i}") { } }.to_a
+      fibers = 7.times.map { |i| new_fake_fiber("f#{i}") }.to_a
       fibers.each { |f| l.push(f) }
 
       # local enqueue + overflow
@@ -115,7 +115,7 @@ describe Fiber::ExecutionContext::Runnables do
   describe "#steal_from" do
     it "steals from another runnables" do
       g = Fiber::ExecutionContext::GlobalQueue.new(Thread::Mutex.new)
-      fibers = 6.times.map { |i| Fiber.new(name: "f#{i}") { } }.to_a
+      fibers = 6.times.map { |i| new_fake_fiber("f#{i}") }.to_a
 
       # fill the source queue
       r1 = Fiber::ExecutionContext::Runnables(16).new(g)
@@ -143,7 +143,7 @@ describe Fiber::ExecutionContext::Runnables do
 
     it "steals the last fiber" do
       g = Fiber::ExecutionContext::GlobalQueue.new(Thread::Mutex.new)
-      lone = Fiber.new(name: "lone") { }
+      lone = new_fake_fiber("lone")
 
       # fill the source queue
       r1 = Fiber::ExecutionContext::Runnables(16).new(g)
@@ -185,7 +185,7 @@ describe Fiber::ExecutionContext::Runnables do
       # less fibers than space in runnables (so threads can starve)
       # 54 is roughly half of 16 × 7 and can be divided by 9 (for batch enqueues below)
       fibers = Array(Fiber::ExecutionContext::FiberCounter).new(54) do |i|
-        Fiber::ExecutionContext::FiberCounter.new(Fiber.new(name: "f#{i}") { })
+        Fiber::ExecutionContext::FiberCounter.new(new_fake_fiber("f#{i}"))
       end
 
       global_queue = Fiber::ExecutionContext::GlobalQueue.new(Thread::Mutex.new)

--- a/spec/std/fiber/execution_context/runnables_spec.cr
+++ b/spec/std/fiber/execution_context/runnables_spec.cr
@@ -1,0 +1,264 @@
+require "./spec_helper"
+
+describe Fiber::ExecutionContext::Runnables do
+  it "#initialize" do
+    g = Fiber::ExecutionContext::GlobalQueue.new(Thread::Mutex.new)
+    r = Fiber::ExecutionContext::Runnables(16).new(g)
+    r.capacity.should eq(16)
+  end
+
+  describe "#push" do
+    it "enqueues the fiber in local queue" do
+      fibers = 4.times.map { |i| Fiber.new(name: "f#{i}") { } }.to_a
+
+      # local enqueue
+      g = Fiber::ExecutionContext::GlobalQueue.new(Thread::Mutex.new)
+      r = Fiber::ExecutionContext::Runnables(4).new(g)
+      fibers.each { |f| r.push(f) }
+
+      # local dequeue
+      fibers.each { |f| r.shift?.should be(f) }
+      r.shift?.should be_nil
+
+      # didn't push to global queue
+      g.pop?.should be_nil
+    end
+
+    it "moves half the local queue to the global queue on overflow" do
+      fibers = 5.times.map { |i| Fiber.new(name: "f#{i}") { } }.to_a
+
+      # local enqueue + overflow
+      g = Fiber::ExecutionContext::GlobalQueue.new(Thread::Mutex.new)
+      r = Fiber::ExecutionContext::Runnables(4).new(g)
+      fibers.each { |f| r.push(f) }
+
+      # kept half of local queue
+      r.shift?.should be(fibers[2])
+      r.shift?.should be(fibers[3])
+
+      # moved half of local queue + last push to global queue
+      g.pop?.should eq(fibers[0])
+      g.pop?.should eq(fibers[1])
+      g.pop?.should eq(fibers[4])
+    end
+
+    it "can always push up to capacity" do
+      g = Fiber::ExecutionContext::GlobalQueue.new(Thread::Mutex.new)
+      r = Fiber::ExecutionContext::Runnables(4).new(g)
+
+      4.times do
+        # local
+        4.times { r.push(Fiber.new { }) }
+        2.times { r.shift? }
+        2.times { r.push(Fiber.new { }) }
+
+        # overflow (2+1 fibers are sent to global queue + 1 local)
+        2.times { r.push(Fiber.new { }) }
+
+        # clear
+        3.times { r.shift? }
+      end
+
+      # on each iteration we pushed 2+1 fibers to the global queue
+      g.size.should eq(12)
+
+      # grab fibers back from the global queue
+      fiber = g.unsafe_grab?(r, divisor: 1)
+      fiber.should_not be_nil
+      r.shift?.should_not be_nil
+      r.shift?.should be_nil
+    end
+  end
+
+  describe "#bulk_push" do
+    it "fills the local queue" do
+      l = Fiber::List.new
+      fibers = 4.times.map { |i| Fiber.new(name: "f#{i}") { } }.to_a
+      fibers.each { |f| l.push(f) }
+
+      # local enqueue
+      g = Fiber::ExecutionContext::GlobalQueue.new(Thread::Mutex.new)
+      r = Fiber::ExecutionContext::Runnables(4).new(g)
+      r.bulk_push(pointerof(l))
+
+      fibers.reverse_each { |f| r.shift?.should be(f) }
+      g.empty?.should be_true
+    end
+
+    it "pushes the overflow to the global queue" do
+      l = Fiber::List.new
+      fibers = 7.times.map { |i| Fiber.new(name: "f#{i}") { } }.to_a
+      fibers.each { |f| l.push(f) }
+
+      # local enqueue + overflow
+      g = Fiber::ExecutionContext::GlobalQueue.new(Thread::Mutex.new)
+      r = Fiber::ExecutionContext::Runnables(4).new(g)
+      r.bulk_push(pointerof(l))
+
+      # filled the local queue
+      r.shift?.should eq(fibers[6])
+      r.shift?.should eq(fibers[5])
+      r.shift?.should be(fibers[4])
+      r.shift?.should be(fibers[3])
+
+      # moved the rest to the global queue
+      g.pop?.should eq(fibers[2])
+      g.pop?.should eq(fibers[1])
+      g.pop?.should eq(fibers[0])
+    end
+  end
+
+  describe "#shift?" do
+    # TODO: need specific tests (though we already use it in the above tests?)
+  end
+
+  describe "#steal_from" do
+    it "steals from another runnables" do
+      g = Fiber::ExecutionContext::GlobalQueue.new(Thread::Mutex.new)
+      fibers = 6.times.map { |i| Fiber.new(name: "f#{i}") { } }.to_a
+
+      # fill the source queue
+      r1 = Fiber::ExecutionContext::Runnables(16).new(g)
+      fibers.each { |f| r1.push(f) }
+
+      # steal from source queue
+      r2 = Fiber::ExecutionContext::Runnables(16).new(g)
+      fiber = r2.steal_from(r1)
+
+      # stole half of the runnable fibers
+      fiber.should be(fibers[2])
+      r2.shift?.should be(fibers[0])
+      r2.shift?.should be(fibers[1])
+      r2.shift?.should be_nil
+
+      # left the other half
+      r1.shift?.should be(fibers[3])
+      r1.shift?.should be(fibers[4])
+      r1.shift?.should be(fibers[5])
+      r1.shift?.should be_nil
+
+      # global queue is left untouched
+      g.empty?.should be_true
+    end
+
+    it "steals the last fiber" do
+      g = Fiber::ExecutionContext::GlobalQueue.new(Thread::Mutex.new)
+      lone = Fiber.new(name: "lone") { }
+
+      # fill the source queue
+      r1 = Fiber::ExecutionContext::Runnables(16).new(g)
+      r1.push(lone)
+
+      # steal from source queue
+      r2 = Fiber::ExecutionContext::Runnables(16).new(g)
+      fiber = r2.steal_from(r1)
+
+      # stole the fiber & local queue is still empty
+      fiber.should be(lone)
+      r2.shift?.should be_nil
+
+      # left nothing in original queue
+      r1.shift?.should be_nil
+
+      # global queue is left untouched
+      g.empty?.should be_true
+    end
+
+    it "steals nothing" do
+      g = Fiber::ExecutionContext::GlobalQueue.new(Thread::Mutex.new)
+      r1 = Fiber::ExecutionContext::Runnables(16).new(g)
+      r2 = Fiber::ExecutionContext::Runnables(16).new(g)
+
+      fiber = r2.steal_from(r1)
+      fiber.should be_nil
+      r2.shift?.should be_nil
+      r1.shift?.should be_nil
+    end
+  end
+
+  # interpreter doesn't support threads yet (#14287)
+  pending_interpreted describe: "thread safety" do
+    it "stress test" do
+      n = 7
+      increments = 7919
+
+      # less fibers than space in runnables (so threads can starve)
+      # 54 is roughly half of 16 × 7 and can be divided by 9 (for batch enqueues below)
+      fibers = Array(Fiber::ExecutionContext::FiberCounter).new(54) do |i|
+        Fiber::ExecutionContext::FiberCounter.new(Fiber.new(name: "f#{i}") { })
+      end
+
+      global_queue = Fiber::ExecutionContext::GlobalQueue.new(Thread::Mutex.new)
+      ready = Thread::WaitGroup.new(n)
+      shutdown = Thread::WaitGroup.new(n)
+
+      all_runnables = Array(Fiber::ExecutionContext::Runnables(16)).new(n) do
+        Fiber::ExecutionContext::Runnables(16).new(global_queue)
+      end
+
+      n.times do |i|
+        Thread.new(name: "RUN-#{i}") do |thread|
+          runnables = all_runnables[i]
+          slept = 0
+
+          execute = ->(fiber : Fiber) {
+            fc = fibers.find { |x| x.@fiber == fiber }.not_nil!
+            runnables.push(fiber) if fc.increment < increments
+          }
+
+          ready.done
+
+          loop do
+            # dequeue from local queue
+            if fiber = runnables.shift?
+              execute.call(fiber)
+              slept = 0
+              next
+            end
+
+            # steal from another queue
+            while (r = all_runnables.sample) == runnables
+            end
+            if fiber = runnables.steal_from(r)
+              execute.call(fiber)
+              slept = 0
+              next
+            end
+
+            # dequeue from global queue
+            if fiber = global_queue.grab?(runnables, n)
+              execute.call(fiber)
+              slept = 0
+              next
+            end
+
+            if slept >= 100
+              break
+            end
+
+            slept += 1
+            Thread.sleep(1.nanosecond) # don't burn CPU
+          end
+        rescue exception
+          Crystal::System.print_error "\nthread #{thread.name} raised: #{exception}"
+        ensure
+          shutdown.done
+        end
+      end
+      ready.wait
+
+      # enqueue in batches
+      0.step(to: fibers.size - 1, by: 9) do |i|
+        list = Fiber::List.new
+        9.times { |j| list.push(fibers[i + j].@fiber) }
+        global_queue.bulk_push(pointerof(list))
+        Thread.sleep(10.nanoseconds) if i % 2 == 1
+      end
+
+      shutdown.wait
+
+      # must have dequeued each fiber exactly X times (no less, no more)
+      fibers.each { |fc| fc.counter.should eq(increments) }
+    end
+  end
+end

--- a/spec/std/fiber/execution_context/spec_helper.cr
+++ b/spec/std/fiber/execution_context/spec_helper.cr
@@ -1,0 +1,21 @@
+require "../../spec_helper"
+require "crystal/system/thread_wait_group"
+require "fiber/execution_context/runnables"
+require "fiber/execution_context/global_queue"
+
+module Fiber::ExecutionContext
+  class FiberCounter
+    def initialize(@fiber : Fiber)
+      @counter = Atomic(Int32).new(0)
+    end
+
+    # fetch and add
+    def increment
+      @counter.add(1, :relaxed) + 1
+    end
+
+    def counter
+      @counter.get(:relaxed)
+    end
+  end
+end

--- a/spec/std/fiber/execution_context/spec_helper.cr
+++ b/spec/std/fiber/execution_context/spec_helper.cr
@@ -3,6 +3,22 @@ require "crystal/system/thread_wait_group"
 require "fiber/execution_context/runnables"
 require "fiber/execution_context/global_queue"
 
+# fake stack for `makecontext` to have somewhere to write in #initialize.
+# we don't actually run the fiber.
+FAKE_FIBER_STACK = GC.malloc(32)
+
+def new_fake_fiber(name = nil)
+  stack = FAKE_FIBER_STACK
+  stack_bottom = FAKE_FIBER_STACK + 32
+
+  {% if flag?(:execution_context) %}
+    execution_context = Fiber::ExecutionContext.current
+    Fiber.new(name, stack, stack_bottom, execution_context) { }
+  {% else %}
+    Fiber.new(name, stack, stack_bottom) { }
+  {% end %}
+end
+
 module Fiber::ExecutionContext
   class FiberCounter
     def initialize(@fiber : Fiber)

--- a/spec/std/fiber/execution_context/spec_helper.cr
+++ b/spec/std/fiber/execution_context/spec_helper.cr
@@ -1,24 +1,8 @@
 require "../../spec_helper"
+require "../../../support/fibers"
 require "crystal/system/thread_wait_group"
 require "fiber/execution_context/runnables"
 require "fiber/execution_context/global_queue"
-
-# Fake stack for `makecontext` to have somewhere to write in #initialize; We
-# don't actually run the fiber. The worst case is windows with ~300 bytes (with
-# shadow space and alignment taken into account). We allocate more to be safe.
-FAKE_FIBER_STACK = GC.malloc(512)
-
-def new_fake_fiber(name = nil)
-  stack = FAKE_FIBER_STACK
-  stack_bottom = FAKE_FIBER_STACK + 128
-
-  {% if flag?(:execution_context) %}
-    execution_context = Fiber::ExecutionContext.current
-    Fiber.new(name, stack, stack_bottom, execution_context) { }
-  {% else %}
-    Fiber.new(name, stack, stack_bottom) { }
-  {% end %}
-end
 
 module Fiber::ExecutionContext
   class FiberCounter

--- a/spec/std/fiber/execution_context/spec_helper.cr
+++ b/spec/std/fiber/execution_context/spec_helper.cr
@@ -5,11 +5,11 @@ require "fiber/execution_context/global_queue"
 
 # fake stack for `makecontext` to have somewhere to write in #initialize.
 # we don't actually run the fiber.
-FAKE_FIBER_STACK = GC.malloc(32)
+FAKE_FIBER_STACK = GC.malloc(128)
 
 def new_fake_fiber(name = nil)
   stack = FAKE_FIBER_STACK
-  stack_bottom = FAKE_FIBER_STACK + 32
+  stack_bottom = FAKE_FIBER_STACK + 128
 
   {% if flag?(:execution_context) %}
     execution_context = Fiber::ExecutionContext.current

--- a/spec/std/fiber/execution_context/spec_helper.cr
+++ b/spec/std/fiber/execution_context/spec_helper.cr
@@ -3,9 +3,10 @@ require "crystal/system/thread_wait_group"
 require "fiber/execution_context/runnables"
 require "fiber/execution_context/global_queue"
 
-# fake stack for `makecontext` to have somewhere to write in #initialize.
-# we don't actually run the fiber.
-FAKE_FIBER_STACK = GC.malloc(128)
+# Fake stack for `makecontext` to have somewhere to write in #initialize; We
+# don't actually run the fiber. The worst case is windows with ~300 bytes (with
+# shadow space and alignment taken into account). We allocate more to be safe.
+FAKE_FIBER_STACK = GC.malloc(512)
 
 def new_fake_fiber(name = nil)
   stack = FAKE_FIBER_STACK

--- a/spec/std/fiber/list_spec.cr
+++ b/spec/std/fiber/list_spec.cr
@@ -1,0 +1,183 @@
+require "../spec_helper"
+require "fiber/list"
+
+describe Fiber::List do
+  describe "#initialize" do
+    it "creates an empty queue" do
+      list = Fiber::List.new
+      list.@head.should be_nil
+      list.@tail.should be_nil
+      list.size.should eq(0)
+      list.empty?.should be_true
+    end
+
+    it "creates a filled queue" do
+      f1 = Fiber.new(name: "f1") { }
+      f2 = Fiber.new(name: "f2") { }
+      f1.list_next = f2
+      f2.list_next = nil
+
+      list = Fiber::List.new(f2, f1, size: 2)
+      list.@head.should be(f2)
+      list.@tail.should be(f1)
+      list.size.should eq(2)
+      list.empty?.should be_false
+    end
+  end
+
+  describe "#push" do
+    it "to head" do
+      list = Fiber::List.new
+      f1 = Fiber.new(name: "f1") { }
+      f2 = Fiber.new(name: "f2") { }
+      f3 = Fiber.new(name: "f3") { }
+
+      # simulate fibers previously added to other queues
+      f1.list_next = f3
+      f2.list_next = f1
+
+      # push first fiber
+      list.push(f1)
+      list.@head.should be(f1)
+      list.@tail.should be(f1)
+      f1.list_next.should be_nil
+      list.size.should eq(1)
+
+      # push second fiber
+      list.push(f2)
+      list.@head.should be(f2)
+      list.@tail.should be(f1)
+      f2.list_next.should be(f1)
+      f1.list_next.should be_nil
+      list.size.should eq(2)
+
+      # push third fiber
+      list.push(f3)
+      list.@head.should be(f3)
+      list.@tail.should be(f1)
+      f3.list_next.should be(f2)
+      f2.list_next.should be(f1)
+      f1.list_next.should be_nil
+      list.size.should eq(3)
+    end
+  end
+
+  describe "#bulk_unshift" do
+    it "to empty queue" do
+      # manually create a queue
+      f1 = Fiber.new(name: "f1") { }
+      f2 = Fiber.new(name: "f2") { }
+      f3 = Fiber.new(name: "f3") { }
+      f3.list_next = f2
+      f2.list_next = f1
+      f1.list_next = nil
+      q1 = Fiber::List.new(f3, f1, size: 3)
+
+      # push in bulk
+      q2 = Fiber::List.new(nil, nil, size: 0)
+      q2.bulk_unshift(pointerof(q1))
+      q2.@head.should be(f3)
+      q2.@tail.should be(f1)
+      q2.size.should eq(3)
+    end
+
+    it "to filled queue" do
+      f1 = Fiber.new(name: "f1") { }
+      f2 = Fiber.new(name: "f2") { }
+      f3 = Fiber.new(name: "f3") { }
+      f4 = Fiber.new(name: "f4") { }
+      f5 = Fiber.new(name: "f5") { }
+
+      # source queue
+      f3.list_next = f2
+      f2.list_next = f1
+      f1.list_next = nil
+      q1 = Fiber::List.new(f3, f1, size: 3)
+
+      # destination queue
+      f5.list_next = f4
+      f4.list_next = nil
+      q2 = Fiber::List.new(f5, f4, size: 2)
+
+      # push in bulk
+      q2.bulk_unshift(pointerof(q1))
+      q2.@head.should be(f5)
+      q2.@tail.should be(f1)
+      q2.size.should eq(5)
+
+      f5.list_next.should be(f4)
+      f4.list_next.should be(f3)
+      f3.list_next.should be(f2)
+      f2.list_next.should be(f1)
+      f1.list_next.should be(nil)
+    end
+  end
+
+  describe "#pop" do
+    it "from head" do
+      f1 = Fiber.new(name: "f1") { }
+      f2 = Fiber.new(name: "f2") { }
+      f3 = Fiber.new(name: "f3") { }
+      f3.list_next = f2
+      f2.list_next = f1
+      f1.list_next = nil
+      list = Fiber::List.new(f3, f1, size: 3)
+
+      # removes third element
+      list.pop.should be(f3)
+      list.@head.should be(f2)
+      list.@tail.should be(f1)
+      list.size.should eq(2)
+
+      # removes second element
+      list.pop.should be(f2)
+      list.@head.should be(f1)
+      list.@tail.should be(f1)
+      list.size.should eq(1)
+
+      # removes first element
+      list.pop.should be(f1)
+      list.@head.should be_nil
+      list.@tail.should be_nil
+      list.size.should eq(0)
+
+      # empty queue
+      expect_raises(IndexError) { list.pop }
+      list.size.should eq(0)
+    end
+  end
+
+  describe "#pop?" do
+    it "from head" do
+      f1 = Fiber.new(name: "f1") { }
+      f2 = Fiber.new(name: "f2") { }
+      f3 = Fiber.new(name: "f3") { }
+      f3.list_next = f2
+      f2.list_next = f1
+      f1.list_next = nil
+      list = Fiber::List.new(f3, f1, size: 3)
+
+      # removes third element
+      list.pop?.should be(f3)
+      list.@head.should be(f2)
+      list.@tail.should be(f1)
+      list.size.should eq(2)
+
+      # removes second element
+      list.pop?.should be(f2)
+      list.@head.should be(f1)
+      list.@tail.should be(f1)
+      list.size.should eq(1)
+
+      # removes first element
+      list.pop?.should be(f1)
+      list.@head.should be_nil
+      list.@tail.should be_nil
+      list.size.should eq(0)
+
+      # empty queue
+      list.pop?.should be_nil
+      list.size.should eq(0)
+    end
+  end
+end

--- a/spec/std/fiber/list_spec.cr
+++ b/spec/std/fiber/list_spec.cr
@@ -1,4 +1,4 @@
-require "../spec_helper"
+require "../../support/fibers"
 require "fiber/list"
 
 describe Fiber::List do
@@ -12,8 +12,8 @@ describe Fiber::List do
     end
 
     it "creates a filled queue" do
-      f1 = Fiber.new(name: "f1") { }
-      f2 = Fiber.new(name: "f2") { }
+      f1 = new_fake_fiber("f1")
+      f2 = new_fake_fiber("f2")
       f1.list_next = f2
       f2.list_next = nil
 
@@ -28,9 +28,9 @@ describe Fiber::List do
   describe "#push" do
     it "to head" do
       list = Fiber::List.new
-      f1 = Fiber.new(name: "f1") { }
-      f2 = Fiber.new(name: "f2") { }
-      f3 = Fiber.new(name: "f3") { }
+      f1 = new_fake_fiber("f1")
+      f2 = new_fake_fiber("f2")
+      f3 = new_fake_fiber("f3")
 
       # simulate fibers previously added to other queues
       f1.list_next = f3
@@ -65,9 +65,9 @@ describe Fiber::List do
   describe "#bulk_unshift" do
     it "to empty queue" do
       # manually create a queue
-      f1 = Fiber.new(name: "f1") { }
-      f2 = Fiber.new(name: "f2") { }
-      f3 = Fiber.new(name: "f3") { }
+      f1 = new_fake_fiber("f1")
+      f2 = new_fake_fiber("f2")
+      f3 = new_fake_fiber("f3")
       f3.list_next = f2
       f2.list_next = f1
       f1.list_next = nil
@@ -82,11 +82,11 @@ describe Fiber::List do
     end
 
     it "to filled queue" do
-      f1 = Fiber.new(name: "f1") { }
-      f2 = Fiber.new(name: "f2") { }
-      f3 = Fiber.new(name: "f3") { }
-      f4 = Fiber.new(name: "f4") { }
-      f5 = Fiber.new(name: "f5") { }
+      f1 = new_fake_fiber("f1")
+      f2 = new_fake_fiber("f2")
+      f3 = new_fake_fiber("f3")
+      f4 = new_fake_fiber("f4")
+      f5 = new_fake_fiber("f5")
 
       # source queue
       f3.list_next = f2
@@ -115,9 +115,9 @@ describe Fiber::List do
 
   describe "#pop" do
     it "from head" do
-      f1 = Fiber.new(name: "f1") { }
-      f2 = Fiber.new(name: "f2") { }
-      f3 = Fiber.new(name: "f3") { }
+      f1 = new_fake_fiber("f1")
+      f2 = new_fake_fiber("f2")
+      f3 = new_fake_fiber("f3")
       f3.list_next = f2
       f2.list_next = f1
       f1.list_next = nil
@@ -149,9 +149,9 @@ describe Fiber::List do
 
   describe "#pop?" do
     it "from head" do
-      f1 = Fiber.new(name: "f1") { }
-      f2 = Fiber.new(name: "f2") { }
-      f3 = Fiber.new(name: "f3") { }
+      f1 = new_fake_fiber("f1")
+      f2 = new_fake_fiber("f2")
+      f3 = new_fake_fiber("f3")
       f3.list_next = f2
       f2.list_next = f1
       f1.list_next = nil

--- a/spec/support/fibers.cr
+++ b/spec/support/fibers.cr
@@ -31,4 +31,3 @@ def new_fake_fiber(name = nil)
     Fiber.new(name, stack, stack_bottom) { }
   {% end %}
 end
-

--- a/spec/support/fibers.cr
+++ b/spec/support/fibers.cr
@@ -14,3 +14,21 @@ def wait_until_finished(f : Fiber, timeout = 5.seconds)
     raise "Fiber failed to finish within #{timeout}" if (Time.monotonic - now) > timeout
   end
 end
+
+# Fake stack for `makecontext` to have somewhere to write in #initialize; We
+# don't actually run the fiber. The worst case is windows with ~300 bytes (with
+# shadow space and alignment taken into account). We allocate more to be safe.
+FAKE_FIBER_STACK = GC.malloc(512)
+
+def new_fake_fiber(name = nil)
+  stack = FAKE_FIBER_STACK
+  stack_bottom = FAKE_FIBER_STACK + 128
+
+  {% if flag?(:execution_context) %}
+    execution_context = Fiber::ExecutionContext.current
+    Fiber.new(name, stack, stack_bottom, execution_context) { }
+  {% else %}
+    Fiber.new(name, stack, stack_bottom) { }
+  {% end %}
+end
+

--- a/src/crystal/event_loop.cr
+++ b/src/crystal/event_loop.cr
@@ -27,12 +27,20 @@ abstract class Crystal::EventLoop
 
   @[AlwaysInline]
   def self.current : self
-    Crystal::Scheduler.event_loop
+    {% if flag?(:execution_context) %}
+      Fiber::ExecutionContext.current.event_loop
+    {% else %}
+      Crystal::Scheduler.event_loop
+    {% end %}
   end
 
   @[AlwaysInline]
-  def self.current? : self?
-    Crystal::Scheduler.event_loop?
+  def self.current? : self | Nil
+    {% if flag?(:execution_context) %}
+      Fiber::ExecutionContext.current.event_loop
+    {% else %}
+      Crystal::Scheduler.event_loop?
+    {% end %}
   end
 
   # Runs the loop.
@@ -45,6 +53,13 @@ abstract class Crystal::EventLoop
   # events but blocking was false) and `false` when there are no registered
   # events.
   abstract def run(blocking : Bool) : Bool
+
+  {% if flag?(:execution_context) %}
+    # Same as `#run` but collects runnable fibers into *queue* instead of
+    # enqueueing in parallel, so the caller is responsible and in control for
+    # when and how the fibers will be enqueued.
+    abstract def run(queue : Fiber::Queue*, blocking : Bool) : Nil
+  {% end %}
 
   # Tells a blocking run loop to no longer wait for events to activate. It may
   # for example enqueue a NOOP event with an immediate (or past) timeout. Having

--- a/src/crystal/event_loop/iocp.cr
+++ b/src/crystal/event_loop/iocp.cr
@@ -55,6 +55,7 @@ class Crystal::EventLoop::IOCP < Crystal::EventLoop
     iocp
   end
 
+  # thread unsafe
   def run(blocking : Bool) : Bool
     enqueued = false
 
@@ -65,6 +66,13 @@ class Crystal::EventLoop::IOCP < Crystal::EventLoop
 
     enqueued
   end
+
+  {% if flag?(:execution_context) %}
+    # thread unsafe
+    def run(queue : Fiber::Queue*, blocking : Bool) : Nil
+      run_impl(blocking) { |fiber| queue.value.push(fiber) }
+    end
+  {% end %}
 
   # Runs the event loop and enqueues the fiber for the next upcoming event or
   # completion.

--- a/src/crystal/event_loop/libevent.cr
+++ b/src/crystal/event_loop/libevent.cr
@@ -20,26 +20,55 @@ class Crystal::EventLoop::LibEvent < Crystal::EventLoop
     event_base.loop(flags)
   end
 
+  {% if flag?(:execution_context) %}
+    def run(queue : Fiber::Queue*, blocking : Bool) : Nil
+      Crystal.trace :evloop, "run", fiber: fiber, blocking: blocking
+      @runnables = queue
+      run(blocking)
+    ensure
+      @runnables = nil
+    end
+
+    def callback_enqueue(fiber : Fiber) : Nil
+      if queue = @runnables
+        queue.value.push(fiber)
+      else
+        raise "BUG: libevent callback executed outside of #run(queue*, blocking) call"
+      end
+    end
+  {% end %}
+
   def interrupt : Nil
     event_base.loop_exit
   end
 
-  # Create a new resume event for a fiber.
+  # Create a new resume event for a fiber (sleep).
   def create_resume_event(fiber : Fiber) : Crystal::EventLoop::LibEvent::Event
     event_base.new_event(-1, LibEvent2::EventFlags::None, fiber) do |s, flags, data|
-      data.as(Fiber).enqueue
+      f = data.as(Fiber)
+      {% if flag?(:execution_context) %}
+        event_loop = Crystal::EventLoop.current.as(Crystal::EventLoop::LibEvent)
+        event_loop.callback_enqueue(f)
+      {% else %}
+        f.enqueue
+      {% end %}
     end
   end
 
-  # Creates a timeout_event.
+  # Creates a timeout event (timeout action of select expression).
   def create_timeout_event(fiber) : Crystal::EventLoop::LibEvent::Event
     event_base.new_event(-1, LibEvent2::EventFlags::None, fiber) do |s, flags, data|
       f = data.as(Fiber)
-      if (select_action = f.timeout_select_action)
+      if select_action = f.timeout_select_action
         f.timeout_select_action = nil
-        select_action.time_expired(f)
-      else
-        f.enqueue
+        if select_action.time_expired?
+          {% if flag?(:execution_context) %}
+            event_loop = Crystal::EventLoop.current.as(Crystal::EventLoop::LibEvent)
+            event_loop.callback_enqueue(f)
+          {% else %}
+            f.enqueue
+          {% end %}
+        end
       end
     end
   end

--- a/src/crystal/event_loop/polling.cr
+++ b/src/crystal/event_loop/polling.cr
@@ -112,13 +112,24 @@ abstract class Crystal::EventLoop::Polling < Crystal::EventLoop
     end
   {% end %}
 
-  # NOTE: thread unsafe
+  # thread unsafe
   def run(blocking : Bool) : Bool
     system_run(blocking) do |fiber|
-      Crystal::Scheduler.enqueue(fiber)
+      {% if flag?(:execution_context) %}
+        fiber.execution_context.enqueue(fiber)
+      {% else %}
+        Crystal::Scheduler.enqueue(fiber)
+      {% end %}
     end
     true
   end
+
+  {% if flag?(:execution_context) %}
+    # thread unsafe
+    def run(queue : Fiber::Queue*, blocking : Bool) : Nil
+      system_run(blocking) { |fiber| queue.value.push(fiber) }
+    end
+  {% end %}
 
   # fiber interface, see Crystal::EventLoop
 
@@ -303,13 +314,21 @@ abstract class Crystal::EventLoop::Polling < Crystal::EventLoop
     Polling.arena.free(index) do |pd|
       pd.value.@readers.ready_all do |event|
         pd.value.@event_loop.try(&.unsafe_resume_io(event) do |fiber|
-          Crystal::Scheduler.enqueue(fiber)
+          {% if flag?(:execution_context) %}
+            fiber.execution_context.enqueue(fiber)
+          {% else %}
+            Crystal::Scheduler.enqueue(fiber)
+          {% end %}
         end)
       end
 
       pd.value.@writers.ready_all do |event|
         pd.value.@event_loop.try(&.unsafe_resume_io(event) do |fiber|
-          Crystal::Scheduler.enqueue(fiber)
+          {% if flag?(:execution_context) %}
+            fiber.execution_context.enqueue(fiber)
+          {% else %}
+            Crystal::Scheduler.enqueue(fiber)
+          {% end %}
         end)
       end
 

--- a/src/crystal/scheduler.cr
+++ b/src/crystal/scheduler.cr
@@ -1,3 +1,5 @@
+{% skip_file if flag?(:execution_context) %}
+
 require "crystal/event_loop"
 require "crystal/system/print_error"
 require "fiber"
@@ -66,7 +68,6 @@ class Crystal::Scheduler
   end
 
   def self.sleep(time : Time::Span) : Nil
-    Crystal.trace :sched, "sleep", for: time
     Thread.current.scheduler.sleep(time)
   end
 

--- a/src/crystal/system/thread.cr
+++ b/src/crystal/system/thread.cr
@@ -79,6 +79,47 @@ class Thread
 
   getter name : String?
 
+  {% if flag?(:execution_context) %}
+    # :nodoc:
+    getter! execution_context : Fiber::ExecutionContext
+
+    # :nodoc:
+    property! scheduler : Fiber::ExecutionContext::Scheduler
+
+    # :nodoc:
+    def execution_context=(@execution_context : Fiber::ExecutionContext) : Fiber::ExecutionContext
+      main_fiber.execution_context = execution_context
+    end
+
+    # When a fiber terminates we can't release its stack until we swap context
+    # to another fiber. We can't free/unmap nor push it to a shared stack pool,
+    # that would result in a segfault.
+    @dead_fiber_stack : Pointer(Void)?
+
+    # :nodoc:
+    def dying_fiber(fiber : Fiber) : Pointer(Void)?
+      stack = @dead_fiber_stack
+      @dead_fiber_stack = fiber.@stack
+      stack
+    end
+
+    # :nodoc:
+    def dead_fiber_stack? : Pointer(Void)?
+      if stack = @dead_fiber_stack
+        @dead_fiber_stack = nil
+        stack
+      end
+    end
+  {% else %}
+    # :nodoc:
+    getter scheduler : Crystal::Scheduler { Crystal::Scheduler.new(self) }
+
+    # :nodoc:
+    def scheduler? : ::Crystal::Scheduler?
+      @scheduler
+    end
+  {% end %}
+
   def self.unsafe_each(&)
     # nothing to iterate when @@threads is nil + don't lazily allocate in a
     # method called from a GC collection callback!
@@ -163,14 +204,6 @@ class Thread
   def self.name=(name : String) : String
     thread = Thread.current
     thread.name = name
-  end
-
-  # :nodoc:
-  getter scheduler : Crystal::Scheduler { Crystal::Scheduler.new(self) }
-
-  # :nodoc:
-  def scheduler? : ::Crystal::Scheduler?
-    @scheduler
   end
 
   protected def start

--- a/src/crystal/system/thread_wait_group.cr
+++ b/src/crystal/system/thread_wait_group.cr
@@ -1,0 +1,20 @@
+# :nodoc:
+class Thread::WaitGroup
+  def initialize(@count : Int32)
+    @mutex = Thread::Mutex.new
+    @condition = Thread::ConditionVariable.new
+  end
+
+  def done : Nil
+    @mutex.synchronize do
+      @count -= 1
+      @condition.broadcast if @count == 0
+    end
+  end
+
+  def wait : Nil
+    @mutex.synchronize do
+      @condition.wait(@mutex) unless @count == 0
+    end
+  end
+end

--- a/src/crystal/tracing.cr
+++ b/src/crystal/tracing.cr
@@ -81,6 +81,16 @@ module Crystal
           write value.name || '?'
         end
 
+        {% if flag?(:execution_context) %}
+          def write(value : Fiber::ExecutionContext) : Nil
+            write value.name
+          end
+
+          def write(value : Fiber::ExecutionContext::Scheduler) : Nil
+            write value.name
+          end
+        {% end %}
+
         def write(value : Pointer) : Nil
           write "0x"
           System.to_int_slice(value.address, 16, true, 2) { |bytes| write(bytes) }

--- a/src/fiber.cr
+++ b/src/fiber.cr
@@ -76,6 +76,9 @@ class Fiber
   property previous : Fiber?
 
   # :nodoc:
+  property list_next : Fiber?
+
+  # :nodoc:
   def self.inactive(fiber : Fiber)
     fibers.delete(fiber)
   end

--- a/src/fiber.cr
+++ b/src/fiber.cr
@@ -67,13 +67,20 @@ class Fiber
   property name : String?
 
   @alive = true
-  {% if flag?(:preview_mt) %} @current_thread = Atomic(Thread?).new(nil) {% end %}
+
+  {% if flag?(:preview_mt) && !flag?(:execution_context) %}
+    @current_thread = Atomic(Thread?).new(nil)
+  {% end %}
 
   # :nodoc:
   property next : Fiber?
 
   # :nodoc:
   property previous : Fiber?
+
+  {% if flag?(:execution_context) %}
+    property! execution_context : ExecutionContext
+  {% end %}
 
   # :nodoc:
   property list_next : Fiber?
@@ -95,16 +102,19 @@ class Fiber
     fibers.each { |fiber| yield fiber }
   end
 
+  {% begin %}
   # Creates a new `Fiber` instance.
   #
   # When the fiber is executed, it runs *proc* in its context.
   #
   # *name* is an optional and used only as an internal reference.
-  def initialize(@name : String? = nil, &@proc : ->)
+  def initialize(@name : String? = nil, {% if flag?(:execution_context) %}@execution_context : ExecutionContext = ExecutionContext.current,{% end %} &@proc : ->)
     @context = Context.new
     @stack, @stack_bottom =
       {% if flag?(:interpreted) %}
         {Pointer(Void).null, Pointer(Void).null}
+      {% elsif flag?(:execution_context) %}
+        execution_context.stack_pool.checkout
       {% else %}
         Crystal::Scheduler.stack_pool.checkout
       {% end %}
@@ -134,6 +144,7 @@ class Fiber
 
     Fiber.fibers.push(self)
   end
+  {% end %}
 
   # :nodoc:
   def initialize(@stack : Void*, thread)
@@ -150,13 +161,22 @@ class Fiber
       {% end %}
     thread.gc_thread_handler, @stack_bottom = GC.current_thread_stack_bottom
     @name = "main"
-    {% if flag?(:preview_mt) %} @current_thread.set(thread) {% end %}
+
+    {% if flag?(:preview_mt) && !flag?(:execution_context) %}
+      @current_thread.set(thread)
+    {% end %}
+
     Fiber.fibers.push(self)
+
+    # we don't initialize @execution_context here (we may not have an execution
+    # context yet), and we can't detect ExecutionContext.current (we may reach
+    # an infinite recursion).
   end
 
   # :nodoc:
   def run
     GC.unlock_read
+
     @proc.call
   rescue ex
     if name = @name
@@ -178,9 +198,21 @@ class Fiber
     @exec_recursive_clone_hash = nil
 
     @alive = false
+
+    # the interpreter is managing the stacks
     {% unless flag?(:interpreted) %}
-      Crystal::Scheduler.stack_pool.release(@stack)
+      {% if flag?(:execution_context) %}
+        # do not prematurely release the stack before we switch to another fiber
+        if stack = Thread.current.dying_fiber(self)
+          # we can however release the stack of a previously dying fiber (we
+          # since swapped context)
+          execution_context.stack_pool.release(stack)
+        end
+      {% else %}
+        Crystal::Scheduler.stack_pool.release(@stack)
+      {% end %}
     {% end %}
+
     Fiber.suspend
   end
 
@@ -222,7 +254,11 @@ class Fiber
   # puts "never reached"
   # ```
   def resume : Nil
-    Crystal::Scheduler.resume(self)
+    {% if flag?(:execution_context) %}
+      ExecutionContext.resume(self)
+    {% else %}
+      Crystal::Scheduler.resume(self)
+    {% end %}
   end
 
   # Adds this fiber to the scheduler's runnables queue for the current thread.
@@ -231,7 +267,11 @@ class Fiber
   # the next time it has the opportunity to reschedule to another fiber. There
   # are no guarantees when that will happen.
   def enqueue : Nil
-    Crystal::Scheduler.enqueue(self)
+    {% if flag?(:execution_context) %}
+      execution_context.enqueue(self)
+    {% else %}
+      Crystal::Scheduler.enqueue(self)
+    {% end %}
   end
 
   # :nodoc:
@@ -299,7 +339,14 @@ class Fiber
   # end
   # ```
   def self.yield : Nil
-    Crystal::Scheduler.yield
+    Crystal.trace :sched, "yield"
+
+    {% if flag?(:execution_context) %}
+      Fiber.current.resume_event.add(0.seconds)
+      Fiber.suspend
+    {% else %}
+      Crystal::Scheduler.yield
+    {% end %}
   end
 
   # Suspends execution of the current fiber indefinitely.
@@ -313,7 +360,11 @@ class Fiber
   # useful if the fiber needs to wait  for something to happen (for example an IO
   # event, a message is ready in a channel, etc.) which triggers a re-enqueue.
   def self.suspend : Nil
-    Crystal::Scheduler.reschedule
+    {% if flag?(:execution_context) %}
+      ExecutionContext.reschedule
+    {% else %}
+      Crystal::Scheduler.reschedule
+    {% end %}
   end
 
   def to_s(io : IO) : Nil
@@ -335,7 +386,7 @@ class Fiber
     GC.push_stack @context.stack_top, @stack_bottom
   end
 
-  {% if flag?(:preview_mt) %}
+  {% if flag?(:preview_mt) && !flag?(:execution_context) %}
     # :nodoc:
     def set_current_thread(thread = Thread.current) : Thread
       @current_thread.set(thread)

--- a/src/fiber/execution_context.cr
+++ b/src/fiber/execution_context.cr
@@ -1,0 +1,117 @@
+require "../crystal/event_loop"
+require "../crystal/system/thread"
+require "../crystal/system/thread_linked_list"
+require "../fiber"
+require "./stack_pool"
+require "./execution_context/scheduler"
+
+{% raise "ERROR: execution contexts require the `preview_mt` compilation flag" unless flag?(:preview_mt) %}
+{% raise "ERROR: execution contexts require the `execution_context` compilation flag" unless flag?(:execution_context) %}
+
+module Fiber::ExecutionContext
+  @@default : ExecutionContext?
+
+  # Returns the default `ExecutionContext` for the process, automatically
+  # started when the program started.
+  @[AlwaysInline]
+  def self.default : ExecutionContext
+    @@default.not_nil!("expected default execution context to have been setup")
+  end
+
+  # :nodoc:
+  def self.init_default_context : Nil
+    raise NotImplementedError.new("No execution context implementations (yet)")
+  end
+
+  # Returns the default number of workers to start in the execution context.
+  def self.default_workers_count : Int32
+    ENV["CRYSTAL_WORKERS"]?.try(&.to_i?) || Math.min(System.cpu_count.to_i, 32)
+  end
+
+  # :nodoc:
+  protected class_getter(execution_contexts) { Thread::LinkedList(ExecutionContext).new }
+
+  # :nodoc:
+  property next : ExecutionContext?
+
+  # :nodoc:
+  property previous : ExecutionContext?
+
+  # :nodoc:
+  def self.unsafe_each(&) : Nil
+    @@execution_contexts.try(&.unsafe_each { |execution_context| yield execution_context })
+  end
+
+  # Iterates all execution contexts.
+  def self.each(&) : Nil
+    execution_contexts.each { |execution_context| yield execution_context }
+  end
+
+  # Returns the `ExecutionContext` the current fiber is running in.
+  @[AlwaysInline]
+  def self.current : ExecutionContext
+    Thread.current.execution_context
+  end
+
+  # :nodoc:
+  #
+  # Tells the current scheduler to suspend the current fiber and resume the
+  # next runnable fiber. The current fiber will never be resumed; you're
+  # responsible to reenqueue it.
+  #
+  # This method is safe as it only operates on the current `ExecutionContext`
+  # and `Scheduler`.
+  @[AlwaysInline]
+  def self.reschedule : Nil
+    Scheduler.current.reschedule
+  end
+
+  # :nodoc:
+  #
+  # Tells the current scheduler to suspend the current fiber and to resume
+  # *fiber* instead. The current fiber will never be resumed; you're responsible
+  # to reenqueue it.
+  #
+  # Raises `RuntimeError` if the fiber doesn't belong to the current execution
+  # context.
+  #
+  # This method is safe as it only operates on the current `ExecutionContext`
+  # and `Scheduler`.
+  def self.resume(fiber : Fiber) : Nil
+    if fiber.execution_context == current
+      Scheduler.current.resume(fiber)
+    else
+      raise RuntimeError.new("Can't resume fiber from #{fiber.execution_context} into #{current}")
+    end
+  end
+
+  # Creates a new fiber then calls `#enqueue` to add it to the execution
+  # context.
+  #
+  # May be called from any `ExecutionContext` (i.e. must be thread-safe).
+  def spawn(*, name : String? = nil, &block : ->) : Fiber
+    Fiber.new(name, self, &block).tap { |fiber| enqueue(fiber) }
+  end
+
+  # :nodoc:
+  #
+  # Legacy support for the `same_thread` argument. Each execution context may
+  # decide to support it or not (e.g. a single threaded context can accept it).
+  abstract def spawn(*, name : String? = nil, same_thread : Bool, &block : ->) : Fiber
+
+  # :nodoc:
+  abstract def stack_pool : Fiber::StackPool
+
+  # :nodoc:
+  abstract def stack_pool? : Fiber::StackPool?
+
+  # :nodoc:
+  abstract def event_loop : Crystal::EventLoop
+
+  # :nodoc:
+  #
+  # Enqueues a fiber to be resumed inside the execution context.
+  #
+  # May be called from any ExecutionContext (i.e. must be thread-safe).
+  abstract def enqueue(fiber : Fiber) : Nil
+end

--- a/src/fiber/execution_context/global_queue.cr
+++ b/src/fiber/execution_context/global_queue.cr
@@ -1,0 +1,106 @@
+# The queue is a port of Go's `globrunq*` functions, distributed under a
+# BSD-like license:
+# <https://cs.opensource.google/go/go/+/release-branch.go1.23:LICENSE>
+
+require "../list"
+require "./runnables"
+
+module Fiber::ExecutionContext
+  # :nodoc:
+  #
+  # Global queue of runnable fibers.
+  # Unbounded.
+  # Shared by all schedulers in an execution context.
+  #
+  # Basically a `Fiber::List` protected by a `Thread::Mutex`, at the exception of
+  # the `#grab?` method that tries to grab 1/Nth of the queue at once.
+  class GlobalQueue
+    def initialize(@mutex : Thread::Mutex)
+      @list = Fiber::List.new
+    end
+
+    # Grabs the lock and enqueues a runnable fiber on the global runnable queue.
+    def push(fiber : Fiber) : Nil
+      @mutex.synchronize { unsafe_push(fiber) }
+    end
+
+    # Enqueues a runnable fiber on the global runnable queue. Assumes the lock
+    # is currently held.
+    def unsafe_push(fiber : Fiber) : Nil
+      @list.push(fiber)
+    end
+
+    # Grabs the lock and puts a runnable fiber on the global runnable queue.
+    def bulk_push(list : Fiber::List*) : Nil
+      @mutex.synchronize { unsafe_bulk_push(list) }
+    end
+
+    # Puts a runnable fiber on the global runnable queue. Assumes the lock is
+    # currently held.
+    def unsafe_bulk_push(list : Fiber::List*) : Nil
+      @list.bulk_unshift(list)
+    end
+
+    # Grabs the lock and dequeues one runnable fiber from the global runnable
+    # queue.
+    def pop? : Fiber?
+      @mutex.synchronize { unsafe_pop? }
+    end
+
+    # Dequeues one runnable fiber from the global runnable queue. Assumes the
+    # lock is currently held.
+    def unsafe_pop? : Fiber?
+      @list.pop?
+    end
+
+    # Grabs the lock then tries to grab a batch of fibers from the global
+    # runnable queue. Returns the next runnable fiber or `nil` if the queue was
+    # empty.
+    #
+    # `divisor` is meant for fair distribution of fibers across threads in the
+    # execution context; it should be the number of threads.
+    def grab?(runnables : Runnables, divisor : Int32) : Fiber?
+      @mutex.synchronize { unsafe_grab?(runnables, divisor) }
+    end
+
+    # Try to grab a batch of fibers from the global runnable queue. Returns the
+    # next runnable fiber or `nil` if the queue was empty. Assumes the lock is
+    # currently held.
+    #
+    # `divisor` is meant for fair distribution of fibers across threads in the
+    # execution context; it should be the number of threads.
+    def unsafe_grab?(runnables : Runnables, divisor : Int32) : Fiber?
+      # ported from Go: globrunqget
+      return if @list.empty?
+
+      divisor = 1 if divisor < 1
+      size = @list.size
+
+      n = {
+        size,                    # can't grab more than available
+        size // divisor + 1,     # divide + try to take at least 1 fiber
+        runnables.capacity // 2, # refill half the destination queue
+      }.min
+
+      fiber = @list.pop?
+
+      # OPTIMIZE: list = @list.split(n - 1) then `runnables.push(pointerof(list))` (?)
+      (n - 1).times do
+        break unless f = @list.pop?
+        runnables.push(f)
+      end
+
+      fiber
+    end
+
+    @[AlwaysInline]
+    def empty? : Bool
+      @list.empty?
+    end
+
+    @[AlwaysInline]
+    def size : Int32
+      @list.size
+    end
+  end
+end

--- a/src/fiber/execution_context/runnables.cr
+++ b/src/fiber/execution_context/runnables.cr
@@ -1,0 +1,209 @@
+# The queue is a port of Go's `runq*` functions, distributed under a BSD-like
+# license: <https://cs.opensource.google/go/go/+/release-branch.go1.23:LICENSE>
+#
+# The queue derivates from the chase-lev lock-free queue with adaptations:
+#
+# - single ring buffer (per scheduler);
+# - on overflow: bulk push half the ring to `GlobalQueue`;
+# - on empty: bulk grab up to half the ring from `GlobalQueue`;
+# - bulk push operation;
+
+require "../list"
+require "./global_queue"
+
+module Fiber::ExecutionContext
+  # :nodoc:
+  #
+  # Local queue or runnable fibers for schedulers.
+  # Bounded.
+  # First-in, first-out semantics (FIFO).
+  # Single producer, multiple consumers thread safety.
+  #
+  # Private to an execution context scheduler, except for stealing methods that
+  # can be called from any thread in the execution context.
+  class Runnables(N)
+    def initialize(@global_queue : GlobalQueue)
+      # head is an index to the buffer where the next fiber to dequeue is.
+      #
+      # tail is an index to the buffer where the next fiber to enqueue will be
+      # (on the next push).
+      #
+      # head is always behind tail (not empty) or equal (empty) but never after
+      # tail (the queue would have a negative size => bug).
+      @head = Atomic(UInt32).new(0)
+      @tail = Atomic(UInt32).new(0)
+      @buffer = uninitialized Fiber[N]
+    end
+
+    @[AlwaysInline]
+    def capacity : Int32
+      N
+    end
+
+    # Tries to push fiber on the local runnable queue. If the run queue is full,
+    # pushes fiber on the global queue, which will grab the global lock.
+    #
+    # Executed only by the owner.
+    def push(fiber : Fiber) : Nil
+      # ported from Go: runqput
+      loop do
+        head = @head.get(:acquire) # sync with consumers
+        tail = @tail.get(:relaxed)
+
+        if (tail &- head) < N
+          # put fiber to local queue
+          @buffer.to_unsafe[tail % N] = fiber
+
+          # make the fiber available for consumption
+          @tail.set(tail &+ 1, :release)
+          return
+        end
+
+        if push_slow(fiber, head, tail)
+          return
+        end
+
+        # failed to advance head (another scheduler stole fibers),
+        # the queue isn't full, now the push above must succeed
+      end
+    end
+
+    private def push_slow(fiber : Fiber, head : UInt32, tail : UInt32) : Bool
+      # ported from Go: runqputslow
+      n = (tail &- head) // 2
+      raise "BUG: queue is not full" if n != N // 2
+
+      # first, try to grab half of the fibers from local queue
+      batch = uninitialized Fiber[N] # actually N // 2 + 1 but that doesn't compile
+      n.times do |i|
+        batch.to_unsafe[i] = @buffer.to_unsafe[(head &+ i) % N]
+      end
+      _, success = @head.compare_and_set(head, head &+ n, :acquire_release, :acquire)
+      return false unless success
+
+      # append fiber to the batch
+      batch.to_unsafe[n] = fiber
+
+      # link the fibers
+      n.times do |i|
+        batch.to_unsafe[i].list_next = batch.to_unsafe[i &+ 1]
+      end
+      list = Fiber::List.new(batch.to_unsafe[0], batch.to_unsafe[n], size: (n &+ 1).to_i32)
+
+      # now put the batch on global queue (grabs the global lock)
+      @global_queue.bulk_push(pointerof(list))
+
+      true
+    end
+
+    # Tries to enqueue all the fibers in *list* into the local queue. If the
+    # local queue is full, the overflow will be pushed to the global queue; in
+    # that case this will temporarily acquire the global queue lock.
+    #
+    # Executed only by the owner.
+    def bulk_push(list : Fiber::List*) : Nil
+      # ported from Go: runqputbatch
+      head = @head.get(:acquire) # sync with other consumers
+      tail = @tail.get(:relaxed)
+
+      while !list.value.empty? && (tail &- head) < N
+        fiber = list.value.pop
+        @buffer.to_unsafe[tail % N] = fiber
+        tail &+= 1
+      end
+
+      # make the fibers available for consumption
+      @tail.set(tail, :release)
+
+      # put any overflow on global queue
+      @global_queue.bulk_push(list) unless list.value.empty?
+    end
+
+    # Dequeues the next runnable fiber from the local queue.
+    #
+    # Executed only by the owner.
+    def shift? : Fiber?
+      # ported from Go: runqget
+
+      head = @head.get(:acquire) # sync with other consumers
+      loop do
+        tail = @tail.get(:relaxed)
+        return if tail == head
+
+        fiber = @buffer.to_unsafe[head % N]
+        head, success = @head.compare_and_set(head, head &+ 1, :acquire_release, :acquire)
+        return fiber if success
+      end
+    end
+
+    # Steals half the fibers from the local queue of `src` and puts them onto
+    # the local queue. Returns one of the stolen fibers, or `nil` on failure.
+    #
+    # Executed only by the owner (when the local queue is empty).
+    def steal_from(src : Runnables(N)) : Fiber?
+      # ported from Go: runqsteal
+
+      tail = @tail.get(:relaxed)
+      n = src.grab(@buffer.to_unsafe, tail)
+      return if n == 0
+
+      # 'dequeue' last fiber from @buffer
+      n &-= 1
+      fiber = @buffer.to_unsafe[(tail &+ n) % N]
+      return fiber if n == 0
+
+      head = @head.get(:acquire) # sync with consumers
+      if tail &- head &+ n >= N
+        raise "BUG: local queue overflow"
+      end
+
+      # make the fibers available for consumption
+      @tail.set(tail &+ n, :release)
+
+      fiber
+    end
+
+    # Grabs a batch of fibers from local queue into `buffer` of size N (normally
+    # the ring buffer of another `Runnables`) starting at `buffer_head`. Returns
+    # number of grabbed fibers.
+    #
+    # Can be executed by any scheduler.
+    protected def grab(buffer : Fiber*, buffer_head : UInt32) : UInt32
+      # ported from Go: runqgrab
+
+      head = @head.get(:acquire) # sync with other consumers
+      loop do
+        tail = @tail.get(:acquire) # sync with the producer
+
+        n = tail &- head
+        n -= n // 2
+        return 0_u32 if n == 0 # queue is empty
+
+        if n > N // 2
+          # read inconsistent head and tail
+          head = @head.get(:acquire)
+          next
+        end
+
+        n.times do |i|
+          fiber = @buffer.to_unsafe[(head &+ i) % N]
+          buffer[(buffer_head &+ i) % N] = fiber
+        end
+
+        # try to mark the fiber as consumed
+        head, success = @head.compare_and_set(head, head &+ n, :acquire_release, :acquire)
+        return n if success
+      end
+    end
+
+    @[AlwaysInline]
+    def empty? : Bool
+      @head.get(:relaxed) == @tail.get(:relaxed)
+    end
+
+    @[AlwaysInline]
+    def size : UInt32
+      @tail.get(:relaxed) &- @head.get(:relaxed)
+    end
+  end
+end

--- a/src/fiber/execution_context/scheduler.cr
+++ b/src/fiber/execution_context/scheduler.cr
@@ -1,0 +1,72 @@
+module Fiber::ExecutionContext
+  # :nodoc:
+  module Scheduler
+    @[AlwaysInline]
+    def self.current : Scheduler
+      Thread.current.scheduler
+    end
+
+    protected abstract def thread : Thread
+    protected abstract def execution_context : ExecutionContext
+
+    # Instantiates a fiber and enqueues it into the scheduler's local queue.
+    def spawn(*, name : String? = nil, &block : ->) : Fiber
+      fiber = Fiber.new(name, execution_context, &block)
+      enqueue(fiber)
+      fiber
+    end
+
+    # Legacy support for the *same_thread* argument. Each execution context may
+    # decide to support it or not (e.g. a single threaded context can accept it).
+    abstract def spawn(*, name : String? = nil, same_thread : Bool, &block : ->) : Fiber
+
+    # Suspends the current fiber and resumes *fiber* instead.
+    # The current fiber will never be resumed; you're responsible to reenqueue it.
+    #
+    # Unsafe. Must only be called on `ExecutionContext.current`. Prefer
+    # `ExecutionContext.enqueue` instead.
+    protected abstract def enqueue(fiber : Fiber) : Nil
+
+    # Suspends the execution of the current fiber and resumes the next runnable
+    # fiber.
+    #
+    # Unsafe. Must only be called on `ExecutionContext.current`. Prefer
+    # `ExecutionContext.reschedule` instead.
+    protected abstract def reschedule : Nil
+
+    # Suspends the execution of the current fiber and resumes *fiber*.
+    #
+    # The current fiber will never be resumed; you're responsible to reenqueue
+    # it.
+    #
+    # Unsafe. Must only be called on `ExecutionContext.current`. Prefer
+    # `ExecutionContext.resume` instead.
+    protected abstract def resume(fiber : Fiber) : Nil
+
+    # Switches the thread from running the current fiber to run *fiber* instead.
+    #
+    # Handles thread safety around fiber stacks by locking the GC, so it won't
+    # start a GC collection while we're switching context.
+    #
+    # Unsafe. Must only be called by the current scheduler. The caller must
+    # ensure that the fiber indeed belongs to the current execution context and
+    # that the fiber can indeed be resumed.
+    #
+    # WARNING: after switching context you can't trust *self* anymore (it is the
+    # scheduler that resumed *fiber* which may not be the one that suspended
+    # *fiber*) or instance variables; local variables however are the ones from
+    # before swapping context.
+    protected def swapcontext(fiber : Fiber) : Nil
+      current_fiber = thread.current_fiber
+
+      GC.lock_read
+      thread.current_fiber = fiber
+      Fiber.swapcontext(pointerof(current_fiber.@context), pointerof(fiber.@context))
+      GC.unlock_read
+    end
+
+    # Returns the current status of the scheduler. For example `"running"`,
+    # `"event-loop"` or `"parked"`.
+    abstract def status : String
+  end
+end

--- a/src/fiber/list.cr
+++ b/src/fiber/list.cr
@@ -1,0 +1,89 @@
+# The list is modeled after Go's `gQueue`, distributed under a BSD-like
+# license: <https://cs.opensource.google/go/go/+/release-branch.go1.23:LICENSE>
+
+class Fiber
+  # :nodoc:
+  #
+  # Singly-linked list of `Fiber`.
+  # Last-in, first-out (LIFO) semantic.
+  # A fiber can only exist within a single `List` at any time.
+  #
+  # This list if simpler than `Crystal::PointerLinkedList` which is a doubly
+  # linked list. It's meant to maintain a queue of runnable fibers, or to
+  # quickly collect an arbitrary number of fibers; situations where we don't
+  # need arbitrary deletions from anywhere in the list.
+  #
+  # Thread unsafe! An external lock is required for concurrent accesses.
+  struct List
+    getter size : Int32
+
+    def initialize(@head : Fiber? = nil, @tail : Fiber? = nil, @size = 0)
+    end
+
+    # Appends *fiber* to the head of the list.
+    def push(fiber : Fiber) : Nil
+      fiber.list_next = @head
+      @head = fiber
+      @tail = fiber if @tail.nil?
+      @size += 1
+    end
+
+    # Appends all the fibers from *other* to the tail of the list.
+    def bulk_unshift(other : List*) : Nil
+      return unless last = other.value.@tail
+      last.list_next = nil
+
+      if tail = @tail
+        tail.list_next = other.value.@head
+      else
+        @head = other.value.@head
+      end
+      @tail = last
+
+      @size += other.value.size
+    end
+
+    # Removes a fiber from the head of the list. Raises `IndexError` when
+    # empty.
+    @[AlwaysInline]
+    def pop : Fiber
+      pop { raise IndexError.new }
+    end
+
+    # Removes a fiber from the head of the list. Returns `nil` when empty.
+    @[AlwaysInline]
+    def pop? : Fiber?
+      pop { nil }
+    end
+
+    private def pop(&)
+      if fiber = @head
+        @head = fiber.list_next
+        @tail = nil if @head.nil?
+        @size -= 1
+        fiber.list_next = nil
+        fiber
+      else
+        yield
+      end
+    end
+
+    @[AlwaysInline]
+    def empty? : Bool
+      @head == nil
+    end
+
+    def clear : Nil
+      @size = 0
+      @head = @tail = nil
+    end
+
+    def each(&) : Nil
+      cursor = @head
+      while cursor
+        yield cursor
+        cursor = cursor.list_next
+      end
+    end
+  end
+end

--- a/src/fiber/stack_pool.cr
+++ b/src/fiber/stack_pool.cr
@@ -5,6 +5,11 @@ class Fiber
   class StackPool
     STACK_SIZE = 8 * 1024 * 1024
 
+    {% if flag?(:execution_context) %}
+      # must explicitly declare the variable because of the macro in #initialize
+      @lock = uninitialized Crystal::SpinLock
+    {% end %}
+
     # If *protect* is true, guards all top pages (pages with the lowest address
     # values) in the allocated stacks; accessing them triggers an error
     # condition, allowing stack overflows on non-main fibers to be detected.
@@ -13,6 +18,10 @@ class Fiber
     # pointer value) rather than downwards, so *protect* must be false.
     def initialize(@protect : Bool = true)
       @deque = Deque(Void*).new
+
+      {% if flag?(:execution_context) %}
+        @lock = Crystal::SpinLock.new
+      {% end %}
     end
 
     def finalize
@@ -25,7 +34,7 @@ class Fiber
     # returning memory to the operating system.
     def collect(count = lazy_size // 2) : Nil
       count.times do
-        if stack = @deque.shift?
+        if stack = shift?
           Crystal::System::Fiber.free_stack(stack, STACK_SIZE)
         else
           return
@@ -42,7 +51,7 @@ class Fiber
 
     # Removes a stack from the bottom of the pool, or allocates a new one.
     def checkout : {Void*, Void*}
-      if stack = @deque.pop?
+      if stack = pop?
         Crystal::System::Fiber.reset_stack(stack, STACK_SIZE, @protect)
       else
         stack = Crystal::System::Fiber.allocate_stack(STACK_SIZE, @protect)
@@ -52,13 +61,37 @@ class Fiber
 
     # Appends a stack to the bottom of the pool.
     def release(stack) : Nil
-      @deque.push(stack)
+      {% if flag?(:execution_context) %}
+        @lock.sync { @deque.push(stack) }
+      {% else %}
+        @deque.push(stack)
+      {% end %}
     end
 
     # Returns the approximated size of the pool. It may be equal or slightly
     # bigger or smaller than the actual size.
     def lazy_size : Int32
       @deque.size
+    end
+
+    private def shift?
+      {% if flag?(:execution_context) %}
+        @lock.sync { @deque.shift? } unless @deque.empty?
+      {% else %}
+        @deque.shift?
+      {% end %}
+    end
+
+    private def pop?
+      {% if flag?(:execution_context) %}
+        if stack = Thread.current.dead_fiber_stack?
+          stack
+        else
+          @lock.sync { @deque.pop? } unless @deque.empty?
+        end
+      {% else %}
+        @deque.pop?
+      {% end %}
     end
   end
 end

--- a/src/io/evented.cr
+++ b/src/io/evented.cr
@@ -20,7 +20,12 @@ module IO::Evented
     @read_timed_out = timed_out
 
     if reader = @readers.get?.try &.shift?
-      reader.enqueue
+      {% if flag?(:execution_context) && Crystal::EventLoop.has_constant?(:LibEvent) %}
+        event_loop = Crystal::EventLoop.current.as(Crystal::EventLoop::LibEvent)
+        event_loop.callback_enqueue(reader)
+      {% else %}
+        reader.enqueue
+      {% end %}
     end
   end
 
@@ -29,7 +34,12 @@ module IO::Evented
     @write_timed_out = timed_out
 
     if writer = @writers.get?.try &.shift?
-      writer.enqueue
+      {% if flag?(:execution_context) && Crystal::EventLoop.has_constant?(:LibEvent) %}
+        event_loop = Crystal::EventLoop.current.as(Crystal::EventLoop::LibEvent)
+        event_loop.callback_enqueue(reader)
+      {% else %}
+        writer.enqueue
+      {% end %}
     end
   end
 
@@ -89,11 +99,19 @@ module IO::Evented
     @write_event.consume_each &.free
 
     @readers.consume_each do |readers|
-      Crystal::Scheduler.enqueue readers
+      {% if flag?(:execution_context) %}
+        readers.each { |fiber| fiber.execution_context.enqueue fiber }
+      {% else %}
+        Crystal::Scheduler.enqueue readers
+      {% end %}
     end
 
     @writers.consume_each do |writers|
-      Crystal::Scheduler.enqueue writers
+      {% if flag?(:execution_context) %}
+        writers.each { |fiber| fiber.execution_context.enqueue fiber }
+      {% else %}
+        Crystal::Scheduler.enqueue writers
+      {% end %}
     end
   end
 

--- a/src/kernel.cr
+++ b/src/kernel.cr
@@ -608,7 +608,11 @@ end
   Exception::CallStack.load_debug_info if ENV["CRYSTAL_LOAD_DEBUG_INFO"]? == "1"
   Exception::CallStack.setup_crash_handler
 
-  Crystal::Scheduler.init
+  {% if flag?(:execution_context) %}
+    Fiber::ExecutionContext.init_default_context
+  {% else %}
+    Crystal::Scheduler.init
+  {% end %}
 
   {% if flag?(:win32) %}
     Crystal::System::Process.start_interrupt_loop

--- a/src/raise.cr
+++ b/src/raise.cr
@@ -1,5 +1,6 @@
 require "c/stdio"
 require "c/stdlib"
+require "crystal/system/print_error"
 require "exception/call_stack"
 
 Exception::CallStack.skip(__FILE__)


### PR DESCRIPTION
`Fiber#initialize` now takes an explicit stack. The public API doesn't change, and we can still create a `Fiber` without an explicit stack, taken from the current scheduler/context's stack pool.

`Fiber::ExecutionContext#spawn` takes advantage of this to take a stack from the execution context's stack pool, instead of the current context's stack pool. Cross context spawns thus won't take a stack from context A but release the stack in context B (where it actually ran) which would prevent stack recycling.

This also permits to create lots of Fiber instances in specs using a minimal fake stack, instead of requesting 8MB of virtual memory for each fiber, despite the fibers never running... which is leaking memory because we only release the stacks when the fiber terminates.

Follow up to #15345 and #15350 