### PR TITLE
Pass `fd` implicitly to `System::FileDescriptor` and `System::Socket`

### DIFF
--- a/src/crystal/event_loop/iocp.cr
+++ b/src/crystal/event_loop/iocp.cr
@@ -436,7 +436,7 @@ class Crystal::EventLoop::IOCP < Crystal::EventLoop
         # AcceptEx does not automatically set the socket options on the accepted
         # socket to match those of the listening socket, we need to ask for that
         # explicitly with SO_UPDATE_ACCEPT_CONTEXT
-        socket.system_setsockopt client_handle, LibC::SO_UPDATE_ACCEPT_CONTEXT, socket.fd
+        System::Socket.setsockopt client_handle, LibC::SO_UPDATE_ACCEPT_CONTEXT, socket.fd
 
         true
       else

--- a/src/crystal/system/socket.cr
+++ b/src/crystal/system/socket.cr
@@ -54,11 +54,11 @@ module Crystal::System::Socket
 
   # private def system_linger=(val)
 
-  # private def system_getsockopt(fd, optname, optval, level = LibC::SOL_SOCKET, &)
+  # private def system_getsockopt(optname, optval, level = LibC::SOL_SOCKET, &)
 
-  # private def system_getsockopt(fd, optname, optval, level = LibC::SOL_SOCKET)
+  # private def system_getsockopt(optname, optval, level = LibC::SOL_SOCKET)
 
-  # private def system_setsockopt(fd, optname, optval, level = LibC::SOL_SOCKET)
+  # private def system_setsockopt(optname, optval, level = LibC::SOL_SOCKET)
 
   # private def system_blocking?
 

--- a/src/crystal/system/socket.cr
+++ b/src/crystal/system/socket.cr
@@ -70,6 +70,8 @@ module Crystal::System::Socket
 
   # private def system_close_on_exec=(arg : Bool)
 
+  # private def system_fcntl(cmd, arg = 0)
+
   # def self.fcntl(fd, cmd, arg = 0)
 
   # def self.socketpair(type : ::Socket::Type, protocol : ::Socket::Protocol, blocking : Bool) : {Handle, Handle}

--- a/src/crystal/system/unix/socket.cr
+++ b/src/crystal/system/unix/socket.cr
@@ -84,7 +84,7 @@ module Crystal::System::Socket
   end
 
   private def system_reuse_port? : Bool
-    system_getsockopt(fd, LibC::SO_REUSEPORT, 0) do |value|
+    system_getsockopt(LibC::SO_REUSEPORT, 0) do |value|
       return value != 0
     end
 
@@ -135,19 +135,19 @@ module Crystal::System::Socket
     val
   end
 
-  private def system_getsockopt(fd, optname, optval, level = LibC::SOL_SOCKET, &)
+  private def system_getsockopt(optname, optval, level = LibC::SOL_SOCKET, &)
     optsize = LibC::SocklenT.new(sizeof(typeof(optval)))
     ret = LibC.getsockopt(fd, level, optname, pointerof(optval), pointerof(optsize))
     yield optval if ret == 0
     ret
   end
 
-  private def system_getsockopt(fd, optname, optval, level = LibC::SOL_SOCKET)
-    system_getsockopt(fd, optname, optval, level) { |value| return value }
+  private def system_getsockopt(optname, optval, level = LibC::SOL_SOCKET)
+    system_getsockopt(optname, optval, level) { |value| return value }
     raise ::Socket::Error.from_errno("getsockopt #{optname}")
   end
 
-  private def system_setsockopt(fd, optname, optval, level = LibC::SOL_SOCKET)
+  private def system_setsockopt(optname, optval, level = LibC::SOL_SOCKET)
     optsize = LibC::SocklenT.new(sizeof(typeof(optval)))
 
     ret = LibC.setsockopt(fd, level, optname, pointerof(optval), optsize)

--- a/src/crystal/system/unix/socket.cr
+++ b/src/crystal/system/unix/socket.cr
@@ -20,8 +20,8 @@ module Crystal::System::Socket
       Process.lock_read do
         fd = LibC.socket(family, type, protocol)
         raise ::Socket::Error.from_errno("Failed to create socket") if fd == -1
