### PR TITLE
[Backport release/1.16] Fix `Fiber::ExecutionContext::Isolated#wait` must suspend fiber

### DIFF
--- a/src/fiber/execution_context/isolated.cr
+++ b/src/fiber/execution_context/isolated.cr
@@ -191,9 +191,12 @@ module Fiber::ExecutionContext
     def wait : Nil
       if @running
         node = Fiber::PointerLinkedListNode.new(Fiber.current)
+
         @mutex.synchronize do
           @wait_list.push(pointerof(node)) if @running
         end
+
+        Fiber.suspend
       end
 
       if exception = @exception


### PR DESCRIPTION
Automated backport of #15720 to `release/1.16`, triggered by a label.