### PR TITLE
[Backport release/1.20] Refactor `Exception::CallStack` for better boundaries

### DIFF
--- a/src/exception/call_stack.cr
+++ b/src/exception/call_stack.cr
@@ -123,5 +123,13 @@ end
 {% elsif flag?(:wasm32) %}
   require "./call_stack/null"
 {% else %}
+  {% if flag?(:darwin) %}
+    require "./call_stack/mach_o"
+  {% elsif flag?(:win32) %}
+    require "./call_stack/pe"
+  {% else %}
+    require "./call_stack/elf"
+  {% end %}
+  require "./call_stack/dwarf"
   require "./call_stack/libunwind"
 {% end %}

--- a/src/exception/call_stack/dwarf.cr
+++ b/src/exception/call_stack/dwarf.cr
@@ -1,19 +1,8 @@
 require "crystal/dwarf"
-{% if flag?(:darwin) %}
-  require "./mach_o"
-{% else %}
-  require "./elf"
-{% end %}
 
 struct Exception::CallStack
   @@dwarf_line_numbers : Crystal::DWARF::LineNumbers?
   @@dwarf_function_names : Array(Tuple(LibC::SizeT, LibC::SizeT, String))?
-
-  {% if flag?(:win32) %}
-    @@coff_symbols : Hash(Int32, Array(Crystal::PE::COFFSymbol))?
-  {% end %}
-
-  # :nodoc:
 
   protected def self.decode_line_number(pc)
     if ln = @@dwarf_line_numbers
@@ -29,6 +18,48 @@ struct Exception::CallStack
       fn.each do |(low_pc, high_pc, function_name)|
         return function_name if low_pc <= pc <= high_pc
       end
+    end
+  end
+
+  protected def self.read_dwarf_sections(image, base_address) : Nil
+    line_strings = image.read_section?(DEBUG_LINE_STR) do |sh, io|
+      Crystal::DWARF::Strings.new(io, sh.offset, sh.size)
+    end
+
+    strings = image.read_section?(DEBUG_STR) do |sh, io|
+      Crystal::DWARF::Strings.new(io, sh.offset, sh.size)
+    end
+
+    image.read_section?(DEBUG_LINE) do |sh, io|
+      @@dwarf_line_numbers = Crystal::DWARF::LineNumbers.new(io, sh.size, base_address, strings, line_strings)
+    end
+
+    abbrevs_tables = image.read_section?(DEBUG_ABBREV) do |sh, io|
+      all = {} of Int64 => Array(Crystal::DWARF::Abbrev)
+      while (offset = io.pos - sh.offset) < sh.size
+        all[offset] = Crystal::DWARF::Abbrev.read(io)
+      end
+      all
+    end
+
+    image.read_section?(DEBUG_INFO) do |sh, io|
+      names = [] of {LibC::SizeT, LibC::SizeT, String}
+
+      while (offset = io.pos - sh.offset) < sh.size
+        info = Crystal::DWARF::Info.new(io, offset)
+
+        if abbrevs_tables
+          if abbreviations = abbrevs_tables[info.debug_abbrev_offset]?
+            info.abbreviations = abbreviations
+          end
+        end
+
+        parse_function_names_from_dwarf(info, strings, line_strings) do |low_pc, high_pc, name|
+          names << {low_pc + base_address, high_pc + base_address, name}
+        end
+      end
+
+      @@dwarf_function_names = names
     end
   end
 

--- a/src/exception/call_stack/dwarf.cr
+++ b/src/exception/call_stack/dwarf.cr
@@ -21,7 +21,7 @@ struct Exception::CallStack
     end
   end
 
-  protected def self.read_dwarf_sections(image, base_address) : Nil
+  protected def self.read_dwarf_sections(image, base_address = 0_u64) : Nil
     line_strings = image.read_section?(DEBUG_LINE_STR) do |sh, io|
       Crystal::DWARF::Strings.new(io, sh.offset, sh.size)
     end

--- a/src/exception/call_stack/elf.cr
+++ b/src/exception/call_stack/elf.cr
@@ -5,7 +5,7 @@ require "crystal/elf"
 
 struct Exception::CallStack
   DEBUG_LINE_STR = ".debug_line_str"
