### PR TITLE
Add missing `File::NotFoundError` exception documentation for `File.open`

### DIFF
--- a/src/file.cr
+++ b/src/file.cr
@@ -523,9 +523,10 @@ class File < IO::FileDescriptor
     end
   end
 
-  # Returns the content of *filename* as a string.
+  # Returns the content of *filename* as a string. Raises `File::NotFoundError` if the file at filename does not exist.
   #
   # ```
+  # File.read("bar") # raises File::NotFoundError
   # File.write("bar", "foo")
   # File.read("bar") # => "foo"
   # ```


### PR DESCRIPTION
I think this is missing from the documentation. The PR is self explanatory (I believe)