### PR TITLE
Rename duplicated "between 64 and 128 bits" case

### DIFF
--- a/spec/compiler/codegen/abi/arm_spec.cr
+++ b/spec/compiler/codegen/abi/arm_spec.cr
@@ -134,7 +134,7 @@ class Crystal::ABI
           info.return_type.should eq(ArgType.indirect(str, LLVM::Attribute::StructRet))
         end
 
-        test "does with structs between 64 and 128 bits" do |abi, ctx|
+        test "does with structs larger than 128 bits" do |abi, ctx|
           str = ctx.struct([ctx.int64, ctx.int64, ctx.int8])
           arg_types = [str]
           return_type = str


### PR DESCRIPTION
Hello. 
I noticed there are two tests named "does with structs between 64 and 128 bits".
The second test handles a 64 + 64 + 8 bit struct, so I will rename it from "between 64 and 128 bits" to "larger than 128 bits".