### PR TITLE
Fix: `Crystal::PointerLinkedList#each` stops iterating when deleting head

### DIFF
--- a/spec/std/crystal/pointer_linked_list_spec.cr
+++ b/spec/std/crystal/pointer_linked_list_spec.cr
@@ -161,23 +161,46 @@ describe Crystal::PointerLinkedList do
     end
   end
 
-  it "does each" do
-    list = Crystal::PointerLinkedList(TestedObject).new
+  describe "#each" do
+    it "iterates everything" do
+      list = Crystal::PointerLinkedList(TestedObject).new
 
-    x = TestedObject.new 1
-    y = TestedObject.new 2
-    z = TestedObject.new 4
+      x = TestedObject.new 1
+      y = TestedObject.new 2
+      z = TestedObject.new 4
 
-    sum = 0
+      sum = 0
 
-    list.push pointerof(x)
-    list.push pointerof(y)
-    list.push pointerof(z)
+      list.push pointerof(x)
+      list.push pointerof(y)
+      list.push pointerof(z)
 
-    list.each do |object_ptr|
-      sum += object_ptr.value.value
+      list.each do |object_ptr|
+        sum += object_ptr.value.value
+      end
+
+      sum.should eq(7)
     end
 
-    sum.should eq(7)
+    it "can delete while iterating" do
+      list = Crystal::PointerLinkedList(TestedObject).new
+
+      x = TestedObject.new 1
+      y = TestedObject.new 2
+      z = TestedObject.new 4
+
+      sum = 0
+
+      list.push pointerof(x)
+      list.push pointerof(y)
+      list.push pointerof(z)
+
+      list.each do |obj|
+        list.delete(obj)
+        sum += obj.value.value
+      end
+
+      sum.should eq(7)
+    end
   end
 end

--- a/src/crystal/pointer_linked_list.cr
+++ b/src/crystal/pointer_linked_list.cr
@@ -96,13 +96,11 @@ struct Crystal::PointerLinkedList(T)
 
   # Iterates the list.
   def each(&) : Nil
-    return if empty?
-
     node = @head
-    loop do
+    while node
       _next = node.value.next
+      _next = Pointer(T).null if _next == @head
       yield node
-      break if _next == @head
       node = _next
     end
   end


### PR DESCRIPTION
While importing `Sync::ConditionVariable` from the sync shard and porting from `Sync::Dll` to `Crystal::PointerLinkedList` I hit an issue with the following snippet:

```crystal
@waiters.each { |waiter| @waiters.delete(waiter) }
```

The `#each` method correctly gets the next pointer before yielding, but incorrectly compares it to `@head` after the block has run; since the block removed the head pointer, then next == head and the iteration stops (oops).