### PR TITLE
Add `Proc#[]` as alias to `#call`

### DIFF
--- a/spec/std/proc_spec.cr
+++ b/spec/std/proc_spec.cr
@@ -89,5 +89,10 @@ describe "Proc" do
     f2.call('r').should eq(2)
   end
 
+  it "#[]" do
+    f = ->(x : Int32) { x + 1 }
+    f[3].should eq(4)
+  end
+
   typeof(-> { 1 }.hash)
 end

--- a/src/proc.cr
+++ b/src/proc.cr
@@ -221,4 +221,16 @@ struct Proc
     io << '>'
     nil
   end
+
+  # Invokes this `Proc` and returns the result.
+  #
+  # ```
+  # add = ->(x : Int32, y : Int32) { x + y }
+  # add[1, 2] # => 3
+  # ```
+  #
+  # Same as `#call`.
+  def [](*args : *T) : R
+    call(*args)
+  end
 end


### PR DESCRIPTION
Changes:
- added `Proc#[]` that is equivalent to `#call`

Closes #11133