### PR TITLE
Read all DWARF abbreviations tables in a single pass

### DIFF
--- a/src/crystal/dwarf/abbrev.cr
+++ b/src/crystal/dwarf/abbrev.cr
@@ -237,10 +237,9 @@ module Crystal
         @children
       end
 
-      def self.read(io : IO::FileDescriptor, offset)
+      def self.read(io : IO) : Array(Abbrev)
         abbreviations = [] of Abbrev
 
-        io.seek(io.tell + offset)
         loop do
           code = DWARF.read_unsigned_leb128(io)
           break if code == 0

--- a/src/crystal/dwarf/info.cr
+++ b/src/crystal/dwarf/info.cr
@@ -50,10 +50,6 @@ module Crystal
 
       alias Value = Bool | Int32 | Int64 | Slice(UInt8) | String | UInt16 | UInt32 | UInt64 | UInt8 | UInt128
 
-      def read_abbreviations(io)
-        @abbreviations = Abbrev.read(io, debug_abbrev_offset)
-      end
-
       def each(&)
         end_offset = @offset + @unit_length
         attributes = [] of {AT, FORM, Value}
@@ -62,7 +58,7 @@ module Crystal
           code = DWARF.read_unsigned_leb128(@io)
           attributes.clear
 
-          if abbrev = abbreviations[code &- 1]? # abbreviations.find { |a| a.code == abbrev }
+          if abbrev = @abbreviations.try &.[code &- 1]? # @abbreviations.try &.find { |a| a.code == abbrev }
             abbrev.attributes.each do |attr|
               value = read_attribute_value(attr.form, attr)
               attributes << {attr.at, attr.form, value}

--- a/src/exception/call_stack/mach_o.cr
+++ b/src/exception/call_stack/mach_o.cr
@@ -27,14 +27,24 @@ struct Exception::CallStack
         @@dwarf_line_numbers = Crystal::DWARF::LineNumbers.new(io, sh.size, strings: strings, line_strings: line_strings)
       end
 
+      abbrevs_tables = mach_o.read_section?("__debug_abbrev") do |sh, io|
+        all = {} of Int64 => Array(Crystal::DWARF::Abbrev)
+        while (offset = io.pos - sh.offset) < sh.size
+          all[offset] = Crystal::DWARF::Abbrev.read(io)
+        end
+        all
+      end
+
       mach_o.read_section?("__debug_info") do |sh, io|
         names = [] of {LibC::SizeT, LibC::SizeT, String}
 
         while (offset = io.pos - sh.offset) < sh.size
           info = Crystal::DWARF::Info.new(io, offset)
 
-          mach_o.read_section?("__debug_abbrev") do |sh, io|
-            info.read_abbreviations(io)
+          if abbrevs_tables
+            if abbreviations = abbrevs_tables[info.debug_abbrev_offset]?
+              info.abbreviations = abbreviations
+            end
           end
 
           parse_function_names_from_dwarf(info, strings, line_strings) do |low_pc, high_pc, name|


### PR DESCRIPTION
This avoids the need to reseek the executable `IO` for every single DWARF unit header, which can considerably speed up the debug info loader for large binaries, such as the Crystal compiler itself. The following are the mean run times for `load_debug_info_impl` sampled by running a locally built `x86_64-linux-gnu` Crystal compiler 100 times each:

* Non-release, before: 553 ± 4.1 ms
* Non-release, after: 428 ± 3.3 ms
* Release, before: 144 ± 4.6 ms
* Release, after: 142 ± 6.1 ms

Release builds are largely unaffected because their abbreviations tables are extremely small, even with `--debug` passed.