### PR TITLE
Fix: urandom initialization isn't thread safe + refactor

### DIFF
--- a/src/crystal/system/unix/urandom.cr
+++ b/src/crystal/system/unix/urandom.cr
@@ -4,7 +4,7 @@ module Crystal::System::Random
   @@initialized = false
   @@urandom : LibC::Int?
 
-  @[NeverInline]
+  @[NoInline]
   private def self.init
     Crystal.once(pointerof(@@initialized)) do
       # Directly open the urandom device without going through the event loop;


### PR DESCRIPTION
The urandom fallback on UNIX (barely used in practice) uses a lazy initializer based on a `@@initialized` boolean, and zero synchronization. It was thus possible for multiple threads to try to initialize at the same time (oops).

Also refactors the implementation to directly open `/dev/urandom` without going through the event loop. This isn't needed as reading from the device should never block, and as witnessed in #16470, reading may fail with EAGAIN and epoll never be notified (or something), so let's err on the safe side for the few cases where we use urandom (Android 8 and below).