### PR TITLE
Add `StringScanner#peek_behind`

### DIFF
--- a/spec/std/string_scanner_spec.cr
+++ b/spec/std/string_scanner_spec.cr
@@ -434,6 +434,30 @@ describe StringScanner do
     end
   end
 
+  describe "#peek_behind" do
+    it "shows characters behind the scan head" do
+      s = StringScanner.new("abcdefg")
+      s.peek_behind(10).should eq("")
+      s.scan(3)
+      s.peek_behind(10).should eq("abc")
+      s.peek_behind(2).should eq("bc")
+    end
+
+    it "shows characters behind the scan head for multi-byte strings" do
+      s = StringScanner.new("あいうえお")
+      s.peek_behind(10).should eq("")
+      s.scan(3)
+      s.peek_behind(10).should eq("あいう")
+      s.peek_behind(2).should eq("いう")
+    end
+
+    it "errors on negative input" do
+      s = StringScanner.new("abcde")
+      s.scan(3)
+      expect_raises(ArgumentError, "Negative lookbehind count") { s.peek_behind(-1) }
+    end
+  end
+
   describe "#reset" do
     it "resets the scan offset to the beginning and clears the last match" do
       s = StringScanner.new("this is a string")

--- a/src/string_scanner.cr
+++ b/src/string_scanner.cr
@@ -41,8 +41,9 @@
 # * `#skip`
 # * `#skip_until`
 #
-# Methods that look ahead:
+# Methods that look ahead or behind:
 # * `#peek`
+# * `#peek_behind`
 # * `#check`
 # * `#check_until`
 #
@@ -424,6 +425,14 @@ class StringScanner
   def peek(len) : String
     byte_len = lookahead_byte_length(len) || @str.bytesize
     @str.byte_slice(@byte_offset, byte_len)
+  end
+
+  # Extracts a string by looking behind *len* characters, without moving the
+  # scan offset. The return value has at most *len* characters, but may have fewer
+  # if the scan head is close to the beginning of the string.
+  def peek_behind(len) : String
+    byte_len = lookbehind_byte_length(len) || @byte_offset
+    @str.byte_slice(@byte_offset - byte_len, byte_len)
   end
 
   # Returns the remainder of the string after the scan offset.


### PR DESCRIPTION
~~Depends on #16557, will rebase and un-draft when that is merged.~~
Extracted from #16455.

## Rationale

`StringScanner#peek` currently has the implementation:

```crystal
def peek(len)
  @str[offset, len]
end
```

which can be linear-time in string size for multi-byte strings, on account of a full scan in `String#char_index_to_byte_index`.

## Changes
[This change](https://github.com/crystal-lang/crystal/pull/16593/changes#diff-4c6bfbfaa6c25c4de128b3716122fec73165025ca631bd3d45774d0fe4d9d614R426) makes use of #16557's helpers `#lookahead_byte_length` and `#lookbehind_byte_length` to allow the use of a byte slice here, making the process at worst linear in `size`, which is likely to be much smaller. For single-byte-optimizable strings (those with no multi-byte chars), however, this will still be a simple constant-time byte slice.

Also adds `#peek_behind` which is fairly free given the helper functions from #16557.