### PR TITLE
Update library versions for MSVC CI

### DIFF
--- a/.github/workflows/win.yml
+++ b/.github/workflows/win.yml
@@ -10,7 +10,7 @@ concurrency:
 
 env:
   SPEC_SPLIT_DOTS: 160
-  CI_LLVM_VERSION: "20.1.7"
+  CI_LLVM_VERSION: "21.1.3"
   CI_LLVM_TARGETS: "X86,AArch64"
   CI_LLVM_LDFLAGS: "psapi.lib shell32.lib ole32.lib uuid.lib advapi32.lib ws2_32.lib ntdll.lib"
 
@@ -59,13 +59,13 @@ jobs:
         run: .\etc\win-ci\build-pcre.ps1 -BuildTree deps\pcre -Version 8.45
       - name: Build libpcre2
         if: steps.cache-libs.outputs.cache-hit != 'true'
-        run: .\etc\win-ci\build-pcre2.ps1 -BuildTree deps\pcre2 -Version 10.45
+        run: .\etc\win-ci\build-pcre2.ps1 -BuildTree deps\pcre2 -Version 10.46
       - name: Build libiconv
         if: steps.cache-libs.outputs.cache-hit != 'true'
         run: .\etc\win-ci\build-iconv.ps1 -BuildTree deps\iconv -Version 1.18
       - name: Build libffi
         if: steps.cache-libs.outputs.cache-hit != 'true'
-        run: .\etc\win-ci\build-ffi.ps1 -BuildTree deps\ffi -Version 3.5.1
+        run: .\etc\win-ci\build-ffi.ps1 -BuildTree deps\ffi -Version 3.5.2
       - name: Build zlib
         if: steps.cache-libs.outputs.cache-hit != 'true'
         run: .\etc\win-ci\build-z.ps1 -BuildTree deps\z -Version 1.3.1
@@ -77,7 +77,7 @@ jobs:
         run: .\etc\win-ci\build-yaml.ps1 -BuildTree deps\yaml -Version 0.2.5
       - name: Build libxml2
         if: steps.cache-libs.outputs.cache-hit != 'true'
-        run: .\etc\win-ci\build-xml2.ps1 -BuildTree deps\xml2 -Version 2.13.8
+        run: .\etc\win-ci\build-xml2.ps1 -BuildTree deps\xml2 -Version 2.15.0
 
       - name: Cache OpenSSL
         id: cache-openssl
@@ -87,13 +87,13 @@ jobs:
             libs/crypto.lib
             libs/ssl.lib
             libs/openssl_VERSION
-          key: win-openssl-libs-3.4.1-${{ hashFiles('etc/win-ci/build-openssl.ps1') }}-msvc
+          key: win-openssl-libs-3.6.0-${{ hashFiles('etc/win-ci/build-openssl.ps1') }}-msvc
       - name: Set up NASM
         if: steps.cache-openssl.outputs.cache-hit != 'true'
         uses: ilammy/setup-nasm@72793074d3c8cdda771dba85f6deafe00623038b # v1.5.2
       - name: Build OpenSSL
         if: steps.cache-openssl.outputs.cache-hit != 'true'
-        run: .\etc\win-ci\build-openssl.ps1 -BuildTree deps\openssl -Version 3.5.0
+        run: .\etc\win-ci\build-openssl.ps1 -BuildTree deps\openssl -Version 3.6.0
 
   x86_64-windows-dlls:
     runs-on: windows-2025
@@ -147,13 +147,13 @@ jobs:
         run: .\etc\win-ci\build-pcre.ps1 -BuildTree deps\pcre -Version 8.45 -Dynamic
       - name: Build libpcre2
         if: steps.cache-dlls.outputs.cache-hit != 'true'
-        run: .\etc\win-ci\build-pcre2.ps1 -BuildTree deps\pcre2 -Version 10.45 -Dynamic
+        run: .\etc\win-ci\build-pcre2.ps1 -BuildTree deps\pcre2 -Version 10.46 -Dynamic
       - name: Build libiconv
         if: steps.cache-dlls.outputs.cache-hit != 'true'
         run: .\etc\win-ci\build-iconv.ps1 -BuildTree deps\iconv -Version 1.18 -Dynamic
       - name: Build libffi
         if: steps.cache-dlls.outputs.cache-hit != 'true'
-        run: .\etc\win-ci\build-ffi.ps1 -BuildTree deps\ffi -Version 3.4.7 -Dynamic
+        run: .\etc\win-ci\build-ffi.ps1 -BuildTree deps\ffi -Version 3.5.2 -Dynamic
       - name: Build zlib
         if: steps.cache-dlls.outputs.cache-hit != 'true'
         run: .\etc\win-ci\build-z.ps1 -BuildTree deps\z -Version 1.3.1 -Dynamic
@@ -165,7 +165,7 @@ jobs:
         run: .\etc\win-ci\build-yaml.ps1 -BuildTree deps\yaml -Version 0.2.5 -Dynamic
       - name: Build libxml2
         if: steps.cache-dlls.outputs.cache-hit != 'true'
-        run: .\etc\win-ci\build-xml2.ps1 -BuildTree deps\xml2 -Version 2.13.6 -Dynamic
+        run: .\etc\win-ci\build-xml2.ps1 -BuildTree deps\xml2 -Version 2.15.0 -Dynamic
 
       - name: Cache OpenSSL
         id: cache-openssl-dlls
@@ -176,13 +176,13 @@ jobs:
             libs/ssl-dynamic.lib
             dlls/libcrypto-3-x64.dll
             dlls/libssl-3-x64.dll
-          key: win-openssl-dlls-3.4.1-${{ hashFiles('etc/win-ci/build-openssl.ps1') }}-msvc
+          key: win-openssl-dlls-3.6.0-${{ hashFiles('etc/win-ci/build-openssl.ps1') }}-msvc
       - name: Set up NASM
         if: steps.cache-openssl-dlls.outputs.cache-hit != 'true'
         uses: ilammy/setup-nasm@72793074d3c8cdda771dba85f6deafe00623038b # v1.5.2
       - name: Build OpenSSL
         if: steps.cache-openssl-dlls.outputs.cache-hit != 'true'
-        run: .\etc\win-ci\build-openssl.ps1 -BuildTree deps\openssl -Version 3.4.1 -Dynamic
+        run: .\etc\win-ci\build-openssl.ps1 -BuildTree deps\openssl -Version 3.6.0 -Dynamic
 
   x86_64-windows-llvm-dlls:
     runs-on: windows-2025
@@ -215,7 +215,7 @@ jobs:
     uses: ./.github/workflows/win_build_portable.yml
     with:
       release: true
-      llvm_version: "20.1.7"
+      llvm_version: "21.1.3"
       llvm_targets: "X86,AArch64"
       llvm_ldflags: "psapi.lib shell32.lib ole32.lib uuid.lib advapi32.lib ws2_32.lib ntdll.lib"
 


### PR DESCRIPTION
Updates the following libraries:

* PCRE2: 10.45 -> 10.46
* libffi: 3.5.1 -> 3.5.2
* libxml2: 2.13.6 -> 2.15.0
* OpenSSL: 3.5.0 -> 3.6.0
* LLVM: 20.1.7 -> 21.1.3

Depends on crystal-lang/libffi#3

(note to self: static and dynamic library versions should always be in sync)