### PR TITLE
Add `limits.h` for solaris [fixup #16322]

### DIFF
--- a/src/lib_c/x86_64-solaris/c/limits.cr
+++ b/src/lib_c/x86_64-solaris/c/limits.cr
@@ -1,0 +1,4 @@
+lib LibC
+  NAME_MAX =  255
+  PATH_MAX = 1024
+end


### PR DESCRIPTION
Unfortunately, the smoke test workflow failed to detect this missing lib declaration in #16322. Only noticed in the following build on master and the scheduled job.
The workflow configuration should be fixed by #16343.

Fixup for https://github.com/crystal-lang/crystal/issues/16322