### PR TITLE
Embed libxml2 version number on Windows MSVC

### DIFF
--- a/.github/workflows/win.yml
+++ b/.github/workflows/win.yml
@@ -42,6 +42,7 @@ jobs:
             libs/mpir.lib
             libs/yaml.lib
             libs/xml2.lib
+            libs/libxml_VERSION
           key: win-libs-${{ hashFiles('.github/workflows/win.yml', 'etc/win-ci/*.ps1') }}-msvc
       - name: Set up Cygwin
         if: steps.cache-libs.outputs.cache-hit != 'true'

--- a/.github/workflows/win_build_portable.yml
+++ b/.github/workflows/win_build_portable.yml
@@ -51,6 +51,7 @@ jobs:
             libs/mpir.lib
             libs/yaml.lib
             libs/xml2.lib
+            libs/libxml_VERSION
           key: win-libs-${{ hashFiles('.github/workflows/win.yml', 'etc/win-ci/*.ps1') }}-msvc
           fail-on-cache-miss: true
       - name: Restore OpenSSL

--- a/etc/win-ci/build-xml2.ps1
+++ b/etc/win-ci/build-xml2.ps1
@@ -30,3 +30,4 @@ if ($Dynamic) {
 } else {
     mv -Force $BuildTree\Release\libxml2s.lib libs\xml2.lib
 }
+[IO.File]::WriteAllLines("libs\libxml_VERSION", $Version)

--- a/src/xml/libxml2.cr
+++ b/src/xml/libxml2.cr
@@ -21,12 +21,20 @@ lib LibXML
   # assume at least this version is available everywhere.
 
   {% if (version = env("LIBXML_VERSION")) && (version.strip != "") %}
-     VERSION = {{env("LIBXML_VERSION")}}
-   {% elsif !flag?(:win32) || flag?(:gnu) %}
-     VERSION = {{`sh -c "pkg-config libxml-2.0 --silence-errors --modversion 2> /dev/null || echo 2.9.0"`.strip.stringify}}
-   {% else %}
-    # TODO: figure out the actual libxml version on *-windows-msvc target
-    VERSION = "2.9.0"
+    VERSION = {{env("LIBXML_VERSION")}}
+  {% elsif flag?(:msvc) %}
+    {% version = nil %}
+    {% for dir in Crystal::LIBRARY_PATH.split(Crystal::System::Process::HOST_PATH_DELIMITER) %}
+      {% unless version %}
+        {% config_path = "#{dir.id}\\libxml_VERSION" %}
+        {% if config_version = read_file?(config_path) %}
+          {% version = config_version.chomp %}
+        {% end %}
+      {% end %}
+    {% end %}
+    VERSION = {{ version || "2.9.0" }}
+  {% else %}
+    VERSION = {{`sh -c "pkg-config libxml-2.0 --silence-errors --modversion 2> /dev/null || echo 2.9.0"`.strip.stringify}}
   {% end %}
 
   alias Int = LibC::Int


### PR DESCRIPTION
`LibXML` needs this information at build time (see #16103 for example)