### PR TITLE
Add type restrictions to http

### DIFF
--- a/src/http/client.cr
+++ b/src/http/client.cr
@@ -197,7 +197,7 @@ class HTTP::Client
   #
   # This constructor will raise an exception if any scheme but HTTP or HTTPS
   # is used.
-  def self.new(uri : URI, tls : TLSContext = nil)
+  def self.new(uri : URI, tls : TLSContext = nil) : HTTP::Client
     tls = tls_flag(uri, tls)
     host = validate_host(uri)
     new(host, uri.port, tls)
@@ -259,7 +259,7 @@ class HTTP::Client
 
   # Configures this client to perform basic authentication in every
   # request.
-  def basic_auth(username, password) : Nil
+  def basic_auth(username : String, password : String) : Nil
     header = "Basic #{Base64.strict_encode("#{username}:#{password}")}"
     before_request do |request|
       request.headers["Authorization"] = header
@@ -709,7 +709,7 @@ class HTTP::Client
   # response = client.exec "GET", "/"
   # response.body # => "..."
   # ```
-  def exec(method : String, path, headers : HTTP::Headers? = nil, body : BodyType = nil) : HTTP::Client::Response
+  def exec(method : String, path : String, headers : HTTP::Headers? = nil, body : BodyType = nil) : HTTP::Client::Response
     exec new_request method, path, headers, body
   end
 
@@ -739,7 +739,7 @@ class HTTP::Client
   # response = HTTP::Client.exec "GET", "http://www.example.com"
   # response.body # => "..."
   # ```
-  def self.exec(method, url : String | URI, headers : HTTP::Headers? = nil, body : BodyType = nil, tls : TLSContext = nil) : HTTP::Client::Response
+  def self.exec(method : String, url : String | URI, headers : HTTP::Headers? = nil, body : BodyType = nil, tls : TLSContext = nil) : HTTP::Client::Response
     headers = default_one_shot_headers(headers)
     exec(url, tls) do |client, path|
       client.exec method, path, headers, body

--- a/src/http/client/response.cr
+++ b/src/http/client/response.cr
@@ -68,7 +68,7 @@ class HTTP::Client
       end
     end
 
-    def to_io(io : IO)
+    def to_io(io : IO) : Nil
       io << @version << ' ' << @status.code << ' ' << @status_message << "\r\n"
       cookies = @cookies
       headers = cookies ? cookies.add_response_headers(@headers) : @headers

--- a/src/http/common.cr
+++ b/src/http/common.cr
@@ -255,7 +255,7 @@ module HTTP
   end
 
   # :nodoc:
-  def self.serialize_headers_and_body(io, headers : HTTP::Headers, body : String?, body_io, version : String)
+  def self.serialize_headers_and_body(io : IO, headers : HTTP::Headers, body : String?, body_io : IO?, version : String) : Nil
     if body
       serialize_headers_and_string_body(io, headers, body)
     elsif body_io
@@ -282,7 +282,7 @@ module HTTP
     end
   end
 
-  def self.serialize_headers_and_string_body(io, headers : HTTP::Headers, body : String)
+  def self.serialize_headers_and_string_body(io : IO, headers : HTTP::Headers, body : String) : Nil
     headers["Content-Length"] = body.bytesize.to_s
     headers.serialize(io)
     io << "\r\n"
@@ -295,7 +295,7 @@ module HTTP
     io << "\r\n"
   end
 
-  def self.serialize_chunked_body(io, body : IO)
+  def self.serialize_chunked_body(io : IO, body : IO) : Nil
     buf = uninitialized UInt8[8192]
     while (buf_length = body.read(buf.to_slice)) > 0
       buf_length.to_s(io, 16)

--- a/src/http/common.cr
+++ b/src/http/common.cr
@@ -255,7 +255,7 @@ module HTTP
   end
 
   # :nodoc:
-  def self.serialize_headers_and_body(io, headers, body, body_io, version)
+  def self.serialize_headers_and_body(io, headers : HTTP::Headers, body : String?, body_io, version : String)
     if body
       serialize_headers_and_string_body(io, headers, body)
     elsif body_io
@@ -282,7 +282,7 @@ module HTTP
     end
   end
 
-  def self.serialize_headers_and_string_body(io, headers, body)
+  def self.serialize_headers_and_string_body(io, headers : HTTP::Headers, body : String)
     headers["Content-Length"] = body.bytesize.to_s
     headers.serialize(io)
     io << "\r\n"
@@ -295,7 +295,7 @@ module HTTP
     io << "\r\n"
   end
 
