### PR TITLE
[Bug Fix] Allow wants_docs=true to be used with full semantic processing

### DIFF
--- a/spec/std/record_spec.cr
+++ b/spec/std/record_spec.cr
@@ -1,4 +1,5 @@
 require "spec"
+require "../spec_helper"
 
 private module RecordSpec
   record Record1,
@@ -84,5 +85,18 @@ describe "record" do
 
   it "uses the default values on the ivars" do
     CustomInitializer.new(__id: 10).active.should be_false
+  end
+
+  it "expands record macro with comments during wants_doc=true (#16074)" do
+    ret = semantic(<<-CRYSTAL, wants_doc: true)
+    require "macros"
+    require "object/properties"
+
+    record TestRecord,
+      # This is a comment
+      test : String?
+
+    TestRecord.new("test").test
+    CRYSTAL
   end
 end

--- a/src/macros.cr
+++ b/src/macros.cr
@@ -73,11 +73,11 @@ macro record(__name name, *properties, **kwargs)
   struct {{name.id}}
     {% for property in properties %}
       {% if property.is_a?(Assign) %}
-        getter {{property.target.id}}
+        getter({{property.target.id}})
       {% elsif property.is_a?(TypeDeclaration) %}
-        getter {{property}}
+        getter({{property}})
       {% else %}
-        getter :{{property.id}}
+        getter(:{{property.id}})
       {% end %}
     {% end %}
 


### PR DESCRIPTION
This is another attempt at addressing this bug from https://github.com/crystal-lang/crystal/pull/16074. Previous PR was suffering from perpetual build failures that looked unrelated to my changes, so trying again! Sorry for the PR spam! :sweat_smile: 