### PR TITLE
Drop `ENV["CRYSTAL_PATH"]=` in spec helper

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -143,7 +143,7 @@ std_spec: $(O)/std_spec$(EXE) ## Run standard library specs
 
 .PHONY: compiler_spec
 compiler_spec: $(O)/compiler_spec$(EXE) ## Run compiler specs
-	$(O)/compiler_spec$(EXE) $(SPEC_FLAGS)
+	CRYSTAL_PATH=$(CURDIR)/src $(O)/compiler_spec$(EXE) $(SPEC_FLAGS)
 
 .PHONY: primitives_spec
 primitives_spec: $(O)/primitives_spec$(EXE) ## Run primitives specs
@@ -151,7 +151,7 @@ primitives_spec: $(O)/primitives_spec$(EXE) ## Run primitives specs
 
 .PHONY: interpreter_spec
 interpreter_spec: $(O)/interpreter_spec$(EXE) ## Run interpreter specs
-	$(O)/interpreter_spec$(EXE) $(SPEC_FLAGS)
+	CRYSTAL_PATH=$(CURDIR)/src $(O)/interpreter_spec$(EXE) $(SPEC_FLAGS)
 
 .PHONY: simple_smoke_test
 simple_smoke_test: ## Build std specs as a smoke test

--- a/Makefile.win
+++ b/Makefile.win
@@ -121,7 +121,7 @@ std_spec: $(O)\std_spec.exe ## Run standard library specs
 
 .PHONY: compiler_spec
 compiler_spec: $(O)\compiler_spec.exe ## Run compiler specs
-	$(O)\compiler_spec $(SPEC_FLAGS)
+	set "CRYSTAL_PATH=$(CURDIR)\src" && $(O)\compiler_spec $(SPEC_FLAGS)
 
 .PHONY: primitives_spec
 primitives_spec: $(O)\primitives_spec.exe ## Run primitives specs
@@ -129,7 +129,7 @@ primitives_spec: $(O)\primitives_spec.exe ## Run primitives specs
 
 .PHONY: interpreter_spec
 interpreter_spec: $(O)\interpreter_spec ## Run interpreter specs
-	$(O)\interpreter_spec $(SPEC_FLAGS)
+	set "CRYSTAL_PATH=$(CURDIR)\src" && $(O)\interpreter_spec $(SPEC_FLAGS)
 
 .PHONY: smoke_test
 smoke_test: ## Build specs as a smoke test

--- a/spec/spec_helper.cr
+++ b/spec/spec_helper.cr
@@ -1,7 +1,5 @@
 {% raise("Please use `make test` or `bin/crystal` when running specs, or set the i_know_what_im_doing flag if you know what you're doing") unless env("CRYSTAL_HAS_WRAPPER") || flag?("i_know_what_im_doing") %}
 
-ENV["CRYSTAL_PATH"] = "#{__DIR__}/../src"
-
 require "spec"
 
 require "compiler/requires"


### PR DESCRIPTION
Some specs build Crystal programs, so the spec executable itself includes a Crystal compiler. This compiler needs to know where to find the source code.

Specs are usually run with `bin/crystal spec` where the wrapper already assigns `CRYSTAL_PATH` appropriately.

The purpose of this `ENV` assignment is to make sure `CRYSTAL_PATH` points to the correct source path even when the spec executable runs outside the wrapper script. It's as old as `CRYSTAL_PATH` itself (https://github.com/crystal-lang/crystal/commit/363ad5bddd595d911963ed19d88d3e8bc27241dd).

The Makefile splits build and execution into two recipes, so the spec does not execute as a child process of the compiler and wrapper and thus doesn't see its `CRYSTAL_PATH`. This is the unusual part and can be fixed by setting the variable in `Makefile`.

This proposed patch is a very simple change and helps remove `ENV` mutations (cf. #16449).
A consequence is that executing the spec executable manually (e.g. `.build/compiler_spec`) won't work correctly unless you set `CRYSTAL_PATH` explicit. I'm not aware that this would be a very relevant use case, so that this should be acceptable.
In any case, it's easy to work around by assigning `CRYSTAL_PATH`.

There are alternative options we could consider if this approach doesn't work. But they're not as elegant.
This is very straightforward and conceptually simple. When thinking of the spec program as a compiler, it makes sense that it needs a proper configuration just like the compiler does.