### PR TITLE
Support `ProcPointer`s of lib funs with parameter types

### DIFF
--- a/spec/compiler/codegen/proc_spec.cr
+++ b/spec/compiler/codegen/proc_spec.cr
@@ -607,6 +607,101 @@ describe "Code gen: proc" do
       ))
   end
 
+  it "gets proc to lib fun with parameter types" do
+    test_c(<<-C, <<-CRYSTAL, &.to_i.should eq(8))
+      #include <stdint.h>
+
+      int32_t foo(int32_t x, int32_t y) {
+        return x + y;
+      }
+      C
+      lib LibFoo
+        fun foo(x : Int32, y : Int32) : Int32
+      end
+
+      fn = ->LibFoo.foo(Int32, Int32)
+      fn.call(3, 5)
+      CRYSTAL
+  end
+
+  it "gets proc to lib fun with compatible parameter types" do
+    test_c(<<-C, <<-CRYSTAL, &.to_i.should eq(0x1235))
+      void *foo(void *x) {
+        return (void *)((char *)x + 1);
+      }
+      C
+      lib LibFoo
+        fun foo(x : Void*) : Void*
+      end
+
+      x = Pointer(UInt8).new(0x1234)
+      fn = ->LibFoo.foo(UInt8*)
+      fn.call(x).address
+      CRYSTAL
+  end
+
+  it "gets proc to lib fun with compatible `#to_unsafe` type" do
+    test_c(<<-C, <<-CRYSTAL, &.to_i.should eq(42))
+      #include <stdint.h>
+
+      int32_t foo(int32_t x) {
+        return x * 2;
+      }
+      C
+      lib LibFoo
+        fun foo(x : Int32) : Int32
+      end
+
+      class Foo
+        def to_unsafe
+          21
+        end
+      end
+
+      fn = ->LibFoo.foo(Foo)
+      fn.call(Foo.new)
+      CRYSTAL
+  end
+
+  it "gets proc to variadic lib fun with parameter types" do
+    test_c(<<-C, <<-CRYSTAL, &.to_i.should eq(1110))
+      #include <stdarg.h>
+      #include <stdint.h>
+
+      int32_t foo(int32_t n, ...) {
+        va_list args;
+        va_start(args, n);
+        int32_t sum = 0;
+        for (; n > 0; --n)
+          sum += va_arg(args, int32_t);
+        return sum;
+      }
+      C
+      lib LibFoo
+        fun foo(n : Int32, ...) : Int32
+      end
+
+      fn = ->LibFoo.foo(Int32, Int32, Int32, Int32)
+      fn.call(3, 10, 100, 1000)
+      CRYSTAL
+  end
+
+  it "gets same pointer from proc pointers to lib fun with compatible types" do
+    test_c(<<-C, <<-CRYSTAL, &.to_b.should be_true)
+      void foo(void *x) {
+      }
+      C
+      lib LibFoo
+        fun foo(x : Void*)
+      end
+
+      a = ->LibFoo.foo
+      b = ->LibFoo.foo(Void*)
+      c = ->LibFoo.foo(UInt8*)
+      a.pointer == b.pointer && a.pointer == c.pointer
+      CRYSTAL
+  end
+
   it "codegens proc to implicit self in constant (#647)" do
     run(%(
       require "prelude"

--- a/src/compiler/crystal/semantic/main_visitor.cr
+++ b/src/compiler/crystal/semantic/main_visitor.cr
@@ -1246,12 +1246,53 @@ module Crystal
       end
 
       # Check if it's ->LibFoo.foo, so we deduce the type from that method
-      if node.args.empty? && obj && (obj_type = obj.type).is_a?(LibType)
-        matching_fun = obj_type.lookup_first_def(node.name, false)
-        node.raise "undefined fun '#{node.name}' for #{obj_type}" unless matching_fun
+      if obj.type.is_a?(LibType)
+        matching_fun = obj.type.lookup_first_def(node.name, false).as(External?)
+        node.raise "undefined fun '#{node.name}' for #{obj.type}" unless matching_fun
 
-        call.args = matching_fun.args.map_with_index do |arg, i|
-          Var.new("arg#{i}", arg.type).as(ASTNode)
+        if node.args.empty?
+          call.args = matching_fun.args.map_with_index do |arg, i|
+            Var.new("arg#{i}", arg.type).as(ASTNode)
+          end
+        else
+          # Variadic funs are always expanded according to input types, due to
+          # different ABIs.
+          if matching_fun.varargs?
+            expand(node)
+            return false
+          end
+
+          # If it's something like `->LibFoo.foo(Bar)`, check that the supplied
+          # parameter types are compatible with the C fun.
+          # This is partially based on `Call#check_fun_arg_type_matches`
+          unless node.args.size == matching_fun.args.size
+            call.wrong_number_of_arguments "'#{call.full_name(obj.type)}'", node.args.size, matching_fun.args.size
+          end
+
+          if node.args.size == matching_fun.args.size
+            node.args.each_with_index do |node_arg, i|
+              node_arg.accept self
+              node_arg.type = node_arg_type = node_arg.type.instance_type
+              fun_arg_type = matching_fun.args[i].type
+              unless node_arg_type.compatible_with?(fun_arg_type) || node_arg_type.implicitly_converted_in_c_to?(fun_arg_type)
+                # Incompatible parameter type found; expand the pointer just
+                # like for non-lib types. This works for non-extern types as
+                # well; `->LibC.free(Bytes)` will compile, and
+                # `->LibC.getenv(Array(Int32))` will emit the same compiler
+                # error as a direct fun call.
+                expand(node)
+                return false
+              end
+            end
+          end
+
+          # If all parameter types are compatible, no proc literal is formed.
+          # This implies `->LibC.free` and `->LibC.free(Void*)` have exactly the
+          # same function pointer. So does `->LibC.free(UInt8*)`, although the
+          # proc type will be different here.
+          call.args = node.args.map_with_index do |arg, i|
+            Var.new("arg#{i}", arg.type).as(ASTNode)
+          end
         end
       else
         call.args = node.args.map_with_index do |arg, i|

--- a/src/compiler/crystal/semantic/main_visitor.cr
+++ b/src/compiler/crystal/semantic/main_visitor.cr
@@ -1269,20 +1269,18 @@ module Crystal
             call.wrong_number_of_arguments "'#{call.full_name(obj.type)}'", node.args.size, matching_fun.args.size
           end
 
-          if node.args.size == matching_fun.args.size
-            node.args.each_with_index do |node_arg, i|
-              node_arg.accept self
-              node_arg.type = node_arg_type = node_arg.type.instance_type
-              fun_arg_type = matching_fun.args[i].type
-              unless node_arg_type.compatible_with?(fun_arg_type) || node_arg_type.implicitly_converted_in_c_to?(fun_arg_type)
-                # Incompatible parameter type found; expand the pointer just
-                # like for non-lib types. This works for non-extern types as
-                # well; `->LibC.free(Bytes)` will compile, and
-                # `->LibC.getenv(Array(Int32))` will emit the same compiler
-                # error as a direct fun call.
-                expand(node)
-                return false
-              end
+          node.args.each_with_index do |node_arg, i|
+            node_arg.accept self
+            node_arg.type = node_arg_type = node_arg.type.instance_type
+            fun_arg_type = matching_fun.args[i].type
+            unless node_arg_type.compatible_with?(fun_arg_type) || node_arg_type.implicitly_converted_in_c_to?(fun_arg_type)
+              # Incompatible parameter type found; expand the pointer just
+              # like for non-lib types. This works for non-extern types as
+              # well; `->LibC.free(Bytes)` will compile, and
+              # `->LibC.getenv(Array(Int32))` will emit the same compiler
+              # error as a direct fun call.
+              expand(node)
+              return false
             end
           end
 


### PR DESCRIPTION
These `ProcPointer`s would previously emit a `read before assignment to local variable 'arg0'` compiler error (see for example https://github.com/crystal-lang/crystal/pull/12451/files/57c8abe4b33d8a13534f893c952af89a9a940bbc#r963766117); they now work like `ProcPointer`s to non-lib methods.

If all the parameter types are compatible, e.g. `->LibC.free(Void*)` or `->LibC.free(UInt8*)`, then the returned `Proc` will have the same function pointer as a `ProcPointer` without the parameter types supplied. Otherwise, an internal non-closure `ProcLiteral` is generated; non-extern parameter types are also allowed here as long as they have a suitable `#to_unsafe` method, e.g. `->LibC.free(Bytes)`.