### PR TITLE
Add `Process::Status#description`

### DIFF
--- a/spec/std/process/exit_reason_spec.cr
+++ b/spec/std/process/exit_reason_spec.cr
@@ -1,0 +1,10 @@
+require "spec"
+
+describe Process::ExitReason do
+  describe "#description" do
+    it "with exit status" do
+      Process::ExitReason::Normal.description.should eq "Process exited normally"
+      Process::ExitReason::Unknown.description.should eq "Process terminated abnormally, the cause is unknown"
+    end
+  end
+end

--- a/spec/std/process/status_spec.cr
+++ b/spec/std/process/status_spec.cr
@@ -329,4 +329,27 @@ describe Process::Status do
       end
     {% end %}
   end
+
+  describe "#description" do
+    it "with exit status" do
+      Process::Status.new(exit_status(0)).description.should eq "Process exited normally"
+      Process::Status.new(exit_status(255)).description.should eq "Process exited normally"
+    end
+
+    it "on interrupt" do
+      status_for(:interrupted).description.should eq "Process was interrupted"
+    end
+
+    {% if flag?(:unix) && !flag?(:wasi) %}
+      it "with exit signal" do
+        Process::Status.new(Signal::HUP.value).description.should eq "Process terminated abnormally"
+        Process::Status.new(Signal::STOP.value).description.should eq "Process received and didn't handle signal STOP"
+        last_signal = Signal.values[-1]
+        Process::Status.new(last_signal.value).description.should eq "Process received and didn't handle signal #{last_signal}"
+
+        unknown_signal = Signal.new(126)
+        Process::Status.new(unknown_signal.value).description.should eq "Process received and didn't handle signal 126"
+      end
+    {% end %}
+  end
 end

--- a/spec/std/process/status_spec.cr
+++ b/spec/std/process/status_spec.cr
@@ -343,6 +343,7 @@ describe Process::Status do
     {% if flag?(:unix) && !flag?(:wasi) %}
       it "with exit signal" do
         Process::Status.new(Signal::HUP.value).description.should eq "Process terminated abnormally"
+        Process::Status.new(Signal::KILL.value).description.should eq "Process terminated abnormally"
         Process::Status.new(Signal::STOP.value).description.should eq "Process received and didn't handle signal STOP"
         last_signal = Signal.values[-1]
         Process::Status.new(last_signal.value).description.should eq "Process received and didn't handle signal #{last_signal}"

--- a/src/compiler/crystal/command.cr
+++ b/src/compiler/crystal/command.cr
@@ -305,40 +305,12 @@ class Crystal::Command
       exit exit_code
     end
 
-    if message = exit_message(status)
-      STDERR.puts message
+    unless status.exit_reason.normal?
+      STDERR.puts status.description
       STDERR.flush
     end
 
     exit 1
-  end
-
-  private def exit_message(status)
-    case status.exit_reason
-    when .aborted?, .session_ended?, .terminal_disconnected?
-      if signal = status.exit_signal?
-        if signal.kill?
-          "Program was killed"
-        else
-          "Program received and didn't handle signal #{signal} (#{signal.value})"
-        end
-      else
-        "Program exited abnormally"
-      end
-    when .breakpoint?
-      "Program hit a breakpoint and no debugger was attached"
-    when .access_violation?, .bad_memory_access?
-      # NOTE: this only happens with the empty prelude, because the stdlib
-      # runtime catches those exceptions and then exits _normally_ with exit
-      # code 11 or 1
-      "Program exited because of an invalid memory access"
-    when .bad_instruction?
-      "Program exited because of an invalid instruction"
-    when .float_exception?
-      "Program exited because of a floating-point system exception"
-    when .unknown?
-      "Program exited abnormally, the cause is unknown"
-    end
   end
 
   record CompilerConfig,

--- a/src/process/status.cr
+++ b/src/process/status.cr
@@ -405,8 +405,11 @@ class Process::Status
   # Returns a textual description of this process status.
   #
   # ```
-  # Process::Status.new(0).description                             # => "Process exited normally"
-  # Process.new("sleep", ["10"]).tap(&.terminate).wait.description # => "Process received and didn't handle signal TERM (15)"
+  # Process::Status.new(0).description # => "Process exited normally"
+  # process = Process.new("sleep", ["10"])
+  # process.terminate
+  # process.wait.description
+  # # => "Process received and didn't handle signal TERM (15)"
   # ```
   #
   # `ExitReason#description` provides the specific messages for non-signal exits.

--- a/src/process/status.cr
+++ b/src/process/status.cr
@@ -124,7 +124,7 @@ enum Process::ExitReason
     in .float_exception?
       "Process terminated because of a floating-point system exception"
     in .signal?
-      Status::SIGNAL_REASON_DESCRIPTION
+      "Process terminated because of an unhandled signal"
     in .unknown?
       "Process terminated abnormally, the cause is unknown"
     end
@@ -411,21 +411,12 @@ class Process::Status
   #
   # `ExitReason#description` provides the specific messages for non-signal exits.
   def description
-    description = exit_reason.description
-
-    if description.same?(SIGNAL_REASON_DESCRIPTION) && (signal = exit_signal?)
-      if signal.kill?
-        "Process was killed"
-      else
-        "Process received and didn't handle signal #{signal}"
-      end
+    if exit_reason.signal? && (signal = exit_signal?)
+      "Process received and didn't handle signal #{signal}"
     else
-      description
+      exit_reason.description
     end
   end
-
-  # :nodoc:
-  SIGNAL_REASON_DESCRIPTION = "Process terminated because of an unhandled signal"
 
   private def stringify_exit_status_windows(io)
     # On Windows large status codes are typically expressed in hexadecimal

--- a/src/process/status.cr
+++ b/src/process/status.cr
@@ -408,8 +408,7 @@ class Process::Status
   # Process::Status.new(0).description # => "Process exited normally"
   # process = Process.new("sleep", ["10"])
   # process.terminate
-  # process.wait.description
-  # # => "Process received and didn't handle signal TERM (15)"
+  # process.wait.description # => "Process received and didn't handle signal TERM (15)"
   # ```
   #
   # `ExitReason#description` provides the specific messages for non-signal exits.


### PR DESCRIPTION
In the compiler we have a neat feature that shows a human readable description when a process process exited with an abnormal status.
This patch moves this as a gernal tool into stdlib as `Process::Status#description`.

The implementation is split into two parts:
* `Process::ExitReason#description` provides the static description for most exit reasons
* `Process::Status#description` enhances that description with details about the termination signal when it's a signal exit without further specification.