### PR TITLE
[CI] Add `fail-fast: false` to all matrix strategies

### DIFF
--- a/.github/workflows/interpreter.yml
+++ b/.github/workflows/interpreter.yml
@@ -51,9 +51,9 @@ jobs:
     container:
       image: crystallang/crystal:1.19.1-build
     strategy:
+      fail-fast: false
       matrix:
         part: [0, 1, 2, 3]
-      fail-fast: false
     name: "Test std_spec with interpreter (${{ matrix.part }})"
     steps:
       - uses: actions/checkout@v6

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -61,6 +61,7 @@ jobs:
       ARCH_CMD: linux64
     runs-on: ${{ case(startsWith(matrix.arch, 'aarch64'), 'ubuntu-24.04-arm', 'ubuntu-latest') }}
     strategy:
+      fail-fast: false
       matrix:
         arch:
           - x86_64

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -17,6 +17,7 @@ jobs:
     runs-on: ${{ matrix.runs-on }}
     name: "${{ matrix.runs-on }} (${{ matrix.arch }})"
     strategy:
+      fail-fast: false
       matrix:
         include:
         - runs-on: macos-15-intel
@@ -25,7 +26,6 @@ jobs:
           arch: aarch64-darwin
         - runs-on: macos-15
           arch: aarch64-darwin
-      fail-fast: false
     steps:
       - name: Download Crystal source
         uses: actions/checkout@v6

--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -61,8 +61,8 @@ jobs:
     runs-on: ubuntu-latest
 
     strategy:
-      max-parallel: 2
       fail-fast: false
+      max-parallel: 2
       matrix:
         target:
           - aarch64-linux-android


### PR DESCRIPTION
We almost always want `fail-fast: false`: If one matrix job fails, the others should still run.
This patch adds it when missing and moves it always as the first item for better visibility.