### PR TITLE
Add type restrictions to Digest directory

### DIFF
--- a/src/digest/adler32.cr
+++ b/src/digest/adler32.cr
@@ -17,16 +17,16 @@ class Digest::Adler32 < ::Digest
     LibZ.adler32(0, nil, 0).to_u32
   end
 
-  def self.checksum(data) : UInt32
+  def self.checksum(data : Slice(UInt8) | String) : UInt32
     update(data, initial)
   end
 
-  def self.update(data, adler32 : UInt32) : UInt32
+  def self.update(data : Slice(UInt8) | String, adler32 : UInt32) : UInt32
     slice = data.to_slice
     LibZ.adler32(adler32, slice, slice.size).to_u32
   end
 
-  def self.combine(adler1 : UInt32, adler2 : UInt32, len) : UInt32
+  def self.combine(adler1 : UInt32, adler2 : UInt32, len : Int32) : UInt32
     LibZ.adler32_combine(adler1, adler2, len).to_u32
   end
 

--- a/src/digest/adler32.cr
+++ b/src/digest/adler32.cr
@@ -17,11 +17,11 @@ class Digest::Adler32 < ::Digest
     LibZ.adler32(0, nil, 0).to_u32
   end
 
-  def self.checksum(data : Slice(UInt8) | String) : UInt32
+  def self.checksum(data) : UInt32
     update(data, initial)
   end
 
-  def self.update(data : Slice(UInt8) | String, adler32 : UInt32) : UInt32
+  def self.update(data, adler32 : UInt32) : UInt32
     slice = data.to_slice
     LibZ.adler32(adler32, slice, slice.size).to_u32
   end

--- a/src/digest/crc32.cr
+++ b/src/digest/crc32.cr
@@ -17,11 +17,11 @@ class Digest::CRC32 < ::Digest
     LibZ.crc32(0, nil, 0).to_u32
   end
 
-  def self.checksum(data : String) : UInt32
+  def self.checksum(data) : UInt32
     update(data, initial)
   end
 
-  def self.update(data : Slice(UInt8) | String, crc32 : UInt32) : UInt32
+  def self.update(data, crc32 : UInt32) : UInt32
     slice = data.to_slice
     LibZ.crc32(crc32, slice, slice.size).to_u32
   end

--- a/src/digest/crc32.cr
+++ b/src/digest/crc32.cr
@@ -17,16 +17,16 @@ class Digest::CRC32 < ::Digest
     LibZ.crc32(0, nil, 0).to_u32
   end
 
-  def self.checksum(data) : UInt32
+  def self.checksum(data : String) : UInt32
     update(data, initial)
   end
 
-  def self.update(data, crc32 : UInt32) : UInt32
+  def self.update(data : Slice(UInt8) | String, crc32 : UInt32) : UInt32
     slice = data.to_slice
     LibZ.crc32(crc32, slice, slice.size).to_u32
   end
 
-  def self.combine(crc1 : UInt32, crc2 : UInt32, len) : UInt32
+  def self.combine(crc1 : UInt32, crc2 : UInt32, len : Int32) : UInt32
     LibZ.crc32_combine(crc1, crc2, len).to_u32
   end
 

--- a/src/digest/digest.cr
+++ b/src/digest/digest.cr
@@ -21,7 +21,7 @@ abstract class Digest
   # The modules adds convenient class methods as `Digest::MD5.digest`, `Digest::MD5.hexdigest`.
   module ClassMethods
     # Returns the hash of *data*. *data* must respond to `#to_slice`.
-    def digest(data) : Bytes
+    def digest(data : String) : Bytes
       digest do |ctx|
         ctx.update(data.to_slice)
       end
@@ -85,7 +85,7 @@ abstract class Digest
     #
     # Digest::SHA1.base64digest("foo") # => "C+7Hteo/D9vJXQ3UfzxbwnXaijM="
     # ```
-    def base64digest(data) : String
+    def base64digest(data : String) : String
       base64digest &.update(data)
     end
 

--- a/src/digest/digest.cr
+++ b/src/digest/digest.cr
@@ -21,7 +21,7 @@ abstract class Digest
   # The modules adds convenient class methods as `Digest::MD5.digest`, `Digest::MD5.hexdigest`.
   module ClassMethods
     # Returns the hash of *data*. *data* must respond to `#to_slice`.
-    def digest(data : String) : Bytes
+    def digest(data) : Bytes
       digest do |ctx|
         ctx.update(data.to_slice)
       end
@@ -85,7 +85,7 @@ abstract class Digest
     #
     # Digest::SHA1.base64digest("foo") # => "C+7Hteo/D9vJXQ3UfzxbwnXaijM="
     # ```
-    def base64digest(data : String) : String
+    def base64digest(data) : String
       base64digest &.update(data)
     end
 


### PR DESCRIPTION
This is the output of compiling [cr-source-typer](https://github.com/Vici37/cr-source-typer) and running it with the below incantation:

```
CRYSTAL_PATH="./src" ./typer spec/std_spec.cr \
  --error-trace --exclude src/crystal/ \
  --stats --progress \
  --union-size-threshold 2 \
  --ignore-private-defs \
  --ignore-protected-defs \
  src/csv
```

This is related to https://github.com/crystal-lang/crystal/pull/15682 .