### PR TITLE
Use `be_nil` and `be_true`/`be_false` everywhere in specs

### DIFF
--- a/spec/compiler/codegen/const_spec.cr
+++ b/spec/compiler/codegen/const_spec.cr
@@ -566,6 +566,6 @@ describe "Codegen: const" do
 
       CONST = foo
       CONST.nil?
-      )).to_b.should eq(true)
+      )).to_b.should be_true
   end
 end

--- a/spec/compiler/codegen/macro_spec.cr
+++ b/spec/compiler/codegen/macro_spec.cr
@@ -596,7 +596,7 @@ describe "Code gen: macro" do
         end
       end
       Foo(1).new.foo
-    )).to_b.should eq(true)
+    )).to_b.should be_true
   end
 
   it "can access type variables of a tuple" do
@@ -1867,7 +1867,7 @@ describe "Code gen: macro" do
       end
 
       Foo.new.bar
-      )).to_b.should eq(true)
+      )).to_b.should be_true
   end
 
   it "does block unpacking inside macro expression (#13707)" do

--- a/spec/compiler/codegen/regex_literal_spec.cr
+++ b/spec/compiler/codegen/regex_literal_spec.cr
@@ -12,6 +12,6 @@ describe "Code gen: regex literal spec" do
         end
       end
       Foo.check_regex
-      )).to_b.should eq(true)
+      )).to_b.should be_true
   end
 end

--- a/spec/compiler/crystal/tools/doc/type_spec.cr
+++ b/spec/compiler/crystal/tools/doc/type_spec.cr
@@ -140,7 +140,7 @@ describe Doc::Type do
     generator = Doc::Generator.new program, [""]
     macros_module = program.types["Crystal"].types["Macros"]
     astnode = generator.type(macros_module.types["ASTNode"])
-    astnode.superclass.should eq(nil)
+    astnode.superclass.should be_nil
     # Sanity check: subclasses of ASTNode has the right superclass
     generator.type(macros_module.types["Arg"]).superclass.should eq(astnode)
   end

--- a/spec/compiler/crystal/tools/repl_spec.cr
+++ b/spec/compiler/crystal/tools/repl_spec.cr
@@ -14,7 +14,7 @@ describe Crystal::Repl do
     repl.load_prelude
 
     success_value(repl.parse_and_interpret("1 + 2")).value.should eq(3)
-    success_value(repl.parse_and_interpret("def foo; 1 + 2; end")).value.should eq(nil)
+    success_value(repl.parse_and_interpret("def foo; 1 + 2; end")).value.should be_nil
     success_value(repl.parse_and_interpret("foo")).value.should eq(3)
   end
 

--- a/spec/compiler/interpreter/bugs_spec.cr
+++ b/spec/compiler/interpreter/bugs_spec.cr
@@ -136,7 +136,7 @@ describe Crystal::Repl::Interpreter do
     end
 
     it "does multidispatch on virtual struct" do
-      interpret(<<-CRYSTAL).should eq(true)
+      interpret(<<-CRYSTAL).should be_true
         abstract struct Base
         end
 
@@ -187,7 +187,7 @@ describe Crystal::Repl::Interpreter do
     end
 
     it "does multidispatch on virtual struct union nil" do
-      interpret(<<-CRYSTAL).should eq(true)
+      interpret(<<-CRYSTAL).should be_true
         abstract struct Foo
           @value = 1
         end

--- a/spec/compiler/interpreter/casts_spec.cr
+++ b/spec/compiler/interpreter/casts_spec.cr
@@ -25,7 +25,7 @@ describe Crystal::Repl::Interpreter do
     end
 
     it "casts from mixed union type to another mixed union type for caller" do
-      interpret(<<-CRYSTAL).should eq(true)
+      interpret(<<-CRYSTAL).should be_true
         a = 1 == 1 ? 1 : (1 == 1 ? 20_i16 : nil)
         if a
           a < 2
@@ -49,7 +49,7 @@ describe Crystal::Repl::Interpreter do
     end
 
     it "casts from nilable type to mixed union type (2)" do
-      interpret(<<-CRYSTAL).should eq(true)
+      interpret(<<-CRYSTAL).should be_true
         y = 1 == 1 ? "a" : nil
         x = true
         x = y

--- a/spec/compiler/interpreter/constants_spec.cr
+++ b/spec/compiler/interpreter/constants_spec.cr
@@ -4,7 +4,7 @@ require "./spec_helper"
 describe Crystal::Repl::Interpreter do
   context "constants" do
     it "returns nil in the assignment" do
-      interpret(<<-CRYSTAL).should eq(nil)
+      interpret(<<-CRYSTAL).should be_nil
         A = 123
       CRYSTAL
     end

--- a/spec/compiler/interpreter/control_flow_spec.cr
+++ b/spec/compiler/interpreter/control_flow_spec.cr
@@ -70,7 +70,7 @@ describe Crystal::Repl::Interpreter do
     end
 
     it "interprets while, returns nil" do
-      interpret(<<-CRYSTAL).should eq(nil)
+      interpret(<<-CRYSTAL).should be_nil
         a = 0
         while a < 10
           a = a + 1

--- a/spec/compiler/interpreter/primitives_spec.cr
+++ b/spec/compiler/interpreter/primitives_spec.cr
@@ -95,7 +95,7 @@ describe Crystal::Repl::Interpreter do
     end
 
     it "uses a string pool" do
-      interpret(<<-CRYSTAL).should eq(true)
+      interpret(<<-CRYSTAL).should be_true
         "a".object_id == "a".object_id
       CRYSTAL
     end
@@ -153,7 +153,7 @@ describe Crystal::Repl::Interpreter do
     end
 
     it "doesn't declare variable with no type" do
-      interpret(<<-CRYSTAL).should eq(nil)
+      interpret(<<-CRYSTAL).should be_nil
       x = nil
       if x
         y = x
@@ -162,7 +162,7 @@ describe Crystal::Repl::Interpreter do
     end
 
     it "doesn't declare variable with no type inside method" do
-      interpret(<<-CRYSTAL).should eq(nil)
+      interpret(<<-CRYSTAL).should be_nil
         def foo(x)
           if x
             y = x
@@ -702,7 +702,7 @@ describe Crystal::Repl::Interpreter do
 
   context "logical operations" do
     it "interprets not for nil" do
-      interpret("!nil").should eq(true)
+      interpret("!nil").should be_true
     end
 
     it "interprets not for nil type" do
@@ -710,11 +710,11 @@ describe Crystal::Repl::Interpreter do
     end
 
     it "interprets not for bool true" do
-      interpret("!true").should eq(false)
+      interpret("!true").should be_false
     end
 
     it "interprets not for bool false" do
-      interpret("!false").should eq(true)
+      interpret("!false").should be_true
     end
 
     it "discards nil not" do
@@ -726,35 +726,35 @@ describe Crystal::Repl::Interpreter do
     end
 
     it "interprets not for bool false" do
-      interpret("!false").should eq(true)
+      interpret("!false").should be_true
     end
 
     it "interprets not for mixed union (nil)" do
-      interpret("!(1 == 1 ? nil : 2)").should eq(true)
+      interpret("!(1 == 1 ? nil : 2)").should be_true
     end
 
     it "interprets not for mixed union (false)" do
-      interpret("!(1 == 1 ? false : 2)").should eq(true)
+      interpret("!(1 == 1 ? false : 2)").should be_true
     end
 
     it "interprets not for mixed union (true)" do
-      interpret("!(1 == 1 ? true : 2)").should eq(false)
+      interpret("!(1 == 1 ? true : 2)").should be_false
     end
 
     it "interprets not for mixed union (other)" do
-      interpret("!(1 == 1 ? 2 : true)").should eq(false)
+      interpret("!(1 == 1 ? 2 : true)").should be_false
     end
 
     it "interprets not for nilable type (false)" do
-      interpret(%(!(1 == 1 ? "hello" : nil))).should eq(false)
+      interpret(%(!(1 == 1 ? "hello" : nil))).should be_false
     end
 
     it "interprets not for nilable type (true)" do
