### PR TITLE
Macro code coverage tool

### DIFF
--- a/doc/man/crystal-tool-macro_code_coverage.adoc
+++ b/doc/man/crystal-tool-macro_code_coverage.adoc
@@ -1,0 +1,46 @@
+= crystal-tool-macro_code_coverage(1)
+:doctype: manpage
+:date: {localdate}
+:crystal_version: {crystal_version}
+:man manual: Crystal Compiler Command Line Reference Guide
+:man source: crystal {crystal_version}
+
+== Name
+crystal-tool-macro_code_coverage - generate a macro code coverage report.
+
+== Synopsis
+*crystal tool macro_code_coverage* [options] [programfile]
+
+== Description
+
+Generate and output a macro code coverage report to STDERR.
+Any exception raised while computing the report is written to STDOUT.
+
+== Options
+
+*-D* _FLAG_, *--define*=_FLAG_::
+  Define a compile-time flag. This is useful to con    ditionally define types, methods, or commands based
+  on flags available at compile time. The default
+  flags are from the target triple given with *--tar*     get-triple or the hosts default, if none is given.
+*-f* _FORMAT_, *--format*=_FORMAT_::
+  Output format 'codecov' (default).
+*-i* _PATH_, *--include*=_PATH_::
+  Include path in output.
+*-e* _PATH_, *--exclude*=_PATH_::
+  Exclude path in output (default: lib).
+*--error-trace*::
+  Show full error trace.
+*--prelude*::
+  Specify prelude to use. The default one initializes
+  the garbage collector. You can also use *--pre*     lude=empty to use no preludes. This can be useful
+  for checking code generation for a specific source
+  code file.
+*-s*, *--stats*::
+Print statistics about the different compiler stages for the current build. Output time and used memory for each compiler
+process.
+*-p*, *--progress*::
+Print statistics about the progress for the current build.
+*-t*, *--time*::
+Print statistics about the execution time.
+*--no-color*::
+Disable colored output.

--- a/doc/man/crystal.adoc
+++ b/doc/man/crystal.adoc
@@ -104,6 +104,8 @@ regex by using the *-e* flag.
 Show implementations for a given call. Use *--cursor*  to specify the cursor position. The format for the cursor position
 is file:line:column.
 
+*crystal-tool-macro_code_coverage*::  Generate a macro code coverage report.
+
 *crystal-tool-types*::  Show type of main variables of file.
 
 *crystal-tool-unreachable(1)*:: Identify methods that are never called

--- a/etc/completion.bash
+++ b/etc/completion.bash
@@ -66,7 +66,7 @@ _crystal()
                 _crystal_compgen_options "${opts}" "${cur}"
             else
                 if [[ "${prev}" == "tool" ]] ; then
-                    local subcommands="context dependencies expand flags format hierarchy implementations types unreachable"
+                    local subcommands="context dependencies expand flags format hierarchy implementations macro_code_coverage types unreachable"
                     _crystal_compgen_options "${subcommands}" "${cur}"
                 else
                     _crystal_compgen_sources "${cur}"

--- a/etc/completion.fish
+++ b/etc/completion.fish
@@ -221,6 +221,19 @@ complete -c crystal -n "__fish_seen_subcommand_from unreachable" -s p -l progres
 complete -c crystal -n "__fish_seen_subcommand_from unreachable" -s t -l time -d "Enable execution time output"
 complete -c crystal -n "__fish_seen_subcommand_from unreachable" -l stdin-filename -d "Source file name to be read from STDIN"
 
+complete -c crystal -n "__fish_seen_subcommand_from tool; and not __fish_seen_subcommand_from $tool_subcommands" -a "macro_code_coverage" -d "generate a macro code coverage report" -x
+complete -c crystal -n "__fish_seen_subcommand_from macro_code_coverage" -s D -l define -d "Define a compile-time flag"
+complete -c crystal -n "__fish_seen_subcommand_from macro_code_coverage" -s f -l format -d "Output format codecov (default)" -a "codecov" -f
+complete -c crystal -n "__fish_seen_subcommand_from macro_code_coverage" -l error-trace -d "Show full error trace"
+complete -c crystal -n "__fish_seen_subcommand_from macro_code_coverage" -s i -l include -d "Include path"
+complete -c crystal -n "__fish_seen_subcommand_from macro_code_coverage" -s e -l exclude -d "Exclude path (default: lib)"
+complete -c crystal -n "__fish_seen_subcommand_from macro_code_coverage" -l no-color -d "Disable colored output"
+complete -c crystal -n "__fish_seen_subcommand_from macro_code_coverage" -l prelude -d "Use given file as prelude"
+complete -c crystal -n "__fish_seen_subcommand_from macro_code_coverage" -s s -l stats -d "Enable statistics output"
+complete -c crystal -n "__fish_seen_subcommand_from macro_code_coverage" -s p -l progress -d "Enable progress output"
+complete -c crystal -n "__fish_seen_subcommand_from macro_code_coverage" -s t -l time -d "Enable execution time output"
+complete -c crystal -n "__fish_seen_subcommand_from macro_code_coverage" -l stdin-filename -d "Source file name to be read from STDIN"
+
 complete -c crystal -n "__fish_seen_subcommand_from tool; and not __fish_seen_subcommand_from $tool_subcommands" -a "types" -d "show type of main variables" -x
 complete -c crystal -n "__fish_seen_subcommand_from types" -s D -l define -d "Define a compile-time flag"
 complete -c crystal -n "__fish_seen_subcommand_from types" -s f -l format -d "Output format text (default) or json" -a "text json" -f

--- a/etc/completion.zsh
+++ b/etc/completion.zsh
@@ -174,6 +174,7 @@ _crystal-tool() {
         "format:format project, directories and/or files"
         "hierarchy:show type hierarchy"
         "implementations:show implementations for given call in location"
+        "macro_code_coverage:generate a macro code coverage report"
         "types:show type of main variables"
         "unreachable:show methods that are never called"
       )
