### PR TITLE
Add `Fiber::ExecutionContext::ThreadPool`

### DIFF
--- a/spec/std/fiber/execution_context/global_queue_spec.cr
+++ b/spec/std/fiber/execution_context/global_queue_spec.cr
@@ -100,7 +100,7 @@ describe Fiber::ExecutionContext::GlobalQueue do
       queue = Fiber::ExecutionContext::GlobalQueue.new(Thread::Mutex.new)
       ready = Thread::WaitGroup.new(n)
 
-      threads = Array(Thread).new(n) do |i|
+      threads = n.times.map do |i|
         new_thread("ONE-#{i}") do
           slept = 0
           ready.done
@@ -118,7 +118,7 @@ describe Fiber::ExecutionContext::GlobalQueue do
             end
           end
         end
-      end
+      end.to_a
       ready.wait
 
       fibers.each_with_index do |fc, i|
@@ -143,7 +143,7 @@ describe Fiber::ExecutionContext::GlobalQueue do
       queue = Fiber::ExecutionContext::GlobalQueue.new(Thread::Mutex.new)
       ready = Thread::WaitGroup.new(n)
 
-      threads = Array(Thread).new(n) do |i|
+      threads = n.times.map do |i|
         new_thread("BULK-#{i}") do
           slept = 0
 
@@ -196,7 +196,7 @@ describe Fiber::ExecutionContext::GlobalQueue do
             Thread.sleep(1.nanosecond) # don't burn CPU
           end
         end
-      end
+      end.to_a
       ready.wait
 
       # enqueue in batches of 5

--- a/spec/std/fiber/execution_context/runnables_spec.cr
+++ b/spec/std/fiber/execution_context/runnables_spec.cr
@@ -196,7 +196,7 @@ describe Fiber::ExecutionContext::Runnables do
         Fiber::ExecutionContext::Runnables(16).new(global_queue)
       end
 
-      threads = Array(Thread).new(n) do |i|
+      threads = n.times.map do |i|
         new_thread("RUN-#{i}") do
           runnables = all_runnables[i]
           slept = 0
@@ -240,7 +240,7 @@ describe Fiber::ExecutionContext::Runnables do
             Thread.sleep(1.nanosecond) # don't burn CPU
           end
         end
-      end
+      end.to_a
       ready.wait
 
       # enqueue in batches

--- a/spec/std/thread_spec.cr
+++ b/spec/std/thread_spec.cr
@@ -21,7 +21,11 @@ pending_interpreted describe: Thread do
     current = nil
     thread = new_thread { current = Thread.current }
     thread.join
-    current.should be(thread)
+    {% if flag?(:execution_context) %}
+      current.should be(thread.@thread)
+    {% else %}
+      current.should be(thread)
+    {% end %}
     current.should_not be(Thread.current)
   ensure
     # avoids a "GC Warning: Finalization cycle" caused by *current*

--- a/spec/support/thread.cr
+++ b/spec/support/thread.cr
@@ -1,8 +1,7 @@
 {% begin %}
-  def new_thread(name = nil, &block) : Thread
+  def new_thread(name = nil, &block)
     {% if flag?(:execution_context) %}
-      ctx = Fiber::ExecutionContext::Isolated.new(name: name || "SPEC") { block.call }
-      ctx.@thread
+      Fiber::ExecutionContext::Isolated.new(name: name || "SPEC") { block.call }
     {% else %}
       Thread.new(name) { block.call }
     {% end %}

--- a/src/crystal/pointer_linked_list.cr
+++ b/src/crystal/pointer_linked_list.cr
@@ -52,6 +52,9 @@ struct Crystal::PointerLinkedList(T)
     else
       @head = Pointer(T).null
     end
+
+    node.value.previous = Pointer(T).null
+    node.value.next = Pointer(T).null
   end
 
   # Removes and returns head from the list, yields if empty

--- a/src/crystal/system/thread.cr
+++ b/src/crystal/system/thread.cr
@@ -80,15 +80,15 @@ class Thread
   getter name : String?
 
   {% if flag?(:execution_context) %}
