### PR TITLE
Fix reorder `Process.lock_write` outside of `.block_signals`

### DIFF
--- a/src/crystal/system/unix/process.cr
+++ b/src/crystal/system/unix/process.cr
@@ -224,7 +224,7 @@ struct Crystal::System::Process
       nil
     when -1
       # forking process: error
-      RuntimeError.from_os_error("fork", errno)
+      raise RuntimeError.from_os_error("fork", errno)
     else
       # forking process: success
       pid

--- a/src/crystal/system/unix/spawn.cr
+++ b/src/crystal/system/unix/spawn.cr
@@ -80,7 +80,7 @@ struct Crystal::System::Process
       nil
     when -1
       # forking process: error
-      RuntimeError.from_os_error("fork", errno)
+      raise RuntimeError.from_os_error("fork", errno)
     else
       # forking process: success
       pid


### PR DESCRIPTION
This was originally submitted as #16431 but reverted because it broke macos CI.

Signals shouldn't be blocked while the process potentially waits to acquire the write lock. So `lock_write` must be the outermost block.

The fix moves `::Process.after_fork_child_callbacks` outside the `lock_write` to avoid a deadlock when `Signal.after_fork` acquire the lock to opens a new signal pipe.
This is not necessary in `fork_for_exec` because it only calls `Signal.after_fork_before_exec` which only resets signal handlers and closes the signal pipe, so it cannot deadlock.

Best review with whitespace changes hidden.

Originally suggested in https://github.com/crystal-lang/crystal/pull/16402#discussion_r2553146473

