### PR TITLE
Only set up Cygwin on Windows CI if truly required

### DIFF
--- a/.github/workflows/win.yml
+++ b/.github/workflows/win.yml
@@ -23,13 +23,6 @@ jobs:
       - name: Enable Developer Command Prompt
         uses: ilammy/msvc-dev-cmd@0b201ec74fa43914dc39ae48a89fd1d8cb592756 # v1.13.0
 
-      - name: Set up Cygwin
-        uses: cygwin/cygwin-install-action@f61179d72284ceddc397ed07ddb444d82bf9e559 # v5
-        with:
-          packages: make
-          install-dir: C:\cygwin64
-          add-to-path: false
-
       - name: Download Crystal source
         uses: actions/checkout@v4
 
@@ -48,6 +41,13 @@ jobs:
             libs/yaml.lib
             libs/xml2.lib
           key: win-libs-${{ hashFiles('.github/workflows/win.yml', 'etc/win-ci/*.ps1') }}-msvc
+      - name: Set up Cygwin
+        if: steps.cache-libs.outputs.cache-hit != 'true'
+        uses: cygwin/cygwin-install-action@f61179d72284ceddc397ed07ddb444d82bf9e559 # v5
+        with:
+          packages: make
+          install-dir: C:\cygwin64
+          add-to-path: false
       - name: Build libgc
         if: steps.cache-libs.outputs.cache-hit != 'true'
         run: .\etc\win-ci\build-gc.ps1 -BuildTree deps\gc -Version 8.2.8 -AtomicOpsVersion 7.8.2
@@ -102,13 +102,6 @@ jobs:
       - name: Enable Developer Command Prompt
         uses: ilammy/msvc-dev-cmd@0b201ec74fa43914dc39ae48a89fd1d8cb592756 # v1.13.0
 
-      - name: Set up Cygwin
-        uses: cygwin/cygwin-install-action@f61179d72284ceddc397ed07ddb444d82bf9e559 # v5
-        with:
-          packages: make
-          install-dir: C:\cygwin64
-          add-to-path: false
-
       - name: Download Crystal source
         uses: actions/checkout@v4
 
@@ -136,6 +129,13 @@ jobs:
             dlls/yaml.dll
             dlls/libxml2.dll
           key: win-dlls-${{ hashFiles('.github/workflows/win.yml', 'etc/win-ci/*.ps1') }}-msvc
+      - name: Set up Cygwin
+        if: steps.cache-dlls.outputs.cache-hit != 'true'
+        uses: cygwin/cygwin-install-action@f61179d72284ceddc397ed07ddb444d82bf9e559 # v5
+        with:
+          packages: make
+          install-dir: C:\cygwin64
+          add-to-path: false
       - name: Build libgc
         if: steps.cache-dlls.outputs.cache-hit != 'true'
         run: .\etc\win-ci\build-gc.ps1 -BuildTree deps\gc -Version 8.2.8 -AtomicOpsVersion 7.8.2 -Dynamic

--- a/etc/win-ci/build-iconv.ps1
+++ b/etc/win-ci/build-iconv.ps1
@@ -14,6 +14,8 @@ rm libiconv.tar.gz
 
 Run-InDirectory $BuildTree {
     $env:CHERE_INVOKING = 1
+    [System.IO.File]::WriteAllText("src\Makefile.in", [System.IO.File]::ReadAllText("src\Makefile.in").Replace("chmod 777 .", "true"))
+
     & 'C:\cygwin64\bin\bash.exe' --login "$PSScriptRoot\cygwin-build-iconv.sh" "$Version" "$(if ($Dynamic) { 1 })"
     if (-not $?) {
         Write-Host "Error: Failed to build libiconv" -ForegroundColor Red


### PR DESCRIPTION
Extracted from #15660, this doesn't fix the issue but should greatly reduce CI noise as the majority of the affected PRs never touch the workflow definitions