### PR TITLE
CI: build aarch64-linux tarballs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -160,7 +160,7 @@ jobs:
           echo "export CRYSTAL_SHA1=$CIRCLE_SHA1" >> build.env
 
           # Which previous version use
-          echo "export PREVIOUS_CRYSTAL_RELEASE_LINUX64_TARGZ=<< pipeline.parameters.previous_crystal_base_url >>-linux-x86_64.tar.gz" >> build.env
+          echo "export PREVIOUS_CRYSTAL_RELEASE_LINUX64_TARGZ=<< pipeline.parameters.previous_crystal_base_url >>-linux-${uname -m}.tar.gz" >> build.env
           echo "export PREVIOUS_CRYSTAL_RELEASE_DARWIN_TARGZ=<< pipeline.parameters.previous_crystal_base_url >>-darwin-universal.tar.gz" >> build.env
 
           cat build.env
@@ -263,8 +263,12 @@ jobs:
             - distribution-scripts
 
   dist_linux:
+    parameters:
+      arch:
+        type: string
     machine:
       image: default
+    resource_class: << parameters.arch >>
     steps:
       - attach_workspace:
           at: /tmp/workspace
@@ -444,6 +448,7 @@ jobs:
           cd /tmp/workspace/build
           cp crystal-*-darwin-universal.tar.gz /tmp/upload/crystal-nightly-darwin-universal.tar.gz
           cp crystal-*-linux-x86_64.tar.gz /tmp/upload/crystal-nightly-linux-x86_64.tar.gz
+          cp crystal-*-linux-aarch64.tar.gz /tmp/upload/crystal-nightly-linux-aarch64.tar.gz
       - run: s3cmd put --recursive /tmp/upload/* s3://artifacts.crystal-lang.org/dist/
 
   dist_artifacts:
@@ -519,6 +524,9 @@ workflows:
           requires:
             - prepare_common
       - dist_linux:
+          matrix:
+            parameters:
+              arch: [large, arm.medium]
           filters: *release
           requires:
             - prepare_maintenance
@@ -578,6 +586,9 @@ workflows:
           requires:
             - prepare_common
       - dist_linux:
+          matrix:
+            parameters:
+              arch: [large, arm.medium]
           requires:
             - prepare_nightly
       - dist_darwin:


### PR DESCRIPTION
Assuming:

- [x] there is a linux-aarch64 tarball added to the latest crystal release (built manually);
- [x] https://github.com/crystal-lang/distribution-scripts/pull/386 is merged and we upgrade distribution-scripts in this PR;
- [ ] we merge this PR;

Then CI should start building aarch64 tarballs for Linux :tada: