### PR TITLE
Fix `@[Deprecated]` doc comment

### DIFF
--- a/src/annotations.cr
+++ b/src/annotations.cr
@@ -13,7 +13,7 @@
 # @[Deprecated("Here may be dragons")]
 # class Foo
 # end
-
+#
 # def foo(bar, @[Deprecated("Do not try this at home")] baz)
 # end
 # ```


### PR DESCRIPTION
The gap in the comment lines caused it to be parsed with half the comment lines missing. This commit fills that gap.

## [Before](https://crystal-lang.org/api/1.18.2/Deprecated.html):

<img width="1120" height="561" alt="image" src="https://github.com/user-attachments/assets/ee33ea76-ab7c-4eb8-9719-ccc4de262b12" />

## After

<img width="1114" height="863" alt="image" src="https://github.com/user-attachments/assets/52fc187f-09ac-4e4e-b7c3-13ce6c5a98d4" />