### PR TITLE
Add `String#present?`

### DIFF
--- a/src/string.cr
+++ b/src/string.cr
@@ -3028,6 +3028,20 @@ class String
     true
   end
 
+  # Returns `true` if `self` is not `#blank?`.
+  #
+  # ```
+  # "a".present?      # => true
+  # "".present?       # => false
+  # "   ".present?    # => false
+  # "   a   ".present? # => true
+  # ```
+  #
+  # See also: `Object#blank?`.
+  def present? : Bool
+    !blank?
+  end
+
   # Returns `self` unless `#blank?` is `true` in which case it returns `nil`.
   #
   # ```


### PR DESCRIPTION
## Problem

Crystal's standard library lacks a `present?` method for strings, which is a common convenience method in other languages like Ruby on Rails. This requires verbose `!blank?` checks throughout the codebase.

## Solution

Added `String#present?` method that returns `!blank?`:

```crystal
def present? : Bool
  !blank?
end
```

This matches the Ruby on Rails API and provides a more readable alternative to `!blank?`.

## Validation

```crystal
"hello".present?  # => true
"".present?       # => false
nil.present?      # => false
```

Fixes #16757