@@ -273,6 +274,18 @@ _crystal-tool() {
             $prelude_args \
             '(--check)--check[exits with error if there is any unreachable code]' \
             '(--tallies)--tallies[print reachable methods and their call counts as well]' \
+            $stdin_filename_args
+        ;;
+
+        (macro_code_coverage)
+          _arguments \
+            $programfile \
+            $help_args \
+            $no_color_args \
+            $exec_args \
+            $include_exclude_args \
+            '(-f --format)'{-f,--format}'[output format: codecov (default)]:' \
+            $prelude_args \
             $stdin_filename_args
         ;;
 

--- a/spec/compiler/crystal/tools/macro_code_coverage_spec.cr
+++ b/spec/compiler/crystal/tools/macro_code_coverage_spec.cr
@@ -1,0 +1,878 @@
+require "../../../spec_helper"
+include Crystal
+
+private def assert_coverage(code, expected_coverage, *, focus : Bool = false, spec_file = __FILE__, spec_line = __LINE__)
+  it focus: focus, file: spec_file, line: spec_line do
+    compiler = Compiler.new true
+    compiler.prelude = "empty"
+    compiler.no_codegen = true
+    result = compiler.compile(Compiler::Source.new(".", code), "fake-no-build")
+
+    processor = MacroCoverageProcessor.new
+    processor.excludes << Path[Dir.current].to_posix.to_s
+    processor.includes << "."
+
+    hits = processor.compute_coverage(result)
+
+    unless hits = hits["."]?
+      fail "Failed to generate coverage", file: spec_file, line: spec_line
+    end
+
+    hits.should eq(expected_coverage), file: spec_file, line: spec_line
+  end
+end
+
+describe "macro_code_coverage" do
+  assert_coverage <<-'CR', {1 => 1}
+    {{ "foo" }}
+    CR
+
+  assert_coverage <<-'CR', {1 => "1/2"}
+    {{ true ? raise("err") : 0 }}
+    CR
+
+  assert_coverage <<-'CR', {1 => "1/2"}
+    {{ true ? 1 : 0 }}
+    CR
+
+  assert_coverage <<-'CR', {1 => 1, 2 => "1/2"}
+    {% begin %}
+      {{true ? 1 : 0}} + {{2}}
+    {% end %}
+    CR
+
+  assert_coverage <<-'CR', {1 => "1/3"}
+    {{ true ? 1 : x == 2 ? 2 : 3 }}
+    CR
+
+  assert_coverage <<-'CR', {2 => "2/3"}
+    macro test(x)
+    {{ x == 1 ? 1 : x == 2 ? 2 : 3 }}
+    end
+
+    test(1)
+    test(2)
+    CR
+
+  assert_coverage <<-'CR', {2 => "3/3"}
+    macro test(x)
+    {{ x == 1 ? 1 : x == 2 ? 2 : 3 }}
+    end
+
+    test(1)
+    test(2)
+    test(3)
+    CR
+
+  assert_coverage <<-'CR', {2 => "3/3"}
+    macro test(x)
+      {{ x == 1 ? 1 : x == 2 ? 2 : 3 }}
+    end
+
+    test(1)
+    test(2)
+    test(3)
+    test(4)
+    CR
+
+  # 1/2 since the raise would prevent the 2nd execution
+  assert_coverage <<-'CR', {2 => "1/2"}
+    macro test(x)
+      {{ 1 == x ? raise("err") : 0 }}
+    end
+
+    test(1)
+    test(2)
+    CR
+
+  assert_coverage <<-'CR', {2 => "2/2"}
+    macro test(x)
+      {{ 1 == x ? raise("err") : 0 }}
+    end
+
+    test(2)
+    test(1)
+    CR
+
+  assert_coverage <<-'CR', {1 => "1/2"}
+    {% tags = (tags = (1 + 1)) ? tags : nil %}
+    CR
+
+  assert_coverage <<-'CR', {1 => 1, 2 => "1/2", 3 => 3}
+    {% for type in [1, 2, 3] %}
+      {% tags = (tags = type) ? tags : nil %}
+      {% tags %}
+    {% end %}
+    CR
+
+  assert_coverage <<-'CR', {1 => "1/2"}
+    {% if true %}1{% else %}0{% end %}
+    CR
+
+  assert_coverage <<-'CR', {1 => "1/3"}
+    {% if false %}1{% elsif false %}2{% else %}3{% end %}
+    CR
+
+  assert_coverage <<-'CR', {1 => "1/6"}
+    {% if false %}{% if false %}1{% else %}2{% end %}{% elsif false %}3{% else %}{% if false %}4{% elsif false %}5{% else %}6{% end %}{% end %}
+    CR
+
+  assert_coverage <<-'CR', {1 => "1/6"}
+    {% if false; if false; 1; else 2; end; elsif false; 3; else; if false; 4; elsif false; 5; else 6; end; end %}
+    CR
+
+  assert_coverage <<-'CR', {1 => "1/5"}
+    {% unless false; if false; 1; else 2; end; else; if false; 4; elsif false; 5; else 6; end; end %}
+    CR
+
+  assert_coverage <<-'CR', {1 => 1}
+    {% raise "foo" %}
+    {{ 2 }}
+    CR
+
+  assert_coverage <<-'CR', {1 => 1, 2 => "1/2", 3 => 1}
+    {% 1 %}
+    {% 2 if false %}
+    {% 3 %}
+    CR
+
+  assert_coverage <<-'CR', {1 => 1, 2 => "1/2", 3 => 1}
+    {% 1 %}
+    {% 2 if true %}
+    {% 3 %}
+    CR
+
+  assert_coverage <<-'CR', {1 => 1, 2 => "1/2", 3 => 1}
+    {% 1 %}
+    {% 2 unless true %}
+    {% 3 %}
+    CR
+
+  assert_coverage <<-'CR', {1 => 1, 2 => "1/2", 3 => 1}
+    {% 1 %}
+    {% 2 unless false %}
+    {% 3 %}
+    CR
+
+  assert_coverage <<-'CR', {2 => "1/2"}
+    macro test(v)
+      {{3 if v == 1}}
+    end
+
+    test 0
+    test 2
+    CR
+
+  assert_coverage <<-'CR', {2 => "2/2"}
+    macro test(v)
+      {{3 if v == 1}}
+    end
+
+    test 2
+    test 1
+    CR
+
+  assert_coverage <<-'CR', {2 => "2/2"}
+    macro test(v)
+      {{3 if v == 1}}
+    end
+
+    test 1
+    test 2
+    test 1
+    CR
+
+  assert_coverage <<-'CR', {2 => 1, 3 => "1/2"}
+    {%
+      if true
+        raise "foo" if Int32 <= Number
+      end
+    %}
+    CR
+
+  assert_coverage <<-'CR', {4 => 1, 5 => "1/2"}
+    macro finished
+      {% verbatim do %}
+        {%
+          if true
+            a = 1 if true
+          end
+        %}
+      {% end %}
+    end
+    CR
+
+  assert_coverage <<-'CR', {4 => 1, 5 => 1, 7 => 0}
+    macro finished
+      {% verbatim do %}
+        {%
+          if true
+            raise "foo"
+          else
+            pp "foo"
+          end
+        %}
+      {% end %}
+    end
+    CR
+
+  assert_coverage <<-'CR', {1 => 1, 2 => 0, 3 => 1, 4 => 1}
+    {% unless true %}
+      {{0}}
+    {% else %}
+      {{1}}
+    {% end %}
+    CR
+
+  assert_coverage <<-'CR', {1 => 1, 2 => 1, 3 => 0, 4 => 0}
+    {% unless false %}
+      {{0}}
+    {% else %}
+      {{1}}
+    {% end %}
+    CR
+
+  assert_coverage <<-'CR', {2 => 1, 4 => 1}
+    {%
+      a, b, c = {1, 2, 3}
+
+      a + b + c
+    %}
+    CR
+
+  assert_coverage <<-'CR', {2 => 2, 6 => 1, 10 => 1}
+    macro test(&)
+      {{yield}}
+    end
+
+    test do
+      {{2 + 1}}
+    end
+
+    test do
+      {{9 + 12}}
+    end
+    CR
+
+  assert_coverage <<-'CR', {2 => 2, 3 => "1/2", 4 => 2, 8 => 0, 13 => 0}
+    macro test(&)
+      {{ 1 + 1 }}
+      {{yield if false}}
+      {{ 2 + 2 }}
+    end
+
+    test do
+      {{2 + 1}}
+      {{1 + 2}}
+    end
+
+    test do
+      {{4 + 5}}
+      {{5 + 4}}
+    end
+    CR
+
+  assert_coverage <<-'CR', {1 => 1, 2 => 1, 3 => 3, 4 => 1, 5 => 2, 6 => 0, 7 => 2, 8 => 2}
+    {% begin %}
+      {% for v in {1, 2, 3} %}
+        {% if v == 2 %}
+          {{v * 2}}
+        {% elsif v > 5 %}
+          {{v * 5}}
+        {% else %}
+          {{v}}
+        {% end %}
+      {% end %}
+    {% end %}
+    CR
+
+  assert_coverage <<-'CR', {1 => 1, 2 => 1, 4 => 2, 5 => 2, 7 => 2}
+    {% begin %}
+      {% for v in [1, 2] %}
+        {%
+          0 + (10 * 10)
+          20 * 20
+        %}
+        {% 30 * 30 %}
+      {% end %}
+    {% end %}
+    CR
+
+  assert_coverage <<-'CR', {1 => 1, 2 => 1, 4 => "1/2", 5 => 2, 7 => 2}
+    {% begin %}
+      {% for v in [1, 2] %}
+        {%
+          0 + (10 * 10) if false
+          20 * 20
+        %}
+        {% 30 * 30 %}
+      {% end %}
+    {% end %}
+    CR
+
+  assert_coverage <<-'CR', {4 => 1, 5 => 1}
+    macro finished
+      {% verbatim do %}
+        {%
+          10 * 10
+          10 * 20
+        %}
+      {% end %}
+    end
+    CR
+
+  assert_coverage <<-'CR', {1 => 1, 3 => 0}
+    {% if false %}
+      # foo
+      {% 1 + 1 %}
+    {% end %}
+    CR
+
+  assert_coverage <<-'CR', {1 => 1, 2 => 1, 3 => 2, 4 => 1, 5 => 1, 6 => 1}
+    {% begin %}
+      {% for vals in [[] of Int32, [1]] %}
+        {% if vals.empty? %}
+          {{1 + 1}}
+        {% else %}
+          {{2 + 2}}
+        {% end %}
+      {% end %}
+    {% end %}
+    CR
+
+  assert_coverage <<-'CR', {3 => 1, 6 => 1, 7 => 1}
+    macro finished
+      {% verbatim do %}
+        {% 10 * 10 %}
+
+        {%
+          20 * 20
+          30 * 30
+        %}
+      {% end %}
+    end
+    CR
+
+  assert_coverage <<-'CR', {4 => 1, 7 => 1}
+    macro finished
+      {% verbatim do %}
+        {%
+          10 * 10
+
+          # Foo
+          10 * 20
+        %}
+      {% end %}
+    end
+    CR
+
+  assert_coverage <<-'CR', {4 => 1, 8 => 1, 10 => 1}
+    macro finished
+      {% verbatim do %}
+        {%
+          10 * 10
+
+          # Foo
+
+          10 * 20
+
+          10 * 10
+        %}
+      {% end %}
+    end
+    CR
+
+  assert_coverage <<-'CR', {4 => 1, 8 => 1, 9 => 1, 13 => 1, 16 => 1, 17 => 1, 22 => 1}
+    macro finished
+      {% verbatim do %}
+        {%
+          10
+
+          # Foo
+
+          20
+          30
+
+          # Bar
+
+          40
+        %}
+        {%
+          50
+          60
+        %}
+
+
+        {%
+          70
+        %}
+      {% end %}
+    end
+    CR
+
+  assert_coverage <<-'CR', {4 => 1, 5 => 3, 6 => 1, 7 => 2, 8 => 1, 10 => 1, 13 => 3}
+    macro finished
+      {% verbatim do %}
+        {%
+          [0, 1, 2].each do |val|
+            str = if val >= 2
+                    "greater or equal to 2"
+                  elsif val == 1
+                    "equals 1"
+                  else
+                    "other"
+                  end
+
+            "Got: " + str
+          end
+        %}
+      {% end %}
+    end
+    CR
+
+  assert_coverage <<-'CR', {4 => 1, 6 => 1, 7 => 1, 8 => 1, 9 => 1}
+    macro finished
+      {% verbatim do %}
+        {%
+          data = {__nil: nil}
+
+          data["foo"] = {
+            id: 1, active: true,
+            name: "foo".upcase,
+            pie: 3.14,
+          }
+        %}
+      {% end %}
+    end
+    CR
+
+  assert_coverage <<-'CR', {4 => 1, 5 => 1, 7 => 1, 8 => 1, 9 => 1, 10 => 1, 11 => 1, 12 => 1}
+    macro finished
+      {% verbatim do %}
+        {%
+          data = {__nil: nil}
+          num = 4
+
+          data["foo"] = {
+            var: num,
+            hash_literal: {} of Nil => Nil,
+            named_tuple_literal: {id: 10},
+            array_literal: [] of Nil,
+            tuple_literal: {1, 2, 3},
+          }
+        %}
+      {% end %}
+    end
+    CR
+
+  assert_coverage <<-'CR', {3 => 1}
+    macro finished
+      {% verbatim do %}
+        {% [1, 2, 3].find(&.+.==(2)) %}
+      {% end %}
+    end
+    CR
+
+  assert_coverage <<-'CR', {3 => 1, 4 => 0}
+    macro finished
+      {% verbatim do %}
+        {% if false %}
+          {% raise "Oh noes" %}
+        {% end %}
+      {% end %}
+    end
+    CR
+
+  assert_coverage <<-'CR', {4 => 1, 7 => 1}
+    macro finished
+      {% verbatim do %}
+        {%
+          if true
+            # Some comment
+            # Another comment
+            10
+          end
+        %}
+      {% end %}
+    end
+    CR
+
+  assert_coverage <<-'CR', {2 => 1, 5 => 1}
+    {%
+      if true
+        # Some comment
+        # Another comment
+        10
+      end
+    %}
+    CR
+
+  assert_coverage <<-'CR', {4 => "1/2"}
+    macro finished
+      {% verbatim do %}
+        {%
+          pp 1 if false
+        %}
+      {% end %}
+    end
+    CR
+
+  assert_coverage <<-'CR', {2 => 1, 4 => 0}
+    macro test(v)
+      {% if v > 1 %}
+        {%
+          pp v.stringify
+        %}
+      {% end %}
+    end
+
+    test 1
+    CR
+
+  assert_coverage <<-'CR', {2 => 1, 4 => 0}
+    macro test(v)
+      {% if v > 1 %}
+        {%
+          val = v.stringify
+
+          pp val
+        %}
+      {% end %}
+    end
+
+    test 1
+    CR
+
+  assert_coverage <<-'CR', {2 => 1, 4 => 1, 6 => 1, 9 => 1, 10 => 1, 11 => 0, 13 => 0}
+    macro test(v)
+      {% if v > 1 %}
+        {%
+          val = v.stringify
+
+          val = "foo"
+        %}
+
+        {% if v == 2 %}
+          {{v}}
+        {% else %}
+          {%
+            pp v * 2
+          %}
+        {% end %}
+      {% end %}
+    end
+
+    test 2
+    CR
+
+  assert_coverage <<-'CR', {1 => 1, 2 => 0}
+    {% for val in [] of Nil %}
+      {% pp 1 %}
+    {% end %}
+    CR
+
+  assert_coverage <<-'CR', {1 => 1, 2 => 0}
+    {% for val in {} of Nil => Nil %}
+      {% pp 1 %}
+    {% end %}
+    CR
+
+  assert_coverage <<-'CR', {1 => 1, 2 => 0}
+    {% for val in (0...0) %}
+      {% pp 1 %}
+    {% end %}
+    CR
+
+  assert_coverage <<-'CR', {2 => 1, 3 => 0}
+    {%
+      ([] of Nil).each do |v|
+        pp v
+        pp 123
+      end
+    %}
+    CR
+
+  assert_coverage <<-'CR', {2 => 1, 3 => 0}
+    {%
+      ([] of Nil).each do |(a, b, c)|
+        pp v
+        pp 123
+      end
+    %}
+    CR
+
+  assert_coverage <<-'CR', {2 => 1, 3 => 0}
+    {%
+      ({} of Nil => Nil).each do |v|
+        pp v
+        pp 123
+      end
+    %}
+    CR
+
+  assert_coverage <<-'CR', {2 => 1, 3 => 0}
+    {%
+      (0...0).each do |v|
+        pp v
+        pp 123
+      end
+    %}
+    CR
+
+  assert_coverage <<-'CR', {2 => 1, 3 => 0}
+    {%
+      ([] of Nil).map do |v|
+        pp v
+        pp 123
+      end
+    %}
+    CR
+
+  assert_coverage <<-'CR', {2 => 1, 3 => 0}
+    {%
+      ([] of Nil).find do |v|
+        v > 1
+      end
+    %}
+    CR
+
+  assert_coverage <<-'CR', {2 => "1/3"}
+    {%
+      v = false || true || false
+    %}
+    CR
+
+  assert_coverage <<-'CR', {2 => "2/2"}
+    {%
+      true && false
+    %}
+    CR
+
+  assert_coverage <<-'CR', {2 => "1/3"}
+    {%
+      v = 1 || 2 || raise "Oh noes"
+    %}
+    CR
+
+  assert_coverage <<-'CR', {2 => "1/3"}
+    macro test(one, two, three)
+      {{one || two || three}}
+    end
+
+    test true, false, false
+    CR
+
+  assert_coverage <<-'CR', {2 => "2/3"}
+    macro test(one, two, three)
+      {{one || two || three}}
+    end
+
+    test true, false, false
+    test false, true, false
+    CR
+
+  assert_coverage <<-'CR', {2 => "3/3"}
+    macro test(one, two, three)
+      {{one || two || three}}
+    end
+
+    test true, false, false
+    test false, true, false
+    test false, false, true
+    CR
+
+  assert_coverage <<-'CR', {2 => "3/3"}
+    {%
+      v = 1 && 2 && 3
+    %}
+    CR
+
+  assert_coverage <<-'CR', {2 => "3/3"}
+    {%
+      v = 1 && 2 && raise "Oh noes"
+    %}
+    CR
+
+  assert_coverage <<-'CR', {4 => 1, 6 => 1, 10 => 1}
+    macro finished
+      {% verbatim do %}
+        {%
+          ({"a" => "b"} of Nil => Nil).each do |k, v|
+            # stuff and things
+            k + v
+
+            # foo bar
+
+            k + v
+          end
+        %}
+      {% end %}
+    end
+    CR
+
+  assert_coverage <<-'CR', {4 => 1, 6 => 1, 7 => 0, 11 => 1, 12 => 1, 15 => 1}
+    macro finished
+      {% verbatim do %}
+        {%
+          a = nil
+
+          if false
+            a = 1
+
+            # Scalar value
+          else
+            a = 4
+            b = 5
+          end
+
+          a
+        %}
+      {% end %}
+    end
+    CR
+
+  assert_coverage <<-'CR', {5 => 1, 6 => 1, 7 => 1, 8 => 1}
+    macro finished
+      {% verbatim do %}
+        {%
+          {
+            type:     String,
+            services: [4, 1, 12]
+              .sort_by { |v| v }
+              .map { |v| v },
+          }
+        %}
+      {% end %}
+    end
+    CR
+
+  assert_coverage <<-'CR', {4 => 1, 5 => 1, 6 => 1}
+    macro finished
+      {% verbatim do %}
+        {%
+        val = "foo"
+                .strip
+                .strip.strip
+        %}
+      {% end %}
+    end
+    CR
+
+  assert_coverage <<-'CR', {4 => 1, 6 => 1, 7 => 0, 9 => 1}
+    macro finished
+      {% verbatim do %}
+        {%
+          if true &&
+              (
+                true ||
+                false
+              )
+            1
+          end
+        %}
+      {% end %}
+    end
+    CR
+
+  assert_coverage <<-'CR', {4 => 1, 5 => 1, 6 => 0, 8 => 1, 9 => 1}
+    macro finished
+      {% verbatim do %}
+        {%
+          if (
+              true ||
+              false
+            ) &&
+            true
+            1
+          end
+        %}
+      {% end %}
+    end
+    CR
+
+  assert_coverage <<-'CR', {4 => 1, 5 => 1, 6 => 1, 8 => 0, 9 => 0}
+    macro finished
+      {% verbatim do %}
+        {%
+          if (
+              false ||
+              false
+            ) &&
+            true
+            1
+          end
+        %}
+      {% end %}
+    end
+    CR
+
+  assert_coverage <<-'CR', {4 => "1/2", 5 => 1, 6 => 1}
+    macro finished
+      {% verbatim do %}
+        {%
+          if (true || false) &&
+            true
+            1
+          end
+        %}
+      {% end %}
+    end
+    CR
+
+  assert_coverage <<-'CR', {4 => "2/2", 5 => 0, 6 => 0}
+    macro finished
+      {% verbatim do %}
+        {%
+          if (true && false) &&
+            true
+            1
+          end
+        %}
+      {% end %}
+    end
+    CR
+
+  assert_coverage <<-'CR', {4 => 1, 6 => 1, 7 => 0, 9 => 1}
+    macro finished
+      {% verbatim do %}
+        {%
+          if (type = Number) &&
+              (
+                Int32 <= type ||
+                false
+              )
+            id
+          end
+        %}
+      {% end %}
+    end
+    CR
+
+  assert_coverage <<-'CR', {4 => 1, 6 => 1, 7 => 0, 9 => 1}
+    macro finished
+      {% verbatim do %}
+        {%
+          if (type = Number) &&
+              (
+                Int32 <= type ||
+                (type < Int && Int8 <= Number)
+              )
+            id
+          end
+        %}
+      {% end %}
+    end
+    CR
+
+  assert_coverage <<-'CR', {2 => 1, 4 => 0, 7 => 0}
+    {%
+      if (type = nil) &&
+          (
+            Int32 <= type ||
+            (type < Int && Int8 <= Number)
+          )
+        id
+      end
+    %}
+    CR
+end

--- a/spec/compiler/parser/to_s_spec.cr
+++ b/spec/compiler/parser/to_s_spec.cr
@@ -749,4 +749,86 @@ describe "ASTNode#to_s" do
         .map do |v| v end
     %}
     CR
