### PR TITLE
[CI] Pin `nixpkgs` in `lint` workflow

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -16,6 +16,8 @@ jobs:
           persist-credentials: false
           fetch-depth: 0
       - uses: cachix/install-nix-action@4e002c8ec80594ecd40e759629461e26c8abed15 # v31
+        with:
+          nix_path: nixpkgs=https://github.com/NixOS/nixpkgs/archive/e99215c1a21cab2a995a3d01fe20d5714addea27.tar.gz # nixpkgs-unstable@2026-03-06 (with devenv 2.0)
       - uses: cachix/cachix-action@3ba601ff5bbb07c7220846facfa2cd81eeee15a1 # v16
         with:
           name: devenv


### PR DESCRIPTION
Without this, the action would always install the latest `nixpkgs-unstable` which doesn't guarantee the level of stability we would expect in a CI environment. Recently we had to quickly react to the automatic upgrade to devenv 2.0 (https://github.com/crystal-lang/crystal/pull/16705).
I'm pinning `nixpkgs` at a recent commit and expect to upgrade to the next stable channel `nixpkgs-26.05` when available.