### PR TITLE
Move CallConvention and Const properties out of LLVM/codegen

### DIFF
--- a/src/compiler/crystal/call_convention.cr
+++ b/src/compiler/crystal/call_convention.cr
@@ -1,0 +1,20 @@
+# Call convention enum for the Crystal compiler.
+#
+# This is the compiler's own representation of calling conventions,
+# independent of LLVM. The codegen phase maps these to LLVM values.
+
+module Crystal
+  enum CallConvention
+    C            =  0
+    Fast         =  8
+    Cold         =  9
+    WebKit_JS    = 12
+    AnyReg       = 13
+    X86_StdCall  = 64
+    X86_FastCall = 65
+
+    def to_llvm : LLVM::CallConvention
+      LLVM::CallConvention.new(self.value)
+    end
+  end
+end

--- a/src/compiler/crystal/codegen/call.cr
+++ b/src/compiler/crystal/codegen/call.cr
@@ -517,7 +517,7 @@ class Crystal::CodeGenVisitor
     end
 
     if target_def.is_a?(External) && (call_convention = target_def.call_convention)
-      @last.call_convention = call_convention
+      @last.call_convention = call_convention.to_llvm
     end
 
     if @builder.end

--- a/src/compiler/crystal/codegen/fun.cr
+++ b/src/compiler/crystal/codegen/fun.cr
@@ -396,7 +396,7 @@ class Crystal::CodeGenVisitor
     setup_context_fun(mangled_name, target_def, llvm_args_types, llvm_return_type)
 
     if call_convention = target_def.call_convention
-      context.fun.call_convention = call_convention
+      context.fun.call_convention = call_convention.to_llvm
     end
 
     if @single_module && mangled_name.starts_with?("__crystal_")

--- a/src/compiler/crystal/codegen/types.cr
+++ b/src/compiler/crystal/codegen/types.cr
@@ -177,15 +177,6 @@ module Crystal
   class Const
     property initializer : LLVM::Value?
 
-    # Was this constant already read during the codegen phase?
-    # If not, and we are at the place that declares the constant, we can
-    # directly initialize the constant now, without checking for an `init` flag.
-    property? read = false
-
-    # If true, there's no need to check whether the constant was initialized or
-    # not when reading it.
-    property? no_init_flag = false
-
     def initialized_llvm_name
       "#{llvm_name}:const_init"
     end

--- a/src/compiler/crystal/program.cr
+++ b/src/compiler/crystal/program.cr
@@ -1,5 +1,6 @@
 require "llvm"
 require "json"
+require "./call_convention"
 require "./types"
 require "crystal/digest/md5"
 

--- a/src/compiler/crystal/semantic/ast.cr
+++ b/src/compiler/crystal/semantic/ast.cr
@@ -707,7 +707,7 @@ module Crystal
     property? external_var : Bool = false
     property real_name : String
     property! fun_def : FunDef
-    property call_convention : LLVM::CallConvention?
+    property call_convention : Crystal::CallConvention?
     property wasm_import_module : String?
 
     property? dead = false

--- a/src/compiler/crystal/semantic/top_level_visitor.cr
+++ b/src/compiler/crystal/semantic/top_level_visitor.cr
@@ -1207,9 +1207,9 @@ class Crystal::TopLevelVisitor < Crystal::SemanticVisitor
     end
 
     value = call_convention_node.value
-    call_convention = LLVM::CallConvention.parse?(value)
+    call_convention = Crystal::CallConvention.parse?(value)
     unless call_convention
-      call_convention_node.raise "invalid call convention. Valid values are #{LLVM::CallConvention.values.join ", "}"
+      call_convention_node.raise "invalid call convention. Valid values are #{Crystal::CallConvention.values.join ", "}"
     end
     call_convention
   end

--- a/src/compiler/crystal/types.cr
+++ b/src/compiler/crystal/types.cr
@@ -2687,7 +2687,7 @@ module Crystal
   class LibType < ModuleType
     getter link_annotations : Array(LinkAnnotation)?
     property? used = false
-    property call_convention : LLVM::CallConvention?
+    property call_convention : Crystal::CallConvention?
 
     def add_link_annotation(link_annotation : LinkAnnotation)
       link_annotations = @link_annotations ||= [] of LinkAnnotation
@@ -3329,6 +3329,15 @@ module Crystal
 
     # Is this constant accessed with pointerof(...)?
     property? pointer_read = false
+
+    # Was this constant already read during the codegen phase?
+    # If not, and we are at the place that declares the constant, we can
+    # directly initialize the constant now, without checking for an `init` flag.
+    property? read = false
+
+    # If true, there's no need to check whether the constant was initialized or
+    # not when reading it.
+    property? no_init_flag = false
 
     property visitor : MainVisitor?
 


### PR DESCRIPTION
## Summary

Reduces coupling between the semantic analysis phase and LLVM by moving types that semantic uses out of LLVM-specific code:

- **Extract `Crystal::CallConvention` enum** — mirrors `LLVM::CallConvention` values but lives in the compiler namespace. The semantic phase (`types.cr`, `semantic/ast.cr`, `top_level_visitor.cr`) uses the Crystal-owned enum. Codegen converts to `LLVM::CallConvention` via `.to_llvm` when generating code.

- **Move `no_init_flag`/`read` properties on `Const`** from `codegen/types.cr` to `types.cr`, where the `Const` class is defined and where `program.cr` uses them during initialization.

No behavior changes. The compiler produces identical output.

## Context

This is an incremental step toward #15473 (decouple LLVM from semantic passes). The [railcar](https://github.com/rubys/railcar) project uses Crystal's semantic analysis for type inference on translated Ruby code, and currently requires LLVM stubs to do so. Each coupling point removed makes standalone semantic analysis more viable.

## What remains

After this PR, the remaining LLVM references in the semantic layer are:

- `program.cr`: `require "llvm"`, `LLVM.version`, `property(target_machine : LLVM::TargetMachine)`
- `config.cr` → `codegen/target.cr`: `LLVM.normalize_triple`, `LLVM.default_target_triple`

Each can be addressed with the same pattern (compiler-owned abstraction, codegen provides the LLVM implementation) but touches the target triple infrastructure, which seemed like more scope than a first PR should take on.