### PR TITLE
Support `llvm::TargetOptions::EmulatedTLS`

### DIFF
--- a/.github/workflows/mingw-w64.yml
+++ b/.github/workflows/mingw-w64.yml
@@ -24,6 +24,8 @@ jobs:
   aarch64-mingw-w64:
     name: CLANGARM64
     uses: ./.github/workflows/mingw-w64-steps.yml
+    env:
+      CXX: clang++
     with:
       arch: aarch64
       runs-on: windows-11-arm

--- a/.github/workflows/mingw-w64.yml
+++ b/.github/workflows/mingw-w64.yml
@@ -24,8 +24,6 @@ jobs:
   aarch64-mingw-w64:
     name: CLANGARM64
     uses: ./.github/workflows/mingw-w64-steps.yml
-    env:
-      CXX: clang++
     with:
       arch: aarch64
       runs-on: windows-11-arm

--- a/Makefile
+++ b/Makefile
@@ -97,11 +97,11 @@ else
 endif
 
 DEPS = $(LLVM_EXT_OBJ)
-ifneq ($(LLVM_VERSION),)
-  ifeq ($(shell test $(firstword $(subst ., ,$(LLVM_VERSION))) -ge 18; echo $$?),0)
-    DEPS =
-  endif
-endif
+# ifneq ($(LLVM_VERSION),)
+#   ifeq ($(shell test $(firstword $(subst ., ,$(LLVM_VERSION))) -ge 18; echo $$?),0)
+#     DEPS =
+#   endif
+# endif
 
 check_llvm_config = $(eval \
 	check_llvm_config := $(if $(LLVM_VERSION),\

--- a/Makefile.win
+++ b/Makefile.win
@@ -85,11 +85,11 @@ DATADIR ?= $(prefix)
 colorize = $(info $1)
 
 DEPS = $(LLVM_EXT_OBJ)
-ifneq ($(LLVM_VERSION),)
-  ifeq ($(shell if $(firstword $(subst ., ,$(LLVM_VERSION))) GEQ 18 echo 0),0)
-    DEPS =
-  endif
-endif
+# ifneq ($(LLVM_VERSION),)
+#   ifeq ($(shell if $(firstword $(subst ., ,$(LLVM_VERSION))) GEQ 18 echo 0),0)
+#     DEPS =
+#   endif
+# endif
 
 check_llvm_config = $(eval \
 	check_llvm_config := $(if $(LLVM_VERSION),\

--- a/src/llvm/ext/llvm_ext.cc
+++ b/src/llvm/ext/llvm_ext.cc
@@ -173,7 +173,11 @@ LLVMTargetMachineRef LLVMExtCreateTargetMachine(
     if (EmulatedTLS) {
         TO.EmulatedTLS = true;
     }
+#if LLVM_VERSION_GE(21, 0)
+    return wrap(unwrap(T)->createTargetMachine(llvm::Triple(TripleStr), CPU, Features, TO, RM, CM, OL, JIT));
+#else
     return wrap(unwrap(T)->createTargetMachine(TripleStr, CPU, Features, TO, RM, CM, OL, JIT));
+#endif
 }
 
 } // extern "C"

--- a/src/llvm/ext/llvm_ext.cc
+++ b/src/llvm/ext/llvm_ext.cc
@@ -1,6 +1,10 @@
 #include <llvm/Config/llvm-config.h>
 #include <llvm/IR/IRBuilder.h>
+#include "llvm/MC/TargetRegistry.h"
 #include <llvm/Target/TargetMachine.h>
+#include <llvm/Target/TargetOptions.h>
+#include <llvm/Target/CodeGenCWrappers.h>
+#include <llvm-c/Target.h>
 #include <llvm-c/TargetMachine.h>
 
 using namespace llvm;
@@ -20,6 +24,20 @@ using namespace llvm;
 typedef struct LLVMOpaqueOperandBundle *LLVMOperandBundleRef;
 DEFINE_SIMPLE_CONVERSION_FUNCTIONS(OperandBundleDef, LLVMOperandBundleRef)
 #endif
+
+// conversions taken from llvm/lib/Target/TargetMachineC.cpp
+static TargetMachine *unwrap(LLVMTargetMachineRef P) {
+  return reinterpret_cast<TargetMachine *>(P);
+}
+static Target *unwrap(LLVMTargetRef P) {
+  return reinterpret_cast<Target*>(P);
+}
+static LLVMTargetMachineRef wrap(const TargetMachine *P) {
+  return reinterpret_cast<LLVMTargetMachineRef>(const_cast<TargetMachine *>(P));
+}
+static LLVMTargetRef wrap(const Target * P) {
+  return reinterpret_cast<LLVMTargetRef>(const_cast<Target*>(P));
+}
 
 extern "C" {
 
@@ -80,13 +98,72 @@ LLVMValueRef LLVMExtBuildInvokeWithOperandBundles(
 #endif
 
 #if !LLVM_VERSION_GE(18, 0)
-static TargetMachine *unwrap(LLVMTargetMachineRef P) {
-  return reinterpret_cast<TargetMachine *>(P);
-}
-
 void LLVMExtSetTargetMachineGlobalISel(LLVMTargetMachineRef T, LLVMBool Enable) {
   unwrap(T)->setGlobalISel(Enable);
 }
 #endif
+
+LLVMTargetMachineRef LLVMExtCreateTargetMachine(
+    LLVMTargetRef T,
+    const char *TripleStr,
+    const char *CPU,
+    const char *Features,
+    LLVMCodeGenOptLevel Level,
+    LLVMRelocMode Reloc,
+    LLVMCodeModel CodeModel,
+    int EmulatedTLS)
+{
+    // LLVMTargetMachineOptionsSetCodeGenOptLevel()
+    CodeGenOptLevel OL;
+    switch (Level) {
+        case LLVMCodeGenLevelNone:
+            OL = CodeGenOptLevel::None;
+            break;
+        case LLVMCodeGenLevelLess:
+            OL = CodeGenOptLevel::Less;
+            break;
+        case LLVMCodeGenLevelAggressive:
+            OL = CodeGenOptLevel::Aggressive;
+            break;
+        default:
+            OL = CodeGenOptLevel::Default;
+            break;
+    }
+
+    // LLVMTargetMachineOptionsSetRelocModel()
+    std::optional<Reloc::Model> RM;
+    switch (Reloc){
+        case LLVMRelocStatic:
+            RM = Reloc::Static;
+            break;
+        case LLVMRelocPIC:
+            RM = Reloc::PIC_;
+            break;
+        case LLVMRelocDynamicNoPic:
+            RM = Reloc::DynamicNoPIC;
+            break;
+        case LLVMRelocROPI:
+            RM = Reloc::ROPI;
+            break;
+        case LLVMRelocRWPI:
+            RM = Reloc::RWPI;
+            break;
+        case LLVMRelocROPI_RWPI:
+            RM = Reloc::ROPI_RWPI;
+            break;
+        case LLVMRelocDefault:
+            break;
+    }
+
+    // LLVMTargetMachineOptionsSetCodeModel()
+    bool JIT;
+    auto CM = unwrap(CodeModel, JIT);
+
+    TargetOptions TO;
+    if (EmulatedTLS) {
+        TO.EmulatedTLS = true;
+    }
+    return wrap(unwrap(T)->createTargetMachine(TripleStr, CPU, Features, TO, RM, CM, OL, JIT));
+}
 
 } // extern "C"

--- a/src/llvm/ext/llvm_ext.cc
+++ b/src/llvm/ext/llvm_ext.cc
@@ -1,6 +1,5 @@
 #include <llvm/Config/llvm-config.h>
 #include <llvm/IR/IRBuilder.h>
-#include "llvm/MC/TargetRegistry.h"
 #include <llvm/Target/TargetMachine.h>
 #include <llvm/Target/TargetOptions.h>
 #include <llvm/Target/CodeGenCWrappers.h>
@@ -16,11 +15,18 @@ using namespace llvm;
 #include <llvm/IR/DIBuilder.h>
 #endif
 
+#if LLVM_VERSION_GE(14, 0)
+#include "llvm/MC/TargetRegistry.h"
+#else
+#include "llvm/Support/TargetRegistry.h"
+#endif
+
 #if LLVM_VERSION_GE(16, 0)
 #define makeArrayRef ArrayRef
 #endif
 
 #if !LLVM_VERSION_GE(18, 0)
+#define CodeGenOptLevel CodeGenOpt::Level
 typedef struct LLVMOpaqueOperandBundle *LLVMOperandBundleRef;
 DEFINE_SIMPLE_CONVERSION_FUNCTIONS(OperandBundleDef, LLVMOperandBundleRef)
 #endif
@@ -131,7 +137,11 @@ LLVMTargetMachineRef LLVMExtCreateTargetMachine(
     }
 
     // LLVMTargetMachineOptionsSetRelocModel()
+#if LLVM_VERSION_GE(16, 0)
     std::optional<Reloc::Model> RM;
+#else
+    Optional<Reloc::Model> RM;
+#endif
     switch (Reloc){
         case LLVMRelocStatic:
             RM = Reloc::Static;

--- a/src/llvm/lib_llvm_ext.cr
+++ b/src/llvm/lib_llvm_ext.cr
@@ -33,4 +33,6 @@ lib LibLLVMExt
                                                                                name : Char*) : LibLLVM::ValueRef
 
   fun set_target_machine_global_isel = LLVMExtSetTargetMachineGlobalISel(t : LibLLVM::TargetMachineRef, enable : LibLLVM::Bool)
+
+  fun create_target_machine = LLVMExtCreateTargetMachine(t : LibLLVM::TargetRef, triple : Char*, cpu : Char*, features : Char*, level : LLVM::CodeGenOptLevel, reloc : LLVM::RelocMode, code_model : LLVM::CodeModel, emulated_tls : Int) : LibLLVM::TargetMachineRef
 end

--- a/src/llvm/target.cr
+++ b/src/llvm/target.cr
@@ -36,8 +36,9 @@ struct LLVM::Target
   def create_target_machine(triple, cpu = "", features = "",
                             opt_level = LLVM::CodeGenOptLevel::Default,
                             reloc = LLVM::RelocMode::PIC,
-                            code_model = LLVM::CodeModel::Default) : LLVM::TargetMachine
-    target_machine = LibLLVM.create_target_machine(self, triple, cpu, features, opt_level, reloc, code_model)
+                            code_model = LLVM::CodeModel::Default,
+                            emulated_tls = false) : LLVM::TargetMachine
+    target_machine = LibLLVMExt.create_target_machine(self, triple, cpu, features, opt_level, reloc, code_model, emulated_tls ? 1 : 0)
     target_machine ? TargetMachine.new(target_machine) : raise "Couldn't create target machine"
   end
 


### PR DESCRIPTION
Adds support for the `llvm::TargetOptions::EmulatedTLS` setting that is only available through the C++ API. This patch implements a custom alternative to `LLVMCreateTargetMachine` which requires to always compile `src/llvm/llvm_ext.o` again :disappointed:

Emulated TLS is now always set for Android, OpenBSD and MinGW, which should in turn make the `@[ThreadLocal]` annotation portable :crossed_fingers:

TODO:

- [x] compilation with different LLVM versions
- [ ] CI: MinGW/UCRT64
- [ ] CI: MinGW/CLANGARM64

Closes #16176.