### PR TITLE
[Backport release/1.16] Fix `Crystal::EventLoop::LibEvent` and `FiberExecutionContext`  integration

### DIFF
--- a/src/crystal/event_loop/libevent.cr
+++ b/src/crystal/event_loop/libevent.cr
@@ -22,7 +22,7 @@ class Crystal::EventLoop::LibEvent < Crystal::EventLoop
 
   {% if flag?(:execution_context) %}
     def run(queue : Fiber::List*, blocking : Bool) : Nil
-      Crystal.trace :evloop, "run", fiber: fiber, blocking: blocking
+      Crystal.trace :evloop, "run", blocking: blocking
       @runnables = queue
       run(blocking)
     ensure

--- a/src/io/evented.cr
+++ b/src/io/evented.cr
@@ -36,7 +36,7 @@ module IO::Evented
     if writer = @writers.get?.try &.shift?
       {% if flag?(:execution_context) && Crystal::EventLoop.has_constant?(:LibEvent) %}
         event_loop = Crystal::EventLoop.current.as(Crystal::EventLoop::LibEvent)
-        event_loop.callback_enqueue(reader)
+        event_loop.callback_enqueue(writer)
       {% else %}
         writer.enqueue
       {% end %}


### PR DESCRIPTION
Automated backport of #15743 to `release/1.16`, triggered by a label.