### PR TITLE
Allow `LLVM_VERSION` override inside `Makefile`

### DIFF
--- a/Makefile.win
+++ b/Makefile.win
@@ -22,7 +22,6 @@ all:
 ##   $ make -B generate_data
 
 CRYSTAL ?= crystal ## which previous crystal compiler use
-LLVM_CONFIG ?=     ## llvm-config command path to use
 
 release ?=      ## Compile in release mode
 stats ?=        ## Enable statistics output
@@ -67,8 +66,12 @@ CRYSTAL_VERSION ?= $(shell type src\VERSION)
 SOURCE_DATE_EPOCH ?= $(or $(shell type src\SOURCE_DATE_EPOCH 2>NUL),$(shell git show -s --format=%ct HEAD))
 export_vars = $(eval export CRYSTAL_CONFIG_BUILD_COMMIT CRYSTAL_CONFIG_PATH SOURCE_DATE_EPOCH)
 export_build_vars = $(eval export CRYSTAL_CONFIG_LIBRARY_PATH)
-LLVM_CONFIG ?=
-LLVM_VERSION ?= $(if $(LLVM_CONFIG),$(shell $(LLVM_CONFIG) --version))
+
+ifeq ($(LLVM_VERSION),)
+  LLVM_CONFIG ?=
+  LLVM_VERSION ?= $(if $(LLVM_CONFIG),$(shell "$(LLVM_CONFIG)" --version))
+endif
+
 LLVM_EXT_DIR = src\llvm\ext
 LLVM_EXT_OBJ = $(LLVM_EXT_DIR)\llvm_ext.obj
 CXXFLAGS += $(if $(static),$(if $(debug),/MTd /Od ,/MT ),$(if $(debug),/MDd /Od ,/MD ))
@@ -79,7 +82,7 @@ LIBDIR ?= $(prefix)\lib
 SRCDIR ?= $(prefix)\src
 DATADIR ?= $(prefix)
 
-colorize = $1
+colorize = $(info $1)
 
 DEPS = $(LLVM_EXT_OBJ)
 ifneq ($(LLVM_VERSION),)
@@ -90,8 +93,8 @@ endif
 
 check_llvm_config = $(eval \
 	check_llvm_config := $(if $(LLVM_VERSION),\
-		$(info $(call colorize,Using $(LLVM_CONFIG) [version=$(LLVM_VERSION)])),\
-		$(error "Could not locate compatible llvm-config, make sure it is installed and in your PATH, or set LLVM_CONFIG. Compatible versions: $(shell type src\llvm\ext\llvm-versions.txt)))\
+		$(call colorize,Using $(or $(LLVM_CONFIG),externally configured LLVM) [version=$(LLVM_VERSION)]),\
+		$(error "Could not locate compatible llvm-config, make sure it is installed and in your PATH, or set LLVM_VERSION / LLVM_CONFIG. Compatible versions: $(shell type src\llvm\ext\llvm-versions.txt)))\
 	)
 
 .PHONY: all
@@ -232,7 +235,7 @@ $(LLVM_EXT_OBJ): $(LLVM_EXT_DIR)\llvm_ext.cc
 	@rem - warning C4244: 'initializing': conversion from '_Ty' to '_Ty2', possible loss of data
 	@rem - warning C4530: C++ exception handler used, but unwind semantics are not enabled. Specify /EHsc
 	@rem - warning C4624: '...': destructor was implicitly defined as deleted
-	$(CXX) /nologo /c $(CXXFLAGS) /WX /wd4244 /wd4624 /wd4530 "/Fo$@" "$<" $(shell $(LLVM_CONFIG) --cxxflags)
+	$(CXX) /nologo /c $(CXXFLAGS) /WX /wd4244 /wd4624 /wd4530 "/Fo$@" "$<" $(if $(LLVM_CONFIG),$(shell $(LLVM_CONFIG) --cxxflags))
 
 .PHONY: clean
 clean: clean_crystal ## Clean up built directories and files


### PR DESCRIPTION
Resolves #14376.

Setting `LLVM_VERSION` as an environment variable or a command-line argument to `make` will now inhibit LLVM version detection via `LLVM_CONFIG`. This is mainly to support cross-compilation from Linux to Windows MSVC, i.e. `make crystal target=x86_64-windows-msvc LLVM_VERSION=19.1.7` should now just work on WSL. It is also advisable to set the `LLVM_TARGETS` and `LLVM_LDFLAGS` environment variables, as implemented in #15091.

Using LLVM 17 or below will still fail if `LLVM_CONFIG` is not set, since the Makefiles have never supported cross-compiling `llvm_ext.o`, and that object file needs `llvm-config --cxxflags`.

A side benefit is that Crystal can now somewhat target future LLVM versions by simply doing something like `make LLVM_VERSION=21.0.0`, since it is only `find-llvm-config.sh` that imposes the version check.