-      interpret(%(!(1 == 1 ? nil : "hello"))).should eq(true)
+      interpret(%(!(1 == 1 ? nil : "hello"))).should be_true
     end
 
     it "interprets not for nilable proc type (true)" do
-      interpret(<<-CRYSTAL).should eq(true)
+      interpret(<<-CRYSTAL).should be_true
         a =
           if 1 == 1
             nil
@@ -766,7 +766,7 @@ describe Crystal::Repl::Interpreter do
     end
 
     it "interprets not for nilable proc type (false)" do
-      interpret(<<-CRYSTAL).should eq(false)
+      interpret(<<-CRYSTAL).should be_false
         a =
           if 1 == 1
             ->{ 1 }
@@ -778,7 +778,7 @@ describe Crystal::Repl::Interpreter do
     end
 
     it "interprets not for generic class instance type" do
-      interpret(<<-CRYSTAL).should eq(false)
+      interpret(<<-CRYSTAL).should be_false
         class Foo(T)
         end
 
@@ -788,7 +788,7 @@ describe Crystal::Repl::Interpreter do
     end
 
     it "interprets not for nilable type (false)" do
-      interpret(<<-CRYSTAL).should eq(false)
+      interpret(<<-CRYSTAL).should be_false
         class Foo
         end
 
@@ -805,7 +805,7 @@ describe Crystal::Repl::Interpreter do
     end
 
     it "interprets not for nilable type (true)" do
-      interpret(<<-CRYSTAL).should eq(true)
+      interpret(<<-CRYSTAL).should be_true
         class Foo
         end
 
@@ -822,7 +822,7 @@ describe Crystal::Repl::Interpreter do
     end
 
     it "interprets not for module (#12918)" do
-      interpret(<<-CRYSTAL).should eq(false)
+      interpret(<<-CRYSTAL).should be_false
         module MyModule; end
 
         class One
@@ -834,7 +834,7 @@ describe Crystal::Repl::Interpreter do
     end
 
     it "interprets not for generic module" do
-      interpret(<<-CRYSTAL).should eq(false)
+      interpret(<<-CRYSTAL).should be_false
         module MyModule(T); end
 
         class One
@@ -846,7 +846,7 @@ describe Crystal::Repl::Interpreter do
     end
 
     it "interprets not for generic module metaclass" do
-      interpret(<<-CRYSTAL).should eq(false)
+      interpret(<<-CRYSTAL).should be_false
         module MyModule(T); end
 
         !MyModule(Int32)
@@ -854,7 +854,7 @@ describe Crystal::Repl::Interpreter do
     end
 
     it "interprets not for generic class instance metaclass" do
-      interpret(<<-CRYSTAL).should eq(false)
+      interpret(<<-CRYSTAL).should be_false
         class MyClass(T); end
 
         !MyClass(Int32)

--- a/spec/compiler/interpreter/types_spec.cr
+++ b/spec/compiler/interpreter/types_spec.cr
@@ -107,7 +107,7 @@ describe Crystal::Repl::Interpreter do
     end
 
     it "interprets crystal_type_id for virtual metaclass type (#12228)" do
-      interpret(<<-CRYSTAL).should eq(true)
+      interpret(<<-CRYSTAL).should be_true
         class P
         end
 

--- a/spec/compiler/interpreter/unions_spec.cr
+++ b/spec/compiler/interpreter/unions_spec.cr
@@ -11,7 +11,7 @@ describe Crystal::Repl::Interpreter do
     end
 
     it "put and remove from union, together with is_a? (falsey case)" do
-      interpret(<<-CRYSTAL).should eq(true)
+      interpret(<<-CRYSTAL).should be_true
         a = 1 == 2 ? 2 : true
         a.is_a?(Int32) ? true : a
         CRYSTAL

--- a/spec/std/atomic_spec.cr
+++ b/spec/std/atomic_spec.cr
@@ -26,10 +26,10 @@ describe Atomic do
       atomic = Atomic.new(true)
 
       atomic.compare_and_set(false, true).should eq({true, false})
-      atomic.get.should eq(true)
+      atomic.get.should be_true
 
       atomic.compare_and_set(true, false).should eq({true, true})
-      atomic.get.should eq(false)
+      atomic.get.should be_false
     end
 
     it "with integer" do
@@ -258,8 +258,8 @@ describe Atomic do
   describe "#set" do
     it "with bool" do
       atomic = Atomic.new(false)
-      atomic.set(true).should eq(true)
-      atomic.get.should eq(true)
+      atomic.set(true).should be_true
+      atomic.get.should be_true
     end
 
     it "with integer" do
@@ -281,7 +281,7 @@ describe Atomic do
       atomic.get.should eq("foo")
 
       atomic.set(nil)
-      atomic.get.should eq(nil)
+      atomic.get.should be_nil
     end
 
     it "explicit ordering" do
@@ -297,15 +297,15 @@ describe Atomic do
     atomic.lazy_get.should eq(2)
 
     bool = Atomic.new(true)
-    bool.lazy_set(false).should eq(false)
-    bool.lazy_get.should eq(false)
+    bool.lazy_set(false).should be_false
+    bool.lazy_get.should be_false
   end
 
   describe "#swap" do
     it "with bool" do
       atomic = Atomic.new(true)
-      atomic.swap(false).should eq(true)
-      atomic.get.should eq(false)
+      atomic.swap(false).should be_true
+      atomic.get.should be_false
     end
 
     it "with integer" do
@@ -329,11 +329,11 @@ describe Atomic do
     it "with nilable reference" do
       atomic = Atomic(String?).new(nil)
 
-      atomic.swap("not nil").should eq(nil)
+      atomic.swap("not nil").should be_nil
       atomic.get.should eq("not nil")
 
       atomic.swap(nil).should eq("not nil")
-      atomic.get.should eq(nil)
+      atomic.get.should be_nil
     end
 
     it "with reference union" do
@@ -364,31 +364,31 @@ describe Atomic do
     it "gets and sets" do
       booleans = AtomicBooleans.new
 
-      booleans.@one.get.should eq(false)
-      booleans.@two.get.should eq(false)
-      booleans.@three.get.should eq(false)
+      booleans.@one.get.should be_false
+      booleans.@two.get.should be_false
+      booleans.@three.get.should be_false
 
       booleans.@two.set(true)
-      booleans.@one.get.should eq(false)
-      booleans.@two.get.should eq(true)
-      booleans.@three.get.should eq(false)
+      booleans.@one.get.should be_false
+      booleans.@two.get.should be_true
+      booleans.@three.get.should be_false
 
       booleans.@one.set(true)
       booleans.@three.set(true)
-      booleans.@one.get.should eq(true)
-      booleans.@two.get.should eq(true)
-      booleans.@three.get.should eq(true)
+      booleans.@one.get.should be_true
+      booleans.@two.get.should be_true
+      booleans.@three.get.should be_true
 
       booleans.@one.set(false)
       booleans.@three.set(false)
-      booleans.@one.get.should eq(false)
-      booleans.@two.get.should eq(true)
-      booleans.@three.get.should eq(false)
+      booleans.@one.get.should be_false
+      booleans.@two.get.should be_true
+      booleans.@three.get.should be_false
 
       booleans.@two.set(false)
-      booleans.@one.get.should eq(false)
-      booleans.@two.get.should eq(false)
-      booleans.@three.get.should eq(false)
+      booleans.@one.get.should be_false
+      booleans.@two.get.should be_false
+      booleans.@three.get.should be_false
     end
   end
 end

--- a/spec/std/channel_spec.cr
+++ b/spec/std/channel_spec.cr
@@ -215,7 +215,7 @@ describe Channel do
         spawn_and_wait(-> { ch2.close }) do
           i, m = Channel.select(ch.receive_select_action?, ch2.receive_select_action?)
           i.should eq(1)
-          m.should eq(nil)
+          m.should be_nil
         end
       end
     end
@@ -237,7 +237,7 @@ describe Channel do
         spawn_and_wait(-> { ch2.close }) do
           i, m = Channel.select(ch.receive_select_action, ch2.receive_select_action?)
           i.should eq(1)
