### PR TITLE
PoC: let the event loop decide blocking or non blocking

### DIFF
--- a/spec/std/crystal/event_loop/polling/poll_descriptor_spec.cr
+++ b/spec/std/crystal/event_loop/polling/poll_descriptor_spec.cr
@@ -3,6 +3,10 @@
 require "spec"
 
 class Crystal::EventLoop::FakeLoop < Crystal::EventLoop::Polling
+  def self.default_blocking
+    false
+  end
+
   getter operations = [] of {Symbol, Int32, Arena::Index | Bool}
 
   private def system_run(blocking : Bool, & : Fiber ->) : Nil

--- a/spec/std/file_spec.cr
+++ b/spec/std/file_spec.cr
@@ -127,6 +127,33 @@ describe "File" do
         end
       end
     end
+
+    it "can append non-blocking to an existing file" do
+      with_tempfile("append-existing.txt") do |path|
+        File.write(path, "hello")
+        File.write(path, " world", mode: "a", blocking: false)
+        File.read(path).should eq("hello world")
+      end
+    end
+
+    it "returns the actual position after non-blocking append" do
+      with_tempfile("delete-file.txt") do |filename|
+        File.write(filename, "hello")
+
+        File.open(filename, "a", blocking: false) do |file|
+          file.tell.should eq(0)
+
+          file.write "12345".to_slice
+          file.tell.should eq(10)
+
+          file.seek(5, IO::Seek::Set)
+          file.write "6789".to_slice
+          file.tell.should eq(14)
+        end
+
+        File.read(filename).should eq("hello123456789")
+      end
+    end
   end
 
   it "reads entire file" do

--- a/src/crystal/event_loop.cr
+++ b/src/crystal/event_loop.cr
@@ -20,6 +20,10 @@ abstract class Crystal::EventLoop
     {% end %}
   end
 
+  def self.default_blocking : Bool
+    backend_class.default_blocking
+  end
+
   # Creates an event loop instance
   def self.create : self
     backend_class.new

--- a/src/crystal/event_loop/file_descriptor.cr
+++ b/src/crystal/event_loop/file_descriptor.cr
@@ -1,5 +1,14 @@
 abstract class Crystal::EventLoop
   module FileDescriptor
+    # Opens a file named *filename* from the disk.
+    #
+    # Blocks the current fiber until the file has been opened. Avoids blocking
+    # the current thread if possible, especially whebn *blocking* is `false` or
+    # `nil`.
+    #
+    # Returns the system file descriptor/handle or a system error.
+    abstract def open(filename : String, flags : Int32, permissions : File::Permissions, blocking : Bool?) : System::FileDescriptor::Handle | Errno | WinError
+
     # Reads at least one byte from the file descriptor into *slice*.
     #
     # Blocks the current fiber if no data is available for reading, continuing

--- a/src/crystal/event_loop/iocp.cr
+++ b/src/crystal/event_loop/iocp.cr
@@ -228,10 +228,24 @@ class Crystal::EventLoop::IOCP < Crystal::EventLoop
   end
 
   def write(file_descriptor : Crystal::System::FileDescriptor, slice : Bytes) : Int32
-    System::IOCP.overlapped_operation(file_descriptor, "WriteFile", file_descriptor.write_timeout, writing: true) do |overlapped|
+    bytes_written = System::IOCP.overlapped_operation(file_descriptor, "WriteFile", file_descriptor.write_timeout, writing: true) do |overlapped|
+      overlapped.offset = UInt64::MAX if file_descriptor.system_append?
+
       ret = LibC.WriteFile(file_descriptor.windows_handle, slice, slice.size, out byte_count, overlapped)
       {ret, byte_count}
     end.to_i32
+
+    # The overlapped offset forced a write to the end of the file, but unlike
+    # synchronous writes, an asynchronous write incorrectly updates the file
+    # pointer: it merely adds the number of written bytes to the current
+    # position, disregarding that the offset might have changed it.
+    #
+    # We could seek before the async write (it works), but a concurrent fiber or
+    # parallel thread could also seek and we'd end up overwriting instead of
+    # appending; we need both the offset + explicit seek.
+    file_descriptor.system_seek(0, IO::Seek::End) if file_descriptor.system_append?
+
+    bytes_written
   end
 
   def wait_writable(file_descriptor : Crystal::System::FileDescriptor) : Nil

--- a/src/crystal/event_loop/iocp.cr
+++ b/src/crystal/event_loop/iocp.cr
@@ -294,14 +294,6 @@ class Crystal::EventLoop::IOCP < Crystal::EventLoop
     wsabuf
   end
 
-  def socket(family : ::Socket::Family, type : ::Socket::Type, protocol : ::Socket::Protocol) : System::Socket::Handle
-    socket = LibC.WSASocketW(family, type, protocol, nil, 0, LibC::WSA_FLAG_OVERLAPPED)
-    raise ::Socket::Error.from_wsa_error("WSASocketW") if socket == LibC::INVALID_SOCKET
-
-    create_completion_port LibC::HANDLE.new(socket)
-    socket
-  end
-
   def read(socket : ::Socket, slice : Bytes) : Int32
     wsabuf = wsa_buffer(slice)
 

--- a/src/crystal/event_loop/iocp.cr
+++ b/src/crystal/event_loop/iocp.cr
@@ -14,6 +14,10 @@ class Crystal::EventLoop::IOCP < Crystal::EventLoop
   @timer_packet : LibC::HANDLE?
   @timer_key : System::IOCP::CompletionKey?
 
+  def self.default_blocking : Bool
+    false
+  end
+
   def initialize
     @mutex = Thread::Mutex.new
     @timers = Timers(Timer).new

