### PR TITLE
Remove unnecessary calls to `Crystal::CodeGenVisitor#union_type_and_value_pointer`

### DIFF
--- a/src/compiler/crystal/codegen/codegen.cr
+++ b/src/compiler/crystal/codegen/codegen.cr
@@ -2429,9 +2429,9 @@ module Crystal
       target_type = type
       if type.is_a?(VirtualType)
         if type.struct?
-          if (_type = type.remove_indirection).is_a?(UnionType)
+          if (actual_type = type.remove_indirection).is_a?(UnionType)
             # For a struct we need to cast the second part of the union to the base type
-            _, value_ptr = union_type_and_value_pointer(pointer, _type)
+            value_ptr = union_value(llvm_type(actual_type), pointer)
             target_type = type.base_type
             pointer = cast_to_pointer value_ptr, target_type
           else

--- a/src/compiler/crystal/codegen/unions.cr
+++ b/src/compiler/crystal/codegen/unions.cr
@@ -179,7 +179,8 @@ module Crystal
     end
 
     private def type_id_impl(value, type : MixedUnionType)
-      union_type_and_value_pointer(value, type)[0]
+      struct_type = llvm_type(type)
+      load(llvm_context.int32, union_type_id(struct_type, value))
     end
   end
 end


### PR DESCRIPTION
`#union_type_and_value_pointer` always emits a pair of `getelementptr` LLVM instructions, even when the caller is not interested in the pointer to a mixed union value's type ID or data. This PR eliminates those redundant `getelementptr`s.