### PR TITLE
CI: Push docker images directly to registry

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,7 +8,7 @@ parameters:
   distribution-scripts-version:
     description: "Git ref for version of https://github.com/crystal-lang/distribution-scripts/"
     type: string
-    default: "b7af456b433ebf114769ad8eb4f2c51c56c26189"
+    default: "d1d86577200f8a3d567bf83d911f60a05733c4b4"
   previous_crystal_base_url:
     description: "Prefix for URLs to Crystal bootstrap compiler"
     type: string
@@ -353,31 +353,14 @@ jobs:
           cd /tmp/workspace/distribution-scripts
           source build.env
           cd docker
-          make all64 TARBALLS=/tmp/workspace/build/
-          make smoke-all
-      - persist_to_workspace:
-          root: /tmp/workspace/distribution-scripts/docker/
-          paths:
-            - build
-
-  publish_docker:
-    machine:
-      image: default
-    steps:
-      - attach_workspace:
-          at: /tmp/workspace
+          make all TARBALLS=/tmp/workspace/build/ VERSION=${CRYSTAL_VERSION}
+          make smoke-all VERSION=${CRYSTAL_VERSION}
       - run: |
           cd /tmp/workspace/distribution-scripts
-          source ./build.env
-          gunzip -c /tmp/workspace/build/docker-${CRYSTAL_VERSION}-ubuntu-x86_64.tar.gz | docker image load
-          gunzip -c /tmp/workspace/build/docker-${CRYSTAL_VERSION}-ubuntu-x86_64-build.tar.gz | docker image load
-          gunzip -c /tmp/workspace/build/docker-${CRYSTAL_VERSION}-alpine.tar.gz | docker image load
-          gunzip -c /tmp/workspace/build/docker-${CRYSTAL_VERSION}-alpine-build.tar.gz | docker image load
+          source build.env
+          cd docker
           docker login -u ${DOCKER_USER} -p ${DOCKER_PASS}
-          docker push ${DOCKER_REPOSITORY}:${DOCKER_TAG}
-          docker push ${DOCKER_REPOSITORY}:${DOCKER_TAG}-build
-          docker push ${DOCKER_REPOSITORY}:${DOCKER_TAG}-alpine
-          docker push ${DOCKER_REPOSITORY}:${DOCKER_TAG}-alpine-build
+          make push VERSION=${CRYSTAL_VERSION}
 
   dist_snap:
     docker:
@@ -425,7 +408,6 @@ jobs:
           cd /tmp/workspace/distribution-scripts
           source build.env
           cd docs
-          gunzip -c /tmp/workspace/build/docker-${CRYSTAL_VERSION}-ubuntu-x86_64-build.tar.gz | docker image load
           make CRYSTAL_DOCKER_IMAGE=${DOCKER_REPOSITORY}:${DOCKER_TAG}-build
       - store_artifacts:
           path: /tmp/workspace/distribution-scripts/docs/build
@@ -523,10 +505,6 @@ workflows:
           filters: *release
           requires:
             - dist_snap
-      - publish_docker:
-          filters: *release
-          requires:
-            - dist_docker
       - dist_docs:
           filters: *release
           requires:
@@ -578,9 +556,6 @@ workflows:
       - publish_snap:
           requires:
             - dist_snap
-      - publish_docker:
-          requires:
-            - dist_docker
       - dist_docs:
           requires:
             - dist_docker


### PR DESCRIPTION
Exporting docker images to disk and reimporting them in the next job is very expensive. It's more efficient to push them directly from the builder job to the registry. `dist_docs` implicitly pulls the image from the registry.

Updates `distribution-scripts` dependency to https://github.com/crystal-lang/distribution-scripts/commit/d1d86577200f8a3d567bf83d911f60a05733c4b4

This includes the following changes:

* crystal-lang/distribution-scripts#395