### PR TITLE
Fix: resize default execution context, not current [fixup #16444]

### DIFF
--- a/src/spec.cr
+++ b/src/spec.cr
@@ -132,7 +132,7 @@ module Spec
 
       {% if flag?(:execution_context) %}
         if count = ENV["CRYSTAL_WORKERS"]?.try(&.to_i?)
-          Fiber::ExecutionContext.current.resize(count)
+          Fiber::ExecutionContext.default.resize(count)
         end
       {% end %}
 


### PR DESCRIPTION
We shall resize the `default` execution context (parallel), not the `current` context (may be an isolated context).