### PR TITLE
[CI] Add tests for `-Dexecution_context` configuration

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -25,11 +25,10 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        env: [
-          {},
-          {FLAGS: "-Devloop=libevent"},
-          {FLAGS: "-Dpreview_mt -Dexecution_context"},
-        ]
+        env:
+          - FLAGS: ""
+          - FLAGS: "-Devloop=libevent"
+          - FLAGS: "-Dpreview_mt -Dexecution_context"
         include:
           - env:
               CRYSTAL_BOOTSTRAP_VERSION: 1.0.0
@@ -61,11 +60,10 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        env: [
-          {},
-          {FLAGS: "-Devloop=libevent"},
-          {FLAGS: "-Dpreview_mt -Dexecution_context"},
-        ]
+        env:
+          - FLAGS: ""
+          - FLAGS: "-Devloop=libevent"
+          - FLAGS: "-Dpreview_mt -Dexecution_context"
     steps:
       - name: Download Crystal source
         uses: actions/checkout@v5

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -27,7 +27,7 @@ jobs:
       matrix:
         env: [
           {},
-          {FLAGS: "-Duse_libevent"},
+          {FLAGS: "-Devloop=libevent"},
           {FLAGS: "-Dpreview_mt -Dexecution_context"},
         ]
         include:
@@ -63,7 +63,7 @@ jobs:
       matrix:
         env: [
           {},
-          {FLAGS: "-Duse_libevent"},
+          {FLAGS: "-Devloop=libevent"},
           {FLAGS: "-Dpreview_mt -Dexecution_context"},
         ]
     steps:

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -25,7 +25,11 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        env: [{}]
+        env: [
+          {},
+          {FLAGS: "-Duse_libevent"},
+          {FLAGS: "-Dpreview_mt -Dexecution_context"},
+        ]
         include:
           - env:
               CRYSTAL_BOOTSTRAP_VERSION: 1.0.0

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -26,12 +26,15 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        flags: [""]
+        env: [{}]
         crystal_bootstrap_version: ["1.18.2"] # LATEST RELEASE
         include:
-          # libffi is only available starting from the 1.2.2 build images
           - crystal_bootstrap_version: 1.0.0
-            flags: "FLAGS=-Dwithout_ffi USE_PCRE1=true"
+            env:
+              # libffi is only available starting from the 1.2.2 build images
+              FLAGS: "-Dwithout_ffi"
+              # pcre2 is only available starting from the 1.8.0 build images
+              USE_PCRE1: true
     steps:
       - name: Download Crystal source
         uses: actions/checkout@v5
@@ -45,7 +48,8 @@ jobs:
         run: bin/ci prepare_build
 
       - name: Test
-        run: ${{ matrix.flags }} bin/ci build
+        run: bin/ci build
+        env: ${{ matrix.env }}
 
   x86_64-musl-test:
     env:

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -58,6 +58,14 @@ jobs:
       ARCH: x86_64-musl
       ARCH_CMD: linux64
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        env: [
+          {},
+          {FLAGS: "-Duse_libevent"},
+          {FLAGS: "-Dpreview_mt -Dexecution_context"},
+        ]
     steps:
       - name: Download Crystal source
         uses: actions/checkout@v5
@@ -72,6 +80,7 @@ jobs:
 
       - name: Test
         run: bin/ci build
+        env: ${{ matrix.env }}
 
   x86_64-gnu-test-preview_mt:
     env:

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -27,11 +27,11 @@ jobs:
       fail-fast: false
       matrix:
         flags: [""]
+        crystal_bootstrap_version: ["1.18.2"] # LATEST RELEASE
         include:
           # libffi is only available starting from the 1.2.2 build images
           - crystal_bootstrap_version: 1.0.0
             flags: "FLAGS=-Dwithout_ffi USE_PCRE1=true"
-          - crystal_bootstrap_version: 1.18.2 # LATEST RELEASE
     steps:
       - name: Download Crystal source
         uses: actions/checkout@v5

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -82,29 +82,6 @@ jobs:
         run: bin/ci build
         env: ${{ matrix.env }}
 
