### PR TITLE
Avoid deprecated `Pointer.new(Int)` in `dlfcn`

### DIFF
--- a/src/lib_c/aarch64-darwin/c/dlfcn.cr
+++ b/src/lib_c/aarch64-darwin/c/dlfcn.cr
@@ -3,7 +3,7 @@ lib LibC
   RTLD_NOW     = 0x2
   RTLD_GLOBAL  = 0x8
   RTLD_LOCAL   = 0x4
-  RTLD_DEFAULT = Pointer(Void).new(-2)
+  RTLD_DEFAULT = Pointer(Void).new(-2.to_u64!)
   RTLD_NEXT    = Pointer(Void).new(-1.to_u64!)
 
   struct DlInfo

--- a/src/lib_c/aarch64-linux-android/c/dlfcn.cr
+++ b/src/lib_c/aarch64-linux-android/c/dlfcn.cr
@@ -4,7 +4,7 @@ lib LibC
   RTLD_NOW     = 0x00002
   RTLD_GLOBAL  = 0x00100
   RTLD_LOCAL   =       0
-  RTLD_DEFAULT = Pointer(Void).new(0)
+  RTLD_DEFAULT = Pointer(Void).new(0_u64)
 
   struct DlInfo
     dli_fname : Char*

--- a/src/lib_c/aarch64-linux-gnu/c/dlfcn.cr
+++ b/src/lib_c/aarch64-linux-gnu/c/dlfcn.cr
@@ -7,7 +7,7 @@ lib LibC
   RTLD_NOW     = 0x00002
   RTLD_GLOBAL  = 0x00100
   RTLD_LOCAL   =       0
-  RTLD_DEFAULT = Pointer(Void).new(0)
+  RTLD_DEFAULT = Pointer(Void).new(0_u64)
 
   struct DlInfo
     dli_fname : Char*

--- a/src/lib_c/aarch64-linux-musl/c/dlfcn.cr
+++ b/src/lib_c/aarch64-linux-musl/c/dlfcn.cr
@@ -3,7 +3,7 @@ lib LibC
   RTLD_NOW     =   2
   RTLD_GLOBAL  = 256
   RTLD_LOCAL   =   0
-  RTLD_DEFAULT = Pointer(Void).new(0)
+  RTLD_DEFAULT = Pointer(Void).new(0_u64)
   RTLD_NEXT    = Pointer(Void).new(-1.to_u64!)
 
   struct DlInfo

--- a/src/lib_c/arm-linux-gnueabihf/c/dlfcn.cr
+++ b/src/lib_c/arm-linux-gnueabihf/c/dlfcn.cr
@@ -7,7 +7,7 @@ lib LibC
   RTLD_NOW     = 0x00002
   RTLD_GLOBAL  = 0x00100
   RTLD_LOCAL   =       0
-  RTLD_DEFAULT = Pointer(Void).new(0)
+  RTLD_DEFAULT = Pointer(Void).new(0_u64)
 
   struct DlInfo
     dli_fname : Char*

--- a/src/lib_c/i386-linux-gnu/c/dlfcn.cr
+++ b/src/lib_c/i386-linux-gnu/c/dlfcn.cr
@@ -7,7 +7,7 @@ lib LibC
   RTLD_NOW     = 0x00002
   RTLD_GLOBAL  = 0x00100
   RTLD_LOCAL   =       0
-  RTLD_DEFAULT = Pointer(Void).new(0)
+  RTLD_DEFAULT = Pointer(Void).new(0_u64)
 
   struct DlInfo
     dli_fname : Char*

--- a/src/lib_c/i386-linux-musl/c/dlfcn.cr
+++ b/src/lib_c/i386-linux-musl/c/dlfcn.cr
@@ -3,7 +3,7 @@ lib LibC
   RTLD_NOW     =   2
   RTLD_GLOBAL  = 256
   RTLD_LOCAL   =   0
-  RTLD_DEFAULT = Pointer(Void).new(0)
+  RTLD_DEFAULT = Pointer(Void).new(0_u64)
   RTLD_NEXT    = Pointer(Void).new(-1.to_u64!)
 
   struct DlInfo

--- a/src/lib_c/x86_64-darwin/c/dlfcn.cr
+++ b/src/lib_c/x86_64-darwin/c/dlfcn.cr
@@ -3,7 +3,7 @@ lib LibC
   RTLD_NOW     = 0x2
   RTLD_GLOBAL  = 0x8
   RTLD_LOCAL   = 0x4
