### PR TITLE
XML: modernize API when available & workaround issues with legacy versions

### DIFF
--- a/spec/std/xml/html_spec.cr
+++ b/spec/std/xml/html_spec.cr
@@ -60,7 +60,6 @@ describe XML do
   it "parses html5 (#1404)" do
     html5 = "<html><body><nav>Test</nav></body></html>"
     xml = XML.parse_html(html5)
-    xml.errors.should_not be_nil
     xml.xpath_node("//html/body/nav").should_not be_nil
   end
 

--- a/spec/std/xml/reader_spec.cr
+++ b/spec/std/xml/reader_spec.cr
@@ -567,15 +567,16 @@ module XML
         reader.to_unsafe.should be_a(LibXML::XMLTextReader)
       end
     end
-  end
 
-  describe "#errors" do
-    it "makes errors accessible" do
-      reader = XML::Reader.new(%(<people></foo>))
-      reader.read
-      reader.expand?
+    describe "#errors" do
+      it "makes errors accessible" do
+        options = XML::ParserOptions::RECOVER | XML::ParserOptions::NONET
+        reader = XML::Reader.new(%(<people></foo>), options)
+        reader.read
+        reader.expand?
 
-      reader.errors.map(&.to_s).should eq ["Opening and ending tag mismatch: people line 1 and foo"]
+        reader.errors.map(&.to_s).should eq ["Opening and ending tag mismatch: people line 1 and foo"]
+      end
     end
   end
 end

--- a/spec/std/xml/xml_spec.cr
+++ b/spec/std/xml/xml_spec.cr
@@ -159,7 +159,9 @@ describe XML do
   end
 
   it "#errors" do
-    xml = XML.parse(%(<people></foo>))
+    options = XML::ParserOptions::RECOVER | XML::ParserOptions::NONET
+
+    xml = XML.parse(%(<people></foo>), options)
     xml.root.not_nil!.name.should eq("people")
     xml.errors.try(&.map(&.to_s)).should eq ["Opening and ending tag mismatch: people line 1 and foo"]
 

--- a/src/xml.cr
+++ b/src/xml.cr
@@ -1,3 +1,5 @@
+require "./xml/libxml2"
+
 # The XML module allows parsing and generating [XML](https://www.w3.org/XML/) documents.
 #
 # NOTE: To use `XML`, you must explicitly import it with `require "xml"`
@@ -54,23 +56,20 @@ module XML
   # See `ParserOptions.default` for default options.
   def self.parse(string : String, options : ParserOptions = ParserOptions.default) : Node
     raise XML::Error.new("Document is empty", 0) if string.empty?
-    from_ptr { LibXML.xmlReadMemory(string, string.bytesize, nil, nil, options) }
+    ctxt = LibXML.xmlNewParserCtxt
+    from_ptr(ctxt) do
+      LibXML.xmlCtxtReadMemory(ctxt, string, string.bytesize, nil, nil, options)
+    end
   end
 
   # Parses an XML document from *io* with *options* into an `XML::Node`.
   #
   # See `ParserOptions.default` for default options.
   def self.parse(io : IO, options : ParserOptions = ParserOptions.default) : Node
-    from_ptr { LibXML.xmlReadIO(
-      ->(ctx, buffer, len) {
-        LibC::Int.new(Box(IO).unbox(ctx).read Slice.new(buffer, len))
-      },
-      ->(ctx) { 0 },
-      Box(IO).box(io),
-      nil,
-      nil,
-      options,
-    ) }
+    ctxt = LibXML.xmlNewParserCtxt
+    from_ptr(ctxt) do
+      LibXML.xmlCtxtReadIO(ctxt, ->read_callback, ->close_callback, Box(IO).box(io), nil, nil, options)
+    end
   end
 
   # Parses an HTML document from *string* with *options* into an `XML::Node`.
@@ -78,29 +77,46 @@ module XML
   # See `HTMLParserOptions.default` for default options.
   def self.parse_html(string : String, options : HTMLParserOptions = HTMLParserOptions.default) : Node
     raise XML::Error.new("Document is empty", 0) if string.empty?
