### PR TITLE
Fixup call `execvpe` wrapper instead of `LibC.execvpe` [fixup #16286]

### DIFF
--- a/src/crystal/system/unix/process.cr
+++ b/src/crystal/system/unix/process.cr
@@ -354,7 +354,7 @@ struct Crystal::System::Process
 
     ::Dir.cd(chdir) if chdir
 
-    lock_write { LibC.execvp(*prepared_args) }
+    lock_write { execvpe(*prepared_args, LibC.environ) }
   end
 
   private def self.execvpe(command, argv, envp)


### PR DESCRIPTION
Fixup for unintended change in #16286. It should've stayed using the `execvpe` wrapper from #16294

Fixes https://github.com/crystal-lang/crystal/pull/16286#discussion_r2489638501