### PR TITLE
New algorithm for `File.match?`

### DIFF
--- a/spec/std/file/match-fast-glob_spec.cr
+++ b/spec/std/file/match-fast-glob_spec.cr
@@ -215,10 +215,11 @@ describe "File .match? bash tests" do
     refute_file_matches "[^abc]", "b"
     refute_file_matches "[^abc]", "c"
     assert_file_matches "[^abc]", "d"
-    refute_file_matches "[!abc]", "a"
-    refute_file_matches "[!abc]", "b"
-    refute_file_matches "[!abc]", "c"
-    assert_file_matches "[!abc]", "d"
+    assert_file_matches "[!abc]", "a" # unsupported
+    assert_file_matches "[!abc]", "b" # unsupported
+    assert_file_matches "[!abc]", "c" # unsupported
+    refute_file_matches "[!abc]", "d" # unsupported
+    assert_file_matches "[!abc]", "!" # unsupported
     assert_file_matches "[\\!]", "!"
 
     assert_file_matches "a*b*[cy]*d*e*", "axbxcxdxexxx"

--- a/spec/std/file/match-fast-glob_spec.cr
+++ b/spec/std/file/match-fast-glob_spec.cr
@@ -1244,7 +1244,7 @@ describe "File .match? bash tests" do
     assert_file_matches "フォルダ/**/*", "フォルダ/aaa.js"
   end
 
-  it "negation" do
+  pending "negation" do
     refute_file_matches "!*", "abc"
     refute_file_matches "!abc", "abc"
     refute_file_matches "*!.md", "bar.md"

--- a/spec/std/file/match-fast-glob_spec.cr
+++ b/spec/std/file/match-fast-glob_spec.cr
@@ -25,22 +25,22 @@ end
 describe "File .match? bash tests" do
   it "webpack" do
     # Match everything
-    refute_file_matches "**/*", "foo" # bug #15319
+    assert_file_matches "**/*", "foo"
 
     # Match the end
-    refute_file_matches "**/f*", "foo" # bug #15319
+    assert_file_matches "**/f*", "foo"
 
     # Match the start
-    refute_file_matches "**/*o", "foo" # bug #15319
+    assert_file_matches "**/*o", "foo"
 
     # Match the middle
-    refute_file_matches "**/f*uck", "firetruck" # bug #15319
+    assert_file_matches "**/f*uck", "firetruck"
 
     # Don't match without Regexp 'g'
     refute_file_matches "**/uc", "firetruck"
 
     # Match zero characters
-    refute_file_matches "**/f*uck", "fuck" # bug #15319
+    assert_file_matches "**/f*uck", "fuck"
 
     # More complex matches
     assert_file_matches "**/*.min.js", "some/jquery.min.js"
@@ -72,37 +72,37 @@ describe "File .match? bash tests" do
     # Extended mode
 
     # ?: Match one character, no more and no less
-    refute_file_matches "**/f?o", "foo" # bug #15319
+    assert_file_matches "**/f?o", "foo"
     refute_file_matches "**/f?o", "fooo"
     refute_file_matches "**/f?oo", "foo"
 
     # ?: Match one character with RegExp 'g'
-    refute_file_matches "**/f?o", "foo" # bug #15319
+    assert_file_matches "**/f?o", "foo"
     refute_file_matches "**/f?o", "fooo"
-    refute_file_matches "**/f?o?", "fooo" # bug #15319
+    assert_file_matches "**/f?o?", "fooo"
     refute_file_matches "**/?fo", "fooo"
     refute_file_matches "**/f?oo", "foo"
     refute_file_matches "**/foo?", "foo"
 
     # []: Match a character range
-    refute_file_matches "**/fo[oz]", "foo" # bug #15319
-    refute_file_matches "**/fo[oz]", "foz" # bug #15319
+    assert_file_matches "**/fo[oz]", "foo"
+    assert_file_matches "**/fo[oz]", "foz"
     refute_file_matches "**/fo[oz]", "fog"
 
     # []: Match a character range and RegExp 'g' (regresion)
-    refute_file_matches "**/fo[oz]", "foo" # bug #15319
-    refute_file_matches "**/fo[oz]", "foz" # bug #15319
+    assert_file_matches "**/fo[oz]", "foo"
+    assert_file_matches "**/fo[oz]", "foz"
     refute_file_matches "**/fo[oz]", "fog"
 
     # {}: Match a choice of different substrings
-    refute_file_matches "**/foo{bar,baaz}", "foobaaz" # bug #15319
-    refute_file_matches "**/foo{bar,baaz}", "foobar"  # bug #15319
+    assert_file_matches "**/foo{bar,baaz}", "foobaaz"
+    assert_file_matches "**/foo{bar,baaz}", "foobar"
     refute_file_matches "**/foo{bar,baaz}", "foobuzz"
-    refute_file_matches "**/foo{bar,b*z}", "foobuzz" # bug #15319
+    assert_file_matches "**/foo{bar,b*z}", "foobuzz"
 
     # {}: Match a choice of different substrings and RegExp 'g' (regression)
-    refute_file_matches "**/foo{bar,baaz}", "foobaaz" # bug #15319
-    refute_file_matches "**/foo{bar,baaz}", "foobar"  # bug #15319
+    assert_file_matches "**/foo{bar,baaz}", "foobaaz"
+    assert_file_matches "**/foo{bar,baaz}", "foobar"
     refute_file_matches "**/foo{bar,baaz}", "foobuzz"
 
     # More complex extended matches
@@ -121,7 +121,7 @@ describe "File .match? bash tests" do
 
     # globstar
     assert_file_matches "some/**/{*.js,*.html}", "some/bar/jquery.min.js"
-    refute_file_matches "some/**/{*.js,*.html}", "some/bar/baz/jquery.min.js" # bug #15319
+    assert_file_matches "some/**/{*.js,*.html}", "some/bar/baz/jquery.min.js"
     assert_file_matches "some/**", "some/bar/baz/jquery.min.js"
 
     assert_file_matches "\\\\/$^+.()=!|,.*", "\\/$^+.()=!|,.*"
@@ -132,25 +132,25 @@ describe "File .match? bash tests" do
     assert_file_matches "/foo/**", "/foo/bar/baz.txt"
     assert_file_matches "/foo/*/*.txt", "/foo/bar/baz.txt"
     assert_file_matches "/foo/**/*.txt", "/foo/bar/baz.txt"
-    refute_file_matches "/foo/**/*.txt", "/foo/bar/baz/qux.txt" # bug #15319
-    refute_file_matches "/foo/**/bar.txt", "/foo/bar.txt"       # bug #15319
-    refute_file_matches "/foo/**/**/bar.txt", "/foo/bar.txt"    # bug #15319
-    refute_file_matches "/foo/**/*/baz.txt", "/foo/bar/baz.txt" # bug #15319
-    refute_file_matches "/foo/**/*.txt", "/foo/bar.txt"         # bug #15319
-    refute_file_matches "/foo/**/**/*.txt", "/foo/bar.txt"      # bug #15319
-    refute_file_matches "/foo/**/*/*.txt", "/foo/bar/baz.txt"   # bug #15319
-    refute_file_matches "**/*.txt", "/foo/bar/baz/qux.txt"      # bug #15319
-    refute_file_matches "**/foo.txt", "foo.txt"                 # bug #15319
-    refute_file_matches "**/*.txt", "foo.txt"                   # bug #15319
+    assert_file_matches "/foo/**/*.txt", "/foo/bar/baz/qux.txt"
+    assert_file_matches "/foo/**/bar.txt", "/foo/bar.txt"
+    assert_file_matches "/foo/**/**/bar.txt", "/foo/bar.txt"
+    assert_file_matches "/foo/**/*/baz.txt", "/foo/bar/baz.txt"
+    assert_file_matches "/foo/**/*.txt", "/foo/bar.txt"
+    assert_file_matches "/foo/**/**/*.txt", "/foo/bar.txt"
+    assert_file_matches "/foo/**/*/*.txt", "/foo/bar/baz.txt"
+    assert_file_matches "**/*.txt", "/foo/bar/baz/qux.txt"
+    assert_file_matches "**/foo.txt", "foo.txt"
+    assert_file_matches "**/*.txt", "foo.txt"
 
     refute_file_matches "/foo/*", "/foo/bar/baz.txt"
     refute_file_matches "/foo/*.txt", "/foo/bar/baz.txt"
     refute_file_matches "/foo/*/*.txt", "/foo/bar/baz/qux.txt"
     refute_file_matches "/foo/*/bar.txt", "/foo/bar.txt"
     refute_file_matches "/foo/*/*/baz.txt", "/foo/bar/baz.txt"
