### PR TITLE
Fix: thread specs must test `Thread`, not `Fiber::ExecutionContext::Isolated`

### DIFF
--- a/spec/std/thread/condition_variable_spec.cr
+++ b/spec/std/thread/condition_variable_spec.cr
@@ -8,7 +8,7 @@ pending_interpreted describe: Thread::ConditionVariable do
     cond = Thread::ConditionVariable.new
 
     mutex.synchronize do
-      new_thread do
+      Thread.new do
         mutex.synchronize { cond.signal }
       end
 
@@ -23,7 +23,7 @@ pending_interpreted describe: Thread::ConditionVariable do
     waiting = 0
 
     5.times do
-      new_thread do
+      Thread.new do
         mutex.synchronize do
           waiting += 1
           cv1.wait(mutex)
@@ -79,7 +79,7 @@ pending_interpreted describe: Thread::ConditionVariable do
     cond = Thread::ConditionVariable.new
 
     mutex.synchronize do
-      new_thread do
+      Thread.new do
         mutex.synchronize { cond.signal }
       end
 

--- a/spec/std/thread/mutex_spec.cr
+++ b/spec/std/thread/mutex_spec.cr
@@ -8,7 +8,7 @@ pending_interpreted describe: Thread::Mutex do
     mutex = Thread::Mutex.new
 
     threads = Array.new(10) do
-      new_thread do
+      Thread.new do
         mutex.synchronize { a += 1 }
       end
     end
@@ -23,7 +23,7 @@ pending_interpreted describe: Thread::Mutex do
     mutex.try_lock.should be_false
     expect_raises(RuntimeError) { mutex.lock }
     mutex.unlock
-    new_thread { mutex.synchronize { } }.join
+    Thread.new { mutex.synchronize { } }.join
   end
 
   it "won't unlock from another thread" do
@@ -31,7 +31,7 @@ pending_interpreted describe: Thread::Mutex do
     mutex.lock
 
     expect_raises(RuntimeError) do
-      new_thread { mutex.unlock }.join
+      Thread.new { mutex.unlock }.join
     end
 
     mutex.unlock

--- a/spec/std/thread_spec.cr
+++ b/spec/std/thread_spec.cr
@@ -5,13 +5,13 @@ require "../support/thread"
 pending_interpreted describe: Thread do
   it "allows passing an argumentless fun to execute" do
     a = 0
-    thread = new_thread { a = 1; 10 }
+    thread = Thread.new { a = 1; 10 }
     thread.join
     a.should eq(1)
   end
 
   it "raises inside thread and gets it on join" do
-    thread = new_thread { raise "OH NO" }
+    thread = Thread.new { raise "OH NO" }
     expect_raises Exception, "OH NO" do
       thread.join
     end
@@ -19,7 +19,7 @@ pending_interpreted describe: Thread do
 
   it "returns current thread object" do
     current = nil
-    thread = new_thread { current = Thread.current }
+    thread = Thread.new { current = Thread.current }
     thread.join
     current.should be(thread)
     current.should_not be(Thread.current)
@@ -32,7 +32,7 @@ pending_interpreted describe: Thread do
   it "yields the processor" do
     done = false
 
-    thread = new_thread do
+    thread = Thread.new do
       3.times { Thread.yield }
       done = true
     end
@@ -52,7 +52,7 @@ pending_interpreted describe: Thread do
     {% end %}
 
     name = nil
-    thread = new_thread(name: "some-name") do
+    thread = Thread.new(name: "some-name") do
       name = Thread.current.name
     end
     thread.name.should eq("some-name")


### PR DESCRIPTION
The intent is to test `Thread` and there's no need for an isolated context.

Fixes a couple issues when running the std specs that I only just noticed. For example `pthread_mutex_destroy` failing with EBUSY, or an exception not being re-raised (of course, we join the thread, but the exception got captured by the isolated context). The failures might have been introduced by a5fe0aef729c83d6a360feb23845f2d338c1a98c and 3c74705c8dc1bdd7c16eda41358f0ffa45497d44.