### PR TITLE
Remove unnecessary `not_nil!` in spec suite

### DIFF
--- a/spec/compiler/crystal/tools/context_spec.cr
+++ b/spec/compiler/crystal/tools/context_spec.cr
@@ -34,8 +34,7 @@ end
 
 private def assert_context_keys(code, *variables)
   run_context_tool(code) do |result|
-    result.contexts.should_not be_nil
-    result.contexts.not_nil!.each do |context|
+    result.contexts.should_not(be_nil).each do |context|
       context.keys.should eq(variables.to_a)
     end
   end
@@ -43,8 +42,7 @@ end
 
 private def assert_context_includes(code, variable, var_types)
   run_context_tool(code) do |result|
-    result.contexts.should_not be_nil
-    result.contexts.not_nil!.map(&.[variable].to_s).should eq(var_types)
+    result.contexts.should_not(be_nil).map(&.[variable].to_s).should eq(var_types)
   end
 end
 

--- a/spec/compiler/crystal/tools/implementations_spec.cr
+++ b/spec/compiler/crystal/tools/implementations_spec.cr
@@ -187,23 +187,20 @@ describe "implementations" do
       bar
     ), Location.new(".", 12, 9))
 
-    result.implementations.should_not be_nil
-    impls = result.implementations.not_nil!
+    impls = result.implementations.should_not be_nil
     impls.size.should eq(1)
 
     impls[0].line.should eq(11) # location of baz
     impls[0].column.should eq(7)
     impls[0].filename.should eq(".")
 
-    impls[0].expands.should_not be_nil
-    exp = impls[0].expands.not_nil!
+    exp = impls[0].expands.should_not be_nil
     exp.line.should eq(8) # location of foo call in macro baz
     exp.column.should eq(9)
     exp.macro.should eq("baz")
     exp.filename.should eq(".")
 
-    exp.expands.should_not be_nil
-    exp = exp.expands.not_nil!
+    exp = exp.expands.should_not be_nil
     exp.line.should eq(3) # location of def bar in macro foo
     exp.column.should eq(9)
     exp.macro.should eq("foo")

--- a/spec/compiler/normalize/op_assign_spec.cr
+++ b/spec/compiler/normalize/op_assign_spec.cr
@@ -105,9 +105,7 @@ describe "Normalize: op assign" do
 end
 
 private def assert_name_location(node, line_number, column_number, spec_file = __FILE__, spec_line = __LINE__)
-  node.name_location.should_not be_nil, file: spec_file, line: spec_line
-
-  name_location = node.name_location.not_nil!
+  name_location = node.name_location.should_not be_nil, file: spec_file, line: spec_line
   name_location.line_number.should eq(line_number), file: spec_file, line: spec_line
   name_location.column_number.should eq(column_number), file: spec_file, line: spec_line
 end

--- a/spec/compiler/semantic/exception_spec.cr
+++ b/spec/compiler/semantic/exception_spec.cr
@@ -226,7 +226,7 @@ describe "Semantic: exception" do
       CRYSTAL
     mod = result.program
     eh = result.node.as(Expressions).expressions[-2]
-    call_p_n = eh.as(ExceptionHandler).ensure.not_nil!.as(Call)
+    call_p_n = eh.as(ExceptionHandler).ensure.should be_a(Call)
     call_p_n.args.first.type.should eq(mod.nilable(mod.int32))
   end
 
@@ -244,7 +244,7 @@ describe "Semantic: exception" do
       CRYSTAL
     mod = result.program
     eh = result.node.as(Expressions).expressions[-2]
-    call_p_n = eh.as(ExceptionHandler).ensure.not_nil!.as(Call)
+    call_p_n = eh.as(ExceptionHandler).ensure.should be_a(Call)
     call_p_n.args.first.type.should eq(mod.nilable(mod.int32))
   end
 

--- a/spec/compiler/semantic/exception_spec.cr
+++ b/spec/compiler/semantic/exception_spec.cr
@@ -59,8 +59,8 @@ describe "Semantic: exception" do
       CRYSTAL
     mod = result.program
     a_def = mod.lookup_first_def("foo", false)
