### PR TITLE
Do not print adjacent nodes for `Thread::LinkedList` element types

### DIFF
--- a/src/crystal/system/thread.cr
+++ b/src/crystal/system/thread.cr
@@ -154,6 +154,21 @@ class Thread
     Thread.threads.push(self)
   end
 
+  def inspect(io : IO) : Nil
+    to_s(io)
+  end
+
+  def to_s(io : IO) : Nil
+    io << "#<" << self.class.name << ":0x"
+    object_id.to_s(io, 16)
+    io << " @system_handle="
+    @system_handle.inspect io
+    io << ','
+    io << " @name="
+    @name.inspect io
+    io << '>'
+  end
+
   private def detach(&)
     if @detached.test_and_set
       yield

--- a/src/crystal/system/win32/iocp.cr
+++ b/src/crystal/system/win32/iocp.cr
@@ -86,6 +86,21 @@ struct Crystal::System::IOCP
         true
       end
     end
+
+    def inspect(io : IO) : Nil
+      to_s(io)
+    end
+
+    def to_s(io : IO) : Nil
+      io << "#<" << self.class.name << ":0x"
+      object_id.to_s(io, 16)
+      io << " @fiber="
+      @fiber.inspect io
+      io << ','
+      io << " @tag="
+      @tag.inspect io
+      io << '>'
+    end
   end
 
   getter handle : LibC::HANDLE


### PR DESCRIPTION
This is to avoid a single `puts` or `p` on an element printing the entire linked collection of nodes.

`Fiber` and `Fiber::ExecutionContext` are also used as element types of `Thread::LinkedList` and they already have `#to_s` and `#inspect` overridden.