### PR TITLE
Allow closures to use atomic allocation

### DIFF
--- a/src/compiler/crystal/codegen/codegen.cr
+++ b/src/compiler/crystal/codegen/codegen.cr
@@ -2129,8 +2129,11 @@ module Crystal
 
       if closure_vars || self_closured
         closure_vars ||= [] of MetaVar
-        closure_type = @llvm_typer.closure_context_type(closure_vars, parent_closure_type, (self_closured ? current_context.type : nil))
-        closure_ptr = malloc closure_type
+
+        closure_type, closure_has_inner_pointers =
+          @llvm_typer.closure_context_type(closure_vars, parent_closure_type, (self_closured ? current_context.type : nil))
+        closure_ptr = closure_has_inner_pointers ? malloc(closure_type) : malloc_atomic(closure_type)
+
         closure_vars.each_with_index do |var, i|
           current_context.vars[var.name] = LLVMVar.new(gep(closure_type, closure_ptr, 0, i, var.name), var.type)
         end


### PR DESCRIPTION
When a `Proc` has any closured variable, the compiler always uses non-atomic allocation to allocate the context data. Until now:

```crystal
x = 0
-> { x += 1; x } # atomic, since `x` has no inner pointers

record Point, x : Int32, y : Int32 do
  def foo
    -> { @x } # atomic, since `Point` has no inner pointers and `self` is stored into the context by value
  end
end

pt = Point.new(12, 34)
-> { pt } # atomic, since `Point` has no inner pointers

str = ""
-> { str } # non-atomic, since `String` is a pointer

a = 0
-> {
  b = 0
  -> { a + b } # non-atomic, since this creates a pointer to the outer proc's closure
}              # atomic, since `a` has no inner pointers
```

Building `spec/std_spec.cr` reveals 62 sites where a `Proc`'s context data is now atomic, most notably when initializing a `Hash` with a default value:

https://github.com/crystal-lang/crystal/blob/e36c936adfdf2e187a60fbbb6f3014e6141f1117/src/hash.cr#L304-L306

https://github.com/crystal-lang/crystal/blob/e36c936adfdf2e187a60fbbb6f3014e6141f1117/src/hash.cr#L338-L340

Here `default_value` is a closured variable, because the block is captured and forms an implicit `Proc`. If `V` is a pointer-free type, e.g. `Int32`, then so is this `Proc`'s context data. Another example is `Iterator#reject(pattern)`.

Codebases that frequently use functional programming techniques will benefit more from this PR; the standard library itself is not one of them.