### PR TITLE
Fix: Random default thread local [fixup #16174]

### DIFF
--- a/src/random.cr
+++ b/src/random.cr
@@ -54,8 +54,8 @@ module Random
   DEFAULT = PCG32.new
 
   # :nodoc:
-  thread_local(thread_default : ::Random) do
-    ::Random::PCG32.new.as(::Random)
+  thread_local(thread_default : ::Random::PCG32) do
+    ::Random::PCG32.new
   end
 
   # :nodoc:


### PR DESCRIPTION
I noticed a compilation error in the [random shard](https://github.com/ysbaddaden/random.cr) caused by #16174:

```
 > 559 |         if typeof(next_u).new!(max &- 1) == max &- 1
                                   ^---
Error: undefined method 'new!' for (UInt32 | UInt64).class
```

The thread local is an internal detail, it doesn't have to be a general `Random` instance.