### PR TITLE
Rework docs for `getter`, `setter` and `property` macros

### DIFF
--- a/scripts/generate_object_properties.cr
+++ b/scripts/generate_object_properties.cr
@@ -109,119 +109,6 @@ struct Generator
 
   def gen_getter
     puts <<-TEXT
-      # Defines getter methods for each of the given arguments.
-      #
-      # Writing:
-      #
-      # ```
-      # class Person
-      #   #{@macro_prefix}getter name
-      # end
-      # ```
-      #
-      # Is the same as writing:
-      #
-      # ```
-      # class Person
-      #   def #{@method_prefix}name
-      #     #{@var_prefix}name
-      #   end
-      # end
-      # ```
-      #
-      # The arguments can be string literals, symbol literals or plain names:
-      #
-      # ```
-      # class Person
-      #   #{@macro_prefix}getter :name, "age"
-      # end
-      # ```
-      #
-      # If a type declaration is given, a variable with that name
-      # is declared with that type.
-      #
-      # ```
-      # class Person
-      #   #{@macro_prefix}getter name : String
-      # end
-      # ```
-      #
-      # Is the same as writing:
-      #
-      # ```
-      # class Person
-      #   #{@var_prefix}name : String
-      #
-      #   def #{@method_prefix}name : String
-      #     #{@var_prefix}name
-      #   end
-      # end
-      # ```
-      #
-      # The type declaration can also include an initial value:
-      #
-      # ```
-      # class Person
-      #   #{@macro_prefix}getter name : String = "John Doe"
-      # end
-      # ```
-      #
-      # Is the same as writing:
-      #
-      # ```
-      # class Person
-      #   #{@var_prefix}name : String = "John Doe"
-      #
-      #   def #{@method_prefix}name : String
-      #     #{@var_prefix}name
-      #   end
-      # end
-      # ```
-      #
-      # An assignment can be passed too, but in this case the type of the
-      # variable must be easily inferable from the initial value:
-      #
-      # ```
-      # class Person
-      #   #{@macro_prefix}getter name = "John Doe"
-      # end
-      # ```
-      #
-      # Is the same as writing:
-      #
-      # ```
-      # class Person
-      #   #{@var_prefix}name = "John Doe"
-      #
-      #   def #{@method_prefix}name : String
-      #     #{@var_prefix}name
-      #   end
-      # end
-      # ```
-      #
-      # If a block is given to the macro, a getter is generated
-      # with a variable that is lazily initialized with
-      # the block's contents:
-      #
-      # ```
-      # class Person
-      #   #{@macro_prefix}getter(birth_date) { Time.local }
-      # end
-      # ```
-      #
-      # Is the same as writing:
-      #
-      # ```
-      # class Person
-      #   def #{@method_prefix}birth_date
-      #     if (value = #{@var_prefix}birth_date).nil?
-      #       #{@var_prefix}birth_date = Time.local
-      #     else
-      #       value
-      #     end
-      #   end
-      # end
-      # ```
       macro #{@macro_prefix}getter(*names, &block)
         {% for name in names %}
     #{def_vars}
@@ -233,99 +120,6 @@ struct Generator
 
   def gen_getter?
     puts <<-TEXT
-      # Defines query getter methods for each of the given arguments.
-      #
-      # Writing:
-      #
-      # ```
-      # class Person
-      #   #{@macro_prefix}getter? happy
-      # end
-      # ```
-      #
-      # Is the same as writing:
-      #
-      # ```
-      # class Person
-      #   def #{@method_prefix}happy?
-      #     #{@var_prefix}happy
-      #   end
-      # end
-      # ```
-      #
-      # The arguments can be string literals, symbol literals or plain names:
-      #
-      # ```
-      # class Person
-      #   #{@macro_prefix}getter? :happy, "famous"
-      # end
-      # ```
-      #
-      # If a type declaration is given, a variable with that name
-      # is declared with that type.
-      #
-      # ```
-      # class Person
-      #   #{@macro_prefix}getter? happy : Bool
-      # end
-      # ```
-      #
-      # is the same as writing:
-      #
-      # ```
-      # class Person
-      #   #{@var_prefix}happy : Bool
-      #
-      #   def #{@method_prefix}happy? : Bool
-      #     #{@var_prefix}happy
-      #   end
-      # end
-      # ```
-      #
-      # The type declaration can also include an initial value:
-      #
-      # ```
-      # class Person
-      #   #{@macro_prefix}getter? happy : Bool = true
-      # end
-      # ```
-      #
-      # Is the same as writing:
-      #
-      # ```
-      # class Person
-      #   #{@var_prefix}happy : Bool = true
-      #
-      #   def #{@method_prefix}happy? : Bool
-      #     #{@var_prefix}happy
-      #   end
-      # end
-      # ```
-      #
-      # An assignment can be passed too, but in this case the type of the
-      # variable must be easily inferable from the initial value:
-      #
-      # ```
-      # class Person
-      #   #{@macro_prefix}getter? happy = true
-      # end
-      # ```
-      #
-      # Is the same as writing:
-      #
-      # ```
-      # class Person
-      #   #{@var_prefix}happy = true
-      #
-      #   def #{@method_prefix}happy?
-      #     #{@var_prefix}happy
-      #   end
-      # end
-      # ```
-      #
-      # If a block is given to the macro, a getter is generated with a variable
-      # that is lazily initialized with the block's contents, for examples see
-      # `##{@macro_prefix}getter`.
       macro #{@macro_prefix}getter?(*names, &block)
         {% for name in names %}
     #{def_vars}
@@ -337,134 +131,10 @@ struct Generator
 
   def gen_property
     puts <<-TEXT
-      # Defines property methods for each of the given arguments.
+      # Generates both `#{@macro_prefix}getter` and `#{@macro_prefix}setter`
+      # methods to access instance variables.
       #
-      # Writing:
-      #
-      # ```
-      # class Person
-      #   #{@macro_prefix}property name
-      # end
-      # ```
-      #
-      # Is the same as writing:
-      #
-      # ```
-      # class Person
-      #   def #{@method_prefix}name=(#{@var_prefix}name)
-      #   end
-      #
-      #   def #{@method_prefix}name
-      #     #{@var_prefix}name
-      #   end
-      # end
-      # ```
-      #
-      # The arguments can be string literals, symbol literals or plain names:
-      #
-      # ```
-      # class Person
-      #   #{@macro_prefix}property :name, "age"
-      # end
-      # ```
-      #
-      # If a type declaration is given, a variable with that name
-      # is declared with that type.
-      #
-      # ```
-      # class Person
-      #   #{@macro_prefix}property name : String
-      # end
-      # ```
-      #
-      # Is the same as writing:
-      #
-      # ```
-      # class Person
-      #   #{@var_prefix}name : String
-      #
-      #   def #{@method_prefix}name=(#{@var_prefix}name)
-      #   end
-      #
-      #   def #{@method_prefix}name
-      #     #{@var_prefix}name
-      #   end
-      # end
-      # ```
-      #
-      # The type declaration can also include an initial value:
-      #
-      # ```
-      # class Person
-      #   #{@macro_prefix}property name : String = "John Doe"
-      # end
-      # ```
-      #
-      # Is the same as writing:
-      #
-      # ```
-      # class Person
-      #   #{@var_prefix}name : String = "John Doe"
-      #
-      #   def #{@method_prefix}name=(#{@var_prefix}name : String)
-      #   end
-      #
-      #   def #{@method_prefix}name
-      #     #{@var_prefix}name
-      #   end
-      # end
-      # ```
-      #
-      # An assignment can be passed too, but in this case the type of the
-      # variable must be easily inferable from the initial value:
-      #
-      # ```
-      # class Person
-      #   #{@macro_prefix}property name = "John Doe"
-      # end
-      # ```
-      #
-      # Is the same as writing:
-      #
-      # ```
-      # class Person
-      #   #{@var_prefix}name = "John Doe"
-      #
-      #   def #{@method_prefix}name=(#{@var_prefix}name : String)
-      #   end
-      #
-      #   def #{@method_prefix}name
-      #     #{@var_prefix}name
-      #   end
-      # end
-      # ```
-      #
-      # If a block is given to the macro, a property is generated
-      # with a variable that is lazily initialized with
-      # the block's contents:
-      #
-      # ```
-      # class Person
-      #   #{@macro_prefix}property(birth_date) { Time.local }
-      # end
-      # ```
-      #
-      # Is the same as writing:
-      #
-      # ```
-      # class Person
-      #   def #{@method_prefix}birth_date
-      #     if (value = #{@var_prefix}birth_date).nil?
-      #       #{@var_prefix}birth_date = Time.local
-      #     else
-      #       value
-      #     end
-      #   end
-      #
-      #   def #{@method_prefix}birth_date=(#{@var_prefix}birth_date)
-      #   end
-      # end
-      # ```
+      # Refer to the aforementioned macros for details.
       macro #{@macro_prefix}property(*names, &block)
         {% for name in names %}
     #{def_vars}
