### PR TITLE
Fix typos and add `typos` integration

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -101,3 +101,15 @@ jobs:
 
       - name: Check Format
         run: bin/ci format
+
+  lint_spellcheck:
+    name: Spell Check with Typos
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout Actions Repository
+      uses: actions/checkout@v4
+
+    - name: Spell Check Repo
+      uses: crate-ci/typos@v1.33.1
+      env:
+        CLICOLOR: 1

--- a/_typos.toml
+++ b/_typos.toml
@@ -1,0 +1,60 @@
+[default.extend-words]
+flate = "flate"
+
+[default.extend-identifiers]
+ACCES = "ACCES"
+ba = "ba"
+ba2 = "ba2"
+bui = "bui"
+category_Nd = "category_Nd"
+DW_AT_endianity = "DW_AT_endianity"
+EXTA = "EXTA"
+GC_get_thr_restart_signal = "GC_get_thr_restart_signal"
+get_thr_restart_signal = "get_thr_restart_signal"
+IPPROTO_ND = "IPPROTO_ND"
+IST = "IST"
+iTolen = "iTolen"
+iy = "iy"
+larg = "larg"
+Nd = "Nd"
+numer = "numer"
+OLT = "OLT"
+RELA = "RELA"
+RPC_S_CALL_FAILED_DNE = "RPC_S_CALL_FAILED_DNE"
+SEH = "SEH"
+setup_seh_handler = "setup_seh_handler"
+usri4_parms = "usri4_parms"
+
+[default]
+extend-ignore-re = [
+  # numeric literals
+  '0x[0-9a-fA-F_\.\+]+([fiu](8|16|32|64|128))?',
+  '\\u\{[0-9a-fA-F]+\}',
+  # proper names
+  'FLE Standard Time',
+  'Universally Unique IDentifier',
+  # constants
+  'ERROR_\w+',
+  'EVP_CIPH.*',
+  # fixed test values
+  'FOO|/Fo',
+  'rCVZVOThsIa97pEDOxvGu',
+  '\w*AAAAAAAA\w*',
+  # several string specs
+  '"(Fo-ur|thi|abd|alo|tro|tring|ue)"',
+  '"(aGFo|hel|Hel|thr|noe|Noe|BaR|fo|FO)', '(hel|Hel|worl|Worl|fo)"',
+  '/fo|/FO', "'fo", "/\\(fo",
+  'tr‸ue|fo‸o',
+  "\"[^\"]+\"\\.to_slice\\s*=> [\"']\\\\u", # src/html/entities.cr
+  " ([a-zA-Z.]{8} ){4}->", # src/bit_array.cr
+]
+
+[files]
+extend-exclude = [
+  ".git/**",
+  "lib/**",
+  "man/**",
+  "spec/compiler/semantic/did_you_mean_spec.cr",
+  "spec/std/data/**",
+  "src/compiler/crystal/tools/playground/public/vendor/",
+]

--- a/scripts/update-changelog.sh
+++ b/scripts/update-changelog.sh
@@ -8,7 +8,7 @@
 # `scripts/github-changelog.cr`.
 # The section is then inserted into `CHANGELOG.md`, overwriting any previous
 # content for this milestone.
-# Finally, the changes are commited and pushed to `changelog/$VERSION`.
+# Finally, the changes are committed and pushed to `changelog/$VERSION`.
 # If the changelog section is *new*, also creates a draft PR for this branch.
 #
 # Usage:

--- a/scripts/update-shards.sh
+++ b/scripts/update-shards.sh
@@ -20,4 +20,4 @@ if [ -z "$SHARDS_VERSION" ]; then
 fi
 
 # Update shards ref in mingw64 and win-msvc build actions
-sed -i "/repository: crystal-lang\/shards/{n;s/ref: .*/ref: ${SHARDS_VERISON}/}" .github/workflows/mingw-w64.yml .github/workflows/win_build_portable.yml
+sed -i "/repository: crystal-lang\/shards/{n;s/ref: .*/ref: ${SHARDS_VERSION}/}" .github/workflows/mingw-w64.yml .github/workflows/win_build_portable.yml

--- a/spec/compiler/interpreter/primitives_spec.cr
+++ b/spec/compiler/interpreter/primitives_spec.cr
@@ -2,7 +2,7 @@
 require "./spec_helper"
 
 private macro assert_overflows(code, file = __FILE__, line = __LINE__)
