### PR TITLE
Remove useless condition literal

### DIFF
--- a/src/compiler/crystal/progress_tracker.cr
+++ b/src/compiler/crystal/progress_tracker.cr
@@ -44,7 +44,7 @@ module Crystal
       justified_name = "#{current_stage_name}:".ljust(STAGE_PADDING)
       if time_taken
         memory_usage_mb = GC.stats.heap_size / 1024.0 / 1024.0
-        memory_usage_str = " (%7.2fMB)" % {memory_usage_mb} if true # display_memory?
+        memory_usage_str = " (%7.2fMB)" % {memory_usage_mb}
         puts "#{justified_name} #{time_taken}#{memory_usage_str}"
       else
         print "#{justified_name}\r" unless @progress


### PR DESCRIPTION
This was discovered by ameba's `Lint/LiteralInCondition` rule.