### PR TITLE
fix: add interpreter downcast for NilableType to ReferenceUnionType

### DIFF
--- a/spec/compiler/interpreter/bugs_spec.cr
+++ b/spec/compiler/interpreter/bugs_spec.cr
@@ -258,5 +258,23 @@ describe Crystal::Repl::Interpreter do
         parser = "parser"
       CRYSTAL
     end
+
+    it "downcasts from NilableType to ReferenceUnionType (#16596)" do
+      interpret(<<-CRYSTAL).should be_true
+        abstract class Base
+        end
+
+        class Gen(T) < Base
+        end
+
+        Gen(Int64).new
+
+        if gen = Gen(Int32).new.as(Base).as?(Gen) # Error: BUG: missing downcast_distinct from (Gen(T) | Nil) to (Gen(Int32) | Gen(Int64)) (Crystal::NilableType to Crystal::ReferenceUnionType)
+          gen.is_a?(Gen(Int32))
+        else
+          false
+        end
+      CRYSTAL
+    end
   end
 end

--- a/src/compiler/crystal/interpreter/cast.cr
+++ b/src/compiler/crystal/interpreter/cast.cr
@@ -420,6 +420,10 @@ class Crystal::Repl::Compiler
     pop sizeof(Pointer(Void)), node: nil
   end
 
+  private def downcast_distinct(node : ASTNode, from : NilableType, to : ReferenceUnionType)
+    # Nothing to do: both are represented as pointers
+  end
+
   private def downcast_distinct(node : ASTNode, from : NilableReferenceUnionType, to : VirtualType | NonGenericClassType | GenericClassInstanceType | NilableType)
     # Nothing to do
   end


### PR DESCRIPTION
Fixes #16596

## Summary
### Bug Description
The Crystal interpreter failed with the error:

Error: BUG: missing downcast_distinct from (Gen(T) | Nil) to (Gen(Int32) | Gen(Int64)) (Crystal::NilableType to Crystal::ReferenceUnionType)
This occurred when trying to downcast from a NilableType (e.g., Gen(T) | Nil) to a ReferenceUnionType (e.g., Gen(Int32) | Gen(Int64)).

### Root Cause
The interpreter's cast.cr file was missing a downcast_distinct method overload to handle the conversion from NilableType to ReferenceUnionType. While similar handlers existed for other type combinations (like NilableReferenceUnionType to ReferenceUnionType), this specific case was not covered.

### Fix
Added a new downcast_distinct method in 
src/compiler/crystal/interpreter/cast.cr:

```crystal
private def downcast_distinct(node : ASTNode, from : NilableType, to : ReferenceUnionType)
  # Nothing to do: both are represented as pointers
end
```
Since both NilableType and ReferenceUnionType are represented as pointers (reference types) at runtime, no stack manipulation is needed for this cast - similar to the existing handler for NilableType to NonGenericClassType | GenericClassInstanceType.