### PR TITLE
Expand empty `(Named)TupleLiteral` to `(Named)Tuple.new` instead of `{}`

### DIFF
--- a/spec/compiler/macro/macro_expander_spec.cr
+++ b/spec/compiler/macro/macro_expander_spec.cr
@@ -67,6 +67,10 @@ describe "MacroExpander" do
     assert_macro %({{{1, 2, 3}}}), %({1, 2, 3})
   end
 
+  it "expand macro with empty tuple" do
+    assert_macro "{{x}}", "Tuple.new", {x: TupleLiteral.new([] of ASTNode)}
+  end
+
   it "expands macro with range" do
     assert_macro %({{1..3}}), %(1..3)
   end

--- a/spec/compiler/macro/macro_expander_spec.cr
+++ b/spec/compiler/macro/macro_expander_spec.cr
@@ -68,11 +68,11 @@ describe "MacroExpander" do
   end
 
   it "expands macro with empty tuple" do
-    assert_macro "{{x}}", "Tuple.new", {x: TupleLiteral.new([] of ASTNode)}
+    assert_macro "{{x}}", "::Tuple.new", {x: TupleLiteral.new([] of ASTNode)}
   end
 
   it "expands macro with empty named tuple" do
-    assert_macro "{{x}}", "NamedTuple.new", {x: NamedTupleLiteral.new([] of NamedTupleLiteral::Entry)}
+    assert_macro "{{x}}", "::NamedTuple.new", {x: NamedTupleLiteral.new([] of NamedTupleLiteral::Entry)}
   end
 
   it "expands macro with range" do

--- a/spec/compiler/macro/macro_expander_spec.cr
+++ b/spec/compiler/macro/macro_expander_spec.cr
@@ -67,8 +67,12 @@ describe "MacroExpander" do
     assert_macro %({{{1, 2, 3}}}), %({1, 2, 3})
   end
 
-  it "expand macro with empty tuple" do
+  it "expands macro with empty tuple" do
     assert_macro "{{x}}", "Tuple.new", {x: TupleLiteral.new([] of ASTNode)}
+  end
+
+  it "expands macro with empty named tuple" do
+    assert_macro "{{x}}", "NamedTuple.new", {x: NamedTupleLiteral.new([] of NamedTupleLiteral::Entry)}
   end
 
   it "expands macro with range" do

--- a/spec/compiler/normalize/def_spec.cr
+++ b/spec/compiler/normalize/def_spec.cr
@@ -70,13 +70,13 @@ module Crystal
     it "expands with splat and zero" do
       a_def = parse("def foo(*args); args; end").as(Def)
       actual = a_def.expand_default_arguments(Program.new, 0)
-      actual.to_s.should eq("def foo\n  args = {}\n  args\nend")
+      actual.to_s.should eq("def foo\n  args = Tuple.new\n  args\nend")
     end
 
     it "expands with splat and default argument" do
       a_def = parse("def foo(x = 1, *args); args; end").as(Def)
       actual = a_def.expand_default_arguments(Program.new, 0)
-      actual.to_s.should eq("def foo\n  x = 1\n  args = {}\n  args\nend")
+      actual.to_s.should eq("def foo\n  x = 1\n  args = Tuple.new\n  args\nend")
     end
 
     it "expands with named argument" do
@@ -155,7 +155,7 @@ module Crystal
     it "expands a def with double splat and no args" do
       a_def = parse("def foo(**options); options; end").as(Def)
       other_def = a_def.expand_default_arguments(Program.new, 0)
-      other_def.to_s.should eq("def foo\n  options = {}\n  options\nend")
+      other_def.to_s.should eq("def foo\n  options = NamedTuple.new\n  options\nend")
     end
 
     it "expands a def with double splat and two named args" do
@@ -179,7 +179,7 @@ module Crystal
     it "expands arg with default value after splat" do
       a_def = parse("def foo(*args, x = 10); args + x; end").as(Def)
       other_def = a_def.expand_default_arguments(Program.new, 0)
-      other_def.to_s.should eq("def foo\n  x = 10\n  args = {}\n  args + x\nend")
+      other_def.to_s.should eq("def foo\n  x = 10\n  args = Tuple.new\n  args + x\nend")
     end
 
     it "expands default value after splat index" do
@@ -229,7 +229,7 @@ module Crystal
     it "expands def with reserved external name (#6559)" do
       a_def = parse("def foo(abstract __arg0, **options); @abstract = __arg0; end").as(Def)
       other_def = a_def.expand_default_arguments(Program.new, 0, ["abstract"])
-      other_def.to_s.should eq("def foo:abstract(abstract __arg0)\n  options = {}\n  @abstract = __arg0\nend")
+      other_def.to_s.should eq("def foo:abstract(abstract __arg0)\n  options = NamedTuple.new\n  @abstract = __arg0\nend")
     end
 
     describe "gives correct body location with" do

