### PR TITLE
Refactor `Formatter#visit(Call)` 

### DIFF
--- a/src/compiler/crystal/tools/formatter.cr
+++ b/src/compiler/crystal/tools/formatter.cr
@@ -2774,7 +2774,7 @@ module Crystal
       @inside_call_or_assign += 1
 
       unless args.empty?
-        has_newlines, found_comment, needed_indent = format_args_simple(args, needed_indent, do_consume_newlines)
+        has_newlines, found_comment, needed_indent = format_positional_args(args, needed_indent, do_consume_newlines)
       end
 
       if named_args
@@ -2791,7 +2791,7 @@ module Crystal
       {has_newlines, found_comment, needed_indent}
     end
 
-    def format_args_simple(args, needed_indent, do_consume_newlines)
+    def format_positional_args(args, needed_indent, do_consume_newlines)
       has_newlines = false
       found_comment = false
 

--- a/src/compiler/crystal/tools/formatter.cr
+++ b/src/compiler/crystal/tools/formatter.cr
@@ -2639,38 +2639,7 @@ module Crystal
             return false
           end
 
-          write " " if needs_space && !passed_backslash_newline
-          write node.name
-
-          # This is the case of a-1 and a+1
-          if @token.type.number?
-            @lexer.current_pos = @token.start + 1
-          end
-
-          slash_is_regex!
-
-          next_token
-          passed_backslash_newline = @token.passed_backslash_newline
-          found_comment = skip_space
-
-          if found_comment || @token.type.newline?
-            if @inside_call_or_assign == 0
-              next_indent = @indent + 2
-            else
-              next_indent = column == 0 ? 2 : column
-            end
-            indent(next_indent) do
-              skip_space_write_line
-              skip_space_or_newline
-            end
-            write_indent(next_indent, node.args.last)
-          else
-            write " " if needs_space && !passed_backslash_newline
-            inside_call_or_assign do
-              accept node.args.last
-            end
-          end
-
+          format_operator_call(node, column, needs_space, passed_backslash_newline)
           return false
         end
 
@@ -3280,6 +3249,42 @@ module Crystal
       end
 
       skip_space_or_newline
+    end
+
+    def format_operator_call(node, column, needs_space, passed_backslash_newline)
+      write " " if needs_space && !passed_backslash_newline
+      write node.name
+
+      # This is the case of `a-1` and `a+1`
+      if @token.type.number?
+        @lexer.current_pos = @token.start + 1
+      end
+
+      slash_is_regex!
+
+      next_token
+      passed_backslash_newline = @token.passed_backslash_newline
+      found_comment = skip_space
+
+      if found_comment || @token.type.newline?
+        if @inside_call_or_assign == 0
+          next_indent = @indent + 2
+        else
+          next_indent = column == 0 ? 2 : column
+        end
+        indent(next_indent) do
+          skip_space_write_line
+          skip_space_or_newline
+        end
+        write_indent(next_indent, node.args.last)
+      else
+        write " " if needs_space && !passed_backslash_newline
+        inside_call_or_assign do
+          accept node.args.last
+        end
+      end
+
+      return false
     end
 
     def remove_to_skip(node, to_skip)

--- a/src/compiler/crystal/tools/formatter.cr
+++ b/src/compiler/crystal/tools/formatter.cr
@@ -2569,10 +2569,6 @@ module Crystal
       has_newlines = false
       found_comment = false
 
-      # For special calls we want to format `.as (Int32)` into `.as(Int32)`
-      # so we remove the space between "as" and "(".
-      skip_space if pseudo_call?(node)
-
       normalize_parenthesized_single_arg(node)
 
       if @token.type.op_lparen?
@@ -2660,20 +2656,30 @@ module Crystal
     private def normalize_parenthesized_single_arg(node)
       # If the call has a single argument which is a parenthesized `Expressions`,
       # we skip whitespace between the method name and the arg. The parenthesized
-      # arg is transformed into a call with parenthesis: `foo (a)` becomes `foo(a)`.
-      if node.args.size == 1 &&
-         @token.type.space? &&
-         !node.named_args && !node.block_arg && !node.block &&
-         (expressions = node.args[0].as?(Expressions)) &&
-         expressions.keyword.paren? && expressions.expressions.size == 1
+      # arg is transformed into a call with parenthesis: `foo (a)` becomes
+      # `foo(a)`.
+      return unless @token.type.space?
+      return unless node.args.size == 1 &&
+                    !node.named_args && !node.block_arg && !node.block
+
+      case arg = node.args[0]
+      when Expressions
+        return unless arg.keyword.paren? && arg.expressions.size == 1
+        arg = arg.expressions[0]
+
         # ...except do not transform `foo ()` into `foo()`, as the former is
         # actually semantically equivalent to `foo(nil)`