-    # :nodoc:
     getter! execution_context : Fiber::ExecutionContext
+    getter! scheduler : Fiber::ExecutionContext::Scheduler
 
     # :nodoc:
-    property! scheduler : Fiber::ExecutionContext::Scheduler
+    def execution_context=(@execution_context : Fiber::ExecutionContext?)
+    end
 
     # :nodoc:
-    def execution_context=(@execution_context : Fiber::ExecutionContext) : Fiber::ExecutionContext
-      main_fiber.execution_context = execution_context
+    def scheduler=(@scheduler : Fiber::ExecutionContext::Scheduler?)
     end
 
     # When a fiber terminates we can't release its stack until we swap context

--- a/src/crystal/tracing.cr
+++ b/src/crystal/tracing.cr
@@ -82,6 +82,14 @@ module Crystal
           write value.name || '?'
         end
 
+        def write(value : Thread) : Nil
+          {% if flag?(:linux) %}
+            write Pointer(Void).new(value.@system_handle)
+          {% else %}
+            write value.@system_handle
+          {% end %}
+        end
+
         {% if flag?(:execution_context) %}
           def write(value : Fiber::ExecutionContext) : Nil
             write value.name

--- a/src/fiber/execution_context.cr
+++ b/src/fiber/execution_context.cr
@@ -67,7 +67,13 @@ require "./execution_context/*"
 # future.
 @[Experimental]
 module Fiber::ExecutionContext
+  @@thread_pool : ThreadPool?
   @@default : ExecutionContext?
+
+  # :nodoc:
+  def self.thread_pool : ThreadPool
+    @@thread_pool.not_nil!("expected thread pool to have been setup")
+  end
 
   # Returns the default `ExecutionContext` for the process, automatically
   # started when the program started.
@@ -82,6 +88,7 @@ module Fiber::ExecutionContext
 
   # :nodoc:
   def self.init_default_context : Nil
+    @@thread_pool = ThreadPool.new
     @@default = SingleThreaded.default
     @@monitor = Monitor.new
   end

--- a/src/fiber/execution_context/isolated.cr
+++ b/src/fiber/execution_context/isolated.cr
@@ -40,7 +40,7 @@ module Fiber::ExecutionContext
 
     @mutex : Thread::Mutex
     protected getter thread : Thread
-    @main_fiber : Fiber
+    protected getter main_fiber : Fiber
 
     # :nodoc:
     getter event_loop : Crystal::EventLoop = Crystal::EventLoop.create
@@ -58,19 +58,23 @@ module Fiber::ExecutionContext
       @mutex = Thread::Mutex.new
       @thread = uninitialized Thread
       @main_fiber = uninitialized Fiber
+      @main_fiber = Fiber.new(@name, allocate_stack, self) { run }
       @thread = start_thread
       ExecutionContext.execution_contexts.push(self)
     end
 
+    private def allocate_stack : Stack
+      # no stack pool: we directly allocate a stack; it will be automatically
+      # released when the thread is returned to the thread pool
+      pointer = Crystal::System::Fiber.allocate_stack(StackPool::STACK_SIZE, protect: true)
+      Stack.new(pointer, StackPool::STACK_SIZE, reusable: true)
+    end
+
     private def start_thread : Thread
-      Thread.new(name: @name) do |thread|
-        @thread = thread
-        thread.execution_context = self
-        thread.scheduler = self
-        thread.main_fiber.name = @name
-        @main_fiber = thread.main_fiber
-        run
-      end
+      ExecutionContext.thread_pool.checkout(self)
+    end
+
+    protected def thread=(@thread)
     end
 
     # :nodoc:
@@ -122,6 +126,11 @@ module Fiber::ExecutionContext
 
     protected def reschedule : Nil
       Crystal.trace :sched, "reschedule"
+
+      if @main_fiber.dead?
+        ExecutionContext.thread_pool.checkin
+        return # actually unreachable
+      end
 
       loop do
         @mutex.synchronize do

