### PR TITLE
Improve OpenSSL::Cipher docs

### DIFF
--- a/src/openssl/cipher.cr
+++ b/src/openssl/cipher.cr
@@ -42,7 +42,7 @@ require "openssl"
 # key = Random::Secure.random_bytes(64) # You can also use OpenSSL::Cipher#random_key to do this same thing
 # iv = Random::Secure.random_bytes(32)  # You can also use OpenSSL::Cipher#random_iv to do this same thing
 #
-# encrypted_data = encrypt("Encrypted", key, iv) # => Bytes[95, 182, 21, 86, 193, 155, 149, 164, 82, 102, 171, 182, 56, 153, 223, 33]
+# encrypted_data = encrypt("Encrypted", key, iv)    # => Bytes[95, 182, 21, 86, 193, 155, 149, 164, 82, 102, 171, 182, 56, 153, 223, 33]
 # decrypted_data = decrypt(encrypted_data, key, iv) # => "Encrypted"
 # ```
 class OpenSSL::Cipher

--- a/src/openssl/cipher.cr
+++ b/src/openssl/cipher.cr
@@ -11,9 +11,6 @@ require "openssl"
 # require "random/secure"
 # require "openssl"
 #
-# key = Random::Secure.random_bytes(64) # You can also use OpenSSL::Cipher#random_key to do this same thing
-# iv = Random::Secure.random_bytes(32)  # You can also use OpenSSL::Cipher#random_iv to do this same thing
-#
 # def encrypt(data, key, iv)
 #   cipher = OpenSSL::Cipher.new("aes-256-cbc")
 #   cipher.encrypt
@@ -41,6 +38,9 @@ require "openssl"
 #
 #   io.gets_to_end
 # end
+#
+# key = Random::Secure.random_bytes(64) # You can also use OpenSSL::Cipher#random_key to do this same thing
+# iv = Random::Secure.random_bytes(32)  # You can also use OpenSSL::Cipher#random_iv to do this same thing
 #
 # encrypted_data = encrypt("Encrypted", key, iv) # => Bytes[95, 182, 21, 86, 193, 155, 149, 164, 82, 102, 171, 182, 56, 153, 223, 33]
 # decrypted_data = decrypt(encrypted_data, key, iv) # => "Encrypted"

--- a/src/openssl/cipher.cr
+++ b/src/openssl/cipher.cr
@@ -41,6 +41,9 @@ require "openssl"
 #
 #   io.gets_to_end
 # end
+#
+# encrypted_data = encrypt("Encrypted", key, iv) # => Bytes[95, 182, 21, 86, 193, 155, 149, 164, 82, 102, 171, 182, 56, 153, 223, 33]
+# decrypted_data = decrypt(encrypted_data, key, iv) # => "Encrypted"
 # ```
 class OpenSSL::Cipher
   class Error < OpenSSL::Error

--- a/src/openssl/cipher.cr
+++ b/src/openssl/cipher.cr
@@ -14,7 +14,7 @@ require "openssl"
 # key = Random::Secure.random_bytes(64) # You can also use OpenSSL::Cipher#random_key to do this same thing
 # iv = Random::Secure.random_bytes(32)  # You can also use OpenSSL::Cipher#random_iv to do this same thing
 #
-# def encrypt(data)
+# def encrypt(data, key, iv)
 #   cipher = OpenSSL::Cipher.new("aes-256-cbc")
 #   cipher.encrypt
 #   cipher.key = key
@@ -28,7 +28,7 @@ require "openssl"
 #   io.to_slice
 # end
 #
-# def decrypt(data)
+# def decrypt(data, key, iv)
 #   cipher = OpenSSL::Cipher.new("aes-256-cbc")
 #   cipher.decrypt
 #   cipher.key = key

--- a/src/openssl/cipher.cr
+++ b/src/openssl/cipher.cr
@@ -9,6 +9,7 @@ require "openssl"
 #
 # ```
 # require "random/secure"
+# require "openssl"
 #
 # key = Random::Secure.random_bytes(64) # You can also use OpenSSL::Cipher#random_key to do this same thing
 # iv = Random::Secure.random_bytes(32)  # You can also use OpenSSL::Cipher#random_iv to do this same thing


### PR DESCRIPTION
When playing with the encryption example provided by https://crystal-lang.org/api/master/OpenSSL/Cipher.html, it didn't work by default. This add a functional example for encryption and decryption.

Details of the changes are on the commit comments.