### PR TITLE
Avoid calling `times.map`

### DIFF
--- a/spec/compiler/codegen/abi/avr_spec.cr
+++ b/spec/compiler/codegen/abi/avr_spec.cr
@@ -132,14 +132,14 @@ class Crystal::ABI
         end
 
         test "multiple arguments" do |abi, ctx|
-          args = 9.times.map { ctx.int16 }.to_a
+          args = Array.new(9) { ctx.int16 }
           info = abi.abi_info(args, ctx.int8, false, ctx)
           info.arg_types.size.should eq(9)
           info.arg_types.each(&.kind.should eq(Crystal::ABI::ArgKind::Direct))
         end
 
         test "multiple arguments above registers" do |abi, ctx|
-          args = 5.times.map { ctx.int32 }.to_a
+          args = Array.new(5) { ctx.int32 }
           info = abi.abi_info(args, ctx.int8, false, ctx)
           info.arg_types.size.should eq(5)
           info.arg_types[0].kind.should eq(Crystal::ABI::ArgKind::Direct)

--- a/spec/std/crystal/event_loop/polling/arena_spec.cr
+++ b/spec/std/crystal/event_loop/polling/arena_spec.cr
@@ -33,9 +33,9 @@ describe Crystal::EventLoop::Polling::Arena do
     it "allocates up to capacity" do
       arena = Crystal::EventLoop::Polling::Arena(Int32, 96).new(32)
 
-      indexes = 32.times.map do |i|
+      indexes = Array.new(32) do |i|
         arena.allocate_at?(i) { |ptr, _| ptr.value = i }
-      end.to_a
+      end
 
       indexes.size.should eq(32)
 

--- a/spec/std/fiber/execution_context/global_queue_spec.cr
+++ b/spec/std/fiber/execution_context/global_queue_spec.cr
@@ -39,7 +39,7 @@ describe Fiber::ExecutionContext::GlobalQueue do
 
     it "grabs fibers" do
       q = Fiber::ExecutionContext::GlobalQueue.new(Thread::Mutex.new)
-      fibers = 10.times.map { |i| new_fake_fiber("f#{i}") }.to_a
+      fibers = Array.new(10) { |i| new_fake_fiber("f#{i}") }
       fibers.each { |f| q.unsafe_push(f) }
 
       runnables = Fiber::ExecutionContext::Runnables(6).new(q)

--- a/spec/std/fiber/execution_context/runnables_spec.cr
+++ b/spec/std/fiber/execution_context/runnables_spec.cr
@@ -10,7 +10,7 @@ describe Fiber::ExecutionContext::Runnables do
 
   describe "#push" do
     it "enqueues the fiber in local queue" do
-      fibers = 4.times.map { |i| new_fake_fiber("f#{i}") }.to_a
+      fibers = Array.new(4) { |i| new_fake_fiber("f#{i}") }
 
       # local enqueue
       g = Fiber::ExecutionContext::GlobalQueue.new(Thread::Mutex.new)
@@ -26,7 +26,7 @@ describe Fiber::ExecutionContext::Runnables do
     end
 
     it "moves half the local queue to the global queue on overflow" do
-      fibers = 5.times.map { |i| new_fake_fiber("f#{i}") }.to_a
+      fibers = Array.new(5) { |i| new_fake_fiber("f#{i}") }
 
       # local enqueue + overflow
       g = Fiber::ExecutionContext::GlobalQueue.new(Thread::Mutex.new)
@@ -73,7 +73,7 @@ describe Fiber::ExecutionContext::Runnables do
 
   describe "#drain" do
     it "drains the local queue into the global queue" do
-      fibers = 6.times.map { |i| new_fake_fiber("f#{i}") }.to_a
+      fibers = Array.new(6) { |i| new_fake_fiber("f#{i}") }
 
       # local enqueue + overflow
       g = Fiber::ExecutionContext::GlobalQueue.new(Thread::Mutex.new)
@@ -100,7 +100,7 @@ describe Fiber::ExecutionContext::Runnables do
   describe "#bulk_push" do
     it "fills the local queue" do
       l = Fiber::List.new
-      fibers = 4.times.map { |i| new_fake_fiber("f#{i}") }.to_a
+      fibers = Array.new(4) { |i| new_fake_fiber("f#{i}") }
       fibers.each { |f| l.push(f) }
 
       # local enqueue
@@ -114,7 +114,7 @@ describe Fiber::ExecutionContext::Runnables do
 
     it "pushes the overflow to the global queue" do
       l = Fiber::List.new
-      fibers = 7.times.map { |i| new_fake_fiber("f#{i}") }.to_a
+      fibers = Array.new(7) { |i| new_fake_fiber("f#{i}") }
       fibers.each { |f| l.push(f) }
 
       # local enqueue + overflow
@@ -142,7 +142,7 @@ describe Fiber::ExecutionContext::Runnables do
   describe "#steal_from" do
     it "steals from another runnables" do
       g = Fiber::ExecutionContext::GlobalQueue.new(Thread::Mutex.new)
-      fibers = 6.times.map { |i| new_fake_fiber("f#{i}") }.to_a
+      fibers = Array.new(6) { |i| new_fake_fiber("f#{i}") }
 
       # fill the source queue
       r1 = Fiber::ExecutionContext::Runnables(16).new(g)

--- a/spec/std/mutex_spec.cr
+++ b/spec/std/mutex_spec.cr
@@ -12,13 +12,13 @@ describe Mutex do
     x = 0
     mutex = Mutex.new
 
-    fibers = 10.times.map do
+    fibers = Array.new(10) do
       spawn do
         100.times do
           mutex.synchronize { x += 1 }
         end
       end
-    end.to_a
+    end
 
     fibers.each do |f|
       wait_until_finished f

--- a/spec/std/random/pcg32_spec.cr
+++ b/spec/std/random/pcg32_spec.cr
@@ -238,10 +238,10 @@ describe "Random::PCG32" do
     rng2 = rng0.split
     rng3 = rng1.split # split of split
 
-    seq0 = 5.times.map { rng0.next_u }.to_a
-    seq1 = 5.times.map { rng1.next_u }.to_a
-    seq2 = 5.times.map { rng2.next_u }.to_a
-    seq3 = 5.times.map { rng3.next_u }.to_a
+    seq0 = Array.new(5) { rng0.next_u }
+    seq1 = Array.new(5) { rng1.next_u }
+    seq2 = Array.new(5) { rng2.next_u }
+    seq3 = Array.new(5) { rng3.next_u }
 
     seq1.should_not eq(seq0)
     seq1.should_not eq(seq2)

--- a/src/random.cr
+++ b/src/random.cr
@@ -103,9 +103,9 @@ module Random
   # split1 = random.split
   # split2 = random.split
   #
-  # 5.times.map { random.rand(99) }.to_a # => [79, 42, 54, 17, 52]
-  # 5.times.map { split1.rand(99) }.to_a # => [90, 37, 15, 74, 61]
-  # 5.times.map { split2.rand(99) }.to_a # => [6, 87, 5, 73, 71]
+  # Array.new(5) { random.rand(99) } # => [79, 42, 54, 17, 52]
+  # Array.new(5) { split1.rand(99) } # => [90, 37, 15, 74, 61]
+  # Array.new(5) { split2.rand(99) } # => [6, 87, 5, 73, 71]
   # ```
   def split : self
     copy = dup


### PR DESCRIPTION
`Array.new` has the same behavior and avoids the creation of an `Iterator`.