### PR TITLE
Fix `UDPSocket` broadcast spec to not use `connect`

### DIFF
--- a/spec/std/socket/udp_socket_spec.cr
+++ b/spec/std/socket/udp_socket_spec.cr
@@ -186,25 +186,31 @@ describe UDPSocket, tags: "network" do
     end
   end
 
-  it "sends broadcast message" do
-    server = UDPSocket.new(Socket::Family::INET)
-    server.bind("0.0.0.0", 0)
-    addr = Socket::IPAddress.new("255.255.255.255", server.local_address.port)
+  {% if flag?(:darwin) %}
+    # Fails since macOS Sequoia (version 15) with EHOSTUNREACH. The ability to
+    # send UDP broadcasts might need extra requirements.
+    pending "sends broadcast message"
+  {% else %}
+    it "sends broadcast message" do
+      server = UDPSocket.new(Socket::Family::INET)
+      server.bind("0.0.0.0", 0)
+      addr = Socket::IPAddress.new("255.255.255.255", server.local_address.port)
 
-    client = UDPSocket.new(Socket::Family::INET)
-    client.broadcast = true
-    client.broadcast?.should be_true
+      client = UDPSocket.new(Socket::Family::INET)
+      client.broadcast = true
+      client.broadcast?.should be_true
 
-    client.send("broadcast", to: addr).should eq(9)
-    client.close
+      client.send("broadcast", to: addr).should eq(9)
+      client.close
 
-    server.read_timeout = 1.second
-    begin
-      message, _ = server.receive
-      message.should eq("broadcast")
-    rescue IO::TimeoutError
-      # Since this test doesn't run over the loopback interface, this test
-      # fails when there is a firewall in use. Don't fail in that case.
+      server.read_timeout = 1.second
+      begin
+        message, _ = server.receive
+        message.should eq("broadcast")
+      rescue IO::TimeoutError
+        # Since this test doesn't run over the loopback interface, this test
+        # fails when there is a firewall in use. Don't fail in that case.
+      end
     end
-  end
+  {% end %}
 end


### PR DESCRIPTION
AFAICT calling `connect` is only required because we bind the server to the loopback interface that won't receive broadcasted messages otherwise. For example on my linux computer the loopback interface doesn't have BROADCAST traffic enabled (no MULTICAST).

We can however start a regular UDP server and a UDP client socket with `SO_BROADCAST`, then call `sendto` to send a message to the broadcast address.

~~Note: it should make the spec more portable.~~ The spec is now portable: it passes on all the BSD targets for example, except for macOS 15, probably for the same reason as #15981.