### PR TITLE
Show extern union types in hierarchy tool

### DIFF
--- a/spec/compiler/crystal/tools/hierarchy_spec.cr
+++ b/spec/compiler/crystal/tools/hierarchy_spec.cr
@@ -164,6 +164,27 @@ describe Crystal::TextHierarchyPrinter do
                      @x : Proc(Nil) (8 bytes)\n
       EOS
   end
+
+  it "shows extern unions" do
+    assert_text_hierarchy <<-CRYSTAL, "Foo", <<-EOS
+      lib Lib
+        union Foo
+          x : Int32
+          y : Float64
+        end
+      end
+      CRYSTAL
+      - class Object (4 bytes)
+        |
+        +- struct Value (0 bytes)
+           |
+           +- struct Struct (0 bytes)
+              |
+              +- union Lib::Foo (8 bytes)
+                     @x : Int32   (4 bytes)
+                     @y : Float64 (8 bytes)\n
+      EOS
+  end
 end
 
 describe Crystal::JSONHierarchyPrinter do
@@ -194,6 +215,57 @@ describe Crystal::JSONHierarchyPrinter do
                     "name": "Bar",
                     "kind": "class",
                     "size_in_bytes": 4,
+                    "sub_types": []
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      }
+      JSON
+  end
+
+  it "shows extern unions" do
+    assert_json_hierarchy <<-CRYSTAL, "Foo", <<-JSON
+      lib Lib
+        union Foo
+          x : Int32
+          y : Float64
+        end
+      end
+      CRYSTAL
+      {
+        "name": "Object",
+        "kind": "class",
+        "size_in_bytes": 4,
+        "sub_types": [
+          {
+            "name": "Value",
+            "kind": "struct",
+            "size_in_bytes": 0,
+            "sub_types": [
+              {
+                "name": "Struct",
+                "kind": "struct",
+                "size_in_bytes": 0,
+                "sub_types": [
+                  {
+                    "name": "Lib::Foo",
+                    "kind": "union",
+                    "size_in_bytes": 8,
+                    "instance_vars": [
+                      {
+                        "name": "@x",
+                        "type": "Int32",
+                        "size_in_bytes": 4
+                      },
+                      {
+                        "name": "@y",
+                        "type": "Float64",
+                        "size_in_bytes": 8
+                      }
+                    ],
                     "sub_types": []
                   }
                 ]

--- a/src/compiler/crystal/tools/print_hierarchy.cr
+++ b/src/compiler/crystal/tools/print_hierarchy.cr
@@ -102,6 +102,10 @@ module Crystal
       false
     end
 
+    def type_kind(type)
+      type.extern_union? ? "union" : type.struct? ? "struct" : "class"
+    end
+
     def type_size(type)
       return nil unless constant_type_size?(type)
 
@@ -246,7 +250,7 @@ module Crystal
     def print_type_name(type)
       print_indent
       @io << "+" unless @indents.empty?
-      @io << "- " << (type.struct? ? "struct" : "class") << " " << type
+      @io << "- " << type_kind(type) << " " << type
 
       if type_size = type_size(type)
         with_color.light_gray.surround(@io) do
@@ -372,7 +376,7 @@ module Crystal
 
     def print_type_name(type)
       @json.field "name", type.to_s
-      @json.field "kind", type.struct? ? "struct" : "class"
+      @json.field "kind", type_kind(type)
 
       if type_size = type_size(type)
         @json.field "size_in_bytes", type_size(type)


### PR DESCRIPTION
They have different layout rules from structs, and this patch would make it clear.