### PR TITLE
Fix `URI#host=` to wrap IPv6 address in brackets

### DIFF
--- a/spec/std/uri_spec.cr
+++ b/spec/std/uri_spec.cr
@@ -168,9 +168,17 @@ describe "URI" do
 
   describe "#hostname" do
     it { URI.new("http", "www.example.com", path: "/foo").hostname.should eq("www.example.com") }
-    it { URI.new("http", "[::1]", path: "foo").hostname.should eq("::1") }
-    it { URI.new("http", "::1", path: "foo").hostname.should eq("::1") }
     it { URI.new(path: "/foo").hostname.should be_nil }
+
+    it "works with IPv6 address literals" do
+      uri = URI.new("http", "[::1]", path: "foo")
+      uri.hostname.should eq("::1")
+      uri.host.should eq("[::1]")
+
+      uri = URI.new("http", "::1", path: "foo")
+      uri.hostname.should eq("::1")
+      uri.host.should eq("[::1]")
+    end
   end
 
   describe "#authority" do

--- a/spec/std/uri_spec.cr
+++ b/spec/std/uri_spec.cr
@@ -168,16 +168,43 @@ describe "URI" do
 
   describe "#hostname" do
     it { URI.new("http", "www.example.com", path: "/foo").hostname.should eq("www.example.com") }
+    it { URI.new("http", "[::1]", path: "foo").hostname.should eq("::1") }
     it { URI.new(path: "/foo").hostname.should be_nil }
+  end
 
+  describe "#host" do
     it "works with IPv6 address literals" do
       uri = URI.new("http", "[::1]", path: "foo")
       uri.hostname.should eq("::1")
       uri.host.should eq("[::1]")
+      uri.to_s.should eq "http://[::1]/foo"
+      uri.host = "[::1]"
+      uri.to_s.should eq "http://[::1]/foo"
 
       uri = URI.new("http", "::1", path: "foo")
       uri.hostname.should eq("::1")
       uri.host.should eq("[::1]")
+      uri.to_s.should eq "http://[::1]/foo"
+      uri.host = "::1"
+      uri.to_s.should eq "http://[::1]/foo"
+    end
+
+    it "works with IPv4 addresses" do
+      uri = URI.new("http", "192.168.0.2", path: "foo")
+      uri.hostname.should eq("192.168.0.2")
+      uri.host.should eq("192.168.0.2")
+      uri.to_s.should eq "http://192.168.0.2/foo"
+      uri.host = "192.168.0.2"
+      uri.to_s.should eq "http://192.168.0.2/foo"
+    end
+
+    it "works with domain names" do
+      uri = URI.new("http", "test.domain", path: "foo")
+      uri.hostname.should eq("test.domain")
+      uri.host.should eq("test.domain")
+      uri.to_s.should eq "http://test.domain/foo"
+      uri.host = "test.domain"
+      uri.to_s.should eq "http://test.domain/foo"
     end
   end
 
@@ -245,9 +272,6 @@ describe "URI" do
 
     it "normalizes host" do
       URI.parse("http://FoO.cOm/").normalize.should eq URI.parse("http://foo.com/")
-      uri = URI.new("http", port: 8080)
-      uri.host = "::1"
-      uri.normalize.should eq URI.parse("http://[::1]:8080")
     end
 
     it "removes default port" do

--- a/spec/std/uri_spec.cr
+++ b/spec/std/uri_spec.cr
@@ -169,6 +169,7 @@ describe "URI" do
   describe "#hostname" do
     it { URI.new("http", "www.example.com", path: "/foo").hostname.should eq("www.example.com") }
     it { URI.new("http", "[::1]", path: "foo").hostname.should eq("::1") }
+    it { URI.new("http", "::1", path: "foo").hostname.should eq("::1") }
     it { URI.new(path: "/foo").hostname.should be_nil }
   end
 
@@ -236,6 +237,9 @@ describe "URI" do
 
     it "normalizes host" do
       URI.parse("http://FoO.cOm/").normalize.should eq URI.parse("http://foo.com/")
+      uri = URI.new("http", port: 8080)
+      uri.host = "::1"
+      uri.normalize.should eq URI.parse("http://[::1]:8080")
     end
 
     it "removes default port" do

