### PR TITLE
Limit paragraph `max-width` in API docs

### DIFF
--- a/src/compiler/crystal/tools/doc/html/css/style.css
+++ b/src/compiler/crystal/tools/doc/html/css/style.css
@@ -53,6 +53,14 @@ body {
   overflow: auto;
 }
 
+p, li {
+  max-width: 42em;
+}
+
+.methods-inherited {
+  max-width: 60em;
+}
+
 .sidebar {
   width: 30em;
   color: #F8F4FD;


### PR DESCRIPTION
Limits the width of text paragraphs in the API docs for increased readability. 
Previously, the width was unlimited, which leads to long line lengths that are hard to read.

Body copy:
| Before | After |
|-|-|
| ![grafik](https://github.com/user-attachments/assets/214e78a0-eacf-400c-b7b7-fedeff528d53) | ![grafik](https://github.com/user-attachments/assets/78ab57a6-94e4-4747-85ed-2f9eb596c211) |

The exact width may be up for debate. But 42em seems good to me.

Also limits the width of inherited methods, but they get more space because it's not body copy.

Inherited methods list:
| Before | After |
|-|-|
| ![grafik](https://github.com/user-attachments/assets/3b494efc-d732-4d8e-8b42-aeb8590121df) | ![grafik](https://github.com/user-attachments/assets/7c570356-6468-4f94-b1cf-8a15cd51331f)