-    assert_file_matches "/foo/**.txt", "/foo/bar/baz/qux.txt" # bug #15319
+    refute_file_matches "/foo/**.txt", "/foo/bar/baz/qux.txt"
     refute_file_matches "/foo/bar**/*.txt", "/foo/bar/baz/qux.txt"
-    assert_file_matches "/foo/bar**", "/foo/bar/baz.txt" # bug #15319
+    refute_file_matches "/foo/bar**", "/foo/bar/baz.txt"
     refute_file_matches "**/.txt", "/foo/bar/baz/qux.txt"
     refute_file_matches "*/*.txt", "/foo/bar/baz/qux.txt"
     refute_file_matches "*/*.txt", "foo.txt"
@@ -215,10 +215,10 @@ describe "File .match? bash tests" do
     refute_file_matches "[^abc]", "b"
     refute_file_matches "[^abc]", "c"
     assert_file_matches "[^abc]", "d"
-    assert_file_matches "[!abc]", "a" # unsupported
-    assert_file_matches "[!abc]", "b" # unsupported
-    assert_file_matches "[!abc]", "c" # unsupported
-    refute_file_matches "[!abc]", "d" # unsupported
+    refute_file_matches "[!abc]", "a"
+    refute_file_matches "[!abc]", "b"
+    refute_file_matches "[!abc]", "c"
+    assert_file_matches "[!abc]", "d"
     assert_file_matches "[\\!]", "!"
 
     assert_file_matches "a*b*[cy]*d*e*", "axbxcxdxexxx"
@@ -270,13 +270,11 @@ describe "File .match? bash tests" do
     refute_file_matches "a/{a{a,b},b}", "a/ac"
     assert_file_matches "a/{a{a,b},b}", "a/b"
     refute_file_matches "a/{a{a,b},b}", "a/c"
-    refute_file_matches "a/{b,c[}]*}", "a/b" # bug
-    expect_raises File::BadPatternError do   # bug
-      assert_file_matches "a/{b,c[}]*}", "a/c}xx"
-    end
+    assert_file_matches "a/{b,c[}]*}", "a/b"
+    assert_file_matches "a/{b,c[}]*}", "a/c}xx"
 
     assert_file_matches "/**/*a", "/a/a"
-    refute_file_matches "**/*.js", "a/b.c/c.js" # bug #15319
+    assert_file_matches "**/*.js", "a/b.c/c.js"
     assert_file_matches "**/**/*.js", "a/b.c/c.js"
     assert_file_matches "a/**/*.d", "a/b/c.d"
     assert_file_matches "a/**/*.d", "a/.b/c.d"
@@ -479,12 +477,8 @@ describe "File .match? bash tests" do
     refute_file_matches "a*[^c]", "beware"
     refute_file_matches "a*[^c]", "BewAre"
 
-    expect_raises File::BadPatternError do # bug
-      assert_file_matches "a[X-]b", "a-b"
-    end
-    expect_raises File::BadPatternError do # bug
-      assert_file_matches "a[X-]b", "aXb"
-    end
+    assert_file_matches "a[X-]b", "a-b"
+    assert_file_matches "a[X-]b", "aXb"
 
     refute_file_matches "[a-y]*[^c]", "*"
     assert_file_matches "[a-y]*[^c]", "a*"
@@ -600,7 +594,7 @@ describe "File .match? bash tests" do
     refute_file_matches "a[\\b]c", "\\*"
     refute_file_matches "a[\\b]c", "a"
     refute_file_matches "a[\\b]c", "a/*"
-    assert_file_matches "a[\\b]c", "abc" # bug
+    refute_file_matches "a[\\b]c", "abc"
     refute_file_matches "a[\\b]c", "abd"
     refute_file_matches "a[\\b]c", "abe"
     refute_file_matches "a[\\b]c", "b"
@@ -698,20 +692,12 @@ describe "File .match? bash tests" do
   end
 
   it "bash_wildmatch" do
-    expect_raises File::BadPatternError do # bug
-      refute_file_matches "a[]-]b", "aab"
-    end
+    refute_file_matches "a[]-]b", "aab"
     refute_file_matches "[ten]", "ten"
     assert_file_matches "]", "]"
-    expect_raises File::BadPatternError do # bug
-      assert_file_matches "a[]-]b", "a-b"
-    end
-    expect_raises File::BadPatternError do # bug
-      assert_file_matches "a[]-]b", "a]b"
-    end
-    expect_raises File::BadPatternError do # bug
-      assert_file_matches "a[]]b", "a]b"
-    end
+    assert_file_matches "a[]-]b", "a-b"
+    assert_file_matches "a[]-]b", "a]b"
+    assert_file_matches "a[]]b", "a]b"
     assert_file_matches "a[\\]a\\-]b", "aab"
     assert_file_matches "t[a-g]n", "ten"
     assert_file_matches "t[^a-g]n", "ton"
@@ -947,7 +933,7 @@ describe "File .match? bash tests" do
 
     refute_file_matches "*/**/a", "a"
     refute_file_matches "*/**/a", "a/a/b"
-    refute_file_matches "*/**/a", "a/a" # bug #15319
+    assert_file_matches "*/**/a", "a/a"
     assert_file_matches "*/**/a", "a/a/a"
     assert_file_matches "*/**/a", "a/a/a/a"
     assert_file_matches "*/**/a", "a/a/a/a/a"
@@ -998,7 +984,7 @@ describe "File .match? bash tests" do
     refute_file_matches "*/*/", "foo/bar"
 
     assert_file_matches "**/..", "/home/foo/.."
-    refute_file_matches "**/a", "a" # bug #15319
+    assert_file_matches "**/a", "a"
     assert_file_matches "**", "a/a"
     assert_file_matches "a/**", "a/a"
     assert_file_matches "a/**", "a/"
@@ -1007,7 +993,7 @@ describe "File .match? bash tests" do
     # assert_file_matches "**/a/**", "a"
     # assert_file_matches "a/**", "a"
     refute_file_matches "**/", "a/a"
-    refute_file_matches "*/**/a", "a/a" # bug #15319
+    assert_file_matches "*/**/a", "a/a"
     # assert_file_matches "a/**", "a"
     assert_file_matches "*/**", "foo/"
     assert_file_matches "**/*", "foo/bar"
@@ -1026,14 +1012,14 @@ describe "File .match? bash tests" do
     refute_file_matches "foo?bar", "foo/bar"
     refute_file_matches "**/bar*", "foo/bar/baz"
     # refute_file_matches "**/bar**", "foo/bar/baz"
-    assert_file_matches "foo**bar", "foo/baz/bar" # bug #15319
+    refute_file_matches "foo**bar", "foo/baz/bar"
     refute_file_matches "foo*bar", "foo/baz/bar"
     # assert_file_matches "foo/**", "foo"
     assert_file_matches "/*", "/ab"
     assert_file_matches "/*", "/cd"
     assert_file_matches "/*", "/ef"
     assert_file_matches "a/**/j/**/z/*.md", "a/b/j/c/z/x.md"
-    refute_file_matches "a/**/j/**/z/*.md", "a/j/z/x.md" # bug #15319
+    assert_file_matches "a/**/j/**/z/*.md", "a/j/z/x.md"
 
     assert_file_matches "**/foo", "bar/baz/foo"
     assert_file_matches "**/bar/*", "deep/foo/bar/baz"
@@ -1041,32 +1027,32 @@ describe "File .match? bash tests" do
     assert_file_matches "**/bar/*/*", "deep/foo/bar/baz/x"
     assert_file_matches "foo/**/**/bar", "foo/b/a/z/bar"
     assert_file_matches "foo/**/bar", "foo/b/a/z/bar"
-    refute_file_matches "foo/**/**/bar", "foo/bar" # bug #15319
-    refute_file_matches "foo/**/bar", "foo/bar"    # bug #15319
+    assert_file_matches "foo/**/**/bar", "foo/bar"
+    assert_file_matches "foo/**/bar", "foo/bar"
     assert_file_matches "*/bar/**", "foo/bar/baz/x"