--- a/src/fiber/execution_context/multi_threaded.cr
+++ b/src/fiber/execution_context/multi_threaded.cr
@@ -45,8 +45,12 @@ module Fiber::ExecutionContext
     @size : Range(Int32, Int32)
 
     # :nodoc:
+    #
+    # Starts the default execution context. There can be only one for the whole
+    # process. Must be called from the main thread's main fiber; associates the
+    # current thread and fiber to the created execution context.
     protected def self.default(maximum : Int32) : self
-      new("DEFAULT", 1..maximum, hijack: true)
+      Fiber.current.execution_context = new("DEFAULT", 1..maximum, hijack: true)
     end
 
     # Starts a context with a *maximum* number of threads. Threads aren't started
@@ -86,6 +90,9 @@ module Fiber::ExecutionContext
 
       @global_queue = GlobalQueue.new(@mutex)
       @schedulers = Array(Scheduler).new(capacity)
+
+      # FIXME: invalid since schedulers will be transfered to other threads,
+      # keep a mere `@size : Int32` counter instead!
       @threads = Array(Thread).new(capacity)
 
       @rng = Random::PCG32.new
@@ -149,27 +156,17 @@ module Fiber::ExecutionContext
       thread.internal_name = scheduler.name
       thread.execution_context = self
       thread.scheduler = scheduler
-
       scheduler.thread = thread
-      scheduler.main_fiber = Fiber.new("#{scheduler.name}:loop", self) do
-        scheduler.run_loop
-      end
-
-      thread
     end
 
     # Starts a new `Thread` and attaches *scheduler*. Runs the scheduler loop
     # directly in the thread's main `Fiber`.
     private def start_thread(scheduler) : Thread
-      Thread.new(name: scheduler.name) do |thread|
-        thread.execution_context = self
-        thread.scheduler = scheduler
+      ExecutionContext.thread_pool.checkout(scheduler)
+    end
 
-        scheduler.thread = thread
-        scheduler.main_fiber = thread.main_fiber
-        scheduler.main_fiber.name = "#{scheduler.name}:loop"
-        scheduler.run_loop
-      end
+    protected def each_scheduler(& : Scheduler ->) : Nil
+      @schedulers.each { |scheduler| yield scheduler }
     end
 
     # :nodoc:
@@ -216,6 +213,8 @@ module Fiber::ExecutionContext
         Crystal.trace :sched, "park"
         @parked.add(1, :acquire_release)
 
+        # TODO: consider detaching the scheduler and returning the thread back
+        # into ExecutionContext.thread_pool instead
         @condition.wait(@mutex)
 
         # we don't decrement @parked because #wake_scheduler did

--- a/src/fiber/execution_context/multi_threaded.cr
+++ b/src/fiber/execution_context/multi_threaded.cr
@@ -90,11 +90,7 @@ module Fiber::ExecutionContext
 
       @global_queue = GlobalQueue.new(@mutex)
       @schedulers = Array(Scheduler).new(capacity)
-
-      # FIXME: invalid since schedulers will be transfered to other threads,
-      # keep a mere `@size : Int32` counter instead!
-      @threads = Array(Thread).new(capacity)
-
+      @started = @size.begin
       @rng = Random::PCG32.new
 
       start_schedulers
@@ -105,7 +101,7 @@ module Fiber::ExecutionContext
 
     # The number of threads that have been started.
     def size : Int32
-      @threads.size
+      @started
     end
 
     # The maximum number of threads that can be started.
@@ -120,16 +116,15 @@ module Fiber::ExecutionContext
 
     # Starts all schedulers at once.
     #
