### PR TITLE
Add `HTTP::WebSocket#receive` as a synchronous call

### DIFF
--- a/spec/std/http/web_socket_spec.cr
+++ b/spec/std/http/web_socket_spec.cr
@@ -541,7 +541,7 @@ describe HTTP::WebSocket do
   it "allows receiving messages synchronously" do
     ws_handler = HTTP::WebSocketHandler.new do |ws, ctx|
       str = ws.receive.as(String)
-      4.times do
+      2.times do
         ws.send(str)
         ws.send(str.to_slice)
       end
@@ -558,14 +558,8 @@ describe HTTP::WebSocket do
       client.receive.should eq "hello"
       client.receive.should eq "hello".to_slice
 
-      client.receive_string.should eq "hello"
-      client.receive_bytes.should eq "hello".to_slice
-
       client.receive?.should eq "hello"
       client.receive?.should eq "hello".to_slice
-
-      client.receive_string?.should eq "hello"
-      client.receive_bytes?.should eq "hello".to_slice
 
       # The WebSocket is closed after sending the above messages
       client.receive?.should eq nil

--- a/src/http/web_socket.cr
+++ b/src/http/web_socket.cr
@@ -5,20 +5,6 @@ require "./headers"
 class HTTP::WebSocket
   getter? closed = false
 
-  struct Ping
-    getter message : String
-
-    def initialize(@message)
-    end
-  end
-
-  struct Pong
-    getter message : String
-
-    def initialize(@message)
-    end
-  end
-
   # :nodoc:
   def initialize(io : IO, sync_close = true)
     initialize(Protocol.new(io, sync_close: sync_close))
@@ -268,6 +254,22 @@ class HTTP::WebSocket
   private def do_ping(message)
     @on_ping.try &.call(message)
     pong(message) unless closed?
+  end
+
+  # Returned by `receive` when the remote host sends a ping message.
+  struct Ping
+    getter message : String
+
+    def initialize(@message)
+    end
+  end
+
+  # Returned by `receive` when the remote host sends a pong message.
+  struct Pong
+    getter message : String
+
+    def initialize(@message)
+    end
   end
 end
 

--- a/src/http/web_socket.cr
+++ b/src/http/web_socket.cr
@@ -182,10 +182,10 @@ class HTTP::WebSocket
     loop do
       begin
         info = @ws.receive(@buffer)
-      rescue ex : IO::Error
+      rescue
         @on_close.try &.call(CloseCode::AbnormalClosure, "")
         @closed = true
-        raise ex
+        break
       end
 
       case info.opcode

--- a/src/http/web_socket.cr
+++ b/src/http/web_socket.cr
@@ -136,68 +136,6 @@ class HTTP::WebSocket
     @ws.close(code, message)
   end
 
-  # Receives and returns a single WebSocket message as a `String` or
-  # raises `IO::Error` if the `WebSocket` has been closed.
-  #
-  # ```
-  # # Open websocket connection
-  # ws = HTTP::WebSocket.new("websocket.example.com", "/chat")
-  #
-  # loop do
-  #   msg = ws.receive_string
-  #   handle(msg)
-  # end
-  # ```
-  def receive_string : String
-    receive_string? || raise_closed
-  end
-
-  # Receives and returns a single binary WebSocket message as a `Bytes`, or
-  # raises `IO::Error` if the `WebSocket` has been closed.
-  #
-  # ```
-  # # Open websocket connection
-  # ws = HTTP::WebSocket.new("websocket.example.com", "/chat")
-  #
-  # loop do
-  #   msg = ws.receive_bytes
-  #   handle(msg)
-  # end
-  # ```
-  def receive_bytes : Bytes
-    receive_bytes? || raise_closed
-  end
-
-  # Receives and returns a single WebSocket message as a `String` or `nil`
-  # if the `WebSocket` has been closed.
-  #
-  # ```
-  # # Open websocket connection
-  # ws = HTTP::WebSocket.new("websocket.example.com", "/chat")
-  #
-  # while msg = ws.receive_string?
-  #   handle(msg)
-  # end
-  # ```
-  def receive_string? : String?
-    receive?.as(String?)
-  end
-
-  # Receives and returns a single binary WebSocket message as a `Bytes` or `nil`
-  # if the `WebSocket` has been closed.
-  #
-  # ```
-  # # Open websocket connection
-  # ws = HTTP::WebSocket.new("websocket.example.com", "/chat")
-  #
-  # while msg = ws.receive_bytes?
-  #   handle(msg)
-  # end
-  # ```
-  def receive_bytes? : Bytes?
-    receive?.as(Bytes?)
-  end
-
   # Receives and returns a single WebSocket message as a `String` for text
   # messages, `Bytes` for binary messages, or raises `IO::Error` if the
   # `WebSocket` has been closed.

