### PR TITLE
Add `Crystal::System::Time.instant`

### DIFF
--- a/src/crystal/system/time.cr
+++ b/src/crystal/system/time.cr
@@ -20,6 +20,11 @@ module Crystal::System::Time
 
   # Returns the system's current local time zone
   # def self.load_localtime : ::Time::Location?
+
+  def self.instant
+    seconds, nanoseconds = Crystal::System::Time.monotonic
+    ::Time::Instant.new(seconds: seconds, nanoseconds: nanoseconds)
+  end
 end
 
 {% if flag?(:unix) %}

--- a/src/time/instant.cr
+++ b/src/time/instant.cr
@@ -2,8 +2,7 @@
 #
 # The execution time of a block can be measured using `.measure`.
 def Time.instant : Time::Instant
-  seconds, nanoseconds = Crystal::System::Time.monotonic
-  Time::Instant.new(seconds: seconds, nanoseconds: nanoseconds)
+  Crystal::System::Time.instant
 end
 
 # `Time::Instant` represents a reading of a monotonic non-decreasing


### PR DESCRIPTION
The internal system implementation is expected to be unaffected by any kind of time mocking and should be used by internal APIs of the event loop and execution contexts.
See https://github.com/crystal-lang/crystal/pull/16500#issuecomment-3646150602