@@ -477,111 +147,10 @@ struct Generator
 
   def gen_property?
     puts <<-TEXT
-      # Defines query property methods for each of the given arguments.
+      # Generates both `#{@macro_prefix}getter?` and `#{@macro_prefix}setter`
+      # methods to access instance variables.
       #
-      # Writing:
-      #
-      # ```
-      # class Person
-      #   #{@macro_prefix}property? happy
-      # end
-      # ```
-      #
-      # Is the same as writing:
-      #
-      # ```
-      # class Person
-      #   def #{@method_prefix}happy=(#{@var_prefix}happy)
-      #   end
-      #
-      #   def #{@method_prefix}happy?
-      #     #{@var_prefix}happy
-      #   end
-      # end
-      # ```
-      #
-      # The arguments can be string literals, symbol literals or plain names:
-      #
-      # ```
-      # class Person
-      #   #{@macro_prefix}property? :happy, "famous"
-      # end
-      # ```
-      #
-      # If a type declaration is given, a variable with that name
-      # is declared with that type.
-      #
-      # ```
-      # class Person
-      #   #{@macro_prefix}property? happy : Bool
-      # end
-      # ```
-      #
-      # Is the same as writing:
-      #
-      # ```
-      # class Person
-      #   #{@var_prefix}happy : Bool
-      #
-      #   def #{@method_prefix}happy=(#{@var_prefix}happy : Bool)
-      #   end
-      #
-      #   def #{@method_prefix}happy? : Bool
-      #     #{@var_prefix}happy
-      #   end
-      # end
-      # ```
-      #
-      # The type declaration can also include an initial value:
-      #
-      # ```
-      # class Person
-      #   #{@macro_prefix}property? happy : Bool = true
-      # end
-      # ```
-      #
-      # Is the same as writing:
-      #
-      # ```
-      # class Person
-      #   #{@var_prefix}happy : Bool = true
-      #
-      #   def #{@method_prefix}happy=(#{@var_prefix}happy : Bool)
-      #   end
-      #
-      #   def #{@method_prefix}happy? : Bool
-      #     #{@var_prefix}happy
-      #   end
-      # end
-      # ```
-      #
-      # An assignment can be passed too, but in this case the type of the
-      # variable must be easily inferable from the initial value:
-      #
-      # ```
-      # class Person
-      #   #{@macro_prefix}property? happy = true
-      # end
-      # ```
-      #
-      # Is the same as writing:
-      #
-      # ```
-      # class Person
-      #   #{@var_prefix}happy = true
-      #
-      #   def #{@method_prefix}happy=(#{@var_prefix}happy)
-      #   end
-      #
-      #   def #{@method_prefix}happy?
-      #     #{@var_prefix}happy
-      #   end
-      # end
-      # ```
-      #
-      # If a block is given to the macro, a property is generated
-      # with a variable that is lazily initialized with
-      # the block's contents, for examples see `##{@macro_prefix}property`.
+      # Refer to the aforementioned macros for details.
       macro #{@macro_prefix}property?(*names, &block)
         {% for name in names %}
     #{def_vars}
@@ -594,62 +163,6 @@ struct Generator
 
   def gen_getter!
     puts <<-TEXT
-      # Defines raise-on-nil and nilable getter methods for each of the given arguments.
-      #
-      # Writing:
-      #
-      # ```
-      # class Person
-      #   #{@macro_prefix}getter! name
-      # end
-      # ```
-      #
-      # Is the same as writing:
-      #
-      # ```
-      # class Person
-      #   def #{@method_prefix}name?
-      #     #{@var_prefix}name
-      #   end
-      #
-      #   def #{@method_prefix}name
-      #     #{@var_prefix}name.not_nil!
-      #   end
-      # end
-      # ```
-      #
-      # The arguments can be string literals, symbol literals or plain names:
-      #
-      # ```
-      # class Person
-      #   #{@macro_prefix}getter! :name, "age"
-      # end
-      # ```
-      #
-      # If a type declaration is given, a variable with that name
-      # is declared with that type, as nilable.
-      #
-      # ```
-      # class Person
-      #   #{@macro_prefix}getter! name : String
-      # end
-      # ```
-      #
-      # is the same as writing:
-      #
-      # ```
-      # class Person
-      #   #{@var_prefix}name : String?
-      #
-      #   def #{@method_prefix}name?
-      #     #{@var_prefix}name
-      #   end
-      #
-      #   def #{@method_prefix}name
-      #     #{@var_prefix}name.not_nil!
-      #   end
-      # end
-      # ```
       macro #{@macro_prefix}getter!(*names)
         {% for name in names %}
     #{def_vars!}
@@ -661,68 +174,10 @@ struct Generator
 
   def gen_property!
     puts <<-TEXT
-      # Defines raise-on-nil property methods for each of the given arguments.
+      # Generates both `#{@macro_prefix}getter!` and `#{@macro_prefix}setter`
+      # methods to access instance variables.
       #
-      # Writing:
-      #
-      # ```
-      # class Person
-      #   #{@macro_prefix}property! name
-      # end
-      # ```
-      #
-      # Is the same as writing:
-      #
-      # ```
-      # class Person
-      #   def #{@method_prefix}name=(#{@var_prefix}name)
-      #   end
-      #
-      #   def #{@method_prefix}name?
-      #     #{@var_prefix}name
-      #   end
-      #
-      #   def #{@method_prefix}name
-      #     #{@var_prefix}name.not_nil!
-      #   end
-      # end
-      # ```
-      #
-      # The arguments can be string literals, symbol literals or plain names:
-      #
-      # ```
-      # class Person
-      #   #{@macro_prefix}property! :name, "age"
-      # end
-      # ```
-      #
-      # If a type declaration is given, a variable with that name
-      # is declared with that type, as nilable.
-      #
-      # ```
-      # class Person
-      #   #{@macro_prefix}property! name : String
-      # end
-      # ```
-      #
-      # Is the same as writing:
-      #
-      # ```
-      # class Person
-      #   #{@var_prefix}name : String?
-      #
-      #   def #{@method_prefix}name=(#{@var_prefix}name)
-      #   end
-      #
-      #   def #{@method_prefix}name?
-      #     #{@var_prefix}name
-      #   end
-      #
-      #   def #{@method_prefix}name
-      #     #{@var_prefix}name.not_nil!
-      #   end
-      # end
-      # ```
+      # Refer to the aforementioned macros for details.
       macro #{@macro_prefix}property!(*names)
         {% for name in names %}
     #{def_vars!}
@@ -735,91 +190,6 @@ struct Generator
 
   def gen_setter
     puts <<-TEXT
