### PR TITLE
Add specs for `x.[](y)` syntax

### DIFF
--- a/spec/compiler/formatter/formatter_spec.cr
+++ b/spec/compiler/formatter/formatter_spec.cr
@@ -1084,6 +1084,12 @@ describe Crystal::Formatter do
   assert_format "foo.[] =1", "foo.[] = 1"
   assert_format "foo.[ 1 , 2 ]   =3", "foo.[1, 2] = 3"
 
+  assert_format "foo.[]()", "foo.[]"
+  assert_format "foo.[]( 1 , 2 )", "foo.[](1, 2)"
+  assert_format "foo.[]?( 1,  2 )", "foo.[]?(1, 2)"
+  assert_format "foo.[] =(1)", "foo.[] = (1)"
+  assert_format "foo.[]=( 1 , 2 , 3 )", "foo.[]=(1, 2, 3)"
+
   assert_format "1  ||  2", "1 || 2"
   assert_format "a  ||  b", "a || b"
   assert_format "1  &&  2", "1 && 2"


### PR DESCRIPTION
These are some spec additions I had lying around in a branch for a while. This syntax is untested in the formatter, so we should add it.