### PR TITLE
Add type restrictions to spec

### DIFF
--- a/src/spec.cr
+++ b/src/spec.cr
@@ -96,7 +96,7 @@ module Spec
     # :nodoc:
     #
     # Implement formatter configuration.
-    def configure_formatter(formatter, output_path = nil)
+    def configure_formatter(formatter : String, output_path : String? = nil)
       case formatter
       when "junit"
         junit_formatter = Spec::JUnitFormatter.file(self, Path.new(output_path.not_nil!))
@@ -108,7 +108,7 @@ module Spec
       end
     end
 
-    def main(args)
+    def main(args : Array(String)) : Nil
       begin
         option_parser.parse(args)
       rescue e : OptionParser::InvalidOption

--- a/src/spec/cli.cr
+++ b/src/spec/cli.cr
@@ -25,12 +25,12 @@ module Spec
       @color = Colorize.default_enabled?(@stdout, @stderr)
     end
 
-    def add_location(file, line)
+    def add_location(file : String, line : Int32) : Array(Int32)
       locations = @locations ||= {} of String => Array(Int32)
       locations.put_if_absent(File.expand_path(file)) { [] of Int32 } << line
     end
 
-    def add_tag(tag)
+    def add_tag(tag : String) : Set(String)
       if anti_tag = tag.lchop?('~')
         (@anti_tags ||= Set(String).new) << anti_tag
       else
@@ -41,7 +41,7 @@ module Spec
     getter randomizer_seed : UInt64?
     getter randomizer : Random::PCG32?
 
-    def order=(mode)
+    def order=(mode : String | UInt64) : Nil
       seed =
         case mode
         when "default"

--- a/src/spec/context.cr
+++ b/src/spec/context.cr
@@ -8,7 +8,7 @@ module Spec
 
     protected abstract def cli : CLI
 
-    def randomize(randomizer)
+    def randomize(randomizer : Random) : Array(Spec::Example | Spec::ExampleGroup)
       children.each do |child|
         child.randomize(randomizer) if child.is_a?(ExampleGroup)
       end
@@ -159,7 +159,7 @@ module Spec
 
     protected getter cli : CLI
 
-    def results_for(status : Status)
+    def results_for(status : Status) : Array(Spec::Result)
       @results[status]
     end
 
@@ -357,7 +357,7 @@ module Spec
     end
 
     # :nodoc:
-    def run
+    def run : Nil
       cli.formatters.each(&.push(self))
 
       ran = run_around_all_hooks(ExampleGroup::Procsy.new(self) { internal_run })

--- a/src/spec/dsl.cr
+++ b/src/spec/dsl.cr
@@ -40,7 +40,7 @@ module Spec
   end
 
   # :nodoc:
-  def self.to_human(span : Time::Span)
+  def self.to_human(span : Time::Span) : String
     total_milliseconds = span.total_milliseconds
     if total_milliseconds < 1
       return "#{(span.total_milliseconds * 1000).round.to_i} microseconds"
@@ -162,14 +162,14 @@ module Spec
   class CLI
     @aborted = false
 
-    def abort!
+    def abort! : Nil
       @aborted = true
       finish_run
     end
 
     @split_filter : SplitFilter? = nil
 
-    def add_split_filter(filter)
+    def add_split_filter(filter : String?) : Spec::SplitFilter?
       if filter
         r, _, m = filter.partition('%')
         @split_filter = SplitFilter.new(remainder: r.to_i, quotient: m.to_i)
@@ -180,7 +180,7 @@ module Spec
 
     @start_time : Time::Span? = nil
 
-    def run
+    def run : Nil
       @start_time = Time.monotonic
 
       at_exit do |status|
@@ -204,22 +204,22 @@ module Spec
       end
     end
 
-    def colorize(str, status : Status)
+    def colorize(str : String | Char, status : Status) : Colorize::Object(String) | Colorize::Object(Char)
       str.colorize(status.color).toggle(@color)
     end
 
