### PR TITLE
Build snap arm64 target + drop publish_snap target

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -500,7 +500,6 @@ workflows:
           requires:
             - dist_linux
             - dist_darwin
-            - dist_snap
             - dist_docs
 
   nightly_release:
@@ -550,5 +549,4 @@ workflows:
           requires:
             - dist_linux
             - dist_darwin
-            - dist_snap
             - dist_docs


### PR DESCRIPTION
Upgrades to Snapcraft 8 and core22 from core(16), enables the arm64 architecture, and drops the publish job to avoid installing snapcraft twice. The snap files are no longer pushed as workspace artifacts.

Replaces the outdated Docker image build with a local install of snapd and snapcraft on the host Ubuntu machine, set to 22.04 to match core22 because we use the host build environment instead of LXD or multipass that would take much more time to setup for no purpose (no need for isolation).

Replaces the deprecated explicit login command (`snapcraft login --with`) with an implicit login using the `SNAPCRAFT_STORE_CREDENTIALS` environment variable (we can still login explicitly but we can't have _both_ the envvar and the explicit login: further commands would fail).

Brings in:

- [x] https://github.com/crystal-lang/distribution-scripts/pull/397

Build job: 

- https://app.circleci.com/pipelines/github/crystal-lang/crystal/20120