### PR TITLE
Style multi-line codegen specs using heredocs

### DIFF
--- a/spec/compiler/codegen/alias_spec.cr
+++ b/spec/compiler/codegen/alias_spec.cr
@@ -2,40 +2,40 @@ require "../../spec_helper"
 
 describe "Code gen: alias" do
   it "invokes methods on empty array of recursive alias (1)" do
-    run(%(
+    run(<<-CRYSTAL).to_string.should eq("")
       require "prelude"
 
       alias Alias = Array(Alias)
 
       a = [] of Alias
       b = a.map(&.to_s).join
-      )).to_string.should eq("")
+      CRYSTAL
   end
 
   it "invokes methods on empty array of recursive alias (2)" do
-    run(%(
+    run(<<-CRYSTAL).to_string.should eq("")
       require "prelude"
 
       alias Alias = Nil | Array(Alias)
 
       a = [] of Alias
       b = a.map(&.to_s).join
-      )).to_string.should eq("")
+      CRYSTAL
   end
 
   it "invokes methods on empty array of recursive alias (3)" do
-    run(%(
+    run(<<-CRYSTAL).to_string.should eq("")
       require "prelude"
 
       alias Alias = Nil | Array(Alias)
 
       a = [] of Alias
       b = a.map(&.to_s).join
-      )).to_string.should eq("")
+      CRYSTAL
   end
 
   it "casts to recursive alias" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(1)
       require "prelude"
 
       class Bar(T)
@@ -46,11 +46,11 @@ describe "Code gen: alias" do
       a = 1.as(Foo)
       b = a.as(Int32)
       b
-      )).to_i.should eq(1)
+      CRYSTAL
   end
 
   it "casts to recursive alias" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(1)
       class Bar(T)
         def self.new(&block : -> T)
         end
@@ -71,7 +71,7 @@ describe "Code gen: alias" do
       end
 
       foo(2).to_i!
-      )).to_i.should eq(1)
+      CRYSTAL
   end
 
   it "doesn't break with alias for link attributes" do
@@ -87,7 +87,7 @@ describe "Code gen: alias" do
   end
 
   it "doesn't crash on cast to as recursive alias (#639)" do
-    codegen(%(
+    codegen(<<-CRYSTAL)
       class Foo(T)
       end
 
@@ -98,11 +98,11 @@ describe "Code gen: alias" do
       ptr = Pointer(Type).malloc(1_u64)
       ptr.value = 1.as(Type)
       ptr.value = 1
-      ))
+      CRYSTAL
   end
 
   it "lazily solves aliases (#1346)" do
-    run(%(
+    run(<<-CRYSTAL)
       struct Proc
         def self.new(&block : self)
           block
@@ -127,11 +127,11 @@ describe "Code gen: alias" do
 
       cmd = CmdHandler.new { |s| s.foo }
       cmd.call(SmtpSession.new)
-      ))
+      CRYSTAL
   end
 
   it "codegens cast to alias that includes bool" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(2)
       alias Foo = Bool | Array(Foo)
 
       a = false.as(Foo)
@@ -140,11 +140,11 @@ describe "Code gen: alias" do
       else
         2
       end
-      )).to_i.should eq(2)
+      CRYSTAL
   end
 
   it "overloads alias against generic (1) (#3261)" do
-    run(%(
+    run(<<-CRYSTAL, inject_primitives: false).to_i.should eq(2)
       class Foo(T)
       end
 
@@ -159,11 +159,11 @@ describe "Code gen: alias" do
       end
 
       take(Foo(String).new)
-      ), inject_primitives: false).to_i.should eq(2)
+      CRYSTAL
   end
 
   it "overloads alias against generic (2) (#3261)" do
-    run(%(
+    run(<<-CRYSTAL, inject_primitives: false).to_i.should eq(1)
       class Foo(T)
       end
 
@@ -178,6 +178,6 @@ describe "Code gen: alias" do
       end
 
       take(Foo(String).new)
-      ), inject_primitives: false).to_i.should eq(1)
+      CRYSTAL
   end
 end

--- a/spec/compiler/codegen/and_spec.cr
+++ b/spec/compiler/codegen/and_spec.cr
@@ -34,137 +34,137 @@ describe "Code gen: and" do
   end
 
   it "codegens and with primitive type other than bool" do
-    run(%(
+    run(<<-CRYSTAL, Int32).should eq(0)
       struct Nil; def to_i!; 0; end; end
       (nil && 2).to_i!
-      ), Int32).should eq(0)
+      CRYSTAL
   end
 
   it "codegens and with nilable as left node 1" do
-    run("
+    run(<<-CRYSTAL, Int32).should eq(0)
       struct Nil; def to_i!; 0; end; end
       class Object; def to_i!; -1; end; end
       a = Reference.new
       a = nil
       (a && 2).to_i!
-    ", Int32).should eq(0)
+      CRYSTAL
   end
 
   it "codegens and with nilable as left node 2" do
-    run("
+    run(<<-CRYSTAL, Int32).should eq(2)
       class Object; def to_i!; -1; end; end
       a = nil
       a = Reference.new
       (a && 2).to_i!
-    ", Int32).should eq(2)
+      CRYSTAL
   end
 
   it "codegens and with non-false union as left node" do
-    run("
+    run(<<-CRYSTAL, Int32).should eq(2)
       a = 1.5
       a = 1
       (a && 2).to_i!
-    ", Int32).should eq(2)
+      CRYSTAL
   end
 
   it "codegens and with nil union as left node 1" do
-    run("
-      require \"nil\"
+    run(<<-CRYSTAL, Int32).should eq(2)
+      require "nil"
       a = nil
       a = 1
       (a && 2).to_i!
-    ", Int32).should eq(2)
+      CRYSTAL
   end
 
   it "codegens and with nil union as left node 2" do
-    run("
+    run(<<-CRYSTAL, Int32).should eq(0)
       struct Nil; def to_i!; 0; end; end
       a = 1
       a = nil
       (a && 2).to_i!
-    ", Int32).should eq(0)
+      CRYSTAL
   end
 
   it "codegens and with bool union as left node 1" do
-    run("
+    run(<<-CRYSTAL, Int32).should eq(2)
       struct Bool; def to_i!; 0; end; end
       a = false
       a = 1
       (a && 2).to_i!
-    ", Int32).should eq(2)
+      CRYSTAL
   end
 
   it "codegens and with bool union as left node 2" do
-    run("
+    run(<<-CRYSTAL, Int32).should eq(0)
       struct Bool; def to_i!; 0; end; end
       a = 1
       a = false
       (a && 2).to_i!
-    ", Int32).should eq(0)
+      CRYSTAL
   end
 
   it "codegens and with bool union as left node 3" do
-    run("
+    run(<<-CRYSTAL, Int32).should eq(2)
       struct Bool; def to_i!; 0; end; end
       a = 1
       a = true
       (a && 2).to_i!
-    ", Int32).should eq(2)
+      CRYSTAL
   end
 
   it "codegens and with bool union as left node 1" do
-    run("
-      require \"nil\"
+    run(<<-CRYSTAL, Int32).should eq(3)
+      require "nil"
       struct Bool; def to_i!; 1; end; end
       a = false
       a = nil
       a = 2
       (a && 3).to_i!
-    ", Int32).should eq(3)
+      CRYSTAL
   end
 
   it "codegens and with bool union as left node 2" do
-    run("
-      require \"nil\"
+    run(<<-CRYSTAL, Int32).should eq(1)
+      require "nil"
       struct Bool; def to_i!; 1; end; end
       a = nil
       a = 2
       a = false
       (a && 3).to_i!
-    ", Int32).should eq(1)
+      CRYSTAL
   end
 
   it "codegens and with bool union as left node 3" do
-    run("
-      require \"nil\"
+    run(<<-CRYSTAL, Int32).should eq(3)
+      require "nil"
       struct Bool; def to_i!; 1; end; end
       a = nil
       a = 2
       a = true
       (a && 3).to_i!
-    ", Int32).should eq(3)
+      CRYSTAL
   end
 
   it "codegens and with bool union as left node 4" do
-    run("
+    run(<<-CRYSTAL, Int32).should eq(0)
       struct Nil; def to_i!; 0; end; end
       struct Bool; def to_i!; 1; end; end
       a = 2
       a = true
       a = nil
       (a && 3).to_i!
-    ", Int32).should eq(0)
+      CRYSTAL
   end
 
   it "codegens assign in right node, after must be nilable" do
-    run("
+    run(<<-CRYSTAL, Bool).should be_true
       a = 1 == 2 && (b = Reference.new)
       b.nil?
-      ", Bool).should be_true
+      CRYSTAL
   end
 
   it "codegens assign in right node, inside if must not be nil" do
-    run("
+    run(<<-CRYSTAL, Int32).should eq(1)
       struct Nil; end
       class Foo; def foo; 1; end; end
 
@@ -173,14 +173,14 @@ describe "Code gen: and" do
       else
         0
       end
-      ", Int32).should eq(1)
+      CRYSTAL
   end
 
   it "codegens assign in right node, after if must be nilable" do
-    run("
+    run(<<-CRYSTAL, Bool).should be_true
       if 1 == 2 && (b = Reference.new)
       end
       b.nil?
-      ", Bool).should be_true
+      CRYSTAL
   end
 end

--- a/spec/compiler/codegen/array_literal_spec.cr
+++ b/spec/compiler/codegen/array_literal_spec.cr
@@ -178,7 +178,7 @@ describe "Code gen: array literal spec" do
   end
 
   it "creates custom non-generic array, with splats" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(123456)
       #{enumerable_element_type}
 
       class Foo
@@ -211,11 +211,11 @@ describe "Code gen: array literal spec" do
 
       custom = Custom {1, *Foo.new(2), 4, *Foo.new(5)}
       custom.value
-      )).to_i.should eq(123456)
+      CRYSTAL
   end
 
   it "creates custom generic array, with splats" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(123456)
       #{enumerable_element_type}
 
       class Foo
@@ -248,7 +248,7 @@ describe "Code gen: array literal spec" do
 
       custom = Custom {1, *Foo.new(2), 4, *Foo.new(5)}
       custom.value
-      )).to_i.should eq(123456)
+      CRYSTAL
   end
 
   it "creates typed array" do

--- a/spec/compiler/codegen/array_literal_spec.cr
+++ b/spec/compiler/codegen/array_literal_spec.cr
@@ -2,7 +2,7 @@ require "../../spec_helper"
 
 describe "Code gen: array literal spec" do
   it "creates custom non-generic array" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(6)
       class Custom
         def initialize
           @value = 0
@@ -19,11 +19,11 @@ describe "Code gen: array literal spec" do
 
       custom = Custom {1, 2, 3}
       custom.value
-      )).to_i.should eq(6)
+      CRYSTAL
   end
 
   it "creates custom generic array" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(6)
       class Custom(T)
         def initialize
           @value = 0
@@ -40,11 +40,11 @@ describe "Code gen: array literal spec" do
 
       custom = Custom {1, 2, 3}
       custom.value
-      )).to_i.should eq(6)
+      CRYSTAL
   end
 
   it "creates custom generic array with type var" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(6)
       class Custom(T)
         def initialize
           @value = 0
@@ -61,11 +61,11 @@ describe "Code gen: array literal spec" do
 
       custom = Custom(Int32) {1, 2, 3}
       custom.value
-      )).to_i.should eq(6)
+      CRYSTAL
   end
 
   it "creates custom generic array via alias" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(6)
       class Custom(T)
         def initialize
           @value = 0
@@ -84,11 +84,11 @@ describe "Code gen: array literal spec" do
 
       custom = MyCustom {1, 2, 3}
       custom.value
-      )).to_i.should eq(6)
+      CRYSTAL
   end
 
   it "creates custom generic array via alias (2)" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(6)
       class Custom(T)
         def initialize
           @value = 0
@@ -107,11 +107,11 @@ describe "Code gen: array literal spec" do
 
       custom = MyCustom {1, 2, 3}
       custom.value
-      )).to_i.should eq(6)
+      CRYSTAL
   end
 
   it "creates custom non-generic array in nested module" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(6)
       class Foo::Custom
         def initialize
           @value = 0
@@ -128,11 +128,11 @@ describe "Code gen: array literal spec" do
 
       custom = Foo::Custom {1, 2, 3}
       custom.value
-      )).to_i.should eq(6)
+      CRYSTAL
   end
 
   it "creates custom non-generic array in module" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(6)
       module Moo
         class Custom
           def initialize
@@ -151,11 +151,11 @@ describe "Code gen: array literal spec" do
 
       custom = Moo::Custom {1, 2, 3}
       custom.value
-      )).to_i.should eq(6)
+      CRYSTAL
   end
 
   it "creates custom generic array in module (#5684)" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(6)
       module Moo
         class Custom(T)
           def initialize
@@ -174,7 +174,7 @@ describe "Code gen: array literal spec" do
 
       custom = Moo::Custom {1, 2, 3}
       custom.value
-      )).to_i.should eq(6)
+      CRYSTAL
   end
 
   it "creates custom non-generic array, with splats" do

--- a/spec/compiler/codegen/asm_spec.cr
+++ b/spec/compiler/codegen/asm_spec.cr
@@ -12,35 +12,35 @@ describe "Code gen: asm" do
     end
 
     it "codegens without inputs" do
-      run(%(
+      run(<<-CRYSTAL).to_i.should eq(1234)
         dst = uninitialized Int32
         asm("mov $$1234, $0" : "=r"(dst))
         dst
-        )).to_i.should eq(1234)
+        CRYSTAL
     end
 
     it "codegens with two outputs" do
-      run(%(
+      run(<<-CRYSTAL).to_i.should eq(0x12345678)
         dst1 = uninitialized Int32
         dst2 = uninitialized Int32
         asm("
           mov $$0x1234, $0
           mov $$0x5678, $1" : "=r"(dst1), "=r"(dst2))
         (dst1.unsafe_shl(16)) | dst2
-        )).to_i.should eq(0x12345678)
+        CRYSTAL
     end
 
     it "codegens with one input" do
-      run(%(
+      run(<<-CRYSTAL).to_i.should eq(1234)
         src = 1234
         dst = uninitialized Int32
         asm("mov $1, $0" : "=r"(dst) : "r"(src))
         dst
-        )).to_i.should eq(1234)
+        CRYSTAL
     end
 
     it "codegens with two inputs" do
-      run(%(
+      run(<<-CRYSTAL).to_i.should eq(42)
         c = uninitialized Int32
         a = 20
         b = 22
@@ -50,7 +50,7 @@ describe "Code gen: asm" do
              : "0"(a), "r"(b)
           )
         c
-        )).to_i.should eq(42)
+        CRYSTAL
     end
 
     it "codegens with intel dialect" do

--- a/spec/compiler/codegen/automatic_cast_spec.cr
+++ b/spec/compiler/codegen/automatic_cast_spec.cr
@@ -2,67 +2,67 @@ require "../../spec_helper"
 
 describe "Code gen: automatic cast" do
   it "casts literal integer (Int32 -> Int64)" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(12345)
       def foo(x : Int64)
         x
       end
 
       foo(12345)
-      )).to_i.should eq(12345)
+      CRYSTAL
   end
 
   it "casts literal integer (Int64 -> Int32, ok)" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(2147483647)
       def foo(x : Int32)
         x
       end
 
       foo(2147483647_i64)
-      )).to_i.should eq(2147483647)
+      CRYSTAL
   end
 
   it "casts literal integer (Int32 -> Float32)" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(12345)
       def foo(x : Float32)
         x
       end
 
       foo(12345).to_i!
-      )).to_i.should eq(12345)
+      CRYSTAL
   end
 
   it "casts literal integer (Int32 -> Float64)" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(12345)
       def foo(x : Float64)
         x
       end
 
       foo(12345).to_i!
-      )).to_i.should eq(12345)
+      CRYSTAL
   end
 
   it "casts literal float (Float32 -> Float64)" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(12345)
       def foo(x : Float64)
         x
       end
 
       foo(12345.0_f32).to_i!
-      )).to_i.should eq(12345)
+      CRYSTAL
   end
 
   it "casts literal float (Float64 -> Float32)" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(12345)
       def foo(x : Float32)
         x
       end
 
       foo(12345.0).to_i!
-      )).to_i.should eq(12345)
+      CRYSTAL
   end
 
   it "casts symbol literal to enum" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(2)
       :four
 
       enum Foo
@@ -76,11 +76,11 @@ describe "Code gen: automatic cast" do
       end
 
       foo(:three)
-      )).to_i.should eq(2)
+      CRYSTAL
   end
 
   it "casts Int32 to Int64 in ivar assignment" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(10)
       class Foo
         @x : Int64
 
@@ -94,11 +94,11 @@ describe "Code gen: automatic cast" do
       end
 
       Foo.new.x
-      )).to_i.should eq(10)
+      CRYSTAL
   end
 
   it "casts Symbol to Enum in ivar assignment" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(2)
       enum E
         One
         Two
@@ -118,11 +118,11 @@ describe "Code gen: automatic cast" do
       end
 
       Foo.new.x
-      )).to_i.should eq(2)
+      CRYSTAL
   end
 
   it "casts Int32 to Int64 in cvar assignment" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(10)
       class Foo
         @@x : Int64 = 0_i64
 
@@ -133,19 +133,19 @@ describe "Code gen: automatic cast" do
       end
 
       Foo.x
-      )).to_i.should eq(10)
+      CRYSTAL
   end
 
   it "casts Int32 to Int64 in lvar assignment" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(123)
       x : Int64
       x = 123
       x
-      )).to_i.should eq(123)
+      CRYSTAL
   end
 
   it "casts Int32 to Int64 in ivar type declaration" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(10)
       class Foo
         @x : Int64 = 10
 
@@ -155,11 +155,11 @@ describe "Code gen: automatic cast" do
       end
 
       Foo.new.x
-      )).to_i.should eq(10)
+      CRYSTAL
   end
 
   it "casts Symbol to Enum in ivar type declaration" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(2)
       enum Color
         Red
         Green
@@ -175,11 +175,11 @@ describe "Code gen: automatic cast" do
       end
 
       Foo.new.x
-      )).to_i.should eq(2)
+      CRYSTAL
   end
 
   it "casts Int32 to Int64 in cvar type declaration" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(10)
       class Foo
         @@x : Int64 = 10
 
@@ -189,21 +189,21 @@ describe "Code gen: automatic cast" do
       end
 
       Foo.x
-      )).to_i.should eq(10)
+      CRYSTAL
   end
 
   it "casts Int32 -> Int64 in arg restriction" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(123)
       def foo(x : Int64 = 123)
         x
       end
 
       foo
-      )).to_i.should eq(123)
+      CRYSTAL
   end
 
   it "casts Int32 to Int64 in ivar type declaration in generic" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(10)
       class Foo(T)
         @x : T = 10
 
@@ -213,11 +213,11 @@ describe "Code gen: automatic cast" do
       end
 
       Foo(Int64).new.x
-      )).to_i.should eq(10)
+      CRYSTAL
   end
 
   it "does multidispatch with automatic casting (1) (#8217)" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(10)
       def foo(mode : Int64, x : Int32)
         10
       end
@@ -225,11 +225,11 @@ describe "Code gen: automatic cast" do
         20
       end
       foo(1, 1 || "a")
-      )).to_i.should eq(10)
+      CRYSTAL
   end
 
   it "does multidispatch with automatic casting (2) (#8217)" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(20)
       def foo(mode : Int64, x : Int32)
         10
       end
@@ -237,11 +237,11 @@ describe "Code gen: automatic cast" do
         20
       end
       foo(1, "a" || 1)
-      )).to_i.should eq(20)
+      CRYSTAL
   end
 
   it "does multidispatch with automatic casting (3)" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(2)
       abstract class Foo
       end
 
@@ -258,27 +258,27 @@ describe "Code gen: automatic cast" do
       end
 
       Bar.new.as(Foo).foo(1)
-      )).to_i.should eq(2)
+      CRYSTAL
   end
 
   it "doesn't autocast number on union (#8655)" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(255)
       def foo(x : UInt8 | Int32, y : Float64)
         x
       end
 
       foo(255, 60)
-      )).to_i.should eq(255)
+      CRYSTAL
   end
 
   it "casts integer variable to larger type (#9565)" do
-    run(%(
+    run(<<-CRYSTAL).to_i64.should eq(123)
       def foo(x : Int64)
         x
       end
 
       x = 123
       foo(x)
-      )).to_i64.should eq(123)
+      CRYSTAL
   end
 end

--- a/spec/compiler/codegen/block_spec.cr
+++ b/spec/compiler/codegen/block_spec.cr
@@ -2,7 +2,7 @@ require "../../spec_helper"
 
 describe "Code gen: block" do
   it "generate inline" do
-    run("
+    run(<<-CRYSTAL).to_i.should eq(1)
       def foo
         yield
       end
@@ -10,11 +10,11 @@ describe "Code gen: block" do
       foo do
         1
       end
-    ").to_i.should eq(1)
+      CRYSTAL
   end
 
   it "passes yield arguments" do
-    run("
+    run(<<-CRYSTAL).to_i.should eq(2)
       def foo
         yield 1
       end
@@ -22,11 +22,11 @@ describe "Code gen: block" do
       foo do |x|
         x &+ 1
       end
-    ").to_i.should eq(2)
+      CRYSTAL
   end
 
   it "pass arguments to yielder function" do
-    run("
+    run(<<-CRYSTAL).to_i.should eq(4)
       def foo(a)
         yield a
       end
@@ -34,11 +34,11 @@ describe "Code gen: block" do
       foo(3) do |x|
         x &+ 1
       end
-    ").to_i.should eq(4)
+      CRYSTAL
   end
 
   it "pass self to yielder function" do
-    run("
+    run(<<-CRYSTAL).to_i.should eq(4)
       struct Int
         def foo
           yield self
@@ -48,11 +48,11 @@ describe "Code gen: block" do
       3.foo do |x|
         x &+ 1
       end
-    ").to_i.should eq(4)
+      CRYSTAL
   end
 
   it "pass self and arguments to yielder function" do
-    run("
+    run(<<-CRYSTAL).to_i.should eq(5)
       struct Int
         def foo(i)
           yield self, i
@@ -62,11 +62,11 @@ describe "Code gen: block" do
       3.foo(2) do |x, i|
         x &+ i
       end
-    ").to_i.should eq(5)
+      CRYSTAL
   end
 
   it "allows access to local variables" do
-    run("
+    run(<<-CRYSTAL).to_i.should eq(2)
       def foo
         yield
       end
@@ -75,11 +75,11 @@ describe "Code gen: block" do
       foo do
         x &+ 1
       end
-    ").to_i.should eq(2)
+      CRYSTAL
   end
 
   it "can access instance vars from yielder function" do
-    run("
+    run(<<-CRYSTAL).to_i.should eq(2)
       class Foo
         def initialize
           @x = 1
@@ -92,11 +92,11 @@ describe "Code gen: block" do
       Foo.new.foo do |x|
         x &+ 1
       end
-    ").to_i.should eq(2)
+      CRYSTAL
   end
 
   it "can set instance vars from yielder function" do
-    run("
+    run(<<-CRYSTAL).to_i.should eq(2)
       class Foo
         def initialize
           @x = 1
@@ -113,11 +113,11 @@ describe "Code gen: block" do
       a = Foo.new
       a.foo { 2 }
       a.value
-    ").to_i.should eq(2)
+      CRYSTAL
   end
 
   it "can use instance methods from yielder function" do
-    run("
+    run(<<-CRYSTAL).to_i.should eq(2)
       class Foo
         def foo
           yield value
@@ -128,11 +128,11 @@ describe "Code gen: block" do
       end
 
       Foo.new.foo { |x| x &+ 1 }
-    ").to_i.should eq(2)
+      CRYSTAL
   end
 
   it "can call methods from block when yielder is an instance method" do
-    run("
+    run(<<-CRYSTAL).to_i.should eq(1)
       class Foo
         def foo
           yield
@@ -144,11 +144,11 @@ describe "Code gen: block" do
       end
 
       Foo.new.foo { bar }
-    ").to_i.should eq(1)
+      CRYSTAL
   end
 
   it "nested yields" do
-    run("
+    run(<<-CRYSTAL).to_i.should eq(1)
       def bar
         yield
       end
@@ -158,33 +158,33 @@ describe "Code gen: block" do
       end
 
       a = foo { 1 }
-    ").to_i.should eq(1)
+      CRYSTAL
   end
 
   it "assigns yield to argument" do
-    run("
+    run(<<-CRYSTAL).to_i.should eq(1)
       def foo(x)
         yield
         x = 1
       end
 
       foo(1) { 1 }
-      ").to_i.should eq(1)
+      CRYSTAL
   end
 
   it "can use global constant" do
-    run("
+    run(<<-CRYSTAL).to_i.should eq(1)
       FOO = 1
       def foo
         yield
         FOO
       end
       foo { }
-    ").to_i.should eq(1)
+      CRYSTAL
   end
 
   it "return from yielder function" do
-    run("
+    run(<<-CRYSTAL).to_i.should eq(2)
       def foo
         yield
         return 1
@@ -192,11 +192,11 @@ describe "Code gen: block" do
 
       foo { }
       2
-    ").to_i.should eq(2)
+      CRYSTAL
   end
 
   it "return from block" do
-    run("
+    run(<<-CRYSTAL).to_i.should eq(1)
       def foo
         yield
       end
@@ -207,11 +207,11 @@ describe "Code gen: block" do
       end
 
       bar
-    ").to_i.should eq(1)
+      CRYSTAL
   end
 
   it "return from yielder function (2)" do
-    run("
+    run(<<-CRYSTAL).to_i.should eq(1)
       def foo
         yield
         return 1 if true
@@ -223,11 +223,11 @@ describe "Code gen: block" do
       end
 
       bar
-    ").to_i.should eq(1)
+      CRYSTAL
   end
 
   it "union value of yielder function" do
-    run("
+    run(<<-CRYSTAL).to_i.should eq(1)
       def foo
         yield
         a = 1.1
@@ -236,11 +236,11 @@ describe "Code gen: block" do
       end
 
       foo {}.to_i!
-    ").to_i.should eq(1)
+      CRYSTAL
   end
 
   it "allow return from function called from yielder function" do
-    run("
+    run(<<-CRYSTAL).to_i.should eq(1)
       def foo
         return 2
       end
@@ -252,22 +252,22 @@ describe "Code gen: block" do
       end
 
       bar {}
-    ").to_i.should eq(1)
+      CRYSTAL
   end
 
   it "" do
-    run("
+    run(<<-CRYSTAL).to_i.should eq(1)
       def foo
         yield
         true ? return 1 : return 1.1
       end
 
       foo {}.to_i!
-    ").to_i.should eq(1)
+      CRYSTAL
   end
 
   it "return from block that always returns from function that always yields inside if block" do
-    run("
+    run(<<-CRYSTAL).to_i.should eq(1)
       def bar
         yield
         2
@@ -282,11 +282,11 @@ describe "Code gen: block" do
       end
 
       foo
-    ").to_i.should eq(1)
+      CRYSTAL
   end
 
   it "return from block that always returns from function that conditionally yields" do
-    run("
+    run(<<-CRYSTAL).to_i.should eq(1)
       def bar
         if true
           yield
@@ -299,11 +299,11 @@ describe "Code gen: block" do
       end
 
       foo
-    ").to_i.should eq(1)
+      CRYSTAL
   end
 
   it "call block from dispatch" do
-    run("
+    run(<<-CRYSTAL).to_i.should eq(1)
       def bar(y)
         yield y
       end
@@ -315,12 +315,12 @@ describe "Code gen: block" do
       end
 
       foo.to_i!
-    ").to_i.should eq(1)
+      CRYSTAL
   end
 
   it "call block from dispatch and use local vars" do
-    run("
-      require \"prelude\"
+    run(<<-CRYSTAL).to_i.should eq(4)
+      require "prelude"
 
       def bar(y)
         yield y
@@ -338,13 +338,13 @@ describe "Code gen: block" do
       end
 
       foo.to_i
-    ").to_i.should eq(4)
+      CRYSTAL
   end
 
   it "break without value returns nil" do
-    run("
-      require \"nil\"
-      require \"value\"
+    run(<<-CRYSTAL).to_b.should be_true
+      require "nil"
+      require "value"
 
       def foo
         yield
@@ -356,23 +356,23 @@ describe "Code gen: block" do
       end
 
       x.nil?
-    ").to_b.should be_true
+      CRYSTAL
   end
 
   it "break block with yielder inside while" do
-    run("
-      require \"prelude\"
+    run(<<-CRYSTAL).to_i.should eq(6)
+      require "prelude"
       a = 0
       10.times do
         a += 1
         break if a > 5
       end
       a
-    ").to_i.should eq(6)
+      CRYSTAL
   end
 
   it "break from block returns from yielder" do
-    run("
+    run(<<-CRYSTAL).to_i.should eq(1)
       def foo
         yield
         yield
@@ -381,11 +381,11 @@ describe "Code gen: block" do
       a = 0
       foo { a &+= 1; break }
       a
-    ").to_i.should eq(1)
+      CRYSTAL
   end
 
   it "break from block with value" do
-    run("
+    run(<<-CRYSTAL).to_i.should eq(1)
       def foo
         while true
           yield
@@ -396,12 +396,12 @@ describe "Code gen: block" do
       foo do
         break 1
       end
-    ").to_i.should eq(1)
+      CRYSTAL
   end
 
   it "returns from block with value" do
-    run("
-      require \"prelude\"
+    run(<<-CRYSTAL).to_i.should eq(1)
+      require "prelude"
 
       def foo
         while true
@@ -417,11 +417,11 @@ describe "Code gen: block" do
       end
 
       bar.to_i
-    ").to_i.should eq(1)
+      CRYSTAL
   end
 
   it "doesn't codegen after while that always yields and breaks" do
-    run("
+    run(<<-CRYSTAL).to_i.should eq(2)
       def foo
         while true
           yield
@@ -432,30 +432,30 @@ describe "Code gen: block" do
       foo do
         break 2
       end
-    ").to_i.should eq(2)
+      CRYSTAL
   end
 
   it "break from block with value" do
-    run("
-      require \"prelude\"
+    run(<<-CRYSTAL).to_i.should eq(20)
+      require "prelude"
       10.times { break 20 }
-    ").to_i.should eq(20)
+      CRYSTAL
   end
 
   it "doesn't codegen call if arg yields and always breaks" do
-    run("
-      require \"nil\"
+    run(<<-CRYSTAL).to_i.should eq(2)
+      require "nil"
 
       def foo
         1 &+ yield
       end
 
       foo { break 2 }.to_i!
-    ").to_i.should eq(2)
+      CRYSTAL
   end
 
   it "codegens nested return" do
-    run("
+    run(<<-CRYSTAL).to_i.should eq(2)
       def bar
         yield
         a = 1
@@ -470,11 +470,11 @@ describe "Code gen: block" do
       end
 
       z
-    ").to_i.should eq(2)
+      CRYSTAL
   end
 
   it "codegens nested break" do
-    run("
+    run(<<-CRYSTAL).to_i.should eq(2)
       def bar
         yield
         a = 1
@@ -485,11 +485,11 @@ describe "Code gen: block" do
       end
 
       foo { break 2 }
-    ").to_i.should eq(2)
+      CRYSTAL
   end
 
   it "codegens call with block with call with arg that yields" do
-    run("
+    run(<<-CRYSTAL).to_i.should eq(3)
       def bar
         yield
         a = 2
@@ -500,11 +500,11 @@ describe "Code gen: block" do
       end
 
       foo { break 3 }
-    ").to_i.should eq(3)
+      CRYSTAL
   end
 
   it "can break without value from yielder that returns nilable (1)" do
-    run(%(
+    run(<<-CRYSTAL).to_b.should be_true
       def foo
         yield
         ""
@@ -515,11 +515,11 @@ describe "Code gen: block" do
       end
 
       a.nil?
-    )).to_b.should be_true
+      CRYSTAL
   end
 
   it "can break without value from yielder that returns nilable (2)" do
-    run(%(
+    run(<<-CRYSTAL).to_b.should be_true
       def foo
         yield
         ""
@@ -530,11 +530,11 @@ describe "Code gen: block" do
       end
 
       a.nil?
-    )).to_b.should be_true
+      CRYSTAL
   end
 
   it "break with value from yielder that returns a nilable" do
-    run(%(
+    run(<<-CRYSTAL).to_b.should be_false
       def foo
         yield
         ""
@@ -546,11 +546,11 @@ describe "Code gen: block" do
       end
 
       a.nil?
-    )).to_b.should be_false
+      CRYSTAL
   end
 
   it "can use self inside a block called from dispatch" do
-    run("
+    run(<<-CRYSTAL).to_i.should eq(123)
       struct Nil; def to_i!; 0; end; end
 
       class Foo
@@ -580,11 +580,11 @@ describe "Code gen: block" do
 
       123.foo
       Global.x.to_i!
-    ").to_i.should eq(123)
+      CRYSTAL
   end
 
   it "return from block called from dispatch" do
-    run("
+    run(<<-CRYSTAL).to_i.should eq(1)
       class Foo
         def do; yield; end
       end
@@ -599,11 +599,11 @@ describe "Code gen: block" do
       end
 
       foo
-    ").to_i.should eq(1)
+      CRYSTAL
   end
 
   it "breaks from while in function called from block" do
-    run("
+    run(<<-CRYSTAL).to_i.should eq(2)
       def foo
         yield
       end
@@ -618,21 +618,21 @@ describe "Code gen: block" do
       foo do
         bar
       end
-    ").to_i.should eq(2)
+      CRYSTAL
   end
 
   it "allows modifying yielded value (with literal)" do
-    run("
+    run(<<-CRYSTAL).to_i.should eq(2)
       def foo
         yield 1
       end
 
       foo { |x| x = 2; x }
-    ").to_i.should eq(2)
+      CRYSTAL
   end
 
   it "allows modifying yielded value (with variable)" do
-    run("
+    run(<<-CRYSTAL).to_i.should eq(1)
       def foo
         a = 1
         yield a
@@ -640,12 +640,12 @@ describe "Code gen: block" do
       end
 
       foo { |x| x = 2; x }
-    ").to_i.should eq(1)
+      CRYSTAL
   end
 
   it "it yields nil from another call" do
-    run("
-      require \"bool\"
+    run(<<-CRYSTAL)
+      require "bool"
 
       def foo(key, default)
         foo(key) { default }
@@ -659,11 +659,11 @@ describe "Code gen: block" do
       end
 
       foo(1, nil)
-    ")
+      CRYSTAL
   end
 
   it "allows yield from dispatch call" do
-    run("
+    run(<<-CRYSTAL).to_i.should eq(1)
       def foo(x : Value)
         yield 1
       end
@@ -682,11 +682,11 @@ describe "Code gen: block" do
       x = 0
       bar { |i| x = i }
       x
-    ").to_i.should eq(1)
+      CRYSTAL
   end
 
   it "block with nilable type" do
-    run("
+    run(<<-CRYSTAL)
       class Foo
         def foo
           yield 1
@@ -702,11 +702,11 @@ describe "Code gen: block" do
 
       a = Foo.new || Bar.new
       a.foo {}
-    ")
+      CRYSTAL
   end
 
   it "block with nilable type 2" do
-    run("
+    run(<<-CRYSTAL)
       class Foo
         def foo
           yield 1
@@ -723,11 +723,11 @@ describe "Code gen: block" do
 
       a = Foo.new || Bar.new
       a.foo {}
-    ")
+      CRYSTAL
   end
 
   it "codegens block with nilable type with return (1)" do
-    run("
+    run(<<-CRYSTAL).to_b.should be_true
       def foo
         if yield
           return Reference.new
@@ -736,11 +736,11 @@ describe "Code gen: block" do
       end
 
       foo { false }.nil?
-      ").to_b.should be_true
+      CRYSTAL
   end
 
   it "codegens block with nilable type with return (2)" do
-    run("
+    run(<<-CRYSTAL).to_b.should be_false
       def foo
         if yield
           return nil
@@ -749,11 +749,11 @@ describe "Code gen: block" do
       end
 
       foo { false }.nil?
-      ").to_b.should be_false
+      CRYSTAL
   end
 
   it "codegens block with union with return" do
-    run("
+    run(<<-CRYSTAL)
       def foo
         yield
 
@@ -764,11 +764,11 @@ describe "Code gen: block" do
 
       x = foo { }
       1
-      ")
+      CRYSTAL
   end
 
   it "codegens if with call with block (ssa issue)" do
-    run("
+    run(<<-CRYSTAL).to_i.should eq(3)
       def bar
         yield
       end
@@ -784,11 +784,11 @@ describe "Code gen: block" do
       end
 
       foo
-      ").to_i.should eq(3)
+      CRYSTAL
   end
 
   it "codegens block with return and yield and no return" do
-    run("
+    run(<<-CRYSTAL).to_i.should eq(2)
       lib LibC
         fun exit : NoReturn
       end
@@ -805,11 +805,11 @@ describe "Code gen: block" do
       end
 
       foo 1
-      ").to_i.should eq(2)
+      CRYSTAL
   end
 
   it "codegens while/break inside block" do
-    run("
+    run(<<-CRYSTAL).to_i.should eq(1)
       def foo
         yield
       end
@@ -820,21 +820,21 @@ describe "Code gen: block" do
         end
         1
       end
-    ").to_i.should eq(1)
+      CRYSTAL
   end
 
   it "codegens block with union arg (1)" do
-    run("
+    run(<<-CRYSTAL).to_i.should eq(1)
       def foo
         yield 1 || 1.5
       end
 
       foo { |x| x }.to_i!
-      ").to_i.should eq(1)
+      CRYSTAL
   end
 
   it "codegens block with union arg (2)" do
-    run("
+    run(<<-CRYSTAL).to_i.should eq(1)
       struct Number
         def abs
           self
@@ -855,11 +855,11 @@ describe "Code gen: block" do
       a.each do |x|
         x.abs
       end.to_i!
-      ").to_i.should eq(1)
+      CRYSTAL
   end
 
   it "codegens block with virtual type arg" do
-    run("
+    run(<<-CRYSTAL).to_i.should eq(1)
       class Var(T)
         def initialize(x : T)
           @x = x
@@ -886,23 +886,23 @@ describe "Code gen: block" do
       a.each do |x|
         x.bar
       end
-      ").to_i.should eq(1)
+      CRYSTAL
   end
 
   it "codegens call with blocks of different type without args" do
-    run("
+    run(<<-CRYSTAL).to_i.should eq(1)
       def foo
         yield
       end
 
       foo { 1.1 }
       foo { 1 }
-    ").to_i.should eq(1)
+      CRYSTAL
   end
 
   it "codegens dispatch with block and break (1)" do
-    run("
-      require \"prelude\"
+    run(<<-CRYSTAL).to_i.should eq(1)
+      require "prelude"
 
       class Foo(T)
         def initialize(@x : T)
@@ -920,12 +920,12 @@ describe "Code gen: block" do
         n += x
       end
       n.to_i
-      ").to_i.should eq(1)
+      CRYSTAL
   end
 
   it "codegens dispatch with block and break (2)" do
-    run("
-      require \"prelude\"
+    run(<<-CRYSTAL).to_i.should eq(3)
+      require "prelude"
 
       a = [1, 2, 3] || [1.5]
       n = 0
@@ -934,11 +934,11 @@ describe "Code gen: block" do
         n += x
       end
       n.to_i
-      ").to_i.should eq(3)
+      CRYSTAL
   end
 
   it "codegens block call when argument type changes" do
-    run("
+    run(<<-CRYSTAL)
       def foo(x)
         while 1 == 2
           x = 1.5
@@ -948,11 +948,11 @@ describe "Code gen: block" do
 
       foo(1) do
       end
-      ")
+      CRYSTAL
   end
 
   it "returns void when called with block" do
-    run("
+    run(<<-CRYSTAL)
       fun foo : Void
       end
 
@@ -962,11 +962,11 @@ describe "Code gen: block" do
       end
 
       bar {}
-      ")
+      CRYSTAL
   end
 
   it "executes yield expression if no arg is given for block" do
-    run("
+    run(<<-CRYSTAL).to_i.should eq(2)
       def foo
         a = 1
         yield (a = 2)
@@ -974,11 +974,11 @@ describe "Code gen: block" do
       end
 
       foo { }
-      ").to_i.should eq(2)
+      CRYSTAL
   end
 
   it "codegens bug with block and arg and var" do
-    run("
+    run(<<-CRYSTAL).to_i.should eq(65)
       def foo
         yield 1
       end
@@ -989,11 +989,11 @@ describe "Code gen: block" do
         a = 'A'
         a.ord
       end
-      ").to_i.should eq(65)
+      CRYSTAL
   end
 
   it "allows using var as block arg with outer var" do
-    run("
+    run(<<-CRYSTAL).to_i.should eq(1)
       def foo
         yield 'a'
       end
@@ -1001,11 +1001,11 @@ describe "Code gen: block" do
       a = foo do |a|
         1
       end
-      ").to_i.should eq(1)
+      CRYSTAL
   end
 
   it "allows initialize with yield (#224)" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(2)
       class Foo
         @x : Int32
 
@@ -1022,11 +1022,11 @@ describe "Code gen: block" do
         a &+ 1
       end
       foo.x
-      )).to_i.should eq(2)
+      CRYSTAL
   end
 
   it "uses block inside array literal (bug)" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(1)
       require "prelude"
 
       def foo
@@ -1035,11 +1035,11 @@ describe "Code gen: block" do
 
       ary = [foo { |x| x.abs }]
       ary[0]
-      )).to_i.should eq(1)
+      CRYSTAL
   end
 
   it "codegens method invocation on a object of a captured block with a type that was never instantiated" do
-    codegen(%(
+    codegen(<<-CRYSTAL)
       class Bar
         def initialize(@bar : NoReturn)
         end
@@ -1063,11 +1063,11 @@ describe "Code gen: block" do
       foo do |bar|
         bar.baz method(bar).baz
       end
-      ))
+      CRYSTAL
   end
 
   it "codegens method invocation on a object of a captured block with a type that was never instantiated (2)" do
-    codegen(%(
+    codegen(<<-CRYSTAL)
       class Bar
         def initialize(@bar : NoReturn)
         end
@@ -1091,11 +1091,11 @@ describe "Code gen: block" do
       foo do |bar|
         baz method(bar).baz
       end
-      ))
+      CRYSTAL
   end
 
   it "codegens bug with yield not_nil! that is never not nil" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(1)
       lib LibC
         fun exit(Int32) : NoReturn
       end
@@ -1134,11 +1134,11 @@ describe "Code gen: block" do
       end
 
       extra.to_i!
-      )).to_i.should eq(1)
+      CRYSTAL
   end
 
   it "uses block var with same name as local var" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(1)
       def foo
         yield "hello"
       end
@@ -1148,11 +1148,11 @@ describe "Code gen: block" do
         a
       end
       a
-      )).to_i.should eq(1)
+      CRYSTAL
   end
 
   it "doesn't crash on untyped array to_s" do
-    run(%(
+    run(<<-CRYSTAL).to_string.should eq("[]")
       require "prelude"
 
       class Bar(T)
@@ -1167,11 +1167,11 @@ describe "Code gen: block" do
       end
 
       Foo(Int32).new.foo { |k| k + 1 }.to_s
-      )).to_string.should eq("[]")
+      CRYSTAL
   end
 
   it "codegens block which always breaks but never enters (#494)" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(3)
       def foo
         while 1 == 2
           yield
@@ -1182,11 +1182,11 @@ describe "Code gen: block" do
       foo do
         break 10
       end
-      )).to_i.should eq(3)
+      CRYSTAL
   end
 
   it "codegens block bug with conditional next and unconditional break (1)" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(6)
       def foo
         yield 1
         yield 2
@@ -1200,11 +1200,11 @@ describe "Code gen: block" do
         break
       end
       a
-      )).to_i.should eq(6)
+      CRYSTAL
   end
 
   it "codegens block bug with conditional next and unconditional break (2)" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(6)
       def foo
         yield 1
         yield 2
@@ -1218,11 +1218,11 @@ describe "Code gen: block" do
         break
       end
       a
-      )).to_i.should eq(6)
+      CRYSTAL
   end
 
   it "codegens block bug with conditional next and unconditional break (3)" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(1)
       class Global
         @@x = 0
 
@@ -1246,11 +1246,11 @@ describe "Code gen: block" do
         break 0
       end
       Global.x
-      )).to_i.should eq(1)
+      CRYSTAL
   end
 
   it "codegens block bug with conditional next and unconditional break (4)" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(1)
       class Global
         @@x = 0
 
@@ -1275,11 +1275,11 @@ describe "Code gen: block" do
         break 0
       end
       Global.x
-      )).to_i.should eq(1)
+      CRYSTAL
   end
 
   it "returns from proc literal" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(10)
       foo = ->{
         if 1 == 1
           return 10
@@ -1289,11 +1289,11 @@ describe "Code gen: block" do
       }
 
       foo.call
-      )).to_i.should eq(10)
+      CRYSTAL
   end
 
   it "does next from captured block" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(10)
       def foo(&block : -> T) forall T
         block
       end
@@ -1307,11 +1307,11 @@ describe "Code gen: block" do
       end
 
       f.call
-      )).to_i.should eq(10)
+      CRYSTAL
   end
 
   it "codegens captured block with next inside yielded block (#2097)" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(123)
       def foo
         yield
       end
@@ -1326,11 +1326,11 @@ describe "Code gen: block" do
         end
         block.call
       end
-      )).to_i.should eq(123)
+      CRYSTAL
   end
 
   it "codegens captured block that returns union, but proc only returns a single type" do
-    run(%(
+    run(<<-CRYSTAL).to_string.should eq("foo")
       def run_callbacks(&block : -> Int32 | String)
         block.call
       end
@@ -1341,11 +1341,11 @@ describe "Code gen: block" do
       else
         "oops"
       end
-      )).to_string.should eq("foo")
+      CRYSTAL
   end
 
   it "yields inside yield (#682)" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(4)
       def foo
         yield(1, (yield 3))
       end
@@ -1355,11 +1355,11 @@ describe "Code gen: block" do
         a &+= x
       end
       a
-      )).to_i.should eq(4)
+      CRYSTAL
   end
 
   it "yields splat" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(6)
       def foo
         tup = {1, 2, 3}
         yield *tup
@@ -1368,11 +1368,11 @@ describe "Code gen: block" do
       foo do |x, y, z|
         x &+ y &+ z
       end
-      )).to_i.should eq(6)
+      CRYSTAL
   end
 
   it "yields more exps than block arg, through splat" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(1)
       def foo
         yield *{1, 2}
       end
@@ -1380,11 +1380,11 @@ describe "Code gen: block" do
       foo do |x|
         x
       end
-      )).to_i.should eq(1)
+      CRYSTAL
   end
 
   it "uses splat in block argument" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(6)
       def foo
         yield 1, 2, 3
       end
@@ -1392,11 +1392,11 @@ describe "Code gen: block" do
       foo do |*args|
         args[0] &+ args[1] &+ args[2]
       end
-      )).to_i.should eq(6)
+      CRYSTAL
   end
 
   it "uses splat in block argument, many args" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(((((1 + 2) * 3) - 4) * 5) - 6)
       def foo
         yield 1, 2, 3, 4, 5, 6
       end
@@ -1404,11 +1404,11 @@ describe "Code gen: block" do
       foo do |x, y, *z, w|
         ((((x &+ y) &* z[0]) &- z[1]) &* z[2]) &- w
       end
-      )).to_i.should eq(((((1 + 2) * 3) - 4) * 5) - 6)
+      CRYSTAL
   end
 
   it "uses block splat argument with union types" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(3)
       def foo
         yield 1
         yield 2.5
@@ -1419,7 +1419,7 @@ describe "Code gen: block" do
         total &+= args[0].to_i!
       end
       total
-      )).to_i.should eq(3)
+      CRYSTAL
   end
 
   it "works if block has both splat and non-splat underscore parameters" do
@@ -1447,7 +1447,7 @@ describe "Code gen: block" do
   end
 
   it "auto-unpacks tuple" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq((1 + 2) * 4)
       def foo
         tup = {1, 2, 4}
         yield tup
@@ -1456,11 +1456,11 @@ describe "Code gen: block" do
       foo do |x, y, z|
         (x &+ y) &* z
       end
-      )).to_i.should eq((1 + 2) * 4)
+      CRYSTAL
   end
 
   it "unpacks tuple but doesn't override local variables" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(10)
       def foo
         yield({10, 20}, {30, 40})
       end
@@ -1472,11 +1472,11 @@ describe "Code gen: block" do
       foo do |(x, y), (z, w)|
       end
       x &+ y &+ z &+ w
-      )).to_i.should eq(10)
+      CRYSTAL
   end
 
   it "codegens block with multiple underscores (#3054)" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(3)
       def foo(&block : Int32, Int32 -> Int32)
         block.call(1, 2)
       end
@@ -1484,11 +1484,11 @@ describe "Code gen: block" do
       foo do |_, _|
         3
       end
-      )).to_i.should eq(3)
+      CRYSTAL
   end
 
   it "breaks in var assignment (#3364)" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(123)
       def foo
         yield
         456
@@ -1497,11 +1497,11 @@ describe "Code gen: block" do
       foo do
         a = nil || break 123
       end
-      )).to_i.should eq(123)
+      CRYSTAL
   end
 
   it "nexts in var assignment (#3364)" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(123)
       def foo
         yield
       end
@@ -1509,11 +1509,11 @@ describe "Code gen: block" do
       foo do
         a = nil || next 123
       end
-      )).to_i.should eq(123)
+      CRYSTAL
   end
 
   it "dispatches with captured and non-captured block (#3969)" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(3)
       def fn(x : Int32, &block)
         x
       end
@@ -1525,20 +1525,20 @@ describe "Code gen: block" do
       a = fn(1 || 'a') { 2 }
       b = fn('a' || 1) { 2 }
       a &+ b
-      )).to_i.should eq(3)
+      CRYSTAL
   end
 
   it "codegens block with repeated underscore and different types (#4711)" do
-    codegen(%(
+    codegen(<<-CRYSTAL)
       def foo
         yield('0', 0)
       end
       foo{|_, _| }
-      ))
+      CRYSTAL
   end
 
   it "doesn't crash on yield exp without a type (#8100)" do
-    codegen(%(
+    codegen(<<-CRYSTAL)
       def foo
         x = 1
         if x.is_a?(Char)
@@ -1549,11 +1549,11 @@ describe "Code gen: block" do
       end
 
       foo { |x| }
-    ))
+      CRYSTAL
   end
 
   it "clears nilable var before inlining block method (#10087)" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(1)
       class Foo
         @@x = 0
 
@@ -1583,11 +1583,11 @@ describe "Code gen: block" do
       Foo.bar do |z|
         Foo.foo(z) { }
       end
-    )).to_i.should eq(1)
+      CRYSTAL
   end
 
   it "(bug) doesn't set needs_value to true on every yield (#12442)" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(1)
       def foo
         if true
           yield
@@ -1599,11 +1599,11 @@ describe "Code gen: block" do
       foo do
         1
       end
-      )).to_i.should eq(1)
+      CRYSTAL
   end
 
   it "doesn't crash if yield exp has no type (#12670)" do
-    codegen(%(
+    codegen(<<-CRYSTAL)
       def foo : String?
       end
 
@@ -1616,6 +1616,6 @@ describe "Code gen: block" do
       bar do |res|
         res
       end
-      ))
+      CRYSTAL
   end
 end

--- a/spec/compiler/codegen/c_abi/c_abi_x86_64_spec.cr
+++ b/spec/compiler/codegen/c_abi/c_abi_x86_64_spec.cr
@@ -3,7 +3,7 @@ require "../../../spec_helper"
 
 describe "Code gen: C ABI x86_64" do
   it "passes struct less than 64 bits as { i64 }" do
-    mod = codegen(%(
+    mod = codegen(<<-CRYSTAL)
       lib LibFoo
         struct Struct
           x : Int8
@@ -15,14 +15,14 @@ describe "Code gen: C ABI x86_64" do
 
       s = LibFoo::Struct.new
       LibFoo.foo(s)
-      ))
+      CRYSTAL
     str = mod.to_s
     str.should contain("call void @foo({ i64 }")
     str.should contain("declare void @foo({ i64 })")
   end
 
   it "passes struct less than 64 bits as { i64 } in varargs" do
-    mod = codegen(%(
+    mod = codegen(<<-CRYSTAL)
       lib LibFoo
         struct Struct
           x : Int8
@@ -34,13 +34,13 @@ describe "Code gen: C ABI x86_64" do
 
       s = LibFoo::Struct.new
       LibFoo.foo(s)
-      ))
+      CRYSTAL
     str = mod.to_s
     str.should contain("call void (...)")
   end
 
   it "passes struct between 64 and 128 bits as { i64, i64 }" do
-    mod = codegen(%(
+    mod = codegen(<<-CRYSTAL)
       lib LibFoo
         struct Struct
           x : Int64
@@ -52,14 +52,14 @@ describe "Code gen: C ABI x86_64" do
 
       s = LibFoo::Struct.new
       LibFoo.foo(s)
-      ))
+      CRYSTAL
     str = mod.to_s
     str.should contain("call void @foo({ i64, i64 }")
     str.should contain("declare void @foo({ i64, i64 })")
   end
 
   it "passes struct between 64 and 128 bits as { i64, i64 } (with multiple modules/contexts)" do
-    codegen(%(
+    codegen(<<-CRYSTAL)
       require "prelude"
 
       lib LibFoo
@@ -79,11 +79,11 @@ describe "Code gen: C ABI x86_64" do
       end
 
       Moo.moo
-      ))
+      CRYSTAL
   end
 
   it "passes struct bigger than128 bits with byval" do
-    mod = codegen(%(
+    mod = codegen(<<-CRYSTAL)
       lib LibFoo
         struct Struct
           x : Int64
@@ -96,13 +96,13 @@ describe "Code gen: C ABI x86_64" do
 
       s = LibFoo::Struct.new
       LibFoo.foo(s)
-      ))
+      CRYSTAL
     str = mod.to_s
     str.scan(/byval/).size.should eq(2)
   end
 
   it "returns struct less than 64 bits as { i64 }" do
-    mod = codegen(%(
+    mod = codegen(<<-CRYSTAL)
       lib LibFoo
         struct Struct
           x : Int8
@@ -113,14 +113,14 @@ describe "Code gen: C ABI x86_64" do
       end
 
       str = LibFoo.foo
-      ))
+      CRYSTAL
     str = mod.to_s
     str.should contain("call { i64 } @foo()")
     str.should contain("declare { i64 } @foo()")
   end
 
   it "returns struct between 64 and 128 bits as { i64, i64 }" do
-    mod = codegen(%(
+    mod = codegen(<<-CRYSTAL)
       lib LibFoo
         struct Struct
           x : Int64
@@ -131,14 +131,14 @@ describe "Code gen: C ABI x86_64" do
       end
 
       str = LibFoo.foo
-      ))
+      CRYSTAL
     str = mod.to_s
     str.should contain("call { i64, i64 } @foo()")
     str.should contain("declare { i64, i64 } @foo()")
   end
 
   it "returns struct bigger than 128 bits with sret" do
-    mod = codegen(%(
+    mod = codegen(<<-CRYSTAL)
       lib LibFoo
         struct Struct
           x : Int64
@@ -150,7 +150,7 @@ describe "Code gen: C ABI x86_64" do
       end
 
       str = LibFoo.foo(1)
-      ))
+      CRYSTAL
     str = mod.to_s
     str.scan(/sret/).size.should eq(2)
 

--- a/spec/compiler/codegen/c_enum_spec.cr
+++ b/spec/compiler/codegen/c_enum_spec.cr
@@ -53,7 +53,7 @@ describe "Code gen: c enum" do
   end
 
   it "codegens enum that refers to another enum constant" do
-    run("
+    run(<<-CRYSTAL).to_i.should eq(3)
       lib LibFoo
         enum Bar
           A = 1
@@ -63,11 +63,11 @@ describe "Code gen: c enum" do
       end
 
       LibFoo::Bar::C
-      ").to_i.should eq(3)
+      CRYSTAL
   end
 
   it "codegens enum that refers to another constant" do
-    run("
+    run(<<-CRYSTAL).to_i.should eq(12)
       lib LibFoo
         X = 10
         enum Bar
@@ -78,6 +78,6 @@ describe "Code gen: c enum" do
       end
 
       LibFoo::Bar::C
-      ").to_i.should eq(12)
+      CRYSTAL
   end
 end

--- a/spec/compiler/codegen/c_enum_spec.cr
+++ b/spec/compiler/codegen/c_enum_spec.cr
@@ -40,7 +40,7 @@ describe "Code gen: c enum" do
     {"10 % 3", 1},
   ].each do |(code, expected)|
     it "codegens enum with #{code} " do
-      run("
+      run(<<-CRYSTAL).to_i.should eq(expected)
         lib LibFoo
           enum Bar
             X = #{code}
@@ -48,7 +48,7 @@ describe "Code gen: c enum" do
         end
 
         LibFoo::Bar::X
-        ").to_i.should eq(expected)
+        CRYSTAL
     end
   end
 

--- a/spec/compiler/codegen/c_struct_spec.cr
+++ b/spec/compiler/codegen/c_struct_spec.cr
@@ -24,7 +24,7 @@ describe "Code gen: struct" do
   end
 
   it "codegens union inside struct" do
-    run("
+    run(<<-CRYSTAL).to_i.should eq(10)
       lib LibFoo
         union Bar
           x : Int32
@@ -39,11 +39,11 @@ describe "Code gen: struct" do
       a = Pointer(LibFoo::Baz).malloc(1_u64)
       a.value.lala.x = 10
       a.value.lala.x
-      ").to_i.should eq(10)
+      CRYSTAL
   end
 
   it "codegens struct get inside struct" do
-    run("
+    run(<<-CRYSTAL).to_i.should eq(2)
       lib LibC
         struct Bar
           y : Int32
@@ -59,11 +59,11 @@ describe "Code gen: struct" do
       (foo.as(Int32*) + 1_i64).value = 2
 
       foo.value.bar.y
-      ").to_i.should eq(2)
+      CRYSTAL
   end
 
   it "codegens struct set inside struct" do
-    run("
+    run(<<-CRYSTAL).to_i.should eq(2)
       lib LibC
         struct Bar
           y : Int32
@@ -81,11 +81,11 @@ describe "Code gen: struct" do
       foo.value.bar = bar
 
       foo.value.bar.y
-      ").to_i.should eq(2)
+      CRYSTAL
   end
 
   it "codegens pointer malloc of struct" do
-    run("
+    run(<<-CRYSTAL).to_i.should eq(1)
       lib LibC
         struct Foo
           x : Int32
@@ -95,11 +95,11 @@ describe "Code gen: struct" do
       p = Pointer(LibC::Foo).malloc(1_u64)
       p.value.x = 1
       p.value.x
-      ").to_i.should eq(1)
+      CRYSTAL
   end
 
   it "passes struct to method (1)" do
-    run("
+    run(<<-CRYSTAL).to_i.should eq(1)
       lib LibC
         struct Foo
           x : Int32
@@ -117,11 +117,11 @@ describe "Code gen: struct" do
       f2 = foo(f1)
 
       f1.x
-      ").to_i.should eq(1)
+      CRYSTAL
   end
 
   it "passes struct to method (2)" do
-    run("
+    run(<<-CRYSTAL).to_i.should eq(2)
       lib LibC
         struct Foo
           x : Int32
@@ -138,11 +138,11 @@ describe "Code gen: struct" do
 
       f2 = foo(f1)
       f2.x
-      ").to_i.should eq(2)
+      CRYSTAL
   end
 
   it "codegens struct access with -> and then ." do
-    run("
+    run(<<-CRYSTAL).to_i.should eq(0)
       lib LibC
         struct ScalarEvent
           x : Int32
@@ -159,11 +159,11 @@ describe "Code gen: struct" do
 
       e = Pointer(LibC::Event).malloc(1_u64)
       e.value.data.scalar.x
-      ").to_i.should eq(0)
+      CRYSTAL
   end
 
   it "yields struct via ->" do
-    run("
+    run(<<-CRYSTAL).to_i.should eq(0)
       lib LibC
         struct ScalarEvent
           x : Int32
@@ -186,11 +186,11 @@ describe "Code gen: struct" do
       foo do |data|
         data.scalar.x
       end
-      ").to_i.should eq(0)
+      CRYSTAL
   end
 
   it "codegens assign struct to union" do
-    run("
+    run(<<-CRYSTAL).to_b.should be_true
       lib LibFoo
         struct Coco
           x : Int32
@@ -200,11 +200,11 @@ describe "Code gen: struct" do
       x = LibFoo::Coco.new
       c = x || 0
       c.is_a?(LibFoo::Coco)
-    ").to_b.should be_true
+      CRYSTAL
   end
 
   it "codegens passing pointerof(struct) to fun" do
-    run("
+    run(<<-CRYSTAL).to_i.should eq(1)
       lib LibC
         struct Foo
           a : Int32
@@ -219,11 +219,11 @@ describe "Code gen: struct" do
       f.a = 1
 
       foo pointerof(f)
-      ").to_i.should eq(1)
+      CRYSTAL
   end
 
   it "builds struct setter with fun type (1)" do
-    codegen(%(
+    codegen(<<-CRYSTAL)
       require "prelude"
 
       lib LibC
@@ -234,11 +234,11 @@ describe "Code gen: struct" do
 
       foo = LibC::Foo.new
       foo.x = -> { }
-      ))
+      CRYSTAL
   end
 
   it "builds struct setter with fun type (2)" do
-    codegen(%(
+    codegen(<<-CRYSTAL)
       require "prelude"
 
       lib LibC
@@ -249,11 +249,11 @@ describe "Code gen: struct" do
 
       foo = Pointer(LibC::Foo).malloc(1)
       foo.value.x = -> { }
-      ))
+      CRYSTAL
   end
 
   it "allows using named arguments for new" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(3)
       lib LibC
         struct Point
           x, y : Int32
@@ -262,11 +262,11 @@ describe "Code gen: struct" do
 
       point = LibC::Point.new x: 1, y: 2
       point.x &+ point.y
-      )).to_i.should eq(3)
+      CRYSTAL
   end
 
   it "does to_s" do
-    run(%(
+    run(<<-CRYSTAL).to_string.should eq("LibFoo::Point(@x=1, @y=2)")
       require "prelude"
 
       lib LibFoo
@@ -277,11 +277,11 @@ describe "Code gen: struct" do
 
       point = LibFoo::Point.new x: 1, y: 2
       point.to_s
-      )).to_string.should eq("LibFoo::Point(@x=1, @y=2)")
+      CRYSTAL
   end
 
   it "can access instance var from the outside (#1092)" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(123)
       lib LibFoo
         struct Foo
           x : Int32
@@ -290,11 +290,11 @@ describe "Code gen: struct" do
 
       f = LibFoo::Foo.new x: 123
       f.@x
-      )).to_i.should eq(123)
+      CRYSTAL
   end
 
   it "automatically converts numeric type in struct field assignment" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(123)
       lib LibFoo
         struct Foo
           x : Int32
@@ -304,11 +304,11 @@ describe "Code gen: struct" do
       foo = LibFoo::Foo.new
       foo.x = 123_u8
       foo.x
-      )).to_i.should eq(123)
+      CRYSTAL
   end
 
   it "automatically converts numeric union type in struct field assignment" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(57)
       lib LibFoo
         struct Foo
           x : Int8
@@ -320,11 +320,11 @@ describe "Code gen: struct" do
       foo = LibFoo::Foo.new
       foo.x = a
       foo.x
-      )).to_i.should eq(57)
+      CRYSTAL
   end
 
   it "automatically converts nil to pointer" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(0)
       lib LibFoo
         struct Foo
           x : Int32*
@@ -335,11 +335,11 @@ describe "Code gen: struct" do
       foo.x = Pointer(Int32).new(1234_u64)
       foo.x = nil
       foo.x.address
-      )).to_i.should eq(0)
+      CRYSTAL
   end
 
   it "automatically converts by invoking to_unsafe" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(123)
       lib LibFoo
         struct Foo
           x : Int32
@@ -355,11 +355,11 @@ describe "Code gen: struct" do
       foo = LibFoo::Foo.new
       foo.x = Foo.new
       foo.x
-      )).to_i.should eq(123)
+      CRYSTAL
   end
 
   it "sets instance var to proc" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(2)
       require "prelude"
 
       lib LibFoo
@@ -377,11 +377,11 @@ describe "Code gen: struct" do
       foo = LibFoo::Foo.new
       foo.set(->(x : Int32) { x + 1 })
       foo.x.call(1)
-      )).to_i.should eq(2)
+      CRYSTAL
   end
 
   it "can access member of uninitialized struct behind type (#8774)" do
-    run(%(
+    run(<<-CRYSTAL)
       lib LibFoo
         struct Foo
           x : Int32
@@ -392,6 +392,6 @@ describe "Code gen: struct" do
 
       foo = uninitialized LibFoo::FooT
       foo.x
-    ))
+      CRYSTAL
   end
 end

--- a/spec/compiler/codegen/c_union_spec.cr
+++ b/spec/compiler/codegen/c_union_spec.cr
@@ -28,7 +28,7 @@ describe "Code gen: c union" do
   end
 
   it "codegens struct inside union" do
-    run("
+    run(<<-CRYSTAL).to_i.should eq(10)
       lib LibFoo
         struct Baz
           lele : Int64
@@ -46,11 +46,11 @@ describe "Code gen: c union" do
       a.value.z = LibFoo::Baz.new
       a.value.z.lala = 10
       a.value.z.lala
-      ").to_i.should eq(10)
+      CRYSTAL
   end
 
   it "codegens assign c union to union" do
-    run("
+    run(<<-CRYSTAL).to_i.should eq(10)
       lib LibFoo
         union Bar
           x : Int32
@@ -65,11 +65,11 @@ describe "Code gen: c union" do
       else
         1
       end
-      ").to_i.should eq(10)
+      CRYSTAL
   end
 
   it "builds union setter with fun type" do
-    codegen(%(
+    codegen(<<-CRYSTAL)
       require "prelude"
 
       lib LibC
@@ -80,11 +80,11 @@ describe "Code gen: c union" do
 
       foo = LibC::Foo.new
       foo.x = -> { }
-      ))
+      CRYSTAL
   end
 
   it "does to_s" do
-    run(%(
+    run(<<-CRYSTAL).to_string.should eq("LibNVG::Color(@array=0)")
       require "prelude"
 
       lib LibNVG
@@ -95,11 +95,11 @@ describe "Code gen: c union" do
 
       color = LibNVG::Color.new
       color.to_s
-      )).to_string.should eq("LibNVG::Color(@array=0)")
+      CRYSTAL
   end
 
   it "automatically converts numeric type in field assignment" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(57)
       lib LibFoo
         union Foo
           x : Int8
@@ -111,11 +111,11 @@ describe "Code gen: c union" do
       foo = LibFoo::Foo.new
       foo.x = a
       foo.x
-      )).to_i.should eq(57)
+      CRYSTAL
   end
 
   it "automatically converts numeric union type in field assignment" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(57)
       lib LibFoo
         union Foo
           x : Int8
@@ -127,11 +127,11 @@ describe "Code gen: c union" do
       foo = LibFoo::Foo.new
       foo.x = a
       foo.x
-      )).to_i.should eq(57)
+      CRYSTAL
   end
 
   it "automatically converts by invoking to_unsafe" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(123)
       lib LibFoo
         union Foo
           x : Int32
@@ -147,11 +147,11 @@ describe "Code gen: c union" do
       foo = LibFoo::Foo.new
       foo.x = Foo.new
       foo.x
-      )).to_i.should eq(123)
+      CRYSTAL
   end
 
   it "aligns to the member with biggest align requirements" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(0x5858)
       lib LibFoo
         union Foo
           bytes : UInt8[4]
@@ -173,11 +173,11 @@ describe "Code gen: c union" do
       str = "00XX0"
       foo = str.to_unsafe.as(LibFoo::Bar*)
       foo.value.b.short.to_i
-      )).to_i.should eq(0x5858)
+      CRYSTAL
   end
 
   it "fills union type to the max size" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(6)
       lib LibFoo
         union Foo
           bytes : UInt8[4]
@@ -191,11 +191,11 @@ describe "Code gen: c union" do
       end
 
       sizeof(LibFoo::Bar)
-      )).to_i.should eq(6)
+      CRYSTAL
   end
 
   it "reads union instance var" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(42)
       lib LibFoo
         union Foo
           char : Char
@@ -212,11 +212,11 @@ describe "Code gen: c union" do
       foo = LibFoo::Foo.new
       foo.int = 42
       foo.read_int
-      )).to_i.should eq(42)
+      CRYSTAL
   end
 
   it "moves unions around correctly (#12550)" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq((1..6).sum)
       require "prelude"
 
       lib Lib
@@ -238,6 +238,6 @@ describe "Code gen: c union" do
       end
 
       foo.padding.sum
-      )).to_i.should eq((1..6).sum)
+      CRYSTAL
   end
 end

--- a/spec/compiler/codegen/case_spec.cr
+++ b/spec/compiler/codegen/case_spec.cr
@@ -18,8 +18,8 @@ describe "Code gen: case" do
   end
 
   it "codegens case that always returns" do
-    run("
-      require \"prelude\"
+    run(<<-CRYSTAL).to_i.should eq(3)
+      require "prelude"
       def foo
         if true
           case 0
@@ -31,12 +31,12 @@ describe "Code gen: case" do
       end
 
       foo
-    ").to_i.should eq(3)
+      CRYSTAL
   end
 
   it "codegens case when cond is a call" do
-    run("
-      require \"prelude\"
+    run(<<-CRYSTAL).to_i.should eq(2)
+      require "prelude"
 
       def foo
         1
@@ -50,11 +50,11 @@ describe "Code gen: case" do
       else
         3
       end
-    ").to_i.should eq(2)
+      CRYSTAL
   end
 
   it "codegens case with class" do
-    run("
+    run(<<-CRYSTAL).to_i.should eq(-1)
       struct Nil; def to_i!; 0; end; end
 
       struct Int32
@@ -70,11 +70,11 @@ describe "Code gen: case" do
       when Char
         a.ord
       end.to_i!
-      ").to_i.should eq(-1)
+      CRYSTAL
   end
 
   it "codegens value-less case" do
-    run("
+    run(<<-CRYSTAL).to_i.should eq(2)
       case
       when 1 == 2
         1
@@ -83,11 +83,11 @@ describe "Code gen: case" do
       else
         3
       end
-      ").to_i.should eq(2)
+      CRYSTAL
   end
 
   it "codegens case when constant bug (#1028)" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(2)
       struct Nil
         def ===(other)
           self.is_a?(Reference) && other.is_a?(Reference)
@@ -101,11 +101,11 @@ describe "Code gen: case" do
       else
         2
       end
-      )).to_i.should eq(2)
+      CRYSTAL
   end
 
   it "does case when with metaclass" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(2)
       class Foo
         def self.foo
           1
@@ -127,6 +127,6 @@ describe "Code gen: case" do
       else
         3
       end
-      )).to_i.should eq(2)
+      CRYSTAL
   end
 end

--- a/spec/compiler/codegen/cast_spec.cr
+++ b/spec/compiler/codegen/cast_spec.cr
@@ -2,7 +2,7 @@ require "../../spec_helper"
 
 describe "Code gen: cast" do
   it "allows casting object to pointer and back" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(1)
       class Foo
         def initialize(@x : Int32)
         end
@@ -16,31 +16,31 @@ describe "Code gen: cast" do
       p = f.as(Void*)
       f = p.as(Foo)
       f.x
-      )).to_i.should eq(1)
+      CRYSTAL
   end
 
   it "casts from int to int" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(1)
       require "prelude"
 
       a = 1
       b = a.as(Int32)
       b.abs
-      )).to_i.should eq(1)
+      CRYSTAL
   end
 
   it "casts from union to single type" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(1)
       require "prelude"
 
       a = 1 || 'a'
       b = a.as(Int32)
       b.abs
-      )).to_i.should eq(1)
+      CRYSTAL
   end
 
   it "casts from union to single type raises TypeCastError" do
-    run(%(
+    run(<<-CRYSTAL).to_b.should be_true
       require "prelude"
 
       a = 1 || 'a'
@@ -50,21 +50,21 @@ describe "Code gen: cast" do
       rescue ex
         ex.message.not_nil!.includes?("Cast from Int32 to Char failed") && (ex.class == TypeCastError)
       end
-      )).to_b.should be_true
+      CRYSTAL
   end
 
   it "casts from union to another union" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(1)
       require "prelude"
 
       a = 1 || 1.5 || 'a'
       b = a.as(Int32 | Float64)
       b.abs.to_i
-      )).to_i.should eq(1)
+      CRYSTAL
   end
 
   it "casts from union to another union raises TypeCastError" do
-    run(%(
+    run(<<-CRYSTAL).to_b.should be_true
       require "prelude"
 
       a = 1 || 1.5 || 'a'
@@ -74,7 +74,7 @@ describe "Code gen: cast" do
       rescue ex
         ex.message.not_nil!.includes?("Cast from Int32 to (Char | Float64) failed") && (ex.class == TypeCastError)
       end
-      )).to_b.should be_true
+      CRYSTAL
   end
 
   it "upcasts from union to union with different alignment" do
@@ -140,7 +140,7 @@ describe "Code gen: cast" do
   end
 
   it "casts from virtual to single type" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(1)
       require "prelude"
 
       class CastSpecFoo
@@ -158,11 +158,11 @@ describe "Code gen: cast" do
       a = CastSpecBar.new || CastSpecFoo.new || CastSpecBaz.new
       b = a.as(CastSpecBar)
       b.bar
-      )).to_i.should eq(1)
+      CRYSTAL
   end
 
   it "casts from virtual to single type raises TypeCastError" do
-    run(%(
+    run(<<-CRYSTAL).to_b.should be_true
       require "prelude"
 
       class CastSpecFoo
@@ -184,20 +184,20 @@ describe "Code gen: cast" do
       rescue ex
         ex.message.not_nil!.includes?("Cast from CastSpecBar to CastSpecBaz failed") && (ex.class == TypeCastError)
       end
-      )).to_b.should be_true
+      CRYSTAL
   end
 
   it "casts from pointer to pointer" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(1)
       require "prelude"
 
       a = 1_i64
       pointerof(a).as(Int32*).value
-      )).to_i.should eq(1)
+      CRYSTAL
   end
 
   it "casts to module" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(2)
       require "prelude"
 
       module CastSpecMoo
@@ -227,21 +227,21 @@ describe "Code gen: cast" do
       a = CastSpecBar.new || CastSpecFoo.new || CastSpecBaz.new || CastSpecBan.new
       m = a.as(CastSpecMoo)
       m.moo
-      )).to_i.should eq(2)
+      CRYSTAL
   end
 
   it "casts from nilable to nil" do
-    run(%(
+    run(<<-CRYSTAL).to_b.should be_true
       require "prelude"
 
       a = 1 == 2 ? Reference.new : nil
       c = a.as(Nil)
       c == nil
-      )).to_b.should be_true
+      CRYSTAL
   end
 
   it "casts from nilable to nil raises TypeCastError" do
-    run(%(
+    run(<<-CRYSTAL).to_b.should be_true
       require "prelude"
 
       a = 1 == 1 ? Reference.new : nil
@@ -251,11 +251,11 @@ describe "Code gen: cast" do
       rescue ex
         ex.message.not_nil!.includes?("Cast from Reference to Nil failed") && (ex.class == TypeCastError)
       end
-      )).to_b.should be_true
+      CRYSTAL
   end
 
   it "casts to base class making it virtual" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(1)
       class Foo
         def foo
           1
@@ -271,55 +271,55 @@ describe "Code gen: cast" do
       bar = Bar.new
       x = bar.as(Foo).foo
       x.to_i!
-      )).to_i.should eq(1)
+      CRYSTAL
   end
 
   it "casts to bigger union" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(1)
       x = 1.5.as(Int32 | Float64)
       x.to_i!
-      )).to_i.should eq(1)
+      CRYSTAL
   end
 
   it "allows casting nil to Void*" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(0)
       nil.as(Void*).address
-      )).to_i.should eq(0)
+      CRYSTAL
   end
 
   it "allows casting nilable type to Void* (1)" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should_not eq(0)
       a = 1 == 1 ? Reference.new : nil
       a.as(Void*).address
-      )).to_i.should_not eq(0)
+      CRYSTAL
   end
 
   it "allows casting nilable type to Void* (2)" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(0)
       a = 1 == 2 ? Reference.new : nil
       a.as(Void*).address
-      )).to_i.should eq(0)
+      CRYSTAL
   end
 
   it "allows casting nilable type to Void* (3)" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should_not eq(0)
       class Foo
       end
       a = 1 == 1 ? Reference.new : (1 == 2 ? Foo.new : nil)
       a.as(Void*).address
-      )).to_i.should_not eq(0)
+      CRYSTAL
   end
 
   it "casts (bug)" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(123)
       require "prelude"
       (1 || 1.1).as(Int32)
       123
-      )).to_i.should eq(123)
+      CRYSTAL
   end
 
   it "can cast from Void* to virtual type (#3014)" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(42)
       abstract class Foo
         abstract def hi
       end
@@ -331,11 +331,11 @@ describe "Code gen: cast" do
       end
 
       Bar.new.as(Void*).as(Foo).hi
-      )).to_i.should eq(42)
+      CRYSTAL
   end
 
   it "upcasts from non-generic to generic" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(2)
       class Foo(T)
         def foo
           1
@@ -349,11 +349,11 @@ describe "Code gen: cast" do
       end
 
       Bar.new.as(Foo(Int32)).foo
-      )).to_i.should eq(2)
+      CRYSTAL
   end
 
   it "upcasts type to virtual (#3304)" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(1)
       class Foo
         def foo
           1
@@ -367,11 +367,11 @@ describe "Code gen: cast" do
       end
 
       Foo.new.as(Foo).foo
-      )).to_i.should eq(1)
+      CRYSTAL
   end
 
   it "upcasts type to virtual (2) (#3304)" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(1)
       class Foo
         def foo
           1
@@ -391,11 +391,11 @@ describe "Code gen: cast" do
       end
 
       Gen(Foo).cast(Foo.new).foo
-      )).to_i.should eq(1)
+      CRYSTAL
   end
 
   it "casts with block var that changes type (#3341)" do
-    codegen(%(
+    codegen(<<-CRYSTAL)
       require "prelude"
 
       class Object
@@ -409,20 +409,20 @@ describe "Code gen: cast" do
 
       x = Foo.new.as(Int32 | Foo)
       x.try &.as(Foo)
-      ))
+      CRYSTAL
   end
 
   it "casts between union types, where union has a tuple type (#3377)" do
-    codegen(%(
+    codegen(<<-CRYSTAL)
       require "prelude"
 
       v = 1 || true || 1.0
       (v || {v}).as(Bool | Float64)
-      ))
+      CRYSTAL
   end
 
   it "codegens class method when type id is available but not a virtual type (#3490)" do
-    run(%(
+    run(<<-CRYSTAL).to_string.should eq("A")
       class Class
         def name : String
           {{ @type.name.stringify }}
@@ -449,11 +449,11 @@ describe "Code gen: cast" do
       else
         "Nope"
       end
-      )).to_string.should eq("A")
+      CRYSTAL
   end
 
   it "casts from nilable type to virtual type (#3512)" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(1)
       require "prelude"
 
       class Foo
@@ -471,11 +471,11 @@ describe "Code gen: cast" do
       foo = 1 == 2 ? nil : Foo.new
       x = foo.as(Foo)
       x.foo
-      )).to_i.should eq(1)
+      CRYSTAL
   end
 
   it "can cast to metaclass (#11121)" do
-    run(%(
+    run(<<-CRYSTAL)
       class A
       end
 
@@ -483,7 +483,7 @@ describe "Code gen: cast" do
       end
 
       A.as(A.class)
-      ))
+      CRYSTAL
   end
 
   it "cast virtual metaclass type to nilable virtual instance type (#12628)" do

--- a/spec/compiler/codegen/class_spec.cr
+++ b/spec/compiler/codegen/class_spec.cr
@@ -2,7 +2,7 @@ require "../../spec_helper"
 
 describe "Code gen: class" do
   it "codegens call to same instance" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(1)
       class Foo
         def foo
           1
@@ -14,11 +14,11 @@ describe "Code gen: class" do
       end
 
       Foo.new.bar
-      )).to_i.should eq(1)
+      CRYSTAL
   end
 
   it "codegens instance var" do
-    run("
+    run(<<-CRYSTAL).to_i.should eq(42)
       class Foo
         def initialize(@coco : Int32)
         end
@@ -30,11 +30,11 @@ describe "Code gen: class" do
       f = Foo.new(2)
       g = Foo.new(40)
       f.coco &+ g.coco
-      ").to_i.should eq(42)
+      CRYSTAL
   end
 
   it "codegens recursive type" do
-    run("
+    run(<<-CRYSTAL)
       class Foo
         def next=(@next : Foo)
         end
@@ -42,11 +42,11 @@ describe "Code gen: class" do
 
       f = Foo.new
       f.next = f
-      ")
+      CRYSTAL
   end
 
   it "codegens method call of instance var" do
-    run("
+    run(<<-CRYSTAL).to_f64.should eq(1.0)
       class List
         def initialize
           @last = 0
@@ -60,11 +60,11 @@ describe "Code gen: class" do
 
       l = List.new
       l.foo
-      ").to_f64.should eq(1.0)
+      CRYSTAL
   end
 
   it "codegens new which calls initialize" do
-    run("
+    run(<<-CRYSTAL).to_i.should eq(1)
       class Foo
         def initialize(value : Int32)
           @value = value
@@ -77,11 +77,11 @@ describe "Code gen: class" do
 
       f = Foo.new 1
       f.value
-    ").to_i.should eq(1)
+      CRYSTAL
   end
 
   it "codegens method from another method without obj and accesses instance vars" do
-    run("
+    run(<<-CRYSTAL).to_i.should eq(1)
       class Foo
         def foo
           bar
@@ -94,11 +94,11 @@ describe "Code gen: class" do
 
       f = Foo.new
       f.foo
-      ").to_i.should eq(1)
+      CRYSTAL
   end
 
   it "codegens virtual call that calls another method" do
-    run("
+    run(<<-CRYSTAL).to_i.should eq(1)
       class Foo
         def foo
           foo2
@@ -113,11 +113,11 @@ describe "Code gen: class" do
       end
 
       Bar.new.foo
-      ").to_i.should eq(1)
+      CRYSTAL
   end
 
   it "codegens virtual method of generic class" do
-    run("
+    run(<<-CRYSTAL).to_i.should eq(1)
       class Object
         def foo
           bar
@@ -135,11 +135,11 @@ describe "Code gen: class" do
       end
 
       Foo(Int32).new.foo.to_i!
-      ").to_i.should eq(1)
+      CRYSTAL
   end
 
   it "changes instance variable in method (ssa bug)" do
-    run("
+    run(<<-CRYSTAL).to_i.should eq(2)
       class Foo
         def initialize
           @var = 0
@@ -158,7 +158,7 @@ describe "Code gen: class" do
 
       foo = Foo.new
       foo.foo
-      ").to_i.should eq(2)
+      CRYSTAL
   end
 
   # it "gets object_id of class" do
@@ -167,7 +167,7 @@ describe "Code gen: class" do
   # end
 
   it "calls method on Class class" do
-    run("
+    run(<<-CRYSTAL).to_i.should eq(1)
       class Class
         def foo
           1
@@ -178,11 +178,11 @@ describe "Code gen: class" do
       end
 
       Foo.foo
-    ").to_i.should eq(1)
+      CRYSTAL
   end
 
   it "uses number type var" do
-    run("
+    run(<<-CRYSTAL).to_i.should eq(1)
       class Foo(T)
         def self.foo
           T
@@ -190,11 +190,11 @@ describe "Code gen: class" do
       end
 
       Foo(1).foo
-      ").to_i.should eq(1)
+      CRYSTAL
   end
 
   it "calls class method without self" do
-    run("
+    run(<<-CRYSTAL).to_i.should eq(1)
       class Foo
         def self.coco
           1
@@ -203,11 +203,11 @@ describe "Code gen: class" do
         a = coco
       end
       a
-      ").to_i.should eq(1)
+      CRYSTAL
   end
 
   it "calls class method without self (2)" do
-    run("
+    run(<<-CRYSTAL).to_i.should eq(2)
       class Foo
         def self.coco
           lala
@@ -226,11 +226,11 @@ describe "Code gen: class" do
         a = coco
       end
       a
-      ").to_i.should eq(2)
+      CRYSTAL
   end
 
   it "assigns type to reference union type" do
-    run("
+    run(<<-CRYSTAL).to_i.should eq(1)
       class Foo
         def initialize(@x : Bar)
         end
@@ -243,19 +243,19 @@ describe "Code gen: class" do
       f = Foo.new(Bar.new)
       f.x = Baz.new
       1
-      ").to_i.should eq(1)
+      CRYSTAL
   end
 
   it "does to_s for class" do
-    run(%(
+    run(<<-CRYSTAL).to_string.should eq("Reference")
       require "prelude"
 
       Reference.to_s
-      )).to_string.should eq("Reference")
+      CRYSTAL
   end
 
   it "allows fixing an instance variable's type" do
-    run(%(
+    run(<<-CRYSTAL).to_b.should be_true
       class Foo
         @x : Bool
 
@@ -268,11 +268,11 @@ describe "Code gen: class" do
       end
 
       Foo.new(true).x
-      )).to_b.should be_true
+      CRYSTAL
   end
 
   it "codegens initialize with instance var" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(1)
       class Foo
         @x : Nil
 
@@ -283,11 +283,11 @@ describe "Code gen: class" do
 
       Foo.new
       1
-      )).to_i.should eq(1)
+      CRYSTAL
   end
 
   it "reads other instance var" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(1)
       class Foo
         def initialize(@x : Int32)
         end
@@ -295,11 +295,11 @@ describe "Code gen: class" do
 
       foo = Foo.new(1)
       foo.@x
-      )).to_i.should eq(1)
+      CRYSTAL
   end
 
   it "reads a virtual type instance var" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(1)
       class Foo
         def initialize(@x : Int32)
         end
@@ -310,11 +310,11 @@ describe "Code gen: class" do
 
       foo = Foo.new(1) || Bar.new(2)
       foo.@x
-      )).to_i.should eq(1)
+      CRYSTAL
   end
 
   it "reads a union type instance var (reference union, first type)" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(10)
       class Foo
         def initialize(@x : Int32)
         end
@@ -342,11 +342,11 @@ describe "Code gen: class" do
       else
         20
       end
-      )).to_i.should eq(10)
+      CRYSTAL
   end
 
   it "reads a union type instance var (reference union, second type)" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq('a'.ord)
       class Foo
         def initialize(@x : Int32)
         end
@@ -374,11 +374,11 @@ describe "Code gen: class" do
       else
         'b'
       end
-      )).to_i.should eq('a'.ord)
+      CRYSTAL
   end
 
   it "reads a union type instance var (mixed union, first type)" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(10)
       struct Foo
         def initialize(@x : Int32)
         end
@@ -406,11 +406,11 @@ describe "Code gen: class" do
       else
         20
       end
-      )).to_i.should eq(10)
+      CRYSTAL
   end
 
   it "reads a union type instance var (mixed union, second type)" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq('a'.ord)
       struct Foo
         def initialize(@x : Int32)
         end
@@ -438,11 +438,11 @@ describe "Code gen: class" do
       else
         'b'
       end
-      )).to_i.should eq('a'.ord)
+      CRYSTAL
   end
 
   it "never considers read instance var as closure (#12181)" do
-    codegen(%(
+    codegen(<<-CRYSTAL)
       class Foo
         @x = 1
       end
@@ -454,11 +454,11 @@ describe "Code gen: class" do
       end
 
       bug
-      ))
+      CRYSTAL
   end
 
   it "runs with nilable instance var" do
-    run("
+    run(<<-CRYSTAL).to_i.should eq(0)
       struct Nil
         def to_i!
           0
@@ -479,11 +479,11 @@ describe "Code gen: class" do
 
       bar = Bar.new
       bar.x.to_i!
-      ").to_i.should eq(0)
+      CRYSTAL
   end
 
   it "runs with nil instance var when inheriting" do
-    run("
+    run(<<-CRYSTAL).to_i.should eq(0)
       struct Nil
         def to_i!
           0
@@ -509,11 +509,11 @@ describe "Code gen: class" do
 
       bar = Bar.new
       bar.x.to_i!
-      ").to_i.should eq(0)
+      CRYSTAL
   end
 
   it "codegens bug #168" do
-    run("
+    run(<<-CRYSTAL).to_i.should eq(1)
       class Foo
         @x : Foo?
 
@@ -533,11 +533,11 @@ describe "Code gen: class" do
       end
 
       Bar.new(Foo.new).foo
-      ").to_i.should eq(1)
+      CRYSTAL
   end
 
   it "allows initializing var with constant" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(1)
       class Foo
         A = 1
         @x = A
@@ -548,17 +548,17 @@ describe "Code gen: class" do
       end
 
       Foo.new.x
-      )).to_i.should eq(1)
+      CRYSTAL
   end
 
   it "codegens class method" do
-    codegen(%(
+    codegen(<<-CRYSTAL)
       Int32.class
-      ))
+      CRYSTAL
   end
 
   it "codegens virtual class method" do
-    codegen(%(
+    codegen(<<-CRYSTAL)
       class Foo
       end
 
@@ -566,11 +566,11 @@ describe "Code gen: class" do
       end
 
       (Foo.new || Bar.new).class
-      ))
+      CRYSTAL
   end
 
   it "allows using self in class scope" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(1)
       class Foo
         def self.foo
           1
@@ -584,11 +584,11 @@ describe "Code gen: class" do
       end
 
       Foo.x
-      )).to_i.should eq(1)
+      CRYSTAL
   end
 
   it "allows using self in class scope" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(1)
       require "prelude"
 
       class Foo
@@ -604,11 +604,11 @@ describe "Code gen: class" do
       end
 
       Foo.x.foo
-      )).to_i.should eq(1)
+      CRYSTAL
   end
 
   it "makes .class always be a virtual type even if no subclasses" do
-    codegen(%(
+    codegen(<<-CRYSTAL)
       class Foo
       end
 
@@ -617,11 +617,11 @@ describe "Code gen: class" do
       class Bar < Foo
         p.value = self
       end
-      ))
+      CRYSTAL
   end
 
   it "does to_s for virtual metaclass type (1)" do
-    run(%(
+    run(<<-CRYSTAL).to_string.should eq("Foo")
       require "prelude"
 
       class Foo; end
@@ -630,11 +630,11 @@ describe "Code gen: class" do
 
       a = Foo || Bar || Baz
       a.to_s
-      )).to_string.should eq("Foo")
+      CRYSTAL
   end
 
   it "does to_s for virtual metaclass type (2)" do
-    run(%(
+    run(<<-CRYSTAL).to_string.should eq("Bar")
       require "prelude"
 
       class Foo; end
@@ -643,11 +643,11 @@ describe "Code gen: class" do
 
       a = Bar || Foo || Baz
       a.to_s
-      )).to_string.should eq("Bar")
+      CRYSTAL
   end
 
   it "does to_s for virtual metaclass type (3)" do
-    run(%(
+    run(<<-CRYSTAL).to_string.should eq("Baz")
       require "prelude"
 
       class Foo; end
@@ -656,7 +656,7 @@ describe "Code gen: class" do
 
       a = Baz || Bar || Foo
       a.to_s
-      )).to_string.should eq("Baz")
+      CRYSTAL
   end
 
   it "does not combine module metaclass types with same name but different file scopes (#15503)" do
@@ -817,7 +817,7 @@ describe "Code gen: class" do
   end
 
   it "builds generic class bug" do
-    codegen(%(
+    codegen(<<-CRYSTAL)
       abstract class Base
         def initialize
           @value = 1
@@ -839,11 +839,11 @@ describe "Code gen: class" do
 
       ex = Foo(Int32).new || Bar.new
       ex.foo
-      ))
+      CRYSTAL
   end
 
   it "resolves type declaration when accessing instance var (#348)" do
-    codegen(%(
+    codegen(<<-CRYSTAL)
       require "prelude"
 
       lib LibC
@@ -857,11 +857,11 @@ describe "Code gen: class" do
       end
 
       Bar.new.inspect
-      ))
+      CRYSTAL
   end
 
   it "gets class of virtual type" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(2)
       class Foo
         def self.foo
           1
@@ -876,11 +876,11 @@ describe "Code gen: class" do
 
       f = Bar.new || Foo.new
       f.class.foo
-      )).to_i.should eq(2)
+      CRYSTAL
   end
 
   it "notifies superclass recursively on inheritance (#576)" do
-    run(%(
+    run(<<-CRYSTAL).to_string.should eq("Qux")
       class Class
         def name : String
           {{ @type.name.stringify }}
@@ -909,11 +909,11 @@ describe "Code gen: class" do
       class Qux < Baz; end
       ptr.value = Qux
       ptr.value.foo
-      )).to_string.should eq("Qux")
+      CRYSTAL
   end
 
   it "works with array in variable initializer in non-generic type (#855)" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(6)
       require "prelude"
 
       class Foo
@@ -925,11 +925,11 @@ describe "Code gen: class" do
       end
 
       Foo.new.sum
-      )).to_i.should eq(6)
+      CRYSTAL
   end
 
   it "works with array in variable initializer in generic type (#855)" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(6)
       require "prelude"
 
       class Foo(T)
@@ -941,33 +941,33 @@ describe "Code gen: class" do
       end
 
       Foo(Int32).new.sum
-      )).to_i.should eq(6)
+      CRYSTAL
   end
 
   it "doesn't crash on instance variable assigned a proc, and never instantiated (#923)" do
-    codegen(%(
+    codegen(<<-CRYSTAL)
       class Klass
         def self.f(arg)
         end
 
         @a : Proc(String, Nil) = ->f(String)
       end
-      ))
+      CRYSTAL
   end
 
   it "does to_s on class" do
-    run(%(
+    run(<<-CRYSTAL).to_string.should eq("Class")
       require "prelude"
 
       class Foo
       end
 
       Foo.class.to_s
-      )).to_string.should eq("Class")
+      CRYSTAL
   end
 
   it "invokes class method inside instance method (#1119)" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(123)
       class Class
         def bar
           123
@@ -982,11 +982,11 @@ describe "Code gen: class" do
 
       x = Foo.new.test
       x.bar
-      )).to_i.should eq(123)
+      CRYSTAL
   end
 
   it "codegens method of class union including Int (#1476)" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(1)
       class Class
         def foo
           1
@@ -995,11 +995,11 @@ describe "Code gen: class" do
 
       x = Int || Int32
       x.foo
-      )).to_i.should eq(1)
+      CRYSTAL
   end
 
   it "can use a Main class (#1628)" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(1)
       require "prelude"
 
       class Main
@@ -1009,11 +1009,11 @@ describe "Code gen: class" do
       end
 
       Main.foo
-      )).to_i.should eq(1)
+      CRYSTAL
   end
 
   it "codegens singleton (#718)" do
-    run(%(
+    run(<<-CRYSTAL).to_string.should eq("Hello")
       class Singleton
         @@instance = new
 
@@ -1031,11 +1031,11 @@ describe "Code gen: class" do
       end
 
       Singleton.get_instance.msg
-      )).to_string.should eq("Hello")
+      CRYSTAL
   end
 
   it "doesn't crash if not using undefined instance variable in superclass" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(42)
       class Foo
         def initialize(@x)
         end
@@ -1052,11 +1052,11 @@ describe "Code gen: class" do
 
       foo = Bar.new(42)
       foo.x
-      )).to_i.should eq(42)
+      CRYSTAL
   end
 
   it "codegens virtual metaclass union bug (#2597)" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(2)
 
       class Foo
         def self.foo
@@ -1095,11 +1095,11 @@ describe "Code gen: class" do
       end
 
       Bar.new.foo.foo
-      )).to_i.should eq(2)
+      CRYSTAL
   end
 
   it "doesn't crash on #1216" do
-    codegen(%(
+    codegen(<<-CRYSTAL)
       class Foo
         def initialize(@ivar : Int32)
           meth
@@ -1112,11 +1112,11 @@ describe "Code gen: class" do
       end
 
       Foo.new(6)
-      ))
+      CRYSTAL
   end
 
   it "doesn't crash on #1216 with pointerof" do
-    codegen(%(
+    codegen(<<-CRYSTAL)
       class Foo
         def initialize(@ivar : Int32)
           meth
@@ -1129,11 +1129,11 @@ describe "Code gen: class" do
       end
 
       Foo.new(6)
-      ))
+      CRYSTAL
   end
 
   it "doesn't crash on #1216 (reduced)" do
-    codegen(%(
+    codegen(<<-CRYSTAL)
       class Foo
         def foo
           crash.foo
@@ -1147,11 +1147,11 @@ describe "Code gen: class" do
       end
 
       crash
-      ))
+      CRYSTAL
   end
 
   it "doesn't crash on abstract class never instantiated (#2840)" do
-    codegen(%(
+    codegen(<<-CRYSTAL)
       require "prelude"
 
       abstract class Foo
@@ -1162,11 +1162,11 @@ describe "Code gen: class" do
       else
         Pointer(Foo).malloc(1_u64).value.foo
       end
-      ))
+      CRYSTAL
   end
 
   it "can assign virtual metaclass to virtual metaclass (#3007)" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(2)
       class Foo
         def self.foo
           1
@@ -1193,11 +1193,11 @@ describe "Code gen: class" do
       ptr = Pointer(Foo.class).malloc(1_u64)
       ptr.value = Bar || Baz
       ptr.value.foo
-      )).to_i.should eq(2)
+      CRYSTAL
   end
 
   it "transfers initializer from module to generic class" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(123)
       module Moo
         @x = 123
 
@@ -1211,11 +1211,11 @@ describe "Code gen: class" do
       end
 
       Foo(Int32).new.x
-      )).to_i.should eq(123)
+      CRYSTAL
   end
 
   it "transfers initializer from generic module to non-generic class" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(123)
       module Moo(T)
         @x = 123
 
@@ -1229,11 +1229,11 @@ describe "Code gen: class" do
       end
 
       Foo.new.x
-      )).to_i.should eq(123)
+      CRYSTAL
   end
 
   it "transfers initializer from generic module to generic class" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(123)
       module Moo(T)
         @x = 123
 
@@ -1247,11 +1247,11 @@ describe "Code gen: class" do
       end
 
       Foo(Int32).new.x
-      )).to_i.should eq(123)
+      CRYSTAL
   end
 
   it "doesn't skip false initializers (#3272)" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(20)
       class Parent
         @foo = true
 
@@ -1265,11 +1265,11 @@ describe "Code gen: class" do
       end
 
       Child.new.foo ? 10 : 20
-      )).to_i.should eq(20)
+      CRYSTAL
   end
 
   it "doesn't skip zero initializers (#3272)" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(0)
       class Parent
         @foo = 123
 
@@ -1283,11 +1283,11 @@ describe "Code gen: class" do
       end
 
       Child.new.foo
-      )).to_i.should eq(0)
+      CRYSTAL
   end
 
   it "codegens virtual generic class instance metaclass (#3819)" do
-    run(%(
+    run(<<-CRYSTAL).to_string.should eq("Foo")
       module Core
       end
 
@@ -1308,11 +1308,11 @@ describe "Code gen: class" do
       end
 
       Foo.new.as(Core).class.name
-      )).to_string.should eq("Foo")
+      CRYSTAL
   end
 
   it "codegens class with recursive tuple to class (#4520)" do
-    run(%(
+    run(<<-CRYSTAL, inject_primitives: false).to_i.should eq(1)
       class Foo
         @foo : {Foo, Foo}?
 
@@ -1330,11 +1330,11 @@ describe "Code gen: class" do
       foo = Foo.new(1)
       foo.foo = {Foo.new(2), Foo.new(3)}
       foo.x
-      ), inject_primitives: false).to_i.should eq(1)
+      CRYSTAL
   end
 
   it "runs instance variable initializer at the class level" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(42)
       class Foo
         @x : Int32 = bar
 
@@ -1348,11 +1348,11 @@ describe "Code gen: class" do
       end
 
       Foo.new.x
-      )).to_i.should eq(42)
+      CRYSTAL
   end
 
   it "runs instance variable initializer at the class level, for generic type" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(42)
       class Foo(T)
         @x : T = bar
 
@@ -1366,11 +1366,11 @@ describe "Code gen: class" do
       end
 
       Foo(Int32).new.x
-      )).to_i.should eq(42)
+      CRYSTAL
   end
 
   pending "codegens assignment of generic metaclasses (1) (#10394)" do
-    run(%(
+    run(<<-CRYSTAL).to_string.should eq("Bar(T)")
       class Class
         def name : String
           {{ @type.name.stringify }}
@@ -1383,11 +1383,11 @@ describe "Code gen: class" do
       x = Foo
       x = Bar
       x.name
-      )).to_string.should eq("Bar(T)")
+      CRYSTAL
   end
 
   pending "codegens assignment of generic metaclasses (2) (#10394)" do
-    run(%(
+    run(<<-CRYSTAL).to_string.should eq("Bar(Int32)")
       class Class
         def name : String
           {{ @type.name.stringify }}
@@ -1400,11 +1400,11 @@ describe "Code gen: class" do
       x = Foo
       x = Bar(Int32)
       x.name
-      )).to_string.should eq("Bar(Int32)")
+      CRYSTAL
   end
 
   it "codegens assignment of generic metaclasses (3) (#10394)" do
-    run(%(
+    run(<<-CRYSTAL).to_string.should eq("Bar(Int32)")
       class Class
         def name : String
           {{ @type.name.stringify }}
@@ -1417,11 +1417,11 @@ describe "Code gen: class" do
       x = Foo(Int32)
       x = Bar(Int32)
       x.name
-      )).to_string.should eq("Bar(Int32)")
+      CRYSTAL
   end
 
   it "codegens assignment of generic metaclasses (4) (#10394)" do
-    run(%(
+    run(<<-CRYSTAL).to_string.should eq("Bar(Int32)")
       class Class
         def name : String
           {{ @type.name.stringify }}
@@ -1434,11 +1434,11 @@ describe "Code gen: class" do
       x = Foo(String)
       x = Bar(Int32)
       x.name
-      )).to_string.should eq("Bar(Int32)")
+      CRYSTAL
   end
 
   it "codegens assignment of generic metaclasses, base is non-generic (1) (#10394)" do
-    run(%(
+    run(<<-CRYSTAL).to_string.should eq("Bar(T)")
       class Class
         def name : String
           {{ @type.name.stringify }}
@@ -1451,11 +1451,11 @@ describe "Code gen: class" do
       x = Foo
       x = Bar
       x.name
-      )).to_string.should eq("Bar(T)")
+      CRYSTAL
   end
 
   it "codegens assignment of generic metaclasses, base is non-generic (2) (#10394)" do
-    run(%(
+    run(<<-CRYSTAL).to_string.should eq("Bar(Int32)")
       class Class
         def name : String
           {{ @type.name.stringify }}
@@ -1468,6 +1468,6 @@ describe "Code gen: class" do
       x = Foo
       x = Bar(Int32)
       x.name
-      )).to_string.should eq("Bar(Int32)")
+      CRYSTAL
   end
 end

--- a/spec/compiler/codegen/class_var_spec.cr
+++ b/spec/compiler/codegen/class_var_spec.cr
@@ -2,7 +2,7 @@ require "../../spec_helper"
 
 describe "Codegen: class var" do
   it "codegens class var" do
-    run("
+    run(<<-CRYSTAL).to_i.should eq(1)
       class Foo
         @@foo = 1
 
@@ -12,11 +12,11 @@ describe "Codegen: class var" do
       end
 
       Foo.foo
-      ").to_i.should eq(1)
+      CRYSTAL
   end
 
   it "codegens class var as nil" do
-    run("
+    run(<<-CRYSTAL).to_i.should eq(0)
       struct Nil; def to_i; 0; end; end
 
       class Foo
@@ -28,11 +28,11 @@ describe "Codegen: class var" do
       end
 
       Foo.foo.to_i
-      ").to_i.should eq(0)
+      CRYSTAL
   end
 
   it "codegens class var inside instance method" do
-    run("
+    run(<<-CRYSTAL).to_i.should eq(1)
       class Foo
         @@foo = 1
 
@@ -42,11 +42,11 @@ describe "Codegen: class var" do
       end
 
       Foo.new.foo
-      ").to_i.should eq(1)
+      CRYSTAL
   end
 
   it "codegens class var as nil if assigned for the first time inside method" do
-    run("
+    run(<<-CRYSTAL).to_i.should eq(1)
       struct Nil; def to_i!; 0; end; end
 
       class Foo
@@ -57,11 +57,11 @@ describe "Codegen: class var" do
       end
 
       Foo.foo.to_i!
-      ").to_i.should eq(1)
+      CRYSTAL
   end
 
   it "codegens class var inside module" do
-    run("
+    run(<<-CRYSTAL).to_i.should eq(1)
       module Foo
         @@foo = 1
 
@@ -71,11 +71,11 @@ describe "Codegen: class var" do
       end
 
       Foo.foo
-      ").to_i.should eq(1)
+      CRYSTAL
   end
 
   it "accesses class var from proc literal" do
-    run("
+    run(<<-CRYSTAL).to_i.should eq(1)
       class Foo
         @@a = 1
 
@@ -85,11 +85,11 @@ describe "Codegen: class var" do
       end
 
       Foo.foo
-      ").to_i.should eq(1)
+      CRYSTAL
   end
 
   it "reads class var before initializing it (hoisting)" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(42)
       x = Foo.var
 
       class Foo
@@ -101,11 +101,11 @@ describe "Codegen: class var" do
       end
 
       x
-      )).to_i.should eq(42)
+      CRYSTAL
   end
 
   it "uses var in class var initializer" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(6)
       class Foo
         @@var : Int32
         @@var = begin
@@ -123,11 +123,11 @@ describe "Codegen: class var" do
       end
 
       Foo.var
-      )).to_i.should eq(6)
+      CRYSTAL
   end
 
   it "reads simple class var before another complex one" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(42)
       class Foo
         @@var2 : Int32
         @@var2 = @@var &+ 1
@@ -140,11 +140,11 @@ describe "Codegen: class var" do
       end
 
       Foo.var2
-      )).to_i.should eq(42)
+      CRYSTAL
   end
 
   it "initializes class var of union with single type" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(42)
       class Foo
         @@var : Int32 | String
         @@var = 42
@@ -160,11 +160,11 @@ describe "Codegen: class var" do
       else
         0
       end
-      )).to_i.should eq(42)
+      CRYSTAL
   end
 
   it "initializes class var with array literal" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(3)
       require "prelude"
 
       class Foo
@@ -176,11 +176,11 @@ describe "Codegen: class var" do
       end
 
       Foo.var.size
-      )).to_i.should eq(3)
+      CRYSTAL
   end
 
   it "codegens second class var initializer" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(2)
       class Foo
         @@var = 1
         @@var = 2
@@ -191,11 +191,11 @@ describe "Codegen: class var" do
       end
 
       Foo.var
-      )).to_i.should eq(2)
+      CRYSTAL
   end
 
   it "initializes dependent constant before class var" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(3)
       require "prelude"
 
       def foo
@@ -216,11 +216,11 @@ describe "Codegen: class var" do
       end
 
       Foo.foo
-      )).to_i.should eq(3)
+      CRYSTAL
   end
 
   it "declares and initializes" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(42)
       class Foo
         @@x : Int32 = 42
 
@@ -230,11 +230,11 @@ describe "Codegen: class var" do
       end
 
       Foo.x
-      )).to_i.should eq(42)
+      CRYSTAL
   end
 
   it "doesn't use nilable type for initializer" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(42)
       class Foo
         @@foo : Int32?
         @@foo = 42
@@ -248,11 +248,11 @@ describe "Codegen: class var" do
       end
 
       Foo.bar || 10
-      )).to_i.should eq(42)
+      CRYSTAL
   end
 
   it "codegens class var with begin and vars" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(3)
       class Foo
         @@foo : Int32
         @@foo = begin
@@ -267,11 +267,11 @@ describe "Codegen: class var" do
       end
 
       Foo.foo
-      )).to_i.should eq(3)
+      CRYSTAL
   end
 
   it "codegens class var with type declaration begin and vars" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(3)
       class Foo
         @@foo : Int32 = begin
           a = 1
@@ -285,11 +285,11 @@ describe "Codegen: class var" do
       end
 
       Foo.foo
-      )).to_i.should eq(3)
+      CRYSTAL
   end
 
   it "codegens class var with nilable reference type" do
-    run(%(
+    run(<<-CRYSTAL).to_string.should eq("hello")
       class Foo
         @@foo : String? = nil
 
@@ -299,11 +299,11 @@ describe "Codegen: class var" do
       end
 
       Foo.foo
-      )).to_string.should eq("hello")
+      CRYSTAL
   end
 
   it "initializes class var the moment it reaches it" do
-    run(%(
+    run(<<-CRYSTAL).to_string.should eq("BAR")
       require "prelude"
 
       ENV["FOO"] = "BAR"
@@ -319,11 +319,11 @@ describe "Codegen: class var" do
       w = Foo.x
       z = Foo.x
       z
-      )).to_string.should eq("BAR")
+      CRYSTAL
   end
 
   it "gets pointerof class var" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(10)
       z = Foo.foo
 
       class Foo
@@ -335,11 +335,11 @@ describe "Codegen: class var" do
       end
 
       z
-      )).to_i.should eq(10)
+      CRYSTAL
   end
 
   it "gets pointerof class var complex constant" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(10)
       z = Foo.foo
 
       class Foo
@@ -355,11 +355,11 @@ describe "Codegen: class var" do
       end
 
       z
-      )).to_i.should eq(10)
+      CRYSTAL
   end
 
   it "doesn't inherit class var value in subclass" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(1)
       class Foo
         @@var = 1
 
@@ -377,11 +377,11 @@ describe "Codegen: class var" do
       Foo.var = 2
 
       Bar.var
-      )).to_i.should eq(1)
+      CRYSTAL
   end
 
   it "doesn't inherit class var value in module" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(1)
       module Moo
         @@var = 1
 
@@ -400,11 +400,11 @@ describe "Codegen: class var" do
       Moo.var = 2
 
       Foo.new.var
-      )).to_i.should eq(1)
+      CRYSTAL
   end
 
   it "reads class var from virtual type" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(2)
       class Foo
         @@var = 1
 
@@ -428,11 +428,11 @@ describe "Codegen: class var" do
       ptr = Pointer(Foo).malloc(1_u64)
       ptr.value = Bar.new
       ptr.value.var
-      )).to_i.should eq(2)
+      CRYSTAL
   end
 
   it "reads class var from virtual type metaclass" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(2)
       class Foo
         @@var = 1
 
@@ -452,11 +452,11 @@ describe "Codegen: class var" do
       ptr = Pointer(Foo.class).malloc(1_u64)
       ptr.value = Bar
       ptr.value.var
-      )).to_i.should eq(2)
+      CRYSTAL
   end
 
   it "writes class var from virtual type" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(2)
       class Foo
         @@var = 1
 
@@ -479,11 +479,11 @@ describe "Codegen: class var" do
       ptr.value.var = 2
 
       Bar.var
-      )).to_i.should eq(2)
+      CRYSTAL
   end
 
   it "declares var as uninitialized and initializes it unsafely" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(10)
       class Foo
         @@x = uninitialized Int32
         @@x = Foo.bar
@@ -502,11 +502,11 @@ describe "Codegen: class var" do
       end
 
       Foo.x
-      )).to_i.should eq(10)
+      CRYSTAL
   end
 
   it "doesn't crash with pointerof from another module" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(1)
       require "prelude"
 
       class Foo
@@ -525,11 +525,11 @@ describe "Codegen: class var" do
       end
 
       Bar.bar
-      )).to_i.should eq(1)
+      CRYSTAL
   end
 
   it "codegens generic class with class var" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(1 + 1 + 10 + 20)
       class Foo(T)
         @@bar = 1
 
@@ -551,15 +551,15 @@ describe "Codegen: class var" do
       f2.bar = 20
       d = f1.bar
       a &+ b &+ c &+ d
-      )).to_i.should eq(1 + 1 + 10 + 20)
+      CRYSTAL
   end
 
   it "inline initialization of simple class var" do
-    mod = codegen(%(
+    mod = codegen(<<-CRYSTAL)
       class Foo
         @@x = 1
       end
-    ))
+      CRYSTAL
 
     mod.to_s.should_not contain("x:init")
   end
@@ -578,7 +578,7 @@ describe "Codegen: class var" do
   end
 
   it "catch infinite loop in class var initializer" do
-    run(%(
+    run(<<-CRYSTAL).to_string.should eq("error: Recursion while initializing class variables and/or constants")
       require "prelude"
 
       module Crystal
@@ -602,11 +602,11 @@ describe "Codegen: class var" do
       end
 
       nil
-    )).to_string.should eq("error: Recursion while initializing class variables and/or constants")
+      CRYSTAL
   end
 
   it "runs class var side effects (#8862)" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(6)
       require "prelude"
 
       class Foo
@@ -635,6 +635,6 @@ describe "Codegen: class var" do
       end
 
       a &+ Foo.x
-      )).to_i.should eq(6)
+      CRYSTAL
   end
 end

--- a/spec/compiler/codegen/closure_spec.cr
+++ b/spec/compiler/codegen/closure_spec.cr
@@ -2,36 +2,36 @@ require "../../spec_helper"
 
 describe "Code gen: closure" do
   it "codegens simple closure at global scope" do
-    run("
+    run(<<-CRYSTAL).to_i.should eq(1)
       a = 1
       foo = ->{ a }
       foo.call
-    ").to_i.should eq(1)
+      CRYSTAL
   end
 
   it "codegens simple closure in function" do
-    run("
+    run(<<-CRYSTAL).to_i.should eq(1)
       def foo
         a = 1
         ->{ a }
       end
 
       foo.call
-    ").to_i.should eq(1)
+      CRYSTAL
   end
 
   it "codegens simple closure in function with argument" do
-    run("
+    run(<<-CRYSTAL).to_i.should eq(1)
       def foo(a)
         ->{ a }
       end
 
       foo(1).call
-    ").to_i.should eq(1)
+      CRYSTAL
   end
 
   it "codegens simple closure in block" do
-    run("
+    run(<<-CRYSTAL).to_i.should eq(1)
       def foo
         yield
       end
@@ -42,11 +42,11 @@ describe "Code gen: closure" do
       end
 
       f.call
-    ").to_i.should eq(1)
+      CRYSTAL
   end
 
   it "codegens closured nested in block" do
-    run("
+    run(<<-CRYSTAL).to_i.should eq(3)
       def foo
         yield
       end
@@ -57,11 +57,11 @@ describe "Code gen: closure" do
         -> { a &+ b }
       end
       f.call
-    ").to_i.should eq(3)
+      CRYSTAL
   end
 
   it "codegens closured nested in block with a call with a closure with same names" do
-    run("
+    run(<<-CRYSTAL).to_i.should eq(4)
       def foo
         a = 3
         f = -> { a }
@@ -73,11 +73,11 @@ describe "Code gen: closure" do
         -> { a &+ x }
       end
       f.call
-    ").to_i.should eq(4)
+      CRYSTAL
   end
 
   it "codegens closure with block that declares same var" do
-    run("
+    run(<<-CRYSTAL).to_i.should eq(3)
       def foo
         a = 1
         yield a
@@ -88,11 +88,11 @@ describe "Code gen: closure" do
         -> { a &+ x }
       end
       f.call
-      ").to_i.should eq(3)
+      CRYSTAL
   end
 
   it "codegens closure with def that has an if" do
-    run("
+    run(<<-CRYSTAL).to_i.should eq(2)
       def foo
         yield 1 if 1
         yield 2
@@ -102,11 +102,11 @@ describe "Code gen: closure" do
         -> { x }
       end
       f.call
-      ").to_i.should eq(2)
+      CRYSTAL
   end
 
   it "codegens multiple nested blocks" do
-    run("
+    run(<<-CRYSTAL).to_i.should eq(9)
       def foo
         yield 1
         yield 2
@@ -122,11 +122,11 @@ describe "Code gen: closure" do
         end
       end
       f.call
-      ").to_i.should eq(9)
+      CRYSTAL
   end
 
   it "codegens closure with nested context without new closured vars" do
-    run("
+    run(<<-CRYSTAL).to_i.should eq(1)
       def foo
         yield
       end
@@ -136,11 +136,11 @@ describe "Code gen: closure" do
         -> { a }
       end
       f.call
-      ").to_i.should eq(1)
+      CRYSTAL
   end
 
   it "codegens closure with nested context without new closured vars" do
-    run("
+    run(<<-CRYSTAL).to_i.should eq(2)
       def foo
         yield
       end
@@ -157,11 +157,11 @@ describe "Code gen: closure" do
         end
       end
       f.call
-      ").to_i.should eq(2)
+      CRYSTAL
   end
 
   it "codegens closure with nested context without new closured vars but with block arg" do
-    run("
+    run(<<-CRYSTAL).to_i.should eq(2)
       def foo
         yield
       end
@@ -179,31 +179,31 @@ describe "Code gen: closure" do
         end
       end
       f.call
-      ").to_i.should eq(2)
+      CRYSTAL
   end
 
   it "unifies types of closured var" do
-    run("
+    run(<<-CRYSTAL).to_i.should eq(2)
       a = 1
       f = -> { a }
       a = 2.5
       f.call.to_i!
-      ").to_i.should eq(2)
+      CRYSTAL
   end
 
   it "codegens closure with block" do
-    run("
+    run(<<-CRYSTAL).to_i.should eq(1)
       def foo
         yield
       end
 
       a = 1
       ->{ foo { a } }.call
-      ").to_i.should eq(1)
+      CRYSTAL
   end
 
   it "codegens closure with self and var" do
-    run("
+    run(<<-CRYSTAL).to_i.should eq(3)
       class Foo
         def initialize(@x : Int32)
         end
@@ -219,11 +219,11 @@ describe "Code gen: closure" do
       end
 
       Foo.new(1).foo.call
-      ").to_i.should eq(3)
+      CRYSTAL
   end
 
   it "codegens closure with implicit self and var" do
-    run("
+    run(<<-CRYSTAL).to_i.should eq(3)
       class Foo
         def initialize(@x : Int32)
         end
@@ -239,11 +239,11 @@ describe "Code gen: closure" do
       end
 
       Foo.new(1).foo.call
-      ").to_i.should eq(3)
+      CRYSTAL
   end
 
   it "codegens closure with instance var and var" do
-    run("
+    run(<<-CRYSTAL).to_i.should eq(3)
       class Foo
         def initialize(@x : Int32)
         end
@@ -255,11 +255,11 @@ describe "Code gen: closure" do
       end
 
       Foo.new(1).foo.call
-      ").to_i.should eq(3)
+      CRYSTAL
   end
 
   it "codegens closure with instance var" do
-    run("
+    run(<<-CRYSTAL).to_i.should eq(1)
       class Foo
         def initialize(@x : Int32)
         end
@@ -270,11 +270,11 @@ describe "Code gen: closure" do
       end
 
       Foo.new(1).foo.call
-      ").to_i.should eq(1)
+      CRYSTAL
   end
 
   it "codegens closure with instance var and block" do
-    run("
+    run(<<-CRYSTAL).to_i.should eq(3)
       def bar
         yield
       end
@@ -292,11 +292,11 @@ describe "Code gen: closure" do
       end
 
       Foo.new(1).foo.call
-      ").to_i.should eq(3)
+      CRYSTAL
   end
 
   it "codegen closure in instance method without self closured" do
-    run("
+    run(<<-CRYSTAL).to_i.should eq(1)
       class Foo
         def foo
           ->(a : Int32) { a }
@@ -304,11 +304,11 @@ describe "Code gen: closure" do
       end
 
       Foo.new.foo.call(1)
-      ").to_i.should eq(1)
+      CRYSTAL
   end
 
   it "codegens closure inside initialize inside block with self" do
-    run("
+    run(<<-CRYSTAL)
       def foo
         yield
       end
@@ -322,11 +322,11 @@ describe "Code gen: closure" do
       foo do
         Foo.new
       end
-      ")
+      CRYSTAL
   end
 
   it "doesn't free closure memory (bug)" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(1249975000_i64)
       require "prelude"
 
       def foo
@@ -348,57 +348,57 @@ describe "Code gen: closure" do
         a += func.call
       end
       a
-      )).to_i.should eq(1249975000_i64)
+      CRYSTAL
   end
 
   it "codegens nested closure" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(1)
       a = 1
       ->{ ->{ a } }.call.call
-      )).to_i.should eq(1)
+      CRYSTAL
   end
 
   it "codegens super nested closure" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(1)
       a = 1
       ->{ ->{ -> { -> { a } } } }.call.call.call.call
-      )).to_i.should eq(1)
+      CRYSTAL
   end
 
   it "codegens nested closure with block (1)" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(1)
       def foo
         yield
       end
 
       a = 1
       ->{ foo { ->{ a } } }.call.call
-      )).to_i.should eq(1)
+      CRYSTAL
   end
 
   it "codegens nested closure with block (2)" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(1)
       def foo
         yield
       end
 
       a = 1
       ->{ ->{ foo { a } } }.call.call
-      )).to_i.should eq(1)
+      CRYSTAL
   end
 
   it "codegens nested closure with nested closured variable" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(3)
       a = 1
       ->{
         b = 2
         ->{ a &+ b }
       }.call.call
-      )).to_i.should eq(3)
+      CRYSTAL
   end
 
   it "codegens super nested closure with nested closured variable" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(10)
       def foo
         yield 4
       end
@@ -419,11 +419,11 @@ describe "Code gen: closure" do
           }
         }
       }.call.call.call.call.call
-      )).to_i.should eq(10)
+      CRYSTAL
   end
 
   it "codegens proc literal with struct" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(2)
       struct Foo
         def initialize(@x : Int32)
         end
@@ -437,11 +437,11 @@ describe "Code gen: closure" do
 
       obj = Foo.new(2)
       f.call(obj)
-      )).to_i.should eq(2)
+      CRYSTAL
   end
 
   it "codegens closure with struct" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(3)
       struct Foo
         def initialize(@x : Int32)
         end
@@ -458,11 +458,11 @@ describe "Code gen: closure" do
 
       obj = Foo.new(2)
       f.call(obj)
-      )).to_i.should eq(3)
+      CRYSTAL
   end
 
   it "codegens closure with self and arguments" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(3)
       class Foo
         def initialize(@x : Int32)
         end
@@ -478,22 +478,22 @@ describe "Code gen: closure" do
 
       f = Foo.new(1).bar
       f.call(2)
-      )).to_i.should eq(3)
+      CRYSTAL
   end
 
   it "codegens nested closure that mentions var in both contexts" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(1)
       a = 1
       f = ->{
         a
         -> { a }
       }
       f.call.call
-      )).to_i.should eq(1)
+      CRYSTAL
   end
 
   it "transforms block to proc literal" do
-    run("
+    run(<<-CRYSTAL).to_i.should eq(2)
       def foo(&block : Int32 -> Int32)
         block.call(1)
       end
@@ -502,11 +502,11 @@ describe "Code gen: closure" do
       foo do |x|
         x &+ a
       end
-      ").to_i.should eq(2)
+      CRYSTAL
   end
 
   it "transforms block to proc literal with free var" do
-    run("
+    run(<<-CRYSTAL).to_i.should eq(10)
       def foo(&block : Int32 -> U) forall U
         block
       end
@@ -515,11 +515,11 @@ describe "Code gen: closure" do
       g = foo { |x| x &+ a }
       h = foo { |x| x.to_f + a }
       (g.call(3) + h.call(5)).to_i!
-      ").to_i.should eq(10)
+      CRYSTAL
   end
 
   it "allows passing block as proc literal to new and to initialize" do
-    run("
+    run(<<-CRYSTAL).to_i.should eq(2)
       class Foo
         def initialize(&block : Int32 -> Float64)
           @block = block
@@ -533,11 +533,11 @@ describe "Code gen: closure" do
       a = 1
       foo = Foo.new { |x| x.to_f! + a }
       foo.block.call(1).to_i!
-      ").to_i.should eq(2)
+      CRYSTAL
   end
 
   it "allows giving less block args when transforming block to proc literal" do
-    run("
+    run(<<-CRYSTAL).to_i.should eq(2)
       def foo(&block : Int32 -> U) forall U
         block.call(1)
       end
@@ -547,11 +547,11 @@ describe "Code gen: closure" do
         1.5 + a
       end
       v.to_i!
-      ").to_i.should eq(2)
+      CRYSTAL
   end
 
   it "allows passing proc literal to def that captures block with &" do
-    run("
+    run(<<-CRYSTAL).to_i.should eq(2)
       def foo(&block : Int32 -> Int32)
         block.call(1)
       end
@@ -559,11 +559,11 @@ describe "Code gen: closure" do
       a = 1
       f = ->(x : Int32) { x &+ a }
       foo &f
-      ").to_i.should eq(2)
+      CRYSTAL
   end
 
   it "allows mixing yield and block.call" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(3)
       def foo(&block : Int32 ->)
         yield 1
         block.call 2
@@ -572,11 +572,11 @@ describe "Code gen: closure" do
       a = 0
       foo { |x| a &+= x }
       a
-      )).to_i.should eq(3)
+      CRYSTAL
   end
 
   it "closures struct self" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(1)
       struct Foo
         def initialize(@x : Int32)
         end
@@ -587,11 +587,11 @@ describe "Code gen: closure" do
       end
 
       Foo.new(1).foo.call
-      )).to_i.should eq(1)
+      CRYSTAL
   end
 
   it "doesn't form a closure if invoking class method" do
-    run(%(
+    run(<<-CRYSTAL).to_b.should be_false
       require "prelude"
 
       class Foo
@@ -604,11 +604,11 @@ describe "Code gen: closure" do
       end
 
       Foo.foo
-      )).to_b.should be_false
+      CRYSTAL
   end
 
   it "doesn't form a closure if invoking class method with self" do
-    run(%(
+    run(<<-CRYSTAL).to_b.should be_false
       require "prelude"
 
       class Foo
@@ -621,11 +621,11 @@ describe "Code gen: closure" do
       end
 
       Foo.foo
-      )).to_b.should be_false
+      CRYSTAL
   end
 
   it "captures block and accesses local variable (#2050)" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(1)
       require "prelude"
 
       def capture(&block)
@@ -637,11 +637,11 @@ describe "Code gen: closure" do
         coco
       end
       coco
-      )).to_i.should eq(1)
+      CRYSTAL
   end
 
   it "codegens closured self in block (#3388)" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(42)
       class Foo
         def initialize(@x : Int32)
         end
@@ -659,11 +659,11 @@ describe "Code gen: closure" do
       foo = Foo.new(42)
       foo2 = foo.foo { }
       foo2.call.x
-      )).to_i.should eq(42)
+      CRYSTAL
   end
 
   it "doesn't incorrectly consider local as closured (#4948)" do
-    codegen(%(
+    codegen(<<-CRYSTAL)
       arg = 1
 
       f1 = ->{
@@ -679,12 +679,12 @@ describe "Code gen: closure" do
       f2 = ->{ local.to_i! }
 
       f1.call &+ f2.call
-    ))
+      CRYSTAL
   end
 
   it "ensures it can raise from the closure check" do
     expect_raises(Exception, "::raise must be of NoReturn return type!") do
-      codegen(%(
+      codegen(<<-CRYSTAL)
         def raise(m : String)
         end
 
@@ -694,12 +694,12 @@ describe "Code gen: closure" do
         value = 1
         p = ->{ value }
         a(p)
-      ))
+        CRYSTAL
     end
   end
 
   it "allows passing an external function along" do
-    codegen(%(
+    codegen(<<-CRYSTAL)
       require "prelude"
 
 
@@ -710,11 +710,11 @@ describe "Code gen: closure" do
       fun b(a : Void* -> Void*)
         LibA.a(a)
       end
-    ))
+      CRYSTAL
   end
 
   it "allows passing an external function along (2)" do
-    codegen(%(
+    codegen(<<-CRYSTAL)
       lib LibFoo
         struct S
           callback : ->
@@ -723,6 +723,6 @@ describe "Code gen: closure" do
 
       s = LibFoo::S.new
       s.callback = nil
-    ))
+      CRYSTAL
   end
 end

--- a/spec/compiler/codegen/const_spec.cr
+++ b/spec/compiler/codegen/const_spec.cr
@@ -10,7 +10,7 @@ describe "Codegen: const" do
   end
 
   it "support constant inside a def" do
-    run("
+    run(<<-CRYSTAL).to_i.should eq(1)
       class Foo
         A = 1
 
@@ -20,11 +20,11 @@ describe "Codegen: const" do
       end
 
       Foo.new.foo
-    ").to_i.should eq(1)
+      CRYSTAL
   end
 
   it "finds nearest constant first" do
-    run("
+    run(<<-CRYSTAL).to_f32.should eq(2.5)
       CONST = 1
 
       class Foo
@@ -36,11 +36,11 @@ describe "Codegen: const" do
       end
 
       Foo.new.foo
-    ").to_f32.should eq(2.5)
+      CRYSTAL
   end
 
   it "allows constants with same name" do
-    run("
+    run(<<-CRYSTAL).to_f32.should eq(2.5)
       CONST = 1
 
       class Foo
@@ -53,18 +53,18 @@ describe "Codegen: const" do
 
       CONST
       Foo.new.foo
-    ").to_f32.should eq(2.5)
+      CRYSTAL
   end
 
   it "constants with expression" do
-    run("
+    run(<<-CRYSTAL).to_i.should eq(2)
       CONST = 1 + 1
       CONST
-    ").to_i.should eq(2)
+      CRYSTAL
   end
 
   it "finds global constant" do
-    run("
+    run(<<-CRYSTAL).to_i.should eq(1)
       CONST = 1
 
       class Foo
@@ -74,7 +74,7 @@ describe "Codegen: const" do
       end
 
       Foo.new.foo
-    ").to_i.should eq(1)
+      CRYSTAL
   end
 
   it "define a constant in lib" do
@@ -86,17 +86,17 @@ describe "Codegen: const" do
   end
 
   it "declare constants in right order" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(2)
       require "prelude"
 
       CONST1 = 1 + 1
       CONST2 = true ? CONST1 : 0
       CONST2
-      )).to_i.should eq(2)
+      CRYSTAL
   end
 
   it "uses correct types lookup" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(1)
       require "prelude"
 
       module Moo
@@ -114,11 +114,11 @@ describe "Codegen: const" do
       end
 
       foo
-      )).to_i.should eq(1)
+      CRYSTAL
   end
 
   it "codegens variable assignment in const" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(1)
       require "prelude"
 
       class Foo
@@ -140,11 +140,11 @@ describe "Codegen: const" do
       end
 
       foo
-      )).to_i.should eq(1)
+      CRYSTAL
   end
 
   it "declaring var" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(1)
       require "prelude"
 
       BAR = begin
@@ -161,13 +161,13 @@ describe "Codegen: const" do
       end
 
       Foo.new.compile
-      )).to_i.should eq(1)
+      CRYSTAL
   end
 
   it "initialize const that might raise an exception" do
-    run("
-      require \"prelude\"
-      CONST = (raise \"OH NO\" if 1 == 2)
+    run(<<-CRYSTAL).to_b.should be_true
+      require "prelude"
+      CONST = (raise "OH NO" if 1 == 2)
 
       def doit
         CONST
@@ -175,11 +175,11 @@ describe "Codegen: const" do
       end
 
       doit.nil?
-    ").to_b.should be_true
+      CRYSTAL
   end
 
   it "allows implicit self in constant, called from another class (bug)" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(1)
       require "prelude"
 
       module Foo
@@ -197,11 +197,11 @@ describe "Codegen: const" do
       end
 
       Bar.new.bar
-      )).to_i.should eq(1)
+      CRYSTAL
   end
 
   it "codegens two consts with same variable name" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(3)
       require "prelude"
 
       CONST1 = begin
@@ -213,11 +213,11 @@ describe "Codegen: const" do
           end
 
       (CONST1 + CONST2).to_i
-      )).to_i.should eq(3)
+      CRYSTAL
   end
 
   it "works with variable declared inside if" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(4)
       require "prelude"
 
       FOO = begin
@@ -229,11 +229,11 @@ describe "Codegen: const" do
         x
       end
       FOO
-      )).to_i.should eq(4)
+      CRYSTAL
   end
 
   it "codegens constant that refers to another constant that is a struct" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(1)
       require "prelude"
 
       struct Foo
@@ -249,11 +249,11 @@ describe "Codegen: const" do
       end
 
       Foo::Y.value
-      )).to_i.should eq(1)
+      CRYSTAL
   end
 
   it "codegens constant that is declared later because of virtual dispatch" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(1)
       class Base
         def base
         end
@@ -276,11 +276,11 @@ describe "Codegen: const" do
       end
 
       MyBase.new.base
-      )).to_i.should eq(1)
+      CRYSTAL
   end
 
   it "doesn't crash if constant is used, but class is never instantiated (#1106)" do
-    codegen(%(
+    codegen(<<-CRYSTAL)
       require "prelude"
 
       class Foo
@@ -292,11 +292,11 @@ describe "Codegen: const" do
       end
 
       ->(x : Foo) { x.foo }
-      ))
+      CRYSTAL
   end
 
   it "uses const before declaring it (hoisting)" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(3)
       require "prelude"
 
       x = CONST
@@ -310,11 +310,11 @@ describe "Codegen: const" do
       end
 
       x
-      )).to_i.should eq(3)
+      CRYSTAL
   end
 
   it "uses const before declaring it in another module" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(3)
       require "prelude"
 
       def foo
@@ -334,42 +334,42 @@ describe "Codegen: const" do
       CONST = foo
 
       x
-      )).to_i.should eq(3)
+      CRYSTAL
   end
 
   it "initializes simple const" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(10)
       FOO = 10
       FOO
-      )).to_i.should eq(10)
+      CRYSTAL
   end
 
   it "initializes simple const via another const" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(10)
       BAR = 10
       FOO = BAR
       FOO
-      )).to_i.should eq(10)
+      CRYSTAL
   end
 
   it "initializes ARGC_UNSAFE" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(0)
       ARGC_UNSAFE
-      )).to_i.should eq(0)
+      CRYSTAL
   end
 
   it "gets pointerof constant" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(10)
       require "prelude"
 
       z = pointerof(FOO).value
       FOO = 10
       z
-      )).to_i.should eq(10)
+      CRYSTAL
   end
 
   it "gets pointerof complex constant" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(10)
       require "prelude"
 
       z = pointerof(FOO).value
@@ -378,11 +378,11 @@ describe "Codegen: const" do
         a
       end
       z
-      )).to_i.should eq(10)
+      CRYSTAL
   end
 
   it "gets pointerof constant inside class" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(42)
       require "prelude"
 
       class Foo
@@ -400,32 +400,32 @@ describe "Codegen: const" do
       end
 
       Foo.new.z
-      )).to_i.should eq(42)
+      CRYSTAL
   end
 
   it "inlines simple const" do
-    mod = codegen(%(
+    mod = codegen(<<-CRYSTAL)
       CONST = 1
       CONST
-      ))
+      CRYSTAL
 
     mod.to_s.should_not contain("CONST")
   end
 
   it "inlines enum value" do
-    mod = codegen(%(
+    mod = codegen(<<-CRYSTAL)
       enum Foo
         CONST
       end
 
       Foo::CONST
-      ))
+      CRYSTAL
 
     mod.to_s.should_not contain("CONST")
   end
 
   it "inlines const with math" do
-    mod = codegen(%(
+    mod = codegen(<<-CRYSTAL)
       struct Int32
         def //(other)
           self
@@ -434,43 +434,43 @@ describe "Codegen: const" do
 
       CONST = (((1 + 2) * 3 &+ 1 &* 3 &- 2) // 2) + 42000
       CONST
-      ))
+      CRYSTAL
     mod.to_s.should_not contain("CONST")
     mod.to_s.should contain("42005")
   end
 
   it "inlines const referencing another const" do
-    mod = codegen(%(
+    mod = codegen(<<-CRYSTAL)
       OTHER = 1
 
       CONST = OTHER
       CONST
-      ))
+      CRYSTAL
 
     mod.to_s.should_not contain("CONST")
     mod.to_s.should_not contain("OTHER")
   end
 
   it "inlines bool const" do
-    mod = codegen(%(
+    mod = codegen(<<-CRYSTAL)
       CONST = true
       CONST
-      ))
+      CRYSTAL
 
     mod.to_s.should_not contain("CONST")
   end
 
   it "inlines char const" do
-    mod = codegen(%(
+    mod = codegen(<<-CRYSTAL)
       CONST = 'a'
       CONST
-      ))
+      CRYSTAL
 
     mod.to_s.should_not contain("CONST")
   end
 
   it "synchronizes initialization of constants" do
-    run(%(
+    run(<<-CRYSTAL).to_b.should be_true
       require "prelude"
 
       def foo
@@ -504,11 +504,11 @@ describe "Codegen: const" do
       end
 
       test(ch)
-    )).to_b.should be_true
+      CRYSTAL
   end
 
   it "runs const side effects (#8862)" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(6)
       require "prelude"
 
       class Foo
@@ -531,11 +531,11 @@ describe "Codegen: const" do
       end
 
       a &+ Foo.x
-      )).to_i.should eq(6)
+      CRYSTAL
   end
 
   it "supports closured vars inside initializers (#10474)" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(3)
       class Foo
         def bar
           3
@@ -554,11 +554,11 @@ describe "Codegen: const" do
       end
 
       CONST
-      )).to_i.should eq(3)
+      CRYSTAL
   end
 
   it "supports storing function returning nil" do
-    run(%(
+    run(<<-CRYSTAL).to_b.should be_true
       def foo
         "foo"
         nil
@@ -566,6 +566,6 @@ describe "Codegen: const" do
 
       CONST = foo
       CONST.nil?
-      )).to_b.should be_true
+      CRYSTAL
   end
 end

--- a/spec/compiler/codegen/debug_spec.cr
+++ b/spec/compiler/codegen/debug_spec.cr
@@ -2,7 +2,7 @@ require "../../spec_helper"
 
 describe "Code gen: debug" do
   it "codegens abstract struct (#3578)" do
-    codegen(%(
+    codegen(<<-CRYSTAL, debug: Crystal::Debug::All)
       abstract struct Base
       end
 
@@ -13,7 +13,7 @@ describe "Code gen: debug" do
       end
 
       x = Foo.new || Bar.new
-      ), debug: Crystal::Debug::All)
+      CRYSTAL
   end
 
   it "codegens lib union (#7335)" do
@@ -44,7 +44,7 @@ describe "Code gen: debug" do
   end
 
   it "inlines instance var access through getter in debug mode" do
-    run(%(
+    run(<<-CRYSTAL, debug: Crystal::Debug::All, filename: "foo.cr").to_i.should eq(2)
       struct Bar
         @x = 1
 
@@ -72,11 +72,11 @@ describe "Code gen: debug" do
       foo = Foo.new
       foo.set
       foo.bar.x
-      ), debug: Crystal::Debug::All, filename: "foo.cr").to_i.should eq(2)
+      CRYSTAL
   end
 
   it "codegens correct debug info for untyped expression (#4007 and #4008)" do
-    codegen(%(
+    codegen(<<-CRYSTAL, debug: Crystal::Debug::All)
       require "prelude"
 
       int = 3
@@ -88,11 +88,11 @@ describe "Code gen: debug" do
       else
           puts int
       end
-      ), debug: Crystal::Debug::All)
+      CRYSTAL
   end
 
   it "codegens correct debug info for new with custom allocate (#3945)" do
-    codegen(%(
+    codegen(<<-CRYSTAL, debug: Crystal::Debug::All)
       class Foo
         def initialize
         end
@@ -103,11 +103,11 @@ describe "Code gen: debug" do
       end
 
       Foo.new
-      ), debug: Crystal::Debug::All)
+      CRYSTAL
   end
 
   it "correctly restores debug location after fun change (#4254)" do
-    codegen(%(
+    codegen(<<-CRYSTAL, debug: Crystal::Debug::All)
       require "prelude"
 
       class Foo
@@ -129,11 +129,11 @@ describe "Code gen: debug" do
       TWO = Foo.new
 
       ONE.three
-      ), debug: Crystal::Debug::All)
+      CRYSTAL
   end
 
   it "has correct debug location after constant initialization in call with block (#4719)" do
-    codegen(%(
+    codegen(<<-CRYSTAL, debug: Crystal::Debug::All)
       require "prelude"
 
       fun __crystal_malloc_atomic(size : UInt32) : Void*
@@ -155,11 +155,11 @@ describe "Code gen: debug" do
       Bar.new { }
 
       A
-      ), debug: Crystal::Debug::All)
+      CRYSTAL
   end
 
   it "has debug info in closure inside if (#5593)" do
-    codegen(%(
+    codegen(<<-CRYSTAL, debug: Crystal::Debug::All)
       def foo
         if true && true
           yield 1
@@ -175,11 +175,11 @@ describe "Code gen: debug" do
           i
         end
       end
-      ), debug: Crystal::Debug::All)
+      CRYSTAL
   end
 
   it "doesn't emit incorrect debug info for closured self" do
-    codegen(%(
+    codegen(<<-CRYSTAL, debug: Crystal::Debug::All)
       def foo(&block : Int32 ->)
         block.call(1)
       end
@@ -193,17 +193,17 @@ describe "Code gen: debug" do
       end
 
       Foo.new.bar
-      ), debug: Crystal::Debug::All)
+      CRYSTAL
   end
 
   it "doesn't emit debug info for unused variable declarations (#9882)" do
-    codegen(%(
+    codegen(<<-CRYSTAL, debug: Crystal::Debug::All)
       x : Int32
-      ), debug: Crystal::Debug::All)
+      CRYSTAL
   end
 
   it "stores and restores debug location after jumping to main (#6920)" do
-    codegen(%(
+    codegen(<<-CRYSTAL, debug: Crystal::Debug::All)
       require "prelude"
 
       Module.method
@@ -219,11 +219,11 @@ describe "Code gen: debug" do
           @@x
         end
       end
-      ), debug: Crystal::Debug::All)
+      CRYSTAL
   end
 
   it "stores and restores debug location after jumping to main (2)" do
-    codegen(%(
+    codegen(<<-CRYSTAL, debug: Crystal::Debug::All)
       module Foo
         @@x : Int32 = begin
           y = 1
@@ -235,11 +235,11 @@ describe "Code gen: debug" do
       end
 
       Foo.x
-      ), debug: Crystal::Debug::All)
+      CRYSTAL
   end
 
   it "stores and restores debug location after jumping to main (3)" do
-    codegen(%(
+    codegen(<<-CRYSTAL, debug: Crystal::Debug::All)
       def raise(exception)
         x = uninitialized NoReturn
         x
@@ -250,11 +250,11 @@ describe "Code gen: debug" do
       end
 
       LibFoo.foo = ->{ }
-      ), debug: Crystal::Debug::All)
+      CRYSTAL
   end
 
   it "doesn't fail on constant read calls (#11416)" do
-    codegen(%(
+    codegen(<<-CRYSTAL, debug: Crystal::Debug::All)
       require "prelude"
 
       class Foo
@@ -269,11 +269,11 @@ describe "Code gen: debug" do
       THE_FOO.foo
 
       THE_FOO = a_foo
-      ), debug: Crystal::Debug::All)
+      CRYSTAL
   end
 
   it "doesn't fail on splat expansions inside array-like literals" do
-    run(%(
+    run(<<-CRYSTAL, debug: Crystal::Debug::All).to_i.should eq(123)
       require "prelude"
 
       class Foo
@@ -299,7 +299,7 @@ describe "Code gen: debug" do
       x = Foo.new
       y = Bar{*x}
       y.bar
-      ), debug: Crystal::Debug::All).to_i.should eq(123)
+      CRYSTAL
   end
 
   {% unless LibLLVM::IS_LT_210 %}

--- a/spec/compiler/codegen/def_default_value_spec.cr
+++ b/spec/compiler/codegen/def_default_value_spec.cr
@@ -2,17 +2,17 @@ require "../../spec_helper"
 
 describe "Code gen: def with default value" do
   it "codegens def with one default value" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(1)
       def foo(x = 1)
         x
       end
 
       foo
-      )).to_i.should eq(1)
+      CRYSTAL
   end
 
   it "codegens def new with one default value" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(1)
       class Foo
         def initialize(@x = 1)
         end
@@ -23,11 +23,11 @@ describe "Code gen: def with default value" do
       end
 
       Foo.new.x
-      )).to_i.should eq(1)
+      CRYSTAL
   end
 
   it "considers first the one with more arguments" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(2)
       def foo(x, y = 1)
         1
       end
@@ -37,11 +37,11 @@ describe "Code gen: def with default value" do
       end
 
       foo 1, "hello"
-      )).to_i.should eq(2)
+      CRYSTAL
   end
 
   it "considers first the one with a restriction" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(1)
       def foo(x : String, y = "")
         1
       end
@@ -51,7 +51,7 @@ describe "Code gen: def with default value" do
       end
 
       foo "hello"
-      )).to_i.should eq(1)
+      CRYSTAL
   end
 
   it "doesn't mix types of instance vars with initialize and new" do

--- a/spec/compiler/codegen/double_splat_spec.cr
+++ b/spec/compiler/codegen/double_splat_spec.cr
@@ -2,62 +2,62 @@ require "../../spec_helper"
 
 describe "Codegen: double splat" do
   it "double splats named argument into arguments (1)" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(32 - 10)
       def foo(x, y)
         x &- y
       end
 
       tup = {x: 32, y: 10}
       foo **tup
-      )).to_i.should eq(32 - 10)
+      CRYSTAL
   end
 
   it "double splats named argument into arguments (2)" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(32 - 10)
       def foo(x, y)
         x &- y
       end
 
       tup = {y: 10, x: 32}
       foo **tup
-      )).to_i.should eq(32 - 10)
+      CRYSTAL
   end
 
   it "double splats named argument with positional arguments" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(1000 - 20*30)
       def foo(x, y, z)
         x &- y &* z
       end
 
       tup = {y: 20, z: 30}
       foo 1000, **tup
-      )).to_i.should eq(1000 - 20*30)
+      CRYSTAL
   end
 
   it "double splats named argument with named args (1)" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(1000 - 20*30)
       def foo(x, y, z)
         x &- y &* z
       end
 
       tup = {x: 1000, z: 30}
       foo **tup, y: 20
-      )).to_i.should eq(1000 - 20*30)
+      CRYSTAL
   end
 
   it "double splats named argument with named args (2)" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(1000 - 20*30)
       def foo(x, y, z)
         x &- y &* z
       end
 
       tup = {z: 30}
       foo **tup, x: 1000, y: 20
-      )).to_i.should eq(1000 - 20*30)
+      CRYSTAL
   end
 
   it "double splats twice " do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq((1000 - 20*30) * 40)
       def foo(x, y, z, w)
         (x &- y &* z) &* w
       end
@@ -65,41 +65,41 @@ describe "Codegen: double splat" do
       tup1 = {x: 1000, z: 30}
       tup2 = {y: 20, w: 40}
       foo **tup2, **tup1
-      )).to_i.should eq((1000 - 20*30) * 40)
+      CRYSTAL
   end
 
   it "matches double splat on method with named args" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(7)
       def foo(**options)
         options[:x] &- options[:y]
       end
 
       foo x: 10, y: 3
-      )).to_i.should eq(7)
+      CRYSTAL
   end
 
   it "matches double splat on method with named args and regular args" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(1000 - 20*30)
       def foo(x, **args)
         x &- args[:y] &* args[:z]
       end
 
       foo y: 20, z: 30, x: 1000
-      )).to_i.should eq(1000 - 20*30)
+      CRYSTAL
   end
 
   it "matches double splat with regular splat" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq((1000 - 20*30) * 40)
       def foo(*args, **options)
         (args[0] &- args[1] &* options[:z]) &* options[:w]
       end
 
       foo 1000, 20, z: 30, w: 40
-      )).to_i.should eq((1000 - 20*30) * 40)
+      CRYSTAL
   end
 
   it "evaluates double splat argument just once (#2677)" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(1)
       class Global
         @@x = 0
 
@@ -122,11 +122,11 @@ describe "Codegen: double splat" do
       test(**data)
 
       Global.x
-      )).to_i.should eq(1)
+      CRYSTAL
   end
 
   it "removes literal types in all matches (#6239)" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(2)
       def foo(y : Float64)
         y.to_i!
       end
@@ -136,6 +136,6 @@ describe "Codegen: double splat" do
       end
 
       bar(x: 1, y: 2.0)
-      )).to_i.should eq(2)
+      CRYSTAL
   end
 end

--- a/spec/compiler/codegen/enum_spec.cr
+++ b/spec/compiler/codegen/enum_spec.cr
@@ -2,17 +2,17 @@ require "../../spec_helper"
 
 describe "Code gen: enum" do
   it "codegens enum" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(1)
       enum Foo
         A = 1
       end
 
       Foo::A
-      )).to_i.should eq(1)
+      CRYSTAL
   end
 
   it "codegens enum without explicit value" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(2)
       enum Foo
         A
         B
@@ -20,43 +20,43 @@ describe "Code gen: enum" do
       end
 
       Foo::C
-      )).to_i.should eq(2)
+      CRYSTAL
   end
 
   it "codegens enum value" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(1)
       enum Foo
         A = 1
       end
 
       Foo::A.value
-      )).to_i.should eq(1)
+      CRYSTAL
   end
 
   it "creates enum from value" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(1)
       enum Foo
         A
         B
       end
 
       Foo.new(1).value
-      )).to_i.should eq(1)
+      CRYSTAL
   end
 
   it "codegens enum bitflags (1)" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(1)
       @[Flags]
       enum Foo
         A
       end
 
       Foo::A
-      )).to_i.should eq(1)
+      CRYSTAL
   end
 
   it "codegens enum bitflags (2)" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(2)
       @[Flags]
       enum Foo
         A
@@ -64,11 +64,11 @@ describe "Code gen: enum" do
       end
 
       Foo::B
-      )).to_i.should eq(2)
+      CRYSTAL
   end
 
   it "codegens enum bitflags (4)" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(4)
       @[Flags]
       enum Foo
         A
@@ -77,22 +77,22 @@ describe "Code gen: enum" do
       end
 
       Foo::C
-      )).to_i.should eq(4)
+      CRYSTAL
   end
 
   it "codegens enum bitflags None" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(0)
       @[Flags]
       enum Foo
         A
       end
 
       Foo::None
-      )).to_i.should eq(0)
+      CRYSTAL
   end
 
   it "codegens enum bitflags All" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(1 + 2 + 4)
       @[Flags]
       enum Foo
         A
@@ -101,11 +101,11 @@ describe "Code gen: enum" do
       end
 
       Foo::All
-      )).to_i.should eq(1 + 2 + 4)
+      CRYSTAL
   end
 
   it "codegens enum None redefined" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(10)
       lib Lib
         @[Flags]
         enum Foo
@@ -115,11 +115,11 @@ describe "Code gen: enum" do
       end
 
       Lib::Foo::None
-      )).to_i.should eq(10)
+      CRYSTAL
   end
 
   it "codegens enum All redefined" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(10)
       lib Lib
         @[Flags]
         enum Foo
@@ -129,11 +129,11 @@ describe "Code gen: enum" do
       end
 
       Lib::Foo::All
-      )).to_i.should eq(10)
+      CRYSTAL
   end
 
   it "allows class vars in enum" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(1)
       enum Foo
         A
 
@@ -145,11 +145,11 @@ describe "Code gen: enum" do
       end
 
       Foo.class_var
-      )).to_i.should eq(1)
+      CRYSTAL
   end
 
   it "automatically defines question method for each enum member (false case)" do
-    run(%(
+    run(<<-CRYSTAL).to_b.should be_false
       struct Enum
         def ==(other : self)
           value == other.value
@@ -163,11 +163,11 @@ describe "Code gen: enum" do
 
       day = Day::SomeTuesday
       day.some_monday?
-      )).to_b.should be_false
+      CRYSTAL
   end
 
   it "automatically defines question method for each enum member (true case)" do
-    run(%(
+    run(<<-CRYSTAL).to_b.should be_true
       struct Enum
         def ==(other : self)
           value == other.value
@@ -181,11 +181,11 @@ describe "Code gen: enum" do
 
       day = Day::SomeTuesday
       day.some_tuesday?
-      )).to_b.should be_true
+      CRYSTAL
   end
 
   it "automatically defines question method for each enum member (flags, false case)" do
-    run(%(
+    run(<<-CRYSTAL).to_b.should be_false
       struct Enum
         def includes?(other : self)
           (value & other.value) != 0
@@ -201,11 +201,11 @@ describe "Code gen: enum" do
 
       day = Day.new(3)
       day.some_wednesday?
-      )).to_b.should be_false
+      CRYSTAL
   end
 
   it "automatically defines question method for each enum member (flags, true case)" do
-    run(%(
+    run(<<-CRYSTAL).to_b.should be_true
       struct Enum
         def includes?(other : self)
           (value & other.value) != 0
@@ -221,21 +221,21 @@ describe "Code gen: enum" do
 
       day = Day.new(3)
       day.some_tuesday?
-      )).to_b.should be_true
+      CRYSTAL
   end
 
   it "does ~ at compile time for enum member" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(~1)
       enum Foo
         Bar = ~1
       end
 
       Foo::Bar.value
-      )).to_i.should eq(~1)
+      CRYSTAL
   end
 
   it "uses enum value before declaration (hoisting)" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(1)
       x = Bar.bar
 
       enum Foo
@@ -249,11 +249,11 @@ describe "Code gen: enum" do
       end
 
       x
-      )).to_i.should eq(1)
+      CRYSTAL
   end
 
   it "casts All value to base type" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(-1073741824)
       @[Flags]
       enum Foo
         A = 1 << 30
@@ -261,11 +261,11 @@ describe "Code gen: enum" do
       end
 
       Foo::All.value
-      )).to_i.should eq(-1073741824)
+      CRYSTAL
   end
 
   it "can use macro calls inside enum value (#424)" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(30)
       enum Foo
         macro bar
           10 + 20
@@ -275,11 +275,11 @@ describe "Code gen: enum" do
       end
 
       Foo::A.value
-      )).to_i.should eq(30)
+      CRYSTAL
   end
 
   it "can use macro calls inside enum value, macro defined outside enum (#424)" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(30)
       macro bar
         10 + 20
       end
@@ -289,11 +289,11 @@ describe "Code gen: enum" do
       end
 
       Foo::A.value
-      )).to_i.should eq(30)
+      CRYSTAL
   end
 
   it "can use macro calls inside enum value, with receiver (#424)" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(30)
       module Moo
         macro bar
           10 + 20
@@ -305,11 +305,11 @@ describe "Code gen: enum" do
       end
 
       Foo::A.value
-      )).to_i.should eq(30)
+      CRYSTAL
   end
 
   it "adds a none? method to flags enum" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(1)
       @[Flags]
       enum Foo
         A
@@ -320,11 +320,11 @@ describe "Code gen: enum" do
       x &+= 1 if Foo::None.none?
       x &+= 2 if Foo::A.none?
       x
-      )).to_i.should eq(1)
+      CRYSTAL
   end
 
   it "can redefine Enum.new and use previous_def" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(2)
       enum Foo
         FOO = 1
         BAR = 2
@@ -335,7 +335,7 @@ describe "Code gen: enum" do
       end
 
       Foo.new(1)
-      )).to_i.should eq(2)
+      CRYSTAL
   end
 
   it "can define flags enum : UInt64 with more than 32 values (#7268)" do
@@ -361,7 +361,7 @@ describe "Code gen: enum" do
   end
 
   it "can define flags enum : UInt128 with compile-time interpreted values" do
-    run(%(
+    run(<<-CRYSTAL).to_u64.should eq(1 << 6)
       enum Foo : UInt128
         A = 1_u128 << 6
         B = 1_u128 << 20
@@ -369,6 +369,6 @@ describe "Code gen: enum" do
       end
 
       Foo::A.value.to_u64!
-      )).to_u64.should eq(1 << 6)
+      CRYSTAL
   end
 end

--- a/spec/compiler/codegen/enum_spec.cr
+++ b/spec/compiler/codegen/enum_spec.cr
@@ -339,25 +339,25 @@ describe "Code gen: enum" do
   end
 
   it "can define flags enum : UInt64 with more than 32 values (#7268)" do
-    run(%(
+    run(<<-CRYSTAL).to_u64.should eq(1_u64 << 32)
       @[Flags]
       enum Foo : UInt64
         #{Array.new(33) { |i| "V#{i + 1}" }.join "\n"}
       end
 
       Foo::V33.value
-      )).to_u64.should eq(1_u64 << 32)
+      CRYSTAL
   end
 
   it "can define flags enum : UInt128 with 128 values" do
-    run(%(
+    run(<<-CRYSTAL).to_u64.should eq(1_u64 << 63)
       @[Flags]
       enum Foo : UInt128
         #{Array.new(128) { |i| "V#{i + 1}" }.join "\n"}
       end
 
       Foo::V64.value.to_u64!
-      )).to_u64.should eq(1_u64 << 63)
+      CRYSTAL
   end
 
   it "can define flags enum : UInt128 with compile-time interpreted values" do

--- a/spec/compiler/codegen/exception_spec.cr
+++ b/spec/compiler/codegen/exception_spec.cr
@@ -2,7 +2,7 @@ require "../../spec_helper"
 
 describe "Code gen: exception" do
   it "codegens rescue specific leaf exception" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(1)
       require "prelude"
 
       class Foo < Exception
@@ -22,11 +22,11 @@ describe "Code gen: exception" do
       rescue ex : Foo
         bar(ex)
       end
-      )).to_i.should eq(1)
+      CRYSTAL
   end
 
   it "codegens exception handler with return" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(1)
       require "prelude"
 
       def foo
@@ -38,11 +38,11 @@ describe "Code gen: exception" do
       end
 
       foo
-      )).to_i.should eq(1)
+      CRYSTAL
   end
 
   it "does ensure after rescue which returns (#171)" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(2)
       require "prelude"
 
       class Global
@@ -68,11 +68,11 @@ describe "Code gen: exception" do
       foo
 
       Global.x
-      )).to_i.should eq(2)
+      CRYSTAL
   end
 
   it "executes body if nothing raised (1)" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(3)
       require "prelude"
 
       y = 1
@@ -82,11 +82,11 @@ describe "Code gen: exception" do
             y = 10
           end
       x + y
-      )).to_i.should eq(3)
+      CRYSTAL
   end
 
   it "executes rescue if something is raised conditionally" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(8)
       require "prelude"
 
       y = 1
@@ -99,11 +99,11 @@ describe "Code gen: exception" do
             y = 4
           end
       x + y
-      )).to_i.should eq(8)
+      CRYSTAL
   end
 
   it "executes rescue if something is raised unconditionally" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(6)
       require "prelude"
 
       y = 1
@@ -115,11 +115,11 @@ describe "Code gen: exception" do
             y = 3
           end
       x + y
-      )).to_i.should eq(6)
+      CRYSTAL
   end
 
   it "can result into union (1)" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(1)
       require "prelude"
 
       x = begin
@@ -128,11 +128,11 @@ describe "Code gen: exception" do
             2.1
           end
       x.to_i
-      )).to_i.should eq(1)
+      CRYSTAL
   end
 
   it "can result into union (2)" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(2)
       require "prelude"
 
       y = begin
@@ -141,11 +141,11 @@ describe "Code gen: exception" do
             2.1
           end
       y.to_i
-    )).to_i.should eq(2)
+      CRYSTAL
   end
 
   it "handles nested exceptions" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(3)
       require "prelude"
 
       a = 0
@@ -161,11 +161,11 @@ describe "Code gen: exception" do
           end
 
       a + b
-      )).to_i.should eq(3)
+      CRYSTAL
   end
 
   it "executes ensure when no exception is raised (1)" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(10)
       require "prelude"
 
       a = 0
@@ -177,11 +177,11 @@ describe "Code gen: exception" do
             a = 10
           end
       a
-      )).to_i.should eq(10)
+      CRYSTAL
   end
 
   it "executes ensure when no exception is raised (2)" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(1)
       require "prelude"
 
       a = 0
@@ -193,11 +193,11 @@ describe "Code gen: exception" do
             a = 10
           end
       b
-      )).to_i.should eq(1)
+      CRYSTAL
   end
 
   it "executes ensure when exception is raised (1)" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(2)
       require "prelude"
 
       a = 0
@@ -210,11 +210,11 @@ describe "Code gen: exception" do
             a = 2
           end
       a
-      )).to_i.should eq(2)
+      CRYSTAL
   end
 
   it "executes ensure when exception is raised (2)" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(3)
       require "prelude"
 
       a = 0
@@ -227,11 +227,11 @@ describe "Code gen: exception" do
             a = 2
           end
       b
-      )).to_i.should eq(3)
+      CRYSTAL
   end
 
   it "executes ensure when exception is unhandled (1)" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(3)
       require "prelude"
 
       class Ex1 < Exception; end
@@ -250,11 +250,11 @@ describe "Code gen: exception" do
             4
           end
       a
-      )).to_i.should eq(3)
+      CRYSTAL
   end
 
   it "executes ensure when exception is unhandled (2)" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(4)
       require "prelude"
 
       class Ex1 < Exception; end
@@ -273,11 +273,11 @@ describe "Code gen: exception" do
             4
           end
       b
-      )).to_i.should eq(4)
+      CRYSTAL
   end
 
   it "ensure without rescue" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(1)
       require "prelude"
 
       a = 0
@@ -291,11 +291,11 @@ describe "Code gen: exception" do
       end
 
       a
-      )).to_i.should eq(1)
+      CRYSTAL
   end
 
   it "executes ensure when the main block returns" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(0)
       require "prelude"
 
       struct Nil; def to_i; 0; end; end
@@ -310,11 +310,11 @@ describe "Code gen: exception" do
 
       x = 0
       foo(pointerof(x)).to_i
-      )).to_i.should eq(0)
+      CRYSTAL
   end
 
   it "executes ensure when the main block returns" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(1)
       require "prelude"
 
       def foo(x)
@@ -328,11 +328,11 @@ describe "Code gen: exception" do
       x = 0
       foo(pointerof(x))
       x
-      )).to_i.should eq(1)
+      CRYSTAL
   end
 
   it "executes ensure when the main block yields and returns" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(1)
       require "prelude"
 
       def foo2(x)
@@ -352,11 +352,11 @@ describe "Code gen: exception" do
       x = 0
       bar2(pointerof(x))
       x
-      )).to_i.should eq(1)
+      CRYSTAL
   end
 
   it "rescues with type" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(2)
       require "prelude"
 
       class Ex1 < Exception; end
@@ -371,11 +371,11 @@ describe "Code gen: exception" do
           end
 
       a
-      )).to_i.should eq(2)
+      CRYSTAL
   end
 
   it "rescues with types defaults to generic rescue" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(3)
       require "prelude"
 
       class Ex1 < Exception; end
@@ -392,11 +392,11 @@ describe "Code gen: exception" do
           end
 
       a
-      )).to_i.should eq(3)
+      CRYSTAL
   end
 
   it "handles exception in outer block (1)" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(2)
       require "prelude"
 
       class Ex1 < Exception; end
@@ -415,11 +415,11 @@ describe "Code gen: exception" do
           end
 
       x
-      )).to_i.should eq(2)
+      CRYSTAL
   end
 
   it "handles exception in outer block (2)" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(0)
       require "prelude"
 
       class Ex1 < Exception; end
@@ -438,11 +438,11 @@ describe "Code gen: exception" do
           end
 
       p
-      )).to_i.should eq(0)
+      CRYSTAL
   end
 
   it "handles subclass" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(1)
       require "prelude"
 
       class Ex1 < Exception; end
@@ -456,11 +456,11 @@ describe "Code gen: exception" do
         x = 1
       end
       x
-      )).to_i.should eq(1)
+      CRYSTAL
   end
 
   it "handle multiple exception types (1)" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(1)
       require "prelude"
 
       class Ex1 < Exception; end
@@ -473,11 +473,11 @@ describe "Code gen: exception" do
         x = 1
       end
       x
-      )).to_i.should eq(1)
+      CRYSTAL
   end
 
   it "handle multiple exception types (2)" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(1)
       require "prelude"
 
       class Ex1 < Exception; end
@@ -490,11 +490,11 @@ describe "Code gen: exception" do
         x = 1
       end
       x
-      )).to_i.should eq(1)
+      CRYSTAL
   end
 
   it "receives exception object" do
-    run(%(
+    run(<<-CRYSTAL).to_string.should eq("Ex1")
       require "prelude"
 
       class Ex1 < Exception
@@ -511,11 +511,11 @@ describe "Code gen: exception" do
       end
 
       x
-      )).to_string.should eq("Ex1")
+      CRYSTAL
   end
 
   it "executes else if no exception is raised (1)" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(3)
       require "prelude"
 
       x = 1
@@ -526,11 +526,11 @@ describe "Code gen: exception" do
             x = 3
           end
       x
-      )).to_i.should eq(3)
+      CRYSTAL
   end
 
   it "executes else if no exception is raised (2)" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(3)
       require "prelude"
 
       x = 1
@@ -541,11 +541,11 @@ describe "Code gen: exception" do
             x = 3
           end
       y
-      )).to_i.should eq(3)
+      CRYSTAL
   end
 
   it "doesn't execute else if exception is raised (1)" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(2)
       require "prelude"
 
       class Ex1 < Exception; end
@@ -559,11 +559,11 @@ describe "Code gen: exception" do
             x = 3
           end
       x
-      )).to_i.should eq(2)
+      CRYSTAL
   end
 
   it "doesn't execute else if exception is raised (2)" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(2)
       require "prelude"
 
       class Ex1 < Exception; end
@@ -577,11 +577,11 @@ describe "Code gen: exception" do
             x = 3
           end
       y
-      )).to_i.should eq(2)
+      CRYSTAL
   end
 
   it "doesn't execute else if exception is raised conditionally (1)" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(2)
       require "prelude"
 
       class Ex1 < Exception; end
@@ -595,11 +595,11 @@ describe "Code gen: exception" do
             x = 3
           end
       x
-      )).to_i.should eq(2)
+      CRYSTAL
   end
 
   it "doesn't execute else if exception is raised conditionally (2)" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(2)
       require "prelude"
 
       class Ex1 < Exception; end
@@ -613,11 +613,11 @@ describe "Code gen: exception" do
             x = 3
           end
       y
-      )).to_i.should eq(2)
+      CRYSTAL
   end
 
   it "handle exception raised by proc literal" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(1)
       require "prelude"
 
       x = 0
@@ -628,11 +628,11 @@ describe "Code gen: exception" do
         x = 1
       end
       x
-      )).to_i.should eq(1)
+      CRYSTAL
   end
 
   it "codegens issue #118 (1)" do
-    codegen(%(
+    codegen(<<-CRYSTAL)
       require "prelude"
 
       begin
@@ -641,11 +641,11 @@ describe "Code gen: exception" do
       ensure
         p n
       end
-      ))
+      CRYSTAL
   end
 
   it "codegens issue #118 (2)" do
-    codegen(%(
+    codegen(<<-CRYSTAL)
       require "prelude"
 
       n = nil
@@ -655,11 +655,11 @@ describe "Code gen: exception" do
       ensure
         p n
       end
-      ))
+      CRYSTAL
   end
 
   it "captures exception thrown from proc" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(2)
       require "prelude"
 
       def foo
@@ -673,11 +673,11 @@ describe "Code gen: exception" do
         a = 2
       end
       a
-      )).to_i.should eq(2)
+      CRYSTAL
   end
 
   it "uses exception after rescue" do
-    run(%(
+    run(<<-CRYSTAL).to_string.should eq("OH NO")
       require "prelude"
 
       begin
@@ -685,11 +685,11 @@ describe "Code gen: exception" do
       rescue ex
       end
       ex.not_nil!.message
-      )).to_string.should eq("OH NO")
+      CRYSTAL
   end
 
   it "doesn't codegen duplicated ensure if unreachable (#709)" do
-    codegen(%(
+    codegen(<<-CRYSTAL)
       require "prelude"
 
       class Foo
@@ -707,11 +707,11 @@ describe "Code gen: exception" do
         end
       ensure
       end
-      ))
+      CRYSTAL
   end
 
   it "executes ensure when raising inside rescue" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(2)
       require "prelude"
 
       a = 1
@@ -728,11 +728,11 @@ describe "Code gen: exception" do
       end
 
       a
-      )).to_i.should eq(2)
+      CRYSTAL
   end
 
   it "executes ensure of break inside while inside body" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(123)
       require "prelude"
 
       a = 0
@@ -744,11 +744,11 @@ describe "Code gen: exception" do
         end
       end
       a
-      )).to_i.should eq(123)
+      CRYSTAL
   end
 
   it "executes ensure of break inside while inside body with nested handlers" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(1)
       require "prelude"
 
       a = 0
@@ -766,11 +766,11 @@ describe "Code gen: exception" do
         a += 1
       end
       b
-      )).to_i.should eq(1)
+      CRYSTAL
   end
 
   it "executes ensure of break inside while inside body with block" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(0)
       require "prelude"
 
       class Global
@@ -808,11 +808,11 @@ describe "Code gen: exception" do
       end
 
       Global.b
-      )).to_i.should eq(0)
+      CRYSTAL
   end
 
   it "executes ensure of break inside while inside rescue" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(123)
       require "prelude"
 
       a = 0
@@ -826,11 +826,11 @@ describe "Code gen: exception" do
         end
       end
       a
-      )).to_i.should eq(123)
+      CRYSTAL
   end
 
   it "executes ensure of break inside while inside else" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(123)
       require "prelude"
 
       a = 0
@@ -844,11 +844,11 @@ describe "Code gen: exception" do
         end
       end
       a
-      )).to_i.should eq(123)
+      CRYSTAL
   end
 
   it "executes ensure of next inside while inside body" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(123)
       require "prelude"
 
       a = 0
@@ -862,11 +862,11 @@ describe "Code gen: exception" do
         end
       end
       a
-      )).to_i.should eq(123)
+      CRYSTAL
   end
 
   it "executes return inside rescue, executing ensure" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(2)
       require "prelude"
 
       class Global
@@ -896,11 +896,11 @@ describe "Code gen: exception" do
       foo
 
       Global.x
-      )).to_i.should eq(2)
+      CRYSTAL
   end
 
   it "executes ensure from return until target" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(1)
       require "prelude"
 
       def foo
@@ -917,11 +917,11 @@ describe "Code gen: exception" do
       end
 
       a
-      )).to_i.should eq(1)
+      CRYSTAL
   end
 
   it "executes ensure from return until target" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(2)
       require "prelude"
 
       class Global
@@ -956,11 +956,11 @@ describe "Code gen: exception" do
       bar
 
       Global.x
-      )).to_i.should eq(2)
+      CRYSTAL
   end
 
   it "executes ensure of next inside block" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(1)
       require "prelude"
 
       def foo
@@ -984,11 +984,11 @@ describe "Code gen: exception" do
       end
 
       b
-      )).to_i.should eq(1)
+      CRYSTAL
   end
 
   it "executes ensure of next inside block" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(1)
       require "prelude"
 
       class Global
@@ -1032,11 +1032,11 @@ describe "Code gen: exception" do
       end
 
       Global.b
-      )).to_i.should eq(1)
+      CRYSTAL
   end
 
   it "executes ensure of break inside block" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(1)
       require "prelude"
 
       def foo
@@ -1060,11 +1060,11 @@ describe "Code gen: exception" do
       end
 
       b
-      )).to_i.should eq(1)
+      CRYSTAL
   end
 
   it "executes ensure of calling method when doing break inside block (#1233)" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(123)
       require "prelude"
 
       class Global
@@ -1089,11 +1089,11 @@ describe "Code gen: exception" do
       end
 
       Global.x
-      )).to_i.should eq(123)
+      CRYSTAL
   end
 
   it "propagates raise status (#2074)" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(2)
       require "prelude"
 
       class Foo
@@ -1133,11 +1133,11 @@ describe "Code gen: exception" do
         a = 2
       end
       a
-      )).to_i.should eq(2)
+      CRYSTAL
   end
 
   it "doesn't crash on #1988" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(42)
       require "prelude"
 
       begin
@@ -1150,11 +1150,11 @@ describe "Code gen: exception" do
       else
         21
       end
-      )).to_i.should eq(42)
+      CRYSTAL
   end
 
   it "runs #2441" do
-    run(%(
+    run(<<-CRYSTAL).to_string.should eq("foo")
       require "prelude"
 
       while true
@@ -1166,11 +1166,11 @@ describe "Code gen: exception" do
       end
 
       ex.not_nil!.message.to_s
-      )).to_string.should eq("foo")
+      CRYSTAL
   end
 
   it "can rescue TypeCastError (#2607)" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(42)
       require "prelude"
 
       begin
@@ -1181,11 +1181,11 @@ describe "Code gen: exception" do
       rescue e : Exception
         0
       end
-      )).to_i.should eq(42)
+      CRYSTAL
   end
 
   it "can use argument in rescue (#2844)" do
-    run(%(
+    run(<<-CRYSTAL).to_string.should eq("foo")
       require "prelude"
 
       def foo(exe)
@@ -1199,11 +1199,11 @@ describe "Code gen: exception" do
       ex = Exception.new("foo")
       ex = foo(ex)
       ex.message.not_nil!
-      )).to_string.should eq("foo")
+      CRYSTAL
   end
 
   it "can use argument in rescue, with a different type (1) (#2844)" do
-    run(%(
+    run(<<-CRYSTAL).to_string.should eq("foo")
       require "prelude"
 
       def foo(exe)
@@ -1217,11 +1217,11 @@ describe "Code gen: exception" do
 
       ex = foo(1).as(Exception)
       ex.message.not_nil!
-      )).to_string.should eq("foo")
+      CRYSTAL
   end
 
   it "can use argument in rescue, with a different type (2) (#2844)" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(10)
       require "prelude"
 
       def foo(exe)
@@ -1234,11 +1234,11 @@ describe "Code gen: exception" do
       end
 
       foo(10).as(Int32)
-      )).to_i.should eq(10)
+      CRYSTAL
   end
 
   it "runs NoReturn ensure (#3082)" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(123)
       require "prelude"
 
       begin
@@ -1253,11 +1253,11 @@ describe "Code gen: exception" do
         print 4
       end
       print 5
-      )).to_i.should eq(123)
+      CRYSTAL
   end
 
   it "catches exception thrown by as inside method (#4030)" do
-    run(%(
+    run(<<-CRYSTAL).to_string.should eq("good")
       require "prelude"
 
       def foo
@@ -1271,11 +1271,11 @@ describe "Code gen: exception" do
       rescue ex : TypeCastError
         "good"
       end
-      )).to_string.should eq("good")
+      CRYSTAL
   end
 
   it "types parenthesized expression (#5511)" do
-    run(%(
+    run(<<-CRYSTAL).to_string.should eq("foo")
       require "prelude"
 
       begin
@@ -1283,11 +1283,11 @@ describe "Code gen: exception" do
       rescue ex
         ex.message
       end
-      )).to_string.should eq("foo")
+      CRYSTAL
   end
 
   it "codegens return from rescue with value" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(5)
       require "prelude"
 
       def foo
@@ -1299,11 +1299,11 @@ describe "Code gen: exception" do
       end
 
       foo
-      )).to_i.should eq(5)
+      CRYSTAL
   end
 
   it "closures rescue variable (#8141)" do
-    codegen(%(
+    codegen(<<-CRYSTAL)
       require "prelude"
 
       def invoke(&block)
@@ -1317,11 +1317,11 @@ describe "Code gen: exception" do
         rescue ex
         end
       end
-    ))
+      CRYSTAL
   end
 
   it "handles rescuing module type" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(1)
       require "prelude"
 
       module Foo; end
@@ -1337,11 +1337,11 @@ describe "Code gen: exception" do
         x = 1
       end
       x
-      )).to_i.should eq(1)
+      CRYSTAL
   end
 
   it "handles rescuing union between module type and class type" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(1)
       require "prelude"
 
       module Foo; end
@@ -1360,11 +1360,11 @@ describe "Code gen: exception" do
         x = 1
       end
       x
-      )).to_i.should eq(1)
+      CRYSTAL
   end
 
   it "handles rescuing union between module types" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(1)
       require "prelude"
 
       module Foo; end
@@ -1385,11 +1385,11 @@ describe "Code gen: exception" do
         x = 1
       end
       x
-      )).to_i.should eq(1)
+      CRYSTAL
   end
 
   it "does not rescue just any module" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(2)
       require "prelude"
 
       module Foo; end
@@ -1410,11 +1410,11 @@ describe "Code gen: exception" do
         x = 2
       end
       x
-      )).to_i.should eq(2)
+      CRYSTAL
   end
 
   it "rescues a valid union" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(1)
       require "prelude"
 
       module Foo; end
@@ -1431,11 +1431,11 @@ describe "Code gen: exception" do
         x = 1
       end
       x
-      )).to_i.should eq(1)
+      CRYSTAL
   end
 
   it "rescues a valid nested union" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(1)
       require "prelude"
 
       module Foo; end
@@ -1453,11 +1453,11 @@ describe "Code gen: exception" do
         x = 1
       end
       x
-      )).to_i.should eq(1)
+      CRYSTAL
   end
 
   it "does not rescue just any union" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(2)
       require "prelude"
 
       module Foo; end
@@ -1477,6 +1477,6 @@ describe "Code gen: exception" do
         x = 2
       end
       x
-      )).to_i.should eq(2)
+      CRYSTAL
   end
 end

--- a/spec/compiler/codegen/experimental_spec.cr
+++ b/spec/compiler/codegen/experimental_spec.cr
@@ -2,23 +2,23 @@ require "../spec_helper"
 
 describe "Code gen: experimental" do
   it "compiles with no argument" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(2)
       @[Experimental]
       def foo
       end
 
       2
-      )).to_i.should eq(2)
+      CRYSTAL
   end
 
   it "compiles with single string argument" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(2)
       @[Experimental("lorem ipsum")]
       def foo
       end
 
       2
-      )).to_i.should eq(2)
+      CRYSTAL
   end
 
   it "errors if invalid argument type" do

--- a/spec/compiler/codegen/extern_spec.cr
+++ b/spec/compiler/codegen/extern_spec.cr
@@ -502,84 +502,84 @@ describe "Codegen: extern struct" do
     end
 
     it "doesn't crash with proc with extern struct that's a closure" do
-      codegen(%(
-          lib LibMylib
-            struct Struct
-              x : Int64
-              y : Int64
-              z : Int64
-            end
+      codegen(<<-CRYSTAL)
+        lib LibMylib
+          struct Struct
+            x : Int64
+            y : Int64
+            z : Int64
           end
+        end
 
-          a = 1
-          f = ->(s : LibMylib::Struct) {
-            a
-          }
+        a = 1
+        f = ->(s : LibMylib::Struct) {
+          a
+        }
 
-          s = LibMylib::Struct.new
-          f.call(s)
-          ))
+        s = LibMylib::Struct.new
+        f.call(s)
+        CRYSTAL
     end
 
     it "invokes proc with extern struct" do
-      run(%(
-          lib LibMylib
-            struct Struct
-              x : Int32
-              y : Int32
-            end
+      run(<<-CRYSTAL).to_i.should eq(30)
+        lib LibMylib
+          struct Struct
+            x : Int32
+            y : Int32
+          end
+        end
+
+        class Global
+          @@x = 0
+
+          def self.x=(@@x)
           end
 
-          class Global
-            @@x = 0
-
-            def self.x=(@@x)
-            end
-
-            def self.x
-              @@x
-            end
+          def self.x
+            @@x
           end
+        end
 
-          f = ->(s : LibMylib::Struct) {
-            Global.x &+= s.x
-            Global.x &+= s.y
-          }
+        f = ->(s : LibMylib::Struct) {
+          Global.x &+= s.x
+          Global.x &+= s.y
+        }
 
-          s = LibMylib::Struct.new
-          s.x = 10
-          s.y = 20
-          f.call(s)
+        s = LibMylib::Struct.new
+        s.x = 10
+        s.y = 20
+        f.call(s)
 
-          Global.x
-          )).to_i.should eq(30)
+        Global.x
+        CRYSTAL
     end
 
     it "invokes proc with extern struct with sret" do
-      run(%(
-          lib LibMylib
-            struct Struct
-              x : Int32
-              y : Int32
-              z : Int32
-              w : Int32
-              a : Int32
-            end
+      run(<<-CRYSTAL).to_i.should eq(15)
+        lib LibMylib
+          struct Struct
+            x : Int32
+            y : Int32
+            z : Int32
+            w : Int32
+            a : Int32
           end
+        end
 
-          f = ->{
-            s = LibMylib::Struct.new
-            s.x = 1
-            s.y = 2
-            s.z = 3
-            s.w = 4
-            s.a = 5
-            s
-          }
+        f = ->{
+          s = LibMylib::Struct.new
+          s.x = 1
+          s.y = 2
+          s.z = 3
+          s.w = 4
+          s.a = 5
+          s
+        }
 
-          s = f.call
-          s.x &+ s.y &+ s.z &+ s.w &+ s.a
-          )).to_i.should eq(15)
+        s = f.call
+        s.x &+ s.y &+ s.z &+ s.w &+ s.a
+        CRYSTAL
     end
   {% end %}
 end

--- a/spec/compiler/codegen/extern_spec.cr
+++ b/spec/compiler/codegen/extern_spec.cr
@@ -2,7 +2,7 @@ require "../../spec_helper"
 
 describe "Codegen: extern struct" do
   it "declares extern struct with no constructor" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(0)
       @[Extern]
       struct Foo
         @x = uninitialized Int32
@@ -13,11 +13,11 @@ describe "Codegen: extern struct" do
       end
 
       Foo.new.x
-      )).to_i.should eq(0)
+      CRYSTAL
   end
 
   it "declares extern struct with no constructor, assigns var" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(10)
       @[Extern]
       struct Foo
         @x = uninitialized Int32
@@ -33,11 +33,11 @@ describe "Codegen: extern struct" do
       foo = Foo.new
       foo.x = 10
       foo.x
-      )).to_i.should eq(10)
+      CRYSTAL
   end
 
   it "declares extern union with no constructor" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(1069547520)
       @[Extern(union: true)]
       struct Foo
         @x = uninitialized Int32
@@ -58,11 +58,11 @@ describe "Codegen: extern struct" do
       foo.x = 1
       foo.y = 1.5_f32
       foo.x
-      )).to_i.should eq(1069547520)
+      CRYSTAL
   end
 
   it "declares extern struct, sets and gets instance var" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(42)
       @[Extern]
       struct Foo
         @y = uninitialized Float64
@@ -75,11 +75,11 @@ describe "Codegen: extern struct" do
       end
 
       Foo.new.foo
-      )).to_i.should eq(42)
+      CRYSTAL
   end
 
   it "declares extern union, sets and gets instance var" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(1069547520)
       @[Extern(union: true)]
       struct Foo
         @x = uninitialized Int32
@@ -93,11 +93,11 @@ describe "Codegen: extern struct" do
       end
 
       Foo.new.foo
-      )).to_i.should eq(1069547520)
+      CRYSTAL
   end
 
   it "sets callback on extern struct" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(42)
       require "prelude"
 
       @[Extern]
@@ -116,11 +116,11 @@ describe "Codegen: extern struct" do
       foo = Foo.new
       foo.set
       foo.get
-      )).to_i.should eq(42)
+      CRYSTAL
   end
 
   it "sets callback on extern union" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(42)
       require "prelude"
 
       @[Extern(union: true)]
@@ -140,11 +140,11 @@ describe "Codegen: extern struct" do
       foo = Foo.new
       foo.set
       foo.get
-      )).to_i.should eq(42)
+      CRYSTAL
   end
 
   it "codegens extern proc call twice (#4982)" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(3)
       @[Extern]
       struct Data
         def initialize(@foo : Int32)
@@ -161,7 +161,7 @@ describe "Codegen: extern struct" do
       y = f.call(Data.new(2))
 
       x &+ y
-      )).to_i.should eq(3)
+      CRYSTAL
   end
 
   it "codegens proc that takes and returns large extern struct by value" do

--- a/spec/compiler/codegen/generic_class_spec.cr
+++ b/spec/compiler/codegen/generic_class_spec.cr
@@ -2,7 +2,7 @@ require "../../spec_helper"
 
 describe "Code gen: generic class type" do
   it "codegens inherited generic class instance var" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(2)
       class Foo(T)
         def initialize(@x : T)
         end
@@ -16,11 +16,11 @@ describe "Code gen: generic class type" do
       end
 
       Bar.new(1).x
-      )).to_i.should eq(2)
+      CRYSTAL
   end
 
   it "instantiates generic class with default argument in initialize (#394)" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(2)
       class Foo(T)
         def initialize(@x = 1)
         end
@@ -31,11 +31,11 @@ describe "Code gen: generic class type" do
       end
 
       Foo(Int32).new.x &+ 1
-      )).to_i.should eq(2)
+      CRYSTAL
   end
 
   it "allows initializing instance variable (#665)" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(1)
       class SomeType(T)
         @x = 1
 
@@ -45,11 +45,11 @@ describe "Code gen: generic class type" do
       end
 
       SomeType(Char).new.x
-      )).to_i.should eq(1)
+      CRYSTAL
   end
 
   it "allows initializing instance variable in inherited generic type" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(1)
       class Foo(T)
         @x = 1
 
@@ -63,11 +63,11 @@ describe "Code gen: generic class type" do
       end
 
       Bar(Char).new.x
-      )).to_i.should eq(1)
+      CRYSTAL
   end
 
   it "declares instance var with virtual T (#1675)" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(1)
       class Foo
         def foo
           1
@@ -93,11 +93,11 @@ describe "Code gen: generic class type" do
       generic = Generic(Foo).new
       generic.value = Foo.new
       generic.value.foo
-      )).to_i.should eq(1)
+      CRYSTAL
   end
 
   it "runs generic instance var initializers in superclass's metaclass context (#4753)" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(1)
       class Bar(T)
         def x
           {% if T == Int32 %} 1 {% else %} 2 {% end %}
@@ -116,11 +116,11 @@ describe "Code gen: generic class type" do
       end
 
       Foo(Int32).new.bar.x
-      )).to_i.should eq(1)
+      CRYSTAL
   end
 
   it "runs generic instance var initializers in superclass's metaclass context (2) (#6482)" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(1)
       class Bar(T)
         def x
           {% if T == FooBase(Int32) %} 1 {% else %} 2 {% end %}
@@ -139,11 +139,11 @@ describe "Code gen: generic class type" do
       end
 
       Foo(Int32).new.bar.x
-      )).to_i.should eq(1)
+      CRYSTAL
   end
 
   it "doesn't run generic instance var initializers in formal superclass's context (#4753)" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(7)
       class Foo(T)
         @foo = T.new
 
@@ -162,11 +162,11 @@ describe "Code gen: generic class type" do
       end
 
       Bar(Baz).new.foo.baz
-      )).to_i.should eq(7)
+      CRYSTAL
   end
 
   it "codegens static array size after instantiating" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(3)
       struct StaticArray(T, N)
         def size
           N
@@ -177,11 +177,11 @@ describe "Code gen: generic class type" do
 
       x = uninitialized Int32[3]
       x.size
-      )).to_i.should eq(3)
+      CRYSTAL
   end
 
   it "inherited instance var initialize from generic to concrete (#2128)" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(42)
       class Foo(T)
         @x = 42
 
@@ -194,11 +194,11 @@ describe "Code gen: generic class type" do
       end
 
       Bar.new.x
-      )).to_i.should eq(42)
+      CRYSTAL
   end
 
   it "inherited instance var initialize from generic to generic to concrete (#2128)" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(42)
       class Foo(T)
         @x = 10
 
@@ -220,11 +220,11 @@ describe "Code gen: generic class type" do
 
       baz = Baz.new
       baz.x &+ baz.y
-      )).to_i.should eq(42)
+      CRYSTAL
   end
 
   it "invokes super in generic class (#2354)" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(2)
       class Global
         @@x = 1
 
@@ -252,11 +252,11 @@ describe "Code gen: generic class type" do
       b.foo
 
       Global.x
-      )).to_i.should eq(2)
+      CRYSTAL
   end
 
   it "uses big integer as generic type argument (#2353)" do
-    run(%(
+    run(<<-CRYSTAL).to_u64.should eq(2374623294237463578)
       require "prelude"
 
       MIN_RANGE = -2374623294237463578
@@ -269,11 +269,11 @@ describe "Code gen: generic class type" do
       end
 
       Hello(MAX_RANGE).t
-      )).to_u64.should eq(2374623294237463578)
+      CRYSTAL
   end
 
   it "doesn't use virtual + in type arguments (#2839)" do
-    run(%(
+    run(<<-CRYSTAL).to_string.should eq("Gen(Foo)")
       class Class
         def name : String
           {{ @type.name.stringify }}
@@ -290,11 +290,11 @@ describe "Code gen: generic class type" do
       end
 
       Gen(Foo).name
-      )).to_string.should eq("Gen(Foo)")
+      CRYSTAL
   end
 
   it "doesn't use virtual + in type arguments for Tuple (#2839)" do
-    run(%(
+    run(<<-CRYSTAL).to_string.should eq("Tuple(Foo)")
       class Class
         def name : String
           {{ @type.name.stringify }}
@@ -311,11 +311,11 @@ describe "Code gen: generic class type" do
       end
 
       Tuple(Foo).name
-      )).to_string.should eq("Tuple(Foo)")
+      CRYSTAL
   end
 
   it "doesn't use virtual + in type arguments for NamedTuple (#2839)" do
-    run(%(
+    run(<<-CRYSTAL).to_string.should eq("NamedTuple(x: Foo)")
       class Class
         def name : String
           {{ @type.name.stringify }}
@@ -332,11 +332,11 @@ describe "Code gen: generic class type" do
       end
 
       NamedTuple(x: Foo).name
-      )).to_string.should eq("NamedTuple(x: Foo)")
+      CRYSTAL
   end
 
   it "codegens virtual generic metaclass macro method call" do
-    run(%(
+    run(<<-CRYSTAL).to_string.should eq("Bar(Int32)")
       class Class
         def name : String
           {{ @type.name.stringify }}
@@ -350,11 +350,11 @@ describe "Code gen: generic class type" do
       end
 
       Bar(Int32).new.as(Foo(Int32)).class.name
-      )).to_string.should eq("Bar(Int32)")
+      CRYSTAL
   end
 
   it "recomputes two calls that look the same due to generic type being instantiated (#7728)" do
-    run(%(
+    run(<<-CRYSTAL).to_string.should eq("hello")
       require "prelude"
 
       abstract class Base
@@ -377,11 +377,11 @@ describe "Code gen: generic class type" do
       foo(Gen.new(1) || Gen.new(1.5))
       foo(Gen.new(true) || Gen.new(1_u8))
       foo(Gen.new("hello") || Gen.new('z')).as(String)
-      )).to_string.should eq("hello")
+      CRYSTAL
   end
 
   it "doesn't consider abstract types for including types (#7200)" do
-    codegen(%(
+    codegen(<<-CRYSTAL)
       module Moo
       end
 
@@ -399,11 +399,11 @@ describe "Code gen: generic class type" do
       end
 
       Bar(Int32).new.as(Moo).foo
-      ))
+      CRYSTAL
   end
 
   it "doesn't consider abstract generic instantiation when restricting type (#5190)" do
-    codegen(%(
+    codegen(<<-CRYSTAL)
       abstract class Foo(E)
         abstract def foo
       end
@@ -424,11 +424,11 @@ describe "Code gen: generic class type" do
       if x.is_a?(Bar)
         x.foo
       end
-      ))
+      CRYSTAL
   end
 
   it "doesn't crash on generic type restriction with initially no subtypes (#8411)" do
-    codegen(%(
+    codegen(<<-CRYSTAL)
       class Foo
       end
 
@@ -446,11 +446,11 @@ describe "Code gen: generic class type" do
       end
 
       Baz(Int32).new
-      ))
+      CRYSTAL
   end
 
   it "doesn't crash on generic type restriction with no subtypes (#7583)" do
-    codegen(%(
+    codegen(<<-CRYSTAL)
       require "prelude"
 
       class Foo
@@ -468,11 +468,11 @@ describe "Code gen: generic class type" do
       if f.is_a?(Baz)
         x(f.baz)
       end
-      ))
+      CRYSTAL
   end
 
   it "doesn't override guessed instance var in generic type if already declared in superclass (#9431)" do
-    codegen(%(
+    codegen(<<-CRYSTAL)
       class Foo
         @x = 0
       end
@@ -486,11 +486,11 @@ describe "Code gen: generic class type" do
       end
 
       Baz.new
-      ))
+      CRYSTAL
   end
 
   it "codegens compile-time interpreted generic int128" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(4)
       require "prelude"
 
       CONST = 1_i128 + 2_i128
@@ -507,6 +507,6 @@ describe "Code gen: generic class type" do
       end
 
       Bar.new.t_incr
-      )).to_i.should eq(4)
+      CRYSTAL
   end
 end

--- a/spec/compiler/codegen/hash_literal_spec.cr
+++ b/spec/compiler/codegen/hash_literal_spec.cr
@@ -2,7 +2,7 @@ require "../../spec_helper"
 
 describe "Code gen: hash literal spec" do
   it "creates custom non-generic hash" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(90)
       class Custom
         def initialize
           @keys = 0
@@ -25,11 +25,11 @@ describe "Code gen: hash literal spec" do
 
       custom = Custom {1 => 10, 2 => 20}
       custom.keys &* custom.values
-      )).to_i.should eq(90)
+      CRYSTAL
   end
 
   it "creates custom generic hash" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(90)
       class Custom(K, V)
         def initialize
           @keys = 0
@@ -52,11 +52,11 @@ describe "Code gen: hash literal spec" do
 
       custom = Custom {1 => 10, 2 => 20}
       custom.keys &* custom.values
-      )).to_i.should eq(90)
+      CRYSTAL
   end
 
   it "creates custom generic hash with type vars" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(90)
       class Custom(K, V)
         def initialize
           @keys = 0
@@ -79,11 +79,11 @@ describe "Code gen: hash literal spec" do
 
       custom = Custom(Int32, Int32) {1 => 10, 2 => 20}
       custom.keys &* custom.values
-      )).to_i.should eq(90)
+      CRYSTAL
   end
 
   it "creates custom generic hash via alias (1)" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(90)
       class Custom(K, V)
         def initialize
           @keys = 0
@@ -108,11 +108,11 @@ describe "Code gen: hash literal spec" do
 
       custom = MyCustom {1 => 10, 2 => 20}
       custom.keys &* custom.values
-      )).to_i.should eq(90)
+      CRYSTAL
   end
 
   it "creates custom generic hash via alias (2)" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(90)
       class Custom(K, V)
         def initialize
           @keys = 0
@@ -137,11 +137,11 @@ describe "Code gen: hash literal spec" do
 
       custom = MyCustom {1 => 10, 2 => 20}
       custom.keys &* custom.values
-      )).to_i.should eq(90)
+      CRYSTAL
   end
 
   it "doesn't crash on hash literal with proc pointer (#646)" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(1)
       require "prelude"
 
       def blah
@@ -150,11 +150,11 @@ describe "Code gen: hash literal spec" do
 
       b = {"a" => ->blah}
       b["a"].call
-      )).to_i.should eq(1)
+      CRYSTAL
   end
 
   it "creates custom non-generic hash in module" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(90)
       module Moo
         class Custom
           def initialize
@@ -179,11 +179,11 @@ describe "Code gen: hash literal spec" do
 
       custom = Moo::Custom {1 => 10, 2 => 20}
       custom.keys &* custom.values
-      )).to_i.should eq(90)
+      CRYSTAL
   end
 
   it "creates custom generic hash in module (#5684)" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(90)
       module Moo
         class Custom(K, V)
           def initialize
@@ -208,7 +208,7 @@ describe "Code gen: hash literal spec" do
 
       custom = Moo::Custom {1 => 10, 2 => 20}
       custom.keys &* custom.values
-      )).to_i.should eq(90)
+      CRYSTAL
   end
 
   it "assignment in hash literal works" do

--- a/spec/compiler/codegen/hooks_spec.cr
+++ b/spec/compiler/codegen/hooks_spec.cr
@@ -2,7 +2,7 @@ require "../../spec_helper"
 
 describe "Code gen: hooks" do
   it "does inherited macro" do
-    run("
+    run(<<-CRYSTAL).to_i.should eq(1)
       class Foo
         macro inherited
           @@x = 1
@@ -17,11 +17,11 @@ describe "Code gen: hooks" do
       end
 
       Bar.x
-      ").to_i.should eq(1)
+      CRYSTAL
   end
 
   it "does included macro" do
-    run("
+    run(<<-CRYSTAL).to_i.should eq(1)
       module Foo
         macro included
           @@x = 1
@@ -37,11 +37,11 @@ describe "Code gen: hooks" do
       end
 
       Bar.x
-      ").to_i.should eq(1)
+      CRYSTAL
   end
 
   it "does extended macro" do
-    run("
+    run(<<-CRYSTAL).to_i.should eq(1)
       module Foo
         macro extended
           @@x = 1
@@ -57,11 +57,11 @@ describe "Code gen: hooks" do
       end
 
       Bar.x
-      ").to_i.should eq(1)
+      CRYSTAL
   end
 
   it "does added method macro" do
-    run("
+    run(<<-CRYSTAL).to_i.should eq(1)
       class Global
         @@x = 0
 
@@ -82,11 +82,11 @@ describe "Code gen: hooks" do
       end
 
       Global.x
-      ").to_i.should eq(1)
+      CRYSTAL
   end
 
   it "does inherited macro recursively" do
-    run("
+    run(<<-CRYSTAL).to_i.should eq(2)
       class Global
         @@x = 0
 
@@ -111,11 +111,11 @@ describe "Code gen: hooks" do
       end
 
       Global.x
-      ").to_i.should eq(2)
+      CRYSTAL
   end
 
   it "does inherited macro before class body" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(123)
       require "prelude"
 
       class Global
@@ -144,11 +144,11 @@ describe "Code gen: hooks" do
       end
 
       Bar.y
-      )).to_i.should eq(123)
+      CRYSTAL
   end
 
   it "does finished" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(4)
       class Foo
         A = [1]
 
@@ -168,11 +168,11 @@ describe "Code gen: hooks" do
       end
 
       Foo.foo
-      )).to_i.should eq(4)
+      CRYSTAL
   end
 
   it "fixes empty types in hooks (#3946)" do
-    codegen(%(
+    codegen(<<-CRYSTAL)
       lib LibC
         fun exit(x : Int32) : NoReturn
       end
@@ -211,6 +211,6 @@ describe "Code gen: hooks" do
 
       class Bar < Foo
       end
-    ))
+      CRYSTAL
   end
 end

--- a/spec/compiler/codegen/if_spec.cr
+++ b/spec/compiler/codegen/if_spec.cr
@@ -196,14 +196,14 @@ describe "Code gen: if" do
 
   {% if flag?(:bits64) %}
     it "codegens if with pointer 0x100000000 pointer" do
-      run(%(
+      run(<<-CRYSTAL).to_i.should eq(1)
         ptr = Pointer(Void).new(0x100000000_u64)
         if ptr
           1
         else
           2
         end
-      )).to_i.should eq(1)
+        CRYSTAL
     end
   {% end %}
 

--- a/spec/compiler/codegen/if_spec.cr
+++ b/spec/compiler/codegen/if_spec.cr
@@ -70,7 +70,7 @@ describe "Code gen: if" do
   end
 
   it "codegen if with nested if that returns" do
-    run("
+    run(<<-CRYSTAL).to_i.should eq(1)
       def foo
         if true
           if true
@@ -83,11 +83,11 @@ describe "Code gen: if" do
       end
 
       foo
-    ").to_i.should eq(1)
+      CRYSTAL
   end
 
   it "codegen if with union type and then without type" do
-    run("
+    run(<<-CRYSTAL).to_i.should eq(1)
       def foo
         if true
           return 1
@@ -98,11 +98,11 @@ describe "Code gen: if" do
       end
 
       foo
-    ").to_i.should eq(1)
+      CRYSTAL
   end
 
   it "codegen if with union type and else without type" do
-    run("
+    run(<<-CRYSTAL).to_i.should eq(1)
       def foo
         if false
           1 || 1.1
@@ -113,11 +113,11 @@ describe "Code gen: if" do
       end
 
       foo
-    ").to_i.should eq(1)
+      CRYSTAL
   end
 
   it "codegens if with virtual" do
-    run("
+    run(<<-CRYSTAL).to_i.should eq(1)
       class Foo
       end
 
@@ -130,11 +130,11 @@ describe "Code gen: if" do
       else
         2
       end
-      ").to_i.should eq(1)
+      CRYSTAL
   end
 
   it "codegens nested if with var (ssa bug)" do
-    run("
+    run(<<-CRYSTAL).to_i.should eq(1)
       foo = 1
       if 1 == 2
         if 1 == 2
@@ -144,29 +144,29 @@ describe "Code gen: if" do
         end
       end
       foo
-      ").to_i.should eq(1)
+      CRYSTAL
   end
 
   it "codegens if with nested if that raises" do
-    run("
-      require \"prelude\"
+    run(<<-CRYSTAL).to_i.should eq(1)
+      require "prelude"
 
       struct Nil; def to_i; 0; end; end
 
       block = 1 || nil
       if 1 == 2
         if block
-          raise \"Oh no\"
+          raise "Oh no"
         end
       else
         block
       end.to_i
-      ").to_i.should eq(1)
+      CRYSTAL
   end
 
   it "codegens if with return in else preserves type filter" do
-    run("
-      require \"prelude\"
+    run(<<-CRYSTAL).to_i.should eq(2)
+      require "prelude"
 
       def foo
         x = 1 || nil
@@ -179,11 +179,11 @@ describe "Code gen: if" do
       end
 
       foo
-      ").to_i.should eq(2)
+      CRYSTAL
   end
 
   it "codegens bug #1729" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(3)
       n = true ? 3 : 3.2
       z = if n.is_a?(Float64) || false
         0
@@ -191,7 +191,7 @@ describe "Code gen: if" do
         n
       end
       z.to_i!
-      )).to_i.should eq(3)
+      CRYSTAL
   end
 
   {% if flag?(:bits64) %}
@@ -208,7 +208,7 @@ describe "Code gen: if" do
   {% end %}
 
   it "doesn't crash with if !var using var in else" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(1)
       foo = nil
       if !foo
         1
@@ -216,11 +216,11 @@ describe "Code gen: if" do
         foo
       end
       1
-      )).to_i.should eq(1)
+      CRYSTAL
   end
 
   it "doesn't crash with if !is_a? using var in then" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(1)
       foo = 1
       if !foo.is_a?(Int32)
         foo
@@ -228,33 +228,33 @@ describe "Code gen: if" do
         1
       end
       1
-      )).to_i.should eq(1)
+      CRYSTAL
   end
 
   it "restricts with || always falsey" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(2)
       t = 1
       if t.is_a?(String) || t.is_a?(String)
         t
       else
         2
       end
-      )).to_i.should eq(2)
+      CRYSTAL
   end
 
   it "considers or truthy/falsey right" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(2)
       t = 1 || 'a'
       if t.is_a?(Char) || t.is_a?(Char)
         1
       else
         2
       end
-      )).to_i.should eq(2)
+      CRYSTAL
   end
 
   it "codegens #3104" do
-    codegen(%(
+    codegen(<<-CRYSTAL)
       def foo
         yield
       end
@@ -265,11 +265,11 @@ describe "Code gen: if" do
         end
       end
       x
-      ))
+      CRYSTAL
   end
 
   it "doesn't generate truthy if branch if doesn't need value (bug)" do
-    codegen(%(
+    codegen(<<-CRYSTAL)
       class Foo
       end
 
@@ -284,11 +284,11 @@ describe "Code gen: if" do
         end
       end
       1
-      ))
+      CRYSTAL
   end
 
   it "doesn't crash no NoReturn var (true left cond) (#1823)" do
-    codegen(%(
+    codegen(<<-CRYSTAL)
       def foo
         arg = nil
         if true || arg.nil?
@@ -299,11 +299,11 @@ describe "Code gen: if" do
       end
 
       foo
-      ))
+      CRYSTAL
   end
 
   it "doesn't crash no NoReturn var (non-true left cond) (#1823)" do
-    codegen(%(
+    codegen(<<-CRYSTAL)
       def foo
         arg = nil
         if 1 == 2 || arg.nil?
@@ -314,6 +314,6 @@ describe "Code gen: if" do
       end
 
       foo
-      ))
+      CRYSTAL
   end
 end

--- a/spec/compiler/codegen/is_a_spec.cr
+++ b/spec/compiler/codegen/is_a_spec.cr
@@ -60,7 +60,7 @@ describe "Codegen: is_a?" do
   end
 
   it "evaluate method on filtered type nilable type not-nil" do
-    run("
+    run(<<-CRYSTAL).to_i.should eq(1)
       class Foo
         def foo
           1
@@ -74,11 +74,11 @@ describe "Codegen: is_a?" do
       else
         2
       end
-      ").to_i.should eq(1)
+      CRYSTAL
   end
 
   it "evaluate method on filtered type nilable type nil" do
-    run("
+    run(<<-CRYSTAL).to_i.should eq(1)
       struct Nil
         def foo
           1
@@ -95,11 +95,11 @@ describe "Codegen: is_a?" do
       else
         2
       end
-      ").to_i.should eq(1)
+      CRYSTAL
   end
 
   it "evaluates method on filtered union type" do
-    run("
+    run(<<-CRYSTAL).to_i.should eq(2)
       class Foo
         def initialize(x : Int32)
           @x = x
@@ -118,11 +118,11 @@ describe "Codegen: is_a?" do
       else
         0
       end
-      ").to_i.should eq(2)
+      CRYSTAL
   end
 
   it "evaluates method on filtered union type 2" do
-    run("
+    run(<<-CRYSTAL).to_i.should eq(3)
       class Foo
         def initialize(x : Int32)
           @x = x
@@ -152,12 +152,12 @@ describe "Codegen: is_a?" do
       else
         0
       end
-      ").to_i.should eq(3)
+      CRYSTAL
   end
 
   it "evaluates method on filtered union type 3" do
-    run("
-      require \"prelude\"
+    run(<<-CRYSTAL).to_i.should eq(5)
+      require "prelude"
       a = 1
       a = [1.1]
       a = [5]
@@ -167,12 +167,12 @@ describe "Codegen: is_a?" do
       else
         0
       end.to_i
-    ").to_i.should eq(5)
+      CRYSTAL
   end
 
   it "codegens when is_a? is always false but properties are used" do
-    run("
-      require \"prelude\"
+    run(<<-CRYSTAL).to_b.should be_false
+      require "prelude"
 
       class Foo
         def obj; 1 end
@@ -180,11 +180,11 @@ describe "Codegen: is_a?" do
 
       foo = 1
       foo.is_a?(Foo) && foo.obj && foo.obj
-    ").to_b.should be_false
+      CRYSTAL
   end
 
   it "codegens is_a? on right side of and" do
-    run("
+    run(<<-CRYSTAL).to_i.should eq(1)
       class Foo
         def bar
           true
@@ -197,11 +197,11 @@ describe "Codegen: is_a?" do
       else
         2
       end
-      ").to_i.should eq(1)
+      CRYSTAL
   end
 
   it "codegens is_a? with virtual" do
-    run("
+    run(<<-CRYSTAL).to_i.should eq(1)
       class Foo
       end
 
@@ -210,11 +210,11 @@ describe "Codegen: is_a?" do
 
       foo = Bar.new || Foo.new
       foo.is_a?(Bar) ? 1 : 2
-      ").to_i.should eq(1)
+      CRYSTAL
   end
 
   it "codegens is_a? with virtual and nil" do
-    run("
+    run(<<-CRYSTAL).to_i.should eq(1)
       class Foo
       end
 
@@ -223,11 +223,11 @@ describe "Codegen: is_a?" do
 
       f = Foo.new || Bar.new || nil
       f.is_a?(Foo) ? 1 : 2
-      ").to_i.should eq(1)
+      CRYSTAL
   end
 
   it "codegens is_a? with virtual and module" do
-    run("
+    run(<<-CRYSTAL).to_b.should be_true
       module Bar
       end
 
@@ -246,22 +246,22 @@ describe "Codegen: is_a?" do
 
       f = Foo.new || Foo2.new
       f.is_a?(Bar)
-      ").to_b.should be_true
+      CRYSTAL
   end
 
   it "restricts simple type with union" do
-    run("
+    run(<<-CRYSTAL).to_i.should eq(2)
       a = 1
       if a.is_a?(Int32 | Char)
         a &+ 1
       else
         0
       end
-      ").to_i.should eq(2)
+      CRYSTAL
   end
 
   it "restricts union with union" do
-    run("
+    run(<<-CRYSTAL).to_i.should eq(3)
       struct Char
         def &+(other : Int32)
           other
@@ -280,37 +280,37 @@ describe "Codegen: is_a?" do
       else
         a.foo
       end
-      ").to_i.should eq(3)
+      CRYSTAL
   end
 
   it "codegens is_a? with a Const does comparison and gives true" do
-    run("
-      require \"prelude\"
+    run(<<-CRYSTAL).to_b.should be_true
+      require "prelude"
       CONST = 1
       1.is_a?(CONST)
-      ").to_b.should be_true
+      CRYSTAL
   end
 
   it "codegens is_a? with a Const does comparison and gives false" do
-    run("
-      require \"prelude\"
+    run(<<-CRYSTAL).to_b.should be_false
+      require "prelude"
       CONST = 1
       2.is_a?(CONST)
-      ").to_b.should be_false
+      CRYSTAL
   end
 
   it "gives false if generic type doesn't match exactly" do
-    run("
+    run(<<-CRYSTAL).to_i.should eq(2)
       class Foo(T)
       end
 
       foo = Foo(Int32 | Float64).new
       foo.is_a?(Foo(Int32)) ? 1 : 2
-      ").to_i.should eq(2)
+      CRYSTAL
   end
 
   it "does is_a? with more strict virtual type" do
-    run("
+    run(<<-CRYSTAL).to_i.should eq(2)
       class Foo
       end
 
@@ -326,25 +326,25 @@ describe "Codegen: is_a?" do
       else
         1
       end
-      ").to_i.should eq(2)
+      CRYSTAL
   end
 
   it "codegens is_a? casts union to nilable" do
-    run("
+    run(<<-CRYSTAL).to_i.should eq(2)
       class Foo; end
 
-      var = \"hello\" || Foo.new || nil
+      var = "hello" || Foo.new || nil
       if var.is_a?(Foo | Nil)
         var2 = var
         1
       else
         2
       end
-      ").to_i.should eq(2)
+      CRYSTAL
   end
 
   it "codegens is_a? casts union to nilable in method" do
-    run("
+    run(<<-CRYSTAL).to_i.should eq(2)
       class Foo; end
 
       def foo(var)
@@ -356,13 +356,13 @@ describe "Codegen: is_a?" do
         end
       end
 
-      var = \"hello\" || Foo.new || nil
+      var = "hello" || Foo.new || nil
       foo(var)
-      ").to_i.should eq(2)
+      CRYSTAL
   end
 
   it "codegens is_a? from virtual type to module" do
-    run("
+    run(<<-CRYSTAL).to_i.should eq(1)
       module Moo
       end
 
@@ -384,11 +384,11 @@ describe "Codegen: is_a?" do
       else
         2
       end
-      ").to_i.should eq(1)
+      CRYSTAL
   end
 
   it "codegens is_a? from nilable reference union type to nil" do
-    run("
+    run(<<-CRYSTAL).to_i.should eq(2)
       class Foo
       end
 
@@ -402,11 +402,11 @@ describe "Codegen: is_a?" do
       else
         2
       end
-      ").to_i.should eq(2)
+      CRYSTAL
   end
 
   it "codegens is_a? from nilable reference union type to type" do
-    run("
+    run(<<-CRYSTAL).to_i.should eq(1)
       class Foo
       end
 
@@ -420,17 +420,17 @@ describe "Codegen: is_a?" do
       else
         2
       end
-      ").to_i.should eq(1)
+      CRYSTAL
   end
 
   it "says false for value.is_a?(Class)" do
-    run("
+    run(<<-CRYSTAL).to_b.should be_false
       1.is_a?(Class)
-      ").to_b.should be_false
+      CRYSTAL
   end
 
   it "restricts type in else but lazily" do
-    run("
+    run(<<-CRYSTAL).to_i.should eq(2)
       class Foo
         def initialize(@x : Int32)
         end
@@ -449,11 +449,11 @@ describe "Codegen: is_a?" do
       end
 
       z
-      ").to_i.should eq(2)
+      CRYSTAL
   end
 
   it "works with inherited generic class against an instantiation" do
-    run(%(
+    run(<<-CRYSTAL).to_b.should be_true
       class Foo(T)
       end
 
@@ -462,11 +462,11 @@ describe "Codegen: is_a?" do
 
       bar = Bar.new
       bar.is_a?(Foo(Int32))
-      )).to_b.should be_true
+      CRYSTAL
   end
 
   it "doesn't work with inherited generic class against an instantiation (2)" do
-    run(%(
+    run(<<-CRYSTAL).to_b.should be_false
       class Class1
       end
 
@@ -481,11 +481,11 @@ describe "Codegen: is_a?" do
 
       bar = Bar.new
       bar.is_a?(Foo(Class1))
-      )).to_b.should be_false
+      CRYSTAL
   end
 
   it "works with inherited generic class against an instantiation (3)" do
-    run(%(
+    run(<<-CRYSTAL).to_b.should be_false
       class Foo(T)
       end
 
@@ -494,66 +494,66 @@ describe "Codegen: is_a?" do
 
       bar = Bar.new
       bar.is_a?(Foo(Float32))
-      )).to_b.should be_false
+      CRYSTAL
   end
 
   it "doesn't type merge (1) (#548)" do
-    run(%(
+    run(<<-CRYSTAL).to_b.should be_false
       class Base; end
       class Base1 < Base; end
       class Base2 < Base; end
       class Base3 < Base; end
 
       Base3.new.is_a?(Base1 | Base2)
-      )).to_b.should be_false
+      CRYSTAL
   end
 
   it "doesn't type merge (2) (#548)" do
-    run(%(
+    run(<<-CRYSTAL).to_b.should be_true
       class Base; end
       class Base1 < Base; end
       class Base2 < Base; end
       class Base3 < Base; end
 
       Base1.new.is_a?(Base1 | Base2) && Base2.new.is_a?(Base1 | Base2)
-      )).to_b.should be_true
+      CRYSTAL
   end
 
   it "doesn't skip assignment when used in combination with .is_a? (true case, then) (#1121)" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(124)
       a = 123
       if (b = a).is_a?(Int32)
         b &+ 1
       else
         a
       end
-      )).to_i.should eq(124)
+      CRYSTAL
   end
 
   it "doesn't skip assignment when used in combination with .is_a? (true case, else) (#1121)" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(125)
       a = 123
       if (b = a).is_a?(Int32)
         a &+ 2
       else
         b
       end
-      )).to_i.should eq(125)
+      CRYSTAL
   end
 
   it "doesn't skip assignment when used in combination with .is_a? (false case) (#1121)" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(124)
       a = 123
       if (b = a).is_a?(Char)
         b
       else
         b &+ 1
       end
-      )).to_i.should eq(124)
+      CRYSTAL
   end
 
   it "doesn't skip assignment when used in combination with .is_a? and && (#1121)" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(124)
       a = 123
       if (1 == 1) && (b = a).is_a?(Char)
         b
@@ -561,11 +561,11 @@ describe "Codegen: is_a?" do
         a
       end
       b ? b &+ 1 : 0
-      )).to_i.should eq(124)
+      CRYSTAL
   end
 
   it "transforms then if condition is always truthy" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(456)
       def foo
         123 && 456
       end
@@ -575,11 +575,11 @@ describe "Codegen: is_a?" do
       else
         999
       end
-      )).to_i.should eq(456)
+      CRYSTAL
   end
 
   it "transforms else if condition is always falsey" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(456)
       def foo
         123 && 456
       end
@@ -589,30 +589,30 @@ describe "Codegen: is_a?" do
       else
         foo
       end
-      )).to_i.should eq(456)
+      CRYSTAL
   end
 
   it "resets truthy state after visiting nodes (bug)" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(123)
       a = 123
       if !1.is_a?(Int32)
         a = 456
       end
       a
-      )).to_i.should eq(123)
+      CRYSTAL
   end
 
   it "does is_a? with generic class metaclass" do
-    run(%(
+    run(<<-CRYSTAL).to_b.should be_true
       class Foo(T)
       end
 
       Foo(Int32).is_a?(Foo.class)
-      )).to_b.should be_true
+      CRYSTAL
   end
 
   it "says false for GenericChild(Base).is_a?(GenericBase(Child)) (#1294)" do
-    run(%(
+    run(<<-CRYSTAL).to_b.should be_false
       class Base
       end
 
@@ -626,33 +626,33 @@ describe "Codegen: is_a?" do
       end
 
       GenericChild(Base).new.is_a?(GenericBase(Child))
-      )).to_b.should be_false
+      CRYSTAL
   end
 
   it "does is_a?/responds_to? twice (#1451)" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(4)
       a = 1 == 2 ? 1 : false
       if a.is_a?(Int32) && a.is_a?(Int32)
         3
       else
         4
       end
-      )).to_i.should eq(4)
+      CRYSTAL
   end
 
   it "does is_a? with && and true condition" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(3)
       a = 1 == 1 ? 1 : false
       if a.is_a?(Int32) && 1 == 1
         3
       else
         4
       end
-      )).to_i.should eq(3)
+      CRYSTAL
   end
 
   it "does is_a? for union of module and type" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(2)
       module Moo
         def moo
           2
@@ -677,11 +677,11 @@ describe "Codegen: is_a?" do
 
       io = Foo.new.as(Moo) || 1
       foo(io)
-      )).to_i.should eq(2)
+      CRYSTAL
   end
 
   it "does is_a? for virtual generic instance type against generic" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(2)
       class Foo(T)
       end
 
@@ -692,11 +692,11 @@ describe "Codegen: is_a?" do
       end
 
       Bar(Int32).new.as(Foo(Int32)).is_a?(Bar) ? 2 : 3
-      )).to_i.should eq(2)
+      CRYSTAL
   end
 
   it "does is_a?(generic type) for nested generic inheritance (1) (#9660)" do
-    run(%(
+    run(<<-CRYSTAL, inject_primitives: false).to_b.should be_true
       class Cxx
       end
 
@@ -710,11 +710,11 @@ describe "Codegen: is_a?" do
       end
 
       Baz.new.is_a?(Foo)
-      ), inject_primitives: false).to_b.should be_true
+      CRYSTAL
   end
 
   it "does is_a?(generic type) for nested generic inheritance (2)" do
-    run(%(
+    run(<<-CRYSTAL, inject_primitives: false).to_b.should be_true
       class Cxx
       end
 
@@ -728,11 +728,11 @@ describe "Codegen: is_a?" do
       end
 
       Baz(Cxx).new.is_a?(Foo)
-      ), inject_primitives: false).to_b.should be_true
+      CRYSTAL
   end
 
   it "does is_a?(generic type) for nested generic inheritance, through upcast (1)" do
-    run(%(
+    run(<<-CRYSTAL, inject_primitives: false).to_b.should be_true
       class Cxx
       end
 
@@ -746,11 +746,11 @@ describe "Codegen: is_a?" do
       end
 
       Baz.new.as(Foo(Cxx)).is_a?(Bar)
-      ), inject_primitives: false).to_b.should be_true
+      CRYSTAL
   end
 
   it "does is_a?(generic type) for nested generic inheritance, through upcast (2)" do
-    run(%(
+    run(<<-CRYSTAL, inject_primitives: false).to_b.should be_true
       class Cxx
       end
 
@@ -764,50 +764,50 @@ describe "Codegen: is_a?" do
       end
 
       Baz(Cxx).new.as(Foo(Cxx)).is_a?(Bar)
-      ), inject_primitives: false).to_b.should be_true
+      CRYSTAL
   end
 
   it "doesn't consider generic type to be a generic type of a recursive alias (#3524)" do
-    run(%(
+    run(<<-CRYSTAL).to_b.should be_false
       class Gen(T)
       end
 
       alias Type = Int32 | Gen(Type)
       a = Gen(Int32).new
       a.is_a?(Type)
-      )).to_b.should be_false
+      CRYSTAL
   end
 
   it "codegens untyped var (#4009)" do
-    codegen(%(
+    codegen(<<-CRYSTAL)
       i = 1
       1 || i.is_a?(Int32) ? "" : i
-      ))
+      CRYSTAL
   end
 
   it "visits 1.to_s twice, may trigger enclosing_call (#4364)" do
-    run(%(
+    run(<<-CRYSTAL).to_b.should be_true
       require "prelude"
 
       B = String
       1.to_s.is_a?(B)
-      )).to_b.should be_true
+      CRYSTAL
   end
 
   it "says true for Class.is_a?(Class.class) (#4374)" do
-    run("
+    run(<<-CRYSTAL).to_b.should be_true
       Class.is_a?(Class.class)
-    ").to_b.should be_true
+      CRYSTAL
   end
 
   it "says true for Class.is_a?(Class.class.class) (#4374)" do
-    run("
+    run(<<-CRYSTAL).to_b.should be_true
       Class.is_a?(Class.class.class)
-    ").to_b.should be_true
+      CRYSTAL
   end
 
   it "passes is_a? with generic module type on virtual type (#10302)" do
-    run(%(
+    run(<<-CRYSTAL).to_b.should be_true
       module Mod(T)
       end
 
@@ -819,11 +819,11 @@ describe "Codegen: is_a?" do
       end
 
       Sub.new.is_a?(Mod(Sup))
-      )).to_b.should be_true
+      CRYSTAL
   end
 
   it "restricts metaclass against virtual metaclass type" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(1)
       class A
       end
 
@@ -838,11 +838,11 @@ describe "Codegen: is_a?" do
       else
         3
       end
-      )).to_i.should eq(1)
+      CRYSTAL
   end
 
   it "restricts virtual metaclass against virtual metaclass type" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(1)
       class A
       end
 
@@ -860,11 +860,11 @@ describe "Codegen: is_a?" do
       else
         3
       end
-      )).to_i.should eq(1)
+      CRYSTAL
   end
 
   it "does is_a? with union type, don't resolve to virtual type (#10244)" do
-    run(%(
+    run(<<-CRYSTAL).to_b.should be_false
       class A
       end
 
@@ -879,11 +879,11 @@ describe "Codegen: is_a?" do
 
       x = D.new || C.new
       x.is_a?(B | C)
-    )).to_b.should be_false
+      CRYSTAL
   end
 
   it "does is_a? with union type as Union(X, Y), don't resolve to virtual type (#10244)" do
-    run(%(
+    run(<<-CRYSTAL).to_b.should be_false
       class A
       end
 
@@ -898,22 +898,22 @@ describe "Codegen: is_a?" do
 
       x = D.new || C.new
       x.is_a?(Union(B, C))
-    )).to_b.should be_false
+      CRYSTAL
   end
 
   it "restricts union metaclass to metaclass (#12295)" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(2)
       x = true ? Union(String | Int32) : String
       if x.is_a?(String.class)
         1
       else
         2
       end
-    )).to_i.should eq(2)
+      CRYSTAL
   end
 
   it "does is_a? for generic type against generic class instance type (#12304)" do
-    run(%(
+    run(<<-CRYSTAL).to_b.should be_true
       require "prelude"
 
       class A
@@ -926,7 +926,7 @@ describe "Codegen: is_a?" do
       b = a.as(B)
 
       b.is_a?(B(Int32))
-    )).to_b.should be_true
+      CRYSTAL
   end
 
   it "virtual metaclass type is not virtual instance type (#12628)" do

--- a/spec/compiler/codegen/lib_spec.cr
+++ b/spec/compiler/codegen/lib_spec.cr
@@ -2,18 +2,18 @@ require "../../spec_helper"
 
 describe "Code gen: lib" do
   pending "codegens lib var set and get" do
-    run("
+    run(<<-CRYSTAL).to_i.should eq(1)
       lib LibC
         $errno : Int32
       end
 
       LibC.errno = 1
       LibC.errno
-      ").to_i.should eq(1)
+      CRYSTAL
   end
 
   it "call to void function" do
-    run("
+    run(<<-CRYSTAL)
       lib LibC
         fun srand(x : UInt32) : Void
       end
@@ -23,11 +23,11 @@ describe "Code gen: lib" do
       end
 
       foo
-    ")
+      CRYSTAL
   end
 
   it "allows passing type to LibC if it has a converter with to_unsafe" do
-    codegen("
+    codegen(<<-CRYSTAL)
       lib LibC
         fun foo(x : Int32) : Int32
       end
@@ -39,11 +39,11 @@ describe "Code gen: lib" do
       end
 
       LibC.foo Foo.new
-      ")
+      CRYSTAL
   end
 
   it "allows passing type to LibC if it has a converter with to_unsafe (bug)" do
-    codegen(%(
+    codegen(<<-CRYSTAL)
       require "prelude"
 
       lib LibC
@@ -55,11 +55,11 @@ describe "Code gen: lib" do
       end
 
       LibC.foo(foo &.to_s)
-      ))
+      CRYSTAL
   end
 
   it "allows setting/getting external variable as function pointer" do
-    codegen(%(
+    codegen(<<-CRYSTAL)
       require "prelude"
 
       lib LibC
@@ -68,11 +68,11 @@ describe "Code gen: lib" do
 
       LibC.x = ->{}
       LibC.x.call
-      ))
+      CRYSTAL
   end
 
   it "can use enum as fun argument" do
-    codegen(%(
+    codegen(<<-CRYSTAL)
       enum Foo
         A
       end
@@ -82,11 +82,11 @@ describe "Code gen: lib" do
       end
 
       LibC.foo(Foo::A)
-      ))
+      CRYSTAL
   end
 
   it "can use enum as fun return" do
-    codegen(%(
+    codegen(<<-CRYSTAL)
       enum Foo
         A
       end
@@ -96,7 +96,7 @@ describe "Code gen: lib" do
       end
 
       LibC.foo
-      ))
+      CRYSTAL
   end
 
   it "can use tuple as fun return" do
@@ -123,7 +123,7 @@ describe "Code gen: lib" do
   end
 
   it "get fun field from struct (#672)" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(10)
       require "prelude"
 
       lib Moo
@@ -135,11 +135,11 @@ describe "Code gen: lib" do
       p = Pointer(Moo::Type).malloc(1)
       p.value.func = -> (t: Moo::Type*) { 10 }
       p.value.func.call(p)
-      )).to_i.should eq(10)
+      CRYSTAL
   end
 
   it "get fun field from union (#672)" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(10)
       require "prelude"
 
       lib Moo
@@ -151,50 +151,50 @@ describe "Code gen: lib" do
       p = Pointer(Moo::Type).malloc(1)
       p.value.func = -> (t: Moo::Type*) { 10 }
       p.value.func.call(p)
-      )).to_i.should eq(10)
+      CRYSTAL
   end
 
   it "refers to lib type (#960)" do
-    codegen(%(
+    codegen(<<-CRYSTAL)
       lib Thing
       end
 
       Thing
-      ))
+      CRYSTAL
   end
 
   it "allows invoking out with underscore " do
-    codegen(%(
+    codegen(<<-CRYSTAL)
       lib Lib
         fun foo(x : Int32*) : Float64
       end
 
       Lib.foo out _
-      ))
+      CRYSTAL
   end
 
   it "passes int as another float type in literal" do
-    codegen(%(
+    codegen(<<-CRYSTAL)
       lib LibFoo
         fun foo(x : Int32)
       end
 
       LibFoo.foo 1234.5
-      ))
+      CRYSTAL
   end
 
   it "passes nil to varargs (#1570)" do
-    codegen(%(
+    codegen(<<-CRYSTAL)
       lib LibFoo
         fun foo(...)
       end
 
       LibFoo.foo(nil)
-      ))
+      CRYSTAL
   end
 
   it "casts C fun to Crystal proc when accessing instance var (#2515)" do
-    codegen(%(
+    codegen(<<-CRYSTAL)
       require "prelude"
 
       lib LibFoo
@@ -204,37 +204,37 @@ describe "Code gen: lib" do
       end
 
       LibFoo::Some.new.to_s
-      ))
+      CRYSTAL
   end
 
   it "doesn't crash when casting -1 to UInt32 (#3594)" do
-    codegen(%(
+    codegen(<<-CRYSTAL)
       lib LibFoo
         fun foo(x : UInt32) : Nil
       end
 
       LibFoo.foo(-1)
-      ))
+      CRYSTAL
   end
 
   it "doesn't crash with nil and varargs (#4414)" do
-    codegen(%(
+    codegen(<<-CRYSTAL)
       lib LibFoo
         fun foo(Void*, ...)
       end
 
       x = nil
       LibFoo.foo(x)
-      ))
+      CRYSTAL
   end
 
   it "uses static array in lib extern (#5688)" do
-    codegen(%(
+    codegen(<<-CRYSTAL)
       lib LibFoo
         $x : Int32[10]
       end
 
       LibFoo.x
-      ))
+      CRYSTAL
   end
 end

--- a/spec/compiler/codegen/macro_spec.cr
+++ b/spec/compiler/codegen/macro_spec.cr
@@ -6,17 +6,17 @@ describe "Code gen: macro" do
   end
 
   it "expands macro with arguments" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(3)
       macro foo(n)
         {{n}} &+ 2
       end
 
       foo(1)
-      )).to_i.should eq(3)
+      CRYSTAL
   end
 
   it "expands macro that invokes another macro" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(3)
       macro foo
         def x
           1 &+ 2
@@ -29,11 +29,11 @@ describe "Code gen: macro" do
 
       bar
       x
-      )).to_i.should eq(3)
+      CRYSTAL
   end
 
   it "expands macro defined in class" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(1)
       class Foo
         macro foo
           def bar
@@ -46,11 +46,11 @@ describe "Code gen: macro" do
 
       foo = Foo.new
       foo.bar
-    )).to_i.should eq(1)
+      CRYSTAL
   end
 
   it "expands macro defined in base class" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(1)
       class Object
         macro foo
           def bar
@@ -65,48 +65,48 @@ describe "Code gen: macro" do
 
       foo = Foo.new
       foo.bar
-    )).to_i.should eq(1)
+      CRYSTAL
   end
 
   it "expands inline macro" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(1)
       a = {{ 1 }}
       a
-      )).to_i.should eq(1)
+      CRYSTAL
   end
 
   it "expands inline macro for" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(6)
       a = 0
       {% for i in [1, 2, 3] %}
         a &+= {{i}}
       {% end %}
       a
-      )).to_i.should eq(6)
+      CRYSTAL
   end
 
   it "expands inline macro if (true)" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(1)
       a = 0
       {% if 1 == 1 %}
         a &+= 1
       {% end %}
       a
-      )).to_i.should eq(1)
+      CRYSTAL
   end
 
   it "expands inline macro if (false)" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(0)
       a = 0
       {% if 1 == 2 %}
         a &+= 1
       {% end %}
       a
-      )).to_i.should eq(0)
+      CRYSTAL
   end
 
   it "finds macro in class" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(3)
       class Foo
         macro foo
           1 &+ 2
@@ -118,11 +118,11 @@ describe "Code gen: macro" do
       end
 
       Foo.new.bar
-      )).to_i.should eq(3)
+      CRYSTAL
   end
 
   it "expands def macro" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(1)
       def bar_baz
         1
       end
@@ -134,11 +134,11 @@ describe "Code gen: macro" do
       end
 
       foo
-      )).to_i.should eq(1)
+      CRYSTAL
   end
 
   it "expands def macro with var" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(1)
       class Foo
         def foo : Int32
           {{ @type }}
@@ -147,11 +147,11 @@ describe "Code gen: macro" do
       end
 
       Foo.new.foo
-      )).to_i.should eq(1)
+      CRYSTAL
   end
 
   it "expands def macro with @type.instance_vars" do
-    run(%(
+    run(<<-CRYSTAL).to_string.should eq("x")
       class Foo
         def initialize(@x : Int32)
         end
@@ -163,11 +163,11 @@ describe "Code gen: macro" do
 
       foo = Foo.new(1)
       foo.to_s
-      )).to_string.should eq("x")
+      CRYSTAL
   end
 
   it "expands def macro with @type.instance_vars with subclass" do
-    run(%(
+    run(<<-CRYSTAL).to_string.should eq("y")
       class Reference
         def to_s : String
           {{ @type.instance_vars.last.stringify }}
@@ -185,11 +185,11 @@ describe "Code gen: macro" do
       end
 
       Bar.new(1, 2).to_s
-      )).to_string.should eq("y")
+      CRYSTAL
   end
 
   it "expands def macro with @type.instance_vars with virtual" do
-    run(%(
+    run(<<-CRYSTAL).to_string.should eq("y")
       class Reference
         def to_s : String
           {{ @type.instance_vars.last.stringify }}
@@ -207,11 +207,11 @@ describe "Code gen: macro" do
       end
 
       (Bar.new(1, 2) || Foo.new(1)).to_s
-      )).to_string.should eq("y")
+      CRYSTAL
   end
 
   it "expands def macro with @type.name" do
-    run(%(
+    run(<<-CRYSTAL).to_string.should eq("Foo")
       class Foo
         def initialize(@x : Int32)
         end
@@ -223,11 +223,11 @@ describe "Code gen: macro" do
 
       foo = Foo.new(1)
       foo.to_s
-      )).to_string.should eq("Foo")
+      CRYSTAL
   end
 
   it "expands macro and resolves type correctly" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(1)
       class Foo
         def foo : Int32
           {{ @type }}
@@ -240,11 +240,11 @@ describe "Code gen: macro" do
       end
 
       Bar.new.foo
-      )).to_i.should eq(1)
+      CRYSTAL
   end
 
   it "expands def macro with @type.name with virtual" do
-    run(%(
+    run(<<-CRYSTAL).to_string.should eq("Bar")
       class Reference
         def to_s : String
           {{ @type.name.stringify }}
@@ -258,11 +258,11 @@ describe "Code gen: macro" do
       end
 
       (Bar.new || Foo.new).to_s
-      )).to_string.should eq("Bar")
+      CRYSTAL
   end
 
   it "expands def macro with @type.name with virtual (2)" do
-    run(%(
+    run(<<-CRYSTAL).to_string.should eq("Foo")
       class Reference
         def to_s : String
           {{ @type.name.stringify }}
@@ -276,11 +276,11 @@ describe "Code gen: macro" do
       end
 
       (Foo.new || Bar.new).to_s
-      )).to_string.should eq("Foo")
+      CRYSTAL
   end
 
   it "allows overriding macro definition when redefining base class" do
-    run(%(
+    run(<<-CRYSTAL).to_string.should eq("OH NO")
       class Foo
         def inspect : String
           {{@type.name.stringify}}
@@ -297,11 +297,11 @@ describe "Code gen: macro" do
       end
 
       Bar.new.inspect
-      )).to_string.should eq("OH NO")
+      CRYSTAL
   end
 
   it "uses invocation context" do
-    run(%(
+    run(<<-CRYSTAL).to_string.should eq("Foo")
       macro foo
         def bar
           {{@type.name.stringify}}
@@ -313,11 +313,11 @@ describe "Code gen: macro" do
       end
 
       Foo.new.bar
-      )).to_string.should eq("Foo")
+      CRYSTAL
   end
 
   it "allows macro with default arguments" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(3)
       def bar
         2
       end
@@ -327,11 +327,11 @@ describe "Code gen: macro" do
       end
 
       foo(1)
-      )).to_i.should eq(3)
+      CRYSTAL
   end
 
   it "expands def macro with instance var and method call (bug)" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(1)
       struct Nil
         def to_i!
           0
@@ -349,11 +349,11 @@ describe "Code gen: macro" do
       end
 
       Foo.new.foo.to_i!
-      )).to_i.should eq(1)
+      CRYSTAL
   end
 
   it "expands @type.name in virtual metaclass (1)" do
-    run(%(
+    run(<<-CRYSTAL).to_string.should eq("Foo")
       class Class
         def to_s : String
           {{ @type.name.stringify }}
@@ -370,11 +370,11 @@ describe "Code gen: macro" do
       p.value = Bar
       p.value = Foo
       p.value.to_s
-      )).to_string.should eq("Foo")
+      CRYSTAL
   end
 
   it "expands @type.name in virtual metaclass (2)" do
-    run(%(
+    run(<<-CRYSTAL).to_string.should eq("Bar")
       class Class
         def to_s : String
           {{ @type.name.stringify }}
@@ -391,11 +391,11 @@ describe "Code gen: macro" do
       p.value = Foo
       p.value = Bar
       p.value.to_s
-      )).to_string.should eq("Bar")
+      CRYSTAL
   end
 
   it "doesn't skip abstract classes when defining macro methods" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(2)
       class Object
         def foo : Int32
           {{ @type }}
@@ -420,11 +420,11 @@ describe "Code gen: macro" do
 
       t = Type1.new || Type2.new
       t.foo
-      )).to_i.should eq(2)
+      CRYSTAL
   end
 
   it "doesn't reuse macro nodes (bug)" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(2)
       struct Float
         def &+(other)
           self + other
@@ -439,18 +439,18 @@ describe "Code gen: macro" do
 
       foo 1
       foo(1.5).to_i!
-      )).to_i.should eq(2)
+      CRYSTAL
   end
 
   it "can use constants" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(1)
       CONST = 1
       {{ CONST }}
-      )).to_i.should eq(1)
+      CRYSTAL
   end
 
   it "can refer to types" do
-    run(%(
+    run(<<-CRYSTAL).to_string.should eq("y")
       class Foo
         def initialize(@x : Int32, @y : Int32)
         end
@@ -463,31 +463,31 @@ describe "Code gen: macro" do
       end
 
       Foo.new(1, 2).foo
-      )).to_string.should eq("y")
+      CRYSTAL
   end
 
   it "runs macro with splat" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(3)
       macro foo(*args)
         {{args.size}}
       end
 
       foo 1, 1, 1
-      )).to_i.should eq(3)
+      CRYSTAL
   end
 
   it "runs macro with arg and splat" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(3)
       macro foo(name, *args)
         {{args.size}}
       end
 
       foo bar, 1, 1, 1
-      )).to_i.should eq(3)
+      CRYSTAL
   end
 
   it "expands macro that yields" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(3)
       def foo
         {% for i in 0 .. 2 %}
           yield {{i}}
@@ -499,29 +499,29 @@ describe "Code gen: macro" do
         a &+= x
       end
       a
-      )).to_i.should eq(3)
+      CRYSTAL
   end
 
   it "can refer to abstract (1)" do
-    run(%(
+    run(<<-CRYSTAL).to_b.should be_false
       class Foo
       end
 
       {{ Foo.abstract? }}
-      )).to_b.should be_false
+      CRYSTAL
   end
 
   it "can refer to abstract (2)" do
-    run(%(
+    run(<<-CRYSTAL).to_b.should be_true
       abstract class Foo
       end
 
       {{ Foo.abstract? }}
-      )).to_b.should be_true
+      CRYSTAL
   end
 
   it "can refer to @type" do
-    run(%(
+    run(<<-CRYSTAL).to_string.should eq("Foo")
       class Foo
         def foo : String
           {{@type.name.stringify}}
@@ -529,17 +529,17 @@ describe "Code gen: macro" do
       end
 
       Foo.new.foo
-      )).to_string.should eq("Foo")
+      CRYSTAL
   end
 
   it "can refer to union (1)" do
-    run(%(
+    run(<<-CRYSTAL).to_b.should be_false
       {{Int32.union?}}
-    )).to_b.should be_false
+      CRYSTAL
   end
 
   it "can refer to union (2)" do
-    run(%(
+    run(<<-CRYSTAL).to_b.should be_true
       class Foo
         def initialize
           @x = 1; @x = 1.1
@@ -549,11 +549,11 @@ describe "Code gen: macro" do
         end
       end
       Foo.new.foo
-    )).to_b.should be_true
+      CRYSTAL
   end
 
   it "can iterate union types" do
-    run(%(
+    run(<<-CRYSTAL).to_string.should eq("Float64-Int32")
       class Foo
         def initialize
           @x = 1; @x = 1.1
@@ -563,66 +563,66 @@ describe "Code gen: macro" do
         end
       end
       Foo.new.foo
-    )).to_string.should eq("Float64-Int32")
+      CRYSTAL
   end
 
   it "can access type variables" do
-    run(%(
+    run(<<-CRYSTAL).to_string.should eq("Int32")
       class Foo(T)
         def foo
           {{ @type.type_vars.first.name.stringify }}
         end
       end
       Foo(Int32).new.foo
-    )).to_string.should eq("Int32")
+      CRYSTAL
   end
 
   it "can access type variables of a module" do
-    run(%(
+    run(<<-CRYSTAL).to_string.should eq("Int32")
       module Foo(T)
         def self.foo
           {{ @type.type_vars.first.name.stringify }}
         end
       end
       Foo(Int32).foo
-    )).to_string.should eq("Int32")
+      CRYSTAL
   end
 
   it "can access type variables that are not types" do
-    run(%(
+    run(<<-CRYSTAL).to_b.should be_true
       class Foo(T)
         def foo
           {{ @type.type_vars.first.is_a?(NumberLiteral) }}
         end
       end
       Foo(1).new.foo
-    )).to_b.should be_true
+      CRYSTAL
   end
 
   it "can access type variables of a tuple" do
-    run(%(
+    run(<<-CRYSTAL).to_string.should eq("Int32")
       struct Tuple
         def foo
           {{ @type.type_vars.first.name.stringify }}
         end
       end
       {1, 2, 3}.foo
-    )).to_string.should eq("Int32")
+      CRYSTAL
   end
 
   it "can access type variables of a generic type" do
-    run(%(
+    run(<<-CRYSTAL).to_string.should eq("T-K")
       class Foo(T, K)
         def self.foo : String
           {{ @type.type_vars.map(&.stringify).join("-") }}
         end
       end
       Foo.foo
-    )).to_string.should eq("T-K")
+      CRYSTAL
   end
 
   it "receives &block" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(2)
       macro foo(&block)
         bar {{block}}
       end
@@ -634,21 +634,21 @@ describe "Code gen: macro" do
       foo do |x|
         x &+ 1
       end
-      )).to_i.should eq(2)
+      CRYSTAL
   end
 
   it "executes with named arguments" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(3)
       macro foo(x = 1)
         {{x}} &+ 1
       end
 
       foo x: 2
-      )).to_i.should eq(3)
+      CRYSTAL
   end
 
   it "gets correct class name when there are classes in the middle" do
-    run(%(
+    run(<<-CRYSTAL).to_string.should eq("Qux")
       class Foo
         def class_desc : String
           {{@type.name.stringify}}
@@ -667,11 +667,11 @@ describe "Code gen: macro" do
       a = Pointer(Foo).malloc(1_u64)
       a.value = Qux.new
       a.value.class_desc
-      )).to_string.should eq("Qux")
+      CRYSTAL
   end
 
   it "transforms hooks (bug)" do
-    codegen(%(
+    codegen(<<-CRYSTAL)
       require "prelude"
 
       module GC
@@ -690,11 +690,11 @@ describe "Code gen: macro" do
 
       class Bar < Foo
       end
-      ))
+      CRYSTAL
   end
 
   it "executes subclasses" do
-    run(%(
+    run(<<-CRYSTAL).to_string.should eq("Bar-Baz")
       class Foo
       end
 
@@ -708,11 +708,11 @@ describe "Code gen: macro" do
       end
 
       {{ Foo.subclasses.map(&.name).join("-") }}
-      )).to_string.should eq("Bar-Baz")
+      CRYSTAL
   end
 
   it "executes all_subclasses" do
-    run(%(
+    run(<<-CRYSTAL).to_string.should eq("Bar-Baz")
       class Foo
       end
 
@@ -723,11 +723,11 @@ describe "Code gen: macro" do
       end
 
       {{ Foo.all_subclasses.map(&.name).join("-") }}
-      )).to_string.should eq("Bar-Baz")
+      CRYSTAL
   end
 
   it "gets enum members with @type.constants" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(0 + 1 + 2)
       enum Color
         Red
         Green
@@ -747,11 +747,11 @@ describe "Code gen: macro" do
       end
 
       Color.red.value &+ Color.green.value &+ Color.blue.value
-      )).to_i.should eq(0 + 1 + 2)
+      CRYSTAL
   end
 
   it "gets enum members as constants" do
-    run(%(
+    run(<<-CRYSTAL).to_string.should eq("Green")
       enum Color
         Red
         Green
@@ -759,11 +759,11 @@ describe "Code gen: macro" do
       end
 
       {{Color.constants[1].stringify}}
-      )).to_string.should eq("Green")
+      CRYSTAL
   end
 
   it "says that enum has Flags annotation" do
-    run(%(
+    run(<<-CRYSTAL).to_b.should be_true
       @[Flags]
       enum Color
         Red
@@ -772,11 +772,11 @@ describe "Code gen: macro" do
       end
 
       {{Color.annotation(Flags) ? true : false}}
-      )).to_b.should be_true
+      CRYSTAL
   end
 
   it "says that enum doesn't have Flags annotation" do
-    run(%(
+    run(<<-CRYSTAL).to_b.should be_false
       enum Color
         Red
         Green
@@ -784,11 +784,11 @@ describe "Code gen: macro" do
       end
 
       {{Color.annotation(Flags) ? true : false}}
-      )).to_b.should be_false
+      CRYSTAL
   end
 
   it "gets methods" do
-    run(%(
+    run(<<-CRYSTAL).to_string.should eq("bar")
       class Foo
         def bar
           1
@@ -800,11 +800,11 @@ describe "Code gen: macro" do
       end
 
       Foo.new.first_method_name
-      )).to_string.should eq("bar")
+      CRYSTAL
   end
 
   it "copies base macro def to sub-subtype even after it was copied to a subtype (#448)" do
-    run(%(
+    run(<<-CRYSTAL).to_string.should eq("Baz")
       class Object
         def class_name : String
           {{@type.name.stringify}}
@@ -831,11 +831,11 @@ describe "Code gen: macro" do
       class Baz < Bar; end
       Foo.children.value = Baz.new
       Foo.children.value.class_name
-      )).to_string.should eq("Baz")
+      CRYSTAL
   end
 
   it "recalculates method when virtual metaclass type is added" do
-    run(%(
+    run(<<-CRYSTAL).to_string.should eq("Test, RunnableTest")
       require "prelude"
 
       class Global
@@ -883,11 +883,11 @@ describe "Code gen: macro" do
 
       run
       Global.x.join(", ")
-      )).to_string.should eq("Test, RunnableTest")
+      CRYSTAL
   end
 
   it "correctly recomputes call (bug)" do
-    run(%(
+    run(<<-CRYSTAL).to_string.should eq("Baz")
       class Object
         def in_object
           in_class(1)
@@ -918,11 +918,11 @@ describe "Code gen: macro" do
 
       f2 = Baz.new || Foo.new
       f2.class.in_object
-      )).to_string.should eq("Baz")
+      CRYSTAL
   end
 
   it "doesn't override local variable when using macro variable" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(1)
       macro foo(x)
         %a = {{x}}
         %a
@@ -932,11 +932,11 @@ describe "Code gen: macro" do
       foo(2)
       foo(3)
       a
-      )).to_i.should eq(1)
+      CRYSTAL
   end
 
   it "doesn't override local variable when using macro variable (2)" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(26)
       macro foo(x)
         %a = {{x}} &+ 10
         %a
@@ -946,11 +946,11 @@ describe "Code gen: macro" do
       z = foo(2)
       w = foo(3)
       a &+ z &+ w
-      )).to_i.should eq(26)
+      CRYSTAL
   end
 
   it "uses indexed macro variable" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(4 + 5 + 6 + 40 + 50 + 60)
       macro foo(*elems)
         {% for elem, i in elems %}
           %var{i} = {{elem}}
@@ -967,11 +967,11 @@ describe "Code gen: macro" do
       z &+= foo 4, 5, 6
       z &+= foo 40, 50, 60
       z
-      )).to_i.should eq(4 + 5 + 6 + 40 + 50 + 60)
+      CRYSTAL
   end
 
   it "uses indexed macro variable with many keys" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(4 + 5 + 6)
       macro foo(*elems)
         {% for elem, i in elems %}
           %var{elem, i} = {{elem}}
@@ -986,11 +986,11 @@ describe "Code gen: macro" do
 
       z = foo 4, 5, 6
       z
-      )).to_i.should eq(4 + 5 + 6)
+      CRYSTAL
   end
 
   it "codegens macro def with splat (#496)" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(6)
       class Foo
         def bar(*args) : Int32
           {{ @type }}
@@ -999,11 +999,11 @@ describe "Code gen: macro" do
       end
 
       Foo.new.bar(1, 2, 3)
-      )).to_i.should eq(6)
+      CRYSTAL
   end
 
   it "codegens macro def with default arg (similar to #496)" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(3)
       class Foo
         def bar(foo = 1) : Int32
           {{ @type }}
@@ -1012,41 +1012,41 @@ describe "Code gen: macro" do
       end
 
       Foo.new.bar
-      )).to_i.should eq(3)
+      CRYSTAL
   end
 
   it "expands macro with default arg and splat (#784)" do
-    run(%(
+    run(<<-CRYSTAL).to_string.should eq("5")
       macro some_macro(a=5, *args)
         {{a.stringify}}
       end
 
       some_macro
-      )).to_string.should eq("5")
+      CRYSTAL
   end
 
   it "expands macro with default arg and splat (2) (#784)" do
-    run(%(
+    run(<<-CRYSTAL).to_string.should eq("1")
       macro some_macro(a=5, *args)
         {{a.stringify}}
       end
 
       some_macro 1, 2, 3, 4
-      )).to_string.should eq("1")
+      CRYSTAL
   end
 
   it "expands macro with default arg and splat (3) (#784)" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(3)
       macro some_macro(a=5, *args)
         {{args.size}}
       end
 
       some_macro 1, 2, 3, 4
-      )).to_i.should eq(3)
+      CRYSTAL
   end
 
   it "checks if macro expansion returns (#821)" do
-    run(%(
+    run(<<-CRYSTAL, inject_primitives: false).to_i.should eq(123)
       macro pass
         return 123
       end
@@ -1057,11 +1057,11 @@ describe "Code gen: macro" do
       end
 
       me || 0
-      ), inject_primitives: false).to_i.should eq(123)
+      CRYSTAL
   end
 
   it "passes #826" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(123)
       macro foo
         macro bar
           {{yield}}
@@ -1073,11 +1073,11 @@ describe "Code gen: macro" do
       end
 
       bar
-      )).to_i.should eq(123)
+      CRYSTAL
   end
 
   it "declares constant in macro (#838)" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(123)
       macro foo
         {{yield}}
       end
@@ -1087,7 +1087,7 @@ describe "Code gen: macro" do
       end
 
       CONST
-      )).to_i.should eq(123)
+      CRYSTAL
   end
 
   it "errors if dynamic constant assignment after macro expansion" do
@@ -1106,7 +1106,7 @@ describe "Code gen: macro" do
   end
 
   it "finds macro from virtual type" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(123)
       class Foo
         macro foo
           123
@@ -1123,21 +1123,21 @@ describe "Code gen: macro" do
       a = Pointer(Foo).malloc(1_u64)
       a.value = Foo.new
       a.value.bar
-      )).to_i.should eq(123)
+      CRYSTAL
   end
 
   it "expands macro with escaped quotes (#895)" do
-    run(%(
+    run(<<-CRYSTAL).to_string.should eq(%(hello"))
       macro foo(x)
         "{{x}}\\""
       end
 
       foo hello
-      )).to_string.should eq(%(hello"))
+      CRYSTAL
   end
 
   it "expands macro def with return (#1040)" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(123)
       class Foo
         def a : Int32
           {{ @type }}
@@ -1146,11 +1146,11 @@ describe "Code gen: macro" do
       end
 
       Foo.new.a
-      )).to_i.should eq(123)
+      CRYSTAL
   end
 
   it "fixes empty types of macro expansions (#1379)" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(123)
       macro lala(exp)
         {{exp}}
       end
@@ -1166,11 +1166,11 @@ describe "Code gen: macro" do
       end
 
       lala foo
-      )).to_i.should eq(123)
+      CRYSTAL
   end
 
   it "expands macro as class method" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(1)
       class Foo
         macro bar
           1
@@ -1178,11 +1178,11 @@ describe "Code gen: macro" do
       end
 
       Foo.bar
-      )).to_i.should eq(1)
+      CRYSTAL
   end
 
   it "expands macro as class method and accesses @type" do
-    run(%(
+    run(<<-CRYSTAL).to_string.should eq("Foo")
       class Foo
         macro bar
           {{@type.stringify}}
@@ -1190,22 +1190,22 @@ describe "Code gen: macro" do
       end
 
       Foo.bar
-      )).to_string.should eq("Foo")
+      CRYSTAL
   end
 
   it "codegens macro with comment (bug) (#1396)" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(1)
       macro my_macro
         # {{ 1 }}
         {{ 1 }}
       end
 
       my_macro
-      )).to_i.should eq(1)
+      CRYSTAL
   end
 
   it "correctly resolves constant inside block in macro def" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(123)
       def foo
         yield
       end
@@ -1220,21 +1220,21 @@ describe "Code gen: macro" do
       end
 
       Foo.bar
-      )).to_i.should eq(123)
+      CRYSTAL
   end
 
   it "can access free variables" do
-    run(%(
+    run(<<-CRYSTAL).to_string.should eq("Int32")
       def foo(x : T) forall T
         {{ T.stringify }}
       end
 
       foo(1)
-      )).to_string.should eq("Int32")
+      CRYSTAL
   end
 
   it "types macro expansion bug (#1734)" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(1)
       class Foo
         def foo : Int32
           {{ @type }}
@@ -1247,11 +1247,11 @@ describe "Code gen: macro" do
 
       x = true ? Foo.new : Bar.new
       x.foo
-      )).to_i.should eq(1)
+      CRYSTAL
   end
 
   it "expands Path with resolve method" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(1)
       CONST = 1
 
       macro id(path)
@@ -1259,11 +1259,11 @@ describe "Code gen: macro" do
       end
 
       id(CONST)
-      )).to_i.should eq(1)
+      CRYSTAL
   end
 
   it "can use macro inside array literal" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(42)
       require "prelude"
 
       macro foo
@@ -1272,11 +1272,11 @@ describe "Code gen: macro" do
 
       ary = [foo]
       ary[0]
-      )).to_i.should eq(42)
+      CRYSTAL
   end
 
   it "can use macro inside hash literal" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(42)
       require "prelude"
 
       macro foo
@@ -1285,31 +1285,31 @@ describe "Code gen: macro" do
 
       hash = {foo => foo}
       hash[foo]
-      )).to_i.should eq(42)
+      CRYSTAL
   end
 
   it "executes with named arguments for positional arg (1)" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(3)
       macro foo(x)
         {{x}} &+ 1
       end
 
       foo x: 2
-      )).to_i.should eq(3)
+      CRYSTAL
   end
 
   it "executes with named arguments for positional arg (2)" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(6)
       macro foo(x, y)
         {{x}} &+ {{y}} &+ 1
       end
 
       foo x: 2, y: 3
-      )).to_i.should eq(6)
+      CRYSTAL
   end
 
   it "executes with named arguments for positional arg (3)" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(6)
       class String
         def bytesize
           @bytesize
@@ -1321,11 +1321,11 @@ describe "Code gen: macro" do
       end
 
       foo y: "foo", x: 2
-      )).to_i.should eq(6)
+      CRYSTAL
   end
 
   it "stringifies type without virtual marker" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(2)
       class Foo
         def foo_m : Int32
           {{ @type }}.foo
@@ -1343,11 +1343,11 @@ describe "Code gen: macro" do
       end
 
       (Bar.new || Foo.new).foo_m
-      )).to_i.should eq(2)
+      CRYSTAL
   end
 
   it "uses tuple T in method with free vars" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(2)
       struct Tuple
         def foo(x : U) forall U
           {{T.size}}
@@ -1355,11 +1355,11 @@ describe "Code gen: macro" do
       end
 
       {1, 3}.foo(1)
-      )).to_i.should eq(2)
+      CRYSTAL
   end
 
   it "implicitly marks method as macro def when using @type" do
-    run(%(
+    run(<<-CRYSTAL).to_string.should eq("Bar")
       class Foo
         def method
           {{@type.stringify}}
@@ -1370,49 +1370,49 @@ describe "Code gen: macro" do
       end
 
       Bar.new.as(Foo).method
-      )).to_string.should eq("Bar")
+      CRYSTAL
   end
 
   it "doesn't replace %s in string (#2178)" do
-    run(%(
+    run(<<-CRYSTAL).to_string.should eq("hello %s")
       {% begin %}
         "hello %s"
       {% end %}
-      )).to_string.should eq("hello %s")
+      CRYSTAL
   end
 
   it "doesn't replace %q() (#2178)" do
-    run(%(
+    run(<<-CRYSTAL).to_string.should eq("hello")
       {% begin %}
         %q(hello)
       {% end %}
-      )).to_string.should eq("hello")
+      CRYSTAL
   end
 
   it "replaces %s inside string inside interpolation (#2178)" do
-    run(%(
+    run(<<-CRYSTAL).to_string.should eq("hello world")
       require "prelude"
 
       {% begin %}
         %a = "world"
         "hello \#{ %a }"
       {% end %}
-      )).to_string.should eq("hello world")
+      CRYSTAL
   end
 
   it "replaces %s inside string inside interpolation, with braces (#2178)" do
-    run(%(
+    run(<<-CRYSTAL).to_string.should eq(%(hello [{"world", "world"}, "world"]))
       require "prelude"
 
       {% begin %}
         %a = "world"
         "hello \#{ [{ %a, %a }, %a] }"
       {% end %}
-      )).to_string.should eq(%(hello [{"world", "world"}, "world"]))
+      CRYSTAL
   end
 
   it "retains original yield expression (#2923)" do
-    run(%(
+    run(<<-CRYSTAL).to_string.should eq("hi")
       macro foo
         def bar(baz)
           {{yield}}
@@ -1424,11 +1424,11 @@ describe "Code gen: macro" do
       end
 
       bar("hi")
-      )).to_string.should eq("hi")
+      CRYSTAL
   end
 
   it "surrounds {{yield}} with begin/end" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(2)
       macro foo
         a = {{yield}}
       end
@@ -1439,11 +1439,11 @@ describe "Code gen: macro" do
         2
       end
       a
-      )).to_i.should eq(2)
+      CRYSTAL
   end
 
   it "initializes instance var in macro" do
-    run(%(
+    run(<<-CRYSTAL, inject_primitives: false).to_i.should eq(1)
       class Foo
         {% begin %}
           @x = 1
@@ -1451,11 +1451,11 @@ describe "Code gen: macro" do
       end
 
       Foo.new.@x
-      ), inject_primitives: false).to_i.should eq(1)
+      CRYSTAL
   end
 
   it "initializes class var in macro" do
-    run(%(
+    run(<<-CRYSTAL, inject_primitives: false).to_i.should eq(1)
       class Foo
         {% begin %}
           @@x = 1
@@ -1467,21 +1467,21 @@ describe "Code gen: macro" do
       end
 
       Foo.x
-      ), inject_primitives: false).to_i.should eq(1)
+      CRYSTAL
   end
 
   it "expands @def in inline macro" do
-    run(%(
+    run(<<-CRYSTAL).to_string.should eq("foo")
       def foo
         {{@def.name.stringify}}
       end
 
       foo
-      )).to_string.should eq("foo")
+      CRYSTAL
   end
 
   it "expands @def in macro" do
-    run(%(
+    run(<<-CRYSTAL).to_string.should eq("bar")
       macro foo
         {{@def.name.stringify}}
       end
@@ -1491,21 +1491,21 @@ describe "Code gen: macro" do
       end
 
       bar
-      )).to_string.should eq("bar")
+      CRYSTAL
   end
 
   it "gets constant" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(42)
       class Foo
         Bar = 42
       end
 
       {{ Foo.constant("Bar") }}
-      )).to_i.should eq(42)
+      CRYSTAL
   end
 
   it "determines if overrides (false)" do
-    run(%(
+    run(<<-CRYSTAL).to_b.should be_false
       class Foo
         def foo
           1
@@ -1516,11 +1516,11 @@ describe "Code gen: macro" do
       end
 
       {{ Bar.overrides?(Foo, "foo") }}
-      )).to_b.should be_false
+      CRYSTAL
   end
 
   it "determines if overrides (true)" do
-    run(%(
+    run(<<-CRYSTAL).to_b.should be_true
       class Foo
         def foo
           1
@@ -1534,11 +1534,11 @@ describe "Code gen: macro" do
       end
 
       {{ Bar.overrides?(Foo, "foo") }}
-      )).to_b.should be_true
+      CRYSTAL
   end
 
   it "determines if overrides, through another class (true)" do
-    run(%(
+    run(<<-CRYSTAL).to_b.should be_true
       class Foo
         def foo
           1
@@ -1555,11 +1555,11 @@ describe "Code gen: macro" do
       end
 
       {{ Baz.overrides?(Foo, "foo") }}
-      )).to_b.should be_true
+      CRYSTAL
   end
 
   it "determines if overrides, through module (true)" do
-    run(%(
+    run(<<-CRYSTAL).to_b.should be_true
       class Foo
         def foo
           1
@@ -1580,11 +1580,11 @@ describe "Code gen: macro" do
       end
 
       {{ Baz.overrides?(Foo, "foo") }}
-      )).to_b.should be_true
+      CRYSTAL
   end
 
   it "determines if overrides, with macro method (false)" do
-    run(%(
+    run(<<-CRYSTAL).to_b.should be_false
       class Foo
         def foo
           {{ @type }}
@@ -1601,11 +1601,11 @@ describe "Code gen: macro" do
       end
 
       x
-      )).to_b.should be_false
+      CRYSTAL
   end
 
   it "determines if method exists (true)" do
-    run(%(
+    run(<<-CRYSTAL).to_b.should be_true
       class Foo
         def foo
           42
@@ -1613,11 +1613,11 @@ describe "Code gen: macro" do
       end
 
       {{ Foo.has_method?(:foo) }}
-      )).to_b.should be_true
+      CRYSTAL
   end
 
   it "determines if method exists (false)" do
-    run(%(
+    run(<<-CRYSTAL).to_b.should be_false
       class Foo
         def foo
           42
@@ -1625,11 +1625,11 @@ describe "Code gen: macro" do
       end
 
       {{ Foo.has_method?(:bar) }}
-      )).to_b.should be_false
+      CRYSTAL
   end
 
   it "forwards file location" do
-    run(%(
+    run(<<-CRYSTAL, filename: "bar.cr").to_string.should eq("bar.cr")
       macro foo
         bar
       end
@@ -1639,11 +1639,11 @@ describe "Code gen: macro" do
       end
 
       foo
-      ), filename: "bar.cr").to_string.should eq("bar.cr")
+      CRYSTAL
   end
 
   it "forwards dir location" do
-    run(%(
+    run(<<-CRYSTAL, filename: "somedir/bar.cr").to_string.should eq("somedir")
       macro foo
         bar
       end
@@ -1653,11 +1653,11 @@ describe "Code gen: macro" do
       end
 
       foo
-      ), filename: "somedir/bar.cr").to_string.should eq("somedir")
+      CRYSTAL
   end
 
   it "forwards line number" do
-    run(%(
+    run(<<-CRYSTAL, filename: "somedir/bar.cr", inject_primitives: false).to_i.should eq(10)
       macro foo
         bar
       end
@@ -1667,22 +1667,22 @@ describe "Code gen: macro" do
       end
 
       foo
-      ), filename: "somedir/bar.cr", inject_primitives: false).to_i.should eq(10)
+      CRYSTAL
   end
 
   it "keeps line number with no block" do
-    run(%(
+    run(<<-CRYSTAL, filename: "somedir/bar.cr", inject_primitives: false).to_i.should eq(7)
       macro foo
         {{ yield }}
         __LINE__
       end
 
       foo
-    ), filename: "somedir/bar.cr", inject_primitives: false).to_i.should eq(7)
+      CRYSTAL
   end
 
   it "keeps line number with a block" do
-    run(%(
+    run(<<-CRYSTAL, filename: "somedir/bar.cr", inject_primitives: false).to_i.should eq(7)
       macro foo
         {{ yield }}
         __LINE__
@@ -1691,19 +1691,19 @@ describe "Code gen: macro" do
       foo do
         1
       end
-    ), filename: "somedir/bar.cr", inject_primitives: false).to_i.should eq(7)
+      CRYSTAL
   end
 
   it "resolves alias in macro" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(2)
       alias Foo = Int32 | String
 
       {{ Foo.union_types.size }}
-      )).to_i.should eq(2)
+      CRYSTAL
   end
 
   it "gets default value of instance variable" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(1)
       class Foo
         @x = 1
 
@@ -1713,11 +1713,11 @@ describe "Code gen: macro" do
       end
 
       Foo.new.default
-      )).to_i.should eq(1)
+      CRYSTAL
   end
 
   it "gets default value of instance variable of generic type" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(10)
       require "prelude"
 
       struct Int32
@@ -1735,11 +1735,11 @@ describe "Code gen: macro" do
       end
 
       Foo(Int32).new.default
-      )).to_i.should eq(10)
+      CRYSTAL
   end
 
   it "gets default value of instance variable of inherited type that also includes module" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(10)
       module Moo
         @moo = 10
       end
@@ -1756,11 +1756,11 @@ describe "Code gen: macro" do
       end
 
       Bar.new.foo
-      )).to_i.should eq(10)
+      CRYSTAL
   end
 
   it "determines if variable has default value" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(1)
       class Foo
         @x = 1
         @y : Int32
@@ -1781,11 +1781,11 @@ describe "Code gen: macro" do
       a &+= 1 if x
       a &+= 2 if y
       a
-    )).to_i.should eq(1)
+      CRYSTAL
   end
 
   it "expands macro with op assign inside assign (#5568)" do
-    run(%(
+    run(<<-CRYSTAL)
       require "prelude"
 
       macro expand
@@ -1800,11 +1800,11 @@ describe "Code gen: macro" do
         x = foo[:foo] += 1
         puts x
       end
-    )).to_string.chomp.should eq("2")
+      CRYSTAL.to_string.chomp.should eq("2")
   end
 
   it "devirtualizes @type" do
-    run(%(
+    run(<<-CRYSTAL).to_string.should eq("Foo")
       class Foo
         def foo
           {{@type.id.stringify}}
@@ -1815,11 +1815,11 @@ describe "Code gen: macro" do
       end
 
       (Foo.new || Bar.new).foo
-    )).to_string.should eq("Foo")
+      CRYSTAL
   end
 
   it "keeps heredoc contents inside macro" do
-    run(%(
+    run(<<-CRYSTAL).to_string.should eq("  %foo")
       macro foo
         <<-FOO
           %foo
@@ -1827,26 +1827,26 @@ describe "Code gen: macro" do
       end
 
       foo
-    )).to_string.should eq("  %foo")
+      CRYSTAL
   end
 
   it "keeps heredoc contents with interpolation inside macro" do
-    run(%q(
+    run(<<-CRYSTAL).to_string.should eq("  42")
       require "prelude"
 
       macro foo
         %foo = 42
         <<-FOO
-          #{ %foo }
+          \#{ %foo }
         FOO
       end
 
       foo
-    )).to_string.should eq("  42")
+      CRYSTAL
   end
 
   it "access to the program with @top_level" do
-    run(%(
+    run(<<-CRYSTAL).to_string.should eq("main")
       class Foo
         def bar
           {{@top_level.name.stringify}}
@@ -1854,11 +1854,11 @@ describe "Code gen: macro" do
       end
 
       Foo.new.bar
-      )).to_string.should eq("main")
+      CRYSTAL
   end
 
   it "responds correctly to has_constant? with @top_level" do
-    run(%(
+    run(<<-CRYSTAL).to_b.should be_true
       FOO = 1
       class Foo
         def bar
@@ -1867,11 +1867,11 @@ describe "Code gen: macro" do
       end
 
       Foo.new.bar
-      )).to_b.should be_true
+      CRYSTAL
   end
 
   it "does block unpacking inside macro expression (#13707)" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(10)
       {% begin %}
         {%
           data = [{1, 2}, {3, 4}]
@@ -1883,7 +1883,7 @@ describe "Code gen: macro" do
         %}
         {{ value }}
       {% end %}
-      )).to_i.should eq(10)
+      CRYSTAL
   end
 
   it "accepts compile-time flags" do

--- a/spec/compiler/codegen/macro_spec.cr
+++ b/spec/compiler/codegen/macro_spec.cr
@@ -1785,7 +1785,7 @@ describe "Code gen: macro" do
   end
 
   it "expands macro with op assign inside assign (#5568)" do
-    run(<<-CRYSTAL)
+    run(<<-CRYSTAL).to_string.chomp.should eq("2")
       require "prelude"
 
       macro expand
@@ -1800,7 +1800,7 @@ describe "Code gen: macro" do
         x = foo[:foo] += 1
         puts x
       end
-      CRYSTAL.to_string.chomp.should eq("2")
+      CRYSTAL
   end
 
   it "devirtualizes @type" do

--- a/spec/compiler/codegen/macro_spec.cr
+++ b/spec/compiler/codegen/macro_spec.cr
@@ -1657,7 +1657,7 @@ describe "Code gen: macro" do
   end
 
   it "forwards line number" do
-    run(<<-CRYSTAL, filename: "somedir/bar.cr", inject_primitives: false).to_i.should eq(10)
+    run(<<-CRYSTAL, filename: "somedir/bar.cr", inject_primitives: false).to_i.should eq(9)
       macro foo
         bar
       end
@@ -1671,7 +1671,7 @@ describe "Code gen: macro" do
   end
 
   it "keeps line number with no block" do
-    run(<<-CRYSTAL, filename: "somedir/bar.cr", inject_primitives: false).to_i.should eq(7)
+    run(<<-CRYSTAL, filename: "somedir/bar.cr", inject_primitives: false).to_i.should eq(6)
       macro foo
         {{ yield }}
         __LINE__
@@ -1682,7 +1682,7 @@ describe "Code gen: macro" do
   end
 
   it "keeps line number with a block" do
-    run(<<-CRYSTAL, filename: "somedir/bar.cr", inject_primitives: false).to_i.should eq(7)
+    run(<<-CRYSTAL, filename: "somedir/bar.cr", inject_primitives: false).to_i.should eq(6)
       macro foo
         {{ yield }}
         __LINE__

--- a/spec/compiler/codegen/magic_constants_spec.cr
+++ b/spec/compiler/codegen/magic_constants_spec.cr
@@ -2,37 +2,37 @@ require "../../spec_helper"
 
 describe "Code gen: magic constants" do
   it "does __LINE__" do
-    run(%(
+    run(<<-CRYSTAL, inject_primitives: false).to_i.should eq(6)
       def foo(x = __LINE__)
         x
       end
 
       foo
-      ), inject_primitives: false).to_i.should eq(6)
+      CRYSTAL
   end
 
   it "does __FILE__" do
-    run(%(
+    run(<<-CRYSTAL, filename: "/foo/bar/baz.cr").to_string.should eq("/foo/bar/baz.cr")
       def foo(x = __FILE__)
         x
       end
 
       foo
-      ), filename: "/foo/bar/baz.cr").to_string.should eq("/foo/bar/baz.cr")
+      CRYSTAL
   end
 
   it "does __DIR__" do
-    run(%(
+    run(<<-CRYSTAL, filename: "/foo/bar/baz.cr").to_string.should eq("/foo/bar")
       def foo(x = __DIR__)
         x
       end
 
       foo
-      ), filename: "/foo/bar/baz.cr").to_string.should eq("/foo/bar")
+      CRYSTAL
   end
 
   it "does __LINE__ with dispatch" do
-    run(%(
+    run(<<-CRYSTAL, inject_primitives: false).to_i.should eq(11)
       def foo(z : Int32, x = __LINE__)
         x
       end
@@ -43,21 +43,21 @@ describe "Code gen: magic constants" do
 
       a = 1 || "hello"
       foo(a)
-      ), inject_primitives: false).to_i.should eq(11)
+      CRYSTAL
   end
 
   it "does __LINE__ when specifying one default arg with __FILE__" do
-    run(%(
+    run(<<-CRYSTAL, inject_primitives: false).to_i.should eq(6)
       def foo(x, file = __FILE__, line = __LINE__)
         line
       end
 
       foo 1, "hello"
-      ), inject_primitives: false).to_i.should eq(6)
+      CRYSTAL
   end
 
   it "does __LINE__ when specifying one normal default arg" do
-    run(%(
+    run(<<-CRYSTAL, inject_primitives: false).to_i.should eq(28)
       require "primitives"
 
       def foo(x, z = 10, line = __LINE__)
@@ -65,11 +65,11 @@ describe "Code gen: magic constants" do
       end
 
       foo 1, 20
-      ), inject_primitives: false).to_i.should eq(28)
+      CRYSTAL
   end
 
   it "does __LINE__ when specifying one middle argument" do
-    run(%(
+    run(<<-CRYSTAL, inject_primitives: false).to_i.should eq(28)
       require "primitives"
 
       def foo(x, line = __LINE__, z = 1)
@@ -77,51 +77,51 @@ describe "Code gen: magic constants" do
       end
 
       foo 1, z: 20
-      ), inject_primitives: false).to_i.should eq(28)
+      CRYSTAL
   end
 
   it "does __LINE__ in macro" do
-    run(%(
+    run(<<-CRYSTAL, inject_primitives: false).to_i.should eq(6)
       macro foo(line = __LINE__)
         {{line}}
       end
 
       foo
-      ), inject_primitives: false).to_i.should eq(6)
+      CRYSTAL
   end
 
   it "does __FILE__ in macro" do
-    run(%(
+    run(<<-CRYSTAL, filename: "/foo/bar/baz.cr").to_string.should eq("/foo/bar/baz.cr")
       macro foo(file = __FILE__)
         {{file}}
       end
 
       foo
-      ), filename: "/foo/bar/baz.cr").to_string.should eq("/foo/bar/baz.cr")
+      CRYSTAL
   end
 
   it "does __DIR__ in macro" do
-    run(%(
+    run(<<-CRYSTAL, filename: "/foo/bar/baz.cr").to_string.should eq("/foo/bar")
       macro foo(dir = __DIR__)
         {{dir}}
       end
 
       foo
-      ), filename: "/foo/bar/baz.cr").to_string.should eq("/foo/bar")
+      CRYSTAL
   end
 
   it "does __END_LINE__ without block" do
-    run(%(
+    run(<<-CRYSTAL, inject_primitives: false).to_i.should eq(6)
       def foo(x = __END_LINE__)
         x
       end
 
       foo
-      ), inject_primitives: false).to_i.should eq(6)
+      CRYSTAL
   end
 
   it "does __END_LINE__ with block" do
-    run(%(
+    run(<<-CRYSTAL, inject_primitives: false).to_i.should eq(9)
       def foo(x = __END_LINE__)
         yield
         x
@@ -130,21 +130,21 @@ describe "Code gen: magic constants" do
       foo do
         1
       end
-      ), inject_primitives: false).to_i.should eq(9)
+      CRYSTAL
   end
 
   it "does __END_LINE__ in macro without block" do
-    run(%(
+    run(<<-CRYSTAL, inject_primitives: false).to_i.should eq(6)
       macro foo(line = __END_LINE__)
         {{line}}
       end
 
       foo
-      ), inject_primitives: false).to_i.should eq(6)
+      CRYSTAL
   end
 
   it "does __END_LINE__ in macro with block" do
-    run(%(
+    run(<<-CRYSTAL, inject_primitives: false).to_i.should eq(8)
       macro foo(line = __END_LINE__)
         {{line}}
       end
@@ -152,6 +152,6 @@ describe "Code gen: magic constants" do
       foo do
         1
       end
-      ), inject_primitives: false).to_i.should eq(8)
+      CRYSTAL
   end
 end

--- a/spec/compiler/codegen/magic_constants_spec.cr
+++ b/spec/compiler/codegen/magic_constants_spec.cr
@@ -2,7 +2,7 @@ require "../../spec_helper"
 
 describe "Code gen: magic constants" do
   it "does __LINE__" do
-    run(<<-CRYSTAL, inject_primitives: false).to_i.should eq(6)
+    run(<<-CRYSTAL, inject_primitives: false).to_i.should eq(5)
       def foo(x = __LINE__)
         x
       end
@@ -32,7 +32,7 @@ describe "Code gen: magic constants" do
   end
 
   it "does __LINE__ with dispatch" do
-    run(<<-CRYSTAL, inject_primitives: false).to_i.should eq(11)
+    run(<<-CRYSTAL, inject_primitives: false).to_i.should eq(10)
       def foo(z : Int32, x = __LINE__)
         x
       end
@@ -47,7 +47,7 @@ describe "Code gen: magic constants" do
   end
 
   it "does __LINE__ when specifying one default arg with __FILE__" do
-    run(<<-CRYSTAL, inject_primitives: false).to_i.should eq(6)
+    run(<<-CRYSTAL, inject_primitives: false).to_i.should eq(5)
       def foo(x, file = __FILE__, line = __LINE__)
         line
       end
@@ -57,7 +57,7 @@ describe "Code gen: magic constants" do
   end
 
   it "does __LINE__ when specifying one normal default arg" do
-    run(<<-CRYSTAL, inject_primitives: false).to_i.should eq(28)
+    run(<<-CRYSTAL, inject_primitives: false).to_i.should eq(27)
       require "primitives"
 
       def foo(x, z = 10, line = __LINE__)
@@ -69,7 +69,7 @@ describe "Code gen: magic constants" do
   end
 
   it "does __LINE__ when specifying one middle argument" do
-    run(<<-CRYSTAL, inject_primitives: false).to_i.should eq(28)
+    run(<<-CRYSTAL, inject_primitives: false).to_i.should eq(27)
       require "primitives"
 
       def foo(x, line = __LINE__, z = 1)
@@ -81,7 +81,7 @@ describe "Code gen: magic constants" do
   end
 
   it "does __LINE__ in macro" do
-    run(<<-CRYSTAL, inject_primitives: false).to_i.should eq(6)
+    run(<<-CRYSTAL, inject_primitives: false).to_i.should eq(5)
       macro foo(line = __LINE__)
         {{line}}
       end
@@ -111,7 +111,7 @@ describe "Code gen: magic constants" do
   end
 
   it "does __END_LINE__ without block" do
-    run(<<-CRYSTAL, inject_primitives: false).to_i.should eq(6)
+    run(<<-CRYSTAL, inject_primitives: false).to_i.should eq(5)
       def foo(x = __END_LINE__)
         x
       end
@@ -121,7 +121,7 @@ describe "Code gen: magic constants" do
   end
 
   it "does __END_LINE__ with block" do
-    run(<<-CRYSTAL, inject_primitives: false).to_i.should eq(9)
+    run(<<-CRYSTAL, inject_primitives: false).to_i.should eq(8)
       def foo(x = __END_LINE__)
         yield
         x
@@ -134,7 +134,7 @@ describe "Code gen: magic constants" do
   end
 
   it "does __END_LINE__ in macro without block" do
-    run(<<-CRYSTAL, inject_primitives: false).to_i.should eq(6)
+    run(<<-CRYSTAL, inject_primitives: false).to_i.should eq(5)
       macro foo(line = __END_LINE__)
         {{line}}
       end
@@ -144,7 +144,7 @@ describe "Code gen: magic constants" do
   end
 
   it "does __END_LINE__ in macro with block" do
-    run(<<-CRYSTAL, inject_primitives: false).to_i.should eq(8)
+    run(<<-CRYSTAL, inject_primitives: false).to_i.should eq(7)
       macro foo(line = __END_LINE__)
         {{line}}
       end

--- a/spec/compiler/codegen/method_missing_spec.cr
+++ b/spec/compiler/codegen/method_missing_spec.cr
@@ -2,7 +2,7 @@ require "../../spec_helper"
 
 describe "Code gen: method_missing" do
   it "does method_missing macro without args" do
-    run("
+    run(<<-CRYSTAL).to_i.should eq(1)
       class Foo
         def foo_something
           1
@@ -14,11 +14,11 @@ describe "Code gen: method_missing" do
       end
 
       Foo.new.foo
-      ").to_i.should eq(1)
+      CRYSTAL
   end
 
   it "does method_missing macro with args" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(6)
       class Foo
         macro method_missing(call)
           {{call.args.join(" &+ ").id}}
@@ -26,11 +26,11 @@ describe "Code gen: method_missing" do
       end
 
       Foo.new.foo(1, 2, 3)
-      )).to_i.should eq(6)
+      CRYSTAL
   end
 
   it "does method_missing macro with block" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(6)
       class Foo
         def foo_something
           yield 1
@@ -48,11 +48,11 @@ describe "Code gen: method_missing" do
         a &+= x
       end
       a
-      )).to_i.should eq(6)
+      CRYSTAL
   end
 
   it "does method_missing macro with block but not using it" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(3)
       class Foo
         def foo_something
           1 &+ 2
@@ -64,11 +64,11 @@ describe "Code gen: method_missing" do
       end
 
       Foo.new.foo
-      )).to_i.should eq(3)
+      CRYSTAL
   end
 
   it "does method_missing macro with virtual type (1)" do
-    run(%(
+    run(<<-CRYSTAL).to_string.should eq("Foococo")
       class Foo
         macro method_missing(call)
           "{{@type.name.id}}{{call.name.id}}"
@@ -80,11 +80,11 @@ describe "Code gen: method_missing" do
 
       foo = Foo.new || Bar.new
       foo.coco
-      )).to_string.should eq("Foococo")
+      CRYSTAL
   end
 
   it "does method_missing macro with virtual type (2)" do
-    run(%(
+    run(<<-CRYSTAL).to_string.should eq("Barcoco")
       class Foo
         macro method_missing(call)
           "{{@type.name.id}}{{call.name.id}}"
@@ -96,11 +96,11 @@ describe "Code gen: method_missing" do
 
       foo = Bar.new || Foo.new
       foo.coco
-      )).to_string.should eq("Barcoco")
+      CRYSTAL
   end
 
   it "does method_missing macro with virtual type (3)" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(1)
       class Foo
         def lala
           1
@@ -116,11 +116,11 @@ describe "Code gen: method_missing" do
 
       foo = Bar.new || Foo.new
       foo.lala
-      )).to_i.should eq(1)
+      CRYSTAL
   end
 
   it "does method_missing macro with virtual type (4)" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(2)
       class Foo
         macro method_missing(call)
           1
@@ -135,11 +135,11 @@ describe "Code gen: method_missing" do
 
       foo = Bar.new || Foo.new
       foo.lala
-      )).to_i.should eq(2)
+      CRYSTAL
   end
 
   it "does method_missing macro with virtual type (5)" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(3)
       class Foo
         macro method_missing(call)
           1
@@ -160,11 +160,11 @@ describe "Code gen: method_missing" do
 
       foo = Baz.new || Bar.new || Foo.new
       foo.lala
-      )).to_i.should eq(3)
+      CRYSTAL
   end
 
   it "does method_missing macro with virtual type (6)" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(2)
       abstract class Foo
       end
 
@@ -182,11 +182,11 @@ describe "Code gen: method_missing" do
 
       foo = Bar.new || Baz.new
       foo.lala
-      )).to_i.should eq(2)
+      CRYSTAL
   end
 
   it "does method_missing macro with virtual type (7)" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(3)
       abstract class Foo
       end
 
@@ -204,11 +204,11 @@ describe "Code gen: method_missing" do
 
       foo = Baz.new || Bar.new
       foo.lala
-      )).to_i.should eq(3)
+      CRYSTAL
   end
 
   it "does method_missing macro with virtual type (8)" do
-    run(%(
+    run(<<-CRYSTAL).to_string.should eq("Bar")
       class Foo
         macro method_missing(call)
           {{@type.name.stringify}}
@@ -223,11 +223,11 @@ describe "Code gen: method_missing" do
 
       bar = Bar.new
       bar.coco
-      )).to_string.should eq("Bar")
+      CRYSTAL
   end
 
   it "does method_missing macro with module involved" do
-    run("
+    run(<<-CRYSTAL).to_i.should eq(1)
       module Moo
         def lala
           1
@@ -243,11 +243,11 @@ describe "Code gen: method_missing" do
       end
 
       Foo.new.lala
-      ").to_i.should eq(1)
+      CRYSTAL
   end
 
   it "does method_missing macro with top level method involved" do
-    run("
+    run(<<-CRYSTAL).to_i.should eq(1)
       def lala
         1
       end
@@ -264,11 +264,11 @@ describe "Code gen: method_missing" do
 
       foo = Foo.new
       foo.bar
-      ").to_i.should eq(1)
+      CRYSTAL
   end
 
   it "does method_missing macro with included module" do
-    run("
+    run(<<-CRYSTAL).to_string.should eq("Foo")
       module Moo
         macro method_missing(call)
           {{@type.name.stringify}}
@@ -280,11 +280,11 @@ describe "Code gen: method_missing" do
       end
 
       Foo.new.coco
-      ").to_string.should eq("Foo")
+      CRYSTAL
   end
 
   it "does method_missing with assignment (bug)" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(1)
       class Foo
         macro method_missing(call)
           x = {{call.args[0]}}
@@ -294,11 +294,11 @@ describe "Code gen: method_missing" do
 
       foo = Foo.new
       foo.bar(1)
-      )).to_i.should eq(1)
+      CRYSTAL
   end
 
   it "does method_missing with assignment (2) (bug)" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(1)
       struct Nil
         def to_i!
           0
@@ -316,11 +316,11 @@ describe "Code gen: method_missing" do
 
       foo = Foo.new
       foo.bar(1).to_i!
-      )).to_i.should eq(1)
+      CRYSTAL
   end
 
   it "does method_missing macro without args (with call)" do
-    run("
+    run(<<-CRYSTAL).to_i.should eq(1)
       class Foo
         def foo_something
           1
@@ -332,11 +332,11 @@ describe "Code gen: method_missing" do
       end
 
       Foo.new.foo
-      ").to_i.should eq(1)
+      CRYSTAL
   end
 
   it "does method_missing macro with args (with call)" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(6)
       class Foo
         macro method_missing(call)
           {{call.args.join(" &+ ").id}}
@@ -344,11 +344,11 @@ describe "Code gen: method_missing" do
       end
 
       Foo.new.foo(1, 2, 3)
-      )).to_i.should eq(6)
+      CRYSTAL
   end
 
   it "forwards" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(6)
       class Wrapped
         def foo(x, y, z)
           x &+ y &+ z
@@ -365,11 +365,11 @@ describe "Code gen: method_missing" do
       end
 
       Foo.new(Wrapped.new).foo(1, 2, 3)
-      )).to_i.should eq(6)
+      CRYSTAL
   end
 
   it "does method_missing generating method" do
-    run(%(
+    run(<<-CRYSTAL).to_string.should eq("bar")
       class Foo
         macro method_missing(call)
           def {{call.name}}
@@ -379,11 +379,11 @@ describe "Code gen: method_missing" do
       end
 
       Foo.new.bar
-      )).to_string.should eq("bar")
+      CRYSTAL
   end
 
   it "works with named arguments (#3654)" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(3)
       class A
         macro method_missing(call)
           {{call.named_args[0].value}} &+
@@ -393,11 +393,11 @@ describe "Code gen: method_missing" do
 
       a = A.new
       a.b(x: 1, y: 2)
-      )).to_i.should eq(3)
+      CRYSTAL
   end
 
   it "works with named arguments that aren't legal variable names (#10381)" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(3)
       class A
         macro method_missing(call)
           {{call.named_args[0].value}} &+
@@ -407,11 +407,11 @@ describe "Code gen: method_missing" do
 
       a = A.new
       a.b("@x": 1, Y: 2)
-      )).to_i.should eq(3)
+      CRYSTAL
   end
 
   it "finds method_missing with 'with ... yield'" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(10)
       class Foo
         def initialize(@x : Int32)
         end
@@ -429,6 +429,6 @@ describe "Code gen: method_missing" do
       bar do
         x
       end
-      )).to_i.should eq(10)
+      CRYSTAL
   end
 end

--- a/spec/compiler/codegen/module_spec.cr
+++ b/spec/compiler/codegen/module_spec.cr
@@ -2,7 +2,7 @@ require "../../spec_helper"
 
 describe "Code gen: module" do
   it "codegens pointer of module with method" do
-    run("
+    run(<<-CRYSTAL).to_i.should eq(1)
       module Moo
       end
 
@@ -17,11 +17,11 @@ describe "Code gen: module" do
       p = Pointer(Moo).malloc(1_u64)
       p.value = Foo.new
       p.value.foo
-      ").to_i.should eq(1)
+      CRYSTAL
   end
 
   it "codegens pointer of module with method with two including types" do
-    run("
+    run(<<-CRYSTAL).to_i.should eq(2)
       module Moo
       end
 
@@ -45,11 +45,11 @@ describe "Code gen: module" do
       p.value = Foo.new
       p.value = Bar.new
       p.value.foo
-      ").to_i.should eq(2)
+      CRYSTAL
   end
 
   it "codegens pointer of module with method with two including types with one struct" do
-    run("
+    run(<<-CRYSTAL).to_i.should eq(2)
       module Foo
       end
 
@@ -73,11 +73,11 @@ describe "Code gen: module" do
       p.value = Bar.new
       p.value = Coco.new
       p.value.foo
-      ").to_i.should eq(2)
+      CRYSTAL
   end
 
   it "codegens pointer of module with method with two including types with one struct (2)" do
-    run("
+    run(<<-CRYSTAL).to_i.should eq(2)
       module Foo
       end
 
@@ -102,11 +102,11 @@ describe "Code gen: module" do
       p.value = Coco.new
       x = p.value
       x.foo
-      ").to_i.should eq(2)
+      CRYSTAL
   end
 
   it "codegens pointer of module and pass value to method" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(1)
       module Foo
       end
 
@@ -125,11 +125,11 @@ describe "Code gen: module" do
       p = Pointer(Foo).malloc(1_u64)
       p.value = Bar.new
       foo p.value
-      )).to_i.should eq(1)
+      CRYSTAL
   end
 
   it "codegens pointer of module with block" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(1)
       require "prelude"
 
       module Moo
@@ -156,11 +156,11 @@ describe "Code gen: module" do
         x = io
       end
       x.not_nil!.foo
-      )).to_i.should eq(1)
+      CRYSTAL
   end
 
   it "codegens module with virtual type" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(2)
       module Moo
       end
 
@@ -181,11 +181,11 @@ describe "Code gen: module" do
       p = Pointer(Moo).malloc(1_u64)
       p.value = Bar.new
       p.value.foo
-      )).to_i.should eq(2)
+      CRYSTAL
   end
 
   it "declares proc with module type" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(1)
       module Moo
         def moo
           1
@@ -202,11 +202,11 @@ describe "Code gen: module" do
 
       foo = ->(x : Moo) { x.moo }
       foo.call(Bar.new)
-      )).to_i.should eq(1)
+      CRYSTAL
   end
 
   it "declares proc with module type and invoke it with two different types that return themselves" do
-    codegen(%(
+    codegen(<<-CRYSTAL)
       module Moo
         def moo
           1
@@ -224,11 +224,11 @@ describe "Code gen: module" do
       foo = ->(x : Moo) { x }
       foo.call(Foo.new)
       foo.call(Bar.new)
-      ))
+      CRYSTAL
   end
 
   it "codegens proc of a module that was never included" do
-    codegen(%(
+    codegen(<<-CRYSTAL)
       require "prelude"
 
       module Moo
@@ -236,11 +236,11 @@ describe "Code gen: module" do
 
       ->(x : Moo) { x.foo }
       1
-      ))
+      CRYSTAL
   end
 
   it "codegens proc of module when generic type includes it" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(3)
       module Moo
       end
 
@@ -254,11 +254,11 @@ describe "Code gen: module" do
 
       z = ->(x : Moo) { x.foo }
       z.call(Foo(Int32).new)
-      )).to_i.should eq(3)
+      CRYSTAL
   end
 
   it "invokes method on yielded module that has no instances (#1079)" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(456)
       require "prelude"
 
       module Mod
@@ -273,11 +273,11 @@ describe "Code gen: module" do
       end
 
       foo { |x| x.coco }
-      )).to_i.should eq(456)
+      CRYSTAL
   end
 
   it "expands modules to its including types (#1916)" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(1)
       class Reference
         def method(other : Reference)
           1
@@ -303,11 +303,11 @@ describe "Code gen: module" do
       y = x.as(Moo)
 
       x.method(y)
-      )).to_i.should eq(1)
+      CRYSTAL
   end
 
   it "expands modules to its including types (2) (#1916)" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(1)
       class Reference
         def method(other : Reference)
           1
@@ -333,11 +333,11 @@ describe "Code gen: module" do
       file2 = file.as(Moo)
 
       file.method(file2)
-      )).to_i.should eq(1)
+      CRYSTAL
   end
 
   it "expands modules to its including types (3) (#1916)" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(2)
       class Object
         def method(other : Reference)
           1
@@ -363,11 +363,11 @@ describe "Code gen: module" do
       y = x.as(Moo)
 
       x.method(y)
-      )).to_i.should eq(2)
+      CRYSTAL
   end
 
   it "codegens cast to module with class and struct to nilable module" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(10)
       module Moo
         def bar
           10
@@ -393,11 +393,11 @@ describe "Code gen: module" do
       else
         20
       end
-      )).to_i.should eq(10)
+      CRYSTAL
   end
 
   it "codegens cast to module that includes bool" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(2)
       module Moo
       end
 
@@ -416,11 +416,11 @@ describe "Code gen: module" do
       else
         2
       end
-      )).to_i.should eq(2)
+      CRYSTAL
   end
 
   it "declares and includes generic module, in macros T is a tuple literal" do
-    run(%(
+    run(<<-CRYSTAL).to_string.should eq("TupleLiteral")
       module Moo(*T)
         def t
           {{T.class_name}}
@@ -432,11 +432,11 @@ describe "Code gen: module" do
       end
 
       Foo.new.t
-      )).to_string.should eq("TupleLiteral")
+      CRYSTAL
   end
 
   it "can instantiate generic module" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(10)
       struct Int32
         def self.foo
           10
@@ -450,11 +450,11 @@ describe "Code gen: module" do
       end
 
       Foo(Int32).foo
-      )).to_i.should eq(10)
+      CRYSTAL
   end
 
   it "can use generic module as instance variable type" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(3)
       module Moo(T)
         def foo
           1
@@ -489,11 +489,11 @@ describe "Code gen: module" do
       y = mooer.moo
 
       x &+ y
-      )).to_i.should eq(3)
+      CRYSTAL
   end
 
   it "can use generic module as instance variable type (2)" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(3)
       module Moo(T)
         def foo
           1
@@ -528,11 +528,11 @@ describe "Code gen: module" do
       y = mooer.moo
 
       x &+ y
-      )).to_i.should eq(3)
+      CRYSTAL
   end
 
   it "casts to union of module that is included in other module (#3323)" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(10)
       require "prelude"
 
       module Moo
@@ -561,11 +561,11 @@ describe "Code gen: module" do
 
       bar = Bar.new.as(Int32 | Moo)
       bar.as(Moo).moo
-      )).to_i.should eq(10)
+      CRYSTAL
   end
 
   it "casts to union of generic module that is included in other module (#3323)" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(10)
       require "prelude"
 
       module Moo(T)
@@ -594,11 +594,11 @@ describe "Code gen: module" do
 
       bar = Bar.new.as(Int32 | Moo(Char))
       bar.as(Moo(Char)).moo
-      )).to_i.should eq(10)
+      CRYSTAL
   end
 
   it "codegens dispatch of union with module (#3647)" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(234)
       module Moo
       end
 
@@ -620,6 +620,6 @@ describe "Code gen: module" do
       m = Bar.new.as(Moo)
       a = m || 1
       foo(a)
-      )).to_i.should eq(234)
+      CRYSTAL
   end
 end

--- a/spec/compiler/codegen/named_args_spec.cr
+++ b/spec/compiler/codegen/named_args_spec.cr
@@ -2,27 +2,27 @@ require "../../spec_helper"
 
 describe "Code gen: named args" do
   it "calls with named arg" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(10)
       def foo(y = 2)
         y
       end
 
       foo y: 10
-      )).to_i.should eq(10)
+      CRYSTAL
   end
 
   it "calls with named arg and other args" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(13)
       def foo(x, y = 2, z = 3)
         x &+ y &+ z
       end
 
       foo 1, z: 10
-      )).to_i.should eq(13)
+      CRYSTAL
   end
 
   it "calls with named arg as object method" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(13)
       class Foo
         def foo(x, y = 2, z = 3)
           x &+ y &+ z
@@ -30,11 +30,11 @@ describe "Code gen: named args" do
       end
 
       Foo.new.foo 1, z: 10
-      )).to_i.should eq(13)
+      CRYSTAL
   end
 
   it "calls twice with different types" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(5)
       struct Int32
         def &+(other : Float)
           self + other
@@ -49,11 +49,11 @@ describe "Code gen: named args" do
       value &+= add(1, y: 2)
       value &+= add(1, y: 1.3)
       value.to_i!
-      )).to_i.should eq(5)
+      CRYSTAL
   end
 
   it "calls new with named arg" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(13)
       class Foo
         @value : Int32
 
@@ -67,11 +67,11 @@ describe "Code gen: named args" do
       end
 
       Foo.new(1, z: 10).value
-      )).to_i.should eq(13)
+      CRYSTAL
   end
 
   it "uses named args in dispatch" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(22)
       class Foo
         def foo(x, z = 2)
           x &+ z &+ 1
@@ -86,51 +86,51 @@ describe "Code gen: named args" do
 
       a = Foo.new || Bar.new
       a.foo 1, z: 20
-      )).to_i.should eq(22)
+      CRYSTAL
   end
 
   it "sends one regular argument as named argument" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(42)
       def foo(x)
         x
       end
 
       foo x: 42
-      )).to_i.should eq(42)
+      CRYSTAL
   end
 
   it "sends two regular arguments as named arguments" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(42)
       def foo(x, y)
         x &+ y
       end
 
       foo x: 10, y: 32
-      )).to_i.should eq(42)
+      CRYSTAL
   end
 
   it "sends two regular arguments as named arguments in inverted position (1)" do
-    run(%(
+    run(<<-CRYSTAL).to_string.should eq("foo")
       def foo(x, y)
         x
       end
 
       foo y: 42, x: "foo"
-      )).to_string.should eq("foo")
+      CRYSTAL
   end
 
   it "sends two regular arguments as named arguments in inverted position (2)" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(42)
       def foo(x, y)
         y
       end
 
       foo y: 42, x: "foo"
-      )).to_i.should eq(42)
+      CRYSTAL
   end
 
   it "overloads based on required named args" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(10 + 20 + 30*40)
       def foo(x, *, y)
         x &+ y
       end
@@ -142,11 +142,11 @@ describe "Code gen: named args" do
       a = foo(10, y: 20)
       b = foo(30, z: 40)
       a &+ b
-      )).to_i.should eq(10 + 20 + 30*40)
+      CRYSTAL
   end
 
   it "overloads based on required named args, with restrictions" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(10 + 20 + 30*40)
       def foo(x, *, z : Int32)
         x &+ z
       end
@@ -158,11 +158,11 @@ describe "Code gen: named args" do
       a = foo(10, z: 20)
       b = foo(30, z: 40.0)
       a &+ b
-      )).to_i.should eq(10 + 20 + 30*40)
+      CRYSTAL
   end
 
   it "uses bare splat in new (2)" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(42)
       class Foo
         def initialize(*, y = 22)
           @y = y
@@ -176,6 +176,6 @@ describe "Code gen: named args" do
       v1 = Foo.new.y
       v2 = Foo.new(y: 20).y
       v1 &+ v2
-      )).to_i.should eq(42)
+      CRYSTAL
   end
 end

--- a/spec/compiler/codegen/named_tuple_spec.cr
+++ b/spec/compiler/codegen/named_tuple_spec.cr
@@ -2,52 +2,52 @@ require "../../spec_helper"
 
 describe "Code gen: named tuple" do
   it "codegens tuple index" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(42)
       t = {x: 42, y: 'a'}
       t[:x]
-      )).to_i.should eq(42)
+      CRYSTAL
   end
 
   it "codegens tuple index another order" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(42)
       t = {y: 'a', x: 42}
       t[:x]
-      )).to_i.should eq(42)
+      CRYSTAL
   end
 
   it "codegens tuple nilable index (1)" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(42)
       t = {x: 42, y: 'a'}
       t[:x]? || 84
-      )).to_i.should eq(42)
+      CRYSTAL
   end
 
   it "codegens tuple nilable index (2)" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(42)
       t = {x: 'a', y: 42}
       t[:y]? || 84
-      )).to_i.should eq(42)
+      CRYSTAL
   end
 
   it "codegens tuple nilable index (3)" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(84)
       t = {x: 'a', y: 42}
       t[:z]? || 84
-      )).to_i.should eq(84)
+      CRYSTAL
   end
 
   it "passes named tuple to def" do
-    run("
+    run(<<-CRYSTAL).to_i.should eq(42)
       def foo(t)
         t[:x]
       end
 
       foo({y: 'a', x: 42})
-      ").to_i.should eq(42)
+      CRYSTAL
   end
 
   it "gets size at compile time" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(2)
       struct NamedTuple
         def my_size
           {{ T.size }}
@@ -55,11 +55,11 @@ describe "Code gen: named tuple" do
       end
 
       {x: 10, y: 20}.my_size
-      )).to_i.should eq(2)
+      CRYSTAL
   end
 
   it "gets keys at compile time (1)" do
-    run(%(
+    run(<<-CRYSTAL).to_string.should eq("x")
       struct NamedTuple
         def keys
           {{ T.keys.map(&.stringify)[0] }}
@@ -67,11 +67,11 @@ describe "Code gen: named tuple" do
       end
 
       {x: 10, y: 2}.keys
-      )).to_string.should eq("x")
+      CRYSTAL
   end
 
   it "gets keys at compile time (2)" do
-    run(%(
+    run(<<-CRYSTAL).to_string.should eq("y")
       struct NamedTuple
         def keys
           {{ T.keys.map(&.stringify)[1] }}
@@ -79,11 +79,11 @@ describe "Code gen: named tuple" do
       end
 
       {x: 10, y: 2}.keys
-      )).to_string.should eq("y")
+      CRYSTAL
   end
 
   it "doesn't crash when overload doesn't match" do
-    codegen(%(
+    codegen(<<-CRYSTAL)
       struct NamedTuple
         def foo(other : self)
         end
@@ -95,11 +95,11 @@ describe "Code gen: named tuple" do
       tup1 = {a: 1}
       tup2 = {b: 1}
       tup1.foo(tup2)
-      ))
+      CRYSTAL
   end
 
   it "assigns named tuple to compatible named tuple" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(42)
       ptr = Pointer({x: Int32, y: String}).malloc(1_u64)
 
       # Here the compiler should reorder the values to match
@@ -107,11 +107,11 @@ describe "Code gen: named tuple" do
       ptr.value = {y: "hello", x: 42}
 
       ptr.value[:x]
-      )).to_i.should eq(42)
+      CRYSTAL
   end
 
   it "upcasts named tuple inside compatible named tuple" do
-    run(%(
+    run(<<-CRYSTAL).to_string.should eq("Bar")
       def foo
         if 1 == 2
           {name: "Foo", age: 20}
@@ -123,11 +123,11 @@ describe "Code gen: named tuple" do
       end
 
       foo[:name]
-      )).to_string.should eq("Bar")
+      CRYSTAL
   end
 
   it "assigns named tuple union to compatible named tuple" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(42)
       tup1 = {x: 1, y: "foo"}
       tup2 = {x: 3}
       tup3 = {y: "bar", x: 42}
@@ -139,11 +139,11 @@ describe "Code gen: named tuple" do
       ptr.value = tup3
 
       ptr.value[:x]
-      )).to_i.should eq(42)
+      CRYSTAL
   end
 
   it "upcasts named tuple union to compatible named tuple" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(42)
       def foo
         if 1 == 2
           {x: 1, y: "foo"} || {x: 3}
@@ -153,11 +153,11 @@ describe "Code gen: named tuple" do
       end
 
       foo[:x]
-      )).to_i.should eq(42)
+      CRYSTAL
   end
 
   it "assigns named tuple inside union to union with compatible named tuple" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(42)
       tup1 = {x: 21, y: "foo"}
       tup2 = {x: 3}
 
@@ -175,11 +175,11 @@ describe "Code gen: named tuple" do
       ptr.value = union2
 
       ptr.value[:x]
-      )).to_i.should eq(42)
+      CRYSTAL
   end
 
   it "upcasts named tuple inside union to union with compatible named tuple" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(42)
       def foo
         if 1 == 2
           tup1 = {x: 21, y: "foo"}
@@ -198,11 +198,11 @@ describe "Code gen: named tuple" do
       end
 
       foo[:x]
-      )).to_i.should eq(42)
+      CRYSTAL
   end
 
   it "allows named tuple covariance" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(42)
        class Obj
          def initialize
            @tuple = {foo: Foo.new}
@@ -231,11 +231,11 @@ describe "Code gen: named tuple" do
        obj = Obj.new
        obj.tuple = {foo: Bar.new}
        obj.tuple[:foo].bar
-       )).to_i.should eq(42)
+       CRYSTAL
   end
 
   it "merges two named tuple types with same keys but different types (1)" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(20)
        def foo
          if 1 == 2
            {x: "foo", y: 10}
@@ -246,11 +246,11 @@ describe "Code gen: named tuple" do
 
        val = foo[:y]
        val || 20
-       )).to_i.should eq(20)
+       CRYSTAL
   end
 
   it "merges two named tuple types with same keys but different types (2)" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(10)
        def foo
          if 1 == 1
            {x: "foo", y: 10}
@@ -261,11 +261,11 @@ describe "Code gen: named tuple" do
 
        val = foo[:y]
        val || 20
-       )).to_i.should eq(10)
+       CRYSTAL
   end
 
   it "codegens union of tuple of float with tuple of tuple of float" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(42)
       a = {x: 1.5}
       b = {x: {22.0, 20.0} }
       c = b || a
@@ -275,31 +275,31 @@ describe "Code gen: named tuple" do
       else
         v[0].to_i! &+ v[1].to_i!
       end
-      )).to_i.should eq(42)
+      CRYSTAL
   end
 
   it "provides T as a named tuple literal" do
-    run(%(
+    run(<<-CRYSTAL).to_string.should eq("NamedTupleLiteral")
       struct NamedTuple
         def self.foo
           {{ T.class_name }}
         end
       end
       NamedTuple(x: Nil, y: Int32).foo
-      )).to_string.should eq("NamedTupleLiteral")
+      CRYSTAL
   end
 
   it "assigns two same-size named tuple types to a same var (#3132)" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(2)
       t = {x: true}
       t
       t = {x: 2}
       t[:x]
-      )).to_i.should eq(2)
+      CRYSTAL
   end
 
   it "downcasts union inside tuple to value (#3907)" do
-    codegen(%(
+    codegen(<<-CRYSTAL)
       struct Foo
       end
 
@@ -308,11 +308,11 @@ describe "Code gen: named tuple" do
       x = {a: 0, b: foo}
       z = x[:a]
       x = {a: 0, b: z}
-      ))
+      CRYSTAL
   end
 
   it "accesses T and creates instance from it" do
-    run("
+    run(<<-CRYSTAL).to_i.should eq(2)
       struct NamedTuple
         def named_args
           T
@@ -331,19 +331,19 @@ describe "Code gen: named tuple" do
       t = {a: Foo.new(1)}
       f = t.named_args[:a].new(2)
       f.x
-      ").to_i.should eq(2)
+      CRYSTAL
   end
 
   it "does to_s for NamedTuple class" do
-    run(%(
+    run(<<-CRYSTAL).to_string.should eq(%(NamedTuple(a: Int32, "b c": String, "+": Char)))
       require "prelude"
 
       NamedTuple(a: Int32, "b c": String, "+": Char).to_s
-      )).to_string.should eq(%(NamedTuple(a: Int32, "b c": String, "+": Char)))
+      CRYSTAL
   end
 
   it "doesn't error if NamedTuple includes a non-generic module (#10380)" do
-    codegen(%(
+    codegen(<<-CRYSTAL)
       module Foo
       end
 
@@ -353,6 +353,6 @@ describe "Code gen: named tuple" do
 
       x = uninitialized Foo
       x = {a: 1}
-      ))
+      CRYSTAL
   end
 end

--- a/spec/compiler/codegen/new_spec.cr
+++ b/spec/compiler/codegen/new_spec.cr
@@ -2,7 +2,7 @@ require "../../spec_helper"
 
 describe "Code gen: new" do
   it "codegens instance method with allocate" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(1)
       class Foo
         def coco
           1
@@ -10,11 +10,11 @@ describe "Code gen: new" do
       end
 
       Foo.allocate.coco
-      )).to_i.should eq(1)
+      CRYSTAL
   end
 
   it "codegens instance method with new and instance var" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(1)
       class Foo
         def initialize
           @coco = 2
@@ -28,11 +28,11 @@ describe "Code gen: new" do
 
       f = Foo.new
       f.coco
-      )).to_i.should eq(1)
+      CRYSTAL
   end
 
   it "codegens instance method with new" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(1)
       class Foo
         def coco
           1
@@ -40,17 +40,17 @@ describe "Code gen: new" do
       end
 
       Foo.new.coco
-      )).to_i.should eq(1)
+      CRYSTAL
   end
 
   it "can create Reference" do
-    run(%(
+    run(<<-CRYSTAL).to_b.should be_false
       Reference.new.object_id == 0
-      )).to_b.should be_false
+      CRYSTAL
   end
 
   it "inherits initialize" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(42)
       class Foo
         def initialize(@x : Int32)
         end
@@ -64,11 +64,11 @@ describe "Code gen: new" do
       end
 
       Bar.new(42).x
-      )).to_i.should eq(42)
+      CRYSTAL
   end
 
   it "inherits initialize for generic type" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(42)
       class Foo(T)
         def initialize(@x : Int32)
         end
@@ -81,11 +81,11 @@ describe "Code gen: new" do
       end
 
       Bar(Int32).new(42).x
-      )).to_i.should eq(42)
+      CRYSTAL
   end
 
   it "overloads new and initialize, 1 (#2489)" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(10)
       class String
         def size
           10
@@ -110,11 +110,11 @@ describe "Code gen: new" do
       end
 
       Foo.new.foo
-      )).to_i.should eq(10)
+      CRYSTAL
   end
 
   it "overloads new and initialize, 2 (#2489)" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(6)
       class Global
         @@x = 0
 
@@ -141,11 +141,11 @@ describe "Code gen: new" do
       Bar.new(5)
 
       Global.x
-      )).to_i.should eq(6)
+      CRYSTAL
   end
 
   it "overloads new and initialize, 3 (#2489)" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(6)
       class Global
         @@x = 0
 
@@ -170,11 +170,11 @@ describe "Code gen: new" do
       Foo.new(5)
 
       Global.x
-      )).to_i.should eq(6)
+      CRYSTAL
   end
 
   it "defines new for module" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(42)
       module Moo
         @x : Int32
 
@@ -192,11 +192,11 @@ describe "Code gen: new" do
       end
 
       Foo.new(41).x
-      )).to_i.should eq(42)
+      CRYSTAL
   end
 
   it "finds super in deep hierarchy" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(42)
       class Foo
         def initialize(@x : Int32)
         end
@@ -219,11 +219,11 @@ describe "Code gen: new" do
       end
 
       Qux.new.x
-      )).to_i.should eq(42)
+      CRYSTAL
   end
 
   it "finds new in superclass if no initialize is defined (1)" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(42)
       class Foo
         def self.new
           42
@@ -234,11 +234,11 @@ describe "Code gen: new" do
       end
 
       Bar.new
-      )).to_i.should eq(42)
+      CRYSTAL
   end
 
   it "finds new in superclass if no initialize is defined (2)" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(42)
       class Foo
         def self.new
           42
@@ -252,11 +252,11 @@ describe "Code gen: new" do
       end
 
       Bar.new
-      )).to_i.should eq(42)
+      CRYSTAL
   end
 
   it "finds new in superclass for Enum" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(1)
       struct Enum
         def self.new(x : String)
           new(1)
@@ -271,19 +271,19 @@ describe "Code gen: new" do
 
       color = Color.new("foo")
       color.value
-      )).to_i.should eq(1)
+      CRYSTAL
   end
 
   it "can create Tuple with Tuple.new" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(0)
       require "prelude"
 
       Tuple.new.size
-      )).to_i.should eq(0)
+      CRYSTAL
   end
 
   it "evaluates initialize default value at the instance scope (1) (#731)" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(42)
       class Foo
         @x : Int32
 
@@ -300,11 +300,11 @@ describe "Code gen: new" do
       end
 
       Foo.new.x
-      )).to_i.should eq(42)
+      CRYSTAL
   end
 
   it "evaluates initialize default value at the instance scope (2) (#731)" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(42)
       class Foo
         @x : Int32
 
@@ -326,11 +326,11 @@ describe "Code gen: new" do
 
       foo = Foo.new(y: 22)
       foo.x &+ foo.y
-      )).to_i.should eq(42)
+      CRYSTAL
   end
 
   it "evaluates initialize default value at the instance scope (3) (#731)" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(42)
       class Foo
         @x : Int32
 
@@ -354,11 +354,11 @@ describe "Code gen: new" do
       end
       total &+= foo.x
       total
-      )).to_i.should eq(42)
+      CRYSTAL
   end
 
   it "evaluates initialize default value at the instance scope (4) (#731)" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(42)
       class Foo
         @x : Int32
 
@@ -382,6 +382,6 @@ describe "Code gen: new" do
         20
       end
       foo.x &+ foo.block.call
-      )).to_i.should eq(42)
+      CRYSTAL
   end
 end

--- a/spec/compiler/codegen/next_spec.cr
+++ b/spec/compiler/codegen/next_spec.cr
@@ -2,7 +2,7 @@ require "../../spec_helper"
 
 describe "Code gen: next" do
   it "codegens next" do
-    run("
+    run(<<-CRYSTAL).to_i.should eq(1)
       def foo
         yield
       end
@@ -10,11 +10,11 @@ describe "Code gen: next" do
       foo do
         next 1
       end
-      ").to_i.should eq(1)
+      CRYSTAL
   end
 
   it "codegens next conditionally" do
-    run("
+    run(<<-CRYSTAL).to_i.should eq(4)
       def foo
         yield 1
         yield 2
@@ -28,11 +28,11 @@ describe "Code gen: next" do
         a &+= i
       end
       a
-      ").to_i.should eq(4)
+      CRYSTAL
   end
 
   it "codegens next conditionally with int type (2)" do
-    run("
+    run(<<-CRYSTAL).to_i.should eq(100)
       def foo
         x = 0
         x &+= yield 1
@@ -52,11 +52,11 @@ describe "Code gen: next" do
         end
         40
       end
-      ").to_i.should eq(100)
+      CRYSTAL
   end
 
   it "codegens next with break (1)" do
-    run("
+    run(<<-CRYSTAL).to_i.should eq(20)
       def foo
         yield 1
       end
@@ -68,11 +68,11 @@ describe "Code gen: next" do
           next 10
         end
       end
-      ").to_i.should eq(20)
+      CRYSTAL
   end
 
   it "codegens next with break (2)" do
-    run("
+    run(<<-CRYSTAL).to_i.should eq(40)
       def foo
         a = 0
         a &+= yield 1
@@ -88,11 +88,11 @@ describe "Code gen: next" do
         end
         30
       end
-      ").to_i.should eq(40)
+      CRYSTAL
   end
 
   it "codegens next with break (3)" do
-    run("
+    run(<<-CRYSTAL).to_i.should eq(20)
       def foo
         a = 0
         a &+= yield 1
@@ -108,11 +108,11 @@ describe "Code gen: next" do
         end
         30
       end
-      ").to_i.should eq(20)
+      CRYSTAL
   end
 
   it "codegens next with while inside block" do
-    run("
+    run(<<-CRYSTAL).to_i.should eq(30)
       def foo
         a = 0
         a &+= yield 4
@@ -133,11 +133,11 @@ describe "Code gen: next" do
         end
         20
       end
-      ").to_i.should eq(30)
+      CRYSTAL
   end
 
   it "codegens next without expressions" do
-    run("
+    run(<<-CRYSTAL).to_i.should eq(1)
       struct Nil; def to_i!; 0; end; end
 
       def foo
@@ -151,6 +151,6 @@ describe "Code gen: next" do
           next
         end
       end.to_i!
-      ").to_i.should eq(1)
+      CRYSTAL
   end
 end

--- a/spec/compiler/codegen/nilable_cast_spec.cr
+++ b/spec/compiler/codegen/nilable_cast_spec.cr
@@ -2,31 +2,31 @@ require "../../spec_helper"
 
 describe "Code gen: nilable cast" do
   it "does nilable cast (true)" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(42)
       x = 42 || "hello"
       y = x.as?(Int32)
       y || 84
-      )).to_i.should eq(42)
+      CRYSTAL
   end
 
   it "does nilable cast (false)" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(84)
       x = "hello" || 42
       y = x.as?(Int32)
       y || 84
-      )).to_i.should eq(84)
+      CRYSTAL
   end
 
   it "does nilable cast (always true)" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(42)
       x = 42
       y = x.as?(Int32)
       y || 84
-      )).to_i.should eq(42)
+      CRYSTAL
   end
 
   it "does upcast" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(2)
       class Foo
         def bar
           1
@@ -45,34 +45,34 @@ describe "Code gen: nilable cast" do
       else
         3
       end
-      )).to_i.should eq(2)
+      CRYSTAL
   end
 
   it "does cast to nil (1)" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(3)
       x = 1
       y = x.as?(Nil)
       y ? 2 : 3
-      )).to_i.should eq(3)
+      CRYSTAL
   end
 
   it "does cast to nil (2)" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(3)
       x = nil
       y = x.as?(Nil)
       y ? 2 : 3
-      )).to_i.should eq(3)
+      CRYSTAL
   end
 
   it "types as? with wrong type (#2775)" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(20)
       x = 1.as?(String)
       x ? 10 : 20
-      )).to_i.should eq(20)
+      CRYSTAL
   end
 
   it "codegens with NoReturn" do
-    codegen(%(
+    codegen(<<-CRYSTAL)
       lib LibC
         fun exit : NoReturn
       end
@@ -83,11 +83,11 @@ describe "Code gen: nilable cast" do
       end
 
       foo
-      ))
+      CRYSTAL
   end
 
   it "upcasts type to virtual (#3304)" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(1)
       class Foo
         def foo
           1
@@ -102,11 +102,11 @@ describe "Code gen: nilable cast" do
 
       f = Foo.new.as?(Foo)
       f ? f.foo : 10
-      )).to_i.should eq(1)
+      CRYSTAL
   end
 
   it "upcasts type to virtual (2) (#3304)" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(1)
       class Foo
         def foo
           1
@@ -127,11 +127,11 @@ describe "Code gen: nilable cast" do
 
       f = Gen(Foo).cast(Foo.new)
       f ? f.foo : 10
-      )).to_i.should eq(1)
+      CRYSTAL
   end
 
   it "casts with block var that changes type (#3341)" do
-    codegen(%(
+    codegen(<<-CRYSTAL)
       require "prelude"
 
       class Object
@@ -145,11 +145,11 @@ describe "Code gen: nilable cast" do
 
       x = Foo.new.as(Int32 | Foo)
       x.try &.as?(Foo)
-      ))
+      CRYSTAL
   end
 
   it "casts union type to nilable type (#9342)" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(10)
       struct Nil
         def foo
           0
@@ -167,6 +167,6 @@ describe "Code gen: nilable cast" do
 
       a = Gen(String).new(10) || Gen(Int32).new(20)
       a.as?(Gen).foo
-      )).to_i.should eq(10)
+      CRYSTAL
   end
 end

--- a/spec/compiler/codegen/no_return_spec.cr
+++ b/spec/compiler/codegen/no_return_spec.cr
@@ -10,7 +10,7 @@ describe "Code gen: no return" do
   end
 
   it "codegens if with no return and variable used afterwards" do
-    codegen(%(
+    codegen(<<-CRYSTAL)
       require "prelude"
 
       lib LibC
@@ -19,11 +19,11 @@ describe "Code gen: no return" do
 
       if (a = LibC.exit2) && a.size == 3
       end
-      ))
+      CRYSTAL
   end
 
   it "codegen types exception handler as NoReturn if ensure is NoReturn" do
-    codegen(%(
+    codegen(<<-CRYSTAL)
       require "prelude"
 
       lib LibC
@@ -35,18 +35,18 @@ describe "Code gen: no return" do
       ensure
         LibC.foo
       end
-      ))
+      CRYSTAL
   end
 
   it "codegens no return variable declaration (#1508)" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(1)
       foo = uninitialized NoReturn
       1
-      )).to_i.should eq(1)
+      CRYSTAL
   end
 
   it "codegens no return instance variable declaration (#1508)" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(1)
       class Foo
         def initialize
           @foo = uninitialized NoReturn
@@ -59,11 +59,11 @@ describe "Code gen: no return" do
       end
 
       Foo.new.x
-      )).to_i.should eq(1)
+      CRYSTAL
   end
 
   it "codegens call with no return because of falsey if (#3661)" do
-    codegen(%(
+    codegen(<<-CRYSTAL)
       lib LibC
         fun exit(Int32) : NoReturn
       end
@@ -79,14 +79,14 @@ describe "Code gen: no return" do
       foo do |x|
         LibC.exit(0) unless false
       end
-      ))
+      CRYSTAL
   end
 
   it "codegens untyped typeof (#5105)" do
-    codegen(%(
+    codegen(<<-CRYSTAL)
       require "prelude"
 
       typeof(raise("").foo)
-      ))
+      CRYSTAL
   end
 end

--- a/spec/compiler/codegen/not_spec.cr
+++ b/spec/compiler/codegen/not_spec.cr
@@ -18,46 +18,46 @@ describe "Code gen: not" do
   end
 
   it "codegens not nilable type (true)" do
-    run(%(
+    run(<<-CRYSTAL).to_b.should be_true
       class Foo
       end
 
       a = 1 == 2 ? Foo.new : nil
       !a
-      )).to_b.should be_true
+      CRYSTAL
   end
 
   it "codegens not nilable type (false)" do
-    run(%(
+    run(<<-CRYSTAL).to_b.should be_false
       class Foo
       end
 
       a = 1 == 1 ? Foo.new : nil
       !a
-      )).to_b.should be_false
+      CRYSTAL
   end
 
   it "codegens not pointer (true)" do
-    run(%(
+    run(<<-CRYSTAL).to_b.should be_true
       !Pointer(Int32).new(0_u64)
-      )).to_b.should be_true
+      CRYSTAL
   end
 
   it "codegens not pointer (false)" do
-    run(%(
+    run(<<-CRYSTAL).to_b.should be_false
       !Pointer(Int32).new(1_u64)
-      )).to_b.should be_false
+      CRYSTAL
   end
 
   it "doesn't crash" do
-    run(%(
+    run(<<-CRYSTAL).to_b.should be_false
       a = 1
       !a.is_a?(String) && !a
-      )).to_b.should be_false
+      CRYSTAL
   end
 
   it "codegens not with inlinable value (#6451)" do
-    codegen(%(
+    codegen(<<-CRYSTAL)
       class Test
         def test
           false
@@ -65,6 +65,7 @@ describe "Code gen: not" do
       end
 
       !Test.new.test
-      nil))
+      nil
+      CRYSTAL
   end
 end

--- a/spec/compiler/codegen/op_assign_spec.cr
+++ b/spec/compiler/codegen/op_assign_spec.cr
@@ -2,7 +2,7 @@ require "../../spec_helper"
 
 describe "Code gen: op assign" do
   it "evaluates exps once (#3398)" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(1)
       class Global
         @@value = 0
 
@@ -31,11 +31,11 @@ describe "Code gen: op assign" do
       foo.bar &+= 2
 
       Global.value
-      )).to_i.should eq(1)
+      CRYSTAL
   end
 
   it "evaluates exps once, [] (#3398)" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(11)
       class Global
         @@value = 0
 
@@ -69,6 +69,6 @@ describe "Code gen: op assign" do
       foo[bar] &+= 2
 
       Global.value
-      )).to_i.should eq(11)
+      CRYSTAL
   end
 end

--- a/spec/compiler/codegen/or_spec.cr
+++ b/spec/compiler/codegen/or_spec.cr
@@ -38,118 +38,118 @@ describe "Code gen: or" do
   end
 
   it "codegens or with nilable as left node 1" do
-    run("
-      require \"nil\"
+    run(<<-CRYSTAL).to_i.should eq(2)
+      require "nil"
       class Object; def to_i!; -1; end; end
       a = Reference.new
       a = nil
       (a || 2).to_i!
-    ").to_i.should eq(2)
+      CRYSTAL
   end
 
   it "codegens or with nilable as left node 2" do
-    run("
+    run(<<-CRYSTAL).to_i.should eq(-1)
       class Object; def to_i!; -1; end; end
       a = nil
       a = Reference.new
       (a || 2).to_i!
-    ").to_i.should eq(-1)
+      CRYSTAL
   end
 
   it "codegens or with non-false union as left node" do
-    run("
+    run(<<-CRYSTAL).to_i.should eq(1)
       a = 1.5
       a = 1
       (a || 2).to_i!
-    ").to_i.should eq(1)
+      CRYSTAL
   end
 
   it "codegens or with nil union as left node 1" do
-    run("
-      require \"nil\"
+    run(<<-CRYSTAL).to_i.should eq(1)
+      require "nil"
       a = nil
       a = 1
       (a || 2).to_i!
-    ").to_i.should eq(1)
+      CRYSTAL
   end
 
   it "codegens or with nil union as left node 2" do
-    run("
-      require \"nil\"
+    run(<<-CRYSTAL).to_i.should eq(2)
+      require "nil"
       a = 1
       a = nil
       (a || 2).to_i!
-    ").to_i.should eq(2)
+      CRYSTAL
   end
 
   it "codegens or with bool union as left node 1" do
-    run("
+    run(<<-CRYSTAL).to_i.should eq(1)
       struct Bool; def to_i!; 0; end; end
       a = false
       a = 1
       (a || 2).to_i!
-    ").to_i.should eq(1)
+      CRYSTAL
   end
 
   it "codegens or with bool union as left node 2" do
-    run("
+    run(<<-CRYSTAL).to_i.should eq(2)
       struct Bool; def to_i!; 0; end; end
       a = 1
       a = false
       (a || 2).to_i!
-    ").to_i.should eq(2)
+      CRYSTAL
   end
 
   it "codegens or with bool union as left node 3" do
-    run("
+    run(<<-CRYSTAL).to_i.should eq(0)
       struct Bool; def to_i!; 0; end; end
       a = 1
       a = true
       (a || 2).to_i!
-    ").to_i.should eq(0)
+      CRYSTAL
   end
 
   it "codegens or with bool union as left node 1" do
-    run("
-      require \"nil\"
+    run(<<-CRYSTAL).to_i.should eq(2)
+      require "nil"
       struct Bool; def to_i!; 1; end; end
       a = false
       a = nil
       a = 2
       (a || 3).to_i!
-    ").to_i.should eq(2)
+      CRYSTAL
   end
 
   it "codegens or with bool union as left node 2" do
-    run("
-      require \"nil\"
+    run(<<-CRYSTAL).to_i.should eq(3)
+      require "nil"
       struct Bool; def to_i!; 1; end; end
       a = nil
       a = 2
       a = false
       (a || 3).to_i!
-    ").to_i.should eq(3)
+      CRYSTAL
   end
 
   it "codegens or with bool union as left node 3" do
-    run("
-      require \"nil\"
+    run(<<-CRYSTAL).to_i.should eq(1)
+      require "nil"
       struct Bool; def to_i!; 1; end; end
       a = nil
       a = 2
       a = true
       (a || 3).to_i!
-    ").to_i.should eq(1)
+      CRYSTAL
   end
 
   it "codegens or with bool union as left node 4" do
-    run("
-      require \"nil\"
+    run(<<-CRYSTAL).to_i.should eq(3)
+      require "nil"
       struct Bool; def to_i!; 1; end; end
       a = 2
       a = true
       a = nil
       (a || 3).to_i!
-    ").to_i.should eq(3)
+      CRYSTAL
   end
 end

--- a/spec/compiler/codegen/pointer_spec.cr
+++ b/spec/compiler/codegen/pointer_spec.cr
@@ -6,7 +6,7 @@ describe "Code gen: pointer" do
   end
 
   it "get pointer of instance var" do
-    run("
+    run(<<-CRYSTAL).to_i.should eq(10)
       class Foo
         def initialize(value : Int32)
           @value = value
@@ -20,7 +20,7 @@ describe "Code gen: pointer" do
       foo = Foo.new(10)
       value_ptr = foo.value_ptr
       value_ptr.value
-      ").to_i.should eq(10)
+      CRYSTAL
   end
 
   it "set pointer value" do
@@ -36,7 +36,7 @@ describe "Code gen: pointer" do
   end
 
   it "increments pointer" do
-    run("
+    run(<<-CRYSTAL).to_i.should eq(2)
       class Foo
         def initialize
           @a = 1
@@ -49,7 +49,7 @@ describe "Code gen: pointer" do
         end
       end
       Foo.new.value
-    ").to_i.should eq(2)
+      CRYSTAL
   end
 
   it "codegens malloc" do
@@ -77,7 +77,7 @@ describe "Code gen: pointer" do
   end
 
   it "gets pointer of instance variable in virtual type" do
-    run("
+    run(<<-CRYSTAL).to_i.should eq(1)
       class Foo
         def initialize
           @a = 1
@@ -94,11 +94,11 @@ describe "Code gen: pointer" do
       foo = Foo.new || Bar.new
       x = foo.foo
       x.value
-      ").to_i.should eq(1)
+      CRYSTAL
   end
 
   it "sets value of pointer to struct" do
-    run("
+    run(<<-CRYSTAL).to_i.should eq(20)
       lib LibC
         struct Color
           r, g, b, a : UInt8
@@ -114,54 +114,54 @@ describe "Code gen: pointer" do
       color.value = color2.value
 
       color.value.r
-      ").to_i.should eq(20)
+      CRYSTAL
   end
 
   it "changes through var and reads from pointer" do
-    run("
+    run(<<-CRYSTAL).to_i.should eq(2)
       x = 1
       px = pointerof(x)
       x = 2
       px.value
-      ").to_i.should eq(2)
+      CRYSTAL
   end
 
   it "creates pointer by address" do
-    run("
+    run(<<-CRYSTAL).to_i.should eq(123)
       x = Pointer(Int32).new(123_u64)
       x.address
-    ").to_i.should eq(123)
+      CRYSTAL
   end
 
   it "calculates pointer diff" do
-    run("
+    run(<<-CRYSTAL).to_i.should eq(1)
       x = 1
       (pointerof(x) + 1_i64) - pointerof(x)
-    ").to_i.should eq(1)
+      CRYSTAL
   end
 
   it "can dereference pointer to func" do
-    run("
+    run(<<-CRYSTAL).to_i.should eq(1)
       def foo; 1; end
       x = ->foo
       y = pointerof(x)
       y.value.call
-    ").to_i.should eq(1)
+      CRYSTAL
   end
 
   it "gets pointer of argument that is never assigned to" do
-    run("
+    run(<<-CRYSTAL).to_i.should eq(1)
       def foo(x)
         pointerof(x)
       end
 
       foo(1)
       1
-      ").to_i.should eq(1)
+      CRYSTAL
   end
 
   it "codegens nilable pointer type (1)" do
-    run("
+    run(<<-CRYSTAL).to_i.should eq(3)
       p = Pointer(Int32).malloc(1_u64)
       p.value = 3
       a = 1 == 2 ? nil : p
@@ -170,11 +170,11 @@ describe "Code gen: pointer" do
       else
         4
       end
-      ").to_i.should eq(3)
+      CRYSTAL
   end
 
   it "codegens nilable pointer type (2)" do
-    run("
+    run(<<-CRYSTAL).to_i.should eq(4)
       p = Pointer(Int32).malloc(1_u64)
       p.value = 3
       a = 1 == 1 ? nil : p
@@ -183,11 +183,11 @@ describe "Code gen: pointer" do
       else
         4
       end
-      ").to_i.should eq(4)
+      CRYSTAL
   end
 
   it "codegens nilable pointer type dispatch (1)" do
-    run("
+    run(<<-CRYSTAL).to_i.should eq(3)
       def foo(x : Pointer)
         x.value
       end
@@ -200,11 +200,11 @@ describe "Code gen: pointer" do
       p.value = 3
       a = 1 == 1 ? p : nil
       foo(a)
-      ").to_i.should eq(3)
+      CRYSTAL
   end
 
   it "codegens nilable pointer type dispatch (2)" do
-    run("
+    run(<<-CRYSTAL).to_i.should eq(0)
       def foo(x : Pointer)
         x.value
       end
@@ -217,11 +217,11 @@ describe "Code gen: pointer" do
       p.value = 3
       a = 1 == 1 ? nil : p
       foo(a)
-      ").to_i.should eq(0)
+      CRYSTAL
   end
 
   it "assigns nil and pointer to nilable pointer type" do
-    run("
+    run(<<-CRYSTAL).to_i.should eq(3)
       class Foo
         def initialize
         end
@@ -246,19 +246,19 @@ describe "Code gen: pointer" do
       else
         2
       end
-      ").to_i.should eq(3)
+      CRYSTAL
   end
 
   it "gets pointer to constant" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(1)
       require "prelude"
       FOO = 1
       pointerof(FOO).value
-    )).to_i.should eq(1)
+      CRYSTAL
   end
 
   it "passes pointer of pointer to method" do
-    run("
+    run(<<-CRYSTAL).to_i.should eq(1)
       def foo(x)
         x.value.value
       end
@@ -267,33 +267,33 @@ describe "Code gen: pointer" do
       p.value = Pointer(Int32).malloc(1_u64)
       p.value.value = 1
       foo p
-      ").to_i.should eq(1)
+      CRYSTAL
   end
 
   it "codegens pointer as if condition inside union (1)" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(2)
       ptr = Pointer(Int32).new(0_u64) || Pointer(Float64).new(0_u64)
       if ptr
         1
       else
         2
       end
-      )).to_i.should eq(2)
+      CRYSTAL
   end
 
   it "codegens pointer as if condition inside union (2)" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(30)
       if 1 == 1
         ptr = Pointer(Int32).new(0_u64)
       else
         ptr = 10
       end
       ptr ? 20 : 30
-      )).to_i.should eq(30)
+      CRYSTAL
   end
 
   it "can use typedef pointer value get and set (#630)" do
-    codegen(%(
+    codegen(<<-CRYSTAL)
       lib LibFoo
         type MyObj = Int32*
         fun foo : MyObj
@@ -301,11 +301,11 @@ describe "Code gen: pointer" do
 
       LibFoo.foo.value
       LibFoo.foo.value = 1
-      ))
+      CRYSTAL
   end
 
   it "does pointerof class variable" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(2)
       class Foo
         @@a = 1
 
@@ -320,11 +320,11 @@ describe "Code gen: pointer" do
 
       Foo.a_ptr.value = 2
       Foo.a
-      )).to_i.should eq(2)
+      CRYSTAL
   end
 
   it "does pointerof class variable with class" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(2)
       class Bar
         def initialize(@x : Int32)
         end
@@ -348,11 +348,11 @@ describe "Code gen: pointer" do
 
       Foo.a_ptr.value = Bar.new(2)
       Foo.a.x
-      )).to_i.should eq(2)
+      CRYSTAL
   end
 
   it "does pointerof read variable" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(123)
       class Foo
         def initialize
           @x = 1
@@ -366,28 +366,28 @@ describe "Code gen: pointer" do
       foo = Foo.new
       pointerof(foo.@x).value = 123
       foo.x
-      )).to_i.should eq(123)
+      CRYSTAL
   end
 
   it "can assign nil to void pointer" do
-    codegen(%(
+    codegen(<<-CRYSTAL)
       ptr = Pointer(Void).malloc(1_u64)
       ptr.value = ptr.value
-      ))
+      CRYSTAL
   end
 
   it "can pass any pointer to something expecting void* in lib call" do
-    codegen(%(
+    codegen(<<-CRYSTAL)
       lib LibFoo
         fun foo(x : Void*) : Float64
       end
 
       LibFoo.foo(Pointer(Int32).malloc(1_u64))
-      ))
+      CRYSTAL
   end
 
   it "can pass any pointer to something expecting void* in lib call, with to_unsafe" do
-    codegen(%(
+    codegen(<<-CRYSTAL)
       lib LibFoo
         fun foo(x : Void*) : Float64
       end
@@ -399,11 +399,11 @@ describe "Code gen: pointer" do
       end
 
       LibFoo.foo(Foo.new)
-      ))
+      CRYSTAL
   end
 
   it "uses correct llvm module for typedef metaclass (#2877)" do
-    run(%(
+    run(<<-CRYSTAL)
       lib LibFoo
         type Foo = Void*
         type Bar = Void*
@@ -429,7 +429,7 @@ describe "Code gen: pointer" do
       foo.foo
       bar.foo
       1
-      ))
+      CRYSTAL
   end
 
   it "passes arguments correctly for typedef metaclass (#8544)" do
@@ -451,7 +451,7 @@ describe "Code gen: pointer" do
   end
 
   it "generates correct code for Pointer.malloc(0) (#2905)" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(3)
       class Foo
         def initialize(@value : Int32)
         end
@@ -464,11 +464,11 @@ describe "Code gen: pointer" do
       foo = Foo.new(3)
       Pointer(Int32 | UInt8[9]).malloc(0_u64)
       foo.value
-      )).to_i.should eq(3)
+      CRYSTAL
   end
 
   it "compares pointers through typedef" do
-    run(%(
+    run(<<-CRYSTAL).to_b.should be_true
       module Comparable(T)
         def ==(other : T)
           (self <=> other) == 0
@@ -489,7 +489,7 @@ describe "Code gen: pointer" do
 
       ptr = Pointer(Void).malloc(1_u64).as(LibFoo::Ptr)
       ptr == ptr
-      )).to_b.should be_true
+      CRYSTAL
   end
 
   # FIXME: `$external_var` implies __declspec(dllimport), but we only have an

--- a/spec/compiler/codegen/previous_def_spec.cr
+++ b/spec/compiler/codegen/previous_def_spec.cr
@@ -2,7 +2,7 @@ require "../../spec_helper"
 
 describe "codegen: previous_def" do
   it "codegens previous def" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(2)
       def foo
         1
       end
@@ -12,11 +12,11 @@ describe "codegen: previous_def" do
       end
 
       foo
-      )).to_i.should eq(2)
+      CRYSTAL
   end
 
   it "codegens previous def when inside fun and forwards args" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(6)
       def foo(z)
         z &+ 1
       end
@@ -27,11 +27,11 @@ describe "codegen: previous_def" do
 
       x = foo(2)
       x.call(3)
-      )).to_i.should eq(6)
+      CRYSTAL
   end
 
   it "codegens previous def when inside fun with self" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(1)
       class Foo
         def initialize
           @x = 1
@@ -49,11 +49,11 @@ describe "codegen: previous_def" do
       end
 
       Foo.new.bar.call
-      )).to_i.should eq(1)
+      CRYSTAL
   end
 
   it "correctly passes named arguments" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(4)
       def foo(x, *args, other = 1)
         other
       end
@@ -63,6 +63,6 @@ describe "codegen: previous_def" do
       end
 
       foo(1, 2, 3, other: 4)
-      )).to_i.should eq(4)
+      CRYSTAL
   end
 end

--- a/spec/compiler/codegen/primitives_spec.cr
+++ b/spec/compiler/codegen/primitives_spec.cr
@@ -133,7 +133,7 @@ describe "Code gen: primitives" do
   end
 
   it "codegens __LINE__" do
-    run(<<-CRYSTAL, inject_primitives: false).to_i.should eq(3)
+    run(<<-CRYSTAL, inject_primitives: false).to_i.should eq(2)
 
       __LINE__
       CRYSTAL

--- a/spec/compiler/codegen/primitives_spec.cr
+++ b/spec/compiler/codegen/primitives_spec.cr
@@ -17,21 +17,21 @@ describe "Code gen: primitives" do
   it "codegens int128" do
     # LLVM's JIT doesn't seem to support 128
     # bit integers well regarding GenericValue
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(1)
       require "prelude"
 
       1_i128.to_i
-      )).to_i.should eq(1)
+      CRYSTAL
   end
 
   it "codegens uint128" do
     # LLVM's JIT doesn't seem to support 128
     # bit integers well regarding GenericValue
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(1)
       require "prelude"
 
       1_u128.to_i
-      )).to_i.should eq(1)
+      CRYSTAL
   end
 
   it "codegens char" do
@@ -120,7 +120,7 @@ describe "Code gen: primitives" do
   end
 
   it "defined method that calls primitive (bug)" do
-    run("
+    run(<<-CRYSTAL).to_i.should eq(1)
       struct Int64
         def foo
           to_u64!
@@ -129,18 +129,18 @@ describe "Code gen: primitives" do
 
       a = 1_i64
       a.foo.to_i!
-      ").to_i.should eq(1)
+      CRYSTAL
   end
 
   it "codegens __LINE__" do
-    run("
+    run(<<-CRYSTAL, inject_primitives: false).to_i.should eq(3)
 
       __LINE__
-      ", inject_primitives: false).to_i.should eq(3)
+      CRYSTAL
   end
 
   it "codegens crystal_type_id with union type" do
-    run("
+    run(<<-CRYSTAL).to_b.should be_true
       class Foo
       end
 
@@ -149,7 +149,7 @@ describe "Code gen: primitives" do
 
       f = Foo.allocate || Bar.allocate
       f.crystal_type_id == Foo.allocate.crystal_type_id
-      ").to_b.should be_true
+      CRYSTAL
   end
 
   it "doesn't treat `(1 == 1) == true` as `1 == 1 == true` (#328)" do
@@ -161,24 +161,24 @@ describe "Code gen: primitives" do
   end
 
   pending "codegens pointer of int" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(5)
       ptr = Pointer(Int).malloc(1_u64)
       ptr.value = 1
       ptr.value = 2_u8
       ptr.value = 3_u16
       ptr.value = 4_u32
       (ptr.value + 1).to_i32
-      )).to_i.should eq(5)
+      CRYSTAL
   end
 
   pending "sums two numbers out of an [] of Number" do
-    run(%(
+    run(<<-CRYSTAL).to_f32.should eq(2.5)
       p = Pointer(Number).malloc(2_u64)
       p.value = 1
       (p + 1_i64).value = 1.5
 
       (p.value + (p + 1_i64).value).to_f32
-      )).to_f32.should eq(2.5)
+      CRYSTAL
   end
 
   it "codegens crystal_type_id for class" do
@@ -186,29 +186,29 @@ describe "Code gen: primitives" do
   end
 
   it "can invoke cast on primitive typedef (#614)" do
-    codegen(%(
+    codegen(<<-CRYSTAL)
       lib Test
         type K = Int32
         fun foo : K
       end
 
       Test.foo.to_i!
-      ))
+      CRYSTAL
   end
 
   it "can invoke binary on primitive typedef (#614)" do
-    codegen(%(
+    codegen(<<-CRYSTAL)
       lib Test
         type K = Int32
         fun foo : K
       end
 
       Test.foo &+ 1
-      ))
+      CRYSTAL
   end
 
   it "allows redefining a primitive method" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(42)
       struct Int32
         def *(other : Int32)
           42
@@ -216,11 +216,11 @@ describe "Code gen: primitives" do
       end
 
       1 * 2
-      )).to_i.should eq(42)
+      CRYSTAL
   end
 
   it "doesn't optimize away call whose obj is not passed as self (#2226)" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(2)
       class Global
         @@x = 0
 
@@ -240,27 +240,27 @@ describe "Code gen: primitives" do
       foo.class.crystal_type_id
 
       Global.x
-      )).to_i.should eq(2)
+      CRYSTAL
   end
 
   it "uses built-in llvm function that returns a tuple" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(3)
       lib Intrinsics
         fun sadd_i32_with_overflow = "llvm.sadd.with.overflow.i32"(a : Int32, b : Int32) : {Int32, Bool}
       end
 
       x, o = Intrinsics.sadd_i32_with_overflow(1, 2)
       x
-      )).to_i.should eq(3)
+      CRYSTAL
   end
 
   it "gets crystal class instance type id" do
-    run(%(
+    run(<<-CRYSTAL).to_b.should be_true
       class Foo
       end
 
       Foo.new.crystal_type_id == Foo.crystal_instance_type_id
-      )).to_b.should be_true
+      CRYSTAL
   end
 
   describe "va_arg" do
@@ -367,7 +367,7 @@ describe "Code gen: primitives" do
   end
 
   it "allows @[Primitive] on method that has body" do
-    run(%(
+    run(<<-CRYSTAL).to_string.should eq("hello")
       module Moo
         @[Primitive(:symbol_to_s)]
         def self.symbol_to_s(symbol : Symbol) : String
@@ -376,17 +376,17 @@ describe "Code gen: primitives" do
       end
 
       Moo.symbol_to_s(:hello)
-      )).to_string.should eq("hello")
+      CRYSTAL
   end
 
   it "allows @[Primitive] on fun declarations" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(1)
       lib LibFoo
         @[Primitive(:enum_value)]
         fun enum_value(x : Int32) : Int32
       end
 
       LibFoo.enum_value(1)
-      )).to_i.should eq(1)
+      CRYSTAL
   end
 end

--- a/spec/compiler/codegen/primitives_spec.cr
+++ b/spec/compiler/codegen/primitives_spec.cr
@@ -267,7 +267,7 @@ describe "Code gen: primitives" do
     # On Windows and AArch64 llvm's va_arg instruction works incorrectly.
     {% unless flag?(:win32) || flag?(:aarch64) %}
       it "uses llvm's va_arg instruction" do
-        mod = codegen(%(
+        mod = codegen(<<-CRYSTAL)
           struct VaList
             @[Primitive(:va_arg)]
             def next(type)
@@ -276,7 +276,7 @@ describe "Code gen: primitives" do
 
           list = VaList.new
           list.next(Int32)
-        ))
+          CRYSTAL
         type = {% if LibLLVM::IS_LT_150 %} "%VaList*" {% else %} "ptr" {% end %}
         str = mod.to_s
         str.should contain("va_arg #{type} %list")

--- a/spec/compiler/codegen/private_spec.cr
+++ b/spec/compiler/codegen/private_spec.cr
@@ -83,7 +83,7 @@ describe "Codegen: private" do
   end
 
   it "doesn't include filename for private types" do
-    run(%(
+    run(<<-CRYSTAL, filename: "foo").to_string.should eq("Foo")
       private class Foo
         def foo
           {{@type.stringify}}
@@ -91,6 +91,6 @@ describe "Codegen: private" do
       end
 
       Foo.new.foo
-      ), filename: "foo").to_string.should eq("Foo")
+      CRYSTAL
   end
 end

--- a/spec/compiler/codegen/proc_spec.cr
+++ b/spec/compiler/codegen/proc_spec.cr
@@ -22,18 +22,18 @@ describe "Code gen: proc" do
   end
 
   it "call proc pointer with args" do
-    run("
+    run(<<-CRYSTAL).to_i.should eq(3)
       def foo(x, y)
         x &+ y
       end
 
       f = ->foo(Int32, Int32)
       f.call(1, 2)
-    ").to_i.should eq(3)
+      CRYSTAL
   end
 
   it "call proc pointer of instance method" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(1)
       class Foo
         def initialize
           @x = 1
@@ -47,11 +47,11 @@ describe "Code gen: proc" do
       foo = Foo.new
       f = ->foo.coco
       f.call
-    )).to_i.should eq(1)
+      CRYSTAL
   end
 
   it "call proc pointer of instance method that raises" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(1)
       require "prelude"
       class Foo
         def coco
@@ -62,11 +62,11 @@ describe "Code gen: proc" do
       foo = Foo.new
       f = ->foo.coco
       f.call rescue 1
-    )).to_i.should eq(1)
+      CRYSTAL
   end
 
   it "codegens proc with another var" do
-    run("
+    run(<<-CRYSTAL)
       def foo(x)
         bar(x, -> {})
       end
@@ -75,11 +75,11 @@ describe "Code gen: proc" do
       end
 
       foo(1)
-      ")
+      CRYSTAL
   end
 
   it "codegens proc that returns a virtual type" do
-    run("
+    run(<<-CRYSTAL).to_i.should eq(1)
       class Foo
         def coco; 1; end
       end
@@ -90,11 +90,11 @@ describe "Code gen: proc" do
 
       x = -> { Foo.new || Bar.new }
       x.call.coco
-      ").to_i.should eq(1)
+      CRYSTAL
   end
 
   it "codegens proc that accepts a union and is called with a single type" do
-    run("
+    run(<<-CRYSTAL).to_i.should eq(2)
       struct Float
         def &+(other)
           self + other
@@ -103,12 +103,12 @@ describe "Code gen: proc" do
 
       f = ->(x : Int32 | Float64) { x &+ 1 }
       f.call(1).to_i!
-      ").to_i.should eq(2)
+      CRYSTAL
   end
 
   it "makes sure that proc pointer is transformed after type inference" do
-    run("
-      require \"prelude\"
+    run(<<-CRYSTAL).to_i.should eq(1)
+      require "prelude"
 
       class Bar
         def initialize(@x : Int32)
@@ -132,11 +132,11 @@ describe "Code gen: proc" do
       c = ->_on_(Foo*)
       a = Foo.new
       c.call(pointerof(a))
-      ").to_i.should eq(1)
+      CRYSTAL
   end
 
   it "binds function pointer to associated call" do
-    run("
+    run(<<-CRYSTAL).to_i.should eq(12)
       class Foo
         def initialize(@e : Int32)
         end
@@ -155,7 +155,7 @@ describe "Code gen: proc" do
       a.on_something
 
       c.call(pointerof(a))
-      ").to_i.should eq(12)
+      CRYSTAL
   end
 
   it "call simple proc literal with return" do
@@ -163,18 +163,18 @@ describe "Code gen: proc" do
   end
 
   it "calls proc pointer with union (passed by value) arg" do
-    run("
+    run(<<-CRYSTAL).to_i.should eq(1)
       struct Number
         def abs; self; end
       end
 
       f = ->(x : Int32 | Float64) { x.abs }
       f.call(1 || 1.5).to_i!
-      ").to_i.should eq(1)
+      CRYSTAL
   end
 
   it "allows passing proc type to C automatically" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(1)
       require "prelude"
 
       lib LibC
@@ -188,11 +188,11 @@ describe "Code gen: proc" do
         a.value <=> b.value
       })
       ary[0]
-      )).to_i.should eq(1)
+      CRYSTAL
   end
 
   it "allows proc pointer where self is a class" do
-    run("
+    run(<<-CRYSTAL).to_i.should eq(1)
       class Foo
         def self.bla
           1
@@ -201,11 +201,11 @@ describe "Code gen: proc" do
 
       f = ->Foo.bla
       f.call
-      ").to_i.should eq(1)
+      CRYSTAL
   end
 
   it "codegens proc literal hard type inference (1)" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(1)
       require "prelude"
 
       class Foo
@@ -228,11 +228,11 @@ describe "Code gen: proc" do
       bar
 
       1
-      )).to_i.should eq(1)
+      CRYSTAL
   end
 
   it "automatically casts proc that returns something to proc that returns void" do
-    run("
+    run(<<-CRYSTAL).to_i.should eq(1)
       class Global
         @@x = 0
 
@@ -251,11 +251,11 @@ describe "Code gen: proc" do
       foo ->{ Global.x = 1 }
 
       Global.x
-      ").to_i.should eq(1)
+      CRYSTAL
   end
 
   it "allows proc type of enum type" do
-    run("
+    run(<<-CRYSTAL).to_i.should eq(1)
       lib LibFoo
         enum MyEnum
           X = 1
@@ -265,11 +265,11 @@ describe "Code gen: proc" do
       ->(x : LibFoo::MyEnum) {
         x
       }.call(LibFoo::MyEnum::X)
-      ").to_i.should eq(1)
+      CRYSTAL
   end
 
   it "allows proc type of enum type with base type" do
-    run("
+    run(<<-CRYSTAL).to_i.should eq(1)
       lib LibFoo
         enum MyEnum : UInt16
           X = 1
@@ -279,33 +279,33 @@ describe "Code gen: proc" do
       ->(x : LibFoo::MyEnum) {
         x
       }.call(LibFoo::MyEnum::X)
-      ").to_i.should eq(1)
+      CRYSTAL
   end
 
   it "codegens nilable proc type (1)" do
-    run("
+    run(<<-CRYSTAL).to_i.should eq(3)
       a = 1 == 2 ? nil : ->{ 3 }
       if a
         a.call
       else
         4
       end
-      ").to_i.should eq(3)
+      CRYSTAL
   end
 
   it "codegens nilable proc type (2)" do
-    run("
+    run(<<-CRYSTAL).to_i.should eq(4)
       a = 1 == 1 ? nil : ->{ 3 }
       if a
         a.call
       else
         4
       end
-      ").to_i.should eq(4)
+      CRYSTAL
   end
 
   it "codegens nilable proc type dispatch (1)" do
-    run("
+    run(<<-CRYSTAL).to_i.should eq(3)
       def foo(x : -> U) forall U
         x.call
       end
@@ -316,11 +316,11 @@ describe "Code gen: proc" do
 
       a = 1 == 1 ? (->{ 3 }) : nil
       foo(a)
-      ").to_i.should eq(3)
+      CRYSTAL
   end
 
   it "codegens nilable proc type dispatch (2)" do
-    run("
+    run(<<-CRYSTAL).to_i.should eq(0)
       def foo(x : -> U) forall U
         x.call
       end
@@ -331,22 +331,22 @@ describe "Code gen: proc" do
 
       a = 1 == 1 ? nil : ->{ 3 }
       foo(a)
-      ").to_i.should eq(0)
+      CRYSTAL
   end
 
   it "builds proc type from fun" do
-    codegen("
+    codegen(<<-CRYSTAL)
       lib LibC
         fun foo : ->
       end
 
       x = LibC.foo
       x.call
-      ")
+      CRYSTAL
   end
 
   it "builds nilable proc type from fun" do
-    codegen("
+    codegen(<<-CRYSTAL)
       lib LibC
         fun foo : (->)?
       end
@@ -355,11 +355,11 @@ describe "Code gen: proc" do
       if x
         x.call
       end
-      ")
+      CRYSTAL
   end
 
   it "assigns nil and proc to nilable proc type" do
-    run("
+    run(<<-CRYSTAL).to_i.should eq(1)
       class Foo
         def initialize
         end
@@ -381,11 +381,11 @@ describe "Code gen: proc" do
       else
         2
       end
-      ").to_i.should eq(1)
+      CRYSTAL
   end
 
   it "allows invoking proc literal with smaller type" do
-    run("
+    run(<<-CRYSTAL).to_i.should eq(1)
       struct Nil
         def to_i!
           0
@@ -396,11 +396,11 @@ describe "Code gen: proc" do
         x
       }
       f.call(1).to_i!
-      ").to_i.should eq(1)
+      CRYSTAL
   end
 
   it "does new on proc type" do
-    run("
+    run(<<-CRYSTAL).to_i.should eq(3)
       struct Proc
         def self.new(&block : self)
           block
@@ -412,11 +412,11 @@ describe "Code gen: proc" do
       a = 2
       f = Func.new { |x| x &+ a }
       f.call(1)
-      ").to_i.should eq(3)
+      CRYSTAL
   end
 
   it "allows invoking a function with a subtype" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(2)
       class Foo
         def x
           1
@@ -431,11 +431,11 @@ describe "Code gen: proc" do
 
       f = ->(foo : Foo) { foo.x }
       f.call Bar.new
-      )).to_i.should eq(2)
+      CRYSTAL
   end
 
   it "allows invoking a function with a subtype when defined as block spec" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(2)
       class Foo
         def x
           1
@@ -454,11 +454,11 @@ describe "Code gen: proc" do
 
       f = func { |foo| foo.x }
       f.call Bar.new
-      )).to_i.should eq(2)
+      CRYSTAL
   end
 
   it "allows redefining fun" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(2)
       fun foo : Int32
         1
       end
@@ -468,11 +468,11 @@ describe "Code gen: proc" do
       end
 
       foo
-      )).to_i.should eq(2)
+      CRYSTAL
   end
 
   it "passes block to another function (bug: mangling of both methods was the same)" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(1)
       def foo(&block : ->)
         foo(block)
       end
@@ -482,21 +482,21 @@ describe "Code gen: proc" do
       end
 
       foo { }
-      )).to_i.should eq(1)
+      CRYSTAL
   end
 
   it "codegens proc with union type that returns itself" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(1)
       a = 1 || 1.5
 
       foo = ->(x : Int32 | Float64) { x }
       foo.call(a)
       foo.call(a).to_i!
-      )).to_i.should eq(1)
+      CRYSTAL
   end
 
   it "codegens issue with missing byval in proc literal inside struct" do
-    run(%(
+    run(<<-CRYSTAL).to_string.should eq("bar")
       require "prelude"
 
       struct Params
@@ -510,11 +510,11 @@ describe "Code gen: proc" do
       end
 
       Params.new.foo
-      )).to_string.should eq("bar")
+      CRYSTAL
   end
 
   it "codegens proc that references struct (bug)" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should_not eq(42)
       class Ref
       end
 
@@ -546,11 +546,11 @@ describe "Code gen: proc" do
         Foo.new
       end
       context.run
-      )).to_i.should_not eq(42)
+      CRYSTAL
   end
 
   it "codegens captured block that returns tuple" do
-    codegen(%(
+    codegen(<<-CRYSTAL)
       def foo(&block)
         block
       end
@@ -559,19 +559,19 @@ describe "Code gen: proc" do
         {0, 0, 42, 0}
       end
       block.call
-      ))
+      CRYSTAL
   end
 
   it "allows using proc arg name shadowing local variable" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(1)
       a = 1
       f = ->(a : String) { }
       a
-      )).to_i.should eq(1)
+      CRYSTAL
   end
 
   it "codegens proc that accepts array of type" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(2)
       require "prelude"
 
       class Foo
@@ -594,21 +594,21 @@ describe "Code gen: proc" do
       elems = [Bar.new, Foo.new]
       bar = block.call elems
       bar.foo
-      )).to_i.should eq(2)
+      CRYSTAL
   end
 
   it "gets proc to lib fun (#504)" do
-    codegen(%(
+    codegen(<<-CRYSTAL)
       lib LibFoo
         fun bar
       end
 
       ->LibFoo.bar
-      ))
+      CRYSTAL
   end
 
   it "codegens proc to implicit self in constant (#647)" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(1)
       require "prelude"
 
       module Foo
@@ -619,21 +619,21 @@ describe "Code gen: proc" do
       end
 
       Foo::H.call
-      )).to_i.should eq(1)
+      CRYSTAL
   end
 
   it "passes proc as &->expr to method that yields" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(123)
       def foo
         yield
       end
 
       foo &->{ 123 }
-      )).to_i.should eq(123)
+      CRYSTAL
   end
 
   it "mangles strings in such a way they don't conflict with funs (#1006)" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(123)
       a = :foo
 
       fun foo : Int32
@@ -641,11 +641,11 @@ describe "Code gen: proc" do
       end
 
       foo
-      )).to_i.should eq(123)
+      CRYSTAL
   end
 
   it "gets proc pointer using virtual type (#1337)" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(2)
       class Foo
         def foo
           1
@@ -664,11 +664,11 @@ describe "Code gen: proc" do
 
       bar = ->foo(Foo)
       bar.call(Bar.new)
-      )).to_i.should eq(2)
+      CRYSTAL
   end
 
   it "uses alias of proc with virtual type (#1347)" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(2)
       require "prelude"
 
       class Class1
@@ -713,11 +713,11 @@ describe "Code gen: proc" do
       Foo.call
 
       Global.x
-      )).to_i.should eq(2)
+      CRYSTAL
   end
 
   it "doesn't crash on #2196" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(42)
       x = 42
       z = if x.is_a?(Int32)
         x
@@ -726,11 +726,11 @@ describe "Code gen: proc" do
         ->{ y }
       end
       z.is_a?(Int32) ? z : 0
-      )).to_i.should eq(42)
+      CRYSTAL
   end
 
   it "accesses T in macros as a TupleLiteral" do
-    run(%(
+    run(<<-CRYSTAL).to_string.should eq("TupleLiteral")
       struct Proc
         def t
           {{ T.class_name }}
@@ -738,11 +738,11 @@ describe "Code gen: proc" do
       end
 
       ->(x : Int32) { 'a' }.t
-      )).to_string.should eq("TupleLiteral")
+      CRYSTAL
   end
 
   it "codegens proc in instance var initialize (#3016)" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(42)
       class Foo
         @f : -> Int32 = ->foo
 
@@ -752,11 +752,11 @@ describe "Code gen: proc" do
       end
 
       Foo.new.@f.call
-      )).to_i.should eq(42)
+      CRYSTAL
   end
 
   it "codegens proc of generic type" do
-    codegen(%(
+    codegen(<<-CRYSTAL)
       class Gen(T)
       end
 
@@ -765,19 +765,19 @@ describe "Code gen: proc" do
 
       f = ->(x : Gen(Int32)) {}
       f.call(Foo.new)
-      ))
+      CRYSTAL
   end
 
   it "executes proc pointer on primitive" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(21)
       a = 1
       f = ->a.&+(Int32)
       f.call(20)
-      )).to_i.should eq(21)
+      CRYSTAL
   end
 
   it "can pass Proc(T) to Proc(Nil) in type restriction (#8964)" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(2)
       def foo(x : Proc(Nil))
         x
       end
@@ -786,11 +786,11 @@ describe "Code gen: proc" do
       proc = foo(->{ a = 2 })
       proc.call
       a
-      )).to_i.should eq(2)
+      CRYSTAL
   end
 
   it "can assign proc that returns anything to proc that returns nil (#3655)" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(2)
       class Foo
         @block : -> Nil
 
@@ -808,11 +808,11 @@ describe "Code gen: proc" do
       Foo.new(block).call
 
       a
-      )).to_i.should eq(2)
+      CRYSTAL
   end
 
   it "can assign proc that returns anything to proc that returns nil, using union type (#3655)" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(3)
       class Foo
         @block : -> Nil
 
@@ -831,11 +831,11 @@ describe "Code gen: proc" do
       Foo.new(block2 || block1).call
 
       a
-      )).to_i.should eq(3)
+      CRYSTAL
   end
 
   it "calls function pointer" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(2)
       require "prelude"
 
       fun foo(f : Int32 -> Int32) : Int32
@@ -843,23 +843,23 @@ describe "Code gen: proc" do
       end
 
       foo(->(x : Int32) { x &+ 1 })
-    )).to_i.should eq(2)
+      CRYSTAL
   end
 
   it "casts from function pointer to proc" do
-    codegen(%(
+    codegen(<<-CRYSTAL)
       fun a(a : Void* -> Void*)
         Pointer(Proc((Void* -> Void*), Void*)).new(0_u64).value.call(a)
       end
-    ))
+      CRYSTAL
   end
 
   it "takes pointerof function pointer" do
-    codegen(%(
+    codegen(<<-CRYSTAL)
       fun a(a : Void* -> Void*)
         pointerof(a).value.call(Pointer(Void).new(0_u64))
       end
-    ))
+      CRYSTAL
   end
 
   it "returns proc as function pointer inside top-level fun (#14691)" do
@@ -916,7 +916,7 @@ describe "Code gen: proc" do
   end
 
   it "closures var on ->var.call (#8584)" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(1)
       def bar(x)
         x
       end
@@ -946,11 +946,11 @@ describe "Code gen: proc" do
       proc_b = get_proc_b
       proc_b.call
       proc_a.call
-      )).to_i.should eq(1)
+      CRYSTAL
   end
 
   it "saves receiver value of proc pointer `->var.foo`" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(1)
       class Foo
         def initialize(@foo : Int32)
         end
@@ -964,11 +964,11 @@ describe "Code gen: proc" do
       proc = ->var.foo
       var = Foo.new(2)
       proc.call
-      )).to_i.should eq(1)
+      CRYSTAL
   end
 
   it "saves receiver value of proc pointer `->@ivar.foo`" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(1)
       class Foo
         def initialize(@foo : Int32)
         end
@@ -989,11 +989,11 @@ describe "Code gen: proc" do
       end
 
       Test.new.test
-      )).to_i.should eq(1)
+      CRYSTAL
   end
 
   it "saves receiver value of proc pointer `->@@cvar.foo`" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(1)
       require "prelude"
 
       class Foo
@@ -1016,7 +1016,7 @@ describe "Code gen: proc" do
       end
 
       Test.test
-      )).to_i.should eq(1)
+      CRYSTAL
   end
 
   it "doesn't crash when taking a proc pointer to a virtual type (#9823)" do
@@ -1046,7 +1046,7 @@ describe "Code gen: proc" do
   end
 
   it "doesn't crash when taking a proc pointer that multidispatches on the top-level (#3822)" do
-    run(%(
+    run(<<-CRYSTAL)
       class Foo
         def initialize(@proc : Proc(Bar, Nil))
         end
@@ -1069,11 +1069,11 @@ describe "Code gen: proc" do
       end
 
       Foo.new(->test(Bar))
-    ))
+      CRYSTAL
   end
 
   it "doesn't crash when taking a proc pointer that multidispatches on a module (#3822)" do
-    run(%(
+    run(<<-CRYSTAL)
       class Foo
         def initialize(@proc : Proc(Bar, Nil))
         end
@@ -1098,6 +1098,6 @@ describe "Code gen: proc" do
       end
 
       Foo.new(->Moo.test(Bar))
-    ))
+      CRYSTAL
   end
 end

--- a/spec/compiler/codegen/proc_spec.cr
+++ b/spec/compiler/codegen/proc_spec.cr
@@ -1020,7 +1020,7 @@ describe "Code gen: proc" do
   end
 
   it "doesn't crash when taking a proc pointer to a virtual type (#9823)" do
-    run(%(
+    run(<<-CRYSTAL, Proc(Int32, Int32, Int32))
       abstract struct Parent
         abstract def work(a : Int32, b : Int32)
 
@@ -1042,7 +1042,7 @@ describe "Code gen: proc" do
       end
 
       Child1.new.as(Parent).get
-    ), Proc(Int32, Int32, Int32))
+      CRYSTAL
   end
 
   it "doesn't crash when taking a proc pointer that multidispatches on the top-level (#3822)" do

--- a/spec/compiler/codegen/regex_literal_spec.cr
+++ b/spec/compiler/codegen/regex_literal_spec.cr
@@ -2,7 +2,7 @@ require "../../spec_helper"
 
 describe "Code gen: regex literal spec" do
   it "works in a class variable (#10951)" do
-    run(%(
+    run(<<-CRYSTAL).to_b.should be_true
       require "prelude"
       class Foo
         @@regex = /whatever/
@@ -12,6 +12,6 @@ describe "Code gen: regex literal spec" do
         end
       end
       Foo.check_regex
-      )).to_b.should be_true
+      CRYSTAL
   end
 end

--- a/spec/compiler/codegen/responds_to_spec.cr
+++ b/spec/compiler/codegen/responds_to_spec.cr
@@ -30,25 +30,25 @@ describe "Codegen: responds_to?" do
   end
 
   it "codegens responds_to? with generic class (1)" do
-    run(%(
+    run(<<-CRYSTAL).to_b.should be_true
       class Foo(T)
         def foo
         end
       end
 
       Foo(Int32).new.responds_to?(:foo)
-      )).to_b.should be_true
+      CRYSTAL
   end
 
   it "codegens responds_to? with generic class (2)" do
-    run(%(
+    run(<<-CRYSTAL).to_b.should be_false
       class Foo(T)
         def foo
         end
       end
 
       Foo(Int32).new.responds_to?(:bar)
-      )).to_b.should be_false
+      CRYSTAL
   end
 
   it "doesn't error if result is discarded (#14113)" do
@@ -64,7 +64,7 @@ describe "Codegen: responds_to?" do
   end
 
   it "works with virtual type" do
-    run(%(
+    run(<<-CRYSTAL).to_b.should be_true
       class Foo
       end
 
@@ -76,11 +76,11 @@ describe "Codegen: responds_to?" do
 
       foo = Bar.new || Foo.new
       foo.responds_to?(:foo)
-      )).to_b.should be_true
+      CRYSTAL
   end
 
   it "works with two virtual types" do
-    run(%(
+    run(<<-CRYSTAL).to_b.should be_true
       class Foo
       end
 
@@ -110,11 +110,11 @@ describe "Codegen: responds_to?" do
 
       foo = Sub2.new || Bar.new || Bar2.new || Sub.new || Sub2.new
       foo.responds_to?(:foo)
-      )).to_b.should be_true
+      CRYSTAL
   end
 
   it "works with virtual class type (1) (#1926)" do
-    run(%(
+    run(<<-CRYSTAL).to_b.should be_true
       class Foo
       end
 
@@ -126,11 +126,11 @@ describe "Codegen: responds_to?" do
 
       foo = Bar || Foo
       foo.responds_to?(:foo)
-      )).to_b.should be_true
+      CRYSTAL
   end
 
   it "works with virtual class type (2) (#1926)" do
-    run(%(
+    run(<<-CRYSTAL).to_b.should be_false
       class Foo
       end
 
@@ -142,11 +142,11 @@ describe "Codegen: responds_to?" do
 
       foo = Foo || Bar
       foo.responds_to?(:foo)
-      )).to_b.should be_false
+      CRYSTAL
   end
 
   it "works with generic virtual superclass (1)" do
-    run(%(
+    run(<<-CRYSTAL).to_b.should be_true
       class Foo(T)
       end
 
@@ -159,11 +159,11 @@ describe "Codegen: responds_to?" do
 
       foo = Bar.new.as(Foo(Int32))
       foo.responds_to?(:foo)
-      )).to_b.should be_true
+      CRYSTAL
   end
 
   it "works with generic virtual superclass (2)" do
-    run(%(
+    run(<<-CRYSTAL).to_b.should be_true
       class Foo(T)
       end
 
@@ -176,11 +176,11 @@ describe "Codegen: responds_to?" do
 
       foo = Bar(Int32).new.as(Foo(Int32))
       foo.responds_to?(:foo)
-      )).to_b.should be_true
+      CRYSTAL
   end
 
   it "works with module" do
-    run(%(
+    run(<<-CRYSTAL).to_b.should be_true
       module Moo
       end
 
@@ -206,11 +206,11 @@ describe "Codegen: responds_to?" do
 
       moo = ptr.value
       moo.responds_to?(:foo)
-      )).to_b.should be_true
+      CRYSTAL
   end
 
   it "works with generic virtual module (1)" do
-    run(%(
+    run(<<-CRYSTAL).to_b.should be_true
       module Foo(T)
       end
 
@@ -224,11 +224,11 @@ describe "Codegen: responds_to?" do
 
       foo = Bar.new.as(Foo(Int32))
       foo.responds_to?(:foo)
-      )).to_b.should be_true
+      CRYSTAL
   end
 
   it "works with generic virtual module (2) (#8334)" do
-    run(%(
+    run(<<-CRYSTAL).to_b.should be_true
       module Foo(T)
       end
 
@@ -242,11 +242,11 @@ describe "Codegen: responds_to?" do
 
       foo = Bar(Int32).new.as(Foo(Int32))
       foo.responds_to?(:foo)
-      )).to_b.should be_true
+      CRYSTAL
   end
 
   it "does for generic instance type metaclass (#4353)" do
-    run(%(
+    run(<<-CRYSTAL).to_b.should be_true
       class MyGeneric(T)
         def self.hallo
           1
@@ -254,6 +254,6 @@ describe "Codegen: responds_to?" do
       end
 
       MyGeneric(String).responds_to? :hallo
-      )).to_b.should be_true
+      CRYSTAL
   end
 end

--- a/spec/compiler/codegen/return_spec.cr
+++ b/spec/compiler/codegen/return_spec.cr
@@ -30,7 +30,7 @@ describe "Code gen: return" do
   end
 
   it "returns empty from function" do
-    run("
+    run(<<-CRYSTAL).to_i.should eq(1)
       struct Nil; def to_i!; 0; end; end
       def foo(x)
         return if x == 1
@@ -38,69 +38,69 @@ describe "Code gen: return" do
       end
 
       foo(2).to_i!
-    ").to_i.should eq(1)
+      CRYSTAL
   end
 
   it "codegens bug with return if true" do
-    run(%(
+    run(<<-CRYSTAL).to_b.should be_true
       def bar
         return if true
         1
       end
 
       bar.is_a?(Nil)
-      )).to_b.should be_true
+      CRYSTAL
   end
 
   it "codegens assign with if with two returns" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(2)
       def test
         a = 1 ? return 2 : return 3
       end
 
       test
-      )).to_i.should eq(2)
+      CRYSTAL
   end
 
   it "doesn't crash when method returns nil and can be inlined" do
-    codegen(%(
+    codegen(<<-CRYSTAL)
       def foo : Nil
         1
       end
 
       foo
-      ))
+      CRYSTAL
   end
 
   it "returns in var assignment (#3364)" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(123)
       def bar
         a = nil || return 123
       end
 
       bar
-      )).to_i.should eq(123)
+      CRYSTAL
   end
 
   it "forms a tuple from multiple return values" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(2)
       def foo
         return 5, 3
       end
 
       v = foo
       v[0] &- v[1]
-      )).to_i.should eq(2)
+      CRYSTAL
   end
 
   it "flattens splats inside multiple return values" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(18)
       def foo
         return 1, *{3, 9}, 27
       end
 
       v = foo
       v[3] &- v[2]
-      )).to_i.should eq(18)
+      CRYSTAL
   end
 end

--- a/spec/compiler/codegen/sizeof_spec.cr
+++ b/spec/compiler/codegen/sizeof_spec.cr
@@ -33,9 +33,9 @@ describe "Code gen: sizeof" do
   end
 
   it "gets sizeof union" do
-    size = run(<<-CRYSTAL)
+    size = run(<<-CRYSTAL).to_i
       sizeof(Int32 | Float64)
-      CRYSTAL.to_i
+      CRYSTAL
 
     # This union is represented as:
     #
@@ -126,7 +126,7 @@ describe "Code gen: sizeof" do
   end
 
   it "can use sizeof of virtual type" do
-    size = run(<<-CRYSTAL)
+    size = run(<<-CRYSTAL).to_i
       class Foo
         @x = 1
       end
@@ -137,7 +137,7 @@ describe "Code gen: sizeof" do
 
       foo = Bar.new.as(Foo)
       sizeof(typeof(foo))
-      CRYSTAL.to_i
+      CRYSTAL
 
     {% if flag?(:bits64) %}
       size.should eq(8)
@@ -186,7 +186,7 @@ describe "Code gen: sizeof" do
   end
 
   it "returns correct sizeof for abstract struct (#4319)" do
-    size = run(<<-CRYSTAL)
+    size = run(<<-CRYSTAL).to_i
         abstract struct Entry
         end
 
@@ -203,7 +203,7 @@ describe "Code gen: sizeof" do
         end
 
         sizeof(Entry)
-        CRYSTAL.to_i
+        CRYSTAL
 
     size.should eq(16)
   end

--- a/spec/compiler/codegen/sizeof_spec.cr
+++ b/spec/compiler/codegen/sizeof_spec.cr
@@ -6,7 +6,7 @@ describe "Code gen: sizeof" do
   end
 
   it "gets sizeof struct" do
-    run("
+    run(<<-CRYSTAL).to_i.should eq(12)
       struct Foo
         def initialize(@x : Int32, @y : Int32, @z : Int32)
         end
@@ -15,12 +15,12 @@ describe "Code gen: sizeof" do
       Foo.new(1, 2, 3)
 
       sizeof(Foo)
-      ").to_i.should eq(12)
+      CRYSTAL
   end
 
   it "gets sizeof class" do
     # A class is represented as a pointer to its data
-    run("
+    run(<<-CRYSTAL).to_i.should eq(sizeof(Void*))
       class Foo
         def initialize(@x : Int32, @y : Int32, @z : Int32)
         end
@@ -29,13 +29,13 @@ describe "Code gen: sizeof" do
       Foo.new(1, 2, 3)
 
       sizeof(Foo)
-      ").to_i.should eq(sizeof(Void*))
+      CRYSTAL
   end
 
   it "gets sizeof union" do
-    size = run("
+    size = run(<<-CRYSTAL)
       sizeof(Int32 | Float64)
-      ").to_i
+      CRYSTAL.to_i
 
     # This union is represented as:
     #
@@ -56,7 +56,7 @@ describe "Code gen: sizeof" do
   end
 
   it "gets instance_sizeof class" do
-    run("
+    run(<<-CRYSTAL).to_i.should eq(16)
       class Foo
         def initialize(@x : Int32, @y : Int32, @z : Int32)
         end
@@ -65,18 +65,18 @@ describe "Code gen: sizeof" do
       Foo.new(1, 2, 3)
 
       instance_sizeof(Foo)
-      ").to_i.should eq(16)
+      CRYSTAL
   end
 
   it "gets instance_sizeof a generic type with type vars" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(8)
       class Foo(T)
         def initialize(@x : T)
         end
       end
 
       instance_sizeof(Foo(Int32))
-      )).to_i.should eq(8)
+      CRYSTAL
   end
 
   it "gets sizeof Void" do
@@ -100,7 +100,7 @@ describe "Code gen: sizeof" do
   end
 
   it "can use sizeof in type argument (1)" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(4)
       struct StaticArray
         def size
           N
@@ -109,11 +109,11 @@ describe "Code gen: sizeof" do
 
       x = uninitialized UInt8[sizeof(Int32)]
       x.size
-      )).to_i.should eq(4)
+      CRYSTAL
   end
 
   it "can use sizeof in type argument (2)" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(8)
       struct StaticArray
         def size
           N
@@ -122,11 +122,11 @@ describe "Code gen: sizeof" do
 
       x = uninitialized UInt8[sizeof(Float64)]
       x.size
-      )).to_i.should eq(8)
+      CRYSTAL
   end
 
   it "can use sizeof of virtual type" do
-    size = run(%(
+    size = run(<<-CRYSTAL)
       class Foo
         @x = 1
       end
@@ -137,7 +137,7 @@ describe "Code gen: sizeof" do
 
       foo = Bar.new.as(Foo)
       sizeof(typeof(foo))
-      )).to_i
+      CRYSTAL.to_i
 
     {% if flag?(:bits64) %}
       size.should eq(8)
@@ -147,7 +147,7 @@ describe "Code gen: sizeof" do
   end
 
   it "can use instance_sizeof of virtual type" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(12)
       class Foo
         @x = 1
       end
@@ -162,11 +162,11 @@ describe "Code gen: sizeof" do
 
       bar = Baz.new.as(Bar)
       instance_sizeof(typeof(bar))
-      )).to_i.should eq(12)
+      CRYSTAL
   end
 
   it "can use instance_sizeof in type argument" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(12)
       struct StaticArray
         def size
           N
@@ -182,11 +182,11 @@ describe "Code gen: sizeof" do
 
       x = uninitialized UInt8[instance_sizeof(Foo)]
       x.size
-      )).to_i.should eq(12)
+      CRYSTAL
   end
 
   it "returns correct sizeof for abstract struct (#4319)" do
-    size = run(%(
+    size = run(<<-CRYSTAL)
         abstract struct Entry
         end
 
@@ -203,13 +203,13 @@ describe "Code gen: sizeof" do
         end
 
         sizeof(Entry)
-        )).to_i
+        CRYSTAL.to_i
 
     size.should eq(16)
   end
 
   it "doesn't precompute sizeof of abstract struct (#7741)" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(16)
       abstract struct Base
       end
 
@@ -222,11 +222,12 @@ describe "Code gen: sizeof" do
 
       Foo({Int32, Int32, Int32, Int32})
 
-      z)).to_i.should eq(16)
+      z
+      CRYSTAL
   end
 
   it "doesn't precompute sizeof of module (#7741)" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(16)
       module Base
       end
 
@@ -241,7 +242,8 @@ describe "Code gen: sizeof" do
 
       Foo({Int32, Int32, Int32, Int32})
 
-      z)).to_i.should eq(16)
+      z
+      CRYSTAL
   end
 
   describe "alignof" do

--- a/spec/compiler/codegen/special_vars_spec.cr
+++ b/spec/compiler/codegen/special_vars_spec.cr
@@ -3,7 +3,7 @@ require "../../spec_helper"
 describe "Codegen: special vars" do
   ["$~", "$?"].each do |name|
     it "codegens #{name}" do
-      run(%(
+      run(<<-CRYSTAL).to_string.should eq("hey")
         class Object; def not_nil!; self; end; end
 
         def foo(z)
@@ -12,11 +12,11 @@ describe "Codegen: special vars" do
 
         foo(2)
         #{name}
-        )).to_string.should eq("hey")
+        CRYSTAL
     end
 
     it "codegens #{name} with nilable (1)" do
-      run(%(
+      run(<<-CRYSTAL).to_string.should eq("ouch")
         require "prelude"
 
         def foo
@@ -32,11 +32,11 @@ describe "Codegen: special vars" do
         rescue ex
           "ouch"
         end
-        )).to_string.should eq("ouch")
+        CRYSTAL
     end
 
     it "codegens #{name} with nilable (2)" do
-      run(%(
+      run(<<-CRYSTAL).to_string.should eq("foo")
         require "prelude"
 
         def foo
@@ -52,7 +52,7 @@ describe "Codegen: special vars" do
         rescue ex
           "ouch"
         end
-        )).to_string.should eq("foo")
+        CRYSTAL
     end
   end
 

--- a/spec/compiler/codegen/special_vars_spec.cr
+++ b/spec/compiler/codegen/special_vars_spec.cr
@@ -57,7 +57,7 @@ describe "Codegen: special vars" do
   end
 
   it "codegens $~ two levels" do
-    run(%(
+    run(<<-CRYSTAL).to_string.should eq("hey")
       class Object; def not_nil!; self; end; end
 
       def foo
@@ -71,11 +71,11 @@ describe "Codegen: special vars" do
 
       bar
       $?
-      )).to_string.should eq("hey")
+      CRYSTAL
   end
 
   it "works lazily" do
-    run(%(
+    run(<<-CRYSTAL).to_string.should eq("bar")
       require "prelude"
 
       class Foo
@@ -98,11 +98,11 @@ describe "Codegen: special vars" do
         end
       end
       block.call(Foo.new("foo-bar"))
-      )).to_string.should eq("bar")
+      CRYSTAL
   end
 
   it "codegens in block" do
-    run(%(
+    run(<<-CRYSTAL).to_string.should eq("hey")
       require "prelude"
 
       class Object; def not_nil!; self; end; end
@@ -117,11 +117,11 @@ describe "Codegen: special vars" do
         a = $~
       end
       a.not_nil!
-      )).to_string.should eq("hey")
+      CRYSTAL
   end
 
   it "codegens in block with nested block" do
-    run(%(
+    run(<<-CRYSTAL).to_string.should eq("hey")
       require "prelude"
 
       class Object; def not_nil!; self; end; end
@@ -142,11 +142,11 @@ describe "Codegen: special vars" do
         a = $~
       end
       a.not_nil!
-      )).to_string.should eq("hey")
+      CRYSTAL
   end
 
   it "codegens after block" do
-    run(%(
+    run(<<-CRYSTAL).to_string.should eq("hey")
       require "prelude"
 
       class Object; def not_nil!; self; end; end
@@ -159,11 +159,11 @@ describe "Codegen: special vars" do
       a = nil
       foo {}
       $~
-      )).to_string.should eq("hey")
+      CRYSTAL
   end
 
   it "codegens after block 2" do
-    run(%(
+    run(<<-CRYSTAL).to_string.should eq("bye")
       class Object; def not_nil!; self; end; end
 
       def baz
@@ -178,11 +178,11 @@ describe "Codegen: special vars" do
 
       foo do
       end
-      )).to_string.should eq("bye")
+      CRYSTAL
   end
 
   it "codegens with default argument" do
-    run(%(
+    run(<<-CRYSTAL).to_string.should eq("bye")
       class Object; def not_nil!; self; end; end
 
       def baz(x = 1)
@@ -191,11 +191,11 @@ describe "Codegen: special vars" do
 
       baz
       $~
-      )).to_string.should eq("bye")
+      CRYSTAL
   end
 
   it "preserves special vars in macro expansion with call with default arguments (#824)" do
-    run(%(
+    run(<<-CRYSTAL).to_string.should eq("yes")
       class Object; def not_nil!; self; end; end
 
       def bar(x = 0)
@@ -208,11 +208,11 @@ describe "Codegen: special vars" do
       end
 
       foo
-      )).to_string.should eq("yes")
+      CRYSTAL
   end
 
   it "allows with primitive" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(123)
       class Object; def not_nil!; self; end; end
 
       def foo
@@ -223,11 +223,11 @@ describe "Codegen: special vars" do
 
       v = $~
       v || 456
-    )).to_i.should eq(123)
+      CRYSTAL
   end
 
   it "allows with struct" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(123)
       class Object; def not_nil!; self; end; end
 
       struct Foo
@@ -251,11 +251,11 @@ describe "Codegen: special vars" do
       else
         456
       end
-    )).to_i.should eq(123)
+      CRYSTAL
   end
 
   it "preserves special vars if initialized inside block (#2194)" do
-    run(%(
+    run(<<-CRYSTAL).to_string.should eq("foo")
       class Object; def not_nil!; self; end; end
 
       def foo
@@ -276,6 +276,6 @@ describe "Codegen: special vars" do
       else
         "bar"
       end
-      )).to_string.should eq("foo")
+      CRYSTAL
   end
 end

--- a/spec/compiler/codegen/splat_spec.cr
+++ b/spec/compiler/codegen/splat_spec.cr
@@ -2,7 +2,7 @@ require "../../spec_helper"
 
 describe "Code gen: splat" do
   it "splats" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(3)
       struct Tuple
         def size; {{T.size}}; end
       end
@@ -12,11 +12,11 @@ describe "Code gen: splat" do
       end
 
       foo 1, 1, 1
-      )).to_i.should eq(3)
+      CRYSTAL
   end
 
   it "splats with another arg" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(12)
       struct Tuple
         def size; {{T.size}}; end
       end
@@ -26,22 +26,22 @@ describe "Code gen: splat" do
       end
 
       foo 10, 1, 1
-      )).to_i.should eq(12)
+      CRYSTAL
   end
 
   it "splats on call" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(3)
       def foo(x, y)
         x &+ y
       end
 
       tuple = {1, 2}
       foo *tuple
-      )).to_i.should eq(3)
+      CRYSTAL
   end
 
   it "splats without args" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(0)
       struct Tuple
         def size; {{T.size}}; end
       end
@@ -51,11 +51,11 @@ describe "Code gen: splat" do
       end
 
       foo
-      )).to_i.should eq(0)
+      CRYSTAL
   end
 
   it "splats with default value" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(100)
       struct Tuple
         def size; {{T.size}}; end
       end
@@ -65,11 +65,11 @@ describe "Code gen: splat" do
       end
 
       foo
-      )).to_i.should eq(100)
+      CRYSTAL
   end
 
   it "splats with default value (2)" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(110)
       struct Tuple
         def size; {{T.size}}; end
       end
@@ -79,11 +79,11 @@ describe "Code gen: splat" do
       end
 
       foo 10
-      )).to_i.should eq(110)
+      CRYSTAL
   end
 
   it "splats with default value (3)" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(32)
       struct Tuple
         def size; {{T.size}}; end
       end
@@ -93,11 +93,11 @@ describe "Code gen: splat" do
       end
 
       foo 10, 20, 30, 40
-      )).to_i.should eq(32)
+      CRYSTAL
   end
 
   it "splats in initialize" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(3)
       class Foo
         @x : Int32
         @y : Int32
@@ -117,11 +117,11 @@ describe "Code gen: splat" do
 
       foo = Foo.new 1, 2
       foo.x &+ foo.y
-      )).to_i.should eq(3)
+      CRYSTAL
   end
 
   it "does #2407" do
-    codegen(%(
+    codegen(<<-CRYSTAL)
       lib LibC
         fun exit(Int32) : NoReturn
       end
@@ -140,11 +140,11 @@ describe "Code gen: splat" do
       some do |value|
         foo value
       end
-      ))
+      CRYSTAL
   end
 
   it "evaluates splat argument just once (#2677)" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(1)
       class Global
         @@x = 0
 
@@ -168,6 +168,6 @@ describe "Code gen: splat" do
       v = test(*data)
 
       Global.x
-      )).to_i.should eq(1)
+      CRYSTAL
   end
 end

--- a/spec/compiler/codegen/ssa_spec.cr
+++ b/spec/compiler/codegen/ssa_spec.cr
@@ -2,15 +2,15 @@ require "../../spec_helper"
 
 describe "Code gen: ssa" do
   it "codegens a redefined var" do
-    run("
+    run(<<-CRYSTAL).to_i.should eq(1)
       a = 1.5
       a = 1
       a
-      ").to_i.should eq(1)
+      CRYSTAL
   end
 
   it "codegens a redefined var inside method" do
-    run("
+    run(<<-CRYSTAL).to_i.should eq(1)
       def foo
         a = 1.5
         a = 1
@@ -18,22 +18,22 @@ describe "Code gen: ssa" do
       end
 
       foo
-      ").to_i.should eq(1)
+      CRYSTAL
   end
 
   it "codegens a redefined var inside method with argument" do
-    run("
+    run(<<-CRYSTAL).to_i.should eq(1)
       def foo(a)
         a = 1
         a
       end
 
       foo 1.5
-      ").to_i.should eq(1)
+      CRYSTAL
   end
 
   it "codegens declaration of var inside then when false" do
-    run("
+    run(<<-CRYSTAL).to_i.should eq(0)
       struct Nil
         def to_i!
           0
@@ -44,11 +44,11 @@ describe "Code gen: ssa" do
         b = 2
       end
       b.to_i!
-      ").to_i.should eq(0)
+      CRYSTAL
   end
 
   it "codegens declaration of var inside then when true" do
-    run("
+    run(<<-CRYSTAL).to_i.should eq(2)
       struct Nil
         def to_i!
           0
@@ -59,11 +59,11 @@ describe "Code gen: ssa" do
         b = 2
       end
       b.to_i!
-      ").to_i.should eq(2)
+      CRYSTAL
   end
 
   it "codegens a var that is re-assigned in a block" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(10)
       struct Char
         def to_i!
           10
@@ -79,11 +79,11 @@ describe "Code gen: ssa" do
         a = 'a'
       end
       a.to_i!
-      )).to_i.should eq(10)
+      CRYSTAL
   end
 
   it "codegens a var that is re-assigned in a block (1)" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(10)
       struct Char
         def to_i!
           10
@@ -95,11 +95,11 @@ describe "Code gen: ssa" do
         a = 'a'
       end
       a.to_i!
-      )).to_i.should eq(10)
+      CRYSTAL
   end
 
   it "codegens a var that is re-assigned in a block (2)" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(1)
       struct Char
         def to_i!
           10
@@ -111,11 +111,11 @@ describe "Code gen: ssa" do
         a = 'a'
       end
       a.to_i!
-      )).to_i.should eq(1)
+      CRYSTAL
   end
 
   it "codegens a var that is declared in a block (1)" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(0)
       struct Nil
         def to_i!
           0
@@ -126,11 +126,11 @@ describe "Code gen: ssa" do
         a = 1
       end
       a.to_i!
-      )).to_i.should eq(0)
+      CRYSTAL
   end
 
   it "codegens a var that is declared in a block (2)" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(1)
       struct Nil
         def to_i!
           0
@@ -143,11 +143,11 @@ describe "Code gen: ssa" do
         b = 2
       end
       a.to_i!
-      )).to_i.should eq(1)
+      CRYSTAL
   end
 
   it "codegens ssa bug with if/else on var" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(3)
       a = 1 || nil
       if a && false
         b = 2
@@ -157,11 +157,11 @@ describe "Code gen: ssa" do
         b = 4
       end
       b
-      )).to_i.should eq(3)
+      CRYSTAL
   end
 
   it "codegens ssa bug (1)" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(1)
       struct Nil
         def to_i!
           0
@@ -182,13 +182,13 @@ describe "Code gen: ssa" do
         1
       end
       a.to_i!
-      )).to_i.should eq(1)
+      CRYSTAL
   end
 
   it "codegens ssa bug (2)" do
     # This shows a bug where a block variable (coconio in this case)
     # wasn't reset to nil before each block iteration.
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(1)
       struct Nil
         def to_i!
           0
@@ -209,6 +209,6 @@ describe "Code gen: ssa" do
         a &+= coconio.to_i!
       end
       a
-      )).to_i.should eq(1)
+      CRYSTAL
   end
 end

--- a/spec/compiler/codegen/struct_spec.cr
+++ b/spec/compiler/codegen/struct_spec.cr
@@ -2,17 +2,17 @@ require "../../spec_helper"
 
 describe "Code gen: struct" do
   it "creates structs" do
-    run("
+    run(<<-CRYSTAL).to_i.should eq(1)
       struct Foo
       end
 
       f = Foo.allocate
       1
-      ").to_i.should eq(1)
+      CRYSTAL
   end
 
   it "creates structs with instance var" do
-    run("
+    run(<<-CRYSTAL).to_i.should eq(1)
       struct Foo
         def initialize(@x : Int32)
         end
@@ -24,11 +24,11 @@ describe "Code gen: struct" do
 
       f = Foo.new(1)
       f.x
-      ").to_i.should eq(1)
+      CRYSTAL
   end
 
   it "assigning a struct makes a copy (1)" do
-    run("
+    run(<<-CRYSTAL).to_i.should eq(2)
       struct Foo
         def initialize(@x : Int32)
         end
@@ -47,11 +47,11 @@ describe "Code gen: struct" do
       g.x = 2
 
       g.x
-      ").to_i.should eq(2)
+      CRYSTAL
   end
 
   it "assigning a struct makes a copy (2)" do
-    run("
+    run(<<-CRYSTAL).to_i.should eq(1)
       struct Foo
         def initialize(@x : Int32)
         end
@@ -70,11 +70,11 @@ describe "Code gen: struct" do
       g.x = 2
 
       f.x
-      ").to_i.should eq(1)
+      CRYSTAL
   end
 
   it "passes a struct as a parameter makes a copy" do
-    run("
+    run(<<-CRYSTAL).to_i.should eq(1)
       struct Foo
         def initialize(@x : Int32)
         end
@@ -96,11 +96,11 @@ describe "Code gen: struct" do
       foo(f)
 
       f.x
-      ").to_i.should eq(1)
+      CRYSTAL
   end
 
   it "passes a generic struct as a parameter makes a copy" do
-    run("
+    run(<<-CRYSTAL).to_i.should eq(1)
       struct Foo(T)
         def initialize(@x : T)
         end
@@ -122,11 +122,11 @@ describe "Code gen: struct" do
       foo(f)
 
       f.x
-      ").to_i.should eq(1)
+      CRYSTAL
   end
 
   it "returns struct as a copy" do
-    run("
+    run(<<-CRYSTAL).to_i.should eq(2)
       struct Foo
         def initialize(@x : Int32)
         end
@@ -148,11 +148,11 @@ describe "Code gen: struct" do
 
       g = foo(f)
       g.x
-      ").to_i.should eq(2)
+      CRYSTAL
   end
 
   it "creates struct in def" do
-    run("
+    run(<<-CRYSTAL).to_i.should eq(1)
       struct Foo
         def initialize(@x : Int32)
         end
@@ -167,11 +167,11 @@ describe "Code gen: struct" do
       end
 
       foo.x
-      ").to_i.should eq(1)
+      CRYSTAL
   end
 
   it "declares const struct" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(1)
       require "prelude"
 
       struct Foo
@@ -186,11 +186,11 @@ describe "Code gen: struct" do
       FOO = Foo.new(1)
 
       FOO.x
-      )).to_i.should eq(1)
+      CRYSTAL
   end
 
   it "uses struct in if" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(1)
       require "prelude"
 
       struct Foo
@@ -210,21 +210,21 @@ describe "Code gen: struct" do
         foo = FOO
       end
       foo.x
-      )).to_i.should eq(1)
+      CRYSTAL
   end
 
   it "uses nilable struct" do
-    run("
+    run(<<-CRYSTAL).to_i.should eq(2)
       struct Foo
       end
 
       f = Foo.new || nil
       f.nil? ? 1 : 2
-      ").to_i.should eq(2)
+      CRYSTAL
   end
 
   it "returns self" do
-    run("
+    run(<<-CRYSTAL).to_i.should eq(2)
       struct Foo
         def initialize(@x)
         end
@@ -242,11 +242,11 @@ describe "Code gen: struct" do
       f = Foo.new(1)
       g = f.foo
       g.x
-      ").to_i.should eq(2)
+      CRYSTAL
   end
 
   it "returns self with block" do
-    run("
+    run(<<-CRYSTAL).to_i.should eq(2)
       struct Foo
         def initialize(@x)
         end
@@ -265,11 +265,11 @@ describe "Code gen: struct" do
       f = Foo.new(1)
       g = f.foo { }
       g.x
-      ").to_i.should eq(2)
+      CRYSTAL
   end
 
   it "does phi of struct" do
-    run("
+    run(<<-CRYSTAL).to_i.should eq(1)
       struct Foo
         def initialize(@x : Int32)
         end
@@ -285,11 +285,11 @@ describe "Code gen: struct" do
             Foo.new(1)
           end
       x.x
-      ").to_i.should eq(1)
+      CRYSTAL
   end
 
   it "allows assigning to struct argument (bug)" do
-    run("
+    run(<<-CRYSTAL).to_i.should eq(2)
       struct Foo
         def bar
           2
@@ -301,11 +301,11 @@ describe "Code gen: struct" do
       end
 
       foo(Foo.new)
-      ").to_i.should eq(2)
+      CRYSTAL
   end
 
   it "codegens struct assigned to underscore (#1842)" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(123)
       struct Foo
         def initialize
           @value = 123
@@ -321,11 +321,11 @@ describe "Code gen: struct" do
       end
 
       foo.value
-      )).to_i.should eq(123)
+      CRYSTAL
   end
 
   it "codegens virtual struct" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(1)
       abstract struct Foo
       end
 
@@ -351,11 +351,11 @@ describe "Code gen: struct" do
 
       foo = Bar.new || Baz.new
       foo.x
-      )).to_i.should eq(1)
+      CRYSTAL
   end
 
   it "codegens virtual struct with pointer" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(1)
       abstract struct Foo
       end
 
@@ -383,11 +383,11 @@ describe "Code gen: struct" do
       ptr.value = Baz.new
       ptr.value = Bar.new
       ptr.value.x
-      )).to_i.should eq(1)
+      CRYSTAL
   end
 
   it "codegens virtual struct metaclass (#2551) (1)" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(42)
       abstract struct Foo
         def initialize
           @x = 21
@@ -409,11 +409,11 @@ describe "Code gen: struct" do
       end
 
       Bar.new.as(Foo).x
-      )).to_i.should eq(42)
+      CRYSTAL
   end
 
   it "codegens virtual struct metaclass (#2551) (2)" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(42)
       abstract struct Foo
         def initialize
           @x = 21
@@ -430,11 +430,11 @@ describe "Code gen: struct" do
       end
 
       Bar.new.as(Foo).@x
-      )).to_i.should eq(42)
+      CRYSTAL
   end
 
   it "codegens virtual struct metaclass (#2551) (3)" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(42)
       abstract struct Foo
         def initialize
           @x = 21
@@ -455,11 +455,11 @@ describe "Code gen: struct" do
       end
 
       Bar.new.as(Foo).x
-      )).to_i.should eq(42)
+      CRYSTAL
   end
 
   it "codegens virtual struct metaclass (#2551) (4)" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(42)
       require "prelude"
 
       abstract struct Foo
@@ -483,11 +483,11 @@ describe "Code gen: struct" do
       end
 
       (Bar || Baz).new.x
-      )).to_i.should eq(42)
+      CRYSTAL
   end
 
   it "mutates a  virtual struct" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(84)
       abstract struct Foo
         def initialize
           @x = 21
@@ -513,11 +513,11 @@ describe "Code gen: struct" do
       foo = Bar.new.as(Foo)
       foo.x = 84
       foo.x
-      )).to_i.should eq(84)
+      CRYSTAL
   end
 
   it "codegens virtual structs union (1)" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(42)
       abstract struct Foo
       end
 
@@ -549,11 +549,11 @@ describe "Code gen: struct" do
 
       f = foo || foo2
       f.x
-      )).to_i.should eq(42)
+      CRYSTAL
   end
 
   it "codegens virtual structs union (2)" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(84)
       abstract struct Foo
       end
 
@@ -585,11 +585,11 @@ describe "Code gen: struct" do
 
       f = foo2 || foo
       f.x
-      )).to_i.should eq(84)
+      CRYSTAL
   end
 
   it "can cast virtual struct to specific struct" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(1)
        require "prelude"
 
        abstract struct Foo
@@ -609,11 +609,11 @@ describe "Code gen: struct" do
 
        x = Bar.new || Baz.new
        x.as(Bar).foo
-       )).to_i.should eq(1)
+       CRYSTAL
   end
 
   it "casts virtual struct to base type, only one subclass (#2885)" do
-    run(%(
+    run(<<-CRYSTAL).to_string.should eq("1")
       abstract struct Entry
         def initialize(@uid : String, @country : String)
         end
@@ -628,11 +628,11 @@ describe "Code gen: struct" do
 
       entry = MyEntry.new("1", "GER")
       entry.as(Entry).uid
-      )).to_string.should eq("1")
+      CRYSTAL
   end
 
   it "can call new on abstract struct with single child (#7309)" do
-    codegen(%(
+    codegen(<<-CRYSTAL, inject_primitives: false)
       require "prelude"
 
       abstract struct Foo
@@ -644,6 +644,6 @@ describe "Code gen: struct" do
       end
 
       A.as(Foo.class).new
-      ), inject_primitives: false)
+      CRYSTAL
   end
 end

--- a/spec/compiler/codegen/super_spec.cr
+++ b/spec/compiler/codegen/super_spec.cr
@@ -14,7 +14,7 @@ describe "Codegen: super" do
   end
 
   it "codegens super that calls subclass method" do
-    run("
+    run(<<-CRYSTAL).to_i.should eq(2)
       class Foo
         def foo
           bar
@@ -37,11 +37,11 @@ describe "Codegen: super" do
 
       b = Bar.new
       b.foo
-      ").to_i.should eq(2)
+      CRYSTAL
   end
 
   it "codegens super that calls subclass method 2" do
-    run("
+    run(<<-CRYSTAL).to_i.should eq(2)
       class Foo
         def foo
           self.bar
@@ -64,11 +64,11 @@ describe "Codegen: super" do
 
       b = Bar.new
       b.foo
-      ").to_i.should eq(2)
+      CRYSTAL
   end
 
   it "codegens super that calls subclass method 3" do
-    run("
+    run(<<-CRYSTAL).to_i.should eq(1)
       class Foo
         def foo
           self.bar
@@ -91,11 +91,11 @@ describe "Codegen: super" do
 
       b = Foo.new || Bar.new
       b.foo
-      ").to_i.should eq(1)
+      CRYSTAL
   end
 
   it "codegens super that calls subclass method 4" do
-    run("
+    run(<<-CRYSTAL).to_i.should eq(2)
       class Foo
         def foo
           self.bar
@@ -118,11 +118,11 @@ describe "Codegen: super" do
 
       b = Bar.new || Foo.new
       b.foo
-      ").to_i.should eq(2)
+      CRYSTAL
   end
 
   it "codegens super that calls subclass method 5" do
-    run("
+    run(<<-CRYSTAL).to_i.should eq(2)
       module Mod
         def add_def
           another
@@ -154,11 +154,11 @@ describe "Codegen: super" do
 
       c = PrimitiveType.new || IntegerType.new
       c.add_def
-      ").to_i.should eq(2)
+      CRYSTAL
   end
 
   it "codegens super that calls subclass method 6" do
-    run("
+    run(<<-CRYSTAL).to_i.should eq(3)
       module Mod
         def add_def
           another
@@ -190,11 +190,11 @@ describe "Codegen: super" do
 
       c = IntegerType.new || PrimitiveType.new
       c.add_def
-      ").to_i.should eq(3)
+      CRYSTAL
   end
 
   it "codegens super inside closure" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(1)
       class Foo
         def initialize(@x : Int32)
         end
@@ -212,11 +212,11 @@ describe "Codegen: super" do
 
       f = Bar.new(1).foo
       f.call
-      )).to_i.should eq(1)
+      CRYSTAL
   end
 
   it "codegens super inside closure forwarding args" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(6)
       class Foo
         def initialize(@x : Int32)
         end
@@ -234,11 +234,11 @@ describe "Codegen: super" do
 
       f = Bar.new(1).foo(2)
       f.call(3)
-      )).to_i.should eq(6)
+      CRYSTAL
   end
 
   it "build super on generic class (bug)" do
-    codegen(%(
+    codegen(<<-CRYSTAL)
       class Base
         def foo(x)
           1.5
@@ -252,11 +252,11 @@ describe "Codegen: super" do
       end
 
       Foo(Int32).new.foo
-      ))
+      CRYSTAL
   end
 
   it "calls super in module method (#556)" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(1)
       class Parent
         def a
           1
@@ -274,11 +274,11 @@ describe "Codegen: super" do
       end
 
       Child.new.a
-      )).to_i.should eq(1)
+      CRYSTAL
   end
 
   it "calls super in generic module method" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(1)
       class Parent
         def a
           1
@@ -296,11 +296,11 @@ describe "Codegen: super" do
       end
 
       Child.new.a
-      )).to_i.should eq(1)
+      CRYSTAL
   end
 
   it "does super in virtual type including module" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(123)
       module Bar
         def bar
           123
@@ -323,11 +323,11 @@ describe "Codegen: super" do
       end
 
       (Base.new || Child.new).bar
-      )).to_i.should eq(123)
+      CRYSTAL
   end
 
   it "doesn't invoke super twice in inherited generic types (#942)" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(1)
       class Global
         @@x = 0
 
@@ -355,12 +355,12 @@ describe "Codegen: super" do
       Baz(Int8).new
 
       Global.x
-      )).to_i.should eq(1)
+      CRYSTAL
   end
 
   it "calls super in metaclass (#1522)" do
     # We include the prelude so this is codegened for real, because that's where the issue lies
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(5)
       require "prelude"
 
       class Global
@@ -389,11 +389,11 @@ describe "Codegen: super" do
 
       Base.foo
       One.foo
-      )).to_i.should eq(5)
+      CRYSTAL
   end
 
   it "calls super with dispatch (#2318)" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(3)
       class Foo
         def foo(x : Int32)
           x
@@ -412,11 +412,11 @@ describe "Codegen: super" do
 
       z = Bar.new.foo(3 || 2.5)
       z.to_i!
-      )).to_i.should eq(3)
+      CRYSTAL
   end
 
   it "calls super from virtual metaclass type (#2841)" do
-    run(%(
+    run(<<-CRYSTAL)
       abstract class Foo
         def self.bar(x : Bool)
           x
@@ -436,11 +436,11 @@ describe "Codegen: super" do
       end
 
       (Foo || Bar).bar(true)
-      ))
+      CRYSTAL
   end
 
   it "calls super on an object (#10004)" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(42)
       class Foo
         @foo = 42
 
@@ -451,6 +451,6 @@ describe "Codegen: super" do
       end
 
       Foo.new.super
-      )).to_i.should eq(42)
+      CRYSTAL
   end
 end

--- a/spec/compiler/codegen/thread_local_spec.cr
+++ b/spec/compiler/codegen/thread_local_spec.cr
@@ -4,7 +4,7 @@ require "../../spec_helper"
 
 describe "Codegen: thread local" do
   it "works with class variables" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(123)
     require "prelude"
 
     class Foo
@@ -22,11 +22,11 @@ describe "Codegen: thread local" do
     Thread.new { Foo.var = 456 }.join
 
     Foo.var
-  )).to_i.should eq(123)
+    CRYSTAL
   end
 
   it "works with class variable in main thread" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(123)
     require "prelude"
 
     class Foo
@@ -39,11 +39,11 @@ describe "Codegen: thread local" do
     end
 
     Foo.a
-    )).to_i.should eq(123)
+    CRYSTAL
   end
 
   it "compiles with class variable referenced from initializer" do
-    run(%(
+    run(<<-CRYSTAL)
     require "prelude"
 
     class Foo
@@ -61,6 +61,6 @@ describe "Codegen: thread local" do
     end
 
     0
-  ))
+    CRYSTAL
   end
 end

--- a/spec/compiler/codegen/tuple_spec.cr
+++ b/spec/compiler/codegen/tuple_spec.cr
@@ -189,24 +189,24 @@ describe "Code gen: tuple" do
   end
 
   it "codegens splats inside tuples" do
-    run("
+    run(<<-CRYSTAL).to_i.should eq(2 + 4 + 32 + 128)
       x = {1, *{2, 4}, 8, *{16, 32, 64}, 128}
       x[1] &+ x[2] &+ x[5] &+ x[7]
-      ").to_i.should eq(2 + 4 + 32 + 128)
+      CRYSTAL
   end
 
   it "passed tuple to def" do
-    run("
+    run(<<-CRYSTAL).to_i.should eq(2)
       def foo(t)
         t[1]
       end
 
       foo({1, 2, 3})
-      ").to_i.should eq(2)
+      CRYSTAL
   end
 
   it "accesses T and creates instance from it" do
-    run("
+    run(<<-CRYSTAL).to_i.should eq(2)
       struct Tuple
         def type_args
           T
@@ -225,11 +225,11 @@ describe "Code gen: tuple" do
       t = {Foo.new(1)}
       f = t.type_args[0].new(2)
       f.x
-      ").to_i.should eq(2)
+      CRYSTAL
   end
 
   it "allows malloc pointer of tuple" do
-    run("
+    run(<<-CRYSTAL).to_i.should eq(3)
       struct Pointer
         def self.malloc(size : Int)
           malloc(size.to_u64!)
@@ -244,20 +244,20 @@ describe "Code gen: tuple" do
 
       p = foo({1, 2})
       p.value[0] &+ p.value[1]
-      ").to_i.should eq(3)
+      CRYSTAL
   end
 
   it "codegens tuple union (bug because union size was computed incorrectly)" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(1)
       require "prelude"
       x = 1 == 1 ? {1, 1, 1} : {1}
       i = 2
       x[i]
-      )).to_i.should eq(1)
+      CRYSTAL
   end
 
   it "codegens tuple class" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(2)
       class Foo
         def initialize(@x : Int32)
         end
@@ -278,11 +278,11 @@ describe "Code gen: tuple" do
       foo_class = tuple_class[0]
       foo2 = foo_class.new(2)
       foo2.x
-      )).to_i.should eq(2)
+      CRYSTAL
   end
 
   it "gets size at compile time" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(2)
       struct Tuple
         def my_size
           {{ T.size }}
@@ -290,11 +290,11 @@ describe "Code gen: tuple" do
       end
 
       {1, 1}.my_size
-      )).to_i.should eq(2)
+      CRYSTAL
   end
 
   it "allows tuple covariance" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(42)
        class Obj
          def initialize
            @tuple = {Foo.new}
@@ -323,11 +323,11 @@ describe "Code gen: tuple" do
        obj = Obj.new
        obj.tuple = {Bar.new}
        obj.tuple[0].bar
-       )).to_i.should eq(42)
+       CRYSTAL
   end
 
   it "merges two tuple types of same size (1)" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(20)
        def foo
          if 1 == 2
            {"foo", 10}
@@ -338,11 +338,11 @@ describe "Code gen: tuple" do
 
        val = foo[1]
        val || 20
-       )).to_i.should eq(20)
+       CRYSTAL
   end
 
   it "merges two tuple types of same size (2)" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(10)
        def foo
          if 1 == 1
            {"foo", 10}
@@ -353,11 +353,11 @@ describe "Code gen: tuple" do
 
        val = foo[1]
        val || 20
-       )).to_i.should eq(10)
+       CRYSTAL
   end
 
   it "assigns tuple to compatible tuple" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(42)
       ptr = Pointer({Int32 | String, Bool | Char}).malloc(1_u64)
 
       # Here the compiler should cast each value
@@ -365,11 +365,11 @@ describe "Code gen: tuple" do
 
       val = ptr.value[0]
       val.as?(Int32) || 10
-      )).to_i.should eq(42)
+      CRYSTAL
   end
 
   it "upcasts tuple inside compatible tuple" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(42)
       def foo
         if 1 == 2
           {"hello", false}
@@ -380,11 +380,11 @@ describe "Code gen: tuple" do
 
       val = foo[0]
       val.as?(Int32) || 10
-      )).to_i.should eq(42)
+      CRYSTAL
   end
 
   it "assigns tuple union to compatible tuple" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(42)
       tup1 = {"hello", false}
       tup2 = {3}
       tup3 = {42, 'x'}
@@ -393,11 +393,11 @@ describe "Code gen: tuple" do
       ptr.value = tup3
       val = ptr.value[0]
       val.as?(Int32) || 10
-      )).to_i.should eq(42)
+      CRYSTAL
   end
 
   it "upcasts tuple union to compatible tuple" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(42)
       def foo
         if 1 == 2
           {"hello", false} || {3}
@@ -408,11 +408,11 @@ describe "Code gen: tuple" do
 
       val = foo[0]
       val.as?(Int32) || 10
-      )).to_i.should eq(42)
+      CRYSTAL
   end
 
   it "assigns tuple inside union to union with compatible tuple" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(42)
       tup1 = {"hello", false}
       tup2 = {3}
 
@@ -427,11 +427,11 @@ describe "Code gen: tuple" do
       ptr.value = union2
       val = ptr.value[0]
       val.as?(Int32) || 10
-      )).to_i.should eq(42)
+      CRYSTAL
   end
 
   it "upcasts tuple inside union to union with compatible tuple" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(42)
       def foo
         if 1 == 2
           tup1 = {"hello", false}
@@ -448,11 +448,11 @@ describe "Code gen: tuple" do
 
       val = foo[0]
       val.as?(Int32) || 10
-      )).to_i.should eq(42)
+      CRYSTAL
   end
 
   it "codegens union of tuple of float with tuple of tuple of float" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(42)
       a = {1.5}
       b = { {22.0, 20.0} }
       c = b || a
@@ -462,22 +462,22 @@ describe "Code gen: tuple" do
       else
         v[0].to_i! &+ v[1].to_i!
       end
-      )).to_i.should eq(42)
+      CRYSTAL
   end
 
   it "provides T as a tuple literal" do
-    run(%(
+    run(<<-CRYSTAL).to_string.should eq("TupleLiteral")
       struct Tuple
         def self.foo
           {{ T.class_name }}
         end
       end
       Tuple(Nil, Int32).foo
-      )).to_string.should eq("TupleLiteral")
+      CRYSTAL
   end
 
   it "passes empty tuple and empty named tuple to a method (#2852)" do
-    codegen(%(
+    codegen(<<-CRYSTAL)
       def foo(*binds)
         baz(binds)
       end
@@ -492,38 +492,38 @@ describe "Code gen: tuple" do
 
       foo
       bar
-      ))
+      CRYSTAL
   end
 
   it "assigns two same-size tuple types to a same var (#3132)" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(2)
       t = {true}
       t
       t = {2}
       t[0]
-      )).to_i.should eq(2)
+      CRYSTAL
   end
 
   it "downcasts union to mixed tuple type" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(1)
       t = {1} || 2 || {true}
       t = {1}
       t[0]
-      )).to_i.should eq(1)
+      CRYSTAL
   end
 
   it "downcasts union to mixed union with mixed tuple types" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(1)
       require "prelude"
 
       t = {1} || 2 || {true}
       t = {1} || 2
       t.as(Tuple)[0]
-      )).to_i.should eq(1)
+      CRYSTAL
   end
 
   it "downcasts union inside tuple to value (#3907)" do
-    codegen(%(
+    codegen(<<-CRYSTAL)
       struct Foo
       end
 
@@ -532,7 +532,7 @@ describe "Code gen: tuple" do
       x = {0, foo}
       z = x[0]
       x = {0, z}
-      ))
+      CRYSTAL
   end
 end
 

--- a/spec/compiler/codegen/tuple_spec.cr
+++ b/spec/compiler/codegen/tuple_spec.cr
@@ -38,43 +38,43 @@ describe "Code gen: tuple" do
   end
 
   it "codegens tuple [0..0]" do
-    run("
+    run(<<-CRYSTAL).to_b.should be_true
       #{range_new}
 
       val = {1, true}[0..0]
       val.is_a?(Tuple(Int32)) && val[0] == 1
-      ").to_b.should be_true
+      CRYSTAL
   end
 
   it "codegens tuple [0..1]" do
-    run("
+    run(<<-CRYSTAL).to_b.should be_true
       #{range_new}
 
       val = {1, true}[0..1]
       val.is_a?(Tuple(Int32, Bool)) && val[0] == 1 && val[1] == true
-      ").to_b.should be_true
+      CRYSTAL
   end
 
   it "codegens tuple [0..2]" do
-    run("
+    run(<<-CRYSTAL).to_b.should be_true
       #{range_new}
 
       val = {1, true}[0..2]
       val.is_a?(Tuple(Int32, Bool)) && val[0] == 1&& val[1] == true
-      ").to_b.should be_true
+      CRYSTAL
   end
 
   it "codegens tuple [1..1]" do
-    run("
+    run(<<-CRYSTAL).to_b.should be_true
       #{range_new}
 
       val = {1, true}[1..1]
       val.is_a?(Tuple(Bool)) && val[0] == true
-      ").to_b.should be_true
+      CRYSTAL
   end
 
   it "codegens tuple [1..0]" do
-    run("
+    run(<<-CRYSTAL).to_b.should be_true
       #{range_new}
 
       def empty(*args)
@@ -82,11 +82,11 @@ describe "Code gen: tuple" do
       end
 
       {1, true}[1..0].is_a?(typeof(empty))
-      ").to_b.should be_true
+      CRYSTAL
   end
 
   it "codegens tuple [2..2]" do
-    run("
+    run(<<-CRYSTAL).to_b.should be_true
       #{range_new}
 
       def empty(*args)
@@ -94,47 +94,47 @@ describe "Code gen: tuple" do
       end
 
       {1, true}[2..2].is_a?(typeof(empty))
-      ").to_b.should be_true
+      CRYSTAL
   end
 
   it "codegens tuple [0..0]?" do
-    run("
+    run(<<-CRYSTAL).to_b.should be_true
       #{range_new}
 
       val = {1, true}[0..0]?
       val.is_a?(Tuple(Int32)) && val[0] == 1
-      ").to_b.should be_true
+      CRYSTAL
   end
 
   it "codegens tuple [0..1]?" do
-    run("
+    run(<<-CRYSTAL).to_b.should be_true
       #{range_new}
 
       val = {1, true}[0..1]?
       val.is_a?(Tuple(Int32, Bool)) && val[0] == 1 && val[1] == true
-      ").to_b.should be_true
+      CRYSTAL
   end
 
   it "codegens tuple [0..2]?" do
-    run("
+    run(<<-CRYSTAL).to_b.should be_true
       #{range_new}
 
       val = {1, true}[0..2]?
       val.is_a?(Tuple(Int32, Bool)) && val[0] == 1&& val[1] == true
-      ").to_b.should be_true
+      CRYSTAL
   end
 
   it "codegens tuple [1..1]?" do
-    run("
+    run(<<-CRYSTAL).to_b.should be_true
       #{range_new}
 
       val = {1, true}[1..1]?
       val.is_a?(Tuple(Bool)) && val[0] == true
-      ").to_b.should be_true
+      CRYSTAL
   end
 
   it "codegens tuple [1..0]?" do
-    run("
+    run(<<-CRYSTAL).to_b.should be_true
       #{range_new}
 
       def empty(*args)
@@ -142,11 +142,11 @@ describe "Code gen: tuple" do
       end
 
       {1, true}[1..0]?.is_a?(typeof(empty))
-      ").to_b.should be_true
+      CRYSTAL
   end
 
   it "codegens tuple [2..2]?" do
-    run("
+    run(<<-CRYSTAL).to_b.should be_true
       #{range_new}
 
       def empty(*args)
@@ -154,7 +154,7 @@ describe "Code gen: tuple" do
       end
 
       {1, true}[2..2]?.is_a?(typeof(empty))
-      ").to_b.should be_true
+      CRYSTAL
   end
 
   it "codegens tuple [3..2]?" do
@@ -174,14 +174,15 @@ describe "Code gen: tuple" do
   end
 
   it "codegens tuple metaclass [1..0]" do
-    run("
+    run(<<-CRYSTAL).to_b.should be_true
       #{range_new}
 
       def empty(*args)
         args.class
       end
 
-      Tuple(Int32, Char)[1..0].is_a?(typeof(empty))").to_b.should be_true
+      Tuple(Int32, Char)[1..0].is_a?(typeof(empty))
+      CRYSTAL
   end
 
   it "codegens tuple metaclass [3..2]?" do

--- a/spec/compiler/codegen/type_declaration_spec.cr
+++ b/spec/compiler/codegen/type_declaration_spec.cr
@@ -2,7 +2,7 @@ require "../../spec_helper"
 
 describe "Code gen: type declaration" do
   it "codegens initialize instance var" do
-    run("
+    run(<<-CRYSTAL).to_i.should eq(1)
       class Foo
         @x = 1
 
@@ -12,11 +12,11 @@ describe "Code gen: type declaration" do
       end
 
       Foo.new.x
-      ").to_i.should eq(1)
+      CRYSTAL
   end
 
   it "codegens initialize instance var of superclass" do
-    run("
+    run(<<-CRYSTAL).to_i.should eq(1)
       class Foo
         @x = 1
 
@@ -29,11 +29,11 @@ describe "Code gen: type declaration" do
       end
 
       Bar.new.x
-      ").to_i.should eq(1)
+      CRYSTAL
   end
 
   it "codegens initialize instance var with var declaration" do
-    run("
+    run(<<-CRYSTAL).to_i.should eq(1)
       class Foo
         @x : Int32 = begin
           a = 1
@@ -46,11 +46,11 @@ describe "Code gen: type declaration" do
       end
 
       Foo.new.x
-      ").to_i.should eq(1)
+      CRYSTAL
   end
 
   it "declares and initializes" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(42)
       class Foo
         @x : Int32 = 42
 
@@ -60,13 +60,13 @@ describe "Code gen: type declaration" do
       end
 
       Foo.new.x
-      )).to_i.should eq(42)
+      CRYSTAL
   end
 
   it "declares and initializes var" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(42)
       a : Int32 = 42
       a
-      )).to_i.should eq(42)
+      CRYSTAL
   end
 end

--- a/spec/compiler/codegen/uninitialized_spec.cr
+++ b/spec/compiler/codegen/uninitialized_spec.cr
@@ -10,7 +10,7 @@ describe "Code gen: uninitialized" do
   end
 
   it "codegens declare instance var" do
-    run("
+    run(<<-CRYSTAL).to_i.should eq(0)
       class Foo
         def initialize
           @x = uninitialized Int32
@@ -22,11 +22,11 @@ describe "Code gen: uninitialized" do
       end
 
       Foo.new.x
-      ").to_i.should eq(0)
+      CRYSTAL
   end
 
   it "codegens declare instance var with static array type" do
-    run("
+    run(<<-CRYSTAL)
       class Foo
         def initialize
           @x = uninitialized Int32[4]
@@ -39,11 +39,11 @@ describe "Code gen: uninitialized" do
 
       Foo.new.x
       nil
-      ")
+      CRYSTAL
   end
 
   it "doesn't break on inherited declared var (#390)" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(3)
       class Foo
         def initialize
           @x = 1
@@ -68,11 +68,11 @@ describe "Code gen: uninitialized" do
 
       bar = Bar.new
       bar.x &+ bar.y
-      )).to_i.should eq(3)
+      CRYSTAL
   end
 
   it "works inside while/begin/rescue (bug inside #759)" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(3)
       require "prelude"
 
       a = 3
@@ -85,11 +85,11 @@ describe "Code gen: uninitialized" do
         end
       end
       a
-      )).to_i.should eq(3)
+      CRYSTAL
   end
 
   it "works with uninitialized NoReturn (#3314)" do
-    codegen(%(
+    codegen(<<-CRYSTAL, inject_primitives: false)
       def foo
         x = uninitialized NoReturn
         if 1
@@ -103,13 +103,13 @@ describe "Code gen: uninitialized" do
       end
 
       bar
-      ), inject_primitives: false)
+      CRYSTAL
   end
 
   it "codegens value (#3641)" do
-    run(%(
+    run(<<-CRYSTAL).to_b.should be_true
       x = y = uninitialized Int32
       x == y
-      )).to_b.should be_true
+      CRYSTAL
   end
 end

--- a/spec/compiler/codegen/union_type_spec.cr
+++ b/spec/compiler/codegen/union_type_spec.cr
@@ -122,14 +122,14 @@ describe "Code gen: union type" do
   end
 
   it "assigns union to larger union when source is nilable 1" do
-    value = run(<<-CRYSTAL)
+    value = run(<<-CRYSTAL).to_string
       require "prelude"
       a = 1
       b = nil
       b = Reference.new
       a = b
       a.to_s
-      CRYSTAL.to_string
+      CRYSTAL
     value.should contain("Reference")
   end
 
@@ -192,7 +192,7 @@ describe "Code gen: union type" do
   end
 
   it "codegens union to_s" do
-    str = run(<<-CRYSTAL)
+    str = run(<<-CRYSTAL).to_string
       require "prelude"
 
       def foo(x : T) forall T
@@ -201,7 +201,7 @@ describe "Code gen: union type" do
 
       a = 1 || 1.5
       foo(a)
-      CRYSTAL.to_string
+      CRYSTAL
     str.in?("(Int32 | Float64)", "(Float64 | Int32)").should be_true
   end
 

--- a/spec/compiler/codegen/union_type_spec.cr
+++ b/spec/compiler/codegen/union_type_spec.cr
@@ -30,7 +30,7 @@ describe "Code gen: union type" do
   end
 
   it "codegens union type for instance var" do
-    run("
+    run(<<-CRYSTAL).to_f64.should eq(3)
       struct Float
         def &+(other)
           self + other
@@ -56,11 +56,11 @@ describe "Code gen: union type" do
       f = Foo.new(1)
       f.value = 1.5_f32
       (f.value &+ f.value).to_f
-    ").to_f64.should eq(3)
+      CRYSTAL
   end
 
   it "codegens if with same nested union" do
-    run("
+    run(<<-CRYSTAL).to_i.should eq(1)
       if true
         if true
           1
@@ -74,12 +74,12 @@ describe "Code gen: union type" do
           2.5_f32
         end
       end.to_i!
-    ").to_i.should eq(1)
+      CRYSTAL
   end
 
   it "assigns union to union" do
-    run("
-      require \"prelude\"
+    run(<<-CRYSTAL).to_i.should eq(97)
+      require "prelude"
 
       struct Nil; def to_i; 0; end; end
 
@@ -106,58 +106,58 @@ describe "Code gen: union type" do
       f.foo 1
       f.foo 'a'
       f.x.to_i
-      ").to_i.should eq(97)
+      CRYSTAL
   end
 
   it "assigns union to larger union" do
-    run("
-      require \"prelude\"
+    run(<<-CRYSTAL).to_string.should eq("d")
+      require "prelude"
       a = 1
       a = 1.1_f32
-      b = \"c\"
+      b = "c"
       b = 'd'
       a = b
       a.to_s
-    ").to_string.should eq("d")
+      CRYSTAL
   end
 
   it "assigns union to larger union when source is nilable 1" do
-    value = run("
-      require \"prelude\"
+    value = run(<<-CRYSTAL)
+      require "prelude"
       a = 1
       b = nil
       b = Reference.new
       a = b
       a.to_s
-    ").to_string
+      CRYSTAL.to_string
     value.should contain("Reference")
   end
 
   it "assigns union to larger union when source is nilable 2" do
-    run("
-      require \"prelude\"
+    run(<<-CRYSTAL).to_string.should eq("")
+      require "prelude"
       a = 1
       b = Reference.new
       b = nil
       a = b
       a.to_s
-    ").to_string.should eq("")
+      CRYSTAL
   end
 
   it "dispatch call to object method on nilable" do
-    run("
-      require \"prelude\"
+    run(<<-CRYSTAL)
+      require "prelude"
       class Foo
       end
 
       a = nil
       a = Foo.new
       a.nil?
-    ")
+      CRYSTAL
   end
 
   it "sorts restrictions when there are unions" do
-    run("
+    run(<<-CRYSTAL).to_i.should eq(2)
       class Middle
       end
 
@@ -188,11 +188,11 @@ describe "Code gen: union type" do
 
       t = Top.new || Another1.new
       type_id t
-      ").to_i.should eq(2)
+      CRYSTAL
   end
 
   it "codegens union to_s" do
-    str = run(%(
+    str = run(<<-CRYSTAL)
       require "prelude"
 
       def foo(x : T) forall T
@@ -201,19 +201,19 @@ describe "Code gen: union type" do
 
       a = 1 || 1.5
       foo(a)
-      )).to_string
+      CRYSTAL.to_string
     str.in?("(Int32 | Float64)", "(Float64 | Int32)").should be_true
   end
 
   it "provides T as a tuple literal" do
-    run(%(
+    run(<<-CRYSTAL).to_string.should eq("TupleLiteral")
       struct Union
         def self.foo
           {{ T.class_name }}
         end
       end
       Union(Nil, Int32).foo
-      )).to_string.should eq("TupleLiteral")
+      CRYSTAL
   end
 
   it "respects union payload alignment when upcasting Bool (#14898)" do

--- a/spec/compiler/codegen/until_spec.cr
+++ b/spec/compiler/codegen/until_spec.cr
@@ -2,12 +2,12 @@ require "../../spec_helper"
 
 describe "Codegen: until" do
   it "codegens until" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(10)
       a = 1
       until a == 10
         a = a &+ 1
       end
       a
-    )).to_i.should eq(10)
+      CRYSTAL
   end
 end

--- a/spec/compiler/codegen/var_spec.cr
+++ b/spec/compiler/codegen/var_spec.cr
@@ -10,7 +10,7 @@ describe "Code gen: var" do
   end
 
   it "codegens ivar assignment when not-nil type filter applies" do
-    run("
+    run(<<-CRYSTAL).to_i.should eq(2)
       class Foo
         def foo
           if @a
@@ -22,11 +22,11 @@ describe "Code gen: var" do
 
       foo = Foo.new
       foo.foo
-      ").to_i.should eq(2)
+      CRYSTAL
   end
 
   it "codegens bug with instance vars and ssa" do
-    run("
+    run(<<-CRYSTAL).to_i.should eq(-1)
       class Foo
         def initialize
           @angle = 0
@@ -43,11 +43,11 @@ describe "Code gen: var" do
 
       f = Foo.new
       f.foo
-      ").to_i.should eq(-1)
+      CRYSTAL
   end
 
   it "codegens bug with var, while, if, break and ssa" do
-    run("
+    run(<<-CRYSTAL).to_i.should eq(2)
       a = 1
       a = 2
 
@@ -60,11 +60,11 @@ describe "Code gen: var" do
       end
 
       a
-      ").to_i.should eq(2)
+      CRYSTAL
   end
 
   it "codegens bug with union of int, nil and string (1): assigning nil to union must fill all zeros" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(1)
       struct Nil
         def foo
           1
@@ -84,11 +84,11 @@ describe "Code gen: var" do
         x = "a"
       end
       x.foo
-      )).to_i.should eq(1)
+      CRYSTAL
   end
 
   it "codegens bug with union of int, nil and string (2): assigning nil to union must fill all zeros" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(1)
       struct Nil
         def foo
           1
@@ -108,31 +108,31 @@ describe "Code gen: var" do
         x = "a"
       end
       x.foo
-      )).to_i.should eq(1)
+      CRYSTAL
   end
 
   it "codegens assignment that can never be reached" do
-    codegen(%(
+    codegen(<<-CRYSTAL)
       if 1 == 1 && (x = nil)
         z = x
       end
-      ))
+      CRYSTAL
   end
 
   it "works with typeof with assignment (#828)" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(123)
       class String; def to_i!; 0; end; end
 
       a = 123
       typeof(a = "hello")
       a.to_i!
-      )).to_i.should eq(123)
+      CRYSTAL
   end
 
   it "assigns to underscore" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(2)
       _ = (b = 2)
       b
-      )).to_i.should eq(2)
+      CRYSTAL
   end
 end

--- a/spec/compiler/codegen/virtual_spec.cr
+++ b/spec/compiler/codegen/virtual_spec.cr
@@ -2,7 +2,7 @@ require "../../spec_helper"
 
 describe "Code gen: virtual type" do
   it "call base method" do
-    run("
+    run(<<-CRYSTAL).to_i.should eq(1)
       class Foo
         def coco
           1
@@ -15,11 +15,11 @@ describe "Code gen: virtual type" do
       a = Foo.new
       a = Bar.new
       a.coco
-    ").to_i.should eq(1)
+      CRYSTAL
   end
 
   it "call overwritten method" do
-    run("
+    run(<<-CRYSTAL).to_i.should eq(2)
       class Foo
         def coco
           1
@@ -35,11 +35,11 @@ describe "Code gen: virtual type" do
       a = Foo.new
       a = Bar.new
       a.coco
-    ").to_i.should eq(2)
+      CRYSTAL
   end
 
   it "call base overwritten method" do
-    run("
+    run(<<-CRYSTAL).to_i.should eq(1)
       class Foo
         def coco
           1
@@ -55,11 +55,11 @@ describe "Code gen: virtual type" do
       a = Bar.new
       a = Foo.new
       a.coco
-    ").to_i.should eq(1)
+      CRYSTAL
   end
 
   it "dispatch call with virtual type argument" do
-    run("
+    run(<<-CRYSTAL).to_i.should eq(2)
       class Foo
       end
 
@@ -77,11 +77,11 @@ describe "Code gen: virtual type" do
       a = Bar.new
       a = Foo.new
       coco(a)
-    ").to_i.should eq(2)
+      CRYSTAL
   end
 
   it "can belong to union" do
-    run("
+    run(<<-CRYSTAL).to_i.should eq(2)
       class Foo
         def foo; 1; end
       end
@@ -94,11 +94,11 @@ describe "Code gen: virtual type" do
       x = Bar.new
       x = Baz.new
       x.foo
-    ").to_i.should eq(2)
+      CRYSTAL
   end
 
   it "lookup instance variables in parent types" do
-    run("
+    run(<<-CRYSTAL).to_i.should eq(2)
       class Foo
         def initialize
           @x = 1
@@ -116,11 +116,11 @@ describe "Code gen: virtual type" do
 
       a = Bar.new || Foo.new
       a.foo
-    ").to_i.should eq(2)
+      CRYSTAL
   end
 
   it "assign instance variable in virtual type" do
-    run("
+    run(<<-CRYSTAL).to_i.should eq(1)
       class Foo
         def foo
           @x = 1
@@ -132,11 +132,11 @@ describe "Code gen: virtual type" do
 
       f = Foo.new || Bar.new
       f.foo
-    ").to_i.should eq(1)
+      CRYSTAL
   end
 
   it "codegens non-virtual call that calls virtual call to another virtual call" do
-    run("
+    run(<<-CRYSTAL).to_i.should eq(1)
       class Foo
         def foo
           foo2
@@ -155,11 +155,11 @@ describe "Code gen: virtual type" do
 
       bar = Bar.new
       bar.bar
-      ").to_i.should eq(1)
+      CRYSTAL
   end
 
   it "casts virtual type to base virtual type" do
-    run("
+    run(<<-CRYSTAL).to_i.should eq(1)
       class Object
         def bar
           1
@@ -177,12 +177,12 @@ describe "Code gen: virtual type" do
 
       f = Foo.new || Bar.new
       f.foo
-      ").to_i.should eq(1)
+      CRYSTAL
   end
 
   it "codegens call to Object#to_s from virtual type" do
-    run("
-      require \"prelude\"
+    run(<<-CRYSTAL)
+      require "prelude"
 
       class Foo
       end
@@ -192,23 +192,23 @@ describe "Code gen: virtual type" do
 
       a = Foo.new || Bar.new
       a.to_s
-      ")
+      CRYSTAL
   end
 
   it "codegens call to Object#to_s from nilable type" do
-    run("
-      require \"prelude\"
+    run(<<-CRYSTAL)
+      require "prelude"
 
       class Foo
       end
 
       a = nil || Foo.new
       a.to_s
-      ")
+      CRYSTAL
   end
 
   it "codegens virtual call with explicit self" do
-    run("
+    run(<<-CRYSTAL).to_i.should eq(1)
       class Foo
         def foo
           self.bar
@@ -224,11 +224,11 @@ describe "Code gen: virtual type" do
 
       f = Foo.new || Bar.new
       f.foo
-      ").to_i.should eq(1)
+      CRYSTAL
   end
 
   it "codegens virtual call with explicit self and nilable type" do
-    run("
+    run(<<-CRYSTAL).to_i.should eq(1)
       class Foo
         def foo
           self.bar
@@ -250,12 +250,12 @@ describe "Code gen: virtual type" do
 
       f = Bar.new || nil
       f.foo.to_i!
-      ").to_i.should eq(1)
+      CRYSTAL
   end
 
   it "initializes ivars to nil even if object never instantiated" do
-    run("
-      require \"prelude\"
+    run(<<-CRYSTAL)
+      require "prelude"
 
       class Ref
       end
@@ -288,11 +288,11 @@ describe "Code gen: virtual type" do
 
       f = Foo.new || Bar.new
       f.foo
-      ")
+      CRYSTAL
   end
 
   it "doesn't lookup in Value+ when virtual type is Object+" do
-    run(%(
+    run(<<-CRYSTAL).to_b.should be_true
       class Object
         def foo
           !nil?
@@ -304,11 +304,11 @@ describe "Code gen: virtual type" do
 
       a = Foo.new
       a.foo
-      )).to_b.should be_true
+      CRYSTAL
   end
 
   it "correctly dispatch call with block when the obj is a virtual type" do
-    run("
+    run(<<-CRYSTAL).to_i.should eq(2)
       class Foo
         def each
           yield self
@@ -331,11 +331,11 @@ describe "Code gen: virtual type" do
       y = 0
       a.each {|x| y = x.foo}
       y
-    ").to_i.should eq(2)
+      CRYSTAL
   end
 
   it "dispatch call with nilable virtual arg" do
-    run("
+    run(<<-CRYSTAL).to_i.should eq(1)
       class Foo
       end
 
@@ -356,11 +356,11 @@ describe "Code gen: virtual type" do
 
       x = lala
       foo(x)
-    ").to_i.should eq(1)
+      CRYSTAL
   end
 
   it "calls class method 1" do
-    run("
+    run(<<-CRYSTAL).to_i.should eq(1)
       class Foo
         def self.foo
           1
@@ -374,11 +374,11 @@ describe "Code gen: virtual type" do
       end
 
       (Foo.new || Bar.new).class.foo
-      ").to_i.should eq(1)
+      CRYSTAL
   end
 
   it "calls class method 2" do
-    run("
+    run(<<-CRYSTAL).to_i.should eq(2)
       class Foo
         def self.foo
           1
@@ -392,11 +392,11 @@ describe "Code gen: virtual type" do
       end
 
       (Bar.new || Foo.new).class.foo
-      ").to_i.should eq(2)
+      CRYSTAL
   end
 
   it "calls class method 3" do
-    run("
+    run(<<-CRYSTAL).to_i.should eq(1)
       class Base
         def self.foo
           1
@@ -413,11 +413,11 @@ describe "Code gen: virtual type" do
       end
 
       (Foo.new || Base.new).class.foo
-      ").to_i.should eq(1)
+      CRYSTAL
   end
 
   it "dispatches on virtual metaclass (1)" do
-    run("
+    run(<<-CRYSTAL).to_i.should eq(1)
       class Foo
         def self.coco
           1
@@ -432,11 +432,11 @@ describe "Code gen: virtual type" do
 
       some_long_var = Foo || Bar
       some_long_var.coco
-      ").to_i.should eq(1)
+      CRYSTAL
   end
 
   it "dispatches on virtual metaclass (2)" do
-    run("
+    run(<<-CRYSTAL).to_i.should eq(2)
       class Foo
         def self.coco
           1
@@ -451,11 +451,11 @@ describe "Code gen: virtual type" do
 
       some_long_var = Bar || Foo
       some_long_var.coco
-      ").to_i.should eq(2)
+      CRYSTAL
   end
 
   it "dispatches on virtual metaclass (3)" do
-    run("
+    run(<<-CRYSTAL).to_i.should eq(2)
       class Foo
         def self.coco
           1
@@ -473,11 +473,11 @@ describe "Code gen: virtual type" do
 
       some_long_var = Baz || Foo
       some_long_var.coco
-      ").to_i.should eq(2)
+      CRYSTAL
   end
 
   it "codegens new for simple type, then for virtual" do
-    run("
+    run(<<-CRYSTAL).to_i.should eq(1)
       class Foo
         def initialize(@x : Int32)
         end
@@ -493,11 +493,11 @@ describe "Code gen: virtual type" do
       x = Foo.new(1)
       y = (Foo || Bar).new(1)
       y.x
-      ").to_i.should eq(1)
+      CRYSTAL
   end
 
   it "codegens new twice for virtual" do
-    run("
+    run(<<-CRYSTAL).to_i.should eq(1)
       class Foo
         def initialize(@x : Int32)
         end
@@ -513,11 +513,11 @@ describe "Code gen: virtual type" do
       y = (Foo || Bar).new(1)
       y = (Foo || Bar).new(1)
       y.x
-      ").to_i.should eq(1)
+      CRYSTAL
   end
 
   it "codegens allocate for virtual type with custom new" do
-    run("
+    run(<<-CRYSTAL).to_i.should eq(2)
       class Foo
         def self.new
           allocate
@@ -536,11 +536,11 @@ describe "Code gen: virtual type" do
 
       foo = (Bar || Foo).new
       foo.foo
-      ").to_i.should eq(2)
+      CRYSTAL
   end
 
   it "returns type with virtual type def type" do
-    run("
+    run(<<-CRYSTAL).to_i.should eq(1)
       class Foo
         def foo
           1
@@ -559,11 +559,11 @@ describe "Code gen: virtual type" do
       end
 
       foo.foo
-    ").to_i.should eq(1)
+      CRYSTAL
   end
 
   it "casts virtual type to union" do
-    run("
+    run(<<-CRYSTAL).to_i.should eq(3)
       class Foo
       end
 
@@ -589,11 +589,11 @@ describe "Code gen: virtual type" do
 
       f = Baz.new || Bar.new
       x(f)
-      ").to_i.should eq(3)
+      CRYSTAL
   end
 
   it "casts union to virtual" do
-    run("
+    run(<<-CRYSTAL).to_b.should be_true
       module Moo
       end
 
@@ -620,11 +620,11 @@ describe "Code gen: virtual type" do
 
       reference = Bar.new || Baz.new
       reference.object_id == foo(reference)
-      ").to_b.should be_true
+      CRYSTAL
   end
 
   it "codegens virtual method of abstract metaclass" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(2)
       class Foo
         def self.foo
           1
@@ -644,11 +644,11 @@ describe "Code gen: virtual type" do
       end
 
       (Bar || Foo || Baz).foo
-      )).to_i.should eq(2)
+      CRYSTAL
   end
 
   it "codegens new for virtual class with one type" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(123)
       require "prelude"
 
       abstract class Foo
@@ -663,11 +663,11 @@ describe "Code gen: virtual type" do
       p = Pointer(Foo.class).malloc(1_u64)
       p.value = Bar
       p.value.new.foo
-      )).to_i.should eq(123)
+      CRYSTAL
   end
 
   it "codegens new for virtual class with two types" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(456)
       require "prelude"
 
       abstract class Foo
@@ -689,11 +689,11 @@ describe "Code gen: virtual type" do
       p.value = Bar
       p.value = Baz
       p.value.new.foo
-      )).to_i.should eq(456)
+      CRYSTAL
   end
 
   it "codegens new for new on virtual abstract class (#3835)" do
-    run(%(
+    run(<<-CRYSTAL).to_string.should eq("Can't instantiate abstract class Foo")
       require "prelude"
 
       abstract class Foo
@@ -711,11 +711,11 @@ describe "Code gen: virtual type" do
       rescue ex
         ex.message.not_nil!
       end
-      )).to_string.should eq("Can't instantiate abstract class Foo")
+      CRYSTAL
   end
 
   it "casts metaclass union type to virtual metaclass type (#6298)" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(2)
       class Foo
         def self.x
           1
@@ -745,6 +745,6 @@ describe "Code gen: virtual type" do
 
       klass = Bar || Baz
       Moo.new(klass).foo.x
-      )).to_i.should eq(2)
+      CRYSTAL
   end
 end

--- a/spec/compiler/codegen/void_spec.cr
+++ b/spec/compiler/codegen/void_spec.cr
@@ -2,19 +2,19 @@ require "../../spec_helper"
 
 describe "Code gen: void" do
   it "codegens void assignment" do
-    run("
+    run(<<-CRYSTAL).to_i.should eq(1)
       fun foo : Void
       end
 
       a = foo
       a
       1
-      ").to_i.should eq(1)
+      CRYSTAL
   end
 
   it "codegens void assignment in case" do
-    run("
-      require \"prelude\"
+    run(<<-CRYSTAL).to_i.should eq(1)
+      require "prelude"
 
       fun foo : Void
       end
@@ -24,19 +24,19 @@ describe "Code gen: void" do
         when 1
           foo
         when 2
-          raise \"oh no\"
+          raise "oh no"
         else
         end
       end
 
       bar
       1
-      ").to_i.should eq(1)
+      CRYSTAL
   end
 
   it "codegens void assignment in case with local variable" do
-    run("
-      require \"prelude\"
+    run(<<-CRYSTAL).to_i.should eq(1)
+      require "prelude"
 
       fun foo : Void
       end
@@ -47,38 +47,38 @@ describe "Code gen: void" do
           a = 1
           foo
         when 2
-          raise \"oh no\"
+          raise "oh no"
         else
         end
       end
 
       bar
       1
-      ").to_i.should eq(1)
+      CRYSTAL
   end
 
   it "codegens unreachable code" do
-    run(%(
+    run(<<-CRYSTAL)
       a = nil
       if a
         b = a.foo
       end
-      ))
+      CRYSTAL
   end
 
   it "codegens no return assignment" do
-    codegen("
+    codegen(<<-CRYSTAL)
       lib LibC
         fun exit : NoReturn
       end
 
       a = LibC.exit
       a
-      ")
+      CRYSTAL
   end
 
   it "allows passing void as argument to method" do
-    codegen(%(
+    codegen(<<-CRYSTAL)
       lib LibC
         fun foo
       end
@@ -91,11 +91,11 @@ describe "Code gen: void" do
       end
 
       bar(baz)
-    ))
+      CRYSTAL
   end
 
   it "returns void from nil functions, doesn't crash when passing value" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(1)
       def baz(x)
         1
       end
@@ -112,6 +112,6 @@ describe "Code gen: void" do
       end
 
       foo.bar
-      )).to_i.should eq(1)
+      CRYSTAL
   end
 end

--- a/spec/compiler/codegen/while_spec.cr
+++ b/spec/compiler/codegen/while_spec.cr
@@ -22,7 +22,7 @@ describe "Codegen: while" do
   end
 
   it "break with value" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(4)
       struct Nil; def to_i!; 0; end; end
 
       a = 0
@@ -31,11 +31,11 @@ describe "Codegen: while" do
         break a &+ 3
       end
       b.to_i!
-      )).to_i.should eq(4)
+      CRYSTAL
   end
 
   it "conditional break with value" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(9)
       struct Nil; def to_i!; 0; end; end
 
       a = 0
@@ -44,36 +44,36 @@ describe "Codegen: while" do
         break a &+ 3 if a > 5
       end
       b.to_i!
-      )).to_i.should eq(9)
+      CRYSTAL
   end
 
   it "break with value, condition fails" do
-    run(%(
+    run(<<-CRYSTAL).to_b.should be_true
       a = while 1 == 2
         break 1
       end
       a.nil?
-      )).to_b.should be_true
+      CRYSTAL
   end
 
   it "endless break with value" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(4)
       a = 0
       while true
         a &+= 1
         break a &+ 3
       end
-      )).to_i.should eq(4)
+      CRYSTAL
   end
 
   it "endless conditional break with value" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(9)
       a = 0
       while true
         a &+= 1
         break a &+ 3 if a > 5
       end
-      )).to_i.should eq(9)
+      CRYSTAL
   end
 
   it "codegens endless while" do
@@ -81,18 +81,18 @@ describe "Codegen: while" do
   end
 
   it "codegens while with declared var 1" do
-    run("
+    run(<<-CRYSTAL).to_i.should eq(0)
       struct Nil; def to_i!; 0; end; end
 
       while 1 == 2
         a = 2
       end
       a.to_i!
-      ").to_i.should eq(0)
+      CRYSTAL
   end
 
   it "codegens while with declared var 2" do
-    run("
+    run(<<-CRYSTAL).to_i.should eq(3)
       struct Nil; def to_i!; 0; end; end
 
       while 1 == 1
@@ -103,11 +103,11 @@ describe "Codegen: while" do
         end
       end
       a.to_i!
-      ").to_i.should eq(3)
+      CRYSTAL
   end
 
   it "codegens while with declared var 3" do
-    run("
+    run(<<-CRYSTAL).to_i.should eq(1)
       struct Nil; def to_i!; 0; end; end
 
       while 1 == 1
@@ -119,11 +119,11 @@ describe "Codegen: while" do
         end
       end
       a.to_i!
-      ").to_i.should eq(1)
+      CRYSTAL
   end
 
   it "skip block with next" do
-    run("
+    run(<<-CRYSTAL).to_i.should eq(25)
       i = 0
       x = 0
 
@@ -133,11 +133,11 @@ describe "Codegen: while" do
         x &+= i
       end
       x
-    ").to_i.should eq(25)
+      CRYSTAL
   end
 
   it "doesn't crash on a = NoReturn" do
-    codegen(%(
+    codegen(<<-CRYSTAL)
       lib LibFoo
         fun foo : NoReturn
       end
@@ -145,11 +145,11 @@ describe "Codegen: while" do
       while a = LibFoo.foo
         a
       end
-      ))
+      CRYSTAL
   end
 
   it "doesn't crash on #2767" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(10)
       lib LibC
         fun exit(Int32) : NoReturn
       end
@@ -162,11 +162,11 @@ describe "Codegen: while" do
       end
       x
       10
-      )).to_i.should eq(10)
+      CRYSTAL
   end
 
   it "doesn't crash on #2767 (2)" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(10)
       lib LibC
         fun exit(Int32) : NoReturn
       end
@@ -177,11 +177,11 @@ describe "Codegen: while" do
       end
       x
       10
-      )).to_i.should eq(10)
+      CRYSTAL
   end
 
   it "doesn't crash on #2767 (3)" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(10)
       lib LibC
         fun exit(Int32) : NoReturn
       end
@@ -198,11 +198,11 @@ describe "Codegen: while" do
       end
       x
       10
-      )).to_i.should eq(10)
+      CRYSTAL
   end
 
   it "doesn't crash on #2767 (4)" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(10)
       lib LibC
         fun exit(Int32) : NoReturn
       end
@@ -218,11 +218,11 @@ describe "Codegen: while" do
       end
       x
       10
-      )).to_i.should eq(10)
+      CRYSTAL
   end
 
   it "doesn't crash on while true begin break rescue (#7786)" do
-    codegen(%(
+    codegen(<<-CRYSTAL)
       require "prelude"
 
       while true
@@ -233,6 +233,6 @@ describe "Codegen: while" do
         end
       end
       foo
-      ))
+      CRYSTAL
   end
 end

--- a/spec/compiler/codegen/yield_with_scope_spec.cr
+++ b/spec/compiler/codegen/yield_with_scope_spec.cr
@@ -2,19 +2,19 @@ require "../../spec_helper"
 
 describe "Semantic: yield with scope" do
   it "uses scope in global method" do
-    run("
-      require \"prelude\"
+    run(<<-CRYSTAL).to_i.should eq(2)
+      require "prelude"
       def foo; with 1 yield; end
 
       foo do
         succ
       end
-    ").to_i.should eq(2)
+      CRYSTAL
   end
 
   it "uses scope in instance method" do
-    run("
-      require \"prelude\"
+    run(<<-CRYSTAL).to_i.should eq(2)
+      require "prelude"
       def foo; with 1 yield; end
 
       class Foo
@@ -30,12 +30,12 @@ describe "Semantic: yield with scope" do
       end
 
       Foo.new.test
-    ").to_i.should eq(2)
+      CRYSTAL
   end
 
   it "it uses self for instance method" do
-    run("
-      require \"prelude\"
+    run(<<-CRYSTAL).to_i.should eq(10)
+      require "prelude"
       def foo; with 1 yield; end
 
       class Foo
@@ -51,12 +51,12 @@ describe "Semantic: yield with scope" do
       end
 
       Foo.new.test
-    ").to_i.should eq(10)
+      CRYSTAL
   end
 
   it "it invokes global method inside block of yield scope" do
-    run("
-      require \"prelude\"
+    run(<<-CRYSTAL).to_i.should eq(3)
+      require "prelude"
 
       def foo
         with -1 yield
@@ -69,11 +69,11 @@ describe "Semantic: yield with scope" do
       foo do
         plus_two abs
       end
-    ").to_i.should eq(3)
+      CRYSTAL
   end
 
   it "generate right code when yielding struct as scope" do
-    run("
+    run(<<-CRYSTAL).to_i.should eq(1)
       struct Foo
         def bar; end
       end
@@ -84,11 +84,11 @@ describe "Semantic: yield with scope" do
       end
 
       foo { bar }
-    ").to_i.should eq(1)
+      CRYSTAL
   end
 
   it "doesn't explode if specifying &block but never using it (#181)" do
-    codegen(%(
+    codegen(<<-CRYSTAL)
       class Foo
         def a(&block)
           with self yield
@@ -99,11 +99,11 @@ describe "Semantic: yield with scope" do
       a = Foo.new
       a.a { aa }
       a.a { aa }
-      ))
+      CRYSTAL
   end
 
   it "uses instance variable of enclosing scope" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(2)
       class Foo
         def foo
           with self yield
@@ -123,11 +123,11 @@ describe "Semantic: yield with scope" do
       end
 
       Bar.new.bar
-      )).to_i.should eq(2)
+      CRYSTAL
   end
 
   it "uses method of enclosing scope" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(2)
       class Foo
         def foo
           with self yield
@@ -147,11 +147,11 @@ describe "Semantic: yield with scope" do
       end
 
       Bar.new.bar
-      )).to_i.should eq(2)
+      CRYSTAL
   end
 
   it "uses method of with object" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(2)
       class Foo
         def initialize
           @x = 1
@@ -175,11 +175,11 @@ describe "Semantic: yield with scope" do
       end
 
       Bar.new.bar
-      )).to_i.should eq(2)
+      CRYSTAL
   end
 
   it "yields with dispatch (#2171) (1)" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(10)
       class Foo
         def method(x : Int32)
           10
@@ -197,11 +197,11 @@ describe "Semantic: yield with scope" do
       foo do
         method(1 || 1.5)
       end
-      )).to_i.should eq(10)
+      CRYSTAL
   end
 
   it "yields virtual type (#2171) (2)" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(2)
       class Foo
         def method
           1
@@ -219,6 +219,6 @@ describe "Semantic: yield with scope" do
       end
 
       foo { method }
-      )).to_i.should eq(2)
+      CRYSTAL
   end
 end

--- a/spec/compiler/semantic/block_spec.cr
+++ b/spec/compiler/semantic/block_spec.cr
@@ -1406,7 +1406,7 @@ describe "Block inference" do
   end
 
   it "doesn't crash on #2531" do
-    run(%(
+    run(<<-CRYSTAL).to_i.should eq(10)
       def foo
         yield
       end
@@ -1416,7 +1416,7 @@ describe "Block inference" do
         value ? nil : nil
       end
       value ? 10 : 20
-      )).to_i.should eq(10)
+      CRYSTAL
   end
 
   it "yields in overload, matches type" do

--- a/spec/compiler/semantic/macro_spec.cr
+++ b/spec/compiler/semantic/macro_spec.cr
@@ -55,7 +55,7 @@ describe "Semantic: macro" do
   end
 
   it "allows subclasses of return type for macro def" do
-    run(%{
+    run(<<-CRYSTAL).to_i.should eq(2)
       class Foo
         def foo
           1
@@ -76,11 +76,11 @@ describe "Semantic: macro" do
       end
 
       Baz.new.foobar.foo
-    }).to_i.should eq(2)
+      CRYSTAL
   end
 
   it "allows return values that include the return type of the macro def" do
-    run(%{
+    run(<<-CRYSTAL).to_i.should eq(2)
       module Foo
         def foo
           1
@@ -103,11 +103,11 @@ describe "Semantic: macro" do
       end
 
       Baz.new.foobar.foo
-    }).to_i.should eq(2)
+      CRYSTAL
   end
 
   it "allows generic return types for macro def" do
-    run(%{
+    run(<<-CRYSTAL).to_i.should eq(2)
       class Foo(T)
         def foo
           @foo
@@ -125,7 +125,7 @@ describe "Semantic: macro" do
       end
 
       Baz.new.foobar.foo
-    }).to_i.should eq(2)
+      CRYSTAL
 
     assert_error(<<-CRYSTAL, "method Bar#bar must return Foo(String) but it is returning Foo(Int32)")
       class Foo(T)


### PR DESCRIPTION
Resolves part of #11291. Single-line specs are not affected in this PR.

The changes in the first commit are automated using [this Crystal script](https://gist.github.com/HertzDevil/eaab57e57054da7005a9986d5c99c387).