-    def colorize(str, kind : InfoKind)
+    def colorize(str : String, kind : InfoKind) : Colorize::Object(String)
       str.colorize(kind.color).toggle(@color)
     end
 
-    def execute_examples
+    def execute_examples : Nil
       log_setup
       maybe_randomize
       run_filters
       root_context.run
     end
 
-    def execute_list_tags
+    def execute_list_tags : Nil
       run_filters
       tag_counts = collect_tags(root_context)
       print_list_tags(tag_counts)
@@ -287,21 +287,21 @@ module Spec
       end
     end
 
-    def finish_run
+    def finish_run : Nil
       elapsed_time = Time.monotonic - @start_time.not_nil!
       root_context.finish(elapsed_time, @aborted)
       exit 1 if !root_context.succeeded || @aborted || (focus? && ENV["SPEC_FOCUS_NO_FAIL"]? != "1")
     end
 
     # :nodoc:
-    def maybe_randomize
+    def maybe_randomize : Nil
       if randomizer = @randomizer
         root_context.randomize(randomizer)
       end
     end
 
     # :nodoc:
-    def run_filters
+    def run_filters : Nil
       root_context.run_filters(@pattern, @line, @locations, @split_filter, @focus, @tags, @anti_tags)
     end
   end

--- a/src/spec/example.cr
+++ b/src/spec/example.cr
@@ -17,7 +17,7 @@ module Spec
     end
 
     # :nodoc:
-    def run
+    def run : Nil
       @parent.cli.root_context.check_nesting_spec(file, line) do
         @parent.cli.formatters.each(&.before_example(description))
 

--- a/src/spec/example/procsy.cr
+++ b/src/spec/example/procsy.cr
@@ -12,7 +12,7 @@ module Spec
 
       # Executes the wrapped example, possibly executing other
       # `around_each` hooks before that.
-      def run
+      def run : Nil
         @proc.call
       end
     end

--- a/src/spec/example_group/procsy.cr
+++ b/src/spec/example_group/procsy.cr
@@ -12,7 +12,7 @@ module Spec
 
       # Executes the wrapped example group, possibly executing other
       # `around_all` hooks before that.
-      def run
+      def run : Nil
         @proc.call
       end
     end

--- a/src/spec/expectations.cr
+++ b/src/spec/expectations.cr
@@ -85,45 +85,45 @@ module Spec
 
   # :nodoc:
   struct BeTruthyExpectation
-    def match(actual_value)
+    def match(actual_value) : Bool
       !!actual_value
     end
 
-    def failure_message(actual_value)
+    def failure_message(actual_value) : String
       "Expected: #{actual_value.pretty_inspect} to be truthy"
     end
 
-    def negative_failure_message(actual_value)
+    def negative_failure_message(actual_value : Bool?) : String
       "Expected: #{actual_value.pretty_inspect} not to be truthy"
     end
   end
 
   # :nodoc:
   struct BeFalseyExpectation
-    def match(actual_value)
+    def match(actual_value) : Bool
       !actual_value
     end
 
-    def failure_message(actual_value)
+    def failure_message(actual_value : Bool?) : String
       "Expected: #{actual_value.pretty_inspect} to be falsey"
     end
 
-    def negative_failure_message(actual_value)
+    def negative_failure_message(actual_value) : String
       "Expected: #{actual_value.pretty_inspect} not to be falsey"
     end
   end
 
   # :nodoc:
   struct BeNilExpectation
-    def match(actual_value)
+    def match(actual_value) : Bool
       actual_value.nil?
     end
 
-    def failure_message(actual_value)
+    def failure_message(actual_value) : String
       "Expected: #{actual_value.pretty_inspect} to be nil"
     end
 
-    def negative_failure_message(actual_value)
+    def negative_failure_message(actual_value) : String
       "Expected: #{actual_value.pretty_inspect} not to be nil"
     end
   end
@@ -285,15 +285,15 @@ module Spec
 
   # :nodoc:
   struct BeEmptyExpectation
