### PR TITLE
Fix incorrect formatting of multi-line macro expression with comment as first line

### DIFF
--- a/spec/compiler/formatter/formatter_spec.cr
+++ b/spec/compiler/formatter/formatter_spec.cr
@@ -1929,6 +1929,11 @@ describe Crystal::Formatter do
   assert_format "   {%\na = 1 %}", "{%\n  a = 1\n%}"
   assert_format "   {%\na = 1\n   %}", "{%\n  a = 1\n%}"
 
+  # Multi-line macro expression with comment as first line (issue #14450)
+  assert_format "{%\n  # comment\n  a = 1\n%}"
+  assert_format "{%\n  # comment 1\n  # comment 2\n  a = 1\n%}"
+  assert_format "{{\n  # comment\n  a + 1\n}}"
+
   assert_format "macro foo\n  {{\n1 + 2 }}\nend", "macro foo\n  {{\n    1 + 2\n  }}\nend"
   assert_format "macro foo\n  def bar\n    {{\n      1 + 2\n    }}\n  end\nend"
   assert_format "foo &.[]"

--- a/src/compiler/crystal/tools/formatter.cr
+++ b/src/compiler/crystal/tools/formatter.cr
@@ -1928,20 +1928,26 @@ module Crystal
       has_space = @token.type.space?
       skip_space
       has_newline = @token.type.newline?
-      skip_space_or_newline
-
-      if (has_space || !node.output?) && !has_newline
-        write " "
-      end
 
       old_indent = @indent
       @indent = @column
+
       if has_newline
         write_line
         write_indent
+        skip_space_or_newline
+        if @line_output.empty?
+          write_indent(@indent, node.exp)
+        else
+          indent(@indent, node.exp)
+        end
+      else
+        skip_space_or_newline
+        if has_space || !node.output?
+          write " "
+        end
+        indent(@column, node.exp)
       end
-
-      indent(@column, node.exp)
 
       @indent = old_indent
 


### PR DESCRIPTION
Fixes https://github.com/crystal-lang/crystal/issues/14450