### PR TITLE
Add `.set_blocking` to `Socket` and `IO::FileDescriptor` and deprecate `#blocking` property

### DIFF
--- a/spec/std/io/file_descriptor_spec.cr
+++ b/spec/std/io/file_descriptor_spec.cr
@@ -189,19 +189,23 @@ describe IO::FileDescriptor do
     end
   {% end %}
 
-  {% if flag?(:unix) %}
-    it ".set_blocking" do
-      File.open(datapath("test_file.txt"), "r") do |file|
-        fd = file.fd
+  it ".set_blocking and .get_blocking" do
+    File.open(datapath("test_file.txt"), "r") do |file|
+      fd = file.fd
 
+      {% if flag?(:win32) %}
+        expect_raises(NotImplementedError) { IO::FileDescriptor.set_blocking(fd, false) }
+        expect_raises(NotImplementedError) { IO::FileDescriptor.set_blocking(fd, true) }
+        expect_raises(NotImplementedError) { IO::FileDescriptor.get_blocking(fd) }
+      {% else %}
         IO::FileDescriptor.set_blocking(fd, false)
-        IO::FileDescriptor.fcntl(fd, LibC::F_GETFL).bits_set?(LibC::O_NONBLOCK).should be_true
+        IO::FileDescriptor.get_blocking(fd).should be_false
 
         IO::FileDescriptor.set_blocking(fd, true)
-        IO::FileDescriptor.fcntl(fd, LibC::F_GETFL).bits_set?(LibC::O_NONBLOCK).should be_false
-      end
+        IO::FileDescriptor.get_blocking(fd).should be_true
+      {% end %}
     end
-  {% end %}
+  end
 
   typeof(STDIN.noecho { })
   typeof(STDIN.noecho!)

--- a/spec/std/io/file_descriptor_spec.cr
+++ b/spec/std/io/file_descriptor_spec.cr
@@ -189,6 +189,20 @@ describe IO::FileDescriptor do
     end
   {% end %}
 
+  {% if flag?(:unix) %}
+    it ".set_blocking" do
+      File.open(datapath("test_file.txt"), "r") do |file|
+        fd = file.fd
+
+        IO::FileDescriptor.set_blocking(fd, false)
+        IO::FileDescriptor.fcntl(fd, LibC::F_GETFL).bits_set?(LibC::O_NONBLOCK).should be_true
+
+        IO::FileDescriptor.set_blocking(fd, true)
+        IO::FileDescriptor.fcntl(fd, LibC::F_GETFL).bits_set?(LibC::O_NONBLOCK).should be_false
+      end
+    end
+  {% end %}
+
   typeof(STDIN.noecho { })
   typeof(STDIN.noecho!)
   typeof(STDIN.echo { })

--- a/spec/std/socket/socket_spec.cr
+++ b/spec/std/socket/socket_spec.cr
@@ -181,20 +181,22 @@ describe Socket, tags: "network" do
     end
   {% end %}
 
-  it ".set_blocking" do
-    # we can't check the blocking mode on windows; we thus merely check that the
-    # methods compile and run without errors
+  it ".set_blocking and .get_blocking" do
     socket = Socket.tcp(Socket::Family::INET)
     fd = socket.fd
 
     Socket.set_blocking(fd, true)
-    {% unless flag?(:win32) %}
-      Socket.fcntl(fd, LibC::F_GETFL).bits_set?(LibC::O_NONBLOCK).should be_false
+    {% if flag?(:win32) %}
+      expect_raises(NotImplementedError) { IO::FileDescriptor.get_blocking(fd) }
+    {% else %}
+      Socket.get_blocking(fd).should be_true
     {% end %}
 
     Socket.set_blocking(fd, false)
-    {% unless flag?(:win32) %}
-      IO::FileDescriptor.fcntl(fd, LibC::F_GETFL).bits_set?(LibC::O_NONBLOCK).should be_true
+    {% if flag?(:win32) %}
+      expect_raises(NotImplementedError) { IO::FileDescriptor.get_blocking(fd) }
+    {% else %}
+      Socket.get_blocking(fd).should be_false
     {% end %}
   end
 

--- a/spec/std/socket/socket_spec.cr
+++ b/spec/std/socket/socket_spec.cr
@@ -181,6 +181,23 @@ describe Socket, tags: "network" do
     end
   {% end %}
 
