### PR TITLE
Add `IO::Null` object

### DIFF
--- a/spec/std/io/null_spec.cr
+++ b/spec/std/io/null_spec.cr
@@ -1,0 +1,16 @@
+require "spec"
+
+describe IO::Null do
+  it "#read" do
+    slice = Bytes.new(10, 1_u8)
+    io = IO::Null.new
+
+    io.read(slice).should eq(0)
+    slice.each { |byte| byte.should eq(1_u8) }
+  end
+
+  it "#write" do
+    io = IO::Null.new
+    io.write Bytes.new(10)
+  end
+end

--- a/src/io/null.cr
+++ b/src/io/null.cr
@@ -1,0 +1,17 @@
+# An IO object that does nothing, yet always succeeds and never fails.
+#
+# Any attempt to read results in end-of-file (EOF). Any data written is
+# immediately discarded.
+#
+# Can be used in place of another IO when there is nothing to read, or when the
+# output can be discarded.
+class IO::Null < IO
+  # Always returns 0 (reached EOF).
+  def read(slice : Bytes)
+    0
+  end
+
+  # Returns immediately (discards *slice*).
+  def write(slice : Bytes) : Nil
+  end
+end


### PR DESCRIPTION
An IO object that does nothing (always empty, never writes), yet always succeeds. Can be used in place of a regular IO when there is nothing to read or the output shall be discarded, won't even close. Similar to `/dev/null` or equivalent.

NOTES:

- implementation is dumb, docs are more complex (help wanted)
- there could be an `IO.null` singleton

Kept as DRAFT, so we can discuss usefulness and refine.

See https://github.com/crystal-lang/crystal/pull/16735#discussion_r2931331555