### PR TITLE
Deprecate the blocking arg of `File`, `Socket` and `IO::FileDescriptor` constructors

### DIFF
--- a/src/crystal/event_loop/iocp.cr
+++ b/src/crystal/event_loop/iocp.cr
@@ -238,9 +238,11 @@ class Crystal::EventLoop::IOCP < Crystal::EventLoop
 
   def pipe(read_blocking : Bool?, write_blocking : Bool?) : {IO::FileDescriptor, IO::FileDescriptor}
     r, w = System::FileDescriptor.system_pipe(!!read_blocking, !!write_blocking)
+    create_completion_port(LibC::HANDLE.new(r)) unless read_blocking
+    create_completion_port(LibC::HANDLE.new(w)) unless write_blocking
     {
-      IO::FileDescriptor.new(r, !!read_blocking),
-      IO::FileDescriptor.new(w, !!write_blocking),
+      IO::FileDescriptor.new(handle: r, blocking: !!read_blocking),
+      IO::FileDescriptor.new(handle: w, blocking: !!write_blocking),
     }
   end
 

--- a/src/crystal/event_loop/libevent.cr
+++ b/src/crystal/event_loop/libevent.cr
@@ -118,9 +118,11 @@ class Crystal::EventLoop::LibEvent < Crystal::EventLoop
 
   def pipe(read_blocking : Bool?, write_blocking : Bool?) : {IO::FileDescriptor, IO::FileDescriptor}
     r, w = System::FileDescriptor.system_pipe
+    System::FileDescriptor.set_blocking(r, false) unless read_blocking
+    System::FileDescriptor.set_blocking(w, false) unless write_blocking
     {
-      IO::FileDescriptor.new(r, !!read_blocking),
-      IO::FileDescriptor.new(w, !!write_blocking),
+      IO::FileDescriptor.new(handle: r),
+      IO::FileDescriptor.new(handle: w),
     }
   end
 

--- a/src/crystal/event_loop/polling.cr
+++ b/src/crystal/event_loop/polling.cr
@@ -164,9 +164,11 @@ abstract class Crystal::EventLoop::Polling < Crystal::EventLoop
 
   def pipe(read_blocking : Bool?, write_blocking : Bool?) : {IO::FileDescriptor, IO::FileDescriptor}
     r, w = System::FileDescriptor.system_pipe
+    System::FileDescriptor.set_blocking(r, false) unless read_blocking
+    System::FileDescriptor.set_blocking(w, false) unless write_blocking
     {
-      IO::FileDescriptor.new(r, !!read_blocking),
-      IO::FileDescriptor.new(w, !!write_blocking),
+      IO::FileDescriptor.new(handle: r),
+      IO::FileDescriptor.new(handle: w),
     }
   end
 

--- a/src/crystal/system/process.cr
+++ b/src/crystal/system/process.cr
@@ -84,9 +84,9 @@ struct Crystal::System::Process
 end
 
 module Crystal::System
-  ORIGINAL_STDIN  = IO::FileDescriptor.new(Crystal::System::FileDescriptor::STDIN_HANDLE, blocking: true)
-  ORIGINAL_STDOUT = IO::FileDescriptor.new(Crystal::System::FileDescriptor::STDOUT_HANDLE, blocking: true)
-  ORIGINAL_STDERR = IO::FileDescriptor.new(Crystal::System::FileDescriptor::STDERR_HANDLE, blocking: true)
+  ORIGINAL_STDIN  = IO::FileDescriptor.new(handle: Crystal::System::FileDescriptor::STDIN_HANDLE, blocking: true)
+  ORIGINAL_STDOUT = IO::FileDescriptor.new(handle: Crystal::System::FileDescriptor::STDOUT_HANDLE, blocking: true)
+  ORIGINAL_STDERR = IO::FileDescriptor.new(handle: Crystal::System::FileDescriptor::STDERR_HANDLE, blocking: true)
 end
 
 {% if flag?(:wasi) %}

