### PR TITLE
Add `HTTP::Headers#to_json` and `#to_yaml`

### DIFF
--- a/spec/std/http/headers_spec.cr
+++ b/spec/std/http/headers_spec.cr
@@ -1,5 +1,7 @@
 require "spec"
 require "http/headers"
+require "json"
+require "yaml"
 
 describe HTTP::Headers do
   it "is empty" do
@@ -153,6 +155,24 @@ describe HTTP::Headers do
   it "#serialize" do
     headers = HTTP::Headers{"Foo_quux" => "bar", "Baz-Quux" => ["a", "b"]}
     headers.serialize.should eq("Foo_quux: bar\r\nBaz-Quux: a\r\nBaz-Quux: b\r\n")
+  end
+
+  describe "serializes" do
+    it "#to_json" do
+      HTTP::Headers{"Foo_quux" => "bar", "Baz-Quux" => ["a", "b"]}.to_json.should eq <<-JSON
+      {"Foo_quux":"bar","Baz-Quux":["a","b"]}
+      JSON
+    end
+
+    it "#to_yaml" do
+      HTTP::Headers{"Foo_quux" => "bar", "Baz-Quux" => ["a", "b"]}.to_yaml.should eq <<-YAML
+      ---
+      Foo_quux: bar
+      Baz-Quux:
+      - a
+      - b\n
+      YAML
+    end
   end
 
   describe "#merge!" do

--- a/spec/std/http/headers_spec.cr
+++ b/spec/std/http/headers_spec.cr
@@ -2,6 +2,7 @@ require "spec"
 require "http/headers"
 require "json"
 require "yaml"
+require "../../support/wasm32"
 
 describe HTTP::Headers do
   it "is empty" do
@@ -164,7 +165,7 @@ describe HTTP::Headers do
       JSON
     end
 
-    it "#to_yaml" do
+    pending_wasm32 "#to_yaml" do
       HTTP::Headers{"Foo_quux" => "bar", "Baz-Quux" => ["a", "b"]}.to_yaml.should eq <<-YAML
       ---
       Foo_quux: bar

--- a/src/http/headers.cr
+++ b/src/http/headers.cr
@@ -46,6 +46,14 @@ struct HTTP::Headers
 
       byte
     end
+
+    def to_json_object_key
+      name
+    end
+
+    def to_yaml(builder : YAML::Nodes::Builder)
+      name.to_yaml(builder)
+    end
   end
 
   def initialize
@@ -340,6 +348,14 @@ struct HTTP::Headers
         io << name << ": " << value << "\r\n"
       end
     end
+  end
+
+  def to_json(builder : JSON::Builder) : Nil
+    @hash.to_json(builder)
+  end
+
+  def to_yaml(builder : YAML::Nodes::Builder) : Nil
+    @hash.to_yaml(builder)
   end
 
   def valid_value?(value : String) : Bool


### PR DESCRIPTION
This patch fixes a regression on an undocumented behaviour, introduced in #16637. It also adds serialization for `HTTP::Headers` as properly documented feature.

Fixes #16886