-  def self.serialize_chunked_body(io, body)
+  def self.serialize_chunked_body(io, body : IO)
     buf = uninitialized UInt8[8192]
     while (buf_length = body.read(buf.to_slice)) > 0
       buf_length.to_s(io, 16)
@@ -307,7 +307,7 @@ module HTTP
   end
 
   # :nodoc:
-  def self.content_length(headers) : UInt64?
+  def self.content_length(headers : HTTP::Headers) : UInt64?
     length_headers = headers.get? "Content-Length"
     return nil unless length_headers
     first_header = length_headers[0]
@@ -334,7 +334,7 @@ module HTTP
     end
   end
 
-  def self.expect_continue?(headers) : Bool
+  def self.expect_continue?(headers : HTTP::Headers) : Bool
     headers["Expect"]?.try(&.downcase) == "100-continue"
   end
 
@@ -380,7 +380,7 @@ module HTTP
   # quoted = %q(\"foo\\bar\")
   # HTTP.dequote_string(quoted) # => %q("foo\bar")
   # ```
-  def self.dequote_string(str) : String
+  def self.dequote_string(str : String) : String
     data = str.to_slice
     quoted_pair_index = data.index('\\'.ord)
     return str unless quoted_pair_index
@@ -410,7 +410,7 @@ module HTTP
   # io.rewind
   # io.gets_to_end # => %q(\"foo\\\ bar\")
   # ```
-  def self.quote_string(string, io) : Nil
+  def self.quote_string(string : String, io : IO) : Nil
     # Escaping rules: https://evolvis.org/pipermail/evolvis-platfrm-discuss/2014-November/000675.html
 
     string.each_char do |char|
@@ -435,7 +435,7 @@ module HTTP
   # string = %q("foo\ bar")
   # HTTP.quote_string(string) # => %q(\"foo\\\ bar\")
   # ```
-  def self.quote_string(string) : String
+  def self.quote_string(string : String) : String
     String.build do |io|
       quote_string(string, io)
     end

--- a/src/http/content.cr
+++ b/src/http/content.cr
@@ -8,7 +8,7 @@ module HTTP
     @continue_sent = false
     setter expects_continue : Bool = false
 
-    def close
+    def close : Nil
       @expects_continue = false
       super
     end
@@ -73,7 +73,7 @@ module HTTP
       @io.peek
     end
 
-    def skip(bytes_count) : Nil
+    def skip(bytes_count : Int) : Nil
       ensure_send_continue
       @io.skip(bytes_count)
     end
@@ -164,7 +164,7 @@ module HTTP
       peek
     end
 
-    def skip(bytes_count) : Nil
+    def skip(bytes_count : Int) : Nil
       ensure_send_continue
       if bytes_count <= @chunk_remaining
         @io.skip(bytes_count)

--- a/src/http/cookie.cr
+++ b/src/http/cookie.cr
@@ -61,7 +61,7 @@ module HTTP
     # Sets the name of this cookie.
     #
     # Raises `IO::Error` if the value is invalid as per [RFC 6265 §4.1.1](https://tools.ietf.org/html/rfc6265#section-4.1.1).
-    def name=(name : String)
+    def name=(name : String) : Nil
       validate_name(name)
       @name = name
 
@@ -87,7 +87,7 @@ module HTTP
     # Sets the value of this cookie.
     #
     # Raises `IO::Error` if the value is invalid as per [RFC 6265 §4.1.1](https://tools.ietf.org/html/rfc6265#section-4.1.1).
-    def value=(value : String)
+    def value=(value : String) : String
       validate_value(value)
       @value = value
     end
@@ -178,7 +178,7 @@ module HTTP
     end
 
     # :ditto:
-    def to_cookie_header(io) : Nil
+    def to_cookie_header(io : IO) : Nil
       io << @name
       io << '='
       io << @value
@@ -197,7 +197,7 @@ module HTTP
     #
     # *time_reference* can be passed to use a different reference time for
     # comparison. Default is the current time (`Time.utc`).
-    def expired?(time_reference = Time.utc) : Bool
+    def expired?(time_reference : Time = Time.utc) : Bool
       if @max_age.try &.zero?
         true
       elsif expiration_time = self.expiration_time
@@ -253,7 +253,7 @@ module HTTP
     # cookie.value    # => ""
     # cookie.expired? # => true
     # ```
-    def expire
+    def expire : Time::Span
       self.value = ""
       self.expires = Time::UNIX_EPOCH
       self.max_age = Time::Span.zero
@@ -307,13 +307,13 @@ module HTTP
         end
       end
 
-      def parse_cookies(header) : Array(Cookie)
+      def parse_cookies(header : String) : Array(Cookie)
         cookies = [] of Cookie
         parse_cookies(header) { |cookie| cookies << cookie }
         cookies
       end
 
