### PR TITLE
Add `XML.libxml2_version`

### DIFF
--- a/spec/std/xml/xml_spec.cr
+++ b/spec/std/xml/xml_spec.cr
@@ -609,4 +609,8 @@ describe XML do
       end.should eq %[<foo><bar/></foo>\n]
     end
   end
+
+  it ".libxml2_version" do
+    XML.libxml2_version.should match /2\.\d+\.\d+/
+  end
 end

--- a/src/xml.cr
+++ b/src/xml.cr
@@ -125,6 +125,17 @@ module XML
       ptr.value = old
     end
   end
+
+  class_getter libxml2_version : String do
+    version_string = String.new(LibXML.xmlParserVersion)
+
+    # The version string can contain extra information after the version number,
+    # so we ignore any trailing non-numbers with `strict: false`
+    number = version_string.to_i(strict: false)
+
+    # Construct a formatted version string
+    "#{number // 10_000}.#{number % 10_000 // 100}.#{number % 100}"
+  end
 end
 
 require "./xml/*"

--- a/src/xml/libxml2.cr
+++ b/src/xml/libxml2.cr
@@ -16,6 +16,8 @@ require "./save_options"
 lib LibXML
   alias Int = LibC::Int
 
+  $xmlParserVersion : LibC::Char*
+
   fun xmlInitParser
 
   fun __xmlIndentTreeOutput : Int*


### PR DESCRIPTION
As discussed in #13273, we're missing a consistent format for exposing version information.
Returning the version number formatted as string seems the most expected variant though.

We might consider adding extra information as well, but I'm not sure about that.