### PR TITLE
Add thread safety to `at_exit`

### DIFF
--- a/src/crystal/at_exit_handlers.cr
+++ b/src/crystal/at_exit_handlers.cr
@@ -1,21 +1,24 @@
 # :nodoc:
 module Crystal::AtExitHandlers
-  private class_getter(handlers) { [] of Int32, ::Exception? -> }
+  @@mutex = ::Thread::Mutex.new
 
   def self.add(handler)
-    handlers << handler
+    @@mutex.synchronize do
+      handlers = @@handlers ||= [] of Int32, ::Exception? ->
+      handlers << handler
+    end
   end
 
   def self.run(status, exception = nil)
-    if handlers = @@handlers
-      # Run the registered handlers in reverse order
-      while handler = handlers.pop?
-        begin
-          handler.call status, exception
-        rescue handler_ex
-          Crystal::System.print_error "Error running at_exit handler: %s\n", handler_ex.message || ""
-          status = 1 if status.zero?
-        end
+    return status unless @@handlers
+
+    # Run the registered handlers in reverse order
+    while handler = @@mutex.synchronize { @@handlers.try(&.pop?) }
+      begin
+        handler.call status, exception
+      rescue handler_ex
+        Crystal::System.print_error "Error running at_exit handler: %s\n", handler_ex.message || ""
+        status = 1 if status.zero?
       end
     end
 


### PR DESCRIPTION
Protects the `@@handlers` class variable of `Crystal::AtExitHandlers` with a thread mutex. 

Avoids a parallel initialization that could create two distinct arrays, and lose one `at_exit` handler;

Avoids a parallel mutation of the array when `at_exit` is called in parallel to running the handlers, ~~or when `at_exit` is called by an `at_exit` handler :shrug:~~ In these edge cases, the handler is merely added and will be run next.

There should be no behavior change from not using the mutex compared to ST.

I didn't branch based on the `preview_mt` flag because the Mutex should usually not be contended and its impact be negligible overall. That allowed to keep the implementation simple.