### PR TITLE
Handle events in `EventLoop::IOCP` instead of `System::IOCP`

### DIFF
--- a/src/crystal/event_loop/iocp.cr
+++ b/src/crystal/event_loop/iocp.cr
@@ -96,31 +96,21 @@ class Crystal::EventLoop::IOCP < Crystal::EventLoop
   private def run_impl(blocking : Bool, &) : Nil
     Crystal.trace :evloop, "run", blocking: blocking ? 1 : 0
 
-    if @waitable_timer
-      timeout = blocking ? LibC::INFINITE : 0_i64
-    elsif blocking
-      if time = @timers_mutex.synchronize { @timers.next_ready? }
-        # convert absolute time to relative time, expressed in milliseconds,
-        # rounded up; cannot use `::Time.instant` that could be mocked
-        relative = time.duration_since(Crystal::System::Time.instant)
-        timeout = (relative.to_i * 1000 + (relative.nanoseconds + 999_999) // 1_000_000)
-      else
-        timeout = LibC::INFINITE
-      end
-    else
-      timeout = 0_i64
-    end
-
-    # the array must be at least as large as `overlapped_entries` in
-    # `System::IOCP#wait_queued_completions`
+    overlapped_entries = uninitialized LibC::OVERLAPPED_ENTRY[64]
     events = uninitialized FiberEvent[64]
     size = 0
 
-    @iocp.wait_queued_completions(timeout) do |fiber|
+    removed = @iocp.wait_queued_completions(overlapped_entries.to_slice, run_timeout(blocking))
+
+    removed.times do |i|
+      overlapped_entry = overlapped_entries.to_unsafe + i
+      next unless fiber = handle_event(overlapped_entry)
+
       if (event = fiber.@resume_event) && event.wake_at?
         events[size] = event
         size += 1
       end
+
       yield fiber
     end
 
@@ -141,6 +131,59 @@ class Crystal::EventLoop::IOCP < Crystal::EventLoop
     end
 
     @interrupted.set(false, :release)
+  end
+
+  private def handle_event(overlapped_entry)
+    if (ptr = Pointer(Void).new(overlapped_entry.value.lpCompletionKey)).null?
+      # IO operation
+      operation = System::IOCP::OverlappedOperation.unbox(overlapped_entry.value.lpOverlapped)
+
+      Crystal.trace :evloop, "operation", op: operation.class.name, fiber: operation.@fiber
+
+      operation.done!
+      operation.@fiber
+    else
+      # other kind of completion event
+      completion_key = ptr.as(System::IOCP::CompletionKey)
+
+      Crystal.trace :evloop, "completion",
+        tag: completion_key.tag.to_s,
+        bytes: overlapped_entry.value.dwNumberOfBytesTransferred,
+        fiber: completion_key.fiber
+
+      System::IOCP::CompletionKey.unregister(completion_key)
+
+      return unless completion_key.valid?(overlapped_entry.value.dwNumberOfBytesTransferred)
+
+      # if `Process` exits before a call to `#wait`, this fiber will be
+      # reset already
+      # FIXME: prone to race conditions in MT environment
+      return unless fiber = completion_key.fiber
+
+      # this ensures existing references to `completion_key` do not keep
+      # an indirect reference to `::Thread.current`, as that leads to a
+      # finalization cycle
+      completion_key.fiber = nil
+
+      fiber
+    end
+  end
+
+  private def run_timeout(blocking)
+    if @waitable_timer
+      blocking ? LibC::INFINITE : 0_i64
+    elsif blocking
+      if time = @timers_mutex.synchronize { @timers.next_ready? }
+        # convert absolute time to relative time, expressed in milliseconds,
+        # rounded up; cannot use `::Time.instant` that could be mocked
+        relative = time.duration_since(Crystal::System::Time.instant)
+        (relative.to_i * 1000 + (relative.nanoseconds + 999_999) // 1_000_000)
+      else
+        LibC::INFINITE
+      end
+    else
+      0_i64
+    end
   end
 
   private def process_timer(timer : Pointer(Timer), &)

--- a/src/crystal/system/win32/iocp.cr
+++ b/src/crystal/system/win32/iocp.cr
@@ -92,23 +92,21 @@ struct Crystal::System::IOCP
     raise IO::Error.from_winerror("CreateIoCompletionPort") if @handle.null?
   end
 
-  def wait_queued_completions(timeout, alertable = false, &)
-    overlapped_entries = uninitialized LibC::OVERLAPPED_ENTRY[64]
-
+  def wait_queued_completions(buffer, timeout, alertable = false)
     if timeout > UInt64::MAX
       timeout = LibC::INFINITE
     else
       timeout = timeout.to_u64
     end
 
-    result = LibC.GetQueuedCompletionStatusEx(@handle, overlapped_entries, overlapped_entries.size, out removed, timeout, alertable)
+    result = LibC.GetQueuedCompletionStatusEx(@handle, buffer, buffer.size, out removed, timeout, alertable)
 
     if result == 0
       error = WinError.value
       if timeout && error.wait_timeout?
-        return true
+        return 0
       elsif alertable && error.value == LibC::WAIT_IO_COMPLETION
-        return true
+        return 0
       else
         raise IO::Error.from_os_error("GetQueuedCompletionStatusEx", error)
       end
@@ -118,36 +116,7 @@ struct Crystal::System::IOCP
       raise IO::Error.new("GetQueuedCompletionStatusEx returned 0")
     end
 
-    # TODO: wouldn't the processing fit better in `EventLoop::IOCP#run`?
-    removed.times do |i|
-      entry = overlapped_entries[i]
-
-      # See `CompletionKey` for the operations that use a non-nil completion
-      # key. All IO operations (include File, Socket) do not set this field.
-      case completion_key = Pointer(Void).new(entry.lpCompletionKey).as(CompletionKey?)
-      in Nil
-        operation = OverlappedOperation.unbox(entry.lpOverlapped)
-        Crystal.trace :evloop, "operation", op: operation.class.name, fiber: operation.@fiber
-        operation.schedule { |fiber| yield fiber }
-      in CompletionKey
-        Crystal.trace :evloop, "completion", tag: completion_key.tag.to_s, bytes: entry.dwNumberOfBytesTransferred, fiber: completion_key.fiber
-
-        CompletionKey.unregister(completion_key)
-        if completion_key.valid?(entry.dwNumberOfBytesTransferred)
-          # if `Process` exits before a call to `#wait`, this fiber will be
-          # reset already
-          if fiber = completion_key.fiber
-            # this ensures existing references to `completion_key` do not keep
-            # an indirect reference to `::Thread.current`, as that leads to a
-            # finalization cycle
-            completion_key.fiber = nil
-            yield fiber
-          end
-        end
-      end
-    end
-
-    false
+    removed
   end
 
   def post_queued_completion_status(completion_key : CompletionKey, number_of_bytes_transferred = 0)
@@ -211,12 +180,7 @@ struct Crystal::System::IOCP
       pointerof(@overlapped)
     end
 
-    protected def schedule(&)
-      done!
-      yield @fiber
-    end
-
-    private def done!
+    def done!
       @state = :done
     end
 


### PR DESCRIPTION
A refactor to put event handling to the event loop instead of the IOCP system abstraction. This is in anticipation for fixing #16675.

Eventually, most of `CompletionKey` and `*OverlappedOperation` types and constructors shall also be moved to `EventLoop::IOCP` (or maybe `System::Overlapped`) as they're about submitting work and has strong ties to the event loop (especially fiber scheduling) and none with receiving notifications (IOCP).