-    def match(actual_value)
+    def match(actual_value) : Bool
       actual_value.empty?
     end
 
-    def failure_message(actual_value)
+    def failure_message(actual_value) : String
       "Expected: #{actual_value.pretty_inspect} to be empty"
     end
 
-    def negative_failure_message(actual_value)
+    def negative_failure_message(actual_value) : String
       "Expected: #{actual_value.pretty_inspect} not to be empty"
     end
   end
@@ -314,27 +314,27 @@ module Spec
     end
 
     # Creates an `Expectation` that passes if actual is true (`== true`).
-    def be_true
+    def be_true : Spec::EqualExpectation(Bool)
       eq true
     end
 
     # Creates an `Expectation` that passes if actual is false (`== false`).
-    def be_false
+    def be_false : Spec::EqualExpectation(Bool)
       eq false
     end
 
     # Creates an `Expectation` that passes if actual is truthy (neither `nil` nor `false`).
-    def be_truthy
+    def be_truthy : Spec::BeTruthyExpectation
       Spec::BeTruthyExpectation.new
     end
 
     # Creates an `Expectation` that passes if actual is falsy (`nil` or `false`).
-    def be_falsey
+    def be_falsey : Spec::BeFalseyExpectation
       Spec::BeFalseyExpectation.new
     end
 
     # Creates an `Expectation` that passes if actual is nil (`Object#nil?`).
-    def be_nil
+    def be_nil : Spec::BeNilExpectation
       Spec::BeNilExpectation.new
     end
 
@@ -349,35 +349,35 @@ module Spec
     # * passes if actual is lesser than or equal *value*: `be <= value`
     # * passes if actual is greater than *value*: `be > value`
     # * passes if actual is greater than or equal *value*: `be >= value`
-    def be
+    def be : Spec::Be.class
       Spec::Be
     end
 
     # Creates an `Expectation` that passes if actual matches *value* (`=~`).
-    def match(value)
+    def match(value : T) : Spec::MatchExpectation(T) forall T
       Spec::MatchExpectation.new(value)
     end
 
     # Creates an `Expectation` that passes if actual includes *expected* (`.includes?`).
     # Works on collections and `String`.
-    def contain(expected)
+    def contain(expected : T) : Spec::ContainExpectation(T) forall T
       Spec::ContainExpectation.new(expected)
     end
 
     # Creates an `Expectation` that passes if actual starts with *expected* (`.starts_with?`).
     # Works on `String`.
-    def start_with(expected)
+    def start_with(expected : T) : Spec::StartWithExpectation(T) forall T
       Spec::StartWithExpectation.new(expected)
     end
 
     # Creates an `Expectation` that passes if actual ends with *expected* (`.ends_with?`).
     # Works on `String`.
-    def end_with(expected)
+    def end_with(expected : T) : Spec::EndWithExpectation(T) forall T
       Spec::EndWithExpectation.new(expected)
     end
 
     # Creates an `Expectation` that passes if actual is empty (`.empty?`).
-    def be_empty
+    def be_empty : Spec::BeEmptyExpectation
       Spec::BeEmptyExpectation.new
     end
 
@@ -452,7 +452,7 @@ module Spec
     # ```
     #
     # See `Spec::Expectations` for available expectations.
-    def should(expectation : BeAExpectation(T), failure_message : String? = nil, *, file = __FILE__, line = __LINE__) : T forall T
+    def should(expectation : BeAExpectation(T), failure_message : String? = nil, *, file : String = __FILE__, line : Int32 = __LINE__) : T forall T
       if expectation.match self
         self.is_a?(T) ? self : (raise "Bug: expected #{self} to be a #{T}")
       else
@@ -464,7 +464,7 @@ module Spec
     # Validates an expectation and fails the example if it does not match.
     #
     # See `Spec::Expectations` for available expectations.
-    def should(expectation, failure_message : String? = nil, *, file = __FILE__, line = __LINE__)
+    def should(expectation, failure_message : String? = nil, *, file : String = __FILE__, line : Int32 = __LINE__) : Nil
       unless expectation.match self
         failure_message ||= expectation.failure_message(self)
         fail(failure_message, file, line)
