### PR TITLE
Pass `envp` to `execvpe`

### DIFF
--- a/spec/std/process_spec.cr
+++ b/spec/std/process_spec.cr
@@ -388,19 +388,8 @@ describe Process do
         end
       {% end %}
 
-      if {{ flag?(:win32) }}
-        it "finds binary in parent `$PATH`, not `env`" do
-          Process.run(*print_env_command, env: {"PATH" => ""})
-        end
-      else
-        # FIXME: This behaviour is incorrect. It should lookup the command in
-        # the parent process' `$PATH`, without any changes from `env`.
-        # https://github.com/crystal-lang/crystal/issues/6464#issuecomment-3391000914
-        it "finds binary in `env`" do
-          expect_raises(File::NotFoundError) do
-            Process.run(*print_env_command, env: {"PATH" => ""})
-          end
-        end
+      it "finds binary in parent `$PATH`, not `env`" do
+        Process.run(*print_env_command, env: {"PATH" => ""})
       end
 
       it "errors on invalid key" do

--- a/src/crystal/system/unix/process.cr
+++ b/src/crystal/system/unix/process.cr
@@ -344,10 +344,10 @@ struct Crystal::System::Process
     reopen_io(output, ORIGINAL_STDOUT)
     reopen_io(error, ORIGINAL_STDERR)
 
-    LibC.environ = Env.make_envp(env, clear_env)
+    envp = Env.make_envp(env, clear_env)
     ::Dir.cd(chdir) if chdir
 
-    execvpe(*prepared_args, LibC.environ)
+    execvpe(*prepared_args, envp)
   end
 
   private def self.execvpe(file, argv, envp)


### PR DESCRIPTION
With this change, we no longer mutate the environment of the forked process itself, but only pass the environment pointer from `make_envp` (from #16320) to `execvpe` (from #16322).

Closes #6464