### PR TITLE
Fix `Time::Location::InvalidTZDataError` dropping default message

### DIFF
--- a/src/time/location/loader.cr
+++ b/src/time/location/loader.cr
@@ -6,7 +6,7 @@ class Time::Location
   #
   # Details on the exact cause can be found in the error message.
   class InvalidTZDataError < Time::Error
-    def self.initialize(message : String? = "Malformed time zone information", cause : Exception? = nil)
+    def initialize(message : String? = "Malformed time zone information", cause : Exception? = nil)
       super(message, cause)
     end
   end


### PR DESCRIPTION
Overriding `self.initialize` is almost always a typo.