### PR TITLE
Style `test_c` codegen specs using heredocs

### DIFF
--- a/spec/compiler/codegen/c_abi/c_abi_spec.cr
+++ b/spec/compiler/codegen/c_abi/c_abi_spec.cr
@@ -2,290 +2,270 @@ require "../../../spec_helper"
 
 describe "Code gen: C ABI" do
   it "passes struct less than 64 bits (for real)" do
-    test_c(
-      %(
-        struct s {
-          char x;
-          short y;
-        };
+    test_c(<<-C, <<-CRYSTAL, &.to_i.should eq(3))
+      struct s {
+        char x;
+        short y;
+      };
 
-        int foo(struct s a) {
-          return a.x + a.y;
-        }
-      ),
-      %(
-        lib LibFoo
-          struct Struct
-            x : Int8
-            y : Int16
-          end
-
-          fun foo(s : Struct) : Int32
+      int foo(struct s a) {
+        return a.x + a.y;
+      }
+      C
+      lib LibFoo
+        struct Struct
+          x : Int8
+          y : Int16
         end
 
-        s = LibFoo::Struct.new x: 1_i8, y: 2_i16
-        LibFoo.foo(s)
-      ), &.to_i.should eq(3))
+        fun foo(s : Struct) : Int32
+      end
+
+      s = LibFoo::Struct.new x: 1_i8, y: 2_i16
+      LibFoo.foo(s)
+      CRYSTAL
   end
 
   it "passes struct between 64 and 128 bits (for real)" do
-    test_c(
-      %(
-        struct s {
-          long long x;
-          short y;
-        };
+    test_c(<<-C, <<-CRYSTAL, &.to_i.should eq(3))
+      struct s {
+        long long x;
+        short y;
+      };
 
-        long long foo(struct s a) {
-          return a.x + a.y;
-        }
-      ),
-      %(
-        lib LibFoo
-          struct Struct
-            x : Int64
-            y : Int16
-          end
-
-          fun foo(s : Struct) : Int64
+      long long foo(struct s a) {
+        return a.x + a.y;
+      }
+      C
+      lib LibFoo
+        struct Struct
+          x : Int64
+          y : Int16
         end
 
-        s = LibFoo::Struct.new x: 1_i64, y: 2_i16
-        LibFoo.foo(s)
-      ), &.to_i.should eq(3))
+        fun foo(s : Struct) : Int64
+      end
+
+      s = LibFoo::Struct.new x: 1_i64, y: 2_i16
+      LibFoo.foo(s)
+      CRYSTAL
   end
 
   it "passes struct bigger than 128 bits (for real)" do
-    test_c(
-      %(
-        struct s {
-          long long x;
-          long long y;
-          char z;
-        };
+    test_c(<<-C, <<-CRYSTAL, &.to_i.should eq(6))
+      struct s {
+        long long x;
+        long long y;
+        char z;
+      };
 
-        long long foo(struct s a) {
-          return a.x + a.y + a.z;
-        }
-      ),
-      %(
-        lib LibFoo
-          struct Struct
-            x : Int64
-            y : Int64
-            z : Int8
-          end
-
-          fun foo(s : Struct) : Int64
+      long long foo(struct s a) {
+        return a.x + a.y + a.z;
+      }
+      C
+      lib LibFoo
+        struct Struct
+          x : Int64
+          y : Int64
+          z : Int8
         end
 
-        s = LibFoo::Struct.new x: 1_i64, y: 2_i64, z: 3_i8
-        LibFoo.foo(s)
-      ), &.to_i.should eq(6))
+        fun foo(s : Struct) : Int64
+      end
+
+      s = LibFoo::Struct.new x: 1_i64, y: 2_i64, z: 3_i8
+      LibFoo.foo(s)
+      CRYSTAL
   end
 
   it "passes struct after many other args (for real)" do
