### PR TITLE
Adjust triggers for `update-devenv` workflow

### DIFF
--- a/.github/workflows/update-devenv.yml
+++ b/.github/workflows/update-devenv.yml
@@ -4,6 +4,8 @@ on:
   schedule:
     - cron: "0 3 * * 2" # Weekly on Tuesdays
   push:
+    branches:
+      - master
     paths:
       - '.github/workflows/update-devenv.yml'
   workflow_dispatch:


### PR DESCRIPTION
The workflow runs on the `master` branch, so it should only trigger on updates to the workflow file in the `master` branch.