-        arg = expressions.expressions[0]
-        unless arg.is_a?(Nop)
-          skip_space
-          node.args[0] = arg
-        end
+        return if arg.is_a?(Nop)
+      when Path, Generic
+        # The call is a call to a pseudo method such as `#as`.
+        return unless pseudo_call?(node)
+        # The following assignment is a nop, but we still skip space.
+      else
+        return
       end
+
+      skip_space
+      node.args[0] = arg
     end
 
     private def format_backtick_call(node)

--- a/src/compiler/crystal/tools/formatter.cr
+++ b/src/compiler/crystal/tools/formatter.cr
@@ -2554,12 +2554,7 @@ module Crystal
         accept obj
 
         passed_backslash_newline = @token.passed_backslash_newline
-
-        if @token.type.space?
-          needs_space = true
-        else
-          needs_space = node.name != "*" && node.name != "/" && node.name != "**" && node.name != "//"
-        end
+        needs_space = @token.type.space? || !node.name.in?("*", "/", "**", "//")
 
         slash_is_not_regex!
         skip_space

--- a/src/compiler/crystal/tools/formatter.cr
+++ b/src/compiler/crystal/tools/formatter.cr
@@ -2637,17 +2637,17 @@ module Crystal
             end
 
             return false
-          else
-            write " " if needs_space && !passed_backslash_newline
-            write node.name
-
-            # This is the case of a-1 and a+1
-            if @token.type.number?
-              @lexer.current_pos = @token.start + 1
-            end
-
-            slash_is_regex!
           end
+
+          write " " if needs_space && !passed_backslash_newline
+          write node.name
+
+          # This is the case of a-1 and a+1
+          if @token.type.number?
+            @lexer.current_pos = @token.start + 1
+          end
+
+          slash_is_regex!
 
           next_token
           passed_backslash_newline = @token.passed_backslash_newline

--- a/src/compiler/crystal/tools/formatter.cr
+++ b/src/compiler/crystal/tools/formatter.cr
@@ -2500,6 +2500,12 @@ module Crystal
     end
 
     def visit(node : Call)
+      format_call(node)
+
+      false
+    end
+
+    private def format_call(node)
       return if format_backtick_call(node)
       return if format_global_match_data_call(node)
 
@@ -2542,7 +2548,7 @@ module Crystal
           return if format_square_brackets_call(node)
 
           format_operator_call(node, column, needs_space, passed_backslash_newline)
-          return false
+          return
         end
 
         @lexer.wants_def_or_macro_name do

--- a/src/compiler/crystal/tools/formatter.cr
+++ b/src/compiler/crystal/tools/formatter.cr
@@ -2501,6 +2501,7 @@ module Crystal
 
     def visit(node : Call)
       return if format_backtick_call(node)
+      return if format_global_match_data_call(node)
 
       obj = node.obj
 
@@ -2517,14 +2518,6 @@ module Crystal
       column = @column
       # The indent for arguments and block belonging to this node.
       base_indent = @indent
-
-      # Special case: $1, $2, ...
-      if @token.type.global_match_data_index? && node.name.in?("[]", "[]?") && obj.is_a?(Global)
-        write "$"
-        write @token.value
-        next_token
-        return false
-      end
 
       write_token :OP_COLON_COLON if node.global?
 
@@ -2725,6 +2718,18 @@ module Crystal
       return false unless node.name == "`"
 
       accept node.args.first
+      true
+    end
+
+    private def format_global_match_data_call(node)
+      return false unless @token.type.global_match_data_index? &&
+                          node.name.in?("[]", "[]?") &&
+                          node.obj.is_a?(Global)
+
+      write "$"
+      write @token.value
+      next_token
+
       true
     end
 

--- a/src/compiler/crystal/tools/formatter.cr
+++ b/src/compiler/crystal/tools/formatter.cr
@@ -2627,29 +2627,34 @@ module Crystal
             end
             write ")"
             next_token_skip_space_or_newline
+
             indent(block_indent) { format_block block, needs_space }
             return false
-          end
-        end
+          else
+            indent(block_indent) { format_block block, needs_space }
 
