### PR TITLE
Fix formatter `ProcNotation` with parens around argument type

### DIFF
--- a/spec/compiler/formatter/formatter_spec.cr
+++ b/spec/compiler/formatter/formatter_spec.cr
@@ -2032,11 +2032,11 @@ describe Crystal::Formatter do
     assert_format "G_((A) ->)"
 
     assert_format "G_(A, B -> R)"
-    pending { assert_format "G_((A), B -> R)" }
+    assert_format "G_((A), B -> R)"
     assert_format "G_((A, B -> R))"
     assert_format "G_((A, B) -> R)"
-    pending { assert_format "G_(((A), B) -> R)" }
-    pending { assert_format "G_((((A), B) -> R))" }
+    assert_format "G_(((A), B) -> R)"
+    assert_format "G_((((A), B) -> R))"
 
     assert_format "G_((A, B ->) | S)"
 

--- a/src/compiler/crystal/tools/formatter.cr
+++ b/src/compiler/crystal/tools/formatter.cr
@@ -2407,12 +2407,11 @@ module Crystal
 
         inputs.each_with_index do |input, i|
           accept input
-          if @paren_count == sub_paren_count
-            skip_space_or_newline
-            if @token.type.op_comma?
-              write ", " unless last?(i, inputs)
-              next_token_skip_space_or_newline
-            end
+
+          skip_space_or_newline
+          if @token.type.op_comma?
+            write ", " unless last?(i, inputs)
+            next_token_skip_space_or_newline
           end
         end
 


### PR DESCRIPTION
Discovered through specs from #16742