### PR TITLE
Fix: `record` macro must check against absolute `::Crystal::Version` [fixup #16172]

### DIFF
--- a/src/macros.cr
+++ b/src/macros.cr
@@ -73,17 +73,17 @@ macro record(__name name, *properties, **kwargs)
   struct {{name.id}}
     {% for property in properties %}
       {% if property.is_a?(Assign) %}
-        {% if compare_versions(Crystal::VERSION, "1.11.0") >= 0 && property.doc != "" %}# {{property.doc.gsub(/\n/, "\n# ").id}}{% end %}
+        {% if compare_versions(::Crystal::VERSION, "1.11.0") >= 0 && property.doc != "" %}# {{property.doc.gsub(/\n/, "\n# ").id}}{% end %}
         getter {{property.target.id}}
       {% elsif property.is_a?(TypeDeclaration) %}
-        {% if compare_versions(Crystal::VERSION, "1.11.0") >= 0 %}
+        {% if compare_versions(::Crystal::VERSION, "1.11.0") >= 0 %}
           {% unless property.doc == "" %}# {{property.doc.gsub(/\n/, "\n# ").id}}{% end %}
           getter {{property.var.id}} : {{property.type}}{% if !property.value.nil? || property.value.stringify == "nil" %} = {{property.value}}{% end %}
         {% else %}
           getter {{property}}
         {% end %}
       {% else %}
-        {% if compare_versions(Crystal::VERSION, "1.11.0") >= 0 && property.doc != "" %}# {{property.doc.gsub(/\n/, "\n# ").id}}{% end %}
+        {% if compare_versions(::Crystal::VERSION, "1.11.0") >= 0 && property.doc != "" %}# {{property.doc.gsub(/\n/, "\n# ").id}}{% end %}
         getter :{{property.id}}
       {% end %}
     {% end %}


### PR DESCRIPTION
Compiling the [pretty.cr](https://github.com/maiha/pretty.cr) shard specs fails with:

```
In src/pretty/crystal.cr:11:13

 11 | VERSION = (Version.parse(::Crystal::VERSION) rescue Version.new)
                ^
Error: Error: expected first argument to 'compare_versions' to be a StringLiteral, SymbolLiteral or MacroId, not Expressions
Error: Process completed with exit code 1.
```