-    refute_file_matches "foo/**/**/bar", "foo/baz/bar" # bug #15319
+    assert_file_matches "foo/**/**/bar", "foo/baz/bar"
     assert_file_matches "foo/**/bar", "foo/baz/bar"
     assert_file_matches "**/foo", "XXX/foo"
   end
 
   it "globstars" do
-    refute_file_matches "**/*.js", "a/b/c/d.js" # bug #15319
-    refute_file_matches "**/*.js", "a/b/c.js"   # bug #15319
+    assert_file_matches "**/*.js", "a/b/c/d.js"
+    assert_file_matches "**/*.js", "a/b/c.js"
     assert_file_matches "**/*.js", "a/b.js"
-    refute_file_matches "a/b/**/*.js", "a/b/c/d/e/f.js" # bug #15319
-    refute_file_matches "a/b/**/*.js", "a/b/c/d/e.js"   # bug #15319
-    refute_file_matches "a/b/c/**/*.js", "a/b/c/d.js"   # bug #15319
+    assert_file_matches "a/b/**/*.js", "a/b/c/d/e/f.js"
+    assert_file_matches "a/b/**/*.js", "a/b/c/d/e.js"
+    assert_file_matches "a/b/c/**/*.js", "a/b/c/d.js"
     assert_file_matches "a/b/**/*.js", "a/b/c/d.js"
-    refute_file_matches "a/b/**/*.js", "a/b/d.js" # bug #15319
+    assert_file_matches "a/b/**/*.js", "a/b/d.js"
     refute_file_matches "a/b/**/*.js", "a/d.js"
     refute_file_matches "a/b/**/*.js", "d.js"
 
-    assert_file_matches "**c", "a/b/c"   # bug #15319
-    assert_file_matches "a/**c", "a/b/c" # bug #15319
+    refute_file_matches "**c", "a/b/c"
+    refute_file_matches "a/**c", "a/b/c"
     refute_file_matches "a/**z", "a/b/c"
-    assert_file_matches "a/**b**/c", "a/b/c/b/c" # bug #15319
+    refute_file_matches "a/**b**/c", "a/b/c/b/c"
     refute_file_matches "a/b/c**/*.js", "a/b/c/d/e.js"
-    refute_file_matches "a/**/b/**/c", "a/b/c/b/c" # bug #15319
+    assert_file_matches "a/**/b/**/c", "a/b/c/b/c"
     assert_file_matches "a/**b**/c", "a/aba/c"
     assert_file_matches "a/**b**/c", "a/b/c"
     assert_file_matches "a/b/c**/*.js", "a/b/c/d.js"
@@ -1075,9 +1061,9 @@ describe "File .match? bash tests" do
     refute_file_matches "a/**/**/*", "a"
     refute_file_matches "a/**/**/**/*", "a"
     refute_file_matches "**/a", "a/"
-    refute_file_matches "a/**/*", "a/"       # bug #15319
-    refute_file_matches "a/**/**/*", "a/"    # bug #15319
-    refute_file_matches "a/**/**/**/*", "a/" # bug #15319
+    assert_file_matches "a/**/*", "a/"
+    assert_file_matches "a/**/**/*", "a/"
+    assert_file_matches "a/**/**/**/*", "a/"
     refute_file_matches "**/a", "a/b"
     refute_file_matches "a/**/j/**/z/*.md", "a/b/c/j/e/z/c.txt"
     refute_file_matches "a/**/b", "a/bb"
@@ -1086,34 +1072,34 @@ describe "File .match? bash tests" do
     refute_file_matches "**/a", "a/x/y"
     refute_file_matches "**/a", "a/b/c/d"
     assert_file_matches "**", "a"
-    refute_file_matches "**/a", "a" # bug #15319
+    assert_file_matches "**/a", "a"
     # assert_file_matches "a/**", "a"
     assert_file_matches "**", "a/"
-    refute_file_matches "**/a/**", "a/" # bug #15319
+    assert_file_matches "**/a/**", "a/"
     assert_file_matches "a/**", "a/"
-    refute_file_matches "a/**/**", "a/" # bug #15319
+    assert_file_matches "a/**/**", "a/"
     assert_file_matches "**/a", "a/a"
     assert_file_matches "**", "a/b"
     assert_file_matches "*/*", "a/b"
     assert_file_matches "a/**", "a/b"
-    refute_file_matches "a/**/*", "a/b"       # bug #15319
-    refute_file_matches "a/**/**/*", "a/b"    # bug #15319
-    refute_file_matches "a/**/**/**/*", "a/b" # bug #15319
-    refute_file_matches "a/**/b", "a/b"       # bug #15319
+    assert_file_matches "a/**/*", "a/b"
+    assert_file_matches "a/**/**/*", "a/b"
+    assert_file_matches "a/**/**/**/*", "a/b"
+    assert_file_matches "a/**/b", "a/b"
     assert_file_matches "**", "a/b/c"
-    refute_file_matches "**/*", "a/b/c" # bug #15319
+    assert_file_matches "**/*", "a/b/c"
     assert_file_matches "**/**", "a/b/c"
     assert_file_matches "*/**", "a/b/c"
     assert_file_matches "a/**", "a/b/c"
     assert_file_matches "a/**/*", "a/b/c"
-    refute_file_matches "a/**/**/*", "a/b/c"    # bug #15319
-    refute_file_matches "a/**/**/**/*", "a/b/c" # bug #15319
+    assert_file_matches "a/**/**/*", "a/b/c"
+    assert_file_matches "a/**/**/**/*", "a/b/c"
     assert_file_matches "**", "a/b/c/d"
     assert_file_matches "a/**", "a/b/c/d"
-    refute_file_matches "a/**/*", "a/b/c/d" # bug #15319
+    assert_file_matches "a/**/*", "a/b/c/d"
     assert_file_matches "a/**/**/*", "a/b/c/d"
-    refute_file_matches "a/**/**/**/*", "a/b/c/d"      # bug #15319
-    refute_file_matches "a/b/**/c/**/*.*", "a/b/c/d.e" # bug #15319
+    assert_file_matches "a/**/**/**/*", "a/b/c/d"
+    assert_file_matches "a/b/**/c/**/*.*", "a/b/c/d.e"
     assert_file_matches "a/**/f/*.md", "a/b/c/d/e/f/g.md"
     assert_file_matches "a/**/f/**/k/*.md", "a/b/c/d/e/f/g/h/i/j/k/l.md"
     assert_file_matches "a/b/c/*.md", "a/b/c/def.md"
@@ -1123,9 +1109,9 @@ describe "File .match? bash tests" do
     assert_file_matches "a/*/c/*.md", "a/bb/c/ddd.md"
     assert_file_matches "a/*/c/*.md", "a/bbbb/c/ddd.md"
 
-    refute_file_matches "foo/bar/**/one/**/*.*", "foo/bar/baz/one/image.png" # bug #15319
+    assert_file_matches "foo/bar/**/one/**/*.*", "foo/bar/baz/one/image.png"
     assert_file_matches "foo/bar/**/one/**/*.*", "foo/bar/baz/one/two/image.png"
-    refute_file_matches "foo/bar/**/one/**/*.*", "foo/bar/baz/one/two/three/image.png" # bug #15319
+    assert_file_matches "foo/bar/**/one/**/*.*", "foo/bar/baz/one/two/three/image.png"
     refute_file_matches "a/b/**/f", "a/b/c/d/"
     # assert_file_matches "a/**", "a"
     assert_file_matches "**", "a"
@@ -1138,15 +1124,15 @@ describe "File .match? bash tests" do
     assert_file_matches "**/b/**", "a/b/c/d/"
     assert_file_matches "a/b/**", "a/b/c/d/"
     assert_file_matches "a/b/**/", "a/b/c/d/"
-    refute_file_matches "a/b/**/c/**/", "a/b/c/d/"   # bug #15319
-    refute_file_matches "a/b/**/c/**/d/", "a/b/c/d/" # bug #15319
+    assert_file_matches "a/b/**/c/**/", "a/b/c/d/"
+    assert_file_matches "a/b/**/c/**/d/", "a/b/c/d/"
     assert_file_matches "a/b/**/**/*.*", "a/b/c/d/e.f"
