### PR TITLE
file copy may not always chmod permissions

### DIFF
--- a/src/file.cr
+++ b/src/file.cr
@@ -852,7 +852,7 @@ class File < IO::FileDescriptor
         d.flush # need to flush in case permissions are read-only
 
         # Set the permissions after the content is written in case src permissions is read-only
-        d.chmod(s.info.permissions)
+        d.chmod(s.info.permissions) rescue nil
       end
     end
   end


### PR DESCRIPTION
the remote volume may allow copy but not changes to file permissions after writing
as is the case with azure cloud storage volumes attached to docker containers

```
Error changing permissions: '/app/www/1740354627047_3895/scripts/local_auth.js': Operation not permitted (File::Error)
  from /usr/share/crystal/src/crystal/system/unix/file.cr:127:7 in 'system_chmod'
  from /usr/share/crystal/src/file.cr:981:5 in 'chmod'
  from /usr/share/crystal/src/file.cr:855:9 in 'copy'
  from /usr/share/crystal/src/file_utils.cr:94:5 in 'cp'
  from /usr/share/crystal/src/file_utils.cr:136:7 in 'cp_recursive'
  from /usr/share/crystal/src/file_utils.cr:133:9 in 'cp_recursive'
  from /usr/share/crystal/src/file_utils.cr:133:9 in 'cp_recursive'
  from /usr/share/crystal/src/file_utils.cr:124:5 in 'cp_r'
  from /usr/share/crystal/src/file_utils.cr:321:7 in 'mv'
  from lib/git-repository/src/git-repository/generic.cr:94:7 in 'move_into_place'
  from lib/git-repository/src/git-repository/generic.cr:121:7 in 'fetch_commit'
  from src/placeos-frontend-loader/loader.cr:73:11 in 'create_base_www'
  from src/placeos-frontend-loader/loader.cr:52:7 in 'start'
```