### PR TITLE
Handle filenames being too long in `File.info?`

### DIFF
--- a/spec/std/http/server/handlers/static_file_handler_spec.cr
+++ b/spec/std/http/server/handlers/static_file_handler_spec.cr
@@ -34,6 +34,11 @@ describe HTTP::StaticFileHandler do
     File.delete(Path[datapath("static_file_handler"), Path.posix("back\\slash.txt")])
   end
 
+  it "handles long filenames" do
+    response = handle HTTP::Request.new("GET", "/#{"A" * 1_000}"), ignore_body: false
+    response.status_code.should eq 404
+  end
+
   it "adds Etag header" do
     response = handle HTTP::Request.new("GET", "/test.txt")
     response.headers["Etag"].should match(/W\/"\d+"$/)

--- a/src/crystal/system/unix/file.cr
+++ b/src/crystal/system/unix/file.cr
@@ -35,7 +35,7 @@ module Crystal::System::File
     if ret == 0
       ::File::Info.new(stat)
     else
-      if Errno.value.in?(Errno::ENOENT, Errno::ENOTDIR)
+      if Errno.value.in?(Errno::ENOENT, Errno::ENOTDIR, Errno::ENAMETOOLONG)
         nil
       else
         raise ::File::Error.from_errno("Unable to get file info", file: path)


### PR DESCRIPTION
I was originally going to solve #15901 a different way, but on a whim I decided to check the implementation of `File.info?` (invoked [here](https://github.com/crystal-lang/crystal/blob/21114e493cf4af83d361877192ee6e201d6808d6/src/http/server/handlers/static_file_handler.cr#L107)). If a filename is too long for the filesystem, it's a safe assumption that the file does not exist, which is what the line I modified appears to be checking for.

Fixes #15901