-      # Defines setter methods for each of the given arguments.
-      #
-      # Writing:
-      #
-      # ```
-      # class Person
-      #   #{@macro_prefix}setter name
-      # end
-      # ```
-      #
-      # Is the same as writing:
-      #
-      # ```
-      # class Person
-      #   def #{@method_prefix}name=(#{@var_prefix}name)
-      #   end
-      # end
-      # ```
-      #
-      # The arguments can be string literals, symbol literals or plain names:
-      #
-      # ```
-      # class Person
-      #   #{@macro_prefix}setter :name, "age"
-      # end
-      # ```
-      #
-      # If a type declaration is given, a variable with that name
-      # is declared with that type.
-      #
-      # ```
-      # class Person
-      #   #{@macro_prefix}setter name : String
-      # end
-      # ```
-      #
-      # is the same as writing:
-      #
-      # ```
-      # class Person
-      #   #{@var_prefix}name : String
-      #
-      #   def #{@method_prefix}name=(#{@var_prefix}name : String)
-      #   end
-      # end
-      # ```
-      #
-      # The type declaration can also include an initial value:
-      #
-      # ```
-      # class Person
-      #   #{@macro_prefix}setter name : String = "John Doe"
-      # end
-      # ```
-      #
-      # Is the same as writing:
-      #
-      # ```
-      # class Person
-      #   #{@var_prefix}name : String = "John Doe"
-      #
-      #   def #{@method_prefix}name=(#{@var_prefix}name : String)
-      #   end
-      # end
-      # ```
-      #
-      # An assignment can be passed too, but in this case the type of the
-      # variable must be easily inferable from the initial value:
-      #
-      # ```
-      # class Person
-      #   #{@macro_prefix}setter name = "John Doe"
-      # end
-      # ```
-      #
-      # Is the same as writing:
-      #
-      # ```
-      # class Person
-      #   #{@var_prefix}name = "John Doe"
-      #
-      #   def #{@method_prefix}name=(#{@var_prefix}name)
-      #   end
-      # end
-      # ```
       macro #{@macro_prefix}setter(*names)
         {% for name in names %}
     #{def_vars_no_macro_block}
@@ -845,10 +215,79 @@ File.open(output, "w") do |f|
 
   g = Generator.new(f, "", "", "@", "#")
 
+  f.puts <<-MARKDOWN
+  # Defines getter method(s) to access instance variable(s).
+  #
+  # Refer to [Getters](#getters) for details.
+  MARKDOWN
   g.gen_getter
+
+  f.puts <<-MARKDOWN
+  # Identical to `getter` but defines query methods.
+  #
+  # For example writing:
+  #
+  # ```
+  # class Robot
+  #   getter? working
+  # end
+  # ```
+  #
+  # Is equivalent to writing:
+  #
+  # ```
+  # class Robot
+  #   def working?
+  #     @working
+  #   end
+  # end
+  # ```
+  #
+  # Refer to [Getters](#getters) for general details.
+  MARKDOWN
   g.gen_getter?
+
+  f.puts <<-MARKDOWN
+  # Similar to `getter` but defines both raise-on-nil methods as well as query
+  # methods that return a nilable value.
+  #
+  # If a type is specified, then it will become a nilable type (union of the
+  # type and `Nil`). Unlike the other `getter` methods the value is always
+  # initialized to `nil`. There are no initial value or lazy initialization.
+  #
+  # For example writing:
+  #
+  # ```
+  # class Robot
+  #   getter! name : String
+  # end
+  # ```
+  #
+  # Is equivalent to writing:
+  #
+  # ```
+  # class Robot
+  #   @name : String?
+  #
+  #   def name? : String?
+  #     @name
+  #   end
+  #
+  #   def name : String
+  #     @name.not_nil!("Robot#name cannot be nil")
+  #   end
+  # end
+  # ```
+  #
+  # Refer to [Getters](#getters) for general details.
+  MARKDOWN
   g.gen_getter!
 
+  f.puts <<-MARKDOWN
+  # Generates setter methods to set instance variables.
+  #
+  # Refer to [Setters](#setters) for general details.
+  MARKDOWN
   g.gen_setter
 
   g.gen_property
@@ -857,10 +296,118 @@ File.open(output, "w") do |f|
 
   g = Generator.new(f, "class_", "self.", "@@", ".")
 
+  f.puts <<-MARKDOWN
+  # Defines getter method(s) to access class variable(s).
+  #
+  # For example writing:
+  #
+  # ```
+  # class Robot
+  #   class_getter backend
+  # end
+  # ```
+  #
+  # Is equivalent to writing:
+  #
+  # ```
+  # class Robot
+  #   @@backend : String
+  #
+  #   def self.backend
+  #     @@backend
+  #   end
+  # end
+  # ```
+  #
+  # Refer to [Getters](#getters) for details.
+  MARKDOWN
   g.gen_getter
+
+  f.puts <<-MARKDOWN
+  # Identical to `class_getter` but defines query methods.
+  #
+  # For example writing:
+  #
+  # ```
+  # class Robot
+  #   class_getter? backend
+  # end
+  # ```
+  #
+  # Is equivalent to writing:
+  #
+  # ```
+  # class Robot
+  #   def self.backend?
+  #     @@backend
+  #   end
+  # end
+  # ```
+  #
+  # Refer to [Getters](#getters) for general details.
+  MARKDOWN
   g.gen_getter?
+
+  f.puts <<-MARKDOWN
+  # Similar to `class_getter` but defines both raise-on-nil methods as well as
+  # query methods that return a nilable value.
+  #
+  # If a type is specified, then it will become a nilable type (union of the
+  # type and `Nil`). Unlike with `class_getter` the value is always initialized
+  # to `nil`. There are no initial value or lazy initialization.
+  #
+  # For example writing:
+  #
+  # ```
+  # class Robot
+  #   class_getter! backend : String
+  # end
+  # ```
+  #
+  # Is equivalent to writing:
+  #
+  # ```
+  # class Robot
+  #   @@backend : String?
+  #
+  #   def self.backend? : String?
+  #     @@backend
+  #   end
+  #
+  #   def backend : String
+  #     @@backend.not_nil!("Robot.backend cannot be nil")
+  #   end
+  # end
+  # ```
+  #
+  # Refer to [Getters](#getters) for general details.
+  MARKDOWN
   g.gen_getter!
 
+  f.puts <<-MARKDOWN
+  # Generates setter method(s) to set class variable(s).
+  #
+  # For example writing:
+  #
+  # ```
+  # class Robot
+  #   class_setter factories
+  # end
+  # ```
+  #
+  # Is equivalent to writing:
+  #
+  # ```
+  # class Robot
+  #   @@factories
+  #
+  #   def self.factories=(@@factories)
+  #   end
+  # end
+  # ```
+  #
+  # Refer to [Setters](#setters) for general details.
+  MARKDOWN
   g.gen_setter
 
   g.gen_property

--- a/scripts/generate_object_properties.cr
+++ b/scripts/generate_object_properties.cr
@@ -164,7 +164,7 @@ File.open(output, "w") do |f|
   g = Generator.new(f, "", "", "@", "#")
 
   f.puts <<-TEXT
-    # Defines getter method(s) to access instance variable(s).
+    # Defines getter methods to access instance variables.
     #
     # Refer to [Getters](#getters) for details.
     macro getter(*names, &block)
@@ -176,7 +176,7 @@ File.open(output, "w") do |f|
 
     # Identical to `getter` but defines query methods.
     #
-    # For example writing:
+    # For example, writing:
     #
     # ```
     # class Robot
@@ -209,7 +209,7 @@ File.open(output, "w") do |f|
     # type and `Nil`). Unlike the other `getter` methods the value is always
     # initialized to `nil`. There are no initial value or lazy initialization.
     #
-    # For example writing:
+    # For example, writing:
     #
     # ```
     # class Robot
@@ -257,9 +257,9 @@ File.open(output, "w") do |f|
   g = Generator.new(f, "class_", "self.", "@@", ".")
 
   f.puts <<-TEXT
-    # Defines getter method(s) to access class variable(s).
+    # Defines getter methods to access class variables.
     #
-    # For example writing:
+    # For example, writing:
     #
     # ```
     # class Robot
@@ -287,7 +287,7 @@ File.open(output, "w") do |f|
 
     # Identical to `class_getter` but defines query methods.
     #
-    # For example writing:
+    # For example, writing:
     #
     # ```
     # class Robot