-        Socket.fcntl(fd, LibC::F_SETFD, LibC::FD_CLOEXEC)
-        Socket.fcntl(fd, LibC::F_SETFL, Socket.fcntl(fd, LibC::F_GETFL) | LibC::O_NONBLOCK) unless blocking
+        FileDescriptor.fcntl(fd, LibC::F_SETFD, LibC::FD_CLOEXEC)
+        FileDescriptor.fcntl(fd, LibC::F_SETFL, FileDescriptor.fcntl(fd, LibC::F_GETFL) | LibC::O_NONBLOCK) unless blocking
         fd
       end
     {% end %}
@@ -156,41 +156,37 @@ module Crystal::System::Socket
   end
 
   private def system_blocking?
-    Socket.get_blocking(fd)
+    FileDescriptor.get_blocking(fd)
   end
 
   private def system_blocking=(value)
-    Socket.set_blocking(fd, value)
+    FileDescriptor.set_blocking(fd, value)
   end
 
   def self.get_blocking(fd : Handle)
-    fcntl(fd, LibC::F_GETFL) & LibC::O_NONBLOCK == 0
+    FileDescriptor.get_blocking(fd)
   end
 
   def self.set_blocking(fd : Handle, value : Bool)
-    flags = fcntl(fd, LibC::F_GETFL)
-    if value
-      flags &= ~LibC::O_NONBLOCK
-    else
-      flags |= LibC::O_NONBLOCK
-    end
-    fcntl(fd, LibC::F_SETFL, flags)
+    FileDescriptor.set_blocking(fd, value)
   end
 
   private def system_close_on_exec?
-    flags = fcntl(LibC::F_GETFD)
+    flags = system_fcntl(LibC::F_GETFD)
     (flags & LibC::FD_CLOEXEC) == LibC::FD_CLOEXEC
   end
 
   private def system_close_on_exec=(arg : Bool)
-    fcntl(LibC::F_SETFD, arg ? LibC::FD_CLOEXEC : 0)
+    system_fcntl(LibC::F_SETFD, arg ? LibC::FD_CLOEXEC : 0)
     arg
   end
 
   def self.fcntl(fd, cmd, arg = 0)
-    r = LibC.fcntl fd, cmd, arg
-    raise ::Socket::Error.from_errno("fcntl() failed") if r == -1
-    r
+    FileDescriptor.fcntl(fd, cmd, arg)
+  end
+
+  private def system_fcntl(cmd, arg = 0)
+    FileDescriptor.fcntl(fd, cmd, arg)
   end
 
   def self.socketpair(type : ::Socket::Type, protocol : ::Socket::Protocol, blocking : Bool) : {Handle, Handle}
@@ -207,11 +203,11 @@ module Crystal::System::Socket
         if LibC.socketpair(::Socket::Family::UNIX, type, protocol, fds) == -1
           raise ::Socket::Error.new("socketpair() failed")
         end
-        fcntl(fds[0], LibC::F_SETFD, LibC::FD_CLOEXEC)
-        fcntl(fds[1], LibC::F_SETFD, LibC::FD_CLOEXEC)
+        FileDescriptor.fcntl(fds[0], LibC::F_SETFD, LibC::FD_CLOEXEC)
+        FileDescriptor.fcntl(fds[1], LibC::F_SETFD, LibC::FD_CLOEXEC)
         unless blocking
-          fcntl(fds[0], LibC::F_SETFL, fcntl(fds[0], LibC::F_GETFL) | LibC::O_NONBLOCK)
-          fcntl(fds[1], LibC::F_SETFL, fcntl(fds[1], LibC::F_GETFL) | LibC::O_NONBLOCK)
+          FileDescriptor.fcntl(fds[0], LibC::F_SETFL, FileDescriptor.fcntl(fds[0], LibC::F_GETFL) | LibC::O_NONBLOCK)
+          FileDescriptor.fcntl(fds[1], LibC::F_SETFL, FileDescriptor.fcntl(fds[1], LibC::F_GETFL) | LibC::O_NONBLOCK)
         end
       end
     {% end %}

--- a/src/crystal/system/wasi/file_descriptor.cr
+++ b/src/crystal/system/wasi/file_descriptor.cr
@@ -8,9 +8,11 @@ module Crystal::System::FileDescriptor
   end
 
   def self.fcntl(fd, cmd, arg = 0)
