### PR TITLE
Fix: don't use `Time.monotonic` in `Fiber::ExecutionContext::Monitor`

### DIFF
--- a/src/fiber/execution_context/monitor.cr
+++ b/src/fiber/execution_context/monitor.cr
@@ -48,12 +48,12 @@ module Fiber::ExecutionContext
       loop do
         Thread.sleep(remaining)
 
-        seconds, nanoseconds = System::Time.monotonic
+        seconds, nanoseconds = Crystal::System::Time.monotonic
         start = Time::Span.new(seconds: seconds, nanoseconds: nanoseconds)
 
         yield(start)
 
-        seconds, nanoseconds = System::Time.monotonic
+        seconds, nanoseconds = Crystal::System::Time.monotonic
         stop = Time::Span.new(seconds: seconds, nanoseconds: nanoseconds)
 
         remaining = (start + @every - stop).clamp(Time::Span.zero..)


### PR DESCRIPTION
We shouldn't use use the public `Time.monotonic` in the system runtime as we already don't use it in the event loops & timers.

1. https://github.com/crystal-lang/crystal/commit/b14fa3c9ff983700d6c445df21f1e7a5f901113b
2. https://github.com/crystal-lang/crystal/pull/16498#discussion_r2613645850
3. https://github.com/crystal-lang/crystal/pull/16498#discussion_r2613704697