### PR TITLE
Use `to_slice` for presentation in `Pointer` doc examples

### DIFF
--- a/src/pointer.cr
+++ b/src/pointer.cr
@@ -451,13 +451,13 @@ struct Pointer(T)
   #
   # ```
   # ptr = Pointer(Int32).malloc(5) { |i| i }
-  # ptr.to_slice(6) # => Slice[0, 1, 2, 3, 4]
+  # ptr.to_slice(5) # => Slice[0, 1, 2, 3, 4]
   #
   # (ptr + 1).fill(3) { |i| i * i }
-  # ptr.to_slice(6) # => Slice[0, 0, 1, 4, 4]
+  # ptr.to_slice(5) # => Slice[0, 0, 1, 4, 4]
   #
   # (ptr + 1).fill(3, offset: 3) { |i| i * i }
-  # ptr.to_slice(6) # => Slice[0, 9, 16, 25, 4]
+  # ptr.to_slice(5) # => Slice[0, 9, 16, 25, 4]
   # ```
   def fill(count : Int, *, offset : Int = 0, &) : self
     count.times do |i|


### PR DESCRIPTION
`Slice` is a natural presentation of values in a region of memory that a pointer points to.
So we should use that in example code when we want to show the contents of a pointer, using established value expression syntax.

Ref https://github.com/crystal-lang/crystal/pull/16338#discussion_r2502558598