### PR TITLE
Add end locations to scalars and aliases in `YAML::Nodes.parse`

### DIFF
--- a/spec/std/yaml/nodes/parser_spec.cr
+++ b/spec/std/yaml/nodes/parser_spec.cr
@@ -1,0 +1,38 @@
+require "yaml"
+require "spec"
+
+describe YAML::Nodes do
+  describe ".parse" do
+    it "attaches location to scalar nodes" do
+      doc = YAML::Nodes.parse %(1)
+      node = doc.nodes[0]
+      node.location.should eq({1, 1})
+      node.end_line.should eq(1)
+      node.end_column.should eq(2)
+    end
+
+    it "attaches location to sequence nodes" do
+      doc = YAML::Nodes.parse %([1])
+      node = doc.nodes[0]
+      node.location.should eq({1, 1})
+      node.end_line.should eq(1)
+      node.end_column.should eq(4)
+    end
+
+    it "attaches location to mapping nodes" do
+      doc = YAML::Nodes.parse %({"a":1})
+      node = doc.nodes[0]
+      node.location.should eq({1, 1})
+      node.end_line.should eq(1)
+      node.end_column.should eq(8)
+    end
+
+    it "attaches location to alias nodes" do
+      doc = YAML::Nodes.parse %([&a 1, *a])
+      node = doc.nodes[0].as(YAML::Nodes::Sequence).nodes[1]
+      node.location.should eq({1, 8})
+      node.end_line.should eq(1)
+      node.end_column.should eq(10)
+    end
+  end
+end

--- a/src/yaml/parser.cr
+++ b/src/yaml/parser.cr
@@ -102,12 +102,14 @@ abstract class YAML::Parser
 
   protected def parse_scalar
     value = anchor(@pull_parser.anchor, new_scalar)
+    end_value(value)
     @pull_parser.read_next
     value
   end
 
   protected def parse_alias
     value = get_anchor(@pull_parser.anchor.not_nil!)
+    end_value(value)
     @pull_parser.read_next
     value
   end


### PR DESCRIPTION
Currently they are only added for sequence and mapping nodes.