### PR TITLE
[Backport release/1.16] Fix `-Dtracing` raises math overflows on fiber sleep

### DIFF
--- a/src/crystal/tracing.cr
+++ b/src/crystal/tracing.cr
@@ -106,7 +106,7 @@ module Crystal
         end
 
         def write(value : Time::Span) : Nil
-          write(value.seconds * Time::NANOSECONDS_PER_SECOND + value.nanoseconds)
+          write(value.seconds &* Time::NANOSECONDS_PER_SECOND &+ value.nanoseconds)
         end
 
         def write(value : Bool) : Nil


### PR DESCRIPTION
Automated backport of #15722 to `release/1.16`, triggered by a label.