### PR TITLE
Drop `focus` forwarding in spec helper methods

### DIFF
--- a/spec/compiler/crystal/tools/macro_code_coverage_spec.cr
+++ b/spec/compiler/crystal/tools/macro_code_coverage_spec.cr
@@ -1,8 +1,8 @@
 require "../../../spec_helper"
 include Crystal
 
-private def assert_coverage(code, expected_coverage, *, expected_error : String? = nil, focus : Bool = false, spec_file = __FILE__, spec_line = __LINE__)
-  it focus: focus, file: spec_file, line: spec_line do
+private def assert_coverage(code, expected_coverage, *, expected_error : String? = nil, spec_file = __FILE__, spec_line = __LINE__)
+  it file: spec_file, line: spec_line do
     processor = MacroCoverageProcessor.new
 
     compiler = Compiler.new

--- a/spec/compiler/formatter/formatter_spec.cr
+++ b/spec/compiler/formatter/formatter_spec.cr
@@ -1,8 +1,8 @@
 require "spec"
 require "../../../src/compiler/crystal/formatter"
 
-private def assert_format(input, output = input, strict = false, flags = nil, file = __FILE__, line = __LINE__, focus = false)
-  it "formats #{input.inspect}", file, line, focus: focus do
+private def assert_format(input, output = input, strict = false, flags = nil, file = __FILE__, line = __LINE__)
+  it "formats #{input.inspect}", file, line do
     output = "#{output}\n" unless strict
     result = Crystal.format(input, flags: flags)
     unless result == output

--- a/spec/compiler/parser/parser_spec.cr
+++ b/spec/compiler/parser/parser_spec.cr
@@ -4,8 +4,8 @@ private def regex(string, options = Regex::CompileOptions::None)
   RegexLiteral.new(StringLiteral.new(string), options)
 end
 
-private def it_parses(string, expected_node, file = __FILE__, line = __LINE__, *, focus : Bool = false)
-  it "parses #{string.dump}", file, line, focus: focus do
+private def it_parses(string, expected_node, file = __FILE__, line = __LINE__)
+  it "parses #{string.dump}", file, line do
     parser = Parser.new(string)
     parser.filename = "/foo/bar/baz.cr"
     node = parser.parse
@@ -40,8 +40,8 @@ private def node_source(string, node)
   source_between(string, node.location, node.end_location)
 end
 
-private def assert_end_location(source, line_number = 1, column_number = source.size, file = __FILE__, line = __LINE__, *, focus : Bool = false)
-  it "gets corrects end location for #{source.inspect}", file, line, focus: focus do
+private def assert_end_location(source, line_number = 1, column_number = source.size, file = __FILE__, line = __LINE__)
+  it "gets corrects end location for #{source.inspect}", file, line do
     string = "#{source}; 1"
     parser = Parser.new(string)
     node = parser.parse.as(Expressions).expressions[0]

--- a/spec/compiler/parser/to_s_spec.cr
+++ b/spec/compiler/parser/to_s_spec.cr
@@ -1,7 +1,7 @@
 require "../../support/syntax"
 
-private def expect_to_s(original, expected = original, emit_doc = false, file = __FILE__, line = __LINE__, focus = false)
-  it "does to_s of #{original.inspect}", file, line, focus: focus do
+private def expect_to_s(original, expected = original, emit_doc = false, file = __FILE__, line = __LINE__)
+  it "does to_s of #{original.inspect}", file, line do
     str = IO::Memory.new expected.bytesize
 
     source = original

--- a/spec/support/syntax.cr
+++ b/spec/support/syntax.cr
@@ -133,8 +133,8 @@ class Crystal::ASTNode
   end
 end
 
-def assert_syntax_error(str, message = nil, line = nil, column = nil, metafile = __FILE__, metaline = __LINE__, metaendline = __END_LINE__, *, focus : Bool = false)
-  it "says syntax error on #{str.inspect}", metafile, metaline, metaendline, focus: focus do
+def assert_syntax_error(str, message = nil, line = nil, column = nil, metafile = __FILE__, metaline = __LINE__, metaendline = __END_LINE__)
+  it "says syntax error on #{str.inspect}", metafile, metaline, metaendline do
     begin
       parse str
       fail "Expected SyntaxException to be raised", metafile, metaline

--- a/spec/support/wasm32.cr
+++ b/spec/support/wasm32.cr
@@ -2,7 +2,7 @@ require "spec"
 
 {% if flag?(:wasm32) %}
   def pending_wasm32(description = "assert", file = __FILE__, line = __LINE__, end_line = __END_LINE__, focus : Bool = false, tags : String | Enumerable(String) | Nil = nil, &block)
-    pending("#{description} [wasm32]", file, line, end_line, focus: focus, tags: tags)
+    pending("#{description} [wasm32]", file, line, end_line, focus: focus, tags: tags) # ameba:disable Lint/SpecFocus
   end
 
   def pending_wasm32(*, describe, file = __FILE__, line = __LINE__, end_line = __END_LINE__, &block)
@@ -10,7 +10,7 @@ require "spec"
   end
 {% else %}
   def pending_wasm32(description = "assert", file = __FILE__, line = __LINE__, end_line = __END_LINE__, focus : Bool = false, tags : String | Enumerable(String) | Nil = nil, &block)
-    it(description, file, line, end_line, focus: focus, tags: tags, &block)
+    it(description, file, line, end_line, focus: focus, tags: tags, &block) # ameba:disable Lint/SpecFocus
   end
 
   def pending_wasm32(*, describe, file = __FILE__, line = __LINE__, end_line = __END_LINE__, &block)


### PR DESCRIPTION
[Ameba doesn't like it very much](https://github.com/crystal-lang/crystal/actions/runs/19677685672/job/56363300790?pr=16427), even when the `focus` argument is not the `true` literal. The workaround during development would be wrapping the specs of interest inside a `describe(focus: true)` block.

I retained the `focus` parameter in `pending_wasm32` because its sole purpose is to match `describe` and `it`'s method signatures.