@@ -484,7 +484,7 @@ module Spec
     # ```
     #
     # See `Spec::Expectations` for available expectations.
-    def should_not(expectation : BeAExpectation(T), failure_message : String? = nil, *, file = __FILE__, line = __LINE__) forall T
+    def should_not(expectation : BeAExpectation(T), failure_message : String? = nil, *, file : String = __FILE__, line : Int32 = __LINE__) forall T
       if expectation.match self
         failure_message ||= expectation.negative_failure_message(self)
         fail(failure_message, file, line)
@@ -505,7 +505,7 @@ module Spec
     # ```
     #
     # See `Spec::Expectations` for available expectations.
-    def should_not(expectation : BeNilExpectation, failure_message : String? = nil, *, file = __FILE__, line = __LINE__)
+    def should_not(expectation : BeNilExpectation, failure_message : String? = nil, *, file : String = __FILE__, line : Int32 = __LINE__)
       if expectation.match self
         failure_message ||= expectation.negative_failure_message(self)
         fail(failure_message, file, line)
@@ -517,7 +517,7 @@ module Spec
     # Validates an expectation and fails the example if it matches.
     #
     # See `Spec::Expectations` for available expectations.
-    def should_not(expectation, failure_message : String? = nil, *, file = __FILE__, line = __LINE__)
+    def should_not(expectation, failure_message : String? = nil, *, file : String = __FILE__, line : Int32 = __LINE__) : Nil
       if expectation.match self
         failure_message ||= expectation.negative_failure_message(self)
         fail(failure_message, file, line)

--- a/src/spec/filters.cr
+++ b/src/spec/filters.cr
@@ -32,7 +32,7 @@ module Spec
 
   class RootContext
     # :nodoc:
-    def run_filters(pattern = nil, line = nil, locations = nil, split_filter = nil, focus = nil, tags = nil, anti_tags = nil)
+    def run_filters(pattern : Regex? = nil, line : Int32? = nil, locations : Hash(String, Array(Int32))? = nil, split_filter : Spec::SplitFilter? = nil, focus : Bool? = nil, tags : Set(String)? = nil, anti_tags : Set(String)? = nil) : Array(Spec::Example | Spec::ExampleGroup)?
       filter_by_pattern(pattern) if pattern
       filter_by_line(line) if line
       filter_by_locations(locations) if locations
@@ -43,32 +43,32 @@ module Spec
     end
 
     # :nodoc:
-    def filter_by_pattern(pattern : Regex)
+    def filter_by_pattern(pattern : Regex) : Array(Spec::Example | Spec::ExampleGroup)
       children.select!(&.filter_by_pattern(pattern))
     end
 
     # :nodoc:
-    def filter_by_line(line : Int32)
+    def filter_by_line(line : Int32) : Array(Spec::Example | Spec::ExampleGroup)
       children.select!(&.filter_by_line(line))
     end
 
     # :nodoc:
-    def filter_by_locations(locations : Hash(String, Array(Int32)))
+    def filter_by_locations(locations : Hash(String, Array(Int32))) : Array(Spec::Example | Spec::ExampleGroup)
       children.select!(&.filter_by_locations(locations))
     end
 
     # :nodoc:
-    def filter_by_focus
+    def filter_by_focus : Array(Spec::Example | Spec::ExampleGroup)
       children.select!(&.filter_by_focus)
     end
 
     # :nodoc:
-    def filter_by_tags(tags : Set(String))
+    def filter_by_tags(tags : Set(String)) : Array(Spec::Example | Spec::ExampleGroup)
       children.select!(&.filter_by_tags(tags))
     end
 
     # :nodoc:
-    def filter_by_anti_tags(anti_tags : Set(String))
+    def filter_by_anti_tags(anti_tags : Set(String)) : Array(Spec::Example | Spec::ExampleGroup)
       children.select!(&.filter_by_anti_tags(anti_tags))
     end
 

