### PR TITLE
Make `Crystal.check_type_can_be_stored` build error message in a block

### DIFF
--- a/src/compiler/crystal/semantic/ast.cr
+++ b/src/compiler/crystal/semantic/ast.cr
@@ -1,10 +1,10 @@
 require "../syntax/ast"
 
 module Crystal
-  def self.check_type_can_be_stored(node, type, msg)
+  def self.check_type_can_be_stored(node, type, &)
     return if type.can_be_stored?
 
-    node.raise "#{msg} yet, use a more specific type"
+    node.raise "#{yield} yet, use a more specific type"
   end
 
   class ASTNode

--- a/src/compiler/crystal/semantic/bindings.cr
+++ b/src/compiler/crystal/semantic/bindings.cr
@@ -642,7 +642,7 @@ module Crystal
             node.raise "can't use constant as type for NamedTuple"
           end
 
-          Crystal.check_type_can_be_stored(node, node_type, "can't use #{node_type} as generic type argument")
+          Crystal.check_type_can_be_stored(node, node_type) { "can't use #{node_type} as generic type argument" }
           node_type = node_type.virtual_type
 
           entries << NamedArgumentType.new(named_arg.name, node_type)
@@ -702,7 +702,7 @@ module Crystal
                 end
               end
             else
-              Crystal.check_type_can_be_stored(node, node_type, "can't use #{node_type} as generic type argument")
+              Crystal.check_type_can_be_stored(node, node_type) { "can't use #{node_type} as generic type argument" }
               type_var = node_type.virtual_type
             end
           end

--- a/src/compiler/crystal/semantic/call.cr
+++ b/src/compiler/crystal/semantic/call.cr
@@ -893,7 +893,7 @@ class Crystal::Call
         output_type = lookup_node_type?(match.context, output)
         if output_type
           output_type = program.nil if output_type.void?
-          Crystal.check_type_can_be_stored(output, output_type, "can't use #{output_type} as a block return type")
+          Crystal.check_type_can_be_stored(output, output_type) { "can't use #{output_type} as a block return type" }
           output_type = output_type.virtual_type
         end
       end

--- a/src/compiler/crystal/semantic/main_visitor.cr
+++ b/src/compiler/crystal/semantic/main_visitor.cr
@@ -1204,7 +1204,7 @@ module Crystal
     end
 
     def self.check_type_allowed_as_proc_argument(node, type)
-      Crystal.check_type_can_be_stored(node, type, "can't use #{type.to_s(generic_args: false)} as a Proc argument type")
+      Crystal.check_type_can_be_stored(node, type) { "can't use #{type.to_s(generic_args: false)} as a Proc argument type" }
     end
 
     def visit(node : ProcPointer)

--- a/src/compiler/crystal/semantic/semantic_visitor.cr
+++ b/src/compiler/crystal/semantic/semantic_visitor.cr
@@ -563,7 +563,7 @@ abstract class Crystal::SemanticVisitor < Crystal::Visitor
       node.raise "can't declare variable of generic non-instantiated type #{type}"
     end
 
-    Crystal.check_type_can_be_stored(node, type, "can't use #{type} as the type of #{variable_kind}")
+    Crystal.check_type_can_be_stored(node, type) { "can't use #{type} as the type of #{variable_kind}" }
 
     declared_type
   end

--- a/src/compiler/crystal/semantic/type_lookup.cr
+++ b/src/compiler/crystal/semantic/type_lookup.cr
@@ -150,7 +150,7 @@ class Crystal::Type
         return if !@raise && !type
         type = type.not_nil!
 
-        check_type_can_be_stored(ident, type, "can't use #{type} in unions")
+        check_type_can_be_stored(ident, type) { "can't use #{type} in unions" }
 
         type.virtual_type
       end
@@ -191,7 +191,7 @@ class Crystal::Type
           return if !@raise && !type
           type = type.not_nil!
 
-          check_type_can_be_stored(subnode, type, "can't use #{type} as a generic type argument")
+          check_type_can_be_stored(subnode, type) { "can't use #{type} as a generic type argument" }
           entries << NamedArgumentType.new(named_arg.name, type.virtual_type)
         end
 
@@ -279,7 +279,7 @@ class Crystal::Type
 
         case instance_type
         when GenericUnionType, PointerType, StaticArrayType, TupleType, ProcType
-          check_type_can_be_stored(type_var, type, "can't use #{type} as a generic type argument")
+          check_type_can_be_stored(type_var, type) { "can't use #{type} as a generic type argument" }
         end
 
         type_vars << type.virtual_type
@@ -324,7 +324,7 @@ class Crystal::Type
             return if !@raise && !type
             type = type.not_nil!
 
-            check_type_can_be_stored(input, type, "can't use #{type} as proc argument")
+            check_type_can_be_stored(input, type) { "can't use #{type} as proc argument" }
 
             types << type.virtual_type
           end
@@ -336,7 +336,7 @@ class Crystal::Type
         return if !@raise && !type
         type = type.not_nil!
 
-        check_type_can_be_stored(output, type, "can't use #{type} as proc return type")
+        check_type_can_be_stored(output, type) { "can't use #{type} as proc return type" }
 
         types << type.virtual_type
       else
@@ -422,8 +422,8 @@ class Crystal::Type
       end
     end
 
-    def check_type_can_be_stored(ident, type, message)
-      Crystal.check_type_can_be_stored(ident, type, message)
+    def check_type_can_be_stored(ident, type, &)
+      Crystal.check_type_can_be_stored(ident, type) { yield }
     end
 
     def in_generic_args(&)


### PR DESCRIPTION
All calls to this method build the error message with a string interpolation, but in any successful compilation, none of these calls are expected to raise. Moving the messages into blocks defers these costly interpolations.

There are around 3,700 calls for an empty source file and around 60,000 calls for the compiler itself.