### PR TITLE
Add explicit `Crystal::EventLoop#reopened(FileDescriptor)` hook

### DIFF
--- a/src/crystal/event_loop/file_descriptor.cr
+++ b/src/crystal/event_loop/file_descriptor.cr
@@ -23,6 +23,11 @@ abstract class Crystal::EventLoop
     # Blocks the current fiber until the file descriptor is ready for write.
     abstract def wait_writable(file_descriptor : Crystal::System::FileDescriptor) : Nil
 
+    # Hook to react on the file descriptor after it has been reopened. For
+    # example we might want to resume all pending operations to act on the new
+    # file descriptor.
+    abstract def reopened(file_descriptor : Crystal::System::FileDescriptor) : Nil
+
     # Closes the file descriptor resource.
     abstract def close(file_descriptor : Crystal::System::FileDescriptor) : Nil
   end

--- a/src/crystal/event_loop/iocp.cr
+++ b/src/crystal/event_loop/iocp.cr
@@ -238,6 +238,10 @@ class Crystal::EventLoop::IOCP < Crystal::EventLoop
     raise NotImplementedError.new("Crystal::System::IOCP#wait_writable(FileDescriptor)")
   end
 
+  def reopened(file_descriptor : Crystal::System::FileDescriptor) : Nil
+    raise NotImplementedError.new("Crystal::System::IOCP#reopened(FileDescriptor)")
+  end
+
   def close(file_descriptor : Crystal::System::FileDescriptor) : Nil
     LibC.CancelIoEx(file_descriptor.windows_handle, nil) unless file_descriptor.system_blocking?
   end

--- a/src/crystal/event_loop/libevent.cr
+++ b/src/crystal/event_loop/libevent.cr
@@ -140,6 +140,10 @@ class Crystal::EventLoop::LibEvent < Crystal::EventLoop
     end
   end
 
+  def reopened(file_descriptor : Crystal::System::FileDescriptor) : Nil
+    file_descriptor.evented_close
+  end
+
   def close(file_descriptor : Crystal::System::FileDescriptor) : Nil
     file_descriptor.evented_close
   end

--- a/src/crystal/event_loop/polling.cr
+++ b/src/crystal/event_loop/polling.cr
@@ -185,6 +185,10 @@ abstract class Crystal::EventLoop::Polling < Crystal::EventLoop
     end
   end
 
+  def reopened(file_descriptor : System::FileDescriptor) : Nil
+    evented_close(file_descriptor)
+  end
+
   def close(file_descriptor : System::FileDescriptor) : Nil
     evented_close(file_descriptor)
   end

--- a/src/crystal/event_loop/wasi.cr
+++ b/src/crystal/event_loop/wasi.cr
@@ -60,6 +60,10 @@ class Crystal::EventLoop::Wasi < Crystal::EventLoop
     end
   end
 
+  def reopened(file_descriptor : Crystal::System::FileDescriptor) : Nil
+    raise NotImplementedError.new("Crystal::EventLoop#reopened(FileDescriptor)")
+  end
+
   def close(file_descriptor : Crystal::System::FileDescriptor) : Nil
     file_descriptor.evented_close
   end

--- a/src/crystal/system/unix/file_descriptor.cr
+++ b/src/crystal/system/unix/file_descriptor.cr
@@ -109,7 +109,7 @@ module Crystal::System::FileDescriptor
     # Mark the handle open, since we had to have dup'd a live handle.
     @closed = false
 
-    event_loop.close(self)
+    event_loop.reopened(self)
   end
 
   private def system_close


### PR DESCRIPTION
We don't want to _close_ the file descriptor after we reopened it. Instead, some event loops want to resume the pending operations on the old file descriptor, so they can be restarted on the new file descriptor and at worst wait on the new one.

The proposed `#reopened(FileDescriptor)` method explicits this difference in intended behavior.

It doesn't change anything for the current event loops, but io_uring for example can close asynchronously so we must make the distinction, because we definitely don't want to close after reopen :sweat_smile: 

Another pull request will propose to move the actual close to the EventLoop so the `#close(io)` method will do what it's supposed to do (close the FileDescriptor / Socket).

Extracted from #15634 