### PR TITLE
Add `LLVM::CodeModel::Tiny`

### DIFF
--- a/doc/man/crystal-build.adoc
+++ b/doc/man/crystal-build.adoc
@@ -61,7 +61,7 @@ whether SIMD operations are enabled or not. The default set of
 attributes is set by the current CPU. This will pass a -mattr
 flag to LLVM, and is only intended to be used for cross-compilation. For a list of available attributes, invoke "llvm-as <
 /dev/null | llc -march=xyz -mattr=help".
-*--mcmodel* default|kernel|small|medium|large::
+*--mcmodel* default|kernel|tiny|small|medium|large::
 Specifies a specific code model to generate code for. This will
 pass a --code-model flag to LLVM.
 *--no-color*::

--- a/man/crystal.1
+++ b/man/crystal.1
@@ -212,7 +212,7 @@ flag to LLVM, and is only intended to be used for cross\-compilation. For a list
 /dev/null | llc \-march=xyz \-mattr=help".
 .RE
 .sp
-\fB\-\-mcmodel\fP default|kernel|small|medium|large
+\fB\-\-mcmodel\fP default|kernel|tiny|small|medium|large
 .RS 4
 Specifies a specific code model to generate code for. This will
 pass a \-\-code\-model flag to LLVM.

--- a/src/compiler/crystal/command.cr
+++ b/src/compiler/crystal/command.cr
@@ -707,12 +707,13 @@ class Crystal::Command
     opts.on("--mcmodel MODEL", "Target specific code model") do |mcmodel|
       compiler.mcmodel = case mcmodel
                          when "default" then LLVM::CodeModel::Default
+                         when "tiny"    then LLVM::CodeModel::Tiny
                          when "small"   then LLVM::CodeModel::Small
                          when "kernel"  then LLVM::CodeModel::Kernel
                          when "medium"  then LLVM::CodeModel::Medium
                          when "large"   then LLVM::CodeModel::Large
                          else
-                           error "--mcmodel should be one of: default, kernel, small, medium, large"
+                           error "--mcmodel should be one of: default, kernel, tiny, small, medium, large"
                            raise "unreachable"
                          end
     end

--- a/src/llvm/enums.cr
+++ b/src/llvm/enums.cr
@@ -292,6 +292,7 @@ module LLVM
   enum CodeModel
     Default
     JITDefault
+    Tiny
     Small
     Kernel
     Medium


### PR DESCRIPTION
This member has been present since LLVM 8 for AArch64, which means every non-default setting was previously off by one in Crystal.