### PR TITLE
Support debug info of 128-bit enum members

### DIFF
--- a/spec/compiler/codegen/debug_spec.cr
+++ b/spec/compiler/codegen/debug_spec.cr
@@ -301,4 +301,16 @@ describe "Code gen: debug" do
       y.bar
       ), debug: Crystal::Debug::All).to_i.should eq(123)
   end
+
+  {% unless LibLLVM::IS_LT_210 %}
+    it "supports 128-bit enumerators" do
+      codegen(<<-CRYSTAL, debug: Crystal::Debug::All).to_s.should contain(%(!DIEnumerator(name: "X", value: 1002003004005006007008009)))
+        enum Foo : Int128
+          X = 1002003004005006007008009_i128
+        end
+
+        x = Foo::X
+        CRYSTAL
+    end
+  {% end %}
 end

--- a/src/compiler/crystal/codegen/debug.cr
+++ b/src/compiler/crystal/codegen/debug.cr
@@ -128,16 +128,8 @@ module Crystal
 
     def create_debug_type(type : EnumType, original_type : Type)
       elements = type.types.map do |name, item|
-        str_value = item.as?(Const).try &.value.as?(NumberLiteral).try &.value
-
-        value =
-          if type.base_type.kind.unsigned_int?
-            str_value.try(&.to_u64?) || 0_u64
-          else
-            str_value.try(&.to_i64?) || 0_i64
-          end
-
-        di_builder.create_enumerator(name, value)
+        value = item.as?(Const).try &.value.as?(NumberLiteral).try &.integer_value
+        di_builder.create_enumerator(name, value || 0)
       end
 
       size_in_bits = type.base_type.kind.bytesize

--- a/src/llvm/lib_llvm.cr
+++ b/src/llvm/lib_llvm.cr
@@ -73,6 +73,7 @@
     IS_LT_180 = {{compare_versions(LibLLVM::VERSION, "18.0.0") < 0}}
     IS_LT_190 = {{compare_versions(LibLLVM::VERSION, "19.0.0") < 0}}
     IS_LT_200 = {{compare_versions(LibLLVM::VERSION, "20.0.0") < 0}}
+    IS_LT_210 = {{compare_versions(LibLLVM::VERSION, "21.0.0") < 0}}
   end
 {% end %}
 

--- a/src/llvm/lib_llvm/debug_info.cr
+++ b/src/llvm/lib_llvm/debug_info.cr
@@ -60,6 +60,11 @@ lib LibLLVM
       builder : DIBuilderRef, name : Char*, name_len : SizeT, value : Int64, is_unsigned : Bool,
     ) : MetadataRef
   {% end %}
+  {% unless LibLLVM::IS_LT_210 %}
+    fun di_builder_create_enumerator_of_arbitrary_precision = LLVMDIBuilderCreateEnumeratorOfArbitraryPrecision(
+      builder : DIBuilderRef, name : Char*, name_len : SizeT, size_in_bits : UInt64, words : UInt64*, is_unsigned : Bool,
+    ) : MetadataRef
+  {% end %}
   fun di_builder_create_enumeration_type = LLVMDIBuilderCreateEnumerationType(
     builder : DIBuilderRef, scope : MetadataRef, name : Char*, name_len : SizeT, file : MetadataRef,
     line_number : UInt, size_in_bits : UInt64, align_in_bits : UInt32,


### PR DESCRIPTION
On the LLVM 21 development branch, the `LLVMDIBuilderCreateEnumeratorOfArbitraryPrecision` function (which I submitted to LLVM) supports enumerators larger than the 64 bits that `LLVMDIBuilderCreateEnumerator` can handle.

The underlying C++ implementation can be backported all the way back to LLVM 13, but if we added it to `llvm_ext.cc`, this would create an awkward situation where version 18 to 20 would miss out for no apparent reason. Thus this PR requires LLVM 21 or above.