### PR TITLE
Fix: default execution context is `Parallel`

### DIFF
--- a/src/fiber/execution_context.cr
+++ b/src/fiber/execution_context.cr
@@ -69,7 +69,7 @@ require "./execution_context/*"
 # ```
 @[Experimental]
 module Fiber::ExecutionContext
-  @@default : ExecutionContext?
+  @@default : ExecutionContext::Parallel?
 
   # Returns the default `ExecutionContext` for the process, automatically
   # started when the program started.
@@ -78,7 +78,7 @@ module Fiber::ExecutionContext
   # parallelism set to 1. The parallelism can be changed using
   # `Parallel#resize`.
   @[AlwaysInline]
-  def self.default : ExecutionContext
+  def self.default : ExecutionContext::Parallel
     @@default.not_nil!("expected default execution context to have been setup")
   end
 


### PR DESCRIPTION
It was logical for the context to be the abstract `ExecutionContext` (abstract) but then we can't easily resize the default context when the program also has `Isolated` contexts: we either have to manually cast to `Parallel` or check if the context responds to `:resize`.

The alternative could be to add `Isolated#resize` and to have it raise at runtime.