### PR TITLE
Deprecate `Time.monotonic`

### DIFF
--- a/src/time.cr
+++ b/src/time.cr
@@ -339,6 +339,7 @@ struct Time
   # ```
   #
   # The execution time of a block can be measured using `.measure`.
+  @[Deprecated("Use `Time.instant` instead.")]
   def self.monotonic : Time::Span
     seconds, nanoseconds = Crystal::System::Time.monotonic
     Time::Span.new(seconds: seconds, nanoseconds: nanoseconds)


### PR DESCRIPTION
#16490 introduced `Time::Instant` with `Time.instant` as a replacement for `Time.monotonic`.