### PR TITLE
Fix `Indexable#range_to_index_and_count` with unsigned integers

### DIFF
--- a/src/indexable.cr
+++ b/src/indexable.cr
@@ -1039,20 +1039,29 @@ module Indexable(T)
       start_index = 0
     else
       start_index += collection_size if start_index < 0
-      if start_index < 0
-        return nil
-      end
+
+      return nil if start_index < 0
     end
+
+    count = 0
 
     end_index = range.end
     if end_index.nil?
-      count = collection_size - start_index
+      if start_index <= collection_size
+        count = collection_size - start_index
+      end
     else
-      end_index += collection_size if end_index < 0
-      end_index -= 1 if range.excludes_end?
-      count = end_index - start_index + 1
+      if end_index < 0
+        end_index += collection_size
+      end
+
+      # must be careful with computation here, since we may be dealing with
+      # unsigned ints or ints close to MAX.
+      if end_index >= start_index
+        count = end_index - start_index
+        count += 1 unless range.excludes_end? || collection_size < count
+      end
     end
-    count = 0 if count < 0
 
     {start_index, count}
   end


### PR DESCRIPTION
Polished version of #16477.

## Rationale

The following code currently raises an OverflowError, when it should return an empty string:

```crystal
"foobar"[3_u32...3_u32]
```

This happens in `Indexable#range_to_index_and_count` when we try to subtract 1 from `0_u32` to account for the exclusive range.

## Changes

This changeset adds much more test coverage around the boundaries of various integer representations, including ranges of unsigned ints as well as signed ints around `Int32::MAX`, and refactors `Indexable#range_to_index_and_count` to be much more well-behaved in these edge cases. Thanks to @straight-shoota for the help in finding a bunch of these!