-    # We could lazily initialize them as needed, like we do for threads, which
-    # would be safe as long as we only mutate when the mutex is locked... but
-    # unlike @threads, we do iterate the schedulers in #steal without locking
-    # the mutex (for obvious reasons) and there are no guarantees that the new
-    # schedulers.@size will be written after the scheduler has been written to
-    # the array's buffer.
+    # We could lazily initialize them as needed, would be safe as long as we
+    # only mutate when the mutex is locked, but we iterate the schedulers in
+    # #steal without locking the mutex (for obvious reasons) and there are no
+    # guarantees that the new schedulers.@size will be written after the
+    # scheduler has been written to the array's buffer.
     #
     # OPTIMIZE: consider storing schedulers to an array-like object that would
-    # use an atomic/fence to make sure that @size can only be incremented
-    # *after* the value has been written to @buffer.
+    # use an atomic/fence to make sure that @size is only incremented *after*
+    # the value has been written to @buffer.
     private def start_schedulers
       capacity.times do |index|
         @schedulers << Scheduler.new(self, "#{@name}-#{index}")
@@ -140,18 +135,18 @@ module Fiber::ExecutionContext
       offset = 0
 
       if hijack
-        @threads << hijack_current_thread(@schedulers[0])
+        hijack_current_thread(@schedulers[0])
         offset += 1
       end
 
       offset.upto(@size.begin - 1) do |index|
-        @threads << start_thread(@schedulers[index])
+        start_thread(@schedulers[index])
       end
     end
 
     # Attaches *scheduler* to the current `Thread`, usually the process' main
     # thread. Starts a `Fiber` to run the scheduler loop.
-    private def hijack_current_thread(scheduler) : Thread
+    private def hijack_current_thread(scheduler) : Nil
       thread = Thread.current
       thread.internal_name = scheduler.name
       thread.execution_context = self
@@ -161,7 +156,7 @@ module Fiber::ExecutionContext
 
     # Starts a new `Thread` and attaches *scheduler*. Runs the scheduler loop
     # directly in the thread's main `Fiber`.
-    private def start_thread(scheduler) : Thread
+    private def start_thread(scheduler) : Nil
       ExecutionContext.thread_pool.checkout(scheduler)
     end
 
@@ -181,7 +176,7 @@ module Fiber::ExecutionContext
         # local enqueue: push to local queue of current scheduler
         ExecutionContext::Scheduler.current.enqueue(fiber)
       else
-        # cross context: push to global queue
+        # cross context or detached thread: push to global queue
         Crystal.trace :sched, "enqueue", fiber: fiber, to_context: self
         @global_queue.push(fiber)
         wake_scheduler
@@ -213,8 +208,8 @@ module Fiber::ExecutionContext
         Crystal.trace :sched, "park"
         @parked.add(1, :acquire_release)
 
-        # TODO: consider detaching the scheduler and returning the thread back
-        # into ExecutionContext.thread_pool instead
+        # TODO: detach the scheduler and return the thread back into ThreadPool
+        # instead
         @condition.wait(@mutex)
 
         # we don't decrement @parked because #wake_scheduler did
@@ -277,13 +272,12 @@ module Fiber::ExecutionContext
       # check if we can start another thread; no need for atomics, the values
       # shall be rather stable over time and we check them again inside the
       # mutex
-      return if @threads.size == capacity
+      return if @started == capacity
 
       @mutex.synchronize do
-        index = @threads.size
+        index = @started
         return if index == capacity # check again
-
-        @threads << start_thread(@schedulers[index])
+        start_thread(@schedulers[index])
       end
     end
 

--- a/src/fiber/execution_context/multi_threaded/scheduler.cr
+++ b/src/fiber/execution_context/multi_threaded/scheduler.cr
@@ -15,7 +15,7 @@ module Fiber::ExecutionContext
       # :nodoc:
       property execution_context : MultiThreaded
       protected property! thread : Thread
-      protected property! main_fiber : Fiber
+      protected property main_fiber : Fiber
 
       @global_queue : GlobalQueue
       @runnables : Runnables(256)
@@ -30,6 +30,7 @@ module Fiber::ExecutionContext
         @global_queue = @execution_context.global_queue
         @runnables = Runnables(256).new(@global_queue)
         @event_loop = @execution_context.event_loop