--- a/src/file.cr
+++ b/src/file.cr
@@ -165,11 +165,13 @@ class File < IO::FileDescriptor
   #
   # NOTE: On macOS files are always opened in blocking mode because non-blocking
   # FIFO files don't work — the OS exhibits issues with readiness notifications.
-  def self.new(filename : Path | String, mode = "r", perm = DEFAULT_CREATE_PERMISSIONS, encoding = nil, invalid = nil, blocking = nil)
+  {% begin %}
+  def self.new(filename : Path | String, mode = "r", perm = DEFAULT_CREATE_PERMISSIONS, encoding = nil, invalid = nil, {% if compare_versions(Crystal::VERSION, "1.5.0") >= 0 %} @[Deprecated] {% end %} blocking = nil)
     filename = filename.to_s
     fd, blocking = Crystal::System::File.open(filename, mode, perm: perm, blocking: blocking)
     new(filename, fd, mode, blocking, encoding, invalid)
   end
+  {% end %}
 
   getter path : String
 
@@ -509,16 +511,19 @@ class File < IO::FileDescriptor
   # permissions may be set using the *perm* parameter.
   #
   # See `self.new` for what *mode* can be.
-  def self.open(filename : Path | String, mode = "r", perm = DEFAULT_CREATE_PERMISSIONS, encoding = nil, invalid = nil, blocking = nil) : self
+  {% begin %}
+  def self.open(filename : Path | String, mode = "r", perm = DEFAULT_CREATE_PERMISSIONS, encoding = nil, invalid = nil, {% if compare_versions(Crystal::VERSION, "1.5.0") >= 0 %} @[Deprecated] {% end %} blocking = nil) : self
     new filename, mode, perm, encoding, invalid, blocking
   end
+  {% end %}
 
   # Opens the file named by *filename*. If a file is being created, its initial
   # permissions may be set using the *perm* parameter. Then given block will be passed the opened
   # file as an argument, the file will be automatically closed when the block returns.
   #
   # See `self.new` for what *mode* can be.
-  def self.open(filename : Path | String, mode = "r", perm = DEFAULT_CREATE_PERMISSIONS, encoding = nil, invalid = nil, blocking = nil, &)
+  {% begin %}
+  def self.open(filename : Path | String, mode = "r", perm = DEFAULT_CREATE_PERMISSIONS, encoding = nil, invalid = nil, {% if compare_versions(Crystal::VERSION, "1.5.0") >= 0 %} @[Deprecated] {% end %} blocking = nil, &)
     file = new filename, mode, perm, encoding, invalid, blocking
     begin
       yield file
@@ -526,6 +531,7 @@ class File < IO::FileDescriptor
       file.close
     end
   end
+  {% end %}
 
   # Returns the content of *filename* as a string.
   #
@@ -533,7 +539,8 @@ class File < IO::FileDescriptor
   # File.write("bar", "foo")
   # File.read("bar") # => "foo"
   # ```
-  def self.read(filename : Path | String, encoding = nil, invalid = nil, blocking = nil) : String
+  {% begin %}
+  def self.read(filename : Path | String, encoding = nil, invalid = nil, {% if compare_versions(Crystal::VERSION, "1.5.0") >= 0 %} @[Deprecated] {% end %} blocking = nil) : String
     open(filename, "r", blocking: blocking) do |file|
       if encoding
         file.set_encoding(encoding, invalid: invalid)
@@ -550,6 +557,7 @@ class File < IO::FileDescriptor
       end
     end
   end
+  {% end %}
 
   # Yields each line in *filename* to the given block.
   #
@@ -562,13 +570,15 @@ class File < IO::FileDescriptor
   # end
   # array # => ["foo", "bar"]
   # ```
