### PR TITLE
Deprecate `StringLiteral#split(ASTNode)` for non-separator arguments

### DIFF
--- a/src/compiler/crystal/macros.cr
+++ b/src/compiler/crystal/macros.cr
@@ -82,11 +82,24 @@ private macro def_string_methods(klass)
   def lines : ArrayLiteral(StringLiteral)
   end
 
-  # Similar to `String#split`.
+  # Similar to `String#split()`.
   def split : ArrayLiteral(StringLiteral)
   end
 
-  # Similar to `String#split`.
+  # Similar to `String#split(String)`.
+  def split(node : StringLiteral) : ArrayLiteral(StringLiteral)
+  end
+
+  # Similar to `String#split(Char)`.
+  def split(node : CharLiteral) : ArrayLiteral(StringLiteral)
+  end
+
+  # Similar to `String#split(Regex)`.
+  def split(node : RegexLiteral) : ArrayLiteral(StringLiteral)
+  end
+
+  # Similar to `String#split(String)`.
+  @[Deprecated("Use `#split(StringLiteral)` instead")]
   def split(node : ASTNode) : ArrayLiteral(StringLiteral)
   end
 

--- a/src/compiler/crystal/macros/methods.cr
+++ b/src/compiler/crystal/macros/methods.cr
@@ -855,6 +855,7 @@ module Crystal
             when RegexLiteral
               splitter = regex_value(arg)
             else
+              interpreter.warnings.add_warning_at(name_loc, "Deprecated StringLiteral#split(ASTNode). Use `#split(StringLiteral)` instead")
               splitter = arg.to_s
             end
 


### PR DESCRIPTION
Closes #15799.