### PR TITLE
Fix `Process.new(args)` etc. support `Enumerable(String)` args

### DIFF
--- a/spec/std/process_spec.cr
+++ b/spec/std/process_spec.cr
@@ -143,6 +143,10 @@ describe Process do
       # one finishes at all, nothing was broken by the GC
       Process.run(*exit_code_command(0))
     end
+
+    it "accepts tuple args" do
+      Process.new({path_search_command[0]}).wait.success?.should be_true
+    end
   end
 
   describe ".new (command + args)" do
@@ -259,6 +263,10 @@ describe Process do
         command = File.join(path, "foo")
         Process.run?([command]).should be_nil
       end
+    end
+
+    it "accepts tuple args" do
+      Process.run({path_search_command[0]}).success?.should be_true
     end
   end
 

--- a/src/crystal/system/unix/process.cr
+++ b/src/crystal/system/unix/process.cr
@@ -310,8 +310,12 @@ struct Crystal::System::Process
 
   def self.prepare_args(args : Enumerable(String)) : {String, LibC::Char**}
     pathname = args.first
-    argv = args.map(&.check_no_null_byte.to_unsafe)
-    {pathname, argv.to_unsafe}
+    argv = Pointer(Pointer(UInt8)).malloc(args.size)
+    args.each_with_index do |arg, i|
+      argv[i] = arg.check_no_null_byte.to_unsafe
+    end
+
+    {pathname, argv}
   end
 
   private def self.execvpe(file, argv, envp)


### PR DESCRIPTION
Ref https://github.com/crystal-lang/crystal/pull/16780#issuecomment-4117730503