### PR TITLE
Support `elsif` when stringifying `If` nodes

### DIFF
--- a/spec/compiler/normalize/case_spec.cr
+++ b/spec/compiler/normalize/case_spec.cr
@@ -2,7 +2,7 @@ require "../../spec_helper"
 
 describe "Normalize: case" do
   it "normalizes case with call" do
-    assert_expand "case x; when 1; 'b'; when 2; 'c'; else; 'd'; end", "__temp_1 = x\nif 1 === __temp_1\n  'b'\nelse\n  if 2 === __temp_1\n    'c'\n  else\n    'd'\n  end\nend"
+    assert_expand "case x; when 1; 'b'; when 2; 'c'; else; 'd'; end", "__temp_1 = x\nif 1 === __temp_1\n  'b'\nelsif 2 === __temp_1\n  'c'\nelse\n  'd'\nend"
   end
 
   it "normalizes case with var in cond" do
@@ -62,11 +62,11 @@ describe "Normalize: case" do
   end
 
   it "normalizes case without value" do
-    assert_expand "case when 2; 3; when 4; 5; end", "if 2\n  3\nelse\n  if 4\n    5\n  end\nend"
+    assert_expand "case when 2; 3; when 4; 5; end", "if 2\n  3\nelsif 4\n  5\nend"
   end
 
   it "normalizes case without value with many expressions in when" do
-    assert_expand "case when 2, 9; 3; when 4; 5; end", "if 2 || 9\n  3\nelse\n  if 4\n    5\n  end\nend"
+    assert_expand "case when 2, 9; 3; when 4; 5; end", "if 2 || 9\n  3\nelsif 4\n  5\nend"
   end
 
   it "normalizes case with nil to is_a?" do

--- a/spec/compiler/parser/to_s_spec.cr
+++ b/spec/compiler/parser/to_s_spec.cr
@@ -229,6 +229,59 @@ describe "ASTNode#to_s" do
   expect_to_s %(begin\n  (@x = x).is_a?(Foo)\nend)
   expect_to_s %(begin\n  (1)\n  2\nend)
   expect_to_s %(if 1\n  begin\n    2\n  end\nelse\n  begin\n    3\n  end\nend)
+
+  expect_to_s <<-CRYSTAL
+    if 1
+      2
+    elsif 3
+      4
+    elsif 5
+    elsif 6
+    else
+      7
+    end
+    CRYSTAL
+
+  expect_to_s <<-CRYSTAL, <<-CRYSTAL
+    if 1
+      2
+    else
+      if 3
+      end
+    end
+    CRYSTAL
+    if 1
+      2
+    elsif 3
+    end
+    CRYSTAL
+
+  expect_to_s <<-CRYSTAL
+    if 1
+      2
+    else
+      unless 3
+      end
+    end
+    CRYSTAL
+
+  expect_to_s <<-CRYSTAL
+    if 1
+      2
+    else
+      3 ? 4 : 5
+    end
+    CRYSTAL
+
+  expect_to_s <<-CRYSTAL
+    unless 1
+      2
+    else
+      if 3
+      end
+    end
+    CRYSTAL
+
   expect_to_s %(foo do\n  begin\n    bar\n  end\nend)
   expect_to_s %q("\e\0\""), %q("\e\u0000\"")
   expect_to_s %q("#{1}\0"), %q("#{1}\u0000")


### PR DESCRIPTION
When an `If` node's else-clause is itself a non-ternary `If` node, combines the two nodes and emits an `elsif`, instead of an `else` plus an indented `if`. This is done even when the original nodes did not use an `elsif`, and applies to arbitrarily long `If` chains.