### PR TITLE
Use full path to Inno Setup on MSVC CI [fixup #15851]

### DIFF
--- a/.github/workflows/win.yml
+++ b/.github/workflows/win.yml
@@ -328,7 +328,7 @@ jobs:
       - name: Build installer
         working-directory: ./etc/win-ci
         run: |
-          iscc.exe crystal.iss
+          & "C:\Program Files (x86)\Inno Setup 6\ISCC.exe" crystal.iss
 
       - name: Upload Crystal installer
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
Follow-up to #15851.

The Inno Setup compiler is not available in `%PATH%` (the one we currently see is manually exposed by Chocolatey).