### PR TITLE
Fix `Box(Pointer).box` to not allocate pointer storage on the heap

### DIFF
--- a/spec/std/box_spec.cr
+++ b/spec/std/box_spec.cr
@@ -15,6 +15,15 @@ describe "Box" do
     Box(String).unbox(box).should be(a)
   end
 
+  it "boxing a pointer returns the same pointer" do
+    a = 123
+    b = pointerof(a)
+    box = Box.box(b)
+    box.address.should eq(b.address)
+
+    Box(Pointer(Int32)).unbox(box).should eq(b)
+  end
+
   it "boxing a nilable reference returns the same pointer" do
     a = "foo".as(String?)
     box = Box.box(a)

--- a/src/box.cr
+++ b/src/box.cr
@@ -20,13 +20,14 @@ class Box(T)
 
   # Turns *object* into a `Void*`.
   #
-  # If `T` is not a reference type, nor a union between reference types and
-  # `Nil`, this method effectively copies *object* to the dynamic heap.
+  # If `T` is not a reference or pointer type, nor a union between reference
+  # types and `Nil`, this method effectively copies *object* to the dynamic
+  # heap.
   #
   # NOTE: The returned pointer might not be a null pointer even when *object* is
   # `nil`.
   def self.box(object : T) : Void*
-    {% if T.union_types.all? { |t| t == Nil || t < Reference } %}
+    {% if T < Pointer || T.union_types.all? { |t| t == Nil || t < Reference } %}
       object.as(Void*)
     {% else %}
       # NOTE: if `T` is explicitly specified and `typeof(object) < T` (e.g.
@@ -42,7 +43,7 @@ class Box(T)
   # via a different type; in particular, when boxing a `T` and unboxing it as a
   # `T?`, or vice-versa.
   def self.unbox(pointer : Void*) : T
-    {% if T.union_types.all? { |t| t == Nil || t < Reference } %}
+    {% if T < Pointer || T.union_types.all? { |t| t == Nil || t < Reference } %}
       pointer.as(T)
     {% else %}
       pointer.as(self).object


### PR DESCRIPTION
While discussing to use `Box(T)` in #15395 I noticed that `Box(Pointer).box(ptr)` allocates into the GC heap to store the pointer address into.

That felt like an overlook since we don't need to allocate to box a Reference or Nil, so it should be fine to box a raw pointer without allocating an intermediary pointer. Am I missing something?

I only allowed `T < Pointer` in addition to the Reference and nilable Reference cases. I'm not sure a Pointer appearing in an union along Nil or Reference would behave correctly —is it passing the `{type, value}` union by value?