### PR TITLE
Extend Windows `Process` completion key's lifetime

### DIFF
--- a/spec/std/process_spec.cr
+++ b/spec/std/process_spec.cr
@@ -101,6 +101,11 @@ describe Process do
         end
       end
     end
+
+    it "doesn't break if process is collected before completion", tags: %w[slow] do
+      200.times { Process.new(*exit_code_command(0)) }
+      10.times { GC.collect }
+    end
   end
 
   describe "#wait" do

--- a/spec/std/process_spec.cr
+++ b/spec/std/process_spec.cr
@@ -104,7 +104,13 @@ describe Process do
 
     it "doesn't break if process is collected before completion", tags: %w[slow] do
       200.times { Process.new(*exit_code_command(0)) }
+
+      # run the GC multiple times to unmap as much memory as possible
       10.times { GC.collect }
+
+      # the processes above have now been queued after completion; if this last
+      # one finishes at all, nothing was broken by the GC
+      Process.run(*exit_code_command(0))
     end
   end
 


### PR DESCRIPTION
Alternative to #14995. Fixes #15028.

There is probably a better data structure than `Set` here...