### PR TITLE
Fix `declare_fun` attribute copy

### DIFF
--- a/src/compiler/crystal/codegen/fun.cr
+++ b/src/compiler/crystal/codegen/fun.cr
@@ -52,7 +52,10 @@ class Crystal::CodeGenVisitor
     new_fun = typed_fun.func
     source_fun.params.each_index do |index|
       attrs = source_fun.attributes(index + 1)
-      new_fun.add_attribute(attrs, index + 1) unless attrs.value == 0
+      if attrs.value != 0
+        param_type = new_fun.params[index].type
+        new_fun.add_attribute(attrs, index + 1, param_type)
+      end
     end
 
     typed_fun


### PR DESCRIPTION
Hello. This behavior was found by random exploration with Raptor Mini / Codex.
When declaring a function across LLVM module boundaries, argument attributes should be copied from the source function.
Previously, the code read attributes from the newly declared function.
Those attributes are usually `None`.
So `unless attrs.value == 0` skipped the copy.
The practical impact may be limited.