### PR TITLE
Remove redundant `#not_nil!` calls in `OAuth::RequestToken.from_response` [fixup #16634]

### DIFF
--- a/src/oauth/request_token.cr
+++ b/src/oauth/request_token.cr
@@ -25,7 +25,7 @@ class OAuth::RequestToken
       raise Error.new("Missing #{values.join(" and ")}")
     end
 
-    new token.not_nil!, secret.not_nil!
+    new token, secret
   end
 
   def_equals_and_hash @token, @secret


### PR DESCRIPTION
Refs https://github.com/crystal-lang/crystal/pull/16634#discussion_r3066670145