### PR TITLE
Use relative requires for `http/` files

### DIFF
--- a/src/http/content.cr
+++ b/src/http/content.cr
@@ -1,4 +1,4 @@
-require "http/common"
+require "./common"
 
 module HTTP
   # :nodoc:

--- a/src/http/request.cr
+++ b/src/http/request.cr
@@ -1,6 +1,6 @@
 require "./common"
 require "uri"
-require "http/params"
+require "./params"
 require "socket"
 
 # An HTTP request.

--- a/src/http/server/handlers/websocket_handler.cr
+++ b/src/http/server/handlers/websocket_handler.cr
@@ -1,5 +1,5 @@
 require "base64"
-require "http/web_socket"
+require "../../web_socket"
 
 # A handler which adds websocket functionality to an `HTTP::Server`.
 #

--- a/src/http/server/response.cr
+++ b/src/http/server/response.cr
@@ -1,6 +1,6 @@
-require "http/headers"
-require "http/status"
-require "http/cookie"
+require "../headers"
+require "../status"
+require "../cookie"
 
 class HTTP::Server
   # The response to configure and write to in an `HTTP::Server` handler.

--- a/src/http/web_socket/protocol.cr
+++ b/src/http/web_socket/protocol.cr
@@ -1,6 +1,6 @@
 require "socket"
-require "http/client"
-require "http/headers"
+require "../client"
+require "../headers"
 require "base64"
 {% if flag?(:without_openssl) %}
   require "crystal/digest/sha1"


### PR DESCRIPTION
Relative requires ensure that all components are pulled from the same source tree in case of path ambiguities.