+  it ".set_blocking" do
+    # we can't check the blocking mode on windows; we thus merely check that the
+    # methods compile and run without errors
+    socket = Socket.tcp(Socket::Family::INET)
+    fd = socket.fd
+
+    Socket.set_blocking(fd, true)
+    {% unless flag?(:win32) %}
+      Socket.fcntl(fd, LibC::F_GETFL).bits_set?(LibC::O_NONBLOCK).should be_false
+    {% end %}
+
+    Socket.set_blocking(fd, false)
+    {% unless flag?(:win32) %}
+      IO::FileDescriptor.fcntl(fd, LibC::F_GETFL).bits_set?(LibC::O_NONBLOCK).should be_true
+    {% end %}
+  end
+
   describe "#finalize" do
     it "does not flush" do
       port = unused_local_tcp_port

--- a/src/crystal/system/unix/file_descriptor.cr
+++ b/src/crystal/system/unix/file_descriptor.cr
@@ -27,6 +27,10 @@ module Crystal::System::FileDescriptor
     FileDescriptor.set_blocking(fd, value)
   end
 
+  protected def self.get_blocking(fd : Handle)
+    fcntl(fd, LibC::F_GETFL) & LibC::O_NONBLOCK == 0
+  end
+
   protected def self.set_blocking(fd : Handle, value : Bool)
     current_flags = fcntl(fd, LibC::F_GETFL)
     new_flags = current_flags

--- a/src/crystal/system/unix/file_descriptor.cr
+++ b/src/crystal/system/unix/file_descriptor.cr
@@ -27,7 +27,7 @@ module Crystal::System::FileDescriptor
     FileDescriptor.set_blocking(fd, value)
   end
 
-  protected def self.set_blocking(fd, value)
+  protected def self.set_blocking(fd : Handle, value : Bool)
     current_flags = fcntl(fd, LibC::F_GETFL)
     new_flags = current_flags
     if value

--- a/src/crystal/system/unix/process.cr
+++ b/src/crystal/system/unix/process.cr
@@ -361,7 +361,7 @@ struct Crystal::System::Process
       ret = LibC.dup2(src_io.fd, dst_io.fd)
       raise IO::Error.from_errno("dup2") if ret == -1
 
-      dst_io.blocking = true
+      FileDescriptor.set_blocking(dst_io.fd, true)
       dst_io.close_on_exec = false
     end
   end

--- a/src/crystal/system/unix/socket.cr
+++ b/src/crystal/system/unix/socket.cr
@@ -160,13 +160,17 @@ module Crystal::System::Socket
   end
 
   private def system_blocking=(value)
-    flags = fcntl(LibC::F_GETFL)
+    Socket.set_blocking(fd, value)
+  end
+
+  def self.set_blocking(fd : Handle, value : Bool)
+    flags = fcntl(fd, LibC::F_GETFL)
     if value
       flags &= ~LibC::O_NONBLOCK
     else
       flags |= LibC::O_NONBLOCK
     end
-    fcntl(LibC::F_SETFL, flags)
+    fcntl(fd, LibC::F_SETFL, flags)
   end
 
   private def system_close_on_exec?

--- a/src/crystal/system/unix/socket.cr
+++ b/src/crystal/system/unix/socket.cr
@@ -156,11 +156,15 @@ module Crystal::System::Socket
   end
 
   private def system_blocking?
-    fcntl(LibC::F_GETFL) & LibC::O_NONBLOCK == 0
+    Socket.get_blocking(fd)
   end
 
   private def system_blocking=(value)
     Socket.set_blocking(fd, value)
+  end
+
+  def self.get_blocking(fd : Handle)
+    fcntl(fd, LibC::F_GETFL) & LibC::O_NONBLOCK == 0
   end
 
   def self.set_blocking(fd : Handle, value : Bool)

--- a/src/crystal/system/wasi/file_descriptor.cr
+++ b/src/crystal/system/wasi/file_descriptor.cr
@@ -13,6 +13,10 @@ module Crystal::System::FileDescriptor
     r
   end
 
