### PR TITLE
Add @[AlwaysInline] to __mulddi3 helper

### DIFF
--- a/src/crystal/compiler_rt/multi3.cr
+++ b/src/crystal/compiler_rt/multi3.cr
@@ -1,3 +1,4 @@
+@[AlwaysInline]
 private def __mulddi3(a : UInt64, b : UInt64) : Int128
   bits_in_dword_2 = (sizeof(Int64) &* 8) // 2
   lower_mask = ~0_u64 >> bits_in_dword_2


### PR DESCRIPTION
## Summary
- Add `@[AlwaysInline]` annotation to `private def __mulddi3` in `src/crystal/compiler_rt/multi3.cr`
- This single-callsite helper performs 64x64→128 multiplication for `__multi3`
- Only affects arm and wasm32 targets (where `multi3.cr` is included)

## Test plan
- [ ] Existing specs pass (no behavioral change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)