### PR TITLE
Document null-termination on `String#to_unsafe`

### DIFF
--- a/src/string.cr
+++ b/src/string.cr
@@ -5603,9 +5603,10 @@ class String
   # May contain invalid UTF-8 byte sequences; `#scrub` may be used to first
   # obtain a `String` that is guaranteed to be valid UTF-8.
   #
-  # The byte sequence at the pointer is always null-terminated (`string.to_unsafe[string.bytesize] == 0u8`), so it can be passed to C APIs that expect a
-  # NUL-terminated string. The string itself may also contain `\0` bytes in
-  # the middle; the terminator is not a reliable end-of-string marker for
+  # The byte sequence at the pointer is always null-terminated
+  # (`string.to_unsafe[string.bytesize] == 0u8`), so it can be passed to C APIs
+  # that expects a NUL-terminated string. The string itself may also contain `\0`
+  # bytes in the middle; the terminator is not a reliable end-of-string marker for
   # strings that may embed '\0' bytes (see `#check_no_null_byte` for testing that).
   def to_unsafe : UInt8*
     pointerof(@c)

--- a/src/string.cr
+++ b/src/string.cr
@@ -5602,6 +5602,12 @@ class String
   #
   # May contain invalid UTF-8 byte sequences; `#scrub` may be used to first
   # obtain a `String` that is guaranteed to be valid UTF-8.
+  #
+  # The byte sequence at the pointer is always null-terminated (one `\0` byte
+  # past `#bytesize`), so it can be passed to C APIs that expect a
+  # NUL-terminated string. The string itself may also contain `\0` bytes in
+  # the middle; the terminator is not a reliable end-of-string marker for
+  # strings that may embed zeros.
   def to_unsafe : UInt8*
     pointerof(@c)
   end

--- a/src/string.cr
+++ b/src/string.cr
@@ -5603,11 +5603,10 @@ class String
   # May contain invalid UTF-8 byte sequences; `#scrub` may be used to first
   # obtain a `String` that is guaranteed to be valid UTF-8.
   #
-  # The byte sequence at the pointer is always null-terminated (one `\0` byte
-  # past `#bytesize`), so it can be passed to C APIs that expect a
+  # The byte sequence at the pointer is always null-terminated (`string.to_unsafe[string.bytesize] == 0u8`), so it can be passed to C APIs that expect a
   # NUL-terminated string. The string itself may also contain `\0` bytes in
   # the middle; the terminator is not a reliable end-of-string marker for
-  # strings that may embed zeros.
+  # strings that may embed '\0' bytes (see `#check_no_null_byte` for testing that).
   def to_unsafe : UInt8*
     pointerof(@c)
   end


### PR DESCRIPTION
Closes #12483.

Adds an explicit note to `String#to_unsafe` that the returned pointer is always null-terminated (one `\0` byte past `#bytesize`), so it can be handed to C APIs that expect a NUL-terminated string — and a caveat that the terminator is not a reliable end-of-string marker for strings that may contain `\0` bytes in the middle.

The null terminator comes from the allocation in `String.new_with_capacity` (`src/string.cr:266`): `GC.malloc_atomic(capacity.to_u32 + HEADER_SIZE + 1)`. The `+ 1` is the trailing zero byte, which `GC.malloc_atomic` zero-initializes.

Doc-only change; no runtime behavior affected.