### PR TITLE
fix(win32/zone_names): add missing GMT on windows

### DIFF
--- a/src/crystal/system/win32/zone_names.cr
+++ b/src/crystal/system/win32/zone_names.cr
@@ -320,6 +320,7 @@ module Crystal::System::Time
     put(data, "Australia/Melbourne", "AUS Eastern Standard Time", "AEST", "AEDT")
     put(data, "Australia/Perth", "W. Australia Standard Time", "AWST", "AWST")
     put(data, "Australia/Sydney", "AUS Eastern Standard Time", "AEST", "AEDT")
+    put(data, "GMT", "UTC", "GMT", "GMT")
     put(data, "Etc/GMT", "UTC", "GMT", "GMT")
     put(data, "Etc/GMT+1", "Cape Verde Standard Time", "-01", "-01")
     put(data, "Etc/GMT+10", "Hawaiian Standard Time", "-10", "-10")


### PR DESCRIPTION
on windows: `puts ::Time::Location.load("GMT")` will raise: 

```
Unhandled exception: Invalid location name: GMT (Time::Location::InvalidLocationNameError)
  from C:\Users\steve\AppData\Local\Programs\Crystal\src\time\location.cr:344 in 'load'
  from test.cr:1 in '__crystal_main'
  from C:\Users\steve\AppData\Local\Programs\Crystal\src\crystal\main.cr:129 in 'main_user_code'
  from C:\Users\steve\AppData\Local\Programs\Crystal\src\crystal\main.cr:115 in 'main'
  from C:\Users\steve\AppData\Local\Programs\Crystal\src\crystal\main.cr:141 in 'main'
  from C:\Users\steve\AppData\Local\Programs\Crystal\src\crystal\system\win32\wmain.cr:36 in 'wmain'
  from D:\a\_work\1\s\src\vctools\crt\vcstartup\src\startup\exe_common.inl:288 in '__scrt_common_main_seh'
  from C:\windows\System32\KERNEL32.DLL +190679 in 'BaseThreadInitThunk'
  from C:\windows\SYSTEM32\ntdll.dll +574780 in 'RtlUserThreadStart'
```

Issue I am having: https://github.com/spider-gazelle/openssl_ext/actions/runs/18819046827/job/53691685453#step:5:144