### PR TITLE
Add `/etc/zoneinfo` to zoneinfo lookup paths

### DIFF
--- a/src/crystal/system/unix/time.cr
+++ b/src/crystal/system/unix/time.cr
@@ -76,7 +76,7 @@ module Crystal::System::Time
     "/usr/share/zoneinfo/",
     "/usr/share/lib/zoneinfo/",
     "/usr/lib/locale/TZ/",
-    "/etc/zoneinfo",
+    "/etc/zoneinfo/",
   }
 
   # Android Bionic C-specific locations. These are files rather than directories


### PR DESCRIPTION
The IANA time zone database on NixOS is stored at `/etc/zoneinfo`
Resolves #16459
