### PR TITLE
Remove deprecated overload for `IO::Memory` to match positional arg [fixup #16858]

### DIFF
--- a/src/io/memory.cr
+++ b/src/io/memory.cr
@@ -56,7 +56,7 @@ class IO::Memory < IO
 
   # :ditto:
   @[Deprecated("Use `IO::Memory.new(Bytes, writable)` instead")]
-  def self.new(slice : Bytes, writeable writable) : self
+  def self.new(slice : Bytes, *, writeable writable) : self
     new slice, writable: writable
   end
 


### PR DESCRIPTION
Ref https://github.com/crystal-lang/crystal/pull/16858#issuecomment-4317762540