### PR TITLE
Fix `libgc` pkg-config name for version discovery

### DIFF
--- a/src/gc/boehm.cr
+++ b/src/gc/boehm.cr
@@ -50,7 +50,8 @@ require "crystal/tracing"
 {% end %}
 lib LibGC
   {% unless flag?(:win32) %}
-    VERSION = {{ `pkg-config bdw-gc --silence-errors --modversion || printf "0.0.0"`.chomp.stringify }}
+    {% pkg_config_name = ((ann = LibGC.annotations.find(&.["pkg_config"])) && ann["pkg_config"]) || ((ann = LibGC.annotations.find(&.[0])) && ann[0]) %}
+    VERSION = {{ `pkg-config #{pkg_config_name} --silence-errors --modversion || printf "0.0.0"`.chomp.stringify }}
   {% end %}
 
   alias Int = LibC::Int

--- a/src/gc/boehm.cr
+++ b/src/gc/boehm.cr
@@ -50,7 +50,7 @@ require "crystal/tracing"
 {% end %}
 lib LibGC
   {% unless flag?(:win32) %}
-    {% pkg_config_name = ((ann = LibGC.annotations.find(&.["pkg_config"])) && ann["pkg_config"]) || ((ann = LibGC.annotations.find(&.[0])) && ann[0]) %}
+    {% pkg_config_name = ((ann = LibGC.annotations(Link).find(&.["pkg_config"])) && ann["pkg_config"]) || ((ann = LibGC.annotations(Link).find(&.[0])) && ann[0]) %}
     VERSION = {{ `pkg-config #{pkg_config_name} --silence-errors --modversion || printf "0.0.0"`.chomp.stringify }}
   {% end %}
 


### PR DESCRIPTION
We define different names for pkg-config in the `Link` annotations of `LibGC` depending on target, but used a fixed name in version discovery.
This patch re-uses the name declared in the annotation. We need to filter for the appropriate annotation because there are multiple ones. Unfortunately, I haven't found an easier way to do this.