### PR TITLE
Document that reentrant read lock can deadlock

### DIFF
--- a/spec/std/sync/rw_lock_spec.cr
+++ b/spec/std/sync/rw_lock_spec.cr
@@ -7,7 +7,7 @@ describe Sync::RWLock do
 
     lock = Sync::RWLock.new
     lock.lock_read
-    lock.lock_read
+    lock.lock_read # <= safe because no attempt to lock write (yet)
 
     spawn do
       lock.lock_write
@@ -127,7 +127,7 @@ describe Sync::RWLock do
   end
 
   describe "checked" do
-    it "raises on re-kock write" do
+    it "raises on re-lock write" do
       lock = Sync::RWLock.new(:checked)
       lock.lock_write
       expect_raises(Sync::Error::Deadlock) { lock.lock_write }

--- a/src/sync/rw_lock.cr
+++ b/src/sync/rw_lock.cr
@@ -32,6 +32,10 @@ module Sync
     #
     # Multiple fibers can acquire the shared (read) lock at the same time. The
     # block will never run concurrently to an exclusive (write) lock.
+    #
+    # WARNING: the shared lock is technically reentrant but any attempt to
+    # relock read can result in a deadlock if another fiber is trying to lock
+    # write!
     def read(& : -> U) : U forall U
       lock_read
       begin
@@ -49,9 +53,12 @@ module Sync
 
     # Acquires the shared (read) lock.
     #
-    # The shared lock is always reentrant, multiple fibers can lock it multiple
-    # times each, and never checked. Blocks the calling fiber while the
-    # exclusive (write) lock is held.
+    # Multiple fibers can acquire the shared (read) lock at the same time.
+    # Blocks the calling fiber if the exclusive (write) lock is held.
+    #
+    # WARNING: the shared lock is technically reentrant but any attempt to
+    # relock read can result in a deadlock if another fiber is trying to lock
+    # write!
     def lock_read : Nil
       @mu.rlock
     end


### PR DESCRIPTION
Clarify that a reentrant shared/read lock can deadlock.

Ref. https://github.com/crystal-lang/crystal/issues/16829#issuecomment-4237204165