### PR TITLE
Add `Crystal::EventLoop#sleep(duration)` method

### DIFF
--- a/src/concurrent.cr
+++ b/src/concurrent.cr
@@ -26,24 +26,14 @@ end
 # fibers might start their execution.
 def sleep(time : Time::Span) : Nil
   Crystal.trace :sched, "sleep", for: time
-
-  {% if flag?(:execution_context) %}
-    Fiber.current.resume_event.add(time)
-    Fiber::ExecutionContext.reschedule
-  {% else %}
-    Crystal::Scheduler.sleep(time)
-  {% end %}
+  Crystal::EventLoop.current.sleep(time)
 end
 
 # Blocks the current fiber forever.
 #
 # Meanwhile, other ready-to-execute fibers might start their execution.
 def sleep : Nil
-  {% if flag?(:execution_context) %}
-    Fiber::ExecutionContext.reschedule
-  {% else %}
-    Crystal::Scheduler.reschedule
-  {% end %}
+  Fiber.suspend
 end
 
 {% begin %}

--- a/src/crystal/event_loop.cr
+++ b/src/crystal/event_loop.cr
@@ -78,8 +78,10 @@ abstract class Crystal::EventLoop
 
   # Create a new resume event for a fiber.
   #
-  # NOTE: optional, legacy, only needed for Crystal::EventLoop::LibEvent
-  abstract def create_resume_event(fiber : Fiber) : Event
+  # NOTE: optional.
+  def create_resume_event(fiber : Fiber) : Event
+    raise NotImplementedError.new("#{self.class.name}#create_resume_event(fiber)")
+  end
 
   # Creates a timeout_event.
   abstract def create_timeout_event(fiber : Fiber) : Event

--- a/src/crystal/event_loop.cr
+++ b/src/crystal/event_loop.cr
@@ -73,7 +73,12 @@ abstract class Crystal::EventLoop
   #       time in parallel, but this assumption may change in the future!
   abstract def interrupt : Nil
 
+  # Suspend the current fiber for *duration*.
+  abstract def sleep(duration : Time::Span) : Nil
+
   # Create a new resume event for a fiber.
+  #
+  # NOTE: optional, legacy, only needed for Crystal::EventLoop::LibEvent
   abstract def create_resume_event(fiber : Fiber) : Event
 
   # Creates a timeout_event.

--- a/src/crystal/event_loop/iocp/timer.cr
+++ b/src/crystal/event_loop/iocp/timer.cr
@@ -5,6 +5,7 @@
 struct Crystal::EventLoop::IOCP::Timer
   enum Type
     Sleep
+    Timeout
     SelectTimeout
   end
 
@@ -24,7 +25,12 @@ struct Crystal::EventLoop::IOCP::Timer
   # The event can be added to the `Timers` list.
   include PointerPairingHeap::Node
 
-  def initialize(@type : Type, @fiber)
+  def initialize(@type : Type, @fiber, timeout : Time::Span? = nil)
+    if timeout
+      seconds, nanoseconds = System::Time.monotonic
+      now = Time::Span.new(seconds: seconds, nanoseconds: nanoseconds)
+      @wake_at = now + timeout
+    end
   end
 
   def wake_at=(@wake_at)

--- a/src/crystal/event_loop/libevent.cr
+++ b/src/crystal/event_loop/libevent.cr
@@ -42,6 +42,11 @@ class Crystal::EventLoop::LibEvent < Crystal::EventLoop
     event_base.loop_exit
   end
 
+  def sleep(duration : ::Time::Span) : Nil
+    Fiber.current.resume_event.add(duration)
+    Fiber.suspend
+  end
+
   # Create a new resume event for a fiber (sleep).
   def create_resume_event(fiber : Fiber) : Crystal::EventLoop::LibEvent::Event
     event_base.new_event(-1, LibEvent2::EventFlags::None, fiber) do |s, flags, data|

--- a/src/crystal/event_loop/polling.cr
+++ b/src/crystal/event_loop/polling.cr
@@ -139,10 +139,6 @@ abstract class Crystal::EventLoop::Polling < Crystal::EventLoop
     Fiber.suspend
   end
 
-  def create_resume_event(fiber : Fiber) : FiberEvent
-    raise NotImplementedError.new("Crystal::EventLoop::Polling#create_resume_event")
-  end
-
   def create_timeout_event(fiber : Fiber) : FiberEvent
     FiberEvent.new(:select_timeout, fiber)
   end

--- a/src/crystal/event_loop/wasi.cr
+++ b/src/crystal/event_loop/wasi.cr
@@ -9,6 +9,10 @@ class Crystal::EventLoop::Wasi < Crystal::EventLoop
     raise NotImplementedError.new("Crystal::Wasi::EventLoop.interrupt")
   end
 
+  def sleep(duration : ::Time::Span) : Nil
+    raise NotImplementedError.new("Crystal::Wasi::EventLoop.sleep")
+  end
+
   # Create a new resume event for a fiber.
   def create_resume_event(fiber : Fiber) : Crystal::EventLoop::Event
     raise NotImplementedError.new("Crystal::Wasi::EventLoop.create_resume_event")

--- a/src/crystal/event_loop/wasi.cr
+++ b/src/crystal/event_loop/wasi.cr
@@ -13,11 +13,6 @@ class Crystal::EventLoop::Wasi < Crystal::EventLoop
     raise NotImplementedError.new("Crystal::Wasi::EventLoop.sleep")
   end
 
