### PR TITLE
Add git-hook to ensure changing both `Makefile` and `Makefile.win` at the same time

### DIFF
--- a/devenv.nix
+++ b/devenv.nix
@@ -17,6 +17,13 @@
     check-vcs-permalinks.enable = true;
     circleci.enable = true;
     crystal.enable = true;
+    makefile_both = {
+      enable = true;
+      name = "Change both Makefile and Makefile.win";
+      entry = ''${pkgs.runtimeShell} -c 'test "$#" -ne 1 || (echo "Changes only in $@" && false)' --'';
+      files = "^Makefile(\.win)?$";
+      pass_filenames = true;
+    };
     markdownlint.enable = true;
     shellcheck = {
       enable = true;


### PR DESCRIPTION
When changing one of these files, we're often forgetting to change the other (latest example: #16502). Most changes affect both, so I think it makes sense to add this reminder.
In cases where a change is only relevant for one of these files, we can ignore this failure. It might be possible to use a more elaborate mechanism to clarify that it's indeed fine to change only one, but this seems too much effort. The main goal is to avoid neglecting changes that should go in both.