### PR TITLE
Add suppport for deprecated parameters in doc generator

### DIFF
--- a/spec/compiler/crystal/tools/doc/generator_spec.cr
+++ b/spec/compiler/crystal/tools/doc/generator_spec.cr
@@ -204,6 +204,22 @@ describe Doc::Generator do
           doc_method.formatted_doc.should eq %(<p>Some Method</p>\n<p><span class="flag #{color}">#{ann.upcase}</span>  lorem ipsum</p>)
         end
       end
+
+      describe "with #{ann} annotation in parameter" do
+        it "should generate the #{ann} tag" do
+          program = Program.new
+          generator = Doc::Generator.new program, ["."]
+          doc_type = Doc::Type.new generator, program
+
+          a_def = Def.new "foo"
+          a_def.doc = "Some Method"
+          arg = Arg.new("bar")
+          arg.add_annotation(program.types[ann].as(Crystal::AnnotationType), Annotation.new(Crystal::Path.new(ann), ["lorem ipsum".string] of ASTNode))
+          a_def.args << arg
+          doc_method = Doc::Method.new generator, doc_type, a_def, false
+          doc_method.formatted_doc.should eq %(<p>Some Method</p>\n<p><span class="flag #{color}">#{ann.upcase} parameter <code>bar</code></span>  lorem ipsum</p>)
+        end
+      end
     end
 
     describe "with no annotation, and no docs" do

--- a/src/compiler/crystal/tools/doc/generator.cr
+++ b/src/compiler/crystal/tools/doc/generator.cr
@@ -320,7 +320,9 @@ class Crystal::Doc::Generator
 
   def doc(context, string)
     string = isolate_flag_lines string
-    string += build_flag_lines_from_annotations context
+    if annotations = build_flag_lines_from_annotations context
+      string += "\n\n" + annotations
+    end
     markdown = render_markdown(context, string)
     generate_flags markdown
   end
@@ -364,20 +366,15 @@ class Crystal::Doc::Generator
   end
 
   def build_flag_lines_from_annotations(context)
-    first = true
     String.build do |io|
       if anns = context.annotations(@program.deprecated_annotation)
         anns.each do |ann|
-          io << "\n\n" if first
-          first = false
           io << "DEPRECATED: #{DeprecatedAnnotation.from(ann).message}\n\n"
         end
       end
 
       if anns = context.annotations(@program.experimental_annotation)
         anns.each do |ann|
-          io << "\n\n" if first
-          first = false
           io << "EXPERIMENTAL: #{ExperimentalAnnotation.from(ann).message}\n\n"
         end
       end


### PR DESCRIPTION
A deprecation annotation on a parameter generates a deprecation notice on the API doc for the method.

```cr
# This is foo
def foo(@[Deprecated("Do not use")] x = 1)
end
```
> This is foo.
>
> **DEPRECATED parameter `x`**
> Do not use.

This goes alongside #15999 which adds deprecation warnings for deprecated parameters.