### PR TITLE
Fix `Process.fork` [fixup #16191]

### DIFF
--- a/spec/std/process_spec.cr
+++ b/spec/std/process_spec.cr
@@ -662,6 +662,8 @@ describe Process do
           File.exists?(path).should be_true
         end
       end
+
+      typeof(Process.fork)
     end
   {% end %}
 

--- a/src/crystal/system/unix/process.cr
+++ b/src/crystal/system/unix/process.cr
@@ -192,7 +192,7 @@ struct Crystal::System::Process
     end
   {% end %}
 
-  def self.fork(*, will_exec : Bool, &)
+  def self.system_fork(*, will_exec : Bool, &)
     newmask = uninitialized LibC::SigsetT
     oldmask = uninitialized LibC::SigsetT
 
@@ -236,15 +236,21 @@ struct Crystal::System::Process
     pid
   end
 
+  # Only used by deprecated `::Process.fork`
+  def self.fork
+    {% raise("Process fork is unsupported with multithreaded mode") if flag?(:preview_mt) %}
+
+    system_fork(will_exec: false) do
+      ::Process.after_fork_child_callbacks.each(&.call)
+    end
+  end
+
   # Duplicates the current process.
   # Returns a `Process` representing the new child process in the current process
   # and `nil` inside the new child process.
+  # Only used by deprecated `::Process.fork(&)` and compiler `fork_codegen`
   def self.fork(&)
-    {% raise("Process fork is unsupported with multithreaded mode") if flag?(:preview_mt) %}
-
-    pid = fork(will_exec: false) do
-      ::Process.after_fork_child_callbacks.each(&.call)
-    end
+    pid = fork
     return pid if pid
 
     begin
@@ -266,7 +272,7 @@ struct Crystal::System::Process
 
     envp = Env.make_envp(env, clear_env)
 
-    pid = fork(will_exec: true) do
+    pid = system_fork(will_exec: true) do
       Crystal::System::Signal.after_fork_before_exec
     end
 

--- a/src/crystal/system/wasi/process.cr
+++ b/src/crystal/system/wasi/process.cr
@@ -80,7 +80,7 @@ struct Crystal::System::Process
     raise NotImplementedError.new("Process.times")
   end
 
-  def self.fork(*, will_exec = false)
+  def self.fork
     raise NotImplementedError.new("Process.fork")
   end
 


### PR DESCRIPTION
Rename the internal method to `system_fork` so we clearly separate it from the method that the public API and the compiler use.

Fixes https://github.com/crystal-lang/crystal/pull/16191#issuecomment-3536982193