### PR TITLE
Skip non-existent library paths to avoid linker warnings

### DIFF
--- a/src/compiler/crystal/codegen/link.cr
+++ b/src/compiler/crystal/codegen/link.cr
@@ -131,6 +131,7 @@ module Crystal
       # searches user-given library paths.
       if has_flag?("msvc")
         CrystalLibraryPath.paths.each do |path|
+          next unless cross_compiling || Dir.exists?(path)
           flags << quote_flag("/LIBPATH:#{path}", cross_compiling)
         end
       end
@@ -158,6 +159,7 @@ module Crystal
       # Add CRYSTAL_LIBRARY_PATH locations, so the linker preferentially
       # searches user-given library paths.
       CrystalLibraryPath.paths.each do |path|
+        next unless cross_compiling || Dir.exists?(path)
         flags << quote_flag("-L#{path}", cross_compiling)
       end
 


### PR DESCRIPTION
## Summary

- Skip non-existent directories in `CRYSTAL_LIBRARY_PATH` before passing them as `-L` / `/LIBPATH:` flags to the linker
- Prevents cosmetic "search path not found" warnings from `ld` when `$ORIGIN/../lib/crystal` resolves to a directory that doesn't exist

Fixes #16661

## Problem

`CRYSTAL_CONFIG_LIBRARY_PATH` is baked into the compiler binary at build time as `$ORIGIN/../lib/crystal`. When the resolved directory doesn't exist on the host system, the linker warns:

```
ld: warning: search path '/opt/homebrew/Cellar/crystal/x.x.x/lib/crystal' not found
```

The official Homebrew formula works around this by creating an empty `lib/crystal` directory, but third-party packages, forks, or custom installations may not do this — leading to confusing warnings for users who haven't done anything wrong.

## Fix

Add a `Dir.exists?` guard in `lib_flags_posix` and `lib_flags_windows` before emitting path flags. Cross-compilation mode bypasses the check since remote paths can't be verified locally.

When the directory exists, behavior is identical to today.

## Test plan

- [x] Verified: removing `lib/crystal` with the stock compiler produces the warning
- [x] Verified: with this fix, the warning does not appear even when the directory is missing
- [x] Verified: compilation succeeds normally in both cases (libraries found via pkg-config)

🤖 Generated with [Claude Code](https://claude.com/claude-code)