### PR TITLE
Support POSIX TZ environment variable strings

### DIFF
--- a/spec/std/time/location_spec.cr
+++ b/spec/std/time/location_spec.cr
@@ -364,8 +364,8 @@ class Time::Location
       end
 
       it "raises if offset to large" do
-        expect_raises(InvalidTimezoneOffsetError, "90000") do
-          Location.fixed(90000)
+        expect_raises(InvalidTimezoneOffsetError, "93600") do
+          Location.fixed(93600)
         end
         expect_raises(InvalidTimezoneOffsetError, "-90000") do
           Location.fixed(-90000)
@@ -397,6 +397,14 @@ class Time::Location
         location.zones.should eq [
           Location::Zone.new("EST", -18000, false),
           Location::Zone.new("EDT", 89999, true),
+        ]
+        location.transitions.should be_empty
+
+        location = Location.posix_tz("America/New_York", "EST-24:59:59EDT,M3.2.0,M11.1.0")
+        location.name.should eq("America/New_York")
+        location.zones.should eq [
+          Location::Zone.new("EST", 89999, false),
+          Location::Zone.new("EDT", 93599, true),
         ]
         location.transitions.should be_empty
       end

--- a/spec/std/time/location_spec.cr
+++ b/spec/std/time/location_spec.cr
@@ -1,6 +1,25 @@
 require "../spec_helper"
 require "../../support/time"
 
