### PR TITLE
Run `before_request` callback in `HTTP::Client` only once

### DIFF
--- a/spec/std/http/client/client_spec.cr
+++ b/spec/std/http/client/client_spec.cr
@@ -317,6 +317,27 @@ module HTTP
       end
     end
 
+    it "retry does not call before_request callback again" do
+      server = HTTP::Server.new do |context|
+        io = context.response.@io.as(Socket)
+        io.linger = 0 # with linger 0 the socket will be RST on close
+        io.close
+      end
+      address = server.bind_unused_port "127.0.0.1"
+
+      run_server(server) do
+        callback_counts = 0
+        client = HTTP::Client.new("127.0.0.1", address.port)
+        client.before_request do
+          callback_counts += 1
+        end
+        expect_raises(IO::Error) do
+          client.get(path: "/")
+        end
+        callback_counts.should eq 1
+      end
+    end
+
     it "doesn't read the body if request was HEAD" do
       resp_get = test_server("localhost", 0, 0.seconds) do |server|
         client = Client.new("localhost", server.local_address.port)

--- a/src/http/client.cr
+++ b/src/http/client.cr
@@ -580,6 +580,10 @@ class HTTP::Client
 
   private def exec_internal(request)
     implicit_compression = implicit_compression?(request)
+
+    set_defaults request
+    run_before_request_callbacks(request)
+
     begin
       response = exec_internal_single(request, implicit_compression: implicit_compression)
     rescue exc : IO::Error
@@ -628,6 +632,10 @@ class HTTP::Client
 
   private def exec_internal(request, &block : Response -> T) : T forall T
     implicit_compression = implicit_compression?(request)
+
+    set_defaults request
+    run_before_request_callbacks(request)
+
     exec_internal_single(request, ignore_io_error: true, implicit_compression: implicit_compression) do |response|
       if response
         return handle_response(response) { yield response }
@@ -665,8 +673,6 @@ class HTTP::Client
   end
 
   private def send_request(request)
-    set_defaults request
-    run_before_request_callbacks(request)
     request.to_io(io)
     io.flush
   end


### PR DESCRIPTION
If `HTTP::Client` fails to make a request, it retries once. This would also trigger the `before_request` callback twice, which is surprising and incorrect: We're only making a single request, not two of them.
This patch ensures the callback is called only once per request.

Ref https://github.com/crystal-lang/crystal/issues/16028#issuecomment-3135260741