-      def parse_set_cookie(header) : Cookie?
+      def parse_set_cookie(header : String) : Cookie?
         match = header.match(SetCookieString)
         return unless match
 

--- a/src/http/cookies.cr
+++ b/src/http/cookies.cr
@@ -29,12 +29,12 @@ module HTTP
     # Creates a new instance by parsing the `Cookie` headers in the given `HTTP::Headers`.
     #
     # See `HTTP::Client::Response#cookies`.
-    def self.from_client_headers(headers) : self
+    def self.from_client_headers(headers : HTTP::Headers) : self
       new.tap(&.fill_from_client_headers(headers))
     end
 
     # Filling cookies by parsing the `Cookie` headers in the given `HTTP::Headers`.
-    def fill_from_client_headers(headers) : self
+    def fill_from_client_headers(headers : HTTP::Headers) : self
       if values = headers.get?("Cookie")
         values.each do |header|
           Cookie::Parser.parse_cookies(header) { |cookie| self << cookie }
@@ -46,12 +46,12 @@ module HTTP
     # Creates a new instance by parsing the `Set-Cookie` headers in the given `HTTP::Headers`.
     #
     # See `HTTP::Request#cookies`.
-    def self.from_server_headers(headers) : self
+    def self.from_server_headers(headers : HTTP::Headers) : self
       new.tap(&.fill_from_server_headers(headers))
     end
 
     # Filling cookies by parsing the `Set-Cookie` headers in the given `HTTP::Headers`.
-    def fill_from_server_headers(headers) : self
+    def fill_from_server_headers(headers : HTTP::Headers) : self
       if values = headers.get?("Set-Cookie")
         values.each do |header|
           Cookie::Parser.parse_set_cookie(header).try { |cookie| self << cookie }
@@ -77,7 +77,7 @@ module HTTP
     # request = HTTP::Request.new "GET", "/"
     # request.cookies["foo"] = "bar"
     # ```
-    def []=(key, value : String)
+    def []=(key : String, value : String) : HTTP::Cookie
       self[key] = Cookie.new(key, value)
     end
 
@@ -91,7 +91,7 @@ module HTTP
     # response = HTTP::Client::Response.new(200)
     # response.cookies["foo"] = HTTP::Cookie.new("foo", "bar", "/admin", Time.utc + 12.hours, secure: true)
     # ```
-    def []=(key, value : Cookie)
+    def []=(key : String, value : Cookie) : HTTP::Cookie
       unless key == value.name
         raise ArgumentError.new("Cookie name must match the given key")
       end
@@ -104,7 +104,7 @@ module HTTP
     # ```
     # request.cookies["foo"].value # => "bar"
     # ```
-    def [](key) : Cookie
+    def [](key : String) : Cookie
       @cookies[key]
     end
 
@@ -118,7 +118,7 @@ module HTTP
     # request.cookies["foo"] = "bar"
     # request.cookies["foo"]?.try &.value # > "bar"
     # ```
-    def []?(key) : Cookie?
+    def []?(key : String) : Cookie?
       @cookies[key]?
     end
 
@@ -127,7 +127,7 @@ module HTTP
     # ```
     # request.cookies.has_key?("foo") # => true
     # ```
-    def has_key?(key) : Bool
+    def has_key?(key : String) : Bool
       @cookies.has_key?(key)
     end
 
@@ -137,7 +137,7 @@ module HTTP
     # ```
     # response.cookies << HTTP::Cookie.new("foo", "bar", http_only: true)
     # ```
-    def <<(cookie : Cookie)
+    def <<(cookie : Cookie) : HTTP::Cookie
       self[cookie.name] = cookie
     end
 
@@ -149,7 +149,7 @@ module HTTP
     # Deletes and returns the `HTTP::Cookie` for the specified *key*, or
     # returns `nil` if *key* cannot be found in the collection. Note that
     # *key* should match the name attribute of the desired `HTTP::Cookie`.
-    def delete(key) : Cookie?
+    def delete(key : String) : Cookie?
       @cookies.delete(key)
     end
 
@@ -161,7 +161,7 @@ module HTTP
     end
 
     # Returns an iterator over the cookies of this collection.
-    def each
+    def each : Iterator(HTTP::Cookie)
       @cookies.each_value
     end
 
@@ -178,7 +178,7 @@ module HTTP
     # Adds `Cookie` headers for the cookies in this collection to the
     # given `HTTP::Headers` instance and returns it. Removes any existing
     # `Cookie` headers in it.
