### PR TITLE
Remove outdated performance hint in `Bcrypt` docs

### DIFF
--- a/src/crypto/bcrypt.cr
+++ b/src/crypto/bcrypt.cr
@@ -21,11 +21,6 @@ require "./subtle"
 # application. Be sure to test and select this based on your server, not your
 # home computer.
 #
-# This implementation of Bcrypt is currently 50% slower than pure C solutions,
-# so keep this in mind when selecting your cost. It may be wise to test with
-# Ruby's [bcrypt gem](https://github.com/codahale/bcrypt-ruby)
-# which is a binding to OpenBSD's implementation.
-#
 # Last but not least: beware of denial of services! Always protect your
 # application using an external strategy (eg: rate limiting), otherwise
 # endpoints that verifies bcrypt hashes will be an easy target.


### PR DESCRIPTION
Closes #13602.

The implementation seems to be around 10% slower than the C implementation, which I think isn't significant enough to warrant such a disclaimer. 

See #13602.