### PR TITLE
Do not use private linkage for slice literal buffers

### DIFF
--- a/spec/primitives/slice_spec.cr
+++ b/spec/primitives/slice_spec.cr
@@ -2,9 +2,14 @@ require "spec"
 require "../support/number"
 require "../support/interpreted"
 
+private module Foo
+  def self.foo
+    Slice.literal(1)
+  end
+end
+
 describe "Primitives: Slice" do
   describe ".literal" do
-    # TODO: implement in the interpreter
     {% for num in BUILTIN_NUMBER_TYPES %}
       it {{ "creates a read-only Slice(#{num})" }} do
         slice = Slice({{ num }}).literal(0, 1, 4, 9, 16, 25)
@@ -29,5 +34,9 @@ describe "Primitives: Slice" do
         slice.read_only?.should be_true
       end
     {% end %}
+
+    it "links against slice literal from a different LLVM module" do
+      Foo.foo.should eq(Slice.literal(1))
+    end
   end
 end

--- a/src/compiler/crystal/codegen/codegen.cr
+++ b/src/compiler/crystal/codegen/codegen.cr
@@ -449,7 +449,11 @@ module Crystal
       end
 
       global = @llvm_mod.globals.add(llvm_element_type.array(info.args.size), info.name)
-      global.linkage = LLVM::Linkage::Private
+      if @llvm_mod != @main_mod
+        global.linkage = LLVM::Linkage::External
+      elsif @single_module
+        global.linkage = LLVM::Linkage::Internal
+      end
       global.global_constant = true
       global.initializer = llvm_element_type.const_array(llvm_elements)
     end


### PR DESCRIPTION
The following snippet used to fail because a method in `Foo`'s LLVM module refers to a `$Slice:*` buffer variable defined in the main LLVM module:

```crystal
module Foo
  def self.foo
    Slice.literal(1)
  end
end

Foo.foo
```

The correct linkage is now used for the `$Slice:*` variables.

The existing workaround is to move the literal to a constant, in which case the constant initializer (`const_init` or `const_read`) is also defined in the main LLVM module, thus eliminating the link-time failure. But see also #15701.