### PR TITLE
Ensure hash literals are evaluated from left to right

### DIFF
--- a/spec/compiler/normalize/hash_literal_spec.cr
+++ b/spec/compiler/normalize/hash_literal_spec.cr
@@ -55,4 +55,20 @@ describe "Normalize: hash literal" do
       __temp_3
       CRYSTAL
   end
+
+  it "evaluates key and value expressions in correct order" do
+    assert_expand "{foo(1) => foo(2), foo(3) => foo(4), foo(5) => foo(6)}", <<-CRYSTAL
+      __temp_1 = foo(1)
+      __temp_4 = foo(2)
+      __temp_2 = foo(3)
+      __temp_5 = foo(4)
+      __temp_3 = foo(5)
+      __temp_6 = foo(6)
+      __temp_7 = ::Hash(typeof(__temp_1, __temp_2, __temp_3), typeof(__temp_4, __temp_5, __temp_6)).new
+      __temp_7[__temp_1] = __temp_4
+      __temp_7[__temp_2] = __temp_5
+      __temp_7[__temp_3] = __temp_6
+      __temp_7
+      CRYSTAL
+  end
 end

--- a/src/compiler/crystal/semantic/literal_expander.cr
+++ b/src/compiler/crystal/semantic/literal_expander.cr
@@ -279,15 +279,13 @@ module Crystal
       hash_var = new_temp_var
 
       exps = Array(ASTNode).new(node.entries.size + key_temp_var_count + value_temp_var_count + 2)
-      key_temp_vars.try &.each_with_index do |key_temp_var, i|
-        next unless key_temp_var
-        key_exp = node.entries[i].key
-        exps << Assign.new(key_temp_var, key_exp.clone).at(key_temp_var)
-      end
-      value_temp_vars.try &.each_with_index do |value_temp_var, i|
-        next unless value_temp_var
-        value_exp = node.entries[i].value
-        exps << Assign.new(value_temp_var, value_exp.clone).at(value_temp_var)
+      node.entries.each_with_index do |entry, i|
+        if key_temp_var = key_temp_vars.try &.[i]?
+          exps << Assign.new(key_temp_var, entry.key.clone).at(key_temp_var)
+        end
+        if value_temp_var = value_temp_vars.try &.[i]?
+          exps << Assign.new(value_temp_var, entry.value.clone).at(value_temp_var)
+        end
       end
       exps << Assign.new(hash_var.clone, constructor).at(node)
 


### PR DESCRIPTION
#12366 unintentionally changed the evaluation order of hash literals such that all keys are evaluated before all values. All of the following lines should print `123456` instead of `135246`:

```crystal
alias Foo = Hash(Nil, Nil)

{print(1) => print(2), print(3) => print(4), print(5) => print(6)}
Foo{print(1) => print(2), print(3) => print(4), print(5) => print(6)}
Hash{print(1) => print(2), print(3) => print(4), print(5) => print(6)}
Hash(Nil, Nil){print(1) => print(2), print(3) => print(4), print(5) => print(6)}
```