+
+  expect_to_s <<-'CR'
+    {%
+      (
+        1
+      )
+    %}
+    CR
+
+  expect_to_s <<-'CR'
+    {%
+      (
+        1
+        2
+      )
+    %}
+    CR
+
+  expect_to_s <<-'CR'
+    {%
+      (
+        true ||
+        false
+      )
+    %}
+    CR
+
+  expect_to_s <<-'CR'
+    {%
+      (
+        true ||
+        false
+      ) && true
+    %}
+    CR
+
+  expect_to_s <<-'CR'
+    {%
+      true && (
+        true ||
+        false
+      )
+    %}
+    CR
+
+  expect_to_s <<-'CR', <<-'CR'
+    {%
+      if (v = 5) &&
+        (
+          1 < v ||
+          (v < 4 && 5 < 6)
+        )
+        123
+      end
+    %}
+    CR
+    {%
+      if (v = 5) &&
+      (
+        1 < v ||
+        (v < 4 && 5 < 6)
+      )
+        123
+      end
+    %}
+    CR
+
+  expect_to_s <<-'CR', <<-'CR'
+    {%
+      if (true || false) &&
+        true
+        1
+      end
+    %}
+    CR
+    {%
+      if (true || false) &&
+      true
+        1
+      end
+    %}
+    CR
 end

