### PR TITLE
Add type restrictions to `CSV`

### DIFF
--- a/src/csv.cr
+++ b/src/csv.cr
@@ -113,7 +113,7 @@ class CSV
   # rows.next # => ["one", "two"]
   # rows.next # => ["three"]
   # ```
-  def self.each_row(string_or_io : String | IO, separator : Char = DEFAULT_SEPARATOR, quote_char : Char = DEFAULT_QUOTE_CHAR)
+  def self.each_row(string_or_io : String | IO, separator : Char = DEFAULT_SEPARATOR, quote_char : Char = DEFAULT_QUOTE_CHAR) : Iterator(Array(String))
     Parser.new(string_or_io, separator, quote_char).each_row
   end
 
@@ -174,7 +174,7 @@ class CSV
   # Headers are always stripped.
   #
   # See `CSV.parse` about the *separator* and *quote_char* arguments.
-  def initialize(string_or_io : String | IO, headers = false, @strip = false, separator : Char = DEFAULT_SEPARATOR, quote_char : Char = DEFAULT_QUOTE_CHAR)
+  def initialize(string_or_io : String | IO, headers : Bool = false, @strip : Bool = false, separator : Char = DEFAULT_SEPARATOR, quote_char : Char = DEFAULT_QUOTE_CHAR)
     @parser = Parser.new(string_or_io, separator, quote_char)
     if headers
       headers = @parser.next_row || ([] of String)
@@ -280,7 +280,7 @@ class CSV
   # A negative index counts from the end.
   # Raises `IndexError` if any column doesn't exist
   # The behavior of returning a tuple is similar to `Hash#values_at`
-  def values_at(*columns : Int)
+  def values_at(*columns : Int) : Tuple(String, String)
     columns.map { |column| row_internal[column] }
   end
 
@@ -288,7 +288,7 @@ class CSV
   # Raises `KeyError` if any header doesn't exist.
   # Raises `CSV::Error` if headers were not requested
   # The behavior of returning a tuple is similar to `Hash#values_at`
-  def values_at(*headers : String)
+  def values_at(*headers : String) : Tuple(String, String)
     headers.map { |header| row_internal[header] }
   end
 
@@ -430,7 +430,7 @@ class CSV
     # A negative index counts from the end.
     # Raises `IndexError` if any column doesn't exist
     # The behavior of returning a tuple is similar to `Hash#values_at`
-    def values_at(*columns : Int)
+    def values_at(*columns : Int) : Tuple(String, String)
       columns.map { |column| self[column] }
     end
 
@@ -438,7 +438,7 @@ class CSV
     # Raises `KeyError` if any header doesn't exist.
     # Raises `CSV::Error` if headers were not requested
     # The behavior of returning a tuple is similar to `Hash#values_at`
-    def values_at(*headers : String)
+    def values_at(*headers : String) : Tuple(String, String)
       headers.map { |header| self[header] }
     end
 

--- a/src/csv.cr
+++ b/src/csv.cr
@@ -280,7 +280,7 @@ class CSV
   # A negative index counts from the end.
   # Raises `IndexError` if any column doesn't exist
   # The behavior of returning a tuple is similar to `Hash#values_at`
-  def values_at(*columns : Int) : Tuple(String, String)
+  def values_at(*columns : Int)
     columns.map { |column| row_internal[column] }
   end
 
@@ -288,7 +288,7 @@ class CSV
   # Raises `KeyError` if any header doesn't exist.
   # Raises `CSV::Error` if headers were not requested
   # The behavior of returning a tuple is similar to `Hash#values_at`
-  def values_at(*headers : String) : Tuple(String, String)
+  def values_at(*headers : String)
     headers.map { |header| row_internal[header] }
   end
 
@@ -430,7 +430,7 @@ class CSV
     # A negative index counts from the end.
     # Raises `IndexError` if any column doesn't exist
     # The behavior of returning a tuple is similar to `Hash#values_at`
-    def values_at(*columns : Int) : Tuple(String, String)
+    def values_at(*columns : Int)
       columns.map { |column| self[column] }
     end
 
@@ -438,7 +438,7 @@ class CSV
     # Raises `KeyError` if any header doesn't exist.
     # Raises `CSV::Error` if headers were not requested
     # The behavior of returning a tuple is similar to `Hash#values_at`
-    def values_at(*headers : String) : Tuple(String, String)
+    def values_at(*headers : String)
       headers.map { |header| self[header] }
     end
 

--- a/src/csv/builder.cr
+++ b/src/csv/builder.cr
@@ -81,7 +81,7 @@ class CSV::Builder
   end
 
   # :nodoc:
-  def quote_cell(value : String)
+  def quote_cell(value : String) : Bool
     append_cell do
       @io << @quote_char
       value.each_char do |char|
@@ -146,7 +146,7 @@ class CSV::Builder
     end
 
     # :ditto:
-    def concat(*values) : Nil
+    def concat(*values : Int32) : Nil
       concat values
     end
 

