### PR TITLE
Fix: `thread_local` macro exposes `Thread` class in stdlib docs

### DIFF
--- a/src/object.cr
+++ b/src/object.cr
@@ -756,6 +756,7 @@ class Object
       {% end %}
     end
 
+    # :nodoc:
     class ::Thread
       # :nodoc:
       property {{tls_name}} : {{decl.type}} | Nil


### PR DESCRIPTION
See for example https://crystal-lang.org/api/1.19.1/Thread.html

Fixup #16173