### PR TITLE
Add `File.readlink?`

### DIFF
--- a/spec/std/file_spec.cr
+++ b/spec/std/file_spec.cr
@@ -379,7 +379,7 @@ describe "File" do
     end
 
     it "raises when target non-existent" do
-      with_tempfile("target-nonexistent") do |path|
+      with_tempfile("target-nonexistent2") do |path|
         Dir.mkdir_p(path)
         Dir.cd(path) do
           File.symlink("nonexistent.txt", "symlink.txt")
@@ -394,7 +394,7 @@ describe "File" do
       pending! if {{ flag?(:win32) }}
       pending_if_superuser!
 
-      with_tempfile("readlink-inaccessible") do |path|
+      with_tempfile("readlink-inaccessible2") do |path|
         Dir.mkdir_p(path)
         symlink = File.join(path, "symlink.txt")
         File.symlink("nonexistent.txt", symlink)

--- a/spec/std/file_spec.cr
+++ b/spec/std/file_spec.cr
@@ -394,7 +394,7 @@ describe "File" do
       pending! if {{ flag?(:win32) }}
       pending_if_superuser!
 
-      with_tempfile("readlinkq-inaccessible") do |path|
+      with_tempfile("readlink-inaccessible") do |path|
         Dir.mkdir_p(path)
         symlink = File.join(path, "symlink.txt")
         File.symlink("nonexistent.txt", symlink)

--- a/src/file.cr
+++ b/src/file.cr
@@ -493,9 +493,16 @@ class File < IO::FileDescriptor
     end
   end
 
-  # Returns value of a symbolic link .
+  # Returns the target of a symbolic link.
   def self.readlink(path : Path | String) : String
-    Crystal::System::File.readlink(path.to_s)
+    Crystal::System::File.readlink(path.to_s) { }
+  end
+
+  # Returns the target of a symbolic link.
+  #
+  # Returns `nil` if *path* does not exist or is not a symbolic link.
+  def self.readlink?(path : Path | String) : String?
+    Crystal::System::File.readlink(path.to_s) { return nil }
   end
 
   # Opens the file named by *filename*. If a file is being created, its initial


### PR DESCRIPTION
`File.readlink?` is a non-raising alternative to `File.readlink` which returns `nil` if the file doesn't exist or is not a symlink.