### PR TITLE
Fix: `Thread.sleep` is invalid when duration >= 1 minute

### DIFF
--- a/src/crystal/system/unix/pthread.cr
+++ b/src/crystal/system/unix/pthread.cr
@@ -104,8 +104,8 @@ module Crystal::System::Thread
 
   def self.sleep(time : ::Time::Span) : Nil
     req = uninitialized LibC::Timespec
-    req.tv_sec = typeof(req.tv_sec).new(time.seconds)
-    req.tv_nsec = typeof(req.tv_nsec).new(time.nanoseconds)
+    req.tv_sec = typeof(req.tv_sec).new(time.@seconds)
+    req.tv_nsec = typeof(req.tv_nsec).new(time.@nanoseconds)
 
     loop do
       return if LibC.nanosleep(pointerof(req), out rem) == 0

--- a/src/crystal/system/wasi/thread.cr
+++ b/src/crystal/system/wasi/thread.cr
@@ -29,8 +29,8 @@ module Crystal::System::Thread
 
   def self.sleep(time : ::Time::Span) : Nil
     req = uninitialized LibC::Timespec
-    req.tv_sec = typeof(req.tv_sec).new(time.seconds)
-    req.tv_nsec = typeof(req.tv_nsec).new(time.nanoseconds)
+    req.tv_sec = typeof(req.tv_sec).new(time.@seconds)
+    req.tv_nsec = typeof(req.tv_nsec).new(time.@nanoseconds)
 
     loop do
       return if LibC.nanosleep(pointerof(req), out rem) == 0


### PR DESCRIPTION
This went unnoticed because only the monitor thread of execution contexts uses `Thread.sleep` and for durations of 10 milliseconds that were unaffected.