### PR TITLE
Fix typo `writable` in documentation

### DIFF
--- a/_typos.toml
+++ b/_typos.toml
@@ -53,6 +53,7 @@ extend-ignore-re = [
   " ([a-zA-Z.]{8} ){4}->", # src/bit_array.cr
   "[A-z]+[0-9]+", # words including a number are likely some kind of identifier
   "sha256[:-][0-9A-z=]+", # shell.nix
+  "File.writeable", # in docs/changelogs/pre-1.0.md
 ]
 
 [files]

--- a/spec/std/file/tempfile_spec.cr
+++ b/spec/std/file/tempfile_spec.cr
@@ -118,7 +118,7 @@ describe File do
       file.try &.delete
     end
 
-    it "fails in nonwriteable folder" do
+    it "fails in non-writable folder" do
       err_directory = (datapath("non-existing-folder") + Path::SEPARATORS[0]).inspect_unquoted
       expect_raises(File::NotFoundError, "Error creating temporary file: '#{err_directory}") do
         File.tempfile dir: datapath("non-existing-folder")

--- a/spec/std/io/memory_spec.cr
+++ b/spec/std/io/memory_spec.cr
@@ -326,7 +326,7 @@ describe IO::Memory do
     end
   end
 
-  it "creates from slice, non-writeable" do
+  it "creates from slice, non-writable" do
     slice = Slice.new(6) { |i| ('a'.ord + i).to_u8 }
     io = IO::Memory.new slice, writeable: false
 

--- a/src/io/memory.cr
+++ b/src/io/memory.cr
@@ -40,7 +40,7 @@ class IO::Memory < IO
   #
   # ```
   # slice = Slice.new(6) { |i| ('a'.ord + i).to_u8 }
-  # io = IO::Memory.new slice, writable: false
+  # io = IO::Memory.new slice, writeable: false
   # io.pos            # => 0
   # io.read(slice)    # => 6
   # String.new(slice) # => "abcdef"

--- a/src/io/memory.cr
+++ b/src/io/memory.cr
@@ -1,6 +1,6 @@
 # An `IO` that reads and writes from a buffer in memory.
 #
-# The internal buffer can be resizeable and/or writeable depending
+# The internal buffer can be resizeable and/or writable depending
 # on how an `IO::Memory` is constructed.
 class IO::Memory < IO
   # Returns the internal buffer as a `Pointer(UInt8)`.
@@ -11,7 +11,7 @@ class IO::Memory < IO
 
   @capacity : Int32
 
-  # Creates an empty, resizeable and writeable `IO::Memory` with the given
+  # Creates an empty, resizeable and writable `IO::Memory` with the given
   # initial *capacity* for the internal buffer.
   #
   # ```
@@ -40,7 +40,7 @@ class IO::Memory < IO
   #
   # ```
   # slice = Slice.new(6) { |i| ('a'.ord + i).to_u8 }
-  # io = IO::Memory.new slice, writeable: false
+  # io = IO::Memory.new slice, writable: false
   # io.pos            # => 0
   # io.read(slice)    # => 6
   # String.new(slice) # => "abcdef"
@@ -55,7 +55,7 @@ class IO::Memory < IO
   end
 
   # Creates an `IO::Memory` whose contents are the exact contents of *string*.
-  # The created `IO::Memory` is non-resizeable and non-writeable.
+  # The created `IO::Memory` is non-resizeable and non-writable.
   #
   # The `IO` starts at position zero for reading.
   #
@@ -80,7 +80,7 @@ class IO::Memory < IO
     count
   end
 
-  # See `IO#write(slice)`. Raises if this `IO::Memory` is non-writeable,
+  # See `IO#write(slice)`. Raises if this `IO::Memory` is non-writable,
   # or if it's non-resizeable and a resize is needed.
   def write(slice : Bytes) : Nil
     check_writeable
@@ -102,7 +102,7 @@ class IO::Memory < IO
     @bytesize = @pos if @pos > @bytesize
   end
 
-  # See `IO#write_byte`. Raises if this `IO::Memory` is non-writeable,
+  # See `IO#write_byte`. Raises if this `IO::Memory` is non-writable,
   # or if it's non-resizeable and a resize is needed.
   def write_byte(byte : UInt8) : Nil
     check_writeable


### PR DESCRIPTION
`writable` is the generally agreed spelling.

Typos 1.45 complains about `writeable` in the codebase.