### PR TITLE
Replace some uses of `String#%` with justification methods

### DIFF
--- a/src/compiler/crystal/tools/table_print.cr
+++ b/src/compiler/crystal/tools/table_print.cr
@@ -34,13 +34,11 @@ module Crystal
 
         case cell.align
         in .left?
-          "%-#{available_width}s" % cell.text
+          cell.text.ljust(available_width)
         in .right?
-          "%+#{available_width}s" % cell.text
+          cell.text.rjust(available_width)
         in .center?
-          left = " " * ((available_width - cell.text.size) // 2)
-          right = " " * (available_width - cell.text.size - left.size)
-          "#{left}#{cell.text}#{right}"
+          cell.text.center(available_width)
         end
       end
     end

--- a/src/compiler/crystal/util.cr
+++ b/src/compiler/crystal/util.cr
@@ -47,7 +47,7 @@ module Crystal
     line_number_padding = (source.size + line_number_start).to_s.chars.size
     source.map_with_index do |line, i|
       line = line.to_s.chomp
-      line_number = "%#{line_number_padding}d" % (i + line_number_start)
+      line_number = (i + line_number_start).to_s.rjust(line_number_padding)
       target = i + line_number_start == highlight_line_number
       if target
         if color


### PR DESCRIPTION
These uses of `String#%` seemed to predate the introduction of methods like `#rjust`.