### PR TITLE
Remove unused code

### DIFF
--- a/spec/std/http/client/client_spec.cr
+++ b/spec/std/http/client/client_spec.cr
@@ -483,7 +483,6 @@ module HTTP
   class SubClient < HTTP::Client
     def around_exec(request, &)
       raise "from subclass"
-      yield
     end
   end
 end

--- a/src/compiler/crystal/interpreter/compiler.cr
+++ b/src/compiler/crystal/interpreter/compiler.cr
@@ -269,8 +269,6 @@ class Crystal::Repl::Compiler < Crystal::Visitor
     leave aligned_sizeof_type(final_type), node: Nop.new.at(node.end_location)
 
     compiled_def.closure_context = @closure_context
-
-    @instructions
   end
 
   private def move_arg_to_closure_if_closured(node : Def, arg_name : String)


### PR DESCRIPTION
This was discovered with ameba's `Lint/UnreachableCode` and `Lint/UnusedInstanceVariableAccess` rules.