### PR TITLE
fix: actually clear memory using gc_none on unix

### DIFF
--- a/src/gc/none.cr
+++ b/src/gc/none.cr
@@ -18,7 +18,7 @@ module GC
     {% else %}
       # libc malloc is not guaranteed to return cleared memory, so we need to
       # explicitly clear it. Ref: https://github.com/crystal-lang/crystal/issues/14678
-      LibC.malloc(size).tap(&.clear)
+      LibC.malloc(size).tap(&.clear(size))
     {% end %}
   end
 


### PR DESCRIPTION
Closes #14678

The method should now clear all bytes, not just the first byte.
