### PR TITLE
Merge adjacent StringLiterals before yielding

### DIFF
--- a/spec/compiler/parser/to_s_spec.cr
+++ b/spec/compiler/parser/to_s_spec.cr
@@ -330,6 +330,9 @@ describe "ASTNode#to_s" do
   expect_to_s %q(`\n\0`), %q(`\n\u0000`)
   expect_to_s %q(`#{1}\n\0`), %q(`#{1}\n\u0000`)
   expect_to_s Call.new("`", Call.new("String".path, "interpolation", "x".var, global: true)), %q(`#{::String.interpolation(x)}`)
+  expect_to_s StringInterpolation.new(["#".string, "{foo}".string] of ASTNode), %q("\#{foo}")
+  expect_to_s StringInterpolation.new([2.int32, " ".string, "#".string, "{".string] of ASTNode), %q("#{2} \#{")
+  expect_to_s StringInterpolation.new(["a".string, "b".string] of ASTNode), %q("ab")
   expect_to_s "macro foo\n{% verbatim do %}1{% end %}\nend"
   expect_to_s Assign.new("x".var, Expressions.new([1.int32, 2.int32] of ASTNode)), "x = (1\n2\n)"
   expect_to_s "foo.*"

--- a/spec/compiler/semantic/macro_spec.cr
+++ b/spec/compiler/semantic/macro_spec.cr
@@ -1627,6 +1627,19 @@ describe "Semantic: macro" do
       CRYSTAL
   end
 
+  it "preserves escaped interpolation in verbatim (#16413)" do
+    assert_type(<<-'CRYSTAL') { nil_type }
+      {% begin %}
+        {% verbatim do %}
+          {%
+            name = "FOO"
+            "\#{get_env(#{name})}"
+          %}
+        {% end %}
+      {% end %}
+      CRYSTAL
+  end
+
   it "can use macro in instance var initializer (#7666)" do
     assert_type(<<-CRYSTAL) { string }
       class Foo

--- a/src/compiler/crystal/syntax/to_s.cr
+++ b/src/compiler/crystal/syntax/to_s.cr
@@ -136,13 +136,16 @@ module Crystal
     end
 
     def visit_interpolation(node, &)
-      node.expressions.each do |exp|
-        if exp.is_a?(StringLiteral)
-          @str << yield exp.value
+      node.expressions.chunks(&.is_a?(StringLiteral)).each do |(is_string, exps)|
+        if is_string
+          value = exps.join(&.as(StringLiteral).value)
+          @str << yield value
         else
-          @str << "\#{"
-          exp.accept(self)
-          @str << '}'
+          exps.each do |exp|
+            @str << "\#{"
+            exp.accept(self)
+            @str << '}'
+          end
         end
       end
     end


### PR DESCRIPTION
Fixes #16413

Joins adjacent `StringLiteral` values before yielding within interpolations to ensure string is properly escaped if needed. E.g. in the following example:

```cr
{% begin %}
  {% verbatim do %}
    {%
      puts %(#{2} ##{"{"}}) # => 2 #{}
    %}
  {% end %}
{% end %}
```
The string value `" \#{}"` is yielded all at once, versus before each character (` `, `#`, `{`, and `}`) were all yielded on their own which prevented proper escaping of the interpolation.
