### PR TITLE
Fix `HTTP::Request#query=` typing

### DIFF
--- a/src/http/request.cr
+++ b/src/http/request.cr
@@ -285,7 +285,7 @@ class HTTP::Request
   end
 
   # Sets request's query component.
-  def query=(value : String) : String
+  def query=(value : String?) : String?
     uri.query = value
     update_query_params
     value


### PR DESCRIPTION
It internally calls `URI#query=` which accepts `nil` so having `HTTP::Request` be `String` was overly restrictive.

Follow up to #15710.