### PR TITLE
Make all overloads of `ArrayLiteral#[]` return `nil` on out of bounds

### DIFF
--- a/spec/compiler/macro/macro_methods_spec.cr
+++ b/spec/compiler/macro/macro_methods_spec.cr
@@ -1037,8 +1037,18 @@ module Crystal
         assert_macro %({{ [1, 2, 3, 4][nil..nil] }}), %([1, 2, 3, 4])
       end
 
+      it "executes [] with range, start is out of bounds" do
+        assert_macro %({{ [1, 2, 3, 4][5..] }}), %(nil)
+        assert_macro %({{ [1, 2, 3, 4][-5..] }}), %(nil)
+      end
+
       it "executes [] with two numbers" do
         assert_macro %({{ [1, 2, 3, 4, 5][1, 3] }}), %([2, 3, 4])
+      end
+
+      it "executes [] with two numbers, start is out of bounds" do
+        assert_macro %({{ [1, 2, 3, 4][5, 1] }}), %(nil)
+        assert_macro %({{ [1, 2, 3, 4][-5, 4] }}), %(nil)
       end
 
       it "executes []=" do
@@ -1333,6 +1343,20 @@ module Crystal
         assert_macro %({{ {1, 2, 3, 4}[nil...2] }}), %({1, 2})
         assert_macro %({{ {1, 2, 3, 4}[..] }}), %({1, 2, 3, 4})
         assert_macro %({{ {1, 2, 3, 4}[nil..nil] }}), %({1, 2, 3, 4})
+      end
+
+      it "executes [] with range, start is out of bounds" do
+        assert_macro %({{ {1, 2, 3, 4}[5..] }}), %(nil)
+        assert_macro %({{ {1, 2, 3, 4}[-5..] }}), %(nil)
+      end
+
+      it "executes [] with two numbers" do
+        assert_macro %({{ {1, 2, 3, 4, 5}[1, 3] }}), %({2, 3, 4})
+      end
+
+      it "executes [] with two numbers, start is out of bounds" do
+        assert_macro %({{ {1, 2, 3, 4}[5, 1] }}), %(nil)
+        assert_macro %({{ {1, 2, 3, 4}[-5, 4] }}), %(nil)
       end
 
       it "executes size" do

--- a/src/compiler/crystal/macros.cr
+++ b/src/compiler/crystal/macros.cr
@@ -784,12 +784,16 @@ module Crystal::Macros
     def uniq : ArrayLiteral
     end
 
-    # Similar to `Array#[]`, but returns `NilLiteral` on out of bounds.
+    # Similar to `Array#[]?(Int)`.
     def [](index : NumberLiteral) : ASTNode
     end
 
-    # Similar to `Array#[]`.
-    def [](index : RangeLiteral) : ArrayLiteral(ASTNode)
+    # Similar to `Array#[]?(Range)`.
+    def [](index : RangeLiteral) : ArrayLiteral(ASTNode) | NilLiteral
+    end
+
+    # Similar to `Array#[]?(Int, Int)`.
+    def [](start : NumberLiteral, count : NumberLiteral) : ArrayLiteral(ASTNode) | NilLiteral
     end
 
     # Similar to `Array#[]=`.
@@ -1098,12 +1102,17 @@ module Crystal::Macros
     def uniq : TupleLiteral
     end
 
-    # Similar to `Tuple#[]`, but returns `NilLiteral` on out of bounds.
+    # Similar to `Tuple#[]?(Int)`.
     def [](index : NumberLiteral) : ASTNode
     end
 
-    # Similar to `Tuple#[]`.
-    def [](index : RangeLiteral) : TupleLiteral(ASTNode)
+    # Similar to `Tuple#[]?(Range)`.
+    def [](index : RangeLiteral) : TupleLiteral | NilLiteral
+    end
+
+    # Similar to `Array#[]?(Int, Int)`, but returns another `TupleLiteral`
+    # instead of an `ArrayLiteral`.
+    def [](start : NumberLiteral, count : NumberLiteral) : TupleLiteral | NilLiteral
     end
 
     # Similar to `Array#[]=`.

--- a/src/compiler/crystal/macros/methods.cr
+++ b/src/compiler/crystal/macros/methods.cr
@@ -3145,12 +3145,8 @@ private def interpret_array_or_tuple_method(object, klass, method, args, named_a
 
         from = from.to_number.to_i
         to = to.to_number.to_i
-
-        begin
-          klass.new(object.elements[from, to])
-        rescue ex
-          object.raise ex.message
-        end
+        values = object.elements[from, to]?
+        values ? klass.new(values) : Crystal::NilLiteral.new
       else
         case arg = from
         when Crystal::NumberLiteral
@@ -3158,11 +3154,8 @@ private def interpret_array_or_tuple_method(object, klass, method, args, named_a
           object.elements[index]? || Crystal::NilLiteral.new
         when Crystal::RangeLiteral
           range = arg.interpret_to_nilable_range(interpreter)
-          begin
-            klass.new(object.elements[range])
-          rescue ex
-            object.raise ex.message
-          end
+          values = object.elements[range]?
+          values ? klass.new(values) : Crystal::NilLiteral.new
         else
           arg.raise "argument to [] must be a number or range, not #{arg.class_desc}:\n\n#{arg}"
         end


### PR DESCRIPTION
The single-index overload in the macro language has always behaved like `#[]?` in non-macro code, so I don't think there is any particular benefit in making both the range overload and the start + count overload both raise on out-of-bounds start indices.

This actually applies to `TupleLiteral` as well.