### PR TITLE
Fix `Float32#abs` for signed zeros

### DIFF
--- a/spec/std/humanize_spec.cr
+++ b/spec/std/humanize_spec.cr
@@ -60,6 +60,9 @@ describe Number do
     it { assert_prints -0.0.format(decimal_places: 1), "-0.0" }
     it { assert_prints -0.0.format(decimal_places: 1, only_significant: true), "-0.0" }
 
+    it { assert_prints -0.0_f32.format(decimal_places: 1), "-0.0" }
+    it { assert_prints -0.0_f32.format(decimal_places: 1, only_significant: true), "-0.0" }
+
     it { assert_prints -0.01.format(decimal_places: 1), "-0.0" }
 
     it { assert_prints -123.45.format, "-123.45" }

--- a/src/float.cr
+++ b/src/float.cr
@@ -194,6 +194,10 @@ struct Float32
   Number.expand_div [Int8, UInt8, Int16, UInt16, Int32, UInt32, Int64, UInt64, Int128, UInt128], Float32
   Number.expand_div [Float64], Float64
 
+  def abs
+    Math.copysign(self, 1)
+  end
+
   # Rounds towards positive infinity.
   def ceil : Float32
     LibM.ceil_f32(self)


### PR DESCRIPTION
Like #12424, but for `Float32`.