### PR TITLE
Fix pointer access bug in `XML::NodeSet`

### DIFF
--- a/spec/std/xml/xpath_spec.cr
+++ b/spec/std/xml/xpath_spec.cr
@@ -70,9 +70,14 @@ module XML
       end
     end
 
-    it "returns nil with invalid xpath" do
+    it "returns nil when xpath fails to match" do
       doc = doc()
       doc.xpath_node("//invalid").should be_nil
+    end
+
+    it "returns nil when invalid fails to match" do
+      doc = doc()
+      doc.xpath_node("//invalid/text()").should be_nil
     end
 
     it "finds with explicit namespace" do

--- a/src/xml/node_set.cr
+++ b/src/xml/node_set.cr
@@ -3,7 +3,7 @@ struct XML::NodeSet
 
   # :nodoc:
   def self.new(doc : Node, set : LibXML::NodeSet*)
-    return NodeSet.new unless set || set.value.node_nr > 0
+    return NodeSet.new unless set && set.value.node_nr > 0
 
     nodes = Slice(Node).new(set.value.node_nr) do |i|
       Node.new(set.value.node_tab[i], doc)


### PR DESCRIPTION
The following small file segfaults with Crystal version 1.17.x on both OSX and Ubuntu (Arm):
```
require "xml"

subject = XML.parse_html("<html></html>")
nodes = subject.xpath_nodes("//div//text()")
```
Results:
```
% crystal --version
Crystal 1.17.1 [19be240d1] (2025-07-22)

LLVM: 15.0.7
Default target: aarch64-apple-macosx11.0

% crystal test.cr
Invalid memory access (signal 11) at address 0x0
[0x10463e4c8] *Exception::CallStack::print_backtrace:Nil +112 in /Users/toddsundsted/.cache/crystal/crystal-run-test.tmp
[0x10462bab8] ~procProc(Int32, Pointer(LibC::SiginfoT), Pointer(Void), Nil)@/Users/toddsundsted/.asdf/installs/crystal/1.17.1/src/crystal/system/unix/signal.cr:173 +276 in /Users/toddsundsted/.cache/crystal/crystal-run-test.tmp
[0x1902c4624] _sigtramp +56 in /usr/lib/system/libsystem_platform.dylib
[0x1046cec1c] *XML::XPathContext#evaluate<String>:(Bool | Float64 | String | XML::NodeSet) +1056 in /Users/toddsundsted/.cache/crystal/crystal-run-test.tmp (2 times)
[0x1046cbe5c] *XML::Document@XML::Node#xpath<String, Nil, Nil>:(Bool | Float64 | String | XML::NodeSet) +428 in /Users/toddsundsted/.cache/crystal/crystal-run-test.tmp
[0x1046cbc48] *XML::Document@XML::Node#xpath_nodes<String, Nil, Nil>:XML::NodeSet +32 in /Users/toddsundsted/.cache/crystal/crystal-run-test.tmp
[0x1046cbc00] *XML::Document@XML::Node#xpath_nodes<String>:XML::NodeSet +32 in /Users/toddsundsted/.cache/crystal/crystal-run-test.tmp
[0x104624b28] __crystal_main +1000 in /Users/toddsundsted/.cache/crystal/crystal-run-test.tmp
[0x1046859e0] *Crystal::main_user_code<Int32, Pointer(Pointer(UInt8))>:Nil +12 in /Users/toddsundsted/.cache/crystal/crystal-run-test.tmp
[0x10468592c] *Crystal::main<Int32, Pointer(Pointer(UInt8))>:Int32 +64 in /Users/toddsundsted/.cache/crystal/crystal-run-test.tmp
[0x104628510] main +32 in /Users/toddsundsted/.cache/crystal/crystal-run-test.tmp
```

The problem is the logic used to check the pointer when creating a nodeset.

This PR adds a test to demonstrate the bug and a fix.