### PR TITLE
Move `*::Serializable`'s private constructors into `macro included` hook

### DIFF
--- a/spec/std/json/serializable_spec.cr
+++ b/spec/std/json/serializable_spec.cr
@@ -386,6 +386,13 @@ struct JSONAttrPersonWithSelectiveSerialization
   end
 end
 
+struct JSONAttrWithGenericConverter(T)
+  include JSON::Serializable
+
+  @[JSON::Field(converter: T)]
+  property value : Time
+end
+
 abstract class JSONShape
   include JSON::Serializable
 
@@ -505,6 +512,16 @@ module JsonDiscriminatorBug
   end
 
   class C < B
+  end
+end
+
+class JSONInitializeOpts
+  include JSON::Serializable
+
+  property value : Int32
+
+  def initialize(**opts)
+    @value = opts.size
   end
 end
 
@@ -1175,5 +1192,13 @@ describe "JSON mapping" do
 
   it "fixes #13337" do
     JSONSomething.from_json(%({"value":{}})).value.should_not be_nil
+  end
+
+  it "works when type has constructor with double splat parameter (#16140)" do
+    JSONInitializeOpts.from_json(%({"value":123})).value.should eq(123)
+  end
+
+  it "supports generic type variables in converters" do
+    JSONAttrWithGenericConverter(Time::EpochConverter).from_json(%({"value":1459859781})).value.should eq(Time.unix(1459859781))
   end
 end

--- a/spec/std/uri/params/serializable_spec.cr
+++ b/spec/std/uri/params/serializable_spec.cr
@@ -50,6 +50,13 @@ private record ConverterType, value : Int32 do
   @value : Int32
 end
 
+private record GenericConverterType(T), value : Int32 do
+  include URI::Params::Serializable
+
+  @[URI::Params::Field(converter: T)]
+  @value : Int32
+end
+
 class ParentType
   include URI::Params::Serializable
 
@@ -57,6 +64,14 @@ class ParentType
 end
 
 class ChildType < ParentType
+end
+
+private record SimpleTypeInitializeOpts, value : Int32 do
+  include URI::Params::Serializable
+
+  def initialize(**opts)
+    @value = opts.size
+  end
 end
 
 describe URI::Params::Serializable do
@@ -129,5 +144,13 @@ describe URI::Params::Serializable do
       Parent.new(Child.new("active", GrandChild.new("Fred"))).to_www_form
         .should eq "child%5Bstatus%5D=active&child%5Bgrand_child%5D%5Bname%5D=Fred"
     end
+  end
+
+  it "works when type has constructor with double splat parameter (#16140)" do
+    SimpleTypeInitializeOpts.from_www_form("value=123").value.should eq(123)
+  end
+
+  it "supports generic type variables in converters" do
+    GenericConverterType(MyConverter).from_www_form("value=123").value.should eq(1230)
   end
 end

--- a/spec/std/yaml/serializable_spec.cr
+++ b/spec/std/yaml/serializable_spec.cr
@@ -342,6 +342,13 @@ module YAMLAttrModuleWithSameNameClass
   end
 end
 
+struct YAMLAttrWithGenericConverter(T)
+  include YAML::Serializable
+
+  @[YAML::Field(converter: T)]
+  property value : Time
+end
+
 abstract class YAMLShape
   include YAML::Serializable
 
@@ -457,6 +464,16 @@ module YAMLDiscriminatorBug
   end
 
   class C < B
+  end
+end
+
+class YAMLInitializeOpts
+  include YAML::Serializable
+
+  property value : Int32
+
+  def initialize(**opts)
+    @value = opts.size
   end
 end
 
@@ -1159,5 +1176,13 @@ describe "YAML::Serializable" do
 
   it "fixes #13337" do
     YAMLSomething.from_yaml(%({"value":{}})).value.should_not be_nil
+  end
+
+  it "works when type has constructor with double splat parameter (#16140)" do
+    YAMLInitializeOpts.from_yaml(%({"value":123})).value.should eq(123)
+  end
+
+  it "supports generic type variables in converters" do
+    YAMLAttrWithGenericConverter(Time::EpochConverter).from_yaml(%({"value":1459859781})).value.should eq(Time.unix(1459859781))
   end
 end

