### PR TITLE
Fix: remove 1 second sleep in openssl/ssl/server spec

### DIFF
--- a/spec/std/openssl/ssl/server_spec.cr
+++ b/spec/std/openssl/ssl/server_spec.cr
@@ -130,7 +130,6 @@ describe OpenSSL::SSL::Server do
 
     OpenSSL::SSL::Server.open tcp_server, server_context do |server|
       spawn do
-        sleep 1.second
         OpenSSL::SSL::Socket::Client.open(TCPSocket.new(tcp_server.local_address.address, tcp_server.local_address.port), client_context, hostname: "example.com") do |socket|
         end
       end


### PR DESCRIPTION
There's no need for the sleep: the server has started when we spawn to create a client.

Fixup #7291.