-    refute_file_matches "a/b/**/*.*", "a/b/c/d/e.f"        # bug #15319
-    refute_file_matches "a/b/**/c/**/d/*.*", "a/b/c/d/e.f" # bug #15319
-    refute_file_matches "a/b/**/d/**/*.*", "a/b/c/d/e.f"   # bug #15319
+    assert_file_matches "a/b/**/*.*", "a/b/c/d/e.f"
+    assert_file_matches "a/b/**/c/**/d/*.*", "a/b/c/d/e.f"
+    assert_file_matches "a/b/**/d/**/*.*", "a/b/c/d/e.f"
     assert_file_matches "a/b/**/d/**/*.*", "a/b/c/d/g/e.f"
-    refute_file_matches "a/b/**/d/**/*.*", "a/b/c/d/g/g/e.f" # bug #15319
-    refute_file_matches "a/b-*/**/z.js", "a/b-c/z.js"        # bug #15319
+    assert_file_matches "a/b/**/d/**/*.*", "a/b/c/d/g/g/e.f"
+    assert_file_matches "a/b-*/**/z.js", "a/b-c/z.js"
     assert_file_matches "a/b-*/**/z.js", "a/b-c/d/e/z.js"
 
     assert_file_matches "*/*", "a/b"
@@ -1155,7 +1141,7 @@ describe "File .match? bash tests" do
     assert_file_matches "a/*/c/*.md", "a/bb/c/xyz.md"
     assert_file_matches "a/*/c/*.md", "a/bbbb/c/xyz.md"
 
-    refute_file_matches "**/*", "a/b/c" # bug #15319
+    assert_file_matches "**/*", "a/b/c"
     assert_file_matches "**/**", "a/b/c"
     assert_file_matches "*/**", "a/b/c"
     assert_file_matches "a/**/j/**/z/*.md", "a/b/c/d/e/j/n/p/o/z/c.md"
@@ -1171,25 +1157,25 @@ describe "File .match? bash tests" do
     refute_file_matches "a/**/", "a/bb"
     refute_file_matches "a/**/", "a/cb"
     assert_file_matches "/**", "/a/b"
-    refute_file_matches "**/*", "a.b"     # bug #15319
-    refute_file_matches "**/*", "a.js"    # bug #15319
-    refute_file_matches "**/*.js", "a.js" # bug #15319
+    assert_file_matches "**/*", "a.b"
+    assert_file_matches "**/*", "a.js"
+    assert_file_matches "**/*.js", "a.js"
     # assert_file_matches "a/**/", "a/"
     assert_file_matches "**/*.js", "a/a.js"
-    refute_file_matches "**/*.js", "a/a/b.js" # bug #15319
-    refute_file_matches "a/**/b", "a/b"       # bug #15319
+    assert_file_matches "**/*.js", "a/a/b.js"
+    assert_file_matches "a/**/b", "a/b"
     assert_file_matches "a/**b", "a/b"
     assert_file_matches "**/*.md", "a/b.md"
-    refute_file_matches "**/*", "a/b/c.js"  # bug #15319
-    refute_file_matches "**/*", "a/b/c.txt" # bug #15319
+    assert_file_matches "**/*", "a/b/c.js"
+    assert_file_matches "**/*", "a/b/c.txt"
     assert_file_matches "a/**/", "a/b/c/d/"
-    refute_file_matches "**/*", "a/b/c/d/a.js" # bug #15319
+    assert_file_matches "**/*", "a/b/c/d/a.js"
     assert_file_matches "a/b/**/*.js", "a/b/c/z.js"
-    refute_file_matches "a/b/**/*.js", "a/b/z.js" # bug #15319
-    refute_file_matches "**/*", "ab"              # bug #15319
+    assert_file_matches "a/b/**/*.js", "a/b/z.js"
+    assert_file_matches "**/*", "ab"
     assert_file_matches "**/*", "ab/c"
-    refute_file_matches "**/*", "ab/c/d" # bug #15319
-    refute_file_matches "**/*", "abc.js" # bug #15319
+    assert_file_matches "**/*", "ab/c/d"
+    assert_file_matches "**/*", "abc.js"
 
     refute_file_matches "**/", "a"
     refute_file_matches "**/a/*", "a"
@@ -1210,22 +1196,22 @@ describe "File .match? bash tests" do
     refute_file_matches "**/d/*", "a/b/c/d"
     refute_file_matches "b/**", "a/b/c/d"
     assert_file_matches "**", "a"
-    refute_file_matches "**/**", "a"   # bug #15319
-    refute_file_matches "**/**/*", "a" # bug #15319
-    refute_file_matches "**/**/a", "a" # bug #15319
-    refute_file_matches "**/a", "a"    # bug #15319
+    assert_file_matches "**/**", "a"
+    assert_file_matches "**/**/*", "a"
+    assert_file_matches "**/**/a", "a"
+    assert_file_matches "**/a", "a"
     # assert_file_matches "**/a/**", "a"
     # assert_file_matches "a/**", "a"
     assert_file_matches "**", "a/b"
     assert_file_matches "**/**", "a/b"
-    refute_file_matches "**/**/*", "a/b" # bug #15319
-    refute_file_matches "**/**/b", "a/b" # bug #15319
+    assert_file_matches "**/**/*", "a/b"
+    assert_file_matches "**/**/b", "a/b"
     assert_file_matches "**/b", "a/b"
     # assert_file_matches "**/b/**", "a/b"
     # assert_file_matches "*/b/**", "a/b"
     assert_file_matches "a/**", "a/b"
-    refute_file_matches "a/**/*", "a/b"    # bug #15319
-    refute_file_matches "a/**/**/*", "a/b" # bug #15319
+    assert_file_matches "a/**/*", "a/b"
+    assert_file_matches "a/**/**/*", "a/b"
     assert_file_matches "**", "a/b/c"
     assert_file_matches "**/**", "a/b/c"
     assert_file_matches "**/**/*", "a/b/c"
@@ -1234,31 +1220,31 @@ describe "File .match? bash tests" do
     assert_file_matches "*/b/**", "a/b/c"
     assert_file_matches "a/**", "a/b/c"
     assert_file_matches "a/**/*", "a/b/c"
-    refute_file_matches "a/**/**/*", "a/b/c" # bug #15319
+    assert_file_matches "a/**/**/*", "a/b/c"
     assert_file_matches "**", "a/b/c/d"
     assert_file_matches "**/**", "a/b/c/d"
-    refute_file_matches "**/**/*", "a/b/c/d" # bug #15319
+    assert_file_matches "**/**/*", "a/b/c/d"
     assert_file_matches "**/**/d", "a/b/c/d"
     assert_file_matches "**/b/**", "a/b/c/d"
     assert_file_matches "**/b/*/*", "a/b/c/d"
     assert_file_matches "**/d", "a/b/c/d"
     assert_file_matches "*/b/**", "a/b/c/d"
     assert_file_matches "a/**", "a/b/c/d"
-    refute_file_matches "a/**/*", "a/b/c/d" # bug #15319
+    assert_file_matches "a/**/*", "a/b/c/d"
     assert_file_matches "a/**/**/*", "a/b/c/d"
 
     assert_file_matches "**/**.txt.js", "/foo/bar.txt.js"
   end
 
   it "utf8" do
-    refute_file_matches "フ*/**/*", "フォルダ/aaa.js"   # bug #15319
-    refute_file_matches "フォ*/**/*", "フォルダ/aaa.js"  # bug #15319
-    refute_file_matches "フォル*/**/*", "フォルダ/aaa.js" # bug #15319
-    refute_file_matches "フ*ル*/**/*", "フォルダ/aaa.js" # bug #15319
-    refute_file_matches "フォルダ/**/*", "フォルダ/aaa.js" # bug #15319
+    assert_file_matches "フ*/**/*", "フォルダ/aaa.js"
+    assert_file_matches "フォ*/**/*", "フォルダ/aaa.js"
+    assert_file_matches "フォル*/**/*", "フォルダ/aaa.js"
+    assert_file_matches "フ*ル*/**/*", "フォルダ/aaa.js"
+    assert_file_matches "フォルダ/**/*", "フォルダ/aaa.js"
   end
 
-  pending "negation" do
+  it "negation" do
     refute_file_matches "!*", "abc"
     refute_file_matches "!abc", "abc"
     refute_file_matches "*!.md", "bar.md"
@@ -1513,7 +1499,7 @@ describe "File .match? bash tests" do
     assert_file_matches "a/{a,b,c}", "a/c"
     assert_file_matches "a{b,bc}.txt", "abc.txt"
 
