### PR TITLE
Fix: don't lazy initialize execution contexts linked list [fixup #15350]

### DIFF
--- a/src/fiber/execution_context.cr
+++ b/src/fiber/execution_context.cr
@@ -29,7 +29,7 @@ module Fiber::ExecutionContext
   end
 
   # :nodoc:
-  protected class_getter(execution_contexts) = Thread::LinkedList(ExecutionContext).new
+  protected class_getter execution_contexts = Thread::LinkedList(ExecutionContext).new
 
   # :nodoc:
   property next : ExecutionContext?

--- a/src/fiber/execution_context.cr
+++ b/src/fiber/execution_context.cr
@@ -29,7 +29,7 @@ module Fiber::ExecutionContext
   end
 
   # :nodoc:
-  protected class_getter(execution_contexts) { Thread::LinkedList(ExecutionContext).new }
+  protected class_getter(execution_contexts) = Thread::LinkedList(ExecutionContext).new
 
   # :nodoc:
   property next : ExecutionContext?


### PR DESCRIPTION
It's pointless because we always add the default context anyway during runtime startup. Let's make the initialization explicit.