### PR TITLE
Add type restrictions to json

### DIFF
--- a/src/json/any.cr
+++ b/src/json/any.cr
@@ -21,7 +21,7 @@ struct JSON::Any
   alias Type = Nil | Bool | Int64 | Float64 | String | Array(JSON::Any) | Hash(String, JSON::Any)
 
   # Reads a `JSON::Any` value from the given pull parser.
-  def self.new(pull : JSON::PullParser)
+  def self.new(pull : JSON::PullParser) : self
     case pull.kind
     when .null?
       new pull.read_null
@@ -58,13 +58,13 @@ struct JSON::Any
   end
 
   # :ditto:
-  def self.new(raw : Int)
+  def self.new(raw : Int) : self
     # FIXME: Workaround for https://github.com/crystal-lang/crystal/issues/11645
     new(raw.to_i64)
   end
 
   # :ditto:
-  def self.new(raw : Float)
+  def self.new(raw : Float) : self
     # FIXME: Workaround for https://github.com/crystal-lang/crystal/issues/11645
     new(raw.to_f64)
   end
@@ -130,7 +130,7 @@ struct JSON::Any
 
   # Traverses the depth of a structure and returns the value.
   # Returns `nil` if not found.
-  def dig?(index_or_key : String | Int, *subkeys) : JSON::Any?
+  def dig?(index_or_key : String | Int, *subkeys : Int | String) : JSON::Any?
     self[index_or_key]?.try &.dig?(*subkeys)
   end
 
@@ -145,7 +145,7 @@ struct JSON::Any
   end
 
   # Traverses the depth of a structure and returns the value, otherwise raises.
-  def dig(index_or_key : String | Int, *subkeys) : JSON::Any
+  def dig(index_or_key : String | Int, *subkeys : Int | String) : JSON::Any
     self[index_or_key].dig(*subkeys)
   end
 
@@ -305,7 +305,7 @@ struct JSON::Any
   def_hash raw
 
   # :nodoc:
-  def to_json(json : JSON::Builder)
+  def to_json(json : JSON::Builder) : Nil
     raw.to_json(json)
   end
 
@@ -319,7 +319,7 @@ struct JSON::Any
   end
 
   # Returns a new JSON::Any instance with the `raw` value `clone`ed.
-  def clone
+  def clone : JSON::Any
     JSON::Any.new(raw.clone)
   end
 end

--- a/src/json/any.cr
+++ b/src/json/any.cr
@@ -130,12 +130,12 @@ struct JSON::Any
 
   # Traverses the depth of a structure and returns the value.
   # Returns `nil` if not found.
-  def dig?(index_or_key : String | Int, *subkeys : Int | String) : JSON::Any?
+  def dig?(index_or_key : Int | String, *subkeys : Int | String) : JSON::Any?
     self[index_or_key]?.try &.dig?(*subkeys)
   end
 
   # :nodoc:
-  def dig?(index_or_key : String | Int) : JSON::Any?
+  def dig?(index_or_key : Int | String) : JSON::Any?
     case @raw
     when Hash, Array
       self[index_or_key]?
@@ -145,12 +145,12 @@ struct JSON::Any
   end
 
   # Traverses the depth of a structure and returns the value, otherwise raises.
-  def dig(index_or_key : String | Int, *subkeys : Int | String) : JSON::Any
+  def dig(index_or_key : Int | String, *subkeys : Int | String) : JSON::Any
     self[index_or_key].dig(*subkeys)
   end
 
   # :nodoc:
-  def dig(index_or_key : String | Int) : JSON::Any
+  def dig(index_or_key : Int | String) : JSON::Any
     self[index_or_key]
   end
 

--- a/src/json/builder.cr
+++ b/src/json/builder.cr
@@ -277,7 +277,7 @@ class JSON::Builder
   # Writes an object's field and value.
   # The field's name is first converted to a `String` by invoking
   # `to_s` on it.
-  def field(name, value)
+  def field(name : String | Int32, value) : Nil
     string(name)
     value.to_json(self)
   end
@@ -296,7 +296,7 @@ class JSON::Builder
   end
 
   # Sets the indent *string*.
-  def indent=(string : String)
+  def indent=(string : String) : String?
     if string.empty?
       @indent = nil
     else
@@ -305,7 +305,7 @@ class JSON::Builder
   end
 
   # Sets the indent *level* (number of spaces).
-  def indent=(level : Int)
+  def indent=(level : Int) : String?
     if level < 0
       @indent = nil
     else

--- a/src/json/builder.cr
+++ b/src/json/builder.cr
@@ -277,7 +277,7 @@ class JSON::Builder
   # Writes an object's field and value.
   # The field's name is first converted to a `String` by invoking
   # `to_s` on it.
