### PR TITLE
CI: build linux aarch64 tarballs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -160,7 +160,6 @@ jobs:
           echo "export CRYSTAL_SHA1=$CIRCLE_SHA1" >> build.env
 
           # Which previous version use
-          echo "export PREVIOUS_CRYSTAL_RELEASE_LINUX64_TARGZ=<< pipeline.parameters.previous_crystal_base_url >>-linux-$(uname -m).tar.gz" >> build.env
           echo "export PREVIOUS_CRYSTAL_RELEASE_DARWIN_TARGZ=<< pipeline.parameters.previous_crystal_base_url >>-darwin-universal.tar.gz" >> build.env
 
           cat build.env
@@ -277,6 +276,7 @@ jobs:
           command: |
             cd /tmp/workspace/distribution-scripts
             source build.env
+            export PREVIOUS_CRYSTAL_RELEASE_LINUX64_TARGZ="<< pipeline.parameters.previous_crystal_base_url >>-linux-$(uname -m).tar.gz"
             cd linux
             make all64 release=true
       - store_artifacts:


### PR DESCRIPTION
(Replaces #16324 with a new branch name to trigger runs on CI).

Assuming:

- [x] there is a linux-aarch64 tarball added to the latest crystal release (built manually);
- [x] we upgrade distribution-scripts with https://github.com/crystal-lang/distribution-scripts/pull/386;
- [x] debug issues on CI.

Then CI should start building aarch64 tarballs for Linux 🎉