### PR TITLE
Fix link `bcrypt` with `libxml2` on Windows

### DIFF
--- a/src/xml/libxml2.cr
+++ b/src/xml/libxml2.cr
@@ -12,6 +12,9 @@ require "./save_options"
 @[Link("xml2", pkg_config: "libxml-2.0")]
 {% if compare_versions(Crystal::VERSION, "1.11.0-dev") >= 0 %}
   @[Link(dll: "libxml2.dll")]
+  {% if flag?("win32") %}
+    @[Link("BCrypt")]
+  {% end %}
 {% end %}
 lib LibXML
   alias Int = LibC::Int

--- a/src/xml/libxml2.cr
+++ b/src/xml/libxml2.cr
@@ -13,7 +13,7 @@ require "./save_options"
 {% if compare_versions(Crystal::VERSION, "1.11.0-dev") >= 0 %}
   @[Link(dll: "libxml2.dll")]
   {% if flag?("win32") %}
-    @[Link("BCrypt")]
+    @[Link("bcrypt")]
   {% end %}
 {% end %}
 lib LibXML


### PR DESCRIPTION
On Windows, `libxml2` uses `BCryptGenRandom` from `BCrypt`, so we need to link that.
The build configurations for libxml2 on Windows also link `BCrypt`.

Resolves #15646