### PR TITLE
Fix LLVM version detection for `-rc1`

### DIFF
--- a/src/llvm/lib_llvm.cr
+++ b/src/llvm/lib_llvm.cr
@@ -35,7 +35,7 @@
 
   @[Link(ldflags: {{ llvm_ldflags }})]
   lib LibLLVM
-    VERSION = {{ llvm_version.strip.gsub(/git/, "").gsub(/rc.*/, "") }}
+    VERSION = {{ llvm_version.strip.gsub(/git/, "").gsub(/-?rc.*/, "") }}
     BUILT_TARGETS = {{ llvm_targets.strip.downcase.split(' ').map(&.id.symbolize) }}
   end
 {% end %}


### PR DESCRIPTION
The new [LLVM 20.1.0-rc1 release](https://github.com/llvm/llvm-project/releases/tag/llvmorg-20.1.0-rc1)'s `llvm-config` is a proper semantic version that has a hyphen before the `rc1` part, and needs to be stripped.