### PR TITLE
Add convenience methods to `StringScanner`

### DIFF
--- a/spec/std/string_scanner_spec.cr
+++ b/spec/std/string_scanner_spec.cr
@@ -545,34 +545,6 @@ describe StringScanner do
     end
   end
 
-  describe "#unscan" do
-    it "undoes the previous #scan call" do
-      s = StringScanner.new("abcdefg")
-      s.scan(1).should eq("a")
-      s.scan("bc").should eq("bc")
-      s.unscan
-      s.scan(/\w\w\w/).should eq("bcd")
-      s.unscan
-      s.scan(4).should eq("bcde")
-      s.unscan
-      s.current_char.should eq('b')
-    end
-
-    it "undoes the previous #scan call for multibyte strings" do
-      s = StringScanner.new("あいうえお")
-      expect_raises(NilAssertionError, "No previous match") { s.unscan }
-      s.scan(1).should eq("あ")
-      s.scan("いう").should eq("いう")
-      s.unscan
-      s.scan(/\w\w\w/).should eq("いうえ")
-      s.unscan
-      s.scan(4).should eq("いうえお")
-      s.unscan
-      expect_raises(NilAssertionError, "No previous match") { s.unscan }
-      s.current_char.should eq('い')
-    end
-  end
-
   describe "#reset" do
     it "resets the scan offset to the beginning and clears the last match" do
       s = StringScanner.new("this is a string")

--- a/src/string_scanner.cr
+++ b/src/string_scanner.cr
@@ -63,7 +63,6 @@
 # * `#[]`
 # * `#[]?`
 # * `#matched?`
-# * `#unscan`
 #
 # Miscellaneous methods:
 # * `#inspect`
@@ -151,18 +150,6 @@ class StringScanner
   # ```
   def scan(len : Int) : String?
     match(len, advance: true)
-  end
-
-  # Reverts the scan head to before the last match, and clears the last
-  # match information. This can only be used once per scan.
-  #
-  # Raises NilAssertionError if there is no previous match.
-  def unscan : Nil
-    match = @last_match
-    raise NilAssertionError.new("No previous match") if match.nil?
-
-    @byte_offset -= match[0].bytesize
-    @last_match = nil
   end
 
   # Scans the string _until_ the *pattern* is matched. Returns the substring up


### PR DESCRIPTION
~~Depends on #16557.~~
Extracted from #16455.
Fixes #11259, with the exception of the methods that mutate the string.

## Rationale

Ruby's comparable StringScanner library provides a number of extra convenience methods. I've gone through the list and implemented/specced the ones that make sense here.

## Changes

* `#matched? : Bool` to check for the presence of `@last_match`
* `#current_char : Char`, `#previous_char : Char` as well as nilable variants
* `#current_byte : UInt8`, `#previous_byte : UInt8`, as well as nilable variants
* `#beginning_of_line?` I believe originally conceived because anchors like `^` were non-functional in Ruby due to [a bug in their implementation](https://bugs.ruby-lang.org/issues/7092) - not an issue in Crystal. It is generally a useful method though, and I couldn't see an argument against including it.
* `#rewind(Int)` to move the scan head backwards manually
* ~~`#unscan` for rewinding to the start of the previous scan~~ Removed as this has some deep issues in its interactions with `#check` and `#scan_until`. Will open a separate PR for it later.