### PR TITLE
Add file name to file-private generic instance metaclass types during codegen

### DIFF
--- a/spec/compiler/codegen/class_spec.cr
+++ b/spec/compiler/codegen/class_spec.cr
@@ -659,7 +659,7 @@ describe "Code gen: class" do
       )).to_string.should eq("Baz")
   end
 
-  it "does not combine metaclass types with same name but different file scopes (#15503)" do
+  it "does not combine module metaclass types with same name but different file scopes (#15503)" do
     run(<<-CRYSTAL, Int32, filename: "foo.cr").should eq(11)
       module Foo
         def self.foo
@@ -754,6 +754,65 @@ describe "Code gen: class" do
       end
 
       Fred.as(Fred.class).foo &+ Foo.as(Foo.class).foo
+      CRYSTAL
+  end
+
+  it "does not combine generic virtual metaclass types with same name but different file scopes" do
+    run(<<-CRYSTAL, Int32, filename: "foo.cr").should eq(11)
+      module Foo
+        def self.foo
+          1
+        end
+      end
+
+      alias Bar = Foo
+
+      {% Bar %} # forces immediate resolution of `Bar`
+
+      private module Foo
+        def self.foo
+          10
+        end
+      end
+
+      abstract class Base
+      end
+
+      class Gen(T) < Base
+        def self.x
+          T.foo
+        end
+      end
+
+      Gen(Foo).as(Base.class).x &+ Gen(Bar).as(Base.class).x
+      CRYSTAL
+  end
+
+  it "does not combine generic module metaclass types with same name but different file scopes" do
+    run(<<-CRYSTAL, Int32, filename: "foo.cr").should eq(11)
+      module Foo
+        def self.foo
+          1
+        end
+      end
+
+      alias Bar = Foo
+
+      {% Bar %} # forces immediate resolution of `Bar`
+
+      private module Foo
+        def self.foo
+          10
+        end
+      end
+
+      module Gen(T)
+        def self.x
+          T.foo
+        end
+      end
+
+      (Gen(Foo) || Gen(Bar)).x &+ (Gen(Bar) || Gen(Foo)).x
       CRYSTAL
   end
 

--- a/src/compiler/crystal/types.cr
+++ b/src/compiler/crystal/types.cr
@@ -2095,6 +2095,8 @@ module Crystal
               type_var_type.to_s_with_options(io, skip_union_parens: true, codegen: codegen)
             end
           else
+            # `type_var` could only be a non-type such as `NumberLiteral`, no
+            # need to use `#to_s_with_options` here
             io << ", " unless first
             first = false
             type_var.to_s(io)
@@ -3014,7 +3016,7 @@ module Crystal
     end
 
     def to_s_with_options(io : IO, skip_union_parens : Bool = false, generic_args : Bool = true, codegen : Bool = false) : Nil
-      instance_type.to_s(io)
+      instance_type.to_s_with_options(io, codegen: codegen)
       io << ".class"
     end
 
@@ -3068,7 +3070,7 @@ module Crystal
     end
 
     def to_s_with_options(io : IO, skip_union_parens : Bool = false, generic_args : Bool = true, codegen : Bool = false) : Nil
-      instance_type.to_s(io)
+      instance_type.to_s_with_options(io, codegen: codegen)
       io << ".class"
     end
 


### PR DESCRIPTION
Follow-up to #15897.

The specs test only global types with file-private generic variables, but this would also apply to file-private types with global or file-private generic variables.