### PR TITLE
Avoid calling `chars.size` on `String`s

### DIFF
--- a/src/compiler/crystal/exception.cr
+++ b/src/compiler/crystal/exception.cr
@@ -136,14 +136,14 @@ module Crystal
 
         decorator = line_number_decorator(line_number)
         lstripped_line = line.lstrip
-        space_delta = line.chars.size - lstripped_line.chars.size
+        space_delta = line.size - lstripped_line.size
         # Column number should start at `1`. We're using `0` to track bogus passed
         # `column_number`.
         final_column_number = (column_number - space_delta).clamp(0..)
 
         io << "\n\n"
         io << colorize(decorator).dim << colorize(lstripped_line.chomp).bold
-        append_error_indicator(io, decorator.chars.size, final_column_number, size || 0)
+        append_error_indicator(io, decorator.size, final_column_number, size || 0)
       end
     end
 
@@ -259,7 +259,7 @@ module Crystal
         source_slice, spaces_removed = minimize_indentation(source_slice)
 
         io << Crystal.with_line_numbers(source_slice, line_number, @color, from_index + 1)
-        offset = OFFSET_FROM_LINE_NUMBER_DECORATOR + line_number.to_s.chars.size - spaces_removed
+        offset = OFFSET_FROM_LINE_NUMBER_DECORATOR + line_number.to_s.size - spaces_removed
         append_error_indicator(io, offset, @column_number, @size)
       end
     end

--- a/src/compiler/crystal/util.cr
+++ b/src/compiler/crystal/util.cr
@@ -44,7 +44,7 @@ module Crystal
     line_number_start = 1,
   )
     source = source.lines if source.is_a? String
-    line_number_padding = (source.size + line_number_start).to_s.chars.size
+    line_number_padding = (source.size + line_number_start).to_s.size
     source.map_with_index do |line, i|
       line = line.to_s.chomp
       line_number = "%#{line_number_padding}d" % (i + line_number_start)


### PR DESCRIPTION
These are all equivalent to calling just `#size` directly, and there is no need to create an intermediate `Array`.

For the record, they also do not benefit from using the much newer `#grapheme_size`.