### PR TITLE
Fix: don't parse debug sections from bare threads

### DIFF
--- a/src/crystal/event_loop.cr
+++ b/src/crystal/event_loop.cr
@@ -56,7 +56,7 @@ abstract class Crystal::EventLoop
   @[AlwaysInline]
   def self.current? : self | Nil
     {% if flag?(:execution_context) %}
-      Fiber::ExecutionContext.current.event_loop
+      Fiber::ExecutionContext.current?.try(&.event_loop)
     {% else %}
       Crystal::Scheduler.event_loop?
     {% end %}

--- a/src/exception/call_stack/elf.cr
+++ b/src/exception/call_stack/elf.cr
@@ -18,6 +18,11 @@ struct Exception::CallStack
     end
   end
 
+  def self.load_debug_info : Nil
+    # FIXME: Crystal::ELF depends on the event loop (it shouldn't)
+    previous_def if Crystal::EventLoop.current?
+  end
+
   protected def self.load_debug_info_impl : Nil
     program = Process.executable_path
     return unless program && File::Info.readable? program

--- a/src/exception/call_stack/mach_o.cr
+++ b/src/exception/call_stack/mach_o.cr
@@ -15,6 +15,11 @@ struct Exception::CallStack
 
   @@image_slide : LibC::Long?
 
+  def self.load_debug_info : Nil
+    # FIXME: Crystal::Mach-O depends on the event loop (it shouldn't)
+    previous_def if Crystal::EventLoop.current?
+  end
+
   protected def self.load_debug_info_impl : Nil
     locate_dsym_bundle do |image|
       read_dwarf_sections(image)

--- a/src/exception/call_stack/pe.cr
+++ b/src/exception/call_stack/pe.cr
@@ -9,6 +9,11 @@ struct Exception::CallStack
 
   @@coff_symbols : Hash(Int32, Array(Crystal::PE::COFFSymbol))?
 
+  def self.load_debug_info : Nil
+    # FIXME: Crystal::PE depends on the event loop (it shouldn't)
+    previous_def if Crystal::EventLoop.current?
+  end
+
   protected def self.load_debug_info_impl : Nil
     program = Process.executable_path
     return unless program && File::Info.readable? program


### PR DESCRIPTION
The `Crystal::ELF`, `Crystal::MachO`, `Crystal::PE` try to open and read the executable file, which requires a `Crystal::EventLoop` instance. While an event loop is usually available, there are bare threads (e.g. sysmon), or we may raise and try to print an exception's backtrace even before an event loop has been be created.

This patch skips loading the debug info when there isn't an event loop.

A better patch would be for the aforementioned types to not use the event loop, but for now that will do. The backtrace will only print symbols instead of a nice backtrace, but that's better than raising again and failing to print the original backtrace (if not the error).

Follow up to #16896
Related to #16871