### PR TITLE
Add type restrictions to mime

### DIFF
--- a/src/mime.cr
+++ b/src/mime.cr
@@ -148,7 +148,7 @@ module MIME
   #
   # A case-sensitive search is tried first, if this yields no result, it is
   # matched case-insensitive. Returns *default* if *extension* is not registered.
-  def self.from_extension(extension : String, default) : String
+  def self.from_extension(extension : String, default : String) : String
     from_extension(extension) { default }
   end
 
@@ -182,7 +182,7 @@ module MIME
   #
   # A case-sensitive search is tried first, if this yields no result, it is
   # matched case-insensitive. Returns *default* if extension is not registered.
-  def self.from_filename(filename : String | Path, default) : String
+  def self.from_filename(filename : String | Path, default : String) : String
     from_extension(File.extname(filename.to_s), default)
   end
 

--- a/src/mime/media_type.cr
+++ b/src/mime/media_type.cr
@@ -64,7 +64,7 @@ module MIME
     # mime_type["foo"] = "bar"
     # mime_type["foo"] # => "bar"
     # ```
-    def []=(key : String, value : String)
+    def []=(key : String, value : String) : String
       raise Error.new("Invalid parameter name") unless MIME::MediaType.token? key
       @params[key] = value
     end
@@ -488,12 +488,12 @@ module MIME
     end
 
     # :nodoc:
-    def self.token?(string) : Bool
+    def self.token?(string : String) : Bool
       string.each_char.all? { |char| token? char }
     end
 
     # :nodoc:
-    def self.quote_string(string, io) : Nil
+    def self.quote_string(string : String, io : IO) : Nil
       string.each_char do |char|
         case char
         when '"', '\\'

--- a/src/mime/multipart.cr
+++ b/src/mime/multipart.cr
@@ -39,7 +39,7 @@ module MIME::Multipart
   #
   # MIME::Multipart.parse_boundary("multipart/mixed; boundary=\"abcde\"") # => "abcde"
   # ```
-  def self.parse_boundary(content_type) : String?
+  def self.parse_boundary(content_type : String) : String?
     type = MIME::MediaType.parse?(content_type)
 
     if type && type.type == "multipart"

--- a/src/mime/multipart/builder.cr
+++ b/src/mime/multipart/builder.cr
@@ -33,7 +33,7 @@ module MIME::Multipart
     # builder = MIME::Multipart::Builder.new(io, "a4VF")
     # builder.content_type("mixed") # => "multipart/mixed; boundary=a4VF"
     # ```
-    def content_type(subtype = "mixed") : String
+    def content_type(subtype : String = "mixed") : String
       MIME::MediaType.new("multipart/#{subtype}", {"boundary" => @boundary}).to_s
     end
 


### PR DESCRIPTION
This is the output of compiling [cr-source-typer](https://github.com/Vici37/cr-source-typer) and running it with the below incantation:

```
CRYSTAL_PATH="./src" ./typify spec/std_spec.cr
--error-trace --exclude src/crystal/ 
--stats --progress 
--ignore-private-defs 
--ignore-protected-defs  
src/mime
```
This is related to https://github.com/crystal-lang/crystal/pull/15682 .