### PR TITLE
[Backport release/1.16] Fix show `unit_separator` in `#humanize_bytes` with empty prefix

### DIFF
--- a/spec/std/humanize_spec.cr
+++ b/spec/std/humanize_spec.cr
@@ -301,6 +301,7 @@ describe Int do
     it { assert_prints 1099511627776.humanize_bytes(format: Int::BinaryPrefixFormat::JEDEC), "1.0TB" }
     it { assert_prints 1125899906842624.humanize_bytes(format: Int::BinaryPrefixFormat::JEDEC), "1.0PB" }
     it { assert_prints 1152921504606846976.humanize_bytes(format: Int::BinaryPrefixFormat::JEDEC), "1.0EB" }
+    it { assert_prints 1.humanize_bytes(format: Int::BinaryPrefixFormat::JEDEC, unit_separator: '\u2009'), "1\u2009B" }
     it { assert_prints 1152921504606846976.humanize_bytes(format: Int::BinaryPrefixFormat::JEDEC, unit_separator: '\u2009'), "1.0\u2009EB" }
 
     it { assert_prints 1024.humanize_bytes(format: Int::BinaryPrefixFormat::IEC), "1.0kiB" }

--- a/src/humanize.cr
+++ b/src/humanize.cr
@@ -326,7 +326,7 @@ struct Int
   #
   # See `Number#humanize` for more details on the behaviour and arguments.
   def humanize_bytes(io : IO, precision : Int = 3, separator = '.', *, significant : Bool = true, unit_separator = nil, format : BinaryPrefixFormat = :IEC) : Nil
-    humanize(io, precision, separator, nil, base: 1024, significant: significant) do |magnitude|
+    humanize(io, precision, separator, nil, base: 1024, significant: significant, unit_separator: unit_separator) do |magnitude|
       magnitude = Number.prefix_index(magnitude)
 
       prefix = Number.si_prefix(magnitude)
@@ -334,9 +334,9 @@ struct Int
         unit = "B"
       else
         if format.iec?
-          unit = "#{unit_separator}#{prefix}iB"
+          unit = "#{prefix}iB"
         else
-          unit = "#{unit_separator}#{prefix.upcase}B"
+          unit = "#{prefix.upcase}B"
         end
       end
       {magnitude, unit, magnitude > 0}


### PR DESCRIPTION
Automated backport of #15683 to `release/1.16`, triggered by a label.