### PR TITLE
Emit debug metadata for constants and class vars

### DIFF
--- a/spec/compiler/codegen/debug_spec.cr
+++ b/spec/compiler/codegen/debug_spec.cr
@@ -220,6 +220,24 @@ describe "Code gen: debug" do
     str.should contain(%(~A:const_init))
   end
 
+  it "emits global debug info once for constants read before assignment" do
+    mod = codegen(<<-CRYSTAL, debug: Crystal::Debug::All)
+      require "prelude"
+
+      struct Bar
+        def initialize(@x : Int32)
+        end
+      end
+
+      A
+      A = Bar.new(41)
+      CRYSTAL
+
+    str = mod.to_s
+    str.scan(%r{DIGlobalVariable\(name: "A", linkageName: "A",}).size.should eq(1)
+    str.should contain(%(~A:const_init))
+  end
+
   it "keeps literal constants inlined in debug mode" do
     mod = codegen(<<-CRYSTAL, debug: Crystal::Debug::All)
       A = 1

--- a/spec/compiler/codegen/debug_spec.cr
+++ b/spec/compiler/codegen/debug_spec.cr
@@ -234,7 +234,7 @@ describe "Code gen: debug" do
       CRYSTAL
 
     str = mod.to_s
-    str.should contain(%(@"Foo::x" = global ptr null, !dbg !))
+    str.should match(/@"Foo::x" = global (?:ptr|%String\*) null, !dbg !/)
     str.should contain("DIGlobalVariable(name: \"Foo::x\", linkageName: \"Foo::x\",")
   end
 

--- a/spec/compiler/codegen/debug_spec.cr
+++ b/spec/compiler/codegen/debug_spec.cr
@@ -202,6 +202,42 @@ describe "Code gen: debug" do
       CRYSTAL
   end
 
+  it "emits global debug info for constants" do
+    mod = codegen(<<-CRYSTAL, debug: Crystal::Debug::All)
+      struct Bar
+        def initialize(@x : Int32)
+        end
+      end
+
+      A = Bar.new(41)
+
+      v1 = A
+      v1
+      CRYSTAL
+
+    str = mod.to_s
+    str.should contain("DIGlobalVariable(name: \"A\", linkageName: \"A\",")
+    str.should contain(%(~A:const_init))
+  end
+
+  it "emits global debug info for class vars" do
+    mod = codegen(<<-CRYSTAL, debug: Crystal::Debug::All)
+      class Foo
+        @@x = "world"
+
+        def self.x
+          @@x
+        end
+      end
+
+      Foo.x
+      CRYSTAL
+
+    str = mod.to_s
+    str.should contain(%(@"Foo::x" = global ptr null, !dbg !))
+    str.should contain("DIGlobalVariable(name: \"Foo::x\", linkageName: \"Foo::x\",")
+  end
+
   it "stores and restores debug location after jumping to main (#6920)" do
     codegen(<<-CRYSTAL, debug: Crystal::Debug::All)
       require "prelude"

--- a/spec/compiler/codegen/debug_spec.cr
+++ b/spec/compiler/codegen/debug_spec.cr
@@ -220,6 +220,17 @@ describe "Code gen: debug" do
     str.should contain(%(~A:const_init))
   end
 
+  it "keeps literal constants inlined in debug mode" do
+    mod = codegen(<<-CRYSTAL, debug: Crystal::Debug::All)
+      A = 1
+      A
+      CRYSTAL
+
+    str = mod.to_s
+    str.should_not match(/^@A =/)
+    str.should contain("ret i32 1")
+  end
+
   it "emits global debug info for class vars" do
     mod = codegen(<<-CRYSTAL, debug: Crystal::Debug::All)
       class Foo

--- a/src/compiler/crystal/codegen/class_var.cr
+++ b/src/compiler/crystal/codegen/class_var.cr
@@ -337,22 +337,17 @@ class Crystal::CodeGenVisitor
   end
 
   private def declare_class_var_debug_info(global, class_var)
-    initializer = class_var.initializer
-    return unless initializer
-
-    location = initializer.node.location
-    return unless location
-
-    location = location.expanded_location
+    location = class_var.initializer.try(&.node.location).try(&.expanded_location)
     return unless location
 
     debug_type = in_main { get_debug_type(class_var.type) }
     return unless debug_type
 
     file, dir = file_and_dir(location.filename)
-    file_metadata = di_builder(@main_mod).create_file(file, dir)
+    builder = di_builder(@main_mod)
+    file_metadata = builder.create_file(file, dir)
     global_name = class_var_global_name(class_var)
-    gv_expr = di_builder(@main_mod).create_global_variable_expression(
+    gv_expr = builder.create_global_variable_expression(
       scope: file_metadata,
       name: global_name,
       linkage_name: global_name,

--- a/src/compiler/crystal/codegen/class_var.cr
+++ b/src/compiler/crystal/codegen/class_var.cr
@@ -357,6 +357,6 @@ class Crystal::CodeGenVisitor
       local_to_unit: @single_module
     )
 
-    global.add_debug_info(gv_expr)
+    global.global_set_metadata("dbg", gv_expr)
   end
 end

--- a/src/compiler/crystal/codegen/class_var.cr
+++ b/src/compiler/crystal/codegen/class_var.cr
@@ -346,29 +346,22 @@ class Crystal::CodeGenVisitor
     location = location.expanded_location
     return unless location
 
-    old_llvm_mod = @llvm_mod
-    @llvm_mod = @main_mod
+    debug_type = in_main { get_debug_type(class_var.type) }
+    return unless debug_type
 
-    begin
-      debug_type = get_debug_type(class_var.type)
-      return unless debug_type
+    file, dir = file_and_dir(location.filename)
+    file_metadata = di_builder(@main_mod).create_file(file, dir)
+    global_name = class_var_global_name(class_var)
+    gv_expr = di_builder(@main_mod).create_global_variable_expression(
+      scope: file_metadata,
+      name: global_name,
+      linkage_name: global_name,
+      file: file_metadata,
+      line: location.line_number,
+      type: debug_type,
+      local_to_unit: @single_module
+    )
 
-      file, dir = file_and_dir(location.filename)
-      file_metadata = di_builder(@main_mod).create_file(file, dir)
-      global_name = class_var_global_name(class_var)
-      gv_expr = di_builder(@main_mod).create_global_variable_expression(
-        scope: file_metadata,
-        name: global_name,
-        linkage_name: global_name,
-        file: file_metadata,
-        line: location.line_number,
-        type: debug_type,
-        local_to_unit: @single_module
-      )
-
-      global.add_debug_info(gv_expr)
-    ensure
-      @llvm_mod = old_llvm_mod
-    end
+    global.add_debug_info(gv_expr)
   end
 end

--- a/src/compiler/crystal/codegen/class_var.cr
+++ b/src/compiler/crystal/codegen/class_var.cr
@@ -17,6 +17,8 @@ class Crystal::CodeGenVisitor
       if !global.initializer && type.includes_type?(@program.nil_type)
         global.initializer = main_llvm_type.null
       end
+
+      declare_class_var_debug_info(global, class_var) if @debug.variables?
     end
     global
   end
@@ -332,5 +334,41 @@ class Crystal::CodeGenVisitor
 
   def class_var_global_initialized_name(class_var : MetaTypeVar)
     "#{class_var.owner.llvm_name}#{class_var.name.gsub('@', ':')}:init"
+  end
+
+  private def declare_class_var_debug_info(global, class_var)
+    initializer = class_var.initializer
+    return unless initializer
+
+    location = initializer.node.location
+    return unless location
+
+    location = location.expanded_location
+    return unless location
+
+    old_llvm_mod = @llvm_mod
+    @llvm_mod = @main_mod
+
+    begin
+      debug_type = get_debug_type(class_var.type)
+      return unless debug_type
+
+      file, dir = file_and_dir(location.filename)
+      file_metadata = di_builder(@main_mod).create_file(file, dir)
+      global_name = class_var_global_name(class_var)
+      gv_expr = di_builder(@main_mod).create_global_variable_expression(
+        scope: file_metadata,
+        name: global_name,
+        linkage_name: global_name,
+        file: file_metadata,
+        line: location.line_number,
+        type: debug_type,
+        local_to_unit: @single_module
+      )
+
+      global.add_debug_info(gv_expr)
+    ensure
+      @llvm_mod = old_llvm_mod
+    end
   end
 end

--- a/src/compiler/crystal/codegen/const.cr
+++ b/src/compiler/crystal/codegen/const.cr
@@ -69,30 +69,23 @@ class Crystal::CodeGenVisitor
     location = location.try &.expanded_location
     return unless location
 
-    old_llvm_mod = @llvm_mod
-    @llvm_mod = @main_mod
+    debug_type = in_main { get_debug_type(const.value.type) }
+    return unless debug_type
 
-    begin
-      debug_type = get_debug_type(const.value.type)
-      return unless debug_type
+    file, dir = file_and_dir(location.filename)
+    file_metadata = di_builder(@main_mod).create_file(file, dir)
 
-      file, dir = file_and_dir(location.filename)
-      file_metadata = di_builder(@main_mod).create_file(file, dir)
+    gv_expr = di_builder(@main_mod).create_global_variable_expression(
+      scope: file_metadata,
+      name: const.llvm_name,
+      linkage_name: const.llvm_name,
+      file: file_metadata,
+      line: location.line_number,
+      type: debug_type,
+      local_to_unit: @single_module
+    )
 
-      gv_expr = di_builder(@main_mod).create_global_variable_expression(
-        scope: file_metadata,
-        name: const.llvm_name,
-        linkage_name: const.llvm_name,
-        file: file_metadata,
-        line: location.line_number,
-        type: debug_type,
-        local_to_unit: @single_module
-      )
-
-      global.add_debug_info(gv_expr)
-    ensure
-      @llvm_mod = old_llvm_mod
-    end
+    global.add_debug_info(gv_expr)
   end
 
   def declare_const_initialized_flag(const)
@@ -224,31 +217,26 @@ class Crystal::CodeGenVisitor
   end
 
   def read_const(const, node)
-    if @debug.variables? && @main_mod.globals[const.llvm_name]?
-      set_current_debug_location node if @debug.line_numbers?
-      last = read_const_pointer(const)
-      @last = to_lhs last, const.value.type
-    else
-      @last =
-        case value = const.compile_time_value
-        when Bool    then int1(value ? 1 : 0)
-        when Char    then int32(value.ord)
-        when Int8    then int8(value)
-        when Int16   then int16(value)
-        when Int32   then int32(value)
-        when Int64   then int64(value)
-        when Int128  then int128(value)
-        when UInt8   then int8(value)
-        when UInt16  then int16(value)
-        when UInt32  then int32(value)
-        when UInt64  then int64(value)
-        when UInt128 then int128(value)
-        else
-          set_current_debug_location node if @debug.line_numbers?
-          last = read_const_pointer(const)
-          to_lhs last, const.value.type
-        end
-    end
+    # We inline literal constants. Otherwise we use an LLVM const global.
+    @last =
+      case value = const.compile_time_value
+      when Bool    then int1(value ? 1 : 0)
+      when Char    then int32(value.ord)
+      when Int8    then int8(value)
+      when Int16   then int16(value)
+      when Int32   then int32(value)
+      when Int64   then int64(value)
+      when Int128  then int128(value)
+      when UInt8   then int8(value)
+      when UInt16  then int16(value)
+      when UInt32  then int32(value)
+      when UInt64  then int64(value)
+      when UInt128 then int128(value)
+      else
+        set_current_debug_location node if @debug.line_numbers?
+        last = read_const_pointer(const)
+        to_lhs last, const.value.type
+      end
   end
 
   def read_const_pointer(const)

--- a/src/compiler/crystal/codegen/const.cr
+++ b/src/compiler/crystal/codegen/const.cr
@@ -85,7 +85,7 @@ class Crystal::CodeGenVisitor
       local_to_unit: @single_module
     )
 
-    global.add_debug_info(gv_expr)
+    global.global_set_metadata("dbg", gv_expr)
   end
 
   def declare_const_initialized_flag(const)

--- a/src/compiler/crystal/codegen/const.cr
+++ b/src/compiler/crystal/codegen/const.cr
@@ -42,22 +42,24 @@ class Crystal::CodeGenVisitor
 
   def declare_const(const)
     global_name = const.llvm_name
-    global = @main_mod.globals[global_name]? ||
-             @main_mod.globals.add(@main_llvm_typer.llvm_type(const.value.type), global_name)
+    global = @main_mod.globals[global_name]?
+    unless global
+      global = @main_mod.globals.add(@main_llvm_typer.llvm_type(const.value.type), global_name)
 
-    type = const.value.type
-    # TODO: LLVM < 9.0.0 has a bug that prevents us from having internal globals of type i128 or u128:
-    # https://bugs.llvm.org/show_bug.cgi?id=42932
-    # so we just use global in that case.
-    {% if compare_versions(Crystal::LLVM_VERSION, "9.0.0") < 0 %}
-      if @single_module && !(type.is_a?(IntegerType) && (type.kind.i128? || type.kind.u128?))
-        global.linkage = LLVM::Linkage::Internal
-      end
-    {% else %}
-      global.linkage = LLVM::Linkage::Internal if @single_module
-    {% end %}
+      type = const.value.type
+      # TODO: LLVM < 9.0.0 has a bug that prevents us from having internal globals of type i128 or u128:
+      # https://bugs.llvm.org/show_bug.cgi?id=42932
+      # so we just use global in that case.
+      {% if compare_versions(Crystal::LLVM_VERSION, "9.0.0") < 0 %}
+        if @single_module && !(type.is_a?(IntegerType) && (type.kind.i128? || type.kind.u128?))
+          global.linkage = LLVM::Linkage::Internal
+        end
+      {% else %}
+        global.linkage = LLVM::Linkage::Internal if @single_module
+      {% end %}
 
-    declare_const_debug_info(global, const) if @debug.variables?
+      declare_const_debug_info(global, const) if @debug.variables?
+    end
 
     global
   end

--- a/src/compiler/crystal/codegen/const.cr
+++ b/src/compiler/crystal/codegen/const.cr
@@ -65,19 +65,17 @@ class Crystal::CodeGenVisitor
   end
 
   private def declare_const_debug_info(global, const)
-    location = const.locations.try &.first?
-    return unless location
-
-    location = location.try &.expanded_location
+    location = const.locations.try(&.first?).try(&.expanded_location)
     return unless location
 
     debug_type = in_main { get_debug_type(const.value.type) }
     return unless debug_type
 
     file, dir = file_and_dir(location.filename)
-    file_metadata = di_builder(@main_mod).create_file(file, dir)
+    builder = di_builder(@main_mod)
+    file_metadata = builder.create_file(file, dir)
 
-    gv_expr = di_builder(@main_mod).create_global_variable_expression(
+    gv_expr = builder.create_global_variable_expression(
       scope: file_metadata,
       name: const.llvm_name,
       linkage_name: const.llvm_name,

--- a/src/compiler/crystal/codegen/const.cr
+++ b/src/compiler/crystal/codegen/const.cr
@@ -57,7 +57,42 @@ class Crystal::CodeGenVisitor
       global.linkage = LLVM::Linkage::Internal if @single_module
     {% end %}
 
+    declare_const_debug_info(global, const) if @debug.variables?
+
     global
+  end
+
+  private def declare_const_debug_info(global, const)
+    location = const.locations.try &.first?
+    return unless location
+
+    location = location.try &.expanded_location
+    return unless location
+
+    old_llvm_mod = @llvm_mod
+    @llvm_mod = @main_mod
+
+    begin
+      debug_type = get_debug_type(const.value.type)
+      return unless debug_type
+
+      file, dir = file_and_dir(location.filename)
+      file_metadata = di_builder(@main_mod).create_file(file, dir)
+
+      gv_expr = di_builder(@main_mod).create_global_variable_expression(
+        scope: file_metadata,
+        name: const.llvm_name,
+        linkage_name: const.llvm_name,
+        file: file_metadata,
+        line: location.line_number,
+        type: debug_type,
+        local_to_unit: @single_module
+      )
+
+      global.add_debug_info(gv_expr)
+    ensure
+      @llvm_mod = old_llvm_mod
+    end
   end
 
   def declare_const_initialized_flag(const)
@@ -189,26 +224,31 @@ class Crystal::CodeGenVisitor
   end
 
   def read_const(const, node)
-    # We inline constants. Otherwise we use an LLVM const global.
-    @last =
-      case value = const.compile_time_value
-      when Bool    then int1(value ? 1 : 0)
-      when Char    then int32(value.ord)
-      when Int8    then int8(value)
-      when Int16   then int16(value)
-      when Int32   then int32(value)
-      when Int64   then int64(value)
-      when Int128  then int128(value)
-      when UInt8   then int8(value)
-      when UInt16  then int16(value)
-      when UInt32  then int32(value)
-      when UInt64  then int64(value)
-      when UInt128 then int128(value)
-      else
-        set_current_debug_location node if @debug.line_numbers?
-        last = read_const_pointer(const)
-        to_lhs last, const.value.type
-      end
+    if @debug.variables? && @main_mod.globals[const.llvm_name]?
+      set_current_debug_location node if @debug.line_numbers?
+      last = read_const_pointer(const)
+      @last = to_lhs last, const.value.type
+    else
+      @last =
+        case value = const.compile_time_value
+        when Bool    then int1(value ? 1 : 0)
+        when Char    then int32(value.ord)
+        when Int8    then int8(value)
+        when Int16   then int16(value)
+        when Int32   then int32(value)
+        when Int64   then int64(value)
+        when Int128  then int128(value)
+        when UInt8   then int8(value)
+        when UInt16  then int16(value)
+        when UInt32  then int32(value)
+        when UInt64  then int64(value)
+        when UInt128 then int128(value)
+        else
+          set_current_debug_location node if @debug.line_numbers?
+          last = read_const_pointer(const)
+          to_lhs last, const.value.type
+        end
+    end
   end
 
   def read_const_pointer(const)

--- a/src/llvm/di_builder.cr
+++ b/src/llvm/di_builder.cr
@@ -91,6 +91,15 @@ struct LLVM::DIBuilder
     LibLLVM.di_builder_create_parameter_variable(self, scope, name, name.bytesize, argno, file, line, type, 1, flags)
   end
 
+  def create_global_variable_expression(scope, name, linkage_name, file, line, type, local_to_unit, align_in_bits = 0_u32)
+    expr = create_expression(nil, 0)
+    LibLLVM.di_builder_create_global_variable_expression(
+      self, scope, name, name.bytesize,
+      linkage_name, linkage_name.bytesize, file, line,
+      type, local_to_unit, expr, nil, align_in_bits
+    )
+  end
+
   def create_expression(addr, length)
     LibLLVM.di_builder_create_expression(self, addr, length)
   end

--- a/src/llvm/di_builder.cr
+++ b/src/llvm/di_builder.cr
@@ -91,12 +91,12 @@ struct LLVM::DIBuilder
     LibLLVM.di_builder_create_parameter_variable(self, scope, name, name.bytesize, argno, file, line, type, 1, flags)
   end
 
-  def create_global_variable_expression(scope, name, linkage_name, file, line, type, local_to_unit, align_in_bits = 0_u32)
-    expr = create_expression(nil, 0)
+  def create_global_variable_expression(scope, name, linkage_name, file, line, type, local_to_unit, expr = nil, decl = nil, align_in_bits = 0_u32)
+    expr ||= create_expression(nil, 0)
     LibLLVM.di_builder_create_global_variable_expression(
       self, scope, name, name.bytesize,
       linkage_name, linkage_name.bytesize, file, line,
-      type, local_to_unit, expr, nil, align_in_bits
+      type, local_to_unit, expr, decl, align_in_bits
     )
   end
 

--- a/src/llvm/lib_llvm/core.cr
+++ b/src/llvm/lib_llvm/core.cr
@@ -162,6 +162,7 @@ lib LibLLVM
   fun set_thread_local = LLVMSetThreadLocal(global_var : ValueRef, is_thread_local : Bool)
   fun is_global_constant = LLVMIsGlobalConstant(global_var : ValueRef) : Bool
   fun set_global_constant = LLVMSetGlobalConstant(global_var : ValueRef, is_constant : Bool)
+  fun global_set_metadata = LLVMGlobalSetMetadata(global_var : ValueRef, kind : UInt, md : MetadataRef)
 
   fun delete_function = LLVMDeleteFunction(fn : ValueRef)
   fun set_personality_fn = LLVMSetPersonalityFn(fn : ValueRef, personality_fn : ValueRef)

--- a/src/llvm/lib_llvm/debug_info.cr
+++ b/src/llvm/lib_llvm/debug_info.cr
@@ -137,5 +137,11 @@ lib LibLLVM
     file : MetadataRef, line_no : UInt, ty : MetadataRef, always_preserve : Bool, flags : LLVM::DIFlags,
   ) : MetadataRef
 
+  fun di_builder_create_global_variable_expression = LLVMDIBuilderCreateGlobalVariableExpression(
+    builder : DIBuilderRef, scope : MetadataRef, name : Char*, name_len : SizeT,
+    linkage : Char*, linkage_len : SizeT, file : MetadataRef, line_no : UInt,
+    ty : MetadataRef, local_to_unit : Bool, expr : MetadataRef, decl : MetadataRef, align_in_bits : UInt32,
+  ) : MetadataRef
+
   fun set_subprogram = LLVMSetSubprogram(func : ValueRef, sp : MetadataRef)
 end

--- a/src/llvm/value_methods.cr
+++ b/src/llvm/value_methods.cr
@@ -88,6 +88,11 @@ module LLVM::ValueMethods
     init ? LLVM::Value.new(init) : nil
   end
 
+  def add_debug_info(gv : LibLLVM::MetadataRef)
+    kind = LibLLVM.get_md_kind_id_in_context(type.context, "dbg", 3)
+    LibLLVM.global_set_metadata(self, kind, gv)
+  end
+
   def volatile=(volatile)
     LibLLVM.set_volatile(self, volatile ? 1 : 0)
   end

--- a/src/llvm/value_methods.cr
+++ b/src/llvm/value_methods.cr
@@ -88,8 +88,12 @@ module LLVM::ValueMethods
     init ? LLVM::Value.new(init) : nil
   end
 
-  def add_debug_info(metadata : LibLLVM::MetadataRef)
-    kind = LibLLVM.get_md_kind_id_in_context(type.context, "dbg", 3)
+  def global_set_metadata(kind : String, metadata)
+    kind = LibLLVM.get_md_kind_id_in_context(type.context, kind, kind.bytesize)
+    global_set_metadata(kind, metadata)
+  end
+
+  def global_set_metadata(kind, metadata)
     LibLLVM.global_set_metadata(self, kind, metadata)
   end
 

--- a/src/llvm/value_methods.cr
+++ b/src/llvm/value_methods.cr
@@ -88,9 +88,9 @@ module LLVM::ValueMethods
     init ? LLVM::Value.new(init) : nil
   end
 
-  def add_debug_info(gv : LibLLVM::MetadataRef)
+  def add_debug_info(metadata : LibLLVM::MetadataRef)
     kind = LibLLVM.get_md_kind_id_in_context(type.context, "dbg", 3)
-    LibLLVM.global_set_metadata(self, kind, gv)
+    LibLLVM.global_set_metadata(self, kind, metadata)
   end
 
   def volatile=(volatile)


### PR DESCRIPTION
## Summary

This extracts the global debug metadata improvement from #16824 into a focused PR.

It emits `DIGlobalVariable` metadata for non-literal constants and class variables, while preserving literal constant inlining in debug mode.

## Review follow-up from #16824

- Keep literal constants inlined even with debug variables enabled.
- Use the existing `in_main` helper for debug type lookup against the main module.
- Rename the LLVM metadata helper argument from `gv` to `metadata`.

## Validation

- `bin/crystal spec spec/compiler/codegen/debug_spec.cr:215 spec/compiler/codegen/debug_spec.cr:233 spec/compiler/codegen/debug_spec.cr:244`
- `bin/crystal spec spec/compiler/codegen/debug_spec.cr`
- `git diff --check origin/master..HEAD`
