### PR TITLE
Clear debug location of top-level implicit return

### DIFF
--- a/spec/compiler/codegen/debug_spec.cr
+++ b/spec/compiler/codegen/debug_spec.cr
@@ -313,4 +313,12 @@ describe "Code gen: debug" do
         CRYSTAL
     end
   {% end %}
+
+  it "doesn't fail if no top-level code follows discarded class var initializer (#15970)" do
+    codegen <<-CRYSTAL, debug: Crystal::Debug::All
+      module Foo
+        @@x = 1
+      end
+      CRYSTAL
+  end
 end

--- a/src/compiler/crystal/codegen/codegen.cr
+++ b/src/compiler/crystal/codegen/codegen.cr
@@ -519,6 +519,7 @@ module Crystal
     end
 
     def finish
+      clear_current_debug_location if @debug.line_numbers?
       codegen_return @main_ret_type
 
       # If there are no instructions in the alloca block and the


### PR DESCRIPTION
This is a special case of #15970 where the top-level scope has no code at all following a class variable initializer.