### PR TITLE
Fix add missing `#==` overloads for `Log::Metadata::Value` and `YAML::Any`

### DIFF
--- a/spec/std/log/metadata_spec.cr
+++ b/spec/std/log/metadata_spec.cr
@@ -128,4 +128,11 @@ describe Log::Metadata::Value do
   it "json" do
     v({a: 1}).to_json.should eq(%({"a":1}))
   end
+
+  describe "#==" do
+    it "compares with String" do
+      v("foo").should eq "foo"
+      "foo".should eq v("foo")
+    end
+  end
 end

--- a/spec/std/yaml/any_spec.cr
+++ b/spec/std/yaml/any_spec.cr
@@ -453,10 +453,17 @@ describe YAML::Any do
     obj["foo"]["bar"]["baz"][1].as_s.should eq("fox")
   end
 
-  it "compares to other objects" do
-    obj = YAML.parse("- foo\n- bar \n")
-    obj.should eq(%w(foo bar))
-    obj[0].should eq("foo")
+  describe "#==" do
+    it "compares to other objects" do
+      obj = YAML.parse("- foo\n- bar \n")
+      obj.should eq(%w(foo bar))
+      obj[0].should eq("foo")
+    end
+
+    it "compares with Set" do
+      Set{1, 2, 3}.should eq YAML.parse( "!!set { 1, 2, 3 }")
+      YAML.parse( "!!set { 1, 2, 3 }").should eq Set{1, 2, 3}
+    end
   end
 
   it "returns array of any when doing parse all" do

--- a/src/log/metadata.cr
+++ b/src/log/metadata.cr
@@ -231,3 +231,15 @@ class Fiber
     @logging_context = value
   end
 end
+
+class String
+  def ==(other : Log::Metadata::Value)
+    other == self
+  end
+end
+
+struct Value
+  def ==(other : Log::Metadata::Value)
+    other == self
+  end
+end

--- a/src/yaml/any.cr
+++ b/src/yaml/any.cr
@@ -377,6 +377,12 @@ struct Value
   end
 end
 
+struct Struct
+  def ==(other : YAML::Any)
+    self == other.raw
+  end
+end
+
 class Reference
   def ==(other : YAML::Any)
     self == other.raw


### PR DESCRIPTION
These missing methods were detected while exploring https://github.com/crystal-lang/crystal/issues/13409