### PR TITLE
[CI] Fix shards packaging for mingw-w64

### DIFF
--- a/.github/workflows/mingw-w64.yml
+++ b/.github/workflows/mingw-w64.yml
@@ -105,6 +105,7 @@ jobs:
         working-directory: ./shards
         run: |
           make install PREFIX="$(pwd)/../crystal"
+          ldd bin/shards.exe | grep -iv ' => /c/windows/system32' | sed 's/.* => //; s/ (.*//' | xargs -t -i /usr/bin/install -m 0755 '{}' "$(pwd)/../crystal/bin/"
 
       - name: Upload Crystal executable
         uses: actions/upload-artifact@v4

--- a/.github/workflows/mingw-w64.yml
+++ b/.github/workflows/mingw-w64.yml
@@ -102,6 +102,7 @@ jobs:
 
       - name: Package Shards
         shell: msys2 {0}
+        working-directory: ./shards
         run: |
           make install PREFIX="$(pwd)/../crystal"
 


### PR DESCRIPTION
Fixup for #15344

This change was broken as neither shards.exe was installed nor the necessary libraries.