### PR TITLE
Fix: race condition in `Process.run` spec [fixup #16620]

### DIFF
--- a/spec/std/process_spec.cr
+++ b/spec/std/process_spec.cr
@@ -240,10 +240,7 @@ describe Process do
       channel.send process
 
       # Wait a moment for the other fiber to continue and close the IOs
-      wait_for { process.output.closed? }
-
-      process.output.closed?.should be_true
-      process.error.closed?.should be_true
+      wait_for { process.output.closed? && process.error.closed? }
 
       writer.close
       channel.receive?.should be_nil


### PR DESCRIPTION
A race condition appeared in CI after #16620 where the process output may be closed but the error hasn't yet. For example https://github.com/crystal-lang/crystal/actions/runs/21710498845/job/62612544368

I removed the expectations because `wait_for` either passes with both conditions true or raises a timeout error and the expectations are just redundant.