### PR TITLE
Removed unused variables

### DIFF
--- a/.ameba.yml
+++ b/.ameba.yml
@@ -88,9 +88,20 @@ Lint/UnusedArgument:
 Lint/UnusedBlockArgument:
   Enabled: false
 
-# FIXME: Investigate useless assigns.
 Lint/UselessAssign:
-  Enabled: false
+  # BUG: https://github.com/crystal-ameba/ameba/issues/447
+  # This setting is to avoid false positives from the common use of type
+  # declarations in macro arguments.
+  ExcludeTypeDeclarations: true
+  Excluded:
+    - spec/debug/**/*
+    - samples/mt_gc_test.cr
+    # BUG: https://github.com/crystal-ameba/ameba/issues/624
+    - spec/std/concurrent/select_spec.cr
+    # Generators assign top-level variables to pass to ECR templates
+    - scripts/generate_*
+    # BUG: https://github.com/crystal-ameba/ameba/issues/623
+    - scripts/github-changelog.cr
 
 # Metrics
 # =========================

--- a/samples/llvm/brainfuck.cr
+++ b/samples/llvm/brainfuck.cr
@@ -234,7 +234,6 @@ class Program
   def add_cells_init(mod, bb)
     builder.position_at_end bb
 
-    calloc = mod.functions["calloc"]
     call_args = [@ctx.int32.const_int(NUM_CELLS), @ctx.int32.const_int(CELL_SIZE_IN_BYTES)]
     @cells_ptr = call_c_function "calloc", call_args, "cells"
 

--- a/scripts/github-changelog.cr
+++ b/scripts/github-changelog.cr
@@ -338,7 +338,7 @@ class ChangelogEntry
 
   def to_s(io : IO)
     if sub_topic = pr.sub_topic
-      io << "*(" << pr.sub_topic << ")* "
+      io << "*(" << sub_topic << ")* "
     end
     if pr.labels.includes?("security")
       io << "**[security]** "

--- a/scripts/test_ssl_server.cr
+++ b/scripts/test_ssl_server.cr
@@ -16,7 +16,7 @@ server = HTTP::Server.new do |context|
   context.response.content_type = "text/plain"
   context.response.print "Hello world!"
 end
-server_context, client_context = ssl_context_pair
+server_context, _client_context = ssl_context_pair
 address = server.bind_tls "0.0.0.0", 0, server_context
 
 puts "== Starting HTTP server at #{address}"

--- a/spec/compiler/crystal/tools/context_spec.cr
+++ b/spec/compiler/crystal/tools/context_spec.cr
@@ -24,7 +24,7 @@ private def run_context_tool(code, &)
   code = code.delete('‸')
 
   if cursor_location
-    visitor, result = processed_context_visitor(code, cursor_location)
+    _, result = processed_context_visitor(code, cursor_location)
 
     yield result
   else

--- a/spec/compiler/crystal/tools/expand_spec.cr
+++ b/spec/compiler/crystal/tools/expand_spec.cr
@@ -26,7 +26,7 @@ private def run_expand_tool(code, &)
   code = code.delete('‸')
 
   if cursor_location
-    visitor, result = processed_expand_visitor(code, cursor_location)
+    _, result = processed_expand_visitor(code, cursor_location)
 
     yield result
   else

--- a/spec/compiler/crystal/tools/implementations_spec.cr
+++ b/spec/compiler/crystal/tools/implementations_spec.cr
@@ -29,7 +29,7 @@ private def assert_implementations(code)
   code = code.delete &.in?('‸', '༓')
 
   if cursor_location
-    visitor, result = processed_implementation_visitor(code, cursor_location)
+    _, result = processed_implementation_visitor(code, cursor_location)
 
     result_locations = result.implementations.not_nil!.map do |e|
       Location.new(e.filename.not_nil!, e.line.not_nil!, e.column.not_nil!).to_s
