### PR TITLE
RFC 2: MT safe fiber context switch on ARM

### DIFF
--- a/src/fiber/context/arm.cr
+++ b/src/fiber/context/arm.cr
@@ -34,7 +34,9 @@ class Fiber
     # different strategies for atomics. By default it uses the "older"
     # architecture that relies on the libgcc __sync_* symbols; when an armv6 CPU
     # or +v6 feature is specified it uses the coprocessor instruction as used
-    # below; for armv7 / +v7 it uses the `dmb ish` instruction.
+    # below, unless the +db (data barrier) feature is set, in which case it
+    # uses the `dmb ish` instruction. The +db feature is always enabled since
+    # armv7 / +v7.
     #
     # TODO: we should do the same, but we don't know the list of CPU features
     # for the current target machine (and LLVM won't tell us).

--- a/src/fiber/context/arm.cr
+++ b/src/fiber/context/arm.cr
@@ -29,6 +29,15 @@ class Fiber
     #
     # Eventually reset LR to zero to avoid the ARM unwinder to mistake the
     # context switch as a regular call.
+    #
+    # NOTE: depending on the ARM architecture (v7, v6 or older) LLVM uses
+    # different strategies for atomics. By default it uses the "older"
+    # architecture that relies on the libgcc __sync_* symbols; when an armv6 CPU
+    # or +v6 feature is specified it uses the coprocessor instruction as used
+    # below; for armv7 / +v7 it uses the `dmb ish` instruction.
+    #
+    # TODO: we should do the same, but we don't know the list of CPU features
+    # for the current target machine (and LLVM won't tell us).
 
     {% if compare_versions(Crystal::LLVM_VERSION, "9.0.0") >= 0 %}
       asm("
@@ -42,6 +51,10 @@ class Fiber
         vstmdb sp!, {d8-d15}          // push FPU registers
         {% end %}
         str    sp, [r0, #0]           // current_context.stack_top = sp
+        {% if flag?(:execution_context) %}
+        mov    r4, #0                 // barrier: ensure registers are stored
+        mcr    p15, #0, r4, c7, c10, #5
+        {% end %}
         mov    r4, #1                 // current_context.resumable = 1
         str    r4, [r0, #4]
 
@@ -72,6 +85,10 @@ class Fiber
         vstmdb sp!, {d8-d15}          // push FPU registers
         {% end %}
         str    sp, [$0, #0]           // current_context.stack_top = sp
+        {% if flag?(:execution_context) %}
+        mov    r4, #0                 // barrier: ensure registers are stored
+        mcr    p15, #0, r4, c7, c10, #5
+        {% end %}
         mov    r4, #1                 // current_context.resumable = 1
         str    r4, [$0, #4]
 


### PR DESCRIPTION
The ARM32 equivalent of #15581.

As stated in a comment the chosen assembly is compatible with armv6, but might not work on older architectures and it doesn't take advantage of armv7 supporting the `dmb ish` instruction.

We might want to consider to integrate https://github.com/crystal-lang/crystal/issues/14524#issuecomment-2218803975 into the compiler, so we could add flags based on features, for example `armv7` when any feature matches `/\+v7(ve|r|m|em|s|k|)/`.

~~Note: I also reduced the duplicated assembly. Let's use the flags to wrap the FPU instructions intead of duplicating the assembly 4 times.~~ Extracted as #15585 but the commit is still in this branch because I need it.