### PR TITLE
Fix instantiation of abstract generic structs in virtual type lookup

### DIFF
--- a/spec/compiler/semantic/class_spec.cr
+++ b/spec/compiler/semantic/class_spec.cr
@@ -1206,4 +1206,20 @@ describe "Semantic: class" do
       Pointer(Foo(Int32)).malloc(1_u64).value.foo?
       CRYSTAL
   end
+
+  it "doesn't try to instantiate abstract generic struct when iterating subtypes (#9621)" do
+    assert_type(<<-CRYSTAL) { int32 }
+      require "prelude"
+
+      abstract struct Base; end
+      struct A < Base; end
+      struct B < Base; end
+      abstract struct Gen(T) < Base; end
+      struct C < Gen(Int32); end
+
+      [A, B].each &.new
+
+      1
+      CRYSTAL
+  end
 end

--- a/src/compiler/crystal/semantic/method_lookup.cr
+++ b/src/compiler/crystal/semantic/method_lookup.cr
@@ -428,6 +428,8 @@ module Crystal
 
       # Traverse all subtypes
       instance_type.subtypes(base_type).each do |subtype|
+        next if is_new && subtype.is_a?(GenericClassInstanceType) && subtype.abstract?
+
         subtype_lookup = virtual_lookup(subtype)
         subtype_virtual_lookup = virtual_lookup(subtype.virtual_type)
 


### PR DESCRIPTION
From the OP, `EnumType(Test)` was incorrectly included (and found) when looking up `.new` matches on `AbstractType+`. This PR skips abstract generic classes when looking for the proper `.new` to call.

Fixes #9621