### PR TITLE
Parse `ProcNotation` with empty arg parenthesis: `() ->`

### DIFF
--- a/spec/compiler/parser/parser_spec.cr
+++ b/spec/compiler/parser/parser_spec.cr
@@ -488,6 +488,7 @@ module Crystal
     it_parses "def foo(var : Int, Float -> Double); end", Def.new("foo", [Arg.new("var", restriction: ProcNotation.new(["Int".path, "Float".path] of ASTNode, "Double".path))])
     it_parses "def foo(var : (Int, Float -> Double)); end", Def.new("foo", [Arg.new("var", restriction: ProcNotation.new(["Int".path, "Float".path] of ASTNode, "Double".path))])
     it_parses "def foo(var : (Int, Float) -> Double); end", Def.new("foo", [Arg.new("var", restriction: ProcNotation.new(["Int".path, "Float".path] of ASTNode, "Double".path))])
+    it_parses "def foo(var : () -> Double); end", Def.new("foo", [Arg.new("var", restriction: ProcNotation.new([] of ASTNode, "Double".path))])
     it_parses "def foo(var : Char[256]); end", Def.new("foo", [Arg.new("var", restriction: "Char".static_array_of(256))])
     it_parses "def foo(var : Char[N]); end", Def.new("foo", [Arg.new("var", restriction: "Char".static_array_of("N".path))])
     it_parses "def foo(var : Int32 = 1); end", Def.new("foo", [Arg.new("var", 1.int32, "Int32".path)])

--- a/src/compiler/crystal/syntax/parser.cr
+++ b/src/compiler/crystal/syntax/parser.cr
@@ -5104,6 +5104,13 @@ module Crystal
         parse_proc_type_output(nil, location)
       when .op_lparen?
         next_token_skip_space_or_newline
+        if @token.type.op_rparen?
+          # ProcNotation without argument types: `() ->`
+          next_token_skip_space
+          check :OP_MINUS_GT
+          return parse_proc_type_output([] of ASTNode, location)
+        end
+
         type = parse_type_splat { parse_union_type }
         if type.is_a?(Union)
           type.at(location).at_end(@token.location)


### PR DESCRIPTION
While looking into #11966 I noticed the parser breaks on `ProcNotation` with empty arg parenthesis.
This seems like an omission. Any number of arguments is accepted inside this parenthesis, zero should be valid as well.