### PR TITLE
Add `fail-fast: false` for strategy CI jobs

### DIFF
--- a/.github/workflows/interpreter.yml
+++ b/.github/workflows/interpreter.yml
@@ -49,6 +49,7 @@ jobs:
     strategy:
       matrix:
         part: [0, 1, 2, 3]
+    fail-fast: false
     name: "Test std_spec with interpreter (${{ matrix.part }})"
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -23,6 +23,7 @@ jobs:
           arch: x86_64-darwin
         - runs-on: macos-14
           arch: aarch64-darwin
+    fail-fast: false
     steps:
       - name: Download Crystal source
         uses: actions/checkout@v4


### PR DESCRIPTION
We want all parallel jobs to run completely, not abort as soon as one of the strategies fails.