@@ -320,7 +320,7 @@ File.open(output, "w") do |f|
     # type and `Nil`). Unlike with `class_getter` the value is always initialized
     # to `nil`. There are no initial value or lazy initialization.
     #
-    # For example writing:
+    # For example, writing:
     #
     # ```
     # class Robot
@@ -352,9 +352,9 @@ File.open(output, "w") do |f|
       {% end %}
     end
 
-    # Generates setter method(s) to set class variable(s).
+    # Generates setter methods to set class variables.
     #
-    # For example writing:
+    # For example, writing:
     #
     # ```
     # class Robot

--- a/src/object.cr
+++ b/src/object.cr
@@ -127,7 +127,9 @@ require "./object/properties"
 #
 # The `setter` and `class_setter` macros are the write counterparts of the
 # getter macros. They declare `name=(value)` accessor methods. The arguments
-# behave just as for the getter macros.
+# behave just as for the getter macros. Each setter can have a type as well as
+# an initial value. There is no lazy initialization however since the macro
+# doesn't generate a getter method.
 #
 # For example writing:
 #

--- a/src/object.cr
+++ b/src/object.cr
@@ -1,6 +1,201 @@
 require "./object/properties"
 
 # `Object` is the base type of all Crystal objects.
+#
+# ## Getters
+#
+# Multiple macros are available to easily declare, initialize and expose
+# instance variables as well as class variables on an `Object` by generating
+# simple accessor methods.
+#
+# For example writing:
+#
+# ```
+# class Person
+#   getter name
+# end
+# ```
+#
+# Is the same as writing:
+#
+# ```
+# class Person
+#   def name
+#     @name
+#   end
+# end
+# ```
+#
+# For class variables we'd have called `class_getter name` that would have
+# generated a `def self.name` class method returning `@@name`.
+#
+# We can define as many variables as necessary in a single call. For example
+# `getter name, age, city` will create a getter method for each of `name`, `age`
+# and `city`.
+#
+# ### Type and initial value
+#
+# Instead of plain arguments, we can specify a type as well as an initial value.
+# If the initial value is simple enough Crystal should be able to infer the type
+# of the instance or class variable!
+#
+# Specifying a type will also declare the instance or class variable with said
+# type and type the accessor method arguments and return type accordingly.
+#
+# For example writing:
+#
+# ```
+# class Person
+#   getter name : String
+#   getter age = 0
+#   getter city : String = "unspecified"
+# end
+# ```
+#
+# Is the same as writing:
+#
+# ```
+# class Person
+#   @name : String
+#   @age = 0
+#   @city : String = "unspecified"
+#
+#   def name : String
+#     @name
+#   end
+#
+#   def age
+#     @age
+#   end
+#
+#   def city : String
+#     @city
+#   end
+# end
+# ```
+#
+# The initial value of an instance variable is automatically set when the object
+# is constructed. The initial value of a class variable will be set when the
+# program starts up.
+#
+# ### Lazy initialization
+#
+# Instead of eagerly initializing the value, we can lazily initialize it the
+# first time the accessor method is called.
+#
+# Since the variable will be lazily initialized the type of the variable will be
+# a nilable type. The generated method however will return the specified type
+# only (not a nilable).
+#
+# For example writing:
+#
+# ```
+# class Person
+#   getter(city : City) { City.unspecified }
+# end
+# ```
+#
+# Is equivalent to writing:
+#
+# ```
+# class Person
+#   @city : City?
+#
+#   def city : City
+#     if (city == @city).nil?
+#       @city = City.unspecified
+#     else
+#       city
+#     end
+#   end
+# end
+# ```
+#
+# ### Variants
+#
+# Please refer to the different variants to understand how they differ from the
+# general overview presented above:
+#
+# - `getter`
+# - `getter?`
+# - `getter!`
+# - `class_getter`
+# - `class_getter?`
+# - `class_getter!`
+#
+# ## Setters
+#
+# The `setter` and `class_setter` macros are the write counterparts of the
+# getter macros. They declare `name=(value)` accessor methods. The arguments
+# behave just as for the getter macros.
+#
+# For example writing:
+#
+# ```
+# class Person
+#   setter name
+#   setter age = 0
+#   setter city : String = "unspecified"
+# end
+# ```
+#
+# Is the same as writing:
+#
+# ```
+# class Person
+#   @age = 0
+#   @city : String = "unspecified"
+#
+#   def name=(@name)
+#   end
+#
+#   def age=(@age)
+#   end
+#
+#   def city=(@city : String) : String
+#   end
+# end
+# ```
+#
+# For class variables we'd have called `class_setter name` that would have
+# generated a `def self.name=(@@name)` class method instead.
+#
+# ## Properties
+#
+# The property macros define both getter and setter methods at once.
+#
+# For example writing:
+#
+# ```
+# class Person
+#   property name
+# end
+# ```
+#
+# Is equivalent to writing:
+#
+# ```
+# class Person
+#   getter name
+#   setter name
+# end
+# ```
+#
+# Which is the same as writing:
+#
+# ```
+# class Person
+#   def name
+#     @name
+#   end
+#
+#   def name=(@name)
+#   end
+# end
+# ```
+#
+# Refer to [Getters](#getters) and [Setters](#setters) above for details. The
+# macros take the exact same arguments.
 class Object
   # Returns `true` if this object is equal to *other*.
   #

--- a/src/object.cr
+++ b/src/object.cr
@@ -26,8 +26,8 @@ require "./object/properties"
 # end
 # ```
 #
-# For class variables we'd have called `class_getter name` that would have
-# generated a `def self.name` class method returning `@@name`.
+# Similarly, we can write `class_getter name` to define a class variable, which
+# generates a `def self.name` class method returning `@@name`.
 #
 # We can define as many variables as necessary in a single call. For example
 # `getter name, age, city` will create a getter method for each of `name`, `age`

--- a/src/object/properties.cr
+++ b/src/object/properties.cr
@@ -5,119 +5,9 @@
 # DO NOT EDIT
 
 class Object
-  # Defines getter methods for each of the given arguments.
+  # Defines getter method(s) to access instance variable(s).
   #
-  # Writing:
-  #
-  # ```
-  # class Person
-  #   getter name
-  # end
-  # ```
-  #
-  # Is the same as writing:
-  #
-  # ```
-  # class Person
-  #   def name
-  #     @name
-  #   end
-  # end
-  # ```
-  #
-  # The arguments can be string literals, symbol literals or plain names:
-  #
-  # ```
-  # class Person
-  #   getter :name, "age"
-  # end
-  # ```
-  #
-  # If a type declaration is given, a variable with that name
-  # is declared with that type.
-  #
-  # ```
-  # class Person
-  #   getter name : String
-  # end
-  # ```
-  #
-  # Is the same as writing:
-  #
-  # ```
-  # class Person
-  #   @name : String
-  #
-  #   def name : String
-  #     @name
-  #   end
-  # end
-  # ```
-  #
-  # The type declaration can also include an initial value:
-  #
-  # ```
-  # class Person
-  #   getter name : String = "John Doe"
-  # end
-  # ```
-  #
-  # Is the same as writing:
-  #
-  # ```
-  # class Person
-  #   @name : String = "John Doe"
-  #
-  #   def name : String
-  #     @name
-  #   end
-  # end
-  # ```
-  #
-  # An assignment can be passed too, but in this case the type of the
-  # variable must be easily inferable from the initial value:
-  #
-  # ```
-  # class Person
-  #   getter name = "John Doe"
-  # end
-  # ```
-  #
-  # Is the same as writing:
-  #
-  # ```
-  # class Person
-  #   @name = "John Doe"
-  #
-  #   def name : String
-  #     @name
-  #   end
-  # end
-  # ```
-  #
-  # If a block is given to the macro, a getter is generated
-  # with a variable that is lazily initialized with
-  # the block's contents:
-  #
-  # ```
-  # class Person
-  #   getter(birth_date) { Time.local }
-  # end
-  # ```
-  #
-  # Is the same as writing:
-  #
-  # ```
-  # class Person
-  #   def birth_date
-  #     if (value = @birth_date).nil?
-  #       @birth_date = Time.local
-  #     else
-  #       value
-  #     end
-  #   end
-  # end
-  # ```
+  # Refer to [Getters](#getters) for details.
   macro getter(*names, &block)
     {% for name in names %}
       {% if name.is_a?(TypeDeclaration) %}
