### PR TITLE
Add location info to `MacroVar` nodes

### DIFF
--- a/spec/compiler/crystal/tools/macro_code_coverage_spec.cr
+++ b/spec/compiler/crystal/tools/macro_code_coverage_spec.cr
@@ -1013,4 +1013,17 @@ describe "macro_code_coverage" do
     default Int32
     default Int32?
     CR
+
+  assert_coverage <<-'CR', {2 => 2, 3 => 1, 5 => 1}
+    macro test(val)
+      {% if val == 1 %}
+        %a = {{val.id}}
+      {% else %}
+        %a = {{val.id}}
+      {% end %}
+    end
+
+    test 1
+    test 2
+    CR
 end

--- a/src/compiler/crystal/syntax/parser.cr
+++ b/src/compiler/crystal/syntax/parser.cr
@@ -3257,12 +3257,13 @@ module Crystal
           end
         when .macro_var?
           macro_var_name = @token.value.to_s
+          location = @token.location
           if current_char == '{'
             macro_var_exps = parse_macro_var_exps
           else
             macro_var_exps = nil
           end
-          pieces << MacroVar.new(macro_var_name, macro_var_exps)
+          pieces << MacroVar.new(macro_var_name, macro_var_exps).at(location).at_end(token_end_location)
         when .macro_end?
           break
         when .eof?


### PR DESCRIPTION
This manifested itself as:

```cr
macro test(val)
  {% if val == 1 %}
    %a = {{val.id}}
  {% else %}
    %a = {{val.id}}
  {% end %}
end

test 1
test 2
```

having reported coverage of:

```json
{
  "coverage": {
    "test.cr": {
      "2": 1,
      "3": 1,
      "4": 0,
      "5": 1
    }
  }
}
```