### PR TITLE
Lexer: Fix location of token after line continuation

### DIFF
--- a/spec/compiler/parser/parser_spec.cr
+++ b/spec/compiler/parser/parser_spec.cr
@@ -2371,6 +2371,7 @@ module Crystal
       assert_end_location "1 rescue 2"
       assert_end_location "1 ensure 2"
       assert_end_location "foo.bar= *baz"
+      assert_end_location %("hello "\\\n"world"), line_number: 2, column_number: 7
 
       assert_syntax_error %({"a" : 1}), "space not allowed between named argument name and ':'"
       assert_syntax_error %({"a": 1, "b" : 2}), "space not allowed between named argument name and ':'"

--- a/src/compiler/crystal/syntax/lexer.cr
+++ b/src/compiler/crystal/syntax/lexer.cr
@@ -157,7 +157,7 @@ module Crystal
         case next_char
         when '\r', '\n'
           handle_slash_r_slash_n_or_slash_n
-          incr_line_number
+          incr_line_number 0
           @token.passed_backslash_newline = true
           consume_whitespace
           reset_regex_flags = false


### PR DESCRIPTION
Extracted from #15452

```cr
"hello "\
"world" # <-- This token should start at column 1, not column 2!
```