### PR TITLE
Add `Crystal::Config.path=` for spec helper

### DIFF
--- a/spec/spec_helper.cr
+++ b/spec/spec_helper.cr
@@ -1,6 +1,6 @@
 {% raise("Please use `make test` or `bin/crystal` when running specs, or set the i_know_what_im_doing flag if you know what you're doing") unless env("CRYSTAL_HAS_WRAPPER") || flag?("i_know_what_im_doing") %}
 
-ENV["CRYSTAL_PATH"] = "#{__DIR__}/../src"
+Crystal::Config.path = "#{__DIR__}/../src"
 
 require "spec"
 

--- a/src/compiler/crystal/config.cr
+++ b/src/compiler/crystal/config.cr
@@ -2,9 +2,7 @@ require "./codegen/target"
 
 module Crystal
   module Config
-    def self.path
-      {{env("CRYSTAL_CONFIG_PATH") || ""}}
-    end
+    class_property path : String = {{env("CRYSTAL_CONFIG_PATH") || ""}}
 
     def self.version
       {{ read_file("#{__DIR__}/../../VERSION").chomp }}


### PR DESCRIPTION
When running compiler specs, we want them to pick up the standard library at the source location that goes alongside it.

Specs often run with `bin/crystal spec` where the wrapper already assigns `CRYSTAL_PATH` appropriately. But when executing a spec binary independently, this environment variable is missing.
We used to explicitly set the  `CRYSTAL_PATH` env var, but we want to remove `ENV` mutations (cf. https://github.com/crystal-lang/crystal/issues/16449).

For the actual value, I was wondering if we should use `Crystal::PATH` instead of `"#{__DIR__}/../src"`. The result is equivalent, but maybe it's a bit more clear that we're baking the compiler's path. `Crystal::PATH` includes `./lib` though, which we don't really need here. It probably doesn't do any harm, but it shouldn't be there. So we could consider removing it, but then I'm not sure it's worth it over `"#{__DIR__}/../src"`.

Closes #16610