### PR TITLE
Pass `fd` implicitly to `System::File` and `System::Socket` [fixup #16137]

### DIFF
--- a/src/crystal/system/socket.cr
+++ b/src/crystal/system/socket.cr
@@ -14,6 +14,10 @@ module Crystal::System::Socket
 
   # private def system_listen(backlog)
 
+  private def system_accept : {Handle, Bool}?
+    event_loop.accept(self)
+  end
+
   private def system_send_to(bytes : Bytes, addr : ::Socket::Address)
     event_loop.send_to(self, bytes, addr)
   end

--- a/src/crystal/system/unix/file.cr
+++ b/src/crystal/system/unix/file.cr
@@ -108,9 +108,9 @@ module Crystal::System::File
     raise ::File::Error.from_errno("Error changing owner", file: path) if ret == -1
   end
 
-  def self.fchown(path, fd, uid : Int, gid : Int)
+  private def system_chown(uid : Int, gid : Int)
     ret = LibC.fchown(fd, uid, gid)
-    raise ::File::Error.from_errno("Error changing owner", file: path) if ret == -1
+    raise ::File::Error.from_errno("Error changing owner", file: @path) if ret == -1
   end
 
   def self.chmod(path, mode)

--- a/src/crystal/system/unix/file.cr
+++ b/src/crystal/system/unix/file.cr
@@ -110,7 +110,7 @@ module Crystal::System::File
 
   private def system_chown(uid : Int, gid : Int)
     ret = LibC.fchown(fd, uid, gid)
-    raise ::File::Error.from_errno("Error changing owner", file: @path) if ret == -1
+    raise ::File::Error.from_errno("Error changing owner", file: path) if ret == -1
   end
 
   def self.chmod(path, mode)

--- a/src/crystal/system/unix/file.cr
+++ b/src/crystal/system/unix/file.cr
@@ -119,7 +119,7 @@ module Crystal::System::File
     end
   end
 
-  private def system_chmod(path, mode)
+  private def system_chmod(mode)
     if LibC.fchmod(fd, mode) == -1
       raise ::File::Error.from_errno("Error changing permissions", file: path)
     end
@@ -196,7 +196,7 @@ module Crystal::System::File
     end
   end
 
-  private def system_utime(atime : ::Time, mtime : ::Time, filename : String) : Nil
+  private def system_utime(atime : ::Time, mtime : ::Time) : Nil
     ret = {% if LibC.has_method?("futimens") %}
             timespecs = uninitialized LibC::Timespec[2]
             timespecs[0] = Crystal::System::Time.to_timespec(atime)
@@ -212,7 +212,7 @@ module Crystal::System::File
           {% end %}
 
     if ret != 0
-      raise ::File::Error.from_errno("Error setting time on file", file: filename)
+      raise ::File::Error.from_errno("Error setting time on file", file: path)
     end
   end
 

--- a/src/crystal/system/unix/socket.cr
+++ b/src/crystal/system/unix/socket.cr
@@ -47,6 +47,10 @@ module Crystal::System::Socket
     end
   end
 
+  private def system_accept : {Handle, Bool}?
+    event_loop.accept(self)
+  end
+
   private def system_close_read
     if LibC.shutdown(fd, LibC::SHUT_RD) != 0
       raise ::Socket::Error.from_errno("shutdown read")

--- a/src/crystal/system/wasi/file.cr
+++ b/src/crystal/system/wasi/file.cr
@@ -13,6 +13,10 @@ module Crystal::System::File
     raise NotImplementedError.new "Crystal::System::File.chown"
   end
 
+  private def system_chown(uid : Int, gid : Int)
+    raise NotImplementedError.new "Crystal::System::File#system_chown"
+  end
+
   def self.realpath(path)
     raise NotImplementedError.new "Crystal::System::File.realpath"
   end

--- a/src/crystal/system/wasi/socket.cr
+++ b/src/crystal/system/wasi/socket.cr
@@ -21,6 +21,10 @@ module Crystal::System::Socket
     raise NotImplementedError.new "Crystal::System::Socket#system_listen"
   end
 
+  private def system_accept : {Handle, Bool}?
+    raise NotImplementedError.new "Crystal::System::Socket#system_accept"
+  end
+
   private def system_close_read
     if LibC.shutdown(fd, LibC::SHUT_RD) != 0
       raise ::Socket::Error.from_errno("shutdown read")

--- a/src/crystal/system/win32/file.cr
+++ b/src/crystal/system/win32/file.cr
@@ -222,7 +222,7 @@ module Crystal::System::File
     raise NotImplementedError.new("File.chown")
   end
 
-  def self.fchown(path : String, fd : Int, uid : Int32, gid : Int32) : Nil
+  private def system_chown(uid : Int, gid : Int) : Nil
     raise NotImplementedError.new("File#chown")
   end
 

--- a/src/crystal/system/win32/file.cr
+++ b/src/crystal/system/win32/file.cr
@@ -253,7 +253,7 @@ module Crystal::System::File
     end
   end
 
-  private def system_chmod(path : String, mode : Int32 | ::File::Permissions) : Nil
+  private def system_chmod(mode : Int32 | ::File::Permissions) : Nil
     mode = ::File::Permissions.new(mode) unless mode.is_a? ::File::Permissions
     handle = windows_handle
 
@@ -475,7 +475,7 @@ module Crystal::System::File
     end
   end
 
-  private def system_utime(access_time : ::Time, modification_time : ::Time, path : String) : Nil
+  private def system_utime(access_time : ::Time, modification_time : ::Time) : Nil
     Crystal::System::File.utime(windows_handle, access_time, modification_time, path)
   end
 

--- a/src/crystal/system/win32/socket.cr
+++ b/src/crystal/system/win32/socket.cr
@@ -180,6 +180,10 @@ module Crystal::System::Socket
     end
   end
 
+  private def system_accept : {Handle, Bool}?
+    event_loop.accept(self)
+  end
+
   def system_accept(& : Handle -> Bool) : {Handle, Bool}?
     client_socket, blocking = Crystal::EventLoop.current.socket(family, type, protocol, nil)
     initialize_handle(client_socket)

--- a/src/file.cr
+++ b/src/file.cr
@@ -791,12 +791,12 @@ class File < IO::FileDescriptor
   # file.info.permissions.value # => 0o700
   # ```
   def chmod(permissions : Int | Permissions) : Nil
-    system_chmod(@path, permissions)
+    system_chmod(permissions)
   end
 
   # Sets the access and modification times
   def utime(atime : Time, mtime : Time) : Nil
-    system_utime(atime, mtime, @path)
+    system_utime(atime, mtime)
   end
 
   # Attempts to set the access and modification times

--- a/src/file.cr
+++ b/src/file.cr
@@ -778,7 +778,7 @@ class File < IO::FileDescriptor
   # file.chown(gid: 100)
   # ```
   def chown(uid : Int = -1, gid : Int = -1) : Nil
-    Crystal::System::File.fchown(@path, fd, uid, gid)
+    system_chown(uid, gid)
   end
 
   # Changes the permissions of the specified file.

--- a/src/socket.cr
+++ b/src/socket.cr
@@ -244,7 +244,7 @@ class Socket < IO
   # end
   # ```
   def accept? : Socket?
-    if rs = Crystal::EventLoop.current.accept(self)
+    if rs = system_accept
       sock = Socket.new(handle: rs[0], family: family, type: type, protocol: protocol, blocking: rs[1])
       unless (blocking = system_blocking?) == rs[1]
         # FIXME: unlike the overloads in TCPServer and UNIXServer, this version

--- a/src/socket/tcp_server.cr
+++ b/src/socket/tcp_server.cr
@@ -115,7 +115,7 @@ class TCPServer < TCPSocket
   # end
   # ```
   def accept? : TCPSocket?
-    if rs = Crystal::EventLoop.current.accept(self)
+    if rs = system_accept
       sock = TCPSocket.new(handle: rs[0], family: family, type: type, protocol: protocol, blocking: rs[1])
       sock.sync = sync?
       sock

--- a/src/socket/unix_server.cr
+++ b/src/socket/unix_server.cr
@@ -84,7 +84,7 @@ class UNIXServer < UNIXSocket
   # Returns the client socket or `nil` if the server is closed after invoking
   # this method.
   def accept? : UNIXSocket?
-    if rs = Crystal::EventLoop.current.accept(self)
+    if rs = system_accept
       sock = UNIXSocket.new(handle: rs[0], type: type, path: @path, blocking: rs[1])
       sock.sync = sync?
       sock


### PR DESCRIPTION
I missed a couple cases in #16137 in preparation of #16127 where we need a system indirection around the `fd`, so #16128 will be able to count a reference:

- `Crystal::System::File#system_chown`
- `Crystal::System::Socket#system_accept`

Note that by itself the change has no impact or interest.