### PR TITLE
Do not raise from `Crystal::Type#lookup_type?` if union type cannot be stored

### DIFF
--- a/spec/compiler/semantic/def_overload_spec.cr
+++ b/spec/compiler/semantic/def_overload_spec.cr
@@ -1356,6 +1356,15 @@ describe "Semantic: def overload" do
       CRYSTAL
   end
 
+  it "says `no overload matches` instead of `use a more specific type` on union restriction that cannot be stored" do
+    assert_error <<-CRYSTAL, "expected argument #1 to 'foo' to be Array | String, not Int32"
+      def foo(x : Array | String)
+      end
+
+      foo(1)
+      CRYSTAL
+  end
+
   it "finds method after including module in generic module (#1201)" do
     assert_type(<<-CRYSTAL) { char }
       module Bar

--- a/src/compiler/crystal/semantic/type_lookup.cr
+++ b/src/compiler/crystal/semantic/type_lookup.cr
@@ -150,7 +150,10 @@ class Crystal::Type
         return if !@raise && !type
         type = type.not_nil!
 
-        check_type_can_be_stored(ident, type, "can't use #{type} in unions")
+        unless type.can_be_stored?
+          ident.raise "can't use #{type} in unions yet, use a more specific type" if @raise
+          return
+        end
 
         type.virtual_type
       end


### PR DESCRIPTION
Resolves #12616.

The following snippet, which does not compile, complains about an invalid union type:

```crystal
def foo(x : Array | String) # Error: can't use Array(T) in unions yet, use a more specific type
end

foo(1)
```

But this union is permitted here, because def parameter restrictions do not name an actual type of a variable:

```crystal
foo([1] || "a")        # okay
foo(['x', 2.3] || "a") # okay
```

The compiler already knows that there is a "no overload matches" error here. However, while producing the error message, the compiler attempts to resolve the `Array` type in order to show which argument types are not covered by the parameter restriction. This lookup is allowed to fail, but it should never raise, otherwise the `use a more specific type` error prevails, as shown above. It is up to other places in the compiler to reject union types that cannot be stored, e.g. instance variable declarations.

Some other uses of `Crystal::Type#lookup_type?` are more subtle. For example, overload ordering between `Generic` and `Path` nodes calls this method:

```crystal
def foo(x : Array(Array | String)) # Error: can't use Array(T) in unions yet, use a more specific type
end

# no compilation error if this overload is deleted
def foo(y : Int32)
end

foo(["a", [1]])
```

The first overload is now ordered before the second overload. (This is a simplified rule that happens to work for common uses of generics with free variables, and is not 100% correct.)