-    test_c(
-      %(
-        struct s {
-          long long x, y;
-        };
+    test_c(<<-C, <<-CRYSTAL, &.to_string.should eq("28"))
+      struct s {
+        long long x, y;
+      };
 
-        long long foo(long long a, long long b, long long c, long long d, long long e, struct s v) {
-          return a + b + c + d + e + v.x + v.y;
-        }
-      ),
-      %(
-        lib LibFoo
-          struct S
-            x : Int64
-            y : Int64
-          end
-
-          fun foo(a : Int64, b : Int64, c : Int64, d : Int64, e : Int64, v : S) : Int64
+      long long foo(long long a, long long b, long long c, long long d, long long e, struct s v) {
+        return a + b + c + d + e + v.x + v.y;
+      }
+      C
+      lib LibFoo
+        struct S
+          x : Int64
+          y : Int64
         end
 
-        v = LibFoo::S.new(x: 6, y: 7)
-        LibFoo.foo(1, 2, 3, 4, 5, v)
-      ), &.to_string.should eq("28"))
+        fun foo(a : Int64, b : Int64, c : Int64, d : Int64, e : Int64, v : S) : Int64
+      end
+
+      v = LibFoo::S.new(x: 6, y: 7)
+      LibFoo.foo(1, 2, 3, 4, 5, v)
+      CRYSTAL
   end
 
   it "passes struct after many other args when returning a large struct (sret return type)" do
-    test_c(
-      %(
-        struct s {
-          long long x, y;
-        };
-        struct t {
-          long long x, y, z;
-        };
+    test_c(<<-C, <<-CRYSTAL, &.to_string.should eq("[6, 7, 10]"))
+      struct s {
+        long long x, y;
+      };
+      struct t {
+        long long x, y, z;
+      };
 
-        struct t foo(long long a, long long b, long long c, long long d, struct s v) {
-          return (struct t){ v.x, v.y, a + b + c + d };
-        }
-      ),
-      %(
-        lib LibFoo
-          struct S
-            x : Int64
-            y : Int64
-          end
-          struct T
-            x : Int64
-            y : Int64
-            z : Int64
-          end
-
-          fun foo(a : Int64, b : Int64, c : Int64, d : Int64, v : S) : T
+      struct t foo(long long a, long long b, long long c, long long d, struct s v) {
+        return (struct t){ v.x, v.y, a + b + c + d };
+      }
+      C
+      lib LibFoo
+        struct S
+          x : Int64
+          y : Int64
+        end
+        struct T
+          x : Int64
+          y : Int64
+          z : Int64
         end
 
-        v = LibFoo::S.new(x: 6, y: 7)
-        w = LibFoo.foo(1, 2, 3, 4, v)
-        [w.x, w.y, w.z]
-      ), &.to_string.should eq("[6, 7, 10]"))
+        fun foo(a : Int64, b : Int64, c : Int64, d : Int64, v : S) : T
+      end
+
+      v = LibFoo::S.new(x: 6, y: 7)
+      w = LibFoo.foo(1, 2, 3, 4, v)
+      [w.x, w.y, w.z]
+      CRYSTAL
   end
 
   it "returns struct less than 64 bits (for real)" do
-    test_c(
-      %(
-        struct s {
-          char x;
-          short y;
-        };
+    test_c(<<-C, <<-CRYSTAL, &.to_i.should eq(3))
+      struct s {
+        char x;
+        short y;
+      };
 
-        struct s foo() {
-          struct s a = {1, 2};
-          return a;
-        }
-      ),
-      %(
-        lib LibFoo
-          struct Struct
-            x : Int8
-            y : Int16
-          end
-
-          fun foo : Struct
+      struct s foo() {
+        struct s a = {1, 2};
+        return a;
+      }
+      C
+      lib LibFoo
+        struct Struct
+          x : Int8
+          y : Int16
         end
 
-        str = LibFoo.foo
-        str.x.to_i + str.y.to_i
-      ), &.to_i.should eq(3))
+        fun foo : Struct
+      end
+
+      str = LibFoo.foo
+      str.x.to_i + str.y.to_i
+      CRYSTAL
   end
 
   it "returns struct between 64 and 128 bits (for real)" do
-    test_c(
-      %(
-        struct s {
-          long long x;
-          short y;
-        };
+    test_c(<<-C, <<-CRYSTAL, &.to_i.should eq(3))
+      struct s {
+        long long x;
+        short y;
+      };
 
-        struct s foo() {
-          struct s a = {1, 2};
-          return a;
-        }
-      ),
-      %(
-        lib LibFoo
-          struct Struct
-            x : Int64
-            y : Int16
-          end
-
-          fun foo : Struct
+      struct s foo() {
+        struct s a = {1, 2};
+        return a;
+      }
+      C
+      lib LibFoo
+        struct Struct
+          x : Int64
+          y : Int16
         end
 
-        str = LibFoo.foo
-        (str.x + str.y).to_i32
-      ), &.to_i.should eq(3))
+        fun foo : Struct
+      end
+
+      str = LibFoo.foo
+      (str.x + str.y).to_i32
+      CRYSTAL
   end
 
   it "returns struct bigger than 128 bits with sret" do
