### PR TITLE
[CI] Update xcode to 26.0.1 on circleci

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -81,7 +81,7 @@ jobs:
 
   test_darwin:
     macos:
-      xcode: 15.4.0
+      xcode: 26.0.1
     environment:
       <<: *env
       TRAVIS_OS_NAME: osx
@@ -285,7 +285,7 @@ jobs:
 
   dist_darwin:
     macos:
-      xcode: 15.3.0
+      xcode: 26.0.1
     shell: /bin/bash --login -eo pipefail
     steps:
       - restore_cache:


### PR DESCRIPTION
xcode 15.3 is deprecated: https://circleci.com/changelog/deprecation-of-eol-xcode-versions/

I'm taking the chance to upgrade to the newest version available.

No idea why the two jobs were using different versions 🤷 