### PR TITLE
Fix `IO::TimeoutError` documentation use of deprecated `read_timeout=`

### DIFF
--- a/src/io/error.cr
+++ b/src/io/error.cr
@@ -26,7 +26,7 @@ class IO
   # Raised when an `IO` operation times out.
   #
   # ```
-  # STDIN.read_timeout = 1
+  # STDIN.read_timeout = 1.second
   # STDIN.gets # raises IO::TimeoutError (after 1 second)
   # ```
   class TimeoutError < Error


### PR DESCRIPTION
The `IO::Timeout` documentation provides this example usage:

    # Raised when an `IO` operation times out.
    #
    # ```
    # STDIN.read_timeout = 1
    # STDIN.gets # raises IO::TimeoutError (after 1 second)
    # ```

Which when run results in this deprecation warning: 

    Warning: Deprecated IO::FileDescriptor#read_timeout=. Use `#read_timeout=(Time::Span?)` instead.

This pull request fixes the comment to use `#read_timeout=(Time::Span?)` instead as per the deprecation warning:

    # Raised when an `IO` operation times out.
    #
    # ```
    # STDIN.read_timeout = 1.second
    # STDIN.gets # raises IO::TimeoutError (after 1 second)
    # ```