-          m.should eq(nil)
+          m.should be_nil
         end
       end
     end
@@ -327,7 +327,7 @@ describe Channel do
           i, m = Channel.select(ch.receive_select_action, timeout_select_action(0.1.seconds))
 
           i.should eq(1)
-          m.should eq(nil)
+          m.should be_nil
         end
       end
 
@@ -337,7 +337,7 @@ describe Channel do
           i, m = Channel.select(timeout_select_action(0.1.seconds), ch.receive_select_action)
 
           i.should eq(0)
-          m.should eq(nil)
+          m.should be_nil
         end
       end
 
@@ -348,7 +348,7 @@ describe Channel do
             i, m = Channel.select(ch.receive_select_action, timeout_select_action(0.1.seconds))
 
             i.should eq(1)
-            m.should eq(nil)
+            m.should be_nil
           end
         end
       end
@@ -416,7 +416,7 @@ describe Channel do
           i, m = Channel.select(ch.receive_select_action?, timeout_select_action(0.1.seconds))
 
           i.should eq(0)
-          m.should eq(nil)
+          m.should be_nil
         end
       end
     end
@@ -483,7 +483,7 @@ describe Channel do
         spawn_and_wait(-> { ch2.close }) do
           i, m = Channel.non_blocking_select(ch.receive_select_action, ch2.receive_select_action?)
           i.should eq(1)
-          m.should eq(nil)
+          m.should be_nil
         end
       end
     end
@@ -565,7 +565,7 @@ describe Channel do
           i, m = Channel.non_blocking_select(ch.receive_select_action?, timeout_select_action(0.1.seconds))
 
           i.should eq(0)
-          m.should eq(nil)
+          m.should be_nil
         end
       end
     end

--- a/spec/std/complex_spec.cr
+++ b/spec/std/complex_spec.cr
@@ -297,10 +297,10 @@ describe "Complex" do
   end
 
   it "test zero?" do
-    Complex.new(0, 0).zero?.should eq true
-    Complex.new(0, 3.4).zero?.should eq false
-    Complex.new(1.2, 0).zero?.should eq false
-    Complex.new(1.2, 3.4).zero?.should eq false
+    Complex.new(0, 0).zero?.should be_true
+    Complex.new(0, 3.4).zero?.should be_false
+    Complex.new(1.2, 0).zero?.should be_false
+    Complex.new(1.2, 3.4).zero?.should be_false
   end
 
   it "test additive_identity" do

--- a/spec/std/concurrent/select_spec.cr
+++ b/spec/std/concurrent/select_spec.cr
@@ -345,7 +345,7 @@ describe "select" do
         when m = ch2.receive
           w.check
           typeof(m).should eq(Bool)
-          m.should eq(true)
+          m.should be_true
         end
       end
     end
@@ -414,7 +414,7 @@ describe "select" do
         when m = ch2.receive
           w.check
           typeof(m).should eq(Bool)
-          m.should eq(true)
+          m.should be_true
         else
         end
       end
@@ -527,7 +527,7 @@ describe "select" do
         when m = ch2.receive?
           w.check
           typeof(m).should eq(Bool?)
-          m.should eq(true)
+          m.should be_true
         end
       end
     end
@@ -662,7 +662,7 @@ describe "select" do
         when m = ch2.receive?
           w.check
           typeof(m).should eq(Bool?)
-          m.should eq(true)
+          m.should be_true
         else
         end
       end

--- a/spec/std/crypto/subtle_spec.cr
+++ b/spec/std/crypto/subtle_spec.cr
@@ -20,7 +20,7 @@ describe "Subtle" do
   it "compares constant time bytes bug" do
     h1 = "$2a$05$LEC1XBXgXECzKUO2LBDhKOa9lH9zigNKnksVaDwViFNgPU4WkrD53J"
     h2 = "$2a$05$LEC1XBXgXECzKUO2LBDhKOaHlSGFuDDwMuVg6gOzdxQ0xN4rFOwMUn"
-    Crypto::Subtle.constant_time_compare(h1, h2).should eq(false)
+    Crypto::Subtle.constant_time_compare(h1, h2).should be_false
   end
 
   it "compares constant time and slices strings" do

--- a/spec/std/enumerable_spec.cr
+++ b/spec/std/enumerable_spec.cr
@@ -573,12 +573,12 @@ describe "Enumerable" do
     end
 
     it "returns the default value if there are no truthy block results" do
-      {1, 2, 3}.find_value { |i| "4" if i == 4 }.should eq nil
+      {1, 2, 3}.find_value { |i| "4" if i == 4 }.should be_nil
       {1, 2, 3}.find_value "nope" { |i| "4" if i == 4 }.should eq "nope"
-      ([] of Int32).find_value false { true }.should eq false
+      ([] of Int32).find_value false { true }.should be_false
 
       # Same as above but returns `false` instead of `nil`.
-      {1, 2, 3}.find_value { |i| i == 4 && "4" }.should eq nil
+      {1, 2, 3}.find_value { |i| i == 4 && "4" }.should be_nil
       {1, 2, 3}.find_value "nope" { |i| i == 4 && "4" }.should eq "nope"
     end
   end
@@ -716,7 +716,7 @@ describe "Enumerable" do
     end
 
     it "returns nil if no object could be found" do
-      ["Alice", "Bob"].index { |name| name.size < 3 }.should eq nil
+      ["Alice", "Bob"].index { |name| name.size < 3 }.should be_nil
     end
   end
 
@@ -1137,8 +1137,8 @@ describe "Enumerable" do
   end
 
   describe "none?" do
-    it { [1, 2, 2, 3].none? { |x| x == 1 }.should eq(false) }
-    it { [1, 2, 2, 3].none? { |x| x == 0 }.should eq(true) }
+    it { [1, 2, 2, 3].none? { |x| x == 1 }.should be_false }
+    it { [1, 2, 2, 3].none? { |x| x == 0 }.should be_true }
   end
 
   describe "none? without block" do
@@ -1152,9 +1152,9 @@ describe "Enumerable" do
   end
 
   describe "one?" do
-    it { [1, 2, 2, 3].one? { |x| x == 1 }.should eq(true) }
-    it { [1, 2, 2, 3].one? { |x| x == 2 }.should eq(false) }
-    it { [1, 2, 2, 3].one? { |x| x == 0 }.should eq(false) }
+    it { [1, 2, 2, 3].one? { |x| x == 1 }.should be_true }
+    it { [1, 2, 2, 3].one? { |x| x == 2 }.should be_false }
+    it { [1, 2, 2, 3].one? { |x| x == 0 }.should be_false }
     it { [1, 2, false].one?.should be_false }
     it { [1, false, false].one?.should be_true }
     it { [false].one?.should be_false }

--- a/spec/std/float_printer/grisu3_spec.cr
+++ b/spec/std/float_printer/grisu3_spec.cr
@@ -47,42 +47,42 @@ describe "grisu3" do
   context "float64" do
     it "min float" do
       status, point, str = test_grisu 5e-324
-      status.should eq true
+      status.should be_true
       str.should eq "5"
       point.should eq -323
     end
 
     it "max float" do
       status, point, str = test_grisu 1.7976931348623157e308
-      status.should eq true
+      status.should be_true
       str.should eq "17976931348623157"
       point.should eq 309
     end
 
     it "point at end" do
       status, point, str = test_grisu 4294967272.0
-      status.should eq true
+      status.should be_true
       str.should eq "4294967272"
       point.should eq 10
     end
 
     it "large number" do
       status, point, str = test_grisu 4.1855804968213567e298
-      status.should eq true
+      status.should be_true
       str.should eq "4185580496821357"
       point.should eq 299
     end
 
     it "small number" do
       status, point, str = test_grisu 5.5626846462680035e-309
-      status.should eq true
+      status.should be_true
       str.should eq "5562684646268003"
       point.should eq -308
     end
 
     it "another no point move" do
       status, point, str = test_grisu 2147483648.0
-      status.should eq true
+      status.should be_true
       str.should eq "2147483648"
       point.should eq 10
     end
