### PR TITLE
[CI] Filter runs of OpenSSL Test workflow

### DIFF
--- a/.github/workflows/openssl.yml
+++ b/.github/workflows/openssl.yml
@@ -1,6 +1,21 @@
 name: OpenSSL CI
 
-on: [push, pull_request]
+on:
+  push:
+    paths:
+      - 'src/openssl/**'
+      - 'spec/std/digest/**'
+      - 'spec/std/openssl/**'
+      - '.github/workflows/openssl.yml'
+  pull_request:
+    paths:
+      - 'src/openssl/**'
+      - 'spec/std/digest/**'
+      - 'spec/std/openssl/**'
+      - '.github/workflows/openssl.yml'
+  schedule:
+    - cron: '0 3 * * *'
+  workflow_dispatch:
 
 permissions: {}
 


### PR DESCRIPTION
This workflow now only triggers on changes to paths that are directly related to OpenSSL.
It also runs on a nightly schedule and can be triggered manually.

Part of https://github.com/crystal-lang/crystal/issues/14983