### PR TITLE
Fix duplicate keys in hash literals

### DIFF
--- a/spec/std/base64_spec.cr
+++ b/spec/std/base64_spec.cr
@@ -32,7 +32,7 @@ describe "Base64" do
 
   context "\n in multiple places" do
     eqs = {"abcd" => "YWJj\nZA==\n", "abcde" => "YWJj\nZGU=\n", "abcdef" => "YWJj\nZGVm\n",
-           "abcdefg" => "YWJj\nZGVmZw==\n", "abcdefg" => "YWJj\nZGVm\nZw==\n",
+           "abcdefg" => "YWJj\nZGVmZw==\n",
     }
     eqs.each do |a, b|
       it "decode from #{b.inspect} to #{a.inspect}" do

--- a/spec/std/hash_spec.cr
+++ b/spec/std/hash_spec.cr
@@ -428,7 +428,7 @@ describe "Hash" do
     end
 
     it "works with mixed types" do
-      {1 => "a", "a" => 1, 2.0 => "a", "b" => 1.0}.values_at(1, "a", 2.0, "a").should eq({"a", 1, "a", 1.0})
+      {1 => "a", "a" => 1, 2.0 => "a", "b" => 1.0}.values_at(1, "a", 2.0, "b").should eq({"a", 1, "a", 1.0})
     end
   end
 

--- a/spec/std/hash_spec.cr
+++ b/spec/std/hash_spec.cr
@@ -428,7 +428,7 @@ describe "Hash" do
     end
 
     it "works with mixed types" do
-      {1 => "a", "a" => 1, 2.0 => "a", "a" => 1.0}.values_at(1, "a", 2.0, "a").should eq({"a", 1, "a", 1.0})
+      {1 => "a", "a" => 1, 2.0 => "a", "b" => 1.0}.values_at(1, "a", 2.0, "a").should eq({"a", 1, "a", 1.0})
     end
   end
 


### PR DESCRIPTION
This was discovered with ameba's `Lint/HashDuplicatedKey` rule.