### PR TITLE
Deprecate `OAuth::Params#add(Nil)`

### DIFF
--- a/src/oauth/params.cr
+++ b/src/oauth/params.cr
@@ -4,10 +4,12 @@ struct OAuth::Params
     @params = [] of {String, String}
   end
 
-  def add(key : String, value : String?) : Nil
-    if value
-      @params << {URI.encode_www_form(key, space_to_plus: false), URI.encode_www_form(value, space_to_plus: false)}
-    end
+  def add(key : String, value : String) : Nil
+    @params << {URI.encode_www_form(key, space_to_plus: false), URI.encode_www_form(value, space_to_plus: false)}
+  end
+
+  @[Deprecated("Filter out `nil` values when calling `#add`")]
+  def add(key : String, value : Nil) : Nil
   end
 
   def add_query(query : String) : Nil

--- a/src/oauth/signature.cr
+++ b/src/oauth/signature.cr
@@ -31,7 +31,9 @@ struct OAuth::Signature
     auth_header.add "oauth_timestamp", ts
     auth_header.add "oauth_nonce", nonce
     auth_header.add "oauth_signature", oauth_signature
-    auth_header.add "oauth_token", @oauth_token
+    if oauth_token = @oauth_token
+      auth_header.add "oauth_token", oauth_token
+    end
     auth_header.add "oauth_version", "1.0"
     @extra_params.try &.each do |key, value|
       auth_header.add key, value
@@ -65,7 +67,9 @@ struct OAuth::Signature
     params.add "oauth_nonce", nonce
     params.add "oauth_signature_method", "HMAC-SHA1"
     params.add "oauth_timestamp", ts
-    params.add "oauth_token", @oauth_token
+    if oauth_token = @oauth_token
+      params.add "oauth_token", oauth_token
+    end
     params.add "oauth_version", "1.0"
 
     @extra_params.try &.each do |key, value|


### PR DESCRIPTION
This overload is a no-op, so I don't see how it would be useful for anything. It avoids a nil check at the call site, but adding a `nil` is makes no sense conceptually.