### PR TITLE
Fix `System.cpu_count` returns `Int32`

### DIFF
--- a/spec/std/system_spec.cr
+++ b/spec/std/system_spec.cr
@@ -23,6 +23,7 @@ describe System do
           `getconf _NPROCESSORS_ONLN 2>/dev/null || nproc --all 2>/dev/null || grep -sc '^processor' /proc/cpuinfo || sysctl -n hw.ncpu 2>/dev/null`.to_i
         {% end %}
       cpu_count = System.cpu_count
+      cpu_count.should be_a(Int32)
       cpu_count.should eq(shell_cpus)
     end
   end

--- a/src/system.cr
+++ b/src/system.cr
@@ -19,7 +19,7 @@ module System
   # ```
   # System.cpu_count # => 4
   # ```
-  def self.cpu_count : Int
-    Crystal::System.cpu_count
+  def self.cpu_count : Int32
+    Crystal::System.cpu_count.to_i32!
   end
 end


### PR DESCRIPTION
`Int32` is the default number type, and stdlib APIs should usually return that.
Before, the return type of `System.cpu_count` was platform-specific and might have been anything between `Int32`, `Int64` or `UInt32` which makes it difficult to use in portable applications.