### PR TITLE
Fix typo in `Link` annotation spec

### DIFF
--- a/spec/compiler/semantic/lib_spec.cr
+++ b/spec/compiler/semantic/lib_spec.cr
@@ -310,7 +310,7 @@ describe "Semantic: lib" do
       CRYSTAL
   end
 
-  it "errors if fourth argument is not a bool" do
+  it "errors if fourth argument is not a string" do
     assert_error <<-CRYSTAL, "'framework' link argument must be a String"
       @[Link("foo", "bar", true, 1)]
       lib LibFoo


### PR DESCRIPTION
Fixes a typo in a spec description for @[Link] positional arguments.