### PR TITLE
Support debug builds for the MSVC Boehm GC libraries

### DIFF
--- a/etc/win-ci/build-gc.ps1
+++ b/etc/win-ci/build-gc.ps1
@@ -2,6 +2,7 @@ param(
     [Parameter(Mandatory)] [string] $BuildTree,
     [Parameter(Mandatory)] [string] $Version,
     [Parameter(Mandatory)] [string] $AtomicOpsVersion,
+    [ValidateSet("Release", "Debug")] [string] $Config = "Release",
     [switch] $Dynamic
 )
 
@@ -18,8 +19,11 @@ Run-InDirectory $BuildTree {
     } else {
         $args = "-DBUILD_SHARED_LIBS=OFF -DCMAKE_MSVC_RUNTIME_LIBRARY=MultiThreaded $args"
     }
+    if ($Config -eq "Debug") {
+        $args = "-DCMAKE_SHARED_LINKER_FLAGS=/PDBALTPATH:gc.pdb -DCMAKE_MSVC_DEBUG_INFORMATION_FORMAT=Embedded -DCMAKE_POLICY_DEFAULT_CMP0141=NEW $args"
+    }
     & $cmake . $args.split(' ')
-    & $cmake --build . --config Release
+    & $cmake --build . --config $Config
     if (-not $?) {
         Write-Host "Error: Failed to build libgc" -ForegroundColor Red
         Exit 1
@@ -27,9 +31,11 @@ Run-InDirectory $BuildTree {
 }
 
 if ($Dynamic) {
-    mv -Force $BuildTree\Release\gc.lib libs\gc-dynamic.lib
-    mv -Force $BuildTree\Release\gc.dll dlls\
+    mv -Force $BuildTree\$Config\gc.lib libs\gc-dynamic.lib
+    mv -Force $BuildTree\$Config\gc.dll dlls\
+    if ($Config -eq "Debug") {
+        mv -Force $BuildTree\$Config\gc.pdb dlls\
+    }
 } else {
-    mv -Force $BuildTree\Release\gc.lib libs\
+    mv -Force $BuildTree\$Config\gc.lib libs\
 }
-


### PR DESCRIPTION
Adds a `-Config` parameter to `etc/win-ci/build-gc.ps1`, which corresponds to the CMake configuration names (by default `Release` / `Debug` / `RelWithDebInfo` / `MinSizeRel`), and supports `-Config Debug`. The resulting static library contains embedded debug information that will be joined to the final PDB file, whereas the DLL comes with its own relocatable PDB file.

Other third-party libraries will be updated in a similar fashion, and eventually the GUI installer could offer to install these debug versions of the libraries.