### PR TITLE
Update distribution-scripts

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -81,7 +81,7 @@ jobs:
 
   test_darwin:
     macos:
-      xcode: 15.4.0
+      xcode: 16.4.0
     environment:
       <<: *env
       TRAVIS_OS_NAME: osx
@@ -285,7 +285,7 @@ jobs:
 
   dist_darwin:
     macos:
-      xcode: 15.3.0
+      xcode: 16.4.0
     shell: /bin/bash --login -eo pipefail
     steps:
       - restore_cache:


### PR DESCRIPTION
Updates `distribution-scripts` dependency to https://github.com/crystal-lang/distribution-scripts/commit/54d475d5f39dc6c95002683e5258cf8f83ca7415

This includes the following changes:

* crystal-lang/distribution-scripts#381
* crystal-lang/distribution-scripts#382
* crystal-lang/distribution-scripts#378
* crystal-lang/distribution-scripts#380
* crystal-lang/distribution-scripts#379
* crystal-lang/distribution-scripts#374
* crystal-lang/distribution-scripts#372
* crystal-lang/distribution-scripts#373
* crystal-lang/distribution-scripts#370
* crystal-lang/distribution-scripts#366
* crystal-lang/distribution-scripts#357
* crystal-lang/distribution-scripts#353
* crystal-lang/distribution-scripts#356
* crystal-lang/distribution-scripts#352
* crystal-lang/distribution-scripts#351

Also updates Xcode to 16.4 becaus 15.3 is deprecated: [circleci.com/changelog/deprecation-of-eol-xcode-versions](https://circleci.com/changelog/deprecation-of-eol-xcode-versions/)