### PR TITLE
Add file name to file-private virtual types during codegen

### DIFF
--- a/src/compiler/crystal/codegen/match.cr
+++ b/src/compiler/crystal/codegen/match.cr
@@ -38,7 +38,7 @@ class Crystal::CodeGenVisitor
   end
 
   private def match_any_type_id_with_function(type, type_id)
-    match_fun_name = "~match<#{type}>"
+    match_fun_name = "~match<#{type.llvm_name}>"
     func = typed_fun?(@main_mod, match_fun_name) || create_match_fun(match_fun_name, type)
     func = check_main_fun match_fun_name, func
     call func, [type_id] of LLVM::Value

--- a/src/compiler/crystal/types.cr
+++ b/src/compiler/crystal/types.cr
@@ -3466,7 +3466,7 @@ module Crystal
     end
 
     def to_s_with_options(io : IO, skip_union_parens : Bool = false, generic_args : Bool = true, codegen : Bool = false) : Nil
-      base_type.to_s(io)
+      base_type.to_s_with_options(io, codegen: codegen)
       io << '+'
     end
 


### PR DESCRIPTION
This is exactly like #15505, but for `Crystal::VirtualType` and `VirtualMetaclassType`. Also ensures the `~match<...>` internal functions use these file names for proper dynamic dispatch. This discovery led to [this fixup in #15896](https://github.com/crystal-lang/crystal/pull/15896/commits/c7f6e0b604f6e6a8811588e48adb646d0b50d99e).

Of the remaining internal types, `GenericInstanceType`, `GenericClassInstanceMetaclassType`, and `GenericModuleInstanceMetaclassType` call `Type#to_s` directly inside their `#to_s_with_options` overloads, without forwarding the `codegen` parameter. Most likely they are also broken in some way.