--- a/src/csv/builder.cr
+++ b/src/csv/builder.cr
@@ -81,7 +81,7 @@ class CSV::Builder
   end
 
   # :nodoc:
-  def quote_cell(value : String) : Bool
+  def quote_cell(value : String) : Nil
     append_cell do
       @io << @quote_char
       value.each_char do |char|
@@ -146,7 +146,7 @@ class CSV::Builder
     end
 
     # :ditto:
-    def concat(*values : Int32) : Nil
+    def concat(*values) : Nil
       concat values
     end
 

--- a/src/csv/error.cr
+++ b/src/csv/error.cr
@@ -10,7 +10,7 @@ class CSV
     getter line_number : Int32
     getter column_number : Int32
 
-    def initialize(message, @line_number, @column_number)
+    def initialize(message : String, @line_number : Int32, @column_number : Int32)
       super("#{message} at line #{@line_number}, column #{@column_number}")
     end
   end

--- a/src/csv/lexer.cr
+++ b/src/csv/lexer.cr
@@ -15,12 +15,12 @@ require "csv"
 # ```
 abstract class CSV::Lexer
   # Creates a CSV lexer from a `String`.
-  def self.new(string : String, separator : Char = DEFAULT_SEPARATOR, quote_char : Char = DEFAULT_QUOTE_CHAR) : CSV::Lexer::StringBased
+  def self.new(string : String, separator : Char = DEFAULT_SEPARATOR, quote_char : Char = DEFAULT_QUOTE_CHAR) : self
     StringBased.new(string, separator, quote_char)
   end
 
   # Creates a CSV lexer from an `IO`.
-  def self.new(io : IO, separator : Char = DEFAULT_SEPARATOR, quote_char : Char = DEFAULT_QUOTE_CHAR) : CSV::Lexer::IOBased
+  def self.new(io : IO, separator : Char = DEFAULT_SEPARATOR, quote_char : Char = DEFAULT_QUOTE_CHAR) : self
     IOBased.new(io, separator, quote_char)
   end
 

--- a/src/csv/lexer.cr
+++ b/src/csv/lexer.cr
@@ -15,12 +15,12 @@ require "csv"
 # ```
 abstract class CSV::Lexer
   # Creates a CSV lexer from a `String`.
-  def self.new(string : String, separator = DEFAULT_SEPARATOR, quote_char = DEFAULT_QUOTE_CHAR)
+  def self.new(string : String, separator : Char = DEFAULT_SEPARATOR, quote_char : Char = DEFAULT_QUOTE_CHAR) : CSV::Lexer::StringBased
     StringBased.new(string, separator, quote_char)
   end
 
   # Creates a CSV lexer from an `IO`.
-  def self.new(io : IO, separator = DEFAULT_SEPARATOR, quote_char = DEFAULT_QUOTE_CHAR)
+  def self.new(io : IO, separator : Char = DEFAULT_SEPARATOR, quote_char : Char = DEFAULT_QUOTE_CHAR) : CSV::Lexer::IOBased
     IOBased.new(io, separator, quote_char)
   end
 

--- a/src/csv/lexer/io_based.cr
+++ b/src/csv/lexer/io_based.cr
@@ -2,7 +2,7 @@ require "csv"
 
 # :nodoc:
 class CSV::Lexer::IOBased < CSV::Lexer
-  def initialize(@io : IO, separator = DEFAULT_SEPARATOR, quote_char = DEFAULT_QUOTE_CHAR)
+  def initialize(@io : IO, separator : Char = DEFAULT_SEPARATOR, quote_char : Char = DEFAULT_QUOTE_CHAR)
     super(separator, quote_char)
     @current_char = @io.read_char || '\0'
   end

--- a/src/csv/lexer/string_based.cr
+++ b/src/csv/lexer/string_based.cr
@@ -2,7 +2,7 @@ require "csv"
 
 # :nodoc:
 class CSV::Lexer::StringBased < CSV::Lexer
-  def initialize(string, separator = DEFAULT_SEPARATOR, quote_char = DEFAULT_QUOTE_CHAR)
+  def initialize(string : String, separator : Char = DEFAULT_SEPARATOR, quote_char : Char = DEFAULT_QUOTE_CHAR)
     super(separator, quote_char)
     @reader = Char::Reader.new(string)
     if @reader.current_char == '\n'

--- a/src/csv/parser.cr
+++ b/src/csv/parser.cr
@@ -27,7 +27,7 @@ class CSV::Parser
   end
 
   # Returns an `Iterator` of `Array(String)` for the remaining rows.
-  def each_row
+  def each_row : Iterator(Array(String))
     RowIterator.new(self)
   end
 


### PR DESCRIPTION
This is the output of compiling [cr-source-typer](https://github.com/Vici37/cr-source-typer) and running it with the below incantation:

```
CRYSTAL_PATH="./src" ./typer spec/std_spec.cr \
  --error-trace --exclude src/crystal/ \
  --stats --progress \
  --union-size-threshold 2 \
  --ignore-private-defs \
  src/csv
```

This is related to https://github.com/crystal-lang/crystal/pull/15682 .