### PR TITLE
Fix error message for `StaticArray` with non-integer generic argument `N`

### DIFF
--- a/spec/compiler/semantic/static_array_spec.cr
+++ b/spec/compiler/semantic/static_array_spec.cr
@@ -27,6 +27,11 @@ describe "Semantic: static array" do
       x = uninitialized Char[Int32]
       ),
       "can't instantiate StaticArray(T, N) with N = Int32 (N must be an integer)"
+
+    assert_error <<-CRYSTAL,
+      StaticArray(UInt8, 1.2)
+      CRYSTAL
+      "can't instantiate StaticArray(T, N) with N = 1.2 (N must be an integer)"
   end
 
   it "allows instantiating static array instance var in initialize of generic type" do

--- a/src/compiler/crystal/types.cr
+++ b/src/compiler/crystal/types.cr
@@ -2290,7 +2290,11 @@ module Crystal
           raise TypeException.new "can't instantiate StaticArray(T, N) with N = #{n.type} (N must be an integer)"
         end
 
-        value = n.value.to_i
+        value = n.value.to_i?
+        unless value
+          raise TypeException.new "can't instantiate StaticArray(T, N) with N = #{n} (N must be an integer)"
+        end
+
         if value < 0
           raise TypeException.new "can't instantiate StaticArray(T, N) with N = #{value} (N must be positive)"
         end


### PR DESCRIPTION
Resolves #16032