### PR TITLE
Fix handling of double dashes `--` in crystal `eval` command

### DIFF
--- a/src/compiler/crystal/command/eval.cr
+++ b/src/compiler/crystal/command/eval.cr
@@ -3,7 +3,7 @@
 class Crystal::Command
   private def eval
     compiler = new_compiler
-    program_source = nil
+    opt_program_source = nil
     program_args = [] of String
 
     parse_with_crystal_opts do |opts|
@@ -11,16 +11,17 @@ class Crystal::Command
       setup_simple_compiler_options compiler, opts
 
       opts.unknown_args do |before_dash, after_dash|
-        program_source = before_dash.join " "
+        opt_program_source = before_dash.join " "
         program_args = after_dash
       end
     end
 
+    program_source = opt_program_source
     if program_source.nil?
       program_source = STDIN.gets_to_end
     end
 
-    sources = [Compiler::Source.new("eval", program_source.not_nil!)]
+    sources = [Compiler::Source.new("eval", program_source)]
 
     output_filename = Crystal.temp_executable "eval"
 

--- a/src/compiler/crystal/command/eval.cr
+++ b/src/compiler/crystal/command/eval.cr
@@ -3,7 +3,7 @@
 class Crystal::Command
   private def eval
     compiler = new_compiler
-    program_source = ""
+    program_source = nil
     program_args = [] of String
 
     parse_with_crystal_opts do |opts|

--- a/src/compiler/crystal/command/eval.cr
+++ b/src/compiler/crystal/command/eval.cr
@@ -20,7 +20,7 @@ class Crystal::Command
       program_source = STDIN.gets_to_end
     end
 
-    sources = [Compiler::Source.new("eval", program_source)]
+    sources = [Compiler::Source.new("eval", program_source.not_nil!)]
 
     output_filename = Crystal.temp_executable "eval"
 

--- a/src/compiler/crystal/command/eval.cr
+++ b/src/compiler/crystal/command/eval.cr
@@ -3,23 +3,21 @@
 class Crystal::Command
   private def eval
     compiler = new_compiler
+    program_source = ""
+    program_args = [] of String
+
     parse_with_crystal_opts do |opts|
       opts.banner = "Usage: crystal eval [options] [source]\n\nOptions:"
       setup_simple_compiler_options compiler, opts
+
+      opts.unknown_args do |before_dash, after_dash|
+        program_source = before_dash.join " "
+        program_args = after_dash
+      end
     end
 
-    if options.empty?
+    if program_source.empty?
       program_source = STDIN.gets_to_end
-      program_args = [] of String
-    else
-      double_dash_index = options.index("--")
-      if double_dash_index
-        program_source = options[0...double_dash_index].join " "
-        program_args = options[double_dash_index + 1..-1]
-      else
-        program_source = options.join " "
-        program_args = [] of String
-      end
     end
 
     sources = [Compiler::Source.new("eval", program_source)]

--- a/src/compiler/crystal/command/eval.cr
+++ b/src/compiler/crystal/command/eval.cr
@@ -16,7 +16,7 @@ class Crystal::Command
       end
     end
 
-    if program_source.empty?
+    if program_source.nil?
       program_source = STDIN.gets_to_end
     end
 


### PR DESCRIPTION
This is the main part of the pull request #15474 

---

The purpose of this pull request is to pass arguments after a double dash to the program when using the `eval` command.

```sh
crystal eval 'puts ARGV' -- meow neigh
```

### Expected behavior

```
["meow", "neigh"]
```

### Actual behavior
 
```console
syntax error in eval:1
Error: unexpected token: "meow"
```

### Workaround

By using two double dashes, you can pass arguments to the program as expected.

```sh
crystal eval 'puts ARGV' -- -- meow neigh
```

The reason for this behavior is that the `OptionParser` stops at `--` by default, and removes `--`. 
You need to use `unknown_args` to distinguish between arguments that were before `--` and arguments that were after `--`.

This issue was reported to the [forum](https://forum.crystal-lang.org/t/how-to-use-the-double-hyphen-in-the-eval-subcommand-of-crystal/7742).