### PR TITLE
Remove type binding on `T` for `Pointer(T)#value=`

### DIFF
--- a/src/compiler/crystal/semantic/main_visitor.cr
+++ b/src/compiler/crystal/semantic/main_visitor.cr
@@ -2528,7 +2528,6 @@ module Crystal
 
       value = @vars["value"]
 
-      scope.var.bind_to value
       node.bind_to value
     end
 


### PR DESCRIPTION
Fixes #15742. Does not fix the first snippet of https://github.com/crystal-lang/crystal/issues/15742#issuecomment-2854565844 (this is a different bug that also occurs on compilers before 1.16).

Only the type of a whole assignment (`ptr.value = x`) needs to be bound to the right-hand side's type. The element type of `ptr` shall be inferred from the assignments to `ptr` itself, and I don't think it makes sense to do this from the individual `#value=` calls.