### PR TITLE
Add formatter specs for `ProcNotation`

### DIFF
--- a/spec/compiler/formatter/formatter_spec.cr
+++ b/spec/compiler/formatter/formatter_spec.cr
@@ -2038,6 +2038,8 @@ describe Crystal::Formatter do
     pending { assert_format "G_(((A), B) -> R)" }
     pending { assert_format "G_((((A), B) -> R))" }
 
+    assert_format "G_((A, B ->) | S)"
+
     assert_format "G_(A, (B -> R))"
     assert_format "G_(A, ->)"
     assert_format "G_(A, (->))"


### PR DESCRIPTION
Adds specs for examples mentioned in #11966 plus a couple more.

The pending specs identified a formatter bug (will be handled in a follow-up) and a limitation of the parser (https://github.com/crystal-lang/crystal/issues/16741).