### PR TITLE
Fix: `Fiber::ExecutionContext::Parallel::Scheduler#tick` must be unsigned

### DIFF
--- a/src/fiber/execution_context/parallel/scheduler.cr
+++ b/src/fiber/execution_context/parallel/scheduler.cr
@@ -25,7 +25,7 @@ module Fiber::ExecutionContext
       @runnables : Runnables(256)
       @event_loop : Crystal::EventLoop
 
-      @tick : Int32 = 0
+      @tick : UInt32 = 0
       @spinning = false
       @waiting = false
       @parked = false


### PR DESCRIPTION
The tick is expected to overflow, at which point it will reach the negative `Int32::MIN` and the once in a while check to dequeue from the global queue won't happen until we reach a positive value!