### PR TITLE
Drop `assert_expand_second` and `assert_expand_third` helpers

### DIFF
--- a/spec/compiler/normalize/and_spec.cr
+++ b/spec/compiler/normalize/and_spec.cr
@@ -6,23 +6,23 @@ describe "Normalize: and" do
   end
 
   it "normalizes and with variable on the left" do
-    assert_expand_second "a = 1; a && b", "if a\n  b\nelse\n  a\nend"
+    assert_expand "a = 1; a && b", "if a\n  b\nelse\n  a\nend"
   end
 
   it "normalizes and with is_a? on var" do
-    assert_expand_second "a = 1; a.is_a?(Foo) && b", "if a.is_a?(Foo)\n  b\nelse\n  a.is_a?(Foo)\nend"
+    assert_expand "a = 1; a.is_a?(Foo) && b", "if a.is_a?(Foo)\n  b\nelse\n  a.is_a?(Foo)\nend"
   end
 
   it "normalizes and with ! on var" do
-    assert_expand_second "a = 1; !a && b", "if !a\n  b\nelse\n  !a\nend"
+    assert_expand "a = 1; !a && b", "if !a\n  b\nelse\n  !a\nend"
   end
 
   it "normalizes and with ! on var.is_a?(...)" do
-    assert_expand_second "a = 1; !a.is_a?(Int32) && b", "if !a.is_a?(Int32)\n  b\nelse\n  !a.is_a?(Int32)\nend"
+    assert_expand "a = 1; !a.is_a?(Int32) && b", "if !a.is_a?(Int32)\n  b\nelse\n  !a.is_a?(Int32)\nend"
   end
 
   it "normalizes and with is_a? on exp" do
-    assert_expand_second "a = 1; 1.is_a?(Foo) && b", "if __temp_1 = 1.is_a?(Foo)\n  b\nelse\n  __temp_1\nend"
+    assert_expand "a = 1; 1.is_a?(Foo) && b", "if __temp_1 = 1.is_a?(Foo)\n  b\nelse\n  __temp_1\nend"
   end
 
   it "normalizes and with assignment" do

--- a/spec/compiler/normalize/case_spec.cr
+++ b/spec/compiler/normalize/case_spec.cr
@@ -6,27 +6,27 @@ describe "Normalize: case" do
   end
 
   it "normalizes case with var in cond" do
-    assert_expand_second "x = 1; case x; when 1; 'b'; end", "if 1 === x\n  'b'\nend"
+    assert_expand "x = 1; case x; when 1; 'b'; end", "if 1 === x\n  'b'\nend"
   end
 
   it "normalizes case with Path to is_a?" do
-    assert_expand_second "x = 1; case x; when Foo; 'b'; end", "if x.is_a?(Foo)\n  'b'\nend"
+    assert_expand "x = 1; case x; when Foo; 'b'; end", "if x.is_a?(Foo)\n  'b'\nend"
   end
 
   it "normalizes case with generic to is_a?" do
-    assert_expand_second "x = 1; case x; when Foo(T); 'b'; end", "if x.is_a?(Foo(T))\n  'b'\nend"
+    assert_expand "x = 1; case x; when Foo(T); 'b'; end", "if x.is_a?(Foo(T))\n  'b'\nend"
   end
 
   it "normalizes case with Path.class to is_a?" do
-    assert_expand_second "x = 1; case x; when Foo.class; 'b'; end", "if x.is_a?(Foo.class)\n  'b'\nend"
+    assert_expand "x = 1; case x; when Foo.class; 'b'; end", "if x.is_a?(Foo.class)\n  'b'\nend"
   end
 
   it "normalizes case with Generic.class to is_a?" do
-    assert_expand_second "x = 1; case x; when Foo(T).class; 'b'; end", "if x.is_a?(Foo(T).class)\n  'b'\nend"
+    assert_expand "x = 1; case x; when Foo(T).class; 'b'; end", "if x.is_a?(Foo(T).class)\n  'b'\nend"
   end
 
   it "normalizes case with many expressions in when" do
-    assert_expand_second "x = 1; case x; when 1, 2; 'b'; end", "if (1 === x) || (2 === x)\n  'b'\nend"
+    assert_expand "x = 1; case x; when 1, 2; 'b'; end", "if (1 === x) || (2 === x)\n  'b'\nend"
   end
 
   it "normalizes case with implicit call" do
@@ -70,39 +70,39 @@ describe "Normalize: case" do
   end
 
   it "normalizes case with nil to is_a?" do
