### PR TITLE
Support `Proc.new(Void*, Void*)` in the interpreter

### DIFF
--- a/spec/std/http/client/client_spec.cr
+++ b/spec/std/http/client/client_spec.cr
@@ -6,12 +6,6 @@ require "http/server"
 require "http/log"
 require "log/spec"
 
-# TODO: Windows networking in the interpreter requires #12495
-{% if flag?(:interpreted) && flag?(:win32) %}
-  pending HTTP::Client
-  {% skip_file %}
-{% end %}
-
 private def test_server(host, port, read_time = 0.seconds, content_type = "text/plain", write_response = true, &)
   server = TCPServer.new(host, port)
   begin

--- a/spec/std/http/server/server_spec.cr
+++ b/spec/std/http/server/server_spec.cr
@@ -4,12 +4,6 @@ require "http/client"
 require "../../../support/ssl"
 require "../../../support/channel"
 
-# TODO: Windows networking in the interpreter requires #12495
-{% if flag?(:interpreted) && flag?(:win32) %}
-  pending HTTP::Server
-  {% skip_file %}
-{% end %}
-
 # TODO: replace with `HTTP::Client.get` once it supports connecting to Unix socket (#2735)
 private def unix_request(path)
   UNIXSocket.open(path) do |io|

--- a/spec/std/http/web_socket_spec.cr
+++ b/spec/std/http/web_socket_spec.cr
@@ -7,12 +7,6 @@ require "../../support/fibers"
 require "../../support/ssl"
 require "../socket/spec_helper.cr"
 
-# TODO: Windows networking in the interpreter requires #12495
-{% if flag?(:interpreted) && flag?(:win32) %}
-  pending HTTP::WebSocket
-  {% skip_file %}
-{% end %}
-
 private def assert_text_packet(packet, size, final = false)
   assert_packet packet, HTTP::WebSocket::Protocol::Opcode::TEXT, size, final: final
 end

--- a/spec/std/io/io_spec.cr
+++ b/spec/std/io/io_spec.cr
@@ -820,26 +820,23 @@ describe IO do
           io.gets_to_end.should eq("\r\nFoo\nBar")
         end
 
-        # TODO: Windows networking in the interpreter requires #12495
-        {% unless flag?(:interpreted) || flag?(:win32) %}
-          it "gets ascii from socket (#9056)" do
-            server = TCPServer.new "localhost", 0
-            sock = TCPSocket.new "localhost", server.local_address.port
-            begin
-              sock.set_encoding("ascii")
-              spawn do
-                client = server.accept
-                message = client.gets
-                client << "#{message}\n"
-              end
-              sock << "K\n"
-              sock.gets.should eq("K")
-            ensure
-              server.close
-              sock.close
+        it "gets ascii from socket (#9056)" do
+          server = TCPServer.new "localhost", 0
+          sock = TCPSocket.new "localhost", server.local_address.port
+          begin
+            sock.set_encoding("ascii")
+            spawn do
+              client = server.accept
+              message = client.gets
+              client << "#{message}\n"
             end
+            sock << "K\n"
+            sock.gets.should eq("K")
+          ensure
+            server.close
+            sock.close
           end
-        {% end %}
+        end
       end
 
       describe "encode" do

--- a/spec/std/oauth2/client_spec.cr
+++ b/spec/std/oauth2/client_spec.cr
@@ -3,12 +3,6 @@ require "oauth2"
 require "http/server"
 require "../http/spec_helper"
 
-# TODO: Windows networking in the interpreter requires #12495
-{% if flag?(:interpreted) && flag?(:win32) %}
-  pending OAuth2::Client
-  {% skip_file %}
-{% end %}
-
 describe OAuth2::Client do
   describe "authorization uri" do
     it "gets with default endpoint" do

--- a/spec/std/openssl/ssl/server_spec.cr
+++ b/spec/std/openssl/ssl/server_spec.cr
@@ -3,12 +3,6 @@ require "socket"
 require "../../spec_helper"
 require "../../../support/ssl"
 
-# TODO: Windows networking in the interpreter requires #12495
-{% if flag?(:interpreted) && flag?(:win32) %}
-  pending OpenSSL::SSL::Server
-  {% skip_file %}
-{% end %}
-
 describe OpenSSL::SSL::Server do
   it "sync_close" do
     TCPServer.open(Socket::IPAddress::UNSPECIFIED, 0) do |tcp_server|

