### PR TITLE
Fix `Crystal::Target#unix?` to consider `android`

### DIFF
--- a/spec/compiler/codegen/target_spec.cr
+++ b/spec/compiler/codegen/target_spec.cr
@@ -25,4 +25,8 @@ describe Crystal::Codegen::Target do
     Target.new("x86_64-unknown-freebsd8.0").freebsd_version.should eq(8)
     Target.new("x86_64-unknown-freebsd11.0").freebsd_version.should eq(11)
   end
+
+  it "#unix?" do
+    Target.new("aarch64-android").unix?.should be_true
+  end
 end

--- a/src/compiler/crystal/codegen/target.cr
+++ b/src/compiler/crystal/codegen/target.cr
@@ -161,7 +161,7 @@ class Crystal::Codegen::Target
   end
 
   def unix?
-    macos? || bsd? || linux? || wasi? || solaris?
+    macos? || bsd? || linux? || wasi? || solaris? || android?
   end
 
   def gnu?


### PR DESCRIPTION
`aarch64-linux-android` currently gets the `unix` flag, because of `linux`. But the alias `aarch64-android` does not contain `linux`...