### PR TITLE
chore: correct progress step count to 14

### DIFF
--- a/src/compiler/crystal/progress_tracker.cr
+++ b/src/compiler/crystal/progress_tracker.cr
@@ -1,7 +1,7 @@
 module Crystal
   class ProgressTracker
     # FIXME: This assumption is not always true
-    STAGES        = 13
+    STAGES        = 14
     STAGE_PADDING = 34
 
     property? stats = false


### PR DESCRIPTION
When using --progress, the final step displays `[14/13] Codegen (linking)`, 
which incorrectly suggests there are only 13 steps. 

```
$ crystal build --progress

[1/13] Parse                    
[2/13] Semantic (top level)              
[3/13] Semantic (new)                    
[4/13] Semantic (type declarations)      
[5/13] Semantic (abstract def check)     
[6/13] Semantic (restrictions augmenter) 
[7/13] Semantic (ivars initializers)     
[8/13] Semantic (cvars initializers)     
[9/13] Semantic (main)                   
[10/13] Semantic (cleanup)                
[11/13] Semantic (recursive struct check) 
[12/13] Codegen (crystal)                 
[13/13] Codegen (bc+obj)          
[14/13] Codegen (linking)                  
```


Propose to update the maximum step count to 14 to align with the actual number of stages.

## 🎩 Tophat

I have tested localy the progress produces:

```
[1/14] Parse
...
[14/14] Codegen (linking)
```