### PR TITLE
Guess instance variable types from global method calls

### DIFF
--- a/spec/compiler/semantic/instance_var_spec.cr
+++ b/spec/compiler/semantic/instance_var_spec.cr
@@ -3277,6 +3277,52 @@ describe "Semantic: instance var" do
       CRYSTAL
   end
 
+  it "infers from top-level method that has type annotation" do
+    assert_type(<<-CRYSTAL) { types["Bar"] }
+      class Bar
+      end
+
+      def bar : Bar
+        Bar.new
+      end
+
+      class Foo
+        def initialize
+          @bar = ::bar
+        end
+
+        def bar
+          @bar
+        end
+      end
+
+      Foo.new.bar
+      CRYSTAL
+  end
+
+  it "infers from simple top-level method without type annotation" do
+    assert_type(<<-CRYSTAL) { types["Bar"] }
+      class Bar
+      end
+
+      def bar
+        Bar.new
+      end
+
+      class Foo
+        def initialize
+          @bar = ::bar
+        end
+
+        def bar
+          @bar
+        end
+      end
+
+      Foo.new.bar
+      CRYSTAL
+  end
+
   it "infers from class method that has type annotation" do
     assert_type(<<-CRYSTAL) { types["Bar"] }
       class Bar

--- a/src/compiler/crystal/semantic/type_guess_visitor.cr
+++ b/src/compiler/crystal/semantic/type_guess_visitor.cr
@@ -735,6 +735,10 @@ module Crystal
     # method solves to a method with a type annotation
     # (use the type annotation)
     def guess_type_call_with_type_annotation(node : Call)
+      if node.global?
+        return guess_type_from_class_method(@program, node)
+      end
+
       obj = node.obj
       return nil unless obj
 


### PR DESCRIPTION
This allows the following to compile:

```crystal
def foo(x : Int32) : Float64
  # ...
end

class Bar
  def initialize
    @foo = ::foo(1) # okay, `@foo` has the type `Float64`
  end
end
```

The call needs to be global; other than that, type guessing for top-level methods has the same limitations as for class methods.

Perhaps this would also apply to non-global calls as long as `Bar` and its ancestors do not define `#foo`?