### PR TITLE
Let `Crystal::EventLoop#close` do the actual close (not just cleanup)

### DIFF
--- a/src/crystal/event_loop/iocp.cr
+++ b/src/crystal/event_loop/iocp.cr
@@ -244,6 +244,7 @@ class Crystal::EventLoop::IOCP < Crystal::EventLoop
 
   def close(file_descriptor : Crystal::System::FileDescriptor) : Nil
     LibC.CancelIoEx(file_descriptor.windows_handle, nil) unless file_descriptor.system_blocking?
+    file_descriptor.file_descriptor_close
   end
 
   private def wsa_buffer(bytes)
@@ -369,5 +370,6 @@ class Crystal::EventLoop::IOCP < Crystal::EventLoop
   end
 
   def close(socket : ::Socket) : Nil
+    raise NotImplementedError.new("Crystal::System::IOCP#close(Socket)")
   end
 end

--- a/src/crystal/event_loop/libevent.cr
+++ b/src/crystal/event_loop/libevent.cr
@@ -145,7 +145,10 @@ class Crystal::EventLoop::LibEvent < Crystal::EventLoop
   end
 
   def close(file_descriptor : Crystal::System::FileDescriptor) : Nil
+    # perform cleanup before LibC.close. Using a file descriptor after it has
+    # been closed is never defined and can always lead to undefined results
     file_descriptor.evented_close
+    file_descriptor.file_descriptor_close
   end
 
   def read(socket : ::Socket, slice : Bytes) : Int32
@@ -250,7 +253,10 @@ class Crystal::EventLoop::LibEvent < Crystal::EventLoop
   end
 
   def close(socket : ::Socket) : Nil
+    # perform cleanup before LibC.close. Using a file descriptor after it has
+    # been closed is never defined and can always lead to undefined results
     socket.evented_close
+    socket.socket_close
   end
 
   def evented_read(target, errno_msg : String, &) : Int32

--- a/src/crystal/event_loop/wasi.cr
+++ b/src/crystal/event_loop/wasi.cr
@@ -66,6 +66,7 @@ class Crystal::EventLoop::Wasi < Crystal::EventLoop
 
   def close(file_descriptor : Crystal::System::FileDescriptor) : Nil
     file_descriptor.evented_close
+    file_descriptor.file_descriptor_close
   end
 
   def read(socket : ::Socket, slice : Bytes) : Int32
@@ -110,6 +111,7 @@ class Crystal::EventLoop::Wasi < Crystal::EventLoop
 
   def close(socket : ::Socket) : Nil
     socket.evented_close
+    socket.socket_close
   end
 
   def evented_read(target, errno_msg : String, &) : Int32

--- a/src/crystal/system/unix/file_descriptor.cr
+++ b/src/crystal/system/unix/file_descriptor.cr
@@ -113,12 +113,7 @@ module Crystal::System::FileDescriptor
   end
 
   private def system_close
-    # Perform libevent cleanup before LibC.close.
-    # Using a file descriptor after it has been closed is never defined and can
-    # always lead to undefined results. This is not specific to libevent.
     event_loop.close(self)
-
-    file_descriptor_close
   end
 
   def file_descriptor_close(&) : Nil
@@ -131,9 +126,9 @@ module Crystal::System::FileDescriptor
 
     # Clear the @volatile_fd before actually closing it in order to
     # reduce the chance of reading an outdated fd value
-    _fd = @volatile_fd.swap(-1)
+    return unless fd = close_volatile_fd?
 
-    if LibC.close(_fd) != 0
+    if LibC.close(fd) != 0
       case Errno.value
       when Errno::EINTR, Errno::EINPROGRESS
         # ignore
@@ -147,6 +142,11 @@ module Crystal::System::FileDescriptor
     file_descriptor_close do
       raise IO::Error.from_errno("Error closing file", target: self)
     end
+  end
+
+  def close_volatile_fd? : Int32?
+    fd = @volatile_fd.swap(-1)
+    fd unless fd == -1
   end
 
   private def system_flock_shared(blocking)

--- a/src/crystal/system/unix/socket.cr
+++ b/src/crystal/system/unix/socket.cr
@@ -207,18 +207,13 @@ module Crystal::System::Socket
   end
 
   private def system_close
-    # Perform libevent cleanup before LibC.close.
-    # Using a file descriptor after it has been closed is never defined and can
-    # always lead to undefined results. This is not specific to libevent.
     event_loop.close(self)
-
-    socket_close
   end
 
-  private def socket_close(&)
+  def socket_close(&)
     # Clear the @volatile_fd before actually closing it in order to
     # reduce the chance of reading an outdated fd value
-    fd = @volatile_fd.swap(-1)
+    return unless fd = close_volatile_fd?
 
     ret = LibC.close(fd)
 
@@ -232,7 +227,12 @@ module Crystal::System::Socket
     end
   end
 
-  private def socket_close
+  def close_volatile_fd? : Int32?
+    fd = @volatile_fd.swap(-1)
+    fd unless fd == -1
+  end
+
+  def socket_close
     socket_close do
       raise ::Socket::Error.from_errno("Error closing socket")
     end

--- a/src/crystal/system/win32/file_descriptor.cr
+++ b/src/crystal/system/win32/file_descriptor.cr
@@ -190,8 +190,6 @@ module Crystal::System::FileDescriptor
 
   private def system_close
     event_loop.close(self)
-
-    file_descriptor_close
   end
 
   def file_descriptor_close(&)


### PR DESCRIPTION
Internal refactor to have the `Crystal::EventLoop#close(io)` implementations be responsible from actually closing the file descriptor or socket, not only do some internal cleanup before closing. They now follow the abstract methods documentation:

> Closes the file descriptor|socket resource.

This will allow the io_uring event loop to close asynchronously.

Adds a `#close_volatile_fd?` helper on UNIX that will prove helpful in io_uring.

Follow-up to #15640 
Extracted from #15634 