### PR TITLE
Drop `update: true` from `msys2/setup-msys`

### DIFF
--- a/.github/workflows/mingw-w64-steps.yml
+++ b/.github/workflows/mingw-w64-steps.yml
@@ -27,7 +27,6 @@ jobs:
         uses: msys2/setup-msys2@fb197b72ce45fb24f17bf3f807a388985654d1f2 # v2.29.0
         with:
           msystem: ${{ inputs.msystem }}
-          update: true
           install: >-
             git
             make
@@ -87,7 +86,6 @@ jobs:
         uses: msys2/setup-msys2@fb197b72ce45fb24f17bf3f807a388985654d1f2 # v2.29.0
         with:
           msystem: ${{ inputs.msystem }}
-          update: true
           install: >-
             git
             make
@@ -119,7 +117,6 @@ jobs:
         uses: msys2/setup-msys2@fb197b72ce45fb24f17bf3f807a388985654d1f2 # v2.29.0
         with:
           msystem: ${{ inputs.msystem }}
-          update: true
           install: >-
             git
             make


### PR DESCRIPTION
MSYS2 uses a rolling release model, so pulling updates may upgrade packages to incompatible versions.

Without `update: true` the MSYS2 setup action installs packages from the install tarball, which is a snapshot tied to the action version. This enables reproducible runs.


https://github.com/msys2/setup-msys2#update