### PR TITLE
Support `{% if; ...; end; ... %}` macro expressions

### DIFF
--- a/spec/compiler/parser/parser_spec.cr
+++ b/spec/compiler/parser/parser_spec.cr
@@ -1271,6 +1271,19 @@ module Crystal
     assert_syntax_error "{% unless 1; 2; elsif 3; 4; end %}"
     assert_syntax_error "{% unless 1 %} 2 {% elsif 3 %} 3 {% end %}"
 
+    it_parses "{% if 1; 2; end; %}", MacroExpression.new(If.new(1.int32, 2.int32), output: false)
+    it_parses "{% if 1; 2; end; 3 %}", MacroExpression.new(Expressions.new([If.new(1.int32, 2.int32), 3.int32]), output: false)
+    it_parses "{%\nif 1; 2; end; 3\n%}", MacroExpression.new(Expressions.new([If.new(1.int32, 2.int32), 3.int32]), output: false)
+    it_parses "{% 2 if 1; 3 %}", MacroExpression.new(Expressions.new([If.new(1.int32, 2.int32), 3.int32]), output: false)
+    it_parses "{%\n2 if 1; 3\n%}", MacroExpression.new(Expressions.new([If.new(1.int32, 2.int32), 3.int32]), output: false)
+    it_parses "{% if 1; 2; elsif 3; 4; else; 5; end; 6 %}", MacroExpression.new(Expressions.new([If.new(1.int32, 2.int32, If.new(3.int32, 4.int32, 5.int32)), 6.int32]), output: false)
+
+    it_parses "{% unless 1; 2; end; %}", MacroExpression.new(Unless.new(1.int32, 2.int32), output: false)
+    it_parses "{% unless 1; 2; end; 3 %}", MacroExpression.new(Expressions.new([Unless.new(1.int32, 2.int32), 3.int32]), output: false)
+    it_parses "{%\nunless 1; 2; end; 3\n%}", MacroExpression.new(Expressions.new([Unless.new(1.int32, 2.int32), 3.int32]), output: false)
+    it_parses "{% 2 unless 1; 3 %}", MacroExpression.new(Expressions.new([Unless.new(1.int32, 2.int32), 3.int32]), output: false)
+    it_parses "{%\n2 unless 1; 3\n%}", MacroExpression.new(Expressions.new([Unless.new(1.int32, 2.int32), 3.int32]), output: false)
+
     it_parses "{{ 1 // 2 }}", MacroExpression.new(Expressions.from([Call.new(1.int32, "//", 2.int32)] of ASTNode))
     it_parses "{{ //.options }}", MacroExpression.new(Expressions.from([Call.new(RegexLiteral.new(StringLiteral.new("")), "options")] of ASTNode))
 

--- a/spec/compiler/parser/to_s_spec.cr
+++ b/spec/compiler/parser/to_s_spec.cr
@@ -291,6 +291,25 @@ describe "ASTNode#to_s" do
   expect_to_s "{%\n  a = 1 %}"
   expect_to_s "{% a = 1\n%}"
 
+  expect_to_s <<-'CRYSTAL'
+    {%
+      if 1
+        2
+      end
+      3
+    %}
+    CRYSTAL
+
+  expect_to_s <<-'CRYSTAL'
+    {%
+      if 1
+        2
+      end
+      3
+      4
+    %}
+    CRYSTAL
+
   expect_to_s <<-'CR', <<-'CR'
     macro finished
       {% verbatim do %}

--- a/src/compiler/crystal/syntax/parser.cr
+++ b/src/compiler/crystal/syntax/parser.cr
@@ -3477,10 +3477,13 @@ module Crystal
         else
           node = parse_if_after_condition cond, location, true
         end
+        skip_statement_end
+        exps = parse_expressions
         @in_macro_expression = false
-        skip_space_or_newline
         check :OP_PERCENT_RCURLY
-        return MacroExpression.new(node, output: false).at_end(token_end_location)
+
+        exps = Expressions.concat!(node, exps)
+        return MacroExpression.new(exps, output: false).at_end(token_end_location)
       end
 
       check :OP_PERCENT_RCURLY


### PR DESCRIPTION
Follow-up to #14505. The following is already valid: (this is not a `MacroIf` node, but a `MacroExpression` node whose first sub-expression is an `If`, because the `if` is closed within the braces)

```crystal
{%
  2 if 1
  3
%}
```

This PR adds support for the equivalent with a non-trailing `if`:

```crystal
{%
  if 1
    2
  end
  3
%}
```

In fact, macro interpolation already transforms the former into the latter.

`Unless` also works the same way.