-    r = LibC.fcntl(fd, cmd, arg)
-    raise IO::Error.from_errno("fcntl() failed") if r == -1
-    r
+    FileDescriptor.fcntl(fd, cmd, arg)
+  end
+
+  private def system_fcntl(cmd, arg = 0)
+    FileDescriptor.fcntl(fd, cmd, arg)
   end
 
   def self.get_blocking(fd : Handle)

--- a/src/crystal/system/wasi/socket.cr
+++ b/src/crystal/system/wasi/socket.cr
@@ -89,15 +89,15 @@ module Crystal::System::Socket
     raise NotImplementedError.new "Crystal::System::Socket#system_linge="
   end
 
-  private def system_getsockopt(fd, optname, optval, level = LibC::SOL_SOCKET, &)
+  private def system_getsockopt(optname, optval, level = LibC::SOL_SOCKET, &)
     raise NotImplementedError.new "Crystal::System::Socket#system_getsockopt"
   end
 
-  private def system_getsockopt(fd, optname, optval, level = LibC::SOL_SOCKET)
+  private def system_getsockopt(optname, optval, level = LibC::SOL_SOCKET)
     raise NotImplementedError.new "Crystal::System::Socket#system_getsockopt"
   end
 
-  private def system_setsockopt(fd, optname, optval, level = LibC::SOL_SOCKET)
+  private def system_setsockopt(optname, optval, level = LibC::SOL_SOCKET)
     raise NotImplementedError.new "Crystal::System::Socket#system_setsockopt"
   end
 

--- a/src/crystal/system/wasi/socket.cr
+++ b/src/crystal/system/wasi/socket.cr
@@ -139,6 +139,10 @@ module Crystal::System::Socket
     r
   end
 
+  private def system_fcntl(cmd, arg = 0)
+    FileDescriptor.system_fcntl(fd, cmd, arg)
+  end
+
   private def system_tty?
     LibC.isatty(fd) == 1
   end

--- a/src/crystal/system/win32/file_descriptor.cr
+++ b/src/crystal/system/win32/file_descriptor.cr
@@ -154,6 +154,10 @@ module Crystal::System::FileDescriptor
     raise NotImplementedError.new "Crystal::System::FileDescriptor.fcntl"
   end
 
+  private def system_fcntl(cmd, arg = 0)
+    raise NotImplementedError.new "Crystal::System::FileDescriptor#system_fcntl"
+  end
+
   protected def windows_handle
     LibC::HANDLE.new(fd)
   end

--- a/src/crystal/system/win32/socket.cr
+++ b/src/crystal/system/win32/socket.cr
@@ -369,6 +369,10 @@ module Crystal::System::Socket
     raise NotImplementedError.new "Crystal::System::Socket.fcntl"
   end
 
+  private def system_fcntl(cmd, arg = 0)
+    raise NotImplementedError.new "Crystal::System::Socket#system_fcntl"
+  end
+
   private def system_tty?
     LibC.GetConsoleMode(LibC::HANDLE.new(fd), out _) != 0
   end

--- a/src/crystal/system/win32/socket.cr
+++ b/src/crystal/system/win32/socket.cr
@@ -86,9 +86,9 @@ module Crystal::System::Socket
     @blocking = blocking unless blocking.nil?
 
     unless @family.unix?
-      system_getsockopt(handle, LibC::SO_REUSEADDR, 0) do |value|
+      Socket.getsockopt(handle, LibC::SO_REUSEADDR, 0) do |value|
         if value == 0
-          system_setsockopt(handle, LibC::SO_EXCLUSIVEADDRUSE, 1)
+          Socket.setsockopt(handle, LibC::SO_EXCLUSIVEADDRUSE, 1)
         end
       end
     end
@@ -310,20 +310,28 @@ module Crystal::System::Socket
     val
   end
 
-  private def system_getsockopt(handle, optname, optval, level = LibC::SOL_SOCKET, &)
+  private def system_getsockopt(optname, optval, level = LibC::SOL_SOCKET, &)
+    Socket.getsockopt(fd, optname, optval, level) { |value| yield value }
+  end
+
+  private def system_getsockopt(optname, optval, level = LibC::SOL_SOCKET)
+    Socket.getsockopt(fd, optname, optval, level) { |value| return value }
+    raise ::Socket::Error.from_wsa_error("getsockopt #{optname}")
+  end
+
+  private def system_setsockopt(optname, optval, level = LibC::SOL_SOCKET)
+    Socket.setsockopt(fd, optname, optval, level)
+  end
+
+  protected def self.getsockopt(handle, optname, optval, level = LibC::SOL_SOCKET, &)
     optsize = sizeof(typeof(optval))
     ret = LibC.getsockopt(handle, level, optname, pointerof(optval).as(UInt8*), pointerof(optsize))
     yield optval if ret == 0
     ret
   end
 