-    test_c(
-      %(
-        struct s {
-          long long x;
-          long long y;
-          char z;
-        };
+    test_c(<<-C, <<-CRYSTAL, &.to_i.should eq(6))
+      struct s {
+        long long x;
+        long long y;
+        char z;
+      };
 
-        struct s foo(int z) {
-          struct s a = {1, 2, z};
-          return a;
-        }
-      ),
-      %(
-        lib LibFoo
-          struct Struct
-            x : Int64
-            y : Int64
-            z : Int8
-          end
-
-          fun foo(w : Int32) : Struct
+      struct s foo(int z) {
+        struct s a = {1, 2, z};
+        return a;
+      }
+      C
+      lib LibFoo
+        struct Struct
+          x : Int64
+          y : Int64
+          z : Int8
         end
 
-        str = LibFoo.foo(3)
-        (str.x + str.y + str.z).to_i32
-      ), &.to_i.should eq(6))
+        fun foo(w : Int32) : Struct
+      end
+
+      str = LibFoo.foo(3)
+      (str.x + str.y + str.z).to_i32
+      CRYSTAL
   end
 
   it "accepts large struct in a callback (for real)" do
-    test_c(
-      %(
-        struct s {
-            long long x, y, z;
-        };
+    test_c(<<-C, <<-CRYSTAL, &.to_string.should eq("6"))
+      struct s {
+          long long x, y, z;
+      };
 
-        void ccaller(void (*func)(struct s)) {
-            struct s v = {1, 2, 3};
-            func(v);
-        }
-      ),
-      %(
-        lib LibFoo
-          struct S
-            x : Int64
-            y : Int64
-            z : Int64
-          end
-
-          fun ccaller(func : (S) ->)
+      void ccaller(void (*func)(struct s)) {
+          struct s v = {1, 2, 3};
+          func(v);
+      }
+      C
+      lib LibFoo
+        struct S
+          x : Int64
+          y : Int64
+          z : Int64
         end
 
-        module Global
-          class_property x = 0i64
-        end
+        fun ccaller(func : (S) ->)
+      end
 
-        fun callback(v : LibFoo::S)
-          Global.x = v.x &+ v.y &+ v.z
-        end
+      module Global
+        class_property x = 0i64
+      end
 
-        LibFoo.ccaller(->callback)
+      fun callback(v : LibFoo::S)
+        Global.x = v.x &+ v.y &+ v.z
+      end
 
-        Global.x
-      ), &.to_string.should eq("6"))
+      LibFoo.ccaller(->callback)
+
+      Global.x
+      CRYSTAL
   end
 
   it "promotes variadic args (float to double)" do
-    test_c(
-      %(
-        #include <stdarg.h>
+    test_c(<<-C, <<-CRYSTAL, &.to_f64.should eq(1.0))
+      #include <stdarg.h>
 
-        double foo(int n, ...) {
-          va_list args;
-          va_start(args, n);
-          return va_arg(args, double);
-        }
-      ),
-      %(
-        lib LibFoo
-          fun foo(n : Int32, ...) : Float64
-        end
+      double foo(int n, ...) {
+        va_list args;
+        va_start(args, n);
+        return va_arg(args, double);
+      }
+      C
+      lib LibFoo
+        fun foo(n : Int32, ...) : Float64
+      end
 
-        LibFoo.foo(1, 1.0_f32)
-      ), &.to_f64.should eq(1.0))
+      LibFoo.foo(1, 1.0_f32)
+      CRYSTAL
   end
 
   [{"i8", -123},
@@ -294,23 +274,21 @@ describe "Code gen: C ABI" do
    {"u16", 65535},
   ].each do |int_kind, int_value|
     it "promotes variadic args (#{int_kind} to i32) (#9742)" do
