### PR TITLE
Fix error message when `PollDescriptor` can't transfer fd

### DIFF
--- a/src/crystal/event_loop/polling/poll_descriptor.cr
+++ b/src/crystal/event_loop/polling/poll_descriptor.cr
@@ -24,7 +24,7 @@ struct Crystal::EventLoop::Polling::PollDescriptor
     # can optimize (all enqueues are local) and we don't end up with a timer
     # from evloop A to cancel an event from evloop B (currently unsafe)
     if current && !empty?
-      raise RuntimeError.new("Can't transfer fd=#{fd} to another evloop with pending reader/writer fibers")
+      raise RuntimeError.new("Can't transfer fd=#{fd} to another polling event loop with pending reader/writer fibers")
     end
 
     @event_loop = event_loop

--- a/src/crystal/event_loop/polling/poll_descriptor.cr
+++ b/src/crystal/event_loop/polling/poll_descriptor.cr
@@ -24,7 +24,7 @@ struct Crystal::EventLoop::Polling::PollDescriptor
     # can optimize (all enqueues are local) and we don't end up with a timer
     # from evloop A to cancel an event from evloop B (currently unsafe)
     if current && !empty?
-      raise RuntimeError.new("BUG: transfering fd=#{fd} to another evloop with pending reader/writer fibers")
+      raise RuntimeError.new("Can't transfer fd=#{fd} to another evloop with pending reader/writer fibers")
     end
 
     @event_loop = event_loop


### PR DESCRIPTION
Removes the `BUG:` prefer in the RuntimeError message when we can't transfer a `fd` to another event loop.

The prefix usually denotes a broken expectation in the stdlib implementation, which means the stdlib did a mistake and we shall fix it, but this isn't the case here.

An example for a BUG is just a few lines above to catch trying to transfer to the _same_ event loop (it makes no sense).