### PR TITLE
Fix run win32 console reader in bare thread

### DIFF
--- a/src/crystal/system/win32/file_descriptor.cr
+++ b/src/crystal/system/win32/file_descriptor.cr
@@ -521,11 +521,11 @@ private module ConsoleUtils
   @@read_requests = Deque(ReadRequest).new
   @@bytes_read = Deque(Int32).new
   @@mtx = ::Thread::Mutex.new
-  {% if flag?(:execution_context) %}
-    @@reader_thread = ::Fiber::ExecutionContext::Isolated.new("READER-LOOP") { reader_loop }
-  {% else %}
-    @@reader_thread = ::Thread.new { reader_loop }
-  {% end %}
+
+  # Start a dedicated thread to block on reads from the console. Doesn't need an
+  # isolated execution context because there's no fiber communication (only
+  # thread communication) and only blocking I/O within the thread.
+  @@reader_thread = ::Thread.new { reader_loop }
 
   private def self.reader_loop
     while true


### PR DESCRIPTION
Simpler alternative to #15714 that focuses on dropping the isolated context that depends on the default context (not yet initialized at this point) and we don't need the isolated context bubble wrap anyway.

Closes https://github.com/crystal-lang/crystal/pull/15714