### PR TITLE
Fix: don't set external linkage when `@[NoInline]` is specified

### DIFF
--- a/src/compiler/crystal/codegen/fun.cr
+++ b/src/compiler/crystal/codegen/fun.cr
@@ -337,7 +337,7 @@ class Crystal::CodeGenVisitor
       end
     end
 
-    if @single_module && !target_def.no_inline? && !target_def.is_a?(External)
+    if @single_module && !target_def.is_a?(External)
       context.fun.linkage = LLVM::Linkage::Internal
     end
 
@@ -448,11 +448,7 @@ class Crystal::CodeGenVisitor
     context.fun.add_attribute LLVM::Attribute::ReturnsTwice if target_def.returns_twice?
     context.fun.add_attribute LLVM::Attribute::Naked if target_def.naked?
     context.fun.add_attribute LLVM::Attribute::NoReturn if target_def.no_returns?
-
-    if target_def.no_inline?
-      context.fun.add_attribute LLVM::Attribute::NoInline
-      context.fun.linkage = LLVM::Linkage::External
-    end
+    context.fun.add_attribute LLVM::Attribute::NoInline if target_def.no_inline?
   end
 
   def setup_closure_vars(def_vars, closure_vars, context, closure_type, closure_ptr)


### PR DESCRIPTION
Unlike `alwaysinline` that is treated by LLVM as a simple hint, the `noinline` function attribute is enough to tell LLVM to always generate the symbol and never inline the calls (even at aggressive optimizations).

We don't need to set the linkage to external as well.

Related to #921 