@@ -91,20 +91,20 @@ describe "grisu3" do
       # grisu should not be able to do this number
       # this number is reused to ensure the fallback works
       status, point, str = test_grisu 3.5844466002796428e+298
-      status.should eq false
+      status.should be_false
       str.should_not eq "35844466002796428"
     end
 
     it "smallest normal" do
       status, point, str = test_grisu 0x0010000000000000_u64
-      status.should eq true
+      status.should be_true
       str.should eq "22250738585072014"
       point.should eq -307
     end
 
     it "largest denormal" do
       status, point, str = test_grisu 0x000FFFFFFFFFFFFF_u64
-      status.should eq true
+      status.should be_true
       str.should eq "2225073858507201"
       point.should eq -307
     end
@@ -113,77 +113,77 @@ describe "grisu3" do
   context "float32" do
     it "min" do
       status, point, str = test_grisu 1e-45_f32
-      status.should eq true
+      status.should be_true
       str.should eq "1"
       point.should eq -44
     end
 
     it "max" do
       status, point, str = test_grisu 3.4028234e38_f32
-      status.should eq true
+      status.should be_true
       str.should eq "34028235"
       point.should eq 39
     end
 
     it "general whole number, rounding" do
       status, point, str = test_grisu 4294967272.0_f32
-      status.should eq true
+      status.should be_true
       str.should eq "42949673"
       point.should eq 10
     end
 
     it "general whole number, rounding" do
       status, point, str = test_grisu 4294967272.0_f32
-      status.should eq true
+      status.should be_true
       str.should eq "42949673"
       point.should eq 10
     end
 
     it "large number, rounding" do
       status, point, str = test_grisu 3.32306998946228968226e35_f32
-      status.should eq true
+      status.should be_true
       str.should eq "332307"
       point.should eq 36
     end
 
     it "small number" do
       status, point, str = test_grisu 1.2341e-41_f32
-      status.should eq true
+      status.should be_true
       str.should eq "12341"
       point.should eq -40
     end
 
     it "general no rounding" do
       status, point, str = test_grisu 3.3554432e7_f32
-      status.should eq true
+      status.should be_true
       str.should eq "33554432"
       point.should eq 8
     end
 
     it "general with rounding up" do
       status, point, str = test_grisu 3.26494756798464e14_f32
-      status.should eq true
+      status.should be_true
       str.should eq "32649476"
       point.should eq 15
     end
 
     it "general with rounding down" do
       status, point, str = test_grisu 3.91132223637771935344e37_f32
-      status.should eq true
+      status.should be_true
       str.should eq "39113222"
       point.should eq 38
     end
 
     it "smallest normal" do
       status, point, str = test_grisu 0x00800000_u32
-      status.should eq true
+      status.should be_true
       str.should eq "11754944"
       point.should eq -37
     end
 
     it "largest denormal" do
       status, point, str = test_grisu 0x007FFFFF_u32
-      status.should eq true
+      status.should be_true
       str.should eq "11754942"
       point.should eq -37
     end

--- a/spec/std/hash_spec.cr
+++ b/spec/std/hash_spec.cr
@@ -172,7 +172,7 @@ describe "Hash" do
   describe "#put" do
     it "puts in a small hash" do
       a = {} of Int32 => Int32
-      a.put(1, 2) { nil }.should eq(nil)
+      a.put(1, 2) { nil }.should be_nil
       a.put(1, 3) { nil }.should eq(2)
     end
 
@@ -181,7 +181,7 @@ describe "Hash" do
       100.times do |i|
         a[i] = i
       end
-      a.put(100, 2) { nil }.should eq(nil)
+      a.put(100, 2) { nil }.should be_nil
       a.put(100, 3) { nil }.should eq(2)
     end
 
@@ -381,7 +381,7 @@ describe "Hash" do
 
       h.dig("a", "b", "c").should eq([10, 20])
       h.dig(ary, "a").should eq("b")
-      h.dig(ary, "c").should eq(nil)
+      h.dig(ary, "c").should be_nil
     end
 
     it "raises KeyError if not found" do
@@ -467,8 +467,8 @@ describe "Hash" do
 
     it "returns nil if no key pairs with the given value" do
       hash = {"foo" => "bar", "baz" => "qux"}
-      hash.key_for?("foobar").should eq nil
-      hash.key_for?("bazqux").should eq nil
+      hash.key_for?("foobar").should be_nil
+      hash.key_for?("bazqux").should be_nil
     end
   end
 

--- a/spec/std/http/client/response_spec.cr
+++ b/spec/std/http/client/response_spec.cr
@@ -131,12 +131,12 @@ class HTTP::Client::Response
 
     it "parses long request lines" do
       request = Response.from_io?(IO::Memory.new("HTTP/1.1 200 #{"OK" * 600_000}\r\n\r\n"))
-      request.should eq(nil)
+      request.should be_nil
     end
 
     it "parses long headers" do
       request = Response.from_io?(IO::Memory.new("HTTP/1.1 200 OK\r\n#{"X-Test-Header: A pretty log header value\r\n" * 100_000}\r\n"))
-      request.should eq(nil)
+      request.should be_nil
     end
 
     describe "handle invalid IO" do
@@ -312,8 +312,8 @@ class HTTP::Client::Response
       end
       response = Response.from_io(IO::Memory.new("HTTP/1.1 200 OK\r\nContent-Encoding: gzip\r\nContent-Length: #{body.bytesize}\r\n\r\n#{body}"))
       response.body.should eq("hello")
-      response.headers["content-encoding"]?.should eq(nil)
-      response.headers["content-length"]?.should eq(nil)
+      response.headers["content-encoding"]?.should be_nil
+      response.headers["content-length"]?.should be_nil
     end
 
     it "deletes Content-Encoding and Content-Length headers after deflate decompression" do
@@ -322,21 +322,21 @@ class HTTP::Client::Response
       end
       response = Response.from_io(IO::Memory.new("HTTP/1.1 200 OK\r\nContent-Encoding: deflate\r\nContent-Length: #{body.bytesize}\r\n\r\n#{body}"))
       response.body.should eq("hello")
-      response.headers["content-encoding"]?.should eq(nil)
-      response.headers["content-length"]?.should eq(nil)
+      response.headers["content-encoding"]?.should be_nil
+      response.headers["content-length"]?.should be_nil
     end
 
     describe "success?" do
       it "returns true for the 2xx" do
         response = Response.new(:ok)
 
-        response.success?.should eq(true)
+        response.success?.should be_true
       end
 
       it "returns false for other ranges" do
         response = Response.new(500)
 
-        response.success?.should eq(false)
+        response.success?.should be_false
       end
     end
   end

--- a/spec/std/http/request_spec.cr
+++ b/spec/std/http/request_spec.cr
@@ -455,20 +455,20 @@ module HTTP
     describe "#form_params" do
       it "returns can safely be called on get requests" do
         request = Request.from_io(IO::Memory.new("GET /api/v3/some/resource HTTP/1.1\r\n\r\n")).as(Request)
-        request.form_params?.should eq(nil)
+        request.form_params?.should be_nil
         request.form_params.size.should eq(0)
       end
 
       it "returns parsed HTTP::Params" do
         request = Request.new("POST", "/form", HTTP::Headers{"Content-Type" => "application/x-www-form-urlencoded"}, HTTP::Params.encode({"test" => "foobar"}))
-        request.form_params?.should_not eq(nil)
+        request.form_params?.should_not be_nil
         request.form_params.size.should eq(1)
         request.form_params["test"].should eq("foobar")
       end
 
       it "ignores invalid content-type" do
         request = Request.new("POST", "/form", nil, HTTP::Params.encode({"test" => "foobar"}))
-        request.form_params?.should eq(nil)
+        request.form_params?.should be_nil
         request.form_params.size.should eq(0)
       end
     end

--- a/spec/std/http/status_spec.cr
+++ b/spec/std/http/status_spec.cr
@@ -80,7 +80,7 @@ describe HTTP::Status do
     end
 
     it "returns nil on non-existent status" do
-      HTTP::Status.new(999).description.should eq(nil)
+      HTTP::Status.new(999).description.should be_nil
     end
   end
 end

