### PR TITLE
Improve docs for `Channel#close`

### DIFF
--- a/src/channel.cr
+++ b/src/channel.cr
@@ -95,7 +95,7 @@ class Channel(T)
   # If the channel has buffered values, then subsequent calls to `receive` will succeed
   # and consume the buffer until it is empty.
   #
-  # All fibers blocked in `send` or `receive` will be awakened with `Channel::ClosedError`
+  # All fibers blocked in `send` or `receive` will be awakened with `Channel::ClosedError`.
   # All subsequent calls to `#send` will consider the channel closed.
   # Subsequent calls to `#receive` will consider the channel closed if the buffer is empty.
   #

--- a/src/channel.cr
+++ b/src/channel.cr
@@ -90,11 +90,16 @@ class Channel(T)
   end
 
   # Closes the channel.
-  # The method prevents any new value from being sent to / received from the channel.
-  # All fibers blocked in `send` or `receive` will be awakened with `Channel::ClosedError`
+  # The method prevents any new value from being sent to the channel.
   #
-  # Both awaiting and subsequent calls to `#send` will consider the channel closed.
-  # All items successfully sent to the channel can be received, before `#receive` considers the channel closed.
+  # All fibers blocked in `send` or `receive` will be awakened with `Channel::ClosedError`
+  # All subsequent calls to `#send` will consider the channel closed.
+  # Subsequent non-blocking calls to `#receive` will succeed
+  # Subsequent blocking calls to `#receive` will consider the channel closed.
+  #
+  # If the channel has buffered values, then subsequent calls to `receive` will succeed
+  # to consume the 'pending' values until buffer is empty (until the `receive` call would block)
+  #
   # Calling `#close` on a closed channel does not have any effect.
   #
   # It returns `true` when the channel was successfully closed, or `false` if it was already closed.

--- a/src/channel.cr
+++ b/src/channel.cr
@@ -92,13 +92,13 @@ class Channel(T)
   # Closes the channel.
   # The method prevents any new value from being sent to the channel.
   #
-  # All fibers blocked in `send` or `receive` will be awakened with `Channel::ClosedError`
-  # All subsequent calls to `#send` will consider the channel closed.
-  # Subsequent non-blocking calls to `#receive` will succeed
-  # Subsequent blocking calls to `#receive` will consider the channel closed.
   #
   # If the channel has buffered values, then subsequent calls to `receive` will succeed
-  # to consume the 'pending' values until buffer is empty (until the `receive` call would block)
+  # and consume the buffer until it is empty.
+  #
+  # All fibers blocked in `send` or `receive` will be awakened with `Channel::ClosedError`
+  # All subsequent calls to `#send` will consider the channel closed.
+  # Subsequent calls to `#receive` will consider the channel closed if the buffer is empty.
   #
   # Calling `#close` on a closed channel does not have any effect.
   #

--- a/src/channel.cr
+++ b/src/channel.cr
@@ -92,7 +92,6 @@ class Channel(T)
   # Closes the channel.
   # The method prevents any new value from being sent to the channel.
   #
-  #
   # If the channel has buffered values, then subsequent calls to `receive` will succeed
   # and consume the buffer until it is empty.
   #


### PR DESCRIPTION
Improve `Channel#close` documentation to clarify the expected behavior when a `BufferedChannel` gets closed when there are buffered values pending to be consumed

I'm not super happy with the "If the channel has buffered values.." wording, but I'm pushing it as a starting point for discussing a better one 🙂 