--- a/src/uri/params/serializable.cr
+++ b/src/uri/params/serializable.cr
@@ -88,24 +88,26 @@ struct URI::Params
           new_from_www_form(params, name)
         end
       end
-    end
 
-    # :nodoc:
-    def initialize(*, __uri_params params : ::URI::Params, name : String?)
-      {% begin %}
-        {% for ivar, idx in @type.instance_vars %}
-          %name{idx} = name.nil? ? {{ivar.name.stringify}} : "#{name}[#{{{ivar.name.stringify}}}]"
-          %value{idx} = {{(ann = ivar.annotation(URI::Params::Field)) && (converter = ann["converter"]) ? converter : ivar.type}}.from_www_form params, %name{idx}
+      # :nodoc:
+      def initialize(*, __uri_params params : ::URI::Params, name : String?)
+        {% verbatim do %}
+          {% begin %}
+            {% for ivar, idx in @type.instance_vars %}
+              %name{idx} = name.nil? ? {{ivar.name.stringify}} : "#{name}[#{{{ivar.name.stringify}}}]"
+              %value{idx} = {{(ann = ivar.annotation(URI::Params::Field)) && (converter = ann["converter"]) ? converter : ivar.type}}.from_www_form params, %name{idx}
 
-          unless %value{idx}.nil?
-            @{{ivar.name.id}} = %value{idx}
-          else
-            {% unless ivar.type.resolve.nilable? || ivar.has_default_value? %}
-              raise URI::SerializableError.new "Missing required property: '#{%name{idx}}'."
+              unless %value{idx}.nil?
+                @{{ivar.name.id}} = %value{idx}
+              else
+                {% unless ivar.type.resolve.nilable? || ivar.has_default_value? %}
+                  raise URI::SerializableError.new "Missing required property: '#{%name{idx}}'."
+                {% end %}
+              end
             {% end %}
-          end
+          {% end %}
         {% end %}
-      {% end %}
+      end
     end
 
     def to_www_form(*, space_to_plus : Bool = true) : String

--- a/src/yaml/serialization.cr
+++ b/src/yaml/serialization.cr
@@ -182,96 +182,98 @@ module YAML
           new_from_yaml_node(ctx, node)
         end
       end
-    end
 
-    def initialize(*, __context_for_yaml_serializable ctx : YAML::ParseContext, __node_for_yaml_serializable node : ::YAML::Nodes::Node)
-      {% begin %}
-        {% properties = {} of Nil => Nil %}
-        {% for ivar in @type.instance_vars %}
-          {% ann = ivar.annotation(::YAML::Field) %}
-          {% unless ann && (ann[:ignore] || ann[:ignore_deserialize]) %}
-            {%
-              properties[ivar.id] = {
-                key:         ((ann && ann[:key]) || ivar).id.stringify,
-                has_default: ivar.has_default_value?,
-                default:     ivar.default_value,
-                nilable:     ivar.type.nilable?,
-                type:        ivar.type,
-                converter:   ann && ann[:converter],
-                presence:    ann && ann[:presence],
-              }
-            %}
-          {% end %}
-        {% end %}
+      def initialize(*, __context_for_yaml_serializable ctx : YAML::ParseContext, __node_for_yaml_serializable node : ::YAML::Nodes::Node)
+        {% verbatim do %}
+          {% begin %}
+            {% properties = {} of Nil => Nil %}
+            {% for ivar in @type.instance_vars %}
+              {% ann = ivar.annotation(::YAML::Field) %}
+              {% unless ann && (ann[:ignore] || ann[:ignore_deserialize]) %}
+                {%
+                  properties[ivar.id] = {
+                    key:         ((ann && ann[:key]) || ivar).id.stringify,
+                    has_default: ivar.has_default_value?,
+                    default:     ivar.default_value,
+                    nilable:     ivar.type.nilable?,
+                    type:        ivar.type,
+                    converter:   ann && ann[:converter],
+                    presence:    ann && ann[:presence],
+                  }
+                %}
+              {% end %}
+            {% end %}
 
