### PR TITLE
Add `IO` overloads to `Char#upcase`, `#downcase`, `#titlecase`

### DIFF
--- a/spec/std/char_spec.cr
+++ b/spec/std/char_spec.cr
@@ -8,6 +8,14 @@ describe "Char" do
     it { 'a'.upcase.should eq('A') }
     it { '1'.upcase.should eq('1') }
     it { assert_iterates_yielding ['F', 'F', 'L'], 'ﬄ'.upcase }
+
+    it "writes to IO" do
+      io = IO::Memory.new
+      'a'.upcase(io)
+      '1'.upcase(io)
+      'ﬄ'.upcase(io)
+      io.to_s.should eq("A1FFL")
+    end
   end
 
   describe "#downcase" do
@@ -16,8 +24,20 @@ describe "Char" do
     it { assert_iterates_yielding ['i', '\u{0307}'], 'İ'.downcase }
     it { assert_iterates_yielding ['s', 's'], 'ß'.downcase(Unicode::CaseOptions::Fold) }
     it { 'Ń'.downcase(Unicode::CaseOptions::Fold).should eq('ń') }
-    it { 'ꭰ'.downcase(Unicode::CaseOptions::Fold).should eq('Ꭰ') }
-    it { 'Ꭰ'.downcase(Unicode::CaseOptions::Fold).should eq('Ꭰ') }
+    it { 'ꭰ'.downcase(Unicode::CaseOptions::Fold).should eq('Ꭰ') } # U+AB70 CHEROKEE SMALL LETTER A
+    it { 'Ꭰ'.downcase(Unicode::CaseOptions::Fold).should eq('Ꭰ') } # U+13A0 CHEROKEE LETTER A
+
+    it "writes to IO" do
+      io = IO::Memory.new
+      'A'.downcase(io)
+      '1'.downcase(io)
+      'İ'.downcase(io)
+      'ß'.downcase(io, Unicode::CaseOptions::Fold)
+      'Ń'.downcase(io, Unicode::CaseOptions::Fold)
+      'ꭰ'.downcase(io, Unicode::CaseOptions::Fold)
+      'Ꭰ'.downcase(io, Unicode::CaseOptions::Fold)
+      io.to_s.should eq("a1i\u{0307}ssńᎠᎠ")
+    end
   end
 
   describe "#titlecase" do
@@ -25,6 +45,15 @@ describe "Char" do
     it { '1'.titlecase.should eq('1') }
     it { '\u{10D0}'.titlecase.should eq('\u{10D0}') } # GEORGIAN LETTER AN
     it { assert_iterates_yielding ['F', 'f', 'l'], 'ﬄ'.titlecase }
+
+    it "writes to IO" do
+      io = IO::Memory.new
+      'a'.titlecase(io)
+      '1'.titlecase(io)
+      '\u{10D0}'.titlecase(io)
+      'ﬄ'.titlecase(io)
+      io.to_s.should eq("A1\u{10D0}Ffl")
+    end
   end
 
   it "#succ" do

--- a/src/char.cr
+++ b/src/char.cr
@@ -407,7 +407,7 @@ struct Char
   # characters, like 'İ', than when downcased result in multiple
   # characters (in this case: 'I' and the dot mark).
   #
-  # For more correct behavior see the overload that receives a block.
+  # For more correct behavior see the overloads that receive a block or an `IO`.
   #
   # ```
   # 'Z'.downcase # => 'z'
@@ -456,6 +456,22 @@ struct Char
     end
   end
 
+  # Writes the downcase equivalent of this char to the given *io*.
+  #
+  # This method takes into account the possibility that an downcase
+  # version of a char might result in multiple chars, like for
+  # 'İ', which results in 'i' and a dot mark.
+  #
+  # ```
+  # 'Z'.downcase(STDOUT)                             # prints "z"
+  # 'ς'.downcase(STDOUT, Unicode::CaseOptions::Fold) # prints "σ"
+  # 'ẞ'.downcase(STDOUT, Unicode::CaseOptions::Fold) # prints "ss"
+  # 'ᾈ'.downcase(STDOUT, Unicode::CaseOptions::Fold) # prints "ἀι"
+  # ```
+  def downcase(io : IO, options : Unicode::CaseOptions = :none) : Nil
+    downcase(options) { |char| io << char }
+  end
+
   # Returns the upcase equivalent of this char.
   #
   # Note that this only works for characters whose upcase
@@ -463,7 +479,7 @@ struct Char
   # characters, like 'ﬄ', than when upcased result in multiple
   # characters (in this case: 'F', 'F', 'L').
   #
-  # For more correct behavior see the overload that receives a block.
+  # For more correct behavior see the overloads that receive a block or an `IO`.
   #
   # ```
   # 'z'.upcase # => 'Z'
@@ -488,6 +504,20 @@ struct Char
     Unicode.upcase(self, options) { |char| yield char }
   end
 
+  # Writes the upcase equivalent of this char to the given *io*.
+  #
+  # This method takes into account the possibility that an upcase
+  # version of a char might result in multiple chars, like for
+  # 'ﬄ', which results in 'F', 'F' and 'L'.
+  #
+  # ```
+  # 'z'.upcase(STDOUT) # prints "Z"
+  # 'ﬄ'.upcase(STDOUT) # prints "FFL"
+  # ```
+  def upcase(io : IO, options : Unicode::CaseOptions = :none) : Nil
+    upcase(options) { |char| io << char }
+  end
+
   # Returns the titlecase equivalent of this char.
   #
   # Usually this is equivalent to `#upcase`, but a few precomposed characters
@@ -499,7 +529,7 @@ struct Char
   # characters, like 'ﬄ', than when titlecased result in multiple
   # characters (in this case: 'F', 'f', 'l').
   #
