### PR TITLE
Fix `Tuple#to_a(&)` for arbitrary block output type

### DIFF
--- a/spec/std/tuple_spec.cr
+++ b/spec/std/tuple_spec.cr
@@ -334,15 +334,23 @@ describe "Tuple" do
   end
 
   describe "#to_a" do
-    it "basic" do
-      ary = {1, 'a', true}.to_a
-      ary.should eq([1, 'a', true])
-      ary.size.should eq(3)
+    describe "without block" do
+      it "basic" do
+        ary = {1, 'a', true}.to_a
+        ary.should eq([1, 'a', true])
+        ary.size.should eq(3)
+      end
+
+      it "empty" do
+        ary = Tuple.new.to_a
+        ary.size.should eq(0)
+      end
     end
 
-    it "empty" do
-      ary = Tuple.new.to_a
-      ary.size.should eq(0)
+    describe "with block" do
+      it "basic" do
+        {-1, -2, -3}.to_a(&.abs).should eq [1, 2, 3]
+      end
     end
   end
 

--- a/spec/std/tuple_spec.cr
+++ b/spec/std/tuple_spec.cr
@@ -333,13 +333,17 @@ describe "Tuple" do
     ({1, 2} === nil).should be_false
   end
 
-  it "does to_a" do
-    ary = {1, 'a', true}.to_a
-    ary.should eq([1, 'a', true])
-    ary.size.should eq(3)
+  describe "#to_a" do
+    it "basic" do
+      ary = {1, 'a', true}.to_a
+      ary.should eq([1, 'a', true])
+      ary.size.should eq(3)
+    end
 
-    ary = Tuple.new.to_a
-    ary.size.should eq(0)
+    it "empty" do
+      ary = Tuple.new.to_a
+      ary.size.should eq(0)
+    end
   end
 
   # Tuple#to_static_array don't compile on aarch64-darwin and

--- a/spec/std/tuple_spec.cr
+++ b/spec/std/tuple_spec.cr
@@ -351,6 +351,10 @@ describe "Tuple" do
       it "basic" do
         {-1, -2, -3}.to_a(&.abs).should eq [1, 2, 3]
       end
+
+      it "different type" do
+        {1, 2, true}.to_a(&.to_s).should eq ["1", "2", "true"]
+      end
     end
   end
 

--- a/src/tuple.cr
+++ b/src/tuple.cr
@@ -545,11 +545,7 @@ struct Tuple
   # {1, 2, 3, 4, 5}.to_a # => [1, 2, 3, 4, 5]
   # ```
   def to_a : Array(Union(*T))
-    {% if compare_versions(Crystal::VERSION, "1.1.0") < 0 %}
-      to_a(&.itself.as(Union(*T)))
-    {% else %}
-      to_a(&.itself)
-    {% end %}
+    to_a(&.as(Union(*T)))
   end
 
   # Returns an `Array` with the results of running *block* against each element of the tuple.
@@ -557,8 +553,8 @@ struct Tuple
   # ```
   # {1, 2, 3, 4, 5}).to_a { |i| i * 2 } # => [2, 4, 6, 8, 10]
   # ```
-  def to_a(& : Union(*T) -> _)
-    Array(Union(*T)).build(size) do |buffer|
+  def to_a(& : Union(*T) -> U) forall U
+    Array(U).build(size) do |buffer|
       {% for i in 0...T.size %}
         buffer[{{i}}] = yield self[{{i}}]
       {% end %}


### PR DESCRIPTION
Resolves #15430