### PR TITLE
Rename filename to path in WASI `EventLoop#open`

### DIFF
--- a/src/crystal/event_loop/wasi.cr
+++ b/src/crystal/event_loop/wasi.cr
@@ -43,7 +43,7 @@ class Crystal::EventLoop::Wasi < Crystal::EventLoop
     raise NotImplementedError.new("Crystal::EventLoop::Wasi#pipe")
   end
 
-  def open(filename : String, flags : Int32, permissions : File::Permissions, blocking : Bool?) : {System::FileDescriptor::Handle, Bool} | Errno | WinError
+  def open(path : String, flags : Int32, permissions : File::Permissions, blocking : Bool?) : {System::FileDescriptor::Handle, Bool} | Errno | WinError
     raise NotImplementedError.new("Crystal::Wasi::EventLoop#open")
   end
 


### PR DESCRIPTION
Fixes a warning regarding parameter name mismatches. 

```
In /usr/share/crystal/src/crystal/event_loop/wasi.cr:46:12

 46 | def open(filename : String, flags : Int32, permissions : File::Permissions, blocking : Bool?) : {System::FileDescriptor::Handle, Bool} | Errno | WinError
               ^-------
Warning: positional parameter 'filename' corresponds to parameter 'path' of the overridden method Crystal::EventLoop::FileDescriptor#open(path : String, flags : Int32, permissions : File::Permissions, blocking : Bool | ::Nil), which has a different name and may affect named argument passing

A total of 1 warnings were found.
```