### PR TITLE
Respect `$MACOSX_DEPLOYMENT_TARGET` on macOS hosts

### DIFF
--- a/src/compiler/crystal/config.cr
+++ b/src/compiler/crystal/config.cr
@@ -61,6 +61,31 @@ module Crystal
           target = Crystal::Codegen::Target.new(target.to_s.sub(default_libc, "-#{linux_runtime_libc}"))
         end
 
+        if target.macos?
+          # By default, LLVM infers the target macOS SDK version from the host
+          # version detected in `LLVM.default_target_triple`, and independently
+          # Clang will infer a different one from several options: `-target`,
+          # `-mtargetos`, `-mmacosx-version-min`, `$MACOSX_DEPLOYMENT_TARGET`,
+          # `-isysroot`, then finally the LLVM default (see
+          # https://github.com/llvm/llvm-project/blob/5f58f3dda8b17f664a85d4e5e3c808edde41ff46/clang/lib/Driver/ToolChains/Darwin.cpp#L2293-L2378
+          # for details). If the one we use is higher than the linker's, each
+          # object file being linked will produce a warning:
+          #
+          # > ld: warning: object file (...o0.o) was built for newer macOS version (15.0) than being linked (11.0)
+          #
+          # We have to match our SDK version with that of the linker. As long as
+          # we are not passing any of those command-line options to Clang in
+          # `Crystal::Compiler#linker_command`, the only override we need to
+          # handle ourselves is the environment variable one.
+          #
+          # Note that other platforms (e.g. iOS, tvOS) use different environment
+          # variables!
+          if min_version = ENV["MACOSX_DEPLOYMENT_TARGET"]?
+            triple = "#{target.architecture}-#{target.vendor}-macosx#{min_version}"
+            target = Crystal::Codegen::Target.new(triple)
+          end
+        end
+
         target
       end
     end


### PR DESCRIPTION
Fixes #15130.

On a macOS host, if the `MACOSX_DEPLOYMENT_TARGET` environment variable is set, that value now overrides the host triple's environment component:

```sh
$ bin/crystal eval 'p Crystal::HOST_TRIPLE'
"aarch64-apple-darwin24.3.0"
$ MACOSX_DEPLOYMENT_TARGET=10.11 bin/crystal eval 'p Crystal::HOST_TRIPLE'
"aarch64-apple-macosx10.11"
$ MACOSX_DEPLOYMENT_TARGET=13.0 bin/crystal eval 'p Crystal::HOST_TRIPLE'
"aarch64-apple-macosx13.0"
```

(`darwin24.3.0` corresponds to `macosx15.0`; [this is how LLVM converts the former into the latter](https://github.com/llvm/llvm-project/blob/6ddc07163d6c781622384eb83c7220d3051243a6/llvm/lib/TargetParser/Triple.cpp#L1427-L1470).)