### PR TITLE
Do not use equality checks in `Int#upto` and `#downto`

### DIFF
--- a/src/int.cr
+++ b/src/int.cr
@@ -578,7 +578,7 @@ struct Int
     x = self
     while true
       yield x
-      return if x == to
+      return unless x < to
       x += 1
     end
   end
@@ -607,7 +607,7 @@ struct Int
     x = self
     while true
       yield x
-      return if x == to
+      return unless x > to
       x -= 1
     end
   end


### PR DESCRIPTION
Aligns those implementations to `Range#each` and `#reverse_each`, whereby the comparisons aid the LLVM optimizer in proving that the loop index increment / decrement can never overflow, something not done with `#==`.

This has no observable impact on `BigInt`, since it has no Crystal overflow, and any comparison must inspect all digits on the heap anyway.