--- a/spec/std/io/delimited_spec.cr
+++ b/spec/std/io/delimited_spec.cr
@@ -57,10 +57,10 @@ describe "IO::Delimited" do
         delimited.read_char.should eq('e')
         delimited.read_char.should eq('r')
         delimited.read_char.should eq('z')
-        delimited.read_char.should eq(nil)
-        delimited.read_char.should eq(nil)
-        delimited.read_char.should eq(nil)
-        delimited.read_char.should eq(nil)
+        delimited.read_char.should be_nil
+        delimited.read_char.should be_nil
+        delimited.read_char.should be_nil
+        delimited.read_char.should be_nil
 
         io.read_char.should eq('f')
         io.read_char.should eq('g')
@@ -77,7 +77,7 @@ describe "IO::Delimited" do
         io = MemoryIOWithoutPeek.new("ab12312")
         delimited = IO::Delimited.new(io, read_delimiter: "ab1")
 
-        delimited.read_char.should eq(nil)
+        delimited.read_char.should be_nil
       end
 
       it "handles the delimiter at the end" do
@@ -150,10 +150,10 @@ describe "IO::Delimited" do
         delimited.read_char.should eq('e')
         delimited.read_char.should eq('r')
         delimited.read_char.should eq('z')
-        delimited.read_char.should eq(nil)
-        delimited.read_char.should eq(nil)
-        delimited.read_char.should eq(nil)
-        delimited.read_char.should eq(nil)
+        delimited.read_char.should be_nil
+        delimited.read_char.should be_nil
+        delimited.read_char.should be_nil
+        delimited.read_char.should be_nil
 
         io.read_char.should eq('f')
         io.read_char.should eq('g')
@@ -172,7 +172,7 @@ describe "IO::Delimited" do
         delimited = IO::Delimited.new(io, read_delimiter: "ab1")
 
         delimited.peek.should eq(Bytes.empty)
-        delimited.read_char.should eq(nil)
+        delimited.read_char.should be_nil
       end
 
       it "handles the delimiter at the end" do
@@ -385,7 +385,7 @@ describe "IO::Delimited" do
       delimited.read_char.should eq('b')
 
       delimited.close
-      delimited.closed?.should eq(true)
+      delimited.closed?.should be_true
       expect_raises(IO::Error, "Closed stream") do
         delimited.read_char
       end
@@ -394,11 +394,11 @@ describe "IO::Delimited" do
     it "closes the underlying stream if sync_close is true" do
       io = IO::Memory.new "abcdefg"
       delimited = IO::Delimited.new(io, read_delimiter: "zr", sync_close: true)
-      delimited.sync_close?.should eq(true)
+      delimited.sync_close?.should be_true
 
-      io.closed?.should eq(false)
+      io.closed?.should be_false
       delimited.close
-      io.closed?.should eq(true)
+      io.closed?.should be_true
     end
   end
 end

--- a/spec/std/io/memory_spec.cr
+++ b/spec/std/io/memory_spec.cr
@@ -114,14 +114,14 @@ describe IO::Memory do
     io = IO::Memory.new("foo\r\nbar\n")
     io.gets.should eq("foo")
     io.gets.should eq("bar")
-    io.gets.should eq(nil)
+    io.gets.should be_nil
   end
 
   it "reads each line with chomp = false" do
     io = IO::Memory.new("foo\r\nbar\r\n")
     io.gets(chomp: false).should eq("foo\r\n")
     io.gets(chomp: false).should eq("bar\r\n")
-    io.gets(chomp: false).should eq(nil)
+    io.gets(chomp: false).should be_nil
   end
 
   it "gets with char as delimiter" do
@@ -129,7 +129,7 @@ describe IO::Memory do
     io.gets('w').should eq("hello w")
     io.gets('r').should eq("or")
     io.gets('r').should eq("ld")
-    io.gets('r').should eq(nil)
+    io.gets('r').should be_nil
   end
 
   it "does gets with char and limit" do

--- a/spec/std/io/multi_writer_spec.cr
+++ b/spec/std/io/multi_writer_spec.cr
@@ -37,7 +37,7 @@ describe "IO::MultiWriter" do
         writer.puts "foo"
       end
 
-      io.closed?.should eq(false)
+      io.closed?.should be_false
       io.to_s.should eq("")
     end
 
@@ -47,7 +47,7 @@ describe "IO::MultiWriter" do
 
       writer.close
 
-      io.closed?.should eq(true)
+      io.closed?.should be_true
     end
   end
 

--- a/spec/std/io/sized_spec.cr
+++ b/spec/std/io/sized_spec.cr
@@ -92,7 +92,7 @@ describe "IO::Sized" do
       sized.read_char.should eq('b')
 
       sized.close
-      sized.closed?.should eq(true)
+      sized.closed?.should be_true
       expect_raises(IO::Error, "Closed stream") do
         sized.read_char
       end
@@ -101,11 +101,11 @@ describe "IO::Sized" do
     it "closes the underlying stream if sync_close is true" do
       io = IO::Memory.new "abcdefg"
       sized = IO::Sized.new(io, read_size: 5, sync_close: true)
-      sized.sync_close?.should eq(true)
+      sized.sync_close?.should be_true
 
-      io.closed?.should eq(false)
+      io.closed?.should be_false
       sized.close
-      io.closed?.should eq(true)
+      io.closed?.should be_true
     end
   end
 

--- a/spec/std/json/any_spec.cr
+++ b/spec/std/json/any_spec.cr
@@ -5,7 +5,7 @@ require "yaml"
 describe JSON::Any do
   it ".new" do
     JSON::Any.new(nil).raw.should be_nil
-    JSON::Any.new(true).raw.should eq true
+    JSON::Any.new(true).raw.should be_true
     JSON::Any.new(1_i64).raw.should eq 1_i64
     JSON::Any.new(1).raw.should eq 1
     JSON::Any.new(1_u8).raw.should eq 1
@@ -118,13 +118,13 @@ describe JSON::Any do
     it "of array" do
       JSON.parse("[1, 2, 3]")[1]?.not_nil!.raw.should eq(2)
       JSON.parse("[1, 2, 3]")[3]?.should be_nil
-      JSON.parse("[true, false]")[1]?.should eq false
+      JSON.parse("[true, false]")[1]?.should be_false
     end
 
     it "of hash" do
       JSON.parse(%({"foo": "bar"}))["foo"]?.not_nil!.raw.should eq("bar")
       JSON.parse(%({"foo": "bar"}))["fox"]?.should be_nil
-      JSON.parse(%q<{"foo": false}>)["foo"]?.should eq false
+      JSON.parse(%q<{"foo": false}>)["foo"]?.should be_false
     end
   end
 

--- a/spec/std/json/serializable_spec.cr
+++ b/spec/std/json/serializable_spec.cr
@@ -764,38 +764,38 @@ describe "JSON mapping" do
 
     it "bool" do
       json = JSONAttrWithDefaults.from_json(%({}))
-      json.c.should eq true
+      json.c.should be_true
       typeof(json.c).should eq Bool
-      json.d.should eq false
+      json.d.should be_false
       typeof(json.d).should eq Bool
 
       json = JSONAttrWithDefaults.from_json(%({"c":false}))
-      json.c.should eq false
+      json.c.should be_false
       json = JSONAttrWithDefaults.from_json(%({"c":true}))
-      json.c.should eq true
+      json.c.should be_true
 
       json = JSONAttrWithDefaults.from_json(%({"d":false}))
-      json.d.should eq false
+      json.d.should be_false
       json = JSONAttrWithDefaults.from_json(%({"d":true}))
-      json.d.should eq true
+      json.d.should be_true
     end
 
     it "with nilable" do
       json = JSONAttrWithDefaults.from_json(%({}))
 
-      json.e.should eq false
+      json.e.should be_false
       typeof(json.e).should eq(Bool | Nil)
 
       json.f.should eq 1
       typeof(json.f).should eq(Int32 | Nil)
 