-      test_c(
-        %(
-          #include <stdarg.h>
+      test_c(<<-C, <<-CRYSTAL, &.to_i.should eq(int_value))
+        #include <stdarg.h>
 
-          int foo(int n, ...) {
-            va_list args;
-            va_start(args, n);
-            return va_arg(args, int);
-          }
-        ),
-        %(
-          lib LibFoo
-            fun foo(n : Int32, ...) : Int32
-          end
+        int foo(int n, ...) {
+          va_list args;
+          va_start(args, n);
+          return va_arg(args, int);
+        }
+        C
+        lib LibFoo
+          fun foo(n : Int32, ...) : Int32
+        end
 
-          LibFoo.foo(1, #{int_value}_#{int_kind})
-        ), &.to_i.should eq(int_value))
+        LibFoo.foo(1, #{int_value}_#{int_kind})
+        CRYSTAL
     end
   end
 end

--- a/spec/compiler/codegen/extern_spec.cr
+++ b/spec/compiler/codegen/extern_spec.cr
@@ -188,317 +188,305 @@ describe "Codegen: extern struct" do
   # it's just that the specs need to be a bit different)
   {% if flag?(:x86_64) || flag?(:aarch64) %}
     it "codegens proc that takes an extern struct with C ABI" do
-      test_c(
-        %(
-            struct Struct {
-              int x;
-              int y;
-            };
+      test_c(<<-C, <<-CRYSTAL, &.to_i.should eq(3))
+        struct Struct {
+          int x;
+          int y;
+        };
 
-            void foo(struct Struct (*callback)(struct Struct)) {
-              struct Struct s;
-              s.x = 1;
-              s.y = 2;
-              callback(s);
-            }
-          ),
-        %(
-            lib LibMylib
-              struct Struct
-                x : Int32
-                y : Int32
-              end
+        void foo(struct Struct (*callback)(struct Struct)) {
+          struct Struct s;
+          s.x = 1;
+          s.y = 2;
+          callback(s);
+        }
+        C
+        lib LibMylib
+          struct Struct
+            x : Int32
+            y : Int32
+          end
 
-              alias Callback = Struct ->
+          alias Callback = Struct ->
 
-              fun foo(callback : Callback) : LibMylib::Struct
-            end
+          fun foo(callback : Callback) : LibMylib::Struct
+        end
 
-            class Global
-              @@x = 0
-              @@y = 0
+        class Global
+          @@x = 0
+          @@y = 0
 
-              def self.x=(@@x)
-              end
+          def self.x=(@@x)
+          end
 
-              def self.y=(@@y)
-              end
+          def self.y=(@@y)
+          end
 
-              def self.x
-                @@x
-              end
+          def self.x
+            @@x
+          end
 
-              def self.y
-                @@y
-              end
-            end
+          def self.y
+            @@y
+          end
+        end
 
-            LibMylib.foo(->(s) {
-              Global.x = s.x
-              Global.y = s.y
-            })
+        LibMylib.foo(->(s) {
+          Global.x = s.x
+          Global.y = s.y
+        })
 
-            Global.x &+ Global.y
-          ), &.to_i.should eq(3))
+        Global.x &+ Global.y
+        CRYSTAL
     end
 
     it "codegens proc that takes an extern struct with C ABI (2)" do
-      test_c(
-        %(
-            struct Struct {
-              int x;
-              int y;
-            };
+      test_c(<<-C, <<-CRYSTAL, &.to_i.should eq(33))
+        struct Struct {
+          int x;
+          int y;
+        };
 
-            void foo(struct Struct (*callback)(int, struct Struct, int)) {
-              struct Struct s;
-              s.x = 1;
-              s.y = 2;
-              callback(10, s, 20);
-            }
-          ),
-        %(
-            lib LibMylib
-              struct Struct
-                x : Int32
-                y : Int32
-              end
+        void foo(struct Struct (*callback)(int, struct Struct, int)) {
+          struct Struct s;
+          s.x = 1;
+          s.y = 2;
+          callback(10, s, 20);
+        }
+        C
+        lib LibMylib
+          struct Struct
+            x : Int32
+            y : Int32
+          end
 
-              alias Callback = Int32, Struct, Int32 ->
+          alias Callback = Int32, Struct, Int32 ->
 
-              fun foo(callback : Callback) : LibMylib::Struct
-            end
+          fun foo(callback : Callback) : LibMylib::Struct
+        end
 
-            class Global
-              @@x = 0
-              @@y = 0
+        class Global
+          @@x = 0
+          @@y = 0
 
-              def self.x=(@@x)
-              end
+          def self.x=(@@x)
+          end
 
-              def self.y=(@@y)
-              end
+          def self.y=(@@y)
+          end
 
-              def self.x
-                @@x
-              end
+          def self.x
+            @@x
+          end
 
-              def self.y
-                @@y
-              end
-            end
+          def self.y
+            @@y
+          end
+        end
 
-            LibMylib.foo(->(x, s, y) {
-              Global.x = s.x &+ x
-              Global.y = s.y &+ y
-            })
+        LibMylib.foo(->(x, s, y) {
+          Global.x = s.x &+ x
+          Global.y = s.y &+ y
+        })
 
-            Global.x &+ Global.y
-          ), &.to_i.should eq(33))
+        Global.x &+ Global.y
+        CRYSTAL
     end
 
     it "codegens proc that takes an extern struct with C ABI, callback returns nil" do
-      test_c(
-        %(
-            struct Struct {
-              int x;
-              int y;
-            };
+      test_c(<<-C, <<-CRYSTAL, &.to_i.should eq(3))
+        struct Struct {
+          int x;
+          int y;
+        };
 
-            void foo(void (*callback)(struct Struct)) {
-              struct Struct s;
-              s.x = 1;
-              s.y = 2;
-              callback(s);
-            }
-          ),
-        %(
-            lib LibMylib
-              struct Struct
-                x : Int32
-                y : Int32
-              end
+        void foo(void (*callback)(struct Struct)) {
+          struct Struct s;
+          s.x = 1;
+          s.y = 2;
+          callback(s);
+        }
+        C
+        lib LibMylib
+          struct Struct
+            x : Int32
+            y : Int32
+          end
 
-              alias Callback = Struct ->
+          alias Callback = Struct ->
 
-              fun foo(callback : Callback) : LibMylib::Struct
-            end
+          fun foo(callback : Callback) : LibMylib::Struct
+        end
 
-            class Global
-              @@x = 0
-              @@y = 0
+        class Global
+          @@x = 0
+          @@y = 0
 
-              def self.x=(@@x)
-              end
+          def self.x=(@@x)
+          end
 
-              def self.y=(@@y)
-              end
+          def self.y=(@@y)
+          end
 
-              def self.x
-                @@x
-              end
+          def self.x
+            @@x
+          end
 
-              def self.y
-                @@y
-              end
-            end
+          def self.y
+            @@y
+          end
+        end
 
-            LibMylib.foo(->(s) {
-              Global.x = s.x
-              Global.y = s.y
-              nil
-            })
+        LibMylib.foo(->(s) {
+          Global.x = s.x
+          Global.y = s.y
+          nil
+        })
 
-            Global.x &+ Global.y
-          ), &.to_i.should eq(3))
+        Global.x &+ Global.y
+        CRYSTAL
     end
 
     it "codegens proc that takes and returns an extern struct with C ABI" do
-      test_c(
-        %(
-            struct Struct {
-              int x;
-              int y;
-            };
+      test_c(<<-C, <<-CRYSTAL, &.to_i.should eq(303))
+        struct Struct {
+          int x;
+          int y;
+        };
 
-            struct Struct foo(struct Struct (*callback)(struct Struct)) {
-              struct Struct s;
-              s.x = 1;
-              s.y = 2;
-              return callback(s);
-            }
-          ),
-        %(
-            lib LibMylib
-              struct Struct
-                x : Int32
-                y : Int32
-              end
+        struct Struct foo(struct Struct (*callback)(struct Struct)) {
+          struct Struct s;
+          s.x = 1;
+          s.y = 2;
+          return callback(s);
+        }
+        C
+        lib LibMylib
+          struct Struct
+            x : Int32
+            y : Int32
+          end
 
-              alias Callback = Struct -> Struct
+          alias Callback = Struct -> Struct
 
-              fun foo(callback : Callback) : LibMylib::Struct
-            end
+          fun foo(callback : Callback) : LibMylib::Struct
+        end
 
-            class Global
-              @@x = 0
-              @@y = 0
+        class Global
+          @@x = 0
+          @@y = 0
 
-              def self.x=(@@x)
-              end
+          def self.x=(@@x)
+          end
 
-              def self.y=(@@y)
-              end
+          def self.y=(@@y)
+          end
 
-              def self.x
-                @@x
-              end
+          def self.x
+            @@x
+          end
 
-              def self.y
-                @@y
-              end
-            end
+          def self.y
+            @@y
+          end
+        end
 
-            s2 = LibMylib.foo(->(s) {
-              Global.x = s.x
-              Global.y = s.y
-              s.x = 100
-              s.y = 200
-              s
-            })
+        s2 = LibMylib.foo(->(s) {
+          Global.x = s.x
+          Global.y = s.y
+          s.x = 100
+          s.y = 200
+          s
+        })
 
-            Global.x &+ Global.y &+ s2.x &+ s2.y
-          ), &.to_i.should eq(303))
+        Global.x &+ Global.y &+ s2.x &+ s2.y
+        CRYSTAL
     end
 
     it "codegens proc that takes and returns an extern struct with C ABI" do
-      test_c(
-        %(
-            struct Struct {
-              int x;
-              int y;
-            };
+      test_c(<<-C, <<-CRYSTAL, &.to_i.should eq(30))
+        struct Struct {
+          int x;
+          int y;
+        };
 
-            struct Struct foo(struct Struct (*callback)(int, int)) {
-              return callback(10, 20);
-            }
-          ),
-        %(
-            lib LibMylib
-              struct Struct
-                x : Int32
-                y : Int32
-              end
+        struct Struct foo(struct Struct (*callback)(int, int)) {
+          return callback(10, 20);
+        }
+        C
+        lib LibMylib
+          struct Struct
+            x : Int32
+            y : Int32
+          end
 
-              alias Callback = Int32, Int32 -> Struct
+          alias Callback = Int32, Int32 -> Struct
 
-              fun foo(callback : Callback) : LibMylib::Struct
-            end
+          fun foo(callback : Callback) : LibMylib::Struct
+        end
 
-            s2 = LibMylib.foo(->(x, y) {
-              s = LibMylib::Struct.new
-              s.x = x
-              s.y = y
-              s
-            })
+        s2 = LibMylib.foo(->(x, y) {
+          s = LibMylib::Struct.new
+          s.x = x
+          s.y = y
+          s
+        })
 
-            s2.x &+ s2.y
-          ), &.to_i.should eq(30))
+        s2.x &+ s2.y
+        CRYSTAL
     end
 
     it "codegens proc that takes and returns an extern struct with sret" do
-      test_c(
-        %(
-            struct Struct {
-              long long x;
-              long long y;
-              long long z;
-            };
+      test_c(<<-C, <<-CRYSTAL, &.to_i.should eq(12))
+        struct Struct {
+          long long x;
+          long long y;
+          long long z;
+        };
 
-            struct Struct foo(struct Struct (*callback)(struct Struct)) {
-              struct Struct s;
-              s.x = 1;
-              s.y = 2;
-              s.z = 3;
-              return callback(s);
-            }
-          ),
-        %(
-            lib LibMylib
-              struct Struct
-                x : Int64
-                y : Int64
-                z : Int64
-              end
+        struct Struct foo(struct Struct (*callback)(struct Struct)) {
+          struct Struct s;
+          s.x = 1;
+          s.y = 2;
+          s.z = 3;
+          return callback(s);
+        }
+        C
+        lib LibMylib
+          struct Struct
+            x : Int64
+            y : Int64
+            z : Int64
+          end
 
-              alias Callback = Struct -> Struct
+          alias Callback = Struct -> Struct
 
-              fun foo(callback : Callback) : LibMylib::Struct
-            end
+          fun foo(callback : Callback) : LibMylib::Struct
+        end
 
-            class Global
-              @@x = 0
+        class Global
+          @@x = 0
 
-              def self.x=(@@x)
-              end
+          def self.x=(@@x)
+          end
 
-              def self.x
-                @@x
-              end
-            end
+          def self.x
+            @@x
+          end
+        end
 
-            s2 = LibMylib.foo(->(s) {
-              Global.x &+= s.x
-              Global.x &+= s.y
-              Global.x &+= s.z
-              s
-            })
+        s2 = LibMylib.foo(->(s) {
+          Global.x &+= s.x
+          Global.x &+= s.y
+          Global.x &+= s.z
+          s
+        })
 
-            Global.x &+= s2.x
-            Global.x &+= s2.y
-            Global.x &+= s2.z
-            Global.x.to_i32
-          ), &.to_i.should eq(12))
+        Global.x &+= s2.x
+        Global.x &+= s2.y
+        Global.x &+= s2.z
+        Global.x.to_i32
+        CRYSTAL
     end
 
     it "doesn't crash with proc with extern struct that's a closure" do

--- a/spec/compiler/codegen/lib_spec.cr
+++ b/spec/compiler/codegen/lib_spec.cr
@@ -100,26 +100,24 @@ describe "Code gen: lib" do
   end
 
   it "can use tuple as fun return" do
-    test_c(
-      %(
-        struct s {
-          int x;
-          int y;
-        };
+    test_c(<<-C, <<-CRYSTAL, &.to_i.should eq(3))
+      struct s {
+        int x;
+        int y;
+      };
 
-        struct s foo() {
-          struct s a = {1, 2};
-          return a;
-        }
-      ),
-      %(
-        lib LibFoo
-          fun foo : {Int32, Int32}
-        end
+      struct s foo() {
+        struct s a = {1, 2};
+        return a;
+      }
+      C
+      lib LibFoo
+        fun foo : {Int32, Int32}
+      end
 
-        tuple = LibFoo.foo
-        tuple[0] + tuple[1]
-      ), &.to_i.should eq(3))
+      tuple = LibFoo.foo
+      tuple[0] + tuple[1]
+      CRYSTAL
   end
 
   it "get fun field from struct (#672)" do

--- a/spec/compiler/codegen/pointer_spec.cr
+++ b/spec/compiler/codegen/pointer_spec.cr
@@ -497,28 +497,26 @@ describe "Code gen: pointer" do
   # LNK4217 linker warning)
   {% unless flag?(:win32) && flag?(:gnu) %}
     it "takes pointerof lib external var" do
-      test_c(
-        %(
-          int external_var = 0;
-        ),
-        %(
-          lib LibFoo
-            $external_var : Int32
-          end
+      test_c(<<-C, <<-CRYSTAL, &.to_i.should eq(111))
+        int external_var = 0;
+        C
+        lib LibFoo
+          $external_var : Int32
+        end
 
-          LibFoo.external_var = 1
+        LibFoo.external_var = 1
 
-          ptr = pointerof(LibFoo.external_var)
-          x = ptr.value
+        ptr = pointerof(LibFoo.external_var)
+        x = ptr.value
 
-          ptr.value = 10
-          y = ptr.value
+        ptr.value = 10
+        y = ptr.value
 
-          ptr.value = 100
-          z = LibFoo.external_var
+        ptr.value = 100
+        z = LibFoo.external_var
 
-          x + y + z
-        ), &.to_i.should eq(111))
+        x + y + z
+        CRYSTAL
     end
   {% end %}
 end

--- a/spec/compiler/codegen/primitives_spec.cr
+++ b/spec/compiler/codegen/primitives_spec.cr
@@ -283,30 +283,28 @@ describe "Code gen: primitives" do
       end
 
       it "works with C code" do
-        test_c(
-          %(
-            extern int foo_f(int,...);
-            int foo() {
-              return foo_f(3,1,2,3);
-            }
-          ),
-          %(
-            lib LibFoo
-              fun foo() : LibC::Int
-            end
+        test_c(<<-C, <<-CRYSTAL, &.to_i.should eq(6))
+          extern int foo_f(int,...);
+          int foo() {
+            return foo_f(3,1,2,3);
+          }
+          C
+          lib LibFoo
+            fun foo() : LibC::Int
+          end
 
-            fun foo_f(count : Int32, ...) : LibC::Int
-              sum = 0
-              VaList.open do |list|
-                count.times do |i|
-                  sum += list.next(Int32)
-                end
+          fun foo_f(count : Int32, ...) : LibC::Int
+            sum = 0
+            VaList.open do |list|
+              count.times do |i|
+                sum += list.next(Int32)
               end
-              sum
             end
+            sum
+          end
 
-            LibFoo.foo
-          ), &.to_i.should eq(6))
+          LibFoo.foo
+          CRYSTAL
       end
     {% end %}
   end

--- a/spec/spec_helper.cr
+++ b/spec/spec_helper.cr
@@ -343,11 +343,11 @@ end
 
 def test_c(c_code, crystal_code, *, file = __FILE__, &)
   with_temp_c_object_file(c_code, file: file) do |o_filename|
-    yield run(%(
-    require "prelude"
+    yield run(<<-CRYSTAL)
+      require "prelude"
 
-    @[Link(ldflags: #{o_filename.inspect})]
-    #{crystal_code}
-    ))
+      @[Link(ldflags: #{o_filename.inspect})]
+      #{crystal_code}
+      CRYSTAL
   end
 end


### PR DESCRIPTION
Resolves part of #11291. These specs are notable for featuring 2 heredocs per call (as do the AST normalization specs).