### PR TITLE
Pass through variable types unchanged in a while loop

### DIFF
--- a/spec/compiler/semantic/while_spec.cr
+++ b/spec/compiler/semantic/while_spec.cr
@@ -448,4 +448,28 @@ describe "Semantic: while" do
       foo
       )) { union_of nil_type.metaclass, char }
   end
+
+  it "doesn't modify variables unchanged in condition and body" do
+    assert_no_errors <<-CRYSTAL
+      abstract class Base; end
+
+      class A < Base; end
+
+      class B < Base; end
+
+      class C < Base; end
+
+      def foo(x : A | B)
+      end
+
+      el = A.new.as(Base)
+      if el.is_a?(A) || el.is_a?(B)
+        while false
+          break
+        end
+
+        foo(el)
+      end
+      CRYSTAL
+  end
 end

--- a/src/compiler/crystal/semantic/main_visitor.cr
+++ b/src/compiler/crystal/semantic/main_visitor.cr
@@ -2159,6 +2159,13 @@ module Crystal
       @vars.each do |name, while_var|
         before_cond_var = before_cond_vars[name]?
         after_cond_var = after_cond_vars[name]?
+
+        # Check if no types were changed in the condition or the body
+        if while_var.same?(before_cond_var) && while_var.same?(after_cond_var)
+          after_while_vars[name] = while_var
+          next
+        end
+
         after_while_vars[name] = after_while_var = MetaVar.new(name)
 
         # After while's body, bind variables *before* the condition to the


### PR DESCRIPTION
This fixes a bug where the compiler always reduces unions within a class hierarchy to their ancestor, even when a variable is completely untouched in a non-endless while loop that has a break:

```crystal
abstract class Base; end

class A < Base; end

class B < Base; end

class C < Base; end

def foo(x : A | B)
end

el = A.new.as(Base)
if el.is_a?(A) || el.is_a?(B)
  while false
    break
  end

  foo(el) # Error: expected argument #1 to 'foo' to be Base, not Base
end
```