-    from_ptr { LibXML.htmlReadMemory(string, string.bytesize, nil, "utf-8", options) }
+    ctxt = LibXML.htmlNewParserCtxt
+    from_ptr(ctxt) do
+      LibXML.htmlCtxtReadMemory(ctxt, string, string.bytesize, nil, "utf-8", options)
+    end
   end
 
   # Parses an HTML document from *io* with *options* into an `XML::Node`.
   #
   # See `HTMLParserOptions.default` for default options.
   def self.parse_html(io : IO, options : HTMLParserOptions = HTMLParserOptions.default) : Node
-    from_ptr { LibXML.htmlReadIO(
-      ->(ctx, buffer, len) {
-        LibC::Int.new(Box(IO).unbox(ctx).read Slice.new(buffer, len))
-      },
-      ->(ctx) { 0 },
-      Box(IO).box(io),
-      nil,
-      "utf-8",
-      options,
-    ) }
+    ctxt = LibXML.htmlNewParserCtxt
+    from_ptr(ctxt) do
+      LibXML.htmlCtxtReadIO(ctxt, ->read_callback, ->close_callback, Box(IO).box(io), nil, "utf-8", options)
+    end
   end
 
-  protected def self.from_ptr(& : -> LibXML::Doc*)
-    errors = [] of XML::Error
-    doc = XML::Error.collect(errors) { yield }
+  protected def self.read_callback(data : Void*, buffer : UInt8*, len : LibC::Int) : LibC::Int
+    io = Box(IO).unbox(data)
+    buf = Slice.new(buffer, len)
+    ret = {% if LibXML.has_method?(:xmlCtxtSetErrorHandler) %}
+            io.read(buf)
+          {% else %}
+            XML::Error.default_handlers { io.read(buf) }
+          {% end %}
+    LibC::Int.new(ret)
+  end
 
+  protected def self.close_callback(data : Void*) : LibC::Int
+    LibC::Int.new(0)
+  end
+
+  protected def self.from_ptr(ctxt, & : -> LibXML::Doc*)
+    errors = [] of XML::Error
+    doc =
+      {% if LibXML.has_method?(:xmlCtxtSetErrorHandler) %}
+        LibXML.xmlCtxtSetErrorHandler(ctxt, ->Error.structured_callback, Box.box(errors))
+        yield
+      {% else %}
+        XML::Error.unsafe_collect(errors) { yield }
+      {% end %}
     raise Error.new(LibXML.xmlGetLastError) unless doc
 
     Node.new(doc, errors)

--- a/src/xml/error.cr
+++ b/src/xml/error.cr
@@ -16,19 +16,89 @@ class XML::Error < Exception
     {% raise "`XML::Error.errors` was removed because it leaks memory when it's not used. XML errors are accessible directly in the respective context via `XML::Reader#errors` and `XML::Node#errors`.\nSee https://github.com/crystal-lang/crystal/issues/14934 for details. " %}
   end
 
-  def self.collect(errors, &)
-    LibXML.xmlSetStructuredErrorFunc Box.box(errors), ->(ctx, error) {
-      Box(Array(XML::Error)).unbox(ctx) << XML::Error.new(error)
-    }
+  protected def self.structured_callback(data : Void*, error : LibXML::Error*) : Nil
+    Box(Array(Error)).unbox(data) << Error.new(error)
+  end
+
+  protected def self.generic_callback(data : Void*, fmt : UInt8*) : Nil
+    message = String.new(fmt).chomp
+    Box(Array(Error)).unbox(data) << XML::Error.new(message, 0)
+  end
+
+  # Saves the global error handlers (and user data) for the current thread,
+  # replaces them with a custom handler to record reported XML errors in
+  # *errors*, and eventually restores the saved error handlers (and user data)
+  # before returning.
+  #
+  # Saves both structured + generic handlers because libxml < 2.13 use *both* in
+  # practice.
+  #
+  # NOTE: This is for internal compatibility with libxml < 2.13. Do not use.
+  protected def self.unsafe_collect(errors : Array(Error), &)
+    scontext = LibXML.__xmlStructuredErrorContext.value
+    shandler = LibXML.__xmlStructuredError.value
+
+    context = LibXML.__xmlGenericErrorContext.value
+    handler = LibXML.__xmlGenericError.value
+
+    LibXML.xmlSetStructuredErrorFunc(Box.box(errors), ->structured_callback)
+    LibXML.xmlSetGenericErrorFunc(Box.box(errors), ->generic_callback)
+
     begin
       yield
     ensure