@@ -152,99 +42,27 @@ class Object
     {% end %}
   end
 
-  # Defines query getter methods for each of the given arguments.
+  # Identical to `getter` but defines query methods.
   #
-  # Writing:
+  # For example writing:
   #
   # ```
-  # class Person
-  #   getter? happy
+  # class Robot
+  #   getter? working
   # end
   # ```
   #
-  # Is the same as writing:
+  # Is equivalent to writing:
   #
   # ```
-  # class Person
-  #   def happy?
-  #     @happy
+  # class Robot
+  #   def working?
+  #     @working
   #   end
   # end
   # ```
   #
-  # The arguments can be string literals, symbol literals or plain names:
-  #
-  # ```
-  # class Person
-  #   getter? :happy, "famous"
-  # end
-  # ```
-  #
-  # If a type declaration is given, a variable with that name
-  # is declared with that type.
-  #
-  # ```
-  # class Person
-  #   getter? happy : Bool
-  # end
-  # ```
-  #
-  # is the same as writing:
-  #
-  # ```
-  # class Person
-  #   @happy : Bool
-  #
-  #   def happy? : Bool
-  #     @happy
-  #   end
-  # end
-  # ```
-  #
-  # The type declaration can also include an initial value:
-  #
-  # ```
-  # class Person
-  #   getter? happy : Bool = true
-  # end
-  # ```
-  #
-  # Is the same as writing:
-  #
-  # ```
-  # class Person
-  #   @happy : Bool = true
-  #
-  #   def happy? : Bool
-  #     @happy
-  #   end
-  # end
-  # ```
-  #
-  # An assignment can be passed too, but in this case the type of the
-  # variable must be easily inferable from the initial value:
-  #
-  # ```
-  # class Person
-  #   getter? happy = true
-  # end
-  # ```
-  #
-  # Is the same as writing:
-  #
-  # ```
-  # class Person
-  #   @happy = true
-  #
-  #   def happy?
-  #     @happy
-  #   end
-  # end
-  # ```
-  #
-  # If a block is given to the macro, a getter is generated with a variable
-  # that is lazily initialized with the block's contents, for examples see
-  # `#getter`.
+  # Refer to [Getters](#getters) for general details.
   macro getter?(*names, &block)
     {% for name in names %}
       {% if name.is_a?(TypeDeclaration) %}
@@ -279,62 +97,38 @@ class Object
     {% end %}
   end
 
-  # Defines raise-on-nil and nilable getter methods for each of the given arguments.
+  # Similar to `getter` but defines both raise-on-nil methods as well as query
+  # methods that return a nilable value.
   #
-  # Writing:
+  # If a type is specified, then it will become a nilable type (union of the
+  # type and `Nil`). Unlike the other `getter` methods the value is always
+  # initialized to `nil`. There are no initial value or lazy initialization.
   #
-  # ```
-  # class Person
-  #   getter! name
-  # end
-  # ```
-  #
-  # Is the same as writing:
+  # For example writing:
   #
   # ```
-  # class Person
-  #   def name?
-  #     @name
-  #   end
-  #
-  #   def name
-  #     @name.not_nil!
-  #   end
-  # end
-  # ```
-  #
-  # The arguments can be string literals, symbol literals or plain names:
-  #
-  # ```
-  # class Person
-  #   getter! :name, "age"
-  # end
-  # ```
-  #
-  # If a type declaration is given, a variable with that name
-  # is declared with that type, as nilable.
-  #
-  # ```
-  # class Person
+  # class Robot
   #   getter! name : String
   # end
   # ```
   #
-  # is the same as writing:
+  # Is equivalent to writing:
   #
   # ```
-  # class Person
+  # class Robot
   #   @name : String?
   #
-  #   def name?
+  #   def name? : String?
   #     @name
   #   end
   #
-  #   def name
-  #     @name.not_nil!
+  #   def name : String
+  #     @name.not_nil!("Robot#name cannot be nil")
   #   end
   # end
   # ```
+  #
+  # Refer to [Getters](#getters) for general details.
   macro getter!(*names)
     {% for name in names %}
       {% if name.is_a?(TypeDeclaration) %}
@@ -361,91 +155,9 @@ class Object
     {% end %}
   end
 
-  # Defines setter methods for each of the given arguments.
+  # Generates setter methods to set instance variables.
   #
-  # Writing:
-  #
-  # ```
-  # class Person
-  #   setter name
-  # end
-  # ```
-  #
-  # Is the same as writing:
-  #
-  # ```
-  # class Person
-  #   def name=(@name)
-  #   end
-  # end
-  # ```
-  #
-  # The arguments can be string literals, symbol literals or plain names:
-  #
-  # ```
-  # class Person
-  #   setter :name, "age"
-  # end
-  # ```
-  #
-  # If a type declaration is given, a variable with that name
-  # is declared with that type.
-  #
-  # ```
-  # class Person
-  #   setter name : String
-  # end
-  # ```
-  #
-  # is the same as writing:
-  #
-  # ```
-  # class Person
-  #   @name : String
-  #
-  #   def name=(@name : String)
-  #   end
-  # end
-  # ```
-  #
-  # The type declaration can also include an initial value:
-  #
-  # ```
-  # class Person
-  #   setter name : String = "John Doe"
-  # end
-  # ```
-  #
-  # Is the same as writing:
-  #
-  # ```
-  # class Person
-  #   @name : String = "John Doe"
-  #
-  #   def name=(@name : String)
-  #   end
-  # end
-  # ```
-  #
-  # An assignment can be passed too, but in this case the type of the
-  # variable must be easily inferable from the initial value:
-  #
-  # ```
-  # class Person
-  #   setter name = "John Doe"
-  # end
-  # ```
-  #
-  # Is the same as writing:
-  #
-  # ```
-  # class Person
-  #   @name = "John Doe"
-  #
-  #   def name=(@name)
-  #   end
-  # end
-  # ```
+  # Refer to [Setters](#setters) for general details.
   macro setter(*names)
     {% for name in names %}
       {% if name.is_a?(TypeDeclaration) %}
@@ -467,134 +179,10 @@ class Object
     {% end %}
   end
 
-  # Defines property methods for each of the given arguments.
+  # Generates both `getter` and `setter`
+  # methods to access instance variables.
   #
-  # Writing:
-  #
-  # ```
-  # class Person
-  #   property name
-  # end
-  # ```
-  #
-  # Is the same as writing:
-  #
-  # ```
-  # class Person
-  #   def name=(@name)
-  #   end
-  #
-  #   def name
-  #     @name
-  #   end
-  # end
-  # ```
-  #
-  # The arguments can be string literals, symbol literals or plain names:
-  #
-  # ```
-  # class Person
-  #   property :name, "age"
-  # end
-  # ```
-  #
-  # If a type declaration is given, a variable with that name
-  # is declared with that type.
-  #
-  # ```
-  # class Person
-  #   property name : String
-  # end
-  # ```
-  #
-  # Is the same as writing:
-  #
-  # ```
-  # class Person
-  #   @name : String
-  #
-  #   def name=(@name)
-  #   end
-  #
-  #   def name
-  #     @name
-  #   end
-  # end
-  # ```
-  #
-  # The type declaration can also include an initial value:
-  #
-  # ```
-  # class Person
-  #   property name : String = "John Doe"
-  # end
-  # ```
-  #
-  # Is the same as writing:
-  #
-  # ```
-  # class Person
-  #   @name : String = "John Doe"
-  #
-  #   def name=(@name : String)
-  #   end
-  #
-  #   def name
-  #     @name
-  #   end
-  # end
-  # ```
-  #
-  # An assignment can be passed too, but in this case the type of the
-  # variable must be easily inferable from the initial value:
-  #
-  # ```
-  # class Person
-  #   property name = "John Doe"
-  # end
-  # ```
-  #
-  # Is the same as writing:
-  #
-  # ```
-  # class Person
-  #   @name = "John Doe"
-  #
-  #   def name=(@name : String)
-  #   end
-  #
-  #   def name
-  #     @name
-  #   end
-  # end
-  # ```
-  #
-  # If a block is given to the macro, a property is generated
-  # with a variable that is lazily initialized with
-  # the block's contents:
-  #
-  # ```
-  # class Person
-  #   property(birth_date) { Time.local }
-  # end
-  # ```
-  #
-  # Is the same as writing:
-  #
-  # ```
-  # class Person
-  #   def birth_date
-  #     if (value = @birth_date).nil?
-  #       @birth_date = Time.local
-  #     else
-  #       value
-  #     end
-  #   end
-  #
-  #   def birth_date=(@birth_date)
-  #   end
-  # end
-  # ```
+  # Refer to the aforementioned macros for details.
   macro property(*names, &block)
     {% for name in names %}
       {% if name.is_a?(TypeDeclaration) %}
