### PR TITLE
Use canonical IANA name for the local Windows system time zone

### DIFF
--- a/spec/std/time/location_spec.cr
+++ b/spec/std/time/location_spec.cr
@@ -260,10 +260,18 @@ class Time::Location
     describe ".load_local" do
       it "with unset TZ" do
         with_tz(nil) do
-          # This should generally be `Local`, but if `/etc/localtime` doesn't exist,
-          # `Crystal::System::Time.load_localtime` can't resolve a local time zone,
-          # making the return value default to `UTC`.
-          {"Local", "UTC"}.should contain Location.load_local.name
+          local = Location.load_local
+
+          {% if flag?(:win32) %}
+            # On Windows, a system time zone should always be present, and it
+            # should map to a canonical IANA time zone name.
+            local.name.should_not eq "Local"
+          {% else %}
+            # This should generally be `Local`, but if `/etc/localtime` doesn't exist,
+            # `Crystal::System::Time.load_localtime` can't resolve a local time zone,
+            # making the return value default to `UTC`.
+            {"Local", "UTC"}.should contain local.name
+          {% end %}
         end
       end
 

--- a/src/crystal/system/win32/time.cr
+++ b/src/crystal/system/win32/time.cr
@@ -77,7 +77,7 @@ module Crystal::System::Time
       return unless windows_info = iana_to_windows[canonical_iana_name]?
       _, stdname, dstname = windows_info
 
-      initialize_location_from_TZI(pointerof(info).as(LibC::TIME_ZONE_INFORMATION*).value, "Local", windows_name, stdname, dstname)
+      initialize_location_from_TZI(pointerof(info).as(LibC::TIME_ZONE_INFORMATION*).value, canonical_iana_name, windows_name, stdname, dstname)
     end
   end
 


### PR DESCRIPTION
Like #15959, but for Windows system time zones.