+        @main_fiber = Fiber.new("#{@name}:loop", @execution_context) { run_loop }
       end
 
       # :nodoc:

--- a/src/fiber/execution_context/single_threaded.cr
+++ b/src/fiber/execution_context/single_threaded.cr
@@ -22,8 +22,8 @@ module Fiber::ExecutionContext
 
     getter name : String
 
-    protected getter thread : Thread
-    @main_fiber : Fiber
+    protected property thread : Thread
+    protected getter main_fiber : Fiber
 
     @mutex : Thread::Mutex
     @global_queue : GlobalQueue
@@ -41,8 +41,12 @@ module Fiber::ExecutionContext
     @tick : Int32 = 0
 
     # :nodoc:
+    #
+    # Starts the default execution context. There can be only one for the whole
+    # process. Must be called from the main thread's main fiber; associates the
+    # current thread and fiber to the created execution context.
     protected def self.default : self
-      new("DEFAULT", hijack: true)
+      Fiber.current.execution_context = new("DEFAULT", hijack: true)
     end
 
     def self.new(name : String) : self
@@ -53,9 +57,10 @@ module Fiber::ExecutionContext
       @mutex = Thread::Mutex.new
       @global_queue = GlobalQueue.new(@mutex)
       @runnables = Runnables(256).new(@global_queue)
-
       @thread = uninitialized Thread
-      @main_fiber = uninitialized Fiber
+      @main_fiber = uninitialized Thread
+
+      @main_fiber = Fiber.new("#{@name}:loop", self) { run_loop }
       @thread = hijack ? hijack_current_thread : start_thread
 
       ExecutionContext.execution_contexts.push(self)
@@ -78,19 +83,12 @@ module Fiber::ExecutionContext
       thread.internal_name = @name
       thread.execution_context = self
       thread.scheduler = self
-      @main_fiber = Fiber.new("#{@name}:loop", self) { run_loop }
       thread
     end
 
     # Creates a new thread to initialize the scheduler.
     private def start_thread : Thread
-      Thread.new(name: @name) do |thread|
-        thread.execution_context = self
-        thread.scheduler = self
-        @main_fiber = thread.main_fiber
-        @main_fiber.name = "#{@name}:loop"
-        run_loop
-      end
+      ExecutionContext.thread_pool.checkout(self)
     end
 
     # :nodoc:

--- a/src/fiber/execution_context/single_threaded.cr
+++ b/src/fiber/execution_context/single_threaded.cr
@@ -105,7 +105,7 @@ module Fiber::ExecutionContext
         Crystal.trace :sched, "enqueue", fiber: fiber
         @runnables.push(fiber)
       else
-        # cross context enqueue
+        # cross context or detached thread enqueue
         Crystal.trace :sched, "enqueue", fiber: fiber, to_context: self
         @global_queue.push(fiber)
         wake_scheduler

