### PR TITLE
Strip periods, spaces for batch file filtering on Windows

### DIFF
--- a/spec/std/process_spec.cr
+++ b/spec/std/process_spec.cr
@@ -268,7 +268,7 @@ describe Process do
     end
 
     describe "does not execute batch files" do
-      %w[.bat .Bat .BAT .cmd .cmD .CmD].each do |ext|
+      %w[.bat .Bat .BAT .cmd .cmD .CmD .bat\  .cmd\ ... .bat.\ .].each do |ext|
         it ext do
           with_tempfile "process_run#{ext}" do |path|
             File.write(path, "echo '#{ext}'\n")

--- a/src/crystal/system/win32/process.cr
+++ b/src/crystal/system/win32/process.cr
@@ -315,7 +315,7 @@ struct Crystal::System::Process
       # > The problem is that the `cmd.exe` has complicated parsing rules for the command arguments, and programming language runtimes fail to escape the command arguments properly.
       # > Because of this, it’s possible to inject commands if someone can control the part of command arguments of the batch file.
       # https://flatt.tech/research/posts/batbadbut-you-cant-securely-execute-commands-on-windows/
-      if command.byte_slice?(-4, 4).try(&.downcase).in?(".bat", ".cmd")
+      if command.rstrip(". ").byte_slice?(-4, 4).try(&.downcase).in?(".bat", ".cmd")
         raise ::File::Error.from_os_error("Error executing process", WinError::ERROR_BAD_EXE_FORMAT, file: command)
       end
 


### PR DESCRIPTION
fix: #15560 

As discussed in the linked issue, the options on the table are either `GetFullPathNameW` or stripping trailing `.` and ` `. This PR does the latter.

Here's a benchmark between them, the difference seems insignificant, considering executing is going to take longer. Stripping is faster anyway.

```crystal
require "benchmark"

File.write("foo.bat", "calc.exe") unless File.exists?("foo.bat")
COMMAND = "foo.bat . .  .. #{ARGV[0]? || ""}"

Benchmark.ips do |x|
  x.report("GetFullPathNameW") do
    wstr_path = Crystal::System.to_wstr(COMMAND)
    Crystal::System.retry_wstr_buffer do |buffer, small_buf|
      len = LibC.GetFullPathNameW(wstr_path, buffer.size, buffer, nil)
      if 0 < len < buffer.size
        break String.from_utf16(buffer[0, len])
      elsif small_buf && len > 0
        next len
      else
        raise ::File::Error.from_winerror("Error resolving real path", file: COMMAND)
      end
    end
  end

  x.report("rstrip") do
    COMMAND.rstrip(". ")
  end
end

# GetFullPathNameW 967.44k (  1.03µs) (± 2.75%)   112B/op   2.75× slower
#           rstrip   2.66M (376.29ns) (± 1.42%)  32.0B/op        fastest
```

~~Draft until the CI finishes because I haven't actually tested on Windows.~~

<sub>I don't like the commit name that much but it's the most descriptive one I could come up with.</sub>