### PR TITLE
fully exit the process on exit! from repl

### DIFF
--- a/src/compiler/crystal/interpreter/repl.cr
+++ b/src/compiler/crystal/interpreter/repl.cr
@@ -21,6 +21,8 @@ class Crystal::Repl
       case expression
       when "exit"
         break
+      when "exit!"
+        Process.exit(0)
       when .presence
         result = parse_and_interpret(expression)
         result.warnings.report(STDOUT)


### PR DESCRIPTION
Adds a feature similar to [Pry's `!!!`](https://github.com/pry/pry/blob/80816f596774d00afdc81a555724b0819bf26782/lib/pry/commands/exit_program.rb#L25), useful in the case where `debugger` has been put in a loop of some kind. When `exit!` is invoked from the repl, instead of breaking only the local debugger instance, the entire process is exited. I probably would have used `!!!`, but it would have required some changes in the `continue?` logic that I think are a little deeper-reaching than I was willing to go with this.