### PR TITLE
Improve docs for `::delegate`

### DIFF
--- a/src/object.cr
+++ b/src/object.cr
@@ -527,10 +527,10 @@ class Object
   #
   # This macro defines methods with the given names which capture and forward all
   # parameters to the same method on *to*.
-  # 
+  #
   # There is no introspection into the target def, which brings a few limitations:
   # - *to* might not even respond to the method.
-  # - Fowarding procs (e.g. captured blocks) is not supported.
+  # - Forwarding procs (e.g. captured blocks) is not supported.
   # - Parameter have no type restrictions, so autocasting does not work.
   #
   # ```

--- a/src/object.cr
+++ b/src/object.cr
@@ -526,10 +526,10 @@ class Object
   # Delegate *methods* to *to*.
   #
   # This macro defines methods with the given names which capture and forward all
-  # parameters to the same method on `to`.
+  # parameters to the same method on *to*.
   # 
   # There is no introspection into the target def, which brings a few limitations:
-  # - `to` might not even respond to the method.
+  # - *to* might not even respond to the method.
   # - Fowarding procs (e.g. captured blocks) is not supported.
   # - Parameter have no type restrictions, so autocasting does not work.
   #

--- a/src/object.cr
+++ b/src/object.cr
@@ -525,8 +525,13 @@ class Object
 
   # Delegate *methods* to *to*.
   #
-  # Note that due to current language limitations this is only useful
-  # when no captured blocks are involved.
+  # This macro defines methods with the given names which capture and forward all
+  # parameters to the same method on `to`.
+  # 
+  # There is no introspection into the target def, which brings a few limitations:
+  # - `to` might not even respond to the method.
+  # - Fowarding procs (e.g. captured blocks) is not supported.
+  # - Parameter have no type restrictions, so autocasting does not work.
   #
   # ```
   # class StringWrapper


### PR DESCRIPTION
Explain limitations of the macro generated methods.

Resolves #16850
