### PR TITLE
Ensure unary `Float32#-` and `Float64#-` flip sign bit

### DIFF
--- a/spec/std/float_spec.cr
+++ b/spec/std/float_spec.cr
@@ -372,6 +372,15 @@ describe "Float" do
     f = -(1.5_f32)
     f.should eq(-1.5_f32)
     f.should be_a(Float32)
+
+    (-(0.0)).sign_bit.should eq(-1)
+    (-(-0.0)).sign_bit.should eq(1)
+
+    (-(0.0_f32)).sign_bit.should eq(-1)
+    (-(-0.0_f32)).sign_bit.should eq(1)
+
+    (-Math.copysign(Float64::NAN, 1.0)).sign_bit.should eq(-1)
+    (-Math.copysign(Float64::NAN, -1.0)).sign_bit.should eq(1)
   end
 
   it "clones" do

--- a/src/float.cr
+++ b/src/float.cr
@@ -39,7 +39,9 @@ require "./float/printer"
 struct Float
   alias Primitive = Float32 | Float64
 
+  # Negates this value's sign.
   def -
+    # fallback implementation; does not handle IEEE 754 signed zeros correctly
     self.class.zero - self
   end
 
@@ -212,6 +214,17 @@ struct Float32
     when Float32::INFINITY
       1
     end
+  end
+
+  # Negates this value's sign.
+  #
+  # Works on signed zeros and not-a-number values as well. The negation of
+  # `0.0_f32` is `-0.0_f32`, and vice versa. The negation of a not-a-number
+  # value is only observable via `#sign_bit`.
+  def - : Float32
+    # equivalent to `Math.copysign(self, -sign_bit.to_f32)`
+    # TODO: consider using the LLVM `fneg` instruction
+    (unsafe_as(UInt32) ^ 0x80000000_u32).unsafe_as(Float32)
   end
 
   def abs
@@ -422,6 +435,17 @@ struct Float64
     when Float64::INFINITY
       1
     end
+  end
+
+  # Negates this value's sign.
+  #
+  # Works on signed zeros and not-a-number values as well. The negation of
+  # `0.0` is `-0.0`, and vice versa. The negation of a not-a-number value is
+  # only observable via `#sign_bit`.
+  def - : Float64
+    # equivalent to `Math.copysign(self, -sign_bit.to_f64)`
+    # TODO: consider using the LLVM `fneg` instruction
+    (unsafe_as(UInt64) ^ 0x80000000_00000000_u64).unsafe_as(Float64)
   end
 
   def abs


### PR DESCRIPTION
`-0.0` is a number literal representing the negative signed zero, whereas `-(0.0)` is the call `#-()` on the literal `0.0`. The latter is implemented as `0.0 - self` and returns positive zero, but this is incorrect. This PR fixes the discrepancy.