--- a/src/crystal/event_loop/iocp.cr
+++ b/src/crystal/event_loop/iocp.cr
@@ -294,6 +294,14 @@ class Crystal::EventLoop::IOCP < Crystal::EventLoop
     wsabuf
   end
 
+  def socket(family : ::Socket::Family, type : ::Socket::Type, protocol : ::Socket::Protocol) : System::Socket::Handle
+    socket = LibC.WSASocketW(family, type, protocol, nil, 0, LibC::WSA_FLAG_OVERLAPPED)
+    raise ::Socket::Error.from_wsa_error("WSASocketW") if socket == LibC::INVALID_SOCKET
+
+    create_completion_port LibC::HANDLE.new(socket)
+    socket
+  end
+
   def read(socket : ::Socket, slice : Bytes) : Int32
     wsabuf = wsa_buffer(slice)
 

--- a/src/crystal/event_loop/libevent.cr
+++ b/src/crystal/event_loop/libevent.cr
@@ -111,13 +111,41 @@ class Crystal::EventLoop::LibEvent < Crystal::EventLoop
   def open(filename : String, flags : Int32, permissions : File::Permissions, blocking : Bool?) : System::FileDescriptor::Handle | Errno
     filename.check_no_null_byte
 
-    fd = LibC.open(filename, flags | LibC::O_CLOEXEC, permissions)
+    fd = 0
+    flags |= LibC::O_CLOEXEC
 
-    if fd == -1
-      Errno.value
-    else
-      fd
-    end
+    # We can't reliably detect without significant overhead whether *filename*
+    # might block for a while before calling open; while O_NONBLOCK has no
+    # effect on regular disk files, special file types are a different story.
+    # Open with O_NONBLOCK will fail with ENXIO for O_WRONLY (no connected
+    # reader) but it will always succeed for O_RDONLY (regardless of a connected
+    # writer or not), then any attempt to read will return EOF, leaving no means
+    # to wait until a writer connects.
+    #
+    # We thus rely on the *blocking* arg: when false the file might be a special
+    # file type, so we check it; if it's a fifo (named pipe) or a character
+    # device, we open in another thread so we don't risk blocking the current
+    # thread (and thus other fibers) until a reader or writer is also connected.
+    #
+    # We need preview_mt to safely re-enqueue the current fiber from the thread.
+    {% if flag?(:preview_mt) && !flag?(:interpreted) %}
+      if !blocking && System::File.special_file_type?(filename)
+        fd, errno = System::File.async_open(filename, flags, permissions)
+        return errno if fd == -1
+      else
+        fd = LibC.open(filename, flags, permissions)
+        return Errno.value if fd == -1
+      end
+    {% else %}
+      fd = LibC.open(filename, flags, permissions)
+      return Errno.value if fd == -1
+    {% end %}
+
+    # Always set O_NONBLOCK (it's a requirement).
+    status_flags = System::FileDescriptor.fcntl(fd, LibC::F_GETFL)
+    System::FileDescriptor.fcntl(fd, LibC::F_SETFL, status_flags | LibC::O_NONBLOCK)
+
+    fd
   end
 
   def read(file_descriptor : Crystal::System::FileDescriptor, slice : Bytes) : Int32

--- a/src/crystal/event_loop/libevent.cr
+++ b/src/crystal/event_loop/libevent.cr
@@ -2,6 +2,10 @@ require "./libevent/event"
 
 # :nodoc:
 class Crystal::EventLoop::LibEvent < Crystal::EventLoop
+  def self.default_blocking : Bool
+    false
+  end
+
   private getter(event_base) { Crystal::EventLoop::LibEvent::Event::Base.new }
 
   def after_fork_before_exec : Nil

--- a/src/crystal/event_loop/libevent.cr
+++ b/src/crystal/event_loop/libevent.cr
@@ -108,6 +108,18 @@ class Crystal::EventLoop::LibEvent < Crystal::EventLoop
     end
   end
 
+  def open(filename : String, flags : Int32, permissions : File::Permissions, blocking : Bool?) : System::FileDescriptor::Handle | Errno
+    filename.check_no_null_byte
+
+    fd = LibC.open(filename, flags | LibC::O_CLOEXEC, permissions)
+
+    if fd == -1
+      Errno.value
+    else
+      fd
+    end
+  end
+
   def read(file_descriptor : Crystal::System::FileDescriptor, slice : Bytes) : Int32
     evented_read(file_descriptor, "Error reading file_descriptor") do
       LibC.read(file_descriptor.fd, slice, slice.size).tap do |return_code|

--- a/src/crystal/event_loop/polling.cr
+++ b/src/crystal/event_loop/polling.cr
@@ -148,13 +148,41 @@ abstract class Crystal::EventLoop::Polling < Crystal::EventLoop
   def open(filename : String, flags : Int32, permissions : File::Permissions, blocking : Bool?) : System::FileDescriptor::Handle | Errno
     filename.check_no_null_byte
 
-    fd = LibC.open(filename, flags | LibC::O_CLOEXEC, permissions)
+    fd = 0
+    flags |= LibC::O_CLOEXEC
 