+private def assert_tz_boundaries(tz : String, t0 : Time, t1 : Time, t2 : Time, t3 : Time, *, file = __FILE__, line = __LINE__)
+  location = Time::Location.tz("Local", tz)
+  std_zone = location.zones.find(&.dst?.!).should_not be_nil, file: file, line: line
+  dst_zone = location.zones.find(&.dst?).should_not be_nil, file: file, line: line
+  t0, t1, t2, t3 = t0.to_unix, t1.to_unix, t2.to_unix, t3.to_unix
+
+  location.lookup_with_boundaries(t1 - 1).should eq({std_zone, {t0, t1}}), file: file, line: line
+  location.lookup_with_boundaries(t1).should eq({dst_zone, {t1, t2}}), file: file, line: line
+  location.lookup_with_boundaries(t1 + (t2 - t1) // 2).should eq({dst_zone, {t1, t2}}), file: file, line: line
+  location.lookup_with_boundaries(t2 - 1).should eq({dst_zone, {t1, t2}}), file: file, line: line
+  location.lookup_with_boundaries(t2).should eq({std_zone, {t2, t3}}), file: file, line: line
+end
+
+private def assert_tz_raises(str, *, file = __FILE__, line = __LINE__)
+  expect_raises(ArgumentError, "Invalid TZ string: #{str}", file: file, line: line) do
+    Time::Location.tz("", str)
+  end
+end
+
 class Time::Location
   describe Time::Location do
     describe ".load" do
@@ -254,6 +273,18 @@ class Time::Location
         end
       end
 
+      it "with POSIX TZ string" do
+        with_tz("EST5EDT,M3.2.0,M11.1.0") do
+          location = Location.load_local
+          location.name.should eq("Local")
+          location.zones.should eq [
+            Location::Zone.new("EST", -18000, false),
+            Location::Zone.new("EDT", -14400, true),
+          ]
+          location.transitions.should be_empty
+        end
+      end
+
       {% if flag?(:win32) %}
         it "loads time zone information from registry" do
           info = LibC::DYNAMIC_TIME_ZONE_INFORMATION.new(
@@ -322,13 +353,175 @@ class Time::Location
         location.zones.first.offset.should eq -7539
       end
 
+      it "exactly 24 hours" do
+        location = Location.fixed 86400
+        location.name.should eq "+24:00"
+        location.zones.first.offset.should eq 86400
+
+        location = Location.fixed -86400
+        location.name.should eq "-24:00"
+        location.zones.first.offset.should eq -86400
+      end
+
       it "raises if offset to large" do
-        expect_raises(InvalidTimezoneOffsetError, "86401") do
-          Location.fixed(86401)
+        expect_raises(InvalidTimezoneOffsetError, "90000") do
+          Location.fixed(90000)
         end
         expect_raises(InvalidTimezoneOffsetError, "-90000") do
           Location.fixed(-90000)
         end
+      end
+    end
+
+    describe ".tz" do
+      it "parses string with standard time only" do
+        location = Location.tz("America/New_York", "EST5")
+        location.name.should eq("America/New_York")
+        location.zones.should eq [
+          Location::Zone.new("EST", -18000, false),
+        ]
+        location.transitions.should be_empty
+      end
+
+      it "parses string with both standard time and DST" do
+        location = Location.tz("America/New_York", "EST5EDT,M3.2.0,M11.1.0")
+        location.name.should eq("America/New_York")
+        location.zones.should eq [
+          Location::Zone.new("EST", -18000, false),
+          Location::Zone.new("EDT", -14400, true),
+        ]
+        location.transitions.should be_empty
+
+        location = Location.tz("America/New_York", "EST5EDT-24:59:59,M3.2.0,M11.1.0")
+        location.name.should eq("America/New_York")
+        location.zones.should eq [
+          Location::Zone.new("EST", -18000, false),
+          Location::Zone.new("EDT", 89999, true),
+        ]
+        location.transitions.should be_empty
+      end
+
+      it "parses string with all-year DST" do
+        location = Location.tz("America/New_York", "EST5EDT,0/0,J365/25")
+        location.name.should eq("America/New_York")
+        location.zones.should eq [
+          Location::Zone.new("EDT", -14400, true),
+        ]
+        location.transitions.should be_empty
+
+        location = Location.tz("America/New_York", "XXX-6EDT-4:30:10,J1/0,J365/22:30:10")
+        location.name.should eq("America/New_York")
+        location.zones.should eq [
+          Location::Zone.new("EDT", 16210, true),
+        ]
+        location.transitions.should be_empty
+      end
+
+      it "errors on invalid TZ strings" do
+        # std
+        assert_tz_raises ""
+        assert_tz_raises "G"
+        assert_tz_raises "GM"
+        assert_tz_raises "<>"
+        assert_tz_raises "<G>"
+        assert_tz_raises "<GM>"
+        assert_tz_raises "<GMT"
+        assert_tz_raises "012"
+        assert_tz_raises "+00"
+        assert_tz_raises "-00"
+        assert_tz_raises "<$aa>"
+        assert_tz_raises "?"
+        assert_tz_raises ":foobar"
+        assert_tz_raises "/foo/bar"
+        assert_tz_raises "Europe/Berlin"
+
+        # std offset
+        assert_tz_raises "EST"
+        assert_tz_raises "EST "
+        assert_tz_raises "EST 5"
+        assert_tz_raises "EST25"
+        assert_tz_raises "EST123"
+        assert_tz_raises "EST00123"
+        assert_tz_raises "EST-25"
+        assert_tz_raises "EST-123"
+        assert_tz_raises "EST-00123"
+        assert_tz_raises "EST4:"
+        assert_tz_raises "EST4:60"
+        assert_tz_raises "EST4:+30"
+        assert_tz_raises "EST4:-01"
+        assert_tz_raises "EST4:20:"
+        assert_tz_raises "EST4:20:60"
+        assert_tz_raises "EST4:20:+30"
+        assert_tz_raises "EST4:20:-01"
+
+        # dst
+        assert_tz_raises "EST5 "
+        assert_tz_raises "EST5G"
+        assert_tz_raises "EST5GM"
+        assert_tz_raises "EST5<>"
+        assert_tz_raises "EST5<GM>"
+        assert_tz_raises "EST5<GMT"
+        assert_tz_raises "EST5<$aa>"
+        assert_tz_raises "EST5+00"
+        assert_tz_raises "EST5-00"
+
+        # dst offset
+        assert_tz_raises "EST5EDT4:"
+        assert_tz_raises "EST5EDT4:60"
+        assert_tz_raises "EST5EDT4:+30"
+        assert_tz_raises "EST5EDT4:-01"
+        assert_tz_raises "EST5EDT4:20:"
+        assert_tz_raises "EST5EDT4:20:60"
+        assert_tz_raises "EST5EDT4:20:+30"
+        assert_tz_raises "EST5EDT4:20:-01"
+
+        # start
+        assert_tz_raises "EST5EDT"
+        assert_tz_raises "EST5EDT,"
+        assert_tz_raises "EST5EDT,A"
+        assert_tz_raises "EST5EDT,J0"
+        assert_tz_raises "EST5EDT,J366"
+        assert_tz_raises "EST5EDT,-1"
+        assert_tz_raises "EST5EDT,366"
+        assert_tz_raises "EST5EDT,M3"
+        assert_tz_raises "EST5EDT,M3."
+        assert_tz_raises "EST5EDT,M3.2"
+        assert_tz_raises "EST5EDT,M3.2."
+        assert_tz_raises "EST5EDT,M0.2.0"
+        assert_tz_raises "EST5EDT,M13.2.0"
+        assert_tz_raises "EST5EDT,M3.0.0"
+        assert_tz_raises "EST5EDT,M3.6.0"
+        assert_tz_raises "EST5EDT,M3.2.-1"
+        assert_tz_raises "EST5EDT,M3.2.7"
+        assert_tz_raises "EST5EDT,M3.2.0/"
+        assert_tz_raises "EST5EDT,M3.2.0/168"
+        assert_tz_raises "EST5EDT,M3.2.0/-168"
+
+        # end
+        assert_tz_raises "EST5EDT,M3.2.0"
+        assert_tz_raises "EST5EDT,M3.2.0,"
+        assert_tz_raises "EST5EDT,M3.2.0,A"
+        assert_tz_raises "EST5EDT,M3.2.0,J0"
+        assert_tz_raises "EST5EDT,M3.2.0,J366"
+        assert_tz_raises "EST5EDT,M3.2.0,-1"
+        assert_tz_raises "EST5EDT,M3.2.0,366"
+        assert_tz_raises "EST5EDT,M3.2.0,M11"
+        assert_tz_raises "EST5EDT,M3.2.0,M11."
+        assert_tz_raises "EST5EDT,M3.2.0,M11.1"
+        assert_tz_raises "EST5EDT,M3.2.0,M11.1."
+        assert_tz_raises "EST5EDT,M3.2.0,M0.1.0"
+        assert_tz_raises "EST5EDT,M3.2.0,M13.1.0"
+        assert_tz_raises "EST5EDT,M3.2.0,M11.0.0"
+        assert_tz_raises "EST5EDT,M3.2.0,M11.6.0"
+        assert_tz_raises "EST5EDT,M3.2.0,M11.1.-1"
+        assert_tz_raises "EST5EDT,M3.2.0,M11.1.7"
+        assert_tz_raises "EST5EDT,M3.2.0,M11.1.0/"
+        assert_tz_raises "EST5EDT,M3.2.0,M11.1.0/168"
+        assert_tz_raises "EST5EDT,M3.2.0,M11.1.0/-168"
+
+        # trailing characters
+        assert_tz_raises "EST5EDT,M3.2.0,M11.1.0 "
+        assert_tz_raises "EST5EDT,M3.2.0/2,M11.1.0/2 "
       end
     end
 
@@ -428,6 +621,127 @@ class Time::Location
           location.lookup(Time.utc(2017, 11, 23, 22, 6, 12)).should eq cached_zone
         end
       end
+
+      context "TZ string" do
+        it "looks up location with standard time only" do
+          location = Location.tz("Local", "EST5")
+          zone, range = location.lookup_with_boundaries(Time.utc(2025, 1, 1, 22, 6, 12).to_unix)
+          zone.should eq(Zone.new("EST", -18000, false))
+          range.should eq({Int64::MIN, Int64::MAX})
+        end
+
+        it "looks up location with all-year DST" do
+          location = Location.tz("Local", "EST5EDT4,0/0,J365/25")
+          zone, range = location.lookup_with_boundaries(Time.utc(2025, 1, 1, 22, 6, 12).to_unix)
+          zone.should eq(Zone.new("EDT", -14400, true))
+          range.should eq({Int64::MIN, Int64::MAX})
+        end
+
+        context "transition dates" do
+          it "supports one-based ordinal days" do
+            assert_tz_boundaries "EST5EDT4,J1/2,J365/2",
+              Time.utc(2025, 12, 31, 6, 0, 0), Time.utc(2026, 1, 1, 7, 0, 0),
+              Time.utc(2026, 12, 31, 6, 0, 0), Time.utc(2027, 1, 1, 7, 0, 0)
+
+            assert_tz_boundaries "EST5EDT4,J1/2,J365/2",
+              Time.utc(2027, 12, 31, 6, 0, 0), Time.utc(2028, 1, 1, 7, 0, 0),
+              Time.utc(2028, 12, 31, 6, 0, 0), Time.utc(2029, 1, 1, 7, 0, 0)
+          end
+
+          it "excludes Feb 29 if one-based" do
+            assert_tz_boundaries "EST5EDT4,J59/2,J60/2",
+              Time.utc(2027, 3, 1, 6, 0, 0), Time.utc(2028, 2, 28, 7, 0, 0),
+              Time.utc(2028, 3, 1, 6, 0, 0), Time.utc(2029, 2, 28, 7, 0, 0)
+          end
+
+          it "supports zero-based ordinal days" do
+            assert_tz_boundaries "EST5EDT4,50/2,280/2",
+              Time.utc(2025, 10, 8, 6, 0, 0), Time.utc(2026, 2, 20, 7, 0, 0),
+              Time.utc(2026, 10, 8, 6, 0, 0), Time.utc(2027, 2, 20, 7, 0, 0)
+
+            assert_tz_boundaries "EST5EDT4,50/2,280/2",
+              Time.utc(2027, 10, 8, 6, 0, 0), Time.utc(2028, 2, 20, 7, 0, 0),
+              Time.utc(2028, 10, 7, 6, 0, 0), Time.utc(2029, 2, 20, 7, 0, 0)
+          end
+
+          it "includes Feb 29 if zero-based" do
+            assert_tz_boundaries "EST5EDT4,59/2,60/2",
+              Time.utc(2027, 3, 2, 6, 0, 0), Time.utc(2028, 2, 29, 7, 0, 0),
+              Time.utc(2028, 3, 1, 6, 0, 0), Time.utc(2029, 3, 1, 7, 0, 0)
+          end
+
+          it "supports month + week + day of week" do
+            tz = "EST5EDT4,M3.2.0/2,M11.1.0/2"
+
+            trans = [
+              {Time.utc(2020, 11, 1, 6, 0, 0), Time.utc(2021, 3, 14, 7, 0, 0)},
+              {Time.utc(2021, 11, 7, 6, 0, 0), Time.utc(2022, 3, 13, 7, 0, 0)},
+              {Time.utc(2022, 11, 6, 6, 0, 0), Time.utc(2023, 3, 12, 7, 0, 0)},
+              {Time.utc(2023, 11, 5, 6, 0, 0), Time.utc(2024, 3, 10, 7, 0, 0)},
+              {Time.utc(2024, 11, 3, 6, 0, 0), Time.utc(2025, 3, 9, 7, 0, 0)},
+              {Time.utc(2025, 11, 2, 6, 0, 0), Time.utc(2026, 3, 8, 7, 0, 0)},
+              {Time.utc(2026, 11, 1, 6, 0, 0), Time.utc(2027, 3, 14, 7, 0, 0)},
+              {Time.utc(2027, 11, 7, 6, 0, 0), Time.utc(2028, 3, 12, 7, 0, 0)},
+              {Time.utc(2028, 11, 5, 6, 0, 0), Time.utc(2029, 3, 11, 7, 0, 0)},
+            ]
+
+            trans.each_cons_pair do |(t0, t1), (t2, t3)|
+              assert_tz_boundaries(tz, t0, t1, t2, t3)
+            end
+          end
+
+          it "handles time zone differences other than 1 hour" do
+            assert_tz_boundaries "EST4:30EDT-1:23:45,M3.2.0,M11.1.0",
+              Time.utc(2024, 11, 3, 0, 36, 15), Time.utc(2025, 3, 9, 6, 30, 0),
+              Time.utc(2025, 11, 2, 0, 36, 15), Time.utc(2026, 3, 8, 6, 30, 0)
+          end
+
+          it "defaults transition times to 02:00:00 local time" do
+            assert_tz_boundaries "EST5EDT,M3.2.0,M11.1.0",
+              Time.utc(2024, 11, 3, 6, 0, 0), Time.utc(2025, 3, 9, 7, 0, 0),
+              Time.utc(2025, 11, 2, 6, 0, 0), Time.utc(2026, 3, 8, 7, 0, 0)
+          end
+
+          it "supports transition times from -167 to 167 hours" do
+            assert_tz_boundaries "EST5EDT,M3.2.0/-167,M11.1.0/167",
+              Time.utc(2024, 11, 10, 3, 0, 0), Time.utc(2025, 3, 2, 6, 0, 0),
+              Time.utc(2025, 11, 9, 3, 0, 0), Time.utc(2026, 3, 1, 6, 0, 0)
+          end
+
+          it "handles years beginning and ending in DST" do
+            tz = "AEST-10AEDT,M10.1.0,M4.1.0/3"
+
+            trans = [
+              {Time.utc(2020, 4, 4, 16, 0, 0), Time.utc(2020, 10, 3, 16, 0, 0)},
+              {Time.utc(2021, 4, 3, 16, 0, 0), Time.utc(2021, 10, 2, 16, 0, 0)},
+              {Time.utc(2022, 4, 2, 16, 0, 0), Time.utc(2022, 10, 1, 16, 0, 0)},
+              {Time.utc(2023, 4, 1, 16, 0, 0), Time.utc(2023, 9, 30, 16, 0, 0)},
+              {Time.utc(2024, 4, 6, 16, 0, 0), Time.utc(2024, 10, 5, 16, 0, 0)},
+              {Time.utc(2025, 4, 5, 16, 0, 0), Time.utc(2025, 10, 4, 16, 0, 0)},
+              {Time.utc(2026, 4, 4, 16, 0, 0), Time.utc(2026, 10, 3, 16, 0, 0)},
+              {Time.utc(2027, 4, 3, 16, 0, 0), Time.utc(2027, 10, 2, 16, 0, 0)},
+              {Time.utc(2028, 4, 1, 16, 0, 0), Time.utc(2028, 9, 30, 16, 0, 0)},
+              {Time.utc(2029, 3, 31, 16, 0, 0), Time.utc(2029, 10, 6, 16, 0, 0)},
+            ]
+
+            trans.each_cons_pair do |(t0, t1), (t2, t3)|
+              assert_tz_boundaries(tz, t0, t1, t2, t3)
+            end
+          end
+
+          it "handles very distant years" do
+            assert_tz_boundaries "EST5EDT4,M3.2.0/2,M11.1.0/2",
+              Time.utc(1583, 11, 6, 6, 0, 0), Time.utc(1584, 3, 11, 7, 0, 0),
+              Time.utc(1584, 11, 4, 6, 0, 0), Time.utc(1585, 3, 10, 7, 0, 0)
+
+            assert_tz_boundaries "EST5EDT4,M3.2.0/2,M11.1.0/2",
+              Time.utc(3332, 11, 2, 6, 0, 0), Time.utc(3333, 3, 8, 7, 0, 0),
+              Time.utc(3333, 11, 1, 6, 0, 0), Time.utc(3334, 3, 14, 7, 0, 0)
+          end
+        end
+      end
+
+      pending "zoneinfo + POSIX TZ string"
     end
   end
 

--- a/spec/std/time/location_spec.cr
+++ b/spec/std/time/location_spec.cr
@@ -2,7 +2,7 @@ require "../spec_helper"
 require "../../support/time"
 
 private def assert_tz_boundaries(tz : String, t0 : Time, t1 : Time, t2 : Time, t3 : Time, *, file = __FILE__, line = __LINE__)
-  location = Time::Location.tz("Local", tz)
+  location = Time::Location.posix_tz("Local", tz)
   std_zone = location.zones.find(&.dst?.!).should_not be_nil, file: file, line: line
   dst_zone = location.zones.find(&.dst?).should_not be_nil, file: file, line: line
   t0, t1, t2, t3 = t0.to_unix, t1.to_unix, t2.to_unix, t3.to_unix
@@ -16,7 +16,7 @@ end
 
 private def assert_tz_raises(str, *, file = __FILE__, line = __LINE__)
   expect_raises(ArgumentError, "Invalid TZ string: #{str}", file: file, line: line) do
-    Time::Location.tz("", str)
+    Time::Location.posix_tz("", str)
   end
 end
 
@@ -375,7 +375,7 @@ class Time::Location
 
     describe ".tz" do
       it "parses string with standard time only" do
-        location = Location.tz("America/New_York", "EST5")
+        location = Location.posix_tz("America/New_York", "EST5")
         location.name.should eq("America/New_York")
         location.zones.should eq [
           Location::Zone.new("EST", -18000, false),
@@ -384,7 +384,7 @@ class Time::Location
       end
 
       it "parses string with both standard time and DST" do
-        location = Location.tz("America/New_York", "EST5EDT,M3.2.0,M11.1.0")
+        location = Location.posix_tz("America/New_York", "EST5EDT,M3.2.0,M11.1.0")
         location.name.should eq("America/New_York")
         location.zones.should eq [
           Location::Zone.new("EST", -18000, false),
@@ -392,7 +392,7 @@ class Time::Location
         ]
         location.transitions.should be_empty
 
-        location = Location.tz("America/New_York", "EST5EDT-24:59:59,M3.2.0,M11.1.0")
+        location = Location.posix_tz("America/New_York", "EST5EDT-24:59:59,M3.2.0,M11.1.0")
         location.name.should eq("America/New_York")
         location.zones.should eq [
           Location::Zone.new("EST", -18000, false),
@@ -402,14 +402,14 @@ class Time::Location
       end
 
       it "parses string with all-year DST" do
-        location = Location.tz("America/New_York", "EST5EDT,0/0,J365/25")
+        location = Location.posix_tz("America/New_York", "EST5EDT,0/0,J365/25")
         location.name.should eq("America/New_York")
         location.zones.should eq [
           Location::Zone.new("EDT", -14400, true),
         ]
         location.transitions.should be_empty
 
-        location = Location.tz("America/New_York", "XXX-6EDT-4:30:10,J1/0,J365/22:30:10")
+        location = Location.posix_tz("America/New_York", "XXX-6EDT-4:30:10,J1/0,J365/22:30:10")
         location.name.should eq("America/New_York")
         location.zones.should eq [
           Location::Zone.new("EDT", 16210, true),
@@ -624,14 +624,14 @@ class Time::Location
 
       context "TZ string" do
         it "looks up location with standard time only" do
-          location = Location.tz("Local", "EST5")
+          location = Location.posix_tz("Local", "EST5")
           zone, range = location.lookup_with_boundaries(Time.utc(2025, 1, 1, 22, 6, 12).to_unix)
           zone.should eq(Zone.new("EST", -18000, false))
           range.should eq({Int64::MIN, Int64::MAX})
         end
 
         it "looks up location with all-year DST" do
-          location = Location.tz("Local", "EST5EDT4,0/0,J365/25")
+          location = Location.posix_tz("Local", "EST5EDT4,0/0,J365/25")
           zone, range = location.lookup_with_boundaries(Time.utc(2025, 1, 1, 22, 6, 12).to_unix)
           zone.should eq(Zone.new("EDT", -14400, true))
           range.should eq({Int64::MIN, Int64::MAX})

--- a/src/time/location.cr
+++ b/src/time/location.cr
@@ -248,13 +248,13 @@ class Time::Location
   # since no default transition rules are assumed.
   #
   # ```
-  # location = Time::Location.tz("America/New_York", "EST5EDT,M3.2.0,M11.1.0")
+  # location = Time::Location.posix_tz("America/New_York", "EST5EDT,M3.2.0,M11.1.0")
   # Time.utc(2025, 3, 9, 6).in(location)  # => 2025-03-09 01:00:00.0 -05:00 America/New_York
   # Time.utc(2025, 3, 9, 7).in(location)  # => 2025-03-09 03:00:00.0 -04:00 America/New_York
   # Time.utc(2025, 11, 2, 5).in(location) # => 2025-11-02 01:00:00.0 -04:00 America/New_York
   # Time.utc(2025, 11, 2, 6).in(location) # => 2025-11-02 01:00:00.0 -05:00 America/New_York
   # ```
-  def self.tz(name : String, str : String) : self
+  def self.posix_tz(name : String, str : String) : self
     zones = Array(Location::Zone).new(initial_capacity: 2)
     tz = TZ.parse(str, zones, true) || raise ArgumentError.new("Invalid TZ string: #{str}")
     new(name, zones, tz: tz, tz_string: str)
@@ -377,7 +377,7 @@ class Time::Location
   #
   # * `"UTC"`, `"Etc/UTC"` and empty string (`""`) return `Location::UTC`.
   # * POSIX TZ strings (such as `"EST5EDT,M3.2.0,M11.1.0"`) are parsed using
-  #   `Location.tz`.
+  #   `Location.posix_tz`.
   # * Values beginning with a colon are implementation-defined according to
   #   POSIX, and not supported in Crystal.
   # * Any other value (such as `"Europe/Berlin"`) is tried to be resolved using
@@ -546,9 +546,9 @@ class Time::Location
 
   # Returns `true` if this location has a fixed offset.
   #
-  # Locations returned by `Location.tz` have a fixed offset if the TZ string
-  # specifies either no daylight saving time at all, or an all-year daylight
-  # saving time (e.g. `"EST5EDT,0/0,J365/25"`).
+  # Locations returned by `Location.posix_tz` have a fixed offset if the TZ
+  # string specifies either no daylight saving time at all, or an all-year
+  # daylight saving time (e.g. `"EST5EDT,0/0,J365/25"`).
   def fixed? : Bool
     zones.size <= 1
   end

--- a/src/time/location.cr
+++ b/src/time/location.cr
@@ -92,12 +92,12 @@ class Time::Location
     # `#format`).
     #
     # Raises `InvalidTimezoneOffsetError` if *seconds* is outside the supported
-    # value range `-89_999..89_999` seconds (`-24:59:59` to `+24:59:59`).
+    # value range `-89_999..93_599` seconds (`-24:59:59` to `+25:59:59`).
     def initialize(@name : String?, @offset : Int32, @dst : Bool)
       # Maximum offsets of IANA time zone database are -12:00 and +14:00.
-      # The hours component can be up to +/-24 as required by POSIX TZ strings.
-      # (89999.seconds == 24.hours + 59.minutes + 59.seconds)
-      raise InvalidTimezoneOffsetError.new(offset) unless -89999 <= offset <= 89999
+      # The hours component can be up to -24/+25 as required by POSIX TZ
+      # strings (e.g. `EST-24:59:59EDT,...`).
+      raise InvalidTimezoneOffsetError.new(offset) unless -89999 <= offset <= 93599
     end
 
     # Returns the name of the zone.

--- a/src/time/location.cr
+++ b/src/time/location.cr
@@ -1,4 +1,5 @@
 require "./location/loader"
+require "./tz"
 
 # `Location` maps time instants to the zone in use at that time.
 # It typically represents the collection of time offsets observed in
@@ -92,12 +93,12 @@ class Time::Location
     # `#format`).
     #
     # Raises `InvalidTimezoneOffsetError` if *seconds* is outside the supported
-    # value range `-86_400..86_400` seconds (`-24:00` to `+24:00`).
+    # value range `-89_999..89_999` seconds (`-24:59:59` to `+24:59:59`).
     def initialize(@name : String?, @offset : Int32, @dst : Bool)
       # Maximum offsets of IANA time zone database are -12:00 and +14:00.
-      # +/-24 hours allows a generous padding for unexpected offsets.
-      # TODO: Maybe reduce to Int16 (+/- 18 hours).
-      raise InvalidTimezoneOffsetError.new(offset) if offset >= SECONDS_PER_DAY || offset <= -SECONDS_PER_DAY
+      # The hours component can be up to +/-24 as required by POSIX TZ strings.
+      # (89999.seconds == 24.hours + 59.minutes + 59.seconds)
+      raise InvalidTimezoneOffsetError.new(offset) unless -89999 <= offset <= 89999
     end
 
     # Returns the name of the zone.
@@ -214,6 +215,13 @@ class Time::Location
   @cached_range : Tuple(Int64, Int64)
   @cached_zone : Zone
 
+  # Local time transition rules derived from a POSIX TZ string, used for times
+  # past the last defined transition.
+  @tz : TZ?
+
+  # The original TZ string that produced `@tz`, if any.
+  protected getter tz_string : String?
+
   # Creates a `Location` instance named *name* with fixed *offset* in seconds
   # from UTC.
   def self.fixed(name : String, offset : Int32) : Location
@@ -226,6 +234,30 @@ class Time::Location
   def self.fixed(offset : Int32) : self
     zone = Zone.new(nil, offset, false)
     new zone.name, [zone]
+  end
+
+  # Creates a `Location` instance named *name* with the given POSIX TZ string
+  # *str*, as defined in [POSIX.1-2024 Section 8.3](https://pubs.opengroup.org/onlinepubs/9799919799/basedefs/V1_chap08.html).
+  #
+  # *str* must begin with a standard time designator followed by a time offset;
+  # implementation-defined TZ strings beginning with a colon, as well as names
+  # from the time zone database, are not supported.
+  #
+  # If *str* designates a daylight saving time, then the transition times must
+  # also be present. A TZ string like `"PST8PDT"` alone is considered invalid,
+  # since no default transition rules are assumed.
+  #
+  # ```
+  # location = Time::Location.tz("America/New_York", "EST5EDT,M3.2.0,M11.1.0")
+  # Time.utc(2025, 3, 9, 6).in(location)  # => 2025-03-09 01:00:00.0 -05:00 America/New_York
+  # Time.utc(2025, 3, 9, 7).in(location)  # => 2025-03-09 03:00:00.0 -04:00 America/New_York
+  # Time.utc(2025, 11, 2, 5).in(location) # => 2025-11-02 01:00:00.0 -04:00 America/New_York
+  # Time.utc(2025, 11, 2, 6).in(location) # => 2025-11-02 01:00:00.0 -05:00 America/New_York
+  # ```
+  def self.tz(name : String, str : String) : self
+    zones = Array(Location::Zone).new(initial_capacity: 2)
+    tz = TZ.parse(str, zones, true) || raise ArgumentError.new("Invalid TZ string: #{str}")
+    new(name, zones, tz: tz, tz_string: str)
   end
 
   # Loads the `Location` with the given *name*.
@@ -343,7 +375,11 @@ class Time::Location
   # The environment variable `ENV["TZ"]` is consulted for finding the time zone
   # to use.
   #
-  # * `"UTC"`, `"Etc/UTC"` and empty string (`""`) return `Location::UTC`
+  # * `"UTC"`, `"Etc/UTC"` and empty string (`""`) return `Location::UTC`.
+  # * POSIX TZ strings (such as `"EST5EDT,M3.2.0,M11.1.0"`) are parsed using
+  #   `Location.tz`.
+  # * Values beginning with a colon are implementation-defined according to
+  #   POSIX, and not supported in Crystal.
   # * Any other value (such as `"Europe/Berlin"`) is tried to be resolved using
   #   `Location.load`.
   # * If `ENV["TZ"]` is not set, the system's local time zone data will be used
@@ -351,20 +387,32 @@ class Time::Location
   # * If no time zone data could be found (i.e. the previous methods failed),
   #   `Location::UTC` is returned.
   def self.load_local : Location
-    case tz = ENV["TZ"]?
+    case tz_string = ENV["TZ"]?
     when "", "UTC", "Etc/UTC"
       return UTC
     when Nil
       if localtime = Crystal::System::Time.load_localtime
         return localtime
       end
+    when .starts_with?(':')
+      # Do not perform time zone database lookup here. POSIX.1-2024 says:
+      #
+      # > If _TZ_ is of the third format (that is, if the first character is not
+      # > a <colon> and the value does not match the syntax for the second
+      # > format), the value indicates either a geographical timezone or a
+      # > special timezone from an implementation-defined timezone database.
     else
+      zones = Array(Location::Zone).new(initial_capacity: 2)
+      if tz = TZ.parse(tz_string, zones, true)
+        return new("Local", zones, tz: tz, tz_string: tz_string)
+      end
+
       if zoneinfo = ENV["ZONEINFO"]?
-        if location = load_from_dir_or_zip(tz, zoneinfo)
+        if location = load_from_dir_or_zip(tz_string, zoneinfo)
           return location
         end
       end
-      if location = load?(tz, Crystal::System::Time.zone_sources)
+      if location = load?(tz_string, Crystal::System::Time.zone_sources)
         return location
       end
     end
@@ -373,7 +421,7 @@ class Time::Location
   end
 
   # :nodoc:
-  def initialize(@name : String, @zones : Array(Zone), @transitions = [] of ZoneTransition)
+  def initialize(@name : String, @zones : Array(Zone), @transitions = [] of ZoneTransition, @tz = nil, @tz_string = nil)
     @cached_zone = lookup_first_zone
     @cached_range = {Int64::MIN, @zones.size <= 1 ? Int64::MAX : Int64::MIN}
   end
@@ -397,7 +445,7 @@ class Time::Location
   #
   # Two `Location` instances are considered equal if they have the same name,
   # offset zones and transition rules.
-  def_equals_and_hash name, zones, transitions
+  def_equals_and_hash name, zones, transitions, tz_string
 
   # Returns the time zone offset observed at *time*.
   def lookup(time : Time) : Zone
@@ -420,19 +468,36 @@ class Time::Location
   def lookup_with_boundaries(unix_seconds : Int) : {Zone, {Int64, Int64}}
     case
     when zones.empty?
-      return Zone::UTC, {Int64::MIN, Int64::MAX}
-    when transitions.empty? || unix_seconds < transitions.first.when
-      return lookup_first_zone, {Int64::MIN, transitions[0]?.try(&.when) || Int64::MAX}
+      {Zone::UTC, {Int64::MIN, Int64::MAX}}
+    when transitions.empty?
+      tz_lookup(unix_seconds) do
+        {lookup_first_zone, {Int64::MIN, Int64::MAX}}
+      end
+    when unix_seconds < transitions.first.when
+      {lookup_first_zone, {Int64::MIN, transitions.first.when}}
+    when unix_seconds >= transitions.last.when
+      tz_lookup(unix_seconds) do
+        transition = transitions.last
+        {zones[transition.index], {transition.when, Int64::MAX}}
+      end
     else
       tx_index = transitions.bsearch_index do |transition|
         transition.when > unix_seconds
-      end || transitions.size
+      end.not_nil!
 
       tx_index -= 1 unless tx_index == 0
       transition = transitions[tx_index]
       range_end = transitions[tx_index + 1]?.try(&.when) || Int64::MAX
 
-      return zones[transition.index], {transition.when, range_end}
+      {zones[transition.index], {transition.when, range_end}}
+    end
+  end
+
+  private def tz_lookup(unix_seconds, &)
+    if tz = @tz
+      tz.lookup_with_boundaries(unix_seconds, self)
+    else
+      yield
     end
   end
 
@@ -480,6 +545,10 @@ class Time::Location
   end
 
   # Returns `true` if this location has a fixed offset.
+  #
+  # Locations returned by `Location.tz` have a fixed offset if the TZ string
+  # specifies either no daylight saving time at all, or an all-year daylight
+  # saving time (e.g. `"EST5EDT,0/0,J365/25"`).
   def fixed? : Bool
     zones.size <= 1
   end

--- a/src/time/tz.cr
+++ b/src/time/tz.cr
@@ -1,0 +1,312 @@
+# :nodoc:
+# Structure that holds the local time transition rules of a TZ string as defined
+# in [POSIX.1-2024 Section 8.3](https://pubs.opengroup.org/onlinepubs/9799919799/basedefs/V1_chap08.html).
+# Also used by TZif database files (version 2 or higher) as defined in
+# [IETF RFC 9636](https://datatracker.ietf.org/doc/html/rfc9636).
+struct Time::TZ
+  # `J*`: one-based ordinal day, excludes leap day
+  record Julian1, ordinal : Int32
+
+  # `*`: zero-based ordinal day, includes leap day
+  record Julian0, ordinal : Int32
+
+  # `M*.*.*`: month-week-day, week 5 is last week
+  record MonthWeekDay, month : Int32, week : Int32, day : Int32
+
+  record Transition, date : Julian1 | Julian0 | MonthWeekDay, time : Int32 do
+    def unix_date_in_year(year : Int) : Int64
+      case date = @date
+      in Julian1
+        Time.utc(year, 1, 1).to_unix + 86400_i64 * (Time.leap_year?(year) && date.ordinal >= 60 ? date.ordinal : date.ordinal - 1)
+      in Julian0
+        Time.utc(year, 1, 1).to_unix + 86400_i64 * date.ordinal
+      in MonthWeekDay
+        Time.month_week_date(year, date.month, date.week, date.day, location: Time::Location::UTC).to_unix
+      end
+    end
+  end
+
+  # Indices into a parent `Time::Location`'s zones array. Identical if all-year
+  # standard time or DST is in effect.
+  getter std_index : Int32
+  getter dst_index : Int32
+
+  # The first and second transition times defined in the TZ string. Not
+  # meaningful when `std_index == dst_index`.
+  getter transition1 : Transition
+  getter transition2 : Transition
+
+  def initialize(@std_index, @dst_index, @transition1, @transition2)
+  end
+
+  private def self.new(index : Int32) : self
+    default_transition = Transition.new(Julian0.new(0), 0)
+    new(index, index, default_transition, default_transition)
+  end
+
+  def lookup_with_boundaries(unix_seconds : Int64, location : Location) : {Location::Zone, {Int64, Int64}}
+    if @std_index == @dst_index
+      # all-year standard time or DST time
+      is_dst = false
+      range_begin = Int64::MIN
+      range_end = Int64::MAX
+    else
+      std_offset = -location.zones[@std_index].offset
+      dst_offset = -location.zones[@dst_index].offset
+
+      # Find the local year corresponding to `unix_seconds`, except we cannot
+      # rely on `Time`'s timezone facilities since that is exactly what this
+      # method implements. It may differ from the UTC year by 0 or 1. musl uses
+      # a similar loop.
+      utc_time = Time.unix(unix_seconds)
+      utc_year = local_year = utc_time.year
+
+      while true
+        datetime1 = @transition1.unix_date_in_year(local_year) + @transition1.time + std_offset
+        datetime2 = @transition2.unix_date_in_year(local_year) + @transition2.time + dst_offset
+        new_year_is_dst = datetime2 < datetime1
+
+        local_new_year = Time.utc(local_year, 1, 1).to_unix + (new_year_is_dst ? dst_offset : std_offset)
+        local_new_year_next = Time.utc(local_year + 1, 1, 1).to_unix + (new_year_is_dst ? dst_offset : std_offset)
+        break if local_new_year <= unix_seconds < local_new_year_next
+
+        if local_year == utc_year
+          local_year += unix_seconds >= local_new_year_next ? 1 : -1
+        else
+          # Normally `new_year_is_dst` should be identical across all years, but
+          # POSIX does not technically forbid something like `M1.1.0,J4`, where
+          # one transition could be anything within January 1 - 7, and the other
+          # one is January 4 in all years. In this extremely unlikely case there
+          # could be a gap after the `local_new_year_next` for a given year and
+          # before the `local_new_year` for its next year. We assume this is not
+          # practically useful, so we just bail out here.
+          raise Time::Error.new "BUG: Failed to determine local year"
+        end
+      end
+
+      if new_year_is_dst
+        if unix_seconds < datetime2
+          is_dst = true
+          range_begin = @transition1.unix_date_in_year(local_year - 1) + @transition1.time + std_offset
+          range_end = datetime2
+        elsif unix_seconds >= datetime1
+          is_dst = true
+          range_begin = datetime1
+          range_end = @transition2.unix_date_in_year(local_year + 1) + @transition2.time + dst_offset
+        else
+          is_dst = false
+          range_begin = datetime2
+          range_end = datetime1
+        end
+      else
+        if unix_seconds < datetime1
+          is_dst = false
+          range_begin = @transition2.unix_date_in_year(local_year - 1) + @transition2.time + dst_offset
+          range_end = datetime1
+        elsif unix_seconds >= datetime2
+          is_dst = false
+          range_begin = datetime2
+          range_end = @transition1.unix_date_in_year(local_year + 1) + @transition1.time + std_offset
+        else
+          is_dst = true
+          range_begin = datetime1
+          range_end = datetime2
+        end
+      end
+    end
+
+    if last_transition = location.transitions.last?
+      range_begin = {range_begin, last_transition.when}.max
+    end
+
+    {location.zones[is_dst ? @dst_index : @std_index], {range_begin, range_end}}
+  end
+
+  # Parses the given *tz* string. Returns `nil` if *tz* is invalid.
+  #
+  # The returned `TZ`'s `std_index` and `dst_index` members index into the giben
+  # *zones* array, which should belong to a `Time::Location`. Missing entries in
+  # *zones* are automatically created.
+  #
+  # *hours_extension* increases the hours range of transition time offsets from
+  # 0..24 to -167..+167, according to POSIX.1-2024 or RFC 9636 Section 3.3.2
+  # (the latter only for TZif version 3 or higher).
+  #
+  # C runtime library implementations:
+  #
+  # * glibc https://sourceware.org/git/?p=glibc.git;a=blob;f=time/tzset.c;hb=2642002380aafb71a1d3b569b6d7ebeab3284816#l321
+  # * musl https://git.musl-libc.org/cgit/musl/tree/src/time/__tz.c?id=ef7d0ae21240eac9fc1e8088112bfb0fac507578#n239
+  # * bionic https://android.googlesource.com/platform/bionic/+/31fc69f67fc49b1a08f5561ae62d098106da6565/libc/tzcode/localtime.c#1148
+  # * wine msvcrt https://gitlab.winehq.org/wine/wine/-/blob/7f833db11ffea4f3f4fa07be31d30559aff9c5fb/dlls/msvcrt/time.c#L127
+  def self.parse(tz : String, zones : Array(Location::Zone), hours_extension : Bool) : TZ?
+    reader = Char::Reader.new(tz)
+
+    # colon prefix: implementation-defined (not supported in Crystal)
+    # glibc treats the rest of the TZ string as a TZif database path name
+    # (`parse_std_or_dst` will reject strings beginning with a `:` anyway so it
+    # doesn't have to be checked here)
+
+    # std offset [dst [offset] [, start [/ time] , end [/ time]]]
+    reader, std_name = parse_std_or_dst(reader) || return nil
+    reader, std_offset = parse_offset(reader, 24, true) || return nil
+    std_zone = Location::Zone.new(std_name, -std_offset, false)
+
+    unless reader.has_next?
+      # no DST component means all-year standard time
+      return new(zone_index(std_zone, zones))
+    end
+
+    reader, dst_name = parse_std_or_dst(reader) || return nil
+    if result = parse_offset(reader, 24, true)
+      reader, dst_offset = result
+    else
+      dst_offset = std_offset - 3600
+    end
+    dst_zone = Time::Location::Zone.new(dst_name, -dst_offset, true)
+
+    # missing transitions: implementation-defined (not supported in Crystal)
+    # msvcrt and bionic fall back to `M3.2.0,M11.1.0`, i.e. US rules since 2007
+    return nil unless reader.current_char == ','
+    reader.next_char
+    reader, transition1 = parse_transition(reader, hours_extension) || return nil
+
+    return nil unless reader.current_char == ','
+    reader.next_char
+    reader, transition2 = parse_transition(reader, hours_extension) || return nil
+
+    # if there are no trailing characters, we have a valid TZ string with
+    # transition rules
+    return nil if reader.has_next?
+
+    # all-year DST according to POSIX.1-2024 or RFC 9636 Section 3.3.1
+    # (we check here so that these locations return true for `#fixed?`)
+    if transition1.date.in?(Time::TZ::Julian1.new(1), Time::TZ::Julian0.new(0)) && transition1.time == 0
+      # `Julian0` does not represent the last day in all years, so only check
+      # for `J365` exactly
+      if transition2.date == Time::TZ::Julian1.new(365) && transition2.time == 86400 + std_offset - dst_offset
+        return new(zone_index(dst_zone, zones))
+      end
+    end
+
+    std_index = zone_index(std_zone, zones)
+    dst_index = zone_index(dst_zone, zones)
+    new(std_index, dst_index, transition1, transition2)
+  end
+
+  private def self.zone_index(zone : Location::Zone, zones : Array(Location::Zone)) : Int
+    if index = zones.index(zone)
+      index
+    else
+      zones.size.tap { zones << zone }
+    end
+  end
+
+  private def self.parse_transition(reader : Char::Reader, hours_extension : Bool) : {Char::Reader, Transition}?
+    date =
+      case reader.current_char
+      when 'J'
+        reader.next_char
+        reader, day = parse_int(reader, 365) || return
+        return unless day >= 1
+        Julian1.new(day)
+      when 'M'
+        reader.next_char
+        reader, month = parse_int(reader, 12) || return
+        return unless month >= 1
+
+        return unless reader.current_char == '.'
+        reader.next_char
+        reader, week = parse_int(reader, 5) || return
+        return unless week >= 1
+
+        return unless reader.current_char == '.'
+        reader.next_char
+        reader, day = parse_int(reader, 6) || return
+
+        MonthWeekDay.new(month, week, day)
+      else
+        reader, day = parse_int(reader, 365) || return
+        Julian0.new(day)
+      end
+
+    if reader.current_char == '/'
+      reader.next_char
+      reader, time = parse_offset(reader, hours_extension ? 167 : 24, hours_extension) || return
+    else
+      time = 7200 # 02:00:00
+    end
+
+    {reader, Transition.new(date, time)}
+  end
+
+  private def self.parse_offset(reader : Char::Reader, hour_limit : Int, allow_sign : Bool) : {Char::Reader, Int32}?
+    sign = 1
+    if allow_sign
+      case reader.current_char
+      when '-'
+        sign = -1
+        reader.next_char
+      when '+'
+        reader.next_char
+      end
+    end
+
+    reader, hours = parse_int(reader, hour_limit) || return
+    minutes = 0
+    seconds = 0
+
+    if reader.current_char == ':'
+      reader.next_char
+      reader, minutes = parse_int(reader, 59) || return
+      if reader.current_char == ':'
+        reader.next_char
+        reader, seconds = parse_int(reader, 59) || return
+      end
+    end
+
+    total_seconds = sign * (3600 * hours + 60 * minutes + seconds)
+    {reader, total_seconds}
+  end
+
+  private def self.parse_int(reader : Char::Reader, limit : Int) : {Char::Reader, Int32}?
+    start = reader.pos
+    while reader.current_char == '0'
+      reader.next_char
+    end
+
+    value = 0
+    while digit = reader.current_char.to_i?
+      value = value * 10 + digit
+      return unless value <= limit
+      reader.next_char
+    end
+
+    if reader.pos > start
+      {reader, value}
+    end
+  end
+
+  private def self.parse_std_or_dst(reader : Char::Reader) : {Char::Reader, String}?
+    quoted = false
+    if reader.current_char == '<'
+      reader.next_char
+      quoted = true
+    end
+
+    start = reader.pos
+    while ch = reader.current_char?
+      break unless ch.ascii_letter? || (quoted && (ch.ascii_number? || ch.in?('+', '-')))
+      reader.next_char
+    end
+    return unless reader.pos - start >= 3
+    finish = reader.pos
+
+    if quoted
+      return unless reader.current_char == '>'
+      reader.next_char
+    end
+
+    name = reader.string.byte_slice(start, finish - start)
+    {reader, name}
+  end
+end

--- a/src/time/tz.cr
+++ b/src/time/tz.cr
@@ -46,7 +46,7 @@ struct Time::TZ
     end
 
     def unix_date_in_year(year : Int) : Int64
-      Time.month_week_date(year, @month, @week, @day, location: Time::Location::UTC).to_unix
+      Time.month_week_date(year, @month.to_i32, @week.to_i32, @day.to_i32, location: Time::Location::UTC).to_unix
     end
   end
 

--- a/src/time/tz.cr
+++ b/src/time/tz.cr
@@ -44,7 +44,7 @@ struct Time::TZ
     new(index, index, default_transition, default_transition)
   end
 
-  def lookup_with_boundaries(unix_seconds : Int64, location : Location) : {Location::Zone, {Int64, Int64}}
+  def lookup_with_boundaries(unix_seconds : Int, location : Location) : {Location::Zone, {Int64, Int64}}
     if @std_index == @dst_index
       # all-year standard time or DST time
       is_dst = false


### PR DESCRIPTION
This PR adds support for POSIX TZ strings such as `EST5EDT,M3.2.0,M11.1.0`, as defined in [POSIX.1-2024, Section 8.3](https://pubs.opengroup.org/onlinepubs/9799919799/basedefs/V1_chap08.html). When the `TZ` environment variable contains such a string, `Time::Location.load_local`, and by extension `.local`, will return a location with the correct transition datetimes across the entire proleptic Gregorian calendar.

A convenience method `Time::Location.posix_tz` is also added for creating those locations without going through an environment variable.

The implementation-defined aspects of the standard are not supported, and can be added later at will. These include strings prefixed by a colon (`:/etc/localtime`), and TZ strings specifying a DST time zone without transition rules (`EST5EDT`, although the US ones are available in most time zone databases by those names too).

`Time::Location::Zone`'s allowed offset range is slightly extended to accommodate for POSIX TZ strings.

The work here can be followed up in at least two ways:

* TZif database files, as defined in [IETF RFC 9636](https://datatracker.ietf.org/doc/html/rfc9636), also contain POSIX TZ strings in their footers, used to compute time zone transitions beyond the last manually defined transition time. Crystal does not read these at the moment, which means transitions after year 2038 do not work, since most tzdata packages only include entries fitting into 32-bit Unix times, even those using TZif version 2 or above. This would depend also on #11907 as the footer is located after the 64-bit Unix time body.
* Windows system time zones in Crystal are defined by somewhat arbitrarily instantiating all individual transitions 100 years within the current year, but they use month + week + day of week under the hood, so they are actually compatible with POSIX TZ strings. Internally using `Time::TZ` from this PR instead would greatly reduce the memory consumption of `Time::Location` objects on Windows.