### PR TITLE
Revert "Fix reorder `Process.lock_write` outside of `block_signals`"

### DIFF
--- a/src/crystal/system/unix/spawn.cr
+++ b/src/crystal/system/unix/spawn.cr
@@ -59,32 +59,24 @@ struct Crystal::System::Process
   end
 
   private def self.fork_for_exec
-    result = lock_write do
-      block_signals do |sigmask|
-        case pid = LibC.fork
-        when 0
-          # forked process
+    block_signals do |sigmask|
+      case pid = lock_write { LibC.fork }
+      when 0
+        # forked process
 
-          Crystal::System::Signal.after_fork_before_exec
+        Crystal::System::Signal.after_fork_before_exec
 
-          # reset sigmask (inherited on exec)
-          LibC.sigemptyset(sigmask)
+        # reset sigmask (inherited on exec)
+        LibC.sigemptyset(sigmask)
 
-          nil
-        when -1
-          # forking process: error
-          Errno.value
-        else
-          # forking process: success
-          pid
-        end
+        nil
+      when -1
+        # forking process: error
+        raise RuntimeError.from_errno("fork")
+      else
+        # forking process: success
+        pid
       end
-    end
-
-    if result.is_a?(Errno)
-      raise RuntimeError.from_os_error("fork", result)
-    else
-      result
     end
   end
 


### PR DESCRIPTION
#16431 completely stalls macos CI runners. I missed that CI failure before merging.

Macos is the only (?) major platform where `lock_write` is _not_ a no-op.

Reverts crystal-lang/crystal#16431