-    assert_expand_second "x = 1; case x; when nil; 'b'; end", "if x.is_a?(::Nil)\n  'b'\nend"
+    assert_expand "x = 1; case x; when nil; 'b'; end", "if x.is_a?(::Nil)\n  'b'\nend"
   end
 
   it "normalizes case with multiple expressions" do
-    assert_expand_second "x, y = 1, 2; case {x, y}; when {2, 3}; 4; end", "if (2 === x) && (3 === y)\n  4\nend"
+    assert_expand "x, y = 1, 2; case {x, y}; when {2, 3}; 4; end", "if (2 === x) && (3 === y)\n  4\nend"
   end
 
   it "normalizes case with multiple expressions and types" do
-    assert_expand_second "x, y = 1, 2; case {x, y}; when {Int32, Float64}; 4; end", "if x.is_a?(Int32) && y.is_a?(Float64)\n  4\nend"
+    assert_expand "x, y = 1, 2; case {x, y}; when {Int32, Float64}; 4; end", "if x.is_a?(Int32) && y.is_a?(Float64)\n  4\nend"
   end
 
   it "normalizes case with multiple expressions and implicit obj" do
-    assert_expand_second "x, y = 1, 2; case {x, y}; when {.foo, .bar}; 4; end", "if x.foo && y.bar\n  4\nend"
+    assert_expand "x, y = 1, 2; case {x, y}; when {.foo, .bar}; 4; end", "if x.foo && y.bar\n  4\nend"
   end
 
   it "normalizes case with multiple expressions and comma" do
-    assert_expand_second "x, y = 1, 2; case {x, y}; when {2, 3}, {4, 5}; 6; end", "if ((2 === x) && (3 === y)) || ((4 === x) && (5 === y))\n  6\nend"
+    assert_expand "x, y = 1, 2; case {x, y}; when {2, 3}, {4, 5}; 6; end", "if ((2 === x) && (3 === y)) || ((4 === x) && (5 === y))\n  6\nend"
   end
 
   it "normalizes case with multiple expressions with underscore" do
-    assert_expand_second "x, y = 1, 2; case {x, y}; when {2, _}; 4; end", "if 2 === x\n  4\nend"
+    assert_expand "x, y = 1, 2; case {x, y}; when {2, _}; 4; end", "if 2 === x\n  4\nend"
   end
 
   it "normalizes case with multiple expressions with all underscores" do
-    assert_expand_second "x, y = 1, 2; case {x, y}; when {_, _}; 4; end", "if true\n  4\nend"
+    assert_expand "x, y = 1, 2; case {x, y}; when {_, _}; 4; end", "if true\n  4\nend"
   end
 
   it "normalizes case with multiple expressions with all underscores twice" do
-    assert_expand_second "x, y = 1, 2; case {x, y}; when {_, _}, {_, _}; 4; end", "if true\n  4\nend"
+    assert_expand "x, y = 1, 2; case {x, y}; when {_, _}, {_, _}; 4; end", "if true\n  4\nend"
   end
 
   it "normalizes case with multiple expressions and non-tuple" do
-    assert_expand_second "x, y = 1, 2; case {x, y}; when 1; 4; end", "if 1 === {x, y}\n  4\nend"
+    assert_expand "x, y = 1, 2; case {x, y}; when 1; 4; end", "if 1 === {x, y}\n  4\nend"
   end
 
   it "normalizes case without when and else" do
@@ -122,6 +122,6 @@ describe "Normalize: case" do
   end
 
   it "normalizes case with Path.class to is_a? (in)" do
-    assert_expand_second "x = 1; case x; in Foo.class; 'b'; end", "if x.is_a?(Foo.class)\n  'b'\nelse\n  raise \"unreachable\"\nend"
+    assert_expand "x = 1; case x; in Foo.class; 'b'; end", "if x.is_a?(Foo.class)\n  'b'\nelse\n  raise \"unreachable\"\nend"
   end
 end

--- a/spec/compiler/normalize/multi_assign_spec.cr
+++ b/spec/compiler/normalize/multi_assign_spec.cr
@@ -13,7 +13,7 @@ describe "Normalize: multi assign" do
   end
 
   it "normalizes n to n with []" do
-    assert_expand_third "a = 1; b = 2; a[0], b[1] = 2, 3", <<-CRYSTAL
+    assert_expand "a = 1; b = 2; a[0], b[1] = 2, 3", <<-CRYSTAL
       __temp_1 = 2
       __temp_2 = 3
       a[0] = __temp_1
