### PR TITLE
Add note about default constructor in `*::Serializable`

### DIFF
--- a/src/json/serialization.cr
+++ b/src/json/serialization.cr
@@ -81,6 +81,10 @@ module JSON
   # A.from_json(%<{"a":1}>) # => A(@a=1, @b=1.0)
   # ```
   #
+  # NOTE: `JSON::Serializable` defines an internal constructor on any including
+  # type, which prevents the compiler from generating a default constructor,
+  # even when all instance variables have a default initializer.
+  #
   # ### Extensions: `JSON::Serializable::Strict` and `JSON::Serializable::Unmapped`.
   #
   # If the `JSON::Serializable::Strict` module is included, unknown properties in the JSON

--- a/src/json/serialization.cr
+++ b/src/json/serialization.cr
@@ -82,8 +82,9 @@ module JSON
   # ```
   #
   # NOTE: `JSON::Serializable` defines an internal constructor on any including
-  # type, which prevents the compiler from generating a default constructor,
-  # even when all instance variables have a default initializer.
+  # type, which means the default constructor (`def initialize; end`) is absent
+  # unless explicitly defined by the user, even when all instance variables have
+  # a default initializer.
   #
   # ### Extensions: `JSON::Serializable::Strict` and `JSON::Serializable::Unmapped`.
   #

--- a/src/uri/params/serializable.cr
+++ b/src/uri/params/serializable.cr
@@ -57,6 +57,10 @@ struct URI::Params
   #
   # A.from_www_form("a=1") # => A(@a=1, @b=1.0)
   # ```
+  #
+  # NOTE: `URI::Params::Serializable` defines an internal constructor on any
+  # including type, which prevents the compiler from generating a default
+  # constructor, even when all instance variables have a default initializer.
   module Serializable
     macro included
       def self.from_www_form(params : ::String)

--- a/src/uri/params/serializable.cr
+++ b/src/uri/params/serializable.cr
@@ -59,8 +59,9 @@ struct URI::Params
   # ```
   #
   # NOTE: `URI::Params::Serializable` defines an internal constructor on any
-  # including type, which prevents the compiler from generating a default
-  # constructor, even when all instance variables have a default initializer.
+  # including type, which means the default constructor (`def initialize; end`)
+  # is absent unless explicitly defined by the user, even when all instance
+  # variables have a default initializer.
   module Serializable
     macro included
       def self.from_www_form(params : ::String)

--- a/src/yaml/serialization.cr
+++ b/src/yaml/serialization.cr
@@ -81,8 +81,9 @@ module YAML
   # ```
   #
   # NOTE: `YAML::Serializable` defines an internal constructor on any including
-  # type, which prevents the compiler from generating a default constructor,
-  # even when all instance variables have a default initializer.
+  # type, which means the default constructor (`def initialize; end`) is absent
+  # unless explicitly defined by the user, even when all instance variables have
+  # a default initializer.
   #
   # ### Extensions: `YAML::Serializable::Strict` and `YAML::Serializable::Unmapped`.
   #

--- a/src/yaml/serialization.cr
+++ b/src/yaml/serialization.cr
@@ -80,6 +80,10 @@ module YAML
   # A.from_yaml("---\na: 1\n") # => A(@a=1, @b=1.0)
   # ```
   #
+  # NOTE: `YAML::Serializable` defines an internal constructor on any including
+  # type, which prevents the compiler from generating a default constructor,
+  # even when all instance variables have a default initializer.
+  #
   # ### Extensions: `YAML::Serializable::Strict` and `YAML::Serializable::Unmapped`.
   #
   # If the `YAML::Serializable::Strict` module is included, unknown properties in the YAML


### PR DESCRIPTION
Including types do not have default constructors.