### PR TITLE
Make crystal log resilient to empty LOG_LEVEL env var

### DIFF
--- a/spec/std/log/env_config_spec.cr
+++ b/spec/std/log/env_config_spec.cr
@@ -53,6 +53,24 @@ describe "Log.setup_from_env" do
       end
     end
 
+    it "is used if LOG_LEVEL is empty" do
+      with_env "LOG_LEVEL": "" do
+        builder = Log::Builder.new
+        Log.setup_from_env(builder: builder)
+
+        builder.for("").initial_level.should eq(s(:info))
+      end
+    end
+
+    it "is used if LOG_LEVEL is just whitespace" do
+      with_env "LOG_LEVEL": "  " do
+        builder = Log::Builder.new
+        Log.setup_from_env(builder: builder)
+
+        builder.for("").initial_level.should eq(s(:info))
+      end
+    end
+
     it "is not used if LOG_LEVEL is set" do
       with_env "LOG_LEVEL": "DEBUG" do
         builder = Log::Builder.new

--- a/src/log/setup.cr
+++ b/src/log/setup.cr
@@ -32,7 +32,7 @@ class Log
                           default_sources = "*",
                           log_level_env = "LOG_LEVEL",
                           backend = Log::IOBackend.new)
-    level = ENV[log_level_env]?.try { |v| Log::Severity.parse(v) } || default_level
+    level = ENV[log_level_env]?.nil? || ENV[log_level_env].lstrip.empty? ? default_level : Log::Severity.parse(ENV[log_level_env])
 
     Log.setup(default_sources, level, backend, builder: builder)
   end


### PR DESCRIPTION
Before these changes, if the user sets `LOG_LEVEL=""` or LOG_LEVEL="  "`, crystal app would fail on runtime with `Unknown enum Log::Severity value:  (ArgumentError)`

I hit this error by configuring `LOG_LEVEL= ` in a `.env` file by mistake - I had a space right after the `=`

I feel Crystal can handle this better and use the default value in this scenario instead - but perhaps this was intentionally left out. If that's the case, feel free to dismiss and close this PR