### PR TITLE
[Backport release/1.16] Remove type binding on `T` for `Pointer(T)#value=`

### DIFF
--- a/src/compiler/crystal/semantic/main_visitor.cr
+++ b/src/compiler/crystal/semantic/main_visitor.cr
@@ -2528,7 +2528,6 @@ module Crystal
 
       value = @vars["value"]
 
-      scope.var.bind_to value
       node.bind_to value
     end
 


### PR DESCRIPTION
Automated backport of #15751 to `release/1.16`, triggered by a label.