### PR TITLE
Add `with_tempdir` spec helper

### DIFF
--- a/spec/compiler/crystal/tools/doc/project_info_spec.cr
+++ b/spec/compiler/crystal/tools/doc/project_info_spec.cr
@@ -16,11 +16,8 @@ end
 
 describe Crystal::Doc::ProjectInfo do
   around_each do |example|
-    with_tempfile("docs-project") do |tempdir|
-      Dir.mkdir tempdir
-      Dir.cd(tempdir) do
-        example.run
-      end
+    with_tempdir("docs-project") do
+      example.run
     end
   end
 

--- a/spec/compiler/crystal/tools/format_spec.cr
+++ b/spec/compiler/crystal/tools/format_spec.cr
@@ -90,21 +90,18 @@ describe Crystal::Command::FormatCommand do
     stdout = IO::Memory.new
     stderr = IO::Memory.new
 
-    with_tempfile("format_files") do |path|
-      FileUtils.mkdir_p path
-      Dir.cd(path) do
-        File.write "format.cr", "if true\n1\nend"
-        File.write "not_format.cr", "if true\n  1\nend\n"
+    with_tempdir do
+      File.write "format.cr", "if true\n1\nend"
+      File.write "not_format.cr", "if true\n  1\nend\n"
 
-        format_command = Crystal::Command::FormatCommand.new([] of String, color: false, stdin: stdin, stdout: stdout, stderr: stderr)
-        format_command.run
-        format_command.status_code.should eq(0)
-        stdout.to_s.should contain("Format #{Path[".", "format.cr"]}")
-        stdout.to_s.should_not contain("Format #{Path[".", "not_format.cr"]}")
-        stderr.to_s.should be_empty
+      format_command = Crystal::Command::FormatCommand.new([] of String, color: false, stdin: stdin, stdout: stdout, stderr: stderr)
+      format_command.run
+      format_command.status_code.should eq(0)
+      stdout.to_s.should contain("Format #{Path[".", "format.cr"]}")
+      stdout.to_s.should_not contain("Format #{Path[".", "not_format.cr"]}")
+      stderr.to_s.should be_empty
 
-        File.read("format.cr").should eq("if true\n  1\nend\n")
-      end
+      File.read("format.cr").should eq("if true\n  1\nend\n")
     end
   end
 
@@ -113,35 +110,33 @@ describe Crystal::Command::FormatCommand do
     stdout = IO::Memory.new
     stderr = IO::Memory.new
 
-    with_tempfile("format_files_dir") do |path|
-      FileUtils.mkdir_p File.join(path, "dir")
-      Dir.cd(path) do
-        File.write "format.cr", "if true\n1\nend"
-        File.write "not_format.cr", "if true\n  1\nend\n"
-        File.write File.join("dir", "format.cr"), "if true\n1\nend"
-        File.write File.join("dir", "not_format.cr"), "if true\n  1\nend\n"
+    with_temdir do
+      Dir.mkdir "dir"
+      File.write "format.cr", "if true\n1\nend"
+      File.write "not_format.cr", "if true\n  1\nend\n"
+      File.write File.join("dir", "format.cr"), "if true\n1\nend"
+      File.write File.join("dir", "not_format.cr"), "if true\n  1\nend\n"
 
-        format_command = Crystal::Command::FormatCommand.new(["dir"], color: false, stdin: stdin, stdout: stdout, stderr: stderr)
-        format_command.run
-        format_command.status_code.should eq(0)
-        stdout.to_s.should contain("Format #{Path[".", "dir", "format.cr"]}")
-        stdout.to_s.should_not contain("Format #{Path[".", "dir", "not_format.cr"]}")
-        stderr.to_s.should be_empty
+      format_command = Crystal::Command::FormatCommand.new(["dir"], color: false, stdin: stdin, stdout: stdout, stderr: stderr)
+      format_command.run
+      format_command.status_code.should eq(0)
+      stdout.to_s.should contain("Format #{Path[".", "dir", "format.cr"]}")
+      stdout.to_s.should_not contain("Format #{Path[".", "dir", "not_format.cr"]}")
+      stderr.to_s.should be_empty
 
-        {stdout, stderr}.each &.clear
+      {stdout, stderr}.each &.clear
 
