### PR TITLE
Expose `#uri` of `HTTP::Request`

### DIFF
--- a/spec/std/http/request_spec.cr
+++ b/spec/std/http/request_spec.cr
@@ -516,6 +516,22 @@ module HTTP
       end
     end
 
+    describe "#uri" do
+      it "returns request uri object" do
+        raw_resource = "/document?something=true#fragment"
+        request = Request.from_io(IO::Memory.new("GET #{raw_resource} HTTP/1.1\r\n\r\n")).as(Request)
+        request.uri.should eq(URI.parse(raw_resource))
+      end
+
+      it "can change the results of #resource" do
+        request = Request.from_io(IO::Memory.new("GET /route HTTP/1.1\r\n\r\n")).as(Request)
+        request.resource.should eq("/route")
+
+        request.uri.path = "/some_other_route"
+        request.resource.should eq("/some_other_route")
+      end
+    end
+
     it "doesn't raise on request with multiple Content_length headers" do
       io = IO::Memory.new <<-HTTP
         GET / HTTP/1.1

--- a/src/http/request.cr
+++ b/src/http/request.cr
@@ -321,7 +321,10 @@ class HTTP::Request
     @headers["Host"]?
   end
 
-  private def uri
+  # Returns the underlying URI object.
+  #
+  # Used internally to provide the components of the request uri.
+  def uri : URI
     @uri ||= URI::Parser.new(@resource).parse_request_target.uri
   end
 


### PR DESCRIPTION
Follow up to the discussion here https://github.com/crystal-lang/crystal/pull/15789#discussion_r2094358979

There are some scenarios where you'd want the underlying uri object (like reading/changing the fragment component of the request target for a redirect) but this change is mostly just made to allow using `HTTP::Server::Response#redirect` without the possibility of the uri being double encoded.