### PR TITLE
Replace Int128/UInt128 MIN/MAX with literal values

### DIFF
--- a/src/int.cr
+++ b/src/int.cr
@@ -1674,9 +1674,8 @@ struct Int64
 end
 
 struct Int128
-  # TODO: eventually update to literals once UInt128 bit support is finished
-  MIN = new(1) << 127
-  MAX = ~MIN
+  MIN = -170141183460469231731687303715884105728_i128
+  MAX =  170141183460469231731687303715884105727_i128
 
   # Returns an `Int128` by invoking `to_i128` on *value*.
   # See `String#to_i` for more details.
@@ -2622,9 +2621,8 @@ struct UInt64
 end
 
 struct UInt128
-  # TODO: eventually update to literals once UInt128 bit support is finished
-  MIN = new 0
-  MAX = ~MIN
+  MIN =   0_u128
+  MAX = 340282366920938463463374607431768211455_u128
 
   # Returns an `UInt128` by invoking `to_u128` on *value*.
   # See `String#to_i` for more details.


### PR DESCRIPTION
## Summary
- Replace computed `Int128::MIN`/`MAX` and `UInt128::MIN`/`MAX` with direct 128-bit literal values
- Remove stale TODO comments that referenced unfinished UInt128 literal support (which has since been completed)

## Test plan
- [ ] Existing specs pass (no behavioral change — values are identical)
- [ ] Verify `Int128::MIN`, `Int128::MAX`, `UInt128::MIN`, `UInt128::MAX` return correct values

🤖 Generated with [Claude Code](https://claude.com/claude-code)