### PR TITLE
Remove shadowed method arguments

### DIFF
--- a/samples/red_black_tree.cr
+++ b/samples/red_black_tree.cr
@@ -167,7 +167,7 @@ class RedBlackTree
     y
   end
 
-  def inorder_walk(x = root, &)
+  def inorder_walk(&)
     x = self.minimum
     while !x.nil_node?
       yield x.key
@@ -179,7 +179,7 @@ class RedBlackTree
     inorder_walk(x) { |k| yield k }
   end
 
-  def reverse_inorder_walk(x = root, &)
+  def reverse_inorder_walk(&)
     x = self.maximum
     while !x.nil_node?
       yield x.key

--- a/src/compiler/crystal/semantic/call.cr
+++ b/src/compiler/crystal/semantic/call.cr
@@ -492,7 +492,7 @@ class Crystal::Call
   end
 
   def tuple_indexer_helper(args, arg_types, owner, instance_type, nilable, &)
-    index = tuple_indexer_helper_index(args.first, owner, instance_type, nilable)
+    index = tuple_indexer_helper_index(owner, instance_type, nilable)
     return unless index
 
     indexer_def = yield instance_type, index
@@ -500,7 +500,7 @@ class Crystal::Call
     Matches.new([indexer_match] of Match, true)
   end
 
-  private def tuple_indexer_helper_index(arg, owner, instance_type, nilable)
+  private def tuple_indexer_helper_index(owner, instance_type, nilable)
     arg = args.first
 
     # Make it work with constants too


### PR DESCRIPTION
This was discovered with ameba's `Lint/ShadowedArgument` rule.