### PR TITLE
Refactor `unless ... else`

### DIFF
--- a/.ameba.yml
+++ b/.ameba.yml
@@ -184,9 +184,6 @@ Style/RedundantReturn:
 Style/RedundantSelf:
   Enabled: false
 
-Style/UnlessElse:
-  Enabled: false
-
 Style/VerboseBlock:
   Enabled: false
 

--- a/src/compiler/crystal/semantic/type_guess_visitor.cr
+++ b/src/compiler/crystal/semantic/type_guess_visitor.cr
@@ -396,10 +396,10 @@ module Crystal
 
     def add_type_info(vars, name, type, node)
       info = vars[name]?
-      unless info
-        info = TypeInfo.new(type, node.location.not_nil!)
-      else
+      if info
         info.type = Type.merge!(type, info.type)
+      else
+        info = TypeInfo.new(type, node.location.not_nil!)
       end
       info.outside_def = true if @outside_def
       vars[name] = info
@@ -413,10 +413,10 @@ module Crystal
       end
 
       info = vars[name]?
-      unless info
-        info = InstanceVarTypeInfo.new(node.location.not_nil!, type)
-      else
+      if info
         info.type = Type.merge!(info.type, type)
+      else
+        info = InstanceVarTypeInfo.new(node.location.not_nil!, type)
       end
       info.outside_def = true if @outside_def
       info.add_annotations(annotations) if annotations

--- a/src/compiler/crystal/semantic/type_guess_visitor.cr
+++ b/src/compiler/crystal/semantic/type_guess_visitor.cr
@@ -398,13 +398,11 @@ module Crystal
       info = vars[name]?
       unless info
         info = TypeInfo.new(type, node.location.not_nil!)
-        info.outside_def = true if @outside_def
-        vars[name] = info
       else
         info.type = Type.merge!(type, info.type)
-        info.outside_def = true if @outside_def
-        vars[name] = info
       end
+      info.outside_def = true if @outside_def
+      vars[name] = info
     end
 
     def add_instance_var_type_info(vars, name, type : Type, node)
@@ -417,15 +415,12 @@ module Crystal
       info = vars[name]?
       unless info
         info = InstanceVarTypeInfo.new(node.location.not_nil!, type)
-        info.outside_def = true if @outside_def
-        info.add_annotations(annotations) if annotations
-        vars[name] = info
       else
         info.type = Type.merge!(info.type, type)
-        info.outside_def = true if @outside_def
-        info.add_annotations(annotations) if annotations
-        vars[name] = info
       end
+      info.outside_def = true if @outside_def
+      info.add_annotations(annotations) if annotations
+      vars[name] = info
     end
 
     def guess_type(node : NumberLiteral)

--- a/src/compiler/crystal/tools/playground/server.cr
+++ b/src/compiler/crystal/tools/playground/server.cr
@@ -192,14 +192,12 @@ module Crystal::Playground
               length = io.read_utf8(Slice.new(buffer, 4096))
               {length, 0}
             end
-            unless output.empty?
-              send_with_json_builder do |json|
-                json.field "type", "output"
-                json.field "tag", tag
-                json.field "content", output
-              end
-            else
-              break
+            break if output.empty?
+
+            send_with_json_builder do |json|
+              json.field "type", "output"
+              json.field "tag", tag
+              json.field "content", output
             end
           rescue
             break

--- a/src/crystal/pointer_linked_list.cr
+++ b/src/crystal/pointer_linked_list.cr
@@ -33,12 +33,12 @@ struct Crystal::PointerLinkedList(T)
 
   # Appends a node to the tail of the list.
   def push(node : Pointer(T)) : Nil
-    unless empty?
-      typeof(self).insert_impl node, @head.value.previous, @head
-    else
+    if empty?
       node.value.previous = node
       node.value.next = node
       @head = node
+    else
+      typeof(self).insert_impl node, @head.value.previous, @head
     end
   end
 
@@ -56,10 +56,10 @@ struct Crystal::PointerLinkedList(T)
 
   # Removes and returns head from the list, yields if empty
   def shift(&)
-    unless empty?
-      @head.tap { |t| delete(t) }
-    else
+    if empty?
       yield
+    else
+      @head.tap { |t| delete(t) }
     end
   end
 

--- a/src/path.cr
+++ b/src/path.cr
@@ -762,7 +762,9 @@ struct Path
       end
     end
 
-    unless new_instance(name).absolute?
+    if new_instance(name).absolute?
+      expanded = name
+    else
       unless base.absolute? || !expand_base
         base = base.expand
       end
@@ -805,8 +807,6 @@ struct Path
       else
         expanded = base.join(name)
       end
-    else
-      expanded = name
     end
 
     expanded = new_instance(expanded) unless expanded.is_a?(Path)

--- a/src/uri/punycode.cr
+++ b/src/uri/punycode.cr
@@ -119,7 +119,7 @@ class URI
         i += digit * w
         t = k <= bias ? TMIN : k >= bias + TMAX ? TMAX : k - bias
 
-        unless digit < t
+        if digit >= t
           w *= BASE - t
           k += BASE
         else


### PR DESCRIPTION
Replaces `unless` conditionals with an `else` branch. Either by swapping branches, inverting conditions, or other refactors.
Also enables the `Style/UnlessElse` rule in ameba config to avoid `unless ... else` in the future.