### PR TITLE
Fix `StaticFileHandler` spec with broken symlink [fixup #16025]

### DIFF
--- a/spec/std/data/static_file_handler/broken-symlink.txt
+++ b/spec/std/data/static_file_handler/broken-symlink.txt
@@ -1,1 +1,0 @@
-nonexistent.txt

--- a/spec/std/http/server/handlers/static_file_handler_spec.cr
+++ b/spec/std/http/server/handlers/static_file_handler_spec.cr
@@ -552,8 +552,11 @@ describe HTTP::StaticFileHandler do
   end
 
   it "returns 404 for file error" do
-    response = handle HTTP::Request.new("GET", "/broken_symlink.txt")
-    response.status_code.should eq(404)
+    with_tempdir do
+      File.symlink("nonexistent.txt", "broken-symlink.txt")
+      response = handle HTTP::Request.new("GET", "/broken-symlink.txt")
+      response.status_code.should eq(404)
+    end
   end
 
   it "returns 404 for unreadable file" do


### PR DESCRIPTION
Fixup addressing https://github.com/crystal-lang/crystal/pull/16025#issuecomment-3172226714