### PR TITLE
Revert type restriction for `IO#read_bytes`

### DIFF
--- a/src/io.cr
+++ b/src/io.cr
@@ -930,7 +930,7 @@ abstract class IO
   # io.rewind
   # io.read_bytes(Int32, IO::ByteFormat::LittleEndian) # => 0x01020304
   # ```
-  def read_bytes(type : T.class, format : IO::ByteFormat = IO::ByteFormat::SystemEndian) : T forall T
+  def read_bytes(type, format : IO::ByteFormat = IO::ByteFormat::SystemEndian)
     type.from_io(self, format)
   end
 


### PR DESCRIPTION
Resolves #16230
