### PR TITLE
Make `offset` a required parameter in `Indexable#find`

### DIFF
--- a/src/indexable.cr
+++ b/src/indexable.cr
@@ -820,7 +820,7 @@ module Indexable(T)
   # [1, 2, 3, 4].find(-1) { |i| i > 8 }    # => -1
   # [1, 2, 3, 4].find(-1, 2) { |i| i < 2 } # => -1
   # ```
-  def find(if_none = nil, offset : Int = 0, & : T ->)
+  def find(if_none = nil, *, offset : Int, & : T ->)
     offset += size if offset < 0
     return if_none if offset < 0
 
@@ -828,6 +828,11 @@ module Indexable(T)
       return unsafe_fetch(idx)
     end
     if_none
+  end
+
+  # :ditto:
+  def find(if_none, _offset offset : Int, & : T ->)
+    find(if_none, offset: offset) { |e| yield e }
   end
 
   # Returns the first element in the indexable for which the passed block


### PR DESCRIPTION
Since 1.16.0, `Indexable#find` provides the `offset` parameter as an additional feature over `Enumerable#find`.
Calls that do not make use of this parameter don't need the added complexity of offset handling. They should fall back to the base implementation in `Enumerable#find`.

To achieve that, this patch makes `offset` a required parameter for  `Indexable#find`.