### PR TITLE
Add `Time::Location.from_json_object_key`

### DIFF
--- a/spec/std/json/serialization_spec.cr
+++ b/spec/std/json/serialization_spec.cr
@@ -41,6 +41,11 @@ describe "JSON serialization" do
       Hash(Path, String).from_json(%({"foo/bar": "baz"})).should eq({Path.new("foo/bar") => "baz"})
     end
 
+    it "does Time::Location.from_json_object_key" do
+      Hash(Time::Location, String).from_json(%({"UTC": "foo"}))
+        .should eq({Time::Location::UTC => "foo"})
+    end
+
     {% for int in BUILTIN_INTEGER_TYPES %}
       it "does {{ int }}.from_json" do
         {{ int }}.from_json("0").should(be_a({{ int }})).should eq(0)

--- a/src/json/from_json.cr
+++ b/src/json/from_json.cr
@@ -482,6 +482,10 @@ def Time::Location.new(pull : JSON::PullParser)
   load(pull.read_string)
 end
 
+def Time::Location.from_json_object_key?(key : String) : Time::Location
+  load(key)
+end
+
 struct Time::Format
   def from_json(pull : JSON::PullParser) : Time
     string = pull.read_string


### PR DESCRIPTION
Allows `Time::Location` to be deserialized as a JSON object key.