### PR TITLE
[Bug Fix] Allow wants_docs=true to be used with full semantic processing

### DIFF
--- a/src/macros.cr
+++ b/src/macros.cr
@@ -73,11 +73,11 @@ macro record(__name name, *properties, **kwargs)
   struct {{name.id}}
     {% for property in properties %}
       {% if property.is_a?(Assign) %}
-        getter {{property.target.id}}
+        getter({{property.target.id}})
       {% elsif property.is_a?(TypeDeclaration) %}
-        getter {{property}}
+        getter({{property}})
       {% else %}
-        getter :{{property.id}}
+        getter(:{{property.id}})
       {% end %}
     {% end %}
 


### PR DESCRIPTION
This is a very subtle bug discovered during trying to introduce `:nodoc:` filtering into the [cr-source-typer](https://github.com/Vici37/cr-source-typer) tool as initially suggested [here](https://github.com/crystal-lang/crystal/pull/16068#issuecomment-3165789177). My apologies for the long winded PR description; this consumed about 2 days of my time to track down and I want to document it for posterity.

## Semi Minimal Reproduction
After constructing a `Program` and `Parser`, add the `.wants_docs = true` configuration to both of them. Then have the Parser parse `test.cr` below and then run full `semantic` on the resulting parsed node. This is left as an exercise for the reader ([this ](https://github.com/crystal-lang/crystal/blob/master/src/compiler/crystal/compiler.cr#L222-L229)is a decent example within the compiler itself)

my_record.cr:
```
record MyRecord,
    # This is a comment on a field of a record
    hello : String
```

test.cr:
```
require "./my_record"

puts MyRecord.new("world").hello
```

Resulting exception:
```
Unhandled exception: In test.cr:3:28

 3 | puts MyRecord.new("world").hello
                                ^----
Error: undefined method 'hello' for MyRecord  
```

This error goes away if any of the following happen:
1. The single line comment in `my_record.cr` is removed
2. The `wants_docs` is set to `false`
3. If a struct is used instead of the `record` macro
4. `MyRecord` is defined in `test.cr` itself instead of being required (I didn't figure out why)

## Following the Macro Expansions
Trial and error eventually got me to the macro evaluation as the culprit (prior thoughts were on the lexer / parser being overly aggressive somehow, as those were the only places where `wants_docs`, `docs_enabled`, or the `doc` type variable were really being used). It turns out if a type node has a `doc` variable set on it, then macro `{{node}}` will expand that part of it first as a comment, followed by a newline ([here](https://github.com/crystal-lang/crystal/blob/master/src/compiler/crystal/syntax/to_s.cr#L44-L51) for the doc writing in macro expansion, [here](https://github.com/crystal-lang/crystal/blob/master/src/compiler/crystal/macros/interpreter.cr#L129) for the source of the `emit_doc` property). This resulted in the below macro expansion(s).

```
struct MyRecord
    getter # This is a comment on a field of a record
hello : String

... [ snipped other method generation ] ...
end
```
The followup macro expansion of the `getter` macro would result in nothing being generated (empty `*properties` list). The dangling `hello : String` is technically valid but represents a private (protected?) field of the MyRecord struct now. Adding parens on the `getter` macro generation now captures the `hello : String` as part of that `*properties` list in the `getter` macro and now generates the `def` for it as the `TypeDeclaration` it is.

## How did you find this?
The above minimal reproduction represents the `src/compiler/crystal/interpreter/interpreter.cr` -> `CallFrame` record. Running the cr-source-typer tool with full semantic on the `prelude` node with `wants_docs` found that and started complaining about a lack of `real_frame_index` method being defined.

## Why doesn't this show up during doc generation?
Running `crystal docs` only runs the `top_level_semantic` on the AST, which doesn't open up methods, follow calls, and then discover methods don't exist. The impact instead is that these methods generated by the `getter` macro wouldn't be generated and the resulting docs wouldn't include them :shrug: 