### PR TITLE
Fix: race condition in Fiber::ExecutionContext::Isolated#wait

### DIFF
--- a/src/fiber/execution_context/isolated.cr
+++ b/src/fiber/execution_context/isolated.cr
@@ -189,14 +189,14 @@ module Fiber::ExecutionContext
     # ctx.wait # => re-raises "fail"
     # ```
     def wait : Nil
-      if @running
+      if running = @running
         node = Fiber::PointerLinkedListNode.new(Fiber.current)
 
         @mutex.synchronize do
-          @wait_list.push(pointerof(node)) if @running
+          @wait_list.push(pointerof(node)) if running = @running
         end
 
-        Fiber.suspend
+        Fiber.suspend if running
       end
 
       if exception = @exception


### PR DESCRIPTION
I don't always enqueue the calling fiber in the wait list, to avoid a race condition, but always suspend it... which leads to the race condition never suspending the fiber forever :facepalm: 