### PR TITLE
LLVM: simplify target initialization and support more targets

### DIFF
--- a/scripts/generate_llvm_version_info.cr
+++ b/scripts/generate_llvm_version_info.cr
@@ -5,36 +5,7 @@
 # LLVM installation different from the one bundled with Crystal.
 
 require "c/libloaderapi"
-
-# The list of supported targets are hardcoded in:
-# https://github.com/llvm/llvm-project/blob/main/llvm/CMakeLists.txt
-LLVM_ALL_TARGETS = %w(
-  AArch64
-  AMDGPU
-  ARM
-  AVR
-  BPF
-  Hexagon
-  Lanai
-  LoongArch
-  Mips
-  MSP430
-  NVPTX
-  PowerPC
-  RISCV
-  Sparc
-  SPIRV
-  SystemZ
-  VE
-  WebAssembly
-  X86
-  XCore
-  ARC
-  CSKY
-  DirectX
-  M68k
-  Xtensa
-)
+require "llvm/lib_llvm/config"
 
 def find_dll_in_env_path
   ENV["PATH"]?.try &.split(Process::PATH_DELIMITER, remove_empty: true) do |path|
@@ -62,7 +33,7 @@ begin
   patch = uninitialized LibC::UInt
   llvm_get_version.call(pointerof(major), pointerof(minor), pointerof(patch))
 
-  targets_built = LLVM_ALL_TARGETS.select do |target|
+  targets_built = LibLLVM::ALL_TARGETS.select do |target|
     LibC.GetProcAddress(dll, "LLVMInitialize#{target}Target") && LibC.GetProcAddress(dll, "LLVMInitialize#{target}TargetInfo")
   end
 

--- a/src/llvm.cr
+++ b/src/llvm.cr
@@ -18,18 +18,19 @@ module LLVM
     {% end %}
   end
 
-  {% for target, name in LibLLVM::TARGETS %}
-    @@initialized_{{name.id}} = Atomic(Bool).new(false)
+  {% for target in LibLLVM::ALL_TARGETS %}
+    {% name = target.downcase.id %}
+    @@initialized_{{name}} = Atomic(Bool).new(false)
 
-    def self.init_{{name.id}} : Nil
-      return if @@initialized_{{name.id}}.swap(true)
+    def self.init_{{name}} : Nil
+      return if @@initialized_{{name}}.swap(true)
 
-      \{% if LibLLVM::BUILT_TARGETS.includes?({{name}}) %}
-        LibLLVM.initialize_{{name.id}}_target_info
-        LibLLVM.initialize_{{name.id}}_target
-        LibLLVM.initialize_{{name.id}}_target_mc
-        LibLLVM.initialize_{{name.id}}_asm_printer
-        LibLLVM.initialize_{{name.id}}_asm_parser
+      \{% if LibLLVM::BUILT_TARGETS.includes?({{name.symbolize}}) %}
+        LibLLVM.initialize_{{name}}_target_info
+        LibLLVM.initialize_{{name}}_target
+        LibLLVM.initialize_{{name}}_target_mc
+        LibLLVM.initialize_{{name}}_asm_printer
+        LibLLVM.initialize_{{name}}_asm_parser
         LibLLVM.link_in_mc_jit
       \{% else %}
         raise "ERROR: LLVM was built without {{target.id}} target"
@@ -54,8 +55,11 @@ module LLVM
   end
 
   def self.init_all_targets : Nil
-    {% for name in LibLLVM::BUILT_TARGETS %}
-      init_{{name.id}}
+    {% for target in LibLLVM::ALL_TARGETS %}
+      {% name = target.downcase.id %}
+      \{% if LibLLVM::BUILT_TARGETS.includes?({{name.symbolize}}) %}
+        init_{{name}}
+      \{% end %}
     {% end %}
   end
 

--- a/src/llvm/lib_llvm.cr
+++ b/src/llvm/lib_llvm.cr
@@ -51,39 +51,6 @@
   lib LibLLVM
     VERSION = {{ llvm_version.strip.gsub(/git/, "").gsub(/-?rc.*/, "") }}
     BUILT_TARGETS = {{ llvm_targets.strip.downcase.gsub(/;|,/, " ").split(' ').map(&.id.symbolize) }}
