### PR TITLE
Fix `-Dtracing` raises math overflows on fiber sleep

### DIFF
--- a/src/crystal/tracing.cr
+++ b/src/crystal/tracing.cr
@@ -106,7 +106,7 @@ module Crystal
         end
 
         def write(value : Time::Span) : Nil
-          write(value.seconds * Time::NANOSECONDS_PER_SECOND + value.nanoseconds)
+          write(value.seconds &* Time::NANOSECONDS_PER_SECOND &+ value.nanoseconds)
         end
 
         def write(value : Bool) : Nil


### PR DESCRIPTION
Using `-Dtracing` and `CRYSTAL_TRACE=sched` can lead to math overflows when a fiber goes to sleep, especially with exception contexts.