### PR TITLE
Add test for `HTTP::Request` path `//`

### DIFF
--- a/spec/std/http/request_spec.cr
+++ b/spec/std/http/request_spec.cr
@@ -332,6 +332,10 @@ module HTTP
         request.path.should eq("/")
       end
 
+      it "parses with only leading with double slash" do
+        HTTP::Request.new("GET", "//").path.should eq "//"
+      end
+
       it "parses path leading with double slash" do
         Request.new("GET", "//foo:bar").path.should eq "//foo:bar"
       end


### PR DESCRIPTION
While testing the `awscr-signer` library [job](https://github.com/taylorfinnell/awscr-signer/actions/runs/13747246666/job/38443716154?pr=65), I noticed a change in the behavior of `HTTP::Request#path` when handling the case of `//`:

Old behavior:

```crystal
request = HTTP::Request.new("GET", "//", HTTP::Headers.new)
request.path.should eq("/")
```


New behavior:

```crystal
request = HTTP::Request.new("GET", "//", HTTP::Headers.new)
request.path.should eq("//")
```

I am trying to add more tests to cover changes from https://github.com/crystal-lang/crystal/pull/15499