### PR TITLE
Fix underscore and dash counter in `Enum.parse?` [fixup #15927]

### DIFF
--- a/spec/std/enum_spec.cr
+++ b/spec/std/enum_spec.cr
@@ -316,6 +316,8 @@ describe Enum do
     SpecEnum.parse("TWO").should eq(SpecEnum::Two)
     SpecEnum.parse("TwO").should eq(SpecEnum::Two)
     SpecEnum2.parse("FORTY_TWO").should eq(SpecEnum2::FortyTwo)
+    SpecEnum2.parse("FORTY___TWO").should eq(SpecEnum2::FortyTwo)
+    SpecEnum2.parse("FORTY___TWO_").should eq(SpecEnum2::FortyTwo)
 
     SpecEnum2.parse("FORTY_FOUR").should eq(SpecEnum2::FORTY_FOUR)
     SpecEnum2.parse("forty_four").should eq(SpecEnum2::FORTY_FOUR)

--- a/src/enum.cr
+++ b/src/enum.cr
@@ -520,9 +520,11 @@ abstract struct Enum
       {% max_size = @type.constants.map(&.size).sort.last %}
       buffer = uninitialized UInt8[{{ max_size * 4 + 1 }}]
       appender = buffer.to_unsafe.appender
-      string.each_char_with_index do |char, index|
-        return nil if index > {{max_size}}
+      char_counter = 0
+      string.each_char do |char|
         next if char == '-' || char == '_'
+        char_counter += 1
+        return nil if char_counter > {{max_size}}
         char.downcase &.each_byte do |byte|
           appender << byte
         end


### PR DESCRIPTION
The algorithm already skips `_` and `-`, but they were counted in the overall string length and thus would trigger the early return condition.

Resolves #16189