-        format_command = Crystal::Command::FormatCommand.new([] of String, color: false, stdin: stdin, stdout: stdout, stderr: stderr)
-        format_command.run
-        format_command.status_code.should eq(0)
-        stdout.to_s.should contain("Format #{Path[".", "format.cr"]}")
-        stdout.to_s.should_not contain("Format #{Path[".", "not_format.cr"]}")
-        stdout.to_s.should_not contain("Format #{Path[".", "dir", "format.cr"]}")
-        stdout.to_s.should_not contain("Format #{Path[".", "dir", "not_format.cr"]}")
-        stderr.to_s.should be_empty
+      format_command = Crystal::Command::FormatCommand.new([] of String, color: false, stdin: stdin, stdout: stdout, stderr: stderr)
+      format_command.run
+      format_command.status_code.should eq(0)
+      stdout.to_s.should contain("Format #{Path[".", "format.cr"]}")
+      stdout.to_s.should_not contain("Format #{Path[".", "not_format.cr"]}")
+      stdout.to_s.should_not contain("Format #{Path[".", "dir", "format.cr"]}")
+      stdout.to_s.should_not contain("Format #{Path[".", "dir", "not_format.cr"]}")
+      stderr.to_s.should be_empty
 
-        File.read("format.cr").should eq("if true\n  1\nend\n")
-        File.read(File.join("dir", "format.cr")).should eq("if true\n  1\nend\n")
-      end
+      File.read("format.cr").should eq("if true\n  1\nend\n")
+      File.read(File.join("dir", "format.cr")).should eq("if true\n  1\nend\n")
     end
   end
 
@@ -150,22 +145,19 @@ describe Crystal::Command::FormatCommand do
     stdout = IO::Memory.new
     stderr = IO::Memory.new
 
-    with_tempfile("format_files_error") do |path|
-      FileUtils.mkdir_p path
-      Dir.cd(path) do
-        File.write "format.cr", "if true\n1\nend"
-        File.write "syntax_error.cr", "if"
-        File.write "invalid_byte_sequence_error.cr", "\xfe\xff"
+    with_tempdir do
+      File.write "format.cr", "if true\n1\nend"
+      File.write "syntax_error.cr", "if"
+      File.write "invalid_byte_sequence_error.cr", "\xfe\xff"
 
-        format_command = Crystal::Command::FormatCommand.new([] of String, color: false, stdin: stdin, stdout: stdout, stderr: stderr)
-        format_command.run
-        format_command.status_code.should eq(1)
-        stdout.to_s.should contain("Format #{Path[".", "format.cr"]}")
-        stderr.to_s.should contain("syntax error in '#{Path[".", "syntax_error.cr"]}:1:3': unexpected token: EOF")
-        stderr.to_s.should contain("file '#{Path[".", "invalid_byte_sequence_error.cr"]}' is not a valid Crystal source file: Unexpected byte 0xfe at position 0, malformed UTF-8")
+      format_command = Crystal::Command::FormatCommand.new([] of String, color: false, stdin: stdin, stdout: stdout, stderr: stderr)
+      format_command.run
+      format_command.status_code.should eq(1)
+      stdout.to_s.should contain("Format #{Path[".", "format.cr"]}")
+      stderr.to_s.should contain("syntax error in '#{Path[".", "syntax_error.cr"]}:1:3': unexpected token: EOF")
+      stderr.to_s.should contain("file '#{Path[".", "invalid_byte_sequence_error.cr"]}' is not a valid Crystal source file: Unexpected byte 0xfe at position 0, malformed UTF-8")
 
-        File.read("format.cr").should eq("if true\n  1\nend\n")
-      end
+      File.read("format.cr").should eq("if true\n  1\nend\n")
     end
   end
 
@@ -174,16 +166,13 @@ describe Crystal::Command::FormatCommand do
     stdout = IO::Memory.new
     stderr = IO::Memory.new
 
-    with_tempfile("format_files_bug") do |path|
-      FileUtils.mkdir_p path
-      Dir.cd(path) do
-        File.write "empty.cr", ""
+    with_tempdir do
+      File.write "empty.cr", ""
 
-        format_command = BuggyFormatCommand.new([] of String, color: false, stdin: stdin, stdout: stdout, stderr: stderr)
-        format_command.run
-        format_command.status_code.should eq(1)
-        stderr.to_s.should contain("there's a bug formatting '#{Path[".", "empty.cr"]}', to show more information, please run:\n\n  $ crystal tool format --show-backtrace '#{Path[".", "empty.cr"]}'")
-      end
+      format_command = BuggyFormatCommand.new([] of String, color: false, stdin: stdin, stdout: stdout, stderr: stderr)
+      format_command.run
+      format_command.status_code.should eq(1)
+      stderr.to_s.should contain("there's a bug formatting '#{Path[".", "empty.cr"]}', to show more information, please run:\n\n  $ crystal tool format --show-backtrace '#{Path[".", "empty.cr"]}'")
     end
   end
 
@@ -192,17 +181,14 @@ describe Crystal::Command::FormatCommand do
     stdout = IO::Memory.new
     stderr = IO::Memory.new
 
-    with_tempfile("format_files_bug_show_stacktrace") do |path|
-      FileUtils.mkdir_p path
-      Dir.cd(path) do
-        File.write "empty.cr", ""
+    with_tempdir do
+      File.write "empty.cr", ""
 