--- a/src/fiber/execution_context/thread_pool.cr
+++ b/src/fiber/execution_context/thread_pool.cr
@@ -1,0 +1,205 @@
+class Fiber
+  module ExecutionContext
+    # How long a parked thread will be kept waiting in the thread pool.
+    # Defaults to 5 minutes.
+    def self.thread_keepalive : Time::Span
+      @@thread_keepalive ||= 5.minutes
+    end
+
+    def thread_keepalive=(@@thread_keepalive : Time::Span)
+    end
+
+    # :nodoc:
+    class ThreadPool
+      # :nodoc:
+      struct Parked
+        include Crystal::PointerLinkedList::Node
+
+        getter thread : Thread
+
+        def initialize(@thread : Thread)
+          @mutex = Thread::Mutex.new
+          @condition_variable = Thread::ConditionVariable.new
+        end
+
+        def synchronize(&)
+          @mutex.synchronize { yield }
+        end
+
+        def wake
+          @condition_variable.signal
+        end
+
+        def wait
+          @condition_variable.wait(@mutex)
+        end
+
+        def wait(timeout, &)
+          @condition_variable.wait(@mutex, timeout) { yield }
+        end
+
+        def linked?
+          !@previous.null?
+        end
+      end
+
+      def initialize
+        @mutex = Thread::Mutex.new
+        @condition_variable = Thread::ConditionVariable.new
+        @pool = Crystal::PointerLinkedList(Parked).new
+        @main_thread = Thread.current
+      end
+
+      protected def checkout(scheduler)
+        thread =
+          if parked = @mutex.synchronize { @pool.shift? }
+            parked.value.synchronize do
+              attach(parked.value.thread, scheduler)
+              parked.value.wake
+            end
+            parked.value.thread
+          else
+            # OPTIMIZE: start thread with minimum stack size
+            Thread.new do |thread|
+              attach(thread, scheduler)
+              enter_thread_loop(thread)
+            end
+          end
+        Crystal.trace :sched, "thread.checkout", thread: thread
+        thread
+      end
+
+      protected def attach(thread, scheduler) : Nil
+        thread.execution_context = scheduler.execution_context
+        thread.scheduler = scheduler
+        scheduler.thread = thread
+      end
+
+      protected def detach(thread) : Nil
+        thread.execution_context = nil
+        thread.scheduler = nil
+      end
+
+      protected def checkin : Nil
+        Crystal.trace :sched, "thread.checkin"
+        thread = Thread.current
+        detach(thread)
+
+        if thread == @main_thread
+          resume(main_thread_loop)
+        else
+          Thread.name = ""
+          resume(thread.main_fiber)
+        end
+      end
+
+      private def main_thread_loop
+        @main_thread_loop ||= begin
+          # OPTIMIZE: allocate minimum stack size
+          pointer = Crystal::System::Fiber.allocate_stack(StackPool::STACK_SIZE, protect: true)
+          stack = Stack.new(pointer, StackPool::STACK_SIZE, reusable: true)
+          Fiber.new(execution_context: ExecutionContext.default) { enter_thread_loop(@main_thread) }
+        end
+      end
+
+      # Each thread has a general loop, which is used to park the thread while
+      # it's in the thread pool. On startup then on wakeup it will resume the
+      # associated scheduler's main fiber, which itself is running the
+      # scheduler's run loop.
+      #
+      # Upon checkout the thread pool will merely resume the thread's main loop,
+      # leaving the scheduler's main fiber available for resume by another if
+      # needed, or left dead if the scheduler has shut down (e.g. isolated
+      # context).
+      private def enter_thread_loop(thread)
+        parked = Parked.new(thread)
+        parked.synchronize do
+          loop do
+            if scheduler = thread.scheduler?
+              unless thread == @main_thread
+                Thread.name = scheduler.name
+              end
+
+              resume(scheduler.main_fiber)
+
+              {% unless flag?(:interpreted) %}
+                if (stack = Thread.current.dead_fiber_stack?) && stack.reusable?
+                  # release pending fiber stack left after swapcontext; we don't
+                  # know which stack pool to return it to, and it may not even
+                  # have one (e.g. isolated fiber stack)
+                  Crystal::System::Fiber.free_stack(stack.pointer, stack.size)
+                end
+              {% end %}
+            end
+
+            @mutex.synchronize do
+              @pool.push pointerof(parked)
+            end
+
+            if thread == @main_thread
+              # never shutdown the main thread: the main fiber is running on
+              # its original stack, terminating the main thread would invalidate
+              # the main fiber stack (oops)
+              parked.wait
+            else
+              parked.wait(ExecutionContext.thread_keepalive) do
+                # reached timeout: try to shutdown thread, but another thread
+                # might dequeue from @pool in parallel: run checks to avoid any
+                # race condition:
+                if !thread.scheduler? && parked.linked?
+                  deleted = false
+
+                  @mutex.synchronize do
+                    if parked.linked?
+                      @pool.delete pointerof(parked)
+                      deleted = true
+                    end
+                  end
+
+                  if deleted
+                    # no attached scheduler and we removed ourselves from the
+                    # pool: we can safely shutdown (no races)
+                    Crystal.trace :sched, "thread.shutdown"
+                    return
+                  end
+
+                  # no attached scheduler but another thread removed ourselves
+                  # from the pool and is waiting to acquire parked.mutex to
+                  # handoff a scheduler: unsync so it can progress
+                  parked.wait
+                end
+              end
+            end
+          rescue exception
+            Crystal.trace :sched, "thread.exception",
+              class: exception.class.name,
+              message: exception.message
+
+            Crystal.print_error_buffered("BUG: %s#enter_thread_loop crashed",
+              self.class.name, exception: exception)
+          end
+        end
+      end
+
+      private def resume(fiber) : Nil
+        Crystal.trace :sched, "thread.resume", fiber: fiber
+
+        # FIXME: duplicates Fiber::ExecutionContext::MultiThreaded::Scheduler#resume:
+        attempts = 0
+        until fiber.resumable?
+          raise "BUG: tried to resume dead fiber #{fiber} (#{inspect})" if fiber.dead?
+          attempts = Thread.delay(attempts)
+        end
+
+        # FIXME: duplicates Fiber::ExecutionContext::Scheduler#swapcontext:
+        thread = Thread.current
+        current_fiber = thread.current_fiber
+
+        GC.lock_read
+        thread.current_fiber = fiber
+        Fiber.swapcontext(pointerof(current_fiber.@context), pointerof(fiber.@context))
+        GC.unlock_read
+      end
+    end
+  end
+end

