### PR TITLE
Fix use after unlink in `XML::Node`

### DIFF
--- a/src/xml/node.cr
+++ b/src/xml/node.cr
@@ -719,12 +719,14 @@ class XML::Node
   protected def unlink_cached_children(node : LibXML::Node*) : Nil
     child = node.value.children
     while child
-      if obj = cached?(node)
+      # save next pointer before unlinking, as `xmlUnlinkNode` clears it
+      next_child = child.value.next
+      if obj = cached?(child)
         obj.unlink
       else
         unlink_cached_children(child)
       end
-      child = child.value.next
+      child = next_child
     end
   end
 end


### PR DESCRIPTION
This code works because attributes only have a single text node in practice, but the use after unlink is troublesome. The code also checks (`obj = cached?(node)`) the parent when iterating over the children. There is no memory leak here, but I am including the PR since I think it brings the implementation in line with the name of the method.