### PR TITLE
Fix lexing percent literals with `|` delimiter in macro context

### DIFF
--- a/spec/compiler/lexer/lexer_macro_spec.cr
+++ b/spec/compiler/lexer/lexer_macro_spec.cr
@@ -295,7 +295,7 @@ describe "Lexer macro" do
     token.type.should eq(t :MACRO_END)
   end
 
-  [{"(", ")"}, {"[", "]"}, {"<", ">"}].each do |(left, right)|
+  [{"(", ")"}, {"[", "]"}, {"<", ">"}, {"|", "|"}].each do |(left, right)|
     it "lexes macro with embedded string with %#{left}" do
       lexer = Lexer.new("good %#{left} end #{right} day end")
 
@@ -328,6 +328,19 @@ describe "Lexer macro" do
 
     token = lexer.next_macro_token(token.macro_state, false)
     token.type.should eq(t :MACRO_END)
+  end
+
+  ["Q", "q", "w", "i", "r"].each do |prefix|
+    it "lexes macro with %#{prefix}| literal" do
+      lexer = Lexer.new("good %#{prefix}|begin| day end")
+
+      token = lexer.next_macro_token(Token::MacroState.default, false)
+      token.type.should eq(t :MACRO_LITERAL)
+      token.value.should eq("good %#{prefix}|begin| day ")
+
+      token = lexer.next_macro_token(token.macro_state, false)
+      token.type.should eq(t :MACRO_END)
+    end
   end
 
   it "lexes macro with comments" do

--- a/src/compiler/crystal/syntax/lexer.cr
+++ b/src/compiler/crystal/syntax/lexer.cr
@@ -1919,7 +1919,7 @@ module Crystal
             if !delimiter_state && ident_start?(char)
               is_percent_literal =
                 char.in?('q', 'Q', 'w', 'i', 'r', 'x') &&
-                lookahead { next_char; peek_next_char.in?('(', '<', '[', '{', '|') }
+                  lookahead { next_char; peek_next_char.in?('(', '<', '[', '{', '|') }
               break unless is_percent_literal
             end
           end

--- a/src/compiler/crystal/syntax/lexer.cr
+++ b/src/compiler/crystal/syntax/lexer.cr
@@ -1787,36 +1787,29 @@ module Crystal
 
       if !delimiter_state && current_char == '%' && ident_start?(peek_next_char)
         char = next_char
-        # For symmetric delimiters (like ||), use open_count = 0 (no nesting)
         if char == 'q' && peek_next_char.in?('(', '<', '[', '{', '|')
           next_char
-          open_count = current_char == closing_char ? 0 : 1
-          delimiter_state = Token::DelimiterState.new(:string, current_char, closing_char, open_count)
+          delimiter_state = Token::DelimiterState.percent_literal(:string, current_char, closing_char)
           next_char
         elsif char == 'Q' && peek_next_char.in?('(', '<', '[', '{', '|')
           next_char
-          open_count = current_char == closing_char ? 0 : 1
-          delimiter_state = Token::DelimiterState.new(:string, current_char, closing_char, open_count)
+          delimiter_state = Token::DelimiterState.percent_literal(:string, current_char, closing_char)
           next_char
         elsif char == 'i' && peek_next_char.in?('(', '<', '[', '{', '|')
           next_char
-          open_count = current_char == closing_char ? 0 : 1
-          delimiter_state = Token::DelimiterState.new(:symbol_array, current_char, closing_char, open_count)
+          delimiter_state = Token::DelimiterState.percent_literal(:symbol_array, current_char, closing_char)
           next_char
         elsif char == 'w' && peek_next_char.in?('(', '<', '[', '{', '|')
           next_char
-          open_count = current_char == closing_char ? 0 : 1
-          delimiter_state = Token::DelimiterState.new(:string_array, current_char, closing_char, open_count)
+          delimiter_state = Token::DelimiterState.percent_literal(:string_array, current_char, closing_char)
           next_char
         elsif char == 'x' && peek_next_char.in?('(', '<', '[', '{', '|')
           next_char
-          open_count = current_char == closing_char ? 0 : 1
-          delimiter_state = Token::DelimiterState.new(:command, current_char, closing_char, open_count)
+          delimiter_state = Token::DelimiterState.percent_literal(:command, current_char, closing_char)
           next_char
         elsif char == 'r' && peek_next_char.in?('(', '<', '[', '{', '|')
           next_char
-          open_count = current_char == closing_char ? 0 : 1
-          delimiter_state = Token::DelimiterState.new(:regex, current_char, closing_char, open_count)
+          delimiter_state = Token::DelimiterState.percent_literal(:regex, current_char, closing_char)
           next_char
         else
           start = current_pos
@@ -1909,9 +1902,7 @@ module Crystal
           case char = peek_next_char
           when '(', '[', '<', '{', '|'
             next_char
-            # For symmetric delimiters (like ||), use open_count = 0 (no nesting)
-            open_count = char == closing_char ? 0 : 1
-            delimiter_state = Token::DelimiterState.new(:string, char, closing_char, open_count)
+            delimiter_state = Token::DelimiterState.percent_literal(:string, char, closing_char)
           else
             whitespace = false
             # Don't break if this looks like a prefixed percent literal that will

--- a/src/compiler/crystal/syntax/token.cr
+++ b/src/compiler/crystal/syntax/token.cr
@@ -327,6 +327,14 @@ module Crystal
         new kind, nest, the_end, open_count, 0, true
       end
 
+      # Creates a DelimiterState for percent literals in macros.
+      # For symmetric delimiters (||), uses open_count = 0 (no nesting).
+      # For paired delimiters (()), uses open_count = 1 (enables nesting).
+      def self.percent_literal(kind : DelimiterKind, nest, the_end)
+        open_count = nest == the_end ? 0 : 1
+        new kind, nest, the_end, open_count, 0, true
+      end
+
       def with_open_count_delta(delta)
         DelimiterState.new(@kind, @nest, @end, @open_count + delta, @heredoc_indent, @allow_escapes)
       end


### PR DESCRIPTION
Fixes lexing of macros containing percent literals.

The following used to build on versions up to 1.19.0. Percent literals combining a letter and a delimiter fail. For example, the following fails with "Error: unterminated macro" using [compiler 1.19.1](https://play.crystal-lang.org/#/r/injh).

```crystal
macro foo
  foo_attrs = %Q|string|
end
```

This PR includes tests that demonstrate the bug and changes to the lexer that fix it and introduce no new regressions.