-    def add_request_headers(headers)
+    def add_request_headers(headers : HTTP::Headers) : HTTP::Headers
       if empty?
         headers.delete("Cookie")
       else
@@ -195,7 +195,7 @@ module HTTP
     # Adds `Set-Cookie` headers for the cookies in this collection to the
     # given `HTTP::Headers` instance and returns it. Removes any existing
     # `Set-Cookie` headers in it.
-    def add_response_headers(headers)
+    def add_response_headers(headers : HTTP::Headers) : HTTP::Headers
       headers.delete("Set-Cookie")
       each do |cookie|
         headers.add("Set-Cookie", cookie.to_set_cookie_header)

--- a/src/http/formdata.cr
+++ b/src/http/formdata.cr
@@ -130,7 +130,7 @@ module HTTP::FormData
   # `multipart/form-data` is not compatible with the original definition in
   # [RFC 2183](https://tools.ietf.org/html/rfc2183), but are instead specified
   # in [RFC 2388](https://tools.ietf.org/html/rfc2388).
-  def self.parse_content_disposition(content_disposition) : {String, FileMetadata}
+  def self.parse_content_disposition(content_disposition : String) : {String, FileMetadata}
     filename = nil
     creation_time = nil
     modification_time = nil

--- a/src/http/formdata/builder.cr
+++ b/src/http/formdata/builder.cr
@@ -45,7 +45,7 @@ module HTTP::FormData
 
     # Adds a form part with the given *name* and *value*. *Headers* can
     # optionally be provided for the form part.
-    def field(name : String, value, headers : HTTP::Headers = HTTP::Headers.new) : Nil
+    def field(name : String, value : _, headers : HTTP::Headers = HTTP::Headers.new) : Nil
       file(name, IO::Memory.new(value.to_s), headers: headers)
     end
 
@@ -53,7 +53,7 @@ module HTTP::FormData
     # *Metadata* can be provided to add extra metadata about the file to the
     # Content-Disposition header for the form part. Other headers can be added
     # using *headers*.
-    def file(name : String, io, metadata : FileMetadata = FileMetadata.new, headers : HTTP::Headers = HTTP::Headers.new)
+    def file(name : String, io : IO, metadata : FileMetadata = FileMetadata.new, headers : HTTP::Headers = HTTP::Headers.new) : Nil
       fail "Cannot add form part: already finished" if @state.finished?
 
       headers["Content-Disposition"] = generate_content_disposition(name, metadata)

--- a/src/http/headers.cr
+++ b/src/http/headers.cr
@@ -57,24 +57,24 @@ struct HTTP::Headers
     @hash = Hash(Key, String | Array(String)).new
   end
 
-  def []=(key, value : String)
+  def []=(key : String | HTTP::Headers::Key, value : String) : String
     check_invalid_header_content(value)
 
     @hash[wrap(key)] = value
   end
 
-  def []=(key, value : Array(String))
+  def []=(key : String, value : Array(String)) : Array(String)
     value.each { |val| check_invalid_header_content val }
 
     @hash[wrap(key)] = value
   end
 
-  def [](key) : String
+  def [](key : String) : String
     values = @hash[wrap(key)]
     concat values
   end
 
-  def []?(key) : String?
+  def []?(key : String) : String?
     fetch(key, nil)
   end
 
@@ -87,7 +87,7 @@ struct HTTP::Headers
   # headers = HTTP::Headers{"Connection" => "keep-alive, Upgrade"}
   # headers.includes_word?("Connection", "Upgrade") # => true
   # ```
-  def includes_word?(key, word) : Bool
+  def includes_word?(key : String, word : String) : Bool
     return false if word.empty?
 
     values = @hash[wrap(key)]?
@@ -132,31 +132,31 @@ struct HTTP::Headers
   # headers.add("Connection", "Upgrade")
   # headers["Connection"] # => "keep-alive,Upgrade"
   # ```
-  def add(key, value : String) : self
+  def add(key : String, value : String) : self
     check_invalid_header_content value
     unsafe_add(key, value)
     self
   end
 
-  def add(key, value : Array(String)) : self
+  def add(key : String, value : Array(String)) : self
     value.each { |val| check_invalid_header_content val }
     unsafe_add(key, value)
     self
   end
 
-  def add?(key, value : String) : Bool
+  def add?(key : String, value : String) : Bool
     return false unless valid_value?(value)
     unsafe_add(key, value)
     true
   end
 
-  def add?(key, value : Array(String)) : Bool
+  def add?(key : String, value : Array(String)) : Bool
     value.each { |val| return false unless valid_value?(val) }
     unsafe_add(key, value)
     true
   end
 