--- a/spec/compiler/semantic/restrictions_augmenter_spec.cr
+++ b/spec/compiler/semantic/restrictions_augmenter_spec.cr
@@ -1,8 +1,8 @@
 require "../../spec_helper"
 
-private def expect_augment(before : String, after : String)
+private def expect_augment(before : String, after : String, *, file : String = __FILE__, line : Int32 = __LINE__)
   result = semantic(before)
-  result.node.to_s.chomp.should eq(after.chomp)
+  result.node.to_s.chomp.should eq(after.chomp), file: file, line: line
 end
 
 private def expect_no_augment(code : String, flags = nil)
@@ -30,7 +30,7 @@ private def it_augments_for_ivar(ivar_type : String, expected_type : String, fil
       end
       CRYSTAL
 
-    expect_augment before, after
+    expect_augment before, after, file: file, line: line
   end
 end
 

--- a/src/compiler/crystal/command.cr
+++ b/src/compiler/crystal/command.cr
@@ -46,6 +46,7 @@ class Crystal::Command
         format                   format project, directories and/or files
         hierarchy                show type hierarchy
         implementations          show implementations for given call in location
+        macro_code_coverage      generate a macro code coverage report
         types                    show type of main variables
         unreachable              show methods that are never called
         --help, -h               show this help
@@ -209,6 +210,9 @@ class Crystal::Command
     when "unreachable".starts_with?(tool)
       options.shift
       unreachable
+    when "macro_code_coverage".starts_with?(tool)
+      options.shift
+      macro_code_coverage
     when "--help" == tool, "-h" == tool
       puts COMMANDS_USAGE
       exit
@@ -261,8 +265,8 @@ class Crystal::Command
     end
   end
 
-  private def compile_no_codegen(command, wants_doc = false, hierarchy = false, no_cleanup = false, cursor_command = false, top_level = false, path_filter = false, unreachable_command = false, allowed_formats = ["text", "json"])
-    config = create_compiler command, no_codegen: true, hierarchy: hierarchy, cursor_command: cursor_command, path_filter: path_filter, unreachable_command: unreachable_command, allowed_formats: allowed_formats
+  private def compile_no_codegen(command, wants_doc = false, hierarchy = false, no_cleanup = false, cursor_command = false, top_level = false, path_filter = false, unreachable_command = false, macro_code_coverage = false, allowed_formats = ["text", "json"])
+    config = create_compiler command, no_codegen: true, hierarchy: hierarchy, cursor_command: cursor_command, path_filter: path_filter, unreachable_command: unreachable_command, macro_code_coverage: macro_code_coverage, allowed_formats: allowed_formats
     config.compiler.no_codegen = true
     config.compiler.no_cleanup = no_cleanup
     config.compiler.wants_doc = wants_doc
@@ -349,8 +353,8 @@ class Crystal::Command
                               hierarchy = false, cursor_command = false,
                               single_file = false, dependencies = false,
                               path_filter = false, unreachable_command = false,
-                              allowed_formats = ["text", "json"])
-    compiler = new_compiler
+                              macro_code_coverage = false, allowed_formats = ["text", "json"])
+    compiler = new_compiler macro_code_coverage
     compiler.progress_tracker = @progress_tracker
     compiler.no_codegen = no_codegen
     link_flags = [] of String
