### PR TITLE
Improve examples for the syntax highlighter documentation

### DIFF
--- a/src/crystal/syntax_highlighter/colorize.cr
+++ b/src/crystal/syntax_highlighter/colorize.cr
@@ -4,7 +4,11 @@ require "../syntax_highlighter"
 # A syntax highlighter that renders Crystal source code with ANSI escape codes
 # suitable for terminal highlighting.
 #
+# NOTE: To use `Crystal::SyntaxHighlighter::Colorize`, you must explicitly import it with `require "crystal/syntax_highlighter/colorize"`
+#
 # ```
+# require "crystal/syntax_highlighter/colorize"
+#
 # code = %(foo = bar("baz\#{PI + 1}") # comment)
 # colorized = Crystal::SyntaxHighlighter::Colorize.highlight(code)
 # colorized # => "foo \e[91m=\e[0m bar(\e[93m\"baz\#{\e[0;36mPI\e[0;93m \e[0;91m+\e[0;93m \e[0;35m1\e[0;93m}\"\e[0m) \e[90m# comment\e[0m"

--- a/src/crystal/syntax_highlighter/html.cr
+++ b/src/crystal/syntax_highlighter/html.cr
@@ -3,7 +3,11 @@ require "html"
 
 # A syntax highlighter that renders Crystal source code with HTML markup.
 #
+# NOTE: To use `Crystal::SyntaxHighlighter::HTML`, you must explicitly import it with `require "crystal/syntax_highlighter/html"`
+#
 # ```
+# require "crystal/syntax_highlighter/html"
+#
 # code = %(foo = bar("baz\#{PI + 1}") # comment)
 # html = Crystal::SyntaxHighlighter::HTML.highlight(code)
 # html # => "foo <span class=\"o\">=</span> bar(<span class=\"s\">&quot;baz</span><span class=\"i\">\#{</span><span class=\"t\">PI</span> <span class=\"o\">+</span> <span class=\"n\">1</span><span class=\"i\">}</span><span class=\"s\">&quot;</span>) <span class=\"c\"># comment</span>"


### PR DESCRIPTION
## Description

This PR presents changes concerning the syntax highlighter documentation. Explicitly indicating an import for `Crystal::SyntaxHighlighter::Colorize` and `Crystal::SyntaxHighlighter::HTML` classes makes it easier to understand how to use them.