-        format_command = BuggyFormatCommand.new([] of String, show_backtrace: true, color: false, stdin: stdin, stdout: stdout, stderr: stderr)
-        format_command.run
-        format_command.status_code.should eq(1)
-        stderr.to_s.should contain("format command test")
-        stderr.to_s.should contain("couldn't format '#{Path[".", "empty.cr"]}', please report a bug including the contents of it: https://github.com/crystal-lang/crystal/issues")
-      end
+      format_command = BuggyFormatCommand.new([] of String, show_backtrace: true, color: false, stdin: stdin, stdout: stdout, stderr: stderr)
+      format_command.run
+      format_command.status_code.should eq(1)
+      stderr.to_s.should contain("format command test")
+      stderr.to_s.should contain("couldn't format '#{Path[".", "empty.cr"]}', please report a bug including the contents of it: https://github.com/crystal-lang/crystal/issues")
     end
   end
 
@@ -211,23 +197,20 @@ describe Crystal::Command::FormatCommand do
     stdout = IO::Memory.new
     stderr = IO::Memory.new
 
-    with_tempfile("check_files_format") do |path|
-      FileUtils.mkdir_p path
-      Dir.cd(path) do
-        File.write "format.cr", "if true\n1\nend"
-        File.write "not_format.cr", "if true\n  1\nend\n"
-        File.write "syntax_error.cr", "if"
-        File.write "invalid_byte_sequence_error.cr", "\xfe\xff"
+    with_tempdir do
+      File.write "format.cr", "if true\n1\nend"
+      File.write "not_format.cr", "if true\n  1\nend\n"
+      File.write "syntax_error.cr", "if"
+      File.write "invalid_byte_sequence_error.cr", "\xfe\xff"
 
-        format_command = Crystal::Command::FormatCommand.new([] of String, check: true, color: false, stdin: stdin, stdout: stdout, stderr: stderr)
-        format_command.run
-        format_command.status_code.should eq(1)
-        stdout.to_s.should be_empty
-        stderr.to_s.should_not contain("not_format.cr")
-        stderr.to_s.should contain("formatting '#{Path[".", "format.cr"]}' produced changes")
-        stderr.to_s.should contain("syntax error in '#{Path[".", "syntax_error.cr"]}:1:3': unexpected token: EOF")
-        stderr.to_s.should contain("file '#{Path[".", "invalid_byte_sequence_error.cr"]}' is not a valid Crystal source file: Unexpected byte 0xfe at position 0, malformed UTF-8")
-      end
+      format_command = Crystal::Command::FormatCommand.new([] of String, check: true, color: false, stdin: stdin, stdout: stdout, stderr: stderr)
+      format_command.run
+      format_command.status_code.should eq(1)
+      stdout.to_s.should be_empty
+      stderr.to_s.should_not contain("not_format.cr")
+      stderr.to_s.should contain("formatting '#{Path[".", "format.cr"]}' produced changes")
+      stderr.to_s.should contain("syntax error in '#{Path[".", "syntax_error.cr"]}:1:3': unexpected token: EOF")
+      stderr.to_s.should contain("file '#{Path[".", "invalid_byte_sequence_error.cr"]}' is not a valid Crystal source file: Unexpected byte 0xfe at position 0, malformed UTF-8")
     end
   end
 
@@ -236,18 +219,15 @@ describe Crystal::Command::FormatCommand do
     stdout = IO::Memory.new
     stderr = IO::Memory.new
 
-    with_tempfile("check_files_format_ok") do |path|
-      FileUtils.mkdir_p path
-      Dir.cd(path) do
-        File.write "format1.cr", "if true\n  1\nend\n"
-        File.write "format2.cr", "if true\n  2\nend\n"
+    with_tempdir do
+      File.write "format1.cr", "if true\n  1\nend\n"
+      File.write "format2.cr", "if true\n  2\nend\n"
 
-        format_command = Crystal::Command::FormatCommand.new([] of String, check: true, color: false, stdin: stdin, stdout: stdout, stderr: stderr)
-        format_command.run
-        format_command.status_code.should eq(0)
-        stdout.to_s.should be_empty
-        stderr.to_s.should be_empty
-      end
+      format_command = Crystal::Command::FormatCommand.new([] of String, check: true, color: false, stdin: stdin, stdout: stdout, stderr: stderr)
+      format_command.run
+      format_command.status_code.should eq(0)
+      stdout.to_s.should be_empty
+      stderr.to_s.should be_empty
     end
   end
 
@@ -256,18 +236,15 @@ describe Crystal::Command::FormatCommand do
     stdout = IO::Memory.new
     stderr = IO::Memory.new
 