-  RTLD_DEFAULT = Pointer(Void).new(-2)
+  RTLD_DEFAULT = Pointer(Void).new(-2.to_u64!)
   RTLD_NEXT    = Pointer(Void).new(-1.to_u64!)
 
   struct DlInfo

--- a/src/lib_c/x86_64-dragonfly/c/dlfcn.cr
+++ b/src/lib_c/x86_64-dragonfly/c/dlfcn.cr
@@ -3,7 +3,7 @@ lib LibC
   RTLD_NOW     =     2
   RTLD_GLOBAL  = 0x100
   RTLD_LOCAL   =     0
-  RTLD_DEFAULT = Pointer(Void).new(-2)
+  RTLD_DEFAULT = Pointer(Void).new(-2.to_u64!)
   RTLD_NEXT    = Pointer(Void).new(-1.to_u64!)
 
   struct DlInfo

--- a/src/lib_c/x86_64-freebsd/c/dlfcn.cr
+++ b/src/lib_c/x86_64-freebsd/c/dlfcn.cr
@@ -3,7 +3,7 @@ lib LibC
   RTLD_NOW     =     2
   RTLD_GLOBAL  = 0x100
   RTLD_LOCAL   =     0
-  RTLD_DEFAULT = Pointer(Void).new(-2)
+  RTLD_DEFAULT = Pointer(Void).new(-2.to_u64!)
   RTLD_NEXT    = Pointer(Void).new(-1.to_u64!)
 
   struct DlInfo

--- a/src/lib_c/x86_64-linux-gnu/c/dlfcn.cr
+++ b/src/lib_c/x86_64-linux-gnu/c/dlfcn.cr
@@ -7,7 +7,7 @@ lib LibC
   RTLD_NOW     = 0x00002
   RTLD_GLOBAL  = 0x00100
   RTLD_LOCAL   =       0
-  RTLD_DEFAULT = Pointer(Void).new(0)
+  RTLD_DEFAULT = Pointer(Void).new(0_u64)
 
   struct DlInfo
     dli_fname : Char*

--- a/src/lib_c/x86_64-linux-musl/c/dlfcn.cr
+++ b/src/lib_c/x86_64-linux-musl/c/dlfcn.cr
@@ -3,7 +3,7 @@ lib LibC
   RTLD_NOW     =   2
   RTLD_GLOBAL  = 256
   RTLD_LOCAL   =   0
-  RTLD_DEFAULT = Pointer(Void).new(0)
+  RTLD_DEFAULT = Pointer(Void).new(0_u64)
   RTLD_NEXT    = Pointer(Void).new(-1.to_u64!)
 
   struct DlInfo

--- a/src/lib_c/x86_64-netbsd/c/dlfcn.cr
+++ b/src/lib_c/x86_64-netbsd/c/dlfcn.cr
@@ -4,7 +4,7 @@ lib LibC
   RTLD_GLOBAL  = 0x100
   RTLD_LOCAL   = 0x200
   RTLD_NEXT    = Pointer(Void).new(-1.to_u64!)
-  RTLD_DEFAULT = Pointer(Void).new(-2)
+  RTLD_DEFAULT = Pointer(Void).new(-2.to_u64!)
 
   struct DlInfo
     dli_fname : Char*

--- a/src/lib_c/x86_64-openbsd/c/dlfcn.cr
+++ b/src/lib_c/x86_64-openbsd/c/dlfcn.cr
@@ -3,7 +3,7 @@ lib LibC
   RTLD_NOW     =     2
   RTLD_GLOBAL  = 0x100
   RTLD_LOCAL   = 0x000
-  RTLD_DEFAULT = Pointer(Void).new(-2)
+  RTLD_DEFAULT = Pointer(Void).new(-2.to_u64!)
   RTLD_NEXT    = Pointer(Void).new(-1.to_u64!)
 
   struct DlInfo

--- a/src/lib_c/x86_64-solaris/c/dlfcn.cr
+++ b/src/lib_c/x86_64-solaris/c/dlfcn.cr
@@ -3,7 +3,7 @@ lib LibC
   RTLD_NOW     = 0x00002
   RTLD_GLOBAL  = 0x00100
   RTLD_LOCAL   = 0x00000
-  RTLD_DEFAULT = Pointer(Void).new(-2)
+  RTLD_DEFAULT = Pointer(Void).new(-2.to_u64!)
   RTLD_NEXT    = Pointer(Void).new(-1.to_u64!)
 
   struct DlInfo


### PR DESCRIPTION
Fixes #15408