-  def fetch(key, default) : String?
+  def fetch(key : String, default : String?) : String?
     fetch(wrap(key)) { default }
   end
 
@@ -165,7 +165,7 @@ struct HTTP::Headers
     values ? concat(values) : yield key
   end
 
-  def has_key?(key) : Bool
+  def has_key?(key : String) : Bool
     @hash.has_key? wrap(key)
   end
 
@@ -173,7 +173,7 @@ struct HTTP::Headers
     @hash.empty?
   end
 
-  def delete(key) : String?
+  def delete(key : String) : String?
     values = @hash.delete wrap(key)
     values ? concat(values) : nil
   end
@@ -199,7 +199,7 @@ struct HTTP::Headers
   # HTTP::Headers{"Foo" => "bar"} == HTTP::Headers{"Foo" => ["bar"]} # => true
   # HTTP::Headers{"Foo" => "bar"} == HTTP::Headers{"Foo" => "baz"}   # => false
   # ```
-  def ==(other : self)
+  def ==(other : self) : Bool
     # Adapts `Hash#==` to treat string values equal to a single element array.
 
     return false unless @hash.size == other.@hash.size
@@ -247,11 +247,11 @@ struct HTTP::Headers
     end
   end
 
-  def get(key) : Array(String)
+  def get(key : HTTP::Headers::Key | String) : Array(String)
     cast @hash[wrap(key)]
   end
 
-  def get?(key) : Array(String)?
+  def get?(key : String) : Array(String)?
     @hash[wrap(key)]?.try { |value| cast(value) }
   end
 
@@ -263,7 +263,7 @@ struct HTTP::Headers
     dup
   end
 
-  def clone
+  def clone : HTTP::Headers
     dup
   end
 
@@ -339,7 +339,7 @@ struct HTTP::Headers
     end
   end
 
-  def valid_value?(value) : Bool
+  def valid_value?(value : String) : Bool
     invalid_value_char(value).nil?
   end
 

--- a/src/http/request.cr
+++ b/src/http/request.cr
@@ -59,7 +59,7 @@ class HTTP::Request
   # This property is not used by `HTTP::Client`.
   property local_address : Socket::Address?
 
-  def self.new(method : String, resource : String, headers : Headers? = nil, body : String | Bytes | IO | Nil = nil, version = "HTTP/1.1")
+  def self.new(method : String, resource : String, headers : Headers? = nil, body : String | Bytes | IO | Nil = nil, version : String = "HTTP/1.1") : HTTP::Request
     # Duplicate headers to prevent the request from modifying data that the user might hold.
     new(method, resource, headers.try(&.dup), body, version, internal: nil)
   end
@@ -112,7 +112,7 @@ class HTTP::Request
     @method == "HEAD"
   end
 
-  def content_length=(length : Int)
+  def content_length=(length : Int) : String
     headers["Content-Length"] = length.to_s
   end
 
@@ -120,24 +120,24 @@ class HTTP::Request
     HTTP.content_length(headers)
   end
 
-  def body=(body : String)
+  def body=(body : String) : String
     @body = IO::Memory.new(body)
     self.content_length = body.bytesize
   end
 
-  def body=(body : Bytes)
+  def body=(body : Bytes) : String
     @body = IO::Memory.new(body)
     self.content_length = body.size
   end
 
-  def body=(@body : IO)
+  def body=(@body : IO) : IO
   end
 
-  def body=(@body : Nil)
+  def body=(@body : Nil) : Nil
     @headers["Content-Length"] = "0" if @method.in?("POST", "PUT")
   end
 
-  def to_io(io)
+  def to_io(io : IO)
     io << @method << ' ' << resource << ' ' << @version << "\r\n"
     cookies = @cookies
     headers = cookies ? cookies.add_request_headers(@headers) : @headers
@@ -274,7 +274,7 @@ class HTTP::Request
   end
 
   # Sets request's path component.
-  def path=(path)
+  def path=(path : String) : String
     uri.path = path
   end
 
@@ -285,7 +285,7 @@ class HTTP::Request
   end
 
   # Sets request's query component.
-  def query=(value)
+  def query=(value : String) : String
     uri.query = value
     update_query_params
     value

--- a/src/http/request.cr
+++ b/src/http/request.cr
@@ -137,7 +137,7 @@ class HTTP::Request
     @headers["Content-Length"] = "0" if @method.in?("POST", "PUT")
   end
 
-  def to_io(io : IO)
+  def to_io(io : IO) : Nil
     io << @method << ' ' << resource << ' ' << @version << "\r\n"
     cookies = @cookies
     headers = cookies ? cookies.add_request_headers(@headers) : @headers
