### PR TITLE
Support short option bundling

### DIFF
--- a/spec/std/option_parser_spec.cr
+++ b/spec/std/option_parser_spec.cr
@@ -252,7 +252,7 @@ describe "OptionParser" do
     it "parses bundled boolean short options" do
       args = %w(-rf)
       called = [] of String
-      OptionParser.parse(args, bundling: true) do |opts|
+      OptionParser.parse(args) do |opts|
         opts.on("-r", "") { called << "-r" }
         opts.on("-f", "") { called << "-f" }
       end
@@ -263,7 +263,7 @@ describe "OptionParser" do
     it "re-triggers handlers for repeated short flags" do
       args = %w(-vvv)
       verbosity = 0
-      OptionParser.parse(args, bundling: true) do |opts|
+      OptionParser.parse(args) do |opts|
         opts.on("-v", "") { verbosity += 1 }
       end
       verbosity.should eq(3)
@@ -274,7 +274,7 @@ describe "OptionParser" do
       args = %w(-ovalue -r)
       value = nil
       r = false
-      OptionParser.parse(args, bundling: true) do |opts|
+      OptionParser.parse(args) do |opts|
         opts.on("-o VALUE", "") { |v| value = v }
         opts.on("-r", "") { r = true }
       end
@@ -287,7 +287,7 @@ describe "OptionParser" do
       args = %w(-ab123)
       a = false
       b = nil
-      OptionParser.parse(args, bundling: true) do |opts|
+      OptionParser.parse(args) do |opts|
         opts.on("-a", "") { a = true }
         opts.on("-b VALUE", "") { |v| b = v }
       end
@@ -298,7 +298,7 @@ describe "OptionParser" do
 
     it "raises on invalid option inside bundle" do
       expect_raises OptionParser::InvalidOption, "Invalid option: -j" do
-        OptionParser.parse(["-rj"], bundling: true) do |opts|
+        OptionParser.parse(["-rj"]) do |opts|
           opts.on("-r", "") { }
         end
       end
@@ -309,7 +309,7 @@ describe "OptionParser" do
       a = false
       b = false
       e = nil
-      OptionParser.parse(args, bundling: true) do |opts|
+      OptionParser.parse(args) do |opts|
         opts.on("-a", "") { a = true }
         opts.on("-b", "") { b = true }
         opts.on("-e VALUE", "") { |v| e = v }
@@ -454,7 +454,7 @@ describe "OptionParser" do
   end
 
   it "raises on invalid option if value is given to none value handler (short flag, #9553) " do
-    expect_raises OptionParser::InvalidOption, "Invalid option: -foo" do
+    expect_raises OptionParser::InvalidOption, "Invalid option: -o" do
       OptionParser.parse(["-foo"]) do |opts|
         opts.on("-f", "some flag") { }
       end

--- a/src/option_parser.cr
+++ b/src/option_parser.cr
@@ -112,8 +112,8 @@ class OptionParser
   # and uses it to parse the passed *args* (defaults to `ARGV`).
   #
   # Refer to `#gnu_optional_args?` for the behaviour of the named parameter.
-  def self.parse(args = ARGV, *, gnu_optional_args : Bool = false, bundling : Bool = false, &) : self
-    parser = OptionParser.new(gnu_optional_args: gnu_optional_args, bundling: bundling)
+  def self.parse(args = ARGV, *, gnu_optional_args : Bool = false, &) : self
+    parser = OptionParser.new(gnu_optional_args: gnu_optional_args)
     yield parser
     parser.parse(args)
     parser
@@ -122,7 +122,7 @@ class OptionParser
   # Creates a new parser.
   #
   # Refer to `#gnu_optional_args?` for the behaviour of the named parameter.
-  def initialize(*, @gnu_optional_args : Bool = false, @bundling : Bool = false)
+  def initialize(*, @gnu_optional_args : Bool = false)
     @flags = [] of String
     @handlers = Hash(String, Handler).new
     @stop = false
@@ -133,8 +133,8 @@ class OptionParser
   # Creates a new parser, with its configuration specified in the block.
   #
   # Refer to `#gnu_optional_args?` for the behaviour of the named parameter.
-  def self.new(*, gnu_optional_args : Bool = false, bundling : Bool = false, &)
-    new(gnu_optional_args: gnu_optional_args, bundling: bundling).tap { |parser| yield parser }
+  def self.new(*, gnu_optional_args : Bool = false, &)
+    new(gnu_optional_args: gnu_optional_args).tap { |parser| yield parser }
   end
 
   # Returns whether the GNU convention is followed for optional arguments.
@@ -172,27 +172,6 @@ class OptionParser
   # Remaining: []
   # ```
   property? gnu_optional_args : Bool
-
-  # Returns whether short option bundling is enabled.
-  #
-  # If true, short options can be grouped after a single dash:
-  #
-  # ```
-  # require "option_parser"
-  #
-  # removed = false
-  # forced = false
-  # OptionParser.parse(%w(-rf), bundling: true) do |parser|
-  #   parser.on("-r", "") { removed = true }
-  #   parser.on("-f", "") { forced = true }
-  # end
-  #
-  # {removed, forced} # => {true, true}
-  # ```
-  #
-  # Without `bundling: true`, a token like `-rf` is interpreted as
-  # the flag `-r` with an inline value `f`.
-  property? bundling : Bool
 
   # Establishes the initial message for the help printout.
   # Typically, you want to write here the name of your program,
@@ -422,7 +401,7 @@ class OptionParser
           break
         end
 
-        if bundling? && bundled_short_arg?(arg)
+        if bundled_short_arg?(arg)
           arg_index = handle_bundled_short_options(arg, arg_index, args, handled_args)
         else
           flag, value = parse_arg_to_flag_and_value(arg)


### PR DESCRIPTION
This enables short option bundling such as with `-rf` which will with this option trigger separate `-r` and `-f` handlers.

```
require "option_parser"

removed = false
forced = false
OptionParser.parse(%w(-rf), bundling: true) do |parser|
  parser.on("-r", "") { removed = true }
  parser.on("-f", "") { forced = true }
end

{removed, forced} # => {true, true}
```

Fixes #10981