### PR TITLE
Docs' 404 base href

### DIFF
--- a/bin/ci
+++ b/bin/ci
@@ -120,7 +120,7 @@ build() {
       with_build_env 'make docs threads=1'
       ;;
     *)
-      with_build_env 'make crystal primitives_spec std_spec compiler_spec docs threads=1 junit_output=.junit/spec.xml DOCS_OPTIONS="--json-config-url=/api/versions.json --canonical-base-url=https://crystal-lang.org/api/latest/"'
+      with_build_env 'make crystal primitives_spec std_spec compiler_spec docs threads=1 junit_output=.junit/spec.xml DOCS_OPTIONS="--json-config-url=/api/versions.json --canonical-base-url=https://crystal-lang.org/api/latest/ --404-base-href=/api/"'
       ;;
   esac
 

--- a/src/compiler/crystal/command/docs.cr
+++ b/src/compiler/crystal/command/docs.cr
@@ -60,6 +60,10 @@ class Crystal::Command
         project_info.canonical_base_url = value
       end
 
+      opts.on("--404-base-href=PATH", %(Set the base href tag on the 404 page - needed for finding assets)) do |value|
+        project_info.page_404_base_href = value
+      end
+
       opts.on("--sitemap-base-url=URL", "-b URL", "Set the sitemap base URL and generates sitemap") do |value|
         sitemap_base_url = value
       end

--- a/src/compiler/crystal/tools/doc/generator.cr
+++ b/src/compiler/crystal/tools/doc/generator.cr
@@ -85,13 +85,13 @@ class Crystal::Doc::Generator
     raw_body = read_readme
     body = doc(program_type, raw_body)
 
-    File.write File.join(@output_dir, "index.html"), MainTemplate.new(body, types, project_info)
+    File.write File.join(@output_dir, "index.html"), MainTemplate.new(body, types, project_info, nil)
 
     main_index = Main.new(raw_body, Type.new(self, @program), project_info)
     File.write File.join(@output_dir, "index.json"), main_index
     File.write File.join(@output_dir, "search-index.js"), main_index.to_jsonp
 
-    File.write File.join(@output_dir, "404.html"), MainTemplate.new(Error404Template.new.to_s, types, project_info)
+    File.write File.join(@output_dir, "404.html"), MainTemplate.new(Error404Template.new.to_s, types, project_info, :page_404)
   end
 
   def generate_sitemap(types)

--- a/src/compiler/crystal/tools/doc/html/main.html
+++ b/src/compiler/crystal/tools/doc/html/main.html
@@ -1,6 +1,9 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
+  <% if page_type == :page_404 && base_href = project_info.page_404_base_href %>
+    <base href="<%= base_href %>" />
+  <% end %>
   <%= HeadTemplate.new(project_info, nil) %>
   <meta name="repository-name" content="<%= project_info.name %>">
   <title><%= project_info.name %> <%= project_info.version %></title>

--- a/src/compiler/crystal/tools/doc/project_info.cr
+++ b/src/compiler/crystal/tools/doc/project_info.cr
@@ -6,6 +6,7 @@ module Crystal::Doc
     property refname : String? = nil
     property source_url_pattern : String? = nil
     property canonical_base_url : String? = nil
+    property page_404_base_href : String? = nil
 
     def initialize(@name : String? = nil, @version : String? = nil, @refname : String? = nil, @source_url_pattern : String? = nil)
     end

--- a/src/compiler/crystal/tools/doc/templates.cr
+++ b/src/compiler/crystal/tools/doc/templates.cr
@@ -57,7 +57,7 @@ module Crystal::Doc
     ECR.def_to_s "#{__DIR__}/html/_other_types.html"
   end
 
-  record MainTemplate, body : String, types : Array(Type), project_info : ProjectInfo do
+  record MainTemplate, body : String, types : Array(Type), project_info : ProjectInfo, page_type : Symbol? do
     ECR.def_to_s "#{__DIR__}/html/main.html"
   end
 


### PR DESCRIPTION
Since the 404 page of the docs is served at different (sub)paths in a website, relative references to assets (CSS and JS files) don't work for subdirectories.

We now add a `--404-base-href` flag to the docs generator to explicitly set that path.

Adding that `<base href />` tag in other pages makes anchor links (`#links`) relative to that path, so that would break every other page (a `<base href="/docs" />` tag makes an `<a href="#heading">link</a>` of https://example.com/docs/something.html point to https://example.com/docs/#heading - changing the current page).