### PR TITLE
Support Windows system time zone transitions in all years

### DIFF
--- a/spec/std/time/location_spec.cr
+++ b/spec/std/time/location_spec.cr
@@ -300,7 +300,19 @@ class Time::Location
 
           with_system_time_zone(info) do
             location = Location.load_local
-            location.zones.should eq [Time::Location::Zone.new("CET", 3600, false), Time::Location::Zone.new("CEST", 7200, true)]
+            std_zone = Time::Location::Zone.new("CET", 3600, false)
+            dst_zone = Time::Location::Zone.new("CEST", 7200, true)
+            location.zones.should eq [std_zone, dst_zone]
+
+            location.lookup(Time.utc(2000, 10, 29, 0, 59, 59)).should eq(dst_zone)
+            location.lookup(Time.utc(2000, 10, 29, 1, 0, 0)).should eq(std_zone)
+            location.lookup(Time.utc(2001, 3, 25, 0, 59, 59)).should eq(std_zone)
+            location.lookup(Time.utc(2001, 3, 25, 1, 0, 0)).should eq(dst_zone)
+
+            location.lookup(Time.utc(3000, 10, 26, 0, 59, 59)).should eq(dst_zone)
+            location.lookup(Time.utc(3000, 10, 26, 1, 0, 0)).should eq(std_zone)
+            location.lookup(Time.utc(3001, 3, 29, 0, 59, 59)).should eq(std_zone)
+            location.lookup(Time.utc(3001, 3, 29, 1, 0, 0)).should eq(dst_zone)
           end
         end
 

--- a/src/crystal/system/win32/time.cr
+++ b/src/crystal/system/win32/time.cr
@@ -71,7 +71,7 @@ module Crystal::System::Time
 
   def self.load_localtime : ::Time::Location?
     if LibC.GetDynamicTimeZoneInformation(out info) != LibC::TIME_ZONE_ID_INVALID
-      windows_name = String.from_utf16(info.timeZoneKeyName.to_slice[0, info.timeZoneKeyName.index(0) || info.timeZoneKeyName.size])
+      windows_name = String.from_utf16(info.timeZoneKeyName.to_slice, truncate_at_null: true)
       initialize_location_from_TZI(pointerof(info).as(LibC::TIME_ZONE_INFORMATION*).value, "Local", windows_name)
     end
   end

--- a/src/time/tz.cr
+++ b/src/time/tz.cr
@@ -33,6 +33,7 @@ module Time::TZ
   end
 
   # `M*.*.*`: month-week-day, week 5 is last week
+  # also used for Windows system time zones (ignoring the millisecond component)
   record MonthWeekDay, month : Int8, week : Int8, day : Int8, time : Int32 do
     def always_jan1? : Bool
       false
@@ -44,6 +45,10 @@ module Time::TZ
 
     def unix_date_in_year(year : Int) : Int64
       Time.month_week_date(year, @month.to_i32, @week.to_i32, @day.to_i32, location: Time::Location::UTC).to_unix
+    end
+
+    def self.default : self
+      new(0, 0, 0, 0)
     end
   end
 
@@ -367,6 +372,64 @@ class Time::TZLocation < Time::Location
 
   private def lookup_posix_tz(unix_seconds : Int) : {Zone, {Int64, Int64}}
     zone, range = TZ.lookup(unix_seconds, @zones, @std_index, @dst_index, @transition1, @transition2)
+    range_begin, range_end = range
+
+    if last_transition = @transitions.last?
+      range_begin = {range_begin, last_transition.when}.max
+    end
+
+    {zone, {range_begin, range_end}}
+  end
+end
+
+# A time location capable of computing recurring time zone transitions in the
+# past or future using definitions from the Windows Registry.
+#
+# These locations are returned by `Time::Location.load`.
+class Time::WindowsLocation < Time::Location
+  # Two sets of transition rules for times before the first transition or after
+  # the last transition. Each corresponds to a `TZLocation`'s `@std_index`,
+  # `@dst_index`, `@transition1`, and `@transition2` fields. If there are no
+  # fixed transitions then the two sets are equal.
+  @past_tz_args : {Int32, Int32, TZ::MonthWeekDay, TZ::MonthWeekDay}
+  @future_tz_args : {Int32, Int32, TZ::MonthWeekDay, TZ::MonthWeekDay}
+
+  # The original Windows Registry key name for this location.
+  @key_name : String
+
+  def initialize(name : String, zones : Array(Zone), @key_name, @past_tz_args, @future_tz_args = past_tz_args, transitions = [] of ZoneTransition)
+    super(name, zones, transitions)
+  end
+
+  def_equals_and_hash name, zones, transitions, @key_name
+
+  # :nodoc:
+  def lookup_with_boundaries(unix_seconds : Int) : {Zone, {Int64, Int64}}
+    case
+    when zones.empty?
+      {Zone::UTC, {Int64::MIN, Int64::MAX}}
+    when transitions.empty?, unix_seconds < transitions.first.when
+      lookup_past(unix_seconds)
+    when unix_seconds >= transitions.last.when
+      lookup_future(unix_seconds)
+    else
+      lookup_within_fixed_transitions(unix_seconds)
+    end
+  end
+
+  private def lookup_past(unix_seconds : Int) : {Zone, {Int64, Int64}}
+    zone, range = TZ.lookup(unix_seconds, @zones, *@past_tz_args)
+    range_begin, range_end = range
+
+    if first_transition = @transitions.first?
+      range_end = {range_end, first_transition.when}.min
+    end
+
+    {zone, {range_begin, range_end}}
+  end
+
+  private def lookup_future(unix_seconds : Int) : {Zone, {Int64, Int64}}
+    zone, range = TZ.lookup(unix_seconds, @zones, *@future_tz_args)
     range_begin, range_end = range
 
     if last_transition = @transitions.last?


### PR DESCRIPTION
Adds a new `Time::WindowsLocation` class that handles month + week + day-of-week transitions both before the first fixed transition and after the last fixed transition. This eliminates the need to arbitrarily store 201 years' worth of fixed transitions in any Windows system time zone.

The side effect is that there are indeed no fixed transitions now, these will have to wait until #13518.