@@ -803,7 +807,7 @@ class Crystal::Command
     Command.parse_with_crystal_opts(@options) { |opts| yield opts }
   end
 
-  private def new_compiler
-    @compiler = Compiler.new
+  private def new_compiler(macro_code_coverage : Bool = false)
+    @compiler = Compiler.new macro_code_coverage
   end
 end

--- a/src/compiler/crystal/compiler.cr
+++ b/src/compiler/crystal/compiler.cr
@@ -204,6 +204,8 @@ module Crystal
     # Program that was created for the last compilation.
     property! program : Program
 
+    def initialize(@collect_covered_macro_nodes : Bool = false); end
+
     # Compiles the given *source*, with *output_filename* as the name
     # of the generated executable.
     #
@@ -274,6 +276,7 @@ module Crystal
       program.show_error_trace = show_error_trace?
       program.progress_tracker = @progress_tracker
       program.warnings = @warnings
+      program.collect_covered_macro_nodes = @collect_covered_macro_nodes
       program
     end
 

--- a/src/compiler/crystal/macros/macros.cr
+++ b/src/compiler/crystal/macros/macros.cr
@@ -15,19 +15,65 @@ class Crystal::Program
   record CompiledMacroRun, filename : String, elapsed : Time::Span, reused : Bool
   property compiled_macros_cache = {} of String => CompiledMacroRun
 
+  property? collect_covered_macro_nodes : Bool = false
+  getter covered_macro_nodes = Array({ASTNode, Location, Bool}).new
+  getter collected_covered_macro_nodes = Array(Array({ASTNode, Location, Bool})).new
+  property coverage_interrupt_exception : ::Exception? = nil
+
   def expand_macro(a_macro : Macro, call : Call, scope : Type, path_lookup : Type? = nil, a_def : Def? = nil)
     check_call_to_deprecated_macro a_macro, call
 
     interpreter = MacroInterpreter.new self, scope, path_lookup || scope, a_macro, call, a_def, in_macro: true
     a_macro.body.accept interpreter
-    {interpreter.to_s, interpreter.macro_expansion_pragmas}
+    output_str = interpreter.to_s
+
+    # if interpreter.is_test_file?
+    #   puts "1"
+    #   puts
+
+    #   puts output_str
+
+    #   puts
+    #   puts
+    # end
+    {output_str, interpreter.macro_expansion_pragmas}
+  rescue ex
+    raise ex unless self.collect_covered_macro_nodes?
+
+    raise SkipMacroCodeCoverageException.new ex
+  ensure
+    self.flush_collected_nodes
   end
 
   def expand_macro(node : ASTNode, scope : Type, path_lookup : Type? = nil, free_vars = nil, a_def : Def? = nil)
     interpreter = MacroInterpreter.new self, scope, path_lookup || scope, node.location, def: a_def, in_macro: false
     interpreter.free_vars = free_vars
     node.accept interpreter
-    {interpreter.to_s, interpreter.macro_expansion_pragmas}
+    output_str = interpreter.to_s
+
+    # if interpreter.is_test_file?
+    #   puts "2"
+    #   puts
+
+    #   puts output_str
+
+    #   puts
+    #   puts
+    # end
+    {output_str, interpreter.macro_expansion_pragmas}
+  rescue ex
+    raise ex unless self.collect_covered_macro_nodes?
+
+    raise SkipMacroCodeCoverageException.new ex
+  ensure
+    self.flush_collected_nodes
+  end
+
+  private def flush_collected_nodes : Nil
+    if self.collect_covered_macro_nodes?
+      @collected_covered_macro_nodes << @covered_macro_nodes.dup
+      @covered_macro_nodes.clear
+    end
   end
 
   def parse_macro_source(generated_source, macro_expansion_pragmas, the_macro, node, vars, current_def = nil, inside_type = false, inside_exp = false, mode : Parser::ParseMode = :normal, visibility : Visibility = :public)

--- a/src/compiler/crystal/macros/methods.cr
+++ b/src/compiler/crystal/macros/methods.cr
@@ -958,6 +958,10 @@ module Crystal
           block_arg_key = block.args[0]?
           block_arg_value = block.args[1]?
 
+          if entries.empty?
+            interpreter.collect_covered_node block.body, true, true
+          end
+
           entries.each do |entry|
             interpreter.define_var(block_arg_key.name, entry.key) if block_arg_key
             interpreter.define_var(block_arg_value.name, entry.value) if block_arg_value
@@ -970,6 +974,10 @@ module Crystal
         interpret_check_args(uses_block: true) do
           block_arg_key = block.args[0]?
           block_arg_value = block.args[1]?
+
+          if entries.empty?
+            interpreter.collect_covered_node block.body, true, true
+          end
 
           ArrayLiteral.map(entries) do |entry|
             interpreter.define_var(block_arg_key.name, entry.key) if block_arg_key
@@ -1056,6 +1064,10 @@ module Crystal
           block_arg_key = block.args[0]?
           block_arg_value = block.args[1]?
 
+          if entries.empty?
+            interpreter.collect_covered_node block.body, true, true
+          end
+
           entries.each do |entry|
             interpreter.define_var(block_arg_key.name, MacroId.new(entry.key)) if block_arg_key
             interpreter.define_var(block_arg_value.name, entry.value) if block_arg_value
@@ -1068,6 +1080,10 @@ module Crystal
         interpret_check_args(uses_block: true) do
           block_arg_key = block.args[0]?
           block_arg_value = block.args[1]?
+
+          if entries.empty?
+            interpreter.collect_covered_node block.body, true, true
+          end
 
           ArrayLiteral.map(entries) do |entry|
             interpreter.define_var(block_arg_key.name, MacroId.new(entry.key)) if block_arg_key
@@ -1164,7 +1180,13 @@ module Crystal
         interpret_check_args(uses_block: true) do
           block_arg = block.args.first?
 
-          interpret_to_range(interpreter).each do |num|
+          range = interpret_to_range(interpreter)
+
+          if range.empty?
+            interpreter.collect_covered_node block.body, true, true
+          end
+
+          range.each do |num|
             interpreter.define_var(block_arg.name, NumberLiteral.new(num)) if block_arg
             interpreter.accept block.body
           end
@@ -1175,14 +1197,14 @@ module Crystal
         interpret_check_args(uses_block: true) do
           block_arg = block.args.first?
 