-  x86_64-gnu-test-preview_mt:
-    env:
-      ARCH: x86_64
-      ARCH_CMD: linux64
-    runs-on: ubuntu-latest
-    steps:
-      - name: Download Crystal source
-        uses: actions/checkout@v5
-        with:
-          persist-credentials: false
-
-      - name: Prepare System
-        run: bin/ci prepare_system
-
-      - name: Prepare Build
-        run: bin/ci prepare_build
-
-      - name: Make Crystal
-        run: bin/ci with_build_env 'make crystal'
-
-      - name: Test
-        run: bin/ci with_build_env 'CRYSTAL_WORKERS=4 make std_spec threads=1 FLAGS="-D preview_mt"'
-
   check_format:
     env:
       ARCH: x86_64

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -21,16 +21,14 @@ jobs:
     env:
       ARCH: x86_64
       ARCH_CMD: linux64
-      DOCKER_TEST_PREFIX: crystallang/crystal:${{ matrix.crystal_bootstrap_version }}
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
         env: [{}]
-        crystal_bootstrap_version: ["1.18.2"] # LATEST RELEASE
         include:
-          - crystal_bootstrap_version: 1.0.0
-            env:
+          - env:
+              CRYSTAL_BOOTSTRAP_VERSION: 1.0.0
               # libffi is only available starting from the 1.2.2 build images
               FLAGS: "-Dwithout_ffi"
               # pcre2 is only available starting from the 1.8.0 build images

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -17,6 +17,11 @@ jobs:
     runs-on: ${{ matrix.runs-on }}
     strategy:
       matrix:
+        env: [
+          {},
+          {FLAGS: "-Duse_libevent"},
+          {FLAGS: "-Dpreview_mt -Dexecution_context"},
+        ]
         runs-on: [macos-15-intel, macos-15]
       fail-fast: false
     steps:
@@ -43,6 +48,8 @@ jobs:
 
       - name: Test
         run: bin/ci build
+        env: ${{ matrix.env }}
 
       - name: Test interpreter
         run: bin/ci with_build_env 'make interpreter_spec'
+        env: ${{ matrix.env }}

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -18,11 +18,10 @@ jobs:
     strategy:
       matrix:
         runs-on: [macos-15-intel, macos-15]
-        env: [
-          {},
-          {FLAGS: "-Devloop=libevent"},
-          {FLAGS: "-Dpreview_mt -Dexecution_context"},
-        ]
+        env:
+          - FLAGS: ""
+          - FLAGS: "-Devloop=libevent"
+          - FLAGS: "-Dpreview_mt -Dexecution_context"
       fail-fast: false
     steps:
       - name: Download Crystal source

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -17,12 +17,12 @@ jobs:
     runs-on: ${{ matrix.runs-on }}
     strategy:
       matrix:
+        runs-on: [macos-15-intel, macos-15]
         env: [
           {},
           {FLAGS: "-Duse_libevent"},
           {FLAGS: "-Dpreview_mt -Dexecution_context"},
         ]
-        runs-on: [macos-15-intel, macos-15]
       fail-fast: false
     steps:
       - name: Download Crystal source

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ${{ matrix.runs-on }}
     strategy:
       matrix:
-        runs-on: [macos-15-intel, macos-14, macos-15]
+        runs-on: [macos-15-intel, macos-15]
       fail-fast: false
     steps:
       - name: Download Crystal source

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -20,7 +20,7 @@ jobs:
         runs-on: [macos-15-intel, macos-15]
         env: [
           {},
-          {FLAGS: "-Duse_libevent"},
+          {FLAGS: "-Devloop=libevent"},
           {FLAGS: "-Dpreview_mt -Dexecution_context"},
         ]
       fail-fast: false

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -15,16 +15,9 @@ env:
 jobs:
   darwin-test:
     runs-on: ${{ matrix.runs-on }}
-    name: "${{ matrix.runs-on }} (${{ matrix.arch }})"
     strategy:
       matrix:
