### PR TITLE
Drop `EventLoop#after_fork_before_exec`

### DIFF
--- a/src/crystal/event_loop/epoll.cr
+++ b/src/crystal/event_loop/epoll.cr
@@ -19,16 +19,6 @@ class Crystal::EventLoop::Epoll < Crystal::EventLoop::Polling
     @epoll.add(@timerfd.fd, LibC::EPOLLIN, u64: @timerfd.fd.to_u64!)
   end
 
-  def after_fork_before_exec : Nil
-    super
-
-    # O_CLOEXEC would close these automatically, but we don't want to mess with
-    # the parent process fds (it would mess the parent evloop)
-    @epoll.close
-    @eventfd.close
-    @timerfd.close
-  end
-
   {% unless flag?(:preview_mt) %}
     def after_fork : Nil
       super

--- a/src/crystal/event_loop/kqueue.cr
+++ b/src/crystal/event_loop/kqueue.cr
@@ -28,20 +28,6 @@ class Crystal::EventLoop::Kqueue < Crystal::EventLoop::Polling
     {% end %}
   end
 
-  def after_fork_before_exec : Nil
-    super
-
-    # O_CLOEXEC would close these automatically but we don't want to mess with
-    # the parent process fds (that would mess the parent evloop)
-
-    # kqueue isn't inherited by fork on darwin/dragonfly, but we still close
-    @kqueue.close
-
-    {% unless LibC.has_constant?(:EVFILT_USER) %}
-      @pipe.each { |fd| LibC.close(fd) }
-    {% end %}
-  end
-
   {% unless flag?(:preview_mt) %}
     def after_fork : Nil
       super

--- a/src/crystal/event_loop/libevent.cr
+++ b/src/crystal/event_loop/libevent.cr
@@ -12,9 +12,6 @@ class Crystal::EventLoop::LibEvent < Crystal::EventLoop
 
   private getter(event_base) { Crystal::EventLoop::LibEvent::Event::Base.new }
 
-  def after_fork_before_exec : Nil
-  end
-
   {% unless flag?(:preview_mt) %}
     # Reinitializes the event loop after a fork.
     def after_fork : Nil

--- a/src/crystal/event_loop/polling.cr
+++ b/src/crystal/event_loop/polling.cr
@@ -107,12 +107,6 @@ abstract class Crystal::EventLoop::Polling < Crystal::EventLoop
   @lock = SpinLock.new # protects parallel accesses to @timers
   @timers = Timers(Event).new
 
-  # reset the mutexes since another thread may have acquired the lock of one
-  # event loop, which would prevent closing file descriptors for example.
-  def after_fork_before_exec : Nil
-    @lock = SpinLock.new
-  end
-
   {% unless flag?(:preview_mt) %}
     # no parallelism issues, but let's clean-up anyway
     def after_fork : Nil

--- a/src/crystal/system/unix/process.cr
+++ b/src/crystal/system/unix/process.cr
@@ -262,8 +262,6 @@ struct Crystal::System::Process
     r, w = FileDescriptor.system_pipe
 
     pid = fork(will_exec: true) do
-      # notify event loop and reset signal handlers
-      Crystal::EventLoop.current.after_fork_before_exec
       Crystal::System::Signal.after_fork_before_exec
     end
 


### PR DESCRIPTION
It looks like these housekeeping tasks are entirely unnecessary.

When doing fork/exec, we don't need to care about closing file descriptors or resetting locks. The event loop must not be used in the forked process anyway.
The file descriptors are opened with `CLOEXEC` so they automatically close on exec.

This simplifies the housekeeping operations between fork and exec in preparation for #11337.