### PR TITLE
Extract internal `Process.block_signals` helper

### DIFF
--- a/src/crystal/system/unix/process.cr
+++ b/src/crystal/system/unix/process.cr
@@ -198,15 +198,14 @@ struct Crystal::System::Process
     {% raise("Process fork is unsupported with multithreaded mode") if flag?(:preview_mt) %}
 
     block_signals do
-      pid = lock_write { LibC.fork }
-
-      if 0 == pid
+      case pid = lock_write { LibC.fork }
+      when 0
         # forked process
 
         ::Process.after_fork_child_callbacks.each(&.call)
 
         nil
-      elsif pid == -1
+      when -1
         # forking process: error
         raise RuntimeError.from_errno("fork")
       else

--- a/src/crystal/system/unix/spawn.cr
+++ b/src/crystal/system/unix/spawn.cr
@@ -60,9 +60,8 @@ struct Crystal::System::Process
 
   private def self.fork_for_exec
     block_signals do |sigmask|
-      pid = lock_write { LibC.fork }
-
-      if 0 == pid
+      case pid = lock_write { LibC.fork }
+      when 0
         # forked process
 
         Crystal::System::Signal.after_fork_before_exec
@@ -71,7 +70,7 @@ struct Crystal::System::Process
         LibC.sigemptyset(sigmask)
 
         nil
-      elsif pid == -1
+      when -1
         # forking process: error
         raise RuntimeError.from_errno("fork")
       else


### PR DESCRIPTION
Extract common behaviour between the two fork methods and encapsulates the signal blocking behaviour.
As a result, the call site is much cleaner now.