@@ -632,111 +220,10 @@ class Object
     {% end %}
   end
 
-  # Defines query property methods for each of the given arguments.
+  # Generates both `getter?` and `setter`
+  # methods to access instance variables.
   #
-  # Writing:
-  #
-  # ```
-  # class Person
-  #   property? happy
-  # end
-  # ```
-  #
-  # Is the same as writing:
-  #
-  # ```
-  # class Person
-  #   def happy=(@happy)
-  #   end
-  #
-  #   def happy?
-  #     @happy
-  #   end
-  # end
-  # ```
-  #
-  # The arguments can be string literals, symbol literals or plain names:
-  #
-  # ```
-  # class Person
-  #   property? :happy, "famous"
-  # end
-  # ```
-  #
-  # If a type declaration is given, a variable with that name
-  # is declared with that type.
-  #
-  # ```
-  # class Person
-  #   property? happy : Bool
-  # end
-  # ```
-  #
-  # Is the same as writing:
-  #
-  # ```
-  # class Person
-  #   @happy : Bool
-  #
-  #   def happy=(@happy : Bool)
-  #   end
-  #
-  #   def happy? : Bool
-  #     @happy
-  #   end
-  # end
-  # ```
-  #
-  # The type declaration can also include an initial value:
-  #
-  # ```
-  # class Person
-  #   property? happy : Bool = true
-  # end
-  # ```
-  #
-  # Is the same as writing:
-  #
-  # ```
-  # class Person
-  #   @happy : Bool = true
-  #
-  #   def happy=(@happy : Bool)
-  #   end
-  #
-  #   def happy? : Bool
-  #     @happy
-  #   end
-  # end
-  # ```
-  #
-  # An assignment can be passed too, but in this case the type of the
-  # variable must be easily inferable from the initial value:
-  #
-  # ```
-  # class Person
-  #   property? happy = true
-  # end
-  # ```
-  #
-  # Is the same as writing:
-  #
-  # ```
-  # class Person
-  #   @happy = true
-  #
-  #   def happy=(@happy)
-  #   end
-  #
-  #   def happy?
-  #     @happy
-  #   end
-  # end
-  # ```
-  #
-  # If a block is given to the macro, a property is generated
-  # with a variable that is lazily initialized with
-  # the block's contents, for examples see `#property`.
+  # Refer to the aforementioned macros for details.
   macro property?(*names, &block)
     {% for name in names %}
       {% if name.is_a?(TypeDeclaration) %}
@@ -774,68 +261,10 @@ class Object
     {% end %}
   end
 
-  # Defines raise-on-nil property methods for each of the given arguments.
+  # Generates both `getter!` and `setter`
+  # methods to access instance variables.
   #
-  # Writing:
-  #
-  # ```
-  # class Person
-  #   property! name
-  # end
-  # ```
-  #
-  # Is the same as writing:
-  #
-  # ```
-  # class Person
-  #   def name=(@name)
-  #   end
-  #
-  #   def name?
-  #     @name
-  #   end
-  #
-  #   def name
-  #     @name.not_nil!
-  #   end
-  # end
-  # ```
-  #
-  # The arguments can be string literals, symbol literals or plain names:
-  #
-  # ```
-  # class Person
-  #   property! :name, "age"
-  # end
-  # ```
-  #
-  # If a type declaration is given, a variable with that name
-  # is declared with that type, as nilable.
-  #
-  # ```
-  # class Person
-  #   property! name : String
-  # end
-  # ```
-  #
-  # Is the same as writing:
-  #
-  # ```
-  # class Person
-  #   @name : String?
-  #
-  #   def name=(@name)
-  #   end
-  #
-  #   def name?
-  #     @name
-  #   end
-  #
-  #   def name
-  #     @name.not_nil!
-  #   end
-  # end
-  # ```
+  # Refer to the aforementioned macros for details.
   macro property!(*names)
     {% for name in names %}
       {% if name.is_a?(TypeDeclaration) %}
@@ -865,119 +294,29 @@ class Object
     {% end %}
   end
 
-  # Defines getter methods for each of the given arguments.
+  # Defines getter method(s) to access class variable(s).
   #
-  # Writing:
+  # For example writing:
   #
   # ```
-  # class Person
-  #   class_getter name
+  # class Robot
+  #   class_getter backend
   # end
   # ```
   #
-  # Is the same as writing:
+  # Is equivalent to writing:
   #
   # ```
-  # class Person
-  #   def self.name
-  #     @@name
+  # class Robot
+  #   @@backend : String
+  #
+  #   def self.backend
+  #     @@backend
   #   end
   # end
   # ```
   #
-  # The arguments can be string literals, symbol literals or plain names:
-  #
-  # ```
-  # class Person
-  #   class_getter :name, "age"
-  # end
-  # ```
-  #
-  # If a type declaration is given, a variable with that name
-  # is declared with that type.
-  #
-  # ```
-  # class Person
-  #   class_getter name : String
-  # end
-  # ```
-  #
-  # Is the same as writing:
-  #
-  # ```
-  # class Person
-  #   @@name : String
-  #
-  #   def self.name : String
-  #     @@name
-  #   end
-  # end
-  # ```
-  #
-  # The type declaration can also include an initial value:
-  #
-  # ```
-  # class Person
-  #   class_getter name : String = "John Doe"
-  # end
-  # ```
-  #
-  # Is the same as writing:
-  #
-  # ```
-  # class Person
-  #   @@name : String = "John Doe"
-  #
-  #   def self.name : String
-  #     @@name
-  #   end
-  # end
-  # ```
-  #
-  # An assignment can be passed too, but in this case the type of the
-  # variable must be easily inferable from the initial value:
-  #
-  # ```
-  # class Person
-  #   class_getter name = "John Doe"
-  # end
-  # ```
-  #
-  # Is the same as writing:
-  #
-  # ```
-  # class Person
-  #   @@name = "John Doe"
-  #
-  #   def self.name : String
-  #     @@name
-  #   end
-  # end
-  # ```
-  #
-  # If a block is given to the macro, a getter is generated
-  # with a variable that is lazily initialized with
-  # the block's contents:
-  #
-  # ```
-  # class Person
-  #   class_getter(birth_date) { Time.local }
-  # end
-  # ```
-  #
-  # Is the same as writing:
-  #
-  # ```
-  # class Person
-  #   def self.birth_date
-  #     if (value = @@birth_date).nil?
-  #       @@birth_date = Time.local
-  #     else
-  #       value
-  #     end
-  #   end
-  # end
-  # ```
+  # Refer to [Getters](#getters) for details.
   macro class_getter(*names, &block)
     {% for name in names %}
       {% if name.is_a?(TypeDeclaration) %}
@@ -1012,99 +351,27 @@ class Object
     {% end %}
   end
 
-  # Defines query getter methods for each of the given arguments.
+  # Identical to `class_getter` but defines query methods.
   #
-  # Writing:
+  # For example writing:
   #
   # ```
-  # class Person
-  #   class_getter? happy
+  # class Robot
+  #   class_getter? backend
   # end
   # ```
   #