-      json.g.should eq nil
+      json.g.should be_nil
       typeof(json.g).should eq(Int32 | Nil)
 
       json = JSONAttrWithDefaults.from_json(%({"e":false}))
-      json.e.should eq false
+      json.e.should be_false
       json = JSONAttrWithDefaults.from_json(%({"e":true}))
-      json.e.should eq true
+      json.e.should be_true
     end
 
     it "create new array every time" do

--- a/spec/std/log/metadata_spec.cr
+++ b/spec/std/log/metadata_spec.cr
@@ -118,10 +118,10 @@ describe Log::Metadata::Value do
     v("a").as_s.should eq("a")
     v(1).as_s?.should be_nil
 
-    v(true).as_bool.should eq(true)
-    v(false).as_bool.should eq(false)
-    v(true).as_bool?.should eq(true)
-    v(false).as_bool?.should eq(false)
+    v(true).as_bool.should be_true
+    v(false).as_bool.should be_false
+    v(true).as_bool?.should be_true
+    v(false).as_bool?.should be_false
     v(nil).as_bool?.should be_nil
   end
 

--- a/spec/std/mime/multipart/parser_spec.cr
+++ b/spec/std/mime/multipart/parser_spec.cr
@@ -92,7 +92,7 @@ describe MIME::Multipart::Parser do
     parser = MIME::Multipart::Parser.new(IO::Memory.new(input.gsub('\n', "\r\n")), "AaB03x")
 
     parser.next { }
-    parser.has_next?.should eq(false)
+    parser.has_next?.should be_false
 
     expect_raises(MIME::Multipart::Error, "Multipart parser already finished parsing") do
       parser.next { }
@@ -106,7 +106,7 @@ describe MIME::Multipart::Parser do
       parser.next { }
     end
 
-    parser.has_next?.should eq(false)
+    parser.has_next?.should be_false
 
     expect_raises(MIME::Multipart::Error, "Multipart parser is in an errored state") do
       parser.next { }
@@ -145,6 +145,6 @@ describe MIME::Multipart::Parser do
     end
 
     parser.@state.finished?.should be_true
-    ios.each(&.closed?.should(eq(true)))
+    ios.each(&.closed?.should(be_true))
   end
 end

--- a/spec/std/named_tuple_spec.cr
+++ b/spec/std/named_tuple_spec.cr
@@ -271,7 +271,7 @@ describe "NamedTuple" do
 
       h.dig(:a, :b, :c).should eq([10, 20])
       h.dig("x", "a").should eq("b")
-      h.dig("x", "c").should eq(nil)
+      h.dig("x", "c").should be_nil
     end
 
     it "raises KeyError if not found" do

--- a/spec/std/openssl/cipher_spec.cr
+++ b/spec/std/openssl/cipher_spec.cr
@@ -48,7 +48,7 @@ describe OpenSSL::Cipher do
   it "authenticated?" do
     begin
       cipher = OpenSSL::Cipher.new("aes-128-gcm")
-      cipher.authenticated?.should eq(true)
+      cipher.authenticated?.should be_true
     rescue ArgumentError
       # This system doesn't support GCM ciphers
       # Silently skip, as this method will never return true
@@ -56,6 +56,6 @@ describe OpenSSL::Cipher do
     end
 
     cipher = OpenSSL::Cipher.new("aes-128-cbc")
-    cipher.authenticated?.should eq(false)
+    cipher.authenticated?.should be_false
   end
 end

--- a/spec/std/range_spec.cr
+++ b/spec/std/range_spec.cr
@@ -138,9 +138,9 @@ describe "Range" do
       (0...ary.size).bsearch { |i| ary[i] >= 6 }.should eq 2
       (0...ary.size).bsearch { |i| ary[i] >= 8 }.should eq 3
       (0...ary.size).bsearch { |i| ary[i] >= 10 }.should eq 4
-      (0...ary.size).bsearch { |i| ary[i] >= 100 }.should eq nil
+      (0...ary.size).bsearch { |i| ary[i] >= 100 }.should be_nil
       (0...ary.size).bsearch { |i| true }.should eq 0
-      (0...ary.size).bsearch { |i| false }.should eq nil
+      (0...ary.size).bsearch { |i| false }.should be_nil
 
       (0...ary.size).bsearch { |i| ary[i] >= 10 ? 1 : nil }.should eq 4
 
@@ -148,13 +148,13 @@ describe "Range" do
       (0...ary.size).bsearch { |i| ary[i] >= 100 }.should eq 1
 
       (0_i8..10_i8).bsearch { |x| x >= 10 }.should eq 10_i8
-      (0_i8...10_i8).bsearch { |x| x >= 10 }.should eq nil
+      (0_i8...10_i8).bsearch { |x| x >= 10 }.should be_nil
       (-10_i8...10_i8).bsearch { |x| x >= -5 }.should eq -5_i8
 
       (0_u8..10_u8).bsearch { |x| x >= 10 }.should eq 10_u8
-      (0_u8...10_u8).bsearch { |x| x >= 10 }.should eq nil
+      (0_u8...10_u8).bsearch { |x| x >= 10 }.should be_nil
       (0_u32..10_u32).bsearch { |x| x >= 10 }.should eq 10_u32
-      (0_u32...10_u32).bsearch { |x| x >= 10 }.should eq nil
+      (0_u32...10_u32).bsearch { |x| x >= 10 }.should be_nil
     end
 
     it "BigInt" do
@@ -222,7 +222,7 @@ describe "Range" do
       range = 0..-1
       any = false
       range.each { any = true }
-      any.should eq(false)
+      any.should be_false
     end
 
     it "endless" do
@@ -274,7 +274,7 @@ describe "Range" do
       range = 0..-1
       any = false
       range.reverse_each { any = true }
-      any.should eq(false)
+      any.should be_false
     end
 
     it "raises on endless range" do

--- a/spec/std/socket/udp_socket_spec.cr
+++ b/spec/std/socket/udp_socket_spec.cr
@@ -104,7 +104,7 @@ describe UDPSocket, tags: "network" do
         udp.bind(unspecified_address, port)
 
         udp.multicast_loopback = false
-        udp.multicast_loopback?.should eq(false)
+        udp.multicast_loopback?.should be_false
 
         udp.multicast_hops = 4
         udp.multicast_hops.should eq(4)
@@ -159,7 +159,7 @@ describe UDPSocket, tags: "network" do
         end
 
         udp.multicast_loopback = true
-        udp.multicast_loopback?.should eq(true)
+        udp.multicast_loopback?.should be_true
 
         udp.send("testing", addr)
         udp.read_timeout = 1.second

--- a/spec/std/static_array_spec.cr
+++ b/spec/std/static_array_spec.cr
@@ -58,7 +58,7 @@ describe "StaticArray" do
     end
 
     it "compares other" do
-      (StaticArray(Int32, 0).new(0)).should_not eq(nil)
+      (StaticArray(Int32, 0).new(0)).should_not be_nil
       (StaticArray(Int32, 3).new(0)).should eq(StaticArray(Int8, 3).new(0_i8))
     end
   end

--- a/spec/std/string_scanner_spec.cr
+++ b/spec/std/string_scanner_spec.cr
@@ -51,7 +51,7 @@ describe StringScanner do
       s.offset.should eq(5)
       s[0]?.should_not be_nil
 
-      s.skip(/\d+/).should eq(nil)
+      s.skip(/\d+/).should be_nil
       s.offset.should eq(5)
 
       s.skip('i').should eq(1)
@@ -72,7 +72,7 @@ describe StringScanner do
     it "advances the offset but does not returns the string matched" do
       s = StringScanner.new("this is a string")
 
-      s.skip_until(/not/).should eq(nil)
+      s.skip_until(/not/).should be_nil
       s.offset.should eq(0)
       s[0]?.should be_nil
 
@@ -93,9 +93,9 @@ describe StringScanner do
   describe "#eos" do
     it "it is true when the offset is at the end" do
       s = StringScanner.new("this is a string")
-      s.eos?.should eq(false)
+      s.eos?.should be_false
       s.skip(/(\w+\s?){4}/)
