### PR TITLE
Rescale execution context in spec runner with `CRYSTAL_WORKERS`

### DIFF
--- a/src/spec.cr
+++ b/src/spec.cr
@@ -130,6 +130,12 @@ module Spec
         Process.on_terminate { abort! }
       {% end %}
 
+      {% if flag?(:execution_context) %}
+        if count = ENV["CRYSTAL_WORKERS"]?.try(&.to_i?)
+          Fiber::ExecutionContext.current.resize(count)
+        end
+      {% end %}
+
       run
     end
   end


### PR DESCRIPTION
When running specs with execution contexts, it's annoying to have to explicitly scale the default execution context in order to get actual parallelism. This could be handled in some kind of spec helper, but it would still require extra effort and it'd be easy to miss out on it.

Thus, I'm suggesting to resize the EC in the stdlib `spec` package (i.e. for _any_ spec program) if the environment variable `CRYSTAL_WORKERS` is defined.

Extracted from #16339