+  def self.get_blocking(fd : Handle)
+    raise NotImplementedError.new("Crystal::System::FileDescriptor.get_blocking")
+  end
+
   def self.set_blocking(fd : Handle, value : Bool)
     raise NotImplementedError.new("Crystal::System::FileDescriptor.set_blocking")
   end

--- a/src/crystal/system/wasi/file_descriptor.cr
+++ b/src/crystal/system/wasi/file_descriptor.cr
@@ -13,6 +13,10 @@ module Crystal::System::FileDescriptor
     r
   end
 
+  def self.set_blocking(fd : Handle, value : Bool)
+    raise NotImplementedError.new("Crystal::System::FileDescriptor.set_blocking")
+  end
+
   protected def system_blocking_init(blocking : Bool?)
   end
 

--- a/src/crystal/system/wasi/socket.cr
+++ b/src/crystal/system/wasi/socket.cr
@@ -102,11 +102,15 @@ module Crystal::System::Socket
   end
 
   private def system_blocking?
-    fcntl(LibC::F_GETFL) & LibC::O_NONBLOCK == 0
+    Socket.get_blocking(fd)
   end
 
   private def system_blocking=(value)
-    System.set_blocking(fd, value)
+    Socket.set_blocking(fd, value)
+  end
+
+  def self.get_blocking(fd : Handle)
+    fcntl(fd, LibC::F_GETFL) & LibC::O_NONBLOCK == 0
   end
 
   def self.set_blocking(fd : Handle, value : Bool)

--- a/src/crystal/system/wasi/socket.cr
+++ b/src/crystal/system/wasi/socket.cr
@@ -106,13 +106,17 @@ module Crystal::System::Socket
   end
 
   private def system_blocking=(value)
-    flags = fcntl(LibC::F_GETFL)
+    System.set_blocking(fd, value)
+  end
+
+  def self.set_blocking(fd : Handle, value : Bool)
+    flags = fcntl(fd, LibC::F_GETFL)
     if value
       flags &= ~LibC::O_NONBLOCK
     else
       flags |= LibC::O_NONBLOCK
     end
-    fcntl(LibC::F_SETFL, flags)
+    fcntl(fd, LibC::F_SETFL, flags)
   end
 
   private def system_close_on_exec?

--- a/src/crystal/system/win32/file_descriptor.cr
+++ b/src/crystal/system/win32/file_descriptor.cr
@@ -98,6 +98,10 @@ module Crystal::System::FileDescriptor
     @system_blocking
   end
 
+  def self.get_blocking(fd : Handle)
+    raise NotImplementedError.new("Cannot query the blocking mode of an `IO::FileDescriptor`")
+  end
+
   def self.set_blocking(fd : Handle, value : Bool)
     raise NotImplementedError.new("Cannot change the blocking mode of an `IO::FileDescriptor` after creation")
   end

--- a/src/crystal/system/win32/file_descriptor.cr
+++ b/src/crystal/system/win32/file_descriptor.cr
@@ -98,8 +98,12 @@ module Crystal::System::FileDescriptor
     @system_blocking
   end
 
+  def self.set_blocking(fd : Handle, value : Bool)
+    raise NotImplementedError.new("Cannot change the blocking mode of an `IO::FileDescriptor` after creation")
+  end
+
   private def system_blocking=(blocking)
-    unless blocking == self.blocking
+    unless blocking == system_blocking?
       raise IO::Error.new("Cannot reconfigure `IO::FileDescriptor#blocking` after creation")
     end
   end
@@ -366,7 +370,7 @@ module Crystal::System::FileDescriptor
     # `blocking` must be set to `true` because the underlying handles never
     # support overlapped I/O; instead, `#emulated_blocking?` should return
     # `false` for `STDIN` as it uses a separate thread
-    io = IO::FileDescriptor.new(handle.address, blocking: true)
+    io = IO::FileDescriptor.new(handle: handle.address, blocking: true)
 
     # Set sync or flush_on_newline as described in STDOUT and STDERR docs.
     # See https://crystal-lang.org/api/toplevel.html#STDERR

--- a/src/crystal/system/win32/socket.cr
+++ b/src/crystal/system/win32/socket.cr
@@ -345,6 +345,10 @@ module Crystal::System::Socket
     Socket.set_blocking(fd, blocking)
   end
 