-    if fd == -1
-      Errno.value
-    else
-      fd
-    end
+    # We can't reliably detect without significant overhead whether *filename*
+    # might block for a while before calling open; while O_NONBLOCK has no
+    # effect on regular disk files, special file types are a different story.
+    # Open with O_NONBLOCK will fail with ENXIO for O_WRONLY (no connected
+    # reader) but it will always succeed for O_RDONLY (regardless of a connected
+    # writer or not), then any attempt to read will return EOF, leaving no means
+    # to wait until a writer connects.
+    #
+    # We thus rely on the *blocking* arg: when false the file might be a special
+    # file type, so we check it; if it's a fifo (named pipe) or a character
+    # device, we open in another thread so we don't risk blocking the current
+    # thread (and thus other fibers) until a reader or writer is also connected.
+    #
+    # We need preview_mt to safely re-enqueue the current fiber from the thread.
+    {% if flag?(:preview_mt) && !flag?(:interpreted) %}
+      if !blocking && System::File.special_file_type?(filename)
+        fd, errno = System::File.async_open(filename, flags, permissions)
+        return errno if fd == -1
+      else
+        fd = LibC.open(filename, flags, permissions)
+        return Errno.value if fd == -1
+      end
+    {% else %}
+      fd = LibC.open(filename, flags, permissions)
+      return Errno.value if fd == -1
+    {% end %}
+
+    # Always set O_NONBLOCK (it's a requirement).
+    status_flags = System::FileDescriptor.fcntl(fd, LibC::F_GETFL)
+    System::FileDescriptor.fcntl(fd, LibC::F_SETFL, status_flags | LibC::O_NONBLOCK)
+
+    fd
   end
 
   def read(file_descriptor : System::FileDescriptor, slice : Bytes) : Int32

--- a/src/crystal/event_loop/polling.cr
+++ b/src/crystal/event_loop/polling.cr
@@ -56,6 +56,10 @@ end
 # before suspending the fiber, then after resume it will raise
 # `IO::TimeoutError` if the event timed out, and continue otherwise.
 abstract class Crystal::EventLoop::Polling < Crystal::EventLoop
+  def self.default_blocking : Bool
+    false
+  end
+
   # The generational arena:
   #
   # 1. decorrelates the fd from the IO since the evloop only really cares about
@@ -179,8 +183,7 @@ abstract class Crystal::EventLoop::Polling < Crystal::EventLoop
     {% end %}
 
     # Always set O_NONBLOCK (it's a requirement).
-    status_flags = System::FileDescriptor.fcntl(fd, LibC::F_GETFL)
-    System::FileDescriptor.fcntl(fd, LibC::F_SETFL, status_flags | LibC::O_NONBLOCK)
+    System::FileDescriptor.fcntl(fd, LibC::F_SETFL, System::FileDescriptor.fcntl(fd, LibC::F_GETFL) | LibC::O_NONBLOCK)
 
     fd
   end

--- a/src/crystal/event_loop/polling.cr
+++ b/src/crystal/event_loop/polling.cr
@@ -145,6 +145,18 @@ abstract class Crystal::EventLoop::Polling < Crystal::EventLoop
 
   # file descriptor interface, see Crystal::EventLoop::FileDescriptor
 
+  def open(filename : String, flags : Int32, permissions : File::Permissions, blocking : Bool?) : System::FileDescriptor::Handle | Errno
+    filename.check_no_null_byte
+
+    fd = LibC.open(filename, flags | LibC::O_CLOEXEC, permissions)
+
+    if fd == -1
+      Errno.value
+    else
+      fd
+    end
+  end
+
   def read(file_descriptor : System::FileDescriptor, slice : Bytes) : Int32
     size = evented_read(file_descriptor, slice, file_descriptor.@read_timeout)
 

--- a/src/crystal/event_loop/socket.cr
+++ b/src/crystal/event_loop/socket.cr
@@ -4,11 +4,6 @@
 
 abstract class Crystal::EventLoop
   module Socket
-    # Creates a new socket.
-    #
-    # Returns the system socket descriptor or handle. Raises ::Socket::Error on system error.
-    abstract def socket(family : ::Socket::Family, type : ::Socket::Type, protocol : ::Socket::Protocol) : System::Socket::Handle
-
     # Reads at least one byte from the socket into *slice*.
     #
     # Blocks the current fiber if no data is available for reading, continuing

--- a/src/crystal/event_loop/socket.cr
+++ b/src/crystal/event_loop/socket.cr
@@ -4,6 +4,11 @@
 
 abstract class Crystal::EventLoop
   module Socket
+    # Creates a new socket.
+    #
+    # Returns the system socket descriptor or handle. Raises ::Socket::Error on system error.
+    abstract def socket(family : ::Socket::Family, type : ::Socket::Type, protocol : ::Socket::Protocol) : System::Socket::Handle
+
     # Reads at least one byte from the socket into *slice*.
     #
     # Blocks the current fiber if no data is available for reading, continuing

--- a/src/crystal/event_loop/wasi.cr
+++ b/src/crystal/event_loop/wasi.cr
@@ -76,10 +76,6 @@ class Crystal::EventLoop::Wasi < Crystal::EventLoop
     file_descriptor.evented_close
   end
 
-  def socket(family : ::Socket::Family, type : ::Socket::Type, protocol : ::Socket::Protocol) : System::Socket::Handle
-    raise NotImplementedError.new("Crystal::Wasi::EventLoop#socket")
-  end
-
   def read(socket : ::Socket, slice : Bytes) : Int32
     evented_read(socket, "Error reading socket") do
       LibC.recv(socket.fd, slice, slice.size, 0).to_i32

--- a/src/crystal/event_loop/wasi.cr
+++ b/src/crystal/event_loop/wasi.cr
@@ -28,6 +28,10 @@ class Crystal::EventLoop::Wasi < Crystal::EventLoop
     raise NotImplementedError.new("Crystal::Wasi::EventLoop.create_fd_read_event")
   end
 
+  def open(filename : String, flags : Int32, permissions : File::Permissions, blocking : Bool?) : System::FileDescriptor::Handle | Errno | WinError
+    raise NotImplementedError.new("Crystal::Wasi::EventLoop#open")
+  end
+
   def read(file_descriptor : Crystal::System::FileDescriptor, slice : Bytes) : Int32
     evented_read(file_descriptor, "Error reading file_descriptor") do
       LibC.read(file_descriptor.fd, slice, slice.size).tap do |return_code|

