### PR TITLE
Add coverage for Deque.from_json block overload

### DIFF
--- a/spec/std/json/serialization_spec.cr
+++ b/spec/std/json/serialization_spec.cr
@@ -189,6 +189,15 @@ describe "JSON serialization" do
       elements.should eq([1, 2, 3])
     end
 
+    it "does for Deque(Int32) with block" do
+      elements = [] of Int32
+      ret = Deque(Int32).from_json("[1, 2, 3]") do |element|
+        elements << element
+      end
+      ret.should be_nil
+      elements.should eq([1, 2, 3])
+    end
+
     it "does for tuple" do
       tuple = Tuple(Int32, String).from_json(%([1, "hello"]))
       tuple.should eq({1, "hello"})


### PR DESCRIPTION

**Repo:** crystal-lang/crystal (⭐ 19000)
**Type:** test
**Files changed:** 1
**Lines:** +9/-0

## What
Adds a focused spec for `Deque(Int32).from_json` when used with the block overload. The new test verifies that each parsed element is yielded to the block and that the overload returns `nil`, matching the behavior already covered for `Array(Int32).from_json`.

## Why
`Deque.from_json` exposes the same block-based streaming API shape as `Array.from_json`, but only the array overload had an explicit contract test for yielded values and return type. This patch closes that coverage gap and protects API parity against future regressions in JSON deserialization behavior.

## Testing
Static review of the spec addition and surrounding JSON serialization tests. Local execution was not possible in this environment because the `crystal` executable is not installed. To verify with the project toolchain, run `bin/crystal spec spec/std/json/serialization_spec.cr`.

## Risk
Low / test-only change in one spec file with no production code impact.