@@ -149,7 +149,7 @@ class HTTP::Request
 
   # Returns a `HTTP::Request` instance if successfully parsed,
   # `nil` on EOF or `HTTP::Status` otherwise.
-  def self.from_io(io, *, max_request_line_size : Int32 = HTTP::MAX_REQUEST_LINE_SIZE, max_headers_size : Int32 = HTTP::MAX_HEADERS_SIZE) : HTTP::Request | HTTP::Status | Nil
+  def self.from_io(io : IO, *, max_request_line_size : Int32 = HTTP::MAX_REQUEST_LINE_SIZE, max_headers_size : Int32 = HTTP::MAX_HEADERS_SIZE) : HTTP::Request | HTTP::Status | Nil
     line = parse_request_line(io, max_request_line_size)
     return line unless line.is_a?(RequestLine)
 

--- a/src/http/server.cr
+++ b/src/http/server.cr
@@ -175,7 +175,7 @@ class HTTP::Server
   end
 
   # Sets the maximum permitted size for the request line in an HTTP request.
-  def max_request_line_size=(size : Int32)
+  def max_request_line_size=(size : Int32) : Int32
     @processor.max_request_line_size = size
   end
 
@@ -193,7 +193,7 @@ class HTTP::Server
   end
 
   # Sets the maximum permitted combined size for the headers in an HTTP request.
-  def max_headers_size=(size : Int32)
+  def max_headers_size=(size : Int32) : Int32
     @processor.max_headers_size = size
   end
 

--- a/src/http/server.cr
+++ b/src/http/server.cr
@@ -537,7 +537,7 @@ class HTTP::Server
   end
 
   # Builds all handlers as the middleware for `HTTP::Server`.
-  def self.build_middleware(handlers, last_handler : (Context ->)? = nil)
+  def self.build_middleware(handlers : Array(HTTP::Handler), last_handler : (Context ->)? = nil) : HTTP::Handler
     raise ArgumentError.new "You must specify at least one HTTP Handler." if handlers.empty?
     0.upto(handlers.size - 2) { |i| handlers[i].next = handlers[i + 1] }
     handlers.last.next = last_handler if last_handler

--- a/src/http/server/handler.cr
+++ b/src/http/server/handler.cr
@@ -25,7 +25,7 @@ module HTTP::Handler
 
   abstract def call(context : HTTP::Server::Context)
 
-  def call_next(context : HTTP::Server::Context)
+  def call_next(context : HTTP::Server::Context) : HTTP::Server::Response?
     if next_handler = @next
       next_handler.call(context)
     else

--- a/src/http/server/handlers/compress_handler.cr
+++ b/src/http/server/handlers/compress_handler.cr
@@ -10,7 +10,7 @@
 class HTTP::CompressHandler
   include HTTP::Handler
 
-  def call(context)
+  def call(context : HTTP::Server::Context) : HTTP::Server::Response?
     {% if flag?(:without_zlib) %}
       call_next(context)
     {% else %}

--- a/src/http/server/handlers/error_handler.cr
+++ b/src/http/server/handlers/error_handler.cr
@@ -14,7 +14,7 @@ class HTTP::ErrorHandler
   def initialize(@verbose : Bool = false, @log = Log.for("http.server"))
   end
 
-  def call(context) : Nil
+  def call(context : HTTP::Server::Context) : Nil
     call_next(context)
   rescue ex : HTTP::Server::ClientError
     @log.debug(exception: ex.cause) { ex.message }

--- a/src/http/server/handlers/log_handler.cr
+++ b/src/http/server/handlers/log_handler.cr
@@ -10,7 +10,7 @@ class HTTP::LogHandler
   def initialize(@log = Log.for("http.server"))
   end
 
-  def call(context) : Nil
+  def call(context : HTTP::Server::Context) : Nil
     start = Time.monotonic
 
     begin

--- a/src/http/server/request_processor.cr
+++ b/src/http/server/request_processor.cr
@@ -22,7 +22,7 @@ class HTTP::Server::RequestProcessor
     @wants_close = true
   end
 
-  def process(input, output) : Nil
+  def process(input : IO, output : IO) : Nil
     response = Response.new(output)
 
     begin

--- a/src/http/server/response.cr
+++ b/src/http/server/response.cr
@@ -27,7 +27,7 @@ class HTTP::Server
     property output : IO
 
     # :nodoc:
-    def version=(version : String)
+    def version=(version : String) : String
       check_headers
       @version = version
     end
@@ -36,7 +36,7 @@ class HTTP::Server
     # body. If not set, the default value is 200 (OK).
     getter status : HTTP::Status
 
