### PR TITLE
Emit `unreachable` for inlined `NoReturn` returns

### DIFF
--- a/src/compiler/crystal/codegen/call.cr
+++ b/src/compiler/crystal/codegen/call.cr
@@ -492,7 +492,9 @@ class Crystal::CodeGenVisitor
   end
 
   def inline_call_return_value(target_def, body)
-    if target_def.type.nil_type?
+    if target_def.type.no_return?
+      unreachable
+    elsif target_def.type.nil_type?
       @last = llvm_nil
     else
       @last = upcast(@last, target_def.type, body.type)


### PR DESCRIPTION
Fixes #11549

> Reduced:
> 
> ```cr
> struct Foo
>   @foo = uninitialized NoReturn
> 
>   def foo
>     @foo
>   end
> end
> 
> entry = uninitialized Foo
> entry.foo
> false
>```

Also

```cr
class Foo
  @foo = uninitialized NoReturn

  def foo
    @foo
  end
end

entry = Foo.new
entry.foo
false
```

This PR fixes a compilation failure triggered when an inlined call returns `NoReturn`.
The non-inlined path already treats `NoReturn` as terminal and emits `unreachable`:
https://github.com/crystal-lang/crystal/blob/5ce80482a2342af463acfa9d2d9573dcf6c2d049/src/compiler/crystal/codegen/call.cr#L535-L562
This change aligns the inlined path with that behavior, preventing invalid IR generation and the resulting compiler crash.