### PR TITLE
Support pretty printing of `XML` types

### DIFF
--- a/src/xml/attributes.cr
+++ b/src/xml/attributes.cr
@@ -69,6 +69,10 @@ class XML::Attributes
     to_s(io)
   end
 
+  def pretty_print(pp : PrettyPrint) : Nil
+    pp.list("[", self, "]")
+  end
+
   protected def props
     @node.to_unsafe.value.properties
   end

--- a/src/xml/namespace.cr
+++ b/src/xml/namespace.cr
@@ -39,4 +39,30 @@ class XML::Namespace
   def inspect(io : IO) : Nil
     to_s io
   end
+
+  def pretty_print(pp : PrettyPrint) : Nil
+    pp.surround("#<XML::Namespace:0x#{object_id.to_s(16)}", ">", left_break: nil, right_break: nil) do
+      if prefix = self.prefix
+        pp.breakable
+        pp.group do
+          pp.text "prefix="
+          pp.nest do
+            pp.breakable ""
+            prefix.pretty_print(pp)
+          end
+        end
+      end
+
+      if href = self.href
+        pp.breakable
+        pp.group do
+          pp.text "href="
+          pp.nest do
+            pp.breakable ""
+            href.pretty_print(pp)
+          end
+        end
+      end
+    end
+  end
 end

--- a/src/xml/node.cr
+++ b/src/xml/node.cr
@@ -165,33 +165,7 @@ class XML::Node
 
   # Returns detailed information for this node including node type, name, attributes and children.
   def inspect(io : IO) : Nil
-    io << "#<XML::"
-    case type
-    when XML::Node::Type::NONE               then io << "None"
-    when XML::Node::Type::ELEMENT_NODE       then io << "Element"
-    when XML::Node::Type::ATTRIBUTE_NODE     then io << "Attribute"
-    when XML::Node::Type::TEXT_NODE          then io << "Text"
-    when XML::Node::Type::CDATA_SECTION_NODE then io << "CData"
-    when XML::Node::Type::ENTITY_REF_NODE    then io << "EntityRef"
-    when XML::Node::Type::ENTITY_NODE        then io << "Entity"
-    when XML::Node::Type::PI_NODE            then io << "ProcessingInstruction"
-    when XML::Node::Type::COMMENT_NODE       then io << "Comment"
-    when XML::Node::Type::DOCUMENT_NODE      then io << "Document"
-    when XML::Node::Type::DOCUMENT_TYPE_NODE then io << "DocumentType"
-    when XML::Node::Type::DOCUMENT_FRAG_NODE then io << "DocumentFragment"
-    when XML::Node::Type::NOTATION_NODE      then io << "Notation"
-    when XML::Node::Type::HTML_DOCUMENT_NODE then io << "HTMLDocument"
-    when XML::Node::Type::DTD_NODE           then io << "DTD"
-    when XML::Node::Type::ELEMENT_DECL       then io << "Element"
-    when XML::Node::Type::ATTRIBUTE_DECL     then io << "AttributeDecl"
-    when XML::Node::Type::ENTITY_DECL        then io << "EntityDecl"
-    when XML::Node::Type::NAMESPACE_DECL     then io << "NamespaceDecl"
-    when XML::Node::Type::XINCLUDE_START     then io << "XIncludeStart"
-    when XML::Node::Type::XINCLUDE_END       then io << "XIncludeEnd"
-    when XML::Node::Type::DOCB_DOCUMENT_NODE then io << "DOCBDocument"
-    end
-
-    io << ":0x"
+    io << "#<XML::" << type_name << ":0x"
     object_id.to_s(io, 16)
 
     if text?
@@ -222,6 +196,88 @@ class XML::Node
     end
 
     io << '>'