-  DEBUG_STR      = ".debug_line_str"
+  DEBUG_STR      = ".debug_str"
   DEBUG_LINE     = ".debug_line"
   DEBUG_ABBREV   = ".debug_abbrev"
   DEBUG_INFO     = ".debug_info"

--- a/src/exception/call_stack/elf.cr
+++ b/src/exception/call_stack/elf.cr
@@ -1,107 +1,55 @@
-{% if flag?(:win32) %}
-  require "crystal/pe"
-{% else %}
-  require "crystal/elf"
-  {% unless flag?(:wasm32) %}
-    require "c/link"
-  {% end %}
+require "crystal/elf"
+{% unless flag?(:wasm32) %}
+  require "c/link"
 {% end %}
 
 struct Exception::CallStack
-  {% unless flag?(:win32) %}
-    private struct DlPhdrData
-      getter program : String
-      property base_address : LibC::Elf_Addr = 0
+  DEBUG_LINE_STR = ".debug_line_str"
+  DEBUG_STR      = ".debug_line_str"
+  DEBUG_LINE     = ".debug_line"
+  DEBUG_ABBREV   = ".debug_abbrev"
+  DEBUG_INFO     = ".debug_info"
 
-      def initialize(@program : String)
-      end
+  private struct DlPhdrData
+    getter program : String
+    property base_address : LibC::Elf_Addr = 0
+
+    def initialize(@program : String)
     end
-  {% end %}
+  end
 
   protected def self.load_debug_info_impl : Nil
     program = Process.executable_path
     return unless program && File::Info.readable? program
 
-    {% if flag?(:win32) %}
-      if LibC.GetModuleHandleExW(LibC::GET_MODULE_HANDLE_EX_FLAG_UNCHANGED_REFCOUNT, nil, out hmodule) != 0
-        self.read_dwarf_sections(program, hmodule.address)
-      end
-    {% else %}
-      data = DlPhdrData.new(program)
+    data = DlPhdrData.new(program)
 
-      phdr_callback = LibC::DlPhdrCallback.new do |info, size, data|
-        # `dl_iterate_phdr` does not always visit the current program first; on
-        # Android the first object is `/system/bin/linker64`, the second is the
-        # full program path (not the empty string), so we check both here
-        name_c_str = info.value.name
-        if name_c_str && (name_c_str.value == 0 || LibC.strcmp(name_c_str, data.as(DlPhdrData*).value.program) == 0)
-          # The first entry is the header for the current program.
-          # Note that we avoid allocating here and just store the base address
-          # to be passed to self.read_dwarf_sections when dl_iterate_phdr returns.
-          # Calling self.read_dwarf_sections from this callback may lead to reallocations
-          # and deadlocks due to the internal lock held by dl_iterate_phdr (#10084).
-          data.as(DlPhdrData*).value.base_address = info.value.addr
-          1
-        else
-          0
-        end
+    phdr_callback = LibC::DlPhdrCallback.new do |info, size, data|
+      # `dl_iterate_phdr` does not always visit the current program first; on
+      # Android the first object is `/system/bin/linker64`, the second is the
+      # full program path (not the empty string), so we check both here
+      name_c_str = info.value.name
+      if name_c_str && (name_c_str.value == 0 || LibC.strcmp(name_c_str, data.as(DlPhdrData*).value.program) == 0)
+        # The first entry is the header for the current program.
+        # Note that we avoid allocating here and just store the base address
+        # to be passed to self.read_dwarf_sections when dl_iterate_phdr returns.
+        # Calling self.read_dwarf_sections from this callback may lead to reallocations
+        # and deadlocks due to the internal lock held by dl_iterate_phdr (#10084).
+        data.as(DlPhdrData*).value.base_address = info.value.addr
+        1
+      else
+        0
       end
+    end
 
-      LibC.dl_iterate_phdr(phdr_callback, pointerof(data))
-      self.read_dwarf_sections(data.program, data.base_address)
-    {% end %}
+    LibC.dl_iterate_phdr(phdr_callback, pointerof(data))
+
+    Crystal::ELF.open(data.program) do |image|
+      read_dwarf_sections(image, data.base_address)
+    end
   rescue ex
     @@dwarf_line_numbers = nil
     @@dwarf_function_names = nil
