### PR TITLE
RFC 2: MT safe fiber context switch on AArch64

### DIFF
--- a/src/fiber/context/aarch64-generic.cr
+++ b/src/fiber/context/aarch64-generic.cr
@@ -54,6 +54,9 @@ class Fiber
 
       mov     x19, sp               // current_context.stack_top = sp
       str     x19, [x0, #0]
+      {% if flag?(:execution_context) %}
+      dmb     ish                   // barrier: ensure registers are stored
+      {% end %}
       mov     x19, #1               // current_context.resumable = 1
       str     x19, [x0, #8]
 
@@ -97,6 +100,9 @@ class Fiber
 
       mov     x19, sp               // current_context.stack_top = sp
       str     x19, [$0, #0]
+      {% if flag?(:execution_context) %}
+      dmb     ish                   // barrier: ensure registers are stored
+      {% end %}
       mov     x19, #1               // current_context.resumable = 1
       str     x19, [$0, #8]
 

--- a/src/fiber/context/aarch64-microsoft.cr
+++ b/src/fiber/context/aarch64-microsoft.cr
@@ -55,6 +55,9 @@ class Fiber
 
       mov     x19, sp               // current_context.stack_top = sp
       str     x19, [x0, #0]
+      {% if flag?(:execution_context) %}
+      dmb     ish                   // barrier: ensure registers are stored
+      {% end %}
       mov     x19, #1               // current_context.resumable = 1
       str     x19, [x0, #8]
 
@@ -112,6 +115,9 @@ class Fiber
 
       mov     x19, sp               // current_context.stack_top = sp
       str     x19, [$0, #0]
+      {% if flag?(:execution_context) %}
+      dmb     ish                   // barrier: ensure registers are stored
+      {% end %}
       mov     x19, #1               // current_context.resumable = 1
       str     x19, [$0, #8]
 


### PR DESCRIPTION
We need a store-store barrier between pushing the registers to the current stack and setting the resumable flag of the current fiber, otherwise the CPU is allowed to reorder the instructions at runtime and to store the resumable flag before or while storing the registers.

This can happen for example:

- thread 1: enqueues current fiber A
- thread 1: enters swapcontext
- thread 1: set resumable flag (too soon)
- thread 1: is preempted
- thread 2: steals fiber A
- thread 2: resumes fiber A => resumable is set
- thread 2: reads registers => :boom:
- thread 1: saves registers (too late)

The current implementation didn't need the barrier because fibers are stuck to a single thread (it must have finished swapcontext to be able to start another swapcontext), but RFC 2 adds work stealing to the MT environment.

Note: the same issue can happen in ARM32.