### PR TITLE
Add `YAML::Nodes.parse_all`

### DIFF
--- a/spec/std/yaml/nodes/parser_spec.cr
+++ b/spec/std/yaml/nodes/parser_spec.cr
@@ -35,4 +35,35 @@ describe YAML::Nodes do
       node.end_column.should eq(10)
     end
   end
+
+  describe ".parse_all" do
+    it "returns all documents" do
+      docs = YAML::Nodes.parse_all <<-YAML
+        ---
+        1
+        ---
+        [2]
+        YAML
+
+      docs.size.should eq(2)
+      docs[0].location.should eq({1, 1})
+      docs[0].end_line.should eq(3)
+      docs[0].end_column.should eq(1)
+      docs[1].location.should eq({3, 1})
+      docs[1].end_line.should eq(5)
+      docs[1].end_column.should eq(1)
+
+      node = docs[0].nodes[0].should be_a(YAML::Nodes::Scalar)
+      node.value.should eq("1")
+      node.location.should eq({2, 1})
+      node.end_line.should eq(2)
+      node.end_column.should eq(2)
+
+      node = docs[1].nodes[0].should be_a(YAML::Nodes::Sequence)
+      node.nodes[0].should(be_a(YAML::Nodes::Scalar)).value.should eq("2")
+      node.location.should eq({4, 1})
+      node.end_line.should eq(4)
+      node.end_column.should eq(4)
+    end
+  end
 end

--- a/src/yaml/nodes.cr
+++ b/src/yaml/nodes.cr
@@ -5,11 +5,16 @@ require "./parser"
 # with the `YAML::Nodes.parse` method or created with a
 # `YAML::Nodes::Builder`.
 #
-# This document tree can then be converted to YAML be
+# This document tree can then be converted to YAML by
 # invoking `to_yaml` on the document object.
 module YAML::Nodes
-  # Parses a `String` or `IO` into a `YAML::Document`.
+  # Parses a `String` or `IO` into a `YAML::Nodes::Document`.
   def self.parse(string_or_io : String | IO) : Document
     Parser.new string_or_io, &.parse
+  end
+
+  # Parses a `String` or `IO` into multiple `YAML::Nodes::Document`s.
+  def self.parse_all(string_or_io : String | IO) : Array(Document)
+    Parser.new string_or_io, &.parse_all
   end
 end

--- a/src/yaml/nodes/parser.cr
+++ b/src/yaml/nodes/parser.cr
@@ -10,12 +10,15 @@ class YAML::Nodes::Parser < YAML::Parser
     yield parser ensure parser.close
   end
 
-  def new_documents
-    [] of Array(Node)
+  def new_documents : Array(YAML::Nodes::Document)
+    [] of Document
   end
 
   def new_document : YAML::Nodes::Document
-    Document.new
+    document = Document.new
+    document.start_line = @pull_parser.start_line.to_i
+    document.start_column = @pull_parser.start_column.to_i
+    document
   end
 
   def new_sequence : YAML::Nodes::Sequence

--- a/src/yaml/parser.cr
+++ b/src/yaml/parser.cr
@@ -32,7 +32,7 @@ abstract class YAML::Parser
   end
 
   # Deserializes multiple YAML document.
-  def parse_all : Array(YAML::Any)
+  def parse_all
     documents = new_documents
 
     @pull_parser.read_next


### PR DESCRIPTION
This wasn't working before even if one tried to use the internal `YAML::Nodes::Parser` directly, as the return type on `YAML::Parser` was too restrictive.

Similar methods are already present in `YAML` and `YAML::Schema::FailSafe`.