### PR TITLE
Fix: deprecation warning for (expanded) deprecated def

### DIFF
--- a/spec/compiler/semantic/warnings_spec.cr
+++ b/spec/compiler/semantic/warnings_spec.cr
@@ -127,7 +127,7 @@ describe "Semantic: warnings" do
 
         foo(a: 2)
         CRYSTAL
-        "warning in line 5\nWarning: Deprecated ::foo:a."
+        "warning in line 5\nWarning: Deprecated ::foo."
     end
 
     it "detects deprecated initialize" do

--- a/src/compiler/crystal/semantic/ast.cr
+++ b/src/compiler/crystal/semantic/ast.cr
@@ -161,6 +161,9 @@ module Crystal
     # Is this a `new` method that was expanded from an initialize?
     property? new = false
 
+    # Name of the original def if this def has been expanded (default arguments)
+    property? original_name : String?
+
     @macro_owner : Type?
 
     # Used to override the meaning of `self` in restrictions
@@ -175,6 +178,10 @@ module Crystal
 
     def macro_owner?
       @macro_owner
+    end
+
+    def original_name
+      @original_name || @name
     end
 
     def add_special_var(name)
@@ -214,6 +221,7 @@ module Crystal
       a_def.naked = naked?
       a_def.annotations = annotations
       a_def.new = new?
+      a_def.original_name = original_name?
       a_def
     end
 

--- a/src/compiler/crystal/semantic/default_arguments.cr
+++ b/src/compiler/crystal/semantic/default_arguments.cr
@@ -108,6 +108,7 @@ class Crystal::Def
     if owner = self.owner?
       expansion.owner = owner
     end
+    expansion.original_name = original_name? || name
 
     if retain_body
       new_body = [] of ASTNode

--- a/src/compiler/crystal/semantic/warnings.cr
+++ b/src/compiler/crystal/semantic/warnings.cr
@@ -122,11 +122,11 @@ module Crystal
     def short_reference
       case owner
       when Program
-        "::#{name}"
+        "::#{original_name}"
       when .metaclass?
-        "#{owner.instance_type}.#{name}"
+        "#{owner.instance_type}.#{original_name}"
       else
-        "#{owner}##{name}"
+        "#{owner}##{original_name}"
       end
     end
   end


### PR DESCRIPTION
The compiler expands methods with special arguments (default values, named args, splats and double splats), and I noticed that a spec was expecting the expanded method name (`foo:a`) instead of the actual method name (`foo`). I suppose this is because we don't know the original name?

This patch simply retains the original def name, and uses it when it's defined.