### PR TITLE
Fix condition for no-op `lock_write` to work without sockets

### DIFF
--- a/src/crystal/system/unix/process.cr
+++ b/src/crystal/system/unix/process.cr
@@ -158,6 +158,10 @@ struct Crystal::System::Process
   #
   # NOTE: there may still be some potential leaks (e.g. calling `accept` on a
   #       blocking socket).
+  #
+  # `SOCK_CLOEXEC` and `accept4` are defined in `c/sys/socket.cr` which is only
+  # included when using sockets. The absence of `LibC.socket` indicates that
+  # we're not using sockets.
   {% if (LibC.has_constant?(:SOCK_CLOEXEC) && (LibC.has_method?(:accept4)) || !LibC.has_method?(:socket)) && LibC.has_method?(:dup3) && LibC.has_method?(:pipe2) %}
     # we don't implement .lock_read so compilation will fail if we need to
     # support another case, instead of silently skipping the rwlock!


### PR DESCRIPTION
`lock_write` was introduced in #14674. It's supposed to be a no-op on platforms that implement atomic `CLOEXEC`.

The condition however is insufficient: `SOCK_CLOEXEC` and `accept4` are defined in `c/sys/socket.cr` which depends on an explicit `require "socket"`. A program that doesn't use networking is always missing these function definitions.