### PR TITLE
Fix time zone identifier `America/Argentina/Buenos_Aires`

### DIFF
--- a/spec/std/time/format_spec.cr
+++ b/spec/std/time/format_spec.cr
@@ -80,12 +80,12 @@ describe Time::Format do
         assert_prints zoned.to_s("%^Z"), "CET"
         assert_prints zoned.to_s("%Z"), "Europe/Berlin"
 
-        zoned = Time.local(2017, 11, 24, 13, 5, 6, location: Time::Location.load("America/Buenos_Aires"))
+        zoned = Time.local(2017, 11, 24, 13, 5, 6, location: Time::Location.load("America/Argentina/Buenos_Aires"))
         assert_prints zoned.to_s("%z"), "-0300"
         assert_prints zoned.to_s("%:z"), "-03:00"
         assert_prints zoned.to_s("%::z"), "-03:00:00"
         assert_prints zoned.to_s("%^Z"), "-03"
-        assert_prints zoned.to_s("%Z"), "America/Buenos_Aires"
+        assert_prints zoned.to_s("%Z"), "America/Argentina/Buenos_Aires"
       end
 
       offset = Time.local(2017, 11, 24, 13, 5, 6, location: Time::Location.fixed(9000))

--- a/spec/std/time/location_spec.cr
+++ b/spec/std/time/location_spec.cr
@@ -605,7 +605,7 @@ class Time::Location
 
       it "handles value after last transition" do
         with_zoneinfo do
-          location = Location.load("America/Buenos_Aires")
+          location = Location.load("America/Argentina/Buenos_Aires")
           zone = location.lookup(Time.utc(5000, 1, 1))
           zone.name.should eq "-03"
           zone.offset.should eq -3 * 3600

--- a/spec/std/time/time_spec.cr
+++ b/spec/std/time/time_spec.cr
@@ -930,7 +930,7 @@ describe Time do
         Time.week_date(*CALENDAR_WEEK_TEST_DATA[0][1], 11, 57, 32, nanosecond: 123_567, location: location).should eq(
           Time.local(*CALENDAR_WEEK_TEST_DATA[0][0], 11, 57, 32, nanosecond: 123_567, location: location))
 
-        location = Time::Location.load("America/Buenos_Aires")
+        location = Time::Location.load("America/Argentina/Buenos_Aires")
         Time.week_date(*CALENDAR_WEEK_TEST_DATA[0][1], 11, 57, 32, nanosecond: 123_567, location: location).should eq(
           Time.local(*CALENDAR_WEEK_TEST_DATA[0][0], 11, 57, 32, nanosecond: 123_567, location: location))
       end
@@ -963,7 +963,7 @@ describe Time do
         Time.month_week_date(2025, 3, 3, 7, 11, 57, 32, nanosecond: 123_567, location: location).should eq(
           Time.local(2025, 3, 16, 11, 57, 32, nanosecond: 123_567, location: location))
 
-        location = Time::Location.load("America/Buenos_Aires")
+        location = Time::Location.load("America/Argentina/Buenos_Aires")
         Time.month_week_date(2025, 3, 3, 7, 11, 57, 32, nanosecond: 123_567, location: location).should eq(
           Time.local(2025, 3, 16, 11, 57, 32, nanosecond: 123_567, location: location))
       end

--- a/src/time.cr
+++ b/src/time.cr
@@ -105,9 +105,9 @@ require "crystal/system/time"
 #
 # ```
 # time_de = Time.local(2018, 3, 8, 22, 5, 13, location: Time::Location.load("Europe/Berlin"))
-# time_ar = time_de.in Time::Location.load("America/Buenos_Aires")
+# time_ar = time_de.in Time::Location.load("America/Argentina/Buenos_Aires")
 # time_de # => 2018-03-08 22:05:13 +01:00 Europe/Berlin
-# time_ar # => 2018-03-08 18:05:13 -03:00 America/Buenos_Aires
+# time_ar # => 2018-03-08 18:05:13 -03:00 America/Argentina/Buenos_Aires
 # ```
 #
 # Both `Time` instances show a different local date-time, but they represent
@@ -1042,7 +1042,7 @@ struct Time
   #
   # ```
   # time_de = Time.local(2018, 3, 8, 22, 5, 13, location: Time::Location.load("Europe/Berlin"))
-  # time_ar = Time.local(2018, 3, 8, 18, 5, 13, location: Time::Location.load("America/Buenos_Aires"))
+  # time_ar = Time.local(2018, 3, 8, 18, 5, 13, location: Time::Location.load("America/Argentina/Buenos_Aires"))
   # time_de == time_ar # => true
   #
   # # both times represent the same instant:
@@ -1359,9 +1359,9 @@ struct Time
   #
   # ```
   # time_de = Time.local(2018, 3, 8, 22, 5, 13, location: Time::Location.load("Europe/Berlin"))
-  # time_ar = time_de.in Time::Location.load("America/Buenos_Aires")
+  # time_ar = time_de.in Time::Location.load("America/Argentina/Buenos_Aires")
   # time_de # => 2018-03-08 22:05:13 +01:00 Europe/Berlin
-  # time_ar # => 2018-03-08 18:05:13 -03:00 America/Buenos_Aires
+  # time_ar # => 2018-03-08 18:05:13 -03:00 America/Argentina/Buenos_Aires
   # ```
   #
   # In contrast, `#to_local_in` changes to a different location while


### PR DESCRIPTION
The canonical identifier is `America/Argentina/Buenos_Aires`. `America/Buenos_Aires` is just an alias. And this alias is part of a backwards compatibility feature which might not always be available (see #16054).

Note: I'm not updating the identifiers in https://github.com/crystal-lang/crystal/blob/master/src/crystal/system/win32/zone_names.cr because that file is autogenerated from upstream data.