### PR TITLE
Add `Time::Location.load?`

### DIFF
--- a/spec/std/time/location_spec.cr
+++ b/spec/std/time/location_spec.cr
@@ -198,6 +198,67 @@ class Time::Location
       end
     end
 
+    describe ".load?" do
+      it "loads Europe/Berlin" do
+        with_zoneinfo do
+          Time::Location.load?("Europe/Berlin").should eq Time::Location.load("Europe/Berlin")
+        end
+      end
+
+      it "returns nil if unavailable" do
+        Location.load?("Foobar/Baz").should be_nil
+
+        with_zoneinfo(datapath("zoneinfo")) do
+          Location.load?("Foobar/Baz").should be_nil
+        end
+      end
+
+      it "invalid zone file" do
+        expect_raises(Time::Location::InvalidTZDataError) do
+          Location.load?("Foo/invalid", [datapath("zoneinfo")])
+        end
+      end
+
+      it "treats UTC as special case" do
+        with_zoneinfo do
+          Location.load?("UTC").should eq Location::UTC
+          Location.load?("").should eq Location::UTC
+          Location.load?("Etc/UTC").should eq Location::UTC
+        end
+      end
+
+      describe "raises on invalid location name" do
+        it "absolute path" do
+          with_zoneinfo do
+            expect_raises(InvalidLocationNameError) do
+              Location.load?("/America/New_York")
+            end
+            expect_raises(InvalidLocationNameError) do
+              Location.load?("\\Zulu")
+            end
+          end
+        end
+
+        it "dot dot" do
+          with_zoneinfo do
+            expect_raises(InvalidLocationNameError) do
+              Location.load?("../zoneinfo/America/New_York")
+            end
+            expect_raises(InvalidLocationNameError) do
+              Location.load?("a..")
+            end
+          end
+        end
+      end
+
+      it "caches result" do
+        with_zoneinfo do
+          location = Location.load?("Europe/Berlin")
+          Location.load?("Europe/Berlin").should be location
+        end
+      end
+    end
+
     describe ".load_android" do
       it "loads Europe/Berlin" do
         Location.__clear_location_cache

--- a/src/time/location/loader.cr
+++ b/src/time/location/loader.cr
@@ -20,15 +20,25 @@ class Time::Location
 
   # :nodoc:
   def self.load(name : String, sources : Enumerable(String)) : Time::Location?
+    load(name, sources) { |source| raise InvalidLocationNameError.new(name, source) }
+  end
+
+  # :nodoc:
+  def self.load(name : String, sources : Enumerable(String), &) : Time::Location?
     if source = find_zoneinfo_file(name, sources)
-      load_from_dir_or_zip(name, source) || raise InvalidLocationNameError.new(name, source)
+      load_from_dir_or_zip(name, source) || yield source
     end
   end
 
   # :nodoc:
   def self.load_android(name : String, sources : Enumerable(String)) : Time::Location?
+    load_android(name, sources) { |path| raise InvalidLocationNameError.new(name, path) }
+  end
+
+  # :nodoc:
+  def self.load_android(name : String, sources : Enumerable(String), &) : Time::Location?
     if path = find_android_tzdata_file(sources)
-      load_from_android_tzdata(name, path) || raise InvalidLocationNameError.new(name, path)
+      load_from_android_tzdata(name, path) || yield path
     end
   end
 


### PR DESCRIPTION
This is a convenience method that returns `nil` if a location name doesn't exist.
This makes it possible to implement a fallback without a raise/rescue trip: `Time::Location.load?("Asia/Jerusalem") || Time::Location.load?("Asia/Tel_Aviv")`.