### PR TITLE
Deprecate single-letter macro fresh variables with indices

### DIFF
--- a/src/compiler/crystal/syntax/parser.cr
+++ b/src/compiler/crystal/syntax/parser.cr
@@ -3281,6 +3281,9 @@ module Crystal
           macro_var_name = @token.value.to_s
           location = @token.location
           if current_char == '{'
+            if macro_var_name.size == 1
+              warnings.add_warning_at @token.location, "single-letter macro fresh variables with indices are deprecated"
+            end
             macro_var_exps = parse_macro_var_exps
           else
             macro_var_exps = nil

--- a/src/iterator.cr
+++ b/src/iterator.cr
@@ -1457,13 +1457,13 @@ module Iterator(T)
     def next
       {% begin %}
         {% for i in 0...Is.size %}
-          %v{i} = @iterators[{{ i }}].next
-          return stop if %v{i}.is_a?(Stop)
+          %value{i} = @iterators[{{ i }}].next
+          return stop if %value{i}.is_a?(Stop)
         {% end %}
 
         Tuple.new(
           {% for i in 0...Is.size %}
-            %v{i},
+            %value{i},
           {% end %}
         )
       {% end %}


### PR DESCRIPTION
Resolves #14782. Closes #14824.

This does not deprecate uppercase names yet.