### PR TITLE
Group temporary variables by file name: compound array assignments

### DIFF
--- a/spec/compiler/normalize/op_assign_spec.cr
+++ b/spec/compiler/normalize/op_assign_spec.cr
@@ -89,10 +89,17 @@ describe "Normalize: op assign" do
 
   it "normalizes with filename" do
     assert_normalize "a[b, c] += 1", <<-CRYSTAL, filename: "foo.cr"
-      #{__temp_foo_cr_(1)} = b
-      #{__temp_foo_cr_(2)} = c
-      #{__temp_foo_cr_(3)} = a
-      #{__temp_foo_cr_(3)}[#{__temp_foo_cr_(1)}, #{__temp_foo_cr_(2)}] = #{__temp_foo_cr_(3)}[#{__temp_foo_cr_(1)}, #{__temp_foo_cr_(2)}] + 1
+      __temp_cd6ae5dd_1 = b
+      __temp_cd6ae5dd_2 = c
+      __temp_cd6ae5dd_3 = a
+      __temp_cd6ae5dd_3[__temp_cd6ae5dd_1, __temp_cd6ae5dd_2] = __temp_cd6ae5dd_3[__temp_cd6ae5dd_1, __temp_cd6ae5dd_2] + 1
+      CRYSTAL
+
+    assert_normalize "a[b, c] += 1", <<-CRYSTAL, filename: "bar.cr"
+      __temp_fbcf3d84_1 = b
+      __temp_fbcf3d84_2 = c
+      __temp_fbcf3d84_3 = a
+      __temp_fbcf3d84_3[__temp_fbcf3d84_1, __temp_fbcf3d84_2] = __temp_fbcf3d84_3[__temp_fbcf3d84_1, __temp_fbcf3d84_2] + 1
       CRYSTAL
   end
 end

--- a/spec/compiler/normalize/op_assign_spec.cr
+++ b/spec/compiler/normalize/op_assign_spec.cr
@@ -86,6 +86,15 @@ describe "Normalize: op assign" do
     assert_name_location node.as(Call).args[1],
       1, 8
   end
+
+  it "normalizes with filename" do
+    assert_normalize "a[b, c] += 1", <<-CRYSTAL, filename: "foo.cr"
+      #{__temp_foo_cr_(1)} = b
+      #{__temp_foo_cr_(2)} = c
+      #{__temp_foo_cr_(3)} = a
+      #{__temp_foo_cr_(3)}[#{__temp_foo_cr_(1)}, #{__temp_foo_cr_(2)}] = #{__temp_foo_cr_(3)}[#{__temp_foo_cr_(1)}, #{__temp_foo_cr_(2)}] + 1
+      CRYSTAL
+  end
 end
 
 private def assert_name_location(node, line_number, column_number, spec_file = __FILE__, spec_line = __LINE__)

--- a/spec/spec_helper.cr
+++ b/spec/spec_helper.cr
@@ -10,13 +10,6 @@ require "./support/tempfile"
 require "./support/win32"
 require "./support/wasm32"
 
-FOO_CR_MD5 = Crystal::Digest::MD5.hexdigest("foo.cr")[0, 8]
-
-# used by normalization specs, trailing underscore is intentional
-def __temp_foo_cr_(i)
-  "__temp_#{FOO_CR_MD5}_#{i}"
-end
-
 class Crystal::Program
   def reset_temp_vars
     @temp_vars.clear

--- a/spec/spec_helper.cr
+++ b/spec/spec_helper.cr
@@ -11,7 +11,9 @@ require "./support/win32"
 require "./support/wasm32"
 
 class Crystal::Program
-  setter temp_var_counter
+  def reset_temp_vars
+    @temp_vars.clear
+  end
 
   def union_of(type1, type2, type3)
     union_of([type1, type2, type3] of Type).not_nil!
@@ -110,7 +112,7 @@ def assert_normalize(from, to, flags = nil, *, file = __FILE__, line = __LINE__)
 
   # second idempotency check: if the normalizer mutates the original node,
   # further normalizations should not produce a different result
-  program.temp_var_counter = 0
+  program.reset_temp_vars
   to_nodes_str2 = program.normalize(from_nodes).to_s.strip
   unless to_nodes_str2 == to_nodes_str
     fail "Idempotency failed:\nBefore: #{to_nodes_str.inspect}\nAfter:  #{to_nodes_str2.inspect}", file: file, line: line

--- a/spec/spec_helper.cr
+++ b/spec/spec_helper.cr
@@ -10,6 +10,13 @@ require "./support/tempfile"
 require "./support/win32"
 require "./support/wasm32"
 
+FOO_CR_MD5 = Crystal::Digest::MD5.hexdigest("foo.cr")[0, 8]
+
+# used by normalization specs, trailing underscore is intentional
+def __temp_foo_cr_(i)
+  "__temp_#{FOO_CR_MD5}_#{i}"
+end
+
 class Crystal::Program
   def reset_temp_vars
     @temp_vars.clear
@@ -96,10 +103,10 @@ def top_level_semantic(node : ASTNode, wants_doc = false)
   SemanticResult.new(program, node)
 end
 
-def assert_normalize(from, to, flags = nil, *, file = __FILE__, line = __LINE__)
+def assert_normalize(from, to, flags = nil, *, filename = nil, file = __FILE__, line = __LINE__)
   program = new_program
   program.flags.concat(flags.split) if flags
-  from_nodes = Parser.parse(from)
+  from_nodes = parse(from, filename: filename)
   to_nodes = program.normalize(from_nodes)
   to_nodes_str = to_nodes.to_s.strip
   to_nodes_str.should eq(to.strip), file: file, line: line

--- a/src/compiler/crystal/semantic/literal_expander.cr
+++ b/src/compiler/crystal/semantic/literal_expander.cr
@@ -1031,8 +1031,8 @@ module Crystal
       raise "#{node} (#{node.class}) can't be expanded"
     end
 
-    def new_temp_var
-      @program.new_temp_var
+    def new_temp_var(key = nil)
+      @program.new_temp_var(key)
     end
   end
 end

--- a/src/compiler/crystal/semantic/normalizer.cr
+++ b/src/compiler/crystal/semantic/normalizer.cr
@@ -309,8 +309,8 @@ module Crystal
       #     tmp2 = exp2
       #     ...
       #     tmp.[]=(tmp1, tmp2, ..., tmp[tmp1, tmp2, ...] + b)
-      tmp_args = target.args.map { program.new_temp_var.as(ASTNode) }
-      tmp = program.new_temp_var
+      tmp_args = target.args.map { program.new_temp_var(node).as(ASTNode) }
+      tmp = program.new_temp_var(node)
 
       # (1) = tmp1 = exp1; tmp2 = exp2; ...; tmp = a
       tmp_assigns = Array(ASTNode).new(tmp_args.size + 1)


### PR DESCRIPTION
Resolves part of #15711. In the following snippet, if you comment out or uncomment line 3, then rerun the same snippet, all the LLVM bytecode files are now reused for object generation, instead of something like `221/343`:

```crystal
{%
  x = [0]
  x[0] += 1
%}
```

This works by including part of the MD5 hash of the AST node's file name in the temporary variable names; for example, if an AST node came from `foo.cr`, whose hash is `cd6ae5dd8957c51b090b33e898a97380`, then the temporary variable names will all start with `__temp_cd6ae5dd_`, instead of just `__temp_`. This is simpler than determining the current type semantically enclosing the AST node.

Of course, there are dozens of other places where the compiler creates temporary variables, so they will be addressed in subsequent PRs. This one shows that the concept works as intended.