### PR TITLE
Add `String#ensure_suffix` and `String#ensure_prefix`

### DIFF
--- a/spec/std/string_spec.cr
+++ b/spec/std/string_spec.cr
@@ -3173,6 +3173,34 @@ describe "String" do
       end
     end
   end
+
+  describe "ensure_prefix" do
+    context "with string prefix" do
+      it "adds prefix if not present" do
+        "foo".ensure_prefix("bar").should eq("barfoo")
+        "foo".ensure_prefix("FOO").should eq("FOOfoo")
+        "foo".ensure_prefix("").should eq("foo")
+        "foo".ensure_prefix("barf").should eq("barffoo")
+      end
+
+      it "does not add prefix if already present" do
+        "foobar".ensure_prefix("foo").should eq("foobar")
+        "FOOBAR".ensure_prefix("FOO").should eq("FOOBAR")
+      end
+    end
+
+    context "with char prefix" do
+      it "adds prefix if not present" do
+        "foo".ensure_prefix('b').should eq("bfoo")
+        "foo".ensure_prefix('F').should eq("Ffoo")
+      end
+
+      it "does not add prefix if already present" do
+        "bfoo".ensure_prefix('b').should eq("bfoo")
+        "BFOO".ensure_prefix('B').should eq("BFOO")
+      end
+    end
+  end
 end
 
 class String

--- a/spec/std/string_spec.cr
+++ b/spec/std/string_spec.cr
@@ -3145,6 +3145,34 @@ describe "String" do
       it { expect_raises(IndexError) { "セキロ：シャドウズ ダイ トゥワイス".delete_at(-19..1) } }
     end
   end
+
+  describe "ensure_suffix" do
+    context "with string suffix" do
+      it "adds suffix if not present" do
+        "foo".ensure_suffix("bar").should eq("foobar")
+        "foo".ensure_suffix("FOO").should eq("fooFOO")
+        "foo".ensure_suffix("").should eq("foo")
+        "foobar".ensure_suffix("arr").should eq("foobararr")
+      end
+
+      it "does not add suffix if already present" do
+        "foobar".ensure_suffix("bar").should eq("foobar")
+        "FOOBAR".ensure_suffix("BAR").should eq("FOOBAR")
+      end
+    end
+
+    context "with char suffix" do
+      it "adds suffix if not present" do
+        "foo".ensure_suffix('b').should eq("foob")
+        "foo".ensure_suffix('O').should eq("fooO")
+      end
+
+      it "does not add suffix if already present" do
+        "foob".ensure_suffix('b').should eq("foob")
+        "FOOB".ensure_suffix('B').should eq("FOOB")
+      end
+    end
+  end
 end
 
 class String

--- a/src/string.cr
+++ b/src/string.cr
@@ -5584,6 +5584,21 @@ class String
     self
   end
 
+  # Returns `self` if it ends with the given *suffix*. Otherwise, returns a new
+  # `String` with the *suffix* appended.
+  #
+  # ```
+  # "Hell".ensure_suffix("o!")   # => "Hello!"
+  # "Hello!".ensure_suffix("o!") # => "Hello!"
+  # "Hello".ensure_suffix('!')   # => "Hello!"
+  # "Hello!".ensure_suffix('!')  # => "Hello!"
+  # ```
+  def ensure_suffix(suffix : String | Char) : self
+    return self if ends_with?(suffix)
+
+    "#{self}#{suffix}"
+  end
+
   # :nodoc:
   def self.check_capacity_in_bounds(capacity) : Nil
     if capacity < 0

--- a/src/string.cr
+++ b/src/string.cr
@@ -5584,6 +5584,21 @@ class String
     self
   end
 
+  # Returns `self` if it starts with the given *prefix*. Otherwise, returns a new
+  # `String` with the *prefix* prepended.
+  #
+  # ```
+  # "llo!".ensure_prefix("He")   # => "Hello!"
+  # "Hello!".ensure_prefix("He") # => "Hello!"
+  # "ello".ensure_prefix('H')    # => "Hello!"
+  # "Hello!".ensure_prefix('H')  # => "Hello!"
+  # ```
+  def ensure_prefix(prefix : String | Char) : self
+    return self if starts_with?(prefix)
+
+    "#{prefix}#{self}"
+  end
+
   # Returns `self` if it ends with the given *suffix*. Otherwise, returns a new
   # `String` with the *suffix* appended.
   #


### PR DESCRIPTION
Closes #15783

This method returns `self` if the string ends with the given suffix. Otherwise, returns a new string with the suffix appended.

I've seen this pattern repeated several times along the years. Crystal itself does it in at least two places:

https://github.com/crystal-lang/crystal/blob/9791f3112f406ff890d5b13b231375b2afdfe64b/src/compiler/crystal/crystal_path.cr#L132

https://github.com/crystal-lang/crystal/blob/9791f3112f406ff890d5b13b231375b2afdfe64b/src/crystal/system/wasi/wasi.cr#L27

I'm open to other names, if `ensure_suffix` isn't clear enough. If this is merged and the core team agrees, I can add `ensure_prefix` as well.