+  end
+
+  def pretty_print(pp : PrettyPrint) : Nil
+    pp.surround("#<XML::#{type_name}:0x#{object_id.to_s(16)}", ">", left_break: nil, right_break: nil) do
+      if text?
+        pp.breakable
+        content.pretty_print(pp)
+      else
+        unless document?
+          pp.breakable
+          pp.group do
+            pp.text "name="
+            pp.nest do
+              pp.breakable ""
+              name.pretty_print(pp)
+            end
+          end
+        end
+
+        if attribute?
+          pp.breakable
+          pp.group do
+            pp.text "content="
+            pp.nest do
+              pp.breakable ""
+              content.pretty_print(pp)
+            end
+          end
+        else
+          attributes = self.attributes
+          unless attributes.empty?
+            pp.breakable
+            pp.group do
+              pp.text "attributes="
+              pp.nest do
+                pp.breakable ""
+                attributes.pretty_print(pp)
+              end
+            end
+          end
+
+          children = self.children
+          unless children.empty?
+            pp.breakable
+            pp.group do
+              pp.text "children="
+              pp.nest do
+                pp.breakable ""
+                children.pretty_print(pp)
+              end
+            end
+          end
+        end
+      end
+    end
+  end
+
+  private def type_name
+    case type
+    when XML::Node::Type::NONE               then "None"
+    when XML::Node::Type::ELEMENT_NODE       then "Element"
+    when XML::Node::Type::ATTRIBUTE_NODE     then "Attribute"
+    when XML::Node::Type::TEXT_NODE          then "Text"
+    when XML::Node::Type::CDATA_SECTION_NODE then "CData"
+    when XML::Node::Type::ENTITY_REF_NODE    then "EntityRef"
+    when XML::Node::Type::ENTITY_NODE        then "Entity"
+    when XML::Node::Type::PI_NODE            then "ProcessingInstruction"
+    when XML::Node::Type::COMMENT_NODE       then "Comment"
+    when XML::Node::Type::DOCUMENT_NODE      then "Document"
+    when XML::Node::Type::DOCUMENT_TYPE_NODE then "DocumentType"
+    when XML::Node::Type::DOCUMENT_FRAG_NODE then "DocumentFragment"
+    when XML::Node::Type::NOTATION_NODE      then "Notation"
+    when XML::Node::Type::HTML_DOCUMENT_NODE then "HTMLDocument"
+    when XML::Node::Type::DTD_NODE           then "DTD"
+    when XML::Node::Type::ELEMENT_DECL       then "Element"
+    when XML::Node::Type::ATTRIBUTE_DECL     then "AttributeDecl"
+    when XML::Node::Type::ENTITY_DECL        then "EntityDecl"
+    when XML::Node::Type::NAMESPACE_DECL     then "NamespaceDecl"
+    when XML::Node::Type::XINCLUDE_START     then "XIncludeStart"
+    when XML::Node::Type::XINCLUDE_END       then "XIncludeEnd"
+    when XML::Node::Type::DOCB_DOCUMENT_NODE then "DOCBDocument"
+    end
   end
 
   # Returns the next sibling node or `nil` if not found.

--- a/src/xml/node_set.cr
+++ b/src/xml/node_set.cr
@@ -37,6 +37,10 @@ class XML::NodeSet
     io << ']'
   end
 
+  def pretty_print(pp : PrettyPrint) : Nil
+    pp.list("[", self, "]")
+  end
+
   def size : Int32
     @set.value.node_nr
   end


### PR DESCRIPTION
Overrides `#pretty_print` for `XML::Node`, `XML::NodeSet`, `XML::Attributes`, and `XML::Namespace`, consistent with their `#inspect` overrides.

Example:

```crystal
require "xml"

xml = XML.parse(<<-XML)
  <?xml version="1.0" encoding="UTF-8"?>
  <crystal:foo x="1" y="2" xmlns:crystal="https://crystal-lang.org/">
    <bar/>lorem ipsum<baz/>
  </foo>
  XML

pp xml
# #<XML::Document:0x1b9193c2d80
#  children=
#   [#<XML::Element:0x1b9193cdf00
#     name="foo"
#     attributes=
#      [#<XML::Attribute:0x1b9193b3e00 name="x" content="1">,
#       #<XML::Attribute:0x1b9193b3d90 name="y" content="2">]
#     children=
#      [#<XML::Text:0x1b9193cdd80 "\n" + "  ">,
#       #<XML::Element:0x1b9193cdd00 name="bar">,
#       #<XML::Text:0x1b9193cdc80 "lorem ipsum">,
#       #<XML::Element:0x1b9193cdc00 name="baz">,
#       #<XML::Text:0x1b9193cdb80 "\n">]>]>

pp xml.root.not_nil!.namespace
# #<XML::Namespace:0x1b9193b1b00
#  prefix="crystal"
#  href="https://crystal-lang.org/">
```