### PR TITLE
Handle significant whitespace before a blocks body

### DIFF
--- a/spec/compiler/parser/to_s_spec.cr
+++ b/spec/compiler/parser/to_s_spec.cr
@@ -623,4 +623,28 @@ describe "ASTNode#to_s" do
       }
     %}
     CR
+
+  expect_to_s <<-'CR', <<-'CR'
+    {%
+      ({"a" => "b"} of Nil => Nil).each do |k, v|
+        # stuff and things
+        k + v
+
+        # foo bar
+
+        k + v
+      end
+    %}
+    CR
+  {%
+    ({"a" => "b"} of Nil => Nil).each do |k, v|
+
+      k + v
+
+
+
+      k + v
+    end
+  %}
+  CR
 end

--- a/src/compiler/crystal/syntax/to_s.cr
+++ b/src/compiler/crystal/syntax/to_s.cr
@@ -1182,6 +1182,8 @@ module Crystal
         @str << '|'
       end
 
+      write_extra_newlines node.location, node.body.location
+
       if single_line_block
         @str << ' '
         node.body.accept self


### PR DESCRIPTION
Follow up to https://github.com/crystal-lang/crystal/pull/15568 to handle the case of significant whitespace before a block's body.

Previously code like:
```cr
{%
  ({"a" => "b"} of Nil => Nil).each do |k, v|
    # stuff and things
    k + v

    # foo bar

    k + v
  end
%}
```
Would always be stringified as:
```cr
{%
  ({"a" => "b"} of Nil => Nil).each do |k, v|
    k + v



    k + v
  end
%}
```
But now results in:
```cr
{%
  ({"a" => "b"} of Nil => Nil).each do |k, v|
  
    k + v
  
  
  
    k + v
  end
%}
```