### PR TITLE
Update `release-update` script: Truncate CHANGELOG

### DIFF
--- a/scripts/release-update.sh
+++ b/scripts/release-update.sh
@@ -22,6 +22,12 @@ sed -i -E "s/version: .*/version: $(cat src/VERSION)/" shard.yml
 # Remove SOURCE_DATE_EPOCH (only used in source tree of a release)
 rm -f src/SOURCE_DATE_EPOCH
 
+# Truncate CHANGELOG.md
+sed -i -E '/^## \[/,/^## Previous Releases/{/^## Previous Releases/!d}' CHANGELOG.md
+sed -i -E "/For information on prior releases/{ N;a\
+* [${CRYSTAL_VERSION%.*}](https://github.com/crystal-lang/crystal/blob/release/${CRYSTAL_VERSION%.*}/CHANGELOG.md)
+}" CHANGELOG.md
+
 # Edit PREVIOUS_CRYSTAL_BASE_URL in .circleci/config.yml
 sed -i -E "s|[0-9.]+/crystal-[0-9.]+-[0-9]|$CRYSTAL_VERSION/crystal-$CRYSTAL_VERSION-1|g" .circleci/config.yml
 


### PR DESCRIPTION
Truncate `CHANGELOG.md` when going into the development period for the next minor release, so that it always only contains the changes since the last minor. This was discussed in #15609.