### PR TITLE
Fix handling of double dashes (--) in crystal eval command

### DIFF
--- a/src/compiler/crystal/command/eval.cr
+++ b/src/compiler/crystal/command/eval.cr
@@ -3,23 +3,21 @@
 class Crystal::Command
   private def eval
     compiler = new_compiler
+    program_source = ""
+    program_args = [] of String
+
     parse_with_crystal_opts do |opts|
       opts.banner = "Usage: crystal eval [options] [source]\n\nOptions:"
       setup_simple_compiler_options compiler, opts
+
+      opts.unknown_args do |before_dash, after_dash|
+        program_source = before_dash.join " "
+        program_args = after_dash
+      end
     end
 
-    if options.empty?
+    if program_source.empty?
       program_source = STDIN.gets_to_end
-      program_args = [] of String
-    else
-      double_dash_index = options.index("--")
-      if double_dash_index
-        program_source = options[0...double_dash_index].join " "
-        program_args = options[double_dash_index + 1..-1]
-      else
-        program_source = options.join " "
-        program_args = [] of String
-      end
     end
 
     sources = [Compiler::Source.new("eval", program_source)]

--- a/src/compiler/crystal/command/eval.cr
+++ b/src/compiler/crystal/command/eval.cr
@@ -11,7 +11,7 @@ class Crystal::Command
       setup_simple_compiler_options compiler, opts
 
       opts.unknown_args do |before_dash, after_dash|
-        program_source = before_dash.join " "
+        program_source = before_dash.join "; "
         program_args = after_dash
       end
     end


### PR DESCRIPTION
This pull request has two fixes to the behavior of the eval command.

1. The eval command will now allow you to pass command line arguments to a program using a single double hyphen.
2. When more than one argument is given, they will be joined with “;” instead of “ ”

## 1 double dash issue

```sh
crystal eval 'puts ARGV' -- meow neigh
```

### Expected behavior

```
["meow", "neigh"]
```

### Actual behavior
 
```console
syntax error in eval:1
Error: unexpected token: "meow"
```

### Workaround

By using two double dashes, you can pass arguments to the program as expected.

```sh
crystal eval 'puts ARGV' -- -- meow neigh
```

The reason for this behavior is that the OptionParser stops at “--” by default, and removes “--”. Therefore, you need to use unknown_args to distinguish between arguments that were before “--” and arguments that were after “--”.

In the [forum](https://forum.crystal-lang.org/t/how-to-use-the-double-hyphen-in-the-eval-subcommand-of-crystal/7742), I received a comment that this is probably not the intended behavior.

## 2 join arguments with “;” instead of “”.

```
crystal eval "puts 0" "puts 1"
```

### Expected behavior (for kojix2)

```
0
1
```

### Actual behavior

```console
syntax error in eval:1
Error: unexpected token: "puts"
```

Personally, I feel that this behavior is preferable. 
In many programming languages, only one argument is accepted. 

```
python3 -c "print(0)" -c "print(1)"
```

```
0
```

In Ruby, multiple arguments are accepted.

```
ruby -e "puts 0" -e "puts 1"
```

```
0
1
```

However, if the opinion that the current behavior should be maintained for compatibility or other reasons is stronger, I can fully understand that.

---

Also, there are no tests for this pull request. If tests are necessary, please let me know where and what kind of tests should be written.