### PR TITLE
Return `if_none` for invalid offsets in `Indexable#find` [fixup #15552]

### DIFF
--- a/spec/std/indexable_spec.cr
+++ b/spec/std/indexable_spec.cr
@@ -159,9 +159,9 @@ describe Indexable do
       indexable.find(offset: -6) { |i| i.even? }.should eq 2
     end
 
-    it "does not receive a valid negative offset, returns nil" do
+    it "does not receive a valid negative offset, returns if_none value" do
       indexable = SafeIndexable.new(4)
-      indexable.find(offset: -10) { |i| i > 2 }.should be_nil
+      indexable.find(-1, offset: -10) { |i| i > 2 }.should eq -1
     end
 
     it "does not find the element matching the block" do

--- a/src/indexable.cr
+++ b/src/indexable.cr
@@ -822,7 +822,7 @@ module Indexable(T)
   # ```
   def find(if_none = nil, offset : Int = 0, & : T ->)
     offset += size if offset < 0
-    return nil if offset < 0
+    return if_none if offset < 0
 
     if idx = index(offset) { |i| yield i }
       return unsafe_fetch(idx)


### PR DESCRIPTION
Fixes a regression from #15552