### PR TITLE
Revert "Refactor `Formatter` code for simplification"

### DIFF
--- a/spec/compiler/formatter/formatter_spec.cr
+++ b/spec/compiler/formatter/formatter_spec.cr
@@ -1241,6 +1241,7 @@ describe Crystal::Formatter do
   assert_format "class Foo\nx = 1\nend", "class Foo\n  x = 1\nend"
   assert_format "x  =   uninitialized   Int32", "x = uninitialized Int32"
   assert_format "x  :   Int32  =   1", "x : Int32 = 1"
+  assert_format "x : (Foo.class)?"
 
   assert_format "def foo\n@x  :  Int32\nend", "def foo\n  @x : Int32\nend"
   assert_format "def foo\n@x   =  uninitialized   Int32\nend", "def foo\n  @x = uninitialized Int32\nend"

--- a/src/compiler/crystal/tools/formatter.cr
+++ b/src/compiler/crystal/tools/formatter.cr
@@ -1258,21 +1258,37 @@ module Crystal
           break
         end
 
-        unless i == 0
-          skip_space_or_newline
-          write_token " ", :op_bar, " "
-          skip_space
-
-          if @token.type.newline?
-            write_line
-            write_indent(column)
-            next_token_skip_space_or_newline
-          end
-        end
-
         accept type
 
-        skip_space
+        last = last?(i, node.types)
+        if last
+          skip_space
+        else
+          skip_space_or_newline
+        end
+
+        while true
+          case @token.type
+          when .op_bar?
+            write " | "
+            next_token_skip_space
+            if @token.type.newline?
+              write_line
+              write_indent(column)
+              next_token_skip_space_or_newline
+            end
+          when .op_rparen?
+            if @paren_count > 0
+              @paren_count -= 1
+              write ")"
+              next_token_skip_space
+            else
+              break
+            end
+          else
+            break
+          end
+        end
       end
 
       check_close_paren


### PR DESCRIPTION
This partially reverts commit 9546b9f which introduced a regression bug in the formatter.

The reverted diff is subset of #16745, in particular changes from https://github.com/crystal-lang/crystal/pull/16745/changes/b29c22f11b8e848adb2cf8a9ef9e25217b9ee082?w=1

Resolves #16884