-        # `%var`'s type must be exact to avoid type inference issues with
-        # recursively defined serializable types
-        {% for name, value in properties %}
-          %var{name} = uninitialized ::Union({{value[:type]}})
-          %found{name} = false
-        {% end %}
-
-        case node
-        when YAML::Nodes::Mapping
-          YAML::Schema::Core.each(node) do |key_node, value_node|
-            unless key_node.is_a?(YAML::Nodes::Scalar)
-              key_node.raise "Expected scalar as key for mapping"
-            end
-
-            key = key_node.value
-
-            case key
+            # `%var`'s type must be exact to avoid type inference issues with
+            # recursively defined serializable types
             {% for name, value in properties %}
-              when {{value[:key]}}
-                begin
-                  {% if value[:has_default] || value[:nilable] %}
-                    if YAML::Schema::Core.parse_null?(value_node)
-                      {% if value[:nilable] %}
-                        %var{name} = nil
-                        %found{name} = true
-                      {% end %}
-                      next
-                    end
-                  {% end %}
+              %var{name} = uninitialized ::Union({{value[:type]}})
+              %found{name} = false
+            {% end %}
 
-                  %var{name} =
-                    {% if value[:converter] %}
-                      {{value[:converter]}}.from_yaml(ctx, value_node)
-                    {% else %}
-                      ::Union({{value[:type]}}).new(ctx, value_node)
-                    {% end %}
-                  %found{name} = true
+            case node
+            when YAML::Nodes::Mapping
+              YAML::Schema::Core.each(node) do |key_node, value_node|
+                unless key_node.is_a?(YAML::Nodes::Scalar)
+                  key_node.raise "Expected scalar as key for mapping"
                 end
-            {% end %}
+
+                key = key_node.value
+
+                case key
+                {% for name, value in properties %}
+                  when {{value[:key]}}
+                    begin
+                      {% if value[:has_default] || value[:nilable] %}
+                        if YAML::Schema::Core.parse_null?(value_node)
+                          {% if value[:nilable] %}
+                            %var{name} = nil
+                            %found{name} = true
+                          {% end %}
+                          next
+                        end
+                      {% end %}
+
+                      %var{name} =
+                        {% if value[:converter] %}
+                          {{value[:converter]}}.from_yaml(ctx, value_node)
+                        {% else %}
+                          ::Union({{value[:type]}}).new(ctx, value_node)
+                        {% end %}
+                      %found{name} = true
+                    end
+                {% end %}
+                else
+                  on_unknown_yaml_attribute(ctx, key, key_node, value_node)
+                end
+              end
+            when YAML::Nodes::Scalar
+              if node.value.empty? && node.style.plain? && !node.tag
+                # We consider an empty scalar as an empty mapping
+              else
+                node.raise "Expected mapping, not #{node.class}"
+              end
             else
-              on_unknown_yaml_attribute(ctx, key, key_node, value_node)
+              node.raise "Expected mapping, not #{node.class}"
             end
-          end
-        when YAML::Nodes::Scalar
-          if node.value.empty? && node.style.plain? && !node.tag
-            # We consider an empty scalar as an empty mapping
-          else
-            node.raise "Expected mapping, not #{node.class}"
-          end
-        else
-          node.raise "Expected mapping, not #{node.class}"
-        end
 
-        {% for name, value in properties %}
-          if %found{name}
-            @{{name}} = %var{name}
-          else
-            {% unless value[:has_default] || value[:nilable] %}
-              node.raise "Missing YAML attribute: {{value[:key].id}}"
+            {% for name, value in properties %}
+              if %found{name}
+                @{{name}} = %var{name}
+              else
+                {% unless value[:has_default] || value[:nilable] %}
+                  node.raise "Missing YAML attribute: {{value[:key].id}}"
+                {% end %}
+              end
+
+              {% if value[:presence] %}
+                @{{name}}_present = %found{name}
+              {% end %}
             {% end %}
-          end
-
-          {% if value[:presence] %}
-            @{{name}}_present = %found{name}
           {% end %}
         {% end %}
-      {% end %}
-      after_initialize
+        after_initialize
+      end
     end
 
     protected def after_initialize


### PR DESCRIPTION
Fixes #16140.

As a bonus, it is now possible to refer to generic type variables inside converters (see https://github.com/crystal-lang/crystal/pull/16142#discussion_r2328740773 for an example).