### PR TITLE
Add `Fiber::Stack#size`

### DIFF
--- a/src/fiber/stack.cr
+++ b/src/fiber/stack.cr
@@ -3,9 +3,19 @@ class Fiber
   struct Stack
     getter pointer : Void*
     getter bottom : Void*
+    getter size : Int32
     getter? reusable : Bool
 
-    def initialize(@pointer, @bottom, *, @reusable = false)
+    # Constructor for thread stacks (main fibers).
+    def initialize(@pointer : Void*, @bottom : Void*, *, @reusable = false)
+      # FIXME: sometimes gc/boehm reports weird stack limits on linux (over
+      # 2GB) at least, so we always cast to i32 without overflow checks.
+      @size = (@bottom - @pointer).to_i32!
+    end
+
+    # Constructor for fiber stacks.
+    def initialize(@pointer : Void*, @size : Int32, *, @reusable = false)
+      @bottom = @pointer + @size
     end
 
     def first_addressable_pointer : Void**

--- a/src/fiber/stack_pool.cr
+++ b/src/fiber/stack_pool.cr
@@ -26,7 +26,7 @@ class Fiber
 
     def finalize
       @deque.each do |stack|
-        Crystal::System::Fiber.free_stack(stack.pointer, STACK_SIZE)
+        Crystal::System::Fiber.free_stack(stack.pointer, stack.size)
       end
     end
 
@@ -35,7 +35,7 @@ class Fiber
     def collect(count = lazy_size // 2) : Nil
       count.times do
         if stack = shift?
-          Crystal::System::Fiber.free_stack(stack.pointer, STACK_SIZE)
+          Crystal::System::Fiber.free_stack(stack.pointer, stack.size)
         else
           return
         end
@@ -52,11 +52,11 @@ class Fiber
     # Removes a stack from the bottom of the pool, or allocates a new one.
     def checkout : Stack
       if stack = pop?
-        Crystal::System::Fiber.reset_stack(stack.pointer, STACK_SIZE, @protect)
+        Crystal::System::Fiber.reset_stack(stack.pointer, stack.size, @protect)
         stack
       else
         pointer = Crystal::System::Fiber.allocate_stack(STACK_SIZE, @protect)
-        Stack.new(pointer, pointer + STACK_SIZE, reusable: true)
+        Stack.new(pointer, STACK_SIZE, reusable: true)
       end
     end
 


### PR DESCRIPTION
A tiny refactor to save the stack size in the `Fiber::Stack` object, so we can free stacks without assuming the stack's actual size.

Extracted from #15885 where the thread pool will have to free stacks outside of execution contexts and thus outside of any stack pool, for example.