### PR TITLE
Fix: Copy annotations in  `Crystal::Arg#copy_without_location`

### DIFF
--- a/src/compiler/crystal/semantic/ast.cr
+++ b/src/compiler/crystal/semantic/ast.cr
@@ -125,6 +125,8 @@ module Crystal
       # and must be preserved when cloned
       arg.set_type @type
 
+      arg.annotations = @annotations.dup
+
       arg
     end
   end


### PR DESCRIPTION
Extracted from https://github.com/crystal-lang/crystal/pull/15999.