-        indent(block_indent) { format_block block, needs_space }
-        if has_parentheses
-          skip_space
-          if @token.type.newline?
-            ends_with_newline = true
+            skip_space
+            if @token.type.newline?
+              ends_with_newline = true
+            end
+            skip_space_or_newline
           end
-          skip_space_or_newline
-        end
-      end
 
-      if has_args || node.block_arg
+          finish_args(has_parentheses, has_newlines, ends_with_newline, found_comment, base_indent)
+
+          return false
+        else
+          indent(block_indent) { format_block block, needs_space }
+
+          finish_args(has_parentheses, has_newlines, ends_with_newline, found_comment, base_indent)
+
+          return false
+        end
+      else
         finish_args(has_parentheses, has_newlines, ends_with_newline, found_comment, base_indent)
-      elsif has_parentheses
-        skip_space_or_newline
-        write_token :OP_RPAREN
-      end
 
-      false
+        false
+      end
     end
 
     private def pseudo_call?(node)

--- a/src/compiler/crystal/tools/formatter.cr
+++ b/src/compiler/crystal/tools/formatter.cr
@@ -2551,36 +2551,12 @@ module Crystal
 
       return if format_square_brackets_call2(node, base_indent)
 
-      assignment = Lexer.setter?(node.name)
+      return if format_assignment(node, base_indent)
 
-      if assignment
-        write node.name.rchop
-      else
-        write node.name
-      end
+      write node.name
       next_token
 
       passed_backslash_newline = @token.passed_backslash_newline
-
-      if assignment
-        skip_space
-
-        next_token
-        if @token.type.op_lparen?
-          write "=("
-          slash_is_regex!
-          next_token
-          format_call_args(node, base_indent)
-          skip_space_or_newline
-          write_token :OP_RPAREN
-        else
-          write " ="
-          skip_space
-          accept_assign_value_after_equals node.args.last
-        end
-
-        return false
-      end
 
       has_parentheses = false
       ends_with_newline = false
@@ -3278,6 +3254,31 @@ module Crystal
       end
 
       false
+    end
+
+    def format_assignment(node, base_indent)
+      return false unless Lexer.setter?(node.name)
+
+      write node.name.rchop
+      next_token
+
+      skip_space
+
+      next_token
+      if @token.type.op_lparen?
+        write "=("
+        slash_is_regex!
+        next_token
+        format_call_args(node, base_indent)
+        skip_space_or_newline
+        write_token :OP_RPAREN
+      else
+        write " ="
+        skip_space
+        accept_assign_value_after_equals node.args.last
+      end
+
+      true
     end
 
     def format_operator_call(node, column, needs_space, passed_backslash_newline)

--- a/src/compiler/crystal/tools/formatter.cr
+++ b/src/compiler/crystal/tools/formatter.cr
@@ -2503,17 +2503,7 @@ module Crystal
       return if format_backtick_call(node)
       return if format_global_match_data_call(node)
 
-      obj = node.obj
-
-      # Consider the case of `&.as(...)` and similar
-      if obj.is_a?(Nop)
-        obj = nil
-      end
-
-      # Consider the case of `as T`, that is, casting `self` without an explicit `self`
-      if pseudo_call?(node) && obj.is_a?(Var) && obj.name == "self" && !@token.keyword?(:self)
-        obj = nil
-      end
+      obj = resolve_call_receiver(node)
 
       column = @column
       # The indent for arguments and block belonging to this node.
@@ -2731,6 +2721,17 @@ module Crystal
       next_token
 
       true
+    end
+
+    private def resolve_call_receiver(node)
+      obj = node.obj
+      obj = nil if obj.is_a?(Nop)
+
+      if pseudo_call?(node) && obj.is_a?(Var) && obj.name == "self" && !@token.keyword?(:self)
+        obj = nil
+      end
+
+      obj
     end
 
     def format_call_args(node : ASTNode, base_indent)

--- a/src/compiler/crystal/tools/formatter.cr
+++ b/src/compiler/crystal/tools/formatter.cr
@@ -2528,13 +2528,7 @@ module Crystal
         slash_is_not_regex!
         skip_space
 
-        # It's something like `foo.bar\n
-        #                        .baz`
-        if (@token.type.newline?) || @wrote_newline
-          base_indent = @indent + 2
-          indent(base_indent) { consume_newlines }
-          write_indent(base_indent)
-        end
+        base_indent = consume_newlines_in_call(base_indent)
 
         unless @token.type.op_period?
           return if format_square_brackets_call(node)