--- a/src/http/web_socket.cr
+++ b/src/http/web_socket.cr
@@ -241,15 +241,6 @@ class HTTP::WebSocket
   # end
   # ```
   def receive? : String | Bytes | Nil
-    case message = receive_impl
-    in String, Bytes
-      message
-    in Tuple(CloseCode, String)
-      nil
-    end
-  end
-
-  private def receive_impl : String | Bytes | {CloseCode, String}
     loop do
       begin
         info = @ws.receive(@buffer)
@@ -306,7 +297,7 @@ class HTTP::WebSocket
           do_close(code, message)
 
           @current_message.clear
-          return {code, message}
+          return nil
         end
       in .continuation?
         # TODO: (asterite) I think this is good, but this case wasn't originally handled
@@ -331,7 +322,7 @@ class HTTP::WebSocket
   # ```
   def run : Nil
     loop do
-      receive_impl
+      receive?
     rescue
       break
     end

--- a/src/http/web_socket.cr
+++ b/src/http/web_socket.cr
@@ -74,10 +74,10 @@ class HTTP::WebSocket
   end
 
   protected def check_open
-    handle_closed if closed?
+    raise_closed if closed?
   end
 
-  protected def handle_closed
+  protected def raise_closed
     raise IO::Error.new "Closed socket"
   end
 
@@ -149,7 +149,7 @@ class HTTP::WebSocket
   # end
   # ```
   def receive_string : String
-    receive_string? || handle_closed
+    receive_string? || raise_closed
   end
 
   # Receives and returns a single binary WebSocket message as a `Bytes`, or
@@ -165,7 +165,7 @@ class HTTP::WebSocket
   # end
   # ```
   def receive_bytes : Bytes
-    receive_bytes? || handle_closed
+    receive_bytes? || raise_closed
   end
 
   # Receives and returns a single WebSocket message as a `String` or `nil`
@@ -217,7 +217,7 @@ class HTTP::WebSocket
   # end
   # ```
   def receive : String | Bytes
-    receive? || handle_closed
+    receive? || raise_closed
   end
 
   # Receives and returns a single WebSocket message as a `String` for text

--- a/src/http/web_socket.cr
+++ b/src/http/web_socket.cr
@@ -260,9 +260,7 @@ class HTTP::WebSocket
   # ```
   def run : Nil
     loop do
-      receive?
-    rescue
-      break
+      break unless receive?
     end
   end
 


### PR DESCRIPTION
This moves most of `run` into `receive`, leaving `run` as primarily calling `receive` in a loop. `receive` is still implemented with a loop and only returns when receiving a `FIN` packet. The method signature used in this PR is the one recommended by @straight-shoota in [this comment](https://github.com/crystal-lang/crystal/issues/13239#issuecomment-1488569085).

Callbacks are still handled when calling `receive` because, even though I don't think it makes sense to use callbacks with `receive`, I think it'd be more confusing for someone to set up those callbacks and they aren't called.

Ping and pong messages are still handled internally so the program consuming the WebSocket doesn't need to handle protocol details.

Fixes #5600 
Addresses part of #13239