### PR TITLE
Use `_wexecvpe` instead of mutating `ENV` in `System::Process.try_replace` (win32)

### DIFF
--- a/src/lib_c/x86_64-windows-msvc/c/io.cr
+++ b/src/lib_c/x86_64-windows-msvc/c/io.cr
@@ -1,12 +1,13 @@
 require "c/stdint"
 
 lib LibC
-  fun _wexecvp(cmdname : WCHAR*, argv : WCHAR**) : IntPtrT
+  fun _wexecvpe(cmdname : WCHAR*, argv : WCHAR**, envp : WCHAR**) : IntPtrT
   fun _open_osfhandle(osfhandle : HANDLE, flags : LibC::Int) : LibC::Int
   fun _dup(fd : Int) : Int
   fun _dup2(fd1 : Int, fd2 : Int) : Int
 
   # unused
+  fun _wexecvp(cmdname : WCHAR*, argv : WCHAR**) : IntPtrT
   fun _get_osfhandle(fd : Int) : IntPtrT
   fun _close(fd : Int) : Int
   fun _isatty(fd : Int) : Int


### PR DESCRIPTION
Builds an envp array and calls `_wexecvpe` instead of mutating `ENV` and calling `_wexecvp`.

This avoids calling methods in stdlib that we recommend to not use (even though Windows is safe) it's cleaner and avoids the very edge case where a thread would set a variable while we iterate to clear.

TODO

- [ ] fix segfault on CI (windows 2025 MSVC):

```
Invalid memory access (C0000005) at address 0x15e8f9e3000
[0x7ffe21023970] strrchr +448 in C:\Windows\System32\ucrtbase.dll
[0x7ffe2105e91d] y1 +1933 in C:\Windows\System32\ucrtbase.dll
[0x7ffe21051e43] o___p___wargv +147 in C:\Windows\System32\ucrtbase.dll
[0x7ffe21023518] wdupenv_s +456 in C:\Windows\System32\ucrtbase.dll
[0x7ffe2109adab] wspawnv +1147 in C:\Windows\System32\ucrtbase.dll
[0x7ff6b277c206] try_replace at D:\a\crystal\crystal\src\crystal\system\win32\process.cr:371
[0x7ff6b277be0f] replace at D:\a\crystal\crystal\src\crystal\system\win32\process.cr:385
[0x7ff6b277bdc3] exec:env at D:\a\crystal\crystal\src\process.cr:222
```

This is working on my local Windows 11 virtual machine, as well as with MinGW on CI (Windows 2025 too). See comments below for more details.

Related to #16605.