### PR TITLE
Simplify `Enumerable#to_a`

### DIFF
--- a/src/enumerable.cr
+++ b/src/enumerable.cr
@@ -2013,9 +2013,7 @@ module Enumerable(T)
   # (1..5).to_a # => [1, 2, 3, 4, 5]
   # ```
   def to_a : Array(T)
-    ary = [] of T
-    each { |e| ary << e }
-    ary
+    to_a(&.as(T))
   end
 
   # Returns an `Array` with the results of running *block* against each element of the collection.

--- a/src/hash.cr
+++ b/src/hash.cr
@@ -2083,7 +2083,7 @@ class Hash(K, V)
   #
   # The order of the array follows the order the keys were inserted in the Hash.
   def to_a : Array({K, V})
-    to_a(&.itself)
+    super
   end
 
   # Returns an `Array` with the results of running *block* against tuples with key and values

--- a/src/indexable.cr
+++ b/src/indexable.cr
@@ -693,17 +693,6 @@ module Indexable(T)
     end
   end
 
-  # Returns an `Array` with all the elements in the collection.
-  #
-  # ```
-  # {1, 2, 3}.to_a # => [1, 2, 3]
-  # ```
-  def to_a : Array(T)
-    ary = Array(T).new(size)
-    each { |e| ary << e }
-    ary
-  end
-
   # Returns an `Array` with the results of running *block* against each element of the collection.
   #
   # ```

--- a/src/tuple.cr
+++ b/src/tuple.cr
@@ -545,11 +545,7 @@ struct Tuple
   # {1, 2, 3, 4, 5}.to_a # => [1, 2, 3, 4, 5]
   # ```
   def to_a : Array(Union(*T))
-    {% if compare_versions(Crystal::VERSION, "1.1.0") < 0 %}
-      to_a(&.itself.as(Union(*T)))
-    {% else %}
-      to_a(&.itself)
-    {% end %}
+    super
   end
 
   # Returns an `Array` with the results of running *block* against each element of the tuple.


### PR DESCRIPTION
The implementation of `#to_a` is identical to its yielding variant `#to_a(&)`. We can simply delegate to `#to_a(&)`.
As a bonus, inheriting types which override `#to_a(&)` with an optimized implementation will implicitly use the same optimization for `#to_a` as well. This means we can drop `Indexable#to_a`.

Inheriting types `Tuple` and `Hash` already explicitly delegate `#to_a` to their override implementations of `#to_a(&)`.
We probably want to keep these overrides of `#to_a` because they augment the documentation.
But we can replace the method bodies with `super` to make it clear that the behaviour is inherited and the `def` only provides documentation.