--- a/spec/compiler/normalize/def_spec.cr
+++ b/spec/compiler/normalize/def_spec.cr
@@ -70,13 +70,13 @@ module Crystal
     it "expands with splat and zero" do
       a_def = parse("def foo(*args); args; end").as(Def)
       actual = a_def.expand_default_arguments(Program.new, 0)
-      actual.to_s.should eq("def foo\n  args = Tuple.new\n  args\nend")
+      actual.to_s.should eq("def foo\n  args = ::Tuple.new\n  args\nend")
     end
 
     it "expands with splat and default argument" do
       a_def = parse("def foo(x = 1, *args); args; end").as(Def)
       actual = a_def.expand_default_arguments(Program.new, 0)
-      actual.to_s.should eq("def foo\n  x = 1\n  args = Tuple.new\n  args\nend")
+      actual.to_s.should eq("def foo\n  x = 1\n  args = ::Tuple.new\n  args\nend")
     end
 
     it "expands with named argument" do
@@ -155,7 +155,7 @@ module Crystal
     it "expands a def with double splat and no args" do
       a_def = parse("def foo(**options); options; end").as(Def)
       other_def = a_def.expand_default_arguments(Program.new, 0)
-      other_def.to_s.should eq("def foo\n  options = NamedTuple.new\n  options\nend")
+      other_def.to_s.should eq("def foo\n  options = ::NamedTuple.new\n  options\nend")
     end
 
     it "expands a def with double splat and two named args" do
@@ -179,7 +179,7 @@ module Crystal
     it "expands arg with default value after splat" do
       a_def = parse("def foo(*args, x = 10); args + x; end").as(Def)
       other_def = a_def.expand_default_arguments(Program.new, 0)
-      other_def.to_s.should eq("def foo\n  x = 10\n  args = Tuple.new\n  args + x\nend")
+      other_def.to_s.should eq("def foo\n  x = 10\n  args = ::Tuple.new\n  args + x\nend")
     end
 
     it "expands default value after splat index" do
@@ -229,7 +229,7 @@ module Crystal
     it "expands def with reserved external name (#6559)" do
       a_def = parse("def foo(abstract __arg0, **options); @abstract = __arg0; end").as(Def)
       other_def = a_def.expand_default_arguments(Program.new, 0, ["abstract"])
-      other_def.to_s.should eq("def foo:abstract(abstract __arg0)\n  options = NamedTuple.new\n  @abstract = __arg0\nend")
+      other_def.to_s.should eq("def foo:abstract(abstract __arg0)\n  options = ::NamedTuple.new\n  @abstract = __arg0\nend")
     end
 
     describe "gives correct body location with" do

--- a/src/compiler/crystal/syntax/to_s.cr
+++ b/src/compiler/crystal/syntax/to_s.cr
@@ -203,13 +203,13 @@ module Crystal
     end
 
     def visit(node : NamedTupleLiteral)
-      @str << '{'
-
       # short-circuit to handle empty named tuple context
       if node.entries.empty?
-        @str << '}'
+        @str << "NamedTuple.new"
         return false
       end
+
+      @str << '{'
 
       # A node starts multiline when its starting brace is on a different line than the staring line of it's first entry
       start_multiline = (start_loc = node.location) && (first_entry_loc = node.entries.first?.try &.value.location) && first_entry_loc.line_number > start_loc.line_number
@@ -1241,9 +1241,13 @@ module Crystal
     end
 
     def visit(node : TupleLiteral)
+      unless first = node.elements.first?
+        @str << "Tuple.new"
+        return false
+      end
+
       @str << '{'
 
-      first = node.elements.first?
       space = first.is_a?(TupleLiteral) || first.is_a?(NamedTupleLiteral) || first.is_a?(HashLiteral)
       @str << ' ' if space
       node.elements.join(@str, ", ", &.accept self)

--- a/src/compiler/crystal/syntax/to_s.cr
+++ b/src/compiler/crystal/syntax/to_s.cr
@@ -1241,7 +1241,8 @@ module Crystal
     end
 
     def visit(node : TupleLiteral)
-      unless first = node.elements.first?
+      first = node.elements.first?
+      unless first
         @str << "Tuple.new"
         return false
       end

--- a/src/compiler/crystal/syntax/to_s.cr
+++ b/src/compiler/crystal/syntax/to_s.cr
@@ -205,7 +205,7 @@ module Crystal
     def visit(node : NamedTupleLiteral)
       # short-circuit to handle empty named tuple context
       if node.entries.empty?
-        @str << "NamedTuple.new"
+        @str << "::NamedTuple.new"
         return false
       end
 
@@ -1243,7 +1243,7 @@ module Crystal
     def visit(node : TupleLiteral)
       first = node.elements.first?
       unless first
-        @str << "Tuple.new"
+        @str << "::Tuple.new"
         return false
       end
 


### PR DESCRIPTION
Fixes [crystal/crystal-lang#16105](https://github.com/crystal-lang/crystal/issues/16105)

(But not https://github.com/crystal-lang/crystal/issues/16105#issuecomment-3209851088)