### PR TITLE
Fix `Env.make_envp` add final null pointer [fixup #16320]

### DIFF
--- a/src/crystal/system/unix/env.cr
+++ b/src/crystal/system/unix/env.cr
@@ -98,6 +98,8 @@ module Crystal::System::Env
       envp << "#{key.check_no_null_byte("key")}=#{value.check_no_null_byte("value")}".to_unsafe
     end
 
+    envp << Pointer(LibC::Char).null
+
     envp.to_unsafe
   end
 end


### PR DESCRIPTION
The final entry in `envp` must be a null pointer. This would usually be the case implicitly because unused items in the array buffer are zeroed out. But in case we fill the array to capacity, there is no guarantee of a final null pointer. We need to make that explicit.