--- a/src/crystal/event_loop/wasi.cr
+++ b/src/crystal/event_loop/wasi.cr
@@ -76,6 +76,10 @@ class Crystal::EventLoop::Wasi < Crystal::EventLoop
     file_descriptor.evented_close
   end
 
+  def socket(family : ::Socket::Family, type : ::Socket::Type, protocol : ::Socket::Protocol) : System::Socket::Handle
+    raise NotImplementedError.new("Crystal::Wasi::EventLoop#socket")
+  end
+
   def read(socket : ::Socket, slice : Bytes) : Int32
     evented_read(socket, "Error reading socket") do
       LibC.recv(socket.fd, slice, slice.size, 0).to_i32

--- a/src/crystal/event_loop/wasi.cr
+++ b/src/crystal/event_loop/wasi.cr
@@ -1,5 +1,9 @@
 # :nodoc:
 class Crystal::EventLoop::Wasi < Crystal::EventLoop
+  def self.default_blocking
+    false
+  end
+
   # Runs the event loop.
   def run(blocking : Bool) : Bool
     raise NotImplementedError.new("Crystal::Wasi::EventLoop.run")

--- a/src/crystal/system/file.cr
+++ b/src/crystal/system/file.cr
@@ -52,7 +52,7 @@ module Crystal::System::File
   LOWER_ALPHANUM = "0123456789abcdefghijklmnopqrstuvwxyz".to_slice
 
   def self.mktemp(prefix : String?, suffix : String?, dir : String, random : ::Random = ::Random::DEFAULT) : {FileDescriptor::Handle, String}
-    mode = LibC::O_RDWR | LibC::O_CREAT | LibC::O_EXCL
+    flags = LibC::O_RDWR | LibC::O_CREAT | LibC::O_EXCL
     perm = ::File::Permissions.new(0o600)
 
     prefix = ::File.join(dir, prefix || "")
@@ -67,7 +67,7 @@ module Crystal::System::File
         io << suffix
       end
 
-      case result = EventLoop.current.open(path, mode, perm, blocking: true)
+      case result = EventLoop.current.open(path, flags, perm, blocking: true)
       when FileDescriptor::Handle
         return {result, path}
       when Errno::EEXIST, WinError::ERROR_FILE_EXISTS

--- a/src/crystal/system/socket.cr
+++ b/src/crystal/system/socket.cr
@@ -1,9 +1,6 @@
 require "../event_loop/socket"
 
 module Crystal::System::Socket
-  # Creates a file descriptor / socket handle
-  # private def create_handle(family, type, protocol, blocking) : Handle
-
   # Initializes a file descriptor / socket handle for use with Crystal Socket
   # private def initialize_handle(fd)
 

--- a/src/crystal/system/socket.cr
+++ b/src/crystal/system/socket.cr
@@ -76,7 +76,7 @@ module Crystal::System::Socket
 
   # def self.fcntl(fd, cmd, arg = 0)
 
-  # def self.socketpair(type : ::Socket::Type, protocol : ::Socket::Protocol) : {Handle, Handle}
+  # def self.socketpair(type : ::Socket::Type, protocol : ::Socket::Protocol, blocking : Bool) : {Handle, Handle}
 
   private def system_read(slice : Bytes) : Int32
     event_loop.read(self, slice)

--- a/src/crystal/system/socket.cr
+++ b/src/crystal/system/socket.cr
@@ -1,6 +1,9 @@
 require "../event_loop/socket"
 
 module Crystal::System::Socket
+  # Creates a socket. Raises ::Socket::Error on error.
+  # def self.socket(family : ::Socket::Family, type : ::Socket::Type, protocol : ::Socket::Protocol, blocking : Bool) : Handle
+
   # Initializes a file descriptor / socket handle for use with Crystal Socket
   # private def initialize_handle(fd)
 

--- a/src/crystal/system/unix/file.cr
+++ b/src/crystal/system/unix/file.cr
@@ -3,25 +3,15 @@ require "file/error"
 
 # :nodoc:
 module Crystal::System::File
-  def self.open(filename : String, mode : String, perm : Int32 | ::File::Permissions, blocking)
+  def self.open(filename : String, mode : String, perm : Int32 | ::File::Permissions, blocking : Bool?) : FileDescriptor::Handle
     perm = ::File::Permissions.new(perm) if perm.is_a? Int32
 
-    fd, errno = open(filename, open_flag(mode), perm, blocking)
-
-    unless errno.none?
-      raise ::File::Error.from_os_error("Error opening file with mode '#{mode}'", errno, file: filename)
+    case result = EventLoop.current.open(filename, open_flag(mode), perm, blocking)
+    in FileDescriptor::Handle
+      result
+    in Errno
+      raise ::File::Error.from_os_error("Error opening file with mode '#{mode}'", result, file: filename)
     end
-
-    fd
-  end
-
-  def self.open(filename : String, flags : Int32, perm : ::File::Permissions, blocking _blocking) : {LibC::Int, Errno}
-    filename.check_no_null_byte
-    flags |= LibC::O_CLOEXEC
-
-    fd = LibC.open(filename, flags, perm)
-
-    {fd, fd < 0 ? Errno.value : Errno::NONE}
   end
 
   protected def system_set_mode(mode : String)

--- a/src/crystal/system/unix/file_descriptor.cr
+++ b/src/crystal/system/unix/file_descriptor.cr
@@ -35,7 +35,7 @@ module Crystal::System::FileDescriptor
   end
 
   private def system_blocking_init(value)
-    self.system_blocking = false unless value
+    self.system_blocking = value
   end
 
   private def system_close_on_exec?

--- a/src/crystal/system/unix/file_descriptor.cr
+++ b/src/crystal/system/unix/file_descriptor.cr
@@ -34,7 +34,16 @@ module Crystal::System::FileDescriptor
     fcntl(LibC::F_SETFL, new_flags) unless new_flags == current_flags
   end
 
