### PR TITLE
Load `Location.local` by symlink name

### DIFF
--- a/spec/std/time/location_spec.cr
+++ b/spec/std/time/location_spec.cr
@@ -48,7 +48,7 @@ class Time::Location
           location.utc?.should be_false
           location.fixed?.should be_false
 
-          with_tz(nil) do
+          with_tz("UTC") do
             location.local?.should be_false
           end
 
@@ -258,31 +258,34 @@ class Time::Location
     end
 
     describe ".load_local" do
-      it "with unset TZ" do
-        with_tz(nil) do
-          local = Location.load_local
+      context "with unset TZ" do
+        it "is #local?" do
+          with_tz(nil) do
+            Location.load_local.local?.should be_true
+          end
+        end
 
-          {% if flag?(:win32) %}
-            # On Windows, a system time zone should always be present, and it
-            # should map to a canonical IANA time zone name.
+        it "derives location name from system (e.g. /etc/localtime)" do
+          with_tz(nil) do
+            local = Location.load_local
+
+            # This expectation might fail on unix in case /etc/localtime is not
+            # a symlink into the zoneinfo database.
             local.name.should_not eq "Local"
-          {% else %}
-            # This should generally be `Local`, but if `/etc/localtime` doesn't exist,
-            # `Crystal::System::Time.load_localtime` can't resolve a local time zone,
-            # making the return value default to `UTC`.
-            {"Local", "UTC"}.should contain local.name
-          {% end %}
+
+            local.should eq Location.load(local.name)
+          end
         end
       end
 
       it "with TZ" do
-        with_zoneinfo do
-          with_tz("Europe/Berlin") do
+        with_tz("Europe/Berlin") do
+          with_zoneinfo do
             Location.load_local.name.should eq "Europe/Berlin"
           end
         end
-        with_zoneinfo(datapath("zoneinfo")) do
-          with_tz("Foo/Bar") do
+        with_tz("Foo/Bar") do
+          with_zoneinfo(datapath("zoneinfo")) do
             Location.load_local.name.should eq "Foo/Bar"
           end
         end

--- a/spec/support/time.cr
+++ b/spec/support/time.cr
@@ -6,6 +6,7 @@ class Time::Location
   end
 
   def self.__clear_location_cache
+    @@local = nil
     @@location_cache.clear
   end
 end
@@ -14,7 +15,6 @@ ZONEINFO_ZIP = datapath("zoneinfo.zip")
 
 def with_zoneinfo(path = ZONEINFO_ZIP, &)
   with_env("ZONEINFO": path) do
-    Time::Location.local = Time::Location.load_local
     Time::Location.__clear_location_cache
 
     yield

--- a/src/crystal/system/unix/time.cr
+++ b/src/crystal/system/unix/time.cr
@@ -131,11 +131,29 @@ module Crystal::System::Time
     private LOCALTIME = "/etc/localtime"
 
     def self.load_localtime : ::Time::Location?
+      # Try to defer the name of the zoneinfo file from the link target (e.g.
+      # `/usr/share/zoneinfo/Europe/Berlin`) and load the corresponding
+      # location.
+      # We do not load the actual target file, only extract the name so the
+      # resulting location is exactly the same as when loading it explicitly
+      # as `Time::Location.load("Europe/Berlin")`.
+      if ::File.symlink?("/etc/localtime") && (realpath = (File.readlink("/etc/localtime") rescue nil))
+        if pos = realpath.rindex("zoneinfo/")
+          name = realpath[(pos + "zoneinfo/".size)..]
+          return ::Time::Location.load(name)
+        end
+      end
+
+      # Only when /etc/localtime is not a symlink or doesn't point to a
+      # zoneinfo/ directory, we read the TZif data from the actual target file
+      # as a fallback.
       if ::File.file?(LOCALTIME) && ::File::Info.readable?(LOCALTIME)
         ::File.open(LOCALTIME) do |file|
-          ::Time::Location.read_zoneinfo("Local", file)
-        rescue ::Time::Location::InvalidTZDataError
-          nil
+          begin
+            ::Time::Location.read_zoneinfo("Local", file)
+          rescue ::Time::Location::InvalidTZDataError
+            nil
+          end
         end
       end
     end

--- a/src/crystal/system/win32/time.cr
+++ b/src/crystal/system/win32/time.cr
@@ -77,6 +77,9 @@ module Crystal::System::Time
       return unless windows_info = iana_to_windows[canonical_iana_name]?
       _, stdname, dstname = windows_info
 
+      # In Crystal, we use only `UTC` as name for the UTC time zone
+      canonical_iana_name = "UTC" if canonical_iana_name == "Etc/UTC"
+
       initialize_location_from_TZI(pointerof(info).as(LibC::TIME_ZONE_INFORMATION*).value, canonical_iana_name, windows_name, stdname, dstname)
     end
   end


### PR DESCRIPTION
Previously, `Time::Location.local` on Unix systems would always have a generic name, `Local` (or `UTC` if `/etc/localtime` is missing) because the zoneinfo described in `/etc/localtime` does not have an obvious name attached.

`/etc/localtime` is typically a symlink into the zoneinfo database. With this change, we read the symlink and defer the name of the location from the path inside the zoneinfo root directory. We do not actually parse the target file and instead load the location by name.

Originally suggested in https://forum.crystal-lang.org/t/how-do-you-get-the-location-name-of-the-local-timezone/8191/3?u=straight-shoota, with alterations from https://github.com/crystal-lang/crystal/pull/15959#issuecomment-3035370559 (same as jiff).

Supersedes #15959. I think this is the better solution because with #15959 we could end up with two location instances with the same name but potentially different rules.