### PR TITLE
CI: Merge gnu and musl tests into a single matrix

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -17,22 +17,25 @@ jobs:
   #
   # A more advanced test which runs against *each* supported version is available in `forward-compatibility.yml` and
   # runs regularly on a nightly schedule.
-  x86_64-gnu-test:
+  test:
     env:
-      ARCH: x86_64
+      ARCH: ${{ matrix.arch }}
       ARCH_CMD: linux64
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
+        arch: [x86_64, x86_64-musl]
         env: [{}]
         include:
-          - env:
+          - arch: x86_64
+            env:
               CRYSTAL_BOOTSTRAP_VERSION: 1.0.0
               # libffi is only available starting from the 1.2.2 build images
               FLAGS: "-Dwithout_ffi"
               # pcre2 is only available starting from the 1.7.0 build images
               USE_PCRE1: true
+
     steps:
       - name: Download Crystal source
         uses: actions/checkout@v5
@@ -48,26 +51,6 @@ jobs:
       - name: Test
         run: bin/ci build
         env: ${{ matrix.env }}
-
-  x86_64-musl-test:
-    env:
-      ARCH: x86_64-musl
-      ARCH_CMD: linux64
-    runs-on: ubuntu-latest
-    steps:
-      - name: Download Crystal source
-        uses: actions/checkout@v5
-        with:
-          persist-credentials: false
-
-      - name: Prepare System
-        run: bin/ci prepare_system
-
-      - name: Prepare Build
-        run: bin/ci prepare_build
-
-      - name: Test
-        run: bin/ci build
 
   x86_64-gnu-test-preview_mt:
     env:


### PR DESCRIPTION
The steps are already identical, so we can easily pull it into a matrix to reduce duplication.