### PR TITLE
Remove useless parser delimiter state condition [fixup #16672]

### DIFF
--- a/src/compiler/crystal/syntax/lexer.cr
+++ b/src/compiler/crystal/syntax/lexer.cr
@@ -1449,8 +1449,7 @@ module Crystal
         raise_unterminated_quoted delimiter_state
       when string_end
         next_char
-        # For symmetric delimiters (like ||), don't use nesting logic
-        if string_nest == string_end || string_open_count == 0
+        if string_open_count == 0
           @token.type = :DELIMITER_END
         else
           @token.type = :STRING


### PR DESCRIPTION
For symmetric delimiters, `string_open_count == 0` is already true.