### PR TITLE
Add `thread_local` macro

### DIFF
--- a/src/object.cr
+++ b/src/object.cr
@@ -707,4 +707,55 @@ class Object
     ptr.as(Pointer(typeof(crystal_instance_type_id))).value = crystal_instance_type_id
     ptr
   end
+
+  # :nodoc:
+  #
+  # Generates a class getter with a lazy initializer for a thread local
+  # variable.
+  #
+  # Unlike the `ThreadLocal` annotation, the value is guaranteed to always be
+  # reachable by the GC that won't collect it until it's really unreachable. We
+  # achieve that by using the `ThreadLocal` annocation (unreachable by GC) to
+  # speedup direct accesses while still keeping a direct reference on the
+  # current `Thread` object whose lifetime outlives the actual thread.
+  #
+  # For example:
+  #
+  # ```
+  # class Foo
+  #   thread_local(instance : Foo) { Foo.new }
+  # end
+  #
+  # # thread 1:
+  # Foo.instance # => <Foo:0x76a066968000>
+  # Foo.instance # => <Foo:0x76a066968000>
+  #
+  # # thread 2:
+  # Foo.instance # => <Foo:0x76a06116ae30>
+  # ```
+  macro thread_local(decl, &constructor)
+    {% raise "The thread_local macro expects a TypeDeclaration" unless decl.is_a?(TypeDeclaration) %}
+    {% name = decl.var.id %}
+    {% tls_name = "__tls_#{@type.name.gsub(/:/, "_")}__#{name}".id %}
+
+    @[ThreadLocal]
+    @@{{name}} : {{decl.type}} | Nil
+
+    def self.{{name}} : {{decl.type}}
+      {% if flag?(:android) || flag?(:openbsd) || (flag?(:win32) && flag?(:gnu)) %}
+        Thread.current.{{tls_name}} ||= {{yield}}
+      {% else %}
+        if (value = @@{{name}}).nil?
+          Thread.current.{{tls_name}} = @@{{name}} = {{yield}}
+        else
+          value
+        end
+      {% end %}
+    end
+
+    class ::Thread
+      # :nodoc:
+      property {{tls_name}} : {{decl.type}} | Nil
+    end
+  end
 end


### PR DESCRIPTION
After different attempts (#15616, #16029, #16168) that exhibited different issues, I finally came up with a dumb abstraction over the `ThreadLocal` annotation (for quick access) that also injects a reference into `Thread.current` to keep the value visible to the GC (it can't scan `ThreadLocal` values).

For targets where the `ThreadLocal` annotation doesn't work (they could, but that's another issue) we just use the value on `Thread.current`.

It has the same drawback as #16168 in that once a thread local is declared, the ivar will always be declared on `Thread` and the compiler won't optimize them away if they're unused (maybe it could, someday). We don't expect dozens of thread locals so a few wasted pointers shouldn't be an issue.

The macro is mostly useful to avoid repeated boilerplate.

There is no support for destructors. If needed, just use a class with a finalizer. When the Thread is collected the thread local value will also be collected, the finalizer will run, hence acting as a destructor.

Related:
1. drop `Thread::Local(T)`;
2. introduce the unsafe toggle to the annotation from #15889;

See #16174 and #16175 for use cases (PCRE2, default Random).