-  # Create a new resume event for a fiber.
-  def create_resume_event(fiber : Fiber) : Crystal::EventLoop::Event
-    raise NotImplementedError.new("Crystal::Wasi::EventLoop.create_resume_event")
-  end
-
   # Creates a timeout_event.
   def create_timeout_event(fiber) : Crystal::EventLoop::Event
     raise NotImplementedError.new("Crystal::Wasi::EventLoop.create_timeout_event")

--- a/src/crystal/scheduler.cr
+++ b/src/crystal/scheduler.cr
@@ -67,11 +67,6 @@ class Crystal::Scheduler
     Thread.current.scheduler.resume(fiber)
   end
 
-  def self.yield(fiber : Fiber) : Nil
-    validate_running_thread(fiber)
-    Thread.current.scheduler.yield(fiber)
-  end
-
   private def self.validate_running_thread(fiber : Fiber) : Nil
     {% if flag?(:preview_mt) %}
       if th = fiber.get_current_thread
@@ -150,11 +145,6 @@ class Crystal::Scheduler
         end
       end
     end
-  end
-
-  protected def yield(fiber : Fiber) : Nil
-    @thread.current_fiber.resume_event.add(0.seconds)
-    resume(fiber)
   end
 
   {% if flag?(:preview_mt) %}

--- a/src/crystal/scheduler.cr
+++ b/src/crystal/scheduler.cr
@@ -67,19 +67,6 @@ class Crystal::Scheduler
     Thread.current.scheduler.resume(fiber)
   end
 
-  def self.sleep(time : Time::Span) : Nil
-    Thread.current.scheduler.sleep(time)
-  end
-
-  def self.yield : Nil
-    Crystal.trace :sched, "yield"
-
-    # TODO: Fiber switching and libevent for wasm32
-    {% unless flag?(:wasm32) %}
-      Thread.current.scheduler.sleep(0.seconds)
-    {% end %}
-  end
-
   def self.yield(fiber : Fiber) : Nil
     validate_running_thread(fiber)
     Thread.current.scheduler.yield(fiber)
@@ -163,11 +150,6 @@ class Crystal::Scheduler
         end
       end
     end
-  end
-
-  protected def sleep(time : Time::Span) : Nil
-    @thread.current_fiber.resume_event.add(time)
-    reschedule
   end
 
   protected def yield(fiber : Fiber) : Nil

--- a/src/crystal/system/win32/iocp.cr
+++ b/src/crystal/system/win32/iocp.cr
@@ -228,12 +228,9 @@ struct Crystal::System::IOCP
 
     private def wait_for_completion(timeout)
       if timeout
-        event = ::Fiber.current.resume_event
-        event.add(timeout)
+        evloop = EventLoop.current.as(EventLoop::IOCP)
 
-        ::Fiber.suspend
-
-        if event.timed_out?
+        if evloop.timeout(timeout)
           # By the time the fiber was resumed, the operation may have completed
           # concurrently.
           return if @state.done?

--- a/src/fiber.cr
+++ b/src/fiber.cr
@@ -265,8 +265,6 @@ class Fiber
   end
 
   # :nodoc:
-  #
-  # NOTE: optional, legacy, only needed for Crystal::EventLoop::LibEvent
   def resume_event : Crystal::EventLoop::Event
     @resume_event ||= Crystal::EventLoop.current.create_resume_event(self)
   end

--- a/src/fiber.cr
+++ b/src/fiber.cr
@@ -265,6 +265,8 @@ class Fiber
   end
 
   # :nodoc:
+  #
+  # NOTE: optional, legacy, only needed for Crystal::EventLoop::LibEvent
   def resume_event : Crystal::EventLoop::Event
     @resume_event ||= Crystal::EventLoop.current.create_resume_event(self)
   end
@@ -331,11 +333,9 @@ class Fiber
   def self.yield : Nil
     Crystal.trace :sched, "yield"
 
-    {% if flag?(:execution_context) %}
-      Fiber.current.resume_event.add(0.seconds)
-      Fiber.suspend
-    {% else %}
-      Crystal::Scheduler.yield
+    # TODO: Fiber switching and evloop for wasm32
+    {% unless flag?(:wasi) %}
+      Crystal::EventLoop.current.sleep(0.seconds)
     {% end %}
   end
 


### PR DESCRIPTION
The event loop interface for sleeping has been inherited from the libevent event loop. It needs to allocate an event, stores on Fiber to avoid repeated allocations, and we musn't forget to free the event before the fiber terminates.

But none of the new event loops (iocp, epoll, kqueue or the incoming io_uring) need to allocate or free anything :confused: 

I'm proposing here to introduce a `sleep(Time::Span)` method to event loops that behaves just like the other event loop methods: it blocks the current fiber and returns when ready. This removes the indirect "create event object" then interact with that indirect object to have the event loop sleep.

**Note 1**: I kept `Fiber#resume_event` for compatibility reasons (i.e. free the libevent allocation when the fiber terminates). We might consider to only declare it when `Crystal::EventLoop::LibEvent` is defined or have a mechanism to declare fiber local values.

**Note 2**: `Fiber#timeout_event` is different. It handles the special case of `select` timeouts, where a fiber might be resumed _twice_ (by `channel.send` and `sleep`) and arming the timer musn't suspend the current fiber.