@@ -22,7 +22,7 @@ describe "Normalize: multi assign" do
   end
 
   it "normalizes n to n with call" do
-    assert_expand_third "a = 1; b = 2; a.foo, b.bar = 2, 3", <<-CRYSTAL
+    assert_expand "a = 1; b = 2; a.foo, b.bar = 2, 3", <<-CRYSTAL
       __temp_1 = 2
       __temp_2 = 3
       a.foo = __temp_1
@@ -32,7 +32,7 @@ describe "Normalize: multi assign" do
 
   context "without strict_multi_assign" do
     it "normalizes 1 to n" do
-      assert_expand_second "d = 1; a, b, c = d", <<-CRYSTAL
+      assert_expand "d = 1; a, b, c = d", <<-CRYSTAL
         __temp_1 = d
         a = __temp_1[0]
         b = __temp_1[1]
@@ -41,7 +41,7 @@ describe "Normalize: multi assign" do
     end
 
     it "normalizes 1 to n with []" do
-      assert_expand_third "a = 1; b = 2; a[0], b[1] = 2", <<-CRYSTAL
+      assert_expand "a = 1; b = 2; a[0], b[1] = 2", <<-CRYSTAL
         __temp_1 = 2
         a[0] = __temp_1[0]
         b[1] = __temp_1[1]
@@ -49,7 +49,7 @@ describe "Normalize: multi assign" do
     end
 
     it "normalizes 1 to n with call" do
-      assert_expand_third "a = 1; b = 2; a.foo, b.bar = 2", <<-CRYSTAL
+      assert_expand "a = 1; b = 2; a.foo, b.bar = 2", <<-CRYSTAL
         __temp_1 = 2
         a.foo = __temp_1[0]
         b.bar = __temp_1[1]
@@ -59,7 +59,7 @@ describe "Normalize: multi assign" do
 
   context "strict_multi_assign" do
     it "normalizes 1 to n" do
-      assert_expand_second "d = 1; a, b, c = d", <<-CRYSTAL, flags: "strict_multi_assign"
+      assert_expand "d = 1; a, b, c = d", <<-CRYSTAL, flags: "strict_multi_assign"
         __temp_1 = d
         if __temp_1.size != 3
           ::raise(::IndexError.new("Multiple assignment count mismatch"))
@@ -71,7 +71,7 @@ describe "Normalize: multi assign" do
     end
 
     it "normalizes 1 to n with []" do
-      assert_expand_third "a = 1; b = 2; a[0], b[1] = 2", <<-CRYSTAL, flags: "strict_multi_assign"
+      assert_expand "a = 1; b = 2; a[0], b[1] = 2", <<-CRYSTAL, flags: "strict_multi_assign"
         __temp_1 = 2
         if __temp_1.size != 2
           ::raise(::IndexError.new("Multiple assignment count mismatch"))
@@ -82,7 +82,7 @@ describe "Normalize: multi assign" do
     end
 
     it "normalizes 1 to n with call" do
-      assert_expand_third "a = 1; b = 2; a.foo, b.bar = 2", <<-CRYSTAL, flags: "strict_multi_assign"
+      assert_expand "a = 1; b = 2; a.foo, b.bar = 2", <<-CRYSTAL, flags: "strict_multi_assign"
         __temp_1 = 2
         if __temp_1.size != 2
           ::raise(::IndexError.new("Multiple assignment count mismatch"))
@@ -94,7 +94,7 @@ describe "Normalize: multi assign" do
   end
 
   it "normalizes m to n, with splat on left-hand side, splat is empty" do
-    assert_expand_third "a = 1; b = 2; *a[0], b.foo, c = 3, 4", <<-CRYSTAL
+    assert_expand "a = 1; b = 2; *a[0], b.foo, c = 3, 4", <<-CRYSTAL
       __temp_1 = ::Tuple.new
       __temp_2 = 3
       __temp_3 = 4
@@ -105,7 +105,7 @@ describe "Normalize: multi assign" do
   end
 
   it "normalizes m to n, with splat on left-hand side, splat is non-empty" do
-    assert_expand_third "a = 1; b = 2; a[0], *b.foo, c = 3, 4, 5, 6, 7", <<-CRYSTAL
+    assert_expand "a = 1; b = 2; a[0], *b.foo, c = 3, 4, 5, 6, 7", <<-CRYSTAL
       __temp_1 = 3
       __temp_2 = ::Tuple.new(4, 5, 6)
       __temp_3 = 7
@@ -155,7 +155,7 @@ describe "Normalize: multi assign" do
   end
 
   it "normalizes 1 to n, with splat on left-hand side" do
