### PR TITLE
Prefer modern linker (`mold` or `lld`)

### DIFF
--- a/src/compiler/crystal/compiler.cr
+++ b/src/compiler/crystal/compiler.cr
@@ -544,9 +544,9 @@ module Crystal
       return link_flags unless DEFAULT_LINKER == "cc"
       return link_flags if link_flags.includes?("-fuse-ld=")
 
-      if (Process.run("mold") rescue false)
+      if Process.find_executable("mold")
         link_flags + " -fuse-ld=mold"
-      elsif (Process.run("ld.lld") rescue false)
+      elsif Process.find_executable("ld.lld")
         link_flags + " -fuse-ld=lld"
       else
         link_flags


### PR DESCRIPTION
`mold` or `lld` are practically always preferable over the default `ld` because they're much more efficient.

This patch checks whether these linkers are available and implicitly configures the linker driver to use them.

We keep the custom configuration in `Makefile` for now because it needs to work with the previous release compiler as well.

This is a workaround for #13193