### PR TITLE
Add `@[Experimental]` annotation to new Process API

### DIFF
--- a/src/process.cr
+++ b/src/process.cr
@@ -194,6 +194,7 @@ class Process
   # io.to_s # => "hello\n"
   # status  # => Process::Status[0]
   # ```
+  @[Experimental]
   def self.run(args : Enumerable(String), *, env : Env = nil, clear_env : Bool = false,
                input : Stdio = Redirect::Close, output : Stdio = Redirect::Close, error : Stdio = Redirect::Close, chdir : Path | String? = nil) : Process::Status
     new(args, env: env, clear_env: clear_env, input: input, output: output, error: error, chdir: chdir).wait
@@ -240,6 +241,7 @@ class Process
   # Process.run?(["true"])        # => Process::Status[0]
   # Process.run?(["nonexistent"]) # => nil
   # ```
+  @[Experimental]
   def self.run?(args : Enumerable(String), *,
                 env : Env = nil, clear_env : Bool = false,
                 input : Stdio = Redirect::Close, output : Stdio = Redirect::Close, error : Stdio = Redirect::Close,
@@ -269,6 +271,7 @@ class Process
   # status # => Process::Status[0]
   # result # => "hello\n"
   # ```
+  @[Experimental]
   def self.run(args : Enumerable(String), *, env : Env = nil, clear_env : Bool = false,
                input : Stdio = Redirect::Pipe, output : Stdio = Redirect::Pipe, error : Stdio = Redirect::Pipe, chdir : Path | String? = nil, & : Process -> _)
     process = new(args, env: env, clear_env: clear_env, input: input, output: output, error: error, chdir: chdir)
@@ -412,6 +415,7 @@ class Process
   # * `Process.run` is a convenient short cut if you just want to run a command
   #    and wait for it to finish.
   # * `Process.exec` replaces the current process.
+  @[Experimental]
   def self.new(args : Enumerable(String), *, env : Env = nil, clear_env : Bool = false,
                input : Stdio = Redirect::Close, output : Stdio = Redirect::Close, error : Stdio = Redirect::Close, chdir : Path | String? = nil)
     new(args, env: env, clear_env: clear_env, input: input, output: output, error: error, chdir: chdir) do |error, command|

--- a/src/process/capture.cr
+++ b/src/process/capture.cr
@@ -1,4 +1,5 @@
 class Process
+  @[Experimental]
   class ExitError < Exception
     getter args : Enumerable(String)
     getter result : Result
@@ -13,6 +14,7 @@ class Process
     end
   end
 
+  @[Experimental]
   struct Process::Result
     def initialize(@status : Status, @output : String?, @error : String?)
     end
@@ -66,6 +68,7 @@ class Process
   # Process.capture_result(%w[echo foo]).output # => "foo\n"
   # Process.capture_result(%w[nonexist])        # raises Process::ExitError
   # ```
+  @[Experimental]
   def self.capture_result(args : Enumerable(String), *, env : Env = nil, clear_env : Bool = false,
                           input : Stdio = Redirect::Close, output : Stdio = Redirect::Pipe, error : Stdio = Redirect::Pipe, chdir : Path | String? = nil) : Result
     capture_result_impl(output, error) do |error|
@@ -84,6 +87,7 @@ class Process
   # Process.capture_result?(%w[echo foo]).try(&.output) # => "foo\n"
   # Process.capture_result?(%w[nonexist])               # => nil
   # ```
+  @[Experimental]
   def self.capture_result?(args : Enumerable(String), *, env : Env = nil, clear_env : Bool = false,
                            input : Stdio = Redirect::Close, output : Stdio = Redirect::Pipe, error : Stdio = Redirect::Pipe, chdir : Path | String? = nil) : Result?
     capture_result_impl(output, error) do |error|
@@ -120,6 +124,7 @@ class Process
   # Process.capture(%w[echo foo]) # => "foo\n"
   # Process.capture(%w[nonexist]) # raises Process::ExitError
   # ```
+  @[Experimental]
   def self.capture(args : Enumerable(String), *, env : Env = nil, clear_env : Bool = false,
                    input : Stdio = Redirect::Close, error : Stdio = Redirect::Pipe, chdir : Path | String? = nil) : String
     result = capture_result(args, env: env, clear_env: clear_env, input: input, error: error, chdir: chdir)
@@ -142,6 +147,7 @@ class Process
   # Process.capture(%w[echo foo]) # => "foo\n"
   # Process.capture(%w[nonexist]) # => nil
   # ```
+  @[Experimental]
   def self.capture?(args : Enumerable(String), *, env : Env = nil, clear_env : Bool = false,
                     input : Stdio = Redirect::Close, error : Stdio = Redirect::Close, chdir : Path | String? = nil) : String?
     result = capture_result(args, env: env, clear_env: clear_env, input: input, error: error, chdir: chdir)


### PR DESCRIPTION
These new API features are all part of crystal-lang/rfcs#25 and should be considered experimental for now. We should be able to alter the API in case we notice any issues with adoption.