### PR TITLE
Rename parameter to `writable` in `IO::Memory.new`

### DIFF
--- a/_typos.toml
+++ b/_typos.toml
@@ -53,6 +53,8 @@ extend-ignore-re = [
   " ([a-zA-Z.]{8} ){4}->", # src/bit_array.cr
   "[A-z]+[0-9]+", # words including a number are likely some kind of identifier
   "sha256[:-][0-9A-z=]+", # shell.nix
+  "writeable writable", # in src/io/memory.cr
+  "writeable:", # in spec/std/io/memory_spec.cr
   "File.writeable", # in docs/changelogs/pre-1.0.md
 ]
 

--- a/spec/std/io/memory_spec.cr
+++ b/spec/std/io/memory_spec.cr
@@ -328,6 +328,15 @@ describe IO::Memory do
 
   it "creates from slice, non-writable" do
     slice = Slice.new(6) { |i| ('a'.ord + i).to_u8 }
+    io = IO::Memory.new slice, writable: false
+
+    expect_raises(IO::Error, "Read-only stream") do
+      io.print 'z'
+    end
+  end
+
+  it "creates from slice, non-writable (deprecated)" do
+    slice = Slice.new(6) { |i| ('a'.ord + i).to_u8 }
     io = IO::Memory.new slice, writeable: false
 
     expect_raises(IO::Error, "Read-only stream") do

--- a/src/io/memory.cr
+++ b/src/io/memory.cr
@@ -40,18 +40,24 @@ class IO::Memory < IO
   #
   # ```
   # slice = Slice.new(6) { |i| ('a'.ord + i).to_u8 }
-  # io = IO::Memory.new slice, writeable: false
+  # io = IO::Memory.new slice, writable: false
   # io.pos            # => 0
   # io.read(slice)    # => 6
   # String.new(slice) # => "abcdef"
   # ```
-  def initialize(slice : Bytes, writeable = true)
+  def initialize(slice : Bytes, writable = true)
     @buffer = slice.to_unsafe
     @bytesize = @capacity = slice.size.to_i
     @pos = 0
     @closed = false
     @resizeable = false
-    @writeable = !slice.read_only? && writeable
+    @writeable = !slice.read_only? && writable
+  end
+
+  # :ditto:
+  @[Deprecated("Use `IO::Memory.new(Bytes, writable)` instead")]
+  def self.new(slice : Bytes, writeable writable) : self
+    new slice, writable: writable
   end
 
   # Creates an `IO::Memory` whose contents are the exact contents of *string*.
@@ -66,7 +72,7 @@ class IO::Memory < IO
   # io.print "hi" # raises IO::Error
   # ```
   def self.new(string : String) : self
-    new string.to_slice, writeable: false
+    new string.to_slice, writable: false
   end
 
   # See `IO#read(slice)`.
@@ -353,7 +359,7 @@ class IO::Memory < IO
 
     old_writeable = @writeable
     old_resizeable = @resizeable
-    io = IO::Memory.new(to_slice[offset, bytesize], writeable: false)
+    io = IO::Memory.new(to_slice[offset, bytesize], writable: false)
     begin
       @writeable = false
       @resizeable = false

--- a/src/io/memory.cr
+++ b/src/io/memory.cr
@@ -30,7 +30,7 @@ class IO::Memory < IO
     @pos = 0
     @closed = false
     @resizeable = true
-    @writeable = true
+    @writable = true
   end
 
   # Creates an `IO::Memory` that will read, and optionally write, from/to
@@ -51,7 +51,7 @@ class IO::Memory < IO
     @pos = 0
     @closed = false
     @resizeable = false
-    @writeable = !slice.read_only? && writable
+    @writable = !slice.read_only? && writable
   end
 
   # :ditto:
@@ -89,7 +89,7 @@ class IO::Memory < IO
   # See `IO#write(slice)`. Raises if this `IO::Memory` is non-writable,
   # or if it's non-resizeable and a resize is needed.
   def write(slice : Bytes) : Nil
-    check_writeable
+    check_writable
     check_open
 
     count = slice.size
@@ -111,7 +111,7 @@ class IO::Memory < IO
   # See `IO#write_byte`. Raises if this `IO::Memory` is non-writable,
   # or if it's non-resizeable and a resize is needed.
   def write_byte(byte : UInt8) : Nil
-    check_writeable
+    check_writable
     check_open
 
     increase_capacity_by(1)
@@ -184,7 +184,7 @@ class IO::Memory < IO
   def peek : Bytes
     check_open
 
-    Slice.new(@buffer + @pos, @bytesize - @pos, read_only: !@writeable)
+    Slice.new(@buffer + @pos, @bytesize - @pos, read_only: !@writable)
   end
 
   # :nodoc:
@@ -357,16 +357,16 @@ class IO::Memory < IO
       raise ArgumentError.new("Bytesize out of bounds")
     end
 
-    old_writeable = @writeable
+    old_writable = @writable
     old_resizeable = @resizeable
     io = IO::Memory.new(to_slice[offset, bytesize], writable: false)
     begin
-      @writeable = false
+      @writable = false
       @resizeable = false
       yield io
     ensure
       io.close
-      @writeable = old_writeable
+      @writable = old_writable
       @resizeable = old_resizeable
     end
   end
@@ -422,7 +422,7 @@ class IO::Memory < IO
   # io.to_slice # => Bytes[104, 101, 108, 108, 111]
   # ```
   def to_slice : Bytes
-    Slice.new(@buffer, @bytesize, read_only: !@writeable)
+    Slice.new(@buffer, @bytesize, read_only: !@writable)
   end
 
   # Appends this internal buffer to the given `IO`.
@@ -444,8 +444,8 @@ class IO::Memory < IO
     end
   end
 
-  private def check_writeable
-    unless @writeable
+  private def check_writable
+    unless @writable
       raise IO::Error.new "Read-only stream"
     end
   end


### PR DESCRIPTION
Follow-up to #16848

`writable` is the generally agreed spelling.

Typos 1.45 complains about `writeable` in the codebase.