### PR TITLE
Fix: raise on manual fiber resume from sleep

### DIFF
--- a/src/crystal/event_loop/iocp.cr
+++ b/src/crystal/event_loop/iocp.cr
@@ -194,7 +194,7 @@ class Crystal::EventLoop::IOCP < Crystal::EventLoop
     # running the evloop and dequeue the event in parallel, so a "can't resume
     # dead fiber" can still happen in a MT execution context.
     delete_timer(pointerof(timer))
-    raise "BUG: #{timer.fiber} called sleep(#{duration}) but was manually resumed before the timer expired!"
+    raise "BUG: #{timer.fiber} called sleep but was manually resumed before the timer expired!"
   end
 
   # Suspend the current fiber for *duration* and returns true if the timer

--- a/src/crystal/event_loop/iocp.cr
+++ b/src/crystal/event_loop/iocp.cr
@@ -131,9 +131,7 @@ class Crystal::EventLoop::IOCP < Crystal::EventLoop
     fiber = timer.value.fiber
 
     case timer.value.type
-    in .sleep?
-      # nothing to do
-    in .timeout?
+    in .sleep?, .timeout?
       timer.value.timed_out!
     in .select_timeout?
       return unless select_action = fiber.timeout_select_action
@@ -188,6 +186,15 @@ class Crystal::EventLoop::IOCP < Crystal::EventLoop
     timer = Timer.new(:sleep, Fiber.current, duration)
     add_timer(pointerof(timer))
     Fiber.suspend
+
+    # safety check
+    return if event.timed_out?
+
+    # try to avoid a double resume if possible, but another thread might be
+    # running the evloop and dequeue the event in parallel, so a "can't resume
+    # dead fiber" can still happen in a MT execution context.
+    delete_timer(pointerof(event))
+    raise "BUG: #{event.fiber} called sleep(#{duration}) but was manually resumed before the timer expired!"
   end
 
   # Suspend the current fiber for *duration* and returns true if the timer

--- a/src/crystal/event_loop/iocp.cr
+++ b/src/crystal/event_loop/iocp.cr
@@ -188,13 +188,13 @@ class Crystal::EventLoop::IOCP < Crystal::EventLoop
     Fiber.suspend
 
     # safety check
-    return if event.timed_out?
+    return if timer.timed_out?
 
     # try to avoid a double resume if possible, but another thread might be
     # running the evloop and dequeue the event in parallel, so a "can't resume
     # dead fiber" can still happen in a MT execution context.
-    delete_timer(pointerof(event))
-    raise "BUG: #{event.fiber} called sleep(#{duration}) but was manually resumed before the timer expired!"
+    delete_timer(pointerof(timer))
+    raise "BUG: #{timer.fiber} called sleep(#{duration}) but was manually resumed before the timer expired!"
   end
 
   # Suspend the current fiber for *duration* and returns true if the timer

--- a/src/crystal/event_loop/polling.cr
+++ b/src/crystal/event_loop/polling.cr
@@ -145,7 +145,7 @@ abstract class Crystal::EventLoop::Polling < Crystal::EventLoop
     # running the evloop and dequeue the event in parallel, so a "can't resume
     # dead fiber" can still happen in a MT execution context.
     delete_timer(pointerof(event))
-    raise "BUG: #{event.fiber} called sleep(#{duration}) but was manually resumed before the timer expired!"
+    raise "BUG: #{event.fiber} called sleep but was manually resumed before the timer expired!"
   end
 
   def create_timeout_event(fiber : Fiber) : FiberEvent

--- a/src/crystal/event_loop/polling.cr
+++ b/src/crystal/event_loop/polling.cr
@@ -137,6 +137,15 @@ abstract class Crystal::EventLoop::Polling < Crystal::EventLoop
     event = Event.new(:sleep, Fiber.current, timeout: duration)
     add_timer(pointerof(event))
     Fiber.suspend
+
+    # safety check
+    return if event.timed_out?
+
+    # try to avoid a double resume if possible, but another thread might be
+    # running the evloop and dequeue the event in parallel, so a "can't resume
+    # dead fiber" can still happen in a MT execution context.
+    delete_timer(pointerof(event))
+    raise "BUG: #{event.fiber} called sleep(#{duration}) but was manually resumed before the timer expired!"
   end
 
   def create_timeout_event(fiber : Fiber) : FiberEvent
@@ -551,7 +560,7 @@ abstract class Crystal::EventLoop::Polling < Crystal::EventLoop
       return unless select_action.time_expired?
       fiber.@timeout_event.as(FiberEvent).clear
     when .sleep?
-      # nothing to do
+      event.value.timed_out!
     else
       raise RuntimeError.new("BUG: unexpected event in timers: #{event.value}%s\n")
     end


### PR DESCRIPTION
We can suspend a fiber by calling `sleep(time)` and we expect the fiber to only be resumed when the sleep time expires, but there is nothing preventing to enqueue the fiber (because of errors), which will unexpectedly resume the fiber early.

This leads to at best errors (`wake_at` can't be nil) as well as segfaults because the event, allocated on the stack, is still in timers the sleep method returned, or to double resumes, ...

This should usually not happen, unless there is a programming error in the runtime, or someone wants to use `sleep` as a timeout mechanism (it's not).

I discovered this the hard way while implementing sync primitives. Having an explicit exception is much nicer than segfaults and timer related errors because `Fiber.yield` got manually resumed.