-    refute_file_matches "foo[{a,b}]baz", "foo{baz" # bug
+    assert_file_matches "foo[{a,b}]baz", "foo{baz"
 
     refute_file_matches "a{,b}.txt", "abc.txt"
     refute_file_matches "a{a,b,}.txt", "abc.txt"
@@ -1569,10 +1555,10 @@ describe "File .match? bash tests" do
 
     refute_file_matches "a/b/**/c{d,e}/**/xyz.md", "a/b/c/xyz.md"
     refute_file_matches "a/b/**/c{d,e}/**/xyz.md", "a/b/d/xyz.md"
-    refute_file_matches "a/b/**/c{d,e}/**/xyz.md", "a/b/cd/xyz.md" # bug #15319
-    refute_file_matches "a/b/**/{c,d,e}/**/xyz.md", "a/b/c/xyz.md" # bug #15319
-    refute_file_matches "a/b/**/{c,d,e}/**/xyz.md", "a/b/d/xyz.md" # bug #15319
-    refute_file_matches "a/b/**/{c,d,e}/**/xyz.md", "a/b/e/xyz.md" # bug #15319
+    assert_file_matches "a/b/**/c{d,e}/**/xyz.md", "a/b/cd/xyz.md"
+    assert_file_matches "a/b/**/{c,d,e}/**/xyz.md", "a/b/c/xyz.md"
+    assert_file_matches "a/b/**/{c,d,e}/**/xyz.md", "a/b/d/xyz.md"
+    assert_file_matches "a/b/**/{c,d,e}/**/xyz.md", "a/b/e/xyz.md"
 
     assert_file_matches "*{a,b}*", "xax"
     assert_file_matches "*{a,b}*", "xxax"
@@ -1657,9 +1643,9 @@ describe "File .match? bash tests" do
     assert_file_matches "a/bbb/ab??.md", "a/bbb/abcd.md"
     assert_file_matches "a/bbb/ab???md", "a/bbb/abcd.md"
 
-    refute_file_matches "{a,b}/c/{d,e}/**/*.ts", "a/c/d/one/two/three.test.ts" # bug #15319
+    assert_file_matches "{a,b}/c/{d,e}/**/*.ts", "a/c/d/one/two/three.test.ts"
     assert_file_matches "{a,{d,e}b}/c", "a/c"
-    refute_file_matches "{**/a,**/b}", "b" # bug #15319
+    assert_file_matches "{**/a,**/b}", "b"
   end
 
   it "not_paired_braces" do

--- a/spec/std/file/match_spec.cr
+++ b/spec/std/file/match_spec.cr
@@ -36,7 +36,7 @@ describe File do
       refute_file_matches "a*b?c*x", "abxbbxdbxebxczzy"
     end
 
-    describe "multibyte" do
+    pending "multibyte" do
       it "single-character match" do
         assert_file_matches "a?b", "a☺b"
         refute_file_matches "a???b", "a☺b"
@@ -94,7 +94,7 @@ describe File do
       end
     end
 
-    describe "invalid byte sequences" do
+    pending "invalid byte sequences" do
       it "single-character with invalid path" do
         assert_file_matches "?.txt", "\xC3.txt"         # Invalid byte sequence
         refute_file_matches "?.txt", "\xC3\x28.txt"     # Invalid byte sequence
@@ -151,16 +151,16 @@ describe File do
     end
 
     it "** bugs (#15319)" do
-      refute_file_matches "a/**/*", "a/b/c/d.x"
-      assert_file_matches "a/b**/d.x", "a/bb/c/d.x"
-      refute_file_matches "**/*.x", "a/b/c.x"
-      assert_file_matches "**.x", "a/b/c.x"
+      assert_file_matches "a/**/*", "a/b/c/d.x"
+      refute_file_matches "a/b**/d.x", "a/bb/c/d.x"
+      assert_file_matches "**/*.x", "a/b/c.x"
+      refute_file_matches "**.x", "a/b/c.x"
     end
 
     it "** matches path separator" do
-      assert_file_matches "a**", "ab/c"
-      assert_file_matches "a**/b", "a/c/b"
-      assert_file_matches "a*b*c*d*e**/f", "axbxcxdxe/xxx/f"
+      refute_file_matches "a**", "ab/c"
+      refute_file_matches "a**/b", "a/c/b"
+      refute_file_matches "a*b*c*d*e**/f", "axbxcxdxe/xxx/f"
       assert_file_matches "a*b*c*d*e**/f", "axbxcxdxexxx/f"
       refute_file_matches "a*b*c*d*e**/f", "axbxcxdxexxx/fff"
     end
@@ -174,10 +174,10 @@ describe File do
       refute_file_matches "ab[^c]", "abc"
       refute_file_matches "ab[^b-d]", "abc"
       assert_file_matches "ab[^e-g]", "abc"
-      assert_file_matches "a[^a]b", "a☺b"
-      refute_file_matches "a[^a][^a][^a]b", "a☺b"
+      refute_file_matches "a[^a]b", "a☺b"         # mulitbyte pending
+      assert_file_matches "a[^a][^a][^a]b", "a☺b" # mulitbyte pending
       assert_file_matches "[a-ζ]*", "α"
-      refute_file_matches "*[a-ζ]", "A"
+      refute_file_matches "*[a-ζ]", "A" # mulitbyte pending
     end
 
     it "escape" do
@@ -211,25 +211,14 @@ describe File do
       assert_file_matches "[\\-x]", "x"
       assert_file_matches "[\\-x]", "-"
       refute_file_matches "[\\-x]", "a"
-
-      expect_raises(File::BadPatternError, "empty character set") do
-        File.match?("[]a]", "]")
-      end
-      expect_raises(File::BadPatternError, "missing range start") do
-        File.match?("[-]", "-")
-      end
-      expect_raises(File::BadPatternError, "missing range end") do
-        File.match?("[x-]", "x")
-      end
-      expect_raises(File::BadPatternError, "missing range start") do
-        File.match?("[-x]", "x")
-      end
+      assert_file_matches "[]a]", "]"
+      assert_file_matches "[-]", "-"
+      assert_file_matches "[x-]", "x"
+      assert_file_matches "[-x]", "x"
       expect_raises(File::BadPatternError, "Empty escape character") do
         File.match?("\\", "a")
       end
-      expect_raises(File::BadPatternError, "missing range start") do
-        File.match?("[a-b-c]", "a")
-      end
+      assert_file_matches "[a-b-c]", "a"
       expect_raises(File::BadPatternError, "unterminated character set") do
         File.match?("[", "a")
       end
@@ -239,9 +228,7 @@ describe File do
       expect_raises(File::BadPatternError, "unterminated character set") do
         File.match?("[^bc", "a")
       end
-      expect_raises(File::BadPatternError, "unterminated character set") do
-        File.match?("a[", "a")
-      end
+      refute_file_matches "a[", "a"
     end
 
     it "alternates" do

--- a/spec/std/file/match_spec.cr
+++ b/spec/std/file/match_spec.cr
@@ -245,4 +245,13 @@ describe File do
       assert_file_matches "ab{{c,d}ef,}", "abdef"
     end
   end
+
+  it "fuzz tests" do
+    # https://github.com/devongovett/glob-match/issues/1
+    s = "{*{??*{??**,Uz*zz}w**{*{**a,z***b*[!}w??*azzzzzzzz*!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!z[za,z&zz}w**z*z*}"
+    refute_file_matches s, s
+    s = "**** *{*{??*{??***\u{5} *{*{??*{??***\u{5},\0U\0}]*****\u{1},\0***\0,\0\0}w****,\0U\0}]*****\u{1},\0***\0,\0\0}w*****\u{1}***{}*.*\0\0*\0"
+    # Must use `String` overload here because `Path` raises on null byte
+    File.match?(s, s).should be_false
+  end
 end

--- a/spec/std/file/match_spec.cr
+++ b/spec/std/file/match_spec.cr
@@ -36,7 +36,7 @@ describe File do
       refute_file_matches "a*b?c*x", "abxbbxdbxebxczzy"
     end
 
-    pending "multibyte" do
+    describe "multibyte" do
       it "single-character match" do
         assert_file_matches "a?b", "a☺b"
         refute_file_matches "a???b", "a☺b"
@@ -94,7 +94,7 @@ describe File do
       end
     end
 