--- a/spec/std/openssl/ssl/socket_spec.cr
+++ b/spec/std/openssl/ssl/socket_spec.cr
@@ -4,12 +4,6 @@ require "../../spec_helper"
 require "../../socket/spec_helper"
 require "../../../support/ssl"
 
-# TODO: Windows networking in the interpreter requires #12495
-{% if flag?(:interpreted) && flag?(:win32) %}
-  pending OpenSSL::SSL::Socket
-  {% skip_file %}
-{% end %}
-
 describe OpenSSL::SSL::Socket do
   describe OpenSSL::SSL::Socket::Server do
     it "auto accept client by default" do

--- a/spec/std/socket/socket_spec.cr
+++ b/spec/std/socket/socket_spec.cr
@@ -2,12 +2,6 @@ require "./spec_helper"
 require "../../support/tempfile"
 require "../../support/win32"
 
-# TODO: Windows networking in the interpreter requires #12495
-{% if flag?(:interpreted) && flag?(:win32) %}
-  pending Socket
-  {% skip_file %}
-{% end %}
-
 describe Socket, tags: "network" do
   describe ".unix" do
     it "creates a unix socket" do

--- a/spec/std/socket/tcp_socket_spec.cr
+++ b/spec/std/socket/tcp_socket_spec.cr
@@ -3,12 +3,6 @@
 require "./spec_helper"
 require "../../support/win32"
 
-# TODO: Windows networking in the interpreter requires #12495
-{% if flag?(:interpreted) && flag?(:win32) %}
-  pending TCPSocket
-  {% skip_file %}
-{% end %}
-
 describe TCPSocket, tags: "network" do
   describe "#connect" do
     each_ip_family do |family, address|

--- a/spec/std/socket/unix_server_spec.cr
+++ b/spec/std/socket/unix_server_spec.cr
@@ -4,12 +4,6 @@ require "../../support/fibers"
 require "../../support/channel"
 require "../../support/tempfile"
 
-# TODO: Windows networking in the interpreter requires #12495
-{% if flag?(:interpreted) && flag?(:win32) %}
-  pending UNIXServer
-  {% skip_file %}
-{% end %}
-
 describe UNIXServer do
   describe ".new" do
     it "raises when path is too long" do

--- a/spec/std/socket/unix_socket_spec.cr
+++ b/spec/std/socket/unix_socket_spec.cr
@@ -2,12 +2,6 @@ require "spec"
 require "socket"
 require "../../support/tempfile"
 
-# TODO: Windows networking in the interpreter requires #12495
-{% if flag?(:interpreted) && flag?(:win32) %}
-  pending UNIXSocket
-  {% skip_file %}
-{% end %}
-
 describe UNIXSocket do
   it "raises when path is too long" do
     with_tempfile("unix_socket-too_long-#{("a" * 2048)}.sock") do |path|

--- a/src/compiler/crystal/interpreter/compiler.cr
+++ b/src/compiler/crystal/interpreter/compiler.cr
@@ -1931,6 +1931,7 @@ class Crystal::Repl::Compiler < Crystal::Visitor
 
     args_bytesizes = [] of Int32
     args_ffi_types = [] of FFI::Type
+    return_bytesize = inner_sizeof_type(external.type)
 
     node.args.each_with_index do |arg, i|
       arg_type = arg.type
@@ -2000,7 +2001,6 @@ class Crystal::Repl::Compiler < Crystal::Visitor
 
     if external.varargs?
       lib_function = LibFunction.new(
-        def: external,
         symbol: @context.c_function(external.real_name),
         call_interface: FFI::CallInterface.variadic(
           external.type.ffi_type,
@@ -2008,17 +2008,18 @@ class Crystal::Repl::Compiler < Crystal::Visitor
           fixed_args: external.args.size
         ),
         args_bytesizes: args_bytesizes,
+        return_bytesize: return_bytesize,
       )
       @context.add_gc_reference(lib_function)
     else
       lib_function = @context.lib_functions[external] ||= LibFunction.new(
-        def: external,
         symbol: @context.c_function(external.real_name),
         call_interface: FFI::CallInterface.new(
           external.type.ffi_type,
           args_ffi_types
         ),
         args_bytesizes: args_bytesizes,
+        return_bytesize: return_bytesize,
       )
     end
 