-  end
-
-  protected def self.read_dwarf_sections(program, base_address = 0)
-    {{ flag?(:win32) ? Crystal::PE : Crystal::ELF }}.open(program) do |image|
-      {% if flag?(:win32) %}
-        base_address -= image.original_image_base
-        @@coff_symbols = image.coff_symbols
-      {% end %}
-
-      line_strings = image.read_section?(".debug_line_str") do |sh, io|
-        Crystal::DWARF::Strings.new(io, sh.offset, sh.size)
-      end
-
-      strings = image.read_section?(".debug_str") do |sh, io|
-        Crystal::DWARF::Strings.new(io, sh.offset, sh.size)
-      end
-
-      image.read_section?(".debug_line") do |sh, io|
-        @@dwarf_line_numbers = Crystal::DWARF::LineNumbers.new(io, sh.size, base_address, strings, line_strings)
-      end
-
-      abbrevs_tables = image.read_section?(".debug_abbrev") do |sh, io|
-        all = {} of Int64 => Array(Crystal::DWARF::Abbrev)
-        while (offset = io.pos - sh.offset) < sh.size
-          all[offset] = Crystal::DWARF::Abbrev.read(io)
-        end
-        all
-      end
-
-      image.read_section?(".debug_info") do |sh, io|
-        names = [] of {LibC::SizeT, LibC::SizeT, String}
-
-        while (offset = io.pos - sh.offset) < sh.size
-          info = Crystal::DWARF::Info.new(io, offset)
-
-          if abbrevs_tables
-            if abbreviations = abbrevs_tables[info.debug_abbrev_offset]?
-              info.abbreviations = abbreviations
-            end
-          end
-
-          parse_function_names_from_dwarf(info, strings, line_strings) do |low_pc, high_pc, name|
-            names << {low_pc + base_address, high_pc + base_address, name}
-          end
-        end
-
-        @@dwarf_function_names = names
-      end
-    end
   end
 
   protected def self.decode_address(ip)

--- a/src/exception/call_stack/libunwind.cr
+++ b/src/exception/call_stack/libunwind.cr
@@ -5,12 +5,6 @@ require "c/stdio"
 require "c/string"
 require "../lib_unwind"
 
-{% if flag?(:darwin) || flag?(:bsd) || flag?(:linux) || flag?(:solaris) || flag?(:win32) %}
-  require "./dwarf"
-{% else %}
-  require "./null"
-{% end %}
-
 struct Exception::CallStack
   skip(__FILE__)
 

--- a/src/exception/call_stack/mach_o.cr
+++ b/src/exception/call_stack/mach_o.cr
@@ -8,7 +8,7 @@ end
 
 struct Exception::CallStack
   DEBUG_LINE_STR = "__debug_line_str"
-  DEBUG_STR      = "__debug_line_str"
+  DEBUG_STR      = "__debug_str"
   DEBUG_LINE     = "__debug_line"
   DEBUG_ABBREV   = "__debug_abbrev"
   DEBUG_INFO     = "__debug_info"

--- a/src/exception/call_stack/mach_o.cr
+++ b/src/exception/call_stack/mach_o.cr
@@ -17,7 +17,7 @@ struct Exception::CallStack
 
   protected def self.load_debug_info_impl : Nil
     locate_dsym_bundle do |image|
-      read_dwarf_sections(image, base_address: 0)
+      read_dwarf_sections(image)
     end
   rescue ex
     @@dwarf_line_numbers = nil

--- a/src/exception/call_stack/mach_o.cr
+++ b/src/exception/call_stack/mach_o.cr
@@ -7,57 +7,21 @@ lib LibC
 end
 
 struct Exception::CallStack
+  DEBUG_LINE_STR = "__debug_line_str"
+  DEBUG_STR      = "__debug_line_str"
+  DEBUG_LINE     = "__debug_line"
+  DEBUG_ABBREV   = "__debug_abbrev"
+  DEBUG_INFO     = "__debug_info"
+
   @@image_slide : LibC::Long?
 
   protected def self.load_debug_info_impl : Nil
