### PR TITLE
Fix calling `Fiber::ExecutionContext#enqueue` from bare `Thread`

### DIFF
--- a/src/fiber/execution_context.cr
+++ b/src/fiber/execution_context.cr
@@ -122,6 +122,10 @@ module Fiber::ExecutionContext
     Thread.current.execution_context
   end
 
+  def self.current? : ExecutionContext?
+    Thread.current.execution_context?
+  end
+
   # :nodoc:
   #
   # Tells the current scheduler to suspend the current fiber and resume the
@@ -181,6 +185,7 @@ module Fiber::ExecutionContext
   #
   # Enqueues a fiber to be resumed inside the execution context.
   #
-  # May be called from any ExecutionContext (i.e. must be thread-safe).
+  # May be called from any ExecutionContext (i.e. must be thread-safe). May also
+  # be called from bare threads (outside of an ExecutionContext).
   abstract def enqueue(fiber : Fiber) : Nil
 end

--- a/src/fiber/execution_context/multi_threaded.cr
+++ b/src/fiber/execution_context/multi_threaded.cr
@@ -180,7 +180,7 @@ module Fiber::ExecutionContext
 
     # :nodoc:
     def enqueue(fiber : Fiber) : Nil
-      if ExecutionContext.current == self
+      if ExecutionContext.current? == self
         # local enqueue: push to local queue of current scheduler
         ExecutionContext::Scheduler.current.enqueue(fiber)
       else

--- a/src/fiber/execution_context/single_threaded.cr
+++ b/src/fiber/execution_context/single_threaded.cr
@@ -102,7 +102,7 @@ module Fiber::ExecutionContext
 
     # :nodoc:
     def enqueue(fiber : Fiber) : Nil
-      if ExecutionContext.current == self
+      if ExecutionContext.current? == self
         # local enqueue
         Crystal.trace :sched, "enqueue", fiber: fiber
         @runnables.push(fiber)


### PR DESCRIPTION
A bare `Thread` doesn't have an execution context, yet may be capable to call `Fiber#enqueue` to enqueue a fiber back into its original execution context instance.