### PR TITLE
Add `:single module` compile time flag

### DIFF
--- a/src/compiler/crystal/command.cr
+++ b/src/compiler/crystal/command.cr
@@ -396,7 +396,7 @@ class Crystal::Command
       unless no_codegen
         unless run
           opts.on("--cross-compile", "cross-compile") do |cross_compile|
-            compiler.cross_compile = true
+            compiler.cross_compile!
           end
         end
         opts.on("-d", "--debug", "Add full symbolic debug info") do
@@ -424,7 +424,7 @@ class Crystal::Command
         valid_emit_values.map!(&.gsub('_', '-').downcase)
 
         opts.on("--emit [#{valid_emit_values.join('|')}]", "Comma separated list of types of output for the compiler to emit") do |emit_values|
-          compiler.emit_targets |= validate_emit_values(emit_values.split(',').map(&.strip))
+          compiler.add_emit_targets validate_emit_values(emit_values.split(',').map(&.strip))
         end
       end
 

--- a/src/compiler/crystal/compiler.cr
+++ b/src/compiler/crystal/compiler.cr
@@ -258,7 +258,7 @@ module Crystal
       @optimization_mode.o3? && @single_module
     end
 
-    def single_module?
+    def single_module_compilation?
       @single_module || @cross_compile || !@emit_targets.none?
     end
 
@@ -269,7 +269,7 @@ module Crystal
       program.codegen_target = codegen_target
       program.target_machine = create_target_machine
       program.flags << "release" if release?
-      program.flags << "single_module" if single_module?
+      program.flags << "single_module" if single_module_compilation?
       program.flags << "debug" unless debug.none?
       program.flags << "static" if static?
       program.flags.concat @flags
@@ -328,7 +328,7 @@ module Crystal
     private def codegen(program, node : ASTNode, sources, output_filename)
       llvm_modules = @progress_tracker.stage("Codegen (crystal)") do
         program.codegen node, debug: debug, frame_pointers: frame_pointers,
-          single_module: @single_module || @cross_compile || !@emit_targets.none?
+          single_module: single_module_compilation?
       end
 
       output_dir = CacheDir.instance.directory_for(sources)

--- a/src/compiler/crystal/compiler.cr
+++ b/src/compiler/crystal/compiler.cr
@@ -258,6 +258,10 @@ module Crystal
       @optimization_mode.o3? && @single_module
     end
 
+    def single_module?
+      @single_module || @cross_compile || !@emit_targets.none?
+    end
+
     private def new_program(sources)
       @program = program = Program.new
       program.compiler = self
@@ -265,6 +269,7 @@ module Crystal
       program.codegen_target = codegen_target
       program.target_machine = create_target_machine
       program.flags << "release" if release?
+      program.flags << "single_module" if single_module?
       program.flags << "debug" unless debug.none?
       program.flags << "static" if static?
       program.flags.concat @flags

--- a/src/compiler/crystal/macros/macros.cr
+++ b/src/compiler/crystal/macros/macros.cr
@@ -134,7 +134,6 @@ class Crystal::Program
           host_compiler.mcpu = compiler.mcpu
           host_compiler.mattr = compiler.mattr
           host_compiler.mcmodel = compiler.mcmodel
-          host_compiler.single_module = compiler.single_module?
           host_compiler.static = compiler.static?
         end
 


### PR DESCRIPTION
Just like the `:release` flag it can be useful to know during macros if we're compiling to a single module.

For example alongside the `Linkage` annotation, we would be able to mark the `__crystal_*` functions as internal only when compiling to a single module. For example:

```crystal
{% if flag?(:single_module) %} @[Linkage("internal")] {% end %}
fun __crystal_once_init : Nil
end
```

Related to #15426 