### PR TITLE
Fix location of double splat named tuple typenode entry locations

### DIFF
--- a/spec/compiler/semantic/macro_spec.cr
+++ b/spec/compiler/semantic/macro_spec.cr
@@ -404,6 +404,35 @@ describe "Semantic: macro" do
           ex.to_s.should contain "error in line 5"
           ex.to_s.scan("error in line").size.should eq 1
         end
+
+        it "points to proper location of a raise on a TypeNode#keys NT element" do
+          ex = assert_error(<<-'CRYSTAL', "OH NO")
+            class Foo
+              def self.test(**args : **T) forall T
+                {% T.keys.each { |k| k.raise "OH NO" } %}
+              end
+            end
+
+            Foo.test foo: 1
+            CRYSTAL
+
+          ex.to_s.should contain "OH NO"
+          ex.to_s.should contain "error in line 7"
+          ex.to_s.should contain "error in line 3"
+          ex.to_s.scan("error in line 7").size.should eq 2
+        end
+
+        it "uses the MacroId's location when a method call on a MacroId proxies through StringLiteral" do
+          assert_no_errors <<-'CRYSTAL'
+            class Foo
+              def self.test(**args : **T) forall T
+                {% raise "expected key on line 7" unless T.keys.first.line_number == 7 %}
+              end
+            end
+
+            Foo.test foo: 1
+            CRYSTAL
+        end
       end
     end
 

--- a/src/compiler/crystal/macros/methods.cr
+++ b/src/compiler/crystal/macros/methods.cr
@@ -2018,8 +2018,8 @@ module Crystal
       when "stringify", "class_name", "symbolize"
         super
       else
-        value = StringLiteral.new(@value).interpret(method, args, named_args, block, interpreter, location)
-        value = MacroId.new(value.value) if value.is_a?(StringLiteral)
+        value = StringLiteral.new(@value).at(self).interpret(method, args, named_args, block, interpreter, location)
+        value = MacroId.new(value.value).at(self) if value.is_a?(StringLiteral)
         value
       end
     rescue UndefinedMacroMethodError
@@ -2142,7 +2142,7 @@ module Crystal
         interpret_check_args do
           type = self.type.instance_type
           if type.is_a?(NamedTupleInstanceType)
-            ArrayLiteral.map(type.entries) { |entry| MacroId.new(entry.name) }
+            ArrayLiteral.map(type.entries) { |entry| MacroId.new(entry.name).at(entry.loc) }
           else
             raise "undefined method 'keys' for TypeNode of type #{type} (must be a named tuple type)"
           end

--- a/src/compiler/crystal/semantic/bindings.cr
+++ b/src/compiler/crystal/semantic/bindings.cr
@@ -648,7 +648,7 @@ module Crystal
 
           node_type = node_type.virtual_type
 
-          entries << NamedArgumentType.new(named_arg.name, node_type)
+          entries << NamedArgumentType.new(named_arg.name, node_type, named_arg.location)
         end
 
         generic_type = instance_type.instantiate_named_args(entries)

--- a/src/compiler/crystal/semantic/call.cr
+++ b/src/compiler/crystal/semantic/call.cr
@@ -159,7 +159,7 @@ class Crystal::Call
 
             named_args_types ||= [] of NamedArgumentType
             raise "duplicate key: #{name}" if named_args_types.any? &.name.==(name)
-            named_args_types << NamedArgumentType.new(name, type)
+            named_args_types << NamedArgumentType.new(name, type, entry.loc)
           end
         when UnionType
           arg.raise "double splatting a union #{arg_type} is not yet supported"
@@ -180,6 +180,7 @@ class Crystal::Call
         named_args_types << NamedArgumentType.new(
           named_arg.name,
           named_arg.value.type(with_autocast: with_autocast),
+          named_arg.location,
         )
       end
     end

--- a/src/compiler/crystal/semantic/match.cr
+++ b/src/compiler/crystal/semantic/match.cr
@@ -125,7 +125,7 @@ module Crystal
 
     def remove_literals
       @arg_types.map!(&.remove_literal)
-      @named_arg_types.try &.map! { |arg| NamedArgumentType.new(arg.name, arg.type.remove_literal) }
+      @named_arg_types.try &.map! { |arg| NamedArgumentType.new(arg.name, arg.type.remove_literal, arg.loc) }
     end
   end
 

