### PR TITLE
Respect `--mcpu=help` in the compiler

### DIFF
--- a/doc/man/crystal-build.adoc
+++ b/doc/man/crystal-build.adoc
@@ -52,8 +52,8 @@ documentation available on the official web site.
 *--mcpu* _CPU_::
 Specify a specific CPU to generate code for. This will pass a
 -mcpu flag to LLVM, and is only intended to be used for cross-
-compilation. For a list of available CPUs, invoke "llvm-as <
-/dev/null | llc -march=xyz -mcpu=help".  Passing --mcpu native
+compilation. For a list of available CPUs, pass --mcpu help
+when building any Crystal source code.  Passing --mcpu native
 will pass the host CPU name to tune performance for the host.
 *--mattr* _CPU_::
 Override or control specific attributes of the target, such as

--- a/man/crystal.1
+++ b/man/crystal.1
@@ -198,8 +198,8 @@ documentation available on the official web site.
 .RS 4
 Specify a specific CPU to generate code for. This will pass a
 \-mcpu flag to LLVM, and is only intended to be used for cross\-
-compilation. For a list of available CPUs, invoke "llvm\-as <
-/dev/null | llc \-march=xyz \-mcpu=help".  Passing \-\-mcpu native
+compilation. For a list of available CPUs, pass \-\-mcpu help
+when building any Crystal source code.  Passing \-\-mcpu native
 will pass the host CPU name to tune performance for the host.
 .RE
 .sp

--- a/src/compiler/crystal/command.cr
+++ b/src/compiler/crystal/command.cr
@@ -681,6 +681,12 @@ class Crystal::Command
         compiler.mcpu = LLVM.host_cpu_name
       else
         compiler.mcpu = cpu
+        if cpu == "help"
+          # LLVM will display a help message the moment the target machine is
+          # created, but "help" is not a valid CPU name, so exit immediately
+          compiler.create_target_machine
+          exit
+        end
       end
     end
     opts.on("--mattr CPU", "Target specific features") do |features|


### PR DESCRIPTION
Passing `--mcpu=help` when building or running any Crystal source code makes LLVM display a list of all valid CPU and feature flags for the currently selected target, but then Crystal will continue with the semantic phase before failing to create a target machine for an invalid CPU. This PR makes the CLI immediately exit instead when that happens.

`--mattr=+help` can be used to display the same help message without exiting the compiler nor adding an invalid feature flag; nothing needs to be done in Crystal about this.