### PR TITLE
Fix: polling event loop doesn't transfer ownership

### DIFF
--- a/src/crystal/event_loop/polling.cr
+++ b/src/crystal/event_loop/polling.cr
@@ -409,6 +409,9 @@ abstract class Crystal::EventLoop::Polling < Crystal::EventLoop
       event = Event.new(type, Fiber.current, index, timeout)
 
       return false unless Polling.arena.get?(index) do |pd|
+                            unless pd.value.owned_by?(self)
+                              pd.value.take_ownership(self, io.fd, index)
+                            end
                             yield pd, pointerof(event)
                           end
     else

--- a/src/crystal/event_loop/polling/poll_descriptor.cr
+++ b/src/crystal/event_loop/polling/poll_descriptor.cr
@@ -7,6 +7,10 @@ struct Crystal::EventLoop::Polling::PollDescriptor
   @readers = Waiters.new
   @writers = Waiters.new
 
+  def owned_by?(event_loop) : Bool
+    @event_loop == event_loop
+  end
+
   # Makes *event_loop* the new owner of *fd*.
   # Removes *fd* from the current event loop (if any).
   def take_ownership(event_loop : EventLoop, fd : Int32, index : Arena::Index) : Nil


### PR DESCRIPTION
An event loop only takes ownership the first time a `fd` is waited upon, and then never checks whether the current event loop owns the `fd`.

It causes issues where connecting a socket in one fiber then trying to read with a timeout in other fiber will never resume on IO ready, because we must be able to cancel the timer to be able to resume the fiber (oops).

It also causes cross event loop instances enqueues that are fine with preview MT (inefficient, but it would push the fiber to its thread), but invalid with execution context MT as it would transfer a fiber to _another_ context :fearful: 

closes #15647