### PR TITLE
Fixes to OpenSSL using Coplit GPT-4.5

### DIFF
--- a/src/openssl/lib_crypto.cr
+++ b/src/openssl/lib_crypto.cr
@@ -1,7 +1,7 @@
 # Supported library versions:
 #
-# * openssl (1.1.0–3.3+)
-# * libressl (2.0–4.0+)
+# * openssl (1.1.1–3.3+)
+# * libressl (3.0–4.0+)
 #
 # See https://crystal-lang.org/reference/man/required_libraries.html#tls
 {% begin %}
@@ -21,10 +21,11 @@
     {% else %}
       # these have to be wrapped in `sh -c` since for MinGW-w64 the compiler
       # passes the command string to `LibC.CreateProcessW`
-      {% from_libressl = (`sh -c 'hash pkg-config 2> /dev/null || printf %s false'` != "false") &&
-                         (`sh -c 'test -f $(pkg-config --silence-errors --variable=includedir libcrypto)/openssl/opensslv.h || printf %s false'` != "false") &&
-                         (`sh -c 'printf "#include <openssl/opensslv.h>\nLIBRESSL_VERSION_NUMBER" | ${CC:-cc} $(pkg-config --cflags --silence-errors libcrypto || true) -E -'`.chomp.split('\n').last != "LIBRESSL_VERSION_NUMBER") %}
-      {% ssl_version = `sh -c 'hash pkg-config 2> /dev/null && pkg-config --silence-errors --modversion libcrypto || printf %s 0.0.0'`.split.last.gsub(/[^0-9.]/, "") %}
+      {% ssl_version_text = `sh -c 'printf "#include <openssl/opensslv.h>\n#ifdef LIBRESSL_VERSION_TEXT\nLIBRESSL_VERSION_TEXT\n#else\nOPENSSL_VERSION_TEXT\n#endif\n" | ${CC:-cc} $(pkg-config --cflags --silence-errors libcrypto 2> /dev/null || true) -E - 2> /dev/null || true'`.chomp.split('\n').last.gsub(/"/, "") %}
+      {% from_libressl = ssl_version_text.includes?("LibreSSL") %}
+      {% ssl_version = ssl_version_text.split.find(&.includes?(".")) || "0.0.0" %}
+      {% ssl_version = ssl_version.gsub(/[^0-9.]/, "") %}
+      {% ssl_version = "0.0.0" if ssl_version.empty? %}
     {% end %}
 
     {% if from_libressl %}
@@ -55,6 +56,10 @@ lib LibCrypto
   alias Long = LibC::Long
   alias ULong = LibC::ULong
   alias SizeT = LibC::SizeT
+
+  OPENSSL_V3_PLUS = {{ OPENSSL_VERSION != "0.0.0" && compare_versions(OPENSSL_VERSION, "3.0.0") >= 0 }}
+  LIBRESSL = {{ LIBRESSL_VERSION != "0.0.0" }}
+  LIBRESSL_V35_PLUS = {{ LIBRESSL_VERSION != "0.0.0" && compare_versions(LIBRESSL_VERSION, "3.5.0") >= 0 }}
 
   type X509 = Void*
   type X509_EXTENSION = Void*

--- a/src/openssl/lib_crypto.cr
+++ b/src/openssl/lib_crypto.cr
@@ -142,7 +142,7 @@ lib LibCrypto
   fun BIO_meth_set_read(BioMethod*, (Bio*, Char*, Int) -> Int)
   fun BIO_meth_set_write(BioMethod*, (Bio*, Char*, Int) -> Int)
 
-  {% unless compare_versions(LIBRESSL_VERSION, "0.0.0") > 0 %}
+  {% if LIBRESSL_VERSION == "0.0.0" %}
     # LibreSSL doesn't support the _ex functions
     fun BIO_meth_set_read_ex(BioMethod*, (Bio*, Char*, SizeT, SizeT*) -> Int)
     fun BIO_meth_set_write_ex(BioMethod*, (Bio*, Char*, SizeT, SizeT*) -> Int)
@@ -325,7 +325,7 @@ lib LibCrypto
   NID_commonName       = 13
   NID_subject_alt_name = 85
 
-  {% if OPENSSL_VERSION != "0.0.0" %}
+  {% if LIBRESSL_VERSION == "0.0.0" %}
     fun sk_free = OPENSSL_sk_free(st : Void*)
     fun sk_num = OPENSSL_sk_num(x0 : Void*) : Int
     fun sk_pop_free = OPENSSL_sk_pop_free(st : Void*, callback : (Void*) ->)

--- a/src/openssl/lib_ssl.cr
+++ b/src/openssl/lib_ssl.cr
@@ -6,8 +6,8 @@ require "./lib_crypto"
 
 # Supported library versions:
 #
-# * openssl (1.1.0–3.3+)
-# * libressl (2.0–4.0+)
+# * openssl (1.1.1–3.3+)
+# * libressl (3.0–4.0+)
 #
 # See https://crystal-lang.org/reference/man/required_libraries.html#tls
 {% begin %}
@@ -27,10 +27,11 @@ require "./lib_crypto"
     {% else %}
       # these have to be wrapped in `sh -c` since for MinGW-w64 the compiler
       # passes the command string to `LibC.CreateProcessW`
-      {% from_libressl = (`sh -c 'hash pkg-config 2> /dev/null || printf %s false'` != "false") &&
-                         (`sh -c 'test -f $(pkg-config --silence-errors --variable=includedir libssl)/openssl/opensslv.h || printf %s false'` != "false") &&
-                         (`sh -c 'printf "#include <openssl/opensslv.h>\nLIBRESSL_VERSION_NUMBER" | ${CC:-cc} $(pkg-config --cflags --silence-errors libssl || true) -E -'`.chomp.split('\n').last != "LIBRESSL_VERSION_NUMBER") %}
-      {% ssl_version = `sh -c 'hash pkg-config 2> /dev/null && pkg-config --silence-errors --modversion libssl || printf %s 0.0.0'`.split.last.gsub(/[^0-9.]/, "") %}
+      {% ssl_version_text = `sh -c 'printf "#include <openssl/opensslv.h>\n#ifdef LIBRESSL_VERSION_TEXT\nLIBRESSL_VERSION_TEXT\n#else\nOPENSSL_VERSION_TEXT\n#endif\n" | ${CC:-cc} $(pkg-config --cflags --silence-errors libssl 2> /dev/null || true) -E - 2> /dev/null || true'`.chomp.split('\n').last.gsub(/"/, "") %}
+      {% from_libressl = ssl_version_text.includes?("LibreSSL") %}
+      {% ssl_version = ssl_version_text.split.find(&.includes?(".")) || "0.0.0" %}
+      {% ssl_version = ssl_version.gsub(/[^0-9.]/, "") %}
+      {% ssl_version = "0.0.0" if ssl_version.empty? %}
     {% end %}
 
     {% if from_libressl %}

--- a/src/openssl/lib_ssl.cr
+++ b/src/openssl/lib_ssl.cr
@@ -100,7 +100,7 @@ lib LibSSL
     SET_TLSEXT_HOSTNAME = 55
   end
 
-  enum TLSExt : Long
+  enum TLSExt : Int
     NAMETYPE_host_name = 0
   end
 
@@ -115,7 +115,7 @@ lib LibSSL
   SSL_CTRL_SET_TLSEXT_SERVERNAME_CB  = 53
   SSL_CTRL_SET_TLSEXT_SERVERNAME_ARG = 54
 
-  enum Options : ULong
+  enum Options : UInt64
     LEGACY_SERVER_CONNECT       = 0x00000004
     ENABLE_KTLS                 = 0x00000008
     SAFARI_ECDHE_ECDSA_BUG      = 0x00000040
@@ -216,7 +216,7 @@ lib LibSSL
   fun ssl_get_error = SSL_get_error(handle : SSL, ret : Int) : SSLError
   fun ssl_get_servername = SSL_get_servername(ssl : SSL, host_type : TLSExt) : UInt8*
   fun ssl_set_bio = SSL_set_bio(handle : SSL, rbio : LibCrypto::Bio*, wbio : LibCrypto::Bio*)
-  fun ssl_select_next_proto = SSL_select_next_proto(output : Char**, output_len : Char*, input : Char*, input_len : Int, client : Char*, client_len : Int) : Int
+  fun ssl_select_next_proto = SSL_select_next_proto(output : Char**, output_len : Char*, input : Char*, input_len : LibC::UInt, client : Char*, client_len : LibC::UInt) : Int
   fun ssl_ctrl = SSL_ctrl(handle : SSL, cmd : Int, larg : Long, parg : Void*) : Long
   fun ssl_free = SSL_free(handle : SSL)
 
@@ -251,7 +251,7 @@ lib LibSSL
   fun ssl_ctx_set_verify = SSL_CTX_set_verify(ctx : SSLContext, mode : VerifyMode, callback : VerifyCallback)
   fun ssl_ctx_set_default_verify_paths = SSL_CTX_set_default_verify_paths(ctx : SSLContext) : Int
   fun ssl_ctx_get_cert_store = SSL_CTX_get_cert_store(ctx : SSLContext) : LibCrypto::X509_STORE
-  fun ssl_ctx_ctrl = SSL_CTX_ctrl(ctx : SSLContext, cmd : Int, larg : ULong, parg : Void*) : ULong
+  fun ssl_ctx_ctrl = SSL_CTX_ctrl(ctx : SSLContext, cmd : Int, larg : Long, parg : Void*) : Long
   fun ssl_ctx_callback_ctrl = SSL_CTX_callback_ctrl(ctx : SSLContext, cmd : Int, fp : Proc(Void)) : Long
   fun ssl_set_ssl_ctx = SSL_set_SSL_CTX(ssl : SSL, ctx : SSLContext) : SSLContext
 
@@ -265,9 +265,9 @@ lib LibSSL
     SSL_CTRL_OPTIONS       = 32
     SSL_CTRL_CLEAR_OPTIONS = 77
   {% else %}
-    fun ssl_ctx_get_options = SSL_CTX_get_options(ctx : SSLContext) : ULong
-    fun ssl_ctx_set_options = SSL_CTX_set_options(ctx : SSLContext, larg : ULong) : ULong
-    fun ssl_ctx_clear_options = SSL_CTX_clear_options(ctx : SSLContext, larg : ULong) : ULong
+    fun ssl_ctx_get_options = SSL_CTX_get_options(ctx : SSLContext) : UInt64
+    fun ssl_ctx_set_options = SSL_CTX_set_options(ctx : SSLContext, larg : UInt64) : UInt64
+    fun ssl_ctx_clear_options = SSL_CTX_clear_options(ctx : SSLContext, larg : UInt64) : UInt64
     fun ssl_ctx_set_ciphersuites = SSL_CTX_set_ciphersuites(ctx : SSLContext, ciphers : Char*) : Int
   {% end %}
 
@@ -285,11 +285,11 @@ lib LibSSL
 
   fun tls_method = TLS_method : SSLMethod
 
-  alias ALPNCallback = (SSL, Char**, Char*, Char*, Int, Void*) -> Int
+  alias ALPNCallback = (SSL, Char**, Char*, Char*, LibC::UInt, Void*) -> Int
 
   fun ssl_get0_alpn_selected = SSL_get0_alpn_selected(handle : SSL, data : Char**, len : LibC::UInt*) : Void
   fun ssl_ctx_set_alpn_select_cb = SSL_CTX_set_alpn_select_cb(ctx : SSLContext, cb : ALPNCallback, arg : Void*) : Void
-  fun ssl_ctx_set_alpn_protos = SSL_CTX_set_alpn_protos(ctx : SSLContext, protos : Char*, protos_len : Int) : Int
+  fun ssl_ctx_set_alpn_protos = SSL_CTX_set_alpn_protos(ctx : SSLContext, protos : Char*, protos_len : LibC::UInt) : Int
 
   alias X509VerifyParam = LibCrypto::X509VerifyParam
 

--- a/src/openssl/ssl/context.cr
+++ b/src/openssl/ssl/context.cr
@@ -423,19 +423,39 @@ abstract class OpenSSL::SSL::Context
     LibCrypto.ec_key_free(key)
   end
 
+  private def ctrl_mask_to_u64(value : LibC::Long) : UInt64
+    {% if sizeof(LibC::Long) == 8 %}
+      value.unsafe_as(UInt64)
+    {% else %}
+      value.unsafe_as(UInt32).to_u64
+    {% end %}
+  end
+
+  private def ctrl_mask_to_long(value : UInt64) : LibC::Long
+    {% if sizeof(LibC::Long) == 8 %}
+      value.unsafe_as(LibC::Long)
+    {% else %}
+      value.to_u32.unsafe_as(LibC::Long)
+    {% end %}
+  end
+
   # Returns the current modes set on the TLS context.
   def modes : LibSSL::Modes
-    OpenSSL::SSL::Modes.new LibSSL.ssl_ctx_ctrl(@handle, LibSSL::SSL_CTRL_MODE, 0, nil).to_u64
+    OpenSSL::SSL::Modes.new ctrl_mask_to_u64(LibSSL.ssl_ctx_ctrl(@handle, LibSSL::SSL_CTRL_MODE, 0, nil))
   end
 
   # Adds modes to the TLS context.
   def add_modes(mode : OpenSSL::SSL::Modes)
-    OpenSSL::SSL::Modes.new LibSSL.ssl_ctx_ctrl(@handle, LibSSL::SSL_CTRL_MODE, mode, nil).to_u64
+    OpenSSL::SSL::Modes.new ctrl_mask_to_u64(
+      LibSSL.ssl_ctx_ctrl(@handle, LibSSL::SSL_CTRL_MODE, ctrl_mask_to_long(mode.to_u64), nil)
+    )
   end
 
   # Removes modes from the TLS context.
   def remove_modes(mode : OpenSSL::SSL::Modes)
-    OpenSSL::SSL::Modes.new LibSSL.ssl_ctx_ctrl(@handle, LibSSL::SSL_CTRL_CLEAR_MODE, mode, nil).to_u64
+    OpenSSL::SSL::Modes.new ctrl_mask_to_u64(
+      LibSSL.ssl_ctx_ctrl(@handle, LibSSL::SSL_CTRL_CLEAR_MODE, ctrl_mask_to_long(mode.to_u64), nil)
+    )
   end
 
   # Returns the current options set on the TLS context.
@@ -443,7 +463,7 @@ abstract class OpenSSL::SSL::Context
     opts = {% if LibSSL.has_method?(:ssl_ctx_get_options) %}
              LibSSL.ssl_ctx_get_options(@handle)
            {% else %}
-             LibSSL.ssl_ctx_ctrl(@handle, LibSSL::SSL_CTRL_OPTIONS, 0, nil).to_u64
+             ctrl_mask_to_u64(LibSSL.ssl_ctx_ctrl(@handle, LibSSL::SSL_CTRL_OPTIONS, 0, nil))
            {% end %}
     OpenSSL::SSL::Options.new(opts)
   end
@@ -462,7 +482,9 @@ abstract class OpenSSL::SSL::Context
     opts = {% if LibSSL.has_method?(:ssl_ctx_set_options) %}
              LibSSL.ssl_ctx_set_options(@handle, options)
            {% else %}
-             LibSSL.ssl_ctx_ctrl(@handle, LibSSL::SSL_CTRL_OPTIONS, options.to_i64, nil).to_u64
+             ctrl_mask_to_u64(
+               LibSSL.ssl_ctx_ctrl(@handle, LibSSL::SSL_CTRL_OPTIONS, ctrl_mask_to_long(options.to_u64), nil)
+             )
            {% end %}
     OpenSSL::SSL::Options.new(opts)
   end
@@ -477,7 +499,9 @@ abstract class OpenSSL::SSL::Context
     opts = {% if LibSSL.has_method?(:ssl_ctx_clear_options) %}
              LibSSL.ssl_ctx_clear_options(@handle, options)
            {% else %}
-             LibSSL.ssl_ctx_ctrl(@handle, LibSSL::SSL_CTRL_CLEAR_OPTIONS, options.to_i64, nil).to_u64
+             ctrl_mask_to_u64(
+               LibSSL.ssl_ctx_ctrl(@handle, LibSSL::SSL_CTRL_CLEAR_OPTIONS, ctrl_mask_to_long(options.to_u64), nil)
+             )
            {% end %}
     OpenSSL::SSL::Options.new(opts)
   end

--- a/src/openssl/ssl/context.cr
+++ b/src/openssl/ssl/context.cr
@@ -93,7 +93,7 @@ abstract class OpenSSL::SSL::Context
     end
 
     private def alpn_protocol=(protocol : Bytes)
-      LibSSL.ssl_ctx_set_alpn_protos(@handle, protocol, protocol.size)
+      LibSSL.ssl_ctx_set_alpn_protos(@handle, protocol, protocol.size.to_u32)
     end
   end
 
@@ -165,9 +165,9 @@ abstract class OpenSSL::SSL::Context
     end
 
     private def alpn_protocol=(protocol : Bytes)
-      alpn_cb = ->(ssl : LibSSL::SSL, o : LibC::Char**, olen : LibC::Char*, i : LibC::Char*, ilen : LibC::Int, data : Void*) {
+      alpn_cb = ->(ssl : LibSSL::SSL, o : LibC::Char**, olen : LibC::Char*, i : LibC::Char*, ilen : LibC::UInt, data : Void*) {
         proto = Box(Bytes).unbox(data)
-        ret = LibSSL.ssl_select_next_proto(o, olen, proto, proto.size, i, ilen)
+        ret = LibSSL.ssl_select_next_proto(o, olen, proto, proto.size.to_u32, i, ilen)
         if ret != LibSSL::OPENSSL_NPN_NEGOTIATED
           LibSSL::SSL_TLSEXT_ERR_NOACK
         else
@@ -207,7 +207,6 @@ abstract class OpenSSL::SSL::Context
     # end
     # ```
     #
-    # See [SSL_CTX_set_tlsext_servername_callback](https://docs.openssl.org/3.5/man3/SSL_CTX_set_tlsext_servername_callback/)
     @[Experimental]
     def on_server_name(&block : String -> OpenSSL::SSL::Context::Server?)
       # Create a C callback that extracts the hostname and calls our Crystal block
@@ -426,17 +425,17 @@ abstract class OpenSSL::SSL::Context
 
   # Returns the current modes set on the TLS context.
   def modes : LibSSL::Modes
-    OpenSSL::SSL::Modes.new LibSSL.ssl_ctx_ctrl(@handle, LibSSL::SSL_CTRL_MODE, 0, nil)
+    OpenSSL::SSL::Modes.new LibSSL.ssl_ctx_ctrl(@handle, LibSSL::SSL_CTRL_MODE, 0, nil).to_u64
   end
 
   # Adds modes to the TLS context.
   def add_modes(mode : OpenSSL::SSL::Modes)
-    OpenSSL::SSL::Modes.new LibSSL.ssl_ctx_ctrl(@handle, LibSSL::SSL_CTRL_MODE, mode, nil)
+    OpenSSL::SSL::Modes.new LibSSL.ssl_ctx_ctrl(@handle, LibSSL::SSL_CTRL_MODE, mode, nil).to_u64
   end
 
   # Removes modes from the TLS context.
   def remove_modes(mode : OpenSSL::SSL::Modes)
-    OpenSSL::SSL::Modes.new LibSSL.ssl_ctx_ctrl(@handle, LibSSL::SSL_CTRL_CLEAR_MODE, mode, nil)
+    OpenSSL::SSL::Modes.new LibSSL.ssl_ctx_ctrl(@handle, LibSSL::SSL_CTRL_CLEAR_MODE, mode, nil).to_u64
   end
 
   # Returns the current options set on the TLS context.
@@ -444,7 +443,7 @@ abstract class OpenSSL::SSL::Context
     opts = {% if LibSSL.has_method?(:ssl_ctx_get_options) %}
              LibSSL.ssl_ctx_get_options(@handle)
            {% else %}
-             LibSSL.ssl_ctx_ctrl(@handle, LibSSL::SSL_CTRL_OPTIONS, 0, nil)
+             LibSSL.ssl_ctx_ctrl(@handle, LibSSL::SSL_CTRL_OPTIONS, 0, nil).to_u64
            {% end %}
     OpenSSL::SSL::Options.new(opts)
   end
@@ -463,7 +462,7 @@ abstract class OpenSSL::SSL::Context
     opts = {% if LibSSL.has_method?(:ssl_ctx_set_options) %}
              LibSSL.ssl_ctx_set_options(@handle, options)
            {% else %}
-             LibSSL.ssl_ctx_ctrl(@handle, LibSSL::SSL_CTRL_OPTIONS, options, nil)
+             LibSSL.ssl_ctx_ctrl(@handle, LibSSL::SSL_CTRL_OPTIONS, options.to_i64, nil).to_u64
            {% end %}
     OpenSSL::SSL::Options.new(opts)
   end
@@ -478,7 +477,7 @@ abstract class OpenSSL::SSL::Context
     opts = {% if LibSSL.has_method?(:ssl_ctx_clear_options) %}
              LibSSL.ssl_ctx_clear_options(@handle, options)
            {% else %}
-             LibSSL.ssl_ctx_ctrl(@handle, LibSSL::SSL_CTRL_CLEAR_OPTIONS, options, nil)
+             LibSSL.ssl_ctx_ctrl(@handle, LibSSL::SSL_CTRL_CLEAR_OPTIONS, options.to_i64, nil).to_u64
            {% end %}
     OpenSSL::SSL::Options.new(opts)
   end


### PR DESCRIPTION
Hello. Based on the review by Copilot + GPT-4.5, the following changes were suggested. Since I haven’t reviewed every section, this pull request is intended solely for information sharing. I’m closing this pull request. Sorry.

> The first PR revises how OpenSSL and LibreSSL versions are detected. The previous implementation relied heavily on `pkg-config` output and header layout, which made it harder to determine the actual SSL implementation and version being used in some build environments. This PR changes the logic to preprocess `opensslv.h` directly and extract either `OPENSSL_VERSION_TEXT` or `LIBRESSL_VERSION_TEXT`, then uses that result to determine whether the library is OpenSSL or LibreSSL and to derive the version number that matters for conditional bindings. The affected files are lib_crypto.cr and lib_ssl.cr. As part of that change, the “supported library versions” comments at the top of these files are also updated to match the current project requirements. The main purpose of this PR is to make later compile-time branching depend on a more trustworthy source of truth. It does not primarily extend functionality; rather, it strengthens the foundation by making library identification more accurate and more robust across environments.

> The second PR fixes how different C symbols are selected for OpenSSL and LibreSSL. OpenSSL exposes stack APIs under names such as `OPENSSL_sk_num`, while LibreSSL provides corresponding functions under names such as `sk_num`. Crystal’s bindings in lib_crypto.cr need to choose the right symbol set depending on which SSL implementation is actually in use. If that choice is wrong, the code may compile but fail later at link time with unresolved symbols, which is exactly what can happen in code paths exercised by hostname validation. This PR corrects that symbol selection for `sk_free`, `sk_num`, `sk_pop_free`, and `sk_value`, and also keeps the handling of `BIO_meth_set_read_ex` and `BIO_meth_set_write_ex` aligned with LibreSSL support. The resulting conditionals are also written in a more direct and readable way. Although the diff is small, this is not really a stylistic cleanup. It is a straightforward bug fix that prevents a concrete linker failure, which is why it makes sense to keep it separate from the more structural changes.

> The third PR aligns the integer types used in the SSL bindings with the underlying C API and then adjusts the calling code so that bitmasks remain correct on 32-bit targets. The affected files are lib_ssl.cr and context.cr. It updates several binding definitions so that Crystal types better match the C declarations for values such as `int`, `unsigned int`, `long`, and `unsigned long`, including `TLSExt`, `Options`, ALPN-related lengths, and `SSL_CTX_ctrl`. However, changing `SSL_CTX_ctrl` to use `Long` at the FFI boundary is not sufficient by itself: if the returned or passed value is then converted with ordinary numeric conversions such as `to_u64` or `to_i64`, 32-bit targets may suffer from sign extension and end up with corrupted option or mode bitmasks. To address that, this PR adds helper methods in context.cr that preserve the raw bit pattern when converting between `long` and unsigned mask types. That logic is then applied to `modes`, `add_modes`, `remove_modes`, `options`, `add_options`, and `remove_options`. So while this PR may initially look like a simple type cleanup, it is really about both ABI correctness and 32-bit safety. It keeps the existing behavior intact on 64-bit systems while improving portability and preventing subtle mask-handling bugs on narrower targets.