### PR TITLE
Replace `Mutex` use cases with `Sync::Mutex`

### DIFF
--- a/src/compiler/crystal/compiler.cr
+++ b/src/compiler/crystal/compiler.cr
@@ -635,7 +635,7 @@ module Crystal
     private def mt_codegen(units, n_threads)
       channel = Channel(CompilationUnit).new(n_threads * 2)
       wg = WaitGroup.new
-      mutex = Mutex.new
+      mutex = Sync::Mutex.new
 
       n_threads.times do
         wg.spawn do

--- a/src/crystal/system/unix/signal.cr
+++ b/src/crystal/system/unix/signal.cr
@@ -23,7 +23,7 @@ module Crystal::System::Signal
   @@handlers = {} of ::Signal => Handler
   @@sigset = Sigset.new
   class_property child_handler : Handler?
-  @@mutex = Mutex.new(:unchecked)
+  @@mutex = Sync::Mutex.new(:unchecked)
 
   def self.trap(signal, handler) : Nil
     @@mutex.synchronize do
@@ -287,7 +287,7 @@ module Crystal::System::SignalChildHandler
 
   @@pending = {} of LibC::PidT => Int32
   @@waiting = {} of LibC::PidT => Channel(Int32)
-  @@mutex = Mutex.new(:unchecked)
+  @@mutex = Sync::Mutex.new(:unchecked)
 
   def self.wait(pid : LibC::PidT) : Channel(Int32)
     channel = Channel(Int32).new(1)

--- a/src/log/builder.cr
+++ b/src/log/builder.cr
@@ -12,7 +12,7 @@ end
 class Log::Builder
   include Configuration
 
-  @mutex = Mutex.new(:unchecked)
+  @mutex = Sync::Mutex.new(:unchecked)
   @logs = Hash(String, WeakRef(Log)).new
 
   private record Binding, source : String, level : Severity, backend : Backend

--- a/src/log/dispatch.cr
+++ b/src/log/dispatch.cr
@@ -83,7 +83,7 @@ class Log
     include Dispatcher
 
     def initialize
-      @mutex = Mutex.new(:unchecked)
+      @mutex = Sync::Mutex.new(:unchecked)
     end
 
     def dispatch(entry : Entry, backend : Backend)


### PR DESCRIPTION
Follow-up #16737.