### PR TITLE
Add missing type restrictions to benchmark directory

### DIFF
--- a/src/benchmark/bm.cr
+++ b/src/benchmark/bm.cr
@@ -44,13 +44,13 @@ module Benchmark
       end
 
       # Reports a single benchmark unit.
-      def report(label = " ", &block)
+      def report(label : String = " ", &block) : Nil
         @label_width = label.size if label.size > @label_width
         @reports << {label, block}
       end
 
       # :nodoc:
-      def execute
+      def execute : Nil
         if @label_width > 0
           print " " * @label_width
         end

--- a/src/benchmark/ips.cr
+++ b/src/benchmark/ips.cr
@@ -31,7 +31,7 @@ module Benchmark
       end
 
       # Adds code to be benchmarked
-      def report(label = "", &action) : Benchmark::IPS::Entry
+      def report(label : String = "", &action) : Benchmark::IPS::Entry
         item = Entry.new(label, action)
         @items << item
         item
@@ -175,12 +175,12 @@ module Benchmark
         cycles.times { action.call }
       end
 
-      def set_cycles(duration, iterations) : Nil
+      def set_cycles(duration : Time::Span, iterations : Int32) : Nil
         @cycles = (iterations / duration.total_milliseconds * 100).to_i
         @cycles = 1 if cycles <= 0
       end
 
-      def calculate_stats(samples) : Nil
+      def calculate_stats(samples : Array(Float64) | Array(Int32)) : Nil
         @ran = true
         @size = samples.size
         @mean = samples.sum.to_f / size.to_f


### PR DESCRIPTION
This is the output of compiling [cr-source-typer](https://github.com/Vici37/cr-source-typer) and running it with the below incantation:

```
CRYSTAL_PATH="./src" ./typer spec/std_spec.cr --error-trace --exclude src/crystal/ --stats --progress --union-size-threshold 2 --ignore-private-defs src/benchmark
```

This is related to https://github.com/crystal-lang/crystal/pull/15682 .