### PR TITLE
Extract bindings for LibC errno to `src/lib_c/`

### DIFF
--- a/src/errno.cr
+++ b/src/errno.cr
@@ -74,7 +74,7 @@ enum Errno
     {% elsif LibC.has_method?(:__error) %}
       LibC.__error.value = errno.value
     {% elsif LibC.has_method?(:___errno) %}
-      LibC.___errno.value = errno.vaue
+      LibC.___errno.value = errno.value
     {% elsif flag?(:wasi) %}
       LibC.errno = errno.value
     {% elsif flag?(:win32) %}

--- a/src/errno.cr
+++ b/src/errno.cr
@@ -1,23 +1,6 @@
 require "c/errno"
 require "c/string"
 
-lib LibC
-  {% if flag?(:netbsd) || flag?(:openbsd) || flag?(:android) %}
-    fun __errno : Int*
-  {% elsif flag?(:solaris) %}
-    fun ___errno : Int*
-  {% elsif flag?(:linux) || flag?(:dragonfly) %}
-    fun __errno_location : Int*
-  {% elsif flag?(:wasi) %}
-    $errno : Int
-  {% elsif flag?(:darwin) || flag?(:freebsd) %}
-    fun __error : Int*
-  {% elsif flag?(:win32) %}
-    fun _get_errno(value : Int*) : ErrnoT
-    fun _set_errno(value : Int) : ErrnoT
-  {% end %}
-end
-
 # Errno wraps and gives access to libc's errno. This is mostly useful when
 # dealing with C libraries.
 enum Errno
@@ -63,36 +46,26 @@ enum Errno
 
   # returns the value of libc's errno.
   def self.value : self
-    {% if flag?(:netbsd) || flag?(:openbsd) || flag?(:android) %}
-      Errno.new LibC.__errno.value
-    {% elsif flag?(:solaris) %}
-      Errno.new LibC.___errno.value
-    {% elsif flag?(:linux) || flag?(:dragonfly) %}
-      Errno.new LibC.__errno_location.value
-    {% elsif flag?(:wasi) %}
+    {% if flag?(:wasi) %}
       Errno.new LibC.errno
-    {% elsif flag?(:darwin) || flag?(:freebsd) %}
-      Errno.new LibC.__error.value
     {% elsif flag?(:win32) %}
       ret = LibC._get_errno(out errno)
       raise RuntimeError.from_os_error("_get_errno", Errno.new(ret)) unless ret == 0
       Errno.new errno
+    {% else %}
+      Errno.new LibC.__errno_location.value
     {% end %}
   end
 
   # Sets the value of libc's errno.
   def self.value=(errno : Errno)
-    {% if flag?(:netbsd) || flag?(:openbsd) || flag?(:android) %}
-      LibC.__errno.value = errno.value
-    {% elsif flag?(:solaris) %}
-      LibC.___errno.value = errno.value
-    {% elsif flag?(:linux) || flag?(:dragonfly) %}
-      LibC.__errno_location.value = errno.value
-    {% elsif flag?(:darwin) || flag?(:freebsd) %}
-      LibC.__error.value = errno.value
+    {% if flag?(:wasi) %}
+      LibC.errno = errno.value
     {% elsif flag?(:win32) %}
       ret = LibC._set_errno(errno.value)
       raise RuntimeError.from_os_error("_set_errno", Errno.new(ret)) unless ret == 0
+    {% else %}
+      LibC.__errno_location.value = errno.value
     {% end %}
     errno
   end

--- a/src/lib_c/aarch64-android/c/errno.cr
+++ b/src/lib_c/aarch64-android/c/errno.cr
@@ -1,5 +1,5 @@
 lib LibC
-  fun __errno_location = __errno : Int*
+  fun __errno : Int*
 
   E2BIG           =   7
   EACCES          =  13

--- a/src/lib_c/aarch64-android/c/errno.cr
+++ b/src/lib_c/aarch64-android/c/errno.cr
@@ -1,4 +1,6 @@
 lib LibC
+  fun __errno_location = __errno : Int*
+
   E2BIG           =   7
   EACCES          =  13
   EADDRINUSE      =  98

