### PR TITLE
Move shadow space reservation to x86_64 makecontext

### DIFF
--- a/src/fiber.cr
+++ b/src/fiber.cr
@@ -108,21 +108,9 @@ class Fiber
 
     fiber_main = ->(f : Fiber) { f.run }
 
-    # FIXME: This line shouldn't be necessary (#7975)
-    stack_ptr = nil
-    {% if flag?(:win32) %}
-      # align stack bottom to 16 bytes
-      @stack_bottom = Pointer(Void).new(@stack_bottom.address & ~0x0f_u64)
-
-      # It's the caller's responsibility to allocate 32 bytes of "shadow space" on the stack right
-      # before calling the function (regardless of the actual number of parameters used)
-
-      stack_ptr = @stack_bottom - sizeof(Void*) * 6
-    {% else %}
-      # point to first addressable pointer on the stack (@stack_bottom points past
-      # the stack because the stack grows down):
-      stack_ptr = @stack_bottom - sizeof(Void*)
-    {% end %}
+    # point to first addressable pointer on the stack (@stack_bottom points past
+    # the stack because the stack grows down):
+    stack_ptr = @stack_bottom - sizeof(Void*)
 
     # align the stack pointer to 16 bytes:
     stack_ptr = Pointer(Void*).new(stack_ptr.address & ~0x0f_u64)


### PR DESCRIPTION
_This has been puzzling me for a while, and working on #15409 I finally took the time to investigate._

The shadow space (or home space) is a requirement of the x64 call convention: we must reserve 32 bytes before the return address on the stack. It only applies to x64, not to arm64 for example.

We don't have to deal with this when creating the stack. This is a consideration for each individual `makecontext` to handle.

References:

- [Microsoft: x64 call convention](https://learn.microsoft.com/en-us/cpp/build/x64-calling-convention?view=msvc-170)
- [Shadow Space and Stack Alignment (x64)](https://open-advanced-windows-exploitati.gitbook.io/open-advanced-windows-exploitation/custom-shellcode/64-bit-architecture/calling-conventions#shadow-space-and-stack-alignment)
- [Microsoft: arm64 call convention](https://learn.microsoft.com/en-us/cpp/build/arm64-windows-abi-conventions?view=msvc-170)