-    with_tempfile("check_files_format_excludes") do |path|
-      FileUtils.mkdir_p path
-      Dir.cd(path) do
-        File.write "format.cr", "if true\n1\nend"
-        File.write "not_format.cr", "if true\n  1\nend\n"
+    with_tempdir do
+      File.write "format.cr", "if true\n1\nend"
+      File.write "not_format.cr", "if true\n  1\nend\n"
 
-        format_command = Crystal::Command::FormatCommand.new([] of String, check: true, excludes: ["format.cr"], color: false, stdin: stdin, stdout: stdout, stderr: stderr)
-        format_command.run
-        format_command.status_code.should eq(0)
-        stdout.to_s.should be_empty
-        stderr.to_s.should be_empty
-      end
+      format_command = Crystal::Command::FormatCommand.new([] of String, check: true, excludes: ["format.cr"], color: false, stdin: stdin, stdout: stdout, stderr: stderr)
+      format_command.run
+      format_command.status_code.should eq(0)
+      stdout.to_s.should be_empty
+      stderr.to_s.should be_empty
     end
   end
 
@@ -276,18 +253,15 @@ describe Crystal::Command::FormatCommand do
     stdout = IO::Memory.new
     stderr = IO::Memory.new
 
-    with_tempfile("check_files_format_excludes_includes") do |path|
-      FileUtils.mkdir_p path
-      Dir.cd(path) do
-        File.write "format.cr", "if true\n1\nend"
-        File.write "not_format.cr", "if true\n  1\nend\n"
+    with_tempdir do
+      File.write "format.cr", "if true\n1\nend"
+      File.write "not_format.cr", "if true\n  1\nend\n"
 
-        format_command = Crystal::Command::FormatCommand.new([] of String, check: true, excludes: ["format.cr"], includes: ["format.cr"], color: false, stdin: stdin, stdout: stdout, stderr: stderr)
-        format_command.run
-        format_command.status_code.should eq(1)
-        stdout.to_s.should be_empty
-        stderr.to_s.should contain("formatting '#{Path[".", "format.cr"]}' produced changes")
-      end
+      format_command = Crystal::Command::FormatCommand.new([] of String, check: true, excludes: ["format.cr"], includes: ["format.cr"], color: false, stdin: stdin, stdout: stdout, stderr: stderr)
+      format_command.run
+      format_command.status_code.should eq(1)
+      stdout.to_s.should be_empty
+      stderr.to_s.should contain("formatting '#{Path[".", "format.cr"]}' produced changes")
     end
   end
 end

--- a/spec/compiler/crystal/tools/format_spec.cr
+++ b/spec/compiler/crystal/tools/format_spec.cr
@@ -93,8 +93,8 @@ describe Crystal::Command::FormatCommand do
     with_tempfile("format_files") do |path|
       FileUtils.mkdir_p path
       Dir.cd(path) do
-        File.write File.join(path, "format.cr"), "if true\n1\nend"
-        File.write File.join(path, "not_format.cr"), "if true\n  1\nend\n"
+        File.write "format.cr", "if true\n1\nend"
+        File.write "not_format.cr", "if true\n  1\nend\n"
 
         format_command = Crystal::Command::FormatCommand.new([] of String, color: false, stdin: stdin, stdout: stdout, stderr: stderr)
         format_command.run
@@ -103,7 +103,7 @@ describe Crystal::Command::FormatCommand do
         stdout.to_s.should_not contain("Format #{Path[".", "not_format.cr"]}")
         stderr.to_s.should be_empty
 
-        File.read(File.join(path, "format.cr")).should eq("if true\n  1\nend\n")
+        File.read("format.cr").should eq("if true\n  1\nend\n")
       end
     end
   end
@@ -116,10 +116,10 @@ describe Crystal::Command::FormatCommand do
     with_tempfile("format_files_dir") do |path|
       FileUtils.mkdir_p File.join(path, "dir")
       Dir.cd(path) do
-        File.write File.join(path, "format.cr"), "if true\n1\nend"
-        File.write File.join(path, "not_format.cr"), "if true\n  1\nend\n"
-        File.write File.join(path, "dir", "format.cr"), "if true\n1\nend"
-        File.write File.join(path, "dir", "not_format.cr"), "if true\n  1\nend\n"
+        File.write "format.cr", "if true\n1\nend"
+        File.write "not_format.cr", "if true\n  1\nend\n"
+        File.write File.join("dir", "format.cr"), "if true\n1\nend"
+        File.write File.join("dir", "not_format.cr"), "if true\n  1\nend\n"
 
         format_command = Crystal::Command::FormatCommand.new(["dir"], color: false, stdin: stdin, stdout: stdout, stderr: stderr)
         format_command.run
@@ -139,8 +139,8 @@ describe Crystal::Command::FormatCommand do
         stdout.to_s.should_not contain("Format #{Path[".", "dir", "not_format.cr"]}")
         stderr.to_s.should be_empty
 