-        include:
-        - runs-on: macos-15-intel
-          arch: x86_64-darwin
-        - runs-on: macos-14
-          arch: aarch64-darwin
-        - runs-on: macos-15
-          arch: aarch64-darwin
+        runs-on: [macos-15-intel, macos-14, macos-15]
       fail-fast: false
     steps:
       - name: Download Crystal source

--- a/.github/workflows/mingw-w64-steps.yml
+++ b/.github/workflows/mingw-w64-steps.yml
@@ -81,6 +81,14 @@ jobs:
 
   test-stdlib:
     runs-on: ${{ inputs.runs-on }}
+    strategy:
+      fail-fast: false
+      matrix:
+        env: [
+          {},
+          {FLAGS: "-Duse_libevent"},
+          {FLAGS: "-Dpreview_mt -Dexecution_context"},
+        ]
     steps:
       - name: Setup MSYS2
         id: msys2
@@ -109,6 +117,7 @@ jobs:
         run: |
           export CRYSTAL_SPEC_COMPILER_BIN="$(which crystal.exe)"
           make std_spec
+        env: ${{ matrix.env }}
 
   test-compiler:
     runs-on: ${{ inputs.runs-on }}

--- a/.github/workflows/mingw-w64-steps.yml
+++ b/.github/workflows/mingw-w64-steps.yml
@@ -86,7 +86,6 @@ jobs:
       matrix:
         env: [
           {},
-          {FLAGS: "-Duse_libevent"},
           {FLAGS: "-Dpreview_mt -Dexecution_context"},
         ]
     steps:

--- a/.github/workflows/mingw-w64-steps.yml
+++ b/.github/workflows/mingw-w64-steps.yml
@@ -84,10 +84,9 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        env: [
-          {},
-          {FLAGS: "-Dpreview_mt -Dexecution_context"},
-        ]
+        env:
+          - FLAGS: ""
+          - FLAGS: "-Dpreview_mt -Dexecution_context"
     steps:
       - name: Setup MSYS2
         id: msys2

--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -57,18 +57,12 @@ env:
 
 jobs:
   smoke-test:
-    name: ${{ matrix.target }}
     runs-on: ubuntu-latest
 
     strategy:
       max-parallel: 2
       fail-fast: false
       matrix:
-        env: [
-          {},
-          {FLAGS: "-Duse_libevent"},
-          {FLAGS: "-Dpreview_mt -Dexecution_context"},
-        ]
         target:
           - aarch64-linux-android
           - arm-linux-gnueabihf
@@ -79,6 +73,11 @@ jobs:
           - x86_64-netbsd
           - x86_64-openbsd
           - x86_64-solaris
+        env: [
+          {},
+          {FLAGS: "-Duse_libevent"},
+          {FLAGS: "-Dpreview_mt -Dexecution_context"},
+        ]
 
     steps:
       - name: Download Crystal source

--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -75,7 +75,6 @@ jobs:
           - x86_64-solaris
         env: [
           {},
-          {FLAGS: "-Duse_libevent"},
           {FLAGS: "-Dpreview_mt -Dexecution_context"},
         ]
 

--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -64,6 +64,11 @@ jobs:
       max-parallel: 2
       fail-fast: false
       matrix:
+        env: [
+          {},
+          {FLAGS: "-Duse_libevent"},
+          {FLAGS: "-Dpreview_mt -Dexecution_context"},
+        ]
         target:
           - aarch64-linux-android
           - arm-linux-gnueabihf
@@ -86,3 +91,4 @@ jobs:
 
       - name: Run smoke test
         run: bin/ci with_build_env make smoke_test target=${{ matrix.target }}
+        env: ${{ matrix.env }}

--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -73,10 +73,9 @@ jobs:
           - x86_64-netbsd
           - x86_64-openbsd
           - x86_64-solaris
-        env: [
-          {},
-          {FLAGS: "-Dpreview_mt -Dexecution_context"},
-        ]
+        env:
+          - FLAGS: ""
+          - FLAGS: "-Dpreview_mt -Dexecution_context"
         include:
           - target: x86_64-freebsd
             env:

