### PR TITLE
Add type restrictions to regex directory

### DIFF
--- a/src/regex.cr
+++ b/src/regex.cr
@@ -410,7 +410,7 @@ class Regex
   # options = Regex::CompileOptions::IGNORE_CASE | Regex::CompileOptions::EXTENDED
   # Regex.new("dog", options) # => /dog/ix
   # ```
-  def self.new(source : String, options : Options = Options::None)
+  def self.new(source : String, options : Options = Options::None) : self
     new(_source: source, _options: options)
   end
 
@@ -430,7 +430,7 @@ class Regex
   # Regex.error?("(foo|bar)") # => nil
   # Regex.error?("(foo|bar")  # => "missing ) at 8"
   # ```
-  def self.error?(source) : String?
+  def self.error?(source : String) : String?
     Engine.error_impl(source)
   end
 
@@ -461,7 +461,7 @@ class Regex
   # string = Regex.escape("*?{}.") # => "\\*\\?\\{\\}\\."
   # /#{string}/                    # => /\*\?\{\}\./
   # ```
-  def self.escape(str) : String
+  def self.escape(str : String) : String
     String.build do |result|
       str.each_byte do |byte|
         {% begin %}
@@ -526,7 +526,7 @@ class Regex
   # re.match("Skiing")   # => Regex::MatchData("Skiing")
   # re.match("sledding") # => Regex::MatchData("sledding")
   # ```
-  def +(other) : Regex
+  def +(other : Regex) : Regex
     Regex.union(self, other)
   end
 
@@ -537,7 +537,7 @@ class Regex
   # /abc/i == /ABC/i # => false
   # /abc/i == /abc/i # => true
   # ```
-  def ==(other : Regex)
+  def ==(other : Regex) : Bool
     source == other.source && options == other.options
   end
 
@@ -564,7 +564,7 @@ class Regex
   #     end
   # b # => "Upper case"
   # ```
-  def ===(other : String)
+  def ===(other : String) : Bool
     match = match(other)
     $~ = match
     !match.nil?
@@ -669,7 +669,7 @@ class Regex
 
   # :ditto:
   @[Deprecated("Use the overload with `Regex::MatchOptions` instead.")]
-  def match(str, pos = 0, *, options) : MatchData?
+  def match(str : String, pos : Int32 = 0, *, options : Regex::Options) : MatchData?
     if byte_index = str.char_index_to_byte_index(pos)
       $~ = match_at_byte_index(str, byte_index, options)
     else
@@ -718,7 +718,7 @@ class Regex
 
   # :ditto:
   @[Deprecated("Use the overload with `Regex::MatchOptions` instead.")]
-  def match_at_byte_index(str, byte_index = 0, *, options) : MatchData?
+  def match_at_byte_index(str : String, byte_index : Int32 = 0, *, options : Regex::Options) : MatchData?
     if byte_index > str.bytesize
       $~ = nil
     else
@@ -728,7 +728,7 @@ class Regex
 
   # :ditto:
   @[Deprecated("Use the overload with `Regex::MatchOptions` instead.")]
-  def match_at_byte_index(str, byte_index, _options) : MatchData?
+  def match_at_byte_index(str : String, byte_index : Int32, _options : Regex::Options) : MatchData?
     match_at_byte_index(str, byte_index, options: _options)
   end
 
@@ -752,7 +752,7 @@ class Regex
 
   # :ditto:
   @[Deprecated("Use the overload with `Regex::MatchOptions` instead.")]
-  def matches?(str, pos = 0, *, options) : Bool
+  def matches?(str : String, pos : Int32 = 0, *, options : Regex::Options) : Bool
     if byte_index = str.char_index_to_byte_index(pos)
       matches_at_byte_index?(str, byte_index, options)
     else
@@ -776,7 +776,7 @@ class Regex
 
   # :ditto:
   @[Deprecated("Use the overload with `Regex::MatchOptions` instead.")]
-  def matches_at_byte_index?(str, byte_index = 0, *, options) : Bool
+  def matches_at_byte_index?(str : String, byte_index : Int32 = 0, *, options : Regex::Options) : Bool
     return false if byte_index > str.bytesize
 
     matches_impl(str, byte_index, options)
@@ -784,7 +784,7 @@ class Regex
 
   # :ditto:
   @[Deprecated("Use the overload with `Regex::MatchOptions` instead.")]
-  def matches_at_byte_index?(str, byte_index, _options) : Bool
+  def matches_at_byte_index?(str : String, byte_index : Int32, _options : Regex::Options) : Bool
     matches_at_byte_index?(str, byte_index, options: _options)
   end
 
@@ -842,7 +842,7 @@ class Regex
   end
 
   # :nodoc:
