### PR TITLE
Fix return type of `system_close_on_exec=` on Windows [fixup #15698]

### DIFF
--- a/src/crystal/system/win32/file_descriptor.cr
+++ b/src/crystal/system/win32/file_descriptor.cr
@@ -132,6 +132,7 @@ module Crystal::System::FileDescriptor
 
   private def system_close_on_exec=(close_on_exec)
     raise NotImplementedError.new("Crystal::System::FileDescriptor#system_close_on_exec=") if close_on_exec
+    false
   end
 
   private def system_closed? : Bool


### PR DESCRIPTION
`#system_close_on_exec=` (and thus `#close_on_exec=`) returns `Nil` on Windows. But #15698 added a type-restriction to `Bool`. We didn't notice this discrepancy before, because this method was never called on Windows until we enabled the specs for that in #14716.

Changing the return value to `false` on Windows should be the correct behaviour. If the parameter is `true`, the method raises.

This is a classic integration issue. It could've been avoided by testing each change against current master directly before merging it. But luckily they are pretty rare, so there's no urgent need to do something about it.