### PR TITLE
Fix `Pointer#to_s` with lib typedefs

### DIFF
--- a/spec/std/pointer_spec.cr
+++ b/spec/std/pointer_spec.cr
@@ -1,5 +1,10 @@
 require "spec"
 
+private lib LibPointerSpec
+  type A = Void
+  type B = Void
+end
+
 private def reset(p1, p2)
   p1.value = 10
   p2.value = 20
@@ -187,6 +192,11 @@ describe "Pointer" do
   it "does to_s" do
     Pointer(Int32).null.to_s.should eq("Pointer(Int32).null")
     Pointer(Int32).new(1234_u64).to_s.should eq("Pointer(Int32)@0x4d2")
+  end
+
+  it "doesn't confuse lib typedefs (#16686)" do
+    Pointer(LibPointerSpec::A).null.inspect.should eq "Pointer(LibPointerSpec::A).null"
+    Pointer(LibPointerSpec::B).null.inspect.should eq "Pointer(LibPointerSpec::B).null"
   end
 
   it "creates from int" do

--- a/src/pointer.cr
+++ b/src/pointer.cr
@@ -341,9 +341,7 @@ struct Pointer(T)
   # ptr2.to_s # => "Pointer(Int32).null"
   # ```
   def to_s(io : IO) : Nil
-    io << "Pointer("
-    io << T.to_s
-    io << ')'
+    io << {{ @type.name.stringify }}
     if address == 0
       io << ".null"
     else


### PR DESCRIPTION
`T.to_s` at runtime seems to confuse different `type` defs pointing to the same base type.
I'm not quite sure why that is because both types should be distinct. They have different type ids. 🤔

This might just be a workaround for a codegen bug (see https://github.com/crystal-lang/crystal/issues/16686#issuecomment-3971573721).

Regardless, it seems like a good idea to generate the type name at compile time.

Ref #16686