### PR TITLE
Disable buggy ameba rule `Lint/SpecFocus`

### DIFF
--- a/.ameba.yml
+++ b/.ameba.yml
@@ -63,6 +63,10 @@ Lint/LiteralsComparison:
 Lint/NotNil:
   Enabled: false
 
+# BUG: https://github.com/crystal-ameba/ameba/issues/605
+Lint/SpecFocus:
+  Enabled: false
+
 Lint/RandZero:
   Excluded:
   # Explicit tests


### PR DESCRIPTION
This rule creates way too many false positives due to https://github.com/crystal-ameba/ameba/issues/605 that it's just annoying.

Note: This bug has been fixed for almost a year now, but unfortunately not released yet: https://github.com/crystal-ameba/ameba/pull/606 😞 