### PR TITLE
Switch OpenSSL::SSL::Socket from BIO to SSL_set_fd

### DIFF
--- a/spec/std/openssl/ssl/context_spec.cr
+++ b/spec/std/openssl/ssl/context_spec.cr
@@ -13,7 +13,7 @@ describe OpenSSL::SSL::Context do
     (context.options & OpenSSL::SSL::Options::ALL).should eq(OpenSSL::SSL::Options::ALL)
     (context.options & OpenSSL::SSL::Options::NO_SESSION_RESUMPTION_ON_RENEGOTIATION).should eq(OpenSSL::SSL::Options::NO_SESSION_RESUMPTION_ON_RENEGOTIATION)
 
-    context.modes.should eq(OpenSSL::SSL::Modes.flags(AUTO_RETRY, RELEASE_BUFFERS))
+    context.modes.should eq(OpenSSL::SSL::Modes.flags(AUTO_RETRY, RELEASE_BUFFERS, ENABLE_PARTIAL_WRITE))
     context.verify_mode.should eq(OpenSSL::SSL::VerifyMode::PEER)
 
     OpenSSL::SSL::Context::Client.new(LibSSL.tlsv1_method)
@@ -26,7 +26,7 @@ describe OpenSSL::SSL::Context do
     (context.options & OpenSSL::SSL::Options::NO_SESSION_RESUMPTION_ON_RENEGOTIATION).should eq(OpenSSL::SSL::Options::NO_SESSION_RESUMPTION_ON_RENEGOTIATION)
     (context.options & OpenSSL::SSL::Options::NO_RENEGOTIATION).should eq(OpenSSL::SSL::Options::NO_RENEGOTIATION)
 
-    context.modes.should eq(OpenSSL::SSL::Modes.flags(AUTO_RETRY, RELEASE_BUFFERS))
+    context.modes.should eq(OpenSSL::SSL::Modes.flags(AUTO_RETRY, RELEASE_BUFFERS, ENABLE_PARTIAL_WRITE))
     context.verify_mode.should eq(OpenSSL::SSL::VerifyMode::NONE)
 
     OpenSSL::SSL::Context::Server.new(LibSSL.tlsv1_method)

--- a/src/openssl/lib_crypto.cr
+++ b/src/openssl/lib_crypto.cr
@@ -111,6 +111,8 @@ lib LibCrypto
 
   type BioMethod = Void
 
+  fun BIO_ctrl(bio : Bio*, cmd : Int, larg : Long, parg : Void*) : Long
+
   fun BIO_new(BioMethod*) : Bio*
   fun BIO_free(Bio*) : Int
 

--- a/src/openssl/lib_ssl.cr
+++ b/src/openssl/lib_ssl.cr
@@ -214,6 +214,9 @@ lib LibSSL
   fun ssl_get_error = SSL_get_error(handle : SSL, ret : Int) : SSLError
   fun ssl_get_servername = SSL_get_servername(ssl : SSL, host_type : TLSExt) : UInt8*
   fun ssl_set_bio = SSL_set_bio(handle : SSL, rbio : LibCrypto::Bio*, wbio : LibCrypto::Bio*)
+  fun ssl_set_fd = SSL_set_fd(handle : SSL, fd : Int) : Int
+  fun ssl_get_rbio = SSL_get_rbio(handle : SSL) : LibCrypto::Bio*
+  fun ssl_get_wbio = SSL_get_wbio(handle : SSL) : LibCrypto::Bio*
   fun ssl_select_next_proto = SSL_select_next_proto(output : Char**, output_len : Char*, input : Char*, input_len : Int, client : Char*, client_len : Int) : Int
   fun ssl_ctrl = SSL_ctrl(handle : SSL, cmd : Int, larg : Long, parg : Void*) : Long
   fun ssl_free = SSL_free(handle : SSL)

--- a/src/openssl/ssl/context.cr
+++ b/src/openssl/ssl/context.cr
@@ -259,7 +259,7 @@ abstract class OpenSSL::SSL::Context
       NO_SESSION_RESUMPTION_ON_RENEGOTIATION,
       NO_RENEGOTIATION,
     ))
-    add_modes(OpenSSL::SSL::Modes.flags(AUTO_RETRY, RELEASE_BUFFERS))
+    add_modes(OpenSSL::SSL::Modes.flags(AUTO_RETRY, RELEASE_BUFFERS, ENABLE_PARTIAL_WRITE))
 
     # OpenSSL does not support reading from the system root certificate store on
     # Windows, so we have to import them ourselves

--- a/src/openssl/ssl/server.cr
+++ b/src/openssl/ssl/server.cr
@@ -63,7 +63,7 @@ class OpenSSL::SSL::Server
   #
   # This method calls `@wrapped.accept` and wraps the resulting IO in a SSL socket (`OpenSSL::SSL::Socket::Server`) with `context` configuration.
   def accept : OpenSSL::SSL::Socket::Server
-    new_ssl_socket(@wrapped.accept)
+    new_ssl_socket(@wrapped.accept.as(::Socket))
   end
 
   # Implements `::Socket::Server#accept?`.
@@ -71,11 +71,11 @@ class OpenSSL::SSL::Server
   # This method calls `@wrapped.accept?` and wraps the resulting IO in a SSL socket (`OpenSSL::SSL::Socket::Server`) with `context` configuration.
   def accept? : OpenSSL::SSL::Socket::Server?
     if socket = @wrapped.accept?
-      new_ssl_socket(socket)
+      new_ssl_socket(socket.as(::Socket))
     end
   end
 
-  private def new_ssl_socket(io)
+  private def new_ssl_socket(io : ::Socket)
     OpenSSL::SSL::Socket::Server.new(io, @context, sync_close: @sync_close, accept: @start_immediately)
   end
 


### PR DESCRIPTION
## Summary

- Replace the custom Crystal BIO wrapper with `SSL_set_fd()` so OpenSSL operates directly on the socket file descriptor, enabling kTLS (kernel TLS) offload when available
- Handle `WANT_READ`/`WANT_WRITE` during handshake, read, write, and shutdown by waiting via `Crystal::EventLoop`, making the SSL socket properly non-blocking
- Add `ktls_send?`/`ktls_recv?` methods to query kTLS status

### Details

The previous implementation used a custom `OpenSSL::BIO` that proxied all I/O through Crystal's `IO` interface. This prevented the kernel from intercepting socket operations for kTLS. By switching to `SSL_set_fd`, OpenSSL reads/writes directly on the socket fd, which allows the kernel's kTLS module to take over encryption when supported.

**New bindings:** `SSL_set_fd`, `SSL_get_rbio`, `SSL_get_wbio` (LibSSL), `BIO_ctrl` (LibCrypto)

**Breaking change:** The `io` parameter of `OpenSSL::SSL::Socket` is now type-restricted to `::Socket` (was untyped `IO`). In practice all callers (`HTTP::Client`, `HTTP::WebSocket`, `OpenSSL::SSL::Server`, all specs) already pass `TCPSocket`, so nothing should break.

## Test plan

- [x] `crystal spec spec/std/openssl/ssl/socket_spec.cr` — 11 examples, 0 failures
- [x] `crystal spec spec/std/openssl/ssl/server_spec.cr` — 8 examples, 0 failures
- [x] `crystal spec spec/std/http/server/server_spec.cr` — 31 examples, 0 failures
- [x] `crystal spec spec/std/http/client/client_spec.cr` — 35 examples, 0 failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)