-  def self.each_line(filename : Path | String, encoding = nil, invalid = nil, chomp = true, blocking = nil, &)
+  {% begin %}
+  def self.each_line(filename : Path | String, encoding = nil, invalid = nil, chomp = true, {% if compare_versions(Crystal::VERSION, "1.5.0") >= 0 %} @[Deprecated] {% end %} blocking = nil, &)
     open(filename, "r", encoding: encoding, invalid: invalid, blocking: blocking) do |file|
       file.each_line(chomp: chomp) do |line|
         yield line
       end
     end
   end
+  {% end %}
 
   # Returns all lines in *filename* as an array of strings.
   #
@@ -576,13 +586,15 @@ class File < IO::FileDescriptor
   # File.write("foobar", "foo\nbar")
   # File.read_lines("foobar") # => ["foo", "bar"]
   # ```
-  def self.read_lines(filename : Path | String, encoding = nil, invalid = nil, chomp = true, blocking = nil) : Array(String)
+  {% begin %}
+  def self.read_lines(filename : Path | String, encoding = nil, invalid = nil, chomp = true, {% if compare_versions(Crystal::VERSION, "1.5.0") >= 0 %} @[Deprecated] {% end %} blocking = nil) : Array(String)
     lines = [] of String
     each_line(filename, encoding: encoding, invalid: invalid, chomp: chomp, blocking: blocking) do |line|
       lines << line
     end
     lines
   end
+  {% end %}
 
   # Writes the given *content* to *filename*.
   #
@@ -601,7 +613,8 @@ class File < IO::FileDescriptor
   # (the result of invoking `to_s` on *content*).
   #
   # See `self.new` for what *mode* can be.
-  def self.write(filename : Path | String, content, perm = DEFAULT_CREATE_PERMISSIONS, encoding = nil, invalid = nil, mode = "w", blocking = nil)
+  {% begin %}
+  def self.write(filename : Path | String, content, perm = DEFAULT_CREATE_PERMISSIONS, encoding = nil, invalid = nil, mode = "w", {% if compare_versions(Crystal::VERSION, "1.5.0") >= 0 %} @[Deprecated] {% end %} blocking = nil)
     open(filename, mode, perm, encoding: encoding, invalid: invalid, blocking: blocking) do |file|
       case content
       when Bytes
@@ -615,6 +628,7 @@ class File < IO::FileDescriptor
       end
     end
   end
+  {% end %}
 
   # Copies the file *src* to the file *dst*.
   # Permission bits are copied too.

--- a/src/io/file_descriptor.cr
+++ b/src/io/file_descriptor.cr
@@ -53,11 +53,13 @@ class IO::FileDescriptor < IO
   #
   # NOTE: On Windows, the handle should have been created with
   # `FILE_FLAG_OVERLAPPED`.
-  def self.new(fd : Handle, blocking = nil, *, close_on_finalize = true)
+  {% begin %}
+  def self.new(fd : Handle, {% if compare_versions(Crystal::VERSION, "1.5.0") >= 0 %} @[Deprecated("Use IO::FileDescriptor.set_blocking instead.")] {% end %} blocking = nil, *, close_on_finalize = true)
     file_descriptor = new(handle: fd, close_on_finalize: close_on_finalize)
     file_descriptor.system_blocking_init(blocking) unless file_descriptor.closed?
     file_descriptor
   end
+  {% end %}
 
   # :nodoc:
   #

--- a/src/socket.cr
+++ b/src/socket.cr
@@ -51,29 +51,45 @@ class Socket < IO
 
   # Creates a TCP socket. Consider using `TCPSocket` or `TCPServer` unless you
   # need full control over the socket.
-  def self.tcp(family : Family, blocking = nil) : self
-    new(family, Type::STREAM, Protocol::TCP, blocking)
+  {% begin %}
+  def self.tcp(family : Family, {% if compare_versions(Crystal::VERSION, "1.5.0") >= 0 %} @[Deprecated("Use Socket.set_blocking instead.")] {% end %} blocking = nil) : self
+    new(af: family, type: Type::STREAM, protocol: Protocol::TCP, blocking: blocking)
   end
