### PR TITLE
Add `Time.month_week_date`

### DIFF
--- a/spec/std/time/time_spec.cr
+++ b/spec/std/time/time_spec.cr
@@ -961,10 +961,10 @@ describe Time do
     end
 
     it "raises on invalid week or day of week" do
-      expect_raises(ArgumentError) { Time.month_week_date(2025, 1, 0, Time::DayOfWeek::Monday) }
-      expect_raises(ArgumentError) { Time.month_week_date(2025, 1, 6, Time::DayOfWeek::Monday) }
-      expect_raises(ArgumentError) { Time.month_week_date(2025, 1, 1, -1) }
-      expect_raises(ArgumentError) { Time.month_week_date(2025, 1, 1, 8) }
+      expect_raises(Exception) { Time.month_week_date(2025, 1, 0, Time::DayOfWeek::Monday) }
+      expect_raises(Exception) { Time.month_week_date(2025, 1, 6, Time::DayOfWeek::Monday) }
+      expect_raises(Exception) { Time.month_week_date(2025, 1, 1, -1) }
+      expect_raises(Exception) { Time.month_week_date(2025, 1, 1, 8) }
     end
   end
 

--- a/spec/std/time/time_spec.cr
+++ b/spec/std/time/time_spec.cr
@@ -928,6 +928,46 @@ describe Time do
     end
   end
 
+  describe ".month_week_date" do
+    it "works with DayOfWeek" do
+      Time.month_week_date(2025, 4, 1, Time::DayOfWeek::Tuesday, location: Time::Location::UTC).should eq(Time.utc(2025, 4, 1))
+      Time.month_week_date(2025, 4, 1, Time::DayOfWeek::Sunday, location: Time::Location::UTC).should eq(Time.utc(2025, 4, 6))
+      Time.month_week_date(2025, 4, 1, Time::DayOfWeek::Monday, location: Time::Location::UTC).should eq(Time.utc(2025, 4, 7))
+      Time.month_week_date(2025, 4, 2, Time::DayOfWeek::Wednesday, location: Time::Location::UTC).should eq(Time.utc(2025, 4, 9))
+      Time.month_week_date(2025, 4, 5, Time::DayOfWeek::Thursday, location: Time::Location::UTC).should eq(Time.utc(2025, 4, 24))
+      Time.month_week_date(2025, 2, 5, Time::DayOfWeek::Saturday, location: Time::Location::UTC).should eq(Time.utc(2025, 2, 22))
+    end
+
+    it "works with integer day of week" do
+      Time.month_week_date(2025, 4, 1, 2, location: Time::Location::UTC).should eq(Time.utc(2025, 4, 1))
+      Time.month_week_date(2025, 4, 1, 7, location: Time::Location::UTC).should eq(Time.utc(2025, 4, 6))
+      Time.month_week_date(2025, 4, 1, 0, location: Time::Location::UTC).should eq(Time.utc(2025, 4, 6))
+      Time.month_week_date(2025, 4, 1, 1, location: Time::Location::UTC).should eq(Time.utc(2025, 4, 7))
+      Time.month_week_date(2025, 4, 2, 3, location: Time::Location::UTC).should eq(Time.utc(2025, 4, 9))
+      Time.month_week_date(2025, 4, 5, 4, location: Time::Location::UTC).should eq(Time.utc(2025, 4, 24))
+      Time.month_week_date(2025, 2, 5, 6, location: Time::Location::UTC).should eq(Time.utc(2025, 2, 22))
+    end
+
+    it "accepts time arguments" do
+      with_zoneinfo do
+        location = Time::Location.load("Europe/Berlin")
+        Time.month_week_date(2025, 3, 3, 7, 11, 57, 32, nanosecond: 123_567, location: location).should eq(
+          Time.local(2025, 3, 16, 11, 57, 32, nanosecond: 123_567, location: location))
+
+        location = Time::Location.load("America/Buenos_Aires")
+        Time.month_week_date(2025, 3, 3, 7, 11, 57, 32, nanosecond: 123_567, location: location).should eq(
+          Time.local(2025, 3, 16, 11, 57, 32, nanosecond: 123_567, location: location))
+      end
+    end
+
+    it "raises on invalid week or day of week" do
+      expect_raises(ArgumentError) { Time.month_week_date(2025, 1, 0, Time::DayOfWeek::Monday) }
+      expect_raises(ArgumentError) { Time.month_week_date(2025, 1, 6, Time::DayOfWeek::Monday) }
+      expect_raises(ArgumentError) { Time.month_week_date(2025, 1, 1, -1) }
+      expect_raises(ArgumentError) { Time.month_week_date(2025, 1, 1, 8) }
+    end
+  end
+
   typeof(Time.local.year)
   typeof(1.minute.from_now.year)
   typeof(1.minute.ago.year)

--- a/src/crystal/system/win32/time.cr
+++ b/src/crystal/system/win32/time.cr
@@ -159,32 +159,16 @@ module Crystal::System::Time
     # wDayOfWeek is appropriate weekday (Sunday=0 to Saturday=6)
     # wDay is week within the month (1 to 5, where 5 is last week of the month)
     # wHour, wMinute and wSecond are absolute time
-    day = 1
-
-    time = ::Time.utc(year, systemtime.wMonth.to_i32, day, systemtime.wHour.to_i32, systemtime.wMinute.to_i32, systemtime.wSecond.to_i32)
-    i = systemtime.wDayOfWeek.to_i32 - (time.day_of_week.to_i32 % 7)
-
-    if i < 0
-      i += 7
-    end
-
-    day += i
-
-    week = systemtime.wDay - 1
-
-    if week < 4
-      day += week * 7
-    else
-      # "Last" instance of the day.
-      day += 4 * 7
-      if day > ::Time.days_in_month(year, systemtime.wMonth)
-        day -= 7
-      end
-    end
-
-    time += (day - 1).days
-
-    time.to_unix
+    ::Time.month_week_date(
+      year,
+      systemtime.wMonth.to_i32,
+      systemtime.wDay.to_i32,
+      systemtime.wDayOfWeek.to_i32,
+      systemtime.wHour.to_i32,
+      systemtime.wMinute.to_i32,
+      systemtime.wSecond.to_i32,
+      location: ::Time::Location::UTC,
+    ).to_unix
   end
 
   # Normalizes the names of the standard and dst zones.

--- a/src/time.cr
+++ b/src/time.cr
@@ -939,7 +939,7 @@ struct Time
   # * `day_of_week`: `0..7`
   def self.month_week_date(year : Int32, month : Int32, week : Int32, day_of_week : Int32 | DayOfWeek, hour : Int32 = 0, minute : Int32 = 0, second : Int32 = 0, *, nanosecond : Int32 = 0, location : Location = Location.local) : self
     raise ArgumentError.new "Invalid week of month" unless week.in?(1..5)
-    raise ArgumentError.new "Invalid day of week" if day_of_week.is_a?(Int32) && !day_of_week.in?(0..7)
+    day_of_week = DayOfWeek.from_value(day_of_week) if day_of_week.is_a?(Int32)
 
     day_of_week = day_of_week.to_i32
     first_day_of_week = Time.utc(year, month, 1).day_of_week.to_i32


### PR DESCRIPTION
This function returns a `Time` instance using a given month, week of month, and day of week. It is similar to the existing `.week_date`, except the week number is relative to the given month, not the beginning of the given year (or the end of the previous year).

Windows time zone transitions are specified in this manner, as are the [`M` dates of POSIX `TZ` strings](https://pubs.opengroup.org/onlinepubs/9799919799/basedefs/V1_chap08.html).