### PR TITLE
Support `{% elsif %}` when stringifying `MacroIf` nodes

### DIFF
--- a/spec/compiler/parser/to_s_spec.cr
+++ b/spec/compiler/parser/to_s_spec.cr
@@ -284,6 +284,44 @@ describe "ASTNode#to_s" do
     end
     CRYSTAL
 
+  expect_to_s <<-'CRYSTAL'
+    {% if 1 %}
+      2
+    {% elsif 3 %}
+      4
+    {% elsif 5 %}
+    {% elsif 6 %}
+    {% else %}
+      7
+    {% end %}
+    CRYSTAL
+
+  expect_to_s <<-'CRYSTAL', <<-'CRYSTAL'
+    {% if 1 %}
+      2
+    {% else %}{% if 3 %}
+    {% end %}{% end %}
+    CRYSTAL
+    {% if 1 %}
+      2
+    {% elsif 3 %}
+    {% end %}
+    CRYSTAL
+
+  expect_to_s <<-'CRYSTAL'
+    {% if 1 %}
+      2
+    {% else %}{% unless 3 %}
+    {% end %}{% end %}
+    CRYSTAL
+
+  expect_to_s <<-'CRYSTAL'
+    {% unless 1 %}
+      2
+    {% else %}{% if 3 %}
+    {% end %}{% end %}
+    CRYSTAL
+
   expect_to_s %(foo do\n  begin\n    bar\n  end\nend)
   expect_to_s %q("\e\0\""), %q("\e\u0000\"")
   expect_to_s %q("#{1}\0"), %q("#{1}\u0000")

--- a/src/compiler/crystal/syntax/to_s.cr
+++ b/src/compiler/crystal/syntax/to_s.cr
@@ -924,8 +924,8 @@ module Crystal
         end
 
         # combine `{% else %}{% if %}` into `{% elsif %}` (does not apply to
-        # `{% unless %}`, nor when there is whitespace inbetween which as that
-        # would show up as a `MacroLiteral`)
+        # `{% unless %}`, nor when there is whitespace inbetween, as that would
+        # show up as a `MacroLiteral`)
         if !node.is_unless? && else_node.is_a?(MacroIf) && !else_node.is_unless?
           node = else_node
         else


### PR DESCRIPTION
Like #15918, but for macros.