### PR TITLE
Add `after_initialize` method for `URI::Params::Serializable`

### DIFF
--- a/spec/std/json/serializable_spec.cr
+++ b/spec/std/json/serializable_spec.cr
@@ -5,6 +5,7 @@ require "big"
 require "big/json"
 require "uuid"
 require "uuid/json"
+require "uri/params/serializable"
 
 enum JSONSerializableEnum
   Zero
@@ -372,9 +373,10 @@ struct JSONAttrPersonWithYAML
   end
 end
 
-struct JSONAttrPersonWithYAMLInitializeHook
+struct JSONAttrPersonWithYAMLandURIParamsInitializeHook
   include JSON::Serializable
   include YAML::Serializable
+  include URI::Params::Serializable
 
   property name : String
   property age : Int32?
@@ -385,6 +387,7 @@ struct JSONAttrPersonWithYAMLInitializeHook
 
   @[JSON::Field(ignore: true)]
   @[YAML::Field(ignore: true)]
+  @[URI::Params::Field(ignore: true)]
   property msg : String?
 
   def after_initialize
@@ -1190,15 +1193,17 @@ describe "JSON::Serializable" do
     JSONAttrPersonWithYAML.from_yaml(person.to_yaml).should eq person
   end
 
-  it "yaml and json with after_initialize hook" do
-    person = JSONAttrPersonWithYAMLInitializeHook.new("Vasya", 30)
+  it "yaml, json and uri params with after_initialize hook" do
+    person = JSONAttrPersonWithYAMLandURIParamsInitializeHook.new("Vasya", 30)
     person.msg.should eq "Hello Vasya"
 
     person.to_json.should eq "{\"name\":\"Vasya\",\"age\":30}"
     person.to_yaml.should eq "---\nname: Vasya\nage: 30\n"
+    person.to_www_form.should eq "name=Vasya&Age=30"
 
-    JSONAttrPersonWithYAMLInitializeHook.from_json(person.to_json).msg.should eq "Hello Vasya"
-    JSONAttrPersonWithYAMLInitializeHook.from_yaml(person.to_yaml).msg.should eq "Hello Vasya"
+    JSONAttrPersonWithYAMLandURIParamsInitializeHook.from_json(person.to_json).msg.should eq "Hello Vasya"
+    JSONAttrPersonWithYAMLandURIParamsInitializeHook.from_yaml(person.to_yaml).msg.should eq "Hello Vasya"
+    JSONAttrPersonWithYAMLandURIParamsInitializeHook.from_www_form(person.to_www_form).msg.should eq "Hello Vasya"
   end
 
   it "json with selective serialization" do

--- a/src/uri/params/serializable.cr
+++ b/src/uri/params/serializable.cr
@@ -62,6 +62,27 @@ struct URI::Params
   # including type, which means the default constructor (`def initialize; end`)
   # is absent unless explicitly defined by the user, even when all instance
   # variables have a default initializer.
+  # ## `after_initialize` method
+  #
+  # `#after_initialize` is a method that runs after an instance is deserialized
+  # from URI::Params. It can be used as a hook to post-process the initialized object.
+  #
+  # Example:
+  # ```
+  # require "uri/params/serializable"
+  #
+  # class Person
+  #   include URI::Params::Serializable
+  #   getter name : String
+  #
+  #   def after_initialize
+  #     @name = @name.upcase
+  #   end
+  # end
+  #
+  # person = Person.from_www_form("name=Jane")
+  # person.name # => "JANE"
+  # ```
   module Serializable
     macro included
       def self.from_www_form(params : ::String)
@@ -112,7 +133,11 @@ struct URI::Params
             {% end %}
           {% end %}
         {% end %}
+        after_initialize
       end
+    end
+
+    protected def after_initialize
     end
 
     def to_www_form(*, space_to_plus : Bool = true) : String


### PR DESCRIPTION
Adds the `after_initialize` method for `URI::Params::Serializable`. 

Spec currently fails due to missing `ignore` property of `URI::Params::Field` for `@msg`.

Requires https://github.com/crystal-lang/crystal/issues/16873 to be fixed so the spec can successfully pass.