-    assert_expand_third "c = 1; d = 2; a, b, *c.foo, d[0], e, f = 3", <<-CRYSTAL
+    assert_expand "c = 1; d = 2; a, b, *c.foo, d[0], e, f = 3", <<-CRYSTAL
       __temp_1 = 3
       if __temp_1.size < 5
         ::raise(::IndexError.new("Multiple assignment count mismatch"))

--- a/spec/compiler/normalize/or_spec.cr
+++ b/spec/compiler/normalize/or_spec.cr
@@ -6,7 +6,7 @@ describe "Normalize: or" do
   end
 
   it "normalizes or with variable on the left" do
-    assert_expand_second "a = 1; a || b", "if a\n  a\nelse\n  b\nend"
+    assert_expand "a = 1; a || b", "if a\n  a\nelse\n  b\nend"
   end
 
   it "normalizes or with assignment on the left" do
@@ -14,14 +14,14 @@ describe "Normalize: or" do
   end
 
   it "normalizes or with is_a? on var" do
-    assert_expand_second "a = 1; a.is_a?(Foo) || b", "if a.is_a?(Foo)\n  a.is_a?(Foo)\nelse\n  b\nend"
+    assert_expand "a = 1; a.is_a?(Foo) || b", "if a.is_a?(Foo)\n  a.is_a?(Foo)\nelse\n  b\nend"
   end
 
   it "normalizes or with ! on var" do
-    assert_expand_second "a = 1; !a || b", "if !a\n  !a\nelse\n  b\nend"
+    assert_expand "a = 1; !a || b", "if !a\n  !a\nelse\n  b\nend"
   end
 
   it "normalizes or with ! on var.is_a?(...)" do
-    assert_expand_second "a = 1; !a.is_a?(Int32) || b", "if !a.is_a?(Int32)\n  !a.is_a?(Int32)\nelse\n  b\nend"
+    assert_expand "a = 1; !a.is_a?(Int32) || b", "if !a.is_a?(Int32)\n  !a.is_a?(Int32)\nelse\n  b\nend"
   end
 end

--- a/spec/compiler/normalize/proc_pointer_spec.cr
+++ b/spec/compiler/normalize/proc_pointer_spec.cr
@@ -42,7 +42,7 @@ describe "Normalize: proc pointer" do
   end
 
   it "normalizes proc pointer with variable receiver" do
-    assert_expand_second "foo = 1; ->foo.bar(Int32)", <<-CRYSTAL
+    assert_expand "foo = 1; ->foo.bar(Int32)", <<-CRYSTAL
       __temp_1 = foo
       ->(__temp_2 : Int32) do
         __temp_1.bar(__temp_2)

--- a/spec/spec_helper.cr
+++ b/spec/spec_helper.cr
@@ -122,7 +122,11 @@ def assert_normalize(from, to, flags = nil, *, filename = nil, file = __FILE__, 
 end
 
 def assert_expand(from : String, to, *, flags = nil, file = __FILE__, line = __LINE__)
-  assert_expand Parser.parse(from), to, flags: flags, file: file, line: line
+  node = Parser.parse(from)
+  if node.is_a?(Expressions)
+    node = node.last
+  end
+  assert_expand node, to, flags: flags, file: file, line: line
 end
 
 def assert_expand(from_nodes : ASTNode, to, *, flags = nil, file = __FILE__, line = __LINE__)
@@ -136,16 +140,6 @@ def assert_expand(from_nodes : ASTNode, *, flags = nil, file = __FILE__, line = 
   program.flags.concat(flags.split) if flags
   to_nodes = LiteralExpander.new(program).expand(from_nodes)
   yield to_nodes, program
-end
-
-def assert_expand_second(from : String, to, *, flags = nil, file = __FILE__, line = __LINE__)
-  node = (Parser.parse(from).as(Expressions))[1]
-  assert_expand node, to, flags: flags, file: file, line: line
-end
-
-def assert_expand_third(from : String, to, *, flags = nil, file = __FILE__, line = __LINE__)
-  node = (Parser.parse(from).as(Expressions))[2]
-  assert_expand node, to, flags: flags, file: file, line: line
 end
 
 def assert_expand_named(from : String, to, *, generic = nil, flags = nil, file = __FILE__, line = __LINE__)


### PR DESCRIPTION
The AST node of interest is always the last one, the previous elements of an `Expressions` node only serve to turn specific `Call`s into `Var`s. It suffices to have `assert_expand` always expand the last element of any `Expressions` node.