-      s.eos?.should eq(true)
+      s.eos?.should be_true
     end
   end
 
@@ -348,11 +348,11 @@ describe StringScanner do
       s = StringScanner.new("this is a string")
       s.scan_until(/str/)
       s[0]?.should_not be_nil
-      s.eos?.should eq(false)
+      s.eos?.should be_false
 
       s.terminate
       s[0]?.should be_nil
-      s.eos?.should eq(true)
+      s.eos?.should be_true
     end
   end
 end

--- a/spec/std/string_spec.cr
+++ b/spec/std/string_spec.cr
@@ -2440,8 +2440,8 @@ describe "String" do
   end
 
   it "matches, but returns Bool" do
-    "foo".matches?(/foo/).should eq(true)
-    "foo".matches?(/bar/).should eq(false)
+    "foo".matches?(/foo/).should be_true
+    "foo".matches?(/bar/).should be_false
   end
 
   it "#matches_full?" do

--- a/spec/std/system/group_spec.cr
+++ b/spec/std/system/group_spec.cr
@@ -56,7 +56,7 @@ describe System::Group do
 
     it "returns nil on nonexistent group" do
       group = System::Group.find_by?(name: INVALID_GROUP_NAME)
-      group.should eq(nil)
+      group.should be_nil
     end
   end
 
@@ -71,7 +71,7 @@ describe System::Group do
 
     it "returns nil on nonexistent group id" do
       group = System::Group.find_by?(id: INVALID_GROUP_ID)
-      group.should eq(nil)
+      group.should be_nil
     end
   end
 

--- a/spec/std/system/user_spec.cr
+++ b/spec/std/system/user_spec.cr
@@ -67,7 +67,7 @@ describe System::User do
 
     it "returns nil on nonexistent user" do
       user = System::User.find_by?(name: INVALID_USER_NAME)
-      user.should eq(nil)
+      user.should be_nil
     end
   end
 
@@ -82,7 +82,7 @@ describe System::User do
 
     it "returns nil on nonexistent user id" do
       user = System::User.find_by?(id: INVALID_USER_ID)
-      user.should eq(nil)
+      user.should be_nil
     end
   end
 

--- a/spec/std/uri/params_spec.cr
+++ b/spec/std/uri/params_spec.cr
@@ -142,20 +142,20 @@ class URI
 
       it "return nil when there is no such param" do
         params = Params.parse("foo=bar&foo=baz&baz=qux")
-        params["non_existent_param"]?.should eq(nil)
+        params["non_existent_param"]?.should be_nil
       end
     end
 
     describe "#has_key?(name)" do
       it "returns true if param with provided name exists" do
         params = Params.parse("foo=bar&foo=baz&baz=qux")
-        params.has_key?("foo").should eq(true)
-        params.has_key?("baz").should eq(true)
+        params.has_key?("foo").should be_true
+        params.has_key?("baz").should be_true
       end
 
       it "return false if param with provided name does not exist" do
         params = Params.parse("foo=bar&foo=baz&baz=qux")
-        params.has_key?("non_existent_param").should eq(false)
+        params.has_key?("non_existent_param").should be_false
       end
     end
 

--- a/spec/std/uri_spec.cr
+++ b/spec/std/uri_spec.cr
@@ -401,7 +401,7 @@ describe "URI" do
     end
 
     it "returns nil for unknown schemes" do
-      URI.default_port("xyz").should eq(nil)
+      URI.default_port("xyz").should be_nil
     end
 
     it "treats scheme case insensitively" do
@@ -422,7 +422,7 @@ describe "URI" do
       old_port = URI.default_port("ftp")
       begin
         URI.set_default_port("ftp", nil)
-        URI.default_port("ftp").should eq(nil)
+        URI.default_port("ftp").should be_nil
       ensure
         URI.set_default_port("ftp", old_port)
       end

--- a/spec/std/uuid_spec.cr
+++ b/spec/std/uuid_spec.cr
@@ -112,14 +112,14 @@ describe "UUID" do
     end
 
     it "returns nil if it has the wrong number of characters" do
-      UUID.parse?("nope").should eq nil
+      UUID.parse?("nope").should be_nil
     end
 
     it "returns nil if it has incorrect characters" do
-      UUID.parse?("c20335c3-7f46-4126-aae9-f665434ad12?").should eq nil
-      UUID.parse?("lol!wut?-asdf-fork-typo-omglolwtfbbq").should eq nil
-      UUID.parse?("lol!wut?asdfforktypoomglolwtfbbq").should eq nil
-      UUID.parse?("urn:uuid:lol!wut?-asdf-fork-typo-omglolwtfbbq").should eq nil
+      UUID.parse?("c20335c3-7f46-4126-aae9-f665434ad12?").should be_nil
+      UUID.parse?("lol!wut?-asdf-fork-typo-omglolwtfbbq").should be_nil
+      UUID.parse?("lol!wut?asdfforktypoomglolwtfbbq").should be_nil
+      UUID.parse?("urn:uuid:lol!wut?-asdf-fork-typo-omglolwtfbbq").should be_nil
     end
   end
 
@@ -166,7 +166,7 @@ describe "UUID" do
   describe "v1" do
     it "returns true if UUID is v1, false otherwise" do
       uuid = UUID.v1
-      uuid.v1?.should eq(true)
+      uuid.v1?.should be_true
       uuid = UUID.v1(node_id: StaticArray(UInt8, 6).new { |i| (i*10).to_u8 })
       uuid.to_s[24..36].should eq("000a141e2832")
     end
@@ -175,7 +175,7 @@ describe "UUID" do
   describe "v2" do
     it "returns true if UUID is v2, false otherwise" do
       uuid = UUID.v2(UUID::Domain::Person, 42)
-      uuid.v2?.should eq(true)
+      uuid.v2?.should be_true
       uuid = UUID.v2(UUID::Domain::Person, 42, node_id: StaticArray(UInt8, 6).new { |i| (i*10).to_u8 })
       uuid.to_s[24..36].should eq("000a141e2832")
     end
@@ -184,20 +184,20 @@ describe "UUID" do
   describe "v4?" do
     it "returns true if UUID is v4, false otherwise" do
       uuid = UUID.random
-      uuid.v4?.should eq(true)
+      uuid.v4?.should be_true
       uuid = UUID.v4
-      uuid.v4?.should eq(true)
+      uuid.v4?.should be_true
       uuid = UUID.new("00000000-0000-0000-0000-000000000000", version: UUID::Version::V5)
-      uuid.v4?.should eq(false)
+      uuid.v4?.should be_false
     end
   end
 
   describe "v4!" do
     it "returns true if UUID is v4, raises otherwise" do
       uuid = UUID.random
-      uuid.v4!.should eq(true)
+      uuid.v4!.should be_true
       uuid = UUID.v4
-      uuid.v4!.should eq(true)
+      uuid.v4!.should be_true
       uuid = UUID.new("00000000-0000-0000-0000-000000000000", version: UUID::Version::V5)
       expect_raises(UUID::Error) { uuid.v4! }
     end
@@ -209,7 +209,7 @@ describe "UUID" do
       expected = "60a4b7b5-3333-3f1e-a2cd-30d8a2d0b83b"
       UUID.v3(data, UUID::Namespace::DNS).to_s.should eq(expected)
       UUID.v3_dns(data).to_s.should eq(expected)
-      UUID.v3_dns(data).v3?.should eq(true)
+      UUID.v3_dns(data).v3?.should be_true
     end
 
     it "generates URL based names correctly" do
@@ -217,7 +217,7 @@ describe "UUID" do
       expected = "c25c7b79-5f5f-3844-98a4-2548f5d0e7f9"
       UUID.v3(data, UUID::Namespace::URL).to_s.should eq(expected)
       UUID.v3_url(data).to_s.should eq(expected)
-      UUID.v3_url(data).v3?.should eq(true)
+      UUID.v3_url(data).v3?.should be_true
     end
 
     it "generates OID based names correctly" do
@@ -225,7 +225,7 @@ describe "UUID" do
       expected = "77bc1dc3-0a9f-3e7e-bfa5-3f611a660c80"
       UUID.v3(data, UUID::Namespace::OID).to_s.should eq(expected)
       UUID.v3_oid(data).to_s.should eq(expected)
