### PR TITLE
Add `ASTNode#inspect`

### DIFF
--- a/spec/compiler/parser/inspect_spec.cr
+++ b/spec/compiler/parser/inspect_spec.cr
@@ -1,0 +1,912 @@
+require "../../support/syntax"
+
+private def expect_inspect(source, expected = source, file = __FILE__, line = __LINE__)
+  it "inspects #{source.inspect}", file, line do
+    node = Parser.new(source).parse
+    node.inspect.should eq(expected), file: file, line: line
+  end
+end
+
+describe "ASTNode#inspect" do
+  expect_inspect %q{[] of T}, %(ArrayLiteral[of: Path["T"]])
+  expect_inspect %q{([] of T).foo}, %(Call[Expressions.paren(ArrayLiteral[of: Path["T"]]), "foo"])
+  expect_inspect %q{({} of K => V).foo}, <<-CRYSTAL
+  Call[
+    Expressions.paren(HashLiteral[of: HashLiteral::Entry[Path["K"], Path["V"]]]),
+    "foo"
+  ]
+  CRYSTAL
+  expect_inspect %q{foo(bar)}, %(Call["foo", [Call["bar"]]])
+  expect_inspect %q{(~1).foo}, %(Call[Expressions.paren(Call[NumberLiteral["1", :i32], "~"]), "foo"])
+  expect_inspect %q{1 && (a = 2)}, <<-CRYSTAL
+  And[
+    NumberLiteral["1", :i32],
+    Expressions.paren(Assign[Var["a"], NumberLiteral["2", :i32]])
+  ]
+  CRYSTAL
+  expect_inspect %q{(a = 2) && 1}, <<-CRYSTAL
+  And[
+    Expressions.paren(Assign[Var["a"], NumberLiteral["2", :i32]]),
+    NumberLiteral["1", :i32]
+  ]
+  CRYSTAL
+  expect_inspect %q{foo(a.as(Int32))}, %(Call["foo", [Cast[Call["a"], Path["Int32"]]]])
+  expect_inspect %q{(1 + 2).as(Int32)}, <<-CRYSTAL
+  Cast[
+    Expressions.paren(
+      Call[NumberLiteral["1", :i32], "+", [NumberLiteral["2", :i32]]]
+    ),
+    Path["Int32"]
+  ]
+  CRYSTAL
+  expect_inspect %q{a.as?(Int32)}, %(NilableCast[Call["a"], Path["Int32"]])
+  expect_inspect %q{(1 + 2).as?(Int32)}, <<-CRYSTAL
+  NilableCast[
+    Expressions.paren(
+      Call[NumberLiteral["1", :i32], "+", [NumberLiteral["2", :i32]]]
+    ),
+    Path["Int32"]
+  ]
+  CRYSTAL
+  expect_inspect %q{@foo.bar}, %(Call[InstanceVar["@foo"], "bar"])
+  expect_inspect %(:foo), %(SymbolLiteral["foo"])
+  expect_inspect %(:"{"), %(SymbolLiteral["{"])
+  expect_inspect %(%r()), %(RegexLiteral[StringLiteral[""]])
+  expect_inspect %(%r()imx), <<-CRYSTAL
+  RegexLiteral[
+    StringLiteral[""],
+    options: Regex::Options[IGNORE_CASE, MULTILINE, EXTENDED]
+  ]
+  CRYSTAL
+  expect_inspect %(/hello world/), %(RegexLiteral[StringLiteral["hello world"]])
+  expect_inspect %(/hello world/imx), <<-CRYSTAL
+  RegexLiteral[
+    StringLiteral["hello world"],
+    options: Regex::Options[IGNORE_CASE, MULTILINE, EXTENDED]
+  ]
+  CRYSTAL
+  expect_inspect %(/\\s/), %(RegexLiteral[StringLiteral["\\\\s"]])
+  expect_inspect %(/\\?/), %(RegexLiteral[StringLiteral["\\\\?"]])
+  expect_inspect %(/\\(group\\)/), %(RegexLiteral[StringLiteral["\\\\(group\\\\)"]])
+  expect_inspect %(/\\//), %(RegexLiteral[StringLiteral["/"]])
+  expect_inspect %(/\#{1 / 2}/), <<-CRYSTAL
+    RegexLiteral[
+      StringInterpolation[
+        Call[NumberLiteral["1", :i32], "/", [NumberLiteral["2", :i32]]]
+      ]
+    ]
+    CRYSTAL
+  expect_inspect %<%r(/)>, %(RegexLiteral[StringLiteral["/"]])
+  expect_inspect %(/ /), %(RegexLiteral[StringLiteral[" "]])
+  expect_inspect %(%r( )), %(RegexLiteral[StringLiteral[" "]])
+  expect_inspect %(foo &.bar), %(Call["foo", block: Block[Var["__arg0"], body: Call[Var["__arg0"], "bar"]]])
+  expect_inspect %(foo &.bar(1, 2, 3)), <<-CRYSTAL
+    Call[
+      "foo",
+      block: Block[
+        Var["__arg0"],
+        body: Call[
+          Var["__arg0"],
+          "bar",
+          [NumberLiteral["1", :i32],
+           NumberLiteral["2", :i32],
+           NumberLiteral["3", :i32]]
+        ]
+      ]
+    ]
+    CRYSTAL
+  expect_inspect %(foo { |i| i.bar { i } }), <<-CRYSTAL
+    Call[
+      "foo",
+      block: Block[
+        Var["i"],
+        body: Call[Var["i"], "bar", block: Block[body: Var["i"]]]
+      ]
+    ]
+    CRYSTAL
+  expect_inspect %(foo do |k, v|\n  k.bar(1, 2, 3)\nend), <<-CRYSTAL
+    Call[
+      "foo",
+      block: Block[
+        Var["k"], Var["v"],
+        body: Call[
+          Var["k"],
+          "bar",
+          [NumberLiteral["1", :i32],
+           NumberLiteral["2", :i32],
+           NumberLiteral["3", :i32]]
+        ]
+      ]
+    ]
+    CRYSTAL
+  expect_inspect %(foo(3, &.*(2))), <<-CRYSTAL
+    Call[
+      "foo",
+      [NumberLiteral["3", :i32]],
+      block: Block[
+        Var["__arg0"],
+        body: Call[Var["__arg0"], "*", [NumberLiteral["2", :i32]]]
+      ]
+    ]
+    CRYSTAL
+  expect_inspect %(return begin\n  1\n  2\nend), %(Return[Expressions.begin(NumberLiteral["1", :i32], NumberLiteral["2", :i32])])
+  expect_inspect %(macro foo\n  %bar = 1\nend), <<-CRYSTAL
+    Macro[
+      "foo",
+      [],
+      Expressions[MacroLiteral["  "], MacroVar["bar"], MacroLiteral[" = 1\\n"]]
+    ]
+    CRYSTAL
+  expect_inspect %(macro foo\n  %bar = 1; end), <<-CRYSTAL
+    Macro[
+      "foo",
+      [],
+      Expressions[MacroLiteral["  "], MacroVar["bar"], MacroLiteral[" = 1; "]]
+    ]
+    CRYSTAL
+  expect_inspect %(macro foo\n  %bar{1, x} = 1\nend), <<-CRYSTAL
+    Macro[
+      "foo",
+      [],
+      Expressions[
+        MacroLiteral["  "],
+        MacroVar["bar", exps: [NumberLiteral["1", :i32], Var["x"]]],
+        MacroLiteral[" = 1\\n"]
+      ]
+    ]
+    CRYSTAL
+  expect_inspect %({% foo %}), %(MacroExpression[Var["foo"], output: false])
+  expect_inspect %({{ foo }}), %(MacroExpression[Var["foo"]])
+  expect_inspect %({% if foo %}\n  foo_then\n{% end %}), %(MacroIf[Var["foo"], MacroLiteral["\\n" + "  foo_then\\n"], Nop.new])
+  expect_inspect %({% if foo %}\n  foo_then\n{% else %}\n  foo_else\n{% end %}), <<-CRYSTAL
+    MacroIf[
+      Var["foo"],
+      MacroLiteral["\\n" + "  foo_then\\n"],
+      MacroLiteral["\\n" + "  foo_else\\n"]
+    ]
+    CRYSTAL
+  expect_inspect %({% for foo in bar %}\n  {{ foo }}\n{% end %}), <<-CRYSTAL
+    MacroFor[
+      [Var["foo"]],
+      Var["bar"],
+      Expressions[
+        MacroLiteral["\\n" + "  "],
+        MacroExpression[Var["foo"]],
+        MacroLiteral["\\n"]
+      ]
+    ]
+    CRYSTAL
+  expect_inspect %(macro foo\n  {% for foo in bar %}\n    {{ foo }}\n  {% end %}\nend), <<-CRYSTAL
+    Macro[
+      "foo",
+      [],
+      Expressions[
+        MacroLiteral["  "],
+        MacroFor[
+          [Var["foo"]],
+          Var["bar"],
+          Expressions[
+            MacroLiteral["\\n" + "    "],
+            MacroExpression[Var["foo"]],
+            MacroLiteral["\\n" + "  "]
+          ]
+        ],
+        MacroLiteral["\\n"]
+      ]
+    ]
+    CRYSTAL
+  expect_inspect %[1.as(Int32)], %(Cast[NumberLiteral["1", :i32], Path["Int32"]])
+  expect_inspect %[(1 || 1.1).as(Int32)], <<-CRYSTAL
+    Cast[
+      Expressions.paren(Or[NumberLiteral["1", :i32], NumberLiteral["1.1", :f64]]),
+      Path["Int32"]
+    ]
+    CRYSTAL
+  expect_inspect %[1 & 2 & (3 | 4)], <<-CRYSTAL
+    Call[
+      Call[NumberLiteral["1", :i32], "&", [NumberLiteral["2", :i32]]],
+      "&",
+      [Expressions.paren(
+         Call[NumberLiteral["3", :i32], "|", [NumberLiteral["4", :i32]]]
+       )]
+    ]
+    CRYSTAL
+  expect_inspect %[(1 & 2) & (3 | 4)], <<-CRYSTAL
+    Call[
+      Expressions.paren(
+        Call[NumberLiteral["1", :i32], "&", [NumberLiteral["2", :i32]]]
+      ),
+      "&",
+      [Expressions.paren(
+         Call[NumberLiteral["3", :i32], "|", [NumberLiteral["4", :i32]]]
+       )]
+    ]
+    CRYSTAL
+  expect_inspect %Q{def foo(x : T = 1)\nend}, <<-CRYSTAL
+    Def[
+      "foo",
+      [Arg["x", default_value: NumberLiteral["1", :i32], restriction: Path["T"]]],
+      Nop.new
+    ]
+    CRYSTAL
+  expect_inspect %Q{def foo(x : X, y : Y) forall X, Y\nend}, <<-CRYSTAL
+    Def[
+      "foo",
+      [Arg["x", restriction: Path["X"]], Arg["y", restriction: Path["Y"]]],
+      Nop.new
+    ]
+    CRYSTAL
+  expect_inspect %(foo : A | (B -> C)), <<-CRYSTAL
+      TypeDeclaration[
+        Var["foo"],
+        Union[Path["A"], ProcNotation[Path["B"], Path["C"]]]
+      ]
+      CRYSTAL
+  expect_inspect %(foo : Int32 = 1), <<-CRYSTAL
+      TypeDeclaration[Var["foo"], Path["Int32"], value: NumberLiteral["1", :i32]]
+      CRYSTAL
+  expect_inspect %(foo = uninitialized Int32), <<-CRYSTAL
+      UninitializedVar[Var["foo"], Path["Int32"]]
+      CRYSTAL
+  expect_inspect %[%("\#{foo}")], <<-CRYSTAL
+    StringInterpolation[StringLiteral["\\""], Call["foo"], StringLiteral["\\""]]
+    CRYSTAL
+  expect_inspect %Q{class Foo\n  private def bar\n  end\nend}, <<-CRYSTAL
+      ClassDef[
+        Path["Foo"],
+        body: VisibilityModifier[
+          Crystal::Visibility::Private,
+          Def["bar", [], Nop.new]
+        ]
+      ]
+      CRYSTAL
+  expect_inspect %q{abstract class Foo(T) < Bar; end}, <<-CRYSTAL
+      ClassDef[
+        Path["Foo"],
+        superclass: Path["Bar"],
+        type_vars: ["T"],
+        abstract: true,
+        body: Nop.new
+      ]
+      CRYSTAL
+  expect_inspect %q{struct Foo; end}, %q{ClassDef[Path["Foo"], struct: true, body: Nop.new]}
+  expect_inspect %q{module Foo(T); end}, %q{ModuleDef[Path["Foo"], type_vars: ["T"], body: Nop.new]}
+  expect_inspect %q{annotation Foo; end}, %q(AnnotationDef[Path["Foo"]])
+  expect_inspect %q{foo(&.==(2))}, <<-CRYSTAL
+      Call[
+        "foo",
+        block: Block[
+          Var["__arg0"],
+          body: Call[Var["__arg0"], "==", [NumberLiteral["2", :i32]]]
+        ]
+      ]
+      CRYSTAL
+  expect_inspect %q{foo.nil?}, %(IsA[Call["foo"], Path.global("Nil"), nil_check: true])
+  expect_inspect %q{foo._bar}, %(Call[Call["foo"], "_bar"])
+  expect_inspect %q{foo._bar(1)}, %(Call[Call["foo"], "_bar", [NumberLiteral["1", :i32]]])
+  expect_inspect %q{_foo.bar}, %(Call[Call["_foo"], "bar"])
+  expect_inspect %q{1.responds_to?(:inspect)}, %(RespondsTo[NumberLiteral["1", :i32], "inspect"])
+  expect_inspect %q{1.responds_to?(:"&&")}, %(RespondsTo[NumberLiteral["1", :i32], "&&"])
+  expect_inspect %Q{macro foo(x, *y)\nend}, %(Macro["foo", [Arg["x"], Arg["y"]], Expressions[], splat_index: 1])
+
+  expect_inspect %q{{ {1, 2, 3} }}, <<-CRYSTAL
+    TupleLiteral[
+      TupleLiteral[
+        NumberLiteral["1", :i32],
+        NumberLiteral["2", :i32],
+        NumberLiteral["3", :i32]
+      ]
+    ]
+    CRYSTAL
+  expect_inspect %q{{ {1 => 2} }}, <<-CRYSTAL
+    TupleLiteral[
+      HashLiteral[
+        HashLiteral::Entry[NumberLiteral["1", :i32], NumberLiteral["2", :i32]]
+      ]
+    ]
+    CRYSTAL
+  expect_inspect %q{{ {1, 2, 3} => 4 }}, <<-CRYSTAL
+    HashLiteral[
+      HashLiteral::Entry[
+        TupleLiteral[
+          NumberLiteral["1", :i32],
+          NumberLiteral["2", :i32],
+          NumberLiteral["3", :i32]
+        ],
+        NumberLiteral["4", :i32]
+      ]
+    ]
+    CRYSTAL
+  expect_inspect %q{{ {foo: 2} }}, %(TupleLiteral[NamedTupleLiteral["foo": NumberLiteral["2", :i32]]])
+  expect_inspect %Q{def foo(*args)\nend}, %(Def["foo", [Arg["args"]], Nop.new, splat_index: 0])
+  expect_inspect %Q{def foo(*args : _)\nend}, %(Def["foo", [Arg["args", restriction: Underscore.new]], Nop.new, splat_index: 0])
+  expect_inspect %Q{def foo(**args)\nend}, %(Def["foo", [], Nop.new, double_splat: Arg["args"]])
+  expect_inspect %Q{def foo(**args : T)\nend}, %(Def["foo", [], Nop.new, double_splat: Arg["args", restriction: Path["T"]]])
+  expect_inspect %Q{def foo(x, **args)\nend}, %(Def["foo", [Arg["x"]], Nop.new, double_splat: Arg["args"]])
+  expect_inspect %Q{def foo(x, **args, &block)\nend}, <<-CRYSTAL
+    Def[
+      "foo",
+      [Arg["x"]],
+      Nop.new,
+      block_arg: Arg["block"],
+      block_arity: 0,
+      double_splat: Arg["args"]
+    ]
+    CRYSTAL
+  expect_inspect %Q{def foo(x, **args, &block : (_ -> _))\nend}, <<-CRYSTAL
+    Def[
+      "foo",
+      [Arg["x"]],
+      Nop.new,
+      block_arg: Arg[
+        "block",
+        restriction: ProcNotation[Underscore.new, Underscore.new]
+      ],
+      block_arity: 1,
+      double_splat: Arg["args"]
+    ]
+    CRYSTAL
+  expect_inspect %Q{def foo(& : (->))\nend}, <<-CRYSTAL
+    Def[
+      "foo",
+      [],
+      Nop.new,
+      block_arg: Arg["", restriction: ProcNotation[]],
+      block_arity: 0
+    ]
+    CRYSTAL
+  expect_inspect %Q{macro foo(**args)\nend}, %(Macro["foo", [], Expressions[], double_splat: Arg["args"]])
+  expect_inspect %Q{macro foo(x, **args)\nend}, %(Macro["foo", [Arg["x"]], Expressions[], double_splat: Arg["args"]])
+  expect_inspect %Q{def foo(x y)\nend}, %(Def["foo", [Arg["y", external_name: "x"]], Nop.new])
+  expect_inspect %(foo("bar baz": 2)), %(Call["foo", named_args: [NamedArgument["bar baz", NumberLiteral["2", :i32]]]])
+  expect_inspect %(Foo("bar baz": Int32)), %(Generic[Path["Foo"], [], named_args: [NamedArgument["bar baz", Path["Int32"]]]])
+  expect_inspect %({"foo bar": 1}), %(NamedTupleLiteral["foo bar": NumberLiteral["1", :i32]])
+  expect_inspect %(def foo("bar baz" qux)\nend), %(Def["foo", [Arg["qux", external_name: "bar baz"]], Nop.new])
+  expect_inspect %q{foo()}, %(Call["foo"])
+  expect_inspect %q{/a/x}, %(RegexLiteral[StringLiteral["a"], options: Regex::Options::EXTENDED])
+  expect_inspect %q{1_f32}, %(NumberLiteral["1", :f32])
+  expect_inspect %q{1_f64}, %(NumberLiteral["1", :f64])
+  expect_inspect %q{1.0}, %(NumberLiteral["1.0", :f64])
+  expect_inspect %q{1e10_f64}, %(NumberLiteral["1e10", :f64])
+  expect_inspect %q{!a}, %(Not[Call["a"]])
+  expect_inspect %q{!(1 < 2)}, <<-CRYSTAL
+    Not[
+      Expressions.paren(
+        Call[NumberLiteral["1", :i32], "<", [NumberLiteral["2", :i32]]]
+      )
+    ]
+    CRYSTAL
+  expect_inspect %q{(1 + 2)..3}, <<-CRYSTAL
+    RangeLiteral[
+      Expressions.paren(
+        Call[NumberLiteral["1", :i32], "+", [NumberLiteral["2", :i32]]]
+      ),
+      NumberLiteral["3", :i32]
+    ]
+    CRYSTAL
+  expect_inspect %Q{macro foo\n{{ @type }}\nend}, <<-CRYSTAL
+    Macro[
+      "foo",
+      [],
+      Expressions[MacroExpression[InstanceVar["@type"]], MacroLiteral["\\n"]]
+    ]
+    CRYSTAL
+  expect_inspect %Q{macro foo\n\\{{ @type }}\nend}, %(Macro["foo", [], Expressions[MacroLiteral["{"], MacroLiteral["{ @type }}\\n"]]])
+  expect_inspect %Q{macro foo\n{% @type %}\nend}, <<-CRYSTAL
+    Macro[
+      "foo",
+      [],
+      Expressions[
+        MacroExpression[InstanceVar["@type"], output: false],
+        MacroLiteral["\\n"]
+      ]
+    ]
+    CRYSTAL
+  expect_inspect %Q{macro foo\n{{ @type }}\nend}, <<-CRYSTAL
+    Macro[
+      "foo",
+      [],
+      Expressions[MacroExpression[InstanceVar["@type"]], MacroLiteral["\\n"]]
+    ]
+    CRYSTAL
+  expect_inspect %Q{macro foo\n\\{{ @type }}\nend}, %(Macro["foo", [], Expressions[MacroLiteral["{"], MacroLiteral["{ @type }}\\n"]]])
+  expect_inspect %Q{macro foo\n{% @type %}\nend}, <<-CRYSTAL
+    Macro[
+      "foo",
+      [],
+      Expressions[
+        MacroExpression[InstanceVar["@type"], output: false],
+        MacroLiteral["\\n"]
+      ]
+    ]
+    CRYSTAL
+  expect_inspect %Q{macro foo\n\\{%@type %}\nend}, %(Macro["foo", [], Expressions[MacroLiteral["{%"], MacroLiteral["@type %}\\n"]]])
+  expect_inspect %Q{enum A : B\nend}, %(EnumDef[Path["A"], base_type: Path["B"]])
+  expect_inspect %Q{# doc\ndef foo\nend}, %(Def["foo", [], Nop.new])
+  expect_inspect %q{foo[x, y, a: 1, b: 2]}, <<-CRYSTAL
+    Call[
+      Call["foo"],
+      "[]",
+      [Call["x"], Call["y"]],
+      named_args: [NamedArgument["a", NumberLiteral["1", :i32]],
+       NamedArgument["b", NumberLiteral["2", :i32]]]
+    ]
+    CRYSTAL
+  expect_inspect %q{foo[x, y, a: 1, b: 2] = z}, <<-CRYSTAL
+    Call[
+      Call["foo"],
+      "[]=",
+      [Call["x"], Call["y"], Call["z"]],
+      named_args: [NamedArgument["a", NumberLiteral["1", :i32]],
+       NamedArgument["b", NumberLiteral["2", :i32]]]
+    ]
+    CRYSTAL
+  expect_inspect %(@[Foo(1, 2, a: 1, b: 2)]), <<-CRYSTAL
+    Annotation[
+      Path["Foo"],
+      named_args: [NamedArgument["a", NumberLiteral["1", :i32]],
+       NamedArgument["b", NumberLiteral["2", :i32]]]
+    ]
+    CRYSTAL
+  expect_inspect %(lib Foo\nend), %(LibDef[Path["Foo"], Nop.new])
+  expect_inspect %(fun foo(a : Void, b : Void, ...) : Void\n\nend), <<-CRYSTAL
+    FunDef[
+      "foo",
+      Arg["a", restriction: Path["Void"]], Arg["b", restriction: Path["Void"]],
+      return_type: Path["Void"],
+      varargs: true,
+      real_name: "foo",
+      body: Nop.new
+    ]
+    CRYSTAL
+  expect_inspect %(lib Foo\n  struct Foo\n    a : Void\n    b : Void\n  end\nend), <<-CRYSTAL
+    LibDef[
+      Path["Foo"],
+      CStructOrUnionDef[
+        "Foo",
+        Expressions[
+          TypeDeclaration[Var["a"], Path["Void"]],
+          TypeDeclaration[Var["b"], Path["Void"]]
+        ]
+      ]
+    ]
+    CRYSTAL
+  expect_inspect %(lib Foo\n  union Foo\n    a : Int\n    b : Int32\n  end\nend), <<-CRYSTAL
+    LibDef[
+      Path["Foo"],
+      CStructOrUnionDef[
+        "Foo",
+        Expressions[
+          TypeDeclaration[Var["a"], Path["Int"]],
+          TypeDeclaration[Var["b"], Path["Int32"]]
+        ],
+        union: true
+      ]
+    ]
+    CRYSTAL
+  expect_inspect %(lib Foo\n  FOO = 0\nend), %(LibDef[Path["Foo"], Assign[Path["FOO"], NumberLiteral["0", :i32]]])
+  expect_inspect %(lib LibC\n  fun getch = "get.char"\nend), %(LibDef[Path["LibC"], FunDef["getch", real_name: "get.char"]])
+  expect_inspect %(enum Foo\n  A = 0\n  B\nend), <<-CRYSTAL
+    EnumDef[
+      Path["Foo"],
+      Arg["A", default_value: NumberLiteral["0", :i32]], Arg["B"]
+    ]
+    CRYSTAL
+  expect_inspect %(alias Foo = Void), %(Alias[Path["Foo"], Path["Void"]])
+  expect_inspect %(alias Foo::Bar = Void), %(Alias[Path["Foo", "Bar"], Path["Void"]])
+  expect_inspect %(type(Foo = Void)), %(Call["type", [Assign[Path["Foo"], Path["Void"]]]])
+  expect_inspect %(return true ? 1 : 2), <<-CRYSTAL
+    Return[
+      If[
+        BoolLiteral[true],
+        NumberLiteral["1", :i32],
+        NumberLiteral["2", :i32],
+        ternary: true
+      ]
+    ]
+    CRYSTAL
+  expect_inspect %(1 <= 2 <= 3), <<-CRYSTAL
+    Call[
+      Call[NumberLiteral["1", :i32], "<=", [NumberLiteral["2", :i32]]],
+      "<=",
+      [NumberLiteral["3", :i32]]
+    ]
+    CRYSTAL
+  expect_inspect %((1 <= 2) <= 3), <<-CRYSTAL
+    Call[
+      Expressions.paren(
+        Call[NumberLiteral["1", :i32], "<=", [NumberLiteral["2", :i32]]]
+      ),
+      "<=",
+      [NumberLiteral["3", :i32]]
+    ]
+    CRYSTAL
+  expect_inspect %(1 <= (2 <= 3)), <<-CRYSTAL
+    Call[
+      NumberLiteral["1", :i32],
+      "<=",
+      [Expressions.paren(
+         Call[NumberLiteral["2", :i32], "<=", [NumberLiteral["3", :i32]]]
+       )]
+    ]
+    CRYSTAL
+  expect_inspect %(case 1; when .foo?; 2; end), <<-CRYSTAL
+    Case[
+      When[Call[ImplicitObj.new, "foo?"], NumberLiteral["2", :i32]],
+      cond: NumberLiteral["1", :i32]
+    ]
+    CRYSTAL
+  expect_inspect %(select; when foo.bar; 2; end), <<-CRYSTAL
+    Select[When[Call[Call["foo"], "bar"], NumberLiteral["2", :i32]]]
+    CRYSTAL
+  expect_inspect %(select; when foo.bar; 2; else 3; end), <<-CRYSTAL
+    Select[
+      When[Call[Call["foo"], "bar"], NumberLiteral["2", :i32]],
+      else: NumberLiteral["3", :i32]
+    ]
+    CRYSTAL
+  expect_inspect %(case 1; in .foo?; 2; end), <<-CRYSTAL
+    Case[
+      When[
+        Call[ImplicitObj.new, "foo?"],
+        NumberLiteral["2", :i32],
+        exhaustive: true
+      ],
+      cond: NumberLiteral["1", :i32],
+      exhaustive: true
+    ]
+    CRYSTAL
+  expect_inspect %(case 1; when .!; 2; when .< 0; 3; end), <<-CRYSTAL
+    Case[
+      When[Not[ImplicitObj.new], NumberLiteral["2", :i32]],
+      When[
+        Call[ImplicitObj.new, "<", [NumberLiteral["0", :i32]]],
+        NumberLiteral["3", :i32]
+      ],
+      cond: NumberLiteral["1", :i32]
+    ]
+    CRYSTAL
+  expect_inspect %(case 1\nwhen .[](2)\n  3\nwhen .[]=(4)\n  5\nend), <<-CRYSTAL
+    Case[
+      When[
+        Call[ImplicitObj.new, "[]", [NumberLiteral["2", :i32]]],
+        NumberLiteral["3", :i32]
+      ],
+      When[
+        Call[ImplicitObj.new, "[]=", [NumberLiteral["4", :i32]]],
+        NumberLiteral["5", :i32]
+      ],
+      cond: NumberLiteral["1", :i32]
+    ]
+    CRYSTAL
+  expect_inspect %({(1 + 2)}), <<-CRYSTAL
+    TupleLiteral[
+      Expressions.paren(
+        Call[NumberLiteral["1", :i32], "+", [NumberLiteral["2", :i32]]]
+      )
+    ]
+    CRYSTAL
+  expect_inspect %({foo: (1 + 2)}), <<-CRYSTAL
+    NamedTupleLiteral[
+      "foo": Expressions.paren(
+        Call[NumberLiteral["1", :i32], "+", [NumberLiteral["2", :i32]]]
+      )
+    ]
+    CRYSTAL
+  expect_inspect %q("#{(1 + 2)}"), <<-CRYSTAL
+    StringInterpolation[
+      Expressions.paren(
+        Call[NumberLiteral["1", :i32], "+", [NumberLiteral["2", :i32]]]
+      )
+    ]
+    CRYSTAL
+  expect_inspect %({(1 + 2) => (3 + 4)}), <<-CRYSTAL
+    HashLiteral[
+      HashLiteral::Entry[
+        Expressions.paren(
+          Call[NumberLiteral["1", :i32], "+", [NumberLiteral["2", :i32]]]
+        ),
+        Expressions.paren(
+          Call[NumberLiteral["3", :i32], "+", [NumberLiteral["4", :i32]]]
+        )
+      ]
+    ]
+    CRYSTAL
+  expect_inspect %([(1 + 2)] of Int32), <<-CRYSTAL
+    ArrayLiteral[
+      Expressions.paren(
+        Call[NumberLiteral["1", :i32], "+", [NumberLiteral["2", :i32]]]
+      ),
+      of: Path["Int32"]
+    ]
+    CRYSTAL
+  expect_inspect %(foo(1, (2 + 3), bar: (4 + 5))), <<-CRYSTAL
+    Call[
+      "foo",
+      [NumberLiteral["1", :i32],
+       Expressions.paren(
+         Call[NumberLiteral["2", :i32], "+", [NumberLiteral["3", :i32]]]
+       )],
+      named_args: [NamedArgument[
+         "bar",
+         Expressions.paren(
+           Call[NumberLiteral["4", :i32], "+", [NumberLiteral["5", :i32]]]
+         )
+       ]]
+    ]
+    CRYSTAL
+  expect_inspect %(if (1 + 2\n3)\n  4\nend), <<-CRYSTAL
+    If[
+      Expressions.paren(
+        Call[NumberLiteral["1", :i32], "+", [NumberLiteral["2", :i32]]],
+        NumberLiteral["3", :i32]
+      ),
+      NumberLiteral["4", :i32],
+      Nop.new
+    ]
+    CRYSTAL
+  expect_inspect %q(while foo; bar; end), %(While[Call["foo"], body: Call["bar"]])
+  expect_inspect %q(until foo; bar; end), %(Until[Call["foo"], body: Call["bar"]])
+  expect_inspect %q{%x(whoami)}, %(Call["`", [StringLiteral["whoami"]]])
+  expect_inspect %(begin\n  ()\nend), %(Expressions.begin(Expressions.paren(Nop.new)))
+  expect_inspect %q("\e\0\""), %q(StringLiteral["\e\u0000\""])
+  expect_inspect %q("#{1}\0"), <<-CRYSTAL
+    StringInterpolation[NumberLiteral["1", :i32], StringLiteral["\\u0000"]]
+    CRYSTAL
+  expect_inspect %q(%r{\/\0}), %(RegexLiteral[StringLiteral["/\\\\0"]])
+  expect_inspect %q(%r{#{1}\/\0}), <<-CRYSTAL
+    RegexLiteral[
+      StringInterpolation[
+        NumberLiteral["1", :i32], StringLiteral["/"], StringLiteral["\\\\0"]
+      ]
+    ]
+    CRYSTAL
+  expect_inspect %q(`\n\0`), %(Call["`", [StringLiteral["\\n" + "\\u0000"]]])
+  expect_inspect %q(`#{1}\n\0`), <<-CRYSTAL
+    Call[
+      "`",
+      [StringInterpolation[
+         NumberLiteral["1", :i32], StringLiteral["\\n"], StringLiteral["\\u0000"]
+       ]]
+    ]
+    CRYSTAL
+  expect_inspect %Q{macro foo\n{% verbatim do %}1{% end %}\nend}, <<-CRYSTAL
+    Macro[
+      "foo",
+      [],
+      Expressions[MacroVerbatim[MacroLiteral["1"]], MacroLiteral["\\n"]]
+    ]
+    CRYSTAL
+  expect_inspect %q{foo.*}, %(Call[Call["foo"], "*"])
+  expect_inspect %q{foo.%}, %(Call[Call["foo"], "%"])
+  expect_inspect %q{&+1}, %(Call[NumberLiteral["1", :i32], "&+"])
+  expect_inspect %q{&-1}, %(Call[NumberLiteral["1", :i32], "&-"])
+  expect_inspect %q{1.&*}, %(Call[NumberLiteral["1", :i32], "&*"])
+  expect_inspect %q{1.&**}, %(Call[NumberLiteral["1", :i32], "&**"])
+  expect_inspect %q{1.~(2)}, %(Call[NumberLiteral["1", :i32], "~", [NumberLiteral["2", :i32]]])
+  expect_inspect %Q{1.~(2) do\nend}, <<-CRYSTAL
+    Call[
+      NumberLiteral["1", :i32],
+      "~",
+      [NumberLiteral["2", :i32]],
+      block: Block[body: Nop.new]
+    ]
+    CRYSTAL
+  expect_inspect %Q{1.+ do\nend}, %(Call[NumberLiteral["1", :i32], "+", block: Block[body: Nop.new]])
+  expect_inspect %Q{1.[](2) do\nend}, <<-CRYSTAL
+    Call[
+      NumberLiteral["1", :i32],
+      "[]",
+      [NumberLiteral["2", :i32]],
+      block: Block[body: Nop.new]
+    ]
+    CRYSTAL
+  expect_inspect %q{1.[]=}, %(Call[NumberLiteral["1", :i32], "[]="])
+  expect_inspect %q{1.+(a: 2)}, <<-CRYSTAL
+    Call[
+      NumberLiteral["1", :i32],
+      "+",
+      named_args: [NamedArgument["a", NumberLiteral["2", :i32]]]
+    ]
+    CRYSTAL
+  expect_inspect %q{1.+(&block)}, %(Call[NumberLiteral["1", :i32], "+", block_arg: Call["block"]])
+  expect_inspect %q{1.//(2, a: 3)}, <<-CRYSTAL
+    Call[
+      NumberLiteral["1", :i32],
+      "//",
+      [NumberLiteral["2", :i32]],
+      named_args: [NamedArgument["a", NumberLiteral["3", :i32]]]
+    ]
+    CRYSTAL
+  expect_inspect %q{1.//(2, &block)}, <<-CRYSTAL
+    Call[
+      NumberLiteral["1", :i32],
+      "//",
+      [NumberLiteral["2", :i32]],
+      block_arg: Call["block"]
+    ]
+    CRYSTAL
+  expect_inspect %({% verbatim do %}\n  1{{ 2 }}\n  3{{ 4 }}\n{% end %}), <<-CRYSTAL
+    MacroVerbatim[
+      Expressions[
+        MacroLiteral["\\n" + "  1"],
+        MacroExpression[NumberLiteral["2", :i32]],
+        MacroLiteral["\\n" + "  3"],
+        MacroExpression[NumberLiteral["4", :i32]],
+        MacroLiteral["\\n"]
+      ]
+    ]
+    CRYSTAL
+  expect_inspect %({% for foo in bar %}\n  {{ if true\n  foo\n  bar\nend }}\n{% end %}), <<-CRYSTAL
+    MacroFor[
+      [Var["foo"]],
+      Var["bar"],
+      Expressions[
+        MacroLiteral["\\n" + "  "],
+        MacroExpression[
+          If[BoolLiteral[true], Expressions[Var["foo"], Var["bar"]], Nop.new]
+        ],
+        MacroLiteral["\\n"]
+      ]
+    ]
+    CRYSTAL
+  expect_inspect %(asm("nop" ::::)), %(Asm["nop"])
+  expect_inspect %(asm("nop" : "a"(1), "b"(2) : "c"(3), "d"(4) : "e", "f" : "volatile", "alignstack", "intel")), <<-CRYSTAL
+    Asm[
+      "nop",
+      outputs: [AsmOperand["a", NumberLiteral["1", :i32]],
+       AsmOperand["b", NumberLiteral["2", :i32]]],
+      inputs: [AsmOperand["c", NumberLiteral["3", :i32]],
+       AsmOperand["d", NumberLiteral["4", :i32]]],
+      clobbers: ["e", "f"],
+      volatile: true,
+      alignstack: true,
+      intel: true
+    ]
+    CRYSTAL
+  expect_inspect %(asm("nop" :: "c"(3), "d"(4) ::)), <<-CRYSTAL
+    Asm[
+      "nop",
+      inputs: [AsmOperand["c", NumberLiteral["3", :i32]],
+       AsmOperand["d", NumberLiteral["4", :i32]]]
+    ]
+    CRYSTAL
+  expect_inspect %(asm("nop" :::: "volatile")), %(Asm["nop", volatile: true])
+  expect_inspect %(asm("nop" :: "a"(1) :: "volatile")), %(Asm["nop", inputs: [AsmOperand["a", NumberLiteral["1", :i32]]], volatile: true])
+  expect_inspect %(asm("nop" ::: "e" : "volatile")), %(Asm["nop", clobbers: ["e"], volatile: true])
+  expect_inspect %[(1..)], %(Expressions.paren(RangeLiteral[NumberLiteral["1", :i32], Nop.new]))
+  expect_inspect %[..3], %(RangeLiteral[Nop.new, NumberLiteral["3", :i32]])
+  expect_inspect %q{offsetof(Foo, @bar)}, %(OffsetOf[Path["Foo"], InstanceVar["@bar"]])
+  expect_inspect %Q{def foo(**options, &block)\nend}, <<-CRYSTAL
+    Def[
+      "foo",
+      [],
+      Nop.new,
+      block_arg: Arg["block"],
+      block_arity: 0,
+      double_splat: Arg["options"]
+    ]
+    CRYSTAL
+  expect_inspect %Q{macro foo\n  123\nend}, %(Macro["foo", [], MacroLiteral["  123\\n"]])
+  expect_inspect %Q{if true\n(  1)\nend}, %(If[BoolLiteral[true], Expressions.paren(NumberLiteral["1", :i32]), Nop.new])
+  expect_inspect %Q{unless true\n(  1)\nend}, %(Unless[BoolLiteral[true], Expressions.paren(NumberLiteral["1", :i32]), Nop.new])
+  expect_inspect %Q{begin\n(  1)\nrescue\nend}, <<-CRYSTAL
+    ExceptionHandler[
+      rescues: [Rescue[]],
+      body: Expressions.paren(NumberLiteral["1", :i32])
+    ]
+    CRYSTAL
+  expect_inspect %q{begin; rescue exc; end}, <<-CRYSTAL
+    ExceptionHandler[rescues: [Rescue[name: "exc"]]]
+    CRYSTAL
+  expect_inspect %q{begin; rescue exc : Foo; end}, <<-CRYSTAL
+    ExceptionHandler[rescues: [Rescue[types: [Path["Foo"]], name: "exc"]]]
+    CRYSTAL
+  expect_inspect %q{begin; rescue Foo | Bar; end}, <<-CRYSTAL
+    ExceptionHandler[rescues: [Rescue[types: [Path["Foo"], Path["Bar"]]]]]
+    CRYSTAL
+  expect_inspect %q{begin; 2; ensure; 1; end}, <<-CRYSTAL
+    ExceptionHandler[
+      ensure: NumberLiteral["1", :i32],
+      body: NumberLiteral["2", :i32]
+    ]
+    CRYSTAL
+  expect_inspect %[他.说("你好")], %(Call[Call["他"], "说", [StringLiteral["你好"]]])
+  expect_inspect %[他.说 = "你好"], %(Call[Call["他"], "说=", [StringLiteral["你好"]]])
+  expect_inspect %[あ.い, う.え.お = 1, 2], <<-CRYSTAL
+    MultiAssign[
+      [Call[Call["あ"], "い"], Call[Call[Call["う"], "え"], "お"]],
+      [NumberLiteral["1", :i32], NumberLiteral["2", :i32]]
+    ]
+    CRYSTAL
+  expect_inspect %q(Foo(Bar)), %(Generic[Path["Foo"], [Path["Bar"]]])
+  expect_inspect %q(Foo?), <<-CRYSTAL
+    Generic.question(Path.global("Union"), [Path["Foo"], Path.global("Nil")])
+    CRYSTAL
+  expect_inspect %q(Foo(Bar*)), %q(Generic[Path["Foo"], [Generic.asterisk(Path.global("Pointer"), [Path["Bar"]])]])
+  expect_inspect %q(Foo(Bar[12])), <<-CRYSTAL
+    Generic[
+      Path["Foo"],
+      [Generic.bracket(
+         Path.global("StaticArray"),
+         [Path["Bar"], NumberLiteral["12", :i32]]
+       )]
+    ]
+    CRYSTAL
+  expect_inspect %q(nil), %(NilLiteral.new)
+  expect_inspect %q('c'), %(CharLiteral['c'])
+  expect_inspect %q(Set(String){"foo", "bar"}), <<-CRYSTAL
+    ArrayLiteral[
+      StringLiteral["foo"], StringLiteral["bar"],
+      name: Generic[Path["Set"], [Path["String"]]]
+    ]
+    CRYSTAL
+  expect_inspect %q(1...2), <<-CRYSTAL
+    RangeLiteral[
+      NumberLiteral["1", :i32],
+      NumberLiteral["2", :i32],
+      exclusive: true
+    ]
+    CRYSTAL
+  expect_inspect %q(/foo/ix), <<-CRYSTAL
+    RegexLiteral[
+      StringLiteral["foo"],
+      options: Regex::Options[IGNORE_CASE, EXTENDED]
+    ]
+    CRYSTAL
+  expect_inspect %q(foo = 1; foo += 2), <<-CRYSTAL
+    Expressions[
+      Assign[Var["foo"], NumberLiteral["1", :i32]],
+      OpAssign[Var["foo"], "+", NumberLiteral["2", :i32]]
+    ]
+    CRYSTAL
+  expect_inspect %q(foo.@bar), %(ReadInstanceVar[Call["foo"], "@bar"])
+  expect_inspect %q(@@bar), %(ClassVar["@@bar"])
+  expect_inspect %q($?), %(Global["$?"])
+  expect_inspect %q(def Foo.bar; end), <<-CRYSTAL
+    Def["bar", [], Nop.new, receiver: Path["Foo"]]
+    CRYSTAL
+  expect_inspect %q(abstract def foo : _), %q(Def["foo", [], Nop.new, return_type: Underscore.new, abstract: true])
+  expect_inspect %q(pointerof(foo)), %(PointerOf[Call["foo"]])
+  expect_inspect %q(sizeof(Int32)), %(SizeOf[Path["Int32"]])
+  expect_inspect %q(instance_sizeof(Int32)), %(InstanceSizeOf[Path["Int32"]])
+  expect_inspect %q(alignof(Int32)), %(AlignOf[Path["Int32"]])
+  expect_inspect %q(instance_alignof(Int32)), %(InstanceAlignOf[Path["Int32"]])
+  expect_inspect %q(LibFoo.bar(out baz)), <<-CRYSTAL
+    Call[Path["LibFoo"], "bar", [Out[Var["baz"]]]]
+    CRYSTAL
+  expect_inspect %q(private def foo; end), %(VisibilityModifier[Crystal::Visibility::Private, Def["foo", [], Nop.new]])
+  expect_inspect %q(require "foo"), %(Require["foo"])
+  expect_inspect %q(->(i : Int32) { i * 2 }), <<-CRYSTAL
+    ProcLiteral[
+      Def[
+        "->",
+        [Arg["i", restriction: Path["Int32"]]],
+        Call[Var["i"], "*", [NumberLiteral["2", :i32]]]
+      ]
+    ]
+    CRYSTAL
+  expect_inspect %q(->add(Int32, Int32)), <<-CRYSTAL
+    ProcPointer["add", [Path["Int32"], Path["Int32"]]]
+    CRYSTAL
+  expect_inspect %q(->Foo.add), <<-CRYSTAL
+    ProcPointer[Path["Foo"], "add"]
+    CRYSTAL
+  expect_inspect %q(yield), %(Yield[])
+  expect_inspect %q(with foo yield), %(Yield[scope: Call["foo"]])
+  expect_inspect %q(yield 1), %(Yield[NumberLiteral["1", :i32]])
+  expect_inspect %q(yield(1, 2)), <<-CRYSTAL
+    Yield[
+      NumberLiteral["1", :i32], NumberLiteral["2", :i32],
+      has_parentheses: true
+    ]
+    CRYSTAL
+  expect_inspect %q(include Foo), %(Include[Path["Foo"]])
+  expect_inspect %q(extend Foo), %(Extend[Path["Foo"]])
+  expect_inspect %q(lib Foo; type Bar = Baz; end), <<-CRYSTAL
+    LibDef[Path["Foo"], TypeDef["Bar", Path["Baz"]]]
+    CRYSTAL
+  expect_inspect %q(typeof(1)), %q(TypeOf[NumberLiteral["1", :i32]])
+  expect_inspect %q(foo(*x)), %q(Call["foo", [Splat[Call["x"]]]])
+  expect_inspect %q(foo(**x)), %q(Call["foo", [DoubleSplat[Call["x"]]]])
+end

--- a/spec/compiler/parser/inspect_spec.cr
+++ b/spec/compiler/parser/inspect_spec.cr
@@ -157,7 +157,7 @@ describe "ASTNode#inspect" do
     CRYSTAL
   expect_inspect %({% foo %}), %(MacroExpression[Var["foo"], output: false])
   expect_inspect %({{ foo }}), %(MacroExpression[Var["foo"]])
-  expect_inspect %({% if foo %}\n  foo_then\n{% end %}), %(MacroIf[Var["foo"], MacroLiteral["\\n" + "  foo_then\\n"], Nop.new])
+  expect_inspect %({% if foo %}\n  foo_then\n{% end %}), %(MacroIf[Var["foo"], MacroLiteral["\\n" + "  foo_then\\n"]])
   expect_inspect %({% if foo %}\n  foo_then\n{% else %}\n  foo_else\n{% end %}), <<-CRYSTAL
     MacroIf[
       Var["foo"],

--- a/src/compiler/crystal/syntax/ast.cr
+++ b/src/compiler/crystal/syntax/ast.cr
@@ -1,3 +1,39 @@
+# Helper for `#pretty_print` implementation. It describes the type.
+private def pp_type(pp, left, right, &) : Nil
+  pp.text left
+  pp.group_sub do
+    pp.nest(2) do
+      pp.breakable ""
+      yield
+    end
+    pp.breakable ""
+  end
+  pp.text right
+end
+
+# Helper for `#pretty_print` to emit optional properties.
+private macro pp_option(pp, name, comma = true, default = nil)
+  %value = {{ name.id }}
+  if %value {% if default %}!= {{ default }}{% end %}
+    {{ pp }}.comma if {{ comma }}
+    {{ pp }}.group do
+      {{ pp }}.text "#{{{name.id.stringify}}.rchop('?').lchop("self.")}: "
+      %value.pretty_print({{ pp }})
+    end
+    true
+  else
+    false
+  end
+end
+
+# Helper for joining elements with commas in `#pretty_print`.
+private def pp_join(pp, ary)
+  ary.each_with_index do |elem, i|
+    pp.comma if i > 0
+    elem.pretty_print(pp)
+  end
+end
+
 module Crystal
   # Base class for nodes in the grammar.
   abstract class ASTNode
@@ -110,6 +146,10 @@ module Crystal
     def single_expression?
       nil
     end
+
+    def inspect(io : IO) : Nil
+      PrettyPrint.format(self, io, 79)
+    end
   end
 
   class Nop < ASTNode
@@ -118,6 +158,10 @@ module Crystal
     end
 
     def_equals_and_hash
+
+    def pretty_print(pp) : Nil
+      pp.text "Nop.new"
+    end
   end
 
   # A container for one or many expressions.
@@ -213,6 +257,17 @@ module Crystal
     end
 
     def_equals_and_hash expressions
+
+    def pretty_print(pp) : Nil
+      if keyword.none?
+        before, after = "Expressions[", "]"
+      else
+        before, after = "Expressions.#{keyword.to_s.downcase}(", ")"
+      end
+      pp_type(pp, before, after) do
+        pp_join(pp, expressions)
+      end
+    end
   end
 
   # The nil literal.
@@ -225,6 +280,10 @@ module Crystal
     end
 
     def_equals_and_hash
+
+    def pretty_print(pp) : Nil
+      pp.text "NilLiteral.new"
+    end
   end
 
   # A bool literal.
@@ -242,6 +301,12 @@ module Crystal
     end
 
     def_equals_and_hash value
+
+    def pretty_print(pp) : Nil
+      pp_type(pp, "BoolLiteral[", "]") do
+        value.pretty_print(pp)
+      end
+    end
   end
 
   # The kind of primitive numbers.
@@ -377,6 +442,14 @@ module Crystal
 
     def_equals value.to_f64, kind
     def_hash value, kind
+
+    def pretty_print(pp) : Nil
+      pp_type(pp, "NumberLiteral[", "]") do
+        value.pretty_print(pp)
+        pp.comma
+        pp.text ":#{kind}"
+      end
+    end
   end
 
   # A char literal.
@@ -394,6 +467,12 @@ module Crystal
     end
 
     def_equals_and_hash value
+
+    def pretty_print(pp) : Nil
+      pp_type(pp, "CharLiteral[", "]") do
+        value.pretty_print(pp)
+      end
+    end
   end
 
   class StringLiteral < ASTNode
@@ -407,6 +486,12 @@ module Crystal
     end
 
     def_equals_and_hash value
+
+    def pretty_print(pp) : Nil
+      pp_type(pp, "StringLiteral[", "]") do
+        value.pretty_print(pp)
+      end
+    end
   end
 
   class StringInterpolation < ASTNode
@@ -428,6 +513,14 @@ module Crystal
     end
 
     def_equals_and_hash expressions
+
+    def pretty_print(pp) : Nil
+      pp_type(pp, "StringInterpolation[", "]") do
+        pp.group do
+          pp_join(pp, expressions)
+        end
+      end
+    end
   end
 
   class SymbolLiteral < ASTNode
@@ -441,6 +534,12 @@ module Crystal
     end
 
     def_equals_and_hash value
+
+    def pretty_print(pp) : Nil
+      pp_type(pp, "SymbolLiteral[", "]") do
+        value.pretty_print(pp)
+      end
+    end
   end
 
   # An array literal.
@@ -474,6 +573,17 @@ module Crystal
     end
 
     def_equals_and_hash @elements, @of, @name
+
+    def pretty_print(pp) : Nil
+      pp_type(pp, "ArrayLiteral[", "]") do
+        pp.group do
+          pp_join(pp, elements)
+        end
+
+        pp_option pp, of, comma: !elements.empty?
+        pp_option pp, name, comma: !elements.empty? || of
+      end
+    end
   end
 
   class HashLiteral < ASTNode
@@ -502,7 +612,25 @@ module Crystal
 
     def_equals_and_hash @entries, @of, @name
 
-    record Entry, key : ASTNode, value : ASTNode
+    record Entry, key : ASTNode, value : ASTNode do
+      def pretty_print(pp) : Nil
+        pp_type(pp, "HashLiteral::Entry[", "]") do
+          key.pretty_print pp
+          pp.comma
+          value.pretty_print pp
+        end
+      end
+    end
+
+    def pretty_print(pp) : Nil
+      pp_type(pp, "HashLiteral[", "]") do
+        pp.group do
+          pp_join(pp, entries)
+        end
+        pp_option pp, of, comma: !entries.empty?
+        pp_option pp, name, comma: !entries.empty? || of
+      end
+    end
   end
 
   class NamedTupleLiteral < ASTNode
@@ -524,6 +652,17 @@ module Crystal
     def_equals_and_hash @entries
 
     record Entry, key : String, value : ASTNode
+
+    def pretty_print(pp) : Nil
+      pp_type(pp, "NamedTupleLiteral[", "]") do
+        entries.each_with_index do |entry, i|
+          pp.comma if i > 0
+          entry.key.pretty_print pp
+          pp.text ": "
+          entry.value.pretty_print pp
+        end
+      end
+    end
   end
 
   class RangeLiteral < ASTNode
@@ -544,6 +683,15 @@ module Crystal
     end
 
     def_equals_and_hash @from, @to, @exclusive
+
+    def pretty_print(pp) : Nil
+      pp_type(pp, "RangeLiteral[", "]") do
+        from.pretty_print(pp)
+        pp.comma
+        to.pretty_print(pp)
+        pp_option pp, exclusive?
+      end
+    end
   end
 
   class RegexLiteral < ASTNode
@@ -562,6 +710,13 @@ module Crystal
     end
 
     def_equals_and_hash @value, @options
+
+    def pretty_print(pp) : Nil
+      pp_type(pp, "RegexLiteral[", "]") do
+        value.pretty_print(pp)
+        pp_option(pp, options, default: Regex::CompileOptions::None)
+      end
+    end
   end
 
   class TupleLiteral < ASTNode
@@ -587,6 +742,12 @@ module Crystal
     end
 
     def_equals_and_hash elements
+
+    def pretty_print(pp) : Nil
+      pp_type(pp, "TupleLiteral[", "]") do
+        pp_join(pp, elements)
+      end
+    end
   end
 
   module SpecialVar
@@ -613,8 +774,13 @@ module Crystal
       Var.new(@name)
     end
 
-    def_equals name
-    def_hash name
+    def_equals_and_hash name
+
+    def pretty_print(pp) : Nil
+      pp_type(pp, "Var[", "]") do
+        name.pretty_print(pp)
+      end
+    end
   end
 
   # A code block.
@@ -655,6 +821,16 @@ module Crystal
     end
 
     def_equals_and_hash args, body, splat_index, unpacks
+
+    def pretty_print(pp) : Nil
+      pp_type(pp, "Block[", "]") do
+        pp.group do
+          pp_join(pp, args)
+        end
+        pp_option(pp, body, comma: !args.empty?)
+        pp_option(pp, splat_index)
+      end
+    end
   end
 
   # A method call.
@@ -754,6 +930,24 @@ module Crystal
     end
 
     def_equals_and_hash obj, name, args, block, block_arg, named_args, global?
+
+    def pretty_print(pp) : Nil
+      pp_type(pp, "Call[", "]") do
+        if obj = @obj
+          obj.pretty_print(pp)
+          pp.comma
+        end
+        name.pretty_print(pp)
+        unless args.empty?
+          pp.comma
+          args.pretty_print(pp)
+        end
+        pp_option(pp, block)
+        pp_option(pp, block_arg)
+        pp_option(pp, named_args)
+        pp_option(pp, global?)
+      end
+    end
   end
 
   class NamedArgument < ASTNode
@@ -776,6 +970,14 @@ module Crystal
     end
 
     def_equals_and_hash name, value
+
+    def pretty_print(pp) : Nil
+      pp_type(pp, "NamedArgument[", "]") do
+        name.pretty_print(pp)
+        pp.comma
+        value.pretty_print(pp)
+      end
+    end
   end
 
   # An if expression.
@@ -815,6 +1017,21 @@ module Crystal
     end
 
     def_equals_and_hash @cond, @then, @else
+
+    def pretty_print(pp) : Nil
+      pp_type(pp, "If[", "]") do
+        cond.pretty_print(pp)
+        if a_then = @then
+          pp.comma
+          a_then.pretty_print(pp)
+        end
+        if a_else = @else
+          pp.comma
+          a_else.pretty_print(pp)
+        end
+        pp_option(pp, ternary?)
+      end
+    end
   end
 
   class Unless < ASTNode
@@ -841,6 +1058,20 @@ module Crystal
     end
 
     def_equals_and_hash @cond, @then, @else
+
+    def pretty_print(pp) : Nil
+      pp_type(pp, "Unless[", "]") do
+        cond.pretty_print(pp)
+        if a_then = @then
+          pp.comma
+          a_then.pretty_print(pp)
+        end
+        if a_else = @else
+          pp.comma
+          a_else.pretty_print(pp)
+        end
+      end
+    end
   end
 
   # Assign expression.
@@ -873,6 +1104,14 @@ module Crystal
     end
 
     def_equals_and_hash @target, @value
+
+    def pretty_print(pp) : Nil
+      pp_type(pp, "Assign[", "]") do
+        target.pretty_print(pp)
+        pp.comma
+        value.pretty_print(pp)
+      end
+    end
   end
 
   # Operator assign expression.
@@ -905,6 +1144,16 @@ module Crystal
     end
 
     def_equals_and_hash @target, @op, @value
+
+    def pretty_print(pp) : Nil
+      pp_type(pp, "OpAssign[", "]") do
+        target.pretty_print(pp)
+        pp.comma
+        op.pretty_print(pp)
+        pp.comma
+        value.pretty_print(pp)
+      end
+    end
   end
 
   # Assign expression.
@@ -932,6 +1181,14 @@ module Crystal
     end
 
     def_equals_and_hash @targets, @values
+
+    def pretty_print(pp) : Nil
+      pp_type(pp, "MultiAssign[", "]") do
+        targets.pretty_print(pp)
+        pp.comma
+        values.pretty_print(pp)
+      end
+    end
   end
 
   # An instance variable.
@@ -950,6 +1207,12 @@ module Crystal
     end
 
     def_equals_and_hash name
+
+    def pretty_print(pp) : Nil
+      pp_type(pp, "InstanceVar[", "]") do
+        name.pretty_print(pp)
+      end
+    end
   end
 
   class ReadInstanceVar < ASTNode
@@ -968,6 +1231,14 @@ module Crystal
     end
 
     def_equals_and_hash @obj, @name
+
+    def pretty_print(pp) : Nil
+      pp_type(pp, "ReadInstanceVar[", "]") do
+        obj.pretty_print(pp)
+        pp.comma
+        name.pretty_print(pp)
+      end
+    end
   end
 
   class ClassVar < ASTNode
@@ -981,6 +1252,12 @@ module Crystal
     end
 
     def_equals_and_hash name
+
+    def pretty_print(pp) : Nil
+      pp_type(pp, "ClassVar[", "]") do
+        name.pretty_print(pp)
+      end
+    end
   end
 
   # A global variable.
@@ -999,6 +1276,12 @@ module Crystal
     end
 
     def_equals_and_hash name
+
+    def pretty_print(pp) : Nil
+      pp_type(pp, "Global[", "]") do
+        name.pretty_print(pp)
+      end
+    end
   end
 
   abstract class BinaryOp < ASTNode
@@ -1018,6 +1301,15 @@ module Crystal
     end
 
     def_equals_and_hash left, right
+
+    def pretty_print(pp) : Nil
+      _, _, name = self.class.name.rpartition("::")
+      pp_type(pp, "#{name}[", "]") do
+        left.pretty_print(pp)
+        pp.comma
+        right.pretty_print(pp)
+      end
+    end
   end
 
   # Expressions and.
@@ -1070,6 +1362,17 @@ module Crystal
     end
 
     def_equals_and_hash name, default_value, restriction, external_name, parsed_annotations
+
+    def pretty_print(pp) : Nil
+      pp_type(pp, "Arg[", "]") do
+        name.pretty_print(pp)
+        pp_option(pp, default_value)
+        pp_option(pp, restriction)
+        if @external_name != @name
+          pp_option(pp, external_name)
+        end
+      end
+    end
   end
 
   # The Proc notation in the type grammar:
@@ -1092,6 +1395,18 @@ module Crystal
     end
 
     def_equals_and_hash inputs, output
+
+    def pretty_print(pp) : Nil
+      pp_type(pp, "ProcNotation[", "]") do
+        if inputs = @inputs
+          pp_join(pp, inputs)
+        end
+        if output = @output
+          pp.comma if @inputs
+          output.pretty_print(pp)
+        end
+      end
+    end
   end
 
   # A method definition.
@@ -1167,6 +1482,25 @@ module Crystal
     def has_any_args?
       args.present? || !block_arity.nil?
     end
+
+    def pretty_print(pp) : Nil
+      pp_type(pp, "Def[", "]") do
+        name.pretty_print(pp)
+        pp.comma
+        args.pretty_print(pp)
+        pp.comma
+        body.pretty_print(pp)
+
+        pp_option(pp, receiver)
+        pp_option(pp, block_arg)
+        pp_option(pp, return_type)
+        pp_option(pp, macro_def?)
+        pp_option(pp, block_arity)
+        pp_option(pp, abstract?)
+        pp_option(pp, splat_index)
+        pp_option(pp, double_splat)
+      end
+    end
   end
 
   class Macro < ASTNode
@@ -1205,6 +1539,19 @@ module Crystal
     end
 
     def_equals_and_hash @name, @args, @body, @block_arg, @splat_index, @double_splat
+
+    def pretty_print(pp) : Nil
+      pp_type(pp, "Macro[", "]") do
+        name.pretty_print(pp)
+        pp.comma
+        args.pretty_print(pp)
+        pp.comma
+        body.pretty_print(pp)
+        pp_option(pp, block_arg)
+        pp_option(pp, splat_index)
+        pp_option(pp, double_splat)
+      end
+    end
   end
 
   abstract class UnaryExpression < ASTNode
@@ -1222,6 +1569,13 @@ module Crystal
     end
 
     def_equals_and_hash exp
+
+    def pretty_print(pp) : Nil
+      _, _, name = self.class.name.rpartition("::")
+      pp_type(pp, "#{name}[", "]") do
+        exp.pretty_print(pp)
+      end
+    end
   end
 
   # Used only for flags
@@ -1284,6 +1638,14 @@ module Crystal
     end
 
     def_equals_and_hash @offsetof_type, @offset
+
+    def pretty_print(pp) : Nil
+      pp_type(pp, "OffsetOf[", "]") do
+        offsetof_type.pretty_print(pp)
+        pp.comma
+        offset.pretty_print(pp)
+      end
+    end
   end
 
   class VisibilityModifier < ASTNode
@@ -1307,6 +1669,14 @@ module Crystal
     end
 
     def_equals_and_hash modifier, exp
+
+    def pretty_print(pp) : Nil
+      pp_type(pp, "VisibilityModifier[", "]") do
+        modifier.pretty_print(pp)
+        pp.comma
+        exp.pretty_print(pp)
+      end
+    end
   end
 
   class IsA < ASTNode
@@ -1327,6 +1697,15 @@ module Crystal
     end
 
     def_equals_and_hash @obj, @const, @nil_check
+
+    def pretty_print(pp) : Nil
+      pp_type(pp, "IsA[", "]") do
+        obj.pretty_print(pp)
+        pp.comma
+        const.pretty_print(pp)
+        pp_option(pp, nil_check?)
+      end
+    end
   end
 
   class RespondsTo < ASTNode
@@ -1345,6 +1724,14 @@ module Crystal
     end
 
     def_equals_and_hash @obj, @name
+
+    def pretty_print(pp) : Nil
+      pp_type(pp, "RespondsTo[", "]") do
+        obj.pretty_print(pp)
+        pp.comma
+        name.pretty_print(pp)
+      end
+    end
   end
 
   class Require < ASTNode
@@ -1358,6 +1745,12 @@ module Crystal
     end
 
     def_equals_and_hash string
+
+    def pretty_print(pp) : Nil
+      pp_type(pp, "Require[", "]") do
+        string.pretty_print(pp)
+      end
+    end
   end
 
   class When < ASTNode
@@ -1383,6 +1776,17 @@ module Crystal
     end
 
     def_equals_and_hash @conds, @body, @exhaustive
+
+    def pretty_print(pp) : Nil
+      pp_type(pp, "When[", "]") do
+        pp.group do
+          pp_join(pp, conds)
+        end
+        pp.comma
+        body.pretty_print(pp)
+        pp_option(pp, exhaustive?)
+      end
+    end
   end
 
   class Case < ASTNode
@@ -1408,6 +1812,17 @@ module Crystal
     end
 
     def_equals_and_hash @exhaustive, @cond, @whens, @else
+
+    def pretty_print(pp) : Nil
+      pp_type(pp, "Case[", "]") do
+        pp.group do
+          pp_join(pp, whens)
+        end
+        pp_option(pp, :else)
+        pp_option(pp, cond)
+        pp_option(pp, exhaustive?)
+      end
+    end
   end
 
   class Select < ASTNode
@@ -1427,6 +1842,15 @@ module Crystal
     end
 
     def_equals_and_hash @whens, @else
+
+    def pretty_print(pp) : Nil
+      pp_type(pp, "Select[", "]") do
+        pp.group do
+          pp_join(pp, whens)
+        end
+        pp_option(pp, :else)
+      end
+    end
   end
 
   # Node that represents an implicit obj in:
@@ -1444,6 +1868,10 @@ module Crystal
     end
 
     def_hash
+
+    def pretty_print(pp) : Nil
+      pp.text "ImplicitObj.new"
+    end
   end
 
   # A qualified identifier.
@@ -1491,6 +1919,17 @@ module Crystal
     end
 
     def_equals_and_hash @names, @global
+
+    def pretty_print(pp) : Nil
+      if global?
+        before, after = "Path.global(", ")"
+      else
+        before, after = "Path[", "]"
+      end
+      pp_type(pp, before, after) do
+        pp_join(pp, names)
+      end
+    end
   end
 
   # Class definition:
@@ -1527,6 +1966,17 @@ module Crystal
     end
 
     def_equals_and_hash @name, @body, @superclass, @type_vars, @abstract, @struct, @splat_index
+
+    def pretty_print(pp) : Nil
+      pp_type(pp, "ClassDef[", "]") do
+        name.pretty_print(pp)
+        pp_option(pp, superclass)
+        pp_option(pp, type_vars)
+        pp_option(pp, abstract?)
+        pp_option(pp, struct?)
+        pp_option(pp, body)
+      end
+    end
   end
 
   # Module definition:
@@ -1558,7 +2008,15 @@ module Crystal
       clone
     end
 
-    def_equals_and_hash @name, @body, @type_vars, @splat_index
+    def_equals_and_hash @name, @body, @type_vars
+
+    def pretty_print(pp) : Nil
+      pp_type(pp, "ModuleDef[", "]") do
+        name.pretty_print(pp)
+        pp_option(pp, type_vars)
+        pp_option(pp, body)
+      end
+    end
   end
 
   # Annotation definition:
@@ -1584,6 +2042,12 @@ module Crystal
     end
 
     def_equals_and_hash @name
+
+    def pretty_print(pp) : Nil
+      pp_type(pp, "AnnotationDef[", "]") do
+        name.pretty_print(pp)
+      end
+    end
   end
 
   # While expression.
@@ -1610,6 +2074,13 @@ module Crystal
     end
 
     def_equals_and_hash @cond, @body
+
+    def pretty_print(pp) : Nil
+      pp_type(pp, "While[", "]") do
+        cond.pretty_print(pp)
+        pp_option(pp, body) unless body.is_a?(Nop)
+      end
+    end
   end
 
   # Until expression.
@@ -1636,6 +2107,13 @@ module Crystal
     end
 
     def_equals_and_hash @cond, @body
+
+    def pretty_print(pp) : Nil
+      pp_type(pp, "Until[", "]") do
+        cond.pretty_print(pp)
+        pp_option(pp, body) unless body.is_a?(Nop)
+      end
+    end
   end
 
   class Generic < ASTNode
@@ -1673,6 +2151,20 @@ module Crystal
     end
 
     def_equals_and_hash @name, @type_vars, @named_args
+
+    def pretty_print(pp) : Nil
+      if suffix.none?
+        before, after = "Generic[", "]"
+      else
+        before, after = "Generic.#{suffix.to_s.downcase}(", ")"
+      end
+      pp_type(pp, before, after) do
+        name.pretty_print(pp)
+        pp.comma
+        type_vars.pretty_print(pp)
+        pp_option(pp, named_args)
+      end
+    end
   end
 
   class TypeDeclaration < ASTNode
@@ -1711,6 +2203,15 @@ module Crystal
     end
 
     def_equals_and_hash @var, @declared_type, @value
+
+    def pretty_print(pp) : Nil
+      pp_type(pp, "TypeDeclaration[", "]") do
+        var.pretty_print(pp)
+        pp.comma
+        declared_type.pretty_print(pp)
+        pp_option(pp, value)
+      end
+    end
   end
 
   class UninitializedVar < ASTNode
@@ -1744,6 +2245,14 @@ module Crystal
     end
 
     def_equals_and_hash @var, @declared_type
+
+    def pretty_print(pp) : Nil
+      pp_type(pp, "UninitializedVar[", "]") do
+        var.pretty_print(pp)
+        pp.comma
+        declared_type.pretty_print(pp)
+      end
+    end
   end
 
   class Rescue < ASTNode
@@ -1765,6 +2274,19 @@ module Crystal
     end
 
     def_equals_and_hash @body, @types, @name
+
+    def pretty_print(pp) : Nil
+      pp_type(pp, "Rescue[", "]") do
+        comma = false
+        unless body.is_a?(Nop)
+          body.pretty_print(pp)
+          comma = true
+        end
+        c = pp_option(pp, types, comma: comma)
+        comma ||= c
+        pp_option(pp, name, comma: comma)
+      end
+    end
   end
 
   class ExceptionHandler < ASTNode
@@ -1800,6 +2322,23 @@ module Crystal
     end
 
     def_equals_and_hash @body, @rescues, @else, @ensure
+
+    def pretty_print(pp) : Nil
+      pp_type(pp, "ExceptionHandler[", "]") do
+        comma = false
+        c = pp_option(pp, rescues, comma: comma)
+        comma ||= c
+        c = pp_option(pp, self.else, comma: comma)
+        comma ||= c
+        c = pp_option(pp, self.ensure, comma: comma)
+        comma ||= c
+        c = pp_option(pp, implicit, comma: comma)
+        comma ||= c
+        c = pp_option(pp, suffix, comma: comma)
+        comma ||= c
+        pp_option(pp, body, comma: comma) unless body.is_a?(Nop)
+      end
+    end
   end
 
   class ProcLiteral < ASTNode
@@ -1817,6 +2356,12 @@ module Crystal
     end
 
     def_equals_and_hash @def
+
+    def pretty_print(pp) : Nil
+      pp_type(pp, "ProcLiteral[", "]") do
+        @def.pretty_print(pp)
+      end
+    end
   end
 
   class ProcPointer < ASTNode
@@ -1839,6 +2384,21 @@ module Crystal
 
     def_equals_and_hash @obj, @name, @args, @global
 
+    def pretty_print(pp) : Nil
+      pp_type(pp, "ProcPointer[", "]") do
+        if obj = @obj
+          obj.pretty_print(pp)
+          pp.comma
+        end
+        name.pretty_print(pp)
+        unless args.empty?
+          pp.comma
+          args.pretty_print(pp)
+        end
+        pp_option(pp, global?)
+      end
+    end
+
     def has_any_args?
       args.present?
     end
@@ -1859,6 +2419,12 @@ module Crystal
     end
 
     def_equals_and_hash types
+
+    def pretty_print(pp) : Nil
+      pp_type(pp, "Union[", "]") do
+        pp_join(pp, types)
+      end
+    end
   end
 
   class Self < ASTNode
@@ -1871,6 +2437,10 @@ module Crystal
     end
 
     def_hash
+
+    def pretty_print(pp) : Nil
+      pp.text "Self.new"
+    end
   end
 
   abstract class ControlExpression < ASTNode
@@ -1888,6 +2458,13 @@ module Crystal
     end
 
     def_equals_and_hash exp
+
+    def pretty_print(pp) : Nil
+      _, _, name = self.class.name.rpartition("::")
+      pp_type(pp, "#{name}[", "]") do
+        exp.pretty_print(pp)
+      end
+    end
   end
 
   class Return < ControlExpression
@@ -1930,6 +2507,16 @@ module Crystal
     end
 
     def_equals_and_hash @exps, @scope, @has_parentheses
+
+    def pretty_print(pp) : Nil
+      pp_type(pp, "Yield[", "]") do
+        pp.group do
+          pp_join(pp, exps)
+        end
+        pp_option(pp, scope, comma: !@exps.empty?)
+        pp_option(pp, has_parentheses?)
+      end
+    end
   end
 
   class Include < ASTNode
@@ -1951,6 +2538,12 @@ module Crystal
     end
 
     def_equals_and_hash name
+
+    def pretty_print(pp) : Nil
+      pp_type(pp, "Include[", "]") do
+        name.pretty_print(pp)
+      end
+    end
   end
 
   class Extend < ASTNode
@@ -1972,6 +2565,12 @@ module Crystal
     end
 
     def_equals_and_hash name
+
+    def pretty_print(pp) : Nil
+      pp_type(pp, "Extend[", "]") do
+        name.pretty_print(pp)
+      end
+    end
   end
 
   class LibDef < ASTNode
@@ -1996,6 +2595,14 @@ module Crystal
     end
 
     def_equals_and_hash @name, @body
+
+    def pretty_print(pp) : Nil
+      pp_type(pp, "LibDef[", "]") do
+        name.pretty_print(pp)
+        pp.comma
+        body.pretty_print(pp)
+      end
+    end
   end
 
   class FunDef < ASTNode
@@ -2032,6 +2639,20 @@ module Crystal
     end
 
     def_equals_and_hash @name, @args, @return_type, @varargs, @body, @real_name
+
+    def pretty_print(pp) : Nil
+      pp_type(pp, "FunDef[", "]") do
+        name.pretty_print(pp)
+        pp.comma if args.present?
+        pp.group do
+          pp_join(pp, args)
+        end
+        pp_option(pp, return_type)
+        pp_option(pp, varargs?)
+        pp_option(pp, real_name)
+        pp_option(pp, body)
+      end
+    end
   end
 
   class TypeDef < ASTNode
@@ -2054,6 +2675,14 @@ module Crystal
     end
 
     def_equals_and_hash @name, @type_spec
+
+    def pretty_print(pp) : Nil
+      pp_type(pp, "TypeDef[", "]") do
+        name.pretty_print(pp)
+        pp.comma
+        type_spec.pretty_print(pp)
+      end
+    end
   end
 
   # A c struct/union definition inside a lib declaration
@@ -2076,6 +2705,15 @@ module Crystal
     end
 
     def_equals_and_hash @name, @union, @body
+
+    def pretty_print(pp) : Nil
+      pp_type(pp, "CStructOrUnionDef[", "]") do
+        name.pretty_print(pp)
+        pp.comma
+        body.pretty_print(pp)
+        pp_option(pp, union?)
+      end
+    end
   end
 
   class EnumDef < ASTNode
@@ -2098,6 +2736,17 @@ module Crystal
     end
 
     def_equals_and_hash @name, @members, @base_type
+
+    def pretty_print(pp) : Nil
+      pp_type(pp, "EnumDef[", "]") do
+        name.pretty_print(pp)
+        pp.comma if members.present?
+        pp.group do
+          pp_join(pp, members)
+        end
+        pp_option(pp, base_type)
+      end
+    end
   end
 
   class ExternalVar < ASTNode
@@ -2118,6 +2767,15 @@ module Crystal
     end
 
     def_equals_and_hash @name, @type_spec, @real_name
+
+    def pretty_print(pp) : Nil
+      pp_type(pp, "ExternalVar[", "]") do
+        name.pretty_print(pp)
+        pp.comma
+        type_spec.pretty_print(pp)
+        pp_option(pp, real_name)
+      end
+    end
   end
 
   class Alias < ASTNode
@@ -2138,6 +2796,14 @@ module Crystal
     end
 
     def_equals_and_hash @name, @value
+
+    def pretty_print(pp) : Nil
+      pp_type(pp, "Alias[", "]") do
+        name.pretty_print(pp)
+        pp.comma
+        value.pretty_print(pp)
+      end
+    end
   end
 
   class Metaclass < ASTNode
@@ -2155,6 +2821,12 @@ module Crystal
     end
 
     def_equals_and_hash name
+
+    def pretty_print(pp) : Nil
+      pp_type(pp, "Metaclass[", "]") do
+        name.pretty_print(pp)
+      end
+    end
   end
 
   # obj as to
@@ -2179,6 +2851,14 @@ module Crystal
     end
 
     def_equals_and_hash @obj, @to
+
+    def pretty_print(pp) : Nil
+      pp_type(pp, "Cast[", "]") do
+        obj.pretty_print(pp)
+        pp.comma
+        to.pretty_print(pp)
+      end
+    end
   end
 
   # obj.as?(to)
@@ -2203,6 +2883,14 @@ module Crystal
     end
 
     def_equals_and_hash @obj, @to
+
+    def pretty_print(pp) : Nil
+      pp_type(pp, "NilableCast[", "]") do
+        obj.pretty_print(pp)
+        pp.comma
+        to.pretty_print(pp)
+      end
+    end
   end
 
   # typeof(exp, exp, ...)
@@ -2221,6 +2909,14 @@ module Crystal
     end
 
     def_equals_and_hash expressions
+
+    def pretty_print(pp) : Nil
+      pp_type(pp, "TypeOf[", "]") do
+        pp.group do
+          pp_join(pp, expressions)
+        end
+      end
+    end
   end
 
   class Annotation < ASTNode
@@ -2247,6 +2943,17 @@ module Crystal
     end
 
     def_equals_and_hash path, args, named_args
+
+    def pretty_print(pp) : Nil
+      pp_type(pp, "Annotation[", "]") do
+        path.pretty_print(pp)
+        unless !@args.empty?
+          pp.comma
+          args.pretty_print(pp)
+        end
+        pp_option(pp, named_args)
+      end
+    end
   end
 
   # A macro expression,
@@ -2268,6 +2975,13 @@ module Crystal
     end
 
     def_equals_and_hash exp, output?
+
+    def pretty_print(pp) : Nil
+      pp_type(pp, "MacroExpression[", "]") do
+        exp.pretty_print(pp)
+        pp_option(pp, output?, default: true)
+      end
+    end
   end
 
   # Free text that is part of a macro
@@ -2282,6 +2996,12 @@ module Crystal
     end
 
     def_equals_and_hash value
+
+    def pretty_print(pp) : Nil
+      pp_type(pp, "MacroLiteral[", "]") do
+        value.pretty_print(pp)
+      end
+    end
   end
 
   class MacroVerbatim < UnaryExpression
@@ -2319,6 +3039,17 @@ module Crystal
     end
 
     def_equals_and_hash @cond, @then, @else, @is_unless
+
+    def pretty_print(pp) : Nil
+      pp_type(pp, "MacroIf[", "]") do
+        cond.pretty_print(pp)
+        pp.comma
+        @then.pretty_print(pp)
+        pp.comma
+        @else.pretty_print(pp)
+        pp_option(pp, is_unless?)
+      end
+    end
   end
 
   # for inside a macro:
@@ -2345,6 +3076,16 @@ module Crystal
     end
 
     def_equals_and_hash @vars, @exp, @body
+
+    def pretty_print(pp) : Nil
+      pp_type(pp, "MacroFor[", "]") do
+        vars.pretty_print(pp)
+        pp.comma
+        exp.pretty_print(pp)
+        pp.comma
+        body.pretty_print(pp)
+      end
+    end
   end
 
   # A uniquely named variable inside a macro (like %var)
@@ -2364,6 +3105,13 @@ module Crystal
     end
 
     def_equals_and_hash @name, @exps
+
+    def pretty_print(pp) : Nil
+      pp_type(pp, "MacroVar[", "]") do
+        name.pretty_print(pp)
+        pp_option(pp, exps)
+      end
+    end
   end
 
   # An underscore matches against any type
@@ -2377,6 +3125,10 @@ module Crystal
     end
 
     def_hash
+
+    def pretty_print(pp) : Nil
+      pp.text "Underscore.new"
+    end
   end
 
   class Splat < UnaryExpression
@@ -2441,6 +3193,12 @@ module Crystal
     end
 
     def_equals_and_hash name
+
+    def pretty_print(pp) : Nil
+      pp_type(pp, "MagicConstant[", "]") do
+        name.pretty_print(pp)
+      end
+    end
   end
 
   class Asm < ASTNode
@@ -2466,6 +3224,19 @@ module Crystal
     end
 
     def_equals_and_hash text, outputs, inputs, clobbers, volatile?, alignstack?, intel?, can_throw?
+
+    def pretty_print(pp) : Nil
+      pp_type(pp, "Asm[", "]") do
+        text.pretty_print(pp)
+        pp_option(pp, outputs)
+        pp_option(pp, inputs)
+        pp_option(pp, clobbers)
+        pp_option(pp, :volatile?)
+        pp_option(pp, :alignstack?)
+        pp_option(pp, :intel?)
+        pp_option(pp, :can_throw?)
+      end
+    end
   end
 
   class AsmOperand < ASTNode
@@ -2484,6 +3255,14 @@ module Crystal
     end
 
     def_equals_and_hash constraint, exp
+
+    def pretty_print(pp) : Nil
+      pp_type(pp, "AsmOperand[", "]") do
+        constraint.pretty_print(pp)
+        pp.comma
+        exp.pretty_print(pp)
+      end
+    end
   end
 
   enum Visibility : Int8

--- a/src/compiler/crystal/syntax/ast.cr
+++ b/src/compiler/crystal/syntax/ast.cr
@@ -3045,9 +3045,11 @@ module Crystal
         cond.pretty_print(pp)
         pp.comma
         @then.pretty_print(pp)
-        pp.comma
-        @else.pretty_print(pp)
-        pp_option(pp, is_unless?)
+        unless @else.is_a?(Nop)
+          pp.comma
+          @else.pretty_print(pp)
+          pp_option(pp, is_unless?)
+        end
       end
     end
   end

--- a/src/compiler/crystal/syntax/to_s.cr
+++ b/src/compiler/crystal/syntax/to_s.cr
@@ -3,10 +3,6 @@ require "./visitor"
 
 module Crystal
   class ASTNode
-    def inspect(io : IO) : Nil
-      to_s(io)
-    end
-
     def to_s(io : IO, macro_expansion_pragmas = nil, emit_doc = false, emit_location_pragmas : Bool = false) : Nil
       visitor = ToSVisitor.new(io, macro_expansion_pragmas: macro_expansion_pragmas, emit_doc: emit_doc, emit_location_pragmas: emit_location_pragmas)
       self.accept visitor

--- a/src/pretty_print.cr
+++ b/src/pretty_print.cr
@@ -119,7 +119,8 @@ class PrettyPrint
     text close_obj
   end
 
-  private def group_sub(&)
+  # :nodoc:
+  def group_sub(&)
     group = Group.new(@group_stack.last.depth + 1)
     @group_stack.push group
     @group_queue.enq group


### PR DESCRIPTION
Implements an unambiguous representation of a syntax tree.

Previously, the only option for `ASTNode` was to stringify it into source code via `ToSVisitor`. But the source representation can be ambiguous, which is a problem when comparing source trees.

This is a completely new string representation format that clearly the depicts the AST node structure. The format resembles Crystal code, though it does not actually compile. This could be an option, though. The main reason not to produce actual source code is conciseness. We can work towards that if it appears useful. For now, it is already a major improvement being able to clearly differentiate AST node trees.
The exact format shouldn't matter too much because it's intended for human eyes, specifically for unambiguously comparing trees in parser specs.

The representation is limited to syntax features, but excludes location information for simplicity.
Semantic and codegen properties are less relevant because we rarely need to inspect entire syntax trees in those stages, and it would be a lot more complex (if even feasible because of cyclic references).

This has been brewing for a long time (see author date: 2021-09-24) and I finally managed to polish it up enough for submitting. I have been using this feature multiple times while working on different parts of the parser in the past years.

Resolves #9205