-    pending "invalid byte sequences" do
+    describe "invalid byte sequences" do
       it "single-character with invalid path" do
         assert_file_matches "?.txt", "\xC3.txt"         # Invalid byte sequence
         refute_file_matches "?.txt", "\xC3\x28.txt"     # Invalid byte sequence
@@ -174,10 +174,10 @@ describe File do
       refute_file_matches "ab[^c]", "abc"
       refute_file_matches "ab[^b-d]", "abc"
       assert_file_matches "ab[^e-g]", "abc"
-      refute_file_matches "a[^a]b", "a☺b"         # mulitbyte pending
-      assert_file_matches "a[^a][^a][^a]b", "a☺b" # mulitbyte pending
+      assert_file_matches "a[^a]b", "a☺b"
+      refute_file_matches "a[^a][^a][^a]b", "a☺b"
       assert_file_matches "[a-ζ]*", "α"
-      refute_file_matches "*[a-ζ]", "A" # mulitbyte pending
+      refute_file_matches "*[a-ζ]", "A"
     end
 
     it "escape" do

--- a/spec/std/file/match_spec.cr
+++ b/spec/std/file/match_spec.cr
@@ -244,6 +244,18 @@ describe File do
       assert_file_matches "ab{{c,d}ef,}", "abcef"
       assert_file_matches "ab{{c,d}ef,}", "abdef"
     end
+
+    describe "brace stack" do
+      it "allows up to 10 levels" do
+        assert_file_matches "{{{{{{{{{{a},b},b},b},b},b},b},b},b},b}", "a"
+      end
+
+      it "raises at more than 10 levels" do
+        expect_raises File::BadPatternError, "Brace nesting too deep: must not exceed 10 levels" do
+          File.match? "{{{{{{{{{{{a},b},b},b},b},b},b},b},b},b},b}", "b"
+        end
+      end
+    end
   end
 
   it "fuzz tests" do

--- a/src/file/match.cr
+++ b/src/file/match.cr
@@ -284,7 +284,7 @@ class File < IO::FileDescriptor
 
             # Check if the character class is negated.
             negated_class = false
-            if @glob_index < glob.size && glob[@glob_index].in?('^'.ord, '!'.ord)
+            if @glob_index < glob.size && glob[@glob_index] === '^'
               negated_class = true
               @glob_index += 1
             end

--- a/src/file/match.cr
+++ b/src/file/match.cr
@@ -10,20 +10,18 @@ class File < IO::FileDescriptor
   #
   # The pattern syntax is similar to shell filename globbing. It may contain the following metacharacters:
   #
-  # * `*` matches an unlimited number of arbitrary characters, excluding any directory separators.
-  #   * `"*"` matches all regular files.
-  #   * `"c*"` matches all files beginning with `c`.
-  #   * `"*c"` matches all files ending with `c`.
-  #   * `"*c*"` matches all files that have `c` in them (including at the beginning or end).
-  # * `**` matches directories recursively if followed by `/`.
-  #   If this path segment contains any other characters, it is the same as the usual `*`.
-  # * `?` matches one arbitrary character, excluding any directory separators.
+  # * `*`: Wildcard matches zero or more characters, except for directory separators.
+  # * `**`: Globstar matches zero or more characters, including directory separators.
+  #   It must match a complete path segment, i.e. it must be wrapped in `/`
+  #   except for the beginning and end of the pattern.
+  # * `?`: Matches a single Unicode character, except for directory separators.
   # * character sets:
-  #   * `[abc]` matches any one of these characters.
-  #   * `[^abc]` matches any one character other than these.
-  #   * `[a-z]` matches any one character in the range.
-  # * `{a,b}` matches subpattern `a` or `b`.
-  # * `\\` escapes the next character.
+  #   * `[abc]`: Character set matches one of the Unicode characters contained in the brackets.
+  #   * `[^abc]`: Negated character set matches any Unicode character _except_ those contained in the brackes.
+  #   * `[a-z]`: Character range matches one Unicode character contained in the character range.
+  # * `{a,b}`: Branches matches one of the subpatterns contained in the braces. Subpatterns
+  #   may contain any other pattern feature, including nested branches (max nesting depth is 10 levels deep).
+  # * `\\`: Backslash escapes the next character.
   #
   # If *path* is a `Path`, all directory separators supported by *path* are
   # recognized, according to the path's kind. If *path* is a `String`, only `/`

--- a/src/file/match.cr
+++ b/src/file/match.cr
@@ -1,3 +1,7 @@
+# This implementation of glob matching for `File.match?` is a port from the Rust
+# crate https://github.com/devongovett/glob-match, which is adapted from the
+# linear-time algorithm described in https://research.swtch.com/glob
+
 class File < IO::FileDescriptor
   class BadPatternError < Exception
   end
@@ -27,9 +31,6 @@ class File < IO::FileDescriptor
   #
   # NOTE: Only `/` in *pattern* matches directory separators in *path*.
   def self.match?(pattern : String, path : Path | String) : Bool
-    expanded_patterns = [] of String
-    File.expand_brace_pattern(pattern, expanded_patterns)
-
     if path.is_a?(Path)
       separators = Path.separators(path.@kind)
       path = path.to_s
@@ -37,186 +38,368 @@ class File < IO::FileDescriptor
       separators = Path.separators(Path::Kind::POSIX)
     end
 
-    expanded_patterns.each do |expanded_pattern|
-      return true if match_single_pattern(expanded_pattern, path, separators)
-    end
-    false
+    match_internal(pattern, path, separators)
   end
 
-  private def self.match_single_pattern(pattern : String, path : String, separators)
-    # linear-time algorithm adapted from https://research.swtch.com/glob
-    preader = Char::Reader.new(pattern)
-    sreader = Char::Reader.new(path)
-    next_ppos = 0
-    next_spos = 0
-    strlen = path.bytesize
-    escaped = false
+  private def self.match_internal(glob_str, path_str, separators)
+    glob = glob_str.to_slice
+    state = State.new(separators: separators.to_static_array.to_slice)
 
-    while true
-      pnext = preader.has_next?
-      snext = sreader.has_next?
+    # Store the state when we see an opening '{' brace in a stack.
+    # Up to 10 nested braces are supported.
+    brace_stack_data = uninitialized StaticArray({UInt32, UInt32}, 10)
+    brace_stack = BraceStack.new(brace_stack_data.to_slice)
 
-      return true unless pnext || snext
+    # First, check if the pattern is negated with a leading '!' character.
+    # Multiple negations can occur.
+    negated = false
 
-      if pnext
-        pchar = preader.current_char
-        char = sreader.current_char
+    while state.glob_index < glob.size && glob[state.glob_index] === '!'
+      negated = !negated
+      state.glob_index += 1
+    end
 
-        case {pchar, escaped}
-        when {'\\', false}
-          escaped = true
-          preader.next_char
-          next
-        when {'?', false}
-          if snext && !char.in?(separators)
-            preader.next_char
-            sreader.next_char
-            next
+    matched = state.match_from(glob_str, path_str, 0, brace_stack)
+
+    matched != negated
+  end
+
+  private record State,
+    separators : Slice(Char),
+    path_index = 0_u64,
+    glob_index = 0_u64,
+    brace_depth = 0_u64,
+    wildcard = Wildcard.new,
+    globstar = Wildcard.new
+
+  private record Wildcard,
+    glob_index = 0_u32,
+    path_index = 0_u32,
+    brace_depth = 0_u32 do
+    setter path_index
+  end
+
+  struct BraceStack(T)
+    def initialize(@slice : Slice(T), @size = 0)
+    end
+
+    getter size
+
+    @[AlwaysInline]
+    def push(item : T)
+      @slice[@size] = item
+      @size += 1
+    end
+
+    @[AlwaysInline]
+    def pop : T
+      @size -= 1
+      @slice[@size]
+    end
+
+    def to_slice
+      @slice[0, @size]
+    end
+  end
+
+  struct State
+    setter glob_index
+
+    @[AlwaysInline]
+    def backtrack
+      @glob_index = @wildcard.glob_index.to_u64
+      @path_index = @wildcard.path_index.to_u64
+      @brace_depth = @wildcard.brace_depth.to_u64
+    end
+
+    # Coalesce multiple ** segments into one.
+    @[AlwaysInline]
+    private def skip_globstars(glob)
+      glob_index = @glob_index + 2
+      while glob_index + 4 <= glob.size && glob[glob_index, 4] == "/**/".to_slice
+        glob_index += 3
+      end
+
+      if glob[glob_index..] == "/**".to_slice
+        glob_index += 3
+      end
+
+      @glob_index = glob_index - 2
+    end
+
+    @[AlwaysInline]
+    def skip_to_separator(path, is_end_invalid)
+      if @path_index == path.size
+        @wildcard.path_index += 1
+        return
+      end
+
+      path_index = @path_index
+      while path_index < path.size && !separators.includes?(path[path_index].unsafe_chr)
+        path_index += 1
+      end
+
+      if is_end_invalid || path_index != path.size
+        path_index += 1
+      end
+
+      @wildcard.path_index = path_index.to_u32!
+      @globstar = @wildcard
+    end
+
+    @[AlwaysInline]
+    def skip_branch(glob)
+      in_brackets = false
+      end_brace_depth = @brace_depth - 1
+
+      while @glob_index < glob.size
+        c = glob[@glob_index]
+        # Skip nested braces.
+        if c === '{' && !in_brackets
+          @brace_depth += 1
+        elsif c === '}' && !in_brackets
+          @brace_depth -= 1
+          if @brace_depth == end_brace_depth
+            @glob_index += 1
+            return
           end
