### PR TITLE
CI: Run smoke tests on docker images

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -354,6 +354,7 @@ jobs:
           source build.env
           cd docker
           make all64 TARBALLS=/tmp/workspace/build/
+          make smoke-all
       - persist_to_workspace:
           root: /tmp/workspace/distribution-scripts/docker/
           paths:


### PR DESCRIPTION
Updates `distribution-scripts` dependency to https://github.com/crystal-lang/distribution-scripts/commit/b7af456b433ebf114769ad8eb4f2c51c56c26189

This includes the following changes:

* crystal-lang/distribution-scripts#392
