### PR TITLE
Add `::exit(Process::Status)`

### DIFF
--- a/spec/std/kernel_spec.cr
+++ b/spec/std/kernel_spec.cr
@@ -53,6 +53,16 @@ describe "exit" do
     status.success?.should be_false
     status.exit_code.should eq(42)
   end
+
+  it "exists with Process::Status", tags: %w[slow] do
+    status, _, _ = compile_and_run_source "exit Process::Status.new(0)"
+    status.success?.should be_true
+  end
+
+  it "exists with abnormal status", tags: %w[slow] do
+    status, _, _ = compile_and_run_source "exit Process::Status.new({% if flag?(:unix) %}Signal::INT.value{% else %}LibC::STATUS_CONTROL_C_EXIT{% end %})"
+    status.exit_reason.should eq Process::ExitReason::Interrupted
+  end
 end
 
 describe "at_exit" do

--- a/src/crystal/at_exit_handlers.cr
+++ b/src/crystal/at_exit_handlers.cr
@@ -9,6 +9,14 @@ module Crystal::AtExitHandlers
     end
   end
 
+  def self.run(status : ::Process::Status, exception = nil)
+    if code = status.exit_code?
+      run(code, exception)
+    else
+      status
+    end
+  end
+
   def self.run(status, exception = nil)
     return status unless @@handlers
 

--- a/src/crystal/system/win32/process.cr
+++ b/src/crystal/system/win32/process.cr
@@ -119,8 +119,12 @@ struct Crystal::System::Process
     LibC.TerminateProcess(@process_handle, 1)
   end
 
-  def self.exit(status)
+  def self.exit(status : Int32)
     LibC.exit(status)
+  end
+
+  def self.exit(status : ::Process::Status)
+    exit status.system_exit_status.to_i32!
   end
 
   def self.pid

--- a/src/kernel.cr
+++ b/src/kernel.cr
@@ -563,7 +563,7 @@ end
 # to the invoking environment.
 #
 # Registered `at_exit` procs are executed.
-def exit(status = 0) : NoReturn
+def exit(status : Int32 | Process::Status = 0) : NoReturn
   status = Crystal::AtExitHandlers.run status
   Crystal.ignore_stdio_errors { STDOUT.flush }
   Crystal.ignore_stdio_errors { STDERR.flush }

--- a/src/process.cr
+++ b/src/process.cr
@@ -17,7 +17,7 @@ class Process
   # not run any handlers registered with `at_exit`, use `::exit` for that.
   #
   # *status* is the exit status of the current process.
-  def self.exit(status = 0) : NoReturn
+  def self.exit(status : Int32 | Process::Status = 0) : NoReturn
     Crystal::System::Process.exit(status)
   end
 


### PR DESCRIPTION
This overload easily allows forwarding the exit status of a sub-process like this:
```cr
status = Process.run("exit 12", shell: true)
exit status
```

It's a component for building a `Process.exec` alternative with portable semantics (#14422). But I figure it can be useful on its own, so it should be exposed in the public API.