### PR TITLE
Fix: must take `Errno.value` within `Fiber.syscall(&)` [fixup #15871]

### DIFF
--- a/src/crystal/event_loop/libevent.cr
+++ b/src/crystal/event_loop/libevent.cr
@@ -134,10 +134,11 @@ class Crystal::EventLoop::LibEvent < Crystal::EventLoop
   def open(path : String, flags : Int32, permissions : File::Permissions, blocking : Bool?) : {System::FileDescriptor::Handle, Bool} | Errno
     path.check_no_null_byte
 
-    fd = ::Fiber.syscall do
-      LibC.open(path, flags | LibC::O_CLOEXEC, permissions)
+    fd, errno = ::Fiber.syscall do
+      ret = LibC.open(path, flags | LibC::O_CLOEXEC, permissions)
+      {ret, Errno.value}
     end
-    return Errno.value if fd == -1
+    return errno if fd == -1
 
     {% if flag?(:darwin) %}
       # FIXME: poll of non-blocking fifo fd on darwin appears to be broken, so

--- a/src/crystal/event_loop/polling.cr
+++ b/src/crystal/event_loop/polling.cr
@@ -174,10 +174,11 @@ abstract class Crystal::EventLoop::Polling < Crystal::EventLoop
   def open(path : String, flags : Int32, permissions : File::Permissions, blocking : Bool?) : {System::FileDescriptor::Handle, Bool} | Errno
     path.check_no_null_byte
 
-    fd = ::Fiber.syscall do
-      LibC.open(path, flags | LibC::O_CLOEXEC, permissions)
+    fd, errno = ::Fiber.syscall do
+      ret = LibC.open(path, flags | LibC::O_CLOEXEC, permissions)
+      {ret, Errno.value}
     end
-    return Errno.value if fd == -1
+    return errno if fd == -1
 
     {% if flag?(:darwin) %}
       # FIXME: poll of non-blocking fifo fd on darwin appears to be broken, so


### PR DESCRIPTION
We must access `Errno.value` within the `Fiber.syscall(&)` block, not after the block returned because there can be a context switch before the method returns, and `errno` is no longer valid.

Fixup #15871.