### PR TITLE
Fix: don't terminate thread on Windows/IOCP

### DIFF
--- a/src/fiber/execution_context/thread_pool.cr
+++ b/src/fiber/execution_context/thread_pool.cr
@@ -136,7 +136,7 @@ class Fiber
               # original stack, terminating the main thread would invalidate the
               # main fiber stack (oops)
               #
-              # never shutdown a thread on windows: it would abort pending I/O
+              # FIXME: never shutdown a thread on windows: it would abort pending I/O
               # operations (for example `Socket#accept`) that the thread started
               parked.wait
             else


### PR DESCRIPTION
Exiting a thread will terminate any I/O operation it initiated, for example `Socket#accept`. A quick fix is to never terminate a thread until we figure out a better solution.

Fixes #16674.