### PR TITLE
Add specs for block association in nested calls

### DIFF
--- a/spec/compiler/parser/parser_spec.cr
+++ b/spec/compiler/parser/parser_spec.cr
@@ -637,7 +637,7 @@ module Crystal
               block: Block.new(body: 3.int32)
             ),
             block: Block.new(body: 4.int32))
-          )
+        )
       end
 
       describe "surprise three: arguments affect block binding (#15303)" do


### PR DESCRIPTION
These specs document the current behaviour as described in #15303