### PR TITLE
Fix: OpenSSL Kernel TLS support should be opt-in

### DIFF
--- a/spec/std/openssl/ssl/context_spec.cr
+++ b/spec/std/openssl/ssl/context_spec.cr
@@ -10,7 +10,11 @@ describe OpenSSL::SSL::Context do
   it "new for client" do
     context = OpenSSL::SSL::Context::Client.new
 
-    (context.options & OpenSSL::SSL::Options::ALL).should eq(OpenSSL::SSL::Options::ALL)
+    {% if OpenSSL.has_constant?(:KTLS) %}
+      (context.options & OpenSSL::SSL::Options::ALL).should eq(OpenSSL::SSL::Options::ALL & ~OpenSSL::SSL::Options::ENABLE_KTLS)
+    {% else %}
+      (context.options & OpenSSL::SSL::Options::ALL).should eq(OpenSSL::SSL::Options::ALL)
+    {% end %}
     (context.options & OpenSSL::SSL::Options::NO_SESSION_RESUMPTION_ON_RENEGOTIATION).should eq(OpenSSL::SSL::Options::NO_SESSION_RESUMPTION_ON_RENEGOTIATION)
 
     context.modes.should eq(OpenSSL::SSL::Modes.flags(AUTO_RETRY, RELEASE_BUFFERS))
@@ -22,7 +26,11 @@ describe OpenSSL::SSL::Context do
   it "new for server" do
     context = OpenSSL::SSL::Context::Server.new
 
-    (context.options & OpenSSL::SSL::Options::ALL).should eq(OpenSSL::SSL::Options::ALL)
+    {% if OpenSSL.has_constant?(:KTLS) %}
+      (context.options & OpenSSL::SSL::Options::ALL).should eq(OpenSSL::SSL::Options::ALL & ~OpenSSL::SSL::Options::ENABLE_KTLS)
+    {% else %}
+      (context.options & OpenSSL::SSL::Options::ALL).should eq(OpenSSL::SSL::Options::ALL)
+    {% end %}
     (context.options & OpenSSL::SSL::Options::NO_SESSION_RESUMPTION_ON_RENEGOTIATION).should eq(OpenSSL::SSL::Options::NO_SESSION_RESUMPTION_ON_RENEGOTIATION)
     (context.options & OpenSSL::SSL::Options::NO_RENEGOTIATION).should eq(OpenSSL::SSL::Options::NO_RENEGOTIATION)
 

--- a/src/openssl/ssl/context.cr
+++ b/src/openssl/ssl/context.cr
@@ -259,6 +259,7 @@ abstract class OpenSSL::SSL::Context
       NO_SESSION_RESUMPTION_ON_RENEGOTIATION,
       NO_RENEGOTIATION,
     ))
+    remove_options(OpenSSL::SSL::Options::ENABLE_KTLS)
     add_modes(OpenSSL::SSL::Modes.flags(AUTO_RETRY, RELEASE_BUFFERS))
 
     # OpenSSL does not support reading from the system root certificate store on

--- a/src/openssl/ssl/context.cr
+++ b/src/openssl/ssl/context.cr
@@ -259,7 +259,9 @@ abstract class OpenSSL::SSL::Context
       NO_SESSION_RESUMPTION_ON_RENEGOTIATION,
       NO_RENEGOTIATION,
     ))
-    remove_options(OpenSSL::SSL::Options::ENABLE_KTLS)
+    {% if OpenSSL.has_constant?(:KTLS) %}
+      remove_options(OpenSSL::SSL::Options::ENABLE_KTLS)
+    {% end %}
     add_modes(OpenSSL::SSL::Modes.flags(AUTO_RETRY, RELEASE_BUFFERS))
 
     # OpenSSL does not support reading from the system root certificate store on


### PR DESCRIPTION
Removes the `ENABLE_KTLS` context option (set by default by OpenSSL) to workaround an issue with some servers on Linux where the decryption can fail in the kernel (#16881).

The option can be manually added again.