### PR TITLE
Document `GC::Stats` properties

### DIFF
--- a/src/gc.cr
+++ b/src/gc.cr
@@ -77,6 +77,16 @@ module GC
 
     def initialize(@heap_size, @free_bytes, @unmapped_bytes, @bytes_since_gc, @total_bytes)
     end
+
+    @[Deprecated]
+    def copy_with(heap_size = @heap_size, free_bytes = @free_bytes, unmapped_bytes = @unmapped_bytes, bytes_since_gc = @bytes_since_gc, total_bytes = @total_bytes)
+      self.class.new(heap_size, free_bytes, unmapped_bytes, bytes_since_gc, total_bytes)
+    end
+
+    @[Deprecated]
+    def clone
+      self.class.new(@heap_size.clone, @free_bytes.clone, @unmapped_bytes.clone, @bytes_since_gc.clone, @total_bytes.clone)
+    end
   end
 
   record ProfStats,

--- a/src/gc.cr
+++ b/src/gc.cr
@@ -75,9 +75,6 @@ module GC
     # back to zero.
     getter total_bytes : UInt64
 
-    # getter collections : UInt64
-    # getter bytes_found : Int64
-
     def initialize(@heap_size, @free_bytes, @unmapped_bytes, @bytes_since_gc, @total_bytes)
     end
   end

--- a/src/gc.cr
+++ b/src/gc.cr
@@ -47,14 +47,37 @@ fun __crystal_realloc64(ptr : Void*, size : UInt64) : Void*
 end
 
 module GC
-  record Stats,
-    # collections : UInt64,
-    # bytes_found : Int64,
-    heap_size : UInt64,
-    free_bytes : UInt64,
-    unmapped_bytes : UInt64,
-    bytes_since_gc : UInt64,
-    total_bytes : UInt64
+  struct Stats
+    # The system memory allocated by the GC for its HEAP, in bytes. The memory
+    # may or may not have been allocated by the OS (for example some pages
+    # haven't been accessed). The number can grow and shrink as needed by the
+    # process.
+    getter heap_size : UInt64
+
+    # Number of free bytes in the GC HEAP. The number is relative the
+    # `#heap_size`.
+    getter free_bytes : UInt64
+
+    # The system memory returned to the OS by the GC but that can be reallocated
+    # at any time to grow the GC HEAP. The OS may have freed the memory already,
+    # or keep it allocated until there is memory pressure.
+    getter unmapped_bytes : UInt64
+
+    # Total memory allocated by the GC into its HEAP since the last GC
+    # collection, in bytes.
+    getter bytes_since_gc : UInt64
+
+    # Total memory allocated by the GC into its HEAP since the program started,
+    # in bytes. The number keeps growing indefinitely until the integer wraps
+    # back to zero.
+    getter total_bytes : UInt64
+
+    # getter collections : UInt64
+    # getter bytes_found : Int64
+
+    def initialize(@heap_size, @free_bytes, @unmapped_bytes, @bytes_since_gc, @total_bytes)
+    end
+  end
 
   record ProfStats,
     heap_size : UInt64,

--- a/src/gc.cr
+++ b/src/gc.cr
@@ -54,13 +54,16 @@ module GC
     # process.
     getter heap_size : UInt64
 
-    # Number of free bytes in the GC HEAP. The number is relative the
-    # `#heap_size`.
+    # Approximate number of free bytes in the GC HEAP. The number is relative to
+    # the `#heap_size`. The reported value is pessimistic, there might be more
+    # free bytes in reality.
     getter free_bytes : UInt64
 
-    # The system memory returned to the OS by the GC but that can be reallocated
-    # at any time to grow the GC HEAP. The OS may have freed the memory already,
-    # or keep it allocated until there is memory pressure.
+    # The size (in bytes) of virtual system memory that the GC returned to the
+    # OS when shrinking its HEAP. The OS may have reclaimed the memory already,
+    # reducing the resident memory usage, or may do so later (for example on
+    # memory pressure). The GC will reuse this memory when it needs to grow its
+    # HEAP again.
     getter unmapped_bytes : UInt64
 
     # Total memory allocated by the GC into its HEAP since the last GC


### PR DESCRIPTION
As reported on the forum https://forum.crystal-lang.org/t/memory-leak/7964 it would be useful to know the details of the GC stats when debugging a memory leak.