### PR TITLE
Fix use of `File.readlink` in `Crystal::System::Time.load_localtime` [fixup #16002]

### DIFF
--- a/src/crystal/system/unix/time.cr
+++ b/src/crystal/system/unix/time.cr
@@ -137,7 +137,7 @@ module Crystal::System::Time
       # We do not load the actual target file, only extract the name so the
       # resulting location is exactly the same as when loading it explicitly
       # as `Time::Location.load("Europe/Berlin")`.
-      if ::File.symlink?("/etc/localtime") && (realpath = (File.readlink("/etc/localtime") rescue nil))
+      if ::File.symlink?("/etc/localtime") && (realpath = ::File.readlink?("/etc/localtime"))
         if pos = realpath.rindex("zoneinfo/")
           name = realpath[(pos + "zoneinfo/".size)..]
           return ::Time::Location.load(name)


### PR DESCRIPTION
Fixes a regression caused by simultaneous changes to the same code in #16004 and #16002 (https://github.com/crystal-lang/crystal/pull/16004#issuecomment-3104982015).

The call was never supposed to go to `File.readlink` (i.e. `Crystal::System::File.readlink`) but the public method `::File.readlink`.
Now with `::File.readlink?` available from #16004, we can use that directly.