### PR TITLE
Fix some doc inconsistencies for macros

### DIFF
--- a/spec/compiler/crystal/tools/doc/directives_spec.cr
+++ b/spec/compiler/crystal/tools/doc/directives_spec.cr
@@ -47,6 +47,23 @@ describe Crystal::Doc::Generator do
       a_def.visibility.should eq("private")
     end
 
+    it "shows documentation for private macros" do
+      program = top_level_semantic(<<-CRYSTAL, wants_doc: true).program
+        class Foo
+          # :showdoc:
+          #
+          # Some docs
+          private macro foo
+          end
+        end
+        CRYSTAL
+
+      generator = Doc::Generator.new program, [""]
+      a_macro = generator.type(program.types["Foo"]).lookup_macro("foo").not_nil!
+      a_macro.doc.should eq("Some docs")
+      a_macro.visibility.should eq("private")
+    end
+
     it "shows documentation for nested objects if a lib is marked with :showdoc:" do
       program = top_level_semantic(<<-CRYSTAL, wants_doc: true).program
         # :showdoc:

--- a/src/compiler/crystal/tools/doc/macro.cr
+++ b/src/compiler/crystal/tools/doc/macro.cr
@@ -20,7 +20,7 @@ class Crystal::Doc::Macro
   end
 
   def doc
-    @macro.doc
+    @macro.doc.try &.strip.lchop(":showdoc:").strip
   end
 
   def doc_copied_from
@@ -55,7 +55,13 @@ class Crystal::Doc::Macro
   end
 
   def visibility
-    @type.visibility
+    case @macro.visibility
+    in .public?
+    in .protected?
+      "protected"
+    in .private?
+      "private"
+    end
   end
 
   def real_name


### PR DESCRIPTION
Follow up to #15337.

Noticed that if you use a `:showdoc:` directive on a `private macro` it wasn't stripping the directive like it did for a `private def`. Also fixes up the `#visibility` method, as it was returning the visibility of the type, not the macro itself.

A copy of the method spec, but for a macro now passes.