-    def status=(status : HTTP::Status)
+    def status=(status : HTTP::Status) : HTTP::Status
       check_headers
       @status = status
     end
@@ -56,7 +56,7 @@ class HTTP::Server
     end
 
     # :nodoc:
-    def reset
+    def reset : Nil
       # This method is called by RequestProcessor to avoid allocating a new instance for each iteration.
       @headers.clear
       @cookies = nil
@@ -68,13 +68,13 @@ class HTTP::Server
     end
 
     # Convenience method to set the `Content-Type` header.
-    def content_type=(content_type : String)
+    def content_type=(content_type : String) : String
       check_headers
       headers["Content-Type"] = content_type
     end
 
     # Convenience method to set the `Content-Length` header.
-    def content_length=(content_length : Int)
+    def content_length=(content_length : Int) : String
       check_headers
       headers["Content-Length"] = content_length.to_s
     end
@@ -85,7 +85,7 @@ class HTTP::Server
     end
 
     # Convenience method to set the HTTP status code.
-    def status_code=(status_code : Int32)
+    def status_code=(status_code : Int32) : Int32
       self.status = HTTP::Status.new(status_code)
       status_code
     end
@@ -133,7 +133,7 @@ class HTTP::Server
     end
 
     # Sets the status message.
-    def status_message=(status_message : String?)
+    def status_message=(status_message : String?) : String
       check_headers
       @status_message = status_message
     end
@@ -183,7 +183,7 @@ class HTTP::Server
     #
     # Raises `IO::Error` if the response is closed or headers were already
     # sent.
-    def redirect(location : String | URI, status : HTTP::Status = :found)
+    def redirect(location : String | URI, status : HTTP::Status = :found) : Nil
       check_headers
 
       self.status = status

--- a/src/http/status.cr
+++ b/src/http/status.cr
@@ -81,7 +81,7 @@ enum HTTP::Status
   # HTTP::Status.new(123)  # => 123
   # HTTP::Status.new(1000) # raises ArgumentError
   # ```
-  def self.new(status_code : Int32)
+  def self.new(status_code : Int32) : HTTP::Status
     raise ArgumentError.new("Invalid HTTP status code: #{status_code}") unless 100 <= status_code <= 999
     previous_def(status_code)
   end

--- a/src/http/web_socket.cr
+++ b/src/http/web_socket.cr
@@ -34,7 +34,7 @@ class HTTP::WebSocket
   # HTTP::WebSocket.new(
   #   URI.parse("ws://user:password@websocket.example.com/chat")) # Creates a new WebSocket to `websocket.example.com` with an HTTP basic auth Authorization header
   # ```
-  def self.new(uri : URI | String, headers = HTTP::Headers.new)
+  def self.new(uri : URI | String, headers : HTTP::Headers = HTTP::Headers.new) : HTTP::WebSocket
     new(Protocol.new(uri, headers: headers))
   end
 
@@ -47,7 +47,7 @@ class HTTP::WebSocket
   # HTTP::WebSocket.new("websocket.example.com", "/chat")            # Creates a new WebSocket to `websocket.example.com`
   # HTTP::WebSocket.new("websocket.example.com", "/chat", tls: true) # Creates a new WebSocket with TLS to `ẁebsocket.example.com`
   # ```
-  def self.new(host : String, path : String, port = nil, tls : HTTP::Client::TLSContext = nil, headers = HTTP::Headers.new)
+  def self.new(host : String, path : String, port : Int32? = nil, tls : HTTP::Client::TLSContext = nil, headers : HTTP::Headers = HTTP::Headers.new) : HTTP::WebSocket
     new(Protocol.new(host, path, port, tls, headers))
   end
 
@@ -62,15 +62,15 @@ class HTTP::WebSocket
   end
 
   # Called when a text message is received.
-  def on_message(&@on_message : String ->)
+  def on_message(&@on_message : String ->) : Proc(String, Nil)
   end
 
   # Called when a binary message is received.
-  def on_binary(&@on_binary : Bytes ->)
+  def on_binary(&@on_binary : Bytes ->) : Proc(Bytes, Nil)
   end
 
   # Called when the connection is closed by the other party.
-  def on_close(&@on_close : CloseCode, String ->)
+  def on_close(&@on_close : CloseCode, String ->) : Proc(HTTP::WebSocket::CloseCode, String, Nil)
   end
 
   protected def check_open
@@ -78,7 +78,7 @@ class HTTP::WebSocket
   end
 
   # Sends a message payload (message).
-  def send(message) : Nil
+  def send(message : String) : Nil
     check_open
     @ws.send(message)
   end
