### PR TITLE
File: let the event loop decide the blocking mode

### DIFF
--- a/spec/std/file_spec.cr
+++ b/spec/std/file_spec.cr
@@ -48,7 +48,7 @@ describe "File" do
     end
   end
 
-  {% if LibC.has_method?(:mkfifo) %}
+  {% if LibC.has_method?(:mkfifo) && !flag?(:darwin) %}
     # interpreter doesn't support threads yet (#14287)
     pending_interpreted "can read/write fifo file without blocking" do
       path = File.tempname("chardev")

--- a/src/crystal/event_loop/iocp.cr
+++ b/src/crystal/event_loop/iocp.cr
@@ -244,7 +244,7 @@ class Crystal::EventLoop::IOCP < Crystal::EventLoop
   end
 
   def open(path : String, flags : Int32, permissions : File::Permissions, blocking : Bool?) : {System::FileDescriptor::Handle, Bool} | WinError
-    access, disposition, attributes = System::File.posix_to_open_opts(flags, permissions, blocking)
+    access, disposition, attributes = System::File.posix_to_open_opts(flags, permissions, !!blocking)
 
     handle = LibC.CreateFileW(
       System.to_wstr(path),

--- a/src/crystal/event_loop/libevent.cr
+++ b/src/crystal/event_loop/libevent.cr
@@ -130,6 +130,12 @@ class Crystal::EventLoop::LibEvent < Crystal::EventLoop
     fd = LibC.open(path, flags | LibC::O_CLOEXEC, permissions)
     return Errno.value if fd == -1
 
+    {% if flag?(:darwin) %}
+      # FIXME: poll of non-blocking fifo fd on darwin appears to be broken, so
+      # we default to blocking for the time being
+      blocking = true if blocking.nil?
+    {% end %}
+
     System::FileDescriptor.set_blocking(fd, false) unless blocking
     {fd, !!blocking}
   end

--- a/src/crystal/event_loop/libevent.cr
+++ b/src/crystal/event_loop/libevent.cr
@@ -130,13 +130,8 @@ class Crystal::EventLoop::LibEvent < Crystal::EventLoop
     fd = LibC.open(path, flags | LibC::O_CLOEXEC, permissions)
     return Errno.value if fd == -1
 
-    blocking = !System::File.special_type?(fd) if blocking.nil?
-    unless blocking
-      status_flags = System::FileDescriptor.fcntl(fd, LibC::F_GETFL)
-      System::FileDescriptor.fcntl(fd, LibC::F_SETFL, status_flags | LibC::O_NONBLOCK)
-    end
-
-    {fd, blocking}
+    System::FileDescriptor.set_blocking(fd, false) unless blocking
+    {fd, !!blocking}
   end
 
   def read(file_descriptor : Crystal::System::FileDescriptor, slice : Bytes) : Int32

--- a/src/crystal/event_loop/polling.cr
+++ b/src/crystal/event_loop/polling.cr
@@ -176,6 +176,12 @@ abstract class Crystal::EventLoop::Polling < Crystal::EventLoop
     fd = LibC.open(path, flags | LibC::O_CLOEXEC, permissions)
     return Errno.value if fd == -1
 
+    {% if flag?(:darwin) %}
+      # FIXME: poll of non-blocking fifo fd on darwin appears to be broken, so
+      # we default to blocking for the time being
+      blocking = true if blocking.nil?
+    {% end %}
+
     System::FileDescriptor.set_blocking(fd, false) unless blocking
     {fd, !!blocking}
   end

--- a/src/crystal/event_loop/polling.cr
+++ b/src/crystal/event_loop/polling.cr
@@ -176,13 +176,8 @@ abstract class Crystal::EventLoop::Polling < Crystal::EventLoop
     fd = LibC.open(path, flags | LibC::O_CLOEXEC, permissions)
     return Errno.value if fd == -1
 
-    blocking = !System::File.special_type?(fd) if blocking.nil?
-    unless blocking
-      status_flags = System::FileDescriptor.fcntl(fd, LibC::F_GETFL)
-      System::FileDescriptor.fcntl(fd, LibC::F_SETFL, status_flags | LibC::O_NONBLOCK)
-    end
-
-    {fd, blocking}
+    System::FileDescriptor.set_blocking(fd, false) unless blocking
+    {fd, !!blocking}
   end
 
   def read(file_descriptor : System::FileDescriptor, slice : Bytes) : Int32

--- a/src/crystal/system/unix/file_descriptor.cr
+++ b/src/crystal/system/unix/file_descriptor.cr
@@ -24,14 +24,18 @@ module Crystal::System::FileDescriptor
   end
 
   private def system_blocking=(value)
-    current_flags = fcntl(LibC::F_GETFL)
+    FileDescriptor.set_blocking(fd, value)
+  end
+
+  protected def self.set_blocking(fd, value)
+    current_flags = fcntl(fd, LibC::F_GETFL)
     new_flags = current_flags
     if value
       new_flags &= ~LibC::O_NONBLOCK
     else
       new_flags |= LibC::O_NONBLOCK
     end
-    fcntl(LibC::F_SETFL, new_flags) unless new_flags == current_flags
+    fcntl(fd, LibC::F_SETFL, new_flags) unless new_flags == current_flags
   end
 
   protected def system_blocking_init(blocking : Bool?)

--- a/src/file.cr
+++ b/src/file.cr
@@ -164,7 +164,7 @@ class File < IO::FileDescriptor
   # change it anymore.
   #
   # NOTE: On macOS files are always opened in blocking mode because non-blocking
-  # FIFO files don't work —the OS exhibits issues with readiness notifications.
+  # FIFO files don't work — the OS exhibits issues with readiness notifications.
   def self.new(filename : Path | String, mode = "r", perm = DEFAULT_CREATE_PERMISSIONS, encoding = nil, invalid = nil, blocking = nil)
     filename = filename.to_s
     fd, blocking = Crystal::System::File.open(filename, mode, perm: perm, blocking: blocking)

--- a/src/file.cr
+++ b/src/file.cr
@@ -159,8 +159,12 @@ class File < IO::FileDescriptor
   # NOTE: The *blocking* arg is deprecated since Crystal 1.17. It used to be
   # true by default to denote a regular disk file (always ready in system event
   # loops) and could be set to false when the file was known to be a fifo, pipe,
-  # or character device (for example `/dev/tty`). Event loops now properly
-  # handle this and there are no reasons to change the blocking mode anymore.
+  # or character device (for example `/dev/tty`). The event loop now chooses
+  # the appropriate blocking mode automatically and there are no reasons to
+  # change it anymore.
+  #
+  # NOTE: On macOS files are always opened in blocking mode because non-blocking
+  # FIFO files don't work —the OS exhibits issues with readiness notifications.
   def self.new(filename : Path | String, mode = "r", perm = DEFAULT_CREATE_PERMISSIONS, encoding = nil, invalid = nil, blocking = nil)
     filename = filename.to_s
     fd, blocking = Crystal::System::File.open(filename, mode, perm: perm, blocking: blocking)

--- a/src/file.cr
+++ b/src/file.cr
@@ -128,7 +128,7 @@ class File < IO::FileDescriptor
   # This constructor is for constructors to be able to initialize a `File` with
   # a *path* and *fd*. The *blocking* param is informational and must reflect
   # the non/blocking state of the underlying fd.
-  private def initialize(@path, fd : Int, mode = "", blocking = true, encoding = nil, invalid = nil)
+  private def initialize(@path, fd : Int, mode = "", blocking = nil, encoding = nil, invalid = nil)
     super(handle: fd)
     system_init(mode, blocking)
     set_encoding(encoding, invalid: invalid) if encoding
@@ -156,19 +156,12 @@ class File < IO::FileDescriptor
   # Line endings are preserved on all platforms. The `b` mode flag has no
   # effect; it is provided only for POSIX compatibility.
   #
-  # *blocking* is set to `true` by default because system event queues (e.g.
-  # epoll, kqueue) will always report the file descriptor of regular disk files
-  # as ready.
-  #
-  # *blocking* must be set to `false` on POSIX targets when the file to open
-  # isn't a regular file but a character device (e.g. `/dev/tty`) or fifo. These
-  # files depend on another process or thread to also be reading or writing, and
-  # system event queues will properly report readiness.
-  #
-  # *blocking* may also be set to `nil` in which case the blocking or
-  # non-blocking flag will be determined automatically, at the expense of an
-  # additional syscall.
-  def self.new(filename : Path | String, mode = "r", perm = DEFAULT_CREATE_PERMISSIONS, encoding = nil, invalid = nil, blocking = true)
+  # NOTE: The *blocking* arg is deprecated since Crystal 1.17. It used to be
+  # true by default to denote a regular disk file (always ready in system event
+  # loops) and could be set to false when the file was known to be a fifo, pipe,
+  # or character device (for example `/dev/tty`). Event loops now properly
+  # handle this and there are no reasons to change the blocking mode anymore.
+  def self.new(filename : Path | String, mode = "r", perm = DEFAULT_CREATE_PERMISSIONS, encoding = nil, invalid = nil, blocking = nil)
     filename = filename.to_s
     fd, blocking = Crystal::System::File.open(filename, mode, perm: perm, blocking: blocking)
     new(filename, fd, mode, blocking, encoding, invalid)
@@ -505,7 +498,7 @@ class File < IO::FileDescriptor
   # permissions may be set using the *perm* parameter.
   #
   # See `self.new` for what *mode* can be.
-  def self.open(filename : Path | String, mode = "r", perm = DEFAULT_CREATE_PERMISSIONS, encoding = nil, invalid = nil, blocking = true) : self
+  def self.open(filename : Path | String, mode = "r", perm = DEFAULT_CREATE_PERMISSIONS, encoding = nil, invalid = nil, blocking = nil) : self
     new filename, mode, perm, encoding, invalid, blocking
   end
 
@@ -514,7 +507,7 @@ class File < IO::FileDescriptor
   # file as an argument, the file will be automatically closed when the block returns.
   #
   # See `self.new` for what *mode* can be.
-  def self.open(filename : Path | String, mode = "r", perm = DEFAULT_CREATE_PERMISSIONS, encoding = nil, invalid = nil, blocking = true, &)
+  def self.open(filename : Path | String, mode = "r", perm = DEFAULT_CREATE_PERMISSIONS, encoding = nil, invalid = nil, blocking = nil, &)
     file = new filename, mode, perm, encoding, invalid, blocking
     begin
       yield file
@@ -529,7 +522,7 @@ class File < IO::FileDescriptor
   # File.write("bar", "foo")
   # File.read("bar") # => "foo"
   # ```
-  def self.read(filename : Path | String, encoding = nil, invalid = nil, blocking = true) : String
+  def self.read(filename : Path | String, encoding = nil, invalid = nil, blocking = nil) : String
     open(filename, "r", blocking: blocking) do |file|
       if encoding
         file.set_encoding(encoding, invalid: invalid)
@@ -558,7 +551,7 @@ class File < IO::FileDescriptor
   # end
   # array # => ["foo", "bar"]
   # ```
-  def self.each_line(filename : Path | String, encoding = nil, invalid = nil, chomp = true, blocking = true, &)
+  def self.each_line(filename : Path | String, encoding = nil, invalid = nil, chomp = true, blocking = nil, &)
     open(filename, "r", encoding: encoding, invalid: invalid, blocking: blocking) do |file|
       file.each_line(chomp: chomp) do |line|
         yield line
@@ -572,7 +565,7 @@ class File < IO::FileDescriptor
   # File.write("foobar", "foo\nbar")
   # File.read_lines("foobar") # => ["foo", "bar"]
   # ```
-  def self.read_lines(filename : Path | String, encoding = nil, invalid = nil, chomp = true, blocking = true) : Array(String)
+  def self.read_lines(filename : Path | String, encoding = nil, invalid = nil, chomp = true, blocking = nil) : Array(String)
     lines = [] of String
     each_line(filename, encoding: encoding, invalid: invalid, chomp: chomp, blocking: blocking) do |line|
       lines << line
@@ -597,7 +590,7 @@ class File < IO::FileDescriptor
   # (the result of invoking `to_s` on *content*).
   #
   # See `self.new` for what *mode* can be.
-  def self.write(filename : Path | String, content, perm = DEFAULT_CREATE_PERMISSIONS, encoding = nil, invalid = nil, mode = "w", blocking = true)
+  def self.write(filename : Path | String, content, perm = DEFAULT_CREATE_PERMISSIONS, encoding = nil, invalid = nil, mode = "w", blocking = nil)
     open(filename, mode, perm, encoding: encoding, invalid: invalid, blocking: blocking) do |file|
       case content
       when Bytes


### PR DESCRIPTION
This is the last missing bit from #15685.

The difference with the PoC is that opening a pipe, fifo or chardev file will still block until another thread of process has also opened the file. This was separately extracted in #15768 and obsoleted by #15871 that provides a reusable solution, leading the `blocking` arg to no longer have any purpose.

- The `blocking` args of File constructors now default to `nil` to let the event loops decide how to configure the fd / handle.

- The polling evloops now set the fd to non blocking by default. There's no downside for regular disk files to have `O_NONBLOCK` set (the OS overlooks it) while not having it for other the kinds of file is an issue (it blocks).

  **Errata**: on macOS the polling evloops set the fd to blocking because polling a non-blocking fifo seems incorrect (at the OS level).

- The IOCP evloop uses OVERLAPPED IO by default. Reading and writing files is now fully async on Windows :tada: