### PR TITLE
OpenSSL sockets: prefer individual BIO setters

### DIFF
--- a/src/openssl/lib_crypto.cr
+++ b/src/openssl/lib_crypto.cr
@@ -127,6 +127,7 @@ lib LibCrypto
   {% end %}
 
   fun BIO_new(BioMethod*) : Bio*
+  fun BIO_up_ref(Bio*) : Int
   fun BIO_free(Bio*) : Int
 
   {% if compare_versions(LibCrypto::OPENSSL_VERSION, "1.1.0") >= 0 || compare_versions(LibCrypto::LIBRESSL_VERSION, "2.7.0") >= 0 %}

--- a/src/openssl/lib_ssl.cr
+++ b/src/openssl/lib_ssl.cr
@@ -199,7 +199,12 @@ lib LibSSL
 
   fun ssl_get_error = SSL_get_error(handle : SSL, ret : Int) : SSLError
   fun ssl_get_servername = SSL_get_servername(ssl : SSL, host_type : TLSExt) : UInt8*
-  fun ssl_set_bio = SSL_set_bio(handle : SSL, rbio : LibCrypto::Bio*, wbio : LibCrypto::Bio*)
+  {% if compare_versions(OPENSSL_VERSION, "1.1.0") >= 0 %}
+    fun ssl_set0_rbio = SSL_set0_rbio(handle : SSL, rbio : LibCrypto::Bio*)
+    fun ssl_set0_wbio = SSL_set0_wbio(handle : SSL, wbio : LibCrypto::Bio*)
+  {% else %}
+    fun ssl_set_bio = SSL_set_bio(handle : SSL, rbio : LibCrypto::Bio*, wbio : LibCrypto::Bio*)
+  {% end %}
   fun ssl_select_next_proto = SSL_select_next_proto(output : Char**, output_len : Char*, input : Char*, input_len : Int, client : Char*, client_len : Int) : Int
   fun ssl_ctrl = SSL_ctrl(handle : SSL, cmd : Int, larg : Long, parg : Void*) : Long
   fun ssl_free = SSL_free(handle : SSL)

--- a/src/openssl/ssl/socket.cr
+++ b/src/openssl/ssl/socket.cr
@@ -118,6 +118,7 @@ abstract class OpenSSL::SSL::Socket < IO
       # that don't change the BIO ref count (safe because @bio is owned by @ssl
       # and never shared with other OpenSSL objects), while the older
       # `SSL_set_bio` sometimes leads SSL_free to not free the BIO in #finalize
+      LibCrypto.BIO_up_ref(@bio)
       LibSSL.ssl_set0_rbio(@ssl, @bio)
       LibSSL.ssl_set0_wbio(@ssl, @bio)
     {% else %}

--- a/src/openssl/ssl/socket.cr
+++ b/src/openssl/ssl/socket.cr
@@ -113,7 +113,7 @@ abstract class OpenSSL::SSL::Socket < IO
     end
 
     @bio = BIO.new(io)
-    {% if LibSSL.has_method?(:ssl_set0_rbio) %}
+    {% if LibSSL.has_method?(:ssl_set0_rbio) && LibSSL.has_method?(:ssl_set0_wbio) %}
       # prefer the new individual setters, as recommended by the OpenSSL docs,
       # that don't change the BIO ref count (safe because @bio is owned by @ssl
       # and never shared with other OpenSSL objects), while the older


### PR DESCRIPTION
The OpenSSL documentation recommends to prefer the individual `SSL_set0_rbio` and `SSL_set0_wbio` functions instead of the complex `SSL_set_bio`.

This avoids an issue sometimes where the OpenSSL BIO object created to handle the crystal IO object isn't freed by `SSL_free` called from `OpenSSL::SSL::Socket::Server#accept` for example.

Since the BIO is owned by the SSL object, we can merely set the read and write BIOs (actually the same object) and don't need to count references. We expect `SSL_free` to always call `BIO_free_all`.