### PR TITLE
Fix track line increment when formatting macro literal only

### DIFF
--- a/spec/compiler/formatter/formatter_spec.cr
+++ b/spec/compiler/formatter/formatter_spec.cr
@@ -2945,4 +2945,26 @@ describe Crystal::Formatter do
       assert_format %(<<-'EOS'\n#{char}\nEOS)
     end
   end
+
+  # #16755
+  assert_format <<-CRYSTAL, <<-CRYSTAL
+    macro foo
+      Foo(
+      )
+    end
+
+    {
+      a:           1,
+      description: 2,
+    }
+    CRYSTAL
+    macro foo
+      Foo()
+    end
+
+    {
+      a:           1,
+      description: 2,
+    }
+    CRYSTAL
 end

--- a/src/compiler/crystal/tools/formatter.cr
+++ b/src/compiler/crystal/tools/formatter.cr
@@ -1761,10 +1761,20 @@ module Crystal
       write_line
       write value
 
+      # `write` doesn't update `@line` for embedded newlines.
+      # Track the output lines from the formatted macro body explicitly,
+      # then ignore line mutations while consuming original macro tokens.
+      increment_lines(value.count('\n'))
+      line = @line
+
       next_macro_token
 
       until @token.type.macro_end?
         next_macro_token
+      end
+
+      if @line != line
+        increment_lines(line - @line)
       end
 
       skip_space_or_newline


### PR DESCRIPTION
`Formatter#format_macro_literal_only` writes the result of a subformat run to the output, but `@line` advances according to the original lexer locations. If the subformat produces a different number of lines than the original because it removes unnecessary newlines (or adds additional ones), the counting is off.

This patch applies the same mechanism as `Formatter#format_macro_contents` (which performs a similar subformat) to advance `@lines` explicitly by the number of lines in the subformat output.

We could potentially merge both implementations, but we might refactor this entirely (see https://github.com/crystal-lang/crystal/issues/16755#issuecomment-4091761571).

Fixes the original example in #16755.