### PR TITLE
Add `Crystal::EventLoop::FileDescriptor#open`

### DIFF
--- a/src/crystal/event_loop/file_descriptor.cr
+++ b/src/crystal/event_loop/file_descriptor.cr
@@ -1,5 +1,14 @@
 abstract class Crystal::EventLoop
   module FileDescriptor
+    # Opens a file at *path* from the disk.
+    #
+    # Blocks the current fiber until the file has been opened. Avoids blocking
+    # the current thread if possible, especially when *blocking* is `false` or
+    # `nil`.
+    #
+    # Returns the system file descriptor or handle, or a system error.
+    abstract def open(path : String, flags : Int32, permissions : File::Permissions, blocking : Bool?) : System::FileDescriptor::Handle | Errno | WinError
+
     # Reads at least one byte from the file descriptor into *slice*.
     #
     # Blocks the current fiber if no data is available for reading, continuing

--- a/src/crystal/event_loop/file_descriptor.cr
+++ b/src/crystal/event_loop/file_descriptor.cr
@@ -1,6 +1,6 @@
 abstract class Crystal::EventLoop
   module FileDescriptor
-    # Opens a file at *path* from the disk.
+    # Opens a file at *path*.
     #
     # Blocks the current fiber until the file has been opened. Avoids blocking
     # the current thread if possible, especially when *blocking* is `false` or

--- a/src/crystal/event_loop/iocp.cr
+++ b/src/crystal/event_loop/iocp.cr
@@ -216,6 +216,26 @@ class Crystal::EventLoop::IOCP < Crystal::EventLoop
     FiberEvent.new(:select_timeout, fiber)
   end
 
+  def open(path : String, flags : Int32, permissions : File::Permissions, blocking : Bool?) : System::FileDescriptor::Handle | WinError
+    access, disposition, attributes = System::File.posix_to_open_opts(flags, permissions, blocking)
+
+    handle = LibC.CreateFileW(
+      System.to_wstr(path),
+      access,
+      LibC::DEFAULT_SHARE_MODE, # UNIX semantics
+      nil,
+      disposition,
+      attributes,
+      LibC::HANDLE.null
+    )
+
+    if handle == LibC::INVALID_HANDLE_VALUE
+      WinError.value
+    else
+      handle.address
+    end
+  end
+
   def read(file_descriptor : Crystal::System::FileDescriptor, slice : Bytes) : Int32
     System::IOCP.overlapped_operation(file_descriptor, "ReadFile", file_descriptor.read_timeout) do |overlapped|
       ret = LibC.ReadFile(file_descriptor.windows_handle, slice, slice.size, out byte_count, overlapped)

--- a/src/crystal/event_loop/libevent.cr
+++ b/src/crystal/event_loop/libevent.cr
@@ -108,6 +108,18 @@ class Crystal::EventLoop::LibEvent < Crystal::EventLoop
     end
   end
 
+  def open(path : String, flags : Int32, permissions : File::Permissions, blocking : Bool?) : System::FileDescriptor::Handle | Errno
+    path.check_no_null_byte
+
+    fd = LibC.open(path, flags | LibC::O_CLOEXEC, permissions)
+
+    if fd == -1
+      Errno.value
+    else
+      fd
+    end
+  end
+
   def read(file_descriptor : Crystal::System::FileDescriptor, slice : Bytes) : Int32
     evented_read(file_descriptor, "Error reading file_descriptor") do
       LibC.read(file_descriptor.fd, slice, slice.size).tap do |return_code|

--- a/src/crystal/event_loop/polling.cr
+++ b/src/crystal/event_loop/polling.cr
@@ -145,6 +145,18 @@ abstract class Crystal::EventLoop::Polling < Crystal::EventLoop
 
   # file descriptor interface, see Crystal::EventLoop::FileDescriptor
 
+  def open(path : String, flags : Int32, permissions : File::Permissions, blocking : Bool?) : System::FileDescriptor::Handle | Errno
+    path.check_no_null_byte
+
+    fd = LibC.open(path, flags | LibC::O_CLOEXEC, permissions)
+
+    if fd == -1
+      Errno.value
+    else
+      fd
+    end
+  end
+
   def read(file_descriptor : System::FileDescriptor, slice : Bytes) : Int32
     size = evented_read(file_descriptor, slice, file_descriptor.@read_timeout)
 

--- a/src/crystal/event_loop/wasi.cr
+++ b/src/crystal/event_loop/wasi.cr
@@ -28,6 +28,10 @@ class Crystal::EventLoop::Wasi < Crystal::EventLoop
     raise NotImplementedError.new("Crystal::Wasi::EventLoop.create_fd_read_event")
   end
 
