### PR TITLE
Stringify `MacroIf` `unless` nodes properly

### DIFF
--- a/spec/compiler/parser/to_s_spec.cr
+++ b/spec/compiler/parser/to_s_spec.cr
@@ -63,6 +63,8 @@ describe "ASTNode#to_s" do
   expect_to_s %({{ foo }})
   expect_to_s %({% if foo %}\n  foo_then\n{% end %})
   expect_to_s %({% if foo %}\n  foo_then\n{% else %}\n  foo_else\n{% end %})
+  expect_to_s %({% unless foo %}\n  foo_then\n{% end %})
+  expect_to_s %({% unless foo %}\n  foo_then\n{% else %}\n  foo_else\n{% end %})
   expect_to_s %({% for foo in bar %}\n  {{ foo }}\n{% end %})
   expect_to_s %(macro foo\n  {% for foo in bar %}\n    {{ foo }}\n  {% end %}\nend)
   expect_to_s %[1.as(Int32)]

--- a/src/compiler/crystal/syntax/to_s.cr
+++ b/src/compiler/crystal/syntax/to_s.cr
@@ -885,18 +885,29 @@ module Crystal
     end
 
     def visit(node : MacroIf)
-      @str << "{% if "
+      if node.is_unless?
+        @str << "{% unless "
+        then_node = node.else
+        else_node = node.then
+      else
+        @str << "{% if "
+        then_node = node.then
+        else_node = node.else
+      end
       node.cond.accept self
       @str << " %}"
+
       inside_macro do
-        node.then.accept self
+        then_node.accept self
       end
-      unless node.else.nop?
+
+      unless else_node.nop?
         @str << "{% else %}"
         inside_macro do
-          node.else.accept self
+          else_node.accept self
         end
       end
+
       @str << "{% end %}"
       false
     end


### PR DESCRIPTION
They now no longer transform to their equivalent `if` nodes.