### PR TITLE
Fix permissions application in `File.copy`

### DIFF
--- a/spec/std/file_spec.cr
+++ b/spec/std/file_spec.cr
@@ -1687,6 +1687,32 @@ describe "File" do
         File.same_content?(src_path, out_path).should be_true
       end
     end
+
+    it "copies read-only permission" do
+      with_tempfile("cp-permissions-src.txt", "cp-permissions-out.txt") do |src_path, out_path|
+        File.write(src_path, "foo")
+        File.chmod(src_path, 0o444)
+
+        File.copy(src_path, out_path)
+
+        File.info(out_path).permissions.should eq normalize_permissions(0o444, directory: false)
+        File.same_content?(src_path, out_path).should be_true
+      end
+    end
+
+    it "copies read-only permission over existing file" do
+      with_tempfile("cp-permissions-src.txt", "cp-permissions-out.txt") do |src_path, out_path|
+        File.write(src_path, "foo")
+        File.chmod(src_path, 0o444)
+
+        File.write(out_path, "bar")
+
+        File.copy(src_path, out_path)
+
+        File.info(out_path).permissions.should eq normalize_permissions(0o444, directory: false)
+        File.same_content?(src_path, out_path).should be_true
+      end
+    end
   end
 
   describe ".match?" do


### PR DESCRIPTION
Applying the final permissions already to a newly created file makes the extra call to `chmod` unnecessary.

For this to work we need to detect whether a new file was created with correct permissions or an existing file has already the intended permissions. Otherwise we need to adjust the permissions. In that case this patch introduce an addional syscall (accessing `d.info` before `d.chmod`). There is no other way to determine whether `File.open` created a new file or opened an existing one.
This change ensures correct behaviour by avoiding unnecessary file mode changes which can be impossible in some environments (see #15518).