### PR TITLE
Add support for markdown output format in `crystal docs` command

### DIFF
--- a/etc/completion.bash
+++ b/etc/completion.bash
@@ -81,7 +81,15 @@ _crystal()
                 _crystal_compgen_sources "${cur}"
             fi
             ;;
-        clear_cache|docs|eval|spec|version|help)
+        docs)
+            if [[ "${cur}" == -* ]] ; then
+                local opts="--output --format --help"
+                _crystal_compgen_options "${opts}" "${cur}"
+            else
+                _crystal_compgen_files "${cur}"
+            fi
+            ;;
+        clear_cache|eval|spec|version|help)
             # These commands do not accept any options nor subcommands
             _crystal_compgen_files "${cur}"
             ;;

--- a/etc/completion.fish
+++ b/etc/completion.fish
@@ -46,7 +46,7 @@ complete -c crystal -n "__fish_seen_subcommand_from docs" -l project-version -d 
 complete -c crystal -n "__fish_seen_subcommand_from docs" -l source-refname -d "Set source refname (e.g. git tag, commit hash)"
 complete -c crystal -n "__fish_seen_subcommand_from docs" -l source-url-pattern -d "Set URL pattern for source code links"
 complete -c crystal -n "__fish_seen_subcommand_from docs" -s o -l output -d "Set the output directory (default: ./docs)"
-complete -c crystal -n "__fish_seen_subcommand_from docs" -s f -l format -d "Set the output format (default: html)" -a "html json"
+complete -c crystal -n "__fish_seen_subcommand_from docs" -s f -l format -d "Set the output format (default: html)" -a "html json markdown"
 complete -c crystal -n "__fish_seen_subcommand_from docs" -l json-config-url -d "Set the URL pointing to a config file (used for discovering versions)"
 complete -c crystal -n "__fish_seen_subcommand_from docs" -l canonical-base-url -d "Indicate the preferred URL with rel="canonical" link element"
 complete -c crystal -n "__fish_seen_subcommand_from docs" -s b -l sitemap-base-url -d "Set the sitemap base URL and generates sitemap"