-  private def system_blocking_init(value)
+  def system_blocking_init(value)
+    if value.nil?
+      value =
+        case system_info.type
+        when .pipe?, .socket?, .character_device?
+          false
+        else
+          true
+        end
+    end
     self.system_blocking = value
   end
 

--- a/src/crystal/system/unix/file_descriptor.cr
+++ b/src/crystal/system/unix/file_descriptor.cr
@@ -36,13 +36,16 @@ module Crystal::System::FileDescriptor
 
   def system_blocking_init(value)
     if value.nil?
-      value =
+      if EventLoop.default_blocking
+        value = true
+      else
         case system_info.type
         when .pipe?, .socket?, .character_device?
-          false
+          value = false
         else
-          true
+          value = true
         end
+      end
     end
     self.system_blocking = value
   end

--- a/src/crystal/system/unix/process.cr
+++ b/src/crystal/system/unix/process.cr
@@ -264,7 +264,7 @@ struct Crystal::System::Process
     end
 
     LibC.close(w)
-    reader_pipe = IO::FileDescriptor.new(r, blocking: false)
+    reader_pipe = IO::FileDescriptor.new(r, EventLoop.default_blocking)
 
     begin
       case reader_pipe.read_byte

--- a/src/crystal/system/unix/socket.cr
+++ b/src/crystal/system/unix/socket.cr
@@ -9,21 +9,6 @@ module Crystal::System::Socket
 
   alias Handle = Int32
 
-  private def create_handle(family, type, protocol, blocking) : Handle
-    {% if LibC.has_constant?(:SOCK_CLOEXEC) %}
-      fd = LibC.socket(family, type.value | LibC::SOCK_CLOEXEC, protocol)
-      raise ::Socket::Error.from_errno("Failed to create socket") if fd == -1
-      fd
-    {% else %}
-      Process.lock_read do
-        fd = LibC.socket(family, type, protocol)
-        raise ::Socket::Error.from_errno("Failed to create socket") if fd == -1
-        Socket.fcntl(fd, LibC::F_SETFD, LibC::FD_CLOEXEC)
-        fd
-      end
-    {% end %}
-  end
-
   private def initialize_handle(fd)
     {% if Crystal::EventLoop.has_constant?(:Polling) %}
       @__evloop_data = Crystal::EventLoop::Polling::Arena::INVALID_INDEX

--- a/src/crystal/system/wasi/file_descriptor.cr
+++ b/src/crystal/system/wasi/file_descriptor.cr
@@ -17,7 +17,7 @@ module Crystal::System::FileDescriptor
     r
   end
 
-  private def system_blocking_init(value)
+  def system_blocking_init(value)
   end
 
   private def system_reopen(other : IO::FileDescriptor)

--- a/src/crystal/system/wasi/socket.cr
+++ b/src/crystal/system/wasi/socket.cr
@@ -131,7 +131,7 @@ module Crystal::System::Socket
     r
   end
 
-  def self.socketpair(type : ::Socket::Type, protocol : ::Socket::Protocol) : {Handle, Handle}
+  def self.socketpair(type : ::Socket::Type, protocol : ::Socket::Protocol, blocking : Bool) : {Handle, Handle}
     raise NotImplementedError.new("Crystal::System::Socket.socketpair")
   end
 

--- a/src/crystal/system/wasi/socket.cr
+++ b/src/crystal/system/wasi/socket.cr
@@ -8,6 +8,10 @@ module Crystal::System::Socket
 
   alias Handle = Int32
 
+  def self.socket(family : ::Socket::Family, type : ::Socket::Type, protocol : ::Socket::Protocol, blocking : Bool) : Handle
+    raise NotImplementedError.new "Crystal::System::Socket.socket"
+  end
+
   private def initialize_handle(fd)
   end
 

--- a/src/crystal/system/wasi/socket.cr
+++ b/src/crystal/system/wasi/socket.cr
@@ -8,10 +8,6 @@ module Crystal::System::Socket
 
   alias Handle = Int32
 
-  private def create_handle(family, type, protocol, blocking) : Handle
-    raise NotImplementedError.new "Crystal::System::Socket#create_handle"
-  end
-
   private def initialize_handle(fd)
   end
 

--- a/src/crystal/system/win32/file.cr
+++ b/src/crystal/system/win32/file.cr
@@ -12,7 +12,7 @@ module Crystal::System::File
   # On Windows we cannot rely on the system mode `FILE_APPEND_DATA` and
   # keep track of append mode explicitly. When writing data, this ensures to only
   # write at the end of the file.
-  @system_append = false
+  getter? system_append = false
 
   def self.open(filename : String, mode : String, perm : Int32 | ::File::Permissions, blocking : Bool?) : FileDescriptor::Handle
     perm = ::File::Permissions.new(perm) if perm.is_a? Int32

--- a/src/crystal/system/win32/file_descriptor.cr
+++ b/src/crystal/system/win32/file_descriptor.cr
@@ -18,6 +18,10 @@ module Crystal::System::FileDescriptor
 
   @system_blocking = true
 
+  def system_append?
+    false
+  end
+
   private def system_read(slice : Bytes) : Int32
     handle = windows_handle
     if ConsoleUtils.console?(handle)
@@ -160,7 +164,7 @@ module Crystal::System::FileDescriptor
     FileDescriptor.system_info windows_handle
   end
 
-  private def system_seek(offset, whence : IO::Seek) : Nil
+  def system_seek(offset, whence : IO::Seek) : Nil
     if LibC.SetFilePointerEx(windows_handle, offset, nil, whence) == 0
       raise IO::Error.from_winerror("Unable to seek", target: self)
     end

