### PR TITLE
Compiler: Add "Top 10 slowest modules" to --stats output

### DIFF
--- a/src/compiler/crystal/compiler.cr
+++ b/src/compiler/crystal/compiler.cr
@@ -629,7 +629,11 @@ module Crystal
         while i = input.gets(chomp: true).presence
           unit = units[i.to_i]
           unit.compile
-          result = {name: unit.name, reused: unit.reused_previous_compilation?}
+          result = {
+            name:   unit.name,
+            reused: unit.reused_previous_compilation?,
+            time:   unit.compilation_time.total_seconds,
+          }
           output.puts result.to_json
         end
       rescue ex
@@ -697,9 +701,11 @@ module Crystal
         end
 
         if @progress_tracker.stats?
+          name = result["name"].as_s
+          unit = units.find { |unit| unit.name == name }.not_nil!
+          unit.compilation_time = result["time"].as_f.seconds
+
           if result["reused"].as_bool
-            name = result["name"].as_s
-            unit = units.find { |unit| unit.name == name }.not_nil!
             unit.reused_previous_compilation = true
           end
         end
@@ -776,6 +782,15 @@ module Crystal
         units.each do |unit|
           next if unit.reused_previous_compilation?
           puts " - #{unit.original_name} (#{unit.name}.bc)"
+        end
+      end
+
+      if units.size != reused
+        puts
+        puts("Top 10 slowest modules:")
+        units.sort_by! { |u| u.compilation_time * -1 }
+        units.first(10).each do |unit|
+          puts " - #{unit.compilation_time} #{unit.original_name} (#{unit.name}.bc)"
         end
       end
     end
@@ -916,6 +931,7 @@ module Crystal
       getter llvm_mod
       property? reused_previous_compilation = false
       getter object_extension : String
+      property! compilation_time : Time::Span
       @memory_buffer : LLVM::MemoryBuffer?
       @object_name : String?
       @bc_name : String?
@@ -973,9 +989,12 @@ module Crystal
         if must_compile?
           isolate_module_context if isolate_context
           update_bitcode_cache
-          compile_to_object
+          @compilation_time = Time.measure do
+            compile_to_object
+          end
         else
           @reused_previous_compilation = true
+          @compilation_time = Time::Span::ZERO
         end
         dump_llvm_ir
       end


### PR DESCRIPTION
Rebase of #12942 on current release