-        when {'*', false}
-          double_star = preader.peek_next_char == '*'
-          if char.in?(separators) && !double_star
-            preader.next_char
-            next_spos = 0
-            next
-          else
-            next_ppos = preader.pos
-            next_spos = sreader.pos + sreader.current_char_width
-            preader.next_char
-            preader.next_char if double_star
-            next
-          end
-        when {'[', false}
-          pnext = preader.has_next?
+        elsif c === '[' && !in_brackets
+          in_brackets = true
+        elsif c === ']'
+          in_brackets = false
+        elsif c === '\\'
+          @glob_index += 1
+        end
+        @glob_index += 1
+      end
+    end
 
-          character_matched = false
-          character_set_open = true
-          escaped = false
-          inverted = false
-          case preader.peek_next_char
-          when '^'
-            inverted = true
-            preader.next_char
-          when ']'
-            raise BadPatternError.new "Invalid character set: empty character set"
-          else
-            # Nothing
-            # TODO: check if this branch is fine
-          end
+    def match_brace_branch(
+      glob : String,
+      path : String,
+      open_brace_index,
+      branch_index,
+      brace_stack,
+    )
+      brace_stack.push({open_brace_index.to_u32!, branch_index})
 
-          while pnext
-            pchar = preader.next_char
-            case {pchar, escaped}
-            when {'\\', false}
-              escaped = true
-            when {']', false}
-              character_set_open = false
-              break
-            when {'-', false}
-              raise BadPatternError.new "Invalid character set: missing range start"
-            else
-              escaped = false
-              if preader.has_next? && preader.peek_next_char == '-'
-                preader.next_char
-                range_end = preader.next_char
-                case range_end
-                when ']'
-                  raise BadPatternError.new "Invalid character set: missing range end"
-                when '\\'
-                  range_end = preader.next_char
-                else
-                  # Nothing
-                  # TODO: check if this branch is fine
-                end
-                range = (pchar..range_end)
-                character_matched = true if range.includes?(char)
-              elsif char == pchar
-                character_matched = true
-              end
+      branch_state = self.copy_with(
+        glob_index: branch_index.to_u64,
+        brace_depth: brace_stack.size.to_u64
+      )
+
+      matched = branch_state.match_from(glob, path, branch_index, brace_stack)
+
+      brace_stack.pop
+
+      matched
+    end
+
+    def match_brace(glob : String, path : String, brace_stack)
+      brace_depth = 0
+      in_brackets = false
+      open_brace_index = @glob_index
+      branch_index = 0_u32
+
+      while @glob_index < glob.bytesize
+        c = glob.to_slice[@glob_index]
+        # Skip nested braces.
+        if c === '{' && !in_brackets
+          brace_depth += 1
+          if brace_depth == 1
+            branch_index = (@glob_index + 1).to_u32!
+          end
+        elsif c === '}' && !in_brackets
+          brace_depth -= 1
+          if brace_depth == 0
+            return true if match_brace_branch(glob, path, open_brace_index, branch_index, brace_stack)
+            break
+          end
+        elsif c === ',' && brace_depth == 1
+          return true if match_brace_branch(glob, path, open_brace_index, branch_index, brace_stack)
+          branch_index = (@glob_index + 1).to_u32!
+        elsif c === '[' && !in_brackets
+          in_brackets = true
+        elsif c === ']'
+          in_brackets = false
+        elsif c === '\\'
+          @glob_index += 1
+        end
+        @glob_index += 1
+      end
+      false
+    end
+
+    def match_from(glob_str, path_str, match_start, brace_stack)
+      glob = glob_str.to_slice
+      path = path_str.to_slice
+
+      while @glob_index < glob.size || @path_index < path.size
+        if @glob_index < glob.size
+          g = glob[@glob_index]
+          if '*' === g
+            is_globstar = @glob_index + 1 < glob.size && glob[@glob_index + 1] === '*'
+
+            if is_globstar
+              skip_globstars(glob)
             end
-            pnext = preader.has_next?
-            false
-          end
-          raise BadPatternError.new "Invalid character set: unterminated character set" if character_set_open
 
-          if character_matched != inverted && snext
-            preader.next_char
-            sreader.next_char
-            next
-          end
-        else
-          escaped = false
+            @wildcard = Wildcard.new(
+              @glob_index.to_u32!,
+              @path_index.to_u32! + 1,
+              @brace_depth.to_u32!
+            )
 
-          if snext && sreader.current_char == pchar
-            preader.next_char
-            sreader.next_char
+            in_globstar = false
+            # `**` allows path separators, whereas `*` does not.
+            # However, `**` must be a full path component, i.e. `a/**/b` not `a**b`.
+            if is_globstar
+              @glob_index += 2
+              is_end_invalid = @glob_index != glob.size
+
+              if (@glob_index.to_i64 - match_start < 3 || glob[@glob_index - 3] === '/') && (!is_end_invalid || glob[@glob_index] === '/')
+                if is_end_invalid
+                  @glob_index += 1
+                end
+
+                skip_to_separator(path, is_end_invalid)
+                in_globstar = true
+              end
+            else
+              @glob_index += 1
+            end
+
+            if !in_globstar && @path_index < path.size && separators.includes?(path[@path_index].unsafe_chr)
+              @wildcard = @globstar
+            end
+
             next
+          elsif '?' === g && @path_index < path.size
+            if !separators.includes?(path[@path_index].unsafe_chr)
+              @glob_index += 1
+              @path_index += 1
+              next
+            end
+          elsif '[' === g && @path_index < path.size
+            @glob_index += 1
+
+            # Check if the character class is negated.
+            negated_class = false
+            if @glob_index < glob.size && glob[@glob_index].in?('^'.ord, '!'.ord)
+              negated_class = true
+              @glob_index += 1
+            end
+
+            # Try each range.
+            first = true
+            is_match = false
+
+            c = path[@path_index]
+
+            while @glob_index < glob.size && (first || !(']' === glob[@glob_index]))
+              low = glob[@glob_index]
+              if !unescape(pointerof(low), glob, pointerof(@glob_index))
+                raise File::BadPatternError.new("Invalid pattern")
+              end
+              @glob_index += 1
+
+              # If there is a - and the following character is not ], read the range end character.
+              if @glob_index + 1 < glob.size &&
+                 glob[@glob_index] === '-' &&
+                 !(glob[@glob_index + 1] === ']')
+                @glob_index += 1
+                high = glob[@glob_index]
+                if !unescape(pointerof(high), glob, pointerof(@glob_index))
+                  raise File::BadPatternError.new("Invalid pattern")
+                end
+                @glob_index += 1
+              else
+                high = low
+              end
+
+              if low <= c <= high
+                is_match = true
+              end
+
+              first = false
+            end
+            if @glob_index >= glob.size
+              raise BadPatternError.new "unterminated character set"
+            end
+            @glob_index += 1
+            if is_match != negated_class
+              @path_index += 1
+              next
+            end
+          elsif g === '{'
+            if brace_stack_entry = brace_stack.to_slice.find { |open_brace_index, _| open_brace_index == @glob_index }
+              _, branch_index = brace_stack_entry
+              @glob_index = branch_index.to_u64
+              @brace_depth += 1
+              next
+            end
+
+            return match_brace(glob_str, path_str, brace_stack)
+          elsif (g === '}' || g === ',') && @brace_depth > 0
+            skip_branch(glob)
+            next
+          elsif @path_index < path.size
+            c = g
+            # Match escaped characters as literals.
+            if !unescape(pointerof(c), glob, pointerof(@glob_index))
+              raise BadPatternError.new "Empty escape character"
+            end
+
+            is_match = if c === '/'
+                         separators.includes?(path[@path_index].unsafe_chr)
+                       else
+                         path[@path_index] == c
+                       end
+
+            if is_match
+              @glob_index += 1
+              @path_index += 1
+
+              if c === '/'
+                @wildcard = @globstar
+              end
+
+              next
+            end
           end
         end
