### PR TITLE
Add `BigRational#to_i`

### DIFF
--- a/spec/std/big/big_rational_spec.cr
+++ b/spec/std/big/big_rational_spec.cr
@@ -84,6 +84,14 @@ describe BigRational do
     r.to_s(36).should eq("4woiz/9b3djm")
   end
 
+  it "#to_i" do
+    br(10, 3).to_i.should eq(3)
+    br(90, 3).to_i.should eq(30)
+    br(1, 98).to_i.should eq(0)
+    br(-10, 3).to_i.should eq(-3)
+    expect_raises(OverflowError) { br(Int64::MAX, 1).to_i }
+  end
+
   it "#to_f64" do
     r = br(10, 3)
     f = 10.to_f64 / 3.to_f64

--- a/src/big/big_rational.cr
+++ b/src/big/big_rational.cr
@@ -310,6 +310,10 @@ struct BigRational < Number
     to_f64!
   end
 
+  def to_i : Int32
+    to_i32
+  end
+
   delegate to_i8, to_i16, to_i32, to_i64, to_u8, to_u16, to_u32, to_u64, to: to_f64
 
   # Returns `self`.


### PR DESCRIPTION
This is the only type in the standard library where `#to_i32` is already defined but `#to_i` isn't.

This makes `BigRational` suspectible to precision loss when passed to `sprintf` `%i` (see also #15808), since `BigRational#to_i32` currently delegates to `#to_f64` instead of `#to_big_i`. However this is still an improvement over the current situation where `BigRational` isn't supported by `sprintf` at all.