### PR TITLE
Support `Slice.literal` in the interpreter

### DIFF
--- a/spec/primitives/slice_spec.cr
+++ b/spec/primitives/slice_spec.cr
@@ -6,7 +6,7 @@ describe "Primitives: Slice" do
   describe ".literal" do
     # TODO: implement in the interpreter
     {% for num in BUILTIN_NUMBER_TYPES %}
-      pending_interpreted {{ "creates a read-only Slice(#{num})" }} do
+      it {{ "creates a read-only Slice(#{num})" }} do
         slice = Slice({{ num }}).literal(0, 1, 4, 9, 16, 25)
         slice.should be_a(Slice({{ num }}))
         slice.to_a.should eq([0, 1, 4, 9, 16, 25] of {{ num }})
@@ -14,7 +14,7 @@ describe "Primitives: Slice" do
       end
 
       # TODO: these should probably return the same pointers
-      pending_interpreted "creates multiple literals" do
+      it "creates multiple literals" do
         slice1 = Slice({{ num }}).literal(1, 2, 3)
         slice2 = Slice({{ num }}).literal(1, 2, 3)
         slice1.should eq(slice2)

--- a/src/compiler/crystal/codegen/codegen.cr
+++ b/src/compiler/crystal/codegen/codegen.cr
@@ -329,7 +329,7 @@ module Crystal
         symbol_table.initializer = llvm_type(@program.string).const_array(@symbol_table_values)
       end
 
-      program.const_slices.each do |info|
+      program.const_slices.each_value do |info|
         define_slice_constant(info)
       end
 

--- a/src/compiler/crystal/interpreter/context.cr
+++ b/src/compiler/crystal/interpreter/context.cr
@@ -44,6 +44,11 @@ class Crystal::Repl::Context
   # the proc in this Hash.
   getter ffi_closure_to_compiled_def : Hash(Void*, CompiledDef)
 
+  # Cached underlying buffers for constant slices constructed via the
+  # `Slice.literal` compiler built-in, indexed by the internal buffer name
+  # (e.g. `$Slice:0`).
+  @const_slice_buffers = {} of String => UInt8*
+
   def initialize(@program : Program)
     @program.flags << "interpreted"
 
@@ -284,6 +289,36 @@ class Crystal::Repl::Context
       value = sub_interpreter.interpret(compiled_def.def.body, compiled_def.def.vars.not_nil!)
 
       value.copy_to(ret.as(UInt8*))
+    end
+  end
+
+  def const_slice_buffer(info : Program::ConstSliceInfo) : UInt8*
+    @const_slice_buffers.put_if_absent(info.name) do
+      kind = info.element_type
+      element_size = kind.bytesize // 8
+      buffer = Pointer(UInt8).malloc(info.args.size * element_size)
+      ptr = buffer
+
+      info.args.each do |arg|
+        num = arg.as(NumberLiteral)
+        case kind
+        in .i8?   then ptr.as(Int8*).value = num.value.to_i8
+        in .i16?  then ptr.as(Int16*).value = num.value.to_i16
+        in .i32?  then ptr.as(Int32*).value = num.value.to_i32
+        in .i64?  then ptr.as(Int64*).value = num.value.to_i64
+        in .i128? then ptr.as(Int128*).value = num.value.to_i128
+        in .u8?   then ptr.as(UInt8*).value = num.value.to_u8
+        in .u16?  then ptr.as(UInt16*).value = num.value.to_u16
+        in .u32?  then ptr.as(UInt32*).value = num.value.to_u32
+        in .u64?  then ptr.as(UInt64*).value = num.value.to_u64
+        in .u128? then ptr.as(UInt128*).value = num.value.to_u128
+        in .f32?  then ptr.as(Float32*).value = num.value.to_f32
+        in .f64?  then ptr.as(Float64*).value = num.value.to_f64
+        end
+        ptr += element_size
+      end
+
+      buffer
     end
   end
 

--- a/src/compiler/crystal/program.cr
+++ b/src/compiler/crystal/program.cr
@@ -89,8 +89,9 @@ module Crystal
       element_type : NumberKind,
       args : Array(ASTNode)
 
-    # All constant slices constructed via the `Slice.literal` primitive.
-    getter const_slices = [] of ConstSliceInfo
+    # All constant slices constructed via the `Slice.literal` compiler built-in,
+    # indexed by their buffers' internal names (e.g. `$Slice:0`).
+    getter const_slices = {} of String => ConstSliceInfo
 
     # Here we store constants, in the
     # order that they are used. They will be initialized as soon

--- a/src/compiler/crystal/semantic/main_visitor.cr
+++ b/src/compiler/crystal/semantic/main_visitor.cr
@@ -1607,7 +1607,7 @@ module Crystal
           const_value.type = @program.static_array_of(element_type, node.args.size)
           const = Const.new(@program, @program, const_name, const_value)
           @program.types[const_name] = const
-          @program.const_slices << Program::ConstSliceInfo.new(const_name, kind, node.args)
+          @program.const_slices[const_name] = Program::ConstSliceInfo.new(const_name, kind, node.args)
 
           # ::Slice.new(pointerof($Slice:n.@buffer), {{ args.size }}, read_only: true)
           pointer_node = PointerOf.new(ReadInstanceVar.new(Path.new(const_name).at(node), "@buffer").at(node)).at(node)

--- a/src/compiler/crystal/syntax/ast.cr
+++ b/src/compiler/crystal/syntax/ast.cr
@@ -239,6 +239,7 @@ module Crystal
       super.downcase
     end
 
+    # TODO: rename to `bit_width`
     def bytesize
       case self
       in .i8?   then 8


### PR DESCRIPTION
This works by adding a specialized cache for the results of `pointerof` expressions that have the form `pointerof($Slice:n.@buffer)`, which can only arise from literal expansion of `Slice.literal` calls during the semantic phase.

As with string literals, the contents of slice literals are not truly read-only at the moment (#12422).