### PR TITLE
Add type restrictions to crypto directory

### DIFF
--- a/src/crypto/bcrypt.cr
+++ b/src/crypto/bcrypt.cr
@@ -56,7 +56,7 @@ class Crypto::Bcrypt
   #
   # Crypto::Bcrypt.hash_secret "secret"
   # ```
-  def self.hash_secret(password, cost = DEFAULT_COST) : String
+  def self.hash_secret(password : String, cost : Int32 = DEFAULT_COST) : String
     # We make a clone here to we don't keep a mutable reference to the original string
     passwordb = password.to_unsafe.to_slice(password.bytesize + 1).clone # include leading 0
     saltb = Random::Secure.random_bytes(SALT_SIZE)
@@ -71,7 +71,7 @@ class Crypto::Bcrypt
   # password = Crypto::Bcrypt.new "secret", "salt_of_16_chars"
   # password.digest
   # ```
-  def self.new(password : String, salt : String, cost = DEFAULT_COST)
+  def self.new(password : String, salt : String, cost : Int32 = DEFAULT_COST) : Crypto::Bcrypt
     # We make a clone here to we don't keep a mutable reference to the original string
     passwordb = password.to_unsafe.to_slice(password.bytesize + 1).clone # include leading 0
     saltb = Base64.decode(salt, SALT_SIZE)

--- a/src/crypto/bcrypt/base64.cr
+++ b/src/crypto/bcrypt/base64.cr
@@ -20,7 +20,7 @@ module Crypto::Bcrypt::Base64
     51, 52, 53, -1, -1, -1, -1, -1,
   ]
 
-  def self.encode(d, len) : String
+  def self.encode(d : Slice(UInt8) | Array(UInt8), len : Int32) : String
     off = 0
 
     String.build do |str|
@@ -57,7 +57,7 @@ module Crypto::Bcrypt::Base64
     end
   end
 
-  def self.decode(string, maxolen) : Bytes
+  def self.decode(string : String, maxolen : Int32) : Bytes
     off, slen, olen = 0, string.size, 0
 
     i = -1

--- a/src/crypto/bcrypt/blowfish.cr
+++ b/src/crypto/bcrypt/blowfish.cr
@@ -3,7 +3,7 @@ require "../blowfish"
 
 # :nodoc:
 class Crypto::Bcrypt::Blowfish < Crypto::Blowfish
-  def enhance_key_schedule(data, key, cost) : Nil
+  def enhance_key_schedule(data : Slice(UInt8), key : Slice(UInt8), cost : Int32) : Nil
     enhance_key_schedule(data, key)
 
     (1_u32 << cost).times do
@@ -12,7 +12,7 @@ class Crypto::Bcrypt::Blowfish < Crypto::Blowfish
     end
   end
 
-  def enhance_key_schedule(data, key) : Nil
+  def enhance_key_schedule(data : Slice(UInt8), key : Slice(UInt8)) : Nil
     pos = 0
 
     0.upto(17) do |i|

--- a/src/crypto/bcrypt/password.cr
+++ b/src/crypto/bcrypt/password.cr
@@ -27,7 +27,7 @@ class Crypto::Bcrypt::Password
   # password = Crypto::Bcrypt::Password.create("super secret", cost: 10)
   # # => $2a$10$rI4xRiuAN2fyiKwynO6PPuorfuoM4L2PVv6hlnVJEmNLjqcibAfHq
   # ```
-  def self.create(password, cost = DEFAULT_COST) : self
+  def self.create(password : String, cost : Int32 = DEFAULT_COST) : self
     new(Bcrypt.hash_secret(password, cost).to_s)
   end
 

--- a/src/crypto/blowfish.cr
+++ b/src/crypto/blowfish.cr
@@ -15,7 +15,7 @@ class Crypto::Blowfish
     @s3 = @s.to_unsafe + 768
   end
 
-  def expand_key(key) : Nil
+  def expand_key(key : Array(UInt8) | Slice(UInt8)) : Nil
     pos = 0
 
     0.upto(17) do |i|
@@ -37,7 +37,7 @@ class Crypto::Blowfish
     end
   end
 
-  def encrypt_pair(l : UInt32, r : UInt32)
+  def encrypt_pair(l : UInt32, r : UInt32) : Tuple(UInt32, UInt32)
     0.upto(@rounds - 1) do |i|
       l ^= @p.to_unsafe[i]
       r ^= f(l)

--- a/src/crypto/subtle.cr
+++ b/src/crypto/subtle.cr
@@ -23,7 +23,7 @@ module Crypto::Subtle
     constant_time_byte_eq(v, 0) == 1
   end
 
-  def self.constant_time_byte_eq(x, y)
+  def self.constant_time_byte_eq(x : UInt8 | Int32, y : Int32 | UInt8) : UInt8 | Int32
     z = ~(x ^ y)
     z &= z >> 4
     z &= z >> 2


### PR DESCRIPTION
This is the output of compiling [cr-source-typer](https://github.com/Vici37/cr-source-typer) and running it with the below incantation:
```
CRYSTAL_PATH="./src" ./typer spec/std_spec.cr \
  --error-trace --exclude src/crystal/ \
  --stats --progress \
  --union-size-threshold 2 \
  --ignore-private-defs \
  src/crypto
```

This is related to https://github.com/crystal-lang/crystal/pull/15682 .