### PR TITLE
CI: Update deprecated `macos-13` to `macos-15-intel`

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -19,7 +19,7 @@ jobs:
     strategy:
       matrix:
         include:
-        - runs-on: macos-13
+        - runs-on: macos-15-intel
           arch: x86_64-darwin
         - runs-on: macos-14
           arch: aarch64-darwin


### PR DESCRIPTION
Ref https://github.com/crystal-lang/distribution-scripts/issues/371