### PR TITLE
Add `devenv` profile `lint`

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -22,11 +22,11 @@ jobs:
         run: git fetch origin "${TARGET_BRANCH}"
       - name: Run pre-commit hooks for changes against target branch (${{ github.base_ref || 'master' }})
         run: pre-commit run --from-ref "origin/${TARGET_BRANCH}" --to-ref HEAD
-        shell: devenv shell bash -- -e {0}
+        shell: devenv --profile lint shell bash -- -e {0}
         if: "${{ github.event_name != 'workflow_dispatch' }}"
       - name: Run pre-commit on all files
         run: pre-commit run --all-files
-        shell: devenv shell bash -- -e {0}
+        shell: devenv --profile lint shell bash -- -e {0}
         if: "${{ github.event_name == 'workflow_dispatch' }}"
     env:
       TARGET_BRANCH: "${{ github.base_ref || 'master' }}"

--- a/devenv.nix
+++ b/devenv.nix
@@ -17,7 +17,6 @@
     circleci.enable = true;
     crystal.enable = true;
     markdownlint.enable = true;
-    reuse.enable = true;
     shellcheck = {
       enable = true;
       excludes = [
@@ -25,5 +24,16 @@
       ];
     };
     typos.enable = true;
+  };
+
+  profiles = {
+    lint.module = {
+      # More expensive hooks that we don't want to execute on every commit all the time
+      git-hooks.hooks = {
+        # reuse always runs on all files in the repo which takes some time.
+        # Violations are very rare, so a longer feedback loop doesn't matter much.
+        reuse.enable = true;
+      };
+    };
   };
 }


### PR DESCRIPTION
Move the `reuse` hook from the default configuration to a specific `lint` profile. This hook is a bit expensive. It causes a delay that's not huge but still noticable when committing. We can opt-in to this profile in CI and locally, but the default config excludes it.
You can run `devenv` with `--profile lint` option to use the extended hooks (this also works with direnv integration).