--- a/src/crystal/system/win32/file_descriptor.cr
+++ b/src/crystal/system/win32/file_descriptor.cr
@@ -16,7 +16,7 @@ module Crystal::System::FileDescriptor
   STDOUT_HANDLE = LibC.GetStdHandle(LibC::STD_OUTPUT_HANDLE).address
   STDERR_HANDLE = LibC.GetStdHandle(LibC::STD_ERROR_HANDLE).address
 
-  @system_blocking = true
+  @system_blocking = false
 
   def system_append?
     false
@@ -103,7 +103,8 @@ module Crystal::System::FileDescriptor
     end
   end
 
-  private def system_blocking_init(value)
+  def system_blocking_init(value)
+    value = false if value.nil?
     @system_blocking = value
     Crystal::EventLoop.current.create_completion_port(windows_handle) unless value
   end

--- a/src/crystal/system/win32/file_descriptor.cr
+++ b/src/crystal/system/win32/file_descriptor.cr
@@ -104,7 +104,14 @@ module Crystal::System::FileDescriptor
   end
 
   def system_blocking_init(value)
-    value = false if value.nil?
+    if value.nil?
+      # TODO: We could determine if the HANDLE is OVERLAPPED capable by asking
+      # the file mode (FileModeInformation) with NtQueryInformationFile
+      # (ntifs.h). If the call succeeds and the file mode includes neither of
+      # FILE_SYNCHRONOUS_IO_ALERT or FILE_SYNCHRONOUS_IO_NONALERT then the
+      # HANDLE is OVERLAPPED capable.
+      value = true
+    end
     @system_blocking = value
     Crystal::EventLoop.current.create_completion_port(windows_handle) unless value
   end

--- a/src/crystal/system/win32/iocp.cr
+++ b/src/crystal/system/win32/iocp.cr
@@ -264,6 +264,11 @@ struct Crystal::System::IOCP
     def initialize(@handle : LibC::HANDLE)
     end
 
+    def offset=(value : UInt64)
+      @overlapped.union.offset.offset = LibC::DWORD.new!(value)
+      @overlapped.union.offset.offsetHigh = LibC::DWORD.new!(value >> 32)
+    end
+
     def wait_for_result(timeout, & : WinError ->)
       wait_for_completion(timeout)
 

--- a/src/crystal/system/win32/socket.cr
+++ b/src/crystal/system/win32/socket.cr
@@ -346,7 +346,7 @@ module Crystal::System::Socket
     raise NotImplementedError.new "Crystal::System::Socket.fcntl"
   end
 
-  def self.socketpair(type : ::Socket::Type, protocol : ::Socket::Protocol) : {Handle, Handle}
+  def self.socketpair(type : ::Socket::Type, protocol : ::Socket::Protocol, blocking : Bool) : {Handle, Handle}
     raise NotImplementedError.new("Crystal::System::Socket.socketpair")
   end
 

--- a/src/file.cr
+++ b/src/file.cr
@@ -126,11 +126,10 @@ class File < IO::FileDescriptor
   include Crystal::System::File
 
   # This constructor is for constructors to be able to initialize a `File` with
-  # a *path* and *fd*.
+  # a *path* and *fd*. Expects the non/blocking flag to have been set already
+  # for the handle (for example by the event loop).
   private def initialize(@path, fd : Int, encoding = nil, invalid = nil)
-    # don't call super because it would affect the non/blocking flag
-    @volatile_fd = Atomic.new(fd)
-    @closed = system_closed?
+    super(handle: fd)
     set_encoding(encoding, invalid: invalid) if encoding
   end
 

--- a/src/file.cr
+++ b/src/file.cr
@@ -132,11 +132,6 @@ class File < IO::FileDescriptor
     super(fd, blocking)
   end
 
-  # :nodoc:
-  def self.from_fd(path : String, fd : Int, *, blocking = false, encoding = nil, invalid = nil)
-    new(path, fd, blocking: blocking, encoding: encoding, invalid: invalid)
-  end
-
   # Opens the file named by *filename*.
   #
   # *mode* must be one of the following file open modes:

--- a/src/file/tempfile.cr
+++ b/src/file/tempfile.cr
@@ -65,7 +65,7 @@ class File
   # It is the caller's responsibility to remove the file when no longer needed.
   def self.tempfile(prefix : String?, suffix : String?, *, dir : String = Dir.tempdir, encoding = nil, invalid = nil)
     fileno, path = Crystal::System::File.mktemp(prefix, suffix, dir)
-    new(path, fileno, blocking: true, encoding: encoding, invalid: invalid)
+    new(path, fileno, encoding: encoding, invalid: invalid)
   end
 
   # Creates a temporary file.

--- a/src/io.cr
+++ b/src/io.cr
@@ -137,7 +137,10 @@ abstract class IO
   # reader.gets # => "hello"
   # reader.gets # => "world"
   # ```
-  def self.pipe(read_blocking = false, write_blocking = false) : {IO::FileDescriptor, IO::FileDescriptor}
+  def self.pipe(read_blocking = nil, write_blocking = nil) : {IO::FileDescriptor, IO::FileDescriptor}
+    read_blocking = Crystal::EventLoop.default_blocking if read_blocking.nil?
+    write_blocking = Crystal::EventLoop.default_blocking if write_blocking.nil?
+
     Crystal::System::FileDescriptor.pipe(read_blocking, write_blocking)
   end
 
@@ -152,7 +155,7 @@ abstract class IO
   #   reader.gets # => "world"
   # end
   # ```
-  def self.pipe(read_blocking = false, write_blocking = false, &)
+  def self.pipe(read_blocking = nil, write_blocking = nil, &)
     r, w = IO.pipe(read_blocking, write_blocking)
     begin
       yield r, w