-      UUID.v3_oid(data).v3?.should eq(true)
+      UUID.v3_oid(data).v3?.should be_true
     end
 
     it "generates X500 based names correctly" do
@@ -233,7 +233,7 @@ describe "UUID" do
       expected = "fcab1a4c-fc81-3ebc-9874-9a8b931911d3"
       UUID.v3(data, UUID::Namespace::X500).to_s.should eq(expected)
       UUID.v3_x500(data).to_s.should eq(expected)
-      UUID.v3_x500(data).v3?.should eq(true)
+      UUID.v3_x500(data).v3?.should be_true
     end
   end
 
@@ -243,7 +243,7 @@ describe "UUID" do
       expected = "11caf27c-b803-5e62-9c4b-15332b04047e"
       UUID.v5(data, UUID::Namespace::DNS).to_s.should eq(expected)
       UUID.v5_dns(data).to_s.should eq(expected)
-      UUID.v5_dns(data).v5?.should eq(true)
+      UUID.v5_dns(data).v5?.should be_true
     end
 
     it "generates URL based names correctly" do
@@ -251,7 +251,7 @@ describe "UUID" do
       expected = "29fec3f0-9ad0-5e8a-a42e-214ff695f50e"
       UUID.v5(data, UUID::Namespace::URL).to_s.should eq(expected)
       UUID.v5_url(data).to_s.should eq(expected)
-      UUID.v5_url(data).v5?.should eq(true)
+      UUID.v5_url(data).v5?.should be_true
     end
 
     it "generates OID based names correctly" do
@@ -259,7 +259,7 @@ describe "UUID" do
       expected = "6aab0456-7392-582a-b92a-ba5a7096945d"
       UUID.v5(data, UUID::Namespace::OID).to_s.should eq(expected)
       UUID.v5_oid(data).to_s.should eq(expected)
-      UUID.v5_oid(data).v5?.should eq(true)
+      UUID.v5_oid(data).v5?.should be_true
     end
 
     it "generates X500 based names correctly" do
@@ -267,15 +267,15 @@ describe "UUID" do
       expected = "bc10b2d9-f370-5c65-9561-5e3f6d9b236d"
       UUID.v5(data, UUID::Namespace::X500).to_s.should eq(expected)
       UUID.v5_x500(data).to_s.should eq(expected)
-      UUID.v5_x500(data).v5?.should eq(true)
+      UUID.v5_x500(data).v5?.should be_true
     end
   end
 
   describe "v7" do
     it "generates a v7 UUID" do
       uuid = UUID.v7
-      uuid.v7?.should eq true
-      uuid.variant.rfc9562?.should eq true
+      uuid.v7?.should be_true
+      uuid.variant.rfc9562?.should be_true
     end
 
     pending_wasm32 "generates UUIDs that are sortable with 1ms precision" do

--- a/spec/std/wait_group_spec.cr
+++ b/spec/std/wait_group_spec.cr
@@ -129,7 +129,7 @@ describe WaitGroup do
       16.times do
         select
         when x = exited.receive
-          x.should eq(true)
+          x.should be_true
         when timeout(1.millisecond)
           fail "Expected channel to receive value"
         end

--- a/spec/std/xml/xml_spec.cr
+++ b/spec/std/xml/xml_spec.cr
@@ -534,7 +534,7 @@ describe XML do
     node = document.xpath_node("//lastname").not_nil!
     node.unlink
 
-    document.xpath_node("//lastname").should eq(nil)
+    document.xpath_node("//lastname").should be_nil
   end
 
   it "does to_s with correct encoding (#2319)" do

--- a/spec/std/yaml/any_spec.cr
+++ b/spec/std/yaml/any_spec.cr
@@ -91,7 +91,7 @@ end
 describe YAML::Any do
   it ".new" do
     YAML::Any.new(nil).raw.should be_nil
-    YAML::Any.new(true).raw.should eq true
+    YAML::Any.new(true).raw.should be_true
     YAML::Any.new(1_i64).raw.should eq 1_i64
     YAML::Any.new(1).raw.should eq 1
     YAML::Any.new(1_u8).raw.should eq 1

--- a/spec/std/yaml/serializable_spec.cr
+++ b/spec/std/yaml/serializable_spec.cr
@@ -860,38 +860,38 @@ describe "YAML::Serializable" do
 
     it "bool" do
       yaml = YAMLAttrWithDefaults.from_yaml(%({}))
-      yaml.c.should eq true
+      yaml.c.should be_true
       typeof(yaml.c).should eq Bool
-      yaml.d.should eq false
+      yaml.d.should be_false
       typeof(yaml.d).should eq Bool
 
       yaml = YAMLAttrWithDefaults.from_yaml(%({"c":false}))
-      yaml.c.should eq false
+      yaml.c.should be_false
       yaml = YAMLAttrWithDefaults.from_yaml(%({"c":true}))
-      yaml.c.should eq true
+      yaml.c.should be_true
 
       yaml = YAMLAttrWithDefaults.from_yaml(%({"d":false}))
-      yaml.d.should eq false
+      yaml.d.should be_false
       yaml = YAMLAttrWithDefaults.from_yaml(%({"d":true}))
-      yaml.d.should eq true
+      yaml.d.should be_true
     end
 
     it "with nilable" do
       yaml = YAMLAttrWithDefaults.from_yaml(%({}))
 
-      yaml.e.should eq false
+      yaml.e.should be_false
       typeof(yaml.e).should eq(Bool | Nil)
 
       yaml.f.should eq 1
       typeof(yaml.f).should eq(Int32 | Nil)
 
-      yaml.g.should eq nil
+      yaml.g.should be_nil
       typeof(yaml.g).should eq(Int32 | Nil)
 
       yaml = YAMLAttrWithDefaults.from_yaml(%({"e":false}))
-      yaml.e.should eq false
+      yaml.e.should be_false
       yaml = YAMLAttrWithDefaults.from_yaml(%({"e":true}))
-      yaml.e.should eq true
+      yaml.e.should be_true
     end
 
     it "create new array every time" do

--- a/spec/std/yaml/serialization_spec.cr
+++ b/spec/std/yaml/serialization_spec.cr
@@ -452,16 +452,16 @@ describe "YAML serialization" do
 
   describe "to_yaml" do
     it "does for Nil" do
-      Nil.from_yaml(nil.to_yaml).should eq(nil)
+      Nil.from_yaml(nil.to_yaml).should be_nil
     end
 
     it "does for Nil (empty string)" do
-      Nil.from_yaml("").should eq(nil)
+      Nil.from_yaml("").should be_nil
     end
 
     it "does for Bool" do
-      Bool.from_yaml(true.to_yaml).should eq(true)
-      Bool.from_yaml(false.to_yaml).should eq(false)
+      Bool.from_yaml(true.to_yaml).should be_true
+      Bool.from_yaml(false.to_yaml).should be_false
     end
 
     it "does for Int32" do

--- a/spec/std/yaml/yaml_spec.cr
+++ b/spec/std/yaml/yaml_spec.cr
@@ -8,7 +8,7 @@ describe "YAML" do
     it { YAML.parse_all("---\nfoo\n---\nbar\n").should eq(["foo", "bar"]) }
     it { YAML.parse("foo: bar").should eq({"foo" => "bar"}) }
     it { YAML.parse("--- []\n").should eq([] of YAML::Any) }
-    it { YAML.parse("---\n...").should eq nil }
+    it { YAML.parse("---\n...").should eq YAML::Any.new(nil) }
 
     it "parses recursive sequence" do
       doc = YAML.parse("--- &foo\n- *foo\n")


### PR DESCRIPTION
Transforms all `eq nil` and `eq true`/`eq false` calls in specs to `be_nil` and `be_true`/`be_false` to enforce a consistent style.
We're already using `be_*` in the vast majority of cases. Less than 10% of expectations are using the `eq` style.

This was discovered with ameba's `Lint/SpecEqWithBoolOrNilLiteral` rule.