### PR TITLE
Remove invalid `Pointer.new` constructor from API docs

### DIFF
--- a/src/pointer.cr
+++ b/src/pointer.cr
@@ -498,6 +498,14 @@ struct Pointer(T)
     Pointer(T).new((self.address &+ (boundary &- 1)) & (&-boundary))
   end
 
+  # :nodoc:
+  #
+  # This definition is required for the invalid `Pointer.new` method to not get
+  # documented. This will never be called, the compiler will fail to compile.
+  def initialize
+    raise "can't create instance of a pointer type"
+  end
+
   # Returns a pointer whose memory address is zero. This doesn't allocate memory.
   #
   # When calling a C function you can also pass `nil` instead of constructing a


### PR DESCRIPTION
The compiler seems to inject an `#initialize` because `Pointer(T)` has no ivars and we associate the `:pointer_new` primitive to the `.new` method and there's no `#initialize` method.

Trying to associate the primitive to a `#initialize(address)` method doesn't work: the compiler refuses to instantiate a `Pointer` instance, period.

But we can declare a `#initialize` method and mark it `:nodoc:` with no impact on compilation: the compiler still complains at comptime and the method is no longer documented.

Closes #16733.