### PR TITLE
Add type restrictions to big

### DIFF
--- a/src/big/big_decimal.cr
+++ b/src/big/big_decimal.cr
@@ -38,7 +38,7 @@ struct BigDecimal < Number
   #
   # NOTE: Floats are fundamentally less precise than BigDecimals,
   # which makes initialization from them risky.
-  def self.new(num : Float)
+  def self.new(num : Float) : BigDecimal
     raise ArgumentError.new "Can only construct from a finite number" unless num.finite?
     new(num.to_s)
   end
@@ -47,13 +47,13 @@ struct BigDecimal < Number
   #
   # NOTE: BigRational are fundamentally more precise than BigDecimals,
   # which makes initialization from them risky.
-  def self.new(num : BigRational)
+  def self.new(num : BigRational) : BigDecimal
     num.numerator.to_big_d / num.denominator.to_big_d
   end
 
   # Returns *num*. Useful for generic code that does `T.new(...)` with `T`
   # being a `Number`.
-  def self.new(num : BigDecimal)
+  def self.new(num : BigDecimal) : BigDecimal
     num
   end
 
@@ -235,7 +235,7 @@ struct BigDecimal < Number
   # BigDecimal.new(1).div(BigDecimal.new(2))    # => BigDecimal(@value=5, @scale=2)
   # BigDecimal.new(1).div(BigDecimal.new(3), 5) # => BigDecimal(@value=33333, @scale=5)
   # ```
-  def div(other : BigDecimal, precision = DEFAULT_PRECISION) : BigDecimal
+  def div(other : BigDecimal, precision : UInt64 | Int32 = DEFAULT_PRECISION) : BigDecimal
     check_division_by_zero other
     return self if @value.zero?
     other.factor_powers_of_ten
@@ -349,7 +349,7 @@ struct BigDecimal < Number
     self <=> other.to_big_r
   end
 
-  def <=>(other : Int)
+  def <=>(other : Int) : Int32
     self <=> BigDecimal.new(other)
   end
 
@@ -772,7 +772,7 @@ struct BigDecimal < Number
   end
 
   # returns `self * 10 ** exponent`
-  protected def mul_power_of_ten(exponent : Int)
+  protected def mul_power_of_ten(exponent : Int) : BigDecimal
     if exponent <= scale
       BigDecimal.new(@value, @scale - exponent)
     else
@@ -782,7 +782,7 @@ struct BigDecimal < Number
 
   # Factors out any extra powers of ten in the internal representation.
   # For instance, value=100 scale=2 => value=1 scale=0
-  protected def factor_powers_of_ten
+  protected def factor_powers_of_ten : UInt64?
     if @scale > 0
       reduced, exp = value.factor_by(TEN_I)
       if exp <= @scale
@@ -878,7 +878,7 @@ end
 
 # :nodoc:
 struct Crystal::Hasher
-  def self.reduce_num(value : BigDecimal)
+  def self.reduce_num(value : BigDecimal) : UInt64
     v = reduce_num(value.value.abs)
 
     # v = UInt64.mulmod(v, 10_u64.powmod(-scale, HASH_MODULUS), HASH_MODULUS)

--- a/src/big/big_float.cr
+++ b/src/big/big_float.cr
@@ -77,11 +77,11 @@ struct BigFloat < Float
     new(mpf)
   end
 
-  def self.default_precision
+  def self.default_precision : UInt64
     LibGMP.mpf_get_default_prec
   end
 
-  def self.default_precision=(prec : Int)
+  def self.default_precision=(prec : Int) : Nil
     LibGMP.mpf_set_default_prec(prec.to_u64)
   end
 
@@ -93,11 +93,11 @@ struct BigFloat < Float
     LibGMP.mpf_cmp_z(self, other)
   end
 
-  def <=>(other : Float::Primitive)
+  def <=>(other : Float::Primitive) : Int32?
     LibGMP.mpf_cmp_d(self, other) unless other.nan?
   end
 
