### PR TITLE
Reorder implementation of `HTTP::Cookies#<<` and `[]=`

### DIFF
--- a/src/http/cookies.cr
+++ b/src/http/cookies.cr
@@ -78,7 +78,7 @@ module HTTP
     # request.cookies["foo"] = "bar"
     # ```
     def []=(key, value : String)
-      self[key] = Cookie.new(key, value)
+      self << Cookie.new(key, value)
     end
 
     # Sets a new cookie in the collection to the given `HTTP::Cookie`
@@ -96,7 +96,7 @@ module HTTP
         raise ArgumentError.new("Cookie name must match the given key")
       end
 
-      @cookies[key] = value
+      self << value
     end
 
     # Gets the current `HTTP::Cookie` for the given *key*.
@@ -138,7 +138,7 @@ module HTTP
     # response.cookies << HTTP::Cookie.new("foo", "bar", http_only: true)
     # ```
     def <<(cookie : Cookie)
-      self[cookie.name] = cookie
+      @cookies[cookie.name] = cookie
     end
 
     # Clears the collection, removing all cookies.


### PR DESCRIPTION
`HTTP::Cookies#[]=(key, value : Cookie)` is an odd method because `key` is redundant. It must be equal to `value.name`. This method makes sure of that.
But there's no need to call this method from `#<<` and `#[]=(key, value : String)`. The extra comparison is unnecessary there.

We should probably also deprecate `HTTP::Cookies#[]=(key, value : Cookie)`, but that would be a separate change. This refactor enables that by removing dependencies.