@@ -173,7 +173,7 @@ describe "implementations" do
   end
 
   it "find full trace for macro expansions" do
-    visitor, result = processed_implementation_visitor(%(
+    _, result = processed_implementation_visitor(%(
       macro foo
         def bar
         end
@@ -211,7 +211,7 @@ describe "implementations" do
   end
 
   it "can display text output" do
-    visitor, result = processed_implementation_visitor(%(
+    _, result = processed_implementation_visitor(%(
       macro foo
         def bar
         end

--- a/spec/compiler/macro/macro_methods_spec.cr
+++ b/spec/compiler/macro/macro_methods_spec.cr
@@ -1773,7 +1773,7 @@ module Crystal
         it "does not include trailing + for virtual type" do
           assert_macro("{{klass.id}}", "Foo") do |program|
             foo = NonGenericClassType.new(program, program, "Foo", program.reference)
-            bar = NonGenericClassType.new(program, program, "Bar", foo)
+            NonGenericClassType.new(program, program, "Bar", foo)
             {klass: TypeNode.new(foo.virtual_type)}
           end
         end

--- a/spec/compiler/semantic/class_spec.cr
+++ b/spec/compiler/semantic/class_spec.cr
@@ -48,7 +48,7 @@ describe "Semantic: class" do
     ") do
       foo = types["Foo"].as(GenericClassType)
       foo_i32 = foo.instantiate([int32] of TypeVar)
-      foo_foo_i32 = foo.instantiate([foo_i32] of TypeVar)
+      _foo_foo_i32 = foo.instantiate([foo_i32] of TypeVar)
     end
   end
 

--- a/spec/compiler/semantic/pointer_spec.cr
+++ b/spec/compiler/semantic/pointer_spec.cr
@@ -56,7 +56,7 @@ describe "Semantic: pointer" do
   end
 
   it "types pointer of constant" do
-    result = assert_type("
+    assert_type("
       FOO = 1
       pointerof(FOO)
     ") { pointer_of(int32) }

--- a/spec/compiler/semantic/virtual_spec.cr
+++ b/spec/compiler/semantic/virtual_spec.cr
@@ -107,7 +107,7 @@ describe "Semantic: virtual" do
       x.foo
       ")
     result = semantic nodes
-    mod, nodes = result.program, result.node.as(Expressions)
+    _, nodes = result.program, result.node.as(Expressions)
     nodes.last.as(Call).target_defs.not_nil!.size.should eq(1)
   end
 
@@ -130,7 +130,7 @@ describe "Semantic: virtual" do
       x.foo
       ")
     result = semantic nodes
-    mod, nodes = result.program, result.node.as(Expressions)
+    _, nodes = result.program, result.node.as(Expressions)
     nodes.last.as(Call).target_defs.not_nil!.size.should eq(2)
   end
 

--- a/spec/compiler/semantic/warnings_spec.cr
+++ b/spec/compiler/semantic/warnings_spec.cr
@@ -268,7 +268,7 @@ describe "Semantic: warnings" do
     end
 
     it "ignores nested calls to deprecated methods" do
-      x = assert_warning <<-CRYSTAL,
+      assert_warning <<-CRYSTAL,
         @[Deprecated]
         def foo; bar; end
 

--- a/spec/primitives/pointer_spec.cr
+++ b/spec/primitives/pointer_spec.cr
@@ -17,7 +17,7 @@ describe "Primitives: pointer" do
   describe ".malloc" do
     pending_interpreted "is non-atomic for ReferenceStorage(T) if T is non-atomic (#14692)" do
       FinalizeState.reset
-      outer = Outer.unsafe_construct(Pointer(ReferenceStorage(Outer)).malloc(1))
+      Outer.unsafe_construct(Pointer(ReferenceStorage(Outer)).malloc(1))
       GC.collect
       FinalizeState.count("reference-storage").should eq(0)
     end

--- a/spec/std/crystal/event_loop/polling/arena_spec.cr
+++ b/spec/std/crystal/event_loop/polling/arena_spec.cr
@@ -32,7 +32,6 @@ describe Crystal::EventLoop::Polling::Arena do
 
     it "allocates up to capacity" do
       arena = Crystal::EventLoop::Polling::Arena(Int32, 96).new(32)
-      indexes = [] of Crystal::EventLoop::Polling::Arena::Index
 
       indexes = 32.times.map do |i|
         arena.allocate_at?(i) { |ptr, _| ptr.value = i }

--- a/spec/std/file/tempfile_spec.cr
+++ b/spec/std/file/tempfile_spec.cr
@@ -221,7 +221,7 @@ describe Crystal::System::File do
         Dir.mkdir tempdir
         File.touch Path[tempdir, "A789abcdeZ"]
         expect_raises(File::AlreadyExistsError, "Error creating temporary file") do
-          fd, path, _ = Crystal::System::File.mktemp("A", "Z", dir: tempdir, random: TestRNG.new([7, 8, 9, 10, 11, 12, 13, 14]))
+          fd, _, _ = Crystal::System::File.mktemp("A", "Z", dir: tempdir, random: TestRNG.new([7, 8, 9, 10, 11, 12, 13, 14]))
         ensure
           IO::FileDescriptor.new(fd).close if fd
         end

--- a/spec/std/float_printer/grisu3_spec.cr
+++ b/spec/std/float_printer/grisu3_spec.cr
@@ -90,7 +90,7 @@ describe "grisu3" do
     it "failure case" do
       # grisu should not be able to do this number
       # this number is reused to ensure the fallback works
-      status, point, str = test_grisu 3.5844466002796428e+298
+      status, _, str = test_grisu 3.5844466002796428e+298
       status.should be_false
       str.should_not eq "35844466002796428"
     end

--- a/spec/std/http/request_spec.cr
+++ b/spec/std/http/request_spec.cr
@@ -444,7 +444,6 @@ module HTTP
 
       it "is affected when #query is modified" do
         request = Request.from_io(IO::Memory.new("GET /api/v3/some/resource?foo=bar&foo=baz&baz=qux HTTP/1.1\r\n\r\n")).as(Request)
-        params = request.query_params
 
         new_query = "foo=not-bar&foo=not-baz&not-baz=hello&name=world"
         request.query = new_query

--- a/spec/std/http/server/server_spec.cr
+++ b/spec/std/http/server/server_spec.cr
@@ -274,7 +274,6 @@ describe HTTP::Server do
         server = HTTP::Server.new { }
 
         private_key = datapath("openssl", "openssl.key")
-        certificate = datapath("openssl", "openssl.crt")
 
         begin
           expect_raises(ArgumentError, "missing private key") { server.bind "tls://127.0.0.1:8081" }

--- a/spec/std/io/argf_spec.cr
+++ b/spec/std/io/argf_spec.cr
@@ -42,9 +42,9 @@ describe IO::ARGF do
     argf = IO::ARGF.new [datapath("argf_test_file_3.xml")], IO::Memory.new
     argf.read(Bytes.new(4))
     buf = Bytes.new(4096)
-    z = argf.read(buf)
-    z = argf.read(buf)
-    z = argf.read(buf)
+    argf.read(buf)
+    argf.read(buf)
+    argf.read(buf)
     z = argf.read(buf)
     z.should_not eq 0
     String.new(buf[0...z]).should_not be_empty

--- a/spec/std/oauth2/session_spec.cr
+++ b/spec/std/oauth2/session_spec.cr
@@ -5,7 +5,7 @@ module OAuth2
   typeof(begin
     client = Client.new "localhost", "client_id", "client_secret", redirect_uri: "uri", authorize_uri: "/baz"
     token = OAuth2::AccessToken::Bearer.new("token", 3600)
-    session = Session.new(client, token) { |_| }
+    Session.new(client, token) { |_| }
     session = Session.new(client, token, Time.utc) { |_| }
     session.authenticate(HTTP::Client.new("localhost"))
   end)

--- a/spec/std/string/utf16_spec.cr
+++ b/spec/std/string/utf16_spec.cr
@@ -75,7 +75,7 @@ describe "String UTF16" do
       pointer = input.to_unsafe
       string, pointer = String.from_utf16(pointer)
       string.should eq("")
-      string, pointer = String.from_utf16(pointer)
+      string, _ = String.from_utf16(pointer)
       string.should eq("hello\u{d7ff}")
     end
 

--- a/spec/std/uri/params_spec.cr
+++ b/spec/std/uri/params_spec.cr
@@ -90,7 +90,7 @@ class URI
 
       it "builds from named tuple with IO" do
         io = IO::Memory.new
-        encoded = Params.encode(io, {foo: "bar", baz: ["quux", "quuz"]})
+        Params.encode(io, {foo: "bar", baz: ["quux", "quuz"]})
         io.to_s.should eq("foo=bar&baz=quux&baz=quuz")
       end
     end

--- a/spec/std/weak_ref_spec.cr
+++ b/spec/std/weak_ref_spec.cr
@@ -27,6 +27,7 @@ describe WeakRef do
     foo = "foo"
     ref = WeakRef.new(foo)
     GC.collect
+    ref.value.should be(foo)
   end
 
   it "FinalizeState counts released objects" do

--- a/src/big/big_int.cr
+++ b/src/big/big_int.cr
@@ -725,7 +725,6 @@ struct BigInt < Int
     end
 
     x = T.zero
-    preshift_limit = T::MAX >> bits_per_limb
     limbs.reverse_each do |limb|
       x <<= bits_per_limb
       x |= limb

--- a/src/compiler/crystal/codegen/const.cr
+++ b/src/compiler/crystal/codegen/const.cr
@@ -146,7 +146,7 @@ class Crystal::CodeGenVisitor
   end
 
   def create_initialize_const_function(fun_name, const)
-    global, initialized_flag = declare_const_and_initialized_flag(const)
+    global, _ = declare_const_and_initialized_flag(const)
 
     in_main do
       define_main_function(fun_name, ([] of LLVM::Type), llvm_context.void, needs_alloca: true) do |func|

--- a/src/compiler/crystal/codegen/primitives.cr
+++ b/src/compiler/crystal/codegen/primitives.cr
@@ -139,7 +139,7 @@ class Crystal::CodeGenVisitor
     when "*"      then return codegen_mul_with_overflow(t1, t2, p1, p2)
     end
 
-    tmax, p1, p2 = codegen_binary_extend_int(t1, t2, p1, p2)
+    _, p1, p2 = codegen_binary_extend_int(t1, t2, p1, p2)
 
     case op
     when "&+"              then codegen_trunc_binary_op_result(t1, t2, builder.add(p1, p2))

--- a/src/compiler/crystal/command.cr
+++ b/src/compiler/crystal/command.cr
@@ -259,7 +259,7 @@ class Crystal::Command
   end
 
   private def types
-    config, result = compile_no_codegen "tool types"
+    _, result = compile_no_codegen "tool types"
     @progress_tracker.stage("Tool (types)") do
       Crystal.print_types result.node
     end

--- a/src/compiler/crystal/compiler.cr
+++ b/src/compiler/crystal/compiler.cr
@@ -553,7 +553,6 @@ module Crystal
 
     private def codegen(program, units : Array(CompilationUnit), output_filename, output_dir)
       object_names = units.map &.object_filename
-      target_triple = target_machine.triple
 
       @progress_tracker.stage("Codegen (bc+obj)") do
         @progress_tracker.stage_progress_total = units.size

--- a/src/compiler/crystal/compiler.cr
+++ b/src/compiler/crystal/compiler.cr
@@ -254,7 +254,7 @@ module Crystal
       source = [source] unless source.is_a?(Array)
       program = new_program(source)
       node = parse program, source
-      node, processor = program.top_level_semantic(node)
+      node, _ = program.top_level_semantic(node)
 
       @progress_tracker.clear
       print_macro_run_stats(program)

--- a/src/compiler/crystal/interpreter/cast.cr
+++ b/src/compiler/crystal/interpreter/cast.cr
@@ -48,7 +48,9 @@ class Crystal::Repl::Compiler
         compatible_type = to.union_types.find! { |union_type| type_needing_cast.implements?(union_type) }
 
         # Get the type id of the "from" union
-        from_type_id = get_union_type_id(aligned_sizeof_type(from), node: node)
+        # FIXME: This looks fishy. The variable is never used, only referenced in another comment.
+        # Can we safely drop this entire line?
+        from_type_id = get_union_type_id(aligned_sizeof_type(from), node: node) # ameba:disable Lint/UselessAssign
 
         # Check if `from_type_id` is the same as `type_needing_cast`
         put_i32 type_id(type_needing_cast), node: node

--- a/src/compiler/crystal/interpreter/cast.cr
+++ b/src/compiler/crystal/interpreter/cast.cr
@@ -267,7 +267,6 @@ class Crystal::Repl::Compiler
 
   private def cast_tuple(node : ASTNode, from : TupleInstanceType, to : TupleInstanceType)
     from_aligned_size = aligned_sizeof_type(from)
-    to_aligned_size = aligned_sizeof_type(to)
     to_element_offset = 0
 
     to.tuple_types.each_with_index do |to_element_type, i|
@@ -309,7 +308,6 @@ class Crystal::Repl::Compiler
 
   private def cast_named_tuple(node : ASTNode, from : NamedTupleInstanceType, to : NamedTupleInstanceType)
     from_aligned_size = aligned_sizeof_type(from)
-    to_aligned_size = aligned_sizeof_type(to)
     to_element_offset = 0
 
     from_entry_indices = to.entries.map_with_index do |to_entry, i|

--- a/src/compiler/crystal/interpreter/compiler.cr
+++ b/src/compiler/crystal/interpreter/compiler.cr
@@ -1235,9 +1235,7 @@ class Crystal::Repl::Compiler < Crystal::Visitor
       end
     end
 
-    ivar = obj_type.lookup_instance_var(name)
     ivar_offset = ivar_offset(obj_type, name)
-    ivar_size = inner_sizeof_type(ivar)
 
     # Get a pointer to the object
     if obj_type.passed_by_value?
@@ -1554,8 +1552,7 @@ class Crystal::Repl::Compiler < Crystal::Visitor
     var = lookup_local_var_or_closured_var(name)
     case var
     in LocalVar
-      index, type = var.index, var.type
-      pointerof_var(index, node: node)
+      pointerof_var(var.index, node: node)
     in ClosuredVar
       read_closured_var_pointer(var, node: node)
     end

--- a/src/compiler/crystal/interpreter/primitives.cr
+++ b/src/compiler/crystal/interpreter/primitives.cr
@@ -389,7 +389,6 @@ class Crystal::Repl::Compiler
       ivar_name = '@' + node.name.rchop # remove the '=' suffix
       ivar = type.lookup_instance_var(ivar_name)
       ivar_offset = ivar_offset(type, ivar_name)
-      ivar_size = inner_sizeof_type(type.lookup_instance_var(ivar_name))
 
       # pointer_set needs first arg, then obj
       request_value(arg)

--- a/src/compiler/crystal/semantic/call.cr
+++ b/src/compiler/crystal/semantic/call.cr
@@ -1115,7 +1115,7 @@ class Crystal::Call
     # This will insert this node into the trace as the new first frame.
     self.raise ex.message, ex, exception_type: Crystal::MacroRaiseException
   rescue ex : Crystal::CodeError
-    if (obj = @obj) && name == "initialize"
+    if @obj && name == "initialize"
       # Avoid putting 'initialize' in the error trace
       # because it's most likely that this is happening
       # inside a generated 'new' method

--- a/src/compiler/crystal/semantic/main_visitor.cr
+++ b/src/compiler/crystal/semantic/main_visitor.cr
@@ -1020,8 +1020,6 @@ module Crystal
 
       before_block_vars = node.vars.try(&.dup) || MetaVars.new
 
-      body_exps = node.body.as?(Expressions).try(&.expressions)
-
       # Variables that we don't want to get their type merged
       # with local variables before the block occurrence:
       # mainly block arguments (locally override vars), but

--- a/src/compiler/crystal/syntax/lexer.cr
+++ b/src/compiler/crystal/syntax/lexer.cr
@@ -2037,7 +2037,7 @@ module Crystal
     end
 
     def macro_starts_with_keyword?(beginning_of_line) : MacroKeywordState?
-      case char = current_char
+      case current_char
       when 'a'
         case next_char
         when 'b'

--- a/src/compiler/crystal/syntax/parser.cr
+++ b/src/compiler/crystal/syntax/parser.cr
@@ -2246,7 +2246,7 @@ module Crystal
       pieces = [] of Piece
       has_interpolation = false
 
-      delimiter_state, has_interpolation, options, end_location = consume_delimiter pieces, delimiter_state, has_interpolation
+      delimiter_state, has_interpolation, _options, end_location = consume_delimiter pieces, delimiter_state, has_interpolation
 
       if has_interpolation
         pieces = combine_interpolation_pieces(pieces, delimiter_state)
@@ -3895,7 +3895,7 @@ module Crystal
         allow_restrictions = false
       else
         param_location = @token.location
-        param_name, external_name, found_space, uses_param = parse_param_name(param_location, extra_assigns, allow_external_name: allow_external_name)
+        param_name, external_name, found_space, _uses_param = parse_param_name(param_location, extra_assigns, allow_external_name: allow_external_name)
 
         params.each do |param|
           if param.name == param_name
@@ -3989,7 +3989,7 @@ module Crystal
       if @token.type.op_rparen? || @token.type.newline? || @token.type.op_colon?
         param_name = ""
       else
-        param_name, external_name, found_space, uses_param = parse_param_name(name_location, extra_assigns, allow_external_name: false)
+        param_name, _external_name, found_space, uses_param = parse_param_name(name_location, extra_assigns, allow_external_name: false)
         @uses_block_arg = true if uses_param
       end
 

--- a/src/compiler/crystal/syntax/parser.cr
+++ b/src/compiler/crystal/syntax/parser.cr
@@ -4504,7 +4504,6 @@ module Crystal
     def parse_block_params(location)
       block_params = [] of Var
       all_names = [] of String
-      block_body = nil
       param_index = 0
       splat_index = nil
       unpacks = nil

--- a/src/compiler/crystal/syntax/to_s.cr
+++ b/src/compiler/crystal/syntax/to_s.cr
@@ -1100,8 +1100,6 @@ module Crystal
     end
 
     def visit(node : Generic)
-      name = node.name
-
       node.name.accept self
 
       printed_arg = false

--- a/src/compiler/crystal/tools/formatter.cr
+++ b/src/compiler/crystal/tools/formatter.cr
@@ -4246,7 +4246,6 @@ module Crystal
 
     def visit(node : ProcLiteral)
       write_token :OP_MINUS_GT
-      whitespace_after_op_minus_gt = @token.type.space?
       skip_space_or_newline
 
       a_def = node.def

--- a/src/compiler/crystal/tools/macro_code_coverage.cr
+++ b/src/compiler/crystal/tools/macro_code_coverage.cr
@@ -177,7 +177,7 @@ module Crystal
         # Keep track of what specific conditional branches were hit and missed as to ensure a proper partial count.
         # In certain cases there may be more than 1 missed node, in which case we'll use the last non-missed node.
         # Otherwise if there are none that are missed or only one, it's safe to just use the last node.
-        node, _, missed = case missed_count = nodes.count { |(_, _, missed)| missed }
+        node, _, missed = case nodes.count { |(_, _, missed)| missed }
                           when 0, 1
                             nodes.last
                           else

--- a/src/compiler/crystal/tools/print_hierarchy.cr
+++ b/src/compiler/crystal/tools/print_hierarchy.cr
@@ -375,7 +375,7 @@ module Crystal
       @json.field "kind", type.struct? ? "struct" : "class"
 
       if type_size = type_size(type)
-        @json.field "size_in_bytes", type_size(type)
+        @json.field "size_in_bytes", type_size
       end
     end
 

--- a/src/compress/gzip/header.cr
+++ b/src/compress/gzip/header.cr
@@ -37,7 +37,7 @@ class Compress::Gzip::Header
     seconds = IO::ByteFormat::LittleEndian.decode(Int32, header.to_slice[4, 4])
     @modification_time = Time.unix(seconds).to_local
 
-    xfl = header[8]
+    _xfl = header[8]
     @os = header[9]
 
     if flg.extra?
@@ -55,7 +55,7 @@ class Compress::Gzip::Header
     end
 
     if flg.hcrc?
-      crc16 = io.read_bytes(UInt16, IO::ByteFormat::LittleEndian)
+      _crc16 = io.read_bytes(UInt16, IO::ByteFormat::LittleEndian)
       # TODO check crc16
     end
   end

--- a/src/crystal/digest/md5.cr
+++ b/src/crystal/digest/md5.cr
@@ -108,25 +108,25 @@ class Crystal::Digest::MD5 < ::Digest
   private def ff(a, b, c, d, x, s, ac)
     a &+= f(b, c, d) &+ x &+ ac.to_u32
     a = a.rotate_left s
-    a &+= b
+    a &+ b
   end
 
   private def gg(a, b, c, d, x, s, ac)
     a &+= g(b, c, d) &+ x &+ ac.to_u32
     a = a.rotate_left s
-    a &+= b
+    a &+ b
   end
 
   private def hh(a, b, c, d, x, s, ac)
     a &+= h(b, c, d) &+ x &+ ac.to_u32
     a = a.rotate_left s
-    a &+= b
+    a &+ b
   end
 
   private def ii(a, b, c, d, x, s, ac)
     a &+= i(b, c, d) &+ x &+ ac.to_u32
     a = a.rotate_left s
-    a &+= b
+    a &+ b
   end
 
   private def transform(input)

--- a/src/crystal/system/win32/socket.cr
+++ b/src/crystal/system/win32/socket.cr
@@ -198,7 +198,7 @@ module Crystal::System::Socket
       result = yield operation
 
       if result == 0
-        case error = WinError.wsa_value
+        case WinError.wsa_value
         when .wsa_io_pending?
           # the operation is running asynchronously; do nothing
         else

--- a/src/fiber/execution_context/parallel.cr
+++ b/src/fiber/execution_context/parallel.cr
@@ -294,8 +294,8 @@ module Fiber::ExecutionContext
           # we must also decrement the number of parked threads because another
           # thread could lock the mutex and increment @spinning again before the
           # signaled thread is resumed
-          spinning = @spinning.add(1, :acquire_release)
-          parked = @parked.sub(1, :acquire_release)
+          @spinning.add(1, :acquire_release)
+          @parked.sub(1, :acquire_release)
 
           @condition.signal
         end

--- a/src/file/match.cr
+++ b/src/file/match.cr
@@ -44,7 +44,6 @@ class File < IO::FileDescriptor
   end
 
   private def self.match_internal(glob_str, path_str, separators)
-    glob = glob_str.to_slice
     state = State.new(separators: separators.to_static_array.to_slice)
 
     # Store the state when we see an opening '{' brace in a stack.

--- a/src/float/printer/cached_powers.cr
+++ b/src/float/printer/cached_powers.cr
@@ -156,7 +156,6 @@ module Float::Printer::CachedPowers
   # around *exp* (boundaries included).
   def self.get_cached_power_for_binary_exponent(exp) : {DiyFP, Int32}
     min_exp = MIN_TARGET_EXP - (exp + DiyFP::SIGNIFICAND_SIZE)
-    max_exp = MAX_TARGET_EXP - (exp + DiyFP::SIGNIFICAND_SIZE)
     k = ((min_exp + DiyFP::SIGNIFICAND_SIZE - 1) * D_1_LOG2_10).ceil
     index = ((CACHED_POWER_OFFSET + k.to_i - 1) // CACHED_EXP_STEP) + 1
     pow = PowCache[index]

--- a/src/float/printer/ryu_printf.cr
+++ b/src/float/printer/ryu_printf.cr
@@ -128,7 +128,7 @@ module Float::Printer::RyuPrintf
   end
 
   private def self.mulshift_mod1e9(m : UInt64, mul : {UInt64, UInt64, UInt64}, j : Int32) : UInt32
-    high0, low0 = umul128(m, mul[0])
+    high0, _ = umul128(m, mul[0])
     high1, low1 = umul128(m, mul[1])
     high2, low2 = umul128(m, mul[2])
 

--- a/src/regex/pcre2.cr
+++ b/src/regex/pcre2.cr
@@ -219,7 +219,7 @@ module Regex::PCRE2
   end
 
   private def matches_impl(str, byte_index, options)
-    if match_data = match_data(str, byte_index, options)
+    if match_data(str, byte_index, options)
       true
     else
       false

--- a/src/string_scanner.cr
+++ b/src/string_scanner.cr
@@ -411,7 +411,7 @@ class StringScanner
 
     def []?(range : Range) : Array(String)?
       start, count = Indexable.range_to_index_and_count(range, 1) || return nil
-      start, count = Indexable.normalize_start_and_count(start, count, 1) { return nil }
+      _, count = Indexable.normalize_start_and_count(start, count, 1) { return nil }
       return [] of String if count == 0
       [@str]
     end

--- a/src/time/location/loader.cr
+++ b/src/time/location/loader.cr
@@ -291,7 +291,7 @@ class Time::Location
       file.skip 6
       compression_method = file.read_bytes(Int16, IO::ByteFormat::LittleEndian)
       file.skip 12
-      uncompressed_size = file.read_bytes(Int32, IO::ByteFormat::LittleEndian)
+      _uncompressed_size = file.read_bytes(Int32, IO::ByteFormat::LittleEndian)
       filename_length = file.read_bytes(Int16, IO::ByteFormat::LittleEndian)
       extra_field_length = file.read_bytes(Int16, IO::ByteFormat::LittleEndian)
       file_comment_length = file.read_bytes(Int16, IO::ByteFormat::LittleEndian)

--- a/src/time/tz.cr
+++ b/src/time/tz.cr
@@ -31,7 +31,6 @@ module Time::TZ
     if numyears == 4 # leap
       numyears = 3
     end
-    total_days -= numyears * 365
 
     num400 * 400 + num100 * 100 + num4 * 4 + numyears + 1
   end


### PR DESCRIPTION
Unused variables are a code smell. This refactor either removes the assignment, or makes sure the variable is used. There were only a few cases where a variable was intended to be used, but that was missed (https://github.com/crystal-lang/crystal/commit/bc9763f441c367dfc6b360339bc24a39fa8c945c). They don't seem to have any effect on correctness, though.

Also enables the `Lint/UselessAssign` rule in ameba config to avoid these in the future.