### PR TITLE
Revert "[CI] Update xcode to 26.0.1 on circleci"

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -81,7 +81,7 @@ jobs:
 
   test_darwin:
     macos:
-      xcode: 26.0.1
+      xcode: 15.4.0
     environment:
       <<: *env
       TRAVIS_OS_NAME: osx
@@ -285,7 +285,7 @@ jobs:
 
   dist_darwin:
     macos:
-      xcode: 26.0.1
+      xcode: 15.3.0
     shell: /bin/bash --login -eo pipefail
     steps:
       - restore_cache:


### PR DESCRIPTION
Reverts crystal-lang/crystal#16201

The update is broken. Let's revert for now xcode 15 still works until November 7th.