### PR TITLE
Fix: OpenSSL sockets shouldn't flush on read

### DIFF
--- a/src/openssl/bio.cr
+++ b/src/openssl/bio.cr
@@ -84,6 +84,14 @@ struct OpenSSL::BIO
   @boxed_io : Void*
 
   def initialize(@io : IO)
+    if io.is_a?(IO::Buffered)
+      # Disable buffers of the underlying IO (e.g. TCP socket) so OpenSSL
+      # becomes responsible of what needs to be read/written on the wire;
+      # instead, buffers shall be on OpenSSL::SSL::Socket (for example).
+      io.sync = true
+      io.read_buffering = false
+    end
+
     @bio = LibCrypto.BIO_new(CRYSTAL_BIO)
 
     # We need to store a reference to the box because it's

--- a/src/openssl/ssl/socket.cr
+++ b/src/openssl/ssl/socket.cr
@@ -101,13 +101,6 @@ abstract class OpenSSL::SSL::Socket < IO
       raise OpenSSL::Error.new("SSL_new")
     end
 
-    # Since OpenSSL::SSL::Socket is buffered it makes no
-    # sense to wrap a IO::Buffered with buffering activated.
-    if io.is_a?(IO::Buffered)
-      io.sync = true
-      io.read_buffering = false
-    end
-
     @bio = BIO.new(io)
     LibSSL.ssl_set_bio(@ssl, @bio, @bio)
   end


### PR DESCRIPTION
See https://github.com/crystal-lang/crystal/pull/16640#discussion_r2770458991

There's no reason for reading from the socket to autoflush the write buffer of the underlying IO object (e.g. TCP socket), especially since we already disable the buffers in `OpenSSL::SSL::Socket#initialize`, so it ends up being a NOOP in practice.

`Crystal::BIO#initialize` now always disables the buffers, so the logic is grouped together, instead of having `OpenSSL::SSL::Socket` do it.

NOTE: this is potentially a breaking change if someone re-enabled buffers or expects the buffers to be buffered (in non SSL socket situations).