### PR TITLE
Enable interpreter integration test for XML

### DIFF
--- a/spec/compiler/interpreter/integration_spec.cr
+++ b/spec/compiler/interpreter/integration_spec.cr
@@ -113,7 +113,7 @@ describe Crystal::Repl::Interpreter do
       CRYSTAL
     end
 
-    pending "does XML" do
+    it "does XML" do
       interpret(<<-CRYSTAL, prelude: "prelude").should eq("3")
         require "xml"
 


### PR DESCRIPTION
This spec seems to be working, maybe whatever was holding it back got fixed at some point.