### PR TITLE
Split `StaticFileHandler#call` into structured components

### DIFF
--- a/src/http/server/handlers/static_file_handler.cr
+++ b/src/http/server/handlers/static_file_handler.cr
@@ -257,7 +257,7 @@ class HTTP::StaticFileHandler
     path
   end
 
-  private def redirect_to(context, url)
+  private def redirect_to(context : Server::Context, url)
     context.response.redirect url.to_s
   end
 

--- a/src/http/server/handlers/static_file_handler.cr
+++ b/src/http/server/handlers/static_file_handler.cr
@@ -124,7 +124,7 @@ class HTTP::StaticFileHandler
 
     # Checks if pre-gzipped file can be served
     if context.request.headers.includes_word?("Accept-Encoding", "gzip")
-      gz_file_path = "#{file_path}.gz"
+      gz_file_path = Path["#{file_path}.gz"]
 
       if (gz_file_info = File.info?(gz_file_path)) &&
          last_modified - gz_file_info.modification_time < TIME_DRIFT

--- a/src/http/server/handlers/static_file_handler.cr
+++ b/src/http/server/handlers/static_file_handler.cr
@@ -62,12 +62,8 @@ class HTTP::StaticFileHandler
     context.response.headers["Accept-Ranges"] = "bytes"
 
     if file_info.directory?
-      unless @directory_listing
-        return call_next(context)
-      end
-      context.response.content_type = "text/html; charset=utf-8"
-      directory_listing(context.response, request_path, file_path)
-    elsif file_info.file?
+      directory_index(context, request_path, file_path)
+    elsif is_file
       last_modified = file_info.modification_time
       add_cache_headers(context.response.headers, last_modified)
 
@@ -281,7 +277,16 @@ class HTTP::StaticFileHandler
     ECR.def_to_s "#{__DIR__}/static_file_handler.html"
   end
 
-  private def directory_listing(io, request_path, path)
+  private def directory_index(context : Server::Context, request_path : Path, path : Path)
+    unless @directory_listing
+      return call_next(context)
+    end
+
+    context.response.content_type = "text/html; charset=utf-8"
+    directory_listing(context.response, request_path, path)
+  end
+
+  private def directory_listing(io : IO, request_path : Path, path : Path)
     DirectoryListing.new(request_path.to_s, path.to_s).to_s(io)
   end
 end

--- a/src/http/server/handlers/static_file_handler.cr
+++ b/src/http/server/handlers/static_file_handler.cr
@@ -120,7 +120,7 @@ class HTTP::StaticFileHandler
   end
 
   private def serve_file_compressed(context : Server::Context, file_info, file_path : Path, last_modified : Time)
-    context.response.content_type = MIME.from_filename(file_path.to_s, "application/octet-stream")
+    original_file_path = file_path
 
     # Checks if pre-gzipped file can be served
     if context.request.headers.includes_word?("Accept-Encoding", "gzip")
@@ -134,10 +134,12 @@ class HTTP::StaticFileHandler
       end
     end
 
-    serve_file(context : Server::Context, file_info, file_path : Path, last_modified : Time)
+    serve_file(context : Server::Context, file_info, file_path : Path, original_file_path, last_modified : Time)
   end
 
-  private def serve_file(context : Server::Context, file_info, file_path : Path, last_modified : Time)
+  private def serve_file(context : Server::Context, file_info, file_path : Path, original_file_path : Path, last_modified : Time)
+    context.response.content_type = MIME.from_filename(original_file_path.to_s, "application/octet-stream")
+
     File.open(file_path) do |file|
       if range_header = context.request.headers["Range"]?
         serve_file_range(context, file, range_header, file_info)

--- a/src/http/server/handlers/static_file_handler.cr
+++ b/src/http/server/handlers/static_file_handler.cr
@@ -59,8 +59,6 @@ class HTTP::StaticFileHandler
 
     return call_next(context) unless file_info
 
-    context.response.headers["Accept-Ranges"] = "bytes"
-
     if file_info.directory?
       directory_index(context, request_path, file_path)
     elsif file_info.file?
