### PR TITLE
Simplify `String#byte_slice(Int)` and `String#byte_slice?(Int)`

### DIFF
--- a/src/string.cr
+++ b/src/string.cr
@@ -1173,9 +1173,8 @@ class String
   # ```
   # "hello".byte_slice(0, 2)   # => "he"
   # "hello".byte_slice(0, 100) # => "hello"
-  # "hello".byte_slice(-2, 3)  # => "he"
-  # "hello".byte_slice(-2, 5)  # => "he"
-  # "hello".byte_slice(-2, 5)  # => "he"
+  # "hello".byte_slice(-2, 3)  # => "lo"
+  # "hello".byte_slice(-2, 5)  # => "lo"
   # "¥hello".byte_slice(0, 2)  # => "¥"
   # "¥hello".byte_slice(2, 2)  # => "he"
   # "¥hello".byte_slice(0, 1)  # => "\xC2" (invalid UTF-8 character)


### PR DESCRIPTION
Closes #14078

Removed the following lines in String#byte_slice(Int) and String#byte_slice?(Int):

```crystal
count = bytesize - start
raise IndexError.new if start > 0 && count < 0
```

as far as they duplicate logic for handling `start` that's greater than `bytesize` implemented in  `Indexable.normalize_start_and_count`