### PR TITLE
Never generate assignments to a block's underscore parameters

### DIFF
--- a/spec/compiler/codegen/block_spec.cr
+++ b/spec/compiler/codegen/block_spec.cr
@@ -1422,6 +1422,30 @@ describe "Code gen: block" do
       )).to_i.should eq(3)
   end
 
+  it "works if block has both splat and non-splat underscore parameters" do
+    run(<<-CRYSTAL, Int32).should eq(34)
+      def foo(&)
+        yield 1, 2, 4, 8, 16, 32
+      end
+
+      foo do |_, a, *_, b|
+        a &+ b
+      end
+      CRYSTAL
+  end
+
+  it "works if block has both splat parameter and multiple non-splat underscore parameters" do
+    run(<<-CRYSTAL, Int32).should eq(40)
+      def foo(&)
+        yield 1, 2, 4, 8, "", 32
+      end
+
+      foo do |_, *a, _, b|
+         a[2] &+ b
+      end
+      CRYSTAL
+  end
+
   it "auto-unpacks tuple" do
     run(%(
       def foo

--- a/src/compiler/crystal/codegen/codegen.cr
+++ b/src/compiler/crystal/codegen/codegen.cr
@@ -1766,21 +1766,25 @@ module Crystal
 
         # Now assign exp values to block arguments
         if splat_index
-          j = 0
+          exp_index = 0
           block.args.each_with_index do |arg, i|
-            block_var = block_context.vars[arg.name]
-            if i == splat_index
-              exp_value = allocate_tuple(arg.type.as(TupleInstanceType)) do
-                exp_value2, exp_type = exp_values[j]
-                j += 1
-                {exp_type, exp_value2}
+            if arg.name != "_"
+              block_var = block_context.vars[arg.name]
+              if i == splat_index
+                exp_value = allocate_tuple(arg.type.as(TupleInstanceType)) do
+                  exp_value2, exp_type = exp_values[exp_index]
+                  exp_index += 1
+                  {exp_type, exp_value2}
+                end
+                exp_type = arg.type
+              else
+                exp_value, exp_type = exp_values[exp_index]
+                exp_index += 1
               end
-              exp_type = arg.type
+              assign block_var.pointer, block_var.type, exp_type, exp_value
             else
-              exp_value, exp_type = exp_values[j]
-              j += 1
+              exp_index += (i == splat_index ? arg.type.as(TupleInstanceType).size : 1)
             end
-            assign block_var.pointer, block_var.type, exp_type, exp_value
           end
         else
           # Check if tuple unpacking is needed


### PR DESCRIPTION
If one of the block's parameters is a splat, codegen will emit assignments to those underscores, which lead to similar internal errors as those in #13474 when the corresponding yield arguments have different types.