-  def field(name : String | Int32, value : _) : Nil
+  def field(name : _, value : _) : Nil
     string(name)
     value.to_json(self)
   end
@@ -291,7 +291,7 @@ class JSON::Builder
   end
 
   # Flushes the underlying `IO`.
-  def flush : IO?
+  def flush : Nil
     @io.flush
   end
 

--- a/src/json/builder.cr
+++ b/src/json/builder.cr
@@ -110,7 +110,7 @@ class JSON::Builder
   # ```
   #
   # This method can also be used to write the name of an object field.
-  def string(value) : Nil
+  def string(value : _) : Nil
     string do |io|
       value.to_s(io)
     end
@@ -277,7 +277,7 @@ class JSON::Builder
   # Writes an object's field and value.
   # The field's name is first converted to a `String` by invoking
   # `to_s` on it.
-  def field(name : String | Int32, value) : Nil
+  def field(name : String | Int32, value : _) : Nil
     string(name)
     value.to_json(self)
   end
@@ -291,7 +291,7 @@ class JSON::Builder
   end
 
   # Flushes the underlying `IO`.
-  def flush
+  def flush : IO?
     @io.flush
   end
 

--- a/src/json/from_json.cr
+++ b/src/json/from_json.cr
@@ -116,11 +116,11 @@ module Iterator(T)
   end
 end
 
-def Nil.new(pull : JSON::PullParser) : Nil
+def Nil.new(pull : JSON::PullParser) : self
   pull.read_null
 end
 
-def Bool.new(pull : JSON::PullParser) : Bool
+def Bool.new(pull : JSON::PullParser) : self
   pull.read_bool
 end
 
@@ -172,7 +172,7 @@ def Float32.from_json_object_key?(key : String) : Float32?
   key.to_f32?
 end
 
-def Float64.new(pull : JSON::PullParser) : Float64
+def Float64.new(pull : JSON::PullParser) : self
   case pull.kind
   when .int?
     value = pull.int_value.to_f
@@ -187,11 +187,11 @@ def Float64.from_json_object_key?(key : String) : Float64?
   key.to_f64?
 end
 
-def String.new(pull : JSON::PullParser) : String
+def String.new(pull : JSON::PullParser) : self
   pull.read_string
 end
 
-def Path.new(pull : JSON::PullParser) : Path
+def Path.new(pull : JSON::PullParser) : self
   new(pull.read_string)
 end
 
@@ -470,7 +470,7 @@ end
 # time value.
 #
 # See `#to_json` for reference.
-def Time.new(pull : JSON::PullParser) : Time
+def Time.new(pull : JSON::PullParser) : self
   Time::Format::ISO_8601_DATE_TIME.parse(pull.read_string)
 end
 

--- a/src/json/from_json.cr
+++ b/src/json/from_json.cr
@@ -157,7 +157,7 @@ end
   end
 {% end %}
 
-def Float32.new(pull : JSON::PullParser) : Float32
+def Float32.new(pull : JSON::PullParser) : self
   case pull.kind
   when .int?
     value = pull.int_value.to_f32

--- a/src/json/from_json.cr
+++ b/src/json/from_json.cr
@@ -8,7 +8,7 @@
 # Int32.from_json("1")                # => 1
 # Array(Int32).from_json("[1, 2, 3]") # => [1, 2, 3]
 # ```
-def Object.from_json(string_or_io)
+def Object.from_json(string_or_io : String | IO) : Object
   parser = JSON::PullParser.new(string_or_io)
   new parser
 end
@@ -21,7 +21,7 @@ end
 # ```
 # Int32.from_json(%({"main": 1}), root: "main") # => 1
 # ```
-def Object.from_json(string_or_io, root : String)
+def Object.from_json(string_or_io : String | IO, root : String) : Object
   parser = JSON::PullParser.new(string_or_io)
   parser.on_key!(root) do
     new parser
@@ -116,11 +116,11 @@ module Iterator(T)
   end
 end
 
-def Nil.new(pull : JSON::PullParser)
+def Nil.new(pull : JSON::PullParser) : Nil
   pull.read_null
 end
 
-def Bool.new(pull : JSON::PullParser)
+def Bool.new(pull : JSON::PullParser) : Bool
   pull.read_bool
 end
 
@@ -157,7 +157,7 @@ end
   end
 {% end %}
 
-def Float32.new(pull : JSON::PullParser)
+def Float32.new(pull : JSON::PullParser) : Float32
   case pull.kind
   when .int?
     value = pull.int_value.to_f32
