### PR TITLE
[CI] Add lint workflow running `pre-commit`

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -18,8 +18,9 @@ jobs:
           name: devenv
       - name: Install devenv.sh
         run: nix profile install nixpkgs#devenv
-      - run: git fetch origin "${TARGET_BRANCH}"
-      - name: Run pre-commit hooks for changes against target branch (${TARGET_BRANCH})
+      - name: "Download target branch: ${{ github.base_ref || 'master' }}"
+        run: git fetch origin "${TARGET_BRANCH}"
+      - name: Run pre-commit hooks for changes against target branch (${{ github.base_ref || 'master' }})
         run: pre-commit run --from-ref "origin/${TARGET_BRANCH}" --to-ref HEAD
         shell: devenv shell bash -- -e {0}
         if: "${{ github.event_name != 'workflow_dispatch' }}"


### PR DESCRIPTION
This is a follow-up to #16263 which introduced a `pre-commit` configuration based on `devenv`.

It adds a new _Lint_  workflow which runs `pre-commit` in CI. It uses differential testing that only tests files that have changes compared to the base ref of a PR, or `master`.
Workflow dispatch allows running `pre-commit` against all files in the repo.

We already have a couple of individual CI job that run some of these linter: `lint-actionlint`, `lint-shellcheck`, `lint_spellcheck`. The new setup replaced them. But I'm keeping them around for a while to ensure the new workflow functions properly.