### PR TITLE
Add `LLVM.init_native_target` and `LLVM.init_all_targets`

### DIFF
--- a/src/llvm.cr
+++ b/src/llvm.cr
@@ -111,6 +111,8 @@ module LLVM
       init_webassembly
     {% elsif flag?(:avr) %}
       init_avr
+    {% else %}
+      {% raise "Unsupported platform" %}
     {% end %}
   end
 

--- a/src/llvm.cr
+++ b/src/llvm.cr
@@ -100,6 +100,28 @@ module LLVM
     {% end %}
   end
 
+  def self.init_native_target : Nil
+    {% if flag?(:i386) || flag?(:x86_64) %}
+      init_x86
+    {% elsif flag?(:aarch64) %}
+      init_aarch64
+    {% elsif flag?(:arm) %}
+      init_arm
+    {% elsif flag?(:wasm32) %}
+      init_webassembly
+    {% elsif flag?(:avr) %}
+      init_avr
+    {% end %}
+  end
+
+  def self.init_all_targets : Nil
+    {% for target in %i(x86 aarch64 arm avr webassembly) %}
+      {% if LibLLVM::BUILT_TARGETS.includes?(target) %}
+        init_{{ target.id }}
+      {% end %}
+    {% end %}
+  end
+
   @[Deprecated("This method has no effect")]
   def self.start_multithreaded : Bool
     if multithreaded?

--- a/src/llvm/target.cr
+++ b/src/llvm/target.cr
@@ -8,7 +8,7 @@ struct LLVM::Target
   end
 
   def self.first : self
-    first? || raise "No LLVM targets available (did you forget to invoke LLVM.init_x86?)"
+    first? || raise "No LLVM targets available (did you forget to invoke LLVM.init_native_target?)"
   end
 
   def self.first? : self?


### PR DESCRIPTION
LLVM's targets need to be initialized before they can be used. The Crystal compiler does this in `Crystal::Codegen::Target#to_target_machine`, but for external code that uses the LLVM wrappers directly, there is no simple way to do this. This PR adds two convenience methods which are more or less equivalent to LLVM's `LLVMInitializeNativeTarget` and `LLVMInitializeAllTargets`, both static line functions in `llvm-c/Target.h`, except the latter only initializes targets already supported by Crystal itself (e.g. no RISC-V or PowerPC at the moment even if `llvm-config` indicates their availability).