-        File.read(File.join(path, "format.cr")).should eq("if true\n  1\nend\n")
-        File.read(File.join(path, "dir", "format.cr")).should eq("if true\n  1\nend\n")
+        File.read("format.cr").should eq("if true\n  1\nend\n")
+        File.read(File.join("dir", "format.cr")).should eq("if true\n  1\nend\n")
       end
     end
   end
@@ -153,9 +153,9 @@ describe Crystal::Command::FormatCommand do
     with_tempfile("format_files_error") do |path|
       FileUtils.mkdir_p path
       Dir.cd(path) do
-        File.write File.join(path, "format.cr"), "if true\n1\nend"
-        File.write File.join(path, "syntax_error.cr"), "if"
-        File.write File.join(path, "invalid_byte_sequence_error.cr"), "\xfe\xff"
+        File.write "format.cr", "if true\n1\nend"
+        File.write "syntax_error.cr", "if"
+        File.write "invalid_byte_sequence_error.cr", "\xfe\xff"
 
         format_command = Crystal::Command::FormatCommand.new([] of String, color: false, stdin: stdin, stdout: stdout, stderr: stderr)
         format_command.run
@@ -164,7 +164,7 @@ describe Crystal::Command::FormatCommand do
         stderr.to_s.should contain("syntax error in '#{Path[".", "syntax_error.cr"]}:1:3': unexpected token: EOF")
         stderr.to_s.should contain("file '#{Path[".", "invalid_byte_sequence_error.cr"]}' is not a valid Crystal source file: Unexpected byte 0xfe at position 0, malformed UTF-8")
 
-        File.read(File.join(path, "format.cr")).should eq("if true\n  1\nend\n")
+        File.read("format.cr").should eq("if true\n  1\nend\n")
       end
     end
   end
@@ -177,7 +177,7 @@ describe Crystal::Command::FormatCommand do
     with_tempfile("format_files_bug") do |path|
       FileUtils.mkdir_p path
       Dir.cd(path) do
-        File.write File.join(path, "empty.cr"), ""
+        File.write "empty.cr", ""
 
         format_command = BuggyFormatCommand.new([] of String, color: false, stdin: stdin, stdout: stdout, stderr: stderr)
         format_command.run
@@ -195,7 +195,7 @@ describe Crystal::Command::FormatCommand do
     with_tempfile("format_files_bug_show_stacktrace") do |path|
       FileUtils.mkdir_p path
       Dir.cd(path) do
-        File.write File.join(path, "empty.cr"), ""
+        File.write "empty.cr", ""
 
         format_command = BuggyFormatCommand.new([] of String, show_backtrace: true, color: false, stdin: stdin, stdout: stdout, stderr: stderr)
         format_command.run
@@ -214,10 +214,10 @@ describe Crystal::Command::FormatCommand do
     with_tempfile("check_files_format") do |path|
       FileUtils.mkdir_p path
       Dir.cd(path) do
-        File.write File.join(path, "format.cr"), "if true\n1\nend"
-        File.write File.join(path, "not_format.cr"), "if true\n  1\nend\n"
-        File.write File.join(path, "syntax_error.cr"), "if"
-        File.write File.join(path, "invalid_byte_sequence_error.cr"), "\xfe\xff"
+        File.write "format.cr", "if true\n1\nend"
+        File.write "not_format.cr", "if true\n  1\nend\n"
+        File.write "syntax_error.cr", "if"
+        File.write "invalid_byte_sequence_error.cr", "\xfe\xff"
 
         format_command = Crystal::Command::FormatCommand.new([] of String, check: true, color: false, stdin: stdin, stdout: stdout, stderr: stderr)
         format_command.run
@@ -239,8 +239,8 @@ describe Crystal::Command::FormatCommand do
     with_tempfile("check_files_format_ok") do |path|
       FileUtils.mkdir_p path
       Dir.cd(path) do
-        File.write File.join(path, "format1.cr"), "if true\n  1\nend\n"
-        File.write File.join(path, "format2.cr"), "if true\n  2\nend\n"
+        File.write "format1.cr", "if true\n  1\nend\n"
+        File.write "format2.cr", "if true\n  2\nend\n"
 
         format_command = Crystal::Command::FormatCommand.new([] of String, check: true, color: false, stdin: stdin, stdout: stdout, stderr: stderr)
         format_command.run
@@ -259,8 +259,8 @@ describe Crystal::Command::FormatCommand do
     with_tempfile("check_files_format_excludes") do |path|
       FileUtils.mkdir_p path
       Dir.cd(path) do
-        File.write File.join(path, "format.cr"), "if true\n1\nend"
-        File.write File.join(path, "not_format.cr"), "if true\n  1\nend\n"
+        File.write "format.cr", "if true\n1\nend"
+        File.write "not_format.cr", "if true\n  1\nend\n"
 
         format_command = Crystal::Command::FormatCommand.new([] of String, check: true, excludes: ["format.cr"], color: false, stdin: stdin, stdout: stdout, stderr: stderr)
         format_command.run
