### PR TITLE
Add `Crystal::EventLoop#resume_all` to replace `#reopened`

### DIFF
--- a/src/crystal/event_loop/file_descriptor.cr
+++ b/src/crystal/event_loop/file_descriptor.cr
@@ -41,10 +41,12 @@ abstract class Crystal::EventLoop
     # Blocks the current fiber until the file descriptor is ready for write.
     abstract def wait_writable(file_descriptor : Crystal::System::FileDescriptor) : Nil
 
-    # Hook to react on the file descriptor after it has been reopened. For
-    # example we might want to resume all pending operations to act on the new
-    # file descriptor.
-    abstract def reopened(file_descriptor : Crystal::System::FileDescriptor) : Nil
+    # Resumes fibers waiting on the file descriptor.
+    #
+    # Optional. Only called on UNIX targets.
+    def resume_all(file_descriptor : Crystal::System::FileDescriptor) : Nil
+      raise NotImplementedError.new("#{self.class.name}#resume_all(Crystal::System::FileDescriptor)")
+    end
 
     # Closes the file descriptor resource.
     abstract def close(file_descriptor : Crystal::System::FileDescriptor) : Nil

--- a/src/crystal/event_loop/iocp.cr
+++ b/src/crystal/event_loop/iocp.cr
@@ -303,10 +303,6 @@ class Crystal::EventLoop::IOCP < Crystal::EventLoop
     raise NotImplementedError.new("Crystal::System::IOCP#wait_writable(FileDescriptor)")
   end
 
-  def reopened(file_descriptor : Crystal::System::FileDescriptor) : Nil
-    raise NotImplementedError.new("Crystal::System::IOCP#reopened(FileDescriptor)")
-  end
-
   def close(file_descriptor : Crystal::System::FileDescriptor) : Nil
     LibC.CancelIoEx(file_descriptor.windows_handle, nil) unless file_descriptor.system_blocking?
     file_descriptor.file_descriptor_close

--- a/src/crystal/event_loop/libevent.cr
+++ b/src/crystal/event_loop/libevent.cr
@@ -174,14 +174,11 @@ class Crystal::EventLoop::LibEvent < Crystal::EventLoop
     end
   end
 
-  def reopened(file_descriptor : Crystal::System::FileDescriptor) : Nil
+  def resume_all(file_descriptor : Crystal::System::FileDescriptor) : Nil
     file_descriptor.evented_close
   end
 
   def close(file_descriptor : Crystal::System::FileDescriptor) : Nil
-    # perform cleanup before LibC.close. Using a file descriptor after it has
-    # been closed is never defined and can always lead to undefined results
-    file_descriptor.evented_close
     file_descriptor.file_descriptor_close
   end
 
@@ -299,10 +296,11 @@ class Crystal::EventLoop::LibEvent < Crystal::EventLoop
     end
   end
 
-  def close(socket : ::Socket) : Nil
-    # perform cleanup before LibC.close. Using a file descriptor after it has
-    # been closed is never defined and can always lead to undefined results
+  def resume_all(socket : ::Socket) : Nil
     socket.evented_close
+  end
+
+  def close(socket : ::Socket) : Nil
     socket.socket_close
   end
 

--- a/src/crystal/event_loop/socket.cr
+++ b/src/crystal/event_loop/socket.cr
@@ -74,6 +74,13 @@ abstract class Crystal::EventLoop
     # and the source address.
     abstract def receive_from(socket : ::Socket, slice : Bytes) : Tuple(Int32, ::Socket::Address)
 
+    # Resumes fibers waiting on the socket.
+    #
+    # Optional. Only called on UNIX targets.
+    def resume_all(file_descriptor : Crystal::System::FileDescriptor) : Nil
+      raise NotImplementedError.new("#{self.class.name}#resume_all(Crystal::System::FileDescriptor)")
+    end
+
     # Closes the socket.
     abstract def close(socket : ::Socket) : Nil
   end

--- a/src/crystal/event_loop/wasi.cr
+++ b/src/crystal/event_loop/wasi.cr
@@ -76,10 +76,6 @@ class Crystal::EventLoop::Wasi < Crystal::EventLoop
     end
   end
 
-  def reopened(file_descriptor : Crystal::System::FileDescriptor) : Nil
-    raise NotImplementedError.new("Crystal::EventLoop#reopened(FileDescriptor)")
-  end
-
   def close(file_descriptor : Crystal::System::FileDescriptor) : Nil
     file_descriptor.evented_close
     file_descriptor.file_descriptor_close

--- a/src/crystal/system/unix/file_descriptor.cr
+++ b/src/crystal/system/unix/file_descriptor.cr
@@ -126,10 +126,13 @@ module Crystal::System::FileDescriptor
     # Mark the handle open, since we had to have dup'd a live handle.
     @closed = false
 
-    event_loop.reopened(self)
+    # resume all pending waiters so they can start waiting on the new fd
+    event_loop.resume_all(self)
   end
 
   private def system_close
+    # resume pending fibers before closing the fd
+    event_loop.resume_all(self)
     event_loop.close(self)
   end
 

--- a/src/crystal/system/unix/socket.cr
+++ b/src/crystal/system/unix/socket.cr
@@ -224,6 +224,8 @@ module Crystal::System::Socket
   end
 
   private def system_close
+    # resume pending fibers before closing the fd
+    event_loop.resume_all(self)
     event_loop.close(self)
   end
 


### PR DESCRIPTION
Allows to distinguish the "resume all waiters" from the actual "close" action. Only called on UNIX targets for now.

Extracted from #16128 and renamed from `#before_close` to `#resume_all` and replaces the now obsolete `#reopened` hook.