--- a/src/fiber/stack.cr
+++ b/src/fiber/stack.cr
@@ -3,9 +3,16 @@ class Fiber
   struct Stack
     getter pointer : Void*
     getter bottom : Void*
+    getter size : Int32
     getter? reusable : Bool
 
-    def initialize(@pointer, @bottom, *, @reusable = false)
+    def initialize(@pointer : Void*, @bottom : Void*, *, @reusable = false)
+      # NOTE: sometimes gc/boehm reports weird stacks on linux (over 2GB)
+      @size = (@bottom - @pointer).to_i32!
+    end
+
+    def initialize(@pointer : Void*, @size : Int32, *, @reusable = false)
+      @bottom = @pointer + @size
     end
 
     def first_addressable_pointer : Void**

--- a/src/fiber/stack_pool.cr
+++ b/src/fiber/stack_pool.cr
@@ -56,7 +56,7 @@ class Fiber
         stack
       else
         pointer = Crystal::System::Fiber.allocate_stack(STACK_SIZE, @protect)
-        Stack.new(pointer, pointer + STACK_SIZE, reusable: true)
+        Stack.new(pointer, STACK_SIZE, reusable: true)
       end
     end
 


### PR DESCRIPTION
Introduces a pool of threads for execution contexts.

This changes the runtime behavior of threads: we no longer start a thread to run a specific scheduler run loop and never terminate in practice (except for the isolated context). Each thread now has its own inner loop that switches to a scheduler loop fiber (the scheduler's main fiber) then switches back to its inner loop (the thread's main fiber) to sleep for a while, then eventually terminates.

The benefit of the global thread loop is that threads are kept around instead of being created and thrown away. This is for example helpful for #15871 that will allow to move a scheduler to another thread, as well as for applications that regularly start an isolated fiber. They can keep reusing a pending thread instead of having to create one every time.

Threads still eventually terminate after some configurable inactive time, except for the main thread because we need to keep the main fiber's stack alive.

A future improvement could park MT threads back into the thread pool, instead of keeping them tied to the MT context. They could be reused by any context that needs parallelism, or to boot a new isolated fiber or ST context, instead of sitting around.

**NOTE**: the thread pool makes the min/max range in MT contexts kinda moot; it sounds better to settle to a maximum number of schedulers instead.

**NOTE**: the more we decouple schedulers from threads, the more I'm convinced that using "thread" in the execution context names doesn't make much sense; I'm strongly leaning to rename `SingleThreaded` to `Concurrent` and `MultiThreaded` to `Parallel`.

Extracted from #15871 