### PR TITLE
[CI] Add CI workflow for MinGW-w64 ARM64 builds

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -5,6 +5,7 @@ self-hosted-runner:
     - runner=*
     - family=*
     - ram=*
+    - windows-11-arm # actionlint doesn't understand this label yet
 
 # Configuration variables in array of strings defined in your repository or
 # organization. `null` means disabling configuration variables check.

--- a/.github/workflows/mingw-w64.yml
+++ b/.github/workflows/mingw-w64.yml
@@ -150,3 +150,174 @@ jobs:
           make -o .build/crystal.exe primitives_spec # we know the compiler is fresh; do not rebuild it here
         env:
           SPEC_FLAGS: --tag=~external_commands # skip exec_external_command spec because it doesn't work with this setup
+
+  aarch64-mingw-w64-cross-compile:
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Download Crystal source
+        uses: actions/checkout@v4
+
+      - name: Install LLVM
+        run: |
+          _llvm_major="$(wget -qO- https://raw.githubusercontent.com/msys2/MINGW-packages/refs/heads/master/mingw-w64-llvm/PKGBUILD | grep '_pkgver=' | sed -E 's/_pkgver=([0-9]+).*/\1/')"
+          sudo apt remove 'llvm-*' 'libllvm*'
+          wget -qO- https://apt.llvm.org/llvm-snapshot.gpg.key | sudo tee /etc/apt/trusted.gpg.d/apt.llvm.org.asc
+          sudo apt-add-repository -y deb http://apt.llvm.org/noble/ "llvm-toolchain-noble-${_llvm_major}" main
+          sudo apt install -y "llvm-${_llvm_major}-dev"
+
+      - name: Install Crystal
+        uses: crystal-lang/install-crystal@v1
+        with:
+          crystal: "1.16.3"
+
+      - name: Cross-compile Crystal
+        run: make && make -B target=aarch64-windows-gnu release=1 interpreter=1
+
+      - name: Upload crystal.obj
+        uses: actions/upload-artifact@v4
+        with:
+          name: aarch64-mingw-w64-crystal-obj
+          path: .build/crystal.obj
+
+  aarch64-mingw-w64-link:
+    runs-on: windows-11-arm
+    needs: [aarch64-mingw-w64-cross-compile]
+    steps:
+      - name: Setup MSYS2
+        id: msys2
+        uses: msys2/setup-msys2@61f9e5e925871ba6c9e3e8da24ede83ea27fa91f # v2.27.0
+        with:
+          msystem: CLANGARM64
+          update: true
+          install: >-
+            make
+            mingw-w64-clang-aarch64-pkgconf
+            mingw-w64-clang-aarch64-cc
+            mingw-w64-clang-aarch64-gc
+            mingw-w64-clang-aarch64-pcre2
+            mingw-w64-clang-aarch64-libiconv
+            mingw-w64-clang-aarch64-zlib
+            mingw-w64-clang-aarch64-llvm
+            mingw-w64-clang-aarch64-libffi
+            mingw-w64-clang-aarch64-libyaml
+
+      - name: Disable CRLF line ending substitution
+        run: |
+          git config --global core.autocrlf false
+
+      - name: Download Crystal source
+        uses: actions/checkout@v4
+
+      - name: Download crystal.obj
+        uses: actions/download-artifact@v4
+        with:
+          name: aarch64-mingw-w64-crystal-obj
+
+      - name: Link Crystal executable
+        shell: msys2 {0}
+        run: |
+          mkdir .build
+          cc crystal.obj -o .build/crystal.exe -municode \
+            $(pkg-config bdw-gc libpcre2-8 iconv zlib libffi --libs) \
+            $(llvm-config --libs --system-libs --ldflags) \
+            -lole32 -lWS2_32 -lntdll -Wl,--stack,0x800000
+
+      - name: Package Crystal
+        shell: msys2 {0}
+        run: |
+          make install install_dlls deref_symlinks=1 PREFIX="$(pwd)/crystal"
+
+      - name: Download shards release
+        uses: actions/checkout@v4
+        with:
+          repository: crystal-lang/shards
+          ref: v0.19.1
+          path: shards
+
+      - name: Build shards release
+        shell: msys2 {0}
+        working-directory: ./shards
+        run: make CRYSTAL=$(pwd)/../crystal/bin/crystal SHARDS=false release=1
+
+      - name: Package Shards
+        shell: msys2 {0}
+        working-directory: ./shards
+        run: |
+          make install PREFIX="$(pwd)/../crystal" SHARDS=false
+          # FIXME: remove after crystal-lang/shards#668
+          ldd bin/shards.exe | grep -iv ' => /c/windows/system32' | sed 's/.* => //; s/ (.*//' | xargs -t -i /usr/bin/install -m 0755 '{}' "$(pwd)/../crystal/bin/"
+
+      - name: Upload Crystal executable
+        uses: actions/upload-artifact@v4
+        with:
+          name: aarch64-mingw-w64-crystal
+          path: crystal
+
+  aarch64-mingw-w64-test:
+    runs-on: windows-11-arm
+    needs: [aarch64-mingw-w64-link]
+    steps:
+      - name: Setup MSYS2
+        id: msys2
+        uses: msys2/setup-msys2@61f9e5e925871ba6c9e3e8da24ede83ea27fa91f # v2.27.0
+        with:
+          msystem: CLANGARM64
+          update: true
+          install: >-
+            git
+            make
+            mingw-w64-clang-aarch64-pkgconf
+            mingw-w64-clang-aarch64-cc
+            mingw-w64-clang-aarch64-gc
+            mingw-w64-clang-aarch64-pcre2
+            mingw-w64-clang-aarch64-libiconv
+            mingw-w64-clang-aarch64-zlib
+            mingw-w64-clang-aarch64-llvm
+            mingw-w64-clang-aarch64-gmp
+            mingw-w64-clang-aarch64-libxml2
+            mingw-w64-clang-aarch64-libyaml
+            mingw-w64-clang-aarch64-openssl
+            mingw-w64-clang-aarch64-libffi
+
+      - name: Disable CRLF line ending substitution
+        run: |
+          git config --global core.autocrlf false
+
+      - name: Download Crystal source
+        uses: actions/checkout@v4
+
+      - name: Download Crystal executable
+        uses: actions/download-artifact@v4
+        with:
+          name: aarch64-mingw-w64-crystal
+          path: crystal
+
+      - name: Run stdlib specs
+        shell: msys2 {0}
+        run: |
+          export PATH="$(pwd)/crystal/bin:$PATH"
+          export CRYSTAL_SPEC_COMPILER_BIN="$(pwd)/crystal/bin/crystal.exe"
+          make std_spec
+
+      - name: Run compiler specs
+        shell: msys2 {0}
+        run: |
+          export PATH="$(pwd)/crystal/bin:$PATH"
+          export CRYSTAL_SPEC_COMPILER_BIN="$(pwd)/crystal/bin/crystal.exe"
+          make compiler_spec
+
+      - name: Run interpreter specs
+        shell: msys2 {0}
+        run: |
+          export PATH="$(pwd)/crystal/bin:$PATH"
+          export CRYSTAL_SPEC_COMPILER_BIN="$(pwd)/crystal/bin/crystal.exe"
+          make interpreter_spec
+
+      - name: Run primitives specs
+        shell: msys2 {0}
+        run: |
+          export PATH="$(pwd)/crystal/bin:$PATH"
+          export CRYSTAL_SPEC_COMPILER_BIN="$(pwd)/crystal/bin/crystal.exe"
+          make -o .build/crystal.exe primitives_spec # we know the compiler is fresh; do not rebuild it here
+        env:
+          SPEC_FLAGS: --tag=~external_commands # skip exec_external_command spec because it doesn't work with this setup


### PR DESCRIPTION
If CI is green, this means Crystal will be available on the `aarch64-windows-gnu` target even before `aarch64-windows-msvc`. (The latter is blocked by the use of MPIR, which uses x86-64 assembly extensively but is no longer maintained.)

This is mostly just a copy of the workflow definition before #15453, slightly adjusted for ARM64. The cross-compilation itself does not require an AArch64 host machine, and an x86-64 will just work equally fine. Once 1.17.0 is out and a release package is available, we could drop this again and use a job matrix instead.