### PR TITLE
Fix reorder `Process.lock_write` outside of `block_signals`

### DIFF
--- a/src/crystal/system/unix/spawn.cr
+++ b/src/crystal/system/unix/spawn.cr
@@ -59,7 +59,7 @@ struct Crystal::System::Process
   end
 
   private def self.fork_for_exec
-    lock_write do
+    result = lock_write do
       block_signals do |sigmask|
         case pid = LibC.fork
         when 0
@@ -73,12 +73,18 @@ struct Crystal::System::Process
           nil
         when -1
           # forking process: error
-          raise RuntimeError.from_errno("fork")
+          Errno.value
         else
           # forking process: success
           pid
         end
       end
+    end
+
+    if result.is_a?(Errno)
+      raise RuntimeError.from_os_error("fork", result)
+    else
+      result
     end
   end
 


### PR DESCRIPTION
Signals shouldn't be blocked while the process potentially waits to acquire the write lock. So `lock_write` must be the outermost block.

Best review with whitespace changes hidden.

Originally suggested in https://github.com/crystal-lang/crystal/pull/16402#discussion_r2553146473