### PR TITLE
Fix parse parenthesized expression in block arg assignment

### DIFF
--- a/spec/compiler/formatter/formatter_spec.cr
+++ b/spec/compiler/formatter/formatter_spec.cr
@@ -1852,6 +1852,7 @@ describe Crystal::Formatter do
   assert_format "foo.bar += \n1", "foo.bar +=\n  1"
   assert_format "->{}", "-> { }"
   assert_format "foo &.[a] = 1"
+  assert_format "x(&.y = (a.b))" # 16875
   assert_format "[\n  # foo\n  1,\n\n  # bar\n  2,\n]"
   assert_format "[c.x]\n  .foo"
   assert_format "foo([\n  1,\n  2,\n  3,\n])"

--- a/spec/compiler/parser/parser_spec.cr
+++ b/spec/compiler/parser/parser_spec.cr
@@ -667,6 +667,7 @@ module Crystal
     it_parses "foo &.block[]", Call.new("foo", block: Block.new([Var.new("__arg0")], Call.new(Call.new(Var.new("__arg0"), "block"), "[]")))
     it_parses "foo &.block[0]", Call.new("foo", block: Block.new([Var.new("__arg0")], Call.new(Call.new(Var.new("__arg0"), "block"), "[]", 0.int32)))
     it_parses "foo &.block=(0)", Call.new("foo", block: Block.new([Var.new("__arg0")], Call.new(Var.new("__arg0"), "block=", 0.int32)))
+    it_parses "foo &.block = (0)", Call.new("foo", block: Block.new([Var.new("__arg0")], Call.new(Var.new("__arg0"), "block=", Expressions.new([0.int32] of ASTNode).tap(&.keyword = :paren)))) # 16875
     it_parses "foo &.block = 0", Call.new("foo", block: Block.new([Var.new("__arg0")], Call.new(Var.new("__arg0"), "block=", 0.int32)))
     it_parses "foo &.block[] = 1", Call.new("foo", block: Block.new([Var.new("__arg0")], Call.new(Call.new(Var.new("__arg0"), "block"), "[]=", 1.int32)))
     it_parses "foo &.block[0] = 1", Call.new("foo", block: Block.new([Var.new("__arg0")], Call.new(Call.new(Var.new("__arg0"), "block"), "[]=", 0.int32, 1.int32)))

--- a/src/compiler/crystal/syntax/parser.cr
+++ b/src/compiler/crystal/syntax/parser.cr
@@ -1660,8 +1660,10 @@ module Crystal
         if @token.type.op_eq?
           unexpected_token unless can_be_assigned?(call)
 
-          next_token_skip_space
+          next_token
+
           if @token.type.op_lparen?
+            skip_space
             next_token_skip_space
             exp = parse_op_assign
             check :OP_RPAREN
@@ -1670,6 +1672,7 @@ module Crystal
             call.args = [exp] of ASTNode
             call = parse_atomic_method_suffix call, location
           else
+            skip_space
             exp = parse_op_assign
             call.name = "#{call.name}="
             call.args = [exp] of ASTNode


### PR DESCRIPTION
If there is space after the method name, parenthesis should be considered the start of a parenthesized expression, not parenthesis of the method call.
This patch ensures that for calls in a block arg.

Resolves #16875
