### PR TITLE
Optimize `Indexable#find`

### DIFF
--- a/src/indexable.cr
+++ b/src/indexable.cr
@@ -824,9 +824,13 @@ module Indexable(T)
     offset += size if offset < 0
     return if_none if offset < 0
 
-    if idx = index(offset) { |i| yield i }
-      return unsafe_fetch(idx)
+    offset.upto(size - 1) do |i|
+      elem = unsafe_fetch(i)
+      if yield elem
+        return elem
+      end
     end
+
     if_none
   end
 


### PR DESCRIPTION
The call to `index` performs the bounds check twice and calls `unsafe_fetch` for the found element again. It's better to iterate and return the element directly on a match.

A further enhancement could perhaps extract the shared implementation of `index` and `find` into `find_with_index` (which might or might not be a public method).