### PR TITLE
Extract `unix/spawn.cr` as a separate file

### DIFF
--- a/src/crystal/system/unix/process.cr
+++ b/src/crystal/system/unix/process.cr
@@ -5,6 +5,7 @@ require "c/unistd"
 require "c/limits"
 require "crystal/rw_lock"
 require "file/error"
+require "./spawn"
 
 struct Crystal::System::Process
   getter pid : LibC::PidT
@@ -252,100 +253,6 @@ struct Crystal::System::Process
     end
   end
 
-  def self.spawn(command, args, shell, env, clear_env, input, output, error, chdir)
-    prepared_args = prepare_args(command, args, shell)
-
-    r, w = FileDescriptor.system_pipe
-
-    envp = Env.make_envp(env, clear_env)
-
-    pid = self.fork_for_exec
-    if !pid
-      LibC.close(r)
-      begin
-        self.try_replace(prepared_args, envp, input, output, error, chdir)
-        byte = 1_u8
-        errno = Errno.value.to_i32
-        FileDescriptor.write_fully(w, pointerof(byte))
-        FileDescriptor.write_fully(w, pointerof(errno))
-      rescue ex
-        byte = 0_u8
-        message = ex.inspect_with_backtrace
-        FileDescriptor.write_fully(w, pointerof(byte))
-        FileDescriptor.write_fully(w, message.to_slice)
-      ensure
-        LibC.close(w)
-        LibC._exit 127
-      end
-    end
-
-    LibC.close(w)
-    reader_pipe = IO::FileDescriptor.new(r)
-
-    begin
-      case reader_pipe.read_byte
-      when nil
-        # Pipe was closed, no error
-      when 0
-        # Error message coming
-        message = reader_pipe.gets_to_end
-        raise RuntimeError.new("Error executing process: '#{prepared_args[0]}': #{message}")
-      when 1
-        # Errno coming
-        # can't use IO#read_bytes(Int32) because we skipped system/network
-        # endianness check when writing the integer while read_bytes would;
-        # we thus read it in the same as order as written
-        buf = uninitialized StaticArray(UInt8, 4)
-        reader_pipe.read_fully(buf.to_slice)
-        raise_exception_from_errno(prepared_args[0], Errno.new(buf.unsafe_as(Int32)))
-      else
-        raise RuntimeError.new("BUG: Invalid error response received from subprocess")
-      end
-    ensure
-      reader_pipe.close
-    end
-
-    pid
-  end
-
-  private def self.fork_for_exec
-    newmask = uninitialized LibC::SigsetT
-    oldmask = uninitialized LibC::SigsetT
-
-    # block signals while we fork, so the child process won't forward signals it
-    # may receive to the parent through the signal pipe, but make sure to not
-    # block stop-the-world signals as it appears to create deadlocks in glibc
-    # for example; this is safe because these signal handlers musn't be
-    # registered through `Signal.trap` but directly through `sigaction`.
-    LibC.sigfillset(pointerof(newmask))
-    LibC.sigdelset(pointerof(newmask), System::Thread.sig_suspend)
-    LibC.sigdelset(pointerof(newmask), System::Thread.sig_resume)
-    ret = LibC.pthread_sigmask(LibC::SIG_SETMASK, pointerof(newmask), pointerof(oldmask))
-    raise RuntimeError.from_errno("Failed to disable signals") unless ret == 0
-
-    case pid = lock_write { LibC.fork }
-    when 0
-      # child:
-      pid = nil
-
-      Crystal::System::Signal.after_fork_before_exec
-
-      # reset sigmask (inherited on exec)
-      LibC.sigemptyset(pointerof(newmask))
-      LibC.pthread_sigmask(LibC::SIG_SETMASK, pointerof(newmask), nil)
-    when -1
-      # error:
-      errno = Errno.value
-      LibC.pthread_sigmask(LibC::SIG_SETMASK, pointerof(oldmask), nil)
-      raise RuntimeError.from_os_error("fork", errno)
-    else
-      # parent:
-      LibC.pthread_sigmask(LibC::SIG_SETMASK, pointerof(oldmask), nil)
-    end
-
-    pid
-  end
-
   def self.prepare_args(command : String, args : Enumerable(String)?, shell : Bool) : {String, LibC::Char**}
     if shell
       command = %(#{command} "${@}") unless command.includes?(' ')
@@ -367,23 +274,6 @@ struct Crystal::System::Process
 
     argv = argv_ary.map(&.check_no_null_byte.to_unsafe)
     {pathname, argv.to_unsafe}
-  end
-
-  # This method is similar to `.replace` (used for `Process.exec`) with some
-  # differences because we're limited in what we can do in the pre-exec phase
-  # between `fork` and `exec`.
-  private def self.try_replace(prepared_args, envp, input, output, error, chdir)
-    reopen_io(input, ORIGINAL_STDIN)
-    reopen_io(output, ORIGINAL_STDOUT)
-    reopen_io(error, ORIGINAL_STDERR)
-
-    if chdir
-      if 0 != LibC.chdir(chdir)
-        return
-      end
-    end
-
-    execvpe(*prepared_args, envp)
   end
 
   private def self.execvpe(file, argv, envp)

--- a/src/crystal/system/unix/spawn.cr
+++ b/src/crystal/system/unix/spawn.cr
@@ -1,0 +1,115 @@
+require "c/signal"
+require "c/unistd"
+
+struct Crystal::System::Process
+  def self.spawn(command, args, shell, env, clear_env, input, output, error, chdir)
+    prepared_args = prepare_args(command, args, shell)
+
+    r, w = FileDescriptor.system_pipe
+
+    envp = Env.make_envp(env, clear_env)
+
+    pid = self.fork_for_exec
+    if !pid
+      LibC.close(r)
+      begin
+        self.try_replace(prepared_args, envp, input, output, error, chdir)
+        byte = 1_u8
+        errno = Errno.value.to_i32
+        FileDescriptor.write_fully(w, pointerof(byte))
+        FileDescriptor.write_fully(w, pointerof(errno))
+      rescue ex
+        byte = 0_u8
+        message = ex.inspect_with_backtrace
+        FileDescriptor.write_fully(w, pointerof(byte))
+        FileDescriptor.write_fully(w, message.to_slice)
+      ensure
+        LibC.close(w)
+        LibC._exit 127
+      end
+    end
+
+    LibC.close(w)
+    reader_pipe = IO::FileDescriptor.new(r)
+
+    begin
+      case reader_pipe.read_byte
+      when nil
+        # Pipe was closed, no error
+      when 0
+        # Error message coming
+        message = reader_pipe.gets_to_end
+        raise RuntimeError.new("Error executing process: '#{prepared_args[0]}': #{message}")
+      when 1
+        # Errno coming
+        # can't use IO#read_bytes(Int32) because we skipped system/network
+        # endianness check when writing the integer while read_bytes would;
+        # we thus read it in the same as order as written
+        buf = uninitialized StaticArray(UInt8, 4)
+        reader_pipe.read_fully(buf.to_slice)
+        raise_exception_from_errno(prepared_args[0], Errno.new(buf.unsafe_as(Int32)))
+      else
+        raise RuntimeError.new("BUG: Invalid error response received from subprocess")
+      end
+    ensure
+      reader_pipe.close
+    end
+
+    pid
+  end
+
+  private def self.fork_for_exec
+    newmask = uninitialized LibC::SigsetT
+    oldmask = uninitialized LibC::SigsetT
+
+    # block signals while we fork, so the child process won't forward signals it
+    # may receive to the parent through the signal pipe, but make sure to not
+    # block stop-the-world signals as it appears to create deadlocks in glibc
+    # for example; this is safe because these signal handlers musn't be
+    # registered through `Signal.trap` but directly through `sigaction`.
+    LibC.sigfillset(pointerof(newmask))
+    LibC.sigdelset(pointerof(newmask), System::Thread.sig_suspend)
+    LibC.sigdelset(pointerof(newmask), System::Thread.sig_resume)
+    ret = LibC.pthread_sigmask(LibC::SIG_SETMASK, pointerof(newmask), pointerof(oldmask))
+    raise RuntimeError.from_errno("Failed to disable signals") unless ret == 0
+
+    case pid = lock_write { LibC.fork }
+    when 0
+      # child:
+      pid = nil
+
+      Crystal::System::Signal.after_fork_before_exec
+
+      # reset sigmask (inherited on exec)
+      LibC.sigemptyset(pointerof(newmask))
+      LibC.pthread_sigmask(LibC::SIG_SETMASK, pointerof(newmask), nil)
+    when -1
+      # error:
+      errno = Errno.value
+      LibC.pthread_sigmask(LibC::SIG_SETMASK, pointerof(oldmask), nil)
+      raise RuntimeError.from_os_error("fork", errno)
+    else
+      # parent:
+      LibC.pthread_sigmask(LibC::SIG_SETMASK, pointerof(oldmask), nil)
+    end
+
+    pid
+  end
+
+  # This method is similar to `.replace` (used for `Process.exec`) with some
+  # differences because we're limited in what we can do in the pre-exec phase
+  # between `fork` and `exec`.
+  private def self.try_replace(prepared_args, envp, input, output, error, chdir)
+    reopen_io(input, ORIGINAL_STDIN)
+    reopen_io(output, ORIGINAL_STDOUT)
+    reopen_io(error, ORIGINAL_STDERR)
+
+    if chdir
+      if 0 != LibC.chdir(chdir)
+        return
+      end
+    end
+
+    execvpe(*prepared_args, envp)
+  end
+end


### PR DESCRIPTION
`unix/process.cr` contains a lot of different features and is quite big. This patch extracts the code related to spawning a new process into a separate file to improve maintainability.