-  private def system_getsockopt(fd, optname, optval, level = LibC::SOL_SOCKET)
-    system_getsockopt(fd, optname, optval, level) { |value| return value }
-    raise ::Socket::Error.from_wsa_error("getsockopt #{optname}")
-  end
-
   # :nodoc:
-  def system_setsockopt(handle, optname, optval, level = LibC::SOL_SOCKET)
+  protected def self.setsockopt(handle, optname, optval, level = LibC::SOL_SOCKET)
     optsize = sizeof(typeof(optval))
 
     ret = LibC.setsockopt(handle, level, optname, pointerof(optval).as(UInt8*), optsize)

--- a/src/io/console.cr
+++ b/src/io/console.cr
@@ -92,7 +92,7 @@ class IO::FileDescriptor < IO
   @[Deprecated]
   macro noecho_from_tc_mode!
     mode.c_lflag &= ~(Termios::LocalMode.flags(ECHO, ECHOE, ECHOK, ECHONL).value)
-    Crystal::System::FileDescriptor.tcsetattr(fd, Termios::LineControl::TCSANOW, pointerof(mode))
+    system_tcsetattr(Termios::LineControl::TCSANOW, pointerof(mode))
   end
 
   @[Deprecated]
@@ -109,12 +109,12 @@ class IO::FileDescriptor < IO
                      Termios::LocalMode::ICANON |
                      Termios::LocalMode::ISIG |
                      Termios::LocalMode::IEXTEN).value
-    Crystal::System::FileDescriptor.tcsetattr(fd, Termios::LineControl::TCSANOW, pointerof(mode))
+    system_tcsetattr(Termios::LineControl::TCSANOW, pointerof(mode))
   end
 
   @[Deprecated]
   macro raw_from_tc_mode!
     Crystal::System::FileDescriptor.cfmakeraw(pointerof(mode))
-    Crystal::System::FileDescriptor.tcsetattr(fd, Termios::LineControl::TCSANOW, pointerof(mode))
+    system_tcsetattr(Termios::LineControl::TCSANOW, pointerof(mode))
   end
 end

--- a/src/socket.cr
+++ b/src/socket.cr
@@ -416,25 +416,25 @@ class Socket < IO
 
   # Returns the modified *optval*.
   protected def getsockopt(optname, optval, level = LibC::SOL_SOCKET)
-    system_getsockopt(fd, optname, optval, level)
+    system_getsockopt(optname, optval, level)
   end
 
   protected def getsockopt(optname, optval, level = LibC::SOL_SOCKET, &)
-    system_getsockopt(fd, optname, optval, level) { |value| yield value }
+    system_getsockopt(optname, optval, level) { |value| yield value }
   end
 
   protected def setsockopt(optname, optval, level = LibC::SOL_SOCKET)
-    system_setsockopt(fd, optname, optval, level)
+    system_setsockopt(optname, optval, level)
   end
 
   private def getsockopt_bool(optname, level = LibC::SOL_SOCKET)
-    ret = getsockopt optname, 0, level
+    ret = system_getsockopt optname, 0, level
     ret != 0
   end
 
   private def setsockopt_bool(optname, optval : Bool, level = LibC::SOL_SOCKET)
     v = optval ? 1 : 0
-    setsockopt optname, v, level
+    system_setsockopt optname, v, level
     optval
   end
 

--- a/src/socket.cr
+++ b/src/socket.cr
@@ -478,11 +478,11 @@ class Socket < IO
   end
 
   def self.fcntl(fd, cmd, arg = 0)
-    Crystal::System::Socket.fcntl(fd, cmd, arg)
+    Socket.fcntl(fd, cmd, arg)
   end
 
   def fcntl(cmd, arg = 0)
-    self.class.fcntl fd, cmd, arg
+    system_fcntl(cmd, arg)
   end
 
   # Finalizes the socket resource.


### PR DESCRIPTION
Extracts the refactors out of #16128.

The main point is to not pass `fd` explicitly as an argument and to instead let `System::FileDescriptor` and `System::Socket` use the `fd` property.

See each individual commit for details on each change.