### PR TITLE
Ensure that heredoc lexing allows only valid identifiers

### DIFF
--- a/spec/compiler/lexer/lexer_spec.cr
+++ b/spec/compiler/lexer/lexer_spec.cr
@@ -712,4 +712,6 @@ describe "Lexer" do
     token.delimiter_state.kind.should eq(Token::DelimiterKind::HEREDOC)
     token.raw.should eq "<<-EOS"
   end
+
+  assert_syntax_error "<<-123\n456\n123", "heredoc identifier starts with invalid character"
 end

--- a/src/compiler/crystal/syntax/lexer.cr
+++ b/src/compiler/crystal/syntax/lexer.cr
@@ -2469,7 +2469,7 @@ module Crystal
         next_char
       end
 
-      unless ident_part?(current_char)
+      unless ident_start?(current_char)
         raise "heredoc identifier starts with invalid character"
       end
 


### PR DESCRIPTION
Resolves #15855 (although it still allows `_` as an identifier since it's valid elsewhere too)