### PR TITLE
Make `Enum.from_value` raise `ArgumentError` instead of `Exception`

### DIFF
--- a/spec/std/enum_spec.cr
+++ b/spec/std/enum_spec.cr
@@ -264,7 +264,7 @@ describe Enum do
       SpecEnum.from_value(0).should eq(SpecEnum::One)
       SpecEnum.from_value(1).should eq(SpecEnum::Two)
       SpecEnum.from_value(2).should eq(SpecEnum::Three)
-      expect_raises(Exception, "Unknown enum SpecEnum value: 3") { SpecEnum.from_value(3) }
+      expect_raises(ArgumentError, "Unknown enum SpecEnum value: 3") { SpecEnum.from_value(3) }
     end
 
     it "for flags enum" do
@@ -272,7 +272,7 @@ describe Enum do
       SpecEnumFlags.from_value(1).should eq(SpecEnumFlags::One)
       SpecEnumFlags.from_value(2).should eq(SpecEnumFlags::Two)
       SpecEnumFlags.from_value(3).should eq(SpecEnumFlags::One | SpecEnumFlags::Two)
-      expect_raises(Exception, "Unknown enum SpecEnumFlags value: 8") { SpecEnumFlags.from_value(8) }
+      expect_raises(ArgumentError, "Unknown enum SpecEnumFlags value: 8") { SpecEnumFlags.from_value(8) }
     end
 
     it "for private enum" do

--- a/src/enum.cr
+++ b/src/enum.cr
@@ -446,10 +446,10 @@ abstract struct Enum
   # Color.from_value(0) # => Color::Red
   # Color.from_value(1) # => Color::Green
   # Color.from_value(2) # => Color::Blue
-  # Color.from_value(3) # raises Exception
+  # Color.from_value(3) # raises ArgumentError
   # ```
   def self.from_value(value : Int) : self
-    from_value?(value) || raise "Unknown enum #{self} value: #{value}"
+    from_value?(value) || raise ArgumentError.new("Unknown enum #{self} value: #{value}")
   end
 
   # Returns `true` if the given *value* is an enum member, otherwise `false`.


### PR DESCRIPTION
Aligns the exception type with the similar `Enum.parse`.