@@ -140,6 +138,8 @@ class HTTP::StaticFileHandler
       if range_header = context.request.headers["Range"]?
         serve_file_range(context, file, range_header, file_info)
       else
+        context.response.headers["Accept-Ranges"] = "bytes"
+
         serve_file_full(context, file, file_info)
       end
     end

--- a/src/http/server/handlers/static_file_handler.cr
+++ b/src/http/server/handlers/static_file_handler.cr
@@ -134,7 +134,7 @@ class HTTP::StaticFileHandler
       end
     end
 
-    serve_file(context : Server::Context, file_info, file_path : Path, original_file_path, last_modified : Time)
+    serve_file(context, file_info, file_path, original_file_path, last_modified)
   end
 
   private def serve_file(context : Server::Context, file_info, file_path : Path, original_file_path : Path, last_modified : Time)

--- a/src/http/server/handlers/static_file_handler.cr
+++ b/src/http/server/handlers/static_file_handler.cr
@@ -44,8 +44,7 @@ class HTTP::StaticFileHandler
   def call(context) : Nil
     check_request_method!(context) || return
 
-    original_path = context.request.path.not_nil!
-    request_path = request_path(URI.decode(original_path))
+    request_path = request_path(context)
 
     check_request_path!(context, request_path) || return
 
@@ -249,6 +248,12 @@ class HTTP::StaticFileHandler
       ranges << range
     end
     ranges unless ranges.empty?
+  end
+
+  private def request_path(context : Server::Context) : String
+    original_path = context.request.path.not_nil!
+
+    request_path(URI.decode(original_path))
   end
 
   # given a full path of the request, returns the path

--- a/src/http/server/handlers/static_file_handler.cr
+++ b/src/http/server/handlers/static_file_handler.cr
@@ -52,8 +52,7 @@ class HTTP::StaticFileHandler
     request_path = Path.posix(request_path)
     expanded_path = request_path.expand("/")
 
-    file_path = @public_dir.join(expanded_path.to_kind(Path::Kind.native))
-    file_info = File.info? file_path
+    file_info, file_path = file_info(expanded_path)
 
     check_redirect_to_expanded_path!(context, request_path, expanded_path, file_info) || return
 
@@ -107,7 +106,13 @@ class HTTP::StaticFileHandler
     return true
   end
 
-  private def serve_file_with_cache(context : Server::Context, file_info : File::Info, file_path : Path)
+  private def file_info(expanded_path : Path)
+    file_path = @public_dir.join(expanded_path.to_kind(Path::Kind.native))
+
+    {File.info?(file_path), file_path}
+  end
+
+  private def serve_file_with_cache(context : Server::Context, file_info, file_path : Path)
     last_modified = file_info.modification_time
     add_cache_headers(context.response.headers, last_modified)
 

--- a/src/http/server/handlers/static_file_handler.cr
+++ b/src/http/server/handlers/static_file_handler.cr
@@ -116,10 +116,10 @@ class HTTP::StaticFileHandler
       return
     end
 
-    serve_file(context, file_info, file_path, last_modified)
+    serve_file_compressed(context, file_info, file_path, last_modified)
   end
 
-  private def serve_file(context : Server::Context, file_info, file_path : Path, last_modified : Time)
+  private def serve_file_compressed(context : Server::Context, file_info, file_path : Path, last_modified : Time)
     context.response.content_type = MIME.from_filename(file_path.to_s, "application/octet-stream")
 
     # Checks if pre-gzipped file can be served
@@ -134,6 +134,10 @@ class HTTP::StaticFileHandler
       end
     end
 
+    serve_file(context : Server::Context, file_info, file_path : Path, last_modified : Time)
+  end
+
+  private def serve_file(context : Server::Context, file_info, file_path : Path, last_modified : Time)
     File.open(file_path) do |file|
       if range_header = context.request.headers["Range"]?
         serve_file_range(context, file, range_header, file_info)


### PR DESCRIPTION
`StaticFileHandler#call` is a complex method with > 100 loc. This patch extracts individual aspects into helper methods which gives it more structure.
This also makes it easy for inheriting types to inject partial custom behaviour by overriding individual helper methods (see https://github.com/kemalcr/kemal/pull/714 for an example).
