### PR TITLE
CI: Remove `test_dist_linux_on_docker` job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -462,32 +462,6 @@ jobs:
           path: /tmp/workspace/build
           destination: dist_packages
 
-  test_dist_linux_on_docker:
-    machine:
-      image: default
-    environment:
-      <<: *env
-      TRAVIS_OS_NAME: linux
-      ARCH: x86_64
-      ARCH_CMD: linux64
-    resource_class: large
-    steps:
-      - attach_workspace:
-          at: /tmp/workspace
-      - run: |
-          cd /tmp/workspace/distribution-scripts
-          source ./build.env
-          gunzip -c /tmp/workspace/build/docker-${CRYSTAL_VERSION}-ubuntu-x86_64-build.tar.gz | docker image load
-          echo "export DOCKER_TEST_PREFIX=crystallang/crystal:${DOCKER_TAG}" >> $BASH_ENV
-      - checkout
-      - run: bin/ci prepare_system
-      - run: echo 'export CURRENT_TAG="$CIRCLE_TAG"' >> $BASH_ENV
-      - run: bin/ci prepare_build
-      - run: bin/ci with_build_env 'shards --version'
-      - run:
-          command: bin/ci build
-          no_output_timeout: 30m
-
 workflows:
   version: 2
   release:
@@ -549,14 +523,10 @@ workflows:
           filters: *release
           requires:
             - dist_snap
-      - test_dist_linux_on_docker:
-          filters: *release
-          requires:
-            - dist_docker
       - publish_docker:
           filters: *release
           requires:
-            - test_dist_linux_on_docker
+            - dist_docker
       - dist_docs:
           filters: *release
           requires:
@@ -608,9 +578,6 @@ workflows:
       - publish_snap:
           requires:
             - dist_snap
-      - test_dist_linux_on_docker:
-          requires:
-            - dist_docker
       - publish_docker:
           requires:
             - dist_docker


### PR DESCRIPTION
`test_dist_linux_on_docker` is a heavy (30 minutes) job for little gain. We introduced a lighter smoke test in #16441.

Ref https://github.com/crystal-lang/distribution-scripts/issues/389