### PR TITLE
Fix: don't flush twice in `File#truncate` (UNIX)

### DIFF
--- a/src/crystal/system/unix/file.cr
+++ b/src/crystal/system/unix/file.cr
@@ -217,7 +217,6 @@ module Crystal::System::File
   end
 
   private def system_truncate(size) : Nil
-    flush
     code = LibC.ftruncate(fd, size)
     if code != 0
       raise ::File::Error.from_errno("Error truncating file", file: path)


### PR DESCRIPTION
The UNIX system method for truncating a file calls `File#flush` but `File#truncate` already flushed, and the system method should only focus on truncating the file.

The Windows version doesn't flush.