### PR TITLE
Fix decode gzip MTIME as `UInt32`

### DIFF
--- a/src/compress/gzip/header.cr
+++ b/src/compress/gzip/header.cr
@@ -34,7 +34,7 @@ class Compress::Gzip::Header
 
     flg = Flg.new(header[3])
 
-    seconds = IO::ByteFormat::LittleEndian.decode(Int32, header.to_slice[4, 4])
+    seconds = IO::ByteFormat::LittleEndian.decode(UInt32, header.to_slice[4, 4])
     @modification_time = Time.unix(seconds).to_local
 
     _xfl = header[8]


### PR DESCRIPTION
The MTIME field in gzip is a 4-byte Unix timestamp. 
https://datatracker.ietf.org/doc/html/rfc1952
Reading it as `Int32` breaks timestamps after Jan 19, 2038. 
Writing already used `UInt32`, so reading now uses `UInt32` as well.