### PR TITLE
Suspend Windows processes until job objects are set up

### DIFF
--- a/src/crystal/system/win32/process.cr
+++ b/src/crystal/system/win32/process.cr
@@ -54,6 +54,12 @@ struct Crystal::System::Process
     if LibC.AssignProcessToJobObject(@job_object, @process_handle) == 0
       raise RuntimeError.from_winerror("AssignProcessToJobObject")
     end
+
+    if LibC.ResumeThread(process_info.hThread) == 0xFFFFFFFF_u32
+      raise RuntimeError.from_winerror("ResumeThread")
+    end
+
+    close_handle(process_info.hThread)
   end
 
   private def config_job_object(kind, info)
@@ -285,7 +291,7 @@ struct Crystal::System::Process
     command_args = ::Process.quote_windows(command_args) unless command_args.is_a?(String)
 
     if LibC.CreateProcessW(
-         nil, System.to_wstr(command_args), nil, nil, true, LibC::CREATE_UNICODE_ENVIRONMENT,
+         nil, System.to_wstr(command_args), nil, nil, true, LibC::CREATE_SUSPENDED | LibC::CREATE_UNICODE_ENVIRONMENT,
          make_env_block(env, clear_env), chdir.try { |str| System.to_wstr(str) } || Pointer(UInt16).null,
          pointerof(startup_info), pointerof(process_info)
        ) == 0
@@ -297,8 +303,6 @@ struct Crystal::System::Process
         raise IO::Error.from_os_error("Error executing process: '#{command_args}'", error)
       end
     end
-
-    close_handle(process_info.hThread)
 
     close_handle(startup_info.hStdInput)
     close_handle(startup_info.hStdOutput)

--- a/src/lib_c/x86_64-windows-msvc/c/processthreadsapi.cr
+++ b/src/lib_c/x86_64-windows-msvc/c/processthreadsapi.cr
@@ -3,6 +3,7 @@ require "c/wtypesbase"
 require "c/sdkddkver"
 
 lib LibC
+  CREATE_SUSPENDED           = 0x00000004
   CREATE_UNICODE_ENVIRONMENT = 0x00000400
 
   struct PROCESS_INFORMATION


### PR DESCRIPTION
Under rare conditions, a newly created Windows process might have terminated so fast that `LibC.AssignProcessToJobObject` fails with `ERROR_ACCESS_DENIED`, because it requires an alive process (e.g. https://github.com/crystal-lang/crystal/actions/runs/15293884475/job/43022118390). This PR prevents that by creating the process in a suspended state and resuming it after the `LibC.AssignProcessToJobObject` call.

In this case, `LibC.GetExitCodeProcess` inside `#wait` must return a valid exit code that isn't `LibC::STILL_ACTIVE`.