### PR TITLE
Do not add `ReferenceStorage` to `Value`'s subclasses twice

### DIFF
--- a/spec/compiler/semantic/reference_storage_spec.cr
+++ b/spec/compiler/semantic/reference_storage_spec.cr
@@ -69,4 +69,14 @@ describe "Semantic: ReferenceStorage" do
       MyRef(Foo).new.u
       CRYSTAL
   end
+
+  it "adds ReferenceStorage to Value.subclasses once (#15677)" do
+    assert_type(<<-CRYSTAL) { bool }
+      @[Primitive(:ReferenceStorageType)]
+      struct ReferenceStorage(T) < Value
+      end
+
+      {{ Value.subclasses.select(&.<=(ReferenceStorage)).size == 1 ? true : nil }}
+      CRYSTAL
+  end
 end

--- a/src/compiler/crystal/semantic/top_level_visitor.cr
+++ b/src/compiler/crystal/semantic/top_level_visitor.cr
@@ -120,7 +120,7 @@ class Crystal::TopLevelVisitor < Crystal::SemanticVisitor
         when node.splat_index
           node.raise "BUG: Expected ReferenceStorageType to have no splat parameter"
         end
-        type = GenericReferenceStorageType.new @program, scope, name, @program.value, type_vars
+        type = GenericReferenceStorageType.new @program, scope, name, @program.value, type_vars, false
         type.declare_instance_var("@type_id", @program.int32)
         type.can_be_stored = false
       end


### PR DESCRIPTION
Fixes #15677.