--- a/src/lib_c/aarch64-darwin/c/errno.cr
+++ b/src/lib_c/aarch64-darwin/c/errno.cr
@@ -1,5 +1,5 @@
 lib LibC
-  fun __errno_location = __error : Int*
+  fun __error : Int*
 
   E2BIG           =   7
   EACCES          =  13

--- a/src/lib_c/aarch64-darwin/c/errno.cr
+++ b/src/lib_c/aarch64-darwin/c/errno.cr
@@ -1,4 +1,6 @@
 lib LibC
+  fun __errno_location = __error : Int*
+
   E2BIG           =   7
   EACCES          =  13
   EADDRINUSE      =  48

--- a/src/lib_c/aarch64-linux-gnu/c/errno.cr
+++ b/src/lib_c/aarch64-linux-gnu/c/errno.cr
@@ -1,4 +1,6 @@
 lib LibC
+  fun __errno_location : Int*
+
   E2BIG           =   7
   EACCES          =  13
   EADDRINUSE      =  98

--- a/src/lib_c/aarch64-linux-musl/c/errno.cr
+++ b/src/lib_c/aarch64-linux-musl/c/errno.cr
@@ -1,4 +1,6 @@
 lib LibC
+  fun __errno_location : Int*
+
   E2BIG           =   7
   EACCES          =  13
   EADDRINUSE      =  98

--- a/src/lib_c/arm-linux-gnueabihf/c/errno.cr
+++ b/src/lib_c/arm-linux-gnueabihf/c/errno.cr
@@ -1,4 +1,6 @@
 lib LibC
+  fun __errno_location : Int*
+
   E2BIG           =   7
   EACCES          =  13
   EADDRINUSE      =  98

--- a/src/lib_c/i386-linux-gnu/c/errno.cr
+++ b/src/lib_c/i386-linux-gnu/c/errno.cr
@@ -1,4 +1,6 @@
 lib LibC
+  fun __errno_location : Int*
+
   E2BIG           =   7
   EACCES          =  13
   EADDRINUSE      =  98

--- a/src/lib_c/i386-linux-musl/c/errno.cr
+++ b/src/lib_c/i386-linux-musl/c/errno.cr
@@ -1,4 +1,6 @@
 lib LibC
+  fun __errno_location : Int*
+
   E2BIG           =   7
   EACCES          =  13
   EADDRINUSE      =  98

--- a/src/lib_c/wasm32-wasi/c/errno.cr
+++ b/src/lib_c/wasm32-wasi/c/errno.cr
@@ -1,4 +1,6 @@
 lib LibC
+  $errno : Int
+
   E2BIG           =  1_u16
   EACCES          =  2_u16
   EADDRINUSE      =  3_u16

--- a/src/lib_c/x86_64-darwin/c/errno.cr
+++ b/src/lib_c/x86_64-darwin/c/errno.cr
@@ -1,5 +1,5 @@
 lib LibC
-  fun __errno_location = __error : Int*
+  fun __error : Int*
 
   E2BIG           =   7
   EACCES          =  13

--- a/src/lib_c/x86_64-darwin/c/errno.cr
+++ b/src/lib_c/x86_64-darwin/c/errno.cr
@@ -1,4 +1,6 @@
 lib LibC
+  fun __errno_location = __error : Int*
+
   E2BIG           =   7
   EACCES          =  13
   EADDRINUSE      =  48

--- a/src/lib_c/x86_64-dragonfly/c/errno.cr
+++ b/src/lib_c/x86_64-dragonfly/c/errno.cr
@@ -1,4 +1,6 @@
 lib LibC
+  fun __errno_location : Int*
+
   E2BIG         =  7
   EACCES        = 13
   EADDRINUSE    = 48

--- a/src/lib_c/x86_64-freebsd/c/errno.cr
+++ b/src/lib_c/x86_64-freebsd/c/errno.cr
@@ -1,4 +1,6 @@
 lib LibC
+  fun __errno_location = __error : Int*
+
   E2BIG           =  7
   EACCES          = 13
   EADDRINUSE      = 48