-  def <=>(other : Int)
+  def <=>(other : Int) : Int32
     Int.primitive_si_ui_check(other) do |si, ui, big_i|
       {
         si:    LibGMP.mpf_cmp_si(self, {{ si }}),
@@ -357,7 +357,7 @@ struct BigFloat < Float
     LibGMP.mpf_get_ui(self).to_u64!
   end
 
-  def to_unsafe
+  def to_unsafe : Pointer(LibGMP::MPF)
     mpf
   end
 
@@ -466,7 +466,7 @@ struct BigFloat < Float
     {% end %}
   end
 
-  def clone
+  def clone : BigFloat
     self
   end
 
@@ -538,7 +538,7 @@ struct Number
 end
 
 struct Int
-  def <=>(other : BigFloat)
+  def <=>(other : BigFloat) : Int32
     -(other <=> self)
   end
 

--- a/src/big/big_int.cr
+++ b/src/big/big_int.cr
@@ -35,7 +35,7 @@ struct BigInt < Int
   # BigInt.new("123_456_789_123_456_789_123_456_789")  # => 123456789123456789123456789
   # BigInt.new("1234567890ABCDEF", base: 16)           # => 1311768467294899695
   # ```
-  def initialize(str : String, base = 10)
+  def initialize(str : String, base : Int32 = 10)
     # Strip leading '+' char to smooth out cases with strings like "+123"
     str = str.lchop('+')
     # Strip '_' to make it compatible with int literals like "1_000_000"
@@ -47,7 +47,7 @@ struct BigInt < Int
   end
 
   # Creates a `BigInt` from the given *num*.
-  def self.new(num : Int::Primitive)
+  def self.new(num : Int::Primitive) : BigInt
     Int.primitive_si_ui_check(num) do |si, ui, _|
       {
         si: begin
@@ -110,23 +110,23 @@ struct BigInt < Int
   end
 
   # :ditto:
-  def self.new(num : BigFloat)
+  def self.new(num : BigFloat) : BigInt
     num.to_big_i
   end
 
   # :ditto:
-  def self.new(num : BigDecimal)
+  def self.new(num : BigDecimal) : BigInt
     num.to_big_i
   end
 
   # :ditto:
-  def self.new(num : BigRational)
+  def self.new(num : BigRational) : BigInt
     num.to_big_i
   end
 
   # Returns *num*. Useful for generic code that does `T.new(...)` with `T`
   # being a `Number`.
-  def self.new(num : BigInt)
+  def self.new(num : BigInt) : BigInt
     num
   end
 
@@ -155,7 +155,7 @@ struct BigInt < Int
     end
   end
 
-  def <=>(other : Float::Primitive)
+  def <=>(other : Float::Primitive) : Int32?
     LibGMP.cmp_d(mpz, other) unless other.nan?
   end
 
@@ -338,7 +338,7 @@ struct BigInt < Int
     {the_q, the_r}
   end
 
-  def unsafe_truncated_divmod(number : BigInt)
+  def unsafe_truncated_divmod(number : BigInt) : Tuple(BigInt, BigInt)
     the_q = BigInt.new
     the_r = BigInt.new { |r| LibGMP.tdiv_qr(the_q, r, self, number) }
     {the_q, the_r}
@@ -385,7 +385,7 @@ struct BigInt < Int
     BigInt.new { |mpz| LibGMP.com(mpz, self) }
   end
 
-  def bit(bit : Int)
+  def bit(bit : Int) : Int32
     return 0 if bit < 0
     return self < 0 ? 1 : 0 if bit > LibGMP::BitcntT::MAX
     LibGMP.tstbit(self, LibGMP::BitcntT.new!(bit))
@@ -792,7 +792,7 @@ struct BigInt < Int
     BigRational.new(self)
   end
 
-  def clone
+  def clone : BigInt
     self
   end
 
@@ -806,7 +806,7 @@ struct BigInt < Int
     pointerof(@mpz)
   end
 
-  def to_unsafe
+  def to_unsafe : Pointer(LibGMP::MPZ)
     mpz
   end
 end
@@ -901,7 +901,7 @@ class String
   #
   # "3a060dbf8d1a5ac3e67bc8f18843fc48".to_big_i(16)
   # ```
-  def to_big_i(base = 10) : BigInt
+  def to_big_i(base : Int32 = 10) : BigInt
     BigInt.new(self, base)
   end
 end
@@ -919,7 +919,7 @@ module Math
   end
 
   # Calculates the integer square root of *value*.
-  def isqrt(value : BigInt)
+  def isqrt(value : BigInt) : BigInt
     BigInt.new { |mpz| LibGMP.sqrt(mpz, value) }
   end
 
@@ -984,7 +984,7 @@ end
 struct Crystal::Hasher
   private HASH_MODULUS_INT_P = BigInt.new(HASH_MODULUS)
 
-  def self.reduce_num(value : BigInt)
+  def self.reduce_num(value : BigInt) : UInt64
     {% if LibGMP::UI == UInt64 %}
       v = LibGMP.tdiv_ui(value, HASH_MODULUS)
       value < 0 ? &-v : v

--- a/src/big/big_rational.cr
+++ b/src/big/big_rational.cr
@@ -46,23 +46,23 @@ struct BigRational < Number
   # Creates an exact representation of float as rational.
   #
   # Raises `ArgumentError` if *num* is not finite.
-  def self.new(num : Float::Primitive)
+  def self.new(num : Float::Primitive) : BigRational
     raise ArgumentError.new "Can only construct from a finite number" unless num.finite?
     new { |mpq| LibGMP.mpq_set_d(mpq, num) }
   end
 
   # Creates an exact representation of float as rational.
-  def self.new(num : BigFloat)
+  def self.new(num : BigFloat) : BigRational
     new { |mpq| LibGMP.mpq_set_f(mpq, num) }
   end
 
   # Creates a `BigRational` from the given *num*.
-  def self.new(num : BigRational)
+  def self.new(num : BigRational) : BigRational
     num
   end
 
   # :ditto:
-  def self.new(num : BigDecimal)
+  def self.new(num : BigDecimal) : BigRational
     num.to_big_r
   end
 
@@ -90,19 +90,19 @@ struct BigRational < Number
     BigInt.new(@mpq._mp_den)
   end
 
-  def <=>(other : BigRational)
+  def <=>(other : BigRational) : Int32
     LibGMP.mpq_cmp(mpq, other)
   end
 
-  def <=>(other : Float::Primitive)
+  def <=>(other : Float::Primitive) : Int32?
     self <=> BigRational.new(other) unless other.nan?
   end
 
-  def <=>(other : BigFloat)
+  def <=>(other : BigFloat) : Int32
     self <=> other.to_big_r
   end
 
-  def <=>(other : Int)
+  def <=>(other : Int) : Int32
     Int.primitive_si_ui_check(other) do |si, ui, big_i|
       {
         si:    LibGMP.mpq_cmp_si(self, {{ si }}, 1),
@@ -112,7 +112,7 @@ struct BigRational < Number
     end
   end
 
-  def <=>(other : BigInt)
+  def <=>(other : BigInt) : Int32
     LibGMP.mpq_cmp_z(self, other)
   end
 
@@ -367,7 +367,7 @@ struct BigRational < Number
     denominator.format(io, separator, delimiter, decimal_places, group: group, only_significant: only_significant)
   end
 
-  def clone
+  def clone : BigRational
     self
   end
 
@@ -375,7 +375,7 @@ struct BigRational < Number
     pointerof(@mpq)
   end
 
-  def to_unsafe
+  def to_unsafe : Pointer(LibGMP::MPQ)
     mpq
   end
 
@@ -402,7 +402,7 @@ struct Int
     BigRational.new(self, 1)
   end
 
-  def <=>(other : BigRational)
+  def <=>(other : BigRational) : Int32
     -(other <=> self)
   end
 
@@ -463,7 +463,7 @@ end
 
 # :nodoc:
 struct Crystal::Hasher
-  def self.reduce_num(value : BigRational)
+  def self.reduce_num(value : BigRational) : UInt64
     inverse = BigInt.new do |mpz|
       if LibGMP.invert(mpz, value.denominator, HASH_MODULUS_INT_P) == 0
         # inverse doesn't exist, i.e. denominator is a multiple of HASH_MODULUS

--- a/src/big/json.cr
+++ b/src/big/json.cr
@@ -11,7 +11,7 @@ class JSON::Builder
 end
 
 struct BigInt
-  def self.new(pull : JSON::PullParser)
+  def self.new(pull : JSON::PullParser) : BigInt
     case pull.kind
     when .int?
       value = pull.raw_value
@@ -38,7 +38,7 @@ struct BigInt
 end
 
 struct BigFloat
-  def self.new(pull : JSON::PullParser)
+  def self.new(pull : JSON::PullParser) : BigFloat
     case pull.kind
     when .int?, .float?
       value = pull.raw_value
@@ -65,7 +65,7 @@ struct BigFloat
 end
 
 struct BigDecimal
-  def self.new(pull : JSON::PullParser)
+  def self.new(pull : JSON::PullParser) : BigDecimal
     case pull.kind
     when .int?, .float?
       value = pull.raw_value

--- a/src/big/yaml.cr
+++ b/src/big/yaml.cr
@@ -1,7 +1,7 @@
 require "yaml"
 require "big"
 
-def BigInt.new(ctx : YAML::ParseContext, node : YAML::Nodes::Node)
+def BigInt.new(ctx : YAML::ParseContext, node : YAML::Nodes::Node) : BigInt
   unless node.is_a?(YAML::Nodes::Scalar)
     node.raise "Expected scalar, not #{node.class}"
   end
@@ -9,7 +9,7 @@ def BigInt.new(ctx : YAML::ParseContext, node : YAML::Nodes::Node)
   BigInt.new(node.value)
 end
 
-def BigFloat.new(ctx : YAML::ParseContext, node : YAML::Nodes::Node)
+def BigFloat.new(ctx : YAML::ParseContext, node : YAML::Nodes::Node) : BigFloat
   unless node.is_a?(YAML::Nodes::Scalar)
     node.raise "Expected scalar, not #{node.class}"
   end
@@ -17,7 +17,7 @@ def BigFloat.new(ctx : YAML::ParseContext, node : YAML::Nodes::Node)
   BigFloat.new(node.value)
 end
 
-def BigDecimal.new(ctx : YAML::ParseContext, node : YAML::Nodes::Node)
+def BigDecimal.new(ctx : YAML::ParseContext, node : YAML::Nodes::Node) : BigDecimal
   unless node.is_a?(YAML::Nodes::Scalar)
     node.raise "Expected scalar, not #{node.class}"
   end


### PR DESCRIPTION
This is the output of compiling [cr-source-typer](https://github.com/Vici37/cr-source-typer) and running it with the below incantation:

```
CRYSTAL_PATH="./src" ./typer spec/std_spec.cr --error-trace --exclude src/crystal/ --stats --progress --union-size-threshold 2 --ignore-private-defs src/big
```

This is related to https://github.com/crystal-lang/crystal/pull/15682 .