### PR TITLE
Call `Pointer.malloc(size, value)` in `Slice.new(size, value)`

### DIFF
--- a/src/slice.cr
+++ b/src/slice.cr
@@ -119,7 +119,8 @@ struct Slice(T)
   # slice # => Slice[10, 10, 10]
   # ```
   def self.new(size : Int, value : T, *, read_only = false)
-    new(size, read_only: read_only) { value }
+    pointer = Pointer(T).malloc(size, value)
+    new(pointer, size, read_only: read_only)
   end
 
   # Returns a deep copy of this slice.


### PR DESCRIPTION
Passing the value to `Pointer.malloc` enables the use of several optimizations which are possible when filling with a static value.

Ref #16203