-  # For more correct behavior see the overload that receives a block.
+  # For more correct behavior see the overloads that receive a block or an `IO`.
   #
   # ```
   # 'z'.titlecase # => 'Z'
@@ -529,6 +559,25 @@ struct Char
   # ```
   def titlecase(options : Unicode::CaseOptions = :none, &)
     Unicode.titlecase(self, options) { |char| yield char }
+  end
+
+  # Writes the titlecase equivalent of this char to the given *io*.
+  #
+  # Usually this is equivalent to `#upcase`, but a few precomposed characters
+  # consisting of multiple letters may yield a different character sequence
+  # where only the first letter is uppercase and the rest lowercase.
+  #
+  # This method takes into account the possibility that a titlecase
+  # version of a char might result in multiple chars, like for
+  # 'ﬄ', which results in 'F', 'f' and 'l'.
+  #
+  # ```
+  # 'z'.titlecase(STDOUT) # prints "Z"
+  # 'Ǳ'.titlecase(STDOUT) # prints "ǲ"
+  # 'ﬄ'.titlecase(STDOUT) # prints "Ffl"
+  # ```
+  def titlecase(io : IO, options : Unicode::CaseOptions = :none) : Nil
+    titlecase(options) { |char| io << char }
   end
 
   # See `Object#hash(hasher)`

--- a/src/string.cr
+++ b/src/string.cr
@@ -1370,9 +1370,7 @@ class String
   # ```
   def downcase(io : IO, options : Unicode::CaseOptions = :none) : Nil
     each_char do |char|
-      char.downcase(options) do |res|
-        io << res
-      end
+      char.downcase(io, options)
     end
   end
 
@@ -1406,9 +1404,7 @@ class String
   # ```
   def upcase(io : IO, options : Unicode::CaseOptions = :none) : Nil
     each_char do |char|
-      char.upcase(options) do |res|
-        io << res
-      end
+      char.upcase(io, options)
     end
   end
 
@@ -1451,9 +1447,9 @@ class String
   def capitalize(io : IO, options : Unicode::CaseOptions = :none) : Nil
     each_char_with_index do |char, i|
       if i.zero?
-        char.titlecase(options) { |c| io << c }
+        char.titlecase(io, options)
       else
-        char.downcase(options) { |c| io << c }
+        char.downcase(io, options)
       end
     end
   end
@@ -1514,13 +1510,13 @@ class String
     each_char_with_index do |char, i|
       if upcase_next
         upcase_next = false
-        char.titlecase(options) { |c| io << c }
+        char.titlecase(io, options)
       elsif underscore_to_space && '_' == char
         upcase_next = true
         io << ' '
       else
         upcase_next = char.whitespace?
-        char.downcase(options) { |c| io << c }
+        char.downcase(io, options)
       end
     end
   end
@@ -4405,7 +4401,7 @@ class String
       end
 
       if first
-        char.downcase(options) { |c| io << c }
+        char.downcase(io, options)
       elsif last_is_downcase && upcase
         if mem
           # This is the case of A1Bcd, we need to put 'mem' (not to need to convert as downcase
@@ -4417,7 +4413,7 @@ class String
         # This is the case of AbcDe, we need to put an underscore before the 'D'
         #                        ^
         io << '_'
-        char.downcase(options) { |c| io << c }
+        char.downcase(io, options)
       elsif (last_is_upcase || last_is_digit) && (upcase || digit)
         # This is the case of 1) A1Bcd, 2) A1BCd or 3) A1B_cd:if the next char is upcase (case 1) we need
         #                          ^         ^           ^
@@ -4427,7 +4423,7 @@ class String
         # 3) we need to append this char as downcase and then a single underscore
         if mem
           # case 2
-          mem.downcase(options) { |c| io << c }
+          mem.downcase(io, options)
         end
         mem = char
       else
@@ -4438,11 +4434,11 @@ class String
             # case 1
             io << '_'
           end
-          mem.downcase(options) { |c| io << c }
+          mem.downcase(io, options)
           mem = nil
         end
 
-        char.downcase(options) { |c| io << c }
+        char.downcase(io, options)
       end
 
       last_is_downcase = downcase
@@ -4451,7 +4447,7 @@ class String
       first = false
     end
 
-    mem.downcase(options) { |c| io << c } if mem
+    mem.downcase(io, options) if mem
   end
 
   # Converts underscores to camelcase boundaries.
@@ -4485,14 +4481,14 @@ class String
     each_char do |char|
       if first
         if lower
-          char.downcase(options) { |c| io << c }
+          char.downcase(io, options)
         else
-          char.titlecase(options) { |c| io << c }
+          char.titlecase(io, options)
         end
       elsif char == '_'
         last_is_underscore = true
       elsif last_is_underscore
-        char.titlecase(options) { |c| io << c }
+        char.titlecase(io, options)
         last_is_underscore = false
       else
         io << char


### PR DESCRIPTION
These additions mirror `String#upcase`, `#downcase`, and `#capitalize` respectively, which also have overloads that accept an `IO`.

There is a more technical reason for this PR. Case conversion methods in `String` are among the largest functions in the standard library when measured by the number of lines of LLVM IR; `#underscore` measures 4.2k lines, `#camelcase` 1.9k lines, and `#titleize` 1.4k lines. This is due to inlining of the multiple `{ |c| io << c }` blocks, which go all the way down to the body of e.g. `Unicode.downcase(char : Char, options : CaseOptions, &)`. By establishing an inlining boundary, those line counts are now 0.67k, 0.23k, and 0.25k, whereas the new `Char` methods themselves contribute another 0.75k lines total.