### PR TITLE
Do not consider type in `Crystal::Var#==`

### DIFF
--- a/src/compiler/crystal/semantic/ast.cr
+++ b/src/compiler/crystal/semantic/ast.cr
@@ -47,8 +47,6 @@ module Crystal
   class Var
     def initialize(@name : String, @type : Type)
     end
-
-    def_equals name, type?
   end
 
   # Fictitious node to represent primitives


### PR DESCRIPTION
`Crystal::Var` already has `def_equals name` in `src/compiler/crystal/syntax/ast.cr`; the use of `type?` appears to be unnecessary.

This might affect macros in subtle ways, but the chances are very small: few (none?) `Var`s accessible inside macros are typed, and it is hard to find `Var`s with the same name but different types in the same context anyway.