-    read_dwarf_sections
+    locate_dsym_bundle do |image|
+      read_dwarf_sections(image, base_address: 0)
+    end
   rescue ex
     @@dwarf_line_numbers = nil
     @@dwarf_function_names = nil
-  end
-
-  protected def self.read_dwarf_sections : Nil
-    locate_dsym_bundle do |mach_o|
-      line_strings = mach_o.read_section?("__debug_line_str") do |sh, io|
-        Crystal::DWARF::Strings.new(io, sh.offset, sh.size)
-      end
-
-      strings = mach_o.read_section?("__debug_str") do |sh, io|
-        Crystal::DWARF::Strings.new(io, sh.offset, sh.size)
-      end
-
-      mach_o.read_section?("__debug_line") do |sh, io|
-        @@dwarf_line_numbers = Crystal::DWARF::LineNumbers.new(io, sh.size, strings: strings, line_strings: line_strings)
-      end
-
-      abbrevs_tables = mach_o.read_section?("__debug_abbrev") do |sh, io|
-        all = {} of Int64 => Array(Crystal::DWARF::Abbrev)
-        while (offset = io.pos - sh.offset) < sh.size
-          all[offset] = Crystal::DWARF::Abbrev.read(io)
-        end
-        all
-      end
-
-      mach_o.read_section?("__debug_info") do |sh, io|
-        names = [] of {LibC::SizeT, LibC::SizeT, String}
-
-        while (offset = io.pos - sh.offset) < sh.size
-          info = Crystal::DWARF::Info.new(io, offset)
-
-          if abbrevs_tables
-            if abbreviations = abbrevs_tables[info.debug_abbrev_offset]?
-              info.abbreviations = abbreviations
-            end
-          end
-
-          parse_function_names_from_dwarf(info, strings, line_strings) do |low_pc, high_pc, name|
-            names << {low_pc, high_pc, name}
-          end
-        end
-
-        @@dwarf_function_names = names
-      end
-    end
   end
 
   # DWARF uses fixed addresses but Darwin loads executables at a random

--- a/src/exception/call_stack/pe.cr
+++ b/src/exception/call_stack/pe.cr
@@ -1,0 +1,31 @@
+require "crystal/pe"
+
+struct Exception::CallStack
+  DEBUG_LINE_STR = ".debug_line_str"
+  DEBUG_STR      = ".debug_line_str"
+  DEBUG_LINE     = ".debug_line"
+  DEBUG_ABBREV   = ".debug_abbrev"
+  DEBUG_INFO     = ".debug_info"
+
+  @@coff_symbols : Hash(Int32, Array(Crystal::PE::COFFSymbol))?
+
+  protected def self.load_debug_info_impl : Nil
+    program = Process.executable_path
+    return unless program && File::Info.readable? program
+
+    ret = LibC.GetModuleHandleExW(LibC::GET_MODULE_HANDLE_EX_FLAG_UNCHANGED_REFCOUNT, nil, out hmodule)
+    return if ret == 0
+
+    Crystal::PE.open(program) do |image|
+      @@coff_symbols = image.coff_symbols
+      read_dwarf_sections(image, hmodule.address - image.original_image_base)
+    end
+  rescue ex
+    @@dwarf_line_numbers = nil
+    @@dwarf_function_names = nil
+  end
+
+  protected def self.decode_address(ip)
+    ip.address
+  end
+end

--- a/src/exception/call_stack/pe.cr
+++ b/src/exception/call_stack/pe.cr
@@ -2,7 +2,7 @@ require "crystal/pe"
 
 struct Exception::CallStack
   DEBUG_LINE_STR = ".debug_line_str"
-  DEBUG_STR      = ".debug_line_str"
+  DEBUG_STR      = ".debug_str"
   DEBUG_LINE     = ".debug_line"
   DEBUG_ABBREV   = ".debug_abbrev"
   DEBUG_INFO     = ".debug_info"


### PR DESCRIPTION
_Backport of #16876 to `release/1.20`_

Keep each concern in its distinct file, for example don't load pe, elf, macho (executable format) or even dwarf (debug format) in libunwind.cr (stack unwinding).

Refactor a single `.read_dwarf_sections` instead of duplicating it to every file format.

Extract `CallStack::PE` from `CallStack::ELF`.