### PR TITLE
Support arbitrary `IO`s in `Spec::CLI`

### DIFF
--- a/src/spec.cr
+++ b/src/spec.cr
@@ -102,13 +102,14 @@ module Spec
         junit_formatter = Spec::JUnitFormatter.file(Path.new(output_path.not_nil!))
         add_formatter(junit_formatter)
       when "verbose"
-        override_default_formatter(Spec::VerboseFormatter.new)
+        override_default_formatter(Spec::VerboseFormatter.new(@stdout))
       when "tap"
-        override_default_formatter(Spec::TAPFormatter.new)
+        override_default_formatter(Spec::TAPFormatter.new(@stdout))
       end
     end
 
     def main(args)
+      # TODO: should not be global state
       Colorize.on_tty_only!
 
       begin
@@ -118,12 +119,11 @@ module Spec
       end
 
       unless args.empty?
-        STDERR.puts "Error: unknown argument '#{args.first}'"
-        exit 1
+        abort "Error: unknown argument '#{args.first}'"
       end
 
       if ENV["SPEC_VERBOSE"]? == "1"
-        override_default_formatter(Spec::VerboseFormatter.new)
+        override_default_formatter(Spec::VerboseFormatter.new(@stdout))
       end
 
       add_split_filter ENV["SPEC_SPLIT"]?

--- a/src/spec/cli.cr
+++ b/src/spec/cli.cr
@@ -17,6 +17,12 @@ module Spec
     getter? dry_run = false
     getter? list_tags = false
 
+    getter stdout : IO
+    getter stderr : IO
+
+    def initialize(@stdout : IO = STDOUT, @stderr : IO = STDERR)
+    end
+
     def add_location(file, line)
       locations = @locations ||= {} of String => Array(Int32)
       locations.put_if_absent(File.expand_path(file)) { [] of Int32 } << line
@@ -69,8 +75,7 @@ module Spec
           if location =~ /\A(.+?)\:(\d+)\Z/
             add_location $1, $2.to_i
           else
-            STDERR.puts "location #{location} must be file:line"
-            exit 1
+            abort "location #{location} must be file:line"
           end
         end
         opts.on("--tag TAG", "run examples with the specified TAG, or exclude examples by adding ~ before the TAG.") do |tag|
@@ -92,7 +97,7 @@ module Spec
           configure_formatter("junit", output_path)
         end
         opts.on("-h", "--help", "show this help") do |pattern|
-          puts opts
+          @stdout.puts opts
           exit
         end
         opts.on("-v", "--verbose", "verbose output") do
@@ -102,9 +107,11 @@ module Spec
           configure_formatter("tap")
         end
         opts.on("--color", "Enabled ANSI colored output") do
+          # TODO: should not be global state
           Colorize.enabled = true
         end
         opts.on("--no-color", "Disable ANSI colored output") do
+          # TODO: should not be global state
           Colorize.enabled = false
         end
         opts.on("--dry-run", "Pass all tests without execution") do
@@ -120,6 +127,11 @@ module Spec
     # module.
     # The real implementation in `../spec.cr` overrides this for actual use.
     def configure_formatter(formatter, output_path = nil)
+    end
+
+    private def abort(msg)
+      @stderr.puts msg
+      exit 1
     end
   end
 

--- a/src/spec/dsl.cr
+++ b/src/spec/dsl.cr
@@ -220,9 +220,9 @@ module Spec
             execute_examples
           end
         rescue ex
-          STDERR.print "Unhandled exception: "
-          ex.inspect_with_backtrace(STDERR)
-          STDERR.flush
+          @stderr.print "Unhandled exception: "
+          ex.inspect_with_backtrace(@stderr)
+          @stderr.flush
           @aborted = true
         ensure
           finish_run unless list_tags?
@@ -273,7 +273,7 @@ module Spec
       return if tag_counts.empty?
       longest_name_size = tag_counts.keys.max_of(&.size)
       tag_counts.to_a.sort_by! { |k, v| {-v, k} }.each do |tag_name, count|
-        puts "#{tag_name.rjust(longest_name_size)}: #{count}"
+        @stdout.puts "#{tag_name.rjust(longest_name_size)}: #{count}"
       end
     end
 

--- a/src/spec/formatter.cr
+++ b/src/spec/formatter.cr
@@ -1,7 +1,7 @@
 module Spec
   # :nodoc:
   abstract class Formatter
-    def initialize(@io : IO = STDOUT)
+    def initialize(@io : IO)
     end
 
     def push(context)
@@ -118,18 +118,16 @@ module Spec
 
   # :nodoc:
   class CLI
-    @formatters = [Spec::DotFormatter.new] of Spec::Formatter
-
     def formatters
-      @formatters
+      @formatters ||= [Spec::DotFormatter.new(@stdout)] of Spec::Formatter
     end
 
     def override_default_formatter(formatter)
-      @formatters[0] = formatter
+      formatters[0] = formatter
     end
 
     def add_formatter(formatter)
-      @formatters << formatter
+      formatters << formatter
     end
   end
 


### PR DESCRIPTION
This continues the effort to make `Spec` more modular and testable.

Colorization state is still global and will be addressed in a subsequent PR.