-
-    # The list of targets is hardcoded at:
-    # https://github.com/llvm/llvm-project/blob/main/llvm/CMakeLists.txt
-    TARGETS = {
-      # enabled by default
-      "AArch64" => :aarch64,
-      "AMDGPU" => :amdgpu,
-      "ARM" => :arm,
-      "AVR" => :avr,
-      "BPF" => :bpf,
-      "Hexagon" => :hexagon,
-      "Lanai" => :lanai,
-      "LoongArch" => :loongarch,
-      "MSP430" => :msp430,
-      "Mips" => :mips,
-      "NVPTX" => :nvptx,
-      "PowerPC" => :powerpc,
-      "RISCV" => :riscv,
-      "SPIRV" => :spirv,
-      "Sparc" => :sparc,
-      "SystemZ" => :systemz,
-      "VE" => :ve,
-      "WebAssembly" => :webassembly,
-      "X86" => :x86,
-      "XCore" => :xcore,
-
-      # experimental
-      "ARC" => :arc,
-      "CSKY" => :csky,
-      "DirectX" => :directx,
-      "M68k" => :m68k,
-      "Xtensa" => :xtensa,
-    }
   end
 {% end %}
 
@@ -120,4 +87,5 @@ lib LibLLVM
   alias SizeT = LibC::SizeT
 end
 
+require "./lib_llvm/config"
 require "./lib_llvm/**"

--- a/src/llvm/lib_llvm/config.cr
+++ b/src/llvm/lib_llvm/config.cr
@@ -1,0 +1,35 @@
+# The list of supported targets are hardcoded in:
+# https://github.com/llvm/llvm-project/blob/main/llvm/CMakeLists.txt
+
+lib LibLLVM
+  ALL_TARGETS = [
+    # default targets (as of LLVM 21)
+    "AArch64",
+    "AMDGPU",
+    "ARM",
+    "AVR",
+    "BPF",
+    "Hexagon",
+    "Lanai",
+    "LoongArch",
+    "MSP430",
+    "Mips",
+    "NVPTX",
+    "PowerPC",
+    "RISCV",
+    "SPIRV",
+    "Sparc",
+    "SystemZ",
+    "VE",
+    "WebAssembly",
+    "X86",
+    "XCore",
+
+    # experimental targets (as of LLVM 21)
+    "ARC",
+    "CSKY",
+    "DirectX",
+    "M68k",
+    "Xtensa",
+  ]
+end

--- a/src/llvm/lib_llvm/target.cr
+++ b/src/llvm/lib_llvm/target.cr
@@ -3,12 +3,13 @@ require "./types"
 lib LibLLVM
   type TargetDataRef = Void*
 
-  {% for target, name in TARGETS %}
-    fun initialize_{{name.id}}_target_info = LLVMInitialize{{target.id}}TargetInfo
-    fun initialize_{{name.id}}_target = LLVMInitialize{{target.id}}Target
-    fun initialize_{{name.id}}_target_mc = LLVMInitialize{{target.id}}TargetMC
-    fun initialize_{{name.id}}_asm_printer = LLVMInitialize{{target.id}}AsmPrinter
-    fun initialize_{{name.id}}_asm_parser = LLVMInitialize{{target.id}}AsmParser
+  {% for target in ALL_TARGETS %}
+    {% name = target.downcase.id %}
+    fun initialize_{{name}}_target_info = LLVMInitialize{{target.id}}TargetInfo
+    fun initialize_{{name}}_target = LLVMInitialize{{target.id}}Target
+    fun initialize_{{name}}_target_mc = LLVMInitialize{{target.id}}TargetMC
+    fun initialize_{{name}}_asm_printer = LLVMInitialize{{target.id}}AsmPrinter
+    fun initialize_{{name}}_asm_parser = LLVMInitialize{{target.id}}AsmParser
   {% end %}
 
   fun set_module_data_layout = LLVMSetModuleDataLayout(m : ModuleRef, dl : TargetDataRef)


### PR DESCRIPTION
The LLVM bindings only expose the targets that the Crystal compiler itself supports, and each target copy-pastes the LibLLVM bindings and LLVM init methods which should use a macro.

I introduce a `LibLLVM::ALL_TARGETS` constant that's only used in macros to check if a known target has been built and generate the bindings and init methods accordingly.

~~The constant is a Hash because we need the original LLVM target name (e.g. `AArch64`) and Crystal chose to use lowercased symbols and aliases (e.g. `aarch64`). Maybe it should be an Array and macros use `target.id.downcase` instead :thinking:~~ The constant is now an Array.

The `@@initialized_` class variables are now an atomic, and the dead `@@initialized` has been removed.

~~The list of targets is duplicated with the `scripts/generate_llvm_version_info.cr` file but the script musn't load `src/llvm/lib_llvm.cr`. Maybe the target list could be extracted into another file :thinking:~~ The list has been extracted to `src/llvm/lib_llvm/config.cr`.