### PR TITLE
Fix `BigFloat#format` not compiling

### DIFF
--- a/spec/std/humanize_spec.cr
+++ b/spec/std/humanize_spec.cr
@@ -93,6 +93,18 @@ describe Number do
     it { assert_prints (-Float64::INFINITY).format, "-Infinity" }
     it { assert_prints Float64::NAN.format, "NaN" }
 
+    it { assert_prints "12345678.90123".to_big_f.format, "12,345,678.90123" }
+    it { assert_prints "12345678.90123".to_big_f.format(decimal_places: 10), "12,345,678.9012300000" }
+    it { assert_prints "12345678.90123".to_big_f.format(decimal_places: -4), "12,350,000" }
+
+    it { assert_prints (2.to_big_f ** 58).format, "288,230,376,151,711,744.0" }
+    it { assert_prints (2.to_big_f ** 58).format(decimal_places: 10), "288,230,376,151,711,744.0000000000" }
+    it { assert_prints (2.to_big_f ** 58).format(decimal_places: -5), "288,230,376,151,700,000" }
+
+    it { assert_prints (2.to_big_f ** -16).format, "0.0000152587890625" }
+    it { assert_prints (2.to_big_f ** -16).format(decimal_places: 10), "0.00001525878906250000" }
+    it { assert_prints (2.to_big_f ** -16).format(decimal_places: -5), "0.00001526" }
+
     it { assert_prints "12345.67890123456789012345".to_big_d.format, "12,345.67890123456789012345" }
 
     it "extracts integer part correctly (#12997)" do

--- a/src/humanize.cr
+++ b/src/humanize.cr
@@ -56,10 +56,23 @@ struct Number
       integer, _, decimals = string.partition('.')
     end
 
+    is_negative = number.is_a?(Float::Primitive) ? Math.copysign(1, number) < 0 : number < 0
+
+    format_impl(io, is_negative, integer, decimals, separator, delimiter, decimal_places, group, only_significant)
+  end
+
+  # :ditto:
+  def format(separator = '.', delimiter = ',', decimal_places : Int? = nil, *, group : Int = 3, only_significant : Bool = false) : String
+    String.build do |io|
+      format(io, separator, delimiter, decimal_places, group: group, only_significant: only_significant)
+    end
+  end
+
+  private def format_impl(io, is_negative, integer, decimals, separator, delimiter, decimal_places, group, only_significant) : Nil
     int_size = integer.size
     dec_size = decimals.size
 
-    io << '-' if number.is_a?(Float::Primitive) ? Math.copysign(1, number) < 0 : number < 0
+    io << '-' if is_negative
 
     start = int_size % group
     start += group if start == 0
@@ -88,13 +101,6 @@ struct Number
           io << '0'
         end
       end
-    end
-  end
-
-  # :ditto:
-  def format(separator = '.', delimiter = ',', decimal_places : Int? = nil, *, group : Int = 3, only_significant : Bool = false) : String
-    String.build do |io|
-      format(io, separator, delimiter, decimal_places, group: group, only_significant: only_significant)
     end
   end
 


### PR DESCRIPTION
Apparently this was broken around the time Ryu Printf was added, because `Float::Printer.shortest` does not accept a `BigFloat` argument.