### PR TITLE
Skip `src/termios.cr` on Windows

### DIFF
--- a/src/termios.cr
+++ b/src/termios.cr
@@ -1,3 +1,5 @@
+{% skip_file if flag?(:win32) %}
+
 require "c/termios"
 
 @[Deprecated]


### PR DESCRIPTION
Fixes a regression in #15621 where `make docs` would fail because `src/docs_main.cr` now requires this file via a glob (https://github.com/crystal-lang/crystal/actions/runs/15298374520/job/43037496217). The file is now a no-op on Windows.