--- a/src/uri.cr
+++ b/src/uri.cr
@@ -402,7 +402,10 @@ class URI
   # ```
   def normalize! : URI
     @scheme = @scheme.try &.downcase
-    @host = @host.try &.downcase
+    if host = @host
+      host = host.downcase
+      @host = !host.starts_with?('[') && host.includes?(':') ? "[#{host}]" : host
+    end
     @port = nil if default_port?
     @path = remove_dot_segments(path)
 

--- a/src/uri.cr
+++ b/src/uri.cr
@@ -392,7 +392,7 @@ class URI
   # The following normalizations are applied to the individual components (if available):
   #
   # * `scheme` is lowercased.
-  # * `host` is lowercased and IPv6 addresses are wrapped with `[]`.
+  # * `host` is lowercased.
   # * `port` is removed if it is the `.default_port?` of the scheme.
   # * `path` is resolved to a minimal, semantic equivalent representation removing
   #    dot segments `/.` and `/..`.

--- a/src/uri.cr
+++ b/src/uri.cr
@@ -390,7 +390,7 @@ class URI
   # The following normalizations are applied to the individual components (if available):
   #
   # * `scheme` is lowercased.
-  # * `host` is lowercased.
+  # * `host` is lowercased and IPv6 addresses are wrapped with `[]`.
   # * `port` is removed if it is the `.default_port?` of the scheme.
   # * `path` is resolved to a minimal, semantic equivalent representation removing
   #    dot segments `/.` and `/..`.

--- a/src/uri.cr
+++ b/src/uri.cr
@@ -99,7 +99,9 @@ class URI
   getter host : String?
 
   # Sets the host component of the URI.
-  setter host : String?
+  def host=(host : String?)
+    @host = host && !host.starts_with?('[') && host.includes?(':') ? "[#{host}]" : host
+  end
 
   # Returns the port component of the URI.
   #
@@ -177,7 +179,7 @@ class URI
 
   def initialize(@scheme = nil, host : String? = nil, @port = nil, @path = "", query : String | Params | Nil = nil, @user = nil, @password = nil, @fragment = nil)
     # wrap IPv6 addresses
-    @host = host && !host.starts_with?('[') && host.includes?(':') ? "[#{host}]" : host
+    self.host = host
     @query = query.try(&.to_s)
   end
 
@@ -402,10 +404,7 @@ class URI
   # ```
   def normalize! : URI
     @scheme = @scheme.try &.downcase
-    if host = @host
-      host = host.downcase
-      @host = !host.starts_with?('[') && host.includes?(':') ? "[#{host}]" : host
-    end
+    @host = @host.try &.downcase
     @port = nil if default_port?
     @path = remove_dot_segments(path)
 

--- a/src/uri.cr
+++ b/src/uri.cr
@@ -175,7 +175,9 @@ class URI
 
   def_equals_and_hash scheme, host, port, path, query, user, password, fragment
 
-  def initialize(@scheme = nil, @host = nil, @port = nil, @path = "", query : String | Params | Nil = nil, @user = nil, @password = nil, @fragment = nil)
+  def initialize(@scheme = nil, host : String? = nil, @port = nil, @path = "", query : String | Params | Nil = nil, @user = nil, @password = nil, @fragment = nil)
+    # wrap IPv6 addresses
+    @host = host && !host.starts_with?('[') && host.includes?(':') ? "[#{host}]" : host
     @query = query.try(&.to_s)
   end
 

--- a/src/uri.cr
+++ b/src/uri.cr
@@ -177,7 +177,7 @@ class URI
 
   def_equals_and_hash scheme, host, port, path, query, user, password, fragment
 
-  def initialize(@scheme = nil, host : String? = nil, @port = nil, @path = "", query : String | Params | Nil = nil, @user = nil, @password = nil, @fragment = nil)
+  def initialize(@scheme = nil, host = nil, @port = nil, @path = "", query : String | Params | Nil = nil, @user = nil, @password = nil, @fragment = nil)
     # wrap IPv6 addresses
     self.host = host
     @query = query.try(&.to_s)


### PR DESCRIPTION
The square brackets around IPv6 addresses are only required for URIs

We found this issue when migrating a service to run on IPv6 - this change would make the code compatible with either IPv4 or IPv6 without additional logic changes to the service

This ensures a URI initialized with otherwise valid data is a valid URI