### PR TITLE
Add specs for parsing `MacroVar` syntax inside literals

### DIFF
--- a/spec/compiler/parser/parser_spec.cr
+++ b/spec/compiler/parser/parser_spec.cr
@@ -141,6 +141,16 @@ module Crystal
     it_parses %(%q{hello \\n world}), "hello \\n world".string
     it_parses %(%q{hello \#{foo} world}), "hello \#{foo} world".string
 
+    it_parses %(macro foo\n%q(%t{})\nend), Macro.new("foo", body: Expressions.from(["%q(%t".macro_literal, "{})\n".macro_literal] of ASTNode))
+    it_parses %(macro foo\n%(%t{})\nend), Macro.new("foo", body: Expressions.from(["%(%t".macro_literal, "{})\n".macro_literal] of ASTNode))
+    it_parses %(macro foo\n%q(%t{)\nend), Macro.new("foo", body: Expressions.from(["%q(%t".macro_literal, "{)\n".macro_literal] of ASTNode))
+    it_parses %(macro foo\n%(%t{)\nend), Macro.new("foo", body: Expressions.from(["%(%t".macro_literal, "{)\n".macro_literal] of ASTNode))
+
+    assert_syntax_error %({% begin %}\n%q(%t{})\n{% end %}), %(unexpected token: "}") # #16772
+    it_parses %({% begin %}\n%(%t{})\n{% end %}), MacroIf.new(true.bool, Expressions.from(["\n%(%t".macro_literal, "{})\n".macro_literal] of ASTNode))
+    assert_syntax_error %({% begin %}\n%q(%t{)\n{% end %}), %{unexpected token: ")"}
+    it_parses %({% begin %}\n%(%t{)\n{% end %}), MacroIf.new(true.bool, Expressions.from(["\n%(%t".macro_literal, "{)\n".macro_literal] of ASTNode))
+
     it_parses ":foo", "foo".symbol
     it_parses ":foo!", "foo!".symbol
     it_parses ":foo?", "foo?".symbol


### PR DESCRIPTION
This change adds specs to document the current behaviour, which seems very incorrect: We shouldn't be parsing `MacroVar` inside a literal.
It doesn't affect the result when the macro var syntax is valid, but it easily breaks when it's not (see #16772 for example)