### PR TITLE
Add `LLVM::Attribute::Cold` for overflow handling in function attributes

### DIFF
--- a/src/compiler/crystal/codegen/fun.cr
+++ b/src/compiler/crystal/codegen/fun.cr
@@ -460,6 +460,7 @@ class Crystal::CodeGenVisitor
     context.fun.add_attribute LLVM::Attribute::ReturnsTwice if target_def.returns_twice?
     context.fun.add_attribute LLVM::Attribute::Naked if target_def.naked?
     context.fun.add_attribute LLVM::Attribute::NoReturn if target_def.no_returns?
+    context.fun.add_attribute LLVM::Attribute::Cold if mangled_name == RAISE_OVERFLOW_NAME
     context.fun.add_attribute LLVM::Attribute::NoInline if target_def.no_inline?
   end
 


### PR DESCRIPTION
This pull request is intended to present an idea.
I explored LLVM attributes that are not currently used in Crystal but might contribute to performance improvements with the help of LLMs. As a result, `cold` emerged as one candidate. As a trial, I added the `cold` attribute to the function that raises overflow exceptions. Unfortunately, benchmarks showed no clear improvement and results were slightly slower. I'll close this.