### PR TITLE
[CI] Filter runs of regex engine workflow

### DIFF
--- a/.github/workflows/regex-engine.yml
+++ b/.github/workflows/regex-engine.yml
@@ -1,6 +1,23 @@
 name: Regex Engine CI
 
-on: [push, pull_request]
+on:
+  push:
+    paths:
+      - 'src/regex.cr'
+      - 'src/regex/**'
+      - 'spec/std/regex_spec.cr'
+      - 'spec/std/regex/**'
+      - '.github/workflows/regex-engine.yml'
+  pull_request:
+    paths:
+      - 'src/regex.cr'
+      - 'src/regex/**'
+      - 'spec/std/regex_spec.cr'
+      - 'spec/std/regex/**'
+      - '.github/workflows/regex-engine.yml'
+  schedule:
+    - cron: '0 3 * * *'
+  workflow_dispatch:
 
 permissions: {}
 


### PR DESCRIPTION
This workflow now only triggers on changes to paths that are directly related to Regex. It also runs on a nightly schedule and can be triggered manually.

Part of https://github.com/crystal-lang/crystal/issues/14983