--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -77,6 +77,10 @@ jobs:
           {},
           {FLAGS: "-Dpreview_mt -Dexecution_context"},
         ]
+        include:
+          - target: x86_64-freebsd
+            env:
+              FLAGS: "-Devloop=libevent"
 
     steps:
       - name: Download Crystal source

--- a/.github/workflows/win.yml
+++ b/.github/workflows/win.yml
@@ -228,6 +228,15 @@ jobs:
   x86_64-windows-test:
     runs-on: windows-2025
     needs: [x86_64-windows-release]
+    strategy:
+      fail-fast: false
+      matrix:
+        env: [
+          {},
+          {FLAGS: "-Duse_libevent"},
+          {FLAGS: "-Dpreview_mt -Dexecution_context"},
+        ]
+    env: ${{ matrix.env }}
     steps:
       - name: Disable CRLF line ending substitution
         run: |

--- a/.github/workflows/win.yml
+++ b/.github/workflows/win.yml
@@ -231,10 +231,9 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        env: [
-          {},
-          {FLAGS: "-Dpreview_mt -Dexecution_context"},
-        ]
+        env:
+          - FLAGS: ""
+          - FLAGS: "-Dpreview_mt -Dexecution_context"
     env: ${{ matrix.env }}
     steps:
       - name: Disable CRLF line ending substitution

--- a/.github/workflows/win.yml
+++ b/.github/workflows/win.yml
@@ -233,7 +233,6 @@ jobs:
       matrix:
         env: [
           {},
-          {FLAGS: "-Duse_libevent"},
           {FLAGS: "-Dpreview_mt -Dexecution_context"},
         ]
     env: ${{ matrix.env }}

--- a/bin/ci
+++ b/bin/ci
@@ -189,7 +189,7 @@ with_build_env() {
 
   on_linux verify_linux_environment
 
-  export DOCKER_TEST_PREFIX="${DOCKER_TEST_PREFIX:=crystallang/crystal:1.18.2}"
+  export DOCKER_TEST_PREFIX="${DOCKER_TEST_PREFIX:="crystallang/crystal:${CRYSTAL_BOOTSTRAP_VERSION:-1.18.2}"}"
 
   case $ARCH in
     x86_64)


### PR DESCRIPTION
[Execution contexts (RFC 0002)](https://github.com/crystal-lang/rfcs/pull/2) are nearing maturity (#15342) and until now we aren't even running CI with this configuration.
This is not as bad as it may seem: Because they're actively worked on, there is ample local test coverage. If anything were to break, we'd probably notice relatively quickly.
But going into the future, we want the additional confidence from regular CI tests.

So here is a patch to get this going in GitHub actions.

The first commits are clean-up and refactoring to simplify the configuration. I'll extract that to a separate PR. This requires changes to `release-update.sh` as well.

The meat of the change is adding a matrix with three compiler flags configurations to most of the general test jobs: 
* no flags
* `-Duse_libevent`
* `-Dpreview_mt -Dexecution_context`

That's what I considered most relevant, but I'm open to suggestions.
We could of course test even more, for example only `-Dpreview_mt` or the combination `-Duse_libevent -Dpreview_mt -Dexecution_context`.
But that escalate quickly.

In fact, this patch increases the number of jobs on a normal commit from 40 to about 51 (estimate). With smoke tests (which only run under special conditions), it's up from 49 to 78.
The increase naturally also reflects in the overall run time. Unfortunately, this resets most of the improvements we made with #14983 so far.

In order to reduce overall jobs a little bit, I'm dropping `macos-14`. Testing on `macos-15` should be sufficient.

Perhaps we could restrict some configuration tests to run less often. Similar to forward compatibility test, for example? This would make the workflow configurations more complex, unfortunately.
But it could be well worth it, especially providing the ability to easily add additional configurations to the test matrix without exponential growth of CI jobs on most typical commits.

Note: The errors from actionlint seem to be false positives. The workflows work just fine and as expected.

