### PR TITLE
[CI] Run `lint` workflow on all files when `devenv.lock` was changed

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -23,13 +23,24 @@ jobs:
         run: nix profile install nixpkgs#devenv
       - name: "Download target branch: ${{ github.base_ref || 'master' }}"
         run: git fetch origin "${TARGET_BRANCH}"
+      - name: Check whether to run full test on all files
+        id: test_full_run
+        if: ${{ github.event_name != 'workflow_dispatch' }}
+        run: |
+          # Trigger full run if devenv.lock or this workflow file changed
+          if git diff --quiet "origin/${TARGET_BRANCH}" HEAD -- devenv.lock .github/workflows/lint.yml; then
+            echo "test_full_run=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "test_full_run=true" >> "$GITHUB_OUTPUT"
+          fi
+      - name: Run prek on all files
+        id: run_full
+        run: prek run --all-files
+        shell: devenv --profile lint shell bash -- -e {0}
+        if: ${{ github.event_name == 'workflow_dispatch' || steps.test_full_run.outputs.test_full_run == 'true' }}
       - name: Run prek hooks for changes against target branch (${{ github.base_ref || 'master' }})
         run: prek run --from-ref "origin/${TARGET_BRANCH}" --to-ref HEAD
         shell: devenv --profile lint shell bash -- -e {0}
-        if: "${{ github.event_name != 'workflow_dispatch' }}"
-      - name: Run prek on all files
-        run: prek run --all-files
-        shell: devenv --profile lint shell bash -- -e {0}
-        if: "${{ github.event_name == 'workflow_dispatch' }}"
+        if: "${{ steps.run_full.outcome == 'skipped' }}"
     env:
       TARGET_BRANCH: "${{ github.base_ref || 'master' }}"


### PR DESCRIPTION
When updating the linting tools, we should run a full tests against the entire repo content.
This detects linting issues reported by new tool versions even in files that are not changed in the current diff.

Changes to `devenv.lock` may contain updates to the linting tools, so we use that as a reference.