### PR TITLE
Add `YAML::Builder#start_document(*, implicit_start_indicator)`

### DIFF
--- a/src/yaml/builder.cr
+++ b/src/yaml/builder.cr
@@ -73,8 +73,11 @@ class YAML::Builder
   end
 
   # Starts a document.
-  def start_document
-    emit document_start, nil, nil, nil, 0
+  #
+  # If *implict_start_indicator* is true, skips printing the document start
+  # indicator (`---`) if this is the first document in the stream.
+  def start_document(*, implicit_start_indicator : Bool = false)
+    emit document_start, nil, nil, nil, implicit_start_indicator.to_unsafe
   end
 
   # Ends a document.
@@ -83,8 +86,11 @@ class YAML::Builder
   end
 
   # Starts a document, invokes the block, and then ends it.
-  def document(&)
-    start_document
+  #
+  # If *implict_start_indicator* is true, skips printing the document start
+  # indicator (`---`) if this is the first document in the stream.
+  def document(*, implicit_start_indicator : Bool = false, &)
+    start_document(implicit_start_indicator: implicit_start_indicator)
     yield.tap { end_document }
   end
 


### PR DESCRIPTION
Exposes the `implicit` parameter of libyaml's `yaml_document_start_event_initialize` function in `#start_document` and `#document`.