-  def self.append_source(source, io) : Nil
+  def self.append_source(source : String, io : IO) : Nil
     reader = Char::Reader.new(source)
     while reader.has_next?
       case char = reader.current_char
@@ -862,7 +862,7 @@ class Regex
     self
   end
 
-  def clone
+  def clone : Regex
     self
   end
 end

--- a/src/regex/lib_pcre2.cr
+++ b/src/regex/lib_pcre2.cr
@@ -191,7 +191,7 @@ lib LibPCRE2
     INTERNAL_DUPMATCH = -65
     DFA_UINVALID_UTF  = -66
 
-    def utf8_validity?
+    def utf8_validity? : Bool
       in?(UTF8_ERR21..UTF8_ERR1)
     end
   end

--- a/src/regex/match_data.cr
+++ b/src/regex/match_data.cr
@@ -67,7 +67,7 @@ class Regex
     # "Crystal".match!(/r/).begin(1)     # IndexError: Invalid capture group index: 1
     # "Crystal".match!(/r(x)?/).begin(1) # IndexError: Capture group 1 was not matched
     # ```
-    def begin(n = 0) : Int32
+    def begin(n : Int32 = 0) : Int32
       @string.byte_index_to_char_index(byte_begin(n)).not_nil!
     end
 
@@ -86,7 +86,7 @@ class Regex
     # "Crystal".match!(/r/).end(1)     # IndexError: Invalid capture group index: 1
     # "Crystal".match!(/r(x)?/).end(1) # IndexError: Capture group 1 was not matched
     # ```
-    def end(n = 0) : Int32
+    def end(n : Int32 = 0) : Int32
       @string.byte_index_to_char_index(byte_end(n)).not_nil!
     end
 
@@ -105,7 +105,7 @@ class Regex
     # "Crystal".match!(/r/).byte_begin(1)     # IndexError: Invalid capture group index: 1
     # "Crystal".match!(/r(x)?/).byte_begin(1) # IndexError: Capture group 1 was not matched
     # ```
-    def byte_begin(n = 0) : Int32
+    def byte_begin(n : Int32 = 0) : Int32
       check_index_out_of_bounds n
       byte_range(n) { |normalized_n| raise_capture_group_was_not_matched(normalized_n) }.begin
     end
@@ -125,7 +125,7 @@ class Regex
     # "Crystal".match!(/r/).byte_end(1)     # IndexError: Invalid capture group index: 1
     # "Crystal".match!(/r(x)?/).byte_end(1) # IndexError: Capture group 1 was not matched
     # ```
-    def byte_end(n = 0) : Int32
+    def byte_end(n : Int32 = 0) : Int32
       check_index_out_of_bounds n
       byte_range(n) { |normalized_n| raise_capture_group_was_not_matched(normalized_n) }.end
     end
@@ -390,7 +390,7 @@ class Regex
       self
     end
 
-    def ==(other : Regex::MatchData)
+    def ==(other : Regex::MatchData) : Bool
       return false unless size == other.size
       return false unless regex == other.regex
       return false unless string == other.string

--- a/src/regex/pcre2.cr
+++ b/src/regex/pcre2.cr
@@ -92,7 +92,7 @@ module Regex::PCRE2
     flag
   end
 
-  def self.supports_compile_flag?(options)
+  def self.supports_compile_flag?(options : Regex::Options) : Bool
     true
   end
 
@@ -146,7 +146,7 @@ module Regex::PCRE2
     flag
   end
 
-  def self.supports_match_flag?(options)
+  def self.supports_match_flag?(options : Regex::MatchOptions) : Bool
     true
   end
 
@@ -238,7 +238,7 @@ module Regex::PCRE2
   # can't be any concurrent access to the JIT stack.
   @@jit_stack = Crystal::ThreadLocalValue(LibPCRE2::JITStack*).new
 
-  def self.jit_stack
+  def self.jit_stack : Pointer(LibPCRE2::JITStack)
     @@jit_stack.get do
       LibPCRE2.jit_stack_create(32_768, 1_048_576, nil) || raise "Error allocating JIT stack"
     end
@@ -256,7 +256,7 @@ module Regex::PCRE2
     end
   end
 
-  def finalize
+  def finalize : Nil
     @match_data.consume_each do |match_data|
       LibPCRE2.match_data_free(match_data)
     end


### PR DESCRIPTION
This is the output of compiling [cr-source-typer](https://github.com/Vici37/cr-source-typer) and running it with the below incantation:

```
CRYSTAL_PATH="./src" ./typer spec/std_spec.cr \
  --error-trace --exclude src/crystal/ \
  --stats --progress \
  --union-size-threshold 2 \
  --ignore-private-defs \
  src/regex
```

This is related to #15682 .