+  {% end %}
 
   # Creates an UDP socket. Consider using `UDPSocket` unless you need full
   # control over the socket.
-  def self.udp(family : Family, blocking = nil)
-    new(family, Type::DGRAM, Protocol::UDP, blocking)
+  {% begin %}
+  def self.udp(family : Family, {% if compare_versions(Crystal::VERSION, "1.5.0") >= 0 %} @[Deprecated("Use Socket.set_blocking instead.")] {% end %} blocking = nil) : self
+    new(af: family, type: Type::DGRAM, protocol: Protocol::UDP, blocking: blocking)
   end
+  {% end %}
 
   # Creates an UNIX socket. Consider using `UNIXSocket` or `UNIXServer` unless
   # you need full control over the socket.
-  def self.unix(type : Type = Type::STREAM, blocking = nil) : self
-    new(Family::UNIX, type, blocking: blocking)
+  {% begin %}
+  def self.unix(type : Type = Type::STREAM, {% if compare_versions(Crystal::VERSION, "1.5.0") >= 0 %} @[Deprecated("Use Socket.set_blocking instead.")] {% end %} blocking = nil) : self
+    new(af: Family::UNIX, type: type, protocol: Protocol::IP, blocking: blocking)
   end
+  {% end %}
 
   # Creates a socket. Consider using `TCPSocket`, `TCPServer`, `UDPSocket`,
   # `UNIXSocket` or `UNIXServer` unless you need full control over the socket.
-  def initialize(family : Family, type : Type, protocol : Protocol = Protocol::IP, blocking = nil)
+  {% begin %}
+  def initialize(family : Family, type : Type, protocol : Protocol = Protocol::IP, {% if compare_versions(Crystal::VERSION, "1.5.0") >= 0 %} @[Deprecated("Use Socket.set_blocking instead.")] {% end %} blocking = nil)
     # This method is `#initialize` instead of `.new` because it is used as super
     # constructor from subclasses.
-    fd, blocking = Crystal::EventLoop.current.socket(family, type, protocol, blocking)
-    initialize(handle: fd, family: family, type: type, protocol: protocol, blocking: blocking)
+    initialize(af: family, type: type, protocol: protocol, blocking: blocking)
+  end
+  {% end %}
+
+  # :nodoc:
+  #
+  # Internal initializer for the above constructors to avoid deprecation
+  # warnings on the blocking arg.
+  protected def initialize(*, af : Family, type : Type, protocol : Protocol, blocking)
+    fd, blocking = Crystal::EventLoop.current.socket(af, type, protocol, blocking)
+    initialize(handle: fd, family: af, type: type, protocol: protocol, blocking: blocking)
     self.sync = true
   end
 
@@ -84,12 +100,14 @@ class Socket < IO
   #
   # NOTE: On Windows, the handle must have been created with
   # `WSA_FLAG_OVERLAPPED`.
-  def initialize(fd, @family : Family, @type : Type, @protocol : Protocol = Protocol::IP, blocking = nil)
+  {% begin %}
+  def initialize(fd, @family : Family, @type : Type, @protocol : Protocol = Protocol::IP, {% if compare_versions(Crystal::VERSION, "1.5.0") >= 0 %} @[Deprecated("Use Socket.set_blocking instead.")] {% end %} blocking = nil)
     initialize(handle: fd, family: family, type: type, protocol: protocol)
     blocking = Crystal::EventLoop.default_socket_blocking? if blocking.nil?
     self.blocking = blocking unless blocking
     self.sync = true
   end
+  {% end %}
 
   # :nodoc:
   #

--- a/src/socket/tcp_socket.cr
+++ b/src/socket/tcp_socket.cr
@@ -15,16 +15,19 @@ require "./ip_socket"
 # ```
 class TCPSocket < IPSocket
   # Creates a new `TCPSocket`, waiting to be connected.
