### PR TITLE
Do not load `Path` call receiver if known to be pure load

### DIFF
--- a/src/compiler/crystal/codegen/call.cr
+++ b/src/compiler/crystal/codegen/call.cr
@@ -55,9 +55,18 @@ class Crystal::CodeGenVisitor
 
     obj = node.obj
 
-    # Always accept obj: even if it's not passed as self this might
-    # involve intermediate calls with side effects.
-    if obj
+    case obj
+    when Path
+      # Non-generic metaclasses and lib types do not need a self argument,
+      # reading them should not have side effects unless `obj` turns out to be
+      # a constant with an initializer (e.g. `A = (puts 1; Int32)` has a side
+      # effect).
+      if obj.type.passed_as_self? || obj.target_const
+        request_value(obj)
+      end
+    when ASTNode
+      # Always accept obj: even if it's not passed as self this might
+      # involve intermediate calls with side effects.
       request_value(obj)
     end
 


### PR DESCRIPTION
Follow-up to #15485.

The compiler always emits LLVM instructions to load the receiver of a call even if it has a metaclass type, because there could be other side effects. This adds a large number of superfluous type ID loads when calling class methods:

```llvm
  %0 = load i32, ptr @"Foo0.class:type_id", align 4
  %1 = call ptr @"*Foo0@Reference::new:Foo0"()
  %2 = load i32, ptr @"Foo1.class:type_id", align 4
  %3 = call ptr @"*Foo1@Reference::new:Foo1"()
  %4 = load i32, ptr @"Foo2.class:type_id", align 4
  %5 = call ptr @"*Foo2@Reference::new:Foo2"()
  ; ...
```

Although `.new` does load the type ID later, this ID should never show up as an implicit argument to the `Foo*.new` methods. Here the `%0`, `%2`, and `%4` variables are a consequence of un-inlining the type IDs. This PR removes those loads when the call receiver is a `Path` known to refer to a non-generic metaclass type. (In isolation, the PR skips over whatever is in `Crystal::CodeGenVisitor#visit(Crystal::Path)`.)