### PR TITLE
Fix typo in `Object` docs

### DIFF
--- a/src/object.cr
+++ b/src/object.cr
@@ -102,7 +102,7 @@ require "./object/properties"
 #   @city : City?
 #
 #   def city : City
-#     if (city == @city).nil?
+#     if (city = @city).nil?
 #       @city = City.unspecified
 #     else
 #       city


### PR DESCRIPTION
I noticed a minor typo in the docs for `Object`.  It looks like there's already an issue opened, but I didn't see a related pull request, so here is one.

Closes #15787
