### PR TITLE
[CI] Fix lint workflow to use `prek` instead of `pre-commit`

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -14,6 +14,7 @@ jobs:
         uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6
         with:
           persist-credentials: false
+          fetch-depth: 0
       - uses: cachix/install-nix-action@4e002c8ec80594ecd40e759629461e26c8abed15 # v31
       - uses: cachix/cachix-action@3ba601ff5bbb07c7220846facfa2cd81eeee15a1 # v16
         with:
@@ -22,10 +23,6 @@ jobs:
         run: nix profile install nixpkgs#devenv
       - name: "Download target branch: ${{ github.base_ref || 'master' }}"
         run: git fetch origin "${TARGET_BRANCH}"
-      - name: Diagnostic
-        run: |
-          git log --oneline --graph --decorate --all | head -n 20
-          git merge-base origin/master HEAD || echo "No merge base found"
       - name: Run prek hooks for changes against target branch (${{ github.base_ref || 'master' }})
         run: prek run --from-ref "origin/${TARGET_BRANCH}" --to-ref HEAD
         shell: devenv --profile lint shell bash -- -e {0}


### PR DESCRIPTION
The recent devenv update (#16623) changed the git hook runner from `pre-commit` to `prek`.