-      LibXML.xmlSetStructuredErrorFunc nil, nil
+      # can't call xmlSetStructuredErrorFunc or xmlSetGenericErrorFunc: the
+      # compiler complains that it's passing a closure to C (it's not)
+      LibXML.__xmlStructuredErrorContext.value = scontext
+      LibXML.__xmlStructuredError.value = shandler
+
+      LibXML.__xmlGenericErrorContext.value = context
+      LibXML.__xmlGenericError.value = handler
     end
   end
 
+  # Saves the current global error handlers (and user data) and restore the
+  # default handlers for the duration of the block. Eventually restores the
+  # saved error handlers (and user data) before returning.
+  #
+  # Use this when a callback can potentially do a fiber context switch, for
+  # example IO operations.
+  #
+  # Saves both structured + generic handlers because libxml < 2.13 use *both* in
+  # practice.
+  #
+  # NOTE: This is for internal compatibility with libxml < 2.13. Do not use.
+  protected def self.default_handlers(&)
+    scontext = LibXML.__xmlStructuredErrorContext.value
+    shandler = LibXML.__xmlStructuredError.value
+
+    context = LibXML.__xmlGenericErrorContext.value
+    handler = LibXML.__xmlGenericError.value
+
+    LibXML.xmlSetStructuredErrorFunc(nil, nil)
+    LibXML.xmlSetGenericErrorFunc(nil, nil)
+
+    begin
+      yield
+    ensure
+      # can't call xmlSetStructuredErrorFunc or xmlSetGenericErrorFunc: the
+      # compiler complains that it's passing a closure to C (it's not)
+      LibXML.__xmlStructuredErrorContext.value = scontext
+      LibXML.__xmlStructuredError.value = shandler
+
+      LibXML.__xmlGenericErrorContext.value = context
+      LibXML.__xmlGenericError.value = handler
+    end
+  end
+
+  @[Deprecated("Legacy libxml2 API that mutate global state. Do not use.")]
+  def self.collect(errors, &)
+    unsafe_collect(errors) { yield }
+  end
+
+  @[Deprecated("Legacy libxml2 API that mutate global state. Do not use.")]
   def self.collect_generic(errors, &)
