### PR TITLE
Interpreter: never generate assignments to a block's underscore parameters

### DIFF
--- a/spec/compiler/interpreter/blocks_spec.cr
+++ b/spec/compiler/interpreter/blocks_spec.cr
@@ -721,5 +721,29 @@ describe Crystal::Repl::Interpreter do
         end
         CRYSTAL
     end
+
+    it "interprets underscore parameters corresponding to yield arguments with different types + tuple unpacking (#13474)" do
+      interpret(<<-CRYSTAL).should eq(9)
+        def foo(&)
+          yield({1, 2, "4", 8})
+        end
+
+        foo do |a, _, _, b|
+          a &+ b
+        end
+        CRYSTAL
+    end
+
+    it "interprets block with both splat and non-splat underscore parameter + tuple unpacking (#13474)" do
+      interpret(<<-CRYSTAL).should eq(34)
+        def foo(&)
+          yield({1, 2, 4, 8, 16, 32})
+        end
+
+        foo do |_, a, *_, b|
+          a &+ b
+        end
+        CRYSTAL
+    end
   end
 end

--- a/spec/compiler/interpreter/blocks_spec.cr
+++ b/spec/compiler/interpreter/blocks_spec.cr
@@ -733,17 +733,5 @@ describe Crystal::Repl::Interpreter do
         end
         CRYSTAL
     end
-
-    it "interprets block with both splat and non-splat underscore parameter + tuple unpacking (#13474)" do
-      interpret(<<-CRYSTAL).should eq(34)
-        def foo(&)
-          yield({1, 2, 4, 8, 16, 32})
-        end
-
-        foo do |_, a, *_, b|
-          a &+ b
-        end
-        CRYSTAL
-    end
   end
 end

--- a/spec/compiler/interpreter/blocks_spec.cr
+++ b/spec/compiler/interpreter/blocks_spec.cr
@@ -697,5 +697,29 @@ describe Crystal::Repl::Interpreter do
         end
       CRYSTAL
     end
+
+    it "interprets underscore parameters corresponding to yield arguments with different types (#13474)" do
+      interpret(<<-CRYSTAL).should eq(9)
+        def foo(&)
+          yield 1, 2, "4", 8
+        end
+
+        foo do |a, _, _, b|
+          a &+ b
+        end
+        CRYSTAL
+    end
+
+    it "interprets block with both splat and non-splat underscore parameter (#13474)" do
+      interpret(<<-CRYSTAL).should eq(34)
+        def foo(&)
+          yield 1, 2, 4, 8, 16, 32
+        end
+
+        foo do |_, a, *_, b|
+          a &+ b
+        end
+        CRYSTAL
+    end
   end
 end

--- a/src/compiler/crystal/interpreter/cast.cr
+++ b/src/compiler/crystal/interpreter/cast.cr
@@ -237,14 +237,17 @@ class Crystal::Repl::Compiler
   # Unpacks a tuple into a series of types.
   # Each of the tuple elements is upcasted to the corresponding type in `to_types`.
   # Every individual element is stack-aligned. Use `#cast_tuple` instead if they
-  # should follow their natural alignments inside a target tuple type.
+  # should follow their natural alignments inside a target tuple type. Nils
+  # inside `to_types` are discarded.
   # It's the caller's responsibility to pop the original, unpacked tuple, from the
   # stack if needed.
-  private def unpack_tuple(node : ASTNode, from : TupleInstanceType, to_types : Array(Type))
+  private def unpack_tuple(node : ASTNode, from : TupleInstanceType, to_types : Array(Type?))
     from_aligned_size = aligned_sizeof_type(from)
     to_element_offset = 0
 
     to_types.each_with_index do |to_element_type, i|
+      next unless to_element_type
+
       from_element_type = from.tuple_types[i]
 
       from_inner_size = inner_sizeof_type(from_element_type)


### PR DESCRIPTION
Resolves #13474.