### PR TITLE
Fix unclosed codeblock in `__crystal_pseudo_alignof` docs

### DIFF
--- a/src/docs_pseudo_methods.cr
+++ b/src/docs_pseudo_methods.cr
@@ -76,6 +76,7 @@ end
 # alignof(Int32)        # => 4
 # alignof(Float64)      # usually 4 or 8
 # alignof(typeof(true)) # => 1
+# ```
 #
 # For `Reference` types, the alignment is the same as the alignment of a pointer:
 #


### PR DESCRIPTION
A codeblock wasn't properly closed in the doc comments for `__crystal_pseudo_alignof` causing markdown issues.

![image showing the markdown rendering problems caused by an unclosed codeblock](https://github.com/user-attachments/assets/43275b12-a507-4580-83ad-719e0d591b85)


https://crystal-lang.org/api/1.16.3/toplevel.html#alignof%28type%3AClass%29%3AInt32-class-method