### PR TITLE
Add block type restriction to abstract def

### DIFF
--- a/spec/compiler/formatter/formatter_spec.cr
+++ b/spec/compiler/formatter/formatter_spec.cr
@@ -2886,4 +2886,11 @@ describe Crystal::Formatter do
       assert_format %(<<-'EOS'\n#{char}\nEOS)
     end
   end
+
+  describe "abstract def block type" do
+    assert_format "abstract def foo(& : Foo -> Bar)"
+    assert_format "abstract def foo(&block : Foo -> Bar)"
+    assert_format "abstract def foo(&)", "abstract def foo(& : -> _)"
+    assert_format "abstract def foo(&block)", "abstract def foo(&block : -> _)"
+  end
 end

--- a/src/compiler/crystal/tools/formatter.cr
+++ b/src/compiler/crystal/tools/formatter.cr
@@ -1524,10 +1524,10 @@ module Crystal
 
     def format_def_args(node : Def | Macro)
       yields = node.is_a?(Def) && !node.block_arity.nil?
-      format_def_args node.args, node.block_arg, node.splat_index, false, node.double_splat, yields
+      format_def_args node, node.args, node.block_arg, node.splat_index, false, node.double_splat, yields
     end
 
-    def format_def_args(args : Array, block_arg, splat_index, variadic, double_splat, yields)
+    def format_def_args(node, args : Array, block_arg, splat_index, variadic, double_splat, yields)
       # If there are no args, remove extra "()"
       if args.empty? && !block_arg && !double_splat && !variadic
         if @token.type.op_lparen?
@@ -1594,6 +1594,10 @@ module Crystal
 
           to_skip += 1 if at_skip?
           block_arg.accept self
+
+          if block_arg.restriction.nil? && abstract_def?(node)
+            write " : -> _"
+          end
         end
       elsif yields
         wrote_newline = format_def_arg(wrote_newline, false) do
@@ -1718,7 +1722,7 @@ module Crystal
         end
       end
 
-      format_def_args node.args, nil, nil, node.varargs?, nil, false
+      format_def_args node, node.args, nil, nil, node.varargs?, nil, false
 
       if return_type = node.return_type
         skip_space

--- a/src/crystal/event_loop/polling.cr
+++ b/src/crystal/event_loop/polling.cr
@@ -550,7 +550,7 @@ abstract class Crystal::EventLoop::Polling < Crystal::EventLoop
   protected abstract def system_del(fd : Int32, closing = true) : Nil
 
   # Identical to `#system_del` but yields on error.
-  protected abstract def system_del(fd : Int32, closing = true, &) : Nil
+  protected abstract def system_del(fd : Int32, closing = true, & : -> _) : Nil
 
   # Arm a timer to interrupt a run at *time*. Set to `nil` to disarm the timer.
   private abstract def system_set_timer(time : Time::Span?) : Nil

--- a/src/crystal/syntax_highlighter.cr
+++ b/src/crystal/syntax_highlighter.cr
@@ -18,13 +18,13 @@ abstract class Crystal::SyntaxHighlighter
   abstract def render(type : TokenType, value : String)
 
   # Renders a delimiter sequence.
-  abstract def render_delimiter(&)
+  abstract def render_delimiter(& : -> _)
 
   # Renders an interpolation sequence.
-  abstract def render_interpolation(&)
+  abstract def render_interpolation(& : -> _)
 
   # Renders a string array sequence.
-  abstract def render_string_array(&)
+  abstract def render_string_array(& : -> _)
 
   # Describes the type of a highlighter token.
   enum TokenType


### PR DESCRIPTION
As suggested in https://github.com/crystal-lang/crystal/issues/15391#issuecomment-2626822742

We may want to put this change behind a flag (`abstract_dev_block_type`?) for a concentrated rollout (cf. #13002).