@@ -2548,11 +2542,7 @@ module Crystal
         end
         skip_space
 
-        if (@token.type.newline?) || @wrote_newline
-          base_indent = @indent + 2
-          indent(base_indent) { consume_newlines }
-          write_indent(base_indent)
-        end
+        base_indent = consume_newlines_in_call(base_indent)
 
         write "."
 
@@ -2743,6 +2733,18 @@ module Crystal
       accept obj
 
       true
+    end
+
+    private def consume_newlines_in_call(base_indent)
+      # It's something like `foo.bar\n
+      #                        .baz`
+      if (@token.type.newline?) || @wrote_newline
+        base_indent = @indent + 2
+        indent(base_indent) { consume_newlines }
+        write_indent(base_indent)
+      end
+
+      base_indent
     end
 
     def format_call_args(node : ASTNode, base_indent)

--- a/src/compiler/crystal/tools/formatter.cr
+++ b/src/compiler/crystal/tools/formatter.cr
@@ -2594,7 +2594,7 @@ module Crystal
       if node.name.in?("[]", "[]?") && @token.type.op_lsquare?
         write "["
         next_token_skip_space_or_newline
-        format_call_args(node, false, base_indent)
+        format_call_args(node, base_indent)
         skip_space_or_newline
         write_token :OP_RSQUARE
         write_token :OP_QUESTION if node.name == "[]?"
@@ -2607,7 +2607,7 @@ module Crystal
         next_token_skip_space_or_newline
         args = node.args
         last_arg = args.pop
-        format_call_args(node, true, base_indent)
+        format_call_args(node, base_indent)
         skip_space_or_newline
         write_token :OP_RSQUARE
         skip_space_or_newline
@@ -2646,7 +2646,7 @@ module Crystal
           write "=("
           slash_is_regex!
           next_token
-          format_call_args(node, true, base_indent)
+          format_call_args(node, base_indent)
           skip_space_or_newline
           write_token :OP_RPAREN
         else
@@ -2702,7 +2702,7 @@ module Crystal
 
         write "("
         has_parentheses = true
-        has_newlines, found_comment, _ = format_call_args(node, true, base_indent)
+        has_newlines, found_comment, _ = format_call_args(node, base_indent)
         found_comment ||= skip_space
         if @token.type.newline?
           ends_with_newline = true
@@ -2711,7 +2711,7 @@ module Crystal
       elsif has_args || node.block_arg
         write " " unless passed_backslash_newline
         skip_space
-        has_newlines, found_comment, _ = format_call_args(node, false, base_indent)
+        has_newlines, found_comment, _ = format_call_args(node, base_indent)
       end
 
       if block = node.block
@@ -2764,11 +2764,11 @@ module Crystal
       false
     end
 
-    def format_call_args(node : ASTNode, has_parentheses, base_indent)
-      indent(base_indent) { format_args node.args, has_parentheses, node.named_args, node.block_arg }
+    def format_call_args(node : ASTNode, base_indent)
+      indent(base_indent) { format_args node.args, node.named_args, node.block_arg }
     end
 
-    def format_args(args : Array, has_parentheses, named_args = nil, block_arg = nil, needed_indent = @indent + 2, do_consume_newlines = false)
+    def format_args(args : Array, named_args = nil, block_arg = nil, needed_indent = @indent + 2, do_consume_newlines = false)
       has_newlines = false
       found_comment = false
       @inside_call_or_assign += 1
@@ -2866,7 +2866,7 @@ module Crystal
         end
       end
 
-      format_args named_args, false, needed_indent: named_args_column, do_consume_newlines: true
+      format_args named_args, needed_indent: named_args_column, do_consume_newlines: true
     end
 
     def format_block_arg(block_arg, needed_indent)
@@ -2927,7 +2927,7 @@ module Crystal
     def format_parenthesized_args(args, named_args = nil)
       write "("
       next_token_skip_space
-      has_newlines, found_comment, _ = format_args args, true, named_args: named_args
+      has_newlines, found_comment, _ = format_args args, named_args: named_args
       skip_space
       ends_with_newline = false
       if @token.type.newline?
@@ -3195,7 +3195,7 @@ module Crystal
           last_arg = args.pop
         end
 
-        has_newlines, found_comment, _ = format_args args, true, node.named_args
+        has_newlines, found_comment, _ = format_args args, node.named_args
         if @token.type.op_comma? || @token.type.newline?
           if has_newlines
             write ","