--- a/src/io/file_descriptor.cr
+++ b/src/io/file_descriptor.cr
@@ -6,6 +6,7 @@ class IO::FileDescriptor < IO
   include IO::Buffered
 
   @volatile_fd : Atomic(Handle)
+  @closed = true # this is necessary so we can reference `self` in `system_closed?` (in case of an exception)
 
   # Returns the raw file-descriptor handle. Its type is platform-specific.
   def fd : Handle
@@ -41,7 +42,6 @@ class IO::FileDescriptor < IO
 
   def initialize(fd : Handle, blocking = nil, *, @close_on_finalize = true)
     @volatile_fd = Atomic.new(fd)
-    @closed = true # This is necessary so we can reference `self` in `system_closed?` (in case of an exception)
 
     # TODO: Refactor to avoid calling `GetFileType` twice on Windows (once in `system_closed?` and once in `system_info`)
     @closed = system_closed?

--- a/src/lib_c/aarch64-android/c/sys/socket.cr
+++ b/src/lib_c/aarch64-android/c/sys/socket.cr
@@ -27,6 +27,7 @@ lib LibC
   SHUT_RDWR      =         2
   SHUT_WR        =         1
   SOCK_CLOEXEC   = 0o2000000
+  SOCK_NONBLOCK  = 0o0004000
 
   alias SocklenT = UInt32
   alias SaFamilyT = UShort

--- a/src/lib_c/aarch64-linux-gnu/c/sys/socket.cr
+++ b/src/lib_c/aarch64-linux-gnu/c/sys/socket.cr
@@ -27,6 +27,7 @@ lib LibC
   SHUT_RDWR      =      2
   SHUT_WR        =      1
   SOCK_CLOEXEC   = 524288
+  SOCK_NONBLOCK  =   2048
 
   alias SocklenT = UInt
   alias SaFamilyT = UShort

--- a/src/lib_c/aarch64-linux-musl/c/sys/socket.cr
+++ b/src/lib_c/aarch64-linux-musl/c/sys/socket.cr
@@ -27,6 +27,7 @@ lib LibC
   SHUT_RDWR      =         2
   SHUT_WR        =         1
   SOCK_CLOEXEC   = 0o2000000
+  SOCK_NONBLOCK  = 0o0004000
 
   alias SocklenT = UInt
   alias SaFamilyT = UShort

--- a/src/lib_c/arm-linux-gnueabihf/c/sys/socket.cr
+++ b/src/lib_c/arm-linux-gnueabihf/c/sys/socket.cr
@@ -27,6 +27,7 @@ lib LibC
   SHUT_RDWR      =      2
   SHUT_WR        =      1
   SOCK_CLOEXEC   = 524288
+  SOCK_NONBLOCK  =   2048
 
   alias SocklenT = UInt
   alias SaFamilyT = UShort

--- a/src/lib_c/i386-linux-gnu/c/sys/socket.cr
+++ b/src/lib_c/i386-linux-gnu/c/sys/socket.cr
@@ -27,6 +27,7 @@ lib LibC
   SHUT_RDWR      =      2
   SHUT_WR        =      1
   SOCK_CLOEXEC   = 524288
+  SOCK_NONBLOCK  =   2048
 
   alias SocklenT = UInt
   alias SaFamilyT = UShort

--- a/src/lib_c/i386-linux-musl/c/sys/socket.cr
+++ b/src/lib_c/i386-linux-musl/c/sys/socket.cr
@@ -27,6 +27,7 @@ lib LibC
   SHUT_RDWR      =         2
   SHUT_WR        =         1
   SOCK_CLOEXEC   = 0o2000000
+  SOCK_NONBLOCK  = 0o0004000
 
   alias SocklenT = UInt
   alias SaFamilyT = UShort

--- a/src/lib_c/x86_64-dragonfly/c/sys/socket.cr
+++ b/src/lib_c/x86_64-dragonfly/c/sys/socket.cr
@@ -27,6 +27,7 @@ lib LibC
   SHUT_RDWR      =          2
   SHUT_WR        =          1
   SOCK_CLOEXEC   = 0x10000000
+  SOCK_NONBLOCK  = 0x20000000
 
   alias SocklenT = UInt
   alias SaFamilyT = Char

--- a/src/lib_c/x86_64-freebsd/c/sys/socket.cr
+++ b/src/lib_c/x86_64-freebsd/c/sys/socket.cr
@@ -27,6 +27,7 @@ lib LibC
   SHUT_RDWR      =          2
   SHUT_WR        =          1
   SOCK_CLOEXEC   = 0x10000000
+  SOCK_NONBLOCK  = 0x20000000
 
   alias SocklenT = UInt
   alias SaFamilyT = Char

--- a/src/lib_c/x86_64-linux-gnu/c/sys/socket.cr
+++ b/src/lib_c/x86_64-linux-gnu/c/sys/socket.cr
@@ -27,6 +27,7 @@ lib LibC
   SHUT_RDWR      =      2
   SHUT_WR        =      1
   SOCK_CLOEXEC   = 524288
+  SOCK_NONBLOCK  =   2048
 
   alias SocklenT = UInt
   alias SaFamilyT = UShort

--- a/src/lib_c/x86_64-linux-musl/c/sys/socket.cr
+++ b/src/lib_c/x86_64-linux-musl/c/sys/socket.cr
@@ -27,6 +27,7 @@ lib LibC
   SHUT_RDWR      =         2
   SHUT_WR        =         1
   SOCK_CLOEXEC   = 0o2000000
+  SOCK_NONBLOCK  = 0o0004000
 
   alias SocklenT = UInt
   alias SaFamilyT = UShort

--- a/src/lib_c/x86_64-netbsd/c/sys/socket.cr
+++ b/src/lib_c/x86_64-netbsd/c/sys/socket.cr
@@ -27,6 +27,7 @@ lib LibC
   SHUT_WR        =          1
   SHUT_RDWR      =          2
   SOCK_CLOEXEC   = 0x10000000
