### PR TITLE
Add function name to `CRYSTAL_DEBUG_CODEGEN` log helper

### DIFF
--- a/src/compiler/crystal/codegen/codegen.cr
+++ b/src/compiler/crystal/codegen/codegen.cr
@@ -2142,7 +2142,7 @@ module Crystal
       printf_args = {printf_args, [] of LLVM::Value} if printf_args.is_a?(String)
       printf_args = {printf_args[0], [] of LLVM::Value} if printf_args.is_a?({String})
       msg, args = printf_args
-      printf("<block: #{insert_block.name || "???"} @ #{Crystal.relative_filename(file)}:#{line}> #{msg}\n", args)
+      printf("<function=#{insert_block.parent.try(&.name) || "???"} block=#{insert_block.name || "???"} source=#{Crystal.relative_filename(file)}:#{line}> #{msg}\n", args)
     end
 
     # :ditto:

--- a/src/llvm/basic_block.cr
+++ b/src/llvm/basic_block.cr
@@ -22,4 +22,9 @@ struct LLVM::BasicBlock
     block_name = LibLLVM.get_basic_block_name(self)
     block_name ? String.new(block_name) : nil
   end
+
+  def parent : Function?
+    parent_func = LibLLVM.get_basic_block_parent(self)
+    parent_func ? Function.new(parent_func) : nil
+  end
 end

--- a/src/llvm/lib_llvm/core.cr
+++ b/src/llvm/lib_llvm/core.cr
@@ -188,6 +188,7 @@ lib LibLLVM
   {% end %}
 
   fun get_basic_block_name = LLVMGetBasicBlockName(bb : BasicBlockRef) : Char*
+  fun get_basic_block_parent = LLVMGetBasicBlockParent(bb : BasicBlockRef) : ValueRef
   fun get_first_basic_block = LLVMGetFirstBasicBlock(fn : ValueRef) : BasicBlockRef
   fun get_next_basic_block = LLVMGetNextBasicBlock(bb : BasicBlockRef) : BasicBlockRef
   fun append_basic_block_in_context = LLVMAppendBasicBlockInContext(c : ContextRef, fn : ValueRef, name : Char*) : BasicBlockRef


### PR DESCRIPTION
When diagnosing bad code generation, it is helpful to know whether a program actually reached an `unreachable` instruction, because this is usually where observable undefined behavior stems from. There is already a little-known way, which is setting the environment variable `CRYSTAL_DEBUG_CODEGEN=1`:

```crystal
lib LibC
  # actually returns Int32
  fun puts(str : UInt8*) : NoReturn
end

def foo
  LibC.puts "a"
end

foo
# since `LibC.puts` and `foo` are not actually `NoReturn`, the program will
# reach this line where an `unreachable` instruction is emitted
```

```
a
<block: entry @ C:\M\B\src\mingw-w64-ucrt-x86_64-crystal-1.15.1\src\compiler\crystal\codegen\call.cr:528> Reached the unreachable!
Program hit a breakpoint and no debugger was attached
```

The log includes the LLVM basic block name, as well as the source location of the compiler call that builds the `unreachable`. However, this is insufficient to pinpoint the `unreachable` in the LLVM IR, since the block name can be something very generic, e.g. `entry` or `current_def3`. This PR adds the LLVM function name as well; all functions have unique names, as do basic blocks within a single function. The above now prints:

```
<function=*foo:NoReturn block=entry source=src\compiler\crystal\codegen\call.cr:537> Reached the unreachable!
```