### PR TITLE
Resolve types when guessing return type from class method overloads

### DIFF
--- a/spec/compiler/semantic/instance_var_spec.cr
+++ b/spec/compiler/semantic/instance_var_spec.cr
@@ -3425,6 +3425,36 @@ describe "Semantic: instance var" do
       CRYSTAL
   end
 
+  it "infers from multiple class method overloads with same type but different spellings" do
+    assert_type(<<-CRYSTAL) { types["Bar"] }
+      class Bar
+        def self.bar(x : Int32) : Bar
+          Bar.new
+        end
+
+        def self.bar(x : Float64) : ::Bar
+          Bar.new
+        end
+
+        def self.bar(x : String) : self
+          Bar.new
+        end
+      end
+
+      class Foo
+        def initialize(x)
+          @bar = Bar.bar(x)
+        end
+
+        def bar
+          @bar
+        end
+      end
+
+      Foo.new(1).bar
+      CRYSTAL
+  end
+
   it "infers from new with return type" do
     assert_type(<<-CRYSTAL) { int32 }
       class Foo

--- a/src/compiler/crystal/semantic/type_guess_visitor.cr
+++ b/src/compiler/crystal/semantic/type_guess_visitor.cr
@@ -788,10 +788,10 @@ module Crystal
         # We can only infer the type if all overloads return
         # the same type (because we can't know the call
         # argument's type)
-        return_types = defs.map(&.return_type.not_nil!).uniq!
+        return_types = defs.map { |a_def| lookup_type?(a_def.return_type.not_nil!, obj_type) || return nil }.uniq!
         return unless return_types.size == 1
 
-        return lookup_type?(return_types[0], obj_type)
+        return return_types[0]
       end
 
       # If we only have one def, check the body, we might be


### PR DESCRIPTION
In the following snippet, the compiler is able to infer `@foo`'s type to be `Foo`, since both overloads of `Foo.foo` have a return type of `Foo`:

```crystal
class Foo
  def self.foo(x : Int32) : Foo
    new
  end

  def self.foo(x : String) : Foo
    new
  end
end

class Bar
  def initialize
    @foo = Foo.foo(1)
  end
end

Bar.new
```

Changing either return type to `::Foo` or `self` breaks the type guesser, because currently all the type names are required to be identical in spelling. Those names are now resolved so that different spellings can be used (an example in the standard library is `Log::Metadata.build`, whose overloads return `Metadata` and `self` respectively).