### PR TITLE
Fix: memory leak in `XML::Node#content=`

### DIFF
--- a/src/xml/node.cr
+++ b/src/xml/node.cr
@@ -135,13 +135,15 @@ class XML::Node
       # children before replacing the node's contents
       child = @node.value.children
       while child
+        # save next pointer before unlinking, as `xmlUnlinkNode` clears it
+        next_child = child.value.next
         if node = document.cached?(child)
           node.unlink
         else
           document.unlinked_nodes << child
           LibXML.xmlUnlinkNode(child)
         end
-        child = child.value.next
+        child = next_child
       end
     end
 


### PR DESCRIPTION
This PR saves the `next` pointer before unlinking, as `xmlUnlinkNode` clears it. In practice, this means the first child is added to the list of unlinked nodes, but all siblings are left off and become leaks.

Sorry for sending these one-by-one. I'm encountering them as I'm stress testing my LibXML extensions. Also, I created this PR against a branch this time, instead of master, hopefully ending the cycle of my nuking the previous PRs.

```
require "spec"
require "xml"

describe "XML memory management" do
  it "properly unlinks children" do
    xml = %Q|<root>#{"<child/>" * 10}</root>|

    GC.collect
    baseline_rss = get_rss_kb

    1_000_000.times do
      doc = XML.parse(xml)
      root = doc.root.not_nil!
      root.content = "text"
    end

    GC.collect
    final_rss = get_rss_kb
    growth = final_rss - baseline_rss

    p growth: growth

    (growth < 50_000).should be_true
  end
end

private def get_rss_kb : Int64
  {% if flag?(:darwin) %}
    `ps -o rss= -p #{Process.pid}`.strip.to_i64
  {% else %}
    File.read("/proc/self/status").lines.each do |line|
      return line.split[1].to_i64 if line.starts_with?("VmRSS:")
    end
    0_i64
  {% end %}
end
```