--- a/src/spec/formatter.cr
+++ b/src/spec/formatter.cr
@@ -67,7 +67,7 @@ module Spec
         @printed = false
       end
 
-      def print(io)
+      def print(io : IO) : Nil
         return if @printed
         @printed = true
 
@@ -90,15 +90,15 @@ module Spec
       @indent -= 1
     end
 
-    def print_indent
+    def print_indent : Nil
       self.class.print_indent(@io, @indent)
     end
 
-    def self.print_indent(io, indent)
+    def self.print_indent(io : IO, indent : Int32) : Nil
       indent.times { io << "  " }
     end
 
-    def before_example(description)
+    def before_example(description : String) : String
       @items.each &.print(@io)
       print_indent
       @io << description
@@ -118,15 +118,15 @@ module Spec
 
   # :nodoc:
   class CLI
-    def formatters
+    def formatters : Array(Spec::Formatter)
       @formatters ||= [Spec::DotFormatter.new(self)] of Spec::Formatter
     end
 
-    def override_default_formatter(formatter)
+    def override_default_formatter(formatter : Spec::Formatter) : Spec::Formatter
       formatters[0] = formatter
     end
 
-    def add_formatter(formatter)
+    def add_formatter(formatter : Spec::Formatter) : Array(Spec::Formatter)
       formatters << formatter
     end
   end

--- a/src/spec/junit_formatter.cr
+++ b/src/spec/junit_formatter.cr
@@ -34,7 +34,7 @@ module Spec
       io.close
     end
 
-    def self.file(cli : CLI, output_path : Path)
+    def self.file(cli : CLI, output_path : Path) : Spec::JUnitFormatter
       if output_path.extension != ".xml"
         output_path = output_path.join("output.xml")
       end

--- a/src/spec/methods.cr
+++ b/src/spec/methods.cr
@@ -16,7 +16,7 @@ module Spec::Methods
   # ```
   #
   # If `focus` is `true`, only this `describe`, and others marked with `focus: true`, will run.
-  def describe(description = nil, file = __FILE__, line = __LINE__, end_line = __END_LINE__, focus : Bool = false, tags : String | Enumerable(String) | Nil = nil, &block)
+  def describe(description = nil, file : String = __FILE__, line : Int32 = __LINE__, end_line : Int32 = __END_LINE__, focus : Bool = false, tags : String | Enumerable(String) | Nil = nil, &block) : Nil
     Spec.cli.root_context.describe(description.to_s, file, line, end_line, focus, tags, &block)
   end
 
@@ -27,7 +27,7 @@ module Spec::Methods
   # It is functionally equivalent to `#describe`.
   #
   # If `focus` is `true`, only this `context`, and others marked with `focus: true`, will run.
-  def context(description = nil, file = __FILE__, line = __LINE__, end_line = __END_LINE__, focus : Bool = false, tags : String | Enumerable(String) | Nil = nil, &block)
+  def context(description : String? = nil, file : String = __FILE__, line : Int32 = __LINE__, end_line : Int32 = __END_LINE__, focus : Bool = false, tags : String | Enumerable(String) | Nil = nil, &block) : Nil
     describe(description.to_s, file, line, end_line, focus, tags, &block)
   end
 
@@ -45,7 +45,7 @@ module Spec::Methods
   # It is usually used inside a `#describe` or `#context` section.
   #
   # If `focus` is `true`, only this test, and others marked with `focus: true`, will run.
-  def it(description = "assert", file = __FILE__, line = __LINE__, end_line = __END_LINE__, focus : Bool = false, tags : String | Enumerable(String) | Nil = nil, &block)
+  def it(description = "assert", file : String = __FILE__, line : Int32 = __LINE__, end_line : Int32 = __END_LINE__, focus : Bool = false, tags : String | Enumerable(String) | Nil = nil, &block) : Array(Spec::Example | Spec::ExampleGroup)
     Spec.cli.root_context.it(description.to_s, file, line, end_line, focus, tags, &block)
   end
 