+  def open(filename : String, flags : Int32, permissions : File::Permissions, blocking : Bool?) : System::FileDescriptor::Handle | Errno | WinError
+    raise NotImplementedError.new("Crystal::Wasi::EventLoop#open")
+  end
+
   def read(file_descriptor : Crystal::System::FileDescriptor, slice : Bytes) : Int32
     evented_read(file_descriptor, "Error reading file_descriptor") do
       LibC.read(file_descriptor.fd, slice, slice.size).tap do |return_code|

--- a/src/crystal/system/file.cr
+++ b/src/crystal/system/file.cr
@@ -1,5 +1,7 @@
 # :nodoc:
 module Crystal::System::File
+  # def self.open(filename : String, mode : String, perm : Int32 | ::File::Permissions, blocking : Bool?) : FileDescriptor::Handle
+
   # Helper method for calculating file open modes on systems with posix-y `open`
   # calls.
   private def self.open_flag(mode)
@@ -50,7 +52,7 @@ module Crystal::System::File
   LOWER_ALPHANUM = "0123456789abcdefghijklmnopqrstuvwxyz".to_slice
 
   def self.mktemp(prefix : String?, suffix : String?, dir : String, random : ::Random = ::Random::DEFAULT) : {FileDescriptor::Handle, String}
-    mode = LibC::O_RDWR | LibC::O_CREAT | LibC::O_EXCL
+    flags = LibC::O_RDWR | LibC::O_CREAT | LibC::O_EXCL
     perm = ::File::Permissions.new(0o600)
 
     prefix = ::File.join(dir, prefix || "")
@@ -65,27 +67,17 @@ module Crystal::System::File
         io << suffix
       end
 
-      handle, errno = open(path, mode, perm, blocking: true)
-
-      if error_is_none?(errno)
-        return {handle, path}
-      elsif error_is_file_exists?(errno)
+      case result = EventLoop.current.open(path, flags, perm, blocking: true)
+      when FileDescriptor::Handle
+        return {result, path}
+      when Errno::EEXIST, WinError::ERROR_FILE_EXISTS
         # retry
-        next
       else
-        raise ::File::Error.from_os_error("Error creating temporary file", errno, file: path)
+        raise ::File::Error.from_os_error("Error creating temporary file", result, file: path)
       end
     end
 
     raise ::File::AlreadyExistsError.new("Error creating temporary file", file: "#{prefix}********#{suffix}")
-  end
-
-  private def self.error_is_none?(errno)
-    errno.in?(Errno::NONE, WinError::ERROR_SUCCESS)
-  end
-
-  private def self.error_is_file_exists?(errno)
-    errno.in?(Errno::EEXIST, WinError::ERROR_FILE_EXISTS)
   end
 end
 

--- a/src/crystal/system/unix/file.cr
+++ b/src/crystal/system/unix/file.cr
@@ -3,25 +3,15 @@ require "file/error"
 
 # :nodoc:
 module Crystal::System::File
-  def self.open(filename : String, mode : String, perm : Int32 | ::File::Permissions, blocking)
+  def self.open(filename : String, mode : String, perm : Int32 | ::File::Permissions, blocking : Bool?) : FileDescriptor::Handle
     perm = ::File::Permissions.new(perm) if perm.is_a? Int32
 
-    fd, errno = open(filename, open_flag(mode), perm, blocking)
-
-    unless errno.none?
-      raise ::File::Error.from_os_error("Error opening file with mode '#{mode}'", errno, file: filename)
+    case result = EventLoop.current.open(filename, open_flag(mode), perm, blocking)
+    in FileDescriptor::Handle
+      result
+    in Errno
+      raise ::File::Error.from_os_error("Error opening file with mode '#{mode}'", result, file: filename)
     end
-
-    fd
-  end
-
-  def self.open(filename : String, flags : Int32, perm : ::File::Permissions, blocking _blocking) : {LibC::Int, Errno}
-    filename.check_no_null_byte
-    flags |= LibC::O_CLOEXEC
-
-    fd = LibC.open(filename, flags, perm)
-
-    {fd, fd < 0 ? Errno.value : Errno::NONE}
   end
 
   protected def system_set_mode(mode : String)


### PR DESCRIPTION
Moves the internal `Crystal::System::File.open` method to be the responsibility of each event loop, so they can open a file asynchronously or non-blocking when the underlying system supports it (for example io_uring).

They can also become responsible to set the `FILE_FLAG_OVERLAPPED` (Windows) or `O_NONBLOCK` (UNIX poll, epoll, kqueue) or not (Linux io_uring) flag as per their requirements, instead of merely expecting the flag.

Extracted from #15685.
Related to #15634.