### PR TITLE
Add `Crystal::PointerLinkedList#first?`

### DIFF
--- a/spec/std/crystal/pointer_linked_list_spec.cr
+++ b/spec/std/crystal/pointer_linked_list_spec.cr
@@ -93,6 +93,40 @@ describe Crystal::PointerLinkedList do
     end
   end
 
+  describe "#first?" do
+    it "returns nil when the list is empty" do
+      list = Crystal::PointerLinkedList(TestedObject).new
+
+      obj = list.first?
+
+      obj.should be_nil
+    end
+
+    it "returns the head item" do
+      list = Crystal::PointerLinkedList(TestedObject).new
+
+      x = TestedObject.new 0
+      y = TestedObject.new 1
+      z = TestedObject.new 2
+
+      list.push pointerof(x)
+      list.first?.should eq(pointerof(x))
+
+      list.push pointerof(y)
+      list.first?.should eq(pointerof(x))
+
+      list.push pointerof(z)
+      list.first?.should eq(pointerof(x))
+
+      list.shift?
+      list.shift?
+      list.first?.should eq(pointerof(z))
+
+      list.shift?
+      list.first?.should be_nil
+    end
+  end
+
   describe "shift?" do
     it "remove and return the first element" do
       list = Crystal::PointerLinkedList(TestedObject).new

--- a/src/crystal/pointer_linked_list.cr
+++ b/src/crystal/pointer_linked_list.cr
@@ -26,6 +26,12 @@ struct Crystal::PointerLinkedList(T)
     _next.value.previous = new
   end
 
+  def first?
+    if node = @head
+      node
+    end
+  end
+
   # Returns `true` if the list is empty, otherwise false.
   def empty? : Bool
     @head.null?


### PR DESCRIPTION
This is needed to import `Sync::ConditionVariable` from the sync shard: we need to access the first waiter. We could access `.@head` but a properly tested method is nicer.

NOTE: the nilable methods of `Crystal::PointerLinkedList` such as `#first?`, `#pop?` and `#shift?` should return a mere NULL pointer instead of a nilable `Pointer(T) | Nil` union.