### PR TITLE
[CI] Update darwin jobs in circleci to `m4pro.medium` resource class

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -82,6 +82,7 @@ jobs:
   test_darwin:
     macos:
       xcode: 16.4.0
+    resource_class: m4pro.medium
     environment:
       <<: *env
       TRAVIS_OS_NAME: osx
@@ -290,6 +291,7 @@ jobs:
   dist_darwin:
     macos:
       xcode: 16.4.0
+    resource_class: m4pro.medium
     shell: /bin/bash --login -eo pipefail
     steps:
       - restore_cache:


### PR DESCRIPTION
All runners except m4pro are [deprecated with EOL 2026-02-16](https://circleci.com/changelog/deprecation-of-mac-m1-and-m2-resource-classes/).