### PR TITLE
[CI] Filter runs of LLVM Test workflow

### DIFF
--- a/.github/workflows/llvm.yml
+++ b/.github/workflows/llvm.yml
@@ -14,7 +14,7 @@ on:
       - 'spec/llvm-ir/**'
       - '.github/workflows/llvm.yml'
   schedule:
-  - cron: '0 3 * * *'
+    - cron: '0 3 * * *'
   workflow_dispatch:
 
 permissions: {}

--- a/.github/workflows/llvm.yml
+++ b/.github/workflows/llvm.yml
@@ -1,6 +1,21 @@
 name: LLVM CI
 
-on: [push, pull_request]
+on:
+  push:
+    paths:
+      - 'src/llvm/**'
+      - 'spec/std/llvm/**'
+      - 'spec/llvm-ir/**'
+      - '.github/workflows/llvm.yml'
+  pull_request:
+    paths:
+      - 'src/llvm/**'
+      - 'spec/std/llvm/**'
+      - 'spec/llvm-ir/**'
+      - '.github/workflows/llvm.yml'
+  schedule:
+  - cron: '0 3 * * *'
+  workflow_dispatch:
 
 permissions: {}
 


### PR DESCRIPTION
This workflow now only triggers on changes to paths that are directly related to LLVM.
It also runs on a nightly schedule and can be triggered manually.

Part of https://github.com/crystal-lang/crystal/issues/14983