### PR TITLE
Extract `Exception::CallStack.decode_backtrace_frame` helper

### DIFF
--- a/src/exception/call_stack.cr
+++ b/src/exception/call_stack.cr
@@ -47,60 +47,65 @@ struct Exception::CallStack
       show_full_info = ENV["CRYSTAL_CALLSTACK_FULL_INFO"]? == "1"
 
       @callstack.compact_map do |ip|
-        pc = CallStack.decode_address(ip)
-
-        file, line_number, column_number = CallStack.decode_line_number(pc)
-
-        if file && file != "??"
-          next if @@skip.includes?(file)
-
-          # Turn to relative to the current dir, if possible
-          if current_dir = CURRENT_DIR
-            if rel = Path[file].relative_to?(current_dir)
-              rel = rel.to_s
-              file = rel unless rel.starts_with?("..")
-            end
-          end
-
-          file_line_column = file
-          unless line_number == 0
-            file_line_column = "#{file_line_column}:#{line_number}"
-            file_line_column = "#{file_line_column}:#{column_number}" unless column_number == 0
-          end
-        end
-
-        if name = CallStack.decode_function_name(pc)
-          function = name
-        elsif frame = CallStack.decode_frame(ip)
-          _, function, file = frame
-          # Crystal methods (their mangled name) start with `*`, so
-          # we remove that to have less clutter in the output.
-          function = function.lchop('*')
-        else
-          function = "??"
-        end
-
-        if file_line_column
-          if show_full_info && (frame = CallStack.decode_frame(ip))
-            _, sname, _ = frame
-            line = "#{file_line_column} in '#{sname}'"
-          else
-            line = "#{file_line_column} in '#{function}'"
-          end
-        else
-          if file == "??" && function == "??"
-            line = "???"
-          else
-            line = "#{file} in '#{function}'"
-          end
-        end
-
-        if show_full_info
-          line = "#{line} at 0x#{ip.address.to_s(16)}"
-        end
-
-        line
+        CallStack.decode_backtrace_frame(ip, show_full_info)
       end
     {% end %}
+  end
+
+  # :nodoc:
+  def self.decode_backtrace_frame(ip, show_full_info) : String?
+    pc = decode_address(ip)
+
+    file, line_number, column_number = decode_line_number(pc)
+
+    if file && file != "??"
+      return if @@skip.includes?(file)
+
+      # Turn to relative to the current dir, if possible
+      if current_dir = CURRENT_DIR
+        if rel = Path[file].relative_to?(current_dir)
+          rel = rel.to_s
+          file = rel unless rel.starts_with?("..")
+        end
+      end
+
+      file_line_column = file
+      unless line_number == 0
+        file_line_column = "#{file_line_column}:#{line_number}"
+        file_line_column = "#{file_line_column}:#{column_number}" unless column_number == 0
+      end
+    end
+
+    if name = decode_function_name(pc)
+      function = name
+    elsif frame = decode_frame(ip)
+      _, function, file = frame
+      # Crystal methods (their mangled name) start with `*`, so
+      # we remove that to have less clutter in the output.
+      function = function.lchop('*')
+    else
+      function = "??"
+    end
+
+    if file_line_column
+      if show_full_info && (frame = decode_frame(ip))
+        _, sname, _ = frame
+        line = "#{file_line_column} in '#{sname}'"
+      else
+        line = "#{file_line_column} in '#{function}'"
+      end
+    else
+      if file == "??" && function == "??"
+        line = "???"
+      else
+        line = "#{file} in '#{function}'"
+      end
+    end
+
+    if show_full_info
+      line = "#{line} at 0x#{ip.address.to_s(16)}"
+    end
+
+    line
   end
 end


### PR DESCRIPTION
Internal refactor: allows to generate a decoded backtrace for any given instruction pointer, without requiring an `Array` or an `Exception::CallStack` object.

My use case is https://github.com/crystal-lang/perf-tools/pull/27 where I use slices and where I could merely call this helper method.