### PR TITLE
Reuse a global default OpenSSL::SSL::Context::Client in HTTP::Client

### DIFF
--- a/src/http/client.cr
+++ b/src/http/client.cr
@@ -137,7 +137,7 @@ class HTTP::Client
     {% else %}
       @tls = case tls
              when true
-               OpenSSL::SSL::Context::Client.new
+               OpenSSL::SSL::Context::Client.default
              when OpenSSL::SSL::Context::Client
                tls
              when false, nil

--- a/src/openssl/ssl/context.cr
+++ b/src/openssl/ssl/context.cr
@@ -49,6 +49,17 @@ abstract class OpenSSL::SSL::Context
       {% end %}
     end
 
+    # Returns a shared, global, default OpenSSL::SSL::Context::Client.
+    #
+    # The returned instance must not be modified. For customization,
+    # first instantiate your own OpenSSL::SSL::Context::Client.new.
+    #
+    # "A single SSL_CTX object can be used to create many connections [...]
+    # Note that you should not normally make changes to an SSL_CTX after the first
+    # SSL object has been created from it."
+    # - https://docs.openssl.org/3.4/man7/ossl-guide-libssl-introduction/
+    class_getter(default) { new }
+
     # Returns a new TLS client context with only the given method set.
     #
     # For everything else this uses the defaults of your OpenSSL.


### PR DESCRIPTION
Fixes https://github.com/crystal-lang/crystal/issues/15419 for a 12X performance win on `HTTP::Client.get("https://...")`, but exposes a mutable global default, which is not great.