-  def self.new(family : Family = Family::INET, blocking = nil)
+  {% begin %}
+  def self.new(family : Family = Family::INET, {% if compare_versions(Crystal::VERSION, "1.5.0") >= 0 %} @[Deprecated("Use Socket.set_blocking instead.")] {% end %} blocking = nil)
     super(family, Type::STREAM, Protocol::TCP, blocking)
   end
+  {% end %}
 
   # Creates a new TCP connection to a remote TCP server.
   #
   # You may limit the DNS resolution time with `dns_timeout` and limit the
   # connection time to the remote server with `connect_timeout`. Both values
   # must be in seconds (integers or floats).
-  def initialize(host : String, port, dns_timeout = nil, connect_timeout = nil, blocking = nil)
+  {% begin %}
+  def initialize(host : String, port, dns_timeout = nil, connect_timeout = nil, {% if compare_versions(Crystal::VERSION, "1.5.0") >= 0 %} @[Deprecated("Use Socket.set_blocking instead.")] {% end %} blocking = nil)
     Addrinfo.tcp(host, port, timeout: dns_timeout) do |addrinfo|
       super(addrinfo.family, addrinfo.type, addrinfo.protocol, blocking)
       connect(addrinfo, timeout: connect_timeout) do |error|
@@ -33,12 +36,14 @@ class TCPSocket < IPSocket
       end
     end
   end
+  {% end %}
 
   protected def initialize(family : Family, type : Type, protocol : Protocol = Protocol::IP)
     super family, type, protocol
   end
 
   # Internal constructor for `TCPServer#accept?`.
+  # The *blocking* arg is purely informational.
   protected def initialize(*, handle, family, type, protocol, blocking)
     super(handle: handle, family: family, type: type, protocol: protocol, blocking: blocking)
   end
@@ -51,9 +56,11 @@ class TCPSocket < IPSocket
   #
   # NOTE: On Windows, the handle must have been created with
   # `WSA_FLAG_OVERLAPPED`.
-  def initialize(*, fd : Handle, family : Family = Family::INET, blocking = nil)
+  {% begin %}
+  def initialize(*, fd : Handle, family : Family = Family::INET, {% if compare_versions(Crystal::VERSION, "1.5.0") >= 0 %} @[Deprecated("Use Socket.set_blocking instead.")] {% end %} blocking = nil)
     super fd, family, Type::STREAM, Protocol::TCP, blocking
   end
+  {% end %}
 
   # Opens a TCP socket to a remote TCP server, yields it to the block, then
   # eventually closes the socket when the block returns.

--- a/src/socket/unix_socket.cr
+++ b/src/socket/unix_socket.cr
@@ -32,7 +32,8 @@ class UNIXSocket < Socket
     super family, type, Protocol::IP
   end
 
-  # Internal constructor for `UNIXSocket#pair` and `UNIXServer#accept?`
+  # Internal constructor for `UNIXSocket#pair` and `UNIXServer#accept?`.
+  # The *blocking* arg is purely informational.
   protected def initialize(*, handle : Handle, type : Type = Type::STREAM, path : Path | String? = nil, blocking : Bool = nil)
     @path = path.to_s
     super handle: handle, family: Family::UNIX, type: type, protocol: Protocol::IP, blocking: blocking
@@ -44,7 +45,7 @@ class UNIXSocket < Socket
   # This adopts the system socket into the IO system that will reconfigure it as
   # per the event loop runtime requirements.
   #
-  # NOTE: On Windows, the handle must have been created with,
+  # NOTE: On Windows, the handle must have been created with
   # `WSA_FLAG_OVERLAPPED`.
   def initialize(*, fd : Handle, type : Type = Type::STREAM, path : Path | String? = nil)
     @path = path.to_s


### PR DESCRIPTION
The final patch to the blocking behavior rework. Each event loop configures the system file descriptor or handle as per its internal requirement, and we shall deprecate the `blocking` argument.

Extracted from #15924. Follow up to #15804, #15754, #15753, #15750, #15930 and #15977. Depends on #15999 and #16012 for the deprecations to be visible.