### PR TITLE
Fix end location of call with block arg and no parentheses

### DIFF
--- a/spec/compiler/parser/parser_spec.cr
+++ b/spec/compiler/parser/parser_spec.cr
@@ -2372,6 +2372,10 @@ module Crystal
       assert_end_location "1 ensure 2"
       assert_end_location "foo.bar= *baz"
       assert_end_location %("hello "\\\n"world"), line_number: 2, column_number: 7
+      assert_end_location "foo(&.bar)"
+      assert_end_location "foo &.bar"
+      assert_end_location "foo(&bar)"
+      assert_end_location "foo &bar"
 
       assert_syntax_error %({"a" : 1}), "space not allowed between named argument name and ':'"
       assert_syntax_error %({"a": 1, "b" : 2}), "space not allowed between named argument name and ':'"

--- a/src/compiler/crystal/syntax/parser.cr
+++ b/src/compiler/crystal/syntax/parser.cr
@@ -1587,11 +1587,11 @@ module Crystal
         call ||= parse_call_block_arg_after_dot(obj)
 
         block = Block.new([Var.new(block_arg_name)], call).at(location)
+        end_location = call.end_location
       else
         block_arg = parse_op_assign
+        end_location = block_arg.end_location
       end
-
-      end_location = token_end_location
 
       if check_paren
         skip_space_or_newline


### PR DESCRIPTION
For example: `foo &.bar` and `foo &bar`

Related: crystal-ameba/ameba#548