### PR TITLE
Fix thread name expectation with parallel execution context

### DIFF
--- a/spec/std/thread_spec.cr
+++ b/spec/std/thread_spec.cr
@@ -46,7 +46,7 @@ pending_interpreted describe: Thread do
 
   it "names the thread" do
     {% if flag?(:execution_context) %}
-      Thread.current.name.should eq("DEFAULT-0")
+      Thread.current.name.should match(/DEFAULT-\d+/)
     {% else %}
       Thread.current.name.should be_nil
     {% end %}


### PR DESCRIPTION
With parallel execution contexts, this spec can run on any thread. We must not assume `DEFAULT-0` in particular.