--- a/src/compiler/crystal/interpreter/compiler.cr
+++ b/src/compiler/crystal/interpreter/compiler.cr
@@ -1925,6 +1925,65 @@ class Crystal::Repl::Compiler < Crystal::Visitor
     false
   end
 
+  def compile_extern_proc_wrapper(node, proc_type, symbol)
+    proc_type.arg_types.each_with_index do |arg_type, i|
+      index = @local_vars.name_to_index("arg#{i}", 0)
+
+      case arg_type
+      when NilType
+        # Nil is used to mean Pointer.null
+        put_i64 0, node: nil
+      when StaticArrayInstanceType
+        # Static arrays are passed as pointers to C
+        pointerof_var index, node: nil
+      else
+        get_local index, aligned_sizeof_type(arg_type), node: nil
+        if arg_type.is_a?(ProcInstanceType)
+          proc_to_c_fun arg_type.ffi_call_interface, node: nil
+        end
+      end
+    end
+
+    lib_function = @context.lib_functions.put_if_absent(symbol) do
+      args_bytesizes = [] of Int32
+      args_ffi_types = [] of FFI::Type
+      return_bytesize = inner_sizeof_type(proc_type.return_type)
+
+      proc_type.arg_types.each do |arg_type|
+        case arg_type
+        when NilType
+          args_bytesizes << sizeof(Pointer(Void))
+          args_ffi_types << FFI::Type.pointer
+        when ProcInstanceType
+          args_bytesizes << sizeof(Void*)
+          args_ffi_types << FFI::Type.pointer
+        when StaticArrayInstanceType
+          # Static arrays are passed as pointers to C
+          args_bytesizes << sizeof(Void*)
+          args_ffi_types << FFI::Type.pointer
+        else
+          args_bytesizes << aligned_sizeof_type(arg_type)
+          args_ffi_types << arg_type.ffi_arg_type
+        end
+      end
+
+      LibFunction.new(
+        symbol: symbol,
+        call_interface: FFI::CallInterface.new(
+          proc_type.return_type.ffi_type,
+          args_ffi_types,
+        ),
+        args_bytesizes: args_bytesizes,
+        return_bytesize: return_bytesize,
+      )
+    end
+
+    lib_call(lib_function, node: node)
+
+    # Use a dummy node so that pry stops at `end`
+    leave aligned_sizeof_type(proc_type.return_type), node: Nop.new.at(node.end_location)
+  end
+
   private def compile_lib_call(node : Call)
     target_def = node.target_def
     external = target_def.as(External)
@@ -2828,6 +2887,7 @@ class Crystal::Repl::Compiler < Crystal::Visitor
     compiler = Compiler.new(@context, compiled_def, scope: scope, top_level: false)
     begin
       compiler.compile_def(compiled_def, is_closure ? @closure_context : nil)
+      @context.compiled_procs << compiled_def.object_id
     rescue ex : Crystal::CodeError
       node.raise "compiling #{node}", inner: ex
     end

--- a/src/compiler/crystal/interpreter/context.cr
+++ b/src/compiler/crystal/interpreter/context.cr
@@ -49,6 +49,14 @@ class Crystal::Repl::Context
   # (e.g. `$Slice:0`).
   @const_slice_buffers = {} of String => UInt8*
 
+  # A cache of object IDs of the `CompiledDef`s corresponding to `ProcLiteral`s.
+  # Used to determine whether such an object ID or a raw function pointer is
+  # passed to `Proc.new`.
+  getter compiled_procs = Set(UInt64).new
+
+  # A cache from C proc pointers to `CompiledDef`s, formed using `Proc.new`.
+  getter extern_proc_wrappers = {} of Void* => CompiledDef
+
   def initialize(@program : Program)
     @program.flags << "interpreted"
 
@@ -249,6 +257,23 @@ class Crystal::Repl::Context
       {value.index, value.compiled_def}
     else
       nil
+    end
+  end
+
+  def extern_proc_wrapper(proc_type : ProcInstanceType, symbol : Void*) : CompiledDef
+    extern_proc_wrappers.put_if_absent(symbol) do
+      crystal_args_bytesize = proc_type.arg_types.sum { |arg| aligned_sizeof_type(arg) }
+      target_def = proc_type.lookup_first_def("call", false).not_nil!
+      compiled_def = CompiledDef.new(self, target_def, proc_type, crystal_args_bytesize)
+
+      proc_type.arg_types.each_with_index do |arg_type, i|
+        compiled_def.local_vars.declare("arg#{i}", arg_type)
+      end
+
+      compiler = Compiler.new(self, compiled_def, top_level: false)
+      compiler.compile_extern_proc_wrapper(target_def, proc_type, symbol)
+
+      compiled_def
     end
   end
 