@@ -71,14 +71,14 @@ module Spec::Methods
   # Defines a yet-to-be-implemented pending test case
   #
   # If `focus` is `true`, only this test, and others marked with `focus: true`, will run.
-  def pending(description = "assert", file = __FILE__, line = __LINE__, end_line = __END_LINE__, focus : Bool = false, tags : String | Enumerable(String) | Nil = nil)
+  def pending(description : String = "assert", file : String = __FILE__, line : Int32 = __LINE__, end_line : Int32 = __END_LINE__, focus : Bool = false, tags : String | Enumerable(String) | Nil = nil) : Array(Spec::Example | Spec::ExampleGroup)
     Spec.cli.root_context.pending(description.to_s, file, line, end_line, focus, tags)
   end
 
   # Fails an example.
   #
   # This method can be used to manually fail an example defined in an `#it` block.
-  def fail(msg, file = __FILE__, line = __LINE__)
+  def fail(msg : String, file : String = __FILE__, line : Int32 = __LINE__) : Nil
     raise Spec::AssertionFailed.new(msg, file, line)
   end
 
@@ -96,7 +96,7 @@ module Spec::Methods
   #   cmd.should end_with("git")
   # end
   # ```
-  def pending!(msg = "Cannot run example", file = __FILE__, line = __LINE__)
+  def pending!(msg : String = "Cannot run example", file : String = __FILE__, line : Int32 = __LINE__) : Nil
     raise Spec::ExamplePending.new(msg, file, line)
   end
 
@@ -123,7 +123,7 @@ module Spec::Methods
   #   it "sample_b" { }
   # end
   # ```
-  def before_each(&block)
+  def before_each(&block) : Nil
     if Spec.cli.current_context.is_a?(RootContext)
       raise "Can't call `before_each` outside of a describe/context"
     end
@@ -153,7 +153,7 @@ module Spec::Methods
   #   it "sample_b" { }
   # end
   # ```
-  def after_each(&block)
+  def after_each(&block) : Nil
     if Spec.cli.current_context.is_a?(RootContext)
       raise "Can't call `after_each` outside of a describe/context"
     end
@@ -183,7 +183,7 @@ module Spec::Methods
   #   it "sample_b" { }
   # end
   # ```
-  def before_all(&block)
+  def before_all(&block) : Nil
     if Spec.cli.current_context.is_a?(RootContext)
       raise "Can't call `before_all` outside of a describe/context"
     end
@@ -213,7 +213,7 @@ module Spec::Methods
   #   it "sample_b" { }
   # end
   # ```
-  def after_all(&block)
+  def after_all(&block) : Nil
     if Spec.cli.current_context.is_a?(RootContext)
       raise "Can't call `after_all` outside of a describe/context"
     end
@@ -251,7 +251,7 @@ module Spec::Methods
   #   it "sample_b" { }
   # end
   # ```
-  def around_each(&block : Example::Procsy ->)
+  def around_each(&block : Example::Procsy ->) : Nil
     if Spec.cli.current_context.is_a?(RootContext)
       raise "Can't call `around_each` outside of a describe/context"
     end
@@ -296,7 +296,7 @@ module Spec::Methods
   #   end
   # end
   # ```
-  def around_all(&block : ExampleGroup::Procsy ->)
+  def around_all(&block : ExampleGroup::Procsy ->) : Nil
     if Spec.cli.current_context.is_a?(RootContext)
       raise "Can't call `around_all` outside of a describe/context"
     end


### PR DESCRIPTION
This is the output of compiling [cr-source-typer](https://github.com/Vici37/cr-source-typer) and running it with the below incantation:

```
CRYSTAL_PATH="./src" ./typer spec/std_spec.cr \
  --error-trace --exclude src/crystal/ \
  --stats --progress \
  --union-size-threshold 2 \
  --ignore-private-defs \
  src/spec
```

This is related to #15682 .

This touched more than I expected, but everything looks correct to me. Comments always welcome :)