--- a/etc/completion.zsh
+++ b/etc/completion.zsh
@@ -46,7 +46,7 @@ local -a exec_args; exec_args=(
 )
 
 local -a format_args; format_args=(
-  '(-f --format)'{-f,--format}'[output format text (default) or json]:'
+  '(-f --format)'{-f,--format}'[output format text (default), json, or markdown]:'
 )
 
 local -a debug_args; debug_args=(

--- a/src/compiler/crystal/command/docs.cr
+++ b/src/compiler/crystal/command/docs.cr
@@ -4,7 +4,7 @@
 # is in `crystal/tools/doc/`
 
 class Crystal::Command
-  private VALID_OUTPUT_FORMATS = %w(html json)
+  private VALID_OUTPUT_FORMATS = %w(html json markdown)
 
   private def docs
     output_format = "html"

--- a/src/compiler/crystal/tools/doc/generator.cr
+++ b/src/compiler/crystal/tools/doc/generator.cr
@@ -1,5 +1,6 @@
 require "markd"
 require "crystal/syntax_highlighter/html"
+require "./markdown_converter"
 
 class Crystal::Doc::Generator
   getter program : Program
@@ -43,6 +44,8 @@ class Crystal::Doc::Generator
 
     if @output_format == "json"
       generate_docs_json program_type, types
+    elsif @output_format == "markdown"
+      generate_docs_markdown program_type, types
     else
       generate_docs_html program_type, types
     end
@@ -72,6 +75,14 @@ class Crystal::Doc::Generator
     readme = read_readme
     json = Main.new(readme, Type.new(self, @program), project_info)
     puts json
+  end
+
+  def generate_docs_markdown(program_type, types)
+    readme = read_readme
+    json_data = Main.new(readme, Type.new(self, @program), project_info)
+    
+    markdown_converter = MarkdownConverter.new(json_data, @output_dir)
+    markdown_converter.generate
   end
 
   def generate_docs_html(program_type, types)

--- a/src/compiler/crystal/tools/doc/markdown_converter.cr
+++ b/src/compiler/crystal/tools/doc/markdown_converter.cr
@@ -1,0 +1,254 @@
+require "json"
+require "file_utils"
+
+class Crystal::Doc::MarkdownConverter
+  def initialize(@json_data : Main, @output_dir : String)
+  end
+
+  def generate
+    Dir.mkdir_p(@output_dir)
+    generate_readme
+    generate_index
+    generate_type_files
+  end
+
+  private def generate_readme
+    readme_content = @json_data.body
+    File.write(File.join(@output_dir, "README.md"), readme_content)
+  end
+
+  private def generate_index
+    program = @json_data.program
+    repository_name = @json_data.project_info.name
+    
+    content = String.build do |io|
+      io.puts "# #{repository_name} API Documentation"
+      io.puts
+      io.puts "## Top Level Namespace"
+      io.puts
+      
+      # Add program summary if available
+      if summary = program.formatted_summary
+        io.puts summary
+      end
+      
+      # List all types
+      io.puts
+      io.puts "## Types"
+      io.puts
+      
+      # Create a table of types
+      io.puts "| Name | Kind | Description |"
+      io.puts "|------|------|-------------|"
+      
+      all_types = collect_all_types(program)
+      all_types.each do |type|
+        kind = type.kind
+        name = type.name
+        summary = type.formatted_summary || ""
+        # Remove HTML tags from summary
+        summary = summary.gsub(/<[^>]*>/, "")
+        
+        # Create link to type file
+        type_link = "[#{name}](#{type_filename(type)})"
+        
+        io.puts "| #{type_link} | #{kind} | #{summary} |"
+      end
+    end
+    
+    File.write(File.join(@output_dir, "index.md"), content)
+  end
+
+  private def generate_type_files
+    all_types = collect_all_types(@json_data.program)
+    
+    all_types.each do |type|
+      content = generate_type_content(type)
+      filename = type_filename(type)
+      File.write(File.join(@output_dir, filename), content)
+    end
+  end
+
+  private def generate_type_content(type)
+    String.build do |io|
+      # Type header
+      io.puts "# #{type.name}"
+      io.puts
+      
+      # Type kind and inheritance
+      io.puts "**#{type.kind.capitalize}**"
+      
+      if type.superclass
+        io.puts
+        io.puts "Inherits: #{type_link(type.superclass)}"
+      end
+      
+      # Included modules
+      unless type.included_modules.empty?
+        io.puts
+        io.puts "Includes:"
+        type.included_modules.each do |mod|
+          io.puts "* #{type_link(mod)}"
+        end
+      end
+      
+      # Extended modules
+      unless type.extended_modules.empty?
+        io.puts
+        io.puts "Extends:"
+        type.extended_modules.each do |mod|
+          io.puts "* #{type_link(mod)}"
+        end
+      end
+      
+      # Type documentation
+      if doc = type.doc
+        io.puts
+        io.puts doc.gsub(/<[^>]*>/, "")
+      end
+      
+      # Constants
+      unless type.constants.empty?
+        io.puts
+        io.puts "## Constants"
+        io.puts
+        
+        io.puts "| Name | Value | Description |"
+        io.puts "|------|-------|-------------|"
+        
+        type.constants.each do |constant|
+          name = constant.name
+          value = constant.value.to_s.gsub(/<[^>]*>/, "")
+          summary = constant.formatted_summary.to_s.gsub(/<[^>]*>/, "")
+          
+          io.puts "| #{name} | #{value} | #{summary} |"
+        end
+      end
+      
+      # Class methods
+      unless type.class_methods.empty?
+        io.puts
+        io.puts "## Class Methods"
+        io.puts
+        
+        type.class_methods.each do |method|
+          generate_method_documentation(io, method)
+        end
+      end
+      
+      # Constructors
+      unless type.constructors.empty?
+        io.puts
+        io.puts "## Constructors"
+        io.puts
+        
+        type.constructors.each do |constructor|
+          generate_method_documentation(io, constructor)
+        end
+      end
+      
+      # Instance methods
+      unless type.instance_methods.empty?
+        io.puts
+        io.puts "## Instance Methods"
+        io.puts
+        
+        type.instance_methods.each do |method|
+          generate_method_documentation(io, method)
+        end
+      end
+      
+      # Macros
+      unless type.macros.empty?
+        io.puts
+        io.puts "## Macros"
+        io.puts
+        
+        type.macros.each do |macro_def|
+          generate_macro_documentation(io, macro_def)
+        end
+      end
+      
+      # Nested types
+      unless type.types.empty?
+        io.puts
+        io.puts "## Nested Types"
+        io.puts
+        
+        io.puts "| Name | Kind | Description |"
+        io.puts "|------|------|-------------|"
+        
+        type.types.each do |nested_type|
+          kind = nested_type.kind
+          name = nested_type.name
+          summary = nested_type.formatted_summary.to_s.gsub(/<[^>]*>/, "")
+          
+          # Create link to type file
+          type_link = "[#{name}](#{type_filename(nested_type)})"
+          
+          io.puts "| #{type_link} | #{kind} | #{summary} |"
+        end
+      end
+    end
+  end
+
+  private def generate_method_documentation(io, method)
+    # Method signature
+    io.puts "### #{method.name}"
+    io.puts
+    io.puts "```crystal"
+    io.puts method.to_s.gsub(/<[^>]*>/, "")
+    io.puts "```"
+    io.puts
+    
+    # Method documentation
+    if doc = method.doc
+      io.puts doc.gsub(/<[^>]*>/, "")
+      io.puts
+    end
+  end
+
+  private def generate_macro_documentation(io, macro_def)
+    # Macro signature
+    io.puts "### #{macro_def.name}"
+    io.puts
+    io.puts "```crystal"
+    io.puts macro_def.to_s.gsub(/<[^>]*>/, "")
+    io.puts "```"
+    io.puts
+    
+    # Macro documentation
+    if doc = macro_def.doc
+      io.puts doc.gsub(/<[^>]*>/, "")
+      io.puts
+    end
+  end
+
+  private def collect_all_types(program)
+    result = [] of Type
+    collect_types(program, result)
+    result
+  end
+
+  private def collect_types(type, types)
+    types << type
+    
+    type.types.each do |subtype|
+      collect_types(subtype, types)
+    end
+  end
+
+  private def type_filename(type)
+    return "unknown.md" unless type
+    if type.program?
+      "toplevel.md"
+    else
+      "#{type.full_name.gsub(/::|~|\*|\+|-|\/|=|&|\?|\|/, "_")}.md"
+    end
+  end
+
+  private def type_link(type)
+    return "Unknown" unless type
+    "[#{type.name}](#{type_filename(type)})"
+  end
+end


### PR DESCRIPTION
Hello,

This pull request adds Markdown documentation generation to the `crystal docs` command, utilizing Vibe Coding techniques for the Crystal language.

```sh
crystal docs --format markdown
```

### Background

Recently, Vibe Coding (AI-assisted coding) has become increasingly popular. However, AI is not always familiar with the details of Crystal's libraries and APIs. Therefore, when explaining a library's API to an AI, a documentation format that is easy for both humans and AI to read is essential.\
Markdown is the optimal format for such communication.

### Development Process

This feature was developed through the following process:

1. Investigated how to add Markdown output to `crystal docs` using DeepWiki.com
2. Created an implementation plan on DeepWiki.com
3. Reviewed and refined the plan on DeepWiki.com to make it simpler and more robust
4. Reviewed the proposal with VSCode/Cline (ChatGPT 4o)
5. Implemented the feature with VSCode/Cline (Sonnet-3.7)
6. Built, tested, and fixed issues with VSCode/Cline (Sonnet-3.7)

### Summary

This pull request demonstrates which files need to be modified within the relatively large Crystal project to enable this functionality. I hope the Crystal team will consider an official implementation.
