### PR TITLE
Replace `is_a?` calls with convenient alternatives

### DIFF
--- a/src/comparable.cr
+++ b/src/comparable.cr
@@ -40,10 +40,10 @@ module Comparable(T)
   def ==(other : T)
     if self.is_a?(Reference)
       # Need to do two different comparisons because the compiler doesn't yet
-      # restrict something like `other.is_a?(Reference) || other.is_a?(Nil)`.
+      # restrict something like `other.is_a?(Reference) || other.nil?`.
       # See #2461
       return true if other.is_a?(Reference) && self.same?(other)
-      return true if other.is_a?(Nil) && self.same?(other)
+      return true if other.nil? && self.same?(other)
     end
 
     cmp = self <=> other

--- a/src/compiler/crystal/interpreter/compiler.cr
+++ b/src/compiler/crystal/interpreter/compiler.cr
@@ -1099,7 +1099,8 @@ class Crystal::Repl::Compiler < Crystal::Visitor
   end
 
   private def dispatch_class_var(owner : Type, metaclass : Bool, node : ASTNode, &)
-    types = owner.all_subclasses.select(ClassVarContainer)
+    types = [] of Crystal::Type
+    owner.all_subclasses.each {|t| types << t if t.is_a?(ClassVarContainer) }
     types.push(owner)
     types.sort_by! { |type| -type.depth }
 

--- a/src/compiler/crystal/interpreter/compiler.cr
+++ b/src/compiler/crystal/interpreter/compiler.cr
@@ -1099,7 +1099,7 @@ class Crystal::Repl::Compiler < Crystal::Visitor
   end
 
   private def dispatch_class_var(owner : Type, metaclass : Bool, node : ASTNode, &)
-    types = owner.all_subclasses.select { |t| t.is_a?(ClassVarContainer) }
+    types = owner.all_subclasses.select(ClassVarContainer)
     types.push(owner)
     types.sort_by! { |type| -type.depth }
 

--- a/src/compiler/crystal/interpreter/compiler.cr
+++ b/src/compiler/crystal/interpreter/compiler.cr
@@ -1100,7 +1100,7 @@ class Crystal::Repl::Compiler < Crystal::Visitor
 
   private def dispatch_class_var(owner : Type, metaclass : Bool, node : ASTNode, &)
     types = [] of Crystal::Type
-    owner.all_subclasses.each {|t| types << t if t.is_a?(ClassVarContainer) }
+    owner.all_subclasses.each { |t| types << t if t.is_a?(ClassVarContainer) }
     types.push(owner)
     types.sort_by! { |type| -type.depth }
 


### PR DESCRIPTION
These were discovered with ameba's `Style/IsAFilter` and `Style/IsANil` rules.