### PR TITLE
Fix internal error if multi-assign RHS has splats

### DIFF
--- a/spec/compiler/parser/parser_spec.cr
+++ b/spec/compiler/parser/parser_spec.cr
@@ -289,6 +289,16 @@ module Crystal
     assert_syntax_error "*a, b, c, d, e = 1, 2", "Multiple assignment count mismatch"
     assert_syntax_error "a, b, c, d, *e = 1, 2, 3", "Multiple assignment count mismatch"
 
+    assert_syntax_error "a = *1", %(unexpected token: "*")
+    assert_syntax_error "a = *1, 2", %(unexpected token: "*")
+    assert_syntax_error "a = 1, *2", %(unexpected token: "*")
+    assert_syntax_error "a, b = *1", %(unexpected token: "*")
+    assert_syntax_error "a, b = *1, 2", %(unexpected token: "*")
+    assert_syntax_error "a, b = 1, *2", %(unexpected token: "*")
+    assert_syntax_error "a, *b = *1", %(unexpected token: "*")
+    assert_syntax_error "a, *b = *1, 2", %(unexpected token: "*")
+    assert_syntax_error "a, *b = 1, *2", %(unexpected token: "*")
+
     # #11442, #12911
     assert_syntax_error "a, b.<="
     assert_syntax_error "*a == 1"

--- a/src/compiler/crystal/syntax/parser.cr
+++ b/src/compiler/crystal/syntax/parser.cr
@@ -177,8 +177,12 @@ module Crystal
 
         next_token_skip_space_or_newline
         if @token.type.op_star?
-          raise "splat assignment already specified" if lhs_splat
-          lhs_splat = {index: i, location: @token.location}
+          if assign_index == -1
+            raise "splat assignment already specified" if lhs_splat
+            lhs_splat = {index: i, location: @token.location}
+          else
+            unexpected_token
+          end
           next_token_skip_space
         end
 


### PR DESCRIPTION
Fixes #16180.

They were never supported in the first place, but became internal errors ever since the left-hand side supported splats. (Ruby supports this, so `a, *b = *[1, 2], 3; b` evaluates to `[2, 3]` there.)