@@ -279,8 +279,8 @@ describe Crystal::Command::FormatCommand do
     with_tempfile("check_files_format_excludes_includes") do |path|
       FileUtils.mkdir_p path
       Dir.cd(path) do
-        File.write File.join(path, "format.cr"), "if true\n1\nend"
-        File.write File.join(path, "not_format.cr"), "if true\n  1\nend\n"
+        File.write "format.cr", "if true\n1\nend"
+        File.write "not_format.cr", "if true\n  1\nend\n"
 
         format_command = Crystal::Command::FormatCommand.new([] of String, check: true, excludes: ["format.cr"], includes: ["format.cr"], color: false, stdin: stdin, stdout: stdout, stderr: stderr)
         format_command.run

--- a/spec/compiler/crystal/tools/format_spec.cr
+++ b/spec/compiler/crystal/tools/format_spec.cr
@@ -110,7 +110,7 @@ describe Crystal::Command::FormatCommand do
     stdout = IO::Memory.new
     stderr = IO::Memory.new
 
-    with_temdir do
+    with_tempdir do
       Dir.mkdir "dir"
       File.write "format.cr", "if true\n1\nend"
       File.write "not_format.cr", "if true\n  1\nend\n"

--- a/spec/compiler/crystal/tools/init_spec.cr
+++ b/spec/compiler/crystal/tools/init_spec.cr
@@ -20,17 +20,6 @@ private def exec_init(project_name, project_dir = nil, type = "lib", force = fal
   Crystal::Init::InitProject.new(config).run
 end
 
-# Creates a temporary directory, cd to it and run the block inside it.
-# The directory and its content is deleted when the block return.
-private def within_temporary_directory(&)
-  with_tempfile "init_spec_tmp" do |tmp_path|
-    Dir.mkdir_p(tmp_path)
-    Dir.cd(tmp_path) do
-      yield
-    end
-  end
-end
-
 private def with_file(name, &)
   yield File.read(name)
 end
@@ -52,7 +41,7 @@ module Crystal
     it "correctly uses git config" do
       pending! "Git is not available" unless git_available?
 
-      within_temporary_directory do
+      with_tempdir("git-config") do
         File.write(".gitconfig", <<-INI)
         [user]
           email = dorian@dorianmarie.fr
@@ -70,7 +59,7 @@ module Crystal
     end
 
     it "has proper contents" do
-      within_temporary_directory do
+      with_tempdir("proper-contents") do
         run_init_project("lib", "example", "John Smith", "john@smith.com", "jsmith")
         run_init_project("app", "example_app", "John Smith", "john@smith.com", "jsmith")
         run_init_project("app", "num-followed-hyphen-1", "John Smith", "john@smith.com", "jsmith")
@@ -231,7 +220,7 @@ module Crystal
 
   describe "Init invocation" do
     it "produces valid yaml file" do
-      within_temporary_directory do
+      with_tempdir("valid-yaml") do
         exec_init("example", "example", "app")
 
         with_file "example/shard.yml" do |file|
@@ -241,7 +230,7 @@ module Crystal
     end
 
     it "prints error if a file is already present" do
-      within_temporary_directory do
+      with_tempdir("already-present") do
         existing_file = "existing-file"
         File.touch(existing_file)
         expect_raises(Crystal::Init::Error, "#{existing_file.inspect} is a file") do
@@ -251,7 +240,7 @@ module Crystal
     end
 
     it "honors the custom set directory name" do
-      within_temporary_directory do
+      with_tempdir("directory-name") do
         project_name = "my_project"
         project_dir = "project_dir"
 
@@ -266,7 +255,7 @@ module Crystal
     end
 
     it "errors if files will be overwritten by a generated file" do
-      within_temporary_directory do
+      with_tempdir("generated-file") do
         File.write("README.md", "content before init")
 
         ex = expect_raises(Crystal::Init::FilesConflictError) do
@@ -280,7 +269,7 @@ module Crystal
     end
 
     it "doesn't error if files will be overwritten by a generated file and --force is used" do
-      within_temporary_directory do
+      with_tempdir("generated-force") do
         File.write("README.md", "content before init")
         File.exists?("README.md").should be_true
 
@@ -292,7 +281,7 @@ module Crystal
     end
 
     it "doesn't error when asked to skip existing files" do
-      within_temporary_directory do
+      with_tempdir("skip-existing") do
         File.write("README.md", "content before init")
 
         exec_init("my_lib", ".", skip_existing: true)
@@ -336,7 +325,7 @@ module Crystal
     end
 
     it "DIR = ." do
-      within_temporary_directory do
+      with_tempdir("DIR=.") do
         config = Crystal::Init.parse_args(["lib", "."])
         config.name.should eq File.basename(Dir.current)
         config.dir.should eq "."

--- a/spec/compiler/crystal/tools/init_spec.cr
+++ b/spec/compiler/crystal/tools/init_spec.cr
@@ -325,7 +325,7 @@ module Crystal
     end
 
     it "DIR = ." do
-      with_tempdir("DIR=.") do
+      with_tempdir("dir-dot") do
         config = Crystal::Init.parse_args(["lib", "."])
         config.name.should eq File.basename(Dir.current)
         config.dir.should eq "."

--- a/spec/compiler/semantic/warnings_spec.cr
+++ b/spec/compiler/semantic/warnings_spec.cr
@@ -228,42 +228,40 @@ describe "Semantic: warnings" do
     end
 
     it "ignore deprecation excluded locations" do
-      with_tempfile("check_warnings_excludes") do |path|
-        FileUtils.mkdir_p File.join(path, "lib")
+      with_tempdir("check_warnings_excludes") do
+        Dir.mkdir "lib"
 
         # NOTE tempfile might be created in symlinked folder
         # which affects how to match current dir /var/folders/...
         # with the real path /private/var/folders/...
-        path = File.realpath(path)
+        path = File.realpath(".")
 
         main_filename = File.join(path, "main.cr")
         output_filename = File.join(path, "main")
 
-        Dir.cd(path) do
-          File.write main_filename, <<-CRYSTAL
-            require "./lib/foo"
+        File.write main_filename, <<-CRYSTAL
+          require "./lib/foo"
 
-            bar
+          bar
+          foo
+          CRYSTAL
+        File.write File.join(path, "lib", "foo.cr"), <<-CRYSTAL
+          @[Deprecated("Do not use me")]
+          def foo
+          end
+
+          def bar
             foo
-            CRYSTAL
-          File.write File.join(path, "lib", "foo.cr"), <<-CRYSTAL
-            @[Deprecated("Do not use me")]
-            def foo
-            end
+          end
+          CRYSTAL
 
-            def bar
-              foo
-            end
-            CRYSTAL
+        compiler = create_spec_compiler
+        compiler.warnings.level = :all
+        compiler.warnings.exclude_lib_path = true
+        compiler.prelude = "empty"
+        compiler.compile Compiler::Source.new(main_filename, File.read(main_filename)), output_filename
 
-          compiler = create_spec_compiler
-          compiler.warnings.level = :all
-          compiler.warnings.exclude_lib_path = true
-          compiler.prelude = "empty"
-          compiler.compile Compiler::Source.new(main_filename, File.read(main_filename)), output_filename
-
-          compiler.warnings.infos.size.should eq(1)
-        end
+        compiler.warnings.infos.size.should eq(1)
       end
     end
 
@@ -410,42 +408,40 @@ describe "Semantic: warnings" do
     end
 
     it "ignore deprecation excluded locations" do
-      with_tempfile("check_warnings_excludes") do |path|
-        FileUtils.mkdir_p File.join(path, "lib")
+      with_tempdir("check_warnings_excludes") do
+        Dir.mkdir_p "lib"
 
         # NOTE tempfile might be created in symlinked folder
         # which affects how to match current dir /var/folders/...
         # with the real path /private/var/folders/...
-        path = File.realpath(path)
+        path = File.realpath(".")
 
         main_filename = File.join(path, "main.cr")
         output_filename = File.join(path, "main")
 
-        Dir.cd(path) do
-          File.write main_filename, %(
-            require "./lib/foo"
+        File.write main_filename, %(
+          require "./lib/foo"
 
-            bar
+          bar
+          foo
+        )
+        File.write File.join(path, "lib", "foo.cr"), %(
+          @[Deprecated("Do not use me")]
+          macro foo
+          end
+
+          macro bar
             foo
-          )
-          File.write File.join(path, "lib", "foo.cr"), %(
-            @[Deprecated("Do not use me")]
-            macro foo
-            end
+          end
+        )
 
-            macro bar
-              foo
-            end
-          )
+        compiler = create_spec_compiler
+        compiler.warnings.level = :all
+        compiler.warnings.exclude_lib_path = true
+        compiler.prelude = "empty"
+        compiler.compile Compiler::Source.new(main_filename, File.read(main_filename)), output_filename
 
-          compiler = create_spec_compiler
-          compiler.warnings.level = :all
-          compiler.warnings.exclude_lib_path = true
-          compiler.prelude = "empty"
-          compiler.compile Compiler::Source.new(main_filename, File.read(main_filename)), output_filename
-
-          compiler.warnings.infos.size.should eq(1)
-        end
+        compiler.warnings.infos.size.should eq(1)
       end
     end
 

--- a/spec/std/dir_spec.cr
+++ b/spec/std/dir_spec.cr
@@ -224,36 +224,30 @@ describe "Dir" do
     end
 
     it "tests double recursive matcher (#10807)" do
-      with_tempfile "glob-double-recurse" do |path|
-        Dir.mkdir_p path
-        Dir.cd(path) do
-          path1 = Path["x", "b", "x"]
-          Dir.mkdir_p path1
-          File.touch path1.join("file")
+      with_tempdir "glob-double-recurse" do
+        path1 = Path["x", "b", "x"]
+        Dir.mkdir_p path1
+        File.touch path1.join("file")
 
-          Dir["**/b/**/*"].sort.should eq [
-            path1.to_s,
-            path1.join("file").to_s,
-          ].sort
-        end
+        Dir["**/b/**/*"].sort.should eq [
+          path1.to_s,
+          path1.join("file").to_s,
+        ].sort
       end
     end
 
     it "tests double recursive matcher, multiple paths" do
-      with_tempfile "glob-double-recurse2" do |path|
-        Dir.mkdir_p path
-        Dir.cd(path) do
-          p1 = Path["x", "a", "x", "c"]
-          p2 = Path["x", "a", "x", "a", "x", "c"]
+      with_tempdir "glob-double-recurse2" do
+        p1 = Path["x", "a", "x", "c"]
+        p2 = Path["x", "a", "x", "a", "x", "c"]
 
-          Dir.mkdir_p p1
-          Dir.mkdir_p p2
+        Dir.mkdir_p p1
+        Dir.mkdir_p p2
 
-          Dir["**/a/**/c"].sort.should eq [
-            p1.to_s,
-            p2.to_s,
-          ].sort
-        end
+        Dir["**/a/**/c"].sort.should eq [
+          p1.to_s,
+          p2.to_s,
+        ].sort
       end
     end
 
@@ -314,22 +308,19 @@ describe "Dir" do
       pending "tests with \\"
     {% else %}
       it "tests with \\" do
-        with_tempfile "glob-escape-pattern" do |path|
-          Dir.mkdir_p path
-          Dir.cd(path) do
-            File.touch "g1.txt"
-            File.touch %q(\g3)
-            File.touch %q(\g4*)
+        with_tempdir "glob-escape-pattern" do
+          File.touch "g1.txt"
+          File.touch %q(\g3)
+          File.touch %q(\g4*)
 
-            Dir[%q(\\g*)].sort.should eq [
-              "\\g3",
-              "\\g4*",
-            ].sort
+          Dir[%q(\\g*)].sort.should eq [
+            "\\g3",
+            "\\g4*",
+          ].sort
 
-            Dir[%q(*g?\*)].sort.should eq [
-              "\\g4*",
-            ].sort
-          end
+          Dir[%q(*g?\*)].sort.should eq [
+            "\\g4*",
+          ].sort
         end
       end
     {% end %}

--- a/spec/std/exception/call_stack_spec.cr
+++ b/spec/std/exception/call_stack_spec.cr
@@ -79,14 +79,11 @@ describe "Backtrace" do
       source_file = datapath("blank_test_file.txt")
       compile_file(source_file) do |executable_file|
         output, error = IO::Memory.new, IO::Memory.new
-        with_tempfile("non-existent") do |path|
-          Dir.mkdir path
-          Dir.cd(path) do
-            Dir.delete(path)
-            status = Process.run executable_file
+        with_tempdir("non-existent") do
+          Dir.delete(Dir.current)
+          status = Process.run executable_file
 
-            status.success?.should be_true
-          end
+          status.success?.should be_true
         end
       end
     end

--- a/spec/support/tempfile.cr
+++ b/spec/support/tempfile.cr
@@ -38,6 +38,24 @@ def with_tempfile(*paths, file = __FILE__, &)
   end
 end
 
+# Creates a temporary directory and exposes it as working directory in the
+# block.
+#
+# Use the `name` parameter to specify the name of the directory.
+# It should be unique per spec file. If nil, a random name is chosen
+# (`File.tempname`).
+#
+# The lifetime of the temporary directory is the same was for `.with_tempfile`.
+def with_tempdir(name : String? = nil, *, file = __FILE__, &)
+  name ||= File.tempname(dir: ".")
+  with_tempfile(name, file: file) do |path|
+    Dir.mkdir_p(path)
+    Dir.cd(path) do
+      yield
+    end
+  end
+end
+
 def with_temp_executable(name, file = __FILE__, &)
   {% if flag?(:win32) %}
     name += ".exe"


### PR DESCRIPTION
Adds a convenient spec helper to simplify the pattern `with_tempfile` + `Dir.mkdir` + `Dir.cd` which is found all over the place.
Like `with_tempfile`, this helper is part of the spec library and available to all users of the standard library.

It also replaces the private `within_temporary_directory` helper from `init_spec`.