-          interpret_map(interpreter) do |num|
+          interpret_map(block, interpreter) do |num|
             interpreter.define_var(block_arg.name, NumberLiteral.new(num)) if block_arg
             interpreter.accept block.body
           end
         end
       when "to_a"
         interpret_check_args do
-          interpret_map(interpreter) do |num|
+          interpret_map(nil, interpreter) do |num|
             NumberLiteral.new(num)
           end
         end
@@ -1191,8 +1213,14 @@ module Crystal
       end
     end
 
-    def interpret_map(interpreter, &)
-      ArrayLiteral.map(interpret_to_range(interpreter)) do |num|
+    def interpret_map(block, interpreter, &)
+      range = interpret_to_range(interpreter)
+
+      if block && range.empty?
+        interpreter.collect_covered_node block.body, true, true
+      end
+
+      ArrayLiteral.map(range) do |num|
         yield num
       end
     end
@@ -2887,6 +2915,10 @@ private def interpret_array_or_tuple_method(object, klass, method, args, named_a
     interpret_check_args(node: object, uses_block: true) do
       block_arg = block.args.first?
 
+      if object.elements.empty?
+        interpreter.collect_covered_node block.body, true, true
+      end
+
       Crystal::BoolLiteral.new(object.elements.any? do |elem|
         interpreter.define_var(block_arg.name, elem) if block_arg
         interpreter.accept(block.body).truthy?
@@ -2895,6 +2927,10 @@ private def interpret_array_or_tuple_method(object, klass, method, args, named_a
   when "all?"
     interpret_check_args(node: object, uses_block: true) do
       block_arg = block.args.first?
+
+      if object.elements.empty?
+        interpreter.collect_covered_node block.body, true, true
+      end
 
       Crystal::BoolLiteral.new(object.elements.all? do |elem|
         interpreter.define_var(block_arg.name, elem) if block_arg
@@ -2923,6 +2959,10 @@ private def interpret_array_or_tuple_method(object, klass, method, args, named_a
     interpret_check_args(node: object, uses_block: true) do
       block_arg = block.args.first?
 
+      if object.elements.empty?
+        interpreter.collect_covered_node block.body, true, true
+      end
+
       found = object.elements.find do |elem|
         interpreter.define_var(block_arg.name, elem) if block_arg
         interpreter.accept(block.body).truthy?
@@ -2947,6 +2987,10 @@ private def interpret_array_or_tuple_method(object, klass, method, args, named_a
     interpret_check_args(node: object, uses_block: true) do
       block_arg = block.args.first?
 
+      if object.elements.empty?
+        interpreter.collect_covered_node block.body, true, true
+      end
+
       object.elements.each do |elem|
         interpreter.define_var(block_arg.name, elem) if block_arg
         interpreter.accept block.body
@@ -2958,6 +3002,10 @@ private def interpret_array_or_tuple_method(object, klass, method, args, named_a
     interpret_check_args(node: object, uses_block: true) do
       block_arg = block.args[0]?
       index_arg = block.args[1]?
+
+      if object.elements.empty?
+        interpreter.collect_covered_node block.body, true, true
+      end
 
       object.elements.each_with_index do |elem, idx|
         interpreter.define_var(block_arg.name, elem) if block_arg
@@ -2971,6 +3019,10 @@ private def interpret_array_or_tuple_method(object, klass, method, args, named_a
     interpret_check_args(node: object, uses_block: true) do
       block_arg = block.args.first?
 
+      if object.elements.empty?
+        interpreter.collect_covered_node block.body, true, true
+      end
+
       klass.map(object.elements) do |elem|
         interpreter.define_var(block_arg.name, elem) if block_arg
         interpreter.accept block.body
@@ -2980,6 +3032,10 @@ private def interpret_array_or_tuple_method(object, klass, method, args, named_a
     interpret_check_args(node: object, uses_block: true) do
       block_arg = block.args[0]?
       index_arg = block.args[1]?
+
+      if object.elements.empty?
+        interpreter.collect_covered_node block.body, true, true
+      end
 
       klass.map_with_index(object.elements) do |elem, idx|
         interpreter.define_var(block_arg.name, elem) if block_arg
@@ -2999,6 +3055,10 @@ private def interpret_array_or_tuple_method(object, klass, method, args, named_a
     interpret_check_args(node: object, min_count: 0, uses_block: true) do |memo|
       accumulate_arg = block.args.first?
       value_arg = block.args[1]?
+
+      if object.elements.empty?
+        interpreter.collect_covered_node block.body, true, true
+      end
 
       if memo
         object.elements.reduce(memo) do |accumulate, elem|
@@ -3264,6 +3324,10 @@ end
 private def filter(object, klass, block, interpreter, keep = true)
   block_arg = block.args.first?
 
+  if object.elements.empty?
+    interpreter.collect_covered_node block.body, true, true
+  end
+
   klass.new(object.elements.select do |elem|
     interpreter.define_var(block_arg.name, elem) if block_arg
     block_result = interpreter.accept(block.body).truthy?
@@ -3309,6 +3373,10 @@ end
 
 private def sort_by(object, klass, block, interpreter)
   block_arg = block.args.first?
+
+  if object.elements.empty?
+    interpreter.collect_covered_node block.body, true, true
+  end
 
   klass.new(object.elements.sort_by do |elem|
     block_arg.try { |arg| interpreter.define_var(arg.name, elem) }

--- a/src/compiler/crystal/semantic.cr
+++ b/src/compiler/crystal/semantic.cr
@@ -67,7 +67,11 @@ class Crystal::Program
       visitor.vars = main_visitor.vars.dup unless main_visitor.vars.empty?
 
       node.accept visitor
-      visitor.process_finished_hooks
+      begin
+        visitor.process_finished_hooks
+      rescue ex : SkipMacroCodeCoverageException
+        self.coverage_interrupt_exception = ex.cause
+      end
       visitor.new_expansions
     end
     @progress_tracker.stage("Semantic (new)") do

--- a/src/compiler/crystal/semantic/exception.cr
+++ b/src/compiler/crystal/semantic/exception.cr
@@ -306,6 +306,16 @@ module Crystal
     end
   end
 
+  # Raised when another exception is raised when calculating macro code coverage.
+  # Extends `SkipMacroException` to ensure it's also treated as a somewhat non-failure exception.
+  class SkipMacroCodeCoverageException < SkipMacroException
+    def initialize(exception : ::Exception)
+      super "", nil
+      @message = exception.message
+      @cause = exception
+    end
+  end
+
   class Program
     def undefined_class_variable(node, owner, similar_name)
       common = String.build do |str|

--- a/src/compiler/crystal/syntax/to_s.cr
+++ b/src/compiler/crystal/syntax/to_s.cr
@@ -269,9 +269,13 @@ module Crystal
     end
 
     def visit(node : Expressions)
+      is_multiline = false
+
       case node.keyword
       in .paren?
-        @str << '('
+        # Handled via dedicated #in_parenthesis call below
+        is_multiline = (loc = node.location) && (first_loc = node.expressions.first?.try &.location) && (first_loc.line_number > loc.line_number)
+        append_indent if is_multiline
       in .begin?
         @str << "begin"
         @indent += 1
@@ -280,33 +284,35 @@ module Crystal
         # Not a special condition
       end
 
-      if @inside_macro > 0
-        node.expressions.each &.accept self
-      else
-        last_node = nil
+      in_parenthesis node.keyword.paren?, is_multiline do
+        if @inside_macro > 0
+          node.expressions.each &.accept self
+        else
+          last_node = nil
 
-        node.expressions.each_with_index do |exp, i|
-          unless exp.nop?
-            write_extra_newlines (last_node || exp).end_location, exp.location
+          node.expressions.each_with_index do |exp, i|
+            unless exp.nop?
+              write_extra_newlines (last_node || exp).end_location, exp.location
 
-            append_indent unless node.keyword.paren? && i == 0
-            exp.accept self
+              append_indent unless node.keyword.paren? && i == 0
+              exp.accept self
 
-            if (root = @root_level_macro_expressions) && root.same?(node) && i == node.expressions.size - 1
-              # Do not add a trailing newline after the last node in the root `Expressions` within a `MacroExpression`.
-              # This is handled by the `MacroExpression` logic.
-            elsif !(node.keyword.paren? && i == node.expressions.size - 1)
-              newline
+              if (root = @root_level_macro_expressions) && root.same?(node) && i == node.expressions.size - 1
+                # Do not add a trailing newline after the last node in the root `Expressions` within a `MacroExpression`.
+                # This is handled by the `MacroExpression` logic.
+              elsif !(node.keyword.paren? && i == node.expressions.size - 1)
+                newline
+              end
+
+              last_node = exp
             end
-
-            last_node = exp
           end
         end
       end
 
       case node.keyword
       in .paren?
-        @str << ')'
+        # Handled via dedicated #in_parenthesis call above
       in .begin?
         @indent -= 1
         append_indent
@@ -585,18 +591,28 @@ module Crystal
       end
     end
 
-    def in_parenthesis(need_parens, &)
-      if need_parens
-        @str << '('
-        yield
-        @str << ')'
-      else
-        yield
+    def in_parenthesis(need_parens, is_multiline = false, &)
+      @str << '(' if need_parens
+
+      if is_multiline
+        newline
+        @indent += 1
+        append_indent
       end
+
+      yield
+
+      if is_multiline
+        newline
+        @indent -= 1
+        append_indent
+      end
+
+      @str << ')' if need_parens
     end
 
-    def in_parenthesis(need_parens, node)
-      in_parenthesis(need_parens) do
+    def in_parenthesis(need_parens, node, is_multiline = false)
+      in_parenthesis(need_parens, is_multiline) do
         if node.is_a?(Expressions) && node.expressions.size == 1
           node.expressions.first.accept self
         else
@@ -1269,14 +1285,23 @@ module Crystal
 
     def to_s_binary(node, op)
       left_needs_parens = need_parens(node.left)
-      in_parenthesis(left_needs_parens, node.left)
+      left_parens_multiline = left_needs_parens && (begin_loc = node.left.location) && (end_loc = node.left.end_location) && (end_loc.line_number > begin_loc.line_number)
+      in_parenthesis(left_needs_parens, node.left, left_parens_multiline)
 
       @str << ' '
       @str << op
-      @str << ' '
+
+      if (right_loc = node.right.location) && (left_end_loc = node.left.end_location) && (right_loc.line_number > left_end_loc.line_number)
+        newline
+        append_indent
+      else
+        @str << ' '
+      end
 
       right_needs_parens = need_parens(node.right)
-      in_parenthesis(right_needs_parens, node.right)
+      right_parens_multiline = right_needs_parens && (begin_loc = node.right.location) && (end_loc = node.right.end_location) && (end_loc.line_number > begin_loc.line_number)
+      in_parenthesis(right_needs_parens, node.right, right_parens_multiline)
+
       false
     end
 

--- a/src/compiler/crystal/syntax/to_s.cr
+++ b/src/compiler/crystal/syntax/to_s.cr
@@ -7,8 +7,8 @@ module Crystal
       to_s(io)
     end
 
-    def to_s(io : IO, macro_expansion_pragmas = nil, emit_doc = false) : Nil
-      visitor = ToSVisitor.new(io, macro_expansion_pragmas: macro_expansion_pragmas, emit_doc: emit_doc)
+    def to_s(io : IO, macro_expansion_pragmas = nil, emit_doc = false, emit_location_pragmas : Bool = false) : Nil
+      visitor = ToSVisitor.new(io, macro_expansion_pragmas: macro_expansion_pragmas, emit_doc: emit_doc, emit_location_pragmas: emit_location_pragmas)
       self.accept visitor
     end
   end
@@ -35,7 +35,7 @@ module Crystal
       BLOCK_ARG
     end
 
-    def initialize(@str = IO::Memory.new, @macro_expansion_pragmas = nil, @emit_doc = false)
+    def initialize(@str = IO::Memory.new, @macro_expansion_pragmas = nil, @emit_doc = false, @emit_location_pragmas : Bool = false)
       @indent = 0
       @inside_macro = 0
     end
@@ -342,19 +342,39 @@ module Crystal
     end
 
     def visit_if_or_unless(prefix, node)
+      if @emit_location_pragmas && (loc = node.location) && (filename = loc.filename).is_a?(String)
+        @str << %(#<loc:"#{filename}",#{loc.line_number},#{loc.column_number}>)
+      end
+
       @str << prefix
       @str << ' '
       node.cond.accept self
       newline
+
+      if @emit_location_pragmas && (loc = node.then.location) && (filename = loc.filename).is_a?(String)
+        @str << %(#<loc:"#{filename}",#{loc.line_number},#{loc.column_number}>)
+      end
+
       accept_with_indent(node.then)
       unless node.else.nop?
         append_indent
         @str << "else"
         newline
+
+        if @emit_location_pragmas && (loc = node.else.location) && (filename = loc.filename).is_a?(String)
+          @str << %(#<loc:"#{filename}",#{loc.line_number},#{loc.column_number}>)
+        end
+
         accept_with_indent(node.else)
       end
       append_indent
+
+      if @emit_location_pragmas && (loc = node.end_location) && (filename = loc.filename).is_a?(String)
+        @str << %(#<loc:"#{filename}",#{loc.line_number},#{loc.column_number}>)
+      end
+
       @str << "end"
+
       false
     end
 

--- a/src/compiler/crystal/tools/macro_code_coverage.cr
+++ b/src/compiler/crystal/tools/macro_code_coverage.cr
@@ -1,0 +1,218 @@
+require "../syntax/ast"
+require "../compiler"
+require "json"
+
+module Crystal
+  class Command
+    private def macro_code_coverage
+      config, result = compile_no_codegen "tool macro_code_coverage", path_filter: true, macro_code_coverage: true, allowed_formats: ["codecov"]
+
+      coverage_processor = MacroCoverageProcessor.new
+
+      coverage_processor.includes.concat config.includes.map { |path| ::Path[path].expand.to_posix.to_s }
+
+      coverage_processor.excludes.concat CrystalPath.default_paths.map { |path| ::Path[path].expand.to_posix.to_s }
+      coverage_processor.excludes.concat config.excludes.map { |path| ::Path[path].expand.to_posix.to_s }
+
+      coverage_processor.process result
+    end
+  end
+
+  struct MacroCoverageProcessor
+    private CURRENT_DIR = Dir.current
+
+    @hits = Hash(String, Hash(Int32, Int32 | String)).new { |hash, key| hash[key] = Hash(Int32, Int32 | String).new(0) }
+    @conditional_hit_cache = Hash(String, Hash(Int32, Set({ASTNode, Bool}))).new { |hash, key| hash[key] = Hash(Int32, Set({ASTNode, Bool})).new { |h, k| h[k] = Set({ASTNode, Bool}).new } }
+
+    property includes = [] of String
+    property excludes = [] of String
+
+    def process(result : Compiler::Result) : Nil
+      @hits.clear
+
+      self.compute_coverage result
+
+      if err = result.program.coverage_interrupt_exception
+        puts "Encountered an error while computing coverage report:"
+        puts
+        err.inspect_with_backtrace STDOUT
+        puts
+        puts
+      end
+
+      self.write_output STDERR
+
+      exit 1 if err
+    end
+
+    # See https://docs.codecov.com/docs/codecov-custom-coverage-format
+    private def write_output(io : IO) : Nil
+      JSON.build io, indent: "  " do |builder|
+        builder.object do
+          builder.string "coverage"
+          builder.object do
+            @hits.each do |filename, line_coverage|
+              builder.field filename do
+                builder.object do
+                  line_coverage.to_a.sort_by! { |(line, count)| line }.each do |line, count|
+                    builder.field line, count
+                  end
+                end
+              end
+            end
+          end
+        end
+      end
+    end
+
+    # First filters the nodes to only those with locations we care about.
+    # The nodes are then chunked by line number, essentially grouping them.
+    # Each group is then processed to determine if that line is a hit or miss, but may also yield more than once, such as to mark an `If` conditional as a hit, but it's `else` block as a miss.
+    #
+    # The coverage information is stored in a similar way as the resulting output report: https://docs.codecov.com/docs/codecov-custom-coverage-format.
+    def compute_coverage(result : Compiler::Result)
+      result.program.collected_covered_macro_nodes
+        .select { |nodes| nodes.any? { |(_, location, _)| match_path? location.filename.as(String) } }
+        .each do |nodes|
+          nodes
+            .chunk { |(_, location, _)| location.line_number }
+            .each do |(line_number, nodes_by_line)|
+              self.process_line(line_number, nodes_by_line) do |(count, location, branches)|
+                next unless location.filename.is_a? String
+
+                location = self.normalize_location(location)
+
+                # p({location, count})
+
+                @hits[location.filename][location.line_number] = case existing_hits = @hits[location.filename][location.line_number]?
+                                                                 in String
+                                                                   hits, _, total = existing_hits.partition '/'
+
+                                                                   "#{(hits.to_i + count).clamp(1, total.to_i)}/#{total}"
+                                                                 in Int32 then existing_hits + count
+                                                                 in Nil
+                                                                   branches && count >= 1 ? "#{count.clamp(1, branches)}/#{branches}" : count
+                                                                 end
+              end
+            end
+          # puts ""
+          # puts "-" * 10
+          # puts ""
+        end
+
+      # pp @conditional_hit_cache
+
+      @hits
+    end
+
+    private alias NodeTuple = {ASTNode, Location, Bool}
+
+    private def process_line(line : Int32, nodes : Array(NodeTuple), & : {Int32, Location, Int32?} ->) : Nil
+      # nodes.each do |(node, location, missed)|
+      #   p({node: node.to_s.gsub("\n", "|=|"), class: node.class, location: location, end_location: node.end_location, missed: missed})
+      # end
+
+      # puts ""
+
+      # It's safe to use the first location since they were chunked by line.
+      _, location, _ = nodes.first
+
+      # Check for conditional hits first so that suffix conditionals are still treated as `1/2`.
+      if match = has_conditional_node?(nodes)
+        conditional_node, branches = match
+
+        # Keep track of what specific conditional branches were hit and missed as to enure a proper partial count
+        # We'll use the last missed node, or the last one if none were missed.
+        node, _, missed = nodes.reverse.find(nodes.last) { |_, _, is_missed| !is_missed }
+        newly_hit = @conditional_hit_cache[location.filename][location.line_number].add?({node, missed})
+
+        hit_count = if newly_hit
+                      if conditional_node.is_a?(If | Unless) && (loc = conditional_node.location) && (end_loc = conditional_node.end_location) && loc.line_number == end_loc.line_number
+                        # Special case: Handle suffix `If` and `Unless` given there is no missed node in this context.
+                        1
+                      elsif nodes.all? { |(_, _, missed)| missed }
+                        # If all nodes on this line were missed, it's a miss
+                        0
+                      else
+                        # Otherwise, if no nodes were missed on this line, then all branches of this conditional were hit at once.
+                        nodes.none? { |(_, _, missed)| missed } ? branches : 1
+                      end
+                    else
+                      0
+                    end
+
+        # p({newly_hit: newly_hit, hit_count: hit_count, location: location, branches: branches})
+
+        yield({hit_count, location, branches})
+        return
+      end
+
+      # If no nodes on this line were missed, we can be assured it was a hit
+      if nodes.none? { |(_, _, missed)| missed }
+        yield({1, location, nil})
+        return
+      end
+
+      yield({0, location, nil})
+    end
+
+    private def has_conditional_node?(nodes : Array(NodeTuple)) : {ASTNode, Int32}?
+      nodes.each do |(node, _, _)|
+        if (n = node).is_a?(If | Unless | MacroIf | Or | And) && (branches = self.conditional_statement_branches(n)) > 1
+          return node, branches.not_nil!
+        end
+      end
+    end
+
+    # Returns how many unique values a conditional statement could return on a single line.
+    private def conditional_statement_branches(node : If | Unless | MacroIf | Or | And) : Int32
+      return 1 unless start_location = node.location
+      return 1 unless end_location = node.end_location
+      return 1 if end_location.line_number > start_location.line_number
+
+      self.count_branches node
+    end
+
+    private def count_branches(node : Or | And) : Int32
+      self.count_branches node.left, node.right
+    end
+
+    private def count_branches(node : MacroIf | If | Unless) : Int32
+      self.count_branches node.then, node.else
+    end
+
+    private def count_branches(left : ASTNode, right : ASTNode) : Int32
+      then_depth = case n = left
+                   when MacroIf, If, Unless, Or, And then self.count_branches n
+                   else
+                     1
+                   end
+
+      else_depth = case n = right
+                   when MacroIf, If, Unless, Or, And then self.count_branches n
+                   else
+                     1
+                   end
+
+      then_depth + else_depth
+    end
+
+    private def normalize_location(location : Location) : Location
+      Location.new(
+        ::Path[location.filename.as(String)].relative_to(CURRENT_DIR).to_s,
+        location.line_number,
+        location.column_number
+      )
+    end
+
+    private def match_path?(path)
+      paths = ::Path[path].parents << ::Path[path]
+
+      match_any_pattern?(includes, paths) || !match_any_pattern?(excludes, paths)
+    end
+
+    private def match_any_pattern?(patterns, paths)
+      patterns.any? { |pattern| paths.any? { |path| path == pattern || File.match?(pattern, path.to_posix) } }
+    end
+  end
+end


### PR DESCRIPTION
## Intro

This PR represents an initial implementation of a new compiler tool to generate a https://docs.codecov.com/docs/codecov-custom-coverage-format coverage report for macro code. Functionally, the tool feels very robust, with a ton of spec coverage. I tested it out on the various macro code within Athena and I'm at the point now where I'm satisfied with how it's working to the point where I feel comfortable opening this PR.

I've created the PR as a draft as it depends on some other PRs, and because it intentionally includes debug code commented out. The intent/goal around this PR is to mainly show off the implementation thus far, and to solicit feedback either in the form of other changes that would make this PR's implementation simpler, or general high level tweaks.

Please go try it out on your own project(s) to see if you can find any problems/issues.

## Implementation Overview

At a high level the current implementation adds a new crystal tool that when executed enables a new collect_covered_macro_nodes property on the program. When enabled, the macro interpreter will collect macro AST nodes via the #collect_covered_node method. Because a new macro interpreter is used for each expansion, the collected nodes are "flushed" to another array pending processing via the tool after each macro is expanded.

The tool itself iterates over each "group" of collected nodes from each expansion, skipping any that do not relate to user code. It then iterates over reach "group", chunking them based on the line number. The chunking ensures that each node can increment that line's count by `1` or `0`, not how many nodes are on that single line.

From here, we then perform some heuristics to determine if a given line was a hit, partial hit, or a miss. Partial hits are kept track by caching the specific conditionals and if it was a hit/miss on a line so we can know how many paths of the total possibilities we hit on that single line.

Macro raise is handled by raising a new SkipMacroCodeCoverageException that extends SkipMacroException. Rescuing this exception allows the tool to run on the code that was collected up to before the exception was raised, while not resulting in an error/running all the other code after it. The exception's message/trace is printed to STDOUT while the report is written to STDERR. This is esp useful for testing error flows of custom macro logic as it allows the code to assert the proper error was raised, while still allowing to save the coverage report. I.e. the report JSON/exception outputs are not co-mingled. The main benefit of this is preventing the need to run these kind of tests twice, once for the coverage report and once for the actual test assertions.

Depends on #15709

Resolves #14880