-  # Is the same as writing:
+  # Is equivalent to writing:
   #
   # ```
-  # class Person
-  #   def self.happy?
-  #     @@happy
+  # class Robot
+  #   def self.backend?
+  #     @@backend
   #   end
   # end
   # ```
   #
-  # The arguments can be string literals, symbol literals or plain names:
-  #
-  # ```
-  # class Person
-  #   class_getter? :happy, "famous"
-  # end
-  # ```
-  #
-  # If a type declaration is given, a variable with that name
-  # is declared with that type.
-  #
-  # ```
-  # class Person
-  #   class_getter? happy : Bool
-  # end
-  # ```
-  #
-  # is the same as writing:
-  #
-  # ```
-  # class Person
-  #   @@happy : Bool
-  #
-  #   def self.happy? : Bool
-  #     @@happy
-  #   end
-  # end
-  # ```
-  #
-  # The type declaration can also include an initial value:
-  #
-  # ```
-  # class Person
-  #   class_getter? happy : Bool = true
-  # end
-  # ```
-  #
-  # Is the same as writing:
-  #
-  # ```
-  # class Person
-  #   @@happy : Bool = true
-  #
-  #   def self.happy? : Bool
-  #     @@happy
-  #   end
-  # end
-  # ```
-  #
-  # An assignment can be passed too, but in this case the type of the
-  # variable must be easily inferable from the initial value:
-  #
-  # ```
-  # class Person
-  #   class_getter? happy = true
-  # end
-  # ```
-  #
-  # Is the same as writing:
-  #
-  # ```
-  # class Person
-  #   @@happy = true
-  #
-  #   def self.happy?
-  #     @@happy
-  #   end
-  # end
-  # ```
-  #
-  # If a block is given to the macro, a getter is generated with a variable
-  # that is lazily initialized with the block's contents, for examples see
-  # `#class_getter`.
+  # Refer to [Getters](#getters) for general details.
   macro class_getter?(*names, &block)
     {% for name in names %}
       {% if name.is_a?(TypeDeclaration) %}
@@ -1139,62 +406,38 @@ class Object
     {% end %}
   end
 
-  # Defines raise-on-nil and nilable getter methods for each of the given arguments.
+  # Similar to `class_getter` but defines both raise-on-nil methods as well as
+  # query methods that return a nilable value.
   #
-  # Writing:
+  # If a type is specified, then it will become a nilable type (union of the
+  # type and `Nil`). Unlike with `class_getter` the value is always initialized
+  # to `nil`. There are no initial value or lazy initialization.
+  #
+  # For example writing:
   #
   # ```
-  # class Person
-  #   class_getter! name
+  # class Robot
+  #   class_getter! backend : String
   # end
   # ```
   #
-  # Is the same as writing:
+  # Is equivalent to writing:
   #
   # ```
-  # class Person
-  #   def self.name?
-  #     @@name
+  # class Robot
+  #   @@backend : String?
+  #
+  #   def self.backend? : String?
+  #     @@backend
   #   end
   #
-  #   def self.name
-  #     @@name.not_nil!
-  #   end
-  # end
-  # ```
-  #
-  # The arguments can be string literals, symbol literals or plain names:
-  #
-  # ```
-  # class Person
-  #   class_getter! :name, "age"
-  # end
-  # ```
-  #
-  # If a type declaration is given, a variable with that name
-  # is declared with that type, as nilable.
-  #
-  # ```
-  # class Person
-  #   class_getter! name : String
-  # end
-  # ```
-  #
-  # is the same as writing:
-  #
-  # ```
-  # class Person
-  #   @@name : String?
-  #
-  #   def self.name?
-  #     @@name
-  #   end
-  #
-  #   def self.name
-  #     @@name.not_nil!
+  #   def backend : String
+  #     @@backend.not_nil!("Robot.backend cannot be nil")
   #   end
   # end
   # ```
+  #
+  # Refer to [Getters](#getters) for general details.
   macro class_getter!(*names)
     {% for name in names %}
       {% if name.is_a?(TypeDeclaration) %}
@@ -1221,91 +464,28 @@ class Object
     {% end %}
   end
 
-  # Defines setter methods for each of the given arguments.
+  # Generates setter method(s) to set class variable(s).
   #
-  # Writing:
+  # For example writing:
   #
   # ```
-  # class Person
-  #   class_setter name
+  # class Robot
+  #   class_setter factories
   # end
   # ```
   #
-  # Is the same as writing:
+  # Is equivalent to writing:
   #
   # ```
-  # class Person
-  #   def self.name=(@@name)
+  # class Robot
+  #   @@factories
+  #
+  #   def self.factories=(@@factories)
   #   end
   # end
   # ```
   #
-  # The arguments can be string literals, symbol literals or plain names:
-  #
-  # ```
-  # class Person
-  #   class_setter :name, "age"
-  # end
-  # ```
-  #
-  # If a type declaration is given, a variable with that name
-  # is declared with that type.
-  #
-  # ```
-  # class Person
-  #   class_setter name : String
-  # end
-  # ```
-  #
-  # is the same as writing:
-  #
-  # ```
-  # class Person
-  #   @@name : String
-  #
-  #   def self.name=(@@name : String)
-  #   end
-  # end
-  # ```
-  #
-  # The type declaration can also include an initial value:
-  #
-  # ```
-  # class Person
-  #   class_setter name : String = "John Doe"
-  # end
-  # ```
-  #
-  # Is the same as writing:
-  #
-  # ```
-  # class Person
-  #   @@name : String = "John Doe"
-  #
-  #   def self.name=(@@name : String)
-  #   end
-  # end
-  # ```
-  #
-  # An assignment can be passed too, but in this case the type of the
-  # variable must be easily inferable from the initial value:
-  #
-  # ```
-  # class Person
-  #   class_setter name = "John Doe"
-  # end
-  # ```
-  #
-  # Is the same as writing:
-  #
-  # ```
-  # class Person
-  #   @@name = "John Doe"
-  #
-  #   def self.name=(@@name)
-  #   end
-  # end
-  # ```
+  # Refer to [Setters](#setters) for general details.
   macro class_setter(*names)
     {% for name in names %}
       {% if name.is_a?(TypeDeclaration) %}
@@ -1327,134 +507,10 @@ class Object
     {% end %}
   end
 
-  # Defines property methods for each of the given arguments.
+  # Generates both `class_getter` and `class_setter`
+  # methods to access instance variables.
   #
-  # Writing:
-  #
-  # ```
-  # class Person
-  #   class_property name
-  # end
-  # ```
-  #
-  # Is the same as writing:
-  #
-  # ```
-  # class Person
-  #   def self.name=(@@name)
-  #   end
-  #
-  #   def self.name
-  #     @@name
-  #   end
-  # end
-  # ```
-  #
-  # The arguments can be string literals, symbol literals or plain names:
-  #
-  # ```
-  # class Person
-  #   class_property :name, "age"
-  # end
-  # ```
-  #
-  # If a type declaration is given, a variable with that name
-  # is declared with that type.
-  #
-  # ```
-  # class Person
-  #   class_property name : String
-  # end
-  # ```
-  #
-  # Is the same as writing:
-  #
-  # ```
-  # class Person
-  #   @@name : String
-  #
-  #   def self.name=(@@name)
-  #   end
-  #
-  #   def self.name
-  #     @@name
-  #   end
-  # end
-  # ```
-  #
-  # The type declaration can also include an initial value:
-  #
-  # ```
-  # class Person
-  #   class_property name : String = "John Doe"
-  # end
-  # ```
-  #
-  # Is the same as writing:
-  #
-  # ```
-  # class Person
-  #   @@name : String = "John Doe"
-  #
-  #   def self.name=(@@name : String)
-  #   end
-  #
-  #   def self.name
-  #     @@name
-  #   end
-  # end
-  # ```
-  #
-  # An assignment can be passed too, but in this case the type of the
-  # variable must be easily inferable from the initial value:
-  #
-  # ```
-  # class Person
-  #   class_property name = "John Doe"
-  # end
-  # ```
-  #
-  # Is the same as writing:
-  #
-  # ```
-  # class Person
-  #   @@name = "John Doe"
-  #
-  #   def self.name=(@@name : String)
-  #   end
-  #
-  #   def self.name
-  #     @@name
-  #   end
-  # end
-  # ```
-  #
-  # If a block is given to the macro, a property is generated
-  # with a variable that is lazily initialized with
-  # the block's contents:
-  #
-  # ```
-  # class Person
-  #   class_property(birth_date) { Time.local }
-  # end
-  # ```
-  #
-  # Is the same as writing:
-  #
-  # ```
-  # class Person
-  #   def self.birth_date
-  #     if (value = @@birth_date).nil?
-  #       @@birth_date = Time.local
-  #     else
-  #       value
-  #     end
-  #   end
-  #
-  #   def self.birth_date=(@@birth_date)
-  #   end
-  # end
-  # ```
+  # Refer to the aforementioned macros for details.
   macro class_property(*names, &block)
     {% for name in names %}
       {% if name.is_a?(TypeDeclaration) %}
