### PR TITLE
Extract `WebSocket#do_ping`, `#do_close` helper methods for overrides

### DIFF
--- a/src/http/web_socket.cr
+++ b/src/http/web_socket.cr
@@ -163,7 +163,7 @@ class HTTP::WebSocket
         @current_message.write @buffer[0, info.size]
         if info.final
           message = @current_message.to_s
-          @on_ping.try &.call(message)
+          do_ping(message)
           @current_message.clear
         end
       in .pong?
@@ -197,8 +197,7 @@ class HTTP::WebSocket
           end
           message = @current_message.gets_to_end
 
-          @on_close.try &.call(code, message)
-          close
+          do_close(code, message)
 
           @current_message.clear
           break
@@ -207,6 +206,16 @@ class HTTP::WebSocket
         # TODO: (asterite) I think this is good, but this case wasn't originally handled
       end
     end
+  end
+
+  private def do_close(code, message)
+    @on_close.try &.call(code, message)
+    close
+  end
+
+  private def do_ping(message)
+    @on_ping.try &.call(message)
+    pong(message) unless closed?
   end
 end
 

--- a/src/http/web_socket.cr
+++ b/src/http/web_socket.cr
@@ -14,7 +14,6 @@ class HTTP::WebSocket
   def initialize(@ws : Protocol)
     @buffer = Bytes.new(4096)
     @current_message = IO::Memory.new
-    @on_ping = ->(message : String) { pong(message) unless closed? }
   end
 
   # Opens a new websocket using the information provided by the URI. This will also handle the handshake

--- a/src/http/web_socket.cr
+++ b/src/http/web_socket.cr
@@ -14,6 +14,7 @@ class HTTP::WebSocket
   def initialize(@ws : Protocol)
     @buffer = Bytes.new(4096)
     @current_message = IO::Memory.new
+    @on_ping = ->(message : String) { pong(message) unless closed? }
   end
 
   # Opens a new websocket using the information provided by the URI. This will also handle the handshake
@@ -163,7 +164,6 @@ class HTTP::WebSocket
         if info.final
           message = @current_message.to_s
           @on_ping.try &.call(message)
-          pong(message) unless closed?
           @current_message.clear
         end
       in .pong?


### PR DESCRIPTION
Before this change, when using `#on_ping` callback and defining your own block of code to handle it, resulted in two `pong` frames being sent to the other site of the WebSocket.

This change setups a default ping <-> pong response cycle but once you override it, it will use yours instead.

Thank you
❤️ ❤️ ❤️ 