+  SOCK_NONBLOCK  = 0x20000000
 
   alias SocklenT = UInt
   alias SaFamilyT = UInt8

--- a/src/lib_c/x86_64-openbsd/c/sys/socket.cr
+++ b/src/lib_c/x86_64-openbsd/c/sys/socket.cr
@@ -27,6 +27,7 @@ lib LibC
   SHUT_RDWR      =      2
   SHUT_WR        =      1
   SOCK_CLOEXEC   = 0x8000
+  SOCK_NONBLOCK  = 0x4000
 
   alias SocklenT = UInt
   alias SaFamilyT = Char

--- a/src/lib_c/x86_64-solaris/c/sys/socket.cr
+++ b/src/lib_c/x86_64-solaris/c/sys/socket.cr
@@ -28,6 +28,7 @@ lib LibC
   SHUT_RDWR      =        2
   SHUT_WR        =        1
   SOCK_CLOEXEC   = 0x080000
+  SOCK_NONBLOCK  = 0x100000
 
   alias SocklenT = UInt32
   alias SaFamilyT = UInt16

--- a/src/socket.cr
+++ b/src/socket.cr
@@ -64,7 +64,8 @@ class Socket < IO
   def initialize(family : Family, type : Type, protocol : Protocol = Protocol::IP, blocking = nil)
     # This method is `#initialize` instead of `.new` because it is used as super
     # constructor from subclasses.
-    fd = event_loop.socket(family, type, protocol)
+    default_blocking = blocking.nil? ? Crystal::EventLoop.default_blocking : blocking
+    fd = Crystal::System::Socket.socket(family, type, protocol, default_blocking)
     initialize(fd, family, type, protocol, blocking)
   end
 

--- a/src/socket/tcp_socket.cr
+++ b/src/socket/tcp_socket.cr
@@ -15,7 +15,7 @@ require "./ip_socket"
 # ```
 class TCPSocket < IPSocket
   # Creates a new `TCPSocket`, waiting to be connected.
-  def self.new(family : Family = Family::INET, blocking = false)
+  def self.new(family : Family = Family::INET, blocking = nil)
     super(family, Type::STREAM, Protocol::TCP, blocking)
   end
 
@@ -26,7 +26,7 @@ class TCPSocket < IPSocket
   # must be in seconds (integers or floats).
   #
   # NOTE: *dns_timeout* is currently only supported on Windows.
-  def initialize(host : String, port, dns_timeout = nil, connect_timeout = nil, blocking = false)
+  def initialize(host : String, port, dns_timeout = nil, connect_timeout = nil, blocking = nil)
     Addrinfo.tcp(host, port, timeout: dns_timeout) do |addrinfo|
       super(addrinfo.family, addrinfo.type, addrinfo.protocol, blocking)
       connect(addrinfo, timeout: connect_timeout) do |error|
@@ -36,16 +36,16 @@ class TCPSocket < IPSocket
     end
   end
 
-  protected def initialize(family : Family, type : Type, protocol : Protocol = Protocol::IP, blocking = false)
+  protected def initialize(family : Family, type : Type, protocol : Protocol = Protocol::IP, blocking = nil)
     super family, type, protocol, blocking
   end
 
-  protected def initialize(fd : Handle, family : Family, type : Type, protocol : Protocol = Protocol::IP, blocking = false)
+  protected def initialize(fd : Handle, family : Family, type : Type, protocol : Protocol = Protocol::IP, blocking = nil)
     super fd, family, type, protocol, blocking
   end
 
   # Creates a TCPSocket from an already configured raw file descriptor
-  def initialize(*, fd : Handle, family : Family = Family::INET, blocking = false)
+  def initialize(*, fd : Handle, family : Family = Family::INET, blocking = nil)
     super fd, family, Type::STREAM, Protocol::TCP, blocking
   end
 

--- a/src/socket/unix_socket.cr
+++ b/src/socket/unix_socket.cr
@@ -71,7 +71,7 @@ class UNIXSocket < Socket
   # ```
   def self.pair(type : Type = Type::STREAM) : {UNIXSocket, UNIXSocket}
     Crystal::System::Socket
-      .socketpair(type, Protocol::IP)
+      .socketpair(type, Protocol::IP, Crystal::EventLoop.default_blocking)
       .map { |fd| UNIXSocket.new(fd: fd, type: type) }
   end
 


### PR DESCRIPTION
The experimental branch as per my thread in #15652. Not meant to be merged. Multiple smaller PRs shall be extracted.

Overall:

1. moves `File.open` to the event loop (for #15634).
2. moves setting `O_NONBLOCK`, `FILE_FLAG_OVERLAPPED` and `WSA_FLAG_OVERLAPPED` to be the responsibility of the event loop (for #15634 again).
3. the `blocking` argument for `File` class methods now only applies to _opening_ the file:
   - UNIX: when explicitly set to `false` on Linux it won't block the current thread anymore (#15634 will never block) see #15652 for details;
   - WINDOWS: now discards the arg and always sets `WSA_FLAG_OVERLAPPED`, so `File` is now fully async on Windows, which required a patch (#15681) and a hack (see c37e54f6d34601e1cf05452880bb5ae3ef79eb7f and 5f096f5eee86ef0a00a7b29c566641e1cf3f5bec).
4. `Socket` now defaults to `blocking: nil`:
   - UNIX: still respects an explicit `blocking: true` (for #15634), otherwise the event loops set `O_NONBLOCK`;
   - WINDOWS: still discards the arg and always sets `WSA_FLAG_OVERLAPPED` (no change);
   - we might consider to deprecate the arg.
5. The behavior of `IO::FileDescriptor` shouldn't have changed.

Related to #15634 