### PR TITLE
Fix FreeBSD version check only uses major version [fixup #16294]

### DIFF
--- a/src/lib_c/x86_64-freebsd/c/unistd.cr
+++ b/src/lib_c/x86_64-freebsd/c/unistd.cr
@@ -20,7 +20,7 @@ lib LibC
   fun _exit(x0 : Int) : NoReturn
   fun execvp(x0 : Char*, x1 : Char**) : Int
   # `execvpe` is introduced in FreeBSD 15, but it already seems to be available in 14.
-  {% unless flag?("freebsd12.0") || flag?("freebsd13.0") %}
+  {% unless flag?("freebsd12") || flag?("freebsd13") %}
     fun execvpe(file : Char*, argv : Char**, envp : Char**) : Int
   {% end %}
   fun fdatasync(fd : Int) : Int


### PR DESCRIPTION
The FreeBSD version flag designates only the major version, so this usage was wrong.