### PR TITLE
Add backports to changelog generator

### DIFF
--- a/scripts/github-changelog.cr
+++ b/scripts/github-changelog.cr
@@ -271,6 +271,10 @@ record PullRequest,
     md = title.match(/\[fixup #(.\d+)/) || return
     md[1]?.try(&.to_i)
   end
+
+  def clean_title
+    title.sub(/^\[?(?:#{type}|#{sub_topic})(?::|\]:?) /i, "")
+  end
 end
 
 def query_milestone(api_token, repository, number)
@@ -342,7 +346,7 @@ struct ChangelogEntry
     if pr.deprecated?
       io << "**[deprecation]** "
     end
-    io << pr.title.sub(/^\[?(?:#{pr.type}|#{pr.sub_topic})(?::|\]:?) /i, "")
+    io << pr.clean_title
 
     io << " ("
     pull_requests.join(io, ", ") do |pr|

--- a/scripts/github-changelog.cr
+++ b/scripts/github-changelog.cr
@@ -273,7 +273,15 @@ record PullRequest,
   end
 
   def clean_title
-    title.sub(/^\[?(?:#{type}|#{sub_topic})(?::|\]:?) /i, "")
+    title.sub(/^\[?(?:#{type}|#{sub_topic})(?::|\]:?) /i, "").sub(/\s*\[Backport [^\]]+\]\s*/, "")
+  end
+
+  def backported?
+    labels.any?(&.starts_with?("backport"))
+  end
+
+  def backport?
+    title.includes?("[Backport ")
   end
 end
 
@@ -316,8 +324,9 @@ end
 
 milestone = query_milestone(api_token, repository, milestone)
 
-struct ChangelogEntry
+class ChangelogEntry
   getter pull_requests : Array(PullRequest)
+  property backported_from : PullRequest?
 
   def initialize(pr : PullRequest)
     @pull_requests = [pr]
@@ -353,6 +362,11 @@ struct ChangelogEntry
       pr.link_ref(io)
     end
 
+    if backported_from = self.backported_from
+      io << ", backported from "
+      backported_from.link_ref(io)
+    end
+
     authors = collect_authors
     if authors.present?
       io << ", thanks "
@@ -365,15 +379,26 @@ struct ChangelogEntry
 
   def collect_authors
     authors = [] of String
-    pull_requests.each do |pr|
+
+    if backported_from = self.backported_from
+      if author = backported_from.author
+        authors << author
+      end
+    end
+
+    pull_requests.each_with_index do |pr, i|
+      next if backported_from && i.zero?
+
       author = pr.author || next
       authors << author unless authors.includes?(author)
     end
+
     authors
   end
 
   def print_ref_labels(io)
     pull_requests.each { |pr| print_ref_label(io, pr) }
+    backported_from.try { |pr| print_ref_label(io, pr) }
   end
 
   def print_ref_label(io, pr)
@@ -384,7 +409,7 @@ struct ChangelogEntry
 end
 
 entries = milestone.pull_requests.compact_map do |pr|
-  ChangelogEntry.new(pr) unless pr.fixup?
+  ChangelogEntry.new(pr) unless pr.fixup? || pr.backported?
 end
 
 milestone.pull_requests.each do |pr|
@@ -395,6 +420,17 @@ milestone.pull_requests.each do |pr|
     parent_entry.pull_requests << pr
   else
     STDERR.puts "Unresolved fixup: ##{parent_number} for: #{pr.title} (##{pr.number})"
+  end
+end
+
+milestone.pull_requests.each do |pr|
+  next unless pr.backported?
+
+  backport = entries.find { |entry| entry.pr.backport? && entry.pr.clean_title == pr.clean_title }
+  if backport
+    backport.backported_from = pr
+  else
+    STDERR.puts "Unresolved backport: #{pr.clean_title.inspect} (##{pr.number})"
   end
 end
 


### PR DESCRIPTION
_Re-submission of #15402 which got inadvertedly reverted during the release process in https://github.com/crystal-lang/crystal/pull/15406_

Adds support for the automated backport workflow added in #15372.

See the changelog for 1.15.1 as an example: #15401.