### PR TITLE
Deprecate each `LLVM::ABI::*` classes

### DIFF
--- a/src/llvm/abi/aarch64.cr
+++ b/src/llvm/abi/aarch64.cr
@@ -2,6 +2,7 @@ require "../abi"
 
 # Based on
 # https://github.com/rust-lang/rust/blob/master/src/librustc_trans/cabi_aarch64.rs
+@[Deprecated("This API is now internal to the compiler and no longer updated publicly.")]
 class LLVM::ABI::AArch64 < LLVM::ABI
   def abi_info(atys : Array(Type), rty : Type, ret_def : Bool, context : Context) : LLVM::ABI::FunctionType
     ret_ty = compute_return_type(rty, ret_def, context)

--- a/src/llvm/abi/arm.cr
+++ b/src/llvm/abi/arm.cr
@@ -1,6 +1,7 @@
 require "../abi"
 
 # Based on https://github.com/rust-lang/rust/blob/dfe8bd10fe6763e0a1d5d55fa2574ecba27d3e2e/src/librustc_trans/cabi_arm.rs
+@[Deprecated("This API is now internal to the compiler and no longer updated publicly.")]
 class LLVM::ABI::ARM < LLVM::ABI
   def abi_info(atys : Array(Type), rty : Type, ret_def : Bool, context : Context) : LLVM::ABI::FunctionType
     ret_ty = compute_return_type(rty, ret_def, context)

--- a/src/llvm/abi/avr.cr
+++ b/src/llvm/abi/avr.cr
@@ -1,5 +1,6 @@
 require "../abi"
 
+@[Deprecated("This API is now internal to the compiler and no longer updated publicly.")]
 class LLVM::ABI::AVR < LLVM::ABI
   AVRTINY = StaticArray[
     "attiny4",

--- a/src/llvm/abi/wasm32.cr
+++ b/src/llvm/abi/wasm32.cr
@@ -1,5 +1,6 @@
 require "../abi"
 
+@[Deprecated("This API is now internal to the compiler and no longer updated publicly.")]
 class LLVM::ABI::Wasm32 < LLVM::ABI
   def abi_info(atys : Array(Type), rty : Type, ret_def : Bool, context : Context)
     ret_ty = compute_return_type(rty, ret_def, context)

--- a/src/llvm/abi/x86.cr
+++ b/src/llvm/abi/x86.cr
@@ -1,6 +1,7 @@
 require "../abi"
 
 # Based on https://github.com/rust-lang/rust/blob/29ac04402d53d358a1f6200bea45a301ff05b2d1/src/librustc_trans/trans/cabi_x86.rs
+@[Deprecated("This API is now internal to the compiler and no longer updated publicly.")]
 class LLVM::ABI::X86 < LLVM::ABI
   def abi_info(atys : Array(Type), rty : Type, ret_def : Bool, context : Context)
     ret_ty = compute_return_type(rty, ret_def, context)

--- a/src/llvm/abi/x86_64.cr
+++ b/src/llvm/abi/x86_64.cr
@@ -2,6 +2,7 @@ require "../abi"
 
 # Based on https://github.com/rust-lang/rust/blob/29ac04402d53d358a1f6200bea45a301ff05b2d1/src/librustc_trans/trans/cabi_x86_64.rs
 # See also, section 3.2.3 of the System V Application Binary Interface AMD64 Architecture Processor Supplement
+@[Deprecated("This API is now internal to the compiler and no longer updated publicly.")]
 class LLVM::ABI::X86_64 < LLVM::ABI
   MAX_INT_REGS = 6 # %rdi, %rsi, %rdx, %rcx, %r8, %r9
   MAX_SSE_REGS = 8 # %xmm0-%xmm7

--- a/src/llvm/abi/x86_win64.cr
+++ b/src/llvm/abi/x86_win64.cr
@@ -1,6 +1,7 @@
 require "../abi"
 
 # Based on https://github.com/rust-lang/rust/blob/29ac04402d53d358a1f6200bea45a301ff05b2d1/src/librustc_trans/trans/cabi_x86_win64.rs
+@[Deprecated("This API is now internal to the compiler and no longer updated publicly.")]
 class LLVM::ABI::X86_Win64 < LLVM::ABI::X86
   private def compute_arg_types(atys, context)
     atys.map do |t|


### PR DESCRIPTION
It documents each individual class as deprecated, not just the `LLVM::ABI` superclass.

This will also avoid warnings about the superclass after #15962 just because we required LLVM and that in turn required the deprecated abi classes.

Extracted from #15962.