-  it "overlows on {{code}}", file: {{file}}, line: {{line}} do
+  it "overflows on {{code}}", file: {{file}}, line: {{line}} do
     interpret(%(
       class OverflowError < Exception; end
 

--- a/spec/compiler/semantic/splat_spec.cr
+++ b/spec/compiler/semantic/splat_spec.cr
@@ -821,8 +821,8 @@ describe "Semantic: splat" do
       Foo.new.bar("test")
       CRYSTAL
     program = result.program
-    a_typ = program.types["Foo"].as(NonGenericClassType)
-    a_def = a_typ.def_instances.values[0]
+    a_type = program.types["Foo"].as(NonGenericClassType)
+    a_def = a_type.def_instances.values[0]
 
     a_def.location.should eq Location.new("", line_number: 2, column_number: 3)
     a_def.body.location.should eq Location.new("", line_number: 3, column_number: 5)

--- a/spec/std/file/match-fast-glob_spec.cr
+++ b/spec/std/file/match-fast-glob_spec.cr
@@ -89,7 +89,7 @@ describe "File .match? bash tests" do
     assert_file_matches "**/fo[oz]", "foz"
     refute_file_matches "**/fo[oz]", "fog"
 
-    # []: Match a character range and RegExp 'g' (regresion)
+    # []: Match a character range and RegExp 'g' (regression)
     assert_file_matches "**/fo[oz]", "foo"
     assert_file_matches "**/fo[oz]", "foz"
     refute_file_matches "**/fo[oz]", "fog"
@@ -112,7 +112,7 @@ describe "File .match? bash tests" do
     refute_file_matches "?o[oz].b*z.com/{*.js,*.html}", "moz.bar.com/index.html"
     refute_file_matches "?o[oz].b*z.com/{*.js,*.html}", "flozz.buzz.com/index.html"
 
-    # More complex extended matches and RegExp 'g' (regresion)
+    # More complex extended matches and RegExp 'g' (regression)
     assert_file_matches "?o[oz].b*z.com/{*.js,*.html}", "foo.baaz.com/jquery.min.js"
     assert_file_matches "?o[oz].b*z.com/{*.js,*.html}", "moz.buzz.com/index.html"
     refute_file_matches "?o[oz].b*z.com/{*.js,*.html}", "moz.buzz.com/index.htm"

--- a/src/crystal/event_loop/polling.cr
+++ b/src/crystal/event_loop/polling.cr
@@ -49,7 +49,7 @@ end
 #
 # When the IO operation is ready, the fiber will eventually be resumed (one
 # fiber at a time). If it's an IO operation, the operation is tried again which
-# may block again, until the operation succeeds or an error occured (e.g.
+# may block again, until the operation succeeds or an error occurred (e.g.
 # closed, broken pipe).
 #
 # If the IO operation has a timeout, the event is also registered into `@timers`
@@ -629,7 +629,7 @@ abstract class Crystal::EventLoop::Polling < Crystal::EventLoop
 
   # Remove *fd* from the polling system. Must raise a `RuntimeError` on error.
   #
-  # If *closing* is true, then it preceeds a call to `close(2)`. Some
+  # If *closing* is true, then it precedes a call to `close(2)`. Some
   # implementations may take advantage of close doing the book keeping.
   #
   # If *closing* is false then the fd must be deleted from the polling system.

--- a/src/crystal/event_loop/polling/arena.cr
+++ b/src/crystal/event_loop/polling/arena.cr
@@ -1,6 +1,6 @@
 # Generational Arena.
 #
-# The arena allocates objects `T` at a predefined index. The object iself is
+# The arena allocates objects `T` at a predefined index. The object itself is
 # uninitialized (outside of having its memory initialized to zero). The object
 # can be allocated and later retrieved using the generation index (Arena::Index)
 # that contains both the actual index (Int32) and the generation number

--- a/src/crystal/event_loop/polling/waiters.cr
+++ b/src/crystal/event_loop/polling/waiters.cr
@@ -37,7 +37,7 @@ struct Crystal::EventLoop::Polling::Waiters
   # Removes one pending event or marks the list as ready when there are no
   # pending events (we got notified of readiness before a thread enqueued).
   def ready_one(& : Pointer(Event) -> Bool) : Nil
-    # loop until the block succesfully processes an event (it may have to
+    # loop until the block successfully processes an event (it may have to
     # dequeue the timeout from timers)
     loop do
       if event = @list.shift?

--- a/src/crystal/system/unix/main.cr
+++ b/src/crystal/system/unix/main.cr
@@ -1,7 +1,7 @@
 require "c/stdlib"
 
 # Prefer explicit exit over returning the status, so we are free to resume the
-# main thread's fiber on any thread, without occuring a weird behavior where
+# main thread's fiber on any thread, without occurring a weird behavior where
 # another thread returns from main when the caller might expect the main thread
 # to be the one returning.
 

--- a/src/crystal/system/win32/wmain.cr
+++ b/src/crystal/system/win32/wmain.cr
@@ -43,7 +43,7 @@ fun wmain(argc : Int32, argv : UInt16**) : Int32
   LibC.free(utf8_argv)
 
   # prefer explicit exit over returning the status, so we are free to resume the
-  # main thread's fiber on any thread, without occuring a weird behavior where
+  # main thread's fiber on any thread, without occurring a weird behavior where
   # another thread returns from main when the caller might expect the main
   # thread to be the one returning.
   LibC.exit(status)

--- a/src/fiber.cr
+++ b/src/fiber.cr
@@ -340,7 +340,7 @@ class Fiber
   # Suspends execution of the current fiber indefinitely.
   #
   # Unlike `Fiber.yield` the current fiber is not automatically
-  # reenqueued and can only be resumed whith an explicit call to `#enqueue`.
+  # reenqueued and can only be resumed with an explicit call to `#enqueue`.
   #
   # This is equivalent to `sleep` without a time.
   #

--- a/src/fiber/execution_context/runnables.cr
+++ b/src/fiber/execution_context/runnables.cr
@@ -1,7 +1,7 @@
 # The queue is a port of Go's `runq*` functions, distributed under a BSD-like
 # license: <https://cs.opensource.google/go/go/+/release-branch.go1.23:LICENSE>
 #
-# The queue derivates from the chase-lev lock-free queue with adaptations:
+# The queue derives from the chase-lev lock-free queue with adaptations:
 #
 # - single ring buffer (per scheduler);
 # - on overflow: bulk push half the ring to `GlobalQueue`;

--- a/src/lib_c/aarch64-android/c/signal.cr
+++ b/src/lib_c/aarch64-android/c/signal.cr
@@ -58,7 +58,7 @@ lib LibC
     si_errno : Int
     si_code : Int
     __pad0 : Int
-    si_addr : Void*  # Assuming the sigfault form of siginfo_t
+    si_addr : Void*  # Assuming the segfault form of siginfo_t
     __pad1 : Int[26] # SI_MAX_SIZE (128) / sizeof(int) - ...
   end
 

--- a/src/lib_c/aarch64-linux-gnu/c/signal.cr
+++ b/src/lib_c/aarch64-linux-gnu/c/signal.cr
@@ -57,7 +57,7 @@ lib LibC
     si_errno : Int
     si_code : Int
     __pad0 : Int
-    si_addr : Void*               # Assuming the sigfault form of siginfo_t
+    si_addr : Void*               # Assuming the segfault form of siginfo_t
     __pad1 : StaticArray(Int, 26) # __SI_PAD_SIZE (28) - sizeof(void*) / sizeof(int) = 26
   end
 

--- a/src/lib_c/aarch64-linux-musl/c/signal.cr
+++ b/src/lib_c/aarch64-linux-musl/c/signal.cr
@@ -56,7 +56,7 @@ lib LibC
     si_errno : Int
     si_code : Int
     __pad0 : Int
-    si_addr : Void*               # Assuming the sigfault form of siginfo_t
+    si_addr : Void*               # Assuming the segfault form of siginfo_t
     __pad1 : StaticArray(Int, 20) # __SI_PAD_SIZE (28) - sizeof(void*) (8) = 20
   end
 

--- a/src/lib_c/arm-linux-gnueabihf/c/signal.cr
+++ b/src/lib_c/arm-linux-gnueabihf/c/signal.cr
@@ -56,7 +56,7 @@ lib LibC
     si_signo : Int
     si_errno : Int
     si_code : Int
-    si_addr : Void*              # Assuming the sigfault form of siginfo_t
+    si_addr : Void*              # Assuming the segfault form of siginfo_t
     __pad : StaticArray(Int, 25) # __SI_PAD_SIZE (29) - sizeof(void*) (4) = 25
   end
 

--- a/src/lib_c/i386-linux-gnu/c/signal.cr
+++ b/src/lib_c/i386-linux-gnu/c/signal.cr
@@ -56,7 +56,7 @@ lib LibC
     si_signo : Int
     si_errno : Int
     si_code : Int
-    si_addr : Void*              # Assuming the sigfault form of siginfo_t
+    si_addr : Void*              # Assuming the segfault form of siginfo_t
     __pad : StaticArray(Int, 27) # __SI_PAD_SIZE (29) - sizeof(void*) (4) = 25
   end
 

--- a/src/lib_c/i386-linux-musl/c/signal.cr
+++ b/src/lib_c/i386-linux-musl/c/signal.cr
@@ -55,7 +55,7 @@ lib LibC
     si_signo : Int
     si_errno : Int
     si_code : Int
-    si_addr : Void*              # Assuming the sigfault form of siginfo_t
+    si_addr : Void*              # Assuming the segfault form of siginfo_t
     __pad : StaticArray(Int, 25) # __SI_PAD_SIZE (29) - sizeof(void*) (4) = 25
   end
 

--- a/src/lib_c/x86_64-linux-gnu/c/signal.cr
+++ b/src/lib_c/x86_64-linux-gnu/c/signal.cr
@@ -57,7 +57,7 @@ lib LibC
     si_errno : Int
     si_code : Int
     __pad0 : Int
-    si_addr : Void*               # Assuming the sigfault form of siginfo_t
+    si_addr : Void*               # Assuming the segfault form of siginfo_t
     __pad1 : StaticArray(Int, 26) # __SI_PAD_SIZE (28) - sizeof(void*) / sizeof(int) = 26
   end
 

--- a/src/lib_c/x86_64-linux-musl/c/signal.cr
+++ b/src/lib_c/x86_64-linux-musl/c/signal.cr
@@ -56,7 +56,7 @@ lib LibC
     si_errno : Int
     si_code : Int
     __pad0 : Int
-    si_addr : Void*               # Assuming the sigfault form of siginfo_t
+    si_addr : Void*               # Assuming the segfault form of siginfo_t
     __pad1 : StaticArray(Int, 20) # __SI_PAD_SIZE (28) - sizeof(void*) (8) = 20
   end
 

--- a/src/openssl/ssl/context.cr
+++ b/src/openssl/ssl/context.cr
@@ -227,7 +227,7 @@ abstract class OpenSSL::SSL::Context
   # makes it either impossible to access the parent versions or makes the parent
   # versions public too. So to provide insecure in the child classes, we need
   # a second constructor that we call from there without getting the
-  # overridden ones of the childs.
+  # overridden ones of the children.
   protected def _initialize_insecure(method : LibSSL::SSLMethod)
     @handle = LibSSL.ssl_ctx_new(method)
     raise OpenSSL::Error.new("SSL_CTX_new") if @handle.null?

--- a/src/yaml/builder.cr
+++ b/src/yaml/builder.cr
@@ -74,7 +74,7 @@ class YAML::Builder
 
   # Starts a document.
   #
-  # If *implict_start_indicator* is true, skips printing the document start
+  # If *implicit_start_indicator* is true, skips printing the document start
   # indicator (`---`) if this is the first document in the stream.
   def start_document(*, implicit_start_indicator : Bool = false)
     emit document_start, nil, nil, nil, implicit_start_indicator.to_unsafe
@@ -87,7 +87,7 @@ class YAML::Builder
 
   # Starts a document, invokes the block, and then ends it.
   #
-  # If *implict_start_indicator* is true, skips printing the document start
+  # If *implicit_start_indicator* is true, skips printing the document start
   # indicator (`---`) if this is the first document in the stream.
   def document(*, implicit_start_indicator : Bool = false, &)
     start_document(implicit_start_indicator: implicit_start_indicator)


### PR DESCRIPTION
Using https://github.com/crate-ci/typos as spellchecker and adding a config for it. We need a bunch of custom rules because especially in specs we use lots of strings that look similar to actual words and the spell-checker tries to correct them 😏