### PR TITLE
Fix mark method overrides on `ExecutionContext` as `:nodoc:`

### DIFF
--- a/src/fiber/execution_context/isolated.cr
+++ b/src/fiber/execution_context/isolated.cr
@@ -42,6 +42,7 @@ module Fiber::ExecutionContext
     protected getter thread : Thread
     @main_fiber : Fiber
 
+    # :nodoc:
     getter event_loop : Crystal::EventLoop = Crystal::EventLoop.create
 
     getter? running : Bool = true
@@ -96,6 +97,7 @@ module Fiber::ExecutionContext
       @spawn_context.spawn(name: name, &block)
     end
 
+    # :nodoc:
     def enqueue(fiber : Fiber) : Nil
       Crystal.trace :sched, "enqueue", fiber: fiber, context: self
 

--- a/src/fiber/execution_context/multi_threaded.cr
+++ b/src/fiber/execution_context/multi_threaded.cr
@@ -21,7 +21,10 @@ module Fiber::ExecutionContext
     @condition : Thread::ConditionVariable
     protected getter global_queue : GlobalQueue
 
+    # :nodoc:
     getter stack_pool : Fiber::StackPool = Fiber::StackPool.new
+
+    # :nodoc:
     getter event_loop : Crystal::EventLoop = Crystal::EventLoop.create
     @event_loop_lock = Atomic(Bool).new(false)
 
@@ -91,6 +94,7 @@ module Fiber::ExecutionContext
       @size.end
     end
 
+    # :nodoc:
     def stack_pool? : Fiber::StackPool?
       @stack_pool
     end
@@ -156,11 +160,13 @@ module Fiber::ExecutionContext
       end
     end
 
+    # :nodoc:
     def spawn(*, name : String? = nil, same_thread : Bool, &block : ->) : Fiber
       raise ArgumentError.new("#{self.class.name}#spawn doesn't support same_thread:true") if same_thread
       self.spawn(name: name, &block)
     end
 
+    # :nodoc:
     def enqueue(fiber : Fiber) : Nil
       if ExecutionContext.current == self
         # local enqueue: push to local queue of current scheduler

--- a/src/fiber/execution_context/single_threaded.cr
+++ b/src/fiber/execution_context/single_threaded.cr
@@ -22,7 +22,10 @@ module Fiber::ExecutionContext
     @global_queue : GlobalQueue
     @runnables : Runnables(256)
 
+    # :nodoc:
     getter stack_pool : Fiber::StackPool = Fiber::StackPool.new
+
+    # :nodoc:
     getter event_loop : Crystal::EventLoop = Crystal::EventLoop.create
 
     @waiting = Atomic(Bool).new(false)
@@ -56,6 +59,7 @@ module Fiber::ExecutionContext
       self
     end
 
+    # :nodoc:
     def stack_pool? : Fiber::StackPool?
       @stack_pool
     end
@@ -89,6 +93,7 @@ module Fiber::ExecutionContext
       self.spawn(name: name, &block)
     end
 
+    # :nodoc:
     def enqueue(fiber : Fiber) : Nil
       if ExecutionContext.current == self
         # local enqueue


### PR DESCRIPTION
The documentation of descendant defs is taken from the parent abstract defs that contain  `:nodoc:` and the docs generator doesn't recognizes `:nodoc:` from the copy. This led to internal methods being documented as `:nodoc:`.