### PR TITLE
Make `Colorize.on_tty_only!` the default behavior

### DIFF
--- a/src/colorize.cr
+++ b/src/colorize.cr
@@ -129,14 +129,19 @@ module Colorize
   # "hello".colorize.red.to_s # => "hello"
   # ```
   #
-  # NOTE: This is by default disabled if the environment variable `NO_COLOR` contains any value.
-  class_property? enabled : Bool { !ENV.has_key?("NO_COLOR") }
+  # NOTE: This is by default enabled according to `.on_tty_only!`.
+  class_property? enabled : Bool do
+    STDOUT.tty? && STDERR.tty? && ENV["TERM"]? != "dumb" && !ENV.has_key?("NO_COLOR")
+  end
 
   # Makes `Colorize.enabled` `true` if and only if both of `STDOUT.tty?`
   # and `STDERR.tty?` are `true` and the tty is not considered a dumb terminal.
   # This is determined by the environment variable called `TERM`.
   # If `TERM=dumb`, color won't be enabled.
   # If `NO_COLOR` contains any value color won't be enabled conforming to https://no-color.org
+  #
+  # This can be used to revert `Colorize.enabled?` to its default value after
+  # colorization is explicitly enabled or disabled.
   def self.on_tty_only!
     self.enabled = STDOUT.tty? && STDERR.tty? && ENV["TERM"]? != "dumb" && !ENV.has_key?("NO_COLOR")
   end

--- a/src/colorize.cr
+++ b/src/colorize.cr
@@ -140,10 +140,13 @@ module Colorize
   # If `TERM=dumb`, color won't be enabled.
   # If `NO_COLOR` contains any value color won't be enabled conforming to https://no-color.org
   #
+  # Returns the new value of `Colorize.enabled?`.
+  #
   # This can be used to revert `Colorize.enabled?` to its default value after
   # colorization is explicitly enabled or disabled.
-  def self.on_tty_only!
-    self.enabled = STDOUT.tty? && STDERR.tty? && ENV["TERM"]? != "dumb" && !ENV.has_key?("NO_COLOR")
+  def self.on_tty_only! : Bool
+    @@enabled = nil
+    enabled?
   end
 
   # Resets the color and text decoration of the *io*.

--- a/src/colorize.cr
+++ b/src/colorize.cr
@@ -143,7 +143,7 @@ module Colorize
   # This can be used to revert `Colorize.enabled?` to its default value after
   # colorization is explicitly enabled or disabled.
   def self.on_tty_only!
-    @@enabled = nil
+    self.enabled = STDOUT.tty? && STDERR.tty? && ENV["TERM"]? != "dumb" && !ENV.has_key?("NO_COLOR")
   end
 
   # Resets the color and text decoration of the *io*.

--- a/src/colorize.cr
+++ b/src/colorize.cr
@@ -143,7 +143,7 @@ module Colorize
   # This can be used to revert `Colorize.enabled?` to its default value after
   # colorization is explicitly enabled or disabled.
   def self.on_tty_only!
-    self.enabled = STDOUT.tty? && STDERR.tty? && ENV["TERM"]? != "dumb" && !ENV.has_key?("NO_COLOR")
+    @@enabled = nil
   end
 
   # Resets the color and text decoration of the *io*.


### PR DESCRIPTION
Originally part of #7690, this seems to be the more sensible behavior compared to ignoring non-terminal streams and `$TERM`. This does not deprecate `.on_tty_only!` because it is still useful after the default is overridden.

Effectively reverts #14258.