### PR TITLE
[Backport release/1.19] Fix: `HTTP::Server` is no longer vulnerable to request smuggling

### DIFF
--- a/spec/std/http/server/server_spec.cr
+++ b/spec/std/http/server/server_spec.cr
@@ -615,6 +615,33 @@ describe HTTP::Server do
     end
   end
 
+  describe "request smuggling/splitting mitigations (RFC 9112, Section 6.1)" do
+    it "rejects when content-length and transfer-encoding are both defined then closes the connection" do
+      channel = Channel({String, String, String?}).new(4)
+      response = nil
+
+      server = HTTP::Server.new do |ctx|
+        channel.send({ctx.request.method, ctx.request.path, ctx.request.body.try(&.gets_to_end)})
+      end
+
+      with_tempfile("socket") do |path|
+        server.bind_unix(path)
+        spawn { server.listen }
+
+        UNIXSocket.open(path) do |socket|
+          socket << "GET /one HTTP/1.1\r\nhost: example.org\r\ncontent-length: 4\r\ntransfer-encoding: chunked\r\n\r\n2a\r\nGET /admin HTTP/1.1\r\nhost: example.org\r\n\r\n\r\n0\r\n\r\nGET /two HTTP/1.1\r\nhost: example.org\r\n\r\n"
+          socket.close_write
+          response = socket.gets_to_end
+        end
+
+        channel.close
+      end
+
+      channel.receive?.should be_nil
+      response.not_nil!.should start_with("HTTP/1.1 400 ")
+    end
+  end
+
   typeof(begin
     # Initialize with custom host
     server = HTTP::Server.new { |ctx| }

--- a/src/http/common.cr
+++ b/src/http/common.cr
@@ -35,12 +35,16 @@ module HTTP
       when EndOfRequest
         body = nil
 
+        # RFC 9112, Section 6.1: Transfer-Encoding is defined as overriding the
+        # Content-Length header that must be ignored.
+        transfer_encoding = headers["Transfer-Encoding"]?
+
         if body_type.prohibited?
           body = nil
-        elsif content_length = content_length(headers)
-          body = FixedLengthContent.new(io, content_length)
-        elsif headers["Transfer-Encoding"]? == "chunked"
+        elsif transfer_encoding == "chunked"
           body = ChunkedContent.new(io)
+        elsif !transfer_encoding && (content_length = content_length(headers))
+          body = FixedLengthContent.new(io, content_length)
         elsif body_type.mandatory?
           body = UnknownLengthContent.new(io)
         end

--- a/src/http/server/request_processor.cr
+++ b/src/http/server/request_processor.cr
@@ -43,6 +43,13 @@ class HTTP::Server::RequestProcessor
           return
         end
 
+        # RFC 9112, Section 6.1: reject & close on ambiguous body content to
+        # prevent request smuggling
+        if request.headers.has_key?("Content-Length") && request.headers.has_key?("Transfer-Encoding")
+          response.respond_with_status(HTTP::Status::BAD_REQUEST)
+          return
+        end
+
         response.version = request.version
         response.headers["Connection"] = "keep-alive" if request.keep_alive?
         context = Context.new(request, response)


### PR DESCRIPTION
_Backport to `release/1.19` of c948b31ee6d5414050e771f89955c7dc02883ebc_

The HTTP request and response parsers now ignore the `Content-Length` header when the `Transfer-Encoding` header is also set.

`HTTP::Server` rejects requests with both headers and closes the connection.

See [GHSA-wqh5-7w63-pm68](https://github.com/crystal-lang/crystal/security/advisories/GHSA-wqh5-7w63-pm68) for details.