### PR TITLE
Fix race condition in `Process#wait` on Windows

### DIFF
--- a/src/crystal/event_loop/iocp.cr
+++ b/src/crystal/event_loop/iocp.cr
@@ -153,19 +153,9 @@ class Crystal::EventLoop::IOCP < Crystal::EventLoop
 
       System::IOCP::CompletionKey.unregister(completion_key)
 
-      return unless completion_key.valid?(overlapped_entry.value.dwNumberOfBytesTransferred)
-
-      # if `Process` exits before a call to `#wait`, this fiber will be
-      # reset already
-      # FIXME: prone to race conditions in MT environment
-      return unless fiber = completion_key.fiber
-
-      # this ensures existing references to `completion_key` do not keep
-      # an indirect reference to `::Thread.current`, as that leads to a
-      # finalization cycle
-      completion_key.fiber = nil
-
-      fiber
+      if completion_key.valid?(overlapped_entry.value.dwNumberOfBytesTransferred)
+        completion_key.reset_fiber?
+      end
     end
   end
 

--- a/src/crystal/system/win32/iocp.cr
+++ b/src/crystal/system/win32/iocp.cr
@@ -42,7 +42,7 @@ struct Crystal::System::IOCP
       Timer
     end
 
-    property fiber : ::Fiber?
+    @fiber = Atomic(::Fiber?).new(nil)
     getter tag : Tag
 
     property next : CompletionKey?
@@ -56,8 +56,29 @@ struct Crystal::System::IOCP
       @@pending.delete(key)
     end
 
-    def initialize(@tag : Tag, @fiber : ::Fiber? = nil)
+    def initialize(@tag : Tag, fiber : ::Fiber? = nil)
+      @fiber.lazy_set(fiber)
       @@pending.push(self)
+    end
+
+    def fiber=(fiber : ::Fiber)
+      @fiber.set(fiber, :sequentially_consistent)
+      fiber
+    end
+
+    def fiber
+      @fiber.lazy_get
+    end
+
+    # The caller that succeeds to reset the fiber owns it (it may resume or skip
+    # suspend). The caller that fails to reset the fiber doesn't (it musn't
+    # resume or must suspend).
+    #
+    # Setting the fiber to nil also avoids to keep a @@pending -> CompletionKey
+    # -> ::Fiber -> ::Thread indirect reference that leads to a GC finalization
+    # cycle.
+    def reset_fiber?
+      @fiber.swap(nil, :relaxed)
     end
 
     def valid?(number_of_bytes_transferred)

--- a/src/crystal/system/win32/process.cr
+++ b/src/crystal/system/win32/process.cr
@@ -78,16 +78,24 @@ struct Crystal::System::Process
   end
 
   def wait
+    @completion_key.fiber = ::Fiber.current
+
     if LibC.GetExitCodeProcess(@process_handle, out exit_code) == 0
       raise RuntimeError.from_winerror("GetExitCodeProcess")
     end
-    return exit_code unless exit_code == LibC::STILL_ACTIVE
+
+    unless exit_code == LibC::STILL_ACTIVE
+      # MT race? another thread received the completion event and will resume
+      # the fiber, we must suspend the current fiber before we can return
+      ::Fiber.suspend unless @completion_key.reset_fiber?
+
+      return exit_code
+    end
 
     # let `@job_object` do its job
     # TODO: message delivery is "not guaranteed"; does it ever happen? Are we
     # stuck forever in that case?
     # (https://learn.microsoft.com/en-us/windows/win32/api/winnt/ns-winnt-jobobject_associate_completion_port)
-    @completion_key.fiber = ::Fiber.current
     ::Fiber.suspend
 
     # If the IOCP notification is delivered before the process fully exits,


### PR DESCRIPTION
On Windows, we must create the CompletionKey when spawning a Process, but the fiber that created the Process may not be the one that will wait, so we can only set the fiber before waiting.

There's a race condition where one thread would check if the process has exited then be preempted, another thread receives the notification checks that there's no waiting fiber and do nothing, then the initial thread is resumed, sets the fiber and suspends => infinite hang.

To fix that, we can set the fiber _before_ checking if the process exited, then check if we can atomically reset the fiber back to nil. On success we can return immediately, otherwise we must suspend before returning.

The event loop works the same as before, but atomically.

Follow up to #16765.