+  def self.get_blocking(fd : Handle)
+    raise NotImplementedError.new("Cannot query the blocking mode of a `Socket`")
+  end
+
   # Changes the blocking mode as per BSD sockets, has no effect on the
   # overlapped flag.
   def self.set_blocking(fd : Handle, value : Bool)

--- a/src/crystal/system/win32/socket.cr
+++ b/src/crystal/system/win32/socket.cr
@@ -331,7 +331,7 @@ module Crystal::System::Socket
     ret
   end
 
-  @blocking = true
+  @blocking : Bool = true
 
   # WSA does not provide a direct way to query the blocking mode of a file descriptor.
   # The best option seems to be just keeping track in an instance variable.
@@ -347,8 +347,8 @@ module Crystal::System::Socket
 
   # Changes the blocking mode as per BSD sockets, has no effect on the
   # overlapped flag.
-  def self.set_blocking(fd, blocking)
-    mode = blocking ? 1_u32 : 0_u32
+  def self.set_blocking(fd : Handle, value : Bool)
+    mode = value ? 1_u32 : 0_u32
     ret = LibC.WSAIoctl(fd, LibC::FIONBIO, pointerof(mode), sizeof(UInt32), nil, 0, out _, nil, nil)
     raise ::Socket::Error.from_wsa_error("WSAIoctl") unless ret.zero?
   end

--- a/src/io/file_descriptor.cr
+++ b/src/io/file_descriptor.cr
@@ -79,10 +79,19 @@ class IO::FileDescriptor < IO
   # This might be different from the internal file descriptor. For example, when
   # `STDIN` is a terminal on Windows, this returns `false` since the underlying
   # blocking reads are done on a completely separate thread.
+  @[Deprecated("There are no replacement.")]
   def blocking
     emulated = emulated_blocking?
     return emulated unless emulated.nil?
     system_blocking?
+  end
+
+  # Changes the blocking mode of *fd* to be blocking (true) or non blocking
+  # (false).
+  #
+  # NOTE: Only implemented on UNIX targets. Raises on Windows.
+  def self.set_blocking(fd : Handle, value : Bool)
+    Crystal::System::FileDescriptor.set_blocking(fd, value)
   end
 
   # Changes the file descriptor's mode to blocking (true) or non blocking
@@ -92,6 +101,7 @@ class IO::FileDescriptor < IO
   # the event loop runtime requirements. Changing the blocking mode can cause
   # the event loop to misbehave, for example block the entire program when a
   # fiber tries to read from this file descriptor.
+  @[Deprecated("Use IO::FileDescriptor.set_blocking instead.")]
   def blocking=(value)
     self.system_blocking = value
   end

--- a/src/io/file_descriptor.cr
+++ b/src/io/file_descriptor.cr
@@ -83,7 +83,7 @@ class IO::FileDescriptor < IO
   # This might be different from the internal file descriptor. For example, when
   # `STDIN` is a terminal on Windows, this returns `false` since the underlying
   # blocking reads are done on a completely separate thread.
-  @[Deprecated("There are no replacement.")]
+  @[Deprecated("There is no replacement.")]
   def blocking
     emulated = emulated_blocking?
     return emulated unless emulated.nil?

--- a/src/io/file_descriptor.cr
+++ b/src/io/file_descriptor.cr
@@ -61,11 +61,15 @@ class IO::FileDescriptor < IO
 
   # :nodoc:
   #
-  # Internal constructor to wrap a system *handle*.
-  def initialize(*, handle : Handle, @close_on_finalize = true)
+  # Internal constructor to wrap a system *handle*. The *blocking* arg is purely
+  # informational.
+  def initialize(*, handle : Handle, @close_on_finalize = true, blocking = nil)
     @volatile_fd = Atomic.new(handle)
     @closed = true # This is necessary so we can reference `self` in `system_closed?` (in case of an exception)
     @closed = system_closed?
+    {% if flag?(:win32) %}
+      @system_blocking = !!blocking
+    {% end %}
   end
 
   # :nodoc:

--- a/src/io/file_descriptor.cr
+++ b/src/io/file_descriptor.cr
@@ -83,19 +83,11 @@ class IO::FileDescriptor < IO
   # This might be different from the internal file descriptor. For example, when
   # `STDIN` is a terminal on Windows, this returns `false` since the underlying
   # blocking reads are done on a completely separate thread.
