### PR TITLE
Add type restrictions to Dir directory

### DIFF
--- a/src/dir.cr
+++ b/src/dir.cr
@@ -284,14 +284,14 @@ class Dir
   # Dir.mkdir("testdir")
   # Dir.exists?("testdir") # => true
   # ```
-  def self.mkdir(path : Path | String, mode = 0o777) : Nil
+  def self.mkdir(path : Path | String, mode : Int32 = 0o777) : Nil
     Crystal::System::Dir.create(path.to_s, mode)
   end
 
   # Creates a new directory at the given path, including any non-existing
   # intermediate directories. The linux-style permission mode can be specified,
   # with a default of 777 (0o777).
-  def self.mkdir_p(path : Path | String, mode = 0o777) : Nil
+  def self.mkdir_p(path : Path | String, mode : Int32 = 0o777) : Nil
     return if Dir.exists?(path)
 
     path = Path.new path

--- a/src/dir/glob.cr
+++ b/src/dir/glob.cr
@@ -64,7 +64,7 @@ class Dir
   # equivalent to
   # `match: File::MatchOptions.glob_default | File::MatchOptions::DotFiles`.
   @[Deprecated("Use the overload with a `match` parameter instead")]
-  def self.glob(*patterns : Path | String, match_hidden, follow_symlinks = false) : Array(String)
+  def self.glob(*patterns : Path | String, match_hidden : Bool, follow_symlinks : Bool = false) : Array(String)
     glob(patterns, match: match_hidden_to_options(match_hidden), follow_symlinks: follow_symlinks)
   end
 
@@ -138,7 +138,7 @@ class Dir
     record DirectoriesOnly
     record ConstantEntry, path : String, merged : Bool
     record EntryMatch, pattern : String do
-      def matches?(string) : Bool
+      def matches?(string : String) : Bool
         File.match?(pattern, string)
       end
     end
@@ -146,7 +146,7 @@ class Dir
     record ConstantDirectory, path : String
     record RootDirectory
     record DirectoryMatch, pattern : String do
-      def matches?(string) : Bool
+      def matches?(string : String) : Bool
         File.match?(pattern, string)
       end
     end


### PR DESCRIPTION
This is the output of compiling [cr-source-typer](https://github.com/Vici37/cr-source-typer) and running it with the below incantation:

```
CRYSTAL_PATH="./src" ./typer spec/std_spec.cr \
  --error-trace --exclude src/crystal/ \
  --stats --progress \
  --union-size-threshold 2 \
  --ignore-private-defs \
  --ignore-protected-defs \
  src/dir
```

This is related to https://github.com/crystal-lang/crystal/pull/15682 .