### PR TITLE
Fix socketpair fcntl reference bug for fds[1]

### DIFF
--- a/src/crystal/system/unix/socket.cr
+++ b/src/crystal/system/unix/socket.cr
@@ -211,7 +211,7 @@ module Crystal::System::Socket
         fcntl(fds[1], LibC::F_SETFD, LibC::FD_CLOEXEC)
         unless blocking
           fcntl(fds[0], LibC::F_SETFL, fcntl(fds[0], LibC::F_GETFL) | LibC::O_NONBLOCK)
-          fcntl(fds[1], LibC::F_SETFL, fcntl(fds[0], LibC::F_GETFL) | LibC::O_NONBLOCK)
+          fcntl(fds[1], LibC::F_SETFL, fcntl(fds[1], LibC::F_GETFL) | LibC::O_NONBLOCK)
         end
       end
     {% end %}


### PR DESCRIPTION
Hi

While reviewing Crystal’s implementation with AI, I came across a potential bug in the non-blocking setup of socketpair. According to the AI, the issue is as follows:

---

**Problem**
On line 206, the code reads flags from `fds[0]` when setting them for `fds[1]`:

```crystal
fcntl(fds[1], LibC::F_SETFL, fcntl(fds[0], LibC::F_GETFL) | LibC::O_NONBLOCK)
```

It should read the flags from `fds[1]` itself:

```crystal
fcntl(fds[1], LibC::F_SETFL, fcntl(fds[1], LibC::F_GETFL) | LibC::O_NONBLOCK)
```

This affects only older systems without `SOCK_CLOEXEC` support, where the second socket may incorrectly inherit the first socket’s settings.

---

I’m not an expert on sockets, so I can’t confirm this. If it’s incorrect, please close the issue. Thank you.