### PR TITLE
Optimize `Enum.parse?`, avoiding allocations

### DIFF
--- a/src/enum.cr
+++ b/src/enum.cr
@@ -519,7 +519,7 @@ abstract struct Enum
       # `string.gsub('-', '_').camelcase.downcase` but does not allocate.
       {% max_size = @type.constants.map(&.size).sort.last %}
       buffer = uninitialized UInt8[{{ max_size * 4 + 1 }}]
-      appender = buffer.to_slice.to_unsafe.appender
+      appender = buffer.to_unsafe.appender
       string.each_char_with_index do |char, index|
         return nil if index > {{max_size}}
         next if char == '-' || char == '_'


### PR DESCRIPTION
I noticed that `Enum.parse` allocates two separate strings via `tr` and `downcase`. I had a quick pass at optimizing it by comparing char-by-char, (edit: it has gone through several iterations after conversations in this PR). According to my benchmark, the current version performs no allocations and is anywhere from ~1.11-2.69x as fast~ 4.3-6x as fast for common cases and 18x as fast for pathological cases:

<details><summary>Benchmark code</summary>

```crystal
require "benchmark"

enum Status
  Enqueued
  InProgress
  Complete
  Incomplete
  Failed
  EPIC_FAIL
end

status = nil

# Quick function check
{
  Status::Enqueued   => %w[enqueued Enqueued],
  Status::InProgress => %w[inprogress InProgress inProgress in_progress in-progress],
  Status::Complete   => %w[complete Complete],
  Status::Incomplete => %w[incomplete Incomplete InComplete],
  Status::Failed     => %w[failed Failed],
  Status::EPIC_FAIL  => %w[epicfail EpicFail Epic_Fail EPIC_FAIL Epic-Fail],
  nil                => %w[EpicFailure EPIC_FAILURE Completed Incompleted Enqueue],
}.each do |status, strings|
  strings.each do |string|
    assert_parses(status, string) { Status.parse?(string) }
    assert_parses(status, string) { Status.parse_optimized?(string) }
    assert_parses(status, string) { Status.parse_optimized_yxhuvud?(string) }
    assert_parses(status, string) { Status.parse_stack_optimized?(string) }
  end
end

{
  Status::Enqueued   => %w[enqueued Enqueued],
  Status::InProgress => %w[inprogress InProgress inProgress in_progress in-progress],
  Status::Complete   => %w[complete Complete],
  Status::Incomplete => %w[incomplete Incomplete InComplete],
  Status::Failed     => %w[failed Failed],
  Status::EPIC_FAIL  => %w[epicfail EpicFail Epic_Fail EPIC_FAIL Epic-Fail],
  nil                => %w[NoMatch EpicFailure EPIC_FAILURE Completed Incompleted Enqueue] + ["-" * 50 + "Enqueued\u{1f602}"],
}.each do |status, strings|
  strings.each do |string|
    puts
    puts "Status.parse?(#{string.inspect}) # => #{status.inspect}"
    Benchmark.ips do |x|
      iterations = 1_000
      x.report "stdlib" { Status.parse? string }
      x.report "optimized jgaskins" { Status.parse_optimized? string }
      x.report "optimized yxhuvud" { Status.parse_optimized_yxhuvud? string }
      x.report "stdlib stack" { Status.parse_stack_optimized? string }
    end
  end
end

struct Enum
  def self.parse_optimized?(string : String)
    chars_to_skip = {'-', '_'}
    {% for member in @type.constants %}
      member_chars_skipped = 0i64
      string_chars_skipped = 0i64
      string_index = 0i64
      matched = true

      "{{member}}".each_char_with_index do |member_char, index|
        next unless matched

        if member_char.in? chars_to_skip
          member_chars_skipped &+= 1
          next
        end

        string_index = index - member_chars_skipped + string_chars_skipped
        while (string_char = string[string_index]?) && string_char.in?(chars_to_skip)
          string_chars_skipped &+= 1
          string_index = index - member_chars_skipped + string_chars_skipped
        end
        # If we went past the end of the input string, this member is not a match
        break if string_char.nil?

        if member_char.downcase != string_char.downcase
          matched = false
          break
        end
      end
      if matched && string_index == string.size &- 1
        return {{@type}}::{{member}}
      end
    {% end %}

    nil
  end

  def self.parse_stack_optimized?(string : String)
    return parse?(string) if string.bytesize > 100

    {% begin %}
      buffer = uninitialized UInt8[{{ @type.constants.map(&.size).sort.last * 4 + 1 }}]
      max_size = {{ @type.constants.map(&.size).sort.last }}
      appender = buffer.to_slice.to_unsafe.appender
      string.each_char_with_index do |char, index|
        return nil if index > max_size
        next if char == '-' || char == '_'
        char.downcase &.each_byte do |byte|
          appender << byte
        end
      end
      # Temporarily map all constants to their normalized value in order to
      # avoid duplicates in the `case` conditions.
      # `FOO` and `Foo` members would both generate `when "foo"` which creates a compile time error.
      # The first matching member is chosen, like with symbol autocasting.
      # That's different from the predicate methods which return true for the last matching member.
      {% constants = {} of _ => _ %}
      {% for member in @type.constants %}
        {% key = member.stringify.camelcase.downcase %}
        {% constants[key] = member unless constants[key] %}
      {% end %}

      case appender.to_slice
      {% for name, member in constants %}
        when {{name}}.to_slice
          new({{@type.constant(member)}})
      {% end %}
      else
        nil
      end
    {% end %}
  end

  def self.parse_optimized_yxhuvud?(string : String)
    {% for member in @type.constants %}
      return {{@type}}::{{member}} if parse_member_yxhuvud?(string, "{{member}}")
    {% end %}
    nil
  end

  private def self.parse_member_yxhuvud?(string, member)
    consumed_string_chars = 0

    member.each_char do |member_char|
      next if skip_yxhuvud?(member_char)

      while (string_char = string[consumed_string_chars]?) && skip_yxhuvud?(string_char)
        consumed_string_chars &+= 1
      end
      consumed_string_chars &+= 1

      # If we went past the end of the input string, this member is not a match
      return false if string_char.nil?
      return false if member_char.downcase != string_char.downcase
    end
    consumed_string_chars == string.size
  end

  private def self.skip_yxhuvud?(char)
    char == '_' || char == '-'
  end
end

def assert_parses(expected_status : Status?, input : String, &)
  result = yield
  unless result == expected_status
    raise "Expected to parse #{input.inspect} as #{expected_status.inspect}, got: #{result.inspect}"
  end
end
```

