### PR TITLE
Add `Process.new?`

### DIFF
--- a/spec/std/process_spec.cr
+++ b/spec/std/process_spec.cr
@@ -74,6 +74,48 @@ end
 {% end %}
 
 describe Process do
+  describe ".new?" do
+    it "raises if args is empty" do
+      expect_raises(File::NotFoundError, "Error executing process: No command") do
+        Process.new?([] of String)
+      end
+    end
+
+    it "returns nil if args[0] is empty" do
+      Process.new?([""] of String).should be_nil
+    end
+
+    it "returns nil command doesn't exist" do
+      Process.new?(["foobarbaz"]).should be_nil
+    end
+
+    it "returns nil for long path" do
+      Process.new?(["a" * 1000]).should be_nil
+    end
+
+    it "returns nil if command is not executable" do
+      with_tempfile("crystal-spec-run") do |path|
+        File.touch path
+        Process.new?([path]).should be_nil
+      end
+    end
+
+    it "returns nil if command is not executable" do
+      with_tempfile("crystal-spec-run") do |path|
+        Dir.mkdir path
+        Process.new?([path]).should be_nil
+      end
+    end
+
+    it "returns nil if command could not be executed" do
+      with_tempfile("crystal-spec-run") do |path|
+        File.touch path
+        command = File.join(path, "foo")
+        Process.new?([command]).should be_nil
+      end
+    end
+  end
+
   describe ".new (args)" do
     it "raises if args is empty" do
       expect_raises(File::NotFoundError, "Error executing process: No command") do

--- a/src/crystal/system/win32/process.cr
+++ b/src/crystal/system/win32/process.cr
@@ -286,7 +286,7 @@ struct Crystal::System::Process
     {new_handle, dup_handle}
   end
 
-  def self.spawn(prepared_args, shell, env, clear_env, input, output, error, chdir)
+  def self.spawn(prepared_args, shell, env, clear_env, input, output, error, chdir, &)
     startup_info = LibC::STARTUPINFOW.new
     startup_info.cb = sizeof(LibC::STARTUPINFOW)
     startup_info.dwFlags = LibC::STARTF_USESTDHANDLES
@@ -306,7 +306,7 @@ struct Crystal::System::Process
        ) == 0
       error = WinError.value
       if ::File::NotFoundError.os_error?(error) || ::File::AccessDeniedError.os_error?(error) || error == WinError::ERROR_BAD_EXE_FORMAT
-        raise ::File::Error.from_os_error("Error executing process", error, file: prepared_args)
+        yield error, prepared_args
       else
         raise IO::Error.from_os_error("Error executing process: '#{prepared_args}'", error)
       end


### PR DESCRIPTION
A new `Process` constructor which returns `nil` instead of raising when the executable could not be executed.

Part of https://github.com/crystal-lang/crystal/issues/9896