### PR TITLE
[Backport release/1.16] Fix run win32 console reader in bare thread

### DIFF
--- a/src/crystal/system/win32/file_descriptor.cr
+++ b/src/crystal/system/win32/file_descriptor.cr
@@ -519,11 +519,11 @@ private module ConsoleUtils
   @@read_requests = Deque(ReadRequest).new
   @@bytes_read = Deque(Int32).new
   @@mtx = ::Thread::Mutex.new
-  {% if flag?(:execution_context) %}
-    @@reader_thread = ::Fiber::ExecutionContext::Isolated.new("READER-LOOP") { reader_loop }
-  {% else %}
-    @@reader_thread = ::Thread.new { reader_loop }
-  {% end %}
+
+  # Start a dedicated thread to block on reads from the console. Doesn't need an
+  # isolated execution context because there's no fiber communication (only
+  # thread communication) and only blocking I/O within the thread.
+  @@reader_thread = ::Thread.new { reader_loop }
 
   private def self.reader_loop
     while true


### PR DESCRIPTION
Automated backport of #15724 to `release/1.16`, triggered by a label.