### PR TITLE
Prepare `envp` in `Process.prepare_args`

### DIFF
--- a/spec/std/process_spec.cr
+++ b/spec/std/process_spec.cr
@@ -393,10 +393,10 @@ describe Process do
       end
 
       it "errors on invalid key" do
-        expect_raises({% if flag?(:win32) %}ArgumentError{% else %}RuntimeError{% end %}, %(Invalid env key "")) do
+        expect_raises(ArgumentError, %(Invalid env key "")) do
           Process.run(*print_env_command, env: {"" => "baz"})
         end
-        expect_raises({% if flag?(:win32) %}ArgumentError{% else %}RuntimeError{% end %}, %(Invalid env key "foo=bar")) do
+        expect_raises(ArgumentError, %(Invalid env key "foo=bar")) do
           Process.run(*print_env_command, env: {"foo=bar" => "baz"})
         end
       end

--- a/src/crystal/system/process.cr
+++ b/src/crystal/system/process.cr
@@ -74,13 +74,13 @@ struct Crystal::System::Process
   # def self.fork(&)
 
   # Launches a child process with the command + args.
-  # def self.spawn(prepared_args : Args, env : Env?, clear_env : Bool, input : Stdio, output : Stdio, error : Stdio, chdir : Path | String?) : ProcessInformation
+  # def self.spawn(prepared_args : Args, input : Stdio, output : Stdio, error : Stdio, chdir : Path | String?) : ProcessInformation
 
   # Replaces the current process with a new one.
-  # def self.replace(command : String, prepared_args : Args, env : Env?, clear_env : Bool, input : Stdio, output : Stdio, error : Stdio, chdir : Path | String?) : NoReturn
+  # def self.replace(command : String, prepared_args : Args, input : Stdio, output : Stdio, error : Stdio, chdir : Path | String?) : NoReturn
 
   # Converts a command and array of arguments to the system-specific representation.
-  # def self.prepare_args(command : String, args : Enumerable(String)?, shell : Bool) : Args
+  # def self.prepare_args(command : String, args : Enumerable(String)?, env : Hash?, clear_env : Bool,  shell : Bool) : Args
 
   # Changes the root directory for the current process.
   # def self.chroot(path : String)

--- a/src/crystal/system/wasi/process.cr
+++ b/src/crystal/system/wasi/process.cr
@@ -88,15 +88,15 @@ struct Crystal::System::Process
     raise NotImplementedError.new("Process.fork")
   end
 
-  def self.spawn(prepared_args, env, clear_env, input, output, error, chdir)
+  def self.spawn(prepared_args, input, output, error, chdir)
     raise NotImplementedError.new("Process.spawn")
   end
 
-  def self.prepare_args(command : String, args : Enumerable(String)?, shell : Bool) : Array(String)
+  def self.prepare_args(command : String, args : Enumerable(String)?, env : Hash?, clear_env : Bool, shell : Bool) : Array(String)
     raise NotImplementedError.new("Process.prepare_args")
   end
 
-  def self.replace(command, prepared_args, env, clear_env, input, output, error, chdir)
+  def self.replace(command, prepared_args, input, output, error, chdir)
     raise NotImplementedError.new("Process.replace")
   end
 

--- a/src/process.cr
+++ b/src/process.cr
@@ -215,13 +215,13 @@ class Process
   # Raises `IO::Error` if executing the command fails (for example if the executable doesn't exist).
   def self.exec(command : String, args : Enumerable(String)? = nil, env : Env = nil, clear_env : Bool = false, shell : Bool = false,
                 input : ExecStdio = Redirect::Inherit, output : ExecStdio = Redirect::Inherit, error : ExecStdio = Redirect::Inherit, chdir : Path | String? = nil) : NoReturn
-    prepared_args = Crystal::System::Process.prepare_args(command, args, shell)
+    prepared_args = Crystal::System::Process.prepare_args(command, args, env, clear_env, shell)
 
     input = exec_stdio_to_fd(input, for: STDIN)
     output = exec_stdio_to_fd(output, for: STDOUT)
     error = exec_stdio_to_fd(error, for: STDERR)
 
-    Crystal::System::Process.replace(command, prepared_args, env, clear_env, input, output, error, chdir)
+    Crystal::System::Process.replace(command, prepared_args, input, output, error, chdir)
   end
 
   private def self.exec_stdio_to_fd(stdio : ExecStdio, for dst_io : IO::FileDescriptor) : IO::FileDescriptor
@@ -280,13 +280,13 @@ class Process
   # Raises `IO::Error` if executing the command fails (for example if the executable doesn't exist).
   def initialize(command : String, args : Enumerable(String)? = nil, env : Env = nil, clear_env : Bool = false, shell : Bool = false,
                  input : Stdio = Redirect::Close, output : Stdio = Redirect::Close, error : Stdio = Redirect::Close, chdir : Path | String? = nil)
-    prepared_args = Crystal::System::Process.prepare_args(command, args, shell)
+    prepared_args = Crystal::System::Process.prepare_args(command, args, env, clear_env, shell)
 
     fork_input = stdio_to_fd(input, for: STDIN)
     fork_output = stdio_to_fd(output, for: STDOUT)
     fork_error = stdio_to_fd(error, for: STDERR)
 
-    pid = Crystal::System::Process.spawn(prepared_args, env, clear_env, fork_input, fork_output, fork_error, chdir.try &.to_s)
+    pid = Crystal::System::Process.spawn(prepared_args, fork_input, fork_output, fork_error, chdir.try &.to_s)
     @process_info = Crystal::System::Process.new(pid)
 
     fork_input.close unless fork_input.in?(input, STDIN)


### PR DESCRIPTION
Pulls creating the `envp` out of the pre-exec stage. It can be prepared entirely before `fork`.

This fits well into `prepare_args` which simplifies the entire process a bit: We pass the arguments directly to `prepare_args` which wraps it all in a tuple which is then passed on and expands in `try_replace`.

This is a minimal change to fix the issue. I'm planning on refactoring the entire process of passing prepared arguments in a follow-up.

Resolves #6464