### PR TITLE
Resolve aliases in `YAML::Any`

### DIFF
--- a/spec/std/yaml/any_spec.cr
+++ b/spec/std/yaml/any_spec.cr
@@ -253,6 +253,25 @@ describe YAML::Any do
       end
     end
 
+    it "splats anchor" do
+      value = YAML::Any.from_yaml <<-YAML
+      map: &an
+        inner: 4
+      aliased: *an
+      splatted:
+        <<: *an
+        extra: 5
+      YAML
+      h = value["splatted"].as_h
+      h.keys.should eq(["inner", "extra"])
+      h["inner"].should eq(4)
+      h["extra"].should eq(5)
+
+      h = value["aliased"].as_h
+      h.keys.should eq(["inner"])
+      h["inner"].should eq(4)
+    end
+
     it "gets yes/no unquoted booleans" do
       YAML.parse("yes").as_bool.should be_true
       YAML.parse("no").as_bool.should be_false

--- a/src/yaml/any.cr
+++ b/src/yaml/any.cr
@@ -44,7 +44,19 @@ struct YAML::Any
       hash = {} of YAML::Any => YAML::Any
 
       node.each do |key, value|
-        hash[new(ctx, key)] = new(ctx, value)
+        if value.is_a?(YAML::Nodes::Alias) && key.is_a?(YAML::Nodes::Scalar) && key.value == "<<"
+          unless target_value = value.value
+            raise "YAML::Nodes::Alias misses anchor value"
+          end
+          any_alias = new(ctx, target_value)
+          if aliased_hash = any_alias.as_h?
+            hash.merge!(aliased_hash)
+          else
+            hash[new(ctx, key)] = any_alias
+          end
+        else
+          hash[new(ctx, key)] = new(ctx, value)
+        end
       end
 
       new hash


### PR DESCRIPTION
Fixes #15937 where `YAML::Any` will not correctly merge aliases into maps.

This file is parsed correctly:

```yaml
hello: &single_alias world
single: *single_alias

map: &map_alias
  foo: bar
splatted: *map_alias
modified:
  <<: *map_alias
  food: bark
nonsense:
  <<: *single_alias
```

With this patch the result is:

```yaml
hello: world
single: world
map:
  foo: bar
splatted:
  foo: bar
modified:
  foo: bar
  food: bark
nonsense:
  <<: world
```

With 1.16.3 the result is:

```yaml
hello: world
single: world
map:
  foo: bar
splatted:
  foo: bar
modified:
  <<:
    foo: bar
  food: bark
nonsense:
  <<: world
```

(note the `<<` submessage in `modified` that should have been splatted into the outer map).

I'm not sure if this is the best way to fix the issue, I don't really have a good understanding of how all the YAML parsing fits together, so I could totally be putting an inappropriate bandaid on this.