### PR TITLE
Fix `HTTP::Headers#merge!` to not wrap key

### DIFF
--- a/spec/std/http/headers_spec.cr
+++ b/spec/std/http/headers_spec.cr
@@ -172,6 +172,19 @@ describe HTTP::Headers do
       headers.merge!({"foo" => "baz", "qux" => "quux"})
       headers.should eq HTTP::Headers{"foo" => "baz", "boo" => "baz", "qux" => "quux"}
     end
+
+    it "raises an error if header value contains invalid character" do
+      headers = HTTP::Headers.new
+      expect_raises ArgumentError do
+        headers.merge!({"invalid-header" => "\r\nLocation: http://example.com"})
+      end
+    end
+  end
+
+  it "dispatch with union type (#16622)" do
+    headers = HTTP::Headers.new
+    headers.merge!(HTTP::Headers.new)
+    headers["foo"] = "bar".as(String | Array(String))
   end
 
   it "matches word" do

--- a/src/http/headers.cr
+++ b/src/http/headers.cr
@@ -180,7 +180,7 @@ struct HTTP::Headers
 
   def merge!(other) : self
     other.each do |key, value|
-      self[wrap(key)] = value
+      self[key] = value
     end
     self
   end


### PR DESCRIPTION
Fixes a regression from 1.18.

Resolves #16622

Also adds a couple more specs for this method.