### PR TITLE
Add `@[Linkage("value")]` annotation (applies to `fun`)

### DIFF
--- a/spec/compiler/codegen/fun_spec.cr
+++ b/spec/compiler/codegen/fun_spec.cr
@@ -1,0 +1,22 @@
+require "../../spec_helper"
+
+describe "Codegen: fun" do
+  it "sets linkage" do
+    mod = codegen(<<-CRYSTAL, inject_primitives: false)
+    fun foo
+    end
+
+    @[Linkage("external")]
+    fun ext_foo
+    end
+
+    @[Linkage("internal")]
+    fun int_foo
+    end
+    CRYSTAL
+
+    mod.functions["foo"].linkage.should eq(LLVM::Linkage::External)
+    mod.functions["ext_foo"].linkage.should eq(LLVM::Linkage::External)
+    mod.functions["int_foo"].linkage.should eq(LLVM::Linkage::Internal)
+  end
+end

--- a/spec/compiler/semantic/annotation_spec.cr
+++ b/spec/compiler/semantic/annotation_spec.cr
@@ -1126,7 +1126,7 @@ describe "Semantic: annotation" do
         fun foo : Void
         end
       ),
-        "funs can only be annotated with: NoInline, AlwaysInline, Naked, ReturnsTwice, Raises, CallConvention"
+        "funs can only be annotated with: NoInline, AlwaysInline, Naked, ReturnsTwice, Raises, CallConvention or Linkage"
     end
 
     it "doesn't carry link annotation from lib to fun" do

--- a/src/compiler/crystal/codegen/ast.cr
+++ b/src/compiler/crystal/codegen/ast.cr
@@ -72,6 +72,10 @@ module Crystal
       nil
     end
 
+    def linkage
+      nil
+    end
+
     @c_calling_convention : Bool? = nil
     property c_calling_convention
 

--- a/src/compiler/crystal/codegen/fun.cr
+++ b/src/compiler/crystal/codegen/fun.cr
@@ -395,6 +395,10 @@ class Crystal::CodeGenVisitor
       context.fun.call_convention = call_convention
     end
 
+    if linkage = target_def.linkage
+      context.fun.linkage = linkage
+    end
+
     i = 0
     args.each do |arg|
       param = context.fun.params[i + offset]

--- a/src/compiler/crystal/program.cr
+++ b/src/compiler/crystal/program.cr
@@ -239,6 +239,7 @@ module Crystal
       types["Extern"] = @extern_annotation = AnnotationType.new self, self, "Extern"
       types["Flags"] = @flags_annotation = AnnotationType.new self, self, "Flags"
       types["Link"] = @link_annotation = AnnotationType.new self, self, "Link"
+      types["Linkage"] = @linkage_annotation = AnnotationType.new self, self, "Linkage"
       types["Naked"] = @naked_annotation = AnnotationType.new self, self, "Naked"
       types["NoInline"] = @no_inline_annotation = AnnotationType.new self, self, "NoInline"
       types["Packed"] = @packed_annotation = AnnotationType.new self, self, "Packed"
@@ -534,7 +535,8 @@ module Crystal
                      packed_annotation thread_local_annotation no_inline_annotation
                      always_inline_annotation naked_annotation returns_twice_annotation
                      raises_annotation primitive_annotation call_convention_annotation
-                     flags_annotation link_annotation extern_annotation deprecated_annotation experimental_annotation) %}
+                     flags_annotation link_annotation linkage_annotation extern_annotation
+                     deprecated_annotation experimental_annotation) %}
       def {{name.id}}
         @{{name.id}}.not_nil!
       end

--- a/src/compiler/crystal/semantic/ast.cr
+++ b/src/compiler/crystal/semantic/ast.cr
@@ -689,6 +689,7 @@ module Crystal
     property real_name : String
     property! fun_def : FunDef
     property call_convention : LLVM::CallConvention?
+    property linkage : LLVM::Linkage?
     property wasm_import_module : String?
 
     property? dead = false

--- a/src/compiler/crystal/semantic/top_level_visitor.cr
+++ b/src/compiler/crystal/semantic/top_level_visitor.cr
@@ -540,14 +540,12 @@ class Crystal::TopLevelVisitor < Crystal::SemanticVisitor
 
     case arg.value
     when "internal"
-      LLVM::Linkage::Internal
+      node.linkage = LLVM::Linkage::Internal
     when "external"
-      LLVM::Linkage::External
+      node.linkage = LLVM::Linkage::External
     else
       arg.raise "invalid linkage. Valid values are 'external' and 'internal'"
     end
-
-    node.linkage = value
   end
 
   def visit(node : Include)


### PR DESCRIPTION
Declares a new compiler annotation, `Linkage`, that may take one of the following values:

- `"external"` —the symbol is referenced in the object file and is visible to all symbols from all object files (this is the default).

- `"internal"` —the symbol will be referenced in the object file, but is only visible to symbols within that object only.

The annotation can only be specified on `fun` definitions (with a body). Incidentally it can also be specified to extern `fun` in `lib` declarations (without a body), though the only value accepted by LLVM will be `external` and a few other values (not implemented).

I chose to limit the possible values, and not expose all values from `LLVM::Linkage`. We should have a proper discussion about adding more. For example we might consider the `weak` value in a future development, but we'll need to correctly define what we mean with "weak" linkage (there are multiple definitions).

Related to #921 