--- a/src/compiler/crystal/interpreter/context.cr
+++ b/src/compiler/crystal/interpreter/context.cr
@@ -20,7 +20,7 @@ class Crystal::Repl::Context
   getter! class_vars : ClassVars
 
   # libffi information about external functions.
-  getter lib_functions : Hash(External, LibFunction)
+  getter lib_functions : Hash(Void*, LibFunction)
 
   # Cache of multidispatch expansions.
   getter multidispatchs : Hash(MultidispatchKey, Def)
@@ -57,8 +57,7 @@ class Crystal::Repl::Context
     @defs = {} of Def => CompiledDef
     @defs.compare_by_identity
 
-    @lib_functions = {} of External => LibFunction
-    @lib_functions.compare_by_identity
+    @lib_functions = {} of Void* => LibFunction
 
     @symbol_to_index = {} of String => Int32
     @symbols = [] of String

--- a/src/compiler/crystal/interpreter/instructions.cr
+++ b/src/compiler/crystal/interpreter/instructions.cr
@@ -1648,6 +1648,23 @@ require "./repl"
       # >>> ARGV (2)
 
       # <<< Overrides (6)
+      interpreter_proc_new: {
+        operands:   [proc_type_id : Int32],
+        pop_values: [pointer : Void*, closure_data : Void*],
+        push:       true,
+        code:       begin
+          if @context.compiled_procs.includes?(pointer.address)
+            {pointer, closure_data}
+          else
+            raise "BUG: closure_data not nil but pointer is not a CompiledDef" if closure_data
+
+            proc_type = type_from_type_id(proc_type_id).as(ProcInstanceType)
+            compiled_def = @context.extern_proc_wrapper(proc_type, pointer)
+
+            {compiled_def.as(Void*), Pointer(Void).null}
+          end
+        end,
+      },
       interpreter_call_stack_unwind: {
         push:       true,
         code:       backtrace,

--- a/src/compiler/crystal/interpreter/interpreter.cr
+++ b/src/compiler/crystal/interpreter/interpreter.cr
@@ -627,10 +627,10 @@ class Crystal::Repl::Interpreter
   end
 
   private macro lib_call(lib_function)
-    %target_def = lib_function.def
     %cif = lib_function.call_interface
     %fn = lib_function.symbol
     %args_bytesizes = lib_function.args_bytesizes
+    %return_bytesize = lib_function.return_bytesize
 
     # Assume C calls don't have more than 100 arguments
     # TODO: use the stack for this?
@@ -649,7 +649,6 @@ class Crystal::Repl::Interpreter
     rescue ex : EscapingException
       raise_exception(ex.exception_pointer)
     else
-      %return_bytesize = inner_sizeof_type(%target_def.type)
       %aligned_return_bytesize = align(%return_bytesize)
 
       (stack - %offset).move_from(stack, %return_bytesize)

--- a/src/compiler/crystal/interpreter/lib_function.cr
+++ b/src/compiler/crystal/interpreter/lib_function.cr
@@ -2,9 +2,6 @@ require "./repl"
 
 # Information about a C function that needs to be called.
 class Crystal::Repl::LibFunction
-  # The external function
-  getter def : External
-
   # Symbol returned by dlopen and dlsym that is a pointer
   # to the actual function.
   getter symbol : Void*
@@ -15,11 +12,14 @@ class Crystal::Repl::LibFunction
   # Bytesize for each argument in the call
   getter args_bytesizes : Array(Int32)
 
+  # Bytesize for the call's return value
+  getter return_bytesize : Int32
+
   def initialize(
-    @def : External,
     @symbol : Void*,
     @call_interface : FFI::CallInterface,
     @args_bytesizes : Array(Int32),
+    @return_bytesize : Int32,
   )
   end
 end

--- a/src/compiler/crystal/interpreter/primitives.cr
+++ b/src/compiler/crystal/interpreter/primitives.cr
@@ -422,6 +422,9 @@ class Crystal::Repl::Compiler
       else
         pointer_set(inner_sizeof_type(ivar.type), node: node)
       end
+    when "interpreter_proc_new"
+      accept_call_args(node)
+      interpreter_proc_new(type_id(owner.instance_type), node: node)
     when "interpreter_call_stack_unwind"
       interpreter_call_stack_unwind(node: node)
     when "interpreter_raise_without_backtrace"

--- a/src/crystal/system/win32/iocp.cr
+++ b/src/crystal/system/win32/iocp.cr
@@ -8,48 +8,30 @@ require "crystal/system/thread_linked_list"
 struct Crystal::System::IOCP
   @@wait_completion_packet_methods : Bool? = nil
 
-  {% if flag?(:interpreted) %}
-    # We can't load the symbols from interpreted code since it would create
-    # interpreted Proc. We thus merely check for the existence of the symbols,
-    # then let the interpreter load the symbols, which will create interpreter
-    # Proc (not interpreted) that can be called.
-    class_getter?(wait_completion_packet_methods : Bool) do
-      detect_wait_completion_packet_methods
-    end
+  @@_NtCreateWaitCompletionPacket = uninitialized LibNTDLL::NtCreateWaitCompletionPacketProc
+  @@_NtAssociateWaitCompletionPacket = uninitialized LibNTDLL::NtAssociateWaitCompletionPacketProc
+  @@_NtCancelWaitCompletionPacket = uninitialized LibNTDLL::NtCancelWaitCompletionPacketProc
 
-    private def self.detect_wait_completion_packet_methods : Bool
-      if handle = LibC.LoadLibraryExW(Crystal::System.to_wstr("ntdll.dll"), nil, 0)
-        !LibC.GetProcAddress(handle, "NtCreateWaitCompletionPacket").null?
-      else
-        false
-      end
-    end
-  {% else %}
-    @@_NtCreateWaitCompletionPacket = uninitialized LibNTDLL::NtCreateWaitCompletionPacketProc
-    @@_NtAssociateWaitCompletionPacket = uninitialized LibNTDLL::NtAssociateWaitCompletionPacketProc
-    @@_NtCancelWaitCompletionPacket = uninitialized LibNTDLL::NtCancelWaitCompletionPacketProc
+  class_getter?(wait_completion_packet_methods : Bool) do
+    load_wait_completion_packet_methods
+  end
 
-    class_getter?(wait_completion_packet_methods : Bool) do
-      load_wait_completion_packet_methods
-    end
+  private def self.load_wait_completion_packet_methods : Bool
+    handle = LibC.LoadLibraryExW(Crystal::System.to_wstr("ntdll.dll"), nil, 0)
+    return false if handle.null?
 
-    private def self.load_wait_completion_packet_methods : Bool
-      handle = LibC.LoadLibraryExW(Crystal::System.to_wstr("ntdll.dll"), nil, 0)
-      return false if handle.null?
+    pointer = LibC.GetProcAddress(handle, "NtCreateWaitCompletionPacket")
+    return false if pointer.null?
+    @@_NtCreateWaitCompletionPacket = LibNTDLL::NtCreateWaitCompletionPacketProc.new(pointer, Pointer(Void).null)
 
-      pointer = LibC.GetProcAddress(handle, "NtCreateWaitCompletionPacket")
-      return false if pointer.null?
-      @@_NtCreateWaitCompletionPacket = LibNTDLL::NtCreateWaitCompletionPacketProc.new(pointer, Pointer(Void).null)
+    pointer = LibC.GetProcAddress(handle, "NtAssociateWaitCompletionPacket")
+    @@_NtAssociateWaitCompletionPacket = LibNTDLL::NtAssociateWaitCompletionPacketProc.new(pointer, Pointer(Void).null)
 
-      pointer = LibC.GetProcAddress(handle, "NtAssociateWaitCompletionPacket")
-      @@_NtAssociateWaitCompletionPacket = LibNTDLL::NtAssociateWaitCompletionPacketProc.new(pointer, Pointer(Void).null)
+    pointer = LibC.GetProcAddress(handle, "NtCancelWaitCompletionPacket")
+    @@_NtCancelWaitCompletionPacket = LibNTDLL::NtCancelWaitCompletionPacketProc.new(pointer, Pointer(Void).null)
 
-      pointer = LibC.GetProcAddress(handle, "NtCancelWaitCompletionPacket")
-      @@_NtCancelWaitCompletionPacket = LibNTDLL::NtCancelWaitCompletionPacketProc.new(pointer, Pointer(Void).null)
-
-      true
-    end
-  {% end %}
+    true
+  end
 
   # :nodoc:
   class CompletionKey
@@ -176,39 +158,23 @@ struct Crystal::System::IOCP
   def create_wait_completion_packet : LibC::HANDLE
     packet_handle = LibC::HANDLE.null
     object_attributes = Pointer(LibC::OBJECT_ATTRIBUTES).null
-    status =
-      {% if flag?(:interpreted) %}
-        LibNTDLL.NtCreateWaitCompletionPacket(pointerof(packet_handle), LibNTDLL::GENERIC_ALL, object_attributes)
-      {% else %}
-        @@_NtCreateWaitCompletionPacket.call(pointerof(packet_handle), LibNTDLL::GENERIC_ALL, object_attributes)
-      {% end %}
+    status = @@_NtCreateWaitCompletionPacket.call(pointerof(packet_handle), LibNTDLL::GENERIC_ALL, object_attributes)
     raise RuntimeError.from_os_error("NtCreateWaitCompletionPacket", WinError.from_ntstatus(status)) unless status == 0
     packet_handle
   end
 
   def associate_wait_completion_packet(wait_handle : LibC::HANDLE, target_handle : LibC::HANDLE, completion_key : CompletionKey) : Bool
     signaled = 0_u8
-    status =
-      {% if flag?(:interpreted) %}
-        LibNTDLL.NtAssociateWaitCompletionPacket(wait_handle, @handle,
-          target_handle, completion_key.as(Void*), nil, 0, nil, pointerof(signaled))
-      {% else %}
-        @@_NtAssociateWaitCompletionPacket.call(wait_handle, @handle,
-          target_handle, completion_key.as(Void*), Pointer(Void).null,
-          LibNTDLL::NTSTATUS.new!(0), Pointer(LibC::ULONG).null,
-          pointerof(signaled))
-      {% end %}
+    status = @@_NtAssociateWaitCompletionPacket.call(wait_handle, @handle,
+      target_handle, completion_key.as(Void*), Pointer(Void).null,
+      LibNTDLL::NTSTATUS.new!(0), Pointer(LibC::ULONG).null,
+      pointerof(signaled))
     raise RuntimeError.from_os_error("NtAssociateWaitCompletionPacket", WinError.from_ntstatus(status)) unless status == 0
     signaled == 1
   end
 
   def cancel_wait_completion_packet(wait_handle : LibC::HANDLE, remove_signaled : Bool) : LibNTDLL::NTSTATUS
-    status =
-      {% if flag?(:interpreted) %}
-        LibNTDLL.NtCancelWaitCompletionPacket(wait_handle, remove_signaled ? 1 : 0)
-      {% else %}
-        @@_NtCancelWaitCompletionPacket.call(wait_handle, remove_signaled ? 1_u8 : 0_u8)
-      {% end %}
+    status = @@_NtCancelWaitCompletionPacket.call(wait_handle, remove_signaled ? 1_u8 : 0_u8)
     case status
     when LibC::STATUS_CANCELLED, LibC::STATUS_SUCCESS, LibC::STATUS_PENDING
       status

--- a/src/proc.cr
+++ b/src/proc.cr
@@ -100,7 +100,8 @@
 # The C library will of course store the callback, but Crystal's GC has
 # no way of knowing that.
 struct Proc
-  def self.new(pointer : Void*, closure_data : Void*)
+  {% if flag?(:interpreted) %} @[Primitive(:interpreter_proc_new)] {% end %}
+  def self.new(pointer : Void*, closure_data : Void*) : self
     func = {pointer, closure_data}
     ptr = pointerof(func).as(self*)
     ptr.value


### PR DESCRIPTION
Fixes part of #12495.

This constructor is now a primitive in interpreted code, and accepts both `CompiledDef` pointers and C function pointers, assuming the latter by default, unless a previous `ProcLiteral` has created the pointer. The interpreter will then compile a wrapper on the fly; eventually the `external_var_get` primitive from the original issue may adopt a similar technique.

Two `Proc`s with the same C function pointer will refer to the same `CompiledDef`. Each `CompiledDef` more or less maintains its own `FFI::CallInterface`; there is no FFI closure involved, unlike Crystal procs.

This enables networking on Windows inside the interpreter, and also drops a workaround in the IOCP event loop.