### PR TITLE
Fix `shell.nix` on Linux

### DIFF
--- a/shell.nix
+++ b/shell.nix
@@ -39,7 +39,7 @@ let
       src = builtins.fetchTarball { inherit url sha256; };
 
       # Extract only the compiler binary
-      buildCommand = ''
+      installPhase = ''
         mkdir -p $out/bin
 
         if [ -f "${src}/embedded/bin/crystal" ]; then


### PR DESCRIPTION
The executable location has been standardized in `./bin` since https://github.com/crystal-lang/distribution-scripts/pull/129 (first release: 1.2.0) 🙈 