### PR TITLE
Fix: always use getrandom on Linux and Android >= 28

### DIFF
--- a/src/crystal/system/random.cr
+++ b/src/crystal/system/random.cr
@@ -12,11 +12,9 @@ end
 
 {% if flag?(:wasi) %}
   require "./wasi/random"
-{% elsif flag?(:android) && LibC::ANDROID_API >= 28 %}
-  require "./unix/getrandom"
 {% elsif flag?(:bsd) || flag?(:darwin) %}
   require "./unix/arc4random"
-{% elsif flag?(:linux) && !flag?(:android) %}
+{% elsif flag?(:linux) && (!flag?(:android) || LibC::ANDROID_API >= 28) %}
   require "./unix/getrandom"
 {% elsif flag?(:unix) %}
   require "./unix/urandom"


### PR DESCRIPTION
Crystal < 1.7 don't support calling the `has_method?` macro from the top level. We already assume the `getrandom` libc function to be available on every Linux targets with the exception of Android 24 to 27 for which we now check the actual API version instead of the libc fun.

Related to #16475