### PR TITLE
Fix `@[Primitive]` codegen for typedefs

### DIFF
--- a/spec/compiler/codegen/primitives_spec.cr
+++ b/spec/compiler/codegen/primitives_spec.cr
@@ -207,6 +207,56 @@ describe "Code gen: primitives" do
       CRYSTAL
   end
 
+  it "can invoke binary on primitive typedef (2) (#16097)" do
+    codegen(<<-CRYSTAL)
+      lib Test
+        type K = Int32
+        fun foo : K
+      end
+
+      Test.foo == Test.foo
+      CRYSTAL
+  end
+
+  it "can invoke pointer primitives on typedef" do
+    codegen(<<-CRYSTAL)
+      lib Test
+        type K = Void*
+        fun foo : K
+      end
+
+      Test.foo + 1
+      Test.foo - Test.foo
+      Test.foo.realloc(1)
+      CRYSTAL
+  end
+
+  it "can invoke struct setter on primitive typedef" do
+    codegen(<<-CRYSTAL)
+      lib Test
+        struct Foo
+          x : Int32
+        end
+
+        type K = Foo
+        fun foo : K
+      end
+
+      Test.foo.x = 1
+      CRYSTAL
+  end
+
+  it "can invoke proc call on primitive typedef" do
+    codegen(<<-CRYSTAL)
+      lib Test
+        type K = ->
+        fun foo : K
+      end
+
+      Test.foo.call
+      CRYSTAL
+  end
+
   it "allows redefining a primitive method" do
     run(<<-CRYSTAL).to_i.should eq(42)
       struct Int32

--- a/spec/compiler/codegen/primitives_spec.cr
+++ b/spec/compiler/codegen/primitives_spec.cr
@@ -246,7 +246,7 @@ describe "Code gen: primitives" do
       CRYSTAL
   end
 
-  it "can invoke proc call on primitive typedef" do
+  pending "can invoke proc call on primitive typedef" do
     codegen(<<-CRYSTAL)
       lib Test
         type K = ->

--- a/src/compiler/crystal/codegen/llvm_builder_helper.cr
+++ b/src/compiler/crystal/codegen/llvm_builder_helper.cr
@@ -217,7 +217,7 @@ module Crystal
     end
 
     def cast_to_pointer(value : LLVM::ValueMethods, type : Type)
-      pointer_cast value, llvm_type(type).pointer
+      pointer_cast value, llvm_type(@program.pointer_of(type))
     end
 
     def cast_to_void_pointer(pointer : LLVM::ValueMethods)

--- a/src/compiler/crystal/semantic/main_visitor.cr
+++ b/src/compiler/crystal/semantic/main_visitor.cr
@@ -2600,7 +2600,7 @@ module Crystal
     end
 
     def visit_struct_or_union_set(node)
-      scope = @scope.as(NonGenericClassType)
+      scope = self.scope.remove_typedef.as(NonGenericClassType)
 
       field_name = call.not_nil!.name.rchop
       expected_type = scope.instance_vars['@' + field_name].type


### PR DESCRIPTION
Fixes #16097.

These include typedef receivers in `Pointer#+`, `Pointer#-`, `Pointer#realloc`, ~~`Proc#call`,~~ and all lib struct or union setters, as well as typedef arguments in all `@[Primitive(:binary)]` methods (e.g. `#&+` and `#==`).

This does not affect the interpreter (see #14151).