-    def_instance = mod.lookup_def_instance DefInstanceKey.new(a_def.object_id, [] of Type, nil, nil)
-    def_instance.not_nil!.raises?.should be_true
+    def_instance = mod.lookup_def_instance(DefInstanceKey.new(a_def.object_id, [] of Type, nil, nil)).should_not be_nil
+    def_instance.raises?.should be_true
   end
 
   it "marks method calling lib fun that raises as raises" do
@@ -76,8 +76,8 @@ describe "Semantic: exception" do
       CRYSTAL
     mod = result.program
     a_def = mod.lookup_first_def("foo", false)
-    def_instance = mod.lookup_def_instance DefInstanceKey.new(a_def.object_id, [] of Type, nil, nil)
-    def_instance.not_nil!.raises?.should be_true
+    def_instance = mod.lookup_def_instance(DefInstanceKey.new(a_def.object_id, [] of Type, nil, nil)).should_not be_nil
+    def_instance.raises?.should be_true
   end
 
   it "types exception var with no types" do
@@ -255,8 +255,8 @@ describe "Semantic: exception" do
       foo
       CRYSTAL
     mod = result.program
-    a_def = mod.lookup_first_def("foo", false)
-    a_def.not_nil!.raises?.should be_true
+    a_def = mod.lookup_first_def("foo", false).should_not be_nil
+    a_def.raises?.should be_true
   end
 
   it "marks def as raises" do
@@ -269,8 +269,8 @@ describe "Semantic: exception" do
       foo
       CRYSTAL
     mod = result.program
-    a_def = mod.lookup_first_def("foo", false)
-    a_def.not_nil!.raises?.should be_true
+    a_def = mod.lookup_first_def("foo", false).should_not be_nil
+    a_def.raises?.should be_true
   end
 
   it "marks method that calls another method that raises as raises, recursively" do

--- a/spec/std/crystal/event_loop/polling/arena_spec.cr
+++ b/spec/std/crystal/event_loop/polling/arena_spec.cr
@@ -67,7 +67,7 @@ describe Crystal::EventLoop::Polling::Arena do
       called = 0
 
       2.times do
-        arena.get(index.not_nil!) do |ptr|
+        arena.get(index) do |ptr|
           ptr.should eq(pointer)
           ptr.value.should eq(654321)
           called += 1

--- a/spec/std/crystal/event_loop/polling/arena_spec.cr
+++ b/spec/std/crystal/event_loop/polling/arena_spec.cr
@@ -23,9 +23,9 @@ describe Crystal::EventLoop::Polling::Arena do
       called.should eq(1)
 
       pointer.should_not be_nil
-      index.should_not be_nil
+      index = index.should_not be_nil
 
-      arena.get(index.not_nil!) do |ptr|
+      arena.get(index) do |ptr|
         ptr.should eq(pointer)
       end
     end
@@ -40,9 +40,10 @@ describe Crystal::EventLoop::Polling::Arena do
       indexes.size.should eq(32)
 
       indexes.each do |index|
-        arena.get(index.not_nil!) do |pointer|
+        index = index.should_not(be_nil)
+        arena.get(index) do |pointer|
           pointer.should eq(pointer)
-          pointer.value.should eq(index.not_nil!.index)
+          pointer.value.should eq(index.index)
         end
       end
     end

--- a/spec/std/crystal/pointer_linked_list_spec.cr
+++ b/spec/std/crystal/pointer_linked_list_spec.cr
@@ -147,10 +147,10 @@ describe Crystal::PointerLinkedList do
 
       typeof(obj).should eq(Pointer(TestedObject)?)
 
-      obj.should_not be_nil
+      obj = obj.should_not be_nil
       obj.should eq(pointerof(x))
-      obj.not_nil!.value.next.should eq(Pointer(TestedObject).null)
-      obj.not_nil!.value.previous.should eq(Pointer(TestedObject).null)
+      obj.value.next.should eq(Pointer(TestedObject).null)
+      obj.value.previous.should eq(Pointer(TestedObject).null)
 
       ExpectOrderHelper.by_next(y, z, w, y)
       ExpectOrderHelper.by_previous(y, w, z, y)
@@ -183,10 +183,10 @@ describe Crystal::PointerLinkedList do
 
       typeof(obj).should eq(Pointer(TestedObject)?)
 
-      obj.should_not be_nil
+      obj = obj.should_not be_nil
       obj.should eq(pointerof(w))
