### PR TITLE
Support 0X, 0O, 0B prefixes in string to integer conversion

### DIFF
--- a/spec/std/string_spec.cr
+++ b/spec/std/string_spec.cr
@@ -302,10 +302,13 @@ describe "String" do
     it { "1101".to_i(base: 2).should eq(13) }
     it { "12ab".to_i(16).should eq(4779) }
     it { "0x123abc".to_i(prefix: true).should eq(1194684) }
+    it { "0X123abc".to_i(prefix: true).should eq(1194684) }
     it { "0b1101".to_i(prefix: true).should eq(13) }
+    it { "0B1101".to_i(prefix: true).should eq(13) }
     it { "0b001101".to_i(prefix: true).should eq(13) }
     it { "0123".to_i(prefix: true).should eq(123) }
     it { "0o123".to_i(prefix: true).should eq(83) }
+    it { "0O123".to_i(prefix: true).should eq(83) }
     it { "0123".to_i(leading_zero_is_octal: true).should eq(83) }
     it { "123".to_i(leading_zero_is_octal: true).should eq(123) }
     it { "0o755".to_i(prefix: true, leading_zero_is_octal: true).should eq(493) }

--- a/src/string.cr
+++ b/src/string.cr
@@ -646,13 +646,13 @@ class String
       last_is_underscore = false
       if prefix
         case ptr.value.unsafe_chr
-        when 'b'
+        when 'b', 'B'
           base = 2
           ptr += 1
-        when 'x'
+        when 'x', 'X'
           base = 16
           ptr += 1
-        when 'o'
+        when 'o', 'O'
           base = 8
           ptr += 1
         else


### PR DESCRIPTION
So now `String#to_i{,8,16,32,64,128}` and `String#to_u{8,16,32,64,128}` treat "0X", "0O", "0B" at the beginning of a string as valid prefixes.

Closes #15237