### PR TITLE
Fix: `TupleLiteral#*` [fixup #16154]

### DIFF
--- a/spec/compiler/macro/macro_methods_spec.cr
+++ b/spec/compiler/macro/macro_methods_spec.cr
@@ -1545,6 +1545,10 @@ module Crystal
           end
         end
       end
+
+      it "executes *" do
+        assert_macro %({{ {"na"} * 5}}), %({"na", "na", "na", "na", "na"})
+      end
     end
 
     describe "regex methods" do

--- a/src/compiler/crystal/macros.cr
+++ b/src/compiler/crystal/macros.cr
@@ -1123,6 +1123,10 @@ module Crystal::Macros
     # Similar to `Array#-`.
     def -(other : TupleLiteral) : TupleLiteral
     end
+
+    # Similar to `Tuple#*`
+    def *(other : NumberLiteral) : TupleLiteral
+    end
   end
 
   # A fictitious node representing a variable or instance

--- a/src/compiler/crystal/macros/methods.cr
+++ b/src/compiler/crystal/macros/methods.cr
@@ -702,7 +702,7 @@ module Crystal
           num = arg.to_number
 
           unless num.is_a?(Int)
-            arg.raise "argument to StringLiteral#* cannot be a float"
+            arg.raise "argument to StringLiteral#* must be an integer"
           end
 
           StringLiteral.new(@value * num)
@@ -3188,13 +3188,13 @@ private def interpret_array_or_tuple_method(object, klass, method, args, named_a
   when "*"
     interpret_check_args(node: object) do |arg|
       unless arg.is_a?(Crystal::NumberLiteral)
-        arg.raise "argument to ArrayLiteral#* must be a number, not #{arg.class_desc}"
+        arg.raise "argument to `#{klass}#*` must be a number, not #{arg.class_desc}"
       end
 
       num = arg.to_number
 
       unless num.is_a?(Int)
-        arg.raise "argument to ArrayLiteral#* cannot be a float"
+        arg.raise "argument to `#{klass}#*` must be an integer"
       end
 
       klass.new(object.elements * num)


### PR DESCRIPTION
As reported by @Sija in #16154 the implementation also added support for `TupleLiteral#*` so this patch adds a spec + doc + fixes & improves the error messages.

We might want this for 1.18 so I tentatively added it to the milestone.