</details>

```

Status.parse?("enqueued") # => Status::Enqueued
            stdlib  21.17M ( 47.23ns) (± 0.57%)  160B/op   4.43× slower
optimized jgaskins  48.32M ( 20.69ns) (± 5.92%)  0.0B/op   1.94× slower
 optimized yxhuvud  52.46M ( 19.06ns) (± 6.29%)  0.0B/op   1.79× slower
      stdlib stack  93.75M ( 10.67ns) (± 2.04%)  0.0B/op        fastest

Status.parse?("Enqueued") # => Status::Enqueued
            stdlib  20.70M ( 48.31ns) (± 1.17%)  160B/op   4.64× slower
optimized jgaskins  47.57M ( 21.02ns) (± 5.89%)  0.0B/op   2.02× slower
 optimized yxhuvud  51.58M ( 19.39ns) (± 6.63%)  0.0B/op   1.86× slower
      stdlib stack  96.03M ( 10.41ns) (± 1.28%)  0.0B/op        fastest

Status.parse?("inprogress") # => Status::InProgress
            stdlib  18.57M ( 53.85ns) (± 0.56%)  160B/op   4.24× slower
optimized jgaskins  33.77M ( 29.61ns) (± 2.79%)  0.0B/op   2.33× slower
 optimized yxhuvud  37.46M ( 26.70ns) (± 5.72%)  0.0B/op   2.10× slower
      stdlib stack  78.71M ( 12.71ns) (± 0.79%)  0.0B/op        fastest

Status.parse?("InProgress") # => Status::InProgress
            stdlib  18.45M ( 54.21ns) (± 0.57%)  160B/op   4.47× slower
optimized jgaskins  33.52M ( 29.83ns) (± 2.00%)  0.0B/op   2.46× slower
 optimized yxhuvud  36.45M ( 27.44ns) (± 3.20%)  0.0B/op   2.26× slower
      stdlib stack  82.36M ( 12.14ns) (± 1.69%)  0.0B/op        fastest

Status.parse?("inProgress") # => Status::InProgress
            stdlib  18.30M ( 54.64ns) (± 1.09%)  160B/op   4.31× slower
optimized jgaskins  33.47M ( 29.88ns) (± 3.15%)  0.0B/op   2.36× slower
 optimized yxhuvud  36.26M ( 27.58ns) (± 5.13%)  0.0B/op   2.18× slower
      stdlib stack  78.91M ( 12.67ns) (± 1.99%)  0.0B/op        fastest

Status.parse?("in_progress") # => Status::InProgress
            stdlib  17.06M ( 58.60ns) (± 0.64%)  160B/op   4.39× slower
optimized jgaskins  32.78M ( 30.51ns) (± 2.62%)  0.0B/op   2.29× slower
 optimized yxhuvud  35.44M ( 28.22ns) (± 5.48%)  0.0B/op   2.11× slower
      stdlib stack  74.92M ( 13.35ns) (± 1.57%)  0.0B/op        fastest

Status.parse?("in-progress") # => Status::InProgress
            stdlib  15.43M ( 64.83ns) (± 0.63%)  192B/op   4.87× slower
optimized jgaskins  32.27M ( 30.99ns) (± 3.55%)  0.0B/op   2.33× slower
 optimized yxhuvud  33.94M ( 29.46ns) (± 4.96%)  0.0B/op   2.21× slower
      stdlib stack  75.16M ( 13.30ns) (± 0.93%)  0.0B/op        fastest

Status.parse?("complete") # => Status::Complete
            stdlib  20.11M ( 49.72ns) (± 0.51%)  160B/op   4.41× slower
optimized jgaskins  32.41M ( 30.86ns) (± 2.45%)  0.0B/op   2.74× slower
 optimized yxhuvud  34.38M ( 29.08ns) (±13.20%)  0.0B/op   2.58× slower
      stdlib stack  88.74M ( 11.27ns) (± 1.26%)  0.0B/op        fastest

Status.parse?("Complete") # => Status::Complete
            stdlib  20.09M ( 49.78ns) (± 0.48%)  160B/op   4.55× slower
optimized jgaskins  31.82M ( 31.43ns) (± 2.84%)  0.0B/op   2.87× slower
 optimized yxhuvud  33.41M ( 29.93ns) (±13.00%)  0.0B/op   2.74× slower
      stdlib stack  91.41M ( 10.94ns) (± 1.86%)  0.0B/op        fastest

Status.parse?("incomplete") # => Status::Incomplete
            stdlib  18.04M ( 55.42ns) (± 0.62%)  160B/op   4.17× slower
optimized jgaskins  23.00M ( 43.48ns) (± 4.92%)  0.0B/op   3.27× slower
 optimized yxhuvud  22.75M ( 43.96ns) (±12.49%)  0.0B/op   3.31× slower
      stdlib stack  75.19M ( 13.30ns) (± 0.69%)  0.0B/op        fastest

Status.parse?("Incomplete") # => Status::Incomplete
            stdlib  18.01M ( 55.51ns) (± 0.61%)  160B/op   4.25× slower
optimized jgaskins  23.45M ( 42.64ns) (± 3.59%)  0.0B/op   3.26× slower
 optimized yxhuvud  22.76M ( 43.93ns) (± 8.42%)  0.0B/op   3.36× slower
      stdlib stack  76.49M ( 13.07ns) (± 1.71%)  0.0B/op        fastest

Status.parse?("InComplete") # => Status::Incomplete
            stdlib  18.09M ( 55.28ns) (± 0.46%)  160B/op   4.42× slower
optimized jgaskins  22.87M ( 43.72ns) (± 3.97%)  0.0B/op   3.50× slower
 optimized yxhuvud  24.03M ( 41.62ns) (±11.86%)  0.0B/op   3.33× slower
      stdlib stack  79.95M ( 12.51ns) (± 2.93%)  0.0B/op        fastest

Status.parse?("failed") # => Status::Failed
            stdlib  21.72M ( 46.04ns) (± 0.73%)  160B/op   5.08× slower
optimized jgaskins  32.09M ( 31.17ns) (± 3.86%)  0.0B/op   3.44× slower
 optimized yxhuvud  32.87M ( 30.43ns) (±19.59%)  0.0B/op   3.36× slower
      stdlib stack 110.27M (  9.07ns) (± 1.51%)  0.0B/op        fastest

Status.parse?("Failed") # => Status::Failed
            stdlib  21.87M ( 45.72ns) (± 0.75%)  160B/op   5.14× slower
optimized jgaskins  32.16M ( 31.10ns) (± 2.22%)  0.0B/op   3.50× slower
 optimized yxhuvud  32.00M ( 31.25ns) (±17.90%)  0.0B/op   3.51× slower
      stdlib stack 112.47M (  8.89ns) (± 1.95%)  0.0B/op        fastest

Status.parse?("epicfail") # => Status::EPIC_FAIL
            stdlib  19.94M ( 50.16ns) (± 0.59%)  160B/op   4.44× slower
optimized jgaskins  23.32M ( 42.89ns) (± 3.31%)  0.0B/op   3.80× slower
 optimized yxhuvud  21.77M ( 45.93ns) (± 8.14%)  0.0B/op   4.06× slower
      stdlib stack  88.49M ( 11.30ns) (± 1.76%)  0.0B/op        fastest

Status.parse?("EpicFail") # => Status::EPIC_FAIL
            stdlib  19.47M ( 51.36ns) (± 8.09%)  160B/op   4.88× slower
optimized jgaskins  22.62M ( 44.20ns) (± 3.15%)  0.0B/op   4.20× slower
 optimized yxhuvud  21.67M ( 46.14ns) (± 8.26%)  0.0B/op   4.39× slower
      stdlib stack  95.08M ( 10.52ns) (± 2.48%)  0.0B/op        fastest

Status.parse?("Epic_Fail") # => Status::EPIC_FAIL
            stdlib  18.04M ( 55.44ns) (± 0.64%)  160B/op   5.36× slower
optimized jgaskins  22.26M ( 44.93ns) (± 1.99%)  0.0B/op   4.35× slower
 optimized yxhuvud  21.48M ( 46.56ns) (±10.35%)  0.0B/op   4.50× slower
      stdlib stack  96.75M ( 10.34ns) (± 3.20%)  0.0B/op        fastest

Status.parse?("EPIC_FAIL") # => Status::EPIC_FAIL
            stdlib  18.05M ( 55.41ns) (± 0.84%)  160B/op   6.05× slower
optimized jgaskins  22.71M ( 44.04ns) (± 1.11%)  0.0B/op   4.81× slower
 optimized yxhuvud  22.71M ( 44.03ns) (±11.05%)  0.0B/op   4.81× slower
      stdlib stack 109.21M (  9.16ns) (± 2.92%)  0.0B/op        fastest

Status.parse?("Epic-Fail") # => Status::EPIC_FAIL
            stdlib  16.35M ( 61.17ns) (± 0.66%)  192B/op   5.92× slower
optimized jgaskins  21.98M ( 45.50ns) (± 1.82%)  0.0B/op   4.40× slower
 optimized yxhuvud  20.31M ( 49.23ns) (±10.07%)  0.0B/op   4.77× slower
      stdlib stack  96.81M ( 10.33ns) (± 3.35%)  0.0B/op        fastest

Status.parse?("NoMatch") # => nil
            stdlib  20.33M ( 49.19ns) (± 0.48%)  160B/op   5.84× slower
optimized jgaskins  50.38M ( 19.85ns) (± 0.89%)  0.0B/op   2.36× slower
 optimized yxhuvud  44.19M ( 22.63ns) (±26.77%)  0.0B/op   2.69× slower
      stdlib stack 118.68M (  8.43ns) (± 3.37%)  0.0B/op        fastest

Status.parse?("EpicFailure") # => nil
            stdlib  17.09M ( 58.51ns) (± 0.56%)  160B/op   4.43× slower
optimized jgaskins  23.12M ( 43.26ns) (± 1.90%)  0.0B/op   3.28× slower
 optimized yxhuvud  21.24M ( 47.07ns) (±10.90%)  0.0B/op   3.56× slower
      stdlib stack  75.73M ( 13.20ns) (± 1.78%)  0.0B/op        fastest

Status.parse?("EPIC_FAILURE") # => nil
            stdlib  15.59M ( 64.15ns) (± 1.12%)  160B/op   6.06× slower
optimized jgaskins  22.64M ( 44.17ns) (± 1.71%)  0.0B/op   4.17× slower
 optimized yxhuvud  21.55M ( 46.40ns) (±10.91%)  0.0B/op   4.38× slower
      stdlib stack  94.47M ( 10.58ns) (± 5.36%)  0.0B/op        fastest

Status.parse?("Completed") # => nil
            stdlib  18.92M ( 52.84ns) (± 0.48%)  160B/op   4.50× slower
optimized jgaskins  24.63M ( 40.60ns) (± 2.89%)  0.0B/op   3.45× slower
 optimized yxhuvud  25.68M ( 38.94ns) (±17.04%)  0.0B/op   3.31× slower
      stdlib stack  85.10M ( 11.75ns) (± 1.88%)  0.0B/op        fastest

Status.parse?("Incompleted") # => nil
            stdlib  17.03M ( 58.71ns) (± 0.52%)  160B/op   4.38× slower
optimized jgaskins  20.41M ( 49.00ns) (± 3.91%)  0.0B/op   3.66× slower
 optimized yxhuvud  21.72M ( 46.05ns) (±16.13%)  0.0B/op   3.44× slower
      stdlib stack  74.68M ( 13.39ns) (± 1.60%)  0.0B/op        fastest

Status.parse?("Enqueue") # => nil
            stdlib  20.24M ( 49.40ns) (± 0.77%)  160B/op   5.20× slower
optimized jgaskins  25.00M ( 40.00ns) (± 6.26%)  0.0B/op   4.21× slower
 optimized yxhuvud  20.68M ( 48.36ns) (± 5.77%)  0.0B/op   5.09× slower
      stdlib stack 105.22M (  9.50ns) (± 2.04%)  0.0B/op        fastest

Status.parse?("--------------------------------------------------Enqueued😂") # => nil
            stdlib   6.14M (162.90ns) (± 1.31%)  416B/op   18.00× slower
optimized jgaskins 176.54k (  5.66µs) (± 2.97%)  0.0B/op  625.78× slower
 optimized yxhuvud 194.02k (  5.15µs) (± 2.64%)  0.0B/op  569.39× slower
      stdlib stack 110.48M (  9.05ns) (± 3.50%)  0.0B/op         fastest
```