### PR TITLE
Use MSYS2 to build MSVC package's GNU libiconv on Windows CI

### DIFF
--- a/.github/workflows/win.yml
+++ b/.github/workflows/win.yml
@@ -29,6 +29,7 @@ jobs:
         with:
           msystem: MSYS
           update: true
+          path-type: inherit
           install: >-
             make
 
@@ -110,6 +111,7 @@ jobs:
         with:
           msystem: MSYS
           update: true
+          path-type: inherit
           install: >-
             make
 

--- a/.github/workflows/win.yml
+++ b/.github/workflows/win.yml
@@ -23,16 +23,6 @@ jobs:
       - name: Enable Developer Command Prompt
         uses: ilammy/msvc-dev-cmd@0b201ec74fa43914dc39ae48a89fd1d8cb592756 # v1.13.0
 
-      - name: Set up MSYS2
-        id: msys2
-        uses: msys2/setup-msys2@61f9e5e925871ba6c9e3e8da24ede83ea27fa91f # v2.27.0
-        with:
-          msystem: MSYS
-          update: true
-          path-type: inherit
-          install: >-
-            make
-
       - name: Download Crystal source
         uses: actions/checkout@v4
 
@@ -51,6 +41,16 @@ jobs:
             libs/yaml.lib
             libs/xml2.lib
           key: win-libs-${{ hashFiles('.github/workflows/win.yml', 'etc/win-ci/*.ps1') }}-msvc
+      - name: Set up MSYS2
+        if: steps.cache-libs.outputs.cache-hit != 'true'
+        id: msys2
+        uses: msys2/setup-msys2@61f9e5e925871ba6c9e3e8da24ede83ea27fa91f # v2.27.0
+        with:
+          msystem: MSYS
+          update: true
+          path-type: inherit
+          install: >-
+            make
       - name: Build libgc
         if: steps.cache-libs.outputs.cache-hit != 'true'
         run: .\etc\win-ci\build-gc.ps1 -BuildTree deps\gc -Version 8.2.8 -AtomicOpsVersion 7.8.2
@@ -105,16 +105,6 @@ jobs:
       - name: Enable Developer Command Prompt
         uses: ilammy/msvc-dev-cmd@0b201ec74fa43914dc39ae48a89fd1d8cb592756 # v1.13.0
 
-      - name: Set up MSYS2
-        id: msys2
-        uses: msys2/setup-msys2@61f9e5e925871ba6c9e3e8da24ede83ea27fa91f # v2.27.0
-        with:
-          msystem: MSYS
-          update: true
-          path-type: inherit
-          install: >-
-            make
-
       - name: Download Crystal source
         uses: actions/checkout@v4
 
@@ -142,6 +132,16 @@ jobs:
             dlls/yaml.dll
             dlls/libxml2.dll
           key: win-dlls-${{ hashFiles('.github/workflows/win.yml', 'etc/win-ci/*.ps1') }}-msvc
+      - name: Set up MSYS2
+        if: steps.cache-dlls.outputs.cache-hit != 'true'
+        id: msys2
+        uses: msys2/setup-msys2@61f9e5e925871ba6c9e3e8da24ede83ea27fa91f # v2.27.0
+        with:
+          msystem: MSYS
+          update: true
+          path-type: inherit
+          install: >-
+            make
       - name: Build libgc
         if: steps.cache-dlls.outputs.cache-hit != 'true'
         run: .\etc\win-ci\build-gc.ps1 -BuildTree deps\gc -Version 8.2.8 -AtomicOpsVersion 7.8.2 -Dynamic

--- a/.github/workflows/win.yml
+++ b/.github/workflows/win.yml
@@ -62,7 +62,7 @@ jobs:
         run: .\etc\win-ci\build-pcre2.ps1 -BuildTree deps\pcre2 -Version 10.45
       - name: Build libiconv
         if: steps.cache-libs.outputs.cache-hit != 'true'
-        run: .\etc\win-ci\build-iconv.ps1 -BuildTree deps\iconv -Version 1.18
+        run: .\etc\win-ci\build-iconv.ps1 -BuildTree deps\iconv -Version 1.18 -Msys2Root ${{ steps.msys2.outputs.msys2-location }}
       - name: Build libffi
         if: steps.cache-libs.outputs.cache-hit != 'true'
         run: .\etc\win-ci\build-ffi.ps1 -BuildTree deps\ffi -Version 3.4.7
@@ -153,7 +153,7 @@ jobs:
         run: .\etc\win-ci\build-pcre2.ps1 -BuildTree deps\pcre2 -Version 10.45 -Dynamic
       - name: Build libiconv
         if: steps.cache-dlls.outputs.cache-hit != 'true'
-        run: .\etc\win-ci\build-iconv.ps1 -BuildTree deps\iconv -Version 1.18 -Dynamic
+        run: .\etc\win-ci\build-iconv.ps1 -BuildTree deps\iconv -Version 1.18 -Msys2Root ${{ steps.msys2.outputs.msys2-location }} -Dynamic
       - name: Build libffi
         if: steps.cache-dlls.outputs.cache-hit != 'true'
         run: .\etc\win-ci\build-ffi.ps1 -BuildTree deps\ffi -Version 3.4.7 -Dynamic

