### PR TITLE
Fix `OptionParser` subcommand help to respect custom `summary_indent`

### DIFF
--- a/spec/std/option_parser_spec.cr
+++ b/spec/std/option_parser_spec.cr
@@ -899,4 +899,25 @@ describe "OptionParser with summary_width and summary_indent" do
       parser.summary_width = -10
     end
   end
+
+  it "formats subcommand help with custom summary_indent" do
+    help = nil
+    OptionParser.parse(%w(subcommand --help)) do |opts|
+      opts.summary_indent = "||"
+      opts.banner = "Usage: foo"
+
+      opts.on("subcommand", "Subcommand description") do
+        opts.banner = "Usage: foo subcommand"
+        opts.on("--local", "Local flag") { }
+      end
+      opts.on("other", "Other subcommand") { }
+      opts.on("--help", "Help") { help = opts.to_s }
+    end
+
+    help.should eq <<-USAGE
+      Usage: foo subcommand
+      ||--help                           Help
+      ||--local                          Local flag
+      USAGE
+  end
 end

--- a/src/option_parser.cr
+++ b/src/option_parser.cr
@@ -493,7 +493,7 @@ class OptionParser
     # subcommands since they are no longer valid.
     unless flag.starts_with?('-')
       @handlers.select! { |k, _| k.starts_with?('-') }
-      @flags.select!(&.starts_with?("    -"))
+      @flags.select!(&.starts_with?("#{summary_indent}-"))
     end
 
     handler.block.call(value || "")


### PR DESCRIPTION
Hi

This PR fixes a bug in `OptionParser#handle_flag` where subcommand help output did not respect custom `summary_indent` settings.

This change only affects help message formatting (to_s output)