### PR TITLE
Add error message to `CrystalPath::NotFoundError`

### DIFF
--- a/src/compiler/crystal/crystal_path.cr
+++ b/src/compiler/crystal/crystal_path.cr
@@ -9,9 +9,9 @@ module Crystal
 
       def initialize(@filename : String, @relative_to : String?)
         if relative_to = @relative_to
-          super "Cannot find #{@filename} relative to #{relative_to}"
+          super "can't find #{@filename.inspect} relative to #{relative_to.inspect}"
         else
-          super "Cannot find #{@filename}"
+          super "can't find #{@filename.inspect}"
         end
       end
     end


### PR DESCRIPTION
If you use the `run` macro on a path that doesn't exist, you get a confusing empty error. 

For example without this change, if you have the code:

```crystal
{{ run "missing" }}
```

You get this error:

```
$ crystal build macro.cr
Showing last frame. Use --error-trace for full trace.

In macro.cr:1:4

 1 | {{ run "missing" }}
        ^--
Error: error executing macro 'run':
```

This is because in [`find_source_file`](https://github.com/crystal-lang/crystal/blob/1c72aa8f20d40bfdfed1324df35bb33419b774e1/src/compiler/crystal/macros/methods.cr#L24) it yields `ex.message`, which for a `NotFoundError` is empty.

This PR sets the message, so we get a more informative error:

```
$ crystal build macro.cr
Using compiled compiler at /home/will/Projects/crystal/.build/crystal
Showing last frame. Use --error-trace for full trace.

In macro.cr:1:4

 1 | {{ run "missing" }}
        ^--
Error: error executing macro 'run': Cannot find missing relative to /home/will/tmp
```