@@ -172,7 +172,7 @@ def Float32.from_json_object_key?(key : String) : Float32?
   key.to_f32?
 end
 
-def Float64.new(pull : JSON::PullParser)
+def Float64.new(pull : JSON::PullParser) : Float64
   case pull.kind
   when .int?
     value = pull.int_value.to_f
@@ -187,11 +187,11 @@ def Float64.from_json_object_key?(key : String) : Float64?
   key.to_f64?
 end
 
-def String.new(pull : JSON::PullParser)
+def String.new(pull : JSON::PullParser) : String
   pull.read_string
 end
 
-def Path.new(pull : JSON::PullParser)
+def Path.new(pull : JSON::PullParser) : Path
   new(pull.read_string)
 end
 
@@ -315,7 +315,7 @@ end
 # See `#to_json` for reference.
 #
 # Raises `JSON::ParseException` if the deserialization fails.
-def Enum.new(pull : JSON::PullParser)
+def Enum.new(pull : JSON::PullParser) : self
   {% if @type.annotation(Flags) %}
     value = {{ @type }}::None
     pull.read_array do
@@ -470,7 +470,7 @@ end
 # time value.
 #
 # See `#to_json` for reference.
-def Time.new(pull : JSON::PullParser)
+def Time.new(pull : JSON::PullParser) : Time
   Time::Format::ISO_8601_DATE_TIME.parse(pull.read_string)
 end
 

--- a/src/json/lexer.cr
+++ b/src/json/lexer.cr
@@ -1,11 +1,11 @@
 require "string_pool"
 
 abstract class JSON::Lexer
-  def self.new(string : String)
+  def self.new(string : String) : self
     StringBased.new(string)
   end
 
-  def self.new(io : IO)
+  def self.new(io : IO) : self
     IOBased.new(io)
   end
 

--- a/src/json/lexer/string_based.cr
+++ b/src/json/lexer/string_based.cr
@@ -50,11 +50,11 @@ class JSON::Lexer::StringBased < JSON::Lexer
     @reader.pos
   end
 
-  def string_range(start_pos, end_pos) : String
+  def string_range(start_pos : Int, end_pos : Int) : String
     @reader.string.byte_slice(start_pos, end_pos - start_pos)
   end
 
-  def slice_range(start_pos, end_pos) : Bytes
+  def slice_range(start_pos : Int, end_pos : Int) : Bytes
     @reader.string.to_slice[start_pos, end_pos - start_pos]
   end
 

--- a/src/json/pull_parser.cr
+++ b/src/json/pull_parser.cr
@@ -137,13 +137,13 @@ class JSON::PullParser
   end
 
   # Reads the beginning of an array.
-  def read_begin_array
+  def read_begin_array : JSON::PullParser::Kind
     expect_kind :begin_array
     read_next
   end
 
   # Reads the end of an array.
-  def read_end_array
+  def read_end_array : JSON::PullParser::Kind
     expect_kind :end_array
     read_next
   end
@@ -163,13 +163,13 @@ class JSON::PullParser
   end
 
   # Reads the beginning of an object.
-  def read_begin_object
+  def read_begin_object : JSON::PullParser::Kind
     expect_kind :begin_object
     read_next
   end
 
   # Reads the end of an object.
-  def read_end_object
+  def read_end_object : JSON::PullParser::Kind
     expect_kind :end_object
     read_next
   end
@@ -268,7 +268,7 @@ class JSON::PullParser
   # Reads the new value and fill the a JSON builder with it.
   #
   # Use this method with a `JSON::Builder` to read a JSON while building another one.
-  def read_raw(json) : Nil
+  def read_raw(json : JSON::Builder) : Nil
     case @kind
     when .null?
       read_next

--- a/src/json/to_json.cr
+++ b/src/json/to_json.cr
@@ -215,7 +215,7 @@ struct Enum
   #
   # `ValueConverter.to_json` offers a different serialization strategy based on the
   # member value.
-  def to_json(json : JSON::Builder)
+  def to_json(json : JSON::Builder) : Nil
     {% if @type.annotation(Flags) %}
       json.array do
         each do |member, _value|


### PR DESCRIPTION
This is the output of compiling [cr-source-typer](https://github.com/Vici37/cr-source-typer) and running it with the below incantation:

```
CRYSTAL_PATH="./src" CRYSTAL_HAS_WRAPPER=1 ./typify spec/std_spec.cr
--error-trace --exclude src/crystal/ 
--stats --progress 
--union-size-threshold 2
--ignore-private-defs 
--ignore-protected-defs  
src/json
```

This is related to https://github.com/crystal-lang/crystal/pull/15682 .