### PR TITLE
Fix: duplicated `#shutdown` methods in WASI event loop [fixup #16288]

### DIFF
--- a/src/crystal/event_loop/wasi.cr
+++ b/src/crystal/event_loop/wasi.cr
@@ -84,9 +84,6 @@ class Crystal::EventLoop::Wasi < Crystal::EventLoop
     file_descriptor.evented_close
   end
 
-  def shutdown(file_descriptor : Crystal::System::FileDescriptor) : Nil
-  end
-
   def close(file_descriptor : Crystal::System::FileDescriptor) : Nil
     file_descriptor.file_descriptor_close
   end
@@ -141,9 +138,6 @@ class Crystal::EventLoop::Wasi < Crystal::EventLoop
 
   def shutdown(socket : ::Socket) : Nil
     socket.evented_close
-  end
-
-  def shutdown(socket : ::Socket) : Nil
   end
 
   def close(socket : ::Socket) : Nil


### PR DESCRIPTION
Ref https://github.com/crystal-lang/crystal/pull/16289#discussion_r2478948957

fixup #16288