@@ -92,7 +92,7 @@ class HTTP::WebSocket
   end
 
   # Sends a PONG frame, which must be in response to a previously received PING frame from `#on_ping`.
-  def pong(message = nil) : Nil
+  def pong(message : String? = nil) : Nil
     check_open
     @ws.pong(message)
   end
@@ -126,7 +126,7 @@ class HTTP::WebSocket
 
   # Sends a close frame, and closes the connection.
   # The close frame may contain a body (message) that indicates the reason for closing.
-  def close(code : CloseCode | Int? = nil, message = nil) : Nil
+  def close(code : CloseCode | Int? = nil, message : String? = nil) : Nil
     return if closed?
     @closed = true
     @ws.close(code, message)

--- a/src/http/web_socket/close_code.cr
+++ b/src/http/web_socket/close_code.cr
@@ -17,7 +17,7 @@ enum HTTP::WebSocket::CloseCode
 
   # Create a new instance with the given close code, or raise an
   # error if the close code given is not inside 0..4999.
-  def self.new(close_code : Int32)
+  def self.new(close_code : Int32) : HTTP::WebSocket::CloseCode
     unless 0 <= close_code <= 4999
       raise ArgumentError.new("Invalid HTTP::WebSocket::CloseCode: #{close_code}")
     end

--- a/src/http/web_socket/protocol.cr
+++ b/src/http/web_socket/protocol.cr
@@ -100,7 +100,7 @@ class HTTP::WebSocket::Protocol
     stream_io.flush
   end
 
-  def send(data : Bytes, opcode : Opcode, flags = Flags::FINAL, flush = true) : Nil
+  def send(data : Bytes, opcode : Opcode, flags : HTTP::WebSocket::Protocol::Flags = Flags::FINAL, flush : Bool = true) : Nil
     write_header(data.size, opcode, flags)
     write_payload(data)
     @io.flush if flush
@@ -250,7 +250,7 @@ class HTTP::WebSocket::Protocol
     end
   end
 
-  def pong(message = nil) : Nil
+  def pong(message : String? = nil) : Nil
     if message
       send(message.to_slice, Opcode::PONG)
     else
@@ -258,7 +258,7 @@ class HTTP::WebSocket::Protocol
     end
   end
 
-  def close(code : CloseCode? = nil, message = nil) : Nil
+  def close(code : CloseCode? = nil, message : String? = nil) : Nil
     return if @io.closed?
 
     if message
@@ -282,11 +282,11 @@ class HTTP::WebSocket::Protocol
     @io.close if @sync_close
   end
 
-  def close(code : Int, message = nil) : Nil
+  def close(code : Int, message : String? = nil) : Nil
     close(CloseCode.new(code), message)
   end
 
-  def self.new(host : String, path : String, port = nil, tls : HTTP::Client::TLSContext = nil, headers = HTTP::Headers.new)
+  def self.new(host : String, path : String, port : Int32? = nil, tls : HTTP::Client::TLSContext = nil, headers : HTTP::Headers = HTTP::Headers.new) : HTTP::WebSocket::Protocol
     {% if flag?(:without_openssl) %}
       if tls
         raise "WebSocket TLS is disabled because `-D without_openssl` was passed at compile time"
@@ -338,7 +338,7 @@ class HTTP::WebSocket::Protocol
     new(socket, masked: true)
   end
 
-  def self.new(uri : URI | String, headers = HTTP::Headers.new)
+  def self.new(uri : URI | String, headers : HTTP::Headers = HTTP::Headers.new) : HTTP::WebSocket::Protocol
     uri = URI.parse(uri) if uri.is_a?(String)
 
     if (host = uri.hostname) && (path = uri.request_target)
@@ -352,7 +352,7 @@ class HTTP::WebSocket::Protocol
     raise ArgumentError.new("No host or path specified which are required.")
   end
 
-  def self.key_challenge(key)
+  def self.key_challenge(key : String) : String
     {% if flag?(:without_openssl) %}
       ::Crystal::Digest::SHA1.base64digest(key + GUID)
     {% else %}


### PR DESCRIPTION
This is the output of compiling [cr-source-typer](https://github.com/Vici37/cr-source-typer) and running it with the below incantation:

CRYSTAL_PATH="./src" ./typer spec/std_spec.cr \
  --error-trace --exclude src/crystal/ \
  --stats --progress \
  --union-size-threshold 2 \
  --ignore-private-defs \
  --ignore-protected-defs \
  src/http

This is related to https://github.com/crystal-lang/crystal/pull/15682 .

I also reran the above command but without the --union-size-threshold 2, and updated several long union types to a common base class (typically IO).