-      obj.not_nil!.value.next.should eq(Pointer(TestedObject).null)
-      obj.not_nil!.value.previous.should eq(Pointer(TestedObject).null)
+      obj.value.next.should eq(Pointer(TestedObject).null)
+      obj.value.previous.should eq(Pointer(TestedObject).null)
 
       ExpectOrderHelper.by_next(x, y, z, x)
       ExpectOrderHelper.by_previous(x, z, y, x)

--- a/spec/std/http/cookie_spec.cr
+++ b/spec/std/http/cookie_spec.cr
@@ -10,9 +10,7 @@ private def parse_first_cookie(header)
 end
 
 private def parse_set_cookie(header)
-  cookie = HTTP::Cookie::Parser.parse_set_cookie(header)
-  cookie.should_not be_nil
-  cookie.not_nil!
+  HTTP::Cookie::Parser.parse_set_cookie(header).should_not be_nil
 end
 
 # invalid printable ascii characters, non-printable ascii characters and control characters

--- a/spec/std/openssl/ssl/server_spec.cr
+++ b/spec/std/openssl/ssl/server_spec.cr
@@ -60,9 +60,7 @@ describe OpenSSL::SSL::Server do
 
       OpenSSL::SSL::Server.open tcp_server, server_context do |server|
         spawn do
-          client = server.accept?
-          client.should be_a(OpenSSL::SSL::Socket::Server)
-          client = client.not_nil!
+          client = server.accept?.should be_a(OpenSSL::SSL::Socket::Server)
           client.gets.should eq "Hello, SSL!"
           client.puts "Hello back, SSL!"
           client.close

--- a/spec/std/slice_spec.cr
+++ b/spec/std/slice_spec.cr
@@ -127,17 +127,14 @@ describe "Slice" do
   it "does []? with start and count" do
     slice = Slice.new(4) { |i| i + 1 }
 
-    slice1 = slice[1, 2]?
-    slice1.should_not be_nil
-    slice1 = slice1.not_nil!
+    slice1 = slice[1, 2]?.should_not be_nil
     slice1.size.should eq(2)
     slice1.to_unsafe.should eq(slice.to_unsafe + 1)
     slice1[0].should eq(2)
     slice1[1].should eq(3)
 
     slice2 = slice[-1, 1]?
-    slice2.should_not be_nil
-    slice2 = slice2.not_nil!
+    slice2 = slice2.should_not be_nil
     slice2.size.should eq(1)
     slice2.to_unsafe.should eq(slice.to_unsafe + 3)
 
@@ -149,9 +146,7 @@ describe "Slice" do
   it "does []? with range" do
     slice = Slice.new(4) { |i| i + 1 }
 
-    slice1 = slice[1..2]?
-    slice1.should_not be_nil
-    slice1 = slice1.not_nil!
+    slice1 = slice[1..2]?.should_not be_nil
     slice1.size.should eq(2)
     slice1.to_unsafe.should eq(slice.to_unsafe + 1)
     slice1[0].should eq(2)

--- a/spec/std/socket/addrinfo_spec.cr
+++ b/spec/std/socket/addrinfo_spec.cr
@@ -103,7 +103,7 @@ describe Socket::Addrinfo, tags: "network" do
       it ".new (deprecated)" do
         error = Socket::Addrinfo::Error.new(LibC::EAI_NONAME, "No address found", "foobar.com")
         error.os_error.should eq Errno.new(LibC::EAI_NONAME)
-        error.message.not_nil!.should eq "Hostname lookup for foobar.com failed: No address found"
+        error.message.should eq "Hostname lookup for foobar.com failed: No address found"
       end
     {% end %}
   end

--- a/spec/std/socket/socket_spec.cr
+++ b/spec/std/socket/socket_spec.cr
@@ -90,7 +90,7 @@ describe Socket, tags: "network" do
     server.listen
     address = Socket::IPAddress.new("127.0.0.1", port)
     spawn do
-      client = server.not_nil!.accept
+      client = server.accept
       client.gets.should eq "foo"
       client.puts "bar"
     ensure
@@ -198,7 +198,7 @@ describe Socket, tags: "network" do
       server.listen
 
       spawn do
-        client = server.not_nil!.accept
+        client = server.accept
         client.sync = false
         client << "foo"
         client.flush

