### PR TITLE
feat: allow taking `pointerof(self)` in structs

### DIFF
--- a/spec/compiler/parser/parser_spec.cr
+++ b/spec/compiler/parser/parser_spec.cr
@@ -2192,7 +2192,6 @@ module Crystal
     assert_syntax_error "case when .foo? then 1; end"
     assert_syntax_error "macro foo;{%end};end"
     assert_syntax_error "foo {1, 2}", %(unexpected token: ",")
-    assert_syntax_error "pointerof(self)", "can't take address of self"
     assert_syntax_error "def foo 1; end"
 
     assert_syntax_error %<{"x": [] of Int32,\n}\n1.foo(>, "unterminated call", 3, 6

--- a/src/compiler/crystal/semantic/main_visitor.cr
+++ b/src/compiler/crystal/semantic/main_visitor.cr
@@ -2599,6 +2599,14 @@ module Crystal
     def pointerof_var(node)
       case exp = node.exp
       when Var
+        if exp.name == "self"
+          exp.accept self
+
+          unless exp.type.struct?
+            node.raise "can only take address of self in struct"
+          end
+        end
+
         meta_var = @meta_vars[exp.name]
         meta_var.assigned_to = true
         meta_var

--- a/src/compiler/crystal/syntax/parser.cr
+++ b/src/compiler/crystal/syntax/parser.cr
@@ -5919,10 +5919,6 @@ module Crystal
       check :OP_LPAREN
       next_token_skip_space_or_newline
 
-      if @token.keyword?(:self)
-        raise "can't take address of self", @token.line_number, @token.column_number
-      end
-
       exp = parse_op_assign
       skip_space_or_newline
 


### PR DESCRIPTION
This MR allows taking `pointerof(self)` inside a struct instance.  
It only works for structs, there's an error message when attempting to take `pointerof(self)` inside a class or meta-class since it would be hard to define proper behavior for them.

This is already possible by defining a empty ivar at the beginning of the struct, this just makes it simpler and safer:
```cr
struct Foo
  # Before
  @beginning = uninitialized UInt8[0]
  def this : self*
    pointerof(@beginning).as(self*)
  end

  # After
  def this : self*
    pointerof(self)
  end
end
```

I think this MR might be a bit controversial, but since the change was so simple, I thought I'd just create the MR directly.

TODO:
- [ ] Add specs
- [ ] Test with interpreter