--- a/src/compiler/crystal/semantic/method_lookup.cr
+++ b/src/compiler/crystal/semantic/method_lookup.cr
@@ -51,12 +51,14 @@ require "../types"
 # multidispatch. However, we do need to analyze it to check if there's an ambiguity.
 
 module Crystal
-  record NamedArgumentType, name : String, type : Type do
+  record NamedArgumentType, name : String, type : Type, loc : Location? = nil do
     def self.from_args(named_args : Array(NamedArgument)?, with_autocast = false)
       named_args.try &.map do |named_arg|
-        new(named_arg.name, named_arg.value.type(with_autocast: with_autocast))
+        new(named_arg.name, named_arg.value.type(with_autocast: with_autocast), named_arg.location)
       end
     end
+
+    def_equals_and_hash name, type
   end
 
   record CallSignature,
@@ -312,7 +314,7 @@ module Crystal
             end
 
             matched_named_arg_types ||= [] of NamedArgumentType
-            matched_named_arg_types << NamedArgumentType.new(named_arg.name, match_arg_type)
+            matched_named_arg_types << NamedArgumentType.new(named_arg.name, match_arg_type, named_arg.loc)
           else
             # If there's a double splat it's OK, the named arg will be put there
             if a_def.double_splat
@@ -331,7 +333,7 @@ module Crystal
               end
 
               matched_named_arg_types ||= [] of NamedArgumentType
-              matched_named_arg_types << NamedArgumentType.new(named_arg.name, match_arg_type)
+              matched_named_arg_types << NamedArgumentType.new(named_arg.name, match_arg_type, named_arg.loc)
 
               found_unmatched_named_arg = true
               next

--- a/src/compiler/crystal/semantic/type_guess_visitor.cr
+++ b/src/compiler/crystal/semantic/type_guess_visitor.cr
@@ -852,7 +852,7 @@ module Crystal
         guessed_arg_type = guess_type(named_arg.value)
         return unless guessed_arg_type
 
-        NamedArgumentType.new(named_arg.name, guessed_arg_type)
+        NamedArgumentType.new(named_arg.name, guessed_arg_type, named_arg.location)
       end)
 
       signature = CallSignature.new(

--- a/src/compiler/crystal/semantic/type_lookup.cr
+++ b/src/compiler/crystal/semantic/type_lookup.cr
@@ -197,7 +197,7 @@ class Crystal::Type
             subnode.raise "can't use #{type} as a generic type argument yet, use a more specific type"
           end
 
-          entries << NamedArgumentType.new(named_arg.name, type.virtual_type)
+          entries << NamedArgumentType.new(named_arg.name, type.virtual_type, named_arg.location)
         end
 
         begin

--- a/src/compiler/crystal/semantic/type_merge.cr
+++ b/src/compiler/crystal/semantic/type_merge.cr
@@ -294,7 +294,7 @@ module Crystal
         name = self_entry.name
         other_type = type2.name_type(name)
         merged_type = merge!(self_entry.type, other_type).as(Type)
-        NamedArgumentType.new(name, merged_type)
+        NamedArgumentType.new(name, merged_type, self_entry.loc)
       end
 
       type1.program.named_tuple_of(merged_entries)

--- a/src/compiler/crystal/types.cr
+++ b/src/compiler/crystal/types.cr
@@ -2626,7 +2626,7 @@ module Crystal
 
     def replace_type_parameters(instance)
       new_entries = entries.map do |entry|
-        NamedArgumentType.new(entry.name, entry.type.replace_type_parameters(instance))
+        NamedArgumentType.new(entry.name, entry.type.replace_type_parameters(instance), entry.loc)
       end
       program.named_tuple_of(new_entries)
     end


### PR DESCRIPTION
Previously, code that raised an exception off of a double splat named tuple typenode key would fallback to that of the macro raise. E.g.

```cr
def test(**args : **T) forall T
  {% T.keys.first.raise "Oh noes" %}
end

test foo: 1, bar: 2
```
Would raise:
```txt
In test.cr:2:3

 2 | {% T.keys.first.raise "Oh noes" %}
     ^
Error: Oh noes
```
This PR adds a new `loc` field to the typed entry record so that the location of each related node can be passed thru to the array returned via `TypeNode#keys` such that the same code now raises:
```txt
In test.cr:5:6

 5 | test foo: 1, bar: 2
          ^
Error: Oh noes
```