--- a/spec/std/socket/unix_server_spec.cr
+++ b/spec/std/socket/unix_server_spec.cr
@@ -126,8 +126,7 @@ describe UNIXServer do
       with_tempfile("unix_server-accept_.sock") do |path|
         UNIXServer.open(path) do |server|
           UNIXSocket.open(path) do |_|
-            client = server.accept?.not_nil!
-            client.should be_a(UNIXSocket)
+            client = server.accept?.should be_a(UNIXSocket)
             client.close
           end
         end

--- a/spec/std/system/group_spec.cr
+++ b/spec/std/system/group_spec.cr
@@ -47,9 +47,9 @@ describe System::Group do
 
   describe ".find_by?(*, name)" do
     it "returns a group by name" do
-      group = System::Group.find_by?(name: GROUP_NAME).not_nil!
+      group = System::Group.find_by?(name: GROUP_NAME)
 
-      group.should be_a(System::Group)
+      group = group.should be_a(System::Group)
       group.name.should eq(GROUP_NAME)
       group.id.should eq(GROUP_ID)
     end
@@ -62,9 +62,9 @@ describe System::Group do
 
   describe ".find_by?(*, id)" do
     it "returns a group by id" do
-      group = System::Group.find_by?(id: GROUP_ID).not_nil!
+      group = System::Group.find_by?(id: GROUP_ID)
 
-      group.should be_a(System::Group)
+      group = group.should be_a(System::Group)
       group.id.should eq(GROUP_ID)
       group.name.should eq(GROUP_NAME)
     end

--- a/spec/std/system/user_spec.cr
+++ b/spec/std/system/user_spec.cr
@@ -58,9 +58,9 @@ describe System::User do
 
   describe ".find_by?(*, name)" do
     it "returns a user by name" do
-      user = System::User.find_by?(name: USER_NAME).not_nil!
+      user = System::User.find_by?(name: USER_NAME)
 
-      user.should be_a(System::User)
+      user = user.should be_a(System::User)
       normalized_username(user.username).should eq(normalized_username(USER_NAME))
       user.id.should eq(USER_ID)
     end
@@ -73,9 +73,9 @@ describe System::User do
 
   describe ".find_by?(*, id)" do
     it "returns a user by id" do
-      user = System::User.find_by?(id: USER_ID).not_nil!
+      user = System::User.find_by?(id: USER_ID)
 
-      user.should be_a(System::User)
+      user = user.should be_a(System::User)
       user.id.should eq(USER_ID)
       normalized_username(user.username).should eq(normalized_username(USER_NAME))
     end

--- a/spec/std/xml/reader_spec.cr
+++ b/spec/std/xml/reader_spec.cr
@@ -527,9 +527,9 @@ module XML
         reader.expand?.should be_nil
         reader.read # <root id="1">
         node = reader.expand?
-        node.should be_a(XML::Node)
-        node.not_nil!.attributes["id"].content.should eq("1")
-        node.not_nil!.xpath_node("child").should be_a(XML::Node)
+        node = node.should be_a(XML::Node)
+        node.attributes["id"].content.should eq("1")
+        node.xpath_node("child").should be_a(XML::Node)
       end
 
       it "is only available until the next read" do
@@ -537,11 +537,11 @@ module XML
         reader.read # <root>
         reader.read # <child>
         node = reader.expand?
-        node.should be_a(XML::Node)
-        node.not_nil!.xpath_node("subchild").should be_a(XML::Node)
+        node = node.should be_a(XML::Node)
+        node.xpath_node("subchild").should be_a(XML::Node)
         reader.read # <subchild/>
         reader.read # </child>
-        node.not_nil!.xpath_node("subchild").should be_nil
+        node.xpath_node("subchild").should be_nil
       end
     end
 


### PR DESCRIPTION
This is a bit of code cleanup. Many `not_nil!` calls in the spec suite are actually unnecessary.
Many are used in combination with type expectations such as `should(be_a)`, where we can easily use the resulting type restriction to lose the nil type.

Includes the following removals for `not_nil!` calls:

* Drop `not_nil!` when combined with `should_not(be_nil)`
* Replace `not_nil!` plus cast with `should(be_a)`
* Drop unnecessary `not_nil!`
* Drop `not_nil!` when combined with `be_a`
