### PR TITLE
Allow multiple redefinitions of the same top-level fun

### DIFF
--- a/spec/compiler/codegen/fun_spec.cr
+++ b/spec/compiler/codegen/fun_spec.cr
@@ -18,4 +18,22 @@ describe "Codegen: fun" do
     mod.functions["foo"].linkage.should eq(LLVM::Linkage::External)
     mod.functions["__crystal_foo"].linkage.should eq(LLVM::Linkage::Internal)
   end
+
+  it "defines same fun 3 or more times (#15523)" do
+    run(<<-CRYSTAL, Int32).should eq(3)
+      fun foo : Int32
+        1
+      end
+
+      fun foo : Int32
+        2
+      end
+
+      fun foo : Int32
+        3
+      end
+
+      foo
+      CRYSTAL
+  end
 end

--- a/src/compiler/crystal/semantic/type_declaration_visitor.cr
+++ b/src/compiler/crystal/semantic/type_declaration_visitor.cr
@@ -150,8 +150,7 @@ class Crystal::TypeDeclarationVisitor < Crystal::SemanticVisitor
 
     external.set_type(return_type)
 
-    old_external = add_external external
-    old_external.dead = true if old_external
+    add_external external
 
     if current_type.is_a?(Program)
       key = DefInstanceKey.new external.object_id, external.args.map(&.type), nil, nil
@@ -181,14 +180,12 @@ class Crystal::TypeDeclarationVisitor < Crystal::SemanticVisitor
   def add_external(external : External)
     existing = @externals[external.real_name]?
     if existing
-      if existing.compatible_with?(external)
-        return existing
-      else
+      unless existing.compatible_with?(external)
         external.raise "fun redefinition with different signature (was `#{existing}` at #{existing.location})"
       end
+      existing.dead = true
     end
     @externals[external.real_name] = external
-    nil
   end
 
   def declare_c_struct_or_union_field(node)


### PR DESCRIPTION
Fixes #15523.

After the compiler defines a top-level fun once, every subsequent redefinition marks that same single fun as "dead", omitting it from code generation, but these redefinitions themselves are not "dead". This PR ensures only the last definition wins.