### PR TITLE
Fix parsing HTTP resource string that looks like absolute URL

### DIFF
--- a/spec/std/http/request_spec.cr
+++ b/spec/std/http/request_spec.cr
@@ -331,6 +331,14 @@ module HTTP
         request = Request.new("GET", "")
         request.path.should eq("/")
       end
+
+      it "parses path leading with double slash" do
+        Request.new("GET", "//foo:bar").path.should eq "//foo:bar"
+      end
+
+      it "parses path leading with scheme" do
+        Request.new("GET", "http://example.com/foo:bar").path.should eq "http://example.com/foo:bar"
+      end
     end
 
     describe "#path=" do

--- a/spec/std/http/request_spec.cr
+++ b/spec/std/http/request_spec.cr
@@ -337,7 +337,7 @@ module HTTP
       end
 
       it "parses path leading with scheme" do
-        Request.new("GET", "http://example.com/foo:bar").path.should eq "http://example.com/foo:bar"
+        Request.new("GET", "http://example.com/foo/bar").path.should eq "http://example.com/foo/bar"
       end
     end
 

--- a/src/http/request.cr
+++ b/src/http/request.cr
@@ -322,7 +322,7 @@ class HTTP::Request
   end
 
   private def uri
-    (@uri ||= URI.parse(@resource)).not_nil!
+    @uri ||= URI::Parser.new(@resource).tap(&.parse_request_target).uri
   end
 
   private def update_query_params

--- a/src/http/request.cr
+++ b/src/http/request.cr
@@ -322,7 +322,7 @@ class HTTP::Request
   end
 
   private def uri
-    @uri ||= URI::Parser.new(@resource).tap(&.parse_request_target).uri
+    @uri ||= URI::Parser.new(@resource).parse_request_target.uri
   end
 
   private def update_query_params

--- a/src/uri/uri_parser.cr
+++ b/src/uri/uri_parser.cr
@@ -16,6 +16,7 @@ class URI
       @uri = URI.new
       @input = input.strip.to_unsafe
       @ptr = 0
+      @double_slash_is_authority = true
     end
 
     def c : UInt8
@@ -24,6 +25,12 @@ class URI
 
     def run : self
       parse_scheme_start
+      self
+    end
+
+    def parse_request_target : self
+      @double_slash_is_authority = false
+      parse_no_scheme
       self
     end
 
@@ -168,7 +175,7 @@ class URI
     end
 
     private def parse_relative_slash
-      if @input[@ptr + 1] === '/'
+      if @double_slash_is_authority && @input[@ptr + 1] === '/'
         @ptr += 1
         @uri.host ||= ""
         parse_authority


### PR DESCRIPTION
When parsing an HTTP resource string into a URI we expect this to be a relative URL, i.e. only the path, fragment and query components. Using `URI.parse` would misinterpret a path that looks like an absolute URL.

This patch introduces a new method `URI::Parser#parse_request_target`, mirroring `URI#request_target`. We use this to parse the request string of an HTTP request.
In the process I also simplified the URI parser a bit: We can pull up the recognition of a double-slash prefix directly to the entrypoint.

Resolves  #15498