### PR TITLE
Replace deprecated `LibXML.xmlGcMemSetup` with `.xmlMemSetup`

### DIFF
--- a/src/xml/libxml2.cr
+++ b/src/xml/libxml2.cr
@@ -149,11 +149,15 @@ lib LibXML
   fun xmlNodeSetName(node : Node*, name : UInt8*)
   fun xmlUnlinkNode(node : Node*)
 
-  fun xmlGcMemSetup(free_func : Void* ->,
-                    malloc_func : LibC::SizeT -> Void*,
-                    malloc_atomic_func : LibC::SizeT -> Void*,
-                    realloc_func : Void*, LibC::SizeT -> Void*,
-                    strdup_func : UInt8* -> UInt8*) : Int
+  alias FreeFunc = Void* ->
+  alias MallocFunc = LibC::SizeT -> Void*
+  alias ReallocFunc = Void*, LibC::SizeT -> Void*
+  alias StrdupFunc = UInt8* -> UInt8*
+
+  fun xmlMemSetup(freeFunc : FreeFunc,
+                  mallocFunc : MallocFunc,
+                  reallocFunc : ReallocFunc,
+                  strdupFunc : StrdupFunc) : Int
 
   alias OutputWriteCallback = (Void*, UInt8*, Int) -> Int
   alias OutputCloseCallback = (Void*) -> Int
@@ -326,15 +330,9 @@ end
 
 LibXML.xmlInitParser
 
-LibXML.xmlGcMemSetup(
+LibXML.xmlMemSetup(
   ->GC.free,
   ->GC.malloc(LibC::SizeT),
-  # TODO(interpreted): remove this condition
-  {% if flag?(:interpreted) %}
-    ->GC.malloc(LibC::SizeT)
-  {% else %}
-    ->GC.malloc_atomic(LibC::SizeT)
-  {% end %},
   ->GC.realloc(Void*, LibC::SizeT),
   ->(str) {
     len = LibC.strlen(str) + 1


### PR DESCRIPTION
`xmlGcMemSetup` has been deprecated in libxml2 2.14 and should be replaced by `xmlMemSetup` (available since 2.0.0)

https://gitlab.gnome.org/GNOME/libxml2/-/commit/5d36664fc91d44f1fc8426a7db6ec2400280d54c

This removes support for atomic memory allocation in libxml2, which might potentially affect GC performance.
