### PR TITLE
Improve formatter spec helper to show trailing whitespace

### DIFF
--- a/spec/compiler/formatter/formatter_spec.cr
+++ b/spec/compiler/formatter/formatter_spec.cr
@@ -10,19 +10,19 @@ private def assert_format(input, output = input, strict = false, flags = nil, fi
         Expected
 
         ~~~
-        #{input}
+        #{input.gsub(/([ \t])\n/, "\\1¶\n")}
         ~~~
 
         to format to:
 
         ~~~
-        #{output}
+        #{output.gsub(/([ \t])\n/, "\\1¶\n")}
         ~~~
 
         but got:
 
         ~~~
-        #{result}
+        #{result.gsub(/([ \t])\n/, "\\1¶\n")}
         ~~~
 
           assert_format #{input.inspect}, #{result.chomp.inspect}


### PR DESCRIPTION
Differences in trailing whitespace are invisible in the spec output. Adding a pilcrow character to make it visible.
We don't use this character in any test code, so it shouldn't cause any issues.

```text
  1) Crystal::Formatter formats "<<-TEXT\n  \#{\n  1  \n\n}\nTEXT"
     Failure/Error: assert_format <<-CRYSTAL

       Expected

       ~~~
       <<-TEXT
         #{
         1  ¶

       }
       TEXT
       ~~~

       to format to:

       ~~~
       <<-TEXT
         #{
         1  ¶

       }
       TEXT

       ~~~

       but got:

       ~~~
       <<-TEXT
         #{
         1
       }
       TEXT

       ~~~

         assert_format "<<-TEXT\n  \#{\n  1  \n\n}\nTEXT", "<<-TEXT\n  \#{\n  1\n}\nTEXT"
```