### PR TITLE
Protect `Box.unbox` from dereferencing null pointer

### DIFF
--- a/spec/std/box_spec.cr
+++ b/spec/std/box_spec.cr
@@ -61,8 +61,6 @@ describe "Box" do
     it "returns nil if nilable" do
       Box(Nil).unbox(Pointer(Void).null).should be_nil
       Box(String?).unbox(Pointer(Void).null).should be_nil
-      Box(Int32?).unbox(Pointer(Void).null).should be_nil
-      Box(Int32 | String?).unbox(Pointer(Void).null).should be_nil
       Box(UInt8*).unbox(Pointer(Void).null).should eq Pointer(UInt8).null
     end
 
@@ -72,6 +70,15 @@ describe "Box" do
       end
       expect_raises(NilAssertionError, "Unboxing null pointer") do
         Box(Int32).unbox(Pointer(Void).null)
+      end
+    end
+
+    it "raises for mixed union" do
+      expect_raises(NilAssertionError, "Unboxing null pointer in mixed union") do
+        Box(Int32 | String?).unbox(Pointer(Void).null)
+      end
+      expect_raises(NilAssertionError, "Unboxing null pointer in mixed union") do
+        Box(Int32?).unbox(Pointer(Void).null)
       end
     end
   end

--- a/src/box.cr
+++ b/src/box.cr
@@ -56,13 +56,7 @@ class Box(T)
       pointer.as(T)
     {% else %}
       if pointer.null?
-        {% if T.union_types.any? { |t| t == Nil } %}
-          # This branch is necessary to prevent null pointer dereference for
-          # `Box(Int32?).unbox(Pointer(Void).null)`.
-          return nil.as(T)
-        {% else %}
-          raise NilAssertionError.new("Unboxing null pointer")
-        {% end %}
+        raise NilAssertionError.new("Unboxing null pointer in mixed union")
       end
 
       pointer.as(self).object


### PR DESCRIPTION
Unboxing a null pointer leads to invalid memory access when the target type is not nilable.

We can avoid this by raising an explicit exception. This makes `Box.unbox` a little bit safer.

Of course we can still not protect against any other invalid pointer. But null pointers are easily identifiable as invalid.
This is low hanging fruit for a bit more implicit memory safety.