### PR TITLE
Fix formatting whitespace in ternary `if` with trailing comments

### DIFF
--- a/spec/compiler/formatter/formatter_spec.cr
+++ b/spec/compiler/formatter/formatter_spec.cr
@@ -184,6 +184,9 @@ describe Crystal::Formatter do
 
   assert_format "1 ? 2 : 3"
   assert_format "1 ?\n  2    :   \n 3", "1 ? 2 : 3"
+  assert_format "1  ?  # b\n  2    :   # c\n 3", "1 ? # b\n2 : # c\n3"
+  assert_format "1  ?  # b\n  2       # c\n : 3", "1 ? # b\n2   # c\n: 3"
+  assert_format "1  ?# b\n  2 :# c\n3", "1 ? # b\n2 : # c\n3"
 
   assert_format "1   if   2", "1 if 2"
   assert_format "1   unless   2", "1 unless 2"

--- a/src/compiler/crystal/tools/formatter.cr
+++ b/src/compiler/crystal/tools/formatter.cr
@@ -1283,13 +1283,13 @@ module Crystal
     def visit(node : If)
       if node.ternary?
         accept node.cond
-        skip_space_or_newline
-        write_token " ", :OP_QUESTION, " "
-        skip_space_or_newline
+        skip_space_or_newline || write " "
+        write_token :OP_QUESTION
+        skip_space_or_newline || write " "
         accept node.then
-        skip_space_or_newline
-        write_token " ", :OP_COLON, " "
-        skip_space_or_newline
+        skip_space_or_newline || write " "
+        write_token :OP_COLON
+        skip_space_or_newline || write " "
         accept node.else
         return false
       end


### PR DESCRIPTION
`skip_space_or_newline` always writes a space if it finds a comment. That would duplicate the space that's already written explicitly.