@@ -1492,111 +548,10 @@ class Object
     {% end %}
   end
 
-  # Defines query property methods for each of the given arguments.
+  # Generates both `class_getter?` and `class_setter`
+  # methods to access instance variables.
   #
-  # Writing:
-  #
-  # ```
-  # class Person
-  #   class_property? happy
-  # end
-  # ```
-  #
-  # Is the same as writing:
-  #
-  # ```
-  # class Person
-  #   def self.happy=(@@happy)
-  #   end
-  #
-  #   def self.happy?
-  #     @@happy
-  #   end
-  # end
-  # ```
-  #
-  # The arguments can be string literals, symbol literals or plain names:
-  #
-  # ```
-  # class Person
-  #   class_property? :happy, "famous"
-  # end
-  # ```
-  #
-  # If a type declaration is given, a variable with that name
-  # is declared with that type.
-  #
-  # ```
-  # class Person
-  #   class_property? happy : Bool
-  # end
-  # ```
-  #
-  # Is the same as writing:
-  #
-  # ```
-  # class Person
-  #   @@happy : Bool
-  #
-  #   def self.happy=(@@happy : Bool)
-  #   end
-  #
-  #   def self.happy? : Bool
-  #     @@happy
-  #   end
-  # end
-  # ```
-  #
-  # The type declaration can also include an initial value:
-  #
-  # ```
-  # class Person
-  #   class_property? happy : Bool = true
-  # end
-  # ```
-  #
-  # Is the same as writing:
-  #
-  # ```
-  # class Person
-  #   @@happy : Bool = true
-  #
-  #   def self.happy=(@@happy : Bool)
-  #   end
-  #
-  #   def self.happy? : Bool
-  #     @@happy
-  #   end
-  # end
-  # ```
-  #
-  # An assignment can be passed too, but in this case the type of the
-  # variable must be easily inferable from the initial value:
-  #
-  # ```
-  # class Person
-  #   class_property? happy = true
-  # end
-  # ```
-  #
-  # Is the same as writing:
-  #
-  # ```
-  # class Person
-  #   @@happy = true
-  #
-  #   def self.happy=(@@happy)
-  #   end
-  #
-  #   def self.happy?
-  #     @@happy
-  #   end
-  # end
-  # ```
-  #
-  # If a block is given to the macro, a property is generated
-  # with a variable that is lazily initialized with
-  # the block's contents, for examples see `#class_property`.
+  # Refer to the aforementioned macros for details.
   macro class_property?(*names, &block)
     {% for name in names %}
       {% if name.is_a?(TypeDeclaration) %}
@@ -1634,68 +589,10 @@ class Object
     {% end %}
   end
 
-  # Defines raise-on-nil property methods for each of the given arguments.
+  # Generates both `class_getter!` and `class_setter`
+  # methods to access instance variables.
   #
-  # Writing:
-  #
-  # ```
-  # class Person
-  #   class_property! name
-  # end
-  # ```
-  #
-  # Is the same as writing:
-  #
-  # ```
-  # class Person
-  #   def self.name=(@@name)
-  #   end
-  #
-  #   def self.name?
-  #     @@name
-  #   end
-  #
-  #   def self.name
-  #     @@name.not_nil!
-  #   end
-  # end
-  # ```
-  #
-  # The arguments can be string literals, symbol literals or plain names:
-  #
-  # ```
-  # class Person
-  #   class_property! :name, "age"
-  # end
-  # ```
-  #
-  # If a type declaration is given, a variable with that name
-  # is declared with that type, as nilable.
-  #
-  # ```
-  # class Person
-  #   class_property! name : String
-  # end
-  # ```
-  #
-  # Is the same as writing:
-  #
-  # ```
-  # class Person
-  #   @@name : String?
-  #
-  #   def self.name=(@@name)
-  #   end
-  #
-  #   def self.name?
-  #     @@name
-  #   end
-  #
-  #   def self.name
-  #     @@name.not_nil!
-  #   end
-  # end
-  # ```
+  # Refer to the aforementioned macros for details.
   macro class_property!(*names)
     {% for name in names %}
       {% if name.is_a?(TypeDeclaration) %}

--- a/src/object/properties.cr
+++ b/src/object/properties.cr
@@ -308,8 +308,6 @@ class Object
   #
   # ```
   # class Robot
-  #   @@backend : String
-  #
   #   def self.backend
   #     @@backend
   #   end

--- a/src/object/properties.cr
+++ b/src/object/properties.cr
@@ -5,7 +5,7 @@
 # DO NOT EDIT
 
 class Object
-  # Defines getter method(s) to access instance variable(s).
+  # Defines getter methods to access instance variables.
   #
   # Refer to [Getters](#getters) for details.
   macro getter(*names, &block)
@@ -44,7 +44,7 @@ class Object
 
   # Identical to `getter` but defines query methods.
   #
-  # For example writing:
+  # For example, writing:
   #
   # ```
   # class Robot
@@ -104,7 +104,7 @@ class Object
   # type and `Nil`). Unlike the other `getter` methods the value is always
   # initialized to `nil`. There are no initial value or lazy initialization.
   #
-  # For example writing:
+  # For example, writing:
   #
   # ```
   # class Robot
@@ -294,9 +294,9 @@ class Object
     {% end %}
   end
 
-  # Defines getter method(s) to access class variable(s).
+  # Defines getter methods to access class variables.
   #
-  # For example writing:
+  # For example, writing:
   #
   # ```
   # class Robot
@@ -351,7 +351,7 @@ class Object
 
   # Identical to `class_getter` but defines query methods.
   #
-  # For example writing:
+  # For example, writing:
   #
   # ```
   # class Robot
@@ -411,7 +411,7 @@ class Object
   # type and `Nil`). Unlike with `class_getter` the value is always initialized
   # to `nil`. There are no initial value or lazy initialization.
   #
-  # For example writing:
+  # For example, writing:
   #
   # ```
   # class Robot
@@ -462,9 +462,9 @@ class Object
     {% end %}
   end
 
-  # Generates setter method(s) to set class variable(s).
+  # Generates setter methods to set class variables.
   #
-  # For example writing:
+  # For example, writing:
   #
   # ```
   # class Robot


### PR DESCRIPTION
Initial rework of the documentation for Object getter, setter and property macros to avoid duplication and repetition.

A general description of the behavior has been added to `Object` itself, with references to the different variants. Then each macro has a smaller description on how it is different from the main behavior.

Even if imperfect I believe it's a good start. Feel free to edit, modify and take over the PR as you see fit (or better: work on a follow up).

Follow up to #15386 

<details><summary>Screenshot of what the general doc looks</summary>

![image](https://github.com/user-attachments/assets/4c3fbdde-cf1c-48e6-8013-1fbc52afa3e5)
</details>

<details><summary>Screenshot of what a macro doc looks</summary>

![image](https://github.com/user-attachments/assets/708716f0-dcb8-443d-a910-69ee0d21a483)

</details>