-    LibXML.xmlSetGenericErrorFunc Box.box(errors), ->(ctx, fmt) {
+    LibXML.xmlSetGenericErrorFunc Box.box(errors), ->(data, fmt) {
       # TODO: use va_start and va_end to
       message = String.new(fmt).chomp
       error = XML::Error.new(message, 0)
@@ -36,7 +106,7 @@ class XML::Error < Exception
       {% if flag?(:arm) || flag?(:aarch64) %}
         # libxml2 is likely missing ARM unwind tables (.ARM.extab and .ARM.exidx
         # sections) which prevent raising from a libxml2 context.
-        Box(Array(XML::Error)).unbox(ctx) << error
+        Box(Array(XML::Error)).unbox(data) << error
       {% else %}
         raise error
       {% end %}

--- a/src/xml/libxml2.cr
+++ b/src/xml/libxml2.cr
@@ -17,14 +17,17 @@ require "./save_options"
   {% end %}
 {% end %}
 lib LibXML
-   {% if (version = env("LIBXML_VERSION")) && (version.strip != "") %}
+  # The bindings default to libxml 2.9 that was released in 2012. We can safely
+  # assume at least this version is available everywhere.
+
+  {% if (version = env("LIBXML_VERSION")) && (version.strip != "") %}
      VERSION = {{env("LIBXML_VERSION")}}
    {% elsif !flag?(:win32) || flag?(:gnu) %}
-     VERSION = {{`pkg-config libxml-2.0 --silence-errors --modversion 2> /dev/null || echo 2.9.0`.strip.stringify}}
+     VERSION = {{`sh -c "pkg-config libxml-2.0 --silence-errors --modversion 2> /dev/null || echo 2.9.0"`.strip.stringify}}
    {% else %}
-     # TODO: figure out the actual libxml version on *-windows-msvc target
-     VERSION = "2.9.0"
-   {% end %}
+    # TODO: figure out the actual libxml version on *-windows-msvc target
+    VERSION = "2.9.0"
+  {% end %}
 
   alias Int = LibC::Int
 

--- a/src/xml/libxml2.cr
+++ b/src/xml/libxml2.cr
@@ -17,6 +17,15 @@ require "./save_options"
   {% end %}
 {% end %}
 lib LibXML
+   {% if (version = env("LIBXML_VERSION")) && (version.strip != "") %}
+     VERSION = {{env("LIBXML_VERSION")}}
+   {% elsif !flag?(:win32) || flag?(:gnu) %}
+     VERSION = {{`pkg-config libxml-2.0 --silence-errors --modversion 2> /dev/null || echo 2.9.0`.strip.stringify}}
+   {% else %}
+     # TODO: figure out the actual libxml version on *-windows-msvc target
+     VERSION = "2.9.0"
+   {% end %}
+
   alias Int = LibC::Int
 
   $xmlParserVersion : LibC::Char*
@@ -69,6 +78,8 @@ lib LibXML
     properties : Int
   end
 
+  alias HTMLDoc = Doc
+
   struct Attr
     include NodeCommon
     ns : NS*
@@ -96,6 +107,9 @@ lib LibXML
   alias InputBuffer = Void*
   alias XMLTextReader = Void*
   alias XMLTextReaderLocator = Void*
+
+  alias ParserCtxt = Void*
+  alias HTMLParserCtxt = ParserCtxt
 
   enum ParserSeverity
     VALIDITY_WARNING = 1
@@ -135,7 +149,6 @@ lib LibXML
 
   fun xmlTextReaderSetErrorHandler(reader : XMLTextReader, f : TextReaderErrorFunc) : Void
   fun xmlTextReaderSetStructuredErrorHandler(reader : XMLTextReader, f : StructuredErrorFunc, arg : Void*) : Void
-
   fun xmlTextReaderLocatorLineNumber(XMLTextReaderLocator) : Int
 
   fun xmlReadMemory(buffer : UInt8*, size : Int, url : UInt8*, encoding : UInt8*, options : XML::ParserOptions) : Doc*
@@ -146,6 +159,14 @@ lib LibXML
 
   fun xmlReadIO(ioread : InputReadCallback, ioclose : InputCloseCallback, ioctx : Void*, url : UInt8*, encoding : UInt8*, options : XML::ParserOptions) : Doc*
   fun htmlReadIO(ioread : InputReadCallback, ioclose : InputCloseCallback, ioctx : Void*, url : UInt8*, encoding : UInt8*, options : XML::HTMLParserOptions) : Doc*
+
+  fun xmlNewParserCtxt : ParserCtxt
+  fun xmlCtxtReadIO(ParserCtxt, ioread : InputReadCallback, ioclose : InputCloseCallback, ioctx : Void*, url : UInt8*, encoding : UInt8*, options : XML::ParserOptions) : Doc*
+  fun xmlCtxtReadMemory(ParserCtxt, buffer : UInt8*, size : Int, url : UInt8*, encoding : UInt8*, options : XML::ParserOptions) : Doc*
+
+  fun htmlNewParserCtxt : HTMLParserCtxt
+  fun htmlCtxtReadMemory(HTMLParserCtxt, buffer : UInt8*, size : Int, url : UInt8*, encoding : UInt8*, options : XML::HTMLParserOptions) : Doc*
+  fun htmlCtxtReadIO(HTMLParserCtxt, ioread : InputReadCallback, ioclose : InputCloseCallback, ioctx : Void*, url : UInt8*, encoding : UInt8*, options : XML::HTMLParserOptions) : Doc*
 
   fun xmlDocGetRootElement(doc : Doc*) : Node*
   fun xmlXPathNodeSetCreate(node : Node*) : NodeSet*
@@ -322,8 +343,15 @@ lib LibXML
   alias StructuredErrorFunc = (Void*, Error*) ->
   alias GenericErrorFunc = (Void*, UInt8*) ->
 
-  fun xmlSetStructuredErrorFunc(ctx : Void*, f : StructuredErrorFunc)
+  # deprecated
   fun xmlSetGenericErrorFunc(ctx : Void*, f : GenericErrorFunc)
+  fun __xmlGenericError : GenericErrorFunc*
+  fun __xmlGenericErrorContext : Void**
+
+  # deprecated since 2.13
+  fun xmlSetStructuredErrorFunc(ctx : Void*, f : StructuredErrorFunc)
+  fun __xmlStructuredError : StructuredErrorFunc*
+  fun __xmlStructuredErrorContext : Void**
 
   fun xmlGetNsList(doc : Doc*, node : Node*) : NS**
 
@@ -332,6 +360,15 @@ lib LibXML
   fun xmlUnsetProp(node : Node*, name : UInt8*) : Int
 
   fun xmlValidateNameValue(value : UInt8*) : Int
+
+  {% if compare_versions(LibXML::VERSION, "2.13.0") >= 0 %}
+    fun xmlCtxtSetErrorHandler(ctxt : ParserCtxt, handler : StructuredErrorFunc, data : Void*)
+    fun xmlXPathSetErrorHandler(ctxt : XPathContext*, handler : StructuredErrorFunc, data : Void*)
+  {% end %}
+
+  {% if compare_versions(LibXML::VERSION, "2.14.0") >= 0 %}
+    fun xmlSaveSetIndentString(SaveCtxPtr, UInt8*)
+  {% end %}
 end
 
 LibXML.xmlInitParser

--- a/src/xml/libxml2.cr
+++ b/src/xml/libxml2.cr
@@ -134,6 +134,7 @@ lib LibXML
   fun xmlTextReaderCurrentNode(reader : XMLTextReader) : Node*
 
   fun xmlTextReaderSetErrorHandler(reader : XMLTextReader, f : TextReaderErrorFunc) : Void
+  fun xmlTextReaderSetStructuredErrorHandler(reader : XMLTextReader, f : StructuredErrorFunc, arg : Void*) : Void
 
   fun xmlTextReaderLocatorLineNumber(XMLTextReaderLocator) : Int
 

--- a/src/xml/node.cr
+++ b/src/xml/node.cr
@@ -487,36 +487,66 @@ class XML::Node
     end
   end
 
-  # :nodoc:
-  SAVE_MUTEX = ::Mutex.new
-
   # Serialize this Node as XML to *io* using default options.
   #
   # See `XML::SaveOptions.xml_default` for default options.
   def to_xml(io : IO, indent = 2, indent_text = " ", options : SaveOptions = SaveOptions.xml_default)
-    # We need to use a mutex because we modify global libxml variables
-    SAVE_MUTEX.synchronize do
+    {% if LibXML.has_method?(:xmlSaveSetIndentString) %}
+      # indentation is now always enabled by default (it can be disabled per
+      # save context with the XML_SAVE_NO_INDENT option); the indent string is
+      # explicitly set on the save context (no more global default)
+      ctxt = LibXML.xmlSaveToIO(
+        ->Node.write_callback,
+        ->Node.close_callback,
+        Box(IO).box(io),
+        @node.value.doc.value.encoding,
+        options)
+      LibXML.xmlSaveSetIndentString(ctxt, indent_text * indent)
+      LibXML.xmlSaveTree(ctxt, self)
+      LibXML.xmlSaveClose(ctxt)
+    {% else %}
+      # indentation is disabled by default and it can only be enabled globally
+      # for the current thread (no per context value)
       XML.with_indent_tree_output(true) do
-        XML.with_tree_indent_string(indent_text * indent) do
-          save_ctx = LibXML.xmlSaveToIO(
-            ->(ctx, buffer, len) {
-              Box(IO).unbox(ctx).write_string Slice.new(buffer, len)
-              len
-            },
-            ->(ctx) {
-              Box(IO).unbox(ctx).flush
-              0
-            },
+        # the indent string will be copied to the save context... from the
+        # default thread local value; at least we can reset the thread local
+        # immediately after creating the save context
+        ctxt = XML.with_tree_indent_string(indent_text * indent) do
+          LibXML.xmlSaveToIO(
+            ->Node.write_callback,
+            ->Node.close_callback,
             Box(IO).box(io),
             @node.value.doc.value.encoding,
             options)
-          LibXML.xmlSaveTree(save_ctx, self)
-          LibXML.xmlSaveClose(save_ctx)
         end
+        LibXML.xmlSaveTree(ctxt, self)
+        LibXML.xmlSaveClose(ctxt)
       end
-    end
+    {% end %}
 
     io
+  end
+
+  protected def self.write_callback(data : Void*, buffer : UInt8*, len : LibC::Int) : LibC::Int
+    io = Box(IO).unbox(data)
+    buf = Slice.new(buffer, len)
+
+    {% if LibXML.has_method?(:xmlSaveSetIndentString) %}
+      io.write_string(buf)
+    {% else %}
+      XML.save_indent_tree_output { io.write_string(buf) }
+    {% end %}
+
+    len
+  end
+
+  protected def self.close_callback(data : Void*) : LibC::Int
+    {% if LibXML.has_method?(:xmlSaveSetIndentString) %}
+      Box(IO).unbox(data).flush
+    {% else %}
+      XML.save_indent_tree_output { Box(IO).unbox(data).flush }
+    {% end %}
+    LibC::Int.new(0)
   end
 
   # Returns underlying `LibXML::Node*` instance.

--- a/src/xml/node.cr
+++ b/src/xml/node.cr
@@ -541,11 +541,10 @@ class XML::Node
   end
 
   protected def self.close_callback(data : Void*) : LibC::Int
-    {% if LibXML.has_method?(:xmlSaveSetIndentString) %}
-      Box(IO).unbox(data).flush
-    {% else %}
-      XML.save_indent_tree_output { Box(IO).unbox(data).flush }
-    {% end %}
+    # no need to save the indent tree output thread local, even though we flush
+    # and the current fiber might swapcontext: libxml is closing the output and
+    # won't write to the IO anymore
+    Box(IO).unbox(data).flush
     LibC::Int.new(0)
   end
 

--- a/src/xml/reader.cr
+++ b/src/xml/reader.cr
@@ -31,9 +31,7 @@ class XML::Reader
   # See `XML::ParserOptions.default` for default options.
   def initialize(str : String, options : XML::ParserOptions = XML::ParserOptions.default)
     @reader = LibXML.xmlReaderForMemory(str, str.bytesize, nil, nil, options)
-    LibXML.xmlTextReaderSetStructuredErrorHandler(@reader, ->(_, error) {
-      raise Error.new(error)
-    }, nil)
+    LibXML.xmlTextReaderSetStructuredErrorHandler(@reader, ->Error.structured_callback, Box.box(@errors))
   end
 
   # Creates a new reader from an IO.
@@ -48,9 +46,7 @@ class XML::Reader
       nil,
       options
     )
-    LibXML.xmlTextReaderSetStructuredErrorHandler(@reader, ->(arg, error) {
-      Box(Array(XML::Error)).unbox(arg) << XML::Error.new(error)
-    }, Box.box(@errors))
+    LibXML.xmlTextReaderSetStructuredErrorHandler(@reader, ->Error.structured_callback, Box.box(@errors))
   end
 
   # Moves the reader to the next node.


### PR DESCRIPTION
Uses the libxml per context error handlers when available.

For example we can always use it for `XML::Reader` since it's available since at least libxml 2.9 (released in 2012), that becomes the default expected libxml version.

Sadly the other per context error handlers only appeared in libxml 2.13 (released in 2024) so we can't assume they exist, but can still use them when compiling against this version.

This patch adds a libxml version detection using `pkg-config`. We can specify the `LIBXML_VERSION` environment variable to target another release if the runtime version will be different (though it is highly recommended to use libxml 2.13+), or for the Windows MSVC target.

On older libxml releases, errors can be raised per context (e.g. xml reader) _and_ through the structured error handler (now deprecated) _and_ the older generic (long deprecated).

For these older releases, this patch still sets the globals (actually thread locals), be they error handlers or some xml save configuration, but saves them when the fiber might `yield`, restoring the default handlers; it eventually restores the globals when the fiber is resumed, so the current thread will see the values previously configured for the fiber, whatever if another fiber did something else, or the fiber got resumed by another thread (execution context).

~~NOTE: libxml 2.14 almost always segfaults during GC while running `spec/std/xml`, while the 2.9 to 2.13 releases are fine.~~ fixed in #15906.