### PR TITLE
Deprecate `Process::Status#exit_signal`

### DIFF
--- a/src/process/status.cr
+++ b/src/process/status.cr
@@ -249,6 +249,7 @@ class Process::Status
   #
   # NOTE: `#exit_reason` is preferred over this method as a portable alternative
   # which also works on Windows.
+  @[Deprecated("Use `#exit_signal?` instead.")]
   def exit_signal : Signal
     {% if flag?(:unix) && !flag?(:wasm32) %}
       Signal.new(signal_code)


### PR DESCRIPTION
`#exit_signal` is weird because it _always_ returns a `Signal` on Unix systems, even if there was no signal exit (i.e. `Signal[0]`). The nilable variant `#exit_signal` is more useful and there's no need to have both. So let's deprecate it.

Addresses https://github.com/crystal-lang/crystal/issues/15271#issuecomment-2625032486