@@ -3712,7 +3712,7 @@ module Crystal
         # The tuple depth is 2 in both cases but only 1 leading curly brace is
         # present on the first return.
         if exp.is_a?(TupleLiteral) && opening_curly_brace_count < leading_tuple_depth(exp)
-          format_args(exp.elements, has_parentheses)
+          format_args(exp.elements)
           skip_space if has_parentheses
         else
           indent(@indent, exp)
@@ -3760,7 +3760,7 @@ module Crystal
       else
         write " " unless node.exps.empty?
         skip_space
-        format_args node.exps, false
+        format_args node.exps
       end
 
       false

--- a/src/compiler/crystal/tools/formatter.cr
+++ b/src/compiler/crystal/tools/formatter.cr
@@ -2553,6 +2553,10 @@ module Crystal
 
       return if format_assignment(node, base_indent)
 
+      format_regular_call(node, obj, base_indent)
+    end
+
+    private def format_regular_call(node, obj, base_indent)
       write node.name
       next_token
 

--- a/src/compiler/crystal/tools/formatter.cr
+++ b/src/compiler/crystal/tools/formatter.cr
@@ -2567,7 +2567,7 @@ module Crystal
           write_indent(base_indent)
         end
 
-        if !@token.type.op_period?
+        unless @token.type.op_period?
           # It's an operator
           if @token.type.op_lsquare?
             write "["

--- a/src/compiler/crystal/tools/formatter.cr
+++ b/src/compiler/crystal/tools/formatter.cr
@@ -2500,11 +2500,7 @@ module Crystal
     end
 
     def visit(node : Call)
-      # This is the case of `...`
-      if node.name == "`"
-        accept node.args.first
-        return false
-      end
+      return if format_backtick_call(node)
 
       obj = node.obj
 
@@ -2723,6 +2719,13 @@ module Crystal
 
     private def pseudo_call?(node)
       node.name.in?("as", "as?", "is_a?", "nil?", "responds_to?")
+    end
+
+    private def format_backtick_call(node)
+      return false unless node.name == "`"
+
+      accept node.args.first
+      true
     end
 
     def format_call_args(node : ASTNode, base_indent)

--- a/src/compiler/crystal/tools/formatter.cr
+++ b/src/compiler/crystal/tools/formatter.cr
@@ -2603,32 +2603,35 @@ module Crystal
         needs_space = !has_parentheses || has_args
         block_indent = base_indent
         skip_space
-        if has_parentheses && @token.type.op_comma?
-          next_token
-          wrote_newline = skip_space(block_indent, write_comma: true)
-          if wrote_newline || @token.type.newline?
-            unless wrote_newline
-              next_token_skip_space_or_newline
-              write ","
-              write_line
+        if has_parentheses
+          if @token.type.op_comma?
+            next_token
+            wrote_newline = skip_space(block_indent, write_comma: true)
+            if wrote_newline || @token.type.newline?
+              unless wrote_newline
+                next_token_skip_space_or_newline
+                write ","
+                write_line
+              end
+              needs_space = false
+              block_indent += 2 if !@token.type.op_rparen? # foo(1, ↵  &.foo) case
+              write_indent(block_indent)
+            else
+              write "," if !@token.type.op_rparen? # foo(1, &.foo) case
             end
-            needs_space = false
-            block_indent += 2 if !@token.type.op_rparen? # foo(1, ↵  &.foo) case
-            write_indent(block_indent)
-          else
-            write "," if !@token.type.op_rparen? # foo(1, &.foo) case
+          end
+          if @token.type.op_rparen?
+            if ends_with_newline
+              write_line unless found_comment || @wrote_newline
+              write_indent
+            end
+            write ")"
+            next_token_skip_space_or_newline
+            indent(block_indent) { format_block block, needs_space }
+            return false
           end
         end
-        if has_parentheses && @token.type.op_rparen?
-          if ends_with_newline
-            write_line unless found_comment || @wrote_newline
-            write_indent
-          end
-          write ")"
-          next_token_skip_space_or_newline
-          indent(block_indent) { format_block block, needs_space }
-          return false
-        end
+
         indent(block_indent) { format_block block, needs_space }
         if has_parentheses
           skip_space

--- a/src/compiler/crystal/tools/formatter.cr
+++ b/src/compiler/crystal/tools/formatter.cr
@@ -2518,15 +2518,7 @@ module Crystal
       write_token :OP_COLON_COLON if node.global?
 
       if obj