-  @[Deprecated("There is no replacement.")]
+  @[Deprecated("Use Socket.get_blocking instead.")]
   def blocking
     emulated = emulated_blocking?
     return emulated unless emulated.nil?
     system_blocking?
-  end
-
-  # Changes the blocking mode of *fd* to be blocking (true) or non blocking
-  # (false).
-  #
-  # NOTE: Only implemented on UNIX targets. Raises on Windows.
-  def self.set_blocking(fd : Handle, value : Bool)
-    Crystal::System::FileDescriptor.set_blocking(fd, value)
   end
 
   # Changes the file descriptor's mode to blocking (true) or non blocking
@@ -108,6 +100,22 @@ class IO::FileDescriptor < IO
   @[Deprecated("Use IO::FileDescriptor.set_blocking instead.")]
   def blocking=(value)
     self.system_blocking = value
+  end
+
+  # Returns whether the blocking mode of *fd* is blocking (true) or non blocking
+  # (false).
+  #
+  # NOTE: Only implemented on UNIX targets. Raises on Windows.
+  def self.get_blocking(fd : Handle) : Bool
+    Crystal::System::Socket.get_blocking(fd)
+  end
+
+  # Changes the blocking mode of *fd* to be blocking (true) or non blocking
+  # (false).
+  #
+  # NOTE: Only implemented on UNIX targets. Raises on Windows.
+  def self.set_blocking(fd : Handle, value : Bool)
+    Crystal::System::FileDescriptor.set_blocking(fd, value)
   end
 
   def close_on_exec? : Bool

--- a/src/process.cr
+++ b/src/process.cr
@@ -296,7 +296,7 @@ class Process
       # regular files will report an error and those require a separate pipe
       # (https://github.com/crystal-lang/crystal/pull/13362#issuecomment-1519082712)
       {% if flag?(:win32) %}
-        unless stdio.blocking || stdio.info.type.pipe?
+        unless stdio.system_blocking? || stdio.info.type.pipe?
           return io_to_fd(stdio, for: dst_io)
         end
       {% end %}

--- a/src/socket.cr
+++ b/src/socket.cr
@@ -421,7 +421,7 @@ class Socket < IO
   end
 
   # Returns whether the socket's mode is blocking (true) or non blocking (false).
-  @[Deprecated("There are no replacement.")]
+  @[Deprecated("Use Socket.get_blocking instead.")]
   def blocking
     system_blocking?
   end
@@ -432,9 +432,18 @@ class Socket < IO
   # loop runtime requirements. Changing the blocking mode can cause the event
   # loop to misbehave, for example block the entire program when a fiber tries
   # to read from this socket.
-  @[Deprecated("Use Socket.set_blocking(fd, value) instead.")]
+  @[Deprecated("Use Socket.set_blocking instead.")]
   def blocking=(value)
     self.system_blocking = value
+  end
+
+
+  # Returns whether the blocking mode of *fd* is blocking (true) or non blocking
+  # (false).
+  #
+  # NOTE: Only implemented on UNIX targets. Raises on Windows.
+  def self.get_blocking(fd : Handle) : Bool
+    Crystal::System::Socket.get_blocking(fd)
   end
 
   # Changes the blocking mode of *fd* to be blocking (true) or non blocking

--- a/src/socket.cr
+++ b/src/socket.cr
@@ -437,7 +437,6 @@ class Socket < IO
     self.system_blocking = value
   end
 
-
   # Returns whether the blocking mode of *fd* is blocking (true) or non blocking
   # (false).
   #


### PR DESCRIPTION
The `#blocking` properties on `Socket` and `IO::FileDescriptor` changes the underlying configuration of the system file descriptor or handle, and can conflict with the IO runtime (i.e. the event loop requirements) and lead to runtime issues.

This PR deprecates the `#blocking` property and instead introduces a couple class methods to change the blocking configuration of a raw file descriptor or handle _outside_ of the IO objects when you really need to change it:

- `IO::FileDescriptor.set_blocking(fd, value)` that's only available on UNIX targets (raises on Windows);
- `Socket.set_blocking(fd, value)` that's available on all targets (though it's legacy on Windows).

Extracted from #15924.