### PR TITLE
Add endianness guard to compiler-rt shift builtins

### DIFF
--- a/src/crystal/compiler_rt/shift.cr
+++ b/src/crystal/compiler_rt/shift.cr
@@ -1,8 +1,11 @@
+{% raise "compiler-rt shift builtins assume little-endian byte order for unsafe_as(Tuple) reinterpretation" if flag?(:big_endian) %}
+
 # :nodoc:
 # Ported from https://github.com/llvm/llvm-project/blob/ce59ccd04023cab3a837da14079ca2dcbfebb70c/compiler-rt/lib/builtins/ashlti3.c
 #
 # Returns: a << b
 # Precondition:  0 <= b < bits_in_tword
+# NOTE: The Tuple reinterpretation below assumes little-endian layout: {low, high}
 fun __ashlti3(a : Int128, b : Int32) : Int128
   low, high = a.unsafe_as(Tuple(UInt64, Int64))
   if b >= 64
@@ -21,6 +24,7 @@ end
 #
 # Returns: a >> b
 # Precondition:  0 <= b < bits_in_tword
+# NOTE: The Tuple reinterpretation below assumes little-endian layout: {low, high}
 fun __ashrti3(a : Int128, b : Int32) : Int128
   low, high = a.unsafe_as(Tuple(UInt64, Int64))
   if b >= 64
@@ -39,6 +43,7 @@ end
 #
 # Returns: logical a >> b
 # Precondition:  0 <= b < bits_in_tword
+# NOTE: The Tuple reinterpretation below assumes little-endian layout: {low, high}
 fun __lshrti3(a : Int128, b : Int32) : Int128
   low, high = a.unsafe_as(Tuple(UInt64, UInt64))
   if b >= 64


### PR DESCRIPTION
## Summary
- Add compile-time `{% raise %}` guard for big-endian targets in `src/crystal/compiler_rt/shift.cr`
- Document the little-endian assumption on each `unsafe_as(Tuple)` usage
- No behavioral change on current targets (all little-endian)

The `unsafe_as(Tuple(UInt64, Int64))` reinterpretation assumes `{low, high}` memory layout, which is only correct on little-endian systems. This prevents silent miscompilation if Crystal is ever ported to a big-endian target.

## Test plan
- [ ] Existing specs pass (no behavioral change on LE targets)

🤖 Generated with [Claude Code](https://claude.com/claude-code)