+
+        # If we didn't match, restore state to the previous star pattern.
+        if @wildcard.path_index > 0 && @wildcard.path_index.to_u32! <= path.size
+          backtrack
+          next
+        end
+
+        return false
       end
 
-      if 0 < next_spos <= strlen
-        preader.pos = next_ppos
-        sreader.pos = next_spos
-        next
-      end
+      true
+    end
+  end
+end
 
-      raise BadPatternError.new "Empty escape character" if escaped
-
+@[AlwaysInline]
+private def unescape(c, glob, glob_index) : Bool
+  if '\\' === c.value
+    glob_index.value += 1
+    if glob_index.value >= glob.size
+      # Invalid pattern!
       return false
     end
+    c.value = case escaped_char = glob[glob_index.value]
+              when 'a' then 0x61_u8
+              when 'b' then 0x08_u8
+              when 'n' then '\n'.ord.to_u8!
+              when 'r' then '\r'.ord.to_u8!
+              when 't' then '\t'.ord.to_u8!
+              else          escaped_char
+              end
   end
 
-  # :nodoc:
-  def self.expand_brace_pattern(pattern : String, expanded) : Array(String)?
-    reader = Char::Reader.new(pattern)
-
-    lbrace = nil
-    rbrace = nil
-    alt_start = nil
-
-    alternatives = [] of String
-
-    nest = 0
-    escaped = false
-    reader.each do |char|
-      case {char, escaped}
-      when {'{', false}
-        lbrace = reader.pos if nest == 0
-        nest += 1
-      when {'}', false}
-        nest -= 1
-
-        if nest == 0
-          rbrace = reader.pos
-          start = (alt_start || lbrace).not_nil! + 1
-          alternatives << pattern.byte_slice(start, reader.pos - start)
-          break
-        end
-      when {',', false}
-        if nest == 1
-          start = (alt_start || lbrace).not_nil! + 1
-          alternatives << pattern.byte_slice(start, reader.pos - start)
-          alt_start = reader.pos
-        end
-      when {'\\', false}
-        escaped = true
-      else
-        escaped = false
-      end
-    end
-
-    if lbrace && rbrace
-      front = pattern.byte_slice(0, lbrace)
-      back = pattern.byte_slice(rbrace + 1)
-
-      alternatives.each do |alt|
-        brace_pattern = {front, alt, back}.join
-
-        expand_brace_pattern brace_pattern, expanded
-      end
-    else
-      expanded << pattern
-    end
-  end
+  true
 end

--- a/src/file/match.cr
+++ b/src/file/match.cr
@@ -54,10 +54,11 @@ class File < IO::FileDescriptor
     # Multiple negations can occur.
     negated = false
 
-    while state.glob_index < glob.size && glob[state.glob_index] === '!'
-      negated = !negated
-      state.glob_index += 1
-    end
+    # TODO: Enable negation
+    # while state.glob_index < glob.size && glob[state.glob_index] === '!'
+    #   negated = !negated
+    #   state.glob_index += 1
+    # end
 
     matched = state.match_from(glob_str, path_str, 0, brace_stack)
 
@@ -103,8 +104,6 @@ class File < IO::FileDescriptor
   end
 
   struct State
-    setter glob_index
-
     @[AlwaysInline]
     def backtrack
       @glob_index = @wildcard.glob_index.to_u64

--- a/src/file/match.cr
+++ b/src/file/match.cr
@@ -15,13 +15,17 @@ class File < IO::FileDescriptor
   #   It must match a complete path segment, i.e. it must be wrapped in `/`
   #   except for the beginning and end of the pattern.
   # * `?`: Matches a single Unicode character, except for directory separators.
-  # * character sets:
+  # * Character classes:
   #   * `[abc]`: Character set matches one of the Unicode characters contained in the brackets.
-  #   * `[^abc]`: Negated character set matches any Unicode character _except_ those contained in the brackes.
+  #   * `[^abc]`: Negated character set matches any Unicode character _except_ those contained in the brackets.
   #   * `[a-z]`: Character range matches one Unicode character contained in the character range.
+  #   * `[^a-z]`: Negated character range matches one Unicode character _except_ those contained in the character range.
   # * `{a,b}`: Branches matches one of the subpatterns contained in the braces. Subpatterns
   #   may contain any other pattern feature, including nested branches (max nesting depth is 10 levels deep).
   # * `\\`: Backslash escapes the next character.
+  #
+  # Multiple character pattern can be combined in the same brackets to define a
+  # character class (for example: `[0-9a-f]`).
   #
   # If *path* is a `Path`, all directory separators supported by *path* are
   # recognized, according to the path's kind. If *path* is a `String`, only `/`

--- a/src/file/match.cr
+++ b/src/file/match.cr
@@ -86,7 +86,10 @@ class File < IO::FileDescriptor
 
     @[AlwaysInline]
     def push(item : T)
-      @slice[@size] = item
+      if @size >= @slice.size
+        raise BadPatternError.new("Brace nesting too deep: must not exceed 10 levels")
+      end
+      @slice.unsafe_put(@size, item)
       @size += 1
     end
 


### PR DESCRIPTION
This is a complete rewrite of `File.match?`, necessary to fix some serious shortcomings, as explained in #15319.

The implementation is ported from the Rust crate https://github.com/oxc-project/fast-glob. It is based on the same [linear-time algorithm](https://research.swtch.com/glob) as our old implementation, but implements backtracking, which is necessary to properly handle patterns with multiple wildcards or globstars (#15319).

It comes with a big test suite, and together with our existing tests I'm pretty confident of its soundness.

There is some divergence from the current implementation, of course. But I've made sure to keep it minimal.

### Changes from previous Crystal implementation

Most impactful is fixing the incorrect behaviour, which of course leads to differences. This part is inevitable.
This new implementation fixes several bugs in pattern matching. This may break use cases which (perhaps inadvertently) relied on the buggy behaviour.

There are some debatable edge cases, however. For example, `a**` no longer matches `ab/c`. The documentation already claimed this to be the case. And it's in accordance to most other libraries (see [comparison table](https://github.com/crystal-lang/crystal/issues/15319#issuecomment-2734626671)). I believe this is generally the more sensible and expected behaviour. So it seems to be the right thing to do, but it's still breaking.

The new algorithm is more lenient when parsing character ranges, for example it accepts `[-]` as a character set. Previously, this was considered a pattern error (incomplete range) and raised an exception. So we're going from an error to defined behaviour.
This is a breaking change in behaviour. But I believe it is a good one and the result is more sensible and matches that of other implementations.
But of course this could be debatable. We could bring back the old behaviour.

I'm not aware of any other breaking changes in the new implementation.
All known behaviour changes are all documented in the spec diff.
I explain more details in https://github.com/crystal-lang/crystal/issues/15319#issuecomment-2757497875 and we can discuss these changes there.

### Changes from fast-glob

The fast-glob does not support UTF-8 decoding, which our current implementation does. So I integrated that into the new algorithm. UTF-8 awareness is only necessary for single char ( `?`) and character set/range (`[a]`, `[a-b]`) patterns. In all other situations, it really doesn't matter whether a byte is a part of a multibyte character or not.
So the matching is generally byte-oriented and only decodes UTF-8 when necessary.

I have explicitly disabled some features of the original Rust implementation because they are breaking changes in the pattern language with respect to our previous implementation:

* Pattern negation: A pattern starting with `!` would be negated.
* Character set negation with `!` or `^` (only the latter is supported in Crystal).

We can consider adding these back later on. The implementation is trivial. But it should be a separate decision to do that.

Fixes https://github.com/crystal-lang/crystal/issues/15319
Depends on #15604, https://github.com/crystal-lang/crystal/pull/15601