### PR TITLE
[CI] Fix install `llvm` in `mingw-w64.yml` [fixup #15453]

### DIFF
--- a/.github/workflows/mingw-w64.yml
+++ b/.github/workflows/mingw-w64.yml
@@ -25,6 +25,7 @@ jobs:
             git
             make
             mingw-w64-ucrt-x86_64-pkgconf
+            mingw-w64-ucrt-x86_64-llvm
             mingw-w64-ucrt-x86_64-crystal
 
       - name: Disable CRLF line ending substitution
@@ -81,6 +82,7 @@ jobs:
             git
             make
             mingw-w64-ucrt-x86_64-pkgconf
+            mingw-w64-ucrt-x86_64-llvm
             mingw-w64-ucrt-x86_64-crystal
 
       - name: Disable CRLF line ending substitution
@@ -109,6 +111,7 @@ jobs:
             git
             make
             mingw-w64-ucrt-x86_64-pkgconf
+            mingw-w64-ucrt-x86_64-llvm
             mingw-w64-ucrt-x86_64-crystal
 
       - name: Disable CRLF line ending substitution


### PR DESCRIPTION
Since https://github.com/msys2/MINGW-packages/pull/23360 the second package iteration of the `crystal` package replaces the `llvm` dependendy for `lib-llvm`. We need to explicitly install the full `llvm` package in order to get `llvm-config`.