### PR TITLE
Use literals in Int128/UInt128 negation operators

### DIFF
--- a/src/int.cr
+++ b/src/int.cr
@@ -1704,8 +1704,7 @@ struct Int128
   Number.expand_div [Float64], Float64
 
   def -
-    # TODO: use 0_i128 - self
-    Int128.new(0) - self
+    0_i128 - self
   end
 
   # Returns `self` converted to a signed value of the same size.
@@ -2652,8 +2651,7 @@ struct UInt128
   Number.expand_div [Float64], Float64
 
   def &-
-    # TODO: use 0_u128 &- self
-    UInt128.new(0) &- self
+    0_u128 &- self
   end
 
   # Returns `self` converted to a signed value of the same size.


### PR DESCRIPTION
## Summary
- Replace `Int128.new(0)` with `0_i128` in `Int128#-`
- Replace `UInt128.new(0)` with `0_u128` in `UInt128#&-`
- Remove stale TODO comments that indicated this was the intended change

## Test plan
- [ ] Existing specs pass (no behavioral change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)