### PR TITLE
Fix run win32 console reader in thread instead of isolated context

### DIFF
--- a/src/kernel.cr
+++ b/src/kernel.cr
@@ -1,6 +1,9 @@
 require "crystal/at_exit_handlers"
 
-{% unless flag?(:win32) %}
+{% if flag?(:win32) %}
+  # Set console to UTF-8 and start thread to read from STDIN asynchronously.
+  Crystal::System::FileDescriptor.setup_console
+{% else %}
   require "c/unistd"
 {% end %}
 


### PR DESCRIPTION
Also takes control over when the console is setup for UTF-8 and when we start the thread (in `kernel.cr` right before we start the stdios), instead of running at whatever time during the runtime startup.

Follow up to #15704