### PR TITLE
Fix nested sigil delimiter parsing inside macros

### DIFF
--- a/spec/compiler/parser/parser_spec.cr
+++ b/spec/compiler/parser/parser_spec.cr
@@ -1444,6 +1444,10 @@ module Crystal
       it_parses "macro foo;unless var;true;end;end", Macro.new("foo", [] of Arg, Expressions.from(["unless var;true;".macro_literal, "end;".macro_literal] of ASTNode))
     end
 
+    {'i', 'q', 'r', 'w', 'x', 'Q'}.each do |ch|
+      it_parses "macro foo;%#{ch}[#{ch}];end", Macro.new("foo", [] of Arg, "%#{ch}[#{ch}];".macro_literal)
+    end
+
     it_parses "a = 1; pointerof(a)", [Assign.new("a".var, 1.int32), PointerOf.new("a".var)]
     it_parses "pointerof(@a)", PointerOf.new("@a".instance_var)
     it_parses "a = 1; pointerof(a)", [Assign.new("a".var, 1.int32), PointerOf.new("a".var)]

--- a/src/compiler/crystal/syntax/lexer.cr
+++ b/src/compiler/crystal/syntax/lexer.cr
@@ -1788,27 +1788,27 @@ module Crystal
         char = next_char
         if char == 'q' && peek_next_char.in?('(', '<', '[', '{', '|')
           next_char
-          delimiter_state = Token::DelimiterState.new(:string, char, closing_char, 1)
+          delimiter_state = Token::DelimiterState.new(:string, current_char, closing_char, 1)
           next_char
         elsif char == 'Q' && peek_next_char.in?('(', '<', '[', '{', '|')
           next_char
-          delimiter_state = Token::DelimiterState.new(:string, char, closing_char, 1)
+          delimiter_state = Token::DelimiterState.new(:string, current_char, closing_char, 1)
           next_char
         elsif char == 'i' && peek_next_char.in?('(', '<', '[', '{', '|')
           next_char
-          delimiter_state = Token::DelimiterState.new(:symbol_array, char, closing_char, 1)
+          delimiter_state = Token::DelimiterState.new(:symbol_array, current_char, closing_char, 1)
           next_char
         elsif char == 'w' && peek_next_char.in?('(', '<', '[', '{', '|')
           next_char
-          delimiter_state = Token::DelimiterState.new(:string_array, char, closing_char, 1)
+          delimiter_state = Token::DelimiterState.new(:string_array, current_char, closing_char, 1)
           next_char
         elsif char == 'x' && peek_next_char.in?('(', '<', '[', '{', '|')
           next_char
-          delimiter_state = Token::DelimiterState.new(:command, char, closing_char, 1)
+          delimiter_state = Token::DelimiterState.new(:command, current_char, closing_char, 1)
           next_char
         elsif char == 'r' && peek_next_char.in?('(', '<', '[', '{', '|')
           next_char
-          delimiter_state = Token::DelimiterState.new(:regex, char, closing_char, 1)
+          delimiter_state = Token::DelimiterState.new(:regex, current_char, closing_char, 1)
           next_char
         else
           start = current_pos


### PR DESCRIPTION
Sigils record their opening and closing delimiters so that the delimiters themselves could be nested in the sigil body. Sigils inside macros are no exception:

```crystal
macro foo
  %w(four (five) six) # okay, second element is "(five)"
end
```

However, it turns out the lexer uses the sigil name itself as the start delimiter, instead of its next character. This leads to some rather strange behavior:

```crystal
# okay, second `(` does not start a nested region
# errors on macro expansion instead
macro foo
  %w(four (five) %w(six)
end
```

```crystal
# error, `w` inside `two` starts a nested region but only one `)` found
macro foo
  %w(one two three)
end
```

```crystal
# okay, every `w` is "matched" by a closing `)`
# errors on expansion
macro foo
  %w(www))))
end
```

This PR ensures the correct start delimiters are used.