### PR TITLE
Default to LLVM 16 in `shell.nix`

### DIFF
--- a/shell.nix
+++ b/shell.nix
@@ -19,7 +19,7 @@
 # $ nix-shell --pure --arg musl true
 #
 
-{llvm ? 11, musl ? false, system ? builtins.currentSystem}:
+{llvm ? 16, musl ? false, system ? builtins.currentSystem}:
 
 let
   nixpkgs = import (builtins.fetchTarball {


### PR DESCRIPTION
Updates `shell.nix` to install LLVM 16 instead of LLVM 11 by default. The immediate benefit is that the macOS CI will finally use a less outdated LLVM release.

Sadly, newer LLVM releases would require to upgrade to nixOS 24.05 at least, but it exhibits some bugs around iconv. See #14651 and #15212 for example.