### PR TITLE
Support deserialization of YAML anchors of value types

### DIFF
--- a/spec/std/yaml/serializable_spec.cr
+++ b/spec/std/yaml/serializable_spec.cr
@@ -514,6 +514,14 @@ describe "YAML::Serializable" do
     YAMLAttrPoint.from_yaml("---\nx: 1\ny: 2\n").should eq YAMLAttrPoint.new(1, 2)
   end
 
+  it "works with anchors of value types" do
+    YAMLAttrPoint.from_yaml(<<-YAML).should eq YAMLAttrPoint.new(123, 123)
+      ---
+      x: &foo 123
+      y: *foo
+      YAML
+  end
+
   it "empty class" do
     e = YAMLAttrEmptyClass.new
     e.to_yaml.should eq "--- {}\n"

--- a/spec/std/yaml/serialization_spec.cr
+++ b/spec/std/yaml/serialization_spec.cr
@@ -138,6 +138,14 @@ describe "YAML serialization" do
       Hash(Int32, Bool).from_yaml("---\n1: true\n2: false\n").should eq({1 => true, 2 => false})
     end
 
+    it "does Hash#from_yaml with value type anchors" do
+      Hash(String, Int32).from_yaml(<<-YAML).should eq({"x" => 123, "y" => 123})
+        ---
+        x: &foo 123
+        y: *foo
+        YAML
+    end
+
     it "does Hash#from_yaml with merge" do
       yaml = <<-YAML
         - &foo


### PR DESCRIPTION
Resolves #13830. All objects are now boxed so that they can be stored into the parse context uniformly.

This does not affect how the GC sees `YAML::ParseContext#@anchors`; since the hash's key type is `String`, `Hash::Entry(String, T)` is always non-atomic, thus the switch from `UInt64` to `Void*` makes no differences. (In fact `Void*` is probably more correct here.)

`YAML.parse` already handles anchors regardless of their types, since they are all `YAML::Any`s; `YAML::Nodes.parse` returns a document and never resolves aliases. These methods are not affected in this patch.