-        # This handles unary operators written in prefix notation.
-        # The relevant distinction is that the call has a receiver and the
-        # current token is not that object but a unary operator.
-        if @token.type.unary_operator? && node.name == @token.type.to_s && !node.has_any_args?
-          write @token.type
-          next_token_skip_space_or_newline
-          accept obj
-          return false
-        end
+        return if format_unary_operator_call(node, obj)
 
         accept obj
 
@@ -2738,6 +2730,19 @@ module Crystal
       end
 
       obj
+    end
+
+    # This handles unary operators written in prefix notation.
+    # The relevant distinction is that the call has a receiver and the
+    # current token is not that object but a unary operator.
+    private def format_unary_operator_call(node, obj)
+      return false unless @token.type.unary_operator? && node.name == @token.type.to_s && !node.has_any_args?
+
+      write @token.type
+      next_token_skip_space_or_newline
+      accept obj
+
+      true
     end
 
     def format_call_args(node : ASTNode, base_indent)

--- a/src/compiler/crystal/tools/formatter.cr
+++ b/src/compiler/crystal/tools/formatter.cr
@@ -2590,42 +2590,7 @@ module Crystal
         skip_space_or_newline
       end
 
-      # This is for foo &.[bar] and &.[bar]?, or foo.[bar] and foo.[bar]?
-      if node.name.in?("[]", "[]?") && @token.type.op_lsquare?
-        write "["
-        next_token_skip_space_or_newline
-        format_call_args(node, base_indent)
-        skip_space_or_newline
-        write_token :OP_RSQUARE
-        write_token :OP_QUESTION if node.name == "[]?"
-        return false
-      end
-
-      # This is for foo.[bar] = baz
-      if node.name == "[]=" && @token.type.op_lsquare?
-        write "["
-        next_token_skip_space_or_newline
-        args = node.args
-        last_arg = args.pop
-        format_call_args(node, base_indent)
-        skip_space_or_newline
-        write_token :OP_RSQUARE
-        skip_space_or_newline
-        write " ="
-        next_token_skip_space
-        accept_assign_value_after_equals last_arg
-        return false
-      end
-
-      # This is for foo.[] = bar
-      if node.name == "[]=" && @token.type.op_lsquare_rsquare?
-        write_token :OP_LSQUARE_RSQUARE
-        next_token_skip_space_or_newline
-        write " ="
-        next_token_skip_space
-        accept_assign_value_after_equals node.args.last
-        return false
-      end
+      return if format_square_brackets_call2(node, base_indent)
 
       assignment = Lexer.setter?(node.name)
 
@@ -3254,6 +3219,47 @@ module Crystal
       end
 
       true
+    end
+
+    def format_square_brackets_call2(node, base_indent)
+      # This is for foo &.[bar] and &.[bar]?, or foo.[bar] and foo.[bar]?
+      if node.name.in?("[]", "[]?") && @token.type.op_lsquare?
+        write "["
+        next_token_skip_space_or_newline
+        format_call_args(node, base_indent)
+        skip_space_or_newline
+        write_token :OP_RSQUARE
+        write_token :OP_QUESTION if node.name == "[]?"
+        return true
+      end
+
+      # This is for foo.[bar] = baz
+      if node.name == "[]=" && @token.type.op_lsquare?
+        write "["
+        next_token_skip_space_or_newline
+        args = node.args
+        last_arg = args.pop
+        format_call_args(node, base_indent)
+        skip_space_or_newline
+        write_token :OP_RSQUARE
+        skip_space_or_newline
+        write " ="
+        next_token_skip_space
+        accept_assign_value_after_equals last_arg
+        return true
+      end
+
+      # This is for foo.[] = bar
+      if node.name == "[]=" && @token.type.op_lsquare_rsquare?
+        write_token :OP_LSQUARE_RSQUARE
+        next_token_skip_space_or_newline
+        write " ="
+        next_token_skip_space
+        accept_assign_value_after_equals node.args.last
+        return true
+      end
+
+      false
     end
 
     def format_operator_call(node, column, needs_space, passed_backslash_newline)


### PR DESCRIPTION
This PR contains a series of patches to refactor the formatter logic for formatting a `Call` node. This is quite a complex matter with lots of alternative strategies.
The primary change is extracting all these different cases into separate methods, in order to clarify scopes and control flow. 
Alongside are a couple smaller improvements for code simplification.

I'm not sure if this should be merged as a single change because we lose the commit history. We might want to merge the `Extract` commits together as one major edit which only moves code around. And a few smaller PRs for the other changes.