--- a/src/lib_c/x86_64-freebsd/c/errno.cr
+++ b/src/lib_c/x86_64-freebsd/c/errno.cr
@@ -1,5 +1,5 @@
 lib LibC
-  fun __errno_location = __error : Int*
+  fun __error : Int*
 
   E2BIG           =  7
   EACCES          = 13

--- a/src/lib_c/x86_64-linux-gnu/c/errno.cr
+++ b/src/lib_c/x86_64-linux-gnu/c/errno.cr
@@ -1,4 +1,6 @@
 lib LibC
+  fun __errno_location : Int*
+
   E2BIG           =   7
   EACCES          =  13
   EADDRINUSE      =  98

--- a/src/lib_c/x86_64-linux-musl/c/errno.cr
+++ b/src/lib_c/x86_64-linux-musl/c/errno.cr
@@ -1,4 +1,6 @@
 lib LibC
+  fun __errno_location : Int*
+
   E2BIG           =   7
   EACCES          =  13
   EADDRINUSE      =  98

--- a/src/lib_c/x86_64-netbsd/c/errno.cr
+++ b/src/lib_c/x86_64-netbsd/c/errno.cr
@@ -1,4 +1,6 @@
 lib LibC
+  fun __errno_location = __errno : Int*
+
   EPERM           =  1     # Operation not permitted
   ENOENT          =  2     # No such file or directory
   ESRCH           =  3     # No such process

--- a/src/lib_c/x86_64-netbsd/c/errno.cr
+++ b/src/lib_c/x86_64-netbsd/c/errno.cr
@@ -1,5 +1,5 @@
 lib LibC
-  fun __errno_location = __errno : Int*
+  fun __errno : Int*
 
   EPERM           =  1     # Operation not permitted
   ENOENT          =  2     # No such file or directory

--- a/src/lib_c/x86_64-openbsd/c/errno.cr
+++ b/src/lib_c/x86_64-openbsd/c/errno.cr
@@ -1,4 +1,6 @@
 lib LibC
+  fun __errno_location = __errno : Int*
+
   E2BIG           =  7
   EACCES          = 13
   EADDRINUSE      = 48

--- a/src/lib_c/x86_64-openbsd/c/errno.cr
+++ b/src/lib_c/x86_64-openbsd/c/errno.cr
@@ -1,5 +1,5 @@
 lib LibC
-  fun __errno_location = __errno : Int*
+  fun __errno : Int*
 
   E2BIG           =  7
   EACCES          = 13

--- a/src/lib_c/x86_64-solaris/c/errno.cr
+++ b/src/lib_c/x86_64-solaris/c/errno.cr
@@ -1,5 +1,5 @@
 lib LibC
-  fun __errno_location = ___errno : Int*
+  fun ___errno : Int*
 
   E2BIG           =   7
   EACCES          =  13

--- a/src/lib_c/x86_64-solaris/c/errno.cr
+++ b/src/lib_c/x86_64-solaris/c/errno.cr
@@ -1,4 +1,6 @@
 lib LibC
+  fun __errno_location = ___errno : Int*
+
   E2BIG           =   7
   EACCES          =  13
   EADDRINUSE      = 125

--- a/src/lib_c/x86_64-windows-msvc/c/errno.cr
+++ b/src/lib_c/x86_64-windows-msvc/c/errno.cr
@@ -1,4 +1,7 @@
 lib LibC
+  fun _get_errno(value : Int*) : ErrnoT
+  fun _set_errno(value : Int) : ErrnoT
+
   # source https://docs.microsoft.com/en-us/cpp/c-runtime-library/errno-doserrno-sys-errlist-and-sys-nerr
   EPERM        =   1
   ENOENT       =   2


### PR DESCRIPTION
I noticed multiple times that we define the LibC errno bindings right in `src/errno.cr` instead of doing in the per-target `src/lib_c/*/c/errno.cr` bindings.

I also harmonized the POSIX funs to be aliased as `LibC.__errno_location` so we avoid each target having its own name. I didn't harmonize as `LibC.errno` because `errno` is supposed to be the value, not a pointer to the value.