### PR TITLE
Add `ameba` to `git-hooks`

### DIFF
--- a/devenv.nix
+++ b/devenv.nix
@@ -5,6 +5,13 @@
 
   git-hooks.hooks = {
     actionlint.enable = true;
+    ameba = {
+      enable = true;
+      name = "Ameba";
+      entry = "${pkgs.ameba}/bin/ameba --fix";
+      files = "\\.e?cr$";
+      pass_filenames = true;
+    };
     check-toml.enable = true;
     check-vcs-permalinks.enable = true;
     circleci.enable = true;


### PR DESCRIPTION
`ameba` is not yet supported as a standard hook, but we can add a custom one.