### PR TITLE
Use `UInt64` to track iteration count during warm-up calculation in `Benchmark::IPS`

### DIFF
--- a/src/benchmark/ips.cr
+++ b/src/benchmark/ips.cr
@@ -65,7 +65,7 @@ module Benchmark
         @items.each do |item|
           GC.collect
 
-          count = 0_i64
+          count = 0_u64
           elapsed = Time.measure do
             target = Time.monotonic + @warmup_time
 

--- a/src/benchmark/ips.cr
+++ b/src/benchmark/ips.cr
@@ -65,7 +65,7 @@ module Benchmark
         @items.each do |item|
           GC.collect
 
-          count = 0
+          count = 0_i64
           elapsed = Time.measure do
             target = Time.monotonic + @warmup_time
 


### PR DESCRIPTION
If the warm-up duration is long enough then the iteration count in `run_warmup` can easily exceed the 32 bit integer limit in a little under a minute resulting in an `OverflowError`. 

This PR just change the tracker variable to an unsigned 64 bit integer so that an overflow is pretty much impossible

You can reproduce the overflow with: 

```crystal
require "benchmark"

# 100 seconds to be safe but I always get an overflow ~ 40 seconds in
Benchmark.ips(warmup: 100.seconds, &.report("") {  }) 
```

I don't think there's any practical reasons someone would set the `warmup` duration to be that high but I don't think `Benchmark.ips` should fail this easily either.