--- a/.github/workflows/win.yml
+++ b/.github/workflows/win.yml
@@ -27,7 +27,7 @@ jobs:
         id: msys2
         uses: msys2/setup-msys2@61f9e5e925871ba6c9e3e8da24ede83ea27fa91f # v2.27.0
         with:
-          msystem: UCRT64
+          msystem: MSYS
           update: true
           install: >-
             make
@@ -108,7 +108,7 @@ jobs:
         id: msys2
         uses: msys2/setup-msys2@61f9e5e925871ba6c9e3e8da24ede83ea27fa91f # v2.27.0
         with:
-          msystem: UCRT64
+          msystem: MSYS
           update: true
           install: >-
             make

--- a/.github/workflows/win.yml
+++ b/.github/workflows/win.yml
@@ -23,12 +23,14 @@ jobs:
       - name: Enable Developer Command Prompt
         uses: ilammy/msvc-dev-cmd@0b201ec74fa43914dc39ae48a89fd1d8cb592756 # v1.13.0
 
-      - name: Set up Cygwin
-        uses: cygwin/cygwin-install-action@f61179d72284ceddc397ed07ddb444d82bf9e559 # v5
+      - name: Set up MSYS2
+        id: msys2
+        uses: msys2/setup-msys2@61f9e5e925871ba6c9e3e8da24ede83ea27fa91f # v2.27.0
         with:
-          packages: make
-          install-dir: C:\cygwin64
-          add-to-path: false
+          msystem: UCRT64
+          update: true
+          install: >-
+            make
 
       - name: Download Crystal source
         uses: actions/checkout@v4
@@ -102,12 +104,14 @@ jobs:
       - name: Enable Developer Command Prompt
         uses: ilammy/msvc-dev-cmd@0b201ec74fa43914dc39ae48a89fd1d8cb592756 # v1.13.0
 
-      - name: Set up Cygwin
-        uses: cygwin/cygwin-install-action@f61179d72284ceddc397ed07ddb444d82bf9e559 # v5
+      - name: Set up MSYS2
+        id: msys2
+        uses: msys2/setup-msys2@61f9e5e925871ba6c9e3e8da24ede83ea27fa91f # v2.27.0
         with:
-          packages: make
-          install-dir: C:\cygwin64
-          add-to-path: false
+          msystem: UCRT64
+          update: true
+          install: >-
+            make
 
       - name: Download Crystal source
         uses: actions/checkout@v4

--- a/etc/win-ci/build-iconv.ps1
+++ b/etc/win-ci/build-iconv.ps1
@@ -1,6 +1,7 @@
 param(
     [Parameter(Mandatory)] [string] $BuildTree,
     [Parameter(Mandatory)] [string] $Version,
+    [string] $Msys2Root,
     [switch] $Dynamic
 )
 
@@ -12,9 +13,13 @@ tar -xzf libiconv.tar.gz
 mv libiconv-* $BuildTree
 rm libiconv.tar.gz
 
+if ($Msys2Root -eq '') {
+    $Msys2Root = 'C:\msys64'
+}
+
 Run-InDirectory $BuildTree {
     $env:CHERE_INVOKING = 1
-    & 'C:\msys64\usr\bin\bash.exe' --login "$PSScriptRoot\cygwin-build-iconv.sh" "$Version" "$(if ($Dynamic) { 1 })"
+    & "$Msys2Root\usr\bin\bash.exe" --login "$PSScriptRoot\cygwin-build-iconv.sh" "$Version" "$(if ($Dynamic) { 1 })"
     if (-not $?) {
         Write-Host "Error: Failed to build libiconv" -ForegroundColor Red
         Exit 1

--- a/etc/win-ci/build-iconv.ps1
+++ b/etc/win-ci/build-iconv.ps1
@@ -14,7 +14,7 @@ rm libiconv.tar.gz
 
 Run-InDirectory $BuildTree {
     $env:CHERE_INVOKING = 1
-    & 'C:\cygwin64\bin\bash.exe' --login "$PSScriptRoot\cygwin-build-iconv.sh" "$Version" "$(if ($Dynamic) { 1 })"
+    & 'C:\msys64\usr\bin\bash.exe' --login "$PSScriptRoot\cygwin-build-iconv.sh" "$Version" "$(if ($Dynamic) { 1 })"
     if (-not $?) {
         Write-Host "Error: Failed to build libiconv" -ForegroundColor Red
         Exit 1


### PR DESCRIPTION
Windows CI is intermittently failing because the Cygwin install step is somewhat unstable (e.g. [1](https://github.com/crystal-lang/crystal/actions/runs/14361018382/job/40262278713) [2](https://github.com/crystal-lang/crystal/actions/runs/14351492951/job/40231130874) [3](https://github.com/crystal-lang/crystal/actions/runs/14329675308/job/40162611778) [4](https://github.com/crystal-lang/crystal/actions/runs/14319193891/job/40132310317)), so we use MSYS2 instead, which should be compatible.