### PR TITLE
Add "compile" spec helper

### DIFF
--- a/spec/compiler/codegen/private_spec.cr
+++ b/spec/compiler/codegen/private_spec.cr
@@ -2,84 +2,52 @@ require "../../spec_helper"
 
 describe "Codegen: private" do
   it "codegens private def in same file" do
-    compiler = create_spec_compiler
-    sources = [
-      Compiler::Source.new("foo.cr", %(
-                                        private def foo
-                                          1
-                                        end
+    compile(<<-CRYSTAL)
+      private def foo
+        1
+      end
 
-                                        foo
-                                      )),
-    ]
-    compiler.prelude = "empty"
-
-    with_temp_executable "crystal-spec-output" do |output_filename|
-      compiler.compile sources, output_filename
-    end
+      foo
+      CRYSTAL
   end
 
   it "codegens overloaded private def in same file" do
-    compiler = create_spec_compiler
-    sources = [
-      Compiler::Source.new("foo.cr", %(
-                                        private def foo(x : Int32)
-                                          1
-                                        end
+    compile(<<-CRYSTAL)
+      private def foo(x : Int32)
+        1
+      end
 
-                                        private def foo(x : Char)
-                                          2
-                                        end
+      private def foo(x : Char)
+        2
+      end
 
-                                        a = 3 || 'a'
-                                        foo a
-                                      )),
-    ]
-    compiler.prelude = "empty"
-
-    with_temp_executable "crystal-spec-output" do |output_filename|
-      compiler.compile sources, output_filename
-    end
+      a = 3 || 'a'
+      foo a
+      CRYSTAL
   end
 
   it "codegens class var of private type with same name as public type (#11620)" do
-    src1 = Compiler::Source.new("foo.cr", <<-CRYSTAL)
+    compile(<<-CRYSTAL, <<-CRYSTAL)
       module Foo
         @@x = true
       end
-      CRYSTAL
-
-    src2 = Compiler::Source.new("foo_private.cr", <<-CRYSTAL)
+    CRYSTAL
       private module Foo
         @@x = 1
       end
-      CRYSTAL
-
-    compiler = create_spec_compiler
-    compiler.prelude = "empty"
-    with_temp_executable "crystal-spec-output" do |output_filename|
-      compiler.compile [src1, src2], output_filename
-    end
+    CRYSTAL
   end
 
   it "codegens class vars of private types with same name (#11620)" do
-    src1 = Compiler::Source.new("foo1.cr", <<-CRYSTAL)
+    compile(<<-CRYSTAL, <<-CRYSTAL)
       private module Foo
         @@x = true
       end
-      CRYSTAL
-
-    src2 = Compiler::Source.new("foo2.cr", <<-CRYSTAL)
+    CRYSTAL
       private module Foo
         @@x = 1
       end
-      CRYSTAL
-
-    compiler = create_spec_compiler
-    compiler.prelude = "empty"
-    with_temp_executable "crystal-spec-output" do |output_filename|
-      compiler.compile [src1, src2], output_filename
-    end
+    CRYSTAL
   end
 
   it "doesn't include filename for private types" do

--- a/spec/spec_helper.cr
+++ b/spec/spec_helper.cr
@@ -228,6 +228,26 @@ def codegen(code, *, inject_primitives = true, single_module = false, debug = Cr
   result.program.codegen(result.node, single_module: single_module, debug: debug)[""].mod
 end
 
+def compile(*codes, prelude = "empty", debug = Crystal::Debug::None, target = nil)
+  sources = codes.map_with_index do |code, index|
+    Compiler::Source.new("file#{index}.cr", code)
+  end.to_a
+
+  compiler = create_spec_compiler
+  compiler.prelude = prelude
+  compiler.debug = debug
+  compiler.stdout = IO::Memory.new # don't print anything
+
+  if target
+    compiler.cross_compile = true # skip linker
+    compiler.codegen_target = Crystal::Codegen::Target.new(target)
+  end
+
+  with_temp_executable("crystal-spec-output") do |output_filename|
+    compiler.compile(sources, output_filename)
+  end
+end
+
 private def new_program
   program = Program.new
   program.color = false


### PR DESCRIPTION
The helper compiles up to LLVM codegen for any target. Sits between the "codegen" helper that compiles up to Crystal codegen and the "run" helper that builds an executable and runs it.

There aren't much use cases. The codegen/private specs are an example. #16717 could also use it.