### PR TITLE
Update library versions for MSVC CI

### DIFF
--- a/.github/workflows/win.yml
+++ b/.github/workflows/win.yml
@@ -10,7 +10,7 @@ concurrency:
 
 env:
   SPEC_SPLIT_DOTS: 160
-  CI_LLVM_VERSION: "19.1.7"
+  CI_LLVM_VERSION: "20.1.7"
   CI_LLVM_TARGETS: "X86,AArch64"
   CI_LLVM_LDFLAGS: "psapi.lib shell32.lib ole32.lib uuid.lib advapi32.lib ws2_32.lib ntdll.lib"
 
@@ -64,7 +64,7 @@ jobs:
         run: .\etc\win-ci\build-iconv.ps1 -BuildTree deps\iconv -Version 1.18
       - name: Build libffi
         if: steps.cache-libs.outputs.cache-hit != 'true'
-        run: .\etc\win-ci\build-ffi.ps1 -BuildTree deps\ffi -Version 3.4.7
+        run: .\etc\win-ci\build-ffi.ps1 -BuildTree deps\ffi -Version 3.5.1
       - name: Build zlib
         if: steps.cache-libs.outputs.cache-hit != 'true'
         run: .\etc\win-ci\build-z.ps1 -BuildTree deps\z -Version 1.3.1
@@ -76,7 +76,7 @@ jobs:
         run: .\etc\win-ci\build-yaml.ps1 -BuildTree deps\yaml -Version 0.2.5
       - name: Build libxml2
         if: steps.cache-libs.outputs.cache-hit != 'true'
-        run: .\etc\win-ci\build-xml2.ps1 -BuildTree deps\xml2 -Version 2.13.6
+        run: .\etc\win-ci\build-xml2.ps1 -BuildTree deps\xml2 -Version 2.13.8
 
       - name: Cache OpenSSL
         id: cache-openssl
@@ -92,7 +92,7 @@ jobs:
         uses: ilammy/setup-nasm@72793074d3c8cdda771dba85f6deafe00623038b # v1.5.2
       - name: Build OpenSSL
         if: steps.cache-openssl.outputs.cache-hit != 'true'
-        run: .\etc\win-ci\build-openssl.ps1 -BuildTree deps\openssl -Version 3.4.1
+        run: .\etc\win-ci\build-openssl.ps1 -BuildTree deps\openssl -Version 3.5.0
 
   x86_64-windows-dlls:
     runs-on: windows-2022
@@ -214,7 +214,7 @@ jobs:
     uses: ./.github/workflows/win_build_portable.yml
     with:
       release: true
-      llvm_version: "19.1.7"
+      llvm_version: "20.1.7"
       llvm_targets: "X86,AArch64"
       llvm_ldflags: "psapi.lib shell32.lib ole32.lib uuid.lib advapi32.lib ws2_32.lib ntdll.lib"
 


### PR DESCRIPTION
Updates the following libraries:

* libffi: 3.4.7 -> 3.5.1
* libxml2: 2.13.6 -> 2.13.8 (this is not 2.14 since it might be broken on Windows as well)
* OpenSSL: 3.4.1 -> 3.5.0
* LLVM: 19.1.7 -> 20.1.7